### PR TITLE
Update learning_rate_schedule.py

### DIFF
--- a/tensorflow/python/keras/optimizer_v2/learning_rate_schedule.py
+++ b/tensorflow/python/keras/optimizer_v2/learning_rate_schedule.py
@@ -630,7 +630,7 @@ class CosineDecay(LearningRateSchedule):
       global_step_recomp = math_ops.minimum(global_step_recomp, decay_steps)
       completed_fraction = global_step_recomp / decay_steps
       cosine_decayed = 0.5 * (1.0 + math_ops.cos(
-          constant_op.constant(math.pi) * completed_fraction))
+          constant_op.constant(math.pi, dtype=dtype) * completed_fraction))
 
       decayed = (1 - self.alpha) * cosine_decayed + self.alpha
       return math_ops.multiply(initial_learning_rate, decayed)


### PR DESCRIPTION
Make sure math.pi has the same dtype as completed_fraction

The dtype of initial_learning_rate could be different from math.pi and this can lead to problems like:
```python
import tensorflow as tf
import numpy as np
schedule = tf.keras.optimizers.schedules.CosineDecay(
  initial_learning_rate=np.float64(0.001),
  decay_steps=100
)
schedule(1)
```
```
/usr/local/lib/python3.7/dist-packages/tensorflow/python/keras/optimizer_v2/learning_rate_schedule.py in __call__(self, step)
    630       completed_fraction = global_step_recomp / decay_steps
    631       cosine_decayed = 0.5 * (1.0 + math_ops.cos(
--> 632           constant_op.constant(math.pi) * completed_fraction))
    633 
    634       decayed = (1 - self.alpha) * cosine_decayed + self.alpha

/usr/local/lib/python3.7/dist-packages/tensorflow/python/ops/math_ops.py in binary_op_wrapper(x, y)
   1232         #   r_binary_op_wrapper use different force_same_dtype values.
   1233         x, y = maybe_promote_tensors(x, y, force_same_dtype=False)
-> 1234         return func(x, y, name=name)
   1235       except (TypeError, ValueError) as e:
   1236         # Even if dispatching the op failed, the RHS may be a tensor aware

/usr/local/lib/python3.7/dist-packages/tensorflow/python/ops/math_ops.py in _mul_dispatch(x, y, name)
   1573     return sparse_tensor.SparseTensor(y.indices, new_vals, y.dense_shape)
   1574   else:
-> 1575     return multiply(x, y, name=name)
   1576 
   1577 

/usr/local/lib/python3.7/dist-packages/tensorflow/python/util/dispatch.py in wrapper(*args, **kwargs)
    204     """Call target, and fall back on dispatchers if there is a TypeError."""
    205     try:
--> 206       return target(*args, **kwargs)
    207     except (TypeError, ValueError):
    208       # Note: convert_to_eager_tensor currently raises a ValueError, not a

/usr/local/lib/python3.7/dist-packages/tensorflow/python/ops/math_ops.py in multiply(x, y, name)
    528   """
    529 
--> 530   return gen_math_ops.mul(x, y, name)
    531 
    532 

/usr/local/lib/python3.7/dist-packages/tensorflow/python/ops/gen_math_ops.py in mul(x, y, name)
   6238       return _result
   6239     except _core._NotOkStatusException as e:
-> 6240       _ops.raise_from_not_ok_status(e, name)
   6241     except _core._FallbackException:
   6242       pass

/usr/local/lib/python3.7/dist-packages/tensorflow/python/framework/ops.py in raise_from_not_ok_status(e, name)
   6895   message = e.message + (" name: " + name if name is not None else "")
   6896   # pylint: disable=protected-access
-> 6897   six.raise_from(core._status_to_exception(e.code, message), None)
   6898   # pylint: enable=protected-access
   6899 

/usr/local/lib/python3.7/dist-packages/six.py in raise_from(value, from_value)

InvalidArgumentError: cannot compute Mul as input #1(zero-based) was expected to be a float tensor but is a double tensor [Op:Mul]
```