### PR TITLE
[tf.data] add AutotuneOptions for performance tuning of dataset operations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -158,7 +158,11 @@
         *   `tf.data.experimental.MapVectorizationOptions.*`
         *   `tf.data.experimental.OptimizationOptions.filter_with_random_uniform_fusion`
         *   `tf.data.experimental.OptimizationOptions.hoist_random_uniform`
-        *   `tf.data.experimental.OptimizationOptions.map_vectorization`                 *   `tf.data.experimental.OptimizationOptions.reorder_data_discarding_ops`
+        *   `tf.data.experimental.OptimizationOptions.map_vectorization`
+        *   `tf.data.experimental.OptimizationOptions.reorder_data_discarding_ops`
+    *   Added `tf.data.AutotuneOptions()` to tune the performance of dataset
+        operations. Added nested option, `autotune` (which takes a
+        `tf.data.AutotuneOptions` object), to `tf.data.Options`.
 *   `tf.keras`:
     *   Fix usage of `__getitem__` slicing in Keras Functional APIs when the
         inputs are `RaggedTensor` objects.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -162,7 +162,8 @@
         *   `tf.data.experimental.OptimizationOptions.reorder_data_discarding_ops`
     *   Added `tf.data.AutotuneOptions()` to tune the performance of dataset
         operations. Added nested option, `autotune` (which takes a
-        `tf.data.AutotuneOptions` object), to `tf.data.Options`.
+        `tf.data.AutotuneOptions` object), to `tf.data.Options`. Deprecate
+        respective attributes of `tf.data.experimental.OptimizationOptions`.
 *   `tf.keras`:
     *   Fix usage of `__getitem__` slicing in Keras Functional APIs when the
         inputs are `RaggedTensor` objects.

--- a/tensorflow/core/data/dataset_utils.cc
+++ b/tensorflow/core/data/dataset_utils.cc
@@ -191,17 +191,18 @@ void DefaultOptimizationGraphRewrites(
       optimization_disabled->insert(kShuffleAndRepeatFusionOpt);
     }
   }
-  const bool has_autotune = optimization_options.optional_autotune_case() ==
-                            OptimizationOptions::kAutotune;
+  const auto& autotune_options = options.autotune_options();
+  const bool has_autotune = autotune_options.optional_enabled_case() ==
+                            AutotuneOptions::kEnabled;
   const bool has_autotune_buffers =
-      optimization_options.optional_autotune_buffers_case() ==
-      OptimizationOptions::kAutotuneBuffers;
-  if (!(has_autotune && !optimization_options.autotune()) &&
-      (has_autotune_buffers && optimization_options.autotune_buffers())) {
+      autotune_options.optional_autotune_buffers_case() ==
+      AutotuneOptions::kAutotuneBuffers;
+  if (!(has_autotune && !autotune_options.enabled()) &&
+      (has_autotune_buffers && autotune_options.autotune_buffers())) {
     optimization_enabled->insert(kAutotuneBufferSizesOpt);
     optimization_enabled->insert(kDisablePrefetchLegacyAutotuneOpt);
   }
-  if (has_autotune && !optimization_options.autotune()) {
+  if (has_autotune && !autotune_options.enabled()) {
     optimization_disabled->insert(kAutotuneBufferSizesOpt);
     optimization_disabled->insert(kDisablePrefetchLegacyAutotuneOpt);
   }
@@ -1045,15 +1046,15 @@ Status CopyBatch(bool parallel_copy, IteratorContext* ctx,
 
 absl::flat_hash_set<tstring> CreateGraphRewriteConfigs(const Options& options) {
   absl::flat_hash_set<tstring> configs;
-  const auto& optimization_options = options.optimization_options();
+  const auto& autotune_options = options.autotune_options();
   std::vector<tstring> autotune_only_optimizations = {
       kAutotuneBufferSizesOpt, kBatchParallelizationOpt,
       kDisablePrefetchLegacyAutotuneOpt, kEnableGradientDescentOpt,
       kMapParallelizationOpt};
 
-  if (optimization_options.optional_autotune_case() ==
-          OptimizationOptions::kAutotune &&
-      !optimization_options.autotune()) {
+  if (autotune_options.optional_enabled_case() ==
+          AutotuneOptions::kEnabled &&
+      !autotune_options.enabled()) {
     for (const auto& optimization : autotune_only_optimizations) {
       configs.insert(
           absl::StrCat(optimization.data(), ":", kAutotuneOpt, ":false"));
@@ -1087,9 +1088,9 @@ bool ShouldUsePrivateThreadPool(const Options& options) {
 }
 
 bool ShouldUseAutotuning(const Options& options) {
-  return options.optimization_options().optional_autotune_case() !=
-             OptimizationOptions::kAutotune ||
-         options.optimization_options().autotune();
+  return options.autotune_options().optional_enabled_case() !=
+             AutotuneOptions::kEnabled ||
+         options.autotune_options().enabled();
 }
 
 bool ShouldApplyOptimizations(

--- a/tensorflow/core/data/dataset_utils_test.cc
+++ b/tensorflow/core/data/dataset_utils_test.cc
@@ -627,7 +627,7 @@ GetOptimizationsTestCase GetOptimizationTestCase3() {
 GetOptimizationsTestCase GetOptimizationTestCase4() {
   Options options;
   options.set_deterministic(false);
-  options.mutable_optimization_options()->set_autotune_buffers(true);
+  options.mutable_autotune_options()->set_autotune_buffers(true);
   options.mutable_optimization_options()->set_filter_fusion(true);
   options.mutable_optimization_options()->set_map_and_batch_fusion(true);
   options.mutable_optimization_options()->set_map_and_filter_fusion(true);

--- a/tensorflow/core/data/root_dataset.cc
+++ b/tensorflow/core/data/root_dataset.cc
@@ -62,7 +62,7 @@ Status RootDataset::FromOptions(DatasetBase* input, DatasetBase** output) {
     // check for deprecated autotune options in optimization_options
     // the condition below checks for the presence of the deprecated option
     // and decides whether to go with the deprecated options or not.
-    if(optimization_options.optional_autotune_buffers_case() ==
+    if(options.optimization_options().optional_autotune_buffers_case() ==
       OptimizationOptions::kAutotuneBuffers){
       if (options.optimization_options().autotune_buffers()) {
         params.autotune_algorithm = model::AutotuneAlgorithm::GRADIENT_DESCENT;

--- a/tensorflow/core/data/root_dataset.cc
+++ b/tensorflow/core/data/root_dataset.cc
@@ -59,14 +59,14 @@ Status RootDataset::FromOptions(DatasetBase* input, DatasetBase** output) {
   params.autotune = ShouldUseAutotuning(options);
   if (params.autotune) {
     params.autotune_algorithm = model::AutotuneAlgorithm::HILL_CLIMB;
-    if (options.optimization_options().autotune_buffers()) {
+    if (options.autotune_options().autotune_buffers()) {
       params.autotune_algorithm = model::AutotuneAlgorithm::GRADIENT_DESCENT;
     }
     params.autotune_cpu_budget =
-        value_or_default(options.optimization_options().autotune_cpu_budget(),
+        value_or_default(options.autotune_options().cpu_budget(),
                          0, port::NumSchedulableCPUs());
     params.autotune_ram_budget =
-        value_or_default(options.optimization_options().autotune_ram_budget(),
+        value_or_default(options.autotune_options().ram_budget(),
                          0, kRamBudgetShare * port::AvailableRam());
   }
   *output = new RootDataset(input, params);

--- a/tensorflow/core/framework/dataset_options.proto
+++ b/tensorflow/core/framework/dataset_options.proto
@@ -39,27 +39,6 @@ message OptimizationOptions {
   oneof optional_apply_default_optimizations {
     bool apply_default_optimizations = 1;
   }
-  // Whether to automatically tune performance knobs.
-  oneof optional_autotune {
-    bool autotune = 2;
-  }
-  // When autotuning is enabled (through autotune), determines whether to also
-  // autotune buffer sizes for datasets with parallelism.
-  oneof optional_autotune_buffers {
-    bool autotune_buffers = 3;
-  }
-  // When autotuning is enabled (through autotune), determines the CPU budget to
-  // use. Values greater than the number of schedulable CPU cores are allowed
-  // but may result in CPU contention.
-  oneof optional_autotune_cpu_budget {
-    int32 autotune_cpu_budget = 4;
-  }
-  // When autotuning is enabled (through autotune), determines the RAM budget to
-  // use. Values greater than the available RAM in bytes may result in OOM. If
-  // 0, defaults to half of the available RAM in bytes.
-  oneof optional_autotune_ram_budget {
-    int64 autotune_ram_budget = 5;
-  }
   // Whether to fuse filter transformations.
   oneof optional_filter_fusion {
     bool filter_fusion = 6;

--- a/tensorflow/core/framework/dataset_options.proto
+++ b/tensorflow/core/framework/dataset_options.proto
@@ -127,6 +127,30 @@ enum ExternalStatePolicy {
   POLICY_FAIL = 2;
 }
 
+message AutotuneOptions {
+  // Whether to automatically tune performance knobs.
+  oneof optional_enabled {
+    bool enabled = 1;
+  }
+  // When autotuning is enabled (through autotune), determines whether to also
+  // autotune buffer sizes for datasets with parallelism.
+  oneof optional_autotune_buffers {
+    bool autotune_buffers = 2;
+  }
+  // When autotuning is enabled (through autotune), determines the CPU budget to
+  // use. Values greater than the number of schedulable CPU cores are allowed
+  // but may result in CPU contention.
+  oneof optional_cpu_budget {
+    int32 cpu_budget = 3;
+  }
+  // When autotuning is enabled (through autotune), determines the RAM budget to
+  // use. Values greater than the available RAM in bytes may result in OOM. If
+  // 0, defaults to half of the available RAM in bytes.
+  oneof optional_ram_budget {
+    int64 ram_budget = 4;
+  }
+}
+
 // Message stored with Dataset objects to control how datasets are processed and
 // optimized.
 message Options {
@@ -155,4 +179,6 @@ message Options {
   oneof optional_external_state_policy {
     ExternalStatePolicy external_state_policy = 6;
   }
+  // The autotune options associated with the dataset
+  AutotuneOptions autotune_options = 7;
 }

--- a/tensorflow/core/framework/dataset_options.proto
+++ b/tensorflow/core/framework/dataset_options.proto
@@ -39,6 +39,27 @@ message OptimizationOptions {
   oneof optional_apply_default_optimizations {
     bool apply_default_optimizations = 1;
   }
+  // Whether to automatically tune performance knobs.
+  oneof optional_autotune {
+    bool autotune = 2 [deprecated=true];
+  }
+  // When autotuning is enabled (through autotune), determines whether to also
+  // autotune buffer sizes for datasets with parallelism.
+  oneof optional_autotune_buffers {
+    bool autotune_buffers = 3 [deprecated=true];
+  }
+  // When autotuning is enabled (through autotune), determines the CPU budget to
+  // use. Values greater than the number of schedulable CPU cores are allowed
+  // but may result in CPU contention.
+  oneof optional_autotune_cpu_budget {
+    int32 autotune_cpu_budget = 4 [deprecated=true];
+  }
+  // When autotuning is enabled (through autotune), determines the RAM budget to
+  // use. Values greater than the available RAM in bytes may result in OOM. If
+  // 0, defaults to half of the available RAM in bytes.
+  oneof optional_autotune_ram_budget {
+    int64 autotune_ram_budget = 5 [deprecated=true];
+  }
   // Whether to fuse filter transformations.
   oneof optional_filter_fusion {
     bool filter_fusion = 6;

--- a/tensorflow/core/kernels/data/finalize_dataset_op.cc
+++ b/tensorflow/core/kernels/data/finalize_dataset_op.cc
@@ -42,7 +42,7 @@ void GetModelDatasetParams(const Options& options,
   // check for deprecated autotune options in optimization_options
   // the condition below checks for the presence of the deprecated option
   // and decides whether to go with the deprecated options or not.
-  if(options.optimization_options.optional_autotune_buffers_case() ==
+  if(options.optimization_options().optional_autotune_buffers_case() ==
     OptimizationOptions::kAutotuneBuffers){
       if (options.optimization_options().autotune_buffers()) {
         *algorithm = model::AutotuneAlgorithm::GRADIENT_DESCENT;

--- a/tensorflow/core/kernels/data/finalize_dataset_op.cc
+++ b/tensorflow/core/kernels/data/finalize_dataset_op.cc
@@ -38,11 +38,11 @@ void GetModelDatasetParams(const Options& options,
                            model::AutotuneAlgorithm* algorithm,
                            bool* cpu_budget, bool* ram_budget) {
   *algorithm = model::AutotuneAlgorithm::HILL_CLIMB;
-  if (options.optimization_options().autotune_buffers()) {
+  if (options.autotune_options().autotune_buffers()) {
     *algorithm = model::AutotuneAlgorithm::GRADIENT_DESCENT;
   }
-  *cpu_budget = options.optimization_options().autotune_cpu_budget();
-  *ram_budget = options.optimization_options().autotune_ram_budget();
+  *cpu_budget = options.autotune_options().cpu_budget();
+  *ram_budget = options.autotune_options().ram_budget();
 }
 
 void MakeDatasetHelper(OpKernelContext* ctx, bool has_captured_ref,

--- a/tensorflow/core/kernels/data/finalize_dataset_op.cc
+++ b/tensorflow/core/kernels/data/finalize_dataset_op.cc
@@ -38,11 +38,24 @@ void GetModelDatasetParams(const Options& options,
                            model::AutotuneAlgorithm* algorithm,
                            bool* cpu_budget, bool* ram_budget) {
   *algorithm = model::AutotuneAlgorithm::HILL_CLIMB;
-  if (options.autotune_options().autotune_buffers()) {
-    *algorithm = model::AutotuneAlgorithm::GRADIENT_DESCENT;
+
+  // check for deprecated autotune options in optimization_options
+  // the condition below checks for the presence of the deprecated option
+  // and decides whether to go with the deprecated options or not.
+  if(options.optimization_options.optional_autotune_buffers_case() ==
+    OptimizationOptions::kAutotuneBuffers){
+      if (options.optimization_options().autotune_buffers()) {
+        *algorithm = model::AutotuneAlgorithm::GRADIENT_DESCENT;
+      }
+      *cpu_budget = options.optimization_options().autotune_cpu_budget();
+      *ram_budget = options.optimization_options().autotune_ram_budget();
+  } else {
+    if (options.autotune_options().autotune_buffers()) {
+      *algorithm = model::AutotuneAlgorithm::GRADIENT_DESCENT;
+    }
+    *cpu_budget = options.autotune_options().cpu_budget();
+    *ram_budget = options.autotune_options().ram_budget();
   }
-  *cpu_budget = options.autotune_options().cpu_budget();
-  *ram_budget = options.autotune_options().ram_budget();
 }
 
 void MakeDatasetHelper(OpKernelContext* ctx, bool has_captured_ref,

--- a/tensorflow/core/kernels/data/finalize_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/finalize_dataset_op_test.cc
@@ -77,25 +77,30 @@ class FinalizeDatasetOpTest : public DatasetOpsTestBase {
 };
 
 constexpr char kNoOptimizationOptions[] = R"proto(
-  optimization_options { apply_default_optimizations: false autotune: false }
+  optimization_options { apply_default_optimizations: false }
+  autotune_options { enabled: false }
 )proto";
 constexpr char kMaxIntraOpParallelismOptions[] = R"proto(
-  optimization_options { apply_default_optimizations: false autotune: false }
+  optimization_options { apply_default_optimizations: false }
+  autotune_options { enabled: false }
   threading_options { max_intra_op_parallelism: 10 }
 )proto";
 constexpr char kPrivateThreadPoolOptions[] = R"proto(
-  optimization_options { apply_default_optimizations: false autotune: false }
+  optimization_options { apply_default_optimizations: false }
   threading_options { private_threadpool_size: 10 }
+  autotune_options { enabled: false }
 )proto";
 constexpr char kModelOptions[] = R"proto(
   optimization_options { apply_default_optimizations: false }
 )proto";
 constexpr char kOptimizationsDefaultOptions[] = R"proto(
-  optimization_options { apply_default_optimizations: true autotune: false }
+  optimization_options { apply_default_optimizations: true }
+  autotune_options { enabled: false }
 )proto";
 constexpr char kAllChainedDatasetsOptions[] = R"proto(
-  optimization_options { apply_default_optimizations: true autotune: true }
+  optimization_options { apply_default_optimizations: true }
   threading_options { max_intra_op_parallelism: 10 private_threadpool_size: 10 }
+  autotune_options { enabled: true }
 )proto";
 
 OptionsDatasetParams NoOptimizationOptionsParams() {

--- a/tensorflow/python/data/experimental/__init__.py
+++ b/tensorflow/python/data/experimental/__init__.py
@@ -22,6 +22,7 @@ removing existing functionality.
 
 See [Importing Data](https://tensorflow.org/guide/datasets) for an overview.
 
+@@AutotuneOptions
 @@AutoShardPolicy
 @@CheckpointInputPipelineHook
 @@Counter
@@ -95,6 +96,7 @@ from __future__ import print_function
 
 # pylint: disable=unused-import
 from tensorflow.python.data.experimental import service
+from tensorflow.python.data.experimental.ops.autotune_options import AutotuneOptions
 from tensorflow.python.data.experimental.ops.batching import dense_to_ragged_batch
 from tensorflow.python.data.experimental.ops.batching import dense_to_sparse_batch
 from tensorflow.python.data.experimental.ops.batching import map_and_batch

--- a/tensorflow/python/data/experimental/kernel_tests/optimization/autotune_buffer_sizes_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/optimization/autotune_buffer_sizes_test.py
@@ -31,7 +31,7 @@ class AutotuneBufferSizesTest(test_base.DatasetTestBase,
 
   def _enable_autotune_buffers(self, dataset):
     options = dataset_ops.Options()
-    options.experimental_optimization.autotune_buffers = True
+    options.autotune.experimental_autotune_buffers = True
     return dataset.with_options(options)
 
   @combinations.generate(test_base.default_test_combinations())

--- a/tensorflow/python/data/experimental/kernel_tests/optimization/map_parallelization_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/optimization/map_parallelization_test.py
@@ -115,7 +115,7 @@ class MapParallelizationTest(test_base.DatasetTestBase, parameterized.TestCase):
     options.experimental_optimization.apply_default_optimizations = False
     options.experimental_optimization.map_parallelization = True
     if apply_autotune is not None:
-      options.experimental_optimization.autotune = apply_autotune
+      options.autotune.enabled = apply_autotune
     dataset = dataset.with_options(options)
     self.assertDatasetProduces(dataset, expected_output=[2, 3, 4, 5])
 

--- a/tensorflow/python/data/experimental/kernel_tests/optimization/optimization_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/optimization/optimization_test.py
@@ -230,7 +230,7 @@ class OptimizationTest(test_base.DatasetTestBase, parameterized.TestCase):
 
     options = dataset_ops.Options()
     if autotune is not None:
-      options.experimental_optimization.autotune = autotune
+      options.autotune.enabled = autotune
     if map_parallelization is not None:
       options.experimental_optimization.map_parallelization = (
           map_parallelization)

--- a/tensorflow/python/data/experimental/ops/BUILD
+++ b/tensorflow/python/data/experimental/ops/BUILD
@@ -4,6 +4,16 @@ package(
 )
 
 py_library(
+    name = "autotune_options",
+    srcs = ["autotune_options.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//tensorflow/python:util",
+        "//tensorflow/python/data/util:options",
+    ],
+)
+
+py_library(
     name = "batching",
     srcs = ["batching.py"],
     srcs_version = "PY3",

--- a/tensorflow/python/data/experimental/ops/autotune_options.py
+++ b/tensorflow/python/data/experimental/ops/autotune_options.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tensorflow/python/data/experimental/ops/autotune_options.py
+++ b/tensorflow/python/data/experimental/ops/autotune_options.py
@@ -1,0 +1,98 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""API for controlling performance auto-tuning in `tf.data` pipelines."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.core.framework import dataset_options_pb2
+from tensorflow.python.data.util import options
+from tensorflow.python.util.tf_export import tf_export
+
+
+@tf_export("data.AutotuneOptions")
+class AutotuneOptions(options.OptionsBase):
+  """Represents options for performance auto-tuning in
+  dataset operations.
+
+  You can set the auto-tune options of a dataset through the
+  `autotune` property of `tf.data.Options`; the property is
+  an instance of `tf.data.AutotuneOptions`.
+
+  ```python
+  options = tf.data.Options()
+  options.autotune.enabled = True
+  options.autotune.cpu_budget = 8
+  dataset = dataset.with_options(options)
+  ```
+  """
+  enabled = options.create_option(
+      name="enabled",
+      ty=bool,
+      docstring=
+      "Whether to automatically tune performance knobs. If None, defaults to "
+      "True.")
+
+  experimental_autotune_buffers = options.create_option(
+      name="experimental_autotune_buffers",
+      ty=bool,
+      docstring=
+      "When autotuning is enabled (through `enabled`), determines whether to "
+      "also autotune buffer sizes for datasets with parallelism. If None,"
+      " defaults to False.")
+
+  cpu_budget = options.create_option(
+      name="cpu_budget",
+      ty=int,
+      docstring=
+      "When autotuning is enabled (through `autotune`), determines the CPU "
+      "budget to use. Values greater than the number of schedulable CPU cores "
+      "are allowed but may result in CPU contention. If None, defaults to the "
+      "number of schedulable CPU cores.")
+
+  ram_budget = options.create_option(
+      name="ram_budget",
+      ty=int,
+      docstring=
+      "When autotuning is enabled (through `autotune`), determines the RAM "
+      "budget to use. Values greater than the available RAM in bytes may "
+      "result in OOM. If None, defaults to half of the available RAM in bytes.")
+
+  def _to_proto(self):
+    pb = dataset_options_pb2.AutotuneOptions()
+    if self.enabled is not None:
+      pb.enabled = self.enabled
+    if self.experimental_autotune_buffers is not None:
+      pb.autotune_buffers = self.experimental_autotune_buffers
+    if self.cpu_budget is not None:
+      pb.cpu_budget = self.cpu_budget
+    if self.ram_budget is not None:
+      pb.ram_budget = self.ram_budget
+    return pb
+
+  def _from_proto(self, pb):
+    if pb.WhichOneof("optional_enabled") is not None:
+      self.enabled = pb.enabled
+    if pb.WhichOneof("optional_autotune_buffers") is not None:
+      self.experimental_autotune_buffers = pb.autotune_buffers
+    if pb.WhichOneof("optional_cpu_budget") is not None:
+      self.cpu_budget = pb.cpu_budget
+    if pb.WhichOneof("optional_ram_budget") is not None:
+      self.ram_budget = pb.ram_budget
+
+  def _set_mutable(self, mutable):
+    """Change the mutability value to `mutable` on this options and children."""
+    # pylint: disable=protected-access
+    object.__setattr__(self, "_mutable", mutable)

--- a/tensorflow/python/data/experimental/ops/autotune_options.py
+++ b/tensorflow/python/data/experimental/ops/autotune_options.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""API for controlling performance auto-tuning in `tf.data` pipelines."""
+"""API for controlling performance autotuning in `tf.data` pipelines."""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -24,10 +24,10 @@ from tensorflow.python.util.tf_export import tf_export
 
 @tf_export("data.AutotuneOptions")
 class AutotuneOptions(options.OptionsBase):
-  """Represents options for performance auto-tuning in
+  """Represents options for performance autotuning in
   dataset operations.
 
-  You can set the auto-tune options of a dataset through the
+  You can set the autotune options of a dataset through the
   `autotune` property of `tf.data.Options`; the property is
   an instance of `tf.data.AutotuneOptions`.
 

--- a/tensorflow/python/data/experimental/ops/optimization_options.py
+++ b/tensorflow/python/data/experimental/ops/optimization_options.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import enum
+from absl import logging
 
 from tensorflow.core.framework import dataset_options_pb2
 from tensorflow.python.data.experimental.ops import autotune_options
@@ -109,6 +110,11 @@ class OptimizationOptions(options.OptionsBase):
       docstring="Whether to fuse shuffle and repeat transformations. If None, "
       "defaults to True.")
 
+  # The `autotune` related options in this class have been moved to
+  # `tf.data.AutotuneOptions`. To ensure backward-compatibility with the
+  # deprecated `autotune` options in this class, we are creating a private
+  # `AutotuneOption` based attribute (which will not be serialized/deserialized
+  # as a part of `OptimizationOptions`) and handling the mapping.
   _autotune_option = options.create_option(
       name="_autotune_option",
       ty=autotune_options.AutotuneOptions,
@@ -133,6 +139,9 @@ class OptimizationOptions(options.OptionsBase):
     # handle backward compatibility with deprecated options
     compatibility_map = self._get_autotune_option_compatibility_map()
     if name in compatibility_map:
+      logging.warning("options.experimental_optimization.{} is deprecated."
+                      " Use options.autotune.{} instead.".format(
+                        name, compatibility_map[name]))
       return getattr(self._autotune_option, compatibility_map[name])
     else:
       return getattr(self, name)
@@ -141,6 +150,9 @@ class OptimizationOptions(options.OptionsBase):
     # handle backward compatibility with deprecated options
     compatibility_map = self._get_autotune_option_compatibility_map()
     if name in compatibility_map:
+      logging.warning("options.experimental_optimization.{} is deprecated."
+                      " Use options.autotune.{} instead.".format(
+                        name, compatibility_map[name]))
       setattr(self._autotune_option, compatibility_map[name], value)
     else:
       super(OptimizationOptions, self).__setattr__(name, value)

--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -645,6 +645,7 @@ tf_py_test(
     deps = [
         ":test_base",
         "//tensorflow/python:client_testlib",
+        "//tensorflow/python/data/experimental/ops:autotune_options",
         "//tensorflow/python/data/experimental/ops:optimization_options",
         "//tensorflow/python/data/experimental/ops:testing",
         "//tensorflow/python/data/experimental/ops:threading_options",

--- a/tensorflow/python/data/kernel_tests/options_test.py
+++ b/tensorflow/python/data/kernel_tests/options_test.py
@@ -24,6 +24,7 @@ import sys
 from absl.testing import parameterized
 
 from tensorflow.core.framework import dataset_options_pb2
+from tensorflow.python.data.experimental.ops import autotune_options
 from tensorflow.python.data.experimental.ops import distribute_options
 from tensorflow.python.data.experimental.ops import optimization_options
 from tensorflow.python.data.experimental.ops import testing
@@ -114,6 +115,7 @@ class OptionsTest(test_base.DatasetTestBase, parameterized.TestCase):
     self.assertEqual(options1.experimental_optimization,
                      optimization_options.OptimizationOptions())
     self.assertEqual(options1.threading, threading_options.ThreadingOptions())
+    self.assertEqual(options1.autotune, autotune_options.AutotuneOptions())
 
   @combinations.generate(test_base.default_test_combinations())
   def testMutatingOptionsRaiseValueError(self):
@@ -189,6 +191,8 @@ class OptionsTest(test_base.DatasetTestBase, parameterized.TestCase):
         dataset_options_pb2.OptimizationOptions())
     expected_pb.threading_options.CopyFrom(
         dataset_options_pb2.ThreadingOptions())
+    expected_pb.autotune_options.CopyFrom(
+        dataset_options_pb2.AutotuneOptions())
     self.assertProtoEquals(expected_pb, result)
 
   @combinations.generate(test_base.default_test_combinations())

--- a/tensorflow/python/data/ops/BUILD
+++ b/tensorflow/python/data/ops/BUILD
@@ -25,6 +25,7 @@ py_library(
         "//tensorflow/python:tensor_shape",
         "//tensorflow/python:tensor_util",
         "//tensorflow/python:util",
+        "//tensorflow/python/data/experimental/ops:autotune_options",
         "//tensorflow/python/data/experimental/ops:distribute_options",
         "//tensorflow/python/data/experimental/ops:optimization_options",
         "//tensorflow/python/data/experimental/ops:threading_options",

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -33,6 +33,7 @@ from six.moves import queue as Queue  # pylint: disable=redefined-builtin
 from tensorflow.core.framework import dataset_options_pb2
 from tensorflow.core.framework import graph_pb2
 from tensorflow.python import tf2
+from tensorflow.python.data.experimental.ops import autotune_options
 from tensorflow.python.data.experimental.ops import distribute_options
 from tensorflow.python.data.experimental.ops import optimization_options
 from tensorflow.python.data.experimental.ops import threading_options
@@ -3675,6 +3676,13 @@ class Options(options_lib.OptionsBase):
       "`tf.data.ThreadingOptions` for more details.",
       default_factory=threading_options.ThreadingOptions)
 
+  autotune = options_lib.create_option(
+      name="autotune",
+      ty=autotune_options.AutotuneOptions,
+      docstring="The autotune options associated with the dataset. See "
+      "`tf.data.AutotuneOptions` for more details.",
+      default_factory=autotune_options.AutotuneOptions)
+
   def __getattr__(self, name):
     if name == "experimental_threading":
       logging.warning("options.experimental_threading is deprecated. "
@@ -3704,6 +3712,7 @@ class Options(options_lib.OptionsBase):
     if self.experimental_slack is not None:
       pb.slack = self.experimental_slack
     pb.threading_options.CopyFrom(self.threading._to_proto())  # pylint: disable=protected-access
+    pb.autotune_options.CopyFrom(self.autotune._to_proto())  # pylint: disable=protected-access
     return pb
 
   def _from_proto(self, pb):
@@ -3718,6 +3727,7 @@ class Options(options_lib.OptionsBase):
     if pb.WhichOneof("optional_slack") is not None:
       self.experimental_slack = pb.slack
     self.threading._from_proto(pb.threading_options)  # pylint: disable=protected-access
+    self.autotune._from_proto(pb.autotune_options)  # pylint: disable=protected-access
 
   def _set_mutable(self, mutable):
     """Change the mutability value to `mutable` on this options and children."""
@@ -3726,6 +3736,7 @@ class Options(options_lib.OptionsBase):
     self.experimental_distribute._set_mutable(mutable)
     self.experimental_optimization._set_mutable(mutable)
     self.threading._set_mutable(mutable)
+    self.autotune._set_mutable(mutable)
 
   def merge(self, options):
     """Merges itself with the given `tf.data.Options`.

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-autotune-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-autotune-options.pbtxt
@@ -1,0 +1,26 @@
+path: "tensorflow.data.AutotuneOptions"
+tf_class {
+  is_instance: "<class \'tensorflow.python.data.experimental.ops.autotune_options.AutotuneOptions\'>"
+  is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
+  is_instance: "<type \'object\'>"
+  member {
+    name: "cpu_budget"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "enabled"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "experimental_autotune_buffers"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "ram_budget"
+    mtype: "<type \'property\'>"
+  }
+  member_method {
+    name: "__init__"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+}

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-options.pbtxt
@@ -4,6 +4,10 @@ tf_class {
   is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
   is_instance: "<type \'object\'>"
   member {
+    name: "autotune"
+    mtype: "<type \'property\'>"
+  }
+  member {
     name: "experimental_deterministic"
     mtype: "<type \'property\'>"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-options.pbtxt
@@ -4,10 +4,6 @@ tf_class {
   is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
   is_instance: "<type \'object\'>"
   member {
-    name: "autotune"
-    mtype: "<type \'property\'>"
-  }
-  member {
     name: "experimental_deterministic"
     mtype: "<type \'property\'>"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-optimization-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-optimization-options.pbtxt
@@ -8,22 +8,6 @@ tf_class {
     mtype: "<type \'property\'>"
   }
   member {
-    name: "autotune"
-    mtype: "<type \'property\'>"
-  }
-  member {
-    name: "autotune_buffers"
-    mtype: "<type \'property\'>"
-  }
-  member {
-    name: "autotune_cpu_budget"
-    mtype: "<type \'property\'>"
-  }
-  member {
-    name: "autotune_ram_budget"
-    mtype: "<type \'property\'>"
-  }
-  member {
     name: "filter_fusion"
     mtype: "<type \'property\'>"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.pbtxt
@@ -5,6 +5,10 @@ tf_module {
     mtype: "<type \'int\'>"
   }
   member {
+    name: "AutotuneOptions"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "Dataset"
     mtype: "<type \'type\'>"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-autotune-options.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-autotune-options.pbtxt
@@ -1,0 +1,26 @@
+path: "tensorflow.data.AutotuneOptions"
+tf_class {
+  is_instance: "<class \'tensorflow.python.data.experimental.ops.autotune_options.AutotuneOptions\'>"
+  is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
+  is_instance: "<type \'object\'>"
+  member {
+    name: "cpu_budget"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "enabled"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "experimental_autotune_buffers"
+    mtype: "<type \'property\'>"
+  }
+  member {
+    name: "ram_budget"
+    mtype: "<type \'property\'>"
+  }
+  member_method {
+    name: "__init__"
+    argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
+  }
+}

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-options.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-options.pbtxt
@@ -4,6 +4,10 @@ tf_class {
   is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
   is_instance: "<type \'object\'>"
   member {
+    name: "autotune"
+    mtype: "<type \'property\'>"
+  }
+  member {
     name: "experimental_deterministic"
     mtype: "<type \'property\'>"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-options.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-options.pbtxt
@@ -4,10 +4,6 @@ tf_class {
   is_instance: "<class \'tensorflow.python.data.util.options.OptionsBase\'>"
   is_instance: "<type \'object\'>"
   member {
-    name: "autotune"
-    mtype: "<type \'property\'>"
-  }
-  member {
     name: "experimental_deterministic"
     mtype: "<type \'property\'>"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-optimization-options.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-optimization-options.pbtxt
@@ -8,22 +8,6 @@ tf_class {
     mtype: "<type \'property\'>"
   }
   member {
-    name: "autotune"
-    mtype: "<type \'property\'>"
-  }
-  member {
-    name: "autotune_buffers"
-    mtype: "<type \'property\'>"
-  }
-  member {
-    name: "autotune_cpu_budget"
-    mtype: "<type \'property\'>"
-  }
-  member {
-    name: "autotune_ram_budget"
-    mtype: "<type \'property\'>"
-  }
-  member {
     name: "filter_fusion"
     mtype: "<type \'property\'>"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.pbtxt
@@ -5,6 +5,10 @@ tf_module {
     mtype: "<type \'int\'>"
   }
   member {
+    name: "AutotuneOptions"
+    mtype: "<type \'type\'>"
+  }
+  member {
     name: "Dataset"
     mtype: "<type \'type\'>"
   }


### PR DESCRIPTION
This PR adds the `tf.data.AutotuneOptions` class, which is a split of options from `tf.data.experimental.OptimizationOptions`.

- [x] add new proto message for `AutotuneOptions` and extend the `Options` message.
- [x] add `tf.data.AutotuneOptions` class.
- [x] add `autotune` attribute to `Options`.
- [x] regenerate golden APIs.
- [x] handle backward-comaptibility with `options.experimental_optimization` attributes.
- [x] add/modify `options_test` w.r.t the new `autotune` attribute.
- [x] switch to `autotune_options` in:
    - [x] `tensorflow/core/kernels/data/finalize_dataset_op.cc`
    - [x] `tensorflow/core/data/dataset_utils.cc`
    - [x] `tensorflow/core/data/root_dataset.cc `
- [x] update RELEASE.md.

TEST LOG
```
IINFO: Elapsed time: 42.805s, Critical Path: 41.39s
INFO: 354 processes: 130 internal, 224 local.
INFO: Build completed successfully, 354 total actions
//tensorflow/python/data/kernel_tests:options_test                       PASSED in 3.6s

INFO: Build completed successfully, 354 total actions

---------------

INFO: Found 13 test targets...
INFO: Elapsed time: 23.775s, Critical Path: 22.98s
INFO: 44 processes: 31 internal, 13 local.
INFO: Build completed successfully, 44 total actions
//tensorflow/python/data/experimental/kernel_tests/optimization:map_parallelization_test (cached) PASSED in 3.8s
//tensorflow/python/data/experimental/kernel_tests/optimization:autotune_buffer_sizes_test PASSED in 5.0s
//tensorflow/python/data/experimental/kernel_tests/optimization:filter_fusion_test PASSED in 13.6s
//tensorflow/python/data/experimental/kernel_tests/optimization:grappler_test PASSED in 5.6s
//tensorflow/python/data/experimental/kernel_tests/optimization:grappler_test_gpu PASSED in 5.7s
//tensorflow/python/data/experimental/kernel_tests/optimization:hoist_random_uniform_test PASSED in 6.1s
//tensorflow/python/data/experimental/kernel_tests/optimization:map_and_batch_fusion_test PASSED in 5.6s
//tensorflow/python/data/experimental/kernel_tests/optimization:map_and_filter_fusion_test PASSED in 9.0s
//tensorflow/python/data/experimental/kernel_tests/optimization:map_fusion_test PASSED in 9.8s
//tensorflow/python/data/experimental/kernel_tests/optimization:noop_elimination_test PASSED in 6.6s
//tensorflow/python/data/experimental/kernel_tests/optimization:reorder_data_discarding_ops_test PASSED in 5.5s
//tensorflow/python/data/experimental/kernel_tests/optimization:shuffle_and_repeat_fusion_test PASSED in 5.5s
//tensorflow/python/data/experimental/kernel_tests/optimization:optimization_test PASSED in 23.0s
  Stats over 2 runs: max = 23.0s, min = 7.0s, avg = 15.0s, dev = 8.0s

```

cc: @jsimsa Let me know if I have missed something. Thanks!