### PR TITLE
When CUDA libs cannot be loaded, TF should exit

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -1767,9 +1767,8 @@ Status BaseGPUDeviceFactory::GetValidDeviceIds(
                     "if you would like to use GPU. Follow the guide at "
                     "https://www.tensorflow.org/install/gpu for how to "
                     "download and setup the required libraries for your "
-                    "platform.\nSkipping registering "
-                    "GPU devices...";
-    return Status::OK();
+                    "platform.\n";
+    return errors::FailedPrecondition("Cannot dlopen some GPU libraries.");
   }
 #endif
 

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -1768,7 +1768,7 @@ Status BaseGPUDeviceFactory::GetValidDeviceIds(
                     "https://www.tensorflow.org/install/gpu for how to "
                     "download and setup the required libraries for your "
                     "platform.\n";
-    return errors::FailedPrecondition("Cannot dlopen some GPU libraries.");
+    return handle_or;
   }
 #endif
 


### PR DESCRIPTION
When a job cannot acquire GPU due to some CUDA libs missing, TF should fail early instead of falling back to CPU.  
If TF ignores the error and continue, it could potentially cause unexpected behavior in MWMS - E.g one worker has GPU while one doesn't. Currently when MWMS is running with mixed setup like this, it just hung.

Based on the discussion where the original change of falling back to CPU when CUDA lib cannot be loaded(https://github.com/tensorflow/tensorflow/commit/fcfb99bc3aa3110feae5233dbe4634bffa70dc59) was originated from: https://groups.google.com/a/tensorflow.org/g/developers/c/MUq0ee3g-xk/m/4H84DeiAAQAJ , it mentioned two options facing CUDA lib not being installed properly
 1. fallback to CPU
 2. exit with error message.

option 2 makes more sense to me as I stated above.