### PR TITLE
[Intel MKL] Fix for eager_c_api_test with oneDNN Enabled

### DIFF
--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
@@ -181,6 +181,10 @@ bool MklEagerOpRewrite::ShouldRewriteOp(EagerOperation* op) {
   if (op->Attrs().Get("T", &data_type) != Status::OK()) {
     return false;
   }
+  // Only rewrite if op is to be run on CPU device.
+  if (op->GetDeviceParsedName().type != "CPU") {
+    return false;
+  }
   // Check if we have registered MKL kernel for this op.
   bool kernel_found = FastCheckIfKernelRegistered(op->Name(), data_type);
   if (!kernel_found) {

--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
@@ -50,6 +50,9 @@ class EagerOpRewriteTest : public ::testing::Test {
         new tensorflow::EagerOperation(eager_ctx_));
     EXPECT_EQ(Status::OK(),
               op.get()->Reset(op_name.c_str(), nullptr, false, &executor_));
+    EXPECT_EQ(Status::OK(),
+              op.get()->SetDeviceName(
+                  "/job:localhost/replica:0/task:0/device:CPU:0"));
     return op;
   }
 


### PR DESCRIPTION
This fix resolves the failure with //tensorflow/c/eager:c_api_test running with oneDNN enabled with stock TF under a config=CUDA build executed on a GPU by preventing mkl_eager_op_rewrite for non cpu devices.
