### PR TITLE
Cudnn Frontend API respects the TF32 switch

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.h
@@ -627,7 +627,8 @@ class CudnnSupport : public dnn::DnnSupport {
       dnn::ProfileResult* output_profile_result);
 
   port::Status DoFusedConvolveWithExecutionPlanImpl(
-      Stream* stream, const dnn::BatchDescriptor& conv_input_descriptor,
+      Stream* stream, dnn::DataType element_type,
+      const dnn::BatchDescriptor& conv_input_descriptor,
       DeviceMemoryBase conv_input_data, double conv_input_scale,
       const dnn::FilterDescriptor& filter_descriptor,
       DeviceMemoryBase filter_data,


### PR DESCRIPTION
For the TF using legacy Cudnn APIs, we use a global switch `tensor_float_32_execution_enabled` to determine whether the TF32 math should be used or not. However, it has no control of the new Cudnn frontend APIs (`TF_CUDNN_USE_FRONTEND=1`).

This PR fixes this issue by allowing the frontend API to respect the TF32 switch. Besides, we replaced the existing and cumbersome execution plan filters with a generic filter that can filter out (1) winograd engines, (2) non-deterministic engines, (3) tensor core engines when specified.

This PR currently relies on the pending PR: https://github.com/tensorflow/tensorflow/pull/50181. 

cc. @nluehr 