### PR TITLE
Remove `noincompatible_prohibit_aapt1` from bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -128,11 +128,6 @@ build --define=grpc_no_ares=true
 # archives in -whole_archive -no_whole_archive.
 build --noincompatible_remove_legacy_whole_archive
 
-# These are bazel 2.0's incompatible flags. Tensorflow needs to use bazel 2.0.0
-# to use cc_shared_library, as part of the Tensorflow Build Improvements RFC:
-# https://github.com/tensorflow/community/pull/179
-build --noincompatible_prohibit_aapt1
-
 build --enable_platform_specific_config
 
 # Enable XLA support by default.


### PR DESCRIPTION
`--noincompatible_prohibit_aapt1` is a noop and is being removed from bazel in a future version.

See

https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2070#20d4703d-abdf-44cc-a6b6-2f2c9a38bc48

https://github.com/bazelbuild/bazel/commit/aefd107e163087d7dbc822b3342455d91669a58e