### PR TITLE
[MLIR][TOSA] Adding tf.BatchMatMulV2 legalization.

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
@@ -647,6 +647,27 @@ func @test_log_softmax(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 
 // -----
 
+// CHECK-LABEL: test_batch_matmul_3d
+// CHECK: %[[VAR0:.*]] = "tosa.matmul"(%arg0, %arg1)
+func @test_batch_matmul_3d(%arg0: tensor<13x21x3xf32>, %arg1: tensor<13x3x42xf32>) -> tensor<13x21x42xf32> {
+  %0 = "tf.BatchMatMulV2"(%arg0, %arg1) {adj_x = false, adj_y = false, device = ""} : (tensor<13x21x3xf32>, tensor<13x3x42xf32>) -> tensor<13x21x42xf32>
+  return %0 : tensor<13x21x42xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_batch_matmul_4d
+// CHECK-DAG: %[[VAR0:.*]] = "tosa.reshape"(%arg0) {new_shape = [65, 21, 3]}
+// CHECK-DAG: %[[VAR1:.*]] = "tosa.reshape"(%arg1) {new_shape = [65, 3, 42]}
+// CHECK-DAG: %[[VAR2:.*]] = "tosa.matmul"(%[[VAR0]], %[[VAR1]])
+// CHECK: %[[VAR3:.*]] = "tosa.reshape"(%[[VAR2]]) {new_shape = [5, 13, 21, 42]}
+func @test_batch_matmul_4d(%arg0: tensor<5x13x21x3xf32>, %arg1: tensor<5x13x3x42xf32>) -> tensor<5x13x21x42xf32> {
+  %0 = "tf.BatchMatMulV2"(%arg0, %arg1) {adj_x = false, adj_y = false, device = ""} : (tensor<5x13x21x3xf32>, tensor<5x13x3x42xf32>) -> tensor<5x13x21x42xf32>
+  return %0 : tensor<5x13x21x42xf32>
+}
+
+// -----
+
 // CHECK-LABEL: test_matmul
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.reshape"(%arg0) {new_shape = [1, 14, 19]}
 // CHECK-DAG: %[[VAR1:.*]] = "tosa.reshape"(%arg1) {new_shape = [1, 19, 28]}


### PR DESCRIPTION
Legaize tf.BatchMatMulV2 with tosa.MatMul.
If input rank == 3, trivially lower to tosa.MatMul.
If input rank > 3, reshape input tensors to rank 3 tensor, feed to tosa.MatMul, and then reshape from rank 3 to output tensor shape.