### PR TITLE
[INTEL MKL] Fix failing auto_mixed_precision test

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
@@ -558,7 +558,7 @@ TEST_F(AutoMixedPrecisionTest, FusedBatchNorm) {
   EXPECT_EQ(tensors.size(), tensors_expected.size());
   EXPECT_EQ(tensors.size(), item.fetch.size());
   for (int i = 0; i < item.fetch.size(); ++i) {
-    test::ExpectClose(tensors_expected[i], tensors[i], -1, 1e-3);
+    test::ExpectClose(tensors_expected[i], tensors[i], -1, 1e-2);
   }
 }
 


### PR DESCRIPTION
The test, TEST_F(AutoMixedPrecisionTest, FusedBatchNorm), compares FP16 (emulated in Eigen when run on CPU) with float32 results. It is well known that float32 addition is not associative, so difference in results between different implementations is possible. Even using different number of threads leads to different values of variance computation (a part of FusedBatchNorm computation) as the reduction happens in different sequence. 
Moreover, if we change the input shape to {1, 28, 28, 4} or {8, 28, 28, 16} and many others, even the Stock TF fails (i.e. with TF_ENABLE_ONEDNN_OPTS=0). Given these, we think it is appropriate to increase the rtol