### PR TITLE
Fixed tfl to tosa lowering for convolutions with mixed quantization

### DIFF
--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.h
@@ -223,6 +223,12 @@ llvm::Optional<Value> convertDequantizeOp(PatternRewriter& rewriter,
                                           Value input_value, double scale,
                                           int64_t zeropoint);
 
+// Lowers Per-axis Dequantize to a sequence of TOSA dequantization ops.
+llvm::Optional<Value> convertDequantizePerAxisOp(
+    PatternRewriter& rewriter, Operation* op, RankedTensorType output_type,
+    Value input_value, ArrayRef<double> scale, ArrayRef<int64_t> zp,
+    int32_t axis);
+
 // Lowers FakeQuant to a sequence of TOSA quantization ops.
 llvm::Optional<Value> convertFakeQuantOp(PatternRewriter& rewriter,
                                          Operation* op,

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
@@ -116,9 +116,9 @@ template <typename T>
 llvm::Optional<Value> getConstTensor(PatternRewriter& rewriter, Operation* op,
                                      ArrayRef<T> vec, ArrayRef<int64_t> shape);
 
-// Strip off quantization information for bias tensor and return a unquantized
-// bias
-Value getUnquantizedBias(PatternRewriter& rewriter, Operation* op, Value input);
+Value getZeroBiasTensor(PatternRewriter& rewriter, Operation* op,
+                        RankedTensorType input_ty, RankedTensorType filter_ty,
+                        RankedTensorType output_ty, bool quantized);
 
 // Check if scale32 mode is used for given output_element_type
 bool isScale32(mlir::quant::UniformQuantizedType output_element_type);


### PR DESCRIPTION
Mixed quantization operation should dequantize all inputs, perform the operation in floating point, then Quantize back to the output type. This change adds this behavior to the convolution operation lowerings (2D, transpose, and depthwise).

It includes some refactoring including removing no longer needed utilities and lowering tflite constants to tosa consts as a separate pattern rewrite. This is performed to guarantee quantization information remains for all other tflite to tosa lowerings without depending on op lowerings stripping quantization information off of i32 tensors (not supported by tosa).