### PR TITLE
set --distinct_host_configuration=false by default for linux builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -353,6 +353,8 @@ build:windows --verbose_failures
 
 # On windows, we never cross compile
 build:windows --distinct_host_configuration=false
+# On linux, don't cross compile by default
+build:linux --distinct_host_configuration=false
 
 # Configure short or long logs
 build:short_logs --output_filter=DONT_MATCH_ANYTHING


### PR DESCRIPTION
default linux build of TF compiles both host and target.
Host is not needed for most scenarios, and skipping is speeds up the build by 40% on a DGX