### PR TITLE
Prevent glGetError infinity

### DIFF
--- a/tensorflow/lite/delegates/gpu/gl/gl_errors.cc
+++ b/tensorflow/lite/delegates/gpu/gl/gl_errors.cc
@@ -67,6 +67,10 @@ absl::Status GetOpenGlErrors() {
   if (error2 == GL_NO_ERROR) {
     return absl::InternalError(ErrorToString(error));
   }
+  EGLContext context = eglGetCurrentContext();
+  if (context == EGL_NO_CONTEXT) {
+    return absl::InternalError("EGL Context is not available");
+  }
   std::vector<GLenum> errors = {error, error2};
   for (error = glGetError(); error != GL_NO_ERROR; error = glGetError()) {
     errors.push_back(error);


### PR DESCRIPTION
if EGL context is not available, the glGetError always return GL_INVALID_OPERATION.

I use my simple EGL to WGL wrapper, and found an infinite loop when destroying interpreter.
https://github.com/metarutaiga/TensorFlowLiteReduce/blob/master/third_party/EGL/egl_windows.cc
