### PR TITLE
Restore original framebuffer in ForceSyncTurning

### DIFF
--- a/tensorflow/lite/delegates/gpu/gl/egl_environment.cc
+++ b/tensorflow/lite/delegates/gpu/gl/egl_environment.cc
@@ -127,6 +127,9 @@ absl::Status EglEnvironment::InitPBufferContext() {
 }
 
 void EglEnvironment::ForceSyncTurning() {
+  int framebuffer = 0;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer);
+
   glGenFramebuffers(1, &dummy_framebuffer_);
   glBindFramebuffer(GL_FRAMEBUFFER, dummy_framebuffer_);
 
@@ -141,6 +144,8 @@ void EglEnvironment::ForceSyncTurning() {
 
   glViewport(0, 0, 4, 4);
   glClear(GL_COLOR_BUFFER_BIT);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
 }
 
 }  // namespace gl


### PR DESCRIPTION
It broken OpenGL framebuffer in some render engine that using OpenGL state cache.
So we need to backup and restore current framebuffer.