### PR TITLE
[PluggableDevice] Enable TF_TensorFromProto

### DIFF
--- a/tensorflow/c/c_api.cc
+++ b/tensorflow/c/c_api.cc
@@ -36,7 +36,6 @@ limitations under the License.
 #include "tensorflow/core/framework/op_gen_lib.h"
 #endif  // !defined(IS_MOBILE_PLATFORM) && !defined(IS_SLIM_BUILD)
 #include "tensorflow/c/c_api_internal.h"
-#include "tensorflow/c/tf_status_helper.h"
 #include "tensorflow/c/tf_status_internal.h"
 #include "tensorflow/c/tf_tensor.h"
 #include "tensorflow/core/common_runtime/device_mgr.h"
@@ -159,15 +158,13 @@ void TF_TensorFromProto(const TF_Buffer* from, TF_Tensor* to,
                         TF_Status* status) {
   TF_SetStatus(status, TF_OK, "");
   tensorflow::TensorProto from_tensor_proto;
-  Status cc_status;
-  cc_status = BufferToMessage(from, &from_tensor_proto);
-  if (!cc_status.ok()) {
-    Set_TF_Status_from_Status(status, cc_status);
+  status->status = BufferToMessage(from, &from_tensor_proto);
+  if (!status->status.ok()) {
     return;
   }
-  cc_status = tensorflow::down_cast<tensorflow::TensorInterface*>(to->tensor)
-                  ->FromProto(from_tensor_proto);
-  Set_TF_Status_from_Status(status, cc_status);
+  status->status =
+      tensorflow::down_cast<tensorflow::TensorInterface*>(to->tensor)
+          ->FromProto(from_tensor_proto);
 }
 // --------------------------------------------------------------------------
 

--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -125,6 +125,10 @@ TF_CAPI_EXPORT extern void TF_DeleteBuffer(TF_Buffer*);
 
 TF_CAPI_EXPORT extern TF_Buffer TF_GetBuffer(TF_Buffer* buffer);
 
+// Parsing a serialized TensorProto into a TF_Tensor.
+TF_CAPI_EXPORT extern void TF_TensorFromProto(const TF_Buffer* from,
+                                              TF_Tensor* to, TF_Status* status);
+
 // --------------------------------------------------------------------------
 // Used to return strings across the C API. The caller does not take ownership
 // of the underlying data pointer and is not responsible for freeing it.

--- a/tensorflow/c/c_api_test.cc
+++ b/tensorflow/c/c_api_test.cc
@@ -39,6 +39,7 @@ limitations under the License.
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/partial_tensor_shape.h"
 #include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor.pb.h"
 #include "tensorflow/core/framework/tensor_shape.pb.h"
 #include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/graph/tensor_id.h"
@@ -1550,7 +1551,7 @@ TEST(CAPI, TestFromProto) {
   t_cc.AsProtoField(&t_proto);
 
   TF_Buffer* t_buffer = TF_NewBuffer();
-  tensorflow::MessageToBuffer(t_proto, t_buffer);
+  TF_CHECK_OK(MessageToBuffer(t_proto, t_buffer));
 
   const int num_bytes = 6 * sizeof(float);
   float* values =
@@ -1566,6 +1567,7 @@ TEST(CAPI, TestFromProto) {
   EXPECT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
 
   EXPECT_EQ(1.0, *(static_cast<float*>(TF_TensorData(t_c))));
+  TF_DeleteStatus(status);
   TF_DeleteTensor(t_c);
   TF_DeleteBuffer(t_buffer);
 }

--- a/tensorflow/c/tf_tensor.cc
+++ b/tensorflow/c/tf_tensor.cc
@@ -229,6 +229,12 @@ Status TensorInterface::BitcastFrom(const TensorInterface& from, DataType type,
   return tensor_.BitcastFrom(from.tensor_, type, s);
 }
 
+Status TensorInterface::FromProto(const tensorflow::TensorProto& from) {
+  bool success = tensor_.FromProto(from);
+  if (success) return Status::OK();
+  return errors::InvalidArgument("Unparseable tensor proto");
+}
+
 }  // namespace tensorflow
 
 // --------------------------------------------------------------------------

--- a/tensorflow/c/tf_tensor_internal.h
+++ b/tensorflow/c/tf_tensor_internal.h
@@ -109,6 +109,7 @@ class TensorInterface : public AbstractTensorInterface {
   Status ToTensor(tensorflow::Tensor* dst) const;
   Status BitcastFrom(const TensorInterface& from, DataType type,
                      const int64_t* new_dims, int num_new_dims);
+  Status FromProto(const tensorflow::TensorProto& from);
 
   tensorflow::Tensor& Tensor() { return tensor_; }
 


### PR DESCRIPTION
Add a new C API `TF_TensorFromProto`, which is designed for converting TensorProto(TF_Buffer) to Tensor(TF_Tensor). Typical use case is to get tensor value from TensorProto in graph pass.