### PR TITLE
[MLIR] Add conversion of unary operation from lmhlo to affine

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/lhlo_legalize_to_affine.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/lhlo_legalize_to_affine.cc
@@ -513,6 +513,41 @@ struct BinaryOpConverter : public OpRewritePattern<LhloOpTy> {
   }
 };
 
+/// Conversion for unary operations i.e. tanh sin cos log log1p etc.
+template <typename LhloOpTy>
+struct UnaryOpConverter : public OpRewritePattern<LhloOpTy> {
+  using OpRewritePattern<LhloOpTy>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LhloOpTy op,
+                                PatternRewriter& rewriter) const override {
+
+    Value input = op.input();
+    auto inputType = input.getType().cast<MemRefType>();
+    auto elementType = inputType.getElementType();
+    ArrayRef<int64_t> shape = inputType.getShape();
+
+    SmallVector<Value, 4> induction_vars;
+    Location loc = op.getLoc();
+
+    LogicalResult map_status = success();
+    auto body_builder = [&](OpBuilder& builder, Location loc,
+                            ValueRange induction_vars) {
+      Value loadInput =
+          builder.create<AffineLoadOp>(loc, input, induction_vars);
+      Value opResult = lmhlo::HloOpToStdScalarOp::map<LhloOpTy>(
+          op, elementType, {loadInput}, &builder);
+      map_status = success(opResult != nullptr);
+      if (failed(map_status)) return;
+      rewriter.create<AffineStoreOp>(loc, opResult, op.output(),
+                                     induction_vars);
+    };
+    BuildBoundedAffineLoopNest(rewriter, op.getLoc(), shape, body_builder);
+    if (failed(map_status)) return failure();
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 void populateLHLOToAffineConversionPattern(MLIRContext* context,
                                            OwningRewritePatternList* patterns) {
   // clang-format off
@@ -526,14 +561,15 @@ void populateLHLOToAffineConversionPattern(MLIRContext* context,
       BinaryOpConverter<lmhlo::SubOp>,
       ConcatOpConverter,
       DotOpConverter,
-      GatherOpConverter>(context);
+      GatherOpConverter,
+      UnaryOpConverter<lmhlo::LogOp>>(context);
   // clang-format on
 }
 
 struct LhloLegalizeToAffinePass
     : public LhloLegalizeToAffinePassBase<LhloLegalizeToAffinePass> {
   void getDependentDialects(DialectRegistry& registry) const override {
-    registry.insert<AffineDialect>();
+    registry.insert<AffineDialect, math::MathDialect>();
   }
   void runOnFunction() override {
     auto func = getFunction();

--- a/tensorflow/compiler/mlir/hlo/tests/lhlo-legalize-to-affine.mlir
+++ b/tensorflow/compiler/mlir/hlo/tests/lhlo-legalize-to-affine.mlir
@@ -439,3 +439,19 @@ func @gather_5(%arg0: memref<28996x512x256xf32>, %arg1: memref<10x3xi32>, %arg2:
 }
 // CHECK: %[[and1:.*]] = and %{{.*}}, %{{.*}} : i1
 // CHECK-NEXT: and %[[and1]], %{{.*}} : i1
+
+// CHECK-LABEL: func @log
+func @log(%arg0: memref<2x2xf32>, %arg1: memref<2x2xf32>) {
+  
+// CHECK-NEXT: %[[RES:.*]] = memref.alloc() : memref<2x2xf32>
+// CHECK-NEXT: affine.for %{{.*}} = 0 to 2 {
+// CHECK-NEXT:   affine.for %{{.*}} = 0 to 2 {
+// CHECK-NEXT:     %[[LOAD:.*]] = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<2x2xf32>
+// CHECK-NEXT:     %[[LOG:.*]] = math.log %[[LOAD]] : f32
+// CHECK-NEXT:     affine.store %[[LOG]], %[[RES]][%{{.*}}, %{{.*}}] : memref<2x2xf32>
+
+  %0 = memref.alloc() : memref<2x2xf32>
+  "lmhlo.log"(%arg0, %0) : (memref<2x2xf32>, memref<2x2xf32>) -> ()
+  "lmhlo.copy"(%0, %arg1) : (memref<2x2xf32>, memref<2x2xf32>) -> ()
+  "lmhlo.terminator"() : () -> ()
+}


### PR DESCRIPTION
Unary op converter has been added from lmhlo to affine dialect.
The changes have been made as a part of `lhlo-legalize-to-affine` pass.