### PR TITLE
Applying MKL Eager Rewriter to CPU Ops

### DIFF
--- a/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.h
+++ b/tensorflow/core/common_runtime/eager/eager_op_rewrite_registry.h
@@ -50,7 +50,6 @@ class EagerOpRewrite {
 class EagerOpRewriteRegistry {
  public:
   // Phases at which the Eager op rewrite pass should run.
-  // For now we only added PRE_EXECUTION. Expand as needed.
   enum Phase {
     PRE_EXECUTION = 0,  // right before executing an eager op
     POST_PLACEMENT = 1  // after device placement

--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
@@ -81,7 +81,7 @@ class MklEagerOpRewrite : public EagerOpRewrite {
   std::unordered_map<std::string, bool> registered_kernels_map_;
 };
 
-REGISTER_REWRITE(EagerOpRewriteRegistry::PRE_EXECUTION, 20000,
+REGISTER_REWRITE(EagerOpRewriteRegistry::POST_PLACEMENT, 10000,
                  MklEagerOpRewrite);
 
 // Constructor

--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
@@ -61,7 +61,7 @@ class EagerOpRewriteTest : public ::testing::Test {
     std::unique_ptr<tensorflow::EagerOperation> out_op;
     EXPECT_EQ(Status::OK(),
               EagerOpRewriteRegistry::Global()->RunRewrite(
-                  EagerOpRewriteRegistry::PRE_EXECUTION, orig_op, &out_op));
+                  EagerOpRewriteRegistry::POST_PLACEMENT, orig_op, &out_op));
 
     // actual_op_name is same as original op name if rewrite didn't happen.
     string actual_op_name = orig_op->Name();


### PR DESCRIPTION
Registers the MKL eager rewriter for the POST_PLACEMENT phase, allowing its selective application to ops assigned to a CPU.