### PR TITLE
[MLIR][DISC] Add LhloFusionInliner Pass

### DIFF
--- a/tensorflow/compiler/mlir/hlo/BUILD
+++ b/tensorflow/compiler/mlir/hlo/BUILD
@@ -1252,6 +1252,17 @@ cc_library(
 )
 
 cc_library(
+    name = "lhlo_fusion_inliner",
+    srcs = ["lib/Dialect/mhlo/transforms/lhlo_fusion_inliner.cc"],
+    deps = [
+        ":lhlo",
+        ":pass_details",
+        "@llvm-project//mlir:Pass",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
     name = "chlo_legalize_to_hlo",
     srcs = ["lib/Dialect/mhlo/transforms/chlo_legalize_to_hlo.cc"],
     hdrs = ["include/mlir-hlo/Dialect/mhlo/transforms/rewriters.h"],
@@ -1356,6 +1367,7 @@ cc_library(
         ":lhlo",
         ":lhlo_fuse_linalg",
         ":lhlo_fusion",
+        ":lhlo_fusion_inliner",
         ":lhlo_legalize_to_affine",
         ":lhlo_legalize_to_gpu",
         ":lhlo_legalize_to_parallel_loops",

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/lmhlo_passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/lmhlo_passes.td
@@ -65,3 +65,8 @@ def LhloFusionPass : FunctionPass<"lhlo-fusion"> {
   ];
 }
 
+def LhloFusionInlinerPass : FunctionPass<"lhlo-fusion-inliner"> {
+  let summary = "Inline the contents of its body to the parent region "
+    "after its body has been lowered";
+  let constructor = "createLhloFusionInlinerPass()";
+}

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/passes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/passes.h
@@ -121,6 +121,9 @@ std::unique_ptr<OperationPass<FuncOp>> createLegalizeTensorLoadOpPass();
 std::unique_ptr<OperationPass<FuncOp>> createLhloFusionPass(
     int max_num_arguments_per_kernel = 64);
 
+// inline lmhlo.Fusion
+std::unique_ptr<OperationPass<FuncOp>> createLhloFusionInlinerPass();
+
 }  // namespace lmhlo
 
 namespace disc_ral {

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/CMakeLists.txt
@@ -141,6 +141,7 @@ add_mlir_library(LmhloPasses
   legalize_tensor_load_op.cc
   lhlo_fuse_linalg.cc
   lhlo_fusion.cc
+  lhlo_fusion_inliner.cc
   lhlo_legalize_to_affine.cc
   lhlo_legalize_to_gpu.cc
   lhlo_legalize_to_parallel_loops.cc

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/lhlo_fusion_inliner.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/lhlo_fusion_inliner.cc
@@ -1,0 +1,58 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file implements LhloFusionInlinerPass, which inline the body
+// contents of lmhlo.fusion_op after its body is fully lowered.
+//
+#include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace lmhlo {
+
+#define GEN_PASS_CLASSES
+#include "mlir-hlo/Dialect/mhlo/transforms/lmhlo_passes.h.inc"
+
+struct LhloFusionInlinerPass
+    : public LhloFusionInlinerPassBase<LhloFusionInlinerPass> {
+ public:
+  void runOnFunction() override {
+    auto func = getFunction();
+    SmallVector<FusionOp> worklist;
+    func.walk([&](FusionOp fusion) { worklist.push_back(fusion); });
+    for (FusionOp fusion : worklist) {
+      InlineFusion(fusion);
+      fusion.erase();
+    }
+  }
+
+ private:
+  void InlineFusion(FusionOp fusion) {
+    Block& block = fusion.region().front();
+    assert(block.getNumArguments() == 0);
+    for (Operation& op : llvm::make_early_inc_range(block.getOperations())) {
+      if (!isa<TerminatorOp>(&op)) {
+        op.moveBefore(fusion.getOperation());
+      }
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<FuncOp>> createLhloFusionInlinerPass() {
+  return std::make_unique<LhloFusionInlinerPass>();
+}
+
+}  // namespace lmhlo
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/tests/lhlo-fusion-inliner.mlir
+++ b/tensorflow/compiler/mlir/hlo/tests/lhlo-fusion-inliner.mlir
@@ -1,0 +1,54 @@
+// RUN: mlir-hlo-opt %s -lhlo-fusion-inliner -split-input-file | mlir-hlo-opt | FileCheck %s
+
+// CHECK-LABEL: @fusion_after_codegen
+// CHECK-SAME: (%[[ARG0:.*]]: memref<?xf32>, %[[ARG1:.*]]: memref<?xf32>, %[[ARG2:.*]]: memref<3xi32>, %[[ARG3:.*]]: memref<?xf32>, %[[ARG4:.*]]: memref<?x?x?xf32>) -> memref<?x?x?xf32>
+func @fusion_after_codegen(%arg0: memref<?xf32>, %arg1: memref<?xf32>, %arg2: memref<3xi32>, %arg3: memref<?xf32>, %arg4: memref<?x?x?xf32>) -> memref<?x?x?xf32> {
+  // CHECK: %[[C0:.*]] = constant 0 : index
+  // CHECK: %[[C1:.*]] = constant 1 : index
+  // CHECK: %[[C2:.*]] = constant 2 : index
+  %c0 = constant 0 : index
+  %c1 = constant 1 : index
+  %c2 = constant 2 : index
+  // CHECK:  %[[TMP0:.*]] = memref.dim %[[ARG4]], %[[C0]] : memref<?x?x?xf32>
+  // CHECK:  %[[TMP1:.*]] = memref.dim %[[ARG4]], %[[C1]] : memref<?x?x?xf32>
+  // CHECK:  %[[TMP2:.*]] = muli %[[TMP0]], %[[TMP1]] : index
+  // CHECK:  %[[TMP3:.*]] = memref.dim %[[ARG4]], %[[C2]] : memref<?x?x?xf32>
+  // CHECK:  %[[TMP4:.*]] = muli %[[TMP2]], %[[TMP3]] : index
+  // CHECK:  scf.parallel (%[[ARG5:.*]]) = (%[[C0]]) to (%[[TMP4]]) step (%[[C1]]) {
+  // CHECK:    %[[TMP5:.*]] = muli %[[TMP3]], %[[TMP1]] : index
+  // CHECK:    %[[TMP6:.*]] = remi_unsigned %[[ARG5]], %[[TMP5]] : index
+  // CHECK:    %[[TMP7:.*]] = remi_unsigned %[[TMP6]], %[[TMP3]] : index
+  // CHECK:    %[[TMP8:.*]] = memref.dim %[[ARG3]], %[[C0]] : memref<?xf32>
+  // CHECK:    %[[TMP9:.*]] = cmpi eq, %[[TMP8]], %[[C1]] : index
+  // CHECK:    %[[TMP10:.*]] = select %[[TMP9]], %[[C0]], %[[TMP7]] : index
+  // CHECK:    %[[TMP11:.*]] = memref.load %[[ARG0]][%[[TMP10]]] : memref<?xf32>
+  // CHECK:    %[[TMP12:.*]] = memref.load %[[ARG1]][%[[TMP10]]] : memref<?xf32>
+  // CHECK:    %[[TMP13:.*]] = addf %[[TMP11]], %[[TMP12]] : f32
+  // CHECK:    %[[TMP14:.*]] = memref.reinterpret_cast %[[ARG4]] to offset: [%[[C0]]], sizes: [%[[TMP4]]], strides: [%[[C1]]] : memref<?x?x?xf32> to memref<?xf32>
+  // CHECK:    memref.store %[[TMP13]], %[[TMP14]][%[[ARG5]]] : memref<?xf32>
+  // CHECK:    scf.yield
+  // CHECK:  }
+  "lmhlo.fusion"() ( {
+    %0 = memref.dim %arg4, %c0 : memref<?x?x?xf32>
+    %1 = memref.dim %arg4, %c1 : memref<?x?x?xf32>
+    %2 = muli %0, %1 : index
+    %3 = memref.dim %arg4, %c2 : memref<?x?x?xf32>
+    %4 = muli %2, %3 : index
+    scf.parallel (%arg5) = (%c0) to (%4) step (%c1) {
+      %5 = muli %3, %1 : index
+      %6 = remi_unsigned %arg5, %5 : index
+      %7 = remi_unsigned %6, %3 : index
+      %8 = memref.dim %arg3, %c0 : memref<?xf32>
+      %9 = cmpi eq, %8, %c1 : index
+      %10 = select %9, %c0, %7 : index
+      %11 = memref.load %arg0[%10] : memref<?xf32>
+      %12 = memref.load %arg1[%10] : memref<?xf32>
+      %13 = addf %11, %12 : f32
+      %14 = memref.reinterpret_cast %arg4 to offset: [%c0], sizes: [%4], strides: [%c1] : memref<?x?x?xf32> to memref<?xf32>
+      memref.store %13, %14[%arg5] : memref<?xf32>
+      scf.yield
+    }
+    "lmhlo.terminator"() : () -> ()
+  }) : () -> ()
+  return %arg4 : memref<?x?x?xf32>
+}


### PR DESCRIPTION
This pass inlines the body contents of lmhlo.fusion_op. 
Typically it should work after the body has been lowered into loops. For disc, it works after LhloLegalizeRootsToParallelLoops &  InputInlineFusion in #50102 .