### PR TITLE
Add 'supported formats' to ValueError

### DIFF
--- a/tensorflow/python/keras/preprocessing/image_dataset.py
+++ b/tensorflow/python/keras/preprocessing/image_dataset.py
@@ -206,7 +206,9 @@ def image_dataset_from_directory(directory,
   image_paths, labels = dataset_utils.get_training_or_validation_split(
       image_paths, labels, validation_split, subset)
   if not image_paths:
-    raise ValueError('No images found.')
+    raise ValueError((
+        'No images found. '
+        'Supported image formats: %s' % (str(ALLOWLIST_FORMATS,)[1:-1])))
 
   dataset = paths_and_labels_to_dataset(
       image_paths=image_paths,


### PR DESCRIPTION
While using ` tf.keras.preprocessing.image_dataset_from_directory ` I got a Value Error "No images Found". 
That happened  because i had images in .ppm format, which is not supported (duh!..).  Wasted quite some time. So, to **clarify** I added a line about required image formats in `tensorflow/python/keras/preprocessing/image_dataset.py/image_dataset_from_directory`` raise ValueError`.
Slicing is to get rid of brakets and make it look pretty.

p.s that's my first ever contribution.