### PR TITLE
Fix edge case names in to_snake_case internal util

### DIFF
--- a/tensorflow/python/keras/utils/generic_utils.py
+++ b/tensorflow/python/keras/utils/generic_utils.py
@@ -1108,7 +1108,8 @@ def to_list(x):
 
 
 def to_snake_case(name):
-  intermediate = re.sub('(.)([A-Z][a-z0-9]+)', r'\1_\2', name)
+  intermediate = re.sub('(ReLU)(?![A-Z]{2})', 'Relu', name)
+  intermediate = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', intermediate)
   insecure = re.sub('([a-z])([A-Z])', r'\1_\2', intermediate).lower()
   # If the class is private the name starts with "_" which is not secure
   # for creating scopes. We prefix the name with "private" in this case.


### PR DESCRIPTION
Fixes #50288.

```python
>>> for cls in sorted(Layer.__subclasses__(), key=lambda c: c.__name__):
>>>   new = to_snake_case_proposed(cls.__name__)
>>>   old = to_snake_case_orig(cls.__name__)
>>>   if new != old:
>>>       print(old, '-->', new) 
conv_lst_m2d_cell --> conv_lstm2d_cell
leaky_re_lu --> leaky_relu
p_re_lu --> p_relu
re_lu --> relu
thresholded_re_lu --> thresholded_relu
```