### PR TITLE
Fix race condition in TRTDeviceAllocator

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/utils/trt_allocator.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_allocator.cc
@@ -80,6 +80,7 @@ void* TRTDeviceAllocator::allocate(uint64_t size, uint64_t alignment,
 
   void* alloc_mem = mem;
   QCHECK(Align(alignment, size, mem, total_size));
+  mutex_lock lock(mu_);
   if (mem != alloc_mem) {
     QCHECK(mem_map_.insert({mem, alloc_mem}).second);
   }
@@ -95,6 +96,7 @@ TRTDeviceAllocator::TRTDeviceAllocator(Allocator* allocator)
 }
 
 void TRTDeviceAllocator::free(void* memory) {
+  mutex_lock lock(mu_);
   VLOG(2) << "Deallocating @ " << memory;
   // allocated memory adjusted for alignment, restore the original pointer
   if (memory) {

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_allocator.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_allocator.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <unordered_map>
 
 #include "tensorflow/core/framework/allocator.h"
+#include "tensorflow/core/platform/mutex.h"
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 #include "third_party/tensorrt/NvInfer.h"
@@ -57,10 +58,11 @@ class TRTDeviceAllocator : public TRTBaseAllocator {
   void free(void* memory) override;
 
  private:
+  mutex mu_;
   Allocator* allocator_;
 
   // supporting alignment from allocation request requires a map to free;
-  std::unordered_map<void*, void*> mem_map_;
+  std::unordered_map<void*, void*> mem_map_ TF_GUARDED_BY(mu_);
 };
 
 }  // namespace tensorrt


### PR DESCRIPTION
This PR adds a mutex to prevent race condition while accessing to the `mem_map_` member variable.

Tagging @bixia1 for review and @DEKHTIARJonathan for visibility.