### PR TITLE
Rename template IN / OUT to INPUT / OUTPUT for Windows on ARM

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/portable_tensor_utils_impl.h
+++ b/tensorflow/lite/kernels/internal/reference/portable_tensor_utils_impl.h
@@ -200,11 +200,11 @@ void PortableVectorScalarMultiply(const int8_t* vector, int v_size, float scale,
 // output_size: output vector size.
 // reduction_size: number of consecutive elements from input vector which are
 // added to get one element of output.
-template <typename IN, typename OUT>
-void PortableReductionSumVector(const IN* input_vector, OUT* output_vector,
+template <typename INPUT, typename OUTPUT>
+void PortableReductionSumVector(const INPUT* input_vector, OUTPUT* output_vector,
                                 int output_size, int reduction_size) {
   for (int o = 0; o < output_size; o++) {
-    OUT result = 0;
+    OUTPUT result = 0;
     for (int r = 0; r < reduction_size; r++) {
       result += input_vector[r];
     }


### PR DESCRIPTION
It build failed in Windows on ARM because the IN / OUT is defined in windows.h(minwindef.h)
```
#ifndef IN
#define IN
#endif

#ifndef OUT
#define OUT
#endif
```
So I replace it to INPUT / OUTPUT