### PR TITLE
[TFLite] Add quantization support for SQUARED_DIFFERENCE using the MLIR-based quantizer

### DIFF
--- a/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
+++ b/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
@@ -3036,8 +3036,7 @@ def TFL_SquaredDifferenceOp : TFL_Op<"squared_difference", [
     BinaryOpSameElementTypeConstraint,
     TFL_SameFirstOperandAndFirstResultElementType,
     ResultsBroadcastableShape,
-    NoSideEffect,
-    NoQuantizableResult]> {
+    NoSideEffect]> {
   let summary = "Squared difference operator";
 
   let description = [{


### PR DESCRIPTION
Hello,

The int8 quantization for the SQUARED_DIFFERENCE operator was added a couple of months ago in commit c7b8cbaf60871882b4310c42ef2656d17c5dd2cc and it's working fine with the old quantizer by setting `converter.experimental_new_quantizer = False`  but it isn't working with the new default MLIR-based quantizer as the operator has the `NoQuantizableResult` trait.

The PR just removes the `NoQuantizableResult` trait which is sufficient to make it works but I can eventually add some extra tests.

Thibaut