### PR TITLE
[MLIR][DISC] canonicalize hlo reduce op for codegen

### DIFF
--- a/tensorflow/compiler/mlir/hlo/BUILD
+++ b/tensorflow/compiler/mlir/hlo/BUILD
@@ -953,7 +953,6 @@ cc_library(
         ":hlo",
         ":pass_details",
     ],
-    alwayslink = 1,
 )
 
 cc_library(

--- a/tensorflow/compiler/mlir/hlo/BUILD
+++ b/tensorflow/compiler/mlir/hlo/BUILD
@@ -952,6 +952,9 @@ cc_library(
     deps = [
         ":hlo",
         ":pass_details",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:TensorDialect",
     ],
 )
 

--- a/tensorflow/compiler/mlir/hlo/BUILD
+++ b/tensorflow/compiler/mlir/hlo/BUILD
@@ -946,6 +946,17 @@ cc_library(
 )
 
 cc_library(
+    name = "hlo_canonicalize_reduction",
+    srcs = ["lib/Dialect/mhlo/transforms/hlo_canonicalize_reduction.cc"],
+    hdrs = ["include/mlir-hlo/Dialect/mhlo/transforms/passes.h"],
+    deps = [
+        ":hlo",
+        ":pass_details",
+    ],
+    alwayslink = 1,
+)
+
+cc_library(
     name = "hlo_legalize_to_lhlo",
     srcs = ["lib/Dialect/mhlo/transforms/hlo_legalize_to_lhlo.cc"],
     hdrs = [
@@ -1293,6 +1304,7 @@ cc_library(
         ":MhloPassIncGen",
         ":broadcast_propagation",
         ":chlo_legalize_to_hlo",
+        ":hlo_canonicalize_reduction",
         ":hlo_legalize_to_lhlo",
         ":legalize_control_flow",
         ":legalize_gather_to_torch_index_select",

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/mhlo_passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/mhlo_passes.td
@@ -26,6 +26,11 @@ def ChloLegalizeToHloPass : FunctionPass<"chlo-legalize-to-hlo"> {
   ];
 }
 
+def HloCanonicalizeReductionPass : FunctionPass<"hlo-canonicalize-reduction"> {
+  let summary = "canonicalize reduction ops to be suitable for codegen.";
+  let constructor = "createHloCanonicalizeReductionPass()";
+}
+
 def HloLegalizeToLhloPass : Pass<"hlo-legalize-to-lhlo", "ModuleOp"> {
   let summary = "Legalize from HLO dialect to LHLO dialect.";
   let constructor = "createLegalizeToLhloPass()";

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/passes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/passes.h
@@ -48,6 +48,9 @@ std::unique_ptr<OperationPass<FuncOp>> createLegalizeToStdPass();
 std::unique_ptr<FunctionPass> createChloLegalizeToHloPass(
     bool legalize_broadcasts = true, bool expand_compositions = true);
 
+// canonicalize reduction ops to be suitable for codegen.
+std::unique_ptr<FunctionPass> createHloCanonicalizeReductionPass();
+
 /// Lowers from HLO dialect to LHLO dialect allocating/deallocating temporary
 /// buffers if necessary.
 std::unique_ptr<OperationPass<ModuleOp>> createLegalizeToLhloPass(

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/hlo_canonicalize_reduction.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/hlo_canonicalize_reduction.cc
@@ -18,7 +18,9 @@ limitations under the License.
 
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/transforms/PassDetail.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
 
 namespace mlir {
 namespace mhlo {

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/hlo_canonicalize_reduction.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/hlo_canonicalize_reduction.cc
@@ -122,10 +122,10 @@ struct HloCanonicalizeReductionPass
 
       // empty reduction is just a no-op, thus no need to do codegen.
       if (dims_to_reduce.empty()) return;
-      
+
       // suppose reduce input is a ranked tensor
       auto ty = op.getOperand(0).getType().dyn_cast<RankedTensorType>();
-      if(!ty) return signalPassFailure();
+      if (!ty) return signalPassFailure();
       int rank = ty.getRank();
       int ndims_to_reduce = dims_to_reduce.size();
       auto elem_ty = ty.getElementType();

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/hlo_canonicalize_reduction.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/hlo_canonicalize_reduction.cc
@@ -1,0 +1,238 @@
+// This file canonicalize reduction ops in hlo dialect to match the
+// capacity of codgen backend.
+#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/PassDetail.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+
+namespace mlir {
+namespace mhlo {
+namespace {
+
+// All the reduce ops can be divided into following four types:
+//  - a) column reduction, only reduce the most significant dimensions.
+//  - b) row reduction, only reduce the least significant dimensions.
+//  - c) reduce to scalar, all dimensions are reduced.
+//  - d) others. (not support now, maybe use transpose to canonicalize)
+//
+// Currently we do following canonicalization to match the capacity of codegen
+// backend.
+//
+// For case a):
+// ====================================================================================
+//   we convert all column reduction to rank-2 column reduction.
+//   For example, suppose we have:
+//   ```
+//     func @test(%arg0: tensor<?x?x?xf32>) -> tensor<?x?xf32> {
+//       ...
+//       %2 = "mhlo.reduce"(%arg0, ...) ( {...})
+//         {dimensions = dense<[0]> : tensor<1xi64>} :
+//         (tensor<?x?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
+//       return %2 : tensor<?x?xf32>
+//     }
+//  ```
+//   After conversion:
+//     func @test(%arg0: tensor<?x?x?xf32>) -> tensor<?x?xf32> {
+//       // [a, b, c] -> [a, b*c]
+//       %1 = mhlo.dynamic_reshape(%arg0, ...) : (tensor<?x?x?xf32>,
+//       tensor<2xi64>) -> tensor<?x?xf32> %2 = "mhlo.reduce"(%1, ...) ( {...})
+//         {dimensions = dense<[0]> : tensor<1xi64>} :
+//         (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
+//       %3 = "mhlo.dynamic_reshape"(%2, ...) : (tensor<?xf32>, tensor<1xi64>)
+//       -> tensor<?x?f32> return %3 : tensor<?x?xf32>
+//     }
+//  ```
+//
+// For case b):
+// ====================================================================================
+//   we convert all row reduction to rank-2 row reduction.
+//   For example, suppose we have:
+//   ```
+//     func @test(%arg0: tensor<?x?x?xf32>) -> tensor<?x?xf32> {
+//       ...
+//       %2 = "mhlo.reduce"(%arg0, ...) ( {...})
+//         {dimensions = dense<[2]> : tensor<1xi64>} :
+//         (tensor<?x?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
+//       return %2 : tensor<?x?xf32>
+//     }
+//  ```
+//   After conversion:
+//     func @test(%arg0: tensor<?x?x?xf32>) -> tensor<?x?xf32> {
+//       // [a, b, c] -> [a*b, c]
+//       %1 = mhlo.dynamic_reshape(%arg0, ...) : (tensor<?x?x?xf32>,
+//       tensor<2xi64>) -> tensor<?x?xf32> %2 = "mhlo.reduce"(%1, ...) ( {...})
+//         {dimensions = dense<[1]> : tensor<1xi64>} :
+//         (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
+//       %3 = "mhlo.dynamic_reshape"(%2, ...) : (tensor<?xf32>, tensor<1xi64>)
+//       -> tensor<?x?f32> return %3 : tensor<?x?xf32>
+//     }
+//  ```
+//
+// For case c):
+// ====================================================================================
+//   we convert all reduce-to-scalar to rank-2 column reduction.
+//
+//   For example, suppose we have:
+//   ```
+//     func @test(%arg0: tensor<?x?x?xf32>) -> tensor<f32> {
+//       ...
+//       %2 = "mhlo.reduce"(%arg0, ...) ( {...})
+//         {dimensions = dense<[0,1,2]> : tensor<3xi64>} :
+//         (tensor<?x?x?xf32>, tensor<f32>) -> tensor<f32>
+//       return %2 : tensor<f32>
+//     }
+//  ```
+//   After conversion:
+//     func @test(%arg0: tensor<?x?x?xf32>) -> tensor<f32> {
+//       // [a, b, c] -> [a*b*c, 1]
+//       %1 = mhlo.dynamic_reshape(%arg0, ...) : (tensor<?x?x?xf32>,
+//       tensor<2xi64>) -> tensor<?x?xf32> %2 = "mhlo.reduce"(%1, ...) ( {...})
+//         {dimensions = dense<[0]> : tensor<1xi64>} :
+//         (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
+//       %3 = "mhlo.reshape"(%2, ...) : (tensor<?xf32>, tensor<1xi64>) ->
+//       tensor<f32> return %3 : tensor<f32>
+//     }
+//  ```
+
+struct HloCanonicalizeReductionPass
+    : HloCanonicalizeReductionPassBase<HloCanonicalizeReductionPass> {
+  void runOnFunction() override {
+    getFunction().walk([&](ReduceOp op) {
+      SmallVector<int64_t, 4> dims_to_reduce;
+      DenseSet<int64_t> dims_to_reduce_set;
+      for (auto dim : op.dimensions().getIntValues()) {
+        dims_to_reduce.push_back(dim.getSExtValue());
+        dims_to_reduce_set.insert(dims_to_reduce.back());
+      }
+
+      // empty reduction is just a no-op, thus no need to do codegen.
+      if (dims_to_reduce.empty()) return;
+      auto ty = op.getOperand(0).getType().dyn_cast<RankedTensorType>();
+      assert(ty && ty.hasRank() && "suppose reduce input is a ranked tensor");
+      int rank = ty.getRank();
+      int ndims_to_reduce = dims_to_reduce.size();
+      auto elem_ty = ty.getElementType();
+      std::sort(dims_to_reduce.begin(), dims_to_reduce.end());
+
+      // skip case d) form since we don't support it.
+      if ((dims_to_reduce.back() - dims_to_reduce[0]) !=
+              (ndims_to_reduce - 1) ||
+          (dims_to_reduce[0] != 0 && dims_to_reduce.back() != (rank - 1))) {
+        return;
+      }
+
+      // rank 2 row/column reduction is already supported.
+      if (rank == 2 && ndims_to_reduce == 1) {
+        return;
+      }
+
+      SmallVector<int64_t, 4> dims_to_keep;
+      for (int i = 0; i < rank; ++i) {
+        if (!dims_to_reduce_set.count(i)) dims_to_keep.push_back(i);
+      }
+
+      OpBuilder b(op);
+      auto loc = op.getLoc();
+      // TODO(disc): uniformed shape_scalar_type with shape_derivation
+      auto shape_scalar_type = b.getIntegerType(32);
+      auto one = b.create<ConstantIntOp>(loc, 1ll, shape_scalar_type);
+
+      // funtion to get total elements in selected dimensions
+      auto dim_prod = [&](ArrayRef<int64_t> dims) {
+        Value nelems = one;
+        for (int64_t v : dims) {
+          Value dim_index = b.create<memref::DimOp>(loc, op.getOperand(0), v);
+          nelems = b.create<MulIOp>(
+              loc, nelems,
+              b.create<IndexCastOp>(loc, dim_index, shape_scalar_type));
+        }
+        return nelems;
+      };
+
+      SmallVector<Value, 2> new_operand_dims;
+      DenseIntElementsAttr attr;
+      Value nelem_to_reduce = dim_prod(dims_to_reduce);
+      Value nelem_to_keep = dim_prod(dims_to_keep);
+      if (rank == ndims_to_reduce) {
+        // case c) Reduce to scalar.
+        // Currently we don't support reduce to scalar directly.
+        // As a workaround, we convert the `reduce to scalar` to a rank 2
+        // column reduction having following form:
+        // Suppose nelems = ProdutionOp(ShapeOp(I)), We convert I into
+        // shape `[nelems, 1]`.
+        // TODO(disc): this may have performance issue. Implements a reduce to
+        // scalar schedule if necessnary.
+        new_operand_dims.push_back(nelem_to_reduce);
+        new_operand_dims.push_back(nelem_to_keep);
+        attr = DenseIntElementsAttr::get(
+            RankedTensorType::get({1}, b.getIntegerType(64)), {0ll});
+      } else if (dims_to_reduce[0] == 0) {
+        // case a) column reduction
+        new_operand_dims.push_back(nelem_to_reduce);
+        new_operand_dims.push_back(nelem_to_keep);
+        attr = DenseIntElementsAttr::get(
+            RankedTensorType::get({1}, b.getIntegerType(64)), {0ll});
+      } else {
+        // case b) raw reduction
+        new_operand_dims.push_back(nelem_to_keep);
+        new_operand_dims.push_back(nelem_to_reduce);
+        attr = DenseIntElementsAttr::get(
+            RankedTensorType::get({1}, b.getIntegerType(64)), {1ll});
+      }
+
+      Value new_operand_shape =
+          b.create<tensor::FromElementsOp>(loc, new_operand_dims);
+
+      SmallVector<Value, 4> new_operands;
+      for (Value operand : op.inputs()) {
+        new_operands.push_back(b.create<DynamicReshapeOp>(
+            loc,
+            RankedTensorType::get(
+                SmallVector<int64_t, 4>(new_operand_dims.size(),
+                                        ShapedType::kDynamicSize),
+                elem_ty),
+            operand, new_operand_shape));
+      }
+      auto new_op =
+          b.create<ReduceOp>(loc, new_operands, op.init_values(), attr);
+      BlockAndValueMapping mapping;
+      op.body().cloneInto(&new_op.body(), new_op.body().end(), mapping);
+
+      SmallVector<Value, 4> new_results;
+      if (dims_to_keep.empty()) {
+        // case c) reduce to scalar
+        // reshape rank 1 tensor with size 1 to a rank 0 tensor
+        for (Value result : new_op.getResults()) {
+          new_results.push_back(b.create<ReshapeOp>(
+              loc, RankedTensorType::get({}, elem_ty), result));
+        }
+      } else {
+        SmallVector<Value, 4> result_dims;
+        for (int64_t i : dims_to_keep) {
+          Value dim_index = b.create<memref::DimOp>(loc, op.getOperand(0), i);
+          result_dims.push_back(
+              b.create<IndexCastOp>(loc, dim_index, shape_scalar_type));
+        }
+        Value result_shape = b.create<tensor::FromElementsOp>(loc, result_dims);
+        for (auto&& e : llvm::zip(op.getResults(), new_op.getResults())) {
+          new_results.push_back(b.create<DynamicReshapeOp>(
+              loc, std::get<0>(e).getType(), std::get<1>(e), result_shape));
+        }
+      }
+
+      for (auto&& e : llvm::zip(op.getResults(), new_results)) {
+        std::get<0>(e).replaceAllUsesWith(std::get<1>(e));
+      }
+      op.erase();
+    });
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<FunctionPass> createHloCanonicalizeReductionPass() {
+  return std::make_unique<HloCanonicalizeReductionPass>();
+}
+
+}  // namespace mhlo
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/tests/hlo_canonicalize_reduction.mlir
+++ b/tensorflow/compiler/mlir/hlo/tests/hlo_canonicalize_reduction.mlir
@@ -1,0 +1,107 @@
+// RUN: mlir-hlo-opt --hlo-canonicalize-reduction %s | FileCheck %s
+
+// rank2 column reduction should not be converted
+// CHECK-LABEL: @test_rank2_column_reduction
+// CHECK-NOT: reshape
+func @test_rank2_column_reduction(%arg0: tensor<?x?xf32>) -> tensor<?xf32> {
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<f32>
+  %2 = "mhlo.reduce"(%arg0, %0) ( {
+  ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+    %4 = mhlo.add %arg1, %arg2 : tensor<f32>
+    "mhlo.return"(%4) : (tensor<f32>) -> ()
+  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
+  return %2 : tensor<?xf32>
+}
+
+// -----
+
+// rank2 row reduction should not be converted
+// CHECK-LABEL: @test_rank2_row_reduction
+// CHECK-NOT: reshape
+func @test_rank2_row_reduction(%arg0: tensor<?x?xf32>) -> tensor<?xf32> {
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<f32>
+  %2 = "mhlo.reduce"(%arg0, %0) ( {
+  ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+    %4 = mhlo.add %arg1, %arg2 : tensor<f32>
+    "mhlo.return"(%4) : (tensor<f32>) -> ()
+  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
+  return %2 : tensor<?xf32>
+}
+
+// -----
+
+// rank3 column reduction
+// CHECK-LABEL: @test_rank3_column_reduction
+// CHECK: [[R1:%[a-zA-Z0-9]+]] = "mhlo.dynamic_reshape"
+// CHECK-SAME: (tensor<?x?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+// CHECK-NEXT: [[R2:%[a-zA-Z0-9]+]] = "mhlo.reduce"
+// CHECK-SAME: [[R1]]
+// CHECK: dimensions = dense<0> : tensor<1xi64>
+// CHECK: "mhlo.dynamic_reshape"
+// CHECK-SAME:  (tensor<?xf32>, tensor<1xi32>) -> tensor<?xf32>
+func @test_rank3_column_reduction(%arg0: tensor<?x?x?xf32>) -> tensor<?xf32> {
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<f32>
+  %2 = "mhlo.reduce"(%arg0, %0) ( {
+  ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+    %4 = mhlo.add %arg1, %arg2 : tensor<f32>
+    "mhlo.return"(%4) : (tensor<f32>) -> ()
+  }) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<?x?x?xf32>, tensor<f32>) -> tensor<?xf32>
+  return %2 : tensor<?xf32>
+}
+
+// // -----
+
+// rank3 row reduction
+// CHECK-LABEL: @test_rank3_row_reduction
+// CHECK: [[R1:%[a-zA-Z0-9]+]] = "mhlo.dynamic_reshape"
+// CHECK-SAME: (tensor<?x?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+// CHECK-NEXT: [[R2:%[a-zA-Z0-9]+]] = "mhlo.reduce"
+// CHECK-SAME: [[R1]]
+// CHECK: dimensions = dense<1> : tensor<1xi64>
+// CHECK: "mhlo.dynamic_reshape"
+// CHECK-SAME:  (tensor<?xf32>, tensor<1xi32>) -> tensor<?xf32>
+func @test_rank3_row_reduction(%arg0: tensor<?x?x?xf32>) -> tensor<?xf32> {
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<f32>
+  %2 = "mhlo.reduce"(%arg0, %0) ( {
+  ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+    %4 = mhlo.add %arg1, %arg2 : tensor<f32>
+    "mhlo.return"(%4) : (tensor<f32>) -> ()
+  }) {dimensions = dense<[1, 2]> : tensor<2xi64>} : (tensor<?x?x?xf32>, tensor<f32>) -> tensor<?xf32>
+  return %2 : tensor<?xf32>
+}
+
+// // -----
+
+// reduce to scalar
+// CHECK-LABEL: @test_reduce_to_scalar
+// CHECK: [[R1:%[a-zA-Z0-9]+]] = "mhlo.dynamic_reshape"
+// CHECK-SAME: (tensor<?x?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+// CHECK-NEXT: [[R2:%[a-zA-Z0-9]+]] = "mhlo.reduce"
+// CHECK-SAME: [[R1]]
+// CHECK: dimensions = dense<0> : tensor<1xi64>
+// CHECK: "mhlo.reshape"
+// CHECK-SAME: (tensor<?xf32>) -> tensor<f32>
+func @test_reduce_to_scalar(%arg0: tensor<?x?x?xf32>) -> tensor<f32> {
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<f32>
+  %2 = "mhlo.reduce"(%arg0, %0) ( {
+  ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+    %4 = mhlo.add %arg1, %arg2 : tensor<f32>
+    "mhlo.return"(%4) : (tensor<f32>) -> ()
+  }) {dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<?x?x?xf32>, tensor<f32>) -> tensor<f32>
+  return %2 : tensor<f32>
+}
+
+// -----
+
+// reduce the dimension in the middle, should not be converted.
+// CHECK-LABEL: @test_mid_reduction
+// CHECK-NOT: reshape
+func @test_mid_reduction(%arg0: tensor<?x?x?xf32>) -> tensor<?x?xf32> {
+  %0 = mhlo.constant dense<0.000000e+00> : tensor<f32>
+  %2 = "mhlo.reduce"(%arg0, %0) ( {
+  ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
+    %4 = mhlo.add %arg1, %arg2 : tensor<f32>
+    "mhlo.return"(%4) : (tensor<f32>) -> ()
+  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
+  return %2 : tensor<?x?xf32>
+}


### PR DESCRIPTION
This pass canonicalize `mhlo.ReduceOp` to the suitable forms, so that we can simplify the codegen process