### PR TITLE
Assign unique path to go package

### DIFF
--- a/tensorflow/core/framework/full_type.proto
+++ b/tensorflow/core/framework/full_type.proto
@@ -6,7 +6,7 @@ option cc_enable_arenas = true;
 option java_outer_classname = "FullTypeProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
-option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/types_go_proto";
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/full_type_go_proto";
 
 // Experimental. Represents the complete type information of a TensorFlow value.
 enum FullTypeId {


### PR DESCRIPTION
PR assigns a unique go_package path for full_types.proto; paths for those in core/framework are unique since 4221d1a 