### PR TITLE
Create 90-keras-issue.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/90-keras-issue.md
+++ b/.github/ISSUE_TEMPLATE/90-keras-issue.md
@@ -1,0 +1,18 @@
+---
+name: Keras Issue
+about: Use this template for reporting a keras issue
+labels: 'type:keras'
+
+---
+
+<em>Please make sure that this is an issue related to keras.
+tag:keras_template</em>
+
+
+**Important Notice**
+-
+Please note that `tf.keras` code was moved entirely to [keras-team/keras](https://github.com/keras-team/keras) repository
+-
+You can open any code/doc bugs, performance issues, and feature requests in [keras-team/keras](https://github.com/keras-team/keras/issues) repository
+-
+`tf.keras` related issues opened in [tensorflow/tensorflow](https://github.com/tensorflow/tensorflow) repository may not get attention as [keras-team/keras](https://github.com/keras-team/keras) repository is dedicated for the development of `keras` code  


### PR DESCRIPTION
Added a tf.keras template to notify the users about `tf.keras` code moved from [tensorflow/tensorflow](https://github.com/tensorflow/tensorflow) repository to [keras-team/keras](https://github.com/keras-team/keras) repository. 

Also, asking users to create new issues in [keras-team/keras](https://github.com/keras-team/keras/issues) repository.