### PR TITLE
[TFTRT] Correct SimpleITensor Assertion

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/utils/trt_tensor_proxy.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_tensor_proxy.h
@@ -163,7 +163,7 @@ class ITensorProxy {
 
   SimpleITensor* simple_tensor() const {
     assert(simple_tensor_ != nullptr);
-    assert(ttype_ == TensorType::kTRT);
+    assert(ttype_ == TensorType::kSIMPLE);
     return simple_tensor_.get();
   }
 


### PR DESCRIPTION
This fixes an incorrect assertion where the tensor type should be checked as kSIMPLE instead of kTRT.

CC @bixia1 @DEKHTIARJonathan @tfeher 