### PR TITLE
CombinedNMS plugin deactivated with TRT < 8. Only FP32 allowed with TRT >= 8

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -6948,7 +6948,7 @@ Status ConvertSquaredDifference(OpConverterParams* params) {
   return Status::OK();
 }
 
-#if IS_TRT_VERSION_GE(7, 1, 3, 0)
+#if IS_TRT_VERSION_GE(8, 0, 0, 0)
 
 bool AllowNmsTopkOverride() {
   static bool result = [] {
@@ -6989,6 +6989,11 @@ Status ConvertCombinedNMS(OpConverterParams* params) {
     return errors::Unimplemented(
         "TensorRT BatchedNMS Plugin requires input with static shape");
   }
+
+  // CombinedNMS Plugin only allow FP32 precision
+  std::set<DataType> allowed_types{DataType::DT_FLOAT};
+  TF_RETURN_IF_ERROR(AllowDataTypes(*params, allowed_types));
+
   const int offset = params->use_implicit_batch ? 0 : 1;
   if (boxes_dims.nbDims != 3 + offset) {
     return errors::InvalidArgument(
@@ -7150,7 +7155,7 @@ Status ConvertCombinedNMS(OpConverterParams* params) {
 
   return Status::OK();
 }
-#endif  // IS_TRT_VERSION_GE(7, 1, 3, 0)
+#endif  // IS_TRT_VERSION_GE(8, 0, 0 ,0)
 
 #if IS_TRT_VERSION_GE(6, 0, 0, 0)
 Status ConvertResize(OpConverterParams* params) {
@@ -7301,7 +7306,7 @@ static void RegisterValidatableOpConverters(
 #if IS_TRT_VERSION_GE(5, 1, 2, 0)
   (*registration)["ClipByValue"] = ConvertClipByValue;
 #endif
-#if IS_TRT_VERSION_GE(7, 1, 3, 0)
+#if IS_TRT_VERSION_GE(8, 0, 0, 0)
   (*registration)["CombinedNonMaxSuppression"] = ConvertCombinedNMS;
 #endif
   (*registration)["AddN"] = ConvertAddN;

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -3424,7 +3424,7 @@ TEST_P(OpConverter_FP32_FP16_Test, ConvertSquare) {
                   ArrayFloatNear(expected_outputs, 0));
 }
 
-#if IS_TRT_VERSION_GE(7, 1, 3, 0)
+#if IS_TRT_VERSION_GE(8, 0, 0 ,0)
 TEST_P(OpConverter_FP32_Test, ConvertCombinedNMS) {
   // Get the NodeDef for CombinedNMS.
   auto get_nms_nodedef = [](DataType tf_type, bool clip_boxes = true,
@@ -3472,11 +3472,16 @@ TEST_P(OpConverter_FP32_Test, ConvertCombinedNMS) {
     Status runtime_status;
   };
 
-  Status conv_status =
-      trt_mode_ == TrtTestMode::kDynamicShape
-          ? errors::Unimplemented(
-                "TensorRT BatchedNMS Plugin requires input with static shape")
-          : Status::OK();
+  Status conv_status;
+  if (trt_mode_ == TrtTestMode::kDynamicShape) {
+    conv_status = errors::Unimplemented(
+          "TensorRT BatchedNMS Plugin requires input with static shape");
+  } else if () {
+    errors::Unimplemented(StrCat("Data type int32 is not supported for ",
+                          node_def.op(), ", must be one of [float], at my_nms");
+  } else {
+    conv_status = Status::OK();
+  }
 
   std::vector<TestParams> params = {
       // TODO(aaroey): there is a bug in TRT's CombinedNonMaxSuppression
@@ -3627,7 +3632,7 @@ TEST_P(OpConverter_FP32_Test, ConvertCombinedNMS) {
                             {tf_type_, tf_type_, tf_type_, DT_INT32});
   }
 }
-#endif  // IS_TRT_VERSION_GE(7, 1, 3, 0)
+#endif  // IS_TRT_VERSION_GE(8, 0, 0 ,0)
 
 template <typename T>
 NodeDef CreateUnaryOp(DataType tf_type) {

--- a/tensorflow/python/compiler/tensorrt/test/combined_nms_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/combined_nms_test.py
@@ -95,12 +95,14 @@ class CombinedNmsTest(trt_test.TfTrtIntegrationTestBase):
 
   def ShouldRunTest(self, run_params):
     should_run, reason = super().ShouldRunTest(run_params)
-    should_run = should_run and \
-        not trt_test.IsQuantizationMode(run_params.precision_mode)
-    reason += ' and precision != INT8'
-    # Only run for TRT 7.1.3 and above.
-    return should_run and trt_test.IsTensorRTVersionGreaterEqual(7, 1, 3), \
-        reason + ' and >= TRT 7.1.3'
+
+    # CombinedNMS TensorRT Plugin only supports FP32 precision
+    should_run = should_run and run_params.precision_mode == "FP32"
+    reason += ' and precision != FP32'
+
+    # Only run for TRT 8.0.0 and above.
+    return should_run and trt_test.IsTensorRTVersionGreaterEqual(8, 0, 0), \
+        reason + ' and >= TRT 8.0.0'
 
 
 class CombinedNmsExecuteNativeSegmentTest(CombinedNmsTest):


### PR DESCRIPTION
This PR closes and replaces https://github.com/tensorflow/tensorflow/pull/48950.

- Disallow CombinedNMS Converter for TensorRT < 8.
- Only allow FP32 CombinedNMS with TensorRT >= 8.

This PR addresses issues with the CombinedNMS TensorRT plugin.

@bixia1 for review
CC: @jhalakpatel @tfeher 