### PR TITLE
support fixed64 in features parser .

### DIFF
--- a/tensorflow/core/example/feature.proto
+++ b/tensorflow/core/example/feature.proto
@@ -74,6 +74,9 @@ message FloatList {
 message Int64List {
   repeated int64 value = 1 [packed = true];
 }
+message Fixed64List {
+  repeated fixed64 value = 1 [packed = true];
+}
 
 // Containers for non-sequential data.
 message Feature {
@@ -82,6 +85,7 @@ message Feature {
     BytesList bytes_list = 1;
     FloatList float_list = 2;
     Int64List int64_list = 3;
+    Fixed64List fixed64_list = 4;
   }
 }
 


### PR DESCRIPTION
### Current:
1. Our model have 900+ features(will be expanded to 2000 features within one year).
2. We run tensorflow on A100 machine, and our model currently consumes TFRecord very fast, now 1700,000 TFRecords/s. PS:We replace TFRecord reader from disk to high-performance network and memory cache.
After the above change, we find deserialize varint64 is very hot, so we check how to decode varint64 in pb.

### Varint64 and Fixed64

**Varint64:** A variable-length storage format, the details:https://developers.google.com/protocol-buffers/docs/encoding
**Fixed64**: A fixed-length storage format, fixed use 64bit to save uint64_t
Decoding varint64 needs two loop.
1. Check whether the highest bit of each byte is 1
2. Iterate and decode each byte, and then compose each byte into uint64_t
Varint64 decodes very fast when the number is small, such as using 2-3 bytes numbers(1bytes special deal).

### Why we replace Varint64 to fixed64:

But unfortunately, because our confidential data, we have to save big hash values.The storage of the hash value usually uses 7-8 bytes, and varint64 is very unfriendly to decode the hash value.
so I want to replace from varint64 to fixed64, we have **a small test in _protobuf_**, through varint64 and fixed64 decoding the same hash data, we get fixed64 10 times faster than varint64.(The example is a bit complicated, but I can provide it if necessary)

**Do you think it is necessary for TF to add the fixed64 type? If necessary, I can contribute this part of the code.**

 ### Remarks some profiling result:
![image](https://user-images.githubusercontent.com/33950866/123361876-5f95c080-d5a2-11eb-8184-e9cb79b5875c.png)
![image](https://user-images.githubusercontent.com/33950866/123410135-8aebd000-d5e1-11eb-9770-197fdfb8473b.png)
![image](https://user-images.githubusercontent.com/33950866/123410172-963efb80-d5e1-11eb-9f0c-b015cba5c07b.png)