### PR TITLE
Add the newly added kernels_experimental header file to pip package.

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -554,7 +554,10 @@ tf_cuda_library(
 
 cc_library(
     name = "kernels_hdrs",
-    hdrs = ["kernels.h"],
+    hdrs = [
+        "kernels.h",
+        "kernels_experimental.h"
+    ],
     visibility = ["//tensorflow:internal"],
     deps = [
         ":c_api_internal",


### PR DESCRIPTION
The change adds the kernels_experimental.h header file to `kernels_hdrs` target so that it can appear to pip package.

@penpornk can you please take a look.