### PR TITLE
Fix indices rank in decompose ResourceScatterOp 

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/transforms/decompose_resource_ops.td
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/decompose_resource_ops.td
@@ -348,7 +348,8 @@ def DecomposeResourceScatterAdd : Pat<
     $resource,
     (TF_TensorScatterAddOp
       (CreateTFReadVariableOp $src_op, $updates, $resource),
-      $indices,
+      (TF_ExpandDimsOp $indices,
+       (TF_ConstOp (GetScalarOfType<-1> $indices))),
       $updates
     )
   )>;
@@ -363,7 +364,8 @@ def DecomposeResourceScatterUpdate : Pat<
     $resource,
     (TF_TensorScatterUpdateOp
       (CreateTFReadVariableOp $src_op, $updates, $resource),
-      $indices,
+      (TF_ExpandDimsOp $indices,
+       (TF_ConstOp (GetScalarOfType<-1> $indices))),
       $updates
     )
   )>;


### PR DESCRIPTION
Since indices.shape[:-1] + tensor.shape[indices.shape[-1]:], we need
indices.shape[-1] to be 1. This fix ensures that indices has the right
rank, S.T above condition is met.
