### PR TITLE
WAR a bazel cache corruption issue.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -352,6 +352,10 @@ build:windows --distinct_host_configuration=false
 # On linux, don't cross compile by default
 build:linux --distinct_host_configuration=false
 
+# Do not risk cache corruption. See:
+# https://github.com/bazelbuild/bazel/issues/3360
+build:linux --experimental_guard_against_concurrent_changes
+
 # Configure short or long logs
 build:short_logs --output_filter=DONT_MATCH_ANYTHING
 build:verbose_logs --output_filter=


### PR DESCRIPTION
Bazel is taking much time to enable the WAR.
@sanjoy suggested to enable it now for us.

Having a potential cache corruption is something very bad to have.