### PR TITLE
[ROCm] Adding complex type support for SparseTensorDenseMatMul op (on the ROCm platform)

### DIFF
--- a/tensorflow/core/kernels/sparse_tensor_dense_matmul_op.cc
+++ b/tensorflow/core/kernels/sparse_tensor_dense_matmul_op.cc
@@ -203,12 +203,8 @@ namespace functor {
 DECLARE_ADJOINT_GPU_SPEC(Eigen::half);
 DECLARE_ADJOINT_GPU_SPEC(float);
 DECLARE_ADJOINT_GPU_SPEC(double);
-
-// ROCm's GpuAtomicAdd doesn't support std::complex yet.
-#ifndef TENSORFLOW_USE_ROCM
 DECLARE_ADJOINT_GPU_SPEC(complex64);
 DECLARE_ADJOINT_GPU_SPEC(complex128);
-#endif
 
 #undef DECLARE_ADJOINT_GPU_SPEC
 #undef DECLARE_GPU_SPEC
@@ -232,12 +228,8 @@ DECLARE_ADJOINT_GPU_SPEC(complex128);
 REGISTER_KERNELS_GPU(Eigen::half);
 REGISTER_KERNELS_GPU(float);
 REGISTER_KERNELS_GPU(double);
-
-// ROCm's GpuAtomicAdd doesn't support std::complex yet.
-#ifndef TENSORFLOW_USE_ROCM
 REGISTER_KERNELS_GPU(complex64);
 REGISTER_KERNELS_GPU(complex128);
-#endif
 
 #undef REGISTER_GPU
 #undef REGISTER_KERNELS_GPU

--- a/tensorflow/core/kernels/sparse_tensor_dense_matmul_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/sparse_tensor_dense_matmul_op_gpu.cu.cc
@@ -155,12 +155,8 @@ struct SparseTensorDenseMatMulFunctor<GPUDevice, T, Tindices, ADJ_A, ADJ_B> {
 DEFINE_ALL_INDEX_TYPES(Eigen::half);
 DEFINE_ALL_INDEX_TYPES(float);
 DEFINE_ALL_INDEX_TYPES(double);
-
-// ROCm's GpuAtomicAdd doesn't support std::complex yet.
-#ifndef TENSORFLOW_USE_ROCM
 DEFINE_ALL_INDEX_TYPES(complex64);
 DEFINE_ALL_INDEX_TYPES(complex128);
-#endif
 
 #undef DEFINE_ALL_INDEX_TYPES
 #undef DEFINE


### PR DESCRIPTION
/cc @cheshire @chsigg 