### PR TITLE
r2.6 cherry-pick request: Add the missing kernels_experimental header file to pip package

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -554,7 +554,10 @@ tf_cuda_library(
 
 cc_library(
     name = "kernels_hdrs",
-    hdrs = ["kernels.h"],
+    hdrs = [
+        "kernels.h",
+        "kernels_experimental.h"
+    ],
     visibility = ["//tensorflow:internal"],
     deps = [
         ":c_api_internal",

--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -556,7 +556,7 @@ cc_library(
     name = "kernels_hdrs",
     hdrs = [
         "kernels.h",
-        "kernels_experimental.h"
+        "kernels_experimental.h",
     ],
     visibility = ["//tensorflow:internal"],
     deps = [


### PR DESCRIPTION
PR #49717 adds [Resource Variable ops support to kernel C API](https://github.com/tensorflow/community/pull/387) in a new `kernel_experimental` file. However, it failed to add the new header file to the pip package, so PluggableDevices aren't able to use it yet. This PR fixed that. With this fix, TensorFlow can train models on PluggableDevices.

Original PR (merged into master on 6/26): #50462 
cc: @kulinseth @saxenasaurabh 