### PR TITLE
remove unnecessary cudaFree(nullptr) call

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -1277,12 +1277,6 @@ Status BaseGPUDeviceFactory::CreateDevices(
             "cudaSetDevice() on GPU:", platform_device_id.value(),
             " failed. Status: ", cudaGetErrorString(err));
       }
-      err = cudaFree(nullptr);
-      if (err != cudaSuccess) {
-        return errors::Internal("CUDA runtime implicit initialization on GPU:",
-                                platform_device_id.value(),
-                                " failed. Status: ", cudaGetErrorString(err));
-      }
       int priority_low, priority_high;
       cudaDeviceGetStreamPriorityRange(&priority_low, &priority_high);
       if (err != cudaSuccess) {


### PR DESCRIPTION
Corresponding issue: https://github.com/tensorflow/tensorflow/issues/50232
As commented here: https://github.com/tensorflow/tensorflow/issues/50232#issuecomment-862034257, this cudaFree call could be unnecessary. 

The behavior of `cudaSetDevice` remains for CUDA version 9+.

[gpu_device_test.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/common_runtime/gpu/gpu_device_test.cc) contains comprehensive test cases to prevent regression, so not writing unit tests here.