### PR TITLE
Fix numpy 1.20 deprecation warnings

### DIFF
--- a/tensorflow/compiler/tests/binary_ops_test.py
+++ b/tensorflow/compiler/tests/binary_ops_test.py
@@ -772,123 +772,123 @@ class BinaryOpsTest(xla_test.XLATestCase):
   def testLogicalOps(self):
     self._testBinary(
         math_ops.logical_and,
-        np.array([[True, False], [False, True]], dtype=np.bool),
-        np.array([[False, True], [False, True]], dtype=np.bool),
-        expected=np.array([[False, False], [False, True]], dtype=np.bool))
+        np.array([[True, False], [False, True]], dtype=np.bool_),
+        np.array([[False, True], [False, True]], dtype=np.bool_),
+        expected=np.array([[False, False], [False, True]], dtype=np.bool_))
 
     self._testBinary(
         math_ops.logical_or,
-        np.array([[True, False], [False, True]], dtype=np.bool),
-        np.array([[False, True], [False, True]], dtype=np.bool),
-        expected=np.array([[True, True], [False, True]], dtype=np.bool))
+        np.array([[True, False], [False, True]], dtype=np.bool_),
+        np.array([[False, True], [False, True]], dtype=np.bool_),
+        expected=np.array([[True, True], [False, True]], dtype=np.bool_))
 
   def testComparisons(self):
     self._testBinary(
         math_ops.equal,
         np.array([1, 5, 20], dtype=np.float32),
         np.array([10, 5, 2], dtype=np.float32),
-        expected=np.array([False, True, False], dtype=np.bool))
+        expected=np.array([False, True, False], dtype=np.bool_))
     self._testBinary(
         math_ops.equal,
         np.float32(5),
         np.array([1, 5, 20], dtype=np.float32),
-        expected=np.array([False, True, False], dtype=np.bool))
+        expected=np.array([False, True, False], dtype=np.bool_))
     self._testBinary(
         math_ops.equal,
         np.array([[10], [7], [2]], dtype=np.float32),
         np.float32(7),
-        expected=np.array([[False], [True], [False]], dtype=np.bool))
+        expected=np.array([[False], [True], [False]], dtype=np.bool_))
 
     self._testBinary(
         math_ops.not_equal,
         np.array([1, 5, 20], dtype=np.float32),
         np.array([10, 5, 2], dtype=np.float32),
-        expected=np.array([True, False, True], dtype=np.bool))
+        expected=np.array([True, False, True], dtype=np.bool_))
     self._testBinary(
         math_ops.not_equal,
         np.float32(5),
         np.array([1, 5, 20], dtype=np.float32),
-        expected=np.array([True, False, True], dtype=np.bool))
+        expected=np.array([True, False, True], dtype=np.bool_))
     self._testBinary(
         math_ops.not_equal,
         np.array([[10], [7], [2]], dtype=np.float32),
         np.float32(7),
-        expected=np.array([[True], [False], [True]], dtype=np.bool))
+        expected=np.array([[True], [False], [True]], dtype=np.bool_))
 
     for greater_op in [math_ops.greater, (lambda x, y: x > y)]:
       self._testBinary(
           greater_op,
           np.array([1, 5, 20], dtype=np.float32),
           np.array([10, 5, 2], dtype=np.float32),
-          expected=np.array([False, False, True], dtype=np.bool))
+          expected=np.array([False, False, True], dtype=np.bool_))
       self._testBinary(
           greater_op,
           np.float32(5),
           np.array([1, 5, 20], dtype=np.float32),
-          expected=np.array([True, False, False], dtype=np.bool))
+          expected=np.array([True, False, False], dtype=np.bool_))
       self._testBinary(
           greater_op,
           np.array([[10], [7], [2]], dtype=np.float32),
           np.float32(7),
-          expected=np.array([[True], [False], [False]], dtype=np.bool))
+          expected=np.array([[True], [False], [False]], dtype=np.bool_))
 
     for greater_equal_op in [math_ops.greater_equal, (lambda x, y: x >= y)]:
       self._testBinary(
           greater_equal_op,
           np.array([1, 5, 20], dtype=np.float32),
           np.array([10, 5, 2], dtype=np.float32),
-          expected=np.array([False, True, True], dtype=np.bool))
+          expected=np.array([False, True, True], dtype=np.bool_))
       self._testBinary(
           greater_equal_op,
           np.float32(5),
           np.array([1, 5, 20], dtype=np.float32),
-          expected=np.array([True, True, False], dtype=np.bool))
+          expected=np.array([True, True, False], dtype=np.bool_))
       self._testBinary(
           greater_equal_op,
           np.array([[10], [7], [2]], dtype=np.float32),
           np.float32(7),
-          expected=np.array([[True], [True], [False]], dtype=np.bool))
+          expected=np.array([[True], [True], [False]], dtype=np.bool_))
 
     for less_op in [math_ops.less, (lambda x, y: x < y)]:
       self._testBinary(
           less_op,
           np.array([1, 5, 20], dtype=np.float32),
           np.array([10, 5, 2], dtype=np.float32),
-          expected=np.array([True, False, False], dtype=np.bool))
+          expected=np.array([True, False, False], dtype=np.bool_))
       self._testBinary(
           less_op,
           np.float32(5),
           np.array([1, 5, 20], dtype=np.float32),
-          expected=np.array([False, False, True], dtype=np.bool))
+          expected=np.array([False, False, True], dtype=np.bool_))
       self._testBinary(
           less_op,
           np.array([[10], [7], [2]], dtype=np.float32),
           np.float32(7),
-          expected=np.array([[False], [False], [True]], dtype=np.bool))
+          expected=np.array([[False], [False], [True]], dtype=np.bool_))
       if np.int64 in self.numeric_types:
         self._testBinary(
             less_op,
             np.array([[10], [7], [2], [-1]], dtype=np.int64),
             np.int64(7),
             expected=np.array(
-                [[False], [False], [True], [True]], dtype=np.bool))
+                [[False], [False], [True], [True]], dtype=np.bool_))
 
     for less_equal_op in [math_ops.less_equal, (lambda x, y: x <= y)]:
       self._testBinary(
           less_equal_op,
           np.array([1, 5, 20], dtype=np.float32),
           np.array([10, 5, 2], dtype=np.float32),
-          expected=np.array([True, True, False], dtype=np.bool))
+          expected=np.array([True, True, False], dtype=np.bool_))
       self._testBinary(
           less_equal_op,
           np.float32(5),
           np.array([1, 5, 20], dtype=np.float32),
-          expected=np.array([False, True, True], dtype=np.bool))
+          expected=np.array([False, True, True], dtype=np.bool_))
       self._testBinary(
           less_equal_op,
           np.array([[10], [7], [2]], dtype=np.float32),
           np.float32(7),
-          expected=np.array([[False], [True], [True]], dtype=np.bool))
+          expected=np.array([[False], [True], [True]], dtype=np.bool_))
 
   def testS64Comparisons(self):
     for op in [(lambda x, y: x < y), (lambda x, y: x <= y),
@@ -961,7 +961,7 @@ class BinaryOpsTest(xla_test.XLATestCase):
               np.int64(-1)
           ],
           dtype=np.int64)
-      expected = np.array([op(l, r) for l, r in zip(lhs, rhs)], dtype=np.bool)
+      expected = np.array([op(l, r) for l, r in zip(lhs, rhs)], dtype=np.bool_)
       self._testBinary(op, lhs, rhs, expected=expected)
 
   def testBroadcasting(self):

--- a/tensorflow/compiler/tests/reduce_ops_test.py
+++ b/tensorflow/compiler/tests/reduce_ops_test.py
@@ -92,8 +92,8 @@ class ReduceOpsTest(xla_test.XLATestCase, parameterized.TestCase):
   NONEMPTY_REAL_DATA = [x for x in REAL_DATA if np.size(x) > 0]
   NONEMPTY_COMPLEX_DATA = [x for x in COMPLEX_DATA if np.size(x) > 0]
   BOOL_DATA = [
-      np.array([], dtype=np.bool).reshape(2, 0),
-      np.array([], dtype=np.bool).reshape(0, 3),
+      np.array([], dtype=np.bool_).reshape(2, 0),
+      np.array([], dtype=np.bool_).reshape(0, 3),
       np.array([[False, True, False], [True, True, False]]),
   ]
   ONES = [np.ones([34000, 2])]
@@ -165,11 +165,11 @@ class ReduceOpsTest(xla_test.XLATestCase, parameterized.TestCase):
                         self.NONEMPTY_COMPLEX_DATA, index_dtype)
 
   def testReduceAll(self, index_dtype):
-    self._testReduction(math_ops.reduce_all, np.all, np.bool, self.BOOL_DATA,
+    self._testReduction(math_ops.reduce_all, np.all, np.bool_, self.BOOL_DATA,
                         index_dtype)
 
   def testReduceAny(self, index_dtype):
-    self._testReduction(math_ops.reduce_any, np.any, np.bool, self.BOOL_DATA,
+    self._testReduction(math_ops.reduce_any, np.any, np.bool_, self.BOOL_DATA,
                         index_dtype)
 
   @test_util.disable_mlir_bridge('Error messages differ')

--- a/tensorflow/compiler/tests/ternary_ops_test.py
+++ b/tensorflow/compiler/tests/ternary_ops_test.py
@@ -102,14 +102,14 @@ class TernaryOpsTest(xla_test.XLATestCase, parameterized.TestCase):
 
       self._testTernary(
           array_ops.where,
-          np.array([0, 1, 1, 0], dtype=np.bool),
+          np.array([0, 1, 1, 0], dtype=np.bool_),
           np.array([1, 2, 3, 4], dtype=dtype),
           np.array([5, 6, 7, 8], dtype=dtype),
           expected=np.array([5, 2, 3, 8], dtype=dtype))
 
       self._testTernary(
           array_ops.where,
-          np.array([0, 1, 0], dtype=np.bool),
+          np.array([0, 1, 0], dtype=np.bool_),
           np.array([[1, 2], [3, 4], [5, 6]], dtype=dtype),
           np.array([[7, 8], [9, 10], [11, 12]], dtype=dtype),
           expected=np.array([[7, 8], [3, 4], [11, 12]], dtype=dtype))
@@ -139,7 +139,7 @@ class TernaryOpsTest(xla_test.XLATestCase, parameterized.TestCase):
 
       self._testTernary(
           array_ops.where_v2,
-          np.array([0, 1, 1, 0], dtype=np.bool),
+          np.array([0, 1, 1, 0], dtype=np.bool_),
           np.array([1, 2, 3, 4], dtype=dtype),
           np.array([5, 6, 7, 8], dtype=dtype),
           expected=np.array([5, 2, 3, 8], dtype=dtype))
@@ -147,7 +147,7 @@ class TernaryOpsTest(xla_test.XLATestCase, parameterized.TestCase):
       # Broadcast the condition
       self._testTernary(
           array_ops.where_v2,
-          np.array([0, 1], dtype=np.bool),
+          np.array([0, 1], dtype=np.bool_),
           np.array([[1, 2], [3, 4], [5, 6]], dtype=dtype),
           np.array([[7, 8], [9, 10], [11, 12]], dtype=dtype),
           expected=np.array([[7, 2], [9, 4], [11, 6]], dtype=dtype))
@@ -155,7 +155,7 @@ class TernaryOpsTest(xla_test.XLATestCase, parameterized.TestCase):
       # Broadcast the then branch to the else
       self._testTernary(
           array_ops.where_v2,
-          np.array([[0, 1], [1, 0], [1, 1]], dtype=np.bool),
+          np.array([[0, 1], [1, 0], [1, 1]], dtype=np.bool_),
           np.array([[1, 2]], dtype=dtype),
           np.array([[7, 8], [9, 10], [11, 12]], dtype=dtype),
           expected=np.array([[7, 2], [1, 10], [1, 2]], dtype=dtype))
@@ -163,7 +163,7 @@ class TernaryOpsTest(xla_test.XLATestCase, parameterized.TestCase):
       # Broadcast the else branch to the then
       self._testTernary(
           array_ops.where_v2,
-          np.array([[1, 0], [0, 1], [0, 0]], dtype=np.bool),
+          np.array([[1, 0], [0, 1], [0, 0]], dtype=np.bool_),
           np.array([[7, 8], [9, 10], [11, 12]], dtype=dtype),
           np.array([[1, 2]], dtype=dtype),
           expected=np.array([[7, 2], [1, 10], [1, 2]], dtype=dtype))
@@ -171,13 +171,13 @@ class TernaryOpsTest(xla_test.XLATestCase, parameterized.TestCase):
       # Broadcast the then/else branches to the condition
       self._testTernary(
           array_ops.where_v2,
-          np.array([[1, 0], [0, 1], [1, 1]], dtype=np.bool),
+          np.array([[1, 0], [0, 1], [1, 1]], dtype=np.bool_),
           np.array(7, dtype=dtype),
           np.array(8, dtype=dtype),
           expected=np.array([[7, 8], [8, 7], [7, 7]], dtype=dtype))
       self._testTernary(
           array_ops.where_v2,
-          np.array([[1, 0], [0, 1], [0, 0]], dtype=np.bool),
+          np.array([[1, 0], [0, 1], [0, 0]], dtype=np.bool_),
           np.array(7, dtype=dtype),
           np.array([8, 9], dtype=dtype),
           expected=np.array([[7, 9], [8, 7], [8, 9]], dtype=dtype))

--- a/tensorflow/compiler/tests/unary_ops_test.py
+++ b/tensorflow/compiler/tests/unary_ops_test.py
@@ -147,6 +147,7 @@ class UnaryOpsTest(xla_test.XLATestCase):
   def testLog(self):
     for dtype in self.float_types - {dtypes.bfloat16.as_numpy_dtype}:
       tol = 1e-4 if dtype == np.float32 else 1e-9
+      # pylint: disable=invalid-unary-operand-type
       x = np.linspace(-np.e, np.e, num=1000, dtype=dtype)
       self._assertOpOutputMatchesExpected(
           math_ops.log, x, expected=np.log(x), atol=tol, rtol=tol)
@@ -263,7 +264,7 @@ class UnaryOpsTest(xla_test.XLATestCase):
           math_ops.is_finite,
           np.array(
               [[np.NINF, -2, -1, 0, 0.5, 1, 2, np.inf, np.nan]], dtype=dtype),
-          expected=np.array([[0, 1, 1, 1, 1, 1, 1, 0, 0]], dtype=np.bool))
+          expected=np.array([[0, 1, 1, 1, 1, 1, 1, 0, 0]], dtype=np.bool_))
 
       # Tests for tf.nn ops.
       self._assertOpOutputMatchesExpected(
@@ -449,7 +450,7 @@ class UnaryOpsTest(xla_test.XLATestCase):
           np.array(
               [[42, float("inf"), -123], [float("nan"), 0, -0.0]], dtype=dtype),
           expected=np.array(
-              [[True, False, True], [False, True, True]], dtype=np.bool))
+              [[True, False, True], [False, True, True]], dtype=np.bool_))
 
       self._assertOpOutputMatchesExpected(
           math_ops.lgamma,
@@ -855,12 +856,12 @@ class UnaryOpsTest(xla_test.XLATestCase):
           math_ops.is_inf,
           np.array(
               [[np.NINF, -2, -1, 0, 0.5, 1, 2, np.inf, np.nan]], dtype=dtype),
-          expected=np.array([[1, 0, 0, 0, 0, 0, 0, 1, 0]], dtype=np.bool))
+          expected=np.array([[1, 0, 0, 0, 0, 0, 0, 1, 0]], dtype=np.bool_))
       self._assertOpOutputMatchesExpected(
           math_ops.is_nan,
           np.array(
               [[np.NINF, -2, -1, 0, 0.5, 1, 2, np.inf, np.nan]], dtype=dtype),
-          expected=np.array([[0, 0, 0, 0, 0, 0, 0, 0, 1]], dtype=np.bool))
+          expected=np.array([[0, 0, 0, 0, 0, 0, 0, 0, 1]], dtype=np.bool_))
       self._assertOpOutputMatchesExpected(
           math_ops.sign,
           np.array([[np.nan]], dtype=dtype),
@@ -869,8 +870,8 @@ class UnaryOpsTest(xla_test.XLATestCase):
   def testLogicalOps(self):
     self._assertOpOutputMatchesExpected(
         math_ops.logical_not,
-        np.array([[True, False], [False, True]], dtype=np.bool),
-        expected=np.array([[False, True], [True, False]], dtype=np.bool))
+        np.array([[True, False], [False, True]], dtype=np.bool_),
+        expected=np.array([[False, True], [True, False]], dtype=np.bool_))
 
   def testBiasAddGrad(self):
     self._assertOpOutputMatchesExpected(

--- a/tensorflow/compiler/xla/python/xla_client_test.py
+++ b/tensorflow/compiler/xla/python/xla_client_test.py
@@ -126,8 +126,8 @@ def TestFactory(xla_backend,
     return np.array(*args, dtype=np.int32, **kwargs)
 
   def NumpyArrayBool(*args, **kwargs):
-    """Convenience wrapper to create Numpy arrays with a np.bool dtype."""
-    return np.array(*args, dtype=np.bool, **kwargs)
+    """Convenience wrapper to create Numpy arrays with a np.bool_ dtype."""
+    return np.array(*args, dtype=np.bool_, **kwargs)
 
   class ComputationPrinting(absltest.TestCase):
 
@@ -731,7 +731,7 @@ def TestFactory(xla_backend,
         "src_dtype": src_dtype,
         "dst_dtype": dst_dtype,
     } for src_dtype, dst_dtype in itertools.permutations(
-        [np.bool, np.int32, np.int64, np.float32, np.float64], 2))
+        [np.bool_, np.int32, np.int64, np.float32, np.float64], 2))
     # pyformat: enable
     def testConvertElementType(self, src_dtype, dst_dtype):
       if ((src_dtype in [np.int64, np.float64] or

--- a/tensorflow/compiler/xla/python_api/types.py
+++ b/tensorflow/compiler/xla/python_api/types.py
@@ -116,7 +116,7 @@ MAP_XLA_TYPE_TO_RECORD = {
     xla_data_pb2.PRED:
         TypeConversionRecord(
             primitive_type=xla_data_pb2.PRED,
-            numpy_dtype=_np.bool,
+            numpy_dtype=_np.bool_,
             literal_field_name='preds',
             literal_field_type=bool)
 }

--- a/tensorflow/lite/experimental/mlir/testing/op_tests/cond.py
+++ b/tensorflow/lite/experimental/mlir/testing/op_tests/cond.py
@@ -57,7 +57,7 @@ def make_cond_tests(options):
     input_values = [
         create_tensor_data(parameters["dtype"], (1,)),
         create_tensor_data(parameters["dtype"], (1,)),
-        np.array([parameters["pred"]], dtype=np.bool),
+        np.array([parameters["pred"]], dtype=np.bool_),
     ]
     return input_values, sess.run(
         outputs, feed_dict=dict(zip(inputs, input_values)))

--- a/tensorflow/lite/testing/zip_test_utils.py
+++ b/tensorflow/lite/testing/zip_test_utils.py
@@ -80,7 +80,7 @@ TF_TYPE_INFO = {
     tf.uint8: (np.uint8, "QUANTIZED_UINT8"),
     tf.int16: (np.int16, "QUANTIZED_INT16"),
     tf.int64: (np.int64, "INT64"),
-    tf.bool: (np.bool, "BOOL"),
+    tf.bool: (np.bool_, "BOOL"),
     tf.string: (np.string_, "STRING"),
 }
 

--- a/tensorflow/python/client/session.py
+++ b/tensorflow/python/client/session.py
@@ -1440,7 +1440,7 @@ class BaseSession(SessionInterface):
         fetches.append(mover[1])
       handles = self.run(fetches, feed_dict=feeds)
       for handle_mover, handle in zip(handle_movers, handles):
-        np_val = np.array(handle.handle, dtype=np.object)
+        np_val = np.array(handle.handle, dtype=np.object_)
         feed_name = handle_mover[0]
         feed_tensor = feed_map[feed_name][0]
         feed_dict[feed_tensor.ref()] = np_val

--- a/tensorflow/python/client/session_test.py
+++ b/tensorflow/python/client/session_test.py
@@ -1571,7 +1571,7 @@ class SessionTest(test_util.TensorFlowTestCase):
           size *= s
         c_list = np.array(
             [compat.as_bytes(str(i)) for i in xrange(size)],
-            dtype=np.object).reshape(shape) if size > 0 else []
+            dtype=np.object_).reshape(shape) if size > 0 else []
         c = constant_op.constant(c_list)
         self.assertAllEqual(c, c_list)
 
@@ -1583,7 +1583,7 @@ class SessionTest(test_util.TensorFlowTestCase):
           size *= s
         c_list = np.array(
             [compat.as_bytes(str(i)) for i in xrange(size)],
-            dtype=np.object).reshape(shape)
+            dtype=np.object_).reshape(shape)
         feed_t = array_ops.placeholder(dtype=dtypes.string, shape=shape)
         c = array_ops.identity(feed_t)
         self.assertAllEqual(sess.run(c, feed_dict={feed_t: c_list}), c_list)
@@ -1617,7 +1617,7 @@ class SessionTest(test_util.TensorFlowTestCase):
       for i in range(len(c_list)):
         self.assertEqual(c_list[i], out[i].decode('utf-8'))
 
-      out = c.eval(feed_dict={feed_t: np.array(c_list, dtype=np.object)})
+      out = c.eval(feed_dict={feed_t: np.array(c_list, dtype=np.object_)})
       for i in range(len(c_list)):
         self.assertEqual(c_list[i], out[i].decode('utf-8'))
 

--- a/tensorflow/python/debug/cli/tensor_format.py
+++ b/tensorflow/python/debug/cli/tensor_format.py
@@ -536,7 +536,7 @@ def numeric_summary(tensor):
     return debugger_cli_common.RichTextLines([
         "No numeric summary available due to empty tensor."])
   elif (np.issubdtype(tensor.dtype, np.floating) or
-        np.issubdtype(tensor.dtype, np.complex) or
+        np.issubdtype(tensor.dtype, np.complexfloating) or
         np.issubdtype(tensor.dtype, np.integer)):
     counts = [
         ("nan", np.sum(np.isnan(tensor))),
@@ -559,7 +559,7 @@ def numeric_summary(tensor):
           ("std", np.std(valid_array))]
       output.extend(_counts_summary(stats, skip_zeros=False))
     return output
-  elif tensor.dtype == np.bool:
+  elif tensor.dtype == np.bool_:
     counts = [
         ("False", np.sum(tensor == 0)),
         ("True", np.sum(tensor > 0)),]

--- a/tensorflow/python/debug/cli/tensor_format_test.py
+++ b/tensorflow/python/debug/cli/tensor_format_test.py
@@ -686,29 +686,29 @@ class NumericSummaryTest(test_util.TensorFlowTestCase):
         self, [-3, 3, 1.79282868526, 2.39789673081], out.lines[3:4])
 
   def testNumericSummaryOnBool(self):
-    x = np.array([False, True, True, False], dtype=np.bool)
+    x = np.array([False, True, True, False], dtype=np.bool_)
     out = tensor_format.numeric_summary(x)
     cli_test_utils.assert_lines_equal_ignoring_whitespace(
         self,
         ["| False  True | total |", "|     2     2 |     4 |"], out.lines)
 
-    x = np.array([True] * 10, dtype=np.bool)
+    x = np.array([True] * 10, dtype=np.bool_)
     out = tensor_format.numeric_summary(x)
     cli_test_utils.assert_lines_equal_ignoring_whitespace(
         self, ["| True | total |", "|   10 |    10 |"], out.lines)
 
-    x = np.array([False] * 10, dtype=np.bool)
+    x = np.array([False] * 10, dtype=np.bool_)
     out = tensor_format.numeric_summary(x)
     cli_test_utils.assert_lines_equal_ignoring_whitespace(
         self, ["| False | total |", "|    10 |    10 |"], out.lines)
 
-    x = np.array([], dtype=np.bool)
+    x = np.array([], dtype=np.bool_)
     out = tensor_format.numeric_summary(x)
     self.assertEqual(["No numeric summary available due to empty tensor."],
                      out.lines)
 
   def testNumericSummaryOnStrTensor(self):
-    x = np.array(["spam", "egg"], dtype=np.object)
+    x = np.array(["spam", "egg"], dtype=np.object_)
     out = tensor_format.numeric_summary(x)
     self.assertEqual(
         ["No numeric summary available due to tensor dtype: object."],

--- a/tensorflow/python/debug/lib/debug_data.py
+++ b/tensorflow/python/debug/lib/debug_data.py
@@ -224,7 +224,7 @@ def has_inf_or_nan(datum, tensor):
     # arrays.
     return False
   elif (np.issubdtype(tensor.dtype, np.floating) or
-        np.issubdtype(tensor.dtype, np.complex) or
+        np.issubdtype(tensor.dtype, np.complexfloating) or
         np.issubdtype(tensor.dtype, np.integer)):
     return np.any(np.isnan(tensor)) or np.any(np.isinf(tensor))
   else:

--- a/tensorflow/python/debug/lib/dumping_callback_test.py
+++ b/tensorflow/python/debug/lib/dumping_callback_test.py
@@ -396,8 +396,8 @@ class DumpingCallbackTest(
     def func(x, y):
       return math_ops.logical_not(math_ops.logical_and(x, y))
 
-    x = np.array([[False, False], [True, True]], dtype=np.bool)
-    y = np.array([[False, True], [False, True]], dtype=np.bool)
+    x = np.array([[False, False], [True, True]], dtype=np.bool_)
+    y = np.array([[False, True], [False, True]], dtype=np.bool_)
     self.assertAllEqual(
         self.evaluate(func(x, y)), [[True, True], [True, False]])
 

--- a/tensorflow/python/eager/tensor_test.py
+++ b/tensorflow/python/eager/tensor_test.py
@@ -360,8 +360,8 @@ class TFETensorTest(test_util.TensorFlowTestCase):
   @test_util.run_in_graph_and_eager_modes
   def testConvertToTensorNumpyScalar(self):
     x = ops.convert_to_tensor(
-        [np.array(321, dtype=np.int).item(),
-         np.array(16, dtype=np.int).item()])
+        [np.array(321, dtype=np.int64).item(),
+         np.array(16, dtype=np.int64).item()])
     self.assertAllEqual(x, [321, 16])
 
   def testEagerTensorError(self):

--- a/tensorflow/python/framework/dtypes.py
+++ b/tensorflow/python/framework/dtypes.py
@@ -579,10 +579,10 @@ _TF_TO_NP = {
         np.int16,
     types_pb2.DT_INT8:
         np.int8,
-    # NOTE(touts): For strings we use np.object as it supports variable length
+    # NOTE(touts): For strings we use np.object_ as it supports variable length
     # strings.
     types_pb2.DT_STRING:
-        np.object,
+        np.object_,
     types_pb2.DT_COMPLEX64:
         np.complex64,
     types_pb2.DT_COMPLEX128:
@@ -624,7 +624,7 @@ _TF_TO_NP = {
     types_pb2.DT_INT8_REF:
         np.int8,
     types_pb2.DT_STRING_REF:
-        np.object,
+        np.object_,
     types_pb2.DT_COMPLEX64_REF:
         np.complex64,
     types_pb2.DT_COMPLEX128_REF:
@@ -634,7 +634,7 @@ _TF_TO_NP = {
     types_pb2.DT_UINT64_REF:
         np.uint64,
     types_pb2.DT_BOOL_REF:
-        np.bool,
+        np.bool_,
     types_pb2.DT_QINT8_REF:
         _np_qint8,
     types_pb2.DT_QUINT8_REF:

--- a/tensorflow/python/framework/python_tensor_converter_test.py
+++ b/tensorflow/python/framework/python_tensor_converter_test.py
@@ -163,7 +163,7 @@ class PythonTensorConverterTest(test_util.TensorFlowTestCase,
 
   def testConvertNumpyArrayWithUnsupportedDtype(self):
     converter = self.makePythonTensorConverter()
-    x = np.array([[1, 2], ["a", "b"]], np.object)
+    x = np.array([[1, 2], ["a", "b"]], np.object_)
     with self.assertRaises((ValueError, TypeError)):
       converter.Convert(x, types_pb2.DT_INVALID)
 

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -105,9 +105,9 @@ if _FAST_TENSOR_UTIL_AVAILABLE:
           fast_tensor_util.AppendComplex64ArrayToTensorProto,
       np.complex128:
           fast_tensor_util.AppendComplex128ArrayToTensorProto,
-      np.object:
+      np.object_:
           fast_tensor_util.AppendObjectArrayToTensorProto,
-      np.bool:
+      np.bool_:
           fast_tensor_util.AppendBoolArrayToTensorProto,
       dtypes.qint8.as_numpy_dtype:
           fast_tensor_util.AppendInt8ArrayToTensorProto,
@@ -173,8 +173,8 @@ else:
       np.int16: SlowAppendIntArrayToTensorProto,
       np.complex64: SlowAppendComplex64ArrayToTensorProto,
       np.complex128: SlowAppendComplex128ArrayToTensorProto,
-      np.object: SlowAppendObjectArrayToTensorProto,
-      np.bool: SlowAppendBoolArrayToTensorProto,
+      np.object_: SlowAppendObjectArrayToTensorProto,
+      np.bool_: SlowAppendBoolArrayToTensorProto,
       dtypes.qint8.as_numpy_dtype: SlowAppendQIntArrayToTensorProto,
       dtypes.quint8.as_numpy_dtype: SlowAppendQIntArrayToTensorProto,
       dtypes.qint16.as_numpy_dtype: SlowAppendQIntArrayToTensorProto,
@@ -539,7 +539,7 @@ def make_tensor_proto(values, dtype=None, shape=None, verify_shape=False,
 
     # At this point, values may be a list of objects that we could not
     # identify a common type for (hence it was inferred as
-    # np.object/dtypes.string).  If we are unable to convert it to a
+    # np.object_/dtypes.string).  If we are unable to convert it to a
     # string, we raise a more helpful error message.
     #
     # Ideally, we'd be able to convert the elements of the list to a
@@ -604,7 +604,7 @@ def MakeNdarray(tensor):
                           dtype=dtype).copy().reshape(shape))
 
   if tensor_dtype == dtypes.string:
-    # np.pad throws on these arrays of type np.object.
+    # np.pad throws on these arrays of type np.object_.
     values = list(tensor.string_val)
     padding = num_elements - len(values)
     if padding > 0:

--- a/tensorflow/python/framework/tensor_util_test.py
+++ b/tensorflow/python/framework/tensor_util_test.py
@@ -518,7 +518,7 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
       string_val: "foo"
       """, t)
     a = tensor_util.MakeNdarray(t)
-    self.assertEqual(np.object, a.dtype)
+    self.assertEqual(np.object_, a.dtype)
     self.assertEqual([b"foo"], a)
 
   def testStringWithImplicitRepeat(self):
@@ -527,7 +527,7 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
     self.assertAllEqual(
         np.array([[b"f", b"g", b"g", b"g"], [b"g", b"g", b"g", b"g"],
                   [b"g", b"g", b"g", b"g"]],
-                 dtype=np.object), a)
+                 dtype=np.object_), a)
 
   def testStringN(self):
     t = tensor_util.make_tensor_proto([b"foo", b"bar", b"baz"], shape=[1, 3])
@@ -539,7 +539,7 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
       string_val: "baz"
       """, t)
     a = tensor_util.MakeNdarray(t)
-    self.assertEqual(np.object, a.dtype)
+    self.assertEqual(np.object_, a.dtype)
     self.assertAllEqual(np.array([[b"foo", b"bar", b"baz"]]), a)
 
   def testStringNpArray(self):
@@ -554,7 +554,7 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
       string_val: "abcd"
       """, t)
     a = tensor_util.MakeNdarray(t)
-    self.assertEqual(np.object, a.dtype)
+    self.assertEqual(np.object_, a.dtype)
     self.assertAllEqual(np.array([[b"a", b"ab"], [b"abc", b"abcd"]]), a)
 
   def testArrayMethod(self):
@@ -573,7 +573,7 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
       string_val: "baz"
       """, t)
     a = tensor_util.MakeNdarray(t)
-    self.assertEqual(np.object, a.dtype)
+    self.assertEqual(np.object_, a.dtype)
     self.assertAllEqual(np.array([[b"foo", b"bar", b"baz"]]), a)
 
   def testArrayInterface(self):
@@ -593,7 +593,7 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
       string_val: "baz"
       """, t)
     a = tensor_util.MakeNdarray(t)
-    self.assertEqual(np.object, a.dtype)
+    self.assertEqual(np.object_, a.dtype)
     self.assertAllEqual(np.array([[b"foo", b"bar", b"baz"]]), a)
 
   def testStringTuple(self):
@@ -607,7 +607,7 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
       string_val: "abcd"
       """, t)
     a = tensor_util.MakeNdarray(t)
-    self.assertEqual(np.object, a.dtype)
+    self.assertEqual(np.object_, a.dtype)
     self.assertAllEqual(np.array((b"a", b"ab", b"abc", b"abcd")), a)
 
   def testStringNestedTuple(self):
@@ -621,7 +621,7 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
       string_val: "abcd"
       """, t)
     a = tensor_util.MakeNdarray(t)
-    self.assertEqual(np.object, a.dtype)
+    self.assertEqual(np.object_, a.dtype)
     self.assertAllEqual(np.array(((b"a", b"ab"), (b"abc", b"abcd"))), a)
 
   def testComplex64(self):

--- a/tensorflow/python/keras/feature_column/sequence_feature_column_test.py
+++ b/tensorflow/python/keras/feature_column/sequence_feature_column_test.py
@@ -655,7 +655,7 @@ class SequenceFeaturesSavingTest(test.TestCase, parameterized.TestCase):
     inputs_a = sparse_tensor.SparseTensor(indices_a, values_a,
                                           (batch_size, timesteps, 1))
 
-    values_b = np.zeros(10, dtype=np.str)
+    values_b = np.zeros(10, dtype=np.str_)
     indices_b = np.zeros((10, 3), dtype=np.int64)
     indices_b[:, 0] = np.arange(10)
     inputs_b = sparse_tensor.SparseTensor(indices_b, values_b,

--- a/tensorflow/python/keras/layers/gru_v2_test.py
+++ b/tensorflow/python/keras/layers/gru_v2_test.py
@@ -569,7 +569,7 @@ class GRUV2Test(keras_parameterized.TestCase):
     units = 4
 
     inputs = np.random.randn(batch_size, timestep, units).astype(np.float32)
-    mask = np.ones((batch_size, timestep)).astype(np.bool)
+    mask = np.ones((batch_size, timestep)).astype(np.bool_)
     mask[:, masksteps:] = 0
 
     # Test for V1 behavior.

--- a/tensorflow/python/keras/layers/lstm_v2_test.py
+++ b/tensorflow/python/keras/layers/lstm_v2_test.py
@@ -774,7 +774,7 @@ class LSTMV2Test(keras_parameterized.TestCase):
     units = 4
 
     inputs = np.random.randn(batch_size, timestep, units).astype(np.float32)
-    mask = np.ones((batch_size, timestep)).astype(np.bool)
+    mask = np.ones((batch_size, timestep)).astype(np.bool_)
     mask[:, masksteps:] = 0
 
     # Test for V1 behavior.

--- a/tensorflow/python/keras/saving/save_test.py
+++ b/tensorflow/python/keras/saving/save_test.py
@@ -217,7 +217,7 @@ class TestSaveModel(test.TestCase, parameterized.TestCase):
     inputs_a = sparse_tensor.SparseTensor(indices_a, values_a,
                                           (batch_size, timesteps, 1))
 
-    values_b = np.zeros(10, dtype=np.str)
+    values_b = np.zeros(10, dtype=np.str_)
     indices_b = np.zeros((10, 3), dtype=np.int64)
     indices_b[:, 0] = np.arange(10)
     inputs_b = sparse_tensor.SparseTensor(indices_b, values_b,

--- a/tensorflow/python/keras/utils/conv_utils.py
+++ b/tensorflow/python/keras/utils/conv_utils.py
@@ -274,7 +274,7 @@ def conv_kernel_mask(input_shape, kernel_shape, strides, padding):
   output_shape = conv_output_shape(input_shape, kernel_shape, strides, padding)
 
   mask_shape = input_shape + output_shape
-  mask = np.zeros(mask_shape, np.bool)
+  mask = np.zeros(mask_shape, np.bool_)
 
   output_axes_ticks = [range(dim) for dim in output_shape]
   for output_position in itertools.product(*output_axes_ticks):

--- a/tensorflow/python/keras/utils/conv_utils_test.py
+++ b/tensorflow/python/keras/utils/conv_utils_test.py
@@ -165,7 +165,7 @@ class TestConvUtils(test.TestCase, parameterized.TestCase):
     ndims = len(input_shape)
     strides = (1,) * ndims
     output_shape = _get_const_output_shape(input_shape, dim=1)
-    mask = np.ones(input_shape + output_shape, np.bool)
+    mask = np.ones(input_shape + output_shape, np.bool_)
     self.assertAllEqual(
         mask,
         conv_utils.conv_kernel_mask(
@@ -182,7 +182,7 @@ class TestConvUtils(test.TestCase, parameterized.TestCase):
     strides = (1,) * ndims
 
     for padding in ['valid', 'same']:
-      mask = np.identity(int(np.prod(input_shape)), np.bool)
+      mask = np.identity(int(np.prod(input_shape)), np.bool_)
       mask = np.reshape(mask, input_shape * 2)
       self.assertAllEqual(
           mask,
@@ -201,7 +201,7 @@ class TestConvUtils(test.TestCase, parameterized.TestCase):
     strides = tuple([max(d, 1) for d in input_shape])
     output_shape = _get_const_output_shape(input_shape, dim=1)
 
-    mask = np.zeros(input_shape + output_shape, np.bool)
+    mask = np.zeros(input_shape + output_shape, np.bool_)
     if all(d > 0 for d in mask.shape):  # pylint: disable=not-an-iterable
       mask[(0,) * len(output_shape)] = True
 
@@ -222,7 +222,7 @@ class TestConvUtils(test.TestCase, parameterized.TestCase):
     strides = tuple([max(d - 1, 1) for d in input_shape])
     output_shape = _get_const_output_shape(input_shape, dim=2)
 
-    mask = np.zeros(input_shape + output_shape, np.bool)
+    mask = np.zeros(input_shape + output_shape, np.bool_)
     if all(d > 0 for d in mask.shape):  # pylint: disable=not-an-iterable
       for in_position in itertools.product(*[[0, d - 1] for d in input_shape]):
         out_position = tuple([min(p, 1) for p in in_position])
@@ -250,7 +250,7 @@ class TestConvUtils(test.TestCase, parameterized.TestCase):
       output_shape = list(input_shape)
       output_shape[d] = min(1, input_shape[d])
 
-      mask = np.identity(int(np.prod(input_shape)), np.bool)
+      mask = np.identity(int(np.prod(input_shape)), np.bool_)
       mask = np.reshape(mask, input_shape * 2)
 
       for p in itertools.product(*[range(input_shape[dim])

--- a/tensorflow/python/kernel_tests/array_ops/slice_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/slice_op_test.py
@@ -241,7 +241,7 @@ class SliceTest(test.TestCase):
   def testSimple(self):
     with test_util.use_gpu():
       for dtype in [
-          np.uint8, np.int8, np.uint16, np.int16, np.int32, np.int64, np.bool,
+          np.uint8, np.int8, np.uint16, np.int16, np.int32, np.int64, np.bool_,
           np.float16, np.float32, np.float64, np.complex64, np.complex128,]:
         inp = np.random.rand(4, 4).astype(dtype)
         a = constant_op.constant(

--- a/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
@@ -43,7 +43,7 @@ class StackOpTest(test.TestCase):
 
   def randn(self, shape, dtype):
     data = np.random.randn(*shape)
-    if dtype == np.bool:
+    if dtype == np.bool_:
       return data < 0  # Naive casting yields True with P(1)!
     else:
       return data.astype(dtype)
@@ -53,7 +53,7 @@ class StackOpTest(test.TestCase):
     for shape in (2,), (3,), (2, 3), (3, 2), (8, 2, 10):
       rank = len(shape)
       for axis in range(-rank, rank):
-        for dtype in [np.bool, np.float32, np.int32, np.int64]:
+        for dtype in [np.bool_, np.float32, np.int32, np.int64]:
           data = self.randn(shape, dtype)
           xs = np_split_squeeze(data, axis)
           # Stack back into a single tensorflow tensor
@@ -94,7 +94,7 @@ class StackOpTest(test.TestCase):
 
       # Check on a variety of shapes and types
       for shape in (2,), (3,), (2, 3), (3, 2), (4, 3, 2), (8, 2, 10):
-        for dtype in [np.bool, np.float32, np.int16, np.int32, np.int64]:
+        for dtype in [np.bool_, np.float32, np.int16, np.int32, np.int64]:
           with self.subTest(shape=shape, dtype=dtype):
             data = self.randn(shape, dtype)
             # Stack back into a single tensorflow tensor directly using np array
@@ -235,7 +235,7 @@ class StackOpTest(test.TestCase):
     for shape in (3,), (2, 2, 3), (4, 1, 2, 2), (8, 2, 10):
       rank = len(shape)
       expected = self.randn(shape, np.float32)
-      for dtype in [np.bool, np.float32, np.int32, np.int64]:
+      for dtype in [np.bool_, np.float32, np.int32, np.int64]:
         # For all the possible axis to split it, including negative indices.
         for axis in range(-rank, rank):
           test_arrays = np_split_squeeze(expected, axis)

--- a/tensorflow/python/kernel_tests/array_ops/unstack_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/unstack_op_test.py
@@ -42,7 +42,7 @@ class UnstackOpTest(test.TestCase):
 
   def randn(self, shape, dtype):
     data = np.random.randn(*shape)
-    if dtype == np.bool:
+    if dtype == np.bool_:
       return data < 0  # Naive casting yields True with P(1)!
     else:
       return data.astype(dtype)
@@ -68,7 +68,7 @@ class UnstackOpTest(test.TestCase):
       rank = len(shape)
       for axis in range(-rank, rank):
         for dtype in [
-            np.bool, np.float16, np.float32, np.float64, np.uint8, np.int32,
+            np.bool_, np.float16, np.float32, np.float64, np.uint8, np.int32,
             np.int64
         ]:
           data = self.randn(shape, dtype)
@@ -94,7 +94,7 @@ class UnstackOpTest(test.TestCase):
         rank = len(shape)
         for axis in range(-rank, rank):
           for dtype in [
-              np.bool, np.float16, np.float32, np.float64, np.uint8, np.int32,
+              np.bool_, np.float16, np.float32, np.float64, np.uint8, np.int32,
               np.int64
           ]:
             data = self.randn(shape, dtype)

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -440,7 +440,7 @@ class ReverseV2Test(test_util.TensorFlowTestCase):
   def testReverse1DimAuto(self):
     for dtype in [
         np.uint8, np.int8, np.uint16, np.int16, np.uint32, np.int32,
-        np.uint64, np.int64, np.bool,
+        np.uint64, np.int64, np.bool_,
         np.float16, np.float32, np.float64, np.complex64, np.complex128,
         np.array(b"").dtype.type
     ]:
@@ -449,7 +449,7 @@ class ReverseV2Test(test_util.TensorFlowTestCase):
   def testReverse2DimAuto(self):
     for dtype in [
         np.uint8, np.int8, np.uint16, np.int16, np.uint32, np.int32,
-        np.uint64, np.int64, np.bool,
+        np.uint64, np.int64, np.bool_,
         np.float16, np.float32, np.float64, np.complex64, np.complex128,
         np.array(b"").dtype.type
     ]:
@@ -559,7 +559,7 @@ class StridedSliceChecker(object):
   def __init__(self, test, x, tensor_type=dtypes.int32, check_type_infer=True):
     self.x_np = np.array(x).astype(tensor_type.as_numpy_dtype)
     if tensor_type.is_bool:
-      self.x_np = np.array(x % 3).astype(np.bool)
+      self.x_np = np.array(x % 3).astype(np.bool_)
     # Give the value a non-zero imaginary component for complex types.
     if tensor_type.is_complex:
       self.x_np -= 1j * self.x_np
@@ -1445,7 +1445,7 @@ class SequenceMaskTest(test_util.TensorFlowTestCase):
 
     check_output_dtype(dtypes.bool)
     check_output_dtype("bool")
-    check_output_dtype(np.bool)
+    check_output_dtype(np.bool_)
     check_output_dtype(dtypes.int32)
     check_output_dtype("int32")
     check_output_dtype(np.int32)

--- a/tensorflow/python/kernel_tests/betainc_op_test.py
+++ b/tensorflow/python/kernel_tests/betainc_op_test.py
@@ -166,9 +166,9 @@ class BetaincTest(test.TestCase):
            gradients_impl.gradients(tf_gout_t, [ga_s_t, gb_s_t, gx_s_t])[2]])
 
       # Equivalent to `assertAllFalse` (if it existed).
-      self.assertAllEqual(np.zeros_like(grads_x).astype(np.bool),
+      self.assertAllEqual(np.zeros_like(grads_x).astype(np.bool_),
                           np.isnan(tf_gout))
-      self.assertAllEqual(np.zeros_like(grads_x).astype(np.bool),
+      self.assertAllEqual(np.zeros_like(grads_x).astype(np.bool_),
                           np.isnan(grads_x))
 
   @test_util.run_deprecated_v1

--- a/tensorflow/python/kernel_tests/broadcast_to_ops_test.py
+++ b/tensorflow/python/kernel_tests/broadcast_to_ops_test.py
@@ -48,7 +48,7 @@ class BroadcastToTest(test_util.TensorFlowTestCase):
 
   def testBroadcastToBool(self):
     with self.session():
-      x = np.array([True, False, True], dtype=np.bool)
+      x = np.array([True, False, True], dtype=np.bool_)
       v_tf = array_ops.broadcast_to(constant_op.constant(x), [3, 3])
       v_np = np.broadcast_to(x, [3, 3])
       self.assertAllEqual(v_tf, v_np)
@@ -100,7 +100,7 @@ class BroadcastToTest(test_util.TensorFlowTestCase):
 
   def testBroadcastScalarToNonScalar(self):
     with self.session():
-      x = np.array(1.0, dtype=np.float)
+      x = np.array(1.0, dtype=np.float64)
       v_tf = array_ops.broadcast_to(constant_op.constant(1.0), [2, 3, 4,
                                                                 1, 1, 1])
       v_np = np.broadcast_to(x, [2, 3, 4, 1, 1, 1])

--- a/tensorflow/python/kernel_tests/cast_op_test.py
+++ b/tensorflow/python/kernel_tests/cast_op_test.py
@@ -43,7 +43,7 @@ class CastOpTest(test.TestCase):
       return dtypes.int32
     elif dtype == np.int64:
       return dtypes.int64
-    elif dtype == np.bool:
+    elif dtype == np.bool_:
       return dtypes.bool
     elif dtype == np.complex64:
       return dtypes.complex64
@@ -79,10 +79,10 @@ class CastOpTest(test.TestCase):
       for to_type in type_list:
         self._test(x.astype(from_type), to_type, use_gpu)
 
-    self._test(x.astype(np.bool), np.float32, use_gpu)
+    self._test(x.astype(np.bool_), np.float32, use_gpu)
     self._test(x.astype(np.uint8), np.float32, use_gpu)
     if not use_gpu:
-      self._test(x.astype(np.bool), np.int32, use_gpu)
+      self._test(x.astype(np.bool_), np.int32, use_gpu)
       self._test(x.astype(np.int32), np.int32, use_gpu)
 
   def _testAll(self, x):

--- a/tensorflow/python/kernel_tests/constant_op_eager_test.py
+++ b/tensorflow/python/kernel_tests/constant_op_eager_test.py
@@ -133,19 +133,17 @@ class ConstantTest(test.TestCase):
 
   def testComplex64(self):
     self._testAll(
-        np.complex(1, 2) *
-        np.arange(-15, 15).reshape([2, 3, 5]).astype(np.complex64))
+        (1 + 2j) * np.arange(-15, 15).reshape([2, 3, 5]).astype(np.complex64))
     self._testAll(
-        np.complex(1, 2) *
+        (1 + 2j) *
         np.random.normal(size=30).reshape([2, 3, 5]).astype(np.complex64))
     self._testAll(np.empty((2, 0, 5)).astype(np.complex64))
 
   def testComplex128(self):
     self._testAll(
-        np.complex(1, 2) * np.arange(-15, 15).reshape([2, 3, 5
-                                                      ]).astype(np.complex128))
+        (1 + 2j) * np.arange(-15, 15).reshape([2, 3, 5]).astype(np.complex128))
     self._testAll(
-        np.complex(1, 2) * np.random.normal(size=30).reshape(
+        (1 + 2j) * np.random.normal(size=30).reshape(
             [2, 3, 5]).astype(np.complex128))
     self._testAll(np.empty((2, 0, 5)).astype(np.complex128))
 
@@ -407,7 +405,7 @@ class ZerosLikeTest(test.TestCase):
   def _compareZeros(self, dtype, use_gpu):
     # Creates a tensor of non-zero values with shape 2 x 3.
     # NOTE(kearnes): The default numpy dtype associated with tf.string is
-    # np.object (and can't be changed without breaking a lot things), which
+    # np.object_ (and can't be changed without breaking a lot things), which
     # causes a TypeError in constant_op.constant below. Here we catch the
     # special case of tf.string and set the numpy dtype appropriately.
     if dtype == dtypes_lib.string:

--- a/tensorflow/python/kernel_tests/constant_op_test.py
+++ b/tensorflow/python/kernel_tests/constant_op_test.py
@@ -117,20 +117,20 @@ class ConstantTest(test.TestCase):
   @test_util.run_deprecated_v1
   def testComplex64(self):
     self._testAll(
-        np.complex(1, 2) *
+        (1 + 2j) *
         np.arange(-15, 15).reshape([2, 3, 5]).astype(np.complex64))
     self._testAll(
-        np.complex(1, 2) *
+        (1 + 2j) *
         np.random.normal(size=30).reshape([2, 3, 5]).astype(np.complex64))
     self._testAll(np.empty((2, 0, 5)).astype(np.complex64))
 
   @test_util.run_deprecated_v1
   def testComplex128(self):
     self._testAll(
-        np.complex(1, 2) *
+        (1 + 2j) *
         np.arange(-15, 15).reshape([2, 3, 5]).astype(np.complex128))
     self._testAll(
-        np.complex(1, 2) *
+        (1 + 2j) *
         np.random.normal(size=30).reshape([2, 3, 5]).astype(np.complex128))
     self._testAll(np.empty((2, 0, 5)).astype(np.complex128))
 
@@ -496,7 +496,7 @@ class ZerosLikeTest(test.TestCase):
     with self.cached_session(use_gpu=use_gpu):
       # Creates a tensor of non-zero values with shape 2 x 3.
       # NOTE(kearnes): The default numpy dtype associated with tf.string is
-      # np.object (and can't be changed without breaking a lot things), which
+      # np.object_ (and can't be changed without breaking a lot things), which
       # causes a TypeError in constant_op.constant below. Here we catch the
       # special case of tf.string and set the numpy dtype appropriately.
       if dtype == dtypes_lib.string:
@@ -880,7 +880,7 @@ class PlaceholderTest(test.TestCase):
       with ops.control_dependencies([p]):
         c = constant_op.constant(5, dtypes_lib.int32)
       d = math_ops.multiply(p, c)
-      val = np.array(2).astype(np.int)
+      val = np.array(2).astype(np.int64)
       self.assertEqual(10, d.eval(feed_dict={p: val}))
 
   @test_util.run_deprecated_v1

--- a/tensorflow/python/kernel_tests/cwise_ops_binary_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_binary_test.py
@@ -96,7 +96,7 @@ class BinaryOpTest(test.TestCase):
         np_var_left = self.evaluate(tf_func(x, var_y))
         np_var_right = self.evaluate(tf_func(var_x, y))
 
-    if np_ans.dtype != np.object:
+    if np_ans.dtype != np.object_:
       self.assertAllClose(np_ans, tf_cpu)
       self.assertAllClose(np_ans, np_left)
       self.assertAllClose(np_ans, np_right)
@@ -363,9 +363,9 @@ class BinaryOpTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testComplex64Basic(self):
-    x = np.complex(1, 1) * np.linspace(-10, 10, 6).reshape(1, 3, 2).astype(  # pylint: disable=too-many-function-args
+    x = (1 + 1j) * np.linspace(-10, 10, 6).reshape(1, 3, 2).astype(  # pylint: disable=too-many-function-args
         np.complex64)
-    y = np.complex(1, 1) * np.linspace(20, -20, 6).reshape(1, 3, 2).astype(  # pylint: disable=too-many-function-args
+    y = (1 + 1j) * np.linspace(20, -20, 6).reshape(1, 3, 2).astype(  # pylint: disable=too-many-function-args
         np.complex64)
     self._compareBoth(x, y, np.add, math_ops.add)
     self._compareBoth(x, y, np.subtract, math_ops.subtract)
@@ -378,9 +378,9 @@ class BinaryOpTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testComplex128Basic(self):
-    x = np.complex(1, 1) * np.linspace(-10, 10, 6).reshape(1, 3, 2).astype(  # pylint: disable=too-many-function-args
+    x = (1 + 1j) * np.linspace(-10, 10, 6).reshape(1, 3, 2).astype(  # pylint: disable=too-many-function-args
         np.complex128)
-    y = np.complex(1, 1) * np.linspace(20, -20, 6).reshape(1, 3, 2).astype(  # pylint: disable=too-many-function-args
+    y = (1 + 1j) * np.linspace(20, -20, 6).reshape(1, 3, 2).astype(  # pylint: disable=too-many-function-args
         np.complex128)
     self._compareBoth(x, y, np.add, math_ops.add)
     self._compareBoth(x, y, np.subtract, math_ops.subtract)
@@ -404,12 +404,12 @@ class BinaryOpTest(test.TestCase):
   def testString(self):
     x = np.array([["x_0_0", "x_0_1", "x_0_2"], ["x_1_0", "x_1_1", "x_1_2"],
                   ["x_2_0", "x_2_1", "x_2_2"]],
-                 dtype=np.object)
+                 dtype=np.object_)
     y = np.array([["y_0_0", "y_0_1", "y_0_2"], ["y_1_0", "y_1_1", "y_1_2"],
                   ["y_2_0", "y_2_1", "y_2_2"]],
-                 dtype=np.object)
-    z = np.array([["z_0", "z_1", "z_2"]], dtype=np.object)
-    w = np.array("w", dtype=np.object)
+                 dtype=np.object_)
+    z = np.array([["z_0", "z_1", "z_2"]], dtype=np.object_)
+    w = np.array("w", dtype=np.object_)
     self._compareCpu(x, y, _ADD, _ADD)
     self._compareCpu(x, z, _ADD, _ADD)
     self._compareCpu(x, w, _ADD, _ADD)
@@ -433,8 +433,8 @@ class BinaryOpTest(test.TestCase):
           # care is taken with choosing the inputs and the delta. This is
           # a weaker check (in particular, it does not test the op itself,
           # only its gradient), but it's much better than nothing.
-          self._compareGradientX(x, y, np_func, tf_func, np.float)
-          self._compareGradientY(x, y, np_func, tf_func, np.float)
+          self._compareGradientX(x, y, np_func, tf_func, np.float64)
+          self._compareGradientY(x, y, np_func, tf_func, np.float64)
         else:
           self._compareGradientX(x, y, np_func, tf_func)
           self._compareGradientY(x, y, np_func, tf_func)
@@ -975,7 +975,7 @@ class ComparisonOpTest(test.TestCase):
         np.uint16,
         np.uint32,
         np.uint64,
-        np.bool,
+        np.bool_,
     ]
     x = np.asarray([0, 1, 2, 3, 4])
     y = np.asarray([0, 1, 2, 3, 4])

--- a/tensorflow/python/kernel_tests/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_test.py
@@ -261,8 +261,8 @@ class LogicalOpTest(test.TestCase):
                                 use_gpu)
 
   def testTensor(self):
-    x = np.random.randint(0, 2, 6).astype(np.bool).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
-    y = np.random.randint(0, 2, 6).astype(np.bool).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
+    x = np.random.randint(0, 2, 6).astype(np.bool_).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
+    y = np.random.randint(0, 2, 6).astype(np.bool_).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
     for use_gpu in [True, False]:
       with self.subTest(use_gpu=use_gpu):
         self._not(x, use_gpu)
@@ -285,8 +285,8 @@ class LogicalOpTest(test.TestCase):
         ([2, 3, 0], [2, 3, 1]),
     ]
     for (xs, ys) in shapes:
-      x = np.random.randint(0, 2, np.prod(xs)).astype(np.bool).reshape(xs)
-      y = np.random.randint(0, 2, np.prod(ys)).astype(np.bool).reshape(ys)
+      x = np.random.randint(0, 2, np.prod(xs)).astype(np.bool_).reshape(xs)
+      y = np.random.randint(0, 2, np.prod(ys)).astype(np.bool_).reshape(ys)
       for use_gpu in [True, False]:
         with self.subTest(xs=xs, ys=ys, use_gpu=use_gpu):
           self._compareBinary(x, y, np.logical_and, math_ops.logical_and,
@@ -297,8 +297,8 @@ class LogicalOpTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testShapeMismatch(self):
-    x = np.random.randint(0, 2, 6).astype(np.bool).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
-    y = np.random.randint(0, 2, 6).astype(np.bool).reshape(3, 2, 1)  # pylint: disable=too-many-function-args
+    x = np.random.randint(0, 2, 6).astype(np.bool_).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
+    y = np.random.randint(0, 2, 6).astype(np.bool_).reshape(3, 2, 1)  # pylint: disable=too-many-function-args
     for f in [math_ops.logical_and, math_ops.logical_or, math_ops.logical_xor]:
       with self.subTest(f=f):
         with self.assertRaisesWithPredicateMatch(
@@ -460,7 +460,7 @@ class SelectOpTest(test.TestCase):
     self._testScalarBroadcast(array_ops.where_v2, c, y, x)
 
   def _testBasic(self, fn):
-    c = np.random.randint(0, 2, 6).astype(np.bool).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
+    c = np.random.randint(0, 2, 6).astype(np.bool_).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
     x = np.random.rand(1, 3, 2) * 100
     y = np.random.rand(1, 3, 2) * 100
     for t in [
@@ -491,10 +491,10 @@ class SelectOpTest(test.TestCase):
           self._compare(fn, c, xt, yt, use_gpu=True)
 
   def testBasicBroadcast(self):
-    c0 = np.random.randint(0, 2, 6).astype(np.bool).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
-    c1 = np.random.randint(0, 2, 2).astype(np.bool).reshape(1, 1, 2)  # pylint: disable=too-many-function-args
-    c2 = np.random.randint(0, 2, 3).astype(np.bool).reshape(1, 3, 1)  # pylint: disable=too-many-function-args
-    c3 = np.random.randint(0, 2, 1).astype(np.bool).reshape(1, 1, 1)  # pylint: disable=too-many-function-args
+    c0 = np.random.randint(0, 2, 6).astype(np.bool_).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
+    c1 = np.random.randint(0, 2, 2).astype(np.bool_).reshape(1, 1, 2)  # pylint: disable=too-many-function-args
+    c2 = np.random.randint(0, 2, 3).astype(np.bool_).reshape(1, 3, 1)  # pylint: disable=too-many-function-args
+    c3 = np.random.randint(0, 2, 1).astype(np.bool_).reshape(1, 1, 1)  # pylint: disable=too-many-function-args
     for c in [c0, c1, c2, c3]:
       # where_v2 only
       with self.subTest(c=c):
@@ -528,7 +528,7 @@ class SelectOpTest(test.TestCase):
         self._testBasicBroadcast(array_ops.where_v2, c, y, x)
 
   def _testGradients(self, fn):
-    c = np.random.randint(0, 2, 6).astype(np.bool).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
+    c = np.random.randint(0, 2, 6).astype(np.bool_).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
     x = np.random.rand(1, 3, 2) * 100
     y = np.random.rand(1, 3, 2) * 100
     for t in [np.float16, np.float32, np.float64]:
@@ -541,8 +541,8 @@ class SelectOpTest(test.TestCase):
           # care is taken with choosing the inputs and the delta. This is
           # a weaker check (in particular, it does not test the op itself,
           # only its gradient), but it's much better than nothing.
-          self._compareGradientX(fn, c, xt, yt, np.float)
-          self._compareGradientY(fn, c, xt, yt, np.float)
+          self._compareGradientX(fn, c, xt, yt, np.float64)
+          self._compareGradientY(fn, c, xt, yt, np.float64)
         else:
           self._compareGradientX(fn, c, xt, yt)
           self._compareGradientY(fn, c, xt, yt)
@@ -554,7 +554,7 @@ class SelectOpTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testGradientsBroadcast(self):
-    c = np.random.randint(0, 2, 6).astype(np.bool).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
+    c = np.random.randint(0, 2, 6).astype(np.bool_).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
     for t in [np.float32, np.float64]:
       # where_v2 only
       with self.subTest(t=t):
@@ -581,7 +581,7 @@ class SelectOpTest(test.TestCase):
         self._compareGradientX(array_ops.where_v2, c, x.astype(t), y.astype(t))
 
   def _testShapeMismatch(self, fn):
-    c = np.random.randint(0, 2, 6).astype(np.bool).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
+    c = np.random.randint(0, 2, 6).astype(np.bool_).reshape(1, 3, 2)  # pylint: disable=too-many-function-args
     x = np.random.rand(1, 3, 2) * 100
     y = np.random.rand(2, 5, 3) * 100
     for t in [
@@ -600,7 +600,7 @@ class SelectOpTest(test.TestCase):
     self._testShapeMismatch(array_ops.where_v2)
 
   def _testEmptyTensor(self, fn):
-    c = np.random.randint(0, 3, 0).astype(np.bool).reshape(1, 3, 0)  # pylint: disable=too-many-function-args
+    c = np.random.randint(0, 3, 0).astype(np.bool_).reshape(1, 3, 0)  # pylint: disable=too-many-function-args
     x = np.random.rand(1, 3, 0) * 100
     y = np.random.rand(1, 3, 0) * 100
     z_expected = np.zeros((1, 3, 0), dtype=np.float32)
@@ -694,7 +694,7 @@ class BatchSelectOpTest(test.TestCase):
       self.assertAllClose(jacob_t, jacob_n, rtol=1e-5, atol=1e-5)
 
   def testBasic(self):
-    c = np.random.randint(0, 2, 16).astype(np.bool)
+    c = np.random.randint(0, 2, 16).astype(np.bool_)
     x = np.random.rand(16, 2, 8) * 100
     y = np.random.rand(16, 2, 8) * 100
     for t in [
@@ -710,7 +710,7 @@ class BatchSelectOpTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testGradients(self):
-    c = np.random.randint(0, 2, 16).astype(np.bool)
+    c = np.random.randint(0, 2, 16).astype(np.bool_)
     x = np.random.rand(16, 2, 8) * 100
     y = np.random.rand(16, 2, 8) * 100
     for t in [np.float16, np.float32, np.float64]:
@@ -723,15 +723,15 @@ class BatchSelectOpTest(test.TestCase):
           # care is taken with choosing the inputs and the delta. This is
           # a weaker check (in particular, it does not test the op itself,
           # only its gradient), but it's much better than nothing.
-          self._compareGradientX(c, xt, yt, np.float)
-          self._compareGradientY(c, xt, yt, np.float)
+          self._compareGradientX(c, xt, yt, np.float64)
+          self._compareGradientY(c, xt, yt, np.float64)
         else:
           self._compareGradientX(c, xt, yt)
           self._compareGradientY(c, xt, yt)
 
   @test_util.run_deprecated_v1
   def testShapeMismatch(self):
-    c = np.random.randint(0, 2, 8).astype(np.bool)
+    c = np.random.randint(0, 2, 8).astype(np.bool_)
     x = np.random.rand(16, 3, 2) * 100
     y = np.random.rand(16, 3, 2) * 100
     for t in [

--- a/tensorflow/python/kernel_tests/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/cwise_ops_unary_test.py
@@ -100,7 +100,7 @@ class UnaryOpTest(test.TestCase):
         s = list(np.shape(x))
         jacob_t, _ = gradient_checker.compute_gradient(
             inx, s, y, s, x_init_value=x)
-        xf = x.astype(np.float)
+        xf = x.astype(np.float64)
         inxf = ops.convert_to_tensor(xf)
         yf = tf_func(inxf)
         _, jacob_n = gradient_checker.compute_gradient(
@@ -490,9 +490,8 @@ class UnaryOpTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testComplex64Basic(self):
-    x = np.complex(1, 1) * np.arange(-3, 3).reshape(1, 3, 2).astype(
-        np.complex64)
-    y = x + np.complex(0.5, 0.5)  # no zeros
+    x = (1 + 1j) * np.arange(-3, 3).reshape(1, 3, 2).astype(np.complex64)
+    y = x + (0.5 + 0.5j)  # no zeros
     self._compareBoth(x, np.abs, math_ops.abs)
     self._compareBoth(x, np.abs, _ABS)
     self._compareBoth(x, np.negative, math_ops.negative)
@@ -535,9 +534,8 @@ class UnaryOpTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testComplex128Basic(self):
-    x = np.complex(1, 1) * np.arange(-3, 3).reshape(1, 3, 2).astype(
-        np.complex128)
-    y = x + np.complex(0.5, 0.5)  # no zeros
+    x = (1 + 1j) * np.arange(-3, 3).reshape(1, 3, 2).astype(np.complex128)
+    y = x + (0.5 + 0.5j)  # no zeros
     self._compareBoth(x, np.abs, math_ops.abs)
     self._compareBoth(x, np.abs, _ABS)
     self._compareBoth(x, np.negative, math_ops.negative)

--- a/tensorflow/python/kernel_tests/diag_op_test.py
+++ b/tensorflow/python/kernel_tests/diag_op_test.py
@@ -437,7 +437,7 @@ class MatrixDiagTest(test.TestCase):
     self._testVectorBatch(np.float64)
     self._testVectorBatch(np.int32)
     self._testVectorBatch(np.int64)
-    self._testVectorBatch(np.bool)
+    self._testVectorBatch(np.bool_)
 
   @test_util.run_deprecated_v1
   def testRectangularBatch(self):
@@ -664,7 +664,7 @@ class MatrixSetDiagTest(test.TestCase):
     self._testSquareBatch(np.float64)
     self._testSquareBatch(np.int32)
     self._testSquareBatch(np.int64)
-    self._testSquareBatch(np.bool)
+    self._testSquareBatch(np.bool_)
 
   @test_util.run_deprecated_v1
   def testRectangularBatch(self):
@@ -849,7 +849,7 @@ class MatrixDiagPartTest(test.TestCase):
     self._testSquareBatch(np.float64)
     self._testSquareBatch(np.int32)
     self._testSquareBatch(np.int64)
-    self._testSquareBatch(np.bool)
+    self._testSquareBatch(np.bool_)
 
   @test_util.run_deprecated_v1
   def testRectangularBatch(self):

--- a/tensorflow/python/kernel_tests/distributions/beta_test.py
+++ b/tensorflow/python/kernel_tests/distributions/beta_test.py
@@ -182,7 +182,7 @@ class BetaTest(test.TestCase):
   def testLogPdfOnBoundaryIsFiniteWhenAlphaIsOne(self):
     b = [[0.01, 0.1, 1., 2], [5., 10., 2., 3]]
     pdf = self.evaluate(beta_lib.Beta(1., b).prob(0.))
-    self.assertAllEqual(np.ones_like(pdf, dtype=np.bool), np.isfinite(pdf))
+    self.assertAllEqual(np.ones_like(pdf, dtype=np.bool_), np.isfinite(pdf))
 
   def testBetaMean(self):
     a = [1., 2, 3]
@@ -330,8 +330,8 @@ class BetaTest(test.TestCase):
       b = 10. * np.random.random(shape).astype(dt)
       x = np.random.random(shape).astype(dt)
       actual = self.evaluate(beta_lib.Beta(a, b).cdf(x))
-      self.assertAllEqual(np.ones(shape, dtype=np.bool), 0. <= x)
-      self.assertAllEqual(np.ones(shape, dtype=np.bool), 1. >= x)
+      self.assertAllEqual(np.ones(shape, dtype=np.bool_), 0. <= x)
+      self.assertAllEqual(np.ones(shape, dtype=np.bool_), 1. >= x)
       if not stats:
         return
       self.assertAllClose(stats.beta.cdf(x, a, b), actual, rtol=9e-3, atol=5e-6)
@@ -343,8 +343,8 @@ class BetaTest(test.TestCase):
       b = 10. * np.random.random(shape).astype(dt)
       x = np.random.random(shape).astype(dt)
       actual = self.evaluate(math_ops.exp(beta_lib.Beta(a, b).log_cdf(x)))
-      self.assertAllEqual(np.ones(shape, dtype=np.bool), 0. <= x)
-      self.assertAllEqual(np.ones(shape, dtype=np.bool), 1. >= x)
+      self.assertAllEqual(np.ones(shape, dtype=np.bool_), 0. <= x)
+      self.assertAllEqual(np.ones(shape, dtype=np.bool_), 1. >= x)
       if not stats:
         return
       self.assertAllClose(stats.beta.cdf(x, a, b), actual, rtol=3e-3, atol=2e-5)

--- a/tensorflow/python/kernel_tests/distributions/dirichlet_test.py
+++ b/tensorflow/python/kernel_tests/distributions/dirichlet_test.py
@@ -92,13 +92,13 @@ class DirichletTest(test.TestCase):
     dist = dirichlet_lib.Dirichlet(concentration)
     log_prob = self.evaluate(dist.log_prob(x))
     self.assertAllEqual(
-        np.ones_like(log_prob, dtype=np.bool), np.isfinite(log_prob))
+        np.ones_like(log_prob, dtype=np.bool_), np.isfinite(log_prob))
 
     # Test when concentration[k] = 1., and x is zero at various dimensions.
     dist = dirichlet_lib.Dirichlet(10 * [1.])
     log_prob = self.evaluate(dist.log_prob(x))
     self.assertAllEqual(
-        np.ones_like(log_prob, dtype=np.bool), np.isfinite(log_prob))
+        np.ones_like(log_prob, dtype=np.bool_), np.isfinite(log_prob))
 
   def testPdfZeroBatches(self):
     alpha = [1., 2]

--- a/tensorflow/python/kernel_tests/distributions/normal_test.py
+++ b/tensorflow/python/kernel_tests/distributions/normal_test.py
@@ -57,7 +57,7 @@ class NormalTest(test.TestCase):
 
   def assertAllFinite(self, tensor):
     is_finite = np.isfinite(self.evaluate(tensor))
-    all_true = np.ones_like(is_finite, dtype=np.bool)
+    all_true = np.ones_like(is_finite, dtype=np.bool_)
     self.assertAllEqual(all_true, is_finite)
 
   def _testParamShapes(self, sample_shape, expected):

--- a/tensorflow/python/kernel_tests/distributions/special_math_test.py
+++ b/tensorflow/python/kernel_tests/distributions/special_math_test.py
@@ -86,7 +86,7 @@ class NdtriTest(test.TestCase):
 
   def assertAllFinite(self, x):
     is_finite = np.isfinite(x)
-    all_true = np.ones_like(is_finite, dtype=np.bool)
+    all_true = np.ones_like(is_finite, dtype=np.bool_)
     self.assertAllEqual(all_true, is_finite)
 
   @test_util.run_in_graph_and_eager_modes
@@ -267,10 +267,10 @@ class NdtrGradientTest(test.TestCase):
   _error64 = ErrorSpec(rtol=1e-7, atol=0)
 
   def assert_all_true(self, v):
-    self.assertAllEqual(np.ones_like(v, dtype=np.bool), v)
+    self.assertAllEqual(np.ones_like(v, dtype=np.bool_), v)
 
   def assert_all_false(self, v):
-    self.assertAllEqual(np.zeros_like(v, dtype=np.bool), v)
+    self.assertAllEqual(np.zeros_like(v, dtype=np.bool_), v)
 
   def _test_grad_finite(self, dtype):
     x = constant_op.constant([-100., 0., 100.], dtype=dtype)
@@ -399,7 +399,7 @@ class LogCDFLaplaceTest(test.TestCase):
   CUTOFF_FLOAT32_UPPER = np.log(1. / (2. * np.finfo(np.float32).eps)) - 1.
 
   def assertAllTrue(self, x):
-    self.assertAllEqual(np.ones_like(x, dtype=np.bool), x)
+    self.assertAllEqual(np.ones_like(x, dtype=np.bool_), x)
 
   def _test_grid_log(self, dtype, scipy_dtype, grid_spec, error_spec):
     with self.cached_session():

--- a/tensorflow/python/kernel_tests/distributions/util_test.py
+++ b/tensorflow/python/kernel_tests/distributions/util_test.py
@@ -937,15 +937,15 @@ class SoftplusTest(test.TestCase):
     self.assertAllCloseAccordingToType(
         np_features, tf_softplus_inverse,
         atol=0., rtol=rtol)
-    self.assertAllEqual(np.ones_like(tf_softplus).astype(np.bool),
+    self.assertAllEqual(np.ones_like(tf_softplus).astype(np.bool_),
                         tf_softplus > 0)
 
     self.assertShapeEqual(np_softplus, softplus)
     self.assertShapeEqual(np_softplus, softplus_inverse)
 
-    self.assertAllEqual(np.ones_like(tf_softplus).astype(np.bool),
+    self.assertAllEqual(np.ones_like(tf_softplus).astype(np.bool_),
                         np.isfinite(tf_softplus))
-    self.assertAllEqual(np.ones_like(tf_softplus_inverse).astype(np.bool),
+    self.assertAllEqual(np.ones_like(tf_softplus_inverse).astype(np.bool_),
                         np.isfinite(tf_softplus_inverse))
 
   @test_util.run_deprecated_v1
@@ -1004,7 +1004,8 @@ class SoftplusTest(test.TestCase):
       y = du.softplus_inverse(x)
       grads = self.evaluate(gradients_impl.gradients(y, x)[0])
       # Equivalent to `assertAllFalse` (if it existed).
-      self.assertAllEqual(np.zeros_like(grads).astype(np.bool), np.isnan(grads))
+      self.assertAllEqual(np.zeros_like(grads).astype(np.bool_),
+                          np.isnan(grads))
 
   @test_util.run_deprecated_v1
   def testInverseSoftplusGradientFinite(self):
@@ -1016,7 +1017,7 @@ class SoftplusTest(test.TestCase):
       grads = self.evaluate(gradients_impl.gradients(y, x)[0])
       # Equivalent to `assertAllTrue` (if it existed).
       self.assertAllEqual(
-          np.ones_like(grads).astype(np.bool), np.isfinite(grads))
+          np.ones_like(grads).astype(np.bool_), np.isfinite(grads))
 
 
 @test_util.run_all_in_graph_and_eager_modes

--- a/tensorflow/python/kernel_tests/dynamic_partition_op_test.py
+++ b/tensorflow/python/kernel_tests/dynamic_partition_op_test.py
@@ -119,7 +119,7 @@ class DynamicPartitionTest(test.TestCase):
     self.assertEqual(num_partitions, len(partition_vals))
     for i in range(num_partitions):
       # reshape because of empty parts
-      parts_np = np.array(parts[i], dtype=np.float).reshape(-1, cols)
+      parts_np = np.array(parts[i], dtype=np.float64).reshape(-1, cols)
       self.assertAllEqual(parts_np, partition_vals[i])
 
   def testSimpleComplex(self):
@@ -210,7 +210,7 @@ class DynamicPartitionTest(test.TestCase):
     self.assertEqual(3, len(partition_vals))
     self.assertAllEqual([[]], partition_vals[0])
     self.assertAllEqual([[]], partition_vals[1])
-    self.assertAllEqual(np.array([], dtype=np.float).reshape(0, 0),
+    self.assertAllEqual(np.array([], dtype=np.float64).reshape(0, 0),
                         partition_vals[2])
 
   def testEmptyPartitions(self):

--- a/tensorflow/python/kernel_tests/in_topk_op_test.py
+++ b/tensorflow/python/kernel_tests/in_topk_op_test.py
@@ -28,7 +28,7 @@ from tensorflow.python.platform import test
 class InTopKTest(test.TestCase):
 
   def _validateInTopK(self, predictions, target, k, expected):
-    np_ans = np.array(expected, np.bool)
+    np_ans = np.array(expected, np.bool_)
     with self.cached_session():
       precision = nn_ops.in_top_k(predictions, target, k)
       out = self.evaluate(precision)

--- a/tensorflow/python/kernel_tests/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/lookup_ops_test.py
@@ -136,7 +136,7 @@ class StaticHashTableTest(BaseLookupTableTest):
 
   def testStaticHashTableInitWithNumPyArrays(self):
     default_val = -1
-    keys = np.array(["brain", "salad", "surgery"], dtype=np.str)
+    keys = np.array(["brain", "salad", "surgery"], dtype=np.str_)
     values = np.array([0, 1, 2], dtype=np.int64)
     table = self.getHashTable()(
         lookup_ops.KeyValueTensorInitializer(keys, values), default_val)

--- a/tensorflow/python/kernel_tests/matrix_band_part_op_test.py
+++ b/tensorflow/python/kernel_tests/matrix_band_part_op_test.py
@@ -141,7 +141,7 @@ class MatrixBandPartBenchmark(test_lib.Benchmark):
 
 
 if __name__ == "__main__":
-  dtypes = (np.bool, np.int32, np.int64, np.float16,
+  dtypes = (np.bool_, np.int32, np.int64, np.float16,
             dtypes_lib.bfloat16.as_numpy_dtype, np.float32, np.float64,
             np.complex64, np.complex128)
   for dtype in dtypes:

--- a/tensorflow/python/kernel_tests/parsing_ops_test.py
+++ b/tensorflow/python/kernel_tests/parsing_ops_test.py
@@ -2376,7 +2376,7 @@ class DecodeRawTest(test.TestCase):
 class DecodeJSONExampleTest(test.TestCase):
 
   def _testRoundTrip(self, examples):
-    examples = np.array(examples, dtype=np.object)
+    examples = np.array(examples, dtype=np.object_)
 
     json_tensor = constant_op.constant(
         [json_format.MessageToJson(m) for m in examples.flatten()],

--- a/tensorflow/python/kernel_tests/py_func_test.py
+++ b/tensorflow/python/kernel_tests/py_func_test.py
@@ -241,7 +241,7 @@ class PyFuncTest(PyFuncTestBase):
   def testObjectArraysAreConvertedToBytes(self):
 
     def read_object_array():
-      return np.array([b" there", u" ya"], dtype=np.object)
+      return np.array([b" there", u" ya"], dtype=np.object_)
 
     def read_and_return_strings(x, y):
       return x + y

--- a/tensorflow/python/kernel_tests/reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/reduction_ops_test.py
@@ -1164,12 +1164,12 @@ class CountNonzeroReductionTest(test.TestCase):
   def testStringReduce1D(self):
     # Create a 1D array of strings
     x = np.asarray(["", "", "a", "", "", "b"])
-    self._compare(x, None, keepdims=False, zero=np.str(""))
-    self._compare(x, [], keepdims=False, zero=np.str(""))
-    self._compare(x, [0], keepdims=False, zero=np.str(""))
-    self._compare(x, None, keepdims=True, zero=np.str(""))
-    self._compare(x, [], keepdims=True, zero=np.str(""))
-    self._compare(x, [0], keepdims=True, zero=np.str(""))
+    self._compare(x, None, keepdims=False, zero=np.str_(""))
+    self._compare(x, [], keepdims=False, zero=np.str_(""))
+    self._compare(x, [0], keepdims=False, zero=np.str_(""))
+    self._compare(x, None, keepdims=True, zero=np.str_(""))
+    self._compare(x, [], keepdims=True, zero=np.str_(""))
+    self._compare(x, [0], keepdims=True, zero=np.str_(""))
 
   @test_util.run_deprecated_v1
   def testStringReduce2D(self):
@@ -1177,15 +1177,15 @@ class CountNonzeroReductionTest(test.TestCase):
     x = np.asarray([["", "", "a", "", "", "b"],
                     ["", "c", "", "d", "", ""],
                     ["e", "", "f", "", "", ""]])
-    self._compare(x, None, keepdims=False, zero=np.str(""))
-    self._compare(x, [], keepdims=False, zero=np.str(""))
-    self._compare(x, [0], keepdims=False, zero=np.str(""))
-    self._compare(x, [1], keepdims=False, zero=np.str(""))
-    self._compare(x, [0, 1], keepdims=False, zero=np.str(""))
-    self._compare(x, None, keepdims=True, zero=np.str(""))
-    self._compare(x, [], keepdims=True, zero=np.str(""))
-    self._compare(x, [0], keepdims=True, zero=np.str(""))
-    self._compare(x, [0, 1], keepdims=True, zero=np.str(""))
+    self._compare(x, None, keepdims=False, zero=np.str_(""))
+    self._compare(x, [], keepdims=False, zero=np.str_(""))
+    self._compare(x, [0], keepdims=False, zero=np.str_(""))
+    self._compare(x, [1], keepdims=False, zero=np.str_(""))
+    self._compare(x, [0, 1], keepdims=False, zero=np.str_(""))
+    self._compare(x, None, keepdims=True, zero=np.str_(""))
+    self._compare(x, [], keepdims=True, zero=np.str_(""))
+    self._compare(x, [0], keepdims=True, zero=np.str_(""))
+    self._compare(x, [0, 1], keepdims=True, zero=np.str_(""))
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/reduction_ops_test_big.py
+++ b/tensorflow/python/kernel_tests/reduction_ops_test_big.py
@@ -150,7 +150,7 @@ class BigReductionTest(BaseReductionTest):
   def testBooleanAll(self):
     # make sure we test all possible kernel invocations
     # test operation where T(0) is not the identity
-    arr_ = np.ones([4097, 4097], dtype=np.bool)
+    arr_ = np.ones([4097, 4097], dtype=np.bool_)
     for size_x in [
         1, 2, 3, 4, 16, 17, 32, 33, 64, 65, 128, 131, 256, 263, 1024, 1025,
         4096, 4097
@@ -160,12 +160,12 @@ class BigReductionTest(BaseReductionTest):
           4096, 4097
       ]:
         arr = arr_[0:size_x, 0:size_y]
-        col_sum = np.ones([size_y], dtype=np.bool)
-        row_sum = np.ones([size_x], dtype=np.bool)
-        full_sum = np.ones([1], dtype=np.bool).reshape([])
+        col_sum = np.ones([size_y], dtype=np.bool_)
+        row_sum = np.ones([size_x], dtype=np.bool_)
+        full_sum = np.ones([1], dtype=np.bool_).reshape([])
 
         with self.session(graph=ops.Graph(), use_gpu=True) as sess:
-          arr_placeholder = array_ops.placeholder(dtype=np.bool,
+          arr_placeholder = array_ops.placeholder(dtype=np.bool_,
                                                   shape=(size_x, size_y))
           tf_row_sum = self._tf_reduce_all(arr_placeholder, 1, False)
           tf_col_sum = self._tf_reduce_all(arr_placeholder, 0, False)
@@ -176,17 +176,17 @@ class BigReductionTest(BaseReductionTest):
         self.assertAllClose(row_sum, tf_out_row)
         self.assertAllClose(full_sum, tf_out_full)
 
-    arr_ = np.ones([130, 130, 130], dtype=np.bool)
+    arr_ = np.ones([130, 130, 130], dtype=np.bool_)
     for size_x in range(1, 130, 13):
       for size_y in range(1, 130, 13):
         for size_z in range(1, 130, 13):
           arr = arr_[0:size_x, 0:size_y, 0:size_z]
-          sum_y = np.ones([size_x, size_z], dtype=np.bool)
-          sum_xz = np.ones([size_y], dtype=np.bool)
+          sum_y = np.ones([size_x, size_z], dtype=np.bool_)
+          sum_xz = np.ones([size_y], dtype=np.bool_)
 
           with self.session(graph=ops.Graph(), use_gpu=True) as sess:
             arr_placeholder = array_ops.placeholder(
-                dtype=np.bool, shape=(size_x, size_y, size_z))
+                dtype=np.bool_, shape=(size_x, size_y, size_z))
             tf_sum_xz = self._tf_reduce_all(arr_placeholder, [0, 2], False)
             tf_sum_y = self._tf_reduce_all(arr_placeholder, 1, False)
             tf_out_sum_xz, tf_out_sum_y = sess.run(

--- a/tensorflow/python/kernel_tests/relu_op_test.py
+++ b/tensorflow/python/kernel_tests/relu_op_test.py
@@ -235,7 +235,7 @@ class Relu6Test(test.TestCase):
   def testNumbersGPU(self):
     if not test.is_gpu_available():
       self.skipTest("No GPU available")
-    for t in [np.float16, np.float, np.double]:
+    for t in [np.float16, np.float64, np.double]:
       self._testRelu6(
           np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t))
 

--- a/tensorflow/python/kernel_tests/reverse_sequence_op_test.py
+++ b/tensorflow/python/kernel_tests/reverse_sequence_op_test.py
@@ -112,7 +112,7 @@ class ReverseSequenceTest(test.TestCase):
     x = np.asarray(
         [[[1, 2, 3, 4], [5, 6, 7, 8]], [[9, 10, 11, 12], [13, 14, 15, 16]],
          [[17, 18, 19, 20], [21, 22, 23, 24]]],
-        dtype=np.float)
+        dtype=np.float64)
     x = x.reshape(3, 2, 4, 1, 1)
     x = x.transpose([2, 1, 0, 3, 4])  # transpose axes 0 <=> 2
 

--- a/tensorflow/python/kernel_tests/sets_test.py
+++ b/tensorflow/python/kernel_tests/sets_test.py
@@ -40,7 +40,7 @@ _DTYPES = set([
 def _values(values, dtype):
   return np.array(
       values,
-      dtype=(np.unicode if (dtype == dtypes.string) else dtype.as_numpy_dtype))
+      dtype=(np.str_ if (dtype == dtypes.string) else dtype.as_numpy_dtype))
 
 
 def _constant(values, dtype):

--- a/tensorflow/python/kernel_tests/softsign_op_test.py
+++ b/tensorflow/python/kernel_tests/softsign_op_test.py
@@ -42,7 +42,7 @@ class SoftsignTest(test.TestCase):
     self.assertShapeEqual(np_softsign, softsign)
 
   def testNumbers(self):
-    for t in [np.float, np.double]:
+    for t in [np.float64, np.double]:
       self._testSoftsign(
           np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t),
           use_gpu=False)

--- a/tensorflow/python/kernel_tests/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops_test.py
@@ -77,7 +77,7 @@ class SparseToIndicatorTest(test_util.TensorFlowTestCase):
       sp_input = self._SparseTensor_5x6(dtypes.int32)
       output = sparse_ops.sparse_to_indicator(sp_input, 50)
 
-      expected_output = np.zeros((5, 50), dtype=np.bool)
+      expected_output = np.zeros((5, 50), dtype=np.bool_)
       expected_trues = ((0, 0), (1, 10), (1, 13), (1, 14), (3, 32), (3, 33))
       for expected_true in expected_trues:
         expected_output[expected_true] = True
@@ -89,7 +89,7 @@ class SparseToIndicatorTest(test_util.TensorFlowTestCase):
       sp_input = self._SparseTensor_5x6(dtypes.int64)
       output = sparse_ops.sparse_to_indicator(sp_input, 50)
 
-      expected_output = np.zeros((5, 50), dtype=np.bool)
+      expected_output = np.zeros((5, 50), dtype=np.bool_)
       expected_trues = [(0, 0), (1, 10), (1, 13), (1, 14), (3, 32), (3, 33)]
       for expected_true in expected_trues:
         expected_output[expected_true] = True
@@ -101,7 +101,7 @@ class SparseToIndicatorTest(test_util.TensorFlowTestCase):
       sp_input = self._SparseTensor_2x3x4(dtypes.int64)
       output = sparse_ops.sparse_to_indicator(sp_input, 200)
 
-      expected_output = np.zeros((2, 3, 200), dtype=np.bool)
+      expected_output = np.zeros((2, 3, 200), dtype=np.bool_)
       expected_trues = [(0, 0, 1), (0, 1, 10), (0, 1, 12), (1, 0, 103),
                         (1, 1, 149), (1, 1, 150), (1, 2, 122)]
       for expected_true in expected_trues:
@@ -300,7 +300,7 @@ class SparseRetainTest(test_util.TensorFlowTestCase):
   def testBasic(self):
     with test_util.force_cpu():
       for sp_input in (self._SparseTensorValue_5x6(), self._SparseTensor_5x6()):
-        to_retain = np.array([1, 0, 0, 1, 1, 0], dtype=np.bool)
+        to_retain = np.array([1, 0, 0, 1, 1, 0], dtype=np.bool_)
         sp_output = sparse_ops.sparse_retain(sp_input, to_retain)
 
         output = self.evaluate(sp_output)
@@ -312,7 +312,7 @@ class SparseRetainTest(test_util.TensorFlowTestCase):
   def testRetainNone(self):
     with test_util.force_cpu():
       sp_input = self._SparseTensor_5x6()
-      to_retain = np.zeros((6,), dtype=np.bool)
+      to_retain = np.zeros((6,), dtype=np.bool_)
       sp_output = sparse_ops.sparse_retain(sp_input, to_retain)
 
       output = self.evaluate(sp_output)
@@ -324,7 +324,7 @@ class SparseRetainTest(test_util.TensorFlowTestCase):
   def testMismatchedRetainShape(self):
     with test_util.force_cpu():
       sp_input = self._SparseTensor_5x6()
-      to_retain = np.array([1, 0, 0, 1, 0], dtype=np.bool)
+      to_retain = np.array([1, 0, 0, 1, 0], dtype=np.bool_)
       with self.assertRaises(ValueError):
         sparse_ops.sparse_retain(sp_input, to_retain)
 
@@ -516,7 +516,7 @@ class SparseFillEmptyRowsTest(test_util.TensorFlowTestCase):
         self.assertAllEqual(output.values, [0, 10, 13, 14, -1, 32, 33, -1])
         self.assertAllEqual(output.dense_shape, [5, 6])
         self.assertAllEqual(empty_row_indicator_out,
-                            np.array([0, 0, 1, 0, 1]).astype(np.bool))
+                            np.array([0, 0, 1, 0, 1]).astype(np.bool_))
 
   @test_util.run_deprecated_v1
   def testFillFloat(self):
@@ -538,7 +538,7 @@ class SparseFillEmptyRowsTest(test_util.TensorFlowTestCase):
       self.assertAllClose(output.values, [0, 10, 13, 14, -1, 32, 33, -1])
       self.assertAllEqual(output.dense_shape, [5, 6])
       self.assertAllEqual(empty_row_indicator_out,
-                          np.array([0, 0, 1, 0, 1]).astype(np.bool))
+                          np.array([0, 0, 1, 0, 1]).astype(np.bool_))
 
       values_grad_err = gradient_checker.compute_gradient_error(
           values, values.shape.as_list(), sp_output.values, [8], delta=1e-8)
@@ -569,7 +569,7 @@ class SparseFillEmptyRowsTest(test_util.TensorFlowTestCase):
                           [b"a", b"b", b"c", b"d", b"", b"e", b"f", b""])
       self.assertAllEqual(output.dense_shape, [5, 6])
       self.assertAllEqual(empty_row_indicator_out,
-                          np.array([0, 0, 1, 0, 1]).astype(np.bool))
+                          np.array([0, 0, 1, 0, 1]).astype(np.bool_))
 
   def testNoEmptyRows(self):
     with test_util.use_gpu():
@@ -583,7 +583,7 @@ class SparseFillEmptyRowsTest(test_util.TensorFlowTestCase):
       self.assertAllEqual(output.indices, [[0, 0], [1, 0], [1, 3], [1, 4]])
       self.assertAllEqual(output.values, [0, 10, 13, 14])
       self.assertAllEqual(output.dense_shape, [2, 6])
-      self.assertAllEqual(empty_row_indicator_out, np.zeros(2).astype(np.bool))
+      self.assertAllEqual(empty_row_indicator_out, np.zeros(2).astype(np.bool_))
 
   def testNoEmptyRowsAndUnordered(self):
     with test_util.use_gpu():
@@ -600,7 +600,7 @@ class SparseFillEmptyRowsTest(test_util.TensorFlowTestCase):
       self.assertAllEqual(output.indices, [[0, 1], [0, 3], [1, 2], [1, 3]])
       self.assertAllEqual(output.values, [2, 4, 1, 3])
       self.assertAllEqual(output.dense_shape, [2, 5])
-      self.assertAllEqual(empty_row_indicator_out, np.zeros(2).astype(np.bool))
+      self.assertAllEqual(empty_row_indicator_out, np.zeros(2).astype(np.bool_))
 
   def testUnordered(self):
     with test_util.use_gpu():
@@ -635,7 +635,7 @@ class SparseFillEmptyRowsTest(test_util.TensorFlowTestCase):
       self.assertAllEqual(output.indices, [[0, 0], [1, 0]])
       self.assertAllEqual(output.values, [-1, -1])
       self.assertAllEqual(output.dense_shape, [2, 5])
-      self.assertAllEqual(empty_row_indicator_out, np.ones(2).astype(np.bool))
+      self.assertAllEqual(empty_row_indicator_out, np.ones(2).astype(np.bool_))
 
   def testEmptyOutput(self):
     with test_util.use_gpu():

--- a/tensorflow/python/kernel_tests/tensor_array_ops_test.py
+++ b/tensorflow/python/kernel_tests/tensor_array_ops_test.py
@@ -52,7 +52,7 @@ from tensorflow.python.platform import test
 def _make_converter(tf_dtype):
   def _converter(x):
     if tf_dtype == dtypes.string:
-      # In Python3, np.str is unicode, while we always want bytes
+      # In Python3, np.str_ is unicode, while we always want bytes
       return np.asarray(x).astype("|S")
     x = np.asarray(x).astype(tf_dtype.as_numpy_dtype)
     if tf_dtype.is_complex:

--- a/tensorflow/python/kernel_tests/transpose_op_test.py
+++ b/tensorflow/python/kernel_tests/transpose_op_test.py
@@ -379,29 +379,28 @@ class TransposeTest(test.TestCase):
         np.arange(0, 16).reshape([1, 2, 1, 2, 1, 2, 1, 2]).astype(np.float64))
 
   def testComplex64(self):
-    self._testBoth(np.array(np.complex(1, 2)).astype(np.complex64))
-    self._testBoth(np.complex(1, 2) * np.arange(0, 21).astype(np.complex64))
+    self._testBoth(np.array(1 + 2j).astype(np.complex64))
     self._testBoth(
-        np.complex(1, 2) *
-        np.arange(0, 21).reshape([3, 7]).astype(np.complex64))
+        (1 + 2j) * np.arange(0, 21).astype(np.complex64))
     self._testBoth(
-        np.complex(1, 2) *
+        (1 + 2j) * np.arange(0, 21).reshape([3, 7]).astype(np.complex64))
+    self._testBoth(
+        (1 + 2j) *
         np.arange(0, 210).reshape([2, 3, 5, 7]).astype(np.complex64))
     self._testBoth(
-        np.complex(1, 2) *
+        (1 + 2j) *
         np.arange(0, 1260).reshape([2, 3, 5, 7, 2, 3]).astype(np.complex64))
 
   def testComplex128(self):
-    self._testBoth(np.array(np.complex(1, 2)).astype(np.complex128))
-    self._testBoth(np.complex(1, 2) * np.arange(0, 21).astype(np.complex128))
+    self._testBoth(np.array(1 + 2j).astype(np.complex128))
+    self._testBoth((1 + 2j) * np.arange(0, 21).astype(np.complex128))
     self._testBoth(
-        np.complex(1, 2) *
-        np.arange(0, 21).reshape([3, 7]).astype(np.complex128))
+        (1 + 2j) * np.arange(0, 21).reshape([3, 7]).astype(np.complex128))
     self._testBoth(
-        np.complex(1, 2) *
+        (1 + 2j) *
         np.arange(0, 210).reshape([2, 3, 5, 7]).astype(np.complex128))
     self._testBoth(
-        np.complex(1, 2) *
+        (1 + 2j) *
         np.arange(0, 1260).reshape([2, 3, 5, 7, 2, 3]).astype(np.complex128))
 
   def testInt8(self):

--- a/tensorflow/python/kernel_tests/tridiagonal_solve_op_test.py
+++ b/tensorflow/python/kernel_tests/tridiagonal_solve_op_test.py
@@ -108,7 +108,7 @@ class TridiagonalSolveOpTest(test.TestCase):
       result = self.evaluate(result)
       if expected is None:
         self.assertAllEqual(
-            np.zeros_like(result, dtype=np.bool), np.isfinite(result))
+            np.zeros_like(result, dtype=np.bool_), np.isfinite(result))
       else:
         self.assertAllClose(result, expected)
 

--- a/tensorflow/python/kernel_tests/where_op_test.py
+++ b/tensorflow/python/kernel_tests/where_op_test.py
@@ -128,7 +128,7 @@ class WhereOpTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testRandomBool(self):
-    self._testRandom(np.bool)
+    self._testRandom(np.bool_)
 
   @test_util.run_deprecated_v1
   def testRandomInt32(self):
@@ -186,7 +186,7 @@ class WhereOpTest(test.TestCase):
     self._testBasic3Tensor(array_ops.where_v2)
 
   def testV2RandomBool(self):
-    self._testRandom(np.bool, None, array_ops.where_v2)
+    self._testRandom(np.bool_, None, array_ops.where_v2)
 
   def testV2RandomInt32(self):
     self._testRandom(np.int32, None, array_ops.where_v2)

--- a/tensorflow/python/ops/gradient_checker_v2_test.py
+++ b/tensorflow/python/ops/gradient_checker_v2_test.py
@@ -126,7 +126,7 @@ class GradientCheckerTest(test.TestCase):
     p_shape = (4, 2)
     p_size = 8
     params = constant_op.constant(
-        np.arange(p_size).astype(np.float), shape=p_shape, name="p")
+        np.arange(p_size).astype(np.float64), shape=p_shape, name="p")
     error = gradient_checker.max_error(
         *gradient_checker.compute_gradient(f, [params]))
     tf_logging.info("gather error = %f", error)
@@ -145,7 +145,7 @@ class GradientCheckerTest(test.TestCase):
     p_shape = (8, 2)
     p_size = 16
     params = constant_op.constant(
-        np.arange(p_size).astype(np.float), shape=p_shape, name="p")
+        np.arange(p_size).astype(np.float64), shape=p_shape, name="p")
     error = gradient_checker.max_error(
         *gradient_checker.compute_gradient(f, [params]))
     tf_logging.info("nested gather error = %f", error)

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -1526,13 +1526,13 @@ class AdjustContrastTest(test_util.TensorFlowTestCase):
   def testDoubleContrastFloat(self):
     x_shape = [1, 2, 2, 3]
     x_data = [0, 5, 13, 54, 135, 226, 37, 8, 234, 90, 255, 1]
-    x_np = np.array(x_data, dtype=np.float).reshape(x_shape) / 255.
+    x_np = np.array(x_data, dtype=np.float64).reshape(x_shape) / 255.
 
     y_data = [
         -45.25, -90.75, -92.5, 62.75, 169.25, 333.5, 28.75, -84.75, 349.5,
         134.75, 409.25, -116.5
     ]
-    y_np = np.array(y_data, dtype=np.float).reshape(x_shape) / 255.
+    y_np = np.array(y_data, dtype=np.float64).reshape(x_shape) / 255.
 
     self._testContrast(x_np, y_np, contrast_factor=2.0)
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -403,7 +403,7 @@ class ApproximateEqualTest(test_util.TensorFlowTestCase):
     for dtype in [np.float32, np.double]:
       x = np.array([[[[-1, 2.00009999], [-3, 4.01]]]], dtype=dtype)
       y = np.array([[[[-1.001, 2], [-3.00009, 4]]]], dtype=dtype)
-      z = np.array([[[[False, True], [True, False]]]], dtype=np.bool)
+      z = np.array([[[[False, True], [True, False]]]], dtype=np.bool_)
       with test_util.device(use_gpu=True):
         z_tf = self.evaluate(math_ops.approximate_equal(x, y, tolerance=0.0001))
         self.assertAllEqual(z, z_tf)

--- a/tensorflow/python/ops/numpy_ops/__init__.py
+++ b/tensorflow/python/ops/numpy_ops/__init__.py
@@ -148,7 +148,7 @@ tf_var.assign_add(tnp.square(tf_var))
 Here is a non-exhaustive list of differences:
 
 *   Not all dtypes are currently supported. e.g. `np.float96`, `np.float128`.
-    `np.object`, `np.str`, `np.recarray` types are not supported.
+    `np.object_`, `np.str_`, `np.recarray` types are not supported.
 *   `ndarray` storage is in C order only. Fortran order, views, `stride_tricks`
     are not supported.
 *   Only a subset of functions and modules are supported. This set will be

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1392,7 +1392,7 @@ def sign(x, out=None, where=None, **kwargs):  # pylint: disable=missing-docstrin
 
   x = asarray(x)
   dtype = x.dtype.as_numpy_dtype
-  if np.issubdtype(dtype, np.complex):
+  if np.issubdtype(dtype, np.complexfloating):
     result = math_ops.cast(math_ops.sign(math_ops.real(x)), dtype)
   else:
     result = math_ops.sign(x)
@@ -1801,7 +1801,7 @@ def _getitem(self, slice_spec):
   if (isinstance(slice_spec, bool) or (isinstance(slice_spec, ops.Tensor) and
                                        slice_spec.dtype == dtypes.bool) or
       (isinstance(slice_spec, (np.ndarray, np_arrays.ndarray)) and
-       slice_spec.dtype == np.bool)):
+       slice_spec.dtype == np.bool_)):
     return array_ops.boolean_mask(tensor=self, mask=slice_spec)
 
   if not isinstance(slice_spec, tuple):
@@ -1816,7 +1816,7 @@ def _with_index_update_helper(update_method, a, slice_spec, updates):
   if (isinstance(slice_spec, bool) or (isinstance(slice_spec, ops.Tensor) and
                                        slice_spec.dtype == dtypes.bool) or
       (isinstance(slice_spec, (np.ndarray, np_arrays.ndarray)) and
-       slice_spec.dtype == np.bool)):
+       slice_spec.dtype == np.bool_)):
     slice_spec = nonzero(slice_spec)
 
   if not isinstance(slice_spec, tuple):

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -601,7 +601,7 @@ class ArrayMethodsTest(test.TestCase):
           self.match(
               np_array_ops.compress(arg1, arg2, *args, **kwargs),
               np.compress(
-                  np.asarray(arg1).astype(np.bool), arg2, *args, **kwargs))
+                  np.asarray(arg1).astype(np.bool_), arg2, *args, **kwargs))
 
     run_test([True], 5)
     run_test([False], 5)
@@ -1115,7 +1115,7 @@ class ArrayMethodsTest(test.TestCase):
 
     for dtype in test_types:
       for shape in test_shapes:
-        if np.issubdtype(dtype, np.complex):
+        if np.issubdtype(dtype, np.complexfloating):
           arr = (np.asarray(state.randn(*shape) * 100, dtype=dtype) +
                  1j * np.asarray(state.randn(*shape) * 100, dtype=dtype))
         else:

--- a/tensorflow/python/ops/numpy_ops/np_random.py
+++ b/tensorflow/python/ops/numpy_ops/np_random.py
@@ -107,7 +107,7 @@ def rand(*size):
 
 
 @np_utils.np_doc('random.randint')
-def randint(low, high=None, size=None, dtype=onp.int):  # pylint: disable=missing-function-docstring
+def randint(low, high=None, size=None, dtype=onp.int64):  # pylint: disable=missing-function-docstring
   low = int(low)
   if high is None:
     high = low

--- a/tensorflow/python/ops/parallel_for/test_util.py
+++ b/tensorflow/python/ops/parallel_for/test_util.py
@@ -44,7 +44,7 @@ class PForTestCase(test.TestCase):
     outputs = nest.flatten(outputs)  # flatten SparseTensorValues
     n = len(outputs) // 2
     for i in range(n):
-      if outputs[i + n].dtype != np.object:
+      if outputs[i + n].dtype != np.object_:
         self.assertAllClose(outputs[i + n], outputs[i], rtol=rtol, atol=atol)
       else:
         self.assertAllEqual(outputs[i + n], outputs[i])

--- a/tensorflow/python/ops/ragged/ragged_constant_value_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_constant_value_op_test.py
@@ -164,7 +164,7 @@ class RaggedConstantValueOpTest(test_util.TensorFlowTestCase,
       dict(pylist=[[1., 2.], [], [4., 5., 6.]], expected_dtype=np.float64),
       dict(pylist=[[1, 2], [3.], [4, 5, 6]], expected_dtype=np.float64),
       dict(pylist=[[b'a', b'b'], [b'c']], expected_dtype=np.dtype('S1')),
-      dict(pylist=[[True]], expected_dtype=np.bool),
+      dict(pylist=[[True]], expected_dtype=np.bool_),
       dict(
           pylist=[np.array([1, 2]), np.array([3.]), [4, 5, 6]],
           expected_dtype=np.float64),

--- a/tensorflow/python/ops/v1_compat_tests/gradient_checker_test.py
+++ b/tensorflow/python/ops/v1_compat_tests/gradient_checker_test.py
@@ -105,7 +105,7 @@ class GradientCheckerTest(test.TestCase):
       index_values = [1, 3]
       y_shape = [2, 2]
       params = constant_op.constant(
-          np.arange(p_size).astype(np.float), shape=p_shape, name="p")
+          np.arange(p_size).astype(np.float64), shape=p_shape, name="p")
       indices = constant_op.constant(index_values, name="i")
       y = array_ops.gather(params, indices, name="y")
 
@@ -125,7 +125,7 @@ class GradientCheckerTest(test.TestCase):
       y2_shape = [2, 2]
 
       params = constant_op.constant(
-          np.arange(p_size).astype(np.float), shape=p_shape, name="p")
+          np.arange(p_size).astype(np.float64), shape=p_shape, name="p")
       indices = constant_op.constant(index_values, name="i")
       y = array_ops.gather(params, indices, name="y")
       indices2 = constant_op.constant(index_values2, name="i2")


### PR DESCRIPTION
Replaced
* np.bool with np.bool_,
* np.int with np.int64,
* np.float with np.float64,
* np.complex with np.complex128
* np.object with np.object_,
* np.str with np.str_, and
* np.unicode with np.str_.

Repaired 4 uses of np.complex that should have been np.complexfloating.

According to https://numpy.org/doc/stable/release/1.20.0-notes.html,
this will have no effect except to suppress deprecation warnings.