### PR TITLE
Update setup.py

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -103,7 +103,7 @@ REQUIRED_PACKAGES = [
     # When updating these, please also update the nightly versions below
     'tensorboard ~= 2.5',
     'tf-estimator-nightly == 2.6.0.dev2021062501',
-    'keras == 2.6.0rc0',
+    'keras == 2.6.0rc1',
 ]
 
 


### PR DESCRIPTION
Update Keras package version to 2.6.0rc1, which pins the protobuf version back to 3.9.2. It is aligned with the protobuf version used by TF in the workspace.