### PR TITLE
Improve BiasAdd GPU performance with more threads

### DIFF
--- a/tensorflow/core/kernels/bias_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bias_op_gpu.cu.cc
@@ -84,13 +84,16 @@ void BiasGPU<T>::compute(const GPUDevice& d, const T* input, const T* bias,
   if (total_count == 0) {
     return;
   }
-  GpuLaunchConfig config = GetGpuLaunchConfig(total_count, d);
   if (data_format == FORMAT_NHWC) {
+    GpuLaunchConfig config = GetGpuLaunchConfig(total_count, d,
+                                                BiasNHWCKernel<T>, 0, 0);
     TF_CHECK_OK(GpuLaunchKernel(BiasNHWCKernel<T>, config.block_count,
                                 config.thread_per_block, 0, d.stream(),
                                 config.virtual_thread_count, input, bias,
                                 output, bias_size));
   } else {
+    GpuLaunchConfig config = GetGpuLaunchConfig(total_count, d,
+                                                BiasNCHWKernel<T>, 0, 0);
     TF_CHECK_OK(GpuLaunchKernel(BiasNCHWKernel<T>, config.block_count,
                                 config.thread_per_block, 0, d.stream(),
                                 config.virtual_thread_count, input, bias,


### PR DESCRIPTION
Originally, the launch config is too conservative and it only uses the number of SMs as the block number when the workload is large enough. This can barely saturate the GPU resources especially for the memory bound kernels, like the BiasAdd. Our tests show `tf.nn.bias_add` might be significantly slower than the `tf.math.add`.

This PR changes the launch config by using the `cudaOccupancyMaxPotentialBlockSize` based method to get a more reasonable block/thread config. The new results show `tf.nn.bias_add` can get comparable performance with `tf.math.add` after this change.


cc. @nluehr 