### PR TITLE
Cherry-pick: Disable the cudnn frontend for cudnn 8.1.0

### DIFF
--- a/tensorflow/core/util/use_cudnn.cc
+++ b/tensorflow/core/util/use_cudnn.cc
@@ -39,12 +39,16 @@ namespace tensorflow {
 bool CudnnUseFrontend() {
   static bool result = [] {
     bool value = false;
-#if GOOGLE_CUDA && CUDNN_VERSION >= 8100
-    Status status = ReadBoolFromEnvVar("TF_CUDNN_USE_FRONTEND", true, &value);
-    if (!status.ok()) {
-      LOG(ERROR) << status;
+#if GOOGLE_CUDA
+    if (CUDNN_VERSION >= 8100) {
+      // cuDNN 8.1.0 + the frontend has issues regarding fused convolution.
+      Status status = ReadBoolFromEnvVar("TF_CUDNN_USE_FRONTEND",
+                                         CUDNN_VERSION >= 8200, &value);
+      if (!status.ok()) {
+        LOG(ERROR) << status;
+      }
     }
-#endif  // GOOGLE_CUDA && CUDNN_VERSION >= 8100
+#endif  // GOOGLE_CUDA
     return value;
   }();
   return result;


### PR DESCRIPTION
git cherry-pick 75ee2f3c02559d4a3cc0ffdaf863666fca174627

Disable the cudnn frontend for cudnn 8.1.0. It causes some failures in conv + relu cases:

```
errors_impl.UnknownError:  CUDNN_STATUS_INTERNAL_ERROR
in tensorflow/stream_executor/cuda/cuda_dnn.cc(4358): 'status'
   [[node sequential/conv2d/Relu (...) ]] [Op:__inference_train_function_962]
```

b/191767626
PiperOrigin-RevId: 382139944
Change-Id: I21d4aeda4f40d900083da37fe57831ff7e549bad