### PR TITLE
Cherry-pick: Fix deprecation notice.

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4847,7 +4847,7 @@ def reverse_sequence_v2(input,
                              ("The `validate_indices` argument has no effect. "
                               "Indices are always validated on CPU and never "
                               "validated on GPU."),
-                             "validate_indices")
+                             ("validate_indices", None))
 @dispatch.add_dispatch_support
 def gather(params,
            indices,

--- a/tensorflow/python/util/deprecation.py
+++ b/tensorflow/python/util/deprecation.py
@@ -393,8 +393,8 @@ def deprecated_args(date, instructions, *deprecated_arg_names_or_tuples,
       Must be ISO 8601 (YYYY-MM-DD), or None.
     instructions: String. Instructions on how to update code using the
       deprecated function.
-    *deprecated_arg_names_or_tuples: String or 2-Tuple(String,
-      [ok_vals]).  The string is the deprecated argument name.
+    *deprecated_arg_names_or_tuples: String or 2-Tuple (String,
+      ok_val).  The string is the deprecated argument name.
       Optionally, an ok-value may be provided.  If the user provided
       argument equals this value, the warning is suppressed.
     **kwargs: If `warn_once=False` is passed, every call with a deprecated


### PR DESCRIPTION
`None` is the acceptable value here.

`deprecation.py` fix description of `deprecated_args`'s `*deprecated_arg_names_or_tuples` argument. The Okay value should be a single value, not a list.

b/192248069
PiperOrigin-RevId: 382287123
Change-Id: Ief25b4a9db03bc0ff3bc7847692f2f130635fb61