### PR TITLE
Be explicit about the type signature of map_func

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1981,7 +1981,8 @@ name=None))
     ...     deterministic=False)
 
     Args:
-      map_func: A function mapping a dataset element to a dataset.
+      map_func: A function that takes a dataset element and returns a
+        `tf.data.Dataset`.
       cycle_length: (Optional.) The number of input elements that will be
         processed concurrently. If not set, the tf.data runtime decides what it
         should be based on available CPU. If `num_parallel_calls` is set to


### PR DESCRIPTION
Highlight tf.data.Dataset such that the reader doesn't miss it. The typing was mentioned at the top of the doc but not immediately visible at the params table.

Motivation for this change is that after studying this doc, a user still came up with code calling `interleave` with a function that takes element and returns element.