### PR TITLE
Support Cudnn Frontend Errata Filter

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -3258,26 +3258,6 @@ namespace {
 
 #if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 
-absl::optional<int64_t> GetEngineId(cudnnBackendDescriptor_t engine_config) {
-  int64_t count;
-  int64_t engine_id;
-  cudnn_frontend::ManagedOpaqueDescriptor managed_engine =
-      cudnn_frontend::make_shared_backend_pointer(
-          CUDNN_BACKEND_ENGINE_DESCRIPTOR);
-  cudnnBackendDescriptor_t engine = managed_engine->get_backend_descriptor();
-  if (cudnnBackendGetAttribute(engine_config, CUDNN_ATTR_ENGINECFG_ENGINE,
-                               CUDNN_TYPE_BACKEND_DESCRIPTOR, 1, &count,
-                               &engine) != CUDNN_STATUS_SUCCESS) {
-    return absl::nullopt;
-  }
-  if (cudnnBackendGetAttribute(engine, CUDNN_ATTR_ENGINE_GLOBAL_INDEX,
-                               CUDNN_TYPE_INT64, 1, &count,
-                               &engine_id) != CUDNN_STATUS_SUCCESS) {
-    return absl::nullopt;
-  }
-  return engine_id;
-}
-
 bool GenericEngineFilter(cudnnBackendDescriptor_t engine_config,
                          bool disable_winograd, bool disable_nondeterminism,
                          bool disable_tensor_core) {
@@ -3298,11 +3278,6 @@ bool GenericEngineFilter(cudnnBackendDescriptor_t engine_config,
   if (disable_tensor_core) {
     ret |= cudnn_frontend::hasNumericalNote<CUDNN_NUMERICAL_NOTE_TENSOR_CORE>(
         engine_config);
-  }
-
-  auto maybe_engine_id = GetEngineId(engine_config);
-  if (maybe_engine_id.has_value()) {
-    ret |= *maybe_engine_id == 0;
   }
 
   return ret;

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -159,11 +159,11 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = "//third_party:cudnn_frontend_header_fix.patch",
-        sha256 = "60b085e1412144e0b24f8b01809857d3a4491c9b2b1c58f0766f673b791d05ca",
-        strip_prefix = "cudnn-frontend-51e60d891b689d618e7a623509a779c422a420f7",
+        sha256 = "fdf4234e9c9c481b3b3a80ad404bc278e6ecb761c5574beb4d3a2cde4a9002ad",
+        strip_prefix = "cudnn-frontend-73210a930333eaf66b42b01693bce7b70719c354",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/NVIDIA/cudnn-frontend/archive/51e60d891b689d618e7a623509a779c422a420f7.zip",
-            "https://github.com/NVIDIA/cudnn-frontend/archive/51e60d891b689d618e7a623509a779c422a420f7.zip",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/NVIDIA/cudnn-frontend/archive/73210a930333eaf66b42b01693bce7b70719c354.zip",
+            "https://github.com/NVIDIA/cudnn-frontend/archive/73210a930333eaf66b42b01693bce7b70719c354.zip",
         ],
     )
 

--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,4 +1,4 @@
-From 7bbdd3663cfb6a74541e95fe4b9dd5fe16659963 Mon Sep 17 00:00:00 2001
+From 12c0db4e4d7d36137536885142ac226b526794a8 Mon Sep 17 00:00:00 2001
 From: Kaixi Hou <kaixih@nvidia.com>
 Date: Tue, 4 May 2021 15:21:11 -0700
 Subject: [PATCH] Update headers path
@@ -34,7 +34,7 @@ index b07b336..3fb06a7 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_ConvDesc.h b/include/cudnn_frontend_ConvDesc.h
-index d8706d4..6cabf6e 100644
+index 2bcf0bc..fa26dc7 100644
 --- a/include/cudnn_frontend_ConvDesc.h
 +++ b/include/cudnn_frontend_ConvDesc.h
 @@ -29,8 +29,8 @@
@@ -92,7 +92,7 @@ index e7d918b..7298ef3 100644
  
  namespace cudnn_frontend {
 diff --git a/include/cudnn_frontend_ExecutionPlan.h b/include/cudnn_frontend_ExecutionPlan.h
-index 8ceb03a..048713c 100644
+index 858e067..b10ee88 100644
 --- a/include/cudnn_frontend_ExecutionPlan.h
 +++ b/include/cudnn_frontend_ExecutionPlan.h
 @@ -29,8 +29,8 @@
@@ -120,7 +120,7 @@ index b244766..3e9273b 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_Heuristics.h b/include/cudnn_frontend_Heuristics.h
-index 446f932..b15f472 100644
+index 3f61156..ce040b7 100644
 --- a/include/cudnn_frontend_Heuristics.h
 +++ b/include/cudnn_frontend_Heuristics.h
 @@ -24,8 +24,8 @@
@@ -133,7 +133,7 @@ index 446f932..b15f472 100644
 +#include "third_party/gpus/cudnn/cudnn_backend.h"
  
  #include "cudnn_frontend_OperationGraph.h"
- #include "cudnn_frontend_utils.h"
+ #include "cudnn_frontend_EngineConfig.h"
 diff --git a/include/cudnn_frontend_MatMulDesc.h b/include/cudnn_frontend_MatMulDesc.h
 index e416002..da2deb1 100644
 --- a/include/cudnn_frontend_MatMulDesc.h
@@ -150,7 +150,7 @@ index e416002..da2deb1 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Operation.h b/include/cudnn_frontend_Operation.h
-index dd3633d..a533a30 100644
+index 15f9b7c..c4a4cbb 100644
 --- a/include/cudnn_frontend_Operation.h
 +++ b/include/cudnn_frontend_Operation.h
 @@ -29,8 +29,8 @@


### PR DESCRIPTION
Cudnn frontend v0.4 introduces a new API to allow users to filtering out undesired engines: https://github.com/NVIDIA/cudnn-frontend/releases/tag/v0.4. Users can either hard-code a list of those engines or provide a JSON file via `CUDNN_ERRATA_JSON_FILE` during runtime. This feature could greatly improve the debugging process.

This PR integrate this feature by allowing both hard-coded errata list (intentionally blank for now) and runtime list. An example of using runtime list:
```bash
# cat /home/tmp/sample_errata.json
{ "version" : 1,
  "rules"   : [
    { "rule_id"             : "ConvFwd_eng1",
      "operation"           : "ConvFwd",
      "engine"              : 1,
      "knob"                : [],
      "cudnn_version_start" : 8000,
      "cudnn_version_end"   : -1
    }
  ]
}

# CUDNN_ERRATA_JSON_FILE=/home/tmp/sample_errata.json TF_CPP_VMODULE=cuda_dnn=4 python -u conv2d_tf2_func.py
...
2021-07-01 20:50:21.828423: I tensorflow/stream_executor/cuda/cuda_dnn.cc:4489] Exclude engine (runtime): ConvFwd_eng1_k2=3_k3=0
2021-07-01 20:50:21.828626: I tensorflow/stream_executor/cuda/cuda_dnn.cc:4489] Exclude engine (runtime): ConvFwd_eng1_k2=0_k3=0
...
```

cc. @nluehr 