### PR TITLE
Cudnn frontend v0.4: Support of int8x4, API updates

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -3479,25 +3479,18 @@ GetCudnnOperationGraph(dnn::ConvolutionKind kind, dnn::DataType element_type,
                        .build();
   RETURN_MSG_IF_CUDNN_ERROR(conv_desc);
 
-  // TODO(kaixih@nvidia): Remove the redundant float/double alpha/beta when the
-  // cudnn frontend can deduce the compute type from the operation.
-  // Alpha is the scaling factor for input.
-  float falpha = 1.0;
-  double dalpha = 1.0;
-  // Beta is the scaling factor for output.
-  float fbeta = 0.0;
-  double dbeta = 0.0;
+  double alpha = 1.0;
+  double beta = 0.0;
 
   // CUDNN Operation
-  auto op_builder = cudnn_frontend::OperationBuilder(conv_mode);
-  op_builder.setxDesc(tensor_x).setyDesc(tensor_y).setwDesc(tensor_w).setcDesc(
-      conv_desc);
-  if (cudnn_type == CUDNN_DATA_DOUBLE) {
-    op_builder.setAlpha(dalpha).setBeta(dbeta);
-  } else {
-    op_builder.setAlpha(falpha).setBeta(fbeta);
-  }
-  auto op = op_builder.build();
+  auto op = cudnn_frontend::OperationBuilder(conv_mode)
+                .setxDesc(tensor_x)
+                .setyDesc(tensor_y)
+                .setwDesc(tensor_w)
+                .setcDesc(conv_desc)
+                .setAlpha(alpha)
+                .setBeta(beta)
+                .build();
   RETURN_MSG_IF_CUDNN_ERROR(op);
 
   // CUDNN OperationGraph
@@ -3684,49 +3677,33 @@ GetCudnnFusedOperationGraph(
                        .build();
   RETURN_MSG_IF_CUDNN_ERROR(conv_desc);
 
-  // TODO(kaixih@nvidia): Remove the redundant float/double alpha/beta when the
-  // cudnn frontend can deduce the compute type from the operation.
-  bool use_float_scale = true;
-  if (element_type == dnn::DataType::kDouble) {
-    use_float_scale = false;
-  }
   // Beta is the scaling factor for output.
   double beta = 0.0;
-  float beta_float = 0.0f;
-
-  float alpha_float = static_cast<float>(alpha);
-  float alpha2_float = static_cast<float>(alpha2);
 
   // CUDNN Operation
-  auto conv_op_builder = cudnn_frontend::OperationBuilder(conv_mode);
-  conv_op_builder.setxDesc(tensor_x)
-      .setyDesc(tensor_conv)
-      .setwDesc(tensor_w)
-      .setcDesc(conv_desc);
-  if (use_float_scale) {
-    conv_op_builder.setAlpha(alpha_float).setBeta(beta_float);
-  } else {
-    conv_op_builder.setAlpha(alpha).setBeta(beta);
-  }
-  auto conv_op = conv_op_builder.build();
+  auto conv_op = cudnn_frontend::OperationBuilder(conv_mode)
+                     .setxDesc(tensor_x)
+                     .setyDesc(tensor_conv)
+                     .setwDesc(tensor_w)
+                     .setcDesc(conv_desc)
+                     .setAlpha(alpha)
+                     .setBeta(beta)
+                     .build();
   RETURN_MSG_IF_CUDNN_ERROR(conv_op);
 
   auto add_desc = cudnn_frontend::PointWiseDescBuilder()
                       .setMode(CUDNN_POINTWISE_ADD)
                       .setMathPrecision(cudnn_type)
                       .build();
-  auto add_op_builder = cudnn_frontend::OperationBuilder(
-      CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR);
-  add_op_builder.setxDesc(conv_op.getOutputTensor())
-      .setbDesc(tensor_z)
-      .setyDesc(tensor_add)
-      .setpwDesc(add_desc);
-  if (use_float_scale) {
-    add_op_builder.setAlpha(alpha_float).setAlpha2(alpha2_float);
-  } else {
-    add_op_builder.setAlpha(alpha).setAlpha2(alpha2);
-  }
-  auto add_op = add_op_builder.build();
+  auto add_op = cudnn_frontend::OperationBuilder(
+                    CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                    .setxDesc(conv_op.getOutputTensor())
+                    .setbDesc(tensor_z)
+                    .setyDesc(tensor_add)
+                    .setpwDesc(add_desc)
+                    .setAlpha(alpha)
+                    .setAlpha2(alpha2)
+                    .build();
   RETURN_MSG_IF_CUDNN_ERROR(add_op);
 
   auto bias_add_desc = cudnn_frontend::PointWiseDescBuilder()

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -3399,6 +3399,11 @@ GetCudnnOperationGraph(dnn::ConvolutionKind kind, dnn::DataType element_type,
   std::vector<int64_t> input_strides = GetTensorStrides(
       input_descriptor, dnn::DataLayout::kBatchDepthYX, vector_size,
       vector_dim);
+  
+  if (vector_size == 32) {
+    return port::InternalError("cuDNN frontend doesn't support int8x32 at the "
+                               "moment.");
+  }
 
   auto tensor_x = cudnn_frontend::TensorBuilder()
                       .setDim(input_dims.size(), &input_dims[0])
@@ -3539,6 +3544,12 @@ GetCudnnFusedOperationGraph(
   std::vector<int64_t> input_strides = GetTensorStrides(
       input_descriptor, dnn::DataLayout::kBatchDepthYX, vector_size,
       vector_dim);
+
+  if (vector_size == 32) {
+    return port::InternalError("cuDNN frontend doesn't support int8x32 at the "
+                               "moment.");
+  }
+
   auto tensor_x = cudnn_frontend::TensorBuilder()
                       .setDim(input_dims.size(), &input_dims[0])
                       .setStrides(input_dims.size(), &input_strides[0])

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -384,6 +384,28 @@ std::vector<int64> BatchDescriptor::full_strides(
   return ReorderDims(phys_strides, this->layout(), layout);
 }
 
+std::vector<int64> BatchDescriptor::vectorized_dims(
+    const DataLayout& layout, int vector_size, int vector_dim) const {
+  std::vector<int64> bdyx_dims = full_dims(dnn::DataLayout::kBatchDepthYX);
+  if (vector_dim != -1) {
+    bdyx_dims[vector_dim] /= vector_size;
+  }
+  return dnn::ReorderDims(
+             bdyx_dims, dnn::DataLayout::kBatchDepthYX, layout);
+}
+
+std::vector<int64> BatchDescriptor::vectorized_strides(
+    const DataLayout& layout, int vector_size, int vector_dim) const {
+  std::vector<int64> phys_dims = vectorized_dims(
+                                     this->layout(), vector_size, vector_dim);
+  std::vector<int64> phys_strides(phys_dims.size());
+  phys_strides[ndims() + 1] = 1;
+  for (int i = ndims(); i >= 0; i--) {
+    phys_strides[i] = phys_strides[i + 1] * phys_dims[i + 1];
+  }
+  return ReorderDims(phys_strides, this->layout(), layout);
+}
+
 void BatchDescriptor::CloneFrom(const BatchDescriptor& other) {
   tensor_ = other.tensor_;
   value_max_ = other.value_max_;
@@ -568,6 +590,27 @@ std::vector<int64> FilterDescriptor::full_dims(
 std::vector<int64> FilterDescriptor::full_strides(
     const FilterLayout& layout) const {
   std::vector<int64> phys_dims = full_dims(this->layout());
+  std::vector<int64> phys_strides(phys_dims.size());
+  phys_strides[ndims() + 1] = 1;
+  for (int i = ndims(); i >= 0; i--) {
+    phys_strides[i] = phys_strides[i + 1] * phys_dims[i + 1];
+  }
+  return ReorderDims(phys_strides, this->layout(), layout);
+}
+
+std::vector<int64> FilterDescriptor::vectorized_dims(
+    const FilterLayout& layout, int vector_size, int vector_dim) const {
+  std::vector<int64> oiyx_dims = full_dims(dnn::FilterLayout::kOutputInputYX);
+  if (vector_dim != -1) {
+    oiyx_dims[vector_dim] /= vector_size;
+  }
+  return ReorderDims(oiyx_dims, FilterLayout::kOutputInputYX, layout);
+}
+
+std::vector<int64> FilterDescriptor::vectorized_strides(
+    const FilterLayout& layout, int vector_size, int vector_dim) const {
+  std::vector<int64> phys_dims = vectorized_dims(
+                                     this->layout(), vector_size, vector_dim);
   std::vector<int64> phys_strides(phys_dims.size());
   phys_strides[ndims() + 1] = 1;
   for (int i = ndims(); i >= 0; i--) {

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -399,8 +399,8 @@ std::vector<int64> BatchDescriptor::vectorized_strides(
   std::vector<int64> phys_dims = vectorized_dims(
                                      this->layout(), vector_size, vector_dim);
   std::vector<int64> phys_strides(phys_dims.size());
-  phys_strides[ndims() + 1] = 1;
-  for (int i = ndims(); i >= 0; i--) {
+  phys_strides[phys_dims.size() - 1] = 1;
+  for (int i = phys_dims.size() - 2; i >= 0; i--) {
     phys_strides[i] = phys_strides[i + 1] * phys_dims[i + 1];
   }
   return ReorderDims(phys_strides, this->layout(), layout);
@@ -612,8 +612,8 @@ std::vector<int64> FilterDescriptor::vectorized_strides(
   std::vector<int64> phys_dims = vectorized_dims(
                                      this->layout(), vector_size, vector_dim);
   std::vector<int64> phys_strides(phys_dims.size());
-  phys_strides[ndims() + 1] = 1;
-  for (int i = ndims(); i >= 0; i--) {
+  phys_strides[phys_dims.size() - 1] = 1;
+  for (int i = phys_dims.size() - 2; i >= 0; i--) {
     phys_strides[i] = phys_strides[i + 1] * phys_dims[i + 1];
   }
   return ReorderDims(phys_strides, this->layout(), layout);

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -285,6 +285,15 @@ class BatchDescriptor {
   // layout.
   std::vector<int64> full_strides(const DataLayout& layout) const;
 
+  // Vectorized dimensions where users can specify the dimension that the number
+  // of dimensions is reported rather than the full number of elements.
+  std::vector<int64> vectorized_dims(
+      const DataLayout& layout, int vector_size, int vector_dim) const;
+
+  // Vectorized strides correspond to the vectorized_dims.
+  std::vector<int64> vectorized_strides(
+      const DataLayout& layout, int vector_size, int vector_dim) const;
+
   // Named-argument helpers for avoiding user error during construction.
   BatchDescriptor& set_count(int64 value) {
     tensor_.set_dimensions(0, value);
@@ -472,6 +481,14 @@ class FilterDescriptor {
   // ordered according to a specific layout.
   std::vector<int64> full_strides(const FilterLayout& layout) const;
 
+  // Vectorized dimensions where users can specify the dimension that the number
+  // of dimensions is reported rather than the full number of elements.
+  std::vector<int64> vectorized_dims(
+      const FilterLayout& layout, int vector_size, int vector_dim) const;
+
+  // Vectorized strides correspond to the vectorized_dims.
+  std::vector<int64> vectorized_strides(
+      const FilterLayout& layout, int vector_size, int vector_dim) const;
  private:
   absl::Span<int64> input_filter_dims() {
     return AsInt64Slice(tensor_.mutable_dimensions()).subspan(2);

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -63,6 +63,10 @@ enum class DimIndex : int {
 std::vector<int64> ReorderDims(const std::vector<int64>& input,
                                const DataLayout& from, const DataLayout& to);
 
+std::vector<int64> ReorderDims(const std::vector<int64>& input,
+                               const FilterLayout& from,
+                               const FilterLayout& to);
+
 // Helper functions to make methods more readable.
 inline int64 GetDim(absl::Span<const int64> data, DimIndex dim) {
   return data.rbegin()[static_cast<int64>(dim)];

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -63,10 +63,6 @@ enum class DimIndex : int {
 std::vector<int64> ReorderDims(const std::vector<int64>& input,
                                const DataLayout& from, const DataLayout& to);
 
-std::vector<int64> ReorderDims(const std::vector<int64>& input,
-                               const FilterLayout& from,
-                               const FilterLayout& to);
-
 // Helper functions to make methods more readable.
 inline int64 GetDim(absl::Span<const int64> data, DimIndex dim) {
   return data.rbegin()[static_cast<int64>(dim)];

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -159,11 +159,11 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = "//third_party:cudnn_frontend_header_fix.patch",
-        sha256 = "60b085e1412144e0b24f8b01809857d3a4491c9b2b1c58f0766f673b791d05ca",
-        strip_prefix = "cudnn-frontend-51e60d891b689d618e7a623509a779c422a420f7",
+        sha256 = "fdf4234e9c9c481b3b3a80ad404bc278e6ecb761c5574beb4d3a2cde4a9002ad",
+        strip_prefix = "cudnn-frontend-73210a930333eaf66b42b01693bce7b70719c354",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/NVIDIA/cudnn-frontend/archive/51e60d891b689d618e7a623509a779c422a420f7.zip",
-            "https://github.com/NVIDIA/cudnn-frontend/archive/51e60d891b689d618e7a623509a779c422a420f7.zip",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/NVIDIA/cudnn-frontend/archive/73210a930333eaf66b42b01693bce7b70719c354.zip",
+            "https://github.com/NVIDIA/cudnn-frontend/archive/73210a930333eaf66b42b01693bce7b70719c354.zip",
         ],
     )
 

--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,4 +1,4 @@
-From 7bbdd3663cfb6a74541e95fe4b9dd5fe16659963 Mon Sep 17 00:00:00 2001
+From 12c0db4e4d7d36137536885142ac226b526794a8 Mon Sep 17 00:00:00 2001
 From: Kaixi Hou <kaixih@nvidia.com>
 Date: Tue, 4 May 2021 15:21:11 -0700
 Subject: [PATCH] Update headers path
@@ -34,7 +34,7 @@ index b07b336..3fb06a7 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_ConvDesc.h b/include/cudnn_frontend_ConvDesc.h
-index d8706d4..6cabf6e 100644
+index 2bcf0bc..fa26dc7 100644
 --- a/include/cudnn_frontend_ConvDesc.h
 +++ b/include/cudnn_frontend_ConvDesc.h
 @@ -29,8 +29,8 @@
@@ -92,7 +92,7 @@ index e7d918b..7298ef3 100644
  
  namespace cudnn_frontend {
 diff --git a/include/cudnn_frontend_ExecutionPlan.h b/include/cudnn_frontend_ExecutionPlan.h
-index 8ceb03a..048713c 100644
+index 858e067..b10ee88 100644
 --- a/include/cudnn_frontend_ExecutionPlan.h
 +++ b/include/cudnn_frontend_ExecutionPlan.h
 @@ -29,8 +29,8 @@
@@ -120,7 +120,7 @@ index b244766..3e9273b 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_Heuristics.h b/include/cudnn_frontend_Heuristics.h
-index 446f932..b15f472 100644
+index 3f61156..ce040b7 100644
 --- a/include/cudnn_frontend_Heuristics.h
 +++ b/include/cudnn_frontend_Heuristics.h
 @@ -24,8 +24,8 @@
@@ -133,7 +133,7 @@ index 446f932..b15f472 100644
 +#include "third_party/gpus/cudnn/cudnn_backend.h"
  
  #include "cudnn_frontend_OperationGraph.h"
- #include "cudnn_frontend_utils.h"
+ #include "cudnn_frontend_EngineConfig.h"
 diff --git a/include/cudnn_frontend_MatMulDesc.h b/include/cudnn_frontend_MatMulDesc.h
 index e416002..da2deb1 100644
 --- a/include/cudnn_frontend_MatMulDesc.h
@@ -150,7 +150,7 @@ index e416002..da2deb1 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Operation.h b/include/cudnn_frontend_Operation.h
-index dd3633d..a533a30 100644
+index 15f9b7c..c4a4cbb 100644
 --- a/include/cudnn_frontend_Operation.h
 +++ b/include/cudnn_frontend_Operation.h
 @@ -29,8 +29,8 @@


### PR DESCRIPTION
Cudnn frontend v0.4 released: https://github.com/NVIDIA/cudnn-frontend/releases/tag/v0.4

Accordingly, this PR does the following things:
- Support vector data type (Currently only int8x4);
- Change setDataType() in OperationBuilder to setComputePrecision()
- Update setAlpha/Beta which can deduce the datatype from the compute precision instead of given alpha/beta.

cc. @nluehr 