### PR TITLE
Update tf.keras engine sequential.py: add predict_classes, predict_proba deprecation warnings

### DIFF
--- a/tensorflow/python/keras/engine/sequential.py
+++ b/tensorflow/python/keras/engine/sequential.py
@@ -418,6 +418,8 @@ class Sequential(functional.Functional):
 
     The input samples are processed batch by batch.
 
+    Warning: THIS API IS DEPRECATED.
+
     Args:
         x: input data, as a Numpy array or list of Numpy arrays
             (if the model has multiple inputs).
@@ -442,6 +444,14 @@ class Sequential(functional.Functional):
     """Generate class predictions for the input samples.
 
     The input samples are processed batch by batch.
+
+    Warning: THIS API IS DEPRECATED.
+
+    Use `Model.predict` for multi-class classification (e.g.
+    `np.argmax(model.predict(x), axis=-1)` if your model uses a `softmax`
+    last-layer activation) and binary classification (e.g.
+    `(model.predict(x) > 0.5).astype("int32")` if your model uses a `sigmoid`
+    last-layer activation).
 
     Args:
         x: input data, as a Numpy array or list of Numpy arrays

--- a/tensorflow/python/keras/engine/sequential.py
+++ b/tensorflow/python/keras/engine/sequential.py
@@ -420,6 +420,8 @@ class Sequential(functional.Functional):
 
     Warning: THIS API IS DEPRECATED.
 
+    Use `Model.predict`.
+
     Args:
         x: input data, as a Numpy array or list of Numpy arrays
             (if the model has multiple inputs).


### PR DESCRIPTION
`Model.predict_classes` and `Model.predict_proba` are deprecated and the warnings won't be seen by the users until they attempt to call the methods.

The messages should be in line with https://developers.google.com/devsite/reference/styles/notices#warning as discussed @lamberta @MarkDaoust