### PR TITLE
Throw ValueError if shapes don't match in keras.layers.Softmax #50467

### DIFF
--- a/tensorflow/python/keras/layers/advanced_activations.py
+++ b/tensorflow/python/keras/layers/advanced_activations.py
@@ -340,7 +340,11 @@ class Softmax(Layer):
 
       # Since we are adding it to the raw scores before the softmax, this is
       # effectively the same as removing these entirely.
-      inputs += adder
+      try:
+        inputs += adder
+      except ValueError:
+        raise ValueError('Cannot apply mask to the given input. Make sure '
+                         'that shapes of input and mask match.')
     if isinstance(self.axis, (tuple, list)):
       if len(self.axis) > 1:
         return math_ops.exp(inputs - math_ops.reduce_logsumexp(


### PR DESCRIPTION
I think that we should raise ValueError in case Add is not successful. The reason is that after using tf.keras.layers.Masking, the timestep will be masked (skipped) in all downstream layers (as long as they support masking). The user may be not aware of that.