### PR TITLE
Fix equations in Adam docs

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_ApplyAdam.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ApplyAdam.pbtxt
@@ -82,9 +82,9 @@ END
   }
   summary: "Update \'*var\' according to the Adam algorithm."
   description: <<END
-$$lr_t := \text{learning\_rate} * \sqrt{1 - beta_2^t} / (1 - beta_1^t)$$
-$$m_t := beta_1 * m_{t-1} + (1 - beta_1) * g$$
-$$v_t := beta_2 * v_{t-1} + (1 - beta_2) * g * g$$
-$$variable := variable - lr_t * m_t / (\sqrt{v_t} + \epsilon)$$
+$$\text{lr}_t := \mathrm{lr} \cdot \frac{\sqrt{1 - \beta_2^t}}{1 - \beta_1^t}$$
+$$m_t := \beta_1 \cdot m_{t-1} + (1 - \beta_1) \cdot g$$
+$$v_t := \beta_2 \cdot v_{t-1} + (1 - \beta_2) \cdot g^2$$
+$$\text{var} := \begin{cases} \text{var} - (m_t \beta_1 + g \cdot (1 - \beta_1))\cdot\text{lr}_t/(\sqrt{v_t} + \epsilon), &\text{if use_nesterov}\\\\  \text{var} - m_t \cdot \text{lr}_t /(\sqrt{v_t} + \epsilon), &\text{otherwise} \end{cases}$$
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_ResourceApplyAdam.pbtxt
@@ -76,9 +76,9 @@ END
   }
   summary: "Update \'*var\' according to the Adam algorithm."
   description: <<END
-$$\text{lr}_t := \mathrm{learning_rate} * \sqrt{1 - \beta_2^t} / (1 - \beta_1^t)$$
-$$m_t := \beta_1 * m_{t-1} + (1 - \beta_1) * g$$
-$$v_t := \beta_2 * v_{t-1} + (1 - \beta_2) * g * g$$
-$$\text{variable} := \text{variable} - \text{lr}_t * m_t / (\sqrt{v_t} + \epsilon)$$
+$$\text{lr}_t := \mathrm{lr} \cdot \frac{\sqrt{1 - \beta_2^t}}{1 - \beta_1^t}$$
+$$m_t := \beta_1 \cdot m_{t-1} + (1 - \beta_1) \cdot g$$
+$$v_t := \beta_2 \cdot v_{t-1} + (1 - \beta_2) \cdot g^2$$
+$$\text{var} := \begin{cases} \text{var} - (m_t \beta_1 + g \cdot (1 - \beta_1))\cdot\text{lr}_t/(\sqrt{v_t} + \epsilon), &\text{if use_nesterov}\\\\  \text{var} - m_t \cdot \text{lr}_t /(\sqrt{v_t} + \epsilon), &\text{otherwise} \end{cases}$$
 END
 }


### PR DESCRIPTION
Equations for Adam and other optimizers do not look good. My PR tries to fix it. 

I didn't find any good way to produce exact htmls from api_docs with working jax. I tried those changes locally and looks better:
![image](https://user-images.githubusercontent.com/37601244/124335906-41c8ec80-db9c-11eb-9557-4722954d2a41.png)
- [https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/apply-adam](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/apply-adam)
- [https://www.tensorflow.org/api_docs/python/tf/raw_ops/ApplyAdam](https://www.tensorflow.org/api_docs/python/tf/raw_ops/ApplyAdam)
- [https://www.tensorflow.org/api_docs/python/tf/raw_ops/ResourceApplyAdam](https://www.tensorflow.org/api_docs/python/tf/raw_ops/ResourceApplyAdam)
