### PR TITLE
adjust abseil version to be compatible between cmake tensorflowlite and bazel

### DIFF
--- a/tensorflow/lite/tools/cmake/modules/abseil-cpp.cmake
+++ b/tensorflow/lite/tools/cmake/modules/abseil-cpp.cmake
@@ -23,7 +23,7 @@ include(OverridableFetchContent)
 OverridableFetchContent_Declare(
   abseil-cpp
   GIT_REPOSITORY https://github.com/abseil/abseil-cpp
-  GIT_TAG 20200225.2 # TODO: What version does GRPC and TFLite need?
+  GIT_TAG 20200923.2 # TODO: What version does GRPC
   GIT_SHALLOW TRUE
   GIT_PROGRESS TRUE
   PREFIX "${CMAKE_BINARY_DIR}"


### PR DESCRIPTION
At the moment version of libabseil library defined in bazel and cmake scripts are different:

Bazel will add those namespace prefix `lts_2020_09_23` and cmake this one `lts_2020_02_25`.

In case you compile tensorflowlite library via cmake and build remaining libraries for tensorflow lite using bazel (for example `libmetal-delegate`) you can't use link them later as you will get unresolved symbols:

Unresolved symbol:
```bash
absl::lts_2020_09_23::UnknownError(absl::lts_2020_09_23::string_view), 
referenced from: tflite::gpu::metal::(anonymous namespace)::AllocateTensorMemory(
id<MTLDevice>,tflite::gpu::StrongShape<(tflite::gpu::Layout)12> const&, tflite::gpu::TensorDescriptor const&, void const*, id<MTLBuffer> __autoreleasing*, id<MTLTexture> __autoreleasing*) 
in libmetal_spatial_tensor.a(metal_spatial_tensor.o)
```

But, for libraries compiled by cmake (and used in tf lite):
```bash
nm ./tensorflow/lite/tf_build/_deps/abseil-cpp-build/absl/status/libabsl_status.a | grep UnknownError
0000000000003110 T __ZN4absl14lts_2020_02_2512UnknownErrorENS0_11string_viewE
```

`absl::lts_2020_09_23::UnknownError(absl::lts_2020_09_23::string_view`
vs
`absl::lts_2020_02_25::UnknownError string_view`