### PR TITLE
[TFLite] Avoid passing negative quantized multipliers to MultiplyByQuantizedMultiplier

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -2694,15 +2694,19 @@ inline void BroadcastDivSlow(const ArithmeticParams& params,
   TFLITE_DCHECK_LT(params.output_offset, 256);
 
   auto div_func = [&](int indexes[N]) {
-    const int32 input1_val =
+    int32 input1_val =
         params.input1_offset + input1_data[SubscriptToIndex(desc1, indexes)];
-    const int32 input2_val =
+    int32 input2_val =
         params.input2_offset + input2_data[SubscriptToIndex(desc2, indexes)];
     TFLITE_DCHECK_NE(input2_val, 0);
+    if (input2_val < 0) {
+      // Invert signs to avoid a negative input2_val as input2_inv needs to be
+      // positive to be used as multiplier of MultiplyByQuantizedMultiplier.
+      input1_val = -input1_val;
+      input2_val = -input2_val;
+    }
     int recip_shift;
-    const int32 input2_inv =
-        (input2_val > 0) ? GetReciprocal(input2_val, 31, &recip_shift)
-                         : -GetReciprocal(-input2_val, 31, &recip_shift);
+    const int32 input2_inv = GetReciprocal(input2_val, 31, &recip_shift);
     const int headroom = CountLeadingSignBits(input1_val);
     const int32 unscaled_quotient = MultiplyByQuantizedMultiplierGreaterThanOne(
         input1_val, input2_inv, headroom);

--- a/tensorflow/lite/kernels/sub.cc
+++ b/tensorflow/lite/kernels/sub.cc
@@ -92,7 +92,7 @@ TfLiteStatus PrepareGeneralSubOp(TfLiteContext* context,
                                  const TfLiteTensor* input_1,
                                  const TfLiteTensor* input_2,
                                  TfLiteTensor* output, TfLiteSubParams* params,
-                                 OpData* op_params, int op_sign) {
+                                 OpData* op_params) {
   TF_LITE_ENSURE(context, output->type == kTfLiteUInt8 ||
                               output->type == kTfLiteInt8 ||
                               output->type == kTfLiteInt16);
@@ -151,7 +151,6 @@ TfLiteStatus PrepareGeneralSubOp(TfLiteContext* context,
   tflite::QuantizeMultiplierSmallerThanOneExp(real_input2_multiplier,
                                               &op_params->input2_multiplier,
                                               &op_params->input2_shift);
-  op_params->input2_multiplier *= op_sign;
   tflite::QuantizeMultiplierSmallerThanOneExp(real_output_multiplier,
                                               &op_params->output_multiplier,
                                               &op_params->output_shift);
@@ -287,7 +286,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   if (output->type == kTfLiteUInt8 || output->type == kTfLiteInt8 ||
       general_scale_int16) {
     TF_LITE_ENSURE_OK(context, PrepareGeneralSubOp(context, input1, input2,
-                                                   output, params, data, -1));
+                                                   output, params, data));
   } else if (output->type == kTfLiteInt16) {
     // LSTM-special case with scale parameter of POT
     TF_LITE_ENSURE_OK(context, PrepareInt16SubOpPOT(context, input1, input2,
@@ -391,43 +390,25 @@ void EvalQuantized(TfLiteContext* context, TfLiteNode* node,
                GetTensorData<data_type>(input1), GetTensorShape(input2), \
                GetTensorData<data_type>(input2), GetTensorShape(output), \
                GetTensorData<data_type>(output))
-  // NOTE: We are using the add kernels. This is possible as the second values
-  // multiplier is negated before being passed down.
   if (output->type == kTfLiteInt8) {
     if (need_broadcast) {
-      TF_LITE_SUB(reference_integer_ops, BroadcastAdd4DSlow, int8_t);
+      TF_LITE_SUB(reference_ops, BroadcastQuantSubSlow, int8_t);
     } else {
-      TF_LITE_SUB(reference_integer_ops, Add, int8_t);
+      TF_LITE_SUB(reference_ops, Sub, int8_t);
     }
   } else if (!data->pot_scale_int16) {
     if (need_broadcast) {
-      TF_LITE_SUB(reference_ops, BroadcastAdd4DSlow, int16_t);
+      TF_LITE_SUB(reference_ops, BroadcastQuantSubSlow, int16_t);
     } else {
-      reference_ops::Add(op_params, GetTensorShape(input1),
-                         GetTensorData<int16_t>(input1), GetTensorShape(input2),
-                         GetTensorData<int16_t>(input2), GetTensorShape(output),
-                         GetTensorData<int16_t>(output), false);
+      TF_LITE_SUB(reference_ops, Sub, int16_t);
     }
   } else if (output->type == kTfLiteUInt8) {
-    if (kernel_type == kReference) {
-      if (need_broadcast) {
-        TF_LITE_SUB(reference_ops, BroadcastAdd4DSlow, uint8_t);
-      } else {
-        TF_LITE_SUB(reference_ops, Add, uint8_t);
-      }
+    if (need_broadcast) {
+      TF_LITE_SUB(reference_ops, BroadcastQuantSubSlow, uint8_t);
     } else {
-      if (need_broadcast) {
-        optimized_ops::BroadcastAddDispatch(
-            op_params, GetTensorShape(input1), GetTensorData<uint8_t>(input1),
-            GetTensorShape(input2), GetTensorData<uint8_t>(input2),
-            GetTensorShape(output), GetTensorData<uint8_t>(output));
-      } else {
-        TF_LITE_SUB(optimized_ops, Add, uint8_t);
-      }
+      TF_LITE_SUB(reference_ops, Sub, uint8_t);
     }
   } else {
-    // In the case of 16-bit sub with POT scaling, we use the sub kernels as
-    // there is no multiplier to negate to reuse the add kernels.
     if (kernel_type == kReference) {
       if (need_broadcast) {
         TF_LITE_SUB(reference_ops, BroadcastSub16POTSlow, int16_t);

--- a/tensorflow/lite/kernels/sub_test.cc
+++ b/tensorflow/lite/kernels/sub_test.cc
@@ -312,7 +312,7 @@ TEST(Int64SubOpModel, WithBroadcast) {
 
 template <TensorType tensor_type, typename integer_dtype>
 void QuantizedTestsNoActivation() {
-  float kQuantizedTolerance = GetTolerance<integer_dtype>(-1.0, 1.0);
+  float kQuantizedTolerance = GetTolerance<integer_dtype>(-0.9, 0.9);
   std::vector<std::vector<float>> inputs1 = {
       {0.1, 0.2, 0.3, 0.4}, {-0.2, 0.2, 0.4, 0.7}, {-0.01, 0.2, 0.7, 0.3}};
   std::vector<std::vector<float>> inputs2 = {
@@ -321,9 +321,9 @@ void QuantizedTestsNoActivation() {
                                              {-0.8, -0.2, -0.1, 0.9},
                                              {-0.61, -0.2, 0.88, -0.2}};
   for (int i = 0; i < inputs1.size(); ++i) {
-    QuantizedSubOpModel m({tensor_type, {1, 2, 2, 1}, -1.0, 1.0},
-                          {tensor_type, {1, 2, 2, 1}, -1.0, 1.0},
-                          {tensor_type, {}, -1.0, 1.0},
+    QuantizedSubOpModel m({tensor_type, {1, 2, 2, 1}, -0.7, 0.7},
+                          {tensor_type, {1, 2, 2, 1}, -0.6, 0.6},
+                          {tensor_type, {}, -0.9, 0.9},
                           ActivationFunctionType_NONE);
     m.QuantizeAndPopulate<integer_dtype>(m.input1(), inputs1[i]);
     m.QuantizeAndPopulate<integer_dtype>(m.input2(), inputs2[i]);
@@ -357,8 +357,8 @@ void QuantizedTestsActivationRELU_N1_TO_1() {
   std::vector<std::vector<float>> results = {{-1.0, -0.2, 0.0, 1.0},
                                              {-1.0, -0.2, 1.0, 0.2}};
   for (int i = 0; i < inputs1.size(); ++i) {
-    QuantizedSubOpModel m({tensor_type, {1, 2, 2, 1}, -1.0, 1.0},
-                          {tensor_type, {1, 2, 2, 1}, -1.0, 1.0},
+    QuantizedSubOpModel m({tensor_type, {1, 2, 2, 1}, -0.9, 0.9},
+                          {tensor_type, {1, 2, 2, 1}, -0.9, 0.9},
                           {tensor_type, {}, -1.0, 1.0},
                           ActivationFunctionType_RELU_N1_TO_1);
     m.QuantizeAndPopulate<integer_dtype>(m.input1(), inputs1[i]);
@@ -384,13 +384,13 @@ TEST(QuantizedSubOpModel, QuantizedTestsActivationRELUN1TO1Int16) {
 
 template <TensorType tensor_type, typename integer_dtype>
 void QuantizedVariousInputShapes() {
-  float kQuantizedTolerance = GetTolerance<integer_dtype>(-3.0, 3.0);
+  float kQuantizedTolerance = GetTolerance<integer_dtype>(-2.1, 2.1);
   std::vector<std::vector<int>> test_shapes = {
       {6}, {2, 3}, {2, 1, 3}, {1, 3, 1, 2}};
   for (int i = 0; i < test_shapes.size(); ++i) {
-    QuantizedSubOpModel m({tensor_type, test_shapes[i], -3.0, 3.0},
-                          {tensor_type, test_shapes[i], -3.0, 3.0},
-                          {tensor_type, {}, -3.0, 3.0},
+    QuantizedSubOpModel m({tensor_type, test_shapes[i], -2.0, 2.0},
+                          {tensor_type, test_shapes[i], -1.1, 1.1},
+                          {tensor_type, {}, -2.1, 2.1},
                           ActivationFunctionType_NONE);
     m.QuantizeAndPopulate<integer_dtype>(m.input1(),
                                          {-2.0, 0.2, 0.7, 0.8, 1.1, 2.0});
@@ -418,13 +418,13 @@ TEST(QuantizedSubOpModel, QuantizedVariousInputShapesInt16) {
 
 template <TensorType tensor_type, typename integer_dtype>
 void QuantizedWithBroadcast() {
-  float kQuantizedTolerance = GetTolerance<integer_dtype>(-3.0, 3.0);
+  float kQuantizedTolerance = GetTolerance<integer_dtype>(-2.7, 2.7);
   std::vector<std::vector<int>> test_shapes = {
       {6}, {2, 3}, {2, 1, 3}, {1, 3, 1, 2}};
   for (int i = 0; i < test_shapes.size(); ++i) {
     QuantizedSubOpModel m(
-        {tensor_type, test_shapes[i], -3.0, 3.0}, {tensor_type, {}, -1.0, 1.0},
-        {tensor_type, {}, -3.0, 3.0}, ActivationFunctionType_NONE);
+        {tensor_type, test_shapes[i], -2.0, 2.0}, {tensor_type, {}, -0.7, 0.7},
+        {tensor_type, {}, -2.7, 2.7}, ActivationFunctionType_NONE);
     m.QuantizeAndPopulate<integer_dtype>(m.input1(),
                                          {-2.0, 0.2, 0.7, 0.8, 1.1, 2.0});
     m.QuantizeAndPopulate<integer_dtype>(m.input2(), {0.7});
@@ -449,7 +449,7 @@ TEST(QuantizedSubOpModel, QuantizedWithBroadcastInt16) {
 }
 
 TEST(QuantizedSubOpModel, QuantizedTestsNoActivationInt16) {
-  float kQuantizedTolerance = GetTolerance<int16_t>(-2.0, 2.0);
+  float kQuantizedTolerance = GetTolerance<int16_t>(-1.1, 1.1);
   std::vector<std::vector<float>> inputs1 = {
       {0.7, 0.6, 0.6, 0.5}, {-0.2, 0.6, 0.9, -0.1}, {-0.2, 0.6, -0.3, 0.8}};
   std::vector<std::vector<float>> inputs2 = {
@@ -457,9 +457,9 @@ TEST(QuantizedSubOpModel, QuantizedTestsNoActivationInt16) {
   std::vector<std::vector<float>> results = {
       {0.1, 0.2, 0.3, 0.4}, {-0.8, 0.2, 0.4, 0.7}, {-0.8, 0.2, -1.1, 0.3}};
   for (int i = 0; i < inputs1.size(); ++i) {
-    QuantizedSubOpModel m({TensorType_INT16, {1, 2, 2, 1}, -2.0, 2.0},
-                          {TensorType_INT16, {1, 2, 2, 1}, -1.0, 1.0},
-                          {TensorType_INT16, {}, -2.0, 2.0},
+    QuantizedSubOpModel m({TensorType_INT16, {1, 2, 2, 1}, -0.9, 0.9},
+                          {TensorType_INT16, {1, 2, 2, 1}, -0.8, 0.8},
+                          {TensorType_INT16, {}, -1.1, 1.1},
                           ActivationFunctionType_NONE);
     m.QuantizeAndPopulate<int16_t>(m.input1(), inputs1[i]);
     m.QuantizeAndPopulate<int16_t>(m.input2(), inputs2[i]);
@@ -472,7 +472,7 @@ TEST(QuantizedSubOpModel, QuantizedTestsNoActivationInt16) {
 }
 
 TEST(QuantizedSubOpModel, QuantizedTestsReluActivationInt16) {
-  float kQuantizedTolerance = GetTolerance<int16_t>(-2.0, 2.0);
+  float kQuantizedTolerance = GetTolerance<int16_t>(-1.0, 1.0);
   std::vector<std::vector<float>> inputs1 = {{-0.8, 0.2, 0.9, 0.7},
                                              {-0.8, 0.2, 0.7, 0.5}};
   std::vector<std::vector<float>> inputs2 = {{0.6, 0.4, 0.9, -0.8},
@@ -480,9 +480,9 @@ TEST(QuantizedSubOpModel, QuantizedTestsReluActivationInt16) {
   std::vector<std::vector<float>> results = {{-1.0, -0.2, 0.0, 1.0},
                                              {-1.0, -0.2, 1.0, 0.2}};
   for (int i = 0; i < inputs1.size(); ++i) {
-    QuantizedSubOpModel m({TensorType_INT16, {1, 2, 2, 1}, -2.0, 2.0},
-                          {TensorType_INT16, {1, 2, 2, 1}, -1.0, 1.0},
-                          {TensorType_INT16, {}, -2.0, 2.0},
+    QuantizedSubOpModel m({TensorType_INT16, {1, 2, 2, 1}, -0.9, 0.9},
+                          {TensorType_INT16, {1, 2, 2, 1}, -0.9, 0.9},
+                          {TensorType_INT16, {}, -1.0, 1.0},
                           ActivationFunctionType_RELU_N1_TO_1);
     m.QuantizeAndPopulate<int16_t>(m.input1(), inputs1[i]);
     m.QuantizeAndPopulate<int16_t>(m.input2(), inputs2[i]);
@@ -495,13 +495,13 @@ TEST(QuantizedSubOpModel, QuantizedTestsReluActivationInt16) {
 }
 
 TEST(QuantizedSubOpModel, QuantizedTestsNoActivationBroadcastInt16) {
-  float kQuantizedTolerance = GetTolerance<int16_t>(-2.0, 2.0);
+  float kQuantizedTolerance = GetTolerance<int16_t>(-1.1, 1.1);
   std::vector<std::vector<int>> test_shapes = {
       {6}, {2, 3}, {2, 1, 3}, {1, 3, 1, 2}, {1, 3, 1, 2, 1}};
   for (int i = 0; i < test_shapes.size(); ++i) {
-    QuantizedSubOpModel m({TensorType_INT16, test_shapes[i], -2.0, 2.0},
-                          {TensorType_INT16, {}, -1.0, 1.0},
-                          {TensorType_INT16, {}, -2.0, 2.0},
+    QuantizedSubOpModel m({TensorType_INT16, test_shapes[i], -0.9, 0.9},
+                          {TensorType_INT16, {}, -0.2, 0.2},
+                          {TensorType_INT16, {}, -1.1, 1.1},
                           ActivationFunctionType_NONE);
     m.QuantizeAndPopulate<int16_t>(m.input1(),
                                    {-0.9, -0.7, -0.3, 0.0, 0.3, 0.5});
@@ -515,13 +515,13 @@ TEST(QuantizedSubOpModel, QuantizedTestsNoActivationBroadcastInt16) {
 }
 
 TEST(QuantizedSubOpModel, QuantizedTestsReluActivationBroadcastInt16) {
-  float kQuantizedTolerance = GetTolerance<int16_t>(-2.0, 2.0);
+  float kQuantizedTolerance = GetTolerance<int16_t>(-1.0, 1.0);
   std::vector<std::vector<int>> test_shapes = {
       {6}, {2, 3}, {2, 1, 3}, {1, 3, 1, 2}, {1, 3, 1, 2, 1}};
   for (int i = 0; i < test_shapes.size(); ++i) {
-    QuantizedSubOpModel m({TensorType_INT16, test_shapes[i], -2.0, 2.0},
+    QuantizedSubOpModel m({TensorType_INT16, test_shapes[i], -0.9, 0.9},
+                          {TensorType_INT16, {}, -0.2, 0.2},
                           {TensorType_INT16, {}, -1.0, 1.0},
-                          {TensorType_INT16, {}, -2.0, 2.0},
                           ActivationFunctionType_RELU_N1_TO_1);
     m.QuantizeAndPopulate<int16_t>(m.input1(),
                                    {-0.9, -0.7, -0.3, 0.0, 0.3, 0.5});


### PR DESCRIPTION
Hello,

This PR updates the SUB and DIV kernels to avoid passing negative quantized multipliers to the `MultiplyByQuantizedMultiplier` method.

It allows us to later on add a restriction on the quantized multiplier of the int32 `MultiplyByQuantizedMultiplier` similar to the one already present in the int64 version. 

Thibaut