### PR TITLE
Fixing a build failure in a CI test

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -580,7 +580,8 @@ def _tf_repositories():
 
     tf_http_archive(
         name = "com_google_googletest",
-        sha256 = "ff7a82736e158c077e76188232eac77913a15dac0b22508c390ab3f88e6d6d86",
+	patch_file = "//third_party:gtest_build_fix.diff",
+	sha256 = "ff7a82736e158c077e76188232eac77913a15dac0b22508c390ab3f88e6d6d86",
         strip_prefix = "googletest-b6cd405286ed8635ece71c72f118e659f4ade3fb",
         urls = [
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/googletest/archive/b6cd405286ed8635ece71c72f118e659f4ade3fb.zip",

--- a/third_party/gtest_build_fix.diff
+++ b/third_party/gtest_build_fix.diff
@@ -1,0 +1,16 @@
+diff --git a/googletest/include/gtest/gtest-param-test.h b/googletest/include/gtest/gtest-param-test.h
+index a0eecc69..2f5e7ade 100644
+--- a/googletest/include/gtest/gtest-param-test.h
++++ b/googletest/include/gtest/gtest-param-test.h
+@@ -297,9 +297,9 @@ internal::ParamGenerator<T> Range(T start, T end) {
+ //
+ template <typename ForwardIterator>
+ internal::ParamGenerator<
+-  typename ::testing::internal::IteratorTraits<ForwardIterator>::value_type>
++  typename std::iterator_traits<ForwardIterator>::value_type>
+ ValuesIn(ForwardIterator begin, ForwardIterator end) {
+-  typedef typename ::testing::internal::IteratorTraits<ForwardIterator>
++  typedef typename std::iterator_traits<ForwardIterator>
+       ::value_type ParamType;
+   return internal::ParamGenerator<ParamType>(
+       new internal::ValuesInIteratorRangeGenerator<ParamType>(begin, end));


### PR DESCRIPTION
This PR fixes a CI build failure in the test 
//tensorflow/core/tpu/kernels:sharding_util_ops_test. This [log](https://tensorflow-ci.intel.com/job/tensorflow-mkl-linux-cpu/25746/artifact/dnnl_test.log/*view*/) shows the build failure details. 