### PR TITLE
cudaMallocAsync: better VLOG and error message.

### DIFF
--- a/tensorflow/core/common_runtime/bfc_allocator.cc
+++ b/tensorflow/core/common_runtime/bfc_allocator.cc
@@ -256,6 +256,7 @@ void* BFCAllocator::AllocateRawInternalWithRetry(
 void* BFCAllocator::AllocateRaw(size_t unused_alignment, size_t num_bytes,
                                 const AllocationAttributes& allocation_attr) {
   VLOG(3) << "AllocateRaw " << Name() << "  " << num_bytes;
+  void* result = nullptr;
   if (!allocation_attr.retry_on_failure) {
     // Return immediately upon the first failure if this is for allocating an
     // optional scratch space.
@@ -264,8 +265,8 @@ void* BFCAllocator::AllocateRaw(size_t unused_alignment, size_t num_bytes,
     if (allocation_attr.freed_by_func != nullptr) {
       freed_by_count = (*allocation_attr.freed_by_func)();
     }
-    void* result = AllocateRawInternal(unused_alignment, num_bytes,
-                                       dump_log_on_failure, freed_by_count);
+    result = AllocateRawInternal(unused_alignment, num_bytes,
+                                 dump_log_on_failure, freed_by_count);
     if (result == nullptr) {
       static std::atomic<int32> log_counter{0};
       int32 counter_value = log_counter.load(std::memory_order_relaxed);
@@ -283,9 +284,12 @@ void* BFCAllocator::AllocateRaw(size_t unused_alignment, size_t num_bytes,
     }
     return result;
   } else {
-    return AllocateRawInternalWithRetry(unused_alignment, num_bytes,
-                                        allocation_attr);
+    result = AllocateRawInternalWithRetry(unused_alignment, num_bytes,
+                                          allocation_attr);
   }
+  VLOG(3) << "AllocateRaw " << Name() << "  " << num_bytes << " "
+          << result;
+  return result;
 }
 
 // static

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.cc
@@ -49,6 +49,8 @@ void* GPUcudaMallocAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
                << "\n Error string: " << error_string;
     return nullptr;
   }
+  VLOG(10) << "AllocateRaw " << Name() << "  " << num_bytes << " "
+           << reinterpret_cast<void*>(rv);
   return reinterpret_cast<void*>(rv);
 #else
   return nullptr;
@@ -56,6 +58,7 @@ void* GPUcudaMallocAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
 }
 void GPUcudaMallocAllocator::DeallocateRaw(void* ptr) {
 #ifdef GOOGLE_CUDA
+  VLOG(10) << Name() << " Freed ptr: " << ptr;
   // free with cudaFree
   CUresult res = cuMemFree(reinterpret_cast<CUdeviceptr>(ptr));
   if (res == CUDA_ERROR_DEINITIALIZED) {

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.cc
@@ -58,7 +58,6 @@ void* GPUcudaMallocAllocator::AllocateRaw(size_t alignment, size_t num_bytes) {
 }
 void GPUcudaMallocAllocator::DeallocateRaw(void* ptr) {
 #ifdef GOOGLE_CUDA
-  VLOG(10) << Name() << " Freed ptr: " << ptr;
   // free with cudaFree
   CUresult res = cuMemFree(reinterpret_cast<CUdeviceptr>(ptr));
   if (res == CUDA_ERROR_DEINITIALIZED) {
@@ -77,6 +76,7 @@ void GPUcudaMallocAllocator::DeallocateRaw(void* ptr) {
                << "\n Error name: " << error_name
                << "\n Error string: " << error_string;
   }
+  VLOG(10) << Name() << " Freed ptr: " << ptr;
 #endif  // GOOGLE_CUDA
 }
 

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -242,6 +242,7 @@ void* GpuCudaMallocAsyncAllocator::AllocateRaw(size_t alignment,
     VLOG(8) << "\nThe sorted list of (ptr,size):";
     VLOG(8) << absl::StrJoin(ptr_size_string, ",");
 
+#if CUDA_VERSION >= 11030
     cuuint64_t mem_reserved_current;
     if (auto result2 = cuMemPoolGetAttribute(pool_, CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT, &mem_reserved_current)) {
       LOG(ERROR) << "Error while fetching extra cudaMallocAsync pool attribute: "
@@ -266,6 +267,7 @@ void* GpuCudaMallocAsyncAllocator::AllocateRaw(size_t alignment,
     LOG(ERROR) << "CU_MEMPOOL_ATTR_USED_MEM_CURRENT: " << mem_used_current;
     LOG(ERROR) << "CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH: " << mem_reserved_high;
     LOG(ERROR) << "CU_MEMPOOL_ATTR_USED_MEM_HIGH: " << mem_used_high;
+#endif
 
     return nullptr;
   }

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -232,11 +232,11 @@ void* GpuCudaMallocAsyncAllocator::AllocateRaw(size_t alignment,
       }
       size_map_historgram[p.second]++;
     }
-    VLOG(ERROR)
+    LOG(ERROR)
       << "Histogram of current allocation: (allocation_size_in_bytes, "
       << "nb_allocation_of_that_sizes), ...;";
     for (auto p : size_map_historgram) {
-      VLOG(ERROR) << p.first << ", " << p.second;
+      LOG(ERROR) << p.first << ", " << p.second;
     }
 
     VLOG(8) << "\nThe sorted list of (ptr,size):";
@@ -244,28 +244,28 @@ void* GpuCudaMallocAsyncAllocator::AllocateRaw(size_t alignment,
 
     cuuint64_t mem_reserved_current;
     if (auto result2 = cuMemPoolGetAttribute(pool_, CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT, &mem_reserved_current)) {
-      VLOG(ERROR) << "Error while fethcing extra cudaMallocAsync pool attribute: "
+      LOG(ERROR) << "Error while fetching extra cudaMallocAsync pool attribute: "
                   << GetCudaErrorMessage(result);
     }
     cuuint64_t mem_used_current;
     if (auto result2 = cuMemPoolGetAttribute(pool_, CU_MEMPOOL_ATTR_USED_MEM_CURRENT, &mem_used_current)) {
-      VLOG(ERROR) << "Error while fethcing extra cudaMallocAsync pool attribute: "
+      LOG(ERROR) << "Error while fetching extra cudaMallocAsync pool attribute: "
                   << GetCudaErrorMessage(result);
     }
     cuuint64_t mem_reserved_high;
     if (auto result2 = cuMemPoolGetAttribute(pool_, CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH, &mem_reserved_high)) {
-      VLOG(ERROR) << "Error while fethcing extra cudaMallocAsync pool attribute: "
+      LOG(ERROR) << "Error while fetching extra cudaMallocAsync pool attribute: "
                   << GetCudaErrorMessage(result);
     }
     cuuint64_t mem_used_high;
     if (auto result2 = cuMemPoolGetAttribute(pool_, CU_MEMPOOL_ATTR_USED_MEM_HIGH, &mem_used_high)) {
-      VLOG(ERROR) << "Error while fethcing extra cudaMallocAsync pool attribute: "
+      LOG(ERROR) << "Error while fetching extra cudaMallocAsync pool attribute: "
                   << GetCudaErrorMessage(result);
     }
-    VLOG(ERROR) << "CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT: " << mem_reserved_current;
-    VLOG(ERROR) << "CU_MEMPOOL_ATTR_USED_MEM_CURRENT: " << mem_used_current;
-    VLOG(ERROR) << "CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH: " << mem_reserved_high;
-    VLOG(ERROR) << "CU_MEMPOOL_ATTR_USED_MEM_HIGH: " << mem_used_high;
+    LOG(ERROR) << "CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT: " << mem_reserved_current;
+    LOG(ERROR) << "CU_MEMPOOL_ATTR_USED_MEM_CURRENT: " << mem_used_current;
+    LOG(ERROR) << "CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH: " << mem_reserved_high;
+    LOG(ERROR) << "CU_MEMPOOL_ATTR_USED_MEM_HIGH: " << mem_used_high;
 
     return nullptr;
   }

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
@@ -89,6 +89,12 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
 #endif
   }
 
+  // With the right VLOG set, it prints:
+  // - the number of ptr currently allocated per size (histogram).
+  // - each ptr value and its size.
+  // - If CUDA_VERSION >= 11030, print cudaMallocAsync statistics.
+  void PrintAllocatorStatistics();
+
  private:
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
   se::StreamExecutor* stream_exec_;  // Not owned.


### PR DESCRIPTION
This combine a few trivial changes related to memory allocator: 
WAR some OOM, and better VLOG and error message.

In detail:

* cudaMallocAsync:
    - When OOM happens, sync the stream and try to allocate again. This allow extra coalescing/remapping and WAR some OOM.
    - VLOG the peak memory usage.
    - Extra VLOG when OOM including histogram of allocation, the list of allocated ptr and size and cudaMallocAsync stats.
    - Better Error message.
    - Check some return status that wasn't checked.
* cudaMalloc allocator: Add extra VLOG
* BFC Allocator VLOG.
    - Allow to print a trace of allocation/free and to print the peak memory usage.
    - Use increasing VLOG number for basic log, the peak then the trace.

@sanjoy 