### PR TITLE
Disable ppc64le custom gemm_pack_rhs to use the convolution specialization

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -942,6 +942,9 @@ cc_library(
         "eigen_convolution_helpers.h",
     ],
     compatible_with = get_compatible_with_portable(),
+    defines = [
+        "EIGEN_ALTIVEC_USE_CUSTOM_PACK=0",
+    ],
 )
 
 # OpKernel libraries ----------------------------------------------------------

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3976,8 +3976,7 @@ cc_library(
     ],
 )
 
-NN_DEPS = [
-    ":conv_2d",
+NN_DEPS = if_cuda_or_rocm([":conv_2d"]) + [
     ":eigen_contraction_kernel",
     ":ops_util",
     "//tensorflow/core:framework",

--- a/tensorflow/core/kernels/eigen_backward_cuboid_convolutions.h
+++ b/tensorflow/core/kernels/eigen_backward_cuboid_convolutions.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_CORE_KERNELS_EIGEN_BACKWARD_CUBOID_CONVOLUTIONS_H_
 
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "tensorflow/core/kernels/eigen_cuboid_convolution.h"
 
 namespace Eigen {
 

--- a/tensorflow/core/kernels/eigen_backward_spatial_convolutions.h
+++ b/tensorflow/core/kernels/eigen_backward_spatial_convolutions.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_CORE_KERNELS_EIGEN_BACKWARD_SPATIAL_CONVOLUTIONS_H_
 
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "tensorflow/core/kernels/eigen_spatial_convolutions.h"
 
 namespace Eigen {
 

--- a/tensorflow/core/kernels/eigen_cuboid_convolution.h
+++ b/tensorflow/core/kernels/eigen_cuboid_convolution.h
@@ -24,17 +24,11 @@ limitations under the License.
 
 #include "tensorflow/core/kernels/eigen_convolution_helpers.h"
 
-#if defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)
-#define TF_USE_CUSTOM_EIGEN_PACK 0
-#else
-#define TF_USE_CUSTOM_EIGEN_PACK 1
-#endif
-
 namespace Eigen {
 
 namespace internal {
 
-#if TF_USE_CUSTOM_EIGEN_PACK
+#if !EIGEN_ALTIVEC_USE_CUSTOM_PACK
 // WARNING: Most of the code here implicitly assumes that the matrix is in
 // ColMajor layout. This is guaranteed by the tensor contraction (see
 // TensorContraction.h).
@@ -1364,6 +1358,15 @@ struct gemm_pack_rhs<
     }
 
     // Copy the remaining columns one at a time (nr==1).
+#if defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX)
+    // remaining columns are handled different for PPC
+    for (Index k = 0; k < depth; k++) {
+      for (Index j2 = packet_cols4; j2 < cols; ++j2) {
+        *block = rhs(k, j2);
+        block += 1;
+      }
+    }
+#else
     for (Index j2 = packet_cols4; j2 < cols; ++j2) {
       const SubMapper dm0 = rhs.getLinearMapper(0, j2);
       for (Index k = 0; k < depth; k++) {
@@ -1371,6 +1374,7 @@ struct gemm_pack_rhs<
         block += 1;
       }
     }
+#endif
   }
 };
 


### PR DESCRIPTION
Eigen ppc64le has a gemm_pack_rhs specialization for AltiVec architecture. TF Convolution also specializes this packing routine, improving the Tensor code and avoiding a lot of index computation. Based on eigen_benchmark_cpu_test, we found a good scenario for ppc64le, where gemm_pack_rhs from TF headers together with VSX/MMA from ppc64le speeds up the performance of convolution.

This patch fixes the column computation for convolution in case of ppc64le and disables the Eigen ppc64le gemm_pack_rhs using the define EIGEN_ALTIVEC_USE_CUSTOM_PACK=0.