### PR TITLE
Disabling MKL on XLA Devices

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -1092,6 +1092,12 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
       reason = "User has assigned a device that is not CPU.";
     }
 
+    // XLA devices not supported by MKL
+    if(absl::StrContains(n->assigned_device_name(), "XLA")){
+      result = false;
+      reason = "MKL currently incompatible with XLA devices.";
+    }
+
     if (result == false) {
       VLOG(1) << "MklLayoutRewritePass: Skipping rewriting of the node "
               << n->type_string() << ", reason: " << reason;


### PR DESCRIPTION
Mitigates compatibility issues of XLA and MKL by disabling the MKL graph rewriter for ops assigned to XLA devices.