### PR TITLE
[CherryPick2.6][TF XLA AOT] Assume aarch64 is always available.

### DIFF
--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -787,10 +787,7 @@ def tf_google_mobile_srcs_only_runtime():
     return []
 
 def if_llvm_aarch64_available(then, otherwise = []):
-    return select({
-        "//tensorflow:linux_aarch64": then,
-        "//conditions:default": otherwise,
-    })
+    return then
 
 def if_llvm_system_z_available(then, otherwise = []):
     return select({

--- a/tensorflow/python/tools/BUILD
+++ b/tensorflow/python/tools/BUILD
@@ -355,8 +355,6 @@ py_test(
     python_version = "PY3",
     srcs_version = "PY3",
     tags = [
-        "manual",
-        "no-internal-py3",
         "nosan",
     ],
     deps = [

--- a/tensorflow/python/tools/saved_model_aot_compile.py
+++ b/tensorflow/python/tools/saved_model_aot_compile.py
@@ -75,7 +75,9 @@ def _sysconfig_module():
   """Load tf.sysconfig if available and working (i.e., inside a pip package)."""
   try:
     _ = sysconfig_lib.get_include()
-  except ImportError:
+  except (ImportError, ValueError):
+    # ValueError may come from saved_model_cli_test trying to enable
+    # eager mode twice.
     return None
   return sysconfig_lib
 


### PR DESCRIPTION
This is useful for e.g. saved_model_cli aot_compile_cpu with a target
architecture of aarch64.

Previously this failed to build but now it seems OK.

While we're at it, remove the manual tag from saved_model_cli_test.

PiperOrigin-RevId: 383569229
Change-Id: I91dcfccfbd0c817e12dee7e45985437001f56b50