### PR TITLE
cudaMallocAsync: If OOM, sync the stream and retry allocation.

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -210,7 +210,9 @@ void* GpuCudaMallocAsyncAllocator::AllocateRaw(size_t alignment,
   auto result = cuMemAllocFromPoolAsync(reinterpret_cast<CUdeviceptr*>(&ptr),
                                         num_bytes, pool_, cuda_stream_);
   if (result == CUDA_ERROR_OUT_OF_MEMORY) {
-    // This can fix some OOM when memory is tight.
+    // Doing a stream synchronization give the driver more flexibility
+    // for blocks coalescing and doing memory remapping. So it can
+    // solve some OOM cases when memory is tight.
     cuStreamSynchronize(cuda_stream_);
     result = cuMemAllocFromPoolAsync(reinterpret_cast<CUdeviceptr*>(&ptr),
                                      num_bytes, pool_, cuda_stream_);

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -207,9 +207,16 @@ void* GpuCudaMallocAsyncAllocator::AllocateRaw(size_t alignment,
   }
   se::cuda::ScopedActivateExecutorContext scoped_activation{stream_exec_};
   void* ptr = nullptr;
-  if (auto result =
-          cuMemAllocFromPoolAsync(reinterpret_cast<CUdeviceptr*>(&ptr),
-                                  num_bytes, pool_, cuda_stream_)) {
+  auto result = cuMemAllocFromPoolAsync(reinterpret_cast<CUdeviceptr*>(&ptr),
+                                        num_bytes, pool_, cuda_stream_);
+  if (result == CUDA_ERROR_OUT_OF_MEMORY) {
+    // This can fix some OOM when memory is tight.
+    cuStreamSynchronize(cuda_stream_);
+    result = cuMemAllocFromPoolAsync(reinterpret_cast<CUdeviceptr*>(&ptr),
+                                     num_bytes, pool_, cuda_stream_);
+  }
+
+  if (result) {
     size_t free, total;
     cuMemGetInfo(&free, &total);
     mutex_lock lock(lock_);


### PR DESCRIPTION
The sync allow the driver more option to find memory. So sometimes it can find memory available after a sync.

@sanjoy 