### PR TITLE
Refactor SparseConcat CPU implem and add two tests

### DIFF
--- a/tensorflow/core/kernels/sparse_concat_op.cc
+++ b/tensorflow/core/kernels/sparse_concat_op.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
+#include "tensorflow/core/kernels/sparse_concat_op.h"
+
 #include <algorithm>
 #include <numeric>
 #include <unordered_map>
@@ -32,7 +34,62 @@ limitations under the License.
 
 namespace tensorflow {
 
+typedef Eigen::ThreadPoolDevice CPUDevice;
+
+namespace functor {
+
 template <typename T>
+struct SparseConcatFunctor<CPUDevice, T> {
+  void operator()(OpKernelContext* context, const OpInputList& inds,
+                  const OpInputList& vals, const OpInputList& shapes,
+                  int concat_dim) {
+    const int N = inds.size();
+    const TensorShape input_shape(shapes[0].vec<int64>());
+    const int input_rank = input_shape.dims();
+
+    // The input and output sparse tensors are assumed to be ordered along
+    // increasing dimension number. But in order for concat to work properly,
+    // order[0] must be concat_dim. So we will reorder the inputs to the
+    // concat ordering, concatenate, then reorder back to the standard order.
+    // We make a deep copy of the input tensors to ensure that the in-place
+    // reorder doesn't create race conditions for other ops that may be
+    // concurrently reading the indices and values tensors.
+
+    gtl::InlinedVector<int64, 8> std_order(input_rank);
+    std::iota(std_order.begin(), std_order.end(), 0);
+
+    std::vector<int64> concat_order;
+    concat_order.reserve(input_rank);
+    concat_order.push_back(concat_dim);
+    for (int j = 0; j < input_rank; ++j) {
+      if (j != concat_dim) {
+        concat_order.push_back(j);
+      }
+    }
+
+    std::vector<sparse::SparseTensor> sp_inputs;
+    for (int i = 0; i < N; ++i) {
+      const TensorShape current_shape(shapes[i].vec<int64>());
+      sparse::SparseTensor tensor;
+      OP_REQUIRES_OK(context,
+                     sparse::SparseTensor::Create(
+                         tensor::DeepCopy(inds[i]), tensor::DeepCopy(vals[i]),
+                         current_shape, std_order, &tensor));
+      sp_inputs.push_back(std::move(tensor));
+      sp_inputs[i].Reorder<T>(concat_order);
+    }
+
+    sparse::SparseTensor concat = sparse::SparseTensor::Concat<T>(sp_inputs);
+    concat.Reorder<T>(std_order);
+
+    context->set_output(0, concat.indices());
+    context->set_output(1, concat.values());
+  }
+};
+
+}  // namespace functor
+
+template <typename Device, typename T>
 class SparseConcatOp : public OpKernel {
  public:
   explicit SparseConcatOp(OpKernelConstruction* context) : OpKernel(context) {
@@ -102,6 +159,7 @@ class SparseConcatOp : public OpKernel {
                 errors::InvalidArgument("Concat dimension must be in range [",
                                         -input_rank, ", ", input_rank,
                                         "), got ", concat_dim_attr_));
+    TensorShape output_shape = input_shape;
     for (int i = 1; i < N; ++i) {
       const TensorShape current_shape(shapes[i].vec<int64>());
       OP_REQUIRES(
@@ -117,57 +175,39 @@ class SparseConcatOp : public OpKernel {
                   "Input shapes must match: expected ", input_shape.dim_size(j),
                   " for dimension ", j, " but got ", current_shape.dim_size(j),
                   " at position ", i));
+        } else {
+          output_shape.set_dim(
+              j, output_shape.dim_size(j) + current_shape.dim_size(j));
         }
       }
     }
 
-    // The input and output sparse tensors are assumed to be ordered along
-    // increasing dimension number. But in order for concat to work properly,
-    // order[0] must be concat_dim. So we will reorder the inputs to the
-    // concat ordering, concatenate, then reorder back to the standard order.
-    // We make a deep copy of the input tensors to ensure that the in-place
-    // reorder doesn't create race conditions for other ops that may be
-    // concurrently reading the indices and values tensors.
-
-    gtl::InlinedVector<int64, 8> std_order(input_rank);
-    std::iota(std_order.begin(), std_order.end(), 0);
-
-    std::vector<int64> concat_order;
-    concat_order.reserve(input_rank);
-    concat_order.push_back(concat_dim);
-    for (int j = 0; j < input_rank; ++j) {
-      if (j != concat_dim) {
-        concat_order.push_back(j);
-      }
-    }
-
-    std::vector<sparse::SparseTensor> sp_inputs;
-    for (int i = 0; i < N; ++i) {
-      const TensorShape current_shape(shapes[i].vec<int64>());
-      sparse::SparseTensor tensor;
-      OP_REQUIRES_OK(context,
-                     sparse::SparseTensor::Create(
-                         tensor::DeepCopy(inds[i]), tensor::DeepCopy(vals[i]),
-                         current_shape, std_order, &tensor));
-      sp_inputs.push_back(std::move(tensor));
-      sp_inputs[i].Reorder<T>(concat_order);
-    }
-
-    sparse::SparseTensor concat = sparse::SparseTensor::Concat<T>(sp_inputs);
-    concat.Reorder<T>(std_order);
-
-    context->set_output(0, concat.indices());
-    context->set_output(1, concat.values());
-
     Tensor* output_shape_out = nullptr;
-    OP_REQUIRES_OK(context,
-                   context->allocate_output(2, TensorShape({concat.dims()}),
-                                            &output_shape_out));
-    auto output_shape = output_shape_out->vec<int64>();
-    auto concat_shape = concat.shape();
-    for (int j = 0; j < concat.dims(); ++j) {
-      output_shape(j) = concat_shape[j];
+    OP_REQUIRES_OK(
+        context, context->allocate_output(2, TensorShape({output_shape.dims()}),
+                                          &output_shape_out));
+    auto output_shape_t = output_shape_out->vec<int64>();
+    for (int j = 0; j < output_shape.dims(); ++j) {
+      output_shape_t(j) = output_shape.dim_size(j);
     }
+
+    int64 output_nnz = 0;
+    for (int i = 0; i < N; ++i) {
+      output_nnz += inds[i].dim_size(0);
+    }
+    if (output_nnz == 0) {
+      Tensor* output_inds = nullptr;
+      OP_REQUIRES_OK(context,
+                     context->allocate_output(0, TensorShape({0, input_rank}),
+                                              &output_inds));
+      Tensor* output_vals = nullptr;
+      OP_REQUIRES_OK(
+          context, context->allocate_output(1, TensorShape({0}), &output_vals));
+      return;  // No work to do
+    }
+
+    functor::SparseConcatFunctor<Device, T>()(context, inds, vals, shapes,
+                                              concat_dim);
   }
 
  private:
@@ -177,7 +217,7 @@ class SparseConcatOp : public OpKernel {
 #define REGISTER_KERNELS(type)                                           \
   REGISTER_KERNEL_BUILDER(                                               \
       Name("SparseConcat").Device(DEVICE_CPU).TypeConstraint<type>("T"), \
-      SparseConcatOp<type>)
+      SparseConcatOp<CPUDevice, type>)
 
 TF_CALL_ALL_TYPES(REGISTER_KERNELS);
 #undef REGISTER_KERNELS

--- a/tensorflow/core/kernels/sparse_concat_op.h
+++ b/tensorflow/core/kernels/sparse_concat_op.h
@@ -1,0 +1,36 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_SPARSE_CONCAT_OP_H_
+#define TENSORFLOW_CORE_KERNELS_SPARSE_CONCAT_OP_H_
+
+#include "tensorflow/core/framework/op_kernel.h"
+
+namespace tensorflow {
+
+namespace functor {
+
+template <typename Device, typename T>
+struct SparseConcatFunctor {
+  void operator()(OpKernelContext* context, const OpInputList& inds,
+                  const OpInputList& vals, const OpInputList& shapes,
+                  int concat_dim);
+};
+
+}  // namespace functor
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_SPARSE_CONCAT_OP_H_

--- a/tensorflow/python/kernel_tests/sparse_concat_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_concat_op_test.py
@@ -273,7 +273,8 @@ class SparseConcatTest(test.TestCase):
 
       concat_out = self.evaluate(sp_concat)
 
-      self.assertAllEqual(concat_out.indices, sp_b.indices + [0, 7, 0])
+      self.assertAllEqual(concat_out.indices,
+                          sp_b.indices + [0, sp_a.dense_shape[1], 0])
       self.assertAllEqual(concat_out.values, sp_b.values)
       self.assertAllEqual(concat_out.dense_shape, [2, 15, 4])
 

--- a/tensorflow/python/kernel_tests/sparse_concat_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_concat_op_test.py
@@ -108,6 +108,15 @@ class SparseConcatTest(test.TestCase):
         constant_op.constant(val, dtypes.float32),
         constant_op.constant(shape, dtypes.int64))
 
+  def _SparseTensor_NoNonZeros(self, dense_shape):
+    ind = np.empty(shape=(0, len(dense_shape)))
+    val = np.array([])
+    shape = np.array(dense_shape)
+    return sparse_tensor.SparseTensor(
+        constant_op.constant(ind, dtypes.int64),
+        constant_op.constant(val, dtypes.float32),
+        constant_op.constant(shape, dtypes.int64))
+
   def _SparseTensor_String3x3(self):
     # [    a]
     # [b    ]
@@ -228,6 +237,45 @@ class SparseConcatTest(test.TestCase):
                                                  [2, 7], [2, 8]])
         self.assertAllEqual(concat_out.values, [1, 2, 1, 1, 3, 4, 2, 1, 0, 2])
         self.assertAllEqual(concat_out.dense_shape, [3, 10])
+
+  def testConcatNoNonZeros(self):
+    sp_a = self._SparseTensor_NoNonZeros((2, 3, 4))
+    sp_b = self._SparseTensor_NoNonZeros((2, 7, 4))
+    sp_c = self._SparseTensor_NoNonZeros((2, 5, 4))
+
+    with self.session(use_gpu=False) as sess:
+      concat_dim = 1
+      sp_concat = sparse_ops.sparse_concat(concat_dim, [sp_a, sp_b, sp_c])
+
+      self.assertEqual(sp_concat.indices.get_shape(), [0, 3])
+      self.assertEqual(sp_concat.values.get_shape(), [0])
+      self.assertEqual(sp_concat.dense_shape.get_shape(), [3])
+
+      concat_out = self.evaluate(sp_concat)
+
+      self.assertEqual(concat_out.indices.shape, (0, 3))
+      self.assertEqual(concat_out.values.shape, (0,))
+      self.assertAllEqual(concat_out.dense_shape, [2, 15, 4])
+
+  def testConcatSomeNoNonZeros(self):
+    sp_a = self._SparseTensor_NoNonZeros((2, 7, 4))
+    sp_b = self._SparseTensor_2x3x4()
+    sp_c = self._SparseTensor_NoNonZeros((2, 5, 4))
+    output_nnz = sp_b.indices.get_shape()[0]
+
+    with self.session(use_gpu=False) as sess:
+      concat_dim = 1
+      sp_concat = sparse_ops.sparse_concat(concat_dim, [sp_a, sp_b, sp_c])
+
+      self.assertEqual(sp_concat.indices.get_shape(), [output_nnz, 3])
+      self.assertEqual(sp_concat.values.get_shape(), [output_nnz])
+      self.assertEqual(sp_concat.dense_shape.get_shape(), [3])
+
+      concat_out = self.evaluate(sp_concat)
+
+      self.assertAllEqual(concat_out.indices, sp_b.indices + [0, 7, 0])
+      self.assertAllEqual(concat_out.values, sp_b.values)
+      self.assertAllEqual(concat_out.dense_shape, [2, 15, 4])
 
   def testConcatNonNumeric(self):
     with self.session(use_gpu=False) as sess:


### PR DESCRIPTION
- This is in preparation for adding a GPU implementation.
- Adds early-exit when the output is empty (no non-zeros).
- Adds tests for all/some inputs being empty (no non-zeros).
- No functional change.

cc @nluehr @sanjoy 