### PR TITLE
Update imagenet_utils.py

### DIFF
--- a/tensorflow/python/keras/applications/imagenet_utils.py
+++ b/tensorflow/python/keras/applications/imagenet_utils.py
@@ -187,8 +187,7 @@ def _preprocess_numpy_input(x, data_format, mode):
     x = x.astype(backend.floatx(), copy=False)
 
   if mode == 'tf':
-    x /= 127.5
-    x -= 1.
+    x /= 255.
     return x
   elif mode == 'torch':
     x /= 255.


### PR DESCRIPTION
when using keras builtin models InceptionV3, Xception, VGG etc with preprocess function from imagenet_utils the models shows weird behaviour and never predict correct results , the newly trained models from tensorflow hub are most probably compatible with only images in range [0,1] unlike the old ranges in tf [-1,1] this is a bug.