### PR TITLE
[XLA] Enable pointwise row vectorization for small row.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -168,7 +168,7 @@ void AnnotateWithInt32Value(string name, int64_t value,
             llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
                 llvm::IntegerType::get(llvm_context, /*NumBits=*/32),
                 value))}));
-};
+}
 
 // Annotates the launch dimensions of the corresponding IR kernel in
 // `llvm_module`.

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -1719,7 +1719,7 @@ Status IrEmitterUnnested::EmitLoopFusion(mlir::Operation* op) {
       if (auto broadcast = mlir::dyn_cast<mlir::mhlo::BroadcastInDimOp>(op)) {
         if (broadcast.broadcast_dimensions().empty() ||
             // More then 2 bit inputs cause one speed regression.
-            (row_vectorized && num_big_inputs <= 2)) {
+            (row_vectorized && num_big_inputs <= 3)) {
           continue;
         }
       }

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -174,6 +174,26 @@ void AnnotateThunkLaunchDimensions(const LaunchDimensions& launch_dims,
       {llvm::ConstantAsMetadata::get(ir_kernel),
        llvm::MDString::get(llvm_context, "reqntidx"),
        llvm::ConstantAsMetadata::get(threads_per_block_ir_value)}));
+  if (launch_dims.thread_counts_per_block().y > 1) {
+    threads_per_block_ir_value = llvm::ConstantInt::get(
+        llvm::IntegerType::get(llvm_context, /*NumBits=*/32),
+        launch_dims.thread_counts_per_block().y);
+    nvvm_annotations_node->addOperand(llvm::MDNode::get(
+        llvm_context,
+        {llvm::ConstantAsMetadata::get(ir_kernel),
+         llvm::MDString::get(llvm_context, "reqntidy"),
+         llvm::ConstantAsMetadata::get(threads_per_block_ir_value)}));
+  }
+  if (launch_dims.thread_counts_per_block().z > 1) {
+    threads_per_block_ir_value = llvm::ConstantInt::get(
+        llvm::IntegerType::get(llvm_context, /*NumBits=*/32),
+        launch_dims.thread_counts_per_block().z);
+    nvvm_annotations_node->addOperand(llvm::MDNode::get(
+        llvm_context,
+        {llvm::ConstantAsMetadata::get(ir_kernel),
+         llvm::MDString::get(llvm_context, "reqntidz"),
+         llvm::ConstantAsMetadata::get(threads_per_block_ir_value)}));
+  }
 }
 
 bool BinarySearchDenseElementsAttr(mlir::DenseIntElementsAttr elements,

--- a/tensorflow/compiler/xla/service/gpu/launch_dimensions.cc
+++ b/tensorflow/compiler/xla/service/gpu/launch_dimensions.cc
@@ -68,8 +68,7 @@ int64_t ThreadsPerBlockRowVectorized(const Shape& shape,
       // path that use a block size of 256. This give small speed up on V100.
       // Vectorization of the row load was already happening.
       (shape.dimensions().back() % 256) != 0 &&
-      // Do not trigger the row vectorized codepath if this create too
-      // small block size as this hurt performance.
+      // We do not support row that do not fit in one block.
       threads_per_block_row_vectorized <=
           gpu_device_info.threads_per_block_limit) {
     return threads_per_block_row_vectorized;
@@ -99,57 +98,58 @@ StatusOr<LaunchDimensions> CalculateLaunchDimensions(
   //
   // TODO(jlebar): Investigate this further, and tune this heuristic so we can
   // run faster on the few benchmarks where smaller block size helps.
-  int64_t threads_per_block = ThreadsPerBlockLimit(gpu_device_info);
-  int64_t threads_per_block_y = 1;
   int64_t threads_per_block_row_vectorized =
       ThreadsPerBlockRowVectorized(shape, gpu_device_info, dim_config);
-  if (threads_per_block_row_vectorized > 0) {
-    CHECK(dim_config.row_vectorized);
-    threads_per_block = threads_per_block_row_vectorized;
-    if (threads_per_block < 128 && num_elements > 128) {
-      // This case happens for small row size.
-      threads_per_block_y =
-          CeilOfRatio((int64_t)128, threads_per_block);
-    VLOG(2) << "Update # of threads per block to (.x=" << threads_per_block
-            << ", .y=" << threads_per_block_y
-            << ") to be row_vectorized.";
+  // If row vectorized, threads_per_block_x is the vectorized size.
+  // Otherwise, we unroll kernels to make use of vectorized
+  // loads/stores. This means we need more registers to hold
+  // intermediate values. Reduce the number of threads per block to
+  // increase the number of registers available to ptxas.  Make sure
+  // we still have a multiple of 32.
+  int64_t threads_per_block_x = [&]() {
+    int64_t max_threads_per_block_x =
+    threads_per_block_row_vectorized > 0 ?
+    threads_per_block_row_vectorized :
+    RoundUpToNearest(
+        ThreadsPerBlockLimit(gpu_device_info) / dim_config.unroll_factor,
+        int64_t{32});
+    if (num_elements < max_threads_per_block_x) {
+      return num_elements;
     }
-  } else {
-    CHECK(!dim_config.row_vectorized);
-    // We unroll kernels to make use of vectorized loads/stores. This means we
-    // need more registers to hold intermediate values. Reduce the number of
-    // threads per block to increase the number of registers available to ptxas.
-    // Make sure we still have a multiple of 32.
-    threads_per_block = RoundUpToNearest(
-        threads_per_block / dim_config.unroll_factor, int64_t{32});
-    if (num_elements < threads_per_block) {
-      threads_per_block = num_elements;
-      VLOG(2) << "Update # of threads per block to the element count ("
-              << threads_per_block << ") because the latter is smaller.";
-    }
-  }
+    return max_threads_per_block_x;
+  }();
+  // threads_per_block_y > 1 when we row vectorize and have small row size.
+  int64_t threads_per_block_y =
+      threads_per_block_row_vectorized > 0 &&
+      threads_per_block_row_vectorized < 128 &&
+      num_elements > 128 ?
+      CeilOfRatio(static_cast<int64_t>(128), threads_per_block_row_vectorized) :
+      1;
+  VLOG(2) << "Set # of threads per block to (.x=" << threads_per_block_x
+          << ", .y=" << threads_per_block_y
+          << ")";
 
   int64_t block_count = CeilOfRatio(num_elements,
-                                  threads_per_block * threads_per_block_y);
+                                  threads_per_block_x * threads_per_block_y);
   if (dim_config.few_waves && !dim_config.row_vectorized) {
-    int64_t capped_threads_per_block =
-        std::min<int64_t>(threads_per_block, 128);
+    int64_t capped_threads_per_block_x =
+        std::min<int64_t>(threads_per_block_x, 128);
     int64_t capped_block_count =
         gpu_device_info.core_count *
         (gpu_device_info.threads_per_core_limit /
-         (capped_threads_per_block * threads_per_block_y));
+         (capped_threads_per_block_x * threads_per_block_y));
     if (capped_block_count < block_count) {
-      threads_per_block = capped_threads_per_block;
+      threads_per_block_x = capped_threads_per_block_x;
       block_count = capped_block_count;
       VLOG(2) << "Update the # of blocks to " << block_count
               << " and the # of threads per blocks to "
-              << threads_per_block << " as the few waves mode is enabled.";
+              << threads_per_block_x << " as the few waves mode is enabled.";
     }
   } else if (dim_config.few_waves && dim_config.row_vectorized) {
     int64_t min_block_count =
         gpu_device_info.core_count *
         (gpu_device_info.threads_per_core_limit /
-         (threads_per_block * threads_per_block_y));
+         (threads_per_block_x * threads_per_block_y));
     int64_t capped_block_count = block_count;
     // This multiple of 32 was tuned to not cause regression on multiple
     // benchmarks.  It isn't a value that is optimal for all
@@ -176,9 +176,9 @@ StatusOr<LaunchDimensions> CalculateLaunchDimensions(
   VLOG(2) << absl::StrFormat(
       "Initialized the block count to %d, the block size .x=%d and .y=%d"
       " for %d elements in the tensor.",
-      block_count, threads_per_block, threads_per_block_y, num_elements);
+      block_count, threads_per_block_x, threads_per_block_y, num_elements);
   return LaunchDimensions({block_count, 1, 1},
-                          {threads_per_block, threads_per_block_y, 1});
+                          {threads_per_block_x, threads_per_block_y, 1});
 }
 
 }  // namespace gpu

--- a/tensorflow/compiler/xla/service/gpu/launch_dimensions.h
+++ b/tensorflow/compiler/xla/service/gpu/launch_dimensions.h
@@ -52,7 +52,7 @@ class LaunchDimensions {
 
   Dim3D thread_counts_per_block() const { return thread_counts_per_block_; }
 
-  // Return the total number of threads in a block.
+  // Returns the total number of threads in a block.
   int64_t total_nb_threads() const {
     return thread_counts_per_block_.x *
         thread_counts_per_block_.y *

--- a/tensorflow/compiler/xla/service/gpu/launch_dimensions.h
+++ b/tensorflow/compiler/xla/service/gpu/launch_dimensions.h
@@ -52,10 +52,16 @@ class LaunchDimensions {
 
   Dim3D thread_counts_per_block() const { return thread_counts_per_block_; }
 
+  int64_t total_nb_threads() const {
+    return thread_counts_per_block_.x *
+        thread_counts_per_block_.y *
+        thread_counts_per_block_.z;
+  }
+
   int64_t launch_bound() const {
     return block_counts_.x * thread_counts_per_block_.x * block_counts_.y *
-           thread_counts_per_block_.y * block_counts_.z *
-           thread_counts_per_block_.z;
+        thread_counts_per_block_.y * block_counts_.z *
+        thread_counts_per_block_.z;
   }
 
   std::string ToString() const {

--- a/tensorflow/compiler/xla/service/gpu/launch_dimensions.h
+++ b/tensorflow/compiler/xla/service/gpu/launch_dimensions.h
@@ -52,6 +52,7 @@ class LaunchDimensions {
 
   Dim3D thread_counts_per_block() const { return thread_counts_per_block_; }
 
+  // Return the total number of threads in a block.
   int64_t total_nb_threads() const {
     return thread_counts_per_block_.x *
         thread_counts_per_block_.y *
@@ -60,8 +61,8 @@ class LaunchDimensions {
 
   int64_t launch_bound() const {
     return block_counts_.x * thread_counts_per_block_.x * block_counts_.y *
-        thread_counts_per_block_.y * block_counts_.z *
-        thread_counts_per_block_.z;
+           thread_counts_per_block_.y * block_counts_.z *
+           thread_counts_per_block_.z;
   }
 
   std::string ToString() const {

--- a/tensorflow/compiler/xla/service/gpu/parallel_loop_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/parallel_loop_emitter.cc
@@ -62,16 +62,29 @@ ParallelLoopEmitter::EmitIndexAndSetExitBasicBlock(absl::string_view loop_name,
                                                    llvm::Type* index_type,
                                                    llvm::Value* base_index) {
   // Emit the following code in LLVM IR:
-  //   linear_index = blockIdx.x * blockDim.x + threadIdx.x;
+  //   linear_index = blockIdx.x * blockDim.x * blockDim.y [+ threadIdx.y * blockDim.x] + threadIdx.x;
   //   if (linear_index < num_elements) {
   //     array_index = LinearIndexToMultidimensionalIndex(shape_, linear_index);
   //     ...
   //   }
+  // The part between [] are added only if blockDim.y > 1.
 
   // Per the PTX documentation:
   //   "It is guaranteed that [...] 0  <=  %ctaid.x <  %nctaid.x"
   //
   // %nctaid.x is currently specified as 2147483647.
+  if (launch_dimensions_.thread_counts_per_block().y > 1) {
+    // When blockDim.y > 1, then we are in the small row case. Each
+    // blockDim.x do exatly to one row and blockDim.y map to some
+    // consecutive row.
+    CHECK(launch_config_.row_vectorized);
+    CHECK_EQ(shape_.dimensions().back(),
+	     launch_dimensions_.thread_counts_per_block().x *
+             launch_config_.unroll_factor);
+  }
+  CHECK_EQ(launch_dimensions_.thread_counts_per_block().z, 1);
+  CHECK_EQ(launch_dimensions_.block_counts().y, 1);
+  CHECK_EQ(launch_dimensions_.block_counts().z, 1);
   VLOG(3) << "EmitIndexAndSetExitBasicBlock unroll_factor "
           << launch_config_.unroll_factor;
   CHECK_NE(index_type, nullptr);
@@ -84,22 +97,36 @@ ParallelLoopEmitter::EmitIndexAndSetExitBasicBlock(absl::string_view loop_name,
 
   // Per the PTX documentation:
   //   "It is guaranteed that [...] 0  <=  %tid.x <  %ntid.x"
-  //
-  // %ntid.x is currently specified as 1024.
-  llvm::Value* thread_id =
+  llvm::Value* thread_id_x =
       EmitCallToTargetIntrinsic(TargetIntrinsicID::kThreadIdx, {}, {}, b_);
   llvm_ir::AddRangeMetadata(0, launch_dimensions_.thread_counts_per_block().x,
-                            static_cast<llvm::Instruction*>(thread_id));
-  thread_id = b_->CreateZExtOrTrunc(thread_id, index_type, "thread_id");
+                            static_cast<llvm::Instruction*>(thread_id_x));
+  thread_id_x = b_->CreateZExtOrTrunc(thread_id_x, index_type, "thread_id_x");
 
-  llvm::Value* linear_index_base = b_->CreateAdd(
-      b_->CreateMul(
+  llvm::Value* linear_index_base = b_->CreateMul(
           block_id,
           llvm::ConstantInt::get(
-              index_type, launch_dimensions_.thread_counts_per_block().x),
+              index_type, launch_dimensions_.total_nb_threads()),
           "",
-          /*HasNUW=*/true, /*HasNSW=*/true),
-      thread_id, "linear_index", /*HasNUW=*/true, /*HasNSW=*/true);
+          /*HasNUW=*/true, /*HasNSW=*/true);
+  if (launch_dimensions_.thread_counts_per_block().y > 1) {
+    llvm::Value* thread_id_y = EmitCallToTargetIntrinsic(TargetIntrinsicID::kThreadIdy, {}, {}, b_);
+    llvm_ir::AddRangeMetadata(0, launch_dimensions_.thread_counts_per_block().y,
+                              static_cast<llvm::Instruction*>(thread_id_y));
+    thread_id_y = b_->CreateZExtOrTrunc(thread_id_y, index_type, "thread_id_y");
+    linear_index_base =  b_->CreateAdd(
+        linear_index_base,
+        b_->CreateMul(
+            thread_id_y,
+            llvm::ConstantInt::get(
+                index_type, launch_dimensions_.thread_counts_per_block().x),
+            "",
+            /*HasNUW=*/true, /*HasNSW=*/true),
+        "",
+        /*HasNUW=*/true, /*HasNSW=*/true);
+  }
+  linear_index_base = b_->CreateAdd(
+      linear_index_base, thread_id_x, "linear_index", /*HasNUW=*/true, /*HasNSW=*/true);
 
   // Add an @llvm.assume(linear_index < threads_per_block * num_blocks).
   //
@@ -114,7 +141,7 @@ ParallelLoopEmitter::EmitIndexAndSetExitBasicBlock(absl::string_view loop_name,
       {b_->CreateICmpULT(
           linear_index_base,
           llvm::ConstantInt::get(
-              index_type, launch_dimensions_.thread_counts_per_block().x *
+              index_type, launch_dimensions_.total_nb_threads() *
                               launch_dimensions_.block_counts().x),
           "linear_index_in_range")},
       {}, b_);
@@ -143,7 +170,7 @@ ParallelLoopEmitter::EmitIndexAndSetExitBasicBlock(absl::string_view loop_name,
     // Simpler index for row computation.
     // This will allow LLVM to vectorize.
     row_index = b_->CreateMul(
-        thread_id,
+        thread_id_x,
         llvm::ConstantInt::get(index_type, launch_config_.unroll_factor),
         "row_index", /*HasNUW=*/true, /*HasNSW=*/true);
     std::vector<llvm::Value*> multidim(shape_.rank(), nullptr);

--- a/tensorflow/compiler/xla/service/gpu/parallel_loop_emitter.cc
+++ b/tensorflow/compiler/xla/service/gpu/parallel_loop_emitter.cc
@@ -68,6 +68,7 @@ ParallelLoopEmitter::EmitIndexAndSetExitBasicBlock(absl::string_view loop_name,
   //     ...
   //   }
   // The part between [] are added only if blockDim.y > 1.
+  // blockIdx.y and gridDim.y are always 1.
 
   // Per the PTX documentation:
   //   "It is guaranteed that [...] 0  <=  %ctaid.x <  %nctaid.x"
@@ -76,7 +77,8 @@ ParallelLoopEmitter::EmitIndexAndSetExitBasicBlock(absl::string_view loop_name,
   if (launch_dimensions_.thread_counts_per_block().y > 1) {
     // When blockDim.y > 1, then we are in the small row case. Each
     // blockDim.x do exatly to one row and blockDim.y map to some
-    // consecutive row.
+    // consecutive row. This prevents too small block size that isn't
+    // efficient.
     CHECK(launch_config_.row_vectorized);
     CHECK_EQ(shape_.dimensions().back(),
 	     launch_dimensions_.thread_counts_per_block().x *

--- a/tensorflow/compiler/xla/service/gpu/parallel_loop_emitter.h
+++ b/tensorflow/compiler/xla/service/gpu/parallel_loop_emitter.h
@@ -30,8 +30,9 @@ namespace gpu {
 // collectively iterates over the entire array.
 class ParallelLoopEmitter : public llvm_ir::LoopEmitter {
  public:
-  // `thread_count` is the number of threads to parallelize the loop on.
-  // The meanings of other parameters are the same as LoopEmitter.
+  // `launch_dimensions` specify the number of threads and blocks to
+  // parallelize the loop on.  `launch_config` specify some detail on
+  // how to parallelize.
   ParallelLoopEmitter(BodyEmitter body_emitter, const Shape& shape,
                       const LaunchDimensions& launch_dimensions,
                       llvm::IRBuilder<>* b,

--- a/tensorflow/compiler/xla/service/gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/tests/BUILD
@@ -65,6 +65,7 @@ tf_cc_test(
     tags = tf_cuda_tests_tags(),
     deps = [
         ":gpu_codegen_test",
+        "//tensorflow/compiler/xla:error_spec",
         "//tensorflow/compiler/xla/tests:hlo_test_base",
         "//tensorflow/compiler/xla/tests:xla_internal_test_main",
     ],

--- a/tensorflow/compiler/xla/service/gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/tests/BUILD
@@ -59,6 +59,17 @@ cc_library(
     ],
 )
 
+tf_cc_test(
+    name = "element_wise_row_vectorization_test",
+    srcs = ["element_wise_row_vectorization_test.cc"],
+    tags = tf_cuda_tests_tags(),
+    deps = [
+        ":gpu_codegen_test",
+        "//tensorflow/compiler/xla/tests:hlo_test_base",
+        "//tensorflow/compiler/xla/tests:xla_internal_test_main",
+    ],
+)
+
 cc_library(
     name = "mlir_gpu_test_base",
     testonly = True,

--- a/tensorflow/compiler/xla/service/gpu/tests/element_wise_row_vectorization.hlo
+++ b/tensorflow/compiler/xla/service/gpu/tests/element_wise_row_vectorization.hlo
@@ -25,6 +25,29 @@ ENTRY main {
 
 // -----
 
+HloModule SimpleAddSmallRowBroadcasting
+
+%fused_computation.0 (param_0: f32[48], param_1: f32[512,14,14,48]) -> f32[512,14,14,48]{
+  %param_0 = f32[48]{0} parameter(0)
+  %broadcast = f32[512,14,14,48]{3,2,1,0} broadcast(%param_0), dimensions={3}
+  %param_1 = f32[512,14,14,48]{3,2,1,0} parameter(1)
+  ROOT %add = f32[512,14,14,48]{3,2,1,0} add(%broadcast, %param_1)
+}
+
+ENTRY main {
+  %param_0 = f32[48]{0} parameter(0)
+  %param_1 = f32[512,14,14,48]{3,2,1,0} parameter(1)
+
+  ROOT %fusion.0_small = f32[512,14,14,48]{3,2,1,0} fusion(%param_0, %param_1), kind=kLoop, calls=%fused_computation.0
+}
+
+// CHECK-LABEL: fusion_0_small
+// CHECK: .reqntid 12, 11, 1
+// CHECK-NOT: ld.global.nc.f
+// CHECK-NOT: ld.global.nc.b
+
+// -----
+
 // This test an BatchNorm fused kernel found in EfficientNet.
 HloModule EfficientNetSwish
 

--- a/tensorflow/compiler/xla/service/gpu/tests/element_wise_row_vectorization_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/element_wise_row_vectorization_test.cc
@@ -1,0 +1,48 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <vector>
+
+#include "tensorflow/compiler/xla/error_spec.h"
+#include "tensorflow/compiler/xla/tests/hlo_test_base.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+class ElementWiseRowVectorizationTest : public HloTestBase {};
+
+TEST_F(ElementWiseRowVectorizationTest, SimpleAddSmallRowBroadcastingTest) {
+  const char* hlo_text = R"(
+HloModule SimpleAddSmallRowBroadcasting
+
+%fused_computation.0 {
+  %param_0 = f32[48]{0} parameter(0)
+  %broadcast = f32[256,14,14,48]{3,2,1,0} broadcast(%param_0), dimensions={3}
+  %param_1 = f32[256,14,14,48]{3,2,1,0} parameter(1)
+  ROOT %add = f32[256,14,14,48]{3,2,1,0} add(%broadcast, %param_1)
+}
+
+ENTRY main {
+  %param_0 = f32[48]{0} parameter(0)
+  %param_1 = f32[256,14,14,48]{3,2,1,0} parameter(1)
+
+  ROOT %fusion.0_small = f32[256,14,14,48]{3,2,1,0} fusion(%param_0, %param_1), kind=kLoop, calls=%fused_computation.0
+}
+)";
+  auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla


### PR DESCRIPTION
Follow up on : https://github.com/tensorflow/tensorflow/pull/48527
This speed up the same efficient net fusion but when the row size is small. That kernel happens for with many different size.

This enable row vectorization for small row. This lower the numbers of threads per block by 4x. This cause blocks that are too small and trigger speed regression in some cases due to the blocks being too small. To prevent those small blocks problems, this PR use blockIdx.y in addition to blockIdx.x. blockIdx.x continue to handle one row. But each elements in blockIdx.y handle a different consecutive row.

@akuegel @cheshire 

I join 2 hlo that contain multiple kernels. 
[swish_fusion_5_160,190,190,48_simpler.txt](https://github.com/tensorflow/tensorflow/files/6858339/swish_fusion_5_160.190.190.48_simpler.txt)
[swish_fusion_5_160,190,190,48.txt](https://github.com/tensorflow/tensorflow/files/6858340/swish_fusion_5_160.190.190.48.txt)

The kernels:
fusion_5: The fusion I want to optimize. It come from EfficientNet.
fusion_5_new: A new version of that if we mark kExp as cheap. This is what we want to enable. It does extra computation, but read less data. An exponential is duplicated to save bandwidth.
fusion_5_simpler[_new]: Variation of above kernels that have less row inputs. They are synthetic HLO that doesn't exist in models.

The shape is a real shape from the EfficientNet model. Just one picked that have small row size that wasn't vectorized before.

Here is the current sped result that I have.

V100 | 72ac61dbed (upstream) | ...0_block | ...0_grid | fb71bc2388 (PR) | ...1_block | ...1_grid | af3beedbd24 PR+1commit | ...2_block | ...2_grid | 39f5185dc7 PR+2commit | ...3_block | ...3_grid
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
fusion_5 | 3059.776 | 256 | 270750 | 2730.784 | 132 | 525091 | 2928.48 | 132 | 32818 | 2868.544 | 264 | 16409
fusion_5_new | 2623.712 | 256 | 270750 | 2539.392 | 132 | 32818 | 2546.208 | 132 | 32818 | 2337.664 | 264 | 16409
fusion_5_simpler | 2676.832 | 256 | 270750 | **2711.008** | 132 | 525091 | **2867.552** | 132 | 32818 | **2880.832** | 264 | 16409
fusion_5_simpler_new | 2450.368 | 256 | 270750 | **2533.536** | 132 | 32818 | **2541.536** | 132 | 32818 | 2350.048 | 264 | 16409
  |   |   |   |   |   |   |   |   |   |   |   |  
A100 | 72ac61dbed (upstream) | ...0_block | ...0_grid | fb71bc2388 (PR) | ...1_block | ...1_grid | af3beedbd24 PR+1commit | ...2_block | ...2_grid | 39f5185dc7 PR+2commit | ...3_block | ...3_grid
fusion_5 | 2538.24 | 256 | 270750 | 2399.776 | 132 | 525091 | 2150.24 | 132 | 32818 | 1953.568 | 264 | 16409
fusion_5_new | 3079.04 | 256 | 270750 | 2760.064 | 132 | 32818 | 2760.288 | 132 | 32818 | 2494.528 | 264 | 16409
fusion_5_simpler | 2357.44 | 256 | 270750 | 2208.576 | 132 | 525091 | 2149.088 | 132 | 32818 | 2106.848 | 264 | 16409
fusion_5_simpler_new | 2819.904 | 256 | 270750 | 2736.48 | 132 | 32818 | 2736.288 | 132 | 32818 | 2502.432 | 264 | 16409

The columns is the matching commit. PR mean the first version of the PR. I added 2 commits to limit the slowdown on V100. That also give a speed up on A100 at the same time.