### PR TITLE
[ROCm] Enable xlogy and xlog1py for HIP GPU.

### DIFF
--- a/tensorflow/core/kernels/cwise_op_gpu_xlog1py.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_xlog1py.cu.cc
@@ -24,11 +24,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED) || \
     !defined(MLIR_GENERATED_EXPERIMENTAL_KERNELS_ENABLED)
 DEFINE_BINARY3(xlog1py, Eigen::half, float, double);
-
-// TODO(ROCm): enable complex64 / complex128 after compiler fix.
-#if GOOGLE_CUDA
 DEFINE_BINARY2(xlog1py, complex64, complex128);
-#endif
 #endif
 #endif
 

--- a/tensorflow/core/kernels/cwise_op_gpu_xlogy.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_xlogy.cu.cc
@@ -27,10 +27,7 @@ DEFINE_BINARY3(xlogy, Eigen::half, float, double);
 #endif
 #endif
 
-// TODO(ROCm): enable complex64 / complex128 after compiler fix.
-#if GOOGLE_CUDA
 DEFINE_BINARY2(xlogy, complex64, complex128);
-#endif
 
 }  // namespace functor
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_xlog1py.cc
+++ b/tensorflow/core/kernels/cwise_op_xlog1py.cc
@@ -25,9 +25,7 @@ REGISTER5(BinaryOp, CPU, "Xlog1py", functor::xlog1py, float, Eigen::half,
     !defined(MLIR_GENERATED_EXPERIMENTAL_KERNELS_ENABLED)
 REGISTER3(BinaryOp, GPU, "Xlog1py", functor::xlog1py, float, Eigen::half,
           double);
-#if GOOGLE_CUDA
 REGISTER2(BinaryOp, GPU, "Xlog1py", functor::xlog1py, complex64, complex128);
-#endif
 #endif
 #endif
 

--- a/tensorflow/core/kernels/cwise_op_xlogy.cc
+++ b/tensorflow/core/kernels/cwise_op_xlogy.cc
@@ -24,9 +24,7 @@ REGISTER5(BinaryOp, CPU, "Xlogy", functor::xlogy, float, Eigen::half, double,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED) || \
     !defined(MLIR_GENERATED_EXPERIMENTAL_KERNELS_ENABLED)
 REGISTER3(BinaryOp, GPU, "Xlogy", functor::xlogy, float, Eigen::half, double);
-#if GOOGLE_CUDA
 REGISTER2(BinaryOp, GPU, "Xlogy", functor::xlogy, complex64, complex128);
-#endif
 #endif
 #endif
 

--- a/tensorflow/core/kernels/mlir_generated/gpu_binary_ops_test.cc
+++ b/tensorflow/core/kernels/mlir_generated/gpu_binary_ops_test.cc
@@ -976,7 +976,7 @@ GENERATE_DEFAULT_TESTS(Xlogy, /*test_name=*/Double, double, double,
                        test::OpsTestConfig().ExpectStrictlyEqual())
 GENERATE_DEFAULT_TESTS(Xlogy, /*test_name=*/Complex64, std::complex<float>,
                        std::complex<float>, baseline_xlogy,
-                       test::OpsTestConfig())
+                       test::OpsTestConfig().ATol(2e-6).RTol(2e-6))
 GENERATE_DEFAULT_TESTS(Xlogy, /*test_name=*/Complex128, std::complex<double>,
                        std::complex<double>, baseline_xlogy,
                        test::OpsTestConfig())


### PR DESCRIPTION
Relax tolerance for xlogy for complex64 in gpu_binary_ops_test to enable that test to pass on HIP.