### PR TITLE
profiling: memory_info: add support for new mallinfo API

### DIFF
--- a/tensorflow/lite/profiling/memory_info.cc
+++ b/tensorflow/lite/profiling/memory_info.cc
@@ -24,7 +24,7 @@ namespace tflite {
 namespace profiling {
 namespace memory {
 
-const int MemoryUsage::kValueNotSet = 0;
+const size_t MemoryUsage::kValueNotSet = 0;
 
 bool MemoryUsage::IsSupported() {
 #ifdef __linux__
@@ -40,7 +40,11 @@ MemoryUsage GetMemoryUsage() {
   if (getrusage(RUSAGE_SELF, &res) == 0) {
     result.max_rss_kb = res.ru_maxrss;
   }
+#if defined(__GLIBC__) && __GLIBC_MINOR__ >= 33
+  const auto mem = mallinfo2();
+#else
   const auto mem = mallinfo();
+#endif
   result.total_allocated_bytes = mem.arena;
   result.in_use_allocated_bytes = mem.uordblks;
 #endif

--- a/tensorflow/lite/profiling/memory_info.h
+++ b/tensorflow/lite/profiling/memory_info.h
@@ -23,7 +23,7 @@ namespace profiling {
 namespace memory {
 
 struct MemoryUsage {
-  static const int kValueNotSet;
+  static const size_t kValueNotSet;
 
   // Indicates whether obtaining memory usage is supported on the platform, thus
   // indicating whether the values defined in this struct make sense or not.
@@ -41,11 +41,11 @@ struct MemoryUsage {
 
   // Total non-mmapped space allocated from system in bytes. This is an alias to
   // mallinfo::arena.
-  int total_allocated_bytes;
+  size_t total_allocated_bytes;
 
   // Total allocated (including mmapped) bytes that's in use (i.e. excluding
   // those are freed). This is an alias to mallinfo::uordblks.
-  int in_use_allocated_bytes;
+  size_t in_use_allocated_bytes;
 
   MemoryUsage operator+(MemoryUsage const& obj) const {
     MemoryUsage res;


### PR DESCRIPTION
Starting with glibc 2.33 the mallinfo API is deprecated
in favor of the newer mallinfo2 which returns the exact
same struct but with size_t elements instead of int.

For reference:
https://man7.org/linux/man-pages/man3/mallinfo.3.html