### PR TITLE
Fix build after previous cherrypick (#50773).

### DIFF
--- a/tensorflow/core/common_runtime/shape_refiner.cc
+++ b/tensorflow/core/common_runtime/shape_refiner.cc
@@ -135,7 +135,7 @@ Status ShapeRefiner::InferShapesForFunctionSubNode(
         TF_RETURN_IF_ERROR(
             outer_context->MakeShapeFromShapeProto(proto, &handle));
         copied_shapes_and_types.push_back(
-            ShapeAndType(handle, shape_and_type.dtype, shape_and_type.type));
+            ShapeAndType(handle, shape_and_type.dtype, shape_and_type.specialized_type));
       }
 
       outer_context->set_output_handle_shapes_and_types(


### PR DESCRIPTION
This is needed because of refactoring in 7c3f96bf324cebe443a7eb814ce771c66c073998 (on master). The cherrypick in #50773 includes code after this refactoring but for all releases before 2.6 we need this fix too.