### PR TITLE
[TF-TRT] ActivationLayer inaccuracy in TRT 8 - Unittest fix

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -3717,8 +3717,16 @@ TEST_P(OpConverter_FP32_Test, ConvertActivation) {
     std::vector<float> output_values;
     std::transform(input.begin(), input.end(),
                    std::back_inserter(output_values), op_map[op_name].second);
-    TestOpConverter("my_unary", node_def, p.expected_output_dims, Status::OK(),
-                    Status::OK(), ArrayFloatNear(output_values, 0, false));
+
+    TestOpConverter(
+      "my_unary", node_def, p.expected_output_dims, Status::OK(), Status::OK(),
+#if IS_TRT_VERSION_GE(8, 0, 0, 0)
+      // NVBug # 3322482 - Known bug with TRT 8.0 on specific GPU architectures
+      ArrayFloatNear(output_values, 1e-4, false)
+#else
+      ArrayFloatNear(output_values, 0, false)
+#endif
+    );
 
     TRT_TensorOrWeights output;
     TF_EXPECT_OK(GetTensorOrWeights("my_unary", &output));


### PR DESCRIPTION
This PR fixes the unit test to workaround NVBug 3322482.
Adds a small tolerance to the unit test to workaround a bug with TRT 8.