### PR TITLE
Add missing dep on MLIRMhloUtils

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/CMakeLists.txt
@@ -190,6 +190,7 @@ add_mlir_library(LmhloPasses
 
   LINK_LIBS PUBLIC
   LmhloDialect
+  MLIRMhloUtils
   MLIRIR
   MLIRPass
 )


### PR DESCRIPTION
The LmhloPasses makes use of `mlir::codegen_utils` functions, part of
the MLIRMhloUtils target. This adds the missing dep on MLIRMhloUtils.