### PR TITLE
[tf.data] Fix a performance regression for input pipelines that creat…

### DIFF
--- a/tensorflow/core/data/snapshot_utils.cc
+++ b/tensorflow/core/data/snapshot_utils.cc
@@ -658,6 +658,7 @@ void Reader::NestedDatasetOp::MakeDataset(OpKernelContext* ctx,
     inputs.push_back(input);
   }
   *output = new Reader::NestedDataset(DatasetContext(ctx), inputs);
+  (*output)->Initialize();
 }
 
 Status Reader::MakeNestedDataset(Env* env,
@@ -684,6 +685,7 @@ Status Reader::MakeNestedDataset(Env* env,
                          strings::StrCat("SnapshotDatasetReader/_", i)})),
                     shard_dirs.at(i), compression_type, version, dtypes, shapes,
                     dataset_start_index));
+    datasets.back()->Initialize();
   }
 
   // Rotate the vector such that the first dataset contains the next element
@@ -699,6 +701,7 @@ Status Reader::MakeNestedDataset(Env* env,
       DatasetContext(DatasetContext::Params(
           {"SnapshotNestedDatasetReader", "SnapshotNestedDatasetReader"})),
       datasets);
+  (*output)->Initialize();
   return Status::OK();
 }
 

--- a/tensorflow/core/kernels/data/window_dataset.cc
+++ b/tensorflow/core/kernels/data/window_dataset.cc
@@ -20,7 +20,7 @@ limitations under the License.
 #include "tensorflow/core/data/name_utils.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/graph/graph.h"
-#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/platform/errors.h"
 
 namespace tensorflow {
 namespace data {
@@ -83,17 +83,19 @@ class Window : public DatasetBase {
   Status AsGraphDefInternal(SerializationContext* ctx,
                             DatasetGraphDefBuilder* b,
                             Node** output) const override {
+    if (!ctx->serialize_data_tensors()) {
+      // If data tensors are not to be serialized (e.g. when the serialization
+      // is done for the sake of graph optimizations) and errors::Unimplemented
+      // is handled gracefully, we return `errors::Unimplemented` to
+      // short-circuit the computation.
+      return errors::Unimplemented(DebugString(),
+                                   " does not support serialization");
+    }
     std::vector<Node*> input_nodes;
     for (const auto& element : elements_) {
       for (const auto& t : element) {
         Node* node;
-        if (ctx->serialize_data_tensors()) {
-          TF_RETURN_IF_ERROR(b->AddDatasetOrTensor(ctx, t, &node));
-        } else {
-          TF_RETURN_IF_ERROR(b->AddPlaceholder(t, &node));
-          DCHECK_NE(ctx->input_list(), nullptr);
-          ctx->input_list()->emplace_back(node->name(), t);
-        }
+        TF_RETURN_IF_ERROR(b->AddDatasetOrTensor(ctx, t, &node));
         input_nodes.emplace_back(node);
       }
     }
@@ -186,6 +188,7 @@ Status NewWindow(std::vector<std::vector<Tensor>> elements,
   // the elements match the output_types and output_shapes.
   *out_dataset = new Window(std::move(elements), std::move(output_types),
                             std::move(output_shapes));
+  (*out_dataset)->Initialize();
   return Status::OK();
 }
 


### PR DESCRIPTION
…e iterators for window datasets and add missing initialization of datasets that are not created through op kernel execution.

**Reasons to cherry-pick this into branch 2.6**
1) This commit fixes a performance regression
2) Without this commit, all users of [group_by_window](https://www.tensorflow.org/api_docs/python/tf/data/experimental/group_by_window) will see error logs along the lines of `Failed precondition: Cannot compute input sources for dataset of type PaddedBatchDatasetV2, because sources could not be computed for input dataset of type Window`. This issue was reported by @guillaumekln  in https://github.com/tensorflow/tensorflow/issues/50693

@jsimsa FYI

PiperOrigin-RevId: 382427031
Change-Id: I5ced4692659101ad09dc65a3fc71c036ad272f7a