### PR TITLE
Fix TF_DEVICE_MIN_SYS_MEMORY_IN_MB for big size

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -1054,8 +1054,8 @@ Status SingleVirtualDeviceMemoryLimit(const GPUOptions& gpu_options,
       std::getenv("TF_DEVICE_MIN_SYS_MEMORY_IN_MB");
   if (force_device_reserved_bytes != nullptr &&
       strcmp(force_device_reserved_bytes, "") != 0) {
-    int32 reserved_mb;
-    if (!strings::safe_strto32(force_device_reserved_bytes, &reserved_mb) ||
+    int64 reserved_mb;
+    if (!strings::safe_strto64(force_device_reserved_bytes, &reserved_mb) ||
         reserved_mb < 0) {
       LOG(WARNING) << "The requested reserved device memory "
                    << force_device_reserved_bytes

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -1062,7 +1062,7 @@ Status SingleVirtualDeviceMemoryLimit(const GPUOptions& gpu_options,
                    << " is invalid. The request will be ignored.";
     } else {
       // Convert MBytes to Bytes.
-      size_t allowable_reserved_memory = reserved_mb * 1024 * 1024;
+      int64 allowable_reserved_memory = reserved_mb * 1024 * 1024;
       // TF_DEVICE_MIN_SYS_MEMORY_IN_MB overrides
       // per_process_gpu_memory_fraction.
       if (allowable_reserved_memory <= available_memory) {


### PR DESCRIPTION
This fix some casting issue that show up when using: `TF_DEVICE_MIN_SYS_MEMORY_IN_MB=2048`.