### PR TITLE
r2.6 cherry-pick request: Downgrade oneDNN version from v2.3 back to v2.3-rc2

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -181,11 +181,11 @@ def _tf_repositories():
     tf_http_archive(
         name = "mkl_dnn_v1",
         build_file = "//third_party/mkl_dnn:mkldnn_v1.BUILD",
-        sha256 = "ccb2dbd9da36cd873cf573b4201d61bdba7438f12b144e6c7d061eb12a641751",
-        strip_prefix = "oneDNN-2.3",
+        sha256 = "82795714f11649b2a3f797d99bd07d117cde97215f55654b028ca00f3b33e0cb",
+        strip_prefix = "oneDNN-2.3-rc2",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v2.3.tar.gz",
-            "https://github.com/oneapi-src/oneDNN/archive/v2.3.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v2.3-rc2.tar.gz",
+            "https://github.com/oneapi-src/oneDNN/archive/v2.3-rc2.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Intel found that oneDNN v2.3 has a performance degradation in int8 AVX-512 convolution kernels. 
We recently cherry-picked PR [#50708](https://github.com/tensorflow/tensorflow/pull/50708) into r2.6 to upgrade oneDNN from v2.3-rc2 to v2.3. This PR reverts it back to using oneDNN v2.3-rc2.

(The aarch64 backend is fine since the issue is specific to AVX-512).

The corresponding rollback commit for master went in this afternoon: https://github.com/tensorflow/tensorflow/commit/797721dc79d9972214821673c98e823bfce70f62

cc: @nammbash @agramesh1 
