### PR TITLE
FIx random gamma and space to depth tests.

### DIFF
--- a/tensorflow/python/kernel_tests/random/random_gamma_test.py
+++ b/tensorflow/python/kernel_tests/random/random_gamma_test.py
@@ -40,7 +40,7 @@ class RandomGammaTest(test.TestCase):
     np.random.seed(137)
     random_seed.set_random_seed(137)
 
-  def _Sampler(self, num, alpha, beta, dtype, use_gpu, seed=None):
+  def _Sampler(self, num, alpha, beta, dtype, use_gpu=True, seed=None):
 
     def func():
       with self.session(use_gpu=use_gpu, graph=ops.Graph()) as sess:
@@ -90,7 +90,7 @@ class RandomGammaTest(test.TestCase):
           # Gamma moments only defined for values less than the scale param.
           max_moment = min(6, scale // 2)
           sampler = self._Sampler(
-              20000, alpha, 1 / scale, dt, use_gpu=False, seed=12345)
+              20000, alpha, 1 / scale, dt, seed=12345)
           z_scores = util.test_moment_matching(
               sampler(),
               max_moment,
@@ -119,16 +119,15 @@ class RandomGammaTest(test.TestCase):
         dtypes.float64: stats.gamma(alpha).cdf(np.finfo(np.float64).tiny)
     }
     failures = []
-    for use_gpu in [False, True]:
-      for dt in dtypes.float16, dtypes.float32, dtypes.float64:
-        sampler = self._Sampler(
-            10000, alpha, 1.0, dt, use_gpu=use_gpu, seed=12345)
-        x = sampler()
-        allowable = allowable_zeros[dt] * x.size
-        allowable = allowable * 2 if allowable < 10 else allowable * 1.05
-        if np.sum(x <= 0) > allowable:
-          failures += [(use_gpu, dt)]
-      self.assertEqual([], failures)
+    for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+      sampler = self._Sampler(
+          10000, alpha, 1.0, dt, seed=12345)
+      x = sampler()
+      allowable = allowable_zeros[dt] * x.size
+      allowable = allowable * 2 if allowable < 10 else allowable * 1.05
+      if np.sum(x <= 0) > allowable:
+        failures += [dt]
+    self.assertEqual([], failures)
 
   def testNonZeroSmallShape(self):
     self._testZeroDensity(0.01)
@@ -140,23 +139,18 @@ class RandomGammaTest(test.TestCase):
   # to see the same sequence of values. Will catch buggy
   # implementations which uses the same random number seed.
   def testDistinct(self):
-    for use_gpu in [False, True]:
-      for dt in dtypes.float16, dtypes.float32, dtypes.float64:
-        sampler = self._Sampler(1000, 2.0, 1.0, dt, use_gpu=use_gpu)
-        x = sampler()
-        y = sampler()
-        # Number of different samples.
-        count = (x == y).sum()
-        count_limit = 20 if dt == dtypes.float16 else 10
-        if count >= count_limit:
-          print(use_gpu, dt)
-          print("x = ", x)
-          print("y = ", y)
-          print("count = ", count)
-        self.assertLess(count, count_limit)
+    for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+      sampler = self._Sampler(1000, 2.0, 1.0, dt)
+      x = sampler()
+      y = sampler()
+      # Number of different samples.
+      count = (x == y).sum()
+      count_limit = 20 if dt == dtypes.float16 else 10
+      self.assertLess(count, count_limit)
 
   # Checks that the CPU and GPU implementation returns the same results,
   # given the same random seed
+  @test_util.run_deprecated_v1
   def testCPUGPUMatch(self):
     for dt in dtypes.float16, dtypes.float32, dtypes.float64:
       results = {}
@@ -169,11 +163,10 @@ class RandomGammaTest(test.TestCase):
         self.assertAllClose(results[False], results[True], rtol=1e-6, atol=1e-6)
 
   def testSeed(self):
-    for use_gpu in [False, True]:
-      for dt in dtypes.float16, dtypes.float32, dtypes.float64:
-        sx = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=use_gpu, seed=345)
-        sy = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=use_gpu, seed=345)
-        self.assertAllEqual(sx(), sy())
+    for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+      sx = self._Sampler(1000, 0.0, 1.0, dt, seed=345)
+      sy = self._Sampler(1000, 0.0, 1.0, dt, seed=345)
+      self.assertAllEqual(sx(), sy())
 
   @test_util.run_deprecated_v1
   def testNoCSE(self):
@@ -183,12 +176,11 @@ class RandomGammaTest(test.TestCase):
     merged.
     """
     for dtype in dtypes.float16, dtypes.float32, dtypes.float64:
-      for use_gpu in [False, True]:
-        with self.cached_session(use_gpu=use_gpu):
-          rnd1 = random_ops.random_gamma([24], 2.0, dtype=dtype)
-          rnd2 = random_ops.random_gamma([24], 2.0, dtype=dtype)
-          diff = rnd2 - rnd1
-          self.assertGreater(np.linalg.norm(diff.eval()), 0.1)
+      with self.cached_session():
+        rnd1 = random_ops.random_gamma([24], 2.0, dtype=dtype)
+        rnd2 = random_ops.random_gamma([24], 2.0, dtype=dtype)
+        diff = rnd2 - rnd1
+        self.assertGreater(np.linalg.norm(diff.eval()), 0.1)
 
   @test_util.run_deprecated_v1
   def testShape(self):

--- a/tensorflow/python/kernel_tests/spacetodepth_op_test.py
+++ b/tensorflow/python/kernel_tests/spacetodepth_op_test.py
@@ -37,16 +37,12 @@ class SpaceToDepthTest(test.TestCase):
 
   def _testOne(self, inputs, block_size, outputs, dtype=dtypes.float32):
     input_nhwc = math_ops.cast(inputs, dtype)
-    with test_util.force_cpu():
-      # test NHWC (default) on CPU
-      x_tf = array_ops.space_to_depth(input_nhwc, block_size)
-      self.assertAllEqual(self.evaluate(x_tf), outputs)
+    # test NHWC (default)
+    x_tf = array_ops.space_to_depth(input_nhwc, block_size)
+    self.assertAllEqual(self.evaluate(x_tf), outputs)
 
     if test_util.is_gpu_available():
       with test_util.force_gpu():
-        # test NHWC (default) on GPU
-        x_tf = array_ops.space_to_depth(input_nhwc, block_size)
-        self.assertAllEqual(self.evaluate(x_tf), outputs)
         # test NCHW on GPU
         input_nchw = test_util.NHWCToNCHW(input_nhwc)
         output_nchw = array_ops.space_to_depth(
@@ -133,21 +129,9 @@ class SpaceToDepthTest(test.TestCase):
   def testBatchSize0(self):
     block_size = 2
     batch_size = 0
-    input_nhwc = array_ops.ones([batch_size, 4, 6, 3])
+    x_np = array_ops.ones([batch_size, 4, 6, 3])
     x_out = array_ops.ones([batch_size, 2, 3, 12])
-
-    with test_util.force_cpu():
-      # test NHWC (default) on CPU
-      x_tf = array_ops.space_to_depth(input_nhwc, block_size)
-      self.assertAllEqual(x_tf.shape, x_out.shape)
-      self.evaluate(x_tf)
-
-    if test.is_gpu_available():
-      with test_util.use_gpu():
-        # test NHWC (default) on GPU
-        x_tf = array_ops.space_to_depth(input_nhwc, block_size)
-        self.assertAllEqual(x_tf.shape, x_out.shape)
-        self.evaluate(x_tf)
+    self._testOne(x_np, block_size, x_out)
 
   # Tests for different width and height.
   def testNonSquare(self):


### PR DESCRIPTION
Fix random gamma tests to use deprecated v1 graph mode so
that test is executed in both CPU and accelerator because in eager
mode, same device will be be only selected irrespective of use_gpu
flag. Remove loop of use_gpu where not required.
Space to depth testBatchSize0 verification fixed with common
code.

Signed-off-by: puneeshkhanna <puneesh.khanna83@gmail.com>