### PR TITLE
Adds header for TFE_OpSetAttrValueProto

### DIFF
--- a/tensorflow/c/eager/c_api.h
+++ b/tensorflow/c/eager/c_api.h
@@ -365,6 +365,12 @@ TF_CAPI_EXPORT extern void TFE_OpSetAttrFunctionList(TFE_Op* op,
                                                      const TFE_Op** value,
                                                      int num_values);
 
+TF_CAPI_EXPORT extern void TFE_OpSetAttrValueProto(const TFE_Op* op,
+                                                   const char* attr_name,
+                                                   const void* proto,
+                                                   size_t proto_len,
+                                                   TF_Status* status);
+
 // Returns the length (number of tensors) of the input argument `input_name`
 // found in the provided `op`.
 TF_CAPI_EXPORT extern int TFE_OpGetInputLength(TFE_Op* op,


### PR DESCRIPTION
`TFE_OpSetAttrValueProto` was added to the C api, but no header was added for it.  This fixes that.

This would be nice to have in 2.6 if possible (for SIG JVM), I'm not sure what the criteria are for that.  It is kind of a bug fix.