### PR TITLE
Add default value in `Attention` layer docs

### DIFF
--- a/tensorflow/python/keras/layers/dense_attention.py
+++ b/tensorflow/python/keras/layers/dense_attention.py
@@ -239,8 +239,9 @@ class Attention(BaseDenseAttention):
     causal: Boolean. Set to `True` for decoder self-attention. Adds a mask such
       that position `i` cannot attend to positions `j > i`. This prevents the
       flow of information from the future towards the past.
+      Defaults to `False`.
     dropout: Float between 0 and 1. Fraction of the units to drop for the
-      attention scores.
+      attention scores. Defaults to 0.0.
 
   Call Args:
 
@@ -378,8 +379,9 @@ class AdditiveAttention(BaseDenseAttention):
     causal: Boolean. Set to `True` for decoder self-attention. Adds a mask such
       that position `i` cannot attend to positions `j > i`. This prevents the
       flow of information from the future towards the past.
+      Defaults to `False`.
     dropout: Float between 0 and 1. Fraction of the units to drop for the
-      attention scores.
+      attention scores. Defaults to 0.0.
 
   Call Args:
 


### PR DESCRIPTION
In https://www.tensorflow.org/api_docs/python/tf/keras/layers/Attention, default values of `causal` and `dropout` are not specified and a user have to look up in the source code.

I added default values to this document in this pull request.