### PR TITLE
fix cropping layer return empty list if crop is higher than data shap…

### DIFF
--- a/tensorflow/python/keras/layers/convolutional.py
+++ b/tensorflow/python/keras/layers/convolutional.py
@@ -3098,6 +3098,12 @@ class Cropping1D(Layer):
     return tensor_shape.TensorShape([input_shape[0], length, input_shape[2]])
 
   def call(self, inputs):
+    if sum(self.cropping) >= inputs.shape[1]:
+      raise ValueError(
+        'cropping parameter of Cropping layer is too high,' +
+        'the result of crop' + str(inputs.shape) + ' with cropping ' +
+        str(self.cropping) + ' is an empty tensor'
+      )
     if self.cropping[1] == 0:
       return inputs[:, self.cropping[0]:, :]
     else:


### PR DESCRIPTION
initialy the PR was in #50612 but the Tensorflow/Keras policy changed. Now is #14958

I do a first try to solve this issue. I think we can do a prototype with `Cropping1D` and after when everything is perfect, copy the same pattern to `Cropping2D`, `Cropping3D`, etc.

Pls, give me your thoughts. @ymodak