### PR TITLE
[CherryPick2.6]Ensure non-empty compressed input in tf.raw_ops.UncompressElement

### DIFF
--- a/tensorflow/core/kernels/data/experimental/compression_ops.cc
+++ b/tensorflow/core/kernels/data/experimental/compression_ops.cc
@@ -48,6 +48,11 @@ void UncompressElementOp::Compute(OpKernelContext* ctx) {
   Tensor tensor = ctx->input(0);
   const Variant& variant = tensor.scalar<Variant>()();
   const CompressedElement* compressed = variant.get<CompressedElement>();
+  OP_REQUIRES(
+      ctx, compressed != nullptr,
+      errors::InvalidArgument(
+          "Input does not contain a compressed element. Instead got tensor ",
+          tensor.DebugString()));
 
   std::vector<Tensor> components;
   OP_REQUIRES_OK(ctx, UncompressElement(*compressed, &components));


### PR DESCRIPTION
PiperOrigin-RevId: 383955815
Change-Id: I072a84fd02738dd2f51b3f42836ed80067dba4a8