### PR TITLE
Fix numerical stability issue in binary search

### DIFF
--- a/tensorflow/core/lib/io/block.cc
+++ b/tensorflow/core/lib/io/block.cc
@@ -154,7 +154,7 @@ class Block::Iter : public Iterator {
     uint32 left = 0;
     uint32 right = num_restarts_ - 1;
     while (left < right) {
-      uint32 mid = (left + right + 1) / 2;
+      uint32 mid = left + (right - left + 1) / 2;
       uint32 region_offset = GetRestartPoint(mid);
       uint32 shared, non_shared, value_length;
       const char* key_ptr =


### PR DESCRIPTION
Binary search algorithm implementation can result in an overflow caused by a variable that holds the index of the middle element of the input array. If the number of elements is very large, the operation left + right for calculating the middle index has a risk of overflow. Please refer the following link for more information: https://en.wikipedia.org/wiki/Binary_search_algorithm#Implementation_issues.
mid = left + (right - left + 1)/2 is mathematically equivalent to mid = (left + right +1)/2, but more numerically stable.
mid = left + (right - left + 1)/2 = left + right/2 - left/2 + ½ = left/2 + right/2 + ½ = (left + right +1)/2.
This fix follows the implementation in PyTorch.