### PR TITLE
Allow use of non-system compiler to build mlir_generated tests

### DIFF
--- a/tensorflow/core/kernels/mlir_generated/build_defs.bzl
+++ b/tensorflow/core/kernels/mlir_generated/build_defs.bzl
@@ -162,6 +162,7 @@ def _gen_kernel_bin_impl(ctx):
             "--cpu_codegen=%s" % ctx.attr.cpu_codegen,
         ],
         mnemonic = "compile",
+	use_default_shell_env = True,
     )
     compilation_outputs = cc_common.create_compilation_outputs(
         # We always produce PIC object files, so use the same object files for both.


### PR DESCRIPTION
Allow setting of LD_LIBRARY_PATH to reach execution environment of tf_to_kernel so it can load correct version of libstdc++ and so avoid build failure when built with non-system gcc
Fixes #50873 