### PR TITLE
Backport 'Make element_shape_except_first_dim as a local variable instead of in…' to r2.4

### DIFF
--- a/tensorflow/core/kernels/list_kernels.h
+++ b/tensorflow/core/kernels/list_kernels.h
@@ -282,16 +282,16 @@ class TensorListConcat : public OpKernel {
   explicit TensorListConcat(OpKernelConstruction* c) : OpKernel(c) {
     OP_REQUIRES_OK(c, c->GetAttr("element_dtype", &element_dtype_));
     if (c->HasAttr("element_shape")) {
-      PartialTensorShape element_shape;
-      OP_REQUIRES_OK(c, c->GetAttr("element_shape", &element_shape));
-      if (!element_shape.unknown_rank()) {
-        element_shape_except_first_dim_ = PartialTensorShape(
-            gtl::ArraySlice<int64>(element_shape.dim_sizes()).subspan(1));
-      }
+      OP_REQUIRES_OK(c, c->GetAttr("element_shape", &element_shape_));
     }
   }
 
   void Compute(OpKernelContext* c) override {
+    PartialTensorShape element_shape_except_first_dim;
+    if (!element_shape_.unknown_rank()) {
+      element_shape_except_first_dim = PartialTensorShape(
+          gtl::ArraySlice<int64>(element_shape_.dim_sizes()).subspan(1));
+    }
     // Check that the input Variant tensor is indeed a TensorList and has the
     // correct element type.
     const TensorList* tensor_list = nullptr;
@@ -315,21 +315,21 @@ class TensorListConcat : public OpKernel {
                       "Concat requires elements to be at least vectors, ",
                       "found scalars instead."));
       // Split `element_shape` into `first_dim` and
-      // `element_shape_except_first_dim_`.
+      // `element_shape_except_first_dim`.
       first_dim = element_shape.dim_size(0);
-      element_shape_except_first_dim_ = element_shape;
-      element_shape_except_first_dim_.RemoveDim(0);
+      element_shape_except_first_dim = element_shape;
+      element_shape_except_first_dim.RemoveDim(0);
     }
-    // If the TensorList is empty, element_shape_except_first_dim_ must be fully
+    // If the TensorList is empty, element_shape_except_first_dim must be fully
     // defined.
     OP_REQUIRES(c,
                 !tensor_list->tensors().empty() ||
-                    element_shape_except_first_dim_.IsFullyDefined(),
+                    element_shape_except_first_dim.IsFullyDefined(),
                 errors::InvalidArgument(
                     "All except the first dimension must be fully defined ",
                     "when concating an empty tensor list. element_shape: ",
-                    element_shape_except_first_dim_.DebugString()));
-    // 1. Check that `element_shape_except_first_dim_` input tensor is
+                    element_shape_except_first_dim.DebugString()));
+    // 1. Check that `element_shape_except_first_dim` input tensor is
     //    compatible with the shapes of element tensors.
     // 2. Check that the elements have the same shape except the first dim.
     // 3. If `first_dim` is known, check that it is compatible with the leading
@@ -343,7 +343,7 @@ class TensorListConcat : public OpKernel {
       for (int i = 0; i < tensor_list->tensors().size(); ++i) {
         const Tensor& t = tensor_list->tensors()[i];
         if (t.dtype() != DT_INVALID) {
-          PartialTensorShape tmp = element_shape_except_first_dim_;
+          PartialTensorShape tmp = element_shape_except_first_dim;
           OP_REQUIRES(
               c, TensorShapeUtils::IsVectorOrHigher(t.shape()),
               errors::InvalidArgument("Concat saw a scalar shape at index ", i,
@@ -351,7 +351,7 @@ class TensorListConcat : public OpKernel {
           TensorShape shape_except_first_dim = TensorShape(
               gtl::ArraySlice<int64>(t.shape().dim_sizes()).subspan(1));
           OP_REQUIRES_OK(c, tmp.MergeWith(shape_except_first_dim,
-                                          &element_shape_except_first_dim_));
+                                          &element_shape_except_first_dim));
           OP_REQUIRES(c, first_dim == -1 || first_dim == t.shape().dim_size(0),
                       errors::InvalidArgument(
                           "First entry of element_shape input does not match ",
@@ -371,12 +371,11 @@ class TensorListConcat : public OpKernel {
       first_dim = inferred_first_dim;
     }
     TensorShape output_shape;
-    OP_REQUIRES(
-        c, element_shape_except_first_dim_.AsTensorShape(&output_shape),
-        errors::InvalidArgument(
-            "Trying to concat list with only uninitialized tensors ",
-            "but element_shape_except_first_dim_ is not fully defined: ",
-            element_shape_except_first_dim_.DebugString()));
+    OP_REQUIRES(c, element_shape_except_first_dim.AsTensorShape(&output_shape),
+                errors::InvalidArgument(
+                    "Trying to concat list with only uninitialized tensors ",
+                    "but element_shape_except_first_dim is not fully defined: ",
+                    element_shape_except_first_dim.DebugString()));
     // Build the lengths_tensor and leading dim of the output tensor by
     // iterating over all element tensors.
     Tensor* lengths_tensor = nullptr;
@@ -467,7 +466,7 @@ class TensorListConcat : public OpKernel {
 
  private:
   DataType element_dtype_;
-  PartialTensorShape element_shape_except_first_dim_;
+  PartialTensorShape element_shape_;
 };
 
 template <typename Device, typename T>

--- a/tensorflow/python/kernel_tests/list_ops_test.py
+++ b/tensorflow/python/kernel_tests/list_ops_test.py
@@ -1425,7 +1425,7 @@ class ListOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     with self.assertRaisesRegex(
         errors.InvalidArgumentError,
         r"Trying to concat list with only uninitialized tensors "
-        r"but element_shape_except_first_dim_ is not fully defined"):
+        r"but element_shape_except_first_dim is not fully defined"):
       t = list_ops.tensor_list_concat(l, element_dtype=dtypes.float32)
       self.evaluate(t)
 

--- a/tensorflow/python/kernel_tests/tensor_array_ops_test.py
+++ b/tensorflow/python/kernel_tests/tensor_array_ops_test.py
@@ -147,6 +147,47 @@ class TensorArrayTest(test.TestCase):
       c0 = self.evaluate(c0)
       self.assertAllEqual([3, 0, 1], c0.shape)
 
+  def testTensorArrayWriteConcatInParallel(self):
+    with self.session(use_gpu=True):
+
+      def _concat_1():
+        ta = tensor_array_ops.TensorArray(
+            dtype=dtypes.int32, size=2, infer_shape=False)
+        w0 = ta.write(0, constant_op.constant([1]))
+        w1 = w0.write(1, constant_op.constant([],
+                                              shape=(0,),
+                                              dtype=dtypes.int32))
+        return w1.concat()
+
+      def _concat_2():
+        ta = tensor_array_ops.TensorArray(
+            dtype=dtypes.int32, size=3, infer_shape=False)
+        w0 = ta.write(0, constant_op.constant([8]))
+        w1 = w0.write(1, constant_op.constant([],
+                                              shape=(0,),
+                                              dtype=dtypes.int32))
+        w2 = w1.write(2, constant_op.constant([9]))
+        return w2.concat()
+
+      def _write(index, output):
+        elements = control_flow_ops.cond(
+            math_ops.less(index, 3), _concat_1, _concat_2)
+        return (index + 1, output.write(index, elements))
+
+      num_iterations = 6
+      init_state = (0,
+                    tensor_array_ops.TensorArray(
+                        dtype=dtypes.int32,
+                        size=num_iterations,
+                        infer_shape=False))
+      _, final_state = control_flow_ops.while_loop(
+          lambda i, _: i < num_iterations, _write, init_state)
+
+      c0 = final_state.concat()
+
+      c0 = self.evaluate(c0)
+      self.assertAllEqual([1, 1, 1, 8, 9, 8, 9, 8, 9], c0)
+
   def _testTensorArrayWriteConcat(self, tf_dtype):
     with self.cached_session(use_gpu=True):
       ta = tensor_array_ops.TensorArray(


### PR DESCRIPTION
Commit 603d88d fixes a data race bug in TensorListConcat op, which is incoporated into v2.5.0 and later versions, but not backported to 2.4.x versions. This PR is directly performed using

`git cherry-pick 603d88d72c1f739cc46fb250edfc9924d9517b17`