### PR TITLE
2.6rc2 cherry-pick request: Fix issue where disabling TensorFloat-32 had no effect.

### DIFF
--- a/tensorflow/core/common_runtime/pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/pluggable_device/BUILD
@@ -53,7 +53,6 @@ cc_library(
         "//tensorflow/core:protos_all_cc",
         "//tensorflow/core/common_runtime/device:device_event_mgr",
         "//tensorflow/core/platform:stream_executor",
-        "//tensorflow/core/platform:tensor_float_32_utils",
         "//tensorflow/stream_executor:event",
         "//tensorflow/stream_executor:kernel",
     ],


### PR DESCRIPTION
This fixes a bug where disabling TensorFloat-32 with `tf.config.experimental.enable_tensor_float_32_execution(False)` had no effect.