### PR TITLE
Enable '--distinct_host_configuration' for arm builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -542,8 +542,10 @@ build:elinux --crosstool_top=@local_config_embedded_arm//:toolchain
 build:elinux --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
 build:elinux_aarch64 --config=elinux
 build:elinux_aarch64 --cpu=aarch64
+build:elinux_aarch64 --distinct_host_configuration=true
 build:elinux_armhf --config=elinux
 build:elinux_armhf --cpu=armhf
+build:elinux_armhf --distinct_host_configuration=true
 # END TF REMOTE BUILD EXECUTION OPTIONS
 
 # Config-specific options should come above this line.


### PR DESCRIPTION
This option is needed to cross compilation

PiperOrigin-RevId: 383284957
Change-Id: Ic49c3807c050ea5c71c31995e5a38ae6f06044a8