### PR TITLE
Added Python 3.9 support for "Building TensorFlow Lite Standalone Pip"

### DIFF
--- a/tensorflow/lite/tools/pip_package/README.md
+++ b/tensorflow/lite/tools/pip_package/README.md
@@ -97,6 +97,13 @@ tensorflow/tools/ci_build/ci_build.sh PI-PYTHON38 \
   tensorflow/lite/tools/pip_package/build_pip_package_with_bazel.sh aarch64
 ```
 
+### Cross build for aarch64 Python 3.9
+
+```sh
+tensorflow/tools/ci_build/ci_build.sh PI-PYTHON39 \
+  tensorflow/lite/tools/pip_package/build_pip_package_with_bazel.sh aarch64
+```
+
 ### Native build for Windows
 
 ```sh

--- a/tensorflow/tools/ci_build/Dockerfile.pi-python39
+++ b/tensorflow/tools/ci_build/Dockerfile.pi-python39
@@ -1,0 +1,29 @@
+FROM ubuntu:16.04
+
+LABEL maintainer="Katsuya Hyodo <rmsdh122@yahoo.co.jp>"
+
+ENV CI_BUILD_PYTHON=python3.9
+ENV CROSSTOOL_PYTHON_INCLUDE_PATH=/usr/include/python3.9
+
+# Copy and run the install scripts.
+COPY install/*.sh /install/
+RUN /install/install_bootstrap_deb_packages.sh
+RUN add-apt-repository -y ppa:openjdk-r/ppa
+RUN /install/install_deb_packages.sh --without_cmake
+RUN /install/install_cmake.sh
+
+# The following line installs the Python 3.9 cross-compilation toolchain.
+RUN /install/install_pi_python3x_toolchain.sh "3.9"
+
+RUN /install/install_bazel.sh
+RUN /install/install_proto3.sh
+RUN /install/install_buildifier.sh
+RUN /install/install_auditwheel.sh
+RUN /install/install_golang.sh
+
+# Set up the master bazelrc configuration file.
+COPY install/.bazelrc /etc/bazel.bazelrc
+RUN chmod 644 /etc/bazel.bazelrc
+
+# XLA is not needed for PI
+ENV TF_ENABLE_XLA=0

--- a/tensorflow/tools/ci_build/install/install_pi_python3x_toolchain.sh
+++ b/tensorflow/tools/ci_build/install/install_pi_python3x_toolchain.sh
@@ -30,7 +30,8 @@ ln -sf /usr/bin/python${PYTHON_VERSION} /usr/local/bin/python${PYTHON_VERSION}
 apt-get install -y libpython${PYTHON_VERSION}-dev:armhf
 apt-get install -y libpython${PYTHON_VERSION}-dev:arm64
 
-if [[ "${PYTHON_VERSION}" == "3.8" ]]; then
+SPLIT_VERSION=(`echo ${PYTHON_VERSION} | tr -s '.' ' '`)
+if [[ SPLIT_VERSION[0] -eq 3 ]] && [[ SPLIT_VERSION[1] -ge 8 ]]; then
   apt-get install -y python${PYTHON_VERSION}-distutils
 fi
 


### PR DESCRIPTION
Add support for Python 3.9 to the Standalone Pip build of TensorFlow Lite by Bazel.