### PR TITLE
Fix unchecked int32 indexing in some GPU kernels

### DIFF
--- a/tensorflow/core/framework/tensor_types.h
+++ b/tensorflow/core/framework/tensor_types.h
@@ -174,12 +174,12 @@ struct MaybeWith32BitIndexingImpl<Eigen::GpuDevice> {
   template <typename Func, typename... Args>
   void operator()(Func func, Args&&... args) const {
     auto all = [](const auto&... bool_vals) {
-      bool result = true;
-      int unpack[] = {0, (result = result && bool_vals, 0)...};
-      (void)unpack;
-      return result;
+      for (bool b : {bool_vals...}) {
+        if (!b) return false;
+      }
+      return true;
     };
-    if (all((SafeFor32BitIndexing(std::forward<Args>(args)))...)) {
+    if (all(SafeFor32BitIndexing(std::forward<Args>(args))...)) {
       func(To32Bit(std::forward<Args>(args))...);
     } else {
       func(std::forward<Args>(args)...);

--- a/tensorflow/core/framework/tensor_types.h
+++ b/tensorflow/core/framework/tensor_types.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_FRAMEWORK_TENSOR_TYPES_H_
 #define TENSORFLOW_CORE_FRAMEWORK_TENSOR_TYPES_H_
 
+#include "tensorflow/core/platform/default/logging.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
@@ -104,11 +105,46 @@ struct TTypes {
 
 typedef typename TTypes<float, 1>::Tensor32Bit::Index Index32;
 
-template <typename DSizes>
-Eigen::DSizes<Index32, DSizes::count> To32BitDims(const DSizes& in) {
-  Eigen::DSizes<Index32, DSizes::count> out;
-  for (int i = 0; i < DSizes::count; ++i) {
-    out[i] = in[i];
+template <typename Index, int NumDims>
+bool SafeFor32BitIndexing(const Eigen::DSizes<Index, NumDims>& in) {
+  for (int i = 0; i < NumDims; ++i) {
+    if (in[i] > std::numeric_limits<Index32>::max()) return false;
+  }
+  return true;
+}
+
+template <typename Index, size_t NumDims>
+bool SafeFor32BitIndexing(const Eigen::array<Index, NumDims>& in) {
+  for (int i = 0; i < (int)NumDims; ++i) {
+    if (in[i] > std::numeric_limits<Index32>::max()) return false;
+  }
+  return true;
+}
+
+template <typename TensorType,
+          typename Enable = typename TTypes<
+              typename TensorType::Scalar, TensorType::NumIndices>::Tensor32Bit>
+bool SafeFor32BitIndexing(TensorType in) {
+  return in.size() <= std::numeric_limits<Index32>::max();
+}
+
+template <typename Index, int NumDims>
+Eigen::DSizes<Index32, NumDims> To32Bit(
+    const Eigen::DSizes<Index, NumDims>& in) {
+  DCHECK(SafeFor32BitIndexing(in));
+  Eigen::DSizes<Index32, NumDims> out;
+  for (int i = 0; i < NumDims; ++i) {
+    out[i] = static_cast<Index32>(in[i]);
+  }
+  return out;
+}
+
+template <typename Index, size_t NumDims>
+Eigen::array<Index32, NumDims> To32Bit(const Eigen::array<Index, NumDims>& in) {
+  DCHECK(SafeFor32BitIndexing(in));
+  Eigen::array<Index32, NumDims> out;
+  for (int i = 0; i < (int)NumDims; ++i) {
+    out[i] = static_cast<Index32>(in[i]);
   }
   return out;
 }
@@ -119,7 +155,44 @@ typename TTypes<typename TensorType::Scalar,
 To32Bit(TensorType in) {
   typedef typename TTypes<typename TensorType::Scalar,
                           TensorType::NumIndices>::Tensor32Bit RetType;
-  return RetType(in.data(), To32BitDims(in.dimensions()));
+  DCHECK(SafeFor32BitIndexing(in));
+  return RetType(in.data(), To32Bit(in.dimensions()));
+}
+
+namespace internal {
+
+template <typename Device>
+struct MaybeWith32BitIndexingImpl {
+  template <typename Func, typename... Args>
+  void operator()(Func func, Args&&... args) const {
+    func(std::forward<Args>(args)...);
+  }
+};
+
+template <>
+struct MaybeWith32BitIndexingImpl<Eigen::GpuDevice> {
+  template <typename Func, typename... Args>
+  void operator()(Func func, Args&&... args) const {
+    auto all = [](const auto&... bool_vals) {
+      bool result = true;
+      int unpack[] = {0, (result = result && bool_vals, 0)...};
+      (void)unpack;
+      return result;
+    };
+    if (all((SafeFor32BitIndexing(std::forward<Args>(args)))...)) {
+      func(To32Bit(std::forward<Args>(args))...);
+    } else {
+      func(std::forward<Args>(args)...);
+    }
+  }
+};
+
+}  // namespace internal
+
+template <typename Device, typename Func, typename... Args>
+void MaybeWith32BitIndexing(Func func, Args&&... args) {
+  return internal::MaybeWith32BitIndexingImpl<Device>()(
+      func, std::forward<Args>(args)...);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/broadcast_to_op.h
+++ b/tensorflow/core/kernels/broadcast_to_op.h
@@ -32,37 +32,24 @@ namespace functor {
 template <typename Device, typename T>
 struct BroadcastTo {
   template <int NDIMS>
-  void DoBCast32Bit(const Device &device, typename TTypes<T, NDIMS>::Tensor out,
-                    typename TTypes<T, NDIMS>::ConstTensor in,
-                    const typename Eigen::array<int, NDIMS> &bcast) const {
-    To32Bit(out).device(device) = To32Bit(in).broadcast(bcast);
-  }
-
-  template <int NDIMS>
   void DoBCast(
       const Device &device, typename TTypes<T, NDIMS>::Tensor out,
       typename TTypes<T, NDIMS>::ConstTensor in,
       const typename Eigen::array<Eigen::DenseIndex, NDIMS> &bcast) const {
-    out.device(device) = in.broadcast(bcast);
+    MaybeWith32BitIndexing<Device>(
+        [&](auto out32, auto in32, const auto& bcast32) {
+          out32.device(device) = in32.broadcast(bcast32);
+        },
+        out, in, bcast);
   }
 
   template <int NDIMS>
   void ReshapeAndBCast(const Device &device, Tensor &output_tensor,
                        const Tensor &input_tensor, const BCast &bcast) const {
-    const bool can_use_32bit = std::is_same<Eigen::GpuDevice, Device>::value &&
-                               output_tensor.NumElements() < kint32max &&
-                               input_tensor.NumElements() < kint32max;
-    if (can_use_32bit) {
-      DoBCast32Bit<NDIMS>(
-          device, output_tensor.template shaped<T, NDIMS>(bcast.result_shape()),
-          input_tensor.template shaped<T, NDIMS>(bcast.x_reshape()),
-          BCast::ToIndexArrayType<int, NDIMS>(bcast.x_bcast()));
-    } else {
-      DoBCast<NDIMS>(
-          device, output_tensor.template shaped<T, NDIMS>(bcast.result_shape()),
-          input_tensor.template shaped<T, NDIMS>(bcast.x_reshape()),
-          BCast::ToIndexArrayType<Eigen::DenseIndex, NDIMS>(bcast.x_bcast()));
-    }
+    DoBCast<NDIMS>(
+        device, output_tensor.template shaped<T, NDIMS>(bcast.result_shape()),
+        input_tensor.template shaped<T, NDIMS>(bcast.x_reshape()),
+        BCast::ToIndexArrayType<Eigen::DenseIndex, NDIMS>(bcast.x_bcast()));
   }
 
   // PRECONDITION: rank(input_shape) > 0 &&

--- a/tensorflow/core/kernels/constant_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/constant_op_gpu.cu.cc
@@ -72,7 +72,8 @@ struct FillFunctor<GPUDevice, T> {
   void operator()(const GPUDevice& d, typename TTypes<T>::Flat out,
                   typename TTypes<T>::ConstScalar in) {
     Eigen::internal::scalar_const_op<T> f(in.data());
-    To32Bit(out).device(d) = To32Bit(out).nullaryExpr(f);
+    MaybeWith32BitIndexing<GPUDevice>(
+        [&](auto out32) { out32.device(d) = out32.nullaryExpr(f); }, out);
   }
 };
 
@@ -85,7 +86,8 @@ TF_CALL_bool(DEFINE_FILL_GPU);
 template <typename T>
 struct SetZeroFunctor<GPUDevice, T> {
   void operator()(const GPUDevice& d, typename TTypes<T>::Flat out) {
-    To32Bit(out).device(d) = To32Bit(out).constant(T(0));
+    MaybeWith32BitIndexing<GPUDevice>(
+        [&](auto out32) { out32.device(d) = out32.constant(T(0)); }, out);
   }
 };
 
@@ -106,7 +108,8 @@ TF_CALL_COMPLEX_TYPES(DEFINE_SETZERO_GPU);
 template <typename T>
 struct SetOneFunctor<GPUDevice, T> {
   void operator()(const GPUDevice& d, typename TTypes<T>::Flat out) {
-    To32Bit(out).device(d) = To32Bit(out).constant(T(1));
+    MaybeWith32BitIndexing<GPUDevice>(
+        [&](auto out32) { out32.device(d) = out32.constant(T(1)); }, out);
   }
 };
 

--- a/tensorflow/core/kernels/cwise_ops_gpu_gradients.cu.h
+++ b/tensorflow/core/kernels/cwise_ops_gpu_gradients.cu.h
@@ -43,8 +43,11 @@ struct SimpleBinaryFunctor<GPUDevice, Functor> {
   void operator()(const GPUDevice& d, typename Functor::tout_type out,
                   typename Functor::tin_type in1,
                   typename Functor::tin_type in2) {
-    To32Bit(out).device(d) =
-        To32Bit(in1).binaryExpr(in2, typename Functor::func());
+    MaybeWith32BitIndexing<GPUDevice>(
+        [&](auto out32, auto in1_32) {
+          out32.device(d) = in1_32.binaryExpr(in2, typename Functor::func());
+        },
+        out, in1);
   }
 };
 

--- a/tensorflow/core/kernels/fill_functor.cu.cc
+++ b/tensorflow/core/kernels/fill_functor.cu.cc
@@ -72,7 +72,8 @@ struct FillFunctor<GPUDevice, T> {
   void operator()(const GPUDevice& d, typename TTypes<T>::Flat out,
                   typename TTypes<T>::ConstScalar in) {
     Eigen::internal::scalar_const_op<T> f(in.data());
-    To32Bit(out).device(d) = To32Bit(out).nullaryExpr(f);
+    MaybeWith32BitIndexing<GPUDevice>(
+        [&](auto out32) { out32.device(d) = out32.nullaryExpr(f); }, out);
   }
 };
 
@@ -85,7 +86,8 @@ TF_CALL_bool(DEFINE_FILL_GPU);
 template <typename T>
 struct SetZeroFunctor<GPUDevice, T> {
   void operator()(const GPUDevice& d, typename TTypes<T>::Flat out) {
-    To32Bit(out).device(d) = To32Bit(out).constant(T(0));
+    MaybeWith32BitIndexing<GPUDevice>(
+        [&](auto out32) { out32.device(d) = out32.constant(T(0)); }, out);
   }
 };
 
@@ -105,7 +107,8 @@ TF_CALL_variant(DEFINE_SETZERO_GPU);
 template <typename T>
 struct SetOneFunctor<GPUDevice, T> {
   void operator()(const GPUDevice& d, typename TTypes<T>::Flat out) {
-    To32Bit(out).device(d) = To32Bit(out).constant(T(1));
+    MaybeWith32BitIndexing<GPUDevice>(
+        [&](auto out32) { out32.device(d) = out32.constant(T(1)); }, out);
   }
 };
 
@@ -118,8 +121,11 @@ TF_CALL_bool(DEFINE_SETONE_GPU);
 template <typename T>
 struct SetNanFunctor<GPUDevice, T> {
   void operator()(const GPUDevice& d, typename TTypes<T>::Flat out) {
-    To32Bit(out).device(d) =
-        To32Bit(out).constant(Eigen::NumTraits<T>::quiet_NaN());
+    MaybeWith32BitIndexing<GPUDevice>(
+        [&](auto out32) {
+          out32.device(d) = out32.constant(Eigen::NumTraits<T>::quiet_NaN());
+        },
+        out);
   }
 };
 

--- a/tensorflow/core/kernels/image/extract_volume_patches_op.h
+++ b/tensorflow/core/kernels/image/extract_volume_patches_op.h
@@ -31,23 +31,16 @@ struct ExtractVolumePatchesForward {
                   /* int rate_planes, int rate_rows, int rate_cols, */
                   const Eigen::PaddingType& padding,
                   typename TTypes<T, 5>::Tensor output) {
-    const int64_t N = std::max(input.size(), output.size());
-    if (N <= std::numeric_limits<Index32>::max()) {
-      auto output_32bit = To32Bit(output);
-      output_32bit.device(d) =
-          To32Bit(input)
-              .extract_volume_patches(patch_cols, patch_rows, patch_planes,
-                                      stride_cols, stride_rows, stride_planes,
-                                      padding)
-              .reshape(output_32bit.dimensions());
-    } else {
-      output.device(d) =
-          input
-              .extract_volume_patches(patch_cols, patch_rows, patch_planes,
-                                      stride_cols, stride_rows, stride_planes,
-                                      padding)
-              .reshape(output.dimensions());
-    }
+    MaybeWith32BitIndexing<Device>(
+        [&](auto input32, auto output32) {
+          output32.device(d) =
+              input32
+                  .extract_volume_patches(patch_cols, patch_rows, patch_planes,
+                                          stride_cols, stride_rows,
+                                          stride_planes, padding)
+                  .reshape(output32.dimensions());
+        },
+        input, output);
   }
 };
 

--- a/tensorflow/core/kernels/pad_op.h
+++ b/tensorflow/core/kernels/pad_op.h
@@ -33,12 +33,11 @@ struct Pad {
                   typename TTypes<T, Dims>::ConstTensor input,
                   Eigen::array<Eigen::IndexPair<Tpadding>, Dims> paddings,
                   T pad_value) {
-    if (Eigen::internal::is_same<Device, Eigen::GpuDevice>::value &&
-        (output.size() <= std::numeric_limits<int32>::max())) {
-      To32Bit(output).device(d) = To32Bit(input).pad(paddings, pad_value);
-    } else {
-      output.device(d) = input.pad(paddings, pad_value);
-    }
+    MaybeWith32BitIndexing<Device>(
+        [&](auto output32, auto input32) {
+          output32.device(d) = input32.pad(paddings, pad_value);
+        },
+        output, input);
   }
 };
 

--- a/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
+++ b/tensorflow/core/kernels/reduction_gpu_kernels.cu.h
@@ -1131,7 +1131,7 @@ struct ReduceFunctor<GPUDevice, Eigen::internal::SumReducer<T>> {
   template <typename OUT_T>
   static void FillIdentity(const GPUDevice& d, OUT_T out,
                            const Eigen::internal::SumReducer<T>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImpl(d, out, reducer);
   }
 };
 
@@ -1156,7 +1156,7 @@ struct ReduceFunctor<GPUDevice, functor::EuclideanNormReducer<T>> {
   template <typename OUT_T>
   static void FillIdentity(const GPUDevice& d, OUT_T out,
                            const functor::EuclideanNormReducer<T>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImpl(d, out, reducer);
   }
 };
 
@@ -1192,7 +1192,7 @@ struct ReduceFunctor<GPUDevice, functor::MeanReducer<T>> {
   template <typename OUT_T>
   static void FillIdentity(const GPUDevice& d, OUT_T out,
                            const functor::MeanReducer<T>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImpl(d, out, reducer);
   }
 };
 
@@ -1235,7 +1235,7 @@ struct ReduceFunctor<GPUDevice, functor::MeanReducer<Eigen::half>> {
   template <typename OUT_T>
   static void FillIdentity(const GPUDevice& d, OUT_T out,
                            const functor::MeanReducer<Eigen::half>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImpl(d, out, reducer);
   }
 };
 
@@ -1258,7 +1258,7 @@ struct ReduceFunctor<GPUDevice,
   static void FillIdentity(
       const GPUDevice& d, OUT_T out,
       const Eigen::internal::MaxReducer<T, Eigen::PropagateNaN>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImpl(d, out, reducer);
   }
 };
 
@@ -1281,7 +1281,7 @@ struct ReduceFunctor<GPUDevice,
   static void FillIdentity(
       const GPUDevice& d, OUT_T out,
       const Eigen::internal::MinReducer<T, Eigen::PropagateNaN>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImpl(d, out, reducer);
   }
 };
 
@@ -1301,7 +1301,7 @@ struct ReduceFunctor<GPUDevice, Eigen::internal::ProdReducer<T>> {
   template <typename OUT_T>
   static void FillIdentity(const GPUDevice& d, OUT_T out,
                            const Eigen::internal::ProdReducer<T>& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImpl(d, out, reducer);
   }
 };
 
@@ -1321,7 +1321,7 @@ struct ReduceFunctor<GPUDevice, Eigen::internal::AndReducer> {
   template <typename OUT_T>
   static void FillIdentity(const GPUDevice& d, OUT_T out,
                            const Eigen::internal::AndReducer& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImpl(d, out, reducer);
   }
 };
 
@@ -1340,7 +1340,7 @@ struct ReduceFunctor<GPUDevice, Eigen::internal::OrReducer> {
   template <typename OUT_T>
   static void FillIdentity(const GPUDevice& d, OUT_T out,
                            const Eigen::internal::OrReducer& reducer) {
-    FillIdentityEigenImpl(d, To32Bit(out), reducer);
+    FillIdentityEigenImpl(d, out, reducer);
   }
 };
 

--- a/tensorflow/core/kernels/reduction_ops.h
+++ b/tensorflow/core/kernels/reduction_ops.h
@@ -181,7 +181,11 @@ FIX_MEAN_IDENTITY(double)
 
 template <typename Device, typename OUT_T, typename Reducer>
 void FillIdentityEigenImpl(const Device& d, OUT_T out, const Reducer& reducer) {
-  out.device(d) = out.constant(Identity<Reducer>::identity(reducer));
+  MaybeWith32BitIndexing<Device>(
+      [&](auto out32) {
+        out32.device(d) = out32.constant(Identity<Reducer>::identity(reducer));
+      },
+      out);
 }
 
 template <typename Device, typename Reducer>

--- a/tensorflow/core/kernels/scan_ops.h
+++ b/tensorflow/core/kernels/scan_ops.h
@@ -36,8 +36,12 @@ struct Scan {
     dims[0] = false;
     dims[1] = reverse;
     dims[2] = false;
-    To32Bit(out).device(d) =
-        To32Bit(in).reverse(dims).scan(1, reducer, exclusive).reverse(dims);
+    MaybeWith32BitIndexing<Device>(
+        [&](auto in32, auto out32) {
+          out32.device(d) =
+              in32.reverse(dims).scan(1, reducer, exclusive).reverse(dims);
+        },
+        in, out);
   }
 };
 

--- a/tensorflow/core/kernels/strided_slice_op.h
+++ b/tensorflow/core/kernels/strided_slice_op.h
@@ -34,21 +34,13 @@ struct StridedSlice {
                   const Eigen::DSizes<Eigen::DenseIndex, NDIMS>& start_indices,
                   const Eigen::DSizes<Eigen::DenseIndex, NDIMS>& stop_indices,
                   const Eigen::DSizes<Eigen::DenseIndex, NDIMS>& strides) {
-    const bool use_64bit = input.size() > Eigen::NumTraits<int>::highest();
-    if (!use_64bit &&
-        Eigen::internal::is_same<Device, Eigen::GpuDevice>::value) {
-      Eigen::DSizes<int, NDIMS> start_i, stop_i, strides_i;
-      for (int i = 0; i < NDIMS; ++i) {
-        start_i[i] = start_indices[i];
-        stop_i[i] = stop_indices[i];
-        strides_i[i] = strides[i];
-      }
-      To32Bit(output).device(d) =
-          To32Bit(input).stridedSlice(start_i, stop_i, strides_i);
-    } else {
-      output.device(d) =
-          input.stridedSlice(start_indices, stop_indices, strides);
-    }
+    MaybeWith32BitIndexing<Device>(
+        [&](auto output32, auto input32, const auto& start_indices32,
+            const auto& stop_indices32, const auto& strides32) {
+          output32.device(d) =
+              input32.stridedSlice(start_indices32, stop_indices32, strides32);
+        },
+        output, input, start_indices, stop_indices, strides);
   }
 };
 
@@ -83,21 +75,13 @@ struct StridedSliceGrad {
                   const Eigen::DSizes<Eigen::DenseIndex, NDIMS>& stop_indices,
                   const Eigen::DSizes<Eigen::DenseIndex, NDIMS>& strides) {
     InitOutput<T, NDIMS, Device>::run(d, output);
-    const bool use_64bit = input.size() > Eigen::NumTraits<int>::highest();
-    if (!use_64bit &&
-        Eigen::internal::is_same<Device, Eigen::GpuDevice>::value) {
-      Eigen::DSizes<int, NDIMS> start_i, stop_i, strides_i;
-      for (int i = 0; i < NDIMS; ++i) {
-        start_i[i] = start_indices[i];
-        stop_i[i] = stop_indices[i];
-        strides_i[i] = strides[i];
-      }
-      To32Bit(output).stridedSlice(start_i, stop_i, strides_i).device(d) =
-          input;
-    } else {
-      output.stridedSlice(start_indices, stop_indices, strides).device(d) =
-          input;
-    }
+    MaybeWith32BitIndexing<Device>(
+        [&](auto output32, const auto& start_indices32,
+            const auto& stop_indices32, const auto& strides32) {
+          output32.stridedSlice(start_indices32, stop_indices32, strides32)
+              .device(d) = input;
+        },
+        output, start_indices, stop_indices, strides);
   }
 };
 
@@ -108,21 +92,13 @@ struct StridedSliceAssign {
                   const Eigen::DSizes<Eigen::DenseIndex, NDIMS>& start_indices,
                   const Eigen::DSizes<Eigen::DenseIndex, NDIMS>& stop_indices,
                   const Eigen::DSizes<Eigen::DenseIndex, NDIMS>& strides) {
-    const bool use_64bit = input.size() > Eigen::NumTraits<int>::highest();
-    if (!use_64bit &&
-        Eigen::internal::is_same<Device, Eigen::GpuDevice>::value) {
-      Eigen::DSizes<int, NDIMS> start_i, stop_i, strides_i;
-      for (int i = 0; i < NDIMS; ++i) {
-        start_i[i] = start_indices[i];
-        stop_i[i] = stop_indices[i];
-        strides_i[i] = strides[i];
-      }
-      To32Bit(output).stridedSlice(start_i, stop_i, strides_i).device(d) =
-          To32Bit(input);
-    } else {
-      output.stridedSlice(start_indices, stop_indices, strides).device(d) =
-          input;
-    }
+    MaybeWith32BitIndexing<Device>(
+        [&](auto output32, auto input32, const auto& start_indices32,
+            const auto& stop_indices32, const auto& strides32) {
+          output32.stridedSlice(start_indices32, stop_indices32, strides32)
+              .device(d) = input32;
+        },
+        output, input, start_indices, stop_indices, strides);
   }
 };
 

--- a/tensorflow/core/kernels/tile_functor.h
+++ b/tensorflow/core/kernels/tile_functor.h
@@ -40,19 +40,11 @@ void TileSimple(const Eigen::GpuDevice& d, Tensor* out, const Tensor& in);
 template <typename Device, typename T, typename Tmultiples, int NDIM>
 void TileUsingEigen(const Device& d, Tensor* out, const Tensor& in,
                     const gtl::ArraySlice<Tmultiples> broadcast_array) {
-  auto x = in.tensor<T, NDIM>();
-  auto y = out->tensor<T, NDIM>();
-
-  bool use_32bit = y.size() < Eigen::NumTraits<int>::highest();
-
   Eigen::array<Tmultiples, NDIM> b;
   for (int i = 0; i < NDIM; ++i) b[i] = broadcast_array[i];
-  if (use_32bit && Eigen::internal::is_same<Device, Eigen::GpuDevice>::value) {
-    // Use 32bit indexing to speed up the computations
-    To32Bit(y).device(d) = To32Bit(x).broadcast(b);
-  } else {
-    y.device(d) = x.broadcast(b);
-  }
+  MaybeWith32BitIndexing<Device>(
+      [&](auto out32, auto in32) { out32.device(d) = in32.broadcast(b); },
+      out->tensor<T, NDIM>(), in.tensor<T, NDIM>());
 }
 
 template <typename Device, typename T, typename Tmultiples>


### PR DESCRIPTION
- Many op kernels use the `To32Bit()` function, which does not do any bounds checking and can cause silent corruption due to int32 overflow.
  E.g., `tf.zeros/ones/fill` silently give incorrect results when the number of elements is >= 2**31.
- This commit adds a new helper function `MaybeWith32BitIndexing()` that checks the indexing bounds and converts tensors to 32-bit only if it is safe to do so (and only for GPU devices). This fixes the cases that were previously broken, and simplifies the ones that already had explicit bounds checks.

cc @nluehr @sanjoy 