### PR TITLE
Add back "PR #49173: [Crash fix] Fix cudaMallocAsync crashes."

### DIFF
--- a/tensorflow/core/common_runtime/gpu/BUILD
+++ b/tensorflow/core/common_runtime/gpu/BUILD
@@ -319,6 +319,7 @@ tf_cuda_cc_test(
     tags = tf_cuda_tests_tags(),
     deps = [
         ":gpu_id",
+        ":gpu_runtime",
         "//tensorflow/cc:cc_ops",
         "//tensorflow/core:framework",
         "//tensorflow/core:framework_internal",

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -130,8 +130,9 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
           cuDeviceGetAttribute(&cuda_malloc_async_supported,
                                CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED,
                                platform_device_id.value()))
-    LOG(FATAL) <<  // Crash OK.
-        "Failed to get device attribute: " << GetCudaErrorMessage(status);
+    LOG(FATAL)  // Crash OK.
+        << "On device: " << platform_device_id.value()
+        << ". Failed to get device attribute : " << GetCudaErrorMessage(status);
   if (!cuda_malloc_async_supported)
     LOG(FATAL)  // Crash OK.
         << "TF_GPU_ALLOCATOR=cuda_malloc_async isn't currently supported on "

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -96,10 +96,13 @@ void GpuCudaMallocAsyncAllocator::PrintAllocatorStatistics() {
 #endif
 }
 
+std::atomic<int> GpuCudaMallocAsyncAllocator::number_instantiated_(0);
+
 GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
     PlatformDeviceId platform_device_id, size_t pool_size, bool reserve_memory,
     bool compute_stats)
     : name_(absl::StrCat("gpu_async_", platform_device_id.value())) {
+  ++number_instantiated_;
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
   stream_exec_ = DeviceIdUtil::ExecutorForPlatformDeviceId(GPUMachineManager(),
                                                            platform_device_id)

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -117,6 +117,13 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
   int driverVersion;
   cuDriverGetVersion(&driverVersion);
   VLOG(2) << "DRIVER VERSION: " << driverVersion;
+  if (driverVersion < 11020) {
+    LOG(FATAL)  // Crash OK.
+      << "Disable cuda_malloc_async or update your CUDA driver to a version"
+      << " compitible with CUDA 11.2 or higher."
+      << " We detected a version compatible with: " << driverVersion;
+  }
+
   if (platform_device_id.value() > 0 && driverVersion < 11030) {
     CUcontext pctx;  // We loose track of it. But this is fine.
     if (auto result = cuDevicePrimaryCtxRetain(&pctx, 0))
@@ -131,12 +138,6 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
     LOG(FATAL)  // Crash OK.
       << "Error while fetching driver version: "
       << GetCudaErrorMessage(status2);
-  }
-  if (driverVersion < 11020) {
-    LOG(FATAL)  // Crash OK.
-      << "Disable cuda_malloc_async or update your CUDA driver to a version"
-      << " compitible with CUDA 11.2 or higher."
-      << " We detected a version compatible with: " << driverVersion;
   }
 
   // Check that cudaMallocAsync is supported.

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -129,10 +129,17 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
   if (auto status =
           cuDeviceGetAttribute(&cuda_malloc_async_supported,
                                CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED,
-                               platform_device_id.value()))
+                               platform_device_id.value())) {
+    int driverVersion;
+    if (auto status2 = cuDriverGetVersion(&driverVersion)) {
+      LOG(ERROR) << "Error while fetching driver version: "
+             << GetCudaErrorMessage(status2);
+    }
     LOG(FATAL)  // Crash OK.
         << "On device: " << platform_device_id.value()
+        << " Current driver: " << driverVersion
         << ". Failed to get device attribute : " << GetCudaErrorMessage(status);
+  }
   if (!cuda_malloc_async_supported)
     LOG(FATAL)  // Crash OK.
         << "TF_GPU_ALLOCATOR=cuda_malloc_async isn't currently supported on "

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -314,6 +314,8 @@ void* GpuCudaMallocAsyncAllocator::AllocateRaw(size_t alignment,
 }
 void GpuCudaMallocAsyncAllocator::DeallocateRaw(void* ptr) {
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
+  if (ptr == nullptr)
+    return;
   if (auto result = cuMemFreeAsync(reinterpret_cast<const CUdeviceptr&>(ptr),
                                    cuda_stream_)) {
     if (result == CUDA_ERROR_DEINITIALIZED) {

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -401,7 +401,8 @@ BaseGPUDevice::BaseGPUDevice(const SessionOptions& options, const string& name,
 
 BaseGPUDevice::~BaseGPUDevice() {
   delete gpu_device_info_;
-  gpu_allocator_->DeallocateRaw(scratch_);
+  if (scratch_)
+    gpu_allocator_->DeallocateRaw(scratch_);
   device_context_->Unref();
 }
 

--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -115,16 +115,20 @@ class GPUDeviceTest : public ::testing::Test {
 
 TEST_F(GPUDeviceTest, CudaMallocAsync) {
   // cudaMallocAsync supported only when cuda toolkit and driver supporting CUDA 11.2+
-  #if CUDA_VERSION < 11020
+#ifndef GOOGLE_CUDA
+  return;
+#elif CUDA_VERSION < 11020
   LOG(INFO) << "CUDA toolkit too old, skipping this test: " << CUDA_VERSION;
   return;
-  #endif
+#else
+  // cudaMallocAsync supported only for driver supporting CUDA 11.2+
   int driverVersion;
   cuDriverGetVersion(&driverVersion);
   if (driverVersion < 11020) {
     LOG(INFO) << "Driver version too old, skipping this test: " << driverVersion;
     return;
   }
+#endif
 
   SessionOptions opts = MakeSessionOptions("0", 0, 1, {}, {},
                                            /*use_cuda_malloc_async=*/true);

--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/core/common_runtime/gpu/gpu_device.h"
 
 #include "tensorflow/core/common_runtime/device/device_id_utils.h"
+#include "tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_init.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_process_state.h"
 #include "tensorflow/core/lib/core/errors.h"
@@ -66,7 +67,8 @@ class GPUDeviceTest : public ::testing::Test {
       const string& visible_device_list = "",
       double per_process_gpu_memory_fraction = 0, int gpu_device_count = 1,
       const std::vector<std::vector<float>>& memory_limit_mb = {},
-      const std::vector<std::vector<int32>>& priority = {}) {
+      const std::vector<std::vector<int32>>& priority = {},
+      const bool use_cuda_malloc_async = false) {
     SessionOptions options;
     ConfigProto* config = &options.config;
     (*config->mutable_device_count())["GPU"] = gpu_device_count;
@@ -74,6 +76,8 @@ class GPUDeviceTest : public ::testing::Test {
     gpu_options->set_visible_device_list(visible_device_list);
     gpu_options->set_per_process_gpu_memory_fraction(
         per_process_gpu_memory_fraction);
+    gpu_options->mutable_experimental()->set_use_cuda_malloc_async(
+        use_cuda_malloc_async);
     for (int i = 0; i < memory_limit_mb.size(); ++i) {
       auto virtual_devices =
           gpu_options->mutable_experimental()->add_virtual_devices();
@@ -108,6 +112,33 @@ class GPUDeviceTest : public ::testing::Test {
         gpu_tensor, /*tensor_name=*/"", device, cpu_tensor));
   }
 };
+
+TEST_F(GPUDeviceTest, CudaMallocAsync) {
+  SessionOptions opts = MakeSessionOptions("0", 0, 1, {}, {},
+                                           /*use_cuda_malloc_async=*/true);
+  std::vector<std::unique_ptr<Device>> devices;
+  Status status;
+  int number_instantiated =
+      GpuCudaMallocAsyncAllocator::GetInstantiatedCountTestOnly();
+  {  // The new scope is to trigger the destruction of the object.
+    status = DeviceFactory::GetFactory("GPU")->CreateDevices(
+        opts, kDeviceNamePrefix, &devices);
+    EXPECT_EQ(devices.size(), 1);
+    Device* device = devices[0].get();
+    auto* device_info = device->tensorflow_gpu_device_info();
+    EXPECT_NE(device_info, nullptr);
+
+    AllocatorAttributes allocator_attributes = AllocatorAttributes();
+    allocator_attributes.set_gpu_compatible(true);
+    Allocator* allocator = devices[0]->GetAllocator(allocator_attributes);
+    void* ptr = allocator->AllocateRaw(Allocator::kAllocatorAlignment, 1024);
+    EXPECT_NE(ptr, nullptr);
+    allocator->DeallocateRaw(ptr);
+  }
+  EXPECT_EQ(number_instantiated + 1,
+            GpuCudaMallocAsyncAllocator::GetInstantiatedCountTestOnly());
+  EXPECT_EQ(status.code(), error::OK);
+}
 
 TEST_F(GPUDeviceTest, FailedToParseVisibleDeviceList) {
   SessionOptions opts = MakeSessionOptions("0,abc");

--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -114,6 +114,14 @@ class GPUDeviceTest : public ::testing::Test {
 };
 
 TEST_F(GPUDeviceTest, CudaMallocAsync) {
+  // cudaMallocAsync supported only for driver supporting CUDA 11.2+
+  int driverVersion;
+  cuDriverGetVersion(&driverVersion);
+  if (driverVersion < 11020) {
+    LOG(INFO) << "DRIVER VERSION TOO OLD, skipping this test: " << driverVersion;
+    return;
+  }
+
   SessionOptions opts = MakeSessionOptions("0", 0, 1, {}, {},
                                            /*use_cuda_malloc_async=*/true);
   std::vector<std::unique_ptr<Device>> devices;

--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -114,11 +114,15 @@ class GPUDeviceTest : public ::testing::Test {
 };
 
 TEST_F(GPUDeviceTest, CudaMallocAsync) {
-  // cudaMallocAsync supported only for driver supporting CUDA 11.2+
+  // cudaMallocAsync supported only when cuda toolkit and driver supporting CUDA 11.2+
+  #if CUDA_VERSION < 11020
+  LOG(INFO) << "CUDA toolkit too old, skipping this test: " << CUDA_VERSION;
+  return;
+  #endif
   int driverVersion;
   cuDriverGetVersion(&driverVersion);
   if (driverVersion < 11020) {
-    LOG(INFO) << "DRIVER VERSION TOO OLD, skipping this test: " << driverVersion;
+    LOG(INFO) << "Driver version too old, skipping this test: " << driverVersion;
     return;
   }
 

--- a/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
@@ -207,11 +207,10 @@ Allocator* GPUProcessState::GetGPUAllocator(
       // useful for doing memory debugging with tools like cuda-memcheck
       // **WARNING** probably will not work in a multi-gpu scenario
       delete gpu_bfc_allocator;
-      delete sub_allocator;
       gpu_bfc_allocator = nullptr;
-      sub_allocator = nullptr;
       gpu_allocator = new GPUcudaMallocAllocator(platform_device_id);
-    } else if (UseCudaMallocAsyncAllocator()) {
+    } else if (UseCudaMallocAsyncAllocator() ||
+               options.experimental().use_cuda_malloc_async()) {
       LOG(INFO) << "Using CUDA malloc Async allocator for GPU: "
                 << platform_device_id;
       // If true, passes all allocation requests through to cudaMallocAsync
@@ -219,9 +218,7 @@ Allocator* GPUProcessState::GetGPUAllocator(
       // compute-sanitizer.
       // TODO: **WARNING** probably will not work in a multi-gpu scenario
       delete gpu_bfc_allocator;
-      delete sub_allocator;
       gpu_bfc_allocator = nullptr;
-      sub_allocator = nullptr;
       gpu_allocator =
           new GpuCudaMallocAsyncAllocator(platform_device_id, total_bytes);
     }


### PR DESCRIPTION
This reverts commit a4553f8ad74f5ad486057da400fb8e101f12e09f that was reverting #49173.

When I run it now, //tensorflow/core/common_runtime/gpu:gpu_device_test in asan give me the same output as before. It was already crashing before this PR with my command line:

```bazel test --distinct_host_configuration=false --javabase=@bazel_tools//tools/jdk:remote_jdk11 --config=asan -c opt --config=cuda //tensorflow/core/common_runtime/gpu:gpu_device_test```

@penpornk 

fixes #50669 