### PR TITLE
Crash fix cudaMallocAsync usage of TF_CUDA_MALLOC_ASYNC_SUPPORTED_PREALLOC.

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -111,9 +111,6 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
   // enough CUDA.
   pool_ = nullptr;
   cuda_stream_ = nullptr;
-  // WAR an CUDA 11.2 driver bug for multiple-GPU. It currently
-  // request that the context on GPU 0 is initialized. Which isn't the
-  // case for TF+horovod.
   int driverVersion;
   cuDriverGetVersion(&driverVersion);
   VLOG(2) << "DRIVER VERSION: " << driverVersion;
@@ -124,6 +121,9 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
         << " We detected a version compatible with: " << driverVersion;
   }
 
+  // WAR an CUDA 11.2 driver bug for multiple-GPU. It currently
+  // request that the context on GPU 0 is initialized. Which isn't the
+  // case for TF+horovod.
   if (platform_device_id.value() > 0 && driverVersion < 11030) {
     CUcontext pctx;  // We loose track of it. But this is fine.
     if (auto result = cuDevicePrimaryCtxRetain(&pctx, 0))

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -379,7 +379,7 @@ bool GpuCudaMallocAsyncAllocator::ClearStats() {
   return true;
 }
 
-void GpuCudaMallocAsyncAllocator::SetStream(void* stream) {
+void GpuCudaMallocAsyncAllocator::SetStreamAndPreallocateMemory(void* stream) {
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
   if (cuda_stream_ != nullptr) {
     LOG(FATAL) <<  // Crash OK.

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -381,12 +381,16 @@ bool GpuCudaMallocAsyncAllocator::ClearStats() {
 
 void GpuCudaMallocAsyncAllocator::SetStream(void* stream) {
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
+  if (cuda_stream_ != nullptr) {
+    LOG(FATAL) <<  // Crash OK.
+        "Trying to set the stream twice. This isn't supported. ";
+  }
+
   uint64_t pool_size_64 = 0;
   if (auto status = cuMemPoolGetAttribute(
           pool_, CU_MEMPOOL_ATTR_RELEASE_THRESHOLD, &pool_size_64)) {
     LOG(FATAL) <<  // Crash OK.
         "Failed to get CUDA pool attribute: " << GetCudaErrorMessage(status);
-
   }
   cuda_stream_ = *(reinterpret_cast<CUstream*>(stream));
   int64 prealloc_size = 0;

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
@@ -83,7 +83,7 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
 
   bool ClearStats() override;
 
-  void SetStream(void* stream) override;
+  void SetStreamAndPreallocateMemory(void* stream) override;
 
   // With the right VLOG set, it prints:
   // - the number of ptr currently allocated per size (histogram).

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
@@ -83,11 +83,7 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
 
   bool ClearStats() override;
 
-  void SetStream(void* stream) override {
-#if TF_CUDA_MALLOC_ASYNC_SUPPORTED
-    cuda_stream_ = *(static_cast<CUstream*>(stream));
-#endif
-  }
+  void SetStream(void* stream) override;
 
   // With the right VLOG set, it prints:
   // - the number of ptr currently allocated per size (histogram).
@@ -119,6 +115,8 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
   static std::atomic<int> number_instantiated_;
 
   string name_;
+
+  bool reserve_memory_;
 
   TF_DISALLOW_COPY_AND_ASSIGN(GpuCudaMallocAsyncAllocator);
 

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -1525,7 +1525,7 @@ Status BaseGPUDeviceFactory::CreateGPUDevice(
             << (bytes_limit >> 20) << " MB memory: "
             << " -> " << GetShortDeviceDescription(platform_device_id, *desc);
   TF_RETURN_IF_ERROR(gpu_device->Init(options));
-  gpu_allocator->SetStream(gpu_device->GetStream());
+  gpu_allocator->SetStreamAndPreallocateMemory(gpu_device->GetStream());
   devices->push_back(std::move(gpu_device));
 
   return Status::OK();

--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/lib/core/status_test_util.h"
 #include "tensorflow/core/lib/random/random.h"
+#include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/test.h"
 
 namespace tensorflow {
@@ -155,6 +156,39 @@ TEST_F(GPUDeviceTest, CudaMallocAsync) {
   }
   EXPECT_EQ(number_instantiated + 1,
             GpuCudaMallocAsyncAllocator::GetInstantiatedCountTestOnly());
+  EXPECT_EQ(status.code(), error::OK);
+}
+
+TEST_F(GPUDeviceTest, CudaMallocAsyncPreallocate) {
+  SessionOptions opts = MakeSessionOptions("0", 0, 1, {}, {},
+                                           /*use_cuda_malloc_async=*/true);
+  setenv("TF_CUDA_MALLOC_ASYNC_SUPPORTED_PREALLOC", "2048", 1);
+  std::vector<std::unique_ptr<Device>> devices;
+  Status status;
+
+  int number_instantiated = GpuCudaMallocAsyncAllocator::GetInstantiatedCountTestOnly();
+  { // The new scope is to trigger the destruction of the object.
+    status = DeviceFactory::GetFactory("GPU")->CreateDevices(
+        opts, kDeviceNamePrefix, &devices);
+    EXPECT_EQ(devices.size(), 1);
+    Device* device = devices[0].get();
+    auto* device_info = device->tensorflow_gpu_device_info();
+    CHECK(device_info);
+    DeviceContext* device_context = device_info->default_context;
+
+    AllocatorAttributes allocator_attributes = AllocatorAttributes();
+    allocator_attributes.set_gpu_compatible(true);
+    Allocator* allocator = devices[0]->GetAllocator(allocator_attributes);
+    void* ptr = allocator->AllocateRaw(Allocator::kAllocatorAlignment,
+                                       1024);
+    EXPECT_NE(ptr, nullptr);
+    allocator->DeallocateRaw(ptr);
+  }
+
+  unsetenv("TF_CUDA_MALLOC_ASYNC_SUPPORTED_PREALLOC");
+
+  EXPECT_EQ(number_instantiated + 1 , GpuCudaMallocAsyncAllocator::GetInstantiatedCountTestOnly());
+
   EXPECT_EQ(status.code(), error::OK);
 }
 

--- a/tensorflow/core/framework/allocator.h
+++ b/tensorflow/core/framework/allocator.h
@@ -294,7 +294,7 @@ class Allocator {
 
   // For allocator that are stream aware, allow to specify the compute
   // stream this allocator is used for.
-  virtual void SetStream(void* stream) {}
+  virtual void SetStreamAndPreallocateMemory(void* stream) {}
 };
 
 // An implementation of Allocator that delegates all calls to another Allocator.

--- a/tensorflow/core/framework/allocator.h
+++ b/tensorflow/core/framework/allocator.h
@@ -293,7 +293,8 @@ class Allocator {
   virtual void SetSafeFrontier(uint64 count) {}
 
   // For allocator that are stream aware, allow to specify the compute
-  // stream this allocator is used for.
+  // stream this allocator is used for. This can also trigger memory
+  // preallocation.
   virtual void SetStreamAndPreallocateMemory(void* stream) {}
 };
 


### PR DESCRIPTION
Some of the refactoring caused crash when using TF_CUDA_MALLOC_ASYNC_SUPPORTED_PREALLOC.
This PR fix them and add a test to be sure it continue to work.

This PR is on top of https://github.com/tensorflow/tensorflow/pull/50961 as otherwise there would be code conflict.

Now, GpuCudaMallocAsyncAllocator doesn't create its own compute stream. But it use one stream set after construction when GpuCudaMallocAsyncAllocator::SetStream is called. So it is now impossible to preallocate all memory during the object construction.
So this PR postpone the memory preallocation to when the stream is available, in SetStream.

This PR also check that the stream isn't set when SetStream is called.

@sanjoy 