### PR TITLE
add platfrom_version for rocm in pjrt/gpu_device

### DIFF
--- a/tensorflow/compiler/xla/pjrt/BUILD
+++ b/tensorflow/compiler/xla/pjrt/BUILD
@@ -2,6 +2,7 @@ load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
 load("//tensorflow:tensorflow.bzl", "if_nccl")
 load("//tensorflow:tensorflow.bzl", "tf_cc_test")
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm")
 
 package(
     default_visibility = ["//tensorflow:internal"],
@@ -316,7 +317,7 @@ cc_library(
     name = "gpu_device",
     srcs = ["gpu_device.cc"],
     hdrs = ["gpu_device.h"],
-    defines = if_cuda(["GOOGLE_CUDA=1"]),
+    defines = if_cuda(["GOOGLE_CUDA=1"]) + if_rocm(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         ":pjrt_stream_executor_client",
         "@com_google_absl//absl/base:core_headers",
@@ -331,10 +332,13 @@ cc_library(
         "//tensorflow/core/common_runtime/device:device_mem_allocator",
         "//tensorflow/core/common_runtime/device:device_id",
         "//tensorflow/core:lib_internal",
-        "//tensorflow/stream_executor/cuda:cuda_activation_header",
         "//tensorflow/stream_executor:device_memory",
         "//tensorflow/stream_executor:tf_allocator_adapter",
-    ] + if_nccl([":nccl_plugin"]),
+    ] + if_cuda([
+        "//tensorflow/stream_executor/cuda:cuda_activation_header"
+    ]) + if_rocm([
+        "@local_config_rocm//rocm:rocm_headers"
+    ]) + if_nccl([":nccl_plugin"]),
 )
 
 # We actually wish we could write if_cuda(if_nccl(...)) in :gpu_device,

--- a/tensorflow/compiler/xla/pjrt/gpu_device.cc
+++ b/tensorflow/compiler/xla/pjrt/gpu_device.cc
@@ -26,6 +26,10 @@ limitations under the License.
 #include "tensorflow/stream_executor/cuda/cuda_activation.h"
 #endif  // GOOGLE_CUDA
 
+#ifdef TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#endif  // TENSORFLOW_USE_ROCM
+
 #ifdef NCCL_ENABLED
 #include "third_party/nccl/nccl.h"
 #endif  // NCCL_ENABLED
@@ -166,13 +170,17 @@ class GpuClient : public xla::PjRtStreamExecutorClient {
       int num_replicas, int num_partitions) const override;
 
   absl::string_view platform_version() const override {
-#if defined(CUDART_VERSION)
+#if defined(TF_ROCM_VERSION) || defined(CUDART_VERSION)
 #define STRINGIFY2(X) #X
 #define STRINGIFY(X) STRINGIFY2(X)
+#if TENSORFLOW_USE_ROCM && defined(TF_ROCM_VERSION)  // rocm
+    return "rocm " STRINGIFY(TF_ROCM_VERSION);
+#elif GOOGLE_CUDA && defined(CUDART_VERSION)
     return "cuda " STRINGIFY(CUDART_VERSION);
-#else   // defined(CUDART_VERSION)
+#else
     return "<unknown>";
-#endif  // defined(CUDART_VERSION)
+#endif  // TENSORFLOW_USE_ROCM && defined(TF_ROCM_VERSION)
+#endif  // defined(TF_ROCM_VERSION) || defined(CUDART_VERSION)
   }
 };
 


### PR DESCRIPTION
This PR fixes the returned value from platform_version() for ROCm.
