### PR TITLE
Fix segmentation fault in shape inference logic.

### DIFF
--- a/tensorflow/core/common_runtime/shape_refiner.cc
+++ b/tensorflow/core/common_runtime/shape_refiner.cc
@@ -135,7 +135,7 @@ Status ShapeRefiner::InferShapesForFunctionSubNode(
         TF_RETURN_IF_ERROR(
             outer_context->MakeShapeFromShapeProto(proto, &handle));
         copied_shapes_and_types.push_back(
-            ShapeAndType(handle, shape_and_type.dtype, shape_and_type.type));
+            ShapeAndType(handle, shape_and_type.dtype, shape_and_type.specialized_type));
       }
 
       outer_context->set_output_handle_shapes_and_types(


### PR DESCRIPTION
When running shape functions, some functions (such as `MutableHashTableShape`)
produce extra output information in the form of a `ShapeAndType` struct.  The
shapes embedded in this struct are owned by an inference context that is
cleaned up almost immediately; if the upstream code attempts to access this
shape information, it can trigger a segfault.

`ShapeRefiner` is mitigating this for normal output shapes by cloning them
(and thus putting the newly created shape under ownership of an inference
context that will not die), but we were not doing the same for shapes and
types.  This commit fixes that by doing similar logic on output shapes and
types.

PiperOrigin-RevId: 384761124
Change-Id: I07c0c42d29dfbb55bfa13ec1f09ef825fb0a1a1d