### PR TITLE
Make passthrough alias work for resource updates

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/alias_passthrough_params.cc
+++ b/tensorflow/compiler/xla/service/gpu/alias_passthrough_params.cc
@@ -42,7 +42,7 @@ StatusOr<bool> AliasPassthroughParams::Run(HloModule* module) {
           module->input_output_alias_config().ParameterHasAlias(
               root->operand(i)->parameter_number(), /*param_index=*/{})) {
         VLOG(2) << "Skip setting the above pass-through alias as an alias may"
-                << " have been set up by ResVarIoAliasing.";
+                << " have been set up for alising resource update.";
         continue;
       }
 

--- a/tensorflow/compiler/xla/service/gpu/alias_passthrough_params.cc
+++ b/tensorflow/compiler/xla/service/gpu/alias_passthrough_params.cc
@@ -37,6 +37,15 @@ StatusOr<bool> AliasPassthroughParams::Run(HloModule* module) {
               << " in module " << module->name()
               << " is passed-through to root tuple element " << i << ": "
               << root->shape().ToString();
+
+      if (module->input_output_alias_config().OutputHasAlias({i}) ||
+          module->input_output_alias_config().ParameterHasAlias(
+              root->operand(i)->parameter_number(), /*param_index=*/{})) {
+        VLOG(2) << "Skip setting the above pass-through alias as an alias may"
+                << " have been set up by ResVarIoAliasing.";
+        continue;
+      }
+
       TF_RETURN_IF_ERROR(module->input_output_alias_config().SetUpAlias(
           /*output_index=*/{i},
           /*param_number=*/root->operand(i)->parameter_number(),

--- a/tensorflow/compiler/xla/service/gpu/alias_passthrough_params_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/alias_passthrough_params_test.cc
@@ -77,6 +77,7 @@ TEST_F(AliasPassthroughParamsTest, PresetAliases) {
 
   EXPECT_TRUE(AliasPassthroughParams().Run(module.get()).ValueOrDie());
   const auto& alias_result = module->input_output_alias_config();
+  // Assert that an alias p1 -> p1 is established by `AliasPassthroughParams`.
   EXPECT_EQ(1, alias_result.GetAliasedParameter({2})->parameter_number);
   EXPECT_FALSE(alias_result.OutputHasAlias({0}));
 }


### PR DESCRIPTION

Modify `alias_passthrough_params` so that it can work with `resource update alias`. Concretely, `module->input_output_alias_config()` could have some aliases preset by `resource update alias`.

I will upstream another change to enable `resource update alias` for auto-clustering right after this PR is merged.