### PR TITLE
use `std::make_tuple` in `cupti_tracer.cc`

### DIFF
--- a/tensorflow/core/profiler/internal/gpu/cupti_tracer.cc
+++ b/tensorflow/core/profiler/internal/gpu/cupti_tracer.cc
@@ -159,70 +159,70 @@ DecodeDriverMemcpy(CUpti_CallbackId cbid, const void *params) {
   switch (cbid) {
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoD_v2: {
       const auto *p = reinterpret_cast<const cuMemcpyHtoD_v2_params *>(params);
-      return {p->ByteCount, CuptiTracerEventType::MemcpyH2D, false};
+      return std::make_tuple(p->ByteCount, CuptiTracerEventType::MemcpyH2D, false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpyHtoDAsync_v2: {
       const auto *p =
           reinterpret_cast<const cuMemcpyHtoDAsync_v2_params *>(params);
-      return {p->ByteCount, CuptiTracerEventType::MemcpyH2D, true};
+      return std::make_tuple(p->ByteCount, CuptiTracerEventType::MemcpyH2D, true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoH_v2: {
       const auto *p = reinterpret_cast<const cuMemcpyDtoH_v2_params *>(params);
-      return {p->ByteCount, CuptiTracerEventType::MemcpyD2H, false};
+      return std::make_tuple(p->ByteCount, CuptiTracerEventType::MemcpyD2H, false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoHAsync_v2: {
       const auto *p =
           reinterpret_cast<const cuMemcpyDtoHAsync_v2_params *>(params);
-      return {p->ByteCount, CuptiTracerEventType::MemcpyD2H, true};
+      return std::make_tuple(p->ByteCount, CuptiTracerEventType::MemcpyD2H, true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoD_v2: {
       const auto *p = reinterpret_cast<const cuMemcpyDtoD_v2_params *>(params);
-      return {p->ByteCount, CuptiTracerEventType::MemcpyD2D, false};
+      return std::make_tuple(p->ByteCount, CuptiTracerEventType::MemcpyD2D, false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpyDtoDAsync_v2: {
       const auto *p =
           reinterpret_cast<const cuMemcpyDtoDAsync_v2_params *>(params);
-      return {p->ByteCount, CuptiTracerEventType::MemcpyD2D, true};
+      return std::make_tuple(p->ByteCount, CuptiTracerEventType::MemcpyD2D, true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpy: {
       const auto *p = reinterpret_cast<const cuMemcpy_params *>(params);
-      return {p->ByteCount, CuptiTracerEventType::MemcpyOther, false};
+      return std::make_tuple(p->ByteCount, CuptiTracerEventType::MemcpyOther, false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpyAsync: {
       const auto *p = reinterpret_cast<const cuMemcpyAsync_params *>(params);
-      return {p->ByteCount, CuptiTracerEventType::MemcpyOther, true};
+      return std::make_tuple(p->ByteCount, CuptiTracerEventType::MemcpyOther, true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpy2D_v2: {
       const auto *p = reinterpret_cast<const cuMemcpy2D_v2_params *>(params);
-      return {Bytes2D(p->pCopy), MemcpyKind(p->pCopy), false};
+      return std::make_tuple(Bytes2D(p->pCopy), MemcpyKind(p->pCopy), false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpy2DAsync_v2: {
       const auto *p =
           reinterpret_cast<const cuMemcpy2DAsync_v2_params *>(params);
-      return {Bytes2D(p->pCopy), MemcpyKind(p->pCopy), true};
+      return std::make_tuple(Bytes2D(p->pCopy), MemcpyKind(p->pCopy), true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpy3D_v2: {
       const auto *p = reinterpret_cast<const cuMemcpy3D_v2_params *>(params);
-      return {Bytes3D(p->pCopy), MemcpyKind(p->pCopy), true};
+      return std::make_tuple(Bytes3D(p->pCopy), MemcpyKind(p->pCopy), true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpy3DAsync_v2: {
       const auto *p =
           reinterpret_cast<const cuMemcpy3DAsync_v2_params *>(params);
-      return {Bytes3D(p->pCopy), MemcpyKind(p->pCopy), true};
+      return std::make_tuple(Bytes3D(p->pCopy), MemcpyKind(p->pCopy), true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpyPeer: {
       const auto *p2p_params =
           reinterpret_cast<const cuMemcpyPeer_params *>(params);
-      return {p2p_params->ByteCount, CuptiTracerEventType::MemcpyP2P, false};
+      return std::make_tuple(p2p_params->ByteCount, CuptiTracerEventType::MemcpyP2P, false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemcpyPeerAsync: {
       const auto *p2p_params =
           reinterpret_cast<const cuMemcpyPeerAsync_params *>(params);
-      return {p2p_params->ByteCount, CuptiTracerEventType::MemcpyP2P, true};
+      return std::make_tuple(p2p_params->ByteCount, CuptiTracerEventType::MemcpyP2P, true);
     }
     default: {
       LOG(ERROR) << "Unsupported memcpy activity observed: " << cbid;
-      return {0, CuptiTracerEventType::Unsupported, false};
+      return std::make_tuple(0, CuptiTracerEventType::Unsupported, false);
     }
   }
 }
@@ -232,58 +232,58 @@ DecodeDriverMemset(CUpti_CallbackId cbid, const void *params) {
   switch (cbid) {
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD8_v2: {
       const auto *p = reinterpret_cast<const cuMemsetD8_v2_params *>(params);
-      return {p->N, CuptiTracerEventType::Memset, false};
+      return std::make_tuple(p->N, CuptiTracerEventType::Memset, false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD16_v2: {
       const auto *p = reinterpret_cast<const cuMemsetD16_v2_params *>(params);
-      return {p->N, CuptiTracerEventType::Memset, false};
+      return std::make_tuple(p->N, CuptiTracerEventType::Memset, false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD32_v2: {
       const auto *p = reinterpret_cast<const cuMemsetD32_v2_params *>(params);
-      return {p->N, CuptiTracerEventType::Memset, false};
+      return std::make_tuple(p->N, CuptiTracerEventType::Memset, false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D8_v2: {
       const auto *p = reinterpret_cast<const cuMemsetD2D8_v2_params *>(params);
-      return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, false};
+      return std::make_tuple(p->dstPitch * p->Height, CuptiTracerEventType::Memset, false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D16_v2: {
       const auto *p = reinterpret_cast<const cuMemsetD2D16_v2_params *>(params);
-      return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, false};
+      return std::make_tuple(p->dstPitch * p->Height, CuptiTracerEventType::Memset, false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D32_v2: {
       const auto *p = reinterpret_cast<const cuMemsetD2D32_v2_params *>(params);
-      return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, false};
+      return std::make_tuple(p->dstPitch * p->Height, CuptiTracerEventType::Memset, false);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD8Async: {
       const auto *p = reinterpret_cast<const cuMemsetD8Async_params *>(params);
-      return {p->N, CuptiTracerEventType::Memset, true};
+      return std::make_tuple(p->N, CuptiTracerEventType::Memset, true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD16Async: {
       const auto *p = reinterpret_cast<const cuMemsetD16Async_params *>(params);
-      return {p->N, CuptiTracerEventType::Memset, true};
+      return std::make_tuple(p->N, CuptiTracerEventType::Memset, true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD32Async: {
       const auto *p = reinterpret_cast<const cuMemsetD32Async_params *>(params);
-      return {p->N, CuptiTracerEventType::Memset, true};
+      return std::make_tuple(p->N, CuptiTracerEventType::Memset, true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D8Async: {
       const auto *p =
           reinterpret_cast<const cuMemsetD2D8Async_params *>(params);
-      return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, true};
+      return std::make_tuple(p->dstPitch * p->Height, CuptiTracerEventType::Memset, true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D16Async: {
       const auto *p =
           reinterpret_cast<const cuMemsetD2D16Async_params *>(params);
-      return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, true};
+      return std::make_tuple(p->dstPitch * p->Height, CuptiTracerEventType::Memset, true);
     }
     case CUPTI_DRIVER_TRACE_CBID_cuMemsetD2D32Async: {
       const auto *p =
           reinterpret_cast<const cuMemsetD2D32Async_params *>(params);
-      return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, true};
+      return std::make_tuple(p->dstPitch * p->Height, CuptiTracerEventType::Memset, true);
     }
     default: {
       LOG(ERROR) << "Unsupported memset activity observed: " << cbid;
-      return {0, CuptiTracerEventType::Unsupported, false};
+      return std::make_tuple(0, CuptiTracerEventType::Unsupported, false);
     }
   }
 }


### PR DESCRIPTION
This reverts commit 501a0b2f8cba60b8fc1343646ec61d71af40e0dc and is splited from #50929.

The errors I got during builds were
```
Execution platform: @local_execution_config_platform//:platform
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc: In function 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool> tensorflow::profiler::{anonymous}::DecodeDriverMemcpy(CUpti_CallbackId, const void*)':
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:162:67: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->ByteCount, CuptiTracerEventType::MemcpyH2D, false};
                                                                   ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:167:66: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->ByteCount, CuptiTracerEventType::MemcpyH2D, true};
                                                                  ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:171:67: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->ByteCount, CuptiTracerEventType::MemcpyD2H, false};
                                                                   ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:176:66: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->ByteCount, CuptiTracerEventType::MemcpyD2H, true};
                                                                  ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:180:67: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->ByteCount, CuptiTracerEventType::MemcpyD2D, false};
                                                                   ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:185:66: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->ByteCount, CuptiTracerEventType::MemcpyD2D, true};
                                                                  ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:189:69: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->ByteCount, CuptiTracerEventType::MemcpyOther, false};
                                                                     ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:193:68: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->ByteCount, CuptiTracerEventType::MemcpyOther, true};
                                                                    ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:197:61: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {Bytes2D(p->pCopy), MemcpyKind(p->pCopy), false};
                                                             ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:202:60: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {Bytes2D(p->pCopy), MemcpyKind(p->pCopy), true};
                                                            ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:206:60: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {Bytes3D(p->pCopy), MemcpyKind(p->pCopy), true};
                                                            ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:211:60: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {Bytes3D(p->pCopy), MemcpyKind(p->pCopy), true};
                                                            ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:216:76: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p2p_params->ByteCount, CuptiTracerEventType::MemcpyP2P, false};
                                                                            ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:221:75: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p2p_params->ByteCount, CuptiTracerEventType::MemcpyP2P, true};
                                                                           ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:225:58: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {0, CuptiTracerEventType::Unsupported, false};
                                                          ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc: In function 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool> tensorflow::profiler::{anonymous}::DecodeDriverMemset(CUpti_CallbackId, const void*)':
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:235:56: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->N, CuptiTracerEventType::Memset, false};
                                                        ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:239:56: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->N, CuptiTracerEventType::Memset, false};
                                                        ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:243:56: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->N, CuptiTracerEventType::Memset, false};
                                                        ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:247:75: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, false};
                                                                           ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:251:75: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, false};
                                                                           ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:255:75: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, false};
                                                                           ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:259:55: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->N, CuptiTracerEventType::Memset, true};
                                                       ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:263:55: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->N, CuptiTracerEventType::Memset, true};
                                                       ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:267:55: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const long unsigned int&, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->N, CuptiTracerEventType::Memset, true};
                                                       ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:272:74: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, true};
                                                                          ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:277:74: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, true};
                                                                          ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:282:74: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {p->dstPitch * p->Height, CuptiTracerEventType::Memset, true};
                                                                          ^
tensorflow/core/profiler/internal/gpu/cupti_tracer.cc:286:58: error: converting to 'std::tuple<long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool>' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {int, tensorflow::profiler::CuptiTracerEventType, bool}; <template-parameter-2-2> = void; _Elements = {long unsigned int, tensorflow::profiler::CuptiTracerEventType, bool}]'
       return {0, CuptiTracerEventType::Unsupported, false};
                                                          ^
Target //tensorflow/tools/pip_package:build_pip_package failed to build
```

`std::make_tuple` was replaced in 60b9283c9e5308bae6fe19d2db531a6c230baffd. After I restored `std::make_tuple`, the build passed.

cc @yisitu 