### PR TITLE
[oneDNN]  Fix for build failure.

### DIFF
--- a/third_party/llvm_openmp/BUILD
+++ b/third_party/llvm_openmp/BUILD
@@ -26,6 +26,15 @@ package(
 
 exports_files(["LICENSE.txt"])
 
+py_binary(
+    name = "expand_cmake_vars",
+    srcs = ["expand_cmake_vars.py"],
+    srcs_version = "PY3",
+    visibility = [
+        "@llvm_openmp//:__subpackages__",
+    ],
+)
+
 kmp_i18n_os_type = select({
     "@org_tensorflow//tensorflow:windows": "win",
     "//conditions:default": "lin",


### PR DESCRIPTION
Fixes a build error due to a recent commit https://github.com/tensorflow/tensorflow/commit/d6f2afb314f19090e742da1f94367e08be86ef93. Llvm openMP failed to build due to a missing py_binary call that was not copied over from llvm/BUILD to llvm_openmp/BUILD.