### PR TITLE
[determinism] Add unimplemented exception to nearest-neighbor resizing

### DIFF
--- a/tensorflow/core/kernels/image/BUILD
+++ b/tensorflow/core/kernels/image/BUILD
@@ -308,7 +308,7 @@ tf_kernel_library(
 tf_kernel_library(
     name = "resize_nearest_neighbor_op",
     prefix = "resize_nearest_neighbor_op",
-    deps = IMAGE_DEPS,
+    deps = IMAGE_DEPS + ["//tensorflow/core/util:determinism_for_kernels"],
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/image/resize_nearest_neighbor_op.cc
+++ b/tensorflow/core/kernels/image/resize_nearest_neighbor_op.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/util/determinism.h"
 #include "tensorflow/core/util/image_resizer_state.h"
 
 namespace tensorflow {
@@ -238,6 +239,12 @@ class ResizeNearestNeighborOpGrad : public OpKernel {
     auto sizes = shape_t.vec<int32>();
     OP_REQUIRES(context, sizes(0) > 0 && sizes(1) > 0,
                 errors::InvalidArgument("shape_t's elements must be positive"));
+
+    if (std::is_same<Device, GPUDevice>::value) {
+      OP_REQUIRES(context, !OpDeterminismRequired(), errors::Unimplemented(
+          "A deterministic GPU implementation of ResizeNearestNeighborGrad"
+          " is not currently available."));
+    }
 
     const int64_t batch_size = input.dim_size(0);
     const int64_t in_height = input.dim_size(1);

--- a/tensorflow/python/ops/image_grad_deterministic_test.py
+++ b/tensorflow/python/ops/image_grad_deterministic_test.py
@@ -26,6 +26,7 @@ from tensorflow.python.eager import backprop
 from tensorflow.python.eager import context
 from tensorflow.python.framework import config
 from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import random_seed
@@ -36,6 +37,65 @@ from tensorflow.python.ops import image_grad_test_base as test_base
 from tensorflow.python.ops import image_ops
 from tensorflow.python.ops import random_ops
 from tensorflow.python.platform import test
+
+
+class ResizeNearestNeighborOpDeterminismExceptionsTest(
+    test.TestCase, parameterized.TestCase):
+  """Test d9m-unimplemented exceptions from ResizeNearestNeighborOpGrad.
+
+  Test that tf.errors.UnimplementedError is thrown, as appropriate, by the
+  GPU-specific code-path through ResizeNearestNeighborOpGrad when deterministic
+  ops are enabled.
+
+  This test assumes that image_grad_test.py runs equivalent test cases when
+  deterministic ops are not enabled and will therefore detect erroneous
+  exception throwing in those cases.
+  """
+
+  @parameterized.parameters(
+      {
+          'align_corners': False,
+          'half_pixel_centers': False,
+          'data_type': dtypes.float16
+      },
+      {
+          'align_corners': False,
+          'half_pixel_centers': False,
+          'data_type': dtypes.float32
+      },
+      {
+          'align_corners': False,
+          'half_pixel_centers': False,
+          'data_type': dtypes.float64
+      },
+      {
+          'align_corners': True,
+          'half_pixel_centers': False,
+          'data_type': dtypes.float32
+      },
+      {
+          'align_corners': False,
+          'half_pixel_centers': True,
+          'data_type': dtypes.float32
+      })
+  @test_util.run_gpu_only
+  @test_util.run_all_in_graph_and_eager_modes
+  def testExceptionThrowing(self, align_corners, half_pixel_centers, data_type):
+    with self.session(), test_util.force_gpu():
+      input_image = array_ops.zeros((1, 2, 2, 1), dtype=data_type)
+      with backprop.GradientTape() as tape:
+        tape.watch(input_image)
+        output_image = image_ops.resize_nearest_neighbor(
+            input_image,
+            (3, 3),
+            align_corners=align_corners,
+            half_pixel_centers=half_pixel_centers)
+      with self.assertRaisesRegex(
+          errors.UnimplementedError,
+          "A deterministic GPU implementation of ResizeNearestNeighborGrad" +
+          " is not currently available."):
+        gradient = tape.gradient(output_image, input_image)
+        self.evaluate(gradient)
 
 
 class ResizeBilinearOpDeterministicTest(test_base.ResizeBilinearOpTestBase):


### PR DESCRIPTION
This current PR adds and tests determinism-unimplemented exception-throwing for `tf.image.resize` when `method=ResizeMethod.NEAREST` and when its GPU-implemented backprop code-path is executed.

This PR is related to [RFC: Enabling Determinism in TensorFlow](https://github.com/tensorflow/community/blob/master/rfcs/20210119-determinism.md). For status and history of GPU-determinism for this op, see [here](https://github.com/NVIDIA/framework-determinism/blob/master/tensorflow_status.md#nearest-neighbor-image-resizing).

CC @reedwm, @sanjoy, @nluehr