### PR TITLE
Update snappy library to 1.1.9

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -723,12 +723,12 @@ def _tf_repositories():
     tf_http_archive(
         name = "snappy",
         build_file = "//third_party:snappy.BUILD",
-        sha256 = "16b677f07832a612b0836178db7f374e414f94657c138e6993cbfc5dcc58651f",
-        strip_prefix = "snappy-1.1.8",
+        sha256 = "75c1fbb3d618dd3a0483bff0e26d0a92b495bbe5059c8b4f1c962b478b6e06e7",
+        strip_prefix = "snappy-1.1.9",
         system_build_file = "//third_party/systemlibs:snappy.BUILD",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/snappy/archive/1.1.8.tar.gz",
-            "https://github.com/google/snappy/archive/1.1.8.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/snappy/archive/1.1.9.tar.gz",
+            "https://github.com/google/snappy/archive/1.1.9.tar.gz",
         ],
     )
 


### PR DESCRIPTION
This PR updates snappy library from 1.1.8 to 1.1.9.
The previous version 1.1.8 was one and half year old. The latest one (1.1.9)
was released last month.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>