### PR TITLE
[r2.6] Update RELEASE.md to add entry for modular file system support (s3 and hdfs)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,11 @@
 
 * Keras been split into a separate PIP package (`keras`), and its code has been moved to the GitHub repository[keras-team/keras](http://github.com/keras-team/keras). The API endpoints for `tf.keras` stay unchanged, but are now backed by the `keras` PIP package. The existing code in tensorflow/python/keras is a staled copy and will be removed in future release (2.7). Please remove any imports to `tensorflow.python.keras` and replace them with public tf.keras API instead.
 
+*  Modular File System Migration
+   * S3 and HDFS file system supports have been migrated to modular file systems
+     and is now available in https://github.com/tensorflow/io. The tensorflow-io
+     python package should be installed for S3 and HDFS support with tensorflow.
+
 ## Known Caveats
 
 * TF Core:


### PR DESCRIPTION
**NOTE: This PR is for r2.6 branch**

This PR update RELEASE.md to add entry for modular file system support (s3 and hdfs).

/cc @mihaimaruseac Don't know if this is still ok though I think it might make sense to add the entry to 2.6 branch of RELEASE.md

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>