### PR TITLE
Fix missing preprocess guards in CUDNN wrapper (Fixes build breakage when CUDNN Frontend not used or CUDNN < 8.1)

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -654,6 +654,7 @@ class CudnnFilterDescriptor {
   SE_DISALLOW_COPY_AND_ASSIGN(CudnnFilterDescriptor);
 };
 
+#if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 // The errata sheet (JSON format) for marking the cudnn engines that might be
 // buggy. For example, we don't want the engine 999 of forward convolution:
 // R"({ "version" : 1,
@@ -709,6 +710,7 @@ const json* CudnnExecutionPlanEngineFilterRuntime() {
   }();
   return json_handle;
 }
+#endif // CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 
 // A helper function to decide whether to use
 // CUDNN_BATCHNORM_SPATIAL_PERSISTENT in batchnorm. This mode can be faster in


### PR DESCRIPTION
Fixes a block of code added by by a [previous PR](https://github.com/tensorflow/tensorflow/pull/50569/commits/07ed03809cbf142229c99ab1b3e6a0dc8641f59b). It is improperly gated by preprocessor macros. It uses `json` symbol which isn't defined unless the header at the top is included, which is gated by macros:

```
#if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
#include "third_party/cudnn_frontend/include/cudnn_frontend.h"
#endif  // CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
```
The header indirectly includes `nlohmann/json`, so if this is not present, and your CuDNN version is < 8100, then the build will break.
