### PR TITLE
Update max version of bazel supported by tensorflow to 4.1.0

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -50,7 +50,7 @@ _TF_WORKSPACE_ROOT = ''
 _TF_BAZELRC = ''
 _TF_CURRENT_BAZEL_VERSION = None
 _TF_MIN_BAZEL_VERSION = '3.7.2'
-_TF_MAX_BAZEL_VERSION = '3.99.0'
+_TF_MAX_BAZEL_VERSION = '4.1.0'
 
 NCCL_LIB_PATHS = [
     'lib64/', 'lib/powerpc64le-linux-gnu/', 'lib/x86_64-linux-gnu/', ''

--- a/configure.py
+++ b/configure.py
@@ -52,6 +52,7 @@ _TF_CURRENT_BAZEL_VERSION = None
 _TF_MIN_BAZEL_VERSION = '3.7.2'
 _TF_MAX_BAZEL_VERSION = '4.1.0'
 
+
 NCCL_LIB_PATHS = [
     'lib64/', 'lib/powerpc64le-linux-gnu/', 'lib/x86_64-linux-gnu/', ''
 ]


### PR DESCRIPTION
For fix the issue: https://github.com/tensorflow/tensorflow/issues/50966#issuecomment-888748570

I'm a member of Microsoft VCPKG team, we recently upgraded the version of bazel used in vcpkg to 4.1.0, then tensorflow build failed with following error:
```
You have bazel 4.1.0 installed.
Please downgrade your bazel installation to version 3.99.0 or lower to build TensorFlow! To downgrade: download the installer for the old version (from https://github.com/bazelbuild/bazel/releases) then run the installer.
```
This issue is due to the fact that tensorflow has set the maximum supported version of bazel to 3.99.0 on line 53 of the https://github.com/tensorflow/tensorflow/blob/master/configure.py file.

For fixing this issue, update the max version of bazel supported by tensorflow to 4.1.0.