### PR TITLE
remove cast of y_true to y_pred data type in sparse categorical cross…

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1748,7 +1748,7 @@ def sparse_categorical_crossentropy(y_true, y_pred, from_logits=False, axis=-1):
     Sparse categorical crossentropy loss value.
   """
   y_pred = ops.convert_to_tensor_v2_with_dispatch(y_pred)
-  y_true = math_ops.cast(y_true, y_pred.dtype)
+  
   return backend.sparse_categorical_crossentropy(
       y_true, y_pred, from_logits=from_logits, axis=axis)
 


### PR DESCRIPTION
sparse_categorical_crossentropy in losses.py performs an unnecessary [cast](https://github.com/tensorflow/tensorflow/blob/35639cd25a878ecd7b97c09b48fbcd7119540db2/tensorflow/python/keras/losses.py#L1727) of y_true to y_pred.dtype since it's then [cast](https://github.com/tensorflow/tensorflow/blob/35639cd25a878ecd7b97c09b48fbcd7119540db2/tensorflow/python/keras/backend.py#L4914) to int64 in sparse_categorical_crossentropy in keras.backend.py. Eventual call to sparse_softmax_cross_entropy_with_logits in nn_ops.py is documented to expect int64 as well.

This seems to be the same code as in categorical_crossentropy, but causes issues with sparse, especially with mixed precision training and float16 as the loss in precision causes incorrect encodings or labels outside the domain resulting in incorrect or nan loss. With float16, issues start with a couple thousand labels and a couple hundred labels with bfloat16.

The error can be found in this [notebook](https://colab.research.google.com/drive/1oRbNOnCo1i2HcXD2V4_-D1Bz2EVxiT65)

The [PR](https://github.com/keras-team/keras/pull/15015) in Keras repository has been merged .