### PR TITLE
add missing dependencies for ChloPasses

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/CMakeLists.txt
@@ -37,6 +37,9 @@ add_mlir_library(ChloPasses
   DEPENDS
   MLIRhlo_opsIncGen
   MLIRChloLegalizeToHloIncGen
+  MLIRMhloPassIncGen
+  MLIRLmhloPassIncGen
+  MLIRDiscRalPassIncGen
 
   LINK_COMPONENTS
   Core


### PR DESCRIPTION
I tried to build the IREE project acording to the docs at https://google.github.io/iree/building-from-source/getting-started/.

During compilation I got the following error:
```
Scanning dependencies of target obj.ChloPasses
[ 74%] Building CXX object third_party/mlir-hlo/lib/Dialect/mhlo/transforms/CMakeFiles/obj.ChloPasses.dir/chlo_legalize_to_hlo.cc.o
[ 74%] Building CXX object third_party/mlir-hlo/lib/Dialect/mhlo/transforms/CMakeFiles/obj.ChloPasses.dir/chlo_legalize_to_hlo_pass.cc.o
In file included from /home/stella/iree_self_build/iree/third_party/mlir-hlo/lib/Dialect/mhlo/transforms/chlo_legalize_to_hlo_pass.cc:18:
/home/stella/iree_self_build/iree/third_party/mlir-hlo/include/mlir-hlo/Dialect/mhlo/transforms/PassDetail.h:32:10: fatal error: mlir-hlo/Dialect/mhlo/transforms/mhlo_passes.h.inc: No such file or directory
   32 | #include "mlir-hlo/Dialect/mhlo/transforms/mhlo_passes.h.inc"
      |          ^~~~~~~~~~~~
compilation terminated.
make[2]:  [third_party/mlir-hlo/lib/Dialect/mhlo/transforms/CMakeFiles/obj.ChloPasses.dir/build.make:76: third_party/mlir-hlo/lib/Dialect/mhlo/transforms/CMakeFiles/obj.ChloPasses.dir/chlo_legalize_to_hlo_pass.cc.o] Error 1
make[1]:  [CMakeFiles/Makefile2:51799: third_party/mlir-hlo/lib/Dialect/mhlo/transforms/CMakeFiles/obj.ChloPasses.dir/all] Error 2
make: *** [Makefile:163: all] Error 2
```

I added the lines:
```
MLIRMhloPassIncGen
MLIRLmhloPassIncGen
MLIRDiscRalPassIncGen
```
to get rid of all the errors. After I fixed the error above I got new errors that why the second and third line needed to be included as well.

