### PR TITLE
[doc fix] Inline help of input_length of the embedding layer

### DIFF
--- a/tensorflow/python/keras/layers/embeddings.py
+++ b/tensorflow/python/keras/layers/embeddings.py
@@ -71,7 +71,7 @@ class Embedding(Layer):
       vocabulary + 1).
     input_length: Length of input sequences, when it is constant.
       This argument is required if you are going to connect
-      `Flatten` then `Dense` layers upstream
+      `Flatten` then `Dense` layers downstream
       (without it, the shape of the dense outputs cannot be computed).
 
   Input shape:


### PR DESCRIPTION
To my understanding, the input_length needs to be specified for the embedding layer only if it is upstream of the flatten and then the dense layers, which means those layers are downstream of the embedding layer.