### PR TITLE
Conv2d native FP16 compute

### DIFF
--- a/tensorflow/core/kernels/conv_2d.h
+++ b/tensorflow/core/kernels/conv_2d.h
@@ -16,11 +16,21 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_KERNELS_CONV_2D_H_
 #define TENSORFLOW_CORE_KERNELS_CONV_2D_H_
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "absl/strings/string_view.h"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/kernels/eigen_backward_spatial_convolutions.h"
 #include "tensorflow/core/kernels/eigen_spatial_convolutions.h"
 #include "tensorflow/core/util/tensor_format.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+// Returns true if TF_CONV2D_USE_FP16_ACCUMULATE == 1, false otherwise.
+static bool Conv2dUseFp16Accumulate() {
+  static bool use_fp16_accumulate = []() {
+    const char* env = std::getenv("TF_CONV2D_USE_FP16_ACCUMULATE");
+    return (env != nullptr) && (absl::string_view(env) == "1");
+  }();
+  return use_fp16_accumulate;
+}
 
 namespace tensorflow {
 namespace functor {
@@ -103,11 +113,17 @@ struct SpatialConvolution<Device, Eigen::half, OutputKernel> {
                   int row_stride, int col_stride, int row_dilation,
                   int col_dilation, const Eigen::PaddingType& padding,
                   const OutputKernel& output_kernel = OutputKernel()) {
-    output.device(d) =
-        Eigen::SpatialConvolution(input.cast<float>(), filter.cast<float>(),
-                                  col_stride, row_stride, padding, col_dilation,
-                                  row_dilation, output_kernel)
-            .template cast<Eigen::half>();
+    if (Conv2dUseFp16Accumulate()) {
+      output.device(d) = Eigen::SpatialConvolution(
+          input, filter, col_stride, row_stride, padding, col_dilation,
+          row_dilation, output_kernel);
+    } else {
+      output.device(d) =
+          Eigen::SpatialConvolution(input.cast<float>(), filter.cast<float>(),
+                                    col_stride, row_stride, padding,
+                                    col_dilation, row_dilation, output_kernel)
+              .template cast<Eigen::half>();
+    }
   }
 
   template <typename Input, typename Filter, typename Output>
@@ -115,12 +131,18 @@ struct SpatialConvolution<Device, Eigen::half, OutputKernel> {
                   int row_stride, int col_stride, int row_dilation,
                   int col_dilation, const Eigen::PaddingType& padding,
                   const OutputKernel& output_kernel = OutputKernel()) {
-    output.device(d) =
-        Eigen::SpatialConvolution(input.template cast<float>(),
-                                  filter.template cast<float>(), col_stride,
-                                  row_stride, padding, col_dilation,
-                                  row_dilation, output_kernel)
-            .template cast<Eigen::half>();
+    if (Conv2dUseFp16Accumulate()) {
+      output.device(d) = Eigen::SpatialConvolution(
+          input, filter, col_stride, row_stride, padding, col_dilation,
+          row_dilation, output_kernel);
+    } else {
+      output.device(d) =
+          Eigen::SpatialConvolution(input.template cast<float>(),
+                                    filter.template cast<float>(), col_stride,
+                                    row_stride, padding, col_dilation,
+                                    row_dilation, output_kernel)
+              .template cast<Eigen::half>();
+    }
   }
 
   void operator()(const Device& d,
@@ -131,13 +153,20 @@ struct SpatialConvolution<Device, Eigen::half, OutputKernel> {
                   int col_dilation, int padding_top, int padding_bottom,
                   int padding_left, int padding_right,
                   const OutputKernel& output_kernel = OutputKernel()) {
-    output.device(d) =
-        Eigen::SpatialConvolution(
-            input.cast<float>(), filter.cast<float>(), col_stride, row_stride,
-            Eigen::PaddingType::PADDING_VALID, col_dilation, row_dilation,
-            output_kernel, padding_left, padding_right, padding_top,
-            padding_bottom)
-            .template cast<Eigen::half>();
+    if (Conv2dUseFp16Accumulate()) {
+      output.device(d) = Eigen::SpatialConvolution(
+          input, filter, col_stride, row_stride,
+          Eigen::PaddingType::PADDING_VALID, col_dilation, row_dilation,
+          output_kernel, padding_left, padding_right, padding_top,
+          padding_bottom);
+    } else {
+      Eigen::SpatialConvolution(input.cast<float>(), filter.cast<float>(),
+                                col_stride, row_stride,
+                                Eigen::PaddingType::PADDING_VALID, col_dilation,
+                                row_dilation, output_kernel, padding_left,
+                                padding_right, padding_top, padding_bottom)
+          .template cast<Eigen::half>();
+    }
   }
 
   template <typename Input, typename Filter, typename Output>
@@ -146,13 +175,21 @@ struct SpatialConvolution<Device, Eigen::half, OutputKernel> {
                   int col_dilation, int padding_top, int padding_bottom,
                   int padding_left, int padding_right,
                   const OutputKernel& output_kernel = OutputKernel()) {
-    output.device(d) =
-        Eigen::SpatialConvolution(
-            input.template cast<float>(), filter.template cast<float>(),
-            col_stride, row_stride, Eigen::PaddingType::PADDING_VALID,
-            col_dilation, row_dilation, output_kernel, padding_left,
-            padding_right, padding_top, padding_bottom)
-            .template cast<Eigen::half>();
+    if (Conv2dUseFp16Accumulate()) {
+      output.device(d) = Eigen::SpatialConvolution(
+          input, filter, col_stride, row_stride,
+          Eigen::PaddingType::PADDING_VALID, col_dilation, row_dilation,
+          output_kernel, padding_left, padding_right, padding_top,
+          padding_bottom);
+    } else {
+      output.device(d) =
+          Eigen::SpatialConvolution(
+              input.template cast<float>(), filter.template cast<float>(),
+              col_stride, row_stride, Eigen::PaddingType::PADDING_VALID,
+              col_dilation, row_dilation, output_kernel, padding_left,
+              padding_right, padding_top, padding_bottom)
+              .template cast<Eigen::half>();
+    }
   }
 };
 

--- a/tensorflow/core/kernels/conv_2d.h
+++ b/tensorflow/core/kernels/conv_2d.h
@@ -160,6 +160,7 @@ struct SpatialConvolution<Device, Eigen::half, OutputKernel> {
           output_kernel, padding_left, padding_right, padding_top,
           padding_bottom);
     } else {
+      output.device(d) =
       Eigen::SpatialConvolution(input.cast<float>(), filter.cast<float>(),
                                 col_stride, row_stride,
                                 Eigen::PaddingType::PADDING_VALID, col_dilation,

--- a/tensorflow/core/kernels/conv_2d.h
+++ b/tensorflow/core/kernels/conv_2d.h
@@ -161,12 +161,12 @@ struct SpatialConvolution<Device, Eigen::half, OutputKernel> {
           padding_bottom);
     } else {
       output.device(d) =
-      Eigen::SpatialConvolution(input.cast<float>(), filter.cast<float>(),
-                                col_stride, row_stride,
-                                Eigen::PaddingType::PADDING_VALID, col_dilation,
-                                row_dilation, output_kernel, padding_left,
-                                padding_right, padding_top, padding_bottom)
-          .template cast<Eigen::half>();
+          Eigen::SpatialConvolution(
+              input.cast<float>(), filter.cast<float>(), col_stride, row_stride,
+              Eigen::PaddingType::PADDING_VALID, col_dilation, row_dilation,
+              output_kernel, padding_left, padding_right, padding_top,
+              padding_bottom)
+              .template cast<Eigen::half>();
     }
   }
 


### PR DESCRIPTION
This patch enables use of native FP16 hardware acceleration for Conv2D op, if available on system.
It is tested on ARM Neoverse N1 CPU. With native FP16 vectored instruction up to 45% improvement is
observed on CNN models (without/very minimal accuracy loss). It is showing very good results in
mixed precision training as well. This will further improve with improved GEMM kernel for FP16.

By default native FP16 Conv2D ops are disabled. 
To enable it, environment variable `TF_CONV2D_USE_FP16_ACCUMULATE` must be set to 1.
i.e. without setting environment variable or in absence of environment variable there is no change
in execution of Conv2D operation.

Default behavior is disabled. i.e. without environment variable
```
# export TF_CONV2D_USE_FP16_ACCUMULATE=0
# python <TensorFlow Application>.py
```
does the same.

To Enable native FP16 accumulate
```
# export TF_CONV2D_USE_FP16_ACCUMULATE=1
# python <TensorFlow Application>.py
```

System Software Configuration used to test/build:
Ubuntu 20.04.2 LTS
GCC: gcc-11 (Ubuntu 11.1.0-1ubuntu1~20.04) 11.1.0
