### PR TITLE
[determinism] Add unimplemented exception to tf.image.adjust_contrast

### DIFF
--- a/tensorflow/core/kernels/image/BUILD
+++ b/tensorflow/core/kernels/image/BUILD
@@ -165,7 +165,7 @@ IMAGE_TEST_DEPS = [
 tf_kernel_library(
     name = "adjust_contrast_op",
     prefix = "adjust_contrast_op",
-    deps = IMAGE_DEPS,
+    deps = IMAGE_DEPS + ["//tensorflow/core/util:determinism_for_kernels"],
 )
 
 cc_library(

--- a/tensorflow/core/kernels/image/adjust_contrast_op.cc
+++ b/tensorflow/core/kernels/image/adjust_contrast_op.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/util/determinism.h"
 
 namespace tensorflow {
 
@@ -63,6 +64,14 @@ class AdjustContrastOp : public OpKernel {
     OP_REQUIRES(context, TensorShapeUtils::IsScalar(max_value.shape()),
                 errors::InvalidArgument("max_value must be scalar: ",
                                         max_value.shape().DebugString()));
+
+    if (std::is_same<Device, GPUDevice>::value) {
+      OP_REQUIRES(
+          context, !OpDeterminismRequired(),
+          errors::Unimplemented(
+              "A deterministic GPU implementation of AdjustContrastOp"
+              " is not currently available."));
+    }
 
     Tensor* output = nullptr;
     OP_REQUIRES_OK(context,
@@ -413,6 +422,13 @@ class AdjustContrastOpv2<GPUDevice, T> : public AdjustContrastOpV2Base {
                  const ComputeOptions& options) override {
     const int64_t shape[4] = {options.batch, options.height, options.width,
                               options.channels};
+
+    OP_REQUIRES(
+        context, !OpDeterminismRequired(),
+        errors::Unimplemented(
+            "A deterministic GPU implementation of AdjustContrastOpv2"
+            " is not currently available."));
+
     functor::AdjustContrastv2<GPUDevice, T>()(
         context->eigen_device<GPUDevice>(), options.input->shaped<T, 4>(shape),
         options.factor->scalar<float>(), options.output->shaped<T, 4>(shape));

--- a/tensorflow/core/kernels/image/adjust_contrast_op.cc
+++ b/tensorflow/core/kernels/image/adjust_contrast_op.cc
@@ -69,8 +69,8 @@ class AdjustContrastOp : public OpKernel {
       OP_REQUIRES(
           context, !OpDeterminismRequired(),
           errors::Unimplemented(
-              "A deterministic GPU implementation of AdjustContrastOp"
-              " is not currently available."));
+              "A deterministic GPU implementation of AdjustContrast is not"
+              " currently available."));
     }
 
     Tensor* output = nullptr;
@@ -426,8 +426,8 @@ class AdjustContrastOpv2<GPUDevice, T> : public AdjustContrastOpV2Base {
     OP_REQUIRES(
         context, !OpDeterminismRequired(),
         errors::Unimplemented(
-            "A deterministic GPU implementation of AdjustContrastOpv2"
-            " is not currently available."));
+            "A deterministic GPU implementation of AdjustContrastv2 is not"
+            " currently available."));
 
     functor::AdjustContrastv2<GPUDevice, T>()(
         context->eigen_device<GPUDevice>(), options.input->shaped<T, 4>(shape),

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -2799,6 +2799,7 @@ cuda_py_test(
     deps = [
         ":array_ops",
         ":client_testlib",
+        ":config",
         ":control_flow_ops",
         ":image_ops",
         ":io_ops",

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -1710,6 +1710,16 @@ def force_cpu():
     yield
 
 
+@contextlib.contextmanager
+def deterministic_ops():
+  """Enables deterministic ops."""
+  try:
+    config.enable_deterministic_ops(True)
+    yield
+  finally:
+    config.enable_deterministic_ops(False)
+
+
 class CapturedWrites(object):
   """A utility class to load the captured writes made to a stream."""
 

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -1606,9 +1606,9 @@ class AdjustContrastTest(test_util.TensorFlowTestCase):
       input_shape = (1, 2, 2, 1)
       on_gpu = len(config.list_physical_devices('GPU'))
       # AdjustContrast seems to now be inaccessible via the Python API.
-      # AdjustContrastv2 only suports float16 and float32 on GPU, but the
-      # following types are converted to and from float32 at the Python level
-      # before AdjustContrastv2 is called.
+      # AdjustContrastv2 only supports float16 and float32 on GPU, and other
+      # types are converted to and from float32 at the Python level before
+      # AdjustContrastv2 is called.
       for dtype in [
           dtypes.uint8, dtypes.int8, dtypes.int16, dtypes.int32, dtypes.float16,
           dtypes.float32, dtypes.float64]:


### PR DESCRIPTION
This current PR adds and tests determinism-unimplemented exception-throwing for `tf.image.adjust_contrast`.

This PR is related to [RFC: Enabling Determinism in TensorFlow](https://github.com/tensorflow/community/blob/master/rfcs/20210119-determinism.md). For status and history of GPU-determinism for this op, see [here](https://github.com/NVIDIA/framework-determinism/blob/master/tensorflow_status.md#adjust-contrast).

CC @reedwm, @sanjoy, @nluehr