### PR TITLE
Don't do any work when reshaping 0 elements sparse tensor.

### DIFF
--- a/tensorflow/core/kernels/reshape_util.cc
+++ b/tensorflow/core/kernels/reshape_util.cc
@@ -174,6 +174,12 @@ void ReshapeSparseTensor(OpKernelContext *context,
                                           TensorShape({nnz, output_rank}),
                                           &result_indices));
   if (nnz > 0) {
+    OP_REQUIRES(
+        context, dense_size > 0 && product > 0,
+        errors::InvalidArgument(
+            "Input tensor has ", nnz, " non zero elements but input shape (",
+            input_shape.DebugString(), ") or output shape (",
+            output_shape.DebugString(), ") is empty"));
     OP_REQUIRES_OK(context, functor::ReshapeSparseTensorFunctor<Device>()(
                                 context, input_shape, output_shape,
                                 input_indices_in.matrix<int64>(),


### PR DESCRIPTION
If reshaping to 0 elements tensor, check that input has no elements.
If reshaping no elements input, check that output has no elements.

PiperOrigin-RevId: 388296986
Change-Id: Iadc9fe7252e14313ca987e69bf0d7042fd10232a