### PR TITLE
[CoreML Delegate] Set the padding explicitly for kTfLiteBuiltinMean operation

### DIFF
--- a/tensorflow/lite/delegates/coreml/builders/pooling_layer_builder.cc
+++ b/tensorflow/lite/delegates/coreml/builders/pooling_layer_builder.cc
@@ -51,6 +51,7 @@ CoreML::Specification::NeuralNetworkLayer* PoolingLayerBuilder::Build() {
   auto* pooling_params = layer_->mutable_pooling();
 
   if (pooling_type_ == kTfLiteBuiltinMean) {
+    pooling_params->mutable_same();
     pooling_params->set_type(
         CoreML::Specification::PoolingLayerParams::AVERAGE);
     pooling_params->set_globalpooling(true);


### PR DESCRIPTION
Fixes error with CoreML delegate for some models that use the Mean layer by explicitly setting the padding type to SAME

The specific error that this fixes:
`Error compiling model Error reading protobuf spec. validator error: Padding type for the pooling layer 'PoolingLayerBuilder (MEAN)_2' is not set.`

I received the above error on the nightly build of TensorflowLiteSwift (2.5.0) on my iPhone XS device.

This seems to be a new error, I've only experienced this with a new object detection model that was converted using MLIR and on the 2.5.0 runtime.

I did not have this issue with previous object detection models that were converted using Toco and on the 1.14 runtime.

