### PR TITLE
Update mobilenet_v2.py

### DIFF
--- a/tensorflow/python/keras/applications/mobilenet_v2.py
+++ b/tensorflow/python/keras/applications/mobilenet_v2.py
@@ -447,7 +447,6 @@ def _inverted_res_block(inputs, expansion, stride, alpha, filters, block_id):
         momentum=0.999,
         name=prefix + 'expand_BN')(
             x)
-    x = layers.ReLU(6., name=prefix + 'expand_relu')(x)
   else:
     prefix = 'expanded_conv_'
 


### PR DESCRIPTION
Removed "x = layers.ReLU(6., name=prefix + 'expand_relu')(x)"
Fix for # 50835