### PR TITLE
Bump curl dependency to 7.77.0

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -671,13 +671,13 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
 
     tf_http_archive(
         name = "curl",
-        build_file = clean_dep("//third_party:curl.BUILD"),
-        sha256 = "3b4378156ba09e224008e81dcce854b7ce4d182b1f9cfb97fe5ed9e9c18c6bd3",
-        strip_prefix = "curl-7.76.0",
-        system_build_file = clean_dep("//third_party/systemlibs:curl.BUILD"),
+        build_file = "//third_party:curl.BUILD",
+        sha256 = "b0a3428acb60fa59044c4d0baae4e4fc09ae9af1d8a3aa84b2e3fbcd99841f77",
+        strip_prefix = "curl-7.77.0",
+        system_build_file = "//third_party/systemlibs:curl.BUILD",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/curl.haxx.se/download/curl-7.76.0.tar.gz",
-            "https://curl.haxx.se/download/curl-7.76.0.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/curl.haxx.se/download/curl-7.77.0.tar.gz",
+            "https://curl.haxx.se/download/curl-7.77.0.tar.gz",
         ],
     )
 

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -40,6 +40,8 @@ cc_library(
         "lib/asyn-ares.c",
         "lib/asyn.h",
         "lib/base64.c",
+        "lib/bufref.c",
+        "lib/bufref.h",
         "lib/c-hyper.c",
         "lib/c-hyper.h",
         "lib/config-amigaos.h",


### PR DESCRIPTION
Handles the following CVEs:

* [CVE-2021-22901](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22901)
* [CVE-2021-22898](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22898)
* [CVE-2021-22876](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22876)
* [CVE-2021-22897](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22897)

PiperOrigin-RevId: 384576784
Change-Id: Iaf4f499736039ea957efb0af596d1a46f3062797