### PR TITLE
Enable resource update aliasing in auto-clustering

### DIFF
--- a/tensorflow/compiler/jit/kernels/xla_ops.cc
+++ b/tensorflow/compiler/jit/kernels/xla_ops.cc
@@ -419,8 +419,8 @@ void XlaCompileOp::Compute(OpKernelContext* ctx) {
                                         inputs, resources_, &variable_infos));
     OP_REQUIRES_OK(ctx, LockVariables(absl::MakeSpan(variable_infos)));
 
-    // We turn on the `may_alias_resource_update` using the following strategy.
-    // In XalRunOp, if we observe the resource variables have been written, we
+    // We turn on `may_alias_resource_update` using the following strategy.
+    // In XlaRunOp, if we observe the resource variables have been written, we
     // use the snapshotted tensors as inputs to the XLA executable to ensure the
     // shape consistency. In contrast, if the resource variables have not been
     // written, we could perform in-place updates to the resource var (without
@@ -513,7 +513,7 @@ void XlaRunOp::Compute(OpKernelContext* ctx) {
       ctx, *closure.compilation_result(), closure.num_constant_args());
   OP_REQUIRES_OK(ctx, variable_infos.status());
   OP_REQUIRES_OK(ctx, LockVariables(absl::MakeSpan(*variable_infos)));
-  std::map<int, const Tensor*> resource_var_ptrs;
+  absl::flat_hash_map<int, const Tensor*> resource_var_ptrs;
   for (int i = 0; i < variable_infos->size(); i++) {
     // Normalized back to the indices as seen by XlaCompileOp.
     int compile_time_idx =

--- a/tensorflow/python/eager/BUILD
+++ b/tensorflow/python/eager/BUILD
@@ -966,6 +966,24 @@ tf_xla_py_test(
 )
 
 tf_xla_py_test(
+    name = "def_function_auto_jit_test",
+    size = "small",
+    srcs = ["def_function_auto_jit_test.py"],
+    disabled_backends = [
+        "cpu",
+        "cpu_ondemand",
+        "gpu_ondemand",
+    ],
+    enable_mlir_bridge = False,
+    python_version = "PY3",
+    deps = [
+        ":def_function",
+        "//tensorflow/compiler/tests:xla_test",
+        "//tensorflow/python:constant_op",
+    ],
+)
+
+tf_xla_py_test(
     name = "def_function_xla_test",
     srcs = ["def_function_xla_test.py"],
     enable_mlir_bridge = False,

--- a/tensorflow/python/eager/BUILD
+++ b/tensorflow/python/eager/BUILD
@@ -976,6 +976,12 @@ tf_xla_py_test(
     ],
     enable_mlir_bridge = False,
     python_version = "PY3",
+    tags = [
+        "no_mac",
+        "no_pip",
+        "no_tfrt",
+        "no_windows",
+    ],
     deps = [
         ":def_function",
         "//tensorflow/compiler/tests:xla_test",

--- a/tensorflow/python/eager/def_function_auto_jit_test.py
+++ b/tensorflow/python/eager/def_function_auto_jit_test.py
@@ -1,0 +1,57 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.compiler.tests import xla_test
+from tensorflow.python.eager import context
+from tensorflow.python.eager import def_function
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import random_ops
+from tensorflow.python.ops import variables
+from tensorflow.python.platform import test
+
+class DefFunctionAutoclusteringTest(xla_test.XLATestCase):
+
+  def testUpdateVariableMemoryUsage(self):
+    if 'tpu' in self.device.lower():
+      self.skipTest('Autoclustering does not run on TPU')
+
+    v = variables.Variable(random_ops.random_normal([1024, 1024]))
+
+    @def_function.function(jit_compile=False)
+    def update_var(a, b, c):
+      v.assign_add(a * b + c * c)
+
+    arg1 = random_ops.random_normal([1024, 1024])
+    arg2 = random_ops.random_normal([1024, 1024])
+    arg3 = random_ops.random_normal([1024, 1024])
+
+    initial_usage = context.context().get_memory_info(
+        v.device)['current']
+    with context.collect_graphs(optimized=True) as graphs:
+      update_var(arg1, arg2, arg3)
+    final_usage = context.context().get_memory_info(
+        v.device)['current']
+
+    self.assertIn('_XlaRun', [n.op for n in graphs[0].node])
+    self.assertEqual(initial_usage, final_usage)
+
+if __name__ == '__main__':
+  ops.enable_eager_execution()
+  context.context().optimizer_jit = True
+  test.main()

--- a/tensorflow/python/eager/def_function_auto_jit_test.py
+++ b/tensorflow/python/eager/def_function_auto_jit_test.py
@@ -20,7 +20,9 @@ from __future__ import print_function
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.eager import context
 from tensorflow.python.eager import def_function
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import random_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
@@ -54,6 +56,35 @@ class DefFunctionAutoclusteringTest(xla_test.XLATestCase):
     self.assertIn('_XlaRun', [n.op for n in graphs[0].node])
     self.assertEqual(initial_usage, final_usage)
 
+  def testUpdateVariableWithCompileTimeConstMemoryUsage(self):
+    if 'tpu' in self.device.lower():
+      self.skipTest('Autoclustering does not run on TPU')
+
+    v = variables.Variable(random_ops.random_normal([128, 128]))
+
+    # test a signature of (compile-time const, args, res_var). The compile-time
+    # const will be optimized away so that the kernel signature will become
+    # (args, res_var).
+    @def_function.function(jit_compile=False)
+    def update_var(shape, a, b, c):
+      # create 4 ops here, which is the required minimum cluster size.
+      x = a * b
+      y = x + c
+      v.assign_add(array_ops.reshape(y, shape))
+
+    arg1 = random_ops.random_normal([1])
+    arg2 = random_ops.random_normal([1])
+    arg3 = random_ops.random_normal([1])
+
+    with context.collect_graphs(optimized=True) as graphs:
+      initial_usage = context.context().get_memory_info(
+          v.device)['current']
+      update_var(constant_op.constant([1, 1]), arg1, arg2, arg3)
+      final_usage = context.context().get_memory_info(
+          v.device)['current']
+
+    self.assertIn('_XlaRun', [n.op for n in graphs[0].node])
+    self.assertEqual(initial_usage, final_usage)
 
 if __name__ == '__main__':
   ops.enable_eager_execution()


### PR DESCRIPTION

We see cases where enabling resource update aliasing greatly reduces memory footprints.

