### PR TITLE
[tflite] add same scale constraint to tflite's mean op

### DIFF
--- a/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
+++ b/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
@@ -2100,6 +2100,7 @@ def TFL_MaximumOp : TFL_Op<"maximum", [
 def TFL_MeanOp : TFL_Op<"mean", [
     PredOpTrait<"input and output must have same element type",
       TFL_TCresVTEtIsSameAsOp<0, 0>>,
+    SameOperandsAndResultsScale,
     NoSideEffect]> {
   let summary = "Mean operator";
 


### PR DESCRIPTION
Add SameOperandsAndResultsScal to tflite's mean. Without this constraint, post-training quantization ([PTQ](https://www.tensorflow.org/lite/performance/post_training_quantization)) may result in MEAN with different quantization scales for inputs and outputs. Because NNAPI only supports MEAN with same quantization parameters for inputs and output, this kind of mean ops could not be delegated to NNAPI via the NNAPI delegate.

E.g., if we do PTQ on the [ResNet 50 from tfhub](https://tfhub.dev/tensorflow/resnet_50/classification/1),
```python
import itertools
import os
import pathlib
import requests
import tarfile

import tensorflow as tf
import tensorflow_datasets as tfds

saved_model_dir = "./resnet_saved_model/"
resnet_saved_model_file = "https://tfhub.dev/tensorflow/resnet_50/classification/1?tf-hub-format=compressed"
response = requests.get(resnet_saved_model_file, stream=True)
file = tarfile.open(fileobj=response.raw, mode="r|gz")
file.extractall(path=saved_model_dir)

imagenet_validation = tfds.load(name="imagenet2012", split="validation")

def representative_data_gen():
  for imagenet_example in imagenet_validation.take(100):
    image, label = imagenet_example["image"], imagenet_example["label"]
    image = tf.cast(image, tf.float32) / 255.0
    image = tf.image.central_crop(image, central_fraction=0.875)
    image = tf.expand_dims(image, 0)
    image = tf.image.resize(image, (224,224))
    yield [image]

converter = tf.lite.TFLiteConverter.from_saved_model(saved_model_dir)
converter.optimizations = [tf.lite.Optimize.DEFAULT]
converter.representative_dataset = representative_data_gen
converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
converter.inference_input_type = tf.int8 
converter.inference_output_type = tf.int8 
tflite_quant_model = converter.convert()

tflite_quant_model_file = pathlib.Path('/tmp')/"resnet50_quant.tflite"
tflite_quant_model_file.write_bytes(tflite_quant_model)
```
then `adb push /tmp/resnet50_quant.tflite /data/local/tmp/`, and run `benchmark_model` on device (here I ran it on a Pixel 4)
```
$ ./benchmark_model_validation --graph=resnet50_qnant.tflite   --use_nnapi=1 --enable_op_profiling=1

```
It shows something like:
```
STARTING!
Log parameter values verbosely: [0]
Graph: [resnet_v15_quant_original_mean.tflite]
Enable op profiling: [1]
Use NNAPI: [1]
NNAPI accelerators available: [qti-default,qti-dsp,qti-gpu,google-edgetpu,nnapi-reference]
Loaded model resnet50_quant.tflite
INFO: Initialized TensorFlow Lite runtime.
INFO: Created TensorFlow Lite delegate for NNAPI.
NNAPI delegate created.
WARNING: Operator MEAN (v2) refused by NNAPI delegate: NNAPI requires that the input and output have the same quantization parameters.
INFO: Replacing 75 node(s) with delegate (TfLiteNnapiDelegate) node, yielding 3 partitions.
Explicitly applied NNAPI delegate, and the model graph will be partially executed by the delegate w/ 2 delegate kernels.
.......
Operator-wise Profiling Info for Regular Benchmark Runs:
============================== Run Order ==============================
	             [node type]	          [start]	  [first]	 [avg ms]	     [%]	  [cdf%]	  [mem KB]	[times called]	[Name]
	     TfLiteNnapiDelegate	            0.009	   14.431	   14.449	 48.545%	 48.545%	     0.000	        1	[resnet50/activation_48/Relu;resnet50/add_15/add]:76
	                    MEAN	           14.460	   13.399	   13.501	 45.359%	 93.904%	     0.000	        1	[resnet50/reduce_mean/Mean]:73
	     TfLiteNnapiDelegate	           27.962	    1.754	    1.814	  6.096%	100.000%	     0.000	        1	[StatefulPartitionedCall:0]:77
.......
Number of nodes executed: 3
============================== Summary by node type ==============================
	             [Node type]	  [count]	  [avg ms]	    [avg %]	    [cdf %]	  [mem KB]	[times called]
	     TfLiteNnapiDelegate	        2	    16.263	    54.642%	    54.642%	     0.000	        2
	                    MEAN	        1	    13.500	    45.358%	   100.000%	     0.000	        1

Timings (microseconds): count=50 first=29584 curr=22585 min=22585 max=33233 avg=29764 std=1779
Memory (bytes): count=0
3 nodes observe
```
With this constraint applied, for the same ResNet 50 model, I got something like the following:
```
....
Number of nodes executed: 1
============================== Summary by node type ==============================
	             [Node type]	  [count]	  [avg ms]	    [avg %]	    [cdf %]	  [mem KB]	[times called]
	     TfLiteNnapiDelegate	        1	    14.762	   100.000%	   100.000%	     0.000	        1

Timings (microseconds): count=67 first=14774 curr=15087 min=13959 max=15226 avg=14762.4 std=248
Memory (bytes): count=0
1 nodes observed
```