### PR TITLE
Add expected failing test for path with glob

### DIFF
--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -20,6 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import os.path
+import unittest
 
 from absl.testing import parameterized
 import numpy as np
@@ -187,6 +188,20 @@ class FileIoTest(test.TestCase, parameterized.TestCase):
     dir_path = os.path.join(self._base_dir, "dir_(special)")
     file_io.create_dir(dir_path)
     files = ["file1.txt", "file(2).txt"]
+    for name in files:
+      file_path = os.path.join(dir_path, name)
+      file_io.FileIO(file_path, mode="w").write("testing")
+    expected_match = [os.path.join(dir_path, name) for name in files]
+    glob_pattern = os.path.join(dir_path, "*")
+    self.assertItemsEqual(
+        file_io.get_matching_files(glob_pattern), expected_match)
+
+  @unittest.expectedFailure
+  def testGetMatchingFilesWhenContainsGlob(self):
+    # https://git.io/JR8jL (#35489)
+    dir_path = os.path.join(self._base_dir, "dir_[special]")
+    file_io.create_dir(dir_path)
+    files = ["file1.txt", "file*2?].txt"]
     for name in files:
       file_path = os.path.join(dir_path, name)
       file_io.FileIO(file_path, mode="w").write("testing")

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -208,7 +208,7 @@ class FileIoTest(test.TestCase, parameterized.TestCase):
     glob_pattern = os.path.join(dir_path, "*")
     self.assertItemsEqual(
         file_io.get_matching_files(glob_pattern), expected_match,
-        "Check #35489 https://git.io/JR8jL")
+        "https://github.com/tensorflow/tensorflow/issues/35489")
 
   @run_all_path_types
   def testCreateRecursiveDir(self, join):

--- a/tensorflow/python/lib/io/file_io_test.py
+++ b/tensorflow/python/lib/io/file_io_test.py
@@ -198,8 +198,7 @@ class FileIoTest(test.TestCase, parameterized.TestCase):
 
   @unittest.expectedFailure
   def testGetMatchingFilesWhenContainsGlob(self):
-    # https://git.io/JR8jL (#35489)
-    dir_path = os.path.join(self._base_dir, "dir_[special]")
+    dir_path = os.path.join(self._base_dir, "[dir_special]")
     file_io.create_dir(dir_path)
     files = ["file1.txt", "file*2?].txt"]
     for name in files:
@@ -208,7 +207,8 @@ class FileIoTest(test.TestCase, parameterized.TestCase):
     expected_match = [os.path.join(dir_path, name) for name in files]
     glob_pattern = os.path.join(dir_path, "*")
     self.assertItemsEqual(
-        file_io.get_matching_files(glob_pattern), expected_match)
+        file_io.get_matching_files(glob_pattern), expected_match,
+        "Check #35489 https://git.io/JR8jL")
 
   @run_all_path_types
   def testCreateRecursiveDir(self, join):


### PR DESCRIPTION
Add a failing test for https://github.com/tensorflow/tensorflow/issues/35489

/cc @mihaimaruseac 

You can test locally with:
`bazel test --test_arg=FileIoTest.testGetMatchingFilesWhenContainsGlob  //tensorflow/python/lib/io:file_io_test`

When the test will fail it is probably fixed and you can remove `@unittest.expectedFailure` to pass the test. 
You could temp comment `#@unittest.expectedFailure` for debugging the failure when you are developing a fix.

When it will be fixed, more in general it is suggested that you will locally test the whole target:
`bazel test --test_arg=FileIoTest.testGetMatchingFilesWhenContainsGlob  //tensorflow/python/lib/io:file_io_test`