### PR TITLE
2.6 cherry-pick request: Update tensorboard dependencies.

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -101,7 +101,7 @@ REQUIRED_PACKAGES = [
     # These need to be in sync with the existing TF version
     # They are updated during the release process
     # When updating these, please also update the nightly versions below
-    'tensorboard ~= 2.5',
+    'tensorboard ~= 2.6',
     'tensorflow-estimator >= 2.6.0rc0 , < 2.7.0',
     'keras >= 2.6.0rc1 , < 2.7.0',
 ]
@@ -115,7 +115,7 @@ REQUIRED_PACKAGES = [
 if 'tf_nightly' in project_name:
   for i, pkg in enumerate(REQUIRED_PACKAGES):
     if 'tensorboard' in pkg:
-      REQUIRED_PACKAGES[i] = 'tb-nightly ~= 2.6.0.a'
+      REQUIRED_PACKAGES[i] = 'tb-nightly ~= 2.7.0.a'
     elif 'tensorflow_estimator' in pkg:
       REQUIRED_PACKAGES[i] = 'tf-estimator-nightly ~= 2.6.0.dev'
     elif 'keras' in pkg and 'keras_preprocessing' not in pkg:


### PR DESCRIPTION
Update tensorboard dependency to 2.6.x and tb-nightly dependency to 2.7.x.
Necessary to have a tensorboard version installed with tensorflow 2.6.0 that will work.

PiperOrigin-RevId: 389635311
Change-Id: I73e876a3f398463f600c4c61bfd27468a1d7a2dc