### PR TITLE
Add TF-TRT Python integration tests in dynamic shape mode

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/biasadd_matmul_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/biasadd_matmul_test.py
@@ -121,7 +121,13 @@ class BiasaddMatMulTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    if run_params.dynamic_shape:
+      # Increased conversion rate in dynamic shape mode due to a few additional
+      # conversions for MatMul, Reshape and Concat ops. This increases the size
+      # of the candidate segments and results in two more TrtEngineOps.
+      return ["TRTEngineOp_0", "TRTEngineOp_1", "TRTEngineOp_2"]
+    else:
+      return ["TRTEngineOp_0"]
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/binary_tensor_weight_broadcast_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/binary_tensor_weight_broadcast_test.py
@@ -60,7 +60,10 @@ class BinaryTensorWeightBroadcastTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_%d" % i for i in range(16)]
+    # The final reshape op is converted only in dynamic shape mode. This op is
+    # placed into a new engine due to the preceding trt_incompatible_ops.
+    num_engines = 17 if run_params.dynamic_shape else 16
+    return ["TRTEngineOp_%d" % i for i in range(num_engines)]
 
   # TODO(b/176540862): remove this routine to disallow native segment execution
   # for TensorRT 7+.

--- a/tensorflow/python/compiler/tensorrt/test/combined_nms_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/combined_nms_test.py
@@ -86,13 +86,19 @@ class CombinedNmsTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return {
-        'TRTEngineOp_0': [
-            'combined_nms/CombinedNonMaxSuppression',
-            'max_output_size_per_class', 'max_total_size', 'iou_threshold',
-            'score_threshold'
-        ]
-    }
+    if not run_params.dynamic_shape:
+      return {
+          'TRTEngineOp_0': [
+              'combined_nms/CombinedNonMaxSuppression',
+              'max_output_size_per_class', 'max_total_size', 'iou_threshold',
+              'score_threshold'
+          ]
+      }
+    else:
+      # The CombinedNMS op is currently not converted in dynamic shape mode.
+      # This branch shall be removed once the converter is updated to handle
+      # input with dynamic shape.
+      return dict()
 
   def ShouldRunTest(self, run_params):
     should_run, reason = super().ShouldRunTest(run_params)

--- a/tensorflow/python/compiler/tensorrt/test/rank_two_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/rank_two_test.py
@@ -61,7 +61,7 @@ class RankTwoTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return {
+    expected_engines = {
         "TRTEngineOp_0": [
             "add0_1", "add0_2", "add0_3", "c0_1", "c0_2", "c0_3", "abs0_1",
             "abs0_2", "expand0_0", "expand0_1", "axis"
@@ -69,13 +69,19 @@ class RankTwoTest(trt_test.TfTrtIntegrationTestBase):
         "TRTEngineOp_1": [
             "add1_1", "add1_2", "add1_3", "c1_1", "c1_2", "c1_3", "abs1_1",
             "abs1_2", "reciprocal1"
-        ],
-        # The two ops can't be in the same cluster as the ops in TRTEngineOp_0
-        # due to trt_incompatible_op. They can't be in the same cluster as the
-        # ops in TRTEngineOP_1 because their batch size belongs to a different
-        # equivalent class.
-        "TRTEngineOp_2": ["add", "reciprocal0"]
-    }
+        ]}
+    if not run_params.dynamic_shape:
+      # The two ops can't be in the same cluster as the ops in TRTEngineOp_0
+      # due to trt_incompatible_op. They can't be in the same cluster as the
+      # ops in TRTEngineOP_1 because their batch size belongs to a different
+      # equivalent class.
+      expected_engines["TRTEngineOp_2"] = ["add", "reciprocal0"]
+    else:
+      # In dynamic shape mode the batch size of the ops can differ,
+      # therefore the final ops will be merged to TRTEngineOP_1.
+      expected_engines["TRTEngineOp_1"] += ["add", "reciprocal0"]
+
+    return expected_engines
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/tf_function_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_function_test.py
@@ -41,6 +41,7 @@ class TfFunctionTest(trt_test.TfTrtIntegrationTestBase):
 
   def __init__(self, methodName):  # pylint: disable=invalid-name
     super(TfFunctionTest, self).__init__(methodName)
+    self._profile_strategy = "Range"
     self._trt_engine_op_count_offset = 0
     self._test_conversion_params = {
         "_tftrt_convert_function": True,
@@ -53,7 +54,7 @@ class TfFunctionTest(trt_test.TfTrtIntegrationTestBase):
         "_tftrt_max_cached_engines": 1,
         "_tftrt_use_calibration": False,
         "_tftrt_use_implicit_batch": True,
-        "_tftrt_profile_strategy": "Range",
+        "_tftrt_profile_strategy": self._profile_strategy,
         "_tftrt_allow_build_at_runtime": False
     }
     self._is_v2 = False
@@ -333,6 +334,8 @@ class TfFunctionTest(trt_test.TfTrtIntegrationTestBase):
     else:
       self._test_conversion_params["_tftrt_allow_build_at_runtime"] = (
           run_params.convert_online or run_params.dynamic_engine)
+    self._test_conversion_params["_tftrt_use_implicit_batch"] = \
+        not run_params.dynamic_shape
     self.DisableNonTrtOptimizers()
     trt_test.TfTrtIntegrationTestBase.RunTest(self, run_params)
 

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -87,6 +87,7 @@ RunParams = collections.namedtuple(
         "test_name",
         # Is this test for TF 2.0?
         "is_v2",
+        "dynamic_shape",
     ])
 
 FP32 = "FP32"
@@ -160,8 +161,7 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
     super(TfTrtIntegrationTestBase, self).__init__(methodName)
     self._trt_test_params = None
     self._disable_non_trt_optimizers = False
-    self._use_implicit_batch = True
-    self._profile_strategy = "Unknown"
+    self._profile_strategy = "ImplicitBatchModeCompatible"
 
   def setUp(self):
     """Setup method."""
@@ -265,10 +265,6 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
 
   def DisableNonTrtOptimizers(self):
     self._disable_non_trt_optimizers = True
-
-  def SetDynamicShapeModeAndProfileStrategy(self, profile_strategy="Range"):
-    self._use_implicit_batch = False
-    self._profile_strategy = profile_strategy
 
   def GetParams(self):
     """Returns a TfTrtIntegrationTestParams for the test."""
@@ -457,7 +453,7 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
       converter_v2 = trt_convert.TrtGraphConverterV2(
           input_saved_model_dir=saved_model_dir,
           conversion_params=conversion_params,
-          use_dynamic_shape=not self._use_implicit_batch,
+          use_dynamic_shape=run_params.dynamic_shape,
           dynamic_shape_profile_strategy=self._profile_strategy)
       if self._disable_non_trt_optimizers:
         converter_v2._test_only_disable_non_trt_optimizers = True  # pylint: disable=protected-access
@@ -516,12 +512,13 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
                                       conversion_params)
     converter.convert()
 
-    if not self._use_implicit_batch and self._ShouldConverterBuild(run_params):
+    if run_params.dynamic_shape and self._ShouldConverterBuild(run_params):
       logging.info("Using build mode")
 
       def _BuildInputFn():
         for shapes in self._GetParamsCached().input_dims:
-          yield [np.zeros(x).astype(np.float32) for x in shapes]
+          yield [array_ops.zeros(x, dtype=spec.dtype) for (x, spec) in
+                 zip(shapes, self._GetParamsCached().input_specs)]
 
       converter.build(input_fn=_BuildInputFn)
 
@@ -886,7 +883,7 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
           all_op_names.append(node.name)
           if node.op == "TRTEngineOp":
             trt_op_names.append(node.name)
-            if not self._use_implicit_batch:
+            if run_params.dynamic_shape:
               self.assertEqual(
                   self._ToString(node.attr["profile_strategy"].s).lower(),
                   self._profile_strategy.lower())
@@ -1066,6 +1063,7 @@ def _GetTestConfigsV1():
   convert_online, convert_offline = True, False
   dynamic_engine, static_engine = True, False
   use_calibration, no_calibration = True, False
+  implicit_batch = False
 
   # Add all possible test cases and let the derived test class to decide
   # whether to run specific ones with ShouldRunTest().
@@ -1073,10 +1071,12 @@ def _GetTestConfigsV1():
   # Note: INT8 without calibration behaves like FP32/FP16.
   opts = list(
       itertools.product([FP32, FP16, INT8], [convert_online, convert_offline],
-                        [dynamic_engine, static_engine], [no_calibration]))
+                        [dynamic_engine, static_engine], [no_calibration],
+                        [implicit_batch]))
   # We always run calibration with offline tool.
   # TODO(aaroey): static calibration engine is not supported yet.
-  opts.append((INT8, convert_offline, dynamic_engine, use_calibration))
+  opts.append((INT8, convert_offline, dynamic_engine, use_calibration,
+               implicit_batch))
   return opts
 
 
@@ -1099,7 +1099,7 @@ def _GetTestConfigsV2():
   # - INT8 without calibration behaves like FP32/FP16.
   opts = list(
       itertools.product([FP32, FP16, INT8], [convert_offline], [dynamic_engine],
-                        [no_calibration]))
+                        [no_calibration], [False, True]))
   # We always run calibration with offline tool.
   # TODO(aaroey): INT8+calibration is not supported yet in V2.
   # opts.append((INT8, convert_offline, dynamic_engine, use_calibration))
@@ -1112,9 +1112,10 @@ def _GetTest(run_params):
   def _Test(self):
     logging.info(
         "Running test %s with parameters: convert_online=%s, "
-        "precision_mode=%s, dynamic_engine=%s", run_params.test_name,
-        run_params.convert_online, run_params.precision_mode,
-        run_params.dynamic_engine)
+        "precision_mode=%s, dynamic_engine=%s, dynamic_shape_mode%s",
+        run_params.test_name, run_params.convert_online,
+        run_params.precision_mode, run_params.dynamic_engine,
+        run_params.dynamic_shape)
     self.RunTest(run_params)
 
   return _Test
@@ -1123,20 +1124,22 @@ def _GetTest(run_params):
 def _AddTestsFor(test_class, is_v2):
   """Adds test methods to TfTrtIntegrationTestBase for specific TF version."""
   opts = _GetTestConfigsV2() if is_v2 else _GetTestConfigsV1()
-  for (precision_mode, convert_online, dynamic_engine, use_calibration) in opts:
+  for (precision_mode, convert_online, dynamic_engine, use_calibration,
+       dynamic_shape) in opts:
     conversion = "OnlineConversion" if convert_online else "OfflineConversion"
     engine_type = "DynamicEngine" if dynamic_engine else "StaticEngine"
     calibration_type = "UseCalibration" if use_calibration else "NoCalibration"
-    test_name = "%s_%s_%s_%s_%s" % ("testTfTrtV2" if is_v2 else "testTfTrt",
+    dynamic_shape_type = "DynamicShape" if dynamic_shape else "ImplicitBatch"
+    test_name = "%s_%s_%s_%s_%s_%s" % ("testTfTrtV2" if is_v2 else "testTfTrt",
                                     conversion, engine_type, precision_mode,
-                                    calibration_type)
+                                    calibration_type, dynamic_shape_type)
     run_params = RunParams(
         convert_online=convert_online,
         precision_mode=precision_mode,
         dynamic_engine=dynamic_engine,
         test_name=test_name,
         use_calibration=use_calibration,
-        is_v2=is_v2)
+        is_v2=is_v2, dynamic_shape=dynamic_shape)
     if is_v2:
       setattr(test_class, test_name,
               test_util.run_v2_only(_GetTest(run_params)))

--- a/tensorflow/python/compiler/tensorrt/test/trt_mode_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/trt_mode_test.py
@@ -42,8 +42,9 @@ class TrtModeTestBase(trt_test.TfTrtIntegrationTestBase):
   def ShouldRunTest(self, run_params):
     # Squeeze op produces dynamic shaped values. Therefore, we don't run the
     # test with static engine to avoid native segment execution.
-    return (run_params.dynamic_engine, "test dynamic engine only")
-
+    return (run_params.dynamic_engine and run_params.is_v2 and
+            not run_params.use_calibration, "test v2 dynamic engine and "
+            "non-calibration")
   def GetParams(self):
     """The input has 1 as a first dimension, which is removed by the squeeze.
 
@@ -59,15 +60,6 @@ class TrtModeTestBase(trt_test.TfTrtIntegrationTestBase):
     return self.BuildParams(self.GraphFn, dtypes.float32, [[1, 12, 5]],
                             [[12, 5]])
 
-  @classmethod
-  def setUpClass(cls):
-    if cls is TrtModeTestBase:
-      raise SkipTest("TrtModeTestBase defines base class for other test.")
-    super(TrtModeTestBase, cls).setUpClass()
-
-
-class ImplicitBatchTest(TrtModeTestBase):
-
   def GetMaxBatchSize(self, run_params):
     if run_params.dynamic_engine:
       return None
@@ -75,6 +67,12 @@ class ImplicitBatchTest(TrtModeTestBase):
     # The first dimension of the input is squeezed and the batch size for the
     # rest OPs is 12.
     return 12
+
+  @classmethod
+  def setUpClass(cls):
+    if cls is TrtModeTestBase:
+      raise SkipTest("TrtModeTestBase defines base class for other test.")
+    super(TrtModeTestBase, cls).setUpClass()
 
   def ExpectedEnginesToBuild(self, run_params):
     """Check that the expected engine is built.
@@ -89,12 +87,16 @@ class ImplicitBatchTest(TrtModeTestBase):
     Because of this we have two TRTEngineOp in the graphs: one for the
     subgraph before 'squeeze(q,0)', and another one for the rest of the ops
     after the 'squeeze(q,0)'.
+
+    In explicit batch mode the whole graph is converted using a single engine.
     """
-    return ["TRTEngineOp_0", "TRTEngineOp_1"]
+    if run_params.dynamic_shape:
+      return ["TRTEngineOp_0"]
+    else:
+      return ["TRTEngineOp_0", "TRTEngineOp_1"]
 
 
-class ExplicitBatchTest(TrtModeTestBase):
-
+class StaticInputTest(TrtModeTestBase):
   def GetParams(self):
     """We specify input/output masks with static (known) shapes."""
     return self.BuildParamsWithMask(
@@ -105,42 +107,19 @@ class ExplicitBatchTest(TrtModeTestBase):
         extra_inputs=[],
         extra_outputs=[])
 
-  def ExpectedEnginesToBuild(self, run_params):
-    """Check that the expected engine is built.
 
-    Args:
-      run_params: the run parameters.
-
-    Returns:
-      the expected engines to build.
-
-    In explicit batch mode the whole graph is converted using a single engine.
-    """
-    return ["TRTEngineOp_0"]
-
-  def ShouldRunTest(self, run_params):
-    return (run_params.is_v2 and
-            not run_params.use_calibration, "test v2 and non-calibration")
-
-  def setUp(self):
-    super().setUp()
-    self.SetDynamicShapeModeAndProfileStrategy(
-        profile_strategy="ImplicitBatchModeCompatible")
-
-
-class DynamicShapesTest(TrtModeTestBase):
+class DynamicInputTest(TrtModeTestBase):
   """Test with dynamic input shapes.
 
-  DynamicShapesTest is different from ExplicitBatchTest in that it uses input
-  and output masks to change the input and output shapes to unknown shapes.
+  The difference to the previous test is that we use input and output masks to
+  change the input and output shapes to unknown shapes.
   """
 
   def GetParams(self):
     """We specify input/output mask with dynamic (unknown) shapes.
 
-    A single
-    engine with three optimization profiles can handle the three different
-    input shapes.
+    In dynamic shape mode, single engine with three optimization profiles can
+    handle the three different input shapes.
     """
     return self.BuildParamsWithMask(
         self.GraphFn,
@@ -149,20 +128,6 @@ class DynamicShapesTest(TrtModeTestBase):
         extra_outputs=[[[2, 3]], [[4, 6]]],
         input_mask=[[False, False, False]],
         output_mask=[[False, False]])
-
-  def ExpectedEnginesToBuild(self, run_params):
-    """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
-
-  def ShouldRunTest(self, run_params):
-    return (run_params.is_v2 and
-            not run_params.use_calibration, "test v2 and non-calibration")
-
-  def setUp(self):
-    super().setUp()
-    self.SetDynamicShapeModeAndProfileStrategy(
-        profile_strategy="ImplicitBatchModeCompatible")
-
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/compiler/tensorrt/test/unary_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/unary_test.py
@@ -97,7 +97,13 @@ class UnaryTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0", "TRTEngineOp_1"]
+    if run_params.dynamic_shape:
+      # All the ops are converted into a single TRTEngineOp.
+      return ["TRTEngineOp_0"]
+    else:
+      # Final squeeze and div ops are not converted. The x1 and x2 branches
+      # are segmented into separate TRTEngineOp.
+      return ["TRTEngineOp_0", "TRTEngineOp_1"]
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -1244,12 +1244,6 @@ class TrtGraphConverterV2(object):
     """
     assert self._converted
 
-    if self._need_trt_profiles() and not self._build_called_once:
-      raise NotImplementedError(
-          "build() is not called . Explicit batch mode "
-          "(use_implicit_batch=False) requires generating TensorRT optimization"
-          " profiles which is done by calling build().")
-
     # Serialize the TRT engines in the cache if any, and create trackable
     # resource to track them.
     engine_asset_dir = tempfile.mkdtemp()


### PR DESCRIPTION
This PR updates TF-TRT Python unit test to run both implicit batch and dynamic shape tests. 

Some of the test have to be adjusted because the conversion rate is different in dynamic shape mode. Comments that explain the difference are added to the tests.

Apart from updating the test, this PR also removes the requirement to run build mode in dynamic shape mode. The necessary changes in trt_engine_op were implemented already in dynamic shape phase 3, but the Python side error message was not removed at that time.

Tagging @bixia1 for review. Tracker #45481 