### PR TITLE
[tf.data] graduate sample_from_datasets API from experimental to tf.data.Dataset

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -164,6 +164,9 @@
     *   Added the ability for `TensorSliceDataset` to identify and handle inputs
         that are files. This will enable creating hermetic SavedModels when
         using datasets created from files.
+    *   Promoting `tf.data.experimental.sample_from_datasets` API to
+        `tf.data.Dataset.sample_from_datasets` and deprecating the experimental
+        endpoint.
 *   TF SavedModel:
     *   Custom gradients are now saved by default. See `tf.saved_model.SaveOptions` to disable this.
 *   XLA:

--- a/tensorflow/python/data/experimental/kernel_tests/directed_interleave_dataset_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/directed_interleave_dataset_test.py
@@ -54,8 +54,8 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
     input_datasets = [
         dataset_ops.Dataset.from_tensors(i).repeat(100) for i in range(10)
     ]
-    dataset = interleave_ops._DirectedInterleaveDataset(selector_dataset,
-                                                        input_datasets)
+    dataset = dataset_ops._DirectedInterleaveDataset(selector_dataset,
+                                                     input_datasets)
     next_element = self.getNext(dataset)
 
     for _ in range(100):
@@ -91,7 +91,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
 
       # Create a dataset that samples each integer in `[0, num_datasets)`
       # with probability given by `weights[i]`.
-      dataset = interleave_ops.sample_from_datasets([
+      dataset = dataset_ops.Dataset.sample_from_datasets([
           dataset_ops.Dataset.from_tensors(i).repeat() for i in range(classes)
       ], weights)
       dataset = dataset.take(num_samples)
@@ -116,7 +116,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
         dataset_ops.Dataset.from_tensors(np.int64(1)).repeat(),
         dataset_ops.Dataset.range(10).repeat()
     ]
-    sample_dataset = interleave_ops.sample_from_datasets(
+    sample_dataset = dataset_ops.Dataset.sample_from_datasets(
         datasets, weights=weights, stop_on_empty_dataset=True)
 
     samples_list = self.getIteratorOutput(self.getNext(sample_dataset))
@@ -133,7 +133,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
         dataset_ops.Dataset.from_tensors(np.int64(1)).repeat(),
         dataset_ops.Dataset.range(10).repeat()
     ]
-    sample_dataset = interleave_ops.sample_from_datasets(
+    sample_dataset = dataset_ops.Dataset.sample_from_datasets(
         datasets, weights=weights, stop_on_empty_dataset=False).take(100)
 
     samples_list = self.getIteratorOutput(self.getNext(sample_dataset))
@@ -150,7 +150,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
         dataset_ops.Dataset.from_tensors(-1).repeat(2),
         dataset_ops.Dataset.from_tensors(1).repeat(2)
     ]
-    sample_dataset = interleave_ops.sample_from_datasets(
+    sample_dataset = dataset_ops.Dataset.sample_from_datasets(
         datasets, weights=weights, stop_on_empty_dataset=True)
     self.assertDatasetProduces(sample_dataset, [1, 1])
 
@@ -163,7 +163,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
         dataset_ops.Dataset.range(0),
         dataset_ops.Dataset.range(1).repeat()
     ]
-    sample_dataset = interleave_ops.sample_from_datasets(
+    sample_dataset = dataset_ops.Dataset.sample_from_datasets(
         datasets, weights=weights, stop_on_empty_dataset=True)
     self.assertDatasetProduces(sample_dataset, [])
 
@@ -175,7 +175,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
         dataset_ops.Dataset.from_tensors(-1).repeat(),
         dataset_ops.Dataset.from_tensors(1)
     ]
-    sample_dataset = interleave_ops.sample_from_datasets(
+    sample_dataset = dataset_ops.Dataset.sample_from_datasets(
         datasets, weights=weights, stop_on_empty_dataset=False)
     self.assertDatasetProduces(sample_dataset, [1])
 
@@ -187,7 +187,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
         dataset_ops.Dataset.from_tensors(-1).repeat(),
         dataset_ops.Dataset.from_tensors(1).repeat()
     ]
-    sample_dataset = interleave_ops.sample_from_datasets(
+    sample_dataset = dataset_ops.Dataset.sample_from_datasets(
         datasets, weights=weights, stop_on_empty_dataset=False)
     self.assertDatasetProduces(sample_dataset, [])
 
@@ -195,14 +195,15 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
   def testSampleFromDatasetsCardinality(self):
     ds1 = dataset_ops.Dataset.from_tensors([1.0]).repeat()
     ds2 = dataset_ops.Dataset.from_tensors([2.0]).repeat()
-    ds = interleave_ops.sample_from_datasets([ds1, ds2])
+    ds = dataset_ops.Dataset.sample_from_datasets([ds1, ds2])
     self.assertEqual(self.evaluate(ds.cardinality()), dataset_ops.INFINITE)
 
   @combinations.generate(test_base.default_test_combinations())
   def testSampleFromDatasetsNested(self):
     ds1 = dataset_ops.Dataset.range(10).window(2)
     ds2 = dataset_ops.Dataset.range(10, 20).window(2)
-    ds = interleave_ops.sample_from_datasets([ds1, ds2], weights=[0.3, 0.7])
+    ds = dataset_ops.Dataset.sample_from_datasets(
+        [ds1, ds2], weights=[0.3, 0.7])
     ds = ds.flat_map(lambda x: x)
     next_element = self.getNext(ds)
     self.evaluate(next_element())
@@ -277,26 +278,26 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
   @combinations.generate(test_base.default_test_combinations())
   def testErrors(self):
     with self.assertRaisesRegex(ValueError, r"must have the same length"):
-      interleave_ops.sample_from_datasets(
+      dataset_ops.Dataset.sample_from_datasets(
           [dataset_ops.Dataset.range(10),
            dataset_ops.Dataset.range(20)],
           weights=[0.25, 0.25, 0.25, 0.25])
 
     with self.assertRaisesRegex(TypeError, "`tf.float32` or `tf.float64`"):
-      interleave_ops.sample_from_datasets(
+      dataset_ops.Dataset.sample_from_datasets(
           [dataset_ops.Dataset.range(10),
            dataset_ops.Dataset.range(20)],
           weights=[1, 1])
 
     with self.assertRaisesRegex(TypeError, "must have the same type"):
-      interleave_ops.sample_from_datasets([
+      dataset_ops.Dataset.sample_from_datasets([
           dataset_ops.Dataset.from_tensors(0),
           dataset_ops.Dataset.from_tensors(0.0)
       ])
 
     with self.assertRaisesRegex(
         ValueError, r"`datasets` must be a non-empty list of datasets."):
-      interleave_ops.sample_from_datasets(datasets=[], weights=[])
+      dataset_ops.Dataset.sample_from_datasets(datasets=[], weights=[])
 
     with self.assertRaisesRegex(TypeError, "tf.int64"):
       interleave_ops.choose_from_datasets([
@@ -335,12 +336,10 @@ class SampleFromDatasetsCheckpointTest(checkpoint_test_base.CheckpointTestBase,
                                        parameterized.TestCase):
 
   def _build_dataset(self, probs, num_samples):
-    dataset = interleave_ops.sample_from_datasets([
+    dataset = dataset_ops.Dataset.sample_from_datasets([
         dataset_ops.Dataset.from_tensors(i).repeat(None)
         for i in range(len(probs))
-    ],
-                                                  probs,
-                                                  seed=1813)
+    ], probs, seed=1813)
     return dataset.take(num_samples)
 
   @combinations.generate(

--- a/tensorflow/python/data/experimental/kernel_tests/service/dynamic_sharding_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/service/dynamic_sharding_test.py
@@ -230,7 +230,7 @@ class DynamicShardingTest(data_service_test_base.TestBase,
 
     # Create a dataset that samples each integer in `[0, num_datasets)`
     # with probability given by `weights[i]`.
-    ds = interleave_ops.sample_from_datasets(
+    ds = dataset_ops.Dataset.sample_from_datasets(
         [dataset_ops.Dataset.from_tensors(i).repeat() for i in range(classes)],
         weights)
     ds = self._make_dynamic_sharding_dataset(ds, cluster)

--- a/tensorflow/python/data/experimental/ops/BUILD
+++ b/tensorflow/python/data/experimental/ops/BUILD
@@ -141,12 +141,9 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":random_ops",
-        "//tensorflow/python:array_ops",
         "//tensorflow/python:dtypes",
-        "//tensorflow/python:experimental_dataset_ops_gen",
         "//tensorflow/python:framework_ops",
         "//tensorflow/python:math_ops",
-        "//tensorflow/python:stateless_random_ops_gen",
         "//tensorflow/python:tf2",
         "//tensorflow/python:util",
         "//tensorflow/python/data/ops:dataset_ops",

--- a/tensorflow/python/data/experimental/ops/interleave_ops.py
+++ b/tensorflow/python/data/experimental/ops/interleave_ops.py
@@ -18,18 +18,11 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python import tf2
-from tensorflow.python.data.experimental.ops import random_ops
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.ops import readers
-from tensorflow.python.data.util import nest
 from tensorflow.python.data.util import structure
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_spec
-from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import gen_experimental_dataset_ops
-from tensorflow.python.ops import gen_stateless_random_ops
-from tensorflow.python.ops import math_ops
 from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
 
@@ -99,57 +92,8 @@ def parallel_interleave(map_func,
 
   return _apply_fn
 
-
-class _DirectedInterleaveDataset(dataset_ops.DatasetV2):
-  """A substitute for `Dataset.interleave()` on a fixed list of datasets."""
-
-  def __init__(self, selector_input, data_inputs, stop_on_empty_dataset=False):
-    self._selector_input = selector_input
-    self._data_inputs = list(data_inputs)
-    self._stop_on_empty_dataset = stop_on_empty_dataset
-
-    first_output_types = dataset_ops.get_legacy_output_types(data_inputs[0])
-    first_output_classes = dataset_ops.get_legacy_output_classes(data_inputs[0])
-
-    for i, data_input in enumerate(data_inputs[1:]):
-      if (dataset_ops.get_legacy_output_types(data_input) != first_output_types
-          or dataset_ops.get_legacy_output_classes(data_input) !=
-          first_output_classes):
-        raise TypeError("All datasets must have the same type and class.\n"
-                        "dataset 0 vs dataset %s types: %s ; %s\n"
-                        "classes: %s ; %s" %
-                        (i + 1, first_output_types,
-                         dataset_ops.get_legacy_output_types(data_input),
-                         first_output_classes,
-                         dataset_ops.get_legacy_output_classes(data_input)))
-
-    spec = self._data_inputs[0].element_spec
-    for data_input in self._data_inputs[1:]:
-      spec = nest.pack_sequence_as(spec, [
-          x.most_specific_compatible_type(y) for (x, y) in zip(
-              nest.flatten(spec),
-              nest.flatten(data_input.element_spec))
-      ])
-    self._element_spec = spec
-
-    # pylint: disable=protected-access
-    variant_tensor = (
-        gen_experimental_dataset_ops.directed_interleave_dataset(
-            self._selector_input._variant_tensor,
-            [data_input._variant_tensor for data_input in self._data_inputs],
-            stop_on_empty_dataset=self._stop_on_empty_dataset,
-            **self._flat_structure))
-
-    super(_DirectedInterleaveDataset, self).__init__(variant_tensor)
-
-  def _inputs(self):
-    return [self._selector_input] + self._data_inputs
-
-  @property
-  def element_spec(self):
-    return self._element_spec
-
-
+@deprecation.deprecated(None,
+                        "Use `tf.data.Dataset.sample_from_datasets(...)`.")
 @tf_export("data.experimental.sample_from_datasets", v1=[])
 def sample_from_datasets_v2(datasets,
                             weights=None,
@@ -169,7 +113,7 @@ def sample_from_datasets_v2(datasets,
   Suppose also that we sample from these 2 datasets with the following weights:
 
   ```python
-  sample_dataset = tf.data.experimental.sample_from_datasets(
+  sample_dataset = tf.data.Dataset.sample_from_datasets(
       [dataset1, dataset2], weights=[0.5, 0.5])
   ```
 
@@ -207,83 +151,15 @@ def sample_from_datasets_v2(datasets,
       - If `datasets` is empty, or
       - If `weights` is specified and does not match the length of `datasets`.
   """
-  def _shapes_are_compatible(datasets, weights):
-    if isinstance(weights, ops.Tensor):
-      return weights.shape.is_compatible_with([len(datasets)])
-    return len(datasets) == len(weights)
+  return dataset_ops.Dataset.sample_from_datasets(
+      datasets=datasets,
+      weights=weights,
+      seed=seed,
+      stop_on_empty_dataset=stop_on_empty_dataset
+  )
 
-  def _skip_datasets_with_zero_weight(datasets, weights):
-    datasets_and_weights = [(dataset, weight)
-                            for (dataset, weight) in zip(datasets, weights)
-                            if weight > 0]
-    return (zip(*datasets_and_weights) if datasets_and_weights else
-            ([datasets[0].take(0)], [1.]))
-
-  if not datasets:
-    raise ValueError("`datasets` must be a non-empty list of datasets.")
-
-  if not isinstance(weights, dataset_ops.DatasetV2):
-    if weights is None:
-      # Select inputs with uniform probability.
-      logits = [[1.0] * len(datasets)]
-
-    else:
-      if not _shapes_are_compatible(datasets, weights):
-        raise ValueError("`weights` must have the same length as `datasets`.")
-
-      # Use the given `weights` as the probability of choosing the respective
-      # input.
-      if not isinstance(weights, ops.Tensor):
-        datasets, weights = _skip_datasets_with_zero_weight(datasets, weights)
-      weights = ops.convert_to_tensor(weights, name="weights")
-      if weights.dtype not in (dtypes.float32, dtypes.float64):
-        raise TypeError("`weights` must be convertible to a tensor of "
-                        "`tf.float32` or `tf.float64` elements.")
-
-      # The `stateless_multinomial()` op expects log-probabilities, as opposed
-      # to weights.
-      logits = array_ops.expand_dims(math_ops.log(weights, name="logits"), 0)
-
-    # NOTE(mrry): We only specialize when `weights` is not a `Dataset`. When it
-    # is a `Dataset`, it is possible that evaluating it has a side effect the
-    # user depends on.
-    if len(datasets) == 1:
-      return datasets[0]
-
-    def select_dataset_constant_logits(seed):
-      return array_ops.squeeze(
-          gen_stateless_random_ops.stateless_multinomial(logits, 1, seed=seed),
-          axis=[0, 1])
-
-    selector_input = dataset_ops.MapDataset(
-        random_ops.RandomDataset(seed).batch(2),
-        select_dataset_constant_logits,
-        use_inter_op_parallelism=False)
-
-  else:
-    # Use each element of the given `weights` dataset as the probability of
-    # choosing the respective input.
-    #
-    # The `stateless_multinomial()` op expects log-probabilities, as opposed to
-    # weights.
-    logits_ds = weights.map(lambda *p: math_ops.log(p, name="logits"))
-
-    def select_dataset_varying_logits(logits, seed):
-      return array_ops.squeeze(
-          gen_stateless_random_ops.stateless_multinomial(logits, 1, seed=seed),
-          axis=[0, 1])
-
-    logits_and_seeds = dataset_ops.Dataset.zip(
-        (logits_ds, random_ops.RandomDataset(seed).batch(2)))
-    selector_input = dataset_ops.MapDataset(
-        logits_and_seeds,
-        select_dataset_varying_logits,
-        use_inter_op_parallelism=False)
-
-  return _DirectedInterleaveDataset(selector_input, datasets,
-                                    stop_on_empty_dataset)
-
-
+@deprecation.deprecated(None,
+                        "Use `tf.data.Dataset.sample_from_datasets(...)`.")
 @tf_export(v1=["data.experimental.sample_from_datasets"])
 def sample_from_datasets_v1(datasets,
                             weights=None,
@@ -347,8 +223,11 @@ def choose_from_datasets_v2(datasets,
       choice_dataset.element_spec, tensor_spec.TensorSpec([], dtypes.int64)):
     raise TypeError("`choice_dataset` must be a dataset of scalar "
                     "`tf.int64` tensors.")
-  return _DirectedInterleaveDataset(choice_dataset, datasets,
-                                    stop_on_empty_dataset)
+  return dataset_ops._DirectedInterleaveDataset(
+      choice_dataset,
+      datasets,
+      stop_on_empty_dataset
+  )
 
 
 @tf_export(v1=["data.experimental.choose_from_datasets"])

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -62,6 +62,7 @@ from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gen_dataset_ops
 from tensorflow.python.ops import gen_experimental_dataset_ops as ged_ops
 from tensorflow.python.ops import gen_io_ops
+from tensorflow.python.ops import gen_stateless_random_ops
 from tensorflow.python.ops import logging_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import random_ops
@@ -3101,6 +3102,140 @@ name=None))
           seed=seed,
           stop_on_empty_dataset=True)
 
+  @staticmethod
+  def sample_from_datasets(datasets,
+                           weights=None,
+                           seed=None,
+                           stop_on_empty_dataset=False):
+    """Samples elements at random from the datasets in `datasets`.
+
+    Creates a dataset by interleaving elements of `datasets` with `weight[i]`
+    probability of picking an element from dataset `i`. Sampling is done without
+    replacement. For example, suppose we have 2 datasets:
+
+    ```python
+    dataset1 = tf.data.Dataset.range(0, 3)
+    dataset2 = tf.data.Dataset.range(100, 103)
+    ```
+
+    Suppose that we sample from these 2 datasets with the following weights:
+
+    ```python
+    sample_dataset = tf.data.Dataset.sample_from_datasets(
+        [dataset1, dataset2], weights=[0.5, 0.5])
+    ```
+
+    One possible outcome of elements in sample_dataset is:
+
+    ```
+    print(list(sample_dataset.as_numpy_iterator()))
+    # [100, 0, 1, 101, 2, 102]
+    ```
+
+    Args:
+      datasets: A non-empty list of `tf.data.Dataset` objects with compatible
+        structure.
+      weights: (Optional.) A list or Tensor of `len(datasets)` floating-point
+        values where `weights[i]` represents the probability to sample from
+        `datasets[i]`, or a `tf.data.Dataset` object where each element is such
+        a list. Defaults to a uniform distribution across `datasets`.
+      seed: (Optional.) A `tf.int64` scalar `tf.Tensor`, representing the random
+        seed that will be used to create the distribution. See
+        `tf.random.set_seed` for behavior.
+      stop_on_empty_dataset: If `True`, sampling stops if it encounters an empty
+        dataset. If `False`, it skips empty datasets. It is recommended to set
+        it to `True`. Otherwise, the distribution of samples starts off as the
+        user intends, but may change as input datasets become empty. This can be
+        difficult to detect since the dataset starts off looking correct.
+        Default to `False` for backward compatibility.
+
+    Returns:
+      A dataset that interleaves elements from `datasets` at random, according
+      to `weights` if provided, otherwise with uniform probability.
+
+    Raises:
+      TypeError: If the `datasets` or `weights` arguments have the wrong type.
+      ValueError:
+        - If `datasets` is empty, or
+        - If `weights` is specified and does not match the length of `datasets`.
+    """
+    def _shapes_are_compatible(datasets, weights):
+      if isinstance(weights, ops.Tensor):
+        return weights.shape.is_compatible_with([len(datasets)])
+      return len(datasets) == len(weights)
+
+    def _skip_datasets_with_zero_weight(datasets, weights):
+      datasets_and_weights = [(dataset, weight)
+                              for (dataset, weight) in zip(datasets, weights)
+                              if weight > 0]
+      return (zip(*datasets_and_weights) if datasets_and_weights else
+              ([datasets[0].take(0)], [1.]))
+
+    if not datasets:
+      raise ValueError("`datasets` must be a non-empty list of datasets.")
+
+    if not isinstance(weights, DatasetV2):
+      if weights is None:
+        # Select inputs with uniform probability.
+        logits = [[1.0] * len(datasets)]
+
+      else:
+        if not _shapes_are_compatible(datasets, weights):
+          raise ValueError("`weights` must have the same length as `datasets`.")
+
+        # Use the given `weights` as the probability of choosing the respective
+        # input.
+        if not isinstance(weights, ops.Tensor):
+          datasets, weights = _skip_datasets_with_zero_weight(datasets, weights)
+        weights = ops.convert_to_tensor(weights, name="weights")
+        if weights.dtype not in (dtypes.float32, dtypes.float64):
+          raise TypeError("`weights` must be convertible to a tensor of "
+                          "`tf.float32` or `tf.float64` elements.")
+
+        # The `stateless_multinomial()` op expects log-probabilities, as opposed
+        # to weights.
+        logits = array_ops.expand_dims(math_ops.log(weights, name="logits"), 0)
+
+      # NOTE(mrry): We only specialize when `weights` is not a `Dataset`. When it
+      # is a `Dataset`, it is possible that evaluating it has a side effect the
+      # user depends on.
+      if len(datasets) == 1:
+        return datasets[0]
+
+      def select_dataset_constant_logits(seed):
+        return array_ops.squeeze(
+            gen_stateless_random_ops.stateless_multinomial(
+                logits, 1, seed=seed), axis=[0, 1]
+            )
+
+      selector_input = MapDataset(
+          RandomDataset(seed).batch(2),
+          select_dataset_constant_logits,
+          use_inter_op_parallelism=False)
+
+    else:
+      # Use each element of the given `weights` dataset as the probability of
+      # choosing the respective input.
+      #
+      # The `stateless_multinomial()` op expects log-probabilities, as opposed to
+      # weights.
+      logits_ds = weights.map(lambda *p: math_ops.log(p, name="logits"))
+
+      def select_dataset_varying_logits(logits, seed):
+        return array_ops.squeeze(
+            gen_stateless_random_ops.stateless_multinomial(
+                logits, 1, seed=seed), axis=[0, 1]
+            )
+
+      logits_and_seeds = Dataset.zip(
+          (logits_ds, RandomDataset(seed).batch(2)))
+      selector_input = MapDataset(
+          logits_and_seeds,
+          select_dataset_varying_logits,
+          use_inter_op_parallelism=False)
+
+    return _DirectedInterleaveDataset(selector_input, datasets,
+                                      stop_on_empty_dataset)
 
 @tf_export(v1=["data.Dataset"])
 class DatasetV1(DatasetV2):
@@ -5977,6 +6112,54 @@ class _ScanDataset(UnaryDataset):
   def _transformation_name(self):
     return "Dataset.scan()"
 
+class _DirectedInterleaveDataset(DatasetV2):
+  """A substitute for `Dataset.interleave()` on a fixed list of datasets."""
+
+  def __init__(self, selector_input, data_inputs, stop_on_empty_dataset=False):
+    self._selector_input = selector_input
+    self._data_inputs = list(data_inputs)
+    self._stop_on_empty_dataset = stop_on_empty_dataset
+
+    first_output_types = get_legacy_output_types(data_inputs[0])
+    first_output_classes = get_legacy_output_classes(data_inputs[0])
+
+    for i, data_input in enumerate(data_inputs[1:]):
+      if (get_legacy_output_types(data_input) != first_output_types
+          or get_legacy_output_classes(data_input) !=
+          first_output_classes):
+        raise TypeError("All datasets must have the same type and class.\n"
+                        "dataset 0 vs dataset %s types: %s ; %s\n"
+                        "classes: %s ; %s" %
+                        (i + 1, first_output_types,
+                         get_legacy_output_types(data_input),
+                         first_output_classes,
+                         get_legacy_output_classes(data_input)))
+
+    spec = self._data_inputs[0].element_spec
+    for data_input in self._data_inputs[1:]:
+      spec = nest.pack_sequence_as(spec, [
+          x.most_specific_compatible_type(y) for (x, y) in zip(
+              nest.flatten(spec),
+              nest.flatten(data_input.element_spec))
+      ])
+    self._element_spec = spec
+
+    # pylint: disable=protected-access
+    variant_tensor = (
+        ged_ops.directed_interleave_dataset(
+            self._selector_input._variant_tensor,
+            [data_input._variant_tensor for data_input in self._data_inputs],
+            stop_on_empty_dataset=self._stop_on_empty_dataset,
+            **self._flat_structure))
+
+    super(_DirectedInterleaveDataset, self).__init__(variant_tensor)
+
+  def _inputs(self):
+    return [self._selector_input] + self._data_inputs
+
+  @property
+  def element_spec(self):
+    return self._element_spec
 
 @auto_control_deps.register_acd_resource_resolver
 def _resource_resolver(op, resource_reads, resource_writes):

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
@@ -148,6 +148,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -150,6 +150,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -150,6 +150,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
@@ -150,6 +150,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -150,6 +150,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -150,6 +150,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -150,6 +150,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
@@ -115,6 +115,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -117,6 +117,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -116,6 +116,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
@@ -117,6 +117,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -117,6 +117,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -118,6 +118,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -117,6 +117,10 @@ tf_class {
     argspec: "args=[\'self\', \'count\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "sample_from_datasets"
+    argspec: "args=[\'datasets\', \'weights\', \'seed\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'False\'], "
+  }
+  member_method {
     name: "scan"
     argspec: "args=[\'self\', \'initial_state\', \'scan_func\'], varargs=None, keywords=None, defaults=None"
   }


### PR DESCRIPTION
This PR graduates the `tf.data.experimental.sample_from_datasets` API into `tf.data.Dataset.sample_from_datasets`  by making the following changes:

- [x] Adds the deprecation decorator for the experimental API.
- [x] Add the sample_from_datasets() method to DatasetV2 class.
- [x] Updates example in documentation with new API.
- [x] Regenerate golden API's.
- [x] Updated the `sample_from_datasets` usage in tests.
- [x] Updated the RELEASE.md file

TEST LOG
```
INFO: Elapsed time: 13.473s, Critical Path: 12.85s
INFO: 54 processes: 16 internal, 38 local.
INFO: Build completed successfully, 54 total actions
//tensorflow/python/data/experimental/kernel_tests/service:dynamic_sharding_test PASSED in 9.0s
  Stats over 16 runs: max = 9.0s, min = 7.5s, avg = 8.2s, dev = 0.5s

INFO: Elapsed time: 0.751s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
//tensorflow/python/data/experimental/kernel_tests:directed_interleave_dataset_test (cached) PASSED in 8.3s
  Stats over 24 runs: max = 8.3s, min = 1.9s, avg = 3.6s, dev = 1.9s

INFO: Elapsed time: 6.299s, Critical Path: 5.75s
INFO: 13 processes: 3 internal, 10 local.
INFO: Build completed successfully, 13 total actions
//tensorflow/python/data/kernel_tests:rejection_resample_test            PASSED in 5.7s
  Stats over 10 runs: max = 5.7s, min = 2.8s, avg = 4.2s, dev = 1.2s

```

@aaudiber The lazy import of `interleave_ops` in `dataset_ops.py` is still applicable as `choose_from_datasets_v2` is still experimental. I can work on promoting `choose_from_datasets` after this PR so that we can proceed with refactoring `dataset_ops`.
cc: @jsimsa 