### PR TITLE
(TF-TRT) Refactor "convert_nodes_test.cc" by breaking out major GTest fixture interfaces + other cleanup.

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -109,6 +109,7 @@ cc_library(
     testonly = 1,
     visibility = ["//tensorflow:internal"],
     deps = [
+        ":trt_conversion",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
         "//tensorflow/core:protos_all_cc",

--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -100,6 +100,42 @@ cc_library(
 )
 
 cc_library(
+    name = "testutils",
+    srcs = ["utils/trt_testutils.cc"],
+    hdrs = [
+        "utils/trt_testutils.h"
+    ],
+    copts = tf_copts(),
+    testonly = 1,
+    visibility = ["//tensorflow:internal"],
+    deps = [
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/cc:cc_ops",
+        "//tensorflow/core/framework:tensor_testutil",
+    ] + if_tensorrt([":tensorrt_lib"]),
+)
+
+tf_cuda_cc_test(
+    name = "testutils_test",
+    srcs = ["utils/trt_testutils_test.cc"],
+    size = "small",
+    tags = [
+        "no_windows",
+        "nomac"
+    ],
+    deps = [
+        ":testutils",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:protos_all_cc",
+        "@com_google_protobuf//:protobuf",
+    ]+ if_tensorrt([
+        ":tensorrt_lib",
+    ])
+)
+
+cc_library(
     name = "trt_op_kernels",
     srcs = [
         "kernels/get_calibration_data_op.cc",
@@ -173,6 +209,7 @@ tf_cuda_cc_test(
         ":trt_logging",
         ":trt_resources",
         ":utils",
+        ":testutils",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
@@ -203,6 +240,7 @@ tf_cuda_cc_test(
         ":trt_op_libs",
         ":trt_resources",
         ":trt_conversion",
+        ":testutils",
         "@com_google_googletest//:gtest",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/strings",
@@ -463,6 +501,7 @@ tf_cuda_cc_test(
         ":trt_op_kernels",
         ":trt_op_libs",
         ":trt_conversion",
+        ":testutils",
         "@com_google_googletest//:gtest",
         "@com_google_absl//absl/strings",
         "//tensorflow/cc:cc_ops",
@@ -496,6 +535,7 @@ tf_cuda_cc_test(
         ":trt_plugins",
         ":trt_engine_utils",
         ":utils",
+        ":testutils",
         "@com_google_googletest//:gtest",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
@@ -512,6 +552,7 @@ tf_cuda_cc_test(
         "//tensorflow/core/framework:tensor_testutil",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
+        "//tensorflow/core/platform:status_matchers",
     ] + if_tensorrt([
         ":tensorrt_lib",
         "@local_config_cuda//cuda:cuda_headers",

--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -103,7 +103,8 @@ cc_library(
     name = "testutils",
     srcs = ["utils/trt_testutils.cc"],
     hdrs = [
-        "utils/trt_testutils.h"
+        "utils/trt_testutils.h",
+        "utils/tensor_testutils.h"
     ],
     copts = tf_copts(),
     testonly = 1,
@@ -524,7 +525,13 @@ tf_cuda_cc_test(
 tf_cuda_cc_test(
     name = "convert_nodes_test",
     size = "medium",
-    srcs = ["convert/convert_nodes_test.cc"],
+    srcs = [
+        "convert/convert_nodes_test.cc",
+        "convert/fixtures/op_converter_fixture.cc",
+        "convert/fixtures/op_converter_fixture.h",
+        "convert/fixtures/op_converter_param_fixture.h",
+        "convert/fixtures/op_converter_param_fixture.cc"
+    ],
     tags = [
         "no_cuda_on_cpu_tap",
         "no_windows",

--- a/tensorflow/compiler/tf2tensorrt/common/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.h
@@ -99,6 +99,27 @@ bool operator!=(const T& lhs, const V& rhs) {
   return !(rhs == lhs);
 }
 
+// Prints nvinfer1::DataType type name to given ostream.
+template <typename T, typename std::enable_if<std::is_same<
+                          T, nvinfer1::DataType>::value>::type* = nullptr>
+std::ostream& operator<<(std::ostream& os, const T& v) {
+  os << "nvinfer1::DataType::";
+  switch (v) {
+    case DataType::kFLOAT:
+      return os << "kFlOAT";
+    case DataType::kHALF:
+      return os << "kHALF";
+    case DataType::kBOOL:
+      return os << "kBOOL";
+    case DataType::kINT32:
+      return os << "kINT32";
+    case DataType::kINT8:
+      return os << "kINT8";
+    default:
+      return os << "unknown";
+  }
+}
+
 // Prints nvinfer1::INetworkDefinition* information to the given ostream.
 inline std::ostream& operator<<(std::ostream& os,
                                 nvinfer1::INetworkDefinition* n) {

--- a/tensorflow/compiler/tf2tensorrt/common/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <numeric>
 #include <tuple>
+
 #include "absl/strings/str_join.h"
 
 namespace tensorflow {
@@ -111,8 +112,25 @@ inline std::ostream& operator<<(std::ostream& os,
   os << "}";
   return os;
 }
-
 }  // namespace nvinfer1
+
+namespace nvinfer_factory {
+
+namespace dims {
+
+// Creates a nvinfer1::Dims from the given vector.
+template <typename T = int,
+          typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+nvinfer1::Dims Create(const std::vector<T>& list) {
+  assert(list.size() <= nvinfer1::Dims::MAX_DIMS);
+  nvinfer1::Dims dim;
+  dim.nbDims = list.size();
+  std::copy(list.begin(), list.end(), dim.d);
+  return dim;
+}
+
+}  // namespace dims
+}  // namespace nvinfer_factory
 
 #endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph_test.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/cc/framework/scope.h"
 #include "tensorflow/cc/ops/standard_ops.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h"
 #include "tensorflow/core/common_runtime/device_mgr.h"
 #include "tensorflow/core/common_runtime/device_set.h"
 #include "tensorflow/core/framework/tensor_shape.h"
@@ -39,17 +40,6 @@ limitations under the License.
 namespace tensorflow {
 namespace tensorrt {
 namespace convert {
-
-// TODO(laigd): put this into some test utils file.
-void ExpectStatus(Status status, error::Code code = error::OK,
-                  const char* substr = nullptr) {
-  EXPECT_EQ(code, status.code())
-      << status << " vs expected error code \"" << error::Code_Name(code)
-      << "\" and message \"" << substr << "\"";
-  if (substr) {
-    EXPECT_THAT(status.error_message(), ::testing::HasSubstr(substr)) << status;
-  }
-}
 
 class FakeCluster : public grappler::Cluster {
  public:

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -838,10 +838,30 @@ size_t TRT_ShapedWeights::size_bytes() const {
 }
 
 string TRT_ShapedWeights::DebugString() const {
+  std::string values_str;
+  switch (type_) {
+    case nvinfer1::DataType::kFLOAT:
+      values_str = absl::StrJoin(GetSpan<float>(), ",");
+      break;
+    case nvinfer1::DataType::kINT32:
+      values_str = absl::StrJoin(GetSpan<int32>(), ",");
+      break;
+    case nvinfer1::DataType::kHALF:
+      values_str = absl::StrJoin(GetSpan<Eigen::half>(), ",");
+      break;
+    case nvinfer1::DataType::kINT8:
+      values_str = absl::StrJoin(GetSpan<int8>(), ",");
+      break;
+    case nvinfer1::DataType::kBOOL:
+      values_str = absl::StrJoin(GetSpan<int8>(), ",");
+      break;
+    default:
+      values_str = "unknown dtype";
+  }
   return StrCat(
       "TRT_ShapedWeights(shape=", tensorflow::tensorrt::DebugString(shape_),
       ", type=", tensorflow::tensorrt::DebugString(type_),
-      ", values=", reinterpret_cast<uintptr_t>(GetValues()), ")");
+      ", values=", values_str, ")");
 }
 
 TRT_TensorOrWeights::TRT_TensorOrWeights(ITensorProxyPtr tensor)

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -667,7 +667,7 @@ class Converter {
   int next_constant_layer_id_ = 0;
 
   // The name of the TRTEngineOp node.
-  absl::string_view engine_name_;
+  string engine_name_;
 
   friend class ConverterTest;
   friend class OpConverterTest;

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -241,6 +241,13 @@ class TRT_ShapedWeights {
   friend class TrtWeightStore;
 };
 
+// Prints given weights information to ostream. This is required for GTest to
+// print useful information.
+inline std::ostream& operator<<(std::ostream& os,
+                                const TRT_ShapedWeights& weights) {
+  return os << weights.DebugString();
+}
+
 // Container for TRT_ShapedWeights. We need this container because, TRT doesn't
 // manage the lifetime of the weights buffer, it only keeps a pointer to it and
 // requires that the data referenced by the pointer be available until the

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -26,14 +26,13 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "absl/algorithm/container.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 #include "tensorflow/cc/ops/nn_ops_internal.h"
@@ -42,6 +41,7 @@ limitations under the License.
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_managed_allocator.h"
 #include "tensorflow/core/framework/allocator.h"
 #include "tensorflow/core/framework/node_def.pb.h"  // NOLINT
@@ -56,9 +56,12 @@ limitations under the License.
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/platform/protobuf.h"
+#include "tensorflow/core/platform/status_matchers.h"
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/protobuf/config.pb.h"  // NOLINT
 #include "tensorflow/core/public/session.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/tensorrt/NvInfer.h"
 
 namespace tensorflow {
@@ -107,173 +110,16 @@ namespace convert {
 using absl::StrCat;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;
+using ::testing::HasSubstr;
 using ::testing::Matcher;
+using ::testing::PrintToString;
+
+using ::tensorflow::testing::IsOk;
+using ::tensorflow::testing::StatusIs;
 
 constexpr std::array<TrtTestMode, 3> ValidTrtModes = {
     TrtTestMode::kImplicitBatch, TrtTestMode::kExplicitBatch,
     TrtTestMode::kDynamicShape};
-
-// TODO(laigd): put this into some test utils file.
-void ExpectStatus(Status status, error::Code code = error::OK,
-                  const char* substr = nullptr) {
-  EXPECT_EQ(code, status.code())
-      << status << " vs expected error code \"" << error::Code_Name(code)
-      << "\" and message \"" << substr << "\"";
-  if (substr) {
-    EXPECT_THAT(status.error_message(), ::testing::HasSubstr(substr)) << status;
-  }
-}
-
-nvinfer1::Dims GetTestDims(const std::vector<int>& d) {
-  nvinfer1::Dims dims;
-  dims.nbDims = d.size();
-  for (int i = 0; i < d.size(); ++i) {
-    dims.d[i] = d[i];
-  }
-  return dims;
-}
-
-// Prints the vector to the output stream.
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
-  if (!v.empty()) {
-    os << '[';
-    std::copy(v.begin(), v.end(), std::ostream_iterator<T>(os, ", "));
-    os << "\b\b]";
-  }
-  return os;
-}
-
-NodeDef MakeNodeDef(const string& name, const string& op,
-                    const std::vector<string>& inputs,
-                    const std::map<string, AttrValue> attrs = {}) {
-  NodeDef node_def;
-  node_def.set_name(name);
-  node_def.set_op(op);
-  for (const string& input : inputs) {
-    node_def.add_input(input);
-  }
-  for (const auto& attr : attrs) {
-    (*node_def.mutable_attr())[attr.first] = attr.second;
-  }
-  return node_def;
-}
-
-template <typename T>
-NodeDef MakeConstNodeDef(const string& name, const std::vector<T>& vals,
-                         const TensorShape& shape) {
-  Scope s = Scope::NewRootScope();
-  Tensor t = test::AsTensor<T>(vals, shape);
-  auto const_op = ops::Const(s.WithOpName(name), t);
-  return const_op.node()->def();
-}
-
-template <typename T>
-NodeDef MakeConstNodeDef(const string& name, const std::vector<T>& vals) {
-  TensorShape shape;
-  const std::vector<int32> shape_dims = {static_cast<int32>(vals.size())};
-  TF_EXPECT_OK(TensorShapeUtils::MakeShape(shape_dims, &shape));
-  return MakeConstNodeDef(name, vals, shape);
-}
-
-bool TrtDimsEquals(const nvinfer1::Dims& lhs, const nvinfer1::Dims& rhs) {
-  if (lhs.nbDims != rhs.nbDims) return false;
-  for (int i = 0; i < lhs.nbDims; ++i) {
-    if (lhs.d[i] != rhs.d[i]) return false;
-    // We don't check the types in the tests.
-  }
-  return true;
-}
-
-bool TrtDimsEqualsArray(const std::vector<int>& lhs,
-                        const nvinfer1::Dims& rhs) {
-  return TrtDimsEquals(GetTestDims(lhs), rhs);
-}
-
-// TODO(laigd): define a parameterized matcher that can compare against the
-// vector.
-void ExpectTrtDimsEqualsArray(const std::vector<int>& lhs,
-                              const nvinfer1::Dims& rhs) {
-  EXPECT_TRUE(TrtDimsEqualsArray(lhs, rhs))
-      << "expected: " << DebugString(GetTestDims(lhs)) << "\n"
-      << "  actual: " << DebugString(rhs);
-}
-
-void ExpectTrtLayerNames(absl::Span<const std::string> names,
-                         nvinfer1::INetworkDefinition* network) {
-  EXPECT_EQ(network->getNbLayers(), names.size());
-
-  for (int i = 0; i < network->getNbLayers(); i++) {
-    auto layer = network->getLayer(i);
-    EXPECT_EQ(layer->getName(), names[i]);
-  }
-}
-
-void VerifyTrtLayerNameNotEmpty(nvinfer1::INetworkDefinition* network) {
-  for (int i = 0; i < network->getNbLayers(); i++) {
-    auto layer = network->getLayer(i);
-    EXPECT_NE(layer->getName(), nullptr);
-  }
-}
-
-Matcher<std::vector<float>> ArrayFloatNear(const std::vector<float>& values,
-                                           float max_abs_error = 1e-5,
-                                           bool nan_sensitive = false) {
-  std::vector<Matcher<float>> matchers;
-  matchers.reserve(values.size());
-  for (const float& v : values) {
-    if (nan_sensitive) {
-      matchers.emplace_back(::testing::NanSensitiveFloatNear(v, max_abs_error));
-    } else if (max_abs_error == 0) {
-      matchers.emplace_back(::testing::FloatEq(v));
-    } else {
-      EXPECT_GE(max_abs_error, 0);
-      matchers.emplace_back(::testing::FloatNear(v, max_abs_error));
-    }
-  }
-  return ElementsAreArray(matchers);
-}
-
-template <typename T>
-void ExpectArrayNear(const std::vector<T>& lhs, absl::Span<const T> rhs) {
-  ASSERT_EQ(lhs.size(), rhs.size());
-  for (int i = 0; i < lhs.size(); i++) {
-    EXPECT_FLOAT_EQ(lhs[i], rhs[i]);
-  }
-}
-
-// Eigen::half cannot implicitly convert to float which is required for
-// EXPECT_FLOAT_EQ.
-template <>
-void ExpectArrayNear(const std::vector<Eigen::half>& lhs,
-                     absl::Span<const Eigen::half> rhs) {
-  ASSERT_EQ(lhs.size(), rhs.size());
-  for (int i = 0; i < lhs.size(); i++) {
-    EXPECT_FLOAT_EQ(static_cast<float>(lhs[i]), static_cast<float>(rhs[i]));
-  }
-}
-
-template <typename T>
-void ExpectArrayAlmostEqual(const std::vector<T>& lhs, absl::Span<const T> rhs,
-                            T tolerance) {
-  ASSERT_EQ(lhs.size(), rhs.size());
-  for (int i = 0; i < lhs.size(); i++) {
-    EXPECT_NEAR(lhs[i], rhs[i], tolerance);
-  }
-}
-
-// Eigen::half cannot implicitly convert to float which is required for
-// EXPECT_NEAR.
-template <>
-void ExpectArrayAlmostEqual(const std::vector<Eigen::half>& lhs,
-                            absl::Span<const Eigen::half> rhs,
-                            Eigen::half tolerance) {
-  ASSERT_EQ(lhs.size(), rhs.size());
-  for (int i = 0; i < lhs.size(); i++) {
-    EXPECT_NEAR(static_cast<float>(lhs[i]), static_cast<float>(rhs[i]),
-                static_cast<float>(tolerance));
-  }
-}
 
 bool TrtShapedWeightsEquals(const TRT_ShapedWeights& lhs,
                             const TRT_ShapedWeights& rhs) {
@@ -285,7 +131,7 @@ template <typename T>
 void ValidateWeights(const TRT_ShapedWeights& weights,
                      const std::vector<int>& expected_dims,
                      const std::vector<T>& expected_value) {
-  ExpectTrtDimsEqualsArray(expected_dims, weights.shape_);
+  EXPECT_THAT(weights.shape_, DimsAreArray(expected_dims));
   ASSERT_EQ(expected_value.size(), weights.count()) << weights.DebugString();
   const T* actual_values = static_cast<const T*>(weights.GetValues());
   for (int i = 0; i < expected_value.size(); ++i) {
@@ -352,7 +198,7 @@ TEST(TRT_ShapedWeights_Test, Basic) {
   {
     TrtWeightStore store;
     TRT_ShapedWeights weights =
-        store.GetTempWeights(nvinfer1::DataType::kFLOAT, GetTestDims({2, 5}));
+        store.GetTempWeights(nvinfer1::DataType::kFLOAT, CreateDims({2, 5}));
     TRT_ShapedWeights copy(weights);
     for (auto ptr : {&weights, &copy}) {
       nvinfer1::Weights trt_weights = ptr->GetTrtWeights();
@@ -406,7 +252,7 @@ TEST(TRT_TensorOrWeights_Test, Basic) {
           EXPECT_EQ(1, ptr->batch_size());
         }
         EXPECT_EQ(itensor->simple_tensor(), ptr->tensor()->simple_tensor());
-        ExpectTrtDimsEqualsArray({1}, ptr->GetTrtDims());
+        EXPECT_THAT(ptr->GetTrtDims(), DimsAreArray({1}));
       }
     }
   }
@@ -425,7 +271,7 @@ TEST(TRT_TensorOrWeights_Test, Basic) {
       EXPECT_EQ(false, ptr->is_weights());
       EXPECT_EQ(1, ptr->batch_size());
       EXPECT_NE(nullptr, ptr->tensor()->simple_tensor());
-      ExpectTrtDimsEqualsArray({1}, ptr->GetTrtDims());
+      EXPECT_THAT(ptr->GetTrtDims(), DimsAreArray({1}));
     }
   }
   // Test constructor with TRT_ShapedWeights argument.
@@ -439,7 +285,7 @@ TEST(TRT_TensorOrWeights_Test, Basic) {
       EXPECT_EQ(false, ptr->is_tensor());
       EXPECT_EQ(true, ptr->is_weights());
       EXPECT_TRUE(TrtShapedWeightsEquals(weights, ptr->weights()));
-      ExpectTrtDimsEqualsArray({}, ptr->GetTrtDims());
+      EXPECT_THAT(ptr->GetTrtDims(), DimsAreArray({}));
     }
   }
 }
@@ -489,8 +335,9 @@ TEST_F(ValidatorTest, ConvertToTensorOrWeights) {
     auto node =
         ops::Const(s.WithOpName("my_const"), {1.0f, 2.0f}, TensorShape({2}));
     TRT_TensorOrWeights output;
-    ExpectStatus(ConvertToTensorOrWeights(s, node.op().node(),
-                                          /*output_port=*/0, &output));
+    EXPECT_THAT(ConvertToTensorOrWeights(s, node.op().node(),
+                                         /*output_port=*/0, &output),
+                IsOk());
     ValidateWeights<float>(output.weights(), {2}, {1.0, 2.0});
   }
 
@@ -507,30 +354,33 @@ TEST_F(ValidatorTest, ConvertToTensorOrWeights) {
   // Convert non-Const with #dims > nvinfer1::Dims::MAX_DIMS+1.
   {
     TRT_TensorOrWeights output;
-    ExpectStatus(
+    EXPECT_THAT(
         convert_to_tensor_or_weights(
             std::vector<int64>(nvinfer1::Dims::MAX_DIMS + 2, 1), &output),
-        error::OUT_OF_RANGE, "Input tensor rank is greater than 9");
+        StatusIs(error::OUT_OF_RANGE,
+                 HasSubstr("Input tensor rank is greater than 9")));
   }
   // Convert non-Const with #dims < 1.
   {
     TRT_TensorOrWeights output;
-    ExpectStatus(
-        convert_to_tensor_or_weights({}, &output), error::INVALID_ARGUMENT,
-        "Scalar input tensor is not supported since the first dimension "
-        "is treated as batch dimension by TRT");
+    EXPECT_THAT(convert_to_tensor_or_weights({}, &output),
+                StatusIs(error::INVALID_ARGUMENT,
+                         HasSubstr("Scalar input tensor is not supported since "
+                                   "the first dimension "
+                                   "is treated as batch dimension by TRT")));
   }
   // Convert non-Const. We test the case where the non-batch dimension is
   // unknown as well, to make sure the validator allows that.
   for (const int32 non_batch_dim : {-1, 2}) {
     const int32 batch_size = 12;
     TRT_TensorOrWeights output;
-    ExpectStatus(
-        convert_to_tensor_or_weights({batch_size, non_batch_dim}, &output));
+    EXPECT_THAT(
+        convert_to_tensor_or_weights({batch_size, non_batch_dim}, &output),
+        IsOk());
     ASSERT_TRUE(output.is_tensor());
     EXPECT_EQ(batch_size, output.batch_size());
     EXPECT_NE(nullptr, output.tensor()->simple_tensor());
-    ExpectTrtDimsEqualsArray({non_batch_dim}, output.GetTrtDims());
+    EXPECT_THAT(output.GetTrtDims(), DimsAreArray({non_batch_dim}));
   }
 }
 
@@ -560,8 +410,9 @@ TEST_F(ValidatorTest, IsTensorRTCandidate_Basics) {
 
   // Validator not registered.
   ASSERT_EQ(1, op_validators(&validator).erase("Add"));
-  ExpectStatus(validator.IsTensorRTCandidate(add_node), error::UNIMPLEMENTED,
-               "Op type Add is not supported.");
+  EXPECT_THAT(validator.IsTensorRTCandidate(add_node),
+              StatusIs(error::UNIMPLEMENTED,
+                       HasSubstr("Op type Add is not supported.")));
 
   // Register validator.
   op_validators(&validator)["Add"] = op_converter;
@@ -570,8 +421,8 @@ TEST_F(ValidatorTest, IsTensorRTCandidate_Basics) {
 
   // Let the converter return error.
   should_fail = true;
-  ExpectStatus(validator.IsTensorRTCandidate(add_node),
-               error::INVALID_ARGUMENT);
+  EXPECT_THAT(validator.IsTensorRTCandidate(add_node),
+              StatusIs(error::INVALID_ARGUMENT));
 }
 
 TEST(TrtNodeValidator, IsTensorRTCandidate) {
@@ -629,23 +480,30 @@ TEST(TrtNodeValidator, IsTensorRTCandidate) {
                                /*use_calibration=*/false,
                                /*use_implicit_batch=*/true);
     TF_EXPECT_OK(validator.IsTensorRTCandidate(matmul.operation.node()));
-    ExpectStatus(
+    EXPECT_THAT(
         validator.IsTensorRTCandidate(incompatible_matmul.operation.node()),
-        error::INVALID_ARGUMENT,
-        "MatMul with 2D tensors requires explicit batch mode, or that tensor A "
-        "is not transposed and B is a constant tensor.");
-    ExpectStatus(validator.IsTensorRTCandidate(unsupported_op.operation.node()),
-                 error::UNIMPLEMENTED, "Op type Erfc is not supported");
-    ExpectStatus(validator.IsTensorRTCandidate(
-                     matmul_with_incompatible_input.operation.node()),
-                 error::INTERNAL,
-                 "Failed to convert input feed_1 to a TRT_TensorOrWeights");
+        StatusIs(error::INVALID_ARGUMENT,
+                 HasSubstr("MatMul with 2D tensors requires explicit batch "
+                           "mode, or that tensor A "
+                           "is not transposed and B is a constant tensor.")));
+    EXPECT_THAT(validator.IsTensorRTCandidate(unsupported_op.operation.node()),
+                StatusIs(error::UNIMPLEMENTED,
+                         HasSubstr("Op type Erfc is not supported")));
+    EXPECT_THAT(
+        validator.IsTensorRTCandidate(
+            matmul_with_incompatible_input.operation.node()),
+        StatusIs(
+            error::INTERNAL,
+            HasSubstr(
+                "Failed to convert input feed_1 to a TRT_TensorOrWeights")));
     if (precision_mode == TrtPrecisionMode::INT8) {
       TF_EXPECT_OK(validator.IsTensorRTCandidate(quantize.operation.node()));
     } else {
-      ExpectStatus(validator.IsTensorRTCandidate(quantize.operation.node()),
-                   error::UNIMPLEMENTED,
-                   "Op type FakeQuantWithMinMaxArgs is not supported");
+      EXPECT_THAT(
+          validator.IsTensorRTCandidate(quantize.operation.node()),
+          StatusIs(
+              error::UNIMPLEMENTED,
+              HasSubstr("Op type FakeQuantWithMinMaxArgs is not supported")));
     }
   }
 }
@@ -723,11 +581,12 @@ TEST_F(ConverterTest, ConvertNode) {
   };
   NodeDef node_def = MakeNodeDef("my_op", "MyOp", {"my_input"});
   TF_EXPECT_OK(converter_->AddInputTensor(
-      "my_input", nvinfer1::DataType::kFLOAT, GetTestDims({123}), 1));
+      "my_input", nvinfer1::DataType::kFLOAT, CreateDims({123}), 1));
 
   // Converter not registered.
-  ExpectStatus(converter_->ConvertNode(node_def), error::UNIMPLEMENTED,
-               "No converter registered for op: MyOp");
+  EXPECT_THAT(converter_->ConvertNode(node_def),
+              StatusIs(error::UNIMPLEMENTED,
+                       HasSubstr("No converter registered for op: MyOp")));
 
   // Register the converter and retry.
   AddOpConverter("MyOp", op_converter);
@@ -745,7 +604,7 @@ TEST_F(ConverterTest, ConvertNode) {
             actual_output_2.tensor()->simple_tensor());
   EXPECT_EQ(125, actual_output_2.tensor()->getDimensions().d[0]);
 
-  VerifyTrtLayerNameNotEmpty(converter_->network());
+  EXPECT_THAT(converter_->network(), LayerNamesNonEmpty());
 }
 
 TEST_F(ConverterTest, AddAndGetInputs) {
@@ -757,11 +616,11 @@ TEST_F(ConverterTest, AddAndGetInputs) {
   node_def.add_input("weird_input:2:3:4:0");
 
   TF_EXPECT_OK(converter_->AddInputTensor("input", nvinfer1::DataType::kFLOAT,
-                                          GetTestDims({1}), 1));
+                                          CreateDims({1}), 1));
   TF_EXPECT_OK(converter_->AddInputTensor("input:1", nvinfer1::DataType::kINT32,
-                                          GetTestDims({2, 3}), 1));
+                                          CreateDims({2, 3}), 1));
   TF_EXPECT_OK(converter_->AddInputTensor(
-      "weird_input:2:3:4", nvinfer1::DataType::kHALF, GetTestDims({5, 3}), 1));
+      "weird_input:2:3:4", nvinfer1::DataType::kHALF, CreateDims({5, 3}), 1));
 
   std::vector<TRT_TensorOrWeights> inputs;
   TF_EXPECT_OK(GetInputs(node_def, &inputs));
@@ -773,11 +632,11 @@ TEST_F(ConverterTest, AddAndGetInputs) {
   EXPECT_EQ(nvinfer1::DataType::kFLOAT, inputs[0].tensor()->getType());
   EXPECT_EQ(nvinfer1::DataType::kINT32, inputs[2].tensor()->getType());
   EXPECT_EQ(nvinfer1::DataType::kHALF, inputs[3].tensor()->getType());
-  ExpectTrtDimsEqualsArray({1}, inputs[0].tensor()->getDimensions());
-  ExpectTrtDimsEqualsArray({2, 3}, inputs[2].tensor()->getDimensions());
-  ExpectTrtDimsEqualsArray({5, 3}, inputs[3].tensor()->getDimensions());
+  EXPECT_THAT(inputs[0].tensor()->getDimensions(), DimsAreArray({1}));
+  EXPECT_THAT(inputs[2].tensor()->getDimensions(), DimsAreArray({2, 3}));
+  EXPECT_THAT(inputs[3].tensor()->getDimensions(), DimsAreArray({5, 3}));
 
-  VerifyTrtLayerNameNotEmpty(converter_->network());
+  EXPECT_THAT(converter_->network(), LayerNamesNonEmpty());
 }
 
 TEST_F(ConverterTest, RenameAndMarkOutputTensors) {
@@ -809,51 +668,53 @@ TEST_F(ConverterTest, RenameAndMarkOutputTensors) {
   // Run the conversion.
   NodeDef node_def = MakeNodeDef("my_op", "MyOp", {"my_input"});
   TF_EXPECT_OK(converter_->AddInputTensor(
-      "my_input", nvinfer1::DataType::kFLOAT, GetTestDims({1, 2}), 1));
+      "my_input", nvinfer1::DataType::kFLOAT, CreateDims({1, 2}), 1));
   TF_EXPECT_OK(converter_->ConvertNode(node_def));
 
   // Mark a weight as output, should fail.
-  ExpectStatus(
+  EXPECT_THAT(
       converter_->RenameAndMarkOutputTensors({{"my_op:2", "my_output"}}),
-      error::INVALID_ARGUMENT, "Output my_op:2 is weights not tensor");
+      StatusIs(error::INVALID_ARGUMENT,
+               HasSubstr("Output my_op:2 is weights not tensor")));
 
   // Mark tensors as output, should pass.
   TF_EXPECT_OK(converter_->RenameAndMarkOutputTensors(
       {{"my_op", "my_output"}, {"my_op:1", "my_output_1"}}));
   EXPECT_EQ(2, output_tensors.size());
   for (auto output_tensor : output_tensors) {
-    ExpectTrtDimsEqualsArray({2, 1}, output_tensor->getDimensions());
+    EXPECT_THAT(output_tensor->getDimensions(), DimsAreArray({2, 1}));
   }
   EXPECT_EQ("my_output", string(output_tensors[0]->getName()));
   EXPECT_EQ("my_output_1", string(output_tensors[1]->getName()));
 
-  VerifyTrtLayerNameNotEmpty(converter_->network());
+  EXPECT_THAT(converter_->network(), LayerNamesNonEmpty());
 }
 
 TEST_F(ConverterTest, TransposeTensor) {
   ITensorProxyPtr input_tensor = converter_->network()->addInput(
-      "", nvinfer1::DataType::kFLOAT, GetTestDims({2, 3, 5}));
+      "", nvinfer1::DataType::kFLOAT, CreateDims({2, 3, 5}));
   ITensorProxyPtr output_tensor = nullptr;
   NodeDef dummy_node_def = MakeNodeDef("dummy_op", "DummyOp", {});
   // Rank doesn't match.
-  ExpectStatus(
-      converter_->TransposeTensor(input_tensor, {0, 1}, &output_tensor,
-                                  dummy_node_def, "sub1"),
-      error::INVALID_ARGUMENT,
-      "Rank of perm for transpose does not match with that of the input");
+  EXPECT_THAT(converter_->TransposeTensor(input_tensor, {0, 1}, &output_tensor,
+                                          dummy_node_def, "sub1"),
+              StatusIs(error::INVALID_ARGUMENT,
+                       HasSubstr("Rank of perm for transpose does not match "
+                                 "with that of the input")));
 
   // Transpose at batch dimension.
-  ExpectStatus(
+  EXPECT_THAT(
       converter_->TransposeTensor(input_tensor, {1, 0, 2, 3}, &output_tensor,
                                   dummy_node_def, "sub2"),
-      error::UNIMPLEMENTED, "Transpose at batch dimension is not supported.");
+      StatusIs(error::UNIMPLEMENTED,
+               HasSubstr("Transpose at batch dimension is not supported.")));
 
   // OK.
   TF_EXPECT_OK(converter_->TransposeTensor(
       input_tensor, {0, 3, 1, 2}, &output_tensor, dummy_node_def, "sub3"));
-  ExpectTrtDimsEqualsArray({5, 2, 3}, output_tensor->getDimensions());
-  ExpectTrtLayerNames({"TRTEngineOp_0_0/dummy_op-sub3:SHUFFLE"},
-                      converter_->network());
+  EXPECT_THAT(output_tensor->getDimensions(), DimsAreArray({5, 2, 3}));
+  EXPECT_THAT(converter_->network(),
+              LayerNamesAreArray({"TRTEngineOp_0_0/dummy_op-sub3:SHUFFLE"}));
 }
 
 void TestPrepareTensorForShape(
@@ -865,28 +726,29 @@ void TestPrepareTensorForShape(
   TRT_TensorOrWeights input;
   if (input_is_tensor) {
     input = TRT_TensorOrWeights(converter->network()->addInput(
-        "", nvinfer1::DataType::kFLOAT, GetTestDims(input_dims)));
+        "", nvinfer1::DataType::kFLOAT, CreateDims(input_dims)));
   } else {
     input = TRT_TensorOrWeights(weight_store->GetTempWeights(
-        nvinfer1::DataType::kFLOAT, GetTestDims(input_dims)));
+        nvinfer1::DataType::kFLOAT, CreateDims(input_dims)));
   }
   ITensorProxyPtr output_tensor = nullptr;
 
   NodeDef dummy_node_def = MakeNodeDef("dummy_op", "DummyOp", {});
   for (bool validation_only : {false, true}) {
     const Status status =
-        PrepareTensorForShape(converter, input, GetTestDims(reshape_dims),
+        PrepareTensorForShape(converter, input, CreateDims(reshape_dims),
                               validation_only, &output_tensor, dummy_node_def);
     if (expected_code == error::OK) {
       TF_EXPECT_OK(status);
       if (validation_only) {
         EXPECT_EQ(nullptr, *output_tensor);
       } else {
-        ExpectTrtDimsEqualsArray(expected_tensor_dims,
-                                 output_tensor->getDimensions());
+        EXPECT_THAT(output_tensor->getDimensions(),
+                    DimsAreArray(expected_tensor_dims));
       }
     } else {
-      ExpectStatus(status, expected_code, expected_error_msg_substr);
+      EXPECT_THAT(status, StatusIs(expected_code,
+                                   HasSubstr(expected_error_msg_substr)));
     }
   }
 }
@@ -931,7 +793,7 @@ TEST_F(ConverterTest, PrepareTensorForShape) {
                             weight_store_, error::INVALID_ARGUMENT,
                             "Shape is not fully defined");
 
-  VerifyTrtLayerNameNotEmpty(converter_->network());
+  EXPECT_THAT(converter_->network(), LayerNamesNonEmpty());
 }
 
 TEST_F(ConverterTest, MaybeUpdateBatchSize) {
@@ -949,8 +811,11 @@ TEST_F(ConverterTest, MaybeUpdateBatchSize) {
   TF_EXPECT_OK(MaybeUpdateBatchSize(-1));
   EXPECT_EQ(123, batch_size());
 
-  ExpectStatus(MaybeUpdateBatchSize(124), error::INVALID_ARGUMENT,
-               "Provided batch size does not match converter batch size");
+  EXPECT_THAT(
+      MaybeUpdateBatchSize(124),
+      StatusIs(error::INVALID_ARGUMENT,
+               HasSubstr(
+                   "Provided batch size does not match converter batch size")));
 }
 
 TEST_F(ConverterTest, AddAndGetTensorOrWeights) {
@@ -967,8 +832,9 @@ TEST_F(ConverterTest, AddAndGetTensorOrWeights) {
   EXPECT_EQ(123, added_tensor.batch_size());
 
   // Add the same tensor again.
-  ExpectStatus(AddTensorOrWeights("my_tensor", tensor), error::ALREADY_EXISTS,
-               "tensor/weights my_tensor already exist");
+  EXPECT_THAT(AddTensorOrWeights("my_tensor", tensor),
+              StatusIs(error::ALREADY_EXISTS,
+                       HasSubstr("tensor/weights my_tensor already exist")));
 }
 
 template <typename T>
@@ -976,7 +842,7 @@ void TestGetWeightRange(ConverterTest* test, TrtWeightStore* weight_store) {
   nvinfer1::DataType trt_type;
   TF_ASSERT_OK(TfTypeToTrtType(DataTypeToEnum<T>::v(), &trt_type));
   TRT_ShapedWeights weights =
-      weight_store->GetTempWeights(trt_type, GetTestDims({2, 3}));
+      weight_store->GetTempWeights(trt_type, CreateDims({2, 3}));
   const std::vector<T> values = {T(3), T(1), T(2), T(6), T(5), T(4)};
   memcpy(weights.GetValues(), values.data(), weights.size_bytes());
 
@@ -1008,7 +874,7 @@ TEST_F(ConverterTest, ProvideQuantizationRange) {
   converter_->ProvideQuantizationRange(&simple_tensor, -6.123f, 6.123f);
   EXPECT_EQ(6.123f, quantization_ranges_proxy()[&simple_tensor]);
 
-  VerifyTrtLayerNameNotEmpty(converter_->network());
+  EXPECT_THAT(converter_->network(), LayerNamesNonEmpty());
 }
 
 TEST_F(ConverterTest, MaybeApplyQuantizationRanges) {
@@ -1027,7 +893,7 @@ TEST_F(ConverterTest, MaybeApplyQuantizationRanges) {
   EXPECT_EQ(input->getDynamicRangeMax(), 5.0f);
   EXPECT_EQ(not_infer->getDynamicRangeMax(), 100.0f);
 
-  VerifyTrtLayerNameNotEmpty(int8_converter->network());
+  EXPECT_THAT(int8_converter->network(), LayerNamesNonEmpty());
 }
 
 TEST_F(ConverterTest, GetTrtBroadcastShape) {
@@ -1040,17 +906,17 @@ TEST_F(ConverterTest, GetTrtBroadcastShape) {
                                const std::vector<int>& expected_operand_1_shape,
                                const std::vector<int>& expected_operand_2_shape,
                                error::Code expected_code = error::OK,
-                               const char* expected_error_msg_substr = nullptr,
+                               const char* expected_error_msg_substr = "",
                                const int operand_1_batch_size = -1,
                                const int operand_2_batch_size = -1) {
     auto create_tensor_or_weights = [](const std::vector<int>& shape,
                                        bool is_tensor, int batch_size = -1) {
       if (is_tensor) {
         return TRT_TensorOrWeights{nvinfer1::DataType::kFLOAT,
-                                   GetTestDims(shape), batch_size};
+                                   CreateDims(shape), batch_size};
       }
       TRT_ShapedWeights weights;
-      weights.shape_ = GetTestDims(shape);
+      weights.shape_ = CreateDims(shape);
       return TRT_TensorOrWeights(weights);
     };
 
@@ -1061,24 +927,24 @@ TEST_F(ConverterTest, GetTrtBroadcastShape) {
         operand_2_shape, operand_2_is_tensor, operand_2_batch_size);
 
     // operand_1 broadcast operand_2
-    ExpectStatus(
+    EXPECT_THAT(
         GetTrtBroadcastShape(operand_1, operand_2, /*check_feasibility=*/true,
                              /*use_implicit_batch=*/true, &operand_1_new_dims,
                              &operand_2_new_dims),
-        expected_code, expected_error_msg_substr);
+        StatusIs(expected_code, HasSubstr(expected_error_msg_substr)));
     if (expected_code == error::OK) {
-      ExpectTrtDimsEqualsArray(expected_operand_1_shape, operand_1_new_dims);
-      ExpectTrtDimsEqualsArray(expected_operand_2_shape, operand_2_new_dims);
+      EXPECT_THAT(operand_1_new_dims, DimsAreArray(expected_operand_1_shape));
+      EXPECT_THAT(operand_2_new_dims, DimsAreArray(expected_operand_2_shape));
     }
     // operand_2 broadcast operand_1
-    ExpectStatus(
+    EXPECT_THAT(
         GetTrtBroadcastShape(operand_2, operand_1, /*check_feasibility=*/true,
                              /*use_implicit_batch=*/true, &operand_2_new_dims,
                              &operand_1_new_dims),
-        expected_code, expected_error_msg_substr);
+        StatusIs(expected_code, HasSubstr(expected_error_msg_substr)));
     if (expected_code == error::OK) {
-      ExpectTrtDimsEqualsArray(expected_operand_1_shape, operand_1_new_dims);
-      ExpectTrtDimsEqualsArray(expected_operand_2_shape, operand_2_new_dims);
+      EXPECT_THAT(operand_1_new_dims, DimsAreArray(expected_operand_1_shape));
+      EXPECT_THAT(operand_2_new_dims, DimsAreArray(expected_operand_2_shape));
     }
   };
 
@@ -1132,23 +998,23 @@ TEST_F(ConverterTest, GetTrtBroadcastShape) {
   symmetric_test({2, 3}, {7, 5}, kIsTensor, kIsTensor, {}, {},
                  error::INVALID_ARGUMENT, "Infeasible broadcast scheme");
 
-  VerifyTrtLayerNameNotEmpty(converter_->network());
+  EXPECT_THAT(converter_->network(), LayerNamesNonEmpty());
 }
 
 TEST_F(ConverterTest, CreateConstantLayer) {
   for (auto dtype : {nvinfer1::DataType::kFLOAT, nvinfer1::DataType::kINT32}) {
     TRT_ShapedWeights weights =
-        weight_store_->GetTempWeights(dtype, GetTestDims({2, 3, 5}));
+        weight_store_->GetTempWeights(dtype, CreateDims({2, 3, 5}));
     ITensorProxyPtr tensor =
-        converter_->CreateConstantLayer(weights, GetTestDims({3, 10}));
+        converter_->CreateConstantLayer(weights, CreateDims({3, 10}));
     ASSERT_NE(nullptr, tensor->trt_tensor());
     EXPECT_EQ(dtype, tensor->getType())
         << "Expected " << DebugString(dtype) << " vs. actual "
         << DebugString(tensor->getType());
-    ExpectTrtDimsEqualsArray({3, 10}, tensor->getDimensions());
+    EXPECT_THAT(tensor->getDimensions(), DimsAreArray({3, 10}));
   }
 
-  VerifyTrtLayerNameNotEmpty(converter_->network());
+  EXPECT_THAT(converter_->network(), LayerNamesNonEmpty());
 }
 
 class ConvertGraphDefToEngineTest : public ::testing::Test {
@@ -1237,6 +1103,8 @@ std::vector<float> GetDataAsFloat(InputOutputData& data) {
   }
   LOG(FATAL) << "DataType not supported for testing "
              << DataTypeString(data.tensor.dtype());
+
+  return {};
 }
 // Class to test various op converters, using both a TrtNodeValidator and
 // Converter.
@@ -1491,7 +1359,7 @@ class OpConverterTest : public ::testing::Test {
     // Add weights for conversion.
     nvinfer1::DataType dtype;
     TF_ASSERT_OK(TfTypeToTrtType(DataTypeToEnum<T>::v(), &dtype));
-    const nvinfer1::Dims trt_dims = GetTestDims(dims);
+    const nvinfer1::Dims trt_dims = CreateDims(dims);
     const int64_t num_elements = TRT_ShapedWeights::count(trt_dims);
     QCHECK_EQ(num_elements, values.size())
         << num_elements << " vs " << values.size();
@@ -1535,11 +1403,11 @@ class OpConverterTest : public ::testing::Test {
   }
 
   void RunConversion(const Node* node, error::Code expected_code = error::OK,
-                     const char* expected_msg_substr = nullptr) {
-    ExpectStatus(converter_->ConvertNode(node->def()), expected_code,
-                 expected_msg_substr);
+                     const std::string& expected_msg_substr = "") {
+    EXPECT_THAT(converter_->ConvertNode(node->def()),
+                StatusIs(expected_code, HasSubstr(expected_msg_substr)));
     if (expected_code == error::OK) {
-      VerifyTrtLayerNameNotEmpty(converter_->network());
+      EXPECT_THAT(converter_->network(), LayerNamesNonEmpty());
     }
   }
 
@@ -1547,7 +1415,7 @@ class OpConverterTest : public ::testing::Test {
   // output are same.
   void RunValidationAndConversion(const NodeDef& node_def,
                                   error::Code expected_code = error::OK,
-                                  const char* expected_msg_substr = nullptr,
+                                  const std::string& expected_msg_substr = "",
                                   bool should_run_conversion = true) {
     // Add the node to the graph.
     // TODO(laigd): we should accept a function that adds the node using
@@ -1569,17 +1437,19 @@ class OpConverterTest : public ::testing::Test {
     if (should_run_conversion && status.ok()) {
       RunConversion(node, expected_code, expected_msg_substr);
     } else {
-      ExpectStatus(status, expected_code, expected_msg_substr);
+      EXPECT_THAT(status,
+                  StatusIs(expected_code, HasSubstr(expected_msg_substr)));
     }
   }
 
   // Helper method to run both validation and conversion, and check the output
   // shapes.
   void RunValidationAndConversion(
-      const NodeDef& node_def, const Status& status, const char* output_name,
+      const NodeDef& node_def, const Status& status,
+      const std::string& output_name,
       const std::vector<std::vector<int>>& exp_out_dims) {
-    RunValidationAndConversion(node_def, status.code(),
-                               status.error_message().c_str(), true);
+    RunValidationAndConversion(node_def, status.code(), status.error_message(),
+                               true);
 
     if (status.ok()) {
       // TODO(tfeher): Enable this check in explicit_batch_mode.
@@ -1598,8 +1468,8 @@ class OpConverterTest : public ::testing::Test {
             auto out_dims = std::vector<int>(exp_out_dims[i].begin() + 1,
                                              exp_out_dims[i].end());
             VLOG(2) << "Testing output shape for tensor " << name;
-            ExpectTrtDimsEqualsArray(out_dims,
-                                     output.tensor()->getDimensions());
+            EXPECT_THAT(output.tensor()->getDimensions(),
+                        DimsAreArray(out_dims));
           }
         }
       }
@@ -1657,15 +1527,15 @@ struct TestParamBase {
 };
 
 std::ostream& operator<<(std::ostream& os, const TestParamBase& p) {
-  os << "input_dims" << p.input_dims;
+  os << "input_dims" << PrintToString(p.input_dims);
   if (!p.partial_input_dims.empty()) {
-    os << ", partial_input_dims" << p.partial_input_dims;
+    os << ", partial_input_dims" << PrintToString(p.partial_input_dims);
   }
   if (!p.expected_output_dims.empty()) {
-    os << ", exp_out_dims" << p.expected_output_dims;
+    os << ", exp_out_dims" << PrintToString(p.expected_output_dims);
   }
   if (!p.param.empty()) {
-    os << ", param" << p.param;
+    os << ", param" << PrintToString(p.param);
   }
   os << ", " << p.status;
   return os;
@@ -1836,8 +1706,8 @@ class ParameterizedOpConverterTestBase
       const Status& expected_runtime_status,
       const std::vector<Matcher<std::vector<float>>>& matcher,
       const std::vector<DataType>& out_tf_type = {}) {
-    RunValidationAndConversion(node_def, expected_conversion_status,
-                               name.c_str(), expected_output_dims);
+    RunValidationAndConversion(node_def, expected_conversion_status, name,
+                               expected_output_dims);
     if (expected_conversion_status.ok()) {
       BuildAndRun(name, expected_output_dims, expected_runtime_status, matcher,
                   out_tf_type);
@@ -1853,7 +1723,7 @@ class ParameterizedOpConverterTestBase
                        const Matcher<std::vector<float>>& matcher,
                        const std::vector<DataType>& out_tf_types = {}) {
     RunValidationAndConversion(
-        node_def, expected_conversion_status, name.c_str(),
+        node_def, expected_conversion_status, name,
         std::vector<std::vector<int>>({expected_output_dims}));
     if (expected_conversion_status.ok()) {
       BuildAndRun(name, std::vector<std::vector<int>>({expected_output_dims}),
@@ -2357,7 +2227,7 @@ TEST_P(OpConverter_FP32_Test, ConvertReshape) {
   for (auto p : params) {
     for (auto shape_as_weight : shape_input_options) {
       std::ostringstream oss;
-      oss << "shape " << p.shape;
+      oss << "shape " << PrintToString(p.shape);
       SCOPED_TRACE(StrCat(oss.str(), shape_as_weight ? " weight" : " tensor"));
       if (!shape_as_weight && p.shape.empty()) {
         p.conversion_status = errors::Unimplemented(
@@ -2473,8 +2343,7 @@ void TestMatMulHelper(
     test->RunValidationAndConversion(
         node_def, error::UNIMPLEMENTED,
         StrCat("Data type int32 is not supported for ", node_def.op(),
-               ", must be one of [float, half], at my_matmul")
-            .c_str());
+               ", must be one of [float, half], at my_matmul"));
   }
 
   // FC conversion depends on whether the last dim of A is known or not. In
@@ -2811,120 +2680,120 @@ TEST_P(OpConverter_FP32_Test, ConvertEinsum) {
   Status unimplemented_eq =
       errors::Unimplemented("No conversion for einsum equation.");
 
-  std::vector<TestParams> params{
-      // Dot product.
-      TestParams{"i,i->", {2}, {2, 3}, {2}, {1, 2}, {1}, {8}, unimplemented_eq},
-          // Outer product.
-          TestParams{"i,k->ik",
-                     {2},
-                     {1, 2},
-                     {3},
-                     {1, 2, 3},
-                     {2, 3},
-                     {1, 2, 3, 2, 4, 6},
-                     unimplemented_eq},
-          // Transpose.
-          TestParams{"ik->ki", {2, 3}, {0, 1, 2, 3, 4, 5}, {},
-                     {},       {3, 2}, {0, 3, 1, 4, 2, 5}, unimplemented_eq},
-          // Diag.
-          TestParams{"ii->i",
-                     {3, 3},
-                     {0, 1, 2, 3, 4, 5, 6, 7, 8},
-                     {},
-                     {},
-                     {3},
-                     {0, 4, 8},
-                     unimplemented_eq},
-          // Trace.
-          TestParams{
-              "ii", {3, 3},          {0, 1, 2, 3, 4, 5, 6, 7, 8}, {}, {}, {},
-              {12}, unimplemented_eq},
-          // MatMul with reduction.
-          TestParams{"abbc,dc->ad",
-                     {1, 2, 2, 3},
-                     {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
-                     {2, 3},
-                     {1, 2, 3, 4, 5, 6},
-                     {2, 3},
-                     {1, 2, 3, 2, 4, 6},
-                     unimplemented_eq},
-          // Ellipsis with broadcast.
-          TestParams{"...ik,...jk->...ij",
-                     {1, 3, 1, 4},
-                     {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
-                     {2, 1, 1, 4},
-                     {1, 2, 3, 4, 5, 6, 7, 8},
-                     {2, 3, 1, 1},
-                     {20, 60, 100, 44, 148, 252},
-                     unimplemented_eq},
-          // MatMul and Batched MatMul.
-          TestParams{"ab,bc->ac",        {2, 3}, {0, 1, 2, 3, 4, 5}, {3, 2},
-                     {1, 2, 3, 4, 5, 6}, {2, 2}, {13, 16, 40, 52}},
-          TestParams{"abc,cde->abde",
-                     {1, 2, 3},
-                     {0, 1, 2, 3, 4, 5},
-                     {3, 2, 2},
-                     {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
-                     {1, 2, 2, 2},
-                     {23, 26, 29, 32, 68, 80, 92, 104}},
-          TestParams{"abcd,cde->abe",
-                     {1, 2, 2, 3},
-                     {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
-                     {2, 3, 2},
-                     {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
-                     {1, 2, 2},
-                     {125, 140, 341, 392}},
-          TestParams{"abc,cd->abd",      {1, 2, 3}, {0, 1, 2, 3, 4, 5}, {3, 2},
-                     {1, 2, 3, 4, 5, 6}, {1, 2, 2}, {13, 16, 40, 52}},
-          TestParams{"acbe,aecd->abcd",
-                     {1, 2, 3, 4},
-                     {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
-                      12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
-                     {1, 4, 2, 3},
-                     {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
-                      13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
-                     {1, 3, 2, 3},
-                     {90, 96, 102, 732, 786, 840, 250, 272, 294, 940, 1010,
-                      1080, 410, 448, 486, 1148, 1234, 1320}},
-          TestParams{
-              "aecd,abcd->acbe",
-              {1, 2, 3, 4},
-              {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
-               12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
-              {1, 2, 3, 4},
-              {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
-               13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
-              {1, 3, 2, 2},
-              {20, 140, 92, 788, 148, 460, 412, 1300, 404, 908, 860, 1940}},
-          TestParams{"acd,dce->ae",
-                     {1, 2, 3},
-                     {0, 1, 2, 3, 4, 5},
-                     {3, 2, 2},
-                     {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
-                     {1, 2},
-                     {115, 130}},
-          TestParams{"abcd,bace->bade",
-                     {2, 3, 2, 1},
-                     {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
-                     {3, 2, 2, 1},
-                     {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
-                     {3, 2, 1, 1},
-                     {2, 46, 28, 128, 86, 242}},
+  std::vector<TestParams> params {
+    // Dot product.
+    TestParams{"i,i->", {2}, {2, 3}, {2}, {1, 2}, {1}, {8}, unimplemented_eq},
+        // Outer product.
+        TestParams{"i,k->ik",
+                   {2},
+                   {1, 2},
+                   {3},
+                   {1, 2, 3},
+                   {2, 3},
+                   {1, 2, 3, 2, 4, 6},
+                   unimplemented_eq},
+        // Transpose.
+        TestParams{"ik->ki", {2, 3}, {0, 1, 2, 3, 4, 5}, {},
+                   {},       {3, 2}, {0, 3, 1, 4, 2, 5}, unimplemented_eq},
+        // Diag.
+        TestParams{"ii->i",
+                   {3, 3},
+                   {0, 1, 2, 3, 4, 5, 6, 7, 8},
+                   {},
+                   {},
+                   {3},
+                   {0, 4, 8},
+                   unimplemented_eq},
+        // Trace.
+        TestParams{
+            "ii", {3, 3},          {0, 1, 2, 3, 4, 5, 6, 7, 8}, {}, {}, {},
+            {12}, unimplemented_eq},
+        // MatMul with reduction.
+        TestParams{"abbc,dc->ad",
+                   {1, 2, 2, 3},
+                   {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+                   {2, 3},
+                   {1, 2, 3, 4, 5, 6},
+                   {2, 3},
+                   {1, 2, 3, 2, 4, 6},
+                   unimplemented_eq},
+        // Ellipsis with broadcast.
+        TestParams{"...ik,...jk->...ij",
+                   {1, 3, 1, 4},
+                   {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+                   {2, 1, 1, 4},
+                   {1, 2, 3, 4, 5, 6, 7, 8},
+                   {2, 3, 1, 1},
+                   {20, 60, 100, 44, 148, 252},
+                   unimplemented_eq},
+        // MatMul and Batched MatMul.
+        TestParams{"ab,bc->ac",        {2, 3}, {0, 1, 2, 3, 4, 5}, {3, 2},
+                   {1, 2, 3, 4, 5, 6}, {2, 2}, {13, 16, 40, 52}},
+        TestParams{"abc,cde->abde",
+                   {1, 2, 3},
+                   {0, 1, 2, 3, 4, 5},
+                   {3, 2, 2},
+                   {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+                   {1, 2, 2, 2},
+                   {23, 26, 29, 32, 68, 80, 92, 104}},
+        TestParams{"abcd,cde->abe",
+                   {1, 2, 2, 3},
+                   {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+                   {2, 3, 2},
+                   {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+                   {1, 2, 2},
+                   {125, 140, 341, 392}},
+        TestParams{"abc,cd->abd",      {1, 2, 3}, {0, 1, 2, 3, 4, 5}, {3, 2},
+                   {1, 2, 3, 4, 5, 6}, {1, 2, 2}, {13, 16, 40, 52}},
+        TestParams{"acbe,aecd->abcd",
+                   {1, 2, 3, 4},
+                   {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                    12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+                   {1, 4, 2, 3},
+                   {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                    13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
+                   {1, 3, 2, 3},
+                   {90, 96, 102, 732, 786, 840, 250, 272, 294, 940, 1010, 1080,
+                    410, 448, 486, 1148, 1234, 1320}},
+        TestParams{
+            "aecd,abcd->acbe",
+            {1, 2, 3, 4},
+            {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+             12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+            {1, 2, 3, 4},
+            {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+             13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
+            {1, 3, 2, 2},
+            {20, 140, 92, 788, 148, 460, 412, 1300, 404, 908, 860, 1940}},
+        TestParams{"acd,dce->ae",
+                   {1, 2, 3},
+                   {0, 1, 2, 3, 4, 5},
+                   {3, 2, 2},
+                   {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+                   {1, 2},
+                   {115, 130}},
+        TestParams{"abcd,bace->bade",
+                   {2, 3, 2, 1},
+                   {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+                   {3, 2, 2, 1},
+                   {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+                   {3, 2, 1, 1},
+                   {2, 46, 28, 128, 86, 242}},
 #if !IS_TRT_VERSION_GE(8, 0, 0, 0)
-          // Deactivating buggy test case for TRT8 per nvbug 3322485.
-          TestParams{"cebfad,fageb->abcdg",
-                     {1, 1, 3, 3, 2, 2},
-                     {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
-                      12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-                      24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35},
-                     {3, 2, 2, 1, 3},
-                     {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
-                      13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-                      25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36},
-                     {2, 3, 1, 2, 2},
-                     {252,  288,  291,  336,  768,  912,  810,  963,
-                      1356, 1608, 1401, 1662, 438,  492,  495,  558,
-                      1176, 1338, 1236, 1407, 1986, 2256, 2049, 2328}},
+        // Deactivating buggy test case for TRT8 per nvbug 3322485.
+        TestParams{"cebfad,fageb->abcdg",
+                   {1, 1, 3, 3, 2, 2},
+                   {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                    12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+                    24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35},
+                   {3, 2, 2, 1, 3},
+                   {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                    13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+                    25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36},
+                   {2, 3, 1, 2, 2},
+                   {252,  288,  291,  336,  768,  912,  810,  963,
+                    1356, 1608, 1401, 1662, 438,  492,  495,  558,
+                    1176, 1338, 1236, 1407, 1986, 2256, 2049, 2328}},
 #endif
   };
 
@@ -2987,7 +2856,7 @@ TEST_P(OpConverter_FP32_FP16_Test, ConvertBiasAdd) {
         dims_array[1] = 2;
         dims_array[trt_input_rank] = 3;
       }
-      const int num_input = TrtTensorDimsNumElements(GetTestDims(dims_array));
+      const int num_input = TrtTensorDimsNumElements(CreateDims(dims_array));
       ASSERT_EQ(trt_input_rank > 1 ? 6 : (data_format == "NHWC" ? 3 : 2),
                 num_input);
       std::vector<float> input_data(num_input, 0);
@@ -5535,8 +5404,7 @@ TEST_P(OpConverter_FP32_Test, ConvertPool) {
     AddTestWeights<float>("input", {1, 1, 1, 2, 3}, {1, 2, 3, 4, 5, 6});
     RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
                                StrCat("The input \"input\" for ", node_def.op(),
-                                      " must be a tensor, at my_pool")
-                                   .c_str());
+                                      " must be a tensor, at my_pool"));
   }
 
   struct TestParams {
@@ -6374,8 +6242,8 @@ void TestConvertSplit(OpConverterTest* test) {
       const string name = j == 0 ? StrCat("my_split") : StrCat("my_split:", j);
       TF_EXPECT_OK(test->GetTensorOrWeights(name, &outputs[j]));
       EXPECT_TRUE(outputs[j].is_tensor());
-      ExpectTrtDimsEqualsArray(ok_params[i].expected_output_dims,
-                               outputs[j].tensor()->getDimensions());
+      EXPECT_THAT(outputs[j].tensor()->getDimensions(),
+                  DimsAreArray(ok_params[i].expected_output_dims));
       // Create buffer to store output.
       output_data.push_back(
           {name, test->ConstructTensor<CType>(
@@ -7024,8 +6892,7 @@ void TestConvertDepthSpaceShuffle(
     test->RunValidationAndConversion(
         node_def, error::UNIMPLEMENTED,
         StrCat("The input \"input\" for ", node_def.op(),
-               " must be a tensor, at my_shuffle")
-            .c_str());
+               " must be a tensor, at my_shuffle"));
   }
   {
     // Input rank != 4
@@ -7036,8 +6903,7 @@ void TestConvertDepthSpaceShuffle(
     test->RunValidationAndConversion(node_def, error::INVALID_ARGUMENT,
                                      StrCat("The input to ", node_def.op(),
                                             " must be rank 4, at "
-                                            "my_shuffle")
-                                         .c_str());
+                                            "my_shuffle"));
   }
   {
     // Unsupported format, should fail.

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -139,29 +139,7 @@ void ValidateWeights(const TRT_ShapedWeights& weights,
   }
 }
 
-template <typename CType>
-std::vector<CType> InitTestVector(int size, CType start_value = CType(0)) {
-  std::vector<CType> res;
-  res.reserve(size);
-  for (int i = 0; i < size; ++i) {
-    res.push_back(start_value + CType(i));
-  }
-  return res;
-}
 
-template <typename InCType, typename OutCType>
-struct StaticCaster {
-  OutCType operator()(InCType in) const { return static_cast<OutCType>(in); }
-};
-
-template <typename InCType, typename OutCType>
-std::vector<OutCType> CastTestVector(
-    const gtl::ArraySlice<InCType>& vals) {  // non-absl ok
-  std::vector<OutCType> res(vals.size());
-  std::transform(vals.begin(), vals.end(), res.begin(),
-                 StaticCaster<InCType, OutCType>());
-  return res;
-}
 
 TEST(TRT_ShapedWeights_Test, Basic) {
   // Test constructor with no arguments.

--- a/tensorflow/compiler/tf2tensorrt/convert/fixtures/op_converter_fixture.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/fixtures/op_converter_fixture.cc
@@ -1,0 +1,249 @@
+#include "tensorflow/compiler/tf2tensorrt/convert/fixtures/op_converter_fixture.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "tensorflow/core/platform/status_matchers.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+using ::tensorflow::testing::IsOk;
+using ::tensorflow::testing::StatusIs;
+using ::testing::HasSubstr;
+
+void OpConverterTest::Reset(TrtPrecisionMode precision_mode_to_test,
+                            TrtTestMode trt_mode) {
+  // Destroy existing TRT objects in a proper order.
+  converter_.reset(nullptr);
+  engine_.reset(nullptr);
+
+  // Re-create them in proper order.
+  converter_ = std::move(Converter::Create(precision_mode_to_test,
+                                           /*use_calibration=*/false, &logger_,
+                                           /*use_implicit_batch=*/trt_mode ==
+                                               TrtTestMode::kImplicitBatch,
+                                           /*engine_name=*/"")
+                             .ValueOrDie());
+
+  // Reset other related artifacts.
+  scope_ = Scope::NewRootScope();
+}
+
+void OpConverterTest::CheckDataTypeMatches(const DataVec& datas) {
+  if (VLOG_IS_ON(2)) {
+    int nbBindings = engine_->getNbBindings();
+    VLOG(2) << "Number of engine bindings: " << nbBindings;
+    for (int i = 0; i < nbBindings; i++) {
+      VLOG(2) << "Binding " << i << " name: " << engine_->getBindingName(i);
+    }
+  }
+  for (const auto& data : datas) {
+    VLOG(2) << "Checking if data type matches for tensor " << data.name;
+    const int input_index = engine_->getBindingIndex(data.name.c_str());
+    ASSERT_NE(-1, input_index);
+    const nvinfer1::DataType trt_dtype =
+        engine_->getBindingDataType(input_index);
+    DataType tf_type;
+    TF_ASSERT_OK(TrtTypeToTfType(trt_dtype, &tf_type));
+    ASSERT_EQ(data.tensor.dtype(), tf_type)
+        << DataTypeString(data.tensor.dtype()) << " vs. "
+        << DataTypeString(tf_type);
+  }
+}
+
+Status OpConverterTest::BuildAndRun(const DataVec& input_data,
+                                    DataVec* output_data,
+                                    const int batch_size) {
+  // Mark the output tensor as TRT engine output.
+  std::vector<Converter::EngineOutputInfo> output_info;
+  for (const auto& data : *output_data) {
+    nvinfer1::DataType trt_type;
+    TF_RETURN_IF_ERROR(TfTypeToTrtType(data.tensor.dtype(), &trt_type));
+    output_info.push_back({data.name, data.name, trt_type});
+  }
+  TF_RETURN_IF_ERROR(converter_->RenameAndMarkOutputTensors(output_info));
+
+  // Build the TRT engine.
+  if (engine_.get() != nullptr) {
+    return errors::Internal("Engine already exists");
+  }
+  TrtShapeOptimizationProfile profiles;
+  if (!converter_->use_implicit_batch()) {
+    profiles.SetShapeTensorMask(converter_->network());
+    TF_RETURN_IF_ERROR(profiles.CollectShapeValues(input_data));
+    // Create a single optimization profile for explicit batch mode
+    std::vector<TensorShape> input_shapes;
+    TF_RETURN_IF_ERROR(GetShapeFromDataVec(input_data, &input_shapes));
+    profiles.AddShape(input_shapes);
+    std::vector<PartialTensorShape> input_partial_shapes;
+    TF_RETURN_IF_ERROR(
+        GetNetworkInputShapes(converter_->network(), &input_partial_shapes));
+    profiles.InitProfiles(input_partial_shapes,
+                          ProfileStrategy::kImplicitBatchModeCompatible);
+  }
+  TF_RETURN_IF_ERROR(
+      converter_->BuildCudaEngine(&engine_,
+                                  /*max_batch_size=*/batch_size,
+                                  /*max_workspace_size_bytes=*/1 << 26,
+                                  /*allocator=*/nullptr,
+                                  /*calibrator=*/nullptr,
+                                  /*profiles=*/&profiles));
+  CHECK_NOTNULL(engine_.get());
+  CheckDataTypeMatches(input_data);
+  CheckDataTypeMatches(*output_data);
+
+  const int num_bindings = input_data.size() + output_data->size();
+  std::vector<void*> buffers(num_bindings);
+
+  if (engine_->getNbBindings() != num_bindings) {
+    return errors::Internal("Number of bindings do not match");
+  }
+  // Since we have only 1 optimization profile (which is enabled by default)
+  // it is fine to create execution context directly, instead of calling
+  // profiles.CreateExecutionContexts()
+  TrtUniquePtrType<nvinfer1::IExecutionContext> execution_context(
+      engine_->createExecutionContext());
+
+  // Prepare input bindings.
+  TF_RETURN_IF_ERROR(
+      SetTrtEngineInputs(engine_.get(), execution_context.get(), 0, buffers,
+                         converter_->use_implicit_batch(), batch_size, profiles,
+                         nullptr, &input_data));
+  // Prepare output bindings.
+  TF_RETURN_IF_ERROR(SetTrtEngineOutputs(
+      engine_.get(), execution_context.get(), 0, buffers,
+      converter_->use_implicit_batch(), batch_size, nullptr, output_data));
+  // Execute the TRT engine.
+  TF_RETURN_IF_ERROR(TrtEnqueue(execution_context.get(), buffers, stream_,
+                                converter_->use_implicit_batch(), batch_size));
+  cudaStreamSynchronize(stream_);
+  return Status::OK();
+}
+
+void OpConverterTest::AddTestTensorWithTFDims(const string& name,
+                                              const std::vector<int32>& dims,
+                                              nvinfer1::DataType trt_type,
+                                              Status add_input_status) {
+  DataType tf_type;
+  TF_ASSERT_OK(TrtTypeToTfType(trt_type, &tf_type));
+  ops::Placeholder::Attrs attrs;
+  TF_EXPECT_OK(TensorShapeUtils::MakeShape(dims, &attrs.shape_));
+
+  auto input = ops::Placeholder(scope_.WithOpName(name), tf_type, attrs);
+  node_inputs_[name] = input.output;
+
+  // Add a real ITensor for conversion conditionally.
+  nvinfer1::Dims trt_dims;
+  Status status = TensorShapeToTrtDims(
+      attrs.shape_, converter_->use_implicit_batch(), &trt_dims);
+  if (converter_->use_implicit_batch() && !status.ok()) {
+    ASSERT_EQ(add_input_status, status);
+    return;
+  } else {
+    TF_EXPECT_OK(status);
+  }
+  if (!converter_->use_implicit_batch() || HasStaticShape(trt_dims)) {
+    int batch_size = dims.size() > 0 ? dims[0] : 0;
+    Status status =
+        converter_->AddInputTensor(name, trt_type, trt_dims, batch_size);
+    ASSERT_EQ(add_input_status, status);
+  }
+}
+
+void OpConverterTest::AddTestTensor(const string& name,
+                                    const std::vector<int32>& dims,
+                                    int batch_size,
+                                    nvinfer1::DataType trt_dtype) {
+  std::vector<int32> dims_with_batch(dims.size() + 1);
+  dims_with_batch[0] = batch_size;
+  std::copy(dims.begin(), dims.end(), dims_with_batch.begin() + 1);
+  AddTestTensorWithTFDims(name, dims_with_batch, trt_dtype);
+  if (HasStaticShape(dims)) {
+    ASSERT_EQ(batch_size, converter_->batch_size_);
+  }
+}
+
+Status OpConverterTest::RunValidation(const Node* node) {
+  grappler::GrapplerItem item;
+  TF_EXPECT_OK(scope_.ToGraphDef(&item.graph));
+  grappler::GraphProperties graph_properties(item);
+  TF_EXPECT_OK(graph_properties.InferStatically(true));
+
+  TrtNodeValidator validator(graph_properties, converter_->precision_mode(),
+                             /*use_calibration=*/false,
+                             converter_->use_implicit_batch());
+  return validator.IsTensorRTCandidate(node);
+}
+
+void OpConverterTest::RunConversion(const Node* node, error::Code expected_code,
+                                    const std::string& expected_msg_substr) {
+  EXPECT_THAT(converter_->ConvertNode(node->def()),
+              StatusIs(expected_code, HasSubstr(expected_msg_substr)));
+  if (expected_code == error::OK) {
+    EXPECT_THAT(converter_->network(), LayerNamesNonEmpty());
+  }
+}
+
+void OpConverterTest::RunValidationAndConversion(
+    const NodeDef& node_def, error::Code expected_code,
+    const std::string& expected_msg_substr, bool should_run_conversion) {
+  // Add the node to the graph.
+  // TODO(laigd): we should accept a function that adds the node using
+  // `scope_`, so individual test case can reuse the scope object and we
+  // don't need to add the edges here by ourselves.
+  Graph* graph = scope_.graph();
+  Status status;
+  Node* node = graph->AddNode(std::move(node_def), &status);
+  TF_EXPECT_OK(status);
+  for (int i = 0; i < node_def.input().size(); ++i) {
+    const string& input_name = node_def.input(i);
+    const auto& itr = node_inputs_.find(input_name);
+    QCHECK(itr != node_inputs_.end());
+    const Output& input = itr->second;
+    graph->AddEdge(input.node(), input.index(), node, i);
+  }
+
+  status = RunValidation(node);
+  if (should_run_conversion && status.ok()) {
+    RunConversion(node, expected_code, expected_msg_substr);
+  } else {
+    ASSERT_THAT(status,
+                StatusIs(expected_code, HasSubstr(expected_msg_substr)));
+  }
+}
+
+void OpConverterTest::RunValidationAndConversion(
+    const NodeDef& node_def, const Status& status,
+    const std::string& output_name,
+    const std::vector<std::vector<int>>& exp_out_dims) {
+  RunValidationAndConversion(node_def, status.code(), status.error_message(),
+                             true);
+
+  if (status.ok()) {
+    // TODO(tfeher): Enable this check in explicit_batch_mode.
+    // In dynamic shape mode the output dims cannot be tested here. In that
+    // case we need to wait for the concrate input shapes to be defined (by
+    // setBindingDimensions before enqueue) before we can check the output
+    // dims.
+    if (converter_->use_implicit_batch()) {
+      for (int i = 0; i < exp_out_dims.size(); i++) {
+        TRT_TensorOrWeights output;
+        string name = i == 0 ? output_name : StrCat(output_name, ":", i);
+        TF_EXPECT_OK(GetTensorOrWeights(name.c_str(), &output));
+        ASSERT_TRUE(output.is_tensor());
+        if (!exp_out_dims[i].empty()) {
+          // Removing batch dim.
+          auto out_dims = std::vector<int>(exp_out_dims[i].begin() + 1,
+                                           exp_out_dims[i].end());
+          VLOG(2) << "Testing output shape for tensor " << name;
+          EXPECT_THAT(output.tensor()->getDimensions(), DimsAreArray(out_dims));
+        }
+      }
+    }
+  }
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow

--- a/tensorflow/compiler/tf2tensorrt/convert/fixtures/op_converter_fixture.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/fixtures/op_converter_fixture.h
@@ -1,0 +1,222 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_TEST_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_TEST_H_
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "tensorflow/cc/framework/scope.h"
+#include "tensorflow/compiler/tf2tensorrt/common/datavec.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/tensor_testutils.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h"
+
+#include "tensorflow/core/lib/core/status.h"
+
+namespace tensorflow {
+namespace tensorrt {
+
+// TensorRT modes for testing. We define the following three modes:
+// 1. Implicit batch mode: The tensors have static (known) input shape and the
+//    the batch dimension (first dim) is removed from the TRT tensor shape. In
+//    a loose notation: trt_shape = tf_shape[1:].
+// 2. Explicit batch mode: static (known) input shape, but the batch dimension
+//    is part of the trt tensor shape. (trt_shape = tf_shape)
+// 3. Dynamic shape mode allows unknown input shapes, and requires explicit
+//    batch size definition (trt_shape = tf_shape).
+//
+// Note that the Converter only distinguishes between two modes:
+// - use_implicit_batch == true, this corresponds to kImplicitBatch,
+// - use_implicit_batch == false which includes both kExplicitBatch and
+//   kDynamicShape.
+//
+// For the converter, the distinction between explicit batch or dynamic shape
+// mode follows from the input tensors of the network: dynamic shape input
+// implies dynamic shape mode, while static shape input tensors imply explicit
+// batch mode. We want to test all these modes, therefore we define the
+// TrtTestMode with the following three options.
+enum class TrtTestMode {
+  kImplicitBatch = 0,
+  kExplicitBatch = 1,
+  kDynamicShape = 2
+};
+
+static constexpr std::array<TrtTestMode, 3> ValidTrtModes = {
+    TrtTestMode::kImplicitBatch, TrtTestMode::kExplicitBatch,
+    TrtTestMode::kDynamicShape};
+
+inline string DebugString(const TrtTestMode mode) {
+  switch (mode) {
+    case TrtTestMode::kImplicitBatch:
+      return "kImplicitBatch";
+    case TrtTestMode::kExplicitBatch:
+      return "kExplicitBatch";
+    case TrtTestMode::kDynamicShape:
+      return "kDynamicShape";
+    default:
+      return "Invalid TrtTestMode";
+  }
+}
+
+namespace convert {
+
+// Class to test various op converters, using both a TrtNodeValidator and
+// Converter.
+class OpConverterTest : public ::testing::Test {
+ public:
+  OpConverterTest() : scope_(Scope::NewRootScope()) {
+    QCHECK_EQ(0, cudaStreamCreate(&stream_));
+    Reset();
+  }
+
+  ~OpConverterTest() noexcept { QCHECK_EQ(0, cudaStreamDestroy(stream_)); }
+
+  Status GetTensorOrWeights(const string& name, TRT_TensorOrWeights* output) {
+    return converter_->GetTensorOrWeights(name, output);
+  }
+
+  void Reset(TrtPrecisionMode precision_mode_to_test = TrtPrecisionMode::FP32,
+             TrtTestMode trt_mode = TrtTestMode::kImplicitBatch);
+
+  void CheckDataTypeMatches(const DataVec& datas);
+
+  Status BuildAndRun(const DataVec& input_data, DataVec* output_data,
+                     const int batch_size = 1);
+
+  // Adds ITensor for both validation and conversion, assuming explicit batch
+  // dimension is included in dims (ie for an NCHW tensor dims = {N, C, H,
+  // W}).
+  void AddTestTensorWithTFDims(
+      const string& name, const std::vector<int32>& dims,
+      nvinfer1::DataType trt_type = nvinfer1::DataType::kFLOAT,
+      Status add_input_status = Status::OK());
+
+  // Adds ITensor for both validation and conversion. The difference compared
+  // to AddTestTensorWithTFDims is in the meaning of the dims parameter. To
+  // define a tensor with NCHW shape, here we set dims = {C,H,W} and
+  // batch_size = N.
+  // TODO(tfeher) remove this function once all test are updated to use the
+  // other version of AddTestTensor (defined by
+  // ParameterizedOpConverterTestBase).
+  void AddTestTensor(const string& name, const std::vector<int32>& dims,
+                     int batch_size = 1,
+                     nvinfer1::DataType trt_dtype = nvinfer1::DataType::kFLOAT);
+
+  // Add weights for both validation and conversion.
+  template <typename T>
+  void AddTestWeights(const string& name, const std::vector<int>& dims,
+                      const std::vector<T>& values) {
+    // Add weights for validation.
+    TensorShape shape;
+    TF_EXPECT_OK(TensorShapeUtils::MakeShape(dims, &shape));
+    Tensor t = tensor_factory_.AsTensor<T>(values, shape);
+    node_inputs_[name] = ops::Const(scope_.WithOpName(name), t);
+
+    // Add weights for conversion.
+    nvinfer1::DataType dtype;
+    TF_ASSERT_OK(TfTypeToTrtType(DataTypeToEnum<T>::v(), &dtype));
+    const nvinfer1::Dims trt_dims = nvinfer_factory::dims::Create(dims);
+    const int64_t num_elements = TRT_ShapedWeights::count(trt_dims);
+    QCHECK_EQ(num_elements, values.size())
+        << num_elements << " vs " << values.size();
+    TRT_ShapedWeights weights(dtype);
+    if (num_elements) {
+      weights = converter_->weight_store_.GetTempWeights(dtype, trt_dims);
+      QCHECK_EQ(weights.size_bytes(), sizeof(T) * values.size())
+          << weights.size_bytes() << " vs " << sizeof(T) * values.size();
+      memcpy(weights.GetValues(), values.data(), weights.size_bytes());
+    }
+    TF_EXPECT_OK(
+        converter_->AddTensorOrWeights(name, TRT_TensorOrWeights{weights}));
+  }
+
+  template <typename T = int32>
+  void AddTestWeights(const string& name, const std::vector<int>& dims,
+                      const std::vector<T>& values, DataType tf_type) {
+    if (tf_type == DT_FLOAT) {
+      AddTestWeights(name, dims, CastVector<T, float>(values));
+    } else if (tf_type == DT_HALF) {
+      AddTestWeights(name, dims, CastVector<T, Eigen::half>(values));
+    } else if (tf_type == DT_INT32) {
+      AddTestWeights(name, dims, CastVector<T, int32>(values));
+    } else {
+      FAIL() << "Cannot create test weights with type "
+             << DataTypeString(tf_type);
+    }
+  }
+
+  // Test validation in validation-only mode.
+  Status RunValidation(const Node* node);
+
+  void RunConversion(const Node* node, error::Code expected_code = error::OK,
+                     const std::string& expected_msg_substr = "");
+
+  // Helper method to run both validation and conversion, when the expected
+  // output are same.
+  void RunValidationAndConversion(const NodeDef& node_def,
+                                  error::Code expected_code = error::OK,
+                                  const std::string& expected_msg_substr = "",
+                                  bool should_run_conversion = true);
+
+  // Helper method to run both validation and conversion, and check the output
+  // shapes.
+  void RunValidationAndConversion(
+      const NodeDef& node_def, const Status& status,
+      const std::string& output_name,
+      const std::vector<std::vector<int>>& exp_out_dims);
+
+  // Expose quantization_ranges_ for tests
+  std::unordered_map<ITensorProxyPtr*, float>& quantization_ranges_proxy() {
+    return converter_->quantization_ranges_proxy_;
+  }
+
+  // Expose quantization_ranges_ for tests
+  std::unordered_map<nvinfer1::ITensor*, float>& quantization_ranges() {
+    return converter_->quantization_ranges_;
+  }
+
+  std::unique_ptr<Converter> converter_;
+
+  TensorFactory<GpuManagedAllocator>& GetTensorFactory() {
+    return tensor_factory_;
+  }
+
+  const TensorFactory<GpuManagedAllocator>& GetTensorFactory() const {
+    return tensor_factory_;
+  }
+
+ protected:
+  Logger& logger_ = *Logger::GetLogger();
+  TrtUniquePtrType<nvinfer1::ICudaEngine> engine_;
+  cudaStream_t stream_;
+
+  TensorFactory<GpuManagedAllocator> tensor_factory_;
+
+  // The scope that contains the graph being converted. Because
+  // allocator_ provides the storage for tensor contents that
+  // are represented as attributes for graph nodes within scope_,
+  // allocator_ needs to be available when destructing scope_.
+  // Therefore, scope_ comes after allocator_ in the class
+  // member field list.
+  Scope scope_;
+  std::unordered_map<string, Output> node_inputs_;
+};
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_TEST_H_

--- a/tensorflow/compiler/tf2tensorrt/convert/fixtures/op_converter_param_fixture.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/fixtures/op_converter_param_fixture.cc
@@ -1,0 +1,112 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/tf2tensorrt/convert/fixtures/op_converter_param_fixture.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "tensorflow/core/platform/status_matchers.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+// Builds and runs the converted network. Checks output tensor shape. Tests
+// output values using a matcher. The network can have multiple input and
+// output tensors. The inputs are defined by the input_data_ member
+// variable.
+void ParameterizedOpConverterTestBase::BuildAndRun(
+    const string& name,
+    const std::vector<std::vector<int>>& expected_output_dims,
+    const Status& expected_runtime_status,
+    const std::vector<::testing::Matcher<std::vector<float>>>& matcher,
+    const std::vector<DataType>& out_tf_types) {
+  TensorShape shape;
+  const int n_output = expected_output_dims.size();
+  ASSERT_EQ(n_output, matcher.size());
+  DataVec output_data;
+  for (int i = 0; i < n_output; i++) {
+    TF_EXPECT_OK(TensorShapeUtils::MakeShape(expected_output_dims[i], &shape));
+    string out_name = (i == 0) ? name : StrCat(name, ":", i);
+    DataType out_tf_type = out_tf_types.size() > i ? out_tf_types[i] : tf_type_;
+    InputOutputData data{out_name, tensor_factory_.ConstructTensor(
+                                       shape.num_elements(), 0, out_tf_type)};
+    output_data.push_back(data);
+  }
+  const int batch_size =
+      input_data_.empty() ||
+              TensorShapeUtils::IsScalar(input_data_[0].tensor.shape())
+          ? 1
+          : input_data_[0].tensor.shape().dim_size(0);
+  Status stat =
+      OpConverterTest::BuildAndRun(input_data_, &output_data, batch_size);
+  ASSERT_EQ(expected_runtime_status.ok(), stat.ok())
+      << "expected status: " << expected_runtime_status
+      << ", actual status: " << stat;
+  if (expected_runtime_status.ok() && stat.ok()) {
+    for (int i = 0; i < n_output; i++) {
+      // Check the shape of the actual output tensors
+      TF_EXPECT_OK(
+          TensorShapeUtils::MakeShape(expected_output_dims[i], &shape));
+      EXPECT_TRUE(output_data[i].tensor.shape() == shape)
+          << "Expected shape: " << shape.DebugString()
+          << ", actual shape: " << output_data[i].tensor.shape().DebugString();
+      EXPECT_THAT(GetDataAsFloat(output_data[i]), matcher[i]);
+    }
+  }
+}
+
+// Runs validation and conversion. If conversion is successfull then builds
+// the TRT network, executes it and checks the output. Handles multiple
+// output tensors.
+void ParameterizedOpConverterTestBase::TestOpConverterMultiOut(
+    const string& name, const NodeDef node_def,
+    const std::vector<std::vector<int>>& expected_output_dims,
+    const Status& expected_conversion_status,
+    const Status& expected_runtime_status,
+    const std::vector<::testing::Matcher<std::vector<float>>>& matcher,
+    const std::vector<DataType>& out_tf_type) {
+  RunValidationAndConversion(node_def, expected_conversion_status, name,
+                             expected_output_dims);
+  if (expected_conversion_status.ok()) {
+    BuildAndRun(name, expected_output_dims, expected_runtime_status, matcher,
+                out_tf_type);
+  }
+}
+
+// Runs validation and conversion. If conversion is successfull then builds
+// the TRT network, executes it and checks the output.
+void ParameterizedOpConverterTestBase::TestOpConverter(
+    const string& name, const NodeDef node_def,
+    const std::vector<int>& expected_output_dims,
+    const Status& expected_conversion_status,
+    const Status& expected_runtime_status,
+    const ::testing::Matcher<std::vector<float>>& matcher,
+    const std::vector<DataType>& out_tf_types) {
+  RunValidationAndConversion(
+      node_def, expected_conversion_status, name,
+      std::vector<std::vector<int>>({expected_output_dims}));
+  if (expected_conversion_status.ok()) {
+    BuildAndRun(name, std::vector<std::vector<int>>({expected_output_dims}),
+                expected_runtime_status,
+                std::vector<::testing::Matcher<std::vector<float>>>({matcher}),
+                out_tf_types);
+  }
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow

--- a/tensorflow/compiler/tf2tensorrt/convert/fixtures/op_converter_param_fixture.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/fixtures/op_converter_param_fixture.h
@@ -1,0 +1,189 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_FIXTURES_OP_CONVERTER_PARAM_FIXTURE_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_FIXTURES_OP_CONVERTER_PARAM_FIXTURE_H_
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "tensorflow/cc/framework/scope.h"
+#include "tensorflow/compiler/tf2tensorrt/common/datavec.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/fixtures/op_converter_fixture.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h"
+
+#include "tensorflow/core/lib/core/status.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+// Parameterized version of OpConverterTest. We have the following parameters:
+// 1. TrtTestMode: implicit batch, explicit batch, dynamic shape modes
+// 2. DataType of the input TF tensors: DT_FLOAT, DT_HALF, DT_INT32
+// 3. TrtPrecisionMode argument for the Converter: FP32, FP16, INT8
+// We will introduce subclasses that will be instantiated using different
+// combinations of the DataType and TrtPrecisionMode parameters.
+class ParameterizedOpConverterTestBase
+    : public OpConverterTest,
+      public ::testing::WithParamInterface<
+          std::tuple<TrtTestMode, DataType, TrtPrecisionMode>> {
+ public:
+  ParameterizedOpConverterTestBase()
+      : trt_mode_(std::get<0>(GetParam())),
+        tf_type_(std::get<1>(GetParam())),
+        converter_precision_(std::get<2>(GetParam())) {
+    LOG(INFO) << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%";
+    LOG(INFO) << "tf_type_: " << DebugString(tf_type_);
+    LOG(INFO) << "trt_mode_: " << DebugString(trt_mode_);
+    LOG(INFO) << "converter_precision_: " << DebugString(converter_precision_);
+    LOG(INFO) << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%";
+  }
+
+  void Reset() {
+    OpConverterTest::Reset(converter_precision_, trt_mode_);
+    input_data_.clear();
+  }
+
+  void Reset(TrtPrecisionMode precision) {
+    OpConverterTest::Reset(precision, trt_mode_);
+    input_data_.clear();
+  }
+
+  // Getters of protected attributes
+  DataType get_tf_type() { return tf_type_; }
+  TrtTestMode get_trt_mode() { return trt_mode_; }
+  TrtPrecisionMode get_converter_precision() { return converter_precision_; }
+
+  // Adds an input ITensor for TRT network. Also creates the corresponding TF
+  // tensor, and stores it in the list of inputs (input_data_).
+  //
+  // The TF tensor is always created with concrete static input shape given by
+  // dims. The ITensor can have static or dynamic shape based on the trt_mode
+  // attribute. The ITensor shape is set automatically according to the
+  // trt_mode parameter, unless the user overrides it with an explicit
+  // partial_input_shape_dims argument.
+  //
+  // Parameters:
+  // - name of the input node
+  // - dims actual dimensions of the tensor that we will use during the test
+  //   (including explicit batch dim)
+  // - values initial values for the TF tensor
+  // - dtype data type of the tensor
+  // - partial_input_shape dimensions which can include unknown shapes. This
+  // can
+  //   be empty, in that case the partial_input_shape will be set
+  //   automatically depending on the trt_mode argument. (This argument also
+  //   includes explicit batch dim).
+  // - add_input_status adding ITensor to the network can fail in implicit
+  // batch
+  //   mode if the batch size is inconsistent. Using the add_input_status arg
+  //   we can test such errors.
+  //
+  template <typename T = int>
+  void AddTestTensor(const string& name, const std::vector<int32>& dims,
+                     DataType tf_type, const std::vector<T>& values,
+                     const std::vector<int32>& partial_input_shape_dims = {},
+                     Status add_input_status = Status::OK()) {
+    if (!dims.empty()) {
+      const auto num_elements = std::accumulate(
+          std::begin(dims), std::end(dims), 1, std::multiplies<double>());
+      if (!values.empty() && num_elements != values.size()) {
+        // Note: for conversion only tests, it is valid to have empty values,
+        // otherwise the number of elements should match.
+        LOG(WARNING) << "Expected Test Tensor Shape: " << DebugString(dims)
+                     << ", Received Input Tensor: " << DebugString(values);
+      }
+    }
+
+    std::vector<int32> partial_shape;
+    if (!partial_input_shape_dims.empty()) {
+      partial_shape = partial_input_shape_dims;
+    } else {
+      if (trt_mode_ == TrtTestMode::kDynamicShape) {
+        // In dynamic shape mode we make all dims unknown.
+        partial_shape = std::vector<int32>(dims.size(), -1);
+      } else {
+        // Use static (known) input shapes.
+        partial_shape = dims;
+      }
+    }
+    nvinfer1::DataType trt_type;
+    TF_ASSERT_OK(TfTypeToTrtType(tf_type, &trt_type));
+    AddTestTensorWithTFDims(name, partial_shape, trt_type, add_input_status);
+    if (!values.empty()) {
+      VLOG(2) << "Adding test tensor: " << name << " "
+              << DataTypeString(tf_type);
+      InputOutputData data{name,
+                           tensor_factory_.AsTensor(values, dims, tf_type)};
+      VLOG(2) << "Added tensor: " << data.name << " with dtype "
+              << DataTypeString(data.tensor.dtype());
+      input_data_.push_back(data);
+    }
+  }
+
+  // Adds test tensor (same as above) but with the default tf_type defined by
+  // the test params.
+  template <typename T = int>
+  void AddTestTensor(const string& name, const std::vector<int32>& dims,
+                     const std::vector<T>& values = {},
+                     const std::vector<int32>& partial_input_shape_dims = {}) {
+    AddTestTensor<T>(name, dims, tf_type_, values, partial_input_shape_dims);
+  }
+
+  // Builds and runs the converted network. Checks output tensor shape. Tests
+  // output values using a matcher. The network can have multiple input and
+  // output tensors. The inputs are defined by the input_data_ member
+  // variable.
+  void BuildAndRun(
+      const string& name,
+      const std::vector<std::vector<int>>& expected_output_dims,
+      const Status& expected_runtime_status,
+      const std::vector<::testing::Matcher<std::vector<float>>>& matcher,
+      const std::vector<DataType>& out_tf_types = {});
+
+  // Runs validation and conversion. If conversion is successfull then builds
+  // the TRT network, executes it and checks the output. Handles multiple
+  // output tensors.
+  void TestOpConverterMultiOut(
+      const string& name, const NodeDef node_def,
+      const std::vector<std::vector<int>>& expected_output_dims,
+      const Status& expected_conversion_status,
+      const Status& expected_runtime_status,
+      const std::vector<::testing::Matcher<std::vector<float>>>& matcher,
+      const std::vector<DataType>& out_tf_type = {});
+
+  // Runs validation and conversion. If conversion is successfull then builds
+  // the TRT network, executes it and checks the output.
+  void TestOpConverter(const string& name, const NodeDef node_def,
+                       const std::vector<int>& expected_output_dims,
+                       const Status& expected_conversion_status,
+                       const Status& expected_runtime_status,
+                       const ::testing::Matcher<std::vector<float>>& matcher,
+                       const std::vector<DataType>& out_tf_types = {});
+
+ protected:
+  const TrtTestMode trt_mode_;
+  const DataType tf_type_;
+  const TrtPrecisionMode converter_precision_;
+  DataVec input_data_;
+};
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_FIXTURES_OP_CONVERTER_PARAM_FIXTURE_H_

--- a/tensorflow/compiler/tf2tensorrt/utils/tensor_testutils.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/tensor_testutils.h
@@ -1,0 +1,105 @@
+
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_TENSOR_TESTUTILS_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_TENSOR_TESTUTILS_H_
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include <memory>
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h"
+#include "tensorflow/core/common_runtime/gpu/gpu_managed_allocator.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_testutil.h"
+
+namespace tensorflow {
+namespace tensorrt {
+// This class manages an Allocator of 'AllocatorType' and provides templated
+// methods for creating Tensor objects using that allocator. GpuManagedAllocator
+// should be used in functional unit tests.
+template <typename AllocatorType = GpuManagedAllocator>
+class TensorFactory {
+ public:
+  TensorFactory() : allocator_(std::make_unique<AllocatorType>()) {}
+
+  // Constructs a flat tensor with 'vals'.
+  template <typename T>
+  Tensor AsTensor(gtl::ArraySlice<T> vals) {  // non-absl ok
+    Tensor ret(allocator_.get(), DataTypeToEnum<T>::value,
+               {static_cast<int64>(vals.size())});
+    std::copy_n(vals.data(), vals.size(), ret.flat<T>().data());
+    return ret;
+  }
+
+  // Constructs a tensor of "shape" with values "vals".
+  template <typename T>
+  Tensor AsTensor(gtl::ArraySlice<T> vals,  // non-absl ok
+                  const TensorShape& shape) {
+    Tensor ret(allocator_.get(), DataTypeToEnum<T>::value,
+               {static_cast<int64>(vals.size())});
+    CHECK(ret.CopyFrom(AsTensor(vals), shape));
+    return ret;
+  }
+
+  // Constructs a Tensor with given values 'vals' of shape 'input_dims' and type
+  // 'tf_type'.
+  template <typename T>
+  Tensor AsTensor(const std::vector<T>& vals,
+                  const std::vector<int>& input_dims, DataType tf_type) {
+    Tensor ret(allocator_.get(), tf_type, {static_cast<int64>(vals.size())});
+    if (tf_type == DT_FLOAT) {
+      auto conv_vals = convert::CastVector<T, float>(vals);
+      std::copy_n(conv_vals.data(), conv_vals.size(), ret.flat<float>().data());
+    } else if (tf_type == DT_HALF) {
+      auto conv_vals = convert::CastVector<T, Eigen::half>(vals);
+      std::copy_n(conv_vals.data(), conv_vals.size(),
+                  ret.flat<Eigen::half>().data());
+    } else if (tf_type == DT_INT32) {
+      auto conv_vals = convert::CastVector<T, int32>(vals);
+      std::copy_n(conv_vals.data(), conv_vals.size(), ret.flat<int32>().data());
+    } else {
+      LOG(FATAL) << "Cannot create tensor with type "
+                 << DataTypeString(tf_type);
+    }
+    TensorShape shape;
+    TF_EXPECT_OK(TensorShapeUtils::MakeShape(input_dims, &shape));
+    CHECK(ret.CopyFrom(ret, shape));
+    return ret;
+  }
+
+  // Constructs a flat tensor of the given size and fills with the given value.
+  template <typename T>
+  Tensor ConstructTensor(int data_size, const T& value = T()) {
+    std::vector<T> values(data_size, value);
+    return AsTensor<T>(values);
+  }
+
+  // Constructs a flat Tensor of the  given size and Datatype, and fills with
+  // the given value.
+  template <typename T>
+  Tensor ConstructTensor(int data_size, const T& value, DataType tf_type) {
+    std::vector<T> values(data_size, value);
+    return AsTensor<T>(values, {data_size}, tf_type);
+  }
+
+ private:
+  std::unique_ptr<Allocator> allocator_;
+};
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_TENSOR_TESTUTILS_H_

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
@@ -381,7 +381,7 @@ void TrtShapeOptimizationProfile::SetShapeTensorMask(
     const ITensorProxyPtr input = network->getInput(i);
     is_shape_tensor_[i] = input->isShapeTensor();
     if (is_shape_tensor_[i]) {
-      VLOG(2) << "Found shape tensor " << input->getName() << ' at ' << i;
+      VLOG(2) << "Found shape tensor " << input->getName() << " at " << i;
     }
   }
   has_shape_tensor_ =

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.cc
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -73,7 +73,6 @@ bool TrtDimsEquals(const nvinfer1::Dims& lhs, const nvinfer1::Dims& rhs) {
   if (lhs.nbDims != rhs.nbDims) return false;
   for (int i = 0; i < lhs.nbDims; ++i) {
     if (lhs.d[i] != rhs.d[i]) return false;
-    // We don't check the types in the tests.
   }
   return true;
 }

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.cc
@@ -45,15 +45,6 @@ namespace convert {
   return ::testing::ElementsAreArray(matchers);
 }
 
-nvinfer1::Dims CreateDims(const std::vector<int>& d) {
-  nvinfer1::Dims dims;
-  dims.nbDims = d.size();
-  for (int i = 0; i < d.size(); ++i) {
-    dims.d[i] = d[i];
-  }
-  return dims;
-}
-
 NodeDef MakeNodeDef(const std::string& name, const std::string& op,
                     const std::vector<std::string>& inputs,
                     const std::map<std::string, AttrValue> attrs) {

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.cc
@@ -1,0 +1,85 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h"
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include <gmock/gmock.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace tensorflow {
+
+namespace tensorrt {
+namespace convert {
+
+::testing::Matcher<std::vector<float>> ArrayFloatNear(
+    const std::vector<float>& values, float max_abs_error, bool nan_sensitive) {
+  std::vector<::testing::Matcher<float>> matchers;
+  matchers.reserve(values.size());
+  for (const float& v : values) {
+    if (nan_sensitive) {
+      matchers.emplace_back(::testing::NanSensitiveFloatNear(v, max_abs_error));
+    } else if (max_abs_error == 0) {
+      matchers.emplace_back(::testing::FloatEq(v));
+    } else {
+      EXPECT_GE(max_abs_error, 0);
+      matchers.emplace_back(::testing::FloatNear(v, max_abs_error));
+    }
+  }
+  return ::testing::ElementsAreArray(matchers);
+}
+
+nvinfer1::Dims CreateDims(const std::vector<int>& d) {
+  nvinfer1::Dims dims;
+  dims.nbDims = d.size();
+  for (int i = 0; i < d.size(); ++i) {
+    dims.d[i] = d[i];
+  }
+  return dims;
+}
+
+NodeDef MakeNodeDef(const std::string& name, const std::string& op,
+                    const std::vector<std::string>& inputs,
+                    const std::map<std::string, AttrValue> attrs) {
+  NodeDef node_def;
+  node_def.set_name(name);
+  node_def.set_op(op);
+  for (const auto& input : inputs) {
+    node_def.add_input(input);
+  }
+  for (const auto& attr : attrs) {
+    (*node_def.mutable_attr())[attr.first] = attr.second;
+  }
+  return node_def;
+}
+
+bool TrtDimsEquals(const nvinfer1::Dims& lhs, const nvinfer1::Dims& rhs) {
+  if (lhs.nbDims != rhs.nbDims) return false;
+  for (int i = 0; i < lhs.nbDims; ++i) {
+    if (lhs.d[i] != rhs.d[i]) return false;
+    // We don't check the types in the tests.
+  }
+  return true;
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h
@@ -191,7 +191,7 @@ MATCHER_P2(ShapedWeightsHasDimsAndValues, dims, expected_values, "") {
 }
 
 template <typename InCType, typename OutCType>
-std::vector<OutCType> CastTestVector(
+std::vector<OutCType> CastVector(
     const gtl::ArraySlice<InCType>& vals) {  // non-absl ok
   std::vector<OutCType> res(vals.size());
   std::transform(vals.begin(), vals.end(), res.begin(),
@@ -202,7 +202,7 @@ std::vector<OutCType> CastTestVector(
 }
 
 template <typename CType>
-std::vector<CType> InitTestVector(int size, CType start_value = CType(0)) {
+std::vector<CType> CreateVectorIota(int size, CType start_value = CType(0)) {
   std::vector<CType> res(size);
   std::iota(res.begin(), res.end(), start_value);
   return res;

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h
@@ -1,0 +1,178 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_TEST_UTILS_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_TEST_UTILS_H_
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "absl/strings/str_format.h"
+#include "absl/types/span.h"
+#include "tensorflow/cc/framework/ops.h"
+#include "tensorflow/cc/framework/scope.h"
+#include "tensorflow/cc/ops/standard_ops.h"
+#include "tensorflow/compiler/tf2tensorrt/common/datavec.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h"
+#include "tensorflow/core/framework/node_def.pb.h"  // NOLINT
+#include "tensorflow/core/framework/tensor.pb.h"    // NOLINT
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/tensor_testutil.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace nvinfer1 {
+// Stream printing functions for GTest.
+// These must be in nvinfer1 namespace.
+
+// Alias a useful type computation for nvinfer1::Dims types;
+// legacy dims like nvinfer1::Dims2 inherit from nvinfer1::Dims.
+template <typename T>
+using enable_if_nvinfer_dims =
+    std::enable_if<std::is_base_of<nvinfer1::Dims, T>::value, T>;
+
+// Prints nvinfer1::Dims (and any sub-struct, for legacy Dim types)
+// to ostream.
+template <typename T, typename enable_if_nvinfer_dims<T>::type* = nullptr>
+std::ostream& operator<<(std::ostream& os, const T& v) {
+  os << "nvinfer1::Dims[";
+  for (int i = 0; i < v.nbDims; i++) {
+    os << (i > 0 ? ", " : "") << v.d[i] << "";
+  }
+  os << "]";
+  return os;
+}
+
+// Print nvinfer1::INetworkDefinition* information to ostream
+inline std::ostream& operator<<(std::ostream& os,
+                                nvinfer1::INetworkDefinition* n) {
+  auto print_layers = [](std::ostream& os, nvinfer1::INetworkDefinition* n) {
+    for (int i = 0; i < n->getNbLayers(); i++) {
+      os << " " << n->getLayer(i)->getName() << "\n";
+    }
+  };
+  os << "nvinfer1::INetworkDefinition{\n";
+  print_layers(os, n);
+  os << "}";
+  return os;
+}
+
+}  // namespace nvinfer1
+
+// Matchers used in graph/node conversion testing we put under
+// tensorrt::convert.
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+// Node creation utilities
+
+// helper to create node with given op, inputs, and attributes
+NodeDef MakeNodeDef(const std::string& name, const std::string& op,
+                    const std::vector<std::string>& inputs,
+                    const std::map<std::string, AttrValue> attrs = {});
+
+// create a constant node with given vector and shape as tensor
+template <typename T>
+NodeDef MakeConstNodeDef(const std::string& name, const std::vector<T>& vals,
+                         const TensorShape& shape) {
+  Scope s = Scope::NewRootScope();
+  Tensor t = test::AsTensor<T>(vals, shape);
+  auto const_op = ops::Const(s.WithOpName(name), t);
+  return const_op.node()->def();
+}
+
+// constant node with 1d shape
+template <typename T>
+NodeDef MakeConstNodeDef(const std::string& name, const std::vector<T>& vals) {
+  TensorShape shape;
+  const std::vector<int32> shape_dims = {static_cast<int32>(vals.size())};
+  TF_EXPECT_OK(TensorShapeUtils::MakeShape(shape_dims, &shape));
+  return MakeConstNodeDef(name, vals, shape);
+}
+
+// nvinfer1:: type helpers
+
+// Checks equality of two sets of dims
+bool TrtDimsEquals(const nvinfer1::Dims& lhs, const nvinfer1::Dims& rhs);
+
+// Creates an nvinfer1::Dims struct from the given vector.
+nvinfer1::Dims CreateDims(const std::vector<int>& d);
+
+// general GMock matchers
+// A gmock matcher that check that elements of a float vector match to a given
+// tolerance.
+::testing::Matcher<std::vector<float>> ArrayFloatNear(
+    const std::vector<float>& values, float max_abs_error = 1e-5,
+    bool nan_sensitive = false);
+
+// nvinfer1::Dims GMock matchers
+
+// matches nvinfer1::Dims to initializer list or vector of ints
+// "EXPECT_THAT(my_dims, DimsAreArray({1, 2, 3}))"
+MATCHER_P(DimsAreArrayHelper, array_value,
+          absl::StrFormat("%s [%s]", negation ? "are" : "are not",
+                          ::testing::PrintToString(array_value))) {
+  if (arg.nbDims != array_value.size()) return false;
+  for (int i = 0; i < arg.nbDims; ++i) {
+    if (arg.d[i] != array_value[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+using DimsAreArray = DimsAreArrayHelperMatcherP<std::vector<int>>;
+
+// nvinfer1::INetworkDefinition GMock matchers
+
+// Check layer names are equal to initializer list or vector of strings
+MATCHER_P(LayerNamesAreArrayHelper, array_value,
+          absl::StrFormat("layer names %s [%s]", negation ? "are" : "are not",
+                          ::testing::PrintToString(array_value))) {
+  if (array_value.size() != arg->getNbLayers()) return false;
+  for (int i = 0; i < arg->getNbLayers(); ++i) {
+    if (arg->getLayer(i)->getName() == nullptr) {
+      return false;
+    }
+  }
+  return true;
+}
+using LayerNamesAreArray =
+    LayerNamesAreArrayHelperMatcherP<std::vector<std::string>>;
+
+// Check layer names in INetworkDefinition are all non-empty.
+MATCHER(LayerNamesNonEmpty, "") {
+  for (int i = 0; i < arg->getNbLayers(); ++i) {
+    if (arg->getLayer(i)->getName() == nullptr) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_TEST_UTILS_H_

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h
@@ -76,9 +76,6 @@ NodeDef MakeConstNodeDef(const std::string& name, const std::vector<T>& vals) {
 // Returns true if the given two nvinfer1::Dims are equal.
 bool TrtDimsEquals(const nvinfer1::Dims& lhs, const nvinfer1::Dims& rhs);
 
-// Creates an nvinfer1::Dims struct from the given vector.
-nvinfer1::Dims CreateDims(const std::vector<int>& d);
-
 // A gmock matcher that check that elements of a float vector match to a given
 // tolerance.
 ::testing::Matcher<std::vector<float>> ArrayFloatNear(
@@ -135,12 +132,8 @@ MATCHER(LayerNamesNonEmpty, "") {
 // Checks that the weight dimensions are values are equal to the given values.
 // Example: EXPECT_THAT(my_weights,
 //                      ShapedWeightsHasDimsAndValues({1, 2},{1.0f, 2.0f}))
-MATCHER_P2(ShapedWeightsHasDimsAndValuesHelper, dims_vec, expected_values, "") {
-  nvinfer1::Dims dims;
-  dims.nbDims =
-      std::min(static_cast<int>(dims_vec.size()), nvinfer1::Dims::MAX_DIMS);
-  std::copy_n(dims_vec.begin(), dims.nbDims, dims.d);
-  if (arg.shape_ != dims) {
+MATCHER_P2(ShapedWeightsHasDimsAndValuesHelper, dims, expected_values, "") {
+  if (arg.shape_ != nvinfer_factory::dims::Create(dims)) {
     return false;
   }
   if (arg.count() != expected_values.size()) {

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_testutils_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_testutils_test.cc
@@ -1,0 +1,84 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h"
+
+#include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+using ::testing::AllOf;
+using ::testing::AnyOf;
+using ::testing::Not;
+
+TEST(TrtDimsMatcher, CorrectlyMatches) {
+  EXPECT_THAT(nvinfer1::Dims4(1, 2, 3, 4), DimsAreArray({1, 2, 3, 4}));
+  // empty
+  EXPECT_THAT(nvinfer1::Dims{}, Not(DimsAreArray({1, 2})));
+  EXPECT_THAT(nvinfer1::Dims{}, DimsAreArray({}));
+  // Check incorrect value
+  EXPECT_THAT(nvinfer1::Dims4(1, 2, 3, 4), Not(DimsAreArray({1, 2, 3, 5})));
+  // Check wrong number args
+  EXPECT_THAT(nvinfer1::Dims4(1, 2, 3, 4), Not(DimsAreArray({1, 2, 5})));
+}
+
+TEST(INetworkDefinitionMatchers, CorrectlyMatch) {
+  Logger& logger = *Logger::GetLogger();
+  TrtUniquePtrType<nvinfer1::IBuilder> builder(
+      nvinfer1::createInferBuilder(logger));
+  TrtUniquePtrType<nvinfer1::INetworkDefinition> network(
+      builder->createNetworkV2(0L));
+
+  // Empty network checks.
+  EXPECT_THAT(network.get(), AllOf(Not(LayerNamesAreArray({"some layer"})),
+                                   LayerNamesNonEmpty()));
+
+  // Add the input and FC layer.
+  nvinfer1::Weights weights;
+  weights.type = nvinfer1::DataType::kFLOAT;
+  std::array<float, 1> vals;
+  weights.values = vals.data();
+  weights.count = 1;
+  auto input = network->addInput("input-tensor", nvinfer1::DataType::kFLOAT,
+                                 nvinfer1::Dims3{1, 1, 1});
+  ASSERT_NE(input, nullptr);
+
+  const char* fc_layer_name = "my-fc-layer";
+  auto layer = network->addFullyConnected(*input, 1, weights, weights);
+  ASSERT_NE(layer, nullptr);
+  layer->setName(fc_layer_name);
+
+  // Check layer name matchers
+  EXPECT_THAT(network.get(),
+              AllOf(LayerNamesNonEmpty(), LayerNamesAreArray({fc_layer_name})));
+
+  // add layer without setting name (default name assigned) and check.
+  layer = network->addFullyConnected(*input, 1, weights, weights);
+  EXPECT_THAT(network.get(), AllOf(LayerNamesNonEmpty(),
+                                   Not(LayerNamesAreArray({fc_layer_name}))));
+}
+
+}  // namespace convert
+
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT


### PR DESCRIPTION
Builds upon this [PR](https://github.com/tensorflow/tensorflow/pull/51235). Only commits from `TF-TRT: Elide dangerous absl::string_view...` are relevant here.

This PR's changes are:

Larger changes:
1. It breaks out the operation conversion GTest test fixture classes into a sub-folder `tf2tensorrt/convert/fixtures`. The actual test instantiations `TEST_F(..., ...)` remain in place in `convert_nodes_test.cc`. The purpose of this is to improve clarity of the unit tests, as currently `convert_nodes_test.cc` has a mess of utility functions, and the test fixture classes chained via inheritance further add to the confusion. By breaking out the fixtures (and separating their definition/implementations), it's easier to understand and assess further improvements for the test infrastructure.

Medium:
1. Change unit tests for Converter::PrepareTensorForShape into a
value-parameterized test suite.
2. Change unit tests for Converter quantization helpers into
type-parameterized test suite.
3. Create `nvinfer_factory` namespace with utility methods as appropriate under `common/util.h`. This replaces various "CreateDimsFromX" functions.
4. Pulled methods out of the OpConverter test fixtures for creating `tensorflow::Tensor` objects with ManagedGpuAllocator and bundled into class `TensorFactory` under `utils/`. 

Small:
1. Add `ostream<<(ostream, TRT_ShapedWeights)` printing operator so GTest prints reasonable values for TRT_ShapedWeights.
2. Remove incorrect string_view usage in Converter
3. Rearrange utility functions for InputOutputData and nvinfer1::Dims