### PR TITLE
Fix protobuf errors when using system protobuf

### DIFF
--- a/tensorflow/python/__init__.py
+++ b/tensorflow/python/__init__.py
@@ -37,8 +37,8 @@ import traceback
 # go/tf-wildcard-import
 # pylint: disable=wildcard-import,g-bad-import-order,g-import-not-at-top
 
-from tensorflow.python.eager import context
 from tensorflow.python import pywrap_tensorflow as _pywrap_tensorflow
+from tensorflow.python.eager import context
 
 # pylint: enable=wildcard-import
 


### PR DESCRIPTION
When tensorflow and python protobuf use the same instance of
libprotobuf, pywrap_tensorflow must be imported before anything
else that would import protobuf definitions.

Fixes #50545. See that thread for a Dockerfile with a reproduction
of the error.