### PR TITLE
Add tensorflow-io-gcs-filesystem dependency

### DIFF
--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -76,6 +76,13 @@ except ImportError:
   _logging.warning(
       "Limited tf.summary API due to missing TensorBoard installation.")
 
+# Load tensorflow-io-gcs-filesystem if enabled
+# pylint: disable=g-import-not-at-top
+if (_os.getenv('TF_USE_MODULAR_FILESYSTEM', '0') == 'true' or
+    _os.getenv('TF_USE_MODULAR_FILESYSTEM', '0') == '1'):
+  import tensorflow_io_gcs_filesystem as _tensorflow_io_gcs_filesystem
+# pylint: enable=g-import-not-at-top
+
 # Lazy-load estimator.
 _estimator_module = "tensorflow_estimator.python.estimator.api._v2.estimator"
 estimator = _LazyLoader("estimator", globals(), _estimator_module)

--- a/tensorflow/api_template_v1.__init__.py
+++ b/tensorflow/api_template_v1.__init__.py
@@ -67,6 +67,13 @@ elif _tf_api_dir not in __path__:
 # lazy loading.
 _current_module.compat.v2  # pylint: disable=pointless-statement
 
+# Load tensorflow-io-gcs-filesystem if enabled
+# pylint: disable=g-import-not-at-top
+if (_os.getenv('TF_USE_MODULAR_FILESYSTEM', '0') == 'true' or
+    _os.getenv('TF_USE_MODULAR_FILESYSTEM', '0') == '1'):
+  import tensorflow_io_gcs_filesystem as _tensorflow_io_gcs_filesystem
+# pylint: enable=g-import-not-at-top
+
 # Lazy-load estimator.
 _estimator_module = "tensorflow_estimator.python.estimator.api._v1.estimator"
 estimator = _LazyLoader("estimator", globals(), _estimator_module)

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -104,6 +104,7 @@ REQUIRED_PACKAGES = [
     'tensorboard ~= 2.6',
     'tensorflow_estimator ~= 2.6',
     'keras ~= 2.6',
+    'tensorflow-io-gcs-filesystem >= 0.20.0',
 ]
 
 


### PR DESCRIPTION
This PR is part of the effort to migrate to modular file systems.
This PR add the dependency of tensorflow-io-gcs-filesystem package
while at the same time, only enable using it with
`TF_USE_MODULAR_FILESYSTEM=1`.

This allows end user to not getting impacted by default.

The switch off will happen after a period of transition time.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>