### PR TITLE
TF-TRT MNIST test with V2 converter

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/quantization_mnist_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/quantization_mnist_test.py
@@ -14,9 +14,12 @@
 # ==============================================================================
 """Script to test TF-TRT INT8 conversion without calibration on Mnist model."""
 
+import os.path
+import tempfile
 import tensorflow_datasets as tfds
 from tensorflow.compiler.tf2tensorrt._pywrap_py_utils import is_tensorrt_enabled
 from tensorflow.core.protobuf import config_pb2
+from tensorflow.python.client import session
 from tensorflow.python.compiler.tensorrt import trt_convert
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.estimator.estimator import Estimator
@@ -28,6 +31,7 @@ from tensorflow.python.framework import graph_util
 from tensorflow.python.framework import importer
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
+from tensorflow.python.keras.metrics import Accuracy
 from tensorflow.python.layers import layers
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_array_ops
@@ -39,6 +43,12 @@ from tensorflow.python.ops import variable_scope
 from tensorflow.python.ops.losses import losses
 from tensorflow.python.platform import test
 from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.saved_model import builder
+from tensorflow.python.saved_model import signature_constants
+from tensorflow.python.saved_model import tag_constants
+from tensorflow.python.saved_model import utils as saved_model_utils
+from tensorflow.python.saved_model import signature_def_utils
+from tensorflow.python.saved_model.load import load as saved_model_load
 from tensorflow.python.summary import summary
 from tensorflow.python.training import saver
 from tensorflow.python.training.adam import AdamOptimizer
@@ -47,6 +57,27 @@ from tensorflow.python.training.training_util import get_global_step
 
 INPUT_NODE_NAME = 'input'
 OUTPUT_NODE_NAME = 'output'
+MNIST_TEST_DIR_PATH = 'python/compiler/tensorrt/test/testdata/mnist'
+
+def _PreprocessFn(entry):
+  """Normalizes the pixel values to lay within the [-1, 1] range.
+
+   The same normalization shall be used during training and inference.
+  """
+  x, y = entry['image'], entry['label']
+  x = math_ops.cast(x, dtypes.float32)
+  x = 2.0 * (x / 255.0) - 1.0
+  y = math_ops.cast(y, dtypes.int32)
+  return x, y
+
+
+def _GetDataSet(batch_size):
+  dataset = tfds.load('mnist', split='test')
+  dataset = dataset.map(
+      map_func=_PreprocessFn,
+      num_parallel_calls=8).batch(batch_size=batch_size)
+  dataset = dataset.repeat(count=1)
+  return dataset
 
 
 class QuantizationAwareTrainingMNISTTest(test_util.TensorFlowTestCase):
@@ -59,7 +90,7 @@ class QuantizationAwareTrainingMNISTTest(test_util.TensorFlowTestCase):
       return x
 
     def _DenseLayer(x, num_inputs, num_outputs, quantization_range, name):
-      """Dense layer with quantized outputs.
+      """Defines a dense layer with quantized outputs.
 
       Args:
         x: input to the dense layer
@@ -106,8 +137,17 @@ class QuantizationAwareTrainingMNISTTest(test_util.TensorFlowTestCase):
     x = array_ops.identity(x, name=OUTPUT_NODE_NAME)
     return x
 
+  def _LoadWeights(self, model_dir, sess):
+    mnist_saver = saver.Saver()
+    checkpoint_file = latest_checkpoint(model_dir)
+    if checkpoint_file is None:
+      raise ValueError(
+          'latest_checkpoint returned None. check if' +
+          'model_dir={} is the right directory'.format(model_dir))
+    mnist_saver.restore(sess, checkpoint_file)
+
   def _GetGraphDef(self, use_trt, max_batch_size, model_dir):
-    """Get the frozen mnist GraphDef.
+    """Gets the frozen mnist GraphDef.
 
     Args:
       use_trt: whether use TF-TRT to convert the graph.
@@ -123,14 +163,7 @@ class QuantizationAwareTrainingMNISTTest(test_util.TensorFlowTestCase):
         x = array_ops.placeholder(
             shape=(None, 28, 28, 1), dtype=dtypes.float32, name=INPUT_NODE_NAME)
         self._BuildGraph(x)
-      # Load weights
-      mnist_saver = saver.Saver()
-      checkpoint_file = latest_checkpoint(model_dir)
-      if checkpoint_file is None:
-        raise ValueError(
-            'latest_checkpoint returned None. check if' +
-            'model_dir={} is the right directory'.format(model_dir))
-      mnist_saver.restore(sess, checkpoint_file)
+      self._LoadWeights(model_dir, sess)
       # Freeze
       graph_def = graph_util.convert_variables_to_constants(
           sess, sess.graph_def, output_node_names=[OUTPUT_NODE_NAME])
@@ -158,7 +191,7 @@ class QuantizationAwareTrainingMNISTTest(test_util.TensorFlowTestCase):
     return graph_def
 
   def _Run(self, is_training, use_trt, batch_size, num_epochs, model_dir):
-    """Train or evaluate the model.
+    """Trains or evaluates the model.
 
     Args:
       is_training: whether to train or evaluate the model. In training mode,
@@ -175,19 +208,8 @@ class QuantizationAwareTrainingMNISTTest(test_util.TensorFlowTestCase):
       The Estimator evaluation result.
     """
 
-    def _PreprocessFn(entry):
-      x, y = entry['image'], entry['label']
-      x = math_ops.cast(x, dtypes.float32)
-      x = 2.0 * (x / 255.0) - 1.0
-      y = math_ops.cast(y, dtypes.int32)
-      return x, y
-
     def _EvalInputFn():
-      dataset = tfds.load('mnist', split='test')
-      dataset = dataset.map(
-          map_func=_PreprocessFn,
-          num_parallel_calls=8).batch(batch_size=batch_size)
-      dataset = dataset.repeat(count=1)
+      dataset = _GetDataSet(batch_size)
       iterator = dataset_ops.make_one_shot_iterator(dataset)
       features, labels = iterator.get_next()
       return features, labels
@@ -255,8 +277,7 @@ class QuantizationAwareTrainingMNISTTest(test_util.TensorFlowTestCase):
   #     model_dir=model_dir)
   def testEval(self):
 
-    model_dir = test.test_src_dir_path(
-        'python/compiler/tensorrt/test/testdata/mnist')
+    model_dir = test.test_src_dir_path(MNIST_TEST_DIR_PATH)
 
     accuracy_tf_native = self._Run(
         is_training=False,
@@ -276,6 +297,110 @@ class QuantizationAwareTrainingMNISTTest(test_util.TensorFlowTestCase):
     logging.info('accuracy_tf_trt: %f', accuracy_tf_trt)
     self.assertAllClose(0.9675, accuracy_tf_trt, rtol=1e-3, atol=1e-3)
 
+
+class MNISTTestV2(QuantizationAwareTrainingMNISTTest):
+
+  def _SaveModel(self, model_dir, output_dir):
+    saved_model_builder = builder.SavedModelBuilder(output_dir)
+    graph = ops.Graph()
+    with session.Session(graph=graph) as sess:
+      with graph.device('/GPU:0'):
+        x = array_ops.placeholder(
+            shape=(None, 28, 28, 1), dtype=dtypes.float32, name=INPUT_NODE_NAME)
+        self._BuildGraph(x)
+      self._LoadWeights(model_dir, sess)
+      input_tensor = graph.get_tensor_by_name(INPUT_NODE_NAME + ":0")
+      output = graph.get_tensor_by_name(OUTPUT_NODE_NAME + ":0")
+      signature_def = signature_def_utils.build_signature_def(
+            inputs={"input": saved_model_utils.build_tensor_info(input_tensor)},
+            outputs={"output": saved_model_utils.build_tensor_info(output)},
+            method_name=signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY)
+      saved_model_builder.add_meta_graph_and_variables(
+            sess, [tag_constants.SERVING],
+            signature_def_map={
+                signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY:
+                signature_def
+            })
+    saved_model_builder.save()
+
+  def _GetFunc(self, use_trt, model_dir, use_dynamic_shape):
+    """Gets the mnist function.
+
+    Args:
+      use_trt: whether use TF-TRT to convert the graph.
+      model_dir: the model directory to load the checkpoints.
+      use_dynamic_shape: whether to run the TF-TRT conversion in dynamic shape
+        mode.
+
+    Returns:
+      The mnist model function.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+      saved_model_dir = os.path.join(tmpdir, 'mnist')
+      self._SaveModel(model_dir, saved_model_dir)
+
+      if use_trt:
+        conv_params=trt_convert.TrtConversionParams(
+            precision_mode='FP16', minimum_segment_size=2,
+            max_workspace_size_bytes=1<<28, maximum_cached_engines=1)
+        converter = trt_convert.TrtGraphConverterV2(
+            input_saved_model_dir=saved_model_dir,
+            conversion_params=conv_params,
+            use_dynamic_shape=use_dynamic_shape,
+            dynamic_shape_profile_strategy='ImplicitBatchModeCompatible')
+        converter.convert()
+        func = converter._converted_func
+      else:
+        saved_model_loaded = saved_model_load(
+            saved_model_dir, tags=[tag_constants.SERVING])
+        func = saved_model_loaded.signatures[
+            signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY]
+    return func
+
+  def _Run(self, use_trt, batch_size, model_dir, use_dynamic_shape=False):
+    """Evaluates the model.
+
+    Args:
+      use_trt: if true, use TRT INT8 mode for evaluation, which will perform
+        real quantization. Otherwise use native TensorFlow which will perform
+        simulated quantization. Ignored if is_training is True.
+      batch_size: batch size.
+      model_dir: where to save or load checkpoint.
+      use_dynamic_shape: if true, then TF-TRT dynamic shape mode is enabled,
+        otherwise disabled. Ignored if use_trt is false.
+
+    Returns:
+      The Estimator evaluation result.
+    """
+    func = self._GetFunc(use_trt, model_dir, use_dynamic_shape)
+    ds = _GetDataSet(batch_size)
+
+    m = Accuracy()
+    for example in ds:
+      image, label = example[0], example[1]
+      pred = func(image)
+      m.update_state(math_ops.argmax(pred['output'], axis=1), label)
+
+    return m.result().numpy()
+
+  def testEval(self):
+    model_dir = test.test_src_dir_path(MNIST_TEST_DIR_PATH)
+
+    accuracy_tf_trt = self._Run(
+        use_trt=True,
+        batch_size=128,
+        use_dynamic_shape=False,
+        model_dir=model_dir)
+    logging.info('accuracy_tf_trt: %f', accuracy_tf_trt)
+    self.assertAllClose(0.9675, accuracy_tf_trt, rtol=1e-3, atol=1e-3)
+
+    accuracy_tf_trt = self._Run(
+        use_trt=True,
+        batch_size=128,
+        use_dynamic_shape=True,
+        model_dir=model_dir)
+    logging.info('accuracy_tf_trt: %f', accuracy_tf_trt)
+    self.assertAllClose(0.9675, accuracy_tf_trt, rtol=1e-3, atol=1e-3)
 
 if __name__ == '__main__' and is_tensorrt_enabled():
   test.main()


### PR DESCRIPTION
This PR extends the MNIST test to use the V2 converter. We create a saved model, and convert it both with and without dynamic shape mode.

Tagging @bixia1 for review. Tracker #45481