### PR TITLE
update `@pasta` to work when `@org_tensorflow` is *not* the main repo

### DIFF
--- a/third_party/pasta/BUILD.bazel
+++ b/third_party/pasta/BUILD.bazel
@@ -1,6 +1,6 @@
 # Description:
 #   AST-based python refactoring.
-load("@//third_party/pasta:build_defs.bzl", "copy_srcs")
+load("//:build_defs.bzl", "copy_srcs")
 
 licenses(["notice"])  # Apache2
 

--- a/third_party/pasta/build_defs.bzl
+++ b/third_party/pasta/build_defs.bzl
@@ -1,4 +1,4 @@
-"""Skylark makros for building pasta."""
+"""Starlark macros for building pasta."""
 
 def copy_srcs(srcs):
     """Copies srcs from 'pasta' to parent directory."""
@@ -10,3 +10,4 @@ def copy_srcs(srcs):
             cmd = "mkdir -p $$(dirname $@); cp $< $@",
         )
     return srcs
+

--- a/third_party/pasta/workspace.bzl
+++ b/third_party/pasta/workspace.bzl
@@ -13,4 +13,21 @@ def repo():
         sha256 = "c6dc1118250487d987a7b1a404425822def2e8fb2b765eeebc96887e982b6085",
         build_file = "//third_party/pasta:BUILD.bazel",
         system_build_file = "//third_party/pasta:BUILD.system",
+
+        # We want to add a bazel macro for use in the `@pasta` BUILD file.
+        #
+        # If we have this file live in this repo, referencing it from `@pasta`
+        # becomes tricky. If we do `@//` the build breaks when this repo
+        # (TensorFlow) is *not* the main repo (i.e. when TensorFlow is used as
+        # a dependency in another workspace). If we hardcode `@org_tensorflow`,
+        # the build breaks when this repo is used in another workspace under a
+        # different name.
+        #
+        # We could generate `build_defs.bzl` to reference this repo by whatever
+        # name it's registered with. Or we could just symlink `build_defs.bzl`
+        # into the `@pasta` repo and then reference it with a repo relative
+        # label; i.e. `//:build_defs.bzl`:
+        link_files = {
+            "//third_party/pasta:build_defs.bzl": "build_defs.bzl",
+        },
     )


### PR DESCRIPTION
`@pasta`'s BUILD file uses a helper macro (in `build_defs.bzl`) that lives in `@org_tensorflow` which it references using `@//` (the main repo). This breaks when `@org_tensorflow` isn't the main repo; i.e. if it's a dependency in another workspace.

This PR changes the setup for the `@pasta` repo to symlink `build_defs.bzl` into the `@pasta` repo.