### PR TITLE
[TF:TRT] Enable dynamic shape for "slice" and "strided slice" operations.

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -445,11 +445,14 @@ tf_cuda_library(
     srcs = [
         "convert/convert_graph.cc",
         "convert/convert_nodes.cc",
+        "convert/ops/slice_ops.cc",
         "convert/trt_optimization_pass.cc",
     ],
     hdrs = [
         "convert/convert_graph.h",
         "convert/convert_nodes.h",
+        "convert/ops/layer_utils.h",
+        "convert/ops/slice_ops.h",
         "convert/trt_optimization_pass.h",
     ],
     deps = [
@@ -525,7 +528,9 @@ tf_cuda_cc_test(
 tf_cuda_cc_test(
     name = "convert_nodes_test",
     size = "medium",
-    srcs = ["convert/convert_nodes_test.cc"],
+    srcs = [
+        "convert/convert_nodes_test.cc",
+    ],
     tags = [
         "no_cuda_on_cpu_tap",
         "no_windows",

--- a/tensorflow/compiler/tf2tensorrt/common/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.h
@@ -35,8 +35,40 @@ std::tuple<int, int, int> GetLoadedTensorRTVersion();
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 
+#include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/status.h"
 #include "third_party/tensorrt/NvInfer.h"
+
+// Use this macro within functions that return a Status or StatusOR<T> to check
+// boolean conditions. If the condition fails, it returns an
+// errors::Internal message with the file and line number.
+#define TRT_ENSURE(x)                                                        \
+  if (!(x)) {                                                                \
+    return errors::Internal(__FILE__, ":", __LINE__, " TRT_ENSURE failure"); \
+  }
+
+// Checks that a Status or StatusOr<T> object does not carry an error message.
+// If it does have an error, returns an errors::Internal instance
+// containing the error message, along with the file and line number. For
+// pointer-containing StatusOr<T*>, use the below TRT_ENSURE_PTR_OK macro.
+#define TRT_ENSURE_OK(x)                                   \
+  if (!x.ok()) {                                           \
+    return errors::Internal(__FILE__, ":", __LINE__,       \
+                            " TRT_ENSURE_OK failure:\n  ", \
+                            x.status().ToString());        \
+  }
+
+// Checks that a StatusOr<T* >object does not carry an error, and that the
+// contained T* is non-null. If it does have an error status, returns an
+// errors::Internal instance containing the error message, along with the file
+// and line number.
+#define TRT_ENSURE_PTR_OK(x)                            \
+  TRT_ENSURE_OK(x);                                     \
+  if (*x == nullptr) {                                  \
+    return errors::Internal(__FILE__, ":", __LINE__,    \
+                            " pointer had null value"); \
+  }
 
 namespace tensorflow {
 namespace tensorrt {

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -27,14 +27,14 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "absl/algorithm/container.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 #include "tensorflow/cc/ops/nn_ops_internal.h"
@@ -63,6 +63,8 @@ limitations under the License.
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/protobuf/config.pb.h"  // NOLINT
 #include "tensorflow/core/public/session.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/tensorrt/NvInfer.h"
 
 namespace tensorflow {
@@ -3820,7 +3822,7 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
   // Same input is used for all tests.
   const std::vector<float> ok_input = {1, 2, 3, 4, 5, 6};
 
-  Status batch_conv_status =
+  Status modified_batch_dim_status =
       (trt_mode_ == TrtTestMode::kImplicitBatch)
           ? errors::Unimplemented(
                 "TensorRT does not allow modifications to "
@@ -3828,20 +3830,20 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           : Status::OK();
   std::vector<TestParams> params = {
       // Modify batch dim, should fail in implicit batch mode.
-      TestParams{
-          /*input_dims=*/{2, 1, 1, 3},
-          /*begin=*/{0, 0, 0, 0},
-          /*end=*/{1, 1, 1, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({0, 0, 0, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 1, 2},
-          /*expected_output=*/{1, 2},
-          batch_conv_status,
-      },
+      TestParams{/*input_dims=*/{2, 1, 1, 3},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*end=*/{1, 1, 1, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({0, 0, 0, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 1, 2},
+                 /*expected_output=*/{1, 2},
+                 /*conversion_status=*/modified_batch_dim_status,
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{}},
       // Unknown batch size without end_mask.
       TestParams{
           /*input_dims=*/{2, 1, 1, 3},
@@ -3855,11 +3857,11 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*shrink_axis_mask=*/0,
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{1, 2},
-          batch_conv_status,
+          modified_batch_dim_status,
           Status::OK(),
-          {-1, 1, 1, 3},
+          /*partial_input_dims=*/{-1, 1, 1, 3},
       },
-      // Unknown batch size but using end_mask, ok.
+      // Test Case 2: Unknown batch size with end_mask.
       TestParams{
           /*input_dims=*/{2, 1, 1, 3},
           /*begin=*/{0, 0, 0, 0},
@@ -3874,24 +3876,25 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output=*/{1, 2, 4, 5},
           Status::OK(),
           Status::OK(),
-          {-1, 1, 1, 3},
+          /*partial_input_dims=*/{-1, 1, 1, 3},
       },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 2, 0},
-          /*end=*/{1, 1, 0, 3},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/0,
-          /*end_mask=*/0,
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{},
-          /*expected_output=*/{},
-          errors::InvalidArgument("\"size\" cannot be negative for "
-                                  "StridedSlice"),
-      },
-      // 2D Crop.
+      // Invalid parameters: end[2] < begin[2]
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 2, 0},
+                 /*end=*/{1, 1, 0, 3},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/0,
+                 /*end_mask=*/0,
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{},
+                 /*expected_output=*/{},
+                 errors::InvalidArgument("\"size\" cannot be negative for "
+                                         "StridedSlice"),
+                 Status::OK(),
+                 /*partial_input_dims=*/{}},
+      // Slice on the last two dimensions. All dimensions are static.
       TestParams{
           /*input_dims=*/{1, 1, 2, 3},
           /*begin=*/{0, 0, 0, 0},
@@ -3905,6 +3908,27 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{1, 2},
       },
+      // Slice on the last two dimensions. The slice is fully
+      // specified for the dynamic dimensions.
+      TestParams{
+          /*input_dims=*/{1, 1, 2, 3},
+          /*begin=*/{0, 0, 0, 0},
+          /*end=*/{0, 0, 1, 2},
+          /*strides=*/{1, 1, 1, 1},
+          /*begin_mask=*/get_mask({0, 0, 0, 0}),
+          /*end_mask=*/get_mask({1, 1, 0, 0}),
+          /*ellipsis_mask=*/0,
+          /*new_axis_mask=*/0,
+          /*shrink_axis_mask=*/0,
+          /*expected_output_dims=*/{1, 1, 1, 2},
+          /*expected_output=*/{1, 2},
+          Status::OK(),
+          Status::OK(),
+          /*partial_input_dims=*/{1, 1, -1, -1},
+      },
+      // End mask is provided on all dimensions. This should override the fact
+      // that the end value is 0. For dynamic shape, it tests
+      // that we can infer tensor size when "end mask" is provided.
       TestParams{
           /*input_dims=*/{1, 1, 2, 3},
           /*begin=*/{0, 0, 1, 1},
@@ -3917,7 +3941,12 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*shrink_axis_mask=*/0,
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{5, 6},
+          Status::OK(),
+          Status::OK(),
+          /*partial_input_dims=*/{1, 1, -1, -1},
       },
+      // End mask is provided for the batch dimension to overwrite the end value
+      // 0 for that dimension.
       TestParams{
           /*input_dims=*/{1, 1, 2, 3},
           /*begin=*/{0, 0, 1, 1},
@@ -3931,60 +3960,73 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{5, 6},
       },
-      // 2D crop with negative stride
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 1, 2},
-          /*end=*/{0, 0, 0, 0},
-          /*strides=*/{1, 1, -1, -1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({1, 1, 0, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 1, 2},
-          /*expected_output=*/{6, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 1, 1},
-          /*end=*/{0, 0, 0, 0},
-          /*strides=*/{1, 1, -1, -1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({1, 1, 1, 1}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 2},
-          /*expected_output=*/{5, 4, 2, 1},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 0},
-          /*end=*/{0, 0, 0, 0},
-          /*strides=*/{1, 1, -1, -1},
-          /*begin_mask=*/get_mask({0, 0, 1, 1}),
-          /*end_mask=*/get_mask({1, 1, 0, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 1, 2},
-          /*expected_output=*/{6, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 0},
-          /*end=*/{0, 0, 0, 0},
-          /*strides=*/{1, -1, -1, -1},
-          /*begin_mask=*/get_mask({1, 1, 1, 1}),
-          /*end_mask=*/get_mask({1, 1, 1, 1}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 3},
-          /*expected_output=*/{6, 5, 4, 3, 2, 1},
-      },
-      // 2D Crop, with transpose.
+      // Test slice on two dimensions with negative stride, without end_mask set
+      // on crop dimensions.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 1, 2},
+                 /*end=*/{0, 0, 0, 0},
+                 /*strides=*/{1, 1, -1, -1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 1, 0, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 1, 2},
+                 /*expected_output=*/{6, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, 1, -1, -1}},
+      // Test slice on two dimensions with negative stride, with end_mask set on
+      // crop dimensions. In dynamic shape mode, this tests the runtime size
+      // computation.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 1, 1},
+                 /*end=*/{0, 0, 0, 0},
+                 /*strides=*/{1, 1, -1, -1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 1, 1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 2},
+                 /*expected_output=*/{5, 4, 2, 1},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, 1, -1, -1}},
+      // Test slice on two dimensions with negative stride, with begin_mask set
+      // on the crop dimensions. In dynamic shape mode, this tests the runtime
+      // size computation.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*end=*/{0, 0, 0, 0},
+                 /*strides=*/{1, 1, -1, -1},
+                 /*begin_mask=*/get_mask({0, 0, 1, 1}),
+                 /*end_mask=*/get_mask({1, 1, 0, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 1, 2},
+                 /*expected_output=*/{6, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, 1, -1, -1}},
+      // Test the reversal of all non-batch dimensions by providing the begin
+      // masks, end masks, and -1 as strides.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*end=*/{0, 0, 0, 0},
+                 /*strides=*/{1, -1, -1, -1},
+                 /*begin_mask=*/get_mask({1, 1, 1, 1}),
+                 /*end_mask=*/get_mask({1, 1, 1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 3},
+                 /*expected_output=*/{6, 5, 4, 3, 2, 1},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, -1, -1, -1}},
+      // Slice on dimensions 1 and 2.
       TestParams{
           /*input_dims=*/{1, 2, 3, 1},
           /*begin=*/{0, 0, 0, 0},
@@ -3998,6 +4040,7 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 2, 1},
           /*expected_output=*/{1, 2},
       },
+      // Slice on dimensions 1 and 2.
       TestParams{
           /*input_dims=*/{1, 2, 3, 1},
           /*begin=*/{0, 1, 1, 0},
@@ -4011,6 +4054,7 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 2, 1},
           /*expected_output=*/{5, 6},
       },
+      // Slice on dimensions 1 and 3.
       TestParams{
           /*input_dims=*/{1, 2, 1, 3},
           /*begin=*/{0, 0, 0, 0},
@@ -4024,6 +4068,7 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{1, 2},
       },
+      // Slice on dimensions 1 and 3 with non-zero slice start.
       TestParams{
           /*input_dims=*/{1, 2, 1, 3},
           /*begin=*/{0, 1, 0, 1},
@@ -4037,7 +4082,7 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{5, 6},
       },
-      // 2D Crop, with reshape.
+      // Slice on 3D tensor.
       TestParams{
           /*input_dims=*/{1, 2, 3},
           /*begin=*/{0, 0, 0},
@@ -4051,33 +4096,38 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 2},
           /*expected_output=*/{1, 2},
       },
-      TestParams{
-          /*input_dims=*/{1, 2, 3},
-          /*begin=*/{0, 1, 1},
-          /*end=*/{0, 0, 0},
-          /*strides=*/{1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0}),
-          /*end_mask=*/get_mask({1, 1, 1}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2},
-          /*expected_output=*/{5, 6},
-      },
-      // 1D Crop.
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 0},
-          /*end=*/{0, 0, 0, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({1, 1, 1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 2},
-          /*expected_output=*/{1, 2, 4, 5},
-      },
+      // Slice on 3D tensor using end_mask. For dynamic shape, all
+      // dimensions are dynamic.
+      TestParams{/*input_dims=*/{1, 2, 3},
+                 /*begin=*/{0, 1, 1},
+                 /*end=*/{0, 0, 0},
+                 /*strides=*/{1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2},
+                 /*expected_output=*/{5, 6},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1}},
+      // Slice on 3D tensor using end_mask. For dynamic shape, all
+      // dimensions are dynamic.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*end=*/{0, 0, 0, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 1, 1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 2},
+                 /*expected_output=*/{1, 2, 4, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
       TestParams{
           /*input_dims=*/{1, 1, 2, 3},
           /*begin=*/{0, 0, 1, 0},
@@ -4091,20 +4141,21 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 1, 3},
           /*expected_output=*/{4, 5, 6},
       },
-      // 1D Crop, with transpose.
-      TestParams{
-          /*input_dims=*/{1, 2, 3, 1},
-          /*begin=*/{0, 0, 0, 0},
-          /*end=*/{0, 1, 0, 0},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({1, 0, 1, 1}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 3, 1},
-          /*expected_output=*/{1, 2, 3},
-      },
+      // 1D simple slice.
+      TestParams{/*input_dims=*/{1, 2, 3, 1},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*end=*/{0, 1, 0, 0},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 0, 1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 3, 1},
+                 /*expected_output=*/{1, 2, 3},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
       TestParams{
           /*input_dims=*/{1, 2, 3, 1},
           /*begin=*/{0, 1, 0, 0},
@@ -4118,20 +4169,21 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 3, 1},
           /*expected_output=*/{4, 5, 6},
       },
-      // 1D Crop, with reshape.
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 0},
-          /*end=*/{0, 3},
-          /*strides=*/{1, 1},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{1, 2, 3},
-      },
+      // Simple 1D slice on 2D input.
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 0},
+                 /*end=*/{0, 3},
+                 /*strides=*/{1, 1},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{1, 2, 3},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
       TestParams{
           /*input_dims=*/{1, 1, 6},
           /*begin=*/{0, 0, 2},
@@ -4199,113 +4251,125 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 2, 3},
           /*expected_output=*/{1, 2, 3, 4, 5, 6},
       },
-      // Strides
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 0},
-          /*end=*/{0, 5},
-          /*strides=*/{1, 2},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{1, 3, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 0},
-          /*end=*/{0, 6},
-          /*strides=*/{1, 2},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{1, 3, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 1},
-          /*end=*/{0, 6},
-          /*strides=*/{1, 2},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{2, 4, 6},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 2},
-          /*end=*/{0, 6},
-          /*strides=*/{1, 3},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 2},
-          /*expected_output=*/{3, 6},
-      },
-      // Negative non -1 strides
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 5},
-          /*end=*/{0, 0},
-          /*strides=*/{1, -2},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 1}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{6, 4, 2},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 5},
-          /*end=*/{0, 0},
-          /*strides=*/{1, -2},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{6, 4, 2},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 5},
-          /*end=*/{0, 1},
-          /*strides=*/{1, -3},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 2},
-          /*expected_output=*/{6, 3},
-      },
-      // ellipsis_mask
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 1},
-          /*end=*/{0, 2},
-          /*strides=*/{1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({0, 0, 0, 0}),
-          /*ellipsis_mask=*/get_mask({1, 0, 0, 0}),
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 1},
-          /*expected_output=*/{2, 5},
-      },
+      // Stride values >= 2.
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 0},
+                 /*end=*/{0, 5},
+                 /*strides=*/{1, 2},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{1, 3, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 0},
+                 /*end=*/{0, 6},
+                 /*strides=*/{1, 2},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{1, 3, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 1},
+                 /*end=*/{0, 6},
+                 /*strides=*/{1, 2},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{2, 4, 6},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 2},
+                 /*end=*/{0, 6},
+                 /*strides=*/{1, 3},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 2},
+                 /*expected_output=*/{3, 6},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      // Stride values <= -2.
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 5},
+                 /*end=*/{0, 0},
+                 /*strides=*/{1, -2},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{6, 4, 2},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 5},
+                 /*end=*/{0, 0},
+                 /*strides=*/{1, -2},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{6, 4, 2},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 5},
+                 /*end=*/{0, 1},
+                 /*strides=*/{1, -3},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 2},
+                 /*expected_output=*/{6, 3},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      // Ellipsis_mask causes leading dimensions to be ignored. Begin, end,
+      // stride, and mask values of size 2 should be interpreted as applying to
+      // the last 2 dimensions, while the ellipsis applies to the first 2 (for a
+      // 4D input tensor).
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 1},
+                 /*end=*/{0, 2},
+                 /*strides=*/{1, 1},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({0, 0}),
+                 /*ellipsis_mask=*/get_mask({1, 0, 0}),
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 1},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
+      // Ellipsis_mask on single inner dimension.
       TestParams{
           /*input_dims=*/{1, 1, 2, 3},
           /*begin=*/{0, 0, 1},
@@ -4319,106 +4383,154 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 2, 1},
           /*expected_output=*/{2, 5},
       },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 1},
-          /*end=*/{0, 1, 2, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({0, 0, 0, 0}),
-          /*ellipsis_mask=*/get_mask({1, 0, 0, 0}),
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 1},
-          /*expected_output=*/{2, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 1},
-          /*end=*/{1, 1, 2, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({0, 0, 0, 0}),
-          /*ellipsis_mask=*/get_mask({0, 1, 0, 0}),
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 1},
-          /*expected_output=*/{2, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 0, 1},
-          /*end=*/{0, 1, 1, 2, 2},
-          /*strides=*/{1, 1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({0, 0, 0, 0}),
-          /*ellipsis_mask=*/get_mask({1, 0, 0, 0}),
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 1},
-          /*expected_output=*/{2, 5},
-      },
-      // shrink_axis_mask
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 1},
-          /*end=*/{0, 0, 0, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({1, 1, 1, 0}),
-          /*end_mask=*/get_mask({1, 1, 1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/get_mask({0, 0, 0, 1}),
-          /*expected_output_dims=*/{1, 1, 2},
-          /*expected_output=*/{2, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 1},
-          /*end=*/{0, 1, 2, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({1, 0, 0, 0}),
-          /*end_mask=*/get_mask({1, 0, 0, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/get_mask({0, 1, 0, 1}),
-          /*expected_output_dims=*/{1, 2},
-          /*expected_output=*/{2, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 0},
-          /*end=*/{0, 1},
-          /*strides=*/{1, 1},
-          /*begin_mask=*/get_mask({1, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/get_mask({0, 1}),
-          /*expected_output_dims=*/{1},
-          /*expected_output=*/{1},
-      },
+      // Ellipsis_mask on single leading dimension.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 1},
+                 /*end=*/{0, 1, 2, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({0, 0, 0, 0}),
+                 /*ellipsis_mask=*/get_mask({1, 0, 0, 0}),
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 1},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
+      // Ellipsis_mask on single inner dimension overrides that dimensions'
+      // begin/end values.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 1, 0, 1},
+                 /*end=*/{1, 1, 2, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({0, 0, 0, 0}),
+                 /*ellipsis_mask=*/get_mask({0, 1, 0, 0}),
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 1},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
+      // Ellipsis mask on single leading dimension should throw out extra
+      // leading values of begin/end vectors so that only the last N-1 values of
+      // each remain.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 0, 1},
+                 /*end=*/{0, 1, 1, 2, 2},
+                 /*strides=*/{1, 1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({0, 0, 0, 0}),
+                 /*ellipsis_mask=*/get_mask({1, 0, 0, 0}),
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 1},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
+      // Shrink-axis mask set for the final dimension of final size 1 should
+      // remove that dimension from the final shape.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 1},
+                 /*end=*/{0, 0, 0, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({1, 1, 1, 0}),
+                 /*end_mask=*/get_mask({1, 1, 1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/get_mask({0, 0, 0, 1}),
+                 /*expected_output_dims=*/{1, 1, 2},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, 1, 2, -1}},
+      // Shrink-axis mask set for multiple dimensions that have a final size of
+      // 1 should remove those dimensions from the final shape.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 1},
+                 /*end=*/{0, 1, 2, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({1, 0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 0, 0, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/get_mask({0, 1, 0, 1}),
+                 /*expected_output_dims=*/{1, 2},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, 1, 2, -1}},
+      // Shrink-axis mask set for multiple sequential dimensions of final size 1 should
+      // remove those dimensions from the final shape.
+      TestParams{/*input_dims=*/{6, 1, 1},
+                 /*begin=*/{0, 0, 0},
+                 /*end=*/{0, 0, 0},
+                 /*strides=*/{1, 1, 1},
+                 /*begin_mask=*/get_mask({1, 1, 1}),
+                 /*end_mask=*/get_mask({1, 1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/get_mask({0, 1, 1}),
+                 /*expected_output_dims=*/{6},
+                 /*expected_output=*/{1, 2, 3, 4, 5, 6},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1}},
+      // The new_axis_mask parameter is not supported.
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 0, 0},
+                 /*end=*/{0, 0, 0},
+                 /*strides=*/{1, 1, 1},
+                 /*begin_mask=*/
+                 get_mask({0, 1, 1}),
+                 /*end_mask=*/get_mask({0, 1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/get_mask({1, 0, 0}),
+                 /*shrink_axis_mask=*/get_mask({0, 0, 0}),
+                 /*expected_output_dims=*/{1, 1, 6},
+                 /*expected_output=*/{1, 1, 6},
+                 /*conversion_status=*/
+                 errors::Unimplemented(
+                     "new_axis_mask is not supported for StridedSlice, at"),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, 6}},
   };
 
+  int i = 0;
   for (auto p : params) {
-    if (trt_mode_ == TrtTestMode::kDynamicShape ||
-        (trt_mode_ == TrtTestMode::kExplicitBatch &&
-         !HasStaticShape(p.partial_input_dims))) {
-      p.conversion_status = errors::Unimplemented(
-          "Strided slice op not implemented for dynamic shape input");
-    }
     Reset();
     NodeDef node_def = get_strided_slice_nodedef(
         tf_type_, p.begin_mask, p.end_mask, p.ellipsis_mask, p.new_axis_mask,
         p.shrink_axis_mask);
 
-    VLOG(2) << "Preparing test case with dims " << DebugString(p.input_dims);
-    if (p.partial_input_dims.empty()) {
-      AddTestTensor("input", p.input_dims, ok_input);
-    } else {
-      AddTestTensor("input", p.input_dims, tf_type_, ok_input,
-                    p.partial_input_dims);
+    VLOG(2) << "Preparing test case " << i++ << " with dims "
+            << DebugString(p.input_dims);
+
+    switch (trt_mode_) {
+      case TrtTestMode::kImplicitBatch: {
+        AddTestTensor("input", p.input_dims, ok_input);
+        break;
+      }
+      case TrtTestMode::kExplicitBatch: {
+        AddTestTensor("input", p.input_dims, ok_input);
+        break;
+      }
+      case TrtTestMode::kDynamicShape: {
+        if (p.partial_input_dims.size() > 0) {
+          AddTestTensor("input", p.input_dims, tf_type_, ok_input,
+                        p.partial_input_dims);
+
+        } else {
+          AddTestTensor("input", p.input_dims, tf_type_, ok_input,
+                        p.input_dims);
+        }
+        break;
+      }
     }
+
     VLOG(2) << "Adding weights begin: " << DebugString(p.begin)
             << ", end: " << DebugString(p.end)
             << ", strides: " << DebugString(p.strides);
@@ -4446,6 +4558,8 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertSlice) {
 
   struct TestParams {
     std::vector<int> input_dims;
+    std::vector<int>
+        partial_input_dims;  // Symbolic shape in dynamic shape mode.
     std::vector<int> begin;
     std::vector<int> size;
     std::vector<int> expected_output_dims;
@@ -4454,90 +4568,76 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertSlice) {
     Status runtime_status;
   };
 
-  Status conv_dynamic =
-      trt_mode_ == TrtTestMode::kDynamicShape
-          ? errors::Unimplemented(
-                "Strided slice op not implemented for dynamic shape input")
-          : Status::OK();
-  Status conv_dynamic2 =
-      trt_mode_ == TrtTestMode::kDynamicShape
-          ? errors::Unimplemented(
-                "Input dims must be defined for size = -1, at my_slice")
-          : Status::OK();
   std::vector<TestParams> params = {
-      // Begin is below bounds, should fail.
-      TestParams{
-          {1, 1, 2, 3},
-          {0, 0, -1, 0},
-          {1, 1, 2, 3},
-          {},
-          {},
-          trt_mode_ == TrtTestMode::kDynamicShape
-              ? conv_dynamic
-              : errors::InvalidArgument("\"begin\" for dimension 2 in Slice "
-                                        "is out of range, at my_slice")},
-      // Batch dimension is modified, should fail in implicit batch mode.
-      TestParams{
-          {2, 1, 1, 3},
-          {0, 0, 0, 0},
-          {1, 1, 1, 3},
-          {1, 1, 1, 3},
-          {1, 2, 3},
-          trt_mode_ == TrtTestMode::kImplicitBatch
-              ? errors::Unimplemented("TensorRT does not allow modifications"
-                                      " to the batch dimension, at my_slice")
-              : Status::OK()},
+      // Slice start points must always be >= 0.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
+                 /*begin=*/{0, 0, -1, 0},
+                 /*size=*/{1, 1, 2, 3},
+                 /*expected_output_dims=*/{},
+                 /*expected_output=*/{},
+                 /*conversion_status=*/
+                 errors::InvalidArgument("\"begin\" in Slice "
+                                         "is out of range, at my_slice")},
+      // In implicit batch mode, slicing the batch dimension is not allowed.
+      TestParams{/*input_dims=*/{2, 1, 1, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*size=*/{1, 1, 1, 3},
+                 /*expected_output_dims=*/{1, 1, 1, 3},
+                 /*expected_output=*/{1, 2, 3},
+                 /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+                     ? errors::Unimplemented(
+                           "TensorRT does not allow modifications to the batch "
+                           "dimension in implicit batch mode")
+                     : Status::OK()},
       // Dynamic batch size but using size[0] of -1, ok.
       TestParams{{1, 1, 2, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
                  {0, 0, 0, 0},
                  {-1, 1, 2, 2},
                  {1, 1, 2, 2},
                  {1, 2, 4, 5},
-                 conv_dynamic2},
-      // OK test: but converter fails in dynamic shape mode
+                 Status::OK()},
       TestParams{{1, 1, 2, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
                  {0, 0, 0, 0},
                  {-1, -1, -1, -1},
                  {1, 1, 2, 3},
                  {1, 2, 3, 4, 5, 6},
-                 conv_dynamic2},
+                 Status::OK()},
       TestParams{{1, 1, 2, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
                  {0, 0, 0, 0},
                  {1, 1, 2, 3},
                  {1, 1, 2, 3},
                  {1, 2, 3, 4, 5, 6}},
       TestParams{{1, 1, 2, 3},
-                 {0, 0, 0, 0},
-                 {1, -1, 2, 2},
-                 {1, 1, 2, 2},
-                 {1, 2, 4, 5},
-                 conv_dynamic2},
-      TestParams{{1, 6}, {0, 1}, {1, 5}, {1, 5}, {2, 3, 4, 5, 6}},
-      TestParams{{1, 6}, {0, 1}, {-1, 3}, {1, 3}, {2, 3, 4}, conv_dynamic2},
-      //
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*size=*/{1, -1, 2, 2},
+                 /*expected_output_dims=*/{1, 1, 2, 2},
+                 /*expected_output=*/{1, 2, 4, 5},
+                 Status::OK()},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*partial_input_dims=*/{-1, -1},
+                 /*being=*/{0, 1},
+                 /*size=*/{1, 5},
+                 /*expected_output_dims=*/{1, 5},
+                 /*expected_output=*/{2, 3, 4, 5, 6}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*partial_input_dims=*/{-1, -1},
+                 /*begin=*/{0, 1},
+                 /*size=*/{-1, 3},
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{2, 3, 4}, Status::OK()},
       // In dynamic shape mode we do not know the input shape during
       // conversion, therfore we cannot check out of bound access.
       TestParams{
           {1, 1, 2, 3},
-          {0, 0, 3, 0},
-          {1, 1, 2, 3},
-          {},
-          {},
-          trt_mode_ == TrtTestMode::kDynamicShape
-              ? Status::OK()
-              : errors::InvalidArgument("\"begin\" for dimension 2 in Slice "
-                                        "is out of range, at my_slice"),
-          errors::Internal("Internal: Failed to build TensorRT engine")},
-      TestParams{{1, 1, 2, 3},
-                 {0, 0, 0, 0},
-                 {1, 1, 2, -2},
-                 {},
-                 {},
-                 errors::InvalidArgument("Invalid size value at my_slice")},
-      TestParams{
-          {1, 1, 2, 3},
-          {0, 0, 0, 0},
-          {1, 1, 3, 2},
+          /*partial_input_dims=*/{-1, -1, -1, -1},
+          /*begin=*/{0, 0, 3, 0},
+          /*end=*/{1, 1, 2, 3},
           {},
           {},
           trt_mode_ == TrtTestMode::kDynamicShape
@@ -4546,12 +4646,64 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertSlice) {
                                         "2 in Slice is out of range, at "
                                         "my_slice"),
           errors::Internal("Internal: Failed to build TensorRT engine")},
+      // The slice operation should expect that the "size[i]" values are not
+      // less than -1.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*size=*/{1, 1, 2, -2},
+                 {},
+                 {},
+                 errors::InvalidArgument(
+                     "\"size\" in Slice is out of range, at my_slice")},
+      TestParams{
+          /*input_dims=*/{1, 1, 2, 3},
+          /*partial_input_dims=*/{-1, -1, -1, -1},
+          /*begin=*/{0, 0, 0, 0},
+          /*size=*/{1, 1, 3, 2},
+          /*expected_output_dims=*/{},
+          /*expected_output=*/{},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kDynamicShape
+              ? Status::OK()
+              : errors::InvalidArgument("\"begin\" + \"size\" for dimension "
+                                        "2 in Slice is out of range, at "
+                                        "my_slice"),
+          errors::Internal("Internal: Failed to build TensorRT engine")},
   };
 
+  int i = 0;
   for (auto p : params) {
     Reset();
     NodeDef node_def = get_slice_nodedef(tf_type_);
-    AddTestTensor("input", p.input_dims, {1, 2, 3, 4, 5, 6});
+
+    VLOG(2) << "Preparing test case " << i++ << " with dims "
+            << DebugString(p.input_dims);
+
+    // The input tensor always has size 6.
+    std::vector<int> input_vals = {1, 2, 3, 4, 5, 6};
+
+    switch (trt_mode_) {
+      case TrtTestMode::kImplicitBatch: {
+        AddTestTensor("input", p.input_dims, input_vals);
+        break;
+      }
+      case TrtTestMode::kExplicitBatch: {
+        AddTestTensor("input", p.input_dims, input_vals);
+        break;
+      }
+      case TrtTestMode::kDynamicShape: {
+        if (p.partial_input_dims.size() > 0) {
+          AddTestTensor("input", p.input_dims, tf_type_, input_vals,
+                        p.partial_input_dims);
+
+        } else {
+          AddTestTensor("input", p.input_dims, tf_type_, input_vals,
+                        p.input_dims);
+        }
+        break;
+      }
+    }
+
     AddTestWeights<int32>("begin", {static_cast<int>(p.begin.size())}, p.begin);
     AddTestWeights<int32>("size", {static_cast<int>(p.size.size())}, p.size);
 
@@ -6489,11 +6641,11 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertUnpack) {
 
   const std::vector<float> common_input = CreateVectorIota<float>(6);
 
-  Status run_status = trt_mode_ == TrtTestMode::kDynamicShape
-                          ? errors::Unimplemented(
-                                "Strided slice op not implemented for dynamic "
-                                "shape input")
-                          : Status::OK();
+  Status run_status =
+      trt_mode_ == TrtTestMode::kDynamicShape
+          ? errors::InvalidArgument(
+                "must have statically defined dimensions, at my_unpack")
+          : Status::OK();
 
   std::vector<UnpackTestParams> params = {
       {/*input_shape=*/{1, 1, 2, 1, 3, 1},

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h
@@ -1,0 +1,381 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_LAYER_UTILS_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_LAYER_UTILS_H_
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include <type_traits>
+
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/platform/statusor.h"
+#include "third_party/tensorrt/NvInfer.h"
+#include "third_party/tensorrt/NvInferRuntimeCommon.h"
+
+namespace tensorflow {
+namespace tensorrt {
+
+namespace convert {
+
+// Facilitates the creation of TensorRT layers inside a network. The user
+// provides a INetworkDefinition pointer during construction. They can then add
+// operations to the network through the provided functions. Each function
+// returns a struct which contains the symbolic result of the operation (ITensor
+// pointer) as well as a pointer to the last TensorRT ILayer created. Some
+// operations may create multiple layers in order to accomplish the desired
+// result (e.g. Sign).
+class TRTNetworkBuilder {
+ public:
+  static StatusOr<TRTNetworkBuilder> Create(
+      nvinfer1::INetworkDefinition* network, TrtWeightStore* weight_store) {
+    TRT_ENSURE(network);
+    TRT_ENSURE(weight_store);
+    return TRTNetworkBuilder(network, weight_store);
+  }
+
+ private:
+  TRTNetworkBuilder(nvinfer1::INetworkDefinition* network,
+                    TrtWeightStore* weight_store)
+      : network_(network), weight_store_(weight_store) {}
+
+ public:
+  // Adds an Add operation to the network.
+  StatusOr<nvinfer1::IElementWiseLayer*> Add(nvinfer1::ITensor* lhs,
+                                             nvinfer1::ITensor* rhs) noexcept {
+    TRT_ENSURE(lhs);
+    TRT_ENSURE(rhs);
+    nvinfer1::IElementWiseLayer* layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kSUM);
+    TRT_ENSURE(layer);
+    return layer;
+  };
+
+  // Adds an elementwise min(lhs, rhs) operation to the network. The output has
+  // the same data type as the input.
+  StatusOr<nvinfer1::IElementWiseLayer*> Min(nvinfer1::ITensor* lhs,
+                                             nvinfer1::ITensor* rhs) noexcept {
+    TRT_ENSURE(lhs);
+    TRT_ENSURE(rhs);
+    nvinfer1::IElementWiseLayer* layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kMIN);
+    TRT_ENSURE(layer);
+    return layer;
+  };
+
+  // Adds an elementwise max(lhs, rhs) operation to the network. The output has
+  // the same datatype as the input.
+  StatusOr<nvinfer1::IElementWiseLayer*> Max(nvinfer1::ITensor* lhs,
+                                             nvinfer1::ITensor* rhs) noexcept {
+    TRT_ENSURE(lhs);
+    TRT_ENSURE(rhs);
+    nvinfer1::IElementWiseLayer* layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kMAX);
+    TRT_ENSURE(layer);
+    return layer;
+  };
+
+  // Adds an absolute value operation to the network. Note that this unary
+  // operation will do an implict float conversion. For int32 tensors, use
+  // "AbsInt".
+  StatusOr<nvinfer1::IUnaryLayer*> AbsFloat(nvinfer1::ITensor* input) noexcept {
+    TRT_ENSURE(input);
+    TRT_ENSURE(input->getType() != nvinfer1::DataType::kFLOAT &&
+               input->getType() != nvinfer1::DataType::kHALF);
+    nvinfer1::IUnaryLayer* layer =
+        network_->addUnary(*input, nvinfer1::UnaryOperation::kABS);
+    TRT_ENSURE(layer);
+    return layer;
+  }
+
+  // Performs Abs without implict float conversion. The input should be of type
+  // kInt32. For float datatypes, use "Abs".
+  StatusOr<nvinfer1::IElementWiseLayer*> AbsInt(
+      nvinfer1::ITensor* input) noexcept {
+    TRT_ENSURE(input);
+    TRT_ENSURE(input->getType() == nvinfer1::DataType::kINT32);
+    StatusOr<nvinfer1::IElementWiseLayer*> sign = this->SignInt(input);
+    return this->Mul(input, (*sign)->getOutput(0));
+  }
+
+  // Returns elementwise sign(x) for int32 input tensors where sign(x) is
+  // defined as 1 where x > 0, -1 where x < 0 and 0 where x == 0.
+  StatusOr<nvinfer1::IElementWiseLayer*> SignInt(
+      nvinfer1::ITensor* input) noexcept {
+    TRT_ENSURE(input);
+
+    // Create constants +1 and -1.
+    StatusOr<nvinfer1::IConstantLayer*> one =
+        this->Constant<int32>(1, input->getDimensions().nbDims);
+    TRT_ENSURE_PTR_OK(one);
+
+    StatusOr<nvinfer1::IConstantLayer*> neg_one =
+        this->Constant<int32>(-1, input->getDimensions().nbDims);
+    TRT_ENSURE_PTR_OK(neg_one);
+
+    // Turn all negaitve elements into -1, positive and zero elements
+    // unaffected.
+    StatusOr<nvinfer1::IElementWiseLayer*> max =
+        this->Max(input, (*neg_one)->getOutput(0));
+    TRT_ENSURE_PTR_OK(max);
+
+    // Turn all positive elements into +1, negative and zero elements
+    // unaffected.
+    StatusOr<nvinfer1::IElementWiseLayer*> min =
+        this->Min((*max)->getOutput(0), (*one)->getOutput(0));
+    TRT_ENSURE_PTR_OK(min);
+    return min;
+  }
+
+  // Adds a Sub operation to the network.
+  StatusOr<nvinfer1::IElementWiseLayer*> Sub(nvinfer1::ITensor* lhs,
+                                             nvinfer1::ITensor* rhs) noexcept {
+    TRT_ENSURE(lhs);
+    TRT_ENSURE(rhs);
+    nvinfer1::IElementWiseLayer* layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kSUB);
+    TRT_ENSURE(layer);
+    return layer;
+  }
+
+  // Adds an Greater operation to the network.
+  StatusOr<nvinfer1::IElementWiseLayer*> Greater(
+      nvinfer1::ITensor* lhs, nvinfer1::ITensor* rhs) noexcept {
+    TRT_ENSURE(lhs);
+    TRT_ENSURE(rhs);
+    nvinfer1::IElementWiseLayer* layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kGREATER);
+    TRT_ENSURE(layer);
+    return layer;
+  }
+
+  // Adds an Equal operation to the network.
+  StatusOr<nvinfer1::IElementWiseLayer*> Equal(
+      nvinfer1::ITensor* lhs, nvinfer1::ITensor* rhs) noexcept {
+    TRT_ENSURE(lhs);
+    TRT_ENSURE(rhs);
+    nvinfer1::IElementWiseLayer* layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kEQUAL);
+    TRT_ENSURE(layer);
+    return layer;
+  }
+
+  // Adds a FloorDiv operation to the network.
+  StatusOr<nvinfer1::IElementWiseLayer*> FloorDiv(
+      nvinfer1::ITensor* lhs, nvinfer1::ITensor* rhs) noexcept {
+    TRT_ENSURE(lhs);
+    TRT_ENSURE(rhs);
+    nvinfer1::IElementWiseLayer* layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kFLOOR_DIV);
+    TRT_ENSURE(layer);
+    return layer;
+  }
+
+  // Returns the equivalent of ceil_divide(abs(x)/abs(y))) operation. The inputs
+  // "lhs" and "rhs" should be int32 tensors.
+  StatusOr<nvinfer1::IElementWiseLayer*> AbsCeilDivInt(
+      nvinfer1::ITensor* lhs, nvinfer1::ITensor* rhs) noexcept {
+    TRT_ENSURE(lhs);
+    TRT_ENSURE(rhs);
+    TRT_ENSURE(lhs->getType() == nvinfer1::DataType::kINT32);
+    TRT_ENSURE(rhs->getType() == nvinfer1::DataType::kINT32);
+
+    StatusOr<nvinfer1::IElementWiseLayer*> rhs_abs = this->AbsInt(rhs);
+    TRT_ENSURE_PTR_OK(rhs_abs);
+    StatusOr<nvinfer1::IElementWiseLayer*> lhs_abs = this->AbsInt(lhs);
+    TRT_ENSURE_PTR_OK(lhs_abs);
+    StatusOr<nvinfer1::IElementWiseLayer*> add1 =
+        this->Add((*lhs_abs)->getOutput(0), (*rhs_abs)->getOutput(0));
+    TRT_ENSURE_PTR_OK(add1);
+    StatusOr<nvinfer1::IConstantLayer*> one_const =
+        this->Constant<int32>(1, rhs->getDimensions().nbDims);
+    TRT_ENSURE_PTR_OK(one_const);
+    StatusOr<nvinfer1::IElementWiseLayer*> numerator =
+        this->Sub((*add1)->getOutput(0), (*one_const)->getOutput(0));
+    TRT_ENSURE_PTR_OK(numerator);
+    return FloorDiv((*numerator)->getOutput(0), (*rhs_abs)->getOutput(0));
+  }
+
+  // Adds an elementwise multiplication operation to the network.
+  StatusOr<nvinfer1::IElementWiseLayer*> Mul(nvinfer1::ITensor* lhs,
+                                             nvinfer1::ITensor* rhs) noexcept {
+    TRT_ENSURE(lhs);
+    TRT_ENSURE(rhs);
+    nvinfer1::IElementWiseLayer* layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kPROD);
+    TRT_ENSURE(layer);
+    return layer;
+  }
+
+  // Adds a Constant layer whose output is a TensorRT shape tensor. The shape
+  // tensor's size and values correspond to dim's nbDims and d[], respectively.
+  StatusOr<nvinfer1::IConstantLayer*> ConstantShape(
+      const nvinfer1::Dims& shape_data) noexcept {
+    TRT_ENSURE(shape_data.nbDims > 0);
+    nvinfer1::Dims shape_dims;
+    shape_dims.nbDims = 1;
+    shape_dims.d[0] = shape_data.nbDims;
+    TRT_ShapedWeights const_weights =
+        weight_store_->GetTempWeights(nvinfer1::DataType::kINT32, shape_dims);
+    int32* values = const_weights.GetPointer<int32>();
+    for (int i = 0; i < shape_data.nbDims; i++) {
+      values[i] = static_cast<int32>(shape_data.d[i]);
+    }
+    nvinfer1::IConstantLayer* const_layer = network_->addConstant(
+        const_weights.shape_, const_weights.GetTrtWeights());
+    TRT_ENSURE(const_layer);
+    nvinfer1::ITensor* output = const_layer->getOutput(0);
+    TRT_ENSURE(output);
+    TRT_ENSURE(output->getType() == nvinfer1::DataType::kINT32);
+    TRT_ENSURE(const_layer);
+    return const_layer;
+  }
+
+  // Adds a Constant layer whose output is a TensorRT shape tensor. The shape
+  // tensor's size and values correspond to dim's nbDims and d[], respectively.
+  StatusOr<nvinfer1::IConstantLayer*> Constant(
+      const std::vector<int>& data) noexcept {
+    nvinfer1::Dims shape_dims;
+    shape_dims.nbDims = 1;
+    shape_dims.d[0] = data.size();
+    TRT_ShapedWeights const_weights =
+        weight_store_->GetTempWeights(nvinfer1::DataType::kINT32, shape_dims);
+    int32* values = const_weights.GetPointer<int32>();
+    for (int i = 0; i < data.size(); i++) {
+      values[i] = static_cast<int32>(data[i]);
+    }
+    nvinfer1::IConstantLayer* const_layer = network_->addConstant(
+        const_weights.shape_, const_weights.GetTrtWeights());
+    TRT_ENSURE(const_layer);
+    nvinfer1::ITensor* output = const_layer->getOutput(0);
+    TRT_ENSURE(output);
+    TRT_ENSURE(output->getType() == nvinfer1::DataType::kINT32);
+    TRT_ENSURE(const_layer);
+    return const_layer;
+  }
+
+  // Adds a Constant layer that produces a tensor with a single value "scalar".
+  // The tensor has "nb_dims" dimensions and each dimension has only one
+  // element. The data type of the tensor is determined by the data type of
+  // "scalar".
+  template <typename T,
+            typename std::enable_if<std::is_pod<T>::value>::type* = nullptr>
+  StatusOr<nvinfer1::IConstantLayer*> Constant(const T scalar,
+                                               const int nb_dims) noexcept {
+    TRT_ENSURE(nb_dims <= nvinfer1::Dims::MAX_DIMS);
+    auto data_type = nvinfer1::DataType::kINT32;
+    if (std::is_floating_point<T>::value) {
+      data_type = nvinfer1::DataType::kFLOAT;
+    }
+    nvinfer1::Dims zero_shape;
+    zero_shape.nbDims = nb_dims;
+    std::fill_n(zero_shape.d, nb_dims, 1);
+    TRT_ShapedWeights const_weights =
+        weight_store_->GetTempWeights(data_type, zero_shape);
+    const_weights.GetPointer<T>()[0] = scalar;
+    nvinfer1::IConstantLayer* const_layer =
+        network_->addConstant(zero_shape, const_weights.GetTrtWeights());
+    TRT_ENSURE(const_layer);
+    return const_layer;
+  };
+
+  // Adds a TensorRT Slice operation to the network.
+  StatusOr<nvinfer1::ISliceLayer*> Slice(
+      nvinfer1::ITensor* input, const nvinfer1::Dims& begin,
+      const nvinfer1::Dims& size, const nvinfer1::Dims& stride) noexcept {
+    nvinfer1::ISliceLayer* layer =
+        network_->addSlice(*input, begin, size, stride);
+    TRT_ENSURE(layer);
+    return layer;
+  }
+
+  // Adds a TensorRT Shape operation, which determines the runtime shape of the
+  // input tensor, to the network.
+  StatusOr<nvinfer1::IShapeLayer*> Shape(nvinfer1::ITensor* input) {
+    TRT_ENSURE(input);
+    nvinfer1::IShapeLayer* layer = network_->addShape(*input);
+    TRT_ENSURE(layer);
+    return layer;
+  }
+
+  // Creates a Gather operation on the shape of the input tensor. The output of
+  // the gather operation is a 1D shape tensor where output[i] = (!sub_one ?
+  // input_shape[i] : input_shape[i] -1) if i is in "indices", otherwise zero.
+  StatusOr<nvinfer1::IGatherLayer*> GetPartialShapeOf(
+      nvinfer1::ITensor* input, absl::InlinedVector<int64, 4> indices,
+      bool sub_one = false) {
+    TRT_ENSURE(input);
+    TRT_ENSURE(indices.size() <= nvinfer1::Dims::MAX_DIMS);
+
+    // Get the runtime shape of input;
+    StatusOr<nvinfer1::IShapeLayer*> shape_layer = this->Shape(input);
+    TRT_ENSURE_PTR_OK(shape_layer);
+    nvinfer1::ITensor* runtime_shape = (*shape_layer)->getOutput(0);
+
+    if (sub_one) {
+      StatusOr<nvinfer1::IConstantLayer*> ones = this->Constant<int32>(1, 1);
+      TRT_ENSURE_PTR_OK(ones);
+      StatusOr<nvinfer1::IElementWiseLayer*> sub =
+          this->Sub(runtime_shape, (*ones)->getOutput(0));
+      TRT_ENSURE_PTR_OK(sub);
+      runtime_shape = (*sub)->getOutput(0);
+    }
+
+    // Create a constant tensor containing the gather indices.
+    // For any dim not in "indices", we mark it size to gather a zero.
+    const int input_nb_dims = input->getDimensions().nbDims;
+    std::vector<int> indices_all(input_nb_dims, input_nb_dims);
+    for (auto idx : indices) {
+      TRT_ENSURE(idx < input_nb_dims);
+      indices_all[idx] = idx;
+    }
+
+    StatusOr<nvinfer1::IConstantLayer*> indices_result =
+        this->Constant(indices_all);
+    TRT_ENSURE_PTR_OK(indices_result);
+    nvinfer1::ITensor* gather_indices = (*indices_result)->getOutput(0);
+    TRT_ENSURE(gather_indices->getDimensions().nbDims == 1);
+    TRT_ENSURE(gather_indices->getType() == nvinfer1::DataType::kINT32);
+
+    // Append a zero to the shape tensor.
+    StatusOr<nvinfer1::IConstantLayer*> zero_result =
+        this->Constant(std::vector<int>{0});
+    TRT_ENSURE_PTR_OK(zero_result);
+    std::array<nvinfer1::ITensor*, 2> cat_inputs = {
+        runtime_shape, (*zero_result)->getOutput(0)};
+    nvinfer1::IConcatenationLayer* cat_layer =
+        network_->addConcatenation(cat_inputs.data(), cat_inputs.size());
+    TRT_ENSURE(cat_layer);
+    nvinfer1::ITensor* gather_input = cat_layer->getOutput(0);
+    TRT_ENSURE(gather_input);
+
+    // Finally, gather the indices from the input.
+    nvinfer1::IGatherLayer* gather =
+        network_->addGather(*gather_input, *gather_indices, 0);
+    TRT_ENSURE(gather);
+    return gather;
+  };
+
+ private:
+  nvinfer1::INetworkDefinition* const network_;
+  TrtWeightStore* const weight_store_;
+};
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_LAYER_UTILS_H_

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.cc
@@ -1,0 +1,241 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.h"
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include <bitset>
+#include <vector>
+
+#include "absl/container/inlined_vector.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
+#include "absl/types/span.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_tensor_proxy.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/util/strided_slice_op.h"
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+// Adds a set of operations to the network which set the parameters for the
+// given "slice_layer" in order to handle dynamic input shape.
+Status HandleDynamicStridedSliceInput(
+    TRTNetworkBuilder* builder, nvinfer1::ISliceLayer* slice_layer,
+    const StridedSliceShapeSpec& strided_slice_spec,
+    const absl::InlinedVector<int64, 4>& dynamic_input_size_indices,
+    nvinfer1::Dims begin_dims, nvinfer1::Dims stride_dims,
+    nvinfer1::Dims end_dims);
+
+Status ConvertStridedSliceHelper(
+    OpConverterParams* params, const TRT_TensorOrWeights& input,
+    const PartialTensorShape& input_dims, const SliceDims& begin,
+    const SliceDims& stride, const SliceDims& end,
+    absl::optional<nvinfer1::Dims> final_shape, absl::optional<int> op_instance,
+    absl::optional<StridedSliceShapeSpec> strided_slice_spec) {
+  const auto& node_def = params->node_def;
+
+  nvinfer1::Dims begin_dims, stride_dims, end_dims;
+  TF_RETURN_IF_ERROR(
+      ContainerToTrtDims(begin, &begin_dims, params->use_implicit_batch));
+  TF_RETURN_IF_ERROR(
+      ContainerToTrtDims(stride, &stride_dims, params->use_implicit_batch));
+  TF_RETURN_IF_ERROR(
+      ContainerToTrtDims(end, &end_dims, params->use_implicit_batch));
+
+  // For each dimension, gather information about static vs dynamic dimension
+  // and slice size.
+  nvinfer1::Dims size_dims = begin_dims;
+  absl::InlinedVector<int64, 4> static_input_size_indices;
+  absl::InlinedVector<int64, 4> dynamic_input_size_indices;
+  for (int i = 0; i < begin_dims.nbDims; i++) {
+    size_dims.d[i] = (std::abs(end_dims.d[i] - begin_dims.d[i]) +
+                      std::abs(stride_dims.d[i]) - 1) /
+                     std::abs(stride_dims.d[i]);
+
+    if (input_dims.dim_size(i) < 0) {
+      // end_dims and begin_dims do not have valid information yet.
+      dynamic_input_size_indices.push_back(i);
+    } else {
+      static_input_size_indices.push_back(i);
+      if (end_dims.d[i] < begin_dims.d[i] && stride_dims.d[i] > 0) {
+        return errors::InvalidArgument(
+            "\"size\" cannot be negative for StridedSlice");
+      }
+    }
+  }
+
+  if (!dynamic_input_size_indices.empty() && params->use_implicit_batch) {
+    return errors::InvalidArgument(
+        "In implicit batch mode, dynamic input size is not supported.");
+  }
+
+  if (params->validation_only) return Status::OK();
+
+  StatusOr<TRTNetworkBuilder> builder = TRTNetworkBuilder::Create(params->converter->network(), params->weight_store);
+  TRT_ENSURE_OK(builder);  
+
+  VLOG(2) << "strided slice helper:"
+          << " begin:" << DebugString(begin_dims)
+          << "\n stride: " << DebugString(stride_dims)
+          << "\n end: " << DebugString(end_dims)
+          << "\n size: " << DebugString(size_dims)
+          << "\n Dynamic indices: " << DebugString(dynamic_input_size_indices)
+          << "\n Static indices: " << DebugString(static_input_size_indices);
+  // Create the slice operation. For dynamic dims, the inputs of the operations
+  // may be reassigned later.
+  StatusOr<nvinfer1::ISliceLayer*> slice = builder->Slice(input.tensor()->trt_tensor(), begin_dims,
+                             size_dims, stride_dims);
+  TRT_ENSURE_PTR_OK(slice);
+
+  // Handle dynamic input shapes.
+  if (!dynamic_input_size_indices.empty()) {
+    TRT_ENSURE(strided_slice_spec != absl::nullopt);
+    TF_RETURN_IF_ERROR(HandleDynamicStridedSliceInput(
+        &*builder, *slice, *strided_slice_spec, dynamic_input_size_indices,
+        begin_dims, stride_dims, end_dims));
+  }
+
+  params->converter->SetLayerName(*slice, params->node_def, "slice",
+                                  op_instance);
+  ITensorProxyPtr tensor = (*slice)->getOutput(0);
+
+  // Reshape for shrink_axis.
+  if (final_shape) {
+    TF_RETURN_IF_ERROR(PrepareTensorForShape(
+        params->converter, TRT_TensorOrWeights(tensor), *final_shape,
+        /*validation_only=*/false, &tensor, node_def, op_instance));
+  }
+  params->outputs->push_back(TRT_TensorOrWeights(tensor));
+  return Status::OK();
+}
+
+Status HandleDynamicStridedSliceInput(
+    TRTNetworkBuilder* builder, nvinfer1::ISliceLayer* slice_layer,
+    const StridedSliceShapeSpec& strided_slice_spec,
+    const absl::InlinedVector<int64, 4>& dynamic_input_size_indices,
+    nvinfer1::Dims begin_dims, nvinfer1::Dims stride_dims,
+    nvinfer1::Dims end_dims) {
+  TRT_ENSURE(builder);
+  TRT_ENSURE(slice_layer);
+
+  nvinfer1::ITensor* input_tensor = slice_layer->getInput(0);
+  TRT_ENSURE(input_tensor);
+
+  // For each dynamic input dimension of the input, do some preprocessing based
+  // on whether this dimension is set in "begin_mask" or "end_mask" and the sign
+  // of the dimension's stride value.
+  // When stride is negative:
+  //   - If "begin_mask[dynamic_idx]" is set, then we need to adjust the slice
+  //     start of dimension[i] to the dynamic size.
+  //   - If "end_mask[dynamic_idx]" is set, it suffices to set
+  //     end_dims[dynamic_idx] to -1.
+  // When stride is positive:
+  //   - If "begin_mask[dynamic_idx]" is set, it suffices to set
+  //     begin_dims[dynamic_idx] to zero.
+  //   - If "end_mask[dynamic_idx]" is set, we need to adjust slice end to the
+  //     dynamic size of dimension "dynamic_idx".
+  absl::InlinedVector<int64, 4> dynamic_begin_indices;
+  absl::InlinedVector<int64, 4> dynamic_end_indices;
+  const auto begin_mask = std::bitset<32>(strided_slice_spec.begin_dense_mask);
+  const auto end_mask = std::bitset<32>(strided_slice_spec.end_dense_mask);
+  for (int i = 0; i < dynamic_input_size_indices.size(); i++) {
+    auto dynamic_idx = dynamic_input_size_indices[i];
+    if (begin_mask[dynamic_idx]) {
+      begin_dims.d[dynamic_idx] = 0;
+      if (stride_dims.d[dynamic_idx] < 0) {
+        dynamic_begin_indices.push_back(dynamic_idx);
+      }
+    }
+    if (end_mask[dynamic_idx]) {
+      end_dims.d[dynamic_idx] = stride_dims.d[dynamic_idx] > 0 ? 0 : -1;
+      if (stride_dims.d[dynamic_idx] > 0) {
+        dynamic_end_indices.push_back(dynamic_idx);
+      }
+    }
+  }
+
+  VLOG(2) << " Dynamic begin indices: " << DebugString(dynamic_begin_indices)
+          << " Dynamic end indices: " << DebugString(dynamic_end_indices);
+
+  // Create ITensors for each of the begin/stride/end constants.
+  StatusOr<nvinfer1::IConstantLayer*> begin_const = builder->Constant(
+      std::vector<int>(begin_dims.d, begin_dims.d + begin_dims.nbDims));
+  TRT_ENSURE_PTR_OK(begin_const);
+  nvinfer1::ITensor* begin_tensor = (*begin_const)->getOutput(0);
+  StatusOr<nvinfer1::IConstantLayer*> stride_const = builder->Constant(
+      std::vector<int>(stride_dims.d, stride_dims.d + stride_dims.nbDims));
+  TRT_ENSURE_PTR_OK(stride_const);
+  StatusOr<nvinfer1::IConstantLayer*> end_const = builder->Constant(
+      std::vector<int>(end_dims.d, end_dims.d + end_dims.nbDims));
+  TRT_ENSURE_PTR_OK(end_const);
+  nvinfer1::ITensor* end_tensor = (*end_const)->getOutput(0);
+
+  // Make corrections based on the begin_mask/end_mask values.
+  if (dynamic_end_indices.size() > 0) {
+    StatusOr<nvinfer1::IGatherLayer*> dynamic_end_masked_tensor =
+        builder->GetPartialShapeOf(input_tensor, dynamic_end_indices,
+                                   /*sub_one=*/false);
+    TRT_ENSURE_PTR_OK(dynamic_end_masked_tensor);
+    StatusOr<nvinfer1::IElementWiseLayer*> end_corrected =
+        builder->Add((*dynamic_end_masked_tensor)->getOutput(0), end_tensor);
+    TRT_ENSURE_PTR_OK(end_corrected);
+    end_tensor = (*end_corrected)->getOutput(0);
+  }
+  if (dynamic_begin_indices.size() > 0) {
+    StatusOr<nvinfer1::IGatherLayer*> dynamic_begin_masked_tensor =
+        builder->GetPartialShapeOf(input_tensor, dynamic_begin_indices,
+                                   /*sub_one=*/true);
+    TRT_ENSURE_PTR_OK(dynamic_begin_masked_tensor);
+
+    // Add back the original "begin" values for static dimensions.
+    StatusOr<nvinfer1::IElementWiseLayer*> begin_corrected = builder->Add(
+        (*dynamic_begin_masked_tensor)->getOutput(0), begin_tensor);
+    TRT_ENSURE_PTR_OK(begin_corrected);
+    begin_tensor = (*begin_corrected)->getOutput(0);
+  }
+
+  // Calculate the final size of the slice dynamicaly.
+  nvinfer1::ITensor* size_tensor;
+  {
+    StatusOr<nvinfer1::IElementWiseLayer*> num =
+        builder->Sub(end_tensor, begin_tensor);
+    TRT_ENSURE_PTR_OK(num);
+    StatusOr<nvinfer1::IElementWiseLayer*> ceil_div = builder->AbsCeilDivInt(
+        (*num)->getOutput(0), (*stride_const)->getOutput(0));
+    TRT_ENSURE_PTR_OK(ceil_div);
+    size_tensor = (*ceil_div)->getOutput(0);
+  }
+
+  slice_layer->setInput(1, *begin_tensor);
+  slice_layer->setInput(2, *size_tensor);
+  slice_layer->setInput(3, *(*stride_const)->getOutput(0));
+
+  return Status::OK();
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.h
@@ -1,0 +1,70 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_SLICE_OPS_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_SLICE_OPS_H_
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/util/strided_slice_op.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+using SliceDims = absl::InlinedVector<int64, 4>;
+
+// Creates a strided slice operation using the given information. This function
+// expects that the begin, stride, and end vectors have already been validated.
+// This function converts the [begin:stride:end] specification to the TensorRT
+// [begin:stride:size] ISliceLayer specification. The following algorithm is
+// used to perform this conversion: 1) The given (input_dims,
+// [begin:stride:end]) specification is dividied into
+//  "static dimensions" and "dynamic dimensions". "Dynamic dimensions"
+//  includes all dimensions of the slice where input_dims[i] == -1.
+// 2a) If there are no dynamic dimensions, then the "begin", "stride", and
+//  "size" variables are passed to the ISLiceLayer creation as build-time
+//  constants in the form of nvinfer1::Dims objects.
+// 2b) If there are any dynamic dimensions, then the "begin", "stride", and
+//  "size" variables are treated as runtime dynamic shape Tensors in the
+//  TensorRT graph. In this case, we must calculate "size" at runtime for all
+//  dynamic dimensions, while static dimensions use the constant values.
+//
+// Note that when any dynamic indices are present (2b), the "strided_slice_spec"
+// must be specified. This structure can be obtained through the
+// "tensorflow::ValidateStridedSliceOp" function, or it can be constructed
+// directly. When the ValidateStridedSliceOp helper function is used, it will
+// also return the "begin", "stride", and "end" vectors. When all dimensions are
+// static (2a), the "strided_slice_spec" variable is not required.
+//
+// If the "final_shape" variable is specified, then a reshape operation will be
+// added to the graph to achieve this shape. The shape must be fully specified.
+//
+// "op_instance" is only required if the caller needs to pass this variable
+// through to the Converter functions optionally accept it (SetLayerName,
+// PrepareTensorForShape).
+Status ConvertStridedSliceHelper(
+    OpConverterParams* params, const TRT_TensorOrWeights& input,
+    const PartialTensorShape& input_dims, const SliceDims& begin,
+    const SliceDims& stride, const SliceDims& end,
+    absl::optional<nvinfer1::Dims> final_shape = absl::nullopt,
+    absl::optional<int> op_instance = absl::nullopt,
+    absl::optional<StridedSliceShapeSpec> strided_slice_spec = absl::nullopt);
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_SLICE_OPS_H_

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
 #include "absl/strings/ascii.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status.h"
@@ -53,8 +55,6 @@ Status TrtPrecisionModeFromName(const string& name, TrtPrecisionMode* mode) {
   }
   return Status::OK();
 }
-
-#if GOOGLE_CUDA && GOOGLE_TENSORRT
 
 string DebugString(const nvinfer1::Dims& dims) {
   string out = StrCat("nvinfer1::Dims(nbDims=", dims.nbDims, ", d=");
@@ -271,8 +271,6 @@ Status ProfileStrategyFromName(const string& name, ProfileStrategy* strategy) {
   return Status::OK();
 }
 
-#endif
-
 absl::string_view GetDeviceName(const Node* node) {
   if (node->has_assigned_device_name()) {
     return node->assigned_device_name();
@@ -314,3 +312,5 @@ absl::optional<DeviceNameUtils::ParsedName> MergeIfCompatible(
 
 }  // namespace tensorrt
 }  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -16,10 +16,13 @@ limitations under the License.
 #ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_UTILS_H_
 #define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_UTILS_H_
 
+#include <algorithm>
+#include <iterator>
 #include <memory>
 #include <vector>
 
 #include "absl/algorithm/container.h"
+#include "absl/types/optional.h"
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_tensor_proxy.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -31,7 +34,6 @@ limitations under the License.
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 #include "third_party/tensorrt/NvInfer.h"
-#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
 
 namespace tensorflow {
 namespace tensorrt {
@@ -68,8 +70,6 @@ struct VectorTensorShapeHasher {
   }
 };
 
-#if GOOGLE_CUDA && GOOGLE_TENSORRT
-
 using absl::StrAppend;
 using absl::StrCat;
 
@@ -104,6 +104,11 @@ string DebugString(const nvinfer1::ITensor& tensor);
 string DebugString(const std::vector<nvinfer1::Dims>& dimvec);
 string DebugString(const std::vector<TensorShape>& shapes);
 string DebugString(const std::vector<PartialTensorShape>& shapes);
+
+template <size_t N>
+string DebugString(const absl::InlinedVector<int64, N>& data) {
+  return absl::StrCat("[", absl::StrJoin(data, ","), "]");
+}
 
 inline bool HasStaticShape(const nvinfer1::Dims& dims) {
   if (dims.nbDims < 0) return false;
@@ -165,6 +170,19 @@ Status TensorShapeToTrtDims(const TensorShapeType& shape, bool ignore_first_dim,
 Status GetNetworkInputShapes(const nvinfer1::INetworkDefinition* network,
                              std::vector<PartialTensorShape>* input_shapes);
 
+// Creates PartialTensorShape from nvinfer1::Dims. The "batch_dimension", when
+// provided, is prepended to the shape.
+inline PartialTensorShape TrtDimsToPartialTensorShape(
+    const nvinfer1::Dims& dims,
+    absl::optional<int64> batch_dimension = absl::nullopt) {
+  absl::InlinedVector<int64, 4> dims_vec;
+  if (batch_dimension) {
+    dims_vec.insert(dims_vec.begin(), std::max(int64(-1), *batch_dimension));
+  }
+  std::copy(dims.d, dims.d+dims.nbDims, std::back_inserter(dims_vec));
+  return PartialTensorShape(dims_vec);
+}
+
 Status TrtDimsToTensorShape(const std::vector<int>& trt_dims,
                             TensorShape* shape,
                             absl::optional<int> batch_size = absl::nullopt);
@@ -224,9 +242,8 @@ enum class ProfileStrategy {
 string ProfileStrategyToName(const ProfileStrategy strategy);
 Status ProfileStrategyFromName(const string& name, ProfileStrategy* strategy);
 
-#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
-
 }  // namespace tensorrt
 }  // namespace tensorflow
 
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
 #endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_UTILS_H_


### PR DESCRIPTION
Enables dynamic shape support during conversion of Tensorflow "slice" and "strided slice" operations to TensorRT ISliceLayer.

Moves existing `StridedSliceHelper` function to dedicated `ops/slice_ops.[h|cc]` file and refactors it extensively to support dynamic shape requirements.
To support the creation of ancillary graphs in the TensorRT network, a helper class TRTNetworkBuilder is added to quickly create familiar operations  (e.g. Nonzero, Sign, ZerosLike) via composition of those layers exposed by TensorRT.
Converter functions which utilize StridedSliceHlper (ConvertStridedSlice, ConvertSlice, ConvertSplit) are updated to use the new helper and gain dynamic shape support.
Tests for ConvertStridedSlice are updated to include better documentation and additional tests for dynamic shape. A negative test for new_axis_mask is added.
