### PR TITLE
[tflite] add same scale constraint for mirror pad

### DIFF
--- a/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
+++ b/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
@@ -3589,6 +3589,7 @@ def TFL_CastOp : TFL_Op<"cast", [
 // LINT.ThenChange(//tensorflow/compiler/mlir/lite/transforms/while_loop_outline.cc)
 
 def TFL_MirrorPadOp: TFL_Op<"mirror_pad", [
+                     SameOperandsAndResultsScale,
                      NoSideEffect, TFL_OperandHasRank<1, 2>]> {
   let summary = "MirrorPad Operator. Pads a tensor with mirrored values.";
 


### PR DESCRIPTION
add `SameOperandsAndResultsScale` to MirrorPad so that when the new MLIR quantizer is used for post-training quantization, all
quantized mirror_pad will have the same quantization scaled for inputs and outputs (as what the old non-MLIR one does).

cf. the constrain in old [quantizer](https://github.com/tensorflow/tensorflow/blob/r2.6/tensorflow/lite/tools/optimize/operator_property.cc#L1020-L1026)