### PR TITLE
Fix crash with tf.image.resize if size is large

### DIFF
--- a/tensorflow/core/util/image_resizer_state.h
+++ b/tensorflow/core/util/image_resizer_state.h
@@ -143,11 +143,17 @@ struct ImageResizerState {
   void ValidateAndCreateOutput(OpKernelContext* context) {
     ValidateAndCalculateOutputSize(context);
     if (!context->status().ok()) return;
+
+    TensorShape shape;
+    // Guard against shape overflow
+    OP_REQUIRES_OK(context, shape.AddDimWithStatus(batch_size));
+    OP_REQUIRES_OK(context, shape.AddDimWithStatus(out_height));
+    OP_REQUIRES_OK(context, shape.AddDimWithStatus(out_width));
+    OP_REQUIRES_OK(context, shape.AddDimWithStatus(channels));
+
     OP_REQUIRES_OK(
         context,
-        context->allocate_output(
-            0, TensorShape({batch_size, out_height, out_width, channels}),
-            &output));
+        context->allocate_output( 0, shape, &output));
   }
 
   int64_t batch_size;

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -3161,6 +3161,14 @@ class ResizeImagesV2Test(test_util.TensorFlowTestCase, parameterized.TestCase):
 
     self._assertResizeCheckShape(x, x_shape, [320, 320], [320, 320, 3])
 
+  def testLargeDim(self):
+    with self.session():
+      with self.assertRaises(errors.InternalError):
+        x = np.ones((5, 1, 1, 2))
+        v = image_ops.resize_images_v2(
+          x, [1610637938, 1610637938], image_ops.ResizeMethod.BILINEAR)
+        _ = self.evaluate(v)
+
 
 class ResizeImagesTest(test_util.TensorFlowTestCase,
                        parameterized.TestCase):


### PR DESCRIPTION
This PR tries to address the issue raised in #46914 where tf.image.resize will crash if size is large, (implicitly causes tf.keras.layers.UpSampling2D to crash).

This PR adds necessary shape overflow check to prevent crash.

This PR fixes #46914.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>