### PR TITLE
[TF:TRT] Replace c asserts with CHECK macro

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -768,8 +768,8 @@ TEST_F(ConverterTest, AddAndGetInputs) {
   TF_EXPECT_OK(GetInputs(node_def, &inputs));
 
   EXPECT_EQ(4, inputs.size());
-  EXPECT_EQ(inputs[0].tensor()->simple_tensor(),
-            inputs[1].tensor()->simple_tensor());
+  EXPECT_EQ(inputs[0].tensor()->trt_tensor(),
+            inputs[1].tensor()->trt_tensor());
 
   EXPECT_EQ(nvinfer1::DataType::kFLOAT, inputs[0].tensor()->getType());
   EXPECT_EQ(nvinfer1::DataType::kINT32, inputs[2].tensor()->getType());

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_tensor_proxy.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_tensor_proxy.h
@@ -16,13 +16,13 @@ limitations under the License.
 #ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TRT_TENSOR_PROXY_H
 #define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TRT_TENSOR_PROXY_H
 
-#include <cassert>
 #include <cstddef>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/core/platform/logging.h"
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 #include "third_party/tensorrt/NvInfer.h"
@@ -143,28 +143,26 @@ class ITensorProxy {
         ttype_(TensorType::kSIMPLE) {}
 
   bool is_trt_tensor() const {
-    assert(validate());
-    assert(ttype_ == TensorType::kTRT);
+    CHECK(validate());
     return trt_tensor_ != nullptr;
   }
 
   bool is_simple_tensor() const {
-    assert(validate());
-    assert(ttype_ == TensorType::kSIMPLE);
+    CHECK(validate());
     return simple_tensor_ != nullptr;
   }
 
   TensorType ttype() const { return ttype_; }
 
   nvinfer1::ITensor* trt_tensor() const {
-    assert(trt_tensor_ != nullptr);
-    assert(ttype_ == TensorType::kTRT);
+    CHECK_NOTNULL(trt_tensor_);
+    CHECK(ttype_ == TensorType::kTRT);
     return trt_tensor_;
   }
 
   SimpleITensor* simple_tensor() const {
-    assert(simple_tensor_ != nullptr);
-    assert(ttype_ == TensorType::kSIMPLE);
+    CHECK_NOTNULL(simple_tensor_);
+    CHECK(ttype_ == TensorType::kSIMPLE);
     return simple_tensor_.get();
   }
 
@@ -175,7 +173,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->setName(name);
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   const char* getName() const {
@@ -185,7 +183,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->getName();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   void setDimensions(nvinfer1::Dims dimensions) {
@@ -195,7 +193,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->setDimensions(dimensions);
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   nvinfer1::Dims getDimensions() const {
@@ -205,7 +203,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->getDimensions();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   void setType(nvinfer1::DataType type) {
@@ -215,7 +213,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->setType(type);
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   nvinfer1::DataType getType() const {
@@ -225,7 +223,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->getType();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   bool isNetworkInput() const {
@@ -235,7 +233,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->isNetworkInput();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   bool isNetworkOutput() const {
@@ -245,7 +243,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->isNetworkOutput();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   void setBroadcastAcrossBatch(bool broadcastAcrossBatch) {
@@ -255,7 +253,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->setBroadcastAcrossBatch(broadcastAcrossBatch);
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   bool getBroadcastAcrossBatch() const {
@@ -265,7 +263,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->getBroadcastAcrossBatch();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   nvinfer1::TensorLocation getLocation() const {
@@ -275,7 +273,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->getLocation();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   void setLocation(nvinfer1::TensorLocation location) {
@@ -285,7 +283,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->setLocation(location);
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   bool setDynamicRange(float min, float max) {
@@ -295,7 +293,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->setDynamicRange(min, max);
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   bool dynamicRangeIsSet() const {
@@ -305,7 +303,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->dynamicRangeIsSet();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   void resetDynamicRange() {
@@ -315,7 +313,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->resetDynamicRange();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
   float getDynamicRangeMin() const {
     switch (ttype_) {
@@ -324,7 +322,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->getDynamicRangeMin();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   float getDynamicRangeMax() const {
@@ -334,7 +332,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->getDynamicRangeMax();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 #if !IS_TRT_VERSION_GE(8, 0, 0, 0)
   float getDynamicRange() const {
@@ -344,7 +342,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->getDynamicRange();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 #endif
   void setAllowedFormats(nvinfer1::TensorFormats formats) {
@@ -354,7 +352,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->setAllowedFormats(formats);
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   nvinfer1::TensorFormats getAllowedFormats() const {
@@ -364,7 +362,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->getAllowedFormats();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   bool isShapeTensor() const {
@@ -374,7 +372,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->isShapeTensor();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
   bool isExecutionTensor() const {
@@ -384,7 +382,7 @@ class ITensorProxy {
       case TensorType::kSIMPLE:
         return simple_tensor_->isExecutionTensor();
     }
-    assert(0 && "Unsupported itensor_ type");
+    LOG(FATAL) << "Unsupported itensor_ type";
   }
 
  private:


### PR DESCRIPTION
The default Tensorflow build uses `-c opt`, which implies `-NDEBUG`. Thus, c-style assert statements become no-ops. This PR replaces asserts in ITensorProxy with Tensorflow CHECK macro. This induces failures in the tests, which are corrected.

Test failures indicate no one is using the `-c debug` option, and thus the signal given by the assert statements is being missed. Thus they should be changed to CHECKs.

@bixia1 
@jhalakpatel 
@tfeher 