### PR TITLE
stream_executor/platform/logging.h: catch up with core/platform/logging.h

### DIFF
--- a/tensorflow/stream_executor/platform/logging.h
+++ b/tensorflow/stream_executor/platform/logging.h
@@ -19,7 +19,9 @@ limitations under the License.
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/stream_executor/platform/port.h"
 
-#if !defined(PLATFORM_GOOGLE) && !defined(PLATFORM_GOOGLE_ANDROID)
+#if !(defined(PLATFORM_GOOGLE) || defined(PLATFORM_GOOGLE_ANDROID) || \
+      defined(PLATFORM_GOOGLE_IOS) || defined(GOOGLE_LOGGING) ||      \
+      defined(__EMSCRIPTEN__) || defined(PLATFORM_CHROMIUMOS))
 
 #define PCHECK(invocation) CHECK(invocation)
 


### PR DESCRIPTION
In [core/platform/logging.h](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/platform/logging.h), TensorFlow used `google/logging.h` while `PLATFORM_GOOGLE*`, `GOOGLE_LOGGING` or `__EMSCRIPTEN__` is defined, but its `stream_executor` only considered two cases (`PLATFORM_GOOGLE` and `PLATFORM_GOOGLE_ANDROID`).
This PR is aimed to make their behavior same.