### PR TITLE
Add negative dim support to tf to tosa expand dims

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
@@ -587,6 +587,16 @@ func @test_expand_dims(%arg0: tensor<13x21x3xf32>) -> tensor<1x13x21x3xf32> {
 
 // -----
 
+// CHECK-LABEL: test_expand_dims_negative_index
+// CHECK: %[[VAR0:.*]] = "tosa.reshape"(%arg0) {new_shape = [13, 1, 21, 3]}
+func @test_expand_dims_negative_index(%arg0: tensor<13x21x3xf32>) -> tensor<13x1x21x3xf32> {
+  %2 = "tf.Const"()  {value = dense<-2> : tensor<1xi32>}  : () -> tensor<1xi32>
+  %3 = "tf.ExpandDims"(%arg0, %2)   : (tensor<13x21x3xf32>, tensor<1xi32>) -> tensor<13x1x21x3xf32>
+  return %3 : tensor<13x1x21x3xf32>
+}
+
+// -----
+
 // CHECK-LABEL: test_shape
 // CHECK: %[[VAR0:.*]] = "tosa.const"() {value = dense<[13, 21, 3]> : tensor<3xi32>}
 func @test_shape() -> tensor<3xi32> {

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
@@ -1165,18 +1165,29 @@ llvm::Optional<Value> convertExpandDimsOp(PatternRewriter& rewriter,
   ElementsAttr dim_elem;
   if (!matchPattern(dim_value, m_Constant(&dim_elem))) return llvm::None;
 
-  assert(dim_elem.getType().getRank() == 0 && "expected scalar tensor");
-  int32_t dim = dim_elem.getValue<IntegerAttr>({}).getInt();
-
+  if (dim_elem.getNumElements() > 1) {
+    op->emitOpError("ExpandDims: expected single dimension to expand");
+    return llvm::None;
+  }
+  int32_t dim = dim_elem.getValue<IntegerAttr>({0}).getInt();
+  int32_t input_size = input_shape.size();
   SmallVector<int64_t> reshape_dims;
-  if (dim < 0 || dim >= input_shape.size()) {  // add dim at end of tensor
-    dim = input_shape.size();
+  if ( dim >= input_size ) {  // add dim at end of tensor
+    dim = input_size;
     for (int i = 0; i < input_shape.size(); i++) {
       reshape_dims.emplace_back(input_shape[i]);
     }
     reshape_dims.emplace_back(1);
   } else {
-    for (int i = 0; i < input_shape.size(); i++) {
+    if (dim < 0 ) {
+      dim+=input_size;
+      if (dim < 0) {
+        op->emitOpError(
+          "ExpandDims: dimension to expand + size of input shape < 0");
+        return llvm::None;
+      }
+    }
+    for (int i = 0; i < input_size; i++) {
       if (i == dim) {
         reshape_dims.emplace_back(1);
       }


### PR DESCRIPTION
Also allows for reading tf.expandDims ops with non-scalar dim input. ie 0 vs [0]. 
Replaced some asserts with compiler errors.
 
Addresses the referenced issue.


https://github.com/google/iree/issues/6768