### PR TITLE
replace x86intrin.h to immintrin.h

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8.h
+++ b/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8.h
@@ -24,7 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/types.h"
 
 #ifdef __AVX2__
-#include <x86intrin.h>
+#include <immintrin.h>
 #endif
 
 namespace tflite {


### PR DESCRIPTION
MSVC didn't have `x86intrin.h`, it cause build break when use `/arch:AVX2`.