### PR TITLE
[XLA, test] Fix a test when few GPU memory is available. 

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/tree_reduction_rewriter_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/tree_reduction_rewriter_test.cc
@@ -140,9 +140,9 @@ add {
 }
 
 ENTRY main {
-  input = f32[100,100,90000] parameter(0)
+  input = f32[100,10,90000] parameter(0)
   zero = f32[] constant(0)
-  ROOT out = f32[100,100] reduce(input, zero), dimensions={2}, to_apply=add
+  ROOT out = f32[100,10] reduce(input, zero), dimensions={2}, to_apply=add
 }
 )";
 
@@ -150,17 +150,17 @@ ENTRY main {
 
   MatchOptimizedHloWithShapes(hlo_text,
                               R"(
-// CHECK: %fused_computation (param_0.2: f32[100,100,90000]) -> f32[100,100,300] {
-// CHECK:   %param_0.2 = f32[100,100,90000]{2,1,0} parameter(0)
-// CHECK:   %bitcast.1 = f32[100,100,300,300]{3,2,1,0} bitcast(f32[100,100,90000]{2,1,0} %param_0.2)
+// CHECK: %fused_computation (param_0.2: f32[100,10,90000]) -> f32[100,10,300] {
+// CHECK:   %param_0.2 = f32[100,10,90000]{2,1,0} parameter(0)
+// CHECK:   %bitcast.1 = f32[100,10,300,300]{3,2,1,0} bitcast(f32[100,10,90000]{2,1,0} %param_0.2)
 // CHECK:   %zero_1 = f32[] constant(0)
-// CHECK:   ROOT %reduce.2 = f32[100,100,300]{2,1,0} reduce(f32[100,100,300,300]{3,2,1,0} %bitcast.1, f32[] %zero_1), dimensions={3}, to_apply=%add
+// CHECK:   ROOT %reduce.2 = f32[100,10,300]{2,1,0} reduce(f32[100,10,300,300]{3,2,1,0} %bitcast.1, f32[] %zero_1), dimensions={3}, to_apply=%add
 // CHECK: }
-// CHECK: ENTRY %main (input: f32[100,100,90000]) -> f32[100,100] {
-// CHECK:   %input = f32[100,100,90000]{2,1,0} parameter(0)
-// CHECK:   %fusion = f32[100,100,300]{2,1,0} fusion(f32[100,100,90000]{2,1,0} %input), kind=kInput, calls=%fused_computation
+// CHECK: ENTRY %main (input: f32[100,10,90000]) -> f32[100,10] {
+// CHECK:   %input = f32[100,10,90000]{2,1,0} parameter(0)
+// CHECK:   %fusion = f32[100,10,300]{2,1,0} fusion(f32[100,10,90000]{2,1,0} %input), kind=kInput, calls=%fused_computation
 // CHECK:   %zero = f32[] constant(0)
-// CHECK:   ROOT %reduce.1 = f32[100,100]{1,0} reduce(f32[100,100,300]{2,1,0} %fusion, f32[] %zero), dimensions={2}, to_apply=%add
+// CHECK:   ROOT %reduce.1 = f32[100,10]{1,0} reduce(f32[100,10,300]{2,1,0} %fusion, f32[] %zero), dimensions={2}, to_apply=%add
 // CHECK: }
       )");
 


### PR DESCRIPTION
This happens in particular when bazel run many tests on the same GPU.

@cheshire 

The error I got:
```
2021-08-18 22:13:48.303536: W tensorflow/stream_executor/stream_executor_pimpl.cc:497] Not enough memory to allocate 3600000000 on device 0 within provided limit. [used=0, limit=2147483648]
tensorflow/compiler/xla/service/gpu/tests/tree_reduction_rewriter_test.cc:47: Failure
Value of: RunMultipleTimes(hlo_text, true, &profiles, "", true)
  Actual: false (Failed to allocate request for 3.35GiB (3600000000B) on device ordinal 0)
Expected: true
```

When we tell bazel to run many tests in parallel, it set by default 2 G per jobs. This also speed up the test at the same time.