### PR TITLE
Update flatbuffers in workspace.bzl

### DIFF
--- a/third_party/flatbuffers/workspace.bzl
+++ b/third_party/flatbuffers/workspace.bzl
@@ -6,7 +6,7 @@ def repo():
     tf_http_archive(
         name = "flatbuffers",
         strip_prefix = "flatbuffers-2.0",
-        sha256 = "62f2223fb9181d1d6338451375628975775f7522185266cd5296571ac152bc45",
+        sha256 = "9ddb9031798f4f8754d00fca2f1a68ecf9d0f83dfac7239af1311e4fd9a565c4",
         urls = [
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/flatbuffers/archive/v2.0.0.tar.gz",
             "https://github.com/google/flatbuffers/archive/v2.0.0.tar.gz",

--- a/third_party/flatbuffers/workspace.bzl
+++ b/third_party/flatbuffers/workspace.bzl
@@ -5,7 +5,7 @@ load("//third_party:repo.bzl", "tf_http_archive")
 def repo():
     tf_http_archive(
         name = "flatbuffers",
-        strip_prefix = "flatbuffers-2.0",
+        strip_prefix = "flatbuffers-2.0.0",
         sha256 = "9ddb9031798f4f8754d00fca2f1a68ecf9d0f83dfac7239af1311e4fd9a565c4",
         urls = [
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/flatbuffers/archive/v2.0.0.tar.gz",

--- a/third_party/flatbuffers/workspace.bzl
+++ b/third_party/flatbuffers/workspace.bzl
@@ -9,7 +9,7 @@ def repo():
         sha256 = "62f2223fb9181d1d6338451375628975775f7522185266cd5296571ac152bc45",
         urls = [
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/flatbuffers/archive/v2.0.0.tar.gz",
-            "https://github.com/google/flatbuffers/archive/v1.12.0.tar.gz",
+            "https://github.com/google/flatbuffers/archive/v2.0.0.tar.gz",
         ],
         build_file = "//third_party/flatbuffers:BUILD.bazel",
         system_build_file = "//third_party/flatbuffers:BUILD.system",

--- a/third_party/flatbuffers/workspace.bzl
+++ b/third_party/flatbuffers/workspace.bzl
@@ -8,7 +8,7 @@ def repo():
         strip_prefix = "flatbuffers-2.0",
         sha256 = "62f2223fb9181d1d6338451375628975775f7522185266cd5296571ac152bc45",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/flatbuffers/archive/v1.12.0.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/flatbuffers/archive/v2.0.0.tar.gz",
             "https://github.com/google/flatbuffers/archive/v1.12.0.tar.gz",
         ],
         build_file = "//third_party/flatbuffers:BUILD.bazel",

--- a/third_party/flatbuffers/workspace.bzl
+++ b/third_party/flatbuffers/workspace.bzl
@@ -5,7 +5,7 @@ load("//third_party:repo.bzl", "tf_http_archive")
 def repo():
     tf_http_archive(
         name = "flatbuffers",
-        strip_prefix = "flatbuffers-1.12.0",
+        strip_prefix = "flatbuffers-2.0",
         sha256 = "62f2223fb9181d1d6338451375628975775f7522185266cd5296571ac152bc45",
         urls = [
             "https://storage.googleapis.com/mirror.tensorflow.org/github.com/google/flatbuffers/archive/v1.12.0.tar.gz",


### PR DESCRIPTION
Updated Flatbuffers to "2.0" Uas dependency change to "https://github.com/tensorflow/tensorflow/pull/51504"