### PR TITLE
fix __array__ for numpy support

### DIFF
--- a/tensorflow/python/distribute/ps_values.py
+++ b/tensorflow/python/distribute/ps_values.py
@@ -445,8 +445,8 @@ class CachingVariable(resource_variable_ops.BaseResourceVariable, core.Tensor):
   def constraint(self):
     return self._v.constraint
 
-  def __array__(self):
-    return np.asarray(self.numpy())
+  def __array__(self, dtype=None):
+    return np.asarray(self.numpy(), dtype=dtype)
 
   def __complex__(self):
     return complex(self.value().numpy())

--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -474,7 +474,7 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
     else:
       yield
 
-  def __array__(self):
+  def __array__(self, dtype=None):
     """Allows direct conversion to a numpy array.
 
     >>> np.array(tf.Variable([1.0]))
@@ -489,7 +489,7 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
     # Even `self.read_value().__array__()` and `self.read_value()._numpy()` give
     # the same error. The `EagerTensor` class must be doing something behind the
     # scenes to make `np.array(tf.constant(1))` work.
-    return np.asarray(self.numpy())
+    return np.asarray(self.numpy(), dtype=dtype)
 
   def __nonzero__(self):
     return self.__bool__()


### PR DESCRIPTION
This change is similar to that of fc0f0e61ca9fe3ca3b9b58f51bcf00e0643ed9e3, when an extra parameter is passed to to `__array__` method, it throws an error, the following code can produce this
```
v = tf.Variable([1.0])
print(np.array(v, dtype=int))
```
Which throws
> TypeError: \_\_array\_\_() takes 1 positional argument but 2 were given

After this change, the `np.array` can behave correctly