### PR TITLE
`third_party/py/BUILD.tpl`: add `stub_shebang` for `py_runtime`

### DIFF
--- a/third_party/py/BUILD.tpl
+++ b/third_party/py/BUILD.tpl
@@ -9,12 +9,14 @@ load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
 py_runtime(
     name = "py2_runtime",
     interpreter_path = "%{PYTHON_BIN_PATH}",
+    stub_shebang = "#!%{PYTHON_BIN_PATH}",
     python_version = "PY2",
 )
 
 py_runtime(
     name = "py3_runtime",
     interpreter_path = "%{PYTHON_BIN_PATH}",
+    stub_shebang = "#!%{PYTHON_BIN_PATH}",
     python_version = "PY3",
 )
 


### PR DESCRIPTION
Bazel 4.2.0 by default uses `#!/usr/bin/env python` for all python
scripts, and breaks build on systems that lack a `python` executable.

This commit adds a stub_shebang that points to the python binary
specified by ./configure.py script, the same as the interpreter_path.