### PR TITLE
[PluggableDevice] Enable TensorList C APIs

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -464,6 +464,7 @@ tf_cuda_library(
         "//tensorflow/c/eager:tfe_context_internal",
         "//tensorflow/c/eager:tfe_op_internal",
         "//tensorflow/c/eager:tfe_tensorhandle_internal",
+        "//tensorflow/c/experimental/tensor_list",
         "//tensorflow/compiler/jit:flags",
         "//tensorflow/compiler/jit:get_compiler_ir",
         "//tensorflow/core:core_cpu",

--- a/tensorflow/c/experimental/tensor_list/BUILD
+++ b/tensorflow/c/experimental/tensor_list/BUILD
@@ -1,0 +1,64 @@
+# Description:
+# TensorList C APIs.
+
+load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
+load("//tensorflow:tensorflow.bzl", "tf_cc_test")
+
+package(
+    licenses = ["notice"],
+)
+
+cc_library(
+    name = "tensor_list_c_hdrs",
+    hdrs = ["tensor_list.h"],
+    visibility = ["//tensorflow:internal"],
+    deps = [
+        "//tensorflow/c:c_api",
+        "//tensorflow/c:c_api_macros",
+        "//tensorflow/c:tf_status_headers",
+    ],
+)
+
+cc_library(
+    name = "tensor_list",
+    srcs = [
+        "tensor_list.cc",
+    ],
+    hdrs = [
+        "tensor_list.h",
+    ],
+    visibility = [
+        "//tensorflow:internal",
+    ],
+    deps = [
+        "//tensorflow/c:kernels_hdrs",
+        "//tensorflow/c:tf_status_headers",
+        "//tensorflow/c:tf_tensor",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core/kernels:tensor_list_hdrs",
+        "//tensorflow/core/platform:errors",
+    ],
+)
+
+tf_cc_test(
+    name = "tensor_list_test",
+    size = "small",
+    srcs = ["tensor_list_test.cc"],
+    linkopts = select({
+        "//conditions:default": [],
+    }),
+    tags = ["noasan"],
+    deps = [
+        ":tensor_list",
+        "//tensorflow/c:c_api",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+        "//tensorflow/core/kernels:tensor_list",
+        "@com_google_absl//absl/strings",
+    ],
+)

--- a/tensorflow/c/experimental/tensor_list/tensor_list.cc
+++ b/tensorflow/c/experimental/tensor_list/tensor_list.cc
@@ -1,0 +1,264 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/c/experimental/tensor_list/tensor_list.h"
+
+#include "tensorflow/c/tf_status_helper.h"
+#include "tensorflow/c/tf_tensor_internal.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/variant_encode_decode.h"
+#include "tensorflow/core/kernels/tensor_list.h"
+
+void TF_GetTensorListFromTensor(const TF_Tensor* tensor, int index,
+                                TF_TensorList** list, TF_Status* status) {
+  ::tensorflow::Tensor cc_tensor;
+  ::tensorflow::Status s = ::tensorflow::TF_TensorToTensor(tensor, &cc_tensor);
+  TF_SetStatus(status, TF_OK, "");
+  if (!s.ok()) {
+    *list = nullptr;
+    ::tensorflow::Set_TF_Status_from_Status(status, s);
+    return;
+  }
+
+  if (index >= cc_tensor.NumElements()) {
+    *list = nullptr;
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "input index out of range");
+    return;
+  }
+
+  ::tensorflow::TensorList* tensor_list = nullptr;
+  if (cc_tensor.NumElements() == 1) {
+    tensor_list = cc_tensor.scalar<::tensorflow::Variant>()()
+                      .get<::tensorflow::TensorList>();
+  } else {
+    // there's maybe multiple variants in the Tensor, such as batch input
+    auto values = cc_tensor.flat<::tensorflow::Variant>();
+    tensor_list = values(index).get<::tensorflow::TensorList>();
+  }
+
+  // status has been set to TF_OK
+  *list = reinterpret_cast<TF_TensorList*>(tensor_list);
+}
+
+void TF_SetTensorListToTensor(TF_TensorList* list, int index, TF_Tensor* tensor,
+                              TF_Status* status) {
+  ::tensorflow::Tensor cc_tensor;
+  ::tensorflow::Status s = ::tensorflow::TF_TensorToTensor(tensor, &cc_tensor);
+  TF_SetStatus(status, TF_OK, "");
+  if (!s.ok()) {
+    ::tensorflow::Set_TF_Status_from_Status(status, s);
+    return;
+  }
+
+  if (index >= cc_tensor.NumElements()) {
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "input index out of range");
+    return;
+  }
+
+  tensorflow::TensorList* tensor_list =
+      reinterpret_cast<::tensorflow::TensorList*>(list);
+  if (cc_tensor.NumElements() == 1) {
+    cc_tensor.scalar<::tensorflow::Variant>()() = *tensor_list;
+  } else {
+    // flat the tensor to a vector despite the tensor's shape and there should
+    // be no nullptr
+    auto values = cc_tensor.flat<::tensorflow::Variant>();
+    values(index) = *tensor_list;
+  }
+}
+
+TF_DataType TF_TensorListGetDataType(const TF_TensorList* list) {
+  auto cc_list = reinterpret_cast<const ::tensorflow::TensorList*>(list);
+  return static_cast<TF_DataType>(cc_list->element_dtype);
+}
+
+int TF_TensorListNumDims(const TF_TensorList* list) {
+  auto cc_list = reinterpret_cast<const ::tensorflow::TensorList*>(list);
+  return cc_list->element_shape.dims();
+}
+
+int64_t TF_TensorListDim(const TF_TensorList* list, int dim_index) {
+  auto cc_list = reinterpret_cast<const ::tensorflow::TensorList*>(list);
+  return cc_list->element_shape.dim_size(dim_index);
+}
+
+void TF_TensorListCopy(const TF_TensorList* from, TF_TensorList* to) {
+  auto cc_from = reinterpret_cast<const ::tensorflow::TensorList*>(from);
+  auto cc_to = reinterpret_cast<::tensorflow::TensorList*>(to);
+  // the `to` has been allocated from user and the deep copy will return a new
+  // tensor list
+  *cc_to = std::move(cc_from->Copy());
+}
+
+TF_TensorList* TF_NewTensorList() {
+  auto cc_list = new ::tensorflow::TensorList;
+  return reinterpret_cast<TF_TensorList*>(cc_list);
+}
+
+void TF_DeleteTensorList(TF_TensorList* list) {
+  auto cc_list = reinterpret_cast<::tensorflow::TensorList*>(list);
+  if (cc_list) {
+    delete cc_list;
+  }
+}
+
+int TF_TensorListSize(const TF_TensorList* list) {
+  auto cc_list = reinterpret_cast<const ::tensorflow::TensorList*>(list);
+  return cc_list->tensors().size();
+}
+
+void TF_TensorListSetDataType(TF_TensorList* list, TF_DataType dtype) {
+  auto cc_list = reinterpret_cast<::tensorflow::TensorList*>(list);
+  cc_list->element_dtype = static_cast<::tensorflow::DataType>(dtype);
+}
+
+void TF_TensorListSetShape(TF_TensorList* list, int num_dims, int64_t* dims) {
+  auto cc_list = reinterpret_cast<::tensorflow::TensorList*>(list);
+
+  if (dims) {
+    std::vector<::tensorflow::int64> d;
+    for (int i = 0; i < num_dims; i++) {
+      d.push_back(dims[i]);
+    }
+    ::tensorflow::PartialTensorShape::MakePartialShape(
+        d.data(), d.size(), &(cc_list->element_shape));
+  } else {
+    // if the dims is null, the shape will be an empty.
+    cc_list->element_shape = ::tensorflow::PartialTensorShape();
+  }
+}
+
+void TF_TensorListGetTensor(const TF_TensorList* list, int index,
+                            TF_Tensor** tensor, TF_Status* status) {
+  const tensorflow::TensorList* cc_list =
+      reinterpret_cast<const ::tensorflow::TensorList*>(list);
+  TF_SetStatus(status, TF_OK, "");
+  if (index < cc_list->tensors().size()) {
+    const tensorflow::Tensor& cc_tensor = cc_list->tensors()[index];
+    tensorflow::Status s;
+    TF_Tensor* tf_tensor = TF_TensorFromTensor(cc_tensor, &s);
+    *tensor = tf_tensor;
+    ::tensorflow::Set_TF_Status_from_Status(status, s);
+  } else {
+    // If out of bound, set the tensor to nullptr and return.
+    *tensor = nullptr;
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "input index out of range");
+  }
+}
+
+void TF_TensorListSetTensor(TF_TensorList* list, int index, TF_Tensor* tensor,
+                            TF_Status* status) {
+  tensorflow::TensorList* tensor_list =
+      reinterpret_cast<::tensorflow::TensorList*>(list);
+
+  TF_SetStatus(status, TF_OK, "");
+  if (list == nullptr || tensor == nullptr) {
+    TF_SetStatus(status, TF_INVALID_ARGUMENT, "input argument is invalid");
+  }
+
+  // If out of bound, return directly
+  if (index >= tensor_list->tensors().size()) {
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "input index out of range");
+    return;
+  }
+
+  ::tensorflow::Tensor cc_tensor;
+  ::tensorflow::Status s = ::tensorflow::TF_TensorToTensor(tensor, &cc_tensor);
+  if (!s.ok()) {
+    ::tensorflow::Set_TF_Status_from_Status(status, s);
+    return;
+  }
+
+  tensor_list->tensors()[index] = cc_tensor;
+}
+
+void TF_TensorListPop(TF_TensorList* list) {
+  tensorflow::TensorList* tensor_list =
+      reinterpret_cast<::tensorflow::TensorList*>(list);
+
+  if (tensor_list->tensors().size() > 0) {
+    tensor_list->tensors().pop_back();
+  }
+
+  // if the list has no tensor, it will do nothing
+}
+
+void TF_TensorListPush(TF_TensorList* list, TF_Tensor* tensor) {
+  tensorflow::TensorList* tensor_list =
+      reinterpret_cast<::tensorflow::TensorList*>(list);
+  ::tensorflow::Tensor cc_tensor;
+  ::tensorflow::Status s = ::tensorflow::TF_TensorToTensor(tensor, &cc_tensor);
+  tensor_list->tensors().push_back(cc_tensor);
+}
+
+namespace tensorflow {
+static Status ForwardInputOrCreateNewList(OpKernelContext* c, int32 input_index,
+                                          int32 output_index,
+                                          const TensorList& input_list,
+                                          TensorList** output_list) {
+  // Attempt to forward the input tensor to the output if possible.
+  std::unique_ptr<Tensor> maybe_output = c->forward_input(
+      input_index, output_index, DT_VARIANT, TensorShape{},
+      c->input_memory_type(input_index), AllocatorAttributes());
+  Tensor* output_tensor;
+  if (maybe_output != nullptr && maybe_output->dtype() == DT_VARIANT &&
+      maybe_output->NumElements() == 1) {
+    output_tensor = maybe_output.get();
+    TensorList* tmp_out = output_tensor->scalar<Variant>()().get<TensorList>();
+    if (tmp_out == nullptr) {
+      return errors::InvalidArgument(
+          "Expected input ", input_index, " to be a TensorList but saw ",
+          output_tensor->scalar<Variant>()().TypeName());
+    }
+    if (tmp_out->RefCountIsOne()) {
+      // Woohoo, forwarding succeeded!
+      c->set_output(output_index, *output_tensor);
+      *output_list = tmp_out;
+      return Status::OK();
+    }
+  }
+
+  // If forwarding is not possible allocate a new output tensor and copy
+  // the `input_list` to it.
+  AllocatorAttributes attr;
+  attr.set_on_host(true);
+  TF_RETURN_IF_ERROR(
+      c->allocate_output(output_index, {}, &output_tensor, attr));
+  output_tensor->scalar<Variant>()() = input_list.Copy();
+
+  *output_list = output_tensor->scalar<Variant>()().get<TensorList>();
+  return Status::OK();
+}
+}  // namespace tensorflow
+
+void TF_ForwardInputOrCreateNewList(TF_OpKernelContext* context,
+                                    int input_index, int output_index,
+                                    TF_TensorList* input_list,
+                                    TF_TensorList** output_list,
+                                    TF_Status* status) {
+  auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(context);
+  ::tensorflow::TensorList* cc_input_list =
+      reinterpret_cast<::tensorflow::TensorList*>(input_list);
+  ::tensorflow::TensorList* cc_output_list;
+
+  TF_SetStatus(status, TF_OK, "");
+  ::tensorflow::Status s = ::tensorflow::ForwardInputOrCreateNewList(
+      cc_ctx, input_index, output_index, *cc_input_list, &cc_output_list);
+  if (!s.ok()) {
+    ::tensorflow::Set_TF_Status_from_Status(status, s);
+    return;
+  }
+
+  *output_list = reinterpret_cast<TF_TensorList*>(cc_output_list);
+}

--- a/tensorflow/c/experimental/tensor_list/tensor_list.h
+++ b/tensorflow/c/experimental/tensor_list/tensor_list.h
@@ -1,0 +1,123 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_C_EXPERIMENTAL_TENSOR_LIST_TENSOR_LIST_H_
+#define TENSORFLOW_C_EXPERIMENTAL_TENSOR_LIST_TENSOR_LIST_H_
+
+#include "tensorflow/c/kernels.h"
+#include "tensorflow/c/tf_datatype.h"
+#include "tensorflow/c/tf_tensor.h"
+
+// Macro to control visibility of exported symbols in the shared library (.so,
+// .dylib, .dll).
+// This duplicates the TF_EXPORT macro definition in
+// tensorflow/core/platform/macros.h in order to keep this .h file independent
+// of any other includes.
+#ifdef SWIG
+#define TF_CAPI_EXPORT
+#else
+#if defined(_WIN32)
+#ifdef TF_COMPILE_LIBRARY
+#define TF_CAPI_EXPORT __declspec(dllexport)
+#else
+#define TF_CAPI_EXPORT __declspec(dllimport)
+#endif  // TF_COMPILE_LIBRARY
+#else
+#define TF_CAPI_EXPORT __attribute__((visibility("default")))
+#endif  // _WIN32
+#endif  // SWIG
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct TF_TensorList;
+
+// Create a new TensorList
+TF_CAPI_EXPORT TF_TensorList* TF_NewTensorList();
+
+// Delete the TensorList created by TF_NewTensorList
+TF_CAPI_EXPORT void TF_DeleteTensorList(TF_TensorList* list);
+
+// Distract the TensorList from the tensor by index.
+//
+// The TensorList is as a Variant element in Tensor. The Tensor will be viewed
+// as a vector, and the tensor of index will be returned. And if the index is
+// out of range, the list will be set to nullptr.
+TF_CAPI_EXPORT void TF_GetTensorListFromTensor(const TF_Tensor* tensor,
+                                               int index, TF_TensorList** list,
+                                               TF_Status* status);
+
+// Set the TensorList to Tensor by index.
+TF_CAPI_EXPORT void TF_SetTensorListToTensor(TF_TensorList* list, int index,
+                                             TF_Tensor* tensor,
+                                             TF_Status* status);
+
+// Get the data type of TensorList
+TF_CAPI_EXPORT TF_DataType TF_TensorListGetDataType(const TF_TensorList* list);
+
+// Get the dim number of TensorList
+TF_CAPI_EXPORT int TF_TensorListNumDims(const TF_TensorList* list);
+
+// Get the dim by dim index
+TF_CAPI_EXPORT int64_t TF_TensorListDim(const TF_TensorList* list,
+                                        int dim_index);
+
+// Set the data type for TensorList
+TF_CAPI_EXPORT void TF_TensorListSetDataType(TF_TensorList* list,
+                                             TF_DataType dtype);
+
+// Set the shape for TensorList
+TF_CAPI_EXPORT void TF_TensorListSetShape(TF_TensorList* list, int num_dims,
+                                          int64_t* dims);
+
+// Get the size of vector of tensor in TensorList
+TF_CAPI_EXPORT int TF_TensorListSize(const TF_TensorList* list);
+
+// Deep copy the TensorList and return a new one
+TF_CAPI_EXPORT void TF_TensorListCopy(const TF_TensorList* from,
+                                      TF_TensorList* to);
+
+// Get the tensor in TensorList by index
+//
+// If the index is out of range, the tensor will be set to nullptr.
+TF_CAPI_EXPORT void TF_TensorListGetTensor(const TF_TensorList* list, int index,
+                                           TF_Tensor** tensor,
+                                           TF_Status* status);
+
+// Set the tensor in TensorList by index
+//
+// If out of bound or has nullptr in list and tensor, it will return directly.
+TF_CAPI_EXPORT void TF_TensorListSetTensor(TF_TensorList* list, int index,
+                                           TF_Tensor* tensor,
+                                           TF_Status* status);
+
+// Remove the last tensor of tensor list
+//
+// If the vector of tensor in list is empty, it will return directly.
+TF_CAPI_EXPORT void TF_TensorListPop(TF_TensorList* list);
+
+// Add the tensor to the last of tensor list
+TF_CAPI_EXPORT void TF_TensorListPush(TF_TensorList* list, TF_Tensor* tensor);
+
+// Forward the input TensorList or create a new TensorList.
+TF_CAPI_EXPORT extern void TF_ForwardInputOrCreateNewList(
+    TF_OpKernelContext* context, int input_index, int output_index,
+    TF_TensorList* input_list, TF_TensorList** output_list, TF_Status* status);
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif  // TENSORFLOW_C_EXPERIMENTAL_TENSOR_LIST_TENSOR_LIST_H_

--- a/tensorflow/c/experimental/tensor_list/tensor_list_test.cc
+++ b/tensorflow/c/experimental/tensor_list/tensor_list_test.cc
@@ -1,0 +1,340 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/c/experimental/tensor_list/tensor_list.h"
+
+#include "absl/container/inlined_vector.h"
+#include "tensorflow/c/tf_datatype.h"
+#include "tensorflow/c/tf_status.h"
+#include "tensorflow/c/tf_tensor.h"
+#include "tensorflow/core/common_runtime/device.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/framework/variant.h"
+#include "tensorflow/core/framework/variant_encode_decode.h"
+#include "tensorflow/core/kernels/tensor_list.h"
+#include "tensorflow/core/platform/status.h"
+#include "tensorflow/core/platform/test.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+namespace tensorflow {
+TF_Tensor* TF_TensorFromTensor(const Tensor& src, Status* status);
+Status TF_TensorToTensor(const TF_Tensor* src, Tensor* dst);
+
+TEST(TensorList, CreateAndDelete) {
+  TF_TensorList* list = TF_NewTensorList();
+  ASSERT_NE(nullptr, list);
+  TF_DeleteTensorList(list);
+}
+
+TEST(TensorList, PushBackToEmptyList) {
+  TF_TensorList* list = TF_NewTensorList();
+  ASSERT_NE(nullptr, list);
+  const int num_bytes = 6 * sizeof(float);
+  int64_t dims[] = {2, 3};
+  TF_Tensor* tensor = TF_AllocateTensor(TF_FLOAT, dims, 2, num_bytes);
+  TF_TensorListPush(list, tensor);
+
+  int size = TF_TensorListSize(list);
+  EXPECT_EQ(1, size);
+
+  TF_DeleteTensor(tensor);
+  TF_DeleteTensorList(list);
+}
+
+TEST(TensorList, PushAndPopList) {
+  TF_TensorList* list = TF_NewTensorList();
+  ASSERT_NE(nullptr, list);
+
+  std::vector<TF_Tensor*> tensors;
+  int tensors_size = 10;
+  for (int i = 0; i < tensors_size; i++) {
+    const int num_bytes = 6 * sizeof(float);
+    int64_t dims[] = {2, 3};
+    TF_Tensor* tensor = TF_AllocateTensor(TF_FLOAT, dims, 2, num_bytes);
+    TF_TensorListPush(list, tensor);
+    tensors.push_back(tensor);
+  }
+
+  int size = TF_TensorListSize(list);
+  EXPECT_EQ(tensors_size, size);
+
+  TF_TensorListPop(list);
+  size = TF_TensorListSize(list);
+  EXPECT_EQ(tensors_size - 1, size);
+
+  for (int i = 0; i < tensors_size; i++) {
+    TF_DeleteTensor(tensors[i]);
+  }
+  TF_DeleteTensorList(list);
+}
+
+TEST(TensorList, SetItemToList) {
+  TF_TensorList* list = TF_NewTensorList();
+  ASSERT_NE(nullptr, list);
+
+  TF_Status* status = TF_NewStatus();
+
+  const int num_bytes = 6 * sizeof(float);
+  int64_t dims[] = {2, 3};
+  TF_Tensor* tensor = TF_AllocateTensor(TF_FLOAT, dims, 2, num_bytes);
+  TF_TensorListPush(list, tensor);
+
+  int64_t dims2[] = {1, 8};
+  TF_Tensor* tensor2 = TF_AllocateTensor(TF_FLOAT, dims2, 2, 8 * sizeof(float));
+  TF_TensorListSetTensor(list, 0, tensor2, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status));
+
+  TF_TensorListSetTensor(list, 1, tensor2, status);
+  EXPECT_EQ(TF_OUT_OF_RANGE, TF_GetCode(status));
+
+  TF_Tensor* t = nullptr;
+  TF_TensorListGetTensor(list, 1, &t, status);
+  EXPECT_EQ(TF_OUT_OF_RANGE, TF_GetCode(status));
+  EXPECT_EQ(nullptr, t);
+
+  TF_TensorListGetTensor(list, 0, &t, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status));
+  EXPECT_NE(nullptr, t);
+
+  int64_t dim1 = TF_Dim(t, 0);
+  int64_t dim2 = TF_Dim(t, 1);
+  EXPECT_EQ(dim1, 1);
+  EXPECT_EQ(dim2, 8);
+
+  TF_DeleteTensor(tensor);
+  TF_DeleteTensor(tensor2);
+  TF_DeleteTensor(t);
+
+  TF_DeleteStatus(status);
+
+  TF_DeleteTensorList(list);
+}
+
+TEST(TensorList, TensorListMetaInfo) {
+  TF_TensorList* list = TF_NewTensorList();
+  ASSERT_NE(nullptr, list);
+
+  const int num_bytes = 6 * sizeof(float);
+  int64_t dims[] = {2, 3};
+  TF_Tensor* tensor = TF_AllocateTensor(TF_FLOAT, dims, 2, num_bytes);
+  TF_TensorListPush(list, tensor);
+
+  TF_TensorListSetDataType(list, TF_FLOAT);
+  TF_TensorListSetShape(list, 2, dims);
+
+  {
+    int size = TF_TensorListSize(list);
+    EXPECT_EQ(size, 1);
+
+    int64_t num_dims = TF_TensorListNumDims(list);
+    EXPECT_EQ(num_dims, 2);
+
+    int64_t dim1 = TF_TensorListDim(list, 0);
+    int64_t dim2 = TF_TensorListDim(list, 1);
+    EXPECT_EQ(dim1, 2);
+    EXPECT_EQ(dim2, 3);
+
+    TF_DataType dtype = TF_TensorListGetDataType(list);
+    EXPECT_EQ(dtype, TF_FLOAT);
+  }
+
+  TF_DeleteTensor(tensor);
+  TF_DeleteTensorList(list);
+}
+
+TEST(TensorList, GetTensorList) {
+  ::tensorflow::TensorList list;
+  ::tensorflow::Tensor tensor =
+      ::tensorflow::Tensor(::tensorflow::DT_FLOAT, TensorShape({2, 3}));
+  list.tensors().push_back(tensor);
+
+  ::tensorflow::Tensor t = ::tensorflow::Tensor(DT_VARIANT, TensorShape({}));
+  t.scalar<::tensorflow::Variant>()() = list;
+  ::tensorflow::Status s;
+  TF_Tensor* tf_t = TF_TensorFromTensor(t, &s);
+
+  TF_TensorList* tf_list = nullptr;
+  TF_Status* status = TF_NewStatus();
+
+  TF_GetTensorListFromTensor(tf_t, 1, &tf_list, status);
+  EXPECT_EQ(TF_OUT_OF_RANGE, TF_GetCode(status));
+  EXPECT_EQ(tf_list, nullptr);
+
+  TF_GetTensorListFromTensor(tf_t, 0, &tf_list, status);
+  EXPECT_NE(nullptr, tf_list);
+  EXPECT_EQ(TF_OK, TF_GetCode(status));
+
+  int size = TF_TensorListSize(tf_list);
+  EXPECT_EQ(1, size);
+
+  TF_DeleteStatus(status);
+  TF_DeleteTensor(tf_t);
+}
+
+TEST(TensorList, SetTensorList) {
+  ::tensorflow::Tensor t = ::tensorflow::Tensor(DT_VARIANT, TensorShape({}));
+  ::tensorflow::Status s;
+  TF_Tensor* tf_t = TF_TensorFromTensor(t, &s);
+
+  TF_Status* status = TF_NewStatus();
+  TF_TensorList* list = TF_NewTensorList();
+
+  TF_SetTensorListToTensor(list, 1, tf_t, status);
+  EXPECT_EQ(TF_OUT_OF_RANGE, TF_GetCode(status));
+
+  TF_SetTensorListToTensor(list, 0, tf_t, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status));
+  EXPECT_NE(nullptr, tf_t);
+
+  TF_TensorList* get_back = nullptr;
+  TF_GetTensorListFromTensor(tf_t, 0, &get_back, status);
+  EXPECT_EQ(TF_OK, TF_GetCode(status));
+  EXPECT_NE(nullptr, get_back);
+
+  EXPECT_EQ(1, TF_TensorElementCount(tf_t));
+
+  TF_DeleteStatus(status);
+  TF_DeleteTensorList(list);
+  TF_DeleteTensor(tf_t);
+}
+
+TEST(TensorList, CopyTensorList) {
+  ::tensorflow::Status s;
+  TF_Status* status = TF_NewStatus();
+  TF_TensorList* list = TF_NewTensorList();
+
+  {
+    Tensor t = Tensor(DT_FLOAT, TensorShape({2, 3}));
+    TF_Tensor* tf_t = TF_TensorFromTensor(t, &s);
+    TF_TensorListPush(list, tf_t);
+    TF_DeleteTensor(tf_t);
+  }
+
+  TF_TensorList* copy = TF_NewTensorList();
+  TF_TensorListCopy(list, copy);
+
+  EXPECT_EQ(1, TF_TensorListSize(copy));
+  EXPECT_EQ(1, TF_TensorListSize(list));
+
+  Tensor t = Tensor(DT_FLOAT, TensorShape({2, 3}));
+  TF_Tensor* tf_t = TF_TensorFromTensor(t, &s);
+  TF_TensorListPush(copy, tf_t);
+  EXPECT_EQ(2, TF_TensorListSize(copy));
+  EXPECT_EQ(1, TF_TensorListSize(list));
+
+  TF_DeleteStatus(status);
+  TF_DeleteTensorList(list);
+  TF_DeleteTensorList(copy);
+  TF_DeleteTensor(tf_t);
+}
+
+class DummyDevice : public DeviceBase {
+ public:
+  explicit DummyDevice(Env* env) : DeviceBase(env) {}
+  Allocator* GetAllocator(AllocatorAttributes /*attr*/) override {
+    return cpu_allocator();
+  }
+};
+
+static std::unique_ptr<OpKernel> GetFakeKernel(const char* device_name,
+                                               const char* op_name,
+                                               const char* node_name,
+                                               Status* status) {
+  NodeDef def;
+  def.set_op(op_name);
+  def.set_name(node_name);
+  def.set_device(device_name);
+  def.add_input("input1");
+  def.add_input("input2");
+
+  AttrValue v;
+  v.set_type(DataType::DT_FLOAT);
+  (*def.mutable_attr())["SomeDataTypeAttr"] = v;
+
+  return CreateOpKernel(DeviceType(device_name), nullptr, nullptr, def, 1,
+                        status);
+}
+
+TEST(TensorList, ForwardInputOrCreateNewList) {
+  const char* node_name = "ForwardInputOrCreateNewList";
+  const char* op_name = "FakeListOp";
+  const char* device_name = "FakeDeviceName";
+
+  REGISTER_OP(op_name)
+      .Input("input1: variant")
+      .Input("input2: float")
+      .Output("output1: variant")
+      .Attr("SomeDataTypeAttr: type");
+
+  // A kernel whose Compute function that forwards a tensorlist input to output
+  auto my_compute_func = [](void* kernel, TF_OpKernelContext* ctx) {
+    TF_Status* s = TF_NewStatus();
+    TF_Tensor* input = nullptr;
+    TF_GetInput(ctx, 0, &input, s);
+    TF_TensorList* input_list = nullptr;
+    TF_TensorList* output_list = nullptr;
+    TF_GetTensorListFromTensor(input, 0, &input_list, s);
+    TF_ForwardInputOrCreateNewList(ctx, 0, 0, input_list, &output_list, s);
+    EXPECT_EQ(TF_OK, TF_GetCode(s));
+    EXPECT_EQ(TF_TensorListSize(input_list), TF_TensorListSize(output_list));
+    TF_DeleteStatus(s);
+    TF_DeleteTensor(input);
+  };
+
+  TF_KernelBuilder* builder = TF_NewKernelBuilder(op_name, device_name, nullptr,
+                                                  my_compute_func, nullptr);
+
+  {
+    TF_Status* status = TF_NewStatus();
+    TF_RegisterKernelBuilder(node_name, builder, status);
+    EXPECT_EQ(TF_OK, TF_GetCode(status));
+    TF_DeleteStatus(status);
+  }
+
+  {
+    OpKernelContext::Params p;
+    DummyDevice dummy_device(nullptr);
+    p.device = &dummy_device;
+    AllocatorAttributes alloc_attrs;
+    p.output_attr_array = &alloc_attrs;
+
+    TensorList list;
+    list.element_dtype = DT_FLOAT;
+    list.element_shape = PartialTensorShape({2, 3});
+    list.tensors().push_back(Tensor(DT_FLOAT, TensorShape({2, 3})));
+
+    Tensor t = Tensor(DT_VARIANT, {});
+    t.scalar<Variant>()() = list;
+
+    gtl::InlinedVector<TensorValue, 4> inputs;
+    inputs.emplace_back(&t);
+    p.inputs = &inputs;
+
+    Status status;
+    std::unique_ptr<OpKernel> kernel =
+        GetFakeKernel(device_name, op_name, node_name, &status);
+    EXPECT_EQ(Status::OK(), status);
+    ASSERT_NE(nullptr, kernel.get());
+
+    p.op_kernel = kernel.get();
+    OpKernelContext ctx(&p);
+    kernel->Compute(&ctx);
+
+    TensorList* output_list =
+        ctx.mutable_output(0)->scalar<Variant>()().get<TensorList>();
+    ASSERT_EQ(1, output_list->tensors().size());
+  }
+}
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2802,6 +2802,12 @@ tf_kernel_library(
     ],
 )
 
+cc_library(
+    name = "tensor_list_hdrs",
+    hdrs = ["tensor_list.h"],
+    visibility = ["//tensorflow:internal"],
+)
+
 tf_kernel_library(
     name = "resource_variable_ops",
     srcs = ["resource_variable_ops.cc"],

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -38,6 +38,7 @@ transitive_hdrs(
         "//tensorflow/c/experimental/filesystem:filesystem_interface",
         "//tensorflow/c/experimental/stream_executor:stream_executor_hdrs",
         "//tensorflow/c/experimental/grappler:grappler_hdrs",
+        "//tensorflow/c/experimental/tensor_list:tensor_list_c_hdrs",
         "//tensorflow/c:kernels_hdrs",
         "//tensorflow/c:ops_hdrs",
         # WARNING: None of the C/C++ code under python/ has any API guarantees, and TF team


### PR DESCRIPTION
This PR adds support for TensorList C APIs following to the Variable RFC ideas. It supports

1. create or delete TensorList
2. set/get TensorList from Tensor
3. some TensorList's methods like get tensor, get element shape or dtype, deep copy and so on.

Developer can use these C APIs to implement TensorList relative kernels.