### PR TITLE
Update Delegate.swift

### DIFF
--- a/tensorflow/lite/swift/Sources/Delegate.swift
+++ b/tensorflow/lite/swift/Sources/Delegate.swift
@@ -15,7 +15,7 @@
 import TensorFlowLiteC
 
 /// A delegate that the `Interpreter` uses to perform TensorFlow Lite model computations.
-public protocol Delegate: class {
+public protocol Delegate: AnyObject {
   /// The `TfLiteDelegate` C pointer type.
   typealias CDelegate = UnsafeMutablePointer<TfLiteDelegate>
 


### PR DESCRIPTION
Fixes "Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead" warning