### PR TITLE
Disable XNNPACK for s390x machines

### DIFF
--- a/tensorflow/lite/kernels/test_delegate_providers_test.cc
+++ b/tensorflow/lite/kernels/test_delegate_providers_test.cc
@@ -35,7 +35,7 @@ TEST(KernelTestDelegateProvidersTest, DelegateProvidersParams) {
 }
 
 TEST(KernelTestDelegateProvidersTest, CreateTfLiteDelegates) {
-#if !defined(__Fuchsia__) && !defined(TFLITE_WITHOUT_XNNPACK)
+#if !defined(__Fuchsia__) && !defined(__s390x__) && !defined(TFLITE_WITHOUT_XNNPACK)
   KernelTestDelegateProviders providers;
   providers.MutableParams()->Set<bool>("use_xnnpack", true);
   EXPECT_GE(providers.CreateAllDelegates().size(), 1);

--- a/tensorflow/lite/tools/delegates/delegate_provider_test.cc
+++ b/tensorflow/lite/tools/delegates/delegate_provider_test.cc
@@ -43,7 +43,7 @@ TEST(ProvidedDelegateListTest, AppendCmdlineFlags) {
 }
 
 TEST(KernelTestDelegateProvidersTest, CreateAllRankedDelegates) {
-#if !defined(__Fuchsia__) && !defined(TFLITE_WITHOUT_XNNPACK)
+#if !defined(__Fuchsia__) && !defined(__s390x__) && !defined(TFLITE_WITHOUT_XNNPACK)
   ToolParams params;
   ProvidedDelegateList providers(&params);
   providers.AddAllDelegateParams();

--- a/tensorflow/lite/tools/evaluation/BUILD
+++ b/tensorflow/lite/tools/evaluation/BUILD
@@ -57,6 +57,7 @@ cc_library(
         "//conditions:default": [],
     }) + select({
         "//tensorflow:linux_armhf": [],
+        "//tensorflow:linux_s390x": [],
         "//conditions:default": [
             "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate",
         ],

--- a/tensorflow/lite/tools/evaluation/utils.cc
+++ b/tensorflow/lite/tools/evaluation/utils.cc
@@ -168,7 +168,7 @@ TfLiteDelegatePtr CreateHexagonDelegate(
 }
 #endif
 
-#if defined(TFLITE_WITHOUT_XNNPACK)
+#if defined(__s390x__) || defined(TFLITE_WITHOUT_XNNPACK)
 TfLiteDelegatePtr CreateXNNPACKDelegate(int num_threads) {
   return CreateNullDelegate();
 }

--- a/tensorflow/lite/tools/evaluation/utils.h
+++ b/tensorflow/lite/tools/evaluation/utils.h
@@ -35,7 +35,7 @@ limitations under the License.
 #include "tensorflow/lite/delegates/hexagon/hexagon_delegate.h"
 #endif
 
-#if !defined(TFLITE_WITHOUT_XNNPACK)
+#if !defined(__s390x__) && !defined(TFLITE_WITHOUT_XNNPACK)
 #include "tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h"
 #endif
 
@@ -83,7 +83,7 @@ TfLiteDelegatePtr CreateHexagonDelegate(
     const std::string& library_directory_path);
 #endif
 
-#if !defined(TFLITE_WITHOUT_XNNPACK)
+#if !defined(__s390x__) && !defined(TFLITE_WITHOUT_XNNPACK)
 TfLiteDelegatePtr CreateXNNPACKDelegate();
 TfLiteDelegatePtr CreateXNNPACKDelegate(
     const TfLiteXNNPackDelegateOptions* options);


### PR DESCRIPTION
This PR disable XNNPACK related build targets and function definitions on s390x because XNNPACK is not supported on s390x: https://github.com/google/XNNPACK#supported-architectures
Without this patch, a lot of Lite targets that are not necessarily depending on XNNPACK dependencies will fail to build on s390x, and this patch will allow them to build successfully