### PR TITLE
Fix TF serving build failure on s390x caused by aws lib target

### DIFF
--- a/third_party/aws/BUILD.bazel
+++ b/third_party/aws/BUILD.bazel
@@ -24,6 +24,9 @@ cc_library(
         "@org_tensorflow//tensorflow:linux_ppc64le": glob([
             "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",
         ]),
+        "@org_tensorflow//tensorflow:linux_s390x": glob([
+            "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",
+        ]),
         "@org_tensorflow//tensorflow:raspberry_pi_armeabi": glob([
             "aws-cpp-sdk-core/source/platform/linux-shared/*.cpp",
         ]),


### PR DESCRIPTION
This PR makes the `aws` lib target buildable on s390x and thus resolve a TF serving build failure. Please note that this PR does not aim at enabling any aws features on s390x, as for s390x build `-no-aws` flag is used as default. The only purpose of this PR is make TF serving build pass as TF serving does not support the `-no-aws` flag so this target needs to be analyzed.