### PR TITLE
Fix crash of tf.image.extract_glimpse with negative input

### DIFF
--- a/tensorflow/core/kernels/image/attention_ops.cc
+++ b/tensorflow/core/kernels/image/attention_ops.cc
@@ -87,9 +87,10 @@ class ExtractGlimpseOp : public OpKernel {
 
     const int64_t output_height = window_size.tensor<int, 1>()(0);
     const int64_t output_width = window_size.tensor<int, 1>()(1);
+
     TensorShape output_shape = input_shape;
-    output_shape.set_dim(1, output_height);
-    output_shape.set_dim(2, output_width);
+    OP_REQUIRES_OK(context, output_shape.SetDimWithStatus(1, output_height));
+    OP_REQUIRES_OK(context, output_shape.SetDimWithStatus(2, output_width));
 
     const Tensor& offsets = context->input(2);
     OP_REQUIRES(context, offsets.shape().dims() == 2,

--- a/tensorflow/python/kernel_tests/attention_ops_test.py
+++ b/tensorflow/python/kernel_tests/attention_ops_test.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_image_ops
 from tensorflow.python.ops import image_ops
@@ -300,6 +301,15 @@ class ExtractGlimpseTest(test.TestCase):
       self.assertAllEqual(
           np.asarray([[5, 6, 7], [10, 11, 12], [15, 16, 17]]),
           self.evaluate(result2)[0, :, :, 0])
+
+  def testGlimpseNegativeInput(self):
+    img = np.arange(9).reshape([1,3,3,1])
+    with self.test_session():
+      with self.assertRaises(errors.InternalError):
+        result = image_ops.extract_glimpse_v2(
+            img, size=[1023, -63], offsets=[1023, 63],
+            centered=False, normalized=False)
+        self.evaluate(result)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/kernel_tests/attention_ops_test.py
+++ b/tensorflow/python/kernel_tests/attention_ops_test.py
@@ -305,7 +305,7 @@ class ExtractGlimpseTest(test.TestCase):
   def testGlimpseNegativeInput(self):
     img = np.arange(9).reshape([1,3,3,1])
     with self.test_session():
-      with self.assertRaises(errors.InternalError):
+      with self.assertRaises((errors.InternalError, ValueError)):
         result = image_ops.extract_glimpse_v2(
             img, size=[1023, -63], offsets=[1023, 63],
             centered=False, normalized=False)


### PR DESCRIPTION
This PR tries to fix the issue raised in #51618 where
tf.image.extract_glimpse will crash in case of negative input.

This PR adds additional checking to allow graceful error message.

This PR fixes #51618.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>