### PR TITLE
[TF:TRT]  Enable dynamic shape for Slice and StridedSlice operations

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -405,11 +405,14 @@ tf_cuda_library(
     srcs = [
         "convert/convert_graph.cc",
         "convert/convert_nodes.cc",
+        "convert/ops/slice_ops.cc",
         "convert/trt_optimization_pass.cc",
     ],
     hdrs = [
         "convert/convert_graph.h",
         "convert/convert_nodes.h",
+        "convert/ops/layer_utils.h",
+        "convert/ops/slice_ops.h",
         "convert/trt_optimization_pass.h",
     ],
     deps = [
@@ -484,7 +487,9 @@ tf_cuda_cc_test(
 tf_cuda_cc_test(
     name = "convert_nodes_test",
     size = "medium",
-    srcs = ["convert/convert_nodes_test.cc"],
+    srcs = [
+        "convert/convert_nodes_test.cc",
+    ],
     tags = [
         "no_cuda_on_cpu_tap",
         "no_windows",

--- a/tensorflow/compiler/tf2tensorrt/common/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.h
@@ -32,8 +32,26 @@ std::tuple<int, int, int> GetLoadedTensorRTVersion();
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 
+#include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/platform/logging.h"
 #include "third_party/tensorrt/NvInfer.h"
+
+#define TRT_EXPECT(x)                                  \
+  if (!(x)) {                                          \
+    return errors::Internal(__FILE__, ":", __LINE__,   \
+                            " pre condition failure"); \
+  }
+
+#define TRT_ENSURE(x)                                   \
+  if (!(x)) {                                           \
+    return errors::Internal(__FILE__, ":", __LINE__,    \
+                            " post condition failure"); \
+  }
+
+#define TRT_ENSURE_OK(x)                                 \
+  if (!x.ok()) {                                         \
+    return errors::Internal(x.status().error_message()); \
+  }
 
 namespace tensorflow {
 namespace tensorrt {

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
 
 #include <algorithm>
+#include <bitset>
 #include <cmath>
 #include <cstring>
 #include <map>
@@ -33,6 +34,7 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h"
@@ -42,6 +44,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.pb.h"  // NOLINT
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/tensor_shape.pb.h"  // NOLINT
+#include "tensorflow/core/framework/tensor_util.h"
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/graph/algorithm.h"
 #include "tensorflow/core/graph/graph.h"
@@ -2742,72 +2745,6 @@ Status ConvertSqueeze(OpConverterParams* params) {
   return Status::OK();
 }
 
-template <typename Container>
-Status ConvertStridedSliceHelper(
-    OpConverterParams* params, const TRT_TensorOrWeights& input,
-    Container begin, Container size, const Container& stride,
-    const nvinfer1::Dims* final_shape = nullptr,
-    absl::optional<int> op_instance = absl::nullopt) {
-  if (!params->use_implicit_batch &&
-      (!HasStaticShape(begin) || !HasStaticShape(size))) {
-    return errors::Unimplemented(
-        "Strided slice op not implemented for dynamic shape input");
-  }
-  const auto& node_def = params->node_def;
-  // Get input dims.
-  nvinfer1::Dims dims = input.GetTrtDims();
-  std::vector<int> input_dims(dims.d, dims.d + dims.nbDims);
-  if (params->use_implicit_batch) {
-    // Begin, size and stride does include explicit batch dim. Add batch
-    // dimension to input_dims so that indexes line up properly.
-    input_dims.insert(input_dims.begin(), -1);
-  }
-  // Check bounds.
-  for (int i = 1; i < input_dims.size(); i++) {
-    if (input_dims[i] < 0 || size[i] < 0) continue;
-    if (begin[i] < 0 || begin[i] > input_dims[i]) {
-      return errors::InvalidArgument("\"begin\" for dimension ",
-                                     std::to_string(i), " in ", node_def.op(),
-                                     " is out of range, at ", node_def.name());
-    }
-    int end = begin[i];
-    if (size[i] > 0) end += (size[i] - 1) * stride[i];
-    if (end < 0 || end > input_dims[i]) {
-      return errors::InvalidArgument("\"begin\" + \"size\" for dimension ",
-                                     std::to_string(i), " in ", node_def.op(),
-                                     " is out of range, at ", node_def.name());
-    }
-  }
-
-  nvinfer1::Dims begin_dims, size_dims, stride_dims;
-  TF_RETURN_IF_ERROR(
-      ContainerToTrtDims(begin, &begin_dims,
-                         /*ignore_first_dim=*/params->use_implicit_batch));
-  TF_RETURN_IF_ERROR(
-      ContainerToTrtDims(size, &size_dims,
-                         /*ignore_first_dim=*/params->use_implicit_batch));
-  TF_RETURN_IF_ERROR(
-      ContainerToTrtDims(stride, &stride_dims, params->use_implicit_batch));
-  if (params->validation_only) return Status::OK();
-
-  VLOG(2) << "Adding slice layer with begin=" << DebugString(begin_dims)
-          << ", size=" << DebugString(size_dims)
-          << ", stride=" << DebugString(stride_dims);
-  nvinfer1::ISliceLayer* layer = params->converter->network()->addSlice(
-      *input.tensor()->trt_tensor(), begin_dims, size_dims, stride_dims);
-  params->converter->SetLayerName(layer, params->node_def, "slice",
-                                  op_instance);
-  ITensorProxyPtr tensor = layer->getOutput(0);
-  // Reshape for shrink_axis.
-  if (final_shape) {
-    TF_RETURN_IF_ERROR(PrepareTensorForShape(
-        params->converter, TRT_TensorOrWeights(tensor), *final_shape,
-        /*validation_only=*/false, &tensor, node_def, op_instance));
-  }
-  params->outputs->push_back(TRT_TensorOrWeights(tensor));
-  return Status::OK();
-}
-
 Status ConvertSlice(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
@@ -2815,89 +2752,180 @@ Status ConvertSlice(OpConverterParams* params) {
       *params, {{"input", false}, {"begin", true}, {"size", true}}));
   TF_RETURN_IF_ERROR(AllowDataTypes(
       *params, {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}));
-  std::vector<int> begin = inputs.at(1).weights().ToVector<int>();
-  std::vector<int> size = inputs.at(2).weights().ToVector<int>();
-  // Get input dims.
+
+  auto begin_weights = inputs.at(1).weights();
+  auto size_weights = inputs.at(2).weights();
+
+  // Check that "begin" is not negative.
+  {
+    auto begin_view = begin_weights.GetSpan<int32>();
+    if (std::any_of(begin_view.begin(), begin_view.end(),
+                    [](const int32 val) { return val < 0; })) {
+      return errors::InvalidArgument("\"begin\" in Slice is out of range, at ",
+                                     node_def.name());
+    }
+  }
+
+  // Check that "size" is not less than -1.
+  {
+    auto size_view = size_weights.GetSpan<int32>();
+    if (std::any_of(size_view.begin(), size_view.end(),
+                    [](const int32 val) { return val < -1; })) {
+      return errors::InvalidArgument("\"size\" in Slice is out of range, at ",
+                                     node_def.name());
+    }
+  }
+
+  // Get the input dims and add batch dimension so that indexes line up
+  // properly.
   nvinfer1::Dims dims = inputs.at(0).GetTrtDims();
-  std::vector<int> input_dims(dims.d, dims.d + dims.nbDims);
-  // Add batch dimension so that indexes line up properly.
+  absl::InlinedVector<int64, 4> input_dims(dims.d, dims.d + dims.nbDims);
   if (params->use_implicit_batch) {
     input_dims.insert(input_dims.begin(), inputs.at(0).batch_size());
   }
-  if (!AllLengthsEqual({input_dims, begin, size})) {
-    return errors::InvalidArgument(
-        "Length of begin and size arguments must equal rank of input for "
-        "Slice, at ",
-        node_def.name());
-  }
+
   // Check that batch dimension is unmodified.
   if (params->use_implicit_batch) {
-    const bool begin_is_modified = begin[0] != 0;
+    auto begin_v = begin_weights.GetSpan<int32>();
+    auto size_v = size_weights.GetSpan<int32>();
+    const bool begin_is_modified = begin_v[0] != 0;
+
     // If size[0]s is not -1, we can only know if the batch dimension is
     // unmodified when the batch size is defined. When the batch size is
     // undefined, we don't convert to be safe.
-    const bool size_is_unchanged = size[0] == -1 || size[0] == input_dims[0];
+    const bool size_is_unchanged =
+        size_v[0] == -1 || size_v[0] == input_dims[0];
     if (begin_is_modified || !size_is_unchanged) {
       return errors::Unimplemented(
-          "TensorRT does not allow modifications to the batch dimension, at ",
+          "TensorRT does not allow modifications to the batch dimension in "
+          "implicit batch mode, at ",
           node_def.name());
     }
   }
-  // Size of -1 signifies to take all remaining elements.
-  for (int i = 0; i < input_dims.size(); i++) {
-    if (size[i] == -1) {
-      if (input_dims[i] == -1) {
-        return errors::Unimplemented(
-            "Input dims must be defined for size = -1, at ", node_def.name());
+
+  PartialTensorShape input_shape(input_dims);
+  PartialTensorShape processing_shape;
+  PartialTensorShape final_shape;
+  bool is_identity;
+  bool is_simple_slice;
+  bool slice_dim0;
+  absl::InlinedVector<int64, 4> begin;
+  absl::InlinedVector<int64, 4> end;
+  absl::InlinedVector<int64, 4> strides;
+  StridedSliceShapeSpec strided_slice_spec;
+  std::bitset<32> begin_mask(0);
+  std::bitset<32> end_mask(0);
+  std::bitset<32> ellipsis_mask(0);
+  std::bitset<32> new_axis_mask(0);
+  std::bitset<32> shrink_axis_mask(0);
+  Tensor strides_tensor = tensor::DeepCopy(begin_weights.GetTensor());
+  Tensor end_tensor = tensor::DeepCopy(size_weights.GetTensor());
+  Tensor size_tensor = tensor::DeepCopy(size_weights.GetTensor());
+
+  // Setup begin_mask, end_mask, end_tensor, strides_tensor, and end_tensor.
+  auto strides_vec = strides_tensor.flat<int32>();
+  auto end_vec = end_tensor.flat<int32>();
+  auto size_vec = size_tensor.flat<int32>();
+  auto begin_vec = begin_weights.GetTensor().flat<int32>();
+  for (int i = 0; i < input_shape.dims(); i++) {
+    strides_vec(i) = 1;
+    begin_mask[i] = false;
+    if (size_vec(i) == -1) {
+      end_mask[i] = true;
+      end_vec(i) = 0;
+      size_vec(i) = 0;
+    } else {
+      end_mask[i] = false;
+      end_vec(i) = begin_vec(i) + size_vec(i);
+      if (end_vec(i) > input_dims[i] && input_dims[i] > 0) {
+        return errors::InvalidArgument("\"begin\" + \"size\" for dimension ", i,
+                                       " in Slice is out of range, at ",
+                                       node_def.name());
       }
-      size[i] = input_dims[i] - begin[i];
-    } else if (size[i] < -1) {
-      return errors::InvalidArgument("Invalid size value at ", node_def.name());
-    }
-    if (input_dims[i] != -1 && (begin[i] < 0 || begin[i] > input_dims[i])) {
-      return errors::InvalidArgument("\"begin\" for dimension ",
-                                     std::to_string(i), " in ", node_def.op(),
-                                     " is out of range, at ", node_def.name());
-    }
-    const int end = begin[i] + size[i];
-    if (input_dims[i] != -1 && (end < 0 || end > input_dims[i])) {
-      return errors::InvalidArgument("\"begin\" + \"size\" for dimension ",
-                                     std::to_string(i), " in ", node_def.op(),
-                                     " is out of range, at ", node_def.name());
     }
   }
-  // Stride is 1 for all dims.
-  std::vector<int> stride(begin.size(), 1);
-  return ConvertStridedSliceHelper(params, inputs.at(0), begin, size, stride);
+
+  auto bitset_to_int32 = [](const std::bitset<32>& bs) {
+    return static_cast<int32_t>(bs.to_ulong());
+  };
+
+  TF_RETURN_IF_ERROR(ValidateStridedSliceOp(
+      &begin_weights.GetTensor(), &end_tensor, strides_tensor, input_shape,
+      bitset_to_int32(begin_mask), bitset_to_int32(end_mask),
+      bitset_to_int32(ellipsis_mask), bitset_to_int32(new_axis_mask),
+      bitset_to_int32(shrink_axis_mask), &processing_shape, &final_shape,
+      &is_identity, &is_simple_slice, &slice_dim0, &begin, &end, &strides,
+      &strided_slice_spec));
+
+  VLOG(0) << "ConvertSlice: "
+          << "\n input_shape: " << input_shape
+          << "\n procesing_shape: " << processing_shape
+          << "\n final_shape: " << final_shape
+          << "\n  begin: " << DebugString(begin)
+          << "\n  stride: " << DebugString(strides)
+          << "\n  end: " << DebugString(end)
+          << "\n is identity: " << is_identity
+          << "\n is simple_slice: " << is_simple_slice
+          << "\n slice dim0: " << slice_dim0 << " StridedSliceShapeSpec:"
+          << "\n   begin_dense_mask: "
+          << std::bitset<32>(strided_slice_spec.begin_dense_mask)
+          << "\n   end_dense_mask: "
+          << std::bitset<32>(strided_slice_spec.end_dense_mask)
+          << "\n   shrink_dense_mask: "
+          << std::bitset<32>(strided_slice_spec.shrink_axis_dense_mask);
+
+  // Calcualte the begin, stride, and end parameters to be passed to
+  // ConvertStridedSliceHelper.
+  // auto size = size_weights.GetSpan<int32>();
+  // absl::InlinedVector<int64, 4> stride_v(
+  //     begin.size(), 1);  // The Slice operation always has a stride of 1.
+  // absl::InlinedVector<int64, 4> begin_v;
+  // absl::InlinedVector<int64, 4> end_v;
+  // for (int i = 0; i < input_dims.size(); i++) {
+  //   if (size[i] < 0) {
+  //     if (size[i] == -1) {
+  //       // This case is handled at runtime, see ConvertStridedSliceHelper.
+  //       end_v[i] = 0;
+  //     } else {
+  //       return errors::InvalidArgument("Invalid size value at ",
+  //                                      node_def.name());
+  //     }
+  //   } else {
+  //     if (begin[i] < 0 || begin[i] > input_dims[i]) {
+  //       return errors::InvalidArgument(
+  //           "\"begin\" for dimension ", std::to_string(i), " in ",
+  //           node_def.op(), " is out of range, at ", node_def.name());
+  //     }
+
+  //     const int end = begin[i] + size[i];
+  //     if (end < 0 || end > input_dims[i]) {
+  //       return errors::InvalidArgument(
+  //           "\"begin\" + \"size\" for dimension ", std::to_string(i), " in ",
+  //           node_def.op(), " is out of range, at ", node_def.name());
+  //     }
+  //   }
+  // }
+  return ConvertStridedSliceHelper(params, inputs.at(0), input_shape, begin,
+                                   strides, end, absl::nullopt, absl::nullopt,
+                                   strided_slice_spec);
 }
 
 Status ConvertStridedSlice(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
-  // The TF op allows negative begin/end indices while TRT requires values
-  // within bounds. This is because we use the the default slice mode
-  // (see ISliceLayer::SetMode) with TRT: "Fail with error when the coordinates
-  // are out of bounds". If begin/end tensors have negative values then we map
-  // them to positive vales. The way this is currently implemented requires that
-  // begin / end are constants, therefore we allow only weighs for begin / end.
-  //
-  // The output size is determined by begin, end and strides. For shape tensors
-  // TRT requires that the output size is known at engine construction time. To
-  // reduce complexity of the converter, we also require constant size for non
-  // shape input. This implies that the stride input also have to be a constant
-  // (weights).
+
   TF_RETURN_IF_ERROR(CheckInputsWeights(
       *params,
       {{"input", false}, {"begin", true}, {"end", true}, {"strides", true}}));
   TF_RETURN_IF_ERROR(AllowDataTypes(
       *params, {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}));
 
-  // TODO(tfeher): Enable dynamic shape input.
-  if (!HasStaticShape(inputs.at(0).GetTrtDims())) {
-    return errors::Unimplemented(
-        "Strided slice op not implemented for dynamic shape input");
-  }
   TFAttrs attrs(node_def);
+  const int32 begin_mask = attrs.get<int64>("begin_mask");
+  const int32 end_mask = attrs.get<int64>("end_mask");
+  const int32 ellipsis_mask = attrs.get<int64>("ellipsis_mask");
+  const int32 shrink_axis_mask = attrs.get<int64>("shrink_axis_mask");
+
   // New_axis_mask is not supported. TODO(tfeher): Support this by expanddims.
   const int32 new_axis_mask = attrs.get<int64>("new_axis_mask");
   if (new_axis_mask != 0) {
@@ -2905,14 +2933,11 @@ Status ConvertStridedSlice(OpConverterParams* params) {
         "new_axis_mask is not supported for StridedSlice, at ",
         node_def.name());
   }
-  const int32 begin_mask = attrs.get<int64>("begin_mask");
-  const int32 end_mask = attrs.get<int64>("end_mask");
-  const int32 ellipsis_mask = attrs.get<int64>("ellipsis_mask");
-  const int32 shrink_axis_mask = attrs.get<int64>("shrink_axis_mask");
 
   // Get input dims.
   nvinfer1::Dims dims = inputs.at(0).GetTrtDims();
   std::vector<int64> input_dims(dims.d, dims.d + dims.nbDims);
+
   // Add batch dimension so that indexes line up properly. Set it to -1 if it's
   // unknown, so ValidateStridedSliceOp() can handle it correctly below.
   if (params->use_implicit_batch) {
@@ -2930,15 +2955,6 @@ Status ConvertStridedSlice(OpConverterParams* params) {
         "Length of begin, end, and stride must be equal, at ", node_def.name());
   }
 
-  // The slice op has many ways to define the actual operation that needs to be
-  // performed. We use ValidateStridedSliceOp to map the input parameters to
-  // begin, end, & strides. ValidateStridedSliceOp makes an effort to set known
-  // (static) begin/end/strides parameters. On return, begin, end, stride,
-  // processing_shape has the same rank as input. final_shape has extra dims
-  // added/removed. Negative values in begin/end/stride are converted to
-  // positive values to produce a known processing_shape if the input shape is
-  // static. Otherwise, processing_shape and final_shape may contain unknown
-  // dimension values.
   PartialTensorShape input_shape(input_dims);
   PartialTensorShape processing_shape;
   PartialTensorShape final_shape;
@@ -2948,12 +2964,33 @@ Status ConvertStridedSlice(OpConverterParams* params) {
   absl::InlinedVector<int64, 4> begin;
   absl::InlinedVector<int64, 4> end;
   absl::InlinedVector<int64, 4> strides;
+  StridedSliceShapeSpec strided_slice_spec;
+
   TF_RETURN_IF_ERROR(ValidateStridedSliceOp(
       &begin_weights.GetTensor(), &end_weights.GetTensor(),
       stride_weights.GetTensor(), input_shape, begin_mask, end_mask,
       ellipsis_mask, new_axis_mask, shrink_axis_mask, &processing_shape,
       &final_shape, &is_identity, &is_simple_slice, &slice_dim0, &begin, &end,
-      &strides));
+      &strides, &strided_slice_spec));
+
+  if (!params->validation_only) {
+    VLOG(2) << "After ValidateStridedSliceOp:"
+            << "\n input_shape: " << input_shape
+            << "\n procesing_shape: " << processing_shape
+            << "\n final_shape: " << final_shape
+            << "\n  begin: " << DebugString(begin)
+            << "\n  stride: " << DebugString(strides)
+            << "\n  end: " << DebugString(end)
+            << " is identity: " << is_identity
+            << "\n is simple_slice: " << is_simple_slice
+            << "\n slice dim0: " << slice_dim0 << " StridedSliceShapeSpec:"
+            << "\n   begin_dense_mask: "
+            << std::bitset<32>(strided_slice_spec.begin_dense_mask)
+            << "\n   end_dense_mask: "
+            << std::bitset<32>(strided_slice_spec.end_dense_mask)
+            << "\n   shrink_dense_mask: "
+            << std::bitset<32>(strided_slice_spec.shrink_axis_dense_mask);
+  }
 
   // If batch dimension is covered by the ellipsis mask, it means it's left
   // untouched. Otherwise we check whether it modifies the batch dimension here.
@@ -2978,6 +3015,7 @@ Status ConvertStridedSlice(OpConverterParams* params) {
           node_def.name());
     }
   }
+
   // Can't shrink axis on batch dimension.
   if (params->use_implicit_batch && shrink_axis_mask & 1) {
     return errors::Unimplemented(
@@ -2985,42 +3023,18 @@ Status ConvertStridedSlice(OpConverterParams* params) {
         node_def.name());
   }
 
-  // TRT Slice layer uses (begin, size) instead of (begin, end). We calculate
-  // the size if possible, otherwise we set it to -1.
-  absl::InlinedVector<int64, 4> size(input_dims.size());
-  for (int i = 0; i < input_dims.size(); i++) {
-    if (input_dims[i] < 0) {
-      // Often begin[i] and end[i] could be used to calculate the size.
-      // (Although the presence of begin/end manks make it non-trivial beacues
-      // 0 value might indicate that a mask was used). But the size has to be
-      // clamped to match the array size, for which we need to use the dynamic
-      // version of the helper routines. Therefore we set size to -1,
-      // which will select the dynamic shape helper (to be implemented).
-      size[i] = -1;
-      continue;
-    }
-    // Divide by stride (round up).
-    size[i] = strides[i] > 0
-                  ? (end[i] - begin[i] + strides[i] - 1) / strides[i]
-                  : (begin[i] - end[i] + abs(strides[i]) - 1) / abs(strides[i]);
-    if (size[i] < 0) {
-      return errors::InvalidArgument(
-          "\"size\" cannot be negative for StridedSlice");
-    }
-  }
-
   // shrink_axis_mask requires a reshape after the slice.
-  nvinfer1::Dims final_shape_dims;
-  nvinfer1::Dims* final_shape_dims_ptr = nullptr;
+  absl::optional<nvinfer1::Dims> final_shape_dims = absl::nullopt;
   if (shrink_axis_mask) {
+    final_shape_dims.emplace();
     TF_RETURN_IF_ERROR(TensorShapeToTrtDims(
         final_shape, /*ignore_first_dim=*/params->use_implicit_batch,
-        &final_shape_dims));
-    final_shape_dims_ptr = &final_shape_dims;
+        &*final_shape_dims));
   }
 
-  return ConvertStridedSliceHelper(params, inputs.at(0), begin, size, strides,
-                                   final_shape_dims_ptr, 0);
+  return ConvertStridedSliceHelper(params, inputs.at(0), input_shape, begin,
+                                   strides, end, final_shape_dims, 0,
+                                   strided_slice_spec);
 }
 
 Status ConvertConv2D(OpConverterParams* params) {
@@ -4584,6 +4598,8 @@ Status ConvertSplitHelper(OpConverterParams* params,
   // Slice will begin on zero for all dims, except the one being split which
   // will change.
   std::vector<int> begin(dims.nbDims, 0);
+  std::vector<int64> input_dims(dims.d, dims.d + dims.nbDims);
+
   // Determine size of split. Slice will get the full length of all dims, except
   // the one being split. Undefined dims (-1) will translate to a size of -1
   // which will tell StridedSlice to take full length of that dim.
@@ -4597,23 +4613,25 @@ Status ConvertSplitHelper(OpConverterParams* params,
     begin.insert(begin.begin(), 0);
     size.insert(size.begin(), 1);
     stride.insert(stride.begin(), 1);
+    input_dims.insert(input_dims.begin(), std::max(-1, input.batch_size()));
   }
+  PartialTensorShape input_shape(input_dims);
+
   // Create final shape for Unpack/Unstack, where split axis is squeezed.
-  nvinfer1::Dims final_shape_for_unpack;
-  nvinfer1::Dims* final_shape_for_unpack_ptr = nullptr;
+  absl::optional<nvinfer1::Dims> final_shape_for_unpack = absl::nullopt;
 
   // We can't use final_shape_for_unpack_ptr when input dimensions are not
   // fully defined.
   const bool is_dynamic_shape = !HasStaticShape(dims);
   if (squeeze_after && !is_dynamic_shape) {
+    final_shape_for_unpack.emplace();
     std::vector<int> size_after_squeeze(size);
     const int tf_axis = trt_axis + (params->use_implicit_batch ? 1 : 0);
     size_after_squeeze.erase(size_after_squeeze.begin() + tf_axis);
     TF_RETURN_IF_ERROR(ContainerToTrtDims(size_after_squeeze,
-                                          &final_shape_for_unpack,
+                                          &*final_shape_for_unpack,
                                           /*ignore_first_dim=*/
                                           params->use_implicit_batch));
-    final_shape_for_unpack_ptr = &final_shape_for_unpack;
   }
 
   // Slice the input. ConvertStridedSliceHelper will push the outputs onto
@@ -4621,9 +4639,20 @@ Status ConvertSplitHelper(OpConverterParams* params,
   for (int i = 0; i < num_splits; ++i) {
     const int tf_axis = trt_axis + (params->use_implicit_batch ? 1 : 0);
     begin[tf_axis] = i * split_size_on_axis;
+
+    // Stride is 1 for all dims.
+    absl::InlinedVector<int64, 4> stride_v(begin.size(), 1);
+    absl::InlinedVector<int64, 4> begin_v;
+    absl::InlinedVector<int64, 4> end_v;
+    for (int i = 0; i < begin.size(); i++) {
+      end_v.push_back(begin[i] + size[i]);
+      begin_v.push_back(begin[i]);
+    }
+
     TF_RETURN_IF_ERROR(ConvertStridedSliceHelper(
-        params, input, begin, size, stride, final_shape_for_unpack_ptr,
-        /*op_instance=*/i));
+        params, input, input_shape, begin_v, stride_v, end_v,
+        final_shape_for_unpack,
+        /*op_instance=*/i, /*strided_slice_spec=*/absl::nullopt));
   }
   if (params->validation_only) return Status::OK();
 
@@ -4631,11 +4660,10 @@ Status ConvertSplitHelper(OpConverterParams* params,
   if (squeeze_after && is_dynamic_shape) {
     for (int i = 0; i < params->outputs->size(); i++) {
       ITensorProxyPtr output_tensor = nullptr;
-      std::vector<int> input_dims(dims.d, dims.d + dims.nbDims);
+      std::vector<int> in_dims(dims.d, dims.d + dims.nbDims);
       input_dims[trt_axis] = 0;
       TF_RETURN_IF_ERROR(params->converter->SqueezeTensor(
-          params->outputs->at(i).tensor(), &input_dims, params,
-          &output_tensor));
+          params->outputs->at(i).tensor(), &in_dims, params, &output_tensor));
       (*params->outputs)[i] = TRT_TensorOrWeights(output_tensor);
     }
   }

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -26,14 +26,14 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "absl/algorithm/container.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 #include "tensorflow/cc/ops/nn_ops_internal.h"
@@ -59,6 +59,8 @@ limitations under the License.
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/protobuf/config.pb.h"  // NOLINT
 #include "tensorflow/core/public/session.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/tensorrt/NvInfer.h"
 
 namespace tensorflow {
@@ -3974,7 +3976,7 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
   // Same input is used for all tests.
   const std::vector<float> ok_input = {1, 2, 3, 4, 5, 6};
 
-  Status batch_conv_status =
+  Status modified_batch_dim_status =
       (trt_mode_ == TrtTestMode::kImplicitBatch)
           ? errors::Unimplemented(
                 "TensorRT does not allow modifications to "
@@ -3982,20 +3984,20 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           : Status::OK();
   std::vector<TestParams> params = {
       // Modify batch dim, should fail in implicit batch mode.
-      TestParams{
-          /*input_dims=*/{2, 1, 1, 3},
-          /*begin=*/{0, 0, 0, 0},
-          /*end=*/{1, 1, 1, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({0, 0, 0, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 1, 2},
-          /*expected_output=*/{1, 2},
-          batch_conv_status,
-      },
+      TestParams{/*input_dims=*/{2, 1, 1, 3},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*end=*/{1, 1, 1, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({0, 0, 0, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 1, 2},
+                 /*expected_output=*/{1, 2},
+                 /*conversion_status=*/modified_batch_dim_status,
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{}},
       // Unknown batch size without end_mask.
       TestParams{
           /*input_dims=*/{2, 1, 1, 3},
@@ -4009,11 +4011,11 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*shrink_axis_mask=*/0,
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{1, 2},
-          batch_conv_status,
+          modified_batch_dim_status,
           Status::OK(),
-          {-1, 1, 1, 3},
+          /*partial_input_dims=*/{-1, 1, 1, 3},
       },
-      // Unknown batch size but using end_mask, ok.
+      // Test Case 2: Unknown batch size with end_mask.
       TestParams{
           /*input_dims=*/{2, 1, 1, 3},
           /*begin=*/{0, 0, 0, 0},
@@ -4028,24 +4030,25 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output=*/{1, 2, 4, 5},
           Status::OK(),
           Status::OK(),
-          {-1, 1, 1, 3},
+          /*partial_input_dims=*/{-1, 1, 1, 3},
       },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 2, 0},
-          /*end=*/{1, 1, 0, 3},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/0,
-          /*end_mask=*/0,
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{},
-          /*expected_output=*/{},
-          errors::InvalidArgument("\"size\" cannot be negative for "
-                                  "StridedSlice"),
-      },
-      // 2D Crop.
+      // Invalid parameters: end[2] < begin[2]
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 2, 0},
+                 /*end=*/{1, 1, 0, 3},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/0,
+                 /*end_mask=*/0,
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{},
+                 /*expected_output=*/{},
+                 errors::InvalidArgument("\"size\" cannot be negative for "
+                                         "StridedSlice"),
+                 Status::OK(),
+                 /*partial_input_dims=*/{}},
+      // [Static Input] Support "crop" on the last two dimensions.
       TestParams{
           /*input_dims=*/{1, 1, 2, 3},
           /*begin=*/{0, 0, 0, 0},
@@ -4059,6 +4062,29 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{1, 2},
       },
+      // [Dynamic Input] Test supported "crop" on the last two
+      // dimensions.
+      TestParams{
+          /*input_dims=*/{1, 1, 2, 3},
+          /*begin=*/{0, 0, 0, 0},
+          /*end=*/{0, 0, 1, 2},
+          /*strides=*/{1, 1, 1, 1},
+          /*begin_mask=*/get_mask({0, 0, 0, 0}),
+          /*end_mask=*/get_mask({1, 1, 0, 0}),
+          /*ellipsis_mask=*/0,
+          /*new_axis_mask=*/0,
+          /*shrink_axis_mask=*/0,
+          /*expected_output_dims=*/{1, 1, 1, 2},
+          /*expected_output=*/{1, 2},
+          Status::OK(),
+          Status::OK(),
+          /*partial_input_dims=*/{1, 1, -1, -1},
+      },
+      // End mask is present on all dimensions. This should override the
+      // fact
+      // that we are not providing an end value. For dynamic shape, it
+      // tests
+      // that we can infer tensor size when "end mask" is present.
       TestParams{
           /*input_dims=*/{1, 1, 2, 3},
           /*begin=*/{0, 0, 1, 1},
@@ -4071,7 +4097,11 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*shrink_axis_mask=*/0,
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{5, 6},
+          Status::OK(),
+          Status::OK(),
+          /*partial_input_dims=*/{1, 1, -1, -1},
       },
+      // End mask is present on just the batch dimension.
       TestParams{
           /*input_dims=*/{1, 1, 2, 3},
           /*begin=*/{0, 0, 1, 1},
@@ -4085,60 +4115,73 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{5, 6},
       },
-      // 2D crop with negative stride
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 1, 2},
-          /*end=*/{0, 0, 0, 0},
-          /*strides=*/{1, 1, -1, -1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({1, 1, 0, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 1, 2},
-          /*expected_output=*/{6, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 1, 1},
-          /*end=*/{0, 0, 0, 0},
-          /*strides=*/{1, 1, -1, -1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({1, 1, 1, 1}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 2},
-          /*expected_output=*/{5, 4, 2, 1},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 0},
-          /*end=*/{0, 0, 0, 0},
-          /*strides=*/{1, 1, -1, -1},
-          /*begin_mask=*/get_mask({0, 0, 1, 1}),
-          /*end_mask=*/get_mask({1, 1, 0, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 1, 2},
-          /*expected_output=*/{6, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 0},
-          /*end=*/{0, 0, 0, 0},
-          /*strides=*/{1, -1, -1, -1},
-          /*begin_mask=*/get_mask({1, 1, 1, 1}),
-          /*end_mask=*/get_mask({1, 1, 1, 1}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 3},
-          /*expected_output=*/{6, 5, 4, 3, 2, 1},
-      },
-      // 2D Crop, with transpose.
+      // Test 2D crop with negative stride, without end_mask set on crop
+      // dimensions.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 1, 2},
+                 /*end=*/{0, 0, 0, 0},
+                 /*strides=*/{1, 1, -1, -1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 1, 0, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 1, 2},
+                 /*expected_output=*/{6, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, 1, -1, -1}},
+      // Test 2D crop with negative stride, with end_mask set on crop
+      // dimensions. In dynamic shape mode, this tests the runtime size
+      // computation.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 1, 1},
+                 /*end=*/{0, 0, 0, 0},
+                 /*strides=*/{1, 1, -1, -1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 1, 1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 2},
+                 /*expected_output=*/{5, 4, 2, 1},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, 1, -1, -1}},
+      // Test 2D crop with negative stride, with begin_mask set on the
+      // crop dimensions. In dynamic shape mode, this tests the runtime
+      // size
+      // computation.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*end=*/{0, 0, 0, 0},
+                 /*strides=*/{1, 1, -1, -1},
+                 /*begin_mask=*/get_mask({0, 0, 1, 1}),
+                 /*end_mask=*/get_mask({1, 1, 0, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 1, 2},
+                 /*expected_output=*/{6, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, 1, -1, -1}},
+      // Test the reversal of all non-batch dimensions.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*end=*/{0, 0, 0, 0},
+                 /*strides=*/{1, -1, -1, -1},
+                 /*begin_mask=*/get_mask({1, 1, 1, 1}),
+                 /*end_mask=*/get_mask({1, 1, 1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 3},
+                 /*expected_output=*/{6, 5, 4, 3, 2, 1},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, -1, -1, -1}},
+      // Simple crop on dimensions 1 and 2.
       TestParams{
           /*input_dims=*/{1, 2, 3, 1},
           /*begin=*/{0, 0, 0, 0},
@@ -4152,6 +4195,7 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 2, 1},
           /*expected_output=*/{1, 2},
       },
+      // Simple crop on dimensions 1 and 2.
       TestParams{
           /*input_dims=*/{1, 2, 3, 1},
           /*begin=*/{0, 1, 1, 0},
@@ -4165,6 +4209,7 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 2, 1},
           /*expected_output=*/{5, 6},
       },
+      // Simple crop on dimensions 1 and 3.
       TestParams{
           /*input_dims=*/{1, 2, 1, 3},
           /*begin=*/{0, 0, 0, 0},
@@ -4178,6 +4223,7 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{1, 2},
       },
+      // Simple crop on dimensions 1 and 3 with non-zero slice start.
       TestParams{
           /*input_dims=*/{1, 2, 1, 3},
           /*begin=*/{0, 1, 0, 1},
@@ -4191,7 +4237,7 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 1, 2},
           /*expected_output=*/{5, 6},
       },
-      // 2D Crop, with reshape.
+      // Simple crop on 3D tensor.
       TestParams{
           /*input_dims=*/{1, 2, 3},
           /*begin=*/{0, 0, 0},
@@ -4205,33 +4251,38 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 2},
           /*expected_output=*/{1, 2},
       },
-      TestParams{
-          /*input_dims=*/{1, 2, 3},
-          /*begin=*/{0, 1, 1},
-          /*end=*/{0, 0, 0},
-          /*strides=*/{1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0}),
-          /*end_mask=*/get_mask({1, 1, 1}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2},
-          /*expected_output=*/{5, 6},
-      },
-      // 1D Crop.
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 0},
-          /*end=*/{0, 0, 0, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({1, 1, 1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 2},
-          /*expected_output=*/{1, 2, 4, 5},
-      },
+      // Simple crop on 3D tensor using end_mask. For dynamic shape, all
+      // dimensions are dynamic.
+      TestParams{/*input_dims=*/{1, 2, 3},
+                 /*begin=*/{0, 1, 1},
+                 /*end=*/{0, 0, 0},
+                 /*strides=*/{1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2},
+                 /*expected_output=*/{5, 6},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1}},
+      // Simple crop on 3D tensor using end_mask. For dynamic shape, all
+      // dimensions are dynamic.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*end=*/{0, 0, 0, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 1, 1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 2},
+                 /*expected_output=*/{1, 2, 4, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
       TestParams{
           /*input_dims=*/{1, 1, 2, 3},
           /*begin=*/{0, 0, 1, 0},
@@ -4245,20 +4296,21 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 1, 3},
           /*expected_output=*/{4, 5, 6},
       },
-      // 1D Crop, with transpose.
-      TestParams{
-          /*input_dims=*/{1, 2, 3, 1},
-          /*begin=*/{0, 0, 0, 0},
-          /*end=*/{0, 1, 0, 0},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({1, 0, 1, 1}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 3, 1},
-          /*expected_output=*/{1, 2, 3},
-      },
+      // 1D simple slice.
+      TestParams{/*input_dims=*/{1, 2, 3, 1},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*end=*/{0, 1, 0, 0},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 0, 1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 3, 1},
+                 /*expected_output=*/{1, 2, 3},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
       TestParams{
           /*input_dims=*/{1, 2, 3, 1},
           /*begin=*/{0, 1, 0, 0},
@@ -4272,20 +4324,21 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 3, 1},
           /*expected_output=*/{4, 5, 6},
       },
-      // 1D Crop, with reshape.
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 0},
-          /*end=*/{0, 3},
-          /*strides=*/{1, 1},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{1, 2, 3},
-      },
+      // Simple 1D slice on 2D input.
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 0},
+                 /*end=*/{0, 3},
+                 /*strides=*/{1, 1},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{1, 2, 3},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
       TestParams{
           /*input_dims=*/{1, 1, 6},
           /*begin=*/{0, 0, 2},
@@ -4353,113 +4406,121 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 2, 3},
           /*expected_output=*/{1, 2, 3, 4, 5, 6},
       },
-      // Strides
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 0},
-          /*end=*/{0, 5},
-          /*strides=*/{1, 2},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{1, 3, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 0},
-          /*end=*/{0, 6},
-          /*strides=*/{1, 2},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{1, 3, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 1},
-          /*end=*/{0, 6},
-          /*strides=*/{1, 2},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{2, 4, 6},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 2},
-          /*end=*/{0, 6},
-          /*strides=*/{1, 3},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 2},
-          /*expected_output=*/{3, 6},
-      },
-      // Negative non -1 strides
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 5},
-          /*end=*/{0, 0},
-          /*strides=*/{1, -2},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 1}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{6, 4, 2},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 5},
-          /*end=*/{0, 0},
-          /*strides=*/{1, -2},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 3},
-          /*expected_output=*/{6, 4, 2},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 5},
-          /*end=*/{0, 1},
-          /*strides=*/{1, -3},
-          /*begin_mask=*/get_mask({0, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 2},
-          /*expected_output=*/{6, 3},
-      },
+      // Non-unit strides
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 0},
+                 /*end=*/{0, 5},
+                 /*strides=*/{1, 2},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{1, 3, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 0},
+                 /*end=*/{0, 6},
+                 /*strides=*/{1, 2},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{1, 3, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 1},
+                 /*end=*/{0, 6},
+                 /*strides=*/{1, 2},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{2, 4, 6},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 2},
+                 /*end=*/{0, 6},
+                 /*strides=*/{1, 3},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 2},
+                 /*expected_output=*/{3, 6},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      // Negative non-unit strides
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 5},
+                 /*end=*/{0, 0},
+                 /*strides=*/{1, -2},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{6, 4, 2},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 5},
+                 /*end=*/{0, 0},
+                 /*strides=*/{1, -2},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{6, 4, 2},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 5},
+                 /*end=*/{0, 1},
+                 /*strides=*/{1, -3},
+                 /*begin_mask=*/get_mask({0, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 2},
+                 /*expected_output=*/{6, 3},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1}},
       // ellipsis_mask
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 1},
-          /*end=*/{0, 2},
-          /*strides=*/{1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({0, 0, 0, 0}),
-          /*ellipsis_mask=*/get_mask({1, 0, 0, 0}),
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 1},
-          /*expected_output=*/{2, 5},
-      },
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 1},
+                 /*end=*/{0, 2},
+                 /*strides=*/{1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({0, 0, 0, 0}),
+                 /*ellipsis_mask=*/get_mask({1, 0, 0, 0}),
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 1},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
       TestParams{
           /*input_dims=*/{1, 1, 2, 3},
           /*begin=*/{0, 0, 1},
@@ -4473,107 +4534,130 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
           /*expected_output_dims=*/{1, 1, 2, 1},
           /*expected_output=*/{2, 5},
       },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 1},
-          /*end=*/{0, 1, 2, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({0, 0, 0, 0}),
-          /*ellipsis_mask=*/get_mask({1, 0, 0, 0}),
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 1},
-          /*expected_output=*/{2, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 1},
-          /*end=*/{1, 1, 2, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({0, 0, 0, 0}),
-          /*ellipsis_mask=*/get_mask({0, 1, 0, 0}),
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 1},
-          /*expected_output=*/{2, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 0, 1},
-          /*end=*/{0, 1, 1, 2, 2},
-          /*strides=*/{1, 1, 1, 1, 1},
-          /*begin_mask=*/get_mask({0, 0, 0, 0}),
-          /*end_mask=*/get_mask({0, 0, 0, 0}),
-          /*ellipsis_mask=*/get_mask({1, 0, 0, 0}),
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/0,
-          /*expected_output_dims=*/{1, 1, 2, 1},
-          /*expected_output=*/{2, 5},
-      },
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 1},
+                 /*end=*/{0, 1, 2, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({0, 0, 0, 0}),
+                 /*ellipsis_mask=*/get_mask({1, 0, 0, 0}),
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 1},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 1},
+                 /*end=*/{1, 1, 2, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({0, 0, 0, 0}),
+                 /*ellipsis_mask=*/get_mask({0, 1, 0, 0}),
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 1},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 0, 1},
+                 /*end=*/{0, 1, 1, 2, 2},
+                 /*strides=*/{1, 1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({0, 0, 0, 0}),
+                 /*end_mask=*/get_mask({0, 0, 0, 0}),
+                 /*ellipsis_mask=*/get_mask({1, 0, 0, 0}),
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/0,
+                 /*expected_output_dims=*/{1, 1, 2, 1},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1, -1}},
       // shrink_axis_mask
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 1},
-          /*end=*/{0, 0, 0, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({1, 1, 1, 0}),
-          /*end_mask=*/get_mask({1, 1, 1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/get_mask({0, 0, 0, 1}),
-          /*expected_output_dims=*/{1, 1, 2},
-          /*expected_output=*/{2, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 1, 2, 3},
-          /*begin=*/{0, 0, 0, 1},
-          /*end=*/{0, 1, 2, 2},
-          /*strides=*/{1, 1, 1, 1},
-          /*begin_mask=*/get_mask({1, 0, 0, 0}),
-          /*end_mask=*/get_mask({1, 0, 0, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/get_mask({0, 1, 0, 1}),
-          /*expected_output_dims=*/{1, 2},
-          /*expected_output=*/{2, 5},
-      },
-      TestParams{
-          /*input_dims=*/{1, 6},
-          /*begin=*/{0, 0},
-          /*end=*/{0, 1},
-          /*strides=*/{1, 1},
-          /*begin_mask=*/get_mask({1, 0}),
-          /*end_mask=*/get_mask({1, 0}),
-          /*ellipsis_mask=*/0,
-          /*new_axis_mask=*/0,
-          /*shrink_axis_mask=*/get_mask({0, 1}),
-          /*expected_output_dims=*/{1},
-          /*expected_output=*/{1},
-      },
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 1},
+                 /*end=*/{0, 0, 0, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({1, 1, 1, 0}),
+                 /*end_mask=*/get_mask({1, 1, 1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/get_mask({0, 0, 0, 1}),
+                 /*expected_output_dims=*/{1, 1, 2},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, 1, 2, -1}},
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*begin=*/{0, 0, 0, 1},
+                 /*end=*/{0, 1, 2, 2},
+                 /*strides=*/{1, 1, 1, 1},
+                 /*begin_mask=*/get_mask({1, 0, 0, 0}),
+                 /*end_mask=*/get_mask({1, 0, 0, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/get_mask({0, 1, 0, 1}),
+                 /*expected_output_dims=*/{1, 2},
+                 /*expected_output=*/{2, 5},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, 1, 2, -1}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*begin=*/{0, 0},
+                 /*end=*/{0, 1},
+                 /*strides=*/{1, 1},
+                 /*begin_mask=*/get_mask({1, 0}),
+                 /*end_mask=*/get_mask({1, 0}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/get_mask({0, 1}),
+                 /*expected_output_dims=*/{1},
+                 /*expected_output=*/{1},
+                 /*conversion_status=*/Status::OK(),
+                 /*runtime_status=*/Status::OK(),
+                 /*partial_input_dims=*/{1, -1}},
   };
 
+  int i = 0;
   for (auto p : params) {
-    if (trt_mode_ == TrtTestMode::kDynamicShape ||
-        (trt_mode_ == TrtTestMode::kExplicitBatch &&
-         !HasStaticShape(p.partial_input_dims))) {
-      p.conversion_status = errors::Unimplemented(
-          "Strided slice op not implemented for dynamic shape input");
-    }
     Reset();
     NodeDef node_def = get_strided_slice_nodedef(
         tf_type_, p.begin_mask, p.end_mask, p.ellipsis_mask, p.new_axis_mask,
         p.shrink_axis_mask);
 
-    VLOG(2) << "Preparing test case with dims " << DebugString(p.input_dims);
-    if (p.partial_input_dims.empty()) {
-      AddTestTensor("input", p.input_dims, ok_input);
-    } else {
-      AddTestTensor("input", p.input_dims, tf_type_, ok_input,
-                    p.partial_input_dims);
+    VLOG(0) << "Preparing test case " << i++ << " with dims "
+            << DebugString(p.input_dims);
+
+    switch (trt_mode_) {
+      case TrtTestMode::kImplicitBatch: {
+        AddTestTensor("input", p.input_dims, ok_input);
+        break;
+      }
+      case TrtTestMode::kExplicitBatch: {
+        AddTestTensor("input", p.input_dims, ok_input);
+        break;
+      }
+      case TrtTestMode::kDynamicShape: {
+        if (p.partial_input_dims.size() > 0) {
+          AddTestTensor("input", p.input_dims, tf_type_, ok_input,
+                        p.partial_input_dims);
+
+        } else {
+          AddTestTensor("input", p.input_dims, tf_type_, ok_input,
+                        p.input_dims);
+        }
+        break;
+      }
+      default: {
+        ASSERT_TRUE(false) << absl::StrFormat(
+            "unhandled TensorRT test mode: %d", trt_mode_);
+      }
     }
-    VLOG(2) << "Adding weights begin: " << DebugString(p.begin)
+
+    VLOG(0) << "Adding weights begin: " << DebugString(p.begin)
             << ", end: " << DebugString(p.end)
             << ", strides: " << DebugString(p.strides);
     AddTestWeights<int32>("begin", {static_cast<int>(p.begin.size())}, p.begin);
@@ -4600,6 +4684,8 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertSlice) {
 
   struct TestParams {
     std::vector<int> input_dims;
+    std::vector<int>
+        partial_input_dims;  // Symbolic shape in dynamic shape mode.
     std::vector<int> begin;
     std::vector<int> size;
     std::vector<int> expected_output_dims;
@@ -4608,90 +4694,77 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertSlice) {
     Status runtime_status;
   };
 
-  Status conv_dynamic =
-      trt_mode_ == TrtTestMode::kDynamicShape
-          ? errors::Unimplemented(
-                "Strided slice op not implemented for dynamic shape input")
-          : Status::OK();
-  Status conv_dynamic2 =
-      trt_mode_ == TrtTestMode::kDynamicShape
-          ? errors::Unimplemented(
-                "Input dims must be defined for size = -1, at my_slice")
-          : Status::OK();
   std::vector<TestParams> params = {
-      // Begin is below bounds, should fail.
-      TestParams{
-          {1, 1, 2, 3},
-          {0, 0, -1, 0},
-          {1, 1, 2, 3},
-          {},
-          {},
-          trt_mode_ == TrtTestMode::kDynamicShape
-              ? conv_dynamic
-              : errors::InvalidArgument("\"begin\" for dimension 2 in Slice "
-                                        "is out of range, at my_slice")},
-      // Batch dimension is modified, should fail in implicit batch mode.
-      TestParams{
-          {2, 1, 1, 3},
-          {0, 0, 0, 0},
-          {1, 1, 1, 3},
-          {1, 1, 1, 3},
-          {1, 2, 3},
-          trt_mode_ == TrtTestMode::kImplicitBatch
-              ? errors::Unimplemented("TensorRT does not allow modifications"
-                                      " to the batch dimension, at my_slice")
-              : Status::OK()},
+      // Slice start points must always be >= 0.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
+                 /*begin=*/{0, 0, -1, 0},
+                 /*size=*/{1, 1, 2, 3},
+                 /*expected_output_dims=*/{},
+                 /*expected_output=*/{},
+                 /*conversion_status=*/
+                 errors::InvalidArgument("\"begin\" in Slice "
+                                         "is out of range, at my_slice")},
+      // In implicit batch mode, slicing the batch dimension is not allowed.
+      TestParams{/*input_dims=*/{2, 1, 1, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*size=*/{1, 1, 1, 3},
+                 /*expected_output_dims=*/{1, 1, 1, 3},
+                 /*expected_output=*/{1, 2, 3},
+                 /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+                     ? errors::Unimplemented(
+                           "TensorRT does not allow modifications to the batch "
+                           "dimension in implicit batch mode")
+                     : Status::OK()},
       // Dynamic batch size but using size[0] of -1, ok.
       TestParams{{1, 1, 2, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
                  {0, 0, 0, 0},
                  {-1, 1, 2, 2},
                  {1, 1, 2, 2},
                  {1, 2, 4, 5},
-                 conv_dynamic2},
+                 Status::OK()},
       // OK test: but converter fails in dynamic shape mode
       TestParams{{1, 1, 2, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
                  {0, 0, 0, 0},
                  {-1, -1, -1, -1},
                  {1, 1, 2, 3},
                  {1, 2, 3, 4, 5, 6},
-                 conv_dynamic2},
+                 Status::OK()},
       TestParams{{1, 1, 2, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
                  {0, 0, 0, 0},
                  {1, 1, 2, 3},
                  {1, 1, 2, 3},
                  {1, 2, 3, 4, 5, 6}},
       TestParams{{1, 1, 2, 3},
-                 {0, 0, 0, 0},
-                 {1, -1, 2, 2},
-                 {1, 1, 2, 2},
-                 {1, 2, 4, 5},
-                 conv_dynamic2},
-      TestParams{{1, 6}, {0, 1}, {1, 5}, {1, 5}, {2, 3, 4, 5, 6}},
-      TestParams{{1, 6}, {0, 1}, {-1, 3}, {1, 3}, {2, 3, 4}, conv_dynamic2},
-      //
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*size=*/{1, -1, 2, 2},
+                 /*expected_output_dims=*/{1, 1, 2, 2},
+                 /*expected_output=*/{1, 2, 4, 5},
+                 Status::OK()},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*partial_input_dims=*/{-1, -1},
+                 /*being=*/{0, 1},
+                 /*size=*/{1, 5},
+                 /*expected_output_dims=*/{1, 5},
+                 /*expected_output=*/{2, 3, 4, 5, 6}},
+      TestParams{/*input_dims=*/{1, 6},
+                 /*partial_input_dims=*/{-1, -1},
+                 /*begin=*/{0, 1},
+                 /*size=*/{-1, 3},
+                 /*expected_output_dims=*/{1, 3},
+                 /*expected_output=*/{2, 3, 4}, Status::OK()},
       // In dynamic shape mode we do not know the input shape during
       // conversion, therfore we cannot check out of bound access.
       TestParams{
           {1, 1, 2, 3},
-          {0, 0, 3, 0},
-          {1, 1, 2, 3},
-          {},
-          {},
-          trt_mode_ == TrtTestMode::kDynamicShape
-              ? Status::OK()
-              : errors::InvalidArgument("\"begin\" for dimension 2 in Slice "
-                                        "is out of range, at my_slice"),
-          errors::Internal("Internal: Failed to build TensorRT engine")},
-      TestParams{{1, 1, 2, 3},
-                 {0, 0, 0, 0},
-                 {1, 1, 2, -2},
-                 {},
-                 {},
-                 errors::InvalidArgument("Invalid size value at my_slice")},
-      TestParams{
-          {1, 1, 2, 3},
-          {0, 0, 0, 0},
-          {1, 1, 3, 2},
+          /*partial_input_dims=*/{-1, -1, -1, -1},
+          /*begin=*/{0, 0, 3, 0},
+          /*end=*/{1, 1, 2, 3},
           {},
           {},
           trt_mode_ == TrtTestMode::kDynamicShape
@@ -4700,12 +4773,68 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertSlice) {
                                         "2 in Slice is out of range, at "
                                         "my_slice"),
           errors::Internal("Internal: Failed to build TensorRT engine")},
+      // The slice operation should expect that the "size[i]" values are not
+      // less than -1.
+      TestParams{/*input_dims=*/{1, 1, 2, 3},
+                 /*partial_input_dims=*/{-1, -1, -1, -1},
+                 /*begin=*/{0, 0, 0, 0},
+                 /*size=*/{1, 1, 2, -2},
+                 {},
+                 {},
+                 errors::InvalidArgument(
+                     "\"size\" in Slice is out of range, at my_slice")},
+      TestParams{
+          /*input_dims=*/{1, 1, 2, 3},
+          /*partial_input_dims=*/{-1, -1, -1, -1},
+          /*begin=*/{0, 0, 0, 0},
+          /*size=*/{1, 1, 3, 2},
+          /*expected_output_dims=*/{},
+          /*expected_output=*/{},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kDynamicShape
+              ? Status::OK()
+              : errors::InvalidArgument("\"begin\" + \"size\" for dimension "
+                                        "2 in Slice is out of range, at "
+                                        "my_slice"),
+          errors::Internal("Internal: Failed to build TensorRT engine")},
   };
 
+  int i = 0;
   for (auto p : params) {
     Reset();
     NodeDef node_def = get_slice_nodedef(tf_type_);
-    AddTestTensor("input", p.input_dims, {1, 2, 3, 4, 5, 6});
+
+    VLOG(0) << "Preparing test case " << i++ << " with dims "
+            << DebugString(p.input_dims);
+
+    // The input tensor always has size 6.
+    std::vector<int> input_vals = {1, 2, 3, 4, 5, 6};
+
+    switch (trt_mode_) {
+      case TrtTestMode::kImplicitBatch: {
+        AddTestTensor("input", p.input_dims, input_vals);
+        break;
+      }
+      case TrtTestMode::kExplicitBatch: {
+        AddTestTensor("input", p.input_dims, input_vals);
+        break;
+      }
+      case TrtTestMode::kDynamicShape: {
+        if (p.partial_input_dims.size() > 0) {
+          AddTestTensor("input", p.input_dims, tf_type_, input_vals,
+                        p.partial_input_dims);
+
+        } else {
+          AddTestTensor("input", p.input_dims, tf_type_, input_vals,
+                        p.input_dims);
+        }
+        break;
+      }
+      default: {
+        ASSERT_TRUE(false) << absl::StrFormat(
+            "unhandled TensorRT test mode: %d", trt_mode_);
+      }
+    }
+
     AddTestWeights<int32>("begin", {static_cast<int>(p.begin.size())}, p.begin);
     AddTestWeights<int32>("size", {static_cast<int>(p.size.size())}, p.size);
 
@@ -6593,11 +6722,11 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertUnpack) {
 
   const std::vector<float> common_input = InitTestVector<float>(6);
 
-  Status run_status = trt_mode_ == TrtTestMode::kDynamicShape
-                          ? errors::Unimplemented(
-                                "Strided slice op not implemented for dynamic "
-                                "shape input")
-                          : Status::OK();
+  Status run_status =
+      trt_mode_ == TrtTestMode::kDynamicShape
+          ? errors::InvalidArgument(
+                "must have statically defined dimensions, at my_unpack")
+          : Status::OK();
 
   std::vector<UnpackTestParams> params = {
       {/*input_shape=*/{1, 1, 2, 1, 3, 1},

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h
@@ -1,0 +1,351 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_LAYER_UTILS_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_LAYER_UTILS_H_
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include <type_traits>
+
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/platform/statusor.h"
+#include "third_party/tensorrt/NvInfer.h"
+#include "third_party/tensorrt/NvInferRuntimeCommon.h"
+
+namespace tensorflow {
+namespace tensorrt {
+
+namespace convert {
+
+class NetworkFactoryContext {
+ public:
+  NetworkFactoryContext(nvinfer1::INetworkDefinition* network,
+                        TrtWeightStore* weight_store)
+      : network_(network), weight_store_(weight_store) {}
+
+  template <typename T, typename std::enable_if<std::is_base_of<
+                            nvinfer1::ILayer, T>::value>::type* = nullptr>
+  struct CreationResult {
+    T* layer;
+    nvinfer1::ITensor* output;
+  };
+
+  // Adds an Add operation to the network.
+  StatusOr<CreationResult<nvinfer1::IElementWiseLayer>> Add(
+      nvinfer1::ITensor* lhs, nvinfer1::ITensor* rhs) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(lhs);
+    TRT_EXPECT(rhs);
+    auto layer = network_->addElementWise(*lhs, *rhs,
+                                          nvinfer1::ElementWiseOperation::kSUM);
+    return MakeResult(layer);
+  };
+
+  // Adds an Add operation to the network. Note that this unary operations will
+  // do an implict float conversion.
+  StatusOr<CreationResult<nvinfer1::IUnaryLayer>> Abs(
+      nvinfer1::ITensor* input) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(input);
+    auto layer = network_->addUnary(*input, nvinfer1::UnaryOperation::kABS);
+    return MakeResult(layer);
+  }
+
+  // Performs Abs without implict float conversion.
+  StatusOr<CreationResult<nvinfer1::IElementWiseLayer>> AbsInt(
+      nvinfer1::ITensor* input) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(input);
+    auto sign = this->Sign(input);
+    TRT_ENSURE_OK(sign);
+    return this->Mul(input, sign->output);
+  }
+
+  // Returns elementwise sign(x) operation.
+  StatusOr<CreationResult<nvinfer1::ISelectLayer>> Sign(
+      nvinfer1::ITensor* input) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(input);
+    auto zero = this->Constant<int32>(0, input->getDimensions().nbDims);
+    TRT_ENSURE_OK(zero);
+    auto positive_mask = this->Greater(input, zero->output);
+    TRT_ENSURE_OK(positive_mask);
+    auto pos_one = this->Constant<int32>(1, input->getDimensions().nbDims);
+    TRT_ENSURE_OK(pos_one);
+    auto neg_one = this->Constant<int32>(-1, input->getDimensions().nbDims);
+    TRT_ENSURE_OK(neg_one);
+    return Where(positive_mask->output, pos_one->output, neg_one->output);
+  }
+
+  // Adds an Add operation to the network.
+  StatusOr<CreationResult<nvinfer1::IElementWiseLayer>> Sub(
+      nvinfer1::ITensor* lhs, nvinfer1::ITensor* rhs) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(lhs);
+    TRT_EXPECT(rhs);
+    auto layer = network_->addElementWise(*lhs, *rhs,
+                                          nvinfer1::ElementWiseOperation::kSUB);
+    return MakeResult(layer);
+  }
+
+  // Adds an Greater operation to the network.
+  StatusOr<CreationResult<nvinfer1::IElementWiseLayer>> Greater(
+      nvinfer1::ITensor* lhs, nvinfer1::ITensor* rhs) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(lhs);
+    TRT_EXPECT(rhs);
+    auto layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kGREATER);
+    return MakeResult(layer);
+  }
+
+  // Adds an Equal operation to the network.
+  StatusOr<CreationResult<nvinfer1::IElementWiseLayer>> Equal(
+      nvinfer1::ITensor* lhs, nvinfer1::ITensor* rhs) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(lhs);
+    TRT_EXPECT(rhs);
+    auto layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kEQUAL);
+    return MakeResult(layer);
+  }
+
+  // Simulates the creation of a tensor of the same shape as "input", but filled
+  // with 0's where "input" is non-zero. TensorRT doesn't have dynamic creation
+  // functions, so this function multiplies the input by a zero value to side
+  // step knowing the shape. For static inputs, this can be optimized using one
+  // of the NetworkFactoryContext::Constant function instead.
+  StatusOr<CreationResult<nvinfer1::IElementWiseLayer>> ZerosLikeDyamic(
+      nvinfer1::ITensor* input) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(input);
+    // TODO: add switch statement
+    auto zero = this->Constant<int32>(0, input->getDimensions().nbDims);
+    TRT_ENSURE_OK(zero);
+    return Mul(input, zero->output);
+  }
+
+  // Adds an Add operation to the network.
+  StatusOr<CreationResult<nvinfer1::IElementWiseLayer>> FloorDiv(
+      nvinfer1::ITensor* lhs, nvinfer1::ITensor* rhs) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(lhs);
+    TRT_EXPECT(rhs);
+    auto layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kFLOOR_DIV);
+    return MakeResult(layer);
+  }
+
+  // Abs(Ceiling divide(x/y)) operation for integers
+  StatusOr<CreationResult<nvinfer1::IElementWiseLayer>> AbsCeilDivInt(
+      nvinfer1::ITensor* lhs, nvinfer1::ITensor* rhs) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(lhs);
+    TRT_EXPECT(rhs);
+    auto rhs_abs = this->AbsInt(rhs);
+    TRT_ENSURE_OK(rhs_abs);
+    auto lhs_abs = this->AbsInt(lhs);
+    TRT_ENSURE_OK(lhs_abs);
+    auto add1 = this->Add(lhs_abs->output, rhs_abs->output);
+    TRT_ENSURE_OK(add1);
+    auto one_const = this->Constant<int32>(1, rhs->getDimensions().nbDims);
+    TRT_ENSURE_OK(one_const);
+    auto numerator = this->Sub(add1->output, one_const->output);
+    TRT_ENSURE_OK(numerator);
+    return FloorDiv(numerator->output, rhs_abs->output);
+  }
+
+  // Adds an operation whose output is equal to "true_values" where the
+  // corresponding value in the "bool_condition" tensor is true, otherwise the
+  // output has the corresponding value from "false_values". In TensorRT this is
+  // called "ISelectLayer", but to conform with Tensorflow naming, we use
+  // "where" here.
+  StatusOr<CreationResult<nvinfer1::ISelectLayer>> Where(
+      nvinfer1::ITensor* bool_condition, nvinfer1::ITensor* true_values,
+      nvinfer1::ITensor* false_values) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(bool_condition);
+    TRT_EXPECT(true_values);
+    TRT_EXPECT(false_values);
+    auto layer =
+        network_->addSelect(*bool_condition, *true_values, *false_values);
+    return MakeResult(layer);
+  }
+
+  // Simulates the creation of a tensor of the same shape as "input", but filled
+  // with 1's of type int32 where "input" is non-zero, otherwise it is zero.
+  // TensorRT doesn't have a "cast" operation, so this simulates with a
+  // "select/where" operation.
+  StatusOr<CreationResult<nvinfer1::ISelectLayer>> NonZeroInt(
+      nvinfer1::ITensor* input) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(input);
+    auto zeros = this->Constant<int32>(0, input->getDimensions().nbDims);
+    TRT_ENSURE_OK(zeros);
+    auto ones = this->Constant<int32>(1, input->getDimensions().nbDims);
+    TRT_ENSURE_OK(ones);
+    auto equal_to_zero_mask = this->Equal(input, zeros->output);
+    TRT_ENSURE_OK(equal_to_zero_mask);
+    return this->Where(equal_to_zero_mask->output, input, ones->output);
+  }
+
+  // Adds an elementwise multiplication operation to the network.
+  StatusOr<CreationResult<nvinfer1::IElementWiseLayer>> Mul(
+      nvinfer1::ITensor* lhs, nvinfer1::ITensor* rhs) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(lhs);
+    TRT_EXPECT(rhs);
+    auto layer = network_->addElementWise(
+        *lhs, *rhs, nvinfer1::ElementWiseOperation::kPROD);
+    return MakeResult(layer);
+  }
+
+  // Adds a Constant layer whose output is a TensorRT shape tensor. The shape
+  // tensor's size and values correspond to dim's nbDims and d[], respectively.
+  StatusOr<CreationResult<nvinfer1::IConstantLayer>> Constant(
+      const nvinfer1::Dims& shape_data) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(shape_data.nbDims > 0);
+    nvinfer1::Dims shape_dims;
+    shape_dims.nbDims = 1;
+    shape_dims.d[0] = shape_data.nbDims;
+    auto const_weights =
+        weight_store_->GetTempWeights(nvinfer1::DataType::kINT32, shape_dims);
+    auto values = const_weights.GetPointer<int32>();
+    for (int i = 0; i < shape_data.nbDims; i++) {
+      values[i] = static_cast<int32>(shape_data.d[i]);
+    }
+    auto const_layer = network_->addConstant(const_weights.shape_,
+                                             const_weights.GetTrtWeights());
+    TRT_ENSURE(const_layer);
+    auto output = const_layer->getOutput(0);
+    TRT_ENSURE(output);
+    TRT_ENSURE(output->getType() == nvinfer1::DataType::kINT32);
+    return MakeResult(const_layer);
+  }
+
+  // Adds a Constant layer composed of a single layer
+  template <typename T,
+            typename std::enable_if<std::is_pod<T>::value>::type* = nullptr>
+  StatusOr<CreationResult<nvinfer1::IConstantLayer>> Constant(
+      const T scalar, const int nb_dims) noexcept {
+    TRT_EXPECT(network_);
+    TRT_EXPECT(nb_dims <= nvinfer1::Dims::MAX_DIMS);
+    auto data_type = nvinfer1::DataType::kINT32;
+    if (std::is_floating_point<T>::value) {
+      data_type = nvinfer1::DataType::kFLOAT;
+    }
+    nvinfer1::Dims zero_shape;
+    zero_shape.nbDims = nb_dims;
+    std::fill_n(zero_shape.d, nb_dims, 1);
+    auto const_weights = weight_store_->GetTempWeights(data_type, zero_shape);
+    const_weights.GetPointer<T>()[0] = scalar;
+    auto const_layer =
+        network_->addConstant(zero_shape, const_weights.GetTrtWeights());
+    return MakeResult(const_layer);
+  };
+
+  // Adds a TensorRT Slice operation to the network.
+  StatusOr<CreationResult<nvinfer1::ISliceLayer>> Slice(
+      nvinfer1::ITensor* input, const nvinfer1::Dims& begin,
+      const nvinfer1::Dims& size, const nvinfer1::Dims& stride) noexcept {
+    TRT_EXPECT(network_);
+    nvinfer1::ISliceLayer* layer =
+        network_->addSlice(*input, begin, size, stride);
+    return MakeResult(layer);
+  }
+
+  // Adds a TensorRT Shape operation, which determines the runtime shape of the
+  // input tensor, to the network.
+  StatusOr<CreationResult<nvinfer1::IShapeLayer>> Shape(
+      nvinfer1::ITensor* input) {
+    TRT_EXPECT(input);
+    TRT_EXPECT(network_);
+    return MakeResult(network_->addShape(*input));
+  }
+
+  // Creates a Gather operation on the shape of the input tensor. The output of
+  // the gather operation is a shape tensor of the same size as the input's
+  // shape tensor. The output consists of all zeros except at the specified
+  // indices, where it is equal to the given input tensor's shape in the
+  // corresponding dimension.
+  StatusOr<CreationResult<nvinfer1::IGatherLayer>> GetPartialShapeOf(
+      nvinfer1::ITensor* input, absl::InlinedVector<int64, 4> indices) {
+    TRT_EXPECT(input);
+    TRT_EXPECT(network_);
+    TRT_EXPECT(indices.size() <= nvinfer1::Dims::MAX_DIMS);
+
+    // Get the runtime shape of input;
+    auto shape_layer = this->Shape(input);
+    TRT_ENSURE_OK(shape_layer);
+    auto runtime_shape = shape_layer->output;
+
+    // Create a constant tensor containing the gather indices.
+    // For any dim not in "indices", we mark it size to gather a zero.
+    const auto input_nb_dims = input->getDimensions().nbDims;
+    nvinfer1::Dims indices_as_dims;
+    indices_as_dims.nbDims = input_nb_dims;
+    std::fill_n(indices_as_dims.d, input_nb_dims, input_nb_dims);
+    for (auto idx : indices) {
+      TRT_EXPECT(idx < input_nb_dims);
+      indices_as_dims.d[idx] = idx;
+    }
+    auto indices_result = this->Constant(indices_as_dims);
+    TRT_ENSURE_OK(indices_result);
+    auto gather_indices = indices_result->output;
+    TRT_ENSURE(gather_indices->getDimensions().nbDims == 1);
+    TRT_ENSURE(gather_indices->getType() == nvinfer1::DataType::kINT32);
+
+    // Append a zero to the shape tensor.
+    nvinfer1::Dims zero = {1, {0}};
+    auto zero_result = this->Constant(zero);
+    TRT_ENSURE_OK(zero_result);
+    std::array<nvinfer1::ITensor*, 2> cat_inputs = {runtime_shape,
+                                                    zero_result->output};
+    auto cat_layer =
+        network_->addConcatenation(cat_inputs.data(), cat_inputs.size());
+    TRT_ENSURE(cat_layer);
+    auto gather_input = cat_layer->getOutput(0);
+    TRT_ENSURE(gather_input);
+
+    // Finally, gather the indices from
+    auto gather = network_->addGather(*gather_input, *gather_indices, 0);
+    TRT_ENSURE(gather);
+    return MakeResult(gather);
+  };
+
+ private:
+  // Creates a CreationResult<T>. This helper can use type deduction to simplify
+  // the act of returning a CreationResult<T>.
+  template <typename T>
+  StatusOr<CreationResult<T>> MakeResult(T* layer) {
+    TRT_EXPECT(layer);
+    auto tensor = layer->getOutput(0);
+    TRT_EXPECT(tensor);
+    return CreationResult<T>{layer, tensor};
+  }
+
+ private:
+  nvinfer1::INetworkDefinition* network_;
+  TrtWeightStore* weight_store_;
+};
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_LAYER_UTILS_H_

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.cc
@@ -1,0 +1,212 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.h"
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include <bitset>
+#include <vector>
+
+#include "absl/container/inlined_vector.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
+#include "absl/types/span.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_tensor_proxy.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/util/strided_slice_op.h"
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+Status ConvertStridedSliceHelper(
+    OpConverterParams* params, const TRT_TensorOrWeights& input,
+    const PartialTensorShape& input_dims, const SliceDims& begin,
+    const SliceDims& stride, const SliceDims& end,
+    absl::optional<nvinfer1::Dims> final_shape, absl::optional<int> op_instance,
+    absl::optional<StridedSliceShapeSpec> strided_slice_spec) {
+  const auto& node_def = params->node_def;
+
+  nvinfer1::Dims begin_dims, stride_dims, end_dims;
+  TF_RETURN_IF_ERROR(
+      ContainerToTrtDims(begin, &begin_dims, params->use_implicit_batch));
+  TF_RETURN_IF_ERROR(
+      ContainerToTrtDims(stride, &stride_dims, params->use_implicit_batch));
+  TF_RETURN_IF_ERROR(
+      ContainerToTrtDims(end, &end_dims, params->use_implicit_batch));
+
+  // Try to calculate size dimensions. In the implict batch case, not having
+  // static slice size is an error.
+  nvinfer1::Dims size_dims = begin_dims;
+  absl::InlinedVector<int64, 4> static_input_size_indices;
+  absl::InlinedVector<int64, 4> dynamic_input_size_indices;
+  for (int i = 0; i < begin_dims.nbDims; i++) {
+    size_dims.d[i] = (std::abs(end_dims.d[i] - begin_dims.d[i]) +
+                      std::abs(stride_dims.d[i]) - 1) /
+                     std::abs(stride_dims.d[i]);
+
+    if (input_dims.dim_size(i) < 0) {
+      // In this case, ValidateStridedSliceOp did not appropriate set the begin
+      // and end dims. We need to calculate based on the masks below.
+      dynamic_input_size_indices.push_back(i);
+    } else {
+      static_input_size_indices.push_back(i);
+      if (end_dims.d[i] < begin_dims.d[i] && stride_dims.d[i] > 0) {
+        return errors::InvalidArgument(
+            "\"size\" cannot be negative for StridedSlice");
+      }
+    }
+  }
+
+  if (params->validation_only) return Status::OK();
+
+  NetworkFactoryContext ctx(params->converter->network(), params->weight_store);
+
+  VLOG(2) << "strided slice helper:"
+          << " begin:" << DebugString(begin_dims)
+          << "\n stride: " << DebugString(stride_dims)
+          << "\n end: " << DebugString(end_dims)
+          << "\n size: " << DebugString(size_dims)
+          << "\n Dynamic indices: " << DebugString(dynamic_input_size_indices)
+          << "\n Static indices: " << DebugString(static_input_size_indices);
+
+  // Create the slice operation. This is all that is required in the case of
+  // static dims, but for dynamic dims, we override these paramters below by
+  // assigning inputs to the returned layer.
+  auto slice = ctx.Slice(input.tensor()->trt_tensor(), begin_dims, size_dims,
+                         stride_dims);
+
+  if (!dynamic_input_size_indices.empty()) {
+    // Require strided slice spec when dynamic shape is present.
+    TRT_EXPECT(strided_slice_spec != absl::nullopt);
+
+    if (params->use_implicit_batch) {
+      return errors::InvalidArgument(
+          "In implicit batch mode, dynamic input size is not supported.");
+    }
+
+    // Check if any of our dynamic indices has begin/end mask.
+    absl::InlinedVector<int64, 4> dynamic_begin_indices;
+    absl::InlinedVector<int64, 4> dynamic_end_indices;
+    const auto begin_mask =
+        std::bitset<32>(strided_slice_spec->begin_dense_mask);
+    const auto end_mask = std::bitset<32>(strided_slice_spec->end_dense_mask);
+    for (int i = 0; i < dynamic_input_size_indices.size(); i++) {
+      auto dynamic_idx = dynamic_input_size_indices[i];
+      // When stride is negative:
+      // - If "begin_mask[dynamic_idx]" is set, then we need to adjust the slice
+      // start of dimension[i] to the dynamic size.
+      // - If "end_mask[dynamic_idx]" is set, it suffices to set
+      // end_dims[dynamic_idx] to -1.
+      // When stride is positive:
+      // - If "begin_mask[dynamic_idx]" is set, it suffices to set
+      // begin_dims[dynamic_idx] to zero.
+      // - If "end_mask[dynamic_idx]" is set, we need to adjust slice end to the
+      // dynamic size of dimension "dynamic_idx".
+      if (begin_mask[dynamic_idx]) {
+        // DLOG("begin_dims->d[" << dynamic_idx << "] = 0");
+        begin_dims.d[dynamic_idx] = 0;
+        if (stride_dims.d[dynamic_idx] < 0) {
+          dynamic_begin_indices.push_back(dynamic_idx);
+        }
+      }
+      if (end_mask[dynamic_idx]) {
+        end_dims.d[dynamic_idx] = stride_dims.d[dynamic_idx] > 0 ? 0 : -1;
+        if (stride_dims.d[dynamic_idx] > 0) {
+          dynamic_end_indices.push_back(dynamic_idx);
+        }
+      }
+    }
+
+    VLOG(2) << " Dynamic begin indices: " << DebugString(dynamic_begin_indices)
+            << " Dynamic end indices: " << DebugString(dynamic_end_indices);
+
+    // Create ITensors for each of the begin/stride/end constants.
+    auto begin_const = ctx.Constant(begin_dims);
+    TRT_ENSURE_OK(begin_const);
+    nvinfer1::ITensor* begin_tensor = begin_const->output;
+    auto stride_const = ctx.Constant(stride_dims);
+    TRT_ENSURE_OK(stride_const);
+    auto end_const = ctx.Constant(end_dims);
+    TRT_ENSURE_OK(end_const);
+    nvinfer1::ITensor* end_tensor = end_const->output;
+
+    // Make corrections based on the begin_mask/end_mask values.
+    if (dynamic_end_indices.size() > 0) {
+      auto dynamic_end_masked_tensor = ctx.GetPartialShapeOf(
+          input.tensor()->trt_tensor(), dynamic_end_indices);
+      TRT_ENSURE_OK(dynamic_end_masked_tensor);
+      auto end_corrected =
+          ctx.Add(dynamic_end_masked_tensor->output, end_tensor);
+      TRT_ENSURE_OK(end_corrected);
+      end_tensor = end_corrected->output;
+    }
+    if (dynamic_begin_indices.size() > 0) {
+      auto dynamic_begin_masked_tensor = ctx.GetPartialShapeOf(
+          input.tensor()->trt_tensor(), dynamic_begin_indices);
+      TRT_ENSURE_OK(dynamic_begin_masked_tensor);
+      // We need to subtract one from the size in order to get a valid index.
+      auto nonzero_mask = ctx.NonZeroInt(dynamic_begin_masked_tensor->output);
+      TRT_ENSURE_OK(nonzero_mask);
+      auto sub_one =
+          ctx.Sub(dynamic_begin_masked_tensor->output, nonzero_mask->output);
+      TRT_ENSURE_OK(sub_one)
+      auto begin_corrected = ctx.Add(sub_one->output, begin_tensor);
+      TRT_ENSURE_OK(begin_corrected);
+      begin_tensor = begin_corrected->output;
+    }
+
+    // Calculate the final size of the slice dynamicly.
+    nvinfer1::ITensor* size_tensor;
+    {
+      auto num = ctx.Sub(end_tensor, begin_tensor);
+      TRT_ENSURE_OK(num);
+      auto ceil_div = ctx.AbsCeilDivInt(num->output, stride_const->output);
+      TRT_ENSURE_OK(ceil_div);
+      size_tensor = ceil_div->output;
+    }
+
+    TRT_ENSURE_OK(slice);
+    nvinfer1::ITensor* trt_final_size;
+    slice->layer->setInput(1, *begin_tensor);
+    slice->layer->setInput(2, *size_tensor);
+    slice->layer->setInput(3, *stride_const->output);
+  }
+
+  params->converter->SetLayerName(slice->layer, params->node_def, "slice",
+                                  op_instance);
+  ITensorProxyPtr tensor = slice->output;
+
+  // Reshape for shrink_axis.
+  if (final_shape) {
+    TF_RETURN_IF_ERROR(PrepareTensorForShape(
+        params->converter, TRT_TensorOrWeights(tensor), *final_shape,
+        /*validation_only=*/false, &tensor, node_def, op_instance));
+  }
+  params->outputs->push_back(TRT_TensorOrWeights(tensor));
+  return Status::OK();
+}
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.h
@@ -1,0 +1,42 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_SLICE_OPS_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_SLICE_OPS_H_
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/util/strided_slice_op.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+using SliceDims = absl::InlinedVector<int64, 4>;
+
+Status ConvertStridedSliceHelper(
+    OpConverterParams* params, const TRT_TensorOrWeights& input,
+    const PartialTensorShape& input_dims, const SliceDims& begin,
+    const SliceDims& stride, const SliceDims& end,
+    absl::optional<nvinfer1::Dims> final_shape = absl::nullopt,
+    absl::optional<int> op_instance = absl::nullopt,
+    absl::optional<StridedSliceShapeSpec> strided_slice_spec = absl::nullopt);
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OPS_SLICE_OPS_H_

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -105,6 +105,11 @@ string DebugString(const std::vector<nvinfer1::Dims>& dimvec);
 string DebugString(const std::vector<TensorShape>& shapes);
 string DebugString(const std::vector<PartialTensorShape>& shapes);
 
+template <size_t N>
+string DebugString(const absl::InlinedVector<int64, N>& data) {
+  return absl::StrCat("[", absl::StrJoin(data, ","), "]");
+}
+
 inline bool HasStaticShape(const nvinfer1::Dims& dims) {
   if (dims.nbDims < 0) return false;
   for (int d = 0; d < dims.nbDims; ++d) {


### PR DESCRIPTION
Enables dynamic shape support for conversion of "slice" and "strided slice" Tensorflow operations to the TensorRT ISliceLayer in TF:TRT.