### PR TITLE
Fix `DeprecationWarning: the imp module is deprecated in favour of importlib`

### DIFF
--- a/tensorflow/python/autograph/impl/api.py
+++ b/tensorflow/python/autograph/impl/api.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 import functools
-import imp
+import importlib
 import inspect
 import os
 import sys
@@ -204,7 +204,8 @@ class PyToTF(transpiler.PyToPy):
       # TODO(mdan): Move into core or replace with an actual importable module.
       # Craft a module that exposes the external API as well as certain
       # internal modules.
-      ag_internal = imp.new_module('autograph')
+      module_spec = importlib.machinery.ModuleSpec('autograph', None)
+      ag_internal = importlib.util.module_from_spec(module_spec)
       ag_internal.__dict__.update(inspect.getmodule(PyToTF).__dict__)
       ag_internal.ConversionOptions = converter.ConversionOptions
       ag_internal.STD = converter.STANDARD_OPTIONS

--- a/tensorflow/python/framework/load_library.py
+++ b/tensorflow/python/framework/load_library.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 
 import errno
 import hashlib
-import imp
+import importlib
 import os
 import platform
 import sys
@@ -68,7 +68,8 @@ def load_op_library(library_filename):
   module_name = hashlib.sha1(wrappers).hexdigest()
   if module_name in sys.modules:
     return sys.modules[module_name]
-  module = imp.new_module(module_name)
+  module_spec = importlib.machinery.ModuleSpec(module_name, None)
+  module = importlib.util.module_from_spec(module_spec)
   # pylint: disable=exec-used
   exec(wrappers, module.__dict__)
   # Allow this to be recognized by AutoGraph.


### PR DESCRIPTION
This PR tries to fix the following warning:
```
  /usr/local/lib/python3.9/dist-packages/tensorflow/python/autograph/impl/api.py:22: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp
```

Note: After the fix, the flatbuffer still generates a warning:
```
../usr/local/lib/python3.8/dist-packages/flatbuffers/compat.py:19
  /usr/local/lib/python3.8/dist-packages/flatbuffers/compat.py:19: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp
```

However, this PR at least removes the warnings within tensorflow.

This PR fixes #31412.

This PR fixes #51631.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>