### PR TITLE
[INTEL MKL] Fix MKL related conv_ops_3d_test unit test failure

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -612,6 +612,12 @@ class MklConvOp : public OpKernel {
       // Input tensors
       const Tensor& src_tensor = MklGetInput(context, kInputIndex_Src);
       const Tensor& filter_tensor = MklGetInput(context, kInputIndex_Filter);
+
+      OP_REQUIRES(
+        context, filter_tensor.NumElements() > 0,
+        errors::InvalidArgument("filter must not have zero elements "
+                                "(i.e. all dimensions must be non-zero)"));
+
       MklDnnShape src_mkl_shape, filter_mkl_shape;
       GetMklShape(context, kInputIndex_Src, &src_mkl_shape, native_format);
       GetMklShape(context, kInputIndex_Filter, &filter_mkl_shape,


### PR DESCRIPTION
Fix the issue by adding sanity check for the corner case of "zero element of filter" in mkl_conv_ops.cc. With this fix, MKL conv op  returns a right error message which a newly added conv3d unit test (within python/kernel_tests/conv_ops_3d_test.py) expects. 

The fix just does the same as what the Eigen implements (core/kernels/conv_ops_3d.cc).