### PR TITLE
Refactor SparseSliceOp to use a functor

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -6140,6 +6140,7 @@ filegroup(
         "sparse_xent_op.h",
         "sparse_fill_empty_rows_op.h",
         "sparse_reorder_op.h",
+        "sparse_slice_op.h",
         "sparse_tensor_dense_matmul_op.h",
         "string_util.h",
         "string_to_hash_bucket_op.h",

--- a/tensorflow/core/kernels/sparse_slice_op.cc
+++ b/tensorflow/core/kernels/sparse_slice_op.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
+#include "tensorflow/core/kernels/sparse_slice_op.h"
+
 #include <vector>
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
@@ -22,49 +24,18 @@ limitations under the License.
 
 namespace tensorflow {
 
+typedef Eigen::ThreadPoolDevice CPUDevice;
+
+namespace functor {
+
 template <typename T>
-class SparseSliceOp : public OpKernel {
- public:
-  explicit SparseSliceOp(OpKernelConstruction* context) : OpKernel(context) {}
-
-  void Compute(OpKernelContext* context) override {
-    const Tensor& input_indices = context->input(0);
-    const Tensor& input_values = context->input(1);
-    const Tensor& input_shape = context->input(2);
-    const Tensor& input_start = context->input(3);
-    const Tensor& input_size = context->input(4);
-
-    OP_REQUIRES(context, TensorShapeUtils::IsMatrix(input_indices.shape()),
-                errors::InvalidArgument(
-                    "Input indices should be a matrix but received shape ",
-                    input_indices.shape().DebugString()));
-    OP_REQUIRES(context, TensorShapeUtils::IsVector(input_values.shape()),
-                errors::InvalidArgument(
-                    "Input values should be a vector but received shape ",
-                    input_indices.shape().DebugString()));
-    OP_REQUIRES(context, TensorShapeUtils::IsVector(input_shape.shape()),
-                errors::InvalidArgument(
-                    "Input shape should be a vector but received shape ",
-                    input_shape.shape().DebugString()));
-    OP_REQUIRES(context, TensorShapeUtils::IsVector(input_start.shape()),
-                errors::InvalidArgument(
-                    "Input start should be a vector but received shape ",
-                    input_start.shape().DebugString()));
-    OP_REQUIRES(context, TensorShapeUtils::IsVector(input_size.shape()),
-                errors::InvalidArgument(
-                    "Input size should be a vector but received shape ",
-                    input_size.shape().DebugString()));
-
+struct SparseSliceFunctor<CPUDevice, T> {
+  void operator()(OpKernelContext* context, const Tensor& input_indices,
+                  const Tensor& input_values, const Tensor& input_shape,
+                  const Tensor& input_start, const Tensor& input_size,
+                  typename AsyncOpKernel::DoneCallback done) const {
+    (void)done;  // Unused (only used in GPU implementation)
     const int input_dims = input_shape.NumElements();
-    OP_REQUIRES(context, input_dims == input_start.NumElements(),
-                errors::InvalidArgument(
-                    "Expected start to be a vector of length ", input_dims,
-                    " but got length ", input_start.NumElements()));
-
-    OP_REQUIRES(context, input_dims == input_size.NumElements(),
-                errors::InvalidArgument(
-                    "Expected size to be a vector of length ", input_dims,
-                    " but got length ", input_size.NumElements()));
 
     sparse::SparseTensor sparse_tensor;
     OP_REQUIRES_OK(
@@ -92,14 +63,87 @@ class SparseSliceOp : public OpKernel {
       shape->vec<int64_t>()(dim) = output_shape.dim_size(dim);
     }
   }
+};
 
- private:
+}  // namespace functor
+
+namespace {
+
+template <typename Device, typename T>
+void SparseSliceOpImpl(OpKernelContext* context,
+                       typename AsyncOpKernel::DoneCallback done = nullptr) {
+  // Note that setting this empty lambda as the default parameter value directly
+  // can cause strange compiler/linker errors, so we do it like this instead.
+  if (!done) {
+    done = [] {};
+  }
+
+  const Tensor& input_indices = context->input(0);
+  const Tensor& input_values = context->input(1);
+  const Tensor& input_shape = context->input(2);
+  const Tensor& input_start = context->input(3);
+  const Tensor& input_size = context->input(4);
+
+  OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsMatrix(input_indices.shape()),
+                    errors::InvalidArgument(
+                        "Input indices should be a matrix but received shape ",
+                        input_indices.shape().DebugString()),
+                    done);
+  OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsVector(input_values.shape()),
+                    errors::InvalidArgument(
+                        "Input values should be a vector but received shape ",
+                        input_values.shape().DebugString()),
+                    done);
+  OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsVector(input_shape.shape()),
+                    errors::InvalidArgument(
+                        "Input shape should be a vector but received shape ",
+                        input_shape.shape().DebugString()),
+                    done);
+  OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsVector(input_start.shape()),
+                    errors::InvalidArgument(
+                        "Input start should be a vector but received shape ",
+                        input_start.shape().DebugString()),
+                    done);
+  OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsVector(input_size.shape()),
+                    errors::InvalidArgument(
+                        "Input size should be a vector but received shape ",
+                        input_size.shape().DebugString()),
+                    done);
+
+  const int input_dims = input_shape.NumElements();
+  OP_REQUIRES_ASYNC(context, input_dims == input_start.NumElements(),
+                    errors::InvalidArgument(
+                        "Expected start to be a vector of length ", input_dims,
+                        " but got length ", input_start.NumElements()),
+                    done);
+
+  OP_REQUIRES_ASYNC(context, input_dims == input_size.NumElements(),
+                    errors::InvalidArgument(
+                        "Expected size to be a vector of length ", input_dims,
+                        " but got length ", input_size.NumElements()),
+                    done);
+
+  functor::SparseSliceFunctor<Device, T>()(context, input_indices, input_values,
+                                           input_shape, input_start, input_size,
+                                           done);
+}
+
+}  // namespace
+
+template <typename Device, typename T>
+class SparseSliceOp : public OpKernel {
+ public:
+  explicit SparseSliceOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override {
+    SparseSliceOpImpl<Device, T>(context);
+  }
 };
 
 #define REGISTER_KERNELS(type)                                          \
   REGISTER_KERNEL_BUILDER(                                              \
       Name("SparseSlice").Device(DEVICE_CPU).TypeConstraint<type>("T"), \
-      SparseSliceOp<type>)
+      SparseSliceOp<CPUDevice, type>)
 
 TF_CALL_ALL_TYPES(REGISTER_KERNELS);
 #undef REGISTER_KERNELS

--- a/tensorflow/core/kernels/sparse_slice_op.h
+++ b/tensorflow/core/kernels/sparse_slice_op.h
@@ -1,0 +1,39 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_SPARSE_SLICE_OP_H_
+#define TENSORFLOW_CORE_KERNELS_SPARSE_SLICE_OP_H_
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/lib/core/status.h"
+
+namespace tensorflow {
+
+namespace functor {
+
+template <typename Device, typename T>
+struct SparseSliceFunctor {
+  void operator()(OpKernelContext* context, const Tensor& input_indices,
+                  const Tensor& input_values, const Tensor& input_shape,
+                  const Tensor& input_start, const Tensor& input_size,
+                  typename AsyncOpKernel::DoneCallback done = nullptr) const;
+};
+
+}  // namespace functor
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_SPARSE_SLICE_OP_H_

--- a/tensorflow/python/kernel_tests/sparse_slice_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_slice_op_test.py
@@ -80,6 +80,12 @@ class SparseSliceOpTest(test.TestCase):
     return sparse_tensor.SparseTensor.from_value(
         self._SparseTensorValue_3x4x2())
 
+  def _SparseTensor_4x6_empty(self, val_dtype=np.int64):
+    ind = np.empty(shape=(0, 2), dtype=np.int64)
+    val = np.array([]).astype(val_dtype)
+    shape = np.array([4, 6]).astype(np.int64)
+    return sparse_tensor.SparseTensor(ind, val, shape)
+
   @test_util.run_deprecated_v1
   def testSliceMatrixRows(self):
     with self.session(use_gpu=False):
@@ -243,6 +249,25 @@ class SparseSliceOpTest(test.TestCase):
       self.assertAllEqual(sparse_tensor5.indices, [[0, 0], [2, 0], [3, 0]])
       self.assertAllEqual(sparse_tensor5.values, [5, 25, 35])
       self.assertAllEqual(sparse_tensor5.dense_shape, [4, 1])
+
+  @test_util.run_deprecated_v1
+  def testSliceEmpty(self):
+    with self.session(use_gpu=False):
+      sp_empty = self._SparseTensor_4x6_empty()
+      sp_input = self._SparseTensor_4x6()
+      sparse_tensor0 = sparse_ops.sparse_slice(sp_empty, [0, 0], [4, 1])
+      sparse_tensor1 = sparse_ops.sparse_slice(sp_input, [1, 1], [0, 0])
+      sparse_tensor2 = sparse_ops.sparse_slice(sp_input, [2, 1], [2, 1])
+      empty_inds = np.empty(shape=(0, 2), dtype=np.int64)
+      self.assertAllEqual(sparse_tensor0.indices, empty_inds)
+      self.assertAllEqual(sparse_tensor0.values, [])
+      self.assertAllEqual(sparse_tensor0.dense_shape, [4, 1])
+      self.assertAllEqual(sparse_tensor1.indices, empty_inds)
+      self.assertAllEqual(sparse_tensor1.values, [])
+      self.assertAllEqual(sparse_tensor1.dense_shape, [0, 0])
+      self.assertAllEqual(sparse_tensor2.indices, empty_inds)
+      self.assertAllEqual(sparse_tensor2.values, [])
+      self.assertAllEqual(sparse_tensor2.dense_shape, [2, 1])
 
   @test_util.run_deprecated_v1
   def testGradients(self):

--- a/tensorflow/python/kernel_tests/sparse_slice_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_slice_op_test.py
@@ -250,9 +250,9 @@ class SparseSliceOpTest(test.TestCase):
       self.assertAllEqual(sparse_tensor5.values, [5, 25, 35])
       self.assertAllEqual(sparse_tensor5.dense_shape, [4, 1])
 
-  @test_util.run_deprecated_v1
   def testSliceEmpty(self):
-    with self.session(use_gpu=False):
+    # SparseSlice does not currently have a GPU kernel.
+    with test_util.force_cpu():
       sp_empty = self._SparseTensor_4x6_empty()
       sp_input = self._SparseTensor_4x6()
       sparse_tensor0 = sparse_ops.sparse_slice(sp_empty, [0, 0], [4, 1])


### PR DESCRIPTION
This is in preparation for adding a GPU implementation.
No functional change.
Also adds a few tests for empty input/output sparse tensors.

cc @nluehr 