### PR TITLE
TF-TRT Set binding dimensions even if tensor is not an execution tensor

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
@@ -48,9 +48,9 @@ limitations under the License.
 #include "tensorflow/core/lib/gtl/cleanup.h"
 #include "tensorflow/core/lib/strings/numbers.h"
 #include "tensorflow/core/platform/logging.h"
-#include "tensorflow/core/protobuf/config.pb.h"             // NOLINT
+#include "tensorflow/core/protobuf/config.pb.h"  // NOLINT
 #include "tensorflow/core/protobuf/device_properties.pb.h"  // NOLINT
-#include "tensorflow/core/protobuf/rewriter_config.pb.h"    // NOLINT
+#include "tensorflow/core/protobuf/rewriter_config.pb.h"  // NOLINT
 #include "tensorflow/core/util/device_name_utils.h"
 #include "tensorflow/tools/graph_transforms/transform_utils.h"
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
@@ -48,9 +48,9 @@ limitations under the License.
 #include "tensorflow/core/lib/gtl/cleanup.h"
 #include "tensorflow/core/lib/strings/numbers.h"
 #include "tensorflow/core/platform/logging.h"
-#include "tensorflow/core/protobuf/config.pb.h"  // NOLINT
+#include "tensorflow/core/protobuf/config.pb.h"             // NOLINT
 #include "tensorflow/core/protobuf/device_properties.pb.h"  // NOLINT
-#include "tensorflow/core/protobuf/rewriter_config.pb.h"  // NOLINT
+#include "tensorflow/core/protobuf/rewriter_config.pb.h"    // NOLINT
 #include "tensorflow/core/util/device_name_utils.h"
 #include "tensorflow/tools/graph_transforms/transform_utils.h"
 
@@ -744,6 +744,7 @@ Status ConvertAfterShapes(const ConversionParams& params) {
   segment::SegmentOptions segment_options;
   // TODO(ben,jie,sami): exclude output nodes (DISCUSS IT)
   for (const auto& node : *(params.output_names)) {
+    VLOG(2) << "Adding output node" << node << " to exclude node list";
     segment_options.exclude_node_list.insert(node);
   }
   segment_options.minimum_segment_size = params.minimum_segment_size;

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -1566,9 +1566,9 @@ Status Converter::BuildCudaEngine(
     for (int i = 0; i < nbBindings; i++) {
       auto get_location_string = [&engine](int i) {
         if ((*engine)->getLocation(i) == nvinfer1::TensorLocation::kDEVICE)
-          return "on device";
+          return " on device";
         else
-          return "on host";
+          return " on host";
       };
 
       VLOG(2) << "Binding " << i << " name: " << (*engine)->getBindingName(i)

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -1419,9 +1419,10 @@ Status Converter::RenameAndMarkOutputTensors(
     // Set type after marking as output. TRT only supports setType for engine
     // outputs and inputs (type is inferred otherwise).
     tensor->setType(output.trt_dtype);
-    if (output.trt_dtype == nvinfer1::DataType::kINT32) {
-      network()->markOutputForShapes(*tensor->trt_tensor());
-    }
+    // if (output.trt_dtype == nvinfer1::DataType::kINT32) {
+    //   network()->markOutputForShapes(*tensor->trt_tensor());
+    //   // this is most probably not needed
+    // }
     output_index++;
     VLOG(1) << "Marking output TRT tensor " << output.source_tensor_name
             << " with data type " << DebugString(output.trt_dtype)
@@ -7192,8 +7193,8 @@ Status ConvertSegmentToGraphDef(
     }
   }
   engine_info->engine_name = StrCat(local_scope, engine_info->engine_name);
+  // This does help UNet example
   engine_info->has_int32_input = has_int32_input || has_int32_output;
-  // engine_info->has_int32_output = has_int32_output;
 
   return Status::OK();
 }

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -1419,6 +1419,9 @@ Status Converter::RenameAndMarkOutputTensors(
     // Set type after marking as output. TRT only supports setType for engine
     // outputs and inputs (type is inferred otherwise).
     tensor->setType(output.trt_dtype);
+    if (output.trt_dtype == nvinfer1::DataType::kINT32) {
+      network()->markOutputForShapes(*tensor->trt_tensor());
+    }
     output_index++;
     VLOG(1) << "Marking output TRT tensor " << output.source_tensor_name
             << " with data type " << DebugString(output.trt_dtype)

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -772,6 +772,10 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
     } else if (cache_res->profiles_.GetNumProfiles() == 0) {
       // Add current shape if we did not collect any shapes so far.
       if (!cache_res->profiles_.HasShape()) {
+        VLOG(2) << "Collecting shapes because no shape given so "
+                   "far";
+        OP_REQUIRES_OK_ASYNC(ctx, cache_res->profiles_.CollectShapeValues(ctx),
+                             dummy_async_helper);
         cache_res->profiles_.AddShape(input_concrete_shapes);
       }
       // Create profiles out of collected shapes during profile generation.

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
@@ -80,7 +80,7 @@ Status GetTrtBindingIndex(const char* tensor_name, int profile_index,
   *binding_index = cuda_engine->getBindingIndex(tensor_name);
   if (*binding_index == -1) {
     const string msg = StrCat("Input node ", tensor_name, " not found");
-    LOG(ERROR) << msg;
+    LOG(WARNING) << msg;
     return errors::NotFound(msg);
   }
   int n_profiles = cuda_engine->getNbOptimizationProfiles();
@@ -106,8 +106,16 @@ Status SetTrtEngineInputs(nvinfer1::ICudaEngine* cuda_engine,
     const string input_name =
         ctx ? StrCat(IONamePrefixes::kInputPHName, i) : input_vec->at(i).name;
     int binding_index;
-    TF_RETURN_IF_ERROR(GetTrtBindingIndex(input_name.c_str(), trt_profile_idx,
-                                          cuda_engine, &binding_index));
+    Status status = GetTrtBindingIndex(input_name.c_str(), trt_profile_idx,
+                                       cuda_engine, &binding_index);
+    if (IS_TRT_VERSION_GE(8, 0, 0, 0)) {
+      TF_RETURN_IF_ERROR(status);
+    } else if (!status.ok()) {
+      // Before TRT 8, an input tensor can be pruned if it is not used by the
+      // network (e.g. only its shape is used, but the shape is already defined
+      // by the optimization profile by setting min=max). nvbugs/3153064
+      continue;
+    }
     const Tensor& input_tensor = ctx ? ctx->input(i) : input_vec->at(i).tensor;
     const TensorShape& input_shape = input_tensor.shape();
 

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
@@ -114,6 +114,7 @@ Status SetTrtEngineInputs(nvinfer1::ICudaEngine* cuda_engine,
       // Before TRT 8, an input tensor can be pruned if it is not used by the
       // network (e.g. only its shape is used, but the shape is already defined
       // by the optimization profile by setting min=max). nvbugs/3153064
+      VLOG(2) << "Skipping pruned input " << input_name;
       continue;
     }
     const Tensor& input_tensor = ctx ? ctx->input(i) : input_vec->at(i).tensor;
@@ -207,6 +208,8 @@ Status SetTrtEngineOutputs(nvinfer1::ICudaEngine* cuda_engine,
     // Allocate output tensor of TRTEngineOp.
     Tensor* output_tensor = nullptr;
     if (ctx) {
+      VLOG(2) << "Allocating " << output_name << " with shape "
+              << output_shape.DebugString();
       TF_RETURN_IF_ERROR(ctx->allocate_output(i, output_shape, &output_tensor));
     } else {
       // This path is used for unit tests. The tensor is already allocated.

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
@@ -169,7 +169,7 @@ Status TrtShapeOptimizationProfile::CollectShapeValues(OpKernelContext* ctx) {
       VLOG(2) << "Input " << i << " is (probably) a shape tensor, n_values="
               << input.NumElements();
     } else {
-      VLOG(2) << "Input " << i << " is not a  shape tensor";
+      VLOG(2) << "Input " << i << " is not a shape tensor";
       actual_shape_values_[i] = {0, {}};
     }
   }

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
@@ -150,6 +150,7 @@ Status TrtShapeOptimizationProfile::CollectShapeValues(OpKernelContext* ctx) {
       is_shape_tensor_[i] = IsTrtShapeTensorCompatible(ctx->input(i));
     }
   }
+  VLOG(2) << "Running CollectShapeValues";
   int n_shape_val = 0;
   // First copy all the shape value candidates into actual_shape_values_ vector.
   for (int i = 0; i < ctx->num_inputs(); i++) {
@@ -168,6 +169,7 @@ Status TrtShapeOptimizationProfile::CollectShapeValues(OpKernelContext* ctx) {
       VLOG(2) << "Input " << i << " is (probably) a shape tensor, n_values="
               << input.NumElements();
     } else {
+      VLOG(2) << "Input " << i << " is not a  shape tensor";
       actual_shape_values_[i] = {0, {}};
     }
   }
@@ -509,6 +511,7 @@ Status TrtShapeOptimizationProfile::RestoreProfiles(
   int K = n_bindings / n_profiles;
 #endif
   int n_inputs = GetNumberOfEngineInputs(engine);
+  need_profiles_ &= n_inputs > 0;
   VLOG(2) << "Attempting to restore " << n_profiles << " profiles, each with "
           << n_inputs << " inputs";
   SetShapeTensorMask(engine, n_inputs);

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
@@ -94,16 +94,11 @@ struct OptimizationProfileConfig {
         profile->setShapeValues(name, nvinfer1::OptProfileSelector::kMAX,
                                 max[idx].d, max[idx].nbDims);
       }
-      if (input->isExecutionTensor()) {
-        VLOG(2) << "Setting input dimensions for " << name << ", "
-                << ::tensorflow::tensorrt::DebugString(opt[i]);
-        profile->setDimensions(name, nvinfer1::OptProfileSelector::kMIN,
-                               min[i]);
-        profile->setDimensions(name, nvinfer1::OptProfileSelector::kOPT,
-                               opt[i]);
-        profile->setDimensions(name, nvinfer1::OptProfileSelector::kMAX,
-                               max[i]);
-      }
+      VLOG(2) << "Setting input dimensions for " << name << ", "
+              << ::tensorflow::tensorrt::DebugString(opt[i]);
+      profile->setDimensions(name, nvinfer1::OptProfileSelector::kMIN, min[i]);
+      profile->setDimensions(name, nvinfer1::OptProfileSelector::kOPT, opt[i]);
+      profile->setDimensions(name, nvinfer1::OptProfileSelector::kMAX, max[i]);
     }
     return Status::OK();
   }

--- a/tensorflow/python/compiler/tensorrt/test/base_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/base_test.py
@@ -30,7 +30,7 @@ from tensorflow.python.ops import nn
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import test
 
-# Tamas: this can be disabled
+
 class SimpleSingleEngineTest(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):
@@ -70,7 +70,7 @@ class SimpleSingleEngineTest(trt_test.TfTrtIntegrationTestBase):
         ]
     }
 
-# Tamas: needed
+
 class SimpleMultiEnginesTest(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):
@@ -127,7 +127,6 @@ class SimpleMultiEnginesTest(trt_test.TfTrtIntegrationTestBase):
     self.DisableNonTrtOptimizers()
 
 
-# Tamas: needed
 class SimpleMultiEnginesTest2(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):
@@ -168,7 +167,7 @@ class SimpleMultiEnginesTest2(trt_test.TfTrtIntegrationTestBase):
         not (trt_test.IsQuantizationMode(run_params.precision_mode) and
              not run_params.use_calibration)), "test FP32 and non-calibration"
 
-#Tamas: needed
+
 class ConstInputTest(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):
@@ -204,7 +203,7 @@ class ConstInputTest(trt_test.TfTrtIntegrationTestBase):
         "TRTEngineOp_1": ["add2", "add3", "mul1"]
     }
 
-# Tamas: needed
+
 class ConstDataInputSingleEngineTest(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):
@@ -226,7 +225,6 @@ class ConstDataInputSingleEngineTest(trt_test.TfTrtIntegrationTestBase):
     return {"TRTEngineOp_0": ["c", "add", "add1", "mul"]}
 
 
-#nedded for the error
 class ConstDataInputMultipleEnginesTest(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):

--- a/tensorflow/python/compiler/tensorrt/test/base_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/base_test.py
@@ -30,7 +30,7 @@ from tensorflow.python.ops import nn
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import test
 
-
+# Tamas: this can be disabled
 class SimpleSingleEngineTest(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):
@@ -70,7 +70,7 @@ class SimpleSingleEngineTest(trt_test.TfTrtIntegrationTestBase):
         ]
     }
 
-
+# Tamas: needed
 class SimpleMultiEnginesTest(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):
@@ -127,6 +127,7 @@ class SimpleMultiEnginesTest(trt_test.TfTrtIntegrationTestBase):
     self.DisableNonTrtOptimizers()
 
 
+# Tamas: needed
 class SimpleMultiEnginesTest2(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):
@@ -167,7 +168,7 @@ class SimpleMultiEnginesTest2(trt_test.TfTrtIntegrationTestBase):
         not (trt_test.IsQuantizationMode(run_params.precision_mode) and
              not run_params.use_calibration)), "test FP32 and non-calibration"
 
-
+#Tamas: needed
 class ConstInputTest(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):
@@ -203,7 +204,7 @@ class ConstInputTest(trt_test.TfTrtIntegrationTestBase):
         "TRTEngineOp_1": ["add2", "add3", "mul1"]
     }
 
-
+# Tamas: needed
 class ConstDataInputSingleEngineTest(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):
@@ -225,6 +226,7 @@ class ConstDataInputSingleEngineTest(trt_test.TfTrtIntegrationTestBase):
     return {"TRTEngineOp_0": ["c", "add", "add1", "mul"]}
 
 
+#nedded for the error
 class ConstDataInputMultipleEnginesTest(trt_test.TfTrtIntegrationTestBase):
 
   def GraphFn(self, inp):

--- a/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
@@ -38,7 +38,7 @@ class ShapeOutputTest(trt_test.TfTrtIntegrationTestBase):
 
   def GetParams(self):
     return self.BuildParamsWithMask(self.GraphFn, dtypes.float32,
-                            [[1, 2, 5, 3]], [[4]],
+                            [[2, 2, 5, 3]], [[4]],
                             extra_inputs=[], # [[[1, 1, 2, 3]]],
                             extra_outputs=[], #[[[4]]],
                             input_mask=[[False, False, False, False]],
@@ -46,13 +46,11 @@ class ShapeOutputTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0", "TRTEngineOp_1"]
-
-  def setUp(self):
-    super().setUp()
-    self.SetDynamicShapeModeAndProfileStrategy(
-        profile_strategy="ImplicitBatchModeCompatible")
-
+    if run_params.dynamic_shape:
+      return ["TRTEngineOp_0", "TRTEngineOp_1"]
+    else:
+      # Second segment not converted because its tensors have only one dimensions
+      return ["TRTEngineOp_0"]
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
@@ -1,0 +1,58 @@
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Model script to test TF-TensorRT integration."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.compiler.tensorrt.test import tf_trt_integration_test_base as trt_test
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.platform import test
+
+
+class ShapeOutputTest(trt_test.TfTrtIntegrationTestBase):
+  """Test shape value output with TF-TRT."""
+
+  def GraphFn(self, x):
+   q = 2 * x + 1
+   q = array_ops.shape(q)
+   q = math_ops.cast(q, dtypes.float32)
+   q = self.trt_incompatible_op(q)
+   q = q * 2 + q * q
+   return array_ops.identity(q, name="output_0")
+
+  def GetParams(self):
+    return self.BuildParamsWithMask(self.GraphFn, dtypes.float32,
+                            [[2, 2, 5, 3]], [[4]],
+                            extra_inputs=[], # [[[1, 1, 2, 3]]],
+                            extra_outputs=[], #[[[4]]],
+                            input_mask=[[False, False, False, False]],
+                            output_mask=[[True]])
+
+  def ExpectedEnginesToBuild(self, run_params):
+    """Return the expected engines to build."""
+    return ["TRTEngineOp_0", "TRTEngineOp_1"]
+
+  def setUp(self):
+    super().setUp()
+    self.SetDynamicShapeModeAndProfileStrategy(
+        profile_strategy="ImplicitBatchModeCompatible")
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
@@ -28,6 +28,10 @@ from tensorflow.python.platform import test
 class ShapeOutputTest(trt_test.TfTrtIntegrationTestBase):
   """Test shape value output with TF-TRT."""
 
+  def setUp(self):
+    super(trt_test.TfTrtIntegrationTestBase, self).setUp()  # pylint: disable=bad-super-call
+    self.DisableNonTrtOptimizers()
+
   def GraphFn(self, x):
    q = 2 * x + 1
    q = array_ops.shape(q)
@@ -41,7 +45,7 @@ class ShapeOutputTest(trt_test.TfTrtIntegrationTestBase):
                             [[2, 2, 5, 3]], [[4]],
                             extra_inputs=[], # [[[1, 1, 2, 3]]],
                             extra_outputs=[], #[[[4]]],
-                            input_mask=[[False, False, False, False]],
+                            input_mask=[[False, True, True, True]], #[[False, False, False, False]],
                             output_mask=[[True]])
 
   def ExpectedEnginesToBuild(self, run_params):

--- a/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
@@ -38,7 +38,7 @@ class ShapeOutputTest(trt_test.TfTrtIntegrationTestBase):
 
   def GetParams(self):
     return self.BuildParamsWithMask(self.GraphFn, dtypes.float32,
-                            [[2, 2, 5, 3]], [[4]],
+                            [[1, 2, 5, 3]], [[4]],
                             extra_inputs=[], # [[[1, 1, 2, 3]]],
                             extra_outputs=[], #[[[4]]],
                             input_mask=[[False, False, False, False]],

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -1154,7 +1154,7 @@ def _AddTestsFor(test_class, is_v2):
 
 def _AddTests(test_class):
   """Adds test methods to TfTrtIntegrationTestBase."""
-  _AddTestsFor(test_class, is_v2=False)
+  #_AddTestsFor(test_class, is_v2=False)
   _AddTestsFor(test_class, is_v2=True)
 
 


### PR DESCRIPTION
According to [nvinfer1::ITensor::isExecutionTensor](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_tensor.html#a472db0d89262ae20c1ad247b3a6d64fa) API description:

> A tensor with isShapeTensor() == false and isExecutionTensor() == false can still show up as an input to the engine if its dimensions are required.

This PR fixes optimization profile definition for that case, by always calling profile->setDimension().

A unit test is added to for such a case.