### PR TITLE
[tflite] fix default of xnnpack_delegate_provider

### DIFF
--- a/tensorflow/lite/tools/delegates/xnnpack_delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/xnnpack_delegate_provider.cc
@@ -18,13 +18,22 @@ limitations under the License.
 #include "tensorflow/lite/tools/delegates/delegate_provider.h"
 #include "tensorflow/lite/tools/evaluation/utils.h"
 
+#if (defined(ANDROID) || defined(__ANDROID__)) && \
+    (defined(__arm__) || defined(__aarch64__))
+#define TFLITE_BUILD_WITH_XNNPACK_DELEGATE
+#endif
+
 namespace tflite {
 namespace tools {
 
 class XnnpackDelegateProvider : public DelegateProvider {
  public:
   XnnpackDelegateProvider() {
+#if defined(TFLITE_BUILD_WITH_XNNPACK_DELEGATE)
+    default_params_.AddParam("use_xnnpack", ToolParam::Create<bool>(true));
+#else
     default_params_.AddParam("use_xnnpack", ToolParam::Create<bool>(false));
+#endif
   }
 
   std::vector<Flag> CreateFlags(ToolParams* params) const final;


### PR DESCRIPTION
xnnpack delegate was enabled by default on Android ARM platforms in 0b78d40a54a991e0f2b67e2a9aa5224609536552. But the corresponding default setting of xnnpack delegate provider is not changed, so users of xnnpack delegate provider, e.g., benchmark_model doesn't get right value. E.g., when `benchmark_model --help`, I got

```
...
	--use_xnnpack=true                       	bool	optional	use XNNPack

```

But actually, it uses tflite with xnnpack enabled already. That's a bit confusing.


tag @multiverse-tf who is the author of 0b78d40