### PR TITLE
Fix crash with tf.range when start is large/negative

### DIFF
--- a/tensorflow/core/kernels/sequence_ops.cc
+++ b/tensorflow/core/kernels/sequence_ops.cc
@@ -78,9 +78,11 @@ class RangeOp : public OpKernel {
     } else {
       size = static_cast<int64>(std::ceil(std::abs((limit - start) / delta)));
     }
+    TensorShape shape;
+    OP_REQUIRES_OK(context, shape.AddDimWithStatus(size));
     Tensor* out = nullptr;
     OP_REQUIRES_OK(context,
-                   context->allocate_output(0, TensorShape({size}), &out));
+                   context->allocate_output(0, shape, &out));
     auto flat = out->flat<T>();
     T val = start;
     for (int64_t i = 0; i < size; ++i) {

--- a/tensorflow/python/kernel_tests/init_ops_test.py
+++ b/tensorflow/python/kernel_tests/init_ops_test.py
@@ -550,6 +550,13 @@ class RangeTest(test.TestCase):
         v = math_ops.range(0, 9223372036854775807)
         self.evaluate(v)
 
+  def testLargeStarts(self):
+    # Test case for GitHub issue 46899.
+    with self.session():
+      with self.assertRaises(errors_impl.InternalError):
+        v = math_ops.range(start=-1e+38, limit=1)
+        self.evaluate(v)
+
 
 # TODO(vrv): move to sequence_ops_test?
 class LinSpaceTest(test.TestCase):


### PR DESCRIPTION
This PR tries to address the issue raised in 46899 where
tf.range will crash when start is large/negative.

This PR fixes #46899.

This PR also fixes #46889.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>