### PR TITLE
Upgrade curl from 7.77 to 7.78

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -608,12 +608,12 @@ def _tf_repositories():
     tf_http_archive(
         name = "curl",
         build_file = "//third_party:curl.BUILD",
-        sha256 = "b0a3428acb60fa59044c4d0baae4e4fc09ae9af1d8a3aa84b2e3fbcd99841f77",
-        strip_prefix = "curl-7.77.0",
+        sha256 = "ed936c0b02c06d42cf84b39dd12bb14b62d77c7c4e875ade022280df5dcc81d7",
+        strip_prefix = "curl-7.78.0",
         system_build_file = "//third_party/systemlibs:curl.BUILD",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/curl.haxx.se/download/curl-7.77.0.tar.gz",
-            "https://curl.haxx.se/download/curl-7.77.0.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/curl.haxx.se/download/curl-7.78.0.tar.gz",
+            "https://curl.haxx.se/download/curl-7.78.0.tar.gz",
         ],
     )
 


### PR DESCRIPTION
This PR upgrades curl from 7.77 to 7.78.
The following are CVEs that might be related to curl 7.77 (old version):

CVE-2021-22926: CURLOPT_SSLCERT mixup with Secure Transport
CVE-2021-22925: TELNET stack contents disclosure again
CVE-2021-22924: Bad connection reuse due to flawed path name checks
CVE-2021-22923: Metalink download sends credentials
CVE-2021-22922: Wrong content via metalink not discarded

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>