### PR TITLE
Add missing deps for Legalize to Linalg

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/CMakeLists.txt
@@ -174,6 +174,9 @@ add_mlir_library(MhloLhloToLinalg
   DEPENDS
   MLIRhlo_opsIncGen
   MLIRlhlo_opsIncGen
+  MLIRMhloPassIncGen
+  MLIRLmhloPassIncGen
+  MLIRDiscRalPassIncGen
 
   LINK_COMPONENTS
   Core


### PR DESCRIPTION
When compiling IREE baremetal I ran into mhlo_passes.h.inc file not found
[ 69%] Built target MhloTypeConversion
[ 69%] Building CXX object third_party/llvm-project/llvm/tools/mlir-hlo/lib/Dialect/mhlo/transforms/CMakeFiles/obj.MhloLhloToLinalg.dir/legalize_to_linalg.cc.o
In file included from /home/foo/github/iree-bare-metal-arm/third_party/iree/third_party/mlir-hlo/lib/Dialect/mhlo/transforms/legalize_to_linalg.cc:24:
/home/foo/github/iree-bare-metal-arm/third_party/iree/third_party/mlir-hlo/include/mlir-hlo/Dialect/mhlo/transforms/PassDetail.h:32:10: fatal error: 'mlir-hlo/Dialect/mhlo/transforms/mhlo_passes.h.inc' file not found
#include "mlir-hlo/Dialect/mhlo/transforms/mhlo_passes.h.inc"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [third_party/llvm-project/llvm/tools/mlir-hlo/lib/Dialect/mhlo/transforms/CMakeFiles/obj.MhloLhloToLinalg.dir/build.make:63: third_party/llvm-project/llvm/tools/mlir-hlo/lib/Dialect/mhlo/transforms/CMakeFiles/obj.MhloLhloToLinalg.dir/legalize_to_linalg.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:52089: third_party/llvm-project/llvm/tools/mlir-hlo/lib/Dialect/mhlo/transforms/CMakeFiles/obj.MhloLhloToLinalg.dir/all] Error 2
make: *** [Makefile:152: all] Error 2



Fix is similar to https://github.com/tensorflow/tensorflow/pull/51085/

TEST: Builds after the fix