### PR TITLE
[tf.data] graduate choose_from_datasets API from experimental to tf.data.Dataset

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -170,6 +170,10 @@
         `tf.data.experimental.sample_from_datasets` API to
         `tf.data.Dataset.sample_from_datasets` and deprecating the experimental
         endpoint.
+    *   Promoting
+        `tf.data.experimental.choose_from_datasets` API to
+        `tf.data.Dataset.choose_from_datasets` and deprecating the experimental
+        endpoint.
 *   TF SavedModel:
     *   Custom gradients are now saved by default. See `tf.saved_model.SaveOptions` to disable this.
 *   XLA:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,6 +43,11 @@
   * Add experimental API `experimental_from_jax` to support conversion from Jax
     models to TensorFlow Lite.
 
+* `tf.data`:
+    *   The default value for `stop_on_empty_dataset` parameter in
+        `tf.data.Dataset.choose_from_datasets` API has been changed to `True`.
+        Set it to `False` for deprecated experimental behaviour.
+
 * TF Core:
     *   `tf.Graph.get_name_scope()` now always returns a string, as documented.
         Previously, when called within `name_scope("")` or `name_scope(None)`
@@ -173,7 +178,8 @@
     *   Promoting
         `tf.data.experimental.choose_from_datasets` API to
         `tf.data.Dataset.choose_from_datasets` and deprecating the experimental
-        endpoint.
+        endpoint. Additionally, the default value for `stop_on_empty_dataset` has
+        been changed to `True`. Set it to `False` for deprecated experimental behaviour.
 *   TF SavedModel:
     *   Custom gradients are now saved by default. See `tf.saved_model.SaveOptions` to disable this.
 *   XLA:

--- a/tensorflow/python/data/experimental/kernel_tests/BUILD
+++ b/tensorflow/python/data/experimental/kernel_tests/BUILD
@@ -178,7 +178,6 @@ tf_py_test(
         "//tensorflow/python:errors",
         "//tensorflow/python:extra_py_tests_deps",
         "//tensorflow/python:random_seed",
-        "//tensorflow/python/data/experimental/ops:interleave_ops",
         "//tensorflow/python/data/kernel_tests:checkpoint_test_base",
         "//tensorflow/python/data/kernel_tests:test_base",
         "//tensorflow/python/data/ops:dataset_ops",

--- a/tensorflow/python/data/experimental/kernel_tests/directed_interleave_dataset_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/directed_interleave_dataset_test.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 from absl.testing import parameterized
 import numpy as np
 
-from tensorflow.python.data.experimental.ops import interleave_ops
 from tensorflow.python.data.kernel_tests import checkpoint_test_base
 from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.ops import dataset_ops

--- a/tensorflow/python/data/experimental/kernel_tests/directed_interleave_dataset_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/directed_interleave_dataset_test.py
@@ -214,7 +214,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
     datasets = [dataset_ops.Dataset.from_tensors(w).repeat() for w in words]
     choice_array = np.random.randint(3, size=(15,), dtype=np.int64)
     choice_dataset = dataset_ops.Dataset.from_tensor_slices(choice_array)
-    dataset = interleave_ops.choose_from_datasets(datasets, choice_dataset)
+    dataset = dataset_ops.Dataset.choose_from_datasets(datasets, choice_dataset)
     next_element = self.getNext(dataset)
     for i in choice_array:
       self.assertEqual(words[i], self.evaluate(next_element()))
@@ -230,7 +230,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
     ]
     choice_array = np.asarray([0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=np.int64)
     choice_dataset = dataset_ops.Dataset.from_tensor_slices(choice_array)
-    dataset = interleave_ops.choose_from_datasets(
+    dataset = dataset_ops.Dataset.choose_from_datasets(
         datasets, choice_dataset, stop_on_empty_dataset=True)
     self.assertDatasetProduces(dataset, [b"foo", b"foo"])
 
@@ -243,7 +243,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
     ]
     choice_array = np.asarray([0, 0, 0, 1, 1, 1, 2, 2, 2], dtype=np.int64)
     choice_dataset = dataset_ops.Dataset.from_tensor_slices(choice_array)
-    dataset = interleave_ops.choose_from_datasets(
+    dataset = dataset_ops.Dataset.choose_from_datasets(
         datasets, choice_dataset, stop_on_empty_dataset=False)
     # Chooses 2 elements from the first dataset while the selector specifies 3.
     self.assertDatasetProduces(
@@ -257,7 +257,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
         dataset_ops.Dataset.from_tensors(b"bar").repeat(),
         dataset_ops.Dataset.from_tensors(b"baz").repeat(),
     ]
-    dataset = interleave_ops.choose_from_datasets(
+    dataset = dataset_ops.Dataset.choose_from_datasets(
         datasets, choice_dataset=dataset_ops.Dataset.range(0),
         stop_on_empty_dataset=False)
     self.assertDatasetProduces(dataset, [])
@@ -267,7 +267,7 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
     ds1 = dataset_ops.Dataset.range(10).window(2)
     ds2 = dataset_ops.Dataset.range(10, 20).window(2)
     choice_dataset = dataset_ops.Dataset.range(2).repeat(5)
-    ds = interleave_ops.choose_from_datasets([ds1, ds2], choice_dataset)
+    ds = dataset_ops.Dataset.choose_from_datasets([ds1, ds2], choice_dataset)
     ds = ds.flat_map(lambda x: x)
     expected = []
     for i in range(5):
@@ -300,19 +300,19 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
       dataset_ops.Dataset.sample_from_datasets(datasets=[], weights=[])
 
     with self.assertRaisesRegex(TypeError, "tf.int64"):
-      interleave_ops.choose_from_datasets([
+      dataset_ops.Dataset.choose_from_datasets([
           dataset_ops.Dataset.from_tensors(0),
           dataset_ops.Dataset.from_tensors(1)
       ], choice_dataset=dataset_ops.Dataset.from_tensors(1.0))
 
     with self.assertRaisesRegex(TypeError, "scalar"):
-      interleave_ops.choose_from_datasets([
+      dataset_ops.Dataset.choose_from_datasets([
           dataset_ops.Dataset.from_tensors(0),
           dataset_ops.Dataset.from_tensors(1)
       ], choice_dataset=dataset_ops.Dataset.from_tensors([1.0]))
 
     with self.assertRaisesRegex(errors.InvalidArgumentError, "out of range"):
-      dataset = interleave_ops.choose_from_datasets(
+      dataset = dataset_ops.Dataset.choose_from_datasets(
           [dataset_ops.Dataset.from_tensors(0)],
           choice_dataset=dataset_ops.Dataset.from_tensors(
               constant_op.constant(1, dtype=dtypes.int64)))
@@ -321,12 +321,12 @@ class DirectedInterleaveDatasetTest(test_base.DatasetTestBase,
 
     with self.assertRaisesRegex(
         ValueError, r"`datasets` must be a non-empty list of datasets."):
-      interleave_ops.choose_from_datasets(
+      dataset_ops.Dataset.choose_from_datasets(
           datasets=[], choice_dataset=dataset_ops.Dataset.from_tensors(1.0))
 
     with self.assertRaisesRegex(
         TypeError, r"`choice_dataset` must be a dataset of scalar"):
-      interleave_ops.choose_from_datasets([
+      dataset_ops.Dataset.choose_from_datasets([
           dataset_ops.Dataset.from_tensors(0),
           dataset_ops.Dataset.from_tensors(1)
       ], choice_dataset=None)

--- a/tensorflow/python/data/experimental/kernel_tests/service/dynamic_sharding_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/service/dynamic_sharding_test.py
@@ -252,7 +252,7 @@ class DynamicShardingTest(data_service_test_base.TestBase,
     datasets = [dataset_ops.Dataset.from_tensors(w).repeat() for w in words]
     choice_array = np.random.randint(3, size=(15,), dtype=np.int64)
     choice_dataset = dataset_ops.Dataset.from_tensor_slices(choice_array)
-    ds = interleave_ops.choose_from_datasets(datasets, choice_dataset)
+    ds = dataset_ops.Dataset.choose_from_datasets(datasets, choice_dataset)
     ds = self._make_dynamic_sharding_dataset(ds, cluster)
     expected = [words[i] for i in choice_array]
 

--- a/tensorflow/python/data/experimental/kernel_tests/service/dynamic_sharding_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/service/dynamic_sharding_test.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from tensorflow.python.data.experimental.kernel_tests.service import test_base as data_service_test_base
 from tensorflow.python.data.experimental.ops import data_service_ops
-from tensorflow.python.data.experimental.ops import interleave_ops
 from tensorflow.python.data.kernel_tests import test_base
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.framework import combinations

--- a/tensorflow/python/data/experimental/ops/BUILD
+++ b/tensorflow/python/data/experimental/ops/BUILD
@@ -141,7 +141,6 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":random_ops",
-        "//tensorflow/python:dtypes",
         "//tensorflow/python:framework_ops",
         "//tensorflow/python:math_ops",
         "//tensorflow/python:tf2",
@@ -149,8 +148,6 @@ py_library(
         "//tensorflow/python/data/ops:dataset_ops",
         "//tensorflow/python/data/ops:readers",
         "//tensorflow/python/data/util:nest",
-        "//tensorflow/python/data/util:structure",
-        "//tensorflow/python/framework:tensor_spec",
         "//tensorflow/python/util:tf_export",
     ],
 )

--- a/tensorflow/python/data/experimental/ops/interleave_ops.py
+++ b/tensorflow/python/data/experimental/ops/interleave_ops.py
@@ -20,9 +20,6 @@ from __future__ import print_function
 from tensorflow.python import tf2
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.ops import readers
-from tensorflow.python.data.util import structure
-from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import tensor_spec
 from tensorflow.python.util import deprecation
 from tensorflow.python.util.tf_export import tf_export
 
@@ -172,7 +169,8 @@ def sample_from_datasets_v1(datasets,
 
 sample_from_datasets_v1.__doc__ = sample_from_datasets_v2.__doc__
 
-
+@deprecation.deprecated(None,
+                        "Use `tf.data.Dataset.choose_from_datasets(...)`.")
 @tf_export("data.experimental.choose_from_datasets", v1=[])
 def choose_from_datasets_v2(datasets,
                             choice_dataset,
@@ -189,7 +187,7 @@ def choose_from_datasets_v2(datasets,
   # Define a dataset containing `[0, 1, 2, 0, 1, 2, 0, 1, 2]`.
   choice_dataset = tf.data.Dataset.range(3).repeat(3)
 
-  result = tf.data.experimental.choose_from_datasets(datasets, choice_dataset)
+  result = tf.data.Dataset.choose_from_datasets(datasets, choice_dataset)
   ```
 
   The elements of `result` will be:
@@ -218,17 +216,13 @@ def choose_from_datasets_v2(datasets,
     TypeError: If `datasets` or `choice_dataset` has the wrong type.
     ValueError: If `datasets` is empty.
   """
-  if not datasets:
-    raise ValueError("`datasets` must be a non-empty list of datasets.")
-  if choice_dataset is None or not structure.are_compatible(
-      choice_dataset.element_spec, tensor_spec.TensorSpec([], dtypes.int64)):
-    raise TypeError("`choice_dataset` must be a dataset of scalar "
-                    "`tf.int64` tensors.")
-  # pylint: disable=protected-access
-  return dataset_ops._DirectedInterleaveDataset(choice_dataset, datasets,
-                                                stop_on_empty_dataset)
+  return dataset_ops.Dataset.choose_from_datasets(
+      datasets=datasets,
+      choice_dataset=choice_dataset,
+      stop_on_empty_dataset=stop_on_empty_dataset)
 
-
+@deprecation.deprecated(None,
+                        "Use `tf.data.Dataset.choose_from_datasets(...)`.")
 @tf_export(v1=["data.experimental.choose_from_datasets"])
 def choose_from_datasets_v1(datasets,
                             choice_dataset,

--- a/tensorflow/python/data/experimental/ops/interleave_ops.py
+++ b/tensorflow/python/data/experimental/ops/interleave_ops.py
@@ -170,11 +170,13 @@ def sample_from_datasets_v1(datasets,
 sample_from_datasets_v1.__doc__ = sample_from_datasets_v2.__doc__
 
 @deprecation.deprecated(None,
-                        "Use `tf.data.Dataset.choose_from_datasets(...)`.")
+                        "Use `tf.data.Dataset.choose_from_datasets(...)`. "
+                        "Also, set `stop_on_empty_dataset=False` for deprecated"
+                        " experimental behaviour.")
 @tf_export("data.experimental.choose_from_datasets", v1=[])
 def choose_from_datasets_v2(datasets,
                             choice_dataset,
-                            stop_on_empty_dataset=False):
+                            stop_on_empty_dataset=True):
   """Creates a dataset that deterministically chooses elements from `datasets`.
 
   For example, given the following datasets:
@@ -205,8 +207,7 @@ def choose_from_datasets_v2(datasets,
       dataset. If `False`, it skips empty datasets. It is recommended to set it
       to `True`. Otherwise, the selected elements start off as the user intends,
       but may change as input datasets become empty. This can be difficult to
-      detect since the dataset starts off looking correct. Default to `False`
-      for backward compatibility.
+      detect since the dataset starts off looking correct. Defaults to `True`.
 
   Returns:
     A dataset that interleaves elements from `datasets` according to the values
@@ -222,11 +223,13 @@ def choose_from_datasets_v2(datasets,
       stop_on_empty_dataset=stop_on_empty_dataset)
 
 @deprecation.deprecated(None,
-                        "Use `tf.data.Dataset.choose_from_datasets(...)`.")
+                        "Use `tf.data.Dataset.choose_from_datasets(...)`."
+                        "Also, set `stop_on_empty_dataset=False` for deprecated"
+                        " experimental behaviour.")
 @tf_export(v1=["data.experimental.choose_from_datasets"])
 def choose_from_datasets_v1(datasets,
                             choice_dataset,
-                            stop_on_empty_dataset=False):
+                            stop_on_empty_dataset=True):
   return dataset_ops.DatasetV1Adapter(
       choose_from_datasets_v2(datasets, choice_dataset, stop_on_empty_dataset))
 

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -3232,7 +3232,7 @@ name=None))
   @staticmethod
   def choose_from_datasets(datasets,
                            choice_dataset,
-                           stop_on_empty_dataset=False):
+                           stop_on_empty_dataset=True):
     """Creates a dataset that deterministically chooses elements from `datasets`.
 
     For example, given the following datasets:
@@ -3264,7 +3264,7 @@ name=None))
         to set it to `True`. Otherwise, the selected elements start off as
         the user intends, but may change as input datasets become empty.
         This can be difficult to detect since the dataset starts off looking
-        correct. Default to `False` for backward compatibility.
+        correct. Defaults to `True`.
 
     Returns:
       A dataset that interleaves elements from `datasets` according to the

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -3229,6 +3229,61 @@ name=None))
     return _DirectedInterleaveDataset(selector_input, datasets,
                                       stop_on_empty_dataset)
 
+  @staticmethod
+  def choose_from_datasets(datasets,
+                           choice_dataset,
+                           stop_on_empty_dataset=False):
+    """Creates a dataset that deterministically chooses elements from `datasets`.
+
+    For example, given the following datasets:
+
+    ```python
+    datasets = [tf.data.Dataset.from_tensors("foo").repeat(),
+                tf.data.Dataset.from_tensors("bar").repeat(),
+                tf.data.Dataset.from_tensors("baz").repeat()]
+
+    # Define a dataset containing `[0, 1, 2, 0, 1, 2, 0, 1, 2]`.
+    choice_dataset = tf.data.Dataset.range(3).repeat(3)
+
+    result = tf.data.Dataset.choose_from_datasets(datasets, choice_dataset)
+    ```
+
+    The elements of `result` will be:
+
+    ```
+    "foo", "bar", "baz", "foo", "bar", "baz", "foo", "bar", "baz"
+    ```
+
+    Args:
+      datasets: A non-empty list of `tf.data.Dataset` objects with compatible
+        structure.
+      choice_dataset: A `tf.data.Dataset` of scalar `tf.int64` tensors
+        between `0` and `len(datasets) - 1`.
+      stop_on_empty_dataset: If `True`, selection stops if it encounters an
+        empty dataset. If `False`, it skips empty datasets. It is recommended
+        to set it to `True`. Otherwise, the selected elements start off as
+        the user intends, but may change as input datasets become empty.
+        This can be difficult to detect since the dataset starts off looking
+        correct. Default to `False` for backward compatibility.
+
+    Returns:
+      A dataset that interleaves elements from `datasets` according to the
+      values of `choice_dataset`.
+
+    Raises:
+      TypeError: If `datasets` or `choice_dataset` has the wrong type.
+      ValueError: If `datasets` is empty.
+    """
+    if not datasets:
+      raise ValueError("`datasets` must be a non-empty list of datasets.")
+    if choice_dataset is None or not structure.are_compatible(
+        choice_dataset.element_spec, tensor_spec.TensorSpec([], dtypes.int64)):
+      raise TypeError("`choice_dataset` must be a dataset of scalar "
+                      "`tf.int64` tensors.")
+    # pylint: disable=protected-access
+    return _DirectedInterleaveDataset(choice_dataset, datasets,
+                                                  stop_on_empty_dataset)
+
 
 @tf_export(v1=["data.Dataset"])
 class DatasetV1(DatasetV2):

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
@@ -48,6 +48,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
@@ -49,7 +49,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -51,7 +51,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }  
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -50,6 +50,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }  
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -51,7 +51,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   } 
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -50,6 +50,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  } 
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
@@ -51,7 +51,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-text-line-dataset.pbtxt
@@ -50,6 +50,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -51,7 +51,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -50,6 +50,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -51,7 +51,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -50,6 +50,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -51,7 +51,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -50,6 +50,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.experimental.pbtxt
@@ -122,7 +122,7 @@ tf_module {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "copy_to_device"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
@@ -36,7 +36,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
@@ -35,6 +35,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -38,7 +38,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-fixed-length-record-dataset.pbtxt
@@ -37,6 +37,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -37,7 +37,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-t-f-record-dataset.pbtxt
@@ -36,6 +36,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
@@ -38,7 +38,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-text-line-dataset.pbtxt
@@ -37,6 +37,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -38,7 +38,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-csv-dataset.pbtxt
@@ -37,6 +37,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -39,7 +39,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-random-dataset.pbtxt
@@ -38,6 +38,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -38,7 +38,7 @@ tf_class {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "concatenate"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.-sql-dataset.pbtxt
@@ -37,6 +37,10 @@ tf_class {
     argspec: "args=[\'self\'], varargs=None, keywords=None, defaults=None"
   }
   member_method {
+    name: "choose_from_datasets"
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+  }
+  member_method {
     name: "concatenate"
     argspec: "args=[\'self\', \'dataset\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.experimental.pbtxt
@@ -94,7 +94,7 @@ tf_module {
   }
   member_method {
     name: "choose_from_datasets"
-    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'False\'], "
+    argspec: "args=[\'datasets\', \'choice_dataset\', \'stop_on_empty_dataset\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
   member_method {
     name: "copy_to_device"


### PR DESCRIPTION
This PR graduates the `tf.data.experimental.choose_from_datasets` API into `tf.data.Dataset.choose_from_datasets` by making the following changes:

- [x] Adds the deprecation decorator for the experimental API.
- [x] Add the `choose_from_datasets()` method to DatasetV2 class.
- [x]  Updates example in documentation with new API.
- [x]  Regenerate golden API's.
- [x]  Updated the sample_from_datasets usage in tests.
- [x]  Updated the RELEASE.md file

cc: @aaudiber 