### PR TITLE
[PluggableDevice] Add range checks to TF_ExpectedOutputDataType in non-debug builds

### DIFF
--- a/tensorflow/c/kernels.cc
+++ b/tensorflow/c/kernels.cc
@@ -452,6 +452,8 @@ TF_StringView TF_OpKernelConstruction_GetName(TF_OpKernelConstruction* ctx) {
 
 TF_DataType TF_ExpectedOutputDataType(TF_OpKernelContext* ctx, int i) {
   auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
+  CHECK_GE(i, 0);
+  CHECK_LT(i, cc_ctx->num_outputs());
   return static_cast<TF_DataType>(cc_ctx->expected_output_dtype(i));
 }
 

--- a/tensorflow/c/kernels_test.cc
+++ b/tensorflow/c/kernels_test.cc
@@ -540,6 +540,14 @@ TEST(TestKernel, TestInputAndOutputCount) {
 
     EXPECT_EQ(TF_UINT8, TF_ExpectedOutputDataType(ctx, 0));
 
+    EXPECT_DEATH({
+      TF_ExpectedOutputDataType(ctx, 1);
+    }, "Check failed: i < cc_ctx->num_outputs");
+
+    EXPECT_DEATH({
+      TF_ExpectedOutputDataType(ctx, -1);
+    }, "Check failed: i >= 0");
+
     TF_DeleteStatus(s);
     if (input != nullptr) {
       TF_DeleteTensor(input);


### PR DESCRIPTION
The header comments of `TF_ExpectedOutputDataType` mention that the program aborts when passing an out-of-bounds index, but in non-debug builds we get an AV instead since `OpKernelContext::expected_output_dtype` uses `DCHECK_GE` and `DCHECK_LT` instead of `CHECK_GE` and `CHECK_LT`.