### PR TITLE
[PluggableDevice] Add TF_IsHostMemoryInput and TF_IsHostMemoryOutput to the C API

### DIFF
--- a/tensorflow/c/kernels.cc
+++ b/tensorflow/c/kernels.cc
@@ -471,6 +471,7 @@ bool TF_IsHostMemoryOutput(TF_OpKernelContext* ctx, int i, TF_Status* status) {
     TF_SetStatus(status, TF_OUT_OF_RANGE, "input index out of range");
     return false;
   }
+  TF_SetStatus(status, TF_OK, "");
   return cc_ctx->output_memory_type(i) == tensorflow::HOST_MEMORY;
 }
 

--- a/tensorflow/c/kernels.cc
+++ b/tensorflow/c/kernels.cc
@@ -468,7 +468,7 @@ bool TF_IsHostMemoryInput(TF_OpKernelContext* ctx, int i, TF_Status* status) {
 bool TF_IsHostMemoryOutput(TF_OpKernelContext* ctx, int i, TF_Status* status) {
   auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
   if (i < 0 || i >= cc_ctx->num_outputs()) {
-    TF_SetStatus(status, TF_OUT_OF_RANGE, "input index out of range");
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "output index out of range");
     return false;
   }
   TF_SetStatus(status, TF_OK, "");

--- a/tensorflow/c/kernels.cc
+++ b/tensorflow/c/kernels.cc
@@ -457,24 +457,20 @@ TF_DataType TF_ExpectedOutputDataType(TF_OpKernelContext* ctx, int i) {
 
 bool TF_IsHostMemoryInput(TF_OpKernelContext* ctx, int i, TF_Status* status) {
   auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
-
   if (i < 0 || i >= cc_ctx->num_inputs()) {
     TF_SetStatus(status, TF_OUT_OF_RANGE, "input index out of range");
     return false;
   }
-
   TF_SetStatus(status, TF_OK, "");
   return cc_ctx->input_memory_type(i) == tensorflow::HOST_MEMORY;
 }
 
 bool TF_IsHostMemoryOutput(TF_OpKernelContext* ctx, int i, TF_Status* status) {
   auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
-
   if (i < 0 || i >= cc_ctx->num_outputs()) {
     TF_SetStatus(status, TF_OUT_OF_RANGE, "input index out of range");
     return false;
   }
-
   return cc_ctx->output_memory_type(i) == tensorflow::HOST_MEMORY;
 }
 

--- a/tensorflow/c/kernels.cc
+++ b/tensorflow/c/kernels.cc
@@ -455,17 +455,26 @@ TF_DataType TF_ExpectedOutputDataType(TF_OpKernelContext* ctx, int i) {
   return static_cast<TF_DataType>(cc_ctx->expected_output_dtype(i));
 }
 
-bool TF_IsHostMemoryInput(TF_OpKernelContext* ctx, int i) {
+bool TF_IsHostMemoryInput(TF_OpKernelContext* ctx, int i, TF_Status* status) {
   auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
-  CHECK_GE(i, 0);
-  CHECK_LT(i, cc_ctx->num_inputs());
+
+  if (i < 0 || i >= cc_ctx->num_inputs()) {
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "input index out of range");
+    return false;
+  }
+
+  TF_SetStatus(status, TF_OK, "");
   return cc_ctx->input_memory_type(i) == tensorflow::HOST_MEMORY;
 }
 
-bool TF_IsHostMemoryOutput(TF_OpKernelContext* ctx, int i) {
+bool TF_IsHostMemoryOutput(TF_OpKernelContext* ctx, int i, TF_Status* status) {
   auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
-  CHECK_GE(i, 0);
-  CHECK_LT(i, cc_ctx->num_outputs());
+
+  if (i < 0 || i >= cc_ctx->num_outputs()) {
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "input index out of range");
+    return false;
+  }
+
   return cc_ctx->output_memory_type(i) == tensorflow::HOST_MEMORY;
 }
 

--- a/tensorflow/c/kernels.cc
+++ b/tensorflow/c/kernels.cc
@@ -455,6 +455,20 @@ TF_DataType TF_ExpectedOutputDataType(TF_OpKernelContext* ctx, int i) {
   return static_cast<TF_DataType>(cc_ctx->expected_output_dtype(i));
 }
 
+bool TF_IsHostMemoryInput(TF_OpKernelContext* ctx, int i) {
+  auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
+  CHECK_GE(i, 0);
+  CHECK_LT(i, cc_ctx->num_inputs());
+  return cc_ctx->input_memory_type(i) == tensorflow::HOST_MEMORY;
+}
+
+bool TF_IsHostMemoryOutput(TF_OpKernelContext* ctx, int i) {
+  auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
+  CHECK_GE(i, 0);
+  CHECK_LT(i, cc_ctx->num_outputs());
+  return cc_ctx->output_memory_type(i) == tensorflow::HOST_MEMORY;
+}
+
 int64_t TF_StepId(TF_OpKernelContext* ctx) {
   return reinterpret_cast<::tensorflow::OpKernelContext*>(ctx)->step_id();
 }

--- a/tensorflow/c/kernels.h
+++ b/tensorflow/c/kernels.h
@@ -181,6 +181,15 @@ TF_CAPI_EXPORT extern void TF_OpKernelContext_Failure(TF_OpKernelContext* ctx,
 TF_CAPI_EXPORT extern TF_DataType TF_ExpectedOutputDataType(
     TF_OpKernelContext* ctx, int i);
 
+// Returns true if the ith input is allocated in host memory. If i < 0 or i >=
+// TF_NumInputs(ctx), the program aborts.
+TF_CAPI_EXPORT extern bool TF_IsHostMemoryInput(TF_OpKernelContext* ctx, int i);
+
+// Returns true if the ith output is allocated in host memory. If i < 0 or i >=
+// TF_NumOutputs(ctx), the program aborts.
+TF_CAPI_EXPORT extern bool TF_IsHostMemoryOutput(TF_OpKernelContext* ctx,
+                                                 int i);
+
 // Returns the step ID of the given context.
 TF_CAPI_EXPORT extern int64_t TF_StepId(TF_OpKernelContext* ctx);
 

--- a/tensorflow/c/kernels.h
+++ b/tensorflow/c/kernels.h
@@ -183,12 +183,13 @@ TF_CAPI_EXPORT extern TF_DataType TF_ExpectedOutputDataType(
 
 // Returns true if the ith input is allocated in host memory. If i < 0 or i >=
 // TF_NumInputs(ctx), the program aborts.
-TF_CAPI_EXPORT extern bool TF_IsHostMemoryInput(TF_OpKernelContext* ctx, int i);
+TF_CAPI_EXPORT extern bool TF_IsHostMemoryInput(TF_OpKernelContext* ctx, int i,
+                                                TF_Status* status);
 
 // Returns true if the ith output is allocated in host memory. If i < 0 or i >=
 // TF_NumOutputs(ctx), the program aborts.
-TF_CAPI_EXPORT extern bool TF_IsHostMemoryOutput(TF_OpKernelContext* ctx,
-                                                 int i);
+TF_CAPI_EXPORT extern bool TF_IsHostMemoryOutput(TF_OpKernelContext* ctx, int i,
+                                                 TF_Status* status);
 
 // Returns the step ID of the given context.
 TF_CAPI_EXPORT extern int64_t TF_StepId(TF_OpKernelContext* ctx);

--- a/tensorflow/c/kernels_test.cc
+++ b/tensorflow/c/kernels_test.cc
@@ -677,6 +677,22 @@ TEST(TestKernel, TestHostMemory) {
     EXPECT_EQ(true, TF_IsHostMemoryInput(ctx, 1));
     EXPECT_EQ(true, TF_IsHostMemoryOutput(ctx, 0));
     EXPECT_EQ(false, TF_IsHostMemoryOutput(ctx, 1));
+
+    EXPECT_DEATH({
+      TF_IsHostMemoryInput(ctx, -1);
+    }, "Check failed: i >= 0");
+
+    EXPECT_DEATH({
+      TF_IsHostMemoryInput(ctx, 2);
+    }, "Check failed: i < cc_ctx->num_inputs()");
+
+    EXPECT_DEATH({
+      TF_IsHostMemoryOutput(ctx, -1);
+    }, "Check failed: i >= 0");
+
+    EXPECT_DEATH({
+      TF_IsHostMemoryOutput(ctx, 2);
+    }, "Check failed: i < cc_ctx->num_outputs()");
   };
 
   TF_KernelBuilder* builder = TF_NewKernelBuilder(

--- a/tensorflow/c/kernels_test.cc
+++ b/tensorflow/c/kernels_test.cc
@@ -673,26 +673,41 @@ TEST(TestKernel, TestHostMemory) {
   auto my_compute_func = [](void* kernel, TF_OpKernelContext* ctx) {
     MyComputeFunc(kernel, ctx);
 
-    EXPECT_EQ(false, TF_IsHostMemoryInput(ctx, 0));
-    EXPECT_EQ(true, TF_IsHostMemoryInput(ctx, 1));
-    EXPECT_EQ(true, TF_IsHostMemoryOutput(ctx, 0));
-    EXPECT_EQ(false, TF_IsHostMemoryOutput(ctx, 1));
+    TF_Status* status = TF_NewStatus();
 
-    EXPECT_DEATH({
-      TF_IsHostMemoryInput(ctx, -1);
-    }, "Check failed: i >= 0");
+    TF_SetStatus(status, TF_OK, "");
+    EXPECT_EQ(false, TF_IsHostMemoryInput(ctx, 0, status));
+    EXPECT_EQ(TF_OK, TF_GetCode(status));
 
-    EXPECT_DEATH({
-      TF_IsHostMemoryInput(ctx, 2);
-    }, "Check failed: i < cc_ctx->num_inputs()");
+    TF_SetStatus(status, TF_OK, "");
+    EXPECT_EQ(true, TF_IsHostMemoryInput(ctx, 1, status));
+    EXPECT_EQ(TF_OK, TF_GetCode(status));
 
-    EXPECT_DEATH({
-      TF_IsHostMemoryOutput(ctx, -1);
-    }, "Check failed: i >= 0");
+    TF_SetStatus(status, TF_OK, "");
+    EXPECT_EQ(true, TF_IsHostMemoryOutput(ctx, 0, status));
+    EXPECT_EQ(TF_OK, TF_GetCode(status));
 
-    EXPECT_DEATH({
-      TF_IsHostMemoryOutput(ctx, 2);
-    }, "Check failed: i < cc_ctx->num_outputs()");
+    TF_SetStatus(status, TF_OK, "");
+    EXPECT_EQ(false, TF_IsHostMemoryOutput(ctx, 1, status));
+    EXPECT_EQ(TF_OK, TF_GetCode(status));
+
+    TF_SetStatus(status, TF_OK, "");
+    TF_IsHostMemoryInput(ctx, -1, status);
+    EXPECT_EQ(TF_OUT_OF_RANGE, TF_GetCode(status));
+
+    TF_SetStatus(status, TF_OK, "");
+    TF_IsHostMemoryInput(ctx, 2, status);
+    EXPECT_EQ(TF_OUT_OF_RANGE, TF_GetCode(status));
+
+    TF_SetStatus(status, TF_OK, "");
+    TF_IsHostMemoryOutput(ctx, -1, status);
+    EXPECT_EQ(TF_OUT_OF_RANGE, TF_GetCode(status));
+
+    TF_SetStatus(status, TF_OK, "");
+    TF_IsHostMemoryOutput(ctx, 2, status);
+    EXPECT_EQ(TF_OUT_OF_RANGE, TF_GetCode(status));
+
+    TF_DeleteStatus(status);
   };
 
   TF_KernelBuilder* builder = TF_NewKernelBuilder(

--- a/tensorflow/c/kernels_test.cc
+++ b/tensorflow/c/kernels_test.cc
@@ -28,6 +28,7 @@ limitations under the License.
 
 #include "absl/container/inlined_vector.h"
 #include "absl/strings/str_format.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/c/c_api.h"
 #include "tensorflow/c/tf_datatype.h"
 #include "tensorflow/c/tf_status.h"
@@ -52,7 +53,6 @@ limitations under the License.
 #include "tensorflow/core/platform/status.h"
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/platform/types.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 struct MyCustomKernel {
   bool created;


### PR DESCRIPTION
This reduces boilerplate logic in pluggable devices code that decouple operator registration from kernel implementation. This also makes the transition from TF 1.15 to 2.x easier since the same device code in 1.15 would have been able to use `OpKernelContext::input_memory_type`.