### PR TITLE
[PluggableDevice] Add TF_OpkernelConstruction_GetAttrNamesList

### DIFF
--- a/tensorflow/c/kernels.h
+++ b/tensorflow/c/kernels.h
@@ -184,6 +184,23 @@ TF_CAPI_EXPORT extern TF_DataType TF_ExpectedOutputDataType(
 // Returns the step ID of the given context.
 TF_CAPI_EXPORT extern int64_t TF_StepId(TF_OpKernelContext* ctx);
 
+// Get the list_size and total_size of the attribute names for this kernel.
+// list_size - the length of the list.
+// total_size - the cumulative byte size of all the names in the list.
+TF_CAPI_EXPORT extern void TF_OpkernelConstruction_GetAttrNamesSize(
+    TF_OpKernelConstruction* ctx, int32_t* list_size, int32_t* total_size);
+
+// Gets the list of attribute names for this kernel by filling in `values` and
+// `lengths`, each of which must point to an array of length at least
+// `max_values`. *status is set to TF_OK. The elements of values will point to
+// addresses in `storage` which must be at least `storage_size` bytes in length.
+// Ideally, max_values would be set to list_size and `storage` would be at least
+// total_size, obtained from TF_OpkernelConstruction_GetAttrNameSize(ctx,
+// list_size, total_size).
+TF_CAPI_EXPORT extern void TF_OpkernelConstruction_GetAttrNamesList(
+    TF_OpKernelConstruction* ctx, char** values, size_t* lengths,
+    int max_values, void* storage, size_t storage_size, TF_Status* status);
+
 // Get the list_size and total_size of the attribute `attr_name` of `oper`.
 // list_size - the length of the list.
 // total_size - total size of the list.

--- a/tensorflow/c/kernels_test.cc
+++ b/tensorflow/c/kernels_test.cc
@@ -28,6 +28,7 @@ limitations under the License.
 
 #include "absl/container/inlined_vector.h"
 #include "absl/strings/str_format.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/c/c_api.h"
 #include "tensorflow/c/tf_datatype.h"
 #include "tensorflow/c/tf_status.h"
@@ -52,7 +53,6 @@ limitations under the License.
 #include "tensorflow/core/platform/status.h"
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/platform/types.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 struct MyCustomKernel {
   bool created;


### PR DESCRIPTION
Attribute names, along with their corresponding values, could be used in TF 1.15 by devices to compute hashes of kernels and uniquely identify them for caching purposes. I believe this is an important feature to keep because some device backends have relatively slow kernel creation times and need a way to know whether a kernel that was created previously can be reused or not.