### PR TITLE
Fix abseil compile error using proper HWAES flag on aarch64.

### DIFF
--- a/third_party/absl/com_google_absl_fix_mac_and_nvcc_build.patch
+++ b/third_party/absl/com_google_absl_fix_mac_and_nvcc_build.patch
@@ -252,3 +252,23 @@ index 45a9529..57c954e 100644
      visibility = ["//visibility:public"],
      deps = [
          ":civil_time",
+diff --git a/absl/copts/configure_copts.bzl b/absl/copts/configure_copts.bzl
+index 45a9529..57c954e 100644
+--- a/absl/copts/configure_copts.bzl	2021-09-01 19:31:28.871165726 +0300
++++ b/absl/copts/configure_copts.bzl	2021-09-01 19:31:37.702095719 +0300
+@@ -50,6 +50,7 @@
+     ":cpu_x64_windows": ABSL_RANDOM_HWAES_MSVC_X64_FLAGS,
+     ":cpu_k8": ABSL_RANDOM_HWAES_X64_FLAGS,
+     ":cpu_ppc": ["-mcrypto"],
++    ":cpu_aarch64": ABSL_RANDOM_HWAES_ARM64_FLAGS,
+ 
+     # Supported by default or unsupported.
+     "//conditions:default": [],
+@@ -70,6 +71,7 @@
+         "darwin",
+         "x64_windows_msvc",
+         "x64_windows",
++        "aarch64",
+     ]
+     for cpu in cpu_configs:
+         native.config_setting(


### PR DESCRIPTION
This small PR fixes a compile error on aarch64.

   - It backports a future [absl upstream fix](https://github.com/abseil/abseil-cpp/commit/2e94e5b6e152df9fa9c2fe8c1b96e1393973d32c) of the issue
   -  Fixes compilation [reported in the issue #51750](https://github.com/tensorflow/tensorflow/issues/51750#issuecomment-910717534) 
   
Other way to address the issue is to rise up [abseil requirement](https://github.com/tensorflow/tensorflow/blob/master/third_party/absl/workspace.bzl#L10) to the minimum of this [commit hash](https://github.com/abseil/abseil-cpp/commit/2e94e5b6e152df9fa9c2fe8c1b96e1393973d32c).

Thank you !