### PR TITLE
backport pr 45534 to TF 2.4

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4668,6 +4668,7 @@ def reverse_sequence(input,
 
 
 @tf_export("reverse_sequence", v1=[])
+@dispatch.add_dispatch_support
 def reverse_sequence_v2(input,
                         seq_lengths,
                         seq_axis=None,


### PR DESCRIPTION
backport #45534 to TF 2.4, which will solve the issue for CRF function in TensorFlow addons tensorflow/addons#2250 .

The credits belongs to @WindQAQ 