### PR TITLE
[TFLite] Force the MLIR quantizer to assign the same scale for the quantized operand and result of the FILL op

### DIFF
--- a/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
+++ b/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
@@ -1675,6 +1675,7 @@ shape(squeeze(t, [2, 4])) ==> [1, 2, 3, 1]
 
 def TFL_FillOp: TFL_Op<"fill", [
     NoSideEffect,
+    SameOperandsAndResultsScale,
     PredOpTrait<"input and result must have same element type",
       TFL_TCresVTEtIsSameAsOp<0, 1>>]> {
   let summary = "Fill the tensor with given value.";


### PR DESCRIPTION
Hi,

This PR forces the MLIR quantizer to assign the same scale for the quantized operand and result of the FILL operator in a way [similar](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/tools/optimize/operator_property.cc#L200) to the old TOCO quantizer as it's [required](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/kernels/fill.cc#L95) by the operator.

Thibaut