### PR TITLE
Bugfix/label image fixes

### DIFF
--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -58,7 +58,7 @@ class DelegateProviders {
  public:
   DelegateProviders() : delegate_list_util_(&params_) {
     delegate_list_util_.AddAllDelegateParams();
-    delegate_list_util_.AppendCmdlineFlags(&flags_);
+    delegate_list_util_.AppendCmdlineFlags(flags_);
 
     // Remove the "help" flag to avoid printing "--help=false"
     params_.RemoveParam("help");

--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -309,12 +309,10 @@ void RunInference(Settings* settings,
   interpreter->SetProfiler(profiler.get());
 
   if (settings->profiling) profiler->StartProfiling();
-  if (settings->loop_count > 1) {
-    for (int i = 0; i < settings->number_of_warmup_runs; i++) {
-      if (interpreter->Invoke() != kTfLiteOk) {
-        LOG(ERROR) << "Failed to invoke tflite!";
-        exit(-1);
-      }
+  for (int i = 0; i < settings->number_of_warmup_runs; i++) {
+    if (interpreter->Invoke() != kTfLiteOk) {
+      LOG(ERROR) << "Failed to invoke tflite!";
+      exit(-1);
     }
   }
 

--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -58,21 +58,20 @@ class DelegateProviders {
  public:
   DelegateProviders() : delegate_list_util_(&params_) {
     delegate_list_util_.AddAllDelegateParams();
+    delegate_list_util_.AppendCmdlineFlags(&flags_);
+
+    // Remove the "help" flag to avoid printing "--help=false"
+    params_.RemoveParam("help");
+    delegate_list_util_.RemoveCmdlineFlag(flags_, "help");
   }
 
   // Initialize delegate-related parameters from parsing command line arguments,
   // and remove the matching arguments from (*argc, argv). Returns true if all
   // recognized arg values are parsed correctly.
   bool InitFromCmdlineArgs(int* argc, const char** argv) {
-    std::vector<tflite::Flag> flags;
-    delegate_list_util_.AppendCmdlineFlags(&flags);
-
-    const bool parse_result = Flags::Parse(argc, argv, flags);
-    if (!parse_result) {
-      std::string usage = Flags::Usage(argv[0], flags);
-      LOG(ERROR) << usage;
-    }
-    return parse_result;
+    // Note if '--help' is in argv, the Flags::Parse return false,
+    // see the return expression in Flags::Parse.
+    return Flags::Parse(argc, argv, flags_);
   }
 
   // According to passed-in settings `s`, this function sets corresponding
@@ -139,6 +138,10 @@ class DelegateProviders {
     return delegate_list_util_.CreateAllRankedDelegates();
   }
 
+  std::string GetHelpMessage(const std::string& cmdline) const {
+    return Flags::Usage(cmdline, flags_);
+  }
+
  private:
   // Contain delegate-related parameters that are initialized from command-line
   // flags.
@@ -146,6 +149,9 @@ class DelegateProviders {
 
   // A helper to create TfLite delegates.
   ProvidedDelegateList delegate_list_util_;
+
+  // Contains valid flags
+  std::vector<tflite::Flag> flags_;
 };
 
 // Takes a file name, and loads a list of labels from it, one per line, and
@@ -390,25 +396,27 @@ void RunInference(Settings* settings,
   }
 }
 
-void display_usage() {
+void display_usage(const DelegateProviders &delegate_providers) {
   LOG(INFO)
-      << "label_image\n"
-      << "--accelerated, -a: [0|1], use Android NNAPI or not\n"
-      << "--allow_fp16, -f: [0|1], allow running fp32 models with fp16 or not\n"
-      << "--count, -c: loop interpreter->Invoke() for certain times\n"
-      << "--gl_backend, -g: [0|1]: use GL GPU Delegate on Android\n"
-      << "--hexagon_delegate, -j: [0|1]: use Hexagon Delegate on Android\n"
-      << "--input_mean, -b: input mean\n"
-      << "--input_std, -s: input standard deviation\n"
-      << "--image, -i: image_name.bmp\n"
-      << "--labels, -l: labels for the model\n"
-      << "--tflite_model, -m: model_name.tflite\n"
-      << "--profiling, -p: [0|1], profiling or not\n"
-      << "--num_results, -r: number of results to show\n"
-      << "--threads, -t: number of threads\n"
-      << "--verbose, -v: [0|1] print more information\n"
-      << "--warmup_runs, -w: number of warmup runs\n"
-      << "--xnnpack_delegate, -x [0:1]: xnnpack delegate\n";
+      << "\n"
+      << delegate_providers.GetHelpMessage("label_image")
+      << "\t--accelerated, -a: [0|1] use Android NNAPI or not\n"
+      << "\t--allow_fp16, -f: [0|1], allow running fp32 models with fp16 or not\n"
+      << "\t--count, -c: loop interpreter->Invoke() for certain times\n"
+      << "\t--gl_backend, -g: [0|1]: use GL GPU Delegate on Android\n"
+      << "\t--hexagon_delegate, -j: [0|1]: use Hexagon Delegate on Android\n"
+      << "\t--input_mean, -b: input mean\n"
+      << "\t--input_std, -s: input standard deviation\n"
+      << "\t--image, -i: image_name.bmp\n"
+      << "\t--labels, -l: labels for the model\n"
+      << "\t--tflite_model, -m: model_name.tflite\n"
+      << "\t--profiling, -p: [0|1], profiling or not\n"
+      << "\t--num_results, -r: number of results to show\n"
+      << "\t--threads, -t: number of threads\n"
+      << "\t--verbose, -v: [0|1] print more information\n"
+      << "\t--warmup_runs, -w: number of warmup runs\n"
+      << "\t--xnnpack_delegate, -x [0:1]: xnnpack delegate\n"
+      << "\t--help, -h: Print this help message\n";
 }
 
 int Main(int argc, char** argv) {
@@ -416,6 +424,7 @@ int Main(int argc, char** argv) {
   bool parse_result = delegate_providers.InitFromCmdlineArgs(
       &argc, const_cast<const char**>(argv));
   if (!parse_result) {
+    display_usage(delegate_providers);
     return EXIT_FAILURE;
   }
 
@@ -441,13 +450,14 @@ int Main(int argc, char** argv) {
         {"gl_backend", required_argument, nullptr, 'g'},
         {"hexagon_delegate", required_argument, nullptr, 'j'},
         {"xnnpack_delegate", required_argument, nullptr, 'x'},
+        {"help", no_argument, nullptr, 'h'},
         {nullptr, 0, nullptr, 0}};
 
     /* getopt_long stores the option index here. */
     int option_index = 0;
 
     c = getopt_long(argc, argv,
-                    "a:b:c:d:e:f:g:i:j:l:m:p:r:s:t:v:w:x:", long_options,
+                    "a:b:c:d:e:f:g:i:j:l:m:p:r:s:t:v:w:x:h", long_options,
                     &option_index);
 
     /* Detect the end of the options. */
@@ -518,7 +528,7 @@ int Main(int argc, char** argv) {
       case 'h':
       case '?':
         /* getopt_long already printed an error message. */
-        display_usage();
+        display_usage(delegate_providers);
         exit(-1);
       default:
         exit(-1);

--- a/tensorflow/lite/kernels/test_delegate_providers.cc
+++ b/tensorflow/lite/kernels/test_delegate_providers.cc
@@ -41,7 +41,7 @@ bool KernelTestDelegateProviders::InitFromCmdlineArgs(int* argc,
         this->params_.Set<bool>(kUseSimpleAllocator, val, argv_position);
       },
       false, "Use Simple Memory Allocator for SingleOpModel", Flag::kOptional)};
-  delegate_list_util_.AppendCmdlineFlags(&flags);
+  delegate_list_util_.AppendCmdlineFlags(flags);
 
   bool parse_result = tflite::Flags::Parse(argc, argv, flags);
   if (!parse_result || params_.Get<bool>("help")) {

--- a/tensorflow/lite/tools/benchmark/benchmark_tflite_model.cc
+++ b/tensorflow/lite/tools/benchmark/benchmark_tflite_model.cc
@@ -364,7 +364,7 @@ std::vector<Flag> BenchmarkTfLiteModel::GetFlags() {
   flags.insert(flags.end(), specific_flags.begin(), specific_flags.end());
 
   tools::ProvidedDelegateList delegate_providers(&params_);
-  delegate_providers.AppendCmdlineFlags(&flags);
+  delegate_providers.AppendCmdlineFlags(flags);
 
   return flags;
 }

--- a/tensorflow/lite/tools/command_line_flags.h
+++ b/tensorflow/lite/tools/command_line_flags.h
@@ -117,6 +117,8 @@ class Flag {
 
   FlagType GetFlagType() const { return flag_type_; }
 
+  std::string GetFlagName() const { return name_; };
+
  private:
   friend class Flags;
 

--- a/tensorflow/lite/tools/delegates/delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/delegate_provider.cc
@@ -25,10 +25,10 @@ void ProvidedDelegateList::AddAllDelegateParams() const {
   }
 }
 
-void ProvidedDelegateList::AppendCmdlineFlags(std::vector<Flag>* flags) const {
+void ProvidedDelegateList::AppendCmdlineFlags(std::vector<Flag>& flags) const {
   for (const auto& provider : providers_) {
     auto delegate_flags = provider->CreateFlags(params_);
-    flags->insert(flags->end(), delegate_flags.begin(), delegate_flags.end());
+    flags.insert(flags.end(), delegate_flags.begin(), delegate_flags.end());
   }
 }
 

--- a/tensorflow/lite/tools/delegates/delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/delegate_provider.cc
@@ -32,6 +32,18 @@ void ProvidedDelegateList::AppendCmdlineFlags(std::vector<Flag>* flags) const {
   }
 }
 
+void ProvidedDelegateList::RemoveCmdlineFlag(std::vector<Flag>& flags,
+                                             const std::string& name) const {
+  decltype(flags.begin()) it;
+  for (it = flags.begin(); it < flags.end();) {
+    if (it->GetFlagName() == name) {
+      flags.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
 std::vector<ProvidedDelegateList::ProvidedDelegate>
 ProvidedDelegateList::CreateAllRankedDelegates(const ToolParams& params) const {
   std::vector<ProvidedDelegateList::ProvidedDelegate> delegates;

--- a/tensorflow/lite/tools/delegates/delegate_provider.h
+++ b/tensorflow/lite/tools/delegates/delegate_provider.h
@@ -143,7 +143,7 @@ class ProvidedDelegateList {
   // Append command-line parsable flags to 'flags' of all registered delegate
   // providers, and associate the flag values at runtime with the contained
   // 'params_'.
-  void AppendCmdlineFlags(std::vector<Flag>* flags) const;
+  void AppendCmdlineFlags(std::vector<Flag>& flags) const;
 
   // Removes command-line parsable flag 'name' from 'flags'
   void RemoveCmdlineFlag(std::vector<Flag>& flags,

--- a/tensorflow/lite/tools/delegates/delegate_provider.h
+++ b/tensorflow/lite/tools/delegates/delegate_provider.h
@@ -145,6 +145,10 @@ class ProvidedDelegateList {
   // 'params_'.
   void AppendCmdlineFlags(std::vector<Flag>* flags) const;
 
+  // Removes command-line parsable flag 'name' from 'flags'
+  void RemoveCmdlineFlag(std::vector<Flag>& flags,
+                         const std::string& name) const;
+
   // Return a list of TfLite delegates based on the provided 'params', and the
   // list has been already sorted in ascending order according to the rank of
   // the particular parameter that enables the creation of the delegate.

--- a/tensorflow/lite/tools/delegates/delegate_provider_test.cc
+++ b/tensorflow/lite/tools/delegates/delegate_provider_test.cc
@@ -38,7 +38,7 @@ TEST(ProvidedDelegateListTest, AppendCmdlineFlags) {
   ProvidedDelegateList providers(&params);
   providers.AddAllDelegateParams();
 
-  providers.AppendCmdlineFlags(&flags);
+  providers.AppendCmdlineFlags(flags);
   EXPECT_FALSE(flags.empty());
 }
 

--- a/tensorflow/lite/tools/evaluation/evaluation_delegate_provider.cc
+++ b/tensorflow/lite/tools/evaluation/evaluation_delegate_provider.cc
@@ -91,7 +91,7 @@ DelegateProviders::DelegateProviders()
 
 std::vector<Flag> DelegateProviders::GetFlags() {
   std::vector<Flag> flags;
-  delegate_list_util_.AppendCmdlineFlags(&flags);
+  delegate_list_util_.AppendCmdlineFlags(flags);
   return flags;
 }
 

--- a/tensorflow/lite/tools/tool_params.h
+++ b/tensorflow/lite/tools/tool_params.h
@@ -117,6 +117,10 @@ class ToolParams {
     params_[name] = std::move(value);
   }
 
+  void RemoveParam(const std::string& name) {
+      params_.erase(name);
+  }
+
   bool HasParam(const std::string& name) const {
     return params_.find(name) != params_.end();
   }


### PR DESCRIPTION
This PR fixes following issues with label_image TFLite example: 

1. Behavior of _loop count_ (-c) and _warm_up count_ (-w) command line switch:
Without this patch the warmup_count depends on loop_counts. If the loop_count is less than 2, no warmup loop is performed. E.g. this call will make no warm up loops, however explicitly requested:
`$ ./label_image -c1 -w2`
This call will make 2 Interptetter::Invoke() loops and 2 warm up calls:
`$ ./label_image -c2 -w2`
With this patch, both commands will do 1 resp. 2 Intepretter::Invoke loops and 2 warm up loops, as intuitively expected. 

2. Help message printing for label_image:
There are two paths from where the help message is printed, with different content:
`$ ./label_image -h` will print the help message defined in display_usage(). Moreover it does not even recognize the -h option and getopt print Unrecognized switch error (-h is missing in getopt optstring).
`$ ./label_image --help` prints the help message provided by delegate registrar. 
Switches in both help messages are valid, so none of the help messages provides a complete usage information. 
This patch fix the issue and unites the messages. 