### PR TITLE
Add CITATION.cff for GitHub software citation support

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,93 @@
+cff-version: 1.2.0
+message: "If you use TensorFlow in your research, please cite it using these metadata. Software is available from tensorflow.org."
+title: TensorFlow, Large-scale machine learning on heterogeneous systems
+abstract: TensorFlow is a machine learning system that operates at large scale and in heterogeneous environments. TensorFlow uses dataflow graphs to represent computation, shared state, and the operations that mutate that state. It maps the nodes of a dataflow graph across many machines in a cluster, and within a machine across multiple computational devices, including multicore CPUs, general purpose GPUs, and custom-designed ASICs known as Tensor Processing Units (TPUs). This architecture gives flexibility to the application developer, whereas in previous “parameter server” designs the management of shared state is built into the system, TensorFlow enables developers to experiment with novel optimizations and training algorithms. TensorFlow supports a variety of applications, with a focus on training and inference on deep neural networks. Several Google services use TensorFlow in production, we have released it as an open-source project, and it has become widely used for machine learning research. In this paper, we describe the TensorFlow dataflow model and demonstrate the compelling performance that TensorFlow achieves for several real-world applications.
+authors:
+  - family-names: Abadi
+    given-names: Martín
+  - family-names: Agarwal
+    given-names: Ashish
+  - family-names: Barham
+    given-names: Paul
+  - family-names: Brevdo
+    given-names: Eugene
+  - family-names: Chen
+    given-names: Zhifeng
+  - family-names: Citro
+    given-names: Craig
+  - family-names: Corrado
+    given-names: Greg S.
+  - family-names: Davis
+    given-names: Andy
+  - family-names: Dean
+    given-names: Jeffrey
+  - family-names: Devin
+    given-names: Matthieu
+  - family-names: Ghemawat
+    given-names: Sanjay
+  - family-names: Goodfellow
+    given-names: Ian
+  - family-names: Harp
+    given-names: Andrew
+  - family-names: Irving
+    given-names: Geoffrey
+  - family-names: Isard
+    given-names: Michael
+  - family-names: Jozefowicz
+    given-names: Rafal
+  - family-names: Jia
+    given-names: Yangqing
+  - family-names: Kaiser
+    given-names: Lukasz
+  - family-names: Kudlur
+    given-names: Manjunath
+  - family-names: Levenberg
+    given-names: Josh
+  - family-names: Mané
+    given-names: Dan
+  - family-names: Schuster
+    given-names: Mike
+  - family-names: Monga
+    given-names: Rajat
+  - family-names: Moore
+    given-names: Sherry
+  - family-names: Murray
+    given-names: Derek
+  - family-names: Olah
+    given-names: Chris
+  - family-names: Shlens
+    given-names: Jonathon
+  - family-names: Steiner
+    given-names: Benoit
+  - family-names: Sutskever
+    given-names: Ilya
+  - family-names: Talwar
+    given-names: Kunal
+  - family-names: Tucker
+    given-names: Paul
+  - family-names: Vanhoucke
+    given-names: Vincent
+  - family-names: Vasudevan
+    given-names: Vijay
+  - family-names: Viégas
+    given-names: Fernanda
+  - family-names: Vinyals
+    given-names: Oriol
+  - family-names: Warden
+    given-names: Pete
+  - family-names: Wattenberg
+    given-names: Martin
+  - family-names: Wicke
+    given-names: Martin
+  - family-names: Yu
+    given-names: Yuan
+  - family-names: Zheng
+    given-names: Xiaoqiang
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.4724125
+    description: The concept DOI for the collection containing all versions of the Citation File Format.
+date-released: "2015-11-09"
+license: "Apache-2.0"
+doi: 10.5281/zenodo.4724125
+ 


### PR DESCRIPTION
Hi,

GitHub recently has added support for citing software (See official post and documentation [here](https://github.blog/2021-08-19-enhanced-support-citations-github/) and [here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files)). For repositories that have a CITATION.cff file in their main branch, GitHub will automatically parse a citation for users.

I happen to notice that the project website has a page clarifying how to cite TensorFlow. A BibTex is also carefully provided. What I did is simply to turn that BibTex into a valid CITATION.cff.

If interested you could also specify version releases in the CITATION.cff. For more information about it, see [here](https://citation-file-format.github.io/) and [here](https://github.com/citation-file-format/citation-file-format).

Thanks for attending to my PR.