### PR TITLE
[XLA, GPU] Make kExp not expensive

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/instruction_fusion.cc
+++ b/tensorflow/compiler/xla/service/gpu/instruction_fusion.cc
@@ -44,6 +44,7 @@ bool ElementIsF32OrF16(const Shape& shape) {
   switch (instruction.opcode()) {
     case HloOpcode::kDivide:
     case HloOpcode::kRsqrt:
+    case HloOpcode::kExp:
       if (ElementIsF32OrF16(instruction.shape())) {
         return false;
       }

--- a/tensorflow/compiler/xla/service/gpu/instruction_fusion_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/instruction_fusion_test.cc
@@ -36,11 +36,11 @@ TEST_F(InstructionFusionTest,
   HloComputation::Builder builder(TestName());
   HloInstruction* const0 = builder.AddInstruction(
       HloInstruction::CreateConstant(LiteralUtil::CreateR0(5.0f)));
-  HloInstruction* exp1 = builder.AddInstruction(HloInstruction::CreateUnary(
-      ShapeUtil::MakeShape(F32, {}), HloOpcode::kExp, const0));
+  HloInstruction* log1 = builder.AddInstruction(HloInstruction::CreateUnary(
+      ShapeUtil::MakeShape(F32, {}), HloOpcode::kLog, const0));
   HloInstruction* broadcast2 =
       builder.AddInstruction(HloInstruction::CreateBroadcast(
-          ShapeUtil::MakeShape(F32, {1}), exp1, {}));
+          ShapeUtil::MakeShape(F32, {1}), log1, {}));
 
   auto module = CreateNewVerifiedModule();
   auto computation = module->AddEntryComputation(builder.Build());


### PR DESCRIPTION
This trigger better fusion for EfficientNet and allow to increase the mini-batch size used.
This remove one temporary from the forward to the backward.

At the bottom, there is a python script with a snippet of EfficientNet that show the difference in behavior before and after this PR.
Using replay_computation on the hlo from this script on a V100, I have before this PR:
```
2021-09-07 18:59:47.897674: I tensorflow/compiler/xla/tools/replay_computation.cc:336] Done executing in 0.005307s: a_inference_train_315__XlaMustCompile_true_config_proto___n_007_n_0...02_001_000__executor_type____.188
```
and after this PR
```
2021-09-07 18:59:24.847251: I tensorflow/compiler/xla/tools/replay_computation.cc:336] Done executing in 0.004999s: a_inference_train_315__XlaMustCompile_true_config_proto___n_007_n_0...02_001_000__executor_type____.188
```
So this also give a speed up on V100. 

```
#!/usr/bin/env python

# Usage: XLA_FLAGS="--xla_dump_to=xla-swish --xla_dump_hlo_as_text --xla_dump_hlo_as_dot --xla_dump_hlo_as_html" python swish.v3.py

import tensorflow as tf
import numpy as np

tf.keras.backend.clear_session()
tf.config.optimizer.set_jit(True)
tf.keras.backend.set_image_data_format('channels_last')
policy = tf.keras.mixed_precision.experimental.Policy('mixed_float16', loss_scale='dynamic')
tf.keras.mixed_precision.experimental.set_policy(policy)

# Can't use model = tf.keras.models.Sequential([]) due to BN training
class Foo(tf.keras.Model):
    def __init__(self):
        super(Foo, self).__init__()
        self.conv1 = tf.keras.layers.DepthwiseConv2D(kernel_size=3, padding='same', data_format='channels_last', use_bias=False)
        self.bn1 = tf.keras.layers.BatchNormalization(axis=-1)
        self.act1 = tf.keras.layers.Activation('swish')
        self.conv2 = tf.keras.layers.DepthwiseConv2D(kernel_size=3, padding='same', data_format='channels_last', use_bias=False)
        self.fc = tf.keras.layers.Dense(10, use_bias=False)

    def call(self, x):
        x = self.act1(self.bn1(self.conv1(x), training=True))
        return self.fc(self.conv2(x))

model = Foo()

inp = tf.Variable(np.random.normal(size=(512, 14, 14, 672)), dtype=tf.float16)
oup = tf.random.uniform((512, 14, 14, 10), dtype=tf.float16)

@tf.function(experimental_compile=True)
def train(inp, oup):
    with tf.GradientTape() as tape:
        preds = model(inp)
        loss = tf.keras.losses.mse(preds, oup)
        grads = tape.gradient(loss, model.trainable_variables)
    return loss, grads

print("Before train")
train(inp, oup)
print("Script end")
```

@sanjoy @cheshire 