### PR TITLE
[oneDNN] Fixing tensorflow/python/framework/node_file_writer_test

### DIFF
--- a/tensorflow/python/framework/node_file_writer_test.py
+++ b/tensorflow/python/framework/node_file_writer_test.py
@@ -26,6 +26,7 @@ from tensorflow.python.framework import config
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import tensor_util
+from tensorflow.python.framework.test_util import IsMklEnabled
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import gen_math_ops
@@ -126,7 +127,13 @@ class NodeFileWriterTest(test.TestCase):
       node_defs = self._get_new_node_defs()
       self.assertLen(node_defs, 2)
       node_def1, node_def2 = node_defs  # pylint: disable=unbalanced-tuple-unpacking
-      self.assertEqual(node_def1.op, 'MatMul')
+      if not IsMklEnabled():
+        self.assertEqual(node_def1.op, 'MatMul')
+      else:
+        # Under certain conditions ops can be rewritten by oneDNN optimization
+        # pass.
+        self.assertIn(node_def1.op, ['MatMul', '_MklMatMul'])
+
       self.assertEqual(
           self._get_input_dtypes(node_def1), [dtypes.float32, dtypes.float32])
       self.assertEqual(self._get_input_shapes(node_def1), [(2, 3), (3, 2)])
@@ -177,7 +184,16 @@ class NodeFileWriterTest(test.TestCase):
       y = constant_op.constant(np.zeros((1, 1, 1, 1)).astype(np.float32))
       # Duplicate ops are skipped, even if input values are different
       gen_nn_ops.conv2d(x, y, [1, 1, 1, 1], 'SAME')
-      self.assertLen(self._get_new_node_defs(), 1)
+      if not IsMklEnabled():
+        self.assertLen(self._get_new_node_defs(), 1)
+      else:
+        ndefs = self._get_new_node_defs()
+        if (len(ndefs) >= 1 and ndefs[0].op != ndefs[1].op):
+          # One of the ops got rewritten by oneDNN optimization pass
+          self.assertLen(ndefs, 2)
+        else:
+          self.assertLen(ndefs, 1)
+
 
       x = constant_op.constant(np.ones((1, 1, 1, 1, 1, 1)).astype(np.float32))
       paddings = constant_op.constant(np.ones((6, 2)).astype(np.int32))


### PR DESCRIPTION
This PR fixes failure in the test //tensorflow/python/framework/node_file_writer_test when oneDNN is enabled.
This test tries to write all executed nodes in eager mode to a file with skipping duplicates under certain conditions.
Since we rewrite some ops in eager mode, expected op name can be different. Also number of written nodes can be different since we only rewrite ops that have supported datatypes and are assigned to CPU device.