### PR TITLE
[tf.data] extend multi-threaded MapDataset based tests to eager mode

### DIFF
--- a/tensorflow/python/data/kernel_tests/map_test.py
+++ b/tensorflow/python/data/kernel_tests/map_test.py
@@ -167,8 +167,7 @@ class MapTest(test_base.DatasetTestBase, parameterized.TestCase):
     with self.assertRaises(errors.OutOfRangeError):
       self.evaluate(get_next())
 
-  # TODO(b/117581999): add eager coverage
-  @combinations.generate(_test_combinations_with_mode("graph"))
+  @combinations.generate(_test_combinations())
   def testMapDatasetMultiThreaded(self, apply_map):
     # Test multi-threaded access to the same iterator.
     components = (np.arange(7),
@@ -245,10 +244,9 @@ class MapTest(test_base.DatasetTestBase, parameterized.TestCase):
     with self.assertRaises(errors.OutOfRangeError):
       self.evaluate(get_next())
 
-  # TODO(b/117581999): add eager coverage
   @combinations.generate(
       combinations.times(
-          _test_combinations_with_mode("graph"),
+          _test_combinations(),
           combinations.combine(num_parallel_calls=1, buffer_size=1) +
           combinations.combine(num_parallel_calls=1, buffer_size=2) +
           combinations.combine(num_parallel_calls=2, buffer_size=2) +


### PR DESCRIPTION
This PR attempts to extend the multi-threaded map dataset tests to eager mode.

The `cached_session` context is left untouched as it yields a dummy eager session that simulates execution in eager mode.
TEST LOG
```
INFO: Build completed successfully, 20 total actions
//tensorflow/python/data/kernel_tests:map_test                           PASSED in 33.1s
  Stats over 19 runs: max = 33.1s, min = 15.3s, avg = 20.5s, dev = 4.2s

INFO: Build completed successfully, 20 total actions
```

cc: @aaudiber I tried removing the session context and executing these tests with eager only combinations and it worked fine. However, the tests fail when the `cached_session` is not used during thread `start` and `join` steps in graph mode. Thus, I kept the `cached_session` intact and let it handle the eager and graph scenarios. Let me know what you think of this approach.