### PR TITLE
[TF:TRT] Add static registration system for TF->TRT operation converters

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -439,6 +439,61 @@ tf_cuda_library(
     ] + if_tensorrt([":tensorrt_lib"]),
 )
 
+tf_cuda_library(
+    name = "trt_weights",
+    srcs = ["convert/weights.cc"],
+    hdrs = [
+        "convert/weights.h",
+    ],
+    copts = tf_copts(),
+    deps = [
+        ":utils",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:framework",
+    ] + if_tensorrt([":tensorrt_lib"]),
+)
+
+tf_cuda_library(
+    name = "op_converter",
+    srcs = [],
+    hdrs = [
+        "convert/op_converter.h",
+    ],
+    deps = [
+        ":trt_weights",
+    ] + if_tensorrt([":tensorrt_lib"]),
+)
+
+tf_cuda_library(
+    name = "op_converter_registry",
+    srcs = ["convert/op_converter_registry.cc"],
+    hdrs = [
+        "convert/op_converter_registry.h",
+    ],
+    copts = tf_copts(),
+    deps = [
+        ":utils",
+        ":op_converter",
+        "@com_google_absl//absl/strings",
+        "//tensorflow/core:lib",
+    ] + if_tensorrt([":tensorrt_lib"]),
+)
+
+tf_cc_test(
+    name = "op_converter_registry_test",
+    size = "small",
+    srcs = ["convert/op_converter_registry_test.cc"],
+    tags = [
+        "no_windows",
+        "nomac",
+    ],
+    deps = [
+        ":op_converter_registry",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+    ],
+)
+
 # Library for the node-level conversion portion of TensorRT operation creation
 tf_cuda_library(
     name = "trt_conversion",
@@ -464,6 +519,9 @@ tf_cuda_library(
         ":trt_logging",
         ":trt_resources",
         ":utils",
+        ":trt_weights",
+        ":op_converter",
+        ":op_converter_registry",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "//tensorflow/core/common_runtime:core_cpu",

--- a/tensorflow/compiler/tf2tensorrt/common/datavec.h
+++ b/tensorflow/compiler/tf2tensorrt/common/datavec.h
@@ -19,18 +19,14 @@ limitations under the License.
 #include <vector>
 
 #include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/platform/types.h"
 
 namespace tensorflow {
 namespace tensorrt {
 
 // Input/output data format for OpConverterTest::BuildAndRun().
 struct InputOutputData {
-  void* Buffer() const {
-    return const_cast<char*>(tensor.tensor_data().data());
-  }
-
   size_t TotalBytes() const { return tensor.TotalBytes(); }
-
   string name;
   Tensor tensor;
 };

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"
@@ -759,174 +760,6 @@ Status VerifyShapesMatch(absl::Span<const TRT_TensorOrWeights> inputs,
   return Status::OK();
 }
 
-TRT_ShapedWeights::TRT_ShapedWeights(nvinfer1::DataType type) : type_(type) {
-  shape_.nbDims = 0;
-  shape_.d[0] = 0;
-}
-
-TRT_ShapedWeights::TRT_ShapedWeights(nvinfer1::DataType type,
-                                     nvinfer1::Dims dims, Tensor tensor)
-    : shape_(dims), type_(type), tensor_(tensor) {
-  if (dims.nbDims == 0) {
-    DCHECK(dims.d[0] == 0 || dims.d[0] == 1);
-  }
-}
-
-TRT_ShapedWeights::TRT_ShapedWeights(const TRT_ShapedWeights& rhs)
-    : shape_(rhs.shape_), type_(rhs.type_), tensor_(rhs.tensor_) {}
-
-int64_t TRT_ShapedWeights::count(nvinfer1::Dims dims) {
-  if (dims.nbDims == 0) {
-    assert(dims.d[0] == 0 || dims.d[0] == 1);
-    return dims.d[0];
-  }
-  return Prod(dims);
-}
-
-nvinfer1::Weights TRT_ShapedWeights::GetTrtWeights() const {
-  return nvinfer1::Weights{type_, GetPointer<int8>(), count()};
-}
-
-template <typename T>
-Status TRT_ShapedWeights::SetValues(T value) {
-  switch (type_) {
-    case nvinfer1::DataType::kFLOAT: {
-      float* ptr = tensor_.flat<float>().data();
-      std::fill(ptr, ptr + count(), value);
-      break;
-    }
-    case nvinfer1::DataType::kHALF: {
-      Eigen::half* ptr = tensor_.flat<Eigen::half>().data();
-      std::fill(ptr, ptr + count(), Eigen::half(value));
-      break;
-    }
-    case nvinfer1::DataType::kINT32: {
-      int32* ptr = tensor_.flat<int32>().data();
-      std::fill(ptr, ptr + count(), value);
-      break;
-    }
-    default:
-      return errors::InvalidArgument("Unsupported data type ",
-                                     tensorflow::tensorrt::DebugString(type_));
-  }
-  return Status::OK();
-}
-
-Status TRT_ShapedWeights::SetShape(nvinfer1::Dims dims) {
-  if (this->count() != TRT_ShapedWeights::count(dims)) {
-    VLOG(2) << "Changing shape from "
-            << tensorflow::tensorrt::DebugString(shape_) << ", to "
-            << tensorflow::tensorrt::DebugString(dims);
-    return errors::Internal("SetShape would change number of elements");
-  }
-  shape_ = dims;
-  return Status::OK();
-}
-
-size_t TRT_ShapedWeights::size_bytes() const {
-  size_t data_type_size = -1;
-  switch (type_) {
-    case nvinfer1::DataType::kFLOAT:
-    case nvinfer1::DataType::kINT32:
-      data_type_size = 4;
-      break;
-    case nvinfer1::DataType::kHALF:
-      data_type_size = 2;
-      break;
-    case nvinfer1::DataType::kINT8:
-    case nvinfer1::DataType::kBOOL:
-      data_type_size = 1;
-      break;
-  }
-  return this->count() * data_type_size;
-}
-
-string TRT_ShapedWeights::DebugString() const {
-  return StrCat(
-      "TRT_ShapedWeights(shape=", tensorflow::tensorrt::DebugString(shape_),
-      ", type=", tensorflow::tensorrt::DebugString(type_),
-      ", values=", reinterpret_cast<uintptr_t>(GetPointer<int8>()), ")");
-}
-
-TRT_TensorOrWeights::TRT_TensorOrWeights(ITensorProxyPtr tensor)
-    : tensor_proxy_ptr_(tensor), initialized_(true), is_tensor_(true) {}
-
-TRT_TensorOrWeights::TRT_TensorOrWeights(ITensorProxyPtr tensor, int batch_size)
-    : tensor_proxy_ptr_(tensor),
-      batch_size_(batch_size),
-      initialized_(true),
-      is_tensor_(true) {}
-
-TRT_TensorOrWeights::TRT_TensorOrWeights(nvinfer1::ITensor* tensor,
-                                         int batch_size)
-    : tensor_proxy_ptr_(tensor),
-      batch_size_(batch_size),
-      initialized_(true),
-      is_tensor_(true) {}
-
-TRT_TensorOrWeights::TRT_TensorOrWeights(nvinfer1::DataType trt_dtype,
-                                         const nvinfer1::Dims& trt_dims,
-                                         int batch_size)
-    : tensor_proxy_ptr_(new SimpleITensor(trt_dtype, trt_dims)),
-      batch_size_(batch_size),
-      initialized_(true),
-      is_tensor_(true) {}
-
-TRT_TensorOrWeights::TRT_TensorOrWeights(const TRT_ShapedWeights& weights)
-    : weights_(weights), initialized_(true), is_tensor_(false) {}
-
-TRT_TensorOrWeights::TRT_TensorOrWeights(const TRT_TensorOrWeights& rhs)
-    : tensor_proxy_ptr_(rhs.tensor_proxy_ptr_),
-      batch_size_(rhs.batch_size_),
-      weights_(rhs.weights_),
-      initialized_(rhs.initialized_),
-      is_tensor_(rhs.is_tensor_) {}
-
-void TRT_TensorOrWeights::operator=(const TRT_TensorOrWeights& rhs) {
-  tensor_proxy_ptr_ = rhs.tensor_proxy_ptr_;
-  batch_size_ = rhs.batch_size_;
-  weights_ = rhs.weights_;
-  initialized_ = rhs.initialized_;
-  is_tensor_ = rhs.is_tensor_;
-}
-
-ITensorProxyPtr TRT_TensorOrWeights::tensor() const {
-  CHECK(is_tensor());
-  return tensor_proxy_ptr_;
-}
-
-nvinfer1::Dims TRT_TensorOrWeights::GetTrtDims() const {
-  if (is_tensor()) {
-    return tensor()->getDimensions();
-  } else {
-    return weights().shape_;
-  }
-}
-
-Status TRT_TensorOrWeights::GetTfType(DataType* tf_type) const {
-  if (is_tensor()) {
-    nvinfer1::DataType trt_type = tensor()->getType();
-    return TrtTypeToTfType(trt_type, tf_type);
-  }
-  if (is_weights()) {
-    *tf_type = weights().GetTensor().dtype();
-    return Status::OK();
-  }
-  return errors::Internal("The object is probably not initialized");
-}
-
-string TRT_TensorOrWeights::DebugString() const {
-  string output = "TRT_TensorOrWeights(type=";
-  if (is_tensor()) {
-    StrAppend(&output, "tensor=", tensorflow::tensorrt::DebugString(tensor()),
-              ", batch_size=", batch_size_);
-  } else {
-    StrAppend(&output, "weights=", weights_.DebugString());
-  }
-  StrAppend(&output, ")");
-  return output;
-}
-
 // Perform 5 dimensional reorder of data on CPU
 // This is done once at convert time and does not affect GPU inference perf
 // Example: reorder NDHWC (Tensorflow) -> NCDHW (TensorRT)
@@ -1108,20 +941,6 @@ void ReorderDRSCKToKCDRS(const TRT_ShapedWeights& iweights,
   }
 }
 
-TRT_ShapedWeights TrtWeightStore::GetTempWeights(nvinfer1::DataType trt_dtype,
-                                                 const nvinfer1::Dims& dims) {
-  TensorShape shape;
-  DataType tf_dtype;
-  // TODO(laigd): make it return a status.
-  TF_CHECK_OK(TensorShapeUtils::MakeShape(dims.d, dims.nbDims, &shape));
-  TF_CHECK_OK(TrtTypeToTfType(trt_dtype, &tf_dtype));
-  // TODO(jie): check weights size_bytes. 0 means type error
-  Tensor tensor(tf_dtype, shape);
-  TRT_ShapedWeights weights(trt_dtype, dims, tensor);
-  store_.emplace_back(std::move(tensor));
-  return weights;
-}
-
 OpConverterParams::OpConverterParams(
     const NodeDef& node_def, const std::vector<TRT_TensorOrWeights>& inputs,
     std::vector<TRT_TensorOrWeights>* outputs, TrtWeightStore* weight_store,
@@ -1150,15 +969,10 @@ OpConverterParams::OpConverterParams(
       use_calibration(converter->use_calibration()),
       use_implicit_batch(converter->use_implicit_batch()) {}
 
-const std::set<string>* TrtNodeValidator::quantize_ops = new std::set<string>{
-    "QuantizeAndDequantizeV2",
-    "QuantizeAndDequantizeV3",
-    "FakeQuantWithMinMaxVars",
-    "FakeQuantWithMinMaxArgs",
-};
-
 bool IsQuantizeAndDequantizeOp(const Node* node) {
-  return TrtNodeValidator::quantize_ops->count(node->def().op()) != 0;
+  // return TrtNodeValidator::quantize_ops->count(node->def().op()) != 0;
+  return absl::c_find(kQuantizationOpNames, node->def().op()) !=
+         kQuantizationOpNames.end();
 }
 
 TrtNodeValidator::TrtNodeValidator(
@@ -1168,8 +982,10 @@ TrtNodeValidator::TrtNodeValidator(
     : graph_properties_(graph_properties),
       precision_mode_(precision_mode),
       use_calibration_(use_calibration),
-      use_implicit_batch_(use_implicit_batch) {
-  RegisterOpValidators();
+      use_implicit_batch_(use_implicit_batch) {}
+
+StatusOr<OpConverter> TrtNodeValidator::GetValidator(const std::string& op) {
+  return GetOpConverterRegistry()->LookUp(op);
 }
 
 Status TrtNodeValidator::ConvertToTensorOrWeights(
@@ -1219,11 +1035,12 @@ Status TrtNodeValidator::IsTensorRTCandidate(const Node* node) {
   // these ops to the relevant tensors. This happens regardless of the value of
   // use_calibration.
   bool is_supported_op = false;
-  if (quantize_ops->count(op)) {
+  if (absl::c_find(kQuantizationOpNames, op) != kQuantizationOpNames.end()) {
     is_supported_op = (precision_mode_ == TrtPrecisionMode::INT8);
   } else {
-    is_supported_op = op_validators_.count(op);
+    is_supported_op = GetValidator(op).ok();
   }
+
   if (!is_supported_op) {
     return errors::Unimplemented("Op type ", op, " is not supported.");
   }
@@ -1246,11 +1063,12 @@ Status TrtNodeValidator::IsTensorRTCandidate(const Node* node) {
     inputs.push_back(tensor_or_weights);
   }
 
-  OpConverter validator = op_validators_[op];
+  auto validator = GetValidator(op);
+  TF_RETURN_IF_ERROR(validator.status());
   OpConverterParams params(node->def(), inputs, /*arg_outputs=*/nullptr,
                            &weight_store_, precision_mode_, use_calibration_,
                            use_implicit_batch_);
-  return validator(&params);
+  return (*validator)(&params);
 }
 
 Status TrtNodeValidator::ConvertConstToWeights(
@@ -1261,7 +1079,9 @@ Status TrtNodeValidator::ConvertConstToWeights(
   OpConverterParams params(const_node_def, inputs, &outputs, &weight_store_,
                            precision_mode_, use_calibration_,
                            use_implicit_batch_);
-  Status status = op_validators_["Const"](&params);
+  auto const_val = GetValidator("Const");
+  TF_RETURN_IF_ERROR(const_val.status());
+  Status status = (*const_val)(&params);
   if (status.ok() && output) *output = outputs[0];
   return status;
 }
@@ -1287,7 +1107,6 @@ Converter::Converter(TrtPrecisionMode precision_mode, bool use_calibration,
       use_implicit_batch_(use_implicit_batch),
       engine_name_(engine_name) {
   MaybeInitializeTrtPlugins(trt_logger);
-  this->RegisterOpConverters();
 }
 
 Status Converter::Init(nvinfer1::ILogger* trt_logger) {
@@ -1313,12 +1132,9 @@ Status Converter::ConvertNode(const NodeDef& node_def) {
 
   OpConverterParams params(this, node_def, inputs, &outputs, &weight_store_);
   const string& op = node_def.op();
-  auto itr = op_registry_.find(op);
-  if (itr == op_registry_.end()) {
-    return errors::Unimplemented("No converter registered for op: ", op);
-  }
-  OpConverter op_converter = itr->second;
-  TF_RETURN_IF_ERROR(op_converter(&params));
+  auto op_converter = GetOpConverterRegistry()->LookUp(op);
+  TF_RETURN_IF_ERROR(op_converter.status());
+  TF_RETURN_IF_ERROR((*op_converter)(&params));
 
   for (size_t i = 0; i < outputs.size(); ++i) {
     TRT_TensorOrWeights& output = outputs[i];
@@ -4079,24 +3895,6 @@ Status ConvertIdentity(OpConverterParams* params) {
   return Status::OK();
 }
 
-const std::unordered_map<string, nvinfer1::ElementWiseOperation>*
-BinaryOperationMap() {
-  static auto* const m =
-      new std::unordered_map<string, nvinfer1::ElementWiseOperation>{
-          {"Add", nvinfer1::ElementWiseOperation::kSUM},
-          {"AddV2", nvinfer1::ElementWiseOperation::kSUM},
-          {"Mul", nvinfer1::ElementWiseOperation::kPROD},
-          {"Sub", nvinfer1::ElementWiseOperation::kSUB},
-          {"Div", nvinfer1::ElementWiseOperation::kDIV},
-          {"FloorDiv", nvinfer1::ElementWiseOperation::kFLOOR_DIV},
-          {"RealDiv", nvinfer1::ElementWiseOperation::kDIV},
-          {"Minimum", nvinfer1::ElementWiseOperation::kMIN},
-          {"Maximum", nvinfer1::ElementWiseOperation::kMAX},
-          {"Pow", nvinfer1::ElementWiseOperation::kPOW},
-      };
-  return m;
-}
-
 Status ConvertBinary(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
@@ -4119,8 +3917,13 @@ Status ConvertBinary(OpConverterParams* params) {
   const TRT_TensorOrWeights& operand_l = inputs.at(0);
   const TRT_TensorOrWeights& operand_r = inputs.at(1);
 
-  auto op_pair = BinaryOperationMap()->find(node_def.op());
-  if (op_pair == BinaryOperationMap()->end()) {
+  auto op_pair = absl::c_find_if(
+      kBinaryOperations,
+      [&node_def](
+          const std::pair<std::string, nvinfer1::ElementWiseOperation>& x) {
+        return x.first == node_def.op();
+      });
+  if (op_pair == kBinaryOperations.end()) {
     return errors::Unimplemented("Binary op ", node_def.op(),
                                  " not supported at: ", node_def.name());
   }
@@ -6781,98 +6584,82 @@ Status ConvertAddN(OpConverterParams* params) {
   return Status::OK();
 }
 
-static void RegisterValidatableOpConverters(
-    std::unordered_map<string, OpConverter>* registration) {
-  (*registration)["BiasAdd"] = ConvertBiasAdd;
-  (*registration)["ClipByValue"] = ConvertClipByValue;
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertBiasAdd, "BiasAdd");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertClipByValue, "ClipByValue");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertCombinedNMS,
+                                  "CombinedNonMaxSuppression");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertAddN, "AddN");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertCast, "Cast");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertConcat, "ConcatV2");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertConst, "Const");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertConv2D, "Conv2D");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertConv2DBackpropInput,
+                                  "Conv2DBackpropInput");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertDepthSpaceShuffle, "DepthToSpace");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertConv2DDepthwise,
+                                  "DepthwiseConv2dNative");
 #if IS_TRT_VERSION_GE(7, 1, 3, 0)
-  (*registration)["CombinedNonMaxSuppression"] = ConvertCombinedNMS;
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertEinsum, "Einsum");
 #endif
-  (*registration)["AddN"] = ConvertAddN;
-  (*registration)["Cast"] = ConvertCast;
-  (*registration)["ConcatV2"] = ConvertConcat;
-  (*registration)["Const"] = ConvertConst;
-  (*registration)["Conv2D"] = ConvertConv2D;
-  (*registration)["Conv2DBackpropInput"] = ConvertConv2DBackpropInput;
-  (*registration)["DepthToSpace"] = ConvertDepthSpaceShuffle;
-  (*registration)["DepthwiseConv2dNative"] = ConvertConv2DDepthwise;
-#if IS_TRT_VERSION_GE(7, 1, 3, 0)
-  (*registration)["Einsum"] = ConvertEinsum;
-#endif
-  (*registration)["ExpandDims"] = ConvertExpandDims;
-  (*registration)["FusedConv2DBiasActivation"] =
-      ConvertFusedConv2DBiasActivation;
-  (*registration)["GatherV2"] = ConvertGather;
-  (*registration)["LeakyRelu"] = ConvertLeakyRelu;
-  (*registration)["MatMul"] = ConvertMatMul;
-  (*registration)["Pack"] = ConvertPack;
-  (*registration)["Pad"] = ConvertPad;
-  (*registration)["Relu6"] = ConvertRelu6;
-  (*registration)["Reshape"] = ConvertReshape;
-  (*registration)["Conv3D"] = ConvertConv3D;
-  (*registration)["Conv3DBackpropInputV2"] = ConvertConv3DBackpropInputV2;
-  for (auto resize_mode : {"ResizeBilinear", "ResizeNearestNeighbor"}) {
-    (*registration)[resize_mode] = ConvertResize;
-  }
-  for (auto pool_op_type : {"AvgPool3D", "MaxPool3D"}) {
-    (*registration)[pool_op_type] = ConvertPool3D;
-  }
-  (*registration)["Shape"] = ConvertShape;
-  (*registration)["Rsqrt"] = ConvertRsqrt;
-  (*registration)["Slice"] = ConvertSlice;
-  (*registration)["Softmax"] = ConvertSoftmax;
-  (*registration)["SpaceToDepth"] = ConvertDepthSpaceShuffle;
-  (*registration)["Split"] = ConvertSplit;
-  (*registration)["Square"] = ConvertSquare;
-  (*registration)["SquaredDifference"] = ConvertSquaredDifference;
-  (*registration)["Squeeze"] = ConvertSqueeze;
-  (*registration)["StridedSlice"] = ConvertStridedSlice;
-  (*registration)["TopKV2"] = ConvertTopK;
-  (*registration)["Transpose"] = ConvertTranspose;
-  (*registration)["Unpack"] = ConvertUnpack;
-  (*registration)["_CopyFromHostToGpu"] = ConvertIdentity;
-  for (auto quantization_op_type : *TrtNodeValidator::quantize_ops) {
-    (*registration)[quantization_op_type] = ConvertQuantize;
-  }
-  for (const auto& binary_op_pair : *BinaryOperationMap()) {
-    (*registration)[binary_op_pair.first] = ConvertBinary;
-  }
-  for (const auto& activation_op_pair : *ActivationTypeMap()) {
-    (*registration)[activation_op_pair.first] = ConvertActivation;
-  }
-  for (auto pool_op_type : {"AvgPool", "MaxPool"}) {
-    (*registration)[pool_op_type] = ConvertPool;
-  }
-  for (auto normalization_op_type :
-       {"FusedBatchNorm", "FusedBatchNormV2", "FusedBatchNormV3"}) {
-    (*registration)[normalization_op_type] = ConvertFusedBatchNorm;
-  }
-  for (const auto& unary_op_pair : *UnaryOperationMap()) {
-    (*registration)[unary_op_pair.first] = ConvertUnary;
-  }
-  for (auto reduce_op_type : {"Sum", "Prod", "Max", "Min", "Mean"}) {
-    (*registration)[reduce_op_type] = ConvertReduce;
-  }
-  for (auto arg_minmax_type : {"ArgMin", "ArgMax"}) {
-    (*registration)[arg_minmax_type] = ConvertArgMinMax;
-  }
-  // The following are no-ops during inference and will not be mapped to any TRT
-  // layer.
-  for (auto identity_op_type : {"Identity", "Snapshot", "StopGradient"}) {
-    (*registration)[identity_op_type] = ConvertIdentity;
-  }
-  for (auto batch_matmul_type : {"BatchMatMul", "BatchMatMulV2"}) {
-    (*registration)[batch_matmul_type] = ConvertBatchMatMul;
-  }
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertExpandDims, "ExpandDims");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertFusedConv2DBiasActivation,
+                                  "FusedConv2DBiasActivation");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertGather, "GatherV2");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertLeakyRelu, "LeakyRelu");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertMatMul, "MatMul");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertPack, "Pack");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertPad, "Pad");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertRelu6, "Relu6");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertReshape, "Reshape");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertConv3D, "Conv3D");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertConv3DBackpropInputV2,
+                                  "Conv3DBackpropInputV2");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertResize, "ResizeBilinear");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertResize, "ResizeNearestNeighbor");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertPool3D, "AvgPool3D");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertPool3D, "MaxPool3D");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertShape, "Shape");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertRsqrt, "Rsqrt");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertSlice, "Slice");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertSoftmax, "Softmax");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertDepthSpaceShuffle, "SpaceToDepth");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertSplit, "Split");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertSquare, "Square");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertSquaredDifference,
+                                  "SquaredDifference");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertSqueeze, "Squeeze");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertStridedSlice, "StridedSlice");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertTopK, "TopKV2");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertTranspose, "Transpose");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertUnpack, "Unpack");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertQuantize, kQuantizationOpNames);
+template <typename T>
+absl::InlinedVector<std::string, 10> GetOperationNames(const T& set) {
+  absl::InlinedVector<std::string, 10> result;
+  absl::c_transform(set, std::back_inserter(result),
+                    [](const auto x) { return x.first; });
+  return result;
 }
-
-void TrtNodeValidator::RegisterOpValidators() {
-  RegisterValidatableOpConverters(&op_validators_);
-}
-
-void Converter::RegisterOpConverters() {
-  RegisterValidatableOpConverters(&op_registry_);
-}
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertBinary,
+                                  GetOperationNames(kBinaryOperations));
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertActivation,
+                                  GetOperationNames(*ActivationTypeMap()));
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertPool, {"MaxPool", "AvgPool"});
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertFusedBatchNorm,
+                                  {"FusedBatchNorm", "FusedBatchNormV2",
+                                   "FusedBatchNormV3"});
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertUnary,
+                                  GetOperationNames(*UnaryOperationMap()));
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertReduce,
+                                  {"Sum", "Prod", "Max", "Min", "Mean"});
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertArgMinMax, {"ArgMin", "ArgMax"});
+// The following are no-ops during inference and will not be mapped to any
+// TRT layer.
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertIdentity,
+                                  {"Identity", "Snapshot", "StopGradient",
+                                   "_CopyFromHostToGpu"});
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertBatchMatMul,
+                                  {"BatchMatMul", "BatchMatMulV2"});
 
 Status ConvertGraphDefToEngine(
     const GraphDef& gdef, TrtPrecisionMode precision_mode, int max_batch_size,

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <iterator>
 #include <memory>
 #include <type_traits>
 #include <unordered_map>
@@ -27,6 +28,7 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "absl/algorithm/container.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
@@ -34,14 +36,13 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 #include "tensorflow/cc/ops/nn_ops_internal.h"
 #include "tensorflow/cc/ops/standard_ops.h"
 #include "tensorflow/compiler/tf2tensorrt/common/datavec.h"
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"
@@ -64,6 +65,8 @@ limitations under the License.
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/protobuf/config.pb.h"  // NOLINT
 #include "tensorflow/core/public/session.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/tensorrt/NvInfer.h"
 
 namespace tensorflow {
@@ -271,11 +274,6 @@ TEST(TRT_TensorOrWeights_Test, Basic) {
 
 class ValidatorTest : public ::testing::Test {
  public:
-  std::unordered_map<string, OpConverter>& op_validators(
-      TrtNodeValidator* validator) {
-    return validator->op_validators_;
-  }
-
   Status ConvertToTensorOrWeights(const Scope& scope, const Node* node,
                                   int output_port,
                                   TRT_TensorOrWeights* tensor_or_weights) {
@@ -290,10 +288,6 @@ class ValidatorTest : public ::testing::Test {
     return validator.ConvertToTensorOrWeights(node->def(), output_port,
                                               tensor_or_weights);
   }
-
-  const std::set<string>* GetQuantizeOps(TrtNodeValidator* validator) {
-    return validator->quantize_ops;
-  }
 };
 
 TEST_F(ValidatorTest, QuantizeOpsAreRegistered) {
@@ -302,8 +296,8 @@ TEST_F(ValidatorTest, QuantizeOpsAreRegistered) {
   TrtNodeValidator validator(graph_properties, TrtPrecisionMode::FP32,
                              /*use_calibration=*/false,
                              /*use_implicit_batch=*/true);
-  for (const string& quantize_op : *GetQuantizeOps(&validator)) {
-    QCHECK(op_validators(&validator).count(quantize_op));
+  for (const string& quantize_op : kQuantizationOpNames) {
+    TF_EXPECT_OK(validator.GetValidator(quantize_op).status());
   }
 }
 
@@ -378,6 +372,7 @@ TEST_F(ValidatorTest, IsTensorRTCandidate_Basics) {
                              /*use_calibration=*/false,
                              /*use_implicit_batch=*/true);
 
+  // Override the Add converter.
   bool start_conversion = false;
   bool should_fail = false;
   auto op_converter = [&start_conversion,
@@ -388,13 +383,14 @@ TEST_F(ValidatorTest, IsTensorRTCandidate_Basics) {
   };
 
   // Validator not registered.
-  ASSERT_EQ(1, op_validators(&validator).erase("Add"));
+  auto original_op_converter = GetOpConverterRegistry()->LookUp("Add");
+  ASSERT_TRUE(original_op_converter.ok());
+  GetOpConverterRegistry()->Clear("Add");
   EXPECT_THAT(validator.IsTensorRTCandidate(add_node),
               StatusIs(error::UNIMPLEMENTED,
                        HasSubstr("Op type Add is not supported.")));
-
-  // Register validator.
-  op_validators(&validator)["Add"] = op_converter;
+  GetOpConverterRegistry()->Register("Add", kDefaultConverterPriority + 1,
+                                     op_converter);
   TF_EXPECT_OK(validator.IsTensorRTCandidate(add_node));
   EXPECT_EQ(false, start_conversion);
 
@@ -402,6 +398,9 @@ TEST_F(ValidatorTest, IsTensorRTCandidate_Basics) {
   should_fail = true;
   EXPECT_THAT(validator.IsTensorRTCandidate(add_node),
               StatusIs(error::INVALID_ARGUMENT));
+  GetOpConverterRegistry()->Clear("Add");
+  GetOpConverterRegistry()->Register("Add", kDefaultConverterPriority,
+                                     *original_op_converter);
 }
 
 TEST(TrtNodeValidator, IsTensorRTCandidate) {
@@ -492,6 +491,8 @@ class ConverterTest : public ::testing::Test {
   ConverterTest() { Reset(); }
 
   void Reset() {
+    GetOpConverterRegistry()->Clear("MyOp");
+    GetOpConverterRegistry()->Clear("DummyOp");
     converter_ =
         std::move(Converter::Create(TrtPrecisionMode::FP32,
                                     /*use_calibration=*/false, &logger_,
@@ -501,12 +502,9 @@ class ConverterTest : public ::testing::Test {
     weight_store_ = &converter_->weight_store_;
   }
 
-  void AddOpConverter(const string& op_name, OpConverter op_converter) {
-    converter_->op_registry_[op_name] = op_converter;
-  }
-
+  // TODO(cbate): These should be removed or changed to public per black-box
+  // testing principle.
   // Below we expose private methods of Converter for testing.
-
   Status MaybeUpdateBatchSize(int batch_size) {
     return converter_->MaybeUpdateBatchSize(batch_size);
   }
@@ -559,17 +557,19 @@ TEST_F(ConverterTest, ConvertNode) {
     return Status::OK();
   };
   NodeDef node_def = MakeNodeDef("my_op", "MyOp", {"my_input"});
-  TF_EXPECT_OK(converter_->AddInputTensor(
+
+  TF_ASSERT_OK(converter_->AddInputTensor(
       "my_input", nvinfer1::DataType::kFLOAT, CreateDims({123}), 1));
 
   // Converter not registered.
-  EXPECT_THAT(converter_->ConvertNode(node_def),
-              StatusIs(error::UNIMPLEMENTED,
-                       HasSubstr("No converter registered for op: MyOp")));
+  EXPECT_THAT(
+      converter_->ConvertNode(node_def),
+      StatusIs(error::NOT_FOUND, HasSubstr("No converter for op MyOp")));
 
   // Register the converter and retry.
-  AddOpConverter("MyOp", op_converter);
-  TF_EXPECT_OK(converter_->ConvertNode(node_def));
+  GetOpConverterRegistry()->Register("MyOp", kDefaultConverterPriority,
+                                     op_converter);
+  TF_ASSERT_OK(converter_->ConvertNode(node_def));
 
   TRT_TensorOrWeights actual_output_1;
   TF_EXPECT_OK(GetTensorOrWeights("my_op", &actual_output_1));
@@ -641,7 +641,8 @@ TEST_F(ConverterTest, RenameAndMarkOutputTensors) {
     params->outputs->emplace_back(output_weights);
     return Status::OK();
   };
-  AddOpConverter("MyOp", op_converter);
+  GetOpConverterRegistry()->Register("MyOp", kDefaultConverterPriority,
+                                     op_converter);
 
   // Run the conversion.
   NodeDef node_def = MakeNodeDef("my_op", "MyOp", {"my_input"});
@@ -2908,14 +2909,12 @@ TEST_P(OpConverter_FP32_FP16_Test, ConvertBinary) {
   ADD_OP("Maximum", ops::Maximum, {3, 6, 3, 6, 3, 6, 3, 6});
   ADD_OP("Pow", ops::Pow, {9, 36, 27, 216, 9, 36, 27, 216});
 #undef ADD_OP
-  // Add all ops supported by ConvertBinary.
-  auto* supported_ops = BinaryOperationMap();
   // Test combinations of tensor vs weight inputs (except when both inputs are
   // weights).
   for (const bool operand_1_is_tensor : {true, false}) {
     for (const bool operand_2_is_tensor : {true, false}) {
       if (!operand_1_is_tensor && !operand_2_is_tensor) continue;
-      for (auto& iter : *supported_ops) {
+      for (auto& iter : kBinaryOperations) {
         string op_name = iter.first;
         SCOPED_TRACE(StrCat(op_name, "_", operand_1_is_tensor ? "T" : "W",
                             operand_2_is_tensor ? "T" : "W"));

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter.h
@@ -1,0 +1,64 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_H_
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include <vector>
+
+#include "tensorflow/compiler/tf2tensorrt/convert/weights.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+class Converter;
+
+// Parameters for each op converter.
+struct OpConverterParams {
+  // Constructor used for validation only.
+  OpConverterParams(const NodeDef& node_def,
+                    const std::vector<TRT_TensorOrWeights>& inputs,
+                    std::vector<TRT_TensorOrWeights>* outputs,
+                    TrtWeightStore* weight_store,
+                    TrtPrecisionMode precision_mode, bool use_calibration,
+                    bool use_implicit_batch);
+
+  // Constructor used for conversion.
+  OpConverterParams(Converter* converter, const NodeDef& node_def,
+                    const std::vector<TRT_TensorOrWeights>& inputs,
+                    std::vector<TRT_TensorOrWeights>* outputs,
+                    TrtWeightStore* weight_store);
+
+  Converter* converter = nullptr;
+  const NodeDef& node_def;
+  const std::vector<TRT_TensorOrWeights>& inputs;
+  std::vector<TRT_TensorOrWeights>* outputs;
+  const bool validation_only;
+  TrtWeightStore* weight_store;
+  const TrtPrecisionMode precision_mode;
+  const bool use_calibration;
+  const bool use_implicit_batch;
+};
+
+using OpConverter = std::function<Status(OpConverterParams*)>;
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_H_

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.cc
@@ -1,0 +1,107 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
+
+#include <set>
+#include <utility>
+
+#include "tensorflow/core/platform/mutex.h"
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+struct OpConverterRegistration {
+  OpConverter converter;
+  int priority;
+};
+class OpConverterRegistry::Impl {
+ public:
+  ~Impl() = default;
+
+  InitOnStartupMarker Register(const string& name, const int priority,
+                               OpConverter converter) {
+    mutex_lock lock(mu_);
+    auto item = registry_.find(name);
+    if (item != registry_.end()) {
+      const int existing_priority = item->second.priority;
+      if (priority <= existing_priority) {
+        LOG(WARNING) << absl::StrCat(
+            "Ignoring TF->TRT ", name, " op converter with priority ",
+            existing_priority, " due to another converter with priority ",
+            priority);
+        return {};
+      } else {
+        LOG(WARNING) << absl::StrCat(
+            "Overwriting TF->TRT ", name, " op converter with priority ",
+            existing_priority, " using another converter with priority ",
+            priority);
+        registry_.erase(item);
+      }
+    }
+    registry_.insert({name, OpConverterRegistration{converter, priority}});
+    return {};
+  }
+
+  StatusOr<OpConverter> LookUp(const string& name) {
+    mutex_lock lock(mu_);
+    auto found = registry_.find(name);
+    if (found != registry_.end()) {
+      return found->second.converter;
+    }
+    return errors::NotFound("No converter for op ", name);
+  }
+
+  void Clear(const std::string& name) {
+    mutex_lock lock(mu_);
+    auto itr = registry_.find(name);
+    if (itr == registry_.end()) {
+      return;
+    }
+    registry_.erase(itr);
+  }
+
+ private:
+  mutable mutex mu_;
+  mutable std::unordered_map<std::string, OpConverterRegistration> registry_
+      TF_GUARDED_BY(mu_);
+};
+
+OpConverterRegistry::OpConverterRegistry() : impl_(std::make_unique<Impl>()) {}
+
+StatusOr<OpConverter> OpConverterRegistry::LookUp(const string& name) {
+  return impl_->LookUp(name);
+}
+
+InitOnStartupMarker OpConverterRegistry::Register(const string& name,
+                                                  const int priority,
+                                                  OpConverter converter) {
+  return impl_->Register(name, priority, converter);
+}
+
+void OpConverterRegistry::Clear(const std::string& name) { impl_->Clear(name); }
+
+OpConverterRegistry* GetOpConverterRegistry() {
+  static OpConverterRegistry* registry = new OpConverterRegistry();
+  return registry;
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h
@@ -1,0 +1,101 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_REGISTRY_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_REGISTRY_H_
+
+#include <initializer_list>
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include <array>
+#include <type_traits>
+#include <vector>
+
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter.h"
+#include "tensorflow/core/lib/core/status.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+class OpConverterRegistry {
+ public:
+  OpConverterRegistry();
+  ~OpConverterRegistry() = default;
+
+  InitOnStartupMarker Register(const string& name, const int priority,
+                               OpConverter converter);
+
+  InitOnStartupMarker Register(const std::initializer_list<std::string>& names,
+                               const int priority, OpConverter converter) {
+    for (const auto& name : names) {
+      Register(name, priority, converter);
+    }
+  }
+
+  template <typename T,
+            typename std::enable_if<std::is_convertible<
+                typename T::value_type, std::string>::value>::type* = nullptr>
+  InitOnStartupMarker Register(const T& names, const int priority,
+                               OpConverter converter) {
+    for (const auto& name : names) {
+      Register(name, priority, converter);
+    }
+  }
+
+  // Clear all registered converters for the given Tensorflow operation name.
+  void Clear(const std::string& name);
+
+  StatusOr<OpConverter> LookUp(const string& name);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+OpConverterRegistry* GetOpConverterRegistry();
+
+class RegisterOpConverter {
+ public:
+  RegisterOpConverter(const string& name, const int priority,
+                      OpConverter converter) {
+    GetOpConverterRegistry()->Register(name, priority, converter);
+  }
+};
+
+constexpr int kDefaultConverterPriority = 1;
+
+}  // namespace convert
+}  // namespace tensorrt
+
+#define REGISTER_TRT_OP_CONVERTER_IMPL(ctr, func, priority, ...)    \
+  static ::tensorflow::InitOnStartupMarker const                    \
+      register_trt_op_converter##ctr TF_ATTRIBUTE_UNUSED =          \
+          TF_INIT_ON_STARTUP_IF(true)                               \
+          << tensorrt::convert::GetOpConverterRegistry()->Register( \
+                 __VA_ARGS__, priority, func)
+
+#define REGISTER_TRT_OP_CONVERTER(func, priority, ...)               \
+  TF_NEW_ID_FOR_INIT(REGISTER_TRT_OP_CONVERTER_IMPL, func, priority, \
+                     __VA_ARGS__)
+
+#define REGISTER_DEFAULT_TRT_OP_CONVERTER(func, ...)                  \
+  REGISTER_TRT_OP_CONVERTER(                                          \
+      func, tensorrt::convert::kDefaultConverterPriority, \
+      __VA_ARGS__)
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_REGISTRY_H_

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry_test.cc
@@ -1,0 +1,48 @@
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
+
+#include <gtest/gtest.h>
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+TEST(TestOpConverterRegistry, TestOpConverterRegistry) {
+  bool flag{false};
+
+  auto set_true_func = [&flag](OpConverterParams*) -> Status {
+    flag = true;
+    return Status::OK();
+  };
+
+  auto set_false_func = [&flag](OpConverterParams*) -> Status {
+    flag = false;
+    return Status::OK();
+  };
+
+  GetOpConverterRegistry()->Register("FakeFunc", kDefaultConverterPriority,
+                                     set_true_func);
+
+  // Lower priority fails to override.
+  GetOpConverterRegistry()->Register("FakeFunc", kDefaultConverterPriority - 1,
+                                     set_false_func);
+
+  // The lookup should return set_true_func (default).
+  auto func = GetOpConverterRegistry()->LookUp("FakeFunc");
+  ASSERT_TRUE(func.ok());
+  (*func)(nullptr);
+  ASSERT_TRUE(flag);
+
+  // Override with higher priority.
+  GetOpConverterRegistry()->Register("FakeFunc", kDefaultConverterPriority + 1,
+                                     set_false_func);
+  func = GetOpConverterRegistry()->LookUp("FakeFunc");
+  ASSERT_TRUE(func.ok());
+  (*func)(nullptr);
+  ASSERT_FALSE(flag);
+
+  // After clearing the op, lookup should return an error.
+  GetOpConverterRegistry()->Clear("FakeFunc");
+  ASSERT_FALSE(GetOpConverterRegistry()->LookUp("FakeFunc").ok());
+}
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow

--- a/tensorflow/compiler/tf2tensorrt/convert/weights.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/weights.cc
@@ -1,0 +1,193 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/compiler/tf2tensorrt/convert/weights.h"
+
+#include <functional>
+#include <numeric>
+
+#include "absl/strings/str_cat.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+namespace tensorflow {
+namespace tensorrt {
+
+namespace convert {
+
+TRT_ShapedWeights::TRT_ShapedWeights(nvinfer1::DataType type) : type_(type) {
+  shape_.nbDims = 0;
+  shape_.d[0] = 0;
+}
+
+TRT_ShapedWeights::TRT_ShapedWeights(nvinfer1::DataType type,
+                                     nvinfer1::Dims dims, Tensor tensor)
+    : shape_(dims), type_(type), tensor_(tensor) {
+  if (dims.nbDims == 0) {
+    DCHECK(dims.d[0] == 0 || dims.d[0] == 1);
+  }
+}
+
+TRT_ShapedWeights::TRT_ShapedWeights(const TRT_ShapedWeights& rhs)
+    : shape_(rhs.shape_), type_(rhs.type_), tensor_(rhs.tensor_) {}
+
+int64_t TRT_ShapedWeights::count(nvinfer1::Dims dims) {
+  if (dims.nbDims == 0) {
+    assert(dims.d[0] == 0 || dims.d[0] == 1);
+    return dims.d[0];
+  }
+  return static_cast<int64_t>(
+      std::accumulate(dims.d, dims.d + dims.nbDims, 1, std::multiplies<int>()));
+}
+
+nvinfer1::Weights TRT_ShapedWeights::GetTrtWeights() const {
+  return nvinfer1::Weights{type_, GetPointer<int8>(), count()};
+}
+
+Status TRT_ShapedWeights::SetShape(nvinfer1::Dims dims) {
+  if (this->count() != TRT_ShapedWeights::count(dims)) {
+    VLOG(2) << "Changing shape from "
+            << tensorflow::tensorrt::DebugString(shape_) << ", to "
+            << tensorflow::tensorrt::DebugString(dims);
+    return errors::Internal("SetShape would change number of elements");
+  }
+  shape_ = dims;
+  return Status::OK();
+}
+
+size_t TRT_ShapedWeights::size_bytes() const {
+  size_t data_type_size = -1;
+  switch (type_) {
+    case nvinfer1::DataType::kFLOAT:
+    case nvinfer1::DataType::kINT32:
+      data_type_size = 4;
+      break;
+    case nvinfer1::DataType::kHALF:
+      data_type_size = 2;
+      break;
+    case nvinfer1::DataType::kINT8:
+    case nvinfer1::DataType::kBOOL:
+      data_type_size = 1;
+      break;
+  }
+  return this->count() * data_type_size;
+}
+
+string TRT_ShapedWeights::DebugString() const {
+  return absl::StrCat(
+      "TRT_ShapedWeights(shape=", tensorflow::tensorrt::DebugString(shape_),
+      ", type=", tensorflow::tensorrt::DebugString(type_),
+      ", values=", reinterpret_cast<uintptr_t>(GetPointer<int8>()), ")");
+}
+
+TRT_TensorOrWeights::TRT_TensorOrWeights(ITensorProxyPtr tensor)
+    : tensor_proxy_ptr_(tensor), initialized_(true), is_tensor_(true) {}
+
+TRT_TensorOrWeights::TRT_TensorOrWeights(ITensorProxyPtr tensor, int batch_size)
+    : tensor_proxy_ptr_(tensor),
+      batch_size_(batch_size),
+      initialized_(true),
+      is_tensor_(true) {}
+
+TRT_TensorOrWeights::TRT_TensorOrWeights(nvinfer1::ITensor* tensor,
+                                         int batch_size)
+    : tensor_proxy_ptr_(tensor),
+      batch_size_(batch_size),
+      initialized_(true),
+      is_tensor_(true) {}
+
+TRT_TensorOrWeights::TRT_TensorOrWeights(nvinfer1::DataType trt_dtype,
+                                         const nvinfer1::Dims& trt_dims,
+                                         int batch_size)
+    : tensor_proxy_ptr_(new SimpleITensor(trt_dtype, trt_dims)),
+      batch_size_(batch_size),
+      initialized_(true),
+      is_tensor_(true) {}
+
+TRT_TensorOrWeights::TRT_TensorOrWeights(const TRT_ShapedWeights& weights)
+    : weights_(weights), initialized_(true), is_tensor_(false) {}
+
+TRT_TensorOrWeights::TRT_TensorOrWeights(const TRT_TensorOrWeights& rhs)
+    : tensor_proxy_ptr_(rhs.tensor_proxy_ptr_),
+      batch_size_(rhs.batch_size_),
+      weights_(rhs.weights_),
+      initialized_(rhs.initialized_),
+      is_tensor_(rhs.is_tensor_) {}
+
+void TRT_TensorOrWeights::operator=(const TRT_TensorOrWeights& rhs) {
+  tensor_proxy_ptr_ = rhs.tensor_proxy_ptr_;
+  batch_size_ = rhs.batch_size_;
+  weights_ = rhs.weights_;
+  initialized_ = rhs.initialized_;
+  is_tensor_ = rhs.is_tensor_;
+}
+
+ITensorProxyPtr TRT_TensorOrWeights::tensor() const {
+  CHECK(is_tensor());
+  return tensor_proxy_ptr_;
+}
+
+nvinfer1::Dims TRT_TensorOrWeights::GetTrtDims() const {
+  if (is_tensor()) {
+    return tensor()->getDimensions();
+  } else {
+    return weights().shape_;
+  }
+}
+
+Status TRT_TensorOrWeights::GetTfType(DataType* tf_type) const {
+  if (is_tensor()) {
+    nvinfer1::DataType trt_type = tensor()->getType();
+    return TrtTypeToTfType(trt_type, tf_type);
+  }
+  if (is_weights()) {
+    *tf_type = weights().GetTensor().dtype();
+    return Status::OK();
+  }
+  return errors::Internal("The object is probably not initialized");
+}
+
+string TRT_TensorOrWeights::DebugString() const {
+  string output = "TRT_TensorOrWeights(type=";
+  if (is_tensor()) {
+    absl::StrAppend(&output,
+                    "tensor=", tensorflow::tensorrt::DebugString(tensor()),
+                    ", batch_size=", batch_size_);
+  } else {
+    absl::StrAppend(&output, "weights=", weights_.DebugString());
+  }
+  absl::StrAppend(&output, ")");
+  return output;
+}
+
+TRT_ShapedWeights TrtWeightStore::GetTempWeights(nvinfer1::DataType trt_dtype,
+                                                 const nvinfer1::Dims& dims) {
+  TensorShape shape;
+  DataType tf_dtype;
+  // TODO(laigd): make it return a status.
+  TF_CHECK_OK(TensorShapeUtils::MakeShape(dims.d, dims.nbDims, &shape));
+  TF_CHECK_OK(TrtTypeToTfType(trt_dtype, &tf_dtype));
+  // TODO(jie): check weights size_bytes. 0 means type error
+  Tensor tensor(tf_dtype, shape);
+  TRT_ShapedWeights weights(trt_dtype, dims, tensor);
+  store_.emplace_back(std::move(tensor));
+  return weights;
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/weights.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/weights.h
@@ -1,0 +1,252 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TRT_WEIGHTS_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TRT_WEIGHTS_H_
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include <vector>
+
+#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_tensor_proxy.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/types.h"
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+// Class to convert TF compile-time constants (e.g. Const nodes) to TRT weight.
+class TRT_ShapedWeights {
+ public:
+  explicit TRT_ShapedWeights(
+      nvinfer1::DataType type = nvinfer1::DataType::kFLOAT);
+
+  // Constructs a weights from another weights.
+  //
+  // NOTE: this does not copy the underlying buffer but only increase its
+  // reference count.
+  TRT_ShapedWeights(const TRT_ShapedWeights& rhs);
+
+  nvinfer1::Weights GetTrtWeights() const;
+
+  const Tensor& GetTensor() const { return tensor_; }
+
+  // Returns a pointer of type const T to the underlying buffer of the tensor.
+  template <typename T>
+  const T* GetPointer() const {
+    int64 num_elem =
+        (tensor_.NumElements() * DataTypeSize(tensor_.dtype())) / sizeof(T);
+    return tensor_.bit_casted_shaped<T, 1>({num_elem}).data();
+  }
+
+  // Returns a pointer of type T to the underlying buffer of the tensor.
+  template <typename T>
+  T* GetPointer() {
+    int64 num_elem =
+        (tensor_.NumElements() * DataTypeSize(tensor_.dtype())) / sizeof(T);
+    return tensor_.bit_casted_shaped<T, 1>({num_elem}).data();
+  }
+
+  // Fills all the weight values with value.
+  template <typename T>
+  Status SetValues(T value) {
+    switch (type_) {
+      case nvinfer1::DataType::kFLOAT: {
+        float* ptr = tensor_.flat<float>().data();
+        std::fill(ptr, ptr + count(), value);
+        break;
+      }
+      case nvinfer1::DataType::kHALF: {
+        Eigen::half* ptr = tensor_.flat<Eigen::half>().data();
+        std::fill(ptr, ptr + count(), Eigen::half(value));
+        break;
+      }
+      case nvinfer1::DataType::kINT32: {
+        int32* ptr = tensor_.flat<int32>().data();
+        std::fill(ptr, ptr + count(), value);
+        break;
+      }
+      default:
+        return errors::InvalidArgument(
+            "Unsupported data type ", tensorflow::tensorrt::DebugString(type_));
+    }
+    return Status::OK();
+  }
+
+  Status SetShape(nvinfer1::Dims dims);
+
+  // Returns total number of elements. Returning 0 means either some dim is 0
+  // or the number of dims is 0. Note that a TF scalar constant is marked as
+  // Dims{0, {1}}, and has a count() == 1.
+  int64_t count() const { return count(shape_); }
+
+  // Returns the total number of elements in a weight with shape dims.
+  static int64_t count(nvinfer1::Dims dims);
+
+  size_t size_bytes() const;
+
+  string DebugString() const;
+
+  template <typename T>
+  absl::Span<const T> GetSpan() const {
+    return absl::Span<const T>(tensor_.flat<T>().data(), count());
+  }
+
+  template <typename T>
+  std::vector<T> ToVector() const {
+    auto span = GetSpan<T>();
+    return std::vector<T>(span.data(), span.data() + span.size());
+  }
+
+  nvinfer1::DataType TrtDType() const { return type_; }
+
+  // TODO(aaroey): make these private.
+  // Scalar weights are supported, a scalar constant tensor is represented via
+  // TRT_ShapedWeights::shape_ = {0, {1}}.
+  nvinfer1::Dims shape_;  // Note: shape.type[] is not used.
+
+ private:
+  // This constructor is only used by TrtWeightStore, which creates the
+  // underlying buffer.
+  TRT_ShapedWeights(nvinfer1::DataType type, nvinfer1::Dims dims,
+                    Tensor tensor);
+
+  nvinfer1::DataType type_;
+
+  // All weights should be stored inside TrtWeightStore to make sure lifetime of
+  // all the underlying tensors are available until the engine is built. For
+  // this reason, tensor_ should never be reassigned to a different value that
+  // is not already present in the TrtWeightStore.
+  Tensor tensor_;
+
+  friend class TrtWeightStore;
+};
+
+// Container for TRT_ShapedWeights. We need this container because TRT does not
+// manage the lifetime of the weights buffer, it only keeps a pointer to it and
+// requires that the data referenced by the pointer be available until the
+// building of engine is complete. For more information see
+// https://docs.nvidia.com/deeplearning/sdk/tensorrt-api/c_api/classnvinfer1_1_1_weights.html
+//
+// TODO(laigd): consider adding garbage collection to the unused weights.
+class TrtWeightStore {
+ public:
+  // Gets a TRT_ShapedWeights with 'type' and 'dims'.
+  TRT_ShapedWeights GetTempWeights(nvinfer1::DataType trt_type,
+                                   const nvinfer1::Dims& dims);
+
+  // Gets a TRT_ShapedWeights with the same data type and dimensions as
+  // 'weights'.
+  TRT_ShapedWeights GetTempWeights(const TRT_ShapedWeights& weights) {
+    return GetTempWeights(weights.TrtDType(), weights.shape_);
+  }
+
+ private:
+  // The backend storage of the TRT_ShapedWeights.
+  std::vector<Tensor> store_;
+};
+
+// Represents a TRT-style input to a TF node, it can be either a
+// ITensorProxyPtr (representing nvinfer1::ITensor* or SimpleITensor),
+// or TRT_ShapedWeights which is compile-time constant.
+//
+// TODO(laigd): maybe rename it to TrtArgument, or mimic XlaCompiler::Argument.
+class TRT_TensorOrWeights {
+ public:
+  TRT_TensorOrWeights() {}
+  TRT_TensorOrWeights(ITensorProxyPtr);
+  TRT_TensorOrWeights(ITensorProxyPtr tensor, int batch_size);
+
+  // Constructs a wrapper for the given ITensor.
+  // This is used by Converter when building the TRT network, where the ITensor
+  // is owned by the TRT network being built. See comment for 'trt_tensor_'
+  // in trt_proxy_tensor.h.
+  explicit TRT_TensorOrWeights(nvinfer1::ITensor* tensor, int batch_size = -1);
+
+  // Creates a SimpleITensor for trt_dtype and trt_dims and takes ownership of
+  // the object. Constructs a wrapper for the SimpleITensor. This is used by
+  // TrtNodeValidator to encapsulate the type and shape information for
+  // validation of graph nodes, and the created ITensor is fake and temporary,
+  // and should not be used to build any TRT network. See comment for
+  // 'simple_tensor_' in trt_proxy_tensor.h.
+  explicit TRT_TensorOrWeights(nvinfer1::DataType trt_dtype,
+                               const nvinfer1::Dims& trt_dims, int batch_size);
+
+  // Constructs a wrapper for the given weights.
+  explicit TRT_TensorOrWeights(const TRT_ShapedWeights& weights);
+
+  TRT_TensorOrWeights(const TRT_TensorOrWeights& rhs);
+
+  void operator=(const TRT_TensorOrWeights& rhs);
+
+  bool is_tensor() const { return initialized_ && is_tensor_; }
+  bool is_weights() const { return initialized_ && !is_tensor_; }
+
+  ITensorProxyPtr tensor() const;
+
+  TRT_ShapedWeights& weights() {
+    CHECK(is_weights());
+    return weights_;
+  }
+
+  const TRT_ShapedWeights& weights() const {
+    CHECK(is_weights());
+    return weights_;
+  }
+
+  nvinfer1::Dims GetTrtDims() const;
+
+  Status GetTfType(DataType* tf_type) const;
+
+  int batch_size() const { return batch_size_; }
+
+  string DebugString() const;
+
+ private:
+  void set_batch_size(int batch_size) { batch_size_ = batch_size; }
+
+  // First dimension of the TF tensor (NOT tensor_) that is represented by
+  // tensor_ is treated as the "batch dimension" by TRT, and tensor_'s
+  // dimensions (obtained via tensor_->getDimensions()) do not contain the batch
+  // dimension. For example, when a TF tensor with shape (A,B,C) is represented
+  // in TRT, tensor_->getDimensions() will be (B,C) and batch_size_ will be A.
+  //
+  // This requires that all tensors in the subgraph that is converted to a TRT
+  // engine have the same batch size are represented by the first dimension of
+  // their shape, and Converter will verify this during conversion. The drawback
+  // is that currently it cannot convert a graph that doesn't have the batch
+  // size represented in the shapes or the batch sizes are different. See
+  // b/118387490 for more details.
+  //
+  // If use_implicit_batch is false, batch_size_ is unused and
+  // tensor_->getDimensions() will contain the entire shape (A,B,C).
+  ITensorProxyPtr tensor_proxy_ptr_ = nullptr;
+  int batch_size_ = -1;
+
+  TRT_ShapedWeights weights_;
+  bool initialized_ = false;
+  bool is_tensor_ = false;
+
+  friend class Converter;
+};
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TRT_WEIGHTS_H_


### PR DESCRIPTION
This PR is the first stage of refactoring the TF-TRT op converters. It adds a static registration system for the conversion functions which map from Tensorflow operations to TensorRT. The end result is that converters can be defined outside of `convert_nodes.cc` and users can link in their own converter functions, overriding existing functions.
The following changes are made:
1. TRT Weights-related classes defined in convert_nodes.h are moved into `convert/weights.[h|cc]`. This is required to capture correct class and include dependencies.
2. Static OpConverter registration system is introduced.
3. Changes in `convert_nodes.cc` and `convert_nodes_test.cc` are made in order to use the new registration system.

More easily reviewed by commit. The "TRT Weights classes to seperate files" commit is purely moving classes around. The main changes are in the final commit, which accomplishes points #2 and #3.