### PR TITLE
fix Windows MSVC debug build

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -255,6 +255,15 @@ config_setting(
 )
 
 config_setting(
+    name = "msvc_cl_debug",
+    values = {
+        "compiler": "msvc-cl",
+        "compilation_mode": "dbg",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "no_tensorflow_py_deps",
     define_values = {"no_tensorflow_py_deps": "true"},
     visibility = ["//visibility:public"],
@@ -1043,6 +1052,11 @@ tf_cc_shared_object(
             "-z defs",
             "-Wl,--version-script,$(location //tensorflow:tf_version_script.lds)",
         ],
+    }) + select({
+        "//tensorflow:msvc_cl_debug": [
+            "/DEBUG:FASTLINK",
+        ],
+        "//conditions:default": [],
     }),
     per_os_targets = True,
     soversion = VERSION,

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -255,15 +255,6 @@ config_setting(
 )
 
 config_setting(
-    name = "msvc_cl_debug",
-    values = {
-        "compiler": "msvc-cl",
-        "compilation_mode": "dbg",
-    },
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
     name = "no_tensorflow_py_deps",
     define_values = {"no_tensorflow_py_deps": "true"},
     visibility = ["//visibility:public"],
@@ -1052,11 +1043,6 @@ tf_cc_shared_object(
             "-z defs",
             "-Wl,--version-script,$(location //tensorflow:tf_version_script.lds)",
         ],
-    }) + select({
-        "//tensorflow:msvc_cl_debug": [
-            "/DEBUG:FASTLINK",
-        ],
-        "//conditions:default": [],
     }),
     per_os_targets = True,
     soversion = VERSION,

--- a/tensorflow/core/kernels/depthtospace_op.cc
+++ b/tensorflow/core/kernels/depthtospace_op.cc
@@ -112,8 +112,11 @@ class DepthToSpaceOp : public OpKernel {
     auto Tinput = input.tensor<T, kDims>();
     auto Toutput = outputs_tensor->tensor<T, kDims>();
 
-    constexpr bool is_gpu = std::is_same<Device, GPUDevice>::value;
-    if (is_gpu) {
+#if _HAS_CXX17
+    if constexpr (std::is_same<Device, GPUDevice>::value) {
+#else
+    if (std::is_same<Device, GPUDevice>::value) {
+#endif
       if (is_int8x4) {
         // NCHW_VECT_C with 4 x qint8 can be treated as NCHW int32.
         auto Tinput_v = input.template reinterpret_last_dimension<int32, 4>();

--- a/tensorflow/core/kernels/depthtospace_op.cc
+++ b/tensorflow/core/kernels/depthtospace_op.cc
@@ -112,7 +112,8 @@ class DepthToSpaceOp : public OpKernel {
     auto Tinput = input.tensor<T, kDims>();
     auto Toutput = outputs_tensor->tensor<T, kDims>();
 
-    if constexpr (std::is_same<Device, GPUDevice>::value) {
+    constexpr bool is_gpu = std::is_same<Device, GPUDevice>::value;
+    if (is_gpu) {
       if (is_int8x4) {
         // NCHW_VECT_C with 4 x qint8 can be treated as NCHW int32.
         auto Tinput_v = input.template reinterpret_last_dimension<int32, 4>();

--- a/tensorflow/core/kernels/depthtospace_op.cc
+++ b/tensorflow/core/kernels/depthtospace_op.cc
@@ -112,11 +112,7 @@ class DepthToSpaceOp : public OpKernel {
     auto Tinput = input.tensor<T, kDims>();
     auto Toutput = outputs_tensor->tensor<T, kDims>();
 
-#if _HAS_CXX17
-    if constexpr (std::is_same<Device, GPUDevice>::value) {
-#else
     if (std::is_same<Device, GPUDevice>::value) {
-#endif
       if (is_int8x4) {
         // NCHW_VECT_C with 4 x qint8 can be treated as NCHW int32.
         auto Tinput_v = input.template reinterpret_last_dimension<int32, 4>();

--- a/tensorflow/core/kernels/depthtospace_op.cc
+++ b/tensorflow/core/kernels/depthtospace_op.cc
@@ -112,7 +112,7 @@ class DepthToSpaceOp : public OpKernel {
     auto Tinput = input.tensor<T, kDims>();
     auto Toutput = outputs_tensor->tensor<T, kDims>();
 
-    if (std::is_same<Device, GPUDevice>::value) {
+    if constexpr (std::is_same<Device, GPUDevice>::value) {
       if (is_int8x4) {
         // NCHW_VECT_C with 4 x qint8 can be treated as NCHW int32.
         auto Tinput_v = input.template reinterpret_last_dimension<int32, 4>();
@@ -172,16 +172,6 @@ struct DepthToSpaceOpFunctor<CPUDevice, T, FORMAT_NHWC> {
     }
   }
 };
-
-#ifdef WIN32
-template <typename T>
-struct DepthToSpaceOpFunctor<CPUDevice, T, FORMAT_NCHW> {
-  void operator()(const CPUDevice& d, typename TTypes<T, 4>::ConstTensor input,
-                  int block_size, typename TTypes<T, 4>::Tensor output) {
-    LOG(FATAL) << "Trivial implementation to make debug build compile.";
-  }
-};
-#endif
 }  // namespace functor
 
 #define REGISTER(type)                                                \

--- a/tensorflow/core/kernels/spacetodepth_op.cc
+++ b/tensorflow/core/kernels/spacetodepth_op.cc
@@ -126,7 +126,8 @@ class SpaceToDepthOp : public OpKernel {
                                        output_width, output_depth),
                        &outputs_tensor));
 
-    if constexpr (std::is_same<Device, GPUDevice>::value) {
+    constexpr bool is_gpu = std::is_same<Device, GPUDevice>::value;
+    if (is_gpu) {
       using RT = typename RawType<T>::type;
       if (data_format_ == FORMAT_NCHW_VECT_C) {
         // NCHW_VECT_C with 4 x qint8 can be treated as NCHW int32.

--- a/tensorflow/core/kernels/spacetodepth_op.cc
+++ b/tensorflow/core/kernels/spacetodepth_op.cc
@@ -126,8 +126,11 @@ class SpaceToDepthOp : public OpKernel {
                                        output_width, output_depth),
                        &outputs_tensor));
 
-    constexpr bool is_gpu = std::is_same<Device, GPUDevice>::value;
-    if (is_gpu) {
+#if _HAS_CXX17
+    if constexpr (std::is_same<Device, GPUDevice>::value) {
+#else
+    if (std::is_same<Device, GPUDevice>::value) {
+#endif
       using RT = typename RawType<T>::type;
       if (data_format_ == FORMAT_NCHW_VECT_C) {
         // NCHW_VECT_C with 4 x qint8 can be treated as NCHW int32.

--- a/tensorflow/core/kernels/spacetodepth_op.cc
+++ b/tensorflow/core/kernels/spacetodepth_op.cc
@@ -126,7 +126,7 @@ class SpaceToDepthOp : public OpKernel {
                                        output_width, output_depth),
                        &outputs_tensor));
 
-    if (std::is_same<Device, GPUDevice>::value) {
+    if constexpr (std::is_same<Device, GPUDevice>::value) {
       using RT = typename RawType<T>::type;
       if (data_format_ == FORMAT_NCHW_VECT_C) {
         // NCHW_VECT_C with 4 x qint8 can be treated as NCHW int32.
@@ -188,16 +188,6 @@ struct SpaceToDepthOpFunctor<CPUDevice, T, FORMAT_NHWC> {
     }
   }
 };
-
-#ifdef WIN32
-template <typename T>
-struct SpaceToDepthOpFunctor<CPUDevice, T, FORMAT_NCHW> {
-  void operator()(const CPUDevice& d, typename TTypes<T, 4>::ConstTensor input,
-                  int block_size, typename TTypes<T, 4>::Tensor output) {
-    LOG(FATAL) << "Trivial implementation to make debug build compile.";
-  }
-};
-#endif
 }  // namespace functor
 
 #define REGISTER(type)                                                \

--- a/tensorflow/core/kernels/spacetodepth_op.cc
+++ b/tensorflow/core/kernels/spacetodepth_op.cc
@@ -126,11 +126,7 @@ class SpaceToDepthOp : public OpKernel {
                                        output_width, output_depth),
                        &outputs_tensor));
 
-#if _HAS_CXX17
-    if constexpr (std::is_same<Device, GPUDevice>::value) {
-#else
     if (std::is_same<Device, GPUDevice>::value) {
-#endif
       using RT = typename RawType<T>::type;
       if (data_format_ == FORMAT_NCHW_VECT_C) {
         // NCHW_VECT_C with 4 x qint8 can be treated as NCHW int32.


### PR DESCRIPTION
previous fix in #42676 using partial dummy template specializations (which are not needed but without optimization the compiler doesn't find out about it) stopped working, thus fix using `constexpr`, which is a better fix anyway