### PR TITLE
[XLA:GPU] Use arg_num instead of kernel parameter to check resource_updates

### DIFF
--- a/tensorflow/compiler/jit/xla_launch_util.cc
+++ b/tensorflow/compiler/jit/xla_launch_util.cc
@@ -262,6 +262,8 @@ XlaComputationLaunchContext::PopulateInputs(
         is_resource_variable &&
         absl::c_any_of(compilation_result->resource_updates,
                        [&](const XlaCompiler::ResourceUpdate& update) {
+                         // XlaCompiler records `arg_num` in
+                         // `resource_updates` instead of kernel parameters.
                          return update.input_index == arg_num &&
                                 update.modified;
                        });

--- a/tensorflow/compiler/jit/xla_launch_util.cc
+++ b/tensorflow/compiler/jit/xla_launch_util.cc
@@ -262,8 +262,8 @@ XlaComputationLaunchContext::PopulateInputs(
         is_resource_variable &&
         absl::c_any_of(compilation_result->resource_updates,
                        [&](const XlaCompiler::ResourceUpdate& update) {
-                         // XlaCompiler records `arg_num` in
-                         // `resource_updates` instead of kernel parameters.
+                         // XlaCompiler records `arg_num` (instead of kernel
+                         // parameters) in `resource_updates`.
                          return update.input_index == arg_num &&
                                 update.modified;
                        });

--- a/tensorflow/compiler/jit/xla_launch_util.cc
+++ b/tensorflow/compiler/jit/xla_launch_util.cc
@@ -262,7 +262,8 @@ XlaComputationLaunchContext::PopulateInputs(
         is_resource_variable &&
         absl::c_any_of(compilation_result->resource_updates,
                        [&](const XlaCompiler::ResourceUpdate& update) {
-                         return update.input_index == i && update.modified;
+                         return update.input_index == arg_num &&
+                                update.modified;
                        });
 
     const Tensor* t = is_resource_variable

--- a/tensorflow/python/eager/def_function_xla_jit_test.py
+++ b/tensorflow/python/eager/def_function_xla_jit_test.py
@@ -682,6 +682,28 @@ class DefFunctionTest(xla_test.XLATestCase):
           v.device)['current'] if on_gpu else 0
       self.assertEqual(initial_usage, final_usage)
 
+  def testUpdateVariableWithCompileTimeConstMemoryUsage(self):
+    with ops.device('device:{}:0'.format(self.device)):
+
+      on_gpu = 'gpu' in self.device.lower()
+      v = variables.Variable(random_ops.random_normal([1024, 1024]))
+
+      # test a signature of (compile-time const, arg, res_var). The compile-time
+      # const will be optimized away so that the kernel signature will become
+      # (arg, res_var).
+      @def_function.function(jit_compile=True)
+      def update_var(shape, arg):
+        v.assign_add(array_ops.reshape(arg, shape))
+
+      arg = random_ops.random_normal([1])
+
+      initial_usage = context.context().get_memory_info(
+          v.device)['current'] if on_gpu else 0
+      update_var(constant_op.constant([1, 1]), arg)
+      final_usage = context.context().get_memory_info(
+          v.device)['current'] if on_gpu else 0
+      self.assertEqual(initial_usage, final_usage)
+
   @test_util.disable_mlir_bridge('TODO(b/162381930): MLIR bridge renames '
                                  ' functions')
   def testUpdateVariableInClass(self):

--- a/tensorflow/python/eager/def_function_xla_jit_test.py
+++ b/tensorflow/python/eager/def_function_xla_jit_test.py
@@ -682,6 +682,8 @@ class DefFunctionTest(xla_test.XLATestCase):
           v.device)['current'] if on_gpu else 0
       self.assertEqual(initial_usage, final_usage)
 
+  @test_util.disable_mlir_bridge('MLIR does not support resource update for'
+                                 ' signature with compile-time constant.')
   def testUpdateVariableWithCompileTimeConstMemoryUsage(self):
     with ops.device('device:{}:0'.format(self.device)):
 


### PR DESCRIPTION
Separate some codes into this PR for cleanness from [a previous PR](https://github.com/tensorflow/tensorflow/pull/51353). 

It turns out this is a bug that can cause buffer_donation (in resource var update) to not work as expected in manual clustering (in addition to auto-clustering). The added test `testUpdateVariableWithCompileTimeConstMemoryUsage` fails without the fix to use `arg_num` (instead of kernel parameters) to check whether a parameter is a resource update or not.
