### PR TITLE
[determinism] Add d9m-unimplemented exception for tf.nn.depthwise_conv2d

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4016,6 +4016,7 @@ tf_kernel_library(
         ":ops_util",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",
+        "//tensorflow/core/util:determinism_for_kernels",
         "//tensorflow/core:lib",
         "//tensorflow/core/framework:bounds_check",
     ] + if_cuda([

--- a/tensorflow/core/kernels/depthwise_conv_op_gpu.h
+++ b/tensorflow/core/kernels/depthwise_conv_op_gpu.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/kernels/depthwise_conv_op.h"
 #include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/determinism.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/core/util/tensor_format.h"
 
@@ -1756,6 +1757,10 @@ void LaunchDepthwiseConvBackpropFilterOp<GpuDevice, T>::operator()(
     OpKernelContext* ctx, const DepthwiseArgs& args, const T* out_backprop,
     const T* input, T* filter_backprop, TensorFormat data_format) {
   auto stream = ctx->op_device_context()->stream();
+
+  OP_REQUIRES(ctx, !OpDeterminismRequired(), errors::Unimplemented(
+      "A deterministic GPU implementation of DepthwiseConvBackpropFilter is"
+      " not currently available."));
 
   // Initialize the results to 0.
   int num_filter_backprop =

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -3127,6 +3127,8 @@ cuda_py_test(
         "//tensorflow/python:nn",
         "//tensorflow/python:nn_grad",
         "//tensorflow/python:nn_ops",
+        "//tensorflow/python:random_ops",
+        "//tensorflow/python/eager:backprop",
         "//third_party/py/numpy",
     ],
 )

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -1594,7 +1594,7 @@ class AdjustContrastTest(test_util.TensorFlowTestCase):
                                 "Shape must be rank 0 but is rank 1"):
       image_ops.adjust_contrast(x_np, [2.0])
 
-  @test_util.run_all_in_graph_and_eager_modes
+  @test_util.run_in_graph_and_eager_modes
   def testDeterminismUnimplementedExceptionThrowing(self):
     """Test d9m-unimplemented exception-throwing when op-determinism is enabled.
 


### PR DESCRIPTION
This current PR adds and tests determinism-unimplemented exception-throwing for `tf.nn.depthwise_conv2d` when determinism is expected but not available. It also tests that the op functions deterministically when determinism is expected and is available (forward/backward CPU and forward/backward GPU using cuDNN).

This PR is related to [RFC: Enabling Determinism in TensorFlow](https://github.com/tensorflow/community/blob/master/rfcs/20210119-determinism.md). For status and history of GPU-determinism for this op, see [here](https://github.com/NVIDIA/framework-determinism/blob/master/tensorflow_status.md#depthwise-convolution).

I believe that when this op uses cuDNN convolution functionality, it benefits from all the determinism solutions associated with that, including deterministic algorithm selection (assuming that still works).

CC @reedwm, @sanjoy, @nluehr