### PR TITLE
[tf.data] move `StructuredFunctionWrapper` into a separate module

### DIFF
--- a/tensorflow/python/data/benchmarks/from_tensor_slices_benchmark.py
+++ b/tensorflow/python/data/benchmarks/from_tensor_slices_benchmark.py
@@ -22,6 +22,7 @@ import numpy as np
 from tensorflow.python.data.benchmarks import benchmark_base
 from tensorflow.python.data.experimental.ops import get_single_element
 from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.data.ops import structured_function
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.ops import gen_dataset_ops
@@ -33,7 +34,7 @@ class SingleThreadedFlatMapDataset(dataset_ops.UnaryDataset):
   def __init__(self, input_dataset, map_func):
     """See `Dataset.flat_map()` for details."""
     self._input_dataset = input_dataset
-    self._map_func = dataset_ops.StructuredFunctionWrapper(
+    self._map_func = structured_function.StructuredFunctionWrapper(
         map_func,
         self._transformation_name(),
         dataset=input_dataset,

--- a/tensorflow/python/data/experimental/ops/batching.py
+++ b/tensorflow/python/data/experimental/ops/batching.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.data.ops import structured_function
 from tensorflow.python.data.util import convert
 from tensorflow.python.data.util import nest
 from tensorflow.python.framework import dtypes
@@ -339,7 +340,7 @@ class _MapAndBatchDataset(dataset_ops.UnaryDataset):
                drop_remainder, use_legacy_function=False):
     self._input_dataset = input_dataset
 
-    self._map_func = dataset_ops.StructuredFunctionWrapper(
+    self._map_func = structured_function.StructuredFunctionWrapper(
         map_func,
         "tf.data.experimental.map_and_batch()",
         dataset=input_dataset,
@@ -445,7 +446,7 @@ class _DenseToRaggedDataset(dataset_ops.UnaryDataset):
         return spec._to_tensor_list(value)[0]  # pylint: disable=protected-access
 
     # Tuples are automatically unpacked by `dataset.map` so we repack them.
-    if dataset_ops._should_unpack(input_dataset.element_spec):  # pylint: disable=protected-access
+    if structured_function._should_unpack(input_dataset.element_spec):  # pylint: disable=protected-access
       map_fn = lambda *value: nest.map_structure(to_ragged_variant, value)
     else:
       map_fn = lambda value: nest.map_structure(to_ragged_variant, value)

--- a/tensorflow/python/data/experimental/ops/grouping.py
+++ b/tensorflow/python/data/experimental/ops/grouping.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.data.ops import structured_function
 from tensorflow.python.data.util import nest
 from tensorflow.python.data.util import structure
 from tensorflow.python.framework import dtypes
@@ -285,7 +286,7 @@ class _GroupByReducerDataset(dataset_ops.UnaryDataset):
 
   def _make_key_func(self, key_func, input_dataset):
     """Make wrapping defun for key_func."""
-    self._key_func = dataset_ops.StructuredFunctionWrapper(
+    self._key_func = structured_function.StructuredFunctionWrapper(
         key_func, self._transformation_name(), dataset=input_dataset)
     if not self._key_func.output_structure.is_compatible_with(
         tensor_spec.TensorSpec([], dtypes.int64)):
@@ -298,7 +299,7 @@ class _GroupByReducerDataset(dataset_ops.UnaryDataset):
 
   def _make_init_func(self, init_func):
     """Make wrapping defun for init_func."""
-    self._init_func = dataset_ops.StructuredFunctionWrapper(
+    self._init_func = structured_function.StructuredFunctionWrapper(
         init_func,
         self._transformation_name(),
         input_structure=tensor_spec.TensorSpec([], dtypes.int64))
@@ -315,7 +316,7 @@ class _GroupByReducerDataset(dataset_ops.UnaryDataset):
     need_to_rerun = True
     while need_to_rerun:
 
-      wrapped_func = dataset_ops.StructuredFunctionWrapper(
+      wrapped_func = structured_function.StructuredFunctionWrapper(
           reduce_func,
           self._transformation_name(),
           input_structure=(self._state_structure, input_dataset.element_spec),
@@ -370,7 +371,7 @@ class _GroupByReducerDataset(dataset_ops.UnaryDataset):
 
   def _make_finalize_func(self, finalize_func):
     """Make wrapping defun for finalize_func."""
-    self._finalize_func = dataset_ops.StructuredFunctionWrapper(
+    self._finalize_func = structured_function.StructuredFunctionWrapper(
         finalize_func, self._transformation_name(),
         input_structure=self._state_structure)
 

--- a/tensorflow/python/data/experimental/ops/io.py
+++ b/tensorflow/python/data/experimental/ops/io.py
@@ -23,6 +23,7 @@ import os
 
 from tensorflow.python.compat import compat
 from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.data.ops import structured_function
 from tensorflow.python.data.util import structure
 from tensorflow.python.eager import context
 from tensorflow.python.framework import dtypes
@@ -178,7 +179,7 @@ def _set_save_dataset_attributes(dataset, shard_func, path):
   else:
     use_shard_func = True
 
-  wrapped_func = dataset_ops.StructuredFunctionWrapper(
+  wrapped_func = structured_function.StructuredFunctionWrapper(
       shard_func,
       "save()",
       input_structure=dataset.element_spec,
@@ -223,7 +224,7 @@ class _LoadDataset(dataset_ops.DatasetSource):
     else:
       self._element_spec = element_spec
     self._compression = compression
-    self._reader_func = dataset_ops.StructuredFunctionWrapper(
+    self._reader_func = structured_function.StructuredFunctionWrapper(
         reader_func,
         "load()",
         # Dataset of datasets of input elements

--- a/tensorflow/python/data/experimental/ops/prefetching_ops.py
+++ b/tensorflow/python/data/experimental/ops/prefetching_ops.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.data.ops import iterator_ops
+from tensorflow.python.data.ops import structured_function
 from tensorflow.python.data.util import structure
 from tensorflow.python.eager import function
 from tensorflow.python.framework import device as framework_device
@@ -239,7 +240,7 @@ class _MapOnGpuDataset(dataset_ops.UnaryDataset):
     self._input_dataset = input_dataset
     self._use_inter_op_parallelism = use_inter_op_parallelism
 
-    self._map_func = dataset_ops.StructuredFunctionWrapper(
+    self._map_func = structured_function.StructuredFunctionWrapper(
         map_func,
         self._transformation_name(),
         dataset=input_dataset,

--- a/tensorflow/python/data/ops/BUILD
+++ b/tensorflow/python/data/ops/BUILD
@@ -4,12 +4,26 @@ package(
 )
 
 py_library(
+    name = "structured_function",
+    srcs = ["structured_function.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//tensorflow/python:framework_ops",
+        "//tensorflow/python:function",
+        "//tensorflow/python:util",
+        "//tensorflow/python/data/util:nest",
+        "//tensorflow/python/data/util:structure",
+    ],
+)
+
+py_library(
     name = "dataset_ops",
     srcs = ["dataset_ops.py"],
     srcs_version = "PY3",
     deps = [
         ":iterator_ops",
         ":options",
+        ":structured_function",
         "//tensorflow/python:constant_op",
         "//tensorflow/python:control_flow_ops",
         "//tensorflow/python:dataset_ops_gen",

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -36,13 +36,12 @@ from tensorflow.python import tf2
 from tensorflow.python.compat import compat
 from tensorflow.python.data.ops import iterator_ops
 from tensorflow.python.data.ops import options as options_lib
+from tensorflow.python.data.ops import structured_function
 from tensorflow.python.data.util import nest
 from tensorflow.python.data.util import random_seed
 from tensorflow.python.data.util import structure
 from tensorflow.python.data.util import traverse
 from tensorflow.python.eager import context
-from tensorflow.python.eager import def_function
-from tensorflow.python.eager import function as eager_function
 from tensorflow.python.framework import auto_control_deps
 from tensorflow.python.framework import auto_control_deps_utils as acd_utils
 from tensorflow.python.framework import composite_tensor
@@ -73,7 +72,6 @@ from tensorflow.python.ops.ragged import ragged_tensor
 from tensorflow.python.training.tracking import base as tracking_base
 from tensorflow.python.training.tracking import tracking
 from tensorflow.python.util import deprecation
-from tensorflow.python.util import function_utils
 from tensorflow.python.util import lazy_loader
 from tensorflow.python.util import nest as tf_nest
 from tensorflow.python.util.compat import collections_abc
@@ -85,13 +83,6 @@ from tensorflow.python.util.tf_export import tf_export
 wrap_function = lazy_loader.LazyLoader(
     "wrap_function", globals(),
     "tensorflow.python.eager.wrap_function")
-# TODO(mdan): Create a public API for this.
-autograph_ctx = lazy_loader.LazyLoader(
-    "autograph_ctx", globals(),
-    "tensorflow.python.autograph.core.ag_ctx")
-autograph = lazy_loader.LazyLoader(
-    "autograph", globals(),
-    "tensorflow.python.autograph.impl.api")
 # Loaded lazily due to a circular dependency
 # dataset_ops->parsing_ops->dataset_ops
 # TODO(varshaan): Use a regular import.
@@ -2420,7 +2411,7 @@ name=None))
     need_to_rerun = True
     while need_to_rerun:
 
-      wrapped_func = StructuredFunctionWrapper(
+      wrapped_func = structured_function.StructuredFunctionWrapper(
           reduce_func,
           "reduce()",
           input_structure=(state_structure, self.element_spec),
@@ -4346,239 +4337,6 @@ class DatasetSpec(type_spec.BatchableTypeSpec):
     return self
 
 
-class StructuredFunctionWrapper(object):
-  """A function wrapper that supports structured arguments and return values."""
-
-  def __init__(self,
-               func,
-               transformation_name,
-               dataset=None,
-               input_classes=None,
-               input_shapes=None,
-               input_types=None,
-               input_structure=None,
-               add_to_graph=True,
-               use_legacy_function=False,
-               defun_kwargs=None):
-    """Creates a new `StructuredFunctionWrapper` for the given function.
-
-    Args:
-      func: A function from a (nested) structure to another (nested) structure.
-      transformation_name: Human-readable name of the transformation in which
-        this function is being instantiated, for error messages.
-      dataset: (Optional.) A `tf.data.Dataset`. If given, the structure of this
-        dataset will be assumed as the structure for `func` arguments; otherwise
-        `input_classes`, `input_shapes`, and `input_types` must be defined.
-      input_classes: (Optional.) A (nested) structure of `type`. If given, this
-        argument defines the Python types for `func` arguments.
-      input_shapes: (Optional.) A (nested) structure of `tf.TensorShape`. If
-        given, this argument defines the shapes and structure for `func`
-        arguments.
-      input_types: (Optional.) A (nested) structure of `tf.DType`. If given,
-        this argument defines the element types and structure for `func`
-        arguments.
-      input_structure: (Optional.) A `Structure` object. If given, this argument
-        defines the element types and structure for `func` arguments.
-      add_to_graph: (Optional.) If `True`, the function will be added to the
-        default graph, if it exists.
-      use_legacy_function: (Optional.) A boolean that determines whether the
-        function be created using `tensorflow.python.eager.function.defun`
-        (default behavior) or `tensorflow.python.framework.function.Defun`
-        (legacy behavior).
-      defun_kwargs: (Optional.) A dictionary mapping string argument names to
-        values. If supplied, will be passed to `function` as keyword arguments.
-
-    Raises:
-      ValueError: If an invalid combination of `dataset`, `input_classes`,
-        `input_shapes`, and `input_types` is passed.
-    """
-    # pylint: disable=protected-access
-    if input_structure is None:
-      if dataset is None:
-        if input_classes is None or input_shapes is None or input_types is None:
-          raise ValueError("Either `dataset`, `input_structure` or all of "
-                           "`input_classes`, `input_shapes`, and `input_types` "
-                           "must be specified.")
-        self._input_structure = structure.convert_legacy_structure(
-            input_types, input_shapes, input_classes)
-      else:
-        if not (input_classes is None and input_shapes is None and
-                input_types is None):
-          raise ValueError("Either `dataset`, `input_structure` or all of "
-                           "`input_classes`, `input_shapes`, and `input_types` "
-                           "must be specified.")
-        self._input_structure = dataset.element_spec
-    else:
-      if not (dataset is None and input_classes is None and input_shapes is None
-              and input_types is None):
-        raise ValueError("Either `dataset`, `input_structure`, or all of "
-                         "`input_classes`, `input_shapes`, and `input_types` "
-                         "must be specified.")
-      self._input_structure = input_structure
-
-    self._func = func
-
-    if defun_kwargs is None:
-      defun_kwargs = {}
-
-    readable_transformation_name = transformation_name.replace(
-        ".", "_")[:-2] if len(transformation_name) > 2 else ""
-
-    func_name = "_".join(
-        [readable_transformation_name,
-         function_utils.get_func_name(func)])
-    # Sanitize function name to remove symbols that interfere with graph
-    # construction.
-    for symbol in ["<", ">", "\\", "'", " "]:
-      func_name = func_name.replace(symbol, "")
-
-    ag_ctx = autograph_ctx.control_status_ctx()
-
-    def wrapper_helper(*args):
-      """Wrapper for passing nested structures to and from tf.data functions."""
-      nested_args = structure.from_compatible_tensor_list(
-          self._input_structure, args)
-      if not _should_unpack(nested_args):
-        nested_args = (nested_args,)
-      ret = autograph.tf_convert(self._func, ag_ctx)(*nested_args)
-      if _should_pack(ret):
-        ret = tuple(ret)
-
-      try:
-        self._output_structure = structure.type_spec_from_value(ret)
-      except (ValueError, TypeError):
-        six.reraise(
-            TypeError,
-            TypeError(f"Unsupported return value from function passed to "
-                      f"{transformation_name}: {ret}."),
-            sys.exc_info()[2])
-      return ret
-
-    def trace_legacy_function(defun_kwargs):
-      @function.Defun(*structure.get_flat_tensor_types(self._input_structure),
-                      **defun_kwargs)
-      def wrapped_fn(*args):
-        ret = wrapper_helper(*args)
-        return structure.to_tensor_list(self._output_structure, ret)
-
-      return lambda: wrapped_fn
-
-    def trace_py_function(defun_kwargs):
-      # First we trace the function to infer the output structure.
-      @eager_function.defun_with_attributes(
-          input_signature=structure.get_flat_tensor_specs(
-              self._input_structure),
-          autograph=False,
-          attributes=defun_kwargs)
-      def unused(*args):  # pylint: disable=missing-docstring,unused-variable
-        ret = wrapper_helper(*args)
-        ret = structure.to_tensor_list(self._output_structure, ret)
-        return [ops.convert_to_tensor(t) for t in ret]
-
-      _ = unused.get_concrete_function()
-
-      def py_function_wrapper(*args):
-        nested_args = structure.from_compatible_tensor_list(
-            self._input_structure, args)
-        if not _should_unpack(nested_args):
-          nested_args = (nested_args,)
-        ret = self._func(*nested_args)
-        if _should_pack(ret):
-          ret = tuple(ret)
-        ret = structure.to_tensor_list(self._output_structure, ret)
-        return [ops.convert_to_tensor(t) for t in ret]
-
-      # Next we trace the function wrapped in `eager_py_func` to force eager
-      # execution.
-      @eager_function.defun_with_attributes(
-          input_signature=structure.get_flat_tensor_specs(
-              self._input_structure),
-          autograph=False,
-          attributes=defun_kwargs)
-      def wrapped_fn(*args):  # pylint: disable=missing-docstring
-        return script_ops.eager_py_func(
-            py_function_wrapper, args,
-            structure.get_flat_tensor_types(self._output_structure))
-
-      return wrapped_fn.get_concrete_function
-
-    def trace_tf_function(defun_kwargs):
-      # Note: wrapper_helper will apply autograph based on context.
-      @eager_function.defun_with_attributes(
-          input_signature=structure.get_flat_tensor_specs(
-              self._input_structure),
-          autograph=False,
-          attributes=defun_kwargs)
-      def wrapped_fn(*args):  # pylint: disable=missing-docstring
-        ret = wrapper_helper(*args)
-        ret = structure.to_tensor_list(self._output_structure, ret)
-        return [ops.convert_to_tensor(t) for t in ret]
-
-      return wrapped_fn.get_concrete_function
-
-    if use_legacy_function:
-      defun_kwargs.update({"func_name": func_name + "_" + str(ops.uid())})
-      fn_factory = trace_legacy_function(defun_kwargs)
-    else:
-      defun_kwargs.update({"func_name": func_name})
-      defun_kwargs.update({"_tf_data_function": True})
-      if DEBUG_MODE:
-        fn_factory = trace_py_function(defun_kwargs)
-      else:
-        if def_function.functions_run_eagerly():
-          warnings.warn(
-              "Even though the `tf.config.experimental_run_functions_eagerly` "
-              "option is set, this option does not apply to tf.data functions. "
-              "To force eager execution of tf.data functions, please use "
-              "`tf.data.experimental.enable_debug_mode()`.")
-        fn_factory = trace_tf_function(defun_kwargs)
-
-    self._function = fn_factory()
-    # There is no graph to add in eager mode.
-    add_to_graph &= not context.executing_eagerly()
-    # There are some lifetime issues when a legacy function is not added to a
-    # out-living graph. It's already deprecated so de-prioritizing the fix.
-    add_to_graph |= use_legacy_function
-    if add_to_graph:
-      self._function.add_to_graph(ops.get_default_graph())
-
-    if not use_legacy_function:
-      outer_graph_seed = ops.get_default_graph().seed
-      if outer_graph_seed and self._function.graph.seed == outer_graph_seed:
-        if self._function.graph._seed_used:
-          warnings.warn(
-              "Seed %s from outer graph might be getting used by function %s, "
-              "if the random op has not been provided any seed. Explicitly set "
-              "the seed in the function if this is not the intended behavior."
-              %(outer_graph_seed, func_name), stacklevel=4)
-
-  @property
-  def output_structure(self):
-    return self._output_structure
-
-  @property
-  def output_classes(self):
-    return nest.map_structure(
-        lambda component_spec: component_spec._to_legacy_output_classes(),  # pylint: disable=protected-access
-        self._output_structure)
-
-  @property
-  def output_shapes(self):
-    return nest.map_structure(
-        lambda component_spec: component_spec._to_legacy_output_shapes(),  # pylint: disable=protected-access
-        self._output_structure)
-
-  @property
-  def output_types(self):
-    return nest.map_structure(
-        lambda component_spec: component_spec._to_legacy_output_types(),  # pylint: disable=protected-access
-        self._output_structure)
-
-  @property
-  def function(self):
-    return self._function
-
-
 class _NumpyIterator(object):
   """Iterator over a dataset with elements converted to numpy."""
 
@@ -4754,17 +4512,17 @@ class _GeneratorDataset(DatasetSource):
 
     self._init_structure = structure.type_spec_from_value(init_args)
 
-    self._init_func = StructuredFunctionWrapper(
+    self._init_func = structured_function.StructuredFunctionWrapper(
         init_func,
         self._transformation_name(),
         input_structure=self._init_structure)
 
-    self._next_func = StructuredFunctionWrapper(
+    self._next_func = structured_function.StructuredFunctionWrapper(
         next_func,
         self._transformation_name(),
         input_structure=self._init_func.output_structure)
 
-    self._finalize_func = StructuredFunctionWrapper(
+    self._finalize_func = structured_function.StructuredFunctionWrapper(
         finalize_func,
         self._transformation_name(),
         input_structure=self._init_func.output_structure)
@@ -5407,40 +5165,6 @@ class PaddedBatchDataset(UnaryDataset):
   def element_spec(self):
     return self._structure
 
-
-def _should_pack(arg):
-  """Determines whether the caller needs to pack the argument in a tuple.
-
-  If user-defined function returns a list of tensors, `nest.flatten()` and
-  `ops.convert_to_tensor()` and would conspire to attempt to stack those tensors
-  into a single tensor because the tf.data version of `nest.flatten()` does
-  not recurse into lists. Since it is more likely that the list arose from
-  returning the result of an operation (such as `tf.numpy_function()`) that
-  returns a list of not-necessarily-stackable tensors, we treat the returned
-  value as a `tuple` instead. A user wishing to pack the return value into a
-  single tensor can use an explicit `tf.stack()` before returning.
-
-  Args:
-    arg: argument to check
-
-  Returns:
-    Indication of whether the caller needs to pack the argument in a tuple.
-  """
-  return isinstance(arg, list)
-
-
-def _should_unpack(arg):
-  """Determines whether the caller needs to unpack the argument from a tuple.
-
-  Args:
-    arg: argument to check
-
-  Returns:
-    Indication of whether the caller needs to unpack the argument from a tuple.
-  """
-  return type(arg) is tuple  # pylint: disable=unidiomatic-typecheck
-
-
 class MapDataset(UnaryDataset):
   """A `Dataset` that maps a function over elements in its input."""
 
@@ -5455,7 +5179,7 @@ class MapDataset(UnaryDataset):
     self._input_dataset = input_dataset
     self._use_inter_op_parallelism = use_inter_op_parallelism
     self._preserve_cardinality = preserve_cardinality
-    self._map_func = StructuredFunctionWrapper(
+    self._map_func = structured_function.StructuredFunctionWrapper(
         map_func,
         self._transformation_name(),
         dataset=input_dataset,
@@ -5501,7 +5225,7 @@ class ParallelMapDataset(UnaryDataset):
     """See `Dataset.map()` for details."""
     self._input_dataset = input_dataset
     self._use_inter_op_parallelism = use_inter_op_parallelism
-    self._map_func = StructuredFunctionWrapper(
+    self._map_func = structured_function.StructuredFunctionWrapper(
         map_func,
         self._transformation_name(),
         dataset=input_dataset,
@@ -5549,7 +5273,7 @@ class FlatMapDataset(UnaryDataset):
   def __init__(self, input_dataset, map_func, name=None):
     """See `Dataset.flat_map()` for details."""
     self._input_dataset = input_dataset
-    self._map_func = StructuredFunctionWrapper(
+    self._map_func = structured_function.StructuredFunctionWrapper(
         map_func, self._transformation_name(), dataset=input_dataset)
     if not isinstance(self._map_func.output_structure, DatasetSpec):
       raise TypeError(
@@ -5592,7 +5316,7 @@ class InterleaveDataset(UnaryDataset):
     """See `Dataset.interleave()` for details."""
 
     self._input_dataset = input_dataset
-    self._map_func = StructuredFunctionWrapper(
+    self._map_func = structured_function.StructuredFunctionWrapper(
         map_func, self._transformation_name(), dataset=input_dataset)
     if not isinstance(self._map_func.output_structure, DatasetSpec):
       raise TypeError(
@@ -5644,7 +5368,7 @@ class ParallelInterleaveDataset(UnaryDataset):
                name=None):
     """See `Dataset.interleave()` for details."""
     self._input_dataset = input_dataset
-    self._map_func = StructuredFunctionWrapper(
+    self._map_func = structured_function.StructuredFunctionWrapper(
         map_func, self._transformation_name(), dataset=input_dataset)
     if not isinstance(self._map_func.output_structure, DatasetSpec):
       raise TypeError(
@@ -5714,7 +5438,7 @@ class FilterDataset(UnaryUnchangedStructureDataset):
                name=None):
     """See `Dataset.filter()` for details."""
     self._input_dataset = input_dataset
-    wrapped_func = StructuredFunctionWrapper(
+    wrapped_func = structured_function.StructuredFunctionWrapper(
         predicate,
         self._transformation_name(),
         dataset=input_dataset,
@@ -5867,7 +5591,7 @@ def normalize_to_dense(dataset):
   # non-tensor components.
   #
   # TODO(mrry): Consider optimizing this if it turns out to be a bottleneck.
-  if _should_unpack(dataset.element_spec):
+  if structured_function._should_unpack(dataset.element_spec):
 
     def normalize(*args):
       return structure.to_batched_tensor_list(dataset.element_spec, tuple(args))
@@ -5971,7 +5695,7 @@ class _GroupByWindowDataset(UnaryDataset):
     def window_size_func_wrapper(key):
       return ops.convert_to_tensor(window_size_func(key), dtype=dtypes.int64)
 
-    self._window_size_func = StructuredFunctionWrapper(
+    self._window_size_func = structured_function.StructuredFunctionWrapper(
         window_size_func_wrapper,
         self._transformation_name(),
         input_structure=tensor_spec.TensorSpec([], dtypes.int64))
@@ -5988,7 +5712,7 @@ class _GroupByWindowDataset(UnaryDataset):
     def key_func_wrapper(*args):
       return ops.convert_to_tensor(key_func(*args), dtype=dtypes.int64)
 
-    self._key_func = StructuredFunctionWrapper(
+    self._key_func = structured_function.StructuredFunctionWrapper(
         key_func_wrapper, self._transformation_name(), dataset=input_dataset)
     if not self._key_func.output_structure.is_compatible_with(
         tensor_spec.TensorSpec([], dtypes.int64)):
@@ -6000,7 +5724,7 @@ class _GroupByWindowDataset(UnaryDataset):
     """Make wrapping defun for reduce_func."""
     nested_dataset = DatasetSpec(input_dataset.element_spec)
     input_structure = (tensor_spec.TensorSpec([], dtypes.int64), nested_dataset)
-    self._reduce_func = StructuredFunctionWrapper(
+    self._reduce_func = structured_function.StructuredFunctionWrapper(
         reduce_func,
         self._transformation_name(),
         input_structure=input_structure)
@@ -6264,7 +5988,7 @@ class _TakeWhileDataset(UnaryUnchangedStructureDataset):
     """See `take_while()` for details."""
 
     self._input_dataset = input_dataset
-    wrapped_func = StructuredFunctionWrapper(
+    wrapped_func = structured_function.StructuredFunctionWrapper(
         predicate, self._transformation_name(), dataset=self._input_dataset)
 
     if not wrapped_func.output_structure.is_compatible_with(
@@ -6340,13 +6064,13 @@ class _SnapshotDataset(UnaryUnchangedStructureDataset):
     self._path = path
     self._compression = compression
 
-    self._reader_func = StructuredFunctionWrapper(
+    self._reader_func = structured_function.StructuredFunctionWrapper(
         reader_func,
         self._transformation_name() + ".reader_func",
         # Dataset of datasets of input elements
         input_structure=DatasetSpec(DatasetSpec(input_dataset.element_spec)),
         use_legacy_function=use_legacy_function)
-    self._shard_func = StructuredFunctionWrapper(
+    self._shard_func = structured_function.StructuredFunctionWrapper(
         shard_func,
         self._transformation_name() + ".shard_func",
         dataset=input_dataset,
@@ -6407,7 +6131,7 @@ class _ScanDataset(UnaryDataset):
     need_to_rerun = True
     while need_to_rerun:
 
-      wrapped_func = StructuredFunctionWrapper(
+      wrapped_func = structured_function.StructuredFunctionWrapper(
           scan_func,
           self._transformation_name(),
           input_structure=(self._state_structure, input_dataset.element_spec),

--- a/tensorflow/python/data/ops/readers.py
+++ b/tensorflow/python/data/ops/readers.py
@@ -23,6 +23,7 @@ from tensorflow.core.framework import dataset_metadata_pb2
 from tensorflow.python import tf2
 from tensorflow.python.compat import compat
 from tensorflow.python.data.ops import dataset_ops
+from tensorflow.python.data.ops import structured_function
 from tensorflow.python.data.util import convert
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -343,7 +344,7 @@ class ParallelInterleaveDataset(dataset_ops.UnaryDataset):
                name=None):
     """See `tf.data.experimental.parallel_interleave()` for details."""
     self._input_dataset = input_dataset
-    self._map_func = dataset_ops.StructuredFunctionWrapper(
+    self._map_func = structured_function.StructuredFunctionWrapper(
         map_func, self._transformation_name(), dataset=input_dataset)
     if not isinstance(self._map_func.output_structure, dataset_ops.DatasetSpec):
       raise TypeError(

--- a/tensorflow/python/data/ops/structured_function.py
+++ b/tensorflow/python/data/ops/structured_function.py
@@ -1,0 +1,311 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Common helpers for building the `Dataset` class"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+import warnings
+
+import six
+
+from tensorflow.python.data.util import nest
+from tensorflow.python.data.util import structure
+from tensorflow.python.eager import context
+from tensorflow.python.eager import def_function
+from tensorflow.python.eager import function as eager_function
+
+from tensorflow.python.framework import function
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import script_ops
+from tensorflow.python.util import function_utils
+from tensorflow.python.util import lazy_loader
+
+autograph = lazy_loader.LazyLoader(
+    "autograph", globals(),
+    "tensorflow.python.autograph.impl.api")
+# TODO(mdan): Create a public API for this.
+autograph_ctx = lazy_loader.LazyLoader(
+    "autograph_ctx", globals(),
+    "tensorflow.python.autograph.core.ag_ctx")
+dataset_ops = lazy_loader.LazyLoader(
+    "dataset_ops", globals(),
+    "tensorflow.python.data.ops.dataset_ops")
+
+def _should_pack(arg):
+  """Determines whether the caller needs to pack the argument in a tuple.
+
+  If user-defined function returns a list of tensors, `nest.flatten()` and
+  `ops.convert_to_tensor()` and would conspire to attempt to stack those tensors
+  into a single tensor because the tf.data version of `nest.flatten()` does
+  not recurse into lists. Since it is more likely that the list arose from
+  returning the result of an operation (such as `tf.numpy_function()`) that
+  returns a list of not-necessarily-stackable tensors, we treat the returned
+  value as a `tuple` instead. A user wishing to pack the return value into a
+  single tensor can use an explicit `tf.stack()` before returning.
+
+  Args:
+    arg: argument to check
+
+  Returns:
+    Indication of whether the caller needs to pack the argument in a tuple.
+  """
+  return isinstance(arg, list)
+
+def _should_unpack(arg):
+  """Determines whether the caller needs to unpack the argument from a tuple.
+
+  Args:
+    arg: argument to check
+
+  Returns:
+    Indication of whether the caller needs to unpack the argument from a tuple.
+  """
+  return type(arg) is tuple  # pylint: disable=unidiomatic-typecheck
+
+
+class StructuredFunctionWrapper():
+  """A function wrapper that supports structured arguments and return values."""
+
+  def __init__(self,
+               func,
+               transformation_name,
+               dataset=None,
+               input_classes=None,
+               input_shapes=None,
+               input_types=None,
+               input_structure=None,
+               add_to_graph=True,
+               use_legacy_function=False,
+               defun_kwargs=None):
+    """Creates a new `StructuredFunctionWrapper` for the given function.
+
+    Args:
+      func: A function from a (nested) structure to another (nested) structure.
+      transformation_name: Human-readable name of the transformation in which
+        this function is being instantiated, for error messages.
+      dataset: (Optional.) A `tf.data.Dataset`. If given, the structure of this
+        dataset will be assumed as the structure for `func` arguments; otherwise
+        `input_classes`, `input_shapes`, and `input_types` must be defined.
+      input_classes: (Optional.) A (nested) structure of `type`. If given, this
+        argument defines the Python types for `func` arguments.
+      input_shapes: (Optional.) A (nested) structure of `tf.TensorShape`. If
+        given, this argument defines the shapes and structure for `func`
+        arguments.
+      input_types: (Optional.) A (nested) structure of `tf.DType`. If given,
+        this argument defines the element types and structure for `func`
+        arguments.
+      input_structure: (Optional.) A `Structure` object. If given, this argument
+        defines the element types and structure for `func` arguments.
+      add_to_graph: (Optional.) If `True`, the function will be added to the
+        default graph, if it exists.
+      use_legacy_function: (Optional.) A boolean that determines whether the
+        function be created using `tensorflow.python.eager.function.defun`
+        (default behavior) or `tensorflow.python.framework.function.Defun`
+        (legacy behavior).
+      defun_kwargs: (Optional.) A dictionary mapping string argument names to
+        values. If supplied, will be passed to `function` as keyword arguments.
+
+    Raises:
+      ValueError: If an invalid combination of `dataset`, `input_classes`,
+        `input_shapes`, and `input_types` is passed.
+    """
+    # pylint: disable=protected-access
+    if input_structure is None:
+      if dataset is None:
+        if input_classes is None or input_shapes is None or input_types is None:
+          raise ValueError("Either `dataset`, `input_structure` or all of "
+                           "`input_classes`, `input_shapes`, and `input_types` "
+                           "must be specified.")
+        self._input_structure = structure.convert_legacy_structure(
+            input_types, input_shapes, input_classes)
+      else:
+        if not (input_classes is None and input_shapes is None and
+                input_types is None):
+          raise ValueError("Either `dataset`, `input_structure` or all of "
+                           "`input_classes`, `input_shapes`, and `input_types` "
+                           "must be specified.")
+        self._input_structure = dataset.element_spec
+    else:
+      if not (dataset is None and input_classes is None and input_shapes is None
+              and input_types is None):
+        raise ValueError("Either `dataset`, `input_structure`, or all of "
+                         "`input_classes`, `input_shapes`, and `input_types` "
+                         "must be specified.")
+      self._input_structure = input_structure
+
+    self._func = func
+
+    if defun_kwargs is None:
+      defun_kwargs = {}
+
+    readable_transformation_name = transformation_name.replace(
+        ".", "_")[:-2] if len(transformation_name) > 2 else ""
+
+    func_name = "_".join(
+        [readable_transformation_name,
+         function_utils.get_func_name(func)])
+    # Sanitize function name to remove symbols that interfere with graph
+    # construction.
+    for symbol in ["<", ">", "\\", "'", " "]:
+      func_name = func_name.replace(symbol, "")
+
+    ag_ctx = autograph_ctx.control_status_ctx()
+
+    def wrapper_helper(*args):
+      """Wrapper for passing nested structures to and from tf.data functions."""
+      nested_args = structure.from_compatible_tensor_list(
+          self._input_structure, args)
+      if not _should_unpack(nested_args):
+        nested_args = (nested_args,)
+      ret = autograph.tf_convert(self._func, ag_ctx)(*nested_args)
+      if _should_pack(ret):
+        ret = tuple(ret)
+
+      try:
+        self._output_structure = structure.type_spec_from_value(ret)
+      except (ValueError, TypeError):
+        six.reraise(
+            TypeError,
+            TypeError("Unsupported return value from function passed to "
+                      "%s: %s." % (transformation_name, ret)),
+            sys.exc_info()[2])
+      return ret
+
+    def trace_legacy_function(defun_kwargs):
+      @function.Defun(*structure.get_flat_tensor_types(self._input_structure),
+                      **defun_kwargs)
+      def wrapped_fn(*args):
+        ret = wrapper_helper(*args)
+        return structure.to_tensor_list(self._output_structure, ret)
+
+      return lambda: wrapped_fn
+
+    def trace_py_function(defun_kwargs):
+      # First we trace the function to infer the output structure.
+      @eager_function.defun_with_attributes(
+          input_signature=structure.get_flat_tensor_specs(
+              self._input_structure),
+          autograph=False,
+          attributes=defun_kwargs)
+      def unused(*args):  # pylint: disable=missing-docstring,unused-variable
+        ret = wrapper_helper(*args)
+        ret = structure.to_tensor_list(self._output_structure, ret)
+        return [ops.convert_to_tensor(t) for t in ret]
+
+      _ = unused.get_concrete_function()
+
+      def py_function_wrapper(*args):
+        nested_args = structure.from_compatible_tensor_list(
+            self._input_structure, args)
+        if not _should_unpack(nested_args):
+          nested_args = (nested_args,)
+        ret = self._func(*nested_args)
+        if _should_pack(ret):
+          ret = tuple(ret)
+        ret = structure.to_tensor_list(self._output_structure, ret)
+        return [ops.convert_to_tensor(t) for t in ret]
+
+      # Next we trace the function wrapped in `eager_py_func` to force eager
+      # execution.
+      @eager_function.defun_with_attributes(
+          input_signature=structure.get_flat_tensor_specs(
+              self._input_structure),
+          autograph=False,
+          attributes=defun_kwargs)
+      def wrapped_fn(*args):  # pylint: disable=missing-docstring
+        return script_ops.eager_py_func(
+            py_function_wrapper, args,
+            structure.get_flat_tensor_types(self._output_structure))
+
+      return wrapped_fn.get_concrete_function
+
+    def trace_tf_function(defun_kwargs):
+      # Note: wrapper_helper will apply autograph based on context.
+      @eager_function.defun_with_attributes(
+          input_signature=structure.get_flat_tensor_specs(
+              self._input_structure),
+          autograph=False,
+          attributes=defun_kwargs)
+      def wrapped_fn(*args):  # pylint: disable=missing-docstring
+        ret = wrapper_helper(*args)
+        ret = structure.to_tensor_list(self._output_structure, ret)
+        return [ops.convert_to_tensor(t) for t in ret]
+
+      return wrapped_fn.get_concrete_function
+
+    if use_legacy_function:
+      defun_kwargs.update({"func_name": func_name + "_" + str(ops.uid())})
+      fn_factory = trace_legacy_function(defun_kwargs)
+    else:
+      defun_kwargs.update({"func_name": func_name})
+      defun_kwargs.update({"_tf_data_function": True})
+      if dataset_ops.DEBUG_MODE:
+        fn_factory = trace_py_function(defun_kwargs)
+      else:
+        if def_function.functions_run_eagerly():
+          warnings.warn(
+              "Even though the `tf.config.experimental_run_functions_eagerly` "
+              "option is set, this option does not apply to tf.data functions. "
+              "To force eager execution of tf.data functions, please use "
+              "`tf.data.experimental.enable_debug_mode()`.")
+        fn_factory = trace_tf_function(defun_kwargs)
+
+    self._function = fn_factory()
+    # There is no graph to add in eager mode.
+    add_to_graph &= not context.executing_eagerly()
+    # There are some lifetime issues when a legacy function is not added to a
+    # out-living graph. It's already deprecated so de-prioritizing the fix.
+    add_to_graph |= use_legacy_function
+    if add_to_graph:
+      self._function.add_to_graph(ops.get_default_graph())
+
+    if not use_legacy_function:
+      outer_graph_seed = ops.get_default_graph().seed
+      if outer_graph_seed and self._function.graph.seed == outer_graph_seed:
+        if self._function.graph._seed_used:
+          warnings.warn(
+              "Seed %s from outer graph might be getting used by function %s, "
+              "if the random op has not been provided any seed. Explicitly set "
+              "the seed in the function if this is not the intended behavior."
+              %(outer_graph_seed, func_name), stacklevel=4)
+
+  @property
+  def output_structure(self):
+    return self._output_structure
+
+  @property
+  def output_classes(self):
+    return nest.map_structure(
+        lambda component_spec: component_spec._to_legacy_output_classes(),  # pylint: disable=protected-access
+        self._output_structure)
+
+  @property
+  def output_shapes(self):
+    return nest.map_structure(
+        lambda component_spec: component_spec._to_legacy_output_shapes(),  # pylint: disable=protected-access
+        self._output_structure)
+
+  @property
+  def output_types(self):
+    return nest.map_structure(
+        lambda component_spec: component_spec._to_legacy_output_types(),  # pylint: disable=protected-access
+        self._output_structure)
+
+  @property
+  def function(self):
+    return self._function

--- a/tensorflow/python/data/ops/structured_function.py
+++ b/tensorflow/python/data/ops/structured_function.py
@@ -181,8 +181,8 @@ class StructuredFunctionWrapper():
       except (ValueError, TypeError):
         six.reraise(
             TypeError,
-            TypeError("Unsupported return value from function passed to "
-                      "%s: %s." % (transformation_name, ret)),
+            TypeError(f"Unsupported return value from function passed to "
+                      f"{transformation_name}: {ret}."),
             sys.exc_info()[2])
       return ret
 


### PR DESCRIPTION
This PR refactors `dataset_ops.py` by moving the `StructuredFunctionWrapper` class into a `common` module. This enables further refactoring of function-specific `Dataset`s.

**side note for future PR's:** after further examination of the function-specific `Dataset` classes (for ex: `MapDataset`), I see that they inherit from `UnaryDataset` which itself inherits from `DatasetV2`. And since the `DatasetV2` class itself needs `MapDataset` for the `def map()` functionality, this poses a circular dependency challenge even if we split the classes into different files. Thus, lazy loading would be imminent and the files might get a bit messy.

cc: @aaudiber What do you think?