### PR TITLE
include abseil/base/attributes.h instead of macos.h

### DIFF
--- a/tensorflow/lite/delegates/gpu/gl_delegate.h
+++ b/tensorflow/lite/delegates/gpu/gl_delegate.h
@@ -19,7 +19,7 @@ limitations under the License.
 #include <GLES3/gl31.h>
 #include <stdint.h>
 
-#include "absl/base/macros.h"
+#include "absl/base/attributes.h"
 #include "tensorflow/lite/c/common.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
ABSL_DEPRECATED is defined in atributes.h