### PR TITLE
Fix crash with tf.range when start is large/negative--cherrypick to r2.4

### DIFF
--- a/tensorflow/core/kernels/sequence_ops.cc
+++ b/tensorflow/core/kernels/sequence_ops.cc
@@ -75,9 +75,10 @@ class RangeOp : public OpKernel {
                       ? ((std::abs(limit - start) + std::abs(delta) - 1) /
                          std::abs(delta))
                       : std::ceil(std::abs((limit - start) / delta)));
+    TensorShape shape;
+    OP_REQUIRES_OK(context, shape.AddDimWithStatus(size));
     Tensor* out = nullptr;
-    OP_REQUIRES_OK(context,
-                   context->allocate_output(0, TensorShape({size}), &out));
+    OP_REQUIRES_OK(context, context->allocate_output(0, shape, &out));
     auto flat = out->flat<T>();
     T val = start;
     for (int64 i = 0; i < size; ++i) {

--- a/tensorflow/python/kernel_tests/init_ops_test.py
+++ b/tensorflow/python/kernel_tests/init_ops_test.py
@@ -541,7 +541,13 @@ class RangeTest(test.TestCase):
     tf_ans = math_ops.range(
         constant_op.constant(4, dtype=dtypes.int32), dtype=dtypes.int64)
     self.assertAllEqual(self.evaluate(tf_ans), np.array([0, 1, 2, 3]))
-
+ 
+ def testLargeStarts(self):
+    # Test case for GitHub issue 46899.
+    with self.session():
+      with self.assertRaises(errors_impl.InternalError):
+        v = math_ops.range(start=-1e+38, limit=1)
+        self.evaluate(v)
 
 # TODO(vrv): move to sequence_ops_test?
 class LinSpaceTest(test.TestCase):


### PR DESCRIPTION
PiperOrigin-RevId: 393844345
Change-Id: I2a72193d4416b8b009bc0b21489a42061f164203