### PR TITLE
Fix tf.pad crashes with large paddings

### DIFF
--- a/tensorflow/core/kernels/pad_op.cc
+++ b/tensorflow/core/kernels/pad_op.cc
@@ -85,7 +85,8 @@ class PadOp : public OpKernel {
                   errors::InvalidArgument("Paddings must be non-negative: ",
                                           before_d, " ", after_d));
       const int64_t size_d = in0.dim_size(d);
-      output_shape.AddDim(before_d + size_d + after_d);
+      OP_REQUIRES_OK(
+          context, output_shape.AddDimWithStatus(before_d + size_d + after_d));
     }
 
     // If there is no padding to be done, forward the input to output.

--- a/tensorflow/python/kernel_tests/pad_op_test.py
+++ b/tensorflow/python/kernel_tests/pad_op_test.py
@@ -431,6 +431,18 @@ class PadOpTest(test.TestCase):
               np.zeros([row[1] for row in paddings_value]),
               self.evaluate(right))
 
+  def testWithLargePadding(self):
+    # Test case for GitHub issue 51908.
+    with self.session():
+      input_tensor = array_ops.zeros([1, 32, 32, 3], dtype=dtypes.float32)
+      paddings = [[125106557, 1415887920],
+                  [747509374, 2136925906],
+                  [413308538, 904601717],
+                  [1900762018, 831358864]]
+      with self.assertRaises((ValueError, errors.InternalError)):
+        res = array_ops.pad(input_tensor,paddings)
+        self.evaluate(res)
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
This PR tries to address the issue raised in #51908 where
tf.pad crashes with large paddings.
In any case, instead of a crash with undefined behavior,
tensorflow should return an error gracefully.

This PR fixes the issue by adding the necessary checks.

This PR fixes #51908.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>