### PR TITLE
Fix crash of max_pool3d when ksize is 0 or negative

### DIFF
--- a/tensorflow/core/kernels/pooling_ops_3d.cc
+++ b/tensorflow/core/kernels/pooling_ops_3d.cc
@@ -141,6 +141,11 @@ class Pooling3DOp : public UnaryOp<T> {
     OP_REQUIRES(context, ksize_.size() == 5,
                 errors::InvalidArgument("Sliding window ksize field must "
                                         "specify 5 dimensions"));
+    bool non_negative = std::all_of(
+        ksize_.begin(), ksize_.end(), [](int k) { return k > 0; });
+    OP_REQUIRES(context, non_negative,
+                errors::InvalidArgument("Sliding window ksize field must "
+                                        "have non-negative dimensions"));
     OP_REQUIRES_OK(context, context->GetAttr("strides", &stride_));
     OP_REQUIRES(context, stride_.size() == 5,
                 errors::InvalidArgument("Sliding window stride field must "

--- a/tensorflow/python/kernel_tests/pooling_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/pooling_ops_3d_test.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import gradient_checker
 from tensorflow.python.ops import gradients_impl
@@ -504,6 +505,22 @@ class PoolingTest(test.TestCase):
         window=(3, 3, 3),
         strides=(1, 1, 1),
         padding="SAME")
+
+  def testMaxPool3DZeroPoolSize(self):
+    # Test case for GitHub issue 51936.
+    with self.session():
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        input_sizes = [3, 4, 10, 11, 12]
+
+        input_data = 1.
+        input_tensor = constant_op.constant(
+            input_data, shape=input_sizes, name="input")
+        max_pool_3d = nn_ops.max_pool3d(
+            input_tensor,
+            ksize=[2, 2, 0],
+            strides=1,
+            padding="VALID")
+        self.evaluate(max_pool_3d)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/pooling_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/pooling_ops_3d_test.py
@@ -508,19 +508,20 @@ class PoolingTest(test.TestCase):
 
   def testMaxPool3DZeroPoolSize(self):
     # Test case for GitHub issue 51936.
-    with self.session():
-      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
-        input_sizes = [3, 4, 10, 11, 12]
+    for f in [nn_ops.max_pool3d, nn_ops.avg_pool3d]:
+      with self.session():
+        with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+          input_sizes = [3, 4, 10, 11, 12]
 
-        input_data = 1.
-        input_tensor = constant_op.constant(
-            input_data, shape=input_sizes, name="input")
-        max_pool_3d = nn_ops.max_pool3d(
-            input_tensor,
-            ksize=[2, 2, 0],
-            strides=1,
-            padding="VALID")
-        self.evaluate(max_pool_3d)
+          input_data = 1.
+          input_tensor = constant_op.constant(
+              input_data, shape=input_sizes, name="input")
+          pool_3d = f(
+              input_tensor,
+              ksize=[2, 2, 0],
+              strides=1,
+              padding="VALID")
+          self.evaluate(pool_3d)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR tries to address the issue raised in #51936 where
max_pool3d will crash when any dim of ksize is 0 or negative.

While the original issue was raised toward tf.keras.layers.MaxPooling3D,
the issue can also be triggered when max_pool3d is called directly
with tensorflow itself.

For that reason a separate fix inside tensorflow is also fixed here.

This PR fixes #51936.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>