### PR TITLE
Bump tensorflow-io-gcs-filesystem to 0.21.0

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -104,7 +104,7 @@ REQUIRED_PACKAGES = [
     'tensorboard ~= 2.6',
     'tensorflow_estimator ~= 2.6',
     'keras ~= 2.6',
-    'tensorflow-io-gcs-filesystem >= 0.20.0',
+    'tensorflow-io-gcs-filesystem >= 0.21.0',
 ]
 
 


### PR DESCRIPTION
This PR bumps tensorflow-io-gcs-filesystem to 0.21.0 so that TF 2.7
branch cut can carry the latest change which includes the fix that removes the extra
build directory in the python pip package (https://github.com/tensorflow/io/pull/1497)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>