### PR TITLE
revert PR #47351 (doesn't work)

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -255,15 +255,6 @@ config_setting(
 )
 
 config_setting(
-    name = "msvc_cl_debug",
-    values = {
-        "compiler": "msvc-cl",
-        "compilation_mode": "dbg",
-    },
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
     name = "no_tensorflow_py_deps",
     define_values = {"no_tensorflow_py_deps": "true"},
     visibility = ["//visibility:public"],
@@ -1052,11 +1043,6 @@ tf_cc_shared_object(
             "-z defs",
             "-Wl,--version-script,$(location //tensorflow:tf_version_script.lds)",
         ],
-    }) + select({
-        "//tensorflow:msvc_cl_debug": [
-            "/DEBUG:FASTLINK",
-        ],
-        "//conditions:default": [],
     }),
     per_os_targets = True,
     soversion = VERSION,


### PR DESCRIPTION
PR 47351 doesn't work as expected. The `msvc_cl_debug` condition would need to be checked against the toolchain, not against the compiler switch, e.g. like this:
```
selects.config_setting_group(
++    name = "msvc_cl_debug",
++    match_all = [
++        "@bazel_tools//src/conditions:windows_msvc",
++        ":debug",
++    ],
++    visibility = ["//visibility:public"],
++)
```
But even a fix like this would not lead to the desired outcome because `bazel` will add `/DEBUG:FULL` in `dbg` mode after `/DEBUG:FASTBUILD` and thus override it. The only way to compile with `/DEBUG:FASTBUILD` is using `--compilation_mode=fastbuild` or `--compilation_mode=dbg --features=fastbuild`. So PR 47351 is not necessary. Thus revert it.