### PR TITLE
[oneDNN] BatchMatMulV2+Mul+AddV2 fusion with oneDNN CPU backend

### DIFF
--- a/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
@@ -737,6 +737,105 @@ class FusedMatMulBiasAddAndGeluTest : public GrapplerTest {
 // changed by other optimizers before the remapper optimizer.
 TEST_F(FusedMatMulBiasAddAndGeluTest, Float32GeluExact) { RunTest<DT_FLOAT>(); }
 
+class MklFuseBatchMatMul: public MklRemapperTest {
+ public:
+  template <typename T>
+  void VerifyFused(bool adjx, bool adjy) {
+    using ::tensorflow::ops::Placeholder;
+    using normal_generator = Eigen::internal::NormalRandomGenerator<T>;
+
+    int b0 = 2;
+    int b1 = 2;
+    int m = 32;
+    int k = 16;
+    int n = 64;
+
+    tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+
+    auto input_shape =
+        adjx ? TensorShape({b0, b1, k, m}) : TensorShape({b0, b1, m, k});
+    auto weight_shape =
+        adjy ? TensorShape({b0, b1, n, k}) : TensorShape({b0, b1, k, n});
+    auto add_shape = TensorShape({b0, 1, m, n});
+
+    auto input_placeholder_shape = ops::Placeholder::Shape(input_shape);
+    auto weight_placeholder_shape = ops::Placeholder::Shape(weight_shape);
+    auto add_placeholder_shape = ops::Placeholder::Shape(add_shape);
+
+    auto input = Placeholder(s.WithOpName("input"), DataTypeToEnum<T>::v(),
+                             input_placeholder_shape);
+    auto weight = Placeholder(s.WithOpName("weight"), DataTypeToEnum<T>::v(),
+                              weight_placeholder_shape);
+    auto addend = Placeholder(s.WithOpName("addend"), DataTypeToEnum<T>::v(),
+                              add_placeholder_shape);
+
+    auto batchmatmul =
+        ops::BatchMatMulV2(s.WithOpName("batchmatmul"), input, weight,
+                           ops::BatchMatMulV2::Attrs().AdjX(adjx).AdjY(adjy));
+    auto scale_const = ops::Const(s.WithOpName("scale_const"), {0.1f});
+    auto scale =
+        ops::Cast(s.WithOpName("scale"), scale_const, DataTypeToEnum<T>::v());
+    auto mul = ops::Multiply(s.WithOpName("mul"), batchmatmul, scale);
+    auto add = ops::AddV2(s.WithOpName("add"), mul, addend);
+    auto fetch = ops::Identity(s.WithOpName("fetch"), add);
+
+    Tensor input_t = Tensor(DataTypeToEnum<T>::v(), input_shape);
+    Tensor weight_t = Tensor(DataTypeToEnum<T>::v(), weight_shape);
+    Tensor add_t = Tensor(DataTypeToEnum<T>::v(), add_shape);
+    input_t.flat<T>() =
+        input_t.flat<T>().template setRandom<normal_generator>();
+    weight_t.flat<T>() =
+        weight_t.flat<T>().template setRandom<normal_generator>();
+    add_t.flat<T>() = add_t.flat<T>().template setRandom<normal_generator>();
+
+    GrapplerItem item;
+    item.fetch = {"fetch"};
+    item.feed = {{"input", input_t}, {"weight", weight_t}, {"addend", add_t}};
+    TF_CHECK_OK(s.ToGraphDef(&item.graph));
+
+    // Place all nodes on CPU.
+    for (int i = 0; i < item.graph.node_size(); ++i) {
+      item.graph.mutable_node(i)->set_device("/device:CPU:0");
+    }
+
+    Remapper optimizer(RewriterConfig::ON);
+    GraphDef output;
+    TF_CHECK_OK(optimizer.Optimize(nullptr, item, &output));
+
+    int found = 0;
+    for (const NodeDef& node : output.node()) {
+      if (node.name() == "add") {
+        EXPECT_EQ("_MklFusedBatchMatMulV2", node.op());
+        EXPECT_EQ("input", node.input(0));
+        EXPECT_EQ("weight", node.input(1));
+        EXPECT_EQ("scale", node.input(2));
+        EXPECT_EQ("addend", node.input(3));
+        const auto fused_ops = node.attr().at("fused_ops").list().s();
+        EXPECT_EQ(2, fused_ops.size());
+        EXPECT_EQ("Mul", fused_ops[0]);
+        found++;
+        EXPECT_EQ("Add", fused_ops[1]);
+        found++;
+      }
+    }
+    EXPECT_EQ(2, found);
+
+    auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
+    auto tensors = EvaluateNodes(output, item.fetch, item.feed);
+    std::is_same<T, float>::value
+        ? test::ExpectClose(tensors_expected[0], tensors[0], 1e-6, 1e-6)
+        : test::ExpectClose(tensors_expected[0], tensors[0], 1e-2, 1e-2);
+  }
+};
+
+TEST_F(MklFuseBatchMatMul, MulAndAdd) {
+  for (const auto adjx : {false, true})
+    for (const auto adjy : {false, true}) {
+      this->VerifyFused<float>(adjx, adjy);
+      this->VerifyFused<bfloat16>(adjx, adjy);
+    }
+}
+
 }  // namespace grappler
 }  // namespace tensorflow
 #endif  // INTEL_MKL && ENABLE_MKL

--- a/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
@@ -737,7 +737,7 @@ class FusedMatMulBiasAddAndGeluTest : public GrapplerTest {
 // changed by other optimizers before the remapper optimizer.
 TEST_F(FusedMatMulBiasAddAndGeluTest, Float32GeluExact) { RunTest<DT_FLOAT>(); }
 
-class MklFuseBatchMatMul: public MklRemapperTest {
+class MklFusedBatchMatMul : public MklRemapperTest {
  public:
   template <typename T>
   void VerifyFused(bool adjx, bool adjy) {
@@ -828,7 +828,7 @@ class MklFuseBatchMatMul: public MklRemapperTest {
   }
 };
 
-TEST_F(MklFuseBatchMatMul, MulAndAdd) {
+TEST_F(MklFusedBatchMatMul, MulAndAdd) {
   for (const auto adjx : {false, true})
     for (const auto adjy : {false, true}) {
       this->VerifyFused<float>(adjx, adjy);

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -275,7 +275,8 @@ bool IsCpuCompatibleDataType(const NodeDef* contraction,
 
   if (is_one_dnn_enabled) {
     return (IsConv2D(*contraction) || IsDepthwiseConv2dNative(*contraction) ||
-            IsMatMul(*contraction) || IsConv3D(*contraction)) &&
+            IsMatMul(*contraction) || IsConv3D(*contraction) ||
+            IsAnyBatchMatMul(*contraction)) &&
            (dtype == DT_FLOAT || dtype == DT_BFLOAT16);
   }
   if (IsConv2D(*contraction)) {
@@ -1475,6 +1476,99 @@ bool FindTensorToHashBucket(const RemapperContext& ctx, int node_index,
   return true;
 }
 
+bool FindFusedBatchMatMul(RemapperContext* ctx, int node_index,
+                          std::map<string, int>* matched_nodes_map,
+                          std::set<int>* remove_node_indices) {
+  if (!IsMKLEnabled()) return false;
+
+  using utils::MatchingDirection;
+  using utils::NodeStatus;
+  // clang-format off
+  utils::OpTypePattern fusion_pattern1 =
+    {"AddV2", "output", NodeStatus::kReplace,
+      {
+        {"Mul", "mul", NodeStatus::kRemove,
+          {
+            {"BatchMatMulV2", "batch_matmul", NodeStatus::kRemove},
+            {"*", "multiplicand", NodeStatus::kRemain}
+          }
+        },
+        {"*", "addend", NodeStatus::kRemain}
+      }
+    };
+
+  utils::OpTypePattern fusion_pattern2 =
+    {"AddV2", "output", NodeStatus::kReplace,
+      {
+        {"*", "addend", NodeStatus::kRemain},
+        {"Mul", "mul", NodeStatus::kRemove,
+          {
+            {"BatchMatMulV2", "batch_matmul", NodeStatus::kRemove},
+            {"*", "multiplicand", NodeStatus::kRemain}
+          }
+        }
+      }
+    };
+  // clang-format on
+
+  utils::SubGraphMatcher<MatchingDirection::kFollowInputs> graph_matcher(
+      &(ctx->graph_view));
+  bool found_op_type_match = false;
+  matched_nodes_map->clear();
+  remove_node_indices->clear();
+  found_op_type_match =
+      graph_matcher.GetMatchedNodes(fusion_pattern1, ctx->nodes_to_preserve,
+                                    ctx->graph_view.GetNode(node_index),
+                                    matched_nodes_map, remove_node_indices);
+
+  if (!found_op_type_match) {
+    matched_nodes_map->clear();
+    remove_node_indices->clear();
+    found_op_type_match =
+        graph_matcher.GetMatchedNodes(fusion_pattern2, ctx->nodes_to_preserve,
+                                      ctx->graph_view.GetNode(node_index),
+                                      matched_nodes_map, remove_node_indices);
+  }
+
+  // OneDNN is not optimized for all shapes with regard to binary-post ops
+  // fusion. Allow limited cases only for now that are optimized, (i)
+  // multiplicand is scalar, (ii) BatchMatmulV2 output is 4D tensor, and (iii)
+  // addend is 4D tensor with second dim_size = 1.
+  if (found_op_type_match) {
+    if (!ctx->inferred_graph_properties) {
+      Status s = ctx->graph_properties.InferStatically(
+          /*assume_valid_feeds=*/true,
+          /*aggressive_shape_inference=*/false,
+          /*include_input_tensor_values=*/false,
+          /*include_output_tensor_values=*/true);
+      if (!s.ok()) return false;
+      ctx->inferred_graph_properties = true;
+    }
+    NodeDef* multiplicand_node_def =
+        ctx->graph_view.GetNode(matched_nodes_map->at("multiplicand"))->node();
+    auto multiplicand_props = ctx->graph_properties.GetOutputProperties(
+        multiplicand_node_def->name());
+    if (NumCoefficients(multiplicand_props[0].shape()) != 1) return false;
+
+    NodeDef* batch_matmul_node_def =
+        ctx->graph_view.GetNode(matched_nodes_map->at("batch_matmul"))->node();
+    if (!IsCpuCompatibleMatMul(*ctx, batch_matmul_node_def)) return false;
+
+    auto batch_matmul_props = ctx->graph_properties.GetOutputProperties(
+        batch_matmul_node_def->name());
+    if (Rank(batch_matmul_props[0].shape()) != 4) return false;
+
+    NodeDef* addend_node_def =
+        ctx->graph_view.GetNode(matched_nodes_map->at("addend"))->node();
+    auto addend_props =
+        ctx->graph_properties.GetOutputProperties(addend_node_def->name());
+    auto addend_shape = addend_props[0].shape();
+    if (!(Rank(addend_shape) == 4 && addend_shape.dim(1).size() == 1))
+      return false;
+  }
+  return found_op_type_match;
+}
+
 void CopyConv2DAttributes(const NodeDef& conv2d, NodeDef* fused_conv2d,
                           const NodeDef* activation = nullptr) {
   DCHECK(IsConv2D(conv2d)) << "Input node must be a Conv2D";
@@ -1597,6 +1691,18 @@ void CopyMatMulAttributes(const NodeDef& matmul, NodeDef* fused_matmul,
     auto& activation_attr = activation->attr();
     (*attr)["leakyrelu_alpha"] = activation_attr.at("alpha");
   }
+}
+
+void CopyBatchMatMulAttributes(const NodeDef& batchmatmul,
+                               NodeDef* fused_batch_matmul) {
+  DCHECK(IsAnyBatchMatMul(batchmatmul)) << "Input node must be a BatchMatMul";
+
+  auto* attr = fused_batch_matmul->mutable_attr();
+  auto& src_attr = batchmatmul.attr();
+
+  (*attr)["T"] = src_attr.at("T");
+  (*attr)["adj_x"] = src_attr.at("adj_x");
+  (*attr)["adj_y"] = src_attr.at("adj_y");
 }
 
 void SetFusedOpAttributes(NodeDef* fused,
@@ -2359,6 +2465,52 @@ Status AddTensorToHashBucketNode(RemapperContext* ctx,
   return Status::OK();
 }
 
+Status AddFusedBatchMatMul(RemapperContext* ctx,
+                           const std::map<string, int>& matched_nodes_map,
+                           const std::set<int>& remove_node_indices,
+                           std::vector<bool>* invalidated_nodes,
+                           std::vector<bool>* nodes_to_delete) {
+  auto* output_node =
+      ctx->graph_view.GetNode(matched_nodes_map.at("output"))->node();
+  auto* batch_matmul_node =
+      ctx->graph_view.GetNode(matched_nodes_map.at("batch_matmul"))->node();
+  auto* multiplicand_node =
+      ctx->graph_view.GetNode(matched_nodes_map.at("multiplicand"))->node();
+  auto* addend_node =
+      ctx->graph_view.GetNode(matched_nodes_map.at("addend"))->node();
+
+  NodeDef fused_node;
+  fused_node.set_name(output_node->name());
+  fused_node.set_op("_MklFusedBatchMatMulV2");
+  fused_node.set_device(batch_matmul_node->device());
+  fused_node.add_input(batch_matmul_node->input(0));
+  fused_node.add_input(batch_matmul_node->input(1));
+  fused_node.add_input(multiplicand_node->name());
+  fused_node.add_input(addend_node->name());
+
+  CopyBatchMatMulAttributes(*batch_matmul_node, &fused_node);
+  auto* attr = fused_node.mutable_attr();
+  absl::Span<const absl::string_view> fused_ops{"Mul", "Add"};
+  SetAttrValue(fused_ops, &(*attr)["fused_ops"]);
+  SetAttrValue(2, &(*attr)["num_args"]);
+
+  utils::Mutation* mutation = ctx->graph_view.GetMutationBuilder();
+  Status status;
+  mutation->AddNode(std::move(fused_node), &status);
+  TF_RETURN_IF_ERROR(status);
+  TF_RETURN_IF_ERROR(mutation->Apply());
+  (*invalidated_nodes)[matched_nodes_map.at("output")] = true;
+
+  for (const auto& node_idx : remove_node_indices) {
+    (*nodes_to_delete)[node_idx] = true;
+  }
+  return Status::OK();
+}
+
+bool IsConv2DOrMatMul(const NodeDef& node) {
+  return IsConv2D(node) || IsMatMul(node);
+}
+
 bool IsContractionWithAdd(const RemapperContext& ctx, int node_index) {
   const auto* node_view = ctx.graph_view.GetNode(node_index);
 
@@ -2577,6 +2729,18 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
         TF_RETURN_IF_ERROR(AddFusedMatMulBiasAddAndGelu(
             &ctx, matched_nodes_map, remove_node_indices, &invalidated_nodes,
             &nodes_to_delete, is_gelu_approximate));
+        continue;
+      }
+
+      // Remap BatchMatMul+Mul+AddV2 into the _FusedBatchMatMul.
+      matched_nodes_map.clear();
+      remove_node_indices.clear();
+      if (FindFusedBatchMatMul(&ctx, i, &matched_nodes_map,
+                               &remove_node_indices)) {
+        string name = ctx.graph_view.GetNode(i)->GetName();
+        TF_RETURN_IF_ERROR(
+            AddFusedBatchMatMul(&ctx, matched_nodes_map, remove_node_indices,
+                                &invalidated_nodes, &nodes_to_delete));
         continue;
       }
     }

--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
@@ -25,7 +25,6 @@ limitations under the License.
 
 #if defined(INTEL_MKL)
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
@@ -37,6 +36,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/matmul_bcast.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 
@@ -44,7 +44,8 @@ typedef Eigen::ThreadPoolDevice CPUDevice;
 
 //  The third parameter v2_bcast is set to true if we are using V2 otherwise
 //  we set it to false.
-template <typename Device, typename Scalar, bool v2_bcast>
+template <typename Device, typename Tlhs, typename Trhs, typename Toutput,
+          bool v2_bcast>
 class BatchMatMulMkl : public OpKernel {
  public:
   explicit BatchMatMulMkl(OpKernelConstruction* context) : OpKernel(context) {
@@ -127,8 +128,8 @@ class BatchMatMulMkl : public OpKernel {
       return;
     }
     if (lhs.NumElements() == 0 || rhs.NumElements() == 0) {
-      functor::SetZeroFunctor<Device, Scalar> f;
-      f(ctx->eigen_device<Device>(), out->flat<Scalar>());
+      functor::SetZeroFunctor<Device, Toutput> f;
+      f(ctx->eigen_device<Device>(), out->flat<Toutput>());
       return;
     }
 
@@ -145,21 +146,124 @@ class BatchMatMulMkl : public OpKernel {
     static int counter = 1;
     params->aarch64_counter = counter++;
 #endif
+    this->ExtendMklMatMulPararms(ctx, *params);
+
     // Create or retrieve matmul primitive from cache.
-    MklMatMulPrimitive<Scalar>* matmul_prim =
-        MklMatMulPrimitiveFactory<Scalar>::Get(
+    MklMatMulPrimitive<Tlhs, Trhs, Toutput>* matmul_prim =
+        MklMatMulPrimitiveFactory<float, Tlhs, Trhs, Toutput>::Get(
             *params, false /* value for do_not_cache */);
+
     // Execute matmul primitive.
     std::shared_ptr<stream> cpu_stream;
     MklDnnThreadPool eigen_tp(ctx);
     cpu_stream.reset(CreateStream(&eigen_tp, matmul_prim->GetEngine()));
-    matmul_prim->Execute(lhs.flat<Scalar>().data(), rhs.flat<Scalar>().data(),
-                         out->flat<Scalar>().data(), cpu_stream);
+    if (fused_ops_.size() > 0) {
+      void* mul_data = nullptr;
+      void* add_data = nullptr;
+      if (fused_ops_.at(0) == "Mul") {
+        const Tensor& mul_tensor = ctx->input(2);
+        mul_data = static_cast<void*>(
+            const_cast<Toutput*>(mul_tensor.flat<Toutput>().data()));
+      }
+      if (fused_ops_.size() > 1 && fused_ops_.at(1) == "Add") {
+        const Tensor& add_tensor = ctx->input(3);
+        add_data = static_cast<void*>(
+            const_cast<Toutput*>(add_tensor.flat<Toutput>().data()));
+      }
+      matmul_prim->Execute(lhs.flat<Tlhs>().data(), rhs.flat<Trhs>().data(),
+                           out->flat<Toutput>().data(), mul_data, add_data,
+                           cpu_stream);
+    } else {
+      matmul_prim->Execute(lhs.flat<Tlhs>().data(), rhs.flat<Trhs>().data(),
+                           out->flat<Toutput>().data(), cpu_stream);
+    }
   }
+
+ protected:
+  virtual void ExtendMklMatMulPararms(OpKernelContext* ctx,
+                                      MklMatMulParams& params) {}
+  std::vector<string> fused_ops_;
 
  private:
   bool adj_x_;
   bool adj_y_;
+};
+
+template <typename Device, typename Tlhs, typename Trhs, typename Toutput,
+          bool v2_bcast>
+class FusedBatchMatMulMkl
+    : public BatchMatMulMkl<Device, Tlhs, Trhs, Toutput, v2_bcast> {
+ public:
+  explicit FusedBatchMatMulMkl(OpKernelConstruction* context)
+      : BatchMatMulMkl<Device, Tlhs, Trhs, Toutput, v2_bcast>(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("fused_ops", &this->fused_ops_));
+    OP_REQUIRES(context, !this->fused_ops_.empty(),
+                errors::InvalidArgument(
+                    "Fused BatchMatMul must have at least one fused op."));
+
+    int num_args;
+    OP_REQUIRES_OK(context, context->GetAttr("num_args", &num_args));
+
+    if (this->fused_ops_ == std::vector<string>{"Mul"} ||
+        this->fused_ops_ == std::vector<string>{"Mul", "Add"}) {
+      OP_REQUIRES(context, num_args == this->fused_ops_.size(),
+                  errors::InvalidArgument(
+                      "Fused BatchMatmul should have same number of additional "
+                      "inputs as the number of fusions"));
+    } else {
+      OP_REQUIRES(
+          context, false,
+          errors::Unimplemented("Fusion is not implemented: [",
+                                absl::StrJoin(this->fused_ops_, ","), "]"));
+    }
+  }
+
+  virtual ~FusedBatchMatMulMkl() {}
+
+ protected:
+  virtual void ExtendMklMatMulPararms(OpKernelContext* ctx,
+                                      MklMatMulParams& params) {
+    if (this->fused_ops_.size() > 0) {
+      const Tensor& scale_tensor = ctx->input(2);
+      OP_REQUIRES(ctx, scale_tensor.NumElements() == 1,
+                  errors::InvalidArgument("Scale tensor must be a scalar"));
+
+      memory::data_type data_type = MklDnnType<Toutput>();
+      memory::format_tag format_tag;
+      switch (params.c_dims.size()) {
+        case 3:
+          format_tag = memory::format_tag::abc;
+          break;
+        case 4:
+          format_tag = memory::format_tag::abcd;
+          break;
+        default:
+          OP_REQUIRES(ctx, false, errors::Unimplemented("Unimplemented"));
+      }
+      if (this->fused_ops_.at(0) == "Mul") {
+        memory::dims mul_dims(params.c_dims.size(), 1);
+        params.post_op_params.push_back(
+            {"mul", {}, mul_dims, data_type, format_tag});
+      } else {
+        OP_REQUIRES(ctx, false,
+                    errors::InvalidArgument(
+                        "Currently first fusion is supported only for Mul",
+                        ", but it is ", this->fused_ops_.at(0), " op."));
+      }
+      if (this->fused_ops_.size() > 1 && this->fused_ops_.at(1) == "Add") {
+        auto add_shape = ctx->input(3).shape();
+        memory::dims add_dims = {add_shape.dim_size(0), add_shape.dim_size(1),
+                                 add_shape.dim_size(2), add_shape.dim_size(3)};
+        params.post_op_params.push_back(
+            {"add", {}, add_dims, data_type, format_tag});
+      } else {
+        OP_REQUIRES(ctx, false,
+                    errors::InvalidArgument(
+                        "Currently second fusion is supported only for Add",
+                        ", but it is ", this->fused_ops_.at(1), " op."));
+      }
+    }
+  }
 };
 
 #define REGISTER_BATCH_MATMUL_MKL(TYPE)                                       \
@@ -167,19 +271,29 @@ class BatchMatMulMkl : public OpKernel {
                               .Device(DEVICE_CPU)                             \
                               .TypeConstraint<TYPE>("T")                      \
                               .Label(mkl_op_registry::kMklNameChangeOpLabel), \
-                          BatchMatMulMkl<CPUDevice, TYPE, false>)
+                          BatchMatMulMkl<CPUDevice, TYPE, TYPE, TYPE, false>)
 
 #define REGISTER_BATCH_MATMUL_MKL_V2(TYPE)                                    \
   REGISTER_KERNEL_BUILDER(Name("_MklBatchMatMulV2")                           \
                               .Device(DEVICE_CPU)                             \
                               .TypeConstraint<TYPE>("T")                      \
                               .Label(mkl_op_registry::kMklNameChangeOpLabel), \
-                          BatchMatMulMkl<CPUDevice, TYPE, true>)
+                          BatchMatMulMkl<CPUDevice, TYPE, TYPE, TYPE, true>)
+
+#define REGISTER_FUSED_BATCH_MATMUL_MKL(TYPE) \
+  REGISTER_KERNEL_BUILDER(                    \
+      Name("_MklFusedBatchMatMulV2")          \
+          .Device(DEVICE_CPU)                 \
+          .TypeConstraint<TYPE>("T"),         \
+      FusedBatchMatMulMkl<CPUDevice, TYPE, TYPE, TYPE, true>)
+
 #ifdef INTEL_MKL
 TF_CALL_float(REGISTER_BATCH_MATMUL_MKL);
 TF_CALL_float(REGISTER_BATCH_MATMUL_MKL_V2);
+TF_CALL_float(REGISTER_FUSED_BATCH_MATMUL_MKL);
 TF_CALL_bfloat16(REGISTER_BATCH_MATMUL_MKL);
 TF_CALL_bfloat16(REGISTER_BATCH_MATMUL_MKL_V2);
+TF_CALL_bfloat16(REGISTER_FUSED_BATCH_MATMUL_MKL);
 #endif  // INTEL_MKL
 
 }  // end namespace tensorflow

--- a/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
@@ -110,15 +110,16 @@ struct MklEinsumHelper {
                                          trans_x, trans_y);
 
     // Create or retrieve matmul primitive from cache.
-    MklMatMulPrimitive<T, T, T>* matmul_prim = MklMatMulPrimitiveFactory<T, T, T, T>::Get(
-        *params, false /* value for do_not_cache */);
+    MklMatMulPrimitive<T, T, T>* matmul_prim =
+        MklMatMulPrimitiveFactory<T, T, T, T>::Get(
+            *params, false /* value for do_not_cache */);
     // Execute matmul primitive.
     std::shared_ptr<stream> cpu_stream;
     MklDnnThreadPool eigen_tp(ctx);
     cpu_stream.reset(CreateStream(&eigen_tp, matmul_prim->GetEngine()));
 
-    matmul_prim->Execute(lhs.flat<T>().data(), rhs.flat<T>().data(),
-                         output->flat<T>().data(), cpu_stream);
+    matmul_prim->Execute(cpu_stream, lhs.flat<T>().data(), rhs.flat<T>().data(),
+                         output->flat<T>().data());
 
     Tensor output_reshaped;
     if (output->dims() != 3) {

--- a/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
@@ -110,7 +110,7 @@ struct MklEinsumHelper {
                                          trans_x, trans_y);
 
     // Create or retrieve matmul primitive from cache.
-    MklMatMulPrimitive<T>* matmul_prim = MklMatMulPrimitiveFactory<T>::Get(
+    MklMatMulPrimitive<T, T, T>* matmul_prim = MklMatMulPrimitiveFactory<T, T, T, T>::Get(
         *params, false /* value for do_not_cache */);
     // Execute matmul primitive.
     std::shared_ptr<stream> cpu_stream;

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -555,6 +555,14 @@ struct MklMatMulParams {
 #ifdef DNNL_AARCH64_USE_ACL
   int aarch64_counter;
 #endif
+  struct PostOpParam {
+    string name;
+    std::vector<float> param;
+    memory::dims dims;
+    memory::data_type data_type;
+    memory::format_tag format_tag;
+  };
+  std::vector<PostOpParam> post_op_params;
 
   MklMatMulParams(memory::dims a_dims, memory::dims b_dims, memory::dims c_dims,
                   memory::dims a_strides, memory::dims b_strides,
@@ -567,7 +575,7 @@ struct MklMatMulParams {
         c_strides(c_strides) {}
 };
 
-template <typename T>
+template <typename Tlhs, typename Trhs, typename Toutput>
 class MklMatMulPrimitive : public MklPrimitive {
  public:
   explicit MklMatMulPrimitive(const MklMatMulParams& params)
@@ -578,19 +586,22 @@ class MklMatMulPrimitive : public MklPrimitive {
 
   ~MklMatMulPrimitive() {}
 
-  void Execute(const T* a_data, const T* b_data, T* c_data,
+  void Execute(const Tlhs* a_data, const Trhs* b_data, Toutput* c_data,
                std::shared_ptr<stream> stream) {
 #ifndef ENABLE_ONEDNN_OPENMP
-    context_.a_mem->set_data_handle(static_cast<void*>(const_cast<T*>(a_data)),
-                                    *stream);
-    context_.b_mem->set_data_handle(static_cast<void*>(const_cast<T*>(b_data)),
-                                    *stream);
-    context_.c_mem->set_data_handle(static_cast<void*>(const_cast<T*>(c_data)),
-                                    *stream);
+    context_.a_mem->set_data_handle(
+        static_cast<void*>(const_cast<Tlhs*>(a_data)), *stream);
+    context_.b_mem->set_data_handle(
+        static_cast<void*>(const_cast<Trhs*>(b_data)), *stream);
+    context_.c_mem->set_data_handle(
+        static_cast<void*>(const_cast<Toutput*>(c_data)), *stream);
 #else
-    context_.a_mem->set_data_handle(static_cast<void*>(const_cast<T*>(a_data)));
-    context_.b_mem->set_data_handle(static_cast<void*>(const_cast<T*>(b_data)));
-    context_.c_mem->set_data_handle(static_cast<void*>(const_cast<T*>(c_data)));
+    context_.a_mem->set_data_handle(
+        static_cast<void*>(const_cast<Tlhs*>(a_data)));
+    context_.b_mem->set_data_handle(
+        static_cast<void*>(const_cast<Trhs*>(b_data)));
+    context_.c_mem->set_data_handle(
+        static_cast<void*>(const_cast<Toutput*>(c_data)));
 #endif  // !ENABLE_ONEDNN_OPENMP
     execute_primitives(context_.matmul_primitives, stream, context_.net_args);
 
@@ -600,6 +611,39 @@ class MklMatMulPrimitive : public MklPrimitive {
     context_.c_mem->set_data_handle(DummyData);
   }
 
+  void Execute(const Tlhs* a_data, const Trhs* b_data, Toutput* c_data,
+               void* mul_data, void* add_data, std::shared_ptr<stream> stream) {
+#ifndef ENABLE_ONEDNN_OPENMP
+    context_.a_mem->set_data_handle(
+        static_cast<void*>(const_cast<Tlhs*>(a_data)), *stream);
+    context_.b_mem->set_data_handle(
+        static_cast<void*>(const_cast<Trhs*>(b_data)), *stream);
+    context_.c_mem->set_data_handle(
+        static_cast<void*>(const_cast<Toutput*>(c_data)), *stream);
+    if (mul_data != nullptr)
+      context_.mul_mem->set_data_handle(mul_data, *stream);
+    if (add_data != nullptr)
+      context_.add_mem->set_data_handle(add_data, *stream);
+#else
+    context_.a_mem->set_data_handle(
+        static_cast<void*>(const_cast<Tlhs*>(a_data)));
+    context_.b_mem->set_data_handle(
+        static_cast<void*>(const_cast<Trhs*>(b_data)));
+    context_.c_mem->set_data_handle(
+        static_cast<void*>(const_cast<Toutput*>(c_data)));
+    if (mul_data != nullptr) context_.mul_mem->set_data_handle(mul_data);
+    if (add_data != nullptr) context_.add_mem->set_data_handle(add_data);
+#endif  // !ENABLE_ONEDNN_OPENMP
+    execute_primitives(context_.matmul_primitives, stream, context_.net_args);
+
+    // After execution, set data handle back
+    context_.a_mem->set_data_handle(DummyData);
+    context_.b_mem->set_data_handle(DummyData);
+    context_.c_mem->set_data_handle(DummyData);
+    if (mul_data != nullptr) context_.mul_mem->set_data_handle(DummyData);
+    if (add_data != nullptr) context_.add_mem->set_data_handle(DummyData);
+  }
+
  private:
   // Primitive reuse context for MatMul op
   struct MklMatMulContext {
@@ -607,6 +651,8 @@ class MklMatMulPrimitive : public MklPrimitive {
     std::shared_ptr<dnnl::memory> a_mem;
     std::shared_ptr<dnnl::memory> b_mem;
     std::shared_ptr<dnnl::memory> c_mem;
+    std::shared_ptr<dnnl::memory> mul_mem;
+    std::shared_ptr<dnnl::memory> add_mem;
 
     // Descriptor and primitive-descriptor for MatMul.
     std::shared_ptr<matmul::desc> desc;
@@ -616,6 +662,8 @@ class MklMatMulPrimitive : public MklPrimitive {
     std::shared_ptr<dnnl::memory::desc> a_md;
     std::shared_ptr<dnnl::memory::desc> b_md;
     std::shared_ptr<dnnl::memory::desc> c_md;
+    std::shared_ptr<dnnl::memory::desc> mul_md;
+    std::shared_ptr<dnnl::memory::desc> add_md;
 
     // MatMul primitive.
     std::vector<dnnl::primitive> matmul_primitives;
@@ -625,31 +673,66 @@ class MklMatMulPrimitive : public MklPrimitive {
         : a_mem(nullptr),
           b_mem(nullptr),
           c_mem(nullptr),
+          mul_mem(nullptr),
+          add_mem(nullptr),
           desc(nullptr),
           prim_desc(nullptr),
           a_md(nullptr),
           b_md(nullptr),
-          c_md(nullptr) {}
+          c_md(nullptr),
+          mul_md(nullptr),
+          add_md(nullptr) {}
   };
 
   void Setup(const MklMatMulParams& params) {
     std::shared_ptr<dnnl::primitive> matmul_primitive = nullptr;
 
     // Create MatMul descriptor and primitive descriptor.
-    context_.a_md.reset(
-        new memory::desc({params.a_dims}, MklDnnType<T>(), params.a_strides));
+    context_.a_md.reset(new memory::desc({params.a_dims}, MklDnnType<Tlhs>(),
+                                         params.a_strides));
 
-    context_.b_md.reset(
-        new memory::desc({params.b_dims}, MklDnnType<T>(), params.b_strides));
+    context_.b_md.reset(new memory::desc({params.b_dims}, MklDnnType<Trhs>(),
+                                         params.b_strides));
 
-    context_.c_md.reset(
-        new memory::desc({params.c_dims}, MklDnnType<T>(), params.c_strides));
+    context_.c_md.reset(new memory::desc({params.c_dims}, MklDnnType<Toutput>(),
+                                         params.c_strides));
 
     // Create matmul.
     context_.desc.reset(
         new matmul::desc(*context_.a_md, *context_.b_md, *context_.c_md));
-    context_.prim_desc.reset(
-        new matmul::primitive_desc(*context_.desc, cpu_engine_));
+
+    // Check if there is any fusion as post-ops
+    auto const& post_op_params = params.post_op_params;
+    dnnl::primitive_attr post_ops_attr;
+    dnnl::post_ops post_ops;
+    if (!post_op_params.empty()) {
+      for (auto const& post_op_param : post_op_params) {
+        if (post_op_param.name == "output_scale") {
+          DCHECK_EQ(post_op_param.param.size(), 1);
+          std::vector<float> scales;
+          scales.push_back(post_op_param.param[0]);
+          post_ops_attr.set_output_scales(0, scales);
+        } else if (post_op_param.name == "mul") {
+          context_.mul_md.reset(new memory::desc({post_op_param.dims},
+                                                 post_op_param.data_type,
+                                                 post_op_param.format_tag));
+          post_ops.append_binary(dnnl::algorithm::binary_mul, *context_.mul_md);
+        } else if (post_op_param.name == "add") {
+          context_.add_md.reset(new memory::desc({post_op_param.dims},
+                                                 post_op_param.data_type,
+                                                 post_op_param.format_tag));
+          post_ops.append_binary(dnnl::algorithm::binary_add, *context_.add_md);
+        } else {
+          DCHECK((post_op_param.name == "output_scale"));
+        }
+      }
+      post_ops_attr.set_post_ops(post_ops);
+      context_.prim_desc.reset(new matmul::primitive_desc(
+          *context_.desc, post_ops_attr, cpu_engine_));
+    } else {
+      context_.prim_desc.reset(
+          new matmul::primitive_desc(*context_.desc, cpu_engine_));
+    }
 
     // Create memory primitive based on dummy data.
     context_.a_mem.reset(
@@ -664,6 +747,26 @@ class MklMatMulPrimitive : public MklPrimitive {
     context_.net_args.push_back({{DNNL_ARG_SRC, *context_.a_mem},
                                  {DNNL_ARG_WEIGHTS, *context_.b_mem},
                                  {DNNL_ARG_DST, *context_.c_mem}});
+    if (!post_op_params.empty()) {
+      int count = 0;
+      for (auto const& post_op_param : post_op_params) {
+        if (post_op_param.name == "mul") {
+          context_.mul_mem.reset(
+              new dnnl::memory(*context_.mul_md, cpu_engine_, DummyData));
+          context_.net_args[0].insert(
+              {DNNL_ARG_ATTR_MULTIPLE_POST_OP(count) | DNNL_ARG_SRC_1,
+               *context_.mul_mem});
+          count++;
+        } else if (post_op_param.name == "add") {
+          context_.add_mem.reset(
+              new dnnl::memory(*context_.add_md, cpu_engine_, DummyData));
+          context_.net_args[0].insert(
+              {DNNL_ARG_ATTR_MULTIPLE_POST_OP(count) | DNNL_ARG_SRC_1,
+               *context_.add_mem});
+          count++;
+        }
+      }
+    }
 
     context_.matmul_primitives.push_back(*matmul_primitive);
     return;
@@ -672,24 +775,25 @@ class MklMatMulPrimitive : public MklPrimitive {
   struct MklMatMulContext context_;
 };
 
-template <typename T>
+template <typename T, typename Tlhs, typename Trhs, typename Toutput>
 class MklMatMulPrimitiveFactory : public MklPrimitiveFactory<T> {
  public:
-  static MklMatMulPrimitive<T>* Get(const MklMatMulParams& params,
-                                    bool do_not_cache) {
-    MklMatMulPrimitive<T>* matmul_prim = nullptr;
+  static MklMatMulPrimitive<Tlhs, Trhs, Toutput>* Get(
+      const MklMatMulParams& params, bool do_not_cache) {
+    MklMatMulPrimitive<Tlhs, Trhs, Toutput>* matmul_prim = nullptr;
 
     if (do_not_cache) {
       // Always create new primitive
-      matmul_prim = new MklMatMulPrimitive<T>(params);
+      matmul_prim = new MklMatMulPrimitive<Tlhs, Trhs, Toutput>(params);
     } else {
       // Try to find a suitable one in pool
-      matmul_prim = dynamic_cast<MklMatMulPrimitive<T>*>(
-          MklMatMulPrimitiveFactory<T>::GetInstance().GetMklMatMul(params));
+      matmul_prim = dynamic_cast<MklMatMulPrimitive<Tlhs, Trhs, Toutput>*>(
+          MklMatMulPrimitiveFactory<T, Tlhs, Trhs, Toutput>::GetInstance()
+              .GetMklMatMul(params));
       if (matmul_prim == nullptr) {
-        matmul_prim = new MklMatMulPrimitive<T>(params);
-        MklMatMulPrimitiveFactory<T>::GetInstance().SetMklMatMul(params,
-                                                                 matmul_prim);
+        matmul_prim = new MklMatMulPrimitive<Tlhs, Trhs, Toutput>(params);
+        MklMatMulPrimitiveFactory<T, Tlhs, Trhs, Toutput>::GetInstance()
+            .SetMklMatMul(params, matmul_prim);
       }
     }
 
@@ -719,6 +823,23 @@ class MklMatMulPrimitiveFactory : public MklPrimitiveFactory<T> {
 #ifdef DNNL_AARCH64_USE_ACL
     key_creator.AddAsKey(params.aarch64_counter);
 #endif
+    key_creator.AddAsKey(typeid(Tlhs).name());
+    key_creator.AddAsKey(typeid(Trhs).name());
+    key_creator.AddAsKey(typeid(Toutput).name());
+
+    // Generate keys for post-ops
+    for (auto const& post_op_param : params.post_op_params) {
+      if (post_op_param.name == "output_scale") {
+        DCHECK_EQ(post_op_param.param.size(), 1);
+        key_creator.AddAsKey(post_op_param.name);
+        key_creator.AddAsKey(post_op_param.param[0]);
+      } else if (post_op_param.name == "mul" || post_op_param.name == "add") {
+        key_creator.AddAsKey(post_op_param.name);
+        key_creator.AddAsKey(post_op_param.dims);
+      } else {
+        return string("not_a_key");
+      }
+    }
     return key_creator.GetKey();
   }
 
@@ -755,8 +876,8 @@ void dnnl_gemm(char transa, char transb, int64_t m, int64_t n, int64_t k,
 
   MklMatMulParams params(a_dims, b_dims, c_dims, a_strides, b_strides,
                          c_strides);
-  MklMatMulPrimitive<T>* matmul_prim =
-      MklMatMulPrimitiveFactory<T>::Get(params, 0);
+  MklMatMulPrimitive<T, T, T>* matmul_prim =
+      MklMatMulPrimitiveFactory<T, T, T, T>::Get(params, 0);
 
   // Execute matmul primitive.
   std::shared_ptr<stream> cpu_stream;

--- a/tensorflow/core/ops/mkl_nn_ops.cc
+++ b/tensorflow/core/ops/mkl_nn_ops.cc
@@ -1779,6 +1779,22 @@ Uses oneDNN APIs to perform fused batch normalization and relu.
 expected to invoke these operators.
 )doc");
 
+REGISTER_OP("_MklFusedBatchMatMulV2")
+    .Input("x: T")
+    .Input("y: T")
+    .Input("args: num_args * T")
+    .Output("output: T")
+    .Attr("T: {bfloat16, float}")
+    .Attr("adj_x: bool = false")
+    .Attr("adj_y: bool = false")
+    .Attr("num_args: int >= 0")
+    .Attr("fused_ops: list(string) = []")
+    .SetShapeFn(shape_inference::BatchMatMulV2Shape)
+    .Doc(R"doc(
+*NOTE*: Do not invoke this operator directly in Python. Grappler is
+expected to create these operators.
+)doc");
+
 }  // namespace tensorflow
 
 #endif  // INTEL_MKL


### PR DESCRIPTION
This PR does a fusion of BatchMatMulV2 + Mul + AddV2 with oneDNN CPU backend using grappler remapper optimizer. Such pattern is common in Transformer based language models. It improves inference performance for higher batch sizes.