### PR TITLE
[ROCm] Fix ROCm logger for kernel name

### DIFF
--- a/tensorflow/stream_executor/rocm/rocm_driver.cc
+++ b/tensorflow/stream_executor/rocm/rocm_driver.cc
@@ -408,7 +408,7 @@ GpuDriver::ContextGetSharedMemConfig(GpuContext* context) {
     unsigned int block_dim_z, unsigned int shared_mem_bytes,
     GpuStreamHandle stream, void** kernel_params, void** extra) {
   ScopedActivateContext activation{context};
-  VLOG(2) << "launching kernel: " << function << "; gdx: " << grid_dim_x
+  VLOG(2) << "launching kernel: " << kernel_name << "; gdx: " << grid_dim_x
           << " gdy: " << grid_dim_y << " gdz: " << grid_dim_z
           << " bdx: " << block_dim_x << " bdy: " << block_dim_y
           << " bdz: " << block_dim_z << " smem: " << shared_mem_bytes;


### PR DESCRIPTION
This PR fixes launch kernel name for logging in ROCm.