### PR TITLE
Update MklDnnMatMulFwdPrimitiveFactory to support Arm Compute Library

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -123,6 +123,11 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, T> {
 
     // Extend the basic parameters for data types and fusions.
     ExtendMklDnnMatMulFwdParams(ctx, matmul_params);
+#ifdef DNNL_AARCH64_USE_ACL
+    //Specifics of ACL: a primitive per constant weights ptr
+    matmul_params.weight_address = const_cast<void*>(
+        static_cast<const void*>(weight_tensor.flat<T>().data()));
+#endif
     MklDnnMatMulFwdPrimitive<T, T, T, T, T>* matmul_prim =
         MklDnnMatMulFwdPrimitiveFactory<T, T, T, T, T>::Get(matmul_params, 0);
 

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -56,6 +56,9 @@ struct MklDnnMatMulFwdParams {
   memory::format_tag weight_format;
   memory::format_tag dst_format;
   string dtypes = string("");
+#ifdef DNNL_AARCH64_USE_ACL
+  void* weight_address = nullptr;
+#endif
   struct PostOpParam {
     string name;
     std::vector<float> param;
@@ -352,6 +355,9 @@ class MklDnnMatMulFwdPrimitiveFactory : public MklPrimitiveFactory<T> {
     key_creator.AddAsKey(mkldnn_matmul_fwd_dims.dst_dims);
     key_creator.AddAsKey(mkldnn_matmul_fwd_dims.dtypes);
     key_creator.AddAsKey(mkldnn_matmul_fwd_dims.weight_format);
+#ifdef DNNL_AARCH64_USE_ACL
+    key_creator.AddAsKey(mkldnn_matmul_fwd_dims.weight_address);
+#endif
 
     // Generate keys for post-ops
     for (auto const& post_op_param : mkldnn_matmul_fwd_dims.post_op_params) {

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -199,6 +199,7 @@ def _tf_repositories():
     tf_http_archive(
         name = "mkl_dnn_acl_compatible",
         build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
+        patch_file = "//third_party/mkl_dnn:onednn_acl_primitives.patch",
         sha256 = "ccb2dbd9da36cd873cf573b4201d61bdba7438f12b144e6c7d061eb12a641751",
         strip_prefix = "oneDNN-2.3",
         urls = [

--- a/third_party/mkl_dnn/onednn_acl_primitives.patch
+++ b/third_party/mkl_dnn/onednn_acl_primitives.patch
@@ -1,0 +1,1872 @@
+ *******************************************************************************
+ Copyright 2021 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/aarch64/acl_convolution_utils.cpp b/src/cpu/aarch64/acl_convolution_utils.cpp
+index afa784054..242c799cf 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.cpp
++++ b/src/cpu/aarch64/acl_convolution_utils.cpp
+@@ -14,23 +14,15 @@
+ * limitations under the License.
+ *******************************************************************************/
+ 
+-#include "oneapi/dnnl/dnnl_types.h"
+-
+-#include "common/c_types_map.hpp"
+-#include "common/dnnl_thread.hpp"
+-#include "common/type_helpers.hpp"
+-#include "common/utils.hpp"
+-
+-#include "common/bfloat16.hpp"
+ #include "cpu/aarch64/acl_convolution_utils.hpp"
+ 
+-#include "cpu/platform.hpp"
+-
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+ namespace aarch64 {
+ 
++namespace acl_convolution_utils {
++
+ using namespace dnnl::impl::status;
+ using namespace dnnl::impl::utils;
+ using namespace dnnl::impl::alg_kind;
+@@ -38,8 +30,6 @@ using namespace prop_kind;
+ using namespace data_type;
+ using uint = unsigned int;
+ 
+-namespace acl_convolution_utils {
+-
+ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         memory_desc_t &weights_md, memory_desc_t &dst_md,
+         memory_desc_t &bias_md, const convolution_desc_t &cd,
+@@ -162,14 +152,10 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     const auto acl_layout = is_nspc ? arm_compute::DataLayout::NHWC
+                                     : arm_compute::DataLayout::NCHW;
+ 
+-    auto acl_src_data_t
+-            = acl_convolution_utils::get_acl_data_t(src_d.data_type());
+-    auto acl_wei_data_t
+-            = acl_convolution_utils::get_acl_data_t(wei_d.data_type());
+-    auto acl_dst_data_t
+-            = acl_convolution_utils::get_acl_data_t(dst_d.data_type());
+-    auto acl_bia_data_t
+-            = acl_convolution_utils::get_acl_data_t(bia_d.data_type());
++    auto acl_src_data_t = acl_common_utils::get_acl_data_t(src_d.data_type());
++    auto acl_wei_data_t = acl_common_utils::get_acl_data_t(wei_d.data_type());
++    auto acl_dst_data_t = acl_common_utils::get_acl_data_t(dst_d.data_type());
++    auto acl_bia_data_t = acl_common_utils::get_acl_data_t(bia_d.data_type());
+ 
+     if (acl_bia_data_t == arm_compute::DataType::UNKNOWN)
+         acl_bia_data_t = arm_compute::DataType::F32;
+@@ -221,7 +207,7 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     const auto &post_ops = attr.post_ops_;
+     acp.sum_with_eltwise = (post_ops.len() == 2) && post_ops.entry_[0].is_sum()
+             && post_ops.entry_[1].is_eltwise();
+-    acp.act_info = acl_convolution_utils::get_acl_act(attr);
++    acp.act_info = acl_common_utils::get_acl_act(attr);
+ 
+     return status::success;
+ }
+@@ -236,8 +222,7 @@ status_t init_conf_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+ 
+     // clang-format off
+     // Validate convolution manually to check for return status
+-    arm_compute::NEGEMMConvolutionLayer acl_gemm_conv;
+-    auto acl_st = acl_gemm_conv.validate(
++    auto acl_st = arm_compute::NEGEMMConvolutionLayer::validate(
+         &acp.src_info,
+         &acp.wei_info,
+         acp.with_bias ? &acp.bia_info : nullptr,
+@@ -316,8 +301,7 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+ 
+     // clang-format off
+     // Validate convolution manually to check for return status
+-    arm_compute::NEWinogradConvolutionLayer acl_wino_conv;
+-    auto acl_st = acl_wino_conv.validate(
++    auto acl_st = arm_compute::NEWinogradConvolutionLayer::validate(
+         &acp.src_info,
+         &acp.wei_info,
+         acp.with_bias ? &acp.bia_info : nullptr,
+@@ -333,69 +317,6 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     return status::success;
+ }
+ 
+-arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt) {
+-    switch (dt) {
+-        case bf16: return arm_compute::DataType::BFLOAT16; break;
+-        case f32: return arm_compute::DataType::F32; break;
+-        case s32: return arm_compute::DataType::S32; break;
+-        case f16: return arm_compute::DataType::F16; break;
+-        case s8: return arm_compute::DataType::QASYMM8_SIGNED; break;
+-        case u8: return arm_compute::DataType::QASYMM8; break;
+-        default: return arm_compute::DataType::UNKNOWN;
+-    }
+-}
+-
+-arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr) {
+-    const auto &post_ops = attr.post_ops_;
+-    const int entry_idx = post_ops.find(primitive_kind::eltwise);
+-    if (entry_idx == -1) { return arm_compute::ActivationLayerInfo(); }
+-
+-    const auto eltwise_alg = post_ops.entry_[entry_idx].eltwise.alg;
+-    float alpha = post_ops.entry_[entry_idx].eltwise.alpha;
+-    float beta = post_ops.entry_[entry_idx].eltwise.beta;
+-
+-    using acl_act_t = arm_compute::ActivationLayerInfo::ActivationFunction;
+-    acl_act_t acl_act_alg;
+-    switch (eltwise_alg) {
+-        case eltwise_relu:
+-            // oneDNN defines RELU: f(x) = (x > 0) ? x : a*x
+-            // Compute Library defines LEAKY_RELU: f(x) = (x > 0) ? x : a*x
+-            // whilst Compute Library RELU is defined as: f(x) = max(0,x)
+-            if (alpha == 0) {
+-                acl_act_alg = acl_act_t::RELU;
+-            } else {
+-                acl_act_alg = acl_act_t::LEAKY_RELU;
+-            }
+-            break;
+-        case eltwise_tanh:
+-            // oneDNN defines TANH activation as:          f(x) = tanh(x)
+-            // Compute Library defines TANH activation as: f(x) = a*tanh(b*x)
+-            // Setting a=b=1 makes the two equivalent
+-            alpha = 1.f;
+-            beta = 1.f;
+-            acl_act_alg = acl_act_t::TANH;
+-            break;
+-        case eltwise_elu: acl_act_alg = acl_act_t::ELU; break;
+-        case eltwise_square: acl_act_alg = acl_act_t::SQUARE; break;
+-        case eltwise_abs: acl_act_alg = acl_act_t::ABS; break;
+-        case eltwise_sqrt: acl_act_alg = acl_act_t::SQRT; break;
+-        case eltwise_linear: acl_act_alg = acl_act_t::LINEAR; break;
+-        case eltwise_bounded_relu: acl_act_alg = acl_act_t::BOUNDED_RELU; break;
+-        case eltwise_soft_relu: acl_act_alg = acl_act_t::SOFT_RELU; break;
+-        case eltwise_logistic: acl_act_alg = acl_act_t::LOGISTIC; break;
+-        default: return arm_compute::ActivationLayerInfo();
+-    }
+-
+-    return arm_compute::ActivationLayerInfo(acl_act_alg, alpha, beta);
+-}
+-
+-bool acl_act_ok(alg_kind_t eltwise_activation) {
+-    return utils::one_of(eltwise_activation, eltwise_relu, eltwise_tanh,
+-            eltwise_elu, eltwise_square, eltwise_abs, eltwise_sqrt,
+-            eltwise_linear, eltwise_bounded_relu, eltwise_soft_relu,
+-            eltwise_logistic);
+-}
+-
+ } // namespace acl_convolution_utils
+ 
+ } // namespace aarch64
+diff --git a/src/cpu/aarch64/acl_convolution_utils.hpp b/src/cpu/aarch64/acl_convolution_utils.hpp
+index 9d5273a6b..9b2f486d5 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.hpp
++++ b/src/cpu/aarch64/acl_convolution_utils.hpp
+@@ -17,14 +17,9 @@
+ #ifndef CPU_AARCH64_ACL_CONVOLUTION_UTILS_HPP
+ #define CPU_AARCH64_ACL_CONVOLUTION_UTILS_HPP
+ 
+-#include "common/c_types_map.hpp"
+-#include "common/dnnl_thread.hpp"
+-#include "common/memory_tracking.hpp"
+-
+ #include "cpu/cpu_convolution_pd.hpp"
+-#include "cpu/cpu_engine.hpp"
+ 
+-#include "arm_compute/runtime/NEON/NEFunctions.h"
++#include "cpu/aarch64/acl_utils.hpp"
+ 
+ namespace dnnl {
+ namespace impl {
+@@ -74,12 +69,49 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         memory_desc_t &bias_md, const convolution_desc_t &cd,
+         const primitive_attr_t &attr);
+ 
+-arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt);
+-arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr);
+-bool acl_act_ok(alg_kind_t eltwise_activation);
+-
+ } // namespace acl_convolution_utils
+ 
++template <typename conv_obj_t, typename conv_pd_t, typename src_data_t,
++        typename wei_data_t = src_data_t, typename dst_data_t = src_data_t,
++        typename bia_data_t = src_data_t>
++status_t execute_forward_conv_acl(
++        const exec_ctx_t &ctx, conv_obj_t &acl_conv_obj, const conv_pd_t *pd) {
++    bool with_bias = pd->acp_.with_bias;
++    bool sum_with_eltwise = pd->acp_.sum_with_eltwise;
++
++    auto src_base = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
++    auto wei_base = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
++    auto dst_base = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
++
++    // import_memory() and free() methods do not allocate/free any additional
++    // memory, only acquire/release pointers.
++    acl_conv_obj.src_tensor.allocator()->import_memory(
++            const_cast<src_data_t *>(src_base));
++    acl_conv_obj.wei_tensor.allocator()->import_memory(
++            const_cast<wei_data_t *>(wei_base));
++    acl_conv_obj.dst_tensor.allocator()->import_memory(dst_base);
++
++    if (with_bias) {
++        auto bia_base = CTX_IN_MEM(const bia_data_t *, DNNL_ARG_BIAS);
++        acl_conv_obj.bia_tensor.allocator()->import_memory(
++                const_cast<bia_data_t *>(bia_base));
++    }
++
++    acl_conv_obj.conv.run();
++
++    if (sum_with_eltwise) {
++        acl_conv_obj.add.run();
++        acl_conv_obj.act.run();
++    }
++
++    acl_conv_obj.src_tensor.allocator()->free();
++    acl_conv_obj.wei_tensor.allocator()->free();
++    acl_conv_obj.dst_tensor.allocator()->free();
++    if (with_bias) { acl_conv_obj.bia_tensor.allocator()->free(); }
++
++    return status::success;
++}
++
+ } // namespace aarch64
+ } // namespace cpu
+ } // namespace impl
+diff --git a/src/cpu/aarch64/acl_eltwise.cpp b/src/cpu/aarch64/acl_eltwise.cpp
+new file mode 100644
+index 000000000..4e187a966
+--- /dev/null
++++ b/src/cpu/aarch64/acl_eltwise.cpp
+@@ -0,0 +1,64 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_eltwise.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++using namespace dnnl::impl::status;
++using namespace dnnl::impl::memory_tracking::names;
++using namespace dnnl::impl::utils;
++
++template <data_type_t data_type>
++status_t acl_eltwise_fwd_t<data_type>::execute_forward(
++        const exec_ctx_t &ctx) const {
++    // Lock here is needed because resource_mapper does not support
++    // concurrent access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
++
++    status_t status = status::success;
++    auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
++    auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
++
++    // Retrieve primitive resource and configured Compute Library objects
++    auto *acl_resource
++            = ctx.get_resource_mapper()->get<acl_eltwise_resource_t>(this);
++    acl_eltwise_obj_t &acl_obj = acl_resource->get_acl_obj();
++
++    // import_memory() and free() methods do not allocate/free any additional
++    // memory, only acquire/release pointers.
++    acl_obj.src_tensor.allocator()->import_memory(
++            const_cast<data_t *>(src_base));
++    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
++
++    acl_obj.act.run();
++
++    acl_obj.src_tensor.allocator()->free();
++    acl_obj.dst_tensor.allocator()->free();
++
++    return status;
++}
++
++template struct acl_eltwise_fwd_t<data_type::f32>;
++template struct acl_eltwise_fwd_t<data_type::s8>;
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_eltwise.hpp b/src/cpu/aarch64/acl_eltwise.hpp
+new file mode 100644
+index 000000000..daa6fa8f1
+--- /dev/null
++++ b/src/cpu/aarch64/acl_eltwise.hpp
+@@ -0,0 +1,125 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_ELTWISE_HPP
++#define CPU_AARCH64_ACL_ELTWISE_HPP
++
++#include "cpu/cpu_eltwise_pd.hpp"
++
++#include "cpu/aarch64/acl_eltwise_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_eltwise_resource_t : public resource_t {
++    acl_eltwise_resource_t()
++        : acl_eltwise_obj_(utils::make_unique<acl_eltwise_obj_t>()) {}
++
++    status_t configure(const acl_eltwise_conf_t &aep) {
++        if (!acl_eltwise_obj_) return status::out_of_memory;
++
++        // Init Compute Library tensors based on info from descriptor
++        acl_eltwise_obj_->src_tensor.allocator()->init(aep.src_info);
++        acl_eltwise_obj_->dst_tensor.allocator()->init(aep.dst_info);
++
++        // clang-format off
++        acl_eltwise_obj_->act.configure(
++            &acl_eltwise_obj_->src_tensor,
++            &acl_eltwise_obj_->dst_tensor,
++            aep.act_info);
++        // clang-format on
++
++        return status::success;
++    }
++
++    acl_eltwise_obj_t &get_acl_obj() const { return *acl_eltwise_obj_; }
++
++    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_eltwise_resource_t);
++
++private:
++    std::unique_ptr<acl_eltwise_obj_t> acl_eltwise_obj_;
++}; // acl_eltwise_resource_t
++
++template <data_type_t data_type>
++struct acl_eltwise_fwd_t : public primitive_t {
++    struct pd_t : public cpu_eltwise_fwd_pd_t {
++        using cpu_eltwise_fwd_pd_t::cpu_eltwise_fwd_pd_t;
++        pd_t(const eltwise_desc_t *adesc, const primitive_attr_t *attr,
++                const eltwise_fwd_pd_t *hint_fwd_pd)
++            : cpu_eltwise_fwd_pd_t(adesc, attr, hint_fwd_pd), aep_() {}
++
++        DECLARE_COMMON_PD_T("eltwise:acl", acl_eltwise_fwd_t);
++
++        status_t init(engine_t *engine) {
++            using namespace utils;
++            using sm = primitive_attr_t::skip_mask_t;
++            const auto &po = attr()->post_ops_;
++
++            bool ok = is_fwd() && data_type == desc()->data_desc.data_type
++                    && !has_zero_dim_memory()
++                    && attr()->has_default_values(sm::post_ops)
++                    && po.len() == 0;
++            if (!ok) return status::unimplemented;
++
++            auto conf_status = acl_eltwise_utils::init_conf_eltwise(
++                    aep_, data_md_, *desc(), *attr());
++            if (conf_status != status::success) return status::unimplemented;
++
++            acl_common_utils::acl_thread_bind();
++
++            return status::success;
++        }
++
++        acl_eltwise_conf_t aep_;
++    };
++
++    acl_eltwise_fwd_t(const pd_t *apd) : primitive_t(apd) {}
++
++    using data_t = typename prec_traits<data_type>::type;
++
++    status_t execute(const exec_ctx_t &ctx) const override {
++        return execute_forward(ctx);
++    }
++
++    status_t create_resource(
++            engine_t *engine, resource_mapper_t &mapper) const override {
++        if (mapper.has_resource(this)) return status::success;
++
++        auto r = utils::make_unique<acl_eltwise_resource_t>();
++        if (!r) return status::out_of_memory;
++
++        // Configure the resource based on information from primitive descriptor
++        auto st = r->configure(pd()->aep_);
++        if (st == status::success) { mapper.add(this, std::move(r)); }
++
++        return st;
++    }
++
++private:
++    // execute_forward has to be const thus mutability of mtx
++    mutable std::mutex mtx;
++    status_t execute_forward(const exec_ctx_t &ctx) const;
++    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
++}; // acl_eltwise_fwd_t
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_ELTWISE_HPP
+diff --git a/src/cpu/aarch64/acl_eltwise_utils.cpp b/src/cpu/aarch64/acl_eltwise_utils.cpp
+new file mode 100644
+index 000000000..35e809e04
+--- /dev/null
++++ b/src/cpu/aarch64/acl_eltwise_utils.cpp
+@@ -0,0 +1,125 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_eltwise_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++using namespace dnnl::impl::status;
++using namespace dnnl::impl::utils;
++using namespace dnnl::impl::alg_kind;
++using namespace prop_kind;
++using namespace data_type;
++using uint = unsigned int;
++
++namespace acl_eltwise_utils {
++
++status_t acl_eltwise_check(acl_eltwise_conf_t &aep, memory_desc_t &data_md,
++        const eltwise_desc_t &ed, const primitive_attr_t &attr) {
++
++    const memory_desc_wrapper data_d(&data_md);
++
++    const int ndims = data_d.ndims();
++    const bool is_1d = ndims == 3;
++    const bool is_3d = ndims == 5;
++    const bool is_int8 = one_of(ed.data_desc.data_type, s8, u8);
++    bool is_nspc {true};
++
++    // Compute Library unsupported shape scenarios
++    if (one_of(true, is_3d, is_1d)) { return status::unimplemented; }
++
++    const alg_kind_t eltwise_alg = ed.alg_kind;
++
++    bool activation_supported = acl_common_utils::acl_act_ok(eltwise_alg);
++    if (!activation_supported) { return status::unimplemented; }
++
++    // batch size
++    const int mb = data_d.dims()[0];
++
++    // src/dst channels, height, width
++    const int ic = data_d.dims()[1];
++    const int ih = data_d.dims()[ndims - 2];
++    const int iw = data_d.dims()[ndims - 1];
++
++    const int oc = ic;
++    const int oh = ih;
++    const int ow = iw;
++
++    auto data_tag = memory_desc_matches_one_of_tag(
++            data_md, format_tag::nhwc, format_tag::nchw);
++    if (data_tag == format_tag::undef) { return status::unimplemented; }
++
++    is_nspc = utils::one_of(data_tag, format_tag::nhwc);
++    const auto acl_layout = is_nspc ? arm_compute::DataLayout::NHWC
++                                    : arm_compute::DataLayout::NCHW;
++
++    auto acl_src_data_t = acl_common_utils::get_acl_data_t(data_d.data_type());
++    auto acl_dst_data_t = acl_common_utils::get_acl_data_t(data_d.data_type());
++
++    // clang-format off
++    aep.src_info = arm_compute::TensorInfo(
++            is_nspc ? arm_compute::TensorShape(ic, iw, ih, mb) :
++            arm_compute::TensorShape(iw, ih, ic, mb),
++            1,
++            acl_src_data_t,
++            acl_layout);
++
++    aep.dst_info = arm_compute::TensorInfo(
++            is_nspc ? arm_compute::TensorShape(oc, ow, oh, mb) :
++            arm_compute::TensorShape(ow, oh, oc, mb),
++            1,
++            acl_dst_data_t,
++            acl_layout);
++    // clang-format on
++
++    if (is_int8) {
++        aep.src_info.set_quantization_info(arm_compute::QuantizationInfo(1, 0));
++        aep.dst_info.set_quantization_info(arm_compute::QuantizationInfo(1, 0));
++    }
++
++    aep.act_info = acl_common_utils::get_acl_act(ed);
++
++    return status::success;
++}
++
++status_t init_conf_eltwise(acl_eltwise_conf_t &aep, memory_desc_t &data_md,
++        const eltwise_desc_t &ed, const primitive_attr_t &attr) {
++
++    // General Compute Library checks
++    CHECK(acl_eltwise_check(aep, data_md, ed, attr));
++
++    // clang-format off
++    auto acl_st = arm_compute::NEActivationLayer::validate(
++        &aep.src_info,
++        &aep.dst_info,
++        aep.act_info);
++    // clang-format on
++    if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
++        return status::unimplemented;
++    }
++
++    return status::success;
++}
++
++} // namespace acl_eltwise_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_eltwise_utils.hpp b/src/cpu/aarch64/acl_eltwise_utils.hpp
+new file mode 100644
+index 000000000..84be9b2d7
+--- /dev/null
++++ b/src/cpu/aarch64/acl_eltwise_utils.hpp
+@@ -0,0 +1,53 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_ELTWISE_UTILS_HPP
++#define CPU_AARCH64_ACL_ELTWISE_UTILS_HPP
++
++#include "cpu/cpu_convolution_pd.hpp"
++
++#include "cpu/aarch64/acl_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_eltwise_obj_t {
++    arm_compute::NEActivationLayer act;
++    arm_compute::Tensor src_tensor;
++    arm_compute::Tensor dst_tensor;
++};
++
++struct acl_eltwise_conf_t {
++    arm_compute::ActivationLayerInfo act_info;
++    arm_compute::TensorInfo src_info;
++    arm_compute::TensorInfo dst_info;
++};
++
++namespace acl_eltwise_utils {
++
++status_t init_conf_eltwise(acl_eltwise_conf_t &aep, memory_desc_t &data_md,
++        const eltwise_desc_t &ed, const primitive_attr_t &attr);
++
++} // namespace acl_eltwise_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_ELTWISE_UTILS_HPP
+diff --git a/src/cpu/aarch64/acl_gemm_convolution.cpp b/src/cpu/aarch64/acl_gemm_convolution.cpp
+index 82158e21d..e4b92a126 100644
+--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
++++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
+@@ -14,72 +14,30 @@
+ * limitations under the License.
+ *******************************************************************************/
+ 
+-#include "oneapi/dnnl/dnnl_types.h"
+-
+-#include "common/c_types_map.hpp"
+-#include "common/dnnl_thread.hpp"
+-#include "common/type_helpers.hpp"
+-#include "common/utils.hpp"
+ #include "cpu/aarch64/acl_gemm_convolution.hpp"
+ 
+-#include <cstring>
+-
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+ namespace aarch64 {
+ 
+-using namespace dnnl::impl::status;
+-using namespace dnnl::impl::memory_tracking::names;
+-using namespace dnnl::impl::utils;
+-
++// src_type is enum and is mapped to src_data_t via
++// prec_traits<src_type>::type src_data_t
+ template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type,
+         data_type_t bia_type>
+ status_t acl_gemm_convolution_fwd_t<src_type, wei_type, dst_type,
+         bia_type>::execute_forward(const exec_ctx_t &ctx) const {
+-    status_t status = status::success;
+-    auto src_base = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
+-    auto wei_base = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
+-    auto bia_base = CTX_IN_MEM(const bia_data_t *, DNNL_ARG_BIAS);
+-    auto dst_base = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
+-
+-    bool with_bias = pd()->acp_.with_bias;
+-    bool sum_with_eltwise = pd()->acp_.sum_with_eltwise;
+-
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
+     // Retrieve primitive resource and configured Compute Library objects
+     auto *acl_resource = ctx.get_resource_mapper()->get<acl_resource_t>(this);
+     acl_obj_t<arm_compute::NEGEMMConvolutionLayer> &acl_obj
+             = acl_resource->get_acl_obj();
+ 
+-    acl_obj.src_tensor.allocator()->import_memory(
+-            const_cast<src_data_t *>(src_base));
+-    acl_obj.wei_tensor.allocator()->import_memory(
+-            const_cast<wei_data_t *>(wei_base));
+-    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
+-
+-    // Retrieve extra bias memory from the scratchpad and copy from user memory
+-    if (with_bias) {
+-        const auto scratchpad = ctx.get_scratchpad_grantor();
+-        auto *bia_memory = scratchpad.template get<bia_data_t>(
+-                memory_tracking::names::key_none);
+-        size_t oc = acl_obj.bia_tensor.info()->tensor_shape()[0];
+-        std::memcpy(bia_memory, bia_base, oc * sizeof(bia_data_t));
+-        acl_obj.bia_tensor.allocator()->import_memory(bia_memory);
+-    }
+-
+-    acl_obj.conv.run();
+-
+-    if (sum_with_eltwise) {
+-        acl_obj.add.run();
+-        acl_obj.act.run();
+-    }
+-
+-    acl_obj.src_tensor.allocator()->free();
+-    acl_obj.wei_tensor.allocator()->free();
+-    acl_obj.dst_tensor.allocator()->free();
+-    if (with_bias) { acl_obj.bia_tensor.allocator()->free(); }
+-
+-    return status;
++    return execute_forward_conv_acl<
++            acl_obj_t<arm_compute::NEGEMMConvolutionLayer>, pd_t, src_data_t,
++            wei_data_t, dst_data_t, bia_data_t>(ctx, acl_obj, pd());
+ }
+ 
+ using namespace data_type;
+diff --git a/src/cpu/aarch64/acl_gemm_convolution.hpp b/src/cpu/aarch64/acl_gemm_convolution.hpp
+index 15f8ab06b..5ac3ffde9 100644
+--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
++++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
+@@ -17,17 +17,9 @@
+ #ifndef CPU_AARCH64_ACL_GEMM_CONVOLUTION_HPP
+ #define CPU_AARCH64_ACL_GEMM_CONVOLUTION_HPP
+ 
+-#include "common/c_types_map.hpp"
+-#include "common/memory_tracking.hpp"
+-#include "common/primitive.hpp"
+-
+-#include "cpu/aarch64/acl_convolution_utils.hpp"
+-#include "cpu/gemm/gemm.hpp"
+-
+ #include "cpu/cpu_convolution_pd.hpp"
+ 
+-#include "arm_compute/runtime/NEON/NEFunctions.h"
+-#include "arm_compute/runtime/Scheduler.h"
++#include "cpu/aarch64/acl_convolution_utils.hpp"
+ 
+ namespace dnnl {
+ namespace impl {
+@@ -115,13 +107,7 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
+                     src_md_, weights_md_, dst_md_, bias_md_, *desc(), *attr());
+             if (conf_status != status::success) return status::unimplemented;
+ 
+-            // Number of threads in Compute Library is set by OMP_NUM_THREADS
+-            // dnnl_get_max_threads() == OMP_NUM_THREADS
+-
+-            arm_compute::IScheduler::BindFunc linear
+-                    = [](int i, int max_cores) { return i % max_cores; };
+-            arm_compute::Scheduler::get().set_num_threads_with_affinity(
+-                    dnnl_get_max_threads(), linear);
++            acl_common_utils::acl_thread_bind();
+ 
+             // TODO: remove dependence on scratchpad memory
+             // Using user provided memory for the biases currently segfaults
+@@ -154,6 +140,8 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
+         }
+ 
+         bool post_ops_ok() const {
++            using namespace data_type;
++            using namespace alg_kind;
+             auto const &po = attr()->post_ops_;
+             auto is_eltwise
+                     = [&](int idx) { return po.entry_[idx].is_eltwise(); };
+@@ -167,7 +155,7 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
+             // sum+eltwise post-ops
+             if (eltwise_only || sum_with_eltwise) {
+                 const auto act_type = po.entry_[sum_with_eltwise].eltwise.alg;
+-                eltwise_ok = acl_convolution_utils::acl_act_ok(act_type);
++                eltwise_ok = acl_common_utils::acl_act_ok(act_type);
+             }
+ 
+             return eltwise_ok || (po.len() == 0);
+@@ -200,6 +188,8 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
+     }
+ 
+ private:
++    // To guard the const execute_forward(), the mutex must be 'mutable'
++    mutable std::mutex mtx;
+     status_t execute_forward(const exec_ctx_t &ctx) const;
+     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+ 
+diff --git a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+index c975c516b..204192c45 100644
+--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
++++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+@@ -23,14 +23,9 @@ namespace aarch64 {
+ 
+ status_t acl_indirect_gemm_convolution_fwd_t::execute_forward(
+         const exec_ctx_t &ctx) const {
+-    status_t status = status::success;
+-    auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+-    auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
+-    auto bia_base = CTX_IN_MEM(const data_t *, DNNL_ARG_BIAS);
+-    auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+-
+-    bool with_bias = pd()->acp_.with_bias;
+-
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
+     // Retrieve primitive resource and configured Compute Library objects
+     auto *acl_resource
+             = ctx.get_resource_mapper()->get<acl_indirect_gemm_resource_t>(
+@@ -38,30 +33,8 @@ status_t acl_indirect_gemm_convolution_fwd_t::execute_forward(
+     acl_obj_t<arm_compute::NEGEMMConv2d> &acl_indirect_gemm_obj
+             = acl_resource->get_acl_obj();
+ 
+-    acl_indirect_gemm_obj.src_tensor.allocator()->import_memory(
+-            const_cast<data_t *>(src_base));
+-    acl_indirect_gemm_obj.wei_tensor.allocator()->import_memory(
+-            const_cast<data_t *>(wei_base));
+-    acl_indirect_gemm_obj.dst_tensor.allocator()->import_memory(dst_base);
+-
+-    // Retrieve extra bias memory from the scratchpad and copy from user memory
+-    if (with_bias) {
+-        const auto scratchpad = ctx.get_scratchpad_grantor();
+-        data_t *bia_memory = scratchpad.template get<data_t>(
+-                memory_tracking::names::key_none);
+-        size_t oc = acl_indirect_gemm_obj.bia_tensor.info()->tensor_shape()[0];
+-        std::memcpy(bia_memory, bia_base, oc * sizeof(data_t));
+-        acl_indirect_gemm_obj.bia_tensor.allocator()->import_memory(bia_memory);
+-    }
+-
+-    acl_indirect_gemm_obj.conv.run();
+-
+-    acl_indirect_gemm_obj.src_tensor.allocator()->free();
+-    acl_indirect_gemm_obj.wei_tensor.allocator()->free();
+-    acl_indirect_gemm_obj.dst_tensor.allocator()->free();
+-    if (with_bias) { acl_indirect_gemm_obj.bia_tensor.allocator()->free(); }
+-
+-    return status;
++    return execute_forward_conv_acl<acl_obj_t<arm_compute::NEGEMMConv2d>, pd_t,
++            data_t>(ctx, acl_indirect_gemm_obj, pd());
+ }
+ 
+ } // namespace aarch64
+diff --git a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+index c038770f8..f338623dd 100644
+--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
++++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+@@ -17,16 +17,9 @@
+ #ifndef CPU_AARCH64_ACL_INDIRECT_GEMM_CONVOLUTION_HPP
+ #define CPU_AARCH64_ACL_INDIRECT_GEMM_CONVOLUTION_HPP
+ 
+-#include "common/primitive.hpp"
+-#include "common/utils.hpp"
+-
+-#include "cpu/aarch64/acl_convolution_utils.hpp"
+-
+ #include "cpu/cpu_convolution_pd.hpp"
+ 
+-#include "arm_compute/runtime/FunctionDescriptors.h"
+-#include "arm_compute/runtime/NEON/NEFunctions.h"
+-#include "arm_compute/runtime/Scheduler.h"
++#include "cpu/aarch64/acl_convolution_utils.hpp"
+ 
+ namespace dnnl {
+ namespace impl {
+@@ -34,7 +27,6 @@ namespace cpu {
+ namespace aarch64 {
+ 
+ struct acl_indirect_gemm_resource_t : public resource_t {
+-
+     acl_indirect_gemm_resource_t()
+         : acl_obj_(utils::make_unique<acl_obj_t<arm_compute::NEGEMMConv2d>>()) {
+     }
+@@ -47,19 +39,32 @@ struct acl_indirect_gemm_resource_t : public resource_t {
+         acl_obj_->wei_tensor.allocator()->init(acp.wei_info);
+         acl_obj_->dst_tensor.allocator()->init(acp.dst_info);
+         acl_obj_->bia_tensor.allocator()->init(acp.bia_info);
+-
++        if (acp.sum_with_eltwise) {
++            acl_obj_->dst_acc_tensor.allocator()->init(acp.dst_info);
++        }
+         // clang-format off
+         acl_obj_->conv.configure(
+             &acl_obj_->src_tensor,
+             &acl_obj_->wei_tensor,
+             acp.with_bias ? &acl_obj_->bia_tensor : nullptr,
+-            &acl_obj_->dst_tensor,
++            acp.sum_with_eltwise ? &acl_obj_->dst_acc_tensor
++                                 : &acl_obj_->dst_tensor,
+             arm_compute::Conv2dInfo(acp.padstride_info,
+                                     acp.dilation_info,
+-                                    acp.act_info,
++                                    acp.sum_with_eltwise
++                                        ? arm_compute::ActivationLayerInfo()
++                                        : acp.act_info,
+                                     false,
+                                     1));
+         // clang-format on
++        if (acp.sum_with_eltwise) {
++            acl_obj_->add.configure(&acl_obj_->dst_tensor,
++                    &acl_obj_->dst_acc_tensor, &acl_obj_->dst_acc_tensor,
++                    arm_compute::ConvertPolicy::SATURATE);
++            acl_obj_->act.configure(&acl_obj_->dst_acc_tensor,
++                    &acl_obj_->dst_tensor, acp.act_info);
++            acl_obj_->dst_acc_tensor.allocator()->allocate();
++        }
+ 
+         return status::success;
+     }
+@@ -104,13 +109,7 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
+                     *attr());
+             if (conf_status != status::success) return status::unimplemented;
+ 
+-            // Number of threads in Compute Library is set by OMP_NUM_THREADS
+-            // dnnl_get_max_threads() == OMP_NUM_THREADS
+-
+-            arm_compute::IScheduler::BindFunc linear
+-                    = [](int i, int max_cores) { return i % max_cores; };
+-            arm_compute::Scheduler::get().set_num_threads_with_affinity(
+-                    dnnl_get_max_threads(), linear);
++            acl_common_utils::acl_thread_bind();
+ 
+             // TODO: remove dependence on scratchpad memory
+             // Using user provided memory for the biases currently segfaults
+@@ -133,12 +132,17 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
+             auto const &po = attr()->post_ops_;
+             auto is_eltwise
+                     = [&](int idx) { return po.entry_[idx].is_eltwise(); };
++            auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
+ 
++            bool sum_with_eltwise
++                    = (po.len() == 2) && is_sum(0) && is_eltwise(1);
++            bool eltwise_only = (po.len() == 1) ? is_eltwise(0) : false;
+             bool eltwise_ok = false;
+-            // Compute Library supports only one eltwise post-op
+-            if (po.len() == 1 && is_eltwise(0)) {
+-                const auto act_type = po.entry_[0].eltwise.alg;
+-                eltwise_ok = acl_convolution_utils::acl_act_ok(act_type);
++            // Compute Library supports only one eltwise post-op or
++            // sum+eltwise post-ops
++            if (eltwise_only || sum_with_eltwise) {
++                const auto act_type = po.entry_[sum_with_eltwise].eltwise.alg;
++                eltwise_ok = acl_common_utils::acl_act_ok(act_type);
+             }
+ 
+             return eltwise_ok || (po.len() == 0);
+@@ -168,6 +172,8 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
+     }
+ 
+ private:
++    // To guard the const execute_forward(), the mutex must be 'mutable'
++    mutable std::mutex mtx;
+     status_t execute_forward(const exec_ctx_t &ctx) const;
+     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+ };
+diff --git a/src/cpu/aarch64/acl_inner_product.cpp b/src/cpu/aarch64/acl_inner_product.cpp
+new file mode 100644
+index 000000000..7a316135f
+--- /dev/null
++++ b/src/cpu/aarch64/acl_inner_product.cpp
+@@ -0,0 +1,73 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_inner_product.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++using namespace dnnl::impl::status;
++using namespace dnnl::impl::memory_tracking::names;
++using namespace dnnl::impl::utils;
++
++status_t acl_inner_product_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
++
++    status_t status = status::success;
++    auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
++    auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
++    auto bia_base = CTX_IN_MEM(const data_t *, DNNL_ARG_BIAS);
++    auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
++
++    bool with_bias = pd()->aip_.with_bias;
++    bool with_sum = pd()->aip_.with_sum;
++
++    // Retrieve primitive resource and configured Compute Library objects
++    auto *acl_resource
++            = ctx.get_resource_mapper()->get<acl_ip_resource_t>(this);
++    acl_ip_obj_t &acl_obj = acl_resource->get_acl_obj();
++
++    // import_memory() and free() methods do not allocate/free any additional
++    // memory, only acquire/release pointers.
++    acl_obj.src_tensor.allocator()->import_memory(
++            const_cast<data_t *>(src_base));
++    acl_obj.wei_tensor.allocator()->import_memory(
++            const_cast<data_t *>(wei_base));
++    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
++    if (with_bias) {
++        acl_obj.bia_tensor.allocator()->import_memory(
++                const_cast<data_t *>(bia_base));
++    }
++
++    acl_obj.fc.run();
++    if (with_sum) { acl_obj.add.run(); }
++
++    acl_obj.src_tensor.allocator()->free();
++    acl_obj.wei_tensor.allocator()->free();
++    acl_obj.dst_tensor.allocator()->free();
++    if (with_bias) { acl_obj.bia_tensor.allocator()->free(); }
++
++    return status;
++}
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_inner_product.hpp b/src/cpu/aarch64/acl_inner_product.hpp
+new file mode 100644
+index 000000000..1544ba58a
+--- /dev/null
++++ b/src/cpu/aarch64/acl_inner_product.hpp
+@@ -0,0 +1,155 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_INNER_PRODUCT_HPP
++#define CPU_AARCH64_ACL_INNER_PRODUCT_HPP
++
++#include "cpu/cpu_inner_product_pd.hpp"
++
++#include "cpu/aarch64/acl_inner_product_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_ip_resource_t : public resource_t {
++    acl_ip_resource_t() : acl_ip_obj_(utils::make_unique<acl_ip_obj_t>()) {}
++
++    status_t configure(const acl_ip_conf_t &aip) {
++        if (!acl_ip_obj_) return status::out_of_memory;
++
++        // Init Compute Library tensors based on info from descriptor
++        acl_ip_obj_->src_tensor.allocator()->init(aip.src_info);
++        acl_ip_obj_->wei_tensor.allocator()->init(aip.wei_info);
++        acl_ip_obj_->dst_tensor.allocator()->init(aip.dst_info);
++        acl_ip_obj_->bia_tensor.allocator()->init(aip.bia_info);
++        if (aip.with_sum) {
++            acl_ip_obj_->dst_acc_tensor.allocator()->init(aip.dst_info);
++        }
++
++        // clang-format off
++        acl_ip_obj_->fc.configure(
++            &acl_ip_obj_->src_tensor,
++            &acl_ip_obj_->wei_tensor,
++            aip.with_bias ? &acl_ip_obj_->bia_tensor : nullptr,
++            aip.with_sum ? &acl_ip_obj_->dst_acc_tensor : &acl_ip_obj_->dst_tensor,
++            aip.fc_info);
++        // clang-format on
++        if (aip.with_sum) {
++            acl_ip_obj_->add.configure(&acl_ip_obj_->dst_tensor,
++                    &acl_ip_obj_->dst_acc_tensor, &acl_ip_obj_->dst_tensor,
++                    arm_compute::ConvertPolicy::SATURATE);
++            acl_ip_obj_->dst_acc_tensor.allocator()->allocate();
++        }
++
++        return status::success;
++    }
++
++    acl_ip_obj_t &get_acl_obj() const { return *acl_ip_obj_; }
++
++    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_ip_resource_t);
++
++private:
++    std::unique_ptr<acl_ip_obj_t> acl_ip_obj_;
++}; // acl_ip_resource_t
++
++struct acl_inner_product_fwd_t : public primitive_t {
++    struct pd_t : public cpu_inner_product_fwd_pd_t {
++        using cpu_inner_product_fwd_pd_t::cpu_inner_product_fwd_pd_t;
++
++        DECLARE_COMMON_PD_T("inner_product:acl", acl_inner_product_fwd_t);
++
++        status_t init(engine_t *engine) {
++            using namespace utils;
++
++            const bool ok = is_fwd() && !has_zero_dim_memory()
++                    && expect_data_types(data_type::f32, data_type::f32,
++                            data_type::f32, data_type::f32, data_type::f32)
++                    && attr()->has_default_values(
++                            primitive_attr_t::skip_mask_t::post_ops,
++                            data_type::f32)
++                    && (set_default_params() == status::success)
++                    && post_ops_ok();
++
++            if (!ok) return status::unimplemented;
++
++            auto conf_status = acl_inner_product_utils::init_conf_ip(aip_,
++                    src_md_, weights_md_, dst_md_, bias_md_, *desc(), *attr());
++
++            if (conf_status != status::success) return status::unimplemented;
++
++            acl_common_utils::acl_thread_bind();
++
++            return status::success;
++        }
++
++        acl_ip_conf_t aip_;
++
++    protected:
++        bool post_ops_ok() const {
++            auto const &po = attr()->post_ops_;
++            auto is_eltwise
++                    = [&](int idx) { return po.entry_[idx].is_eltwise(); };
++            auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
++
++            bool eltwise_ok = false;
++            // Compute Library supports here only one eltwise post-op or sum
++            if (po.len() == 1 && is_eltwise(0)) {
++                const auto act_type = po.entry_[0].eltwise.alg;
++                eltwise_ok = acl_common_utils::acl_act_ok(act_type);
++            }
++
++            return eltwise_ok || (po.len() == 1 && is_sum(0))
++                    || (po.len() == 0);
++        }
++    }; // pd_t
++
++    acl_inner_product_fwd_t(const pd_t *apd) : primitive_t(apd) {}
++
++    status_t create_resource(
++            engine_t *engine, resource_mapper_t &mapper) const override {
++        if (mapper.has_resource(this)) return status::success;
++
++        auto r = utils::make_unique<acl_ip_resource_t>();
++        if (!r) return status::out_of_memory;
++
++        // Configure the resource based on information from primitive descriptor
++        auto st = r->configure(pd()->aip_);
++        if (st == status::success) { mapper.add(this, std::move(r)); }
++
++        return st;
++    }
++
++    using data_t = typename prec_traits<data_type::f32>::type;
++
++    status_t execute(const exec_ctx_t &ctx) const override {
++        return execute_forward(ctx);
++    }
++
++private:
++    //To guard the const execute_forward, the mutex must be 'mutable'
++    mutable std::mutex mtx;
++    status_t execute_forward(const exec_ctx_t &ctx) const;
++    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
++}; // acl_inner_product_fwd_t
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_INNER_PRODUCT_HPP
+diff --git a/src/cpu/aarch64/acl_inner_product_utils.cpp b/src/cpu/aarch64/acl_inner_product_utils.cpp
+new file mode 100644
+index 000000000..8a8d1cc93
+--- /dev/null
++++ b/src/cpu/aarch64/acl_inner_product_utils.cpp
+@@ -0,0 +1,158 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_inner_product_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++namespace acl_inner_product_utils {
++
++using namespace format_tag;
++using namespace utils;
++using namespace status;
++
++status_t init_conf_ip(acl_ip_conf_t &aip, memory_desc_t &src_md,
++        memory_desc_t &wei_md, memory_desc_t &dst_md, memory_desc_t &bias_md,
++        const inner_product_desc_t &ipd, const primitive_attr_t &attr) {
++    const memory_desc_wrapper src_d(&src_md);
++    const memory_desc_wrapper wei_d(&wei_md);
++    const memory_desc_wrapper dst_d(&dst_md);
++    const memory_desc_wrapper bia_d(&bias_md);
++
++    // Compute Library currently supports forward propagation only
++    const prop_kind_t prop_kind = ipd.prop_kind;
++    const bool is_fwd = (prop_kind == dnnl_forward_training)
++            || (prop_kind == dnnl_forward_inference);
++    if (!is_fwd) return status::unimplemented;
++
++    const int with_groups = wei_d.ndims() == src_d.ndims() + 1;
++    const int ndims = src_d.ndims();
++
++    // There are two sub-cases: src & wei tensors are either 2- or 4-dimensional
++    const bool is_2d = (ndims == 2) && (wei_d.ndims() == 2);
++    const bool is_4d = (ndims == 4) && (wei_d.ndims() == 4);
++
++    // Compute Library unsupported shape scenarios
++    // FP32 only is supported at the moment
++    if (one_of(true, !(is_4d || is_2d), with_groups)) { return unimplemented; }
++
++    // batch size
++    const int mb = src_d.dims()[0];
++
++    // src/input channels, height, width
++    const int ic = src_d.dims()[1];
++    const int ih = is_4d ? src_d.dims()[ndims - 2] : 0;
++    const int iw = is_4d ? src_d.dims()[ndims - 1] : 0;
++
++    // dst/output channels
++    const int oc = dst_d.dims()[1];
++
++    // weights height, width
++    const int kh = is_4d ? wei_d.dims()[with_groups + ndims - 2] : 0;
++    const int kw = is_4d ? wei_d.dims()[with_groups + ndims - 1] : 0;
++
++    aip.with_bias = ipd.bias_desc.format_kind != format_kind::undef;
++
++    // Data layout is already defined thus should only be checked
++    auto src_tag = memory_desc_matches_one_of_tag(src_md, nhwc, nchw, nc, cn);
++    auto wei_tag = memory_desc_matches_one_of_tag(wei_md, ohwi, oihw, oi, io);
++    auto dst_tag = memory_desc_matches_one_of_tag(dst_md, nc, cn);
++    if (one_of(format_tag::undef, src_tag, wei_tag, dst_tag)) {
++        return status::unimplemented;
++    }
++
++    arm_compute::TensorShape src_shape {(src_tag == nc)
++                    ? arm_compute::TensorShape(ic, mb)
++                    : arm_compute::TensorShape(mb, ic)};
++    if (is_4d) {
++        src_shape = (src_tag == nhwc)
++                ? arm_compute::TensorShape(ic, iw, ih, mb)
++                : arm_compute::TensorShape(iw, ih, ic, mb);
++    }
++
++    // Compute Library requires the weights to be 2-dimensional for FC layer
++    arm_compute::TensorShape wei_shape {
++            arm_compute::TensorShape(is_4d ? ic * kh * kw : ic, oc)};
++    if (is_2d && wei_tag == io) {
++        wei_shape = arm_compute::TensorShape(oc, ic);
++    }
++
++    arm_compute::DataLayout wei_layout {(wei_tag == ohwi || wei_tag == oi)
++                    ? arm_compute::DataLayout::NHWC
++                    : arm_compute::DataLayout::NCHW};
++
++    // clang-format off
++    aip.src_info = arm_compute::TensorInfo(
++            src_shape,
++            1,
++            arm_compute::DataType::F32,
++            (src_tag == nhwc || src_tag == nc) ?
++            arm_compute::DataLayout::NHWC : arm_compute::DataLayout::NCHW);
++
++    aip.wei_info = arm_compute::TensorInfo(
++            wei_shape,
++            1,
++            arm_compute::DataType::F32,
++            wei_layout);
++
++    aip.dst_info = arm_compute::TensorInfo(
++            (dst_tag == nhwc || dst_tag == nc) ?
++            arm_compute::TensorShape(oc, mb) : arm_compute::TensorShape(mb, oc),
++            1,
++            arm_compute::DataType::F32,
++            (dst_tag == nhwc || dst_tag == nc) ?
++            arm_compute::DataLayout::NHWC : arm_compute::DataLayout::NCHW);
++
++    aip.bia_info = arm_compute::TensorInfo(
++            aip.with_bias ?
++            arm_compute::TensorShape(oc) : arm_compute::TensorShape(),
++            1,
++            arm_compute::DataType::F32);
++    // clang-format on
++
++    aip.fc_info.weights_trained_layout = wei_layout;
++    if (is_2d && wei_tag != src_tag) { aip.fc_info.transpose_weights = false; }
++
++    // Either activation or sum is supported as post-op at the moment
++    aip.fc_info.activation_info = acl_common_utils::get_acl_act(attr);
++    const auto &post_ops = attr.post_ops_;
++    aip.with_sum = (post_ops.len() == 1) && post_ops.entry_[0].is_sum();
++
++    // clang-format off
++    // Validate convolution manually to check for return status
++    auto acl_st = arm_compute::NEFullyConnectedLayer::validate(
++        &aip.src_info,
++        &aip.wei_info,
++        aip.with_bias ? &aip.bia_info : nullptr,
++        &aip.dst_info,
++	aip.fc_info);
++    // clang-format on
++    if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
++        return status::unimplemented;
++    }
++
++    return status::success;
++}
++
++} // namespace acl_inner_product_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_inner_product_utils.hpp b/src/cpu/aarch64/acl_inner_product_utils.hpp
+new file mode 100644
+index 000000000..022d0e334
+--- /dev/null
++++ b/src/cpu/aarch64/acl_inner_product_utils.hpp
+@@ -0,0 +1,62 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_INNER_PRODUCT_UTILS_HPP
++#define CPU_AARCH64_ACL_INNER_PRODUCT_UTILS_HPP
++
++#include "cpu/cpu_inner_product_pd.hpp"
++
++#include "cpu/aarch64/acl_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_ip_obj_t {
++    arm_compute::NEFullyConnectedLayer fc;
++    arm_compute::NEArithmeticAddition add;
++    arm_compute::Tensor src_tensor;
++    arm_compute::Tensor wei_tensor;
++    arm_compute::Tensor bia_tensor;
++    arm_compute::Tensor dst_tensor;
++    arm_compute::Tensor dst_acc_tensor;
++};
++
++struct acl_ip_conf_t {
++    bool with_bias;
++    bool with_sum;
++    arm_compute::TensorInfo src_info;
++    arm_compute::TensorInfo wei_info;
++    arm_compute::TensorInfo bia_info;
++    arm_compute::TensorInfo dst_info;
++    arm_compute::FullyConnectedLayerInfo fc_info;
++};
++
++namespace acl_inner_product_utils {
++
++status_t init_conf_ip(acl_ip_conf_t &aip, memory_desc_t &src_md,
++        memory_desc_t &wei_md, memory_desc_t &dst_md, memory_desc_t &bias_md,
++        const inner_product_desc_t &ipd, const primitive_attr_t &attr);
++
++} // namespace acl_inner_product_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_INNER_PRODUCT_UTILS_HPP
+diff --git a/src/cpu/aarch64/acl_utils.cpp b/src/cpu/aarch64/acl_utils.cpp
+new file mode 100644
+index 000000000..ba625c770
+--- /dev/null
++++ b/src/cpu/aarch64/acl_utils.cpp
+@@ -0,0 +1,122 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++namespace acl_common_utils {
++
++using namespace dnnl::impl::alg_kind;
++using namespace data_type;
++
++arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt) {
++    switch (dt) {
++        case bf16: return arm_compute::DataType::BFLOAT16; break;
++        case f32: return arm_compute::DataType::F32; break;
++        case s32: return arm_compute::DataType::S32; break;
++        case f16: return arm_compute::DataType::F16; break;
++        case s8: return arm_compute::DataType::QASYMM8_SIGNED; break;
++        case u8: return arm_compute::DataType::QASYMM8; break;
++        default: return arm_compute::DataType::UNKNOWN;
++    }
++}
++
++arm_compute::ActivationLayerInfo convert_to_acl_act(
++        const alg_kind_t eltwise_alg, const float alpha, const float beta) {
++    using acl_act_t = arm_compute::ActivationLayerInfo::ActivationFunction;
++    acl_act_t acl_act_alg;
++
++    switch (eltwise_alg) {
++        case eltwise_relu:
++            // oneDNN defines RELU: f(x) = (x > 0) ? x : a*x
++            // Compute Library defines LEAKY_RELU: f(x) = (x > 0) ? x : a*x
++            // whilst Compute Library RELU is defined as: f(x) = max(0,x)
++            if (alpha == 0) {
++                acl_act_alg = acl_act_t::RELU;
++            } else {
++                acl_act_alg = acl_act_t::LEAKY_RELU;
++            }
++            break;
++        case eltwise_tanh:
++            // oneDNN defines TANH activation as:          f(x) = tanh(x)
++            // Compute Library defines TANH activation as: f(x) = a*tanh(b*x)
++            // Setting a=b=1 makes the two equivalent
++            return arm_compute::ActivationLayerInfo(acl_act_t::TANH, 1.f, 1.f);
++            break;
++        case eltwise_elu: acl_act_alg = acl_act_t::ELU; break;
++        case eltwise_square: acl_act_alg = acl_act_t::SQUARE; break;
++        case eltwise_abs: acl_act_alg = acl_act_t::ABS; break;
++        case eltwise_sqrt: acl_act_alg = acl_act_t::SQRT; break;
++        case eltwise_linear: acl_act_alg = acl_act_t::LINEAR; break;
++        case eltwise_bounded_relu: acl_act_alg = acl_act_t::BOUNDED_RELU; break;
++        case eltwise_soft_relu: acl_act_alg = acl_act_t::SOFT_RELU; break;
++        case eltwise_logistic: acl_act_alg = acl_act_t::LOGISTIC; break;
++        default: return arm_compute::ActivationLayerInfo();
++    }
++
++    return arm_compute::ActivationLayerInfo(acl_act_alg, alpha, beta);
++}
++
++arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr) {
++    const auto &post_ops = attr.post_ops_;
++    const int entry_idx = post_ops.find(primitive_kind::eltwise);
++    if (entry_idx == -1) { return arm_compute::ActivationLayerInfo(); }
++
++    const auto eltwise_alg = post_ops.entry_[entry_idx].eltwise.alg;
++    float alpha = post_ops.entry_[entry_idx].eltwise.alpha;
++    float beta = post_ops.entry_[entry_idx].eltwise.beta;
++
++    return convert_to_acl_act(eltwise_alg, alpha, beta);
++}
++
++arm_compute::ActivationLayerInfo get_acl_act(const eltwise_desc_t &ed) {
++    const alg_kind_t eltwise_alg = ed.alg_kind;
++    float alpha = ed.alpha;
++    float beta = ed.beta;
++
++    return convert_to_acl_act(eltwise_alg, alpha, beta);
++}
++
++bool acl_act_ok(alg_kind_t eltwise_activation) {
++    return utils::one_of(eltwise_activation, eltwise_relu, eltwise_tanh,
++            eltwise_elu, eltwise_square, eltwise_abs, eltwise_sqrt,
++            eltwise_linear, eltwise_bounded_relu, eltwise_soft_relu,
++            eltwise_logistic);
++}
++
++void acl_thread_bind() {
++    static std::once_flag flag_once;
++    // The threads in Compute Library are bound for the cores 0..max_threads-1
++    // dnnl_get_max_threads() returns OMP_NUM_THREADS
++    const int max_threads = dnnl_get_max_threads();
++    // arm_compute::Scheduler does not support concurrent access thus a
++    // workaround here restricts it to only one call
++    std::call_once(flag_once, [&]() {
++        arm_compute::Scheduler::get().set_num_threads(
++                max_threads);
++    });
++}
++
++} // namespace acl_common_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_utils.hpp b/src/cpu/aarch64/acl_utils.hpp
+new file mode 100644
+index 000000000..9bd0036cd
+--- /dev/null
++++ b/src/cpu/aarch64/acl_utils.hpp
+@@ -0,0 +1,56 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_UTILS_HPP
++#define CPU_AARCH64_ACL_UTILS_HPP
++
++#include <mutex>
++
++#include "oneapi/dnnl/dnnl_types.h"
++
++#include "common/bfloat16.hpp"
++#include "common/c_types_map.hpp"
++#include "common/dnnl_thread.hpp"
++#include "common/memory_tracking.hpp"
++#include "common/primitive.hpp"
++#include "common/utils.hpp"
++
++#include "cpu/cpu_engine.hpp"
++
++#include "arm_compute/runtime/NEON/NEFunctions.h"
++#include "arm_compute/runtime/Scheduler.h"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++namespace acl_common_utils {
++
++arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt);
++arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr);
++arm_compute::ActivationLayerInfo get_acl_act(const eltwise_desc_t &ed);
++bool acl_act_ok(alg_kind_t eltwise_activation);
++void acl_thread_bind();
++
++} // namespace acl_common_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_UTILS_HPP
+diff --git a/src/cpu/aarch64/acl_winograd_convolution.cpp b/src/cpu/aarch64/acl_winograd_convolution.cpp
+index 8e7bc5db6..1494a3f24 100644
+--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
++++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
+@@ -1,5 +1,5 @@
+ /*******************************************************************************
+-* Copyright 2020 Arm Ltd. and affiliates
++* Copyright 2020-2021 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -14,66 +14,27 @@
+ * limitations under the License.
+ *******************************************************************************/
+ 
+-#include "dnnl_types.h"
+-
+-#include "common/c_types_map.hpp"
+-#include "common/dnnl_thread.hpp"
+-#include "common/type_helpers.hpp"
+-#include "common/utils.hpp"
+-#include "cpu/aarch64/acl_convolution_utils.hpp"
+ #include "cpu/aarch64/acl_winograd_convolution.hpp"
+ 
+-#include <cstring>
+-
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+ namespace aarch64 {
+ 
+-using namespace dnnl::impl::status;
+-using namespace dnnl::impl::memory_tracking::names;
+-using namespace dnnl::impl::utils;
+-
+ status_t acl_wino_convolution_fwd_t::execute_forward(
+         const exec_ctx_t &ctx) const {
+-    status_t status = status::success;
+-    auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+-    auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
+-    auto bia_base = CTX_IN_MEM(const data_t *, DNNL_ARG_BIAS);
+-    auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+-
+-    bool with_bias = pd()->acp_.with_bias;
+-
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
+     // Retrieve primitive resource and configured Compute Library objects
+     auto *acl_resource
+             = ctx.get_resource_mapper()->get<acl_wino_resource_t>(this);
+     acl_obj_t<arm_compute::NEWinogradConvolutionLayer> &acl_wino_obj
+             = acl_resource->get_acl_obj();
+ 
+-    acl_wino_obj.src_tensor.allocator()->import_memory(
+-            const_cast<data_t *>(src_base));
+-    acl_wino_obj.wei_tensor.allocator()->import_memory(
+-            const_cast<data_t *>(wei_base));
+-    acl_wino_obj.dst_tensor.allocator()->import_memory(dst_base);
+-
+-    // Retrieve extra bias memory from the scratchpad and copy from user memory
+-    if (with_bias) {
+-        const auto scratchpad = ctx.get_scratchpad_grantor();
+-        data_t *bia_memory = scratchpad.template get<data_t>(
+-                memory_tracking::names::key_none);
+-        size_t oc = acl_wino_obj.bia_tensor.info()->tensor_shape()[0];
+-        std::memcpy(bia_memory, bia_base, oc * sizeof(data_t));
+-        acl_wino_obj.bia_tensor.allocator()->import_memory(bia_memory);
+-    }
+-
+-    acl_wino_obj.conv.run();
+-
+-    acl_wino_obj.src_tensor.allocator()->free();
+-    acl_wino_obj.wei_tensor.allocator()->free();
+-    acl_wino_obj.dst_tensor.allocator()->free();
+-    if (with_bias) { acl_wino_obj.bia_tensor.allocator()->free(); }
+-
+-    return status;
++    return execute_forward_conv_acl<
++            acl_obj_t<arm_compute::NEWinogradConvolutionLayer>, pd_t, data_t>(
++            ctx, acl_wino_obj, pd());
+ }
+ 
+ } // namespace aarch64
+diff --git a/src/cpu/aarch64/acl_winograd_convolution.hpp b/src/cpu/aarch64/acl_winograd_convolution.hpp
+index 08e548ba0..108697129 100644
+--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
++++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
+@@ -17,19 +17,10 @@
+ #ifndef CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP
+ #define CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP
+ 
+-#include "common/c_types_map.hpp"
+-#include "common/dnnl_thread.hpp"
+-#include "common/memory_tracking.hpp"
+-#include "common/primitive.hpp"
+-
+ #include "cpu/cpu_convolution_pd.hpp"
+-#include "cpu/platform.hpp"
+ 
+ #include "cpu/aarch64/acl_convolution_utils.hpp"
+ 
+-#include "arm_compute/runtime/NEON/NEFunctions.h"
+-#include "arm_compute/runtime/NEON/NEScheduler.h"
+-
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+@@ -49,16 +40,30 @@ struct acl_wino_resource_t : public resource_t {
+         acl_wino_obj_->dst_tensor.allocator()->init(acp.dst_info);
+         acl_wino_obj_->bia_tensor.allocator()->init(acp.bia_info);
+ 
++        if (acp.sum_with_eltwise) {
++            acl_wino_obj_->dst_acc_tensor.allocator()->init(acp.dst_info);
++        }
+         // clang-format off
+         acl_wino_obj_->conv.configure(
+             &acl_wino_obj_->src_tensor,
+             &acl_wino_obj_->wei_tensor,
+             acp.with_bias ? &acl_wino_obj_->bia_tensor : nullptr,
+-            &acl_wino_obj_->dst_tensor,
++            acp.sum_with_eltwise ? &acl_wino_obj_->dst_acc_tensor
++                                 : &acl_wino_obj_->dst_tensor,
+             acp.padstride_info,
+-            acp.act_info,
++            acp.sum_with_eltwise ? arm_compute::ActivationLayerInfo()
++                                 : acp.act_info,
+             true); // to support 5x5, 7x7 filter shapes in addition to 3x3
+         // clang-format on
++        if (acp.sum_with_eltwise) {
++            acl_wino_obj_->add.configure(&acl_wino_obj_->dst_tensor,
++                    &acl_wino_obj_->dst_acc_tensor,
++                    &acl_wino_obj_->dst_acc_tensor,
++                    arm_compute::ConvertPolicy::SATURATE);
++            acl_wino_obj_->act.configure(&acl_wino_obj_->dst_acc_tensor,
++                    &acl_wino_obj_->dst_tensor, acp.act_info);
++            acl_wino_obj_->dst_acc_tensor.allocator()->allocate();
++        }
+ 
+         return status::success;
+     }
+@@ -84,7 +89,7 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
+                 "wino:acl", acl_wino_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
+ 
+         status_t init(engine_t *engine) {
+-            bool ok = true && is_fwd()
++            bool ok = is_fwd()
+                     && utils::one_of(desc()->alg_kind,
+                             alg_kind::convolution_auto,
+                             alg_kind::convolution_winograd)
+@@ -102,13 +107,7 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
+ 
+             set_default_alg_kind(alg_kind::convolution_winograd);
+ 
+-            // Number of threads in Compute Library is set by OMP_NUM_THREADS
+-            // dnnl_get_max_threads() == OMP_NUM_THREADS
+-
+-            arm_compute::IScheduler::BindFunc linear
+-                    = [](int i, int max_cores) { return i % max_cores; };
+-            arm_compute::Scheduler::get().set_num_threads_with_affinity(
+-                    dnnl_get_max_threads(), linear);
++            acl_common_utils::acl_thread_bind();
+ 
+             // TODO: remove dependence on scratchpad memory
+             // Using user provided memory for the biases currently segfaults
+@@ -129,12 +128,17 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
+             auto const &po = attr()->post_ops_;
+             auto is_eltwise
+                     = [&](int idx) { return po.entry_[idx].is_eltwise(); };
++            auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
+ 
++            bool sum_with_eltwise
++                    = (po.len() == 2) && is_sum(0) && is_eltwise(1);
++            bool eltwise_only = (po.len() == 1) ? is_eltwise(0) : false;
+             bool eltwise_ok = false;
+-            // Compute Library supports only one eltwise post-op
+-            if (po.len() == 1 && is_eltwise(0)) {
+-                const auto act_type = po.entry_[0].eltwise.alg;
+-                eltwise_ok = acl_convolution_utils::acl_act_ok(act_type);
++            // Compute Library supports only one eltwise post-op or
++            // sum+eltwise post-ops
++            if (eltwise_only || sum_with_eltwise) {
++                const auto act_type = po.entry_[sum_with_eltwise].eltwise.alg;
++                eltwise_ok = acl_common_utils::acl_act_ok(act_type);
+             }
+ 
+             return eltwise_ok || (po.len() == 0);
+@@ -166,6 +170,8 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
+     }
+ 
+ private:
++    // To guard the const execute_forward(), the mutex must be 'mutable'
++    mutable std::mutex mtx;
+     status_t execute_forward(const exec_ctx_t &ctx) const;
+     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+ 
+diff --git a/src/cpu/cpu_eltwise_list.cpp b/src/cpu/cpu_eltwise_list.cpp
+index 9fdbdf9c9..8c8126027 100644
+--- a/src/cpu/cpu_eltwise_list.cpp
++++ b/src/cpu/cpu_eltwise_list.cpp
+@@ -1,6 +1,7 @@
+ /*******************************************************************************
+ * Copyright 2019-2021 Intel Corporation
+ * Copyright 2021 FUJITSU LIMITED
++* Copyright 2021 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -29,6 +30,11 @@ using namespace dnnl::impl::cpu::x64;
+ using namespace dnnl::impl::cpu::aarch64;
+ #endif
+ 
++#if DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
++#include "cpu/aarch64/acl_eltwise.hpp"
++using namespace dnnl::impl::cpu::aarch64;
++#endif
++
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+@@ -62,6 +68,8 @@ const impl_list_item_t impl_list[] = {
+         CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s32>)
+         CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s8>)
+         CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, u8>)
++        CPU_INSTANCE_AARCH64_ACL(acl_eltwise_fwd_t<f32>)
++        CPU_INSTANCE_AARCH64_ACL(acl_eltwise_fwd_t<s8>)
+         CPU_INSTANCE(ref_eltwise_fwd_t<f32>)
+         CPU_INSTANCE(ref_eltwise_bwd_t<f32>)
+         CPU_INSTANCE(ref_eltwise_fwd_t<bf16>)
+diff --git a/src/cpu/cpu_inner_product_list.cpp b/src/cpu/cpu_inner_product_list.cpp
+index 755c74550..6b06414b6 100644
+--- a/src/cpu/cpu_inner_product_list.cpp
++++ b/src/cpu/cpu_inner_product_list.cpp
+@@ -26,6 +26,11 @@
+ using namespace dnnl::impl::cpu::x64;
+ #endif
+ 
++#if DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
++#include "cpu/aarch64/acl_inner_product.hpp"
++using namespace dnnl::impl::cpu::aarch64;
++#endif
++
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+@@ -39,6 +44,7 @@ const impl_list_item_t impl_list[] = {
+         CPU_INSTANCE_X64(brgemm_inner_product_fwd_t<avx512_core>)
+         CPU_INSTANCE_X64(brgemm_inner_product_bwd_data_t<avx512_core>)
+         CPU_INSTANCE_X64(brgemm_inner_product_bwd_weights_t<avx512_core>)
++        CPU_INSTANCE_AARCH64_ACL(acl_inner_product_fwd_t)
+         CPU_INSTANCE(gemm_inner_product_fwd_t<f32>)
+         CPU_INSTANCE(gemm_inner_product_bwd_data_t<f32>)
+         CPU_INSTANCE(gemm_inner_product_bwd_weights_t<f32>)
+


### PR DESCRIPTION
Related to issue #47415 and PR #47775. Adding support for caching inner product primitives.
Includes patch file for oneDNN to include inner product, eltwise primitives and updates to ACL thread binding.