### PR TITLE
TF-TRT C++ conversion

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -86,6 +86,62 @@ tf_cuda_cc_test(
 )
 
 cc_library(
+    name = "trt_convert_api",
+    srcs = ["trt_convert_api.cc"],
+    hdrs = [
+        "trt_convert_api.h",
+    ],
+    copts = tf_copts(),
+    deps = [
+        ":trt_resources",
+        "@com_google_absl//absl/strings",
+        "//tensorflow/core:direct_session",
+        "//tensorflow/core:framework",
+        "//tensorflow/core/grappler:grappler_item_builder",
+        "//tensorflow/core/platform:logging",
+    ] + if_tensorrt([":tensorrt_lib"]),
+)
+
+tf_cuda_cc_test(
+    name = "trt_convert_api_test",
+    size = "small",
+    srcs = ["trt_convert_api_test.cc"],
+    tags = [
+        "no_cuda_on_cpu_tap",
+        "no_windows",
+        "nomac",
+    ],
+    deps = [
+        ":common_utils",
+        ":testutils",
+        ":trt_convert_api",
+        ":trt_conversion",
+        ":trt_logging",
+        ":trt_op_kernels",
+        ":trt_resources",
+        ":utils",
+        "//tensorflow/cc:cc_ops",
+        "//tensorflow/cc:scope",
+        "//tensorflow/core:array_ops_op_lib",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:direct_session",
+        "//tensorflow/core:framework",
+        "//tensorflow/core/kernels:array",
+        "//tensorflow/core/kernels:ops_testutil",
+        "//tensorflow/core/kernels:resource_variable_ops",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:math_ops_op_lib",
+        "//tensorflow/core:no_op_op_lib",
+        "//tensorflow/core:ops",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:state_ops_op_lib",
+    ],
+)
+
+cc_library(
     name = "common_utils",
     srcs = ["common/utils.cc"],
     hdrs = [
@@ -279,6 +335,7 @@ cc_library(
     name = "trt_op_libs",
     deps = [
         ":get_calibration_data_op_op_lib",
+        ":trt_convert_api",
         ":trt_engine_op_op_lib",
         ":trt_engine_utils",
     ],

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -232,6 +232,15 @@ absl::optional<DeviceNameUtils::ParsedName> MergeIfCompatible(
     const DeviceNameUtils::ParsedName& a, absl::string_view b);
 
 // Optimization profile generation strategies.
+// - `kRange`: create one profile that works for inputs with dimension values
+//   in the range of [min_dims, max_dims] where min_dims and max_dims are
+//   derived from the provided inputs.
+// - `kOptimal`: create one profile for each input. The profile only works for
+//   inputs with the same dimensions as the input it is created for. The GPU
+//   engine will be run with optimal performance with such inputs.
+// - `kRangeOptimal`: create the profiles for both `Range` and `Optimal`.
+// - `kImplicitBatchModeCompatible`: create the profiles that will produce the
+//   same GPU engines as the implicit_batch_mode would produce.
 enum class ProfileStrategy {
   kRange,
   kOptimal,

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -455,6 +455,9 @@ TRTEngineOp::TRTEngineOp(OpKernelConstruction* context)
             << ", thus setting _profile_generation_mode=false";
     profile_generation_mode_ = false;
   }
+  if (static_engine_) {
+    if (profile_generation_mode_) profile_generation_mode_ = false;
+  }
   if (use_implicit_batch_) {
     OP_REQUIRES(context, !profile_generation_mode_,
                 errors::InvalidArgument(

--- a/tensorflow/compiler/tf2tensorrt/trt_convert_api.cc
+++ b/tensorflow/compiler/tf2tensorrt/trt_convert_api.cc
@@ -1,0 +1,371 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "trt_convert_api.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "absl/strings/str_join.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.h"
+#include "tensorflow/core/common_runtime/device.h"
+#include "tensorflow/core/common_runtime/device_mgr.h"
+#include "tensorflow/core/common_runtime/graph_constructor.h"
+#include "tensorflow/core/grappler/clusters/virtual_cluster.h"
+#include "tensorflow/core/grappler/grappler_item.h"
+#include "tensorflow/core/grappler/grappler_item_builder.h"
+#include "tensorflow/core/grappler/optimizers/meta_optimizer.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/protobuf/meta_graph.pb.h"
+#include "tensorflow/core/public/session.h"
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+namespace tensorflow {
+
+namespace tensorrt {
+namespace {
+
+Status RunGrappler(const MetaGraphDef& meta_graph_def,
+                   const std::vector<std::string>& input_names,
+                   const std::vector<std::string>& output_names,
+                   const ConfigProto& config_proto, GraphDef* out_graph_def) {
+  grappler::ItemConfig item_config;
+
+  for (const string& name : input_names) {
+    item_config.feed_nodes.insert(name);
+  }
+  for (const string& name : output_names) {
+    item_config.fetch_nodes.insert(name);
+  }
+
+  std::unique_ptr<grappler::GrapplerItem> item =
+      grappler::GrapplerItemFromMetaGraphDef("tf_graph", meta_graph_def,
+                                             item_config);
+  if (!item) {
+    return tensorflow::errors::Internal(
+        "Failed to create grappler item from MetaGraphDef.");
+  }
+
+  TF_RETURN_IF_ERROR(grappler::RunMetaOptimizer(
+      std::move(*item), config_proto, nullptr, nullptr, out_graph_def));
+  VLOG(2) << "Grappler finished\n";
+  return Status::OK();
+}
+
+Status ImportGraphDefToSession(Session* session, const GraphDef& graph_def,
+                               const string& prefix) {
+  ImportGraphDefOptions opts;
+  opts.prefix = prefix;
+  Graph graph(OpRegistry::Global());
+  TF_RETURN_IF_ERROR(ImportGraphDef(opts, graph_def, &graph, nullptr));
+  GraphDef new_graph_def;
+  graph.ToGraphDef(&new_graph_def);
+  TF_RETURN_IF_ERROR(session->Extend(new_graph_def));
+  return Status::OK();
+}
+
+Status GetTrtRewriterConfig(const TfTrtConversionParams& params,
+                            RewriterConfig* opt_config) {
+  opt_config->set_meta_optimizer_iterations(tensorflow::RewriterConfig::ONE);
+  opt_config->set_min_graph_nodes(-1);  // do not skip small graphs
+
+  // Initial transformations before TensorRTOptimizer is called
+  opt_config->add_optimizers("function");
+  opt_config->add_optimizers("constfold");
+  opt_config->add_optimizers("layout");
+  opt_config->add_optimizers("constfold");
+
+  // Parameters for TensorRTOptimizer
+  auto trt_optimizer = opt_config->add_custom_optimizers();
+  trt_optimizer->set_name("TensorRTOptimizer");
+
+  auto trt_parameter_map = trt_optimizer->mutable_parameter_map();
+  (*trt_parameter_map)["is_dynamic_op"].set_b(true);
+  (*trt_parameter_map)["minimum_segment_size"].set_i(
+      params.minimum_segment_size);
+  string prec_string;
+  TF_RETURN_IF_ERROR(
+      TrtPrecisionModeToName(params.precision_mode, &prec_string));
+  (*trt_parameter_map)["precision_mode"].set_s(prec_string);
+  (*trt_parameter_map)["max_batch_size"].set_i(1);
+  (*trt_parameter_map)["max_workspace_size_bytes"].set_i(
+      params.max_workspace_size_bytes);
+  (*trt_parameter_map)["max_cached_engines"].set_i(params.max_cached_engines);
+  (*trt_parameter_map)["use_calibration"].set_b(params.use_calibration);
+  (*trt_parameter_map)["profile_strategy"].set_s(
+      ProfileStrategyToName(params.profile_strategy));
+  (*trt_parameter_map)["use_implicit_batch"].set_b(!params.use_dynamic_shape);
+  (*trt_parameter_map)["_allow_build_at_runtime"].set_b(
+      params.allow_build_at_runtime);
+  return Status::OK();
+}
+
+// Runs TRTOptimizer grappler pass.
+Status RunTfTrt(const MetaGraphDef& meta_graph_def,
+                const std::vector<std::string>& input_names,
+                const std::vector<std::string>& output_names,
+                const RewriterConfig& rewriter_config,
+                GraphDef* segmented_graph_def) {
+  ConfigProto config_proto;
+  RewriterConfig* opt_config =
+      config_proto.mutable_graph_options()->mutable_rewrite_options();
+
+  config_proto.mutable_graph_options()->mutable_rewrite_options()->CopyFrom(
+      rewriter_config);
+
+  VLOG(4) << "Setting up Grappler parameters\n" << config_proto.DebugString();
+
+  TF_RETURN_IF_ERROR(RunGrappler(meta_graph_def, input_names, output_names,
+                                 config_proto, segmented_graph_def));
+
+  return Status::OK();
+}
+
+// Sets the _profile_generation mode attribute of all TRTEngineOp nodes in the
+// graph to mode.
+Status SetProfileGenerationMode(GraphDef* graph_def, bool mode) {
+  VLOG(3) << "Setting _profile_generation_mode=" << mode;
+  std::string op{"TRTEngineOp"};
+  for (auto& node : *(graph_def->mutable_node())) {
+    if (!op.compare(node.op())) {
+      auto* attr = node.mutable_attr();
+      AttrValue profile_generation_mode;
+      profile_generation_mode.set_b(mode);
+      (*attr)["_profile_generation_mode"] = profile_generation_mode;
+    }
+  }
+  return Status::OK();
+}
+
+Status RunSession(Session* session, const std::vector<std::string>& input_names,
+                  const std::vector<std::string>& output_names,
+                  const std::vector<Tensor>& input_tensors,
+                  string prefix = "") {
+  std::vector<std::pair<std::string, tensorflow::Tensor>> input_pairs;
+  std::vector<std::string> prefixed_output_names;
+  auto prefixed_name = [](std::string prefix, std::string name) {
+    return prefix.size() > 0 ? absl::StrJoin({prefix, name}, "/") : name;
+  };
+  for (int i = 0; i < input_names.size(); i++) {
+    input_pairs.push_back(
+        {prefixed_name(prefix, input_names.at(i)), input_tensors.at(i)});
+  }
+  for (int i = 0; i < output_names.size(); i++) {
+    prefixed_output_names.push_back(prefixed_name(prefix, output_names.at(i)));
+  }
+  std::vector<tensorflow::Tensor> output_tensors;
+  for (int i = 0; i < output_names.size(); i++) {
+    output_tensors.push_back({});
+  }
+  VLOG(3) << "TF-TRT Build mode: running inference\n";
+  TF_RETURN_IF_ERROR(
+      session->Run(input_pairs, prefixed_output_names, {}, &output_tensors));
+  return Status::OK();
+}
+
+// Runs the model to create the engines. In dynamic shape mode, before creating
+// the engines, we provide shapes to define optimization profiles.
+Status Build(GraphDef& segmented_graph_def,
+             const std::vector<std::string>& input_names,
+             const std::vector<std::string>& output_names,
+             const std::vector<std::vector<tensorflow::Tensor>>& inputs,
+             Session* session, const TfTrtConversionParams params) {
+  VLOG(2) << "Building the model";
+  bool need_collect_profiles = params.use_dynamic_shape && inputs.size() > 1;
+  if (need_collect_profiles) {
+    TF_RETURN_IF_ERROR(SetProfileGenerationMode(&segmented_graph_def, true));
+  }
+  TF_RETURN_IF_ERROR(session->Create(segmented_graph_def));
+  string prefix = "";
+  if (need_collect_profiles) {
+    for (auto const& input : inputs) {
+      TF_RETURN_IF_ERROR(RunSession(session, input_names, output_names, input));
+    }
+    prefix = "TrtBuildStep";
+    TF_RETURN_IF_ERROR(SetProfileGenerationMode(&segmented_graph_def, false));
+    VLOG(3) << "Importing graph with _profile_generation_mode disabled";
+    TF_RETURN_IF_ERROR(
+        ImportGraphDefToSession(session, segmented_graph_def, prefix));
+  }
+  TF_RETURN_IF_ERROR(
+      RunSession(session, input_names, output_names, *inputs.begin(), prefix));
+  return Status::OK();
+}
+
+// Returns the resource manager associated with the node.
+Status GetResourceManager(const NodeDef& node, Session* session,
+                          ResourceMgr** rm) {
+  const DeviceMgr* device_mgr;
+  TF_RETURN_IF_ERROR(session->LocalDeviceManager(&device_mgr));
+  Device* device;
+  string device_name = node.device().empty()
+                           ? "/job:localhost/replica:0/task:0/device:GPU:0"
+                           : node.device();
+  TF_RETURN_IF_ERROR(device_mgr->LookupDevice(device_name, &device));
+  *rm = device->resource_manager();
+  return Status::OK();
+}
+
+// Looks up the cache resurce associated with the TRT node.
+Status GetEngineCacheResource(const NodeDef& node, Session* session,
+                              TRTEngineCacheResource** resource) {
+  ResourceMgr* rm;
+  TF_RETURN_IF_ERROR(GetResourceManager(node, session, &rm));
+
+  absl::string_view resource_name = node.name();
+  size_t last_slash = resource_name.find_last_of('/');
+  if (last_slash != absl::string_view::npos) {
+    resource_name.remove_prefix(last_slash + 1);
+  }
+  const std::string container(kTfTrtContainerName);
+  *resource = nullptr;
+  TF_RETURN_IF_ERROR(
+      rm->Lookup(container, std::string(resource_name), resource));
+  if (resource == nullptr || (*resource)->cache_.size() == 0) {
+    return errors::Internal("Engine cache not found for", resource_name);
+  }
+  return Status::OK();
+}
+
+// Looks up the engine from the engine cache, and serializes the engine.
+Status ReadSerializedEngine(
+    const NodeDef& node, Session* session,
+    TrtUniquePtrType<nvinfer1::IHostMemory>* engine_data) {
+  TRTEngineCacheResource* resource;
+  TF_RETURN_IF_ERROR(GetEngineCacheResource(node, session, &resource));
+  core::ScopedUnref unref_cache_res(resource);
+  if (resource->cache_.size() > 1) {
+    return errors::Internal(
+        "Multiple engines found, but we can only serialize one");
+  }
+  const std::unique_ptr<EngineContext>& engine =
+      resource->cache_.begin()->second;
+  if (!engine) {
+    return errors::Internal("Engine not found for", node.name());
+  }
+
+  if (engine->cuda_engine) {
+    // Serialize the engine.
+    engine_data->reset(engine->cuda_engine->serialize());
+  } else {
+    LOG(WARNING) << "Engine cache contains nullptr";
+  }
+
+  return Status::OK();
+}
+
+// Saves the TRT engines as attributes of the TRTEngineOp nodes.
+Status ConvertToStaticEngine(const GraphDef graph_def,
+                             GraphDef* static_graph_def, Session* session) {
+  static_graph_def->CopyFrom(graph_def);
+  VLOG(1) << "Saving TRT engines as static engine";
+  std::string op{"TRTEngineOp"};
+  for (auto& node : *(static_graph_def->mutable_node())) {
+    if (!op.compare(node.op())) {
+      VLOG(2) << "Saving TRT engine for " << node.name()
+              << ", device: " << node.device();
+      TrtUniquePtrType<nvinfer1::IHostMemory> engine_data;
+      TF_RETURN_IF_ERROR(ReadSerializedEngine(node, session, &engine_data));
+      auto* attr = node.mutable_attr();
+      AttrValue static_engine;
+      static_engine.set_b(true);
+      AttrValue engine_string;
+      if (engine_data) {
+        engine_string.set_s(engine_data->data(), engine_data->size());
+      }
+      (*attr)["static_engine"] = static_engine;
+      (*attr)["serialized_segment"] = engine_string;
+    }
+  }
+  return Status::OK();
+}
+
+Status ValidateConversionParams(const TfTrtConversionParams& p, int n_inputs) {
+  if (p.precision_mode == TrtPrecisionMode::INT8 && p.use_calibration) {
+    return errors::InvalidArgument(
+        "Calibration not yet implemented through the C++ interface. Please use "
+        "our Python API for calibration.");
+  }
+  if (p.convert_to_static_engine && n_inputs == 0) {
+    return errors::InvalidArgument(
+        "TRT Engine needs to be built before we can convert it to static "
+        "engine. Please provide input data to build the model.");
+  }
+  if (!p.convert_to_static_engine && n_inputs >= 0) {
+    // After the conversion, the session that was used to build the engines
+    // will be destroyed. If we do not convert the engine to static engine,
+    // then we loose the engines.
+    //
+    // TODO(tfeher): Provide a way to save dynamic engines and remove this
+    // warning.
+    LOG(WARNING)
+        << "Skipping build mode because we cannot save the "
+           "engines. Use convert_to_static_engines=true conversion "
+           "parameter to enable build mode and save the engines in the graph.";
+  }
+  if (!p.allow_build_at_runtime && n_inputs == 0) {
+    LOG(WARNING)
+        << "TRT will not be used since allow_build_at_runtime is disabled and "
+           "no inputs are provided to build during conversion.";
+  }
+  return Status::OK();
+}
+}  // namespace
+
+StatusOr<GraphDef> ConvertAndBuild(
+    const GraphDef& frozen_graph_def, const std::vector<string>& input_names,
+    const std::vector<string>& output_names,
+    const std::vector<std::vector<tensorflow::Tensor>>& inputs,
+    const TfTrtConversionParams& conv_params) {
+  TF_RETURN_IF_ERROR(ValidateConversionParams(conv_params, inputs.size()));
+  MetaGraphDef meta_graph;
+  meta_graph.mutable_graph_def()->CopyFrom(frozen_graph_def);
+
+  RewriterConfig rewriter_config;
+  TF_RETURN_IF_ERROR(GetTrtRewriterConfig(conv_params, &rewriter_config));
+  GraphDef segmented_graph_def;
+  TF_RETURN_IF_ERROR(RunTfTrt(meta_graph, input_names, output_names,
+                              rewriter_config, &segmented_graph_def));
+
+  GraphDef output;
+
+  if (inputs.size() > 0 && conv_params.convert_to_static_engine) {
+    // The TRTOptimization pass has inserted placeholder TRTEngineOps. Here we
+    // trigger conversion by inferring the graph.
+    std::unique_ptr<tensorflow::Session> session(
+        tensorflow::NewSession(tensorflow::SessionOptions()));
+    if (!session.get()) {
+      return errors::Internal("Failed to create build session");
+    }
+
+    TF_RETURN_IF_ERROR(Build(segmented_graph_def, input_names, output_names,
+                             inputs, session.get(), conv_params));
+
+    TF_RETURN_IF_ERROR(
+        ConvertToStaticEngine(segmented_graph_def, &output, session.get()));
+  } else {
+    output.CopyFrom(segmented_graph_def);
+  }
+  VLOG(1) << "TF-TRT conversion finished";
+  return output;
+}
+
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/trt_convert_api.h
+++ b/tensorflow/compiler/tf2tensorrt/trt_convert_api.h
@@ -1,0 +1,113 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_TRT_CONVERT_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_TRT_CONVERT_H_
+
+#include <string>
+#include <vector>
+
+#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/platform/statusor.h"
+#include "tensorflow/core/protobuf/meta_graph.pb.h"
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+namespace tensorflow {
+namespace tensorrt {
+
+struct TfTrtConversionParams {
+  // Corresponds 'workspaceSize' parameter of
+  // nvinfer1::IBuilderConfig::setMaxWorkspaceSize.
+  size_t max_workspace_size_bytes = 1 << 30;
+
+  // Minimum precision used by the TRT Engine.
+  TrtPrecisionMode precision_mode = TrtPrecisionMode::FP32;
+
+  // The minimum number of nodes required for a subgraph to be replaced by
+  // TRTEngineOp. Note that many small TRT subgraphs could be detrimental for
+  // performance, increasing the minimum segment size can help avoid the
+  // problem.
+  int minimum_segment_size = 3;
+
+  // Max number of cached TRT engines for dynamic TRT ops (by default we have
+  // dynamic TRT ops).
+  int max_cached_engines = 1;
+
+  // Note that calibration is currently not implemented with the C++ converter.
+  // This argument is ignored if precision_mode is not INT8. If set to True, the
+  // implementation will use the user provided inputs to generate calibration
+  // data. If set to False, quantization nodes will be expected for every tensor
+  // in the graph (excluding those which will be fused). If a range is missing,
+  // an error will occur. Please note that accuracy may be negatively affected
+  // if there is a mismatch between which tensors TRT quantizes and which
+  // tensors were trained with fake quantization.
+  bool use_calibration = true;
+
+  // Whether to enable dynamic shape mode for the TRT engines. It is
+  // recommended to use_dynamic_shape mode to handle dynamic input shape.
+  // Enabling dynamic shape mode can also improve the conversion rate of graphs
+  // with static input shape.
+  bool use_dynamic_shape = true;
+
+  // In dynamic shape mode we create an engine that can handle various input
+  // shape ranges. We derive the shape optimization profiles for the TRT engines
+  // in the graph based on user provided input data and profile_strategy.
+  ProfileStrategy profile_strategy = ProfileStrategy::kRange;
+
+  // Whether to allow bulding TRT engines at runtime. If no TensorRT engine can
+  // be found in cache that can handle the given inputs during runtime, then a
+  // new TensorRT engine is built at runtime if allow_build_at_runtime=True,
+  // otherwise native TF is used. We recommend to set this value false and build
+  // the engine in advance, to avoid runtime overhead.
+  bool allow_build_at_runtime = true;
+
+  // Record the TRT engine as an attribute of the TRTEngineOp. This is only
+  // valid when max_cached_engines == 1. Note: the frozen graph together with
+  // the serialized engines have to be below 2GiB (protobuf size limit). If
+  // convert_to_static_engine = false, then the converted graph_def only
+  // contains placeholder TRTEngineOp nodes.
+  bool convert_to_static_engine = true;
+};
+
+/**
+ * Converts the graph with TF-TRT.
+ *
+ * Performs TF-TRT conversion and returns the converted GraphDef. If inputs is
+ * not empty and convert_to_static_engine is requested, we also build the
+ * engines and convert the engines to static engines.
+ *
+ * Arguments:
+ * - frozen_graph_def input graph, it is assumed to be frozen
+ * - input_names names of the input tensors
+ * - output_names names of the output tensors
+ * - inputs tensors that we will use as input while building the TRT engines
+ * - conv_params parameters for the TF-TRT conversion
+ *
+ * Returns the converted graph_def.
+ */
+StatusOr<GraphDef> ConvertAndBuild(
+    const GraphDef& frozen_graph_def, const std::vector<string>& input_names,
+    const std::vector<string>& output_names,
+    const std::vector<std::vector<tensorflow::Tensor>>& inputs,
+    const TfTrtConversionParams& conv_params);
+
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_TRT_CONVERT_H_

--- a/tensorflow/compiler/tf2tensorrt/trt_convert_api_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/trt_convert_api_test.cc
@@ -1,0 +1,205 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include "tensorflow/compiler/tf2tensorrt/trt_convert_api.h"
+
+#include "tensorflow/cc/ops/standard_ops.h"
+#include "tensorflow/core/framework/tensor_testutil.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/protobuf/meta_graph.pb.h"
+#include "tensorflow/core/public/session.h"
+
+namespace tensorflow {
+namespace tensorrt {
+
+struct TestParam {
+  TfTrtConversionParams conv_params;
+  std::vector<std::vector<int64>> input_shapes;
+};
+
+class TrtConverterTest : public ::testing::TestWithParam<TestParam> {
+ protected:
+  TrtConverterTest() { param_ = GetParam(); }
+
+  // Returns the following graph: output = input * [42, 137] + input
+  MetaGraphDef GetModel() {
+    PartialTensorShape shape({-1, 2});
+
+    Scope root = Scope::NewRootScope();
+    auto c = ops::Const(root.WithOpName("my_const"), {{42.0f, 137.0f}});
+    const auto attrs = ops::Placeholder::Shape(shape);
+    auto x = ops::Placeholder(root.WithOpName("input"), DT_FLOAT, attrs);
+    auto y = ops::Mul(root.WithOpName("my_mul"), x, c);
+    auto z = ops::Add(root.WithOpName("my_add"), x, y);
+    auto q = ops::Identity(root.WithOpName("output"), z);
+
+    MetaGraphDef out;
+    root.ToGraphDef(out.mutable_graph_def());
+
+    TensorShapeProto shape_proto;
+    shape.AsProto(&shape_proto);
+    SignatureDef signature_def;
+    (*signature_def.mutable_inputs())["input"].set_name("input:0");
+    (*signature_def.mutable_inputs())["input"].set_dtype(DT_FLOAT);
+    (*signature_def.mutable_inputs())["input"].mutable_tensor_shape()->CopyFrom(
+        shape_proto);
+    (*signature_def.mutable_outputs())["output"].set_name("output:0");
+    (*signature_def.mutable_outputs())["output"].set_dtype(DT_FLOAT);
+    (*signature_def.mutable_outputs())["output"]
+        .mutable_tensor_shape()
+        ->CopyFrom(shape_proto);
+    (*out.mutable_signature_def())["serving_default"] = signature_def;
+
+    VLOG(2) << signature_def.DebugString();
+    return out;
+  }
+
+  // Confirms that we have a TRT node with the correct attributes.
+  void CheckTrtNode(const GraphDef& converted_graph_def) {
+    int n_trt_ops = 0;
+    string op_name{"TRTEngineOp"};
+    for (const auto& node : converted_graph_def.node()) {
+      if (!op_name.compare(node.op())) {
+        n_trt_ops++;
+        const auto& attr = node.attr();
+        EXPECT_EQ(attr.at("static_engine").b(),
+                  param_.conv_params.convert_to_static_engine);
+        if (param_.conv_params.convert_to_static_engine) {
+          VLOG(2) << "Found serialized segment with size "
+                  << attr.at("serialized_segment").s().size();
+          EXPECT_GT(attr.at("serialized_segment").s().size(), 0);
+        }
+      }
+    }
+    EXPECT_EQ(n_trt_ops, 1);
+  }
+
+  void ConvertAndRun() {
+    MetaGraphDef meta_graph_def = GetModel();
+
+    // Create a list of input tensors, they will be used to build the engines.
+    std::vector<std::vector<Tensor>> input_tensors;
+    for (const std::vector<int64>& shape : param_.input_shapes) {
+      Tensor tensor(DT_FLOAT, TensorShape(shape));
+      test::FillIota(&tensor, 1.0f);
+      input_tensors.push_back({tensor});
+    }
+
+    StatusOr<GraphDef> result = tensorrt::ConvertAndBuild(
+        meta_graph_def.graph_def(), {"input"}, {"output"}, input_tensors,
+        param_.conv_params);
+    TF_ASSERT_OK(result.status());
+    const GraphDef& converted_graph_def = result.ValueOrDie();
+    CheckTrtNode(converted_graph_def);
+
+    // Create sessions to execute the original and the converted graphs.
+    Session* p_session = nullptr;
+    TF_EXPECT_OK(NewSession(SessionOptions(), &p_session));
+    std::unique_ptr<tensorflow::Session> session(p_session);
+    TF_EXPECT_OK(session->Create(meta_graph_def.graph_def()));
+
+    p_session = nullptr;
+    TF_EXPECT_OK(NewSession(SessionOptions(), &p_session));
+    std::unique_ptr<tensorflow::Session> trt_session(p_session);
+    TF_EXPECT_OK(trt_session->Create(converted_graph_def));
+
+    // Run models and compare the output.
+    for (const std::vector<Tensor>& input : input_tensors) {
+      std::vector<Tensor> outputs;
+      TF_EXPECT_OK(
+          session->Run({{"input", input.at(0)}}, {"output"}, {}, &outputs));
+      std::cout << outputs.at(0).DebugString() << std::endl;
+
+      std::vector<Tensor> trt_outputs;
+      TF_EXPECT_OK(trt_session->Run({{"input", input.at(0)}}, {"output"}, {},
+                                    &trt_outputs));
+      std::cout << trt_outputs.at(0).DebugString() << std::endl;
+      ASSERT_EQ(outputs.size(), 1);
+      ASSERT_EQ(trt_outputs.size(), 1);
+      tensorflow::test::ExpectEqual(outputs[0], trt_outputs[0]);
+    }
+  }
+  TestParam param_;
+};
+
+INSTANTIATE_TEST_CASE_P(
+    TrtConverterTestInstantiation, TrtConverterTest,
+    ::testing::Values(
+        // Dynamic shape mode test with conver_to_static_engine=true.
+        TestParam{TfTrtConversionParams{
+                      1 << 20,  // max workspace size
+                      TrtPrecisionMode::FP32,
+                      3,      // minimum_segment_size
+                      1,      // max_cached_engines
+                      false,  // use_calibration
+                      true,   // use_dynamic_shape
+                      ProfileStrategy::kOptimal,
+                      true,  // allow_build_at_runtime
+                      true   // convert_to_static_engine
+                  },
+                  {{1, 2}, {4, 2}}},
+        // Implicit batch mode test with conver_to_static_engine=true.
+        TestParam{TfTrtConversionParams{
+                      1 << 20,  // max workspace size
+                      TrtPrecisionMode::FP16,
+                      3,      // minimum_segment_size
+                      1,      // max_cached_engines
+                      false,  // use_calibration
+                      false,  // use_dynamic_shape
+                      ProfileStrategy::kRange,
+                      true,  // allow_build_at_runtime
+                      true   // convert_to_static_engine
+                  },
+                  {{1, 2}}},
+        // Dynamic shape mode test convert_to_static_engine=false: we cannot
+        // save the engines, therefore we do not generate profiles. A single
+        // engine will be built during runtime, with profile that matches the
+        // first shape ({1,2}). The second shape will run as native segment.
+        TestParam{TfTrtConversionParams{
+                      1 << 20,  // max workspace size
+                      TrtPrecisionMode::FP32,
+                      3,      // minimum_segment_size
+                      1,      // max_cached_engines
+                      false,  // use_calibration
+                      true,   // use_dynamic_shape
+                      ProfileStrategy::kOptimal,
+                      true,  // allow_build_at_runtime
+                      false  // convert_to_static_engine
+                  },
+                  {{1, 2}, {4, 2}}},
+        // Implicit batch mode test with convert_to_static_engine=false. We
+        // will have two engines in the cache to handle the two shapes.
+        TestParam{TfTrtConversionParams{
+                      1 << 20,  // max workspace size
+                      TrtPrecisionMode::FP16,
+                      3,      // minimum_segment_size
+                      2,      // max_cached_engines
+                      false,  // use_calibration
+                      false,  // use_dynamic_shape
+                      ProfileStrategy::kRange,
+                      true,  // allow_build_at_runtime
+                      false  // convert_to_static_engine
+                  },
+                  {{1, 2}, {4, 2}}}));
+
+TEST_P(TrtConverterTest, Basic) { ConvertAndRun(); }
+
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT


### PR DESCRIPTION
TF-TRT C++ interface to convert models. 

Differences compared to the Python API:
- It is assumed that the input graph is frozen. This assumption will be removed in a follow up PR.
- `convert_to_static_engine` conversion param allows to convert dynamic engines to static engines.
- Currently we do not provide a way to save the engine files as assets. 

The steps for model conversion by `ConvertAndBuild`
1. Inline functions
2. Freeze the graph - omitted since we assume frozen input graph
3. Run Grappler with TRTOptimizer pass
4. Infer the graph to provide shape information (only in dynamic shape mode).
5. Infer the graph to build the engines
6. Convert the graph_def to have static engines

(On the Python side, steps 4-5 are done by a separate `build` function.)

Related PRs:
- #52047 
- Example code for the tensorflow/tensorrt repository https://github.com/tensorflow/tensorrt/pull/271
