### PR TITLE
[INTEL MKL] Enabling simple heuristic based tuning for innerproduct primitive

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op.cc
@@ -162,7 +162,7 @@ class MklMatMulOp : public OpKernel {
     // the kernel single threaded. Here we are coming up with a cost model based
     // on L1 sizes. If we find that matrices are small enough, we will execute
     // single threaded. This may need tuning.
-    if (ExecuteSingleThreadedGemm(m, n, k)) {
+    if (ExecuteSingleThreadedGemm(m, n, k, sizeof(float))) {
       // For now, call single-threaded gemm.
       dnnl::threadpool_interop::sgemm(char_transa, char_transb, m, n, k, alpha,
                                       a, lda, b, ldb, beta, c, ldc, nullptr);

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -249,7 +249,8 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, T> {
         }
       }
       std::shared_ptr<stream> cpu_stream;
-      MklDnnThreadPool eigen_tp(ctx);
+      auto st = ExecuteSingleThreadedGemm(batch, channel, k, sizeof(T));
+      MklDnnThreadPool eigen_tp(ctx, st? 1:-1);
       cpu_stream.reset(CreateStream(&eigen_tp, matmul_prim->GetEngine()));
       // Execute fused matmul op.
       matmul_prim->Execute(src_data, weight_data, bias_data, dst_data,

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -42,7 +42,7 @@ inline bool ExecuteSingleThreadedGemm(int m, int n, int k, int bytes) {
   // to determine if the matrix multiplication should be run on a single thread.
   ptrdiff_t l2_size = cache_sizes.m_l2;
   constexpr int kHeuristicMultiplier = 1;
-  int mul_size = bytes * (m * n + k * (m + n));
+  const int mul_size = bytes * (m * n + k * (m + n));
   const int l2_heur = l2_size * kHeuristicMultiplier;
   return mul_size < l2_heur;
 }

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -43,7 +43,7 @@ inline bool ExecuteSingleThreadedGemm(int m, int n, int k, int bytes) {
   ptrdiff_t l2_size = cache_sizes.m_l2;
   constexpr int kHeuristicMultiplier = 1;
   int mul_size = bytes * (m * n + k * (m + n));
-  int l2_heur = l2_size * kHeuristicMultiplier;
+  const int l2_heur = l2_size * kHeuristicMultiplier;
   return mul_size < l2_heur;
 }
 

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -32,18 +32,19 @@ using mkldnn::prop_kind;
 using mkldnn::stream;
 
 namespace tensorflow {
+static Eigen::internal::CacheSizes cache_sizes = Eigen::internal::CacheSizes();
 
-#define L1_SIZE 32 * 1024
 typedef Eigen::ThreadPoolDevice CPUDevice;
-
-inline bool ExecuteSingleThreadedGemm(int m, int n, int k) {
+inline bool ExecuteSingleThreadedGemm(int m, int n, int k, int bytes) {
   // Ideally we would like to determine blocking and then come up with
   // a heuristic but what we are targeting are very small models whose
-  // total size is < few L1's. So we will do this simple calculation
+  // total size is < L2. So we will do this simple calculation
   // to determine if the matrix multiplication should be run on a single thread.
-  constexpr int kHeuristicMultiplier = 8;
-  return ((sizeof(float) * (m * n + k * (m + n))) <
-          L1_SIZE * kHeuristicMultiplier);
+  ptrdiff_t l2_size = cache_sizes.m_l2;
+  constexpr int kHeuristicMultiplier = 1;
+  int mul_size = bytes * (m * n + k * (m + n));
+  int l2_heur = l2_size * kHeuristicMultiplier;
+  return mul_size < l2_heur;
 }
 
 // This structure aggregates multiple inputs to MklDnnMatMul* methods.

--- a/tensorflow/core/util/mkl_threadpool.h
+++ b/tensorflow/core/util/mkl_threadpool.h
@@ -64,12 +64,13 @@ struct MklDnnThreadPool : public threadpool_iface {
   MklDnnThreadPool() = default;
 
   MklDnnThreadPool(OpKernelContext* ctx, int num_threads = -1) {
-    eigen_interface_ = ctx->device()->tensorflow_cpu_worker_threads()->workers->AsEigenThreadPool();
-    num_threads_ = (num_threads == -1) ? eigen_interface_->NumThreads(): num_threads;
+    eigen_interface_ = ctx->device()
+                           ->tensorflow_cpu_worker_threads()
+                           ->workers->AsEigenThreadPool();
+    num_threads_ =
+        (num_threads == -1) ? eigen_interface_->NumThreads() : num_threads;
   }
-  virtual int get_num_threads() const override {
-    return num_threads_;
-  }
+  virtual int get_num_threads() const override { return num_threads_; }
   virtual bool get_in_parallel() const override {
     return (eigen_interface_->CurrentThreadId() != -1) ? true : false;
   }
@@ -106,7 +107,7 @@ struct MklDnnThreadPool : public threadpool_iface {
 
  private:
   Eigen::ThreadPoolInterface* eigen_interface_ = nullptr;
-  int num_threads_ = 1; // Execute in caller thread.
+  int num_threads_ = 1;  // Execute in caller thread.
 };
 
 #else

--- a/tensorflow/core/util/mkl_threadpool.h
+++ b/tensorflow/core/util/mkl_threadpool.h
@@ -63,12 +63,12 @@ inline void balance211(T n, U team, U tid, T* n_start, T* n_end) {
 struct MklDnnThreadPool : public threadpool_iface {
   MklDnnThreadPool() = default;
 
-  MklDnnThreadPool(OpKernelContext* ctx)
-      : eigen_interface_(ctx->device()
-                             ->tensorflow_cpu_worker_threads()
-                             ->workers->AsEigenThreadPool()) {}
+  MklDnnThreadPool(OpKernelContext* ctx, int num_threads = -1) {
+    eigen_interface_ = ctx->device()->tensorflow_cpu_worker_threads()->workers->AsEigenThreadPool();
+    num_threads_ = (num_threads == -1) ? eigen_interface_->NumThreads(): num_threads;
+  }
   virtual int get_num_threads() const override {
-    return eigen_interface_->NumThreads();
+    return num_threads_;
   }
   virtual bool get_in_parallel() const override {
     return (eigen_interface_->CurrentThreadId() != -1) ? true : false;
@@ -106,6 +106,7 @@ struct MklDnnThreadPool : public threadpool_iface {
 
  private:
   Eigen::ThreadPoolInterface* eigen_interface_ = nullptr;
+  int num_threads_ = 1; // Execute in caller thread.
 };
 
 #else
@@ -114,6 +115,7 @@ struct MklDnnThreadPool : public threadpool_iface {
 struct MklDnnThreadPool {
   MklDnnThreadPool() = default;
   MklDnnThreadPool(OpKernelContext* ctx) {}
+  MklDnnThreadPool(OpKernelContext* ctx, int num_threads) {}
 };
 
 #endif  // !ENABLE_ONEDNN_OPENMP


### PR DESCRIPTION
This PR enables a simple heuristic based approach to determine whether inner product primitive should run single threaded or not. If the matmul fits in L2 we have observed that single threaded operation gives better performance than multi-threaded. 