### PR TITLE
[INTEL MKL] Introduce env variable to simulate frozen weights and filters

### DIFF
--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -24,6 +24,7 @@ MKL_SHORT_DEPS = [
     "//tensorflow/core:lib_internal",
     "//tensorflow/core/framework:bounds_check",
     "//tensorflow/core/kernels:ops_util",
+    "//tensorflow/core/util:mkl_util",
 ] + mkl_deps()
 
 MKL_DEPS = MKL_SHORT_DEPS + [
@@ -53,6 +54,7 @@ MKL_TEST_DEPS = [
     "//tensorflow/core:testlib",
     "//tensorflow/core/kernels:ops_testutil",
     "//tensorflow/core/kernels:ops_util",
+    "//tensorflow/core/util:mkl_util",
 ]
 
 tf_mkl_kernel_library(
@@ -263,12 +265,8 @@ tf_mkl_kernel_library(
     name = "mkl_dequantize_op",
     srcs = ["mkl_dequantize_op.cc"],
     deps = [
-        "//third_party/eigen3",
         "@gemmlowp",
         "//tensorflow/core:array_ops_op_lib",
-        "//tensorflow/core:core_cpu",
-        "//tensorflow/core:framework",
-        "//tensorflow/core:lib",
         "//tensorflow/core:math_ops_op_lib",
         "//tensorflow/core/graph:mkl_graph_util",
         "//tensorflow/core:nn_ops_op_lib",
@@ -277,12 +275,12 @@ tf_mkl_kernel_library(
         "//tensorflow/core/kernels:cwise_op",
         "//tensorflow/core/kernels:eigen_helpers",
         "//tensorflow/core/kernels:meta_support",
-        "//tensorflow/core/kernels:ops_util",
         "//tensorflow/core/kernels:pooling_ops",
         "//tensorflow/core/kernels:quantization_utils",
         "//tensorflow/core/kernels:quantized_ops",
         "//tensorflow/core/kernels:transpose_functor",
         "//tensorflow/core/util:image_resizer_state",
+        "//tensorflow/core/util:mkl_util",
     ] + mkl_deps(),
 )
 
@@ -325,11 +323,9 @@ tf_mkl_kernel_library(
     name = "mkl_fused_batch_norm_op",
     srcs = ["mkl_fused_batch_norm_op.cc"],
     deps = [
-        "//third_party/eigen3",
-        "//tensorflow/core:framework",
         "//tensorflow/core/kernels:fused_batch_norm_op",
         "//tensorflow/core/kernels:no_op",
-    ] + mkl_deps(),
+    ] + MKL_DEPS,
 )
 
 tf_cc_test_mkl(

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -568,7 +568,9 @@ class MklConvOp : public OpKernel {
 
     OP_REQUIRES_OK(context, context->GetAttr("padding", &padding_));
     is_filter_const_ = false;
-    if (context->HasAttr("is_filter_const")) {
+    if (AreWeightsFrozen()) {
+      is_filter_const_ = true;
+    } else if (context->HasAttr("is_filter_const")) {
       OP_REQUIRES_OK(context,
                      context->GetAttr("is_filter_const", &is_filter_const_));
     }

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -35,8 +35,12 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, T> {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("fused_ops", &fused_ops_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_a", &transpose_a_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_b", &transpose_b_));
-    OP_REQUIRES_OK(ctx,
-                   ctx->GetAttr("is_filter_const", &(this->is_weight_const_)));
+    if (AreWeightsFrozen()) {
+      this->is_weight_const_= true;
+    } else {
+      OP_REQUIRES_OK(ctx,
+                     ctx->GetAttr("is_filter_const", &(this->is_weight_const_)));
+    }
 
     OP_REQUIRES(ctx, fused_ops_.size() <= 2,
                 errors::InvalidArgument(

--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -405,7 +405,6 @@ cc_library(
         "mkl_util.h",
     ],
     copts = tf_copts() + ["-fexceptions"],
-    linkstatic = 1,
     visibility = [
         "//tensorflow:internal",
     ],
@@ -417,7 +416,6 @@ cc_library(
         "//tensorflow/core/framework:bounds_check",
         "//tensorflow/core/kernels:ops_util",
     ] + mkl_deps(),
-    alwayslink = 1,
 )
 
 cc_library(

--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -16,6 +16,10 @@ load(
     "tf_cuda_only_cc_test",
     "tf_kernel_library",
 )
+load(
+    "//third_party/mkl:build_defs.bzl",
+    "mkl_deps",
+)
 
 # buildifier: disable=same-origin-load
 load("//tensorflow:tensorflow.bzl", "filegroup")
@@ -390,6 +394,30 @@ cc_library(
     visibility = [
         "//tensorflow:internal",
     ],
+)
+
+cc_library(
+    name = "mkl_util",
+    srcs = [
+        "mkl_util.cc",
+    ],
+    hdrs = [
+        "mkl_util.h",
+    ],
+    copts = tf_copts() + ["-fexceptions"],
+    linkstatic = 1,
+    visibility = [
+        "//tensorflow:internal",
+    ],
+    deps = [
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core/framework:bounds_check",
+        "//tensorflow/core/kernels:ops_util",
+    ] + mkl_deps(),
+    alwayslink = 1,
 )
 
 cc_library(

--- a/tensorflow/core/util/mkl_util.cc
+++ b/tensorflow/core/util/mkl_util.cc
@@ -1,4 +1,4 @@
-/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tensorflow/core/util/mkl_util.cc
+++ b/tensorflow/core/util/mkl_util.cc
@@ -1,0 +1,32 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifdef INTEL_MKL
+
+#include "tensorflow/core/util/mkl_util.h"
+
+namespace tensorflow {
+
+bool AreWeightsFrozen() {
+  static bool weights_const = false;
+  static absl::once_flag once;
+  absl::call_once(once, [&] {
+    TF_CHECK_OK(ReadBoolFromEnvVar("TF_ONEDNN_ASSUME_FROZEN_WEIGHTS",
+                                   /*default_value*/ false, &weights_const));
+  });
+  return weights_const;
+}
+}  // namespace tensorflow
+#endif  // INTEL_MKL

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -135,16 +135,7 @@ inline void execute_primitives(
   }
 }
 
-bool inline AreWeightsFrozen() {
-  static bool weights_const = false;
-  static absl::once_flag once;
-  absl::call_once(once, [&] {
-    TF_CHECK_OK(ReadBoolFromEnvVar("TF_ONEDNN_ASSUME_FROZEN_WEIGHTS",
-                                   /*default_value*/ false,
-                                   &weights_const));
-  });
-  return weights_const;
-}
+bool AreWeightsFrozen();
 
 // In MKL-DNN v1.x, the format (ex. NCHW) used to initialize a memory descriptor
 // (md) structure will no longer be recorded in its `format` field. Instead, it

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -135,6 +135,17 @@ inline void execute_primitives(
   }
 }
 
+bool inline AreWeightsFrozen() {
+  static bool weights_const = false;
+  static absl::once_flag once;
+  absl::call_once(once, [&] {
+    TF_CHECK_OK(ReadBoolFromEnvVar("TF_ONEDNN_ASSUME_FROZEN_WEIGHTS",
+                                   /*default_value*/ false,
+                                   &weights_const));
+  });
+  return weights_const;
+}
+
 // In MKL-DNN v1.x, the format (ex. NCHW) used to initialize a memory descriptor
 // (md) structure will no longer be recorded in its `format` field. Instead, it
 // will be set to a canonical `blocked` format for every fully described md.


### PR DESCRIPTION
This PR introduces an env variable which can be used when running inference on unfrozen models to simulate frozen weights and filters. By setting the variable to one, we enable weight caching in the kernel and call the most performant oneDNN kernel  implementation with pre-packed weights.  