### PR TITLE
TF-TRT Add n_build_pass attribute

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
@@ -493,7 +493,8 @@ Status CreateTRTNode(const ConversionParams& params,
       .Attr("use_calibration", info.use_calibration)
       .Attr("_use_implicit_batch", params.use_implicit_batch)
       .Attr("_allow_build_at_runtime", info.allow_build_at_runtime)
-      .Attr("OutT", out_types);
+      .Attr("OutT", out_types)
+      .Attr("_n_build_pass", params.n_build_pass);
 
   if (!params.use_implicit_batch) {
     node_builder.Attr("profile_strategy",

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.h
@@ -49,6 +49,7 @@ struct ConversionParams {
   bool use_implicit_batch = true;
   ProfileStrategy profile_strategy = ProfileStrategy::kRange;
   bool allow_build_at_runtime = true;
+  int n_build_pass = 0;
 };
 
 // Method to call from optimization pass

--- a/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
@@ -193,6 +193,8 @@ Status UpdateFunctionSpecificConversionParams(
       GetAttrValue(attr, "_tftrt_profile_strategy", &cp.profile_strategy));
   TF_RETURN_IF_ERROR(GetAttrValue(attr, "_tftrt_allow_build_at_runtime",
                                   &cp.allow_build_at_runtime));
+  TF_RETURN_IF_ERROR(
+      GetAttrValue(attr, "_tftrt_n_build_pass", &cp.n_build_pass));
   return Status::OK();
 }
 
@@ -240,6 +242,9 @@ Status TRTOptimizationPass::Init(
   if (params.count("profile_strategy")) {
     TF_RETURN_IF_ERROR(ProfileStrategyFromName(
         params.at("profile_strategy").s(), &profile_strategy_));
+  }
+  if (params.count("n_build_pass")) {
+    n_build_pass_ = params.at("n_build_pass").i();
   }
   return Status::OK();
 }
@@ -406,6 +411,7 @@ Status TRTOptimizationPass::Optimize(grappler::Cluster* cluster,
   cp.use_implicit_batch = use_implicit_batch_;
   cp.profile_strategy = profile_strategy_;
   cp.allow_build_at_runtime = allow_build_at_runtime_;
+  cp.n_build_pass = n_build_pass_;
 
   if (item.id != "tf_graph" && do_function_conversion) {
     const grappler::GrapplerFunctionItem& func_item =

--- a/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h
@@ -48,7 +48,8 @@ class TRTOptimizationPass : public grappler::CustomGraphOptimizer {
         use_calibration_(true),
         use_implicit_batch_(true),
         profile_strategy_(ProfileStrategy::kRange),
-        allow_build_at_runtime_(true) {
+        allow_build_at_runtime_(true),
+        n_build_pass_(0) {
     VLOG(1) << "Constructing " << name_;
   }
 
@@ -80,6 +81,7 @@ class TRTOptimizationPass : public grappler::CustomGraphOptimizer {
   bool use_implicit_batch_;
   ProfileStrategy profile_strategy_;
   bool allow_build_at_runtime_;
+  int n_build_pass_;
 };
 
 }  // namespace convert


### PR DESCRIPTION
To convert a model with TF-TRT dynamic shapes, one can provide profile information by inferring the segmented model a number of times. Currently the build mode uses [_profile_generation_mode](https://github.com/tensorflow/tensorflow/blob/6ce1270b038b7407bf6eefded34d543fea85a6ed/tensorflow/python/compiler/tensorrt/trt_convert.py#L1203) attribute of the graph to declare that we are in build mode. This requires two rewrites of the graph. Here is the current workflow
1. Rewrite the graph to set `_profile_generation_mode=True`
2. infer the model n_inputs times
3. rewrite the graph to set `_profile_generation_mode=False` 

This PR introduces a new attribute for TRTEngineOp: `_n_build_pass`, this is can be set by the rewriter config ([example](https://github.com/tfeher/tensorflow/blob/45680b70dc0a59cd5e7ef783b2b35a10a338d4e8/tf_trt_cpp_example/trt_convert.cc#L196)).  If we set this parameter during conversion time then we can avoid rewriting the graph to enable/disable build mode.

This PR is not essential to C++ conversion of TF-TRT, it just decreases the number of graph rewrite steps. Alternatively to this PR we could:
- Mirror a the python side workflow on the C++ side: two rewrites of  `_profile_generation_mode`. No changes needed in the TRT optimization pass, but extra work in the C++ converter.
- Set `_profile_generation_mode` to true already during graph conversion. We would need to read this value from the rewriter config (same way as this PR reads the `_n_build_pass`) attribute.

Tagging @bixia1 for discussing these points and for review.

Tracker: #52012