### PR TITLE
Fix arguments passed to get_environment when failing to locate executables

### DIFF
--- a/third_party/remote_config/common.bzl
+++ b/third_party/remote_config/common.bzl
@@ -69,7 +69,7 @@ def get_python_bin(repository_ctx):
                      "python is installed and add its directory in PATH, or --define " +
                      "%s='/something/else'.\nPATH=%s" % (
                          PYTHON_BIN_PATH,
-                         get_environ("PATH", ""),
+                         get_environ(repository_ctx, "PATH"),
                      ))
     return python_bin  # unreachable
 
@@ -91,7 +91,7 @@ def get_bash_bin(repository_ctx):
                          "bash is installed and add its directory in PATH, or --define " +
                          "%s='/path/to/bash'.\nPATH=%s" % (
                              BAZEL_SH,
-                             get_environ("PATH", ""),
+                             get_environ(repository_ctx, "PATH"),
                          ))
     return bash_bin_path
 


### PR DESCRIPTION
PR fixes an issue where `get_python_bin` and `get_bash_bin` pass a string in place of `repository_ctx` to `get_environ` if these functions fail to locate an executable.