### PR TITLE
Fix segfault with static unpack nodes

### DIFF
--- a/tensorflow/lite/delegates/xnnpack/BUILD
+++ b/tensorflow/lite/delegates/xnnpack/BUILD
@@ -585,6 +585,8 @@ cc_test(
         ":xnnpack_delegate_test_mode",
         "@com_google_googletest//:gtest",
         "@pthreadpool",
+        "//tensorflow/lite:framework",
+        "//tensorflow/lite/kernels:builtin_ops"
     ],
 )
 

--- a/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc
+++ b/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc
@@ -210,7 +210,11 @@ class Subgraph {
     std::sort(tensors.begin(), tensors.end());
 
     // XNNPACK Value IDs for TFLite tensors
-    std::vector<uint32_t> xnnpack_tensors(tensors.back() + 1);
+    size_t tensor_size = 0;
+    if (tensors.size() > 0) {
+      tensor_size = tensors.back() + 1;
+    }
+    std::vector<uint32_t> xnnpack_tensors(tensor_size);
     for (int t : tensors) {
       xnn_datatype datatype = xnn_datatype_invalid;
       switch (context->tensors[t].type) {


### PR DESCRIPTION
Models that have dequantize operations can occasionally cause a segfault because the tensors are skipped in the delegate creation process and the code tries to get an element from an empty array which is undefined.