### PR TITLE
Load and select optimization profiles for static TRT engine

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.h
@@ -19,7 +19,9 @@ limitations under the License.
 
 #include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h"
 #include "tensorflow/core/framework/graph.pb.h"
+#include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/grappler/clusters/cluster.h"
 #include "tensorflow/core/grappler/grappler_item.h"
 #include "tensorflow/core/lib/core/status.h"
@@ -65,6 +67,14 @@ std::pair<int, Allocator*> GetDeviceAndAllocator(const ConversionParams& params,
 Status RegisterGraphToFunctionLibrary(const GraphDef& segment_graph_def,
                                       Graph* graph, const string& engine_name,
                                       bool has_int32_input = false);
+
+// Creates and serializes an ICudaEngine. Used only in is_dynamic_op=false,
+// a.k.a. static engine mode.
+Status CreateStaticEngine(const ConversionParams& params,
+                          const EngineInfo& info, int max_batch_size,
+                          const std::vector<PartialTensorShape>& input_shapes,
+                          TrtShapeOptimizationProfile* profile,
+                          string* segment_string);
 
 }  // namespace convert
 }  // namespace tensorrt

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -769,7 +769,7 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
       VLOG(1) << "Native segment is used during collecting shapes for profiles";
       ExecuteNativeSegment(ctx, async_helper);
       return;
-    } else if (cache_res->profiles_.GetNumProfiles() == 0) {
+    } else if (cache_res->profiles_.GetNumProfiles() == 0 && !static_engine_) {
       // Add current shape if we did not collect any shapes so far.
       if (!cache_res->profiles_.HasShape()) {
         cache_res->profiles_.AddShape(input_concrete_shapes);
@@ -981,7 +981,14 @@ StatusOr<std::pair<EngineContext*, int>> TRTEngineOp::GetEngine(
       // implicit batch is disabled.
       if (!use_implicit_batch_ ||
           AreShapesCompatible(input_concrete_shapes, cache.begin()->first)) {
-        return std::pair<EngineContext*, int>(cache.begin()->second.get(), 0);
+        int profile_id = 0;
+        if (!use_implicit_batch_)
+          profile_id =
+              cache_res->profiles_.GetProfileNumber(input_concrete_shapes);
+        if (profile_id != -1) {
+          return std::pair<EngineContext*, int>(cache.begin()->second.get(),
+                                                profile_id);
+        }
       }
       return std::pair<EngineContext*, int>(&empty_context, 0);
     }
@@ -994,6 +1001,28 @@ StatusOr<std::pair<EngineContext*, int>> TRTEngineOp::GetEngine(
     TrtUniquePtrType<nvinfer1::ICudaEngine> static_engine(
         infer->deserializeCudaEngine(serialized_segment_.c_str(),
                                      serialized_segment_.size(), nullptr));
+    int profile_id = 0;
+    if (static_engine && !use_implicit_batch_) {
+      // load profiles
+      std::vector<ExecutionContext> exec_contexts;
+      TF_RETURN_IF_ERROR(
+          cache_res->profiles_.RestoreProfiles(static_engine.get()));
+      TF_RETURN_IF_ERROR(cache_res->profiles_.CreateExecutionContexts(
+          static_engine.get(), &exec_contexts));
+      cache.emplace(input_concrete_shapes,
+                    absl::make_unique<EngineContext>(std::move(static_engine),
+                                                     std::move(exec_contexts)));
+      VLOG(1) << "Added new engine to cache of " << name()
+              << ". Cache size: " << cache.size();
+      // Query which profile of the new engine matches the actual input.
+      profile_id = cache_res->profiles_.GetProfileNumber(input_concrete_shapes);
+      if (profile_id == -1) {
+        return std::pair<EngineContext*, int>(&empty_context, 0);
+      }
+      EngineContext* engine_context = cache_res->GetEngineContext(profile_id);
+      return std::pair<EngineContext*, int>(engine_context, profile_id);
+    }
+
     if (!static_engine) {
       if (!allow_build_at_runtime_) {
         // Store an empty engine in the cache so we don't try to load the same

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
@@ -58,12 +58,17 @@ namespace tensorrt {
 using ::absl::StrCat;
 using ::testing::ElementsAre;
 
+struct TestParam {
+  bool static_engine;
+};
+
 class TRTEngineOpTestBase : public OpsTestBase {
  public:
   void AddSimpleTrtOp(DataType dtype, int max_cached_engines_count = 1,
                       PartialTensorShape shape = PartialTensorShape({-1, -1}),
                       bool use_implicit_batch = true,
-                      bool allow_build_at_runtime = true) {
+                      bool allow_build_at_runtime = true,
+                      bool static_engine = false) {
     // Create the GPU device.
     std::unique_ptr<Device> device(
         DeviceFactory::NewDevice("GPU", {}, "/job:worker/replica:0/task:0"));
@@ -81,6 +86,34 @@ class TRTEngineOpTestBase : public OpsTestBase {
     TF_ASSERT_OK(convert::RegisterGraphToFunctionLibrary(graph_def, graph,
                                                          std::string(kOpName)));
     TF_ASSERT_OK(flib_def_->AddLibrary(graph->flib_def()));
+
+    string segment_string;
+    if (static_engine) {
+      convert::ConversionParams params;
+      convert::EngineInfo info;
+      info.segment_graph_def.CopyFrom(graph_def);
+      info.precision_mode = TrtPrecisionMode::FP32;
+      info.max_workspace_size_bytes = 1 << 20;
+      info.engine_name = "TRTEngineOP_0_0";
+      params.use_implicit_batch = use_implicit_batch;
+      params.trt_logger_name = "DefaultLogger";
+
+      TrtShapeOptimizationProfile profile;
+      TensorShape my_shape;
+      // We set profile 0 to be incompatible with the input used in the test.
+      // This way we ensure that profile selection is tested.
+      TF_CHECK_OK(
+          TensorShapeUtils::MakeShape(std::vector<int32>{4, 2}, &my_shape));
+      profile.AddShape({my_shape, {}});
+      TF_CHECK_OK(
+          TensorShapeUtils::MakeShape(std::vector<int32>{1, 2}, &my_shape));
+      profile.AddShape({my_shape, {}});
+
+      profile.InitProfiles({shape}, ProfileStrategy::kOptimal);
+      std::vector<PartialTensorShape> shape_vec{shape, {}};
+      TF_CHECK_OK(convert::CreateStaticEngine(params, info, 1, shape_vec,
+                                              &profile, &segment_string));
+    }
 
     // Create the op.
     // In implicit batch mode, the input shapes that we specify here are not
@@ -102,9 +135,9 @@ class TRTEngineOpTestBase : public OpsTestBase {
                      .Input(FakeInput(1, dtype))
                      .Attr("input_shapes", {shape})
                      .Attr("output_shapes", {shape})
-                     .Attr("static_engine", false)
+                     .Attr("static_engine", static_engine)
                      .Attr("segment_func", function)
-                     .Attr("serialized_segment", "")
+                     .Attr("serialized_segment", segment_string)
                      .Attr("calibration_data", "")
                      .Attr("max_cached_engines_count", max_cached_engines_count)
                      .Attr("workspace_size_bytes", 1 << 20)
@@ -119,7 +152,7 @@ class TRTEngineOpTestBase : public OpsTestBase {
     TF_ASSERT_OK(InitOpWithFunctionLibrary());
   }
 
-  static constexpr absl::string_view kOpName = "myop";
+  static const absl::string_view kOpName;
 
   template <typename T>
   void AddSimpleInput(const TensorShape& shape) {
@@ -152,6 +185,24 @@ class TRTEngineOpTestBase : public OpsTestBase {
     return status;
   }
 };
+
+class TRTEngineOpTestWithParam
+    : public TRTEngineOpTestBase,
+      public ::testing::WithParamInterface<TestParam> {
+ public:
+  TRTEngineOpTestWithParam() : param_(GetParam()) {}
+
+ protected:
+  TestParam param_;
+};
+
+const absl::string_view TRTEngineOpTestBase::kOpName = "myop";
+
+constexpr std::array<TestParam, 2> TestParameters{TestParam{false},
+                                                  TestParam{true}};
+
+INSTANTIATE_TEST_CASE_P(TRTEngineOpTestInstantiation, TRTEngineOpTestWithParam,
+                        ::testing::ValuesIn(TestParameters));
 
 TEST_F(TRTEngineOpTestBase, DynamicEngines) {
   // Test dynamic engine creation during inference time
@@ -229,13 +280,15 @@ TEST_F(TRTEngineOpTestBase, AllowBuildAtRuntime) {
   EXPECT_EQ(ectx->cuda_engine, nullptr);
 }
 
-TEST_F(TRTEngineOpTestBase, ExplicitBatch) {
+TEST_P(TRTEngineOpTestWithParam, ExplicitBatch) {
   // Test inference in explicit batch mode with static input shapes. Static
   // shapes in this context means that the TensorRT knows all the input shapes
   // during engine creation time.
   TRTEngineOpTestBase::AddSimpleTrtOp(DT_FLOAT, /*max_cached_engines_count=*/1,
                                       /*shape=*/PartialTensorShape({1, 2}),
-                                      /*use_implicit_batch=*/false);
+                                      /*use_implicit_batch=*/false,
+                                      /*allow_build_at_runtime=*/true,
+                                      /*static_engine=*/param_.static_engine);
 
   TensorShape input_shape({1, 2});
   TRTEngineOpTestBase::AddSimpleInput<float>(input_shape);
@@ -254,7 +307,7 @@ TEST_F(TRTEngineOpTestBase, ExplicitBatch) {
   EXPECT_NE(ectx->cuda_engine, nullptr);
 }
 
-TEST_F(TRTEngineOpTestBase, DynamicShapes) {
+TEST_P(TRTEngineOpTestWithParam, DynamicShapes) {
   // Test inference in explicit batch mode with dynamic input shapes. Dynamic
   // shapes in this context means that some input shapes for TensorRT are
   // unknown during engine creation time. When we create the network, the
@@ -262,7 +315,9 @@ TEST_F(TRTEngineOpTestBase, DynamicShapes) {
   // have to be specified by calling setBindingDimensions.
   TRTEngineOpTestBase::AddSimpleTrtOp(DT_FLOAT, /*max_cached_engines_count=*/1,
                                       /*shape=*/PartialTensorShape({-1, -1}),
-                                      /*use_implicit_batch=*/false);
+                                      /*use_implicit_batch=*/false,
+                                      /*allow_build_at_runtime=*/true,
+                                      param_.static_engine);
 
   TensorShape input_shape({1, 2});
   TRTEngineOpTestBase::AddSimpleInput<float>(input_shape);
@@ -280,6 +335,15 @@ TEST_F(TRTEngineOpTestBase, DynamicShapes) {
   ASSERT_EQ(1, cache->count({input_shape}));
   EngineContext* ectx = cache->at({input_shape}).get();
   EXPECT_NE(ectx->cuda_engine, nullptr);
+
+  // Execute the op with an incompatible shape.
+  ResetInputs();
+  TRTEngineOpTestBase::AddSimpleInput<float>(TensorShape({1, 37}));
+  // Test that the op runs. This should fall back to native segment.
+  TF_ASSERT_OK(OpsTestBase::RunOpKernel());
+  // We should still have a single engine that is not compatible with the input.
+  EXPECT_EQ(1, cache->size());
+  EXPECT_EQ(0, cache->count({TensorShape({1, 37})}));
 }
 
 template <typename T>


### PR DESCRIPTION
This PR implements TRT optimization profile handling in case of static engine:
- Initializes the optimization profile helper class from ICudaEngine
- Select the optimization profile for the input shape

This is PR is necessary to use dynamic shape mode with static engines.

Tracker #52012

Tagging @bixia1 for review.