### PR TITLE
Migrate fuzzing to new atheris version

### DIFF
--- a/tensorflow/security/fuzzing/constant_fuzz.py
+++ b/tensorflow/security/fuzzing/constant_fuzz.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 # ==============================================================================
 """This is a Python API fuzzer for tf.constant."""
-import sys
-import atheris_no_libfuzzer as atheris
-import tensorflow as tf
+import atheris
+with atheris.instrument_imports():
+  import sys
+  import tensorflow as tf
 
 
 def TestOneInput(data):

--- a/tensorflow/security/fuzzing/dataFormatVecPermute_fuzz.py
+++ b/tensorflow/security/fuzzing/dataFormatVecPermute_fuzz.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 """This is a Python API fuzzer for tf.raw_ops.DataFormatVecPermute."""
-import sys
-import atheris_no_libfuzzer as atheris
-from python_fuzzing import FuzzingHelper
-import tensorflow as tf
+import atheris
+with atheris.instrument_imports():
+  import sys
+  from python_fuzzing import FuzzingHelper
+  import tensorflow as tf
 
 
+@atheris.instrument_func
 def TestOneInput(input_bytes):
   """Test randomized integer fuzzing input for tf.raw_ops.DataFormatVecPermute."""
   fh = FuzzingHelper(input_bytes)

--- a/tensorflow/security/fuzzing/immutableConst_fuzz.py
+++ b/tensorflow/security/fuzzing/immutableConst_fuzz.py
@@ -13,14 +13,16 @@
 # limitations under the License.
 # ==============================================================================
 """This is a Python API fuzzer for tf.raw_ops.ImmutableConst."""
-import sys
-import atheris_no_libfuzzer as atheris
-from python_fuzzing import FuzzingHelper
-import tensorflow as tf
+import atheris
+with atheris.instrument_imports():
+  import sys
+  from python_fuzzing import FuzzingHelper
+  import tensorflow as tf
 
 _DEFAULT_FILENAME = '/tmp/test.txt'
 
 
+@atheris.instrument_func
 def TestOneInput(input_bytes):
   """Test randomized integer fuzzing input for tf.raw_ops.ImmutableConst."""
   fh = FuzzingHelper(input_bytes)

--- a/tensorflow/security/fuzzing/raggedCountSparseOutput_fuzz.py
+++ b/tensorflow/security/fuzzing/raggedCountSparseOutput_fuzz.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 """This is a Python API fuzzer for tf.raw_ops.RaggedCountSparseOutput."""
-import sys
-import atheris_no_libfuzzer as atheris
-from python_fuzzing import FuzzingHelper
-import tensorflow as tf
+import atheris
+with atheris.instrument_imports():
+  import sys
+  from python_fuzzing import FuzzingHelper
+  import tensorflow as tf
 
 
+@atheris.instrument_func
 def TestOneInput(input_bytes):
   """Test randomized integer/float fuzzing input for tf.raw_ops.RaggedCountSparseOutput."""
   fh = FuzzingHelper(input_bytes)

--- a/tensorflow/security/fuzzing/sparseCountSparseOutput_fuzz.py
+++ b/tensorflow/security/fuzzing/sparseCountSparseOutput_fuzz.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 """This is a Python API fuzzer for tf.raw_ops.SparseCountSparseOutput."""
-import sys
-import atheris_no_libfuzzer as atheris
-from python_fuzzing import FuzzingHelper
-import tensorflow as tf
+import atheris
+with atheris.instrument_imports():
+  import sys
+  from python_fuzzing import FuzzingHelper
+  import tensorflow as tf
 
 
+@atheris.instrument_func
 def TestOneInput(input_bytes):
   """Test randomized integer fuzzing input for tf.raw_ops.SparseCountSparseOutput."""
   fh = FuzzingHelper(input_bytes)

--- a/tensorflow/security/fuzzing/tf2migration_fuzz.py
+++ b/tensorflow/security/fuzzing/tf2migration_fuzz.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 """This is a Python API fuzzer for v1 vs v2 API comparison."""
-import sys
-import atheris_no_libfuzzer as atheris
-from python_fuzzing import FuzzingHelper
-import tensorflow as tf
+import atheris
+with atheris.instrument_imports():
+  import sys
+  from python_fuzzing import FuzzingHelper
+  import tensorflow as tf
 
 
+@atheris.instrument_func
 def TestOneInput(input_bytes):
   """Test randomized integer fuzzing input for v1 vs v2 APIs."""
   fh = FuzzingHelper(input_bytes)


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

Recently Atheris the Python fuzzer used by tensorflow-py in the OSS-Fuzz repository had an update. This has caused the fuzzers not to build in OSS-Fuzz and consequentially the fuzzers need to be re-written in the way they handle instrumentation of code. This PR fixes this.

Please see the following PR on OSS-Fuzz where the new atheris version is outlined: https://github.com/google/oss-fuzz/pull/6060

Cross-referencing this PR https://github.com/google/oss-fuzz/pull/6417 on the OSS-Fuzz repo as in that PR I outline the build issue in the fuzzers. 