### PR TITLE
Removed README.md

### DIFF
--- a/tensorflow/python/profiler/model_analyzer.py
+++ b/tensorflow/python/profiler/model_analyzer.py
@@ -126,7 +126,6 @@ def _build_advisor_options(options):
 class Profiler(object):
   """TensorFlow multi-step profiler.
 
-  https://github.com/tensorflow/tensorflow/tree/master/tensorflow/core/profiler/README.md
 
   ```python
   Typical use case:


### PR DESCRIPTION
Since the URL is showing 404 error and alternative URL is not present in the repo for README file removed URL https://github.com/tensorflow/tensorflow/tree/master/tensorflow/core/profiler/README.md from the file.