### PR TITLE
[XLA] Make EmitFullWarpShuffleDownLoopForReduce test the required condition.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
@@ -560,7 +560,8 @@ class IrEmitterUnnested : public IrEmitter {
   // reduction: each one should get the output value.
   void EmitFullWarpShuffleDownLoopForReduce(
       const HloComputation* reducer,
-      absl::Span<llvm::Value* const> partial_result_addresses);
+      absl::Span<llvm::Value* const> partial_result_addresses,
+      int threads_per_block);
 
   StatusOr<std::unique_ptr<Thunk>> BuildKernelThunkImpl(
       absl::string_view name, Thunk::ThunkInfo thunk_info,


### PR DESCRIPTION
@cheshire 

This check was recently removed by commit 3b9f82ecd122352c65a26b9b8943e8da73f3e77c. As it is very hard to detect an error, it is better to keep it.