### PR TITLE
fix a document typo in registration.h

### DIFF
--- a/tensorflow/core/framework/registration/registration.h
+++ b/tensorflow/core/framework/registration/registration.h
@@ -141,7 +141,7 @@ struct InitOnStartupMarker {
 //
 // Usage:
 //   #define M_IMPL(id, a, b) ...
-//   #define M(a, b) TF_NEW_ID_FOR_INIT(M, a, b)
+//   #define M(a, b) TF_NEW_ID_FOR_INIT(M_IMPL, a, b)
 #define TF_NEW_ID_FOR_INIT_2(m, c, ...) m(c, __VA_ARGS__)
 #define TF_NEW_ID_FOR_INIT_1(m, c, ...) TF_NEW_ID_FOR_INIT_2(m, c, __VA_ARGS__)
 #define TF_NEW_ID_FOR_INIT(m, ...) \


### PR DESCRIPTION
i found a little typo in the explanation comment of "TF_NEW_ID_FOR_INIT"  in registration.h.
line 144:   //   #define M(a, b) TF_NEW_ID_FOR_INIT(M, a, b)
          ->   //   #define M(a, b) TF_NEW_ID_FOR_INIT(M_IMPL, a, b)
lower one is correct. thank you.