### PR TITLE
Use "pluggable_device_host_bfc" instead of "cpu" allocator when `_Send` to (`_Recv` on) host memory

### DIFF
--- a/tensorflow/core/common_runtime/pluggable_device/pluggable_device.cc
+++ b/tensorflow/core/common_runtime/pluggable_device/pluggable_device.cc
@@ -282,16 +282,16 @@ void PluggableDevice::Compute(OpKernel* op_kernel, OpKernelContext* context) {
     if (sync_every_op_) {
       context->SetStatus(PluggableDeviceUtil::Sync(this));
       if (vlog_1) {
-        VLOG(1) << "PluggableDevice::ComputeHelper finished"
+        VLOG(1) << "PluggableDevice::ComputeHelper finished "
                 << ComputeOpKernelDebugString(*op_kernel, stream_id);
       }
     } else if (vlog_1) {
-      VLOG(1) << "PluggableDevice::ComputeHelper scheduled"
+      VLOG(1) << "PluggableDevice::ComputeHelper scheduled "
               << ComputeOpKernelDebugString(*op_kernel, stream_id);
     }
   } else {
     if (vlog_1) {
-      VLOG(1) << "PluggableDevice::ComputeHelper failed to schedule"
+      VLOG(1) << "PluggableDevice::ComputeHelper failed to schedule "
               << ComputeOpKernelDebugString(*op_kernel, stream_id);
     }
   }

--- a/tensorflow/core/common_runtime/rendezvous_mgr.cc
+++ b/tensorflow/core/common_runtime/rendezvous_mgr.cc
@@ -83,6 +83,12 @@ void SameWorkerRecvDone(const DeviceMgr* device_mgr,
   attr.set_gpu_compatible(send_args.alloc_attrs.gpu_compatible() ||
                           recv_args.alloc_attrs.gpu_compatible());
   Allocator* out_allocator = dst_device->GetAllocator(attr);
+  // Use "pluggable_device_host_bfc" allocator for host memory
+  if (parsed.dst.type == "CPU" &&
+      DeviceFactory::IsPluggableDevice(parsed.src.type)) {
+    attr.set_on_host(true);
+    out_allocator = src_device->GetAllocator(attr);
+  }
   bool sync_dst_compute = true;
   if (in.dtype() != DT_VARIANT) {
     // Variants are handled by CopyTensor::ViaDMA.


### PR DESCRIPTION
1. Use "pluggable_device_host_bfc" instead of "cpu" allocator when _Send to (_Recv on) host memory
2. format logs in pluggable device