### PR TITLE
🔧 Loosen version constraints on `typing-extensions`

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -91,7 +91,9 @@ REQUIRED_PACKAGES = [
     'protobuf >= 3.9.2',
     'six ~= 1.15.0',
     'termcolor ~= 1.1.0',
-    'typing_extensions ~= 3.7.4',
+    # Some packages like black and pylint require typing-extensions >= 3.10, so
+    # we allow higher typing-extensions versions here to prevent conflicts
+    'typing-extensions >= 3.7, < 3.11',
     'wheel ~= 0.35',
     'wrapt ~= 1.12.1',
     # These packages need to be pinned exactly as newer versions are


### PR DESCRIPTION
These changes loosen the version constraints on `typing-extensions` to allow TensorFlow to be installed alongside packages that require `typing-extensions >= 3.10`, such as newer versions of Black and PyLint.

Previously TensorFlow required a `typing-extensions` version in the `3.7.x` series. However, the newer `3.10.x` series is fully backwards-compatible with the `3.7.x` series (and there are no `3.8.x` or `3.9.x` series). Therefore, these changes allow `typing-extensions` to be installed using either the `3.7.x` or `3.10.x` series.

In order to ensure that any future backwards-incompatible changes in the `typing-extensions` package don't cause issues, TensorFlow's dependency on `typing-extensions` does not allow versions from the `3.11.x` series or beyond (`< 3.11`).

Fixes #51743.

I wasn't able to run the unit tests locally due to #47989, but I'm hoping that since this is such a minor change all tests will pass successfully 😅