### PR TITLE
Add better determinism error messages to some random ops.

### DIFF
--- a/tensorflow/python/kernel_tests/fractional_max_pool_op_test.py
+++ b/tensorflow/python/kernel_tests/fractional_max_pool_op_test.py
@@ -307,6 +307,22 @@ class FractionalMaxPoolTest(test.TestCase):
           input_b, row_seq, col_seq, overlapping)
       self.assertSequenceEqual(expected.shape, actual.shape)
 
+  def testDeterminismExceptionThrowing(self):
+    tensor_shape = (5, 20, 20, 3)
+    rand_mat = self._PRNG.random_sample(tensor_shape) * 1000 - 500
+    with test_util.deterministic_ops():
+      with self.assertRaisesRegex(
+          ValueError, 'requires a non-zero seed to be passed in when '
+                      'determinism is enabled'):
+        nn_ops.fractional_max_pool_v2(rand_mat, [1, 1.5, 1.5, 1])
+      nn_ops.fractional_max_pool_v2(rand_mat, [1, 1.5, 1.5, 1], seed=1)
+
+      with self.assertRaisesRegex(
+          ValueError, 'requires "seed" and "seed2" to be non-zero'):
+        nn_ops.fractional_max_pool(rand_mat, [1, 1.5, 1.5, 1])
+      nn_ops.fractional_max_pool(rand_mat, [1, 1.5, 1.5, 1],
+                                 seed=1, seed2=1, deterministic=True)
+
 
 class FractionalMaxPoolGradTest(test.TestCase):
   """Tests for FractionalMaxPoolGrad.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -22,6 +22,7 @@ import functools
 import numpy as np
 
 from tensorflow.python.eager import def_function
+from tensorflow.python.framework import config
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -3382,7 +3383,15 @@ def sample_distorted_bounding_box_v2(image_size,
     the distorted bounding box.
     Provide as input to `tf.image.draw_bounding_boxes`.
   """
-  seed1, seed2 = random_seed.get_seed(seed) if seed else (0, 0)
+  if seed:
+    seed1, seed2 = random_seed.get_seed(seed)
+  else:
+    if config.is_op_determinism_enabled():
+      raise ValueError(
+          'tf.image.sample_distorted_bounding_box requires a non-zero seed to '
+          'be passed in when determinism is enabled. Please pass in a non-zero '
+          'seed, e.g. by passing "seed=1".')
+    seed1, seed2 = (0, 0)
   with ops.name_scope(name, 'sample_distorted_bounding_box'):
     return gen_image_ops.sample_distorted_bounding_box_v2(
         image_size,
@@ -3622,6 +3631,11 @@ def sample_distorted_bounding_box(image_size,
     the distorted bounding box.
       Provide as input to `tf.image.draw_bounding_boxes`.
   """
+  if not seed and not seed2 and config.is_op_determinism_enabled():
+    raise ValueError(
+        'tf.compat.v1.image.sample_distorted_bounding_box requires "seed" or '
+        '"seed2" to be non-zero when determinism is enabled. Please pass in '
+        'a non-zero seed, e.g. by passing "seed=1".')
   with ops.name_scope(name, 'sample_distorted_bounding_box'):
     return gen_image_ops.sample_distorted_bounding_box_v2(
         image_size,

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -2658,6 +2658,29 @@ class SelectDistortedCropBoxTest(test_util.TensorFlowTestCase):
       self.assertAllEqual([3], end.shape)
       self.assertAllEqual([1, 1, 4], bbox_for_drawing.shape)
 
+  def testDeterminismExceptionThrowing(self):
+    with test_util.deterministic_ops():
+      with self.assertRaisesRegex(
+          ValueError, 'requires a non-zero seed to be passed in when '
+                      'determinism is enabled'):
+        image_ops_impl.sample_distorted_bounding_box_v2(
+            image_size=[50, 50, 1],
+            bounding_boxes=[[[0., 0., 1., 1.]]],)
+      image_ops_impl.sample_distorted_bounding_box_v2(
+          image_size=[50, 50, 1],
+          bounding_boxes=[[[0., 0., 1., 1.]]],
+          seed=1)
+
+      with self.assertRaisesRegex(
+          ValueError, 'requires "seed" or "seed2" to be non-zero when '
+                      'determinism is enabled'):
+        image_ops_impl.sample_distorted_bounding_box(
+            image_size=[50, 50, 1],
+            bounding_boxes=[[[0., 0., 1., 1.]]])
+      image_ops_impl.sample_distorted_bounding_box(
+          image_size=[50, 50, 1],
+          bounding_boxes=[[[0., 0., 1., 1.]]],
+          seed=1)
 
 class ResizeImagesV2Test(test_util.TensorFlowTestCase, parameterized.TestCase):
 

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -5813,6 +5813,13 @@ def fractional_max_pool(value,
       [Graham, 2015](https://arxiv.org/abs/1412.6071)
       ([pdf](https://arxiv.org/pdf/1412.6071.pdf))
   """
+  if config.is_op_determinism_enabled() and (not seed or not seed2 or
+                                             not deterministic):
+    raise ValueError(
+        'tf.compat.v1.nn.fractional_max_pool requires "seed" and '
+        '"seed2" to be non-zero and "deterministic" to be true when op '
+        'determinism is enabled. Please pass in such values, e.g. by passing'
+        '"seed=1, seed2=1, deterministic=True"')
   return gen_nn_ops.fractional_max_pool(value, pooling_ratio, pseudo_random,
                                         overlapping, deterministic, seed, seed2,
                                         name)
@@ -5914,6 +5921,11 @@ def fractional_max_pool_v2(value,
   pooling_ratio = _get_sequence(pooling_ratio, 2, 3, "pooling_ratio")
 
   if seed == 0:
+    if config.is_op_determinism_enabled():
+      raise ValueError(
+          'tf.nn.fractional_max_pool requires a non-zero seed to be passed in '
+          'when determinism is enabled. Please pass in a non-zero seed, e.g. '
+          'by passing "seed=1".')
     return gen_nn_ops.fractional_max_pool(value, pooling_ratio, pseudo_random,
                                           overlapping, deterministic=False,
                                           seed=0, seed2=0, name=name)


### PR DESCRIPTION
Better error messages were added to `tf.image.sample_distorted_bounding_box` and `tf.nn.fractional_max_pool` when determinism is enabled and no seed is passed. Such ops do not use the global seed by default, and so a seed must be passed to such ops.