### PR TITLE
[TF:TRT] Always set binding dimension

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -1563,7 +1563,14 @@ Status Converter::BuildCudaEngine(
     int nbBindings = (*engine)->getNbBindings();
     VLOG(2) << "Number of engine bindings: " << nbBindings;
     for (int i = 0; i < nbBindings; i++) {
-      VLOG(2) << "Binding " << i << " name: " << (*engine)->getBindingName(i);
+      auto get_location_string = [&engine](int i) {
+        if ((*engine)->getLocation(i) == nvinfer1::TensorLocation::kDEVICE)
+          return " on device";
+        else
+          return " on host";
+      };
+      VLOG(2) << "Binding " << i << " name: " << (*engine)->getBindingName(i)
+              << get_location_string(i);
     }
   }
   return Status::OK();

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
@@ -94,16 +94,11 @@ struct OptimizationProfileConfig {
         profile->setShapeValues(name, nvinfer1::OptProfileSelector::kMAX,
                                 max[idx].d, max[idx].nbDims);
       }
-      if (input->isExecutionTensor()) {
-        VLOG(2) << "Setting input dimensions for " << name << ", "
-                << ::tensorflow::tensorrt::DebugString(opt[i]);
-        profile->setDimensions(name, nvinfer1::OptProfileSelector::kMIN,
-                               min[i]);
-        profile->setDimensions(name, nvinfer1::OptProfileSelector::kOPT,
-                               opt[i]);
-        profile->setDimensions(name, nvinfer1::OptProfileSelector::kMAX,
-                               max[i]);
-      }
+      VLOG(2) << "Setting input dimensions for " << name << ", "
+              << ::tensorflow::tensorrt::DebugString(opt[i]);
+      profile->setDimensions(name, nvinfer1::OptProfileSelector::kMIN, min[i]);
+      profile->setDimensions(name, nvinfer1::OptProfileSelector::kOPT, opt[i]);
+      profile->setDimensions(name, nvinfer1::OptProfileSelector::kMAX, max[i]);
     }
     return Status::OK();
   }

--- a/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
@@ -1,0 +1,66 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Model script to test TF-TensorRT integration."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.compiler.tensorrt.test import tf_trt_integration_test_base as trt_test
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.platform import test
+
+
+class ShapeOutputTest(trt_test.TfTrtIntegrationTestBase):
+  """Test shape value output with TF-TRT."""
+
+  def setUp(self):
+    super(trt_test.TfTrtIntegrationTestBase, self).setUp()  # pylint: disable=bad-super-call
+    self.DisableNonTrtOptimizers()
+
+  def GraphFn(self, x):
+    # The first engine returns the shape of q, which equals the shape of x. The
+    # values of x are actually not needed for the TRT engine. This way x is
+    # neither a shape tensor nor an execution tensor, we still need to set its
+    # shape (binding dimensions). We confirm with this test that the binding
+    # dimensions of x are correctly set before we execute the engine.
+    q = 2 * x + 1
+    q = array_ops.shape(q)
+    q = math_ops.cast(q, dtypes.float32)
+    q = self.trt_incompatible_op(q)
+    q = q * 2 + q * q
+    return array_ops.identity(q, name="output_0")
+
+  def GetParams(self):
+    return self.BuildParamsWithMask(self.GraphFn, dtypes.float32,
+                            [[2, 2, 5, 3]], [[4]],
+                            extra_inputs=[[[8, 2, 5, 3]]],
+                            extra_outputs=[[[4]]],
+                            input_mask=[[False, True, True, True]],
+                            output_mask=[[True]])
+
+  def ExpectedEnginesToBuild(self, run_params):
+    """Returns the expected engines to build."""
+    if run_params.dynamic_shape:
+      return ["TRTEngineOp_0", "TRTEngineOp_1"]
+    else:
+      # Second segment not converted in implicit batch mode, because its
+      # tensors have only one dimensions
+      return ["TRTEngineOp_0"]
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
This PR fixes a bug related to shape value tensor handling and input shape specification: we need to set binding dimensions even if tensor is not an execution tensor

Background. According to nvinfer1::ITensor::isExecutionTensor API description:

> A tensor with isShapeTensor() == false and isExecutionTensor() == false can still show up as an input to the engine if its dimensions are required.

This PR fixes optimization profile definition for that case, by always calling execution_context->setBindingDimension().

A unit test is added to for such a case.

Tracker #45481

Tagging @bixia1 for review.