### PR TITLE
Fix tfl-to-tosa quantization intermediate type

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -811,6 +811,35 @@ func @test_matmul(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>) -> tensor<
 
 // -----
 
+// CHECK-LABEL: @test_fullyconnected
+func @test_fullyconnected(%arg0: tensor<14x19xf32>, %arg1: tensor<28x19xf32>, %arg2: tensor<28xf32>) -> tensor<14x28xf32> {
+  // CHECK: "tosa.fully_connected"
+  %2 = "tfl.fully_connected"(%arg0, %arg1, %arg2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<14x19xf32>, tensor<28x19xf32>, tensor<28xf32>) -> tensor<14x28xf32>
+  return %2 : tensor<14x28xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_fullyconnected_in_batch_dim
+func @test_fullyconnected_in_batch_dim(%arg0: tensor<1x14x19xf32>, %arg1: tensor<28x19xf32>, %arg2: tensor<28xf32>) -> tensor<14x28xf32> {
+  // CHECK: "tosa.reshape"
+  // CHECK: "tosa.fully_connected"
+  %0 = "tfl.fully_connected"(%arg0, %arg1, %arg2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<1x14x19xf32>, tensor<28x19xf32>, tensor<28xf32>) -> tensor<14x28xf32>
+  return %0 : tensor<14x28xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_fullyconnected_extra_dim
+func @test_fullyconnected_extra_dim(%arg0: tensor<1x14x19xf32>, %arg1: tensor<28x19xf32>, %arg2: tensor<28xf32>) -> tensor<1x14x28xf32> {
+  // CHECK: "tosa.reshape"
+  // CHECK: "tosa.fully_connected"
+  %0 = "tfl.fully_connected"(%arg0, %arg1, %arg2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<1x14x19xf32>, tensor<28x19xf32>, tensor<28xf32>) -> tensor<1x14x28xf32>
+  return %0 : tensor<1x14x28xf32>
+}
+
+// -----
+
 // CHECK-LABEL: test_add_scalar
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<1.000000e+00> : tensor<f32>}
 // CHECK-DAG: %[[VAR1:.*]] = "tosa.reshape"(%[[VAR0]]) {new_shape = [1, 1, 1]}

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -1325,7 +1325,7 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
     // value. TOSA requires bias to be an array of output_channel_count values,
     // so create a constant of the appropriate number and type of zeros.
     SmallVector<int64_t, 1> bias_shape({filter_type.getShape()[0]});
-    RankedTensorType bias_type =
+    RankedTensorType new_bias_type =
         RankedTensorType::get(bias_shape, input_type.getElementType());
 
     DenseElementsAttr bias_attr;
@@ -1336,7 +1336,7 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
         bias_arr[i] = 0.0;
       }
       bias_attr =
-          DenseElementsAttr::get(bias_type, llvm::makeArrayRef(bias_arr));
+          DenseElementsAttr::get(new_bias_type, llvm::makeArrayRef(bias_arr));
     } else {
       SmallVector<int32_t> bias_arr(bias_shape[0]);
 
@@ -1344,11 +1344,12 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
         bias_arr[i] = 0;
       }
       bias_attr =
-          DenseElementsAttr::get(bias_type, llvm::makeArrayRef(bias_arr));
+          DenseElementsAttr::get(new_bias_type, llvm::makeArrayRef(bias_arr));
     }
     auto bias_op = CreateOpAndInfer<tosa::ConstOp>(rewriter, op->getLoc(),
-                                                   bias_type, bias_attr);
+                                                   new_bias_type, bias_attr);
     bias_val = bias_op.getResult();
+    bias_type = new_bias_type;
   } else {
     bias_val = tfl_fc_op.bias();
   }
@@ -1356,7 +1357,7 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
   Type bias_ety = bias_val.getType().cast<ShapedType>().getElementType();
 
   auto fc_op = CreateOpAndInfer<tosa::FullyConnectedOp>(
-      rewriter, op->getLoc(), output_type.clone(bias_ety), input_val,
+      rewriter, op->getLoc(), UnrankedTensorType::get(bias_ety), input_val,
       tfl_fc_op.filter(), bias_val);
 
   Value fc_output;
@@ -1365,6 +1366,18 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
                                          input_type, filter_type, output_type);
   } else {
     fc_output = fc_op.getResult();
+  }
+
+  // If we know the output rank, we need to ensure the output shape is correct.
+  ShapedType fc_type = fc_output.getType().cast<ShapedType>();
+  if (output_type.hasRank() && fc_type.getRank() != output_type.getRank()) {
+    llvm::SmallVector<int64_t> output_shape;
+
+    fc_output = CreateOpAndInfer<tosa::ReshapeOp>(
+      rewriter, op->getLoc(),
+      UnrankedTensorType::get(fc_type.getElementType()),
+      fc_output,
+      rewriter.getI64ArrayAttr(output_type.getShape()));
   }
 
   auto fused_activation_fn = tfl_fc_op.fused_activation_functionAttr();


### PR DESCRIPTION
Intermediate quantized type should be an I32 under all circumstances however
the lowering assumed the intermediate type was the same as the output type.
This recently appeared due to some changes in the linalg compilation.