### PR TITLE
[TF] Creates a Github Issue on PR rollback

### DIFF
--- a/.github/workflows/issue-on-pr-rollback.yml
+++ b/.github/workflows/issue-on-pr-rollback.yml
@@ -1,0 +1,56 @@
+# This is a basic workflow that is manually triggered
+
+name: Creates a GitHub Issue when a PR Rolled back via Commit to Master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  create-issue-on-pr-rollback:
+    runs-on: ubuntu-latest
+    if: "contains(github.event.head_commit.message, '[ROLLBACK_PR=')"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Creates a new Github Issue if a merged PR is rolled back
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const rollback_commit = context.payload.head_commit.id
+            const pr_match_groups = context.payload.head_commit.message.match(/\[ROLLBACK_PR=(\d+).*/) || []
+            if (pr_match_groups.length != 2) {
+              console.log(`PR Number not found in ${context.payload.head_commit.message}`)
+              throw "Error extracting PR Number from commit message"
+            }
+            const pr_number = parseInt(pr_match_groups[1])
+            const owner = context.payload.repository.owner.name
+            const repo = context.payload.repository.name
+            console.log(`Original PR: ${pr_number} and Rollback Commit: ${rollback_commit}`)
+            // Get the Original PR Details
+            const pr_resp = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pr_number
+            })
+            if (pr_resp.status != 200 || pr_resp.data.state != 'closed') {
+              console.log(`PR:{pr_number} is not found or closed.  Not a valid condition to create an issue.`)
+              console.log(pr_resp)
+              throw `PR:{pr_number} needs to be valid and closed (merged)`
+            }
+            const pr_title = pr_resp.data.title
+            // Assign to PR owner and reviewers
+            let assignees = pr_resp.data.assignees
+            assignees.push(pr_resp.data.user.login)
+            // Create an new GH Issue and reference the Original PR
+            const resp = await github.rest.issues.create({
+              owner,
+              repo,
+              assignees,             
+              title: `Issue created for Rollback of PR #${pr_number}: ${pr_title}`,
+              body: `Merged PR #${pr_number} is rolled back in ${rollback_commit}.  
+              Please follow up with the reviewer and close this issue once its resolved.`
+            })
+            console.log(`Issue created: ${resp.data.number} with Title: ${resp.data.title}`)


### PR DESCRIPTION
Creates a GitHub issue when a Merged PR is rolledback.  

The rollback commit is expected to have text `[ROLLBACK_PR=<pr_number>]` in the message.  If the Commit doesn't have this specific tag, this GitHub action is skipped.