### PR TITLE
[TF:TRT] Fix profile handling for pruned inputs

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -281,6 +281,7 @@ tf_cuda_cc_test(
         "//tensorflow/core/kernels:resource_variable_ops",
         "@com_google_absl//absl/container:inlined_vector",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",      
     ],
 )
 

--- a/tensorflow/compiler/tf2tensorrt/common/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <tuple>
 
 #include "absl/strings/str_join.h"
+#include "tensorflow/core/lib/core/status.h"
 
 namespace tensorflow {
 namespace tensorrt {
@@ -86,6 +87,26 @@ namespace tensorrt {
 // Initializes the TensorRT plugin registry if this hasn't been done yet.
 void MaybeInitializeTrtPlugins(nvinfer1::ILogger* trt_logger);
 
+class IONamePrefixes {
+ public:
+  static constexpr const char* const kInputPHName = "TensorRTInputPH_";
+  static constexpr const char* const kOutputPHName = "TensorRTOutputPH_";
+};
+
+// Gets the binding index of a tensor in an engine.
+//
+// The binding index is looked up using the tensor's name and the profile index.
+// Profile index should be set to zero, if we do not have optimization profiles.
+Status GetTrtBindingIndex(const char* tensor_name, int profile_index,
+                          const nvinfer1::ICudaEngine* cuda_engine,
+                          int* binding_index);
+
+// Gets the binding index of a tensor in an engine.
+//
+// Same as above, but uses the network input index to identify the tensor.
+Status GetTrtBindingIndex(int network_input_idx, int profile_index,
+                          const nvinfer1::ICudaEngine* cuda_engine,
+                          int* binding_index);
 }  // namespace tensorrt
 }  // namespace tensorflow
 

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -40,12 +40,6 @@ namespace tensorrt {
 
 static constexpr char kCastOutputTypeAttrName[] = "DstT";
 
-class IONamePrefixes {
- public:
-  static constexpr const char* const kInputPHName = "TensorRTInputPH_";
-  static constexpr const char* const kOutputPHName = "TensorRTOutputPH_";
-};
-
 template <typename T>
 struct TrtDestroyer {
   void operator()(T* t) {

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -1080,8 +1080,8 @@ StatusOr<std::pair<EngineContext*, int>> TRTEngineOp::GetEngine(
     if (static_engine && !use_implicit_batch_) {
       // load profiles
       std::vector<ExecutionContext> exec_contexts;
-      TF_RETURN_IF_ERROR(
-          cache_res->profiles_.RestoreProfiles(static_engine.get()));
+      TF_RETURN_IF_ERROR(cache_res->profiles_.RestoreProfiles(
+          static_engine.get(), ctx->num_inputs()));
       TF_RETURN_IF_ERROR(cache_res->profiles_.CreateExecutionContexts(
           static_engine.get(), &exec_contexts));
       cache.emplace(input_concrete_shapes,

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
@@ -144,7 +144,8 @@ class InitializeTRTResource : public OpKernel {
         // Restore profiles if there are any. Currently only 1 engine is allowed
         // in dynamic mode therefore we call this only for the 0th engine.
         // it is a no-op in implicit batch mode.
-        OP_REQUIRES_OK(ctx, resource->profiles_.RestoreProfiles(raw_engine));
+        OP_REQUIRES_OK(ctx, resource->profiles_.RestoreProfiles(
+                                raw_engine, engine_input_shapes.size()));
         OP_REQUIRES_OK(ctx, resource->profiles_.CreateExecutionContexts(
                                 raw_engine, &ctx_vec));
       } else {

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
@@ -20,7 +20,9 @@ limitations under the License.
 
 #include "absl/container/inlined_vector.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/str_join.h"
 #include "tensorflow/compiler/tf2tensorrt/common/datavec.h"
+#include "tensorflow/compiler/tf2tensorrt/common/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_engine_instance.pb.h"  // NOLINT
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"
@@ -96,7 +98,8 @@ class TRTEngineResourceOpsTest
                                      ITensorProxyPtr input) {
     nvinfer1::Dims dims2{1, {2}};
     ITensorProxyPtr input2 =
-        network->addInput("input2", nvinfer1::DataType::kINT32, dims2);
+        network->addInput(absl::StrCat(IONamePrefixes::kInputPHName, 1).c_str(),
+                          nvinfer1::DataType::kINT32, dims2);
     EXPECT_NE(nullptr, input2->trt_tensor());
 
     nvinfer1::Dims start{2, {0, 0}};
@@ -137,9 +140,9 @@ class TRTEngineResourceOpsTest
     if (this->param_.dynamic_shape) {
       std::fill(dims.d, dims.d + dims.nbDims, -1);
     }
-    const char* in_name = "input";
+    const std::string in_name = StrCat(IONamePrefixes::kInputPHName, 0);
     ITensorProxyPtr input =
-        network->addInput(in_name, nvinfer1::DataType::kFLOAT, dims);
+        network->addInput(in_name.c_str(), nvinfer1::DataType::kFLOAT, dims);
     EXPECT_NE(nullptr, input->trt_tensor());
     // Mark the output.
     ITensorProxyPtr output =
@@ -276,8 +279,13 @@ TEST_P(TRTEngineResourceOpsTest, Basic) {
   TrtUniquePtrType<nvinfer1::ICudaEngine> engine = CreateTRTEngine();
   ExecutionContext context = ExecutionContext::Create(engine.get());
 
+  std::vector<TensorShape> engine_input_shape(1);
+  TrtDimsToTensorShape(param_.dims, &(engine_input_shape[0]));
+  if (param_.n_inputs > 1) {
+    engine_input_shape.push_back(TensorShape({1, 1}));
+  }
   resource->cache_.emplace(
-      std::vector<TensorShape>{TensorShape({1, 1})},
+      engine_input_shape,
       absl::make_unique<EngineContext>(std::move(engine), std::move(context)));
   // Check that the resource has multiple references before it is unregistered
   // from the resource manager.
@@ -320,10 +328,11 @@ TEST_P(TRTEngineResourceOpsTest, Basic) {
   TF_ASSERT_OK(reader->ReadRecord(&offset, &record));
   TRTEngineInstance engine_instance;
   engine_instance.ParseFromString(record);
-  EXPECT_EQ(1, engine_instance.input_shapes_size());
-  EXPECT_EQ(2, engine_instance.input_shapes(0).dim_size());
-  EXPECT_EQ(1, engine_instance.input_shapes(0).dim(0).size());
-  EXPECT_EQ(1, engine_instance.input_shapes(0).dim(1).size());
+  EXPECT_EQ(param_.n_inputs, engine_instance.input_shapes_size());
+  EXPECT_EQ(param_.dims.nbDims, engine_instance.input_shapes(0).dim_size());
+  for (int i = 0; i < param_.dims.nbDims; i++) {
+    EXPECT_EQ(param_.dims.d[i], engine_instance.input_shapes(0).dim(i).size());
+  }
   EXPECT_TRUE(errors::IsOutOfRange(reader->ReadRecord(&offset, &record)));
 
   // Recreate the resource and use the file with the serialized engine to

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <vector>
 
 #include "tensorflow/compiler/tf2tensorrt/common/datavec.h"
+#include "tensorflow/compiler/tf2tensorrt/common/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -36,14 +37,6 @@ using ::stream_executor::port::StatusOr;
 
 // Creates a TensorRT execution context.
 ExecutionContext CreateExecutionContext(nvinfer1::ICudaEngine* cuda_engine);
-
-// Gets the binding index of a tensor in an engine.
-//
-// The binding index is looked up using the tensor's name and the profile index.
-// Profile index should be set to zero, if we do not have optimization profiles.
-Status GetTrtBindingIndex(const char* tensor_name, int profile_index,
-                          const nvinfer1::ICudaEngine* cuda_engine,
-                          int* binding_index);
 
 // Sets input buffers for TRT from a list of input tensors. The input tensors
 // are either defined by ctx or by input_vec.

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <functional>
 
 #include "absl/algorithm/container.h"
+#include "tensorflow/compiler/tf2tensorrt/common/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/core/platform/stream_executor.h"
 
@@ -347,7 +348,8 @@ Status TrtShapeOptimizationProfile::AddProfiles(
   // Update the the mask that flag shape tensors. The network is known now,
   // the mask will be correct.
   SetShapeTensorMask(network);
-  // if TRT_VERSION < 6, then we do not need to add.
+  is_pruned_input_.resize(network->getNbInputs());
+  absl::c_fill(is_pruned_input_, false);
   return Status::OK();
 }
 
@@ -363,7 +365,12 @@ void TrtShapeOptimizationProfile::SetShapeTensorMask(
     const nvinfer1::ICudaEngine* engine, int n_inputs) {
   is_shape_tensor_.resize(n_inputs, false);
   for (int i = 0; i < n_inputs; i++) {
-    is_shape_tensor_[i] = engine->isShapeBinding(i);
+    int binding_index;
+    Status status = GetTrtBindingIndex(i, 0, engine, &binding_index);
+    if (!status.ok()) {
+      continue;
+    }
+    is_shape_tensor_[i] = engine->isShapeBinding(binding_index);
     if (is_shape_tensor_[i]) {
       VLOG(2) << "Found shape tensor at " << i;
     }
@@ -410,7 +417,7 @@ int TrtShapeOptimizationProfile::GetProfileNumber(
   // TODO(tfeher): Return the best profile not just the first compatible.
   for (int i = 0; i < profiles_.size(); i++) {
     if (profiles_[i].IncludesShapes(shapes, HasShapeTensor(),
-                                    actual_shape_values_)) {
+                                    actual_shape_values_, is_pruned_input_)) {
       return i;
     }
   }
@@ -491,8 +498,27 @@ nvinfer1::Dims GetDimsFromShapeVal(int prof_idx, int binding_idx,
   return {0, {0}};
 }
 
+Status TrtShapeOptimizationProfile::SetPrunedMask(
+    const nvinfer1::ICudaEngine* engine, int n_network_inputs) {
+  is_pruned_input_.resize(n_network_inputs);
+  absl::c_fill(is_pruned_input_, false);
+  for (int j = 0; j < n_network_inputs; j++) {
+    int binding_idx;
+    Status status = GetTrtBindingIndex(j, 0, engine, &binding_idx);
+    if (IS_TRT_VERSION_GE(8, 0, 0, 0)) {
+      TF_RETURN_IF_ERROR(status);
+    } else if (!status.ok()) {
+      // Before TRT 8, an input tensor can be pruned (nvbugs/3153064)
+      is_pruned_input_[j] = true;
+      VLOG(2) << "Skipping pruned input " << j;
+      continue;
+    }
+  }
+  return Status::OK();
+}
+
 Status TrtShapeOptimizationProfile::RestoreProfiles(
-    const nvinfer1::ICudaEngine* engine) {
+    const nvinfer1::ICudaEngine* engine, int n_network_inputs) {
   need_profiles_ = false;
   if (!engine) {
     // We do not need to restore profiles for an empty engine.
@@ -509,25 +535,27 @@ Status TrtShapeOptimizationProfile::RestoreProfiles(
   int K = n_bindings / n_profiles;
 #endif
   int n_inputs = GetNumberOfEngineInputs(engine);
+  if (n_inputs > n_network_inputs) {
+    return errors::Internal("Incorrect number of engine inputs");
+  }
   VLOG(2) << "Attempting to restore " << n_profiles << " profiles, each with "
           << n_inputs << " inputs";
-  SetShapeTensorMask(engine, n_inputs);
+  SetShapeTensorMask(engine, n_network_inputs);
+
+  SetPrunedMask(engine, n_network_inputs);
+
   for (int prof_idx = 0; prof_idx < n_profiles; prof_idx++) {
     OptimizationProfileConfig cfg;
 
-    cfg.min.resize(n_inputs * 2);
-    cfg.max.resize(n_inputs * 2);
-    cfg.opt.resize(n_inputs * 2);
+    cfg.min.resize(n_network_inputs * 2);
+    cfg.max.resize(n_network_inputs * 2);
+    cfg.opt.resize(n_network_inputs * 2);
     // restore shape values
-    for (int j = 0; j < n_inputs; j++) {
-#if IS_TRT_VERSION_GE(7, 1, 3, 0)
-      // TODO(tfeher): consider getting the binding idx from
-      // GetTrtBindingIndex. To make that work we need to construct the input
-      // name similarily as it is done in SetTrtEngineInputs.
-      int binding_idx = prof_idx * K + j;
-#else
-      int binding_idx = j;
-#endif
+    for (int j = 0; j < n_network_inputs; j++) {
+      if (is_pruned_input_[j]) continue;
+      int binding_idx;
+      TF_RETURN_IF_ERROR(GetTrtBindingIndex(j, 0, engine, &binding_idx));
+
       nvinfer1::Dims min = engine->getProfileDimensions(
           binding_idx, prof_idx, nvinfer1::OptProfileSelector::kMIN);
       nvinfer1::Dims max = engine->getProfileDimensions(

--- a/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
@@ -115,5 +115,74 @@ class ShapeOutputWithSingleInputAndReshape(trt_test.TfTrtIntegrationTestBase):
     return ["TRTEngineOp_0", "TRTEngineOp_1"]
 
 
+class PrunedInputTest(trt_test.TfTrtIntegrationTestBase):
+  """ In TRT 7, an input tensor can be pruned if it is not used by the network.
+  This happens if only its shape is used, but the shape is already defined by
+  the optimization profile by setting min=max. (nvbugs/3153064)
+
+  After pruning, the TRT network has no input bindings.
+  """
+
+  def setUp(self):
+    super().setUp()
+    self.DisableNonTrtOptimizers()
+
+  def GraphFn(self, x):
+    q = array_ops.shape(x)
+    q = q * 2 + q * q
+    return array_ops.identity(q, name="output_0")
+
+  def GetParams(self):
+    return self.BuildParamsWithMask(
+        self.GraphFn, dtypes.float32,
+        [[1, 2, 5, 3]], [[4]],
+        extra_inputs=[],
+        extra_outputs=[],
+        input_mask=[[False, True, True, True]],
+        output_mask=[[True]])
+
+  def ExpectedEnginesToBuild(self, run_params):
+    """Returns the expected engines to build."""
+    return ["TRTEngineOp_0"]
+
+  def ShouldRunTest(self, run_params):
+    # Shape op is only converted in dynamic shape mode.
+    return (run_params.dynamic_shape and run_params.is_v2,
+            "test v2 dynamic shape")
+
+
+class PrunedInputTest2(trt_test.TfTrtIntegrationTestBase):
+  """ Two inputs, one of the is pruned. """
+
+  def setUp(self):
+    super().setUp()
+    self.DisableNonTrtOptimizers()
+
+  def GraphFn(self, x, y):
+    q = array_ops.shape(x)
+    z = y * y + y
+    z = gen_array_ops.reshape(z, q)
+    out_0 = array_ops.identity(q, name="output_0")
+    out_1 = array_ops.identity(z, name="output_1")
+    return (out_0, out_1)
+
+  def GetParams(self):
+    return self.BuildParamsWithMask(
+        self.GraphFn, dtypes.float32,
+        [[1, 2, 5, 3], [2, 15]], [[4], [1, 2, 5, 3]],
+        extra_inputs=[],
+        extra_outputs=[],
+        input_mask=[[False, True, True, True], [False, True]],
+        output_mask=[[True], [False, True, True, True]])
+
+  def ExpectedEnginesToBuild(self, run_params):
+    """Returns the expected engines to build."""
+    return ["TRTEngineOp_0"]
+
+  def ShouldRunTest(self, run_params):
+    # Shape op is only converted in dynamic shape mode.
+    return (run_params.dynamic_shape and run_params.is_v2,
+            "test v2 dynamic shape")
+
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
Before TRT 8, an input tensor can be pruned if it is not used by the network . This can happen if only the shape of the input tensor is used and the shape of the input tensor is known, that is, min equals max in the shape optimization profile (nvbugs/3153064). This PR fixes optimization profile handling if there are pruned inputs.

Notes:
- The number TRT network input for INetworkDefinition is always the same as the TF network inputs.
- The number of input bindings for a single profile of an ICudaEngine is not larger than the network inputs.

To fix profile handling:
- We add `is_input_pruned_[]` vector to TrtShapeOptimizationProfile. 
- We ensure that in `OptimizationProfileConfig` the `min.size()` is always determined by the number of the network inputs, and not by the number of input bindings.

Tracker: #45481

Tagging @bixia1 for review.