### PR TITLE
Fix errors that occurs when the path to python.exe includes space characters

### DIFF
--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -124,8 +124,8 @@ def _get_python_lib(repository_ctx, python_bin):
     for line in print_lib:
         cmd += "f.write(\"%s\" + linesep);" % line
     cmd += "f.close();"
-    cmd += "from os import system;"
-    cmd += "system(\"%s script.py\");" % python_bin
+    cmd += "from subprocess import call;"
+    cmd += "call([\"%s\", \"script.py\"]);" % python_bin
 
     result = execute(repository_ctx, [python_bin, "-c", cmd])
     return result.stdout.strip()


### PR DESCRIPTION
Currently, when `PYTHON_BIN_PATH` includes space characters, the following command will fail (on Windows).
```bat
Rem Assume that Python is installed to `C:\Program Files (x86)\Python`.
bazel build -c opt --action_env PYTHON_BIN_PATH="C://Program Files (x86)//Python//python.exe" //tensorflow/lite:framework
```
```txt
ERROR: An error occurred during the fetch of repository 'local_execution_config_python':
   Traceback (most recent call last):
        File "C:/users/homul/sources/tensorflow/third_party/py/python_configure.bzl", line 210, column 33, in _create_local_python_repository
                python_lib = _get_python_lib(repository_ctx, python_bin)
        File "C:/users/homul/sources/tensorflow/third_party/py/python_configure.bzl", line 130, column 21, in _get_python_lib
                result = execute(repository_ctx, [python_bin, "-c", cmd])
        File "C:/users/homul/sources/tensorflow/third_party/remote_config/common.bzl", line 230, column 13, in execute
                fail(
Error in fail: Repository command failed
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
```

This PR makes it sure that the command path will be quoted if it includes space characters.