### PR TITLE
fix moments float16 cast bug

### DIFF
--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -23,6 +23,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import candidate_sampling_ops
 from tensorflow.python.ops import check_ops
+from tensorflow.python.ops import clip_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import custom_gradient
 from tensorflow.python.ops import embedding_ops
@@ -1361,6 +1362,10 @@ def moments(
       mean = array_ops.squeeze(mean, axes)
       variance = array_ops.squeeze(variance, axes)
     if x.dtype == dtypes.float16:
+      mean = clip_ops.clip_by_value(
+          mean, dtypes.float16.min, dtypes.float16.max)
+      variance = clip_ops.clip_by_value(
+          variance, dtypes.float16.min, dtypes.float16.max)
       return (math_ops.cast(mean, dtypes.float16),
               math_ops.cast(variance, dtypes.float16))
     else:

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -1123,7 +1123,6 @@ class MomentsTest(test_lib.TestCase):
     is_finite = math_ops.reduce_all(math_ops.is_finite(results))
     self.assertTrue(is_finite)
 
-
   def doOutputTest(self,
                    input_shape,
                    moments_axes,

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -1113,6 +1113,17 @@ class SwishTest(test_lib.TestCase):
 
 class MomentsTest(test_lib.TestCase):
 
+  def testFloat16(self):
+    results = nn_impl.moments(
+        constant_op.constant(
+            [[[[[ -741., 353.2, 1099., -1807., 502.8, -83.4, 333.5, -130.9]]]]],
+            dtype=dtypes.float16),
+        [1, 2, 4],
+        True)
+    is_finite = math_ops.reduce_all(math_ops.is_finite(results))
+    self.assertTrue(is_finite)
+
+
   def doOutputTest(self,
                    input_shape,
                    moments_axes,


### PR DESCRIPTION
Related https://github.com/tensorflow/addons/issues/2550.
Reproduce example:
```python
tf.debugging.enable_check_numerics()
tf.nn.moments(tf.constant([[[[[ -741., 353.2, 1099., -1807. ,502.8, -83.4, 333.5, -130.9]]]]], dtype=tf.float16), [1, 2, 4], True)
```