### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/pylint-presubmit.yml
+++ b/.github/workflows/pylint-presubmit.yml
@@ -24,25 +24,25 @@ jobs:
     name: PyLint
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Get file changes
-      id: get_file_changes
-      uses: trilom/file-changes-action@v1.2.4
-      with:
-        output: ' '
-    - name: Report list of changed files
-      run: |
-        echo Changed files: ${{ steps.get_file_changes.outputs.files }}
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pylint numpy wheel
-        pip install keras_preprocessing --no-deps
-    - name: Run PyLint on changed files
-      run: |
-        echo "${{ steps.get_file_changes.outputs.files}}" | tr " " "\n" | grep ".py$" | xargs pylint --rcfile=tensorflow/tools/ci_build/pylintrc
+      - name: Checkout code
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
+      - name: Get file changes
+        id: get_file_changes
+        uses: trilom/file-changes-action@a6ca26c14274c33b15e6499323aac178af06ad4b # pin@v1.2.4
+        with:
+          output: ' '
+      - name: Report list of changed files
+        run: |
+          echo Changed files: ${{ steps.get_file_changes.outputs.files }}
+      - name: Set up Python 3.8
+        uses: actions/setup-python@152ba7c4dd6521b8e9c93f72d362ce03bf6c4f20 # pin@v1
+        with:
+          python-version: 3.8
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pylint numpy wheel
+          pip install keras_preprocessing --no-deps
+      - name: Run PyLint on changed files
+        run: |
+          echo "${{ steps.get_file_changes.outputs.files}}" | tr " " "\n" | grep ".py$" | xargs pylint --rcfile=tensorflow/tools/ci_build/pylintrc

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -14,16 +14,17 @@
 # ============================================================================
 
 on:
-  workflow_dispatch:  # Allow manual triggers
+  workflow_dispatch: # Allow manual triggers
+    null
   schedule:
-    - cron: 0 4 * * *  # 4am UTC is 9pm PDT and 8pm PST
+    - cron: 0 4 * * * # 4am UTC is 9pm PDT and 8pm PST
 name: Set nightly branch to master HEAD
 jobs:
   master-to-nightly:
     if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks
     runs-on: ubuntu-latest
     steps:
-    - uses: zofrex/mirror-branch@v1
-      name: Set nightly branch to master HEAD
-      with:
-        target-branch: 'nightly'
+      - uses: zofrex/mirror-branch@e7be3484994bd59ebbc7a222b41d8646f1977c49 # pin@v1
+        name: Set nightly branch to master HEAD
+        with:
+          target-branch: 'nightly'


### PR DESCRIPTION
Pinning an action to a full length commit SHA is currently the only way to use an action as
an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a
backdoor to the action's repository, as they would need to generate a SHA-1 collision for
a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
