### PR TITLE
Declare go_package in status proto

### DIFF
--- a/tensorflow/core/protobuf/status.proto
+++ b/tensorflow/core/protobuf/status.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package tensorflow;
 
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
+
 // If included as a payload, this message flags the Status to be a "derived"
 // Status. Used by StatusGroup to ignore certain Statuses when reporting
 // errors to end users.


### PR DESCRIPTION
PR declares `go_package` in status proto definition and resolves protoc-gen-go error (`unable to determine Go import path for "tensorflow/core/protobuf/status.proto"`)