### PR TITLE
Add mlir-hlo unfuse-batch-norm-training pattern

### DIFF
--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/rewriters.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/transforms/rewriters.h
@@ -102,7 +102,6 @@ void PopulateDynamicShapeFusionPatterns(MLIRContext *context,
 
 // Populate a collection of conversion patterns for un-fusing
 // batch_norm_inference and batch_norm_training into constituent HLO ops.
-// TODO(laurenzo): Implement un-fusing of batch_norm_training.
 void PopulateUnfuseBatchNormPatterns(MLIRContext *context,
                                      RewritePatternSet *patterns);
 

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/unfuse_batch_norm.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/unfuse_batch_norm.cc
@@ -65,7 +65,7 @@ Value CalculateShapeValue(Location loc, Value operand,
 }
 
 Value MaterializeEpsilon(Operation* op, FloatAttr epsilon_attr,
-                         FloatType fp_type, Value variance,
+                         FloatType fp_type, Value broadcast_to,
                          RankedTensorType broadcast_to_type,
                          PatternRewriter& rewriter) {  // NOLINT
   Builder b(rewriter.getContext());
@@ -98,7 +98,7 @@ Value MaterializeEpsilon(Operation* op, FloatAttr epsilon_attr,
     return rewriter.create<mhlo::BroadcastInDimOp>(
         op->getLoc(), broadcast_to_type, epsilon, /*broadcast_dims=*/dims);
   }
-  Value shape_value = CalculateShapeValue(op->getLoc(), variance, rewriter);
+  Value shape_value = CalculateShapeValue(op->getLoc(), broadcast_to, rewriter);
   return rewriter.createOrFold<mhlo::DynamicBroadcastInDimOp>(
       op->getLoc(), broadcast_to_type, epsilon, shape_value,
       /*broadcast_dims=*/dims);
@@ -170,6 +170,211 @@ class UnfuseBatchNormInferencePattern
   }
 };
 
+// Create "mhlo.reduce", "operand" is reduce input and "zero" is init value,
+// reduce sum from operand to operand[feature_index].
+Value CreateReduce(Location loc, Value operand, Value zero,
+                   SmallVector<int64_t>& reduce_dims, int64_t feature_index,
+                   PatternRewriter& rewriter) {
+  auto operand_type = operand.getType().cast<RankedTensorType>();
+  Type reduce_result_type = RankedTensorType::get(
+      {operand_type.getDimSize(feature_index)}, operand_type.getElementType());
+  mhlo::ReduceOp reduce =
+      rewriter.create<mhlo::ReduceOp>(loc, reduce_result_type, operand, zero,
+                                      rewriter.getI64TensorAttr(reduce_dims));
+
+  // setup "mhlo.reduce"'s body
+  Region& region = reduce.body();
+  Block& block = region.emplaceBlock();
+  RankedTensorType block_argument_type =
+      RankedTensorType::get({}, operand_type.getElementType());
+  block.addArgument(block_argument_type, loc);
+  block.addArgument(block_argument_type, loc);
+  auto first_argument = block.args_begin();
+  auto second_argument = block.args_rbegin();
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(&block);
+    Value add_result =
+        rewriter.create<mhlo::AddOp>(loc, *first_argument, *second_argument);
+    rewriter.create<mhlo::ReturnOp>(loc, add_result);
+  }
+
+  return reduce.getResult(0);
+}
+
+// Calculate total reduce size, assuming it is a dynamic shape with static rank.
+// Reduce from operand to operand[feature_index]
+Value CalculateReduceSize(Operation* op, Value operand,
+                          RankedTensorType operand_type,
+                          RankedTensorType scale_type, int64_t feature_index,
+                          PatternRewriter& rewriter) {
+  Location loc = op->getLoc();
+  if (!operand_type.hasStaticShape()) {
+    // the "operand" has dynamic shape with static rank
+    llvm::SmallVector<Value, 4> reduce_values;
+    for (int64_t i = 0, e = operand_type.getRank(); i < e; i++) {
+      if (i != feature_index) {
+        reduce_values.push_back(
+            rewriter.create<tensor::DimOp>(loc, operand, i));
+      }
+    }
+    assert(!reduce_values.empty());
+    Value reduce_size = reduce_values[0];
+    for (size_t i = 1, e = reduce_values.size(); i < e; i++) {
+      reduce_size =
+          rewriter.create<arith::MulIOp>(loc, reduce_size, reduce_values[i]);
+    }
+    reduce_size = rewriter.create<arith::IndexCastOp>(
+        loc, rewriter.getI64Type(), reduce_size);
+    reduce_size = rewriter.create<tensor::FromElementsOp>(loc, reduce_size);
+    reduce_size = rewriter.create<mhlo::ConvertOp>(
+        loc, RankedTensorType::get({1}, operand_type.getElementType()),
+        reduce_size);
+    reduce_size = rewriter.create<mhlo::ReshapeOp>(
+        loc, RankedTensorType::get({}, operand_type.getElementType()),
+        reduce_size);
+    Value feature_size =
+        rewriter.create<tensor::DimOp>(loc, operand, feature_index);
+    feature_size = rewriter.create<tensor::FromElementsOp>(loc, feature_size);
+
+    return rewriter.createOrFold<mhlo::DynamicBroadcastInDimOp>(
+        loc, scale_type, reduce_size, feature_size,
+        rewriter.getI64TensorAttr({}));
+  }
+
+  // the "operand" has static shape
+  int64_t reduce_dims_size = 1;
+  for (int64_t i = 0, e = operand_type.getRank(); i < e; i++) {
+    if (i != feature_index) {
+      reduce_dims_size *= operand_type.getDimSize(i);
+    }
+  }
+  llvm::APFloat float_value(static_cast<double>(reduce_dims_size));
+  bool loses_info;
+  float_value.convert(
+      scale_type.getElementType().cast<FloatType>().getFloatSemantics(),
+      APFloat::rmNearestTiesToEven, &loses_info);
+  if (loses_info) {
+    op->emitWarning("Conversion of reduce_dims_size loses precision");
+  }
+  Value reduce_size = rewriter.create<mhlo::ConstOp>(
+      loc, DenseFPElementsAttr::get(scale_type, float_value));
+  return reduce_size;
+}
+
+// BatchNormTraining(X, scale, offset) =
+//    ((X - E[X]) / Sqrt(Var[X] + epsilon)) * scale + offset.
+class UnfuseBatchNormTrainingPattern
+    : public OpRewritePattern<mhlo::BatchNormTrainingOp> {
+ public:
+  using OpRewritePattern<mhlo::BatchNormTrainingOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mhlo::BatchNormTrainingOp bn_op,
+                                PatternRewriter& rewriter) const override {
+    auto operand_type = bn_op.operand().getType().dyn_cast<RankedTensorType>();
+    auto scale_type = bn_op.scale().getType().dyn_cast<RankedTensorType>();
+    if (!operand_type || !scale_type) {
+      return failure();
+    }
+    auto fp_type = operand_type.getElementType().dyn_cast<FloatType>();
+    if (!fp_type) {
+      return failure();
+    }
+    int64_t feature_index = bn_op.feature_index();
+    SmallVector<int64_t> dimensions_without_feature;
+    for (int64_t i = 0, e = operand_type.getRank(); i < e; i++) {
+      if (i != feature_index) {
+        dimensions_without_feature.push_back(i);
+      }
+    }
+
+    // zero constant
+    Value const_zero = rewriter.create<mhlo::ConstOp>(
+        bn_op.getLoc(), DenseFPElementsAttr::get(
+                            RankedTensorType::get({}, fp_type),
+                            APFloat::getZero(fp_type.getFloatSemantics())));
+    // epsilon
+    auto epsilon =
+        MaterializeEpsilon(bn_op.getOperation(), bn_op.epsilonAttr(), fp_type,
+                           bn_op.scale(), scale_type, rewriter);
+    if (!epsilon) {
+      return failure();
+    }
+    // reduce size constant
+    Value reduce_size =
+        CalculateReduceSize(bn_op.getOperation(), bn_op.operand(), operand_type,
+                            scale_type, feature_index, rewriter);
+    if (!reduce_size) {
+      return failure();
+    }
+    // Sum[X]
+    Value sum =
+        CreateReduce(bn_op.getLoc(), bn_op.operand(), const_zero,
+                     dimensions_without_feature, feature_index, rewriter);
+    // X^2
+    Value operand_square = rewriter.create<mhlo::MulOp>(
+        bn_op.getLoc(), bn_op.operand(), bn_op.operand());
+    // Sum[X^2]
+    Value square_sum =
+        CreateReduce(bn_op.getLoc(), operand_square, const_zero,
+                     dimensions_without_feature, feature_index, rewriter);
+    // E[X]
+    Value mean = rewriter.create<mhlo::DivOp>(bn_op.getLoc(), sum, reduce_size);
+    // E[X^2]
+    Value square_mean =
+        rewriter.create<mhlo::DivOp>(bn_op.getLoc(), square_sum, reduce_size);
+    // E^2[X]
+    Value mean_square =
+        rewriter.create<mhlo::MulOp>(bn_op.getLoc(), mean, mean);
+    // Var[X]
+    Value var =
+        rewriter.create<mhlo::SubOp>(bn_op.getLoc(), square_mean, mean_square);
+    // Var[X] + epsilon
+    Value var_add_epsilon =
+        rewriter.create<mhlo::AddOp>(bn_op.getLoc(), var, epsilon);
+    // Sqrt(Var[X] + epsilon)
+    Value sqrt_var =
+        rewriter.create<mhlo::SqrtOp>(bn_op.getLoc(), var_add_epsilon);
+
+    Value shape_value;
+    if (!operand_type.hasStaticShape()) {
+      shape_value =
+          CalculateShapeValue(bn_op.getLoc(), bn_op.operand(), rewriter);
+    }
+    // X - E[X]
+    Value mean_broadcast =
+        BroadcastToFeatureDim(bn_op.getLoc(), operand_type, mean, shape_value,
+                              feature_index, rewriter);
+    Value operand_minus_mean = rewriter.create<mhlo::SubOp>(
+        bn_op.getLoc(), bn_op.operand(), mean_broadcast);
+    // (X - E[X]) / Sqrt(Var[X] + epsilon)
+    Value sqrt_var_broadcast =
+        BroadcastToFeatureDim(bn_op.getLoc(), operand_type, sqrt_var,
+                              shape_value, feature_index, rewriter);
+    Value normalized = rewriter.create<mhlo::DivOp>(
+        bn_op.getLoc(), operand_minus_mean, sqrt_var_broadcast);
+
+    // ((X - E[X]) / Sqrt(Var[X] + epsilon)) * scale
+    Value scale_broadcast =
+        BroadcastToFeatureDim(bn_op.getLoc(), operand_type, bn_op.scale(),
+                              shape_value, feature_index, rewriter);
+    Value scaled_normalized = rewriter.create<mhlo::MulOp>(
+        bn_op.getLoc(), normalized, scale_broadcast);
+    // ((X - E[X]) / Sqrt(Var[X] + epsilon)) * scale + offset.
+    Value offset_broadcast =
+        BroadcastToFeatureDim(bn_op.getLoc(), operand_type, bn_op.offset(),
+                              shape_value, feature_index, rewriter);
+    Value shifted_normalized = rewriter.create<mhlo::AddOp>(
+        bn_op.getLoc(), scaled_normalized, offset_broadcast);
+
+    // results
+    SmallVector<Value> results = {shifted_normalized, mean, var};
+    rewriter.replaceOp(bn_op, results);
+
+    return success();
+  }
+};
+
 }  // namespace
 
 // Populates conversion patterns to unfuse batch normalization operations.
@@ -179,6 +384,7 @@ class UnfuseBatchNormInferencePattern
 void PopulateUnfuseBatchNormPatterns(MLIRContext* context,
                                      RewritePatternSet* patterns) {
   patterns->add<UnfuseBatchNormInferencePattern>(context);
+  patterns->add<UnfuseBatchNormTrainingPattern>(context);
 }
 
 }  // namespace mhlo

--- a/tensorflow/compiler/mlir/hlo/tests/Dialect/mhlo/unfuse_batch_norm.mlir
+++ b/tensorflow/compiler/mlir/hlo/tests/Dialect/mhlo/unfuse_batch_norm.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-hlo-opt -split-input-file -mhlo-test-unfuse-batch-norm -verify-diagnostics %s | FILECHECK_OPTS="" FileCheck --enable-var-scope %s
+// RUN: mlir-hlo-opt -split-input-file -mhlo-test-unfuse-batch-norm -cse -verify-diagnostics %s | FILECHECK_OPTS="" FileCheck --enable-var-scope %s
 
 // CHECK-LABEL: @batchNormInference_2D_inner_features
 // CHECK-SAME: %[[X:[^:[:space:]]+]]
@@ -30,6 +30,40 @@ func.func @batchNormInference_2D_inner_features(
 }
 
 // -----
+// CHECK-LABEL: @batchNormTraining_2D_inner_features
+// CHECK-SAME: %[[X:[^:[:space:]]+]]
+// CHECK-SAME: %[[SCALE:[^:[:space:]]+]]
+// CHECK-SAME: %[[OFFSET:[^:[:space:]]+]]
+func.func @batchNormTraining_2D_inner_features(
+    %x: tensor<4x256xf32>, %scale: tensor<256xf32>, %offset: tensor<256xf32>) -> (tensor<4x256xf32>, tensor<256xf32>, tensor<256xf32>) {
+  // CHECK-DAG: %[[ZERO:.+]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
+  // CHECK-DAG: %[[EPS_BCAST:.+]] = mhlo.constant dense<1.001000e-05> : tensor<256xf32>
+  // CHECK-DAG: %[[NUM_REDUCE:.+]] = mhlo.constant dense<4.000000e+00> : tensor<256xf32>
+  // CHECK-DAG: %[[SumX:.+]] = mhlo.reduce(%[[X]] init: %[[ZERO]]) applies mhlo.add across dimensions = [0] : (tensor<4x256xf32>, tensor<f32>) -> tensor<256xf32>
+  // CHECK-DAG: %[[X2:.+]] = mhlo.multiply %[[X]], %[[X]] : tensor<4x256xf32>
+  // CHECK-DAG: %[[SumX2:.+]] = mhlo.reduce(%[[X2]] init: %[[ZERO]]) applies mhlo.add across dimensions = [0] : (tensor<4x256xf32>, tensor<f32>) -> tensor<256xf32>
+  // CHECK-DAG: %[[EX:.+]] = mhlo.divide %[[SumX]], %[[NUM_REDUCE]] : tensor<256xf32>
+  // CHECK-DAG: %[[EX2:.+]] = mhlo.divide %[[SumX2]], %[[NUM_REDUCE]] : tensor<256xf32>
+  // CHECK-DAG: %[[E2X:.+]] = mhlo.multiply %[[EX]], %[[EX]] : tensor<256xf32>
+  // CHECK-DAG: %[[VARIANCE:.+]] = mhlo.subtract %[[EX2]], %[[E2X]] : tensor<256xf32>
+  // CHECK-DAG: %[[VARIANCE_EPS:.+]] = mhlo.add %[[VARIANCE]], %[[EPS_BCAST]] : tensor<256xf32>
+  // CHECK-DAG: %[[STDDEV:.+]] = "mhlo.sqrt"(%[[VARIANCE_EPS]]) : (tensor<256xf32>) -> tensor<256xf32>
+  // CHECK-DAG: %[[EX_BCAST:.+]] = "mhlo.broadcast_in_dim"(%[[EX]]) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<256xf32>) -> tensor<4x256xf32>
+  // CHECK-DAG: %[[X_CENTER:.+]] = mhlo.subtract %[[X]], %[[EX_BCAST]] : tensor<4x256xf32>
+  // CHECK-DAG: %[[STDDEV_BCAST:.+]] = "mhlo.broadcast_in_dim"(%[[STDDEV]]) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<256xf32>) -> tensor<4x256xf32>
+  // CHECK-DAG: %[[X_NORMED:.+]] = mhlo.divide %[[X_CENTER]], %[[STDDEV_BCAST]] : tensor<4x256xf32>
+  // CHECK-DAG: %[[SCALE_BCAST:.+]] = "mhlo.broadcast_in_dim"(%[[SCALE]]) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<256xf32>) -> tensor<4x256xf32>
+  // CHECK-DAG: %[[X_NORMED_SCALED:.+]] = mhlo.multiply %[[X_NORMED]], %[[SCALE_BCAST]] : tensor<4x256xf32>
+  // CHECK-DAG: %[[OFFSET_BCAST:.+]] = "mhlo.broadcast_in_dim"(%[[OFFSET]]) {broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<256xf32>) -> tensor<4x256xf32>
+  // CHECK-DAG: %[[X_NORMED_SCALED_OFFSET:.+]] = mhlo.add %[[X_NORMED_SCALED]], %[[OFFSET_BCAST]] : tensor<4x256xf32>
+  // CHECK-DAG: return %[[X_NORMED_SCALED_OFFSET]], %[[EX]], %[[VARIANCE]] : tensor<4x256xf32>, tensor<256xf32>, tensor<256xf32>
+  %0:3 = "mhlo.batch_norm_training"(%x, %scale, %offset)
+      {epsilon = 1.001000e-05 : f32, feature_index = 1 : i64} :
+      (tensor<4x256xf32>, tensor<256xf32>, tensor<256xf32>) -> (tensor<4x256xf32>, tensor<256xf32>, tensor<256xf32>)
+  func.return %0#0, %0#1, %0#2 : tensor<4x256xf32>, tensor<256xf32>, tensor<256xf32>
+}
+
+// -----
 // CHECK-LABEL: @batchNormInference_4D_middle_features
 // Just validate that one of the broadcasts happens correctly and rely on
 // the verifier to enforce the rest.
@@ -48,6 +82,41 @@ func.func @batchNormInference_4D_middle_features(
 }
 
 // -----
+// CHECK-LABEL: @batchNormTraining_4D_middle_features
+// CHECK-SAME: %[[X:[^:[:space:]]+]]
+// CHECK-SAME: %[[SCALE:[^:[:space:]]+]]
+// CHECK-SAME: %[[OFFSET:[^:[:space:]]+]]
+func.func @batchNormTraining_4D_middle_features(
+    %x: tensor<3x4x256x6xf32>, %scale: tensor<256xf32>, %offset: tensor<256xf32>)
+    -> (tensor<3x4x256x6xf32>, tensor<256xf32>, tensor<256xf32>) {
+  // CHECK-DAG: %[[ZERO:.+]] = mhlo.constant dense<0.000000e+00> : tensor<f32>
+  // CHECK-DAG: %[[EPS_BCAST:.+]] = mhlo.constant dense<1.001000e-05> : tensor<256xf32>
+  // CHECK-DAG: %[[NUM_REDUCE:.+]] = mhlo.constant dense<7.200000e+01> : tensor<256xf32>
+  // CHECK-DAG: %[[SumX:.+]] = mhlo.reduce(%[[X]] init: %[[ZERO]]) applies mhlo.add across dimensions = [0, 1, 3] : (tensor<3x4x256x6xf32>, tensor<f32>) -> tensor<256xf32>
+  // CHECK-DAG: %[[X2:.+]] = mhlo.multiply %[[X]], %[[X]] : tensor<3x4x256x6xf32>
+  // CHECK-DAG: %[[SumX2:.+]] = mhlo.reduce(%[[X2]] init: %[[ZERO]]) applies mhlo.add across dimensions = [0, 1, 3] : (tensor<3x4x256x6xf32>, tensor<f32>) -> tensor<256xf32>
+  // CHECK-DAG: %[[EX:.+]] = mhlo.divide %[[SumX]], %[[NUM_REDUCE]] : tensor<256xf32>
+  // CHECK-DAG: %[[EX2:.+]] = mhlo.divide %[[SumX2]], %[[NUM_REDUCE]] : tensor<256xf32>
+  // CHECK-DAG: %[[E2X:.+]] = mhlo.multiply %[[EX]], %[[EX]] : tensor<256xf32>
+  // CHECK-DAG: %[[VARIANCE:.+]] = mhlo.subtract %[[EX2]], %[[E2X]] : tensor<256xf32>
+  // CHECK-DAG: %[[VARIANCE_EPS:.+]] = mhlo.add %[[VARIANCE]], %[[EPS_BCAST]] : tensor<256xf32>
+  // CHECK-DAG: %[[STDDEV:.+]] = "mhlo.sqrt"(%[[VARIANCE_EPS]]) : (tensor<256xf32>) -> tensor<256xf32>
+  // CHECK-DAG: %[[EX_BCAST:.+]] = "mhlo.broadcast_in_dim"(%[[EX]]) {broadcast_dimensions = dense<2> : tensor<1xi64>} : (tensor<256xf32>) -> tensor<3x4x256x6xf32>
+  // CHECK-DAG: %[[X_CENTER:.+]] = mhlo.subtract %[[X]], %[[EX_BCAST]] : tensor<3x4x256x6xf32>
+  // CHECK-DAG: %[[STDDEV_BCAST:.+]] = "mhlo.broadcast_in_dim"(%[[STDDEV]]) {broadcast_dimensions = dense<2> : tensor<1xi64>} : (tensor<256xf32>) -> tensor<3x4x256x6xf32>
+  // CHECK-DAG: %[[X_NORMED:.+]] = mhlo.divide %[[X_CENTER]], %[[STDDEV_BCAST]] : tensor<3x4x256x6xf32>
+  // CHECK-DAG: %[[SCALE_BCAST:.+]] = "mhlo.broadcast_in_dim"(%[[SCALE]]) {broadcast_dimensions = dense<2> : tensor<1xi64>} : (tensor<256xf32>) -> tensor<3x4x256x6xf32>
+  // CHECK-DAG: %[[X_NORMED_SCALED:.+]] = mhlo.multiply %[[X_NORMED]], %[[SCALE_BCAST]] : tensor<3x4x256x6xf32>
+  // CHECK-DAG: %[[OFFSET_BCAST:.+]] = "mhlo.broadcast_in_dim"(%[[OFFSET]]) {broadcast_dimensions = dense<2> : tensor<1xi64>} : (tensor<256xf32>) -> tensor<3x4x256x6xf32>
+  // CHECK-DAG: %[[X_NORMED_SCALED_OFFSET:.+]] = mhlo.add %[[X_NORMED_SCALED]], %[[OFFSET_BCAST]] : tensor<3x4x256x6xf32>
+  // CHECK-DAG: return %[[X_NORMED_SCALED_OFFSET]], %[[EX]], %[[VARIANCE]] : tensor<3x4x256x6xf32>, tensor<256xf32>, tensor<256xf32>
+  %0:3 = "mhlo.batch_norm_training"(%x, %scale, %offset)
+      {epsilon = 1.001000e-05 : f32, feature_index = 2 : i64} :
+      (tensor<3x4x256x6xf32>, tensor<256xf32>, tensor<256xf32>) -> (tensor<3x4x256x6xf32>, tensor<256xf32>, tensor<256xf32>)
+  func.return %0#0, %0#1, %0#2 : tensor<3x4x256x6xf32>, tensor<256xf32>, tensor<256xf32>
+}
+
+// -----
 // CHECK-LABEL: @batchNormInference_f64
 // Validate that epsilon is properly promoted to f64
 // CHECK-DAG: %[[EPS:.+]] = mhlo.constant dense<1.000000e+00> : tensor<256xf64>
@@ -63,8 +132,20 @@ func.func @batchNormInference_f64(
 }
 
 // -----
-// CHECK-LABEL: @batchNormInference_f16
 // Validate that epsilon is properly promoted to f64
+// CHECK-DAG: %[[EPS:.+]] = mhlo.constant dense<1.000000e+00> : tensor<256xf64>
+func.func @batchNormTraining_f64(
+    %x: tensor<4x256xf64>, %scale: tensor<256xf64>, %offset: tensor<256xf64>)
+    -> (tensor<4x256xf64>, tensor<256xf64>, tensor<256xf64>) {
+  %0:3 = "mhlo.batch_norm_training"(%x, %scale, %offset)
+      {epsilon = 1.0 : f32, feature_index = 1 : i64} :
+      (tensor<4x256xf64>, tensor<256xf64>, tensor<256xf64>) -> (tensor<4x256xf64>, tensor<256xf64>, tensor<256xf64>)
+  func.return %0#0, %0#1, %0#2 : tensor<4x256xf64>, tensor<256xf64>, tensor<256xf64>
+}
+
+// -----
+// CHECK-LABEL: @batchNormInference_f16
+// Validate that epsilon is properly down to f16
 // CHECK-DAG: %[[EPS:.+]] = mhlo.constant dense<1.000000e+00> : tensor<256xf16>
 func.func @batchNormInference_f16(
     %x: tensor<4x256xf16>, %scale: tensor<256xf16>, %offset: tensor<256xf16>,
@@ -78,7 +159,19 @@ func.func @batchNormInference_f16(
 }
 
 // -----
-// Validate that epsilon is properly promoted to f64
+// Validate that epsilon is properly down to f16
+// CHECK-DAG: %[[EPS:.+]] = mhlo.constant dense<1.000000e+00> : tensor<256xf16>
+func.func @batchNormTraining_f16(
+    %x: tensor<4x256xf16>, %scale: tensor<256xf16>, %offset: tensor<256xf16>)
+    -> (tensor<4x256xf16>, tensor<256xf16>, tensor<256xf16>) {
+  %0:3 = "mhlo.batch_norm_training"(%x, %scale, %offset)
+      {epsilon = 1.0 : f32, feature_index = 1 : i64} :
+      (tensor<4x256xf16>, tensor<256xf16>, tensor<256xf16>) -> (tensor<4x256xf16>, tensor<256xf16>, tensor<256xf16>)
+  func.return %0#0, %0#1, %0#2 : tensor<4x256xf16>, tensor<256xf16>, tensor<256xf16>
+}
+
+// -----
+// Validate that epsilon is overflow
 func.func @batchNormInference_f16_overflow(
     %x: tensor<4x256xf16>, %scale: tensor<256xf16>, %offset: tensor<256xf16>,
     %mean: tensor<256xf16>, %variance: tensor<256xf16>)
@@ -89,6 +182,18 @@ func.func @batchNormInference_f16_overflow(
       (tensor<4x256xf16>, tensor<256xf16>, tensor<256xf16>, tensor<256xf16>,
         tensor<256xf16>) -> tensor<4x256xf16>
   func.return %0 : tensor<4x256xf16>
+}
+
+// -----
+// Validate that epsilon is overflow
+func.func @batchNormTraining_f16_overflow(
+    %x: tensor<4x256xf16>, %scale: tensor<256xf16>, %offset: tensor<256xf16>)
+    -> (tensor<4x256xf16>, tensor<256xf16>, tensor<256xf16>) {
+  // expected-warning @+1 {{Could not convert batch_norm epsilon to target fp type: opStatus = 24}}
+  %0:3 = "mhlo.batch_norm_training"(%x, %scale, %offset)
+      {epsilon = 0.00000001 : f32, feature_index = 1 : i64} :
+      (tensor<4x256xf16>, tensor<256xf16>, tensor<256xf16>) -> (tensor<4x256xf16>, tensor<256xf16>, tensor<256xf16>)
+  func.return %0#0, %0#1, %0#2 :tensor<4x256xf16>, tensor<256xf16>, tensor<256xf16>
 }
 
 // -----
@@ -131,4 +236,16 @@ func.func @batchNormInference_dynamic_shape(
       (tensor<?x?x?x?xf32>, tensor<?xf32>, tensor<?xf32>, tensor<?xf32>,
         tensor<?xf32>) -> tensor<?x?x?x?xf32>
   func.return %0 : tensor<?x?x?x?xf32>
+}
+
+// -----
+// TODO(qingyunqu): complete this testcase
+// CHECK-LABEL: @batchNormTraining_dynamic_shape
+func.func @batchNormTraining_dynamic_shape(
+    %x: tensor<?x?x?x?xf32>, %scale: tensor<?xf32>, %offset: tensor<?xf32>)
+    -> (tensor<?x?x?x?xf32>, tensor<?xf32>, tensor<?xf32>) {
+  %0:3 = "mhlo.batch_norm_training"(%x, %scale, %offset)
+      {epsilon = 1.001000e-05 : f32, feature_index = 2 : i64} :
+      (tensor<?x?x?x?xf32>, tensor<?xf32>, tensor<?xf32>) -> (tensor<?x?x?x?xf32>, tensor<?xf32>, tensor<?xf32>)
+  func.return %0#0, %0#1, %0#2 : tensor<?x?x?x?xf32>, tensor<?xf32>, tensor<?xf32>
 }


### PR DESCRIPTION
Add mlir-hlo unfuse-batch-norm-training pattern.
Question when adding dynamic shape: how can I convert `index` to `tensor<f32>`? I need to convert the dynamic reduction size to a `tensor` value. @joker-eph