### PR TITLE
[Go] Update genop shell script to support module-aware installation 

### DIFF
--- a/tensorflow/go/genop/generate.sh
+++ b/tensorflow/go/genop/generate.sh
@@ -16,7 +16,8 @@
 
 set -e
 
-go get google.golang.org/protobuf/cmd/protoc-gen-go
+go get -d google.golang.org/protobuf/proto
+go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
 if [ -z "${GOPATH}" ]
 then


### PR DESCRIPTION
PR updates genop/generate.sh for Go 1.17 compatibility: the use of `go get` to install executables is [deprecated in Go 1.17](https://golang.org/doc/go-get-install-deprecation).