### PR TITLE
Remove tf-nightly step from the Use XLA with tf.function guide (jit_compile is stable)

### DIFF
--- a/tensorflow/compiler/xla/g3doc/tutorials/jit_compile.ipynb
+++ b/tensorflow/compiler/xla/g3doc/tutorials/jit_compile.ipynb
@@ -74,18 +74,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "ukTmcHYkwx8f"
-      },
-      "outputs": [],
-      "source": [
-        "# In TF 2.4 jit_compile is called experimental_compile\n",
-        "!pip install tf-nightly"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
         "id": "45kUPj5ZFrRa"
       },
       "outputs": [],
@@ -266,30 +254,12 @@
   "metadata": {
     "colab": {
       "collapsed_sections": [],
-      "last_runtime": {
-        "build_target": "//learning/deepmind/public/tools/ml_python:ml_notebook",
-        "kind": "private"
-      },
-      "name": "Use XLA with tf.function",
-      "private_outputs": true,
-      "provenance": [],
+      "name": "jit_compile.ipynb",
       "toc_visible": true
     },
     "kernelspec": {
       "display_name": "Python 3",
       "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.7.5rc1"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
@cheshire 

This PR removes the `tf-nightly` step, since `jit_compile` has been stable since TF v2.5. The Colab has been run without `tf-nightly` (which is v2.7 now?).

Hope this helps 👍 