### PR TITLE
[Go] Fix flaky test of NewTensor

### DIFF
--- a/tensorflow/go/tensor_test.go
+++ b/tensorflow/go/tensor_test.go
@@ -100,9 +100,8 @@ func TestNewTensor(t *testing.T) {
 		// Test that encode and decode gives the same value. We skip arrays because
 		// they're returned as slices.
 		if reflect.TypeOf(test.value).Kind() != reflect.Array {
-			got := tensor.Value()
-			if !reflect.DeepEqual(test.value, got) {
-				t.Errorf("encode/decode: got %v, want %v", got, test.value)
+			if !reflect.DeepEqual(test.value, tensor.Value()) {
+				t.Errorf("encode/decode: got %v, want %v", tensor.Value(), test.value)
 			}
 		}
 	}


### PR DESCRIPTION
PR fixes a flaky test of NewTensor where `tensor` is flagged by GC and its finalizer is executed before comparison to the expected/test value, resulting in occasional failures when the test is run.