### PR TITLE
Make scatter ops deterministic.

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -2265,6 +2265,7 @@ tf_kernel_library(
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core/framework:bounds_check",
+        "//tensorflow/core/util:determinism_for_kernels",
         "//third_party/eigen3",
     ],
 )
@@ -2893,6 +2894,7 @@ tf_kernel_library(
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
         "//tensorflow/core/framework:bounds_check",
+        "//tensorflow/core/util:determinism_for_kernels",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -5128,7 +5130,7 @@ tf_kernel_library(
 tf_kernel_library(
     name = "scatter_op",
     prefix = "scatter_op",
-    deps = STATE_DEPS,
+    deps = STATE_DEPS + ["//tensorflow/core/util:determinism_for_kernels"],
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -49,6 +49,7 @@ limitations under the License.
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
+#include "tensorflow/core/platform/stream_executor.h"
 #endif
 
 #include "tensorflow/core/kernels/resource_variable_ops.h"
@@ -77,6 +78,7 @@ limitations under the License.
 #include "tensorflow/core/platform/mem.h"
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/determinism.h"
 #include "tensorflow/core/util/util.h"
 
 namespace tensorflow {
@@ -869,6 +871,99 @@ bool ValidateInput<Variant>(const Tensor& updates) {
   return true;
 }
 
+template <typename Device, typename T, typename Index, scatter_op::UpdateOp op>
+Status DoScatter(OpKernelContext* c, Tensor* params, const Tensor& indices,
+                 const Tensor& updates, Index num_indices);
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+template <typename T>
+Status CopyTensorToHost(OpKernelContext* c, const Tensor& device_tensor,
+                        Tensor* host_tensor) {
+  AllocatorAttributes alloc_attr;
+  alloc_attr.set_on_host(true);
+  alloc_attr.set_gpu_compatible(true);
+  auto stream = c->op_device_context()->stream();
+  TF_RETURN_IF_ERROR(c->allocate_temp(
+      device_tensor.dtype(), device_tensor.shape(), host_tensor, alloc_attr));
+  se::DeviceMemoryBase device_ptr(
+      const_cast<Tensor&>(device_tensor).flat<T>().data(),
+      device_tensor.flat<T>().size() * sizeof(T));
+  stream->ThenMemcpy(host_tensor->flat<T>().data(), device_ptr,
+                     device_tensor.NumElements() * sizeof(T));
+  if (!stream) {
+    return errors::Internal("Failed to copy indices to host");
+  }
+  return Status::OK();
+}
+
+// Copies inputs to the CPU, runs DoScatter on the CPU, then copies output
+// back to GPU. This is useful because the CPU implementation is deterministic
+// and the GPU implementation is not. Tensor inputs to this function must be on
+// the GPU.
+template <typename T, typename Index, scatter_op::UpdateOp Op>
+Status DoScatterOnCpu(OpKernelContext* c, Tensor* params, const Tensor& indices,
+                      const Tensor& updates, Index num_indices) {
+  auto stream = c->op_device_context()->stream();
+
+  Tensor host_indices;
+  TF_RETURN_IF_ERROR(CopyTensorToHost<Index>(c, indices, &host_indices));
+  Tensor host_updates;
+  TF_RETURN_IF_ERROR(CopyTensorToHost<T>(c, updates, &host_updates));
+  Tensor host_params;
+  TF_RETURN_IF_ERROR(CopyTensorToHost<T>(c, *params, &host_params));
+
+  TF_RETURN_IF_ERROR(stream->BlockHostUntilDone());
+  TF_RETURN_IF_ERROR(DoScatter<CPUDevice, T, Index, Op>(
+      c, &host_params, host_indices, host_updates, num_indices));
+
+  // Copy 'host_params' to device.
+  se::DeviceMemoryBase params_ptr(params->flat<T>().data(),
+                                  params->flat<T>().size() * sizeof(T));
+  stream->ThenMemcpy(&params_ptr, host_params.flat<T>().data(),
+                     host_params.NumElements() * sizeof(T));
+  if (!stream) {
+    return errors::Internal("Failed to copy params to device");
+  }
+  // Block host, since 'host_params' cannot be destructed until the copy is
+  // done.
+  TF_RETURN_IF_ERROR(stream->BlockHostUntilDone());
+  return Status::OK();
+}
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+template <typename Device, typename T, typename Index, scatter_op::UpdateOp op>
+Status DoScatter(OpKernelContext* c, Tensor* params, const Tensor& indices,
+                 const Tensor& updates, Index num_indices) {
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+  if (std::is_same<Device, GPUDevice>::value &&
+      tensorflow::OpDeterminismRequired()) {
+    if (!DataTypeCanUseMemcpy(params->dtype())) {
+      return errors::Unimplemented(
+          "GPU Scatter ops for dtype ", DataTypeString(params->dtype()),
+          " do not yet have a deterministic implementation");
+    }
+    return DoScatterOnCpu<T, Index, op>(c, params, indices, updates,
+                                        num_indices);
+  }
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+  auto indices_flat = indices.flat<Index>();
+  auto params_flat = params->flat_outer_dims<T>();
+  int64_t num_updates = updates.NumElements();
+  auto updates_flat =
+      updates.shaped<T, 2>({num_indices, num_updates / num_indices});
+  functor::ScatterFunctor<Device, T, Index, op> functor;
+  const Index bad_i = functor(c, c->template eigen_device<Device>(),
+                              params_flat, updates_flat, indices_flat);
+  if (bad_i >= 0) {
+    return errors::InvalidArgument(
+        "indices", SliceDebugString(indices.shape(), bad_i), " = ",
+        indices_flat(bad_i), " is not in [0, ", params->dim_size(0), ")");
+  }
+  return Status::OK();
+}
+
 }  // namespace
 
 template <typename Device, typename T, typename Index, scatter_op::UpdateOp op>
@@ -958,23 +1053,14 @@ class ResourceScatterUpdateOp : public OpKernel {
                         " = ", indices_flat(bad_i), " is not in [0, ",
                         params->dim_size(0), ")"));
       } else {
-        int64_t num_updates = updates.NumElements();
         OP_REQUIRES(
             c, TensorShapeUtils::StartsWith(updates.shape(), indices.shape()),
             errors::InvalidArgument(
                 "The shape of indices (", indices.shape().DebugString(),
                 ") must be a prefix of the shape of updates (",
                 updates.shape().DebugString(), ")"));
-        auto updates_flat = updates.shaped<T, 2>({N, num_updates / N});
-
-        functor::ScatterFunctor<Device, T, Index, op> functor;
-        const Index bad_i = functor(c, c->template eigen_device<Device>(),
-                                    params_flat, updates_flat, indices_flat);
-        OP_REQUIRES(c, bad_i < 0,
-                    errors::InvalidArgument(
-                        "indices", SliceDebugString(indices.shape(), bad_i),
-                        " = ", indices_flat(bad_i), " is not in [0, ",
-                        params->dim_size(0), ")"));
+        OP_REQUIRES_OK(
+            c, DoScatter<Device, T, Index, op>(c, params, indices, updates, N));
       }
     }
   }

--- a/tensorflow/core/kernels/scatter_functor.h
+++ b/tensorflow/core/kernels/scatter_functor.h
@@ -26,6 +26,7 @@ limitations under the License.
 #include "tensorflow/core/framework/variant_op_registry.h"
 #include "tensorflow/core/kernels/dense_update_functor.h"
 #include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/determinism.h"
 #include "tensorflow/core/util/work_sharder.h"
 
 namespace tensorflow {
@@ -221,7 +222,8 @@ struct ScatterFunctorBase {
     // serially or parallelly. Also if 'N' is small, overheads of parallel
     // execution outweigh its benefits and hence we check the value of N.
     const bool execute_serial =
-        ((N < min_n_threshold) || ((N / limit) > ser_par_ratio));
+        N < min_n_threshold || (N / limit) > ser_par_ratio ||
+        OpDeterminismRequired();
     if (execute_serial)
       return SerialExecute(c, d, params, updates, indices);
     else

--- a/tensorflow/python/kernel_tests/resource_variable_ops_test.py
+++ b/tensorflow/python/kernel_tests/resource_variable_ops_test.py
@@ -1341,6 +1341,22 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
     with self.assertRaisesRegex(Exception, r"shape.*2.*3"):
       state_ops.scatter_update(v, [0, 1], [0, 1, 2])
 
+  def testScatterAddDeterministic(self):
+    with context.eager_mode(), test_util.deterministic_ops():
+      # Normally a nondeterministic codepath occurs when the variable has at
+      # least 1024 elements. Test that op determinism ensures the op is
+      # deterministc.
+      v = resource_variable_ops.ResourceVariable(array_ops.zeros([1024]))
+      delta = ops.IndexedSlices(values=np.random.normal(size=(1_000_000,)),
+                                indices=array_ops.zeros((1_000_000,),
+                                                        dtype=np.int32),
+                                dense_shape=(1024,))
+      v.scatter_add(delta)
+      for _ in range(5):
+        v2 = resource_variable_ops.ResourceVariable(array_ops.zeros([1024]))
+        v2.scatter_add(delta)
+        self.assertAllEqual(v, v2)
+
   @test_util.run_in_graph_and_eager_modes
   def testAssignIncompatibleShape(self):
     v = resource_variable_ops.ResourceVariable([0, 1, 2, 3])

--- a/tensorflow/python/kernel_tests/scatter_ops_test.py
+++ b/tensorflow/python/kernel_tests/scatter_ops_test.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import state_ops
 from tensorflow.python.ops import variables
@@ -333,6 +334,22 @@ class ScatterTest(test.TestCase):
         self.evaluate(op(ref, indices, updates))
         indices = np.array([2, 0, 6])
         self.evaluate(op(ref, indices, updates))
+
+  @test_util.run_v1_only("ResrouceVariable has deterministic scatter "
+                         "implementation")
+  @test_util.run_cuda_only
+  def testDeterminismExceptionThrowing(self):
+    v = variables.RefVariable(np.array([1., 2., 3.]))
+    indices = np.array([0, 0, 0])
+    updates = np.array([-3, -4, -5]).astype(np.float32)
+    with test_util.deterministic_ops():
+      with self.assertRaisesRegex(
+          errors.UnimplementedError,
+          "Determinism is not yet supported in GPU implementation of Scatter "
+          "ops"):
+        self.evaluate(state_ops.scatter_update(v, indices, updates))
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The GPU deterministic implementation copies the variable to the CPU, runs the scatter op, then copies the result back to the GPU, which is what the Scatter ND ops already do.

Only the ResourceVariable scatter ops are made deterministic, not legacy ref variables.