### PR TITLE
[TF:TRT] Add structured op converter

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -588,6 +588,7 @@ tf_cuda_cc_test(
     size = "medium",
     srcs = [
         "convert/convert_nodes_test.cc",
+        "convert/op_converter_test.cc",
     ],
     tags = [
         "no_cuda_on_cpu_tap",

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -1717,8 +1717,6 @@ Status Converter::GetInputs(const NodeDef& node_def,
   return Status::OK();
 }
 
-enum class TrtInputArg { kTensor = 1, kWeight = 2, kBoth = 3 };
-
 // Checks that the number of inputs match, and enforces that the inputs marked
 // as weights are constant. Inputs are allowed to be both weight and tensor.
 Status CheckInputsWeights(

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -388,6 +388,10 @@ class Converter {
                     absl::string_view sub_op_name,
                     absl::optional<int> sub_op_instance = absl::nullopt);
 
+  std::unordered_map<string, TRT_TensorOrWeights>& TensorsMap() {
+    return trt_tensors_;
+  }
+
  private:
   Converter(TrtPrecisionMode precision_mode, bool use_calibration,
             nvinfer1::ILogger* trt_logger, const bool use_implicit_batch,

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter.h
@@ -14,17 +14,24 @@ limitations under the License.
 ==============================================================================*/
 #ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_H_
 #define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_H_
+
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 
+#include <memory>
 #include <vector>
 
+#include "absl/strings/str_format.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/weights.h"
+#include "third_party/tensorrt/NvInfer.h"
 
 namespace tensorflow {
 namespace tensorrt {
 namespace convert {
 
 class Converter;
+
+// Specifies the possible roles of each op input.
+enum class TrtInputArg { kTensor = 1, kWeight = 2, kBoth = 3 };
 
 // Parameters for each op converter.
 struct OpConverterParams {
@@ -53,12 +60,130 @@ struct OpConverterParams {
   const bool use_implicit_batch;
 };
 
+// Operation converter function specification.
 using OpConverter = std::function<Status(OpConverterParams*)>;
+
+struct InputArgSpec {
+  absl::string_view name;
+  TrtInputArg allowed_roles;
+
+  static constexpr InputArgSpec Create(absl::string_view n, TrtInputArg role) {
+    return InputArgSpec{n, role};
+  }
+};
+
+// A Curiously recurring template pattern (CRTP) template class for operation
+// converters.
+template <typename Impl>
+class OpConverterBase {
+ public:
+  explicit OpConverterBase(OpConverterParams* params)
+      : params_(params), node_def_attrs_(params->node_def) {}
+
+  // Default NodeDef attribute name to inspect in order to determine node data
+  // type. The Impl class can override this by implementing the same function.
+  static constexpr const char* NodeDefDataTypeAttributeName() { return "T"; }
+
+  // Default allowed data types for the NodeDef data type attribute. The Impl
+  // class can override this by implementing the same function.
+  static constexpr std::array<DataType, 2> AllowedDataTypes() {
+    return {DataType::DT_FLOAT, DataType::DT_HALF};
+  }
+
+  // Validate data type of the given NodeDef against allowed types.
+  Status ValidateNodeDefDataType() {
+    // Get the NodeDef data type.
+    auto dtype = GetAttrValue<DataType>(Impl::NodeDefDataTypeAttributeName());
+    if (!dtype.ok()) {
+      return errors::InvalidArgument("Attribute with name ",
+                                     Impl::NodeDefDataTypeAttributeName(),
+                                     " not found.");
+    }
+
+    // Check allowed data types.
+    const auto& node_def = params_->node_def;
+    const auto& allowed_dtypes = Impl::AllowedDataTypes();
+    if (std::find(allowed_dtypes.begin(), allowed_dtypes.end(), *dtype) ==
+        allowed_dtypes.end()) {
+      std::string allowed_types_string = absl::StrJoin(
+          allowed_dtypes, ", ", [](std::string* out, const DataType& type) {
+            absl::StrAppendFormat(out, "%s", DataTypeString(type));
+          });
+      return errors::Unimplemented("Data type ", DataTypeString(*dtype),
+                                   " is not supported for ", node_def.op(),
+                                   ", must be one of [", allowed_types_string,
+                                   "], at ", node_def.name());
+    }
+    return Status::OK();
+  }
+
+  // Validates input argument roles and data types.
+  Status ValidateInputs() {
+    const NodeDef& node_def = params_->node_def;
+    const auto& inputs = params_->inputs;
+    TRT_ENSURE(inputs.size() == Impl::InputSpec().size());
+    for (int i = 0; i < inputs.size(); i++) {
+      const InputArgSpec arg_spec = Impl::InputSpec()[i];
+      if (arg_spec.allowed_roles == TrtInputArg::kWeight &&
+          inputs.at(i).is_tensor()) {
+        return errors::Unimplemented("The input \"", arg_spec.name, "\" for ",
+                                     node_def.op(), " must be a constant, at ",
+                                     node_def.name());
+      }
+      if (arg_spec.allowed_roles == TrtInputArg::kTensor &&
+          inputs.at(i).is_weights()) {
+        return errors::Unimplemented("The input \"", arg_spec.name, "\" for ",
+                                     node_def.op(), " must be a tensor, at ",
+                                     node_def.name());
+      }
+    }
+    return Status::OK();
+  }
+
+  Status operator()() {
+    // Validate data type and inputs.
+    TF_RETURN_IF_ERROR(this->ValidateNodeDefDataType());
+    TF_RETURN_IF_ERROR(this->ValidateInputs());
+
+    // Perform op-level validation.
+    TF_RETURN_IF_ERROR(reinterpret_cast<Impl*>(this)->Validate());
+    if (params_->validation_only) {
+      return Status::OK();
+    }
+
+    // Perform conversion.
+    return reinterpret_cast<Impl*>(this)->Convert();
+  }
+
+ protected:
+  void AddOutput(const TRT_TensorOrWeights& out) {
+    params_->outputs->push_back(out);
+  }
+
+  template <typename T>
+  StatusOr<T> GetAttrValue(absl::string_view key) const {
+    T result;
+    TF_RETURN_IF_ERROR(GetNodeAttr(node_def_attrs_, key, &result));
+    return result;
+  }
+
+  OpConverterParams* const params_;
+  AttrSlice node_def_attrs_;
+};
+
+// Constructs and returns a converter function for a given operation converter
+// class T. This requires T to be a derived class of StructuredOpConverter.
+template <typename T>
+OpConverter MakeConverterFunction() {
+  return [](OpConverterParams* params) -> Status {
+    T converter(params);
+    return converter();
+  };
+}
 
 }  // namespace convert
 }  // namespace tensorrt
 }  // namespace tensorflow
 
 #endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
-
 #endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_OP_CONVERTER_H_

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry_test.cc
@@ -12,16 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
 #include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
 
 #include <gtest/gtest.h>
 
-#if GOOGLE_CUDA && GOOGLE_TENSORRT
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter.h"
 
 namespace tensorflow {
 namespace tensorrt {
 namespace convert {
+
 TEST(TestOpConverterRegistry, TestOpConverterRegistry) {
   bool flag{false};
 

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter_test.cc
@@ -1,0 +1,125 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter.h"
+
+#include "gtest/gtest.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
+#include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/status_matchers.h"
+#include "tensorflow/core/protobuf/error_codes.pb.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+using ::tensorflow::testing::IsOk;
+using ::tensorflow::testing::StatusIs;
+using ::testing::HasSubstr;
+
+class ExampleOpConverter : public OpConverterBase<ExampleOpConverter> {
+ public:
+  explicit ExampleOpConverter(OpConverterParams* params)
+      : OpConverterBase<ExampleOpConverter>(params) {}
+
+  static constexpr const char* NodeDefDataTypeAttributeName() {
+    return "data_type";
+  }
+
+  static constexpr std::array<DataType, 2> AllowedDataTypes() {
+    return {DataType::DT_FLOAT};
+  }
+
+  static constexpr std::array<InputArgSpec, 2> InputSpec() {
+    return std::array<InputArgSpec, 2>{
+        InputArgSpec::Create("input_tensor", TrtInputArg::kTensor),
+        InputArgSpec::Create("weight", TrtInputArg::kWeight)};
+  }
+
+  Status Validate() { return Status::OK(); }
+
+  Status Convert() {
+    AddOutput(TRT_TensorOrWeights(nvinfer1::DataType::kFLOAT,
+                                  nvinfer1::Dims{1, 1, 1, 1}, 1));
+    return Status::OK();
+  }
+};
+
+TEST(TestOpConverterBase, TestOpConverterBase) {
+  // Register a converter which uses the base converter class.
+  GetOpConverterRegistry()->Register(
+      "FakeFunc", 1, MakeConverterFunction<ExampleOpConverter>());
+
+  NodeDef def;
+  def.set_op("FakeFunc");
+  auto converter = Converter::Create(TrtPrecisionMode::FP32, false,
+                                     Logger::GetLogger(), false, "test_engine");
+  EXPECT_THAT(converter, IsOk());
+
+  // Base class should check attribute with key given by
+  // Impl::NodeDefDataTypeAttributeName().
+  Status conversion_status = (*converter)->ConvertNode(def);
+  EXPECT_THAT(conversion_status,
+              StatusIs(error::INVALID_ARGUMENT,
+                       HasSubstr("Attribute with name data_type not found")));
+
+  // Add partial inputs to the node and make the converter aware.
+  def.mutable_input()->Add("input1");
+  (*converter)
+      ->AddInputTensor("input1", nvinfer1::DataType::kFLOAT,
+                       nvinfer1::Dims{4, {1, 1, 1, 1}}, 1);
+
+  // Base class method should check number of inputs.
+  AddNodeAttr("data_type", DT_FLOAT, &def);
+  conversion_status = (*converter)->ConvertNode(def);
+  EXPECT_THAT(conversion_status, StatusIs(error::INTERNAL));
+
+  // Add second input to the node and make the converter aware.
+  def.mutable_input()->Add("input2");
+  (*converter)
+      ->AddInputTensor("input2", nvinfer1::DataType::kFLOAT,
+                       nvinfer1::Dims{4, {1, 1, 1, 1}}, 1);
+
+  // Base class validation should check the type (Constant or Tensor) of the
+  // inputs.
+  conversion_status = (*converter)->ConvertNode(def);
+  EXPECT_THAT(
+      conversion_status,
+      StatusIs(error::UNIMPLEMENTED,
+               HasSubstr("input \"weight\" for FakeFunc must be a constant")));
+
+  // Correct input2 so that it is a weight.
+  (*converter)->TensorsMap().erase("input2");
+  (*converter)
+      ->TensorsMap()
+      .insert(std::make_pair("input2", TRT_TensorOrWeights(TRT_ShapedWeights(
+                                           nvinfer1::DataType::kFLOAT))));
+
+  // With the correct input types, check that the converter is called and sets
+  // one output tensor.
+  conversion_status = (*converter)->ConvertNode(def);
+  EXPECT_THAT(conversion_status, IsOk());
+  EXPECT_EQ((*converter)->TensorsMap().size(), 3U);
+
+  GetOpConverterRegistry()->Clear("FakeFunc");
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_tensor_proxy.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_tensor_proxy.h
@@ -441,6 +441,10 @@ inline bool operator==(const ITensorProxyPtr& p1, const ITensorProxyPtr& p2) {
            p1->simple_tensor() == p2->simple_tensor()));
 }
 
+inline bool operator!=(const ITensorProxyPtr& p1, const ITensorProxyPtr& p2) {
+  return !(p1 == p2);
+}
+
 struct ITensorProxyHash {
   size_t operator()(const ITensorProxyPtr& tensor) const {
     return reinterpret_cast<std::uintptr_t>(tensor.p_.get());


### PR DESCRIPTION
Adds StructuredOpConverter as a Curiously recurring template pattern (CRTP) template class. This is to prepare for registering more future op converters or refactoring of existing op converters. An example for using StructuredOpConverter is provided in op_converter_registry_test.

PR's #52248 and #52188 use this class for adding new QDQ op converters and refactoring the resize op converters, respectively.