### PR TITLE
r2.7 cherry-pick request: Fix missing-device unit test failures 

### DIFF
--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -83,6 +83,7 @@ limitations under the License.
 
 #ifdef INTEL_MKL
 #include "tensorflow/core/graph/mkl_graph_util.h"
+#include "tensorflow/core/util/util.h"
 #endif
 
 namespace tensorflow {
@@ -773,7 +774,7 @@ Status WrapInCallOp(EagerOperation* op, EagerOperation** wrapped_op) {
     ndef->set_device(op->DeviceName());
 
 #ifdef INTEL_MKL
-    if (IsMklEnabled() &&
+    if (IsMKLEnabled() &&
         absl::StartsWith(op->Name(), mkl_op_registry::kMklOpPrefix)) {
       // All MKL eager ops have `_kernel` private attribute that needs to be set
       // to a fixed label.
@@ -1174,6 +1175,13 @@ Status EagerLocalExecute(EagerOperation* op, TensorHandle** retvals,
 
   core::RefCountPtr<KernelAndDevice> kernel;
   auto status = GetOrCreateKernelAndDevice(op, retvals, num_retvals, &kernel);
+
+  if (IsMKLEnabled() && kernel != nullptr && !ctx.RunEagerOpAsFunction() &&
+      op->Device() == kVariantDeviceNull) {
+    // oneDNN optimization pass relies on the op's assigned device to determine
+    // whether it can be rewritten.
+    op->SetDevice(kernel->device());
+  }
 
   // Run all the registered rewrite pass after the placement, regardless whether
   // the placement is successful or not. The passes can either create new ops


### PR DESCRIPTION
Fix oneDNN-related test failures that were because of missing device settings.

Original PR has been merged to master: https://github.com/tensorflow/tensorflow/pull/52021/