### PR TITLE
Copy removal

### DIFF
--- a/tensorflow/compiler/mlir/hlo/BUILD
+++ b/tensorflow/compiler/mlir/hlo/BUILD
@@ -1689,6 +1689,7 @@ cc_library(
         ":broadcast_propagation",
         ":buffer_reuse",
         ":chlo_legalize_to_hlo",
+        ":copy_removal",
         ":expand_hlo_tuples",
         ":hlo_legalize_to_lhlo",
         ":hlo_legalize_to_memref",
@@ -1814,6 +1815,23 @@ cc_library(
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Transforms",
+    ],
+)
+
+cc_library(
+    name = "copy_removal",
+    srcs = ["lib/Transforms/copy_removal.cc"],
+    hdrs = [
+        "include/mlir-hlo/Analysis/userange_analysis.h",
+        "include/mlir-hlo/Transforms/PassDetail.h",
+        "include/mlir-hlo/Transforms/passes.h",
+    ],
+    deps = [
+        ":hlo",
+        ":lhlo",
+        ":transforms_pass_inc_gen",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:Pass",
     ],
 )
 

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Analysis/userange_analysis.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Analysis/userange_analysis.h
@@ -63,9 +63,10 @@ struct UseInterval {
   }
 
   /// Performs an interval subtraction => A = A - B.
-  /// Note: This assumes that all intervals of b are included in some interval
-  ///       of a.
   static void intervalSubtract(Vector &a, const Vector &b);
+
+  /// Performs an interval intersection => A = A ^ B.
+  static void intervalIntersect(Vector &a, const Vector &b);
 
   /// Performs an interval merge => A = A u B.
   /// Note: All overlapping and contiguous UseIntervals are merged.

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Analysis/userange_analysis.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Analysis/userange_analysis.h
@@ -145,6 +145,10 @@ class UserangeAnalysis {
   /// Merges the userange of itemB into the userange of itemA.
   void unionRanges(Value itemA, Value itemB);
 
+  /// Merges listB into listA, sorts the result and removes all duplicates.
+  static void mergeUsePositions(UsePositionList &listA,
+                                const UsePositionList &listB);
+
   /// Dumps the liveness information to the given stream.
   void dump(raw_ostream &os);
 
@@ -155,6 +159,10 @@ class UserangeAnalysis {
   /// Builds an UseInterval::Vector corresponding to the given OperationList.
   UseInterval::Vector computeInterval(
       Value value, const Liveness::OperationListT &operationList);
+
+  /// Computes the UsePositions of the given Value, sorts and inserts them into
+  /// the usePositionMap.
+  void computeUsePositions(Value v);
 
   /// Checks each operand within the operation for its memory effects and
   /// separates them into read and write.

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
@@ -38,6 +38,9 @@ std::unique_ptr<FunctionPass> createTestUserangePass();
 /// Creates a pass that prints the analysis results of ShapeComponentsAnalysis.
 std::unique_ptr<FunctionPass> createTestShapeComponentAnalysisPass();
 
+/// Creates a pass that removes operations that implements a CopyOpInterface.
+std::unique_ptr<FunctionPass> createCopyRemovalPass();
+
 }  // namespace mlir
 
 #endif  // TENSORFLOW_COMPILER_MLIR_HLO_LIB_TRANSFORMS_PASSES_H_

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
@@ -38,7 +38,8 @@ std::unique_ptr<FunctionPass> createTestUserangePass();
 /// Creates a pass that prints the analysis results of ShapeComponentsAnalysis.
 std::unique_ptr<FunctionPass> createTestShapeComponentAnalysisPass();
 
-/// Creates a pass that removes operations that implements a CopyOpInterface.
+/// Creates a pass that removes redundant operations that implement a
+/// CopyOpInterface.
 std::unique_ptr<FunctionPass> createCopyRemovalPass();
 
 }  // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
@@ -38,8 +38,9 @@ def ReshapeSimplifier : FunctionPass<"reshape-simplifier"> {
 }
 
 def CopyRemoval : FunctionPass<"copy-removal"> {
-  let summary = "Removes operations that implements a CopyOpInterface, if the "
-                "userange of the source ends with that operation.";
+  let summary = "Removes redundant operations that implement a "
+                "CopyOpInterface, if the intersection of the useranges from"
+                "copy source and target only contains the CopyOp.";
   let constructor = "createCopyRemovalPass()";
 }
 

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
@@ -37,6 +37,12 @@ def ReshapeSimplifier : FunctionPass<"reshape-simplifier"> {
   let constructor = "createReshapeSimplifierPass()";
 }
 
+def CopyRemoval : FunctionPass<"copy-removal"> {
+  let summary = "Removes operations that implements a CopyOpInterface, if the "
+                "userange of the source ends with that operation.";
+  let constructor = "createCopyRemovalPass()";
+}
+
 def TestUserange : FunctionPass<"test-print-userange"> {
   let summary = "Test pass for checking userange intervals.";
   let constructor = "createTestUserangePass()";

--- a/tensorflow/compiler/mlir/hlo/lib/Transforms/copy_removal.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Transforms/copy_removal.cc
@@ -1,0 +1,186 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir-hlo/Analysis/userange_analysis.h"
+#include "mlir-hlo/Dialect/mhlo/IR/lhlo_ops.h"
+#include "mlir-hlo/Transforms/PassDetail.h"
+#include "mlir-hlo/Transforms/passes.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/BufferUtils.h"
+
+namespace mlir {
+
+namespace {
+
+class CopyRemoval : BufferPlacementTransformationBase {
+public:
+  explicit CopyRemoval(Operation *op)
+      : BufferPlacementTransformationBase(op), userange(op, allocs, aliases),
+        dominators(op) {}
+
+  void removeCopy(Operation *op) {
+    // A set with the copy Operation to process.
+    llvm::SetVector<Operation *> toProcess;
+    fillProcessSet(toProcess);
+
+    while (!toProcess.empty()) {
+      Operation *currentOp = toProcess.pop_back_val();
+
+      // Cast the Operation and get the Source and Target.
+      auto copyOpInterface = dyn_cast<CopyOpInterface>(currentOp);
+      Value copySource = copyOpInterface.getSource();
+      Value copyTarget = copyOpInterface.getTarget();
+
+      // Get the UserangeIntervals.
+      UseInterval::Vector sourceInterval =
+          *userange.getUserangeInterval(copySource).getValue();
+      UseInterval::Vector targetInterval =
+          *userange.getUserangeInterval(copyTarget).getValue();
+
+      // Compute the intersection.
+      UseInterval::intervalIntersect(sourceInterval, targetInterval);
+
+      // If the sourceInterval contains more than one UseInterval, there are
+      // multiple operations that intersect. The sourceInterval must have at
+      // least one UseInterval that contains the copyOp.
+      if (sourceInterval.size() > 1)
+        continue;
+
+      // Check if all Operations inside the intersection are part of the copyOp.
+      if (!checkAncestor(currentOp, *sourceInterval.begin()))
+        continue;
+
+      // Check if the currentOp dominates all uses of the copyTarget.
+      if (!checkDominance(currentOp, copyTarget))
+        continue;
+
+      // Replace all uses of the target with the source.
+      copyTarget.replaceAllUsesWith(copySource);
+
+      // Merge the Useranges.
+      UseInterval::intervalMerge(sourceInterval, targetInterval);
+      toErase.insert(currentOp);
+    }
+    // Erase the copy operations.
+    for (auto eraseOp : toErase)
+      eraseOp->erase();
+
+    // Erase all allocs without uses.
+    for (const BufferPlacementAllocs::AllocEntry &entry : allocs) {
+      Value alloc = std::get<0>(entry);
+      if (alloc.use_empty())
+        alloc.getDefiningOp()->erase();
+    }
+  }
+
+private:
+  /// Iterate over all allocs and their aliases and add their uses to the
+  /// process set that implement a CopyOpInterface, where the alloc or alias is
+  /// the source of the CopyOpInterface.
+  void fillProcessSet(llvm::SetVector<Operation *> &toProcess) {
+    // A Set that contains the already processed aliases.
+    SmallPtrSet<Value, 16U> processedAliases;
+
+    // Iterate over the allocs.
+    for (const BufferPlacementAllocs::AllocEntry &entry : allocs) {
+      Value allocValue = std::get<0>(entry);
+
+      // Resolve the aliases of the current alloc and iterate over them.
+      const ValueSetT &aliasSet = aliases.resolve(allocValue);
+      for (Value alias : aliasSet) {
+        // If the alias is already processed, continue.
+        if (!processedAliases.insert(alias).second)
+          continue;
+
+        // If the value has no uses/ empty userange, continue.
+        auto userangeInterval = userange.getUserangeInterval(alias);
+        if (!userangeInterval)
+          continue;
+
+        // Iterate over the UseIntervals and check if the last Operation in the
+        // UseInterval implements a CopyOpInterface.
+        for (UseInterval interval : *userangeInterval.getValue()) {
+          Operation *currentLastUse = userange.getOperation(interval.end);
+          auto copyOpInterface = dyn_cast<CopyOpInterface>(currentLastUse);
+          if (!copyOpInterface)
+            continue;
+
+          // Check if the source is the alias.
+          if (copyOpInterface.getSource() != alias)
+            continue;
+
+          toProcess.insert(currentLastUse);
+        }
+      }
+    }
+  }
+
+  /// Check if all uses of the target Value are dominated by given Operation.
+  /// Note: The target has always at least one use which is the copy operation.
+  bool checkDominance(Operation *useOp, Value target) {
+    Block *useBlock = useOp->getBlock();
+    const UserangeAnalysis::UsePositionList &targetUsePosList =
+        *userange.getUserangePositions(target).getValue();
+    // Check if any use of the target is not dominated by the useOp. Erased
+    // operations are ignored as uses.
+    return !llvm::any_of(targetUsePosList,
+                         [=](const UserangeAnalysis::UsePosition targetUsePos) {
+                           Operation *targetUse = targetUsePos.second;
+                           return toErase.find(targetUse) == toErase.end() &&
+                                  !dominators.dominates(useBlock,
+                                                        targetUse->getBlock());
+                         });
+  }
+
+  /// Check if the given Operation is an ancestor of the operations inside the
+  /// UseInterval.
+  bool checkAncestor(Operation *op, UseInterval &interval) {
+    // Divide the start and end by two to remove read/write properties.
+    for (int id = interval.start / 2, e = interval.end / 2; id <= e; ++id) {
+      // Get the operation from the id. Multiply the id by 2, because the
+      // userange operates on doubled ids. Return false if the operation is not
+      // an ancestor.
+      if (!op->isAncestor(userange.getOperation(id * 2)))
+        return false;
+    }
+    return true;
+  }
+
+  /// A set containing copy operations that can be erased.
+  SmallPtrSet<Operation *, 16> toErase;
+
+  /// The current userange info.
+  UserangeAnalysis userange;
+
+  /// The current dominance info.
+  DominanceInfo dominators;
+
+}; // namespace
+
+struct CopyRemovalPass : public CopyRemovalBase<CopyRemovalPass> {
+  void runOnFunction() override {
+    Operation *funcOp = getFunction();
+    CopyRemoval removal(funcOp);
+    removal.removeCopy(funcOp);
+  }
+};
+
+} // namespace
+
+std::unique_ptr<FunctionPass> createCopyRemovalPass() {
+  return std::make_unique<CopyRemovalPass>();
+}
+
+} // namespace mlir


### PR DESCRIPTION
This copy removal pass is based on the UserangeAnalysis. First, all Operations implementing the CopyOpInterface are found, then the useranges of the source and target of the CopyOpInterface are intersected. The only Operation in the intersection must be the CopyOp or Operations that are within the nested region if the CopyOp implements a Region. If this is the case, we can remove the CopyOp.

This PR includes an addition to the UserangeAnalysis to intersect two useranges.

This is the implementation of the Implementation of a Copy Removal Pass #52029.