### PR TITLE
Fix the segfault issue when no fallback in AutotuneEntry

### DIFF
--- a/tensorflow/core/kernels/gpu_utils.h
+++ b/tensorflow/core/kernels/gpu_utils.h
@@ -331,7 +331,7 @@ class AutotuneEntry {
     }
     return absl::StrCat("{", op_runners_.primary->ToString(), ", ",
         (op_runners_.no_scratch_fallback ?
-         op_runners_.no_scratch_fallback->ToString() : ""), "}");
+         op_runners_.no_scratch_fallback->ToString() : "(op_runners have no fallback)"), "}");
   }
 
  private:

--- a/tensorflow/core/kernels/gpu_utils.h
+++ b/tensorflow/core/kernels/gpu_utils.h
@@ -330,7 +330,8 @@ class AutotuneEntry {
       return algorithm_config_.ToString();
     }
     return absl::StrCat("{", op_runners_.primary->ToString(), ", ",
-                        op_runners_.no_scratch_fallback->ToString(), "}");
+        (op_runners_.no_scratch_fallback ?
+         op_runners_.no_scratch_fallback->ToString() : ""), "}");
   }
 
  private:


### PR DESCRIPTION
The new AutotuneEntry might cause a segfault issue when the no_scratch_fallback is null and its ToString() method is called.



cc. @nluehr 