### PR TITLE
Remove C++ content from tensorflow/c/c_api_macros.h

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -144,7 +144,10 @@ cc_library(
 
 cc_library(
     name = "c_api_macros",
-    hdrs = ["c_api_macros.h"],
+    hdrs = [
+        "c_api_macros.h",
+        "c_api_macros_internal.h",
+    ],
     copts = tf_copts(),
     visibility = ["//visibility:public"],
     deps = [

--- a/tensorflow/c/c_api_macros.h
+++ b/tensorflow/c/c_api_macros.h
@@ -16,10 +16,6 @@ limitations under the License.
 #ifndef TENSORFLOW_C_C_API_MACROS_H_
 #define TENSORFLOW_C_C_API_MACROS_H_
 
-#ifdef __cplusplus
-#include "tensorflow/core/platform/status.h"
-#endif  // __cplusplus
-
 #ifdef SWIG
 #define TF_CAPI_EXPORT
 #else
@@ -47,32 +43,4 @@ limitations under the License.
   (offsetof(TYPE, MEMBER) + sizeof(((TYPE *)0)->MEMBER))
 #endif  // TF_OFFSET_OF_END
 
-#ifdef __cplusplus
-
-// Macro to verify that the field `struct_size` of STRUCT_OBJ is initialized.
-// `struct_size` is used for struct member compatibility check between core TF
-// and plug-ins with the same C API minor version. More info here:
-// https://github.com/tensorflow/community/blob/master/rfcs/20200612-stream-executor-c-api/C_API_versioning_strategy.md
-#define TF_VALIDATE_STRUCT_SIZE(STRUCT_NAME, STRUCT_OBJ, SIZE_VALUE_NAME) \
-  do {                                                                    \
-    if (STRUCT_OBJ.struct_size == 0) {                                    \
-      return tensorflow::Status(tensorflow::error::FAILED_PRECONDITION,   \
-                                "Expected initialized `" #STRUCT_NAME     \
-                                "` structure with `struct_size` field "   \
-                                "set to " #SIZE_VALUE_NAME                \
-                                ". Found `struct_size` = 0.");            \
-    }                                                                     \
-  } while (0)
-
-// Macro to verify that the field NAME of STRUCT_OBJ is not null.
-#define TF_VALIDATE_NOT_NULL(STRUCT_NAME, STRUCT_OBJ, NAME)             \
-  do {                                                                  \
-    if (STRUCT_OBJ.NAME == 0) {                                         \
-      return tensorflow::Status(tensorflow::error::FAILED_PRECONDITION, \
-                                "'" #NAME "' field in " #STRUCT_NAME    \
-                                " must be set.");                       \
-    }                                                                   \
-  } while (0)
-
-#endif  // __cplusplus
 #endif  // TENSORFLOW_C_C_API_MACROS_H_

--- a/tensorflow/c/c_api_macros_internal.h
+++ b/tensorflow/c/c_api_macros_internal.h
@@ -1,0 +1,48 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_C_C_API_MACROS_INTERNAL_H_
+#define TENSORFLOW_C_C_API_MACROS_INTERNAL_H_
+
+#ifdef __cplusplus
+#include "tensorflow/core/platform/status.h"
+
+// Macro to verify that the field `struct_size` of STRUCT_OBJ is initialized.
+// `struct_size` is used for struct member compatibility check between core TF
+// and plug-ins with the same C API minor version. More info here:
+// https://github.com/tensorflow/community/blob/master/rfcs/20200612-stream-executor-c-api/C_API_versioning_strategy.md
+#define TF_VALIDATE_STRUCT_SIZE(STRUCT_NAME, STRUCT_OBJ, SIZE_VALUE_NAME) \
+  do {                                                                    \
+    if (STRUCT_OBJ.struct_size == 0) {                                    \
+      return tensorflow::Status(tensorflow::error::FAILED_PRECONDITION,   \
+                                "Expected initialized `" #STRUCT_NAME     \
+                                "` structure with `struct_size` field "   \
+                                "set to " #SIZE_VALUE_NAME                \
+                                ". Found `struct_size` = 0.");            \
+    }                                                                     \
+  } while (0)
+
+// Macro to verify that the field NAME of STRUCT_OBJ is not null.
+#define TF_VALIDATE_NOT_NULL(STRUCT_NAME, STRUCT_OBJ, NAME)             \
+  do {                                                                  \
+    if (STRUCT_OBJ.NAME == 0) {                                         \
+      return tensorflow::Status(tensorflow::error::FAILED_PRECONDITION, \
+                                "'" #NAME "' field in " #STRUCT_NAME    \
+                                " must be set.");                       \
+    }                                                                   \
+  } while (0)
+
+#endif  // __cplusplus
+#endif  // TENSORFLOW_C_C_API_MACROS_INTERNAL_H_

--- a/tensorflow/c/experimental/pluggable_profiler/pluggable_profiler.cc
+++ b/tensorflow/c/experimental/pluggable_profiler/pluggable_profiler.cc
@@ -15,6 +15,7 @@ limitations under the License.
 #include <vector>
 
 #include "tensorflow/c/c_api_macros.h"
+#include "tensorflow/c/c_api_macros_internal.h"
 #include "tensorflow/c/experimental/pluggable_profiler/pluggable_profiler_internal.h"
 #include "tensorflow/c/tf_status_helper.h"
 #include "tensorflow/core/common_runtime/device/device_utils.h"

--- a/tensorflow/c/experimental/stream_executor/stream_executor.cc
+++ b/tensorflow/c/experimental/stream_executor/stream_executor.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include <string>
 
 #include "tensorflow/c/c_api_macros.h"
+#include "tensorflow/c/c_api_macros_internal.h"
 #include "tensorflow/c/experimental/stream_executor/stream_executor_internal.h"
 #include "tensorflow/c/tf_status_helper.h"
 #include "tensorflow/core/common_runtime/device/device_utils.h"


### PR DESCRIPTION
This PR tries to remove C++ conent from tensorflow/c/c_api_macros.h
so that it is possible to include this file from an external plugin
without depending on tensorflow's C++ headers (tensorflow/core/platform/status.h).

The reason for this move is that for external plugins (e.g., file systems plugins)
that utilize C API, it cannot include status.h as otherwise the whole tensorflow's
C++ library will be a dependency. This defeat the purpose of C APi modular plugin.

This PR place C++ content to tensorflow/core/platform/status.h instead so that
everything will still be combined both for C external plugins and C++ plugins.

(Note the C++ inclusion was added in PR #51647.)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>