### PR TITLE
Remove unused `kFloatValuesPerSseVector` variable

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/sse_tensor_utils.cc
+++ b/tensorflow/lite/kernels/internal/optimized/sse_tensor_utils.cc
@@ -138,7 +138,6 @@ float GetFloatVectorElement(__m128 v) {
 
 #ifdef __AVX2__
 constexpr int kFloatValuesPerAvx2Vector = 8;
-constexpr int kFloatValuesPerSseVector = 4;
 template <int PerVectorSize>
 inline int RoundDownVectors(int size) {
   return size & ~(PerVectorSize - 1);


### PR DESCRIPTION
Hi! Thanks for the great library and one of the best open source projects.

Looks like variable `kFloatValuesPerSseVector` is unused and my compiler (`clang-12`) reports error:
```
/contrib/tensorflow/tensorflow/lite/kernels/internal/optimized/sse_tensor_utils.cc:141:15: error: unused variable 'kFloatValuesPerSseVector' [-Werror,-Wunused-const-variable]
constexpr int kFloatValuesPerSseVector = 4;
              ^
1 error generated.
make[2]: *** [tensorflow-lite/CMakeFiles/tensorflow-lite.dir/build.make:356: tensorflow-lite/CMakeFiles/tensorflow-lite.dir/kernels/internal/optimized/sse_tensor_utils.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:1948: tensorflow-lite/CMakeFiles/tensorflow-lite.dir/all] Error 2
make: *** [Makefile:156: all] Error 2

```