### PR TITLE
r2.7 cherry-pick request: Fix oneDNN-related eager nightly test failures

### DIFF
--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -727,7 +727,7 @@ Status PopulateRetMap(FunctionDef* fdef, const AbstractOpAttrs* op_attrs,
 }
 
 #ifdef INTEL_MKL
-void GetMKLNodeDef(NodeDef* ndef) {
+inline void GetMKLNodeDef(NodeDef* ndef) {
   // All MKL eager ops have `_kernel` private attribute that needs to be set
   // to a fixed label.
   AttrValue attr_kernel;

--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -726,6 +726,16 @@ Status PopulateRetMap(FunctionDef* fdef, const AbstractOpAttrs* op_attrs,
   return Status::OK();
 }
 
+#ifdef INTEL_MKL
+void GetMKLNodeDef(NodeDef* ndef) {
+  // All MKL eager ops have `_kernel` private attribute that needs to be set
+  // to a fixed label.
+  AttrValue attr_kernel;
+  attr_kernel.set_s(mkl_op_registry::kMklNameChangeOpLabel);
+  (*ndef->mutable_attr()).insert({"_kernel", attr_kernel});
+}
+#endif  // INTEL_MKL
+
 Status WrapInCallOp(EagerOperation* op, EagerOperation** wrapped_op) {
   DCHECK(!op->is_function());
   const OpDef& opdef = OpRegistry::Global()->LookUp(op->Name())->op_def;
@@ -775,11 +785,7 @@ Status WrapInCallOp(EagerOperation* op, EagerOperation** wrapped_op) {
 #ifdef INTEL_MKL
     if (IsMklEnabled() &&
         absl::StartsWith(op->Name(), mkl_op_registry::kMklOpPrefix)) {
-      // All MKL eager ops have `_kernel` private attribute that needs to be set
-      // to a fixed label.
-      AttrValue attr_kernel;
-      attr_kernel.set_s(mkl_op_registry::kMklNameChangeOpLabel);
-      (*ndef->mutable_attr()).insert({"_kernel", attr_kernel});
+      GetMKLNodeDef(ndef);
     }
 #endif  // INTEL_MKL
 
@@ -926,7 +932,14 @@ Status GetOrCreateKernelAndDevice(
       // place the wrapped op on a GPU (if one is available) which leads to
       // errors because placer pins the function output nodes to GPU thereby
       // forcing a H2D copy of the dataset variant which is not supported.
-      const NodeDef& ndef = op->MutableAttrs()->BuildNodeDef();
+      auto ndef = op->MutableAttrs()->BuildNodeDef();
+#ifdef INTEL_MKL
+      if (IsMKLEnabled() &&
+          absl::StartsWith(op->Name(), mkl_op_registry::kMklOpPrefix)) {
+        GetMKLNodeDef(&ndef);
+      }
+#endif  // INTEL_MKL
+
       TF_RETURN_IF_ERROR(ctx.SelectDevice(preferred_device, ndef, &device));
 
       VLOG(1) << "PreferredDevice " << op->Name() << ": " << preferred_device;


### PR DESCRIPTION
Original PR (merged into master): https://github.com/tensorflow/tensorflow/pull/52204 

Fix `//tensorflow/python/kernel_tests:matmul_op_test` and `run_eager_op_as_function_test`, that failed with error "Could not find device for node:" when oneDNN is on.

These failures are because of the recent `WrapInCallOp` changes https://github.com/tensorflow/tensorflow/commit/1224326

Detailed explanation from the original PR:
> For MKL : we expect WrapInCallOp to be called before we infer device, which marks the '_kernel' attribute as NameChangeOp label for nodeDef of funcDef.
Since with new commit, WrapInCallOp is called AFTER the device inference, no device is found for the MKL Op as no kernel match is found without namechange label.
>
> In this PR: we mark nodeDef with '_kernel' attribute as NameChange label at both places : a) before inferring the device and b) inside WrapInCallOp (already present in current code base)


