### PR TITLE
Use Two-level autotuner for Cudnn Frontend APIs

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -666,30 +666,16 @@ class CudnnFilterDescriptor {
 //          "cudnn_version_end"   : -1
 //        }
 // ]})"
-// We skip eng0 in the static filter because they are too slow. Additionally,
-// users can specify an additional errata JSON file via
+// We skip a non-existing eng999 in the static filter as a placeholder.
+// Additionally, users can specify an additional errata JSON file via
 // CUDNN_ERRATA_JSON_FILE at runtime.
 const json* CudnnExecutionPlanEngineFilterStatic() {
   static absl::string_view filter_str = R"({
       "version" : 1,
         "rules"   : [
-          { "rule_id"             : "ConvFwd_eng0",
+          { "rule_id"             : "ConvFwd_eng999",
             "operation"           : "ConvFwd",
-            "engine"              : 0,
-            "knob"                : [],
-            "cudnn_version_start" : 8000,
-            "cudnn_version_end"   : -1
-          },
-          { "rule_id"             : "ConvBwdData_eng0",
-            "operation"           : "ConvBwdData",
-            "engine"              : 0,
-            "knob"                : [],
-            "cudnn_version_start" : 8000,
-            "cudnn_version_end"   : -1
-          },
-          { "rule_id"             : "ConvBwdFilter_eng0",
-            "operation"           : "ConvBwdFilter",
-            "engine"              : 0,
+            "engine"              : 999,
             "knob"                : [],
             "cudnn_version_start" : 8000,
             "cudnn_version_end"   : -1

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -2956,9 +2956,9 @@ port::StatusOr<bool> UseTensorOps(Stream* stream, dnn::DataType type,
 
 cudnnDataType_t GetRnnComputeType(dnn::DataType data_type);
 dnn::DataType GetConvAccumulatorType(dnn::DataType data_type);
-#if CUDNN_VERSION >= 8100
+#if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 cudnnBackendHeurMode_t GetCudnnFrontendHeurMode();
-#endif // CUDNN_VERSION >= 8100
+#endif // CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 
 port::StatusOr<dnn::AlgorithmDesc> GetCudnnConvolutionForwardAlgorithm(
     Stream* stream, const CudnnHandle& cudnn,
@@ -3325,7 +3325,7 @@ dnn::DataType GetConvAccumulatorType(dnn::DataType data_type) {
   }
 }
 
-#if CUDNN_VERSION >= 8100
+#if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 cudnnBackendHeurMode_t GetCudnnFrontendHeurMode() {
 #if CUDNN_VERSION >= 8200
   return CUDNN_HEUR_MODE_B;
@@ -3333,7 +3333,7 @@ cudnnBackendHeurMode_t GetCudnnFrontendHeurMode() {
   return CUDNN_HEUR_MODE_INSTANT;
 #endif // CUDNN_VERSION >= 8200
 }
-#endif // CUDNN_VERSION >= 8100
+#endif // CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 
 #if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 cudnnBackendDescriptorType_t GetCudnnConvolutionType(

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -3327,11 +3327,7 @@ dnn::DataType GetConvAccumulatorType(dnn::DataType data_type) {
 
 #if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 cudnnBackendHeurMode_t GetCudnnFrontendHeurMode() {
-#if CUDNN_VERSION >= 8200
-  return CUDNN_HEUR_MODE_B;
-#else
   return CUDNN_HEUR_MODE_INSTANT;
-#endif // CUDNN_VERSION >= 8200
 }
 #endif // CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 

--- a/tensorflow/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.h
@@ -241,7 +241,7 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::BatchDescriptor& bias_descriptor,
       const dnn::BatchDescriptor& output_descriptor,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
-      dnn::ActivationMode activation_mode,
+      bool use_fallback, dnn::ActivationMode activation_mode,
       std::vector<std::unique_ptr<const dnn::FusedConvRunner>>* out_exec_plans)
       override;
 

--- a/tensorflow/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.h
@@ -219,6 +219,7 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::BatchDescriptor& output_descriptor,
       DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
+      bool use_fallback,
       ScratchAllocator* scratch_allocator,
       std::vector<std::unique_ptr<const dnn::ConvRunner>>* out_exec_plans)
       override;

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -145,7 +145,7 @@ port::Status DnnSupport::GetFusedConvolveRunners(
     const dnn::FilterDescriptor& filter_descriptor,
     const dnn::BatchDescriptor& bias_descriptor,
     const dnn::BatchDescriptor& output_descriptor,
-    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor, bool use_fallback,
     dnn::ActivationMode activation_mode,
     std::vector<std::unique_ptr<const dnn::FusedConvRunner>>* out_exec_plans) {
   return port::UnimplementedError("GetFusedConvolveRunners not implemented.");

--- a/tensorflow/stream_executor/dnn.cc
+++ b/tensorflow/stream_executor/dnn.cc
@@ -120,6 +120,7 @@ port::Status DnnSupport::GetConvolveRunners(
     const dnn::BatchDescriptor& /*output_descriptor*/,
     DeviceMemoryBase /*output_data*/,
     const dnn::ConvolutionDescriptor& /*convolution_descriptor*/,
+    bool /*use_fallback*/,
     ScratchAllocator* /*scratch_allocator*/,
     std::vector<std::unique_ptr<const dnn::ConvRunner>>* /*exec_plans*/) {
   return port::UnimplementedError("GetConvolveRunners not implemented.");

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -1394,6 +1394,7 @@ class DnnSupport {
       const dnn::BatchDescriptor& output_descriptor,
       DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
+      bool use_fallback,
       ScratchAllocator* scratch_allocator,
       std::vector<std::unique_ptr<const dnn::ConvRunner>>* out_exec_plans);
 

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -1417,7 +1417,7 @@ class DnnSupport {
       const dnn::BatchDescriptor& bias_descriptor,
       const dnn::BatchDescriptor& output_descriptor,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
-      dnn::ActivationMode activation_mode,
+      bool use_fallback, dnn::ActivationMode activation_mode,
       std::vector<std::unique_ptr<const dnn::FusedConvRunner>>* out_exec_plans);
 
   virtual port::StatusOr<std::unique_ptr<const dnn::FusedConvRunner>>

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -330,7 +330,7 @@ port::Status StreamExecutor::GetFusedConvolveRunners(
     const dnn::FilterDescriptor &filter_descriptor,
     const dnn::BatchDescriptor &bias_descriptor,
     const dnn::BatchDescriptor &output_descriptor,
-    const dnn::ConvolutionDescriptor &convolution_descriptor,
+    const dnn::ConvolutionDescriptor &convolution_descriptor, bool use_fallback,
     dnn::ActivationMode activation_mode,
     std::vector<std::unique_ptr<const dnn::FusedConvRunner>> *out_exec_plans) {
   dnn::DnnSupport *dnn_support = AsDnn();
@@ -341,7 +341,7 @@ port::Status StreamExecutor::GetFusedConvolveRunners(
       use_cudnn_frontend, kind, input_type, bias_type, output_type,
       conv_input_scale, side_input_scale, stream, input_descriptor,
       filter_descriptor, bias_descriptor, output_descriptor,
-      convolution_descriptor, activation_mode, out_exec_plans);
+      convolution_descriptor, use_fallback, activation_mode, out_exec_plans);
 }
 
 port::StatusOr<std::unique_ptr<const dnn::FusedConvRunner>>

--- a/tensorflow/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/stream_executor/stream_executor_pimpl.cc
@@ -291,7 +291,7 @@ port::Status StreamExecutor::GetConvolveRunners(
     const dnn::FilterDescriptor &filter_descriptor,
     DeviceMemoryBase filter_data, const dnn::BatchDescriptor &output_descriptor,
     DeviceMemoryBase output_data,
-    const dnn::ConvolutionDescriptor &convolution_descriptor,
+    const dnn::ConvolutionDescriptor &convolution_descriptor, bool use_fallback,
     ScratchAllocator *scratch_allocator,
     std::vector<std::unique_ptr<const dnn::ConvRunner>> *out_exec_plans) {
   dnn::DnnSupport *dnn_support = AsDnn();
@@ -301,8 +301,8 @@ port::Status StreamExecutor::GetConvolveRunners(
   return dnn_support->GetConvolveRunners(
       use_cudnn_frontend, kind, input_type, output_type, stream,
       input_descriptor, input_data, filter_descriptor, filter_data,
-      output_descriptor, output_data, convolution_descriptor, scratch_allocator,
-      out_exec_plans);
+      output_descriptor, output_data, convolution_descriptor, use_fallback,
+      scratch_allocator, out_exec_plans);
 }
 
 port::StatusOr<std::unique_ptr<const dnn::ConvRunner>>

--- a/tensorflow/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/stream_executor/stream_executor_pimpl.h
@@ -379,6 +379,7 @@ class StreamExecutor {
       const dnn::BatchDescriptor &output_descriptor,
       DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor &convolution_descriptor,
+      bool use_fallback,
       ScratchAllocator *scratch_allocator,
       std::vector<std::unique_ptr<const dnn::ConvRunner>> *out_exec_plans);
 

--- a/tensorflow/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/stream_executor/stream_executor_pimpl.h
@@ -401,7 +401,7 @@ class StreamExecutor {
       const dnn::BatchDescriptor &bias_descriptor,
       const dnn::BatchDescriptor &output_descriptor,
       const dnn::ConvolutionDescriptor &convolution_descriptor,
-      dnn::ActivationMode activation_mode,
+      bool use_fallback, dnn::ActivationMode activation_mode,
       std::vector<std::unique_ptr<const dnn::FusedConvRunner>> *out_exec_plans);
 
   port::StatusOr<std::unique_ptr<const dnn::FusedConvRunner>>


### PR DESCRIPTION
This PR reduces the long startup time by applying a two-level autotuning when using the cudnn frontend APIs. Cudnn frontend supports two engine lists: heuristics and fallback. Heuristics engines are normally faster. In the two-level autotuner, we evaluate the fallback engines only when none of the heuristics engines work. 

With the two-level autotuner, we no longer filter out those slow eng0, since they are usually in the fallback list and won't be swept over if any heuristics engines work. We keep them to maintain a better functional coverage.

Also, we upgrade the heuristics mode from the decision tree to a neural network based solution (i.e., CUDNN_HEUR_MODE_INSTANT to CUDNN_HEUR_MODE_B): https://docs.nvidia.com/deeplearning/cudnn/release-notes/rel_8.html#rel-820

cc. @nluehr 