### PR TITLE
[INTEL oneDNN] Fix Pooling3D unit test failure

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
@@ -446,6 +446,11 @@ class MklPoolingOpBase : public OpKernel {
     OP_REQUIRES(context, this->ksize_.size() == 4 || this->ksize_.size() == 5,
                 errors::InvalidArgument("Sliding window ksize field must "
                                         "specify 4 or 5 dimensions"));
+    for (int i = 0; i < this->ksize_.size(); ++i) {
+      OP_REQUIRES(context, this->ksize_[i] > 0,
+                  errors::InvalidArgument("Sliding window ksize for dimension ",
+                                          i, " was zero."));
+    }
     OP_REQUIRES_OK(context, context->GetAttr("strides", &this->stride_));
     OP_REQUIRES(context, this->stride_.size() == 4 || this->stride_.size() == 5,
                 errors::InvalidArgument("Sliding window strides field must "


### PR DESCRIPTION
This PR fixes unit test failure of a newly added test case within
tensorflow/python/kernel_tests/pooling_ops_3d_test.py

This fix is similar to that of Eigen implementation (core/kernels/pooling_ops_common.h),
in the same way of handling ZERO pooling size.