### PR TITLE
Allow to apply tf-promote-resources-to-args on any function

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/tests/promote_resources_to_args_functions.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/promote_resources_to_args_functions.mlir
@@ -1,0 +1,32 @@
+// RUN: tf-opt %s -split-input-file -verify-diagnostics -tf-promote-resources-to-args=functions="add_and_pack,read" | FILECHECK_OPTS="" FileCheck %s
+
+module {
+
+  // One resource, one read. The initial value of the resource is read.
+  // CHECK-LABEL: func @add_and_pack(%arg0: tensor<i1>, %arg1: tensor<f32> {tf.resource_name = "x"}) -> tensor<2xf32>
+  func @add_and_pack(%arg0: tensor<i1>) -> tensor<2xf32> {
+    // CHECK-NOT: "tf.VarHandleOp"
+    // CHECK-NOT: "tf.ReadVariableOp"
+    // CHECK: %[[CONST:.*]] = "tf.Const"()
+    // CHECK: %[[ADD:[0-9]*]] = "tf.AddV2"(%arg1, %[[CONST]])
+    // CHECK: %[[PACK:[0-9]*]] = "tf.Pack"(%[[CONST]], %[[ADD]])
+    // CHECK: return %[[PACK]]
+    %0 = "tf.Const"() {value = dense<4.200000e+01> : tensor<f32>} : () -> tensor<f32>
+    %1 = "tf.VarHandleOp"() {container = "", shared_name = "x"} : () -> tensor<!tf_type.resource<tensor<f32>>>
+    %2 = "tf.ReadVariableOp"(%1) : (tensor<!tf_type.resource<tensor<f32>>>) -> tensor<f32>
+    %3 = "tf.AddV2"(%2, %0) : (tensor<f32>, tensor<f32>) -> tensor<f32>
+    %4 = "tf.Pack"(%0, %3) : (tensor<f32>, tensor<f32>) -> tensor<2xf32>
+    return %4 : tensor<2xf32>
+  }
+
+  // One resource, one read. _is_initialized is true, should be promoted.
+  // CHECK-LABEL: func @read(%arg0: tensor<f32> {tf.resource_name = "x"}) -> tensor<f32>
+  func @read() -> tensor<f32> {
+    // CHECK-NOT: "tf.VarHandleOp"
+    // CHECK-NOT: "tf.ReadVariableOp"
+    // CHECK: return %arg0
+    %1 = "tf.VarHandleOp"() {container = "", shared_name = "x", _is_initialized = true} : () -> tensor<!tf_type.resource<tensor<f32>>>
+    %2 = "tf.ReadVariableOp"(%1) : (tensor<!tf_type.resource<tensor<f32>>>) -> tensor<f32>
+    return %2 : tensor<f32>
+  }
+}

--- a/tensorflow/compiler/mlir/tensorflow/transforms/promote_resources_to_args.cc
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/promote_resources_to_args.cc
@@ -357,7 +357,7 @@ void PromoteResourcesToArgsPass::runOnOperation() {
     functions_ = {"main"};
   }
   SymbolTable symbolTable(module);
-  for (std::string f : functions_) {
+  for (const std::string &f : functions_) {
     FuncOp func = symbolTable.lookup<FuncOp>(f);
     if (!func) continue;
 

--- a/tensorflow/compiler/mlir/tensorflow/transforms/promote_resources_to_args.cc
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/promote_resources_to_args.cc
@@ -356,20 +356,21 @@ void PromoteResourcesToArgsPass::runOnOperation() {
   if (llvm::size(functions_) == 0) {
     functions_ = {"main"};
   }
+  SymbolTable symbolTable(module);
   for (std::string f : functions_) {
-    FuncOp main_func = module.lookupSymbol<FuncOp>(f);
-    if (!main_func) return;
+    FuncOp func = symbolTable.lookup<FuncOp>(f);
+    if (!func) return;
 
     // This routine should only be called when control flow operations are still
     // represented with TF IfOp and WhileOp operations. In this case, there should
     // be only one basic blocks in the MLIR representation.
-    if (failed(CheckSingleBlockFunction(main_func))) return signalPassFailure();
+    if (failed(CheckSingleBlockFunction(func))) return signalPassFailure();
 
     llvm::SmallVector<std::string, 4> var_handle_shared_names;
-    if (failed(ResourceLiftingForFunctionalControlFlow(main_func)) ||
-	failed(PromoteVarHandlesToArguments(main_func, /*add_validation=*/true,
+    if (failed(ResourceLiftingForFunctionalControlFlow(func)) ||
+	failed(PromoteVarHandlesToArguments(func, /*add_validation=*/true,
 					    &var_handle_shared_names)) ||
-	failed(PromoteResourcesToArguments(main_func, var_handle_shared_names)))
+	failed(PromoteResourcesToArguments(func, var_handle_shared_names)))
       return signalPassFailure();
   }
 }

--- a/tensorflow/compiler/mlir/tensorflow/transforms/promote_resources_to_args.cc
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/promote_resources_to_args.cc
@@ -359,7 +359,7 @@ void PromoteResourcesToArgsPass::runOnOperation() {
   SymbolTable symbolTable(module);
   for (std::string f : functions_) {
     FuncOp func = symbolTable.lookup<FuncOp>(f);
-    if (!func) return;
+    if (!func) continue;
 
     // This routine should only be called when control flow operations are still
     // represented with TF IfOp and WhileOp operations. In this case, there should

--- a/tensorflow/compiler/mlir/tensorflow/transforms/tf_passes.td
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/tf_passes.td
@@ -998,8 +998,8 @@ def TensorFlowOptimizePass : FunctionPass<"tf-optimize"> {
 def PromoteResourcesToArgsPass : Pass<"tf-promote-resources-to-args", "ModuleOp"> {
   let summary = "Promote resources reads/writes to function inputs/outputs.";
   let description = [{
-    This pass promotes resource accesses in the main function to input arguments
-    and outputs of the main function.
+    This pass promotes resource accesses in function(s) (by default, the main)
+    to input arguments and outputs of the function(s).
 
     Two types of resources are supported:
     (1) A function argument of TF::ResourceType type (this pass).
@@ -1034,6 +1034,13 @@ def PromoteResourcesToArgsPass : Pass<"tf-promote-resources-to-args", "ModuleOp"
   }];
 
   let constructor = "TF::CreatePromoteResourcesToArgsPass()";
+
+let options = [
+    ListOption<"functions_", "functions", "std::string",
+               "Comma separated list of functions whose resources "
+               "read/writes should be promoted to function inputs/outputs.",
+               "llvm::cl::MiscFlags::CommaSeparated">
+  ];
 }
 
 def PromoteVarHandlesToArgsPass : Pass<"tf-promote-var-handles-to-args", "ModuleOp"> {


### PR DESCRIPTION
Allow to specify on which function apply --tf-promote-resources-to-args, with the following command line : `tf-opt --tf-promote-resources-to-args=functions="func1,func2" myfile.mlir`
The initial behaviour is not broken : --tf-promote-resources-to-args alone still applies on the function "main".
Relative to the discussion on the forum [here](https://discuss.tensorflow.org/t/promote-resources-to-args-with-tf-opt/4915/3)