### PR TITLE
Added lowering for tfl.pad_v2 to tosa.concat operations

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -727,6 +727,26 @@ func @test_pad(%arg0: tensor<2x3xf32>) -> tensor<*xf32> {
   return %0 : tensor<*xf32>
 }
 
+
+// -----
+
+// CHECK-LABEL: test_pad_v2
+func @test_pad_v2(%arg0: tensor<1x256x8x25xf32>) -> (tensor<1x257x9x28xf32>) {
+  // CHECK-DAG: %[[PAD0:.+]] = "tosa.const"() {value = dense<-3.40282347E+38> : tensor<1x1x8x25xf32>}
+  // CHECK-DAG: %[[CONCAT0:.+]] = "tosa.concat"(%[[PAD0]], %arg0) {axis = 1 : i64}
+  // CHECK-DAG: %[[PAD1:.+]] = "tosa.const"() {value = dense<-3.40282347E+38> : tensor<1x257x1x25xf32>}
+  // CHECK-DAG: %[[CONCAT1:.+]] = "tosa.concat"(%[[CONCAT0]], %[[PAD1]]) {axis = 2 : i64}
+  // CHECK-DAG: %[[PAD2:.+]] = "tosa.const"() {value = dense<-3.40282347E+38> : tensor<1x257x9x1xf32>}
+  // CHECK-DAG: %[[PAD3:.+]] = "tosa.const"() {value = dense<-3.40282347E+38> : tensor<1x257x9x2xf32>}
+  // CHECK-DAG: %[[CONCAT2:.+]] = "tosa.concat"(%[[PAD2]], %[[CONCAT1]], %[[PAD3]]) {axis = 3 : i64}
+  %0 = "tfl.pseudo_const"() {value = dense<[[0, 0], [1, 0], [0, 1], [1, 2]]> : tensor<4x2xi32>} : () -> tensor<4x2xi32>
+  %1 = "tfl.pseudo_const"() {value = dense<-3.40282347E+38> : tensor<f32>} : () -> tensor<f32>
+  %2 = "tfl.padv2"(%arg0, %0, %1) : (tensor<1x256x8x25xf32>, tensor<4x2xi32>, tensor<f32>) -> tensor<1x257x9x28xf32>
+
+  // CHECK: return %[[CONCAT2]]
+  return %2 : tensor<1x257x9x28xf32>
+}
+
 // -----
 
 // CHECK-LABEL: test_expand_dims

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -127,6 +127,7 @@ DECL_CONVERT_OP(ZerosLike);
 DECL_CONVERT_OP(Less);
 DECL_CONVERT_OP(LessEqual);
 DECL_CONVERT_OP(Pad);
+DECL_CONVERT_OP(PadV2);
 DECL_CONVERT_OP(ResizeBilinear);
 DECL_CONVERT_OP(ResizeNearestNeighbor);
 DECL_CONVERT_OP(Select);
@@ -2042,6 +2043,70 @@ LogicalResult ConvertTFLPadOp::matchAndRewrite(
   return success();
 }
 
+LogicalResult ConvertTFLPadV2Op::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  auto tfl_pad_op = cast<TFL::PadV2Op>(op);
+
+  Value input = tfl_pad_op.input();
+  auto input_ty = input.getType().cast<ShapedType>();
+
+  if (!input_ty.hasRank()) return failure();
+
+  ElementsAttr constant_values_attr;
+  if (!matchPattern(tfl_pad_op.constant_values(), m_Constant(&constant_values_attr)))
+    return failure();
+
+  ElementsAttr padding_values_attr;
+  if (!matchPattern(tfl_pad_op.padding(), m_Constant(&padding_values_attr)))
+    return failure();
+
+  Attribute constant_attr = constant_values_attr.getValue<Attribute>(0);
+  llvm::SmallVector<int32_t> padding;
+  for (auto pad : padding_values_attr.getValues<int32_t>()) padding.push_back(pad);
+
+  for (int i = 0, s = padding.size(); i < s; i += 2) {
+    int64_t axis = i / 2;
+    int32_t pad_up = padding[i];
+    int32_t pad_down = padding[i + 1];
+    input_ty = input.getType().cast<ShapedType>();
+
+    if (pad_up == 0 && pad_down == 0) continue;
+
+    llvm::SmallVector<Value> concat_inputs;
+    if (pad_up != 0) {
+      llvm::SmallVector<int64_t> pad_shape(input_ty.getShape().begin(), input_ty.getShape().end());
+      pad_shape[axis] = pad_up;
+      auto pad_type = RankedTensorType::get(pad_shape, input_ty.getElementType());
+      // Change this for dynamic shapes.
+      if (!pad_type.hasStaticShape()) return failure();
+
+      auto pad_attr = DenseElementsAttr::get(pad_type, constant_attr);
+      concat_inputs.push_back(rewriter.create<tosa::ConstOp>(op->getLoc(), pad_type, pad_attr).getResult());
+    }
+
+    concat_inputs.push_back(input);
+
+    if (pad_down != 0) {
+      llvm::SmallVector<int64_t> pad_shape(input_ty.getShape().begin(), input_ty.getShape().end());
+      pad_shape[axis] = pad_down;
+      auto pad_type = RankedTensorType::get(pad_shape, input_ty.getElementType());
+      // Change this for dynamic shapes.
+      if (!pad_type.hasStaticShape()) return failure();
+
+      auto pad_attr = DenseElementsAttr::get(pad_type, constant_attr);
+      concat_inputs.push_back(rewriter.create<tosa::ConstOp>(op->getLoc(), pad_type, pad_attr).getResult());
+    }
+
+    auto concat_ty = UnrankedTensorType::get(input_ty.getElementType());
+    input = CreateOpAndInfer<tosa::ConcatOp>(rewriter, op->getLoc(), concat_ty, concat_inputs, rewriter.getI64IntegerAttr(axis)).getResult();
+ }
+
+  rewriter.replaceOp(op, input);
+
+
+  return success();
+}
+
 LogicalResult ConvertTFLResizeBilinearOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_resize_op = cast<TFL::ResizeBilinearOp>(op);
@@ -2970,6 +3035,7 @@ void LegalizeTFL::runOnFunction() {
   DEF_PATTERN_INSERT(TFLLess);
   DEF_PATTERN_INSERT(TFLLessEqual);
   DEF_PATTERN_INSERT(TFLPad);
+  DEF_PATTERN_INSERT(TFLPadV2);
   DEF_PATTERN_INSERT(TFLResizeBilinear);
   DEF_PATTERN_INSERT(TFLResizeNearestNeighbor);
   DEF_PATTERN_INSERT(TFLSelect);


### PR DESCRIPTION
tfl.pad_v2 requires specifying the pad value. Tosa.pad defaults to zero so the
easiest method to pad is to concat the values together. This should work for
most static cases and some dynamic cases.