### PR TITLE
Push upper and lower limits of python deps for the open source people…

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -64,9 +64,9 @@ if '--project_name' in sys.argv:
   sys.argv.pop(project_name_idx)
 
 
-# All versions of TF need these packages. We use the `~=` syntax to pin packages
-# to the latest major.minor release accepting all other patches on top of that.
-# If we already know of a patched version, we pin to that.
+# All versions of TF need these packages. We indicate the widest possible range
+# of package releases possible to be as up-to-date as possible as well as to
+# accomodate as many pre-installed packages as possible.
 # For packages that don't have yet a stable release, we pin using `~= 0.x` which
 # means we accept any `0.y` version (y >= x) but not the first major release. We
 # will need additional testing for that.
@@ -78,25 +78,25 @@ REQUIRED_PACKAGES = [
     # NOTE: As numpy has releases that break semver guarantees and several other
     # deps depend on numpy without an upper bound, we must install numpy before
     # everything else.
-    'numpy ~= 1.19.2',
+    'numpy >= 1.14.5', # keras 2.6 needs 1.19.2, h5py needs 1.14.5 for py37
     # Install other dependencies
-    'absl-py ~= 0.10',
-    'astunparse ~= 1.6.3',
-    'libclang ~= 11.1.0',
-    'flatbuffers ~= 2.0',
-    'google_pasta ~= 0.2',
-    'h5py ~= 3.1.0',
-    'keras_preprocessing ~= 1.1.2',
-    'opt_einsum ~= 3.3.0',
+    'absl-py >= 0.4.0',
+    'astunparse >= 1.6.0',
+    'libclang >= 9.0.1',
+    'flatbuffers >= 1.12, < 3.0', # capped as jax 0.1.71 needs < 3.0
+    'google_pasta >= 0.1.1',
+    'h5py >= 2.9.0', # capped since 3.3.0 lacks py3.6
+    'keras_preprocessing >= 1.1.1', # 1.1.0 needs tensorflow==1.7
+    'opt_einsum >= 2.3.2', # sphinx pin not removed up til 3.3.0 release
     'protobuf >= 3.9.2',
-    'six ~= 1.15.0',
-    'termcolor ~= 1.1.0',
-    'typing_extensions ~= 3.7.4',
-    'wheel ~= 0.35',
-    'wrapt ~= 1.12.1',
+    'six >= 1.12.0',
+    'termcolor >= 1.1.0',
+    'typing_extensions >= 3.6.6',
+    'wheel >= 0.32.0, < 1.0', # capped as astunparse 1.6.0-1.6.3 requires < 1.0
+    'wrapt >= 1.11.0',
     # These packages need to be pinned exactly as newer versions are
     # incompatible with the rest of the ecosystem
-    'gast == 0.4.0',
+    'gast >= 0.2.1, < 0.5.0', # TODO(lpak): if this breaks, revert to 0.4.0
     # TensorFlow ecosystem packages that TF exposes API for
     # These need to be in sync with the existing TF version
     # They are updated during the release process
@@ -127,17 +127,18 @@ if 'tf_nightly' in project_name:
 # BoringSSL support.
 # See https://github.com/tensorflow/tensorflow/issues/17882.
 if sys.byteorder == 'little':
-  REQUIRED_PACKAGES.append('grpcio >= 1.37.0, < 2.0')
+  REQUIRED_PACKAGES.append('grpcio >= 1.24.3, < 2.0')
 
 
 # Packages which are only needed for testing code.
 # Please don't add test-only packages to `REQUIRED_PACKAGES`!
 # Follows the same conventions as `REQUIRED_PACKAGES`
 TEST_PACKAGES = [
-    'portpicker ~= 1.3.1',
-    'scipy ~= 1.5.2',
-    'tblib ~= 1.7.0',
-    'dill ~= 0.3.2',
+    'portpicker >= 1.3.1',
+    'scipy ~= 1.5.2, < 1.7', # NOTE: capped due to py3.6 and opt-einsum requires
+    # sphinx==1.2.3 but scipy 1.7.1 requires sphinx >= 2.4.0, <3.1.0
+    'tblib >= 1.4.0',
+    'dill >= 0.2.9',
 ]
 
 


### PR DESCRIPTION
… who might have a different version of the dep that still works. Dep versions are still pinned in CI

PiperOrigin-RevId: 400270872
Change-Id: Ibf2818764b402b99e637c7624f3af435e78b48b0