### PR TITLE
Fixed tfl.strided_slice lowering to tosa for negative stride

### DIFF
--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
@@ -2064,6 +2064,24 @@ llvm::Optional<SmallVector<Value>> convertSplitVOp(
   return results_vec;
 }
 
+// Helper function to reverse negative striding. Only checks for -1 as that is
+// the only legal negative stride.
+static Value reverseNegativeStride(
+  PatternRewriter& rewriter, Operation*op, Value input, ArrayRef<int32_t> strides) {
+  Type reverse_ty = UnrankedTensorType::get(
+    input.getType().cast<ShapedType>().getElementType());
+  for (auto it : llvm::enumerate(strides)) {
+    auto axis = it.index();
+    auto stride = it.value();
+    if (stride != -1) continue;
+
+    input = CreateOpAndInfer<tosa::ReverseOp>(
+      rewriter, op->getLoc(), reverse_ty, input, rewriter.getI64IntegerAttr(axis)).getResult();
+  }
+
+  return input;
+}
+
 // Lowers StridedSlice to a sequence of TOSA ops.
 llvm::Optional<Value> convertStridedSliceOp(
     PatternRewriter& rewriter, Operation* op, Value result_value,
@@ -2114,17 +2132,21 @@ llvm::Optional<Value> convertStridedSliceOp(
     return llvm::None;
   }
 
-  bool all_strides_one =
-      strides_attr.isSplat() && strides_attr.getSplatValue<int32_t>() == 1;
+  if (failed(getVectorFromValue32(strides_value, strides))) {
+    return (void)rewriter.notifyMatchFailure(op, "strides isn't a constant"),
+           llvm::None;
+  }
+
+  bool all_strides_one = true;
+  for (auto stride : strides) all_strides_one &= abs(stride) == 1;
+
   int32_t strides_size = strides_attr.getNumElements();
 
   // If all of the masks are set we can just bypass the entire thing.
   const int32_t all_masks_one = (1 << strides_size) - 1;
   if (all_strides_one && begin_mask == all_masks_one &&
       end_mask == all_masks_one) {
-    return CreateOpAndInfer<tensor::CastOp>(rewriter, op->getLoc(), result_type,
-                                            input_value)
-        .getResult();
+    return reverseNegativeStride(rewriter, op, input_value, strides);
   }
 
   if (failed(getVectorFromValue32(begin_value, begin))) {
@@ -2139,9 +2161,7 @@ llvm::Optional<Value> convertStridedSliceOp(
 
   if (all_strides_one && begin_mask == all_masks_one &&
       end_mask == all_masks_one) {
-    return CreateOpAndInfer<tensor::CastOp>(rewriter, op->getLoc(), result_type,
-                                            input_value)
-        .getResult();
+    return reverseNegativeStride(rewriter, op, input_value, strides);
   }
 
   if (failed(getVectorFromValue32(end_value, end))) {
@@ -2156,11 +2176,6 @@ llvm::Optional<Value> convertStridedSliceOp(
   }
 
   int32_t input_rank = input_type.getRank();
-
-  if (failed(getVectorFromValue32(strides_value, strides))) {
-    return (void)rewriter.notifyMatchFailure(op, "strides isn't a constant"),
-           llvm::None;
-  }
 
   // If strides is incomplete, pad out to the full size.
   while (strides.size() < input_rank) strides.push_back(1);
@@ -2202,8 +2217,8 @@ llvm::Optional<Value> convertStridedSliceOp(
     a1_begin[i] = begin[i];
     a1_size[i] = end[i] - begin[i];
 
-    a2_shape[i * 2 + 0] = a1_size[i] / strides[i];
-    a2_shape[i * 2 + 1] = strides[i];
+    a2_shape[i * 2 + 0] = a1_size[i] / abs(strides[i]);
+    a2_shape[i * 2 + 1] = abs(strides[i]);
 
     a3_begin[i * 2 + 0] = 0;
     a3_begin[i * 2 + 1] = 0;
@@ -2211,15 +2226,16 @@ llvm::Optional<Value> convertStridedSliceOp(
     if (shrink_axis_mask & (1 << i)) {
       a3_size[i * 2 + 0] = 1;
     } else {
-      a3_size[i * 2 + 0] = a1_size[i] / strides[i];
+      a3_size[i * 2 + 0] = a1_size[i] / abs(strides[i]);
     }
     a3_size[i * 2 + 1] = 1;
 
     if (!(shrink_axis_mask & (1 << i))) {
       if (new_axis_mask & (1 << i)) a4_shape.push_back(1);
-      a4_shape.push_back((a1_size[i] / strides[i]));
+      a4_shape.push_back((a1_size[i] / abs(strides[i])));
     }
   }
+
 
   // Make sure we didn't lose any dimensions from the shrink_axis_mask
   assert(residual == 1);
@@ -2231,9 +2247,7 @@ llvm::Optional<Value> convertStridedSliceOp(
       rewriter.getI64ArrayAttr(a1_begin), rewriter.getI64ArrayAttr(a1_size));
 
   if (all_strides_one) {
-    return CreateOpAndInfer<tensor::CastOp>(rewriter, op->getLoc(), result_type,
-                                            a1_slice_op)
-        .getResult();
+    return reverseNegativeStride(rewriter, op, a1_slice_op.getResult(), strides);
   }
 
   // Step 2: reshape the sliced array
@@ -2250,10 +2264,12 @@ llvm::Optional<Value> convertStridedSliceOp(
       rewriter.getI64ArrayAttr(a3_size));
 
   // Step 4: reshape the now-strided tensor
-  return CreateOpAndInfer<tosa::ReshapeOp>(rewriter, op->getLoc(), result_type,
-                                           a3_slice_op.getResult(),
-                                           rewriter.getI64ArrayAttr(a4_shape))
-      .getResult();
+  auto a4_reshape_op = CreateOpAndInfer<tosa::ReshapeOp>(
+    rewriter, op->getLoc(), result_type, a3_slice_op.getResult(),
+    rewriter.getI64ArrayAttr(a4_shape)).getResult();
+
+  return reverseNegativeStride(
+    rewriter, op, a4_reshape_op, strides);
 }
 
 // Lowers FloorDiv to a sequence of TOSA operators.


### PR DESCRIPTION
Negative strides should reverse those axis after the slice is performed.
We insert tosa.reverse operations after the slicing / reshaping work is
finished.