### PR TITLE
[tensorflow/lite/toco/graph_transformations/unroll_batch_matmul.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/lite/toco/graph_transformations/unroll_batch_matmul.cc
+++ b/tensorflow/lite/toco/graph_transformations/unroll_batch_matmul.cc
@@ -56,6 +56,7 @@ std::vector<std::string> SliceInput(
 
   // Slice along each batch index and remember the slice output for future use.
   std::vector<std::string> slice_outputs;
+  slice_outputs.reserve(batch_size);
   for (int batch_idx = 0; batch_idx < batch_size; ++batch_idx) {
     std::string batch_name =
         absl::StrCat(base_name, "_b", batch_idx, "/slice_", input_name);
@@ -93,7 +94,7 @@ std::vector<std::string> SliceInput(
 std::vector<int32> GetTransposePerm(const Array& input_array) {
   const int32_t dims = input_array.shape().dimensions_count();
   std::vector<int32> perm_array_val(dims);
-  for (int i = 0; i < dims; ++i) {
+  for (int32_t i = 0; i < dims; ++i) {
     perm_array_val[i] = i;
   }
   perm_array_val[dims - 2] = dims - 1;
@@ -105,7 +106,7 @@ std::vector<int32> GetTransposeShape(const Shape& input_shape,
                                      const std::vector<int32>& perm_array_val) {
   const int32_t dims = input_shape.dimensions_count();
   std::vector<int32> output_shape(dims);
-  for (int i = 0; i < dims; ++i) {
+  for (int32_t i = 0; i < dims; ++i) {
     output_shape[i] = input_shape.dims(perm_array_val[i]);
   }
   return output_shape;
@@ -209,7 +210,7 @@ TransposeOperator* TransposeInput(const std::string& input, Model* model) {
   // Compute (single batch) MatMul for each output batch. The MatMul outputs are
   // then packed together into one output Tensor.
   std::vector<std::string> pack_inputs;
-  for (int batch_idx = 0; batch_idx < bcast.output_batch_size(); ++batch_idx) {
+  for (int64_t batch_idx = 0; batch_idx < bcast.output_batch_size(); ++batch_idx) {
     std::string batch_name =
         absl::StrCat(batch_op->outputs[0], "_b", batch_idx);
     const int a_batch_idx = bcast.IsBroadcastingRequired()


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)