### PR TITLE
[tensorflow/core/kernels/matmul_op_impl.h] Use correct size type for `batch_size`

### DIFF
--- a/tensorflow/core/kernels/matmul_op_impl.h
+++ b/tensorflow/core/kernels/matmul_op_impl.h
@@ -483,7 +483,7 @@ struct LaunchBatchMatMul<GPUDevice, Eigen::half> {
     const uint64 m = in_x.dim_size(adj_x || trans_x ? 2 : 1);
     const uint64 k = in_x.dim_size(adj_x || trans_x ? 1 : 2);
     const uint64 n = in_y.dim_size(adj_y || trans_y ? 1 : 2);
-    const uint64 batch_size = bcast.output_batch_size();
+    const int64_t batch_size = bcast.output_batch_size();
     auto blas_transpose_a = trans[adj_x ? 2 : (trans_x ? 1 : 0)];
     auto blas_transpose_b = trans[adj_y ? 2 : (trans_y ? 1 : 0)];
 


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)