### PR TITLE
[tensorflow/compiler/xrt/kernels/xrt_execute_op.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xrt/kernels/xrt_execute_op.cc
+++ b/tensorflow/compiler/xrt/kernels/xrt_execute_op.cc
@@ -338,7 +338,9 @@ xla::StatusOr<RefPtr<XRTTupleAllocation>> RunExecutable(
     auto uid_callback =
         [&](const xla::gpu::NcclCliqueKey& key) -> xla::StatusOr<std::string> {
       std::vector<int64_t> replicas;
-      for (auto& device : key.devices()) {
+      const auto key_devices = key.devices();
+      replicas.reserve(key_devices.size());
+      for (auto& device : key_devices) {
         replicas.push_back(device.value());
       }
       return nccl_factory->GetUniqueId(replicas);


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)