### PR TITLE
[tensorflow/compiler/xla/tests/select_test.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/tests/select_test.cc
+++ b/tensorflow/compiler/xla/tests/select_test.cc
@@ -166,6 +166,9 @@ TEST_F(SelectTest, SelectR1F32WithCmpR1F32sFromParamsLarge) {
   std::vector<float> v1vec;
   std::vector<float> v2vec;
   std::vector<float> expected_vec;
+  v1vec.reserve(datalen);
+  v2vec.reserve(datalen);
+  expected_vec.reserve(datalen);
   for (int i = 0; i < datalen; ++i) {
     float smaller = i;
     float larger = i * 2;


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)