### PR TITLE
[tensorflow/compiler/xla/tests/half_test.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/tests/half_test.cc
+++ b/tensorflow/compiler/xla/tests/half_test.cc
@@ -57,7 +57,9 @@ XLA_TEST_P(UnaryOpTest, Ops) {
 
   std::function<half(half)> compute_func = GetParam().compute_func;
   std::vector<half> expected;
-  for (int64_t i = 0; i < x.size(); ++i) {
+  const int64_t n = x.size();
+  expected.reserve(n);
+  for (int64_t i = 0; i < n; ++i) {
     expected.push_back(compute_func(x[i]));
   }
 
@@ -151,7 +153,9 @@ XLA_TEST_P(BinaryOpTest, Ops) {
 
   std::function<half(half, half)> compute_func = GetParam().compute_func;
   std::vector<half> expected;
-  for (int64_t i = 0; i < x.size(); ++i) {
+  const int64_t n = x.size();
+  expected.reserve(n);
+  for (int64_t i = 0; i < n; ++i) {
     expected.push_back(compute_func(x[i], y[i]));
   }
 


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)