### PR TITLE
[tensorflow/compiler/xla/shape_util.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/shape_util.cc
+++ b/tensorflow/compiler/xla/shape_util.cc
@@ -646,7 +646,9 @@ ShapeUtil::MakeShapeWithDescendingLayoutAndSamePhysicalLayout(
     return text;
   }
   std::vector<string> dim_elements;
-  for (int i = 0; i < shape.dimensions_size(); ++i) {
+  const auto dimensions_size = shape.dimensions_size();
+  dim_elements.reserve(dimensions_size);
+  for (int i = 0; i < dimensions_size; ++i) {
     if (shape.is_dynamic_dimension(i)) {
       dim_elements.push_back(StrCat("<=", shape.dimensions(i)));
     } else {
@@ -690,7 +692,9 @@ ShapeUtil::MakeShapeWithDescendingLayoutAndSamePhysicalLayout(
 
 /* static */ string ShapeUtil::HumanString(const ProgramShape& program_shape) {
   std::vector<string> parameters;
-  for (auto& shape : program_shape.parameters()) {
+  const auto _parameters = program_shape.parameters();
+  parameters.reserve(_parameters.size());
+  for (const auto& shape : _parameters) {
     const int i = parameters.size();
     parameters.push_back(StrCat(i < program_shape.parameter_names_size()
                                     ? program_shape.parameter_names(i)
@@ -1737,7 +1741,9 @@ static std::vector<size_t> ConsecutiveSegments(absl::Span<const int64_t> xs) {
 static Shape MergeDimensions(absl::Span<const size_t> segs,
                              const Shape& shape) {
   std::vector<int64_t> dimensions;
-  for (size_t i = 1; i <= segs.size(); ++i) {
+  const auto size = segs.size();
+  dimensions.reserve(size);
+  for (size_t i = 1; i <= size; ++i) {
     dimensions.push_back(std::accumulate(
         shape.dimensions().begin() + segs[i - 1],
         shape.dimensions().begin() +

--- a/tensorflow/compiler/xla/shape_util.cc
+++ b/tensorflow/compiler/xla/shape_util.cc
@@ -692,9 +692,9 @@ ShapeUtil::MakeShapeWithDescendingLayoutAndSamePhysicalLayout(
 
 /* static */ string ShapeUtil::HumanString(const ProgramShape& program_shape) {
   std::vector<string> parameters;
-  const auto _parameters = program_shape.parameters();
-  parameters.reserve(_parameters.size());
-  for (const auto& shape : _parameters) {
+  const auto& shape_parameters = program_shape.parameters();
+  parameters.reserve(shape_parameters.size());
+  for (const auto& shape : shape_parameters) {
     const int i = parameters.size();
     parameters.push_back(StrCat(i < program_shape.parameter_names_size()
                                     ? program_shape.parameter_names(i)


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)