### PR TITLE
[tensorflow/compiler/xla/service/while_loop_concat_code_motion.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/while_loop_concat_code_motion.cc
+++ b/tensorflow/compiler/xla/service/while_loop_concat_code_motion.cc
@@ -119,7 +119,7 @@ struct ConcatGroup {
       return slice;
     }
     std::vector<int64_t> element_shape;
-    element_shape.reserve(shape.rank());
+    element_shape.reserve(shape.rank() -1);
     for (int64_t i = 0; i < shape.rank(); ++i) {
       if (i != concat_dim) {
         element_shape.push_back(shape.dimensions(i));
@@ -134,7 +134,7 @@ struct ConcatGroup {
     if (inserted_concat_dim) {
       for (int64_t i = 0; i < input_elements.size(); ++i) {
         std::vector<int64_t> element_shape;
-        element_shape.reserve(input_elements[i]->shape().rank());
+        element_shape.reserve(input_elements[i]->shape().rank() + 1);
         for (int64_t j = 0; j < input_elements[i]->shape().rank(); ++j) {
           if (j == concat_dim) {
             element_shape.push_back(1);
@@ -393,7 +393,9 @@ void ModifyHloPropertiesForConcatShape(const ConcatGroup& group,
       CHECK_EQ(hlo->operand(0)->shape().rank(), hlo->dimensions().size());
     }
     std::vector<int64_t> dims;
-    for (int64_t i = 0; i < hlo->operand(0)->shape().rank(); ++i) {
+    const int64_t rank = hlo->operand(0)->shape().rank();
+    dims.reserve(rank);
+    for (int64_t i = 0; i < rank; ++i) {
       if (i == operand_concat_dim && operand_inserted_concat_dim) {
         dims.push_back(group.concat_dim);
       } else {
@@ -869,7 +871,10 @@ Status RewriteLoopWithConcatGroups(HloInstruction* loop,
         Shape data_shape = hlo->operand(i)->shape();
         std::vector<int64_t> broadcast_dims;
         std::vector<int64_t> broadcast_shape;
-        for (int64_t j = 0; j < data_shape.rank(); ++j) {
+        const int64_t data_shape_rank = data_shape.rank();
+        broadcast_dims.reserve(data_shape_rank);
+        broadcast_shape.reserve(data_shape_rank + 1);
+        for (int64_t j = 0; j < data_shape_rank; ++j) {
           if (j < operand_concat_dim) {
             broadcast_dims.push_back(j);
           } else {


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)