### PR TITLE
[tensorflow/compiler/xla/service/while_loop_all_reduce_code_motion.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/while_loop_all_reduce_code_motion.cc
+++ b/tensorflow/compiler/xla/service/while_loop_all_reduce_code_motion.cc
@@ -539,6 +539,7 @@ StatusOr<bool> WhileLoopAllReduceCodeMotion::Run(HloModule* module) {
       std::vector<HloInstruction*> computation_callers =
           call_graph->GetComputationCallers(computation);
       std::vector<HloInstruction*> while_caller_instructions;
+      while_caller_instructions.reserve(computation_callers.size());
       for (HloInstruction* caller_instruction : computation_callers) {
         // For simplicity, we only support while instructions whose shape is
         // tuple.


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)