### PR TITLE
[tensorflow/compiler/xla/service/tuple_points_to_analysis_test.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/tuple_points_to_analysis_test.cc
+++ b/tensorflow/compiler/xla/service/tuple_points_to_analysis_test.cc
@@ -111,6 +111,7 @@ class TuplePointsToAnalysisTest : public HloTestBase {
         points_to_analysis_->GetBufferDefinedAt(instruction, index)
             .ValueOrDie();
     std::vector<BufferAlias> expected_aliases;
+    expected_aliases.reserve(expected.size());
     for (auto& pair : expected) {
       expected_aliases.push_back(BufferAlias(pair.first, pair.second));
     }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)