### PR TITLE
[tensorflow/compiler/xla/service/space_to_batch_converter.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/space_to_batch_converter.cc
+++ b/tensorflow/compiler/xla/service/space_to_batch_converter.cc
@@ -1329,7 +1329,7 @@ void ConvolutionVisitor::PropagateOnBroadcast(HloInstruction* consumer,
   }
 
   std::vector<int64_t> broadcast_dims;
-  const auto dimensions = consumer->dimensions();
+  const auto& dimensions = consumer->dimensions();
   broadcast_dims.reserve(dimensions.size());
   for (auto j : dimensions) {
     broadcast_dims.push_back(DimLookUp(permute_dims, j));

--- a/tensorflow/compiler/xla/service/space_to_batch_converter.cc
+++ b/tensorflow/compiler/xla/service/space_to_batch_converter.cc
@@ -1329,7 +1329,9 @@ void ConvolutionVisitor::PropagateOnBroadcast(HloInstruction* consumer,
   }
 
   std::vector<int64_t> broadcast_dims;
-  for (auto j : consumer->dimensions()) {
+  const auto dimensions = consumer->dimensions();
+  broadcast_dims.reserve(dimensions.size());
+  for (auto j : dimensions) {
     broadcast_dims.push_back(DimLookUp(permute_dims, j));
   }
   auto new_broadcast = MakeBroadcastHlo(consumer->mutable_operand(0),


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)