### PR TITLE
[tensorflow/compiler/xla/service/shape_inference.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/shape_inference.cc
+++ b/tensorflow/compiler/xla/service/shape_inference.cc
@@ -710,11 +710,11 @@ Status ValidateDotDimensionNumbers(
   // dimensions except the contracted and batch dimensions.
   std::vector<int64_t> dimensions;
   std::vector<bool> is_dynamic;
-  const auto lhs_batch_dimensions = dimension_numbers.lhs_batch_dimensions();
+  const auto& lhs_batch_dimensions = dimension_numbers.lhs_batch_dimensions();
   const auto lhs_batch_dimensions_size =
-  lhs.rank() - dimension_numbers.lhs_contracting_dimensions().size() +
-  rhs.rank() - dimension_numbers.rhs_contracting_dimensions().size() -
-  dimension_numbers.rhs_batch_dimensions().size();
+    lhs.rank() - dimension_numbers.lhs_contracting_dimensions().size() +
+    rhs.rank() - dimension_numbers.rhs_contracting_dimensions().size() -
+    dimension_numbers.rhs_batch_dimensions().size();
   dimensions.reserve(lhs_batch_dimensions_size);
   is_dynamic.reserve(lhs_batch_dimensions_size);
   for (const int64_t lhs_dim : lhs_batch_dimensions) {
@@ -2305,7 +2305,7 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
                                 new_dimensions, new_is_dynamic);
   } else {
     std::vector<Shape> result_subshapes;
-    const auto tuple_shapes = to_apply.result().tuple_shapes();
+    const auto& tuple_shapes = to_apply.result().tuple_shapes();
     result_subshapes.reserve(tuple_shapes.size());
     for (const Shape& subshape : tuple_shapes) {
       result_subshapes.push_back(ShapeUtil::MakeShape(

--- a/tensorflow/compiler/xla/service/shape_inference.cc
+++ b/tensorflow/compiler/xla/service/shape_inference.cc
@@ -710,7 +710,11 @@ Status ValidateDotDimensionNumbers(
   // dimensions except the contracted and batch dimensions.
   std::vector<int64_t> dimensions;
   std::vector<bool> is_dynamic;
-  for (int64_t lhs_dim : dimension_numbers.lhs_batch_dimensions()) {
+  const auto lhs_batch_dimensions = dimension_numbers.lhs_batch_dimensions();
+  const auto lhs_batch_dimensions_size = lhs_batch_dimensions.size();
+  dimensions.reserve(lhs_batch_dimensions_size);
+  is_dynamic.reserve(lhs_batch_dimensions_size);
+  for (const int64_t lhs_dim : lhs_batch_dimensions) {
     dimensions.push_back(lhs.dimensions(lhs_dim));
     is_dynamic.push_back(lhs.is_dynamic_dimension(lhs_dim));
   }
@@ -1105,6 +1109,7 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
           }
         }
         std::vector<Shape> operand_shape_values;
+        operand_shape_values.reserve(operand_shapes.size());
         for (const Shape* operand_shape : operand_shapes) {
           operand_shape_values.push_back(*operand_shape);
         }
@@ -1144,6 +1149,7 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
     }
 
     std::vector<string> pieces;
+    pieces.reserve(arg_shapes.size());
     for (const Shape* shape : arg_shapes) {
       pieces.push_back(ShapeUtil::HumanString(*shape));
     }
@@ -2096,6 +2102,7 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
     return *operand_shapes[0];
   }
   std::vector<Shape> operand_shape_values;
+  operand_shape_values.reserve(operand_shapes.size());
   for (const Shape* operand_shape : operand_shapes) {
     operand_shape_values.push_back(*operand_shape);
   }
@@ -2266,6 +2273,7 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
 
   auto init_values = arg_shapes.subspan(num_reduced_args, arg_shapes.size());
   std::vector<PrimitiveType> element_types;
+  element_types.reserve(reduced_args.size());
   for (const Shape* arg : reduced_args) {
     element_types.push_back(arg->element_type());
   }
@@ -2294,7 +2302,9 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
                                 new_dimensions, new_is_dynamic);
   } else {
     std::vector<Shape> result_subshapes;
-    for (const Shape& subshape : to_apply.result().tuple_shapes()) {
+    const auto tuple_shapes = to_apply.result().tuple_shapes();
+    result_subshapes.reserve(tuple_shapes.size());
+    for (const Shape& subshape : tuple_shapes) {
       result_subshapes.push_back(ShapeUtil::MakeShape(
           subshape.element_type(), new_dimensions, new_is_dynamic));
     }
@@ -2328,6 +2338,7 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
     }
   }
   std::vector<PrimitiveType> operand_element_type_vec;
+  operand_element_type_vec.reserve(operands.size());
   for (const Shape* s : operands) {
     operand_element_type_vec.push_back(s->element_type());
   }
@@ -2335,7 +2346,9 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
                                         operand_element_type_vec,
                                         /*inputs=*/number_of_input));
   std::vector<Shape> output_shape_vec;
-  for (int i = 0; i < operands.size(); ++i) {
+  const size_t n = operands.size();
+  output_shape_vec.reserve(n);
+  for (size_t i = 0; i < operands.size(); ++i) {
     TF_ASSIGN_OR_RETURN(
         auto cur_output_shape,
         InferReduceWindowShape(*operands[i], *init_values[i], window));
@@ -2547,7 +2560,9 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
   }
 
   std::vector<int64_t> sizes;
-  for (int64_t dimension = 0; dimension < starts.size(); ++dimension) {
+  const auto starts_size = starts.size();
+  sizes.reserve(starts_size);
+  for (int64_t dimension = 0; dimension < starts_size; ++dimension) {
     int64_t start_index = starts[dimension];
     int64_t limit_index = limits[dimension];
     int64_t stride = strides[dimension];
@@ -3216,6 +3231,7 @@ ShapeInference::InferDegenerateDimensionBroadcastShape(HloOpcode operation,
       inferred_shape.set_dynamic_dimension(output_dynamic_dimension, true);
     } else {
       std::vector<int64_t> output_non_degenerated;
+      output_non_degenerated.reserve(output_dim_end);
       for (int64_t i = output_dim_start; i < output_dim_end; ++i) {
         if (new_sizes[i] != 1) {
           output_non_degenerated.push_back(i);
@@ -3728,7 +3744,9 @@ Status ValidateScatterDimensionNumbers(
 
   int64_t inserted_dims_seen = 0;
   std::vector<int64_t> max_update_slice_sizes;
-  for (int i = 0; i < operand_shape.dimensions_size(); ++i) {
+  const auto dimensions_size = operand_shape.dimensions_size();
+  max_update_slice_sizes.reserve(dimensions_size);
+  for (int i = 0; i < dimensions_size; ++i) {
     if (inserted_dims_seen < scatter_dim_numbers.inserted_window_dims_size() &&
         scatter_dim_numbers.inserted_window_dims(inserted_dims_seen) == i) {
       ++inserted_dims_seen;

--- a/tensorflow/compiler/xla/service/shape_inference.cc
+++ b/tensorflow/compiler/xla/service/shape_inference.cc
@@ -711,7 +711,9 @@ Status ValidateDotDimensionNumbers(
   std::vector<int64_t> dimensions;
   std::vector<bool> is_dynamic;
   const auto lhs_batch_dimensions = dimension_numbers.lhs_batch_dimensions();
-  const auto lhs_batch_dimensions_size = lhs_batch_dimensions.size();
+  const auto lhs_batch_dimensions_size = lhs.rank() - dimension_numbers.lhs_contracting_dimensions().size() \
+    + rhs.rank() - dimension_numbers.rhs_contracting_dimensions().size() \
+    - dimension_numbers.rhs_batch_dimensions().size();
   dimensions.reserve(lhs_batch_dimensions_size);
   is_dynamic.reserve(lhs_batch_dimensions_size);
   for (const int64_t lhs_dim : lhs_batch_dimensions) {

--- a/tensorflow/compiler/xla/service/shape_inference.cc
+++ b/tensorflow/compiler/xla/service/shape_inference.cc
@@ -711,9 +711,10 @@ Status ValidateDotDimensionNumbers(
   std::vector<int64_t> dimensions;
   std::vector<bool> is_dynamic;
   const auto lhs_batch_dimensions = dimension_numbers.lhs_batch_dimensions();
-  const auto lhs_batch_dimensions_size = lhs.rank() - dimension_numbers.lhs_contracting_dimensions().size() \
-    + rhs.rank() - dimension_numbers.rhs_contracting_dimensions().size() \
-    - dimension_numbers.rhs_batch_dimensions().size();
+  const auto lhs_batch_dimensions_size =
+  lhs.rank() - dimension_numbers.lhs_contracting_dimensions().size() +
+  rhs.rank() - dimension_numbers.rhs_contracting_dimensions().size() -
+  dimension_numbers.rhs_batch_dimensions().size();
   dimensions.reserve(lhs_batch_dimensions_size);
   is_dynamic.reserve(lhs_batch_dimensions_size);
   for (const int64_t lhs_dim : lhs_batch_dimensions) {


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)