### PR TITLE
[tensorflow/compiler/xla/service/service.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/service.cc
+++ b/tensorflow/compiler/xla/service/service.cc
@@ -361,7 +361,9 @@ Service::ExecuteParallelAndRegisterResult(
     TF_ASSIGN_OR_RETURN(auto replicas, Replicas(*backend, device_handles[i]));
     CHECK_EQ(replicas.size(), arguments[i].size());
     std::vector<ScopedShapedBuffer> result_buffers;
-    for (int64_t replica = 0; replica < replicas.size(); ++replica) {
+    const int64_t n = replicas.size();
+    replicas.reserve(n);
+    for (int64_t replica = 0; replica < n; ++replica) {
       TF_ASSIGN_OR_RETURN(StreamPool::Ptr stream,
                           backend->BorrowStream(replicas[replica]));
       streams.push_back(std::move(stream));
@@ -477,6 +479,7 @@ StatusOr<GlobalDataHandle> Service::ExecuteAndRegisterResult(
 
   // Set up run options.
   std::vector<ServiceExecutableRunOptions> run_options;
+  run_options.reserve(streams.size());
   for (const StreamPool::Ptr& stream : streams) {
     ExecutableRunOptions options;
     options.set_stream(stream.get());
@@ -941,6 +944,7 @@ Status Service::TransferToServer(const TransferToServerRequest* arg,
 
   // Allocate memory in each replica and transfer the data to all replicas.
   std::vector<ScopedShapedBuffer> replicated_buffers;
+  replicated_buffers.reserve(replicas.size());
   for (se::StreamExecutor* executor : replicas) {
     TF_ASSIGN_OR_RETURN(
         ScopedShapedBuffer shaped_buffer,

--- a/tensorflow/compiler/xla/service/service.cc
+++ b/tensorflow/compiler/xla/service/service.cc
@@ -362,7 +362,7 @@ Service::ExecuteParallelAndRegisterResult(
     CHECK_EQ(replicas.size(), arguments[i].size());
     std::vector<ScopedShapedBuffer> result_buffers;
     const int64_t n = replicas.size();
-    replicas.reserve(n);
+    result_buffers.reserve(n);
     for (int64_t replica = 0; replica < n; ++replica) {
       TF_ASSIGN_OR_RETURN(StreamPool::Ptr stream,
                           backend->BorrowStream(replicas[replica]));


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)