### PR TITLE
[tensorflow/compiler/xla/service/layout_assignment.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/layout_assignment.cc
+++ b/tensorflow/compiler/xla/service/layout_assignment.cc
@@ -1097,7 +1097,7 @@ Status LayoutAssignment::CheckLayouts(HloModule* module) {
           break;
         case HloOpcode::kConditional: {
           std::vector<ComputationLayout> branch_computation_layouts;
-          const auto branch_computations = instruction->branch_computations();
+          const auto& branch_computations = instruction->branch_computations();
           branch_computation_layouts.reserve(branch_computations.size());
           for (const auto branch_computation : branch_computations) {
             branch_computation_layouts.emplace_back(

--- a/tensorflow/compiler/xla/service/layout_assignment.cc
+++ b/tensorflow/compiler/xla/service/layout_assignment.cc
@@ -1097,7 +1097,9 @@ Status LayoutAssignment::CheckLayouts(HloModule* module) {
           break;
         case HloOpcode::kConditional: {
           std::vector<ComputationLayout> branch_computation_layouts;
-          for (auto branch_computation : instruction->branch_computations()) {
+          const auto branch_computations = instruction->branch_computations();
+          branch_computation_layouts.reserve(branch_computations.size());
+          for (const auto branch_computation : branch_computations) {
             branch_computation_layouts.emplace_back(
                 FindOrDie(computation_layouts_, branch_computation)
                     ->computation_layout());


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)