### PR TITLE
[tensorflow/compiler/xla/service/hlo_verifier_test.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_verifier_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_verifier_test.cc
@@ -871,6 +871,7 @@ TEST_F(HloVerifierTestAllowMixedPrecision, ReduceOperandComputationMismatch) {
 
 string ReplicaGroupsStr(std::vector<std::vector<int64_t>> replica_groups) {
   std::vector<string> replica_group_strs;
+  replica_group_strs.reserve(replica_groups.size());
   for (const auto& g : replica_groups) {
     replica_group_strs.push_back(
         absl::StrFormat("{%s}", absl::StrJoin(g, ",")));


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)