### PR TITLE
[tensorflow/compiler/xla/service/hlo_sharding.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_sharding.cc
+++ b/tensorflow/compiler/xla/service/hlo_sharding.cc
@@ -213,7 +213,9 @@ HloSharding HloSharding::Subgroup(
     Array<int64_t> new_tiles(transposed_shape);
     new_tiles.Each([&](absl::Span<const int64_t> indices, int64_t* value) {
       std::vector<int64_t> src_indices(tile_assignment.num_dimensions(), 0);
-      for (int64_t i = 0; i < indices.size(); ++i) {
+      const int64_t indices_size = indices.size();
+      src_indices.reserve(indices_size);
+      for (int64_t i = 0; i < indices_size; ++i) {
         src_indices[perm[i]] = indices[i];
       }
       *value = tile_assignment(src_indices);


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)