### PR TITLE
[tensorflow/compiler/xla/service/hlo_runner.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_runner.cc
+++ b/tensorflow/compiler/xla/service/hlo_runner.cc
@@ -65,6 +65,7 @@ StatusOr<ScopedShapedBuffer> HloRunner::TransferLiteralToDevice(
 StatusOr<std::vector<ScopedShapedBuffer>> HloRunner::TransferLiteralsToDevice(
     absl::Span<const Literal* const> literals) {
   std::vector<ScopedShapedBuffer> buffers;
+  buffers.reserve(literals.size());
   for (const Literal* literal : literals) {
     CHECK(literal != nullptr);
     TF_ASSIGN_OR_RETURN(ScopedShapedBuffer buffer,
@@ -325,6 +326,7 @@ StatusOr<std::vector<Literal>> HloRunner::ExecuteReplicatedImpl(
   LOG(INFO) << "Replicated execution terminated";
 
   std::vector<Literal> exec_results;
+  exec_results.reserve(options.num_replicas);
   for (int64_t i = 0; i < options.num_replicas; ++i) {
     TF_RETURN_IF_ERROR(streams[i]->BlockHostUntilDone());
     TF_ASSIGN_OR_RETURN(Literal literal,


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)