### PR TITLE
[tensorflow/compiler/xla/service/hlo_module_group_test.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_module_group_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_module_group_test.cc
@@ -192,9 +192,9 @@ ENTRY entry {
     ASSERT_EQ(metadata->companion_sets().size(), 1);
 
     std::vector<int64_t> module_ids;
-    const auto _companion_sets = *metadata->companion_sets()[0];
-    module_ids.reserve(_companion_sets.size());
-    for (HloInstruction* companion : _companion_sets) {
+    const auto& companion_sets = *metadata->companion_sets()[0];
+    module_ids.reserve(companion_sets.size());
+    for (HloInstruction* companion : companion_sets) {
       module_ids.push_back(metadata->GetModuleId(companion->GetModule()));
     }
 

--- a/tensorflow/compiler/xla/service/hlo_module_group_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_module_group_test.cc
@@ -192,6 +192,8 @@ ENTRY entry {
     ASSERT_EQ(metadata->companion_sets().size(), 1);
 
     std::vector<int64_t> module_ids;
+    const auto _companion_sets = *metadata->companion_sets()[0];
+    module_ids.reserve(_companion_sets.size());
     for (HloInstruction* companion : *metadata->companion_sets()[0]) {
       module_ids.push_back(metadata->GetModuleId(companion->GetModule()));
     }

--- a/tensorflow/compiler/xla/service/hlo_module_group_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_module_group_test.cc
@@ -194,7 +194,7 @@ ENTRY entry {
     std::vector<int64_t> module_ids;
     const auto _companion_sets = *metadata->companion_sets()[0];
     module_ids.reserve(_companion_sets.size());
-    for (HloInstruction* companion : *metadata->companion_sets()[0]) {
+    for (HloInstruction* companion : _companion_sets) {
       module_ids.push_back(metadata->GetModuleId(companion->GetModule()));
     }
 


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)