### PR TITLE
[tensorflow/compiler/xla/service/hlo_dataflow_analysis_test.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_dataflow_analysis_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_dataflow_analysis_test.cc
@@ -64,9 +64,9 @@ class HloDataflowAnalysisTest : public HloTestBase,
                                     const ShapeIndex& index = {}) {
     CHECK(analysis_ != nullptr);
     std::vector<HloValue> values;
-    const auto _values = analysis_->GetValueSet(instruction, index).values();
-    values.reserve(_values.size());
-    for (const HloValue* value : _values) {
+    const auto& analysis_values = analysis_->GetValueSet(instruction, index).values();
+    values.reserve(analysis_values.size());
+    for (const HloValue* value : analysis_values) {
       values.push_back(*value);
     }
     return values;

--- a/tensorflow/compiler/xla/service/hlo_dataflow_analysis_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_dataflow_analysis_test.cc
@@ -64,8 +64,9 @@ class HloDataflowAnalysisTest : public HloTestBase,
                                     const ShapeIndex& index = {}) {
     CHECK(analysis_ != nullptr);
     std::vector<HloValue> values;
-    for (const HloValue* value :
-         analysis_->GetValueSet(instruction, index).values()) {
+    const auto _values = analysis_->GetValueSet(instruction, index).values();
+    values.reserve(_values.size());
+    for (const HloValue* value : _values) {
       values.push_back(*value);
     }
     return values;


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)