### PR TITLE
[tensorflow/compiler/xla/service/hlo_buffer.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_buffer.cc
+++ b/tensorflow/compiler/xla/service/hlo_buffer.cc
@@ -44,6 +44,7 @@ bool HloBuffer::operator==(const HloBuffer& other) const {
 
 std::vector<HloPosition> HloBuffer::ComputePositions() const {
   std::vector<HloPosition> positions;
+  positions.reserve(values_.size());
   for (const HloValue* value : values_) {
     positions.insert(positions.end(), value->positions().begin(),
                      value->positions().end());


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)