### PR TITLE
[tensorflow/compiler/xla/service/hlo_alias_analysis.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_alias_analysis.cc
+++ b/tensorflow/compiler/xla/service/hlo_alias_analysis.cc
@@ -114,6 +114,7 @@ class BufferValueMap {
   // iterate through all buffers stabily.
   std::vector<BufferNumber> ComputeSortedBufferNumbers() const {
     std::vector<BufferNumber> buffer_numbers;
+    buffer_numbers.reserve(buffers_.size());
     for (const auto& pair : buffers_) {
       buffer_numbers.push_back(pair.first);
     }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)