### PR TITLE
[tensorflow/compiler/xla/service/gpu/tests/parallel_reduction_test.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/parallel_reduction_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/parallel_reduction_test.cc
@@ -115,6 +115,8 @@ TEST_F(ParallelReductionTest, ManyParallelReductions) {
   HloComputation::Builder b(TestName());
   std::vector<HloInstruction*> entry_params;
   std::vector<Shape> output_shapes;
+  entry_params.reserve(num_reduces);
+  output_shapes.reserve(num_reduces);
   for (size_t i = 0; i < num_reduces; ++i) {
     HloInstruction* param = b.AddInstruction(
         HloInstruction::CreateParameter(i, input_shape, "param"));


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)