### PR TITLE
[tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
@@ -80,6 +80,7 @@ StatusOr<ExecutionOutput> MlirGpuTestBase::RunMlirModule(
   ServiceExecutableRunOptions run_options(executable_run_options,
                                           backend_->StreamBorrower());
   std::vector<ExecutionInput> execution_inputs;
+  execution_inputs.reserve(arguments.size());
 
   for (auto arg : arguments) {
     Shape shape =


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)