### PR TITLE
[tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -585,7 +585,7 @@ std::vector<string> GetROCDLPaths(std::string amdgpu_version,
 
   // Construct full path to ROCDL bitcode libraries.
   std::vector<string> result;
-  result.reserve(rocdl_filenames->size());
+  result.reserve(rocdl_filenames->size() + 1);
   for (auto& filename : *rocdl_filenames) {
     result.push_back(tensorflow::io::JoinPath(rocdl_dir_path, filename));
   }

--- a/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
+++ b/tensorflow/compiler/xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.cc
@@ -585,6 +585,7 @@ std::vector<string> GetROCDLPaths(std::string amdgpu_version,
 
   // Construct full path to ROCDL bitcode libraries.
   std::vector<string> result;
+  result.reserve(rocdl_filenames->size());
   for (auto& filename : *rocdl_filenames) {
     result.push_back(tensorflow::io::JoinPath(rocdl_dir_path, filename));
   }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)