### PR TITLE
[tensorflow/compiler/xla/service/gpu/ir_emitter_nested.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_nested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_nested.cc
@@ -57,8 +57,12 @@ Status IrEmitterNested::CodegenNestedComputation() {
   std::vector<const HloInstruction*> io_hlos;
   std::vector<llvm::Type*> argument_types;
   std::vector<int64_t> argument_dereferenceable_bytes;
-  for (const HloInstruction* param :
-       nested_computation_.parameter_instructions()) {
+  const auto params = nested_computation_.parameter_instructions();
+  const auto n = params.size();
+  io_hlos.reserve(n);
+  argument_types.reserve(n);
+  argument_dereferenceable_bytes.reserve(n);
+  for (const HloInstruction* param : params) {
     io_hlos.push_back(param);
     const Shape& param_shape = param->shape();
     argument_types.push_back(

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_nested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_nested.cc
@@ -58,8 +58,8 @@ Status IrEmitterNested::CodegenNestedComputation() {
   std::vector<llvm::Type*> argument_types;
   std::vector<int64_t> argument_dereferenceable_bytes;
   const auto params = nested_computation_.parameter_instructions();
-  const auto n = params.size();
-  io_hlos.reserve(n);
+  const auto n = params.size() + 1;
+  io_hlos.reserve(n - 1);
   argument_types.reserve(n);
   argument_dereferenceable_bytes.reserve(n);
   for (const HloInstruction* param : params) {


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)