### PR TITLE
[tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -385,7 +385,7 @@ bool IsReductionFromOrToContiguousDimensions(mlir::Operation* op) {
   mlir::Value first_input = reduce.inputs()[0];
   Shape operand_shape = GetShape(first_input);
 
-  std::vector<int64_t> dimensions_to_reduce;
+  llvm::SmallVector<int64_t> dimensions_to_reduce;
   const auto& dimensions = reduce.dimensions();
   dimensions_to_reduce.reserve(dimensions.size());
   for (const llvm::APInt& d : dimensions) {
@@ -431,7 +431,7 @@ ReductionDimensions GetReductionKindAndContiguousComponents(
     mlir::Operation* reduce) {
   mlir::Value input = reduce->getOperand(0);
   Shape operand_shape = GetShape(input);
-  std::vector<int64_t> dimensions_to_reduce;
+  llvm::SmallVector<int64_t> dimensions_to_reduce;
   const auto& dimensions = mlir::cast<mlir::mhlo::ReduceOp>(reduce).dimensions();
   dimensions_to_reduce.reserve(dimensions.size());
   for (const llvm::APInt& d : dimensions) {

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -386,9 +386,7 @@ bool IsReductionFromOrToContiguousDimensions(mlir::Operation* op) {
   Shape operand_shape = GetShape(first_input);
 
   llvm::SmallVector<int64_t> dimensions_to_reduce;
-  const auto& dimensions = reduce.dimensions();
-  dimensions_to_reduce.reserve(dimensions.size());
-  for (const llvm::APInt& d : dimensions) {
+  for (const llvm::APInt& d : reduce.dimensions()) {
     dimensions_to_reduce.push_back(d.getZExtValue());
   }
 
@@ -432,9 +430,7 @@ ReductionDimensions GetReductionKindAndContiguousComponents(
   mlir::Value input = reduce->getOperand(0);
   Shape operand_shape = GetShape(input);
   llvm::SmallVector<int64_t> dimensions_to_reduce;
-  const auto& dimensions = mlir::cast<mlir::mhlo::ReduceOp>(reduce).dimensions();
-  dimensions_to_reduce.reserve(dimensions.size());
-  for (const llvm::APInt& d : dimensions) {
+  for (const llvm::APInt& d : mlir::cast<mlir::mhlo::ReduceOp>(reduce).dimensions()) {
     dimensions_to_reduce.push_back(d.getZExtValue());
   }
   return GetReductionKindAndContiguousComponentsImpl(operand_shape,

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -386,7 +386,9 @@ bool IsReductionFromOrToContiguousDimensions(mlir::Operation* op) {
   Shape operand_shape = GetShape(first_input);
 
   std::vector<int64_t> dimensions_to_reduce;
-  for (const llvm::APInt& d : reduce.dimensions()) {
+  const auto dimensions = reduce.dimensions();
+  dimensions_to_reduce.reserve(dimensions.size());
+  for (const llvm::APInt& d : dimensions) {
     dimensions_to_reduce.push_back(d.getZExtValue());
   }
 
@@ -430,8 +432,9 @@ ReductionDimensions GetReductionKindAndContiguousComponents(
   mlir::Value input = reduce->getOperand(0);
   Shape operand_shape = GetShape(input);
   std::vector<int64_t> dimensions_to_reduce;
-  for (const llvm::APInt& d :
-       mlir::cast<mlir::mhlo::ReduceOp>(reduce).dimensions()) {
+  const auto dimensions = mlir::cast<mlir::mhlo::ReduceOp>(reduce).dimensions();
+  dimensions_to_reduce.reserve(dimensions.size());
+  for (const llvm::APInt& d : dimensions) {
     dimensions_to_reduce.push_back(d.getZExtValue());
   }
   return GetReductionKindAndContiguousComponentsImpl(operand_shape,

--- a/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emission_utils.cc
@@ -386,7 +386,7 @@ bool IsReductionFromOrToContiguousDimensions(mlir::Operation* op) {
   Shape operand_shape = GetShape(first_input);
 
   std::vector<int64_t> dimensions_to_reduce;
-  const auto dimensions = reduce.dimensions();
+  const auto& dimensions = reduce.dimensions();
   dimensions_to_reduce.reserve(dimensions.size());
   for (const llvm::APInt& d : dimensions) {
     dimensions_to_reduce.push_back(d.getZExtValue());
@@ -432,7 +432,7 @@ ReductionDimensions GetReductionKindAndContiguousComponents(
   mlir::Value input = reduce->getOperand(0);
   Shape operand_shape = GetShape(input);
   std::vector<int64_t> dimensions_to_reduce;
-  const auto dimensions = mlir::cast<mlir::mhlo::ReduceOp>(reduce).dimensions();
+  const auto& dimensions = mlir::cast<mlir::mhlo::ReduceOp>(reduce).dimensions();
   dimensions_to_reduce.reserve(dimensions.size());
   for (const llvm::APInt& d : dimensions) {
     dimensions_to_reduce.push_back(d.getZExtValue());


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)