### PR TITLE
[tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
@@ -369,7 +369,9 @@ Status HorizontalLoopFusionImpl::CreateFusedComputation(
         continue;
       }
       std::vector<HloInstruction*> new_opnds;
-      for (HloInstruction* old_opnd : old_instr->operands()) {
+      auto old_opnds = old_instr->operands();
+      new_opnds.reserve(old_opnds.size());
+      for (HloInstruction* old_opnd : old_opnds) {
         CHECK(clone_map.find(old_opnd) != clone_map.end());
         new_opnds.push_back(clone_map[old_opnd]);
       }

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
@@ -369,7 +369,7 @@ Status HorizontalLoopFusionImpl::CreateFusedComputation(
         continue;
       }
       std::vector<HloInstruction*> new_opnds;
-      auto old_opnds = old_instr->operands();
+      const auto& old_opnds = old_instr->operands();
       new_opnds.reserve(old_opnds.size());
       for (HloInstruction* old_opnd : old_opnds) {
         CHECK(clone_map.find(old_opnd) != clone_map.end());


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)