### PR TITLE
[tensorflow/compiler/xla/service/elemental_ir_emitter.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/elemental_ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/elemental_ir_emitter.cc
@@ -2821,7 +2821,7 @@ StatusOr<llvm::Value*> ElementalIrEmitter::EmitElementalReduceWindow(
   const Window& window = reduce_window->window();
   llvm_ir::ForLoopNest loops(IrName(reduce_window), b_, index_type);
   std::vector<int64_t> window_size;
-  const auto dimensions = window.dimensions();
+  const auto& dimensions = window.dimensions();
   window_size.reserve(dimensions.size());
   for (const auto& dim : dimensions) {
     window_size.push_back(dim.size());

--- a/tensorflow/compiler/xla/service/elemental_ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/elemental_ir_emitter.cc
@@ -2821,7 +2821,9 @@ StatusOr<llvm::Value*> ElementalIrEmitter::EmitElementalReduceWindow(
   const Window& window = reduce_window->window();
   llvm_ir::ForLoopNest loops(IrName(reduce_window), b_, index_type);
   std::vector<int64_t> window_size;
-  for (const auto& dim : window.dimensions()) {
+  const auto dimensions = window.dimensions();
+  window_size.reserve(dimensions.size());
+  for (const auto& dim : dimensions) {
     window_size.push_back(dim.size());
   }
   const IrArray::Index window_index = loops.AddLoopsForShape(


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)