### PR TITLE
[tensorflow/compiler/xla/service/cpu/vector_support_library.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/vector_support_library.cc
+++ b/tensorflow/compiler/xla/service/cpu/vector_support_library.cc
@@ -375,6 +375,7 @@ VectorSupportLibrary::ComputeAvxOptimizedHorizontalSums(
 
   while (vectors.size() != 2) {
     std::vector<llvm::Value*> new_vectors;
+    new_vectors.reserve(vectors.size() / 2);
     for (int i = 0; i < vectors.size(); i += 2) {
       new_vectors.push_back(AvxStyleHorizontalAdd(vectors[i], vectors[i + 1]));
     }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)