### PR TITLE
[tensorflow/compiler/xla/service/cpu/ir_emitter.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
@@ -736,7 +736,7 @@ Status IrEmitter::HandleSelectAndScatter(HloInstruction* select_and_scatter) {
   // Create the inner loop to iterate over the window.
   llvm_ir::ForLoopNest window_loops(IrName(select_and_scatter, "window"), &b_);
   std::vector<int64_t> window_size;
-  const auto dimensions = window.dimensions();
+  const auto& dimensions = window.dimensions();
   window_size.reserve(dimensions.size());
   for (const auto& dim : dimensions) {
     window_size.push_back(dim.size());
@@ -1926,7 +1926,7 @@ Status IrEmitter::HandleSlice(HloInstruction* slice) {
 
   // Determine the dimensions that get lowered as loops.
   std::vector<int64_t> outer_dims;
-  const int64_t n = num_dims - inner_dims.size() - 1;
+  const int64_t n = num_dims - inner_dims.size() + 1;
   outer_dims.reserve(n);
   for (int64_t i = 0; i < n; ++i) {
     outer_dims.push_back(LayoutUtil::Major(layout, i));

--- a/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
@@ -735,7 +735,7 @@ Status IrEmitter::HandleSelectAndScatter(HloInstruction* select_and_scatter) {
 
   // Create the inner loop to iterate over the window.
   llvm_ir::ForLoopNest window_loops(IrName(select_and_scatter, "window"), &b_);
-  std::vector<int64_t> window_size;
+  llvm::SmallVector<int64_t> window_size;
   const auto& dimensions = window.dimensions();
   window_size.reserve(dimensions.size());
   for (const auto& dim : dimensions) {
@@ -1925,9 +1925,9 @@ Status IrEmitter::HandleSlice(HloInstruction* slice) {
           : 1;
 
   // Determine the dimensions that get lowered as loops.
-  std::vector<int64_t> outer_dims;
-  const int64_t n = num_dims - inner_dims.size() + 1;
-  outer_dims.reserve(n);
+  llvm::SmallVector<int64_t> outer_dims;
+  const int64_t n = num_dims - inner_dims.size() ;
+  outer_dims.reserve(n + 1);
   for (int64_t i = 0; i < n; ++i) {
     outer_dims.push_back(LayoutUtil::Major(layout, i));
   }

--- a/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
@@ -1926,7 +1926,7 @@ Status IrEmitter::HandleSlice(HloInstruction* slice) {
 
   // Determine the dimensions that get lowered as loops.
   llvm::SmallVector<int64_t> outer_dims;
-  const int64_t n = num_dims - inner_dims.size() ;
+  const int64_t n = num_dims - inner_dims.size() - 1;
   outer_dims.reserve(n + 1);
   for (int64_t i = 0; i < n; ++i) {
     outer_dims.push_back(LayoutUtil::Major(layout, i));

--- a/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
@@ -736,7 +736,9 @@ Status IrEmitter::HandleSelectAndScatter(HloInstruction* select_and_scatter) {
   // Create the inner loop to iterate over the window.
   llvm_ir::ForLoopNest window_loops(IrName(select_and_scatter, "window"), &b_);
   std::vector<int64_t> window_size;
-  for (const auto& dim : window.dimensions()) {
+  const auto dimensions = window.dimensions();
+  window_size.reserve(dimensions.size());
+  for (const auto& dim : dimensions) {
     window_size.push_back(dim.size());
   }
   const llvm_ir::IrArray::Index window_index = window_loops.AddLoopsForShape(
@@ -1924,7 +1926,9 @@ Status IrEmitter::HandleSlice(HloInstruction* slice) {
 
   // Determine the dimensions that get lowered as loops.
   std::vector<int64_t> outer_dims;
-  for (int64_t i = 0; i < num_dims - inner_dims.size() - 1; ++i) {
+  const int64_t n = num_dims - inner_dims.size() - 1;
+  outer_dims.reserve(n);
+  for (int64_t i = 0; i < n; ++i) {
     outer_dims.push_back(LayoutUtil::Major(layout, i));
   }
 


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)