### PR TITLE
[tensorflow/c/c_api_function_test.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/c/c_api_function_test.cc
+++ b/tensorflow/c/c_api_function_test.cc
@@ -37,6 +37,7 @@ typedef std::pair<string, DataType> IOSpec;
 
 std::vector<IOSpec> M(const std::initializer_list<string>& names) {
   std::vector<IOSpec> v;
+  v.reserve(names.size());
   for (const string& name : names) {
     v.push_back(IOSpec(name, DT_INVALID));
   }
@@ -144,6 +145,7 @@ class CApiFunctionTest : public ::testing::Test {
 
   std::vector<TF_Output> ToOutput(const std::vector<TF_Operation*> ops) {
     std::vector<TF_Output> out;
+    out.reserve(ops.size());
     for (auto op : ops) {
       out.push_back({op, 0});
     }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)