### PR TITLE
[tensorflow/c/c_test_util.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/c/c_test_util.cc
+++ b/tensorflow/c/c_test_util.cc
@@ -443,7 +443,9 @@ std::vector<std::pair<string, string>> GetGradDefs(
 
 std::vector<string> GetFuncNames(const tensorflow::GraphDef& graph_def) {
   std::vector<string> names;
-  for (const tensorflow::FunctionDef& func : graph_def.library().function()) {
+  auto functions = graph_def.library().function();
+  names.reserve(functions.size());
+  for (const tensorflow::FunctionDef& func : functions) {
     names.push_back(func.signature().name());
   }
   std::sort(names.begin(), names.end());


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)