### PR TITLE
[tensorflow/c/eager/gradients.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/c/eager/gradients.cc
+++ b/tensorflow/c/eager/gradients.cc
@@ -233,6 +233,7 @@ void Tape::RecordOperation(absl::Span<AbstractTensorHandle* const> inputs,
     input_dtypes[i] = inputs[i]->DataType();
   }
   std::vector<TapeTensor> tape_tensors;
+  tape_tensors.reserve(outputs.size());
   for (auto t : outputs) {
     tape_tensors.push_back(TapeTensor(t));
   }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)