### PR TITLE
[tensorflow/c/experimental/filesystem/plugins/gcs/ram_file_block_cache_test.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/c/experimental/filesystem/plugins/gcs/ram_file_block_cache_test.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gcs/ram_file_block_cache_test.cc
@@ -128,6 +128,7 @@ TEST(RamFileBlockCacheTest, BlockAlignment) {
   // do in this test.
   const size_t size = 256;
   std::vector<char> buf;
+  buf.reserve(size);
   for (int i = 0; i < size; i++) {
     buf.push_back(i);
   }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)