### PR TITLE
[tensorflow/c/tf_tensor.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/c/tf_tensor.cc
+++ b/tensorflow/c/tf_tensor.cc
@@ -261,7 +261,9 @@ static TF_Tensor* EmptyTensor(TF_DataType dtype,
   static char empty;
   int64_t nelems = 1;
   std::vector<int64_t> dims;
-  for (int i = 0; i < shape.dims(); ++i) {
+  auto shape_dims = shape.dims();
+  dims.reserve(shape_dims);
+  for (int i = 0; i < shape_dims; ++i) {
     dims.push_back(shape.dim_size(i));
     nelems *= shape.dim_size(i);
   }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)