### PR TITLE
[tensorflow/cc/gradients/array_grad.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/cc/gradients/array_grad.cc
+++ b/tensorflow/cc/gradients/array_grad.cc
@@ -523,6 +523,7 @@ Status ConcatGradHelper(const Scope& scope, const Operation& op,
     return errors::Internal("Invalid input index");
   }
   std::vector<Output> inputs;
+  inputs.reserve(end_value_index - start_value_index);
   for (int i = start_value_index; i < end_value_index; ++i) {
     inputs.push_back(op.input(i));
   }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)