### PR TITLE
[tensorflow/cc/gradients/functional_grad.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/cc/gradients/functional_grad.cc
+++ b/tensorflow/cc/gradients/functional_grad.cc
@@ -35,11 +35,11 @@ Status PartitionedCallGrad(const Scope& scope, const Operation& op,
 
   std::vector<Output> func_inputs;
   std::vector<DataType> input_dtypes;
-  const auto num_inputs = op.num_inputs();
-  func_inputs.reserve(num_inputs);
+  const int num_inputs = op.num_inputs();
+  func_inputs.reserve(num_inputs + grad_inputs.size());
   input_dtypes.reserve(num_inputs);
 
-  for (int32_t i = 0; i < num_inputs; i++) {
+  for (int i = 0; i < num_inputs; i++) {
     func_inputs.push_back(op.input(i));
     input_dtypes.push_back(op.input_type(i));
   }
@@ -48,7 +48,7 @@ Status PartitionedCallGrad(const Scope& scope, const Operation& op,
                      std::end(grad_inputs));
 
   auto grad = SymbolicGradient(scope, func_inputs, input_dtypes, f);
-  for (int32_t i = 0; i < op.num_inputs(); i++) {
+  for (int i = 0; i < num_inputs; i++) {
     grad_outputs->push_back(grad[i]);
   }
 

--- a/tensorflow/cc/gradients/functional_grad.cc
+++ b/tensorflow/cc/gradients/functional_grad.cc
@@ -35,8 +35,11 @@ Status PartitionedCallGrad(const Scope& scope, const Operation& op,
 
   std::vector<Output> func_inputs;
   std::vector<DataType> input_dtypes;
+  const auto num_inputs = op.num_inputs();
+  func_inputs.reserve(num_inputs);
+  input_dtypes.reserve(num_inputs);
 
-  for (int32_t i = 0; i < op.num_inputs(); i++) {
+  for (int32_t i = 0; i < num_inputs; i++) {
     func_inputs.push_back(op.input(i));
     input_dtypes.push_back(op.input_type(i));
   }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)