### PR TITLE
[tensorflow/cc/saved_model/saved_model_bundle_lite_test.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/cc/saved_model/saved_model_bundle_lite_test.cc
+++ b/tensorflow/cc/saved_model/saved_model_bundle_lite_test.cc
@@ -79,7 +79,9 @@ class LoaderTest : public ::testing::Test {
         signature_def.outputs().at(kRegressOutputs).name();
 
     std::vector<tstring> serialized_examples;
-    for (float x : {0, 1, 2, 3}) {
+    const std::initializer_list<float> xs = {0, 1, 2, 3};
+    serialized_examples.reserve(xs.size());
+    for (float x : xs) {
       serialized_examples.push_back(MakeSerializedExample(x));
     }
 


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)