### PR TITLE
[tensorflow/compiler/jit/deadness_analysis.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/jit/deadness_analysis.cc
+++ b/tensorflow/compiler/jit/deadness_analysis.cc
@@ -1550,6 +1550,7 @@ DeadnessAnalysisImpl::GetPredicateFor(Node* n, int oidx) const {
 
 void DeadnessAnalysisImpl::Print() const {
   std::vector<TensorId> tensor_ids;
+  tensor_ids.reserve(predicate_map_.size());
   for (const auto& kv_pair : predicate_map_) {
     tensor_ids.push_back(kv_pair.first);
   }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)