### PR TITLE
[tensorflow/compiler/jit/encapsulate_subgraphs_pass_test.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/jit/encapsulate_subgraphs_pass_test.cc
+++ b/tensorflow/compiler/jit/encapsulate_subgraphs_pass_test.cc
@@ -430,6 +430,7 @@ Node* SendFromHost(ops::NodeOut key_input, const string& cluster,
   node_builder.Input(inputs);
   node_builder.Input(std::move(key_input));
   std::vector<DataType> dtypes;
+  dtypes.reserve(inputs.size());
   for (const auto& node : inputs) {
     dtypes.push_back(node.dt);
   }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)