### PR TITLE
[tensorflow/compiler/jit/extract_outside_compilation_pass.cc] Fold two loops into one; add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/jit/extract_outside_compilation_pass.cc
+++ b/tensorflow/compiler/jit/extract_outside_compilation_pass.cc
@@ -1241,7 +1241,7 @@ Status RewriteShapeInferenceGraph(const string& shape_inference_graph_name,
     // This is an "top-level" outside compilation. Clear the graph, and copy
     // SendFromHost and all its predecessors from `host_graph`.
     std::vector<Node*> nodes;
-    nodes.reserve(g->num_op_nodes())
+    nodes.reserve(g->num_op_nodes());
     for (Node* n : g->op_nodes()) {
       nodes.push_back(n);
       g->RemoveNode(nodes.back());

--- a/tensorflow/compiler/jit/extract_outside_compilation_pass.cc
+++ b/tensorflow/compiler/jit/extract_outside_compilation_pass.cc
@@ -619,7 +619,7 @@ Status PostprocessLiftedArgsForWhile(
 
   // Add edges from outside compilation nodes to While node.
   std::vector<Node*> outside_compilation_nodes;
-  outside_compilation_attr_to_node.reserve(
+  outside_compilation_nodes.reserve(
           lifted_arg_nodes_and_outside_compilation_nodes.size()
   );
   std::transform(
@@ -1229,7 +1229,7 @@ Status RewriteShapeInferenceGraph(const string& shape_inference_graph_name,
   attrs["_device_ordinal"] = device_ordinal_attr;
   std::unique_ptr<FunctionBody> fbody;
   const FunctionDef* shape_inference_graph =
-          fld->Find(shape_inference_graph_name);
+      fld->Find(shape_inference_graph_name);
   TF_RET_CHECK(shape_inference_graph);
   TF_RETURN_IF_ERROR(FunctionDefToBodyHelper(*shape_inference_graph,
                                              AttrSlice(&attrs), fld, &fbody));
@@ -1334,9 +1334,9 @@ Status RewriteShapeInferenceGraph(const string& shape_inference_graph_name,
   // Replace original shape inference graph.
   FunctionDef fdef_replace;
   TF_RETURN_IF_ERROR(
-          GraphToFunctionDef(*g, shape_inference_graph_name, &fdef_replace));
+      GraphToFunctionDef(*g, shape_inference_graph_name, &fdef_replace));
   TF_RETURN_IF_ERROR(
-          fld->ReplaceFunction(shape_inference_graph_name, fdef_replace));
+      fld->ReplaceFunction(shape_inference_graph_name, fdef_replace));
 
   return Status::OK();
 }

--- a/tensorflow/compiler/jit/extract_outside_compilation_pass.cc
+++ b/tensorflow/compiler/jit/extract_outside_compilation_pass.cc
@@ -1241,9 +1241,8 @@ Status RewriteShapeInferenceGraph(const string& shape_inference_graph_name,
     // This is an "top-level" outside compilation. Clear the graph, and copy
     // SendFromHost and all its predecessors from `host_graph`.
     std::vector<Node*> nodes;
-    const auto op_nodes = g->op_nodes();
-    nodes.reserve(std::distance(op_nodes.begin(), op_nodes.end()));
-    for (Node* n : op_nodes) {
+    nodes.reserve(g->num_op_nodes())
+    for (Node* n : g->op_nodes()) {
       nodes.push_back(n);
       g->RemoveNode(nodes.back());
     }

--- a/tensorflow/compiler/jit/extract_outside_compilation_pass.cc
+++ b/tensorflow/compiler/jit/extract_outside_compilation_pass.cc
@@ -146,6 +146,7 @@ StatusOr<Node*> ReplaceArgNodesWithRecvAtHostNode(
     // Record out edges and remove `n` before adding those edges to RecvAtHost.
     // This is to avoid multiple producers.
     std::vector<OutEdgeInfo> out_edge_info;
+    out_edge_info.reserve(n->out_edges().size());
     for (auto edge : n->out_edges()) {
       out_edge_info.push_back(
           {edge->dst(), edge->src_output(), edge->dst_input()});
@@ -1240,11 +1241,11 @@ Status RewriteShapeInferenceGraph(const string& shape_inference_graph_name,
     // This is an "top-level" outside compilation. Clear the graph, and copy
     // SendFromHost and all its predecessors from `host_graph`.
     std::vector<Node*> nodes;
-    for (Node* n : g->op_nodes()) {
+    const auto op_nodes = g->op_nodes();
+    nodes.reserve(std::distance(op_nodes.begin(), op_nodes.end()));
+    for (Node* n : op_nodes) {
       nodes.push_back(n);
-    }
-    for (Node* n : nodes) {
-      g->RemoveNode(n);
+      g->RemoveNode(nodes.back());
     }
     Node* start_node = pivot_node ? pivot_node : host_graph->source_node();
     // Reverse DFS from send_from_host_main_graph, and stop at start_node.


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)