### PR TITLE
[tensorflow/compiler/jit/test_util.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/jit/test_util.cc
+++ b/tensorflow/compiler/jit/test_util.cc
@@ -28,6 +28,7 @@ Status ShapeAnnotationsMatch(
     TF_RET_CHECK(sit != shape_info.end())
         << "Missing shape information for node " << node->name();
     std::vector<PartialTensorShape> shapes;
+    shapes.reserve(sit->second.size());
     for (const auto& output : sit->second) shapes.push_back(output.shape);
 
     auto it = expected_shapes.find(node->name());


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)