### PR TITLE
[tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.cc
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.cc
@@ -1103,6 +1103,7 @@ class LowerBatchToSpaceND : public RewritePattern {
     //       batch / prod(block_shape),
     //       input_shape[1], ..., input_shape[N-1]]
     std::vector<int64_t> reshaped_shape;
+    reshaped_shape.reserve(block_shape.size());
     for (auto val : block_shape) {
       reshaped_shape.push_back(val.getSExtValue());
     }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)