### PR TITLE
[tensorflow/compiler/mlir/tensorflow/utils/convert_tensor.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/utils/convert_tensor.cc
+++ b/tensorflow/compiler/mlir/tensorflow/utils/convert_tensor.cc
@@ -229,7 +229,6 @@ StatusOr<ElementsAttr> ConvertTensorProto(const TensorProto& input_tensor,
                         ConvertTensorProto(tensor_copy, builder));
 
     llvm::SmallVector<int64_t> original_dimensions;
-    original_dimensions.reserve(input_tensor_shape.num_elements());
     for (auto dim : input_tensor_shape) original_dimensions.push_back(dim.size);
     return ElementsAttr(mlir::SplatElementsAttr::get(
         single_attr.getType().clone(original_dimensions),

--- a/tensorflow/compiler/mlir/tensorflow/utils/convert_tensor.cc
+++ b/tensorflow/compiler/mlir/tensorflow/utils/convert_tensor.cc
@@ -228,7 +228,7 @@ StatusOr<ElementsAttr> ConvertTensorProto(const TensorProto& input_tensor,
     TF_ASSIGN_OR_RETURN(ElementsAttr single_attr,
                         ConvertTensorProto(tensor_copy, builder));
 
-    std::vector<int64_t> original_dimensions;
+    llvm::SmallVector<int64_t> original_dimensions;
     original_dimensions.reserve(input_tensor_shape.num_elements());
     for (auto dim : input_tensor_shape) original_dimensions.push_back(dim.size);
     return ElementsAttr(mlir::SplatElementsAttr::get(

--- a/tensorflow/compiler/mlir/tensorflow/utils/convert_tensor.cc
+++ b/tensorflow/compiler/mlir/tensorflow/utils/convert_tensor.cc
@@ -229,6 +229,7 @@ StatusOr<ElementsAttr> ConvertTensorProto(const TensorProto& input_tensor,
                         ConvertTensorProto(tensor_copy, builder));
 
     std::vector<int64_t> original_dimensions;
+    original_dimensions.reserve(input_tensor_shape.num_elements());
     for (auto dim : input_tensor_shape) original_dimensions.push_back(dim.size);
     return ElementsAttr(mlir::SplatElementsAttr::get(
         single_attr.getType().clone(original_dimensions),


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)