### PR TITLE
[tensorflow/compiler/mlir/tfr/integration/tfr_decompose_ctx_test.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/mlir/tfr/integration/tfr_decompose_ctx_test.cc
+++ b/tensorflow/compiler/mlir/tfr/integration/tfr_decompose_ctx_test.cc
@@ -100,7 +100,9 @@ class TFRDecomposeContextTest : public Test {
 
 std::vector<NodeAndType> NodesSequenceOf(const FunctionDef& graph) {
   std::vector<NodeAndType> nodes;
-  for (auto& node : graph.node_def()) {
+  auto node_def = graph.node_def();
+  nodes.reserve(node_def.size());
+  for (auto& node : node_def) {
     nodes.push_back({node.op(), node.attr().at("T").type()});
   }
   return nodes;


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)