### PR TITLE
[tensorflow/compiler/mlir/xla/experimental/conv_emitter/conv_emitter.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/mlir/xla/experimental/conv_emitter/conv_emitter.cc
+++ b/tensorflow/compiler/mlir/xla/experimental/conv_emitter/conv_emitter.cc
@@ -151,6 +151,7 @@ mlir::Operation* HoistAndFix(llvm::iplist<mlir::Operation>::iterator begin_op,
   }
 
   std::vector<int64_t> ancestor_dimensions;
+  ancestor_dimensions.reserve(ancestors.size());
   for (auto ancestor : ancestors) {
     CHECK(IsSimpleLoop(ancestor));
     ancestor_dimensions.push_back(

--- a/tensorflow/compiler/mlir/xla/experimental/conv_emitter/conv_emitter.cc
+++ b/tensorflow/compiler/mlir/xla/experimental/conv_emitter/conv_emitter.cc
@@ -140,7 +140,7 @@ mlir::Operation* HoistAndFix(llvm::iplist<mlir::Operation>::iterator begin_op,
   llvm::SmallVector<mlir::AffineForOp> ancestors;
   getPerfectlyNestedLoops(ancestors, where);
   {
-    llvm::SmallVectorBase::Size i;
+    decltype(ancestors)::size_type i;
     for (i = 0; i < ancestors.size(); i++) {
       if (&ancestors[i].getBody()->front() == &*begin_op) {
         break;
@@ -208,7 +208,6 @@ mlir::Operation* HoistAndFix(llvm::iplist<mlir::Operation>::iterator begin_op,
   if (any_op_is_loop_variant) {
     auto builder = OpBuilder(where);
     llvm::SmallVector<mlir::AffineForOp> new_loops;
-    new_loops.reserve(ancestor_dimensions.size());
     for (auto dim : ancestor_dimensions) {
       auto where =
           builder.create<mlir::AffineForOp>(builder.getUnknownLoc(), 0, dim);
@@ -219,8 +218,8 @@ mlir::Operation* HoistAndFix(llvm::iplist<mlir::Operation>::iterator begin_op,
          llvm::make_early_inc_range(llvm::make_range(begin_op, end_op))) {
       op.moveBefore(&new_loops.back().getBody()->back());
     }
-    CHECK_EQ(ancestors_size, new_loops.size());
-    for (size_t i = 0; i < ancestors_size; i++) {
+    CHECK_EQ(ancestors.size(), new_loops.size());
+    for (decltype(ancestors)::size_type i = 0; i < ancestors.size(); i++) {
       replaceAllUsesInRegionWith(ancestors[i].getInductionVar(),
                                  new_loops[i].getInductionVar(),
                                  new_loops.back().region());

--- a/tensorflow/compiler/mlir/xla/experimental/conv_emitter/conv_emitter.cc
+++ b/tensorflow/compiler/mlir/xla/experimental/conv_emitter/conv_emitter.cc
@@ -151,7 +151,7 @@ mlir::Operation* HoistAndFix(llvm::iplist<mlir::Operation>::iterator begin_op,
     ancestors.resize(i + 1);
   }
 
-  llvm::SmallVector<int64_t, ancestors_size> ancestor_dimensions;
+  llvm::SmallVector<int64_t> ancestor_dimensions;
   for (auto ancestor : ancestors) {
     CHECK(IsSimpleLoop(ancestor));
     ancestor_dimensions.push_back(

--- a/tensorflow/compiler/mlir/xla/experimental/conv_emitter/conv_emitter.cc
+++ b/tensorflow/compiler/mlir/xla/experimental/conv_emitter/conv_emitter.cc
@@ -137,8 +137,7 @@ mlir::Operation* HoistAndFix(llvm::iplist<mlir::Operation>::iterator begin_op,
                              llvm::iplist<mlir::Operation>::iterator end_op,
                              mlir::AffineForOp where) {
   // All loops to hoist through.
-  constexpr size_t ancestors_size = 4;
-  llvm::SmallVector<mlir::AffineForOp, ancestors_size> ancestors;
+  llvm::SmallVector<mlir::AffineForOp> ancestors;
   getPerfectlyNestedLoops(ancestors, where);
   {
     llvm::SmallVectorBase::Size i;

--- a/tensorflow/compiler/mlir/xla/experimental/conv_emitter/conv_emitter.cc
+++ b/tensorflow/compiler/mlir/xla/experimental/conv_emitter/conv_emitter.cc
@@ -141,13 +141,13 @@ mlir::Operation* HoistAndFix(llvm::iplist<mlir::Operation>::iterator begin_op,
   llvm::SmallVector<mlir::AffineForOp, ancestors_size> ancestors;
   getPerfectlyNestedLoops(ancestors, where);
   {
-    size_t i;
-    for (i = 0; i < ancestors_size; i++) {
+    llvm::SmallVectorBase::Size i;
+    for (i = 0; i < ancestors.size(); i++) {
       if (&ancestors[i].getBody()->front() == &*begin_op) {
         break;
       }
     }
-    CHECK(i < ancestors_size);
+    CHECK(i < ancestors.size());
     ancestors.resize(i + 1);
   }
 


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)