### PR TITLE
[tensorflow/compiler/mlir/xla/transforms/adjust_layout.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/mlir/xla/transforms/adjust_layout.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/adjust_layout.cc
@@ -77,9 +77,8 @@ class AdjustLayout : public PassWrapper<AdjustLayout, FunctionPass> {
     auto i64_type = rewriter.getIntegerType(64);
     if (type.isa<TupleType>()) {
       auto tuple_type = type.dyn_cast<TupleType>();
-      std::vector<mlir::Attribute> v;
       auto types = tuple_type.getTypes();
-      v.reserve(types.size());
+      llvm::SmallVector<mlir::Attribute, types.size()> v;
       for (const mlir::Type &t : types) {
         auto layout = GetLayout(t, rewriter);
         if (failed(layout)) return failure();

--- a/tensorflow/compiler/mlir/xla/transforms/adjust_layout.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/adjust_layout.cc
@@ -78,7 +78,9 @@ class AdjustLayout : public PassWrapper<AdjustLayout, FunctionPass> {
     if (type.isa<TupleType>()) {
       auto tuple_type = type.dyn_cast<TupleType>();
       std::vector<mlir::Attribute> v;
-      for (const mlir::Type &t : tuple_type.getTypes()) {
+      auto types = tuple_type.getTypes();
+      v.reserve(types.size());
+      for (const mlir::Type &t : types) {
         auto layout = GetLayout(t, rewriter);
         if (failed(layout)) return failure();
         v.push_back(layout.getValue());

--- a/tensorflow/compiler/mlir/xla/transforms/adjust_layout.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/adjust_layout.cc
@@ -78,7 +78,8 @@ class AdjustLayout : public PassWrapper<AdjustLayout, FunctionPass> {
     if (type.isa<TupleType>()) {
       auto tuple_type = type.dyn_cast<TupleType>();
       auto types = tuple_type.getTypes();
-      llvm::SmallVector<mlir::Attribute, types.size()> v;
+      llvm::SmallVector<mlir::Attribute> v;
+      v.reserve(types.size());
       for (const mlir::Type &t : types) {
         auto layout = GetLayout(t, rewriter);
         if (failed(layout)) return failure();


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)