### PR TITLE
[tensorflow/compiler/mlir/xla/transforms/legalize_tf.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/mlir/xla/transforms/legalize_tf.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/legalize_tf.cc
@@ -5394,7 +5394,9 @@ class ConvertInfeedDequeueTupleOp
 
     // Emit get_tuple_element for each result.
     std::vector<Value> results;
-    for (auto idx_and_type : llvm::enumerate(result_types)) {
+    auto _result_types = llvm::enumerate(result_types);
+    results.reserve(std::distance(_result_types.begin(), _result_types.end()));
+    for (auto idx_and_type : _result_types) {
       auto tuple_element = rewriter.create<GetTupleElementOp>(
           op.getLoc(), idx_and_type.value(), data_tuple,
           rewriter.getI32IntegerAttr(idx_and_type.index()));

--- a/tensorflow/compiler/mlir/xla/transforms/legalize_tf.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/legalize_tf.cc
@@ -5393,10 +5393,8 @@ class ConvertInfeedDequeueTupleOp
         rewriter.getI32IntegerAttr(0));
 
     // Emit get_tuple_element for each result.
-    std::vector<Value> results;
-    auto _result_types = llvm::enumerate(result_types);
-    results.reserve(std::distance(_result_types.begin(), _result_types.end()));
-    for (auto idx_and_type : _result_types) {
+    llvm::SmallVector<Value, result_types.size()> results;
+    for (auto idx_and_type : llvm::enumerate(result_types)) {
       auto tuple_element = rewriter.create<GetTupleElementOp>(
           op.getLoc(), idx_and_type.value(), data_tuple,
           rewriter.getI32IntegerAttr(idx_and_type.index()));

--- a/tensorflow/compiler/mlir/xla/transforms/legalize_tf.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/legalize_tf.cc
@@ -5393,7 +5393,8 @@ class ConvertInfeedDequeueTupleOp
         rewriter.getI32IntegerAttr(0));
 
     // Emit get_tuple_element for each result.
-    llvm::SmallVector<Value, result_types.size()> results;
+    llvm::SmallVector<Value> results;
+    results.reserve(result_types.size());
     for (auto idx_and_type : llvm::enumerate(result_types)) {
       auto tuple_element = rewriter.create<GetTupleElementOp>(
           op.getLoc(), idx_and_type.value(), data_tuple,


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)