### PR TITLE
[tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -6502,6 +6502,7 @@ Status ConvertAddN(OpConverterParams* params) {
 
   // AddN doesn't support broadcast.
   std::vector<ITensorProxyPtr> tensor_inputs;
+  tensor_inputs.reserve(inputs.size());
   for (const auto& input : inputs) {
     if (input.is_tensor()) {
       tensor_inputs.push_back(input.tensor());


### PR DESCRIPTION
Add calls to reserve vector capacity before populating vector.

This is split from PR https://github.com/tensorflow/tensorflow/pull/51739.