### PR TITLE
[tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
@@ -374,7 +374,9 @@ Status TRTOptimizationPass::Optimize(grappler::Cluster* cluster,
   }
 
   std::vector<string> nodes_to_preserve;
-  for (const auto& n : item.NodesToPreserve()) {
+  auto _nodes_to_preserve = item.NodesToPreserve();
+  nodes_to_preserve.reserve(_nodes_to_preserve.size());
+  for (const auto& n : _nodes_to_preserve) {
     auto tokens = str_util::Split(n, ":");
     string s = tokens.at(0);
     for (int i = 1; i < tokens.size() - 1; ++i) {


### PR DESCRIPTION
Add calls to reserve vector capacity before populating vector.

This is split from PR https://github.com/tensorflow/tensorflow/pull/51739.