### PR TITLE
[tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
@@ -127,7 +127,7 @@ class InitializeTRTResource : public OpKernel {
       TRTEngineInstance engine_instance;
       engine_instance.ParseFromString(record);
       std::vector<TensorShape> engine_input_shapes;
-      auto input_shapes = engine_instance.input_shapes();
+      const auto& input_shapes = engine_instance.input_shapes();
       engine_input_shapes.reserve(input_shapes.size());
       for (const TensorShapeProto& shape : input_shapes) {
         engine_input_shapes.emplace_back(shape);

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
@@ -127,7 +127,9 @@ class InitializeTRTResource : public OpKernel {
       TRTEngineInstance engine_instance;
       engine_instance.ParseFromString(record);
       std::vector<TensorShape> engine_input_shapes;
-      for (const TensorShapeProto& shape : engine_instance.input_shapes()) {
+      auto input_shapes = engine_instance.input_shapes();
+      engine_input_shapes.reserve(input_shapes.size());
+      for (const TensorShapeProto& shape : input_shapes) {
         engine_input_shapes.emplace_back(shape);
       }
 


### PR DESCRIPTION
Add calls to reserve vector capacity before populating vector.

This is split from PR https://github.com/tensorflow/tensorflow/pull/51739.