### PR TITLE
[tensorflow/compiler/tf2xla/functionalize_while.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/tf2xla/functionalize_while.cc
+++ b/tensorflow/compiler/tf2xla/functionalize_while.cc
@@ -227,6 +227,7 @@ Status FunctionalizeLoop(Graph* graph, WhileLoopFrame* frame,
   // maintain the invariant of a unique Enter node per argument of the final
   // loop.
   std::vector<WhileLoopArg> args;
+  args.reserve(frame->args.size());
   for (const WhileLoopArg& arg : frame->args) {
     if (arg.is_loop_invariant) {
       args.push_back(arg);


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)