### PR TITLE
[tensorflow/compiler/tf2xla/kernels/cross_op.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/cross_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/cross_op.cc
@@ -49,6 +49,8 @@ class CrossOp : public XlaOpKernel {
 
     std::vector<int64_t> starts(in0_shape.dims(), 0);
     std::vector<int64_t> limits;
+    auto dim_sizes = in0_shape.dim_sizes();
+    limits.reserve(dim_sizes.size());
     for (auto dim_size : in0_shape.dim_sizes()) {
       limits.push_back(dim_size);
     }

--- a/tensorflow/compiler/tf2xla/kernels/cross_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/cross_op.cc
@@ -49,7 +49,7 @@ class CrossOp : public XlaOpKernel {
 
     std::vector<int64_t> starts(in0_shape.dims(), 0);
     std::vector<int64_t> limits;
-    auto dim_sizes = in0_shape.dim_sizes();
+    const auto& dim_sizes = in0_shape.dim_sizes();
     limits.reserve(dim_sizes.size());
     for (auto dim_size : in0_shape.dim_sizes()) {
       limits.push_back(dim_size);


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)