### PR TITLE
[tensorflow/compiler/tf2xla/kernels/resampler_ops.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/resampler_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/resampler_ops.cc
@@ -118,6 +118,7 @@ XlaOp ConcatenateIota(xla::XlaBuilder* b, XlaOp indices,
                       const TensorShape& warp_shape) {
   // We need to create an iota tensor with the same batch dimension.
   std::vector<int64_t> dimensions;
+  dimensions.reserve(warp_shape.size());
   for (auto dim : warp_shape) {
     dimensions.push_back(dim.size);
   }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)