### PR TITLE
[tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
@@ -112,7 +112,9 @@ class StridedSliceOp : public XlaOpKernel {
     xla::PaddingConfig padding_config;
     bool need_padding = false;
     std::vector<bool> result_dims_are_dynamic;
-    for (int64_t i = 0; i < input_shape.dims(); ++i) {
+    const auto dims = input_shape.dims();
+    result_dims_are_dynamic.reserve(dims);
+    for (int64_t i = 0; i < dims; ++i) {
       int64_t sparse_index = shape_spec.processing_to_sparse_mapping[i];
       bool shrink_axis_set = (1 << i) & shape_spec.shrink_axis_dense_mask;
       auto* dims = padding_config.add_dimensions();

--- a/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
@@ -112,7 +112,7 @@ class StridedSliceOp : public XlaOpKernel {
     xla::PaddingConfig padding_config;
     bool need_padding = false;
     std::vector<bool> result_dims_are_dynamic;
-    const auto dims = input_shape.dims();
+    const auto& dims = input_shape.dims();
     result_dims_are_dynamic.reserve(dims);
     for (int64_t i = 0; i < dims; ++i) {
       int64_t sparse_index = shape_spec.processing_to_sparse_mapping[i];


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)