### PR TITLE
[tensorflow/compiler/tf2xla/kernels/tensor_list_ops.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/tensor_list_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/tensor_list_ops.cc
@@ -318,7 +318,7 @@ class TensorListElementShapeOp : public XlaOpKernel {
         break;
       case DT_INT32: {
         std::vector<int32> size;
-        auto dimensions = list_shape.dimensions();
+        const auto& dimensions = list_shape.dimensions();
         size.reserve(dimensions.size());
         for (int64_t s : dimensions) {
           size.push_back(s);

--- a/tensorflow/compiler/tf2xla/kernels/tensor_list_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/tensor_list_ops.cc
@@ -318,7 +318,9 @@ class TensorListElementShapeOp : public XlaOpKernel {
         break;
       case DT_INT32: {
         std::vector<int32> size;
-        for (int64_t s : list_shape.dimensions()) {
+        auto dimensions = list_shape.dimensions();
+        size.reserve(dimensions.size());
+        for (int64_t s : dimensions) {
           size.push_back(s);
         }
         ctx->SetOutput(0, xla::ConstantR1<int32>(b, size));


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)