### PR TITLE
[tensorflow/compiler/tf2xla/tf2xla_supported_ops.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/tf2xla/tf2xla_supported_ops.cc
+++ b/tensorflow/compiler/tf2xla/tf2xla_supported_ops.cc
@@ -47,9 +47,12 @@ void PrintSupportedOps(const string& device, const string& regen_run) {
             << "-------- | ---------------" << std::endl;
   for (const KernelDef* kdef : kdefs) {
     std::vector<string> constraints;
+    constraints.reserve(kdef->constraint()->size());
     for (const KernelDef::AttrConstraint& constraint : kdef->constraint()) {
       std::vector<string> types;
-      for (int type : constraint.allowed_values().list().type()) {
+      auto allowed_values = constraint.allowed_values().list().type();
+      types.reserve(allowed_values.size());
+      for (int type : allowed_values) {
         types.push_back(DataTypeString(static_cast<DataType>(type)));
       }
       std::sort(types.begin(), types.end());

--- a/tensorflow/compiler/tf2xla/tf2xla_supported_ops.cc
+++ b/tensorflow/compiler/tf2xla/tf2xla_supported_ops.cc
@@ -50,7 +50,7 @@ void PrintSupportedOps(const string& device, const string& regen_run) {
     constraints.reserve(kdef->constraint()->size());
     for (const KernelDef::AttrConstraint& constraint : kdef->constraint()) {
       std::vector<string> types;
-      auto allowed_values = constraint.allowed_values().list().type();
+      const auto& allowed_values = constraint.allowed_values().list().type();
       types.reserve(allowed_values.size());
       for (int type : allowed_values) {
         types.push_back(DataTypeString(static_cast<DataType>(type)));


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)