### PR TITLE
[tensorflow/compiler/xla/client/client.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/client/client.cc
+++ b/tensorflow/compiler/xla/client/client.cc
@@ -380,7 +380,9 @@ StatusOr<std::vector<DeviceHandle>> Client::GetDeviceHandles(
   }
 
   std::vector<DeviceHandle> device_handles;
-  for (const DeviceHandle& device_handle : response.device_handles()) {
+  const auto _device_handles = response.device_handles();
+  device_handles.reserve(_device_handles.size());
+  for (const DeviceHandle& device_handle : _device_handles) {
     device_handles.push_back(device_handle);
   }
 

--- a/tensorflow/compiler/xla/client/client.cc
+++ b/tensorflow/compiler/xla/client/client.cc
@@ -380,9 +380,9 @@ StatusOr<std::vector<DeviceHandle>> Client::GetDeviceHandles(
   }
 
   std::vector<DeviceHandle> device_handles;
-  const auto _device_handles = response.device_handles();
-  device_handles.reserve(_device_handles.size());
-  for (const DeviceHandle& device_handle : _device_handles) {
+  const auto& response_device_handles = response.device_handles();
+  device_handles.reserve(response_device_handles.size());
+  for (const DeviceHandle& device_handle : response_device_handles) {
     device_handles.push_back(device_handle);
   }
 


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)