### PR TITLE
[tensorflow/compiler/xla/client/lib/approx_topk.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/client/lib/approx_topk.cc
+++ b/tensorflow/compiler/xla/client/lib/approx_topk.cc
@@ -194,6 +194,7 @@ XlaOp ApproxTopK(XlaBuilder* builder, absl::Span<const XlaOp> operands,
   }
 
   std::vector<XlaOp> partial_reduce_args;
+  partial_reduce_args.reserve(operands.size() + init_values.size());
   for (const auto& op : operands) {
     partial_reduce_args.push_back(op);
   }
@@ -204,6 +205,7 @@ XlaOp ApproxTopK(XlaBuilder* builder, absl::Span<const XlaOp> operands,
       CeilOfRatio<int64_t>(CeilOfRatio(n, tpu_tiling), (1 << log2_reduction)) *
       tpu_tiling;
   std::vector<Shape> approx_output_shapes;
+  approx_output_shapes.reserve(operands_shapes.size());
   for (auto op_shape : operands_shapes) {
     op_shape.mutable_dimensions()[reduction_dim] = output_reduction_size;
     approx_output_shapes.push_back(op_shape);


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)