### PR TITLE
[tensorflow/compiler/xla/client/lib/testing.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/client/lib/testing.cc
+++ b/tensorflow/compiler/xla/client/lib/testing.cc
@@ -53,7 +53,9 @@ XlaOp BuildFakeDataOpOnDevice(const Shape& shape, XlaBuilder* builder) {
         AsInt64Slice(shape.dimensions()));
   }
   std::vector<XlaOp> parts;
-  for (const Shape& s : shape.tuple_shapes()) {
+  const auto tuple_shapes = shape.tuple_shapes();
+  parts.reserve(tuple_shapes.size());
+  for (const Shape& s : tuple_shapes) {
     parts.push_back(BuildFakeDataOpOnDevice(s, builder));
   }
   return Tuple(builder, parts);

--- a/tensorflow/compiler/xla/client/lib/testing.cc
+++ b/tensorflow/compiler/xla/client/lib/testing.cc
@@ -53,7 +53,7 @@ XlaOp BuildFakeDataOpOnDevice(const Shape& shape, XlaBuilder* builder) {
         AsInt64Slice(shape.dimensions()));
   }
   std::vector<XlaOp> parts;
-  const auto tuple_shapes = shape.tuple_shapes();
+  const auto& tuple_shapes = shape.tuple_shapes();
   parts.reserve(tuple_shapes.size());
   for (const Shape& s : tuple_shapes) {
     parts.push_back(BuildFakeDataOpOnDevice(s, builder));


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)