### PR TITLE
[tensorflow/compiler/xla/client/xla_builder_test.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/client/xla_builder_test.cc
+++ b/tensorflow/compiler/xla/client/xla_builder_test.cc
@@ -561,7 +561,9 @@ TEST_F(XlaBuilderTest, BuildWithSpecificRootWithWrongBuilder) {
 
 TEST_F(XlaBuilderTest, ProtoMatches) {
   std::vector<XlaComputation> computations;
-  for (int i = 0; i < 2; ++i) {
+  const int n = 2;
+  computations.reserve(n);
+  for (int i = 0; i < n; ++i) {
     XlaBuilder b_call("the_only_to_apply");
     auto p0 = Parameter(&b_call, 0, ShapeUtil::MakeShape(F32, {}), "p0");
     auto p1 = Parameter(&b_call, 1, ShapeUtil::MakeShape(F32, {}), "p1");


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)