### PR TITLE
[tensorflow/compiler/xla/layout.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/layout.cc
+++ b/tensorflow/compiler/xla/layout.cc
@@ -31,7 +31,9 @@ TileProto Tile::ToProto() const {
 
 string Tile::ToString() const {
   std::vector<string> elements;
-  for (auto dim : dimensions()) {
+  auto dims = dimensions();
+  elements.reserve(dims.size());
+  for (auto dim : dims) {
     if (dim >= 0) {
       elements.push_back(std::to_string(dim));
     } else {

--- a/tensorflow/compiler/xla/layout.cc
+++ b/tensorflow/compiler/xla/layout.cc
@@ -31,7 +31,7 @@ TileProto Tile::ToProto() const {
 
 string Tile::ToString() const {
   std::vector<string> elements;
-  auto dims = dimensions();
+  const auto& dims = dimensions();
   elements.reserve(dims.size());
   for (auto dim : dims) {
     if (dim >= 0) {


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)