### PR TITLE
[tensorflow/compiler/xla/pjrt/utils.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/pjrt/utils.cc
+++ b/tensorflow/compiler/xla/pjrt/utils.cc
@@ -44,7 +44,8 @@ StatusOr<Shape> GetShardedShape(const Shape& shape,
           sharding.DebugString(), shape.ToString());
     }
     std::vector<Shape> sharded_subshapes;
-    for (int i = 0; i < shape.tuple_shapes_size(); ++i) {
+    const auto tuple_shapes_size = shape.tuple_shapes_size();
+    for (int i = 0; i < tuple_shapes_size; ++i) {
       TF_ASSIGN_OR_RETURN(
           Shape sharded_subshape,
           GetShardedShape(shape.tuple_shapes(i), sharding.tuple_shardings(i)));


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)