### PR TITLE
[tensorflow/compiler/xla/python/tpu_driver/recording_tpu_driver.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/python/tpu_driver/recording_tpu_driver.cc
+++ b/tensorflow/compiler/xla/python/tpu_driver/recording_tpu_driver.cc
@@ -209,6 +209,9 @@ class RecordingTpuDriver : public TpuDriver {
 
     std::vector<BufferHandle*> unwrapped_children;
     std::vector<int64_t> child_ids;
+    const auto children_size = children.size();
+    unwrapped_children.reserve(children_size);
+    child_ids.reserve(children_size);
     for (auto child : children) {
       BufferHandle* unwrapped_child =
           static_cast<const RecordingBufferHandle*>(child)->handle_.get();
@@ -420,6 +423,9 @@ class RecordingTpuDriver : public TpuDriver {
 
     std::vector<BufferHandle*> unwrapped_inputs;
     std::vector<int64_t> input_ids;
+    const auto inputs_size = inputs.size();
+    unwrapped_children.reserve(inputs_size);
+    child_ids.reserve(inputs_size);
     for (auto input : inputs) {
       BufferHandle* unwrapped_input =
           static_cast<const RecordingBufferHandle*>(input)->handle_.get();
@@ -430,6 +436,9 @@ class RecordingTpuDriver : public TpuDriver {
 
     std::vector<BufferHandle*> unwrapped_outputs;
     std::vector<int64_t> output_ids;
+    const auto output_size = outputs.size();
+    unwrapped_outputs.reserve(output_size);
+    output_ids.reserve(output_size);
     for (auto output : outputs) {
       BufferHandle* unwrapped_output =
           static_cast<const RecordingBufferHandle*>(output)->handle_.get();


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)