### PR TITLE
[tensorflow/compiler/xla/service/ar_crs_combiner.cc] Add calls to `reserve()` before populating vector

### DIFF
--- a/tensorflow/compiler/xla/service/ar_crs_combiner.cc
+++ b/tensorflow/compiler/xla/service/ar_crs_combiner.cc
@@ -288,7 +288,9 @@ absl::optional<std::vector<HloInstruction*>> ArCrsCombiner::GetAllTuples(
     }
     case HloOpcode::kConditional: {
       std::vector<HloInstruction*> result_tuples;
-      for (HloComputation* body : instruction->branch_computations()) {
+      auto branch_computations = instruction->branch_computations();
+      result_tuples.reserve(branch_computations.size());
+      for (HloComputation* body : branch_computations) {
         if (body->root_instruction()->opcode() != HloOpcode::kTuple) {
           return absl::nullopt;
         }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)