### PR TITLE
[tensorflow/compiler/xla/client/lib/comparators_test.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/client/lib/comparators_test.cc
+++ b/tensorflow/compiler/xla/client/lib/comparators_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/compiler/xla/client/lib/comparators.h"
 
+#include <cmath>
 #include <limits>
 #include <vector>
 
@@ -66,7 +67,7 @@ void BuildComparatorAndComparisons(ComparatorsTest* test,
 
   // Do pairwise comparisons.
   std::vector<XlaOp> all_comparisons;
-  all_comparisons.reserve(all_constants.size() * 2);
+  all_comparisons.reserve(std::pow(all_constants.size(), 2));
   for (const XlaOp& lhs_constant : all_constants) {
     for (const XlaOp& rhs_constant : all_constants) {
       all_comparisons.push_back(Broadcast(

--- a/tensorflow/compiler/xla/client/lib/comparators_test.cc
+++ b/tensorflow/compiler/xla/client/lib/comparators_test.cc
@@ -66,6 +66,7 @@ void BuildComparatorAndComparisons(ComparatorsTest* test,
 
   // Do pairwise comparisons.
   std::vector<XlaOp> all_comparisons;
+  all_comparisons.reserve(all_constants.size() * 2);
   for (const XlaOp& lhs_constant : all_constants) {
     for (const XlaOp& rhs_constant : all_constants) {
       all_comparisons.push_back(Broadcast(


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)