### PR TITLE
[tensorflow/compiler/xla/service/convolution_group_converter.cc] Add calls to `reserve()` before populating vectors

### DIFF
--- a/tensorflow/compiler/xla/service/convolution_group_converter.cc
+++ b/tensorflow/compiler/xla/service/convolution_group_converter.cc
@@ -114,6 +114,7 @@ Shape ExpandedFilterShape(const Shape& shape, int64_t group_count,
 // consists of 'group_size' times the value i.
 std::vector<int32> GetMaskIds(int64_t group_size, int64_t group_count) {
   std::vector<int32> values;
+  values.reserve(group_count * group_size);
   for (int i = 0; i < group_count; ++i) {
     for (int j = 0; j < group_size; ++j) {
       values.push_back(i);


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/51739#issuecomment-940389562 told me to split the larger PR into one PR per file; thus this (thanks `bash`, `git` and `gh`!)