### PR TITLE
Clear global state cached by backend module for moinitored session

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -321,6 +321,17 @@ def clear_session():
 keras_deps.register_clear_session_function(clear_session)
 
 
+def clear_specific_session(graph):
+  """Clear specific graph's global state.
+  """
+  global _GRAPH_LEARNING_PHASES  # pylint: disable=global-variable-not-assigned
+  global _GRAPH_VARIABLES  # pylint: disable=global-variable-not-assigned
+  global _GRAPH_TF_OPTIMIZERS  # pylint: disable=global-variable-not-assigned
+  _GRAPH_LEARNING_PHASES.pop(graph, None)
+  _GRAPH_VARIABLES.pop(graph, None)
+  _GRAPH_TF_OPTIMIZERS.pop(graph, None)
+
+
 @keras_export('keras.backend.manual_variable_initialization')
 @doc_controls.do_not_generate_docs
 def manual_variable_initialization(value):

--- a/tensorflow/python/training/monitored_session.py
+++ b/tensorflow/python/training/monitored_session.py
@@ -25,6 +25,7 @@ from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.distribute import distribute_coordinator_context
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
+from tensorflow.python.keras import backend
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import lookup_ops
@@ -928,7 +929,9 @@ class _MonitoredSession(object):
       try:
         if self._sess is None:
           raise RuntimeError('Session is already closed.')
+        graph = self.graph
         self._sess.close()
+        backend.clear_specific_session(graph)
       finally:
         self._sess = None
         self._coordinated_creator.tf_sess = None


### PR DESCRIPTION
Clear global state cached by backend module for moinitored session to avoid memory leak.

In TF 2.x, the graph created by monitored_session will be cached by backend.py even after monitored_session exit.

If not do clear, it would cause memeory leak, especially when using TF estimator.