### PR TITLE
Add GPU implementation for Range op

### DIFF
--- a/tensorflow/core/kernels/sequence_ops.cc
+++ b/tensorflow/core/kernels/sequence_ops.cc
@@ -129,8 +129,17 @@ TF_CALL_int64(REGISTER_CPU_KERNEL);
 
 TF_CALL_float(REGISTER_GPU_KERNEL);
 TF_CALL_double(REGISTER_GPU_KERNEL);
-TF_CALL_int32(REGISTER_GPU_KERNEL);
 TF_CALL_int64(REGISTER_GPU_KERNEL);
+
+// Special case to execute int32 on the host with host output.
+REGISTER_KERNEL_BUILDER(Name("Range")
+                            .Device(DEVICE_GPU)
+                            .HostMemory("start")
+                            .HostMemory("limit")
+                            .HostMemory("delta")
+                            .HostMemory("output")
+                            .TypeConstraint<int32_t>("Tidx"),
+                        RangeOp<CPUDevice, int32_t>);
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 

--- a/tensorflow/core/kernels/sequence_ops.cc
+++ b/tensorflow/core/kernels/sequence_ops.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 // See docs in ../ops/math_ops.cc.
 
+#include "tensorflow/core/kernels/sequence_ops.h"
+
 #include <cmath>
 
 #include "tensorflow/core/framework/op_kernel.h"
@@ -25,9 +27,27 @@ limitations under the License.
 
 namespace tensorflow {
 
-int32 GetValue(int32_t v) { return v; }
+using CPUDevice = Eigen::ThreadPoolDevice;
+using GPUDevice = Eigen::GpuDevice;
+
+namespace functor {
 
 template <typename T>
+struct RangeFunctor<CPUDevice, T> {
+  void operator()(OpKernelContext* context, int64_t size, T start, T delta,
+                  typename TTypes<T>::Flat output) const {
+    (void)context;
+    T val = start;
+    for (int64_t i = 0; i < size; ++i) {
+      output(i) = T(val);
+      val += delta;
+    }
+  }
+};
+
+}  // namespace functor
+
+template <typename Device, typename T>
 class RangeOp : public OpKernel {
  public:
   explicit RangeOp(OpKernelConstruction* context) : OpKernel(context) {}
@@ -82,27 +102,23 @@ class RangeOp : public OpKernel {
     OP_REQUIRES_OK(context, shape.AddDimWithStatus(size));
     Tensor* out = nullptr;
     OP_REQUIRES_OK(context, context->allocate_output(0, shape, &out));
+    if (size == 0) return;
     auto flat = out->flat<T>();
-    T val = start;
-    for (int64_t i = 0; i < size; ++i) {
-      flat(i) = T(val);
-      val += delta;
-    }
+    functor::RangeFunctor<Device, T>()(context, size, start, delta, flat);
   }
 };
 
-#define REGISTER_KERNEL(DEV, TYPE)                           \
+#define REGISTER_KERNEL(DEV, DEV_TYPE, TYPE)                 \
   REGISTER_KERNEL_BUILDER(Name("Range")                      \
                               .Device(DEV)                   \
                               .HostMemory("start")           \
                               .HostMemory("limit")           \
                               .HostMemory("delta")           \
-                              .HostMemory("output")          \
                               .TypeConstraint<TYPE>("Tidx"), \
-                          RangeOp<TYPE>);
+                          RangeOp<DEV_TYPE, TYPE>);
 
-#define REGISTER_CPU_KERNEL(T) REGISTER_KERNEL(DEVICE_CPU, T)
-#define REGISTER_GPU_KERNEL(T) REGISTER_KERNEL(DEVICE_GPU, T)
+#define REGISTER_CPU_KERNEL(T) REGISTER_KERNEL(DEVICE_CPU, CPUDevice, T)
+#define REGISTER_GPU_KERNEL(T) REGISTER_KERNEL(DEVICE_GPU, GPUDevice, T)
 
 TF_CALL_float(REGISTER_CPU_KERNEL);
 TF_CALL_double(REGISTER_CPU_KERNEL);

--- a/tensorflow/core/kernels/sequence_ops.h
+++ b/tensorflow/core/kernels/sequence_ops.h
@@ -1,0 +1,36 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_SEQUENCE_OPS_H_
+#define TENSORFLOW_CORE_KERNELS_SEQUENCE_OPS_H_
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/tensor_types.h"
+
+namespace tensorflow {
+
+namespace functor {
+
+template <typename Device, typename T>
+struct RangeFunctor {
+  void operator()(OpKernelContext* context, int64_t size, T start, T delta,
+                  typename TTypes<T>::Flat output) const;
+};
+
+}  // namespace functor
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_SEQUENCE_OPS_H_

--- a/tensorflow/core/kernels/sequence_ops_gpu.cu.cc
+++ b/tensorflow/core/kernels/sequence_ops_gpu.cu.cc
@@ -1,0 +1,69 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/kernels/sequence_ops.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
+
+namespace tensorflow {
+
+using GPUDevice = Eigen::GpuDevice;
+
+namespace {
+
+template <typename T>
+__global__ void RangeKernel(int64_t size, T start, T delta,
+                            T* __restrict__ output) {
+  for (int64_t i : GpuGridRangeX(size)) {
+    output[i] = start + static_cast<T>(i) * delta;
+  }
+}
+
+}  // namespace
+
+namespace functor {
+
+template <typename T>
+struct RangeFunctor<GPUDevice, T> {
+  void operator()(OpKernelContext* context, int64_t size, T start, T delta,
+                  typename TTypes<T>::Flat output) const {
+    const GPUDevice& device = context->eigen_gpu_device();
+    GpuLaunchConfig config = GetGpuLaunchConfig(
+        size, device, &RangeKernel<T>,
+        /*dynamic_shared_memory_size=*/0, /*block_size_limit=*/0);
+    OP_REQUIRES_OK(context,
+                   GpuLaunchKernel(RangeKernel<T>, config.block_count,
+                                   config.thread_per_block, 0, device.stream(),
+                                   size, start, delta, output.data()));
+  }
+};
+
+}  // namespace functor
+
+#define DEFINE_FUNCTOR(T) template struct functor::RangeFunctor<GPUDevice, T>;
+TF_CALL_float(DEFINE_FUNCTOR);
+TF_CALL_double(DEFINE_FUNCTOR);
+TF_CALL_int32(DEFINE_FUNCTOR);
+TF_CALL_int64(DEFINE_FUNCTOR);
+#undef DEFINE_FUNCTOR
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
- This op currently has a GPU kernel registered, but it computes and returns its output on the host, which can cause significant slowdowns due to H2D memcopies and slow CPU execution. I don't know if there is a special reason it's like this (hopefully not).
- This patch adds a proper GPU kernel that returns the output on the device.

cc @nluehr 