### PR TITLE
Improve the tf.repeat implementation

### DIFF
--- a/tensorflow/core/kernels/searchsorted_op.cc
+++ b/tensorflow/core/kernels/searchsorted_op.cc
@@ -22,7 +22,9 @@ limitations under the License.
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/lib/core/bits.h"
 #include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/threadpool.h"
 #include "tensorflow/core/platform/types.h"
 
 namespace tensorflow {
@@ -37,18 +39,24 @@ struct UpperBoundFunctor<CPUDevice, T, OutType> {
                         const typename TTypes<T, 1>::ConstTensor& values,
                         int batch_size, int num_inputs, int num_values,
                         typename TTypes<OutType, 1>::Tensor* output) {
-    // TODO(rmlarsen): add multithreading or interleaving.
-    for (int b = 0; b < batch_size; ++b) {
-      const T* sorted_inputs_ptr = sorted_inputs.data() + b * num_inputs;
-      OutType* output_ptr = output->data() + b * num_values;
-      for (int i = 0; i < num_values; ++i) {
-        output_ptr[i] =
-            std::upper_bound(sorted_inputs_ptr, sorted_inputs_ptr + num_inputs,
-                             values(i + b * num_values)) -
-            sorted_inputs_ptr;
+    auto work_fn = [&](int64_t first, int64_t last) {
+      for (int b = 0; b < batch_size; ++b) {
+        const T* sorted_inputs_ptr = sorted_inputs.data() + b * num_inputs;
+        OutType* output_ptr = output->data() + b * num_values;
+        for (int i = first; i < last; ++i) {
+          output_ptr[i] = std::upper_bound(sorted_inputs_ptr,
+                                           sorted_inputs_ptr + num_inputs,
+                                           values(i + b * num_values)) -
+                          sorted_inputs_ptr;
+        }
       }
-    }
-
+    };
+    auto worker_threads = *(context->device()->tensorflow_cpu_worker_threads());
+    thread::ThreadPool* thread_pool = worker_threads.workers;
+    const float kCostMultiplier = 1.f;  // Can be tuned to minimize overhead
+    int64_t cost_per_unit =
+        kCostMultiplier * batch_size * Log2Ceiling(num_inputs);
+    thread_pool->ParallelFor(num_values, cost_per_unit, work_fn);
     return Status::OK();
   }
 };
@@ -60,18 +68,24 @@ struct LowerBoundFunctor<CPUDevice, T, OutType> {
                         const typename TTypes<T, 1>::ConstTensor& values,
                         int batch_size, int num_inputs, int num_values,
                         typename TTypes<OutType, 1>::Tensor* output) {
-    // TODO(rmlarsen): add multithreading or interleaving.
-    for (int b = 0; b < batch_size; ++b) {
-      const T* sorted_inputs_ptr = sorted_inputs.data() + b * num_inputs;
-      OutType* output_ptr = output->data() + b * num_values;
-      for (int i = 0; i < num_values; ++i) {
-        output_ptr[i] =
-            std::lower_bound(sorted_inputs_ptr, sorted_inputs_ptr + num_inputs,
-                             values(i + b * num_values)) -
-            sorted_inputs_ptr;
+    auto work_fn = [&](int64_t first, int64_t last) {
+      for (int b = 0; b < batch_size; ++b) {
+        const T* sorted_inputs_ptr = sorted_inputs.data() + b * num_inputs;
+        OutType* output_ptr = output->data() + b * num_values;
+        for (int i = first; i < last; ++i) {
+          output_ptr[i] = std::lower_bound(sorted_inputs_ptr,
+                                           sorted_inputs_ptr + num_inputs,
+                                           values(i + b * num_values)) -
+                          sorted_inputs_ptr;
+        }
       }
-    }
-
+    };
+    auto worker_threads = *(context->device()->tensorflow_cpu_worker_threads());
+    thread::ThreadPool* thread_pool = worker_threads.workers;
+    const float kCostMultiplier = 1.f;  // Can be tuned to minimize overhead
+    int64_t cost_per_unit =
+        kCostMultiplier * batch_size * Log2Ceiling(num_inputs);
+    thread_pool->ParallelFor(num_values, cost_per_unit, work_fn);
     return Status::OK();
   }
 };

--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -2205,6 +2205,67 @@ class RepeatTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     self.assertAllEqual(v_tf_fn, v_np)
 
 
+class RepeatBenchmark(test_lib.Benchmark):
+  """Benchmark the repeat implementation."""
+
+  def run_and_time(self, op, iters=100, warmup_iters=10):
+    self.evaluate(variables.global_variables_initializer())
+    for _ in range(warmup_iters):
+      _ = self.evaluate(op)
+    t0 = time.time()
+    for _ in range(iters):
+      self.evaluate(op)
+    t1 = time.time()
+    self.report_benchmark(iters=iters, wall_time=(t1 - t0) / float(iters))
+
+  def make_variable(self, shape, dtype=dtypes.float32):
+    items = 1
+    for dim in shape:
+      items *= dim
+    var = variables.Variable(
+        array_ops.reshape(math_ops.linspace(1., float(items), items), shape),
+        dtype=dtype)
+    return var
+
+  def run_benchmark(self, shape, max_repeats, axis=None):
+    with session.Session():
+      var = self.make_variable(shape)
+      if axis is None:
+        axis_size = 1
+        for dim in shape:
+          axis_size *= dim
+      else:
+        axis_size = shape[axis]
+      repeats = constant_op.constant(
+          np.random.randint(max_repeats, size=[axis_size]),
+          dtype=dtypes.int64)
+      repeat_op = array_ops.repeat(var, repeats, axis=axis)
+      # Return a scalar to reduce the device-to-host memcopy overhead.
+      repeat_op = repeat_op[(0,) * len(shape)]
+      self.run_and_time(repeat_op)
+
+  def benchmark_repeat_few_1d(self):
+    self.run_benchmark(shape=[1024 * 1024], max_repeats=8, axis=0)
+
+  def benchmark_repeat_many_1d(self):
+    self.run_benchmark(shape=[8 * 1024], max_repeats=1024, axis=0)
+
+  def benchmark_repeat_few_2d_axis0(self):
+    self.run_benchmark(shape=[8, 128 * 1024], max_repeats=8, axis=0)
+
+  def benchmark_repeat_many_2d_axis0(self):
+    self.run_benchmark(shape=[8, 1024], max_repeats=1024, axis=0)
+
+  def benchmark_repeat_many_2d_axis0_big(self):
+    self.run_benchmark(shape=[1024, 32], max_repeats=1024, axis=0)
+
+  def benchmark_repeat_few_2d_axis1(self):
+    self.run_benchmark(shape=[8, 128 * 1024], max_repeats=8, axis=1)
+
+  def benchmark_repeat_many_2d_axis1(self):
+    self.run_benchmark(shape=[8, 1024], max_repeats=1024, axis=1)
+
+
 @test_util.run_all_in_graph_and_eager_modes
 class TileVariantTest(test_util.TensorFlowTestCase):
 


### PR DESCRIPTION
- Replaces the old implementation with a simpler algorithm that is significantly more memory and compute efficient.
- Fixes https://github.com/tensorflow/tensorflow/issues/50712
- **Requires https://github.com/tensorflow/tensorflow/pull/52543 to be merged first to avoid performance regression.**

cc @nluehr 