### PR TITLE
Update RELEASE.md with a note on modular file-system migration to tensorflow-io

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -111,6 +111,10 @@ This release contains contributions from many people at Google, as well as:
         selective op registration headers else execution would fail with
         unregistered kernels error.
 
+* Modular File System Migration:
+    *   Support for S3 and HDFS file systems has been migrated to a modular file systems
+        based approach and is now available in https://github.com/tensorflow/io. The tensorflow-io
+        python package should be installed for S3 and HDFS support with tensorflow.
 ## Known Caveats
 
 *<CAVEATS REGARDING THE RELEASE (BUT NOT BREAKING CHANGES).>


### PR DESCRIPTION
This PR updates `RELEASE.md` with a note on the modular-filesystems migration to `tensorflow-io`. This is a follow-up of https://github.com/tensorflow/tensorflow/commit/9fcaf0838677d1095a7573e36ebb4d17511af6ed as those changes were not reflected during the 2.6.0 release.

cc: @mihaimaruseac @yongtang 