### PR TITLE
r2.7 cherry-pick request: Update oneDNN to version 2.4.1

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -188,11 +188,11 @@ def _tf_repositories():
     tf_http_archive(
         name = "mkl_dnn_v1",
         build_file = "//third_party/mkl_dnn:mkldnn_v1.BUILD",
-        sha256 = "a19e5fcf04d6ff775cc5f9d9d0ef01e4c74e77519caf4077052f16f037eba6a6",
-        strip_prefix = "oneDNN-2.4-rc",
+        sha256 = "930a2327c4fe4018a604f67ca3c0ebea01436aad7ce1f4e01d088732bd19d16f",
+        strip_prefix = "oneDNN-2.4.1",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v2.4-rc.tar.gz",
-            "https://github.com/oneapi-src/oneDNN/archive/v2.4-rc.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v2.4.1.tar.gz",
+            "https://github.com/oneapi-src/oneDNN/archive/v2.4.1.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Update oneDNN to version 2.4.1 to fix XByak-induced crashes on non-Intel systems. Details here:

https://github.com/oneapi-src/oneDNN/commit/ad901e5489564d0035be0b4ec41f1cff4be96610

PiperOrigin-RevId: 403166809