### PR TITLE
[r2.7 cherry pick] Update RELEASE.md with a note on modular file-system migration to tensorflow-io

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,8 +25,8 @@
     *   Renaming of tensorflow::int64 to int_64_t in numerous places (the former is an alias for the latter) which could result in needing to regenerate selective op registration headers else execution would fail with unregistered kernels error.
 
 * Modular File System Migration:
-    *   Support for S3 and HDFS file systems has been migrated to a modular file systems based approach and is now available in https://github.com/tensorflow/io. The tensorflow-io
-        python package should be installed for S3 and HDFS support with tensorflow.
+    *   Support for S3 and HDFS file systems has been migrated to a modular file systems based approach and is now available in https://github.com/tensorflow/io. The `tensorflow-io` python package should be installed for S3 and HDFS support with tensorflow.
+
 ## Major Features and Improvements
 
 * Improvements to the TensorFlow debugging experience:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,6 +24,9 @@
         * `tf.sparse_segment_sum_grad` (accidentally introduced in TensorFlow 2.6): Use `tf.raw_ops.SparseSegmentSumGrad` instead. Directly calling this op is typically not necessary, as it is automatically used when computing the gradient of `tf.sparse.segment_sum`.
     *   Renaming of tensorflow::int64 to int_64_t in numerous places (the former is an alias for the latter) which could result in needing to regenerate selective op registration headers else execution would fail with unregistered kernels error.
 
+* Modular File System Migration:
+    *   Support for S3 and HDFS file systems has been migrated to a modular file systems based approach and is now available in https://github.com/tensorflow/io. The tensorflow-io
+        python package should be installed for S3 and HDFS support with tensorflow.
 ## Major Features and Improvements
 
 * Improvements to the TensorFlow debugging experience:


### PR DESCRIPTION
This PR updates `RELEASE.md` with a note on the modular-filesystems migration to `tensorflow-io`. This is a follow-up of https://github.com/tensorflow/tensorflow/commit/9fcaf0838677d1095a7573e36ebb4d17511af6ed as those changes were not reflected during the 2.6.0 release.

cc: @mihaimaruseac @yongtang 