### PR TITLE
[TF-TRT] TrtGraphConverterV2 - Deprecating `conversion_params` in favor of direct arguments

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,11 @@
   * Where operation support is added for these data types
     'int32/uint32/int8/uint8/int64'
   * Add builtin support for `Bucketize` op on CPU.
+* `tensorflow.experimental.tensorrt`:
+  * `conversion_params` is now deprecated inside `TrtGraphConverterV2` in favor
+    of direct arguments: `max_workspace_size_bytes`, `precision_mode`, 
+    `minimum_segment_size`, `maximum_cached_engines`, `use_calibration` and
+    `allow_build_at_runtime`.
 
 *<INSERT MAJOR FEATURE HERE, USING MARKDOWN SYNTAX>
 *<IF RELEASE CONTAINS MULTIPLE FEATURES FROM SAME AREA, GROUP THEM TOGETHER>

--- a/tensorflow/python/compiler/tensorrt/model_tests/model_handler.py
+++ b/tensorflow/python/compiler/tensorrt/model_tests/model_handler.py
@@ -509,7 +509,7 @@ class TrtModelHandlerV2(_TrtModelHandlerBase, ModelHandlerV2):
         input_saved_model_tags=self.model_config.saved_model_tags,
         input_saved_model_signature_key=(
             self.model_config.saved_model_signature_key),
-        conversion_params=trt_convert_params)
+        **trt_convert_params._asdict())
 
   def _check_conversion(self, graph_func):
     graph_def = graph_func.graph.as_graph_def()

--- a/tensorflow/python/compiler/tensorrt/test/quantization_mnist_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/quantization_mnist_test.py
@@ -346,9 +346,9 @@ class MNISTTestV2(QuantizationAwareTrainingMNISTTest):
             maximum_cached_engines=1)
         converter = trt_convert.TrtGraphConverterV2(
             input_saved_model_dir=saved_model_dir,
-            conversion_params=conv_params,
             use_dynamic_shape=use_dynamic_shape,
-            dynamic_shape_profile_strategy='ImplicitBatchModeCompatible')
+            dynamic_shape_profile_strategy='ImplicitBatchModeCompatible',
+            **conv_params._asdict())
         converter.convert()
         func = converter._converted_func
       else:

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -448,9 +448,9 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
     if run_params.is_v2:
       converter_v2 = trt_convert.TrtGraphConverterV2(
           input_saved_model_dir=saved_model_dir,
-          conversion_params=conversion_params,
           use_dynamic_shape=run_params.dynamic_shape,
-          dynamic_shape_profile_strategy=self._profile_strategy)
+          dynamic_shape_profile_strategy=self._profile_strategy,
+          **conversion_params._asdict())
       if self._disable_non_trt_optimizers:
         converter_v2._test_only_disable_non_trt_optimizers = True  # pylint: disable=protected-access
       return converter_v2

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -133,19 +133,18 @@ class TrtConversionParams(
   """Parameters that are used for TF-TRT conversion.
 
   Fields:
-    max_workspace_size_bytes: the maximum GPU temporary memory which the TRT
+    max_workspace_size_bytes: the maximum GPU temporary memory that the TRT
       engine can use at execution time. This corresponds to the
       'workspaceSize' parameter of nvinfer1::IBuilder::setMaxWorkspaceSize().
-    precision_mode: one the strings in
+    precision_mode: one of the strings in
       TrtPrecisionMode.supported_precision_modes().
     minimum_segment_size: the minimum number of nodes required for a subgraph
       to be replaced by TRTEngineOp.
     maximum_cached_engines: max number of cached TRT engines for dynamic TRT
-      ops. Created TRT engines for a dynamic dimension are cached. This is the
-      maximum number of engines that can be cached. If the number of cached
-      engines is already at max but none of them supports the input shapes,
-      the TRTEngineOp will fall back to run the original TF subgraph that
-      corresponds to the TRTEngineOp.
+      ops. Created TRT engines for a dynamic dimension are cached. If the
+      number of cached engines is already at max but none of them supports the
+      input shapes, the TRTEngineOp will fall back to run the original TF
+      subgraph that corresponds to the TRTEngineOp.
     use_calibration: this argument is ignored if precision_mode is not INT8.
       If set to True, a calibration graph will be created to calibrate the
       missing ranges. The calibration graph must be converted to an inference
@@ -155,10 +154,10 @@ class TrtConversionParams(
       will occur. Please note that accuracy may be negatively affected if
       there is a mismatch between which tensors TRT quantizes and which
       tensors were trained with fake quantization.
-    allow_build_at_runtime: whether to build TensorRT engines during runtime.
-      If no TensorRT engine can be found in cache that can handle the given
-      inputs during runtime, then a new TensorRT engine is built at runtime if
-      allow_build_at_runtime=True, and otherwise native TF is used.
+    allow_build_at_runtime: whether to allow building TensorRT engines during
+      runtime if no prebuilt TensorRT engine can be found that can handle the
+      given inputs during runtime, then a new TensorRT engine is built at
+      runtime if allow_build_at_runtime=True, and otherwise native TF is used.
   """
 
   def __new__(cls,
@@ -973,12 +972,21 @@ class TrtGraphConverterV2(object):
           ("profile_strategy '{}' is not supported. It should be one of {}"
           ).format(strategy, supported_profile_strategies()))
 
+  @deprecation.deprecated_args(None,
+                               "Use individual converter parameters instead",
+                               "conversion_params")
   def __init__(self,
                input_saved_model_dir=None,
                input_saved_model_tags=None,
                input_saved_model_signature_key=None,
                use_dynamic_shape=None,
                dynamic_shape_profile_strategy=None,
+               max_workspace_size_bytes=DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES,
+               precision_mode=TrtPrecisionMode.FP32,
+               minimum_segment_size=3,
+               maximum_cached_engines=1,
+               use_calibration=True,
+               allow_build_at_runtime=True,
                conversion_params=None):
     """Initialize the converter.
 
@@ -993,14 +1001,46 @@ class TrtGraphConverterV2(object):
       dynamic_shape_profile_strategy: one of the strings in
         supported_profile_strategies(). None is equivalent to Range in the
         current implementation.
-      conversion_params: a TrtConversionParams instance.
+      max_workspace_size_bytes: the maximum GPU temporary memory that the TRT
+        engine can use at execution time. This corresponds to the
+        'workspaceSize' parameter of nvinfer1::IBuilder::setMaxWorkspaceSize().
+      precision_mode: one of the strings in
+        TrtPrecisionMode.supported_precision_modes().
+      minimum_segment_size: the minimum number of nodes required for a subgraph
+        to be replaced by TRTEngineOp.
+      maximum_cached_engines: max number of cached TRT engines for dynamic TRT
+        ops. Created TRT engines for a dynamic dimension are cached. If the
+        number of cached engines is already at max but none of them supports the
+        input shapes, the TRTEngineOp will fall back to run the original TF
+        subgraph that corresponds to the TRTEngineOp.
+      use_calibration: this argument is ignored if precision_mode is not INT8.
+        If set to True, a calibration graph will be created to calibrate the
+        missing ranges. The calibration graph must be converted to an inference
+        graph by running calibration with calibrate(). If set to False,
+        quantization nodes will be expected for every tensor in the graph
+        (excluding those which will be fused). If a range is missing, an error
+        will occur. Please note that accuracy may be negatively affected if
+        there is a mismatch between which tensors TRT quantizes and which
+        tensors were trained with fake quantization.
+      allow_build_at_runtime: whether to allow building TensorRT engines during
+        runtime if no prebuilt TensorRT engine can be found that can handle the
+        given inputs during runtime, then a new TensorRT engine is built at
+        runtime if allow_build_at_runtime=True, and otherwise native TF is used.
+      conversion_params: a TrtConversionParams instance (deprecated).
 
     Raises:
       ValueError: if the combination of the parameters is invalid.
     """
     assert context.executing_eagerly()
     if conversion_params is None:
-      conversion_params = TrtConversionParams()
+      conversion_params = TrtConversionParams(
+        max_workspace_size_bytes=max_workspace_size_bytes,
+        precision_mode=precision_mode,
+        minimum_segment_size=minimum_segment_size,
+        maximum_cached_engines=maximum_cached_engines,
+        use_calibration=use_calibration,
+        allow_build_at_runtime=allow_build_at_runtime
+      )
 
     _check_trt_version_compatibility()
     _check_conversion_params(conversion_params, is_v2=True)

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -379,11 +379,10 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     return trt_convert.TrtGraphConverterV2(
         input_saved_model_dir=input_saved_model_dir,
         input_saved_model_signature_key=input_saved_model_signature_key,
-        conversion_params=trt_convert.DEFAULT_TRT_CONVERSION_PARAMS._replace(
-            max_workspace_size_bytes=max_workspace_size_bytes,
-            precision_mode=precision_mode,
-            maximum_cached_engines=maximum_cached_engines,
-            allow_build_at_runtime=allow_build_at_runtime))
+        max_workspace_size_bytes=max_workspace_size_bytes,
+        precision_mode=precision_mode,
+        maximum_cached_engines=maximum_cached_engines,
+        allow_build_at_runtime=allow_build_at_runtime)
 
   def _CheckTrtOps(self, concrete_func, check_fn=None, num_engines=1):
     graph_def = concrete_func.graph.as_graph_def()
@@ -518,8 +517,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     conv_params = trt_convert.TrtConversionParams(minimum_segment_size=2)
     converter = trt_convert.TrtGraphConverterV2(
         input_saved_model_dir=input_saved_model_dir,
-        conversion_params=conv_params,
-        use_dynamic_shape=True)
+        use_dynamic_shape=True,
+        **conv_params._asdict())
     converter.convert()
 
     # Build the graph with the input generator. This runs the TRTEngineOp native

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -798,7 +798,7 @@ def convert_with_tensorrt(args):
     converter = trt.TrtGraphConverterV2(
         input_saved_model_dir=args.dir,
         input_saved_model_tags=args.tag_set.split(','),
-        conversion_params=params)
+        **params._asdict())
     try:
       converter.convert()
     except Exception as e:

--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
@@ -4,7 +4,7 @@ tf_class {
   is_instance: "<type \'object\'>"
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'input_saved_model_dir\', \'input_saved_model_tags\', \'input_saved_model_signature_key\', \'use_dynamic_shape\', \'dynamic_shape_profile_strategy\', \'conversion_params\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\', \'None\', \'None\'], "
+    argspec: "args=[\'self\', \'input_saved_model_dir\', \'input_saved_model_tags\', \'input_saved_model_signature_key\', \'use_dynamic_shape\', \'dynamic_shape_profile_strategy\', \'max_workspace_size_bytes\', \'precision_mode\', \'minimum_segment_size\', \'maximum_cached_engines\', \'use_calibration\', \'allow_build_at_runtime\', \'conversion_params\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\', \'None\', \'1073741824\', \'FP32\', \'3\', \'1\', \'True\', \'True\', \'None\'], "
   }
   member_method {
     name: "build"


### PR DESCRIPTION
@bixia1 @tfeher for review

This PR essentially deprecates: `TrtGraphConverterV2(conversion_params=params)` in favor of direct arguments like `TrtGraphConverterV2(precision_mode=TrtPrecisionMode.FP32,)`.

Essentially this object `TrtConversionParams` was inherited from C++ and just complicates the API for no good reason.

Shall be removed. The change was made in a way that is backward compatible and shall not break any user code.