### PR TITLE
[NNAPI]Fix error in axis of reduce_mean.

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -5445,7 +5445,8 @@ TfLiteStatus NNAPIDelegateKernel::AddOpsAndTensors(
                   reg->builtin_code == kTfLiteBuiltinReduceMax ||
                   reg->builtin_code == kTfLiteBuiltinReduceMin ||
                   reg->builtin_code == kTfLiteBuiltinReduceProd ||
-                  reg->builtin_code == kTfLiteBuiltinSum) &&
+                  reg->builtin_code == kTfLiteBuiltinSum ||
+                  reg->builtin_code == kTfLiteBuiltinMean) &&
                  (input_pos == 1)) {
         // The axis needs, be converted to a tensor if specified as scalar
         const TfLiteTensor& axis_tensor =


### PR DESCRIPTION
1. create TensorFlow model.
```python
tf.reduce_mean(x, 0)
```
1. convert to TensorFlow lite model.
1. execute in NNAPI delegate.
1. error occurred.
   `E/tflite: NN API returned error ANEURALNETWORKS_BAD_DATA at line 1465 while setting new operand value from memory for tensor XXX.`