### PR TITLE
r2.7 cherry-pick request: Fixing Mac build issue

### DIFF
--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -1189,12 +1189,14 @@ Status EagerLocalExecute(EagerOperation* op, TensorHandle** retvals,
   core::RefCountPtr<KernelAndDevice> kernel;
   auto status = GetOrCreateKernelAndDevice(op, retvals, num_retvals, &kernel);
 
+#ifdef INTEL_MKL
   if (IsMKLEnabled() && kernel != nullptr && !ctx.RunEagerOpAsFunction() &&
       op->Device() == kVariantDeviceNull) {
     // oneDNN optimization pass relies on the op's assigned device to determine
     // whether it can be rewritten.
     op->SetDevice(kernel->device());
   }
+#endif  // INTEL_MKL
 
   // Run all the registered rewrite pass after the placement, regardless whether
   // the placement is successful or not. The passes can either create new ops


### PR DESCRIPTION
Fix a Mac build issue that was caused by https://github.com/tensorflow/tensorflow/pull/52326.
Error message:
```
tensorflow/core/common_runtime/eager/execute.cc:1192:7: error: use of undeclared identifier 'IsMKLEnabled'; did you mean 'IsMklEnabled'?
  if (IsMKLEnabled() && kernel != nullptr && !ctx.RunEagerOpAsFunction() &&
      ^~~~~~~~~~~~
      IsMklEnabled
./tensorflow/core/util/port.h:45:6: note: 'IsMklEnabled' declared here
bool IsMklEnabled();
     ^
```

Original fix PR (merged into master): https://github.com/tensorflow/tensorflow/pull/52551