### PR TITLE
[NNAPI]call memcpy() with null pointer dereference.

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -4665,7 +4665,7 @@ TfLiteStatus NNAPIDelegateKernel::Invoke(TfLiteContext* context,
               "associating NNAPI execution input with a memory object", tensor,
               nnapi_errno);
         }
-      } else if (nn_input_memory_->get_byte_size() > 0) {
+      } else if (operand_mapping_.lite_index_to_ann(absolute_input_index) != -1) {
         // copy data to pre-allocated shared memory.
         memcpy(nn_input_memory_->get_data_ptr() + input_offset,
                tensor->data.raw, tensor->bytes);

--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -4665,7 +4665,7 @@ TfLiteStatus NNAPIDelegateKernel::Invoke(TfLiteContext* context,
               "associating NNAPI execution input with a memory object", tensor,
               nnapi_errno);
         }
-      } else {
+      } else if (nn_input_memory_->get_byte_size() > 0) {
         // copy data to pre-allocated shared memory.
         memcpy(nn_input_memory_->get_data_ptr() + input_offset,
                tensor->data.raw, tensor->bytes);


### PR DESCRIPTION
1. create `initialize.tflite` with [model_personalization](https://github.com/tensorflow/examples/tree/master/lite/examples/model_personalization) `tflite-transfer-convert`.
1. execute delegate with the following option.
   ```cpp
   tflite::StatefulNnApiDelegate::Options options;
   options.accelerator_name = "nnapi-reference"; // use CPU
   auto delegate = new tflite::StatefulNnApiDelegate(options);
   ```
1. fatal error has occurred.
   ```txt
   signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
   Cause: null pointer dereference
   ```
1. `nn_input_memory_->get_data_ptr()` returns `nullptr`.
   - [total_input_byte_size](https://github.com/tensorflow/tensorflow/blob/e042c277ab6375bf4060e099dd20a101cc0685e0/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc#L5700-L5701) == 0