### PR TITLE
[TF:TRT] Move definition of TrtPrecisionMode and ProfileStrategy to a separate header

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -93,6 +93,7 @@ cc_library(
     ],
     copts = tf_copts(),
     deps = [
+        ":trt_parameters",
         ":trt_resources",
         "@com_google_absl//absl/strings",
         "//tensorflow/core:direct_session",
@@ -358,6 +359,7 @@ tf_cuda_library(
         ":trt_logging",
         ":utils",
         ":trt_allocator",
+        ":trt_parameters",
         "@com_google_absl//absl/strings",
         "//tensorflow/core:framework",
         "//tensorflow/core:framework_headers_lib",
@@ -398,6 +400,21 @@ tf_custom_op_py_library(
         "//tensorflow/python:platform",
         "//tensorflow/python:resources",
     ],
+)
+
+tf_cuda_library(
+    name = "trt_parameters",
+    srcs = ["convert/trt_parameters.cc"],
+    hdrs = [
+        "convert/trt_parameters.h",
+    ],
+    copts = tf_copts(),
+    deps = [
+        ":utils",
+        "@com_google_absl//absl/strings",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:framework",
+    ] + if_tensorrt([":tensorrt_lib"]),
 )
 
 tf_cuda_library(
@@ -518,6 +535,7 @@ tf_cuda_library(
         "convert/op_converter.h",
     ],
     deps = [
+        ":trt_parameters",
         ":trt_weights",
     ] + if_tensorrt([":tensorrt_lib"]),
 )
@@ -573,6 +591,7 @@ tf_cuda_library(
         ":logger_registry",
         ":segment",
         ":trt_allocator",
+        ":trt_parameters",
         ":trt_plugins",
         ":trt_logging",
         ":trt_resources",

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/strings/str_format.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/trt_parameters.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/weights.h"
 #include "third_party/tensorrt/NvInfer.h"
 

--- a/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <string>
 
+#include "tensorflow/compiler/tf2tensorrt/convert/trt_parameters.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/core/framework/graph.pb.h"
 #include "tensorflow/core/grappler/optimizers/custom_graph_optimizer.h"

--- a/tensorflow/compiler/tf2tensorrt/convert/trt_parameters.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_parameters.cc
@@ -1,0 +1,104 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/tf2tensorrt/convert/trt_parameters.h"
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include <algorithm>
+#include <cctype>
+
+#include "absl/strings/str_cat.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/errors.h"
+
+namespace tensorflow {
+namespace tensorrt {
+
+Status TrtPrecisionModeToName(const TrtPrecisionMode mode, string* name) {
+  const char* kUnknown = "UNKNOWN";
+  *name = *kUnknown;
+  switch (mode) {
+    case TrtPrecisionMode::FP32:
+      *name = "FP32";
+      break;
+    case TrtPrecisionMode::FP16:
+      *name = "FP16";
+      break;
+    case TrtPrecisionMode::INT8:
+      *name = "INT8";
+      break;
+  }
+  if (name->compare(kUnknown) == 0)
+    return errors::OutOfRange("Unknown precision mode");
+  return Status::OK();
+}
+
+Status TrtPrecisionModeFromName(const string& name, TrtPrecisionMode* mode) {
+  if (name == "FP32") {
+    *mode = TrtPrecisionMode::FP32;
+  } else if (name == "FP16") {
+    *mode = TrtPrecisionMode::FP16;
+  } else if (name == "INT8") {
+    *mode = TrtPrecisionMode::INT8;
+  } else {
+    return errors::InvalidArgument("Invalid precision mode name: ", name);
+  }
+  return Status::OK();
+}
+
+string DebugString(const TrtPrecisionMode mode) {
+  string mode_str;
+  TF_CHECK_OK(TrtPrecisionModeToName(mode, &mode_str));
+  return absl::StrCat("TrtPrecisionMode::", mode_str);
+}
+
+string ProfileStrategyToName(const ProfileStrategy strategy) {
+  switch (strategy) {
+    case ProfileStrategy::kRange:
+      return "Range";
+    case ProfileStrategy::kOptimal:
+      return "Optimal";
+    case ProfileStrategy::kRangeOptimal:
+      return "Range+Optimal";
+    case ProfileStrategy::kImplicitBatchModeCompatible:
+      return "ImplicitBatchModeCompatible";
+  }
+  return "Unknown";
+}
+
+Status ProfileStrategyFromName(const string& name, ProfileStrategy* strategy) {
+  string name_lowercase(name);
+  std::transform(name.begin(), name.end(), name_lowercase.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  if (name_lowercase == "range") {
+    *strategy = ProfileStrategy::kRange;
+  } else if (name_lowercase == "optimal") {
+    *strategy = ProfileStrategy::kOptimal;
+  } else if (name_lowercase == "range+optimal") {
+    *strategy = ProfileStrategy::kRangeOptimal;
+  } else if (name_lowercase == "implicitbatchmodecompatible") {
+    *strategy = ProfileStrategy::kImplicitBatchModeCompatible;
+  } else {
+    return errors::InvalidArgument("Invalid profile strategy: ", name);
+  }
+  return Status::OK();
+}
+
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/trt_parameters.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_parameters.h
@@ -1,0 +1,72 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_TRT_PARAMETERS_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_TRT_PARAMETERS_H_
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include "tensorflow/core/platform/status.h"
+
+namespace tensorflow {
+namespace tensorrt {
+
+// The PrecisionMode controls the precision used in TRT converted parts of the
+// model. Setting PrecisionMode other than FP32 enables TensorRT to select
+// lower-precision implementations when searching for the fastest kernels.
+//
+// For regularized models whose input dynamic range is approximately one, this
+// typically produces significant speedups with negligible change in accuracy.
+// There is additional complexity when working with INT8, see Calibration.
+//
+// - FP32
+// - FP16 Enable FP16 layer selection, with FP32 fallback.
+// - INT8 Enable Int8 layer selection, with FP32 and FP16 fallback.
+//
+// Note that TensorRT will still choose a higher-precision kernel if it results
+// in overall lower runtime, or if no low-precision implementation exists.
+enum class TrtPrecisionMode { FP32, FP16, INT8 };
+
+Status TrtPrecisionModeToName(const TrtPrecisionMode mode, string* name);
+
+Status TrtPrecisionModeFromName(const string& name, TrtPrecisionMode* mode);
+
+string DebugString(const TrtPrecisionMode mode);
+
+// Optimization profile generation strategies.
+// - `kRange`: create one profile that works for inputs with dimension values
+//   in the range of [min_dims, max_dims] where min_dims and max_dims are
+//   derived from the provided inputs.
+// - `kOptimal`: create one profile for each input. The profile only works for
+//   inputs with the same dimensions as the input it is created for. The GPU
+//   engine will be run with optimal performance with such inputs.
+// - `kRangeOptimal`: create the profiles for both `Range` and `Optimal`.
+// - `kImplicitBatchModeCompatible`: create the profiles that will produce the
+//   same GPU engines as the implicit_batch_mode would produce.
+enum class ProfileStrategy {
+  kRange,
+  kOptimal,
+  kRangeOptimal,
+  kImplicitBatchModeCompatible,
+};
+
+string ProfileStrategyToName(const ProfileStrategy strategy);
+Status ProfileStrategyFromName(const string& name, ProfileStrategy* strategy);
+
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_TRT_PARAMETERS_H_

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -25,37 +25,6 @@ limitations under the License.
 namespace tensorflow {
 namespace tensorrt {
 
-Status TrtPrecisionModeToName(const TrtPrecisionMode mode, string* name) {
-  switch (mode) {
-    case TrtPrecisionMode::FP32:
-      *name = "FP32";
-      break;
-    case TrtPrecisionMode::FP16:
-      *name = "FP16";
-      break;
-    case TrtPrecisionMode::INT8:
-      *name = "INT8";
-      break;
-    default:
-      *name = "UNKNOWN";
-      return errors::OutOfRange("Unknown precision mode");
-  }
-  return Status::OK();
-}
-
-Status TrtPrecisionModeFromName(const string& name, TrtPrecisionMode* mode) {
-  if (name == "FP32") {
-    *mode = TrtPrecisionMode::FP32;
-  } else if (name == "FP16") {
-    *mode = TrtPrecisionMode::FP16;
-  } else if (name == "INT8") {
-    *mode = TrtPrecisionMode::INT8;
-  } else {
-    return errors::InvalidArgument("Invalid precision mode name: ", name);
-  }
-  return Status::OK();
-}
-
 string DebugString(const nvinfer1::Dims& dims) {
   string out = StrCat("nvinfer1::Dims(nbDims=", dims.nbDims, ", d=");
   for (int i = 0; i < dims.nbDims; ++i) {
@@ -94,12 +63,6 @@ string DebugString(const nvinfer1::DataType trt_dtype) {
     default:
       return "Invalid TRT data type";
   }
-}
-
-string DebugString(const TrtPrecisionMode mode) {
-  string mode_str;
-  TF_CHECK_OK(TrtPrecisionModeToName(mode, &mode_str));
-  return StrCat("TrtPrecisionMode::", mode_str);
 }
 
 string DebugString(const nvinfer1::Permutation& permutation, int len) {
@@ -237,38 +200,6 @@ int GetNumberOfEngineInputs(const nvinfer1::ICudaEngine* engine) {
   // the number of profiles.
   int n_profiles = engine->getNbOptimizationProfiles();
   return n_input / n_profiles;
-}
-
-string ProfileStrategyToName(const ProfileStrategy strategy) {
-  switch (strategy) {
-    case ProfileStrategy::kRange:
-      return "Range";
-    case ProfileStrategy::kOptimal:
-      return "Optimal";
-    case ProfileStrategy::kRangeOptimal:
-      return "Range+Optimal";
-    case ProfileStrategy::kImplicitBatchModeCompatible:
-      return "ImplicitBatchModeCompatible";
-  }
-  return "Unknown";
-}
-
-Status ProfileStrategyFromName(const string& name, ProfileStrategy* strategy) {
-  string name_lowercase(name);
-  std::transform(name.begin(), name.end(), name_lowercase.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-  if (name_lowercase == "range") {
-    *strategy = ProfileStrategy::kRange;
-  } else if (name_lowercase == "optimal") {
-    *strategy = ProfileStrategy::kOptimal;
-  } else if (name_lowercase == "range+optimal") {
-    *strategy = ProfileStrategy::kRangeOptimal;
-  } else if (name_lowercase == "implicitbatchmodecompatible") {
-    *strategy = ProfileStrategy::kImplicitBatchModeCompatible;
-  } else {
-    return errors::InvalidArgument("Invalid profile strategy: ", name);
-  }
-  return Status::OK();
 }
 
 absl::string_view GetDeviceName(const Node* node) {

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -50,12 +50,6 @@ struct TrtDestroyer {
 template <typename T>
 using TrtUniquePtrType = std::unique_ptr<T, TrtDestroyer<T>>;
 
-enum class TrtPrecisionMode { FP32, FP16, INT8 };
-
-Status TrtPrecisionModeToName(const TrtPrecisionMode mode, string* name);
-
-Status TrtPrecisionModeFromName(const string& name, TrtPrecisionMode* mode);
-
 // Define a hash function for vector<TensorShape> because it is used as the key
 // for the engine cache.
 struct VectorTensorShapeHasher {
@@ -90,7 +84,6 @@ string DebugString(const std::vector<CType>& vector) {
 }
 string DebugString(const nvinfer1::Dims& dims);
 string DebugString(const nvinfer1::DataType trt_dtype);
-string DebugString(const TrtPrecisionMode mode);
 string DebugString(const DataType tf_type);
 string DebugString(const nvinfer1::Permutation& permutation, int len);
 string DebugString(const ITensorProxyPtr& tensor);
@@ -224,26 +217,6 @@ absl::optional<DeviceNameUtils::ParsedName> MergeIfCompatible(
 // by a string_view.
 absl::optional<DeviceNameUtils::ParsedName> MergeIfCompatible(
     const DeviceNameUtils::ParsedName& a, absl::string_view b);
-
-// Optimization profile generation strategies.
-// - `kRange`: create one profile that works for inputs with dimension values
-//   in the range of [min_dims, max_dims] where min_dims and max_dims are
-//   derived from the provided inputs.
-// - `kOptimal`: create one profile for each input. The profile only works for
-//   inputs with the same dimensions as the input it is created for. The GPU
-//   engine will be run with optimal performance with such inputs.
-// - `kRangeOptimal`: create the profiles for both `Range` and `Optimal`.
-// - `kImplicitBatchModeCompatible`: create the profiles that will produce the
-//   same GPU engines as the implicit_batch_mode would produce.
-enum class ProfileStrategy {
-  kRange,
-  kOptimal,
-  kRangeOptimal,
-  kImplicitBatchModeCompatible,
-};
-
-string ProfileStrategyToName(const ProfileStrategy strategy);
-Status ProfileStrategyFromName(const string& name, ProfileStrategy* strategy);
 
 }  // namespace tensorrt
 }  // namespace tensorflow

--- a/tensorflow/compiler/tf2tensorrt/trt_convert_api.h
+++ b/tensorflow/compiler/tf2tensorrt/trt_convert_api.h
@@ -19,7 +19,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/trt_parameters.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/platform/statusor.h"
 #include "tensorflow/core/protobuf/meta_graph.pb.h"

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <vector>
 
 #include "tensorflow/compiler/tf2tensorrt/common/datavec.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/trt_parameters.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_execution_context.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"


### PR DESCRIPTION
The TF-TRT cpp converter needs to include the definition of `TrtPrecisionMode` and `ProfileStrategy`. Previously, these were defined in `convert/utils.h` which depends on `third_party/tensorrt/NvInfer.h`.  This third party header is not installed along with the rest of the header files. This PR moves the definitions to a separate header file. This way `trt_converter_api.h` is not dependent on `NvInfer.h` anymore. 

Tracker: #45481

Tagging @bixia1 for review.