### PR TITLE
fix building from source failed on Python 3.10 #51776

### DIFF
--- a/third_party/protobuf/protobuf.patch
+++ b/third_party/protobuf/protobuf.patch
@@ -1,20 +1,3 @@
-1. Fix BUILD
-
-2. Import MutableSequence from collections.abc on Python 3. (#6272)
-
-   Fixes https://github.com/protocolbuffers/protobuf/issues/5335.
-
-   Backport https://github.com/protocolbuffers/protobuf/commit/9d61eada0f47d7be793983638c4a29707b192d0c
-
-   Signed-off-by: Benjamin Peterson <benjamin@python.org>
-
-Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
----
- BUILD                                   | 4 +++-
- protobuf.bzl                            | 2 ++
- python/google/protobuf/pyext/message.cc | 6 +++++-
- 3 files changed, 10 insertions(+), 2 deletions(-)
-
 diff --git a/BUILD b/BUILD
 index dbae719..87dc384 100644
 --- a/BUILD

--- a/third_party/protobuf/protobuf.patch
+++ b/third_party/protobuf/protobuf.patch
@@ -1,14 +1,31 @@
+1. Fix BUILD
+
+2. Import MutableSequence from collections.abc on Python 3. (#6272)
+
+   Fixes https://github.com/protocolbuffers/protobuf/issues/5335.
+
+   Backport https://github.com/protocolbuffers/protobuf/commit/9d61eada0f47d7be793983638c4a29707b192d0c
+
+   Signed-off-by: Benjamin Peterson <benjamin@python.org>
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ BUILD                                   | 4 +++-
+ protobuf.bzl                            | 2 ++
+ python/google/protobuf/pyext/message.cc | 6 +++++-
+ 3 files changed, 10 insertions(+), 2 deletions(-)
+
 diff --git a/BUILD b/BUILD
-index dbae719ff..87dc38470 100644
+index dbae719..87dc384 100644
 --- a/BUILD
 +++ b/BUILD
 @@ -23,7 +23,7 @@ config_setting(
  # ZLIB configuration
  ################################################################################
-
+ 
 -ZLIB_DEPS = ["@zlib//:zlib"]
 +ZLIB_DEPS = ["@zlib"]
-
+ 
  ################################################################################
  # Protobuf Runtime Library
 @@ -143,6 +143,7 @@ cc_library(
@@ -18,7 +35,7 @@ index dbae719ff..87dc38470 100644
 +    alwayslink = 1,
      visibility = ["//visibility:public"],
  )
-
+ 
 @@ -213,6 +214,7 @@ cc_library(
      copts = COPTS,
      includes = ["src/"],
@@ -28,16 +45,36 @@ index dbae719ff..87dc38470 100644
      deps = [":protobuf_lite"] + PROTOBUF_DEPS,
  )
 diff --git a/protobuf.bzl b/protobuf.bzl
-index e0653321f..253d9cbb5 100644
+index e065332..92ae3b4 100644
 --- a/protobuf.bzl
 +++ b/protobuf.bzl
-@@ -84,7 +84,9 @@ def _proto_gen_impl(ctx):
-
+@@ -85,6 +85,8 @@ def _proto_gen_impl(ctx):
      for dep in ctx.attr.deps:
          import_flags += dep.proto.import_flags
          deps += dep.proto.deps
 +    import_flags = depset(import_flags).to_list()
 +    deps = depset(deps).to_list()
-
+ 
      if not ctx.attr.gen_cc and not ctx.attr.gen_py and not ctx.executable.plugin:
          return struct(
+diff --git a/python/google/protobuf/pyext/message.cc b/python/google/protobuf/pyext/message.cc
+index 3530a9b..c31fa8f 100644
+--- a/python/google/protobuf/pyext/message.cc
++++ b/python/google/protobuf/pyext/message.cc
+@@ -2991,8 +2991,12 @@ bool InitProto2MessageModule(PyObject *m) {
+         reinterpret_cast<PyObject*>(
+             &RepeatedCompositeContainer_Type));
+ 
+-    // Register them as collections.Sequence
++    // Register them as MutableSequence.
++#if PY_MAJOR_VERSION >= 3
++    ScopedPyObjectPtr collections(PyImport_ImportModule("collections.abc"));
++#else
+     ScopedPyObjectPtr collections(PyImport_ImportModule("collections"));
++#endif
+     if (collections == NULL) {
+       return false;
+     }
+-- 
+2.33.0
+


### PR DESCRIPTION
Building from source failed on Python 3.10
...
    from google.protobuf.pyext import _message
AttributeError: module 'collections' has no attribute 'MutableSequence'
...

Backport a patch [1] from protobuf to fix it, and merge it
to existed third_party/protobuf/protobuf.patch

[1] https://github.com/protocolbuffers/protobuf/commit/9d61eada0f47d7be793983638c4a29707b192d0c

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>