### PR TITLE
Removed NV GPU NUMA check for ARM64

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
+++ b/tensorflow/stream_executor/cuda/cuda_gpu_executor.cc
@@ -902,9 +902,6 @@ static int TryToReadNumaNode(const std::string& pci_bus_id,
 #elif defined(PLATFORM_WINDOWS)
   // Windows support for NUMA is not currently implemented. Return node 0.
   return 0;
-#elif defined(__aarch64__)
-  LOG(INFO) << "ARM64 does not support NUMA - returning NUMA node zero";
-  return 0;
 #else
   VLOG(2) << "trying to read NUMA node for device ordinal: " << device_ordinal;
   static const int kUnknownNumaNode = -1;


### PR DESCRIPTION
NUMA support message on ARM64 system

With this patch, on ARM64 system, tested 2 GPUs connected on different sockets.
Both are functional.

Hardware:
Dual socket ARM64 N1 system.
2 GPUs connected on different sockets

Software:
Ubuntu 20.04.3 LTS
Kernel : 5.4.0-89-generic (Linux devBox 5.4.0-89-generic #100-Ubuntu SMP Fri Sep 24 14:29:20 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux)
CUDA SDK : 11.4 (cuda_11.4.2_470.57.02_linux_sbsa.run)
cuDNN : v8.2 (cudnn-11.4-linux-aarch64sbsa-v8.2.2.26.tgz)
TensorRT: v8.0.1.6 (TensorRT-8.0.1.6.Ubuntu-20.04.aarch64-gnu.cuda-11.3.cudnn8.2.tar.gz)

GPU: Tesla T4
PCI slot info:

$lspci | grep -i NVIDIA
0005:01:00.0 3D controller: NVIDIA Corporation TU104GL [Tesla T4] (rev a1)
0009:03:00.0 3D controller: NVIDIA Corporation TU104GL [Tesla T4] (rev a1)

NUMA Info :
$ cat /sys/devices/pci0005:00/0005:00:01.0/0005:01:00.0/numa_node
0
$ cat /sys/devices/pci0009:00/0009:00:05.0/0009:03:00.0/numa_node
1

TensorFlow GPU access info:
```
name: "/device:GPU:0"
device_type: "GPU"
memory_limit: 15558377472
locality {
  bus_id: 1
  links {
  }
}
incarnation: 11914144743508156396
physical_device_desc: "device: 0, name: Tesla T4, pci bus id: 0005:01:00.0, compute capability: 7.5"
xla_global_id: 416903419

name: "/device:GPU:1"
device_type: "GPU"
memory_limit: 15558377472
locality {
  bus_id: 2
  numa_node: 1
  links {
  }
}
incarnation: 14202384483451516137
physical_device_desc: "device: 1, name: Tesla T4, pci bus id: 0009:03:00.0, compute capability: 7.5"
xla_global_id: 2144165316
```

Script to get info:

```
from tensorflow.python.client import device_lib

local_device = device_lib.list_local_devices()

for x in local_device:
  if x.device_type == 'GPU':
    print(x)

```