### PR TITLE
[tflite] make op profiling work when CoreML Delegate is used

### DIFF
--- a/tensorflow/lite/delegates/coreml/coreml_delegate.mm
+++ b/tensorflow/lite/delegates/coreml/coreml_delegate.mm
@@ -195,6 +195,7 @@ TfLiteRegistration GetCoreMlKernelRegistration() {
   // Prepare for prearing the delegate.
   // Free for any cleaning needed by the delegate.
   TfLiteRegistration kernel_registration;
+  kernel_registration.profiling_string = nullptr;
   kernel_registration.builtin_code = kTfLiteBuiltinDelegate;
   kernel_registration.custom_name = "TfLiteCoreMlDelegate";
   kernel_registration.free = [](TfLiteContext* context, void* buffer) -> void {


### PR DESCRIPTION
- issue:
When running CoreML delegate + op profiling, I met bus error most of the time.
- how to reproduce: on MacOS, 
```
benchmark_mode --graph=.. --use_coreml=1 --enable_op_profiling=1 ...
```
on iOS devices, add

```
use_coreml : "true", 
enable_op_profiling : "true", 
``` 

to  `benchmark_params.json`  of  https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/benchmark/ios.

The model I used to test this problem is [MobilenetEdgeTPU](https://storage.cloud.google.com/mobilenet_edgetpu/checkpoints/mobilenet_edgetpu_224_1.0.tgz).

- when it went wrong:
```
% bazel-bin/tensorflow/lite/tools/benchmark/benchmark_model --graph=/tmp/mobilenet_edgetpu_224_1.0_float.tflite --enable_op_profiling=1 --use_coreml=1
STARTING!
Log parameter values verbosely: [0]
Graph: [/tmp/mobilenet_edgetpu_224_1.0_float.tflite]
Enable op profiling: [1]
Use CoreML: [1]
Loaded model /tmp/mobilenet_edgetpu_224_1.0_float.tflite
2021-10-24 20:34:08.503 benchmark_model[42608:216982] coreml_version must be 2 or 3. Setting to 3.
COREML delegate created.
INFO: CoreML delegate: 75 nodes delegated out of 77 nodes, with 2 partitions.

Explicitly applied COREML delegate, and the model graph will be partially executed by the delegate w/ 1 delegate kernels.
The input model file size (MB): 16.3221
Initialized session in 568.672ms.
Running benchmark for at least 1 iterations and at least 0.5 seconds but terminate if exceeding 150 seconds.
count=262 first=3849 curr=1887 min=956 max=11424 avg=1888.11 std=1682

Running benchmark for at least 50 iterations and at least 1 seconds but terminate if exceeding 150 seconds.
zsh: bus error  bazel-bin/tensorflow/lite/tools/benchmark/benchmark_model   --use_coreml=1

```
After adding `profiling_string` initialization
```
% bazel-bin/tensorflow/lite/tools/benchmark/benchmark_model --graph=/tmp/mobilenet_edgetpu_224_1.0_float.tflite --enable_op_profiling=1 --use_coreml=1
STARTING!
Log parameter values verbosely: [0]
Graph: [/tmp/mobilenet_edgetpu_224_1.0_float.tflite]
Enable op profiling: [1]
Use CoreML: [1]
Loaded model /tmp/mobilenet_edgetpu_224_1.0_float.tflite
2021-10-24 20:38:10.823 benchmark_model[45038:226402] coreml_version must be 2 or 3. Setting to 3.
COREML delegate created.
INFO: CoreML delegate: 75 nodes delegated out of 77 nodes, with 2 partitions.

Explicitly applied COREML delegate, and the model graph will be partially executed by the delegate w/ 1 delegate kernels.
The input model file size (MB): 16.3221
Initialized session in 590.552ms.
Running benchmark for at least 1 iterations and at least 0.5 seconds but terminate if exceeding 150 seconds.
count=261 first=2610 curr=8604 min=973 max=10389 avg=1908.45 std=1752

Running benchmark for at least 50 iterations and at least 1 seconds but terminate if exceeding 150 seconds.
count=407 first=2088 curr=5167 min=955 max=11235 avg=2388.13 std=2227

Inference timings in us: Init: 590552, First inference: 2610, Warmup (avg): 1908.45, Inference (avg): 2388.13
Profiling Info for Benchmark Initialization:
============================== Run Order ==============================
	             [node type]	          [start]	  [first]	 [avg ms]	     [%]	  [cdf%]	  [mem KB]	[times called]	[Name]
	 ModifyGraphWithDelegate	            0.000	  576.714	  576.714	 99.988%	 99.988%	     0.000	        1	ModifyGraphWithDelegate/0
	         AllocateTensors	          576.697	    0.066	    0.034	  0.012%	100.000%	     0.000	        2	AllocateTensors/0

============================== Top by Computation Time ==============================
	             [node type]	          [start]	  [first]	 [avg ms]	     [%]	  [cdf%]	  [mem KB]	[times called]	[Name]
	 ModifyGraphWithDelegate	            0.000	  576.714	  576.714	 99.988%	 99.988%	     0.000	        1	ModifyGraphWithDelegate/0
	         AllocateTensors	          576.697	    0.066	    0.034	  0.012%	100.000%	     0.000	        2	AllocateTensors/0

Number of nodes executed: 2
============================== Summary by node type ==============================
	             [Node type]	  [count]	  [avg ms]	    [avg %]	    [cdf %]	  [mem KB]	[times called]
	 ModifyGraphWithDelegate	        1	   576.714	    99.988%	    99.988%	     0.000	        1
	         AllocateTensors	        1	     0.067	     0.012%	   100.000%	     0.000	        2

Timings (microseconds): count=1 curr=576781
Memory (bytes): count=0
2 nodes observed



Operator-wise Profiling Info for Regular Benchmark Runs:
============================== Run Order ==============================
	             [node type]	          [start]	  [first]	 [avg ms]	     [%]	  [cdf%]	  [mem KB]	[times called]	[Name]
	    TfLiteCoreMlDelegate	            0.000	    2.074	    2.379	 99.710%	 99.710%	     0.000	        1	[MobilenetEdgeTPU/Logits/Conv2d_1c_1x1/BiasAdd]:77
	                 RESHAPE	            2.380	    0.002	    0.001	  0.053%	 99.763%	     0.000	        1	[MobilenetEdgeTPU/Logits/Squeeze]:75
	                 SOFTMAX	            2.381	    0.008	    0.006	  0.237%	100.000%	     0.000	        1	[Softmax]:76

============================== Top by Computation Time ==============================
	             [node type]	          [start]	  [first]	 [avg ms]	     [%]	  [cdf%]	  [mem KB]	[times called]	[Name]
	    TfLiteCoreMlDelegate	            0.000	    2.074	    2.379	 99.710%	 99.710%	     0.000	        1	[MobilenetEdgeTPU/Logits/Conv2d_1c_1x1/BiasAdd]:77
	                 SOFTMAX	            2.381	    0.008	    0.006	  0.237%	 99.947%	     0.000	        1	[Softmax]:76
	                 RESHAPE	            2.380	    0.002	    0.001	  0.053%	100.000%	     0.000	        1	[MobilenetEdgeTPU/Logits/Squeeze]:75

Number of nodes executed: 3
============================== Summary by node type ==============================
	             [Node type]	  [count]	  [avg ms]	    [avg %]	    [cdf %]	  [mem KB]	[times called]
	    TfLiteCoreMlDelegate	        1	     2.379	    99.748%	    99.748%	     0.000	        1
	                 SOFTMAX	        1	     0.005	     0.210%	    99.958%	     0.000	        1
	                 RESHAPE	        1	     0.001	     0.042%	   100.000%	     0.000	        1

Timings (microseconds): count=407 first=2084 curr=5164 min=955 max=11231 avg=2386.31 std=2227
Memory (bytes): count=0
3 nodes observed
```

- why it went wrong: in https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/interpreter.h#L637-L642
The interpreter wanted to access non-null string, it profiling_string is not properly set :-(