### PR TITLE
[oneDNN] Bug-fix: add CPU device explicitly in the test.

### DIFF
--- a/tensorflow/python/grappler/remapper_test.py
+++ b/tensorflow/python/grappler/remapper_test.py
@@ -96,16 +96,17 @@ class RemapperTest(test.TestCase, parameterized.TestCase):
 
         # Create MatMul + BiasAdd + Gelu graph
         ops.reset_default_graph()
-        x = _input([m, k])
-        w = _weight([k, n])
-        b = _bias([n])
-        if precision == 'bfloat16':
-          x = math_ops.cast(x, dtypes.bfloat16)
-          w = math_ops.cast(w, dtypes.bfloat16)
-          b = math_ops.cast(b, dtypes.bfloat16)
-        y = math_ops.matmul(x, w)
-        z = nn.bias_add(y, b)
-        out = nn.gelu(z, approximate=approximate)
+        with ops.device('/device:CPU:0'):
+          x = _input([m, k])
+          w = _weight([k, n])
+          b = _bias([n])
+          if precision == 'bfloat16':
+            x = math_ops.cast(x, dtypes.bfloat16)
+            w = math_ops.cast(w, dtypes.bfloat16)
+            b = math_ops.cast(b, dtypes.bfloat16)
+          y = math_ops.matmul(x, w)
+          z = nn.bias_add(y, b)
+          out = nn.gelu(z, approximate=approximate)
 
         # Compute reference value.
         config = _get_config(remapping_on=False)


### PR DESCRIPTION
When TF is build with both cuda and oneDNN, CPU optimization should take place if device placement places CPU device. This PR updates grappler remapper python test with explicitly adding a CPU device.

Following is an example test command
`bazel test --config=cuda --test_env TF_ENABLE_ONEDNN_OPTS=1 -c opt //tensorflow/python/grappler:remapper_test_gpu`