### PR TITLE
Make Transpose's shape inference function validate that negative `per…

### DIFF
--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -166,9 +166,9 @@ Status TransposeShapeFn(InferenceContext* c) {
       data = AsInt64<int64>(perm, rank);
     }
 
-    for (int32 i = 0; i < rank; ++i) {
-      int64 in_idx = data[i];
-      if (in_idx >= rank) {
+    for (int32_t i = 0; i < rank; ++i) {
+      int64_t in_idx = data[i];
+      if (in_idx >= rank || in_idx <= -rank) {
         return errors::InvalidArgument("perm dim ", in_idx,
                                        " is out of range of input rank ", rank);
       }


### PR DESCRIPTION
…m` values are within the tensor's rank.

PiperOrigin-RevId: 403252853
Change-Id: Ia6b31b45b237312668bb31c2c3b3c7bbce2d2610