### PR TITLE
Prevent OOB access in QuantizeV2 shape inference

### DIFF
--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -2521,6 +2521,9 @@ Status QuantizeV2Shape(InferenceContext* c) {
   if (!s.ok() && s.code() != error::NOT_FOUND) {
     return s;
   }
+  if (axis < -1) {
+    return errors::InvalidArgument("axis should be at least -1, got ", axis);
+  }
   const int minmax_rank = (axis == -1) ? 0 : 1;
   TF_RETURN_IF_ERROR(shape_inference::UnchangedShape(c));
   ShapeHandle minmax;


### PR DESCRIPTION
PiperOrigin-RevId: 400309614
Change-Id: I31412c71b05b4f21b677f7fa715a61499cbee39d