### PR TITLE
Fix out-of-bounds memory error in tf.ragged.cross shape inference whe…

### DIFF
--- a/tensorflow/core/ops/ragged_array_ops.cc
+++ b/tensorflow/core/ops/ragged_array_ops.cc
@@ -64,6 +64,7 @@ REGISTER_OP("RaggedCross")
     .SetShapeFn([](shape_inference::InferenceContext* c) {
       std::vector<DataType> ragged_values_types;
       std::vector<DataType> ragged_splits_types;
+      std::vector<DataType> sparse_values_types;
       std::vector<DataType> dense_types;
 
       TF_RETURN_IF_ERROR(
@@ -71,15 +72,21 @@ REGISTER_OP("RaggedCross")
       TF_RETURN_IF_ERROR(
           c->GetAttr("ragged_splits_types", &ragged_splits_types));
       TF_RETURN_IF_ERROR(c->GetAttr("dense_types", &dense_types));
+      TF_RETURN_IF_ERROR(
+          c->GetAttr("sparse_values_types", &sparse_values_types));
 
       int num_ragged = ragged_values_types.size();
       if (num_ragged != ragged_splits_types.size()) {
         return errors::InvalidArgument(
-            "Parameters `values` and `row_splits` must be the same length");
+            "ragged values and splits must have the same length.");
       }
 
       int num_sparse;
       TF_RETURN_IF_ERROR(c->GetAttr("Nsparse", &num_sparse));
+      if (num_sparse != sparse_values_types.size()) {
+        return errors::InvalidArgument(
+            "sparse indices and values must have the same length");
+      }
 
       ShapeHandle out_values = c->UnknownShapeOfRank(1);
       ShapeHandle out_splits = c->UnknownShapeOfRank(1);

--- a/tensorflow/python/ops/ragged/ragged_cross_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_cross_op_test.py
@@ -27,6 +27,7 @@ from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import test_util
+from tensorflow.python.ops import gen_ragged_array_ops
 from tensorflow.python.ops import sparse_ops
 from tensorflow.python.ops.ragged import ragged_array_ops
 from tensorflow.python.ops.ragged import ragged_factory_ops
@@ -391,6 +392,42 @@ class RaggedCrossOpTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       return sparse_tensor.SparseTensor.from_value(t)
     else:
       return ops.convert_to_tensor(t)
+
+  def testSparseValuesAndIndicesMustMatch(self):
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError),
+        'sparse indices and values must have the same length'):
+      self.evaluate(gen_ragged_array_ops.RaggedCross(
+          ragged_values=[],
+          ragged_row_splits=[],
+          sparse_indices=[[5]],
+          sparse_values=[],
+          sparse_shape=[5],
+          dense_inputs=[['a']],
+          input_order='RD',
+          hashed_output=False,
+          num_buckets=5,
+          hash_key=2,
+          out_values_type=dtypes.string,
+          out_row_splits_type=dtypes.int64))
+
+  def testRaggedValuesAndSplitsMustMatch(self):
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError),
+        'ragged values and splits must have the same length'):
+      self.evaluate(gen_ragged_array_ops.RaggedCross(
+          ragged_values=[['a']],
+          ragged_row_splits=[],
+          sparse_indices=[],
+          sparse_values=[],
+          sparse_shape=[],
+          dense_inputs=[['a']],
+          input_order='RD',
+          hashed_output=False,
+          num_buckets=5,
+          hash_key=2,
+          out_values_type=dtypes.string,
+          out_row_splits_type=dtypes.int64))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…n it is called with invalid inputs.

PiperOrigin-RevId: 400049589
Change-Id: Icd535f4c6b96b3c926befb70a0e44e6d2b004c0a