### PR TITLE
Fix null pointer exception in shape inference function when tf.ragged…

### DIFF
--- a/tensorflow/core/ops/ragged_array_ops.cc
+++ b/tensorflow/core/ops/ragged_array_ops.cc
@@ -99,7 +99,14 @@ REGISTER_OP("RaggedCross")
       int dense_start = num_ragged * 2 + num_sparse * 3;
       for (int i = 0; i < dense_types.size(); ++i) {
         ShapeHandle dense_input = c->input(i + dense_start);
-        int64 batch_size = c->Value(c->Dim(dense_input, 0));
+        int32 rank = c->Rank(dense_input);
+        if (rank == InferenceContext::kUnknownRank) {
+          continue;
+        } else if (rank != 2) {
+          return errors::InvalidArgument(
+              "tf.ragged.cross only supports inputs with rank=2");
+        }
+        int64_t batch_size = c->Value(c->Dim(dense_input, 0));
         if (batch_size != InferenceContext::kUnknownDim) {
           ShapeHandle row_splits = c->Vector(batch_size + 1);
           if (!c->Merge(out_splits, row_splits, &out_splits).ok()) {


### PR DESCRIPTION
….cross() is called with invalid inputs.

PiperOrigin-RevId: 400045848
Change-Id: Ia65501583b85cf1ec14a252d83fbdd716817a516