### PR TITLE
PR #51732: Fix crash of tf.image.crop_and_resize when input is large …

### DIFF
--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -5777,6 +5777,16 @@ class DecodeImageTest(test_util.TensorFlowTestCase, parameterized.TestCase):
             crop_size=[1, 1])
         self.evaluate(op)
 
+  def testImageCropAndResizeWithInvalidInput(self):
+    with self.session():
+      with self.assertRaises((errors.InternalError, ValueError)):
+        op = image_ops_impl.crop_and_resize_v2(
+            image=np.ones((1, 1, 1, 1)),
+            boxes=np.ones((11, 4)),
+            box_indices=np.ones((11)),
+            crop_size=[2065374891, 1145309325])
+        self.evaluate(op)
+
   @parameterized.named_parameters(
       ("_jpeg", "JPEG", "jpeg_merge_test1.jpg"),
       ("_png", "PNG", "lena_rgba.png"),


### PR DESCRIPTION
…number

Imported from GitHub PR https://github.com/tensorflow/tensorflow/pull/51732

This PR is part of the effort in #46890 where
tf.image.crop_and_resize will crash if shape consists of large number.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
Copybara import of the project:

--
c8d87055a56d8740d27ad8bdc74a7459ede6900e by Yong Tang <yong.tang.github@outlook.com>:

Fix crash of tf.image.crop_and_resize when input is large number

This PR is part of the effort in 46890 where
tf.image.crop_and_resize will crash if shape consists of large number.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
COPYBARA_INTEGRATE_REVIEW=https://github.com/tensorflow/tensorflow/pull/51732 from yongtang:46890-tf.image.crop_and_resize c8d87055a56d8740d27ad8bdc74a7459ede6900e
PiperOrigin-RevId: 394109830
Change-Id: If049dad0844df9353722029ee95bc76819eda1f4