### PR TITLE
[ROCm] Fix for invalid llvm ir on AMDGPU in reduction

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -4073,8 +4073,13 @@ void IrEmitterUnnested::EmitReductionOutputForRowReduction(
       llvm::Type* element_type =
           state.partial_result_address->getType()->getElementType();
 
-      llvm::Value* initial_value_addr = llvm_ir::EmitAllocaAtFunctionEntry(
-          element_type, "initial_value_addr", &b_);
+/* Insure initial value address is in generic, not scratch. */ 
+      llvm::Value* initial_value_addr = b_.CreateAddrSpaceCast(
+		       llvm_ir::EmitAllocaAtFunctionEntry(
+          		element_type, "initial_value_addr", &b_),
+		      llvm::PointerType::get(element_type,
+			      /*AddressSpace=*/0),
+		      "initial_value_addr");
       b_.CreateStore(state.initial_value, initial_value_addr);
 
       llvm::Value* warp_exists = b_.CreateICmpULT(

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
@@ -724,6 +724,10 @@ class IrEmitterUnnested : public IrEmitter {
   absl::flat_hash_map<const mlir::Region*, std::unique_ptr<HloModule>>
       scratch_nested_computations_;
   // End optional members for XLA HLO -> LMHLO.
+
+  // __shared__ memory uses a different address space, so we cast it to
+  // global address space before writing or reading.
+  llvm::Value* CastSharedToGlobal(llvm::Value* input, llvm::Twine name = "");
 };
 
 }  // namespace gpu


### PR DESCRIPTION
Address Space Casting initial value addr to generic space for a fix for the llvm ir generated on AMD GPU. This is a fix for the invalid llvm IR generated following fc9df104fdbbda6ee9096b40186a50badb147ac7. 