### PR TITLE
[tf.data] Fix memory leak in to_tf_record_op.

### DIFF
--- a/tensorflow/core/kernels/data/experimental/to_tf_record_op.cc
+++ b/tensorflow/core/kernels/data/experimental/to_tf_record_op.cc
@@ -87,6 +87,7 @@ class ToTFRecordOp : public AsyncOpKernel {
     IteratorContext iter_ctx(std::move(params));
     DatasetBase* finalized_dataset;
     TF_RETURN_IF_ERROR(FinalizeDataset(ctx, dataset, &finalized_dataset));
+    core::ScopedUnref unref(finalized_dataset);
 
     std::unique_ptr<IteratorBase> iterator;
     TF_RETURN_IF_ERROR(finalized_dataset->MakeIterator(


### PR DESCRIPTION
PiperOrigin-RevId: 396400385
Change-Id: I13951a206ebff8fa0887f42cd9218f07e9ff27dc