### PR TITLE
Make SparseFillEmptyRows validate that the length of `values` must be…

### DIFF
--- a/tensorflow/core/kernels/sparse_fill_empty_rows_op.cc
+++ b/tensorflow/core/kernels/sparse_fill_empty_rows_op.cc
@@ -22,11 +22,13 @@ limitations under the License.
 #include <vector>
 
 #include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/op_requires.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_util.h"
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/lib/gtl/inlined_vector.h"
+#include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/util/sparse/sparse_tensor.h"
 
 namespace tensorflow {
@@ -64,6 +66,10 @@ class SparseFillEmptyRowsOp : public OpKernel {
     OP_REQUIRES(context, TensorShapeUtils::IsVector(values_t.shape()),
                 errors::InvalidArgument("values must be a vector, saw: ",
                                         values_t.shape().DebugString()));
+    OP_REQUIRES(context, indices_t.dim_size(0) == values_t.dim_size(0),
+                errors::InvalidArgument("The length of `values` (", values_t.dim_size(0),
+                                        ") must match the first dimension of `indices` (",
+                                        indices_t.dim_size(0), ")."));
     OP_REQUIRES(context, TensorShapeUtils::IsScalar(default_value_t.shape()),
                 errors::InvalidArgument("default_value must be a scalar, saw: ",
                                         default_value_t.shape().DebugString()));


### PR DESCRIPTION
… equal to the number of index tuples.

PiperOrigin-RevId: 399969549
Change-Id: I3c2f2ca1c1d2cc88bb5951c6958b38c16e9436c8