### PR TITLE
Adding new patch for LLVM to support building on darwin arm64

### DIFF
--- a/third_party/llvm/macos_build_fix.patch
+++ b/third_party/llvm/macos_build_fix.patch
@@ -1,30 +1,46 @@
-From e5c1ce3e8ec0fd92365285405c9418e52825ff2c Mon Sep 17 00:00:00 2001
-From: yashkatariya <yashkatariya@google.com>
-Date: Tue, 26 Oct 2021 19:57:14 -0700
-Subject: [PATCH] Add new select for darwin which is needed for TF
+From 7b4ce5b36f6fc0e35c3614861d394b9f48d950a4 Mon Sep 17 00:00:00 2001
+From: Dan F-M <foreman.mackey@gmail.com>
+Date: Wed, 27 Oct 2021 21:44:40 -0400
+Subject: [PATCH] Adding macos darwin config
 
 ---
- utils/bazel/llvm-project-overlay/llvm/config.bzl | 6 ++++--
- 1 file changed, 4 insertions(+), 2 deletions(-)
+ utils/bazel/llvm-project-overlay/llvm/BUILD.bazel | 8 ++++++++
+ utils/bazel/llvm-project-overlay/llvm/config.bzl  | 4 ++--
+ 2 files changed, 10 insertions(+), 2 deletions(-)
 
+diff --git a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+index 3e8bbe8a1cc1..8883b16b7350 100644
+--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+@@ -16,6 +16,14 @@ package(
+ 
+ exports_files(["LICENSE.TXT"])
+ 
++config_setting(
++    name = "macos_arm64",
++    values = {
++        "apple_platform_type": "macos",
++        "cpu": "darwin_arm64",
++    },
++)
++
+ # It may be tempting to add compiler flags here, but that should be avoided.
+ # The necessary warnings and other compile flags should be provided by the
+ # toolchain or the `.bazelrc` file. This is just a workaround until we have a
 diff --git a/utils/bazel/llvm-project-overlay/llvm/config.bzl b/utils/bazel/llvm-project-overlay/llvm/config.bzl
-index ff64df694048..c78a620b4b0f 100644
+index ff64df694048..c9c35b01711c 100644
 --- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
 +++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
-@@ -76,10 +76,12 @@ os_defines = select({
+@@ -76,8 +76,8 @@ os_defines = select({
  # TODO: We should split out host vs. target here.
  llvm_config_defines = os_defines + select({
      "@bazel_tools//src/conditions:windows": native_arch_defines("X86", "x86_64-pc-win32"),
 -    "@bazel_tools//src/conditions:darwin_arm64": native_arch_defines("AArch64", "arm64-apple-darwin"),
 -    "@bazel_tools//src/conditions:darwin_x86_64": native_arch_defines("X86", "x86_64-unknown-darwin"),
++    "//llvm:macos_arm64": native_arch_defines("AArch64", "arm64-apple-darwin"),
 +    "@bazel_tools//src/conditions:darwin": native_arch_defines("X86", "x86_64-unknown-darwin"),
      "@bazel_tools//src/conditions:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
      "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu"),
-+}) + select({
-+    "@bazel_tools//src/conditions:darwin_arm64": native_arch_defines("AArch64", "arm64-apple-darwin"),
-+    "//conditions:default": [],
  }) + [
-     # These shouldn't be needed by the C++11 standard, but are for some
-     # platforms (e.g. glibc < 2.18. See
---
-2.33.0.1079.g6e70778dc9-goog
+-- 
+2.30.1 (Apple Git-130)


### PR DESCRIPTION
This should also enable cross-compiling from x86_64 to arm64, without breaking the existing x86_64 builds.

Over in https://github.com/google/jax/issues/5501, we've been struggling to get JAX to compile properly on the Apple arm64 architecture or cross-compiled from x86_64, since the compiler flags for `llvm-project` don't get set properly. This was the simplest method I could find for getting this to work, without breaking the existing builds. I've tested that I can get JAX to compile and cross-compile properly after applying this patch, but I don't know if there are specific TensorFlow tests that would be good to run too.

I don't think that it makes sense to submit this upstream to LLVM since (I think!) the version there, based on platforms, should already work, and I don't entirely understand why it doesn't for the TensorFlow build. Folks over there were (correctly, I think) unhappy about exposing a configuration variable like this just as a workaround for our purposes.

Thanks!

/cc @yashk2810, @hawkinsp