### PR TITLE
Update Keras Model Docs for dataset dictionaries

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -911,7 +911,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             if the model has named inputs.
           - A `tf.data` dataset. Should return a tuple
             of either `(inputs, targets)` or
-            `(inputs, targets, sample_weights)`.
+            `(inputs, targets, sample_weights)`. Note: datasets returning
+            dictionaries are not supported.
           - A generator or `keras.utils.Sequence` returning `(inputs, targets)`
             or `(inputs, targets, sample_weights)`.
           - A `tf.keras.utils.experimental.DatasetCreator`, which wraps a
@@ -1375,7 +1376,8 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             if the model has named inputs.
           - A `tf.data` dataset. Should return a tuple
             of either `(inputs, targets)` or
-            `(inputs, targets, sample_weights)`.
+            `(inputs, targets, sample_weights)`. Note: datasets returning
+            dictionaries are not supported.
           - A generator or `keras.utils.Sequence` returning `(inputs, targets)`
             or `(inputs, targets, sample_weights)`.
           A more detailed description of unpacking behavior for iterator types


### PR DESCRIPTION
Update the documentation for fit and evaluate to specifically note that datasets returning dictionaries is NOT supported.

This is important since previous versions of TF allowed dictionary inputs from datasets, where the name of the input variable was matched to the dictionaries keys.  But this is not longer supported by Keras.

This matter is confusing since fit does seem to accept dictionary inputs, but I'm told by Rick Chao that this is not supported.  Passing a dictionary to evaluate gives a weird error message.  

Better to be explicit.