### PR TITLE
[oneDNN] Avoid converting memory layout for second matrix in the MatMul op.

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -120,8 +120,8 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, T> {
     // Set weight format `any` for primitive as per oneDNN recommendation.
     MklDnnMatMulFwdParams matmul_params(
         src_dims, weight_dims, bias_dims, dst_dims, src_format,
-        memory::format_tag::any, memory::format_tag::nc);
-
+        (this->is_weight_const_) ? memory::format_tag::any : weight_format,
+        memory::format_tag::nc);
     // Extend the basic parameters for data types and fusions.
     ExtendMklDnnMatMulFwdParams(ctx, matmul_params);
 #ifdef DNNL_AARCH64_USE_ACL


### PR DESCRIPTION
This PR reverts a small change in the _FusedMatMul op kernel that has caused regression in some smaller models, particularly when the second tensor to the kernel is not constant.
