### PR TITLE
Fix 16-bit Softmax legalization

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1267,6 +1267,46 @@ func @test_softmax_qi8(%arg0: tensor<13x21x3x!quant.uniform<i8:f32, 0.0156164625
 
 // -----
 
+
+// CHECK-LABEL: test_softmax_qi16
+// CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<31> : tensor<1x1xi32>}
+// CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() {value = dense<7> : tensor<1x1xi32>}
+// CHECK-DAG: %[[VAR2:.*]] = "tosa.const"() {value = dense<32768> : tensor<1x1xi32>}
+// CHECK-DAG: %[[VAR3:.*]] = "tosa.const"() {value = dense<14> : tensor<1x1xi32>}
+// CHECK-DAG: %[[VAR4:.*]] = "tosa.const"() {value = dense<1073741824> : tensor<1x1xi32>}
+// CHECK-DAG: %[[VAR5:.*]] = "tosa.const"() {value = dense<1> : tensor<1x1xi32>}
+// CHECK-DAG: %[[VAR6:.*]] = "tosa.const"() {value = dense<32767> : tensor<1x1xi32>}
+// CHECK-DAG: %[[VAR7:.*]] = "tosa.const"() {value = dense<"0xF{{.*}}>
+// CHECK-DAG: %[[VAR8:.*]] = "tosa.const"() {value = dense<"0x0{{.*}}> : tensor<513xi16>}
+// CHECK-DAG: %[[VAR9:.*]] = "tosa.rescale"(%arg0) {double_round = false, input_zp = 0 : i32, multiplier = [1073741824 : i32], output_zp = 0 : i32, per_channel = false, scale32 = true, shift = [30 : i32]}
+// CHECK-DAG: %[[VAR10:.*]] = "tosa.reduce_max"(%[[VAR9]]) {axis = 1 : i64}
+// CHECK-DAG: %[[VAR11:.*]] = "tosa.sub"(%[[VAR9]], %[[VAR10]])
+// CHECK-DAG: %[[VAR12:.*]] = "tosa.rescale"(%[[VAR11]]) {double_round = true, input_zp = 0 : i32, multiplier = [1717965619 : i32], output_zp = 0 : i32, per_channel = false, scale32 = true, shift = [32 : i32]}
+// CHECK-DAG: %[[VAR13:.*]] = "tosa.add"(%[[VAR12]], %[[VAR6]])
+// CHECK-DAG: %[[VAR14:.*]] = "tosa.cast"(%[[VAR13]])
+// CHECK-DAG: %[[VAR15:.*]] = "tosa.table"(%[[VAR14]], %[[VAR8]])
+// CHECK-DAG: %[[VAR16:.*]] = "tosa.arithmetic_right_shift"(%[[VAR15]], %[[VAR1]]) {round = true}
+// CHECK-DAG: %[[VAR17:.*]] = "tosa.reduce_sum"(%[[VAR16]]) {axis = 1 : i64}
+// CHECK-DAG: %[[VAR18:.*]] = "tosa.clz"(%[[VAR17]])
+// CHECK-DAG: %[[VAR19:.*]] = "tosa.sub"(%[[VAR18]], %[[VAR5]])
+// CHECK-DAG: %[[VAR20:.*]] = "tosa.logical_left_shift"(%[[VAR17]], %[[VAR19]])
+// CHECK-DAG: %[[VAR21:.*]] = "tosa.sub"(%[[VAR20]], %[[VAR4]])
+// CHECK-DAG: %[[VAR22:.*]] = "tosa.arithmetic_right_shift"(%[[VAR21]], %[[VAR3]]) {round = true}
+// CHECK-DAG: %[[VAR23:.*]] = "tosa.sub"(%[[VAR22]], %[[VAR2]])
+// CHECK-DAG: %[[VAR24:.*]] = "tosa.cast"(%[[VAR23]])
+// CHECK-DAG: %[[VAR25:.*]] = "tosa.table"(%[[VAR24]], %[[VAR7]])
+// CHECK-DAG: %[[VAR26:.*]] = "tosa.arithmetic_right_shift"(%[[VAR25]], %[[VAR1]]) {round = true}
+// CHECK-DAG: %[[VAR27:.*]] = "tosa.mul"(%[[VAR26]], %[[VAR16]]) {shift = 0 : i32}
+// CHECK-DAG: %[[VAR28:.*]] = "tosa.sub"(%[[VAR0]], %[[VAR18]])
+// CHECK-DAG: %[[VAR29:.*]] = "tosa.arithmetic_right_shift"(%[[VAR27]], %[[VAR28]]) {round = true}
+// CHECK: %[[VAR30:.*]] = "tosa.rescale"(%[[VAR29]]) {double_round = false, input_zp = 0 : i32, multiplier = [1073741824 : i32], output_zp = 0 : i32, per_channel = false, scale32 = true, shift = [30 : i32]}
+func @test_softmax_qi16(%arg0: tensor<14x19x!quant.uniform<i16:f32, 6.103533087298274E-5>>) -> tensor<14x19x!quant.uniform<i16:f32, 3.0517578125E-5>> {
+  %0 = "tfl.softmax"(%arg0) {beta = 1.000000e+00 : f32} : (tensor<14x19x!quant.uniform<i16:f32, 6.103533087298274E-5>>) -> tensor<14x19x!quant.uniform<i16:f32, 3.0517578125E-5>>
+  return %0 : tensor<14x19x!quant.uniform<i16:f32, 3.0517578125E-5>>
+}
+
+// -----
+
 // CHECK-LABEL: test_sigmoid_qi8
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<{{.*}}> : tensor<256xi8>}
 // CHECK: %[[VAR1:.*]] = "tosa.table"(%arg0, %[[VAR0]])

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
@@ -33,10 +33,10 @@ limitations under the License.
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Quant/QuantTypes.h"  // from @llvm-project
 #include "mlir/Dialect/Tensor/IR/Tensor.h"  // from @llvm-project
-#include "mlir/Dialect/Tosa/IR/TosaOps.h"  // from @llvm-project
-#include "mlir/IR/BuiltinTypes.h"  // from @llvm-project
-#include "mlir/IR/Matchers.h"  // from @llvm-project
-#include "mlir/IR/PatternMatch.h"  // from @llvm-project
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"   // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/IR/Matchers.h"               // from @llvm-project
+#include "mlir/IR/PatternMatch.h"           // from @llvm-project
 #include "tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h"
 
 namespace mlir {
@@ -1562,58 +1562,67 @@ llvm::Optional<Value> convertSoftmaxOp(PatternRewriter& rewriter, Operation* op,
 
       // Step 2. rescale input from [-65535, 0] to [-32768, 32767] for LUT input
       Value op4_rescale_op3 = buildRescale(
-          rewriter, op, int16_logits_type, op3_sub_op1_op2.getResult(),
-          input_diff_scale, 0, 32767, true, true);
+          rewriter, op, int32_logits_type, op3_sub_op1_op2.getResult(),
+          input_diff_scale /* scale */, 0 /* input_zp */, 0 /* output_zp */,
+          true /* double_round */, true /* scale32 */);
+      auto op5_add_op4 = CreateOpAndInfer<tosa::AddOp>(
+          rewriter, op->getLoc(), int32_logits_type, op4_rescale_op3,
+          getTosaConstTensorSingleI32(rewriter, op, 32767));
+
+      auto op6_cast_op5 = CreateOpAndInfer<tosa::CastOp>(
+          rewriter, op->getLoc(), int16_logits_type, op5_add_op4.getResult());
 
       // Step 3. get exp() result
       // Output is 15.7.
       // In 8-bit case, no interpolation here, since input should be right on
       // table entry.
-      auto op5_table_op4 = CreateOpAndInfer<tosa::TableOp>(
-          rewriter, op->getLoc(), int32_logits_type, op4_rescale_op3,
+      auto op7_table_op6 = CreateOpAndInfer<tosa::TableOp>(
+          rewriter, op->getLoc(), int32_logits_type, op6_cast_op5,
           exp_table_const);
 
       // Right shift 7 bits. output 15. Shouldn't lose any precision since last
       // 7 bits should be all 0.
-      auto op6_rshift_op5 = CreateOpAndInfer<tosa::ArithmeticRightShiftOp>(
-          rewriter, op->getLoc(), int32_logits_type, op5_table_op4.getResult(),
+      auto op8_rshift_op7 = CreateOpAndInfer<tosa::ArithmeticRightShiftOp>(
+          rewriter, op->getLoc(), int32_logits_type, op7_table_op6.getResult(),
           getTosaConstTensorSingleI32(rewriter, op, 7), true);
 
       // Step 4. get sum(exp()). output 16.15
-      auto op7_reducesum_op6 = CreateOpAndInfer<tosa::ReduceSumOp>(
-          rewriter, op->getLoc(), int32_rsum_type, op6_rshift_op5.getResult(),
+      auto op9_reducesum_op8 = CreateOpAndInfer<tosa::ReduceSumOp>(
+          rewriter, op->getLoc(), int32_rsum_type, op8_rshift_op7.getResult(),
           rewriter.getI64IntegerAttr(input_rank - 1));
 
       // Step 5. calculate reciprocal(sum(exp()))
       // CLZ returns 32 - first non zero bit
-      auto op8_clz_op7 =
+      auto op10_clz_op9 =
           CreateOpAndInfer<tosa::ClzOp>(rewriter, op->getLoc(), int32_rsum_type,
-                                        op7_reducesum_op6.getResult());
+                                        op9_reducesum_op8.getResult());
 
-      auto op9_sub_op8 = CreateOpAndInfer<tosa::SubOp>(
-          rewriter, op->getLoc(), int32_rsum_type, op8_clz_op7.getResult(),
+      auto op11_sub_op10 = CreateOpAndInfer<tosa::SubOp>(
+          rewriter, op->getLoc(), int32_rsum_type, op10_clz_op9.getResult(),
           getTosaConstTensorSingleI32(rewriter, op, 1));
 
       // Left shift to get  1.30 format
-      auto op10_lshift_op7_op9 = CreateOpAndInfer<tosa::LogicalLeftShiftOp>(
+      auto op12_lshift_op9_op11 = CreateOpAndInfer<tosa::LogicalLeftShiftOp>(
           rewriter, op->getLoc(), int32_rsum_type,
-          op7_reducesum_op6.getResult(), op9_sub_op8.getResult());
+          op9_reducesum_op8.getResult(), op11_sub_op10.getResult());
 
       // Subtract (1 << 30) to make 0 <= x <= 1 under 0.30 format
-      auto op11_sub_op10 = CreateOpAndInfer<tosa::SubOp>(
+      auto op13_sub_op12 = CreateOpAndInfer<tosa::SubOp>(
           rewriter, op->getLoc(), int32_rsum_type,
-          op10_lshift_op7_op9.getResult(),
+          op12_lshift_op9_op11.getResult(),
           getTosaConstTensorSingleI32(rewriter, op, (1u << 30)));
 
       // Right shift 14 bits to get output range [0, 65535]
-      auto op12_rshift_op11 = CreateOpAndInfer<tosa::ArithmeticRightShiftOp>(
-          rewriter, op->getLoc(), int32_rsum_type, op11_sub_op10.getResult(),
+      auto op14_rshift_op13 = CreateOpAndInfer<tosa::ArithmeticRightShiftOp>(
+          rewriter, op->getLoc(), int32_rsum_type, op13_sub_op12.getResult(),
           getTosaConstTensorSingleI32(rewriter, op, 14), true);
 
       // Remap input to [-32768, 32767] for LUT input
-      auto op13_rescale_op12 = buildRescale(rewriter, op, int16_rsum_type,
-                                            op12_rshift_op11.getResult(), 1.0,
-                                            32768, 0, false, true);
+      auto op15_add_op14 = CreateOpAndInfer<tosa::SubOp>(
+          rewriter, op->getLoc(), int32_rsum_type, op14_rshift_op13.getResult(),
+          getTosaConstTensorSingleI32(rewriter, op, 32768));
+      auto op16_cast_op15 = CreateOpAndInfer<tosa::CastOp>(
+          rewriter, op->getLoc(), int16_rsum_type, op15_add_op14.getResult());
 
       // Generate table for 1 / (1 + x), for 0 <= x <= 1
       auto one_over_one_plus_x_func = [](double x) -> double {
@@ -1624,35 +1633,35 @@ llvm::Optional<Value> convertSoftmaxOp(PatternRewriter& rewriter, Operation* op,
           rewriter, op, one_over_one_plus_x_func, 0.0, 1.0);
 
       // Get (1 / sum(exp(x))) result as 23 bits (including sign bit)
-      auto op14_table_op13 = CreateOpAndInfer<tosa::TableOp>(
-          rewriter, op->getLoc(), int32_rsum_type, op13_rescale_op12,
+      auto op17_table_op16 = CreateOpAndInfer<tosa::TableOp>(
+          rewriter, op->getLoc(), int32_rsum_type, op16_cast_op15,
           one_over_one_plus_x_table_const);
 
       // Right shift 7 bits back to 0.15
-      auto op15_rshift_op14 = CreateOpAndInfer<tosa::ArithmeticRightShiftOp>(
-          rewriter, op->getLoc(), int32_rsum_type, op14_table_op13.getResult(),
+      auto op18_rshift_op17 = CreateOpAndInfer<tosa::ArithmeticRightShiftOp>(
+          rewriter, op->getLoc(), int32_rsum_type, op17_table_op16.getResult(),
           getTosaConstTensorSingleI32(rewriter, op, 7), true);
 
       // Step 6. multiply exp(max-x) with 1 / sum(exp(max-x))
       // lhs: 0.15, rhs: 0.15, output: 0.30
-      auto op16_mul_op15_op6 = CreateOpAndInfer<tosa::MulOp>(
-          rewriter, op->getLoc(), int32_logits_type, op15_rshift_op14,
-          op6_rshift_op5, 0);
+      auto op19_mul_op18_op8 = CreateOpAndInfer<tosa::MulOp>(
+          rewriter, op->getLoc(), int32_logits_type, op18_rshift_op17,
+          op8_rshift_op7, 0);
 
-      auto op17_sub_op8 = CreateOpAndInfer<tosa::SubOp>(
+      auto op20_sub_op10 = CreateOpAndInfer<tosa::SubOp>(
           rewriter, op->getLoc(), int32_rsum_type,
           getTosaConstTensorSingleI32(rewriter, op, 31),
-          op8_clz_op7.getResult());
+          op10_clz_op9.getResult());
 
       // Apply the clz back, we get 0.15 output
       // [0, 32767] corresponding to [0.0, 1.0]
-      auto op18_rshift_op16_op17 =
+      auto op21_rshift_op19_op20 =
           CreateOpAndInfer<tosa::ArithmeticRightShiftOp>(
               rewriter, op->getLoc(), int32_logits_type,
-              op16_mul_op15_op6.getResult(), op17_sub_op8.getResult(), true);
+              op19_mul_op18_op8.getResult(), op20_sub_op10.getResult(), true);
 
       return buildRescale(rewriter, op, output_type,
-                          op18_rshift_op16_op17.getResult(),
+                          op21_rshift_op19_op20.getResult(),
                           (1.0 / out_quant_type.getScale()) * (1.0 / 32768.0),
                           0, out_quant_type.getZeroPoint(), false, true);
     } else {


### PR DESCRIPTION
Old 16-bit softmax tfl.softmax legalization is lowered incorrectly with illegal TOSA operators.
New legalization fixes it.
Also add 16-bit softmax legalization test
