### PR TITLE
Re-enable building as a standalone submodule

### DIFF
--- a/tensorflow/compiler/mlir/hlo/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/CMakeLists.txt
@@ -39,7 +39,7 @@ option(MHLO_ENABLE_BINDINGS_PYTHON "Enables MHLO python bindings" OFF)
 #-------------------------------------------------------------------------------
 set(MHLO_EXTERNAL_PROJECT_BUILD OFF)
 
-if(NOT (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR))
+if(NOT (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR) AND NOT MLIR_BINARY_DIR)
   # Building as part of LLVM via the external project mechanism.
   set(MHLO_EXTERNAL_PROJECT_BUILD ON)
 else()


### PR DESCRIPTION
The pattern used to detect if to build via the LLVM external project
mechanism prevented to build MLIR-HLO as a standalone project when added
as a submodule.