### PR TITLE
[TF-TRT] trt_utils.versionTupleToString didn't exist, changing to trt_utils.version_tuple_to_string

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -232,7 +232,7 @@ def _check_trt_version_compatibility():
         "The {version_type} version of TensorRT: `{trt_version}` has now "
         "been removed. Please upgrade to TensorRT 7 or more recent.".format(
             version_type=version_type,
-            trt_version=trt_utils.versionTupleToString(trt_version)))
+            trt_version=trt_utils.version_tuple_to_string(trt_version)))
 
     raise RuntimeError("Incompatible %s TensorRT versions" % version_type)
 
@@ -251,16 +251,16 @@ def _check_trt_version_compatibility():
         "compilation and runtime.\n"
         "\t-TensorRT does not support forward compatibility. The loaded "
         "version has to be equal or more recent than the linked version.",
-        trt_utils.versionTupleToString(loaded_version),
-        trt_utils.versionTupleToString(linked_version))
+        trt_utils.version_tuple_to_string(loaded_version),
+        trt_utils.version_tuple_to_string(linked_version))
     raise RuntimeError("Incompatible TensorRT major version")
 
   elif loaded_version != linked_version:
     logging.info(
         "Loaded TensorRT %s and linked TensorFlow against TensorRT %s. This is "
         "supported because TensorRT minor/patch upgrades are backward "
-        "compatible.", trt_utils.versionTupleToString(loaded_version),
-        trt_utils.versionTupleToString(linked_version))
+        "compatible.", trt_utils.version_tuple_to_string(loaded_version),
+        trt_utils.version_tuple_to_string(linked_version))
 
 
 def _get_tensorrt_rewriter_config(conversion_params,

--- a/tensorflow/python/compiler/tensorrt/utils.py
+++ b/tensorflow/python/compiler/tensorrt/utils.py
@@ -46,7 +46,7 @@ def disable_non_trt_optimizers_in_rewriter_config(rewriter_config):
   rewriter_config.shape_optimization = off
 
 
-def _version_tuple_to_string(ver_tuple):
+def version_tuple_to_string(ver_tuple):
   assert isinstance(ver_tuple, tuple)
   assert len(ver_tuple) == 3
 
@@ -55,8 +55,8 @@ def _version_tuple_to_string(ver_tuple):
 
 
 def _is_tensorrt_version_greater_equal(trt_ver, target_ver):
-  trt_ver = version.LooseVersion(_version_tuple_to_string(trt_ver))
-  target_ver = version.LooseVersion(_version_tuple_to_string(target_ver))
+  trt_ver = version.LooseVersion(version_tuple_to_string(trt_ver))
+  target_ver = version.LooseVersion(version_tuple_to_string(target_ver))
 
   return trt_ver >= target_ver
 


### PR DESCRIPTION
Replace the use of versionTupleToString with version_tuple_to_string to fix a bug introduced by a previous change.