### PR TITLE
Update the keras version used by tf 2.6 release

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -103,7 +103,7 @@ REQUIRED_PACKAGES = [
     # When updating these, please also update the nightly versions below
     'tensorboard ~= 2.6',
     'tensorflow_estimator < 2.7',
-    'keras ~= 2.6',
+    'keras >= 2.6.0, < 2.7',
 ]
 
 


### PR DESCRIPTION
Since Keras 2.7 is not compatible with tf 2.6, we should limit the Keras version used in tf.

This change has been done for tf 2.7 and all the future releases.