### PR TITLE
[TF:TRT] Enable support for TensorRT 8.2

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -28,15 +28,15 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "absl/algorithm/container.h"
+#include "absl/base/call_once.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 #include "tensorflow/cc/ops/nn_ops_internal.h"
@@ -66,6 +66,8 @@ limitations under the License.
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/protobuf/config.pb.h"  // NOLINT
 #include "tensorflow/core/public/session.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/tensorrt/NvInfer.h"
 
 namespace tensorflow {
@@ -141,6 +143,27 @@ void ValidateWeights(const TRT_ShapedWeights& weights,
   for (int i = 0; i < expected_value.size(); ++i) {
     EXPECT_EQ(expected_value[i], actual_values[i]);
   }
+}
+
+// TRT >= 8.2 optimizes memory management in the builder. When all builders
+// are destroyed, it unloads many resources. This test fixture will create and
+// destroy hundreds of builders when run sequentially for parameterized
+// tests. We can hold open an IBuilder in order to prevent TRT from unloading
+// shared resources between engine builds when using TRT shared library. This
+// greatly speeds up unit tests and is safe to do.
+void PreventUnloadBuilderResources() {
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
+  static thread_local absl::once_flag once;
+  static TrtUniquePtrType<nvinfer1::IBuilder> hold_builder = nullptr;
+  absl::call_once(
+      once,
+      [](std::unique_ptr<nvinfer1::IBuilder>& builder) {
+        if (!builder) {
+          builder.reset(nvinfer1::createInferBuilder(*Logger::GetLogger()));
+        }
+      },
+      hold_builder);
+#endif
 }
 
 TEST(TRT_ShapedWeights_Test, Basic) {
@@ -273,6 +296,7 @@ TEST(TRT_TensorOrWeights_Test, Basic) {
 
 class ValidatorTest : public ::testing::Test {
  public:
+  ValidatorTest() { PreventUnloadBuilderResources(); }
   Status ConvertToTensorOrWeights(const Scope& scope, const Node* node,
                                   int output_port,
                                   TRT_TensorOrWeights* tensor_or_weights) {
@@ -487,7 +511,10 @@ TEST(TrtNodeValidator, IsTensorRTCandidate) {
 
 class ConverterTest : public ::testing::Test {
  public:
-  ConverterTest() { Reset(); }
+  ConverterTest() {
+    PreventUnloadBuilderResources();
+    Reset();
+  }
 
   void Reset() {
     GetOpConverterRegistry()->Clear("MyOp");
@@ -1083,6 +1110,7 @@ std::vector<float> GetDataAsFloat(InputOutputData& data) {
 
   return {};
 }
+
 // Class to test various op converters, using both a TrtNodeValidator and
 // Converter.
 class OpConverterTest : public ::testing::Test {
@@ -1090,6 +1118,7 @@ class OpConverterTest : public ::testing::Test {
   OpConverterTest()
       : tensor_buffer_allocator_(new GpuManagedAllocator()),
         scope_(Scope::NewRootScope()) {
+    PreventUnloadBuilderResources();
     QCHECK_EQ(0, cudaStreamCreate(&stream_));
     Reset();
   }

--- a/tensorflow/compiler/tf2tensorrt/stub/NvInferPlugin_8_2.inc
+++ b/tensorflow/compiler/tf2tensorrt/stub/NvInferPlugin_8_2.inc
@@ -1,0 +1,95 @@
+// Auto-generated, do not edit.
+
+extern "C" {
+
+nvinfer1::IPluginV2* createRPNROIPlugin(int featureStride, int preNmsTop,
+                                        int nmsMaxOut, float iouThreshold,
+                                        float minBoxSize, float spatialScale,
+                                        nvinfer1::DimsHW pooling,
+                                        nvinfer1::Weights anchorRatios,
+                                        nvinfer1::Weights anchorScales) {
+  using FuncPtr = nvinfer1::IPluginV2 * ( *)(int, int, int, float, float, float, nvinfer1::DimsHW, nvinfer1::Weights, nvinfer1::Weights);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createRPNROIPlugin");
+  if (!func_ptr) LogFatalSymbolNotFound("createRPNROIPlugin");
+  return func_ptr(featureStride, preNmsTop, nmsMaxOut, iouThreshold, minBoxSize, spatialScale, pooling, anchorRatios, anchorScales);
+}
+
+nvinfer1::IPluginV2* createNormalizePlugin(const nvinfer1::Weights* scales,
+                                           bool acrossSpatial,
+                                           bool channelShared, float eps) {
+  using FuncPtr = nvinfer1::IPluginV2 * ( *)(const nvinfer1::Weights *, bool, bool, float);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createNormalizePlugin");
+  if (!func_ptr) LogFatalSymbolNotFound("createNormalizePlugin");
+  return func_ptr(scales, acrossSpatial, channelShared, eps);
+}
+
+nvinfer1::IPluginV2* createPriorBoxPlugin(
+    nvinfer1::plugin::PriorBoxParameters param) {
+  using FuncPtr = nvinfer1::IPluginV2 * ( *)(nvinfer1::plugin::PriorBoxParameters);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createPriorBoxPlugin");
+  if (!func_ptr) LogFatalSymbolNotFound("createPriorBoxPlugin");
+  return func_ptr(param);
+}
+
+nvinfer1::IPluginV2* createAnchorGeneratorPlugin(
+    nvinfer1::plugin::GridAnchorParameters* param, int numLayers) {
+  using FuncPtr = nvinfer1::IPluginV2 * ( *)(nvinfer1::plugin::GridAnchorParameters *, int);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createAnchorGeneratorPlugin");
+  if (!func_ptr) LogFatalSymbolNotFound("createAnchorGeneratorPlugin");
+  return func_ptr(param, numLayers);
+}
+
+nvinfer1::IPluginV2* createNMSPlugin(
+    nvinfer1::plugin::DetectionOutputParameters param) {
+  using FuncPtr = nvinfer1::IPluginV2 * ( *)(nvinfer1::plugin::DetectionOutputParameters);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createNMSPlugin");
+  if (!func_ptr) LogFatalSymbolNotFound("createNMSPlugin");
+  return func_ptr(param);
+}
+
+nvinfer1::IPluginV2* createLReLUPlugin(float negSlope) {
+  using FuncPtr = nvinfer1::IPluginV2 * ( *)(float);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createLReLUPlugin");
+  if (!func_ptr) LogFatalSymbolNotFound("createLReLUPlugin");
+  return func_ptr(negSlope);
+}
+
+nvinfer1::IPluginV2* createReorgPlugin(int stride) {
+  using FuncPtr = nvinfer1::IPluginV2 * ( *)(int);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createReorgPlugin");
+  if (!func_ptr) LogFatalSymbolNotFound("createReorgPlugin");
+  return func_ptr(stride);
+}
+
+nvinfer1::IPluginV2* createRegionPlugin(
+    nvinfer1::plugin::RegionParameters params) {
+  using FuncPtr = nvinfer1::IPluginV2 * ( *)(nvinfer1::plugin::RegionParameters);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createRegionPlugin");
+  if (!func_ptr) LogFatalSymbolNotFound("createRegionPlugin");
+  return func_ptr(params);
+}
+
+nvinfer1::IPluginV2* createClipPlugin(const char* layerName, float clipMin,
+                                      float clipMax) {
+  using FuncPtr = nvinfer1::IPluginV2 * ( *)(const char *, float, float);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createClipPlugin");
+  if (!func_ptr) LogFatalSymbolNotFound("createClipPlugin");
+  return func_ptr(layerName, clipMin, clipMax);
+}
+
+nvinfer1::IPluginV2* createBatchedNMSPlugin(
+    nvinfer1::plugin::NMSParameters param) {
+  using FuncPtr = nvinfer1::IPluginV2 * ( *)(nvinfer1::plugin::NMSParameters);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createBatchedNMSPlugin");
+  if (!func_ptr) LogFatalSymbolNotFound("createBatchedNMSPlugin");
+  return func_ptr(param);
+}
+
+bool initLibNvInferPlugins(void* logger, const char* libNamespace) {
+  using FuncPtr = bool ( *)(void *, const char *);
+  static auto func_ptr = LoadSymbol<FuncPtr>("initLibNvInferPlugins");
+  if (!func_ptr) LogFatalSymbolNotFound("initLibNvInferPlugins");
+  return func_ptr(logger, libNamespace);
+}
+
+}  // extern "C"

--- a/tensorflow/compiler/tf2tensorrt/stub/NvInfer_8_2.inc
+++ b/tensorflow/compiler/tf2tensorrt/stub/NvInfer_8_2.inc
@@ -1,0 +1,48 @@
+// Auto-generated, do not edit.
+
+extern "C" {
+
+void* createInferBuilder_INTERNAL(void* logger, int version) noexcept {
+  using FuncPtr = void * (*)(void *, int);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createInferBuilder_INTERNAL");
+  if (!func_ptr) LogFatalSymbolNotFound("createInferBuilder_INTERNAL");
+  return func_ptr(logger, version);
+}
+
+void* createInferRefitter_INTERNAL(void* engine, void* logger,
+                                   int version) noexcept {
+  using FuncPtr = void* (*)(void*, void*, int);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createInferRefitter_INTERNAL");
+  if (!func_ptr) LogFatalSymbolNotFound("createInferRefitter_INTERNAL");
+  return func_ptr(engine, logger, version);
+}
+
+void* createInferRuntime_INTERNAL(void* logger, int version) noexcept {
+  using FuncPtr = void * (*)(void *, int);
+  static auto func_ptr = LoadSymbol<FuncPtr>("createInferRuntime_INTERNAL");
+  if (!func_ptr) LogFatalSymbolNotFound("createInferRuntime_INTERNAL");
+  return func_ptr(logger, version);
+}
+
+nvinfer1::ILogger* getLogger() noexcept {
+  using FuncPtr = nvinfer1::ILogger * (*)();
+  static auto func_ptr = LoadSymbol<FuncPtr>("getLogger");
+  if (!func_ptr) LogFatalSymbolNotFound("getLogger");
+  return func_ptr();
+}
+
+int getInferLibVersion() noexcept {
+  using FuncPtr = int (*)();
+  static auto func_ptr = LoadSymbol<FuncPtr>("getInferLibVersion");
+  if (!func_ptr) LogFatalSymbolNotFound("getInferLibVersion");
+  return func_ptr();
+}
+
+nvinfer1::IPluginRegistry* getPluginRegistry() noexcept {
+  using FuncPtr = nvinfer1::IPluginRegistry * (*)();
+  static auto func_ptr = LoadSymbol<FuncPtr>("getPluginRegistry");
+  if (!func_ptr) LogFatalSymbolNotFound("getPluginRegistry");
+  return func_ptr();
+}
+
+}  // extern "C"

--- a/tensorflow/compiler/tf2tensorrt/stub/nvinfer_plugin_stub.cc
+++ b/tensorflow/compiler/tf2tensorrt/stub/nvinfer_plugin_stub.cc
@@ -60,6 +60,8 @@ void LogFatalSymbolNotFound(const char* symbol_name) {
 #include "tensorflow/compiler/tf2tensorrt/stub/NvInferPlugin_7_2.inc"
 #elif NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR == 0
 #include "tensorflow/compiler/tf2tensorrt/stub/NvInferPlugin_8_0.inc"
+#elif NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR == 2
+#include "tensorflow/compiler/tf2tensorrt/stub/NvInferPlugin_8_2.inc"
 #else
 #error This version of TensorRT is not supported.
 #endif

--- a/tensorflow/compiler/tf2tensorrt/stub/nvinfer_stub.cc
+++ b/tensorflow/compiler/tf2tensorrt/stub/nvinfer_stub.cc
@@ -60,6 +60,8 @@ void LogFatalSymbolNotFound(const char* symbol_name) {
 #include "tensorflow/compiler/tf2tensorrt/stub/NvInfer_7_2.inc"
 #elif NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR == 0
 #include "tensorflow/compiler/tf2tensorrt/stub/NvInfer_8_0.inc"
+#elif NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR == 2
+#include "tensorflow/compiler/tf2tensorrt/stub/NvInfer_8_2.inc"
 #else
 #error This version of TensorRT is not supported.
 #endif


### PR DESCRIPTION
Add support for TensorRT 8.2.

Add plugin stubs for TensorRT 8.2.
Modify tests to hold an IBuilder to prevent TensorRT 8.2 from releasing builder resources when running parameterized tests.