### PR TITLE
[TF-TRT] Add DataFormatVecPermute converter

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -576,6 +576,7 @@ tf_cuda_library(
     srcs = [
         "convert/convert_graph.cc",
         "convert/convert_nodes.cc",
+        "convert/ops/data_format_vec_permute.cc",
         "convert/ops/slice_ops.cc",
         "convert/trt_optimization_pass.cc",
     ],

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -28,6 +28,7 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "absl/algorithm/container.h"
 #include "absl/base/call_once.h"
 #include "absl/strings/match.h"
@@ -36,8 +37,6 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 #include "tensorflow/cc/ops/nn_ops_internal.h"
@@ -67,6 +66,8 @@ limitations under the License.
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/protobuf/config.pb.h"  // NOLINT
 #include "tensorflow/core/public/session.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/tensorrt/NvInfer.h"
 
 namespace tensorflow {
@@ -1763,6 +1764,8 @@ class OpConverter_FP32_FP16_Test : public ParameterizedOpConverterTestBase {};
 // Base class for tests that need to be tested for FP32, FP16, and INT32
 class OpConverter_FP32_FP16_INT32_Test
     : public ParameterizedOpConverterTestBase {};
+// Base class for tests that need to be tested for INT32
+class OpConverter_INT32_Test : public ParameterizedOpConverterTestBase {};
 
 // Instantiate parameter combinations to OpConverter_<DT_X...>_Test
 INSTANTIATE_TEST_CASE_P(
@@ -1781,6 +1784,12 @@ INSTANTIATE_TEST_CASE_P(
     OpConvTestInstantiation, OpConverter_FP32_FP16_INT32_Test,
     ::testing::Combine(::testing::ValuesIn(ValidTrtModes),
                        ::testing::Values(DT_FLOAT, DT_HALF, DT_INT32),
+                       ::testing::Values(TrtPrecisionMode::FP32)));
+
+INSTANTIATE_TEST_CASE_P(
+    OpConvTestInstantiation, OpConverter_INT32_Test,
+    ::testing::Combine(::testing::ValuesIn(ValidTrtModes),
+                       ::testing::Values(DT_INT32),
                        ::testing::Values(TrtPrecisionMode::FP32)));
 
 template <typename T>
@@ -5917,6 +5926,180 @@ TEST_P(OpConverter_FP32_FP16_Test, ConvertTopK) {
                             Status::OK(), Status::OK(),
                             {ElementsAre(6, 5, 7, 1), ElementsAre(4, 2, 1, 2)},
                             {tf_type_, DT_INT32});
+  }
+}
+
+struct DataFormatVecPermuteTestParams {
+  string dst_format;
+  string src_format;
+  std::vector<int> x_shape;
+  std::vector<int> x;
+  bool x_is_tensor;
+  std::vector<int> expected_output;
+  Status conversion_status;
+};
+
+NodeDef GetDataFormatVecPermuteNodeDef(string dst_format, string src_format,
+                                       std::vector<int>& x_shape) {
+  Scope s = Scope::NewRootScope();
+  PartialTensorShape tensor_shape;
+  auto x = ops::Placeholder(s.WithOpName("x"), DT_INT32);
+  const auto attrs = ops::DataFormatVecPermute::Attrs()
+                         .DstFormat(dst_format)
+                         .SrcFormat(src_format);
+  auto dfvp = ops::DataFormatVecPermute(s.WithOpName("my_dfvp"), x, attrs);
+  return dfvp.operation.node()->def();
+}
+
+TEST_P(OpConverter_INT32_Test, ConvertDataFormatVecPermute) {
+  Status implicit_error = Status{
+      error::UNIMPLEMENTED, "Implicit batch mode not supported, at my_dfvp"};
+
+  std::vector<DataFormatVecPermuteTestParams> test_params = {
+      // 1D case with tensor.
+      DataFormatVecPermuteTestParams{
+          /*dst_format=*/"NCHW",
+          /*src_format=*/"NHWC",
+          /*x_shape=*/{4},
+          /*x=*/{1, 2, 3, 4},
+          /*x_is_tensor=*/true,
+          /*expected_output=*/{1, 4, 2, 3},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+              ? implicit_error
+              : Status::OK()},
+      // 1D case with weights.
+      DataFormatVecPermuteTestParams{
+          /*dst_format=*/"NCHW",
+          /*src_format=*/"NHWC",
+          /*x_shape=*/{4},
+          /*x=*/{1, 2, 3, 4},
+          /*x_is_tensor=*/false,
+          /*expected_output=*/{1, 4, 2, 3},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+              ? implicit_error
+              : Status::OK()},
+      // 2D case with tensor.
+      DataFormatVecPermuteTestParams{
+          /*dst_format=*/"NCHW",
+          /*src_format=*/"NHWC",
+          /*x_shape=*/{4, 2},
+          /*x=*/{1, 2, 3, 4, 5, 6, 7, 8},
+          /*x_is_tensor=*/true,
+          /*expected_output=*/{1, 2, 7, 8, 3, 4, 5, 6},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+              ? implicit_error
+              : Status::OK()},
+      // 2D case with weights.
+      DataFormatVecPermuteTestParams{
+          /*dst_format=*/"NCHW",
+          /*src_format=*/"NHWC",
+          /*x_shape=*/{4, 2},
+          /*x=*/{1, 2, 3, 4, 5, 6, 7, 8},
+          /*x_is_tensor=*/false,
+          /*expected_output=*/{1, 2, 7, 8, 3, 4, 5, 6},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+              ? implicit_error
+              : Status::OK()},
+      // Format of size 5.
+      DataFormatVecPermuteTestParams{
+          /*dst_format=*/"NCDHW",
+          /*src_format=*/"NDHWC",
+          /*x_shape=*/{5, 2},
+          /*x=*/{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+          /*x_is_tensor=*/true,
+          /*expected_output=*/{1, 2, 9, 10, 3, 4, 5, 6, 7, 8},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+              ? implicit_error
+              : Status::OK()},
+      // Input of size 2: treat the elements as spatial dimensions.
+      DataFormatVecPermuteTestParams{
+          /*dst_format=*/"NCWH",
+          /*src_format=*/"NHWC",
+          /*x_shape=*/{2, 2},
+          /*x=*/{1, 2, 3, 4},
+          /*x_is_tensor=*/true,
+          /*expected_output=*/{3, 4, 1, 2},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+              ? implicit_error
+              : Status::OK()},
+      // Input of size 3: treat the elements as spatial dimensions.
+      DataFormatVecPermuteTestParams{
+          /*dst_format=*/"NCHWD",
+          /*src_format=*/"NDHWC",
+          /*x_shape=*/{3},
+          /*x=*/{1, 2, 3},
+          /*x_is_tensor=*/true,
+          /*expected_output=*/{2, 3, 1},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+              ? implicit_error
+              : Status::OK()},
+      // Invalid rank, should fail.
+      DataFormatVecPermuteTestParams{
+          /*dst_format=*/"NCHW",
+          /*src_format=*/"NHWC",
+          /*x_shape=*/{2, 2, 2},
+          /*x=*/{1, 2, 3, 4, 5, 6, 7, 8},
+          /*x_is_tensor=*/true,
+          /*expected_output=*/{},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+              ? implicit_error
+              : Status{error::INVALID_ARGUMENT,
+                       "Input must be a vector or matrix, but got rank 3, at "
+                       "my_dfvp"}},
+      // Invalid size for 1D input, should fail.
+      DataFormatVecPermuteTestParams{
+          /*dst_format=*/"NCHW",
+          /*src_format=*/"NHWC",
+          /*x_shape=*/{3},
+          /*x=*/{1, 2, 3},
+          /*x_is_tensor=*/true,
+          /*expected_output=*/{},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+              ? implicit_error
+              : Status{error::INVALID_ARGUMENT,
+                       "1D input must be of size 2 or 4, but got size 3, at "
+                       "my_dfvp"}},
+      // Invalid first dim for 2D input, should fail.
+      DataFormatVecPermuteTestParams{
+          /*dst_format=*/"NCDHW",
+          /*src_format=*/"NDHWC",
+          /*x_shape=*/{4, 2},
+          /*x=*/{1, 2, 3, 4, 5, 6, 7, 8},
+          /*x_is_tensor=*/true,
+          /*expected_output=*/{},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+              ? implicit_error
+              : Status{error::INVALID_ARGUMENT,
+                       "First dimension of 2D input must be of size 3 or 5, "
+                       "but got shape (4, 2), at my_dfvp"}},
+      // Invalid second dim for 2D input, should fail.
+      DataFormatVecPermuteTestParams{
+          /*dst_format=*/"NCHW",
+          /*src_format=*/"NHWC",
+          /*x_shape=*/{4, 3},
+          /*x=*/{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+          /*x_is_tensor=*/true,
+          /*expected_output=*/{},
+          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
+              ? implicit_error
+              : Status{error::INVALID_ARGUMENT,
+                       "Second dimension of 2D input must be of size 2, but "
+                       "got shape (4, 3), at my_dfvp"}},
+  };
+
+  for (auto p : test_params) {
+    Reset();
+    const NodeDef node_def =
+        GetDataFormatVecPermuteNodeDef(p.dst_format, p.src_format, p.x_shape);
+
+    if (p.x_is_tensor) {
+      AddTestTensor("x", p.x_shape, DT_INT32, p.x, p.x_shape);
+    } else {
+      AddTestWeights("x", p.x_shape, p.x, DT_INT32);
+    }
+
+    TestOpConverter("my_dfvp", node_def, p.x_shape, p.conversion_status,
+                    Status::OK(), ElementsAreArray(p.expected_output));
   }
 }
 

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/data_format_vec_permute.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/data_format_vec_permute.cc
@@ -1,0 +1,185 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+#include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "third_party/tensorrt/NvInfer.h"
+#include "third_party/tensorrt/NvInferRuntimeCommon.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+int get_spatial_dim_count(string format) {
+  // Spatial dimensions are the dimensions besides NC, and here we assume NC
+  // always appear in the format string.
+  return format.size() - 2;
+}
+
+class ConvertDataFormatVecPermute
+    : public OpConverterBase<ConvertDataFormatVecPermute> {
+ public:
+  ConvertDataFormatVecPermute(OpConverterParams* params)
+      : OpConverterBase<ConvertDataFormatVecPermute>(params) {}
+
+  struct DataFormatVecPermuteAttributes {
+    string dst_format;
+    string src_format;
+    int x_dim_count;
+  };
+
+  static constexpr std::array<InputArgSpec, 1> InputSpec() {
+    return {InputArgSpec::Create("x", TrtInputArg::kBoth)};
+  }
+
+  static constexpr std::array<DataType, 1> AllowedDataTypes() {
+    return {DataType::DT_INT32};
+  }
+
+  Status Validate() {
+    const auto& inputs = params_->inputs;
+    const auto& node_def = params_->node_def;
+
+    if (params_->use_implicit_batch) {
+      return errors::Unimplemented("Implicit batch mode not supported, at ",
+                                   node_def.name());
+    }
+
+    x_input_ = inputs.at(0);
+
+    // Check input rank.
+    const auto x_dims = x_input_.GetTrtDims();
+    int input_rank = x_dims.nbDims;
+    if (input_rank != 1 && input_rank != 2) {
+      return errors::InvalidArgument(
+          "Input must be a vector or matrix, but got rank ", input_rank,
+          ", at ", node_def.name());
+    }
+
+    // Verify and consume node attributes.
+    StatusOr<string> dst_format = GetAttrValue<string>("dst_format");
+    StatusOr<string> src_format = GetAttrValue<string>("src_format");
+    TRT_ENSURE_OK(dst_format);
+    TRT_ENSURE_OK(src_format);
+
+    // Check input dims.
+    const int full_dim_count = src_format->size();
+    const int spatial_dim_count = get_spatial_dim_count(*src_format);
+    if (input_rank == 1) {
+      if (x_dims.d[0] != spatial_dim_count && x_dims.d[0] != full_dim_count) {
+        return errors::InvalidArgument("1D input must be of size ",
+                                       spatial_dim_count, " or ",
+                                       full_dim_count, ", but got size ",
+                                       x_dims.d[0], ", at ", node_def.name());
+      }
+    } else if (input_rank == 2) {
+      if (x_dims.d[0] != spatial_dim_count && x_dims.d[0] != full_dim_count) {
+        return errors::InvalidArgument(
+            "First dimension of 2D input must be of size ", spatial_dim_count,
+            " or ", full_dim_count, ", but got shape (", x_dims.d[0], ", ",
+            x_dims.d[1], "), at ", node_def.name());
+      }
+      if (x_dims.d[1] != 2) {
+        return errors::InvalidArgument(
+            "Second dimension of 2D input must be of size 2, but got shape (",
+            x_dims.d[0], ", ", x_dims.d[1], "), at ", node_def.name());
+      }
+    }
+
+    // Set custom attributes.
+    attrs_.x_dim_count = x_dims.d[0];
+    attrs_.dst_format = *dst_format;
+    attrs_.src_format = *src_format;
+
+    return Status::OK();
+  }
+
+  Status Convert() {
+    const auto& node_def = params_->node_def;
+
+    // Copy format strings in case they need to be modified.
+    string dst_format = attrs_.dst_format;
+    string src_format = attrs_.src_format;
+    const int& spatial_dim_count = get_spatial_dim_count(src_format);
+
+    // If the input is a vector of size spatial_dim_count, treat the elements
+    // as spatial dimensions.
+    if (attrs_.x_dim_count == spatial_dim_count) {
+      auto keep_only_spatial_dimensions =
+          [spatial_dim_count](string* format_str) -> void {
+        auto new_end = std::remove_if(format_str->begin(), format_str->end(),
+                                      [spatial_dim_count](const char dim) {
+                                        return dim == 'N' || dim == 'C';
+                                      });
+        format_str->erase(new_end, format_str->end());
+      };
+      keep_only_spatial_dimensions(&src_format);
+      keep_only_spatial_dimensions(&dst_format);
+    }
+
+    // Create indices for the gather layer and make weights out of them.
+    std::vector<int32> dst_indices(attrs_.x_dim_count);
+    for (int i = 0; i < attrs_.x_dim_count; ++i) {
+      for (int j = 0; j < attrs_.x_dim_count; ++j) {
+        if (src_format[i] == dst_format[j]) {
+          dst_indices[j] = i;
+          break;
+        }
+      }
+    }
+    nvinfer1::Dims indices_dims = {1, {attrs_.x_dim_count}};
+    auto indices_weights = params_->weight_store->GetTempWeights(
+        nvinfer1::DataType::kINT32, indices_dims);
+    int32* indices_ptr = indices_weights.GetPointer<int32>();
+    std::copy(dst_indices.data(), dst_indices.data() + attrs_.x_dim_count,
+              indices_ptr);
+
+    ITensorProxyPtr x_tensor =
+        x_input_.is_weights() ? params_->converter->CreateConstantLayer(
+                                    x_input_.weights(), x_input_.GetTrtDims())
+                              : x_input_.tensor();
+    ITensorProxyPtr indices_tensor =
+        params_->converter->CreateConstantLayer(indices_weights, indices_dims);
+
+    // Gather layer with 1D indices on axis 0, conserves shape.
+    nvinfer1::IGatherLayer* layer = params_->converter->network()->addGather(
+        *x_tensor->trt_tensor(), *indices_tensor->trt_tensor(), 0);
+    TRT_ENSURE(layer);
+    params_->converter->SetLayerName(layer, node_def);
+
+    ITensorProxyPtr output_tensor = layer->getOutput(0);
+
+    params_->outputs->push_back(TRT_TensorOrWeights(output_tensor));
+    return Status::OK();
+  }
+
+ private:
+  TRT_TensorOrWeights x_input_;
+  DataFormatVecPermuteAttributes attrs_{};
+};
+REGISTER_DEFAULT_TRT_OP_CONVERTER(
+    MakeConverterFunction<ConvertDataFormatVecPermute>(),
+    {"DataFormatVecPermute"});
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -39,7 +39,7 @@ from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_resource_variable_ops
-from tensorflow.python.ops import nn_ops
+from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 from tensorflow.python.saved_model import builder
@@ -481,7 +481,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
 
   @test_util.run_v2_only
   def testTrtGraphConverter_ShapeOp_Int32InputOutput_v2(self):
-    """Testing ShapeOp and int32 values as engine input and outpu."""
+    """Testing ShapeOp and int32 values as engine input and output."""
 
     class ShapeOpModel(tracking.AutoTrackable):
 
@@ -497,8 +497,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
         # Add an OP that is not supported by TF-TRT. This allows TF-TRT to build
         # two engines. The first engine produces an int32 output and the second
         # engines has an int32 input and an int32 output.
-        q = nn_ops.data_format_vec_permute(
-            q_shape, src_format="NHWC", dst_format="NCHW")
+        q = math_ops.cumsum(q_shape)
         q = q * 2
         return array_ops.identity(q, name="output")
 


### PR DESCRIPTION
Adds a TF-TRT converter for the [DataFormatVecPermute](https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/data-format-vec-permute) operation.

Example of a model which can benefit from this: Inception v4 with dynamic shapes (2 candidate segments previously, 1 with this change).