### PR TITLE
 [TF-TRT] Allow saving calibration cache without the engine pre-built

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,6 +25,10 @@
         favor of direct arguments: `max_workspace_size_bytes`, `precision_mode`,
         `minimum_segment_size`, `maximum_cached_engines`, `use_calibration` and
         `allow_build_at_runtime`.
+    *   Added a new parameter called `save_gpu_specific_engines` to the `.save()` 
+        function inside `TrtGraphConverterV2`. When `False`, the `.save()` function
+        won't save any TRT engines that have been built. When `True` (default), the
+        original behavior is preserved.
 
 *   <INSERT MAJOR FEATURE HERE, USING MARKDOWN SYNTAX>
 

--- a/tensorflow/compiler/tf2tensorrt/ops/trt_engine_resource_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/ops/trt_engine_resource_ops.cc
@@ -38,6 +38,7 @@ REGISTER_OP("InitializeTRTResource")
 
 REGISTER_OP("SerializeTRTResource")
     .Attr("delete_resource: bool = false")
+    .Attr("save_gpu_specific_engines: bool = True")
     .Input("resource_name: string")
     .Input("filename: string")
     .SetIsStateful()

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -1281,11 +1281,17 @@ class TrtGraphConverterV2(object):
 
     self._build_called_once = True
 
-  def save(self, output_saved_model_dir):
+  def save(self, output_saved_model_dir, save_gpu_specific_engines=True):
     """Save the converted SavedModel.
 
     Args:
       output_saved_model_dir: directory to saved the converted SavedModel.
+      save_gpu_specific_engines: whether to save TRT engines that have been
+        built. When True, all engines are saved and when False, the engines 
+        are not saved and will be rebuilt at inference time. By using
+        save_gpu_specific_engines=False after doing INT8 calibration, inference 
+        can be done on different GPUs than the GPU that the model was calibrated
+        and saved on.
     """
     assert self._converted
 
@@ -1308,7 +1314,8 @@ class TrtGraphConverterV2(object):
         gen_trt_ops.serialize_trt_resource(
             resource_name=canonical_engine_name,
             filename=filename,
-            delete_resource=True)
+            delete_resource=True,
+            save_gpu_specific_engines=save_gpu_specific_engines)
       except errors.NotFoundError:
         logging.info(
             "Could not find %s in TF-TRT cache. "

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -990,6 +990,61 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     self.assertAllClose(
         np.asarray([5.0, 5.0, 5.0, 5.0]).reshape([4, 1, 1]), output)
 
+  @parameterized.named_parameters([
+      ("SaveGPUSpecificEngine", True),
+      ("WithoutSaveGPUSpecificEngine", False),
+  ])
+  @test_util.run_v2_only
+  def testTrtGraphConverter_SaveGPUSpecificEngine(self, save_engine_flag):
+    """Test case for trt_convert.TrtGraphConverter()."""
+
+    np_input1, np_input2 = self._RandomInput([4, 1, 1])
+
+    # Create a model and save it.
+    input_saved_model_dir = self.mkdtemp()
+    root = self._GetModelForV2()
+    save.save(root, input_saved_model_dir,
+              {_SAVED_MODEL_SIGNATURE_KEY: root.run})
+
+    # Run TRT conversion.
+    converter = self._CreateConverterV2(
+      input_saved_model_dir,
+      precision_mode=trt_convert.TrtPrecisionMode.INT8)
+
+    # Run the converted function to populate the engine cache.
+    def CalibrationFn():
+      yield np_input1, np_input2
+
+    converter.convert(calibration_input_fn=CalibrationFn)
+
+    # Verify the converted GraphDef and ConcreteFunction.
+    self._CheckTrtOps(converter._converted_func)
+
+    trt_engine_name = self._GetUniqueTRTEngineOp(
+        converter._converted_graph_def).name
+
+    # Save the converted model with or without any TRT engine cache
+    # based on the value of save_engine_flag.
+    output_saved_model_dir = self.mkdtemp()
+
+    converter.save(
+      output_saved_model_dir,
+      save_gpu_specific_engines=save_engine_flag)
+
+    expected_asset_file = os.path.join(
+        output_saved_model_dir,
+        "assets/trt-serialized-engine." + trt_engine_name)
+
+    self.assertTrue(os.path.exists(expected_asset_file))
+    if save_engine_flag:
+      # engine is saved so we expect engine data
+      self.assertTrue(os.path.getsize(expected_asset_file))
+    else:
+      # engine is not saved so files should be empty
+      self.assertFalse(os.path.getsize(expected_asset_file))
+
+    del converter
+    gc.collect()  # Force GC to destroy the TRT engine cache.
 
 if __name__ == "__main__" and is_tensorrt_enabled():
   test.main()

--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
@@ -16,6 +16,6 @@ tf_class {
   }
   member_method {
     name: "save"
-    argspec: "args=[\'self\', \'output_saved_model_dir\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'self\', \'output_saved_model_dir\', \'save_gpu_specific_engines\'], varargs=None, keywords=None, defaults=[\'True\'], "
   }
 }


### PR DESCRIPTION
@bixia1 for review
@tfeher @DEKHTIARJonathan CC

This PR does the following:

- Adds a new parameter called save_gpu_specific_engine inside the `TRTGraphConverterV2.save()` function. 
  - When `True` (default), the `.save()` function executes normally. 

  - When `False`, the `.save()` will not save any of the TRT engines that have been built. I.e. any engines that are built during `TRTGraphConverterV2.build()` or during INT8 calibration will not be saved.

- This change allows us to reuse calibration tables generated during calibration with a different GPU. Therefore only the need to rebuild the engines, not to recalibrate.
  - Originally, when we reloaded INT8 models we would receive an error when we tried to do inference on GPUs that were not similar to the GPUs that calibration was performed on.
  - When we reload INT8 models that are saved with `save_gpu_specific_engine=False`, a new engine will be built using the saved calibration tables (assuming calibration was done before saving). 
  - Thus when `using save_gpu_specific_engine=False` we are able to run inference in INT8 on different GPUs, without having to re-calibrate during runtime.
