### PR TITLE
CI: Use Python 3.9 for PyLint presubmit action

### DIFF
--- a/.github/workflows/pylint-presubmit.yml
+++ b/.github/workflows/pylint-presubmit.yml
@@ -34,10 +34,10 @@ jobs:
     - name: Report list of changed files
       run: |
         echo Changed files: ${{ steps.get_file_changes.outputs.files }}
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.9"
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
A few small maintenance updates to the PyLint presubmit action.
 - Use Python 3.9 instead of Python 3.8.
 - Update the [setup-python](https://github.com/actions/setup-python) action to v2, which is actively maintained.
 - Parse the Python version as a string (`"3.9"` instead of `3.9`), since otherwise Python 3.10 will be rounded and processed as Python 3.1 in the future.