### PR TITLE
Add NVIDIA/TensorRT repo to third_party/tensorrt

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -66,7 +66,9 @@ alias(
 tf_cuda_cc_test(
     name = "tensorrt_test_cc",
     size = "small",
-    srcs = ["tensorrt_test.cc"],
+    srcs = [
+        "tensorrt_test.cc",
+    ],
     tags = [
         "no_windows",
         "nomac",
@@ -81,7 +83,7 @@ tf_cuda_cc_test(
         "//tensorflow/core:test_main",
     ] + if_tensorrt([
         ":tensorrt_lib",
-        "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_tensorrt//:nvinfer_plugin_nms",
     ]),
 )
 

--- a/tensorflow/compiler/tf2tensorrt/tensorrt_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/tensorrt_test.cc
@@ -12,19 +12,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+#include <functional>
+#include <numeric>
+#include <stack>
 
+#include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"
 #include "tensorflow/core/common_runtime/gpu/gpu_init.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/platform/test.h"
-
-#if GOOGLE_CUDA && GOOGLE_TENSORRT
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
-#include "tensorflow/compiler/tf2tensorrt/common/utils.h"
-#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
-#include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"
 #include "third_party/tensorrt/NvInfer.h"
+#include "third_party/tensorrt/NvInferPlugin.h"
+#include "third_party/tensorrt/NvInferRuntimeCommon.h"
+#include "third_party/tensorrt/nvinfer_plugin_nms/efficientNMSPlugin.h"
 
 namespace tensorflow {
 namespace tensorrt {
@@ -43,9 +48,59 @@ class ScopedWeights {
   nvinfer1::Weights w;
 };
 
+class ScopedShapedWeights {
+ public:
+  ScopedShapedWeights(nvinfer1::Dims dims, float value)
+      : dims_(dims),
+        value_(std::accumulate(dims.d, dims.d + dims.nbDims, 1,
+                               std::multiplies<>()),
+               value) {
+    w.type = nvinfer1::DataType::kFLOAT;
+    w.values = value_.data();
+    w.count = value_.size();
+  }
+
+  nvinfer1::Dims dims_;
+  std::vector<float> value_;
+  nvinfer1::Weights w;
+};
+
 const char* kInputTensor1 = "input1";
 const char* kInputTensor2 = "input2";
-const char* kOutputTensor = "output";
+const char* kOutputTensor1 = "output";
+const char* kOutputTensor2 = "output-nms";
+
+std::unique_ptr<nvinfer1::plugin::EfficientNMSPluginCreator>
+MakeNMSPluginCreator(const std::string& plugin_namespace = "tftrt") {
+  auto pluginCreator =
+      std::make_unique<nvinfer1::plugin::EfficientNMSPluginCreator>();
+  pluginCreator->setPluginNamespace(plugin_namespace.c_str());
+  std::string pluginType = std::string{pluginCreator->getPluginNamespace()} +
+                           "::" + std::string{pluginCreator->getPluginName()} +
+                           " version " +
+                           std::string{pluginCreator->getPluginVersion()};
+  VLOG(0) << "Created plugin type " << pluginType;
+  return pluginCreator;
+}
+
+struct PluginDeleter {
+  void operator()(nvinfer1::IPluginV2* t);
+};
+
+void PluginDeleter::operator()(nvinfer1::IPluginV2* t) { t->destroy(); }
+
+std::unique_ptr<nvinfer1::IPluginV2, PluginDeleter> createPlugin(
+    const std::string& name, nvinfer1::IPluginCreator* pluginCreator,
+    const std::vector<nvinfer1::PluginField>& pluginFields) {
+  if (!pluginCreator) {
+    return nullptr;
+  }
+  nvinfer1::PluginFieldCollection fc;
+  fc.nbFields = pluginFields.size();
+  fc.fields = pluginFields.data();
+  return std::unique_ptr<nvinfer1::IPluginV2, PluginDeleter>{
+      pluginCreator->createPlugin(name.c_str(), &fc)};
+}
 
 // Creates a network to compute x+y.
 TrtUniquePtrType<nvinfer1::IHostMemory> CreateSerializedEngine() {
@@ -53,27 +108,48 @@ TrtUniquePtrType<nvinfer1::IHostMemory> CreateSerializedEngine() {
   TrtUniquePtrType<nvinfer1::IBuilder> builder(
       nvinfer1::createInferBuilder(logger));
   TrtUniquePtrType<nvinfer1::INetworkDefinition> network(
-      builder->createNetworkV2(0L));
+      builder->createNetworkV2(
+          1U << static_cast<uint32_t>(
+              nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH)));
   // Add the input.
   auto input1 = network->addInput(kInputTensor1, nvinfer1::DataType::kFLOAT,
-                                  nvinfer1::Dims3{1, 1, 1});
+                                  nvinfer1::Dims4{1, 1, 1, 1});
   auto input2 = network->addInput(kInputTensor2, nvinfer1::DataType::kFLOAT,
-                                  nvinfer1::Dims3{1, 1, 1});
+                                  nvinfer1::Dims4{1, 1, 1, 1});
   EXPECT_NE(input1, nullptr);
   EXPECT_NE(input2, nullptr);
   // Add an ILayer layer.
   auto layer = network->addElementWise(*input1, *input2,
                                        nvinfer1::ElementWiseOperation::kSUM);
   EXPECT_NE(layer, nullptr);
+
+  // Add an efficient nms plugin.
+  ScopedShapedWeights boxes_weights(nvinfer1::Dims3(1, 10, 4), 0.0f);
+  ScopedShapedWeights scores_weights(nvinfer1::Dims3(1, 10, 10), 0.0f);
+  nvinfer1::IConstantLayer* boxes =
+      network->addConstant(boxes_weights.dims_, boxes_weights.w);
+  nvinfer1::IConstantLayer* scores =
+      network->addConstant(scores_weights.dims_, scores_weights.w);
+
+  std::array<nvinfer1::ITensor*, 2> nms_inputs = {boxes->getOutput(0),
+                                                  scores->getOutput(0)};
+
+  auto plugin_creator = MakeNMSPluginCreator("tftrt");
+  auto plugin = createPlugin("nms_plugin_instance", plugin_creator.get(), {});
+  auto nms = network->addPluginV2(nms_inputs.data(), 2, *plugin);
+
   // Mark the output.
   auto output = layer->getOutput(0);
-  output->setName(kOutputTensor);
+  output->setName(kOutputTensor1);
   network->markOutput(*output);
+  nms->getOutput(0)->setName(kOutputTensor2);
+  network->markOutput(*nms->getOutput(0));
+
   // Build the engine.
   builder->setMaxBatchSize(1);
   TrtUniquePtrType<nvinfer1::IBuilderConfig> builderConfig(
       builder->createBuilderConfig());
-  builderConfig->setMaxWorkspaceSize(1 << 10);
+  builderConfig->setMaxWorkspaceSize(1 << 20);
   TrtUniquePtrType<nvinfer1::ICudaEngine> engine(
       builder->buildEngineWithConfig(*network, *builderConfig));
   EXPECT_NE(engine, nullptr);
@@ -82,22 +158,43 @@ TrtUniquePtrType<nvinfer1::IHostMemory> CreateSerializedEngine() {
   return model;
 }
 
+template <typename T>
+unsigned GetBindingSizeBytes(const nvinfer1::ICudaEngine& engine, int index,
+                             unsigned batch_size) {
+  unsigned vol = batch_size;
+  auto dims = engine.getBindingDimensions(index);
+  nvinfer1::DataType type = engine.getBindingDataType(index);
+  int vecDim = engine.getBindingVectorizedDim(index);
+  if (-1 != vecDim)  // i.e., 0 != lgScalarsPerVector
+  {
+    int scalarsPerVec = engine.getBindingComponentsPerElement(index);
+    // Divide round up.
+    dims.d[vecDim] = (dims.d[vecDim] + scalarsPerVec - 1 / scalarsPerVec);
+    vol *= scalarsPerVec;
+  }
+  vol *= std::accumulate(dims.d, dims.d + dims.nbDims, 1, std::multiplies<>());
+  return vol * sizeof(T);
+};
+
 // Executes the network.
 void Execute(nvinfer1::IExecutionContext* context, const float* input1,
-             const float* input2, float* output) {
+             const float* input2, float* output1, float* output2) {
   const nvinfer1::ICudaEngine& engine = context->getEngine();
 
   // We have two bindings: input and output.
-  ASSERT_EQ(engine.getNbBindings(), 3);
+  ASSERT_EQ(engine.getNbBindings(), 4);
   const int input_index1 = engine.getBindingIndex(kInputTensor1);
   const int input_index2 = engine.getBindingIndex(kInputTensor2);
-  const int output_index = engine.getBindingIndex(kOutputTensor);
+  const int output_index1 = engine.getBindingIndex(kOutputTensor1);
+  const int output_index2 = engine.getBindingIndex(kOutputTensor2);
 
   // Create GPU buffers and a stream
-  void* buffers[3];
-  ASSERT_EQ(0, cudaMalloc(&buffers[input_index1], sizeof(float)));
-  ASSERT_EQ(0, cudaMalloc(&buffers[input_index2], sizeof(float)));
-  ASSERT_EQ(0, cudaMalloc(&buffers[output_index], sizeof(float)));
+  std::vector<void*> buffers(engine.getNbBindings());
+  for (int i = 0; i < buffers.size(); i++) {
+    ASSERT_EQ(
+        0, cudaMalloc(&buffers[i], GetBindingSizeBytes<float>(engine, i, 1)));
+  }
+
   cudaStream_t stream;
   ASSERT_EQ(0, cudaStreamCreate(&stream));
 
@@ -110,19 +207,27 @@ void Execute(nvinfer1::IExecutionContext* context, const float* input1,
                                cudaMemcpyHostToDevice, stream));
   ASSERT_EQ(0, cudaMemcpyAsync(buffers[input_index2], input2, sizeof(float),
                                cudaMemcpyHostToDevice, stream));
-  context->enqueue(1, buffers, stream, nullptr);
-  ASSERT_EQ(0, cudaMemcpyAsync(output, buffers[output_index], sizeof(float),
+  context->enqueueV2(buffers.data(), stream, nullptr);
+  ASSERT_EQ(0, cudaMemcpyAsync(output1, buffers[output_index1], sizeof(float),
                                cudaMemcpyDeviceToHost, stream));
+  ASSERT_EQ(
+      0, cudaMemcpyAsync(output2, buffers[output_index2],
+                         GetBindingSizeBytes<int32>(engine, output_index2, 1),
+                         cudaMemcpyDeviceToHost, stream));
   cudaStreamSynchronize(stream);
 
   // Release the stream and the buffers
-  ASSERT_EQ(0, cudaFree(buffers[input_index1]));
-  ASSERT_EQ(0, cudaFree(buffers[input_index2]));
-  ASSERT_EQ(0, cudaFree(buffers[output_index]));
+  for (int i = 0; i < buffers.size(); i++) {
+    ASSERT_EQ(0, cudaFree(buffers[i]));
+  }
   cudaStreamDestroy(stream);
 }
 
 TEST(TensorrtTest, BasicFunctions) {
+  // We must register the plugin creator in order to deserialize the plugin.
+  auto plugin_creator = MakeNMSPluginCreator("tftrt");
+  getPluginRegistry()->registerCreator(*plugin_creator, "tftrt");
+
   // Handle the case where the test is run on machine with no gpu available.
   if (CHECK_NOTNULL(GPUMachineManager())->VisibleDeviceCount() <= 0) {
     LOG(WARNING) << "No gpu device available, probably not being run on a gpu "
@@ -144,9 +249,15 @@ TEST(TensorrtTest, BasicFunctions) {
   // Execute the network.
   float input1 = 1234;
   float input2 = 567;
-  float output;
-  Execute(context.get(), &input1, &input2, &output);
-  EXPECT_EQ(output, input1 + input2);
+  std::vector<float> output1(
+      GetBindingSizeBytes<float>(*engine, 2, 1) / sizeof(float), 0.0f);
+  std::vector<float> output2(
+      GetBindingSizeBytes<int32>(*engine, 3, 1) / sizeof(int32), 0.0f);
+  ASSERT_EQ(output1.size(), 1);
+  ASSERT_EQ(output2.size(), 1);
+  Execute(context.get(), &input1, &input2, output1.data(), output2.data());
+  EXPECT_EQ(output1[0], input1 + input2);
+  EXPECT_EQ(output2[0], 0);
 }
 
 }  // namespace tensorrt

--- a/tensorflow/opensource_only.files
+++ b/tensorflow/opensource_only.files
@@ -276,6 +276,8 @@ third_party/tensorrt/build_defs.bzl.tpl
 third_party/tensorrt/tensorrt/include/tensorrt_config.h.tpl
 third_party/tensorrt/tensorrt/tensorrt_config.py.tpl
 third_party/tensorrt/tensorrt_configure.bzl
+third_party/tensorrt/plugin/BUILD
+third_party/tensorrt/workspace.bzl
 third_party/termcolor.BUILD
 third_party/tf_toolchains.BUILD
 third_party/tflite_mobilenet.BUILD

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -42,6 +42,8 @@ load("//third_party/psimd:workspace.bzl", psimd = "repo")
 load("//third_party/ruy:workspace.bzl", ruy = "repo")
 load("//third_party/sobol_data:workspace.bzl", sobol_data = "repo")
 load("//third_party/vulkan_headers:workspace.bzl", vulkan_headers = "repo")
+load("//third_party/tensorrt:workspace.bzl", tensorrt = "repo")
+
 
 # Import external repository rules.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
@@ -80,6 +82,7 @@ def _initialize_third_party():
     ruy()
     sobol_data()
     vulkan_headers()
+    tensorrt()
 
 # Toolchains & platforms required by Tensorflow to build.
 def _tf_toolchains():

--- a/third_party/tensorrt/BUILD.tpl
+++ b/third_party/tensorrt/BUILD.tpl
@@ -58,3 +58,5 @@ py_library(
 )
 
 %{copy_rules}
+
+%{oss_rules}

--- a/third_party/tensorrt/plugin/BUILD
+++ b/third_party/tensorrt/plugin/BUILD
@@ -1,0 +1,60 @@
+# NVIDIA TensorRT Open Source Plugins
+# This package contains build targets for select TensorRT plugins included in the
+# TensorRT open source repository.
+load("@local_config_cuda//cuda:build_defs.bzl", "cuda_default_copts", "cuda_library")
+
+exports_files(["LICENSE"])
+
+cuda_library(
+    name = "plugin_common",
+    srcs = [
+        "plugin/common/kernels/common.cu.cc",
+    ],
+    hdrs = [
+        "plugin/common/bboxUtils.h",
+        "plugin/common/checkMacrosPlugin.h",
+        "plugin/common/plugin.h",
+    ],
+    strip_include_prefix = "plugin/common",
+    deps = [
+        "@local_config_tensorrt//:tensorrt",
+        "@local_config_tensorrt//:tensorrt_headers",
+    ],
+)
+
+cc_library(
+    name = "nms_plugin_hdrs",
+    hdrs = [
+        "plugin/efficientNMSPlugin/efficientNMSInference.h",
+        "plugin/efficientNMSPlugin/efficientNMSParameters.h",
+        "plugin/efficientNMSPlugin/efficientNMSPlugin.h",
+    ],
+    strip_include_prefix = "plugin/efficientNMSPlugin",
+)
+
+cuda_library(
+    name = "nvinfer_plugin_nms",
+    srcs = [
+        "plugin/efficientNMSPlugin/efficientNMSInference.cu.cc",
+        "plugin/efficientNMSPlugin/efficientNMSInference.cu.h",
+        "plugin/efficientNMSPlugin/efficientNMSInference.h",
+        "plugin/efficientNMSPlugin/efficientNMSParameters.h",
+        "plugin/efficientNMSPlugin/efficientNMSPlugin.cpp",
+        "plugin/efficientNMSPlugin/efficientNMSPlugin.h",
+    ],
+    hdrs = [
+        "plugin/efficientNMSPlugin/efficientNMSInference.h",
+        "plugin/efficientNMSPlugin/efficientNMSParameters.h",
+        "plugin/efficientNMSPlugin/efficientNMSPlugin.h",
+    ],
+    copts = cuda_default_copts(),
+    include_prefix = "third_party/tensorrt/nvinfer_plugin_nms",
+    strip_include_prefix = "plugin/efficientNMSPlugin",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":nms_plugin_hdrs",
+        ":plugin_common",
+        "@local_config_tensorrt//:tensorrt",
+        "@local_config_tensorrt//:tensorrt_headers",
+    ],
+)

--- a/third_party/tensorrt/plugin/tensorrt_oss.patch
+++ b/third_party/tensorrt/plugin/tensorrt_oss.patch
@@ -1,0 +1,144 @@
+diff --git a/plugin/common/checkMacrosPlugin.h b/plugin/common/checkMacrosPlugin.h
+index 2cff9f8..a803765 100644
+--- a/plugin/common/checkMacrosPlugin.h
++++ b/plugin/common/checkMacrosPlugin.h
+@@ -16,7 +16,7 @@
+ #ifndef CHECK_MACROS_PLUGIN_H
+ #define CHECK_MACROS_PLUGIN_H
+ 
+-#include "NvInfer.h"
++#include "third_party/tensorrt/NvInfer.h"
+ #include <sstream>
+ 
+ #ifndef TRT_CHECK_MACROS_H
+diff --git a/plugin/common/kernels/common.cu b/plugin/common/kernels/common.cu.cc
+similarity index 87%
+rename from plugin/common/kernels/common.cu
+rename to plugin/common/kernels/common.cu.cc
+index 7c8922a..9818a30 100755
+--- a/plugin/common/kernels/common.cu
++++ b/plugin/common/kernels/common.cu.cc
+@@ -18,7 +18,6 @@
+ #include "cublas_v2.h"
+ #include <cub/cub.cuh>
+ #include <stdint.h>
+-#include "kernel.h"
+ #include "bboxUtils.h"
+ 
+ #define CUDA_MEM_ALIGN 256
+@@ -26,28 +25,7 @@
+ // HASH
+ unsigned int hash(const void* array_, size_t size)
+ {
+-    // Apply hashing only when debugging RPN codes.
+-    if (DEBUG_ENABLE)
+-    {
+-        const char* array_const;
+-        char* array;
+-        cudaMallocHost((void**) &array, size);
+-        cudaMemcpy(array, array_, size, cudaMemcpyDeviceToHost);
+-        array_const = array;
+-        unsigned int hash = 45599;
+-        for (size_t i = 0; i < size; i++)
+-        {
+-            unsigned int value = array_const[i];
+-            hash = hash * 1487 + value;
+-            hash = hash * 317;
+-            hash = hash % 105359;
+-        }
+-        return hash;
+-    }
+-    else
+-    {
+-        return 0;
+-    }
++    return 0;
+ }
+ 
+ // ALIGNPTR
+diff --git a/plugin/common/plugin.h b/plugin/common/plugin.h
+index 27a1fb7..f056255 100644
+--- a/plugin/common/plugin.h
++++ b/plugin/common/plugin.h
+@@ -17,7 +17,7 @@
+ #define TRT_PLUGIN_H
+ #include "checkMacrosPlugin.h"
+ 
+-#include "NvInferPlugin.h"
++#include "third_party/tensorrt/NvInferPlugin.h"
+ #include <cstring>
+ #include <cuda_runtime.h>
+ #include <iostream>
+diff --git a/plugin/efficientNMSPlugin/efficientNMSInference.cu b/plugin/efficientNMSPlugin/efficientNMSInference.cu.cc
+similarity index 99%
+rename from plugin/efficientNMSPlugin/efficientNMSInference.cu
+rename to plugin/efficientNMSPlugin/efficientNMSInference.cu.cc
+index f02a2f8..44fa20b 100644
+--- a/plugin/efficientNMSPlugin/efficientNMSInference.cu
++++ b/plugin/efficientNMSPlugin/efficientNMSInference.cu.cc
+@@ -18,7 +18,7 @@
+ #include "cub/cub.cuh"
+ #include "cuda_runtime_api.h"
+ 
+-#include "efficientNMSInference.cuh"
++#include "efficientNMSInference.cu.h"
+ #include "efficientNMSInference.h"
+ 
+ using namespace nvinfer1;
+diff --git a/plugin/efficientNMSPlugin/efficientNMSInference.cuh b/plugin/efficientNMSPlugin/efficientNMSInference.cu.h
+similarity index 100%
+rename from plugin/efficientNMSPlugin/efficientNMSInference.cuh
+rename to plugin/efficientNMSPlugin/efficientNMSInference.cu.h
+diff --git a/plugin/efficientNMSPlugin/efficientNMSPlugin.cpp b/plugin/efficientNMSPlugin/efficientNMSPlugin.cpp
+index 2d05c5c..acda183 100644
+--- a/plugin/efficientNMSPlugin/efficientNMSPlugin.cpp
++++ b/plugin/efficientNMSPlugin/efficientNMSPlugin.cpp
+@@ -31,11 +31,6 @@ const char* EFFICIENT_NMS_ONNX_PLUGIN_VERSION{"1"};
+ const char* EFFICIENT_NMS_ONNX_PLUGIN_NAME{"EfficientNMS_ONNX_TRT"};
+ } // namespace
+ 
+-PluginFieldCollection EfficientNMSPluginCreator::mFC{};
+-PluginFieldCollection EfficientNMSONNXPluginCreator::mFC{};
+-std::vector<PluginField> EfficientNMSPluginCreator::mPluginAttributes;
+-std::vector<PluginField> EfficientNMSONNXPluginCreator::mPluginAttributes;
+-
+ EfficientNMSPlugin::EfficientNMSPlugin(EfficientNMSParameters param)
+     : mParam(param)
+ {
+@@ -386,7 +381,7 @@ EfficientNMSPluginCreator::EfficientNMSPluginCreator()
+     mPluginAttributes.emplace_back(PluginField("max_output_boxes", nullptr, PluginFieldType::kINT32, 1));
+     mPluginAttributes.emplace_back(PluginField("background_class", nullptr, PluginFieldType::kINT32, 1));
+     mPluginAttributes.emplace_back(PluginField("score_activation", nullptr, PluginFieldType::kINT32, 1));
+-    mPluginAttributes.emplace_back(PluginField("box_coding", nullptr, PluginFieldType::kINT32, 1));
++    mPluginAttributes.emplace_back(PluginField("box_coding", nullptr, PluginFieldType::kINT32, 1));    
+     mFC.nbFields = mPluginAttributes.size();
+     mFC.fields = mPluginAttributes.data();
+ }
+diff --git a/plugin/efficientNMSPlugin/efficientNMSPlugin.h b/plugin/efficientNMSPlugin/efficientNMSPlugin.h
+index b342b09..84d5e69 100644
+--- a/plugin/efficientNMSPlugin/efficientNMSPlugin.h
++++ b/plugin/efficientNMSPlugin/efficientNMSPlugin.h
+@@ -85,9 +85,9 @@ public:
+         const char* name, const void* serialData, size_t serialLength) noexcept override;
+ 
+ protected:
+-    static PluginFieldCollection mFC;
++    PluginFieldCollection mFC;
+     EfficientNMSParameters mParam;
+-    static std::vector<PluginField> mPluginAttributes;
++    std::vector<PluginField> mPluginAttributes;
+     std::string mPluginName;
+ };
+ 
+@@ -107,9 +107,9 @@ public:
+         const char* name, const void* serialData, size_t serialLength) noexcept override;
+ 
+ protected:
+-    static PluginFieldCollection mFC;
++    PluginFieldCollection mFC;
+     EfficientNMSParameters mParam;
+-    static std::vector<PluginField> mPluginAttributes;
++    std::vector<PluginField> mPluginAttributes;
+     std::string mPluginName;
+ };
+ 

--- a/third_party/tensorrt/tensorrt_configure.bzl
+++ b/third_party/tensorrt/tensorrt_configure.bzl
@@ -52,6 +52,21 @@ _DEFINE_TENSORRT_SONAME_MAJOR = "#define NV_TENSORRT_SONAME_MAJOR"
 _DEFINE_TENSORRT_SONAME_MINOR = "#define NV_TENSORRT_SONAME_MINOR"
 _DEFINE_TENSORRT_SONAME_PATCH = "#define NV_TENSORRT_SONAME_PATCH"
 
+_TENSORRT_OSS_DUMMY_BUILD_CONTENT = """
+cc_library(
+  name = "nvinfer_plugin_nms",
+  visibility = ["//visibility:public"],
+)
+"""
+
+_TENSORRT_OSS_ARCHIVE_BUILD_CONTENT = """
+alias(
+  name = "nvinfer_plugin_nms",
+  actual = "@tensorrt_oss_archive//:nvinfer_plugin_nms",
+  visibility = ["//visibility:public"],
+)
+"""
+
 def _at_least_version(actual_version, required_version):
     actual = [int(v) for v in actual_version.split(".")]
     required = [int(v) for v in required_version.split(".")]
@@ -81,6 +96,7 @@ def _create_dummy_repository(repository_ctx):
         "%{copy_rules}": "",
         "\":tensorrt_include\"": "",
         "\":tensorrt_lib\"": "",
+        "%{oss_rules}": _TENSORRT_OSS_DUMMY_BUILD_CONTENT,
     })
     _tpl(repository_ctx, "tensorrt/include/tensorrt_config.h", {
         "%{tensorrt_version}": "",
@@ -177,7 +193,10 @@ def _create_local_tensorrt_repository(repository_ctx):
     repository_ctx.template(
         "BUILD",
         tpl_paths["BUILD"],
-        {"%{copy_rules}": "\n".join(copy_rules)},
+        {
+            "%{copy_rules}": "\n".join(copy_rules),
+            "%{oss_rules}": _TENSORRT_OSS_ARCHIVE_BUILD_CONTENT,
+        },
     )
 
     # Copy license file in non-remote build.

--- a/third_party/tensorrt/workspace.bzl
+++ b/third_party/tensorrt/workspace.bzl
@@ -1,0 +1,21 @@
+"""Provides the repository macro to import TensorRT Open Source components."""
+
+load("//third_party:repo.bzl", "tf_http_archive")
+
+def repo(name = "tensorrt_oss_archive"):
+    """Imports TensorRT Open Source Components."""
+    TRT_OSS_COMMIT = "9ec6eb6db39188c9f3d25f49c8ee3a9721636b56"
+    TRT_OSS_SHA256 = "4fa2a712a5f2350b81df01d55c1dc17451e09efd4b2a53322b0433721009e1c7"
+
+    tf_http_archive(
+        name = name,
+        sha256 = TRT_OSS_SHA256,
+        strip_prefix = "TensorRT-{commit}".format(commit = TRT_OSS_COMMIT),
+        urls = [
+            # TODO: Google Mirror "https://storage.googleapis.com/...."
+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/NVIDIA/TensorRT/archive/{commit}.tar.gz".format(commit = TRT_OSS_COMMIT),
+            "https://github.com/NVIDIA/TensorRT/archive/{commit}.tar.gz".format(commit = TRT_OSS_COMMIT),
+        ],
+        build_file = "//third_party/tensorrt/plugin:BUILD",
+        patch_file = "//third_party/tensorrt/plugin:tensorrt_oss.patch",
+    )


### PR DESCRIPTION
Adds ability to download and build TensorRT OSS components (github.com/NVIDIA/TensorRT) to the existing "third_party/tensorrt" package. The mechanism used is the same used for building NCCL components. Currently, only the EfficientNMS plugin and some supporting code is built. A small patch is applied to the external code to change file extensions, make include paths compatible, and ensure compatibility with static/shared library builds.