### PR TITLE
Use the official devel image for presubmit litting

### DIFF
--- a/.github/workflows/pylint-presubmit.yml
+++ b/.github/workflows/pylint-presubmit.yml
@@ -23,6 +23,7 @@ jobs:
   build:
     name: PyLint
     runs-on: ubuntu-latest
+    container: tensorflow/tensorflow:latest-devel
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -34,15 +35,6 @@ jobs:
     - name: Report list of changed files
       run: |
         echo Changed files: ${{ steps.get_file_changes.outputs.files }}
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pylint numpy wheel
-        pip install keras_preprocessing --no-deps
     - name: Run PyLint on changed files
       run: |
         echo "${{ steps.get_file_changes.outputs.files}}" | tr " " "\n" | grep ".py$" | xargs pylint --rcfile=tensorflow/tools/ci_build/pylintrc

--- a/tensorflow/python/keras/utils/data_utils_test.py
+++ b/tensorflow/python/keras/utils/data_utils_test.py
@@ -27,6 +27,7 @@ from tensorflow.python.keras.utils import data_utils
 from tensorflow.python.platform import test
 
 
+
 class TestGetFileAndValidateIt(test.TestCase):
 
   def test_get_file_and_validate_it(self):


### PR DESCRIPTION
This is temp failing now cause we don't distribute a `pytlint` reference version in our official devel image.
I've tried to fix the missing reference version at https://github.com/tensorflow/tensorflow/pull/48371 but it was not reviewed  and some month later my rationale was reject also in https://github.com/tensorflow/tensorflow/pull/51914#issuecomment-916540675.

As I suppose that we don't have too much free time to maintain another potentially unaligned environment I think it is better to lint the PR code in the CI (TF OSS) with exactly the same (prepared) environment that we give to contributors to build, lint and test their contributing code/PR on their own hw resources (or Github workspaces available on this platform).