### PR TITLE
Remove xrange from tensorflow/compiler

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -843,7 +843,6 @@ tf_xla_py_test(
         "//tensorflow/python:framework_for_generated_wrappers",
         "//tensorflow/python:framework_ops",
         "//tensorflow/python:platform_test",
-        "@six_archive//:six",
     ],
 )
 

--- a/tensorflow/compiler/tests/cholesky_op_test.py
+++ b/tensorflow/compiler/tests/cholesky_op_test.py
@@ -15,7 +15,6 @@
 """Tests for tensorflow.ops.tf.Cholesky."""
 
 import numpy as np
-from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.framework import constant_op
@@ -76,7 +75,7 @@ class CholeskyOpTest(xla_test.XLATestCase):
 
       # Generate random positive-definite matrices.
       matrices = np.random.rand(10, 5, 5).astype(dtype)
-      for i in xrange(10):
+      for i in range(10):
         matrices[i] = np.dot(matrices[i].T, matrices[i])
       self._verifyCholesky(matrices, atol=1e-4)
 

--- a/tensorflow/compiler/tests/clustering_test.py
+++ b/tensorflow/compiler/tests/clustering_test.py
@@ -15,7 +15,6 @@
 """Tests for the behavior of the auto-compilation pass."""
 
 import numpy as np
-from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.framework import constant_op
@@ -52,7 +51,7 @@ class ClusteringTest(xla_test.XLATestCase):
         input2 = constant_op.constant(val2, name="const2")
       with self.test_scope():
         output = math_ops.add(input1, input2)
-      for _ in xrange(10):
+      for _ in range(10):
         result = self.evaluate(output)
         self.assertAllClose(result, expected, rtol=1e-3)
 

--- a/tensorflow/compiler/tests/conv3d_test.py
+++ b/tensorflow/compiler/tests/conv3d_test.py
@@ -15,7 +15,6 @@
 """Tests for 3D convolutions using the XLA JIT."""
 
 import numpy as np
-from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.framework import constant_op
@@ -96,11 +95,11 @@ class Conv3DTransposeTest(xla_test.XLATestCase):
       #   kernel_depth * ceil(kernel_height/2) * kernel_width or
       #   kernel_depth * kernel_height * ceil(kernel_width/2)
 
-      for n in xrange(x_shape[0]):
-        for k in xrange(f_shape[3]):
-          for w in xrange(y_shape[3]):
-            for h in xrange(y_shape[2]):
-              for d in xrange(y_shape[1]):
+      for n in range(x_shape[0]):
+        for k in range(f_shape[3]):
+          for w in range(y_shape[3]):
+            for h in range(y_shape[2]):
+              for d in range(y_shape[1]):
                 d_in = d > 0 and d < y_shape[1] - 1
                 h_in = h > 0 and h < y_shape[2] - 1
                 w_in = w > 0 and w < y_shape[3] - 1
@@ -133,11 +132,11 @@ class Conv3DTransposeTest(xla_test.XLATestCase):
           x, f, y_shape, strides=strides, padding="SAME")
       value = self.evaluate(output)
 
-      for n in xrange(x_shape[0]):
-        for k in xrange(f_shape[3]):
-          for w in xrange(y_shape[3]):
-            for h in xrange(y_shape[2]):
-              for d in xrange(y_shape[1]):
+      for n in range(x_shape[0]):
+        for k in range(f_shape[3]):
+          for w in range(y_shape[3]):
+            for h in range(y_shape[2]):
+              for d in range(y_shape[1]):
                 # We add a case for locations divisible by the stride.
                 d_in = d % strides[1] == 0 and 0 < d < y_shape[1] - 1
                 h_in = h % strides[2] == 0 and 0 < h < y_shape[2] - 1
@@ -176,11 +175,11 @@ class Conv3DTransposeTest(xla_test.XLATestCase):
       # The amount of padding added
       pad = 1
 
-      for n in xrange(x_shape[0]):
-        for k in xrange(f_shape[3]):
-          for w in xrange(y_shape[3]):
-            for h in xrange(y_shape[2]):
-              for d in xrange(y_shape[1]):
+      for n in range(x_shape[0]):
+        for k in range(f_shape[3]):
+          for w in range(y_shape[3]):
+            for h in range(y_shape[2]):
+              for d in range(y_shape[1]):
                 # We add a case for locations divisible by the stride.
                 d_in = d % strides[1] == 0 and pad < d < y_shape[1] - 1 - pad
                 h_in = h % strides[2] == 0 and pad < h < y_shape[2] - 1 - pad

--- a/tensorflow/compiler/tests/depthwise_conv_op_test.py
+++ b/tensorflow/compiler/tests/depthwise_conv_op_test.py
@@ -15,7 +15,6 @@
 """Functional tests for depthwise convolutional operations."""
 
 import numpy as np
-from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.framework import constant_op
@@ -35,7 +34,7 @@ def ReferenceDepthwiseConv2D(input_tensor, filter_tensor, strides, padding,
   convs = []
   in_channels = filter_tensor.shape[2]
   # Use a custom implementation of depthwise conv2d using slicing.
-  for channel in xrange(in_channels):
+  for channel in range(in_channels):
     # Slice the input along channel
     if data_format == "NCHW":
       input_slice = input_tensor[:, channel:channel+1, :, :]

--- a/tensorflow/compiler/tests/fifo_queue_test.py
+++ b/tensorflow/compiler/tests/fifo_queue_test.py
@@ -16,8 +16,6 @@
 
 import time
 
-from six.moves import xrange  # pylint: disable=redefined-builtin
-
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.framework import dtypes as dtypes_lib
 from tensorflow.python.ops import data_flow_ops
@@ -86,7 +84,7 @@ class FIFOQueueTest(xla_test.XLATestCase):
 
       # Dequeue every element using a single thread.
       results = []
-      for _ in xrange(len(elems)):
+      for _ in range(len(elems)):
         results.append(dequeued_t.eval())
       self.assertItemsEqual(elems, results)
 
@@ -124,7 +122,7 @@ class FIFOQueueTest(xla_test.XLATestCase):
       for enqueue_op in enqueue_ops:
         enqueue_op.run()
 
-      for i in xrange(len(elems)):
+      for i in range(len(elems)):
         vals = self.evaluate(dequeued_t)
         self.assertEqual([elems[i]], vals)
 
@@ -145,7 +143,7 @@ class FIFOQueueTest(xla_test.XLATestCase):
       results = []
 
       def dequeue():
-        for _ in xrange(len(elems)):
+        for _ in range(len(elems)):
           results.append(sess.run(dequeued_t))
 
       enqueue_thread = self.checkedThread(target=enqueue)
@@ -168,7 +166,7 @@ class FIFOQueueTest(xla_test.XLATestCase):
       for enqueue_op in enqueue_ops:
         enqueue_op.run()
 
-      for i in xrange(len(elems)):
+      for i in range(len(elems)):
         x_val, y_val = sess.run(dequeued_t)
         x, y = elems[i]
         self.assertEqual([x], x_val)

--- a/tensorflow/compiler/tests/image_ops_test.py
+++ b/tensorflow/compiler/tests/image_ops_test.py
@@ -21,8 +21,6 @@ import os
 from absl.testing import parameterized
 import numpy as np
 
-from six.moves import xrange  # pylint: disable=redefined-builtin
-
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -227,7 +225,7 @@ class AdjustHueTest(xla_test.XLATestCase):
     x_v = x_np.reshape([-1, 3])
     y_v = np.ndarray(x_v.shape, dtype=x_v.dtype)
     channel_count = x_v.shape[0]
-    for i in xrange(channel_count):
+    for i in range(channel_count):
       r = x_v[i][0]
       g = x_v[i][1]
       b = x_v[i][2]
@@ -347,7 +345,7 @@ class AdjustSaturationTest(xla_test.XLATestCase):
     x_v = x_np.reshape([-1, 3])
     y_v = np.ndarray(x_v.shape, dtype=x_v.dtype)
     channel_count = x_v.shape[0]
-    for i in xrange(channel_count):
+    for i in range(channel_count):
       r = x_v[i][0]
       g = x_v[i][1]
       b = x_v[i][2]

--- a/tensorflow/compiler/tests/listdiff_op_test.py
+++ b/tensorflow/compiler/tests/listdiff_op_test.py
@@ -15,7 +15,6 @@
 """Tests for XLA listdiff operator."""
 
 import numpy as np
-from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.framework import dtypes
@@ -61,7 +60,7 @@ class ListDiffTest(xla_test.XLATestCase):
     int_low = -7
     int_high = 8
     max_size = 50
-    for _ in xrange(num_random_tests):
+    for _ in range(num_random_tests):
       x_size = np.random.randint(max_size + 1)
       x = np.random.randint(int_low, int_high, size=x_size)
       y_size = np.random.randint(max_size + 1)

--- a/tensorflow/compiler/tests/unary_ops_test.py
+++ b/tensorflow/compiler/tests/unary_ops_test.py
@@ -18,7 +18,6 @@ import unittest
 
 import numpy as np
 import six
-from six.moves import xrange  # pylint: disable=redefined-builtin
 
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.framework import dtypes
@@ -80,7 +79,7 @@ class UnaryOpsTest(xla_test.XLATestCase):
   def ListsAreClose(self, result, expected, rtol, atol):
     """Tests closeness of two lists of floats."""
     self.assertEqual(len(result), len(expected))
-    for i in xrange(len(result)):
+    for i in range(len(result)):
       self.assertAllClose(result[i], expected[i], rtol, atol)
 
   def AssertCloseAndSorted(self, result, expected, rtol, atol):

--- a/tensorflow/compiler/xla/python_api/xla_shape.py
+++ b/tensorflow/compiler/xla/python_api/xla_shape.py
@@ -16,8 +16,6 @@
 
 import numpy as _np  # Avoids becoming a part of public Tensorflow API.
 
-from six.moves import xrange
-
 from tensorflow.compiler.xla import xla_data_pb2
 from tensorflow.compiler.xla.python_api import types
 
@@ -117,7 +115,7 @@ def _CreateShapeFromNumpy(ndarray):  # pylint: disable=invalid-name
   else:
     # Row-major layout. This corresponds to a "dimension order is
     # major-to-minor" layout int XLA.
-    layout = list(reversed(xrange(ndarray.ndim)))
+    layout = list(reversed(range(ndarray.ndim)))
 
   return Shape(element_type, dimensions, layout)
 


### PR DESCRIPTION
Other usages of six's xrange will be removed in other PR's(there's a lot of them).