### PR TITLE
Declare Go import path in distributed runtime payloads proto

### DIFF
--- a/tensorflow/core/protobuf/distributed_runtime_payloads.proto
+++ b/tensorflow/core/protobuf/distributed_runtime_payloads.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package tensorflow.distributed_runtime;
 
 option cc_enable_arenas = true;
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 // Used to serialize and transmit tensorflow::Status payloads through
 // grpc::Status `error_details` since grpc::Status lacks payload API.


### PR DESCRIPTION
PR declares `go_package` in proto definition and resolves protoc-gen-go error.