### PR TITLE
Update `custom_gradient.py`: fix comment w.r.t `gradients` now being `GradientTape`

### DIFF
--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -62,7 +62,7 @@ def custom_gradient(f=None):
   ```python
   x = tf.constant(100.)
   y = log1pexp(x)
-  dy_dx = tf.gradients(y, x) # Will be NaN when evaluated.
+  dy_dx = tf.GradientTape(y, x) # Will be NaN when evaluated.
   ```
 
   The gradient expression can be analytically simplified to provide numerical


### PR DESCRIPTION
In TF 2.x 'gradients' should be replaced with 'GradientTape'. Hence made necessary changes. Please refer updated [gist](https://colab.research.google.com/gist/RenuPatelGoogle/8641fd64952c2febb8038a5fb2e1d51a/untitled30.ipynb).