### PR TITLE
Use `int64_t` instead of `tensorflow::int64`

### DIFF
--- a/tensorflow/core/framework/tensor_shape.h
+++ b/tensorflow/core/framework/tensor_shape.h
@@ -302,7 +302,7 @@ class TensorShapeBase : public TensorShapeRep {
 
   /// Returns sizes of all dimensions.
   // Returns an empty list for unknown rank PartialTensorShape.
-  gtl::InlinedVector<int64, 4> dim_sizes() const;
+  gtl::InlinedVector<int64_t, 4> dim_sizes() const;
 
   /// Return true iff the rank and all of the dimensions are well defined
   // TODO(irving): Rename to is_fully_defined now that it's fast.

--- a/tensorflow/core/platform/default/notification.h
+++ b/tensorflow/core/platform/default/notification.h
@@ -58,8 +58,8 @@ class Notification {
 
  private:
   friend bool WaitForNotificationWithTimeout(Notification* n,
-                                             int64 timeout_in_us);
-  bool WaitForNotificationWithTimeout(int64 timeout_in_us) {
+                                             int64_t timeout_in_us);
+  bool WaitForNotificationWithTimeout(int64_t timeout_in_us) {
     bool notified = HasBeenNotified();
     if (!notified) {
       mutex_lock l(mu_);
@@ -78,7 +78,7 @@ class Notification {
 };
 
 inline bool WaitForNotificationWithTimeout(Notification* n,
-                                           int64 timeout_in_us) {
+                                           int64_t timeout_in_us) {
   return n->WaitForNotificationWithTimeout(timeout_in_us);
 }
 


### PR DESCRIPTION
I realized `tensorflow::int64` was removed in 0b6b491d21d6a4eb5fbab1cca565bc1e94ca9543, but the lines I modified didn't change, leading to a compile warning when building custom ops:

```cpp
/tmp/pip-build-env-9xgnct5m/normal/lib/python3.7/site-packages/tensorflow/include/tensorflow/core/framework/tensor_shape.h:305:22: warning: ‘tensorflow::int64’ is deprecated: Use int64_t instead. [-Wdeprecated-declarations]
       gtl::InlinedVector<int64, 4> dim_sizes() const;
    /tmp/pip-build-env-9xgnct5m/normal/lib/python3.7/site-packages/tensorflow/include/tensorflow/core/platform/default/notification.h:61:65: warning: ‘int64’ is deprecated [-Wdeprecated-declarations]
                                                  int64 timeout_in_us);
                                                                     ^
    /tmp/pip-build-env-9xgnct5m/normal/lib/python3.7/site-packages/tensorflow/include/tensorflow/core/platform/default/notification.h:62:58: warning: ‘int64’ is deprecated [-Wdeprecated-declarations]
       bool WaitForNotificationWithTimeout(int64 timeout_in_us) {
                                                              ^
    /tmp/pip-build-env-9xgnct5m/normal/lib/python3.7/site-packages/tensorflow/include/tensorflow/core/platform/default/notification.h:81:63: warning: ‘int64’ is deprecated [-Wdeprecated-declarations]
                                                int64 timeout_in_us) {
```