### PR TITLE
Update curl to 7.79.1

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -608,12 +608,12 @@ def _tf_repositories():
     tf_http_archive(
         name = "curl",
         build_file = "//third_party:curl.BUILD",
-        sha256 = "ed936c0b02c06d42cf84b39dd12bb14b62d77c7c4e875ade022280df5dcc81d7",
-        strip_prefix = "curl-7.78.0",
+        sha256 = "370b11201349816287fb0ccc995e420277fbfcaf76206e309b3f60f0eda090c2",
+        strip_prefix = "curl-7.79.1",
         system_build_file = "//third_party/systemlibs:curl.BUILD",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/curl.haxx.se/download/curl-7.78.0.tar.gz",
-            "https://curl.haxx.se/download/curl-7.78.0.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/curl.haxx.se/download/curl-7.79.1.tar.gz",
+            "https://curl.haxx.se/download/curl-7.79.1.tar.gz",
         ],
     )
 


### PR DESCRIPTION
This PR updates curl from 7.78 to 7.79.1.

The reason of update is to fix the following vulnerabilities in 7.78:
- CVE-2021-22947: STARTTLS protocol injection via MITM
- CVE-2021-22946: Protocol downgrade required TLS bypassed
- CVE-2021-22945: UAF and double-free in MQTT sending

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>