### PR TITLE
Facilitation of the cross-compiled unit test run on target

### DIFF
--- a/tensorflow/lite/g3doc/guide/build_cmake.md
+++ b/tensorflow/lite/g3doc/guide/build_cmake.md
@@ -123,6 +123,30 @@ the native *flatc* binary needs to be provided along with the
 cmake -DCMAKE_TOOLCHAIN_FILE=${OE_CMAKE_TOOLCHAIN_FILE} -DTFLITE_KERNEL_TEST=on -DTFLITE_HOST_TOOLS_DIR=<flatc_dir_path> ../tensorflow/lite/
 ```
 
+##### Cross-compiled kernel (unit) tests launch on target
+
+Unit tests can be run as separate executables or using the CTest utility. As far as CTest is concerned, if at least one of the parameters `TFLITE_ENABLE_NNAPI, TFLITE_ENABLE_XNNPACK` or `TFLITE_EXTERNAL_DELEGATE` is enabled for the TF Lite build, the resulting tests are generated with two different **labels** (utilizing the same test executable):
+- _plain_ -  denoting the tests ones run on CPU backend
+- _delegate_ - denoting the tests expecting additional launch arguments used for the used delegate specification
+
+Both `CTestTestfile.cmake` and `run-tests.cmake` (as referred below) are available in `<build_dir>/kernels`.
+
+Launch of unit tests with CPU backend (provided the `CTestTestfile.cmake` is present on target in the current directory):
+
+```sh
+ctest -L plain
+```
+
+Launch examples of unit tests using delegates (provided the `CTestTestfile.cmake` as well as `run-tests.cmake` file are present on target in the current directory):
+
+```sh
+cmake -E env TESTS_ARGUMENTS=--use_nnapi=true\;--nnapi_accelerator_name=vsi-npu ctest -L delegate
+cmake -E env TESTS_ARGUMENTS=--use_xnnpack=true ctest -L delegate
+cmake -E env TESTS_ARGUMENTS=--external_delegate_path=<PATH> ctest -L delegate
+```
+
+**A known limitation** of this way of providing additional delegate-related launch arguments to unit tests is that it effectively supports only those with an **expected return value of 0**. Different return values will be reported as a test failure. 
+
 #### OpenCL GPU delegate
 
 If your target machine has OpenCL support, you can use

--- a/tensorflow/lite/kernels/CMakeLists.txt
+++ b/tensorflow/lite/kernels/CMakeLists.txt
@@ -76,6 +76,10 @@ set(DELEGATE_PROVIDERS
   ${TFLITE_SOURCE_DIR}/tools/delegates/xnnpack_delegate_provider.cc
 )
 
+if(TFLITE_ENABLE_EXTERNAL_DELEGATE)
+  list(APPEND DELEGATE_PROVIDERS ${TFLITE_SOURCE_DIR}/tools/delegates/external_delegate_provider.cc)
+endif()
+
 set(TEST_FRAMEWORK_SRC
   ${TFLITE_SOURCE_DIR}/delegates/nnapi/acceleration_test_list.cc
   ${TFLITE_SOURCE_DIR}/delegates/nnapi/acceleration_test_util.cc
@@ -145,6 +149,16 @@ macro(add_kernel_test TEST_SRC TEST_LIB)
   add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME}
     WORKING_DIRECTORY ${TENSORFLOW_SOURCE_DIR}
   )
+  set_tests_properties(${TEST_NAME} PROPERTIES LABELS "plain")
+
+  if(_TFLITE_ENABLE_NNAPI OR TFLITE_ENABLE_EXTERNAL_DELEGATE OR TFLITE_ENABLE_XNNPACK)
+    set(DELEGATE_TEST "${TEST_NAME}_delegate")
+    add_test(
+      NAME ${DELEGATE_TEST}
+      COMMAND cmake -DTEST_EXECUTABLE=$<TARGET_FILE:${TEST_NAME}> -P run-tests.cmake
+    )
+    set_tests_properties(${DELEGATE_TEST} PROPERTIES LABELS "delegate")
+  endif()
 endmacro()
 
 # Tests where main() is provided by the file referenced in TEST_FRAMEWORK_MAIN_SRC
@@ -301,3 +315,12 @@ endforeach()
 foreach(test_src IN LISTS TEST_WITH_GTEST_MAIN_LIST)
   add_kernel_test(${test_src} tensorflow-lite-test-gtest-main)
 endforeach()
+
+# Copy the test utility that facilitates cross-compiled kernel tests run with launch arguments
+if(${CMAKE_CROSSCOMPILING})
+  configure_file(
+    ${TFLITE_SOURCE_DIR}/tools/cmake/test_utils/run-tests.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/run-tests.cmake
+    COPYONLY
+  )
+endif()

--- a/tensorflow/lite/tools/cmake/test_utils/run-tests.cmake
+++ b/tensorflow/lite/tools/cmake/test_utils/run-tests.cmake
@@ -1,0 +1,22 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(NOT DEFINED ENV{TESTS_ARGUMENTS})
+    set(ENV{TESTS_ARGUMENTS} "")
+endif()
+execute_process(COMMAND ${TEST_EXECUTABLE} $ENV{TESTS_ARGUMENTS} RESULT_VARIABLE result)
+if(NOT "${result}" STREQUAL "0")
+    message(FATAL_ERROR "Test failed with return value '${result}'")
+endif()


### PR DESCRIPTION
As of now, _-DTFLITE_KERNEL_TEST_ along with _-DTFLITE_HOST_TOOLS_DIR=DIR_ arguments can be used for the TF Lite unit tests cross-compilation using CMake. This builds ~136 unit test executables for target architecture and the description of the corresponding ~136 test runs of the CTest utility.

This PR extends this feature by **adding delegate tests** (based on the same executables) **for every enabled delegate in the CMake build run** (XNNPACK, NNAPI, external).

As propagation of environment variables to specific tests is not supported by CTest, a new helper CMake module is introduced to work around this (see the updated README file for details).