### PR TITLE
[TFLite] Enable ApplyLazyDelegateProviders in TF-Lite Python Interpreter.

### DIFF
--- a/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.cc
+++ b/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.cc
@@ -259,6 +259,7 @@ InterpreterWrapper::~InterpreterWrapper() {}
 PyObject* InterpreterWrapper::AllocateTensors(int subgraph_index) {
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_BOUNDS_CHECK(subgraph_index);
+  TFLITE_PY_CHECK(interpreter_->ApplyLazyDelegateProviders());
   TFLITE_PY_CHECK(interpreter_->subgraph(subgraph_index)->AllocateTensors());
   Py_RETURN_NONE;
 }


### PR DESCRIPTION
Fixed #53042 .
Enable XNNPACK delegate in TensorFlow Lite Python Interpreter.