### PR TITLE
Change `min_epsilon` to 0

### DIFF
--- a/tensorflow/python/eager/backprop.py
+++ b/tensorflow/python/eager/backprop.py
@@ -806,8 +806,8 @@ class GradientTape(object):
   >>> print(dy_dx)
   tf.Tensor(4.0, shape=(), dtype=float32)
   >>> # No gradients will be available as `w` isn't being watched.
-  >>> dz_dy = tape.gradient(z, w)
-  >>> print(dz_dy)
+  >>> dz_dw = tape.gradient(z, w)
+  >>> print(dz_dw)
   None
 
   Note that when using models you should ensure that your variables exist when

--- a/tensorflow/python/eager/backprop.py
+++ b/tensorflow/python/eager/backprop.py
@@ -806,8 +806,8 @@ class GradientTape(object):
   >>> print(dy_dx)
   tf.Tensor(4.0, shape=(), dtype=float32)
   >>> # No gradients will be available as `w` isn't being watched.
-  >>> dz_dw = tape.gradient(z, w)
-  >>> print(dz_dw)
+  >>> dz_dy = tape.gradient(z, w)
+  >>> print(dz_dy)
   None
 
   Note that when using models you should ensure that your variables exist when

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -1670,9 +1670,9 @@ def fused_batch_norm(
   if variance is None:
     variance = constant_op.constant([])
 
-  # Set a minimum epsilon to 0.0, which is a requirement by CUDNN to
+  # Set a minimum epsilon to 0., which is a requirement by CUDNN to
   # prevent exception (see cudnn.h).
-  min_epsilon = 0.0
+  min_epsilon = 0.
   epsilon = epsilon if epsilon >= min_epsilon else min_epsilon
 
   y, running_mean, running_var, _, _, _ = gen_nn_ops.fused_batch_norm_v3(

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -1670,9 +1670,9 @@ def fused_batch_norm(
   if variance is None:
     variance = constant_op.constant([])
 
-  # Set a minimum epsilon to 1.001e-5, which is a requirement by CUDNN to
+  # Set a minimum epsilon to 0.0, which is a requirement by CUDNN to
   # prevent exception (see cudnn.h).
-  min_epsilon = 1.001e-5
+  min_epsilon = 0.0
   epsilon = epsilon if epsilon >= min_epsilon else min_epsilon
 
   y, running_mean, running_var, _, _, _ = gen_nn_ops.fused_batch_norm_v3(

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -1672,8 +1672,8 @@ def fused_batch_norm(
 
   # Set a minimum epsilon to 1.001e-5, which is a requirement by CUDNN to
   # prevent exception (see cudnn.h).
-  # updating minimum epsilon to 0.0 as per latest document on CUDNN
-  min_epsilon = 0.0
+  
+  min_epsilon = 1.001e-5
   epsilon = epsilon if epsilon >= min_epsilon else min_epsilon
 
   y, running_mean, running_var, _, _, _ = gen_nn_ops.fused_batch_norm_v3(

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -1672,7 +1672,6 @@ def fused_batch_norm(
 
   # Set a minimum epsilon to 1.001e-5, which is a requirement by CUDNN to
   # prevent exception (see cudnn.h).
-  
   min_epsilon = 1.001e-5
   epsilon = epsilon if epsilon >= min_epsilon else min_epsilon
 

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -1672,7 +1672,8 @@ def fused_batch_norm(
 
   # Set a minimum epsilon to 1.001e-5, which is a requirement by CUDNN to
   # prevent exception (see cudnn.h).
-  min_epsilon = 1.001e-5
+  # updating minimum epsilon to 0 as per latest document on CUDNN
+  min_epsilon = 0
   epsilon = epsilon if epsilon >= min_epsilon else min_epsilon
 
   y, running_mean, running_var, _, _, _ = gen_nn_ops.fused_batch_norm_v3(

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -1673,7 +1673,7 @@ def fused_batch_norm(
   # Set a minimum epsilon to 1.001e-5, which is a requirement by CUDNN to
   # prevent exception (see cudnn.h).
   min_epsilon = 1.001e-5
-  epsilon = epsilon if epsilon > min_epsilon else min_epsilon
+  epsilon = epsilon if epsilon >= min_epsilon else min_epsilon
 
   y, running_mean, running_var, _, _, _ = gen_nn_ops.fused_batch_norm_v3(
       x,

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -1672,8 +1672,8 @@ def fused_batch_norm(
 
   # Set a minimum epsilon to 1.001e-5, which is a requirement by CUDNN to
   # prevent exception (see cudnn.h).
-  # updating minimum epsilon to 0 as per latest document on CUDNN
-  min_epsilon = 0
+  # updating minimum epsilon to 0.0 as per latest document on CUDNN
+  min_epsilon = 0.0
   epsilon = epsilon if epsilon >= min_epsilon else min_epsilon
 
   y, running_mean, running_var, _, _, _ = gen_nn_ops.fused_batch_norm_v3(


### PR DESCRIPTION
Compiling issue #37768 on epsilon condition as per users input `"the value of epsilon is required to be greater or equal to CUDNN_BN_MIN_EPSILON which was defined in the cudnn.h file to the value 1e-5. This threshold value is now lowered to 0.0 to allow a wider range of epsilon value.` in this [document ](https://docs.nvidia.com/deeplearning/cudnn/release-notes/)