### PR TITLE
Tag vectorized_reduce_with_no_vector_registers to allow exclusion

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -1189,6 +1189,7 @@ tf_cc_test(
     name = "vectorized_reduce_with_no_vector_registers_test",
     size = "small",
     srcs = ["vectorized_reduce_with_no_vector_registers_test.cc"],
+    tags = ["no_aarch64"],
     deps = [
         ":cpu_compiler",
         ":cpu_transfer_manager",


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tensorflow/issues/53067
The tag can be used on the command line when building on or for AARCH64 platforms to exclude this test that is not applicable.