### PR TITLE
Extend TF:TRT C++ API to handle non-frozen models

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -13,6 +13,7 @@ load(
     "tf_custom_op_library",
     "tf_kernel_library",
 )
+load("@local_config_tensorrt//:build_defs.bzl", "if_tensorrt")
 
 # buildifier: disable=same-origin-load
 load("//tensorflow:tensorflow.bzl", "filegroup")
@@ -41,7 +42,9 @@ filegroup(
         "tf_tensor.h",
         "tf_tstring.h",
         "//tensorflow/core/platform:ctstring",
-    ],
+    ] + if_tensorrt([
+        "//tensorflow/compiler/tf2tensorrt:headers",
+    ]),
     visibility = ["//tensorflow:__subpackages__"],
 )
 
@@ -185,7 +188,9 @@ tf_cuda_library(
             "//tensorflow/compiler/jit",
         ],
         "//conditions:default": [],
-    }),
+    }) + if_tensorrt([
+        "//tensorflow/compiler/tf2tensorrt:trt_convert_api",
+    ]),
 )
 
 # Check that c_api_no_xla does not depend on xla.

--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -127,6 +127,7 @@ cc_library(
     deps = [
         ":trt_parameters",
         ":trt_resources",
+        "//tensorflow/cc/tools:freeze_saved_model",
         "//tensorflow/core:direct_session",
         "//tensorflow/core:framework",
         "//tensorflow/core/grappler:grappler_item_builder",
@@ -134,6 +135,13 @@ cc_library(
         "//tensorflow/core/platform:logging",
         "@com_google_absl//absl/strings",
     ] + if_tensorrt([":tensorrt_lib"]),
+)
+
+filegroup(
+    name = "headers",
+    srcs = [
+        "trt_convert_api.h",
+    ],
 )
 
 tf_cuda_cc_test(
@@ -155,11 +163,14 @@ tf_cuda_cc_test(
         ":trt_resources",
         ":utils",
         "//tensorflow/cc:cc_ops",
+        "//tensorflow/cc:resource_variable_ops",
         "//tensorflow/cc:scope",
         "//tensorflow/core:array_ops_op_lib",
         "//tensorflow/core:core_cpu",
+        "//tensorflow/core:core_cpu_internal",
         "//tensorflow/core:direct_session",
         "//tensorflow/core:framework",
+        "//tensorflow/core:function_ops_op_lib",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
         "//tensorflow/core:math_ops_op_lib",
@@ -169,8 +180,11 @@ tf_cuda_cc_test(
         "//tensorflow/core:state_ops_op_lib",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
         "//tensorflow/core/kernels:array",
+        "//tensorflow/core/kernels:assign_op",
         "//tensorflow/core/kernels:ops_testutil",
+        "//tensorflow/core/kernels:partitioned_function_ops",
         "//tensorflow/core/kernels:resource_variable_ops",
     ],
 )
@@ -370,7 +384,6 @@ cc_library(
     name = "trt_op_libs",
     deps = [
         ":get_calibration_data_op_op_lib",
-        ":trt_convert_api",
         ":trt_engine_op_op_lib",
         ":trt_engine_utils",
     ],

--- a/tensorflow/compiler/tf2tensorrt/trt_convert_api.cc
+++ b/tensorflow/compiler/tf2tensorrt/trt_convert_api.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/strings/str_join.h"
+#include "tensorflow/cc/tools/freeze_saved_model.h"
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.h"
 #include "tensorflow/core/common_runtime/device.h"
@@ -423,6 +424,83 @@ StatusOr<GraphDef> ConvertAndBuild(
   }
   VLOG(1) << "TF-TRT conversion finished";
   return output;
+}
+
+Status InlineFunctions(const MetaGraphDef& meta_graph_def,
+                       GraphDef* out_graph_def) {
+  ConfigProto config_proto;
+  auto opt_config =
+      config_proto.mutable_graph_options()->mutable_rewrite_options();
+
+  opt_config->set_meta_optimizer_iterations(tensorflow::RewriterConfig::ONE);
+  opt_config->set_min_graph_nodes(-1);  // do not skip small graphs
+  opt_config->add_optimizers("function");
+
+  TF_RETURN_IF_ERROR(RunGrappler(meta_graph_def, {}, {}, config_proto, nullptr,
+                                 out_graph_def));
+
+  VLOG(2) << "Graph is inlined";
+  return Status::OK();
+}
+
+// Freezes the graph. It is assumed that the functions are inlined and the
+// variables are initialized.
+Status FreezeGraph(SavedModelBundle& bundle, MetaGraphDef* frozen_meta_graph) {
+  std::unordered_set<std::string> inputs;
+  std::unordered_set<std::string> outputs;
+  GraphDef frozen_graph_def;
+  TF_RETURN_IF_ERROR(
+      FreezeSavedModel(bundle, &frozen_graph_def, &inputs, &outputs));
+
+  frozen_meta_graph->CopyFrom(bundle.meta_graph_def);
+  GraphDef* gdef = frozen_meta_graph->mutable_graph_def();
+  gdef->CopyFrom(frozen_graph_def);
+
+  VLOG(2) << "Graph frozen";
+  return Status::OK();
+}
+
+// Returns the name of nodes listed in the signature definition.
+std::vector<std::string> GetNodeNames(
+    const google::protobuf::Map<std::string, tensorflow::TensorInfo>&
+        signature) {
+  std::vector<std::string> names;
+  for (auto const& item : signature) {
+    absl::string_view name = item.second.name();
+    // Remove tensor suffix like ":0".
+    size_t last_colon = name.find_last_of(':');
+    if (last_colon != absl::string_view::npos) {
+      name.remove_suffix(name.size() - last_colon);
+    }
+    names.push_back(std::string(name));
+  }
+  return names;
+}
+
+StatusOr<GraphDef> ConvertAndBuild(
+    SavedModelBundle* bundle, const std::string& signature_key,
+    const std::vector<std::vector<tensorflow::Tensor>>& inputs,
+    const TfTrtConversionParams& conversion_params) {
+  // Inline the functions.
+  GraphDef inlined_graph_def;
+  TF_RETURN_IF_ERROR(
+      InlineFunctions(bundle->meta_graph_def, &inlined_graph_def));
+
+  // Replace the graph_def with the inlined graph. Note that bundle->session
+  // still has the original graph.
+  bundle->meta_graph_def.mutable_graph_def()->CopyFrom(inlined_graph_def);
+
+  // Freeze variables.
+  MetaGraphDef frozen_meta_graph;
+  TF_RETURN_IF_ERROR(FreezeGraph(*bundle, &frozen_meta_graph));
+
+  // Convert.
+  auto signature_map = bundle->GetSignatures();
+  const tensorflow::SignatureDef& signature = signature_map[signature_key];
+  std::vector<std::string> input_names = GetNodeNames(signature.inputs());
+  std::vector<std::string> output_names = GetNodeNames(signature.outputs());
+  return ConvertAndBuild(frozen_meta_graph.graph_def(), input_names,
+                         output_names, inputs, conversion_params);
 }
 
 }  // namespace tensorrt

--- a/tensorflow/compiler/tf2tensorrt/trt_convert_api.h
+++ b/tensorflow/compiler/tf2tensorrt/trt_convert_api.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "tensorflow/cc/saved_model/loader.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/trt_parameters.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/platform/statusor.h"
@@ -104,6 +105,12 @@ StatusOr<GraphDef> ConvertAndBuild(
     const std::vector<string>& output_names,
     const std::vector<std::vector<tensorflow::Tensor>>& inputs,
     const TfTrtConversionParams& conv_params);
+
+StatusOr<GraphDef> ConvertAndBuild(
+    SavedModelBundle* bundle,
+    const std::string& signature_key = "serving_default",
+    const std::vector<std::vector<tensorflow::Tensor>>& inputs = {},
+    const TfTrtConversionParams& conversion_params = TfTrtConversionParams());
 
 }  // namespace tensorrt
 }  // namespace tensorflow

--- a/tensorflow/compiler/tf2tensorrt/trt_convert_api_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/trt_convert_api_test.cc
@@ -17,7 +17,11 @@ limitations under the License.
 
 #include "tensorflow/compiler/tf2tensorrt/trt_convert_api.h"
 
+#include "tensorflow/cc/ops/resource_variable_ops.h"
 #include "tensorflow/cc/ops/standard_ops.h"
+#include "tensorflow/cc/ops/state_ops.h"
+#include "tensorflow/cc/saved_model/loader.h"
+#include "tensorflow/core/framework/function_testlib.h"
 #include "tensorflow/core/framework/tensor_testutil.h"
 #include "tensorflow/core/lib/core/status_test_util.h"
 #include "tensorflow/core/platform/test.h"
@@ -32,25 +36,131 @@ struct TestParam {
   std::vector<std::vector<int64>> input_shapes;
 };
 
-class TrtConverterTest : public ::testing::TestWithParam<TestParam> {
+class TrtConverterTest
+    : public ::testing::TestWithParam<std::tuple<TestParam, bool, bool>> {
  protected:
-  TrtConverterTest() { param_ = GetParam(); }
+  TrtConverterTest() {
+    param_ = std::get<0>(GetParam());
+    use_variable_ = std::get<1>(GetParam());
+    use_function_ = std::get<2>(GetParam());
+    input_tensors_ = GetInputTensors();
+  }
+
+  // Returns the following graph: output = input * [42, 137] + input
+  GraphDef GetGraphDef(PartialTensorShape input_shape) {
+    Scope root = Scope::NewRootScope();
+    Output c;
+    c = ops::Const(root.WithOpName("my_const"), {{42.0f, 137.0f}});
+    Output v;
+    if (use_variable_) {
+      Output v_handle = ops::VarHandleOp(root.WithOpName("my_var"),
+                                         DataType::DT_FLOAT, {1, 2});
+      v = ops::ReadVariableOp(root.WithOpName("my_var/Read/ReadVariableOp"),
+                              v_handle, DataType::DT_FLOAT);
+      auto v_init =
+          ops::AssignVariableOp(root.WithOpName("my_var/init"), v_handle, c);
+    } else {
+      v = c;
+    }
+    const auto attrs = ops::Placeholder::Shape(input_shape);
+    auto x = ops::Placeholder(root.WithOpName("input"), DT_FLOAT, attrs);
+    auto y = ops::Mul(root.WithOpName("my_mul"), x, v);
+    auto z = ops::Add(root.WithOpName("my_add"), x, y);
+    auto q = ops::Identity(root.WithOpName("output"), z);
+
+    GraphDef out;
+    TF_CHECK_OK(root.ToGraphDef(&out));
+    return out;
+  }
+
+  GraphDef GetGraphWithFunction(PartialTensorShape input_shape) {
+    using ::tensorflow::test::function::GDef;
+    using ::tensorflow::test::function::NDef;
+    GraphConstructorOptions opts;
+    const Tensor kOne = test::AsScalar<float>(1.0f);
+    TensorShapeProto value_shape_proto;
+    kOne.shape().AsProto(&value_shape_proto);
+    TensorShapeProto input_shape_proto;
+    input_shape.AsProto(&input_shape_proto);
+    NodeDef value_node;
+    if (use_variable_) {
+      value_node =
+          NDef("my_value", "Identity", {"my_var:0"}, {{"T", DT_RESOURCE}});
+    } else {
+      value_node =
+          NDef("my_value", "Identity", {"my_const:0"}, {{"T", DT_FLOAT}});
+    }
+    GraphDef gdef = GDef(
+        {
+            NDef("input", "Placeholder", {},
+                 {{"dtype", DT_FLOAT}, {"shape", input_shape_proto}}),
+            NDef("my_const", "Const", {},
+                 {{"dtype", DT_FLOAT}, {"value", kOne}}),
+            value_node,
+            NDef("call", "StatefulPartitionedCall", {"input", "my_value"},
+                 {{"Tin", DataTypeSlice{DT_FLOAT, use_variable_ ? DT_RESOURCE
+                                                                : DT_FLOAT}},
+                  {"Tout", DataTypeSlice{DT_FLOAT}},
+                  {"f", FunctionDefHelper::FunctionRef("f", {})}}),
+            NDef("output", "Identity", {"call:0"}, {{"T", DT_FLOAT}}),
+        },
+        {});
+    FunctionDef fdef;
+    if (use_variable_) {
+      gdef.add_node()->CopyFrom(
+          NDef("my_var", "VarHandleOp", {},
+               {{"dtype", DT_FLOAT}, {"shape", value_shape_proto}}));
+
+      gdef.add_node()->CopyFrom(NDef("my_var/init", "AssignVariableOp",
+                                     {"my_var", "my_const"},
+                                     {{"dtype", DT_FLOAT}}));
+      gdef.add_node()->CopyFrom(NDef("my_var/Read/ReadVariableOp",
+                                     "ReadVariableOp", {"my_var"},
+                                     {{"dtype", DT_FLOAT}}));
+      // Define function f(x, v) = x * v + x, where v is a variable.
+      fdef = FunctionDefHelper::Define(
+          "f",                          // Name
+          {"x: float", "v: resource"},  // Args
+          {"q: float"},                 // Returns
+          {},                           // Attr def
+          // Nodes
+          {{{"my_var/Read/ReadVariableOp"},
+            "ReadVariableOp",
+            {"v"},
+            {{"dtype", DT_FLOAT}}},
+           {{"my_mul"},
+            "Mul",
+            {"x", "my_var/Read/ReadVariableOp"},
+            {{"T", DT_FLOAT}}},
+           {{"my_add"}, "AddV2", {"x", "my_mul"}, {{"T", DT_FLOAT}}},
+           {{"q"}, "Identity", {"my_add"}, {{"T", DT_FLOAT}}}});
+    } else {
+      // Define function f(x, v) = x * v + x, where v is const value.
+      fdef = FunctionDefHelper::Define(
+          "f",                       // Name
+          {"x: float", "v: float"},  // Args
+          {"q: float"},              // Returns
+          {},                        // Attr def
+          // Nodes
+          {{{"my_mul"}, "Mul", {"x", "v"}, {{"T", DT_FLOAT}}},
+           {{"my_add"}, "AddV2", {"x", "my_mul"}, {{"T", DT_FLOAT}}},
+           {{"q"}, "Identity", {"my_add"}, {{"T", DT_FLOAT}}}});
+    }
+    gdef.mutable_library()->add_function()->CopyFrom(fdef);
+
+    return gdef;
+  }
 
   // Returns the following graph: output = input * [42, 137] + input
   MetaGraphDef GetModel() {
     PartialTensorShape shape({-1, 2});
-
-    Scope root = Scope::NewRootScope();
-    auto c = ops::Const(root.WithOpName("my_const"), {{42.0f, 137.0f}});
-    const auto attrs = ops::Placeholder::Shape(shape);
-    auto x = ops::Placeholder(root.WithOpName("input"), DT_FLOAT, attrs);
-    auto y = ops::Mul(root.WithOpName("my_mul"), x, c);
-    auto z = ops::Add(root.WithOpName("my_add"), x, y);
-    auto q = ops::Identity(root.WithOpName("output"), z);
-
     MetaGraphDef out;
-    TF_CHECK_OK(root.ToGraphDef(out.mutable_graph_def()));
-
+    if (use_function_) {
+      *(out.mutable_graph_def()) = GetGraphWithFunction(shape);
+    } else {
+      *(out.mutable_graph_def()) = GetGraphDef(shape);
+    }
+    VLOG(2) << out.graph_def().DebugString();
     TensorShapeProto shape_proto;
     shape.AsProto(&shape_proto);
     SignatureDef signature_def;
@@ -67,6 +177,17 @@ class TrtConverterTest : public ::testing::TestWithParam<TestParam> {
 
     VLOG(2) << signature_def.DebugString();
     return out;
+  }
+
+  Status GetSavedModelBundle(SavedModelBundle* bundle) {
+    bundle->meta_graph_def = GetModel();
+    Session* session = nullptr;
+    TF_RETURN_IF_ERROR(NewSession(tensorflow::SessionOptions(), &session));
+    TF_RETURN_IF_ERROR(session->Create(bundle->meta_graph_def.graph_def()));
+    bundle->session.reset(session);
+    TF_RETURN_IF_ERROR(session->Run(/* inputs */ {}, /*outputs*/ {},
+                                    /*targets*/ {"my_var/init"}, nullptr));
+    return Status::OK();
   }
 
   // Confirms that we have a TRT node with the correct attributes.
@@ -89,37 +210,27 @@ class TrtConverterTest : public ::testing::TestWithParam<TestParam> {
     EXPECT_EQ(n_trt_ops, 1);
   }
 
-  void ConvertAndRun() {
-    MetaGraphDef meta_graph_def = GetModel();
-
-    // Create a list of input tensors, they will be used to build the engines.
+  // Creates a list of input tensors, they will be used to build the engines.
+  std::vector<std::vector<Tensor>> GetInputTensors() {
     std::vector<std::vector<Tensor>> input_tensors;
     for (const std::vector<int64>& shape : param_.input_shapes) {
       Tensor tensor(DT_FLOAT, TensorShape(shape));
       test::FillIota(&tensor, 1.0f);
       input_tensors.push_back({tensor});
     }
+    return input_tensors;
+  }
 
-    StatusOr<GraphDef> result = tensorrt::ConvertAndBuild(
-        meta_graph_def.graph_def(), {"input"}, {"output"}, input_tensors,
-        param_.conv_params);
-    TF_ASSERT_OK(result.status());
-    const GraphDef& converted_graph_def = result.ValueOrDie();
-    CheckTrtNode(converted_graph_def);
-
-    // Create sessions to execute the original and the converted graphs.
+  void RunAndCompareResults(Session* session,
+                            const GraphDef& converted_graph_def) {
+    // Create a session to execute the converted graph.
     Session* p_session = nullptr;
-    TF_EXPECT_OK(NewSession(SessionOptions(), &p_session));
-    std::unique_ptr<tensorflow::Session> session(p_session);
-    TF_EXPECT_OK(session->Create(meta_graph_def.graph_def()));
-
-    p_session = nullptr;
     TF_EXPECT_OK(NewSession(SessionOptions(), &p_session));
     std::unique_ptr<tensorflow::Session> trt_session(p_session);
     TF_EXPECT_OK(trt_session->Create(converted_graph_def));
 
     // Run models and compare the output.
-    for (const std::vector<Tensor>& input : input_tensors) {
+    for (const std::vector<Tensor>& input : input_tensors_) {
       std::vector<Tensor> outputs;
       TF_EXPECT_OK(
           session->Run({{"input", input.at(0)}}, {"output"}, {}, &outputs));
@@ -134,70 +245,116 @@ class TrtConverterTest : public ::testing::TestWithParam<TestParam> {
       tensorflow::test::ExpectEqual(outputs[0], trt_outputs[0]);
     }
   }
+
+  void ConvertAndRunFrozenGraph() {
+    MetaGraphDef meta_graph_def = GetModel();
+
+    StatusOr<GraphDef> result = tensorrt::ConvertAndBuild(
+        meta_graph_def.graph_def(), {"input"}, {"output"}, input_tensors_,
+        param_.conv_params);
+    TF_ASSERT_OK(result.status());
+    const GraphDef& converted_graph_def = result.ValueOrDie();
+    CheckTrtNode(converted_graph_def);
+
+    // Create a session to execute the original graph.
+    Session* p_session = nullptr;
+    TF_EXPECT_OK(NewSession(SessionOptions(), &p_session));
+    std::unique_ptr<tensorflow::Session> session(p_session);
+    TF_EXPECT_OK(session->Create(meta_graph_def.graph_def()));
+
+    RunAndCompareResults(session.get(), converted_graph_def);
+  }
+
+  void ConvertAndRunSavedModel() {
+    SavedModelBundle bundle;
+    TF_CHECK_OK(GetSavedModelBundle(&bundle));
+
+    StatusOr<GraphDef> result = tensorrt::ConvertAndBuild(
+        &bundle, "serving_default", input_tensors_, param_.conv_params);
+    TF_ASSERT_OK(result.status());
+    const GraphDef& converted_graph_def = result.ValueOrDie();
+    CheckTrtNode(converted_graph_def);
+
+    RunAndCompareResults(bundle.GetSession(), converted_graph_def);
+  }
+
   TestParam param_;
+  bool use_variable_;
+  bool use_function_;
+  std::vector<std::vector<Tensor>> input_tensors_;
 };
 
 INSTANTIATE_TEST_CASE_P(
     TrtConverterTestInstantiation, TrtConverterTest,
-    ::testing::Values(
-        // Dynamic shape mode test with conver_to_static_engine=true.
-        TestParam{TfTrtConversionParams{
-                      1 << 20,  // max workspace size
-                      TrtPrecisionMode::FP32,
-                      3,      // minimum_segment_size
-                      1,      // max_cached_engines
-                      false,  // use_calibration
-                      true,   // use_dynamic_shape
-                      ProfileStrategy::kOptimal,
-                      true,  // allow_build_at_runtime
-                      true   // convert_to_static_engine
-                  },
-                  {{1, 2}, {4, 2}}},
-        // Implicit batch mode test with conver_to_static_engine=true.
-        TestParam{TfTrtConversionParams{
-                      1 << 20,  // max workspace size
-                      TrtPrecisionMode::FP16,
-                      3,      // minimum_segment_size
-                      1,      // max_cached_engines
-                      false,  // use_calibration
-                      false,  // use_dynamic_shape
-                      ProfileStrategy::kRange,
-                      true,  // allow_build_at_runtime
-                      true   // convert_to_static_engine
-                  },
-                  {{1, 2}}},
-        // Dynamic shape mode test convert_to_static_engine=false: we cannot
-        // save the engines, therefore we do not generate profiles. A single
-        // engine will be built during runtime, with profile that matches the
-        // first shape ({1,2}). The second shape will run as native segment.
-        TestParam{TfTrtConversionParams{
-                      1 << 20,  // max workspace size
-                      TrtPrecisionMode::FP32,
-                      3,      // minimum_segment_size
-                      1,      // max_cached_engines
-                      false,  // use_calibration
-                      true,   // use_dynamic_shape
-                      ProfileStrategy::kOptimal,
-                      true,  // allow_build_at_runtime
-                      false  // convert_to_static_engine
-                  },
-                  {{1, 2}, {4, 2}}},
-        // Implicit batch mode test with convert_to_static_engine=false. We
-        // will have two engines in the cache to handle the two shapes.
-        TestParam{TfTrtConversionParams{
-                      1 << 20,  // max workspace size
-                      TrtPrecisionMode::FP16,
-                      3,      // minimum_segment_size
-                      2,      // max_cached_engines
-                      false,  // use_calibration
-                      false,  // use_dynamic_shape
-                      ProfileStrategy::kRange,
-                      true,  // allow_build_at_runtime
-                      false  // convert_to_static_engine
-                  },
-                  {{1, 2}, {4, 2}}}));
+    ::testing::Combine(
+        ::testing::Values(
+            // Dynamic shape mode test with conver_to_static_engine=true.
+            TestParam{TfTrtConversionParams{
+                          1 << 20,  // max workspace size
+                          TrtPrecisionMode::FP32,
+                          3,      // minimum_segment_size
+                          1,      // max_cached_engines
+                          false,  // use_calibration
+                          true,   // use_dynamic_shape
+                          ProfileStrategy::kOptimal,
+                          true,  // allow_build_at_runtime
+                          true   // convert_to_static_engine
+                      },
+                      {{1, 2}, {4, 2}}},
+            // Implicit batch mode test with conver_to_static_engine=true.
+            TestParam{TfTrtConversionParams{
+                          1 << 20,  // max workspace size
+                          TrtPrecisionMode::FP16,
+                          3,      // minimum_segment_size
+                          1,      // max_cached_engines
+                          false,  // use_calibration
+                          false,  // use_dynamic_shape
+                          ProfileStrategy::kRange,
+                          true,  // allow_build_at_runtime
+                          true   // convert_to_static_engine
+                      },
+                      {{1, 2}}},
+            // Dynamic shape mode test convert_to_static_engine=false: we cannot
+            // save the engines, therefore we do not generate profiles. A single
+            // engine will be built during runtime, with profile that matches
+            // the first shape ({1,2}). The second shape will run as native
+            // segment.
+            TestParam{TfTrtConversionParams{
+                          1 << 20,  // max workspace size
+                          TrtPrecisionMode::FP32,
+                          3,      // minimum_segment_size
+                          1,      // max_cached_engines
+                          false,  // use_calibration
+                          true,   // use_dynamic_shape
+                          ProfileStrategy::kOptimal,
+                          true,  // allow_build_at_runtime
+                          false  // convert_to_static_engine
+                      },
+                      {{1, 2}, {4, 2}}},
+            // Implicit batch mode test with convert_to_static_engine=false.
+            // We will have two engines in the cache to handle the two shapes.
+            TestParam{TfTrtConversionParams{
+                          1 << 20,  // max workspace size
+                          TrtPrecisionMode::FP16,
+                          3,      // minimum_segment_size
+                          2,      // max_cached_engines
+                          false,  // use_calibration
+                          false,  // use_dynamic_shape
+                          ProfileStrategy::kRange,
+                          true,  // allow_build_at_runtime
+                          false  // convert_to_static_engine
+                      },
+                      {{1, 2}, {4, 2}}}),
+        ::testing::Values(false, true),    // use_variables
+        ::testing::Values(false, true)));  // use_function
 
-TEST_P(TrtConverterTest, Basic) { ConvertAndRun(); }
+TEST_P(TrtConverterTest, Basic) {
+  if (use_variable_) {
+    ConvertAndRunSavedModel();
+  } else {
+    ConvertAndRunFrozenGraph();
+  }
+}
 
 }  // namespace tensorrt
 }  // namespace tensorflow


### PR DESCRIPTION
This PR extends the C++ converter API of TF-TRT #52012 to handle models that are not frozen (i.e. contains variables).

Depends on #53310 . Tracker #45481.