### PR TITLE
[ROCm] Mark a few GPU tests as CUDA only

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_test.cc
@@ -114,7 +114,7 @@ class GPUDeviceTest : public ::testing::Test {
   }
 };
 
-TEST_F(GPUDeviceTest, CudaMallocAsync) {
+TEST_F(GPUDeviceTest, DISABLED_ON_GPU_ROCM(CudaMallocAsync)) {
   // cudaMallocAsync supported only when cuda toolkit and driver supporting
   // CUDA 11.2+
 #ifndef GOOGLE_CUDA
@@ -159,7 +159,7 @@ TEST_F(GPUDeviceTest, CudaMallocAsync) {
   EXPECT_EQ(status.code(), error::OK);
 }
 
-TEST_F(GPUDeviceTest, CudaMallocAsyncPreallocate) {
+TEST_F(GPUDeviceTest, DISABLED_ON_GPU_ROCM(CudaMallocAsyncPreallocate)) {
   SessionOptions opts = MakeSessionOptions("0", 0, 1, {}, {},
                                            /*use_cuda_malloc_async=*/true);
   setenv("TF_CUDA_MALLOC_ASYNC_SUPPORTED_PREALLOC", "2048", 1);

--- a/tensorflow/core/platform/test.h
+++ b/tensorflow/core/platform/test.h
@@ -46,6 +46,12 @@ limitations under the License.
 #endif
 #include <gmock/gmock.h>
 
+#define DISABLED_ON_GPU_ROCM(X) X
+#if TENSORFLOW_USE_ROCM
+#undef DISABLED_ON_GPU_ROCM
+#define DISABLED_ON_GPU_ROCM(X) DISABLED_##X
+#endif  // TENSORFLOW_USE_ROCM
+
 namespace tensorflow {
 namespace testing {
 


### PR DESCRIPTION
The CudaMallocAsync tests in `//tensorflow/core/common_runtime/gpu:gpu_device_test_gpu` are CUDA specific. This PR marks these as DISABLED_ on ROCM platforms. 