### PR TITLE
ROCm specific fix to enable GPU unit tests to pass.

### DIFF
--- a/tensorflow/core/kernels/conv_ops_gpu.cc
+++ b/tensorflow/core/kernels/conv_ops_gpu.cc
@@ -296,10 +296,7 @@ StatusOr<AutotuneEntry<se::dnn::ConvOp>> AutotuneUnfusedConv(
       auto profile_result = algorithms[0];
       results.emplace_back();
       auto& result = results.back();
-      result.mutable_conv()->set_algorithm(
-          profile_result.algorithm().algo_id());
-      result.mutable_conv()->set_tensor_ops_enabled(
-          profile_result.algorithm().tensor_ops_enabled());
+      *result.mutable_algorithm() = profile_result.algorithm().ToProto();
 
       result.set_scratch_bytes(profile_result.scratch_size());
       *result.mutable_run_time() = proto_utils::ToDurationProto(
@@ -317,9 +314,7 @@ StatusOr<AutotuneEntry<se::dnn::ConvOp>> AutotuneUnfusedConv(
         if (miopen_launch_status.ok() && profile_result.is_valid()) {
           results.emplace_back();
           auto& result = results.back();
-          result.mutable_conv()->set_algorithm(profile_algorithm.algo_id());
-          result.mutable_conv()->set_tensor_ops_enabled(
-              profile_algorithm.tensor_ops_enabled());
+          *result.mutable_algorithm() = profile_algorithm.ToProto();
 
           result.set_scratch_bytes(scratch_allocator.TotalByteSize());
           *result.mutable_run_time() = proto_utils::ToDurationProto(

--- a/tensorflow/core/kernels/gpu_utils.cc
+++ b/tensorflow/core/kernels/gpu_utils.cc
@@ -258,16 +258,16 @@ StatusOr<se::dnn::AlgorithmConfig> BestCudnnConvAlgorithm(
                       BestCudnnConvAlgorithmIndices(results));
   VLOG(2) << "fastest algorithm: "
           << proto_utils::FromDurationProto(results[idx].run_time())
-          << " with algo " << results[idx].conv().algorithm()
+          << " with algo " << results[idx].algorithm().algo_id()
           << ", workspace bytes " << results[idx].scratch_bytes();
 
-  se::dnn::AlgorithmConfig result({results[idx].conv().algorithm(),
-                                   results[idx].conv().tensor_ops_enabled()},
-                                  results[idx].scratch_bytes());
+  se::dnn::AlgorithmConfig result(
+      se::dnn::AlgorithmDesc(results[idx].algorithm()),
+      results[idx].scratch_bytes());
+
   if (idx_no_scratch != -1) {
     result.set_algorithm_no_scratch(
-        {results[idx_no_scratch].conv().algorithm(),
-         results[idx_no_scratch].conv().tensor_ops_enabled()});
+        se::dnn::AlgorithmDesc(results[idx_no_scratch].algorithm()));
   }
   return result;
 }


### PR DESCRIPTION
The reason this is necessary is because of recent changes to the ROCm specific convrunner which requires the workspace_size attribute to be present in the algorithm descriptor.

/cc @cheshire @chsigg @jurahul 