### PR TITLE
[TF-TRT] Provide a way to use different Grappler optimizers for the function library than the main graph

### DIFF
--- a/tensorflow/core/grappler/optimizers/meta_optimizer.h
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.h
@@ -68,15 +68,18 @@ class MetaOptimizer : public GraphOptimizer {
   // Initialize active optimizers from RewriterConfig optimizer names.
   Status InitializeOptimizersByName(
       const std::set<string>& device_types,
-      std::vector<std::unique_ptr<GraphOptimizer>>* optimizers) const;
+      std::vector<std::unique_ptr<GraphOptimizer>>* optimizers,
+      bool is_main_graph = true) const;
   // Initialize active optimizers from RewriterConfig.custom_optimizers.
   Status InitializeCustomGraphOptimizers(
       const std::set<string>& device_types,
       const std::set<string>& pre_initialized_optimizers,
-      std::vector<std::unique_ptr<GraphOptimizer>>* optimizers) const;
+      std::vector<std::unique_ptr<GraphOptimizer>>* optimizers,
+      bool is_main_graph = true) const;
   Status InitializePluginGraphOptimizers(
       const std::set<string>& device_types,
-      std::vector<std::unique_ptr<GraphOptimizer>>* optimizers) const;
+      std::vector<std::unique_ptr<GraphOptimizer>>* optimizers,
+      bool is_main_graph = true) const;
   // Returns the config for a custom graph optimizer. Null if none was found.
   const RewriterConfig::CustomGraphOptimizer* GetCustomGraphOptimizerConfig(
       const string& name) const;
@@ -92,7 +95,7 @@ class MetaOptimizer : public GraphOptimizer {
   // Run optimization pass over a single GrapplerItem. Meta optimizer might run
   // multiple such passes: 1) for the main graph 2) for the function library
   Status OptimizeGraph(Cluster* cluster, GrapplerItem&& item,
-                       GraphDef* optimized_graph);
+                       GraphDef* optimized_graph, bool is_main_graph = true);
 
   DeviceBase* const cpu_device_;  // may be NULL
   ConfigProto config_proto_;

--- a/tensorflow/core/protobuf/rewriter_config.proto
+++ b/tensorflow/core/protobuf/rewriter_config.proto
@@ -220,4 +220,25 @@ message RewriterConfig {
   // VerifierConfig specifying the verifiers to be run at the end, after all
   // optimizers have run.
   VerifierConfig post_optimization_verifier_config = 301;
+
+  // If override_function_library_optimizers is true, specifies the
+  // optimizations to turn on when optimizing the function library, and the
+  // order of the optimizations.
+  repeated string function_library_optimizers = 400;
+
+  // If override_function_library_optimizers is true, specifies the
+  // custom optimizers to apply when optimizing the function library.
+  repeated CustomGraphOptimizer function_library_custom_optimizers = 401;
+
+  // If true, will use the optimizers defined by function_library_optimizers and
+  // function_library_custom_optimizers when optimizing the function library
+  // (doesn't affect optimization of the main graph).
+  //
+  // This can also be used to disable optimization of the function library by
+  // keeping these lists empty.
+  bool override_function_library_optimizers = 402;
+
+  // If true, override the value of use_plugin_optimizers when optimizing the
+  // function library.
+  bool disable_plugin_optimizers_for_function_library = 403;
 }

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -311,6 +311,13 @@ def _get_tensorrt_rewriter_config(conversion_params,
     rewriter_config_with_trt.optimizers.extend(
         ["constfold", "layout", "constfold"])
 
+    # TODO: change defaults, this is just a placeholder
+    rewriter_config_with_trt.override_function_library_optimizers = True
+    rewriter_config_with_trt.disable_plugin_optimizers_for_function_library \
+      = True
+    rewriter_config_with_trt.function_library_optimizers.extend(
+        ["constfold"])
+
   rewriter_config_with_trt.meta_optimizer_iterations = (
       rewriter_config_pb2.RewriterConfig.ONE)
   optimizer = rewriter_config_with_trt.custom_optimizers.add()


### PR DESCRIPTION
This is a POC that probably needs some refining. During TF-TRT conversion, we need to turn on different optimizers during optimization of the main graph and `TRTEngine` functions. Since other functions are inlined, it is effectively equivalent to using different optimizers for the function library.

### How it works

- Add fields to `RewriterConfig` to specify an alternate list of optimizers and custom optimizers, along with a boolean to toggle the use of these alternate lists. The default behavior doesn't change (i.e same optimizers for the main graph and function library)
- Add an optional parameter to `MetaOptimizer::OptimizeGraph()` and helper functions to know whether the main graph or function library is being optimized, and set this parameter when optimizing the function library in `MetaOptimizer::OptimizeConsumeItem()`.
- When optimizing the function library, get the optimizer list from these new fields if the boolean is true.

### Example of TRT conversion logs (BERT Base)

```
Optimization results for grappler item: tf_graph
  constant_folding: Graph size after: 2884 nodes (-409), 3897 edges (-410), time = 2186.9751ms.
  layout: Graph size after: 2884 nodes (0), 3897 edges (0), time = 1524.755ms.
  constant_folding: Graph size after: 2884 nodes (0), 3897 edges (0), time = 447.266ms.
  TensorRTOptimizer: Graph size after: 521 nodes (-2363), 664 edges (-3233), time = 4766.79492ms.
  constant_folding: Graph size after: 229 nodes (-292), 445 edges (-219), time = 247.384ms.
Optimization results for grappler item: TRTEngineOp_0_2_native_segment
  constant_folding: Graph size after: 8 nodes (0), 7 edges (0), time = 1.111ms.
Optimization results for grappler item: TRTEngineOp_0_1_native_segment
  constant_folding: Graph size after: 36 nodes (0), 37 edges (0), time = 45.684ms.
Optimization results for grappler item: TRTEngineOp_0_0_native_segment
  constant_folding: Graph size after: 2689 nodes (0), 3132 edges (0), time = 455.876ms.
```

### TODO

- [ ] Gather feedback
- [ ] Add tests
- [ ] Change defaults in `trt_convert.py`