### PR TITLE
[TF:TRT] Fix TrtUniquePtr warnings/error for TRT 8.2

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -28,6 +28,7 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "absl/algorithm/container.h"
 #include "absl/base/call_once.h"
 #include "absl/strings/match.h"
@@ -36,8 +37,6 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 #include "tensorflow/cc/ops/nn_ops_internal.h"
@@ -67,6 +66,8 @@ limitations under the License.
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/protobuf/config.pb.h"  // NOLINT
 #include "tensorflow/core/public/session.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/tensorrt/NvInfer.h"
 
 namespace tensorflow {
@@ -156,7 +157,7 @@ void PreventUnloadBuilderResources() {
   static TrtUniquePtrType<nvinfer1::IBuilder> hold_builder = nullptr;
   absl::call_once(
       once,
-      [](std::unique_ptr<nvinfer1::IBuilder>& builder) {
+      [](TrtUniquePtrType<nvinfer1::IBuilder>& builder) {
         if (!builder) {
           builder.reset(nvinfer1::createInferBuilder(*Logger::GetLogger()));
         }

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -40,15 +40,19 @@ namespace tensorrt {
 
 static constexpr char kCastOutputTypeAttrName[] = "DstT";
 
+#if !IS_TRT_VERSION_GE(8, 2, 0, 0)
 template <typename T>
 struct TrtDestroyer {
   void operator()(T* t) {
     if (t) t->destroy();
   }
 };
-
 template <typename T>
 using TrtUniquePtrType = std::unique_ptr<T, TrtDestroyer<T>>;
+#else
+template <typename T>
+using TrtUniquePtrType = std::unique_ptr<T>;
+#endif
 
 // Define a hash function for vector<TensorShape> because it is used as the key
 // for the engine cache.


### PR DESCRIPTION
In TensorRT 8.2, the `destroy` method was deprecated for API objects. Instead, API users are expected to use `delete` or standard managed pointers after receiving a pointer to an API object created by TensorRT. This change is applied to the `TrtUniquePtr` type used through TF-TRT.