### PR TITLE
update TensorShape::CheckDimsAtLeast

### DIFF
--- a/tensorflow/core/framework/tensor_shape.cc
+++ b/tensorflow/core/framework/tensor_shape.cc
@@ -46,8 +46,8 @@ void TensorShape::CheckDimsEqual(int NDIMS) const {
                           << " from a tensor of " << dims() << " dimensions";
 }
 
-void TensorShape::CheckDimsAtLeast(int NDIMS) const {
-  CHECK_GE(NDIMS, dims()) << "Asking for tensor of at least " << NDIMS
+void TensorShape::CheckDimsAtMost(int NDIMS) const {
+  CHECK_GE(NDIMS, dims()) << "Asking for tensor of at most " << NDIMS
                           << " dimensions from a tensor of " << dims()
                           << " dimensions";
 }

--- a/tensorflow/core/framework/tensor_shape.h
+++ b/tensorflow/core/framework/tensor_shape.h
@@ -414,8 +414,8 @@ class TensorShape : public TensorShapeBase<TensorShape> {
   // These CHECK fail to ease debugging.
   // REQUIRES: dims() == NDIMS
   void CheckDimsEqual(int NDIMS) const;
-  // REQUIRES: dims() >= NDIMS
-  void CheckDimsAtLeast(int NDIMS) const;
+  // REQUIRES: dims() <= NDIMS
+  void CheckDimsAtMost(int NDIMS) const;
 
   // Fill output from `*this`.
   // Helper method for common code between `AsEigenDSize()` and
@@ -653,7 +653,7 @@ Status TensorShape::AsEigenDSizesWithStatus(
 
 template <int NDIMS, typename IndexType>
 Eigen::DSizes<IndexType, NDIMS> TensorShape::AsEigenDSizesWithPadding() const {
-  CheckDimsAtLeast(NDIMS);
+  CheckDimsAtMost(NDIMS);
   return AsEigenDSizesCopyAndPad<NDIMS, IndexType>();
 }
 


### PR DESCRIPTION
 The declaration of `CheckDimsAtLeast` states that 
> REQUIRES: dims() >= NDIMS