### PR TITLE
Fixing version mismatch of Keras and  TF in  2.6

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -103,7 +103,7 @@ REQUIRED_PACKAGES = [
     # When updating these, please also update the nightly versions below
     'tensorboard >= 2.6.0, < 2.7',
     'tensorflow_estimator >= 2.6.0, < 2.7',
-    'keras ~= 2.6.0',
+    'keras > 2.5.0, < 2.7',
 ]
 
 

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -103,7 +103,7 @@ REQUIRED_PACKAGES = [
     # When updating these, please also update the nightly versions below
     'tensorboard >= 2.6.0, < 2.7',
     'tensorflow_estimator >= 2.6.0, < 2.7',
-    'keras >= 2.6.0, < 2.7',
+    'keras ~= 2.6.0',
 ]
 
 


### PR DESCRIPTION
Editing 2.6.0 as default version for Keras  in TF 2.6 Branch , As it is still throwing 

> AlreadyExistsError: Another metric with the same name already exists.

 error for 2.6 users.[Reference1](https://github.com/tensorflow/tensorflow/issues/53077),[Reference2](https://github.com/tensorflow/tensorflow/issues/52922)