### PR TITLE
Update documentation of `DataFormatVecPermute` operation

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_DataFormatVecPermute.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DataFormatVecPermute.pbtxt
@@ -3,13 +3,13 @@ op {
   in_arg {
     name: "x"
     description: <<END
-Vector of size 4 or Tensor of shape (4, 2) in source data format.
+Tensor of rank 1 or 2 in source data format.
 END
   }
   out_arg {
     name: "y"
     description: <<END
-Vector of size 4 or Tensor of shape (4, 2) in destination data format.
+Tensor of rank 1 or 2 in destination data format.
 END
   }
   attr {
@@ -26,25 +26,36 @@ END
   }
   summary: "Permute input tensor from `src_format` to `dst_format`."
   description: <<END
-Input tensor must be a vector of size 4, or a 4x2 tensor.
+Given a source and destination format strings of length n=4 or 5, the input
+tensor must be a vector of size n or n-2, or a 2D tensor of shape
+(n, 2) or (n-2, 2).
 
-For example, with `src_format` of `NHWC`, `dst_format` of `NCHW`, and inputs:
+If the first dimension of the input tensor is n-2, it is assumed that
+non-spatial dimensions are omitted (i.e `N`, `C`).
+
+For example, with `src_format` of `NHWC`, `dst_format` of `NCHW`, and input:
 ```
 [1, 2, 3, 4]
 ```
-and
-```
-[[1, 2, 3, 4],
- [5, 6, 7, 8]]
-```
-, the outputs will be (respectively):
+, the output will be:
 ```
 [1, 4, 2, 3]
 ```
-and
+With `src_format` of `NDHWC`, `dst_format` of `NCDHW`, and input:
 ```
-[[1, 4, 2, 3],
- [5, 8, 6, 7]]
+[[1, 6], [2, 7], [3, 8], [4, 9], [5, 10]]
+```
+, the output will be:
+```
+[[1, 6], [5, 10], [2, 7], [3, 8], [4, 9]]
+```
+With `src_format` of `NHWC`, `dst_format` of `NCHW`, and input:
+```
+[1, 2]
+```
+, the output will be:
+```
+[1, 2]
 ```
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_DataFormatVecPermute.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_DataFormatVecPermute.pbtxt
@@ -26,7 +26,7 @@ END
   }
   summary: "Permute input tensor from `src_format` to `dst_format`."
   description: <<END
-Given a source and destination format strings of length n=4 or 5, the input
+Given source and destination format strings of length n=4 or 5, the input
 tensor must be a vector of size n or n-2, or a 2D tensor of shape
 (n, 2) or (n-2, 2).
 


### PR DESCRIPTION
Resolves #53157 
cc @bixia1 

- Fixes invalid shape in the example.
- Updated description of supported inputs.