### PR TITLE
Correct use of StringRef and ArrayRef

### DIFF
--- a/tensorflow/core/ir/ops.cc
+++ b/tensorflow/core/ir/ops.cc
@@ -194,7 +194,7 @@ void TFGraphDialect::printCustomTfOp(Operation *op,
   }
 
   // Handles the optional "device" and "name" attribute.
-  ArrayRef<llvm::StringRef> keywords{"_mlir_device", "_mlir_assigned_device",
+  std::array<llvm::StringRef, 3> keywords{"_mlir_device", "_mlir_assigned_device",
                                      "_mlir_name"};
   for (StringRef keyword : keywords) {
     if (StringAttr value_attr = op->getAttrOfType<StringAttr>(keyword))


### PR DESCRIPTION
Current code takes a reference to transient objects which go out of scope and get overwritten. This renders the references taken invalid and leads to incorrect operation and possible SIGSEGV.
The objects referred to by StringRef and ArrayRef need to have their own independent lifetime.
Fixes https://github.com/tensorflow/tensorflow/issues/53166