### PR TITLE
Update documentation of the tf.nn.softmax function

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -3831,9 +3831,10 @@ def softmax_v2(logits, axis=None, name=None):
   is 1.
 
   This function performs the equivalent of
-
-      softmax = tf.exp(logits) / tf.reduce_sum(tf.exp(logits), axis, keepdims=True)
-
+  
+  ```
+  softmax = tf.exp(logits) / tf.reduce_sum(tf.exp(logits), axis, keepdims=True)
+  ```
   Example usage:
 
   >>> softmax = tf.nn.softmax([-1, 0., 1.])

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4636,8 +4636,8 @@ def avg_pool3d(input, ksize, strides, padding, data_format="NDHWC", name=None): 
   window in `value`.
 
   Args:
-    input: A 5-D `Tensor` of shape `[batch, depth, height, width, channels]` and type
-      `float32`, `float64`, `qint8`, `quint8`, or `qint32`.
+    input: A 5-D `Tensor` of shape `[batch, depth, height, width, channels]`
+      and type `float32`, `float64`, `qint8`, `quint8`, or `qint32`.
     ksize: An int or list of `ints` that has length `1`, `3` or `5`. The size of
       the window for each dimension of the input tensor.
     strides: An int or list of `ints` that has length `1`, `3` or `5`. The

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -3832,7 +3832,7 @@ def softmax_v2(logits, axis=None, name=None):
 
   This function performs the equivalent of
 
-      softmax = tf.exp(logits) / tf.reduce_sum(tf.exp(logits), axis)
+      softmax = tf.exp(logits) / tf.reduce_sum(tf.exp(logits), axis, keepdims=True)
 
   Example usage:
 


### PR DESCRIPTION
This PR addresses the issue #53112 

As discussed, the tf.nn.softmax documentation states that:

> This function performs the equivalent of
> ```
> softmax = tf.exp(logits) / tf.reduce_sum(tf.exp(logits), axis)
> ```

However the above computation is wrong for tensors with rank greater than 1.

I belive that the correct description would be:
```
softmax = tf.exp(logits) / tf.reduce_sum(tf.exp(logits), axis, keepdims=True)
```