### PR TITLE
TF:TRT Fix shape value collection

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+
 from tensorflow.python.compiler.tensorrt.test import tf_trt_integration_test_base as trt_test
 from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import array_ops
@@ -184,6 +186,43 @@ class PrunedInputTest2(trt_test.TfTrtIntegrationTestBase):
     # Shape op is only converted in dynamic shape mode.
     return (run_params.dynamic_shape and
             run_params.is_v2, "test v2 dynamic shape")
+
+
+class ShapeValueMaskTest(trt_test.TfTrtIntegrationTestBase):
+  """Confirm that 0D and 1D non int tensors are not treated as shape tensors."""
+
+  def setUp(self):
+    super().setUp()
+    # This is to test whether shape value mask is correctly set in case engine
+    # construction has failed.
+    os.environ['TF_TRT_ABORT_CUDA_ENGINE_BUILD'] = 'True'
+    os.environ['TF_TRT_ALLOW_ENGINE_NATIVE_SEGMENT_EXECUTION'] = 'True'
+
+  def tearDown(self):
+    super().tearDown()
+    os.environ['TF_TRT_ABORT_CUDA_ENGINE_BUILD'] = 'False'
+    os.environ['TF_TRT_ALLOW_ENGINE_NATIVE_SEGMENT_EXECUTION'] = 'False'
+
+  def GraphFn(self, x, y):
+    q = 2 * x + y
+    return array_ops.identity(q, name="output_0")
+
+  def GetParams(self):
+    return self.BuildParamsWithMask(
+        self.GraphFn,
+        dtypes.float16, [[3],[]], [[3]],
+        extra_inputs=[],
+        extra_outputs=[],
+        input_mask=[[True], []],
+        output_mask=[[True]])
+
+  def ExpectedEnginesToBuild(self, run_params):
+    """Returns the expected engines to build."""
+    if run_params.dynamic_shape:
+      return ["TRTEngineOp_0"]
+    else:
+      return []
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
TRT has a special API to specify shape value inputs, therefore TF-TRT uses a boolean mask (`is_shape_value_`) that defines which input tensors correspond to shape inputs. 

Whether a tensor is a shape tensor (from TRT's point of view) can be only determined once the TRT network is constructed (or equivalently, the TRT engine is loaded). If the network construction (or engine loading during deserialization) fails, then the input mask might not be correctly initialized, which can lead to an error in the subsequent memory copy. This PR fixes the initialization of the `is_shape_value_` mask to avoid this error.

Tagging @bixia1 for review and @DEKHTIARJonathan for visibility.