### PR TITLE
tflite_runtime: Loosen numpy requirement

### DIFF
--- a/tensorflow/lite/tools/pip_package/setup_with_binary.py
+++ b/tensorflow/lite/tools/pip_package/setup_with_binary.py
@@ -67,5 +67,6 @@ setup(
     package_dir={'': '.'},
     package_data={'': ['*.so', '*.pyd']},
     install_requires=[
-        'numpy ~= 1.19.2',  # Higher versions have a compatibility issue.
+        'numpy >= 1.19.2',  # Better to keep sync with both TF ci_build
+                            # and OpenCV-Python requirement.
     ])


### PR DESCRIPTION
It's a common use case that using OpenCV with tflite_runtime. Since OpenCV requires minimum 1.19.3, we'd better loosen the numpy requirement of tflite_runtime.

PiperOrigin-RevId: 411936173
Change-Id: Idfda9382e5af534a2fc1beffcadc6428acc12201