### PR TITLE
If args is a list, the value of parameter `shell` should be true.

### DIFF
--- a/tensorflow/tools/pip_package/check_load_py_test.py
+++ b/tensorflow/tools/pip_package/check_load_py_test.py
@@ -31,7 +31,7 @@ def check_output_despite_error(args):
     output as string.
   """
   try:
-    output = subprocess.check_output(args, shell=True, stderr=subprocess.STDOUT)
+    output = subprocess.check_output(args, shell=False, stderr=subprocess.STDOUT)
   except subprocess.CalledProcessError as e:
     output = e.output
   return output.strip()


### PR DESCRIPTION
If args is a list, shouldn't the value of parameter a be true? Otherwise, only the first item in the args list will be executed as a shell character. 