### PR TITLE
Refactor SparseSplit kernel into a device-specific functor

### DIFF
--- a/tensorflow/core/kernels/sparse_split_op.cc
+++ b/tensorflow/core/kernels/sparse_split_op.cc
@@ -15,12 +15,116 @@ limitations under the License.
 
 #define EIGEN_USE_THREADS
 
+#include "tensorflow/core/kernels/sparse_split_op.h"
+
 #include <vector>
+
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/util/sparse/sparse_tensor.h"
 
 namespace tensorflow {
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+
+namespace functor {
+
+template <typename T>
+struct SparseSplitFunctor<CPUDevice, T> {
+  void operator()(OpKernelContext* context, const Tensor& input_indices,
+                  const Tensor& input_values, const TensorShape& dense_shape,
+                  const int64_t axis, const int num_split,
+                  typename AsyncOpKernel::DoneCallback done) {
+    (void)done;  // Unused (only used in GPU implementation)
+    sparse::SparseTensor sparse_tensor;
+    OP_REQUIRES_OK(context,
+                   sparse::SparseTensor::Create(input_indices, input_values,
+                                                dense_shape, &sparse_tensor));
+
+    std::vector<sparse::SparseTensor> outputs;
+    OP_REQUIRES_OK(context, sparse::SparseTensor::Split<T>(
+                                sparse_tensor, axis, num_split, &outputs));
+
+    for (int slice_index = 0; slice_index < num_split; ++slice_index) {
+      context->set_output(slice_index, outputs[slice_index].indices());
+      context->set_output(slice_index + num_split,
+                          outputs[slice_index].values());
+      Tensor* shape = nullptr;
+      OP_REQUIRES_OK(context, context->allocate_output(
+                                  slice_index + 2 * num_split,
+                                  {outputs[slice_index].dims()}, &shape));
+      auto output_shape = outputs[slice_index].shape();
+      for (int dim = 0; dim < outputs[slice_index].dims(); ++dim) {
+        shape->vec<int64_t>()(dim) = output_shape[dim];
+      }
+    }
+  }
+};
+
+}  // namespace functor
+
+namespace {
+
+template <typename Device, typename T>
+void SparseSplitOpImpl(OpKernelContext* context, int num_split,
+                       AsyncOpKernel::DoneCallback done = nullptr) {
+  // Note that setting this empty lambda as the default parameter value directly
+  // can cause strange compiler/linker errors, so we do it like this instead.
+  if (!done) {
+    done = [] {};
+  }
+
+  const int64_t axis_input = context->input(0).scalar<int64_t>()();
+  const Tensor& input_indices = context->input(1);
+  const Tensor& input_values = context->input(2);
+  const Tensor& input_shape = context->input(3);
+
+  OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsMatrix(input_indices.shape()),
+                    errors::InvalidArgument(
+                        "Input indices should be a matrix but received shape ",
+                        input_indices.shape().DebugString()),
+                    done);
+  OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsVector(input_values.shape()),
+                    errors::InvalidArgument(
+                        "Input values should be a vector but received shape ",
+                        input_indices.shape().DebugString()),
+                    done);
+  OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsVector(input_shape.shape()),
+                    errors::InvalidArgument(
+                        "Input shape should be a vector but received shape ",
+                        input_shape.shape().DebugString()),
+                    done);
+
+  const int64_t input_rank = input_shape.vec<int64_t>().size();
+  const int64_t axis = (axis_input < 0) ? input_rank + axis_input : axis_input;
+
+  OP_REQUIRES_ASYNC(
+      context, axis >= 0 && axis < input_rank,
+      errors::InvalidArgument("Input axis should be in range [", -input_rank,
+                              ", ", input_rank, "), got ", axis_input),
+      done);
+
+  OP_REQUIRES_ASYNC(
+      context, num_split >= 1 && num_split <= input_shape.vec<int64_t>()(axis),
+      errors::InvalidArgument("Input num_split should be between 1 "
+                              "and the splitting dimension size (",
+                              input_shape.vec<int64_t>()(axis), "), got ",
+                              num_split),
+      done);
+
+  // Prevent overflow by constructing the dense shape separately
+  TensorShape dense_shape;
+  const auto input_shape_flat = input_shape.flat<int64_t>();
+  for (int i = 0; i < input_shape.NumElements(); i++) {
+    OP_REQUIRES_OK_ASYNC(
+        context, dense_shape.AddDimWithStatus(input_shape_flat(i)), done);
+  }
+
+  functor::SparseSplitFunctor<Device, T>()(context, input_indices, input_values,
+                                           dense_shape, axis, num_split, done);
+}
+
+}  // namespace
 
 template <typename T>
 class SparseSplitOp : public OpKernel {
@@ -30,71 +134,7 @@ class SparseSplitOp : public OpKernel {
   }
 
   void Compute(OpKernelContext* context) override {
-    const int64_t axis_input = context->input(0).scalar<int64_t>()();
-    const Tensor& input_indices = context->input(1);
-    const Tensor& input_values = context->input(2);
-    const Tensor& input_shape = context->input(3);
-
-    OP_REQUIRES(context, TensorShapeUtils::IsMatrix(input_indices.shape()),
-                errors::InvalidArgument(
-                    "Input indices should be a matrix but received shape ",
-                    input_indices.shape().DebugString()));
-    OP_REQUIRES(context, TensorShapeUtils::IsVector(input_values.shape()),
-                errors::InvalidArgument(
-                    "Input values should be a vector but received shape ",
-                    input_indices.shape().DebugString()));
-    OP_REQUIRES(context, TensorShapeUtils::IsVector(input_shape.shape()),
-                errors::InvalidArgument(
-                    "Input shape should be a vector but received shape ",
-                    input_shape.shape().DebugString()));
-
-    const int64_t input_rank = input_shape.vec<int64_t>().size();
-    const int64_t axis =
-        (axis_input < 0) ? input_rank + axis_input : axis_input;
-
-    OP_REQUIRES(
-        context, axis >= 0 && axis < input_rank,
-        errors::InvalidArgument("Input axis should be in range [", -input_rank,
-                                ", ", input_rank, "), got ", axis_input));
-
-    OP_REQUIRES(
-        context,
-        num_split_ >= 1 && num_split_ <= input_shape.vec<int64_t>()(axis),
-        errors::InvalidArgument("Input num_split should be between 1 "
-                                "and the splitting dimension size (",
-                                input_shape.vec<int64_t>()(axis), "), got ",
-                                num_split_));
-
-    // Prevent overflow by constructing the dense shape separately
-    TensorShape dense_shape;
-    const auto input_shape_flat = input_shape.flat<int64_t>();
-    for (int i = 0; i < input_shape.NumElements(); i++) {
-      OP_REQUIRES_OK(context,
-                     dense_shape.AddDimWithStatus(input_shape_flat(i)));
-    }
-
-    sparse::SparseTensor sparse_tensor;
-    OP_REQUIRES_OK(context,
-                   sparse::SparseTensor::Create(input_indices, input_values,
-                                                dense_shape, &sparse_tensor));
-
-    std::vector<sparse::SparseTensor> outputs;
-    OP_REQUIRES_OK(context, sparse::SparseTensor::Split<T>(
-                                sparse_tensor, axis, num_split_, &outputs));
-
-    for (int slice_index = 0; slice_index < num_split_; ++slice_index) {
-      context->set_output(slice_index, outputs[slice_index].indices());
-      context->set_output(slice_index + num_split_,
-                          outputs[slice_index].values());
-      Tensor* shape = nullptr;
-      OP_REQUIRES_OK(context, context->allocate_output(
-                                  slice_index + 2 * num_split_,
-                                  {outputs[slice_index].dims()}, &shape));
-      auto output_shape = outputs[slice_index].shape();
-      for (int dim = 0; dim < outputs[slice_index].dims(); ++dim) {
-        shape->vec<int64_t>()(dim) = output_shape[dim];
-      }
-    }
+    SparseSplitOpImpl<CPUDevice, T>(context, num_split_);
   }
 
  private:

--- a/tensorflow/core/kernels/sparse_split_op.h
+++ b/tensorflow/core/kernels/sparse_split_op.h
@@ -1,0 +1,37 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_SPARSE_SPLIT_OP_H_
+#define TENSORFLOW_CORE_KERNELS_SPARSE_SPLIT_OP_H_
+
+#include "tensorflow/core/framework/op_kernel.h"
+
+namespace tensorflow {
+
+namespace functor {
+
+template <typename Device, typename T>
+struct SparseSplitFunctor {
+  void operator()(OpKernelContext* context, const Tensor& input_indices,
+                  const Tensor& input_values, const TensorShape& dense_shape,
+                  const int64_t axis, const int num_split,
+                  typename AsyncOpKernel::DoneCallback done = nullptr);
+};
+
+}  // namespace functor
+
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_SPARSE_SPLIT_OP_H_

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_split_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_split_op_test.py
@@ -72,6 +72,12 @@ class SparseSplitOpTest(test.TestCase):
     return sparse_tensor.SparseTensor.from_value(self._SparseTensorValue_3x4x2(
     ))
 
+  def _SparseTensor_4x6_empty(self, val_dtype=np.int64):
+    ind = np.empty(shape=(0, 2), dtype=np.int64)
+    val = np.array([]).astype(val_dtype)
+    shape = np.array([4, 6]).astype(np.int64)
+    return sparse_tensor.SparseTensor(ind, val, shape)
+
   def testSplitMatrixRows(self):
     for axis in (0, -2):
       sp_tensors = self.evaluate(
@@ -252,6 +258,26 @@ class SparseSplitOpTest(test.TestCase):
       sparse_ops.sparse_split(sp_input=1)
     with self.assertRaisesRegex(ValueError, 'axis is required'):
       sparse_ops.sparse_split(num_split=2, sp_input=1)
+
+  def testSplitEmpty(self):
+    sp_empty = self._SparseTensor_4x6_empty()
+    sparse_splits0 = sparse_ops.sparse_split(
+        sp_input=sp_empty, num_split=2, axis=0)
+    sparse_splits1 = sparse_ops.sparse_split(
+        sp_input=sp_empty, num_split=2, axis=1)
+    empty_inds = np.empty(shape=(0, 2), dtype=np.int64)
+    self.assertAllEqual(sparse_splits0[0].indices, empty_inds)
+    self.assertAllEqual(sparse_splits0[0].values, [])
+    self.assertAllEqual(sparse_splits0[0].dense_shape, [2, 6])
+    self.assertAllEqual(sparse_splits0[1].indices, empty_inds)
+    self.assertAllEqual(sparse_splits0[1].values, [])
+    self.assertAllEqual(sparse_splits0[1].dense_shape, [2, 6])
+    self.assertAllEqual(sparse_splits1[0].indices, empty_inds)
+    self.assertAllEqual(sparse_splits1[0].values, [])
+    self.assertAllEqual(sparse_splits1[0].dense_shape, [4, 3])
+    self.assertAllEqual(sparse_splits1[1].indices, empty_inds)
+    self.assertAllEqual(sparse_splits1[1].values, [])
+    self.assertAllEqual(sparse_splits1[1].dense_shape, [4, 3])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is in preparation for adding a GPU implementation.
Also adds a test case for empty input tensors.
No functional change besides the added test.

cc @nluehr 