### PR TITLE
TF-TRT Enable native segment fallback test with TRT 8

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -75,7 +75,11 @@ string DebugString(const nvinfer1::Permutation& permutation, int len) {
 }
 
 string DebugString(const ITensorProxyPtr& tensor) {
-  return DebugString(*tensor->trt_tensor());
+  return StrCat(
+      tensor->is_trt_tensor() ? "nvinfer1::ITensor(@" : "SimpleItensor(@",
+      reinterpret_cast<uintptr_t>(&tensor), ", name=", tensor->getName(),
+      ", dtype=", DebugString(tensor->getType()),
+      ", dims=", DebugString(tensor->getDimensions()), ")");
 }
 
 string DebugString(const nvinfer1::ITensor& tensor) {

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -27,7 +27,6 @@ from tensorflow.compiler.tf2tensorrt.utils.trt_engine_instance_pb2 import TRTEng
 from tensorflow.core.framework import graph_pb2
 from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.compiler.tensorrt import trt_convert
-from tensorflow.python.compiler.tensorrt import utils as trt_utils
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
@@ -880,14 +879,6 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
 
   @test_util.run_v2_only
   def testTrtGraphConverter_AllowEngineNativeSegmentExecution(self):
-
-    # This test will not work anymore with TRT >= 8. TensorRT does not
-    # preallocate anymore the max_workspace_size_bytes, but rather allocates as
-    # it needs up to this value.
-    # TODO: update the unittest to make this TRTEngine creation fail with TRT8.
-    if trt_utils.is_linked_tensorrt_version_greater_equal(8, 0, 0):
-      return
-
     np_input1, np_input2 = self._RandomInput([4, 1, 1])
 
     # Create a model and save it.
@@ -899,12 +890,13 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     def _InputFn():
       yield np_input1, np_input2
 
-    # Run TRT conversion and request an unreasonably large workspace.
+    # Run TRT conversion
     converter = self._CreateConverterV2(
-        input_saved_model_dir, max_workspace_size_bytes=10 << 40)
+        input_saved_model_dir, max_workspace_size_bytes=1<<20)
     converter.convert()
 
     os.environ["TF_TRT_ALLOW_ENGINE_NATIVE_SEGMENT_EXECUTION"] = "False"
+    os.environ["TF_TRT_ABORT_CUDA_ENGINE_BUILD"] = "True"
     with self.assertRaisesRegex(
         errors.AbortedError,
         r"User disallowed engine native segment execution"):
@@ -913,6 +905,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       finally:
         # Always reset the environment variable.
         os.environ["TF_TRT_ALLOW_ENGINE_NATIVE_SEGMENT_EXECUTION"] = "True"
+        os.environ["TF_TRT_ABORT_CUDA_ENGINE_BUILD"] = "False"
 
     converter.build(input_fn=_InputFn)
 


### PR DESCRIPTION
In case there is an error during TRT ICudaEngine engine creation, TF-TRT falls back to native segment (TF function) execution. Previously it was only possible to test this with TRT 7 or earlier, because the method to trigger the error was specific to TRT version < 8.0. 

This PR introduces an environment variable `TF_TRT_ABORT_CUDA_ENGINE_BUILD`, which can be used  test this fallback mechanism with TRT 8 and later versions.

Additionally `DebugString(ITensorProxyPtr)` is corrected for the case when the object is `SimpleITensor`.

Tagging @bixia1 for review and @DEKHTIARJonathan for visibility.