### PR TITLE
Support CUDNN_HEUR_MODE_B

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -3327,7 +3327,11 @@ dnn::DataType GetConvAccumulatorType(dnn::DataType data_type) {
 
 #if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 cudnnBackendHeurMode_t GetCudnnFrontendHeurMode() {
+#if CUDNN_VERSION >= 8300
+  return CUDNN_HEUR_MODE_B;
+#else
   return CUDNN_HEUR_MODE_INSTANT;
+#endif // CUDNN_VERSION >= 8300
 }
 #endif  // CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 


### PR DESCRIPTION
This PR upgrades the heuristics mode from the previous decision tree to a neural network based solution (i.e., CUDNN_HEUR_MODE_INSTANT to CUDNN_HEUR_MODE_B).
https://docs.nvidia.com/deeplearning/cudnn/release-notes/rel_8.html#rel-820.

It enables this new mode as default from CUDNN v8.3.

cc. @nluehr