### PR TITLE
[ROCm] Fix for a regression in the unit test `//tensorflow/python/kernel_tests/nn_ops:pooling_ops_test_gpu`

### DIFF
--- a/tensorflow/core/kernels/eigen_pooling.h
+++ b/tensorflow/core/kernels/eigen_pooling.h
@@ -284,7 +284,11 @@ struct AvgPoolMeanReducer {
 
   EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE AvgPoolMeanReducer() : scalarCount_(0) {
     typedef typename packet_traits<T>::type Packet;
+#if defined(__HIPCC__)
+    packetCount_ = 0;
+#else
     packetCount_ = pset1<Packet>(T(0.0));
+#endif
   }
 
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void reduce(const T t, T* accum) {
@@ -364,7 +368,11 @@ struct AvgPoolMeanReducer {
  protected:
   typedef typename packet_traits<T>::type Packet;
   int scalarCount_;
+#if defined(__HIPCC__)
+  int packetCount_;
+#else
   Packet packetCount_;
+#endif
 };
 
 template <typename Device>


### PR DESCRIPTION
…

The unit-test `//tensorflow/python/kernel_tests/nn_ops:pooling_ops_test_gpu` started failing, after this change in the Eigen repo - https://gitlab.com/libeigen/eigen/-/commit/cc3573ab4451853774cd5c3497373d5fe8914774

```
INFO: From Testing //tensorflow/python/kernel_tests/nn_ops:pooling_ops_test_gpu:
==================== Test output for //tensorflow/python/kernel_tests/nn_ops:pooling_ops_test_gpu:
Running tests under Python 3.9.7: /usr/bin/python3
[ RUN      ] PoolingTest.testAvgPoolEmpty0 (pool_func=<function avg_pool at 0x7fb968603f70>, data_format='NHWC', data_type=tf.float32, use_gpu=False, v2=False)
...
...
[ RUN      ] PoolingTest.testAvgPoolKernelSmallerThanStride4 (pool_func=<function avg_pool at 0x7fb968603f70>, data_format='NHWC', data_type=tf.float16, use_gpu=True, v2=False)
2021-11-30 15:31:04.335778: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /device:GPU:0 with 31740 MB memory:  -> device: 0, name: Device 738c, pci bus id: 0000:4a:00.0
INFO:tensorflow:Running NHWC test. False [1, 7, 7, 1] 49 <function avg_pool at 0x7fb968603f70> [1, 2, 2, 1] [1, 3, 3, 1] <dtype: 'float16'>
I1130 15:31:04.335854 140444621272896 pooling_ops_test.py:231] Running NHWC test. False [1, 7, 7, 1] 49 <function avg_pool at 0x7fb968603f70> [1, 2, 2, 1] [1, 3, 3, 1] <dtype: 'float16'>
2021-11-30 15:31:04.336372: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 31740 MB memory:  -> device: 0, name: Device 738c, pci bus id: 0000:4a:00.0
2021-11-30 15:31:04.341161: I tensorflow/core/common_runtime/gpu_fusion_pass.cc:507] ROCm Fusion is enabled.
Memory access fault by GPU node-4 (Agent handle: 0x486adb0) on address 0x100000000. Reason: Page not present or supervisor privilege.
...
...
```

The Eigen commit changes the visibility of the `Packet` type ( `Packet4h2`) for the `Eigen::half` datatype. Prior to the commit, `Packet` type is defined as `Packet4h2` during both the `host` and `device` compile phases of hipcc/nvcc. After the commit the `Packet` type is defined as `Eigen::half` (size == 2) in the `host` compile phase, and as `Packet4h2` (size == 8) in the device compile phase.

`struct AvgPoolMeanReducer` has a member of type `Packet`(https://github.com/tensorflow/tensorflow/blob/r2.7/tensorflow/core/kernels/eigen_pooling.h#L367), and hence its size will be different during the `host` compile phase and `device` compile phase. It also seems that the implementation of the `average pooling` op ( https://github.com/tensorflow/tensorflow/blob/r2.7/tensorflow/core/kernels/avgpooling_op.h#L34-L38 ) will result in a `struct AvgPoolMeanReducer` argument being passed across the `host` / `device` compile boundary (atleast for `hipcc`) and size mismatch between the two, leads to the subsequent segfault.

The fix here is to ensure the `Packet` has the same definitition for both the `host` and `device` compile phases. However changing the type `packetCount_` to `int` unconditionally leads to compile errors, because during the non-gpu / gcc compiles the code within the `!defined(__HIPCC__)` block gets activated, and hence the changes in this commit are guarded by `defined(__HIPCC__)`. Using `int` for `packetCount_` is ok because `PacketAcces`s is already set to `false` within (a different) `defined(__HIPCC__)` block.


-----------------------------------------------


/cc @cheshire @chsigg 
