### PR TITLE
all_reduce_indexed_slices remove not eager context

### DIFF
--- a/tensorflow/python/distribute/cross_device_utils.py
+++ b/tensorflow/python/distribute/cross_device_utils.py
@@ -501,7 +501,7 @@ class CollectiveReplicaLauncher(object):
   ) -> indexed_slices.IndexedSlices:
     """All-reduce an IndexedSlices.
 
-    This method must be called inside a tf.function.
+    This method can be called outside  tf.function.
 
     Args:
       input_slices: an IndexedSlices.
@@ -511,12 +511,7 @@ class CollectiveReplicaLauncher(object):
     Returns:
       The reduced IndexedSlices.
 
-    Raises:
-      RuntimeError: if called in eager mode.
     """
-    if context.executing_eagerly():
-      raise RuntimeError(
-          'all_reduce_indexed_slices is not supported in eager mode.')
 
     # Current CollectiveAllGather implementations require input IndexedSlices to
     # have consistent length across the board, we handle the reduction of


### PR DESCRIPTION
@crccw So why there is a eager runtime error before?

all_reduce_indexed_slices can be called in eager mode and runs ok in my environment multiworker mirrored strategy.