### PR TITLE
docs: Removed incorrect note in ctc_beam_search_decoder

### DIFF
--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -376,10 +376,6 @@ def ctc_beam_search_decoder(inputs,
                             merge_repeated=True):
   """Performs beam search decoding on the logits given in input.
 
-  **Note** The `ctc_greedy_decoder` is a special case of the
-  `ctc_beam_search_decoder` with `top_paths=1` and `beam_width=1` (but
-  that decoder is faster for this special case).
-
   If `merge_repeated` is `True`, merge repeated classes in the output beams.
   This means that if consecutive entries in a beam are the same,
   only the first of these is emitted.  That is, when the sequence is

--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -374,14 +374,14 @@ def ctc_beam_search_decoder(inputs,
                             top_paths=1,
                             merge_repeated=True):
   """Performs beam search decoding on the logits given in input.
-  
+
   **Note** Although in general greedy search is a special case of beam-search
   with `top_paths=1` and `beam_width=1`, `ctc_beam_search_decoder` differs
-  from `ctc_gready_decoder` in the treatment of blanks when computing the
+  from `ctc_greedy_decoder` in the treatment of blanks when computing the
   probability of a sequence:
     - `ctc_beam_search_decoder` treats blanks as sequence termination
-    - `ctc_gready_decoder` treats blanks as regular elements
-  
+    - `ctc_greedy_decoder` treats blanks as regular elements
+
   If `merge_repeated` is `True`, merge repeated classes in the output beams.
   This means that if consecutive entries in a beam are the same,
   only the first of these is emitted.  That is, when the sequence is
@@ -442,10 +442,10 @@ def ctc_beam_search_decoder_v2(inputs,
 
   **Note** Although in general greedy search is a special case of beam-search
   with `top_paths=1` and `beam_width=1`, `ctc_beam_search_decoder` differs
-  from `ctc_gready_decoder` in the treatment of blanks when computing the
+  from `ctc_greedy_decoder` in the treatment of blanks when computing the
   probability of a sequence:
     - `ctc_beam_search_decoder` treats blanks as sequence termination
-    - `ctc_gready_decoder` treats blanks as regular elements
+    - `ctc_greedy_decoder` treats blanks as regular elements
 
   Args:
     inputs: 3-D `float` `Tensor`, size `[max_time, batch_size, num_classes]`.

--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -313,9 +313,8 @@ def ctc_greedy_decoder(inputs,
 
   Notes:
 
-  - Regardless of the value of `merge_repeated`, if an index of a
-    given time and batch corresponds to the `blank_index`, no new
-    element is emitted.
+  - Unlike `ctc_beam_search_decoder`, `ctc_greedy_decoder` omits blanks up-to
+    the special treatment under `merge_repeated`.
   - Default `blank_index` is `(num_classes - 1)`, unless overriden.
 
   If `merge_repeated` is `True`, merge repeated classes in output.

--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -313,8 +313,8 @@ def ctc_greedy_decoder(inputs,
 
   Notes:
 
-  - Unlike `ctc_beam_search_decoder`, `ctc_greedy_decoder` omits blanks up-to
-    the special treatment under `merge_repeated`.
+  - Unlike `ctc_beam_search_decoder`, `ctc_greedy_decoder` considers blanks
+    as regular elements when computing the probability of a sequence.
   - Default `blank_index` is `(num_classes - 1)`, unless overriden.
 
   If `merge_repeated` is `True`, merge repeated classes in output.
@@ -374,7 +374,14 @@ def ctc_beam_search_decoder(inputs,
                             top_paths=1,
                             merge_repeated=True):
   """Performs beam search decoding on the logits given in input.
-
+  
+  **Note** Although in general greedy search is a special case of beam-search
+  with `top_paths=1` and `beam_width=1`, `ctc_beam_search_decoder` differs
+  from `ctc_gready_decoder` in the treatment of blanks when computing the
+  probability of a sequence:
+    - `ctc_beam_search_decoder` treats blanks as sequence termination
+    - `ctc_gready_decoder` treats blanks as regular elements
+  
   If `merge_repeated` is `True`, merge repeated classes in the output beams.
   This means that if consecutive entries in a beam are the same,
   only the first of these is emitted.  That is, when the sequence is
@@ -433,9 +440,12 @@ def ctc_beam_search_decoder_v2(inputs,
                                top_paths=1):
   """Performs beam search decoding on the logits given in input.
 
-  **Note** The `ctc_greedy_decoder` is a special case of the
-  `ctc_beam_search_decoder` with `top_paths=1` and `beam_width=1` (but
-  that decoder is faster for this special case).
+  **Note** Although in general greedy search is a special case of beam-search
+  with `top_paths=1` and `beam_width=1`, `ctc_beam_search_decoder` differs
+  from `ctc_gready_decoder` in the treatment of blanks when computing the
+  probability of a sequence:
+    - `ctc_beam_search_decoder` treats blanks as sequence termination
+    - `ctc_gready_decoder` treats blanks as regular elements
 
   Args:
     inputs: 3-D `float` `Tensor`, size `[max_time, batch_size, num_classes]`.


### PR DESCRIPTION
Hello there :wave: 

As mentioned in #21051, there is an issue with the mention in `tf.nn.ctc_beam_search_decoder` claiming that in a special case, it's the same as the greedy decoder. Both from a pure code & theoretical point of view, I would argue that this claim is wrong.

This PR simply removes the incorrect note to fix the documentation :ok_hand: 

Any feedback is welcome!

cc @mihaimaruseac @tatianashp