### PR TITLE
Update autoclustering_xla.ipynb

### DIFF
--- a/tensorflow/compiler/xla/g3doc/tutorials/autoclustering_xla.ipynb
+++ b/tensorflow/compiler/xla/g3doc/tutorials/autoclustering_xla.ipynb
@@ -151,7 +151,7 @@
       "outputs": [],
       "source": [
         "def compile_model(model):\n",
-        "  opt = tf.keras.optimizers.RMSprop(lr=0.0001, decay=1e-6)\n",
+        "  opt = tf.keras.optimizers.RMSprop(learning_rate=0.0001, decay=1e-6)\n",
         "  model.compile(loss='categorical_crossentropy',\n",
         "                optimizer=opt,\n",
         "                metrics=['accuracy'])\n",


### PR DESCRIPTION
Changed `lr` to `learning_rate`, which removes a deprecation warning.