### PR TITLE
fix: GIT_REPOSITORY for eigen

### DIFF
--- a/tensorflow/lite/tools/cmake/modules/eigen.cmake
+++ b/tensorflow/lite/tools/cmake/modules/eigen.cmake
@@ -21,7 +21,7 @@ include(OverridableFetchContent)
 
 OverridableFetchContent_Declare(
   eigen
-  GIT_REPOSITORY https://gitlab.com/libeigen/eigen
+  GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
   # Sync with tensorflow/third_party/eigen3/workspace.bzl
   GIT_TAG 085c2fc5d53f391afcccce21c45e15f61c827ab1
   # It's not currently (cmake 3.17) possible to shallow clone with a GIT TAG


### PR DESCRIPTION
A missing trailing .git of GIT_REPOSITORY is causing git clone error on centos 6 machine.

It seems like this error didn't occur in a ubuntu machine, but it can be reproduced in a centos6 machine.

Reproduce:
1. On a centos 6 machine, add `set(FETCHCONTENT_QUIET FALSE)` to eigen.cmake.
2. run cmake with `cmake ../tensorflow/lite/` (following instructions of https://www.tensorflow.org/lite/guide/build_cmake)
3. Found the following error message:
```
-- Build files have been written to: /tensorflow/tflite_build_centos/_deps/eigen-subbuild
[ 11%] Performing download step (git clone) for 'eigen-populate'
Initialized empty Git repository in 
/tensorflow/tflite_build_centos/eigen/.git/
error: RPC failed; result=22, HTTP code = 422
```

On the other hand, the cmake process hung up after this error occured, maybe we can consider adding `set(FETCHCONTENT_QUIET FALSE)` in the `tensorflow/lite/CMakeLists.txt`.