### PR TITLE
Remove wheel requirement as it is not needed for the pip package

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -88,7 +88,7 @@ REQUIRED_PACKAGES = [
     'six >= 1.12.0',
     'termcolor >= 1.1.0',
     'typing_extensions >= 3.6.6',
-    'wheel >= 0.32.0, < 1.0', # capped as astunparse 1.6.0-1.6.3 requires < 1.0
+    'wheel >= 0.32.0',
     'wrapt >= 1.11.0',
     # These packages need to be pinned exactly as newer versions are
     # incompatible with the rest of the ecosystem

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -88,7 +88,6 @@ REQUIRED_PACKAGES = [
     'six >= 1.12.0',
     'termcolor >= 1.1.0',
     'typing_extensions >= 3.6.6',
-    'wheel >= 0.32.0',
     'wrapt >= 1.11.0',
     # These packages need to be pinned exactly as newer versions are
     # incompatible with the rest of the ecosystem


### PR DESCRIPTION
https://github.com/simonpercivall/astunparse/pull/65

```
astunparse $ for tag in v1.6.0 v1.6.1 v1.6.2 v1.6.3; do git checkout $tag; echo $tag; grep wheel . -R --exclude-dir=.git; done
Previous HEAD position was d7ba156 Bump version
HEAD is now at df08255 Bump version and add HISTORY entry.
v1.6.0
./setup.cfg:[wheel]
./Makefile:	python setup.py bdist_wheel
./requirements.txt:wheel >= 0.23.0, < 1.0
Previous HEAD position was df08255 Bump version and add HISTORY entry.
HEAD is now at c73b675 Bump version.
v1.6.1
./setup.cfg:[wheel]
./Makefile:	python setup.py bdist_wheel
./requirements.txt:wheel >= 0.23.0, < 1.0
Previous HEAD position was c73b675 Bump version.
HEAD is now at d7ba156 Bump version
v1.6.2
./setup.cfg:[wheel]
./Makefile:	python setup.py bdist_wheel
./requirements.txt:wheel >= 0.23.0, < 1.0
Previous HEAD position was d7ba156 Bump version
HEAD is now at 2acce01 Merge pull request #42 from simonpercivall/merge/python3.8-support
v1.6.3
./setup.cfg:[wheel]
./Makefile:	python setup.py bdist_wheel
./requirements.txt:wheel >= 0.23.0, < 1.0
```