### PR TITLE
Add tolerance to ragged square root test so it passes on AARCH64

### DIFF
--- a/tensorflow/python/ops/ragged/ragged_dispatch_test.py
+++ b/tensorflow/python/ops/ragged/ragged_dispatch_test.py
@@ -687,7 +687,9 @@ class RaggedDispatchTest(test_util.TensorFlowTestCase, parameterized.TestCase):
               'num_segments':
                   2
           },
-          expected=[7.0, 2.0]),
+          expected=[7.0, 2.0],
+          rtol=1e-12,
+          ),
       dict(
           op=math_ops.reduce_sum,
           kwargs={


### PR DESCRIPTION
Fixes #53322 