### PR TITLE
[TF-TRT] Fix TRTEngineOP Inference Shape

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
@@ -315,6 +315,23 @@ void UpdateToEngineNode(const std::vector<EngineInfo>& infos,
   LOG(FATAL) << "Node " << node_name << " not found in any engine.";
 }
 
+tensorflow::TensorShapeProto ComputeTRTNodeIOShape(
+  std::vector<PartialTensorShape>& partial_tensorshape_vect,
+  std::vector<tensorflow::TensorShapeProto>& shape_proto_vect,
+  const PartialTensorShape& conn_shape,
+  int port_number
+){
+  tensorflow::TensorShapeProto tmp_shape_proto;
+  conn_shape.AsProto(&tmp_shape_proto);
+
+  if (partial_tensorshape_vect.size() <= port_number) {
+    shape_proto_vect.resize(port_number + 1);
+    partial_tensorshape_vect.resize(port_number + 1);
+  }
+
+  return tmp_shape_proto;
+}
+
 // Function to insert a TRT engine node into the graph.
 // Create engine nodes in the following way:
 // 1. Each invocation of CreateTRTNode creates an engine node for infos[pos]
@@ -333,7 +350,9 @@ Status CreateTRTNode(const ConversionParams& params,
                      std::vector<Node*>* engine_nodes) {
   const auto& info = infos.at(pos);
   std::vector<tensorflow::TensorShapeProto> input_shape_protos;
+  std::vector<tensorflow::TensorShapeProto> output_shape_protos;
   std::vector<PartialTensorShape> input_shapes;
+  std::vector<PartialTensorShape> output_shapes;
   std::vector<NodeDefBuilder::NodeOut> inputs;
   std::vector<Node*> input_nodes;
   std::vector<Node*> control_input_nodes;
@@ -366,19 +385,35 @@ Status CreateTRTNode(const ConversionParams& params,
     } else {
       // Data edges
       if (!conn.is_input_edge) {
-        // Set the data types of output edge.
+        // Set the shapes and data types of the output edge.
+        tensorflow::TensorShapeProto out_shape = ComputeTRTNodeIOShape(
+          /*partial_tensorshape_vect=*/output_shapes,
+          /*shape_proto_vect=*/output_shape_protos,
+          /*conn_shape=*/conn.inside_shape,
+          /*port_number=*/conn.port_number
+        );
+
+        output_shape_protos.at(conn.port_number) = out_shape;
+        output_shapes.at(conn.port_number) = conn.inside_shape;
+
         if (out_types.size() <= conn.port_number) {
           out_types.resize(conn.port_number + 1);
         }
         out_types.at(conn.port_number) = conn.connection_type;
+        VLOG(2) << "Collected output shape "
+                << output_shape_protos.at(conn.port_number).DebugString();
       } else {
-        // Set the shapes and data types of input edge.
-        if (input_shapes.size() <= conn.port_number) {
-          input_shape_protos.resize(conn.port_number + 1);
-          input_shapes.resize(conn.port_number + 1);
-        }
-        conn.outside_shape.AsProto(&input_shape_protos.at(conn.port_number));
+        // Set the shapes of the input edge.
+        tensorflow::TensorShapeProto in_shape = ComputeTRTNodeIOShape(
+          /*partial_tensorshape_vect=*/input_shapes,
+          /*shape_proto_vect=*/input_shape_protos,
+          /*conn_shape=*/conn.outside_shape,
+          /*port_number=*/conn.port_number
+        );
+
+        input_shape_protos.at(conn.port_number) = in_shape;
         input_shapes.at(conn.port_number) = conn.outside_shape;
+
         // Shape must be fully defined (excluding batch dimension) for static
         // mode.
         if (params.use_implicit_batch &&
@@ -451,7 +486,9 @@ Status CreateTRTNode(const ConversionParams& params,
   NodeDef trt_node;
   NameAttrList function;
   function.set_name(StrCat(info.engine_name, "_native_segment"));
+
   node_builder.Attr("input_shapes", input_shape_protos)
+      .Attr("output_shapes", output_shape_protos)
       .Attr("static_engine",
             info.engine_type == EngineInfo::EngineType::TRTStatic)
       .Attr("segment_func", function)
@@ -472,6 +509,7 @@ Status CreateTRTNode(const ConversionParams& params,
   }
 
   Status status = node_builder.Finalize(&trt_node);
+
   if (!status.ok()) {
     LOG(ERROR) << "Node construction failed with" << status;
     return status;

--- a/tensorflow/compiler/tf2tensorrt/ops/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/ops/trt_engine_op.cc
@@ -36,6 +36,7 @@ REGISTER_OP("TRTEngineOp")
     .Attr("InT: list({int8,float16,float32,int32})")
     .Attr("OutT: list({int8,float16,float32,int32})")
     .Attr("input_shapes: list(shape) = []")
+    .Attr("output_shapes: list(shape) = []")
     .Attr("max_cached_engines_count: int = 1")
     .Attr("max_batch_size: int = 1")
     .Attr("workspace_size_bytes: int")
@@ -44,18 +45,24 @@ REGISTER_OP("TRTEngineOp")
     .Attr("use_calibration: bool = true")
     .Input("in_tensor: InT")
     .Output("out_tensor: OutT")
-    // TODO(jie): TF requires concrete output shape for concrete input shapes.
-    // This is tricky for batch dimension, since we cannot ensure which input
-    // would carry the correct batch dimension (for the current stage of the
-    // implementation, we do require all input tensor to carry the same batch
-    // size, but this could change in the future). Hence we disable shape
-    // inference function as a workaround.
-    .SetShapeFn(shape_inference::UnknownShape)
+    .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
+      std::vector<tensorflow::PartialTensorShape> output_shapes;
+      TF_RETURN_IF_ERROR(c->GetAttr("output_shapes", &output_shapes));
+
+      for(int i=0; i<output_shapes.size(); i++) {
+        ::tensorflow::shape_inference::ShapeHandle shape;
+        shape_inference::ShapeHandle output_shape_handle;
+        TF_RETURN_IF_ERROR(c->MakeShapeFromPartialTensorShape(
+            output_shapes[i], &output_shape_handle));
+        c->set_output(i, output_shape_handle);
+      }
+
+      return Status::OK();
+    })
     // Deprecated attributes.
     .Attr("segment_funcdef_name: string = ''")
     .Attr("cached_engine_batches: list(int) >= 0 = []")
     .Attr("fixed_input_size: bool = true")
-    .Attr("output_shapes: list(shape) = []")
     .Attr("static_engine: bool = true")
     .Attr("profile_strategy: string = ''");
 }  // namespace tensorflow

--- a/tensorflow/python/compiler/tensorrt/test/BUILD
+++ b/tensorflow/python/compiler/tensorrt/test/BUILD
@@ -75,6 +75,7 @@ cuda_py_tests(
         "reshape_transpose_test.py",
         "tf_function_test.py",
         "topk_test.py",
+        "trt_engine_op_shape_test.py",
         "trt_mode_test.py",
         "unary_test.py",
         "vgg_block_nchw_test.py",

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -181,9 +181,8 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
     """
 
     input_mask = [[False] + [True] * (len(shape) - 1) for shape in input_shapes]
-    output_mask = [
-        [False] + [True] * (len(shape) - 1) for shape in output_shapes
-    ]
+    output_mask = [[False] + [True] * (len(shape) - 1) if shape else []
+                   for shape in output_shapes]
 
     return self.BuildParamsWithMask(graph_fn, dtype, input_shapes,
                                     output_shapes, input_mask, output_mask, [],

--- a/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
@@ -1,0 +1,93 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""This script test input and output shapes and dtype of the TRTEngineOp."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.compiler.tensorrt.test import tf_trt_integration_test_base as trt_test
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.platform import test
+
+from tensorflow.python import saved_model
+from tensorflow.python.saved_model import signature_constants
+from tensorflow.python.saved_model import tag_constants
+
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import nn
+
+
+class TRTEngineOpInputOutputShapeTest(trt_test.TfTrtIntegrationTestBase):
+  """Testing the output shape of a TRTEngine."""
+
+  def GraphFn(self, inp):
+    b = array_ops.squeeze(inp, axis=[2])
+    c = nn.relu(b)
+    d1 = c + c
+    d2 = math_ops.reduce_sum(d1)
+
+    d1 = array_ops.identity(d1, name="output_0")
+    d2 = array_ops.identity(d2, name="output_1")
+    return d1, d2
+
+  def GetParams(self):
+    return self.BuildParams(self.GraphFn, dtypes.float32, [[1, 2, 1, 4]],
+                            [[1, 2, 4], []])
+
+  def _GetInferGraph(self, *args, **kwargs):
+    trt_saved_model_dir = super(
+        TRTEngineOpInputOutputShapeTest, self
+    )._GetInferGraph(*args, **kwargs)
+
+    def get_func_from_saved_model(saved_model_dir):
+      saved_model_loaded = saved_model.load.load(
+          saved_model_dir, tags=[tag_constants.SERVING])
+      graph_func = saved_model_loaded.signatures[
+          signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY]
+      return graph_func, saved_model_loaded
+
+    func, loaded_model = get_func_from_saved_model(trt_saved_model_dir)
+
+    input_shape = func.inputs[0].shape
+    if isinstance(input_shape, tensor_shape.TensorShape):
+      input_shape = input_shape.as_list()
+
+    output_shapes = [
+      out_shape.shape.as_list()
+      if isinstance(out_shape.shape, tensor_shape.TensorShape) else
+      out_shape.shape
+      for out_shape in func.outputs
+    ]
+
+    self.assertEqual(func.inputs[0].dtype, dtypes.float32)
+    self.assertEqual(func.outputs[0].dtype, dtypes.float32)
+    self.assertEqual(func.outputs[1].dtype, dtypes.float32)
+
+    self.assertEqual(input_shape, [None, 2, 1, 4])
+    self.assertEqual(output_shapes[0], [None, 2, 4])
+    self.assertEqual(output_shapes[1], [])
+
+    return trt_saved_model_dir
+
+  def ExpectedEnginesToBuild(self, run_params):
+    """Return the expected engines to build."""
+    return ["TRTEngineOp_0"]
+
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
@bixia1 for review
CC: @tfeher

This PR addresses that TRTEngineOP do not mention any output shape in the Graphdef, which limit graphdef analysis, and can block large scale deployment with framework like TRITON Inference Server.

Fix : #52934