### PR TITLE
[.clang-format] Init @ root

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+# Run manually to reformat a file:
+# clang-format -i --style=file <file>
+BasedOnStyle: Google
+DerivePointerAlignment: false

--- a/tensorflow/compiler/xla/python/types.h
+++ b/tensorflow/compiler/xla/python/types.h
@@ -118,7 +118,6 @@ pybind11::tuple SpanToTuple(absl::Span<int64_t const> xs);
 template <typename T>
 std::vector<T> IterableToVector(const pybind11::iterable& iterable) {
   std::vector<T> output;
-  output.reserve(std::distance(iterable.begin(), iterable.end()));
   for (auto item : iterable) {
     output.push_back(item.cast<T>());
   }

--- a/tensorflow/compiler/xla/python/types.h
+++ b/tensorflow/compiler/xla/python/types.h
@@ -118,6 +118,7 @@ pybind11::tuple SpanToTuple(absl::Span<int64_t const> xs);
 template <typename T>
 std::vector<T> IterableToVector(const pybind11::iterable& iterable) {
   std::vector<T> output;
+  output.reserve(std::distance(iterable.begin(), iterable.end()));
   for (auto item : iterable) {
     output.push_back(item.cast<T>());
   }


### PR DESCRIPTION
Matches https://github.com/tensorflow/tflite-micro/blob/d1a6c79/.clang-format https://github.com/tensorflow/ngraph-bridge/blob/bad873a/.clang-format:
```yml
# Run manually to reformat a file:
# clang-format -i --style=file <file>
BasedOnStyle: Google
DerivePointerAlignment: false
```

Alternatively can match the [4 year old] one in the xla directory https://github.com/tensorflow/tensorflow/blob/1e67c90/tensorflow/compiler/xla/.clang-format:
```yml
BasedOnStyle: Google
Language: Cpp
PointerBindsToType: true

```