### PR TITLE
[TF-TRT] Add Layout + ConstFold optimization on the TRT engine op

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
@@ -344,6 +344,7 @@ tensorflow::TensorShapeProto ComputeTRTNodeIOShape(
 // 3. In this way, we ensure the graph is topologically sort-able after each
 //    invocation of CreateTRTNode().
 Status CreateTRTNode(const ConversionParams& params,
+                     grappler::Cluster* cluster,
                      const std::vector<EngineInfo>& infos, int pos,
                      int default_max_batch_size, Graph* graph,
                      std::vector<Node*>* engine_nodes) {
@@ -461,7 +462,8 @@ Status CreateTRTNode(const ConversionParams& params,
 
   if (info.engine_type == EngineInfo::EngineType::TRTStatic) {
     TF_RETURN_IF_ERROR(CreateStaticEngine(
-        params, info, max_batch_size, input_shapes, nullptr, &segment_string));
+        params, cluster, info, max_batch_size,
+        input_shapes, nullptr, &segment_string));
   }
 
   string prec_string;
@@ -636,10 +638,11 @@ Status RegisterGraphToFunctionLibrary(const GraphDef& segment_graph_def,
 }
 
 std::pair<int, Allocator*> GetDeviceAndAllocator(const ConversionParams& params,
-                                                 const EngineInfo& engine) {
+                                                 const EngineInfo& engine,
+                                                 const grappler::Cluster* cluster) {
   int cuda_device_id = -1;
   Allocator* dev_allocator = nullptr;
-  if (params.cluster == nullptr || params.cluster->GetDeviceSet() == nullptr ||
+  if (cluster == nullptr || cluster->GetDeviceSet() == nullptr ||
       engine.device.empty()) {
     // If device is not set, use the first found GPU device for the conversion.
     TfDeviceId tf_device_id;
@@ -658,7 +661,7 @@ std::pair<int, Allocator*> GetDeviceAndAllocator(const ConversionParams& params,
   }
 
   // Use the device requested by the engine.
-  auto device_set = params.cluster->GetDeviceSet();
+  auto device_set = cluster->GetDeviceSet();
   std::vector<Device*> devices;
   DeviceNameUtils::ParsedName parsed_name;
   if (DeviceNameUtils::ParseFullName(engine.device, &parsed_name) &&
@@ -686,12 +689,13 @@ std::pair<int, Allocator*> GetDeviceAndAllocator(const ConversionParams& params,
 }
 
 Status CreateStaticEngine(const ConversionParams& params,
+                          grappler::Cluster* cluster,
                           const EngineInfo& info, int max_batch_size,
                           const std::vector<PartialTensorShape>& input_shapes,
                           TrtShapeOptimizationProfile* profile,
                           string* segment_string) {
   std::pair<int, Allocator*> device_allocator =
-      GetDeviceAndAllocator(params, info);
+      GetDeviceAndAllocator(params, info, cluster);
   int cuda_device_id = 0;
   std::unique_ptr<TRTBaseAllocator> trt_allocator;
   if (device_allocator.first >= 0) {
@@ -717,7 +721,8 @@ Status CreateStaticEngine(const ConversionParams& params,
       trt_allocator.get(), /*calibrator=*/nullptr, &engine,
       info.use_calibration, params.use_implicit_batch,
       /*convert_successfully=*/nullptr, profile, info.engine_name,
-      /*use_explicit_precision=*/params.use_explicit_precision));
+      /*use_explicit_precision=*/params.use_explicit_precision,
+      cluster));
   TrtUniquePtrType<nvinfer1::IHostMemory> engine_data(engine->serialize());
   *segment_string = string(static_cast<const char*>(engine_data->data()),
                            engine_data->size());
@@ -725,7 +730,8 @@ Status CreateStaticEngine(const ConversionParams& params,
 }
 
 // Entry function from optimization pass.
-Status ConvertAfterShapes(const ConversionParams& params) {
+Status ConvertAfterShapes(const ConversionParams& params,
+                          grappler::Cluster* cluster) {
   // Sanity checks.
   if (params.precision_mode != TrtPrecisionMode::INT8 &&
       params.use_calibration) {
@@ -900,7 +906,7 @@ Status ConvertAfterShapes(const ConversionParams& params) {
     engine.max_workspace_size_bytes = params.max_workspace_size_bytes;
     VLOG(1) << "Assigned " << engine.max_workspace_size_bytes << " bytes to "
             << engine.engine_name;
-    auto status = CreateTRTNode(params, engine_segments, i,
+    auto status = CreateTRTNode(params, cluster, engine_segments, i,
                                 params.max_batch_size, &graph, &engine_nodes);
 
     string msg = StrCat("segment ", i, " consisting of ",

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.h
@@ -42,7 +42,6 @@ struct ConversionParams {
   GraphDef* output_graph_def = nullptr;
   TrtPrecisionMode precision_mode = TrtPrecisionMode::FP32;
   int minimum_segment_size = 3;
-  const grappler::Cluster* cluster = nullptr;
   // Whether to create engine on conversion or execution time
   bool is_dyn_op = false;
   // maximum number of cached engines
@@ -55,11 +54,13 @@ struct ConversionParams {
 };
 
 // Method to call from optimization pass
-Status ConvertAfterShapes(const ConversionParams& params);
+Status ConvertAfterShapes(const ConversionParams& params,
+                          grappler::Cluster* cluster);
 
 // Helper method for the conversion, expose for testing.
 std::pair<int, Allocator*> GetDeviceAndAllocator(const ConversionParams& params,
-                                                 const EngineInfo& engine);
+                                                 const EngineInfo& engine,
+                                                 const grappler::Cluster* cluster = nullptr);
 
 // Helper method that registers `segment_graph` as a function to the function
 // library in `graph`.
@@ -69,6 +70,7 @@ Status RegisterGraphToFunctionLibrary(const GraphDef& segment_graph_def,
 // Creates and serializes an ICudaEngine. Used only in is_dynamic_op=false,
 // a.k.a. static engine mode.
 Status CreateStaticEngine(const ConversionParams& params,
+                          grappler::Cluster* cluster,
                           const EngineInfo& info, int max_batch_size,
                           const std::vector<PartialTensorShape>& input_shapes,
                           TrtShapeOptimizationProfile* profile,

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph_test.cc
@@ -68,7 +68,7 @@ TEST(ConvertGraphTest, GetDeviceAndAllocator) {
   ConversionParams params;
   EngineInfo engine_info;
   {
-    // params.cluster is not set, and no gpu device is available.
+    // cluster is not set, and no gpu device is available.
     auto result = GetDeviceAndAllocator(params, engine_info);
     EXPECT_EQ(-1, result.first);
     EXPECT_EQ(nullptr, result.second);
@@ -85,7 +85,7 @@ TEST(ConvertGraphTest, GetDeviceAndAllocator) {
   std::unique_ptr<Session> session(NewSession(options));
 
   {
-    // params.cluster is not set, should find and return first gpu id and
+    // cluster is not set, should find and return first gpu id and
     // corresponding allocator.
     auto result = GetDeviceAndAllocator(params, engine_info);
     EXPECT_EQ(0, result.first);
@@ -94,11 +94,10 @@ TEST(ConvertGraphTest, GetDeviceAndAllocator) {
   }
 
   FakeCluster cluster;
-  params.cluster = &cluster;
   {
     // params.cluster->GetDeviceSet() returns null, should find and return first
     // gpu id and corresponding allocator.
-    auto result = GetDeviceAndAllocator(params, engine_info);
+    auto result = GetDeviceAndAllocator(params, engine_info, &cluster);
     EXPECT_EQ(0, result.first);
     EXPECT_NE(nullptr, result.second);
     EXPECT_EQ("GPU_0_bfc", result.second->Name());
@@ -115,7 +114,7 @@ TEST(ConvertGraphTest, GetDeviceAndAllocator) {
   {
     // engine_info.device is not set, should find and return first gpu id and
     // corresponding allocator.
-    auto result = GetDeviceAndAllocator(params, engine_info);
+    auto result = GetDeviceAndAllocator(params, engine_info, &cluster);
     EXPECT_EQ(0, result.first);
     EXPECT_NE(nullptr, result.second);
     EXPECT_EQ("GPU_0_bfc", result.second->Name());
@@ -124,7 +123,7 @@ TEST(ConvertGraphTest, GetDeviceAndAllocator) {
   engine_info.device = "/GPU:1";
   {
     // Set to use second device.
-    auto result = GetDeviceAndAllocator(params, engine_info);
+    auto result = GetDeviceAndAllocator(params, engine_info, &cluster);
     EXPECT_EQ(0, result.first);
     EXPECT_NE(nullptr, result.second);
     EXPECT_EQ("GPU_1_bfc", result.second->Name());
@@ -133,7 +132,7 @@ TEST(ConvertGraphTest, GetDeviceAndAllocator) {
   engine_info.device = "/GPU:3";
   {
     // Set to use nonexistent device.
-    auto result = GetDeviceAndAllocator(params, engine_info);
+    auto result = GetDeviceAndAllocator(params, engine_info, &cluster);
     EXPECT_EQ(-1, result.first);
     EXPECT_EQ(nullptr, result.second);
   }
@@ -161,7 +160,7 @@ class ConvertAfterShapesTest : public ::testing::Test {
     params.use_calibration = false;
     params.trt_logger_name = "DefaultLogger";
 
-    return ConvertAfterShapes(params);
+    return ConvertAfterShapes(params, nullptr);
   }
 };
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -51,7 +51,10 @@ limitations under the License.
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/graph/algorithm.h"
 #include "tensorflow/core/graph/graph.h"
+#include "tensorflow/core/grappler/grappler_item.h"
 #include "tensorflow/core/grappler/op_types.h"
+#include "tensorflow/core/grappler/optimizers/constant_folding.h"
+#include "tensorflow/core/grappler/optimizers/generic_layout_optimizer.h"
 #include "tensorflow/core/kernels/linalg/einsum_op_impl.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status.h"
@@ -6654,7 +6657,8 @@ Status ConvertGraphDefToEngine(
     TrtUniquePtrType<nvinfer1::ICudaEngine>* engine, bool use_calibration,
     const bool use_implicit_batch, bool* convert_successfully,
     TrtShapeOptimizationProfile* profiles, absl::string_view engine_name,
-    bool use_explicit_precision) {
+    bool use_explicit_precision,
+    tensorflow::grappler::Cluster *cluster) {
   engine->reset();
   if (convert_successfully) *convert_successfully = false;
 
@@ -6666,12 +6670,45 @@ Status ConvertGraphDefToEngine(
   TF_RETURN_IF_ERROR(statusor.status());
   std::unique_ptr<Converter> converter = std::move(statusor.ValueOrDie());
 
+  GraphDef graph = gdef;
+  if (cluster != nullptr) {
+    bool apply_layout_optim;
+    Status status =
+        ReadBoolFromEnvVar("TF_TRT_ENABLE_LAYOUT_OPTIMIZER",
+                           /*default_value=*/true, &apply_layout_optim);
+    if (!status.ok()) {
+      LOG(ERROR) << status;
+    }
+    if (apply_layout_optim) {
+      tensorflow::grappler::GrapplerItem grappler_item;
+      grappler_item.graph = gdef;
+      // TensorRT API requires the input for convolution to be in NCHW.
+      tensorflow::grappler::GenericLayoutOptimizer layout_optimizer("NCHW");
+      TF_RETURN_IF_ERROR(layout_optimizer.Optimize(
+        cluster, grappler_item, &graph));
+
+      grappler_item.graph = graph;
+
+      tensorflow::grappler::ConstantFolding const_optimizer(nullptr,
+                            /*disable_compressed_tensor_optimization=*/false,
+                            /*fold_quantization_emulation=*/false);
+      TF_RETURN_IF_ERROR(const_optimizer.Optimize(
+        cluster, grappler_item, &graph));
+
+      // The optimizers may break the topological order
+      // so we need these steps to restore it
+      Graph g(OpRegistry::Global());
+      TF_RETURN_IF_ERROR(
+          ConvertGraphDefToGraph(GraphConstructorOptions(), graph, &g));
+      g.ToGraphDef(&graph);
+    }
+  }
   VLOG(1) << "Starting to convert TensorFlow ops to TensorRT layers";
   std::vector<Converter::EngineOutputInfo> output_tensors;
   int num_layers = converter->network()->getNbLayers();
   absl::flat_hash_set<const char*> layer_names;
   // Graph nodes are already topologically sorted during construction
-  for (const auto& node_def : gdef.node()) {
+  for (const auto& node_def : graph.node()) {
     const string& node_name = node_def.name();
     VLOG(2) << "Converting node " << node_name << ", op=" << node_def.op();
     if (IsEngineInput(node_name)) {

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -149,6 +149,9 @@ Status ConvertSegmentToGraphDef(
 // - convert_successfully: indicates whether the conversion to TensorRT network
 //   is successful. This is different than successfully building the engine:
 //   building can still fail afterwards.
+// Note: When 'cluster' is not null, it contains the graph to be converted.
+//       We may perform additional optimizations to the graph before converting
+//       the graph.
 Status ConvertGraphDefToEngine(
     const GraphDef& gdef, TrtPrecisionMode precision_mode, int max_batch_size,
     size_t max_workspace_size_bytes,
@@ -158,7 +161,8 @@ Status ConvertGraphDefToEngine(
     TrtUniquePtrType<nvinfer1::ICudaEngine>* engine, bool use_calibration,
     const bool use_implicit_batch, bool* convert_successfully,
     TrtShapeOptimizationProfile* profiles, absl::string_view engine_name,
-    bool use_explicit_precision);
+    bool use_explicit_precision,
+    tensorflow::grappler::Cluster *cluster = nullptr);
 
 // Helper class for the segmenter to determine whether an output edge from the
 // TRT segment is valid.

--- a/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
@@ -336,7 +336,6 @@ Status TRTOptimizationPass::Optimize(grappler::Cluster* cluster,
   cp.output_graph_def = optimized_graph;
   cp.precision_mode = precision_mode_;
   cp.minimum_segment_size = minimum_segment_size_;
-  cp.cluster = cluster;
   cp.is_dyn_op = is_dynamic_op_;
   cp.max_cached_engines = max_cached_batches_;
   cp.use_calibration = use_calibration_;
@@ -353,7 +352,7 @@ Status TRTOptimizationPass::Optimize(grappler::Cluster* cluster,
     assert(cp.minimum_segment_size > 0);
   }
 
-  auto status = ConvertAfterShapes(cp);
+  auto status = ConvertAfterShapes(cp, cluster);
   VLOG(1) << "Returning from " << name_;
   return status;
 }

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -37,6 +37,8 @@ limitations under the License.
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/graph/algorithm.h"
+#include "tensorflow/core/grappler/clusters/utils.h"
+#include "tensorflow/core/grappler/clusters/virtual_cluster.h"
 #include "tensorflow/core/lib/core/refcount.h"
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/lib/strings/strcat.h"
@@ -194,7 +196,7 @@ class TRTEngineOp : public AsyncOpKernel {
   StatusOr<TrtUniquePtrType<nvinfer1::ICudaEngine>> BuildEngine(
       const std::vector<TensorShape>& input_concrete_shapes, int batch_size,
       bool use_calibration, TRTInt8Calibrator* calibrator,
-      TRTEngineCacheResource* cache_resource);
+      TRTEngineCacheResource* cache_resource, OpKernelContext* ctx);
 
   // Verify that the input shapes are consistent and can be handled by this op.
   Status VerifyInputShapes(const std::vector<TensorShape>& shapes);
@@ -254,6 +256,8 @@ class TRTEngineOp : public AsyncOpKernel {
   // If true, create calibration graph for INT8 mode. Otherwise, we are using
   // user-provided quantization ranges.
   bool use_calibration_;
+
+  tensorflow::grappler::Cluster *cluster_;
 
   // Array of all input shapes, collected from the input_shapes attribute when
   // constructing the TRTEngineOp. The input_shapes attribute is set during
@@ -1010,7 +1014,10 @@ Status TRTEngineOp::GetEngineCacheResource(OpKernelContext* ctx,
 StatusOr<TrtUniquePtrType<nvinfer1::ICudaEngine>> TRTEngineOp::BuildEngine(
     const std::vector<TensorShape>& input_concrete_shapes, int batch_size,
     bool use_calibration, TRTInt8Calibrator* calibrator,
-    TRTEngineCacheResource* cache_resource) {
+    TRTEngineCacheResource* cache_resource,
+    OpKernelContext* ctx) {
+  TRT_ENSURE(cache_resource);
+  TRT_ENSURE(ctx);
   // Use concrete shapes for implicit batch mode and partial shapes for
   // explicit batch mode.
   bool use_concrete_shapes =
@@ -1024,12 +1031,18 @@ StatusOr<TrtUniquePtrType<nvinfer1::ICudaEngine>> TRTEngineOp::BuildEngine(
   VLOG(1) << "Building a new TensorRT engine for " << name()
           << " with input shapes: " << DebugString(conversion_input_shapes);
 
+  std::unordered_map<string, tensorflow::DeviceProperties> device_map;
+  DeviceNameUtils::ParsedName full_parsed_name;
+  DeviceNameUtils::ParseFullName(ctx->device()->name(), &full_parsed_name);
+  device_map.emplace(ctx->device()->name(), grappler::GetDeviceInfo(full_parsed_name));
+  tensorflow::grappler::VirtualCluster cluster(device_map);
+
   TrtUniquePtrType<nvinfer1::ICudaEngine> engine;
   auto status = convert::ConvertGraphDefToEngine(
       segment_graph_def_, precision_mode_, batch_size, workspace_size_,
       conversion_input_shapes, &logger, cache_resource->allocator_.get(),
       calibrator, &engine, use_calibration, use_implicit_batch_, nullptr,
-      &cache_resource->profiles_, name(), use_explicit_precision_);
+      &cache_resource->profiles_, name(), use_explicit_precision_, &cluster);
   if (!status.ok()) {
     LOG_FIRST_FEW_WARNING_WITH_PREFIX
         << "Engine creation for " << name() << " failed. "
@@ -1131,7 +1144,8 @@ StatusOr<std::pair<EngineContext*, int>> TRTEngineOp::GetEngine(
       }
       auto result = BuildEngine(input_concrete_shapes, batch_size,
                                 /*use_calibration=*/false,
-                                /*calibrator=*/nullptr, cache_res);
+                                /*calibrator=*/nullptr, cache_res,
+                                ctx);
       if (!result.ok()) {
         return std::pair<EngineContext*, int>(&empty_context, 0);
       }
@@ -1198,7 +1212,8 @@ StatusOr<std::pair<EngineContext*, int>> TRTEngineOp::GetEngine(
     // Up to this point, calibrator_ can never be empty, since otherwise it
     // means calibration_mode_ is true and this path won't get executed.
     auto result = BuildEngine(input_concrete_shapes, batch_size,
-                              use_calibration_, calibrator_.get(), cache_res);
+                              use_calibration_, calibrator_.get(), cache_res,
+                              ctx);
     if (!result.ok()) {
       return std::pair<EngineContext*, int>(&empty_context, 0);
     }
@@ -1262,7 +1277,9 @@ Status TRTEngineOp::AllocateCalibrationResources(
   }
 
   cache_res->Ref();
+  string platform_device_name = ctx->device()->name();
   cres->thr_.reset(new std::thread([this, cres, shapes, platform_device_id,
+                                    platform_device_name,
                                     cache_res]() {
     core::ScopedUnref sc(cache_res);
 
@@ -1276,6 +1293,13 @@ Status TRTEngineOp::AllocateCalibrationResources(
     }
     std::vector<PartialTensorShape> partial_shapes(shapes.begin(),
                                                    shapes.end());
+
+    std::unordered_map<string, tensorflow::DeviceProperties> device_map;
+    DeviceNameUtils::ParsedName full_parsed_name;
+    DeviceNameUtils::ParseFullName(platform_device_name, &full_parsed_name);
+    device_map.emplace(platform_device_name, grappler::GetDeviceInfo(full_parsed_name));
+    tensorflow::grappler::VirtualCluster cluster(device_map);
+
     // ConvertGraphDefToEngine() will try to build the engine. This thread
     // will loop inside buildCudaEngine() consuming the calibration data
     // that is set by the TF op, and drive the builder until calibrator
@@ -1291,7 +1315,8 @@ Status TRTEngineOp::AllocateCalibrationResources(
         cres->calibrator_.get(), &cres->engine_, /*use_calibration=*/true,
         this->use_implicit_batch_, /*convert_successfully=*/nullptr,
         /*profiles=*/nullptr, name(),
-        /*use_explicit_precision=*/use_explicit_precision_);
+        /*use_explicit_precision=*/use_explicit_precision_,
+         /*cluster=*/&cluster);
     if (!s.ok()) {
       LOG(ERROR) << "Calibration failed: " << s;
       cres->calibrator_->setDone();  // Ignore further pushes

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
@@ -111,8 +111,9 @@ class TRTEngineOpTestBase : public OpsTestBase {
 
       profile.InitProfiles({shape}, ProfileStrategy::kOptimal);
       std::vector<PartialTensorShape> shape_vec{shape, {}};
-      TF_CHECK_OK(convert::CreateStaticEngine(params, info, 1, shape_vec,
-                                              &profile, &segment_string));
+      TF_CHECK_OK(convert::CreateStaticEngine(params, nullptr, info, 1,
+                                              shape_vec, &profile,
+                                              &segment_string));
     }
 
     // Create the op.


### PR DESCRIPTION
### Motivation
The introduction of Tensor Cores in recent GPU architectures (and the subsequent changes in cuDNN) made `NHWC` the preferred layout for convolutions in TF.

However, the TensorRT API requires the input for convolution to be in `NCHW`. To satisfy this requirement, TF-TRT was inserting transpose ops around convolutions when necessary.

This PR adds a layout optimization pass with a target layout of `NCHW`, which ensures that most of Conv kernels will be in TRT compatible layout. Additionally, the layout optimization pass can eliminate redundant layout transpose operations. This results in a simpler TRT network with a larger potential for optimization.

### Description
TF-TRT now accomplishes it by running both a grapplers's `GenericLayoutOptimizer` followed by a ConstantFolding optimizers  in the `ConvertGraphDefToEngine`, applying them on a segment level.

The LayoutOptimizer ensures that the number of transposition is optimal. This optimization is described in slides 18-21 of [TensorFlow Graph Optimizations presentation ](https://web.stanford.edu/class/cs245/slides/TFGraphOptimizationsStanford.pdf)

This PR also modifies the `GenericLayoutOptimizer` to enforce a specific layout is set as layout target, through a ctor parameter.

The layout optimizer can be enabled with the environment variable `TF_TRT_ENABLE_LAYOUT_OPTIMIZER` (default=1, set to 0 to disable).

### Dependency

This PR needs the changes in https://github.com/tensorflow/tensorflow/pull/53368
