### PR TITLE
[lite] Add flag TFLITE_ENABLE_HEXAGON and update build rules to only …

### DIFF
--- a/tensorflow/lite/delegates/hexagon/BUILD
+++ b/tensorflow/lite/delegates/hexagon/BUILD
@@ -67,6 +67,14 @@ cc_library(
 )
 
 cc_library(
+    name = "enable_hexagon_delegate",
+    defines = select({
+        "//tensorflow:arm_any": ["TFLITE_ENABLE_HEXAGON"],
+        "//conditions:default": [],
+    }),
+)
+
+cc_library(
     name = "hexagon_delegate",
     srcs = ["hexagon_delegate.cc"],
     hdrs = ["hexagon_delegate.h"],
@@ -82,7 +90,12 @@ cc_library(
         "//tensorflow/lite:minimal_logging",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite/delegates/utils:simple_delegate",
-    ],
+    ] + select({
+        "//tensorflow:ios": [],
+        "//tensorflow:ios_x86_64": [],
+        "//tensorflow:macos": [],
+        "//conditions:default": [":enable_hexagon_delegate"],
+    }),
 )
 
 cc_library(

--- a/tensorflow/lite/tools/delegates/hexagon_delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/hexagon_delegate_provider.cc
@@ -18,10 +18,6 @@ limitations under the License.
 #include "tensorflow/lite/tools/delegates/delegate_provider.h"
 #include "tensorflow/lite/tools/evaluation/utils.h"
 
-#if !defined(__APPLE__) && (defined(__arm__) || defined(__aarch64__))
-#define TFLITE_ENABLE_HEXAGON
-#endif
-
 #if defined(TFLITE_ENABLE_HEXAGON)
 #include "tensorflow/lite/delegates/hexagon/hexagon_delegate.h"
 #endif

--- a/tensorflow/lite/tools/evaluation/utils.cc
+++ b/tensorflow/lite/tools/evaluation/utils.cc
@@ -137,16 +137,16 @@ TfLiteDelegatePtr CreateGPUDelegate() {
 
 TfLiteDelegatePtr CreateHexagonDelegate(
     const std::string& library_directory_path, bool profiling) {
-#if !defined(__APPLE__) && (defined(__arm__) || defined(__aarch64__))
+#if TFLITE_ENABLE_HEXAGON
   TfLiteHexagonDelegateOptions options = {0};
   options.print_graph_profile = profiling;
   return CreateHexagonDelegate(&options, library_directory_path);
 #else
   return CreateNullDelegate();
-#endif  // defined(__arm__)
+#endif  // TFLITE_ENABLE_HEXAGON
 }
 
-#if !defined(__APPLE__) && (defined(__arm__) || defined(__aarch64__))
+#if TFLITE_ENABLE_HEXAGON
 TfLiteDelegatePtr CreateHexagonDelegate(
     const TfLiteHexagonDelegateOptions* options,
     const std::string& library_directory_path) {

--- a/tensorflow/lite/tools/evaluation/utils.h
+++ b/tensorflow/lite/tools/evaluation/utils.h
@@ -31,7 +31,7 @@ limitations under the License.
 #include "tensorflow/lite/delegates/gpu/delegate.h"
 #endif
 
-#if !defined(__APPLE__) && (defined(__arm__) || defined(__aarch64__))
+#if TFLITE_ENABLE_HEXAGON
 #include "tensorflow/lite/delegates/hexagon/hexagon_delegate.h"
 #endif
 
@@ -77,7 +77,7 @@ TfLiteDelegatePtr CreateGPUDelegate(TfLiteGpuDelegateOptionsV2* options);
 
 TfLiteDelegatePtr CreateHexagonDelegate(
     const std::string& library_directory_path, bool profiling);
-#if !defined(__APPLE__) && (defined(__arm__) || defined(__aarch64__))
+#if TFLITE_ENABLE_HEXAGON
 TfLiteDelegatePtr CreateHexagonDelegate(
     const TfLiteHexagonDelegateOptions* options,
     const std::string& library_directory_path);


### PR DESCRIPTION
…define it if compiling for arm on non-apple devices.

PiperOrigin-RevId: 414330792
Change-Id: I88e534e506c03554c2cb6b079ba2bde07f1244e1