### PR TITLE
[lite] Remove explicit #define for  TFLITE_ENABLE_HEXAGON. This shoul…

### DIFF
--- a/tensorflow/lite/tools/benchmark/BUILD
+++ b/tensorflow/lite/tools/benchmark/BUILD
@@ -185,6 +185,7 @@ cc_library(
         "@com_google_absl//absl/memory",
         "//tensorflow/core/util:stats_calculator_portable",
         "//tensorflow/lite/c:common",
+        "//tensorflow/lite/delegates/hexagon:hexagon_delegate",
         "//tensorflow/lite/nnapi:nnapi_util",
         "//tensorflow/lite/profiling:time",
         "//tensorflow/lite/tools:command_line_flags",

--- a/tensorflow/lite/tools/benchmark/benchmark_performance_options.cc
+++ b/tensorflow/lite/tools/benchmark/benchmark_performance_options.cc
@@ -33,11 +33,6 @@ limitations under the License.
 #include "tensorflow/lite/tools/command_line_flags.h"
 #include "tensorflow/lite/tools/logging.h"
 
-#if (defined(ANDROID) || defined(__ANDROID__)) && \
-    (defined(__arm__) || defined(__aarch64__))
-#define TFLITE_ENABLE_HEXAGON
-#endif
-
 namespace tflite {
 namespace benchmark {
 


### PR DESCRIPTION
…d be enabled by separate build target.

PiperOrigin-RevId: 414750624
Change-Id: I0650e96f81e840f4f885c7f459a59d75620e3743