### PR TITLE
Update go documenting comment

### DIFF
--- a/tensorflow/go/session_test.go
+++ b/tensorflow/go/session_test.go
@@ -375,8 +375,8 @@ func TestSessionConfig(t *testing.T) {
 	// tensorflow Python program:
 	/*
 	 import tensorflow
-	 c = tensorflow.ConfigProto()
-	 c.intra_op_parallelism_threads = 1
+	 c = tensorflow.compat.v1.ConfigProto()
+	 c.inter_op_parallelism_threads = 1
 	 print c.SerializeToString()
 	*/
 	graph := NewGraph()


### PR DESCRIPTION
Working with tensorflow version 2.6.0 it seems that the toy python program mentioned in the comment no longer works.
`tensorflow.ConfigProto()` seems to have been moved to `tensorflow.compat.v1.ConfigProto()`
And the byteStream shown bellow `(\x01"` seems to correspond to setting the `inter_op` parameter not the `intra_op`