### PR TITLE
Fix wrong output of tf.stack with 0-dimension tensor

### DIFF
--- a/tensorflow/core/kernels/pack_op.cc
+++ b/tensorflow/core/kernels/pack_op.cc
@@ -87,25 +87,25 @@ class PackOp : public OpKernel {
     const int64_t axis_dim = output_shape.dim_size(axis);
 
     const int64_t output_size = output->NumElements();
+    auto output_flat =
+        output->shaped<T, 2>({before_dim, after_dim * axis_dim});
+
+    // Except for shapes, pack is a special case of concat, so we reuse the
+    // same computational kernels.
+    ConstMatrixVector inputs_flat;
+    inputs_flat.reserve(num);
+    for (int i = 0; i < num; ++i) {
+      const Tensor& input = c->input(i);
+      OP_REQUIRES(c, first_input.shape().IsSameSize(input.shape()),
+                  errors::InvalidArgument(
+                      "Shapes of all inputs must match: values[0].shape = ",
+                      first_input.shape().DebugString(), " != values[", i,
+                      "].shape = ", input.shape().DebugString()));
+
+      inputs_flat.emplace_back(new typename TTypes<T, 2>::ConstMatrix(
+          input.shaped<T, 2>({before_dim, after_dim})));
+    }
     if (output_size > 0) {
-      auto output_flat =
-          output->shaped<T, 2>({before_dim, after_dim * axis_dim});
-
-      // Except for shapes, pack is a special case of concat, so we reuse the
-      // same computational kernels.
-      ConstMatrixVector inputs_flat;
-      inputs_flat.reserve(num);
-      for (int i = 0; i < num; ++i) {
-        const Tensor& input = c->input(i);
-        OP_REQUIRES(c, first_input.shape().IsSameSize(input.shape()),
-                    errors::InvalidArgument(
-                        "Shapes of all inputs must match: values[0].shape = ",
-                        first_input.shape().DebugString(), " != values[", i,
-                        "].shape = ", input.shape().DebugString()));
-
-        inputs_flat.emplace_back(new typename TTypes<T, 2>::ConstMatrix(
-            input.shaped<T, 2>({before_dim, after_dim})));
-      }
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
       if (std::is_same<Device, GPUDevice>::value) {
         ConcatGPU<T>(c, inputs_flat, output, &output_flat);

--- a/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/stack_op_test.py
@@ -288,6 +288,16 @@ class StackOpTest(test.TestCase):
             c = array_ops.stack(xs)
             self.assertAllEqual(self.evaluate(c), data)
 
+  def testZeroDimUnmatch(self):
+    # Test case for GitHub issue 53300.
+    # Error message is `Shapes of all inputs must match` in eager mode,
+    # and `Shapes ...` in graph mode. Below is to capture both:
+    with self.assertRaisesRegex((errors.InvalidArgumentError, ValueError),
+                                r"Shapes"):
+      with self.session():
+        t = [array_ops.zeros([0, 3]), array_ops.zeros([1, 3])]
+        self.evaluate(array_ops.stack(t))
+
 
 class AutomaticStackingTest(test.TestCase):
 

--- a/tensorflow/python/kernel_tests/linalg/lu_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/lu_op_test.py
@@ -109,6 +109,8 @@ class LuOpTest(test.TestCase):
           array_ops.broadcast_to(
               math_ops.range(batch_size)[:, None], perm_reshaped.shape),
           dtype=output_idx_type)
+      if inv_perm_reshaped.shape == [0]:
+        inv_perm_reshaped = array_ops.zeros_like(batch_indices)
       permuted_verification_reshaped = array_ops.gather_nd(
           verification_reshaped,
           array_ops.stack([batch_indices, inv_perm_reshaped], axis=-1))


### PR DESCRIPTION
This PR tries to address the issue raised in #53300 where
tf.stack will silently output wrong result with 0-dimension tensor.
The issue was that the shape check was skipped when num of output elements
was zero. This PR fixed the issue.

This PR fixes #53300.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>