### PR TITLE
[Grappler] Add enforced_layout parameter for LayoutOptimizer

### DIFF
--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer.cc
@@ -109,11 +109,19 @@ inline std::pair<string, string> GetSrcAndDstDataFormats(
     const TransposeContext& context, int num_gpus, int num_voltas) {
   string src_format = kNHWC;
   string dst_format = kNCHW;
-  if (((static_cast<float>(num_voltas) / static_cast<float>(num_gpus)) >=
-       kVoltaGPURatioThreshold) &&
-      NumConvOnDeviceWithDataTypeOverThreshold(context, kGPU, DT_HALF)) {
+
+  const bool is_NHWC_enforced = (!context.enforced_layout.empty()
+                                  && context.enforced_layout == "NHWC");
+  const bool should_swap =
+          ((static_cast<float>(num_voltas) / static_cast<float>(num_gpus))
+            >= kVoltaGPURatioThreshold)
+          && NumConvOnDeviceWithDataTypeOverThreshold(context, kGPU, DT_HALF);
+  // We swap only if NHWC is enforced or no layout is enforced and the devices
+  // config meet the thresholds
+  if (is_NHWC_enforced || (context.enforced_layout.empty() && should_swap)) {
     std::swap(src_format, dst_format);
   }
+
   return {src_format, dst_format};
 }
 
@@ -408,12 +416,22 @@ Status GenericLayoutOptimizer::Optimize(Cluster* cluster,
         << "generic layout optimizer was called with cluster == nullptr";
     return errors::Aborted("cluster == nullptr.");
   }
+  if (!enforced_layout_.empty()
+      && enforced_layout_ != "NHWC"
+      && enforced_layout_ != "NCHW") {
+    return Status(tensorflow::error::Code::INVALID_ARGUMENT,
+                  absl::StrCat("Invalid value for enforced_layout: ",
+                               enforced_layout_,
+                               ". Supported layouts: 'NHWC', 'NCHW'."));
+  }
   const auto num_gpus_and_num_volta = GetNumGPUs(*cluster);
   const int num_gpus = num_gpus_and_num_volta.first;
 
   const bool is_aggressive = opt_level_ == RewriterConfig::AGGRESSIVE;
 
   TransposeContext context;
+  context.enforced_layout = enforced_layout_;
+
   if (num_gpus > 0) {
     TF_RETURN_IF_ERROR(TransposeContext::InitializeTransposeContext(
         /*assume_valid_feeds=*/is_aggressive, item, cluster, &context));

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer.h
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer.h
@@ -25,15 +25,21 @@ namespace grappler {
 // Optimize the data layout for convolutional models.
 class GenericLayoutOptimizer : public GraphOptimizer {
  public:
-  GenericLayoutOptimizer()
+  GenericLayoutOptimizer(string enforced_layout="")
       : GenericLayoutOptimizer(RewriterConfig::DEFAULT,
-                               RewriterConfig::NO_CONVERSION_ON_CPU) {}
-  explicit GenericLayoutOptimizer(RewriterConfig::Toggle opt_level)
-      : GenericLayoutOptimizer(opt_level,
-                               RewriterConfig::NO_CONVERSION_ON_CPU) {}
+                               RewriterConfig::NO_CONVERSION_ON_CPU,
+                               enforced_layout) {
+  }
   explicit GenericLayoutOptimizer(RewriterConfig::Toggle opt_level,
-                                  RewriterConfig::CpuLayout layout_conversion)
-      : opt_level_(opt_level), cpu_layout_conversion_(layout_conversion) {}
+                                  string enforced_layout="")
+      : GenericLayoutOptimizer(opt_level,
+                               RewriterConfig::NO_CONVERSION_ON_CPU,
+                               enforced_layout) {}
+  explicit GenericLayoutOptimizer(RewriterConfig::Toggle opt_level,
+                                  RewriterConfig::CpuLayout layout_conversion,
+                                  string enforced_layout="")
+      : opt_level_(opt_level), cpu_layout_conversion_(layout_conversion),
+        enforced_layout_(enforced_layout) {}
   ~GenericLayoutOptimizer() override = default;
 
   string name() const override { return "layout"; };
@@ -46,6 +52,7 @@ class GenericLayoutOptimizer : public GraphOptimizer {
  private:
   RewriterConfig::Toggle opt_level_;
   RewriterConfig::CpuLayout cpu_layout_conversion_;
+  const string enforced_layout_;
 };
 
 }  // namespace grappler

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
@@ -85,6 +85,8 @@ struct TransposeContext {
   absl::flat_hash_map<char, int> dst_dim_indices;
   std::vector<int> src_to_dst;
   std::vector<int> dst_to_src;
+
+  string enforced_layout;
 };
 
 class Transposer {


### PR DESCRIPTION
This PR adds an option to enforce a specific layout in the grappler `LayoutOptimizer`.

The `enforce_layout` can be set to either `NHCW` or `NCHW`.  When set, the layout optimizer will attempt to convert all the layout sensitive operations to the specified layout (thus, not relying on `NumConvOnDeviceWithDataTypeOverThreshold` anymore).