### PR TITLE
Explicitly reset interpreter to prevent memory leaks when using delegate

### DIFF
--- a/tensorflow/lite/examples/label_image/label_image.cc
+++ b/tensorflow/lite/examples/label_image/label_image.cc
@@ -394,6 +394,9 @@ void RunInference(Settings* settings,
     const int index = result.second;
     LOG(INFO) << confidence << ": " << index << " " << labels[index];
   }
+
+  // Destory the interpreter earlier than delegates objects.
+  interpreter.reset();
 }
 
 void display_usage(const DelegateProviders& delegate_providers) {


### PR DESCRIPTION
Internally at Broadcom, we ran into a memory leak when running the label_image app using an external HW delegate.  The delegate was freed/released before the some of the graph data, causing our libraries to report an memory leak.

The fix, calling "Interpreter.reset()" is already done in other test apps.  E.g. see: https://github.com/tensorflow/tensorflow/commit/23873d4d6518a6f169600a076001dc2d7a661dd0 by @terryheo 

Change-Id: I884cde7e31d84b1bcd7b90fe77eb4b2321f3df0c