### PR TITLE
[Go] Stabilize generated wrappers

### DIFF
--- a/tensorflow/go/genop/internal/api_def_map.go
+++ b/tensorflow/go/genop/internal/api_def_map.go
@@ -31,6 +31,7 @@ import (
 	"unsafe"
 
 	"google.golang.org/protobuf/proto"
+
 	adpb "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/api_def_go_proto"
 	odpb "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/op_def_go_proto"
 )

--- a/tensorflow/go/genop/internal/genop.go
+++ b/tensorflow/go/genop/internal/genop.go
@@ -49,6 +49,7 @@ import (
 
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
+
 	adpb "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/api_def_go_proto"
 	odpb "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/op_def_go_proto"
 )
@@ -211,12 +212,12 @@ func makeOutputList(op *tf.Operation, start int, output string) ([]tf.Output, in
 `))
 
 	tmplOp = template.Must(template.New("op").Funcs(template.FuncMap{
-		"MakeComment":       makeComment,
-		"GoType":            goType,
-		"CamelCase":         camelCase,
-		"Identifier":        identifier,
-		"IsListArg":         isListArg,
-		"IsListAttr":        isListAttr,
+		"MakeComment":         makeComment,
+		"GoType":              goType,
+		"CamelCase":           camelCase,
+		"Identifier":          identifier,
+		"IsListArg":           isListArg,
+		"IsListAttr":          isListAttr,
 		"MarshalProtoMessage": marshalProtoMessage,
 	}).Parse(`
 {{if .OptionalAttrs -}}
@@ -572,28 +573,28 @@ func isListAttr(attrdef *odpb.OpDef_AttrDef) bool {
 }
 
 func marshalProtoMessage(m proto.Message) string {
-        // Marshal proto message to string.
-        o := prototext.MarshalOptions{Multiline: false}
-        x := o.Format(m)
+	// Marshal proto message to string.
+	o := prototext.MarshalOptions{Multiline: false}
+	x := o.Format(m)
 
-        // Remove superfluous whitespace, if present.
-        //
-        // Go protobuf output is purposefully unstable, randomly adding
-        // whitespace.  See github.com/golang/protobuf/issues/1121
-        x = strings.ReplaceAll(x, "  ", " ")
+	// Remove superfluous whitespace, if present.
+	//
+	// Go protobuf output is purposefully unstable, randomly adding
+	// whitespace.  See github.com/golang/protobuf/issues/1121
+	x = strings.ReplaceAll(x, "  ", " ")
 
-        // Remove the prefix of the string up to the first colon.
-        //
-        // This is useful when 's' corresponds to a "oneof" protocol buffer
-        // message. For example, consider the protocol buffer message:
-        //   oneof value { bool b = 1;  int64 i = 2; }
-        // proto.CompactTextString) will print "b:true", or "i:7" etc. The
-        // following strips out the leading "b:" or "i:".
-        y := strings.SplitN(x, ":", 2)
-        if len(y) < 2 {
-                return x
-        }
-        return y[1]
+	// Remove the prefix of the string up to the first colon.
+	//
+	// This is useful when 's' corresponds to a "oneof" protocol buffer
+	// message. For example, consider the protocol buffer message:
+	//   oneof value { bool b = 1;  int64 i = 2; }
+	// proto.CompactTextString) will print "b:true", or "i:7" etc. The
+	// following strips out the leading "b:" or "i:".
+	y := strings.SplitN(x, ":", 2)
+	if len(y) < 2 {
+		return x
+	}
+	return y[1]
 }
 
 func parseTFType(tfType string) (list bool, typ string) {

--- a/tensorflow/go/genop/internal/genop_test.go
+++ b/tensorflow/go/genop/internal/genop_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"google.golang.org/protobuf/encoding/prototext"
+
 	adpb "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/api_def_go_proto"
 	odpb "github.com/tensorflow/tensorflow/tensorflow/go/core/framework/op_def_go_proto"
 )

--- a/tensorflow/go/genop/internal/genop_test.go
+++ b/tensorflow/go/genop/internal/genop_test.go
@@ -49,8 +49,6 @@ func GetAPIDef(t *testing.T, opdef *odpb.OpDef, apidefText string) *adpb.ApiDef 
 // are not stable, see https://github.com/golang/protobuf/issues/1121
 func TestGenerateOp(t *testing.T) {
 
-	t.Skip("this test is disabled")
-
 	// TestGenerateOp validates the generated source code for an op.
 	// The OpDef for the test cases are simplified forms of real ops.
 	testdata := []struct {
@@ -726,7 +724,7 @@ func SampleDistortedBoundingBoxMinObjectCovered(value float32) SampleDistortedBo
 // SampleDistortedBoundingBoxAspectRatioRange sets the optional aspect_ratio_range attribute to value.
 //
 // value: Blah blah
-// If not specified, defaults to {f:0.75  f:1.33}
+// If not specified, defaults to {f:0.75 f:1.33}
 func SampleDistortedBoundingBoxAspectRatioRange(value []float32) SampleDistortedBoundingBoxAttr {
 	return func(m optionalAttr) {
 		m["aspect_ratio_range"] = value
@@ -736,7 +734,7 @@ func SampleDistortedBoundingBoxAspectRatioRange(value []float32) SampleDistorted
 // SampleDistortedBoundingBoxAreaRange sets the optional area_range attribute to value.
 //
 // value: Blah blah
-// If not specified, defaults to {f:0.05  f:1}
+// If not specified, defaults to {f:0.05 f:1}
 func SampleDistortedBoundingBoxAreaRange(value []float32) SampleDistortedBoundingBoxAttr {
 	return func(m optionalAttr) {
 		m["area_range"] = value


### PR DESCRIPTION
Multiple commits each day make white-space only changes to `/tensorflow/go/op/wrappers.go` with commit message `Go: Update generated wrapper functions for TensorFlow ops.`  Example: tensorflow/tensorflow@82c3b11

PR stabilizes output from the genop library, which generates these wrappers.  The source of the current instability is the text marshaler in google.golang.org/protobuf, which purposefully adds [random whitespace](https://github.com/protocolbuffers/protobuf-go/blob/v1.27.1/internal/encoding/text/encode.go#L226).
- Catch and remove superfluous whitespace when marshaling proto message
- Sort op list (and thus wrapper functions) lexicographically by name
- Re-enable test TestGeneratedOp which was previously disabled due to output instability