### PR TITLE
Added lowerings for mhlo.sine and mhlo.cosine to mhlo preprocessing

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/lower_complex_patterns.td
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/lower_complex_patterns.td
@@ -76,6 +76,42 @@ def : Pat<(HLO_AbsOp HLO_ComplexTensor:$val),
               (HLO_MulOp (HLO_RealOp:$real $val), $real),
               (HLO_MulOp (HLO_ImagOp:$imag $val), $imag)))>;
 
+// Can deconstruct sin(a + ib) as follows:
+//   sin(a) * cosh(b) + icos(a) * sinh(b)
+//   sinh(b) = (e^x - e^-x) / 2
+//   cosh(b) = (e^x + e^-x) / 2
+def : Pat<(HLO_SinOp HLO_ComplexTensor:$val),
+            (HLO_ComplexOp
+              (HLO_DivOp
+                (HLO_MulOp
+                  (HLO_SinOp (HLO_RealOp:$real $val)),
+                  (HLO_AddOp
+                    (HLO_ExpOp:$exp (HLO_ImagOp:$imag $val)),
+                    (HLO_ExpOp:$nexp (HLO_NegOp $imag)))),
+                 (HLO_ConstOp : $two (ConstantSplat<"2.0"> $real))),
+              (HLO_DivOp
+                (HLO_MulOp
+                  (HLO_CosOp $real),
+                  (HLO_SubOp $exp, $nexp)), $two))>;
+
+// Can deconstruct cos(a + ib) as follows:
+//   cos(a) * cosh(b) - isin(a) * sinh(b)
+//   sinh(b) = (e^x - e^-x) / 2
+//   cosh(b) = (e^x + e^-x) / 2
+def : Pat<(HLO_CosOp HLO_ComplexTensor:$val),
+            (HLO_ComplexOp
+              (HLO_DivOp
+                (HLO_MulOp
+                  (HLO_CosOp (HLO_RealOp:$real $val)),
+                  (HLO_AddOp
+                    (HLO_ExpOp:$exp (HLO_ImagOp:$imag $val)),
+                    (HLO_ExpOp:$nexp (HLO_NegOp $imag)))),
+                 (HLO_ConstOp : $two (ConstantSplat<"2.0"> $real))),
+              (HLO_DivOp
+                (HLO_MulOp
+                  (HLO_SinOp $real),
+                  (HLO_SubOp $nexp, $exp)), $two))>;
+
 // Exponential can be lowered to an exponential on the real component and a
 // sum of sinusoids of the imaginary component, which equates to a normal
 // exponential operator multiplied by Euler's formula.

--- a/tensorflow/compiler/mlir/hlo/tests/lower-complex.mlir
+++ b/tensorflow/compiler/mlir/hlo/tests/lower-complex.mlir
@@ -270,3 +270,49 @@ func @compare_ne(%lhs : tensor<2xcomplex<f32>>, %rhs: tensor<2xcomplex<f32>>) ->
   // CHECK: return [[OUT]]
   return %0 : tensor<2xi1>
 }
+
+// CHECK-LABEL: @sin
+func @sin(%arg0 : tensor<10xf32>, %arg1 : tensor<10xf32>) -> (tensor<10xf32>, tensor<10xf32>) {
+  // CHECK-DAG: %[[TWO:.+]] = mhlo.constant dense<2.000000e+00>
+  // CHECK-DAG: %[[SIN:.+]] = "mhlo.sine"(%arg0)
+  // CHECK-DAG: %[[EXP:.+]] = "mhlo.exponential"(%arg1)
+  // CHECK-DAG: %[[NEG:.+]] = "mhlo.negate"(%arg1)
+  // CHECK-DAG: %[[NEXP:.+]] = "mhlo.exponential"(%[[NEG]])
+  // CHECK-DAG: %[[ADD:.+]] = mhlo.add %[[EXP]], %[[NEXP]]
+  // CHECK-DAG: %[[MUL:.+]] = mhlo.multiply %[[SIN]], %[[ADD]]
+  // CHECK-DAG: %[[RDIV:.+]] = mhlo.divide %[[MUL]], %[[TWO]]
+  // CHECK-DAG: %[[COS:.+]] = "mhlo.cosine"(%arg0)
+  // CHECK-DAG: %[[SUB:.+]] = mhlo.subtract %[[EXP]], %[[NEXP]]
+  // CHECK-DAG: %[[IMUL:.+]] = mhlo.multiply %[[COS]], %[[SUB]]
+  // CHECK-DAG: %[[IDIV:.+]] = mhlo.divide %[[IMUL]], %[[TWO]]
+  %0 = "mhlo.complex"(%arg0, %arg1) : (tensor<10xf32>, tensor<10xf32>) -> (tensor<10xcomplex<f32>>)
+  %1 = "mhlo.sine"(%0) : (tensor<10xcomplex<f32>>) -> (tensor<10xcomplex<f32>>)
+  %2 = "mhlo.real"(%1) : (tensor<10xcomplex<f32>>) -> (tensor<10xf32>)
+  %3 = "mhlo.imag"(%1) : (tensor<10xcomplex<f32>>) -> (tensor<10xf32>)
+
+  // CHECK: return %[[RDIV]], %[[IDIV]]
+  return %2, %3 : tensor<10xf32>, tensor<10xf32>
+}
+
+// CHECK-LABEL: @cos
+func @cos(%arg0 : tensor<10xf32>, %arg1 : tensor<10xf32>) -> (tensor<10xf32>, tensor<10xf32>) {
+  // CHECK-DAG: %[[TWO:.+]] = mhlo.constant dense<2.000000e+00>
+  // CHECK-DAG: %[[COS:.+]] = "mhlo.cosine"(%arg0)
+  // CHECK-DAG: %[[EXP:.+]] = "mhlo.exponential"(%arg1)
+  // CHECK-DAG: %[[NEG:.+]] = "mhlo.negate"(%arg1)
+  // CHECK-DAG: %[[NEXP:.+]] = "mhlo.exponential"(%[[NEG]])
+  // CHECK-DAG: %[[ADD:.+]] = mhlo.add %[[EXP]], %[[NEXP]]
+  // CHECK-DAG: %[[MUL:.+]] = mhlo.multiply %[[COS]], %[[ADD]]
+  // CHECK-DAG: %[[RDIV]] = mhlo.divide %[[MUL]], %[[TWO]]
+  // CHECK-DAG: %[[SIN:.+]] = "mhlo.sine"(%arg0)
+  // CHECK-DAG: %[[SUB:.+]] = mhlo.subtract %[[NEXP]], %[[EXP]]
+  // CHECK-DAG: %[[IMUL:.+]] = mhlo.multiply %[[SIN]], %[[SUB]]
+  // CHECK-DAG: %[[IDIV:.+]] = mhlo.divide %[[IMUL]], %[[TWO]]
+  %0 = "mhlo.complex"(%arg0, %arg1) : (tensor<10xf32>, tensor<10xf32>) -> (tensor<10xcomplex<f32>>)
+  %1 = "mhlo.cosine"(%0) : (tensor<10xcomplex<f32>>) -> (tensor<10xcomplex<f32>>)
+  %2 = "mhlo.real"(%1) : (tensor<10xcomplex<f32>>) -> (tensor<10xf32>)
+  %3 = "mhlo.imag"(%1) : (tensor<10xcomplex<f32>>) -> (tensor<10xf32>)
+
+  // CHECK: return %[[RDIV]], %[[IDIV]]
+  return %2, %3 : tensor<10xf32>, tensor<10xf32>
+}


### PR DESCRIPTION
We can decompose sine and cosine operations to additional sine, cosing, and
exponential operattions. Includes tests for both operations.