### PR TITLE
Update tensorflow-io-gcs-filesystem version and add python3.10 support

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -93,7 +93,7 @@ REQUIRED_PACKAGES = [
     'tensorboard >= 2.7, < 2.8',
     'tensorflow_estimator >= 2.7.0, < 2.8',
     'keras >= 2.7.0, < 2.8',
-    'tensorflow-io-gcs-filesystem >= 0.23.0,
+    'tensorflow-io-gcs-filesystem >= 0.23.0',
 ]
 
 

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -93,7 +93,7 @@ REQUIRED_PACKAGES = [
     'tensorboard >= 2.7, < 2.8',
     'tensorflow_estimator >= 2.7.0, < 2.8',
     'keras >= 2.7.0, < 2.8',
-    'tensorflow-io-gcs-filesystem >= 0.21.0; python_version<"3.10"',  # TODO(b/209682854)
+    'tensorflow-io-gcs-filesystem >= 0.23.0,
 ]
 
 


### PR DESCRIPTION
With the release of 0.23.0 tensorflow-io-gcs-filesystem, it is possible
to update and remove the limitation of python3.10.

/cc @mihaimaruseac 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>