### PR TITLE
Hide JPEG symbols on Darwin (to align with Linux)

### DIFF
--- a/tensorflow/tf_private_symbols.lds
+++ b/tensorflow/tf_private_symbols.lds
@@ -1,9 +1,9 @@
-jpeg_*
-jinit_*
-jdiv_round_up
-jround_up
-jzero_far
-jcopy_*
-jsimd_*
-hwloc_*
+_jpeg_*
+_jinit_*
+_jdiv_round_up
+_jround_up
+_jzero_far
+_jcopy_*
+_jsimd_*
+_hwloc_*
 *mlir*

--- a/tensorflow/tf_private_symbols.lds
+++ b/tensorflow/tf_private_symbols.lds
@@ -1,1 +1,9 @@
+jpeg_*
+jinit_*
+jdiv_round_up
+jround_up
+jzero_far
+jcopy_*
+jsimd_*
+hwloc_*
 *mlir*


### PR DESCRIPTION
//tensorflow:tensorflow_framework specifies a version script so that the internal version of libjpeg isn't leaked, however this is not reflected in the darwin settings.  Align them.