### PR TITLE
Experimental jax natural allocation emit

### DIFF
--- a/tensorflow/compiler/mlir/hlo/BUILD
+++ b/tensorflow/compiler/mlir/hlo/BUILD
@@ -1759,6 +1759,7 @@ cc_library(
         ":lhlo_legalize_to_gpu",
         ":lhlo_legalize_to_parallel_loops",
         ":mhlo_canonicalize_reduction",
+        ":buffer_packing",
         ":mhlo_control_flow_to_scf",
         ":mhlo_flatten_tuple",
         ":mhlo_fusion",
@@ -1845,6 +1846,22 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Shape",
         "@llvm-project//mlir:TensorDialect",
+    ],
+)
+cc_library(
+    name = "buffer_packing",
+    srcs = ["lib/Transforms/buffer_packing.cc"],
+    hdrs = [
+        "include/mlir-hlo/Transforms/PassDetail.h",
+        "include/mlir-hlo/Transforms/passes.h",
+    ],
+    deps = [
+        ":hlo",
+        ":transforms_pass_inc_gen",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
     ],
 )
 

--- a/tensorflow/compiler/mlir/hlo/BUILD
+++ b/tensorflow/compiler/mlir/hlo/BUILD
@@ -1852,6 +1852,7 @@ cc_library(
     name = "buffer_packing",
     srcs = ["lib/Transforms/buffer_packing.cc"],
     hdrs = [
+        "include/mlir-hlo/Analysis/userange_analysis.h",
         "include/mlir-hlo/Transforms/PassDetail.h",
         "include/mlir-hlo/Transforms/passes.h",
     ],

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Analysis/userange_analysis.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Analysis/userange_analysis.h
@@ -98,6 +98,7 @@ struct UseInterval {
 /// compute intervals starting at the first and ending with the last use of
 /// every alloc value.
 class UserangeAnalysis {
+
  public:
   using UsePosition = std::pair<size_t, Operation *>;
   using UsePositionList = std::vector<UsePosition>;
@@ -152,7 +153,7 @@ class UserangeAnalysis {
   /// Dumps the liveness information to the given stream.
   void dump(raw_ostream &os);
 
- private:
+private:
   using ValueSetT = BufferViewFlowAnalysis::ValueSetT;
   using OperationListT = Liveness::OperationListT;
 
@@ -199,6 +200,6 @@ class UserangeAnalysis {
   Liveness liveness;
 };
 
-}  // namespace mlir
+} // namespace mlir
 
-#endif  // TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_ANALYSIS_USERANGE_ANALYSIS_H_
+#endif // TENSORFLOW_COMPILER_MLIR_HLO_INCLUDE_MLIR_HLO_ANALYSIS_USERANGE_ANALYSIS_H_

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
@@ -46,6 +46,7 @@ std::unique_ptr<FunctionPass> createTestShapeComponentAnalysisPass();
 /// CopyOpInterface.
 std::unique_ptr<FunctionPass> createCopyRemovalPass();
 
+/// Creates a pass that computes the allocated memory.
 std::unique_ptr<FunctionPass> createMemoryCountPass();
 
 } // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
@@ -46,6 +46,8 @@ std::unique_ptr<FunctionPass> createTestShapeComponentAnalysisPass();
 /// CopyOpInterface.
 std::unique_ptr<FunctionPass> createCopyRemovalPass();
 
-}  // namespace mlir
+std::unique_ptr<FunctionPass> createMemoryCountPass();
+
+} // namespace mlir
 
 #endif // TENSORFLOW_COMPILER_MLIR_HLO_LIB_TRANSFORMS_PASSES_H_

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
@@ -32,7 +32,9 @@ std::unique_ptr<FunctionPass> createBufferReusePass();
 /// Creates a pass that tries to simplify dynamic reshapes.
 std::unique_ptr<FunctionPass> createReshapeSimplifierPass();
 
-std::unique_ptr<FunctionPass> createBufferPackingPass();
+/// Creates a pass that merges smaller buffer into bigger buffer to optimize
+/// memory consumption.
+std::unique_ptr<FunctionPass> createBufferPackingPass(unsigned window_size = 5);
 
 /// Creates a pass that tests the useranges of the UserangeAnalysis.
 std::unique_ptr<FunctionPass> createTestUserangePass();
@@ -46,4 +48,4 @@ std::unique_ptr<FunctionPass> createCopyRemovalPass();
 
 }  // namespace mlir
 
-#endif  // TENSORFLOW_COMPILER_MLIR_HLO_LIB_TRANSFORMS_PASSES_H_
+#endif // TENSORFLOW_COMPILER_MLIR_HLO_LIB_TRANSFORMS_PASSES_H_

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.h
@@ -32,6 +32,8 @@ std::unique_ptr<FunctionPass> createBufferReusePass();
 /// Creates a pass that tries to simplify dynamic reshapes.
 std::unique_ptr<FunctionPass> createReshapeSimplifierPass();
 
+std::unique_ptr<FunctionPass> createBufferPackingPass();
+
 /// Creates a pass that tests the useranges of the UserangeAnalysis.
 std::unique_ptr<FunctionPass> createTestUserangePass();
 

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
@@ -56,6 +56,11 @@ def BufferPacking : FunctionPass<"buffer-packing"> {
   ];
 }
 
+def MemoryCount : FunctionPass<"memory-count"> {
+  let summary = "";
+  let constructor = "createMemoryCountPass()";
+}
+
 def TestUserange : FunctionPass<"test-print-userange"> {
   let summary = "Test pass for checking userange intervals.";
   let constructor = "createTestUserangePass()";

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
@@ -47,7 +47,8 @@ def CopyRemoval : FunctionPass<"copy-removal"> {
 def BufferPacking : FunctionPass<"buffer-packing"> {
   let summary = "";
   let description = [{ }];
-  let dependentDialects = ["StandardOpsDialect","memref::MemRefDialect"];
+  let dependentDialects = ["StandardOpsDialect","memref::MemRefDialect",
+    "arith::ArithmeticDialect"];
   let constructor = "createBufferPackingPass()";
   let options = [
    Option<"window_size_", "window-size", "unsigned",

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
@@ -44,6 +44,12 @@ def CopyRemoval : FunctionPass<"copy-removal"> {
   let constructor = "createCopyRemovalPass()";
 }
 
+def BufferPacking : FunctionPass<"buffer-packing"> {
+  let summary = "";
+  let description = [{ }];
+  let constructor = "createBufferPackingPass()";
+}
+
 def TestUserange : FunctionPass<"test-print-userange"> {
   let summary = "Test pass for checking userange intervals.";
   let constructor = "createTestUserangePass()";

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
@@ -45,20 +45,27 @@ def CopyRemoval : FunctionPass<"copy-removal"> {
 }
 
 def BufferPacking : FunctionPass<"buffer-packing"> {
-  let summary = "";
-  let description = [{ }];
+  let summary = "Pass to pack allocated buffer to reduce memory consumption.";
+  let description = [{The pass tries to pack smaler buffer into larger buffers.
+  To do this, it sorts all allocated buffer by an selected sorting startegy.
+  After this sorting, the buffers are checked whether subsequent buffers can be
+  packed into them.}];
   let dependentDialects = ["StandardOpsDialect","memref::MemRefDialect",
     "arith::ArithmeticDialect"];
   let constructor = "createBufferPackingPass()";
   let options = [
    Option<"window_size_", "window-size", "unsigned",
-           /*default=*/"5", "The window size to equalize the start position "
-           "of a buffer.">,
+           /*default=*/"5", "The window size blurs the start position of an"
+           "allocated buffer. Buffers allocated in the same sliding window area"
+           "are treated the same in term of the allocation."
+           "A window size of zero is sorting the buffery by memory size.">,
   ];
 }
 
 def MemoryCount : FunctionPass<"memory-count"> {
-  let summary = "";
+  let summary = "Test pass to count the allocated memory of an module.";
+  let description = [{A test pass that prints the size of allocated memory of a
+  module.}];
   let constructor = "createMemoryCountPass()";
 }
 

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
@@ -46,8 +46,9 @@ def CopyRemoval : FunctionPass<"copy-removal"> {
 
 def BufferPacking : FunctionPass<"buffer-packing"> {
   let summary = "Pass to pack allocated buffer to reduce memory consumption.";
-  let description = [{The pass tries to pack smaler buffer into larger buffers.
-  To do this, it sorts all allocated buffer by an selected sorting startegy.
+  let description = [{The pass tries to pack smaller buffers into larger buffers.
+  To do this, it sorts all allocated buffers by multiple criteria depends on the
+  selected window-size.
   After this sorting, the buffers are checked whether subsequent buffers can be
   packed into them.}];
   let dependentDialects = ["StandardOpsDialect","memref::MemRefDialect",
@@ -57,13 +58,14 @@ def BufferPacking : FunctionPass<"buffer-packing"> {
    Option<"window_size_", "window-size", "unsigned",
            /*default=*/"5", "The window size blurs the start position of an"
            "allocated buffer. Buffers allocated in the same sliding window area"
-           "are treated the same in term of the allocation."
-           "A window size of zero is sorting the buffery by memory size.">,
+           "are treated equally in terms of starting position, withing the"
+           "sliding window area they are sorted by memory size."
+           "A window size of zero sorts the buffers only by memory size.">,
   ];
 }
 
 def MemoryCount : FunctionPass<"memory-count"> {
-  let summary = "Test pass to count the allocated memory of an module.";
+  let summary = "Test pass to count the allocated memory of a module.";
   let description = [{A test pass that prints the size of allocated memory of a
   module.}];
   let constructor = "createMemoryCountPass()";

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Transforms/passes.td
@@ -47,7 +47,13 @@ def CopyRemoval : FunctionPass<"copy-removal"> {
 def BufferPacking : FunctionPass<"buffer-packing"> {
   let summary = "";
   let description = [{ }];
+  let dependentDialects = ["StandardOpsDialect","memref::MemRefDialect"];
   let constructor = "createBufferPackingPass()";
+  let options = [
+   Option<"window_size_", "window-size", "unsigned",
+           /*default=*/"5", "The window size to equalize the start position "
+           "of a buffer.">,
+  ];
 }
 
 def TestUserange : FunctionPass<"test-print-userange"> {

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/utils/hlo_utils.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/utils/hlo_utils.h
@@ -110,6 +110,9 @@ bool IsSequenceStartingWith0(Attribute attr);
 // Returns the argument index for the giving FuncOp and its operand value.
 int64_t getArgumentIndex(mlir::FuncOp op, Value value);
 
+/// Computes the memory usage of the given allocations.
+std::pair<size_t, size_t> computeMemory(const std::vector<Value> &allocs);
+
 }  // namespace hlo
 }  // namespace mlir
 

--- a/tensorflow/compiler/mlir/hlo/lib/Transforms/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ add_mlir_library(MLIRBufferTransforms
   buffer_reuse.cc
   copy_removal.cc
   reshape_simplifier.cc
+  buffer_packing.cc
 
   DEPENDS
   LMHLOTransformsPassIncGen

--- a/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
@@ -413,28 +413,6 @@ private:
   }
 };
 
-struct BufferPackingPass : public BufferPackingBase<BufferPackingPass> {
-  explicit BufferPackingPass(unsigned windowSize) {
-    this->window_size_ = windowSize;
-  }
-
-  void runOnFunction() override {
-    MLIRContext *context = &getContext();
-
-    if (window_size_ == 0) {
-      SortedPackingStrategy<AllocInfoMemSizeCompare> strategy(
-          window_size_, AllocInfoMemSizeCompare());
-      BufferPacking packing(getFunction(), strategy);
-    } else {
-      SortedPackingStrategy<AllocInfoWinIdCompare> strategy(
-          window_size_, AllocInfoWinIdCompare());
-      BufferPacking packing(getFunction(), strategy);
-    }
-  }
-};
-
-<<<<<<< HEAD
-=======
 /// Reuses already allocated buffer to save allocation operations.
 class MemoryCount : BufferPlacementTransformationBase {
 public:
@@ -456,12 +434,28 @@ public:
       size_t shapeBytes = shape.getSizeInBits() / 8;
       size_t alignFactor = llvm::divideCeil(shapeBytes, padding);
       size_t size = alignFactor * padding;
-
-      // llvm::errs() << "Alloc: " << alloc << ", Size: " << size << " Byte.\n";
       totalSize += size;
     }
+  }
+};
 
-    llvm::errs() << "Total size: " << totalSize << "\n";
+struct BufferPackingPass : public BufferPackingBase<BufferPackingPass> {
+  explicit BufferPackingPass(unsigned windowSize) {
+    this->window_size_ = windowSize;
+  }
+
+  void runOnFunction() override {
+    MLIRContext *context = &getContext();
+
+    if (window_size_ == 0) {
+      SortedPackingStrategy<AllocInfoMemSizeCompare> strategy(
+          window_size_, AllocInfoMemSizeCompare());
+      BufferPacking packing(getFunction(), strategy);
+    } else {
+      SortedPackingStrategy<AllocInfoWinIdCompare> strategy(
+          window_size_, AllocInfoWinIdCompare());
+      BufferPacking packing(getFunction(), strategy);
+    }
   }
 };
 
@@ -469,11 +463,14 @@ struct MemoryCountPass : MemoryCountBase<MemoryCountPass> {
   void runOnFunction() override { MemoryCount counter(getFunction()); }
 };
 
->>>>>>> 7c4c319549f... Buffer sorting startegy get template of comperator
 } // namespace
 
 std::unique_ptr<FunctionPass> createBufferPackingPass(unsigned window_size) {
   return std::make_unique<BufferPackingPass>(window_size);
+}
+
+std::unique_ptr<FunctionPass> createMemoryCountPass() {
+  return std::make_unique<MemoryCountPass>();
 }
 
 } // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
@@ -378,8 +378,8 @@ public:
         Location loc = viewDefOp->getLoc();
         mlir::OpBuilder viewBuilder(viewDefOp);
 
-        // Create a ConstantOp with the aligned offset.
-        Value constantOp = viewBuilder.create<mlir::ConstantOp>(
+        // Create a arithmetic ConstantOp with the aligned offset.
+        Value constantOp = viewBuilder.create<mlir::arith::ConstantOp>(
             loc, viewBuilder.getIndexType(),
             viewBuilder.getIntegerAttr(viewBuilder.getIndexType(), offset));
 

--- a/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
@@ -1,0 +1,321 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mlir-hlo/Analysis/userange_analysis.h"
+#include "mlir-hlo/Transforms/PassDetail.h"
+#include "mlir-hlo/Transforms/passes.h"
+#include "mlir/Analysis/BufferViewFlowAnalysis.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/BufferUtils.h"
+
+namespace mlir {
+
+namespace {
+
+/// The PackingInfo contains all important information of a value for the buffer
+/// packing.
+struct PackingInfo {
+  using PackingOffsetPair = std::pair<std::pair<size_t, size_t>, Value>;
+
+public:
+  PackingInfo(Value value, UserangeAnalysis analysis)
+      : alloc(std::move(value)), userange(std::move(analysis)) {
+    // Compute the byte size and the aligned byte size of the alloc.
+    lastUsedByte = computeByteSize(alloc);
+    numAlignedSegments = computeAlignedSegments(alloc);
+
+    // Create an UseInterval that contains the first and last use of the value.
+    // Gaps are not considered because the memory must be allocated during this
+    // time.
+    totalUseInterval = UserangeAnalysis::UseInterval(
+        userange.getFirstUseIndex(alloc).getValue(),
+        userange.getLastUseIndex(alloc).getValue());
+
+    std::vector<size_t> userangeIDs;
+    std::vector<PackingOffsetPair> alignedBufferSegment{std::make_pair(
+        std::make_pair((size_t)0, numAlignedSegments - 1), alloc)};
+    // Distribute the aligned buffer segments for the whole useInterval. Also
+    // save the userange IDs for later back mapping.
+    for (size_t i = totalUseInterval.first, e = totalUseInterval.second; i <= e;
+         ++i) {
+      memoryDistribution.insert(std::make_pair(i, alignedBufferSegment));
+      userangeIDs.emplace_back(i);
+    }
+
+    allocToUserangeIDs.insert(std::make_pair(alloc, userangeIDs));
+    valueOffset.insert(std::make_pair(
+        alloc, std::make_pair((size_t)0, numAlignedSegments - 1)));
+  }
+
+  /// Compute the 64 byte alinged segments of a given Value.
+  size_t computeAlignedSegments(Value v) {
+    size_t padding = 64;
+    size_t bytes = computeByteSize(v);
+    return std::ceil(bytes / (double)padding);
+  }
+
+  /// Compute the byte size of a given Value.
+  size_t computeByteSize(Value v) {
+    return v.getType().cast<ShapedType>().getSizeInBits() / 8;
+  }
+
+  /// Compute the potential reusers from the given PackingInfo vector. If the
+  /// useIntervals interfere and the aligned buffer size of the other
+  /// PackingInfo is bigger, we continue. Otherwise we order the potential
+  /// reusers by their aligned buffer size.
+  void computePotentialReuser(std::vector<PackingInfo> &other) {
+    for (auto info : other) {
+      Value v = info.alloc;
+      // Skip if the other PackingInfo is this PackingInfo.
+      if (alloc == v)
+        continue;
+
+      // If the useIntervals of this PackingInfo and the other PackingInfo
+      // interfere, we cannot reuse the other PackingInfo.
+      if (userange.getLastUseIndex(alloc) >= info.totalUseInterval.first &&
+          userange.getFirstUseIndex(alloc) <= info.totalUseInterval.second)
+        continue;
+
+      if (info.numAlignedSegments > numAlignedSegments)
+        continue;
+
+      // Find the correct place to insert the potential reuser based on the
+      // aligned buffer size.
+      auto iter = potentialReuser.begin();
+      while (iter != potentialReuser.end() &&
+             iter->numAlignedSegments >= info.numAlignedSegments)
+        ++iter;
+
+      potentialReuser.insert(iter, info);
+    }
+  }
+
+  /// Try to merge all potential reuser in the current buffer and compute a new
+  /// buffer memory distribution.
+  void packPotentialReuser(DenseSet<Value> &alreadyUnited) {
+    // Iterate over all potential reusers and check if possible candidates fit
+    // into buffer.
+    for (PackingInfo &candidate : potentialReuser) {
+      // Create a copy of the current memory distribution.
+      DenseMap<size_t, std::vector<PackingOffsetPair>> possibleMemeoryDist(
+          memoryDistribution);
+      DenseMap<Value, std::pair<size_t, size_t>> possibleOffsetToAdd;
+      size_t possibleLastUsedByte = candidate.lastUsedByte;
+
+      // Check if the candidate is already packed into an other buffer.
+      if (alreadyUnited.contains(candidate.alloc))
+        continue;
+      // Flag if we can unite the buffers.
+      bool canUnite = true;
+
+      // Iterate over allocs to check if we can allocate the same buffer
+      // segments for all userangeIDs.
+      for (auto &cInterval : candidate.allocToUserangeIDs) {
+        // The possible aligned segments that can be used.
+        std::vector<size_t> possibleOffsets;
+        for (size_t i = 0,
+                    e = (numAlignedSegments - candidate.numAlignedSegments);
+             i <= e; ++i)
+          possibleOffsets.emplace_back(i);
+        Value candidateAlloc = cInterval.first;
+        size_t candidateSegments = computeAlignedSegments(candidateAlloc);
+        std::vector<size_t> userangeIDs = cInterval.second;
+        for (size_t userangeID : userangeIDs) {
+          std::vector<PackingOffsetPair> &occupiedIntervals =
+              possibleMemeoryDist[userangeID];
+          // Check if any interval is occupied
+          if (occupiedIntervals.empty())
+            continue;
+
+          // Delete occupied interval from candidate list.
+          // If we find a interval (a,b) we must delete all candidate
+          // (a - segemnts needed  + 1,b)
+          for (auto &entry : occupiedIntervals) {
+            std::pair<size_t, size_t> interval = entry.first;
+            size_t start = candidateSegments > interval.first
+                               ? 0
+                               : interval.first - candidateSegments + 1;
+
+            // Iterate over the expanded interval to erase possible
+            // offsets.
+            for (size_t i = start, e = interval.second; i <= e; ++i) {
+              auto iter =
+                  std::find(possibleOffsets.begin(), possibleOffsets.end(), i);
+              // Check if we found an interference and delete it.
+              if (iter != possibleOffsets.end())
+                possibleOffsets.erase(iter);
+            }
+          }
+        }
+
+        // Check if we have possible offset if not we must not unite the
+        // buffers.
+        if (possibleOffsets.empty()) {
+          canUnite = false;
+          break;
+        }
+        auto minOffsetIter =
+            std::min(possibleOffsets.begin(), possibleOffsets.end());
+        std::pair<size_t, size_t> interval = std::make_pair(
+            *minOffsetIter, (*minOffsetIter) + candidateSegments - 1);
+        possibleOffsetToAdd.insert(std::make_pair(candidateAlloc, interval));
+        for (size_t time : userangeIDs) {
+          std::vector<PackingOffsetPair> otherIntervals =
+              possibleMemeoryDist[time];
+          otherIntervals.emplace_back(std::make_pair(interval, candidateAlloc));
+          std::sort(otherIntervals.begin(), otherIntervals.end(),
+                    [&](PackingOffsetPair a, PackingOffsetPair b) {
+                      return a.first.first - b.first.first;
+                    });
+          possibleMemeoryDist[time] = otherIntervals;
+        }
+      }
+      if (canUnite) {
+        // Update the memory distribution.
+        memoryDistribution = possibleMemeoryDist;
+
+        // Update the alloc to userangeIDs mapping.
+        allocToUserangeIDs.insert(candidate.allocToUserangeIDs.begin(),
+                                  candidate.allocToUserangeIDs.end());
+        // Add the alloc candidate to the united buffers.
+        alreadyUnited.insert(candidate.alloc);
+        valueOffset.insert(possibleOffsetToAdd.begin(),
+                           possibleOffsetToAdd.end());
+      }
+    }
+  }
+
+  Value alloc;
+  size_t numAlignedSegments;
+  UserangeAnalysis::UseInterval totalUseInterval;
+  std::vector<PackingInfo> potentialReuser;
+  DenseMap<size_t, std::vector<PackingOffsetPair>> memoryDistribution;
+  DenseMap<Value, std::vector<size_t>> allocToUserangeIDs;
+  DenseMap<Value, std::pair<size_t, size_t>> valueOffset;
+  size_t lastUsedByte;
+
+private:
+  UserangeAnalysis userange;
+};
+
+/// Reuses already allocated buffer to save allocation operations.
+class BufferPacking : BufferPlacementTransformationBase {
+public:
+  using AllocList = std::vector<Value>;
+
+public:
+  BufferPacking(Operation *op) : BufferPlacementTransformationBase(op) {
+    std::vector<PackingInfo> packInfos;
+    UserangeAnalysis userange(op, allocs, aliases);
+    for (auto allocEntry : allocs) {
+      Value v = std::get<0>(allocEntry);
+      PackingInfo info(v, userange);
+
+      auto iter = packInfos.begin();
+      while (iter != packInfos.end() &&
+             iter->numAlignedSegments >= info.numAlignedSegments)
+        ++iter;
+      packInfos.insert(iter, info);
+    }
+
+    for (auto &infos : packInfos)
+      infos.computePotentialReuser(packInfos);
+
+    DenseSet<Value> alreadUnitedBuffer;
+    for (auto &infos : packInfos) {
+      if (alreadUnitedBuffer.contains(infos.alloc))
+        continue;
+      infos.packPotentialReuser(alreadUnitedBuffer);
+    }
+
+    for (Value unitedAlloc : alreadUnitedBuffer) {
+      for (auto iter = packInfos.begin(), e = packInfos.end(); iter != e;
+           ++iter) {
+        if (iter->alloc == unitedAlloc) {
+          packInfos.erase(iter);
+          break;
+        }
+      }
+    }
+
+    DenseMap<Value, size_t> valueOffsets;
+    size_t totalBufferSize = 0;
+
+    for (auto infosIter = packInfos.begin(), e = packInfos.end();
+         infosIter != e; ++infosIter) {
+      for (auto &entry : infosIter->valueOffset) {
+        valueOffsets.insert(std::make_pair(
+            entry.first, entry.second.first * 64 + totalBufferSize));
+      }
+      totalBufferSize += infosIter->numAlignedSegments * 64;
+    }
+
+    // Create the packed AllocOp.
+    Value firstAlloc = std::get<0>(*allocs.begin());
+
+    Operation *packDefOp = firstAlloc.getDefiningOp();
+    mlir::OpBuilder packBuilder(packDefOp);
+    auto memrefType =
+        MemRefType::get({totalBufferSize}, packBuilder.getIntegerType(8));
+    Value packedAlloc =
+        packBuilder.create<memref::AllocOp>(packDefOp->getLoc(), memrefType);
+
+    // Iterate over all allocs and create a ConstantOp with aligned offset.
+    for (auto &entry : valueOffsets) {
+      Value currentAlloc = entry.first;
+      size_t offset = entry.second;
+
+      // Initialize a OpBuilder for the ConstantOp and ViewOp.
+      Operation *viewDefOp = currentAlloc.getDefiningOp();
+      Location loc = viewDefOp->getLoc();
+      mlir::OpBuilder viewBuilder(viewDefOp);
+
+      // Create a ConstantOp with the aligned offset.
+      Value constantOp = viewBuilder.create<mlir::ConstantOp>(
+          loc, viewBuilder.getIndexType(),
+          viewBuilder.getIntegerAttr(viewBuilder.getIndexType(), offset));
+
+      // Store the operands for the ViewOp.
+      SmallVector<Value, 4> newOperands{packedAlloc};
+      newOperands.emplace_back(constantOp);
+
+      ShapedType shape = currentAlloc.getType().cast<ShapedType>();
+      // Create a ViewOp with the shape of the old alloc and use the created
+      // packed alloc and the constant for the operands.
+      Value viewOp = viewBuilder.create<memref::ViewOp>(
+          loc, shape.cast<MemRefType>(), newOperands);
+
+      // Replace all old allocs references with the created ViewOp and
+      // afterwards remove the old allocs.
+      currentAlloc.replaceAllUsesWith(viewOp);
+      viewDefOp->erase();
+    }
+  }
+};
+
+struct BufferPackingPass : public BufferPackingBase<BufferPackingPass> {
+  void runOnFunction() override { BufferPacking packing(getFunction()); }
+};
+
+} // end namespace
+
+std::unique_ptr<FunctionPass> createBufferPackingPass() {
+  return std::make_unique<BufferPackingPass>();
+}
+
+} // end namespace mlir

--- a/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
@@ -70,9 +70,8 @@ public:
   std::vector<AllocBufferOffset> allocBufferOffsets;
 };
 
-/// Contains the informations about a buffer allocation. It provides the
-/// information to sort the buffers and to check if it fits into other buffer
-/// and vise versa.
+/// Contains the information about a buffers allocation for sorting and checking
+/// if it fits into other buffers and vise versa.
 /// This structure contains the allocation value, the first and last userangeid
 /// of a buffer, the window id, the number of alligned 64 byte segments and all
 /// userange intervals.
@@ -172,7 +171,7 @@ public:
 
 public:
   /// Constructs the Sorted Packing Strategy. The window size is used as sliding
-  /// window size. Allocation userangepoitions that are in the same range are
+  /// window size. Allocation userangepositions that are in the same range are
   /// mapped to the same window id. So the information of the allocation
   /// starting position is blured.
   SortedPackingStrategy(size_t windowSize, CompareT compare)
@@ -389,7 +388,7 @@ public:
         SmallVector<Value, 4> newOperands{targetBuffer};
         newOperands.push_back(constantOp);
 
-        ShapedType shape = currentAlloc.getType().cast<MemRefType>();
+        auto shape = currentAlloc.getType().cast<MemRefType>();
 
         // Create a ViewOp with the shape of the old alloc and use the created
         // packed alloc and the constant for the operands.

--- a/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include "mlir-hlo/Transforms/PassDetail.h"
 #include "mlir-hlo/Transforms/passes.h"
 #include "mlir/Analysis/BufferViewFlowAnalysis.h"
+#include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Operation.h"
@@ -27,10 +28,33 @@ namespace mlir {
 
 namespace {
 
+/// Represents a memory interval.
+struct MemoryInterval {
+public:
+  MemoryInterval(size_t begin, size_t end) : begin(begin), end(end) {}
+
+  /// Unite two intervals if they overlap.
+  bool intervalUnion(const MemoryInterval &other) {
+    if (other.begin > end + 1 || other.end + 1 < begin)
+      return false;
+    begin = std::min(other.begin, begin);
+    end = std::max(other.end, end);
+    return true;
+  }
+
+  size_t getSize() { return end + 1 - begin; }
+
+  size_t begin;
+  size_t end;
+
+  // TODO: Remove Debug Dump.
+  void dump() { llvm::errs() << "(" << begin << ", " << end << ")\n"; }
+};
+
 /// The PackingInfo contains all important information of a value for the buffer
 /// packing.
 struct PackingInfo {
-  using PackingOffsetPair = std::pair<std::pair<size_t, size_t>, Value>;
+  using MemoryIntervalVector = std::vector<MemoryInterval>;
 
 public:
   PackingInfo(Value value, UserangeAnalysis analysis)
@@ -38,28 +62,21 @@ public:
     // Compute the byte size and the aligned byte size of the alloc.
     lastUsedByte = computeByteSize(alloc);
     numAlignedSegments = computeAlignedSegments(alloc);
+    UserangeAnalysis::IntervalVector intervals = userange.getUserangeOf(alloc);
 
-    // Create an UseInterval that contains the first and last use of the value.
-    // Gaps are not considered because the memory must be allocated during this
-    // time.
-    totalUseInterval = UserangeAnalysis::UseInterval(
-        userange.getFirstUseIndex(alloc).getValue(),
-        userange.getLastUseIndex(alloc).getValue());
+    MemoryInterval memoryInterval((size_t)0, numAlignedSegments - 1);
+    MemoryIntervalVector alignedBufferSegment{memoryInterval};
 
-    std::vector<size_t> userangeIDs;
-    std::vector<PackingOffsetPair> alignedBufferSegment{std::make_pair(
-        std::make_pair((size_t)0, numAlignedSegments - 1), alloc)};
     // Distribute the aligned buffer segments for the whole useInterval. Also
     // save the userange IDs for later back mapping.
-    for (size_t i = totalUseInterval.first, e = totalUseInterval.second; i <= e;
-         ++i) {
-      memoryDistribution.insert(std::make_pair(i, alignedBufferSegment));
-      userangeIDs.emplace_back(i);
+    for (auto &interval : intervals) {
+      for (size_t i = interval.first, e = interval.second; i <= e; ++i) {
+        memoryDistribution.insert(std::make_pair(i, alignedBufferSegment));
+        bufferUserangeIDs.emplace_back(i);
+      }
     }
 
-    allocToUserangeIDs.insert(std::make_pair(alloc, userangeIDs));
-    valueOffset.insert(std::make_pair(
-        alloc, std::make_pair((size_t)0, numAlignedSegments - 1)));
+    occupiedMemoryIntervals.insert(std::make_pair(alloc, memoryInterval));
   }
 
   /// Compute the 64 byte alinged segments of a given Value.
@@ -87,8 +104,7 @@ public:
 
       // If the useIntervals of this PackingInfo and the other PackingInfo
       // interfere, we cannot reuse the other PackingInfo.
-      if (userange.getLastUseIndex(alloc) >= info.totalUseInterval.first &&
-          userange.getFirstUseIndex(alloc) <= info.totalUseInterval.second)
+      if (userange.rangesInterfere(alloc, info.alloc))
         continue;
 
       if (info.numAlignedSegments > numAlignedSegments)
@@ -111,107 +127,246 @@ public:
     // Iterate over all potential reusers and check if possible candidates fit
     // into buffer.
     for (PackingInfo &candidate : potentialReuser) {
-      // Create a copy of the current memory distribution.
-      DenseMap<size_t, std::vector<PackingOffsetPair>> possibleMemeoryDist(
-          memoryDistribution);
-      DenseMap<Value, std::pair<size_t, size_t>> possibleOffsetToAdd;
-      size_t possibleLastUsedByte = candidate.lastUsedByte;
-
-      // Check if the candidate is already packed into an other buffer.
-      if (alreadyUnited.contains(candidate.alloc))
-        continue;
-      // Flag if we can unite the buffers.
-      bool canUnite = true;
-
-      // Iterate over allocs to check if we can allocate the same buffer
-      // segments for all userangeIDs.
-      for (auto &cInterval : candidate.allocToUserangeIDs) {
-        // The possible aligned segments that can be used.
-        std::vector<size_t> possibleOffsets;
-        for (size_t i = 0,
-                    e = (numAlignedSegments - candidate.numAlignedSegments);
-             i <= e; ++i)
-          possibleOffsets.emplace_back(i);
-        Value candidateAlloc = cInterval.first;
-        size_t candidateSegments = computeAlignedSegments(candidateAlloc);
-        std::vector<size_t> userangeIDs = cInterval.second;
-        for (size_t userangeID : userangeIDs) {
-          std::vector<PackingOffsetPair> &occupiedIntervals =
-              possibleMemeoryDist[userangeID];
-          // Check if any interval is occupied
-          if (occupiedIntervals.empty())
-            continue;
-
-          // Delete occupied interval from candidate list.
-          // If we find a interval (a,b) we must delete all candidate
-          // (a - segemnts needed  + 1,b)
-          for (auto &entry : occupiedIntervals) {
-            std::pair<size_t, size_t> interval = entry.first;
-            size_t start = candidateSegments > interval.first
-                               ? 0
-                               : interval.first - candidateSegments + 1;
-
-            // Iterate over the expanded interval to erase possible
-            // offsets.
-            for (size_t i = start, e = interval.second; i <= e; ++i) {
-              auto iter =
-                  std::find(possibleOffsets.begin(), possibleOffsets.end(), i);
-              // Check if we found an interference and delete it.
-              if (iter != possibleOffsets.end())
-                possibleOffsets.erase(iter);
-            }
-          }
-        }
-
-        // Check if we have possible offset if not we must not unite the
-        // buffers.
-        if (possibleOffsets.empty()) {
-          canUnite = false;
-          break;
-        }
-        auto minOffsetIter =
-            std::min(possibleOffsets.begin(), possibleOffsets.end());
-        std::pair<size_t, size_t> interval = std::make_pair(
-            *minOffsetIter, (*minOffsetIter) + candidateSegments - 1);
-        possibleOffsetToAdd.insert(std::make_pair(candidateAlloc, interval));
-        for (size_t time : userangeIDs) {
-          std::vector<PackingOffsetPair> otherIntervals =
-              possibleMemeoryDist[time];
-          otherIntervals.emplace_back(std::make_pair(interval, candidateAlloc));
-          std::sort(otherIntervals.begin(), otherIntervals.end(),
-                    [&](PackingOffsetPair a, PackingOffsetPair b) {
-                      return a.first.first - b.first.first;
-                    });
-          possibleMemeoryDist[time] = otherIntervals;
-        }
-      }
-      if (canUnite) {
-        // Update the memory distribution.
-        memoryDistribution = possibleMemeoryDist;
-
-        // Update the alloc to userangeIDs mapping.
-        allocToUserangeIDs.insert(candidate.allocToUserangeIDs.begin(),
-                                  candidate.allocToUserangeIDs.end());
-        // Add the alloc candidate to the united buffers.
-        alreadyUnited.insert(candidate.alloc);
-        valueOffset.insert(possibleOffsetToAdd.begin(),
-                           possibleOffsetToAdd.end());
-      }
+      tryPackCandidate(candidate, alreadyUnited);
     }
   }
 
   Value alloc;
   size_t numAlignedSegments;
-  UserangeAnalysis::UseInterval totalUseInterval;
   std::vector<PackingInfo> potentialReuser;
-  DenseMap<size_t, std::vector<PackingOffsetPair>> memoryDistribution;
-  DenseMap<Value, std::vector<size_t>> allocToUserangeIDs;
-  DenseMap<Value, std::pair<size_t, size_t>> valueOffset;
+  DenseMap<size_t, MemoryIntervalVector> memoryDistribution;
+  std::vector<size_t> bufferUserangeIDs;
+  DenseMap<Value, MemoryInterval> occupiedMemoryIntervals;
   size_t lastUsedByte;
 
 private:
   UserangeAnalysis userange;
-};
+
+  /// Check if the first segments are not occupied and there is enough
+  /// contiguous memory. If not the memory distribution is updated.
+  llvm::Optional<size_t>
+  updateFirstSegmentUsage(MemoryIntervalVector &userangeOccupiedMemoryDist,
+                          MemoryInterval const &intervalToCheck,
+                          PackingInfo const &candidate) {
+    if (intervalToCheck.begin < candidate.numAlignedSegments) {
+      // Check if overlapping with first interval. If not we must add a new
+      // first interval.
+      if (!userangeOccupiedMemoryDist.begin()->intervalUnion(intervalToCheck))
+        userangeOccupiedMemoryDist.insert(userangeOccupiedMemoryDist.begin(),
+                                          intervalToCheck);
+
+      return 0;
+    }
+    return llvm::None;
+  }
+
+  /// Find the relevant intervals that change the userange occupation of the
+  /// memory.
+  MemoryIntervalVector::iterator findRelevantIntervalsToAdd(
+      MemoryIntervalVector const &userangeOccupiedDistribution,
+      MemoryIntervalVector &intervalsToAdd,
+      llvm::Optional<size_t> const &intervalOffset) {
+    auto addIntervalIter = intervalsToAdd.begin();
+    if (intervalOffset.hasValue()) {
+      auto currentMemoryLocIter = std::next(
+          userangeOccupiedDistribution.begin(), intervalOffset.getValue());
+      addIntervalIter = std::find_if(
+          addIntervalIter, intervalsToAdd.end(), [&](MemoryInterval interval) {
+            return interval.end > currentMemoryLocIter->end;
+          });
+    }
+    return addIntervalIter;
+  }
+
+  /// Check if Contigous emory is availabel and update the interval offset to
+  /// the appropriate position if possible.
+  bool
+  updateContigousMemoryOffset(llvm::Optional<size_t> &intervalOffset,
+                              MemoryIntervalVector &userangeOccupiedMemoryDist,
+                              PackingInfo const &candidate) {
+    // Because of the dummy interval the iterator points never to end.
+    auto iter = userangeOccupiedMemoryDist.begin();
+    size_t firstOccupiedMemorySegemt = iter->begin;
+    bool foundPreviousGap =
+        candidate.numAlignedSegments <= firstOccupiedMemorySegemt;
+    intervalOffset = foundPreviousGap ? llvm::None : llvm::Optional<size_t>(0);
+
+    // counter to find the memory interval offset.
+    size_t count = 0;
+    for (;;) {
+      auto next = std::next(iter);
+      if (next == userangeOccupiedMemoryDist.end())
+        break;
+      // Check interval union.
+      if (next->intervalUnion(*iter)) {
+        iter = userangeOccupiedMemoryDist.erase(iter);
+        continue;
+      }
+
+      // Found a maximal occupied contigous memory segement and check if the
+      // following gap has enough memory to pack the candidate and there exists
+      // no previous suitable gap.
+      if (!foundPreviousGap) {
+        size_t currentGapSize = next->begin - iter->end - 1;
+        if (currentGapSize >= candidate.numAlignedSegments) {
+          foundPreviousGap = true;
+          intervalOffset = count;
+        }
+      }
+      ++count;
+      iter = next;
+    }
+    return foundPreviousGap;
+  }
+
+  /// Inserts an occupied memory interval to the memory distribution and update
+  /// the userange.
+  void packCandidate(PackingInfo &candidate, size_t segment,
+                     DenseSet<Value> &alreadyUnited) {
+
+    alreadyUnited.insert(candidate.alloc);
+    updateMemoryDistribution(candidate, segment);
+    updateOccupiedMemoryIntervals(candidate, segment);
+    std::sort(bufferUserangeIDs.begin(), bufferUserangeIDs.end());
+  }
+
+  /// Update the memory Distribution of all userange IDs of the candidate and
+  /// unit the occupied memory intervals if possible.
+  void updateMemoryDistribution(PackingInfo const &candidate, size_t segment) {
+    // The new occupied memory interval to insert.
+    MemoryInterval addedMemoryInterval =
+        MemoryInterval(segment, segment + candidate.numAlignedSegments - 1);
+
+    // Iterate over the candidate userange to update the memory distribution.
+    for (size_t userangeID : candidate.bufferUserangeIDs) {
+      auto iterUserange = memoryDistribution.find(userangeID);
+
+      // Case found with no memory usage at this userangeID
+      if (iterUserange == memoryDistribution.end()) {
+        memoryDistribution.insert(std::make_pair(
+            userangeID, MemoryIntervalVector{addedMemoryInterval}));
+        bufferUserangeIDs.emplace_back(userangeID);
+        continue;
+      }
+
+      MemoryIntervalVector &memIntervals = iterUserange->second;
+      auto iter = std::find_if(memIntervals.begin(), memIntervals.end(),
+                               [&](MemoryInterval interval) {
+                                 return interval.begin >=
+                                        segment + candidate.numAlignedSegments;
+                               });
+
+      // Check if we must enlarge the first memory interval or insert a new
+      // interval before.
+      if (iter == memIntervals.begin()) {
+        if (iter->begin == segment + candidate.numAlignedSegments)
+          iter->begin = segment;
+        else
+          memIntervals.insert(iter, addedMemoryInterval);
+        continue;
+      }
+      auto prevIter = std::prev(iter);
+
+      // Check if we fit exact.
+      if (iter != memIntervals.end() &&
+          addedMemoryInterval.begin == prevIter->end + 1 &&
+          addedMemoryInterval.end == iter->begin) {
+        prevIter->end = iter->end;
+        memIntervals.erase(iter);
+      }
+      // Check if we must merge us with the left neighbour
+      else if (addedMemoryInterval.begin == prevIter->end + 1) {
+        prevIter->end = addedMemoryInterval.end;
+      }
+      // Check if we must merge us with the right neighbour
+      else if (iter != memIntervals.end() &&
+               addedMemoryInterval.end + 1 == iter->begin) {
+        iter->begin = addedMemoryInterval.begin;
+      }
+      // We must insert the interval.
+      else {
+        memIntervals.insert(iter, addedMemoryInterval);
+      }
+    }
+  }
+
+  /// Compute the beginning of the memory segment to occupie.
+  size_t computeSegment(llvm::Optional<size_t> &intervalOffset,
+                        MemoryIntervalVector &userangeMemoryDist) {
+    size_t segment = 0;
+    if (intervalOffset.hasValue())
+      segment = userangeMemoryDist[intervalOffset.getValue()].end + 1;
+    return segment;
+  }
+
+  /// Compute the packed allocs memory intervals offset and update the map.
+  void updateOccupiedMemoryIntervals(PackingInfo const &candidate,
+                                     size_t segment) {
+    for (auto entry : candidate.occupiedMemoryIntervals) {
+      MemoryInterval currentAllocInterval = entry.second;
+      Value currentAlloc = entry.first;
+      currentAllocInterval.begin += segment;
+      currentAllocInterval.end += segment;
+      occupiedMemoryIntervals.insert(
+          std::make_pair(currentAlloc, currentAllocInterval));
+    }
+  }
+
+  /// Compute a distribution of contiguos memory intervals over the userange of
+  /// the candidate. If we have find a segment with enough contigous memory we
+  /// pack the candidate.
+  void tryPackCandidate(PackingInfo &candidate,
+                        DenseSet<Value> &alreadyUnited) {
+
+    llvm::Optional<size_t> intervalOffset = llvm::None;
+    std::vector<size_t> &userangeToCheck = candidate.bufferUserangeIDs;
+
+    // Initialize the memory distribution over the userange with a dummy
+    // interval.
+    MemoryIntervalVector userangeOccupiedMemoryDist{
+        MemoryInterval(numAlignedSegments, numAlignedSegments)};
+
+    // Iteration over all userange IDs of the candidate to create the
+    // memeorydistribution and find contigous memory segment to pack the
+    // candidate if possible.
+    for (size_t userangeID : userangeToCheck) {
+      auto iterUserange = memoryDistribution.find(userangeID);
+
+      // No memory used at the userangeID
+      if (iterUserange == memoryDistribution.end())
+        continue;
+      MemoryIntervalVector &addIntervals = iterUserange->second;
+
+      // Check if we occupy the first segments of memory.
+      if (!intervalOffset.hasValue())
+        intervalOffset = updateFirstSegmentUsage(
+            userangeOccupiedMemoryDist, *addIntervals.begin(), candidate);
+
+      auto addIntervalIter = findRelevantIntervalsToAdd(
+          userangeOccupiedMemoryDist, addIntervals, intervalOffset);
+
+      userangeOccupiedMemoryDist.insert(userangeOccupiedMemoryDist.end(),
+                                        addIntervalIter, addIntervals.end());
+
+      std::sort(userangeOccupiedMemoryDist.begin(),
+                userangeOccupiedMemoryDist.end(),
+                [&](MemoryInterval a, MemoryInterval b) {
+                  if (a.begin == b.begin)
+                    return a.end > b.end;
+
+                  return a.begin < b.begin;
+                });
+
+      // Check contiguous memory.
+      if (!updateContigousMemoryOffset(intervalOffset,
+                                       userangeOccupiedMemoryDist, candidate))
+        return;
+    }
+    size_t segment = computeSegment(intervalOffset, userangeOccupiedMemoryDist);
+    packCandidate(candidate, segment, alreadyUnited);
+  }
+
+}; // namespace
 
 /// Reuses already allocated buffer to save allocation operations.
 class BufferPacking : BufferPlacementTransformationBase {
@@ -226,11 +381,11 @@ public:
       Value v = std::get<0>(allocEntry);
       PackingInfo info(v, userange);
 
-      auto iter = packInfos.begin();
-      while (iter != packInfos.end() &&
-             iter->numAlignedSegments >= info.numAlignedSegments)
-        ++iter;
-      packInfos.insert(iter, info);
+      auto iterPos = std::find_if(
+          packInfos.begin(), packInfos.end(), [&](PackingInfo pInfo) {
+            return pInfo.numAlignedSegments >= info.numAlignedSegments;
+          });
+      packInfos.insert(iterPos, info);
     }
 
     for (auto &infos : packInfos)
@@ -253,14 +408,14 @@ public:
       }
     }
 
-    DenseMap<Value, size_t> valueOffsets;
+    DenseMap<Value, size_t> occupiedMemoryIntervals;
     size_t totalBufferSize = 0;
 
     for (auto infosIter = packInfos.begin(), e = packInfos.end();
          infosIter != e; ++infosIter) {
-      for (auto &entry : infosIter->valueOffset) {
-        valueOffsets.insert(std::make_pair(
-            entry.first, entry.second.first * 64 + totalBufferSize));
+      for (auto &entry : infosIter->occupiedMemoryIntervals) {
+        occupiedMemoryIntervals.insert(std::make_pair(
+            entry.first, entry.second.begin * 64 + totalBufferSize));
       }
       totalBufferSize += infosIter->numAlignedSegments * 64;
     }
@@ -276,7 +431,7 @@ public:
         packBuilder.create<memref::AllocOp>(packDefOp->getLoc(), memrefType);
 
     // Iterate over all allocs and create a ConstantOp with aligned offset.
-    for (auto &entry : valueOffsets) {
+    for (auto &entry : occupiedMemoryIntervals) {
       Value currentAlloc = entry.first;
       size_t offset = entry.second;
 
@@ -309,10 +464,14 @@ public:
 };
 
 struct BufferPackingPass : public BufferPackingBase<BufferPackingPass> {
-  void runOnFunction() override { BufferPacking packing(getFunction()); }
+  void runOnFunction() override {
+    MLIRContext *context = &getContext();
+    context->getOrLoadDialect("std");
+    BufferPacking packing(getFunction());
+  }
 };
 
-} // end namespace
+} // namespace
 
 std::unique_ptr<FunctionPass> createBufferPackingPass() {
   return std::make_unique<BufferPackingPass>();

--- a/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Transforms/buffer_packing.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "mlir-hlo/Analysis/userange_analysis.h"
 #include "mlir-hlo/Transforms/PassDetail.h"
 #include "mlir-hlo/Transforms/passes.h"
+#include "mlir-hlo/utils/hlo_utils.h"
 #include "mlir/Analysis/BufferViewFlowAnalysis.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -23,42 +24,50 @@ limitations under the License.
 #include "mlir/IR/Operation.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/BufferUtils.h"
+#include <list>
 
 namespace mlir {
 
 namespace {
 
-static size_t computeUserangeSize(const UseInterval &interval);
-
-static size_t computeByteSize(const Value &v);
-
-static size_t computeAlignedSegments(const Value &v);
-
 /// Returns the length of an userange interval.
-static size_t computeUserangeSize(const UseInterval &interval) {
+size_t computeUserangeSize(const UseInterval &interval) {
   return interval.end - interval.start + 1;
 }
 
 /// Compute the byte size of a given Value.
-static size_t computeByteSize(const Value &v) {
-  return v.getType().cast<ShapedType>().getSizeInBits() / 8;
+size_t computeByteSize(const Value &v) {
+  auto type = v.getType().cast<ShapedType>();
+  return type.getSizeInBits() / 8;
 }
 
 /// Compute the 64 byte alinged segments of a given Value.
-static size_t computeAlignedSegments(const Value &v) {
+size_t computeAlignedSegments(const Value &v) {
   size_t padding = 64;
   size_t bytes = computeByteSize(v);
   return std::ceil(bytes / (double)padding);
 }
 
-struct PackedInfo {
+/// The buffer offset information.
+struct AllocBufferOffset {
 public:
-  PackedInfo(Value source, size_t bufferId, size_t offset)
-      : source(source), bufferId(bufferId), offset(offset) {}
+  AllocBufferOffset(Value source, size_t offset)
+      : source(source), offset(offset) {}
 
-  size_t bufferId;
   Value source;
   size_t offset;
+};
+
+/// Contains the information to create a new buffer, that is used to pack
+/// other buffers.
+struct PackedBuffer {
+public:
+  PackedBuffer(size_t numSegments,
+               std::vector<AllocBufferOffset> &packedBuffers)
+      : numSegments(numSegments), allocBufferOffsets(packedBuffers) {}
+
+  size_t numSegments;
+  std::vector<AllocBufferOffset> allocBufferOffsets;
 };
 
 /// Contains the important informations about a buffer allocation.
@@ -95,31 +104,28 @@ public:
   /// The userange intervals of the buffer.
   const UseInterval::Vector *userangeIntervals;
 
-  /// Compute the gas of the alloc userange.
-  std::vector<SizedGap> computeGaps(size_t maxUserangeId = 0) {
-    std::vector<SizedGap> gaps;
-    UseInterval::Vector useranges = *(userangeIntervals);
-    auto useRangeIter = useranges.begin();
+  /// Compute the gaps of the alloc userange. The maxUserangeId is used to add
+  /// a dummy gap from the last used id to the maxUserangeId. By default the
+  /// maxUserangeId is zero and no gap is added.
+  std::list<SizedGap> computeGaps(size_t maxUserangeId = 0) {
+    std::list<SizedGap> gaps;
 
-    // Add a dummy gap in front of the frist use of the buffer.
-    if (useRangeIter->start > 0) {
-      gaps.push_back(
-          std::make_pair(UseInterval(0, useRangeIter->start - 1), numSegments));
-    }
+    // The previous gap ending, initially set to 0.
+    size_t gapEnd = 0;
 
-    // Compute the gap between two userange intervals.
-    for (auto nextUseRangeIter = std::next(useranges.begin());
-         nextUseRangeIter != useranges.end(); ++nextUseRangeIter) {
-      gaps.push_back(std::make_pair(
-          UseInterval(useRangeIter->end + 1, nextUseRangeIter->start - 1),
-          this->numSegments));
-      useRangeIter = nextUseRangeIter;
+    for (auto useRangeIter = userangeIntervals->begin();
+         useRangeIter < userangeIntervals->end(); ++useRangeIter) {
+      // Add a gap if the end is not equal to the start.
+      if (gapEnd < useRangeIter->start)
+        gaps.push_back(std::make_pair(
+            UseInterval(gapEnd, useRangeIter->start - 1), numSegments));
+      gapEnd = useRangeIter->end + 1;
     }
 
     // Add a dummy gap behind the last use of the buffer.
-    if (useRangeIter->end < maxUserangeId) {
-      gaps.push_back(std::make_pair(
-          UseInterval(useRangeIter->end + 1, maxUserangeId), numSegments));
+    if (gapEnd < maxUserangeId) {
+      gaps.push_back(
+          std::make_pair(UseInterval(gapEnd, maxUserangeId), numSegments));
     }
 
     return gaps;
@@ -129,7 +135,7 @@ public:
   size_t getUserangeSize() const { return lastUse - firstUse + 1; }
 };
 
-// Comperator to sort allocation informations by window id, userange and by
+// Comparator to sort allocation informations by window id, userange and by
 // number of memory segments.
 class AllocInfoWinIdCompare {
 public:
@@ -143,7 +149,7 @@ public:
   }
 };
 
-// Comperator to sort the allocation informations by number of segments.
+// Comparator to sort the allocation informations by number of segments.
 class AllocInfoMemSizeCompare {
 public:
   bool operator()(const AllocationInfo &a, const AllocationInfo &b) {
@@ -151,24 +157,27 @@ public:
   }
 };
 
-/// This approach computes an allocation information list and sortes it by
-/// a given comperator. From top to bottom the algortihm tries to fill userange
-/// gaps with appropriate buffers behind it, to optimze the memory.
+/// This approach computes an allocation information list and sorts it by
+/// a given comparator. From top to bottom the algortihm tries to fill userange
+/// gaps with appropriate buffers behind it, to optimze the memory. It is a bin
+/// packing approach.
 template <typename CompareT> class SortedPackingStrategy {
 public:
   using AllocInfoList = std::vector<AllocationInfo>;
   using SizedGap = std::pair<UseInterval, size_t>;
 
 public:
-  /// Constructs the Sorted Packing Strategy.
+  /// Constructs the Sorted Packing Strategy. The window size is used as sliding
+  /// window size. Allocation userangepoitions that are in the same range are
+  /// mapped to the same window id. So the information of the allocation
+  /// starting position is blured.
   SortedPackingStrategy(size_t windowSize, CompareT compare)
       : windowSize(windowSize), compare(compare) {}
 
   /// Optimize the buffer allocations.
   void optimze(const mlir::BufferPlacementAllocs &allocs,
                const UserangeAnalysis &userangeAnalysis,
-               std::vector<PackedInfo> &packingInfos,
-               DenseMap<size_t, size_t> &bufferGen) {
+               std::vector<PackedBuffer> &packedBuffers) {
     AllocInfoList allocInfos;
     allocInfos.reserve(std::distance(allocs.begin(), allocs.end()));
 
@@ -179,21 +188,15 @@ public:
     // Sort the allocation infos.
     std::sort(allocInfos.begin(), allocInfos.end(), compare);
 
-    size_t optMemory = 0;
-    size_t currentOffset = 0;
-    size_t globalBufferOffset = 0;
-
     for (auto currentIter = allocInfos.begin(); currentIter != allocInfos.end();
          ++currentIter) {
-      size_t offsetInBytes = currentOffset * 64;
-      UseInterval::Vector useranges = *(currentIter->userangeIntervals);
+      std::vector<AllocBufferOffset> allocBufferOffsets{
+          AllocBufferOffset(currentIter->alloc, 0)};
 
       // Compute userange gaps.
-      std::vector<std::pair<UseInterval, size_t>> gaps =
+      std::list<std::pair<UseInterval, size_t>> gaps =
           currentIter->computeGaps(maxUserangeId);
 
-      // Add the current buffer to the packing infos.
-      packingInfos.emplace_back(currentIter->alloc, bufferId, offsetInBytes);
       if (gaps.empty())
         continue;
 
@@ -202,49 +205,42 @@ public:
 
         // Check if a gap exists to pack the memory into.
         // If not continue.
-        if (!findGapAndUpdate(gaps, packingInfos, *checkedAllocInfoIter,
-                              *currentIter, offsetInBytes)) {
+        if (!findGapAndUpdate(gaps, allocBufferOffsets, *checkedAllocInfoIter,
+                              *currentIter)) {
           ++checkedAllocInfoIter;
           continue;
         }
-        optMemory += checkedAllocInfoIter->numSegments;
         checkedAllocInfoIter = allocInfos.erase(checkedAllocInfoIter);
       }
-      // Increase the total global memory offset.
-      currentOffset += currentIter->numSegments;
+      // Add the current buffer offets to the packed infos.
+      packedBuffers.emplace_back(currentIter->numSegments * 64,
+                                 allocBufferOffsets);
     }
-
-    size_t totalBufferSize = currentOffset * 64;
-    bufferGen.insert(std::make_pair(bufferId, totalBufferSize));
   }
 
 private:
   const size_t windowSize;
-  const size_t bufferId = 0;
   const CompareT compare;
 
   /// We try to find an appropriate userange gap to pack the buffer into it.
   /// If we find one we update only the gaps and the buffer offset map.
-  bool findGapAndUpdate(std::vector<std::pair<UseInterval, size_t>> &gaps,
-                        std::vector<PackedInfo> &allocBufferOffsets,
-                        AllocationInfo &allocToPack,
-                        AllocationInfo &allocToPackInto,
-                        size_t unitedBufferOffset) {
+  bool findGapAndUpdate(std::list<std::pair<UseInterval, size_t>> &gaps,
+                        std::vector<AllocBufferOffset> &allocBufferOffsets,
+                        const AllocationInfo &allocToPack,
+                        const AllocationInfo &allocToPackInto) {
     // Check if the buffer to pack into has enough memory.
     if (allocToPackInto.numSegments < allocToPack.numSegments)
       return false;
     for (auto gapIter = gaps.begin(); gapIter != gaps.end();) {
-      size_t gapUserangeSize = computeUserangeSize(gapIter->first);
 
-      // If a gap interval has no free contiguous memory anymore, erease it from
-      // list.
-      if (gapIter->second <= 0) {
-        gapIter = gaps.erase(gapIter);
-        continue;
-      }
+      // The list is sorted, so we can break here.
+      if ((gapIter->first.start >= allocToPack.firstUse &&
+           gapIter->first.end < allocToPack.lastUse) ||
+          gapIter->first.start > allocToPack.lastUse)
+        break;
 
-      // Checks if enough the userange and contigous memory segments is
-      // free.
+      // Checks if enough contiguous memory segments are free or if the current
+      // gap is out of bounds.
       if (gapIter->second < allocToPack.numSegments ||
           allocToPack.firstUse < gapIter->first.start ||
           allocToPack.lastUse > gapIter->first.end) {
@@ -254,36 +250,50 @@ private:
 
       // Stores the packed buffer with the offset.
       allocBufferOffsets.emplace_back(
-          allocToPack.alloc, bufferId,
-          unitedBufferOffset +
-              (allocToPackInto.numSegments - gapIter->second) * 64);
-      size_t freeContiguousMemory = gapIter->second;
-      size_t oldStart = gapIter->first.start;
-      size_t oldEnd = gapIter->first.end;
+          allocToPack.alloc,
+          (allocToPackInto.numSegments - gapIter->second) * 64);
 
-      // Update gap
+      // Update gap segments, will removed later if no free contigous memory
+      // exists. It is needed to split the interval, if not the full gap is
+      // used.
+      size_t freeContiguousMemory = gapIter->second;
       gapIter->second = freeContiguousMemory - allocToPack.numSegments;
 
-      // Check if the gap must be splitted.
-      if (gapUserangeSize > allocToPack.getUserangeSize()) {
+      // Check if the gap must be splitted. If so, then the current gap must be
+      // trimmed accordingly. Therefore, new gaps are created in front and after
+      // the current gap.
+      if (computeUserangeSize(gapIter->first) > allocToPack.getUserangeSize()) {
+        size_t oldStart = gapIter->first.start;
+        size_t oldEnd = gapIter->first.end;
         gapIter->first.end = allocToPack.lastUse;
         gapIter->first.start = allocToPack.firstUse;
 
+        // Insert a new gap behind.
         if (allocToPack.lastUse < oldEnd)
-          gaps.push_back(
+          gaps.insert(
+              std::next(gapIter),
               std::make_pair(UseInterval(allocToPack.lastUse + 1, oldEnd),
                              freeContiguousMemory));
+        // Insert a new gap before.
         if (allocToPack.firstUse > oldStart)
-          gaps.push_back(
+          gaps.insert(
+              gapIter,
               std::make_pair(UseInterval(oldStart, allocToPack.firstUse - 1),
                              freeContiguousMemory));
       }
+
+      // If a gap interval has no free contiguous memory anymore, erease it from
+      // list.
+      if (gapIter->second <= 0)
+        gapIter = gaps.erase(gapIter);
+
       return true;
     }
     return false;
   }
 
-  /// Aggreagtes the allocation informations of the allocs.
+  /// Aggreagtes the allocation informations of the allocs and returns the
+  /// maximal userange.
   size_t computeAllocationInfos(AllocInfoList &allocInfos,
                                 const UserangeAnalysis &userangeAnalysis,
                                 const mlir::BufferPlacementAllocs &allocs) {
@@ -313,10 +323,11 @@ private:
                               numSegments, 0, userangeIntervals.getValue());
     }
 
-    // If the window size is zero we are ready.
+    // If the window size is zero we need no sorting anymore.
     if (windowSize == 0)
       return maxUserangeId;
-    // Sorts the allocation informations to compute the window id.
+    // Sorts the allocation informations to compute the window id. The window id
+    // is used to blure the userange starting position of an allocation.
     std::sort(allocInfos.begin(), allocInfos.end(),
               [](const AllocationInfo &a, const AllocationInfo &b) {
                 return a.allocUserangeId < b.allocUserangeId;
@@ -336,7 +347,9 @@ private:
   }
 };
 
-/// Template to reuses already allocated buffer to save allocation operations.
+/// Pass to pack buffer together to optimize the memeory consumption and to
+/// save allocation operations. A strategy must be passed as a template
+/// argument.
 class BufferPacking : BufferPlacementTransformationBase {
 
 public:
@@ -344,54 +357,48 @@ public:
   BufferPacking(Operation *op, StrategyT strategy)
       : BufferPlacementTransformationBase(op),
         userangeAnalysis(op, allocs, aliases), dominators(op) {
-    DenseMap<size_t, size_t> bufferGen;
-    std::vector<PackedInfo> packingInfos;
-    strategy.optimze(allocs, userangeAnalysis, packingInfos, bufferGen);
+    std::vector<PackedBuffer> packedBuffers;
+    strategy.optimze(allocs, userangeAnalysis, packedBuffers);
 
-    DenseMap<size_t, Value> generatedBuffers;
-
-    // Find common dominators.
-    Block *block = findAllocationsDominator(packingInfos);
-    // Find alloc position operation.
-    mlir::OpBuilder packBuilder(&(block->front()));
-    auto location = block->front().getLoc();
-
-    // Create the packed AllocOps.
-    for (auto &entry : bufferGen) {
-      auto memrefType =
-          MemRefType::get({entry.second}, packBuilder.getIntegerType(8));
-      Value packedAlloc =
+    for (auto &packedBuffer : packedBuffers) {
+      // Find common dominators.
+      Block *block = findAllocationsDominator(packedBuffer.allocBufferOffsets);
+      // Find alloc position operation.
+      mlir::OpBuilder packBuilder(&(block->front()));
+      auto location = block->front().getLoc();
+      auto memrefType = MemRefType::get({packedBuffer.numSegments},
+                                        packBuilder.getIntegerType(8));
+      Value targetBuffer =
           packBuilder.create<memref::AllocOp>(location, memrefType);
-      generatedBuffers.insert(std::make_pair(entry.first, packedAlloc));
-    }
 
-    for (auto &packInfo : packingInfos) {
-      Value currentAlloc = packInfo.source;
-      Value targetBuffer = generatedBuffers[packInfo.bufferId];
-      size_t offset = packInfo.offset;
-      Operation *viewDefOp = currentAlloc.getDefiningOp();
-      Location loc = viewDefOp->getLoc();
-      mlir::OpBuilder viewBuilder(viewDefOp);
+      for (auto &packInfo : packedBuffer.allocBufferOffsets) {
+        Value currentAlloc = packInfo.source;
+        size_t offset = packInfo.offset;
+        Operation *viewDefOp = currentAlloc.getDefiningOp();
+        Location loc = viewDefOp->getLoc();
+        mlir::OpBuilder viewBuilder(viewDefOp);
 
-      // Create a ConstantOp with the aligned offset.
-      Value constantOp = viewBuilder.create<mlir::ConstantOp>(
-          loc, viewBuilder.getIndexType(),
-          viewBuilder.getIntegerAttr(viewBuilder.getIndexType(), offset));
+        // Create a ConstantOp with the aligned offset.
+        Value constantOp = viewBuilder.create<mlir::ConstantOp>(
+            loc, viewBuilder.getIndexType(),
+            viewBuilder.getIntegerAttr(viewBuilder.getIndexType(), offset));
 
-      // Store the operands for the ViewOp.
-      SmallVector<Value, 4> newOperands{targetBuffer};
-      newOperands.push_back(constantOp);
-      ShapedType shape = currentAlloc.getType().cast<ShapedType>();
+        // Store the operands for the ViewOp.
+        SmallVector<Value, 4> newOperands{targetBuffer};
+        newOperands.push_back(constantOp);
 
-      // Create a ViewOp with the shape of the old alloc and use the created
-      // packed alloc and the constant for the operands.
-      Value viewOp = viewBuilder.create<memref::ViewOp>(
-          loc, shape.cast<MemRefType>(), newOperands);
+        ShapedType shape = currentAlloc.getType().cast<ShapedType>();
 
-      // Replace all old allocs references with the created ViewOp and
-      // afterwards remove the old allocs.
-      currentAlloc.replaceAllUsesWith(viewOp);
-      viewDefOp->erase();
+        // Create a ViewOp with the shape of the old alloc and use the created
+        // packed alloc and the constant for the operands.
+        Value viewOp = viewBuilder.create<memref::ViewOp>(
+            loc, shape.cast<MemRefType>(), newOperands);
+
+        // Replace all old allocs references with the created ViewOp and
+        // afterwards remove the old allocs.
+        currentAlloc.replaceAllUsesWith(viewOp);
+        viewDefOp->erase();
+      }
     }
   }
 
@@ -401,7 +408,8 @@ private:
   DominanceInfo dominators;
 
   /// Find the block that dominates all buffer allocations.
-  Block *findAllocationsDominator(const std::vector<PackedInfo> &packingInfos) {
+  Block *
+  findAllocationsDominator(const std::vector<AllocBufferOffset> &packingInfos) {
     SmallPtrSet<Value, 16> allocValues;
     for (auto &packInfo : packingInfos) {
       allocValues.insert(packInfo.source);
@@ -413,32 +421,10 @@ private:
   }
 };
 
-/// Reuses already allocated buffer to save allocation operations.
-class MemoryCount : BufferPlacementTransformationBase {
-public:
-  using AllocList = std::vector<Value>;
-
-public:
-  MemoryCount(Operation *op) : BufferPlacementTransformationBase(op) {
-    // Map that stores the allocs to their respective shape.
-    DenseMap<Type, AllocList> shapeMap;
-
-    // Padding in Byte
-    const size_t padding = 64;
-    size_t totalSize = 0;
-
-    // Iterate over all allocs and fill the shapeMap accordingly.
-    for (const BufferPlacementAllocs::AllocEntry &entry : allocs) {
-      Value alloc = std::get<0>(entry);
-      auto shape = alloc.getType().cast<ShapedType>();
-      size_t shapeBytes = shape.getSizeInBits() / 8;
-      size_t alignFactor = llvm::divideCeil(shapeBytes, padding);
-      size_t size = alignFactor * padding;
-      totalSize += size;
-    }
-  }
-};
-
+/// Tries to pack allocated buffer together to save allocation operations and
+/// memory. The window size is used as sliding window size. Allocation
+/// userangepoitions that are in the same range are mapped to the same window
+/// id. The information of the allocation starting position is blured.
 struct BufferPackingPass : public BufferPackingBase<BufferPackingPass> {
   explicit BufferPackingPass(unsigned windowSize) {
     this->window_size_ = windowSize;
@@ -459,8 +445,36 @@ struct BufferPackingPass : public BufferPackingBase<BufferPackingPass> {
   }
 };
 
+/// Pass to find all allocations and to compute memory usage.
 struct MemoryCountPass : MemoryCountBase<MemoryCountPass> {
-  void runOnFunction() override { MemoryCount counter(getFunction()); }
+  void runOnFunction() override {
+    Operation *op = getFunction();
+    std::vector<Value> allocs;
+    op->walk([&](MemoryEffectOpInterface opInterface) {
+      // Try to find a single allocation result.
+      SmallVector<MemoryEffects::EffectInstance, 2> effects;
+      opInterface.getEffects(effects);
+
+      SmallVector<MemoryEffects::EffectInstance, 2> allocateResultEffects;
+      llvm::copy_if(
+          effects, std::back_inserter(allocateResultEffects),
+          [=](MemoryEffects::EffectInstance &it) {
+            Value value = it.getValue();
+            return isa<MemoryEffects::Allocate>(it.getEffect()) && value &&
+                   value.isa<OpResult>() &&
+                   it.getResource() !=
+                       SideEffects::AutomaticAllocationScopeResource::get();
+          });
+
+      if (allocateResultEffects.size() != 1)
+        return;
+      // Insert allocation.
+      allocs.push_back(allocateResultEffects[0].getValue());
+    });
+    auto output = mlir::hlo::computeMemory(allocs);
+    llvm::outs() << "Memory Count Pass:\n"
+                 << output.first << ";" << output.second << "\n";
+  }
 };
 
 } // namespace

--- a/tensorflow/compiler/mlir/hlo/lib/utils/hlo_utils.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/utils/hlo_utils.cc
@@ -22,6 +22,8 @@ limitations under the License.
 namespace mlir {
 namespace hlo {
 
+const size_t sixtyFourBytePadding= 64;
+
 DenseIntElementsAttr getBroadcastDimensionsAttr(Builder* b, Value x, Value y,
                                                 bool allow_empty) {
   TensorType xType = x.getType().dyn_cast<RankedTensorType>();
@@ -165,15 +167,13 @@ int64_t getArgumentIndex(mlir::FuncOp op, Value value) {
 
 /// Computes the memory usage of the given allocations.
 std::pair<size_t, size_t> computeMemory(const std::vector<Value> &allocs){
-  // Padding in Byte
-  const size_t padding = 64;
   size_t totalSize = 0;
   size_t allocCounter = 0;
   for (const Value alloc : allocs) {
     auto shape = alloc.getType().cast<ShapedType>();
     size_t shapeBytes = llvm::divideCeil(shape.getSizeInBits(), 8);
-    size_t alignFactor = llvm::divideCeil(shapeBytes, padding);
-    size_t size = alignFactor * padding;
+    size_t alignFactor = llvm::divideCeil(shapeBytes, sixtyFourBytePadding);
+    size_t size = alignFactor * sixtyFourBytePadding;
     totalSize += size;
     allocCounter++;
   }

--- a/tensorflow/compiler/mlir/hlo/lib/utils/hlo_utils.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/utils/hlo_utils.cc
@@ -163,5 +163,22 @@ int64_t getArgumentIndex(mlir::FuncOp op, Value value) {
   return arg.getArgNumber();
 }
 
+/// Computes the memory usage of the given allocations.
+std::pair<size_t, size_t> computeMemory(const std::vector<Value> &allocs){
+  // Padding in Byte
+  const size_t padding = 64;
+  size_t totalSize = 0;
+  size_t allocCounter = 0;
+  for (const Value alloc : allocs) {
+    auto shape = alloc.getType().cast<ShapedType>();
+    size_t shapeBytes = llvm::divideCeil(shape.getSizeInBits(), 8);
+    size_t alignFactor = llvm::divideCeil(shapeBytes, padding);
+    size_t size = alignFactor * padding;
+    totalSize += size;
+    allocCounter++;
+  }
+  return std::make_pair(totalSize, allocCounter);
+}
+
 }  // namespace hlo
 }  // namespace mlir

--- a/tensorflow/compiler/mlir/hlo/lib/utils/hlo_utils.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/utils/hlo_utils.cc
@@ -22,7 +22,7 @@ limitations under the License.
 namespace mlir {
 namespace hlo {
 
-const size_t sixtyFourBytePadding= 64;
+static constexpr size_t kPaddingSize= 64;
 
 DenseIntElementsAttr getBroadcastDimensionsAttr(Builder* b, Value x, Value y,
                                                 bool allow_empty) {
@@ -172,8 +172,8 @@ std::pair<size_t, size_t> computeMemory(const std::vector<Value> &allocs){
   for (const Value alloc : allocs) {
     auto shape = alloc.getType().cast<ShapedType>();
     size_t shapeBytes = llvm::divideCeil(shape.getSizeInBits(), 8);
-    size_t alignFactor = llvm::divideCeil(shapeBytes, sixtyFourBytePadding);
-    size_t size = alignFactor * sixtyFourBytePadding;
+    size_t alignFactor = llvm::divideCeil(shapeBytes, kPaddingSize);
+    size_t size = alignFactor * kPaddingSize;
     totalSize += size;
     allocCounter++;
   }

--- a/tensorflow/compiler/mlir/xla/transforms/mhlo_to_lhlo_with_xla.h
+++ b/tensorflow/compiler/mlir/xla/transforms/mhlo_to_lhlo_with_xla.h
@@ -227,6 +227,8 @@ class LhloDialectEmitter : public xla::ConstDfsHloVisitorWithDefault {
   // allocations (see below).
   llvm::DenseMap<const xla::BufferAllocation*, Value> allocations_;
 
+  llvm::DenseMap<const xla::BufferAllocation*, Value> customAllocations_;
+
   // This map provides access to MLIR buffers for each HLO instruction, keyed
   // instruction identity. A slice is contained in a BufferAllocation, and has
   // an offset and a size.


### PR DESCRIPTION
**This code is only experimental and should never be used in production!**

It could be use to dump a JAX generated mlir module with xla.

1. Steps: Donwload JAX on github git clone https://github.com/google/jax.
2. Find the Workspace file. Switch to a local tensorflow with this modified mhlo_to_lhlo_with_xla pass.
3. Pick a name of a mlir module and change the string in the modified mhlo_to_lhlo_with_xla.cc.

> - If you do not know the module names dump all modules with the command of step 5.

4. Build JAX with  (see [how to build Jax](https://jax.readthedocs.io/en/latest/developer.html) ) 

> - python build/build.py --enable cuda
> - pip install dist/*.whl --force-reinstall 

5. Use this command to generate mlir modues:
> - XLA_FLAGS="--xla_dump_to=folder/to/dump" python3 ./examples/your_example.py
6. JAX will through a exception but the picked module will be dumped with natural allocs.