### PR TITLE
Use actual number of classes for output layer

### DIFF
--- a/tensorflow/lite/g3doc/tutorials/pose_classification.ipynb
+++ b/tensorflow/lite/g3doc/tutorials/pose_classification.ipynb
@@ -1015,7 +1015,7 @@
         "layer = keras.layers.Dropout(0.5)(layer)\n",
         "layer = keras.layers.Dense(64, activation=tf.nn.relu6)(layer)\n",
         "layer = keras.layers.Dropout(0.5)(layer)\n",
-        "outputs = keras.layers.Dense(5, activation=\"softmax\")(layer)\n",
+        "outputs = keras.layers.Dense(len(class_names), activation=\"softmax\")(layer)\n",
         "\n",
         "model = keras.Model(inputs, outputs)\n",
         "model.summary()"


### PR DESCRIPTION
The problem is that in the yoga example's training data there are 5 classes but when using any other amount of classes as training data the training fails. Set the output layer to the actual number of classes instead.

Without this fix, a ValueError is raised (e.g. `ValueError: Shapes (None, 7) and (None, 5) are incompatible`).