### PR TITLE
Integrating cuBLASLt

### DIFF
--- a/tensorflow/compiler/xla/xla.proto
+++ b/tensorflow/compiler/xla/xla.proto
@@ -274,6 +274,9 @@ message DebugOptions {
   // GZip-compress protos dumped via --xla_dump_hlo_as_proto.
   bool xla_dump_compress_protos = 151;
 
+  // Dump HLO in long text format. Ignored unless xla_dump_hlo_as_text is true.
+  bool xla_dump_hlo_as_long_text = 164;
+
   //
   // END flags controlling dumping HLO modules.
   //
@@ -366,10 +369,21 @@ message DebugOptions {
   // This flag has no effect when xla_gpu_bef_executable is true.
   bool xla_gpu_bef_thunk = 162;
 
-  // Whether to use cuBLASLt for GEMMs on GPUs.
-  bool xla_gpu_enable_cublaslt = 163;
+  // Timeout in seconds before terminating jobs that are stuck in a NCCL
+  // Rendezvous. Negative value disables the timeout and will not terminate.
+  int64 xla_gpu_nccl_termination_timeout_seconds = 163;
 
-  // Next id: 164
+  // Enables shared constants for XLA/GPU. This allows large constants to be
+  // shared among multiple GPU executables.
+  bool xla_gpu_enable_shared_constants = 165;
+
+  // Whether to use cuBLASLt for GEMMs on GPUs.
+  bool xla_gpu_enable_cublaslt = 166;
+
+  // Size threshold (in megabytes) for the GPU redzone scratch allocator.
+  int64 xla_gpu_redzone_scratch_max_megabytes = 167;
+
+  // Next id: 168
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.
@@ -428,6 +442,9 @@ message ExecutionOptions {
   // Indicates whether to use SPMD (true) or MPMD (false) partitioning when
   // num_partitions > 1 and XLA is requested to partition the input program.
   bool use_spmd_partitioning = 11;
+
+  // Whether to automatically generate XLA shardings for SPMD partitioner.
+  bool use_auto_spmd_partitioning = 15;
 
   // If set, deduplicate hlo into function calls to reduce binary size. Only
   // works on TPU.

--- a/tensorflow/stream_executor/matmul_util.cc
+++ b/tensorflow/stream_executor/matmul_util.cc
@@ -12,6 +12,7 @@ limitations under the License.
 
 #include "tensorflow/stream_executor/matmul_util.h"
 
+#include "tensorflow/core/util/env_var.h"
 
 namespace stream_executor {
 

--- a/tensorflow/stream_executor/matmul_util.h
+++ b/tensorflow/stream_executor/matmul_util.h
@@ -14,6 +14,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/platform/stream_executor.h"


### PR DESCRIPTION
Adds support for the cuBLASLt library for GEMM operations on GPUs.

The library can be activated by setting the environment variable `TF_USE_CUBLASLT=1`.