### PR TITLE
[bazel] Remove rules_cc dependency

### DIFF
--- a/tensorflow/core/platform/default/rules_cc.bzl
+++ b/tensorflow/core/platform/default/rules_cc.bzl
@@ -1,19 +1,6 @@
 """This forwards all of rules_cc's relevant rules under a common file"""
 
-load(
-    "@rules_cc//cc:defs.bzl",
-    _cc_binary = "cc_binary",
-    _cc_import = "cc_import",
-    _cc_library = "cc_library",
-    _cc_test = "cc_test",
-)
-load(
-    "@rules_cc//examples:experimental_cc_shared_library.bzl",
-    _cc_shared_library = "cc_shared_library",
-)
-
-cc_binary = _cc_binary
-cc_import = _cc_import
-cc_library = _cc_library
-cc_shared_library = _cc_shared_library
-cc_test = _cc_test
+cc_binary = native.cc_binary
+cc_import = native.cc_import
+cc_library = native.cc_library
+cc_test = native.cc_test

--- a/tensorflow/core/platform/rules_cc.bzl
+++ b/tensorflow/core/platform/rules_cc.bzl
@@ -5,12 +5,10 @@ load(
     _cc_binary = "cc_binary",
     _cc_import = "cc_import",
     _cc_library = "cc_library",
-    _cc_shared_library = "cc_shared_library",
     _cc_test = "cc_test",
 )
 
 cc_binary = _cc_binary
 cc_import = _cc_import
 cc_library = _cc_library
-cc_shared_library = _cc_shared_library
 cc_test = _cc_test

--- a/tensorflow/workspace0.bzl
+++ b/tensorflow/workspace0.bzl
@@ -6,7 +6,6 @@ load("@bazel_toolchains//repositories:repositories.bzl", bazel_toolchains_reposi
 load("@build_bazel_rules_swift//swift:repositories.bzl", "swift_rules_dependencies")
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 load("@local_config_android//:android.bzl", "android_workspace")
-load("@rules_cc//cc:repositories.bzl", "rules_cc_toolchains")
 
 def _tf_bind():
     """Bind targets for some external repositories"""
@@ -102,8 +101,6 @@ def workspace():
             "https://storage.googleapis.com/download.tensorflow.org/data/tf_lite_micro_person_data_grayscale_2020_05_24.zip",
         ],
     )
-
-    rules_cc_toolchains()
 
     bazel_toolchains_repositories()
 

--- a/third_party/flatbuffers/flatbuffers.BUILD
+++ b/third_party/flatbuffers/flatbuffers.BUILD
@@ -19,8 +19,6 @@ config_setting(
     values = {"cpu": "x64_windows"},
 )
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
-
 # Public flatc library to compile flatbuffer files at runtime.
 cc_library(
     name = "flatbuffers",

--- a/third_party/googleapis/build_rules.bzl
+++ b/third_party/googleapis/build_rules.bzl
@@ -16,7 +16,6 @@
 Utilities for building grpc and proto libraries from googleapis.
 """
 
-load("@rules_cc//cc:defs.bzl", native_cc_proto_library = "cc_proto_library")
 load("@com_github_grpc_grpc//bazel:generate_cc.bzl", "generate_cc")
 
 def _tf_cc_headers(ctx):
@@ -45,7 +44,7 @@ def cc_proto_library(name, deps):
       name: the name of the cc_library
       deps: a list that contains exactly one proto_library
     """
-    native_cc_proto_library(
+    native.cc_proto_library(
         name = name,
         deps = deps,
         visibility = ["//visibility:public"],


### PR DESCRIPTION
This public repository is seemingly dead as far as using it as a
replacement cc toolchain. Because of this, and tensorflow's use of some
files under @bazel_tools, this can lead to incompatibilities https://github.com/bazelbuild/bazel/pull/13449#issuecomment-994882040

Since this repo isn't active, and doesn't provide anything over the
default bazel infra that tf needs, we can just drop it.