### PR TITLE
Update tensorflow-io-gcs-filesystem to 0.23.1

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -93,7 +93,7 @@ REQUIRED_PACKAGES = [
     'tensorboard >= 2.7, < 2.8',
     'tensorflow_estimator >= 2.7.0, < 2.8',
     'keras >= 2.7.0, < 2.8',
-    'tensorflow-io-gcs-filesystem >= 0.23.0',
+    'tensorflow-io-gcs-filesystem >= 0.23.1',
 ]
 
 


### PR DESCRIPTION
This PR updates tensorflow-io-gcs-filesystem to 0.23.1,
see https://github.com/tensorflow/io/issues/1591

This PR fixes https://github.com/tensorflow/io/issues/1591

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>