### PR TITLE
Fix typo in `trt_engine_op_shape_test.py`

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
@@ -52,7 +52,7 @@ class TRTEngineOpInputOutputShapeTest(trt_test.TfTrtIntegrationTestBase):
                                 self)._GetInferGraph(*args, **kwargs)
 
     def get_func_from_saved_model(saved_model_dir):
-      saved_model_loaded = saved_model.load.load(
+      saved_model_loaded = saved_model.load(
           saved_model_dir, tags=[tag_constants.SERVING])
       graph_func = saved_model_loaded.signatures[
           signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY]


### PR DESCRIPTION
This PR fixes a small typo introduced in #53327 that prevented the test from being run.

@DEKHTIARJonathan 