### PR TITLE
Support for external delegate in label_image.py python example

### DIFF
--- a/tensorflow/lite/examples/python/label_image.py
+++ b/tensorflow/lite/examples/python/label_image.py
@@ -54,10 +54,42 @@ if __name__ == '__main__':
       help='input standard deviation')
   parser.add_argument(
       '--num_threads', default=None, type=int, help='number of threads')
+  parser.add_argument(
+      '-e',
+      '--ext_delegate',
+      help='external_delegate_library path')
+  parser.add_argument(
+      '-o',
+      '--ext_delegate_options',
+      help='external delegate options, \
+            format: "option1: value1; option2: value2"')
+
   args = parser.parse_args()
 
+  ext_delegate = None
+  ext_delegate_options = {}
+
+  # parse extenal delegate options
+  if args.ext_delegate_options is not None:
+    options = args.ext_delegate_options.split(';')
+    for o in options:
+      kv = o.split(':')
+      if(len(kv) == 2):
+        ext_delegate_options[kv[0].strip()] = kv[1].strip()
+      else:
+        raise RuntimeError("Error parsing delegate option: " + o)
+
+  # load external delegate
+  if args.ext_delegate is not None:
+    print("Loading external delegate from {} with args: {}".format(
+             args.ext_delegate, ext_delegate_options))
+    ext_delegate = [ tflite.load_delegate(args.ext_delegate,
+                                          ext_delegate_options) ]
+
   interpreter = tf.lite.Interpreter(
-      model_path=args.model_file, num_threads=args.num_threads)
+        model_path=args.model_file,
+                   experimental_delegates=ext_delegate,
+                   num_threads=args.num_threads)
   interpreter.allocate_tensors()
 
   input_details = interpreter.get_input_details()


### PR DESCRIPTION
The PR adds 2 command line arguments to label_image.py python example to load and use an external delegate. The behavior is similar to one provided by external delegate Registrar (class `ExternalDelegateProvider` in  [tensorflow/lite/tools/delegates/external_delegate_provider.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/tools/delegates/external_delegate_provider.cc))