### PR TITLE
Improve `saved_model.load.get_config`

### DIFF
--- a/tensorflow/python/keras/saving/saved_model/load.py
+++ b/tensorflow/python/keras/saving/saved_model/load.py
@@ -1029,10 +1029,14 @@ class RevivedLayer(object):
     return self._serialized_attributes.get(constants.KERAS_ATTR, None)
 
   def get_config(self):
-    if hasattr(self, '_config'):
+    try:
       return self._config
-    else:
-      raise NotImplementedError
+    except AttributeError as e:
+      raise NotImplementedError("`_config` not found on layer. "
+                                "For custom layers, make sure you override "
+                                "`self.get_config()` and that your custom class "
+                                "is registered. Find more information in "
+                                "https://keras.io/guides/serialization_and_saving/ ", e)
 
 
 def _revive_setter(layer, name, value):

--- a/tensorflow/python/keras/saving/saved_model/load.py
+++ b/tensorflow/python/keras/saving/saved_model/load.py
@@ -1032,11 +1032,12 @@ class RevivedLayer(object):
     try:
       return self._config
     except AttributeError as e:
-      raise NotImplementedError("`_config` not found on layer. "
-                                "For custom layers, make sure you override "
-                                "`self.get_config()` and that your custom class "
-                                "is registered. Find more information in "
-                                "https://keras.io/guides/serialization_and_saving/ ", e)
+      raise NotImplementedError(
+        "`_config` not found on layer. "
+        "For custom layers, make sure you override "
+        "`self.get_config()` and that your custom class "
+        "is registered. Find more information in "
+        "https://keras.io/guides/serialization_and_saving/ ") from e
 
 
 def _revive_setter(layer, name, value):


### PR DESCRIPTION
This PR makes two minor, nonfunctional improvements to the `saved_model.load.get_config` function:

1. **it’s easier to ask for forgiveness than permission:**  
Idiomatic python: It's better to catch the exception of the exceptional case, rather than checking if the attribute exists beforehand. [more on this](https://devblogs.microsoft.com/python/idiomatic-python-eafp-versus-lbyl/)
2.  **Error description:** 
The NotImplementedError now describes two likely root causes of the problem.