### PR TITLE
[Go] Return correct backing device name for TensorHandle

### DIFF
--- a/tensorflow/go/tensor_handle.go
+++ b/tensorflow/go/tensor_handle.go
@@ -20,6 +20,7 @@ package tensorflow
 // #include "tensorflow/c/c_api.h"
 // #include "tensorflow/c/eager/c_api.h"
 import "C"
+
 import (
 	"runtime"
 	"unsafe"
@@ -120,25 +121,16 @@ func (th *TensorHandle) DeviceName() (string, error) {
 	return C.GoString(name), nil
 }
 
-// BackingDeviceName returns the name of the device in whose memory the tensor
-// handle resides. This function will block till the operation that produces
-// `h` has completed.
-//
-// WARNING: The implementation currently returns the same as DeviceName().
-// After TensoFlow 1.13's C library is released, this implementation will
-// be updated to return what the documentation says!
+// BackingDeviceName returns the name of the device in whose memory tensor
+// handle th resides. This function will block till the operation that produces
+// th has completed.
 func (th *TensorHandle) BackingDeviceName() (string, error) {
-	// TODO(ashankar): Restore after TensorFlow 1.13 is released.
-	// See https://github.com/tensorflow/tensorflow/issues/23257#issuecomment-433751410
-	return th.DeviceName()
-	/*
 	status := newStatus()
 	name := C.TFE_TensorHandleBackingDeviceName(th.c, status.c)
 	if err := status.Err(); err != nil {
 		return "", err
 	}
 	return C.GoString(name), nil
-	*/
 }
 
 // ToTensor returns the Tensor referenced by th. It may block if this tensor is


### PR DESCRIPTION
In Go, `th.BackingDeviceName` currently returns `TFE_TensorHandleDeviceName`, which may differ from the backing device.