### PR TITLE
[oneDNN] Keras LayerNormalization fusion with oneDNN CPU backend

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -683,6 +683,7 @@ cc_library(
         "//tensorflow/core/kernels/mkl:mkl_fused_batch_norm_op",
         "//tensorflow/core/kernels/mkl:mkl_identity_op",
         "//tensorflow/core/kernels/mkl:mkl_input_conversion_op",
+        "//tensorflow/core/kernels/mkl:mkl_layer_norm_op",
         "//tensorflow/core/kernels/mkl:mkl_lrn_op",
         "//tensorflow/core/kernels/mkl:mkl_pooling_ops",
         "//tensorflow/core/kernels/mkl:mkl_qmatmul_op",

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -1138,6 +1138,145 @@ bool FindSigmoidAndMul(RemapperContext* ctx, int node_index,
   return found_op_type_match;
 }
 
+// Keras LayerNormalization api uses multiple TensorFlow ops. Current fusion
+// pattern is only for the case, when LayerNormalization uses FusedBatcNormV3.
+// We further restrict it to only 2D or 3D tensor inputs to keras
+// LayerNormalization api.
+bool FindMklLayerNorm(RemapperContext* ctx, int node_index,
+                      std::map<string, int>* matched_nodes_map,
+                      std::set<int>* remove_node_indices) {
+  if (!IsMKLEnabled()) return false;
+
+  // The following pattern will be searched in the graph with additional
+  // contraints. Here * means any type of op.
+  // clang-format off
+  //              Subgraph for fusion
+  //              -------------------
+  //
+  //     *(input)  *  * Const  *  Const                       FusedOp
+  //          \    |   \  |    |  /        Const              -------
+  //           \   |    \ |    | /  Const   /
+  //           Reshape  Fill   Fill  /     /         *(input) *(gamma)  *(beta)
+  //              \      /      /   /     /                \     |      /
+  //               \    /      /   /     /                  \    |     /
+  //          F u s e d B a t c h N o r m V 3              _MklLayerNorm
+  //                 \
+  //                  \   *
+  //                   \ /
+  //                 Reshape
+  //                    \   *(gamma)
+  //                     \ /
+  //                     Mul
+  //             *(beta) /
+  //                \   /
+  //                AddV2(output)
+  // clang-format on
+  using utils::MatchingDirection;
+  using utils::NodeStatus;
+  // clang-format off
+  utils::OpTypePattern layer_norm_pattern =
+    {"AddV2", "output", NodeStatus::kReplace,
+      {
+        {"*", "beta", NodeStatus::kRemain},
+        {"Mul", "scale", NodeStatus::kRemove,
+          {
+            {"Reshape", "post_reshape", NodeStatus::kRemove,
+              {
+                {"FusedBatchNormV3", "fused_batch_norm", NodeStatus::kRemove,
+                  {
+                    {"Reshape", "pre_reshape", NodeStatus::kRemove,
+                      {
+                        {"*", "input", NodeStatus::kRemain},
+                        {"*", "pre_shape", NodeStatus::kRemain}
+                      }
+                    },
+                    {"Fill", "fill_scale", NodeStatus::kRemove,
+                      {
+                        {"*", "dims_fill_scale", NodeStatus::kRemain},
+                        {"Const", "unit_gamma", NodeStatus::kRemain}
+                      }
+                    },
+                    {"Fill", "fill_offset", NodeStatus::kRemove,
+                      {
+                        {"*", "dims_fill_offset", NodeStatus::kRemain},
+                        {"Const", "zero_beta", NodeStatus::kRemain}
+                      }
+                    },
+                    {"Const", "empty", NodeStatus::kRemain},
+                    {"Const", "empty", NodeStatus::kRemain}
+                  }
+                },
+                {"*", "post_shape", NodeStatus::kRemain}
+              }
+            },
+            {"*", "gamma", NodeStatus::kRemain}
+          }
+        }
+      }
+    };  // clang-format on
+
+  utils::SubGraphMatcher<MatchingDirection::kFollowInputs> graph_matcher(
+      &(ctx->graph_view));
+  bool found_op_type_match = false;
+  matched_nodes_map->clear();
+  remove_node_indices->clear();
+  found_op_type_match =
+      graph_matcher.GetMatchedNodes(layer_norm_pattern, ctx->nodes_to_preserve,
+                                    ctx->graph_view.GetNode(node_index),
+                                    matched_nodes_map, remove_node_indices);
+
+  // Additional check for LayerNorm
+  if (found_op_type_match) {
+    // LayerNorm uses FusedBatchNorm in training mode.
+    NodeDef* fused_batch_norm_node =
+        ctx->graph_view.GetNode(matched_nodes_map->at("fused_batch_norm"))
+            ->node();
+    bool is_training = false;
+    if (!TryGetNodeAttr(*fused_batch_norm_node, kIsTraining, &is_training) ||
+        !is_training)
+      return false;
+
+    // FusedBatchNorm node should have mean/variance as empty constant
+    NodeDef* empty_const_node =
+        ctx->graph_view.GetNode(matched_nodes_map->at("empty"))->node();
+    Tensor const_tensor;
+    if (empty_const_node != nullptr && empty_const_node->op() == "Const" &&
+        const_tensor.FromProto(empty_const_node->attr().at("value").tensor())) {
+      if (const_tensor.NumElements() != 0) return false;
+    } else {
+      return false;
+    }
+
+    // TODO(intel-tf): Relax the restriction of 2D/3D tensor once kernel
+    // supports that.
+    if (!ctx->inferred_graph_properties) {
+      Status s = ctx->graph_properties.InferStatically(
+          /*assume_valid_feeds=*/true,
+          /*aggressive_shape_inference=*/false,
+          /*include_input_tensor_values=*/true,
+          /*include_output_tensor_values=*/false);
+      if (!s.ok()) return false;
+      ctx->inferred_graph_properties = true;
+    }
+    NodeDef* input_node_def =
+        ctx->graph_view.GetNode(matched_nodes_map->at("input"))->node();
+    auto input_props =
+        ctx->graph_properties.GetOutputProperties(input_node_def->name());
+    NodeDef* output_node_def =
+        ctx->graph_view.GetNode(matched_nodes_map->at("output"))->node();
+    auto output_props =
+        ctx->graph_properties.GetOutputProperties(output_node_def->name());
+    if (ShapesSymbolicallyEqual(input_props[0].shape(),
+                                output_props[0].shape())) {
+      int rank = Rank(input_props[0].shape());
+      if (rank < 2 || rank > 3) return false;
+    } else {
+      return false;
+    }
+  }
+  return found_op_type_match;
+}
+
 bool FindFusedBatchNorm(const RemapperContext& ctx, int node_index,
                         FusedBatchNorm* matched) {
   const auto* node_view = ctx.graph_view.GetNode(node_index);
@@ -2136,6 +2275,42 @@ Status AddFusedMatMulBiasAddAndGelu(
   return Status::OK();
 }
 
+Status AddMklLayerNorm(RemapperContext* ctx,
+                       const std::map<string, int>& matched_nodes_map,
+                       const std::set<int>& remove_node_indices,
+                       std::vector<bool>* invalidated_nodes,
+                       std::vector<bool>* nodes_to_delete) {
+  auto* pre_reshape_node =
+      ctx->graph_view.GetNode(matched_nodes_map.at("pre_reshape"))->node();
+  auto* scale_node =
+      ctx->graph_view.GetNode(matched_nodes_map.at("gamma"))->node();
+  auto* output_node =
+      ctx->graph_view.GetNode(matched_nodes_map.at("output"))->node();
+
+  NodeDef fused_node;
+  fused_node.set_name(output_node->name());
+  fused_node.set_op("_MklLayerNorm");
+  fused_node.set_device(output_node->device());
+  fused_node.add_input(pre_reshape_node->input(0));
+  fused_node.add_input(scale_node->name());
+  fused_node.add_input(output_node->input(0));
+  auto* attr = fused_node.mutable_attr();
+  auto& src_attr = output_node->attr();
+  (*attr)["T"] = src_attr.at("T");
+
+  utils::Mutation* mutation = ctx->graph_view.GetMutationBuilder();
+  Status status;
+  mutation->AddNode(std::move(fused_node), &status);
+  TF_RETURN_IF_ERROR(status);
+  TF_RETURN_IF_ERROR(mutation->Apply());
+  (*invalidated_nodes)[matched_nodes_map.at("output")] = true;
+
+  for (const auto& node_idx : remove_node_indices) {
+    (*nodes_to_delete)[node_idx] = true;
+  }
+  return Status::OK();
+}
+
 Status ReplaceSigmoidMulWithSwish(
     RemapperContext* ctx, const std::map<string, int>& matched_nodes_map,
     const std::set<int>& remove_node_indices,
@@ -2822,6 +2997,16 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
         TF_RETURN_IF_ERROR(ReplaceSigmoidMulWithSwish(
             &ctx, sigmoidmul_matched_nodes_map, sigmoidmul_remove_node_indices,
             &invalidated_nodes, &nodes_to_delete));
+        continue;
+      }
+
+      // Remap smaller ops from layernorm python api into _MklLayerNorm
+      matched_nodes_map.clear();
+      remove_node_indices.clear();
+      if (FindMklLayerNorm(&ctx, i, &matched_nodes_map, &remove_node_indices)) {
+        TF_RETURN_IF_ERROR(
+            AddMklLayerNorm(&ctx, matched_nodes_map, remove_node_indices,
+                            &invalidated_nodes, &nodes_to_delete));
         continue;
       }
     }

--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -357,6 +357,15 @@ tf_mkl_kernel_library(
     ] + MKL_DEPS,
 )
 
+tf_mkl_kernel_library(
+    name = "mkl_layer_norm_op",
+    srcs = ["mkl_layer_norm_op.cc"],
+    deps = [
+        "//tensorflow/core:nn_ops_op_lib",
+        "//tensorflow/core:mkl_nn_ops_op_lib",
+    ] + MKL_DEPS,
+)
+
 tf_cc_test_mkl(
     name = "mkl_fused_batch_norm_op_test",
     size = "small",

--- a/tensorflow/core/kernels/mkl/mkl_layer_norm_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_layer_norm_op.cc
@@ -1,0 +1,176 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifdef INTEL_MKL
+
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+#include "dnnl.hpp"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/util/mkl_util.h"
+#include "tensorflow/core/util/tensor_format.h"
+
+using CPUDevice = Eigen::ThreadPoolDevice;
+using dnnl::layer_normalization_forward;
+using dnnl::normalization_flags;
+using dnnl::prop_kind;
+
+namespace tensorflow {
+
+template <typename Device, typename T>
+class MklLayerNormOp : public OpKernel {
+ public:
+  explicit MklLayerNormOp(OpKernelConstruction* context) : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("epsilon", &epsilon_));
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    try {
+      const Tensor& src_tensor = MklGetInput(ctx, kSrcIndex);
+      const Tensor& scale_tensor = MklGetInput(ctx, kScaleIndex);
+      const Tensor& shift_tensor = MklGetInput(ctx, kShiftIndex);
+
+      OP_REQUIRES(ctx, src_tensor.dims() == 2 || src_tensor.dims() == 3,
+                  errors::InvalidArgument("input must be 2D or 3D",
+                                          src_tensor.shape().DebugString()));
+      OP_REQUIRES(ctx, scale_tensor.dims() == 1,
+                  errors::InvalidArgument("scale must be 1D tensor",
+                                          scale_tensor.shape().DebugString()));
+      OP_REQUIRES(ctx, shift_tensor.dims() == 1,
+                  errors::InvalidArgument("offset must be 1D tensor",
+                                          shift_tensor.shape().DebugString()));
+      size_t num_elements_scale = scale_tensor.dim_size(0);
+      size_t num_elements_shift = shift_tensor.dim_size(0);
+      OP_REQUIRES(
+          ctx, num_elements_scale == num_elements_shift,
+          errors::InvalidArgument("Number of elements in scale and shift",
+                                  "tensors are not same."));
+
+      auto cpu_engine = engine(engine::kind::cpu, 0);
+      auto engine_stream = stream(cpu_engine);
+
+      memory::dims src_dims = TFShapeToMklDnnDims(src_tensor.shape());
+      auto src_md =
+          memory::desc(src_dims, MklDnnType<T>(),
+                       (src_dims.size() == 3) ? memory::format_tag::tnc
+                                              : memory::format_tag::nc);
+      void* src_buf =
+          static_cast<void*>(const_cast<T*>(src_tensor.flat<T>().data()));
+      auto src_mem = memory(src_md, cpu_engine, src_buf);
+
+      // oneDNN requires scale-shift as a combined array in float32 type.
+      memory::dims scale_shift_dims = {
+          2, static_cast<dnnl_dim_t>(num_elements_scale)};
+      auto scale_shift_md =
+          memory::desc(static_cast<memory::dims>(scale_shift_dims),
+                       MklDnnType<float>(), memory::format_tag::nc);
+      Tensor scale_shift_tensor;
+      int64_t tensor_shape = scale_shift_md.get_size() / sizeof(float);
+      OP_REQUIRES_OK(
+          ctx, ctx->allocate_temp(DataTypeToEnum<float>::v(), {tensor_shape},
+                                  &scale_shift_tensor));
+      void* scale_shift_buf =
+          static_cast<void*>(scale_shift_tensor.flat<float>().data());
+      auto scale_shift_mem =
+          memory(scale_shift_md, cpu_engine, scale_shift_buf);
+
+      // Copy of reorder scale and shift tensor data into scale_shift_tensor.
+      void* scale_buf_src =
+          static_cast<void*>(const_cast<T*>(scale_tensor.flat<T>().data()));
+      auto scale_mem_src =
+          memory({{num_elements_scale}, MklDnnType<T>(), memory::format_tag::x},
+                 cpu_engine, scale_buf_src);
+      void* scale_buf_dst = scale_shift_buf;
+      auto scale_mem_dst = memory(
+          {{num_elements_scale}, MklDnnType<float>(), memory::format_tag::x},
+          cpu_engine, scale_buf_dst);
+      auto scale_reorder_prim = reorder(scale_mem_src, scale_mem_dst);
+      std::unordered_map<int, memory> scale_reorder_args;
+      scale_reorder_args.insert({DNNL_ARG_FROM, scale_mem_src});
+      scale_reorder_args.insert({DNNL_ARG_TO, scale_mem_dst});
+      scale_reorder_prim.execute(engine_stream, scale_reorder_args);
+
+      void* shift_buf_src =
+          static_cast<void*>(const_cast<T*>(shift_tensor.flat<T>().data()));
+      auto shift_mem_src =
+          memory({{num_elements_shift}, MklDnnType<T>(), memory::format_tag::x},
+                 cpu_engine, shift_buf_src);
+      void* shift_buf_dst =
+          scale_shift_buf + sizeof(float) * num_elements_scale;
+      auto shift_mem_dst = memory(
+          {{num_elements_shift}, MklDnnType<float>(), memory::format_tag::x},
+          cpu_engine, shift_buf_dst);
+      auto shift_reorder_prim = reorder(shift_mem_src, shift_mem_dst);
+      std::unordered_map<int, memory> shift_reorder_args;
+      shift_reorder_args.insert({DNNL_ARG_FROM, shift_mem_src});
+      shift_reorder_args.insert({DNNL_ARG_TO, shift_mem_dst});
+      shift_reorder_prim.execute(engine_stream, shift_reorder_args);
+
+      // Create layer_normalization primitive
+      auto lnorm_desc = layer_normalization_forward::desc(
+          prop_kind::forward_inference, src_md, epsilon_,
+          normalization_flags::use_scale_shift);
+      auto lnorm_pd =
+          layer_normalization_forward::primitive_desc(lnorm_desc, cpu_engine);
+      auto lnorm_prim = layer_normalization_forward(lnorm_pd);
+
+      // mean and variance memory
+      auto mean_mem = memory(lnorm_pd.mean_desc(), cpu_engine);
+      auto variance_mem = memory(lnorm_pd.variance_desc(), cpu_engine);
+
+      // dst memory
+      Tensor* output_tensor = nullptr;
+      OP_REQUIRES_OK(ctx, ctx->forward_input_or_allocate_output(
+                              {0}, 0, src_tensor.shape(), &output_tensor));
+      void* dst_buf =
+          static_cast<void*>(const_cast<T*>(output_tensor->flat<T>().data()));
+      auto dst_mem = memory(src_md, cpu_engine, dst_buf);
+
+      std::unordered_map<int, memory> lnorm_args;
+      lnorm_args.insert({DNNL_ARG_SRC, src_mem});
+      lnorm_args.insert({DNNL_ARG_MEAN, mean_mem});
+      lnorm_args.insert({DNNL_ARG_VARIANCE, variance_mem});
+      lnorm_args.insert({DNNL_ARG_SCALE_SHIFT, scale_shift_mem});
+      lnorm_args.insert({DNNL_ARG_DST, dst_mem});
+      lnorm_prim.execute(engine_stream, lnorm_args);
+    } catch (dnnl::error& e) {
+      string error_msg = "Status: " + std::to_string(e.status) +
+                         ", message: " + string(e.message) + ", in file " +
+                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      OP_REQUIRES_OK(
+          ctx, errors::Aborted("Operation received an exception:", error_msg));
+    }
+  }
+
+ private:
+  float epsilon_;
+  const int kSrcIndex = 0;
+  const int kScaleIndex = 1;
+  const int kShiftIndex = 2;
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("_MklLayerNorm").Device(DEVICE_CPU).TypeConstraint<float>("T"),
+    MklLayerNormOp<CPUDevice, float>);
+
+REGISTER_KERNEL_BUILDER(
+    Name("_MklLayerNorm").Device(DEVICE_CPU).TypeConstraint<bfloat16>("T"),
+    MklLayerNormOp<CPUDevice, bfloat16>);
+
+}  // namespace tensorflow
+
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_layer_norm_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_layer_norm_op.cc
@@ -118,11 +118,6 @@ class MklLayerNormOp : public OpKernel {
                                    MklDnnType<float>(),
                                    memory::format_tag::x},
                                   cpu_engine, shift_buf_dst);
-      void* shift_buf_dst =
-          scale_shift_buf + sizeof(float) * num_elements_scale;
-      auto shift_mem_dst = memory(
-          {{num_elements_shift}, MklDnnType<float>(), memory::format_tag::x},
-          cpu_engine, shift_buf_dst);
       auto shift_reorder_prim = reorder(shift_mem_src, shift_mem_dst);
       std::unordered_map<int, memory> shift_reorder_args;
       shift_reorder_args.insert({DNNL_ARG_FROM, shift_mem_src});

--- a/tensorflow/core/kernels/mkl/mkl_layer_norm_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_layer_norm_op.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #ifdef INTEL_MKL
 
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "dnnl.hpp"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
@@ -22,7 +23,6 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/tensor_format.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 using CPUDevice = Eigen::ThreadPoolDevice;
 using dnnl::layer_normalization_forward;

--- a/tensorflow/core/ops/mkl_nn_ops.cc
+++ b/tensorflow/core/ops/mkl_nn_ops.cc
@@ -1806,6 +1806,15 @@ NOTE Do not invoke this operator directly in Python. Graph rewrite pass is
 expected to invoke these operators.
 )doc");
 
+REGISTER_OP("_MklLayerNorm")
+    .Input("x: T")
+    .Input("scale: T")
+    .Input("offset: T")
+    .Output("y: T")
+    .Attr("T: {float, bfloat16}")
+    .Attr("epsilon: float = 0.001")
+    .SetShapeFn(shape_inference::UnchangedShape);
+
 }  // namespace tensorflow
 
 #endif  // INTEL_MKL


### PR DESCRIPTION
- Explicitly cast `size_t` to `ptrdiff_t`
- Cast `void*` to `char*` before doing pointer arithmetic. `void` pointer arithmetic is illegal in C++ and is a GCC extension. 