### PR TITLE
Fix floating point issue on RequantizeManyInNewRange

### DIFF
--- a/tensorflow/core/kernels/quantization_utils.h
+++ b/tensorflow/core/kernels/quantization_utils.h
@@ -714,7 +714,7 @@ inline void RequantizeManyInNewRangeUsingEigen<qint32, quint8>(
   const int64_t output_offset_fp =
       output_range == 0.0
           ? 0
-          : static_cast<int64_t>((1 << fp_shift) * (min_output * 255.0) /
+          : std::lround((1 << fp_shift) * (min_output * 255.0) /
                                  output_range);
   const int64_t rounding_delta = 1 << (fp_shift - 1);
 

--- a/tensorflow/core/kernels/quantization_utils.h
+++ b/tensorflow/core/kernels/quantization_utils.h
@@ -268,7 +268,7 @@ inline void RequantizeManyInNewRangeReference(const qint32* input,
   const int64_t output_offset_fp =
       output_range == 0.0
           ? 0
-          : static_cast<int64_t>((1 << fp_shift) * (min_output * 255.0) /
+          : std::lround((1 << fp_shift) * (min_output * 255.0) /
                                  output_range);
   const int64_t rounding_delta = 1 << (fp_shift - 1);
 

--- a/tensorflow/core/kernels/quantize_down_and_shrink_range_op_test.cc
+++ b/tensorflow/core/kernels/quantize_down_and_shrink_range_op_test.cc
@@ -57,7 +57,7 @@ TEST_F(QuantizeDownAndShrinkRangeTest, HandCrafted) {
   AddInputFromArray<float>(TensorShape({1}), {256.0f});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_QUINT8, TensorShape({value_count}));
-  test::FillValues<quint8>(&expected, {0, 127, 255});
+  test::FillValues<quint8>(&expected, {0, 128, 255});
   test::ExpectTensorEqual<quint8>(expected, *GetOutput(0));
   Tensor expected_min(allocator(), DT_FLOAT, TensorShape({}));
   test::FillValues<float>(&expected_min, {-1.0f});


### PR DESCRIPTION
Hi,
while comparing tests `requantize_op_test` and `quantize_down_and_shrink_range_op_test` I noticed that both tests are quite similar, like so
```
TEST_F(QuantizeDownAndShrinkRangeTest, HandCrafted) {
  TF_ASSERT_OK(NodeDefBuilder("quantize_down_and_shrink_range_op",
                              "QuantizeDownAndShrinkRange")
                   .Input(FakeInput(DT_QINT32))
                   .Input(FakeInput(DT_FLOAT))
                   .Input(FakeInput(DT_FLOAT))
                   .Attr("Tinput", DataTypeToEnum<qint32>::v())
                   .Attr("out_type", DataTypeToEnum<quint8>::v())
                   .Finalize(node_def()));
  TF_ASSERT_OK(InitOp());

  // For this test we have an input that has the theoretical range of -256.0f to
  // +256.0f, but the actual values present only span -1.0f to 1.0f. We expect
  // the operator to take advantage of this, and rescale the output to fill up
  // the available range in the lower bit depth, and update to the true min and
  // max ranges.
  const int value_count = 3;
  AddInputFromArray<qint32>(TensorShape({value_count}),
                            {-(1 << 23), 0, (1 << 23)});
  AddInputFromArray<float>(TensorShape({1}), {-256.0f});
  AddInputFromArray<float>(TensorShape({1}), {256.0f});
  TF_ASSERT_OK(RunOpKernel());
  Tensor expected(allocator(), DT_QUINT8, TensorShape({value_count}));
  test::FillValues<quint8>(&expected, {0, 127, 255});
  test::ExpectTensorEqual<quint8>(expected, *GetOutput(0));
  Tensor expected_min(allocator(), DT_FLOAT, TensorShape({}));
  test::FillValues<float>(&expected_min, {-1.0f});
  test::ExpectTensorEqual<float>(expected_min, *GetOutput(1));
  Tensor expected_max(allocator(), DT_FLOAT, TensorShape({}));
  test::FillValues<float>(&expected_max, {1.0f});
  test::ExpectTensorEqual<float>(expected_max, *GetOutput(2));
}
```
and 
```
// Runs a manually generated array through the operator, and makes sure that the
// results match the expected hand-calculated values.
TEST_F(RequantizeTest, HandCraftedRequantize) {
  ConfigureRequantize();
  const int value_count = 3;

  // Requantize to -1 to 1.
  AddInputFromArray<qint32>(TensorShape({value_count}),
                            {-(1 << 23), 0, (1 << 23)});
  AddInputFromArray<float>(TensorShape({1}), {-256.0f});
  AddInputFromArray<float>(TensorShape({1}), {256.0f});
  AddInputFromArray<float>(TensorShape({1}), {-1.0f});
  AddInputFromArray<float>(TensorShape({1}), {1.0f});
  TF_ASSERT_OK(RunOpKernel());
  Tensor expected(allocator(), DT_QUINT8, TensorShape({value_count}));
  test::FillValues<quint8>(&expected, {0, 128, 255});
  test::ExpectTensorEqual<quint8>(expected, *GetOutput(0));
  test::ExpectTensorEqual<float>(test::AsScalar<float>(-1.0f), *GetOutput(1));
  test::ExpectTensorEqual<float>(test::AsScalar<float>(1.0f), *GetOutput(2));
}
```
however one expects the result to be 127 and the other 128. 

If you try to pinpoint the problem `RequantizeManyInNewRange` receives on both tests `min_float` as -1 but on one the bit representation is `10111111100000000000000000000000` and the other one `10111111011111111111111111111111` since `static_cast` just truncates the result differs in both executions. This can be seen on both x86 as well as on Arm. 

The patch fixes this using a default rounding strategy as well as the expected value on `quantize_down_and_shrink_range_op_test` to match.