### PR TITLE
Add missing dialect dependency on xla-legalize-tf-control-flow

### DIFF
--- a/tensorflow/compiler/mlir/xla/transforms/xla_legalize_tf_passes.td
+++ b/tensorflow/compiler/mlir/xla/transforms/xla_legalize_tf_passes.td
@@ -76,6 +76,7 @@ def LegalizeTFControlFlow : Pass<"xla-legalize-tf-control-flow", "ModuleOp"> {
   let summary = "Legalize from TF dialect's to HLO dialect's control flow.";
 
   let constructor = "mlir::mhlo::createLegalizeTFControlFlowPass()";
+  let dependentDialects = ["mhlo::MhloDialect"];
 }
 
 def LegalizeTfTypesPass : Pass<"xla-legalize-tf-types"> {


### PR DESCRIPTION
Add missing dialect dependency on xla-legalize-tf-control-flow. This
fixes crashes when using tf-opt to lower tf.while to mhlo.while. The
reason the current test cases for the above pass don't crash is that
those test cases already have mhlo ops and so the dialect is loaded at
parse time hiding this issue.