### PR TITLE
[TF:TRT] Fix Grappler params to enable layout optimizer for the C++ API

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -130,6 +130,7 @@ cc_library(
         "//tensorflow/core:direct_session",
         "//tensorflow/core:framework",
         "//tensorflow/core/grappler:grappler_item_builder",
+        "//tensorflow/core/grappler/clusters:single_machine",
         "//tensorflow/core/platform:logging",
         "@com_google_absl//absl/strings",
     ] + if_tensorrt([":tensorrt_lib"]),


### PR DESCRIPTION
This PR sets the VirtualCluster argument while calling the Grappler optimization pass for TF-TRT. Setting the cluster arg is necessary to enable layout optimizer (otherwise layout optimizer returns without changing the graph). This change only affects conversions initiated by the C++ API of TF-TRT #52012.

Tagging @bixia1 for review.