### PR TITLE
[jax] Combine GlobalJitState and ThreadLocalJitState into single JitState

### DIFF
--- a/tensorflow/compiler/xla/python/jax_jit.h
+++ b/tensorflow/compiler/xla/python/jax_jit.h
@@ -107,7 +107,7 @@ struct CallSignature {
   bool jax_enable_x64;
 
   // Opaque additional context that should be included as part of the cache key.
-  pybind11::object global_extra_jit_context;
+  absl::optional<pybind11::object> global_extra_jit_context;
   absl::optional<pybind11::object> thread_local_extra_jit_context;
 
   bool operator==(const CallSignature& other) const;

--- a/tensorflow/compiler/xla/python/jax_jit.h
+++ b/tensorflow/compiler/xla/python/jax_jit.h
@@ -37,42 +37,37 @@ namespace jax {
 // - possibly a thread-local value, which initially is absl::nullopt and
 //   overrides the global value if set. The thread-local state is
 //   used to implement context managers that locally override the global state.
-// TODO(phawkins): consider changing the global state to optional types to
-// catch cases where we fail to set it.
-struct GlobalJitState {
-  bool disable_jit = false;
-  bool enable_x64 = false;
-
-  // Extra context that should be included in the JIT cache key. Must be
-  // hashable and have an equality defined.
-  pybind11::object extra_jit_context = pybind11::none();
-
-  // A callback that, if present, is called when a JITted function is executed
-  // from cache.
-  absl::optional<pybind11::function> post_hook;
-};
-
-struct ThreadLocalJitState {
-  ~ThreadLocalJitState() {
+struct JitState {
+  ~JitState() {
     if (extra_jit_context) {
-      // We likely do not hold the GIL, so we hand the Python object to the
-      // global reference manager to destroy.
+      // We likely do not hold the GIL if this JitState is thread-local, so we
+      // hand the Python object to the global reference manager to destroy.
       pybind11::object o = std::move(*extra_jit_context);
       xla::GlobalPyRefManager()->AddGarbage(absl::MakeSpan(&o, 1));
       extra_jit_context = absl::nullopt;
     }
   }
+
   absl::optional<bool> disable_jit;
   absl::optional<bool> enable_x64;
+
+  // Extra context that should be included in the JIT cache key. Must be
+  // hashable and have an equality defined.
   absl::optional<pybind11::object> extra_jit_context;
+
+  // A callback that, if present, is called when a JITted function is executed
+  // from cache. May be unset even in global state.
   absl::optional<pybind11::function> post_hook;
 };
 
-// Returns the value for jax_enable_x64 (defined by a thread-local value if
-// defined, defaulting to the value of the flag otherwise).
+JitState& GetGlobalState();
+JitState& GetLocalState();
+
+// Getters for JitState fields that first look in thread-local state, then
+// fallback to global state.
+bool GetDisableJit();
 bool GetEnableX64();
-GlobalJitState& GetGlobalState();
-ThreadLocalJitState& GetLocalState();
+absl::optional<pybind11::function> GetPostHook();
 
 // The signature of Python jitted function call, partitioned into:
 // - dynamic positional arguments (i.e. positional args which are not static)

--- a/tensorflow/compiler/xla/python/pmap_lib.cc
+++ b/tensorflow/compiler/xla/python/pmap_lib.cc
@@ -382,9 +382,7 @@ xla::StatusOr<py::object> PmapFunction::Call(py::args args, py::kwargs kwargs) {
     arguments.signature.dynamic_arg_signatures.push_back(
         std::move(signature_or_error).ValueOrDie());
   }
-  CHECK(global_state.extra_jit_context.has_value());
-  arguments.signature.global_extra_jit_context =
-      *global_state.extra_jit_context;
+  arguments.signature.global_extra_jit_context = global_state.extra_jit_context;
   arguments.signature.thread_local_extra_jit_context = tls.extra_jit_context;
 
   // Retrieve/Maybe add the executable to the cache.

--- a/tensorflow/compiler/xla/python/pmap_lib.cc
+++ b/tensorflow/compiler/xla/python/pmap_lib.cc
@@ -368,9 +368,9 @@ xla::StatusOr<py::object> PmapFunction::Call(py::args args, py::kwargs kwargs) {
   }
 
   // Get dynamic argument signatures.
-  GlobalJitState& global_state = jax::GetGlobalState();
-  ThreadLocalJitState& tls = jax::GetLocalState();
-  const bool jax_enable_x64 = tls.enable_x64.value_or(global_state.enable_x64);
+  JitState& global_state = jax::GetGlobalState();
+  JitState& tls = jax::GetLocalState();
+  const bool jax_enable_x64 = GetEnableX64();
   arguments.signature.jax_enable_x64 = jax_enable_x64;
   for (py::handle arg : arguments.flat_dynamic_args) {
     auto signature_or_error = xla::PyArgSignatureOfValue(arg, jax_enable_x64);
@@ -382,7 +382,9 @@ xla::StatusOr<py::object> PmapFunction::Call(py::args args, py::kwargs kwargs) {
     arguments.signature.dynamic_arg_signatures.push_back(
         std::move(signature_or_error).ValueOrDie());
   }
-  arguments.signature.global_extra_jit_context = global_state.extra_jit_context;
+  CHECK(global_state.extra_jit_context.has_value());
+  arguments.signature.global_extra_jit_context =
+      *global_state.extra_jit_context;
   arguments.signature.thread_local_extra_jit_context = tls.extra_jit_context;
 
   // Retrieve/Maybe add the executable to the cache.
@@ -530,8 +532,7 @@ xla::StatusOr<py::object> PmapFunction::Call(py::args args, py::kwargs kwargs) {
       cache_entry.out_pytree_def.Unflatten(flat_sharded_device_arrays);
 
   // If there is a post-hook function, call it with the inputs and the outputs.
-  absl::optional<py::object> post_hook =
-      tls.post_hook.has_value() ? tls.post_hook : global_state.post_hook;
+  absl::optional<py::object> post_hook = GetPostHook();
   if (post_hook) {
     (*post_hook)(this->AsPyHandle(), args, kwargs, out);
   }

--- a/tensorflow/compiler/xla/python/xla_extension/jax_jit.pyi
+++ b/tensorflow/compiler/xla/python/xla_extension/jax_jit.pyi
@@ -23,20 +23,16 @@ Client = xla_extension.Client
 CompiledFunctionCache = xla_extension.CompiledFunctionCache
 CompiledFunction = xla_extension.CompiledFunction
 
-class GlobalJitState:
-  disable_jit: bool
-  enable_x64: bool
+class JitState:
+  disable_jit: Optional[bool]
+  enable_x64: Optional[bool]
   extra_jit_context: Any
+  post_hook: Optional[Callable]
 
-class ThreadLocalJitState:
-  disable_jit: bool
-  enable_x64: bool
-  extra_jit_context: Any
+def global_state() -> JitState: ...
+def thread_local_state() -> JitState: ...
 
-def global_state() -> GlobalJitState: ...
-def thread_local_state() -> ThreadLocalJitState: ...
-
-def jit_is_enabled() -> bool: ...
+def jit_is_disabled() -> bool: ...
 def get_enable_x64() -> bool: ...
 
 def set_disable_jit_cpp_flag(__arg: bool) -> None: ...


### PR DESCRIPTION
This avoids duplication when defining new fields. This change also
creates standard getters for each field that check if there's
thread-local state defined and make sure a global value is set when
appropriate.