### PR TITLE
[TF-TRT] Fix a bug in getting the DType string representation for the conversion report.

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -900,7 +900,10 @@ def _extract_shapes_from_node(node, key):
 
 
 def _get_engine_dtypes_from_node(node, key):
-  return [dtype.str() for dtype in node.attr[key].list.type]
+  return [
+    dtypes._TYPE_TO_STRING[dtype]
+    for dtype in node.attr[key].list.type
+  ]
 
 
 @tf_export("experimental.tensorrt.Converter", v1=[])


### PR DESCRIPTION
Previously, we use DType.str method to get the string representation for a DType object. This PR fix this to use dtypes[DType object] to get the string representation for the object.