### PR TITLE
[tensorflow/lite/schema/upgrade_schema.py] Move `(see :schema.fbs).` up to `operator_type` arg descriptor

### DIFF
--- a/tensorflow/lite/schema/upgrade_schema.py
+++ b/tensorflow/lite/schema/upgrade_schema.py
@@ -230,8 +230,7 @@ class Converter(object):
 
       Args:
         operator_type: String representing the builtin operator data type
-          string.
-        (see :schema.fbs).
+          string. (see :schema.fbs).
       Raises:
         ValueError: When the model has consistency problems.
       Returns:


### PR DESCRIPTION
Closes #53566

I have custom docstring parsers that is reading in your codebase to make changes down the track (like automatically inferring types and adding them as annotations)… but this line of your codebase it's hiccuping on because it's on a new line and has a colon in it and lower indentation then the line above (indicating same scope as that arg); but doesn't actually refer to a new argument. This PR moves it to the same line as above; so it refers to that arg.