### PR TITLE
[TF:TRT] Elide extra func for nvinfer::Dims equality testing

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -635,19 +635,6 @@ Status ConvertAxis(int tf_axis, int trt_nb_dims, absl::string_view node_name,
   return Status::OK();
 }
 
-inline bool DimsEqual(const nvinfer1::Dims& dim_l,
-                      const nvinfer1::Dims& dim_r) {
-  if (dim_l.nbDims != dim_r.nbDims) {
-    return false;
-  }
-  for (int i = 0; i < dim_l.nbDims; i++) {
-    if (dim_l.d[i] != dim_r.d[i]) {
-      return false;
-    }
-  }
-  return true;
-}
-
 bool AllLengthsEqual(const std::vector<std::vector<int>>& inputs) {
   if (inputs.size() == 0) return true;
   int length = inputs.at(0).size();
@@ -1739,7 +1726,7 @@ Status PrepareTensorForShape(Converter* converter,
 
   TFTRT_RETURN_ERROR_IF_NULLPTR(converter, "converter is nullptr");
   if (input.is_tensor()) {
-    if (DimsEqual(input_dims, dims)) {
+    if (input_dims == dims) {
       *tensor = input.tensor();
     } else {
       nvinfer1::IShuffleLayer* layer =


### PR DESCRIPTION
Removes a redundant helper function `DimsEqual` for comparing two `nvinfer1::Dims` objects. This function is an exact duplicate of the equality operator in `tf2tensorrt/common/utils.h`.