### PR TITLE
[TF:TRT] Consolidate helper functions for TRT and TF tensor shape types

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -169,8 +169,6 @@ class OutputEdgeValidator {
   bool operator()(const Edge* out_edge) const;
 };
 
-int64_t TrtTensorDimsNumElements(const nvinfer1::Dims& dims);
-
 // Class to verify if specific TF node is supported by TRT.
 class TrtNodeValidator {
  public:
@@ -477,7 +475,7 @@ class Converter {
 // If validation_only is false converter must not be nullptr.
 Status PrepareTensorForShape(
     Converter* converter, const TRT_TensorOrWeights& input,
-    const nvinfer1::Dims& dims, const bool validation_only,
+    const DimsAdapter& dims, const bool validation_only,
     ITensorProxyPtr* tensor, const NodeDef& node_def,
     absl::optional<int> op_instance = absl::nullopt,
     absl::optional<std::string> origin_node_name = absl::nullopt);

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -136,7 +136,7 @@ template <typename T>
 void ValidateWeights(const TRT_ShapedWeights& weights,
                      const std::vector<int>& expected_dims,
                      const std::vector<T>& expected_value) {
-  EXPECT_THAT(weights.Shape(), DimsAreArray(expected_dims));
+  EXPECT_EQ(weights.Shape(), DimsAdapter(expected_dims));
   ASSERT_EQ(expected_value.size(), weights.count()) << weights.DebugString();
   const T* actual_values = weights.GetPointer<T>();
   for (int i = 0; i < expected_value.size(); ++i) {
@@ -736,7 +736,7 @@ void TestPrepareTensorForShape(
   NodeDef dummy_node_def = MakeNodeDef("dummy_op", "DummyOp", {});
   for (bool validation_only : {false, true}) {
     const Status status =
-        PrepareTensorForShape(converter, input, CreateDims(reshape_dims),
+        PrepareTensorForShape(converter, input, DimsAdapter(reshape_dims),
                               validation_only, &output_tensor, dummy_node_def);
     if (expected_code == error::OK) {
       TF_EXPECT_OK(status);
@@ -844,8 +844,7 @@ void TestGetWeightRange(ConverterTest* test, TrtWeightStore* weight_store) {
   TRT_ShapedWeights weights =
       weight_store->GetTempWeights(trt_type, CreateDims({2, 3})).ValueOrDie();
   const std::vector<T> values = {T(3), T(1), T(2), T(6), T(5), T(4)};
-  memcpy(weights.GetPointer<int8>(), values.data(), weights.size_bytes());
-
+  absl::c_copy(values, weights.GetPointer<T>());
   float out_min = 0.0f;
   float out_max = 0.0f;
   TF_EXPECT_OK(test->GetWeightRange(weights, &out_min, &out_max));
@@ -912,8 +911,8 @@ TEST_F(ConverterTest, GetTrtBroadcastShape) {
     auto create_tensor_or_weights = [](const std::vector<int>& shape,
                                        bool is_tensor, int batch_size = -1) {
       if (is_tensor) {
-        return TRT_TensorOrWeights{nvinfer1::DataType::kFLOAT,
-                                   CreateDims(shape), batch_size};
+        return TRT_TensorOrWeights(nvinfer1::DataType::kFLOAT,
+                                   CreateDims(shape), batch_size);
       }
       TRT_ShapedWeights weights;
       weights.Shape() = CreateDims(shape);
@@ -1313,19 +1312,19 @@ class OpConverterTest : public ::testing::Test {
     node_inputs_[name] = input.output;
 
     // Add a real ITensor for conversion conditionally.
-    nvinfer1::Dims trt_dims;
-    Status status = TensorShapeToTrtDims(
-        attrs.shape_, converter_->use_implicit_batch(), &trt_dims);
-    if (converter_->use_implicit_batch() && !status.ok()) {
-      ASSERT_EQ(add_input_status, status);
+
+    auto dims_adap =
+        DimsAdapter::Create(attrs.shape_, converter_->use_implicit_batch());
+    if (converter_->use_implicit_batch() && !dims_adap.ok()) {
+      ASSERT_EQ(add_input_status, dims_adap.status());
       return;
     } else {
-      TF_EXPECT_OK(status);
+      TF_EXPECT_OK(dims_adap.status());
     }
-    if (!converter_->use_implicit_batch() || HasStaticShape(trt_dims)) {
+    if (!converter_->use_implicit_batch() || dims_adap->IsStatic()) {
       int batch_size = dims.size() > 0 ? dims[0] : 0;
-      Status status =
-          converter_->AddInputTensor(name, trt_type, trt_dims, batch_size);
+      Status status = converter_->AddInputTensor(
+          name, trt_type, dims_adap->AsTrtDims(), batch_size);
       ASSERT_EQ(add_input_status, status);
     }
   }
@@ -1339,11 +1338,11 @@ class OpConverterTest : public ::testing::Test {
   void AddTestTensor(
       const string& name, const std::vector<int32>& dims, int batch_size = 1,
       nvinfer1::DataType trt_dtype = nvinfer1::DataType::kFLOAT) {
-    std::vector<int32> dims_with_batch(dims.size() + 1);
-    dims_with_batch[0] = batch_size;
-    std::copy(dims.begin(), dims.end(), dims_with_batch.begin() + 1);
-    AddTestTensorWithTFDims(name, dims_with_batch, trt_dtype);
-    if (HasStaticShape(dims)) {
+    DimsAdapter adap(dims);
+    std::vector<int32_t> dims_vec;
+    TF_CHECK_OK(adap.Prepend(batch_size).Vector(&dims_vec));
+    AddTestTensorWithTFDims(name, dims_vec, trt_dtype);
+    if (adap.IsStatic()) {
       ASSERT_EQ(batch_size, converter_->batch_size_);
     }
   }
@@ -1361,14 +1360,15 @@ class OpConverterTest : public ::testing::Test {
     // Add weights for conversion.
     nvinfer1::DataType dtype;
     TF_ASSERT_OK(TfTypeToTrtType(DataTypeToEnum<T>::v(), &dtype));
-    const nvinfer1::Dims trt_dims = CreateDims(dims);
-    const int64_t num_elements = TRT_ShapedWeights::count(trt_dims);
+    const DimsAdapter dims_adap(dims);
+    const int64_t num_elements = dims_adap.Volume();
     QCHECK_EQ(num_elements, values.size())
         << num_elements << " vs " << values.size();
     TRT_ShapedWeights weights(dtype);
     if (num_elements) {
-      weights = converter_->weight_store_.GetTempWeights(dtype, trt_dims)
-                    .ConsumeValueOrDie();
+      weights =
+          converter_->weight_store_.GetTempWeights(dtype, dims_adap.AsTrtDims())
+              .ConsumeValueOrDie();
       QCHECK_EQ(weights.size_bytes(), sizeof(T) * values.size())
           << weights.size_bytes() << " vs " << sizeof(T) * values.size();
       memcpy(weights.GetPointer<int8>(), values.data(), weights.size_bytes());
@@ -2164,8 +2164,8 @@ TEST_P(OpConverter_FP32_Test, ConvertReshape) {
           : Status::OK();
   Status add_scalar_tensor_status =
       trt_mode_ == TrtTestMode::kImplicitBatch
-          ? errors::Internal(
-                "Scalars cannot be represented in implicit batch mode")
+          ? errors::InvalidArgument(
+                "removing first dim requires explicit batch dimension")
           : Status::OK();
   Status reshape_to_scalar_status =
       trt_mode_ == TrtTestMode::kImplicitBatch
@@ -2861,7 +2861,7 @@ TEST_P(OpConverter_FP32_FP16_Test, ConvertBiasAdd) {
         dims_array[1] = 2;
         dims_array[trt_input_rank] = 3;
       }
-      const int num_input = TrtTensorDimsNumElements(CreateDims(dims_array));
+      const int64_t num_input = DimsAdapter(dims_array).Volume();
       ASSERT_EQ(trt_input_rank > 1 ? 6 : (data_format == "NHWC" ? 3 : 2),
                 num_input);
       std::vector<float> input_data(num_input, 0);
@@ -7104,12 +7104,12 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertUnpack) {
       // Output would be TF scalar, should fail.
       Reset();
       NodeDef node_def = get_unpack_nodedef(tf_type_, /*num=*/1, /*axis=*/0);
-      AddTestTensor("value", {}, tf_type_, {}, {},
-                    trt_mode_ == TrtTestMode::kImplicitBatch
-                        ? errors::Internal("Scalars cannot be represented in "
-                                           "implicit batch mode")
-                        : Status::OK());
-
+      AddTestTensor(
+          "value", {}, tf_type_, {}, {},
+          trt_mode_ == TrtTestMode::kImplicitBatch
+              ? errors::InvalidArgument(
+                    "removing first dim requires explicit batch dimension")
+              : Status::OK());
       if (trt_mode_ == TrtTestMode::kImplicitBatch) {
         RunValidationAndConversion(
             node_def, error::INTERNAL,

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -27,7 +27,7 @@ namespace tensorrt {
 
 string DebugString(const nvinfer1::Dims& dims) {
   string out = StrCat("nvinfer1::Dims(nbDims=", dims.nbDims, ", d=");
-  for (int i = 0; i < dims.nbDims; ++i) {
+  for (int i = 0; i < std::max(dims.nbDims,0); ++i) {
     StrAppend(&out, dims.d[i]);
     StrAppend(&out, ",");
   }
@@ -141,17 +141,8 @@ Status GetNetworkInputShapes(const nvinfer1::INetworkDefinition* network,
   for (int i = 0; i < n_inputs; i++) {
     const ITensorProxyPtr input = network->getInput(i);
     const nvinfer1::Dims input_dim = input->getDimensions();
-    TF_RETURN_IF_ERROR(TrtDimsToTensorShape(input_dim, &input_shapes->at(i)));
-  }
-  return Status::OK();
-}
-Status TrtDimsToTensorShape(const std::vector<int>& trt_dims,
-                            TensorShape* shape,
-                            absl::optional<int> batch_size) {
-  TF_RETURN_IF_ERROR(
-      TensorShapeUtils::MakeShape(trt_dims.data(), trt_dims.size(), shape));
-  if (batch_size) {
-    shape->InsertDim(0, batch_size.value());
+    TF_RETURN_IF_ERROR(DimsAdapter(input->getDimensions())
+                           .PartialTensorShape(&input_shapes->at(i)));
   }
   return Status::OK();
 }

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <algorithm>
 #include <iterator>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 #include "absl/algorithm/container.h"
@@ -128,67 +129,221 @@ inline bool IsTrtShapeTensorCompatible(const Tensor& tensor) {
          IsTrtShapeTensorCompatible(tensor.shape());
 }
 
-template <typename Container>
-Status ContainerToTrtDims(const Container& shape, nvinfer1::Dims* trt_dims,
-                          bool ignore_first_dim = false) {
-  if (shape.size() == 0) {
-    // scalar
-    if (ignore_first_dim) {
-      return errors::Internal(
-          "Scalars cannot be represented in implicit batch mode");
-    }
-    *trt_dims = {0, {1}};
-  } else {
-    const int offset = (ignore_first_dim ? 1 : 0);
-    for (int i = offset; i < shape.size(); i++) {
-      trt_dims->d[i - offset] = shape.at(i);
-    }
-    trt_dims->nbDims = shape.size() - offset;
-  }
-  return Status::OK();
-}
+// Adapts various representations of shape (TF Shape, TRT Dims, plain
+// containers) and provides methods for properties (length, volume) and
+// conversion between types. Note that unlike TF's TensorShape, the underlying
+// storage will only contain active dimensions. In the case of scalar shapes,
+// `NumDims` is allowed to return 0 or 1, but the `storage_` vector will contain
+// 1 element in both cases. In the non-scalar case, `NumDims() ==
+// storage_.size()`.
+class DimsAdapter {
+ public:
+  using StorageType = absl::InlinedVector<int64_t, 4>;
 
-template <typename TensorShapeType>
-Status TensorShapeToTrtDims(const TensorShapeType& shape, bool ignore_first_dim,
-                            nvinfer1::Dims* trt_dims) {
-  if (shape.dims() == -1) {
-    trt_dims->nbDims = -1;
+ private:
+  template <typename T>
+  using EnableIfNotTensorShapeType =
+      std::enable_if_t<!std::is_base_of<TensorShapeBase<T>, T>::value>;
+
+  template <typename T>
+  using EnableIfInt = std::enable_if_t<std::is_arithmetic<T>::value &&
+                                       std::is_integral<T>::value>;
+
+ public:
+  //----- Constructors ------
+
+  // Constructs from an absl::Span.
+  template <typename T>
+  explicit DimsAdapter(absl::Span<T> shape)
+      : num_dims_(static_cast<int32_t>(shape.size())) {
+    absl::c_copy(shape, std::back_inserter(storage_));
+  }
+
+  // Constructs from an absl::Span.
+  template <typename T>
+  explicit DimsAdapter(const std::vector<T>& shape)
+      : num_dims_(static_cast<int32_t>(shape.size())) {
+    absl::c_copy(shape, std::back_inserter(storage_));
+  }
+
+  // Constructs from a TRT dims object.
+  DimsAdapter(const nvinfer1::Dims& dims) : num_dims_(dims.nbDims) {
+    absl::c_copy(absl::MakeSpan(dims.d, dims.d + std::max(dims.nbDims, 0)),
+                 std::back_inserter(storage_));
+  }
+
+  // Constructs explicitly specifing num_dims and storage data.
+  DimsAdapter(int32_t num_dims, StorageType data)
+      : num_dims_(num_dims), storage_(std::forward<StorageType>(data)) {}
+
+  // Constructs from a TensorShape or PartialTensorShape.
+  template <typename T>
+  static StatusOr<DimsAdapter> Create(const TensorShapeBase<T>& shape,
+                                      bool ignore_first_dim = false) {
+    if (shape.dims() > nvinfer1::Dims::MAX_DIMS)
+      return errors::InvalidArgument("dims of TensorShape exceed MAX_DIMS");
+    if (ignore_first_dim && shape.dims() <= 0)
+      return errors::InvalidArgument(
+          "removing first dim requires explicit batch dimension");
+    if (shape.dims() == -1) {
+      return DimsAdapter(-1, StorageType{});
+    }
+    if (shape.dims() == 0) {
+      return DimsAdapter(0, StorageType{1});
+    }
+    auto offt = (ignore_first_dim ? 1 : 0);
+    return DimsAdapter(
+        absl::MakeSpan(shape.dim_sizes().begin() + offt, shape.dims() - offt));
+  }
+
+  // Constructs from a container.
+  template <typename InputSequence,
+            typename = EnableIfNotTensorShapeType<InputSequence>>
+  static StatusOr<DimsAdapter> Create(const InputSequence& shape,
+                                      bool ignore_first_dim = false) {
+    if (ignore_first_dim && shape.size() <= 0) {
+      return errors::InvalidArgument(
+          "removing first dim requires explicit batch dimension");
+    }
+    return DimsAdapter(
+        absl::MakeSpan(shape).subspan(ignore_first_dim ? 1 : 0, shape.size()));
+  }
+
+  //----- Conversion Utilities ------
+
+  //  Converts to an nvinfers::Dims and assign the result to the object passed
+  //  in via the result pointer.
+  void TrtDims(nvinfer1::Dims* result) const {
+    result->nbDims = num_dims_;
+    absl::c_copy(storage_, static_cast<int32_t*>(result->d));
+  }
+
+  // Converts to an nvinfer1::Dims and return by value.
+  nvinfer1::Dims AsTrtDims() const {
+    nvinfer1::Dims result;
+    TrtDims(&result);
+    return result;
+  }
+
+  // Converts to a TensorShape and assigns the result to the object passed in
+  // via the shape pointer.
+  Status TensorShape(TensorShape* shape,
+                     absl::optional<int> batch_size = absl::nullopt) const {
+    TF_RETURN_IF_ERROR(TensorShapeUtils::MakeShape(
+        static_cast<const int64_t*>(storage_.data()), storage_.size(), shape));
+    if (batch_size) shape->InsertDim(0, *batch_size);
     return Status::OK();
   }
-  return ContainerToTrtDims(shape.dim_sizes(), trt_dims, ignore_first_dim);
-}
+
+  // Converts to a PartialTensorShape and assigns the result to the object
+  // passed in via the shape pointer.
+  Status PartialTensorShape(
+      PartialTensorShape* shape,
+      absl::optional<int> batch_size = absl::nullopt) const {
+    TF_RETURN_IF_ERROR(TensorShapeUtils::MakeShape(
+        static_cast<const int64_t*>(storage_.data()), storage_.size(), shape));
+    if (batch_size) shape->InsertDim(0, *batch_size);
+    return Status::OK();
+  }
+
+  // Copies the dimension values to the vector passed in via the shape pointer.
+  template <typename T, typename = EnableIfInt<T>>
+  Status Vector(std::vector<T>* shape) const {
+    shape->clear();
+    absl::c_copy(storage_, std::back_inserter(*shape));
+    return Status::OK();
+  }
+
+  //----- Property Accessors ------
+
+  // Returns true if the shape has no dynamic dimensions.
+  bool IsStatic() const {
+    return !absl::c_any_of(storage_, [](auto i) { return i < 0; });
+  }
+
+  // Returns product of all dimensions.
+  int64_t Volume() const {
+    return absl::c_accumulate(storage_, int64_t(1), std::multiplies<>());
+  }
+
+  int32_t NumDims() const { return num_dims_; };
+
+  // Returns true if the shape should be interpreted as a scalar. This follows
+  // TensorRT conversions: a scalar shape can have NumDims()==1 or NumDims()==0,
+  // but the underlying storage_ container has a single dimension of size 1.
+  bool IsScalar() const {
+    return (num_dims_ == 0 || num_dims_ == 1) && storage_.size() == 1 &&
+           storage_[0] == 1;
+  }
+
+  // Returns true if the dimension storage is empty. This indicates an empty
+  // shape in both the scalar and non-scalar case.
+  bool IsEmpty() const { return storage_.empty(); }
+
+  string DebugString() const {
+    auto vol = absl::c_accumulate(storage_, int64_t(1), std::multiplies<>());
+    return absl::StrCat("DimsAdapter(num_dims=", num_dims_, ",shape=[",
+                        absl::StrJoin(storage_, ","), "],", "vol=", vol, ")");
+  }
+
+  // Returns beginning iterator for the underlying storage.
+  StorageType::const_iterator begin() const { return storage_.begin(); }
+
+  // Returns ending iterator for the underlying storage.
+  StorageType::const_iterator end() const { return storage_.end(); }
+
+  // Returns the size of the dimension at `idx`.
+  StorageType::value_type dim(size_t idx) const { return storage_[idx]; }
+
+  // Returns a references to the dimension at `idx`.
+  StorageType::value_type& dim(size_t idx) { return storage_[idx]; }
+
+  //----- Non-Const Operators ------
+
+  DimsAdapter& Append(int32_t dim) {
+    StatusOr<bool> is_scalar = IsScalar();
+    if (!is_scalar.ok()) return *this;
+    num_dims_ = *is_scalar ? 2 : num_dims_ + 1;
+    storage_.push_back(dim);
+    return *this;
+  }
+
+  DimsAdapter& Prepend(absl::optional<int32_t> dim) {
+    if (dim) {
+      num_dims_ = IsScalar() ? 2 : num_dims_ + 1;
+      storage_.insert(storage_.begin(), *dim);
+    }
+    return *this;
+  }
+
+  Status RemoveBatchDimension() {
+    if (storage_.empty())
+      return errors::InvalidArgument(
+          "attempted to remove batch dim from scalar");
+    num_dims_ -= 1;
+    storage_.erase(storage_.begin());
+    return Status::OK();
+  }
+
+  //----- Comparison Operators ------
+
+  bool operator==(const DimsAdapter& rhs) const {
+    if (rhs.num_dims_ != num_dims_) return false;
+    for (int i = 0; i < num_dims_; i++) {
+      if (rhs.storage_[i] != storage_[i]) return false;
+    }
+    return true;
+  }
+
+  bool operator!=(const DimsAdapter& rhs) const { return !(*this == rhs); }
+
+ private:
+  int32_t num_dims_{0};
+  StorageType storage_{};
+};
 
 Status GetNetworkInputShapes(const nvinfer1::INetworkDefinition* network,
                              std::vector<PartialTensorShape>* input_shapes);
-
-// Creates PartialTensorShape from nvinfer1::Dims. The "batch_dimension", when
-// provided, is prepended to the shape.
-inline PartialTensorShape TrtDimsToPartialTensorShape(
-    const nvinfer1::Dims& dims,
-    absl::optional<int64> batch_dimension = absl::nullopt) {
-  absl::InlinedVector<int64, 4> dims_vec;
-  if (batch_dimension) {
-    dims_vec.insert(dims_vec.begin(), std::max(int64(-1), *batch_dimension));
-  }
-  std::copy(dims.d, dims.d + dims.nbDims, std::back_inserter(dims_vec));
-  return PartialTensorShape(dims_vec);
-}
-
-Status TrtDimsToTensorShape(const std::vector<int>& trt_dims,
-                            TensorShape* shape,
-                            absl::optional<int> batch_size = absl::nullopt);
-
-template <typename TensorShapeType>
-Status TrtDimsToTensorShape(const nvinfer1::Dims trt_dims,
-                            TensorShapeType* shape,
-                            absl::optional<int> batch_size = absl::nullopt) {
-  TF_RETURN_IF_ERROR(
-      TensorShapeUtils::MakeShape(trt_dims.d, trt_dims.nbDims, shape));
-  if (batch_size) {
-    shape->InsertDim(0, batch_size.value());
-  }
-  return Status::OK();
-}
 
 Status TfTypeToTrtType(DataType tf_type, nvinfer1::DataType* trt_type);
 Status TrtTypeToTfType(nvinfer1::DataType trt_type, DataType* tf_type);

--- a/tensorflow/compiler/tf2tensorrt/convert/weights.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/weights.cc
@@ -27,43 +27,32 @@ namespace tensorrt {
 
 namespace convert {
 
-TRT_ShapedWeights::TRT_ShapedWeights(nvinfer1::DataType type) : type_(type) {
-  shape_.nbDims = 0;
-  shape_.d[0] = 0;
-}
+TRT_ShapedWeights::TRT_ShapedWeights(nvinfer1::DataType type)
+    : shape_(0, DimsAdapter::StorageType{}), type_(type), volume_(0) {}
 
-TRT_ShapedWeights::TRT_ShapedWeights(nvinfer1::DataType type,
-                                     nvinfer1::Dims dims, Tensor tensor)
-    : shape_(dims), type_(type), tensor_(tensor) {
-  if (dims.nbDims == 0) {
-    DCHECK(dims.d[0] == 0 || dims.d[0] == 1);
+StatusOr<TRT_ShapedWeights> TRT_ShapedWeights::CreateWithTensor(
+    nvinfer1::DataType type, DimsAdapter dims, Tensor tensor) {
+  TRT_ShapedWeights weights(type);
+  weights.shape_ = dims;
+  weights.tensor_ = std::forward<Tensor>(tensor);
+  weights.volume_ = weights.shape_.Volume();
+  if (weights.shape_.NumDims() == 0) {
+    DCHECK(weights.shape_.IsScalar());
   }
-}
-
-TRT_ShapedWeights::TRT_ShapedWeights(const TRT_ShapedWeights& rhs)
-    : shape_(rhs.shape_), type_(rhs.type_), tensor_(rhs.tensor_) {}
-
-int64_t TRT_ShapedWeights::count(nvinfer1::Dims dims) {
-  if (dims.nbDims == 0) {
-    assert(dims.d[0] == 0 || dims.d[0] == 1);
-    return dims.d[0];
-  }
-  return static_cast<int64_t>(
-      std::accumulate(dims.d, dims.d + dims.nbDims, 1, std::multiplies<int>()));
+  return weights;
 }
 
 nvinfer1::Weights TRT_ShapedWeights::GetTrtWeights() const {
-  return nvinfer1::Weights{type_, GetPointer<int8>(), count()};
+  return nvinfer1::Weights{type_, GetPointer<int8>(), volume_};
 }
 
-Status TRT_ShapedWeights::SetShape(nvinfer1::Dims dims) {
-  if (this->count() != TRT_ShapedWeights::count(dims)) {
-    VLOG(2) << "Changing shape from "
-            << tensorflow::tensorrt::DebugString(shape_) << ", to "
-            << tensorflow::tensorrt::DebugString(dims);
+Status TRT_ShapedWeights::SetShape(DimsAdapter dims) {
+  if (volume_ != dims.Volume()) {
+    VLOG(2) << "Changing shape from " << shape_.DebugString() << ", to "
+            << dims.DebugString();
     return errors::Internal("SetShape would change number of elements");
   }
-  shape_ = dims;
+  shape_ = std::move(dims);
   return Status::OK();
 }
 
@@ -82,12 +71,12 @@ size_t TRT_ShapedWeights::size_bytes() const {
       data_type_size = 1;
       break;
   }
-  return this->count() * data_type_size;
+  return volume_ * data_type_size;
 }
 
 string TRT_ShapedWeights::DebugString() const {
   return absl::StrCat(
-      "TRT_ShapedWeights(shape=", tensorflow::tensorrt::DebugString(shape_),
+      "TRT_ShapedWeights(shape=", shape_.DebugString(),
       ", type=", tensorflow::tensorrt::DebugString(type_),
       ", values=", reinterpret_cast<uintptr_t>(GetPointer<int8>()), ")");
 }
@@ -143,7 +132,7 @@ nvinfer1::Dims TRT_TensorOrWeights::GetTrtDims() const {
   if (is_tensor()) {
     return tensor()->getDimensions();
   }
-  return weights().Shape();
+  return weights().Shape().AsTrtDims();
 }
 
 Status TRT_TensorOrWeights::GetTfType(DataType* tf_type) const {
@@ -172,14 +161,16 @@ string TRT_TensorOrWeights::DebugString() const {
 }
 
 StatusOr<TRT_ShapedWeights> TrtWeightStore::GetTempWeights(
-    nvinfer1::DataType trt_dtype, const nvinfer1::Dims& dims) {
-  TensorShape shape;
+    nvinfer1::DataType trt_dtype, const DimsAdapter& dims) {
   DataType tf_dtype;
-  TF_RETURN_IF_ERROR(TensorShapeUtils::MakeShape(dims.d, dims.nbDims, &shape));
   TF_RETURN_IF_ERROR(TrtTypeToTfType(trt_dtype, &tf_dtype));
+  TensorShape shape;
+  TF_RETURN_IF_ERROR(dims.TensorShape(&shape));
   // TODO(jie): check weights size_bytes. 0 means type error
   Tensor tensor(tf_dtype, shape);
-  TRT_ShapedWeights weights(trt_dtype, dims, tensor);
+  StatusOr<TRT_ShapedWeights> weights =
+      TRT_ShapedWeights::CreateWithTensor(trt_dtype, dims, tensor);
+  TRT_ENSURE_OK(weights);
   store_.emplace_back(std::move(tensor));
   return weights;
 }

--- a/tensorflow/compiler/tf2tensorrt/convert/weights.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/weights.h
@@ -40,7 +40,7 @@ class TRT_ShapedWeights {
   //
   // NOTE: this does not copy the underlying buffer but only increase its
   // reference count.
-  TRT_ShapedWeights(const TRT_ShapedWeights& rhs);
+  TRT_ShapedWeights(const TRT_ShapedWeights& rhs) = default;
 
   nvinfer1::Weights GetTrtWeights() const;
 
@@ -68,17 +68,17 @@ class TRT_ShapedWeights {
     switch (type_) {
       case nvinfer1::DataType::kFLOAT: {
         float* ptr = tensor_.flat<float>().data();
-        std::fill(ptr, ptr + count(), value);
+        std::fill(ptr, ptr + volume_, value);
         break;
       }
       case nvinfer1::DataType::kHALF: {
         Eigen::half* ptr = tensor_.flat<Eigen::half>().data();
-        std::fill(ptr, ptr + count(), Eigen::half(value));
+        std::fill(ptr, ptr + volume_, Eigen::half(value));
         break;
       }
       case nvinfer1::DataType::kINT32: {
         int32* ptr = tensor_.flat<int32>().data();
-        std::fill(ptr, ptr + count(), value);
+        std::fill(ptr, ptr + volume_, value);
         break;
       }
       default:
@@ -88,15 +88,13 @@ class TRT_ShapedWeights {
     return Status::OK();
   }
 
-  Status SetShape(nvinfer1::Dims dims);
+  Status SetShape(DimsAdapter dims);
+  void SetShapeUnsafe(DimsAdapter dims) { shape_ = std::move(dims); }
 
   // Returns total number of elements. Returning 0 means either some dim is 0
   // or the number of dims is 0. Note that a TF scalar constant is marked as
   // Dims{0, {1}}, and has a count() == 1.
-  int64_t count() const { return count(shape_); }
-
-  // Returns the total number of elements in a weight with shape dims.
-  static int64_t count(nvinfer1::Dims dims);
+  int64_t count() const { return volume_; }
 
   size_t size_bytes() const;
 
@@ -104,7 +102,7 @@ class TRT_ShapedWeights {
 
   template <typename T>
   absl::Span<const T> GetSpan() const {
-    return absl::Span<const T>(tensor_.flat<T>().data(), count());
+    return absl::Span<const T>(tensor_.flat<T>().data(), volume_);
   }
 
   template <typename T>
@@ -115,18 +113,18 @@ class TRT_ShapedWeights {
 
   nvinfer1::DataType TrtDType() const { return type_; }
 
-  const nvinfer1::Dims& Shape() const { return shape_; }
-  nvinfer1::Dims& Shape() { return shape_; }
+  const DimsAdapter& Shape() const { return shape_; }
+  DimsAdapter& Shape() { return shape_; }
 
  private:
-  // Scalar weights are supported, a scalar constant tensor is represented via
-  // TRT_ShapedWeights::shape_ = {0, {1}}.
-  nvinfer1::Dims shape_;  // Note: shape.type[] is not used.
+  // The shape of the weights. Defaults to the empty shape.
+  DimsAdapter shape_;
 
-  // This constructor is only used by TrtWeightStore, which creates the
+  // This creation method is only used by TrtWeightStore, which creates the
   // underlying buffer.
-  TRT_ShapedWeights(nvinfer1::DataType type, nvinfer1::Dims dims,
-                    Tensor tensor);
+  static StatusOr<TRT_ShapedWeights> CreateWithTensor(nvinfer1::DataType type,
+                                                      DimsAdapter dims,
+                                                      Tensor tensor);
 
   nvinfer1::DataType type_;
 
@@ -135,6 +133,8 @@ class TRT_ShapedWeights {
   // this reason, tensor_ should never be reassigned to a different value that
   // is not already present in the TrtWeightStore.
   Tensor tensor_;
+  // Contains the volume of the weight's shape.
+  int64_t volume_;
 
   friend class TrtWeightStore;
 };
@@ -150,7 +150,7 @@ class TrtWeightStore {
  public:
   // Gets a TRT_ShapedWeights with 'type' and 'dims'.
   StatusOr<TRT_ShapedWeights> GetTempWeights(nvinfer1::DataType trt_type,
-                                             const nvinfer1::Dims& dims);
+                                             const DimsAdapter& dims);
 
   // Gets a TRT_ShapedWeights with the same data type and dimensions as
   // 'weights'.

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
@@ -280,7 +280,7 @@ TEST_P(TRTEngineResourceOpsTest, Basic) {
   ExecutionContext context = ExecutionContext::Create(engine.get());
 
   std::vector<TensorShape> engine_input_shape(1);
-  TF_ASSERT_OK(TrtDimsToTensorShape(param_.dims, &(engine_input_shape[0])));
+  TF_ASSERT_OK(DimsAdapter(param_.dims).TensorShape(&engine_input_shape[0]));
   if (param_.n_inputs > 1) {
     engine_input_shape.push_back(TensorShape({1, 1}));
   }

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
@@ -35,9 +35,9 @@ template <typename TensorShapeType>
 std::vector<nvinfer1::Dims> GetDimVec(std::vector<TensorShapeType> shape_vec) {
   std::vector<nvinfer1::Dims> dimvec(shape_vec.size());
   absl::c_transform(shape_vec, dimvec.begin(), [](TensorShapeType shape) {
-    nvinfer1::Dims dims;
-    TF_CHECK_OK(TensorShapeToTrtDims(shape, false, &dims));
-    return dims;
+    auto adap = DimsAdapter::Create(shape);
+    TF_CHECK_OK(adap.status());
+    return adap->AsTrtDims();
   });
   return dimvec;
 }

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_testutils.h
@@ -129,10 +129,7 @@ MATCHER(LayerNamesNonEmpty, "") {
 // Example: EXPECT_THAT(my_weights,
 //                      ShapedWeightsHasDimsAndValues({1, 2},{1.0f, 2.0f}))
 MATCHER_P2(ShapedWeightsHasDimsAndValuesHelper, dims_vec, expected_values, "") {
-  nvinfer1::Dims dims;
-  dims.nbDims =
-      std::min(static_cast<int>(dims_vec.size()), nvinfer1::Dims::MAX_DIMS);
-  std::copy_n(dims_vec.begin(), dims.nbDims, dims.d);
+  DimsAdapter dims(dims_vec);
   if (arg.Shape() != dims) {
     return false;
   }


### PR DESCRIPTION
Currently, there are  multiple functions for helping convert `nvinfer1::Dims` to  and from other types, yet they are declared in disparate translation units. This PR cleans up the helper functions in `convert_nodes.cc` for converting from TF Tensor shape types to `nvinfer1::Dims`. One helper function accomplishes the same task as `TensorShapeToTrtDims` in `convert/utils.h` yet performs fewer error checks. It is moved to `convert/utils.h` and renamed `TensorShapeToTrtDimsUnsafe`. Another function is highly specific and only used once and thus is inlined at the call site, resulting in code reduction and improved clarity.