### PR TITLE
Xla const output cache on GPU 

### DIFF
--- a/tensorflow/compiler/jit/kernels/xla_ops.cc
+++ b/tensorflow/compiler/jit/kernels/xla_ops.cc
@@ -168,7 +168,21 @@ XlaLocalLaunchBase::XlaLocalLaunchBase(OpKernelConstruction* ctx,
       resources_(resources),
       function_(function),
       platform_info_(XlaPlatformInfoFromDevice(ctx->device())),
-      has_ref_vars_(has_ref_vars) {}
+      has_ref_vars_(has_ref_vars),
+      cache_(nullptr),
+      rm_(nullptr) {}
+
+XlaLocalLaunchBase::~XlaLocalLaunchBase() {
+  if (cache_ != nullptr) {
+    cache_->Unref();
+    if (!rm_->template Delete<XlaConstantOutputResource>(def().name(),
+                                                         def().name())
+             .ok()) {
+      // Do nothing; the resource can have been deleted by session resets.
+    }
+  }
+}
+
 
 static Status CompileToLocalExecutable(
     OpKernelContext* ctx, const NameAttrList& function, bool has_ref_vars,
@@ -307,11 +321,26 @@ void XlaLocalLaunchBase::Compute(OpKernelContext* ctx) {
 
   auto elapsed = env->NowMicros() - start_time;
   VLOG(2) << "Elapsed time: " << elapsed << "us";
+
+  if (cache_ == nullptr) {
+    rm_ = ctx->resource_manager();
+    rm_->LookupOrCreate<XlaConstantOutputResource>(
+        def().name(), def().name(), &cache_,
+        [](XlaConstantOutputResource** ret) {
+          *ret = new XlaConstantOutputResource();
+          return Status::OK();
+        });
+  }
+  // Create a cache for each executable .
+  XlaConstOutputCache& const_output_cache =
+      cache_->FindConstOutput(executable->executable());
+
+
   OP_REQUIRES_OK(
       ctx, launch_context.PopulateOutputs(
                ctx, compilation_result, execution_output->ConsumeResult(),
                /*missing_ctx_input_prefix=*/0, absl::MakeSpan(variable_infos),
-               input_output_alias, resource_var_ptrs));
+               input_output_alias, resource_var_ptrs, const_output_cache));
 
   VLOG(1) << "Done";
 }
@@ -481,7 +510,21 @@ void XlaCompileOp::Compute(OpKernelContext* ctx) {
 }
 
 XlaRunOp::XlaRunOp(OpKernelConstruction* ctx)
-    : OpKernel(ctx), platform_info_(XlaPlatformInfoFromDevice(ctx->device())) {}
+    : OpKernel(ctx),
+      platform_info_(XlaPlatformInfoFromDevice(ctx->device())),
+      cache_(nullptr),
+      rm_(nullptr) {}
+
+XlaRunOp::~XlaRunOp() {
+  if (cache_ != nullptr) {
+    cache_->Unref();
+    if (!rm_->template Delete<XlaConstantOutputResource>(def().name(),
+                                                         def().name())
+             .ok()) {
+      // Do nothing; the resource can have been deleted by session resets.
+    }
+  }
+}
 
 void XlaRunOp::Compute(OpKernelContext* ctx) {
   VLOG(3) << "XlaRunOp " << def().name();
@@ -562,12 +605,26 @@ void XlaRunOp::Compute(OpKernelContext* ctx) {
       ctx, *closure.compilation_result(), closure.num_constant_args());
   OP_REQUIRES_OK(ctx, variable_infos.status());
   OP_REQUIRES_OK(ctx, LockVariables(absl::MakeSpan(*variable_infos)));
+
+  if (cache_ == nullptr) {
+    rm_ = ctx->resource_manager();
+    rm_->LookupOrCreate<XlaConstantOutputResource>(
+        def().name(), def().name(), &cache_,
+        [](XlaConstantOutputResource** ret) {
+          *ret = new XlaConstantOutputResource();
+          return Status::OK();
+        });
+  }
+  // Create a cache for each executable .
+  XlaConstOutputCache& const_output_cache =
+      cache_->FindConstOutput(closure.executable()->executable());
+
   OP_REQUIRES_OK(
       ctx,
       launch_context.PopulateOutputs(
           ctx, closure.compilation_result(), execution_output->ConsumeResult(),
           /*missing_ctx_input_prefix=*/closure.num_constant_args(),
-          absl::MakeSpan(*variable_infos), input_output_alias, snapshot_ptrs));
+          absl::MakeSpan(*variable_infos), input_output_alias, snapshot_ptrs, const_output_cache));
 }
 
 XlaMergeOp::XlaMergeOp(OpKernelConstruction* ctx) : OpKernel(ctx) {}

--- a/tensorflow/compiler/jit/kernels/xla_ops.cc
+++ b/tensorflow/compiler/jit/kernels/xla_ops.cc
@@ -324,12 +324,12 @@ void XlaLocalLaunchBase::Compute(OpKernelContext* ctx) {
 
   if (cache_ == nullptr) {
     rm_ = ctx->resource_manager();
-    rm_->LookupOrCreate<XlaConstantOutputResource>(
+    OP_REQUIRES_OK(ctx, rm_->LookupOrCreate<XlaConstantOutputResource>(
         def().name(), def().name(), &cache_,
         [](XlaConstantOutputResource** ret) {
           *ret = new XlaConstantOutputResource();
           return Status::OK();
-        });
+        }));
   }
   // Create a cache for each executable .
   XlaConstOutputCache& const_output_cache =
@@ -608,12 +608,12 @@ void XlaRunOp::Compute(OpKernelContext* ctx) {
 
   if (cache_ == nullptr) {
     rm_ = ctx->resource_manager();
-    rm_->LookupOrCreate<XlaConstantOutputResource>(
+    OP_REQUIRES_OK(ctx, rm_->LookupOrCreate<XlaConstantOutputResource>(
         def().name(), def().name(), &cache_,
         [](XlaConstantOutputResource** ret) {
           *ret = new XlaConstantOutputResource();
           return Status::OK();
-        });
+        }));
   }
   // Create a cache for each executable .
   XlaConstOutputCache& const_output_cache =

--- a/tensorflow/compiler/jit/kernels/xla_ops.h
+++ b/tensorflow/compiler/jit/kernels/xla_ops.h
@@ -52,7 +52,7 @@ class XlaLocalLaunchBase : public OpKernel {
                      const NameAttrList& function, bool has_ref_vars);
   XlaLocalLaunchBase(const XlaLocalLaunchBase&) = delete;
   XlaLocalLaunchBase& operator=(const XlaLocalLaunchBase&) = delete;
-  ~XlaLocalLaunchBase() override = default;
+  ~XlaLocalLaunchBase() override;
 
   void Compute(OpKernelContext* ctx) override;
 
@@ -66,6 +66,9 @@ class XlaLocalLaunchBase : public OpKernel {
   const XlaPlatformInfo platform_info_;
 
   bool has_ref_vars_;
+  // Cache GPU const output tensor .
+  XlaConstantOutputResource* cache_;
+  ResourceMgr* rm_;
 };
 
 // XlaLocalLaunchOp is used to replace a region of the TensorFlow graph
@@ -123,8 +126,13 @@ class XlaRunOp : public OpKernel {
 
   void Compute(OpKernelContext* ctx) override;
 
+  ~XlaRunOp() override;
+
  private:
   const XlaPlatformInfo platform_info_;
+  // Cache GPU const output tensor .
+  XlaConstantOutputResource* cache_;
+  ResourceMgr* rm_;
 };
 
 class XlaMergeOp : public OpKernel {

--- a/tensorflow/compiler/jit/xla_compile_on_demand_op.cc
+++ b/tensorflow/compiler/jit/xla_compile_on_demand_op.cc
@@ -96,10 +96,24 @@ Status XlaCompileOnDemandOp::Run(OpKernelContext* ctx,
       GatherVariableInfo(ctx, *result, 0);
   TF_RETURN_IF_ERROR(variable_infos.status());
   TF_RETURN_IF_ERROR(LockVariables(absl::MakeSpan(*variable_infos)));
+
+  if (cache_ == nullptr) {
+    rm_ = ctx->resource_manager();
+    rm_->LookupOrCreate<XlaConstantOutputResource>(
+        def().name(), def().name(), &cache_,
+        [](XlaConstantOutputResource** ret) {
+          *ret = new XlaConstantOutputResource();
+          return Status::OK();
+        });
+  }
+  // Create a cache for each executable .
+  XlaConstOutputCache& const_output_cache =
+      cache_->FindConstOutput(executable->executable());
+
   TF_RETURN_IF_ERROR(launch_context.PopulateOutputs(
       ctx, result, execution_output.ConsumeResult(),
       /*missing_ctx_input_prefix=*/0, absl::MakeSpan(*variable_infos),
-      input_output_alias, snapshot_ptrs));
+      input_output_alias, snapshot_ptrs, const_output_cache));
   return Status::OK();
 }
 
@@ -179,6 +193,17 @@ void XlaCompileOnDemandOp::Compute(OpKernelContext* ctx) {
   // this is more obviously correct.)
   core::ScopedUnref cache_ref(cache);
   OP_REQUIRES_OK(ctx, Run(ctx, cache, result, executable, variable_args));
+}
+
+XlaCompileOnDemandOp::~XlaCompileOnDemandOp() {
+  if (cache_ != nullptr) {
+    cache_->Unref();
+    if (!rm_->template Delete<XlaConstantOutputResource>(def().name(),
+                                                         def().name())
+             .ok()) {
+      // Do nothing; the resource can have been deleted by session resets.
+    }
+  }
 }
 
 }  // namespace tensorflow

--- a/tensorflow/compiler/jit/xla_compile_on_demand_op.cc
+++ b/tensorflow/compiler/jit/xla_compile_on_demand_op.cc
@@ -99,12 +99,12 @@ Status XlaCompileOnDemandOp::Run(OpKernelContext* ctx,
 
   if (cache_ == nullptr) {
     rm_ = ctx->resource_manager();
-    rm_->LookupOrCreate<XlaConstantOutputResource>(
+    TF_RETURN_IF_ERROR(rm_->LookupOrCreate<XlaConstantOutputResource>(
         def().name(), def().name(), &cache_,
         [](XlaConstantOutputResource** ret) {
           *ret = new XlaConstantOutputResource();
           return Status::OK();
-        });
+        }));
   }
   // Create a cache for each executable .
   XlaConstOutputCache& const_output_cache =

--- a/tensorflow/compiler/jit/xla_compile_on_demand_op.h
+++ b/tensorflow/compiler/jit/xla_compile_on_demand_op.h
@@ -38,8 +38,11 @@ class XlaCompileOnDemandOp : public OpKernel {
  public:
   explicit XlaCompileOnDemandOp(OpKernelConstruction* ctx)
       : OpKernel(ctx),
-        platform_info_(XlaPlatformInfoFromDevice(ctx->device())) {}
+        platform_info_(XlaPlatformInfoFromDevice(ctx->device())),
+        cache_(nullptr),
+        rm_(nullptr) {}
   void Compute(OpKernelContext* ctx) override;
+  ~XlaCompileOnDemandOp() override;
 
  private:
   XlaCompiler::Argument CreateCompilerArgument(OpKernelContext* ctx, int64_t i);
@@ -55,6 +58,9 @@ class XlaCompileOnDemandOp : public OpKernel {
              const ResourceVarsSnapshot& variable_args);
 
   const XlaPlatformInfo platform_info_;
+  // Cache GPU const output tensor .
+  XlaConstantOutputResource* cache_;
+  ResourceMgr* rm_;
 };
 
 }  // namespace tensorflow

--- a/tensorflow/compiler/jit/xla_launch_util.cc
+++ b/tensorflow/compiler/jit/xla_launch_util.cc
@@ -102,6 +102,41 @@ VariableInfo::~VariableInfo() {
   }
 }
 
+bool XlaConstOutputCache::FindConstOutput(const int64 output_idx,
+                                          Tensor* output) {
+  const auto iter = cache_.find(output_idx);
+  if (iter == cache_.end()) {
+    return false;
+  } else {
+    *output = iter->second;
+    return true;
+  }
+}
+
+string XlaConstOutputCache::DebugString() const {
+  string debug_string;
+  for (const auto& const_output : cache_) {
+    debug_string.append(std::to_string(const_output.first));
+    debug_string.append(":");
+    debug_string.append(const_output.second.DebugString());
+  }
+  return debug_string;
+}
+
+string XlaConstantOutputResource::DebugString() const {
+  string debug_string;
+  for (const auto& cluster : cache_) {
+    debug_string.append("XlaConstantCache save | ");
+    debug_string.append(std::to_string(int64(cluster.first)));
+    debug_string.append(":[");
+    cluster.second.DebugString();
+    debug_string.append("],");
+  }
+  debug_string.append("].");
+  return debug_string;
+}
+
+
 Status GetVariableInfosFromInputs(ResourceMgr* rm, DeviceBase* dev,
                                   absl::Span<const Tensor* const> inputs,
                                   absl::Span<const int> variable_indices,
@@ -456,7 +491,8 @@ Status XlaComputationLaunchContext::PopulateOutputs(
     ScopedShapedBuffer output, int missing_ctx_input_prefix,
     absl::Span<VariableInfo> variable_infos,
     const xla::HloInputOutputAliasConfig& input_output_alias,
-    const std::map<int, const Tensor*>& resource_vars) {
+    const std::map<int, const Tensor*>& resource_vars,
+    XlaConstOutputCache& cache) {
   se::Stream* stream =
       ctx->op_device_context() ? ctx->op_device_context()->stream() : nullptr;
   Allocator* allocator = ctx->device()->GetAllocator({});


### PR DESCRIPTION
#53609

**Problem overview:** the const outputs of xla executable is kept in host memory. if the const output of executable need a device tensor, we need to do an H2D(host memory to device memory) .

**Ideas overview:** cache the const output of xla executable to device memory, then replace H2D with lookup from cache.

**Background(features async H2D)** :

The total ops in out model are set on the gpu device, so model spends data very fast, but the data part(parsing the data from TFRecord to Features) complete run on host memory, so we need copy features from host to device, this H2D will launch lots of requests of H2D on H2D stream. we use prefetch_to_device to overlap the time required for feature H2D.(prefetch_to_device: async copy features from host to device. The method of model obtaining data is replaced from synchronous H2D to obtain from cache)

**Problem**:

We use xla to increase speed of training, but we found gpu util is 0 after xla run and model hung, As follows:

We carefully analyse nsys profiling file, found xla brought H2D once, and this H2D will block by features H2D in background.

**Solution**:

We found that this H2D is generated by the xla op, and then we read the code about xla carefully, we found that the const output tensor of the executable is placed on the host, and then copy to the device side through memcpyH2D.

We can add a cache<executable output index, device tensor> on device. We put pair<executable output index, device tensor> to cache in the first time, and the next time replace to get device tensor from synchronous H2D to get device tensor from cache.

**result(special model)**:

no prefetch_to_device: No performance drop.

prefetch_to_device: preformance 15%↑

Is there a pr template？ It's a little late in China, can I change it tomorrow?