### PR TITLE
Remove meta support for aarch64.

### DIFF
--- a/tensorflow/core/kernels/meta_support.cc
+++ b/tensorflow/core/kernels/meta_support.cc
@@ -23,7 +23,7 @@ limitations under the License.
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/mutex.h"
 
-#if (defined(GEMMLOWP_NEON_32) || defined(GEMMLOWP_NEON_64)) && \
+#if defined(GEMMLOWP_NEON_32) && \
     !defined(TENSORFLOW_DISABLE_META) && !defined(__APPLE__)
 #define TENSORFLOW_USE_META (1)
 #endif


### PR DESCRIPTION
This patch removes meta support for aarch64 as it's currently no longer maintained and tests `quantized_op_test` and `quantize_bias_add_op_test` fail when it is enabled.