### PR TITLE
Update upper bound to numpy to 1.20.

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -79,7 +79,7 @@ REQUIRED_PACKAGES = [
     'h5py >= 2.9.0',
     'keras_preprocessing >= 1.1.1', # 1.1.0 needs tensorflow==1.7
     'libclang >= 9.0.1',
-    'numpy >= 1.14.5',
+    'numpy >= 1.20',
     'opt_einsum >= 2.3.2',
     'protobuf >= 3.9.2',
     'setuptools < 60',  # TODO(b/211495558): Breaking change in v60 on distutils


### PR DESCRIPTION
PiperOrigin-RevId: 419625181
Change-Id: Ic610b47386d029d293a4ab99daf5f3098838d28b
(cherry picked from commit a66666b5ef4baed419ee7d32d1eb60b88486178c)