### PR TITLE
[tflite] Add ruy header for profile in gather

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/gather.h
+++ b/tensorflow/lite/kernels/internal/reference/gather.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <cstring>
 
+#include "ruy/profiler/instrumentation.h"  // from @ruy
 #include "tensorflow/lite/core/c/c_api_types.h"
 #include "tensorflow/lite/kernels/internal/common.h"
 


### PR DESCRIPTION
This will include missing ruy instrumentation header for ruy profile.