### PR TITLE
[jax] Add default_device config to JitState

### DIFF
--- a/tensorflow/compiler/xla/python/jax_jit.h
+++ b/tensorflow/compiler/xla/python/jax_jit.h
@@ -51,6 +51,10 @@ struct JitState {
   absl::optional<bool> disable_jit;
   absl::optional<bool> enable_x64;
 
+  // Used to manually set the default device jax should use. May be unset even
+  // in global state, indicating there is no manual override.
+  absl::optional<xla::ClientAndPtr<xla::PjRtDevice>> default_device;
+
   // Extra context that should be included in the JIT cache key. Must be
   // hashable and have an equality defined.
   absl::optional<pybind11::object> extra_jit_context;
@@ -67,6 +71,7 @@ JitState& GetLocalState();
 // fallback to global state.
 bool GetDisableJit();
 bool GetEnableX64();
+absl::optional<xla::ClientAndPtr<xla::PjRtDevice>> GetDefaultDevice();
 absl::optional<pybind11::function> GetPostHook();
 
 // The signature of Python jitted function call, partitioned into:

--- a/tensorflow/compiler/xla/python/xla_client.py
+++ b/tensorflow/compiler/xla/python/xla_client.py
@@ -44,7 +44,7 @@ profiler = _xla.profiler
 
 # Just an internal arbitrary increasing number to help with backward-compatible
 # changes.
-_version = 51
+_version = 52
 
 # Version number for MLIR:Python components.
 mlir_api_version = 1

--- a/tensorflow/compiler/xla/python/xla_extension/jax_jit.pyi
+++ b/tensorflow/compiler/xla/python/xla_extension/jax_jit.pyi
@@ -19,6 +19,7 @@ import numpy as np
 from tensorflow.compiler.xla.python import xla_extension
 
 Client = xla_extension.Client
+Device = xla_extension.Device
 
 CompiledFunctionCache = xla_extension.CompiledFunctionCache
 CompiledFunction = xla_extension.CompiledFunction
@@ -53,6 +54,7 @@ def jit(fun: Callable[..., Any],
         static_argnums: Sequence[int],
         static_argnames: Sequence[str] = ...,
         donate_argnums: Sequence[int] = ...,
+        jit_device: Optional[Device] = ...,
         cache: Optional[CompiledFunctionCache] = ...) -> CompiledFunction: ...
 
 def device_put(


### PR DESCRIPTION
This can be used to override the system default device when running a
jit'd function. This is the prioritized list which determines which
settings take precedence when determining which device a jit'd
function runs on:

1. `device` or `backend` argument to jit
2. Input(s) with sticky device
3. default_device config (new!)
4. System default device

This also changes the `jit` C++ binding to take a `jit_device`
argument, which is the device determined by the `device` or `backend`
argument to jit (or None if not set), rather than determining it by
calling back into Python.