### PR TITLE
r2.8 cherry-pick request: Updating oneDNN to v2.5.1

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -175,9 +175,9 @@ def _tf_repositories():
     tf_http_archive(
         name = "mkl_dnn_v1",
         build_file = "//third_party/mkl_dnn:mkldnn_v1.BUILD",
-        sha256 = "a86951e569509c670c09f3e4a31fe6b01811e5c1d15cc2374f8b5554b45b4271",
-        strip_prefix = "oneDNN-2.5-rc",
-        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/v2.5-rc.tar.gz"),
+        sha256 = "f1c5a35c2c091e02417d7aa6ede83f863d35cf0ad91a132185952f5cca7b4887",
+        strip_prefix = "oneDNN-2.5.1",
+        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/v2.5.1.tar.gz"),
     )
 
     tf_http_archive(

--- a/third_party/mkl_dnn/mkldnn_v1.BUILD
+++ b/third_party/mkl_dnn/mkldnn_v1.BUILD
@@ -29,6 +29,7 @@ _DNNL_RUNTIME_OMP = {
     "#cmakedefine DNNL_WITH_SYCL": "#undef DNNL_WITH_SYCL",
     "#cmakedefine DNNL_WITH_LEVEL_ZERO": "#undef DNNL_WITH_LEVEL_ZERO",
     "#cmakedefine DNNL_SYCL_CUDA": "#undef DNNL_SYCL_CUDA",
+    "#cmakedefine DNNL_ENABLE_STACK_CHECKER": "#undef DNNL_ENABLE_STACK_CHECKER",
     "#cmakedefine01 BUILD_TRAINING": "#define BUILD_TRAINING 1",
     "#cmakedefine01 BUILD_INFERENCE": "#define BUILD_INFERENCE 0",
     "#cmakedefine01 BUILD_PRIMITIVE_ALL": "#define BUILD_PRIMITIVE_ALL 1",
@@ -56,7 +57,14 @@ _DNNL_RUNTIME_OMP = {
     "#cmakedefine01 BUILD_AVX2": "#define BUILD_AVX2 0",
     "#cmakedefine01 BUILD_AVX512": "#define BUILD_AVX512 0",
     "#cmakedefine01 BUILD_AMX": "#define BUILD_AMX 0",
-    "#cmakedefine DNNL_ENABLE_STACK_CHECKER": "#undef DNNL_ENABLE_STACK_CHECKER",
+
+    "#cmakedefine01 BUILD_PRIMITIVE_GPU_ISA_ALL": "#define BUILD_PRIMITIVE_GPU_ISA_ALL 0",
+    "#cmakedefine01 BUILD_GEN9": "#define BUILD_GEN9 0",
+    "#cmakedefine01 BUILD_GEN11": "#define BUILD_GEN11 0",
+    "#cmakedefine01 BUILD_XELP": "#define BUILD_XELP 0",
+    "#cmakedefine01 BUILD_XEHPG": "#define BUILD_XEHPG 0",
+    "#cmakedefine01 BUILD_XEHPC": "#define BUILD_XEHPC 0",
+    "#cmakedefine01 BUILD_XEHP": "#define BUILD_XEHP 0",
 }
 
 _DNNL_RUNTIME_THREADPOOL = {
@@ -67,6 +75,7 @@ _DNNL_RUNTIME_THREADPOOL = {
     "#cmakedefine DNNL_WITH_SYCL": "#undef DNNL_WITH_SYCL",
     "#cmakedefine DNNL_WITH_LEVEL_ZERO": "#undef DNNL_WITH_LEVEL_ZERO",
     "#cmakedefine DNNL_SYCL_CUDA": "#undef DNNL_SYCL_CUDA",
+    "#cmakedefine DNNL_ENABLE_STACK_CHECKER": "#undef DNNL_ENABLE_STACK_CHECKER",
     "#cmakedefine01 BUILD_TRAINING": "#define BUILD_TRAINING 1",
     "#cmakedefine01 BUILD_INFERENCE": "#define BUILD_INFERENCE 0",
     "#cmakedefine01 BUILD_PRIMITIVE_ALL": "#define BUILD_PRIMITIVE_ALL 1",
@@ -94,7 +103,14 @@ _DNNL_RUNTIME_THREADPOOL = {
     "#cmakedefine01 BUILD_AVX2": "#define BUILD_AVX2 0",
     "#cmakedefine01 BUILD_AVX512": "#define BUILD_AVX512 0",
     "#cmakedefine01 BUILD_AMX": "#define BUILD_AMX 0",
-    "#cmakedefine DNNL_ENABLE_STACK_CHECKER": "#undef DNNL_ENABLE_STACK_CHECKER",
+
+    "#cmakedefine01 BUILD_PRIMITIVE_GPU_ISA_ALL": "#define BUILD_PRIMITIVE_GPU_ISA_ALL 0",
+    "#cmakedefine01 BUILD_GEN9": "#define BUILD_GEN9 0",
+    "#cmakedefine01 BUILD_GEN11": "#define BUILD_GEN11 0",
+    "#cmakedefine01 BUILD_XELP": "#define BUILD_XELP 0",
+    "#cmakedefine01 BUILD_XEHPG": "#define BUILD_XEHPG 0",
+    "#cmakedefine01 BUILD_XEHPC": "#define BUILD_XEHPC 0",
+    "#cmakedefine01 BUILD_XEHP": "#define BUILD_XEHP 0",
 }
 
 template_rule(


### PR DESCRIPTION
Updating oneDNN from v2.5-rc to v2.5.1 which has a performance fix for 4k x 4k x 4k matmuls and also [many other fixes](https://github.com/oneapi-src/oneDNN/compare/v2.5-rc...v2.5.1).

Original PR: https://github.com/tensorflow/tensorflow/pull/53527