### PR TITLE
[PluggableDevice] Link `pywrap_tensorflow_internal` with `kernels_experimental`

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -25,7 +25,6 @@ load("//tensorflow:tensorflow.bzl", "tf_external_workspace_visible")
 
 # buildifier: disable=same-origin-load
 load("//tensorflow:tensorflow.bzl", "tf_pybind_cc_library_wrapper")
-
 load("//tensorflow:tensorflow.bzl", "if_windows")
 
 # buildifier: disable=same-origin-load

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -3268,6 +3268,7 @@ pywrap_tensorflow_macro(
         "//tensorflow/c:c_api",
         "//tensorflow/c:c_api_experimental",
         "//tensorflow/c:checkpoint_reader",
+        "//tensorflow/c:kernels_experimental",
         "//tensorflow/c:python_api",
         "//tensorflow/c:tf_status_helper",
         "//tensorflow/c/eager:c_api",

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -26,6 +26,8 @@ load("//tensorflow:tensorflow.bzl", "tf_external_workspace_visible")
 # buildifier: disable=same-origin-load
 load("//tensorflow:tensorflow.bzl", "tf_pybind_cc_library_wrapper")
 
+load("//tensorflow:tensorflow.bzl", "if_windows")
+
 # buildifier: disable=same-origin-load
 load("//tensorflow:tensorflow.bzl", "tf_py_test")
 load("//tensorflow/core/platform:build_config.bzl", "pyx_library", "tf_additional_all_protos", "tf_additional_lib_deps", "tf_proto_library", "tf_protos_grappler")  # @unused
@@ -3268,7 +3270,6 @@ pywrap_tensorflow_macro(
         "//tensorflow/c:c_api",
         "//tensorflow/c:c_api_experimental",
         "//tensorflow/c:checkpoint_reader",
-        "//tensorflow/c:kernels_experimental",
         "//tensorflow/c:python_api",
         "//tensorflow/c:tf_status_helper",
         "//tensorflow/c/eager:c_api",
@@ -3316,6 +3317,8 @@ pywrap_tensorflow_macro(
         "//tensorflow/core/util:determinism",
         "//tensorflow/core/platform:tensor_float_32_utils",
         "//tensorflow/core/platform:enable_tf2_utils",
+    ]) + if_windows([
+        "//tensorflow/c:kernels_experimental",
     ]),
 )
 


### PR DESCRIPTION
Because Windows python builds don't come with `tensorflow_framework.dll`, they don't currently expose any of the experimental kernel functions which are necessary to support resource operations in pluggable devices.