### PR TITLE
[2.5 backport] Resolve bug with re-saving Estimator-exported SavedModel

### DIFF
--- a/tensorflow/python/saved_model/load_v1_in_v2.py
+++ b/tensorflow/python/saved_model/load_v1_in_v2.py
@@ -138,7 +138,7 @@ class _EagerSavedModelLoader(loader_impl.SavedModelLoader):
     for signature_key, signature_def in meta_graph_def.signature_def.items():
       if signature_def.inputs:
         input_items = sorted(
-            signature_def.inputs.items(), key=lambda item: item[1].name)
+            signature_def.inputs.items(), key=lambda item: item[0])
         original_input_names, input_specs = zip(*input_items)
       else:
         original_input_names = []

--- a/tensorflow/python/saved_model/load_v1_in_v2_test.py
+++ b/tensorflow/python/saved_model/load_v1_in_v2_test.py
@@ -696,6 +696,33 @@ class LoadTest(test.TestCase):
     self.assertEqual(imported.signatures["serving_default"].inputs[1].name,
                      "input2:0")
 
+  def test_resave_signature(self):
+    # Tests that signatures saved using TF1 can be resaved with TF2.
+    # See b/211666001 for context.
+    export_graph = ops.Graph()
+    with export_graph.as_default():
+      a = array_ops.placeholder(
+          shape=[None, 1], dtype=dtypes.float32, name="input_2")
+      b = array_ops.placeholder(
+          shape=[None, 2], dtype=dtypes.float32, name="input_1")
+      c = array_ops.identity(a)
+      with session_lib.Session() as session:
+        path = os.path.join(self.get_temp_dir(), "saved_model", str(ops.uid()))
+        simple_save.simple_save(
+            session,
+            path,
+            inputs={"a": a, "b": b},
+            outputs={"c": c})
+    imported = load.load(path)
+    path2 = os.path.join(self.get_temp_dir(), "saved_model", str(ops.uid()))
+    save.save(imported, path2, imported.signatures)
+
+    imported2 = load.load(path2)
+    self.assertEqual(
+        imported2.signatures["serving_default"](
+            a=constant_op.constant([5.]),
+            b=constant_op.constant([1., 3.]))["c"].numpy(), 5.)
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
# Change description
Sort signature inputs by input key instead of tensor name when loading a TF1 model in TF2.

Signatures are saved using nest.flatten, which sorts the keys alphabetically for determinism. This can cause a mismatch between the lifted signature function's arg_keywords and structured_input_signature, resulting in users not being able to re-save the signature.

Detailed example below.

Say there is a SavedModel signature with the inputs:
```
  inputs['a'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1, 1)
        name: input_2:0
    inputs['b'] tensor_info:
        dtype: DT_FLOAT
        shape: (-1, 2)
        name: input_1:0
```

When this signature is loaded using the TF2 API, it becomes a concrete function with arg keywords = `['b', 'a']` (sorted by tensor name)

The `structured_input_signature` becomes `([], {'b': spec_for_b, 'a': spec_for_a})`

When this function is exported as a signature in a new SavedModel, the structured inputs are flattened and zipped with the arg keywords. However, the flattened `structured_input_signature` is `[spec_for_a, spec_for_b]`, since `nest.flatten` sorts the keys for determinism. This results in the wrong spec being mapped to the wrong arguments.

PiperOrigin-RevId: 417889747
Change-Id: Icdce72a43033027c18f5530068f2d6fd47e8e32d