### PR TITLE
[TF:TRT] Remove redundant NodeDef attr helpers

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/common/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.h
@@ -118,7 +118,7 @@ inline std::ostream& operator<<(std::ostream& os, const nvinfer1::Dims& v) {
   os << absl::StrJoin(std::vector<int>(v.d, v.d + v.nbDims), ",");
   os << "]";
   return os;
-}  // namespace nvinfer1
+}
 
 // Returns true if any two derived nvinfer1::Dims type structs are equivalent.
 inline bool operator==(const nvinfer1::Dims& lhs, const nvinfer1::Dims& rhs) {


### PR DESCRIPTION
Removes a class in `convert_nodes.cc` that is supposed to help with parsing NodeDef attributes. However, the class uses `TF_CHECK`-style error checking and can potentially cause a crash during conversion (although unlikely). This change replaces uses of the class with uses of helper functions from TF's NodeDef utilities.