### PR TITLE
[TF:TRT] Fix oss build

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -40,6 +40,19 @@ package(
     licenses = ["notice"],
 )
 
+# Whether or not to use the EfficientNMSPlugin from NVIDIA OSS archive.
+config_setting(
+    name = "use_efficient_nms_plugin",
+    define_values = {"use_efficient_nms_plugin": "1"},
+)
+
+cc_library(
+    name = "efficient_nms_plugin",
+    deps = if_tensorrt([
+        "@tensorrt_oss_archive//:nvinfer_plugin_nms",
+    ]),
+)
+
 cc_library(
     name = "tensorrt_stub",
     srcs = if_tensorrt([
@@ -69,6 +82,10 @@ tf_cuda_cc_test(
     srcs = [
         "tensorrt_test.cc",
     ],
+    extra_copts = select({
+        ":use_efficient_nms_plugin": ["-DTF_TRT_USE_EFFICIENT_NMS_PLUGIN=1"],
+        "//conditions:default": [],
+    }),
     tags = [
         "no_cuda_on_cpu_tap",
         "no_windows",
@@ -84,8 +101,10 @@ tf_cuda_cc_test(
         "//tensorflow/core:test_main",
     ] + if_tensorrt([
         ":tensorrt_lib",
-        "//third_party/tensorrt/plugin:nvinfer_plugin_nms",
-    ]),
+    ]) + select({
+        ":use_efficient_nms_plugin": [":efficient_nms_plugin"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_library(
@@ -593,7 +612,7 @@ tf_cuda_library(
         "convert/trt_optimization_pass.h",
     ],
     copts = tf_copts() + select({
-        "@local_config_tensorrt//:use_efficient_nms_plugin": ["-DTF_TRT_USE_EFFICIENT_NMS_PLUGIN=1"],
+        ":use_efficient_nms_plugin": ["-DTF_TRT_USE_EFFICIENT_NMS_PLUGIN=1"],
         "//conditions:default": [],
     }),
     deps = [
@@ -636,7 +655,7 @@ tf_cuda_library(
         "//tensorflow/stream_executor/lib",
         "//tensorflow/tools/graph_transforms:transform_utils",
     ] + if_tensorrt([":tensorrt_lib"]) + tf_custom_op_library_additional_deps() + select({
-        "@local_config_tensorrt//:use_efficient_nms_plugin": ["//third_party/tensorrt/plugin:nvinfer_plugin_nms"],
+        ":use_efficient_nms_plugin": [":efficient_nms_plugin"],
         "//conditions:default": [],
     }),
     alwayslink = 1,

--- a/tensorflow/compiler/tf2tensorrt/tensorrt_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/tensorrt_test.cc
@@ -17,8 +17,6 @@ limitations under the License.
 #include <numeric>
 #include <stack>
 
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_logger.h"
@@ -26,10 +24,50 @@ limitations under the License.
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/platform/test.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/tensorrt/NvInfer.h"
 #include "third_party/tensorrt/NvInferPlugin.h"
 #include "third_party/tensorrt/NvInferRuntimeCommon.h"
+
+#ifdef TF_TRT_USE_EFFICIENT_NMS_PLUGIN
 #include "third_party/tensorrt/plugin/efficientNMSPlugin/efficientNMSPlugin.h"
+namespace tensorflow {
+namespace tensorrt {
+std::unique_ptr<nvinfer1::plugin::EfficientNMSPluginCreator>
+MakeNMSPluginCreator(const std::string& plugin_namespace = "tftrt") {
+  auto pluginCreator =
+      std::make_unique<nvinfer1::plugin::EfficientNMSPluginCreator>();
+  pluginCreator->setPluginNamespace(plugin_namespace.c_str());
+  std::string pluginType = std::string{pluginCreator->getPluginNamespace()} +
+                           "::" + std::string{pluginCreator->getPluginName()} +
+                           " version " +
+                           std::string{pluginCreator->getPluginVersion()};
+  VLOG(0) << "Created plugin type " << pluginType;
+  return pluginCreator;
+}
+
+struct PluginDeleter {
+  void operator()(nvinfer1::IPluginV2* t);
+};
+
+void PluginDeleter::operator()(nvinfer1::IPluginV2* t) { t->destroy(); }
+
+std::unique_ptr<nvinfer1::IPluginV2, PluginDeleter> createPlugin(
+    const std::string& name, nvinfer1::IPluginCreator* pluginCreator,
+    const std::vector<nvinfer1::PluginField>& pluginFields) {
+  if (!pluginCreator) {
+    return nullptr;
+  }
+  nvinfer1::PluginFieldCollection fc;
+  fc.nbFields = pluginFields.size();
+  fc.fields = pluginFields.data();
+  return std::unique_ptr<nvinfer1::IPluginV2, PluginDeleter>{
+      pluginCreator->createPlugin(name.c_str(), &fc)};
+}
+}  // namespace tensorrt
+}  // namespace tensorflow
+#endif
 
 namespace tensorflow {
 namespace tensorrt {
@@ -70,38 +108,6 @@ const char* kInputTensor2 = "input2";
 const char* kOutputTensor1 = "output";
 const char* kOutputTensor2 = "output-nms";
 
-std::unique_ptr<nvinfer1::plugin::EfficientNMSPluginCreator>
-MakeNMSPluginCreator(const std::string& plugin_namespace = "tftrt") {
-  auto pluginCreator =
-      std::make_unique<nvinfer1::plugin::EfficientNMSPluginCreator>();
-  pluginCreator->setPluginNamespace(plugin_namespace.c_str());
-  std::string pluginType = std::string{pluginCreator->getPluginNamespace()} +
-                           "::" + std::string{pluginCreator->getPluginName()} +
-                           " version " +
-                           std::string{pluginCreator->getPluginVersion()};
-  VLOG(0) << "Created plugin type " << pluginType;
-  return pluginCreator;
-}
-
-struct PluginDeleter {
-  void operator()(nvinfer1::IPluginV2* t);
-};
-
-void PluginDeleter::operator()(nvinfer1::IPluginV2* t) { t->destroy(); }
-
-std::unique_ptr<nvinfer1::IPluginV2, PluginDeleter> createPlugin(
-    const std::string& name, nvinfer1::IPluginCreator* pluginCreator,
-    const std::vector<nvinfer1::PluginField>& pluginFields) {
-  if (!pluginCreator) {
-    return nullptr;
-  }
-  nvinfer1::PluginFieldCollection fc;
-  fc.nbFields = pluginFields.size();
-  fc.fields = pluginFields.data();
-  return std::unique_ptr<nvinfer1::IPluginV2, PluginDeleter>{
-      pluginCreator->createPlugin(name.c_str(), &fc)};
-}
-
 // Creates a network to compute x+y.
 TrtUniquePtrType<nvinfer1::IHostMemory> CreateSerializedEngine() {
   Logger& logger = *Logger::GetLogger();
@@ -122,7 +128,11 @@ TrtUniquePtrType<nvinfer1::IHostMemory> CreateSerializedEngine() {
   auto layer = network->addElementWise(*input1, *input2,
                                        nvinfer1::ElementWiseOperation::kSUM);
   EXPECT_NE(layer, nullptr);
+  auto output = layer->getOutput(0);
+  output->setName(kOutputTensor1);
+  network->markOutput(*output);
 
+#ifdef TF_TRT_USE_EFFICIENT_NMS_PLUGIN
   // Add an efficient nms plugin.
   ScopedShapedWeights boxes_weights(nvinfer1::Dims3(1, 10, 4), 0.0f);
   ScopedShapedWeights scores_weights(nvinfer1::Dims3(1, 10, 10), 0.0f);
@@ -133,17 +143,18 @@ TrtUniquePtrType<nvinfer1::IHostMemory> CreateSerializedEngine() {
 
   std::array<nvinfer1::ITensor*, 2> nms_inputs = {boxes->getOutput(0),
                                                   scores->getOutput(0)};
-
   auto plugin_creator = MakeNMSPluginCreator("tftrt");
   auto plugin = createPlugin("nms_plugin_instance", plugin_creator.get(), {});
   auto nms = network->addPluginV2(nms_inputs.data(), 2, *plugin);
-
-  // Mark the output.
-  auto output = layer->getOutput(0);
-  output->setName(kOutputTensor1);
-  network->markOutput(*output);
   nms->getOutput(0)->setName(kOutputTensor2);
   network->markOutput(*nms->getOutput(0));
+#else
+  auto sub_layer = network->addElementWise(
+      *input1, *input2, nvinfer1::ElementWiseOperation::kSUB);
+  EXPECT_NE(sub_layer, nullptr);
+  network->markOutput(*sub_layer->getOutput(0));
+  sub_layer->getOutput(0)->setName(kOutputTensor2);
+#endif
 
   // Build the engine.
   builder->setMaxBatchSize(1);
@@ -224,8 +235,10 @@ void Execute(nvinfer1::IExecutionContext* context, const float* input1,
 
 TEST(TensorrtTest, BasicFunctions) {
   // We must register the plugin creator in order to deserialize the plugin.
+#ifdef TF_TRT_USE_EFFICIENT_NMS_PLUGIN
   auto plugin_creator = MakeNMSPluginCreator("tftrt");
   getPluginRegistry()->registerCreator(*plugin_creator, "tftrt");
+#endif
 
   // Handle the case where the test is run on machine with no gpu available.
   if (CHECK_NOTNULL(GPUMachineManager())->VisibleDeviceCount() <= 0) {
@@ -248,15 +261,24 @@ TEST(TensorrtTest, BasicFunctions) {
   // Execute the network.
   float input1 = 1234;
   float input2 = 567;
+
   std::vector<float> output1(
       GetBindingSizeBytes<float>(*engine, 2, 1) / sizeof(float), 0.0f);
+
   std::vector<float> output2(
       GetBindingSizeBytes<int32>(*engine, 3, 1) / sizeof(int32), 0.0f);
+
   ASSERT_EQ(output1.size(), 1);
   ASSERT_EQ(output2.size(), 1);
+
   Execute(context.get(), &input1, &input2, output1.data(), output2.data());
   EXPECT_EQ(output1[0], input1 + input2);
+
+#ifdef TF_TRT_USE_EFFICIENT_NMS_PLUGIN
   EXPECT_EQ(output2[0], 0);
+#else
+  EXPECT_EQ(output2[0], 667);
+#endif  // TF_TRT_USE_EFFICIENT_NMS_PLUGIN
 }
 
 }  // namespace tensorrt

--- a/third_party/tensorrt/BUILD.tpl
+++ b/third_party/tensorrt/BUILD.tpl
@@ -15,12 +15,6 @@ config_setting(
     define_values = {"TF_TENSORRT_STATIC":"1"},
 )
 
-# Use the tensorrt plugin open source.
-config_setting(
-    name = "use_efficient_nms_plugin",
-    define_values = {"use_efficient_nms_plugin": "1"},
-)
-
 cc_library(
     name = "tensorrt_headers",
     hdrs = [


### PR DESCRIPTION
Directly referring to `//third_party/tensorrt/plugins/...` in the OSS build does not work as the archive must be downloaded. So we should refer to the `@tensorrt_oss_archive//` repository to find these targets. A previous commit attempted to add an option `use_efficient_nms_plugin` for turning off/on the use of a plugin in `@tensorrt_oss_archive`, but made the mistake above. This change fixes the issue. It moves the `config_setting` to the TFTRT `BUILD` file. It also updates the `tensorrt_cc_test` test which uses the plugin (a change made when we first introduced TRT OSS archive). Tested with and without `--define=use_efficient_nms_plugin=1`.