### PR TITLE
ci_build: update check_system_libs for numbered workspace files

### DIFF
--- a/tensorflow/tools/ci_build/builds/check_system_libs.py
+++ b/tensorflow/tools/ci_build/builds/check_system_libs.py
@@ -26,12 +26,13 @@ tf_source_path = sys.argv[1]
 
 syslibs_configure_path = os.path.join(tf_source_path, 'third_party',
                                       'systemlibs', 'syslibs_configure.bzl')
-workspace_path = os.path.join(tf_source_path, 'tensorflow', 'workspace.bzl')
+workspace0_path = os.path.join(tf_source_path, 'tensorflow', 'workspace0.bzl')
+workspace_glob = os.path.join(tf_source_path, 'tensorflow', 'workspace*.bzl')
 third_party_path = os.path.join(tf_source_path, 'third_party')
 third_party_glob = os.path.join(third_party_path, '*', 'workspace.bzl')
 
 if not (os.path.isdir(tf_source_path) and os.path.isfile(syslibs_configure_path)
-        and os.path.isfile(workspace_path)):
+        and os.path.isfile(workspace0_path)):
   raise ValueError('The path to the TensorFlow source must be passed as'
                    ' the first argument')
 
@@ -75,7 +76,7 @@ syslibs = extract_valid_libs(syslibs_configure_path)
 
 syslibs_from_workspace = set()
 system_build_files_from_workspace = []
-for current_path in [workspace_path] + glob.glob(third_party_glob):
+for current_path in glob.glob(workspace_glob) + glob.glob(third_party_glob):
   cur_lib_names, build_files = extract_system_builds(current_path)
   syslibs_from_workspace.update(cur_lib_names)
   system_build_files_from_workspace.extend(build_files)


### PR DESCRIPTION
This script was not updated when the workspace files were numbered, noticed it when unbundling some more libraries.

Re-ran against latest main branch and it all passes correctly now