### PR TITLE
[ROCm] Enable unique_op for ROCm

### DIFF
--- a/tensorflow/core/kernels/unique_op_gpu.cu.h
+++ b/tensorflow/core/kernels/unique_op_gpu.cu.h
@@ -332,11 +332,7 @@ class UniqueOpGPU : public AsyncOpKernel {
       const GPUDevice& device = context->eigen_gpu_device();
       int64 uniq_size = (*last_idx_host.data()) + 1;
 
-#if GOOGLE_CUDA
-      se::cuda::ScopedActivateExecutorContext scoped_activation{
-#else
       se::gpu::ScopedActivateExecutorContext scoped_activation{
-#endif
           context->op_device_context()->stream()->parent()};
 
       Tensor unique_input_inds;

--- a/tensorflow/core/kernels/unique_op_gpu.cu.h
+++ b/tensorflow/core/kernels/unique_op_gpu.cu.h
@@ -292,9 +292,10 @@ class UniqueOpGPU : public AsyncOpKernel {
     using namespace unique_op_gpu;
 
     // Create a fancy input iterator to indicate segment boundaries.
+    gpuprim::CountingInputIterator<TIndex> counting_iter(0);
     gpuprim::TransformInputIterator<TIndex, SegmentIndicatorFunctor<T, TIndex>,
                                     gpuprim::CountingInputIterator<TIndex>>
-        segment_indicator_iter(0, {sorted_input_ptr});
+        segment_indicator_iter(counting_iter, {sorted_input_ptr});
 
     Tensor sorted_input_unique_ids;
     TIndex* sorted_input_unique_ids_ptr = nullptr;
@@ -331,7 +332,11 @@ class UniqueOpGPU : public AsyncOpKernel {
       const GPUDevice& device = context->eigen_gpu_device();
       int64 uniq_size = (*last_idx_host.data()) + 1;
 
+#if GOOGLE_CUDA
       se::cuda::ScopedActivateExecutorContext scoped_activation{
+#else
+      se::gpu::ScopedActivateExecutorContext scoped_activation{
+#endif
           context->op_device_context()->stream()->parent()};
 
       Tensor unique_input_inds;

--- a/tensorflow/core/kernels/unique_op_gpu_2.cu.cc
+++ b/tensorflow/core/kernels/unique_op_gpu_2.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/unique_op_gpu.cu.h"

--- a/tensorflow/core/kernels/unique_op_gpu_3.cu.cc
+++ b/tensorflow/core/kernels/unique_op_gpu_3.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/unique_op_gpu.cu.h"
@@ -40,4 +40,4 @@ REGISTER_UNIQUE_GPU(bool);
 
 }  // end namespace tensorflow
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
This PR enables the unique_op_gpu (int32 and int64) for ROCM on AMD GPUs.

@cheshire @chsigg @deven-amd