### PR TITLE
Typo fix

### DIFF
--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -96,7 +96,7 @@ extern "C" {
 
 // --------------------------------------------------------------------------
 // TF_Version returns a string describing version information of the
-// TensorFlow library. TensorFlow using semantic versioning.
+// TensorFlow library. TensorFlow uses semantic versioning.
 TF_CAPI_EXPORT extern const char* TF_Version(void);
 
 // --------------------------------------------------------------------------

--- a/tensorflow/c/c_api.h
+++ b/tensorflow/c/c_api.h
@@ -177,7 +177,7 @@ typedef struct TF_Graph TF_Graph;
 // Return a new graph object.
 TF_CAPI_EXPORT extern TF_Graph* TF_NewGraph(void);
 
-// Destroy an options object.  Graph will be deleted once no more
+// Destroy an options object. Graph will be deleted once no more
 // TFSession's are referencing it.
 TF_CAPI_EXPORT extern void TF_DeleteGraph(TF_Graph*);
 


### PR DESCRIPTION
Shouldn't it be "TensorFlow *uses* semantic versioning", not "TensorFlow *using*"?