### PR TITLE
[ROCm] Enable lu_op for ROCm

### DIFF
--- a/tensorflow/core/kernels/linalg/BUILD
+++ b/tensorflow/core/kernels/linalg/BUILD
@@ -274,9 +274,12 @@ tf_kernel_library(
 tf_kernel_library(
     name = "lu_op",
     prefix = "lu_op",
-    deps = if_cuda([
-        "//tensorflow/core/util:cuda_solvers",
+    deps = if_cuda_or_rocm([
         "//tensorflow/core/kernels:transpose_functor",
+    ]) + if_cuda([
+        "//tensorflow/core/util:cuda_solvers",
+    ]) + if_rocm([
+        "//tensorflow/core/util:rocm_solvers",
     ]) + [
         "//third_party/eigen3",
         "//tensorflow/core:framework",

--- a/tensorflow/core/kernels/linalg/lu_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/linalg/lu_op_gpu.cu.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #define EIGEN_USE_GPU
 
 #include <algorithm>
@@ -182,9 +182,15 @@ class LuOpGpu : public AsyncOpKernel {
       auto packed_triangular_factors_ptrs = solver->GetScratchSpace<uint8>(
           sizeof(Scalar*) * batch_size, "packed_triangular_factors_ptrs",
           /* on_host */ true);
+#if GOOGLE_CUDA
       const Scalar** packed_triangular_factors_ptrs_base =
           reinterpret_cast<const Scalar**>(
               packed_triangular_factors_ptrs.mutable_data());
+#else //TENSORFLOW_USE_ROCM
+      Scalar** packed_triangular_factors_ptrs_base =
+          reinterpret_cast<Scalar**>(
+              packed_triangular_factors_ptrs.mutable_data());
+#endif
       for (int batch = 0; batch < batch_size; ++batch) {
         packed_triangular_factors_ptrs_base[batch] =
             &packed_triangular_factors_transpose_reshaped(batch, 0, 0);


### PR DESCRIPTION
Enable/fix the lu_op for ROCm on AMD GPUs.
GetrfBatched on ROCm uses Scalar ** vs const Scalar ** for the packed_triangular_factors_ptrs_base parameter.

@cheshire @chsigg @deven-amd @stevenireeves @micmelesse 