### PR TITLE
Add float16 support for tf.sparse.softmax

### DIFF
--- a/tensorflow/core/kernels/sparse_softmax_op.cc
+++ b/tensorflow/core/kernels/sparse_softmax_op.cc
@@ -126,6 +126,7 @@ class SparseSoftmaxOp : public OpKernel {
       Name("SparseSoftmax").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
       SparseSoftmaxOp<CPUDevice, T>)
 
+REGISTER_KERNEL(Eigen::half);
 REGISTER_KERNEL(float);
 REGISTER_KERNEL(double);
 #undef REGISTER_KERNEL

--- a/tensorflow/core/ops/sparse_ops.cc
+++ b/tensorflow/core/ops/sparse_ops.cc
@@ -507,7 +507,7 @@ REGISTER_OP("SparseSoftmax")
     .Input("sp_values: T")
     .Input("sp_shape: int64")
     .Output("output: T")
-    .Attr("T: {float, double}")
+    .Attr("T: {half, float, double}")
     .SetShapeFn([](InferenceContext* c) {
       ShapeHandle unused;
       ShapeHandle values;

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_ops_test.py
@@ -987,7 +987,7 @@ class SparseSoftmaxTest(test_util.TensorFlowTestCase):
     np.random.seed(1618)
     n, m = np.random.choice(20, size=2)
 
-    for dtype in [np.float32, np.float64]:
+    for dtype in [np.float16, np.float32, np.float64]:
       sp_vals_np = np.random.rand(n, m).astype(dtype)
 
       batched_sp_t, unused_nnz1 = _sparsify(

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_ops_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_ops_test.py
@@ -1000,7 +1000,7 @@ class SparseSoftmaxTest(test_util.TensorFlowTestCase):
             sparse_ops.sparse_softmax(batched_sp_t)).values.reshape((n, m))
         dense_result = nn_ops.softmax(densified)
 
-        self.assertAllClose(dense_result, sp_result)
+        self.assertAllCloseAccordingToType(dense_result, sp_result)
 
   def testHigherRanks(self):
     # For the first shape:


### PR DESCRIPTION
This PR tries to address the issue raised in #53657 where float16 was not supported for tf.sparse.softmax, while the counterpart of tf.nn.softmax has the float16 support.
This PR adds float16 support.

This PR fixes #53657.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>