### PR TITLE
#undef some macros with generic names to prevent -Wmacro-redefined from being triggered

### DIFF
--- a/tensorflow/tsl/platform/default/logging.h
+++ b/tensorflow/tsl/platform/default/logging.h
@@ -40,6 +40,29 @@ limitations under the License.
 // TODO(mrry): Prevent this Windows.h #define from leaking out of our headers.
 #undef ERROR
 
+// Undef everything in case we're being mixed with some other Google library
+// which already defined them itself.  Presumably all Google libraries will
+// support the same syntax for these so it should not be a big deal if they
+// end up using our definitions instead.
+#undef LOG
+#undef VLOG
+
+#undef CHECK
+#undef CHECK_EQ
+#undef CHECK_NE
+#undef CHECK_LT
+#undef CHECK_LE
+#undef CHECK_GT
+#undef CHECK_GE
+
+#undef DCHECK
+#undef DCHECK_EQ
+#undef DCHECK_NE
+#undef DCHECK_LT
+#undef DCHECK_LE
+#undef DCHECK_GT
+#undef DCHECK_GE
+
 namespace tsl {
 const int INFO = 0;            // base_logging::INFO;
 const int WARNING = 1;         // base_logging::WARNING;


### PR DESCRIPTION
As tensorflow and openfst originate from Google internal codebase, they are using the same macros to implement logging.

This causes `-Wmacro-redefined` when both `fst/log.h` and `tensorflow/core/platform/logging.h` are included.

This PR backports the #undef series from protobuf (the number of macros and their names differ).
It could be better to rename these macros instead (i. e. TF_LOG / FST_LOG / PB_LOG), but I am quite unsure whether such rename would cause any troubles during sync.