### PR TITLE
[TF:TRT] Fix the AlgorithmSelector

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -603,6 +603,29 @@ tf_cuda_cc_test(
     ],
 )
 
+tf_cuda_library(
+    name = "algorithm_selector",
+    srcs = [
+        "convert/algorithm_selector.cc",
+    ],
+    hdrs = [
+        "convert/algorithm_selector.h",
+    ],
+    deps = [":common_utils"] + if_tensorrt([":tensorrt_lib"]),
+)
+
+tf_cuda_cc_test(
+    name = "algorithm_selector_test",
+    srcs = [
+        "convert/algorithm_selector_test.cc",
+    ],
+    deps = [
+        ":algorithm_selector",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+    ] + if_tensorrt([":tensorrt_lib"]),
+)
+
 # Library for the node-level conversion portion of TensorRT operation creation
 tf_cuda_library(
     name = "trt_conversion",
@@ -629,6 +652,7 @@ tf_cuda_library(
         "//conditions:default": [],
     }),
     deps = [
+        ":algorithm_selector",
         ":common_utils",
         ":logger_registry",
         ":segment",

--- a/tensorflow/compiler/tf2tensorrt/common/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.cc
@@ -138,4 +138,89 @@ void MaybeInitializeTrtPlugins(nvinfer1::ILogger* trt_logger) {
 
 }  // namespace tensorrt
 }  // namespace tensorflow
+
+namespace nvinfer1 {
+std::ostream& operator<<(std::ostream& os,
+                         const nvinfer1::TensorFormat& format) {
+  os << "nvinfer1::TensorFormat::";
+  switch (format) {
+    case nvinfer1::TensorFormat::kLINEAR:
+      os << "kLINEAR";
+      break;
+
+    case nvinfer1::TensorFormat::kCHW2:
+      os << "kCHW2";
+      break;
+
+    case nvinfer1::TensorFormat::kHWC8:
+      os << "kHWC8";
+      break;
+
+    case nvinfer1::TensorFormat::kCHW4:
+      os << "kCHW4";
+      break;
+
+    case nvinfer1::TensorFormat::kCHW16:
+      os << "kCHW16";
+      break;
+
+    case nvinfer1::TensorFormat::kCHW32:
+      os << "kCHW32";
+      break;
+
+#if IS_TRT_VERSION_GE(8, 0, 0, 0)
+    case nvinfer1::TensorFormat::kDHWC8:
+      os << "kDHWC8";
+      break;
+
+    case nvinfer1::TensorFormat::kCDHW32:
+      os << "kCDHW32";
+      break;
+
+    case nvinfer1::TensorFormat::kHWC:
+      os << "kHWC";
+      break;
+
+    case nvinfer1::TensorFormat::kDLA_LINEAR:
+      os << "kDLA_LINEAR";
+      break;
+
+    case nvinfer1::TensorFormat::kDLA_HWC4:
+      os << "kDLA_HWC4";
+      break;
+
+    case nvinfer1::TensorFormat::kHWC16:
+      os << "kHWC16";
+      break;
+#endif
+
+    default:
+      os << "unknown format";
+  };
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const nvinfer1::DataType& v) {
+  os << "nvinfer1::DataType::";
+  switch (v) {
+    case nvinfer1::DataType::kFLOAT:
+      os << "kFLOAT";
+      break;
+    case nvinfer1::DataType::kHALF:
+      os << "kHalf";
+      break;
+    case nvinfer1::DataType::kINT8:
+      os << "kINT8";
+      break;
+    case nvinfer1::DataType::kINT32:
+      os << "kINT32";
+      break;
+    case nvinfer1::DataType::kBOOL:
+      os << "kBOOL";
+      break;
+  };
+  return os;
+}
+}  // namespace nvinfer1
+
 #endif

--- a/tensorflow/compiler/tf2tensorrt/common/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.h
@@ -165,6 +165,13 @@ inline std::ostream& operator<<(std::ostream& os,
   return os;
 }
 
+// Prints the TensorFormat enum name to the stream.
+std::ostream& operator<<(std::ostream& os,
+                         const nvinfer1::TensorFormat& format);
+
+// Prints the DataType enum name to the stream.
+std::ostream& operator<<(std::ostream& os, const nvinfer1::DataType& data_type);
+
 }  // namespace nvinfer1
 
 #endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/algorithm_selector.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/algorithm_selector.cc
@@ -1,0 +1,272 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+#include "tensorflow/compiler/tf2tensorrt/convert/algorithm_selector.h"
+
+#include <utility>
+
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/core/util/env_var.h"
+#include "third_party/tensorrt/NvInfer.h"
+
+// getAlgorithmIOInfo is deprecated in TRT >= 8, replaced by
+// getAlgorithmIOInfoByIndex.
+#if IS_TRT_VERSION_GE(8, 0, 0, 0)
+#define ALGORITHM_IO_INFO_BY_IDX(alg, idx) *(alg).getAlgorithmIOInfoByIndex(idx)
+#else
+#define ALGORITHM_IO_INFO_BY_IDX(alg, idx) (alg).getAlgorithmIOInfo(idx)
+#endif
+
+namespace nvinfer1 {
+
+std::ostream& operator<<(std::ostream& os,
+                         const nvinfer1::IAlgorithmContext& ctx) {
+  os << "AlgorithmContext(name=" << ctx.getName()
+     << ",nbInputs=" << ctx.getNbInputs() << ",nbOutputs=" << ctx.getNbOutputs()
+     << ")";
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const nvinfer1::IAlgorithm& alg) {
+  const nvinfer1::IAlgorithmVariant& variant = alg.getAlgorithmVariant();
+  os << "Algorithm("
+     << "variant.implementation=" << variant.getImplementation()
+     << ",variant.tactic=" << variant.getTactic()
+     << ",timingMSec=" << alg.getTimingMSec()
+     << ",workspaceSize=" << alg.getWorkspaceSize() << ")";
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const nvinfer1::IAlgorithmIOInfo& info) {
+  os << "IOTensor(format=" << info.getTensorFormat()
+     << ",dtype=" << info.getDataType() << ",strides=" << info.getStrides()
+     << ")";
+  return os;
+}
+}  // namespace nvinfer1
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+bool operator>=(const AlgorithmSelectorImpl::TRTVersion& lhs,
+                const AlgorithmSelectorImpl::TRTVersion& rhs) {
+  if (lhs[0] > rhs[0]) return true;
+  if (lhs[0] == rhs[0] && lhs[1] > rhs[1]) return true;
+  if (lhs[0] == rhs[0] && lhs[1] == rhs[1] && lhs[2] > rhs[2]) return true;
+  if (lhs[0] == rhs[0] && lhs[1] == rhs[1] && lhs[2] == rhs[2] &&
+      lhs[3] >= rhs[3]) {
+    return true;
+  }
+  return false;
+}
+
+bool AlgorithmSelectorImpl::IsTrtVersionGE(const TRTVersion& version) const {
+  return version_ >= version;
+}
+
+bool AlgorithmSelectorImpl::IsShuffleLayer(ImplementationID id) const {
+  if (IsTrtVersionGE({8, 2, 0, 0})) {
+    return id == 0x80000000 + 13;
+  }
+  if (IsTrtVersionGE({8, 0, 0, 0})) {
+    return id == 0x80000000 + 14;
+  }
+  if (IsTrtVersionGE({7, 2, 0, 0})) {
+    return id == 0x80000000 + 16;
+  }
+  return id == 18;
+}
+
+std::set<AlgorithmSelectorImpl::TacticID>
+AlgorithmSelectorImpl::GetBannedTRT72TuringTactics() {
+  static const std::set<TacticID> banned_turing_72{
+      // turing_fp16_s1688cudnn_fp16_128x128_ldg8_relu_f2f_exp_medium_nhwc_gelu_tn_v1
+      -5927686925093575778,
+      // turing_fp16_s1688cudnn_fp16_128x128_ldg8_relu_f2f_exp_interior_nhwc_gelu_tn_v1
+      -3848538574386518527,
+      // turing_fp16_s1688cudnn_fp16_128x128_ldg8_relu_f2f_exp_small_nhwc_gelu_tn_v1
+      -959009792490796596};
+  return banned_turing_72;
+}
+
+bool AlgorithmSelectorImpl::IsBannedTactic(TacticID id) const {
+  // Disable problematic FP16-Turing tactics in TensorRT 7.2.
+  if (IsTrtVersionGE({7, 2, 0, 0}) && !IsTrtVersionGE({8, 0, 0, 0})) {
+    auto banned_turing_72 = GetBannedTRT72TuringTactics();
+    return banned_turing_72.find(id) != banned_turing_72.end();
+  }
+  return false;
+}
+
+bool AlgorithmSelectorImpl::AllowShuffleAlgorithm(
+    TacticID tactic, nvinfer1::DataType input_dtype,
+    nvinfer1::TensorFormat input_format) const {
+  if (IsTrtVersionGE({8, 0, 0, 0}) && !IsTrtVersionGE({8, 0, 3, 0})) {
+    // Reject shuffle node when input format is linear row major INT8
+    // format in TensorRT 8.0 GA.
+    return !(input_format == nvinfer1::TensorFormat::kLINEAR &&
+             input_dtype == nvinfer1::DataType::kINT8);
+  }
+
+  if (IsTrtVersionGE({7, 2, 0, 0}) && !IsTrtVersionGE({8, 0, 0, 0})) {
+    // For TRT 7.2, accept shuffle node when input format is not 32-wide
+    // channel vectorized row major FP32 format
+    return !(input_format == nvinfer1::TensorFormat::kCHW32 &&
+             input_dtype == nvinfer1::DataType::kFLOAT);
+  }
+  return true;
+}
+
+bool AlgorithmSelectorImpl::IsAlgorithmSelectorRequired() const {
+  // If we are in turing for TensorRT 7.2, we need the  selector for shuffle and
+  // avoiding specfic Turing tactics.
+  if (IsTrtVersionGE({7, 2, 0, 0}) && !IsTrtVersionGE({8, 0, 0, 0})) {
+    return true;
+  }
+
+  // If we are in TensorRT 8.0 GA, we want to reject certain types of shuffles.
+  if (IsTrtVersionGE({8, 0, 0, 0}) && !IsTrtVersionGE({8, 0, 3, 0})) {
+    return true;
+  }
+
+  return false;
+}
+
+namespace {
+
+string FormatAlgorithmList(const nvinfer1::IAlgorithmContext& ctx,
+                           absl::Span<const nvinfer1::IAlgorithm* const> algs) {
+  return absl::StrFormat(
+      "%s:\n\t%s", absl::FormatStreamed(ctx),
+      absl::StrJoin(
+          algs, "\n\t",
+          [&ctx](std::string* out, const nvinfer1::IAlgorithm* const alg) {
+            absl::StrAppendFormat(out, "%s", absl::FormatStreamed(*alg));
+            for (int i = 0; i < ctx.getNbInputs() + ctx.getNbOutputs(); i++) {
+              absl::StrAppendFormat(
+                  out, "\n\t\t%s",
+                  absl::FormatStreamed(ALGORITHM_IO_INFO_BY_IDX(*alg, i)));
+            }
+          }));
+}
+
+}  // namespace
+
+TftrtAlgorithmSelector::TftrtAlgorithmSelector()
+    : fixed_algorithm_idx_(GetFixedAlgorithmID()),
+      selector_(AlgorithmSelectorImpl::CompileTimeTRTVersion()) {}
+
+absl::optional<int64_t> TftrtAlgorithmSelector::GetFixedAlgorithmID() {
+  int64_t trt_algorithm_idx = 0;
+  constexpr auto null_idx =
+      std::numeric_limits<decltype(trt_algorithm_idx)>::min();
+  Status status = tensorflow::ReadInt64FromEnvVar("TF_TRT_FIXED_ALGORITHM_ID",
+                                                  /*default_val=*/null_idx,
+                                                  &trt_algorithm_idx);
+  if (!status.ok()) {
+    LOG(ERROR) << status;
+    return absl::nullopt;
+  }
+  if (trt_algorithm_idx != null_idx) {
+    return std::max(static_cast<int32_t>(trt_algorithm_idx), 0);
+  }
+  return absl::nullopt;
+}
+
+bool TftrtAlgorithmSelector::AlgorithmPolicy(
+    const nvinfer1::IAlgorithmContext& context,
+    const nvinfer1::IAlgorithm& alg) const {
+  const nvinfer1::IAlgorithmVariant& variant = alg.getAlgorithmVariant();
+
+  // Check if this tactic ID is banned.
+  TacticID tactic_id = variant.getTactic();
+  if (selector_.IsBannedTactic(tactic_id)) {
+    return false;
+  }
+
+  if (selector_.IsShuffleLayer(variant.getImplementation())) {
+    return selector_.AllowShuffleAlgorithm(
+        tactic_id, alg.getAlgorithmIOInfo(0).getDataType(),
+        alg.getAlgorithmIOInfo(0).getTensorFormat());
+  }
+  return true;
+}
+
+int32_t TftrtAlgorithmSelector::selectAlgorithms(
+    const nvinfer1::IAlgorithmContext& algoContext,
+    const nvinfer1::IAlgorithm* const* algoChoices, int32_t nbChoices,
+    int32_t* selection) noexcept {
+  if (fixed_algorithm_idx_) {
+    LOG(WARNING) << "Forcing TRT algorithm selection to: ID = "
+                 << *fixed_algorithm_idx_;
+    selection[0] = std::min(*fixed_algorithm_idx_, nbChoices - 1);
+    return 1;
+  }
+
+  int num_selections = 0;
+
+  VLOG(1) << "Algorithm selection choices: "
+          << FormatAlgorithmList(algoContext,
+                                 absl::MakeSpan(algoChoices, nbChoices));
+
+  for (int i = 0; i < nbChoices; i++) {
+    const nvinfer1::IAlgorithm& alg = *algoChoices[i];
+
+    // Check layer-specific issues.
+    if (!AlgorithmPolicy(algoContext, alg)) {
+      LOG(WARNING) << absl::StrFormat("Rejecting Algorithm: %s ",
+                                      absl::FormatStreamed(alg));
+      continue;
+    }
+    selection[num_selections++] = i;
+  }
+  return num_selections;
+}
+
+// Called by TensorRT to report choices it made.
+void TftrtAlgorithmSelector::reportAlgorithms(
+    const nvinfer1::IAlgorithmContext* const* algoContexts,
+    const nvinfer1::IAlgorithm* const* algoChoices,
+    int32_t nbAlgorithms) noexcept {
+  if (VLOG_IS_ON(1)) {
+    string selection_msg = "Algorithms selected:\n";
+    for (int i = 0; i < nbAlgorithms; i++) {
+      absl::StrAppend(&selection_msg,
+                      FormatAlgorithmList(*algoContexts[i],
+                                          absl::MakeSpan(algoChoices + i, 1)));
+    }
+    VLOG(1) << selection_msg;
+  }
+}
+
+std::unique_ptr<TftrtAlgorithmSelector> MaybeCreateAlgorithmSelector() {
+  auto selector = std::make_unique<TftrtAlgorithmSelector>();
+
+  if (selector->IsRequired()) {
+    return selector;
+  }
+
+  return nullptr;
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/algorithm_selector.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/algorithm_selector.h
@@ -1,0 +1,121 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_ALGORITHM_SELECTOR_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_ALGORITHM_SELECTOR_H_
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+#include <array>
+#include <memory>
+#include <set>
+
+#include "absl/types/optional.h"
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+// Implements core algorithm selection logic in a testable manner. The policy
+// implemented depends on the given TRT version. We have this class because TRT
+// interfaces make it difficult to directly test an IAlgorithmSelector
+// implementation.
+class AlgorithmSelectorImpl {
+ public:
+  using TRTVersion = std::array<int, 4>;
+  using ImplementationID = int64_t;
+  using TacticID = int64_t;
+
+  static constexpr TRTVersion CompileTimeTRTVersion() {
+    return TRTVersion{NV_TENSORRT_MAJOR, NV_TENSORRT_MINOR, NV_TENSORRT_PATCH,
+                      NV_TENSORRT_BUILD};
+  }
+
+  explicit AlgorithmSelectorImpl(
+      const TRTVersion& version = CompileTimeTRTVersion())
+      : version_(version) {}
+
+  bool IsShuffleLayer(ImplementationID id) const;
+
+  bool IsBannedTactic(TacticID id) const;
+
+  // Returns true if the algorithm implementing the IShuffleLayer is acceptable.
+  bool AllowShuffleAlgorithm(TacticID tactic, nvinfer1::DataType input_dtype,
+                             nvinfer1::TensorFormat input_format) const;
+
+  bool IsTrtVersionGE(const TRTVersion& version) const;
+
+  // Returns true if we know at compile time that the the algorithm selector
+  // should be required. This is a conservative estimate.
+  bool IsAlgorithmSelectorRequired() const;
+
+  static std::set<TacticID> GetBannedTRT72TuringTactics();
+
+ private:
+  TRTVersion version_;
+};
+
+// Impelements the TRT IAlgorithmSelector interface. The method
+// "selectAlgorithms" selects allowable algorithms for each layer, and
+// "reportAlgorithms" summarizes the algorithms selected by TensorRT.
+class TftrtAlgorithmSelector : public nvinfer1::IAlgorithmSelector {
+ private:
+  using TacticID = AlgorithmSelectorImpl::TacticID;
+
+  // An index we should choose for all algorithms. Used for debugging.
+  absl::optional<int32_t> fixed_algorithm_idx_;
+
+  AlgorithmSelectorImpl selector_;
+
+ public:
+  TftrtAlgorithmSelector();
+
+  // If the environment variable TF_TRT_FIXED_ALGORITHM_ID is empty, this
+  // function returns nullopt. Otherwise, it returns the specified number.
+  static absl::optional<int64_t> GetFixedAlgorithmID();
+
+  // Returns true if the algorithm associated with context is acceptable.
+  bool AlgorithmPolicy(const nvinfer1::IAlgorithmContext& context,
+                       const nvinfer1::IAlgorithm& alg) const;
+
+  // This function fills the array "selection" with the indices of selected
+  // algorithm candidates from "algoChoices", each of which is an implementation
+  // for the kernel described by the given IAlgorithmContext. It should return a
+  // number in [0, nbChoices] indicating the number of selected indices. If 0 is
+  // returned, TensorRT will use its default selection mechanism.
+  int32_t selectAlgorithms(const nvinfer1::IAlgorithmContext& algoContext,
+                           const nvinfer1::IAlgorithm* const* algoChoices,
+                           int32_t nbChoices,
+                           int32_t* selection) noexcept override;
+
+  // Called by TensorRT to report choices it made.
+  void reportAlgorithms(const nvinfer1::IAlgorithmContext* const* algoContexts,
+                        const nvinfer1::IAlgorithm* const* algoChoices,
+                        int32_t nbAlgorithms) noexcept override;
+
+  bool IsRequired() const {
+    return selector_.IsAlgorithmSelectorRequired() ||
+           fixed_algorithm_idx_ != absl::nullopt;
+  }
+};
+
+// Returns an initialized AlgorithmSelector if an algorithm selector is required
+// for the current TRT version. Otherwise, returns nullptr.
+std::unique_ptr<TftrtAlgorithmSelector> MaybeCreateAlgorithmSelector();
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_ALGORITHM_SELECTOR_H_

--- a/tensorflow/compiler/tf2tensorrt/convert/algorithm_selector_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/algorithm_selector_test.cc
@@ -1,0 +1,98 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include "tensorflow/compiler/tf2tensorrt/convert/algorithm_selector.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+TEST(TestAlgorithmSelector, TensorRT7_1) {
+  // Verify that the algorithm selector for TRT 7.1 is not required.
+  AlgorithmSelectorImpl sel71({7, 1, 3, 4});
+  ASSERT_FALSE(sel71.IsAlgorithmSelectorRequired());
+}
+
+TEST(TestAlgorithmSelector, TensorRT7_2) {
+  // Verify that the algorithm selector for TRT 7.2 is required.
+  AlgorithmSelectorImpl sel72({7, 2, 0, 0});
+  ASSERT_TRUE(sel72.IsAlgorithmSelectorRequired());
+
+  // Check that the correct tactics are banned.
+  auto turing_tactics = AlgorithmSelectorImpl::GetBannedTRT72TuringTactics();
+
+  for (auto id : turing_tactics) {
+    EXPECT_TRUE(sel72.IsBannedTactic(id));
+  }
+
+  // Check that a bad shuffle format is banned.
+  EXPECT_FALSE(sel72.AllowShuffleAlgorithm(0, nvinfer1::DataType::kFLOAT,
+                                           nvinfer1::TensorFormat::kCHW32));
+
+  // Check that other formats are not banned.
+  EXPECT_TRUE(sel72.AllowShuffleAlgorithm(0, nvinfer1::DataType::kHALF,
+                                          nvinfer1::TensorFormat::kCHW32));
+  EXPECT_TRUE(sel72.AllowShuffleAlgorithm(0, nvinfer1::DataType::kINT32,
+                                          nvinfer1::TensorFormat::kCHW32));
+  EXPECT_TRUE(sel72.AllowShuffleAlgorithm(0, nvinfer1::DataType::kFLOAT,
+                                          nvinfer1::TensorFormat::kCHW16));
+}
+
+TEST(TestAlgorithmSelector, TensorRT8_0) {
+  // Verify that the algorithm selector for TRT 8.0 is required.
+  AlgorithmSelectorImpl sel80({8, 0, 1, 6});
+  ASSERT_TRUE(sel80.IsAlgorithmSelectorRequired());
+
+  // Check that the turing 7.2 tactics are not banned.
+  auto turing_tactics = AlgorithmSelectorImpl::GetBannedTRT72TuringTactics();
+  for (auto id : turing_tactics) {
+    EXPECT_FALSE(sel80.IsBannedTactic(id));
+  }
+
+  // Check that a bad shuffle format is banned.
+  EXPECT_FALSE(sel80.AllowShuffleAlgorithm(0, nvinfer1::DataType::kINT8,
+                                           nvinfer1::TensorFormat::kLINEAR));
+
+  // Check that other formats are not banned.
+  EXPECT_TRUE(sel80.AllowShuffleAlgorithm(0, nvinfer1::DataType::kHALF,
+                                          nvinfer1::TensorFormat::kLINEAR));
+  EXPECT_TRUE(sel80.AllowShuffleAlgorithm(0, nvinfer1::DataType::kINT32,
+                                          nvinfer1::TensorFormat::kLINEAR));
+  EXPECT_TRUE(sel80.AllowShuffleAlgorithm(0, nvinfer1::DataType::kFLOAT,
+                                          nvinfer1::TensorFormat::kLINEAR));
+  EXPECT_TRUE(sel80.AllowShuffleAlgorithm(0, nvinfer1::DataType::kINT8,
+                                          nvinfer1::TensorFormat::kCHW16));
+  EXPECT_TRUE(sel80.AllowShuffleAlgorithm(0, nvinfer1::DataType::kINT8,
+                                          nvinfer1::TensorFormat::kCHW32));
+}
+
+TEST(TestAlgorithmSelector, TensorRT8_2) {
+  // Verify that the algorithm selector for TRT 8.0 is required.
+  AlgorithmSelectorImpl sel({8, 2, 0, 0});
+  ASSERT_FALSE(sel.IsAlgorithmSelectorRequired());
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/algorithm_selector.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops.h"
@@ -1128,163 +1129,6 @@ Status Converter::RenameAndMarkOutputTensors(
   return Status::OK();
 }
 
-#if IS_TRT_VERSION_GE(7, 2, 3, 4)
-enum class Tactic : int64_t { kINVALID_TACTIC = int64_t(0xD15EA5EDD15EA5ED) };
-
-#if IS_TRT_VERSION_GE(8, 0, 0, 0)
-static constexpr int32_t kLAYER_IMPL_BASE = 0x80000000;
-#else
-static constexpr int32_t kLAYER_IMPL_BASE = 0x00000000;
-#endif
-
-enum class LayerImpl : int64_t {
-#if IS_TRT_VERSION_GE(8, 0, 0, 0)
-  kSHUFFLE = kLAYER_IMPL_BASE + 14
-#else
-  kSHUFFLE = kLAYER_IMPL_BASE + 16
-#endif
-};
-
-// An algorithm selector to support debugging and work around known TensorRT
-// issues.
-class TftrtAlgorithmSelector : public nvinfer1::IAlgorithmSelector {
-  // A list of tactics allowed to be selected. An empty list means that all
-  // tactics are allowed. This list is initialized from environment variable
-  // TF_TRT_FIXED_ALGORITHM_ID.
-  std::unordered_set<int64> allowed_algorithm_ids;
-
-  // A list of tactics that we disallow. Used primarily to go around known
-  // TensorRT issues.
-  std::unordered_set<int64> disallowed_tactics;
-
- public:
-  TftrtAlgorithmSelector() {
-    int64_t trt_algorithm_id;
-    int64_t null_tactic = std::numeric_limits<int64_t>::min();
-    TF_CHECK_OK(tensorflow::ReadInt64FromEnvVar("TF_TRT_FIXED_ALGORITHM_ID",
-                                                /*default_val=*/null_tactic,
-                                                &trt_algorithm_id));
-    // Populate allowed tactics. Used to force select tactics for any layer.
-    // TODO: accepting a list from the environment variable
-    if (trt_algorithm_id != null_tactic) {
-      allowed_algorithm_ids.insert(trt_algorithm_id);
-    }
-
-#if !IS_TRT_VERSION_GE(8, 0, 0, 0)
-    disallowed_tactics = {
-        // turing_fp16_s1688cudnn_fp16_128x128_ldg8_relu_f2f_exp_medium_nhwc_gelu_tn_v1
-        -5927686925093575778,
-        // turing_fp16_s1688cudnn_fp16_128x128_ldg8_relu_f2f_exp_interior_nhwc_gelu_tn_v1
-        -3848538574386518527,
-        // turing_fp16_s1688cudnn_fp16_128x128_ldg8_relu_f2f_exp_small_nhwc_gelu_tn_v1
-        -959009792490796596};
-#endif  // !IS_TRT_VERSION_GE(8, 0, 0, 0)
-  }
-
-  // Returns value in [0, nbChoices] for a valid algorithm.
-  int32_t selectAlgorithms(const nvinfer1::IAlgorithmContext& algoContext,
-                           const nvinfer1::IAlgorithm* const* algoChoices,
-                           int32_t nbChoices,
-                           int32_t* selection) noexcept override {
-    int nbSelections = 0;
-
-    // TensorRT always provides more than zero number of algorithms
-    // in selectAlgorithms.
-    assert(nbChoices > 0);
-
-    absl::optional<int64_t> forced_algorithm_id = absl::nullopt;
-
-    if (!allowed_algorithm_ids.empty()) {
-      assert(allowed_algorithm_ids.size() == 1);
-      forced_algorithm_id = *allowed_algorithm_ids.begin(0);
-      // Making sure that the requested TRT algorithm ID doesn't go above
-      // the max value accepted.
-      int64_t allowed_algorithm_id = forced_algorithm_id.value();
-      forced_algorithm_id = std::min(forced_algorithm_id.value(),
-                                     static_cast<int64_t>(nbChoices) - 1);
-
-      if (allowed_algorithm_id != forced_algorithm_id) {
-        VLOG(1) << "User allowed algorithm ID: " << allowed_algorithm_id
-                << " is not available.";
-      }
-      VLOG(1) << "Forcing TRT algorithm selection to: ID = "
-              << forced_algorithm_id.value();
-    }
-
-    // Disable all disallowed tactics
-    for (auto i = 0; i < nbChoices; i++) {
-      if (algoChoices[i] == nullptr) {
-        continue;
-      }
-
-      if (forced_algorithm_id.has_value() && forced_algorithm_id.value() != i) {
-        continue;
-      }
-
-      int64_t tacticId = algoChoices[i]->getAlgorithmVariant().getTactic();
-      assert(tacticId != static_cast<int64_t>(Tactic::kINVALID_TACTIC));
-
-      if (disallowed_tactics.find(tacticId) != disallowed_tactics.end()) {
-        if (!forced_algorithm_id.has_value()) {
-          VLOG(1) << "Rejecting a disallowed tactic: " << tacticId
-                  << " for node " << algoContext.getName();
-          continue;
-        }
-        VLOG(1) << "Impossible to force TensorRT tactic selection. This tactic "
-                << "has been explicitly banned. Please update the value passed "
-                << "to `TF_TRT_FIXED_ALGORITHM_ID`. Received: "
-                << forced_algorithm_id.value();
-        assert(false);
-      }
-
-      int64_t implementation =
-          algoChoices[i]->getAlgorithmVariant().getImplementation();
-      nvinfer1::TensorFormat format =
-          algoChoices[i]->getAlgorithmIOInfo(0).getTensorFormat();
-      nvinfer1::DataType datatype =
-          algoChoices[i]->getAlgorithmIOInfo(0).getDataType();
-
-      bool reject_tactic = false;
-#if IS_TRT_VERSION_GE(8, 0, 0, 0) && !IS_TRT_VERSION_GE(8, 0, 3, 0)
-      // Reject shuffle node when input format is linear row major INT8 format
-      reject_tactic =
-          (implementation == static_cast<int64_t>(LayerImpl::kSHUFFLE) &&
-           (format == nvinfer1::TensorFormat::kLINEAR &&
-            datatype == nvinfer1::DataType::kINT8));
-#elif !IS_TRT_VERSION_GE(8, 0, 0, 0)
-      // Reject shuffle node when input format is 32-wide channel
-      // vectorized row major FP32 format
-      reject_tactic =
-          (implementation == static_cast<int64_t>(LayerImpl::kSHUFFLE) &&
-           (format == nvinfer1::TensorFormat::kCHW32));
-#endif  // !IS_TRT_VERSION_GE(8, 0, 0, 0)
-      if (reject_tactic) {
-        if (!forced_algorithm_id.has_value()) {
-          VLOG(1) << "Rejecting a disallowed tactic: " << tacticId
-                  << " for node " << algoContext.getName()
-                  << " with implementation " << implementation
-                  << " and input format " << static_cast<int32_t>(format);
-          continue;
-        }
-        VLOG(1) << "Impossible to force TensorRT algorithm selection. The "
-                << "forced tactic corresponds to an implementation that has "
-                << "been explicitly banned. Please update the value passed to "
-                << "`TF_TRT_FIXED_ALGORITHM_ID`. Received: "
-                << forced_algorithm_id.value();
-        assert(false);
-      }
-      selection[nbSelections++] = i;
-    }
-    return nbSelections;
-  }
-
-  // Called by TensorRT to report choices it made.
-  void reportAlgorithms(const nvinfer1::IAlgorithmContext* const* algoContexts,
-                        const nvinfer1::IAlgorithm* const* algoChoices,
-                        int32_t nbAlgorithms) noexcept override {}
-};
-#endif  // #if IS_TRT_VERSION_GE(7, 2, 3, 4)
-
 // Returns the value of TF_TRT_ABORT_CUDA_ENGINE_BUILD environment variable.
 // This variable can be used to abort CUDA engine construction, therefore it
 // provides a way to test and debug the native segment fallback of TF-TRT.
@@ -1323,11 +1167,20 @@ Status Converter::BuildCudaEngine(
       trt_builder_->createBuilderConfig());
   builder_config->setMaxWorkspaceSize(max_workspace_size_bytes);
 
-#if IS_TRT_VERSION_GE(7, 2, 3, 4)
-  std::unique_ptr<nvinfer1::IAlgorithmSelector> trt_algorithm_selector(
-      new TftrtAlgorithmSelector());
-  builder_config->setAlgorithmSelector(trt_algorithm_selector.get());
-#endif
+  // Create the algorithm selector. For TensorRT 7.1, the algorithm selector
+  // cannot be used when building with INT8 calibration.
+  std::unique_ptr<nvinfer1::IAlgorithmSelector> trt_algorithm_selector{nullptr};
+  if (!IS_TRT_VERSION_GE(7, 2, 0, 0)) {
+    if (!use_calibration_ || precision_mode_ != TrtPrecisionMode::INT8) {
+      trt_algorithm_selector = MaybeCreateAlgorithmSelector();
+    }
+  } else {
+    trt_algorithm_selector = MaybeCreateAlgorithmSelector();
+  }
+
+  if (trt_algorithm_selector != nullptr) {
+    builder_config->setAlgorithmSelector(trt_algorithm_selector.get());
+  }
 
 #if IS_TRT_VERSION_GE(8, 0, 0, 0)
   builder_config->setFlag(nvinfer1::BuilderFlag::kSPARSE_WEIGHTS);


### PR DESCRIPTION
This change allows the algorithm selection mechanism to be used in TensorRT 7.1. Previously, the code disabled the algorithm selector unless the TRT version is greater than 7.2. However, the true issue is that TRT7.1 has a bug when the algorithm selector is used in conjunction with calibration and INT8 mode.

In addition, this change cleans up the `TfTrtAlgorithmSelector` class. It removes all `assert` and `CHECK` statements and refactors the code to conform with standards in the rest of the code base. Use of the preprocessor for conditionals is reduced to only necessary cases.