### PR TITLE
Cherrypick python3.10 windows on r2.8

### DIFF
--- a/tensorflow/python/debug/cli/BUILD
+++ b/tensorflow/python/debug/cli/BUILD
@@ -208,6 +208,7 @@ py_test(
     srcs = ["readline_ui_test.py"],
     python_version = "PY3",
     srcs_version = "PY3",
+    tags = ["no_windows"],  # TODO(b/214427155)
     deps = [
         ":cli_config",
         ":debugger_cli_common",

--- a/tensorflow/tools/ci_build/release/requirements_common.txt
+++ b/tensorflow/tools/ci_build/release/requirements_common.txt
@@ -10,7 +10,7 @@ h5py ~= 3.6.0  # NOTE: Earliest version for Python 3.10
 keras_preprocessing ~= 1.1.2
 numpy ~= 1.21.4  # NOTE: Earliest version for h5py in Python 3.10
 opt_einsum ~= 3.3.0
-protobuf >= 3.17.1
+protobuf ~= 3.19.3  # NOTE: Earliest version for Python 3.10
 six ~= 1.16.0
 termcolor ~= 1.1.0
 typing_extensions ~= 3.10.0.0
@@ -29,6 +29,6 @@ tb-nightly ~= 2.8.0.a
 tf-estimator-nightly ~= 2.8.0.dev
 
 # Test dependencies
-grpcio ~= 1.38.1
+grpcio ~= 1.43.0  # NOTE: Earliest version for Python 3.10
 portpicker ~= 1.4.0
 scipy ~= 1.7.2  # NOTE: Earliest version for Python 3.10

--- a/third_party/protobuf/protobuf.patch
+++ b/third_party/protobuf/protobuf.patch
@@ -186,3 +186,16 @@ index 3530a9b37..c31fa8fcc 100644
      if (collections == NULL) {
        return false;
      }
+diff --git a/python/google/protobuf/pyext/unknown_fields.cc b/python/google/protobuf/pyext/unknown_fields.cc
+index c3679c0d3..e80a1d97a 100755
+--- a/python/google/protobuf/pyext/unknown_fields.cc
++++ b/python/google/protobuf/pyext/unknown_fields.cc
+@@ -221,7 +221,7 @@ const UnknownField* GetUnknownField(PyUnknownFieldRef* self) {
+                  "The parent message might be cleared.");
+     return NULL;
+   }
+-  ssize_t total_size = fields->field_count();
++  Py_ssize_t total_size = fields->field_count();
+   if (self->index >= total_size) {
+     PyErr_Format(PyExc_ValueError,
+                  "UnknownField does not exist. "


### PR DESCRIPTION
Cherry Picked commits for R 2.8 to resolve Python 3.10 build errors on Windows - 

1. cl/421654465 - Disable debug pyreadline test (Needs to be cherry picked) - 93d09ee4ac3a44925595884390be6eb48103e840
2. cl/421576429 - Patch Protobuf (Needs to be Cherry Picked) - abfc5731b3b98f11f1bbbcffc2be97a74628901e
3. cl/421044747 - Update grpc, protobuf in ci_build (Needs to be Cherry Picked) - 99514f053019fe06ba26cb0d3faea06eacc1a57f