### PR TITLE
systemlibs: unbundle abseil-cpp

### DIFF
--- a/third_party/absl/system.BUILD
+++ b/third_party/absl/system.BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache
+
+filegroup(
+    name = "LICENSE",
+    visibility = ["//visibility:public"],
+)
+

--- a/third_party/absl/system.absl.algorithm.BUILD
+++ b/third_party/absl/system.absl.algorithm.BUILD
@@ -1,0 +1,6 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+[cc_library(
+    name = n,
+) for n in ["algorithm", "container"]]

--- a/third_party/absl/system.absl.base.BUILD
+++ b/third_party/absl/system.absl.base.BUILD
@@ -1,0 +1,100 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+[cc_library(
+    name = n,
+) for n in [
+    "config",
+    "core_headers",
+    "base_internal",
+    "dynamic_annotations",
+    "atomic_hook",
+    "errno_saver",
+    "fast_type_id",
+    "pretty_function",
+]]
+
+cc_library(
+    name = "log_severity",
+    linkopts = ["-labsl_log_severity"],
+)
+
+cc_library(
+    name = "raw_logging_internal",
+    linkopts = ["-labsl_raw_logging_internal"],
+    visibility = [
+        "//absl:__subpackages__",
+    ],
+    deps = [
+        ":log_severity",
+    ],
+)
+
+cc_library(
+    name = "spinlock_wait",
+    linkopts = ["-labsl_spinlock_wait"],
+    visibility = [
+        "//absl/base:__pkg__",
+    ],
+)
+
+cc_library(
+    name = "malloc_internal",
+    linkopts = ["-labsl_malloc_internal", "-pthread"],
+    deps = [
+        ":base",
+        ":raw_logging_internal",
+    ],
+)
+
+cc_library(
+    name = "base",
+    linkopts = ["-labsl_base", "-pthread"],
+    deps = [
+        ":log_severity",
+        ":raw_logging_internal",
+        ":spinlock_wait",
+    ],
+)
+
+cc_library(
+    name = "throw_delegate",
+    linkopts = ["-labsl_throw_delegate"],
+    visibility = [
+        "//absl:__subpackages__",
+    ],
+    deps = [
+        ":raw_logging_internal",
+    ],
+)
+
+cc_library(
+    name = "endian",
+    deps = [
+        ":base",
+    ],
+)
+
+cc_library(
+    name = "exponential_biased",
+    linkopts = ["-labsl_exponential_biased"],
+    visibility = [
+        "//absl:__subpackages__",
+    ],
+)
+
+cc_library(
+    name = "periodic_sampler",
+    linkopts = ["-labsl_periodic_sampler"],
+    deps = [
+        ":exponential_biased",
+    ],
+)
+
+cc_library(
+    name = "strerror",
+    linkopts = ["-labsl_strerror"],
+    visibility = [
+        "//absl:__subpackages__",
+    ],
+)

--- a/third_party/absl/system.absl.cleanup.BUILD
+++ b/third_party/absl/system.absl.cleanup.BUILD
@@ -1,0 +1,6 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "cleanup",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/absl/system.absl.container.BUILD
+++ b/third_party/absl/system.absl.container.BUILD
@@ -1,0 +1,216 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "compressed_tuple",
+    deps = [
+        "//absl/utility",
+    ],
+)
+
+cc_library(
+    name = "fixed_array",
+    deps = [
+        ":compressed_tuple",
+        "//absl/algorithm",
+        "//absl/base:config",
+        "//absl/base:core_headers",
+        "//absl/base:dynamic_annotations",
+        "//absl/base:throw_delegate",
+        "//absl/memory",
+    ],
+)
+
+cc_library(
+    name = "inlined_vector_internal",
+    deps = [
+        ":compressed_tuple",
+        "//absl/base:core_headers",
+        "//absl/memory",
+        "//absl/meta:type_traits",
+        "//absl/types:span",
+    ],
+)
+
+cc_library(
+    name = "inlined_vector",
+    deps = [
+        ":inlined_vector_internal",
+        "//absl/algorithm",
+        "//absl/base:core_headers",
+        "//absl/base:throw_delegate",
+        "//absl/memory",
+    ],
+)
+
+cc_library(
+    name = "flat_hash_map",
+    deps = [
+        ":container_memory",
+        ":hash_function_defaults",
+        ":raw_hash_map",
+        "//absl/algorithm:container",
+        "//absl/memory",
+    ],
+)
+
+cc_library(
+    name = "flat_hash_set",
+    deps = [
+        ":container_memory",
+        ":hash_function_defaults",
+        ":raw_hash_set",
+        "//absl/algorithm:container",
+        "//absl/base:core_headers",
+        "//absl/memory",
+    ],
+)
+
+cc_library(
+    name = "node_hash_map",
+    deps = [
+        ":container_memory",
+        ":hash_function_defaults",
+        ":node_hash_policy",
+        ":raw_hash_map",
+        "//absl/algorithm:container",
+        "//absl/memory",
+    ],
+)
+
+cc_library(
+    name = "node_hash_set",
+    deps = [
+        ":hash_function_defaults",
+        ":node_hash_policy",
+        ":raw_hash_set",
+        "//absl/algorithm:container",
+        "//absl/memory",
+    ],
+)
+
+cc_library(
+    name = "container_memory",
+    deps = [
+        "//absl/base:config",
+        "//absl/memory",
+        "//absl/meta:type_traits",
+        "//absl/utility",
+    ],
+)
+
+cc_library(
+    name = "hash_function_defaults",
+    deps = [
+        "//absl/base:config",
+        "//absl/hash",
+        "//absl/strings",
+        "//absl/strings:cord",
+    ],
+)
+
+cc_library(
+    name = "hash_policy_traits",
+    deps = ["//absl/meta:type_traits"],
+)
+
+cc_library(
+    name = "hashtable_debug",
+    deps = [
+        ":hashtable_debug_hooks",
+    ],
+)
+
+cc_library(
+    name = "hashtable_debug_hooks",
+    deps = [
+        "//absl/base:config",
+    ],
+)
+
+cc_library(
+    name = "hashtablez_sampler",
+    linkopts = ["-labsl_hashtablez_sampler"],
+    deps = [
+        "//absl/base",
+        "//absl/base:core_headers",
+        "//absl/base:exponential_biased",
+        "//absl/debugging:stacktrace",
+        "//absl/memory",
+        "//absl/synchronization",
+        "//absl/utility",
+    ],
+)
+
+cc_library(
+    name = "node_hash_policy",
+    deps = ["//absl/base:config"],
+)
+
+cc_library(
+    name = "raw_hash_map",
+    deps = [
+        ":container_memory",
+        ":raw_hash_set",
+        "//absl/base:throw_delegate",
+    ],
+)
+
+cc_library(
+    name = "common",
+    deps = [
+        "//absl/meta:type_traits",
+        "//absl/types:optional",
+    ],
+)
+
+cc_library(
+    name = "raw_hash_set",
+    linkopts = ["-labsl_raw_hash_set"],
+    deps = [
+        ":common",
+        ":compressed_tuple",
+        ":container_memory",
+        ":hash_policy_traits",
+        ":hashtable_debug_hooks",
+        ":hashtablez_sampler",
+        ":layout",
+        "//absl/base:config",
+        "//absl/base:core_headers",
+        "//absl/base:endian",
+        "//absl/memory",
+        "//absl/meta:type_traits",
+        "//absl/numeric:bits",
+        "//absl/utility",
+    ],
+)
+
+cc_library(
+    name = "layout",
+    deps = [
+        "//absl/base:config",
+        "//absl/base:core_headers",
+        "//absl/meta:type_traits",
+        "//absl/strings",
+        "//absl/types:span",
+        "//absl/utility",
+    ],
+)
+
+cc_library(
+    name = "btree",
+    deps = [
+        ":common",
+        ":compressed_tuple",
+        ":container_memory",
+        ":layout",
+        "//absl/base:core_headers",
+        "//absl/base:throw_delegate",
+        "//absl/memory",
+        "//absl/meta:type_traits",
+        "//absl/strings",
+        "//absl/strings:cord",
+        "//absl/types:compare",
+        "//absl/utility",
+    ],
+)

--- a/third_party/absl/system.absl.debugging.BUILD
+++ b/third_party/absl/system.absl.debugging.BUILD
@@ -1,0 +1,65 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "stacktrace",
+    linkopts = ["-labsl_stacktrace"],
+    deps = [
+        ":debugging_internal",
+    ],
+)
+
+cc_library(
+    name = "symbolize",
+    linkopts = ["-labsl_symbolize"],
+    deps = [
+        ":debugging_internal",
+        ":demangle_internal",
+        "//absl/base",
+        "//absl/base:dynamic_annotations",
+        "//absl/base:malloc_internal",
+        "//absl/base:raw_logging_internal",
+        "//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "failure_signal_handler",
+    linkopts = ["-labsl_failure_signal_handler", "-labsl_examine_stack"],
+    deps = [
+        ":stacktrace",
+        ":symbolize",
+        "//absl/base",
+        "//absl/base:errno_saver",
+        "//absl/base:raw_logging_internal",
+    ],
+)
+
+cc_library(
+    name = "debugging_internal",
+    linkopts = ["-labsl_debugging_internal"],
+    deps = [
+        "//absl/base:dynamic_annotations",
+        "//absl/base:errno_saver",
+        "//absl/base:raw_logging_internal",
+    ],
+)
+
+cc_library(
+    name = "demangle_internal",
+    linkopts = ["-labsl_demangle_internal"],
+    deps = [
+        "//absl/base",
+    ],
+)
+
+cc_library(
+    name = "leak_check",
+    linkopts = ["-labsl_leak_check"],
+)
+
+cc_library(
+    name = "leak_check_disable",
+    linkopts = ["-labsl_leak_check_disable"],
+    alwayslink = 1,
+)

--- a/third_party/absl/system.absl.flags.BUILD
+++ b/third_party/absl/system.absl.flags.BUILD
@@ -1,0 +1,154 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "program_name",
+    linkopts = ["-labsl_flags_program_name"],
+    visibility = [
+        "//absl/flags:__pkg__",
+    ],
+    deps = [
+        "//absl/strings",
+        "//absl/synchronization",
+    ],
+)
+
+cc_library(
+    name = "config",
+    linkopts = ["-labsl_flags_config"],
+    deps = [
+        ":program_name",
+        "//absl/strings",
+        "//absl/synchronization",
+    ],
+)
+
+cc_library(
+    name = "marshalling",
+    linkopts = ["-labsl_flags_marshalling"],
+    deps = [
+        "//absl/base:log_severity",
+        "//absl/strings",
+        "//absl/strings:str_format",
+    ],
+)
+
+cc_library(
+    name = "commandlineflag_internal",
+    linkopts = ["-labsl_flags_commandlineflag_internal"],
+)
+
+cc_library(
+    name = "commandlineflag",
+    linkopts = ["-labsl_flags_commandlineflag"],
+    deps = [
+        ":commandlineflag_internal",
+        "//absl/strings",
+        "//absl/types:optional",
+    ],
+)
+
+cc_library(
+    name = "private_handle_accessor",
+    linkopts = ["-labsl_flags_private_handle_accessor"],
+    visibility = [
+        "//absl/flags:__pkg__",
+    ],
+    deps = [
+        ":commandlineflag",
+        ":commandlineflag_internal",
+        "//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "reflection",
+    linkopts = ["-labsl_flags_reflection"],
+    deps = [
+        ":commandlineflag",
+        ":commandlineflag_internal",
+        ":config",
+        ":private_handle_accessor",
+        "//absl/container:flat_hash_map",
+        "//absl/strings",
+        "//absl/synchronization",
+    ],
+)
+
+cc_library(
+    name = "flag_internal",
+    linkopts = ["-labsl_flags_internal"],
+    visibility = ["//absl/base:__subpackages__"],
+    deps = [
+        ":commandlineflag",
+        ":commandlineflag_internal",
+        ":config",
+        ":marshalling",
+        ":reflection",
+        "//absl/base",
+        "//absl/memory",
+        "//absl/meta:type_traits",
+        "//absl/strings",
+        "//absl/synchronization",
+        "//absl/utility",
+    ],
+)
+
+cc_library(
+    name = "flag",
+    linkopts = ["-labsl_flags"],
+    deps = [
+        ":config",
+        ":flag_internal",
+        ":reflection",
+        "//absl/base",
+        "//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "usage_internal",
+    linkopts = ["-labsl_flags_usage_internal"],
+    visibility = [
+        "//absl/flags:__pkg__",
+    ],
+    deps = [
+        ":commandlineflag",
+        ":config",
+        ":flag",
+        ":flag_internal",
+        ":private_handle_accessor",
+        ":program_name",
+        ":reflection",
+        "//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "usage",
+    linkopts = ["-labsl_flags_usage"],
+    deps = [
+        ":usage_internal",
+        "//absl/strings",
+        "//absl/synchronization",
+    ],
+)
+
+cc_library(
+    name = "parse",
+    linkopts = ["-labsl_flags_parse"],
+    deps = [
+        ":commandlineflag",
+        ":commandlineflag_internal",
+        ":config",
+        ":flag",
+        ":flag_internal",
+        ":private_handle_accessor",
+        ":program_name",
+        ":reflection",
+        ":usage",
+        ":usage_internal",
+        "//absl/strings",
+        "//absl/synchronization",
+    ],
+)

--- a/third_party/absl/system.absl.functional.BUILD
+++ b/third_party/absl/system.absl.functional.BUILD
@@ -1,0 +1,10 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "bind_front",
+)
+
+cc_library(
+    name = "function_ref",
+)

--- a/third_party/absl/system.absl.hash.BUILD
+++ b/third_party/absl/system.absl.hash.BUILD
@@ -1,0 +1,36 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "hash",
+    linkopts = ["-labsl_hash"],
+    deps = [
+        ":city",
+        ":wyhash",
+        "//absl/base:endian",
+        "//absl/container:fixed_array",
+        "//absl/numeric:int128",
+        "//absl/strings",
+        "//absl/types:optional",
+        "//absl/types:variant",
+        "//absl/utility",
+    ],
+)
+
+cc_library(
+    name = "city",
+    linkopts = ["-labsl_city"],
+    deps = [
+        "//absl/base:endian",
+    ],
+)
+
+cc_library(
+    name = "wyhash",
+    linkopts = ["-labsl_wyhash"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//absl/base:endian",
+        "//absl/numeric:int128",
+    ],
+)

--- a/third_party/absl/system.absl.memory.BUILD
+++ b/third_party/absl/system.absl.memory.BUILD
@@ -1,0 +1,6 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "memory",
+)

--- a/third_party/absl/system.absl.meta.BUILD
+++ b/third_party/absl/system.absl.meta.BUILD
@@ -1,0 +1,6 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "type_traits",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/absl/system.absl.numeric.BUILD
+++ b/third_party/absl/system.absl.numeric.BUILD
@@ -1,0 +1,15 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "bits",
+)
+
+cc_library(
+    name = "int128",
+    linkopts = ["-labsl_int128"],
+)
+
+cc_library(
+    name = "representation",
+)

--- a/third_party/absl/system.absl.random.BUILD
+++ b/third_party/absl/system.absl.random.BUILD
@@ -1,0 +1,52 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "random",
+    deps = [
+        ":distributions",
+        ":seed_sequences",
+        "//absl/base:endian",
+    ],
+)
+
+cc_library(
+    name = "distributions",
+    linkopts = ["-labsl_random_distributions"],
+    deps = [
+        "//absl/numeric:bits",
+        "//absl/numeric:int128",
+        "//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "seed_gen_exception",
+    linkopts = ["-labsl_random_seed_gen_exception"],
+)
+
+cc_library(
+    name = "seed_sequences",
+    linkopts = [
+        "-labsl_random_internal_platform",
+        "-labsl_random_internal_pool_urbg",
+        "-labsl_random_internal_randen",
+        "-labsl_random_internal_randen_hwaes",
+        "-labsl_random_internal_randen_hwaes_impl",
+        "-labsl_random_internal_randen_slow",
+        "-labsl_random_internal_seed_material",
+        "-labsl_random_seed_sequences",
+        "-pthread",
+    ],
+    deps = [
+        ":seed_gen_exception",
+        "//absl/base",
+        "//absl/base:endian",
+        "//absl/base:raw_logging_internal",
+        "//absl/container:inlined_vector",
+        "//absl/numeric:int128",
+        "//absl/strings",
+        "//absl/types:optional",
+        "//absl/types:span",
+    ],
+)

--- a/third_party/absl/system.absl.status.BUILD
+++ b/third_party/absl/system.absl.status.BUILD
@@ -1,0 +1,30 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "status",
+    linkopts = ["-labsl_status"],
+    deps = [
+        "//absl/base:atomic_hook",
+        "//absl/base:raw_logging_internal",
+        "//absl/container:inlined_vector",
+        "//absl/debugging:stacktrace",
+        "//absl/debugging:symbolize",
+        "//absl/strings",
+        "//absl/strings:cord",
+        "//absl/strings:str_format",
+        "//absl/types:optional",
+    ],
+)
+
+cc_library(
+    name = "statusor",
+    linkopts = ["-labsl_statusor"],
+    deps = [
+        ":status",
+        "//absl/base:raw_logging_internal",
+        "//absl/strings",
+        "//absl/types:variant",
+        "//absl/utility",
+    ],
+)

--- a/third_party/absl/system.absl.strings.BUILD
+++ b/third_party/absl/system.absl.strings.BUILD
@@ -1,0 +1,48 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "strings",
+    linkopts = ["-labsl_strings"],
+    deps = [
+        ":internal",
+        "//absl/base",
+        "//absl/base:throw_delegate",
+        "//absl/memory",
+        "//absl/numeric:bits",
+        "//absl/numeric:int128",
+    ],
+)
+
+cc_library(
+    name = "internal",
+    linkopts = ["-labsl_strings_internal"],
+    deps = [
+        "//absl/base:endian",
+        "//absl/base:raw_logging_internal",
+    ],
+)
+
+cc_library(
+    name = "cord",
+    linkopts = ["-labsl_cord"],
+    deps = [
+        ":str_format",
+        "//absl/container:compressed_tuple",
+        "//absl/container:fixed_array",
+        "//absl/container:inlined_vector",
+        "//absl/container:layout",
+    ],
+)
+
+cc_library(
+    name = "str_format",
+    linkopts = ["-labsl_str_format_internal"],
+    deps = [
+        ":strings",
+        "//absl/functional:function_ref",
+        "//absl/numeric:representation",
+        "//absl/types:optional",
+        "//absl/types:span",
+    ],
+)

--- a/third_party/absl/system.absl.synchronization.BUILD
+++ b/third_party/absl/system.absl.synchronization.BUILD
@@ -1,0 +1,32 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+# Internal data structure for efficiently detecting mutex dependency cycles
+cc_library(
+    name = "graphcycles_internal",
+    linkopts = ["-labsl_graphcycles_internal"],
+    visibility = [
+        "//absl:__subpackages__",
+    ],
+    deps = [
+        "//absl/base",
+        "//absl/base:malloc_internal",
+        "//absl/base:raw_logging_internal",
+    ],
+)
+
+cc_library(
+    name = "synchronization",
+    linkopts = ["-labsl_synchronization", "-pthread"],
+    deps = [
+        ":graphcycles_internal",
+        "//absl/base",
+        "//absl/base:atomic_hook",
+        "//absl/base:dynamic_annotations",
+        "//absl/base:malloc_internal",
+        "//absl/base:raw_logging_internal",
+        "//absl/debugging:stacktrace",
+        "//absl/debugging:symbolize",
+        "//absl/time",
+    ],
+)

--- a/third_party/absl/system.absl.time.BUILD
+++ b/third_party/absl/system.absl.time.BUILD
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "time",
+    linkopts = ["-labsl_time", "-labsl_civil_time", "-labsl_time_zone"],
+    deps = [
+        "//absl/base",
+        "//absl/base:raw_logging_internal",
+        "//absl/numeric:int128",
+        "//absl/strings",
+    ],
+)

--- a/third_party/absl/system.absl.types.BUILD
+++ b/third_party/absl/system.absl.types.BUILD
@@ -1,0 +1,58 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "any",
+    deps = [
+        ":bad_any_cast",
+    ],
+)
+
+cc_library(
+    name = "bad_any_cast",
+    linkopts = ["-labsl_bad_any_cast_impl"],
+)
+
+cc_library(
+    name = "span",
+    deps = [
+        "//absl/base:throw_delegate",
+    ],
+)
+
+cc_library(
+    name = "optional",
+    deps = [
+        ":bad_optional_access",
+    ],
+)
+
+cc_library(
+    name = "bad_optional_access",
+    linkopts = ["-labsl_bad_optional_access"],
+    deps = [
+        "//absl/base:raw_logging_internal",
+    ],
+)
+
+cc_library(
+    name = "bad_variant_access",
+    linkopts = ["-labsl_bad_variant_access"],
+    deps = [
+        "//absl/base:raw_logging_internal",
+    ],
+)
+
+cc_library(
+    name = "variant",
+    deps = [
+        ":bad_variant_access",
+    ],
+)
+
+cc_library(
+    name = "compare",
+    deps = [
+        "//absl/meta:type_traits",
+    ],
+)

--- a/third_party/absl/system.absl.utility.BUILD
+++ b/third_party/absl/system.absl.utility.BUILD
@@ -1,0 +1,6 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "utility",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/absl/workspace.bzl
+++ b/third_party/absl/workspace.bzl
@@ -11,10 +11,19 @@ def repo():
     ABSL_SHA256 = "35f22ef5cb286f09954b7cc4c85b5a3f6221c9d4df6b8c4a1e9d399555b366ee"
     # LINT.ThenChange(//tensorflow/lite/tools/cmake/modules/abseil-cpp.cmake)
 
+    SYS_DIRS = ["algorithm", "base", "cleanup", "container", "debugging", "flags", "functional", "hash", "memory",
+                "meta", "numeric", "random", "status", "strings", "synchronization", "time", "types", "utility"]
+    SYS_LINKS = {
+            "//third_party/absl:system.absl.{name}.BUILD".format(name = n): "absl/{name}/BUILD.bazel".format(name = n)
+            for n in SYS_DIRS
+    }
+
     tf_http_archive(
         name = "com_google_absl",
         sha256 = ABSL_SHA256,
         build_file = "//third_party/absl:com_google_absl.BUILD",
+        system_build_file = "//third_party/absl:system.BUILD",
+        system_link_files = SYS_LINKS,
         # TODO(mihaimaruseac): Remove the patch when https://github.com/abseil/abseil-cpp/issues/326 is resolved
         patch_file = ["//third_party/absl:com_google_absl_fix_mac_and_nvcc_build.patch"],
         strip_prefix = "abseil-cpp-{commit}".format(commit = ABSL_COMMIT),

--- a/third_party/systemlibs/syslibs_configure.bzl
+++ b/third_party/systemlibs/syslibs_configure.bzl
@@ -15,6 +15,7 @@ VALID_LIBS = [
     "boringssl",
     "com_github_googlecloudplatform_google_cloud_cpp",
     "com_github_grpc_grpc",
+    "com_google_absl",
     "com_google_protobuf",
     "com_googlesource_code_re2",
     "curl",


### PR DESCRIPTION
This unbundles abseil-cpp, tested and works on Gentoo Linux. It was helpful when building with std=c++17 since there are some quite significant differences in how abseil works between c++14/17.

(NB: This is not sufficient for building with C++17, there are a few targets in `tensorflow/compiler/mlir/lite/BUILD` which hardcode c++14 currently)