### PR TITLE
Added missing 'return true'

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -3421,6 +3421,7 @@ inline bool AveragePool16(const PoolParams& params,
       }
     }
   }
+  return true;
 }
 
 inline bool AveragePool32(const PoolParams& params,


### PR DESCRIPTION
When evaluating particularly sized uint8 quantized AveragPool2D operations, it's broken due to missing 'return true' statement here:
https://github.com/tensorflow/tensorflow/blob/v2.4.4/tensorflow/lite/kernels/internal/optimized/optimized_ops.h#L3424

This regression was originated here:
https://github.com/tensorflow/tensorflow/commit/a5ceb2445d37d9d89a13de3fd0d0d991f4962522#diff-d7e3b0af29f6e121b2c30e4fc932dcb6c67ab073d759bd9786b60d4069637e78R3293

Which appears change specific for the r2.4 branch, master branch doesn't have this code any longer:

https://github.com/tensorflow/tensorflow/commit/b44dd5e97df2f9aec5ad71e8122be98a59a35057