### PR TITLE
Fix the GraphFloat32::outputs() problem in TFLite

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/model.cc
+++ b/tensorflow/lite/delegates/gpu/common/model.cc
@@ -43,7 +43,9 @@ std::vector<Value*> GraphFloat32::values() const {
 }
 
 std::vector<Value*> GraphFloat32::inputs() const {
-  return FilterValues([](const ValueDef& v) { return v.producer == nullptr; });
+  return FilterValues([](const ValueDef& v) {
+    return v.producer == nullptr || v.value->type == ValueType::kGraphInput;
+  });
 }
 
 std::vector<Value*> GraphFloat32::variable_inputs() const {
@@ -52,7 +54,9 @@ std::vector<Value*> GraphFloat32::variable_inputs() const {
 }
 
 std::vector<Value*> GraphFloat32::outputs() const {
-  return FilterValues([](const ValueDef& v) { return v.consumers.empty(); });
+  return FilterValues([](const ValueDef& v) {
+    return v.consumers.empty() || v.value->type == ValueType::kGraphOutput;
+  });
 }
 
 std::vector<Value*> GraphFloat32::FindInputs(NodeId id) const {

--- a/tensorflow/lite/delegates/gpu/common/model.h
+++ b/tensorflow/lite/delegates/gpu/common/model.h
@@ -47,11 +47,18 @@ struct QuantizationParams {
   float scale = 0;
 };
 
+enum class ValueType {
+  kUnkown = 0,
+  kGraphInput,
+  kGraphOutput,
+};
+
 // Connects tensor's producer and operation that depends on this tensor.
 struct Value {
   const ValueId id;
   TensorRef<BHWC> tensor;
   absl::optional<QuantizationParams> quant_params;
+  ValueType type = ValueType::kUnkown;
 };
 
 struct Operation {


### PR DESCRIPTION
Hi TFers,
I just found the problem that I was getting wrong data output from my model having multi-headers. For example, if the graph my model is like `0 -> 1 -> 2 -> 3` and the model inputs is `[0]` outputs is `[2, 3]`, I will only get correct answer from 3 but 2 is not, because our `GraphFloat32::outputs()` only believe the value with no consumer, the `3` above, is an output value. However, our tflite::Interpreter still tell us the outputs is `[2, 3]` and it's right. So, I try to fix with this PR, please take a check.