### PR TITLE
Add linux_aarch64 target to AOT.

### DIFF
--- a/tensorflow/compiler/aot/tfcompile.bzl
+++ b/tensorflow/compiler/aot/tfcompile.bzl
@@ -402,6 +402,7 @@ def target_llvm_triple():
         "//tensorflow:ios": "arm64-none-ios",
         "//tensorflow:ios_x86_64": "x86_64-apple-ios",
         "//tensorflow:linux_ppc64le": "ppc64le-ibm-linux-gnu",
+        "//tensorflow:linux_aarch64": "aarch64-none-linux-gnu",
         "//tensorflow:macos_x86_64": "x86_64-none-darwin",
         "//tensorflow:macos_arm64": "aarch64-none-darwin",
         "//tensorflow:windows": "x86_64-none-windows",


### PR DESCRIPTION
The lack of a target for `linux_aarch64` on AOT breaks tests under `//tensorflow/python/tools`.