### PR TITLE
Add missing return statement to AveragePool16

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -3421,6 +3421,7 @@ inline bool AveragePool16(const PoolParams& params,
       }
     }
   }
+  return true;
 }
 
 inline bool AveragePool32(const PoolParams& params,


### PR DESCRIPTION
Fixes bug in AveragePool16 introduced by #51318