### PR TITLE
Declare Go import path in distributed XLA service protocol

### DIFF
--- a/tensorflow/compiler/xla/pjrt/distributed/protocol.proto
+++ b/tensorflow/compiler/xla/pjrt/distributed/protocol.proto
@@ -28,6 +28,9 @@ syntax = "proto3";
 
 package xla;
 
+option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/compiler/"
+  "xla/pjrt/distributed/protocol_go_proto";
+
 // Describes a device local to a host.
 message DeviceProto {
   int32 local_device_ordinal = 1;

--- a/tensorflow/go/genop/generate.sh
+++ b/tensorflow/go/genop/generate.sh
@@ -68,6 +68,7 @@ fi
 export PATH=$PATH:${GOPATH}/bin
 for FILE in ${TF_DIR}/tensorflow/core/framework/*.proto \
     ${TF_DIR}/tensorflow/core/protobuf/*.proto \
+    ${TF_DIR}/tensorflow/compiler/xla/pjrt/distributed/*.proto \
     ${TF_DIR}/tensorflow/stream_executor/*.proto; do
   ${PROTOC} \
     -I ${TF_DIR} \


### PR DESCRIPTION
PR declares `go_package` in proto and resolves protoc-gen-go error.