### PR TITLE
Delete MklDnnData::operator= to prevent memory leaks in the future

### DIFF
--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1277,6 +1277,12 @@ class MklDnnData {
         allocated_buffer_(nullptr),
         cpu_engine_(e) {}
 
+  // MklDnnData does not use any smart pointers,
+  // hence default operator= will result in memory leak if user_memory was already initialized.
+  // See https://github.com/tensorflow/tensorflow/pull/45593 as an example of such leak.
+  MklDnnData(const MklDnnData&) = default;
+  MklDnnData& operator= (const MklDnnData&) = delete;
+    
   ~MklDnnData() {
     if (allocated_buffer_ != nullptr) {
       cpu_allocator()->DeallocateRaw(allocated_buffer_);


### PR DESCRIPTION
This is the continuation of #45593