### PR TITLE
[ROCm] Turn off SwapConvOperands on ROCm gpu

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -444,6 +444,9 @@ Status GpuCompiler::OptimizeHloModule(
       // bitcast(bitcast) with one bitcast. This leads to having to
       // linearize and then delinearize the index.
       options.set_replace_transpose_with_bitcast(false);
+#if TENSORFLOW_USE_ROCM
+      options.set_enable_conv_operand_swap(false);
+#endif
       pipeline.AddPass<AlgebraicSimplifier>(options);
       pipeline.AddPass<BitcastDtypesExpander>();
       // AlgebraicSimplifier may add contracting dimensions to a dot.

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -287,7 +287,6 @@ GpuCompiler::GpuCompiler(se::Platform::Id platform_id,
 Status GpuCompiler::OptimizeHloModule(
     HloModule* hlo_module, se::StreamExecutor* stream_exec,
     se::DeviceMemoryAllocator* device_allocator) {
-
   // Save proto state before optimizations if we want a snapshot.
   if (DumpingEnabledForHloModule(*hlo_module)) {
     hlo_proto_ = absl::make_unique<HloProto>();

--- a/tensorflow/compiler/xla/service/gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/tests/BUILD
@@ -346,7 +346,7 @@ tf_cc_test(
     srcs = [
         "swap_conv_operands_test.cc",
     ],
-    tags = tf_cuda_tests_tags(),
+    tags = ["no_rocm"] + tf_cuda_tests_tags(),
     deps = [
         ":gpu_codegen_test",
         "//tensorflow/compiler/xla:debug_options_flags",


### PR DESCRIPTION
The following upstream commit turns on SwapConvOperands on gpu, and this does not yet work on the ROCm platform

tensorflow@43abc0f

Unit Test Failures
```
//tensorflow/compiler/xla/service/gpu/tests:swap_conv_operands_test      FAILED in 3 out of 3 in 18.6s
//tensorflow/compiler/xla/tests:convolution_test_gpu                     FAILED in 3 out of 3 in 67.8s
//tensorflow/compiler/xla/tests:convolution_test_gpu_alternative_layout_gpu FAILED in 3 out of 3 in 63.1s
//tensorflow/compiler/xla/tests:convolution_variants_test_gpu            FAILED in 3 out of 3 in 11.5s
```

This commit
* disables the feature on ROCm to get the unit tests working again
* adds a `no_rocm` tag to the new unit test that was added to specifically test the SwapConvOperands feature