### PR TITLE
[ROCM] pass `HIP_PLATFORM` to bazel

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1344,6 +1344,9 @@ def main():
     write_action_env_to_bazelrc('ROCBLAS_TENSILE_LIBPATH',
                                 environ_cp.get('ROCM_PATH') + '/lib/library')
 
+  if (environ_cp.get('TF_NEED_ROCM') == '1' and environ_cp.get('HIP_PLATFORM')):
+    write_action_env_to_bazelrc('HIP_PLATFORM', environ_cp.get('HIP_PLATFORM'))
+
   environ_cp['TF_NEED_CUDA'] = str(
       int(get_var(environ_cp, 'TF_NEED_CUDA', 'CUDA', False)))
   if (environ_cp.get('TF_NEED_CUDA') == '1' and

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -383,6 +383,7 @@ def tf_copts(
         if_libtpu(["-DLIBTPU_ON_GCE"], []) +
         if_xla_available(["-DTENSORFLOW_USE_XLA=1"]) +
         if_tensorrt(["-DGOOGLE_TENSORRT=1"]) +
+        if_rocm(["-DTENSORFLOW_USE_ROCM=1"]) +
         # Compile in oneDNN based ops when building for x86 platforms
         if_mkl(["-DINTEL_MKL"]) +
         # Enable additional ops (e.g., ops with non-NHWC data layout) and


### PR DESCRIPTION
We need to pass HIP_PLATFORM to bazel. Authored by @deven-amd 