### PR TITLE
Unify the Cudnn Execution Plan Runner

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.cc
@@ -140,8 +140,8 @@ Status RunGpuConvUnfused(GpuConvParams params, se::Stream* stream,
   TF_ASSIGN_OR_RETURN(auto* runner,
                       lazy_runner->GetOrCreateRunner(config, stream));
 
-  return (*runner)(stream, input_buf, filter_buf, output_buf, scratch_memory,
-                   options.profile_result);
+  return (*runner)(stream, options.profile_result, scratch_memory, input_buf,
+                   filter_buf, output_buf);
 }
 
 template <typename ElementType, typename BiasType, typename OutputType>
@@ -201,9 +201,8 @@ Status RunGpuConvForwardActivation(GpuConvParams params, se::Stream* stream,
   TF_ASSIGN_OR_RETURN(auto* runner,
                       lazy_runner->GetOrCreateRunner(config, stream));
 
-  return (*runner)(stream, input_buf, filter_buf, side_input,
-                   params.fusion->bias_buf, output_buf, scratch_memory,
-                   options.profile_result);
+  return (*runner)(stream, options.profile_result, scratch_memory, input_buf,
+                   filter_buf, side_input, params.fusion->bias_buf, output_buf);
 }
 
 // StreamExecutor supports various data types via overloading, and the support

--- a/tensorflow/core/kernels/conv_ops_fused_impl.h
+++ b/tensorflow/core/kernels/conv_ops_fused_impl.h
@@ -597,8 +597,8 @@ struct LaunchFusedConv2DOp<GPUDevice, T> {
       auto& runner =
           *std::get<const se::dnn::FusedConvRunner*>(runner_and_scratch);
       cudnn_launch_status = runner(
-          stream, input_ptr, filter_ptr, side_input_ptr, bias_ptr, output_ptr,
-          std::get<se::DeviceMemoryBase>(runner_and_scratch), nullptr);
+          stream, nullptr, std::get<se::DeviceMemoryBase>(runner_and_scratch),
+          input_ptr, filter_ptr, side_input_ptr, bias_ptr, output_ptr);
     } else {
       cudnn_launch_status = stream->FusedConvolveWithAlgorithm(
           input_desc, input_ptr,            // input

--- a/tensorflow/core/kernels/conv_ops_gpu.cc
+++ b/tensorflow/core/kernels/conv_ops_gpu.cc
@@ -145,8 +145,8 @@ StatusOr<AutotuneEntry<se::dnn::FusedConvOp>> AutotuneFusedConv(
             se::dnn::ProfileResult* profile_result) -> Status {
       TF_ASSIGN_OR_RETURN(auto scratch, allocator_used->AllocateBytes(
                                             runner->GetWorkspaceSize()));
-      return (*runner)(stream, input_ptr, filter_ptr, side_input_ptr, bias_ptr,
-                       output_ptr_rz, scratch, profile_result);
+      return (*runner)(stream, profile_result, scratch, input_ptr, filter_ptr,
+                       side_input_ptr, bias_ptr, output_ptr_rz);
     };
 
     SE_ASSIGN_OR_RETURN(
@@ -300,8 +300,8 @@ StatusOr<AutotuneEntry<se::dnn::ConvOp>> AutotuneUnfusedConv(
             se::dnn::ProfileResult* profile_result) -> Status {
       TF_ASSIGN_OR_RETURN(auto scratch, allocator_used->AllocateBytes(
                                             runner->GetWorkspaceSize()));
-      return (*runner)(stream, input_ptr, filter_ptr, output_ptr, scratch,
-                       profile_result);
+      return (*runner)(stream, profile_result, scratch, input_ptr, filter_ptr,
+                       output_ptr);
     };
     SE_ASSIGN_OR_RETURN(
         auto results,

--- a/tensorflow/core/kernels/conv_ops_gpu.h
+++ b/tensorflow/core/kernels/conv_ops_gpu.h
@@ -185,8 +185,9 @@ Status LaunchAutotunedConv(const AutotuneEntry<se::dnn::ConvOp>& autotune_entry,
                         AllocateScratchOrFallback<se::dnn::ConvOp::Signature>(
                             scratch_allocator, primary, no_scratch_fallback));
     auto& runner = *std::get<const se::dnn::ConvRunner*>(runner_and_scratch);
-    return runner(stream, in_ptr, filter_ptr, out_ptr,
-                  std::get<se::DeviceMemoryBase>(runner_and_scratch), nullptr);
+    return runner(
+        stream, nullptr, std::get<se::DeviceMemoryBase>(runner_and_scratch),
+        in_ptr, filter_ptr, out_ptr);
   } else {
     return stream->ConvolveWithAlgorithm(
         kind, input_desc, in_ptr, filter_desc, filter_ptr, output_desc, out_ptr,

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -889,21 +889,20 @@ class OpRunner<port::Status(Args...)> {
   virtual port::StatusOr<AlgorithmDesc> ToAlgorithmDesc() const = 0;
 
   // Launch the operation, with the signature determined by `Sig`.
-  virtual port::Status operator()(Args... args) const = 0;
+  virtual port::Status operator()(Stream*, ProfileResult*, DeviceMemoryBase,
+                                  Args... args) const = 0;
 };
 
-using ConvSignature = port::Status(Stream*, DeviceMemoryBase /* input_data */,
+using ConvSignature = port::Status(DeviceMemoryBase /* input_data */,
                                    DeviceMemoryBase /* filter_data */,
-                                   DeviceMemoryBase /* output_data */,
-                                   DeviceMemoryBase /* scratch_memory */,
-                                   ProfileResult*);
+                                   DeviceMemoryBase /* output_data */);
 using ConvRunner = OpRunner<ConvSignature>;
 
-using FusedConvSignature = port::Status(
-    Stream*, DeviceMemoryBase /* input_data */,
-    DeviceMemoryBase /* filter_data */, DeviceMemoryBase /* side_input_data */,
-    DeviceMemoryBase /* bias_data */, DeviceMemoryBase /* output_data */,
-    DeviceMemoryBase /* scratch_memory */, ProfileResult*);
+using FusedConvSignature = port::Status(DeviceMemoryBase /* input_data */,
+                                        DeviceMemoryBase /* filter_data */,
+                                        DeviceMemoryBase /* side_input_data */,
+                                        DeviceMemoryBase /* bias_data */,
+                                        DeviceMemoryBase /* output_data */);
 using FusedConvRunner = OpRunner<FusedConvSignature>;
 
 // Describes the configuration for the algorithms that will used.

--- a/tensorflow/stream_executor/dnn.h
+++ b/tensorflow/stream_executor/dnn.h
@@ -868,7 +868,7 @@ class OpRunner;
 //
 // All OpRunners must be outlived by their parent Stream.
 template <typename... Args>
-class OpRunner<port::Status(Args...)> {
+class OpRunner<void(Args...)> {
  public:
   virtual ~OpRunner() {}
 
@@ -889,20 +889,21 @@ class OpRunner<port::Status(Args...)> {
   virtual port::StatusOr<AlgorithmDesc> ToAlgorithmDesc() const = 0;
 
   // Launch the operation, with the signature determined by `Sig`.
-  virtual port::Status operator()(Stream*, ProfileResult*, DeviceMemoryBase,
+  virtual port::Status operator()(Stream*, ProfileResult*,
+                                  DeviceMemoryBase scratch_memory,
                                   Args... args) const = 0;
 };
 
-using ConvSignature = port::Status(DeviceMemoryBase /* input_data */,
-                                   DeviceMemoryBase /* filter_data */,
-                                   DeviceMemoryBase /* output_data */);
+using ConvSignature = void(DeviceMemoryBase /* input_data */,
+                           DeviceMemoryBase /* filter_data */,
+                           DeviceMemoryBase /* output_data */);
 using ConvRunner = OpRunner<ConvSignature>;
 
-using FusedConvSignature = port::Status(DeviceMemoryBase /* input_data */,
-                                        DeviceMemoryBase /* filter_data */,
-                                        DeviceMemoryBase /* side_input_data */,
-                                        DeviceMemoryBase /* bias_data */,
-                                        DeviceMemoryBase /* output_data */);
+using FusedConvSignature = void(DeviceMemoryBase /* input_data */,
+                                DeviceMemoryBase /* filter_data */,
+                                DeviceMemoryBase /* side_input_data */,
+                                DeviceMemoryBase /* bias_data */,
+                                DeviceMemoryBase /* output_data */);
 using FusedConvRunner = OpRunner<FusedConvSignature>;
 
 // Describes the configuration for the algorithms that will used.

--- a/tensorflow/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/stream_executor/rocm/rocm_dnn.cc
@@ -2976,11 +2976,11 @@ class RocmConvRunner : public dnn::ConvRunner {
     return {{algo_id_, false, workspace_size_}};
   }
 
-  port::Status operator()(Stream* stream, DeviceMemoryBase input_data,
-                          DeviceMemoryBase filter_data,
-                          DeviceMemoryBase output_data,
+  port::Status operator()(Stream* stream, dnn::ProfileResult* profile_result,
                           DeviceMemoryBase scratch_memory,
-                          dnn::ProfileResult* profile_result) const override {
+                          DeviceMemoryBase input_data,
+                          DeviceMemoryBase filter_data,
+                          DeviceMemoryBase output_data) const override {
     auto miopen = miopen_->GetHandle(parent_, stream);
     // Alpha is the scaling factor for input.
     float alpha = 1.0;
@@ -3122,8 +3122,8 @@ port::Status MIOpenSupport::DoConvolve(
                              output_type, input_descriptor, filter_descriptor,
                              output_descriptor, convolution_descriptor));
 
-  return (*runner)(stream, input_data, filter_data, output_data, scratch_memory,
-                   output_profile_result);
+  return (*runner)(stream, output_profile_result, scratch_memory, input_data,
+                   filter_data, output_data);
 }
 
 bool MIOpenSupport::GetConvolveAlgorithms(


### PR DESCRIPTION
This PR tries to remove the `CudnnConvRunner` and `CudnnFusedConvRunner`, since both the runners (for unfused and fused conv respectively) actually share the same execution path: build op graph -> get execution plans -> allocate workspace -> prepare input/output data -> execute the plan. This execution path is also true for other Cudnn supported ops. So, this PR tries to move all these through the improved `CudnnExecutionPlanRunner`. 

This PR can also help the integration of the new ops from Cudnn in the future. That way, for newly added ops, we just need to (1) prepare a `GetXXXGraph()` to build the op graph (2) add a `XXXSignature` to mark the new inputs/outputs.

cc. @nluehr 