### PR TITLE
[MLIR][LMHLO-Affine] Add PadOp lowering from lmhlo to Affine + Add verifier for lmhlo.Pad op

### DIFF
--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/lhlo/IR/lhlo_ops.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/lhlo/IR/lhlo_ops.td
@@ -1033,6 +1033,7 @@ def LHLO_PadOp: LHLO_Op<"pad", []> {
     I64ElementsAttr:$interior_padding,
     Arg<LHLO_Buffer, "", [MemWrite]>:$output
   );
+  let verifier = [{ return Verify(*this); }];
 }
 
 def LHLO_TransposeOp: LHLO_Op<"transpose", []> {

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/lhlo/IR/lhlo_ops.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/lhlo/IR/lhlo_ops.cc
@@ -229,6 +229,67 @@ static LogicalResult Verify(CustomCallOp op) {
 }
 
 //===----------------------------------------------------------------------===//
+// PadOp
+//===----------------------------------------------------------------------===//
+
+// PadOp's verifier checks if :-
+//  1. Operand and output ranks match.
+//  2. Padding configurations are specified for each dimension.
+//  3. Output shape matches the expected output shape when the padding
+//     configurations are applied to the operand.
+static LogicalResult Verify(PadOp op) {
+  auto operand_type = op.operand().getType().dyn_cast<ShapedType>();
+  auto output_type = op.output().getType().dyn_cast<ShapedType>();
+  if (!(operand_type && output_type && operand_type.hasRank() &&
+        output_type.hasRank())) {
+    return success();
+  }
+
+  unsigned rank = operand_type.getRank();
+  // Checks if operand and output ranks match.
+  if (output_type.getRank() != rank) {
+    return op.emitOpError()
+           << "output's rank(" << output_type.getRank()
+           << ") is not same as operand's rank(" << rank << ")";
+  }
+
+  auto edge_pad_low_ranges = op.edge_padding_low().getValues<int64_t>();
+  auto edge_pad_high_ranges = op.edge_padding_high().getValues<int64_t>();
+  auto interior_pad_ranges = op.interior_padding().getValues<int64_t>();
+  // Checks if padding configurations are specified for each dimension.
+  if (edge_pad_low_ranges.size() != rank ||
+      edge_pad_high_ranges.size() != rank ||
+      interior_pad_ranges.size() != rank) {
+    return op.emitOpError() << "pad configurations to be specified for all "
+                            << rank << " dimensions";
+  }
+
+  // Checks if output shape matches the expected output shape when the padding
+  // configurations are applied to the operand. Expected output shape for each
+  // dimension is calculated as :-
+  //     low_padding + operand_dim_size + total_interior_padding + high_padding
+  //  where, total_interior_padding = (operand_dim_size - 1) * interior_padding.
+  for (auto paddings : llvm::enumerate(llvm::zip(
+           edge_pad_low_ranges, edge_pad_high_ranges, interior_pad_ranges,
+           operand_type.getShape(), output_type.getShape()))) {
+    auto index = static_cast<unsigned>(paddings.index());
+    int64_t low_pad, high_pad, interior_pad, operand_dim_size, output_dim_size;
+    std::tie(low_pad, high_pad, interior_pad, operand_dim_size,
+             output_dim_size) = paddings.value();
+    int64_t expected_dim_size = low_pad + operand_dim_size +
+                                (operand_dim_size - 1) * interior_pad +
+                                high_pad;
+    if (expected_dim_size != output_dim_size) {
+      return op.emitOpError()
+             << "expected " << index << "-th dimension size after padding is "
+             << expected_dim_size << " but found " << output_dim_size;
+    }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // ReduceOp
 //===----------------------------------------------------------------------===//
 

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/lhlo/IR/lhlo_ops.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/lhlo/IR/lhlo_ops.cc
@@ -269,7 +269,7 @@ static LogicalResult Verify(PadOp op) {
   // dimension is calculated as :-
   //     low_padding + operand_dim_size + total_interior_padding + high_padding
   //  where, total_interior_padding = (operand_dim_size - 1) * interior_padding.
-  for (auto paddings : llvm::enumerate(llvm::zip(
+  for (const auto &paddings : llvm::enumerate(llvm::zip(
            edge_pad_low_ranges, edge_pad_high_ranges, interior_pad_ranges,
            operand_type.getShape(), output_type.getShape()))) {
     auto index = static_cast<unsigned>(paddings.index());

--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/lhlo/transforms/lhlo_legalize_to_affine.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/lhlo/transforms/lhlo_legalize_to_affine.cc
@@ -462,6 +462,107 @@ class GatherOpConverter : public OpRewritePattern<GatherOp> {
   }
 };
 
+/// Converts PadOp to Affine nest form.
+/// Pseudocode:
+///   1. Fill `output` tensor with `padding_value`.
+///   2. Compute AffineMap for store into `output`.
+///      out_idx = edge_padding_low +
+///                operand_idx * (1 + interior_padding)
+///   3. Create nested loop from `operand` shape.
+///      3.1 load from `operand`.
+///      3.2 store into `output`.
+/// NOTE: The lowering handles only ranked shapes and bails out in case any of
+///       output type/edge_padding_low/edge_padding_high/interior_padding size
+///       doesn't match that of the operand's rank.
+/// Limitation for now:
+///   interior_padding == 0 && edge_padding_* >= 0
+struct PadOpConverter : public OpRewritePattern<PadOp> {
+  using OpRewritePattern<PadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(PadOp op,
+                                PatternRewriter &rewriter) const override {
+    Value operand = op.operand();
+    Value padding_value = op.padding_value();
+    Value output = op.output();
+
+    auto operand_type = operand.getType().dyn_cast<ShapedType>();
+    auto output_type = output.getType().dyn_cast<ShapedType>();
+    // We allow lowering for only ranked input/output.
+    if (!(operand_type && output_type && operand_type.hasRank() &&
+          output_type.hasRank()))
+      return failure();
+    unsigned rank = operand_type.getRank();
+
+    auto edge_pad_low_ranges = op.edge_padding_low().getValues<int64_t>();
+    auto edge_pad_high_ranges = op.edge_padding_high().getValues<int64_t>();
+    auto interior_pad_ranges = op.interior_padding().getValues<int64_t>();
+    // Check whether the constraints for the lowering are satisfied :-
+    //   1. interior_padding[i] == 0
+    //   2. edge_padding_*[i] >= 0
+    for (auto paddings : llvm::zip(edge_pad_low_ranges, edge_pad_high_ranges,
+                                   interior_pad_ranges)) {
+      // Only handle non-negative edge padding.
+      if (std::get<0>(paddings) < 0 || std::get<1>(paddings) < 0)
+        return rewriter.notifyMatchFailure(
+            op, "expected non-negative edge padding");
+      // Only handle interior padding being zero for now.
+      if (std::get<2>(paddings) != 0)
+        return rewriter.notifyMatchFailure(op,
+                                           "expected zero interior padding");
+    }
+
+    SmallVector<int64_t> edge_padding_low(edge_pad_low_ranges.begin(),
+                                          edge_pad_low_ranges.end());
+    SmallVector<int64_t> edge_padding_high(edge_pad_high_ranges.begin(),
+                                           edge_pad_high_ranges.end());
+    SmallVector<int64_t> interior_padding(interior_pad_ranges.begin(),
+                                          interior_pad_ranges.end());
+
+    ArrayRef<int64_t> operand_shape = operand_type.getShape();
+    ArrayRef<int64_t> output_shape = output_type.getShape();
+
+    // Mapping the `operand` index to the `output` index.
+    SmallVector<AffineExpr, 4> expr;
+    for (unsigned i = 0; i < rank; i++) {
+      AffineExpr dim_expr = rewriter.getAffineDimExpr(i);
+      expr.push_back(dim_expr + edge_padding_low[i]);
+    }
+    AffineMap map =
+        AffineMap::get(rank, /*symbolCount=*/0, expr, rewriter.getContext());
+
+    SmallVector<Value, 4> indices;
+
+    Location loc = op.getLoc();
+    // Set padding_value to output.
+    {
+      OpBuilder::InsertionGuard regionGuard(rewriter);
+      Value scalar_padding_value = rewriter.create<AffineLoadOp>(
+          loc, padding_value, SmallVector<Value, 4>());
+      AffineForOp init_for_op;
+      for (unsigned i = 0; i < rank; i++) {
+        init_for_op = rewriter.create<AffineForOp>(loc, 0, output_shape[i]);
+        indices.push_back(init_for_op.getInductionVar());
+        rewriter.setInsertionPointToStart(init_for_op.getBody());
+      }
+      rewriter.create<AffineStoreOp>(loc, scalar_padding_value, output,
+                                     indices);
+    }
+
+    // Store `operand` into `output`, loop upper bounds from `operand` shape.
+    indices.clear();
+    AffineForOp pad_for_op;
+    for (unsigned i = 0; i < rank; i++) {
+      pad_for_op = rewriter.create<AffineForOp>(loc, 0, operand_shape[i]);
+      indices.push_back(pad_for_op.getInductionVar());
+      rewriter.setInsertionPointToStart(pad_for_op.getBody());
+    }
+    Value store_val = rewriter.create<AffineLoadOp>(loc, operand, indices);
+    rewriter.create<AffineStoreOp>(loc, store_val, output, map, indices);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 template <typename LhloOpTy>
 struct BinaryOpConverter : public OpRewritePattern<LhloOpTy> {
   using OpRewritePattern<LhloOpTy>::OpRewritePattern;
@@ -545,6 +646,7 @@ void populateLHLOToAffineConversionPattern(MLIRContext* context,
       ConcatOpConverter,
       DotOpConverter,
       GatherOpConverter,
+      PadOpConverter,
       UnaryOpConverter<lmhlo::LogOp>>(context);
   // clang-format on
 }

--- a/tensorflow/compiler/mlir/hlo/tests/Dialect/lhlo/ops.mlir
+++ b/tensorflow/compiler/mlir/hlo/tests/Dialect/lhlo/ops.mlir
@@ -996,6 +996,42 @@ func @map_memrefs(%arg0: memref<20xf32>, %arg1: memref<20xf32>, %arg_out: memref
 
 // -----
 
+func @pad_output_rank_error(%arg0: memref<1x2x3xf16>, %arg1: memref<f16>, %arg2: memref<4x5xf16>) {
+  // expected-error@+1{{output's rank(2) is not same as operand's rank(3)}}
+  "lmhlo.pad"(%arg0, %arg1, %arg2) {
+         edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
+         edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
+         interior_padding = dense<0> : tensor<3xi64>
+   } : (memref<1x2x3xf16>, memref<f16>, memref<4x5xf16>) -> ()
+   return
+}
+
+// -----
+
+func @pad_config_rank_error(%arg0: memref<1x2x3xf16>, %arg1: memref<f16>, %arg2: memref<2x4x5xf16>) {
+  // expected-error@+1{{pad configurations to be specified for all 3 dimensions}}
+  "lmhlo.pad"(%arg0, %arg1, %arg2) {
+         edge_padding_high = dense<[1, 1]> : tensor<2xi64>,
+         edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
+         interior_padding = dense<0> : tensor<3xi64>
+   } : (memref<1x2x3xf16>, memref<f16>, memref<2x4x5xf16>) -> ()
+   return
+}
+
+// -----
+
+func @pad_config_error(%arg0: memref<2x2x3xf16>, %arg1: memref<f16>, %arg2: memref<2x4x5xf16>) {
+  // expected-error@+1{{expected 0-th dimension size after padding is 6 but found 2}}
+  "lmhlo.pad"(%arg0, %arg1, %arg2) {
+         edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
+         edge_padding_low = dense<[1, 1, 2]> : tensor<3xi64>,
+         interior_padding = dense<[2, 0, 0]> : tensor<3xi64>
+   } : (memref<2x2x3xf16>, memref<f16>, memref<2x4x5xf16>) -> ()
+   return
+}
+
+// -----
+
 // CHECK-LABEL: func @rng_get_and_update_state_memrefs
 func @rng_get_and_update_state_memrefs(%state: memref<1xui64>) -> () {
   "lmhlo.rng_get_and_update_state"(%state) { delta = 1 : i64 } : (memref<1xui64>) -> ()


### PR DESCRIPTION
This PR adds two commits :-

**Commit 1:**
-- Adds verifier for lmhlo.Pad op which checks :- 
   1. Output and operand rank matches.
   2. Padding configurations are provided for each dimension.
   3. Padding configurations when applied to operand lead to the provided
       output shape.

**Commit 2:**
-- Adds lowering of PadOp from lmhlo -> Affine as a part of `lhlo-legalize-to-affine` pass.
-- The limitation of the implementation is that it expects interior padding to be 0
   and edge padding to be >= 0.

Signed-off-by: Abhishek Varma <abhishek.varma@polymagelabs.com>