### PR TITLE
Properly initialize data_ member of MklDnnShape

### DIFF
--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -263,7 +263,9 @@ class MklDnnShape {
 #define INVALID_DIM_SIZE -1
 
  public:
-  MklDnnShape() {
+  MklDnnShape()
+    : data_{}
+  {
     for (size_t i = 0; i < sizeof(data_.sizes_) / sizeof(data_.sizes_[0]);
          ++i) {
       data_.sizes_[i] = -1;


### PR DESCRIPTION
As MklShapeData is a C-style struct, it does not get initialized without `{}`.
In our case msan reports error in hardly related place. `-fsanitize-memory-track-origins=2` helps to find out the actual reason:

> Uninitialized value was created by an allocation of 'output_mkl_shape' in the stack frame of function '_ZN10tensorflow9MklAddNOpIN5Eigen16ThreadPoolDeviceEfE7ComputeEPNS_15OpKernelContextE'

(that is `tensorflow::MklAddNOp<Eigen::ThreadPoolDevice, float>::Compute(tensorflow::OpKernelContext*)`)