### PR TITLE
[oneDNN] Fixing node_file_writer_test

### DIFF
--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
@@ -172,6 +172,10 @@ bool MklEagerOpRewrite::ShouldRewriteOp(EagerOperation* op) {
   if (!IsMKLEnabled()) {
     return false;
   }
+  // Don't rewrite the op if it should run as a function.
+  if (op->EagerContext().RunEagerOpAsFunction()) {
+    return false;
+  }
   DataType data_type;
   if (op->Attrs().Get("T", &data_type) != Status::OK()) {
     return false;


### PR DESCRIPTION
This PR fixes a failure in //tensorflow/python/framework:node_file_writer_test exposed after eager_op_as_function [feature ](https://github.com/tensorflow/tensorflow/commit/586f4942c50833dad0714adef091a83445c5350d) was enabled by default.