### PR TITLE
Remove the upper bound on setuptools.

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip_new.sh
+++ b/tensorflow/tools/ci_build/builds/pip_new.sh
@@ -468,9 +468,7 @@ install_tensorflow_pip() {
   # Check that requested python version matches configured one.
   check_python_pip_version
 
-  # setuptools v60.0.0 introduced a breaking change on how distutils is linked
-  # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6000
-  ${PIP_BIN_PATH} install --upgrade "setuptools<60" || \
+  ${PIP_BIN_PATH} install --upgrade setuptools || \
     die "Error: setuptools install, upgrade FAILED"
 
   # Force tensorflow reinstallation. Otherwise it may not get installed from

--- a/tensorflow/tools/ci_build/install/install_centos_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_centos_pip_packages.sh
@@ -24,8 +24,8 @@ pip3 install wheel==0.31.1
 
 # Install last working version of setuptools. This must happen before we install
 # absl-py, which uses install_requires notation introduced in setuptools 20.5.
-pip2 install --upgrade setuptools==39.1.0
-pip3 install --upgrade setuptools==39.1.0
+pip2 install --upgrade setuptools
+pip3 install --upgrade setuptools
 
 pip2 install virtualenv
 pip3 install virtualenv

--- a/tensorflow/tools/ci_build/install/install_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_pip_packages.sh
@@ -30,7 +30,7 @@ pip3 install wheel==0.31.1
 
 # Install last working version of setuptools. This must happen before we install
 # absl-py, which uses install_requires notation introduced in setuptools 20.5.
-pip3 install --upgrade setuptools==39.1.0
+pip3 install --upgrade setuptools
 
 pip3 install virtualenv
 

--- a/tensorflow/tools/ci_build/install/install_python3.6_pip_packages.sh
+++ b/tensorflow/tools/ci_build/install/install_python3.6_pip_packages.sh
@@ -51,7 +51,7 @@ pip3 install --upgrade pip
 
 # Install last working version of setuptools. This must happen before we install
 # absl-py, which uses install_requires notation introduced in setuptools 20.5.
-pip3 install --upgrade setuptools==39.1.0
+pip3 install --upgrade setuptools
 
 pip3 install --upgrade virtualenv
 

--- a/tensorflow/tools/ci_build/release/common.sh
+++ b/tensorflow/tools/ci_build/release/common.sh
@@ -117,7 +117,7 @@ function install_ubuntu_16_pip_deps {
   done
 
   # First, upgrade pypi wheels
-  "${PIP_CMD}" install --user --upgrade 'setuptools<60' pip wheel
+  "${PIP_CMD}" install --user --upgrade setuptools pip wheel
 
   # LINT.IfChange(linux_pip_installations_orig)
   # Remove any historical keras package if they are installed.
@@ -146,7 +146,7 @@ function install_ubuntu_16_python_pip_deps {
   done
 
   # First, upgrade pypi wheels
-  ${PIP_CMD} install --user --upgrade 'setuptools<60' pip wheel
+  ${PIP_CMD} install --user --upgrade setuptools pip wheel
 
   # LINT.IfChange(linux_pip_installations)
   # Remove any historical keras package if they are installed.
@@ -189,7 +189,7 @@ function install_ubuntu_pip_deps_novenv () {
   # Install on default python Env (No Virtual Env for pip packages)
   PIP_CMD="${1} -m pip"
   REQUIREMENTS_FNAME="requirements_ubuntu.txt"
-  ${PIP_CMD} install --user --upgrade 'setuptools<60' pip wheel pyparsing auditwheel~=3.3.1
+  ${PIP_CMD} install --user --upgrade setuptools pip wheel pyparsing auditwheel~=3.3.1
   ${PIP_CMD} install --user -r tensorflow/tools/ci_build/release/${REQUIREMENTS_FNAME}
   ${PIP_CMD} list
 
@@ -256,7 +256,7 @@ function install_macos_pip_deps {
   PIP_CMD="python -m pip"
 
   # First, upgrade pypi wheels
-  ${PIP_CMD} install --upgrade 'setuptools<60' pip wheel
+  ${PIP_CMD} install --upgrade setuptools pip wheel
 
   # LINT.IfChange(mac_pip_installations)
   # Remove any historical keras package if they are installed.
@@ -275,7 +275,7 @@ function install_macos_pip_deps_no_venv {
   PIP_CMD="${1} -m pip"
 
   # First, upgrade pypi wheels
-  ${PIP_CMD} install --user --upgrade 'setuptools<60' pip wheel
+  ${PIP_CMD} install --user --upgrade setuptools pip wheel
 
   # LINT.IfChange(mac_pip_installations)
   # Remove any historical keras package if they are installed.

--- a/tensorflow/tools/ci_build/release/common_win.bat
+++ b/tensorflow/tools/ci_build/release/common_win.bat
@@ -24,7 +24,7 @@ SET PY_EXE=C:\%PYTHON_DIRECTORY%\python.exe
 SET PATH=%PATH%;C:\%PYTHON_DIRECTORY%
 
 @REM First, upgrade pypi wheels
-%PY_EXE% -m pip install --upgrade "setuptools<60" pip wheel
+%PY_EXE% -m pip install --upgrade setuptools pip wheel
 
 @REM NOTE: Windows doesn't have any additional requirements from the common ones.
 %PY_EXE% -m pip install -r tensorflow/tools/ci_build/release/requirements_common.txt

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -82,7 +82,7 @@ REQUIRED_PACKAGES = [
     'numpy >= 1.20',
     'opt_einsum >= 2.3.2',
     'protobuf >= 3.9.2',
-    'setuptools < 60',  # TODO(b/211495558): Breaking change in v60 on distutils
+    'setuptools',
     'six >= 1.12.0',
     'termcolor >= 1.1.0',
     'typing_extensions >= 3.6.6',


### PR DESCRIPTION
It seems that our builds are not really determinstic since they now pick
setuptools > 60 in some places and fail. Hence, we remove this bound and
hope that they would pass.