### PR TITLE
Fix out of bound access in DequantizeOp by adding check for axis < in…

### DIFF
--- a/tensorflow/core/kernels/dequantize_op.cc
+++ b/tensorflow/core/kernels/dequantize_op.cc
@@ -94,6 +94,11 @@ class DequantizeOp : public OpKernel {
     const Tensor& input_min_tensor = ctx->input(1);
     const Tensor& input_max_tensor = ctx->input(2);
 
+    OP_REQUIRES(
+        ctx, axis_ < input.dims(),
+        errors::InvalidArgument("Axis must be less than input dimension(",
+                                input.dims(), "), got ", axis_));
+
     int num_slices = 1;
     if (axis_ > -1) {
       num_slices = input.dim_size(axis_);


### PR DESCRIPTION
…put dimension

PiperOrigin-RevId: 411214268
Change-Id: I3249d2a69ddc82f182c589a3a5bbfb71543f4b29