### PR TITLE
Fix several integer overflows

### DIFF
--- a/tensorflow/core/kernels/sparse_dense_binary_op_shared.cc
+++ b/tensorflow/core/kernels/sparse_dense_binary_op_shared.cc
@@ -79,10 +79,23 @@ class SparseDenseBinaryOpShared : public OpKernel {
                     values_t->shape().DebugString(), " and ",
                     shape_t->shape().DebugString()));
     OP_REQUIRES(
+        ctx, TensorShapeUtils::IsVector(shape_t->shape()),
+        errors::InvalidArgument("Input sp_shape must be a vector. Got: ",
+                                shape_t->shape().DebugString()));
+    OP_REQUIRES(
         ctx, values_t->dim_size(0) == indices_t->dim_size(0),
         errors::InvalidArgument(
             "The first dimension of values and indices should match. (",
             values_t->dim_size(0), " vs. ", indices_t->dim_size(0), ")"));
+    OP_REQUIRES(
+        ctx, shape_t->shape().dim_size(0) == indices_t->shape().dim_size(1),
+        errors::InvalidArgument(
+            "Number of dimensions must match second dimension of indices. ",
+            "Got ", shape_t->shape().dim_size(0),
+            " dimensions, indices shape: ", indices_t->shape().DebugString()));
+    OP_REQUIRES(ctx, shape_t->NumElements() > 0,
+                errors::InvalidArgument(
+                    "The shape argument requires at least one element."));
 
     const auto indices_mat = indices_t->matrix<int64>();
     const auto shape_vec = shape_t->vec<int64>();

--- a/tensorflow/core/kernels/sparse_dense_binary_op_shared.cc
+++ b/tensorflow/core/kernels/sparse_dense_binary_op_shared.cc
@@ -99,7 +99,9 @@ class SparseDenseBinaryOpShared : public OpKernel {
 
     const auto indices_mat = indices_t->matrix<int64>();
     const auto shape_vec = shape_t->vec<int64>();
-    const auto lhs_dims = BCast::FromShape(TensorShape(shape_vec));
+    TensorShape lhs_shape;
+    OP_REQUIRES_OK(ctx, TensorShape::BuildTensorShape(shape_vec, &lhs_shape));
+    const auto lhs_dims = BCast::FromShape(lhs_shape);
     const auto rhs_dims = BCast::FromShape(dense_t->shape());
     BCast b(lhs_dims, rhs_dims, false);  // false for keeping the same num dims.
 


### PR DESCRIPTION
Cherrypick 1b54cadd19391b60b6fcccd8d076426f7221d5e8 and 1e4692287b7 on r2.5