### PR TITLE
Fix nullptr exception in QuantizedMaxPool op when empty list is sent …

### DIFF
--- a/tensorflow/core/kernels/quantized_pooling_ops.cc
+++ b/tensorflow/core/kernels/quantized_pooling_ops.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 // See docs in ../ops/nn_ops.cc.
 
+#include "tensorflow/core/framework/op_requires.h"
+#include "tensorflow/core/platform/errors.h"
 #define EIGEN_USE_THREADS
 
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
@@ -117,6 +119,18 @@ class QuantizedMaxPoolingOp : public MaxPoolingOp<Device, T> {
       : MaxPoolingOp<Device, T>(context) {}
 
   void Compute(OpKernelContext* context) override {
+    auto min_input_tensor = context->input(1);
+    auto max_input_tensor = context->input(2);
+    OP_REQUIRES(
+        context, min_input_tensor.NumElements() == 1,
+        errors::InvalidArgument(
+            "min_input must be a scalar float value, got tensor with shape ",
+            min_input_tensor.shape()));
+    OP_REQUIRES(
+        context, max_input_tensor.NumElements() == 1,
+        errors::InvalidArgument(
+            "max_input must be a scalar float value, got tensor with shape ",
+            max_input_tensor.shape()));
     const float min_input = context->input(1).flat<float>()(0);
     const float max_input = context->input(2).flat<float>()(0);
     MaxPoolingOp<Device, T>::Compute(context);


### PR DESCRIPTION
…to min_input or max_input parameters.

PiperOrigin-RevId: 413960973
Change-Id: I9e3ded593f3c4eabf0d6d5dc356e6a19a3ad2682