### PR TITLE
[oneDNN] Enable auto_mixed_precision_mkl for saved_model

### DIFF
--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -1119,6 +1119,7 @@ class Context(object):
     rewriter_toggle("auto_mixed_precision")
     rewriter_toggle("use_plugin_optimizers")
     rewriter_bool("disable_meta_optimizer")
+    rewriter_toggle("auto_mixed_precision_mkl")
     nodes = self._optimizer_experimental_options.get("min_graph_nodes", None)
     if nodes is not None:
       config.graph_options.rewrite_options.min_graph_nodes = nodes
@@ -1746,6 +1747,7 @@ class Context(object):
     rewriter_toggle("auto_mixed_precision")
     rewriter_toggle("use_plugin_optimizers")
     rewriter_bool("disable_meta_optimizer")
+    rewriter_toggle("auto_mixed_precision_mkl")
 
     if rewrite_options.min_graph_nodes != 0:
       options["min_graph_nodes"] = rewrite_options.min_graph_nodes


### PR DESCRIPTION
Add auto_mixed_precision_mkl as an optimizer option to be enabled for saved_model in eager mode using the script change
for example:
Using the following one line in the code the user can enable/disable the optimizer
tf.config.optimizer.set_experimental_options({'auto_mixed_precision_mkl':True})