### PR TITLE
Fix Null-pointer dereference in BuildXlaCompilationCache

### DIFF
--- a/tensorflow/compiler/jit/xla_platform_info.cc
+++ b/tensorflow/compiler/jit/xla_platform_info.cc
@@ -82,11 +82,13 @@ Status BuildXlaCompilationCache(DeviceBase* device, FunctionLibraryRuntime* flr,
   client_options.set_intra_op_parallelism_threads(
       device->tensorflow_cpu_worker_threads()->num_threads);
 
-  string allowed_gpus =
-      flr->config_proto()->gpu_options().visible_device_list();
-  TF_ASSIGN_OR_RETURN(absl::optional<std::set<int>> gpu_ids,
-                      ParseVisibleDeviceList(allowed_gpus));
-  client_options.set_allowed_devices(gpu_ids);
+  if (flr->config_proto()) {
+    string allowed_gpus =
+        flr->config_proto()->gpu_options().visible_device_list();
+    TF_ASSIGN_OR_RETURN(absl::optional<std::set<int>> gpu_ids,
+                        ParseVisibleDeviceList(allowed_gpus));
+    client_options.set_allowed_devices(gpu_ids);
+  }
 
   auto client = xla::ClientLibrary::GetOrCreateLocalClient(client_options);
   if (!client.ok()) {


### PR DESCRIPTION
If ConfigProto is not used, then use the default settings which is to allow all devices.

PiperOrigin-RevId: 420391800
Change-Id: I88161ad7042990aef678e77b597a2fb2c8f815be