### PR TITLE
Fix crash when importing an invalid graph with an empty op type to TFG

### DIFF
--- a/tensorflow/core/ir/importexport/functiondef_import.cc
+++ b/tensorflow/core/ir/importexport/functiondef_import.cc
@@ -158,6 +158,7 @@ Status ImportNodes(ValueMapManager value_manager,
   // Process every node and create a matching MLIR operation
   for (const NodeDef& node : nodes) {
     DVLOG(0) << "Processing node " << node.name() << "\n";
+    if (node.op().empty()) return InvalidArgument("empty op type");
     OperationState state(unknown_loc, absl::StrCat("tfg.", node.op()));
     // Fetch the inputs, creating placeholder if an input hasn't been visited.
     for (const std::string& input : node.input())

--- a/tensorflow/core/ir/importexport/tests/graphdef-to-mlir/invalid_empty_op_type.pbtxt
+++ b/tensorflow/core/ir/importexport/tests/graphdef-to-mlir/invalid_empty_op_type.pbtxt
@@ -1,0 +1,22 @@
+# RUN: not tfg-translate -graphdef-to-mlir %s 2>&1 | FileCheck %s
+
+# CHECK: empty op type
+
+library {
+  function {
+    signature {
+      name: "XTimesTwo"
+    }
+    node_def {
+      name: "value"
+      attr {
+        key: "Tin"
+        value {
+          placeholder: "\t"
+        }
+      }
+    }
+  }
+}
+versions {
+}


### PR DESCRIPTION
Found by proto fuzzing.

PiperOrigin-RevId: 413847837
Change-Id: Icac24d1b389c5661800fb4d622dff0b31d846cca