### PR TITLE
Gracefully catch errors when importing an invalid graphdef in MLIR TFG

### DIFF
--- a/tensorflow/core/ir/importexport/functiondef_import.cc
+++ b/tensorflow/core/ir/importexport/functiondef_import.cc
@@ -65,12 +65,18 @@ class ValueMapManager {
         placeholder_ty_(placeholder_ty),
         control_ty_(control_ty) {}
 
-  void DefineOperation(Operation* op, StringRef node_name) {
+  Status DefineOperation(Operation* op, StringRef node_name) {
     llvm::StringMap<SmallVector<Value, 1>>& op_info = values_map_[node_name];
     SmallVector<Value, 1>& base_operation = op_info["^"];
     // Replace placeholders.
     if (!base_operation.empty()) {
       Operation* placeholder = base_operation[0].getDefiningOp();
+      if (!placeholder ||
+          placeholder->getName().getStringRef() != "tfg.__mlir_placeholder")
+        return InvalidArgument(absl::StrCat(
+            "Duplicated node (or function argument) with the same name: `",
+            node_name.str(), "`"));
+
       op->moveBefore(placeholder);
       placeholder->replaceAllUsesWith(op);
       placeholder->erase();
@@ -78,6 +84,7 @@ class ValueMapManager {
     }
     base_operation.push_back(op->getResult(1));
     base_operation.push_back(op->getResult(0));
+    return Status::OK();
   }
 
   Value GetValueOrCreatePlaceholder(StringRef full_name) {
@@ -186,7 +193,7 @@ Status ImportNodes(ValueMapManager value_manager,
       if (colon_sep != StringRef::npos)
         node_name = node_name.take_front(colon_sep);
     }
-    value_manager.DefineOperation(op, node_name);
+    TF_RETURN_IF_ERROR(value_manager.DefineOperation(op, node_name));
   }
   // We don't expect any placeholder left at this point, fail if any.
   for (Operation& op : *builder.getInsertionBlock()) {
@@ -403,7 +410,9 @@ Status ImportGenericFunction(
   // Import the function body here, after this we have a function with all
   // the nodes, and the nodes_map contains the mapping from node_name to actual
   // MLIR Operations.
-  TF_RETURN_IF_ERROR(ImportNodes(value_manager, func.node_def(), body_builder));
+  TF_RETURN_WITH_CONTEXT_IF_ERROR(
+      ImportNodes(value_manager, func.node_def(), body_builder),
+      " when importing function ", func.signature().name());
 
   // After the body, the final part is to setup the return. It comes in two
   // parts: the `ret` field from the FunctionDef for the regular output and the

--- a/tensorflow/core/ir/importexport/tests/graphdef-to-mlir/invalid_arg_name.pbtxt
+++ b/tensorflow/core/ir/importexport/tests/graphdef-to-mlir/invalid_arg_name.pbtxt
@@ -1,0 +1,50 @@
+# RUN: not tfg-translate -graphdef-to-mlir %s 2>&1 | FileCheck %s
+
+# CHECK: INVALID_ARGUMENT: Duplicated node (or function argument) with the same name: `x`
+# CHECK-NEXT: when importing function DuplicatedName
+
+library {
+  function {
+    signature {
+      name: "DuplicatedName"
+      input_arg {
+        name: "x"
+        type_attr: "T"
+      }
+      output_arg {
+        name: "y"
+        type_attr: "T"
+      }
+      attr {
+        name: "T"
+        type: "type"
+        allowed_values {
+          list {
+            type: DT_FLOAT
+            type: DT_DOUBLE
+            type: DT_INT32
+            type: DT_INT64
+          }
+        }
+      }
+    }
+    node_def {
+      name: "x"
+      op: "Identity"
+      input: "x"
+      attr {
+        key: "T"
+        value {
+          placeholder: "T"
+        }
+      }
+    }
+    ret {
+      key: "y"
+      value: "x"
+    }
+  }
+}
+versions {
+  producer: 762
+}

--- a/tensorflow/core/ir/importexport/tests/graphdef-to-mlir/invalid_duplicated_node_name.pbtxt
+++ b/tensorflow/core/ir/importexport/tests/graphdef-to-mlir/invalid_duplicated_node_name.pbtxt
@@ -1,0 +1,61 @@
+# RUN: not tfg-translate -graphdef-to-mlir %s 2>&1 | FileCheck %s
+
+# CHECK: INVALID_ARGUMENT: Duplicated node (or function argument) with the same name: `y`
+# CHECK-NEXT: when importing function DuplicatedName
+
+library {
+  function {
+    signature {
+      name: "DuplicatedName"
+      input_arg {
+        name: "x"
+        type_attr: "T"
+      }
+      output_arg {
+        name: "y"
+        type_attr: "T"
+      }
+      attr {
+        name: "T"
+        type: "type"
+        allowed_values {
+          list {
+            type: DT_FLOAT
+            type: DT_DOUBLE
+            type: DT_INT32
+            type: DT_INT64
+          }
+        }
+      }
+    }
+    node_def {
+      name: "y"
+      op: "Identity"
+      input: "x"
+      attr {
+        key: "T"
+        value {
+          placeholder: "T"
+        }
+      }
+    }
+    node_def {
+      name: "y"
+      op: "Identity"
+      input: "x"
+      attr {
+        key: "T"
+        value {
+          placeholder: "T"
+        }
+      }
+    }
+    ret {
+      key: "y"
+      value: "y"
+    }
+  }
+}
+versions {
+  producer: 762
+}


### PR DESCRIPTION
When importing a "generic function" in TFG, we don't build a Graph in memory and
so we need to implement a bit more checking in the importer itself.
This particular case catches duplicated names between nodes or between nodes and
function arguments, and fixes a crash found by the fuzzer.

PiperOrigin-RevId: 409331027
Change-Id: Ibaf6290f67908c020c5103a7e009bdffd88690e2