### PR TITLE
Properly handle the case where `SpecializeType()` returns an error `S…

### DIFF
--- a/tensorflow/core/framework/shape_inference.cc
+++ b/tensorflow/core/framework/shape_inference.cc
@@ -170,7 +170,10 @@ void InferenceContext::PreInputInit(
     const std::vector<ShapeHandle>& input_tensors_as_shapes) {
   // TODO(mdan): This is also done at graph construction. Run only here instead?
   const auto ret = full_type::SpecializeType(attrs_, op_def);
-  DCHECK(ret.status().ok()) << "while instantiating types: " << ret.status();
+  if (!ret.status().ok()) {
+    construction_status_ = ret.status();
+    return;
+  }
   ret_types_ = ret.ValueOrDie();
 
   input_tensors_ = input_tensors;


### PR DESCRIPTION
…tatus`.

If the error case in `SpecializeType()` is reached, then we would get a crash when trying to access the value of an errorenous `StatusOr` object

PiperOrigin-RevId: 408380069
Change-Id: If3c3fc876dcf9384d5ec7a4985adc68c23ea7318