### PR TITLE
Add cmake configuration to mlir-hlo for external projects

### DIFF
--- a/tensorflow/compiler/mlir/hlo/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/CMakeLists.txt
@@ -146,6 +146,9 @@ endif()
 
 set(MLIR_HLO_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(MLIR_HLO_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(MLIR_HLO_MAIN_INCLUDE_DIR ${MLIR_HLO_SOURCE_DIR}/include )
+set(MLIR_HLO_GEN_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include)
+set(MLIR_HLO_LIB_DIR ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 add_custom_target(check-mlir-hlo)
 
@@ -157,3 +160,5 @@ add_subdirectory(tests)
 if(MHLO_ENABLE_BINDINGS_PYTHON)
   add_subdirectory(python)
 endif()
+
+add_subdirectory(cmake/modules)

--- a/tensorflow/compiler/mlir/hlo/README.md
+++ b/tensorflow/compiler/mlir/hlo/README.md
@@ -264,3 +264,17 @@ ninja MLIRHLOPythonModules
 export PYTHONPATH=$PWD/tools/mlir_hlo/python_packages/mlir_hlo
 python -c "import mlir.dialects.mhlo"
 ```
+
+## External projects that depend on mlir-hlo
+
+External projects that need to depend on `mlir-hlo` (for example via a git
+submodule) can use the following setting in their cmake configuration in order
+for `find_package(MHLO)` to import all mlir-hlo cmake targets into their build
+setup and have access to the required include and lib variables (see generated
+`MHLOConfig.cmake`).
+
+```
+...
+   -DMHLO_DIR=<path to mlir-hlo build dir>/lib/cmake/mlir-hlo
+   ...
+```

--- a/tensorflow/compiler/mlir/hlo/cmake/modules/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/cmake/modules/CMakeLists.txt
@@ -1,0 +1,63 @@
+# Generate a list of CMake library targets so that other CMake projects can
+# link against them. LLVM calls its version of this file LLVMExports.cmake, but
+# the usual CMake convention is ${Project}Targets.cmake.
+# This configuration has been partly adapted from MLIR project's
+# (llvm-project:mlir/cmake/modules).
+
+include(LLVMDistributionSupport)
+
+set(MHLO_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/mlir-hlo)
+set(mhlo_cmake_builddir "${CMAKE_BINARY_DIR}/${MHLO_INSTALL_PACKAGE_DIR}")
+
+# Keep this in sync with llvm/cmake/CMakeLists.txt!
+set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
+set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
+
+# Since we just use MLIR's cmake functions (add_mlir_library, etc.),
+# MLIR_EXPORTS would have the necessary targets to export.
+get_property(MLIR_EXPORTS GLOBAL PROPERTY MLIR_EXPORTS)
+export(TARGETS ${MLIR_EXPORTS} FILE ${mhlo_cmake_builddir}/MHLOTargets.cmake)
+
+# Generate MlirConfig.cmake for the build tree.
+set(MHLO_CONFIG_CMAKE_DIR "${mhlo_cmake_builddir}")
+set(MHLO_CONFIG_LLVM_CMAKE_DIR "${llvm_cmake_builddir}")
+set(MHLO_CONFIG_INCLUDE_EXPORTS "include(\"\${MHLO_CMAKE_DIR}/MHLOTargets.cmake\")")
+set(MHLO_CONFIG_INCLUDE_DIRS
+  "${MLIR_HLO_MAIN_INCLUDE_DIR}"
+  "${MLIR_HLO_GEN_INCLUDE_DIR}"
+  )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/MHLOConfig.cmake.in
+  ${mhlo_cmake_builddir}/MHLOConfig.cmake
+  @ONLY)
+# Unset the variables now that the file is configured.
+set(MHLO_CONFIG_CMAKE_DIR)
+set(MHLO_CONFIG_LLVM_CMAKE_DIR)
+set(MHLO_CONFIG_INCLUDE_DIRS)
+
+# Generate MHLOConfig.cmake for the install tree.
+set(MHLO_CONFIG_CODE "
+# Compute the installation prefix from this MHLOConfig.cmake file location.
+get_filename_component(MHLO_INSTALL_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)")
+# Construct the proper number of get_filename_component(... PATH)
+# calls to compute the installation prefix.
+string(REGEX REPLACE "/" ";" _count "${MHLO_INSTALL_PACKAGE_DIR}")
+foreach(p ${_count})
+  set(MHLO_CONFIG_CODE "${MHLO_CONFIG_CODE}
+get_filename_component(MHLO_INSTALL_PREFIX \"\${MHLO_INSTALL_PREFIX}\" PATH)")
+endforeach(p)
+set(MHLO_CONFIG_CMAKE_DIR "\${MHLO_INSTALL_PREFIX}/${MHLO_INSTALL_PACKAGE_DIR}")
+set(MHLO_CONFIG_LLVM_CMAKE_DIR "\${MHLO_INSTALL_PREFIX}/${LLVM_INSTALL_PACKAGE_DIR}")
+get_config_exports_includes(MHLO MHLO_CONFIG_INCLUDE_EXPORTS)
+set(MHLO_CONFIG_INCLUDE_DIRS
+  "\${MHLO_INSTALL_PREFIX}/include"
+  )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/MHLOConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/MHLOConfig.cmake
+  @ONLY)
+# Unset the variables now that the file is configured.
+set(MHLO_CONFIG_CODE)
+set(MHLO_CONFIG_CMAKE_DIR)
+set(MHLO_CONFIG_LLVM_CMAKE_DIR)
+set(MHLO_CONFIG_INCLUDE_DIRS)

--- a/tensorflow/compiler/mlir/hlo/cmake/modules/MHLOConfig.cmake.in
+++ b/tensorflow/compiler/mlir/hlo/cmake/modules/MHLOConfig.cmake.in
@@ -1,0 +1,16 @@
+# This file allows users to call find_package(MHLO) and pick up mlir-hlo targets.
+
+@MHLO_CONFIG_CODE@
+
+# MLIR is needed for this setup to be usable.
+find_package(MLIR REQUIRED CONFIG)
+
+# Set variables needed by dependent projects.
+set(MHLO_BUILD_LIBRARY_DIR "@MLIR_HLO_LIB_DIR@")
+set(MHLO_CMAKE_DIR "@MHLO_CONFIG_CMAKE_DIR@")
+set(MHLO_ENABLE_BINDINGS_PYTHON "@MHLO_ENABLE_BINDINGS_PYTHON@")
+set(MHLO_EXPORTED_TARGETS "@MLIR_EXPORTS@")
+set(MHLO_INCLUDE_DIRS "@MHLO_CONFIG_INCLUDE_DIRS@")
+
+# Provide all our library targets to users.
+@MHLO_CONFIG_INCLUDE_EXPORTS@


### PR DESCRIPTION
Add cmake configuration for mlir-hlo so that external projects that want
to depend on it can import its cmake targets using `find_package` and 
`-DMHLO_DIR=...`.