### PR TITLE
Prevent integer overflow in `CalculateTensorSize`.

### DIFF
--- a/tensorflow/core/grappler/costs/BUILD
+++ b/tensorflow/core/grappler/costs/BUILD
@@ -182,6 +182,7 @@ tf_cuda_library(
         "//tensorflow/core:lib_proto_parsing",
         "//tensorflow/core:protos_all_cc",
         "//tensorflow/core/grappler:utils",
+        "//tensorflow/core/util:overflow",
         "//tensorflow/core/grappler/clusters:utils",
     ] + tf_protos_grappler(),
 )

--- a/tensorflow/core/grappler/costs/utils_test.cc
+++ b/tensorflow/core/grappler/costs/utils_test.cc
@@ -202,6 +202,10 @@ TEST(UtilsTest, CalculateTensorSize) {
   EXPECT_EQ(
       DataTypeSize(DT_FLOAT) * 1 * 7 * 1 * 99,
       CalculateTensorSize(ShapeToTensorProperty({-1, 7, -1, 99}, DT_FLOAT)));
+
+  // Test overflow
+  EXPECT_EQ(-1, CalculateTensorSize(ShapeToTensorProperty(
+                    {4096, 4096, 4096, 33554432}, DT_FLOAT)));
 }
 
 TEST(UtilsTest, CalculateOutputSize) {


### PR DESCRIPTION
In order to not change the API, we return a negative value in case of overflow. A better fix is to change the API to return a status instead.

PiperOrigin-RevId: 408714915
Change-Id: I110ec4e1c5bbf4d7ca7ef7c068dfd3e8bc7190cd