### PR TITLE
Eliminate `CHECK`-fails from `IsSimplifiableReshape` via `MakeShape(<…

### DIFF
--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -1725,14 +1725,16 @@ bool ConstantFolding::IsSimplifiableReshape(
       int32 dim = outputs[0]->flat<int32>()(i);
       shp.push_back(dim);
     }
-    TF_CHECK_OK(TensorShapeUtils::MakeShape(shp, &new_dims));
+    s = TensorShapeUtils::MakeShape(shp, &new_dims);
+    if (!s.ok()) return s;
   } else {
     std::vector<int64> shp;
     for (int i = 0; i < outputs[0]->NumElements(); ++i) {
       int64 dim = outputs[0]->flat<int64>()(i);
       shp.push_back(dim);
     }
-    TF_CHECK_OK(TensorShapeUtils::MakeShape(shp, &new_dims));
+    s = TensorShapeUtils::MakeShape(shp, &new_dims);
+    if (!s.ok()) return s;
   }
 
   return shape.IsCompatibleWith(new_dims);


### PR DESCRIPTION
…invalid shape>)`

PiperOrigin-RevId: 409166738
Change-Id: I7f0a3590b8acae3f3e3e2fe636e1f5ef285693cf