### PR TITLE
Prevent use after free in `DecodePng` kernel.

### DIFF
--- a/tensorflow/core/kernels/image/decode_image_op.cc
+++ b/tensorflow/core/kernels/image/decode_image_op.cc
@@ -339,7 +339,6 @@ class DecodeImageV2Op : public OpKernel {
     if (width != static_cast<int64>(decode.width) || width <= 0 ||
         width >= (1LL << 27) || height != static_cast<int64>(decode.height) ||
         height <= 0 || height >= (1LL << 27) || total_size >= (1LL << 29)) {
-      png::CommonFreeDecode(&decode);
       OP_REQUIRES(context, false,
                   errors::InvalidArgument("PNG size too large for int: ",
                                           decode.width, " by ", decode.height));


### PR DESCRIPTION
We are cleaning up the memory in `decode` and then we are using an `OP_REQUIRES` to check an invariant on the `decode` data.

PiperOrigin-RevId: 409299145
Change-Id: I4eb93aaca52483eb202e89b78df07fbb2f6cb254