### PR TITLE
In case of error in `DecodePng`, end kernel execution immediately.

### DIFF
--- a/tensorflow/core/kernels/image/decode_image_op.cc
+++ b/tensorflow/core/kernels/image/decode_image_op.cc
@@ -346,15 +346,18 @@ class DecodeImageV2Op : public OpKernel {
     }
 
     Tensor* output = nullptr;
-    Status status;
     // By the existing API, we support decoding PNG with `DecodeGif` op.
     // We need to make sure to return 4-D shapes when using `DecodeGif`.
     if (op_type_ == "DecodeGif") {
-      status = context->allocate_output(
-          0, TensorShape({1, height, width, decode.channels}), &output);
+      OP_REQUIRES_OK(
+          context,
+          context->allocate_output(
+              0, TensorShape({1, height, width, decode.channels}), &output));
     } else {
-      status = context->allocate_output(
-          0, TensorShape({height, width, decode.channels}), &output);
+      OP_REQUIRES_OK(
+          context,
+          context->allocate_output(
+              0, TensorShape({height, width, decode.channels}), &output));
     }
 
     if (op_type_ == "DecodeBmp") {
@@ -373,9 +376,6 @@ class DecodeImageV2Op : public OpKernel {
                       "DecodeAndCropJpeg operation can run on JPEG only, but "
                       "detected PNG."));
     }
-
-    if (!status.ok()) png::CommonFreeDecode(&decode);
-    OP_REQUIRES_OK(context, status);
 
     if (data_type_ == DataType::DT_UINT8) {
       OP_REQUIRES(


### PR DESCRIPTION
There are scenarios where we detect an error in `DecodePng` kernel, yet the execution continues for a while longer before an error is thrown. This is not safe.

PiperOrigin-RevId: 409299935
Change-Id: Ife488b410148032ae777f59bc51864e172553fdf