### PR TITLE
Prevent overflow in `CalculateTensorElementCount`

### DIFF
--- a/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
+++ b/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
@@ -1544,7 +1544,14 @@ int64_t OpLevelCostEstimator::CalculateTensorElementCount(
   auto tensor_shape =
       MaybeGetMinimumShape(tensor.shape(), num_dims, found_unknown_shapes);
   for (const auto& dim : tensor_shape.dim()) {
-    tensor_size *= dim.size();
+    int64_t new_tensor_size = MultiplyWithoutOverflow(tensor_size, dim.size());
+    if (new_tensor_size < 0) {
+      VLOG(1) << "Overflow encountered when computing element count of a "
+                 "tensor, multiplying "
+              << tensor_size << " with " << dim.size();
+      return -1;
+    }
+    tensor_size = new_tensor_size;
   }
   return tensor_size;
 }


### PR DESCRIPTION
Grappler cost estimation sometimes computes the number of elements in a tensor by multiplying all the dimensions in a shape. However, these tensors can also be controlled by users so a malicious attacker can trigger overflow that can be exploited.

PiperOrigin-RevId: 409575048
Change-Id: I7a958875ba6f3ad9cb5b9943fe5d459efcbe4557