### PR TITLE
Fix `CHECK`-failure caused by constant folding code.

### DIFF
--- a/tensorflow/core/grappler/optimizers/constant_folding.cc
+++ b/tensorflow/core/grappler/optimizers/constant_folding.cc
@@ -1013,7 +1013,12 @@ bool ConstantFolding::IsFoldableUncached(
       }
     }
     for (const auto& output_prop : output_props) {
-      const PartialTensorShape output_shape(output_prop.shape());
+      PartialTensorShape output_shape;
+      if (!PartialTensorShape::BuildPartialTensorShape(output_prop.shape(),
+                                                       &output_shape)
+               .ok()) {
+        return false;
+      }
       if (output_shape.IsFullyDefined()) {
         const int64 num_bytes =
             output_shape.num_elements() * DataTypeSize(output_prop.dtype());


### PR DESCRIPTION
We're losing a `const` qualifier here, but unless we get to use more `StatusOr` objects, this is the best alternative.

PiperOrigin-RevId: 410072241
Change-Id: I69535c91490f0d23facb9587d2ff59db0782cda6