### PR TITLE
[TFLite] Check that the SameOperandsAndResultsScale trait of the Maximum/Minimum ops is respected

### DIFF
--- a/tensorflow/lite/kernels/maximum_minimum.cc
+++ b/tensorflow/lite/kernels/maximum_minimum.cc
@@ -61,6 +61,20 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
                           op_context.input2->type);
   op_context.output->type = op_context.input1->type;
 
+  TF_LITE_ENSURE_EQ(context, op_context.input1->params.scale,
+                    op_context.input2->params.scale);
+  TF_LITE_ENSURE_EQ(context, op_context.input1->params.scale,
+                    op_context.output->params.scale);
+  TF_LITE_ENSURE_EQ(context, op_context.input1->params.zero_point,
+                    op_context.input2->params.zero_point);
+  TF_LITE_ENSURE_EQ(context, op_context.input1->params.zero_point,
+                    op_context.output->params.zero_point);
+  if (op_context.input1->type == kTfLiteInt16) {
+    TF_LITE_ENSURE_EQ(context, op_context.input1->params.zero_point, 0);
+    TF_LITE_ENSURE_EQ(context, op_context.input2->params.zero_point, 0);
+    TF_LITE_ENSURE_EQ(context, op_context.output->params.zero_point, 0);
+  }
+
   bool requires_broadcast =
       !HaveSameShapes(op_context.input1, op_context.input2);
 


### PR DESCRIPTION
Hello,

The Maximum/Minimum ops require the scaling and zero-point to be the same for the inputs and outputs. This PR adds an extra check in the Prepare method of the ops to avoid failing silently if it isn't the case due to wrongly set quantization parameters in a TFLite file.

Thibaut