### PR TITLE
Prevent integer overflow in `CalculateTensorSize`.

### DIFF
--- a/tensorflow/core/grappler/costs/BUILD
+++ b/tensorflow/core/grappler/costs/BUILD
@@ -182,6 +182,7 @@ tf_cuda_library(
         "//tensorflow/core:lib_proto_parsing",
         "//tensorflow/core:protos_all_cc",
         "//tensorflow/core/grappler:utils",
+        "//tensorflow/core/util:overflow",
         "//tensorflow/core/grappler/clusters:utils",
     ] + tf_protos_grappler(),
 )

--- a/tensorflow/core/grappler/costs/utils.cc
+++ b/tensorflow/core/grappler/costs/utils.cc
@@ -45,6 +45,7 @@ limitations under the License.
 #include "tensorflow/core/platform/protobuf.h"
 #include "tensorflow/core/protobuf/config.pb.h"
 #include "tensorflow/core/util/device_name_utils.h"
+#include "tensorflow/core/util/overflow.h"
 
 namespace tensorflow {
 namespace grappler {
@@ -217,7 +218,13 @@ int64 CalculateTensorSize(const OpInfo::TensorProperties& prop) {
   }
 
   int64 num_elems = TensorShape(shape).num_elements();
-  return num_elems * size;
+  int64 tensor_size = MultiplyWithoutOverflow(num_elems, size);
+  if (tensor_size < 0) {
+    VLOG(1) << "Overflow encountered when computing tensor size, multiplying "
+            << num_elems << " with " << size;
+    return -1;
+  }
+  return tensor_size;
 }
 
 int64 CalculateOutputSize(

--- a/tensorflow/core/grappler/costs/utils_test.cc
+++ b/tensorflow/core/grappler/costs/utils_test.cc
@@ -202,6 +202,10 @@ TEST(UtilsTest, CalculateTensorSize) {
   EXPECT_EQ(
       DataTypeSize(DT_FLOAT) * 1 * 7 * 1 * 99,
       CalculateTensorSize(ShapeToTensorProperty({-1, 7, -1, 99}, DT_FLOAT)));
+
+  // Test overflow
+  EXPECT_EQ(-1, CalculateTensorSize(ShapeToTensorProperty(
+                    {4096, 4096, 4096, 33554432}, DT_FLOAT)));
 }
 
 TEST(UtilsTest, CalculateOutputSize) {


### PR DESCRIPTION
In order to not change the API, we return a negative value in case of overflow. A better fix is to change the API to return a status instead.

PiperOrigin-RevId: 408714915
Change-Id: I110ec4e1c5bbf4d7ca7ef7c068dfd3e8bc7190cd