### PR TITLE
AssignOffsetsToTensors with GREEDY_BY_SIZE causes a segfault on NVidia

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -218,6 +218,9 @@ endif()
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_android\\.cc$")
 endif()
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+  list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_default\\.cc$")
+endif()
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "iOS")
   list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_ios\\.cc$")
 endif()
@@ -496,6 +499,13 @@ target_include_directories(tensorflow-lite
   PUBLIC
     ${TFLITE_INCLUDE_DIRS}
 )
+
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+  list(APPEND TFLITE_TARGET_DEPENDENCIES
+    log
+  )
+endif()
+
 target_link_libraries(tensorflow-lite
   PUBLIC
     Eigen3::Eigen

--- a/tensorflow/lite/delegates/gpu/cl/inference_context.cc
+++ b/tensorflow/lite/delegates/gpu/cl/inference_context.cc
@@ -434,7 +434,7 @@ absl::Status InferenceContext::AllocateMemoryForBuffers(const GpuInfo& gpu_info,
   OffsetsAssignment offset_assignment;
   if (CanUseSubBuffer(gpu_info)) {
     RETURN_IF_ERROR(AssignOffsetsToTensors(
-        buffer_usage_records, MemoryStrategy::GREEDY_BY_SIZE,
+        buffer_usage_records, MemoryStrategy::EQUALITY,
         &offset_assignment, base_align_bytes));
     if (offset_assignment.total_size < TotalSize(buffer_assignment) &&
         offset_assignment.total_size <= gpu_info.GetMaxBufferSize()) {


### PR DESCRIPTION
- Calling AssignOffsetsToTensors with MemoryStrategy::GREEDY_BY_SIZE appears to cause a segfault on NVidia OpenCL. See issue https://github.com/tensorflow/tensorflow/issues/53800 for more details.

- Fixed some undefine/duplicate definition linker error (related to logging classes) when building for Android using CMake.