### PR TITLE
Fix crash on invalid graph importing to TFG when there is a func_attr…

### DIFF
--- a/tensorflow/core/ir/importexport/convert_attributes.cc
+++ b/tensorflow/core/ir/importexport/convert_attributes.cc
@@ -365,6 +365,8 @@ tensorflow::StatusOr<Attribute> ConvertNonFuncAttributeValue(
           TF_ASSIGN_OR_RETURN(
               auto attr,
               ConvertAttributeValue(subattr.second, builder, tfgDialect));
+          if (subattr.first.empty())
+            return InvalidArgument("empty func_attr name");
           subattrs.push_back(builder.getNamedAttr(subattr.first, attr));
         }
         attrs.push_back(FuncAttr::get(builder.getContext(), func_attr.name(),

--- a/tensorflow/core/ir/importexport/tests/graphdef-to-mlir/invalid_empty_func_attr_name.pbtxt
+++ b/tensorflow/core/ir/importexport/tests/graphdef-to-mlir/invalid_empty_func_attr_name.pbtxt
@@ -1,0 +1,38 @@
+# RUN: not tfg-translate -graphdef-to-mlir %s 2>&1 | FileCheck %s
+
+# CHECK: empty func_attr name
+
+node {
+  name: "NoOp"
+  op: "NoOp"
+  attr {
+    key: "dense_shapes"
+    value {
+      list {
+        shape {
+          dim {
+            size: 1
+          }
+        }
+        shape {
+          dim {
+            size: 1
+          }
+        }
+        func {
+          attr {
+            key: ""
+            value {
+              type: DT_QINT16
+            }
+          }
+        }
+      }
+    }
+  }
+}
+library {
+}
+versions {
+  producer: 27
+}


### PR DESCRIPTION
… with an empty key.

Found by fuzzing.

PiperOrigin-RevId: 414089748
Change-Id: Ibdbb5aed29f36abd4bb66f7ef854868dc6b9d95c