### PR TITLE
Add disable for depthwise-conv d9m-unimplemented exception

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4133,7 +4133,7 @@ tf_kernel_library(
         "@local_config_cuda//cuda:cudnn_header",
     ]) + if_rocm([
         "@local_config_rocm//rocm:rocprim",
-    ]),
+    ]) + if_cuda_or_rocm([":gpu_utils"]),
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -46,6 +46,7 @@ limitations under the License.
 #endif
 
 #include "tensorflow/core/platform/stream_executor.h"
+#include "tensorflow/core/util/env_var.h"
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace tensorflow {
@@ -264,7 +265,18 @@ extern template struct LaunchDepthwiseConvOp<GPUDevice, Eigen::half>;
 extern template struct LaunchDepthwiseConvOp<GPUDevice, float>;
 extern template struct LaunchDepthwiseConvOp<GPUDevice, double>;
 
-#endif
+bool DisableDepthwiseConvDeterminismExceptions() {
+  static bool cached_disable = [] {
+    bool disable = false;
+    TF_CHECK_OK(tensorflow::ReadBoolFromEnvVar(
+        "TF_DISABLE_DEPTHWISE_CONV_DETERMINISM_EXCEPTIONS",
+        /*default_val*/false, &disable));
+    return disable;
+  }();
+  return cached_disable;
+}
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 template <typename Device, typename T>
 class DepthwiseConv2dNativeOp : public BinaryOp<T> {

--- a/tensorflow/core/kernels/depthwise_conv_op.h
+++ b/tensorflow/core/kernels/depthwise_conv_op.h
@@ -101,7 +101,8 @@ struct LaunchDepthwiseConvBackpropFilterOp<Eigen::GpuDevice, T> {
                   const T* out_backprop, const T* input, T* filter_backprop,
                   TensorFormat data_format);
 };
-#endif
+bool DisableDepthwiseConvDeterminismExceptions();
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/depthwise_conv_op_gpu.h
+++ b/tensorflow/core/kernels/depthwise_conv_op_gpu.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/depthwise_conv_op.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/determinism.h"
+#include "tensorflow/core/util/env_var.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
 #include "tensorflow/core/util/tensor_format.h"
 
@@ -1751,6 +1752,19 @@ Status LaunchDepthwiseConv2dBackpropFilterGPU(
   }
 }
 
+// By disabling this exception, we can discover if other determinism exceptions
+// are reached in the execution of a given model.
+bool DisableDepthwiseConvDeterminismExceptions() {
+  static bool cached_disable = [] {
+    bool disable = false;
+    TF_CHECK_OK(tensorflow::ReadBoolFromEnvVar(
+        "TF_DISABLE_DEPTHWISE_CONV_DETERMINISM_EXCEPTIONS",
+        /*default_val*/false, &disable));
+    return disable;
+  }();
+  return cached_disable;
+}
+
 // A simple launch pad to launch the GPU kernel for depthwise convolution.
 template <typename T>
 void LaunchDepthwiseConvBackpropFilterOp<GpuDevice, T>::operator()(
@@ -1759,7 +1773,8 @@ void LaunchDepthwiseConvBackpropFilterOp<GpuDevice, T>::operator()(
   auto stream = ctx->op_device_context()->stream();
 
   OP_REQUIRES(
-      ctx, !OpDeterminismRequired(),
+      ctx,
+      !OpDeterminismRequired() || DisableDepthwiseConvDeterminismExceptions(),
       errors::Unimplemented(
           "A deterministic GPU implementation of DepthwiseConvBackpropFilter is"
           " not currently available."));


### PR DESCRIPTION
This pull request adds the environment variable `TF_DISABLE_DEPTHWISE_CONV_DETERMINISM_EXCEPTIONS`, which, when set to `'true'` or `'1'` will disable the determinism-unimplemented exception-throwing functionality of `tf.nn.depthwise_conv2d`. The intention of this is to allow a program to run further, to discover if other determinism-unimplemented exceptions would be thrown in the absence of this exception. When this disable is activated, nondeterministic operation is, of course, extremely likely.

This environment variable is intended for debug purposes, and is related to issue [47174](https://github.com/tensorflow/tensorflow/issues/47174) and specifically to [this comment](https://github.com/tensorflow/tensorflow/issues/47174#issuecomment-976179644) in that issue.