### PR TITLE
Requires a newer version of the libclang package.

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -82,7 +82,7 @@ REQUIRED_PACKAGES = [
     'google_pasta >= 0.1.1',
     'h5py >= 2.9.0',
     'keras_preprocessing >= 1.1.1',  # 1.1.0 needs tensorflow==1.7
-    'libclang >= 9.0.1',
+    'libclang >= 13.0.0',
     'numpy >= 1.20',
     'opt_einsum >= 2.3.2',
     'packaging',


### PR DESCRIPTION
We recently made some mistakes during maintaining the package `libclang` and the version v12.0.0 has been broken for some package managers like poetry (see issue https://github.com/sighingnow/libclang/issues/19).

Older versions of libclang has bugs about installed unintented files to users' `site-packages` directory.

This PR force the requirement of libclang to v13.0.0 to fix above issues.
