### PR TITLE
lite: Update Windows tensorflowlite_flex.dll build

### DIFF
--- a/tensorflow/lite/delegates/flex/BUILD
+++ b/tensorflow/lite/delegates/flex/BUILD
@@ -122,7 +122,7 @@ tflite_flex_cc_library(
 # ops and kernels. The output library name is platform dependent:
 #   - Linux/Android: `libtensorflowlite_flex.so`
 #   - Mac: `libtensorflowlite_flex.dylib`
-#   - Windows: `libtensorflowlite_flex.dll`
+#   - Windows: `tensorflowlite_flex.dll`
 tflite_flex_shared_library(
     name = "tensorflowlite_flex",
 )

--- a/tensorflow/lite/delegates/flex/build_def.bzl
+++ b/tensorflow/lite/delegates/flex/build_def.bzl
@@ -216,9 +216,6 @@ def tflite_flex_shared_library(
 
     tflite_cc_shared_object(
         name = name,
-        # Until we have more granular symbol export for the C++ API on Windows,
-        # export all symbols.
-        features = ["windows_export_all_symbols"],
         linkopts = select({
             "//tensorflow:macos": [
                 "-Wl,-exported_symbols_list,$(location //tensorflow/lite/delegates/flex:exported_symbols.lds)",


### PR DESCRIPTION
Removed "windows_export_all_symbols" feature since Flex delegate only requires
to expose `TF_AcquireFlexDelegate` symbol.
This change is needed for Issue#43367.

PiperOrigin-RevId: 424060071
Change-Id: I8874ce6b107f6db9c5445b65e55073ea46266c76