### PR TITLE
kernel_tests/linalg:self_adjoint_eig_op_test.py 

### DIFF
--- a/tensorflow/python/kernel_tests/linalg/self_adjoint_eig_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/self_adjoint_eig_op_test.py
@@ -198,7 +198,7 @@ def _GetSelfAdjointEigGradTest(dtype_, shape_, compute_v_):
 
     # Optimal stepsize for central difference is O(epsilon^{1/3}).
     epsilon = np.finfo(np_dtype).eps
-    delta = 0.1 * epsilon**(1.0 / 3.0)
+    delta = 0.08 * epsilon**(1.0 / 3.0)
     # tolerance obtained by looking at actual differences using
     # np.linalg.norm(theoretical-numerical, np.inf) on -mavx build
     # after discarding one random input sample


### PR DESCRIPTION
Updating delta variable according to the following PR: https://github.com/tensorflow/tensorflow/issues/52544

This is addressing a bug when running the self_adjoint_eig_op_test bazel test on aarch64 devices.
Reducing the delta variable from .1 to .08 resolves this. This bug is confirmed to be present on master branch and resolved by this change on master.

Signed-off-by: Theodore Grey <theodore.grey@gmail.com>