### PR TITLE
Add some tolerance to linear_operator_circulant_test so it will pass …

### DIFF
--- a/tensorflow/python/kernel_tests/linalg/linear_operator_circulant_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linear_operator_circulant_test.py
@@ -638,7 +638,7 @@ class LinearOperatorCirculant2DTestNonHermitianSpectrum(
           [matrix_tensor, matrix_t, imag_matrix])
 
       np.testing.assert_allclose(0, imag_matrix, atol=1e-6)
-      self.assertAllClose(matrix, matrix_transpose, atol=0)
+      self.assertAllClose(matrix, matrix_transpose, atol=1e-6)
 
   def test_real_spectrum_gives_self_adjoint_operator(self):
     with self.cached_session():


### PR DESCRIPTION
…on AARCH4
This test failure was being masked by disabling FMA instructions but as they will be enabled again according to https://github.com/tensorflow/tensorflow/issues/52544 this test will need to be fixed as well.