### PR TITLE
[oneDNN] Add env variable to MKL allocator to control mem allocation.

### DIFF
--- a/tensorflow/core/common_runtime/BUILD
+++ b/tensorflow/core/common_runtime/BUILD
@@ -1213,6 +1213,7 @@ cc_library(
         ":bfc_allocator",
         ":pool_allocator",
         "//tensorflow/core:lib",
+        "//tensorflow/core/util:onednn_env_vars",
     ],
 )
 
@@ -2378,6 +2379,7 @@ tf_cc_test_mkl(
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
         "//tensorflow/core:testlib",
+        "//tensorflow/core/util:onednn_env_vars",
     ],
 )
 

--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "tensorflow/core/platform/mem.h"
 #include "tensorflow/core/platform/numa.h"
 #include "tensorflow/core/util/env_var.h"
+#include "tensorflow/core/util/onednn_env_vars.h"
 #ifdef _WIN32
 typedef unsigned int uint;
 #endif
@@ -217,7 +218,7 @@ class MklCPUAllocator : public Allocator {
     // otherwise call large-size allocator (BFC). We found that BFC allocator
     // does not deliver good performance for small allocations when
     // inter_op_parallelism_threads is high.
-    if (always_use_system_allocator_ ||
+    if (UseSystemAlloc() ||
         num_bytes < kSmallAllocationsThreshold) {
       return small_size_allocator_->AllocateRaw(alignment, num_bytes);
     } else {
@@ -230,7 +231,7 @@ class MklCPUAllocator : public Allocator {
   inline void DeallocateRaw(void* ptr) override {
     // Check if ptr is for "small" allocation. If it is, then call Free
     // directly. Otherwise, call BFC to handle free.
-    if (always_use_system_allocator_ || IsSmallSizeAllocation(ptr)) {
+    if (UseSystemAlloc() || IsSmallSizeAllocation(ptr)) {
       small_size_allocator_->DeallocateRaw(ptr);
     } else {
       mutex_lock l(mutex_);
@@ -265,11 +266,6 @@ class MklCPUAllocator : public Allocator {
 
  private:
   // Hooks provided by this allocator for memory allocation routines from MKL
-  bool always_use_system_allocator_ = [] {
-    bool value = false;
-    TF_CHECK_OK(ReadBoolFromEnvVar("TF_USE_SYSTEM_ALLOCATOR", false, &value));
-    return value;
-  }();
   static inline void* MallocHook(size_t size) {
     VLOG(3) << "MklCPUAllocator: In MallocHook";
     return cpu_allocator()->AllocateRaw(kAlignment, size);

--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -29,7 +29,7 @@ limitations under the License.
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/platform/mem.h"
 #include "tensorflow/core/platform/numa.h"
-
+#include "tensorflow/core/util/env_var.h"
 #ifdef _WIN32
 typedef unsigned int uint;
 #endif
@@ -217,7 +217,8 @@ class MklCPUAllocator : public Allocator {
     // otherwise call large-size allocator (BFC). We found that BFC allocator
     // does not deliver good performance for small allocations when
     // inter_op_parallelism_threads is high.
-    if (num_bytes < kSmallAllocationsThreshold) {
+    if (always_use_system_allocator_ ||
+        num_bytes < kSmallAllocationsThreshold) {
       return small_size_allocator_->AllocateRaw(alignment, num_bytes);
     } else {
       mutex_lock l(mutex_);
@@ -226,11 +227,10 @@ class MklCPUAllocator : public Allocator {
       return ptr;
     }
   }
-
   inline void DeallocateRaw(void* ptr) override {
     // Check if ptr is for "small" allocation. If it is, then call Free
     // directly. Otherwise, call BFC to handle free.
-    if (IsSmallSizeAllocation(ptr)) {
+    if (always_use_system_allocator_ || IsSmallSizeAllocation(ptr)) {
       small_size_allocator_->DeallocateRaw(ptr);
     } else {
       mutex_lock l(mutex_);
@@ -238,7 +238,6 @@ class MklCPUAllocator : public Allocator {
       large_size_allocator_->DeallocateRaw(ptr);
     }
   }
-
   absl::optional<AllocatorStats> GetStats() override {
     auto s_stats = small_size_allocator_->GetStats();
     auto l_stats = large_size_allocator_->GetStats();
@@ -266,7 +265,11 @@ class MklCPUAllocator : public Allocator {
 
  private:
   // Hooks provided by this allocator for memory allocation routines from MKL
-
+  bool always_use_system_allocator_ = [] {
+    bool value = false;
+    TF_CHECK_OK(ReadBoolFromEnvVar("TF_USE_SYSTEM_ALLOCATOR", false, &value));
+    return value;
+  }();
   static inline void* MallocHook(size_t size) {
     VLOG(3) << "MklCPUAllocator: In MallocHook";
     return cpu_allocator()->AllocateRaw(kAlignment, size);

--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -24,7 +24,7 @@ MKL_SHORT_DEPS = [
     "//tensorflow/core:lib_internal",
     "//tensorflow/core/framework:bounds_check",
     "//tensorflow/core/kernels:ops_util",
-    "//tensorflow/core/util:mkl_util",
+    "//tensorflow/core/util:onednn_env_vars",
 ] + mkl_deps()
 
 MKL_DEPS = MKL_SHORT_DEPS + [
@@ -54,7 +54,7 @@ MKL_TEST_DEPS = [
     "//tensorflow/core:testlib",
     "//tensorflow/core/kernels:ops_testutil",
     "//tensorflow/core/kernels:ops_util",
-    "//tensorflow/core/util:mkl_util",
+    "//tensorflow/core/util:onednn_env_vars",
 ]
 
 tf_mkl_kernel_library(
@@ -296,7 +296,7 @@ tf_mkl_kernel_library(
         "//tensorflow/core/kernels:quantized_ops",
         "//tensorflow/core/kernels:transpose_functor",
         "//tensorflow/core/util:image_resizer_state",
-        "//tensorflow/core/util:mkl_util",
+        "//tensorflow/core/util:onednn_env_vars",
     ] + mkl_deps(),
 )
 

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.h
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.h
@@ -38,6 +38,7 @@ limitations under the License.
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/platform/macros.h"
 #include "tensorflow/core/util/mkl_util.h"
+#include "tensorflow/core/util/onednn_env_vars.h"
 #include "tensorflow/core/util/padding.h"
 #include "tensorflow/core/util/tensor_format.h"
 

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/util/mkl_util.h"
+#include "tensorflow/core/util/onednn_env_vars.h"
 
 using dnnl::inner_product_forward;
 using dnnl::primitive_attr;

--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -17,10 +17,6 @@ load(
     "tf_kernel_library",
     "tf_mkl_kernel_library",
 )
-load(
-    "//third_party/mkl:build_defs.bzl",
-    "mkl_deps",
-)
 
 # buildifier: disable=same-origin-load
 load("//tensorflow:tensorflow.bzl", "filegroup")
@@ -171,6 +167,7 @@ filegroup(
         "matmul_autotune.h",
         "matmul_bcast.h",
         "mirror_pad_mode.h",
+        "onednn_env_vars.h",
         "mkl_threadpool.h",
         "mkl_util.h",
         "overflow.h",
@@ -301,6 +298,7 @@ filegroup(
 filegroup(
     name = "mkl_util_hdrs",
     srcs = [
+        "onednn_env_vars.h",
         "mkl_threadpool.h",
         "mkl_util.h",
     ],
@@ -404,9 +402,9 @@ cc_library(
 )
 
 tf_mkl_kernel_library(
-    name = "mkl_util",
-    srcs = ["mkl_util.cc"],
-    hdrs = ["mkl_util.h"],
+    name = "onednn_env_vars",
+    srcs = ["onednn_env_vars.cc"],
+    hdrs = ["onednn_env_vars.h"],
     deps = [
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",
@@ -414,7 +412,7 @@ tf_mkl_kernel_library(
         "//tensorflow/core:lib_internal",
         "//tensorflow/core/framework:bounds_check",
         "//tensorflow/core/kernels:ops_util",
-    ] + mkl_deps(),
+    ],
 )
 
 cc_library(

--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -167,9 +167,9 @@ filegroup(
         "matmul_autotune.h",
         "matmul_bcast.h",
         "mirror_pad_mode.h",
-        "onednn_env_vars.h",
         "mkl_threadpool.h",
         "mkl_util.h",
+        "onednn_env_vars.h",
         "overflow.h",
         "padding.h",
         "permutation_input_iterator.h",
@@ -298,9 +298,9 @@ filegroup(
 filegroup(
     name = "mkl_util_hdrs",
     srcs = [
-        "onednn_env_vars.h",
         "mkl_threadpool.h",
         "mkl_util.h",
+        "onednn_env_vars.h",
     ],
     visibility = ["//tensorflow/core:__pkg__"],
 )

--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -406,7 +406,6 @@ tf_mkl_kernel_library(
     srcs = ["onednn_env_vars.cc"],
     hdrs = ["onednn_env_vars.h"],
     deps = [
-        "//tensorflow/core:core_cpu",
         "//tensorflow/core:framework",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -135,8 +135,6 @@ inline void execute_primitives(
   }
 }
 
-bool AreWeightsFrozen();
-
 // In oneDNN v1.x, the format (ex. NCHW) used to initialize a memory descriptor
 // (md) structure will no longer be recorded in its `format` field. Instead, it
 // will be set to a canonical `blocked` format for every fully described md.

--- a/tensorflow/core/util/onednn_env_vars.cc
+++ b/tensorflow/core/util/onednn_env_vars.cc
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,7 +15,9 @@ limitations under the License.
 
 #ifdef INTEL_MKL
 
-#include "tensorflow/core/util/mkl_util.h"
+#include "absl/base/call_once.h"
+#include "tensorflow/core/util/onednn_env_vars.h"
+#include "tensorflow/core/util/env_var.h"
 
 namespace tensorflow {
 
@@ -28,5 +30,16 @@ bool AreWeightsFrozen() {
   });
   return weights_const;
 }
+
+bool UseSystemAlloc() {
+  static bool use_sys_alloc = false;
+  static absl::once_flag once;
+  absl::call_once(once, [&] {
+    TF_CHECK_OK(ReadBoolFromEnvVar("TF_ONEDNN_USE_SYSTEM_ALLOCATOR",
+                                   /*default_value*/ false, &use_sys_alloc));
+  });
+  return use_sys_alloc;
+}
+
 }  // namespace tensorflow
 #endif  // INTEL_MKL

--- a/tensorflow/core/util/onednn_env_vars.h
+++ b/tensorflow/core/util/onednn_env_vars.h
@@ -1,4 +1,4 @@
-/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,14 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#ifndef TENSORFLOW_CORE_UTIL_ONEDNN_ENV_VARS_H_
+#define TENSORFLOW_CORE_UTIL_ONEDNN_ENV_VARS_H_
 #ifdef INTEL_MKL
 
-#include "tensorflow/core/common_runtime/mkl_cpu_allocator.h"
-
 namespace tensorflow {
-
-constexpr const char* MklCPUAllocator::kMaxLimitStr;
-constexpr const size_t MklCPUAllocator::kDefaultMaxLimit;
+  bool AreWeightsFrozen();
+  bool UseSystemAlloc();
 }  // namespace tensorflow
-
 #endif  // INTEL_MKL
+#endif  // TENSORFLOW_CORE_UTIL_ONEDNN_ENV_VARS_H_


### PR DESCRIPTION
This PR implements an env variable to request the MKL allocator to always use the system allocator. We recently. found a few usages where the lock overhead in BFC allocator was significant and switching back to default allocator helped performance.