### PR TITLE
[TF-TRT] Add converter for tf.fill

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -611,6 +611,7 @@ tf_cuda_library(
         "convert/convert_nodes.cc",
         "convert/ops/data_format_vec_permute.cc",
         "convert/ops/einsum.cc",
+        "convert/ops/fill_ops.cc",
         "convert/ops/quantization_ops.cc",
         "convert/ops/slice_ops.cc",
         "convert/trt_optimization_pass.cc",

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -46,6 +46,19 @@ namespace tensorrt {
 namespace convert {
 using ::stream_executor::port::StatusOr;
 
+#define TFTRT_INTERNAL_ERROR_AT_NODE(node)                           \
+  do {                                                               \
+    return errors::Internal("TFTRT::", __FUNCTION__, ":", __LINE__,  \
+                            " failed to add TRT layer, at: ", node); \
+  } while (0)
+
+#define TFTRT_RETURN_ERROR_IF_NULLPTR(ptr, node) \
+  do {                                           \
+    if (ptr == nullptr) {                        \
+      TFTRT_INTERNAL_ERROR_AT_NODE(node);        \
+    }                                            \
+  } while (0)
+
 struct EngineConnection {
   // Constructs a non-control edge.
   EngineConnection(const string& outside, int out_id, int out_port,

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -3284,6 +3284,68 @@ TEST_P(OpConverter_FP32_FP16_Test, ConvertSquare) {
                   ArrayFloatNear(expected_outputs, 0));
 }
 
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
+
+TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertFill) {
+  Scope s = Scope::NewRootScope();
+  auto dims = ops::Placeholder(s.WithOpName("dims"), DT_INT32);
+  auto value = ops::Placeholder(s.WithOpName("value"), tf_type_);
+  auto fill = ops::Fill(s.WithOpName("my_fill"), dims, value);
+  const NodeDef& node_def = fill.operation.node()->def();
+
+  if (trt_mode_ == TrtTestMode::kImplicitBatch) {
+    Reset();
+    // random data
+    AddTestWeights("dims", {2}, {2,2}, DT_INT32);
+    AddTestWeights("value", {1}, {42.0}, tf_type_);
+    RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
+                               "Conversion for Fill is not implemented in"
+                               "implicit batch mode");
+    return;
+  }
+
+  std::vector<std::vector<int>> output_dims_params = {
+    {8},
+    {8, 2, 4},
+    {32, 32, 3200}};
+  std::vector<std::vector<int>> value_dims_params = {
+    {},
+    {1}
+  };
+
+  float val = 42.0;
+  Status status = Status::OK();
+  for (bool dims_is_tensor : {true, false}) {
+    for (bool value_is_tensor : {true, false}) {
+      for (auto output_dims : output_dims_params) {
+        for (auto value_dims : value_dims_params) {
+          Reset();
+          std::vector<int32> dims_dims = {output_dims.size()};
+          if (dims_is_tensor) {
+            AddTestTensor("dims", dims_dims, DT_INT32, output_dims, dims_dims);
+          } else {
+            AddTestWeights("dims", dims_dims, output_dims, DT_INT32);
+          }
+          if (value_is_tensor) {
+            AddTestTensor("value", value_dims, tf_type_, {val});
+          } else {
+            AddTestWeights("value", value_dims, {val}, tf_type_);
+          }
+          size_t nb_el = 1;
+          for (auto d : output_dims) {
+            nb_el *= d;
+          }
+          std::vector<float> expected_output(nb_el, val);
+          TestOpConverter("my_fill", node_def, output_dims, status,
+                  status, ElementsAreArray(expected_output));
+        }
+      }
+    }
+  }
+}
+
+#endif  // IS_TRT_VERSION_GE(8, 2, 0, 0)
+
 #if IS_TRT_VERSION_GE(8, 2, 1, 6) || defined(TF_TRT_USE_EFFICIENT_NMS_PLUGIN)
 
 TEST_P(OpConverter_FP32_Test, ConvertCombinedNMS) {

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/fill_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/fill_ops.cc
@@ -1,0 +1,140 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
+
+class ConvertFill : public OpConverterBase<ConvertFill> {
+ public:
+  explicit ConvertFill(OpConverterParams* params)
+      : OpConverterBase<ConvertFill>(params) {}
+
+  static constexpr std::array<DataType, 3> AllowedDataTypes() {
+    return {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32};
+  }
+
+  static constexpr std::array<InputArgSpec, 2> InputSpec() {
+    return std::array<InputArgSpec, 2>{
+        InputArgSpec::Create("dims", TrtInputArg::kBoth),
+        InputArgSpec::Create("value", TrtInputArg::kBoth)};
+  }
+
+  Status Validate() {
+    const auto &params = *this->params_;
+
+    if (params.use_implicit_batch) {
+        return errors::Unimplemented("Conversion for Fill is not implemented in"
+                                    "implicit batch mode");
+    }
+
+    const auto &inputs = params.inputs;
+    const auto& node_def = params.node_def;
+    const TRT_TensorOrWeights& dims_input = inputs.at(0);
+
+    nvinfer1::DataType dims_type = dims_input.TrtDType();
+    if (dims_type != nvinfer1::DataType::kINT32) {
+      return errors::InvalidArgument("The dims parameter of ", node_def.op(),
+                                     " operation in ", node_def.name(),
+                                     " is expected to be of type ",
+                                     DebugString(nvinfer1::DataType::kINT32),
+                                     " type, got ", DebugString(dims_type));
+    }
+
+    int nbDims = dims_input.GetTrtDims().nbDims;
+    if (nbDims < 0) {
+      return errors::InvalidArgument("The shape of parameter ", node_def.op(),
+                                     " operation in ", node_def.name(),
+                                     " cannot be partial.");
+    }
+    return Status::OK();
+  }
+
+  Status Convert() {
+    const auto &params = *this->params_;
+    const auto& inputs = params.inputs;
+    auto *converter = params.converter;
+    auto *network = converter->network();
+    const auto& node_def = params.node_def;
+
+    const bool is_dims_static = inputs[0].is_weights();
+    const bool is_value_static = inputs[1].is_weights();
+
+    const TRT_TensorOrWeights& dims_input = inputs.at(0);
+    const TRT_TensorOrWeights& value_input = inputs.at(1);
+
+    int nbDims = dims_input.GetTrtDims().d[0];
+
+    nvinfer1::Dims trt_dims{0};
+    if (is_dims_static) {
+      const auto dims_weights = dims_input.weights();
+      DimsAdapter dims_adapter(dims_weights.GetSpan<int32>());
+      dims_adapter.TrtDims(&trt_dims);
+    }
+
+    // TensorRT IFillLayer requires a rank 0 scalar.
+    ITensorProxyPtr scalar_tensor;
+    nvinfer1::Dims scalar_dims;
+    scalar_dims.nbDims = 0;
+    nvinfer1::DataType value_type = value_input.TrtDType();
+    if (is_value_static) {
+      scalar_tensor = converter->CreateConstantLayer(
+          value_input.weights(), scalar_dims);
+    } else {
+      TF_RETURN_IF_ERROR(PrepareTensorForShape(converter, value_input,
+        scalar_dims, params.validation_only,
+        &scalar_tensor, node_def));
+    }
+
+    auto builder = TRTNetworkBuilder::Create(network,
+                                             params.weight_store);
+    nvinfer1::Dims beta_shape{1, {nbDims}};
+    StatusOr<nvinfer1::IConstantLayer*> const_layer =
+      builder->Constant(0, beta_shape, value_type);
+    TF_RETURN_IF_ERROR(const_layer.status());
+    ITensorProxyPtr empty_beta_tensor = (*const_layer)->getOutput(0);
+
+    nvinfer1::IFillLayer* layer = network->addFill(
+        trt_dims,
+        nvinfer1::FillOperation::kLINSPACE);
+    TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
+    if (!is_dims_static) {
+      layer->setInput(0, *dims_input.tensor()->trt_tensor());
+    }
+    layer->setInput(1, *scalar_tensor->trt_tensor());
+    layer->setInput(2, *empty_beta_tensor->trt_tensor());
+    converter->SetLayerName(layer, node_def, "fill");
+    ITensorProxyPtr output_tensor = layer->getOutput(0);
+    AddOutput(TRT_TensorOrWeights(output_tensor));
+    return Status::OK();
+  }
+};
+
+REGISTER_DEFAULT_TRT_OP_CONVERTER(MakeConverterFunction<ConvertFill>(), "Fill");
+
+#endif  // IS_TRT_VERSION_GE(8, 2, 0, 0)
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h
@@ -292,6 +292,22 @@ class TRTNetworkBuilder {
     return const_layer;
   }
 
+  // Adds a Constant layer that produces a tensor of shape "shape",
+  // type "data_type" and filled with value "scalar".
+  template <typename T>
+  StatusOr<nvinfer1::IConstantLayer*> Constant(
+    const T value, nvinfer1::Dims shape,
+    nvinfer1::DataType data_type) noexcept {
+    StatusOr<TRT_ShapedWeights> const_weights =
+        weight_store_->GetTempWeights(data_type, shape);
+    TRT_ENSURE_OK(const_weights);
+    TRT_ENSURE(const_weights->SetValues(value).ok());
+    nvinfer1::IConstantLayer* const_layer =
+        network_->addConstant(shape, const_weights->GetTrtWeights());
+    TRT_ENSURE(const_layer);
+    return const_layer;
+  }
+
   // Adds a Constant layer that produces a tensor with a single value "scalar".
   // The tensor has "nb_dims" dimensions and each dimension has only one
   // element. The data type of the tensor is determined by the data type of
@@ -308,15 +324,8 @@ class TRTNetworkBuilder {
     nvinfer1::Dims zero_shape;
     zero_shape.nbDims = nb_dims;
     std::fill_n(zero_shape.d, nb_dims, 1);
-    StatusOr<TRT_ShapedWeights> const_weights =
-        weight_store_->GetTempWeights(data_type, zero_shape);
-    TRT_ENSURE_OK(const_weights);
-    const_weights->GetPointer<T>()[0] = scalar;
-    nvinfer1::IConstantLayer* const_layer =
-        network_->addConstant(zero_shape, const_weights->GetTrtWeights());
-    TRT_ENSURE(const_layer);
-    return const_layer;
-  };
+    return Constant<T>(scalar, zero_shape, data_type);
+  }
 
   // Adds a Constant layer from a TRT_ShapedWeights object.
   StatusOr<nvinfer1::IConstantLayer*> WeightsToConstant(
@@ -330,7 +339,7 @@ class TRTNetworkBuilder {
         network_->addConstant(*trt_dims, weights);
     TRT_ENSURE(const_layer);
     return const_layer;
-  };
+  }
 
   // Creates a nvinfer1::Weights object containing a single scalar.
   template <typename T,
@@ -350,7 +359,7 @@ class TRTNetworkBuilder {
     TRT_ENSURE_OK(const_weights);
     const_weights->GetPointer<T>()[0] = scalar;
     return const_weights->GetTrtWeights();
-  };
+  }
 
   // Adds a TensorRT Slice operation to the network.
   StatusOr<nvinfer1::ISliceLayer*> Slice(

--- a/tensorflow/compiler/tf2tensorrt/convert/trt_layout_optimization_pass.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_layout_optimization_pass.cc
@@ -1,0 +1,100 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/tf2tensorrt/convert/trt_layout_optimization_pass.h"
+
+#include "absl/strings/ascii.h"
+#include "absl/strings/escaping.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_graph.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/core/common_runtime/graph_constructor.h"
+#include "tensorflow/core/grappler/clusters/cluster.h"
+#include "tensorflow/core/grappler/grappler_item.h"
+#include "tensorflow/core/grappler/optimizers/custom_graph_optimizer_registry.h"
+#include "tensorflow/core/grappler/utils/functions.h"
+#include "tensorflow/core/lib/strings/numbers.h"
+#include "tensorflow/core/lib/strings/str_util.h"
+#include "tensorflow/core/lib/strings/strcat.h"
+#include "tensorflow/core/platform/casts.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/stacktrace.h"
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+using absl::AsciiStrToUpper;
+using absl::StrAppend;
+using absl::StrCat;
+
+
+TRTLayoutOptimizationPass::TRTLayoutOptimizationPass(const string& name)
+    : name_(name),
+    trt_logger_name_("DefaultLogger"),
+    minimum_segment_size_(3),
+    is_dynamic_op_(false),
+    max_cached_batches_(1),
+    max_workspace_size_bytes_(256LL << 20) {
+    VLOG(1) << "Constructing " << name_;
+}
+
+Status TRTLayoutOptimizationPass::Optimize(grappler::Cluster* cluster,
+                                           const grappler::GrapplerItem& item,
+                                           GraphDef* optimized_graph) {
+
+  GraphDef modified_graph_def = item.graph;
+
+  // Construct a GrapplerItem using the modified graph_def and the input
+  // grappler_item.
+  grappler::GrapplerItem grappler_item =
+      grappler_item.WithGraph(std::move(modified_graph_def));
+  const GraphDef& graph_def = grappler_item.graph;
+
+  // Convert graphdef to graph.
+  FunctionLibraryDefinition flib(OpRegistry::Global(), graph_def.library());
+  Graph graph(flib);
+  TF_RETURN_IF_ERROR(
+      ConvertGraphDefToGraph(GraphConstructorOptions(), graph_def, &graph));
+
+  // Algorithm steps:
+  // 1. We iterate over the graph to find any Conv (or other layout sensitive op)
+  // 2. If found, we continue, else we return
+  // 3. We iterate over the nodes and replace the layout-sensitive params
+  // 3. We add Transpose before the inputs and after the outputs
+
+  
+  grappler::GraphProperties static_graph_properties(grappler_item);
+
+  std::cout << "TRTLayoutOptimizationPass: reading nodes..." << std::endl;
+  for (Node* node : graph.nodes()) {
+    std::cout << node->name() << std::endl;
+  }
+
+  // TODO: assign output *optimized_graph =;
+}
+
+
+
+Status TRTLayoutOptimizationPass::Init(const RewriterConfig_CustomGraphOptimizer* config)  {
+    std::cout << "Do nothing for now" << std::endl;
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/trt_layout_optimization_pass.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_layout_optimization_pass.h
@@ -1,0 +1,70 @@
+/* Copyright 20121 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TRT_LAYOUT_OPTIMIZATION_PASS_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TRT_LAYOUT_OPTIMIZATION_PASS_H_
+
+#include <string>
+
+#include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
+#include "tensorflow/core/framework/graph.pb.h"
+#include "tensorflow/core/grappler/optimizers/custom_graph_optimizer.h"
+#include "tensorflow/core/platform/logging.h"
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#if !IS_TRT_VERSION_GE(7, 0, 0, 0)
+#error From version 2.6, we only support NVIDIA TensorRT version 7 or newer.
+#error Please update your environment and relaunch the compilation.
+#endif
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+class TRTLayoutOptimizationPass : public grappler::CustomGraphOptimizer {
+ public:
+  TRTLayoutOptimizationPass(const string& name = "TRTLayoutOptimizationPass");
+
+  string name() const override { return name_; };
+
+  bool UsesFunctionLibrary() const override { return true; }
+
+  Status Init(
+      const RewriterConfig_CustomGraphOptimizer* config = nullptr) override;
+
+  Status Optimize(grappler::Cluster* cluster,
+                  const grappler::GrapplerItem& item,
+                  GraphDef* optimized_graph) override;
+
+/*  void PrintDebugInfo(grappler::Cluster* cluster,
+                      const grappler::GrapplerItem& item);
+*/ 
+
+ private:
+  const string name_;
+  string trt_logger_name_;
+  int minimum_segment_size_;
+  bool is_dynamic_op_;
+  int max_cached_batches_;
+  int64_t max_workspace_size_bytes_;
+};
+
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TRT_LAYOUT_OPTIMIZATION_PASS_H_

--- a/tensorflow/compiler/tf2tensorrt/convert/weights.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/weights.h
@@ -219,6 +219,10 @@ class TRT_TensorOrWeights {
 
   string DebugString() const;
 
+  nvinfer1::DataType TrtDType() const {
+    return is_tensor_ ? tensor_proxy_ptr_->getType() : weights_.TrtDType();
+  }
+
  private:
   void set_batch_size(int batch_size) { batch_size_ = batch_size; }
 


### PR DESCRIPTION
This PR adds a TF-TRT converter for the [tf.fill operator.](https://www.tensorflow.org/api_docs/python/tf/fill)
The converter supports tensor and weights for both inputs (`dims` and `value`).

It adds an overload for `TRTNetworkBuilder::Constant ` in layer_utils.h to create a Constant layer from a value, a shape and a data type.

It also moves the `TFTRT_INTERNAL_ERROR_AT_NODE` and `TFTRT_RETURN_ERROR_IF_NULLPTR ` macros to the convert_nodes header.