### PR TITLE
Fix OpenCL GPU Delegate segfault on exit on NVidia 

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -218,6 +218,9 @@ endif()
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_android\\.cc$")
 endif()
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+  list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_default\\.cc$")
+endif()
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "iOS")
   list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_ios\\.cc$")
 endif()
@@ -496,6 +499,13 @@ target_include_directories(tensorflow-lite
   PUBLIC
     ${TFLITE_INCLUDE_DIRS}
 )
+
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+  list(APPEND TFLITE_TARGET_DEPENDENCIES
+    log
+  )
+endif()
+
 target_link_libraries(tensorflow-lite
   PUBLIC
     Eigen3::Eigen

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -199,6 +199,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
 endif()
 if(CMAKE_SYSTEM_NAME MATCHES "Android")
   find_library(ANDROID_LOG_LIB log)
+  list(APPEND TFLITE_TARGET_DEPENDENCIES ${ANDROID_LOG_LIB})
 endif()
 # Build a list of source files to compile into the TF Lite library.
 populate_tflite_source_vars("." TFLITE_SRCS)
@@ -206,6 +207,9 @@ populate_tflite_source_vars("." TFLITE_SRCS)
 # This particular file is excluded because the more explicit approach to enable
 # XNNPACK delegate is preferred to the weak-symbol one.
 list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*tflite_with_xnnpack\\.cc$")
+
+# We will be adding back the correct platform specific logging later
+list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_.*\.cc$")
 
 # Exclude Flex related files.
 list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*with_selected_ops\\.cc$")
@@ -215,15 +219,15 @@ if(_TFLITE_ENABLE_MMAP)
 else()
   list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*mmap_allocation\\.cc$")
 endif()
-if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
-  list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_android\\.cc$")
-endif()
+
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
-  list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_default\\.cc$")
+  list(APPEND TFLITE_SRCS "minimal_logging_android.cc")
+elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "iOS")
+  list(APPEND TFLITE_SRCS "minimal_logging_ios.cc")
+else()
+  list(APPEND TFLITE_SRCS "minimal_logging_default.cc")
 endif()
-if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "iOS")
-  list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*minimal_logging_ios\\.cc$")
-endif()
+
 populate_tflite_source_vars("core" TFLITE_CORE_SRCS)
 populate_tflite_source_vars("core/api" TFLITE_CORE_API_SRCS)
 populate_tflite_source_vars("c" TFLITE_C_SRCS)
@@ -499,12 +503,6 @@ target_include_directories(tensorflow-lite
   PUBLIC
     ${TFLITE_INCLUDE_DIRS}
 )
-
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
-  list(APPEND TFLITE_TARGET_DEPENDENCIES
-    log
-  )
-endif()
 
 target_link_libraries(tensorflow-lite
   PUBLIC

--- a/tensorflow/lite/delegates/gpu/cl/inference_context.cc
+++ b/tensorflow/lite/delegates/gpu/cl/inference_context.cc
@@ -220,7 +220,7 @@ absl::Status GetBufferAsignment(
   *use_offset_assignment = false;
   if (*is_sub_buffers_supported) {
     RETURN_IF_ERROR(AssignOffsetsToTensors(
-        *buffer_usage_records, MemoryStrategy::GREEDY_BY_SIZE,
+        *buffer_usage_records, MemoryStrategy::EQUALITY,
         offset_assignment, base_align_bytes));
     if (offset_assignment->total_size <= TotalSize(*buffer_assignment) &&
         offset_assignment->total_size <= gpu_info.GetMaxBufferSize()) {

--- a/tensorflow/lite/delegates/gpu/cl/inference_context.cc
+++ b/tensorflow/lite/delegates/gpu/cl/inference_context.cc
@@ -220,7 +220,7 @@ absl::Status GetBufferAsignment(
   *use_offset_assignment = false;
   if (*is_sub_buffers_supported) {
     RETURN_IF_ERROR(AssignOffsetsToTensors(
-        *buffer_usage_records, MemoryStrategy::EQUALITY,
+        *buffer_usage_records, MemoryStrategy::EQUALITY, /*MemoryStrategy::GREEDY_BY_SIZE causes segfault on exit on NVidia GPU*/
         offset_assignment, base_align_bytes));
     if (offset_assignment->total_size <= TotalSize(*buffer_assignment) &&
         offset_assignment->total_size <= gpu_info.GetMaxBufferSize()) {


### PR DESCRIPTION
- AssignOffsetsToTensors with GREEDY_BY_SIZE causes a segfault on NVidia
- Fixed undefined/duplicate definition error for Android CMake build of C++ API