### PR TITLE
[TF-TRT] Adding CSV export to Detailed Non Conversion Report

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/segment/segment.cc
+++ b/tensorflow/compiler/tf2tensorrt/segment/segment.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include "tensorflow/compiler/tf2tensorrt/segment/segment.h"
 
 #include <algorithm>
+#include <fstream>
 #include <map>
 #include <numeric>
 #include <queue>
@@ -683,13 +684,80 @@ void AddSegmentForNode(const grappler::GraphProperties* graph_properties,
 
 }  // namespace
 
+Status ExportNonConversionReportToCSV(
+  string filename,
+  std::map<string, std::map<string, int>>& nonconverted_ops_map,
+  string sep = "|"
+) {
+  std::fstream csv_file(filename, std::fstream::out | std::fstream::trunc);
+
+  if (!csv_file || !csv_file.good()) {
+      return errors::Internal("Failed to open output file: `", filename, "`");
+  }
+
+  LOG(WARNING) << "TF-TRT Non-Conversion Report saved at: `" << filename << "`";
+
+  csv_file << "OP Name" << sep << "Reason" << sep << "Count" << std::endl;
+
+  for (auto& op_details : nonconverted_ops_map) {
+      auto op_name = op_details.first;
+      auto op_data = op_details.second;
+
+      for (auto& reject_data : op_data) {
+          auto reason = reject_data.first;
+          auto count = reject_data.second;
+          csv_file << op_name << sep << reason << sep << count << std::endl;
+      }
+  }
+
+  csv_file.close();
+
+  if (csv_file.bad() || csv_file.fail()) {
+    return errors::Internal(
+      "Error closing the file `", filename, "`. The file might be corrupted."
+    );
+  }
+
+  return Status::OK();
+}
+
 string GenerateNonConversionReport(
     std::map<string, std::map<string, int>>& nonconverted_ops_map) {
   // Fetch whether to print a detailed version of the TF-TRT conversion report.
-  bool show_detailed_conversion_report;
-  TF_CHECK_OK(ReadBoolFromEnvVar("TF_TRT_SHOW_DETAILED_REPORT",
-                                 /*default_value=*/false,
-                                 &show_detailed_conversion_report));
+  // TF_TRT_SHOW_DETAILED_REPORT triggers three possible behaviors:
+  // - If Number >= 1:      Print detailed non-conversion report on stdout.
+  //                        Usage: TF_TRT_SHOW_DETAILED_REPORT=1
+  // - If non empty string: Exports the non-conversion report in CSV format at
+  //                        the path defined by the environment variable.
+  //                        This will also print the detailed non-conversion
+  //                        report on stdout.
+  //                        Usage: TF_TRT_SHOW_DETAILED_REPORT=/path/to/file.csv
+  // - Else:                Print normal (undetailed) non-conversion report on
+  //                        stdout.
+
+  string detailed_report_var;
+  TF_CHECK_OK(ReadStringFromEnvVar(
+    "TF_TRT_SHOW_DETAILED_REPORT", /*default_value=*/"", &detailed_report_var));
+
+  bool show_detailed_conversion_report = false;
+
+  if (detailed_report_var != "") {
+    // Checking if `TF_TRT_SHOW_DETAILED_REPORT` env var is a string or a number
+    if (detailed_report_var.find_first_not_of("-0123456789") != string::npos) {
+      const Status status = ExportNonConversionReportToCSV(
+        detailed_report_var, nonconverted_ops_map);
+
+      if (!status.ok()) {
+        // Log the error in case of issue, however do not stop execution.
+        LOG(ERROR) << "Problem encountered while generating the TF-TRT "
+                   << "Non-Conversion Report in CSV Format:\n"
+                   << status.error_message();
+      }
+      show_detailed_conversion_report = true;
+    } else if (std::stoi(detailed_report_var) >= 1) {
+      show_detailed_conversion_report = true;
+    }
+  }
 
   string unsupported_op_report =
       StrCat("\n\n", string(80, '#'), "\n",


### PR DESCRIPTION
@bixia1 for review

`TF_TRT_SHOW_DETAILED_REPORT` triggers three possible behaviors:

- **If Number >= 1:**      Print detailed non-conversion report on stdout.
                                      *Usage: `TF_TRT_SHOW_DETAILED_REPORT=1`*
                                 
- **If non empty string:** Exports the non-conversion report in CSV format at
                                       the path defined by the environment variable.
                                       This will also print the detailed non-conversion
                                       report on stdout.
                                       *Usage: `TF_TRT_SHOW_DETAILED_REPORT=/path/to/file.csv`*
                                  
- **Else:**                        Print normal (undetailed) non-conversion report on stdout.