### PR TITLE
Check for negative `nbins` in histogram ops

### DIFF
--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -57,6 +57,7 @@ def histogram_fixed_width_bins(values,
     TypeError: If any unsupported dtype is provided.
     tf.errors.InvalidArgumentError: If value_range does not
         satisfy value_range[0] < value_range[1].
+    ValueError: If the value of nbins is negative.
 
   Examples:
 
@@ -69,6 +70,9 @@ def histogram_fixed_width_bins(values,
   >>> indices.numpy()
   array([0, 0, 1, 2, 4, 4], dtype=int32)
   """
+  if nbins < 0:
+    raise ValueError("nbins should be a positive number.")
+    
   with ops.name_scope(name, 'histogram_fixed_width_bins',
                       [values, value_range, nbins]):
     values = ops.convert_to_tensor(values, name='values')
@@ -124,6 +128,7 @@ def histogram_fixed_width(values,
     TypeError: If any unsupported dtype is provided.
     tf.errors.InvalidArgumentError: If value_range does not
         satisfy value_range[0] < value_range[1].
+    ValueError: If the value of nbins is negative.
 
   Examples:
 
@@ -136,6 +141,9 @@ def histogram_fixed_width(values,
   >>> hist.numpy()
   array([2, 1, 1, 0, 2], dtype=int32)
   """
+  if nbins < 0:
+    raise ValueError("nbins should be a positive number.")
+
   with ops.name_scope(name, 'histogram_fixed_width',
                       [values, value_range, nbins]) as name:
     # pylint: disable=protected-access

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -71,7 +71,7 @@ def histogram_fixed_width_bins(values,
   array([0, 0, 1, 2, 4, 4], dtype=int32)
   """
   if nbins < 0:
-    raise ValueError("nbins should be a positive number.")
+    raise ValueError(f'nbins should be positive number, but got \'{nbins}\'.')
     
   with ops.name_scope(name, 'histogram_fixed_width_bins',
                       [values, value_range, nbins]):
@@ -128,7 +128,7 @@ def histogram_fixed_width(values,
     TypeError: If any unsupported dtype is provided.
     tf.errors.InvalidArgumentError: If value_range does not
         satisfy value_range[0] < value_range[1].
-    ValueError: If the value of nbins is negative.
+    tf.errors.InvalidArgumentError: If the value of nbins is negative.
 
   Examples:
 
@@ -141,9 +141,6 @@ def histogram_fixed_width(values,
   >>> hist.numpy()
   array([2, 1, 1, 0, 2], dtype=int32)
   """
-  if nbins < 0:
-    raise ValueError("nbins should be a positive number.")
-
   with ops.name_scope(name, 'histogram_fixed_width',
                       [values, value_range, nbins]) as name:
     # pylint: disable=protected-access

--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -70,6 +70,8 @@ def histogram_fixed_width_bins(values,
   >>> indices.numpy()
   array([0, 0, 1, 2, 4, 4], dtype=int32)
   """
+  if isinstance(nbins, list):
+    raise ValueError('nbins shape must be of rank 0')
   if nbins < 0:
     raise ValueError(f'nbins should be positive number, but got \'{nbins}\'.')
     

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -49,6 +49,11 @@ class BinValuesFixedWidth(test.TestCase):
           values, value_range, nbins=5, dtype=dtypes.int64)
       self.assertEqual(dtypes.int32, bins.dtype)
       self.assertAllClose(expected_bins, self.evaluate(bins))
+      
+  def test_with_negative_nbins(self):
+    values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
+    with self.assertRaisesRegex(ValueError, "nbins should be positive number"):
+      histogram_ops.histogram_fixed_width_bins(values, [1.0, 5.0], nbins=-5)
 
   def test_1d_float64_values_int32_output(self):
     # Bins will be:

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -50,8 +50,10 @@ class BinValuesFixedWidth(test.TestCase):
       self.assertEqual(dtypes.int32, bins.dtype)
       self.assertAllClose(expected_bins, self.evaluate(bins))
       
-  def test_with_negative_nbins(self):
+  def test_invalid_nbins(self):
     values = [-1.0, 0.0, 1.5, 2.0, 5.0, 15]
+    with self.assertRaisesRegex(ValueError, "nbins shape must be of rank 0"):
+      histogram_ops.histogram_fixed_width_bins(values, [1.0, 5.0], nbins=[1, 2])
     with self.assertRaisesRegex(ValueError, "nbins should be positive number"):
       histogram_ops.histogram_fixed_width_bins(values, [1.0, 5.0], nbins=-5)
 


### PR DESCRIPTION
Added the condition to check the negative value of nbins input.
Fixes https://github.com/tensorflow/tensorflow/issues/54125