### PR TITLE
[ROCm] Fix to enable TFRT BEF Thunk unit tests to pass on ROCm.

### DIFF
--- a/tensorflow/stream_executor/gpu/BUILD
+++ b/tensorflow/stream_executor/gpu/BUILD
@@ -260,6 +260,8 @@ cc_library(
         "//tensorflow/stream_executor/cuda:cuda_driver",
         "//tensorflow/stream_executor/cuda:ptxas_wrapper",
         "//tensorflow/stream_executor/cuda:fatbinary_wrapper",
+    ]) + if_rocm_is_configured([
+        "//tensorflow/stream_executor/rocm:rocm_driver",
     ]) + ["@com_google_absl//absl/container:flat_hash_set"],
 )
 


### PR DESCRIPTION
In order to get the //tensorflow/compiler/xla/service/gpu/tests:mlir_gemm_test unit test to work on ROCm, this fix is needed.

There are other fixes that are needed in TFRT itself, but this is needed for Tensorflow.

/cc @chsigg @hanbinyoon 