### PR TITLE
fft2d/fftsg.c needs the math library

### DIFF
--- a/tensorflow/lite/tools/cmake/modules/fft2d/CMakeLists.txt
+++ b/tensorflow/lite/tools/cmake/modules/fft2d/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(fft2d_fft4f2d "${FFT2D_SOURCE_DIR}/fft4f2d.c")
 target_include_directories(fft2d_fft4f2d PRIVATE "${FFT2D_SOURCE_DIR}")
 
 add_library(fft2d_fftsg "${FFT2D_SOURCE_DIR}/fftsg.c")
+target_link_libraries(fft2d_fftsg m)
 
 # Requires implementation of fft2d_alloc.
 add_library(fft2d_fftsg2d "${FFT2D_SOURCE_DIR}/fftsg2d.c")


### PR DESCRIPTION
Without this, the tensorflow-lite build using CMake fails for me with undefined references.

fftsg.c has `#include <math.h>`, but the CMake configuration lacks the link to the math library.

