### PR TITLE
TF->TOSA: Ignore stride if shrink axis mask is set

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -703,6 +703,19 @@ func @test_strided_slice_shrink(%arg0: tensor<13x21x3xf32>) -> tensor<*xf32> {
 
 // -----
 
+// CHECK-LABEL: test_strided_slice_shrink_ignore_stride
+// CHECK-DAG: %[[VAR0:.*]] =  "tosa.slice"(%arg0) {size = [1, 1, 2], start = [4, 0, 1]}
+// CHECK: %[[VAR1:.*]] = "tosa.reshape"(%[[VAR0]]) {new_shape = [2]}
+func @test_strided_slice_shrink_ignore_stride(%arg0: tensor<13x21x3xf32>) -> tensor<*xf32> {
+  %cst = arith.constant dense<[4, 0, 1]> : tensor<3xi32>
+  %cst_0 = arith.constant dense<[13, 21, 3]> : tensor<3xi32>
+  %cst_1 = arith.constant dense<[1, 3, 1]> : tensor<3xi32>
+  %0 = "tfl.strided_slice"(%arg0, %cst, %cst_0, %cst_1)  {begin_mask = 2 : i32, ellipsis_mask = 0 : i32, end_mask = 3 : i32, new_axis_mask = 0 : i32, shrink_axis_mask = 3 : i32}  : (tensor<13x21x3xf32>, tensor<3xi32>, tensor<3xi32>, tensor<3xi32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}
+
+// -----
+
 // CHECK-LABEL: test_strided_slice_unstrided
 // CHECK: %[[VAR0:.*]] = "tosa.slice"(%arg0) {size = [9, 21, 2], start = [4, 0, 1]}
 // CHECK: %[[VAR1:.*]] = "tosa.reverse"(%[[VAR0]]) {axis = 2 : i64}

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
@@ -2251,7 +2251,11 @@ llvm::Optional<Value> convertStridedSliceOp(
     a1_size[i] = end[i] - begin[i];
 
     // Shrink axis mask means we know the size is 1.
-    if (shrink_axis_mask & (1 << i)) a1_size[i] = 1;
+    // Stride is ignored if shrink axis mask is set.
+    if (shrink_axis_mask & (1 << i)) {
+      a1_size[i] = 1;
+      strides[i] = 1;
+    }
 
     a2_shape[i * 2 + 0] = a1_size[i] / abs(strides[i]);
     a2_shape[i * 2 + 1] = abs(strides[i]);


### PR DESCRIPTION
Strided slice should ignore stride if shrink_axis_mask is set for
that dimension. Set strides to 1 for those dimensions. Otherwise
the reshape ends up with dimensions of size 0, which are invalid.