### PR TITLE
Avoid dequantizing with qi16 convolution

### DIFF
--- a/tensorflow/compiler/mlir/lite/tests/decompose-hybrid-quantization.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/decompose-hybrid-quantization.mlir
@@ -28,6 +28,20 @@ func @test_conv2d_qi8(%arg0: tensor<1x32x32x8x!quant.uniform<i8:f32, 1.0>>) -> t
 
 // -----
 
+// CHECK-LABEL: @test_conv2d_qi16
+func @test_conv2d_qi16(%arg0: tensor<1x32x32x8x!quant.uniform<i16:f32, 1.0>>) -> tensor<1x32x32x16x!quant.uniform<i16:f32, 1.0>> {
+  // CHECK-DAG: %[[BIAS:.+]] = arith.constant dense<0> : tensor<16xi64>
+  // CHECK-DAG: %[[VAL0:.+]] = "tfl.pseudo_qconst"() {qtype = tensor<{{.+}}>, value = dense<42> : tensor<16x1x1x8xi8>}
+  // CHECK-DAG: %[[VAL1:.+]] = "tfl.conv_2d"(%arg0, %[[VAL0]], %[[BIAS]]) {dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 1 : i32}
+  // CHECK: return %[[VAL1]]
+  %0 = "tfl.pseudo_qconst"() {qtype = tensor<16x1x1x8x!quant.uniform<i8:f32, 1.0>>, value = dense<42> : tensor<16x1x1x8xi8>} : () -> tensor<16x1x1x8x!quant.uniform<i8:f32, 1.0>>
+  %1 = "arith.constant"() {value = dense<0> : tensor<16xi64>} : () -> tensor<16xi64>
+  %2 = "tfl.conv_2d"(%arg0, %0, %1) {dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 1 : i32} : (tensor<1x32x32x8x!quant.uniform<i16:f32, 1.0>>, tensor<16x1x1x8x!quant.uniform<i8:f32, 1.0>>, tensor<16xi64>) -> tensor<1x32x32x16x!quant.uniform<i16:f32, 1.0>>
+  return %2 : tensor<1x32x32x16x!quant.uniform<i16:f32, 1.0>>
+}
+
+// -----
+
 // CHECK-LABEL: @test_conv2d_replace_qi8
 func @test_conv2d_replace_qi8(%arg0: tensor<1x32x32x8xf32>) -> tensor<1x32x32x16x!quant.uniform<i8:f32, 1.0>> {
   // CHECK-DAG: %[[VAL0:.+]] = "tfl.pseudo_qconst"() {qtype = tensor<{{.+}}>, value = dense<42> : tensor<16x1x1x8xi8>}

--- a/tensorflow/compiler/mlir/lite/transforms/decompose_hybrid_quantization.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/decompose_hybrid_quantization.cc
@@ -68,22 +68,25 @@ class DequantizeConverter : public OpRewritePattern<SrcOp> {
                                 PatternRewriter &rewriter) const final {
     Operation *op = srcop.getOperation();
     bool allTypesFp = true;
-    bool allTypesQuantized = true;
+    bool allTypesQuantizedOrInt = true;
     for (auto operand : op->getOperands()) {
       ShapedType type = operand.getType().template dyn_cast<ShapedType>();
       if (!type) continue;
       allTypesFp &= !type.getElementType().isa<quant::QuantizedType>();
-      allTypesQuantized &= type.getElementType().isa<quant::QuantizedType>();
+      allTypesQuantizedOrInt &= (type.getElementType().isa<quant::QuantizedType>() || type.getElementType().isa<IntegerType>());
     }
 
     for (auto result : op->getResults()) {
       ShapedType type = result.getType().template cast<ShapedType>();
       allTypesFp &= !type.getElementType().isa<quant::QuantizedType>();
-      allTypesQuantized &= type.getElementType().isa<quant::QuantizedType>();
+      allTypesQuantizedOrInt &= (type.getElementType().isa<quant::QuantizedType>() || type.getElementType().isa<IntegerType>());
     }
 
     // If all quantized or floating point then types are consistent.
-    if (allTypesFp || allTypesQuantized) return failure();
+    // Int is valid in combination with both quantized and floating point.
+    // This occurs when doing qi16 convolution, as bias is passed as a
+    // non-quantized int64
+    if (allTypesFp || allTypesQuantizedOrInt) return failure();
 
     Location loc = op->getLoc();
     SmallVector<Value> newOperands;

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -68,6 +68,20 @@ func @test_conv2d_qi8(%arg0: tensor<1x32x32x8x!quant.uniform<i8:f32, 0.015684768
 
 // -----
 
+// CHECK-LABEL: test_conv2d_qi16
+// CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<0> : tensor<16xi48>}
+// CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() {value = dense<{{.*}}> : tensor<16x1x1x8xi8>}
+// CHECK-DAG: %[[VAR2:.*]] = "tosa.conv2d"(%arg0, %[[VAR1]], %[[VAR0]]) {dilation = [1, 1], pad = [0, 0, 0, 0], quantization_info = {input_zp = 0 : i32, weight_zp = 0 : i32}, stride = [1, 1]}
+// CHECK: %[[VAR3:.*]] = "tosa.rescale"(%[[VAR2]])
+func @test_conv2d_qi16(%arg0: tensor<1x32x32x8x!quant.uniform<i16:f32, 1.0>>) -> tensor<1x32x32x16x!quant.uniform<i16:f32, 1.0>> {
+  %0 = "tfl.pseudo_qconst"() {qtype = tensor<16x1x1x8x!quant.uniform<i8:f32, 1.0>>, value = dense<42> : tensor<16x1x1x8xi8>} : () -> tensor<16x1x1x8x!quant.uniform<i8:f32, 1.0>>
+  %1 = "arith.constant"() {value = dense<0> : tensor<16xi64>} : () -> tensor<16xi64>
+  %2 = "tfl.conv_2d"(%arg0, %0, %1) {dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 1 : i32} : (tensor<1x32x32x8x!quant.uniform<i16:f32, 1.0>>, tensor<16x1x1x8x!quant.uniform<i8:f32, 1.0>>, tensor<16xi64>) -> tensor<1x32x32x16x!quant.uniform<i16:f32, 1.0>>
+  return %2 : tensor<1x32x32x16x!quant.uniform<i16:f32, 1.0>>
+}
+
+// -----
+
 // CHECK-LABEL: test_depthwise_conv2d_bias_qi8
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() {value = dense<{{.*}}> : tensor<1x2x2x16xi8>}
 // CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() {value = dense<[1, 2, 3, 0]> : tensor<4xi32>}

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
@@ -93,6 +93,8 @@ Value buildRescaleOpConvOutput(PatternRewriter& rewriter, Operation* op,
 
   bool scale32 = isScale32(output_qtype);
   int32_t scale_width = scale32 ? 32 : 16;
+  // Only use double round if we are doing 32 bit scaling
+  bool double_round = scale32;
 
   if (auto weight_per_tensor_qtype =
           weight_type.getElementType()
@@ -112,7 +114,7 @@ Value buildRescaleOpConvOutput(PatternRewriter& rewriter, Operation* op,
         rewriter.getI32IntegerAttr(0), rewriter.getI32IntegerAttr(output_zp),
         rewriter.getI32ArrayAttr({multiplier}),
         rewriter.getI32ArrayAttr({shift}), rewriter.getBoolAttr(scale32),
-        rewriter.getBoolAttr(true), rewriter.getBoolAttr(false));
+        rewriter.getBoolAttr(double_round), rewriter.getBoolAttr(false));
 
     return rescale_op.getResult();
 
@@ -148,7 +150,7 @@ Value buildRescaleOpConvOutput(PatternRewriter& rewriter, Operation* op,
         rewriter.getI32IntegerAttr(0), rewriter.getI32IntegerAttr(output_zp),
         rewriter.getI32ArrayAttr(multiplier_arr),
         rewriter.getI32ArrayAttr(shift_arr), rewriter.getBoolAttr(scale32),
-        rewriter.getBoolAttr(true), rewriter.getBoolAttr(true));
+        rewriter.getBoolAttr(double_round), rewriter.getBoolAttr(true));
 
     return rescale_op.getResult();
 


### PR DESCRIPTION
This avoids the decompose-hybrid-quantization pass for quantized int16
convolutions. Those convolutions contain a non-quantized int64 bias.
The hybrid decompose pass is only used when a mixed floating point and
quantized operator is detected.

Also properly set the double_round field in the TOSA rescale after
convolution. When 16-bit scaling is involved, double_round must be
false.

Signed-off-by: Eric Kunze <eric.kunze@arm.com>