### PR TITLE
Properly set the bounds for estimator

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -92,7 +92,7 @@ REQUIRED_PACKAGES = [
     # They are updated during the release process
     # When updating these, please also update the nightly versions below
     'tensorboard >= 2.8, < 2.9',
-    'tf-estimator-nightly == 2.8.0.dev2021122109',
+    'tensorflow-estimator >= 2.8, < 2.9',
     'keras >= 2.8.0rc0, < 2.9',
     'tensorflow-io-gcs-filesystem >= 0.23.1',
 ]


### PR DESCRIPTION
Not affecting TF 2.8 release much (as the nightly that we pinned to is the same we build 2.8 from) but we should fix.