### PR TITLE
[TF:TRT] Remove warning message about missing TRTEngineCacheResource

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
@@ -193,9 +193,12 @@ class SerializeTRTResource : public OpKernel {
 
     // Lookup engine cache resource.
     TRTEngineCacheResource* resource = nullptr;
-    OP_REQUIRES_OK(
-        ctx, ctx->resource_manager()->Lookup(std::string(kTfTrtContainerName),
-                                             resource_name, &resource));
+    OP_REQUIRES(
+        ctx,
+        ctx->resource_manager()
+            ->Lookup(std::string(kTfTrtContainerName), resource_name, &resource)
+            .ok(),
+        errors::NotFound("TRTEngineCacheResource not yet created"));
     core::ScopedUnref unref_me(resource);
 
     // Terminate the calibration if any.


### PR DESCRIPTION
This PR removes a confusing warning message that was printed while saving the model.

Until now, if we convert and save the model without calling build(), then the following message is printed to the console:
```
W tensorflow/core/framework/op_kernel.cc:1745] OP_REQUIRES failed at trt_engine_resource_ops.cc:196 : NOT_FOUND: Container TF-TRT does not exist. (Could not find resource: TF-TRT/TRTEngineOp_0_0)
```

This message is confusing to new users of TF-TRT: it describes a failure, which is printed as a warning `W`, and it is not clear for the user if anything went wrong (in fact nothing went wrong). This PR removes this warning message. 