### PR TITLE
Do not run scorecards analysis in forks

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -27,6 +27,7 @@ permissions: read-all
 
 jobs:
   analysis:
+    if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks
     name: Scorecards analysis
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Since this job has side effects, I am guessing it shouldn't be run by any forks? The analysis is probably going to fail due to permissions errors and would confuse contributors.