### PR TITLE
[TF:TRT] Cleanup TRTOptimizer and convert_graph

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
@@ -49,9 +49,9 @@ limitations under the License.
 #include "tensorflow/core/lib/gtl/cleanup.h"
 #include "tensorflow/core/lib/strings/numbers.h"
 #include "tensorflow/core/platform/logging.h"
-#include "tensorflow/core/protobuf/config.pb.h"  // NOLINT
+#include "tensorflow/core/protobuf/config.pb.h"             // NOLINT
 #include "tensorflow/core/protobuf/device_properties.pb.h"  // NOLINT
-#include "tensorflow/core/protobuf/rewriter_config.pb.h"  // NOLINT
+#include "tensorflow/core/protobuf/rewriter_config.pb.h"    // NOLINT
 #include "tensorflow/core/util/device_name_utils.h"
 #include "tensorflow/tools/graph_transforms/transform_utils.h"
 
@@ -81,15 +81,17 @@ Status BuildNodeMap(const Graph& graph,
   return Status::OK();
 }
 
-EngineInfo::EngineType GetEngineType(const ConversionParams& params) {
-  return (params.is_dyn_op || params.use_calibration)
+EngineInfo::EngineType GetEngineType(
+    const TRTOptimizationPass::ConversionParams& params) {
+  return (params.is_dynamic_op || params.use_calibration)
              ? EngineInfo::EngineType::TRTDynamic
              : EngineInfo::EngineType::TRTStatic;
 }
 
 // Returns true when use_implicit_batch is false or when we are building dynamic
 // engine, to allow unknown size for dimensions rather than dimension 0.
-bool AllowDynamicNonBatchDimension(const ConversionParams& params) {
+bool AllowDynamicNonBatchDimension(
+    const TRTOptimizationPass::ConversionParams& params) {
   return !params.use_implicit_batch ||
          GetEngineType(params) == EngineInfo::EngineType::TRTDynamic;
 }
@@ -133,7 +135,6 @@ bool ShallKeepControlEdgeFrom(const Node* input_node) {
 Status GetEngineInfo(const Graph* g,
                      const grappler::GraphProperties& graph_properties,
                      const Segment& segment,
-                     const std::unordered_map<string, Node*>& node_map,
                      const std::vector<Node*>& reverse_topo_order,
                      EngineInfo* info) {
   std::vector<const Node*> subgraph_nodes;  // Topologically sorted nodes.
@@ -343,10 +344,11 @@ tensorflow::TensorShapeProto ComputeTRTNodeIOShape(
 //         one). Connect to the pre-existing engine node instead.
 // 3. In this way, we ensure the graph is topologically sort-able after each
 //    invocation of CreateTRTNode().
-Status CreateTRTNode(const ConversionParams& params, grappler::Cluster* cluster,
+Status CreateTRTNode(const TRTOptimizationPass::ConversionParams& params,
                      const std::vector<EngineInfo>& infos, int pos,
                      int default_max_batch_size, Graph* graph,
-                     std::vector<Node*>* engine_nodes) {
+                     std::vector<Node*>* engine_nodes,
+                     grappler::Cluster* cluster) {
   const auto& info = infos.at(pos);
   std::vector<tensorflow::TensorShapeProto> input_shape_protos;
   std::vector<tensorflow::TensorShapeProto> output_shape_protos;
@@ -460,9 +462,9 @@ Status CreateTRTNode(const ConversionParams& params, grappler::Cluster* cluster,
                            : default_max_batch_size;
 
   if (info.engine_type == EngineInfo::EngineType::TRTStatic) {
-    TF_RETURN_IF_ERROR(CreateStaticEngine(params, cluster, info, max_batch_size,
+    TF_RETURN_IF_ERROR(CreateStaticEngine(params, info, max_batch_size,
                                           input_shapes, nullptr,
-                                          &segment_string));
+                                          &segment_string, cluster));
   }
 
   string prec_string;
@@ -637,8 +639,7 @@ Status RegisterGraphToFunctionLibrary(const GraphDef& segment_graph_def,
 }
 
 std::pair<int, Allocator*> GetDeviceAndAllocator(
-    const ConversionParams& params, const EngineInfo& engine,
-    const grappler::Cluster* cluster) {
+    const grappler::Cluster* cluster, const EngineInfo& engine) {
   int cuda_device_id = -1;
   Allocator* dev_allocator = nullptr;
   if (cluster == nullptr || cluster->GetDeviceSet() == nullptr ||
@@ -687,14 +688,13 @@ std::pair<int, Allocator*> GetDeviceAndAllocator(
   return std::make_pair(cuda_device_id, dev_allocator);
 }
 
-Status CreateStaticEngine(const ConversionParams& params,
-                          grappler::Cluster* cluster, const EngineInfo& info,
-                          int max_batch_size,
+Status CreateStaticEngine(const TRTOptimizationPass::ConversionParams& params,
+                          const EngineInfo& info, int max_batch_size,
                           const std::vector<PartialTensorShape>& input_shapes,
                           TrtShapeOptimizationProfile* profile,
-                          string* segment_string) {
+                          string* segment_string, grappler::Cluster* cluster) {
   std::pair<int, Allocator*> device_allocator =
-      GetDeviceAndAllocator(params, info, cluster);
+      GetDeviceAndAllocator(cluster, info);
   int cuda_device_id = 0;
   std::unique_ptr<TRTBaseAllocator> trt_allocator;
   if (device_allocator.first >= 0) {
@@ -727,25 +727,20 @@ Status CreateStaticEngine(const ConversionParams& params,
   return Status::OK();
 }
 
-// Entry function from optimization pass.
-Status ConvertAfterShapes(const ConversionParams& params,
-                          grappler::Cluster* cluster) {
+Status ConvertGraph(const TRTOptimizationPass::ConversionParams& params,
+                    grappler::GrapplerItem& grappler_item,
+                    const std::vector<string>& input_output_names,
+                    grappler::Cluster* cluster, GraphDef* output) {
   // Sanity checks.
+  TRT_ENSURE(output != nullptr)
   if (params.precision_mode != TrtPrecisionMode::INT8 &&
       params.use_calibration) {
     return errors::InvalidArgument(
         "Calibration with FP32 or FP16 is not supported.");
   }
 
-  // Make a copy of the input_graph_def because grappler doesn't allow changes
-  // to the input_graph_def and GraphProperties only accepts GraphDef, but not
-  // Graph, as inputs.
-  //
-  // If the overhead of copying the input_graph_def becomes a concern, we can
-  // avoid the copy by (1) enhancing the GraphPropertiers representation to
-  // allow adding shape properties for newly created graph nodes and (2) rewrite
-  // the GraphDef transformation to Graph transformation.
-  GraphDef modified_graph_def = params.grappler_item->graph;
+  GraphDef &graph_def = grappler_item.graph;
+
   // When precision_mode is FP16, transform cast(x, fp32) to
   // cast(cast(x, fp16), fp32). This creates cast(fp16, f32) that can be
   // included in the TRTEngineOp as an TensorRT Identity layer for performance:
@@ -754,18 +749,14 @@ Status ConvertAfterShapes(const ConversionParams& params,
   //  . Changing the input to the TRTEngine from fp32 to fp16 may reduce data
   //    moving from the host to the GPU.
   if (params.precision_mode == TrtPrecisionMode::FP16) {
-    for (int i = 0; i < modified_graph_def.node_size(); i++) {
-      NodeDef* node_def = modified_graph_def.mutable_node(i);
-      TF_RETURN_IF_ERROR(MaybeRewriteCastToFp32(&modified_graph_def, node_def));
+    for (int i = 0; i < graph_def.node_size(); i++) {
+      NodeDef* node_def = graph_def.mutable_node(i);
+      TF_RETURN_IF_ERROR(MaybeRewriteCastToFp32(&graph_def, node_def));
     }
   }
 
   // Construct a GrapplerItem using the modified graph_def and the input
   // grappler_item.
-  grappler::GrapplerItem grappler_item =
-      params.grappler_item->WithGraph(std::move(modified_graph_def));
-  const GraphDef& graph_def = grappler_item.graph;
-
   grappler::GraphProperties static_graph_properties(grappler_item);
   TF_RETURN_IF_ERROR(static_graph_properties.InferStatically(true));
 
@@ -778,7 +769,7 @@ Status ConvertAfterShapes(const ConversionParams& params,
   // Segment the graph into subgraphs that can be converted to TensorRT
   segment::SegmentOptions segment_options;
   // TODO(ben,jie,sami): exclude output nodes (DISCUSS IT)
-  for (const auto& node : *(params.input_output_names)) {
+  for (const auto& node : input_output_names) {
     segment_options.exclude_node_list.insert(node);
   }
   segment_options.minimum_segment_size = params.minimum_segment_size;
@@ -819,7 +810,7 @@ Status ConvertAfterShapes(const ConversionParams& params,
     EngineInfo curr_engine;
     curr_engine.engine_name = StrCat(engine_name_prefix, t);
 
-    bool int8_no_calib = (params.use_calibration == false &&
+    bool int8_no_calib = (!params.use_calibration &&
                           params.precision_mode == TrtPrecisionMode::INT8);
     bool has_qdq = false;
     if (int8_no_calib) {
@@ -827,7 +818,7 @@ Status ConvertAfterShapes(const ConversionParams& params,
     }
 
     Status status = GetEngineInfo(&graph, static_graph_properties, curr_segment,
-                                  node_map, reverse_topo_order, &curr_engine);
+                                  reverse_topo_order, &curr_engine);
     if (!status.ok()) {
       LOG_WARNING_WITH_PREFIX << "Failed to get engine info for segment " << t
                               << ": " << status;
@@ -877,7 +868,7 @@ Status ConvertAfterShapes(const ConversionParams& params,
   // Save the cuda device since we may need to switch to another cuda device to
   // build static engines.
   absl::optional<int> old_cuda_device = absl::nullopt;
-  if (!params.is_dyn_op) {
+  if (!params.is_dynamic_op) {
     int cuda_device_id;
     cudaError_t cuda_error = cudaGetDevice(&cuda_device_id);
     if (cuda_error != cudaSuccess) {
@@ -904,8 +895,9 @@ Status ConvertAfterShapes(const ConversionParams& params,
     engine.max_workspace_size_bytes = params.max_workspace_size_bytes;
     VLOG(1) << "Assigned " << engine.max_workspace_size_bytes << " bytes to "
             << engine.engine_name;
-    auto status = CreateTRTNode(params, cluster, engine_segments, i,
-                                params.max_batch_size, &graph, &engine_nodes);
+    auto status =
+        CreateTRTNode(params, engine_segments, i, params.max_batch_size, &graph,
+                      &engine_nodes, cluster);
 
     string msg = StrCat("segment ", i, " consisting of ",
                         converted_segments.at(i).nodes.size(), " nodes by ",
@@ -934,8 +926,7 @@ Status ConvertAfterShapes(const ConversionParams& params,
       }
     }
   }
-  graph.ToGraphDef(params.output_graph_def);
-  VLOG(1) << "Returning from conversion";
+  graph.ToGraphDef(output);
   return Status::OK();
 }
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.h
@@ -18,6 +18,7 @@ limitations under the License.
 #include <vector>
 
 #include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h"
 #include "tensorflow/core/framework/graph.pb.h"
@@ -33,34 +34,19 @@ namespace tensorflow {
 namespace tensorrt {
 namespace convert {
 
-struct ConversionParams {
-  const grappler::GrapplerItem* grappler_item = nullptr;
-  const std::vector<string>* input_output_names = nullptr;
-  string trt_logger_name;
-  size_t max_batch_size = 1;
-  size_t max_workspace_size_bytes = 1 << 30;
-  GraphDef* output_graph_def = nullptr;
-  TrtPrecisionMode precision_mode = TrtPrecisionMode::FP32;
-  int minimum_segment_size = 3;
-  // Whether to create engine on conversion or execution time
-  bool is_dyn_op = false;
-  // maximum number of cached engines
-  int max_cached_engines = 1;
-  bool use_calibration = true;
-  bool use_implicit_batch = true;
-  ProfileStrategy profile_strategy = ProfileStrategy::kRange;
-  bool allow_build_at_runtime = true;
-  bool use_explicit_precision = false;
-};
+// These functions are internal implementation functions for the
+// TRTOptimizationPass.
 
-// Method to call from optimization pass
-Status ConvertAfterShapes(const ConversionParams& params,
-                          grappler::Cluster* cluster);
+// Performs segmentation and conversion on the given Grappler item. This method
+// contains the core logic of the TRTOptimizationPass.
+Status ConvertGraph(const TRTOptimizationPass::ConversionParams& params,
+                    grappler::GrapplerItem& grappler_item,
+                    const std::vector<string>& input_output_names,
+                    grappler::Cluster* cluster, GraphDef* output);
 
 // Helper method for the conversion, expose for testing.
 std::pair<int, Allocator*> GetDeviceAndAllocator(
-    const ConversionParams& params, const EngineInfo& engine,
-    const grappler::Cluster* cluster = nullptr);
+    const grappler::Cluster* cluster, const EngineInfo& engine);
 
 // Helper method that registers `segment_graph` as a function to the function
 // library in `graph`.
@@ -69,12 +55,11 @@ Status RegisterGraphToFunctionLibrary(const GraphDef& segment_graph_def,
 
 // Creates and serializes an ICudaEngine. Used only in is_dynamic_op=false,
 // a.k.a. static engine mode.
-Status CreateStaticEngine(const ConversionParams& params,
-                          grappler::Cluster* cluster, const EngineInfo& info,
-                          int max_batch_size,
+Status CreateStaticEngine(const TRTOptimizationPass::ConversionParams& params,
+                          const EngineInfo& info, int max_batch_size,
                           const std::vector<PartialTensorShape>& input_shapes,
                           TrtShapeOptimizationProfile* profile,
-                          string* segment_string);
+                          string* segment_string, grappler::Cluster* cluster);
 
 }  // namespace convert
 }  // namespace tensorrt

--- a/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
@@ -14,6 +14,8 @@ limitations under the License.
 
 #include "tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h"
 
+#include <memory>
+
 #include "absl/strings/ascii.h"
 #include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
@@ -24,20 +26,20 @@ limitations under the License.
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/core/grappler/clusters/cluster.h"
 #include "tensorflow/core/grappler/grappler_item.h"
+#include "tensorflow/core/grappler/op_types.h"
 #include "tensorflow/core/grappler/optimizers/custom_graph_optimizer_registry.h"
 #include "tensorflow/core/grappler/utils/functions.h"
+#include "tensorflow/core/grappler/utils/topological_sort.h"
 #include "tensorflow/core/lib/strings/numbers.h"
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/platform/casts.h"
 #include "tensorflow/core/platform/logging.h"
-#include "tensorflow/core/platform/stacktrace.h"
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 namespace tensorflow {
 namespace tensorrt {
 namespace convert {
-// TODO(sami): Remove VLOG messages once the code matures
 using absl::AsciiStrToUpper;
 using absl::StrAppend;
 using absl::StrCat;
@@ -73,7 +75,8 @@ StatusOr<bool> ShouldConvertFunction(const grappler::GrapplerItem& item) {
 
 // Converts function conversion attributes to conversion parameters.
 Status UpdateFunctionSpecificConversionParams(
-    ConversionParams& cp, const tensorflow::AttrSlice& attr) {
+    TRTOptimizationPass::ConversionParams& cp,
+    const tensorflow::AttrSlice& attr) {
   auto get_size_attr = [](const AttrSlice& attr, absl::string_view name,
                           size_t* dst) -> Status {
     int tmp = 0;
@@ -95,7 +98,7 @@ Status UpdateFunctionSpecificConversionParams(
       TrtPrecisionModeFromName(precision_mode, &cp.precision_mode));
   TF_RETURN_IF_ERROR(GetNodeAttr(attr, "_tftrt_minimum_segment_size",
                                  &cp.minimum_segment_size));
-  TF_RETURN_IF_ERROR(GetNodeAttr(attr, "_tftrt_is_dyn_op", &cp.is_dyn_op));
+  TF_RETURN_IF_ERROR(GetNodeAttr(attr, "_tftrt_is_dyn_op", &cp.is_dynamic_op));
   TF_RETURN_IF_ERROR(
       GetNodeAttr(attr, "_tftrt_max_cached_engines", &cp.max_cached_engines));
   TF_RETURN_IF_ERROR(
@@ -111,156 +114,52 @@ Status UpdateFunctionSpecificConversionParams(
                                  &cp.allow_build_at_runtime));
   return Status::OK();
 }
-
 }  // namespace
 
 Status TRTOptimizationPass::Init(
     const RewriterConfig_CustomGraphOptimizer* config) {
-  VLOG(1) << "Called INIT for " << name_ << " with config = " << config;
   if (config == nullptr) {
     return Status::OK();
   }
-  VLOG(1) << "config = " << config->DebugString();
   const auto params = config->parameter_map();
   if (params.count("minimum_segment_size")) {
-    minimum_segment_size_ = params.at("minimum_segment_size").i();
+    params_.minimum_segment_size = params.at("minimum_segment_size").i();
   }
   if (params.count("max_batch_size")) {
-    maximum_batch_size_ = params.at("max_batch_size").i();
+    params_.max_batch_size = params.at("max_batch_size").i();
   }
   if (params.count("is_dynamic_op")) {
-    is_dynamic_op_ = params.at("is_dynamic_op").b();
+    params_.is_dynamic_op = params.at("is_dynamic_op").b();
   }
   if (params.count("maximum_cached_engines")) {
-    max_cached_batches_ = params.at("maximum_cached_engines").i();
+    params_.max_cached_engines = params.at("maximum_cached_engines").i();
   }
   if (params.count("max_workspace_size_bytes")) {
-    max_workspace_size_bytes_ = params.at("max_workspace_size_bytes").i();
+    params_.max_workspace_size_bytes =
+        params.at("max_workspace_size_bytes").i();
   }
   if (params.count("precision_mode")) {
     TF_RETURN_IF_ERROR(TrtPrecisionModeFromName(
-        AsciiStrToUpper(params.at("precision_mode").s()), &precision_mode_));
+        AsciiStrToUpper(params.at("precision_mode").s()),
+        &params_.precision_mode));
   }
   if (params.count("use_calibration")) {
-    use_calibration_ = params.at("use_calibration").b();
+    params_.use_calibration = params.at("use_calibration").b();
   }
   if (params.count("trt_logger")) {
-    trt_logger_name_ = params.at("trt_logger").s();
+    params_.trt_logger_name = params.at("trt_logger").s();
   }
   if (params.count("allow_build_at_runtime")) {
-    allow_build_at_runtime_ = params.at("allow_build_at_runtime").b();
+    params_.allow_build_at_runtime = params.at("allow_build_at_runtime").b();
   }
   if (params.count("use_implicit_batch")) {
-    use_implicit_batch_ = params.at("use_implicit_batch").b();
+    params_.use_implicit_batch = params.at("use_implicit_batch").b();
   }
   if (params.count("profile_strategy")) {
     TF_RETURN_IF_ERROR(ProfileStrategyFromName(
-        params.at("profile_strategy").s(), &profile_strategy_));
+        params.at("profile_strategy").s(), &params_.profile_strategy));
   }
   return Status::OK();
-}
-
-void TRTOptimizationPass::PrintDebugInfo(grappler::Cluster* cluster,
-                                         const grappler::GrapplerItem& item) {
-  LOG(INFO) << "Cluster = " << cluster;
-  string offset("  ");
-  string offset2 = StrCat(offset, offset);
-  string offset3 = StrCat(offset2, offset);
-  string offset4 = StrCat(offset2, offset2);
-
-  if (cluster) {
-    LOG(INFO) << offset << "type             = " << cluster->type();
-    LOG(INFO) << offset << "num warmup steps = " << cluster->NumWarmupSteps();
-    const auto dev_names = cluster->GetDeviceNames();
-    if (!dev_names.empty()) {
-      LOG(INFO) << offset << " Device names:";
-      for (const auto& s : dev_names) {
-        LOG(INFO) << offset2 << s;
-      }
-    }
-    std::unordered_map<string, uint64> peak_mem;
-    auto status = cluster->GetPeakMemoryUsage(&peak_mem);
-    if (status == Status::OK()) {
-      LOG(INFO) << offset << "Peak Memory Usage :";
-      for (const auto& s : peak_mem) {
-        LOG(INFO) << offset2 << s.first << " = " << s.second;
-      }
-    }
-
-    const auto dev_props = cluster->GetDevices();
-    if (!dev_props.empty()) {
-      LOG(INFO) << offset << "Device properties:";
-      for (const auto& k : dev_props) {
-        LOG(INFO) << offset2 << k.first;
-        const auto& dt = k.second;
-        LOG(INFO) << offset3 << "type          = " << dt.type();
-        LOG(INFO) << offset3 << "vendor        = " << dt.vendor();
-        LOG(INFO) << offset3 << "model         = " << dt.model();
-        LOG(INFO) << offset3 << "frequency     = " << dt.frequency();
-        LOG(INFO) << offset3 << "num cores     = " << dt.num_cores();
-        LOG(INFO) << offset3 << "num registers = " << dt.num_registers();
-        LOG(INFO) << offset3 << "L1 cache size = " << dt.l1_cache_size();
-        LOG(INFO) << offset3 << "L2 cache size = " << dt.l2_cache_size();
-        LOG(INFO) << offset3 << "L3 cache size = " << dt.l3_cache_size();
-        LOG(INFO) << offset3 << "SHMem per SMP = "
-                  << dt.shared_memory_size_per_multiprocessor();
-        LOG(INFO) << offset3 << "memory size   = " << dt.memory_size();
-        LOG(INFO) << offset3 << "bandwidth     = " << dt.bandwidth();
-        if (dt.environment_size()) {
-          LOG(INFO) << offset3 << "environment   :";
-          for (const auto& e : dt.environment()) {
-            LOG(INFO) << offset4 << e.first << " = " << e.second;
-          }
-        }
-      }
-    }
-
-    if (cluster->GetDeviceSet()) {
-      for (const auto dev : cluster->GetDeviceSet()->devices()) {
-        LOG(INFO) << "Device name= " << dev->name() << "Pased name= "
-                  << DeviceNameUtils::ParsedNameToString(dev->parsed_name());
-      }
-    }
-  }
-
-  LOG(INFO) << "item: " << item.id;
-  if (!item.feed.empty()) {
-    LOG(INFO) << offset << "Feeds  :";
-    for (const auto& f : item.feed) {
-      const auto& shape = f.second.shape();
-      LOG(INFO) << offset2 << f.first << " = shaped " << shape.DebugString();
-    }
-  } else {
-    LOG(INFO) << offset << "No Feeds";
-  }
-  if (!item.fetch.empty()) {
-    LOG(INFO) << offset << "Fetches  :";
-    for (const auto& f : item.fetch) {
-      LOG(INFO) << offset2 << f;
-    }
-  } else {
-    LOG(INFO) << offset << "No Fetches";
-  }
-
-  if (!item.init_ops.empty()) {
-    LOG(INFO) << offset << "init ops  :";
-    for (const auto& f : item.init_ops) {
-      LOG(INFO) << offset2 << f;
-    }
-  } else {
-    LOG(INFO) << offset << "No init ops";
-  }
-  LOG(INFO) << "Save Op = " << item.save_op;
-  LOG(INFO) << "Restore Op = " << item.restore_op;
-  LOG(INFO) << "save_restore_loc_tensor = " << item.save_restore_loc_tensor;
-  if (!item.keep_ops.empty()) {
-    LOG(INFO) << offset << "keep ops  :";
-    for (const auto& f : item.keep_ops) {
-      LOG(INFO) << offset2 << f;
-    }
-  } else {
-    LOG(INFO) << offset << "No keep ops";
-  }
 }
 
 static bool ExplicitPrecisionModePolicy() {
@@ -275,38 +174,39 @@ Status TRTOptimizationPass::Optimize(grappler::Cluster* cluster,
   TF_ASSIGN_OR_RETURN(bool do_function_conversion, ShouldConvertFunction(item));
   // Optimizing the main graph(identified with `item.id == "tf_graph"`) with
   // `minimim_segment_size == -1` indicates skipping main graph conversion.
-  if ((minimum_segment_size_ == -1 && item.id == "tf_graph") ||
+  if ((params_.minimum_segment_size == -1 && item.id == "tf_graph") ||
       (item.id != "tf_graph" && !do_function_conversion)) {
     VLOG(1) << "Not optimizing this grappler item: " << item.id;
     *optimized_graph = item.graph;
     return Status::OK();
   }
-  if (VLOG_IS_ON(3)) {
-    LOG(INFO) << CurrentStackTrace();
-    PrintDebugInfo(cluster, item);
-  }
 
-  if (use_calibration_ && precision_mode_ != TrtPrecisionMode::INT8) {
+  if (params_.use_calibration &&
+      params_.precision_mode != TrtPrecisionMode::INT8) {
     LOG(WARNING) << "Calibration with FP32 or FP16 is not implemented. "
                  << "Falling back to use_calibration = False."
                  << "Note that the default value of use_calibration is True.";
-    use_calibration_ = false;
+    params_.use_calibration = false;
   }
 
-  const bool use_explicit_precision = ShouldUseExplicitPrecision(item.graph);
-  if (use_explicit_precision) {
+  params_.use_explicit_precision = ShouldUseExplicitPrecision(item.graph);
+  if (params_.use_explicit_precision) {
     LOG(INFO) << "[TF-TRT] Using explicit QDQ mode";
-    if (precision_mode_ != TrtPrecisionMode::INT8 || use_calibration_) {
+    if (params_.precision_mode != TrtPrecisionMode::INT8 ||
+        params_.use_calibration) {
       LOG(WARNING)
           << "Explicit precision mode with calibration or FP32/FP16 mode is "
              "not supported."
           << " Setting precision mode to INT8 and calibration to false.";
-      precision_mode_ = TrtPrecisionMode::INT8;
-      use_calibration_ = false;
+      params_.precision_mode = TrtPrecisionMode::INT8;
+      params_.use_calibration = false;
     }
   } else {
     LOG(INFO) << "[TF-TRT] not using explicit QDQ mode";
   }
+
+  // Create a copy of the graph to optimize.
+  grappler::GrapplerItem optimized_item(item);
 
   std::vector<string> nodes_to_preserve;
   const auto& old_nodes_to_preserve = item.NodesToPreserve();
@@ -327,49 +227,19 @@ Status TRTOptimizationPass::Optimize(grappler::Cluster* cluster,
     nodes_to_preserve.push_back(s);
   }
 
-  ConversionParams cp;
-  cp.grappler_item = &item;
-  cp.input_output_names = &nodes_to_preserve;
-  cp.trt_logger_name = trt_logger_name_;
-  cp.max_batch_size = maximum_batch_size_;
-  cp.max_workspace_size_bytes = max_workspace_size_bytes_;
-  cp.output_graph_def = optimized_graph;
-  cp.precision_mode = precision_mode_;
-  cp.minimum_segment_size = minimum_segment_size_;
-  cp.is_dyn_op = is_dynamic_op_;
-  cp.max_cached_engines = max_cached_batches_;
-  cp.use_calibration = use_calibration_;
-  cp.use_implicit_batch = use_implicit_batch_;
-  cp.profile_strategy = profile_strategy_;
-  cp.allow_build_at_runtime = allow_build_at_runtime_;
-  cp.use_explicit_precision = use_explicit_precision;
-
   if (item.id != "tf_graph" && do_function_conversion) {
     const grappler::GrapplerFunctionItem& func_item =
         tensorflow::down_cast<const grappler::GrapplerFunctionItem&>(item);
     TF_RETURN_IF_ERROR(
-        UpdateFunctionSpecificConversionParams(cp, func_item.func_attr()));
+        UpdateFunctionSpecificConversionParams(params_, func_item.func_attr()));
     assert(cp.minimum_segment_size > 0);
   }
 
-  auto status = ConvertAfterShapes(cp, cluster);
-  VLOG(1) << "Returning from " << name_;
-  return status;
+  return ConvertGraph(params_, optimized_item, nodes_to_preserve, cluster,
+                      optimized_graph);
 }
 
-class VerboseCustomGraphOptimizerRegistrar
-    : public grappler::CustomGraphOptimizerRegistrar {
- public:
-  VerboseCustomGraphOptimizerRegistrar(
-      const grappler::CustomGraphOptimizerRegistry::Creator& cr,
-      const string& name)
-      : grappler::CustomGraphOptimizerRegistrar(cr, name) {
-    VLOG(1) << "Constructing a CustomOptimizationPass registration object for "
-            << name;
-  }
-};
-
-static VerboseCustomGraphOptimizerRegistrar TRTOptimizationPass_Registrar(
+static grappler::CustomGraphOptimizerRegistrar TRTOptimizationPass_Registrar(
     []() {
       VLOG(1)
           << "Instantiating CustomOptimizationPass object TensorRTOptimizer";

--- a/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h
@@ -16,12 +16,15 @@ limitations under the License.
 #ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TRT_OPTIMIZATION_PASS_H_
 #define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TRT_OPTIMIZATION_PASS_H_
 
+#include <memory>
 #include <string>
 
 #include "tensorflow/compiler/tf2tensorrt/convert/trt_parameters.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/core/framework/graph.pb.h"
+#include "tensorflow/core/grappler/costs/graph_properties.h"
 #include "tensorflow/core/grappler/optimizers/custom_graph_optimizer.h"
+#include "tensorflow/core/grappler/utils.h"
 #include "tensorflow/core/platform/logging.h"
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
@@ -37,21 +40,25 @@ namespace convert {
 
 class TRTOptimizationPass : public grappler::CustomGraphOptimizer {
  public:
+  struct ConversionParams {
+    string trt_logger_name = "DefaultLogger";
+    size_t max_batch_size = -1;
+    size_t max_workspace_size_bytes = 1 << 30;
+    TrtPrecisionMode precision_mode = TrtPrecisionMode::FP32;
+    int minimum_segment_size = 3;
+    // Whether to create engine on conversion or execution time
+    bool is_dynamic_op = false;
+    // maximum number of cached engines
+    int max_cached_engines = 1;
+    bool use_calibration = true;
+    bool use_implicit_batch = true;
+    ProfileStrategy profile_strategy = ProfileStrategy::kRange;
+    bool allow_build_at_runtime = true;
+    bool use_explicit_precision = false;
+  };
+
   TRTOptimizationPass(const string& name = "TRTOptimizationPass")
-      : name_(name),
-        trt_logger_name_("DefaultLogger"),
-        minimum_segment_size_(3),
-        precision_mode_(TrtPrecisionMode::FP32),
-        maximum_batch_size_(-1),
-        is_dynamic_op_(false),
-        max_cached_batches_(1),
-        max_workspace_size_bytes_(256LL << 20),
-        use_calibration_(true),
-        use_implicit_batch_(true),
-        profile_strategy_(ProfileStrategy::kRange),
-        allow_build_at_runtime_(true) {
-    VLOG(1) << "Constructing " << name_;
-  }
+      : name_(name) {}
 
   string name() const override { return name_; };
 
@@ -64,23 +71,12 @@ class TRTOptimizationPass : public grappler::CustomGraphOptimizer {
                   const grappler::GrapplerItem& item,
                   GraphDef* optimized_graph) override;
 
-  void PrintDebugInfo(grappler::Cluster* cluster,
-                      const grappler::GrapplerItem& item);
-
  private:
   const string name_;
-  string trt_logger_name_;
-  int minimum_segment_size_;
-  TrtPrecisionMode precision_mode_;
-  int maximum_batch_size_;
-  bool is_dynamic_op_;
+
+  ConversionParams params_;
+
   std::vector<int> batches_;
-  int max_cached_batches_;
-  int64_t max_workspace_size_bytes_;
-  bool use_calibration_;
-  bool use_implicit_batch_;
-  ProfileStrategy profile_strategy_;
-  bool allow_build_at_runtime_;
 };
 
 }  // namespace convert

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
@@ -89,7 +89,7 @@ class TRTEngineOpTestBase : public OpsTestBase {
 
     string segment_string;
     if (static_engine) {
-      convert::ConversionParams params;
+      convert::TRTOptimizationPass::ConversionParams params;
       convert::EngineInfo info;
       info.segment_graph_def.CopyFrom(graph_def);
       info.precision_mode = TrtPrecisionMode::FP32;
@@ -112,7 +112,7 @@ class TRTEngineOpTestBase : public OpsTestBase {
       profile.InitProfiles({shape}, ProfileStrategy::kOptimal);
       std::vector<PartialTensorShape> shape_vec{shape, {}};
       TF_CHECK_OK(convert::CreateStaticEngine(
-          params, nullptr, info, 1, shape_vec, &profile, &segment_string));
+          params, info, 1, shape_vec, &profile, &segment_string, nullptr));
     }
 
     // Create the op.


### PR DESCRIPTION
This change refactors `convert_graph` and `trt_optimization_pass`. 
De-duplicates the amount of data structures holding "conversion parameters". Each conversion parameter was duplicated inside of TRTOptimizationPass class because the `ConversionParams` struct contained const references to state variables. State variables were moved out of the struct and instead passed as function arguments. The `ConversionParams` struct was then moved into the `TRTOptimizationPass` class to make it clear what object owns the struct as an API dependency.
The function `ConvertAfterShapes` is renamed to `ConvertGraph`.
Various debugging output code was removed as it appears to be unused and an artifact of the original implementation.