### PR TITLE
[ROCm] Disable Kronecker linalg test

### DIFF
--- a/tensorflow/python/kernel_tests/linalg/BUILD
+++ b/tensorflow/python/kernel_tests/linalg/BUILD
@@ -375,6 +375,7 @@ cuda_py_test(
     srcs = ["linear_operator_kronecker_test.py"],
     shard_count = 10,
     tags = [
+        "no_rocm",
         "noasan",
         "optonly",
     ],


### PR DESCRIPTION
This test has started to fail on ROCm. Disable while we investigate.

@weihanmines @deven-amd @cheshire FYI