### PR TITLE
[ROCm] Fix to enable the following unit tests for BEF thunk on ROCm:

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/bef_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/bef_thunk.cc
@@ -444,8 +444,8 @@ Status BefThunk::Initialize(const GpuExecutable& executable,
       GpuModuleData module_data;
       // The module data should be null-terminated, so the length of the
       // inserted data is incremented by 1 to include '\0'.
-      module_data.blob = llvm::StringRef(executable.text().c_str(),
-                                         executable.text().size() + 1);
+      module_data.blob = llvm::ArrayRef<uint8_t>(executable.binary().data(),
+                                                 executable.binary().size() + 1);
       for (const auto& constant : executable.constants()) {
         module_data.constants.push_back(GpuModuleData::ConstantInfo{
             constant.symbol_name, constant.content});

--- a/tensorflow/compiler/xla/service/gpu/xlir_kernels.cc
+++ b/tensorflow/compiler/xla/service/gpu/xlir_kernels.cc
@@ -49,9 +49,9 @@ static llvm::Expected<tfrt::gpu::GpuModule> ModuleLoad(
     return tfrt::MakeStringError(
         "No GpuModuleData resource found in the request context.");
   }
-  llvm::StringRef blob = gpu_module_data->blob;
+  llvm::ArrayRef<uint8_t> blob = gpu_module_data->blob;
 
-  if (blob.empty() || blob.back() != 0)
+  if (blob.empty())
     return tfrt::MakeStringError("blob must be null-terminated");
 
   auto current = tfrt::gpu::wrapper::CtxSetCurrent(context->get());

--- a/tensorflow/compiler/xla/service/gpu/xlir_ops.h
+++ b/tensorflow/compiler/xla/service/gpu/xlir_ops.h
@@ -48,7 +48,7 @@ class XlirDialect : public mlir::Dialect {
 // GPU module data container to be stored in TFRT's request context and picked
 // up by xlir.module.load.
 struct GpuModuleData {
-  llvm::StringRef blob;
+  llvm::ArrayRef<uint8_t> blob;
 
   struct ConstantInfo {
     llvm::StringRef symbol_name;


### PR DESCRIPTION
- //tensorflow/compiler/xla/service/gpu/tests:kernel_launch_test
- //tensorflow/compiler/xla/tests:multioutput_fusion_test_gpu
- //tensorflow/compiler/xla/tests:scatter_test_gpu
- //tensorflow/compiler/xla/tests:while_test_gpu

Assign the HSACO binary to the blob which then gets passed to hipModuleLoadData.

The previous implementation assigned the asm text (which is not generated for ROCm) to the blob.

This implementation should work for CUDA as well since cuModuleLoadData accepts both PTX and cubin formats.

/cc @chsigg @hanbinyoon 