### PR TITLE
lite: Fix XNNPACK build for elinux_armhf

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -572,6 +572,7 @@ build:elinux_aarch64 --distinct_host_configuration=true
 build:elinux_armhf --config=elinux
 build:elinux_armhf --cpu=armhf
 build:elinux_armhf --distinct_host_configuration=true
+build:elinux_armhf --copt -mfp16-format=ieee
 # END TF REMOTE BUILD EXECUTION OPTIONS
 
 # Config-specific options should come above this line.


### PR DESCRIPTION
Added XNNPACK build for elinux_armhf from the fix: https://github.com/tensorflow/tensorflow/commit/4ec84aa99372ca7899fb12715edd2bfe3c947c88
Fixes #54268 