### PR TITLE
[bugfix] Use std::set::lower_bound instead of std::lower_bound for improved performance

### DIFF
--- a/tensorflow/lite/toco/allocate_transient_arrays.cc
+++ b/tensorflow/lite/toco/allocate_transient_arrays.cc
@@ -144,7 +144,7 @@ class Allocator {
       // Nothing needs to be done, these aren't kept in the books.
       return;
     }
-    auto iter = std::lower_bound(live_allocs_.begin(), live_allocs_.end(), a);
+    auto iter = live_allocs_.lower_bound(a);
     CHECK(iter != live_allocs_.end());
     CHECK(*iter == a);
     live_allocs_.erase(iter);


### PR DESCRIPTION
Using std::set::lower_bound has a logarithmic (O(log2N)) complexity while using std::lower_bound have a linear (O(n)). Thus, it is preferable to use std::set::lower_bound.

Source:
* cpp reference: [std::set::lower_bound](https://en.cppreference.com/w/cpp/algorithm/lower_bound)
* cpp reference: [std::lower_bound](https://en.cppreference.com/w/cpp/container/set/lower_bound)
* https://www.geeksforgeeks.org/difference-between-stdsetlower_bound-and-stdlower_bound-in-c/