### PR TITLE
Expose CreateLoopInvariantCopy

### DIFF
--- a/tensorflow/compiler/xla/service/while_loop_invariant_code_motion.cc
+++ b/tensorflow/compiler/xla/service/while_loop_invariant_code_motion.cc
@@ -33,12 +33,7 @@ using absl::flat_hash_map;
 using absl::flat_hash_set;
 using absl::InlinedVector;
 
-// Copies `to_hoist` to the computation containing `while_instr`, hoisting its
-// operands as needed.  All of its transitive operands are expected to be either
-// in `hoisted_instructions` or `unhoisted_invariant_instructions`.  This
-// function hoists the operands in `unhoisted_invariant_instructions` and moves
-// them into `hoisted_instructions`.
-static void CreateLoopInvariantCopy(
+void WhileLoopInvariantCodeMotion::CreateLoopInvariantCopy(
     flat_hash_map<HloInstruction*, HloInstruction*>* hoisted_instructions,
     flat_hash_set<HloInstruction*>* unhoisted_invariant_instructions,
     HloInstruction* while_instr, HloInstruction* to_hoist) {

--- a/tensorflow/compiler/xla/service/while_loop_invariant_code_motion.h
+++ b/tensorflow/compiler/xla/service/while_loop_invariant_code_motion.h
@@ -68,6 +68,17 @@ class WhileLoopInvariantCodeMotion : public HloModulePass {
   }
   StatusOr<bool> Run(HloModule* module) override;
 
+  // Copies `to_hoist` to the computation containing `while_instr`, hoisting its
+  // operands as needed.  All of its transitive operands are expected to be
+  // either in `hoisted_instructions` or `unhoisted_invariant_instructions`.
+  // This function hoists the operands in `unhoisted_invariant_instructions` and
+  // moves them into `hoisted_instructions`.
+  static void CreateLoopInvariantCopy(
+      absl::flat_hash_map<HloInstruction*, HloInstruction*>*
+          hoisted_instructions,
+      absl::flat_hash_set<HloInstruction*>* unhoisted_invariant_instructions,
+      HloInstruction* while_instr, HloInstruction* to_hoist);
+
  private:
   bool NotWorthHoistingIndividually(const HloInstruction& instruction);
   StatusOr<bool> TryHoistingInvariantInstructionsFromWhileBody(


### PR DESCRIPTION
Summary:
In order to use this function in other passes that act on while loops
make this function public.