### PR TITLE
Enable XNNPACK in tflite builds for armhf

### DIFF
--- a/tensorflow/lite/tools/pip_package/build_pip_package_with_cmake.sh
+++ b/tensorflow/lite/tools/pip_package/build_pip_package_with_cmake.sh
@@ -91,7 +91,6 @@ case "${TENSORFLOW_TARGET}" in
       -DCMAKE_CXX_FLAGS="${ARMCC_FLAGS}" \
       -DCMAKE_SYSTEM_NAME=Linux \
       -DCMAKE_SYSTEM_PROCESSOR=armv6 \
-      -DTFLITE_ENABLE_XNNPACK=OFF \
       "${TENSORFLOW_LITE_DIR}"
     ;;
   aarch64)
@@ -212,4 +211,3 @@ case "${TENSORFLOW_TARGET}" in
 esac
 
 cat "${BUILD_DIR}/debian/changelog"
-


### PR DESCRIPTION
Reverting b4ffa4cfcc50e7fcb8186b5cedbd0457acbe8ffb To enable XNNPACK for python tflite on Raspberry Pi etc.

@terryheo - given you made the change originally (and I'm not sure why) you're best to comment if this is a bad idea.