### PR TITLE
Add complex support for `tf.math.asin`

### DIFF
--- a/tensorflow/core/kernels/cwise_op_asin.cc
+++ b/tensorflow/core/kernels/cwise_op_asin.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #include "tensorflow/core/kernels/cwise_ops_common.h"
 
 namespace tensorflow {
-REGISTER4(UnaryOp, CPU, "Asin", functor::asin, Eigen::half, bfloat16, float,
-          double);
+REGISTER6(UnaryOp, CPU, "Asin", functor::asin, Eigen::half, bfloat16, float,
+          double, complex64, complex128);
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -533,6 +533,7 @@ class UnaryOpTest(test.TestCase):
     self._compareCpu(x, np.sinh, math_ops.sinh)
     self._compareCpu(x, np.cosh, math_ops.cosh)
     self._compareCpu(x, np.tanh, math_ops.tanh)
+    self._compareCpu(x, np.arcsin, math_ops.asin)
 
     # Complex64 versions of asinh() and acosh() in libstdc++ only have 6 digits
     # of precision.
@@ -583,6 +584,7 @@ class UnaryOpTest(test.TestCase):
     self._compareCpu(x, self._sigmoid, math_ops.sigmoid)
     self._compareCpu(x, np.sin, math_ops.sin)
     self._compareCpu(x, np.cos, math_ops.cos)
+    self._compareCpu(x, np.arcsin, math_ops.asin)
 
     self._compareBothSparse(x, np.abs, math_ops.abs)
     self._compareBothSparse(x, np.negative, math_ops.negative)


### PR DESCRIPTION
This PR address the feature requested by #54317 in adding complex support for tf.math.asin.

This PR fixes #54317.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>