### PR TITLE
Add complex support for `tf.sparse.segment_sum`

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
@@ -43,6 +43,8 @@ namespace tensorflow {
       SparseSegmentReductionSumWithNumSegmentsOp<CPUDevice, type, index_type, \
                                                  segment_ids_type>);
 TF_CALL_REAL_NUMBER_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
+REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE(complex64);
+REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE(complex128);
 #undef REGISTER_CPU_SPARSE_KERNELS
 
 #define REGISTER_CPU_SPARSE_KERNELS(type, index_type, segment_ids_type)        \

--- a/tensorflow/core/ops/compat/ops_history_v2/SparseSegmentSum.pbtxt
+++ b/tensorflow/core/ops/compat/ops_history_v2/SparseSegmentSum.pbtxt
@@ -267,3 +267,73 @@ op {
     }
   }
 }
+op {
+  name: "SparseSegmentSum"
+  input_arg {
+    name: "data"
+    type_attr: "T"
+  }
+  input_arg {
+    name: "indices"
+    type_attr: "Tidx"
+  }
+  input_arg {
+    name: "segment_ids"
+    type_attr: "Tsegmentids"
+  }
+  output_arg {
+    name: "output"
+    type_attr: "T"
+  }
+  attr {
+    name: "T"
+    type: "type"
+    allowed_values {
+      list {
+        type: DT_FLOAT
+        type: DT_DOUBLE
+        type: DT_INT32
+        type: DT_UINT8
+        type: DT_INT16
+        type: DT_INT8
+        type: DT_COMPLEX64
+        type: DT_INT64
+        type: DT_QINT8
+        type: DT_QUINT8
+        type: DT_QINT32
+        type: DT_BFLOAT16
+        type: DT_UINT16
+        type: DT_COMPLEX128
+        type: DT_HALF
+        type: DT_UINT32
+        type: DT_UINT64
+      }
+    }
+  }
+  attr {
+    name: "Tidx"
+    type: "type"
+    default_value {
+      type: DT_INT32
+    }
+    allowed_values {
+      list {
+        type: DT_INT32
+        type: DT_INT64
+      }
+    }
+  }
+  attr {
+    name: "Tsegmentids"
+    type: "type"
+    default_value {
+      type: DT_INT32
+    }
+    allowed_values {
+      list {
+        type: DT_INT32
+        type: DT_INT64
+      }
+    }
+  }
+}

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1351,7 +1351,7 @@ REGISTER_OP("SparseSegmentSum")
     .Input("indices: Tidx")
     .Input("segment_ids: Tsegmentids")
     .Output("output: T")
-    .Attr("T: realnumbertype")
+    .Attr("T: numbertype")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("Tsegmentids: {int32, int64} = DT_INT32")
     .SetShapeFn(SparseSegmentReductionShapeFn);

--- a/tensorflow/core/ops/ops.pbtxt
+++ b/tensorflow/core/ops/ops.pbtxt
@@ -52735,9 +52735,14 @@ op {
         type: DT_UINT8
         type: DT_INT16
         type: DT_INT8
+        type: DT_COMPLEX64
         type: DT_INT64
+        type: DT_QINT8
+        type: DT_QUINT8
+        type: DT_QINT32
         type: DT_BFLOAT16
         type: DT_UINT16
+        type: DT_COMPLEX128
         type: DT_HALF
         type: DT_UINT32
         type: DT_UINT64

--- a/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
@@ -569,7 +569,7 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
   def testValues(self):
     dtypes = [
         dtypes_lib.float32, dtypes_lib.float64, dtypes_lib.int64,
-        dtypes_lib.int32
+        dtypes_lib.int32, dtypes_lib.complex64,  dtypes_lib.complex128
     ]
 
     index_dtypes = [dtypes_lib.int32, dtypes_lib.int64]


### PR DESCRIPTION
This PR address the issue raised in #53655 where tf.sparse.segment_sum does not have complex support (while tf.math.segment_sum has). This PR adds complex support for tf.sparse.segment_sum.

This PR fixes #53655.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>