### PR TITLE
fix slow training start when using sample_weight (issue #48965)

### DIFF
--- a/tensorflow/python/keras/engine/training_utils.py
+++ b/tensorflow/python/keras/engine/training_utils.py
@@ -74,10 +74,10 @@ def handle_partial_sample_weights(outputs, sample_weights, sample_weight_modes,
     Tuple of sample weights, one sample weight for every output, and booleans
     describing the raw sample weights.
   """
-  any_sample_weight = sample_weights is not None and any(
-      w is not None for w in sample_weights)
-  partial_sample_weight = any_sample_weight and any(
-      w is None for w in sample_weights)
+  any_sample_weight = sample_weights is not None and (
+      sample_weights.numpy() != None).all()
+  partial_sample_weight = any_sample_weight and (
+      sample_weights.numpy() == None).any()
 
   if not any_sample_weight:
     return None, any_sample_weight, partial_sample_weight


### PR DESCRIPTION
fix issue 'Keras model.fit takes long until training begins when sample_weight is provided #48965.' previous version used list comprehension to check if any of the sample weights are 'None'. This is very slow. This replaces the list comprehension with array operations by converting the tensor to a numpy array.