### PR TITLE
[TF-TRT] Fix pylint error in `trt_convert.py`

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -306,7 +306,8 @@ def _get_tensorrt_rewriter_config(conversion_params,
   rewriter_config_with_trt.remapping = False
 
   # Prevent folding of Const->QDQ chains.
-  rewriter_config_with_trt.experimental_disable_folding_quantization_emulation = (
+  rewriter_config_with_trt. \
+    experimental_disable_folding_quantization_emulation = (
       trt_utils.is_linked_tensorrt_version_greater_equal(8, 0, 0) or
       trt_utils.is_loaded_tensorrt_version_greater_equal(8, 0, 0))
 


### PR DESCRIPTION
cc @bixia1 

Fixes a pylint error that causes the pylint CI job to fail on any PR that touches `trt_convert.py`.

The pylint error that I saw on one of my PRs earlier wasn't a false positive but a change that was already in master and not in my branch, hence why it appeared in CI but not when I was running pylint locally. The error was introduced in #52248