### PR TITLE
abseil: wyhash is now called low_level_hash

### DIFF
--- a/third_party/absl/system.absl.hash.BUILD
+++ b/third_party/absl/system.absl.hash.BUILD
@@ -7,7 +7,7 @@ cc_library(
     linkopts = ["-labsl_hash"],
     deps = [
         ":city",
-        ":wyhash",
+        ":low_level_hash",
         "//absl/base:endian",
         "//absl/container:fixed_array",
         "//absl/numeric:int128",
@@ -27,8 +27,8 @@ cc_library(
 )
 
 cc_library(
-    name = "wyhash",
-    linkopts = ["-labsl_wyhash"],
+    name = "low_level_hash",
+    linkopts = ["-labsl_low_level_hash"],
     visibility = ["//visibility:private"],
     deps = [
         "//absl/base:endian",


### PR DESCRIPTION
With https://github.com/tensorflow/tensorflow/commit/e45ca6adf2458d4759e5c40f1f27bbf9505a3c79 we have upgraded to the latest abseil LTS version. This did break the build with system abseil as the `wyhash` library was renamed to `low_level_hash`.