### PR TITLE
[TF-TRT] Add TF-TRT converter for ZerosLike and OnesLike

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -612,6 +612,7 @@ tf_cuda_library(
         "convert/ops/data_format_vec_permute.cc",
         "convert/ops/einsum.cc",
         "convert/ops/fill_ops.cc",
+        "convert/ops/like_ops.cc",
         "convert/ops/quantization_ops.cc",
         "convert/ops/slice_ops.cc",
         "convert/ops/tile.cc",

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/fill_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/fill_ops.cc
@@ -28,7 +28,7 @@ namespace convert {
 class ConvertFill : public OpConverterBase<ConvertFill> {
  public:
   explicit ConvertFill(OpConverterParams* params)
-      : OpConverterBase<ConvertFill>(params) {}
+      : OpConverterBase<ConvertFill> (params) {}
 
   static constexpr std::array<DataType, 3> AllowedDataTypes() {
     return {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32};
@@ -73,10 +73,8 @@ class ConvertFill : public OpConverterBase<ConvertFill> {
 
   Status Convert() {
     const auto& params = *this->params_;
+    auto *network = params.converter->network();
     const auto& inputs = params.inputs;
-    auto* converter = params.converter;
-    auto* network = converter->network();
-    const auto& node_def = params.node_def;
 
     const bool is_dims_static = inputs[0].is_weights();
     const bool is_value_static = inputs[1].is_weights();
@@ -93,38 +91,15 @@ class ConvertFill : public OpConverterBase<ConvertFill> {
       dims_adapter.TrtDims(&trt_dims);
     }
 
-    // TensorRT IFillLayer requires a rank 0 scalar.
-    ITensorProxyPtr scalar_tensor;
-    nvinfer1::Dims scalar_dims;
-    scalar_dims.nbDims = 0;
-    nvinfer1::DataType value_type = value_input.TrtDType();
-    if (is_value_static) {
-      scalar_tensor =
-          converter->CreateConstantLayer(value_input.weights(), scalar_dims);
-    } else {
-      TF_RETURN_IF_ERROR(PrepareTensorForShape(
-          converter, value_input, scalar_dims, params.validation_only,
-          &scalar_tensor, node_def));
-    }
-
     auto builder = TRTNetworkBuilder::Create(network, params.weight_store);
-    nvinfer1::Dims beta_shape{1, {nbDims}};
-    StatusOr<nvinfer1::IConstantLayer*> const_layer =
-        builder->Constant(0, beta_shape, value_type);
-    TF_RETURN_IF_ERROR(const_layer.status());
-    ITensorProxyPtr empty_beta_tensor = (*const_layer)->getOutput(0);
-
-    nvinfer1::IFillLayer* layer =
-        network->addFill(trt_dims, nvinfer1::FillOperation::kLINSPACE);
-    TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
-    if (!is_dims_static) {
-      layer->setInput(0, *dims_input.tensor()->trt_tensor());
-    }
-    layer->setInput(1, *scalar_tensor->trt_tensor());
-    layer->setInput(2, *empty_beta_tensor->trt_tensor());
-    converter->SetLayerName(layer, node_def, "fill");
-    ITensorProxyPtr output_tensor = layer->getOutput(0);
-    AddOutput(TRT_TensorOrWeights(output_tensor));
+    StatusOr<nvinfer1::ILayer*> layer = builder->AddFill(value_input,
+                         dims_input,
+                         is_value_static,
+                         is_dims_static,
+                         nbDims,
+                         trt_dims);
+    ITensorProxyPtr output_tensor = (*layer)->getOutput(0);
+    this->AddOutput(TRT_TensorOrWeights(output_tensor));
     return Status::OK();
   }
 };

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h
@@ -479,6 +479,48 @@ class TRTNetworkBuilder {
     return scale_layer;
   }
 
+  StatusOr<nvinfer1::ILayer*> AddFill(const TRT_TensorOrWeights& value_input,
+                 const TRT_TensorOrWeights& dims_input,
+                 bool is_value_static,
+                 bool is_dims_static,
+                 int nbDims,
+                 const nvinfer1::Dims trt_dims) {
+    // TensorRT IFillLayer requires a rank 0 scalar.
+    ITensorProxyPtr scalar_tensor;
+    nvinfer1::Dims scalar_dims;
+    scalar_dims.nbDims = 0;
+    nvinfer1::DataType value_type = value_input.TrtDType();
+    if (is_value_static) {
+      StatusOr<nvinfer1::IConstantLayer*> const_layer
+        = WeightsToConstant(value_input.weights().GetTrtWeights(), scalar_dims);
+      if (!const_layer.status().ok())
+        return const_layer.status();
+      scalar_tensor = (*const_layer)->getOutput(0);
+    } else {
+      StatusOr<nvinfer1::IShuffleLayer*> shuffler_layer
+        = Reshape(value_input.tensor()->trt_tensor(), scalar_dims);
+      if (!shuffler_layer.status().ok())
+        return shuffler_layer.status();
+      scalar_tensor = (*shuffler_layer)->getOutput(0);
+    }
+
+    nvinfer1::Dims beta_shape{1, {nbDims}};
+    StatusOr<nvinfer1::IConstantLayer*> const_layer =
+      Constant(0, beta_shape, value_type);
+    TF_RETURN_IF_ERROR(const_layer.status());
+    ITensorProxyPtr empty_beta_tensor = (*const_layer)->getOutput(0);
+
+    nvinfer1::IFillLayer* layer =
+      network_->addFill(trt_dims, nvinfer1::FillOperation::kLINSPACE);
+    TRT_ENSURE(layer);
+    if (!is_dims_static) {
+      layer->setInput(0, *dims_input.tensor()->trt_tensor());
+    }
+    layer->setInput(1, *scalar_tensor->trt_tensor());
+    layer->setInput(2, *empty_beta_tensor->trt_tensor());
+    return layer;
+  }
+
   // Adds a quantization layer that uniformly scales the input tensor
   // by the given multiplicative "scaling_factor", then rounds
   // (round-to-nearest-ties-to-even) to the nearest integer and clamps in the

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/like_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/like_ops.cc
@@ -1,0 +1,118 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
+
+template <int V>
+class ConvertLikeOps : public OpConverterBase<ConvertLikeOps<V>> {
+ public:
+  explicit ConvertLikeOps(OpConverterParams* params)
+      : OpConverterBase<ConvertLikeOps<V>>(params) {}
+
+  static constexpr std::array<DataType, 3> AllowedDataTypes() {
+    return {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32};
+  }
+
+  static constexpr std::array<InputArgSpec, 1> InputSpec() {
+    return std::array<InputArgSpec, 1>{
+        InputArgSpec::Create("input", TrtInputArg::kBoth),
+    };
+  }
+  Status Validate() {
+    const auto &params = *this->params_;
+
+    const std::string op_name = V == 0 ? "ZerosLike" : "OnesLike";
+    if (params.use_implicit_batch) {
+      return errors::Unimplemented("Conversion for " + op_name +
+                                   " is not implemented in"
+                                   " implicit batch mode");
+    }
+    const auto &inputs = params.inputs;
+    if (inputs.size() != 1) {
+      return errors::InvalidArgument(
+        op_name, " expects 1 input, but received ", inputs.size());
+    }
+    return Status::OK();
+  }
+
+  Status Convert() {
+    const auto &params = *this->params_;
+    const auto& inputs = params.inputs;
+    auto *converter = params.converter;
+    auto *network = converter->network();
+
+    const TRT_TensorOrWeights& input = inputs.at(0);
+
+    nvinfer1::Dims dims{0};
+
+    nvinfer1::DataType value_type = input.TrtDType();
+
+    std::vector<int> value_input_dims_data = {1};
+    DimsAdapter value_input_dims(value_input_dims_data);
+    StatusOr<TRT_ShapedWeights> value_weights =
+      params.weight_store->GetTempWeights(value_type, value_input_dims);
+    TF_RETURN_IF_ERROR(value_weights.status());
+    TF_RETURN_IF_ERROR(value_weights->SetValues(V));
+    TRT_TensorOrWeights value_input(value_weights.ValueOrDie());
+
+    int is_dims_static = true;
+    ITensorProxyPtr dims_input_tensor;
+    if (!HasStaticShape(input.GetTrtDims())) {
+      is_dims_static = false;
+      auto builder = TRTNetworkBuilder::Create(network,
+                                               params.weight_store);
+      StatusOr<nvinfer1::IShapeLayer*> shape_layer =
+        builder->Shape(input.tensor()->trt_tensor());
+      TF_RETURN_IF_ERROR(shape_layer.status());
+      dims_input_tensor = (*shape_layer)->getOutput(0);
+    } else {
+      dims = input.GetTrtDims();
+    }
+
+    TRT_TensorOrWeights dims_input(dims_input_tensor);
+    auto builder = TRTNetworkBuilder::Create(network, params.weight_store);
+    StatusOr<nvinfer1::ILayer*> layer = builder->AddFill(value_input,
+                         dims_input,
+                         true,
+                         is_dims_static,
+                         input.GetTrtDims().nbDims,
+                         dims);
+    ITensorProxyPtr output_tensor = (*layer)->getOutput(0);
+    this->AddOutput(TRT_TensorOrWeights(output_tensor));
+    return Status::OK();
+  }
+};
+
+REGISTER_DEFAULT_TRT_OP_CONVERTER(MakeConverterFunction<ConvertLikeOps<0>>(), "zeros_like");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(MakeConverterFunction<ConvertLikeOps<1>>(), "ones_like");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(MakeConverterFunction<ConvertLikeOps<0>>(), "ZerosLike");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(MakeConverterFunction<ConvertLikeOps<1>>(), "OnesLike");
+
+#endif  // IS_TRT_VERSION_GE(8, 2, 0, 0)
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT


### PR DESCRIPTION
This PR adds a TF-TRT converter for the [tf.zeros_like](https://www.tensorflow.org/api_docs/python/tf/zeros_like) and [tf.ones_like](https://www.tensorflow.org/api_docs/python/tf/ones_like) operators (and the equivalent ops `ZerosLike` and `OnesLike` ).
The converter supports tensor and weights for the input. It supports both explicit batch mode and dynamic shape mode.

The converter uses helper functions introduced in https://github.com/tensorflow/tensorflow/pull/54170#issue-1117203815 , so it can be merged only after the fill converter has been merged.

It refactors the tf.fill converter to reuse the main TRT network building logic in the new converters.
