### PR TITLE
Include c++17 in nvcc allowed std options.

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -183,10 +183,10 @@ def InvokeNvcc(argv, log=False):
   undefines = GetOptionValue(argv, '-U')
   undefines = ''.join([' -U' + define for define in undefines])
   std_options = GetOptionValue(argv, '-std')
-  # Supported -std flags as of CUDA 11.0.
+  # Supported -std flags as of CUDA 11.0. Only keep last to mimic gcc/clang.
   nvcc_allowed_std_options = ["c++03", "c++11", "c++14", "c++17"]
   std_options = ''.join([' -std=' + define
-      for define in std_options if define in nvcc_allowed_std_options])
+      for define in std_options if define in nvcc_allowed_std_options][-1:])
   fatbin_options = ''.join([' --fatbin-options=' + option
       for option in GetOptionValue(argv, '-Xcuda-fatbinary')])
 

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -183,10 +183,10 @@ def InvokeNvcc(argv, log=False):
   undefines = GetOptionValue(argv, '-U')
   undefines = ''.join([' -U' + define for define in undefines])
   std_options = GetOptionValue(argv, '-std')
-  # Supported -std flags as of CUDA 9.0. Only keep last to mimic gcc/clang.
-  nvcc_allowed_std_options = ["c++03", "c++11", "c++14"]
+  # Supported -std flags as of CUDA 11.0.
+  nvcc_allowed_std_options = ["c++03", "c++11", "c++14", "c++17"]
   std_options = ''.join([' -std=' + define
-      for define in std_options if define in nvcc_allowed_std_options][-1:])
+      for define in std_options if define in nvcc_allowed_std_options])
   fatbin_options = ''.join([' --fatbin-options=' + option
       for option in GetOptionValue(argv, '-Xcuda-fatbinary')])
 


### PR DESCRIPTION
Support for c++17 was added in nvcc 11.0.167+:
https://gist.github.com/ax3l/9489132#device-side-c-standard-support

Valid --std values documented here:
https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-altering-compiler-linker-behavior-std