### PR TITLE
Check is redudant, use `state_->code`

### DIFF
--- a/tensorflow/core/platform/status.cc
+++ b/tensorflow/core/platform/status.cc
@@ -192,7 +192,7 @@ std::string Status::ToString() const {
   if (state_ == nullptr) {
     return "OK";
   } else {
-    std::string result(error_name(code()));
+    std::string result(error_name(state_->code));
     result += ": ";
     result += state_->msg;
 


### PR DESCRIPTION
Since `state_` must not be `nullptr` in this branch. We can use `state_->code` directly instead of `code()` which checks `state_` again