### PR TITLE
Implementation of the converter for Tile operation

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -614,6 +614,7 @@ tf_cuda_library(
         "convert/ops/quantization_ops.cc",
         "convert/ops/slice_ops.cc",
         "convert/trt_optimization_pass.cc",
+        "convert/ops/tile.cc",
     ],
     hdrs = [
         "convert/convert_graph.h",

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -78,6 +78,20 @@ limitations under the License.
 // would work!
 #define TFTRT_CHECK_EQ_TYPE(val1, val2) CHECK_EQ((int)val1, (int)val2)
 
+#define TFTRT_INTERNAL_ERROR_AT_NODE(node) \
+  TFTRT_ERROR(errors::Internal, " failed to add TRT layer, at: ", node);
+
+#define TFTRT_RETURN_ERROR_IF_NULLPTR(ptr, node) \
+  if (ptr == nullptr) {                          \
+    TFTRT_INTERNAL_ERROR_AT_NODE(node);          \
+  }
+
+#define TFTRT_CHECK_INPUT_SIZE(size, exp_size, node_def)                 \
+  if ((size) != (exp_size)) {                                            \
+    TFTRT_ERROR(errors::InvalidArgument, node_def.op(), " got ", (size), \
+                " inputs but expected ", (exp_size));                    \
+  }
+
 namespace tensorflow {
 namespace tensorrt {
 namespace convert {
@@ -1701,11 +1715,8 @@ Status CheckInputsWeights(
     const std::vector<std::pair<string, TrtInputArg>>& expected_inputs) {
   const auto& inputs = params.inputs;
   const auto& node_def = params.node_def;
-  if (inputs.size() != expected_inputs.size()) {
-    return errors::InvalidArgument(node_def.op(), " got ", inputs.size(),
-                                   " inputs but expected ",
-                                   expected_inputs.size());
-  }
+  TFTRT_CHECK_INPUT_SIZE(inputs.size(), expected_inputs.size(), node_def);
+
   for (int i = 0; i < inputs.size(); i++) {
     if (expected_inputs[i].second == TrtInputArg::kWeight &&
         inputs.at(i).is_tensor()) {
@@ -3416,11 +3427,7 @@ Status ConvertRelu6(OpConverterParams* params) {
 Status ConvertBiasAdd(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
-
-  if (inputs.size() != 2) {
-    return errors::InvalidArgument(
-        "BiasAdd expects exactly 2 inputs, but received ", inputs.size());
-  }
+  TFTRT_CHECK_INPUT_SIZE(inputs.size(), 2, node_def);
 
   if (inputs[0].is_weights() && inputs[1].is_weights()) {
     return errors::InvalidArgument(
@@ -3649,10 +3656,8 @@ Status ConvertIdentity(OpConverterParams* params) {
 Status ConvertBinary(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
-  if (inputs.size() != 2) {
-    return errors::InvalidArgument(node_def.op(), " got ", inputs.size(),
-                                   " inputs but expected 2");
-  }
+  TFTRT_CHECK_INPUT_SIZE(inputs.size(), 2, node_def);
+
   std::set<DataType> allowed_types{DataType::DT_FLOAT, DataType::DT_HALF,
                                    DataType::DT_INT32};
   TF_RETURN_IF_ERROR(AllowDataTypes(*params, allowed_types));
@@ -4894,10 +4899,8 @@ Status ConvertMatMulHelper(OpConverterParams* params,
 Status ConvertMatMul(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
-  if (inputs.size() != 2) {
-    return errors::InvalidArgument(node_def.op(), " got ", inputs.size(),
-                                   " inputs but expected 2");
-  }
+  TFTRT_CHECK_INPUT_SIZE(inputs.size(), 2, node_def);
+
   TF_RETURN_IF_ERROR(
       AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
 
@@ -4913,10 +4916,8 @@ Status ConvertMatMul(OpConverterParams* params) {
 Status ConvertBatchMatMul(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
-  if (inputs.size() != 2) {
-    return errors::InvalidArgument(node_def.op(), " got ", inputs.size(),
-                                   " inputs but expected 2");
-  }
+  TFTRT_CHECK_INPUT_SIZE(inputs.size(), 2, node_def);
+
   TF_RETURN_IF_ERROR(CheckInputsWeights(
       *params, {{"x", TrtInputArg::kBoth}, {"y", TrtInputArg::kBoth}}));
   // TODO(tfeher): Consider adding INT8 type because FC layer can support it.
@@ -5945,10 +5946,9 @@ Status ConvertAddN(OpConverterParams* params) {
   if (num_inputs < 2) {
     return errors::InvalidArgument("AddN requires at least two inputs");
   }
-  if (inputs.size() != num_inputs) {
-    return errors::InvalidArgument("Got ", inputs.size(),
-                                   " inputs but expected ", num_inputs);
-  }
+
+  TFTRT_CHECK_INPUT_SIZE(inputs.size(), num_inputs, node_def);
+
   for (const auto& input : inputs) {
     if (!input.is_tensor() && input.weights().Shape().dim(0) != 1) {
       return errors::InvalidArgument(

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1379,7 +1379,20 @@ class OpConverterTest : public ::testing::Test {
 
   template <typename T = int32>
   void AddTestWeights(const string& name, const std::vector<int>& dims,
-                      const std::vector<T>& values, DataType tf_type) {
+                      const std::vector<T>& values_inp, DataType tf_type, bool fix_values=true) {
+    const auto num_elements = std::accumulate(
+      std::begin(dims), std::end(dims), 1, std::multiplies<int>());
+
+    std::vector<T>values(values_inp);
+    if (num_elements != values.size()) {
+      if (fix_values) {
+        AdjustVectorByDims<T>(values, num_elements, name, "AddTestWeights");
+      } else {
+        FAIL() << "Unable to create test weights: " << (num_elements > values.size()? "not enough" : "to many")
+               << " values specified: " << values.size() << " vs. " << num_elements << " defined by dims";
+      }
+    }
+
     if (tf_type == DT_FLOAT) {
       AddTestWeights(name, dims, CastVector<T, float>(values));
     } else if (tf_type == DT_HALF) {
@@ -1491,6 +1504,26 @@ class OpConverterTest : public ::testing::Test {
     return converter_->quantization_ranges_;
   }
 
+ protected:
+  template <typename T>
+  void AdjustVectorByDims(std::vector<T>& values, size_t num_elements, const string& name, const char *callingFunc) {
+    const auto old_size = values.size();
+    if (num_elements > old_size) {
+      // Expending vector with 0's.
+      const std::vector<T> zeros(num_elements - old_size, 0);
+      values.reserve(num_elements);
+      values.insert(values.end(), zeros.begin(), zeros.end());
+      VLOG(2) << "In function "<< callingFunc << " the vector '" << name << "' was extended by "
+              << num_elements - old_size << " zeros";
+    } else {
+      // Removing unnecessary elements.
+      values.resize(num_elements);
+      VLOG(2) << "Only first " << num_elements << " out of " << old_size << " elements of the vector '"
+        << name << "' will be used in function" << callingFunc;
+    }
+  }
+
+ public:
   std::unique_ptr<Converter> converter_;
 
  private:
@@ -1544,6 +1577,20 @@ std::ostream& operator<<(std::ostream& os, const TestParamBase& p) {
   }
   os << ", " << p.status;
   return os;
+}
+
+// Printing vector with the numbers of type T which defines tensor or shape.
+template <typename T>
+const std::string get_debug_string_for_vector(const std::vector<T>& vector,
+                                              absl::string_view pComment,
+                                              absl::string_view name,
+                                              absl::string_view type = "") {
+  const std::string t1 = absl::StrCat(pComment, name, " Dims(nbDims=");
+  const std::string t2 = absl::StrJoin(vector, ",");
+  const std::string t3 = type != "" ? absl::StrCat(") of type ", type) : ")";
+  std::stringstream stream;
+  stream << t1 << vector.size() << ", d=" << t2 << t3;
+  return stream.str();
 }
 
 // Parameterized version of OpConverterTest. We have the following parameters:
@@ -1608,17 +1655,26 @@ class ParameterizedOpConverterTestBase
   //
   template <typename T = int>
   void AddTestTensor(const string& name, const std::vector<int32>& dims,
-                     DataType tf_type, const std::vector<T>& values,
+                     DataType tf_type, const std::vector<T>& values_inp,
                      const std::vector<int32>& partial_input_shape_dims = {},
-                     Status add_input_status = Status::OK()) {
+                     Status add_input_status = Status::OK(),
+                     bool fix_values = true) {
+    std::vector<T> values(values_inp);
+    VLOG(2) << "**** AddTestTensor for " << name
+            << " ***** dims empty() = " << dims.empty()
+            << "  tf_type = " << DebugString(tf_type);
     if (!dims.empty()) {
       const auto num_elements = std::accumulate(
           std::begin(dims), std::end(dims), 1, std::multiplies<double>());
       if (!values.empty() && num_elements != values.size()) {
-        // Note: for conversion only tests, it is valid to have empty values,
-        // otherwise the number of elements should match.
-        LOG(WARNING) << "Expected Test Tensor Shape: " << DebugString(dims)
-                     << ", Received Input Tensor: " << DebugString(values);
+        if (fix_values) {
+          AdjustVectorByDims(values, num_elements, name, "AddTestTensor");
+        } else {
+          // Note: for conversion only tests, it is valid to have empty values,
+          // otherwise the number of elements should match.
+          LOG(WARNING) << "Expected Test Tensor Shape: " << DebugString(dims)
+                       << ", Received Input Tensor: " << DebugString(values);
+        }
       }
     }
 
@@ -1633,13 +1689,19 @@ class ParameterizedOpConverterTestBase
         // Use static (known) input shapes.
         partial_shape = dims;
       }
+      if (VLOG_IS_ON(2)) {
+        VLOG(2) << get_debug_string_for_vector(
+            partial_shape, "Using partial_shape: for ", name);
+      }
     }
     nvinfer1::DataType trt_type;
     TF_ASSERT_OK(TfTypeToTrtType(tf_type, &trt_type));
     AddTestTensorWithTFDims(name, partial_shape, trt_type, add_input_status);
     if (!values.empty()) {
-      VLOG(2) << "Adding test tensor: " << name << " "
-              << DataTypeString(tf_type);
+      if (VLOG_IS_ON(2)) {
+        VLOG(2) << get_debug_string_for_vector(
+            values, "Adding test tensor: for ", name, DataTypeString(tf_type));
+      }
       InputOutputData data{name, AsTensor(values, dims, tf_type)};
       VLOG(2) << "Added tensor: " << data.name << " with dtype "
               << DataTypeString(data.tensor.dtype());
@@ -2141,6 +2203,151 @@ TEST_P(OpConverter_FP32_Test, ConvertTranspose) {
     }
     TestOpConverter("my_transpose", node_def, p.expected_output_dims, p.status,
                     p.runtime_status, ElementsAreArray(expected_values));
+  }
+}
+
+TEST_P(OpConverter_FP32_Test, ConvertTile) {
+  Scope s = Scope::NewRootScope();
+  auto input = ops::Placeholder(s.WithOpName("input"), tf_type_);
+  auto weights = ops::Placeholder(s.WithOpName("weights"), DT_INT32);
+  auto tile = ops::Tile(s.WithOpName("my_tile"), input, weights);
+  const NodeDef& node_def = tile.operation.node()->def();
+
+  struct TileParam {
+    std::vector<int> input_dims;
+    std::vector<int> multiplier;
+    std::vector<float> tensor;
+    // Concrete (static) output dimensions, including batch size as first dim.
+    std::vector<int> expected_output_dims;
+    std::vector<int> expected_results;
+    int test_ID;
+    // Expected status of conversion (with concrete error message).
+    Status status;
+    // Expected status of BuildAndRun.
+    Status runtime_status;
+  };
+
+  std::vector<TileParam> test_params = {
+      TileParam{{1, 2, 3},   // input_dims
+                {1, -2, 1},  // multiplier
+                {},          // tensor
+                {},          // expected_output_dims
+                {},          // expected_results
+                1,           // test_ID
+                Status(error::INVALID_ARGUMENT,
+                       "All replications of the Tile operation in "
+                       "my_tile should be positive, got (1, -2, 1).")},
+      TileParam{
+          {1, 2, 3},           // input_dims
+          {1, 2, 1, 3},        // multiplier
+          {0, 1, 2, 3, 4, 5},  // tensor
+          {},                  // expected_output_dims
+          {},                  // expected_results
+          2,                   // test_ID
+          Status(
+              error::INVALID_ARGUMENT,
+              "The length of the replication vector (4) of the Tile operation "
+              "in 'my_tile' "
+              "is expected to be equal to the rank of the input vector (3).")},
+      TileParam{{1, 2},                                 // input_dims
+                {1, 3},                                 // multiplier
+                {2, 3},                                 // tensor
+                {1, 6},                                 // expected_output_dims
+                {2, 3, 2, 3, 2, 3}},                    // out values
+      TileParam{{1, 2, 3},                              // input_dims
+                {1, 2, 1},                              // multiplier
+                {0, 1, 2, 3, 4, 5},                     // tensor
+                {1, 4, 3},                              // output dims
+                {0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5}},  // expected_results
+      TileParam{{1, 2, 3},                              // input_dims
+                {1, 1, 2},                              // multiplier
+                {0, 1, 2, 3, 4, 5},                     // tensor
+                {1, 2, 6},                              // expected_output_dims
+                {0, 1, 2, 0, 1, 2, 3, 4, 5, 3, 4, 5}},  // expected_results
+      TileParam{{1, 2, 3},                              // input_dims
+                {1, 2, 2},                              // multiplier
+                {0, 1, 2, 3, 4, 5},                     // tensor
+                {1, 4, 6},                              // expected_output_dims
+                {0, 1, 2, 0, 1, 2, 3, 4, 5, 3, 4, 5,
+                 0, 1, 2, 0, 1, 2, 3, 4, 5, 3, 4, 5}}  // expected_results
+  };
+
+  for (bool multiplier_is_tensor : {true, false}) {
+    for (bool input_is_tensor : {true, false}) {
+      for (auto p : test_params) {
+        std::vector<int> num_mults = {p.multiplier.size()};
+        std::vector<std::vector<int>> partial_input_dims_options = {{}};
+        if (multiplier_is_tensor) {
+          if (trt_mode_ == TrtTestMode::kImplicitBatch) {
+            p.status =
+                Status(error::INVALID_ARGUMENT,
+                       "Conversion for Tile is not implemented for multipliers "
+                       "passed as a tensor in implicit batch mode");
+            num_mults = {1, p.multiplier.size()};
+          } else {
+            if (p.test_ID == 1) {
+              // Replacement of statuses, since when multiplier is a tensor AND
+              // trt_mode_ != TrtTestMode::kImplicitBatch we cannot define these
+              // statuses in ConvertTile::Validate() for first two tests from
+              // test_params.
+              p.status = Status::OK();
+              p.runtime_status =
+                  Status(error::INTERNAL,
+                         "Incorrect number of profile config parameters");
+            }
+
+            if (trt_mode_ == TrtTestMode::kDynamicShape) {
+              if (p.test_ID == 1)
+                partial_input_dims_options = {num_mults};
+              else
+                partial_input_dims_options = {{}, num_mults};
+            }
+          }
+        }
+
+        for (auto partial_input_dims : partial_input_dims_options) {
+          if (multiplier_is_tensor &&
+              trt_mode_ != TrtTestMode::kImplicitBatch) {
+            if (trt_mode_ == TrtTestMode::kDynamicShape) {
+              if (p.test_ID != 1) {
+                p.runtime_status =
+                    partial_input_dims.empty()
+                        ? Status(error::INTERNAL,
+                                 "Failed to build TensorRT engine")
+                        : Status::OK();
+                p.status = Status::OK();
+              }
+            }
+
+            if (p.test_ID == 2 && (trt_mode_ == TrtTestMode::kExplicitBatch ||
+                                   !partial_input_dims.empty())) {
+              p.status = Status(error::INVALID_ARGUMENT,
+                                "When replications are defined as a tensor, "
+                                "the number of its elements (4) must be equal "
+                                "to the rank of the input tensor (3).");
+            }
+          }
+
+          Reset();
+          if (input_is_tensor) {
+            AddTestTensor("input", p.input_dims, p.tensor);
+          } else {
+            AddTestWeights("input", p.input_dims, p.tensor, tf_type_);
+          }
+
+          if (multiplier_is_tensor) {
+            AddTestTensor<int>("weights", num_mults, DT_INT32, p.multiplier,
+                               partial_input_dims);
+          } else {
+            AddTestWeights<int32>("weights", num_mults, p.multiplier);
+          }
+
+          TestOpConverter("my_tile", node_def, p.expected_output_dims, p.status,
+                          p.runtime_status,
+                          ElementsAreArray(p.expected_results));
+        }
+      }
+    }
   }
 }
 

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/tile.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/tile.cc
@@ -1,0 +1,208 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+class ConvertTile : public OpConverterBase<ConvertTile> {
+ public:
+  explicit ConvertTile(OpConverterParams *params)
+      : OpConverterBase<ConvertTile>(params) {}
+
+  static constexpr std::array<DataType, 3> AllowedDataTypes() {
+    return {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32};
+  }
+
+  static constexpr std::array<InputArgSpec, 2> InputSpec() {
+    return std::array<InputArgSpec, 2>{
+        InputArgSpec::Create("input_tensor", TrtInputArg::kBoth),
+        InputArgSpec::Create("weight", TrtInputArg::kBoth)};
+  }
+
+  Status Validate() {
+    const auto &params = *this->params_;
+    const auto &inputs = params.inputs;
+
+    const auto &repl = inputs.at(1);
+    if (params.use_implicit_batch && repl.is_tensor()) {
+      return errors::InvalidArgument(
+          "Conversion for Tile is not implemented for multipliers "
+          "passed as a tensor in implicit batch mode.");
+    }
+
+    nvinfer1::DataType dtype;
+    const int *multiplies;
+    if (repl.is_weights()) {
+      TFTRT_CHECK_SHAPE_TENSOR(repl.weights().GetTensor());
+      dtype = repl.weights().TrtDType();
+      multiplies = repl.weights().GetPointer<int>();
+    } else {
+      dtype = repl.tensor()->getType();
+      multiplies = nullptr;
+    }
+
+    if (dtype != nvinfer1::DataType::kINT32) {
+      return errors::InvalidArgument(
+          "The replication parameter of the ", params.node_def.op(),
+          " operation in ", params.node_def.name(), " is expected to be of ",
+          DebugString(nvinfer1::DataType::kINT32), " type, got ",
+          DebugString(dtype), ".");
+    }
+
+    const auto dims = inputs.at(0).GetTrtDims();
+    const auto nb_dims =
+        dims.nbDims +
+        (params.use_implicit_batch && inputs.at(0).is_tensor() ? 1 : 0);
+    if (multiplies) {
+      const int mult_numb = repl.weights().count();
+      if (mult_numb != nb_dims) {
+        return errors::InvalidArgument(
+            "The length of the replication vector (", mult_numb,
+            ") of the Tile operation in '", params.node_def.name(),
+            "' is expected to be equal to the rank of the input vector (",
+            nb_dims, ").");
+      }
+
+      if (std::any_of(multiplies, multiplies + nb_dims,
+                      [](int i) { return i <= 0; })) {
+        char buffer[256], *pBuff = buffer;
+        for (int i = 0; i < nb_dims; i++)
+          pBuff += sprintf(pBuff, (i ? ", %d" : "%d"), multiplies[i]);
+
+        return errors::InvalidArgument(
+            "All replications of the Tile operation in ",
+            params.node_def.name(), " should be positive, got (", buffer, ").");
+      }
+    } else {
+      const auto &repl_dims = repl.GetTrtDims();
+      if (repl_dims.nbDims != 1) {
+        return errors::InvalidArgument(
+            "When replications are defined as a tensor, that tensor must be "
+            "1-dimensional. Got ", repl_dims.nbDims, "-dimensional tensor.");
+      }
+
+      // Check the number of elements in multiplyer for tensors with non-dynamic
+      // shape
+      if (repl_dims.d[0] >= 0 && repl_dims.d[0] != nb_dims) {
+        return errors::InvalidArgument(
+            "When replications are defined as a tensor, "
+            "the number of its elements (", repl_dims.d[0],
+            ") must be equal to the rank of the input tensor (", nb_dims, ").");
+      }
+    }
+
+    return Status::OK();
+  }
+
+  Status Convert() {
+    const auto &params = *this->params_;
+    const auto &inputs = params.inputs;
+    auto *converter = params.converter;
+    auto *network = converter->network();
+    const auto &tensor = inputs.at(0);
+    const auto &replics = inputs.at(1);
+    const auto dims = tensor.GetTrtDims();
+    const auto nb_dims = dims.nbDims;
+
+    nvinfer1::Dims size{nb_dims, {1}};
+    bool dynamic_flag = replics.is_tensor();
+    if (!dynamic_flag) {
+      const auto dim_adj =
+          params.use_implicit_batch && tensor.is_tensor() ? 1 : 0;
+      const auto *pSize = dims.d;
+      dynamic_flag = std::any_of(pSize + 1 - dim_adj, pSize + nb_dims,
+                                 [](int i) { return i < 0; });
+      const int *pMultiplies = replics.weights().GetPointer<int>() + dim_adj;
+      for (int i = 1 - dim_adj; i < nb_dims; i++)
+        size.d[i] = pMultiplies[i] * pSize[i];
+    }
+
+    StatusOr<TRTNetworkBuilder> builder;
+    if (tensor.is_weights() || dynamic_flag && replics.is_weights()) {
+      builder =
+          TRTNetworkBuilder::Create(converter->network(), params.weight_store);
+      TRT_ENSURE_OK(builder);
+    }
+
+    ITensorProxyPtr input_tensor;
+    if (tensor.is_weights()) {
+      StatusOr<nvinfer1::IConstantLayer *> weights_const =
+          builder->WeightsToConstant(tensor.weights().GetTrtWeights(), dims);
+      TRT_ENSURE_PTR_OK(weights_const);
+      input_tensor = (*weights_const)->getOutput(0);
+    } else {
+      input_tensor = tensor.tensor();
+    }
+
+    auto &input_trt_tensor = *input_tensor->trt_tensor();
+    nvinfer1::ITensor *target_shape = nullptr;
+    if (dynamic_flag) {
+      nvinfer1::ITensor *mult;
+      if (replics.is_weights()) {
+        StatusOr<nvinfer1::IConstantLayer *> weights_const =
+            builder->WeightsToConstant(replics.weights().GetTrtWeights(),
+                                       replics.GetTrtDims());
+        TRT_ENSURE_PTR_OK(weights_const);
+        mult = (*weights_const)->getOutput(0);
+      } else {
+        const ITensorProxyPtr multiplies = replics.tensor()->trt_tensor();
+        mult = multiplies->trt_tensor();
+      }
+
+      nvinfer1::ITensor *shape =
+          network->addShape(input_trt_tensor)->getOutput(0);
+      target_shape = network
+                         ->addElementWise(*shape, *mult,
+                                          nvinfer1::ElementWiseOperation::kPROD)
+                         ->getOutput(0);
+    }
+
+    nvinfer1::Dims start{nb_dims, {}};
+    DimsAdapter stride(std::vector<int>(nb_dims, 1));
+    auto layer =
+        network->addSlice(input_trt_tensor, start, size, stride.AsTrtDims());
+    layer->setMode(nvinfer1::SliceMode::kWRAP);
+    if (target_shape) layer->setInput(2, *target_shape);
+
+    converter->SetLayerName(layer, params.node_def.name(), "to_tile");
+    ITensorProxyPtr output_tensor = layer->getOutput(0);
+    if (tensor.is_weights() && params.use_implicit_batch) {
+      // Reshape output tensor by removing first dimension.
+      DimsAdapter adap(output_tensor->getDimensions());
+      TF_RETURN_IF_ERROR(adap.RemoveBatchDimension());
+
+      TF_RETURN_IF_ERROR(PrepareTensorForShape(
+          params.converter, TRT_TensorOrWeights(output_tensor),
+          adap.AsTrtDims(), false, &output_tensor, params.node_def));
+    }
+
+    AddOutput(TRT_TensorOrWeights(output_tensor));
+    return Status::OK();
+  }
+};
+
+REGISTER_DEFAULT_TRT_OP_CONVERTER(MakeConverterFunction<ConvertTile>(), "Tile");
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -36,6 +36,19 @@ limitations under the License.
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 #include "third_party/tensorrt/NvInfer.h"
 
+#define TFTRT_ERROR(func, ...)                   \
+    do {                                         \
+      return func("TFTRT::", __FUNCTION__, ":",  \
+                    __LINE__, ": ", __VA_ARGS__);\
+    } while (0)
+
+#define TFTRT_CHECK_SHAPE_TENSOR(tensor)                                  \
+   if (!IsTrtShapeTensorCompatible(tensor)) {                             \
+     TFTRT_ERROR(errors::InvalidArgument, "Tensor of type ",              \
+                 DebugString(tensor.dtype()), " having shape ",           \
+                 tensor.shape().DebugString(), " is not TRT compatible"); \
+   }
+
 namespace tensorflow {
 namespace tensorrt {
 


### PR DESCRIPTION
- ConvertTile operator is implemented so that both parameters (tensor and multiplier) can be passed as tensors and weights. A unit test with 6 tests and all combinations of passed parameters is provided.
- New macro `#define CHECK_INPUT_SIZE (size, exp_size, node_def)` unifies the testing of the number of parameters passed. It is used in 8 different places.
- The helper function template void `AdjustVectorByDims(...)` makes writing tests much easier (especially tests with parameters that can be passed as tensors and weights). For example, today we can use some parameters like tensors with predefined dimensions, but with no real numbers. An attempt to pass the same parameters with the same values as weights leads to the crash. We see a similar crash when the vector providing the values assigned to the tensor is not empty, but its length does not match the number of values defined by the dimensions. `AdjustVectorByDims` fixes these two problems and is called by default in the situations described, but these calls can also be blocked when such failures are intentional.

