### PR TITLE
Update sonartype Maven repo URL to HTTPS

### DIFF
--- a/tensorflow/lite/java/demo/app/build.gradle
+++ b/tensorflow/lite/java/demo/app/build.gradle
@@ -34,7 +34,7 @@ repositories {
     mavenCentral()
     maven {  // Only for snapshot artifacts
         name 'ossrh-snapshot'
-        url 'http://oss.sonatype.org/content/repositories/snapshots'
+        url 'https://oss.sonatype.org/content/repositories/snapshots'
     }
 }
 

--- a/tensorflow/lite/java/demo/build.gradle
+++ b/tensorflow/lite/java/demo/build.gradle
@@ -19,7 +19,7 @@ allprojects {
         mavenCentral()
         maven {  // Only for snapshot artifacts
             name 'ossrh-snapshot'
-            url 'http://oss.sonatype.org/content/repositories/snapshots'
+            url 'https://oss.sonatype.org/content/repositories/snapshots'
         }
     }
 }

--- a/tensorflow/lite/java/ovic/demo/app/build.gradle
+++ b/tensorflow/lite/java/ovic/demo/app/build.gradle
@@ -33,7 +33,7 @@ repositories {
     mavenCentral()
     maven {  // Only for snapshot artifacts
         name 'ossrh-snapshot'
-        url 'http://oss.sonatype.org/content/repositories/snapshots'
+        url 'https://oss.sonatype.org/content/repositories/snapshots'
     }
 }
 

--- a/tensorflow/lite/java/ovic/demo/build.gradle
+++ b/tensorflow/lite/java/ovic/demo/build.gradle
@@ -19,7 +19,7 @@ allprojects {
         mavenCentral()
         maven {  // Only for snapshot artifacts
             name 'ossrh-snapshot'
-            url 'http://oss.sonatype.org/content/repositories/snapshots'
+            url 'https://oss.sonatype.org/content/repositories/snapshots'
         }
     }
 }


### PR DESCRIPTION
Update sonartype Maven repo URL to HTTPS.
Additional files to the fix https://github.com/tensorflow/examples/commit/d315ddb