### PR TITLE
Add appropriate error check for nbins in `tf.histogram_fixed_width_bins`

### DIFF
--- a/tensorflow/python/ops/histogram_ops.py
+++ b/tensorflow/python/ops/histogram_ops.py
@@ -20,6 +20,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import clip_ops
+from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gen_math_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.util import dispatch
@@ -77,6 +78,9 @@ def histogram_fixed_width_bins(values,
     values = array_ops.reshape(values, [-1])
     value_range = ops.convert_to_tensor(value_range, name='value_range')
     nbins = ops.convert_to_tensor(nbins, dtype=dtypes.int32, name='nbins')
+    check = control_flow_ops.Assert(
+        math_ops.greater(nbins, 0), ["nbins %s must > 0" % nbins])
+    nbins = control_flow_ops.with_dependencies([check], nbins)
     nbins_float = math_ops.cast(nbins, values.dtype)
 
     # Map tensor values that fall within value_range to [0, 1].

--- a/tensorflow/python/ops/histogram_ops_test.py
+++ b/tensorflow/python/ops/histogram_ops_test.py
@@ -17,6 +17,7 @@
 import numpy as np
 
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
 from tensorflow.python.framework import constant_op
 from tensorflow.python.ops import array_ops
@@ -74,6 +75,17 @@ class BinValuesFixedWidth(test.TestCase):
           values, value_range, nbins=5)
       self.assertEqual(dtypes.int32, bins.dtype)
       self.assertAllClose(expected_bins, self.evaluate(bins))
+
+  def test_negative_nbins(self):
+    value_range = [0.0, 5.0]
+    values = []
+    with self.assertRaisesRegex(
+        (errors.InvalidArgumentError, ValueError), "must > 0"):
+      with self.session():
+        bins = histogram_ops.histogram_fixed_width_bins(
+            values, value_range, nbins=-1)
+        self.evaluate(bins)
+
 
 
 class HistogramFixedWidthTest(test.TestCase):


### PR DESCRIPTION
This PR tries to address the issue raised in #54415 where
nbins was not checked for tf.histogram_fixed_width_bins
and an incorrect result was returned when nbins < 0.

This PR fixes #54415.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>