### PR TITLE
Add appropriate value check for `tf.clip_by_norm`

### DIFF
--- a/tensorflow/python/kernel_tests/math_ops/clip_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/clip_ops_test.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import indexed_slices as indexed_slices_lib
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
@@ -530,6 +531,15 @@ class ClipTest(test.TestCase):
     w = clip_ops.clip_by_value(zero, 1.0, zero)
     with self.session() as sess:
       sess.run([x, y, z, w], feed_dict={zero: np.zeros((7, 0))})
+
+  def testClipByNormNegative(self):
+    with self.assertRaisesRegex(
+        (errors.InvalidArgumentError, ValueError), "must > 0"):
+      with self.session():
+        x = constant_op.constant([-3.0, 0.0, 0.0, 4.0, 0.0, 0.0], shape=[2, 3])
+        clip_norm = -4.0
+        ans = clip_ops.clip_by_norm(x, clip_norm)
+        self.evaluate(ans)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -19,6 +19,7 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import indexed_slices
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import gen_nn_ops
 from tensorflow.python.ops import math_ops
@@ -213,6 +214,10 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
     values = ops.convert_to_tensor(
         t.values if isinstance(t, indexed_slices.IndexedSlices) else t,
         name="t")
+
+    check = control_flow_ops.Assert(
+        math_ops.greater(clip_norm, 0), ["clip_norm %s must > 0" % clip_norm])
+    clip_norm = control_flow_ops.with_dependencies([check], clip_norm)
 
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
     l2sum = math_ops.reduce_sum(values * values, axes, keepdims=True)


### PR DESCRIPTION
This PR tries to address the issue raised in #54414 where
there is no check for clip_norm for tf.clip_by_norm.
As a result an invalid result was silently returned.

This PR fixes #54414.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
