### PR TITLE
Add appropriate dtype check for `tf.boolean_mask`'s mask

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -318,6 +318,13 @@ class BooleanMaskTest(test_util.TensorFlowTestCase):
     self.assertAllEqual(
         self.evaluate(f(constant_op.constant(0, dtype=dtypes.int32))), [1, 3])
 
+  def testMaskWithNonBoolTensor(self):
+    mask = [1, 2, 3]
+    tensor = [1, 2, 3]
+    with self.session():
+      with self.assertRaisesRegex(TypeError, "expected bool but got"):
+        self.evaluate(array_ops.boolean_mask(tensor, mask))
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class OperatorShapeTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1881,6 +1881,8 @@ def boolean_mask(tensor, mask, name="boolean_mask", axis=None):
   with ops.name_scope(name, values=[tensor, mask]):
     tensor = ops.convert_to_tensor(tensor, name="tensor")
     mask = ops.convert_to_tensor(mask, name="mask")
+    if mask.dtype != dtypes.bool:
+      raise TypeError("Invalid `mask`: expected bool but got %s." % mask.dtype)
 
     shape_mask = mask.get_shape()
     ndims_mask = shape_mask.ndims

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1882,7 +1882,8 @@ def boolean_mask(tensor, mask, name="boolean_mask", axis=None):
     tensor = ops.convert_to_tensor(tensor, name="tensor")
     mask = ops.convert_to_tensor(mask, name="mask")
     if mask.dtype != dtypes.bool:
-      raise TypeError("Invalid `mask`: expected bool but got %s." % mask.dtype)
+      raise TypeError(
+          "Invalid `mask`: expected bool but got %s." % mask.dtype)
 
     shape_mask = mask.get_shape()
     ndims_mask = shape_mask.ndims


### PR DESCRIPTION
This PR tries to address the issue raised in #54412 where
mask's dtype was checked in tf.boolean_mask and an invalid
result has been returned instead.

This PR fixes #54412.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>