### PR TITLE
Add appropriate PyObject type check for bool

### DIFF
--- a/tensorflow/python/eager/pywrap_tfe_src.cc
+++ b/tensorflow/python/eager/pywrap_tfe_src.cc
@@ -347,8 +347,16 @@ bool ParseStringValue(const string& key, PyObject* py_value, TF_Status* status,
 
 bool ParseBoolValue(const string& key, PyObject* py_value, TF_Status* status,
                     unsigned char* value) {
-  *value = PyObject_IsTrue(py_value);
-  return true;
+  if (PyBool_Check(py_value)) {
+    *value = PyObject_IsTrue(py_value);
+    return true;
+  }
+  TF_SetStatus(
+      status, TF_INVALID_ARGUMENT,
+      tensorflow::strings::StrCat("Expecting bool value for attr ", key,
+                                  ", got ", py_value->ob_type->tp_name)
+          .c_str());
+  return false;
 }
 
 // The passed in py_value is expected to be an object of the python type


### PR DESCRIPTION
This PR fixes an issue where PyObject type in tf's C bindings
does not check if an input is a boolean and will always cast
to bool. As an result, an invalid type like int can be passed
to an arg expecting bool:
```
import tensorflow as tf
x = [0.5, 1.0, 2.0, 4.0]
axis = 0
exclusive = -1
reverse = -1
res_1 = tf.math.cumsum(x, axis=axis, exclusive=exclusive, reverse=reverse)
print(res_1) # tf.Tensor([7. 6. 4. 0.], shape=(4,), dtype=float32)
```

Note other PyObejct types (e.g., in ParseIntValue) does perform check in
tensorflow/python/eager/pywrap_tfe_src.cc

This PR adds appropriate check in the input type when PyObject path
is invoked.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>