### PR TITLE
Fixed using invalid iterator (CID:20570650)

### DIFF
--- a/tensorflow/lite/tools/delegates/delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/delegate_provider.cc
@@ -41,7 +41,7 @@ void ProvidedDelegateList::RemoveCmdlineFlag(std::vector<Flag>& flags,
   decltype(flags.begin()) it;
   for (it = flags.begin(); it < flags.end();) {
     if (it->GetFlagName() == name) {
-      flags.erase(it);
+      it = flags.erase(it);
     } else {
       ++it;
     }


### PR DESCRIPTION
`std::vector::erase()` invalidates iterators and references at or after the point of the erase. Return value of `std::vector::erase()` shall be used to initialize the iterator (Return value: Iterator following the last removed element. )