### PR TITLE
[TF:TRT] Update test helpers to handle bool tensors and weights

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -45,6 +45,8 @@ string DebugString(const DataType tf_type) {
       return "DT_INT32";
     case DT_INT8:
       return "DT_INT8";
+    case DT_BOOL:
+      return "DT_BOOL";
     default:
       return "Unknow TF DataType";
   }
@@ -60,6 +62,8 @@ string DebugString(const nvinfer1::DataType trt_dtype) {
       return "kINT8";
     case nvinfer1::DataType::kINT32:
       return "kINT32";
+    case nvinfer1::DataType::kBOOL:
+      return "kBOOL";
     default:
       return "Invalid TRT data type";
   }
@@ -157,6 +161,13 @@ Status TfTypeToTrtType(DataType tf_type, nvinfer1::DataType* trt_type) {
     case DT_INT32:
       *trt_type = nvinfer1::DataType::kINT32;
       break;
+    case DT_INT8:
+      *trt_type = nvinfer1::DataType::kINT8;
+      break;
+      // TODO add #ifdef bool is available
+    case DT_BOOL:
+      *trt_type = nvinfer1::DataType::kBOOL;
+      break;
     default:
       return errors::InvalidArgument("Unsupported tensorflow data type ",
                                      DataTypeString(tf_type));
@@ -174,6 +185,12 @@ Status TrtTypeToTfType(nvinfer1::DataType trt_type, DataType* tf_type) {
       break;
     case nvinfer1::DataType::kINT32:
       *tf_type = DT_INT32;
+      break;
+    case nvinfer1::DataType::kINT8:
+      *tf_type = DT_INT8;
+      break;
+    case nvinfer1::DataType::kBOOL:
+      *tf_type = DT_BOOL;
       break;
     default:
       return errors::InvalidArgument("Invalid TRT data type");

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
@@ -77,6 +77,34 @@ Status GetTrtBindingShape(const nvinfer1::ICudaEngine* cuda_engine,
   return Status::OK();
 }
 
+// Setup bindings.
+Status SetupBindings(nvinfer1::ICudaEngine* cuda_engine, const Tensor& tensor,
+                     std::vector<void*>& buffers, int binding_index) {
+  const auto dtype = cuda_engine->getBindingDataType(binding_index);
+  VLOG(2) << "<<<<<<<<< SetupBindings with dtype = " << (int)dtype;
+  switch (dtype) {
+    case nvinfer1::DataType::kFLOAT:
+      buffers[binding_index] = const_cast<float*>(tensor.flat<float>().data());
+      break;
+    case nvinfer1::DataType::kHALF:
+      buffers[binding_index] =
+          const_cast<Eigen::half*>(tensor.flat<Eigen::half>().data());
+      break;
+    case nvinfer1::DataType::kINT8:
+      return errors::Internal("INT8 inputs are not supported yet!");
+    case nvinfer1::DataType::kINT32:
+      buffers[binding_index] = const_cast<int32*>(tensor.flat<int32>().data());
+      break;
+    case nvinfer1::DataType::kBOOL:
+      buffers[binding_index] = const_cast<bool*>(tensor.flat<bool>().data());
+      break;
+    default:
+      return errors::Internal("Unknown TRT data type: ",
+                              static_cast<int>(dtype));
+  }
+  return Status::OK();
+}
+
 Status SetTrtEngineInputs(nvinfer1::ICudaEngine* cuda_engine,
                           nvinfer1::IExecutionContext* execution_context,
                           const int trt_profile_idx,
@@ -134,27 +162,10 @@ Status SetTrtEngineInputs(nvinfer1::ICudaEngine* cuda_engine,
         }
       }
     }
+
     // Setup input bindings.
-    auto dtype = cuda_engine->getBindingDataType(binding_index);
-    switch (dtype) {
-      case nvinfer1::DataType::kFLOAT:
-        buffers[binding_index] =
-            const_cast<float*>(input_tensor.flat<float>().data());
-        break;
-      case nvinfer1::DataType::kHALF:
-        buffers[binding_index] =
-            const_cast<Eigen::half*>(input_tensor.flat<Eigen::half>().data());
-        break;
-      case nvinfer1::DataType::kINT8:
-        return errors::Internal("INT8 inputs are not supported yet!");
-      case nvinfer1::DataType::kINT32:
-        buffers[binding_index] =
-            const_cast<int32*>(input_tensor.flat<int32>().data());
-        break;
-      default:
-        return errors::Internal("Unknown TRT data type: ",
-                                static_cast<int>(dtype));
-    }
+    TF_RETURN_IF_ERROR(
+        SetupBindings(cuda_engine, input_tensor, buffers, binding_index));
   }
 
   // Ensure all network dynamic dimensions (if any) are set in execution
@@ -210,26 +221,8 @@ Status SetTrtEngineOutputs(nvinfer1::ICudaEngine* cuda_engine,
     }
 
     // Setup output bindings.
-    auto dtype = cuda_engine->getBindingDataType(binding_index);
-    switch (dtype) {
-      case nvinfer1::DataType::kFLOAT:
-        buffers[binding_index] =
-            const_cast<float*>(output_tensor->flat<float>().data());
-        break;
-      case nvinfer1::DataType::kHALF:
-        buffers[binding_index] =
-            const_cast<Eigen::half*>(output_tensor->flat<Eigen::half>().data());
-        break;
-      case nvinfer1::DataType::kINT8:
-        return errors::Internal("int8 is not supported yet!");
-      case nvinfer1::DataType::kINT32:
-        buffers[binding_index] =
-            const_cast<int32*>(output_tensor->flat<int32>().data());
-        break;
-      default:
-        return errors::Internal("Unknown TRT data type: ",
-                                static_cast<int>(dtype));
-    }
+    TF_RETURN_IF_ERROR(
+        SetupBindings(cuda_engine, *output_tensor, buffers, binding_index));
   }
   return Status::OK();
 }


### PR DESCRIPTION
Enable the handling of bool tensors for in TF-TRT test helper subroutines.