### PR TITLE
[oneDNN] Enable BF16 for DepthwiseConv2D* ops

### DIFF
--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -30,6 +30,7 @@ typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
 
 // To be used inside depthwise_conv_grad_op.cc.
+template struct LaunchConv2DBackpropInputOp<CPUDevice, bfloat16>;
 template struct LaunchConv2DBackpropInputOp<CPUDevice, Eigen::half>;
 template struct LaunchConv2DBackpropInputOp<CPUDevice, float>;
 template struct LaunchConv2DBackpropInputOp<CPUDevice, double>;
@@ -506,6 +507,7 @@ REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropInput")
 
 // To be used inside depthwise_conv_grad_op.cc.
 // TODO(reedwm): Move this and the definition to depthwise_conv_grad_op.cc.
+template struct LaunchConv2DBackpropInputOp<GPUDevice, bfloat16>;
 template struct LaunchConv2DBackpropInputOp<GPUDevice, float>;
 template struct LaunchConv2DBackpropInputOp<GPUDevice, Eigen::half>;
 template struct LaunchConv2DBackpropInputOp<GPUDevice, double>;

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -507,7 +507,6 @@ REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropInput")
 
 // To be used inside depthwise_conv_grad_op.cc.
 // TODO(reedwm): Move this and the definition to depthwise_conv_grad_op.cc.
-template struct LaunchConv2DBackpropInputOp<GPUDevice, bfloat16>;
 template struct LaunchConv2DBackpropInputOp<GPUDevice, float>;
 template struct LaunchConv2DBackpropInputOp<GPUDevice, Eigen::half>;
 template struct LaunchConv2DBackpropInputOp<GPUDevice, double>;

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -1205,7 +1205,6 @@ REGISTER_KERNEL_BUILDER(
     Conv2DOp<GPUDevice, int32>);
 
 // To be used inside depthwise_conv_op.cc.
-template struct LaunchConv2DOp<GPUDevice, bfloat16>;
 template struct LaunchConv2DOp<GPUDevice, float>;
 template struct LaunchConv2DOp<GPUDevice, Eigen::half>;
 template struct LaunchConv2DOp<GPUDevice, double>;

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -1205,6 +1205,7 @@ REGISTER_KERNEL_BUILDER(
     Conv2DOp<GPUDevice, int32>);
 
 // To be used inside depthwise_conv_op.cc.
+template struct LaunchConv2DOp<GPUDevice, bfloat16>;
 template struct LaunchConv2DOp<GPUDevice, float>;
 template struct LaunchConv2DOp<GPUDevice, Eigen::half>;
 template struct LaunchConv2DOp<GPUDevice, double>;

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -249,6 +249,7 @@ struct LaunchDepthwiseConvOp<CPUDevice, T> {
 };
 
 // Extern template instantiated in conv_ops.cc.
+extern template struct LaunchConv2DOp<CPUDevice, bfloat16>;
 extern template struct LaunchConv2DOp<CPUDevice, Eigen::half>;
 extern template struct LaunchConv2DOp<CPUDevice, float>;
 extern template struct LaunchConv2DOp<CPUDevice, double>;
@@ -507,6 +508,7 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
       Name("DepthwiseConv2dNative").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
       DepthwiseConv2dNativeOp<CPUDevice, T>)
 
+TF_CALL_bfloat16(REGISTER_CPU_KERNEL);
 TF_CALL_half(REGISTER_CPU_KERNEL);
 TF_CALL_float(REGISTER_CPU_KERNEL);
 #if !defined(PLATFORM_WINDOWS) || !defined(_DEBUG)
@@ -542,6 +544,7 @@ class DepthwiseConv2dGroupedConvOp
                               .Label("cudnn_grouped_convolution"), \
                           DepthwiseConv2dGroupedConvOp<T>)
 
+TF_CALL_bfloat16(REGISTER_GROUPED_CONV_KERNEL);
 TF_CALL_half(REGISTER_GROUPED_CONV_KERNEL);
 TF_CALL_float(REGISTER_GROUPED_CONV_KERNEL);
 TF_CALL_double(REGISTER_GROUPED_CONV_KERNEL);

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -544,7 +544,6 @@ class DepthwiseConv2dGroupedConvOp
                               .Label("cudnn_grouped_convolution"), \
                           DepthwiseConv2dGroupedConvOp<T>)
 
-TF_CALL_bfloat16(REGISTER_GROUPED_CONV_KERNEL);
 TF_CALL_half(REGISTER_GROUPED_CONV_KERNEL);
 TF_CALL_float(REGISTER_GROUPED_CONV_KERNEL);
 TF_CALL_double(REGISTER_GROUPED_CONV_KERNEL);

--- a/tensorflow/core/kernels/depthwise_conv_ops_test.cc
+++ b/tensorflow/core/kernels/depthwise_conv_ops_test.cc
@@ -90,10 +90,11 @@ class DepthwiseConvOpTest : public OpsTestBase {
     const Tensor& output = *GetOutput(0);
     // TODO(csigg): This should happen as part of GetOutput.
     TF_EXPECT_OK(device_->Sync());
-    if (dtype == DT_BFLOAT16)
+    if (dtype == DT_BFLOAT16) {
       test::ExpectClose(expected, output, 1e-2, 1e-2);
-    else
+    } else {
       test::ExpectTensorNear<T>(expected, output, 1e-5);
+    }
   }
 };
 

--- a/tensorflow/core/kernels/depthwise_conv_ops_test.cc
+++ b/tensorflow/core/kernels/depthwise_conv_ops_test.cc
@@ -90,10 +90,14 @@ class DepthwiseConvOpTest : public OpsTestBase {
     const Tensor& output = *GetOutput(0);
     // TODO(csigg): This should happen as part of GetOutput.
     TF_EXPECT_OK(device_->Sync());
-    test::ExpectTensorNear<T>(expected, output, 1e-5);
+    if (dtype == DT_BFLOAT16)
+      test::ExpectClose(expected, output, 1e-2, 1e-2);
+    else
+      test::ExpectTensorNear<T>(expected, output, 1e-5);
   }
 };
 
+TEST_F(DepthwiseConvOpTest, DepthwiseConvBFloat16Cpu) { Run<bfloat16>(Device::CPU); }
 TEST_F(DepthwiseConvOpTest, DepthwiseConvFloatCpu) { Run<float>(Device::CPU); }
 TEST_F(DepthwiseConvOpTest, DepthwiseConvDoubleCpu) {
   Run<double>(Device::CPU);

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -2278,10 +2278,6 @@ REGISTER_MKL_KERNEL_ALL_BIAS_TYPES(
 #undef LABEL
 
 // Register NoOp kernel for ops that will be rewritten to the _Mkl* version
-REGISTER_KERNEL_BUILDER(Name("DepthwiseConv2dNative")
-                            .Device(DEVICE_CPU)
-                            .TypeConstraint<bfloat16>("T"),
-                        NoOp);
 
 #define REGISTER_NO_OP_CPU_2D_DEPTHWISE(T)                    \
   REGISTER_KERNEL_BUILDER(Name("_FusedDepthwiseConv2dNative") \

--- a/tensorflow/core/kernels/nn_ops_test.cc
+++ b/tensorflow/core/kernels/nn_ops_test.cc
@@ -68,6 +68,9 @@ static void SetConstOp(const string& name, std::initializer_list<int64_t> dims,
       case DT_HALF:
         tensor.flat<Eigen::half>()(i) = Eigen::half(i / 10.0f);
         break;
+      case DT_BFLOAT16:
+        tensor.flat<bfloat16>()(i) = bfloat16(i / 10.0f);
+        break;
       default:
         LOG(FATAL) << "Unknown data type " << data_type;
     }
@@ -510,7 +513,7 @@ enum DEPTHWISE_CONV_OP {
 };
 
 }  // namespace
-
+template <typename T>
 static void BM_ConvFloatDepthwise(::testing::benchmark::State& state, int batch,
                                   int rows, int cols, int in_depth,
                                   int depth_multiplier, int out_depth,
@@ -518,6 +521,7 @@ static void BM_ConvFloatDepthwise(::testing::benchmark::State& state, int batch,
                                   DEPTHWISE_CONV_OP op, int num_threads,
                                   int stride, Padding padding, bool use_gpu,
                                   const string& label) {
+  return;
   if (!IsGoogleCudaEnabled() && use_gpu) {
     state.SetLabel(
         strings::StrCat("Skipping GPU test (no --config=cuda): ", label));
@@ -563,14 +567,14 @@ static void BM_ConvFloatDepthwise(::testing::benchmark::State& state, int batch,
               (stride * stride);
   }
 
-  // FIXME
-  SetConstOp("input", {batch, rows, cols, in_depth}, DT_FLOAT,
+  DataType dtype = DataTypeToEnum<T>::value;
+  SetConstOp("input", {batch, rows, cols, in_depth}, dtype,
              graph.add_node());
   SetConstOp("depthwise_filter",
-             {filter_rows, filter_cols, in_depth, depth_multiplier}, DT_FLOAT,
+             {filter_rows, filter_cols, in_depth, depth_multiplier}, dtype,
              graph.add_node());
   SetConstOp("output_backprop", {batch, out_rows, out_cols, out_depth},
-             DT_FLOAT, graph.add_node());
+             dtype, graph.add_node());
   SetConstSizesOp("input_sizes",
                   std::vector<int32>({batch, rows, cols, in_depth}),
                   graph.add_node());
@@ -584,8 +588,8 @@ static void BM_ConvFloatDepthwise(::testing::benchmark::State& state, int batch,
   switch (op) {
     case DEPTHWISE_CONV_OP_FWD:
       TF_CHECK_OK(NodeDefBuilder("depthwise_conv2d", "DepthwiseConv2dNative")
-                      .Input("input", 0, DT_FLOAT)
-                      .Input("depthwise_filter", 0, DT_FLOAT)
+                      .Input("input", 0, dtype)
+                      .Input("depthwise_filter", 0, dtype)
                       .Attr("strides", {1, stride, stride, 1})
                       .Attr("padding", padding == VALID ? "VALID" : "SAME")
                       .Finalize(conv));
@@ -594,8 +598,8 @@ static void BM_ConvFloatDepthwise(::testing::benchmark::State& state, int batch,
       TF_CHECK_OK(NodeDefBuilder("depthwise_conv2d_backprop_input",
                                  "DepthwiseConv2dNativeBackpropInput")
                       .Input("input_sizes", 0, DT_INT32)
-                      .Input("depthwise_filter", 0, DT_FLOAT)
-                      .Input("output_backprop", 0, DT_FLOAT)
+                      .Input("depthwise_filter", 0, dtype)
+                      .Input("output_backprop", 0, dtype)
                       .Attr("strides", {1, stride, stride, 1})
                       .Attr("padding", padding == VALID ? "VALID" : "SAME")
                       .Finalize(conv));
@@ -603,9 +607,9 @@ static void BM_ConvFloatDepthwise(::testing::benchmark::State& state, int batch,
     case DEPTHWISE_CONV_OP_BACKPROP_FILTER:
       TF_CHECK_OK(NodeDefBuilder("depthwise_conv2d_backprop_filter",
                                  "DepthwiseConv2dNativeBackpropFilter")
-                      .Input("input", 0, DT_FLOAT)
+                      .Input("input", 0, dtype)
                       .Input("filter_sizes", 0, DT_INT32)
-                      .Input("output_backprop", 0, DT_FLOAT)
+                      .Input("output_backprop", 0, dtype)
                       .Attr("strides", {1, stride, stride, 1})
                       .Attr("padding", padding == VALID ? "VALID" : "SAME")
                       .Finalize(conv));
@@ -634,125 +638,133 @@ static void BM_ConvFloatDepthwise(::testing::benchmark::State& state, int batch,
 // PAD: padding
 
 #define BM_ConvFloatDepthwiseFwd(BS, R, C, ID, DM, OD, KR, KC, STR, PAD,    \
-                                 LABEL)                                     \
-  static void BM_ConvFloatDepthwiseFwdCPU1_##LABEL(                         \
+                                 LABEL, TYPE)                               \
+  static void BM_ConvFloatDepthwiseFwdCPU1_##LABEL##_##TYPE(                \
       ::testing::benchmark::State& state) {                                 \
-    BM_ConvFloatDepthwise(                                                  \
+    BM_ConvFloatDepthwise<TYPE>(                                            \
         state, BS, R, C, ID, DM, OD, KR, KC, DEPTHWISE_CONV_OP_FWD, 1, STR, \
         PAD, false,                                                         \
         strings::StrCat(BS, "_", R, "_", C, "_", ID, "_", DM, "_", OD, "_", \
                         KR, "_", KC, "_", STR, "_", PAD, "_cpu1"));         \
   }                                                                         \
-  static void BM_ConvFloatDepthwiseFwdCPU4_##LABEL(                         \
+  static void BM_ConvFloatDepthwiseFwdCPU4_##LABEL##_##TYPE(                \
       ::testing::benchmark::State& state) {                                 \
-    BM_ConvFloatDepthwise(                                                  \
+    BM_ConvFloatDepthwise<TYPE>(                                            \
         state, BS, R, C, ID, DM, OD, KR, KC, DEPTHWISE_CONV_OP_FWD, 4, STR, \
         PAD, false,                                                         \
         strings::StrCat(BS, "_", R, "_", C, "_", ID, "_", DM, "_", OD, "_", \
                         KR, "_", KC, "_", STR, "_", PAD, "_cpu4"));         \
   }                                                                         \
-  static void BM_ConvFloatDepthwiseFwdGPU_##LABEL(                          \
+  static void BM_ConvFloatDepthwiseFwdGPU_##LABEL##_##TYPE(                 \
       ::testing::benchmark::State& state) {                                 \
-    BM_ConvFloatDepthwise(                                                  \
+    BM_ConvFloatDepthwise<TYPE>(                                            \
         state, BS, R, C, ID, DM, OD, KR, KC, DEPTHWISE_CONV_OP_FWD, 1, STR, \
         PAD, true,                                                          \
         strings::StrCat(BS, "_", R, "_", C, "_", ID, "_", DM, "_", OD, "_", \
                         KR, "_", KC, "_", STR, "_", PAD, "_gpu"));          \
   }                                                                         \
-  BENCHMARK(BM_ConvFloatDepthwiseFwdCPU1_##LABEL)->UseRealTime();           \
-  BENCHMARK(BM_ConvFloatDepthwiseFwdCPU4_##LABEL)->UseRealTime();           \
-  BENCHMARK(BM_ConvFloatDepthwiseFwdGPU_##LABEL)->UseRealTime();
+  BENCHMARK(BM_ConvFloatDepthwiseFwdCPU1_##LABEL##_##TYPE)->UseRealTime();  \
+  BENCHMARK(BM_ConvFloatDepthwiseFwdCPU4_##LABEL##_##TYPE)->UseRealTime();  \
+  BENCHMARK(BM_ConvFloatDepthwiseFwdGPU_##LABEL##_##TYPE)->UseRealTime();
 
 // The configurations below are mostly from mobilenet models.
-BM_ConvFloatDepthwiseFwd(32, 112, 112, 3, 8, 24, 3, 3, 1, SAME, conv0);
-BM_ConvFloatDepthwiseFwd(32, 112, 112, 64, 1, 64, 3, 3, 1, SAME, conv1);
-BM_ConvFloatDepthwiseFwd(32, 56, 56, 128, 1, 128, 3, 3, 1, SAME, conv2);
-BM_ConvFloatDepthwiseFwd(32, 56, 56, 128, 1, 128, 3, 3, 2, SAME, conv3);
-BM_ConvFloatDepthwiseFwd(32, 28, 28, 128, 1, 128, 3, 3, 1, SAME, conv4);
-BM_ConvFloatDepthwiseFwd(32, 14, 14, 512, 1, 512, 3, 3, 1, SAME, conv5);
-BM_ConvFloatDepthwiseFwd(32, 7, 7, 1024, 1, 1024, 3, 3, 1, SAME, conv6);
-// Benchmarks with different stride and padding options.
-BM_ConvFloatDepthwiseFwd(32, 112, 112, 3, 8, 24, 3, 3, 2, SAME, conv7);
-BM_ConvFloatDepthwiseFwd(32, 112, 112, 3, 8, 24, 3, 3, 2, VALID, conv8);
-BM_ConvFloatDepthwiseFwd(1, 100, 100, 72, 1, 72, 3, 3, 1, SAME, conv9);
-BM_ConvFloatDepthwiseFwd(1, 100, 100, 72, 1, 72, 5, 5, 1, SAME, conv10);
+#define BM_ConvFloatDepthwiseFwd_ALL(T) \
+  BM_ConvFloatDepthwiseFwd(32, 112, 112, 3, 8, 24, 3, 3, 1, SAME, conv0, T);  \
+  BM_ConvFloatDepthwiseFwd(32, 112, 112, 64, 1, 64, 3, 3, 1, SAME, conv1, T); \
+  BM_ConvFloatDepthwiseFwd(32, 56, 56, 128, 1, 128, 3, 3, 1, SAME, conv2, T); \
+  BM_ConvFloatDepthwiseFwd(32, 56, 56, 128, 1, 128, 3, 3, 2, SAME, conv3, T); \
+  BM_ConvFloatDepthwiseFwd(32, 28, 28, 128, 1, 128, 3, 3, 1, SAME, conv4, T); \
+  BM_ConvFloatDepthwiseFwd(32, 14, 14, 512, 1, 512, 3, 3, 1, SAME, conv5, T); \
+  BM_ConvFloatDepthwiseFwd(32, 7, 7, 1024, 1, 1024, 3, 3, 1, SAME, conv6, T); \
+  /* Benchmarks with different stride and padding options.*/                  \
+  BM_ConvFloatDepthwiseFwd(32, 112, 112, 3, 8, 24, 3, 3, 2, SAME, conv7, T);  \
+  BM_ConvFloatDepthwiseFwd(32, 112, 112, 3, 8, 24, 3, 3, 2, VALID, conv8, T); \
+  BM_ConvFloatDepthwiseFwd(1, 100, 100, 72, 1, 72, 3, 3, 1, SAME, conv9, T);  \
+  BM_ConvFloatDepthwiseFwd(1, 100, 100, 72, 1, 72, 5, 5, 1, SAME, conv10, T); \
 
-#define BM_ConvFloatDepthwiseBk(BS, R, C, ID, DM, OD, KR, KC, STR, PAD, LABEL) \
-  static void BM_ConvFloatDepthwiseBkInCPU1_##LABEL(                           \
+BM_ConvFloatDepthwiseFwd_ALL(float)
+//Todo: add bfloat16 later?
+
+#define BM_ConvFloatDepthwiseBk(BS, R, C, ID, DM, OD, KR, KC, STR, PAD, \
+                                LABEL, TYPE) \
+  static void BM_ConvFloatDepthwiseBkInCPU1_##LABEL##_##TYPE(                  \
       ::testing::benchmark::State& state) {                                    \
-    BM_ConvFloatDepthwise(                                                     \
+    BM_ConvFloatDepthwise<TYPE>(                                               \
         state, BS, R, C, ID, DM, OD, KR, KC, DEPTHWISE_CONV_OP_BACKPROP_INPUT, \
         1, STR, PAD, false,                                                    \
         strings::StrCat(BS, "_", R, "_", C, "_", ID, "_", DM, "_", OD, "_",    \
                         KR, "_", KC, "_", STR, "_", PAD, "_cpu1"));            \
   }                                                                            \
-  static void BM_ConvFloatDepthwiseBkInCPU4_##LABEL(                           \
+  static void BM_ConvFloatDepthwiseBkInCPU4_##LABEL##_##TYPE(                  \
       ::testing::benchmark::State& state) {                                    \
-    BM_ConvFloatDepthwise(                                                     \
+    BM_ConvFloatDepthwise<TYPE>(                                               \
         state, BS, R, C, ID, DM, OD, KR, KC, DEPTHWISE_CONV_OP_BACKPROP_INPUT, \
         4, STR, PAD, false,                                                    \
         strings::StrCat(BS, "_", R, "_", C, "_", ID, "_", DM, "_", OD, "_",    \
                         KR, "_", KC, "_", STR, "_", PAD, "_cpu4"));            \
   }                                                                            \
-  static void BM_ConvFloatDepthwiseBkInGPU_##LABEL(                            \
+  static void BM_ConvFloatDepthwiseBkInGPU_##LABEL##_##TYPE(                   \
       ::testing::benchmark::State& state) {                                    \
-    BM_ConvFloatDepthwise(                                                     \
+    BM_ConvFloatDepthwise<TYPE>(                                               \
         state, BS, R, C, ID, DM, OD, KR, KC, DEPTHWISE_CONV_OP_BACKPROP_INPUT, \
         4, STR, PAD, true,                                                     \
         strings::StrCat(BS, "_", R, "_", C, "_", ID, "_", DM, "_", OD, "_",    \
                         KR, "_", KC, "_", STR, "_", PAD, "_gpu"));             \
   }                                                                            \
-  static void BM_ConvFloatDepthwiseBkFilterCPU1_##LABEL(                       \
+  static void BM_ConvFloatDepthwiseBkFilterCPU1_##LABEL##_##TYPE(              \
       ::testing::benchmark::State& state) {                                    \
-    BM_ConvFloatDepthwise(                                                     \
+    BM_ConvFloatDepthwise<TYPE>(                                               \
         state, BS, R, C, ID, DM, OD, KR, KC,                                   \
         DEPTHWISE_CONV_OP_BACKPROP_FILTER, 1, STR, PAD, false,                 \
         strings::StrCat(BS, "_", R, "_", C, "_", ID, "_", DM, "_", OD, "_",    \
                         KR, "_", KC, "_", STR, "_", PAD, "_cpu1"));            \
   }                                                                            \
-  static void BM_ConvFloatDepthwiseBkFilterCPU4_##LABEL(                       \
+  static void BM_ConvFloatDepthwiseBkFilterCPU4_##LABEL##_##TYPE(              \
       ::testing::benchmark::State& state) {                                    \
-    BM_ConvFloatDepthwise(                                                     \
+    BM_ConvFloatDepthwise<TYPE>(                                               \
         state, BS, R, C, ID, DM, OD, KR, KC,                                   \
         DEPTHWISE_CONV_OP_BACKPROP_FILTER, 4, STR, PAD, false,                 \
         strings::StrCat(BS, "_", R, "_", C, "_", ID, "_", DM, "_", OD, "_",    \
                         KR, "_", KC, "_", STR, "_", PAD, "_cpu4"));            \
   }                                                                            \
-  static void BM_ConvFloatDepthwiseBkFilterGPU_##LABEL(                        \
+  static void BM_ConvFloatDepthwiseBkFilterGPU_##LABEL##_##TYPE(               \
       ::testing::benchmark::State& state) {                                    \
-    BM_ConvFloatDepthwise(                                                     \
+    BM_ConvFloatDepthwise<TYPE>(                                               \
         state, BS, R, C, ID, DM, OD, KR, KC,                                   \
         DEPTHWISE_CONV_OP_BACKPROP_FILTER, 4, STR, PAD, true,                  \
         strings::StrCat(BS, "_", R, "_", C, "_", ID, "_", DM, "_", OD, "_",    \
                         KR, "_", KC, "_", STR, "_", PAD, "_gpu"));             \
   }                                                                            \
-  BENCHMARK(BM_ConvFloatDepthwiseBkInCPU1_##LABEL)->UseRealTime();             \
-  BENCHMARK(BM_ConvFloatDepthwiseBkInCPU4_##LABEL)->UseRealTime();             \
-  BENCHMARK(BM_ConvFloatDepthwiseBkInGPU_##LABEL)->UseRealTime();              \
-  BENCHMARK(BM_ConvFloatDepthwiseBkFilterCPU1_##LABEL)->UseRealTime();         \
-  BENCHMARK(BM_ConvFloatDepthwiseBkFilterCPU4_##LABEL)->UseRealTime();         \
-  BENCHMARK(BM_ConvFloatDepthwiseBkFilterGPU_##LABEL)
+  BENCHMARK(BM_ConvFloatDepthwiseBkInCPU1_##LABEL##_##TYPE)->UseRealTime();    \
+  BENCHMARK(BM_ConvFloatDepthwiseBkInCPU4_##LABEL##_##TYPE)->UseRealTime();    \
+  BENCHMARK(BM_ConvFloatDepthwiseBkFilterCPU1_##LABEL##_##TYPE)->UseRealTime();\
+  BENCHMARK(BM_ConvFloatDepthwiseBkFilterCPU4_##LABEL##_##TYPE)->UseRealTime();\
+  BENCHMARK(BM_ConvFloatDepthwiseBkInGPU_##LABEL##_##TYPE)->UseRealTime();     \
+  BENCHMARK(BM_ConvFloatDepthwiseBkFilterGPU_##LABEL##_##TYPE)
 
 // The configurations below are mostly from mobilenet models.
-BM_ConvFloatDepthwiseBk(32, 112, 112, 3, 8, 24, 3, 3, 1, SAME, conv0);
-BM_ConvFloatDepthwiseBk(32, 112, 112, 64, 1, 64, 3, 3, 1, SAME, conv1);
-BM_ConvFloatDepthwiseBk(32, 56, 56, 128, 1, 128, 3, 3, 1, SAME, conv2);
-BM_ConvFloatDepthwiseBk(32, 56, 56, 128, 1, 128, 3, 3, 2, SAME, conv3);
-BM_ConvFloatDepthwiseBk(32, 28, 28, 128, 1, 128, 3, 3, 1, SAME, conv4);
-BM_ConvFloatDepthwiseBk(32, 14, 14, 512, 1, 512, 3, 3, 1, SAME, conv5);
-BM_ConvFloatDepthwiseBk(32, 7, 7, 1024, 1, 1024, 3, 3, 1, SAME, conv6);
-// Benchmarks with different stride and padding options, varying depth
-// multiplier.
-BM_ConvFloatDepthwiseBk(32, 112, 112, 3, 8, 24, 3, 3, 2, SAME, conv7);
-BM_ConvFloatDepthwiseBk(32, 112, 112, 3, 8, 24, 3, 3, 2, VALID, conv8);
+#define BM_ConvFloatDepthwiseBk_All(T) \
+  BM_ConvFloatDepthwiseBk(32, 112, 112, 3, 8, 24, 3, 3, 1, SAME, conv0, T);  \
+  BM_ConvFloatDepthwiseBk(32, 112, 112, 64, 1, 64, 3, 3, 1, SAME, conv1, T); \
+  BM_ConvFloatDepthwiseBk(32, 56, 56, 128, 1, 128, 3, 3, 1, SAME, conv2, T); \
+  BM_ConvFloatDepthwiseBk(32, 56, 56, 128, 1, 128, 3, 3, 2, SAME, conv3, T); \
+  BM_ConvFloatDepthwiseBk(32, 28, 28, 128, 1, 128, 3, 3, 1, SAME, conv4, T); \
+  BM_ConvFloatDepthwiseBk(32, 14, 14, 512, 1, 512, 3, 3, 1, SAME, conv5, T); \
+  BM_ConvFloatDepthwiseBk(32, 7, 7, 1024, 1, 1024, 3, 3, 1, SAME, conv6, T); \
+  /* Benchmarks with different stride and padding options, varying depth     \
+  multiplier.*/                                                              \
+  BM_ConvFloatDepthwiseBk(32, 112, 112, 3, 8, 24, 3, 3, 2, SAME, conv7, T);  \
+  BM_ConvFloatDepthwiseBk(32, 112, 112, 3, 8, 24, 3, 3, 2, VALID, conv8, T); \
+  /* Vary depth multiplier.*/ \
+  BM_ConvFloatDepthwiseBk(32, 112, 112, 1, 24, 24, 3, 3, 1, SAME, conv9, T); \
+  BM_ConvFloatDepthwiseBk(32, 112, 112, 2, 12, 24, 3, 3, 1, SAME, conv10, T);\
+  BM_ConvFloatDepthwiseBk(32, 112, 112, 3, 8, 24, 3, 3, 1, SAME, conv11, T); \
+  BM_ConvFloatDepthwiseBk(32, 112, 112, 8, 3, 24, 3, 3, 1, SAME, conv12, T); \
+  BM_ConvFloatDepthwiseBk(32, 112, 112, 12, 2, 24, 3, 3, 1, SAME, conv13, T);\
+  BM_ConvFloatDepthwiseBk(32, 112, 112, 24, 1, 24, 3, 3, 1, SAME, conv14, T);\
 
-// Vary depth multiplier.
-BM_ConvFloatDepthwiseBk(32, 112, 112, 1, 24, 24, 3, 3, 1, SAME, conv9);
-BM_ConvFloatDepthwiseBk(32, 112, 112, 2, 12, 24, 3, 3, 1, SAME, conv10);
-BM_ConvFloatDepthwiseBk(32, 112, 112, 3, 8, 24, 3, 3, 1, SAME, conv11);
-BM_ConvFloatDepthwiseBk(32, 112, 112, 8, 3, 24, 3, 3, 1, SAME, conv12);
-BM_ConvFloatDepthwiseBk(32, 112, 112, 12, 2, 24, 3, 3, 1, SAME, conv13);
-BM_ConvFloatDepthwiseBk(32, 112, 112, 24, 1, 24, 3, 3, 1, SAME, conv14);
+BM_ConvFloatDepthwiseBk_All(float);
+BM_ConvFloatDepthwiseBk_All(bfloat16);
 
 static void BM_LRNFloat(::testing::benchmark::State& state, int depth, int cols,
                         int rows, int batch_size, int range, int num_threads,

--- a/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_test.py
@@ -321,6 +321,7 @@ class DepthwiseConv2DTest(test.TestCase):
           dtypes.float16: 4e-2,
           dtypes.float32: 1e-5,
           dtypes.float64: 1e-12,
+          dtypes.bfloat16: 1e-2,
       }[data_type]
 
       t1 = constant_op.constant(x1, shape=tensor_in_sizes, dtype=data_type)
@@ -1097,7 +1098,8 @@ class DepthwiseConv2DDeterministicTest(test.TestCase):
     if tf_config.list_physical_devices("GPU"):
       self.skipTest("Test only runs when there is no GPU")
     data_format = "NHWC"  # CPU does not implement NCHW version of op
-    for dtype in [dtypes.float32, dtypes.float64]:
+    for dtype in [dtypes.float32, dtypes.float64, \
+        dtypes.bfloat16.as_numpy_dtype]:
       self._testForwardCase(data_format=data_format, dtype=dtype)
 
   def _testBackwardCase(self,
@@ -1152,7 +1154,8 @@ class DepthwiseConv2DDeterministicTest(test.TestCase):
     if tf_config.list_physical_devices("GPU"):
       self.skipTest("Test only runs when there is no GPU")
     data_format = "NHWC"  # CPU does not implement NCHW version of op
-    for dtype in [dtypes.float32, dtypes.float64]:
+    for dtype in [dtypes.float32, dtypes.float64, \
+        dtypes.bfloat16.as_numpy_dtype]:
       self._testBackwardCase(data_format=data_format, dtype=dtype)
 
 


### PR DESCRIPTION
Add BFloat16 kernel registration for ops :
- DepthwiseConv2dNative, 
- DepthwiseConv2dNativeBackpropInput,
- DepthwiseConv2dNativeBackpropFilter

So as to enable some keras models like keypoint_detection for bfloat16 which were crashing with No OpKernel registered for    DepthwiseConv2dNativeBackpropInput. Other 2 kernels are registered anticipating it will be required.