### PR TITLE
Updated Random_ops tests

### DIFF
--- a/tensorflow/lite/kernels/CMakeLists.txt
+++ b/tensorflow/lite/kernels/CMakeLists.txt
@@ -252,8 +252,7 @@ set(TEST_WITH_EXTERNAL_MAIN_LIST
   pow_test.cc
   quant_basic_lstm_test.cc
   quantize_test.cc
-  random_standard_normal_test.cc
-  random_uniform_test.cc
+  random_ops_test.cc
   range_test.cc
   rank_test.cc
   reduce_test.cc


### PR DESCRIPTION
Removed the non existing files and replaced with the common test file random_ops_test.cc
Fixes https://github.com/tensorflow/tensorflow/issues/54418