### PR TITLE
[mhlo] declare the minimum version 3.15.0 of cmake

### DIFF
--- a/tensorflow/compiler/mlir/hlo/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.15.0)
 
 if(POLICY CMP0068)
   cmake_policy(SET CMP0068 NEW)


### PR DESCRIPTION
When use cmake build_tools build the llvm-project, we give multiple targets
but this feature start with cmake 3.15.0