### PR TITLE
Add appropriate encoding check for `tf.compat.as_bytes`/`as_text`

### DIFF
--- a/tensorflow/python/util/BUILD
+++ b/tensorflow/python/util/BUILD
@@ -711,3 +711,14 @@ filegroup(
     name = "util_hdr",
     srcs = ["util.h"],
 )
+
+tf_py_test(
+    name = "compat_test",
+    srcs = ["compat_test.py"],
+    python_version = "PY3",
+    deps = [
+        ":util",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python:platform",
+    ],
+)

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -47,6 +47,7 @@ import numbers as _numbers
 
 import numpy as _np
 import six as _six
+import codecs
 
 from tensorflow.python.util.tf_export import tf_export
 
@@ -72,6 +73,8 @@ def as_bytes(bytes_or_text, encoding='utf-8'):
   Raises:
     TypeError: If `bytes_or_text` is not a binary or unicode string.
   """
+  # Validate encoding, a LookupError will be raised if invalid.
+  encoding = codecs.lookup(encoding).name
   if isinstance(bytes_or_text, bytearray):
     return bytes(bytes_or_text)
   elif isinstance(bytes_or_text, _six.text_type):
@@ -99,6 +102,8 @@ def as_text(bytes_or_text, encoding='utf-8'):
   Raises:
     TypeError: If `bytes_or_text` is not a binary or unicode string.
   """
+  # Validate encoding, a LookupError will be raised if invalid.
+  encoding = codecs.lookup(encoding).name
   if isinstance(bytes_or_text, _six.text_type):
     return bytes_or_text
   elif isinstance(bytes_or_text, bytes):

--- a/tensorflow/python/util/compat_test.py
+++ b/tensorflow/python/util/compat_test.py
@@ -1,0 +1,37 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Compat tests."""
+
+from tensorflow.python.platform import test
+from tensorflow.python.util import compat
+
+
+class CompatTest(test.TestCase):
+
+  def testCompatValidEncoding(self):
+    self.assertEqual(compat.as_bytes("hello", "utf8"), b"hello")
+    self.assertEqual(compat.as_text(b"hello", "utf-8"), "hello")
+
+
+  def testCompatInvalidEncoding(self):
+    with self.assertRaises(LookupError):
+      compat.as_bytes("hello", "invalid")
+
+    with self.assertRaises(LookupError):
+      compat.as_text(b"hello", "invalid")
+
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
This PR tries to address the issue raised in #54413 where
there were no encoding check for tf.compat.as_bytes/as_text.
As a result, invalid encoding input will silently
return incorrect result, e.g.:
```
bytes_or_text = "hello"
t1 = tf.compat.as_text(bytes_or_text, encoding="valid")
print(t1) # hello
```

This PR looks up python encoding to make sure it is valid.

This PR fixes #54413.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>