### PR TITLE
[TF-TRT] Converter Summary Improved with number of IO nodes

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -20,6 +20,7 @@ import os
 import platform
 import tempfile
 
+import numpy as np
 import six as _six
 
 from tensorflow.core.protobuf import config_pb2
@@ -905,6 +906,8 @@ def _extract_shapes_from_node(node, key):
 def _get_engine_dtypes_from_node(node, key):
   return [dtypes._TYPE_TO_STRING[dtype] for dtype in node.attr[key].list.type]
 
+def _get_engines_io_nodes_count(node, key):
+  return len(node.attr[key].list.type)
 
 @tf_export("experimental.tensorrt.Converter", v1=[])
 class TrtGraphConverterV2(object):
@@ -1444,13 +1447,22 @@ class TrtGraphConverterV2(object):
     # positions are percentage of `line_length`. positions[i]+1 is the starting
     # position for (i+1)th field. We also make sure that the last char printed
     # for each field is a space.
-    positions = [.22, .30, .45, .60, .8, 1.]
-    positions = [int(line_length * p) for p in positions]
-
-    headers = [
-        "TRTEngineOP Name", "# Nodes", "Input DType", "Output Dtype",
-        "Input Shape", "Output Shape"
+    columns = [
+        # (column name, column size in % of line)
+        ("TRTEngineOP Name", .21),  # 21%
+        ("# Nodes", .09),           # 30%
+        ("# Inputs", .09),          # 39%
+        ("# Outputs", .09),         # 48%
+        ("Input DTypes", .13),      # 61%
+        ("Output Dtypes", .13),     # 74%
+        ("Input Shapes", .13),      # 87%
+        ("Output Shapes", .13)      # 100%
     ]
+
+    positions = [int(line_length * p) for _, p in columns]
+    positions = np.cumsum(positions).tolist()
+    headers = [h for h, _ in columns]
+
     _print_row(headers, positions, print_fn=print_fn)
     print_fn("=" * line_length)
 
@@ -1460,34 +1472,48 @@ class TrtGraphConverterV2(object):
 
     graphdef = self._converted_func.graph.as_graph_def(add_shapes=True)
 
+    trtengineops_dict = dict()
     for node in graphdef.node:
       if node.op != "TRTEngineOp":
         n_ops_not_converted += 1
         continue
       else:
+        trtengineops_dict[node.name] = node
         n_engines += 1
 
-        in_shapes = _extract_shapes_from_node(node, "input_shapes")
-        out_shapes = _extract_shapes_from_node(node, "_output_shapes")
-        in_dtypes = _get_engine_dtypes_from_node(node, "InT")
-        out_dtypes = _get_engine_dtypes_from_node(node, "OutT")
-        node_count, converted_ops_dict = _get_nodes_in_engine(
-            graphdef, node.name)
+    for name, node in sorted(trtengineops_dict.items()):
+      in_shapes = _extract_shapes_from_node(node, "input_shapes")
+      out_shapes = _extract_shapes_from_node(node, "_output_shapes")
+      in_dtypes = _get_engine_dtypes_from_node(node, "InT")
+      out_dtypes = _get_engine_dtypes_from_node(node, "OutT")
+      in_nodes_count = _get_engines_io_nodes_count(node, "InT")
+      out_nodes_count = _get_engines_io_nodes_count(node, "OutT")
+      node_count, converted_ops_dict = _get_nodes_in_engine(graphdef, name)
 
-        n_ops_converted += node_count
+      n_ops_converted += node_count
 
-        if n_engines != 1:
-          print_fn(f"\n{'-'*40}\n")
+      if n_engines != 1:
+        print_fn(f"\n{'-'*40}\n")
 
-        _print_row([
-            node.name, node_count, in_dtypes, out_dtypes, in_shapes, out_shapes
+      _print_row(
+        fields=[
+          name,
+          node_count,
+          in_nodes_count,
+          out_nodes_count,
+          in_dtypes,
+          out_dtypes,
+          in_shapes,
+          out_shapes
         ],
-                   positions,
-                   print_fn=print_fn)
-        if detailed:
-          print_fn()
-          for key, value in sorted(dict(converted_ops_dict).items()):
-            print_fn(f"\t- {key}: {value}x")
+        positions=positions,
+        print_fn=print_fn
+      )
+
+      if detailed:
+        print_fn()
+        for key, value in sorted(dict(converted_ops_dict).items()):
+          print_fn(f"\t- {key}: {value}x")
 
     print_fn(f"\n{'='*line_length}")
     print_fn(f"[*] Total number of TensorRT engines: {n_engines}")


### PR DESCRIPTION
Minor changer to `TRTConverterV2.summary()` to include the number of input and output nodes.