### PR TITLE
Added LZ4 support for TFRecordWriter

### DIFF
--- a/tensorflow/compiler/mlir/lite/experimental/tac/py_wrapper/BUILD
+++ b/tensorflow/compiler/mlir/lite/experimental/tac/py_wrapper/BUILD
@@ -89,6 +89,7 @@ pybind_extension(
         "@upb//:__subpackages__",
         "@XNNPACK//:__subpackages__",
         "@zlib//:__subpackages__",
+        "@lz4//:__subpackages__",
     ],
     deps = [
         ":tac_wrapper_lib",

--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -955,6 +955,7 @@ pybind_extension(
         "@snappy//:__subpackages__",
         "//:__subpackages__",
         "@zlib//:__subpackages__",
+        "@lz4//:__subpackages__",
     ],
     deps = [
         ":common_utils",

--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -1400,6 +1400,9 @@ cc_library(
         "//tensorflow/core/lib/io:snappy_outputbuffer",
         "//tensorflow/core/lib/io:table",
         "//tensorflow/core/lib/io:table_options",
+        "//tensorflow/core/lib/io:lz4_compression_options",
+        "//tensorflow/core/lib/io:lz4_inputstream",
+        "//tensorflow/core/lib/io:lz4_outputbuffer",
         "//tensorflow/core/lib/io:zlib_compression_options",
         "//tensorflow/core/lib/io:zlib_inputstream",
         "//tensorflow/core/lib/io:zlib_outputbuffer",
@@ -1482,6 +1485,7 @@ cc_library(
         "//tensorflow/core/util:reporter",  # TODO(gunan): REMOVE as soon as cc_shared_library is supported.
         "@snappy",
         "@zlib",
+        "@lz4",
         "@double_conversion//:double-conversion",
         "@com_google_protobuf//:protobuf",
     ] + select({
@@ -1897,6 +1901,7 @@ tf_cc_tests(
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:optional",
         "@zlib",
+        "@lz4",
     ],
 )
 

--- a/tensorflow/core/api_def/base_api/api_def_TFRecordDataset.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_TFRecordDataset.pbtxt
@@ -12,7 +12,7 @@ END
     name: "compression_type"
     description: <<END
 A scalar containing either (i) the empty string (no
-compression), (ii) "ZLIB", or (iii) "GZIP".
+compression), (ii) "ZLIB", (iii) "GZIP", or (iiii) "LZ4".
 END
   }
   in_arg {

--- a/tensorflow/core/data/dataset_test_base.h
+++ b/tensorflow/core/data/dataset_test_base.h
@@ -46,6 +46,7 @@ limitations under the License.
 #include "tensorflow/core/lib/gtl/array_slice.h"
 #include "tensorflow/core/lib/gtl/inlined_vector.h"
 #include "tensorflow/core/lib/io/zlib_compression_options.h"
+#include "tensorflow/core/lib/io/lz4/lz4_compression_options.h"
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/refcount.h"
 #include "tensorflow/core/platform/status.h"
@@ -93,7 +94,13 @@ std::vector<Tensor> CreateTensors(
   return result;
 }
 
-enum class CompressionType { ZLIB = 0, GZIP = 1, RAW = 2, UNCOMPRESSED = 3 };
+enum class CompressionType {
+  ZLIB = 0,
+  GZIP = 1,
+  RAW = 2,
+  LZ4 = 3,
+  UNCOMPRESSED = 4
+};
 
 // Returns a string representation for the given compression type.
 string ToString(CompressionType compression_type);
@@ -102,6 +109,12 @@ string ToString(CompressionType compression_type);
 // type. Note that `CompressionType::UNCOMPRESSED` is not supported because
 // `ZlibCompressionOptions` does not have an option.
 io::ZlibCompressionOptions GetZlibCompressionOptions(
+    CompressionType compression_type);
+
+// Gets the specified lz4 compression options according to the compression
+// type. Note that `CompressionType::UNCOMPRESSED` is not supported because
+// `Lz4CompressionOptions` does not have an option.
+io::Lz4CompressionOptions GetLz4CompressionOptions(
     CompressionType compression_type);
 
 // Used to specify parameters when writing data into files with compression.

--- a/tensorflow/core/data/snapshot_utils.cc
+++ b/tensorflow/core/data/snapshot_utils.cc
@@ -35,6 +35,9 @@ limitations under the License.
 #include "tensorflow/core/lib/io/zlib_compression_options.h"
 #include "tensorflow/core/lib/io/zlib_inputstream.h"
 #include "tensorflow/core/lib/io/zlib_outputbuffer.h"
+#include "tensorflow/core/lib/io/lz4/lz4_compression_options.h"
+#include "tensorflow/core/lib/io/lz4/lz4_inputstream.h"
+#include "tensorflow/core/lib/io/lz4/lz4_outputbuffer.h"
 #include "tensorflow/core/platform/coding.h"
 #include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/platform/file_system.h"
@@ -189,15 +192,24 @@ Status CustomWriter::Initialize(tensorflow::Env* env) {
   }
 #else   // IS_SLIM_BUILD
   if (compression_type_ == io::compression::kGzip) {
-    zlib_underlying_dest_.swap(dest_);
+    underlying_dest_.swap(dest_);
     io::ZlibCompressionOptions zlib_options;
     zlib_options = io::ZlibCompressionOptions::GZIP();
 
     io::ZlibOutputBuffer* zlib_output_buffer = new io::ZlibOutputBuffer(
-        zlib_underlying_dest_.get(), zlib_options.input_buffer_size,
+        underlying_dest_.get(), zlib_options.input_buffer_size,
         zlib_options.output_buffer_size, zlib_options);
     TF_CHECK_OK(zlib_output_buffer->Init());
     dest_.reset(zlib_output_buffer);
+  } else if (compression_type_ == io::compression::kLz4) {
+    underlying_dest_.swap(dest_);
+    io::Lz4CompressionOptions lz4_options =
+        io::Lz4CompressionOptions::DEFAULT();
+
+    io::Lz4OutputBuffer* lz4_output_buffer = new io::Lz4OutputBuffer(
+        underlying_dest_.get(), lz4_options.input_buffer_size,
+        lz4_options.output_buffer_size, lz4_options);
+    dest_.reset(lz4_output_buffer);
   }
 #endif  // IS_SLIM_BUILD
   simple_tensor_mask_.reserve(dtypes_.size());
@@ -304,9 +316,9 @@ Status CustomWriter::Close() {
     TF_RETURN_IF_ERROR(dest_->Close());
     dest_ = nullptr;
   }
-  if (zlib_underlying_dest_ != nullptr) {
-    TF_RETURN_IF_ERROR(zlib_underlying_dest_->Close());
-    zlib_underlying_dest_ = nullptr;
+  if (underlying_dest_ != nullptr) {
+    TF_RETURN_IF_ERROR(underlying_dest_->Close());
+    underlying_dest_ = nullptr;
   }
   return Status::OK();
 }
@@ -776,6 +788,12 @@ Status CustomReader::Initialize(Env* env) {
       input_stream_ =
           absl::make_unique<io::BufferedInputStream>(file_.get(), 64 << 20);
     }
+  } else if (compression_type_ == io::compression::kLz4) {
+    io::Lz4CompressionOptions lz4_options =
+        io::Lz4CompressionOptions::DEFAULT();
+    input_stream_ = absl::make_unique<io::Lz4InputStream>(
+        input_stream_.release(), lz4_options.input_buffer_size,
+        lz4_options.output_buffer_size, lz4_options, true);
   }
 #endif  // IS_SLIM_BUILD
   simple_tensor_mask_.reserve(dtypes_.size());

--- a/tensorflow/core/data/snapshot_utils.h
+++ b/tensorflow/core/data/snapshot_utils.h
@@ -155,10 +155,11 @@ class CustomWriter : public Writer {
   const std::string filename_;
   const std::string compression_type_;
   const DataTypeVector dtypes_;
-  // We hold zlib_dest_ because we may create a ZlibOutputBuffer and put that
-  // in dest_ if we want compression. ZlibOutputBuffer doesn't own the original
-  // dest_ and so we need somewhere to store the original one.
-  std::unique_ptr<WritableFile> zlib_underlying_dest_;
+  // We hold underlying_dest_ because we may create a ZlibOutputBuffer or
+  // Lz4OutputBuffer and put that in dest_ if we want compression.
+  // ZlibOutputBuffer or Lz4OutputBuffer doesn't own the original dest_ and so
+  // we need somewhere to store the original one.
+  std::unique_ptr<WritableFile> underlying_dest_;
   std::vector<bool> simple_tensor_mask_;  // true for simple, false for complex.
   int num_simple_ = 0;
   int num_complex_ = 0;

--- a/tensorflow/core/data/snapshot_utils_test.cc
+++ b/tensorflow/core/data/snapshot_utils_test.cc
@@ -89,6 +89,7 @@ TEST(SnapshotUtilTest, CombinationRoundTripTest) {
   SnapshotRoundTrip(io::compression::kNone, 2);
   SnapshotRoundTrip(io::compression::kGzip, 2);
   SnapshotRoundTrip(io::compression::kSnappy, 2);
+  SnapshotRoundTrip(io::compression::kLz4, 2);
 }
 
 void SnapshotReaderBenchmarkLoop(::testing::benchmark::State& state,
@@ -141,11 +142,16 @@ void SnapshotTFRecordReaderGzipBenchmark(::testing::benchmark::State& state) {
   SnapshotReaderBenchmarkLoop(state, io::compression::kGzip, 2);
 }
 
+void SnapshotTFRecordReaderLz4Benchmark(::testing::benchmark::State& state) {
+  SnapshotReaderBenchmarkLoop(state, io::compression::kLz4, 2);
+}
+
 BENCHMARK(SnapshotCustomReaderNoneBenchmark);
 BENCHMARK(SnapshotCustomReaderGzipBenchmark);
 BENCHMARK(SnapshotCustomReaderSnappyBenchmark);
 BENCHMARK(SnapshotTFRecordReaderNoneBenchmark);
 BENCHMARK(SnapshotTFRecordReaderGzipBenchmark);
+BENCHMARK(SnapshotTFRecordReaderLz4Benchmark);
 
 void SnapshotWriterBenchmarkLoop(::testing::benchmark::State& state,
                                  std::string compression_type, int version) {
@@ -192,12 +198,17 @@ void SnapshotTFRecordWriterSnappyBenchmark(::testing::benchmark::State& state) {
   SnapshotWriterBenchmarkLoop(state, io::compression::kSnappy, 2);
 }
 
+void SnapshotTFRecordWriterLz4Benchmark(::testing::benchmark::State& state) {
+  SnapshotWriterBenchmarkLoop(state, io::compression::kLz4, 2);
+}
+
 BENCHMARK(SnapshotCustomWriterNoneBenchmark);
 BENCHMARK(SnapshotCustomWriterGzipBenchmark);
 BENCHMARK(SnapshotCustomWriterSnappyBenchmark);
 BENCHMARK(SnapshotTFRecordWriterNoneBenchmark);
 BENCHMARK(SnapshotTFRecordWriterGzipBenchmark);
 BENCHMARK(SnapshotTFRecordWriterSnappyBenchmark);
+BENCHMARK(SnapshotTFRecordWriterLz4Benchmark);
 
 }  // namespace
 }  // namespace snapshot_util

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -7732,6 +7732,7 @@ tf_cc_shared_library(
         "//:__subpackages__",
         "@upb//:__subpackages__",
         "@zlib//:__subpackages__",
+        "@lz4//:__subpackages__",
         # copybara:comment_end
     ],
     visibility = ["//visibility:public"],

--- a/tensorflow/core/kernels/data/tf_record_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/tf_record_dataset_op_test.cc
@@ -137,6 +137,23 @@ TFRecordDatasetParams TFRecordDatasetParams3() {
                                /*buffer_size=*/10,
                                /*node_name=*/kNodeName);
 }
+// Test case 4: multiple text files with LZ4 compression.
+TFRecordDatasetParams TFRecordDatasetParams4() {
+  std::vector<tstring> filenames = {
+      absl::StrCat(testing::TmpDir(), "/tf_record_LZ4_1"),
+      absl::StrCat(testing::TmpDir(), "/tf_record_LZ4_2")};
+  std::vector<std::vector<string>> contents = {{"1", "22", "333"},
+                                               {"a", "bb", "ccc"}};
+  CompressionType compression_type = CompressionType::LZ4;
+  if (!CreateTestFiles(filenames, contents, compression_type).ok()) {
+    VLOG(WARNING) << "Failed to create the test files: "
+                  << absl::StrJoin(filenames, ", ");
+  }
+  return TFRecordDatasetParams(filenames,
+                               /*compression_type=*/compression_type,
+                               /*buffer_size=*/10,
+                               /*node_name=*/kNodeName);
+}
 
 std::vector<GetNextTestCase<TFRecordDatasetParams>> GetNextTestCases() {
   return {
@@ -148,6 +165,9 @@ std::vector<GetNextTestCase<TFRecordDatasetParams>> GetNextTestCases() {
        CreateTensors<tstring>(
            TensorShape({}), {{"1"}, {"22"}, {"333"}, {"a"}, {"bb"}, {"ccc"}})},
       {/*dataset_params=*/TFRecordDatasetParams3(),
+       CreateTensors<tstring>(
+           TensorShape({}), {{"1"}, {"22"}, {"333"}, {"a"}, {"bb"}, {"ccc"}})},
+      {/*dataset_params=*/TFRecordDatasetParams4(),
        CreateTensors<tstring>(
            TensorShape({}), {{"1"}, {"22"}, {"333"}, {"a"}, {"bb"}, {"ccc"}})}};
 }
@@ -187,6 +207,17 @@ std::vector<SkipTestCase<TFRecordDatasetParams>> SkipTestCases() {
            /*expected_outputs=*/
            CreateTensors<tstring>(TensorShape({}), {{"bb"}})},
           {/*dataset_params=*/TFRecordDatasetParams3(),
+           /*num_to_skip*/ 7, /*expected_num_skipped*/ 6},
+
+          {/*dataset_params=*/TFRecordDatasetParams4(),
+           /*num_to_skip*/ 2, /*expected_num_skipped*/ 2, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<tstring>(TensorShape({}), {{"333"}})},
+          {/*dataset_params=*/TFRecordDatasetParams4(),
+           /*num_to_skip*/ 4, /*expected_num_skipped*/ 4, /*get_next*/ true,
+           /*expected_outputs=*/
+           CreateTensors<tstring>(TensorShape({}), {{"bb"}})},
+          {/*dataset_params=*/TFRecordDatasetParams4(),
            /*num_to_skip*/ 7, /*expected_num_skipped*/ 6}};
 }
 
@@ -256,6 +287,10 @@ IteratorSaveAndRestoreTestCases() {
        CreateTensors<tstring>(
            TensorShape({}), {{"1"}, {"22"}, {"333"}, {"a"}, {"bb"}, {"ccc"}})},
       {/*dataset_params=*/TFRecordDatasetParams3(),
+       /*breakpoints=*/{0, 2, 7},
+       CreateTensors<tstring>(
+           TensorShape({}), {{"1"}, {"22"}, {"333"}, {"a"}, {"bb"}, {"ccc"}})},
+      {/*dataset_params=*/TFRecordDatasetParams4(),
        /*breakpoints=*/{0, 2, 7},
        CreateTensors<tstring>(
            TensorShape({}), {{"1"}, {"22"}, {"333"}, {"a"}, {"bb"}, {"ccc"}})}};

--- a/tensorflow/core/lib/io/BUILD
+++ b/tensorflow/core/lib/io/BUILD
@@ -9,6 +9,7 @@ package(
         "//tensorflow/c/experimental/filesystem:__pkg__",
         "//tensorflow/c/experimental/filesystem/plugins/posix:__pkg__",
         "//tensorflow/core/lib/io/snappy:__pkg__",
+        "//tensorflow/core/lib/io/lz4:__pkg__",
         # tensorflow/core:lib effectively exposes all targets under tensorflow/core/lib/**
         "//tensorflow/core:__pkg__",
     ],
@@ -151,6 +152,8 @@ cc_library(
         ":snappy_inputstream",
         ":zlib_compression_options",
         ":zlib_inputstream",
+        ":lz4_compression_options",
+        ":lz4_inputstream",
         "//tensorflow/core/lib/core:coding",
         "//tensorflow/core/lib/core:errors",
         "//tensorflow/core/lib/core:stringpiece",
@@ -172,6 +175,8 @@ cc_library(
         ":snappy_outputbuffer",
         ":zlib_compression_options",
         ":zlib_outputbuffer",
+        ":lz4_compression_options",
+        ":lz4_outputbuffer",
         "//tensorflow/core/lib/core:coding",
         "//tensorflow/core/lib/core:status",
         "//tensorflow/core/lib/core:stringpiece",
@@ -202,6 +207,21 @@ alias(
 alias(
     name = "snappy_compression_options",
     actual = "//tensorflow/core/lib/io/snappy:snappy_compression_options",
+)
+
+alias(
+    name = "lz4_inputstream",
+    actual = "//tensorflow/core/lib/io/lz4:lz4_inputstream",
+)
+
+alias(
+    name = "lz4_outputbuffer",
+    actual = "//tensorflow/core/lib/io/lz4:lz4_outputbuffer",
+)
+
+alias(
+    name = "lz4_compression_options",
+    actual = "//tensorflow/core/lib/io/lz4:lz4_compression_options",
 )
 
 cc_library(
@@ -363,6 +383,9 @@ filegroup(
         "//tensorflow/core/lib/io/snappy:snappy_inputbuffer.h",
         "//tensorflow/core/lib/io/snappy:snappy_inputstream.h",
         "//tensorflow/core/lib/io/snappy:snappy_outputbuffer.h",
+        "//tensorflow/core/lib/io/lz4:lz4_compression_options.h",
+        "//tensorflow/core/lib/io/lz4:lz4_inputstream.h",
+        "//tensorflow/core/lib/io/lz4:lz4_outputbuffer.h",
     ],
     visibility = ["//tensorflow/core:__pkg__"],
 )
@@ -381,6 +404,7 @@ filegroup(
         "table_test.cc",
         "zlib_buffers_test.cc",
         "//tensorflow/core/lib/io/snappy:snappy_test.cc",
+        "//tensorflow/core/lib/io/lz4:lz4_test.cc",
     ],
     visibility = ["//tensorflow/core:__pkg__"],
 )
@@ -416,6 +440,9 @@ filegroup(
         "//tensorflow/core/lib/io/snappy:snappy_inputbuffer.h",
         "//tensorflow/core/lib/io/snappy:snappy_inputstream.h",
         "//tensorflow/core/lib/io/snappy:snappy_outputbuffer.h",
+        "//tensorflow/core/lib/io/lz4:lz4_compression_options.h",
+        "//tensorflow/core/lib/io/lz4:lz4_inputstream.h",
+        "//tensorflow/core/lib/io/lz4:lz4_outputbuffer.h",
     ],
     visibility = ["//tensorflow/core:__pkg__"],
 )

--- a/tensorflow/core/lib/io/compression.h
+++ b/tensorflow/core/lib/io/compression.h
@@ -24,6 +24,7 @@ extern const char kNone[];
 extern const char kGzip[];
 extern const char kSnappy[];
 extern const char kZlib[];
+extern const char kLz4[];
 
 }  // namespace compression
 }  // namespace io

--- a/tensorflow/core/lib/io/lz4/BUILD
+++ b/tensorflow/core/lib/io/lz4/BUILD
@@ -1,0 +1,85 @@
+# lz4 targets.
+
+load(
+    "//tensorflow:tensorflow.bzl",
+    "tf_cc_test",
+)
+load(
+    "//tensorflow/core/platform:rules_cc.bzl",
+    "cc_library",
+)
+
+package(
+    default_visibility = [
+        "//tensorflow/core/lib/io:__pkg__",
+    ],
+    licenses = ["notice"],
+)
+
+exports_files([
+    "lz4_compression_options.h",
+    "lz4_inputstream.h",
+    "lz4_outputbuffer.h",
+    "lz4_inputstream.cc",
+    "lz4_test.cc",
+])
+
+cc_library(
+    name = "lz4_outputbuffer",
+    srcs = ["lz4_outputbuffer.cc"],
+    hdrs = ["lz4_outputbuffer.h"],
+    deps = [
+        ":lz4_compression_options",
+        "//tensorflow/core/lib/core:status",
+        "//tensorflow/core/platform",
+        "//tensorflow/core/platform:env",
+        "//tensorflow/core/platform:macros",
+        "//tensorflow/core/platform:types",
+        "@lz4",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "lz4_inputstream",
+    srcs = ["lz4_inputstream.cc"],
+    hdrs = ["lz4_inputstream.h"],
+    deps = [
+        ":lz4_compression_options",
+        "//tensorflow/core/lib/io:inputstream_interface",
+        "//tensorflow/core/platform:env",
+        "//tensorflow/core/platform:errors",
+        "//tensorflow/core/platform:macros",
+        "//tensorflow/core/platform:types",
+        "@com_google_absl//absl/memory",
+        "@lz4",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "lz4_compression_options",
+    srcs = ["lz4_compression_options.cc"],
+    hdrs = ["lz4_compression_options.h"],
+    deps = [
+        "//tensorflow/core/platform:types",
+        "@lz4",
+    ],
+    alwayslink = True,
+)
+
+tf_cc_test(
+    name = "lz4_test",
+    srcs = ["lz4_test.cc"],
+    deps = [
+        ":lz4_compression_options",
+        ":lz4_inputstream",
+        ":lz4_outputbuffer",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:lib_internal",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+        "@lz4",
+    ],
+)

--- a/tensorflow/core/lib/io/lz4/lz4_compression_options.cc
+++ b/tensorflow/core/lib/io/lz4/lz4_compression_options.cc
@@ -1,4 +1,4 @@
-/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,18 +13,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/core/lib/io/compression.h"
+#include "tensorflow/core/lib/io/lz4/lz4_compression_options.h"
 
 namespace tensorflow {
 namespace io {
-namespace compression {
 
-const char kNone[] = "";
-const char kGzip[] = "GZIP";
-const char kSnappy[] = "SNAPPY";
-const char kZlib[] = "ZLIB";
-const char kLz4[] = "LZ4";
+Lz4CompressionOptions::Lz4CompressionOptions() {
+  // FIXME (adrian.castro): use LZ4 options
+  // input_buffer_size = LZ4_CStreamInSize();
+  // output_buffer_size = LZ4_DStreamOutSize();
 
-}  // namespace compression
+  // window_log = 0;                // default
+  // compression_level = 3;         // LZ4_CLEVEL_DEFAULT
+  // compression_strategy = 0;      // default
+  // nb_workers = 0;                // single-threaded by default
+  // flush_mode = LZ4_e_continue;  // LZ4_e_continue
+}
+
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow/core/lib/io/lz4/lz4_compression_options.h
+++ b/tensorflow/core/lib/io/lz4/lz4_compression_options.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,18 +13,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/core/lib/io/compression.h"
+#ifndef TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_COMPRESSION_OPTIONS_H_
+#define TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_COMPRESSION_OPTIONS_H_
+
+#include <lz4.h>
+
+#include "tensorflow/core/platform/types.h"
 
 namespace tensorflow {
 namespace io {
-namespace compression {
 
-const char kNone[] = "";
-const char kGzip[] = "GZIP";
-const char kSnappy[] = "SNAPPY";
-const char kZlib[] = "ZLIB";
-const char kLz4[] = "LZ4";
+class Lz4CompressionOptions {
+ public:
+  Lz4CompressionOptions();
 
-}  // namespace compression
+  static Lz4CompressionOptions DEFAULT();
+
+  int64 input_buffer_size;
+
+  int64 output_buffer_size;
+
+  int8 compression_level;
+
+  int8 compression_strategy;
+
+  // LZ4_EndDirective flush_mode;
+};
+
+inline Lz4CompressionOptions Lz4CompressionOptions::DEFAULT() {
+  return Lz4CompressionOptions();
+}
+
 }  // namespace io
 }  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_COMPRESSION_OPTIONS_H_

--- a/tensorflow/core/lib/io/lz4/lz4_compression_options.h
+++ b/tensorflow/core/lib/io/lz4/lz4_compression_options.h
@@ -16,7 +16,7 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_COMPRESSION_OPTIONS_H_
 #define TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_COMPRESSION_OPTIONS_H_
 
-#include <lz4.h>
+#include <lz4frame.h>
 
 #include "tensorflow/core/platform/types.h"
 

--- a/tensorflow/core/lib/io/lz4/lz4_inputstream.cc
+++ b/tensorflow/core/lib/io/lz4/lz4_inputstream.cc
@@ -22,44 +22,65 @@ limitations under the License.
 namespace tensorflow {
 namespace io {
 
+struct Lz4InputFrameDef {
+  Lz4InputFrameDef(const size_t input_buffer_bytes,
+                   const size_t output_buffer_bytes)
+      : input_buffer_(new char[input_buffer_bytes]),
+        output_buffer_(new char[output_buffer_bytes]) {
+    LZ4F_createDecompressionContext(&lz4f_dctx, LZ4F_VERSION);
+    next_in_byte_ = input_buffer_.get();
+    next_unread_byte_ = output_buffer_.get();
+    unread_bytes_ = 0;
+    avail_in_ = 0;
+  }
+
+  std::unique_ptr<char[]> input_buffer_;
+  char* next_in_byte_;  // Next unread byte to decompress
+  size_t avail_in_;     // Number of bytes available to be decompressed
+
+  std::unique_ptr<char[]> output_buffer_;  // Inflated buffer
+  char* next_unread_byte_;                 // Next unread byte in output_buffer_
+  size_t unread_bytes_;  // bytes left in the output_buffer_ not yet read.
+
+  LZ4F_decompressionContext_t lz4f_dctx;
+};
+
 Lz4InputStream::Lz4InputStream(InputStreamInterface* input_stream,
-                                 size_t input_buffer_bytes,
-                                 size_t output_buffer_bytes,
-                                 const Lz4CompressionOptions& lz4_options,
-                                 bool owns_input_stream)
+                               size_t input_buffer_bytes,
+                               size_t output_buffer_bytes,
+                               const Lz4CompressionOptions& lz4_options,
+                               bool owns_input_stream)
     : owns_input_stream_(owns_input_stream),
       input_stream_(input_stream),
-      input_buffer_(new char[input_buffer_bytes]),
       input_buffer_capacity_(input_buffer_bytes),
-      output_buffer_(new char[output_buffer_bytes]),
       output_buffer_capacity_(output_buffer_bytes),
       bytes_read_(0),
-      lz4_options_(lz4_options) {
+      lz4_options_(lz4_options),
+      lz4_frame_(
+          new Lz4InputFrameDef(input_buffer_bytes, output_buffer_bytes)) {
   InitLz4Buffer();
 }
 
 Lz4InputStream::Lz4InputStream(InputStreamInterface* input_stream,
-                                 size_t input_buffer_bytes,
-                                 size_t output_buffer_bytes,
-                                 const Lz4CompressionOptions& lz4_options)
+                               size_t input_buffer_bytes,
+                               size_t output_buffer_bytes,
+                               const Lz4CompressionOptions& lz4_options)
     : Lz4InputStream(input_stream, input_buffer_bytes, output_buffer_bytes,
-                      lz4_options, false) {}
+                     lz4_options, false) {}
 
 Lz4InputStream::~Lz4InputStream() {
   if (owns_input_stream_) {
     delete input_stream_;
   }
+  LZ4F_freeDecompressionContext(lz4_frame_->lz4f_dctx);
 }
 
-void Lz4InputStream::InitLz4Buffer() {
-}
+void Lz4InputStream::InitLz4Buffer() {}
 
-Status Lz4InputStream::Reset() {
-  return Status::OK();
-}
+Status Lz4InputStream::Reset() { return Status::OK(); }
 
 size_t Lz4InputStream::ReadBytesFromCache(size_t bytes_to_read,
-                                           tstring* result) {
+                                          tstring* result) {
   return 0;
 }
 
@@ -78,13 +99,9 @@ Status Lz4InputStream::ReadNBytes(int64 bytes_to_read, absl::Cord* result) {
 }
 #endif
 
-Status Lz4InputStream::Inflate() {
-  return Status::OK();
-}
+Status Lz4InputStream::Inflate() { return Status::OK(); }
 
-Status Lz4InputStream::ReadFromStream() {
-  return Status::OK();
-}
+Status Lz4InputStream::ReadFromStream() { return Status::OK(); }
 
 int64 Lz4InputStream::Tell() const { return bytes_read_; }
 

--- a/tensorflow/core/lib/io/lz4/lz4_inputstream.cc
+++ b/tensorflow/core/lib/io/lz4/lz4_inputstream.cc
@@ -1,0 +1,92 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/lib/io/lz4/lz4_inputstream.h"
+
+#include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/strcat.h"
+
+namespace tensorflow {
+namespace io {
+
+Lz4InputStream::Lz4InputStream(InputStreamInterface* input_stream,
+                                 size_t input_buffer_bytes,
+                                 size_t output_buffer_bytes,
+                                 const Lz4CompressionOptions& lz4_options,
+                                 bool owns_input_stream)
+    : owns_input_stream_(owns_input_stream),
+      input_stream_(input_stream),
+      input_buffer_(new char[input_buffer_bytes]),
+      input_buffer_capacity_(input_buffer_bytes),
+      output_buffer_(new char[output_buffer_bytes]),
+      output_buffer_capacity_(output_buffer_bytes),
+      bytes_read_(0),
+      lz4_options_(lz4_options) {
+  InitLz4Buffer();
+}
+
+Lz4InputStream::Lz4InputStream(InputStreamInterface* input_stream,
+                                 size_t input_buffer_bytes,
+                                 size_t output_buffer_bytes,
+                                 const Lz4CompressionOptions& lz4_options)
+    : Lz4InputStream(input_stream, input_buffer_bytes, output_buffer_bytes,
+                      lz4_options, false) {}
+
+Lz4InputStream::~Lz4InputStream() {
+  if (owns_input_stream_) {
+    delete input_stream_;
+  }
+}
+
+void Lz4InputStream::InitLz4Buffer() {
+}
+
+Status Lz4InputStream::Reset() {
+  return Status::OK();
+}
+
+size_t Lz4InputStream::ReadBytesFromCache(size_t bytes_to_read,
+                                           tstring* result) {
+  return 0;
+}
+
+Status Lz4InputStream::ReadNBytes(int64 bytes_to_read, tstring* result) {
+  return Status::OK();
+}
+
+#if defined(TF_CORD_SUPPORT)
+Status Lz4InputStream::ReadNBytes(int64 bytes_to_read, absl::Cord* result) {
+  // TODO(frankchn): Optimize this instead of bouncing through the buffer.
+  tstring buf;
+  TF_RETURN_IF_ERROR(ReadNBytes(bytes_to_read, &buf));
+  result->Clear();
+  result->Append(buf.data());
+  return Status::OK();
+}
+#endif
+
+Status Lz4InputStream::Inflate() {
+  return Status::OK();
+}
+
+Status Lz4InputStream::ReadFromStream() {
+  return Status::OK();
+}
+
+int64 Lz4InputStream::Tell() const { return bytes_read_; }
+
+}  // namespace io
+}  // namespace tensorflow

--- a/tensorflow/core/lib/io/lz4/lz4_inputstream.h
+++ b/tensorflow/core/lib/io/lz4/lz4_inputstream.h
@@ -22,10 +22,13 @@ limitations under the License.
 #include "tensorflow/core/platform/macros.h"
 #include "tensorflow/core/platform/types.h"
 
-#include <lz4.h>
+#include <lz4frame.h>
 
 namespace tensorflow {
 namespace io {
+
+// forward declaration
+struct Lz4InputFrameDef;
 
 class Lz4InputStream : public InputStreamInterface {
  public:
@@ -33,14 +36,14 @@ class Lz4InputStream : public InputStreamInterface {
   //
   // Takes ownership  of `input_stream` iff `owns_input_stream` is true.
   Lz4InputStream(InputStreamInterface* input_stream, size_t input_buffer_bytes,
-                  size_t output_buffer_bytes,
-                  const Lz4CompressionOptions& lz4_options,
-                  bool owns_input_stream);
+                 size_t output_buffer_bytes,
+                 const Lz4CompressionOptions& lz4_options,
+                 bool owns_input_stream);
 
   // Equivalent to the previous constructor with owns_input_stream=false.
   Lz4InputStream(InputStreamInterface* input_stream, size_t input_buffer_bytes,
-                  size_t output_buffer_bytes,
-                  const Lz4CompressionOptions& lz4_options);
+                 size_t output_buffer_bytes,
+                 const Lz4CompressionOptions& lz4_options);
 
   ~Lz4InputStream() override;
 
@@ -76,24 +79,16 @@ class Lz4InputStream : public InputStreamInterface {
   void InitLz4Buffer();
 
   const bool owns_input_stream_;
+  size_t input_buffer_capacity_;   // Size of input_buffer_
+  size_t output_buffer_capacity_;  // Size of output_buffer_
   InputStreamInterface* input_stream_;
-  std::unique_ptr<char[]> input_buffer_;
-  size_t input_buffer_capacity_;  // Size of input_buffer_
-  char* next_in_byte_;            // Next unread byte to decompress
-  size_t avail_in_;  // Number of bytes available to be decompressed
-  LZ4_inBuffer lz4_input_buffer_;
-
-  std::unique_ptr<char[]> output_buffer_;  // Inflated buffer
-  size_t output_buffer_capacity_;          // Size of output_buffer_
-  char* next_unread_byte_;                  // Next unread byte in output_buffer_
-  // bytes left in the output_buffer_ not yet read.
-  size_t unread_bytes_;
 
   // Specifies the number of decompressed bytes currently read.
   size_t bytes_read_;
 
   size_t last_return_;
 
+  std::unique_ptr<Lz4InputFrameDef> lz4_frame_;
   const Lz4CompressionOptions lz4_options_;
 
   TF_DISALLOW_COPY_AND_ASSIGN(Lz4InputStream);

--- a/tensorflow/core/lib/io/lz4/lz4_inputstream.h
+++ b/tensorflow/core/lib/io/lz4/lz4_inputstream.h
@@ -1,0 +1,105 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_INPUTSTREAM_H_
+#define TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_INPUTSTREAM_H_
+
+#include "tensorflow/core/lib/io/inputstream_interface.h"
+#include "tensorflow/core/lib/io/lz4/lz4_compression_options.h"
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/platform/macros.h"
+#include "tensorflow/core/platform/types.h"
+
+#include <lz4.h>
+
+namespace tensorflow {
+namespace io {
+
+class Lz4InputStream : public InputStreamInterface {
+ public:
+  // Creates a Lz4InputStream for `input_stream`.
+  //
+  // Takes ownership  of `input_stream` iff `owns_input_stream` is true.
+  Lz4InputStream(InputStreamInterface* input_stream, size_t input_buffer_bytes,
+                  size_t output_buffer_bytes,
+                  const Lz4CompressionOptions& lz4_options,
+                  bool owns_input_stream);
+
+  // Equivalent to the previous constructor with owns_input_stream=false.
+  Lz4InputStream(InputStreamInterface* input_stream, size_t input_buffer_bytes,
+                  size_t output_buffer_bytes,
+                  const Lz4CompressionOptions& lz4_options);
+
+  ~Lz4InputStream() override;
+
+  // Reads bytes_to_read bytes into *result, overwriting *result.
+  //
+  // Return Status codes:
+  // OK:           If successful.
+  // OUT_OF_RANGE: If there are not enough bytes to read before
+  //               the end of the stream.
+  // ABORTED:      If inflate() fails, we return the error code with the
+  //               error message in `z_stream_->msg`.
+  // others:       If reading from stream failed.
+  Status ReadNBytes(int64 bytes_to_read, tstring* result) override;
+
+#if defined(TF_CORD_SUPPORT)
+  Status ReadNBytes(int64 bytes_to_read, absl::Cord* result) override;
+#endif
+
+  int64 Tell() const override;
+
+  Status Reset() override;
+
+ private:
+  // Decompress the next chunk of data and place the data into the cache.
+  Status Inflate();
+
+  Status ReadFromStream();
+
+  // There may be bytes leftover from last read. We read them so that we don't
+  // lose them, and we optimize resources.
+  size_t ReadBytesFromCache(size_t bytes_to_read, tstring* result);
+
+  void InitLz4Buffer();
+
+  const bool owns_input_stream_;
+  InputStreamInterface* input_stream_;
+  std::unique_ptr<char[]> input_buffer_;
+  size_t input_buffer_capacity_;  // Size of input_buffer_
+  char* next_in_byte_;            // Next unread byte to decompress
+  size_t avail_in_;  // Number of bytes available to be decompressed
+  LZ4_inBuffer lz4_input_buffer_;
+
+  std::unique_ptr<char[]> output_buffer_;  // Inflated buffer
+  size_t output_buffer_capacity_;          // Size of output_buffer_
+  char* next_unread_byte_;                  // Next unread byte in output_buffer_
+  // bytes left in the output_buffer_ not yet read.
+  size_t unread_bytes_;
+
+  // Specifies the number of decompressed bytes currently read.
+  size_t bytes_read_;
+
+  size_t last_return_;
+
+  const Lz4CompressionOptions lz4_options_;
+
+  TF_DISALLOW_COPY_AND_ASSIGN(Lz4InputStream);
+};
+
+}  // namespace io
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_INPUTSTREAM_H_

--- a/tensorflow/core/lib/io/lz4/lz4_outputbuffer.cc
+++ b/tensorflow/core/lib/io/lz4/lz4_outputbuffer.cc
@@ -1,0 +1,97 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/lib/io/lz4/lz4_outputbuffer.h"
+
+namespace tensorflow {
+namespace io {
+
+Lz4OutputBuffer::Lz4OutputBuffer(WritableFile* file, int32 input_buffer_bytes,
+                                   int32 output_buffer_bytes,
+                                   const Lz4CompressionOptions& lz4_options)
+    : file_(file),
+      input_buffer_capacity_(input_buffer_bytes),
+      output_buffer_capacity_(output_buffer_bytes),
+      lz4_options_(lz4_options) {
+  InitLz4Buffer();
+}
+
+Lz4OutputBuffer::~Lz4OutputBuffer() {
+  size_t bytes_to_write = 0;
+  if (bytes_to_write > 0) {
+    LOG(WARNING) << "There is still data in the output buffer. "
+                 << "Possible data loss has occurred.";
+  }
+}
+
+void Lz4OutputBuffer::InitLz4Buffer() {
+}
+
+Status Lz4OutputBuffer::Append(StringPiece data) {
+  return Status::OK();
+}
+
+void Lz4OutputBuffer::AddToInputBuffer(StringPiece data) {
+}
+
+#if defined(TF_CORD_SUPPORT)
+Status Lz4OutputBuffer::Append(const absl::Cord& cord) {
+  for (absl::string_view fragment : cord.Chunks()) {
+    TF_RETURN_IF_ERROR(Append(fragment));
+  }
+  return Status::OK();
+}
+#endif
+
+Status Lz4OutputBuffer::Close() {
+  // Given that we do not own `file`, we don't close it.
+  TF_RETURN_IF_ERROR(Deflate());
+  TF_RETURN_IF_ERROR(FlushOutputBufferToFile());
+  return Status::OK();
+}
+
+Status Lz4OutputBuffer::Name(StringPiece* result) const {
+  return file_->Name(result);
+}
+
+Status Lz4OutputBuffer::Sync() {
+  TF_RETURN_IF_ERROR(Flush());
+  return file_->Sync();
+}
+
+Status Lz4OutputBuffer::Tell(int64* position) { return file_->Tell(position); }
+
+Status Lz4OutputBuffer::Flush() {
+  TF_RETURN_IF_ERROR(Deflate());
+  TF_RETURN_IF_ERROR(FlushOutputBufferToFile());
+  return file_->Flush();
+}
+
+int32 Lz4OutputBuffer::AvailableInputSpace() const {
+  return 0;
+}
+
+Status Lz4OutputBuffer::FlushOutputBufferToFile() {
+  return Status::OK();
+}
+
+Status Lz4OutputBuffer::DeflateBuffered() {}
+
+Status Lz4OutputBuffer::Deflate() {
+  return Status::OK();
+}
+
+}  // namespace io
+}  // namespace tensorflow

--- a/tensorflow/core/lib/io/lz4/lz4_outputbuffer.h
+++ b/tensorflow/core/lib/io/lz4/lz4_outputbuffer.h
@@ -16,7 +16,7 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_OUTPUTBUFFER_H_
 #define TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_OUTPUTBUFFER_H_
 
-#include <lz4.h>
+#include <lz4frame.h>
 
 #include <string>
 
@@ -29,6 +29,9 @@ limitations under the License.
 
 namespace tensorflow {
 namespace io {
+
+// forward declaration
+struct Lz4OutputFrameDef;
 
 // Compresses input data using Lz4 (https://github.com/facebook/lz4) and
 // writes to `file`.
@@ -56,8 +59,8 @@ class Lz4OutputBuffer : public WritableFile {
   // with sizes `input_buffer_bytes` and `output_buffer_bytes` respectively.
   // Does not take ownership of `file`.
   Lz4OutputBuffer(WritableFile* file, int32 input_buffer_bytes,
-                   int32 output_buffer_bytes,
-                   const Lz4CompressionOptions& lz4_options);
+                  int32 output_buffer_bytes,
+                  const Lz4CompressionOptions& lz4_options);
 
   // Per convention, the dtor does not call Flush() or Close(). We expect the
   // caller to call those manually when done.
@@ -115,6 +118,8 @@ class Lz4OutputBuffer : public WritableFile {
   WritableFile* file_;  // Not owned
   size_t input_buffer_capacity_;
   size_t output_buffer_capacity_;
+
+  std::unique_ptr<Lz4OutputFrameDef> lz4_frame_;
 
   const Lz4CompressionOptions lz4_options_;
 

--- a/tensorflow/core/lib/io/lz4/lz4_outputbuffer.h
+++ b/tensorflow/core/lib/io/lz4/lz4_outputbuffer.h
@@ -1,0 +1,127 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_OUTPUTBUFFER_H_
+#define TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_OUTPUTBUFFER_H_
+
+#include <lz4.h>
+
+#include <string>
+
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/lib/io/lz4/lz4_compression_options.h"
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/platform/macros.h"
+#include "tensorflow/core/platform/platform.h"
+#include "tensorflow/core/platform/types.h"
+
+namespace tensorflow {
+namespace io {
+
+// Compresses input data using Lz4 (https://github.com/facebook/lz4) and
+// writes to `file`.
+//
+// The input data is cached in a buffer of size `input_buffer_bytes`. When the
+// buffer does not have enough available space to fit new data (in the call to
+// `Write`), the contents of the buffer are compressed and sent to the output
+// buffer.
+//
+// The compressed output is buffered in a buffer of size `output_buffer_bytes`
+// which gets flushed to file when full.
+//
+// Output file format:
+// The output file consists of a sequence of compressed blocks. Each block
+// starts with a 4 byte header which stores the length (in bytes) of the
+// _compressed_ block _excluding_ this header. The compressed
+// block (excluding the 4 byte header) is a valid snappy block and can directly
+// be uncompressed using Snappy_Uncompress.
+
+class Lz4OutputBuffer : public WritableFile {
+ public:
+  // Create an Lz4OutputBuffer for `file` with two buffers that cache the
+  // 1. input data to be deflated
+  // 2. the deflated output
+  // with sizes `input_buffer_bytes` and `output_buffer_bytes` respectively.
+  // Does not take ownership of `file`.
+  Lz4OutputBuffer(WritableFile* file, int32 input_buffer_bytes,
+                   int32 output_buffer_bytes,
+                   const Lz4CompressionOptions& lz4_options);
+
+  // Per convention, the dtor does not call Flush() or Close(). We expect the
+  // caller to call those manually when done.
+  ~Lz4OutputBuffer() override;
+
+  // Adds `data` to the compression pipeline.
+  //
+  // The input data is buffered internally and will be written to disk at a
+  // later time. To immediately write contents to file call `Flush()`.
+  Status Append(StringPiece data) override;
+
+#if defined(TF_CORD_SUPPORT)
+  Status Append(const absl::Cord& cord) override;
+#endif
+
+  // Compresses any buffered input and writes all output to file. This must be
+  // called before the destructor to avoid any data loss.
+  //
+  // Contrary to `Flush()` this informs snappy that it should not expect any
+  // further input.
+  //
+  // After calling this, any further calls to `Write()`, `Flush()` or `Close()`
+  // will fail.
+  Status Close() override;
+
+  // Returns the name of the underlying file.
+  Status Name(StringPiece* result) const override;
+
+  // Deflates any cached input, writes all output to file and syncs it.
+  Status Sync() override;
+
+  // Returns the write position in the underlying file. The position does not
+  // reflect buffered, un-flushed data.
+  Status Tell(int64* position) override;
+
+  // Compresses any cached input and writes all output to file. This must be
+  // called before the destructor to avoid any data loss.
+  Status Flush();
+
+ private:
+  void InitLz4Buffer();
+  // Appends `data` to `input_buffer_`.
+  // Throws if `data.size()` > AvailableInputSpace().
+  void AddToInputBuffer(StringPiece data);
+
+  // Returns the total space available in `input_buffer_`.
+  int32 AvailableInputSpace() const;
+
+  Status FlushOutputBufferToFile();
+
+  Status DeflateBuffered();
+
+  Status Deflate();
+
+  WritableFile* file_;  // Not owned
+  size_t input_buffer_capacity_;
+  size_t output_buffer_capacity_;
+
+  const Lz4CompressionOptions lz4_options_;
+
+  TF_DISALLOW_COPY_AND_ASSIGN(Lz4OutputBuffer);
+};
+
+}  // namespace io
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_LIB_IO_LZ4_LZ4_OUTPUTBUFFER_H_

--- a/tensorflow/core/lib/io/lz4/lz4_test.cc
+++ b/tensorflow/core/lib/io/lz4/lz4_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,18 +13,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/core/lib/io/compression.h"
+#include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/lib/io/random_inputstream.h"
+#include "tensorflow/core/lib/io/lz4/lz4_compression_options.h"
+#include "tensorflow/core/lib/io/lz4/lz4_inputstream.h"
+#include "tensorflow/core/lib/io/lz4/lz4_outputbuffer.h"
+#include "tensorflow/core/lib/strings/strcat.h"
+#include "tensorflow/core/protobuf/error_codes.pb.h"
+
+#include <lz4.h>
 
 namespace tensorflow {
 namespace io {
-namespace compression {
 
-const char kNone[] = "";
-const char kGzip[] = "GZIP";
-const char kSnappy[] = "SNAPPY";
-const char kZlib[] = "ZLIB";
-const char kLz4[] = "LZ4";
-
-}  // namespace compression
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow/core/lib/io/lz4/lz4_test.cc
+++ b/tensorflow/core/lib/io/lz4/lz4_test.cc
@@ -15,17 +15,116 @@ limitations under the License.
 
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status_test_util.h"
-#include "tensorflow/core/lib/io/random_inputstream.h"
 #include "tensorflow/core/lib/io/lz4/lz4_compression_options.h"
 #include "tensorflow/core/lib/io/lz4/lz4_inputstream.h"
 #include "tensorflow/core/lib/io/lz4/lz4_outputbuffer.h"
+#include "tensorflow/core/lib/io/random_inputstream.h"
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/protobuf/error_codes.pb.h"
 
-#include <lz4.h>
+#include <lz4frame.h>
 
 namespace tensorflow {
 namespace io {
+
+static std::vector<int> InputBufferSizes() {
+  return {10, 100, 200, 500, 1000, 10000, 256 << 10};
+}
+
+static std::vector<int> OutputBufferSizes() {
+  return {100, 200, 500, 1000, 256 << 10};
+}
+
+static std::vector<int> NumCopies() { return {1, 50, 500, 5000}; }
+
+static string GetRecord() {
+  static const string el_dorado =
+      "Gaily bedight,"
+      "A gallant knight,"
+      "In sunshine and in shadow, Had journeyed long, Singing a song,"
+      "In search of Eldorado."
+      "But he grew old— This knight so bold— And o'er his heart a shadow— Fell"
+      "as he found No spot of ground That looked like Eldorado."
+      "And,"
+      "as his strength Failed him at length,"
+      "He met a pilgrim shadow— 'Shadow,' said he,"
+      "'Where can it be— This land of Eldorado ?'"
+      "'Over the Mountains Of the Moon, Down the Valley of the Shadow, Ride,"
+      "boldly ride,' The shade replied,— 'If you seek for Eldorado!'"
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut "
+      "condimentum, mauris sit amet euismod iaculis, sem dolor maximus turpis, "
+      "id cursus magna mauris eu lacus. Vivamus tincidunt ex vitae dolor "
+      "mattis sollicitudin. Nunc nec lacinia lacus. Maecenas sapien nulla, "
+      "volutpat eu maximus fermentum, sollicitudin id est. Nunc venenatis, "
+      "tortor eu pretium dignissim, enim leo elementum ex, nec fermentum ex "
+      "ipsum vitae velit. Ut commodo nunc vel nisi fringilla rhoncus. Cras ac "
+      "diam sapien. Etiam vel velit nec purus molestie gravida non a sem. "
+      "Pellentesque vulputate finibus eros sit amet placerat.";
+  return el_dorado;
+}
+
+static string GenTestString(int copies = 1) {
+  string result = "";
+  for (int i = 0; i < copies; i++) {
+    result += GetRecord();
+  }
+  return result;
+}
+
+typedef io::Lz4CompressionOptions CompressionOptions;
+
+void WriteCompressedFile(Env* env, const string& fname, int input_buf_size,
+                         int output_buf_size,
+                         const CompressionOptions& output_options,
+                         const string& data) {
+  std::unique_ptr<WritableFile> file_writer;
+  TF_ASSERT_OK(env->NewWritableFile(fname, &file_writer));
+
+  Lz4OutputBuffer out(file_writer.get(), input_buf_size, output_buf_size,
+                      output_options);
+
+  TF_ASSERT_OK(out.Append(StringPiece(data)));
+  TF_ASSERT_OK(out.Close());
+  TF_ASSERT_OK(file_writer->Flush());
+  TF_ASSERT_OK(file_writer->Close());
+}
+
+void ReadCompressedFile(Env* env, const string& fname, int input_buf_size,
+                        int output_buf_size,
+                        const CompressionOptions& input_options,
+                        const string& data) {
+  tstring result;
+  std::unique_ptr<RandomAccessFile> file_reader;
+  TF_ASSERT_OK(env->NewRandomAccessFile(fname, &file_reader));
+  std::unique_ptr<RandomAccessInputStream> input_stream(
+      new RandomAccessInputStream(file_reader.get()));
+
+  Lz4InputStream in(input_stream.get(), input_buf_size, output_buf_size,
+                    input_options);
+  TF_ASSERT_OK(in.ReadNBytes(data.size(), &result));
+  EXPECT_EQ(result, data);
+}
+
+void TestAllCombinations(CompressionOptions input_options,
+                         CompressionOptions output_options) {
+  Env* env = Env::Default();
+  string fname;
+  ASSERT_TRUE(env->LocalTempFilename(&fname));
+  for (auto file_size : NumCopies()) {
+    // Write to compressed file
+    string data = GenTestString(file_size);
+    for (auto input_buf_size : InputBufferSizes()) {
+      for (auto output_buf_size : OutputBufferSizes()) {
+        WriteCompressedFile(env, fname, input_buf_size, output_buf_size,
+                            output_options, data);
+        ReadCompressedFile(env, fname, input_buf_size, output_buf_size,
+                           input_options, data);
+      }
+    }
+  }
+}
+
+TEST(Lz4Frame, DefaultOptions) {}
 
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow/core/lib/io/record_reader.h
+++ b/tensorflow/core/lib/io/record_reader.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/core/lib/io/snappy/snappy_inputstream.h"
 #include "tensorflow/core/lib/io/zlib_compression_options.h"
 #include "tensorflow/core/lib/io/zlib_inputstream.h"
+#include "tensorflow/core/lib/io/lz4/lz4_compression_options.h"
 #endif  // IS_SLIM_BUILD
 #include "tensorflow/core/platform/macros.h"
 #include "tensorflow/core/platform/types.h"
@@ -38,7 +39,8 @@ struct RecordReaderOptions {
   enum CompressionType {
     NONE = 0,
     ZLIB_COMPRESSION = 1,
-    SNAPPY_COMPRESSION = 2
+    SNAPPY_COMPRESSION = 2,
+    LZ4_COMPRESSION = 3
   };
   CompressionType compression_type = NONE;
 
@@ -54,6 +56,7 @@ struct RecordReaderOptions {
   // Options specific to compression.
   ZlibCompressionOptions zlib_options;
   SnappyCompressionOptions snappy_options;
+  Lz4CompressionOptions lz4_options;
 #endif  // IS_SLIM_BUILD
 };
 

--- a/tensorflow/core/lib/io/record_writer.h
+++ b/tensorflow/core/lib/io/record_writer.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/core/lib/io/snappy/snappy_outputbuffer.h"
 #include "tensorflow/core/lib/io/zlib_compression_options.h"
 #include "tensorflow/core/lib/io/zlib_outputbuffer.h"
+#include "tensorflow/core/lib/io/lz4/lz4_compression_options.h"
 #endif  // IS_SLIM_BUILD
 #include "tensorflow/core/platform/cord.h"
 #include "tensorflow/core/platform/macros.h"
@@ -41,7 +42,8 @@ struct RecordWriterOptions {
   enum CompressionType {
     NONE = 0,
     ZLIB_COMPRESSION = 1,
-    SNAPPY_COMPRESSION = 2
+    SNAPPY_COMPRESSION = 2,
+    LZ4_COMPRESSION = 3
   };
   CompressionType compression_type = NONE;
 
@@ -52,6 +54,7 @@ struct RecordWriterOptions {
   // Options specific to compression.
   tensorflow::io::ZlibCompressionOptions zlib_options;
   tensorflow::io::SnappyCompressionOptions snappy_options;
+  tensorflow::io::Lz4CompressionOptions lz4_options;
 #endif  // IS_SLIM_BUILD
 };
 

--- a/tensorflow/core/lib/io/recordio_test.cc
+++ b/tensorflow/core/lib/io/recordio_test.cc
@@ -292,10 +292,16 @@ TEST_F(RecordioTest, NonSequentialReadsWithReadBuffer) {
   TestNonSequentialReads(RecordWriterOptions(), options);
 }
 
-TEST_F(RecordioTest, NonSequentialReadsWithCompression) {
+TEST_F(RecordioTest, NonSequentialReadsWithZlibCompression) {
   TestNonSequentialReads(
       RecordWriterOptions::CreateRecordWriterOptions("ZLIB"),
       RecordReaderOptions::CreateRecordReaderOptions("ZLIB"));
+}
+
+TEST_F(RecordioTest, NonSequentialReadsWithLz4Compression) {
+  TestNonSequentialReads(
+      RecordWriterOptions::CreateRecordWriterOptions("LZ4"),
+      RecordReaderOptions::CreateRecordReaderOptions("LZ4"));
 }
 
 // Tests of all the error paths in log_reader.cc follow:
@@ -339,9 +345,14 @@ TEST_F(RecordioTest, ReadErrorWithBuffering) {
   TestReadError(RecordWriterOptions(), options);
 }
 
-TEST_F(RecordioTest, ReadErrorWithCompression) {
+TEST_F(RecordioTest, ReadErrorWithZlibCompression) {
   TestReadError(RecordWriterOptions::CreateRecordWriterOptions("ZLIB"),
                 RecordReaderOptions::CreateRecordReaderOptions("ZLIB"));
+}
+
+TEST_F(RecordioTest, ReadErrorWithLz4Compression) {
+  TestReadError(RecordWriterOptions::CreateRecordWriterOptions("LZ4"),
+                RecordReaderOptions::CreateRecordReaderOptions("LZ4"));
 }
 
 TEST_F(RecordioTest, CorruptLength) {

--- a/tensorflow/core/platform/default/build_config/BUILD
+++ b/tensorflow/core/platform/default/build_config/BUILD
@@ -166,6 +166,7 @@ cc_library(
         "@fft2d",
         "@highwayhash//:sip_hash",
         "@zlib",
+        "@lz4",
     ],
 )
 

--- a/tensorflow/opensource_only.files
+++ b/tensorflow/opensource_only.files
@@ -304,6 +304,7 @@ third_party/systemlibs/sqlite.BUILD:
 third_party/systemlibs/syslibs_configure.bzl:
 third_party/systemlibs/termcolor.BUILD:
 third_party/systemlibs/zlib.BUILD:
+third_party/systemlibs/lz4.BUILD
 third_party/tblib.BUILD:
 third_party/tensorrt/BUILD.tpl:
 third_party/tensorrt/BUILD:
@@ -324,3 +325,4 @@ third_party/tflite_smartreply.BUILD:
 third_party/typing_extensions.BUILD:
 third_party/wrapt.BUILD:
 third_party/zlib.BUILD:
+third_party/lz4.BUILD

--- a/tensorflow/python/data/experimental/kernel_tests/tf_record_writer_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/tf_record_writer_test.py
@@ -85,6 +85,15 @@ class TFRecordWriterTest(test_base.DatasetTestBase, parameterized.TestCase):
       self.assertAllEqual(self._record(i), r)
 
   @combinations.generate(test_base.default_test_combinations())
+  def testWriteLZ4(self):
+    options = tf_record.TFRecordOptions(tf_record.TFRecordCompressionType.LZ4)
+    self.evaluate(
+        self.writer_fn(self._createFile(options), compression_type="LZ4"))
+    for i, r in enumerate(
+        tf_record.tf_record_iterator(self._outputFilename(), options=options)):
+      self.assertAllEqual(self._record(i), r)
+
+  @combinations.generate(test_base.default_test_combinations())
   def testFailDataset(self):
     with self.assertRaises(TypeError):
       writers.TFRecordWriter(self._outputFilename(), "").write("whoops")

--- a/tensorflow/python/kernel_tests/io_ops/reader_ops_test.py
+++ b/tensorflow/python/kernel_tests/io_ops/reader_ops_test.py
@@ -703,6 +703,23 @@ class TFRecordReaderTest(TFCompressionTestCase):
         self.assertTrue(compat.as_text(k).startswith("%s:" % files[i]))
         self.assertAllEqual(self._Record(i, j), v)
 
+  @test_util.run_deprecated_v1
+  def testReadLz4Files(self):
+    options = tf_record.TFRecordOptions(TFRecordCompressionType.LZ4)
+    files = self._CreateFiles(options)
+
+    reader = io_ops.TFRecordReader(name="test_reader", options=options)
+    queue = data_flow_ops.FIFOQueue(99, [dtypes.string], shapes=())
+    key, value = reader.read(queue)
+
+    self.evaluate(queue.enqueue_many([files]))
+    self.evaluate(queue.close())
+    for i in range(self._num_files):
+      for j in range(self._num_records):
+        k, v = self.evaluate([key, value])
+        self.assertTrue(compat.as_text(k).startswith("%s:" % files[i]))
+        self.assertAllEqual(self._Record(i, j), v)
+
 
 class AsyncReaderTest(test.TestCase):
 

--- a/tensorflow/python/lib/io/record_io_wrapper.cc
+++ b/tensorflow/python/lib/io/record_io_wrapper.cc
@@ -316,11 +316,29 @@ PYBIND11_MODULE(_pywrap_record_io, m) {
       .def_readwrite("compression_strategy",
                      &ZlibCompressionOptions::compression_strategy);
 
+  using tensorflow::io::Lz4CompressionOptions;
+  py::class_<Lz4CompressionOptions>(m, "Lz4CompressionOptions")
+      .def_readwrite("input_buffer_size",
+                     &Lz4CompressionOptions::input_buffer_size)
+      .def_readwrite("output_buffer_size",
+                     &Lz4CompressionOptions::output_buffer_size)
+      .def_readwrite("flush_mode",
+                     &Lz4CompressionOptions::flush_mode)
+      .def_readwrite("nb_workers",
+                     &Lz4CompressionOptions::nb_workers)
+      .def_readwrite("compression_level",
+                     &Lz4CompressionOptions::compression_level)
+      .def_readwrite("compression_strategy",
+                     &Lz4CompressionOptions::compression_strategy)
+      .def_readwrite("window_log",
+                     &Lz4CompressionOptions::window_log);
+
   using tensorflow::io::RecordWriterOptions;
   py::class_<RecordWriterOptions>(m, "RecordWriterOptions")
       .def(py::init(&RecordWriterOptions::CreateRecordWriterOptions))
       .def_readonly("compression_type", &RecordWriterOptions::compression_type)
-      .def_readonly("zlib_options", &RecordWriterOptions::zlib_options);
+      .def_readonly("zlib_options", &RecordWriterOptions::zlib_options)
+      .def_readonly("lz4_options", &RecordWriterOptions::lz4_options);
 
   using tensorflow::MaybeRaiseRegisteredFromStatus;
 

--- a/tensorflow/python/lib/io/tf_record.py
+++ b/tensorflow/python/lib/io/tf_record.py
@@ -30,6 +30,7 @@ class TFRecordCompressionType(object):
   NONE = 0
   ZLIB = 1
   GZIP = 2
+  LZ4 = 3
 
 
 @tf_export(
@@ -41,6 +42,7 @@ class TFRecordOptions(object):
   compression_type_map = {
       TFRecordCompressionType.ZLIB: "ZLIB",
       TFRecordCompressionType.GZIP: "GZIP",
+      TFRecordCompressionType.LZ4: "LZ4",
       TFRecordCompressionType.NONE: ""
   }
 
@@ -53,7 +55,14 @@ class TFRecordOptions(object):
                compression_level=None,
                compression_method=None,
                mem_level=None,
-               compression_strategy=None):
+               compression_strategy=None,
+               lz4_input_buffer_size=None,
+               lz4_output_buffer_size=None,
+               lz4_flush_mode=None,
+               lz4_nb_workers=None,
+               lz4_compression_level=None,
+               lz4_compression_strategy=None,
+               lz4_window_log=None):
     # pylint: disable=line-too-long
     """Creates a `TFRecordOptions` instance.
 
@@ -61,10 +70,12 @@ class TFRecordOptions(object):
     Documentation, details, and defaults can be found in
     [`zlib_compression_options.h`](https://www.tensorflow.org/code/tensorflow/core/lib/io/zlib_compression_options.h)
     and in the [zlib manual](http://www.zlib.net/manual.html).
+    For documentation options and details prefixed by `lz4_*`, find the
+    documentation in the [lz4 manual](https://facebook.github.io/lz4/lz4_manual.html).
     Leaving an option as `None` allows C++ to set a reasonable default.
 
     Args:
-      compression_type: `"GZIP"`, `"ZLIB"`, or `""` (no compression).
+      compression_type: `"GZIP"`, `"ZLIB"`, `"LZ4"` or `""` (no compression).
       flush_mode: flush mode or `None`, Default: Z_NO_FLUSH.
       input_buffer_size: int or `None`.
       output_buffer_size: int or `None`.
@@ -73,6 +84,13 @@ class TFRecordOptions(object):
       compression_method: compression method or `None`.
       mem_level: 1 to 9, or `None`.
       compression_strategy: strategy or `None`. Default: Z_DEFAULT_STRATEGY.
+      lz4_input_buffer_size: int or `None`. 
+      lz4_output_buffer_size: int or `None`.
+      lz4_flush_mode: int or `None`.
+      lz4_nb_workers: int or `None`.
+      lz4_compression_level: 0 to 19, or `None`. Default: LZ4_CLEVEL_DEFAULT.
+      lz4_compression_strategy: 0 to 9, or `None`. Default: 0.
+      lz4_window_log: between LZ4_WINDOWLOG_MIN and LZ4_WINDOWLOG_MAX. Default: 0.
 
     Returns:
       A `TFRecordOptions` object.
@@ -93,6 +111,13 @@ class TFRecordOptions(object):
     self.compression_method = compression_method
     self.mem_level = mem_level
     self.compression_strategy = compression_strategy
+    self.lz4_input_buffer_size = lz4_input_buffer_size
+    self.lz4_output_buffer_size = lz4_output_buffer_size
+    self.lz4_flush_mode = lz4_flush_mode
+    self.lz4_nb_workers = lz4_nb_workers
+    self.lz4_compression_level = lz4_compression_level
+    self.lz4_compression_strategy = lz4_compression_strategy
+    self.lz4_window_log = lz4_window_log
 
   @classmethod
   def get_compression_type_string(cls, options):
@@ -102,7 +127,7 @@ class TFRecordOptions(object):
       options: `TFRecordOption`, `TFRecordCompressionType`, or string.
 
     Returns:
-      Compression type as string (e.g. `'ZLIB'`, `'GZIP'`, or `''`).
+      Compression type as string (e.g. `'ZLIB'`, `'GZIP'`, `'LZ4'`, or `''`).
 
     Raises:
       ValueError: If compression_type is invalid.
@@ -142,6 +167,20 @@ class TFRecordOptions(object):
       options.zlib_options.mem_level = self.mem_level
     if self.compression_strategy is not None:
       options.zlib_options.compression_strategy = self.compression_strategy
+    if self.lz4_input_buffer_size is not None:
+      options.lz4_options.input_buffer_size = self.lz4_input_buffer_size
+    if self.lz4_output_buffer_size is not None:
+      options.lz4_options.output_buffer_size = self.lz4_output_buffer_size
+    if self.lz4_flush_mode is not None:
+      options.lz4_options.flush_mode = self.lz4_flush_mode
+    if self.lz4_nb_workers is not None:
+      options.lz4_options.nb_workers = self.lz4_nb_workers
+    if self.lz4_compression_level is not None:
+      options.lz4_options.compression_level = self.lz4_compression_level
+    if self.lz4_compression_strategy is not None:
+      options.lz4_options.compression_strategy = self.lz4_compression_strategy
+    if self.lz4_window_log is not None:
+      options.lz4_options.window_log = self.lz4_window_log
     return options
 
 

--- a/tensorflow/python/lib/io/tf_record_test.py
+++ b/tensorflow/python/lib/io/tf_record_test.py
@@ -286,6 +286,25 @@ class TFRecordWriterTest(TFCompressionTestCase):
           "Setting {} = {}, file was {} smaller didn't match sign of {}".format(
               prop, value, delta, delta_sign))
 
+  def testLz4CompressionType(self):
+    """test Lz4 Compression Type"""
+    lz4_t = tf_record.TFRecordCompressionType.LZ4
+
+    self.assertEqual(
+        "LZ4",
+        tf_record.TFRecordOptions.get_compression_type_string(
+            tf_record.TFRecordOptions("LZ4")))
+
+    self.assertEqual(
+        "LZ4",
+        tf_record.TFRecordOptions.get_compression_type_string(
+            tf_record.TFRecordOptions(lz4_t)))
+
+    self.assertEqual(
+        "LZ4",
+        tf_record.TFRecordOptions.get_compression_type_string(
+            tf_record.TFRecordOptions(tf_record.TFRecordOptions(lz4_t))))
+
 
 class TFRecordWriterZlibTest(TFCompressionTestCase):
   """TFRecordWriter Zlib test"""

--- a/tensorflow/tools/api/golden/v1/tensorflow.io.-t-f-record-compression-type.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.io.-t-f-record-compression-type.pbtxt
@@ -14,6 +14,10 @@ tf_class {
     name: "ZLIB"
     mtype: "<type \'int\'>"
   }
+  member {
+    name: "LZ4"
+    mtype: "<type \'int\'>"
+  }
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.io.-t-f-record-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.io.-t-f-record-options.pbtxt
@@ -8,7 +8,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'compression_type\', \'flush_mode\', \'input_buffer_size\', \'output_buffer_size\', \'window_bits\', \'compression_level\', \'compression_method\', \'mem_level\', \'compression_strategy\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\'], "
+    argspec: "args=[\'self\', \'compression_type\', \'flush_mode\', \'input_buffer_size\', \'output_buffer_size\', \'window_bits\', \'compression_level\', \'compression_method\', \'mem_level\', \'compression_strategy\', \'lz4_input_buffer_size\', \'lz4_output_buffer_size\', \'lz4_flush_mode\', \'lz4_nb_workers\', \'lz4_compression_level\', \'lz4_compression_strategy\', \'lz4_window_log\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\'], "
   }
   member_method {
     name: "get_compression_type_string"

--- a/tensorflow/tools/api/golden/v1/tensorflow.python_io.-t-f-record-compression-type.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.python_io.-t-f-record-compression-type.pbtxt
@@ -14,6 +14,10 @@ tf_class {
     name: "ZLIB"
     mtype: "<type \'int\'>"
   }
+  member {
+    name: "LZ4"
+    mtype: "<type \'int\'>"
+  }
   member_method {
     name: "__init__"
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.python_io.-t-f-record-options.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.python_io.-t-f-record-options.pbtxt
@@ -8,7 +8,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'compression_type\', \'flush_mode\', \'input_buffer_size\', \'output_buffer_size\', \'window_bits\', \'compression_level\', \'compression_method\', \'mem_level\', \'compression_strategy\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\'], "
+    argspec: "args=[\'self\', \'compression_type\', \'flush_mode\', \'input_buffer_size\', \'output_buffer_size\', \'window_bits\', \'compression_level\', \'compression_method\', \'mem_level\', \'compression_strategy\', \'lz4_input_buffer_size\', \'lz4_output_buffer_size\', \'lz4_flush_mode\', \'lz4_nb_workers\', \'lz4_compression_level\', \'lz4_compression_strategy\', \'lz4_window_log\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\'], "
   }
   member_method {
     name: "get_compression_type_string"

--- a/tensorflow/tools/api/golden/v2/tensorflow.io.-t-f-record-options.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.io.-t-f-record-options.pbtxt
@@ -8,7 +8,7 @@ tf_class {
   }
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'compression_type\', \'flush_mode\', \'input_buffer_size\', \'output_buffer_size\', \'window_bits\', \'compression_level\', \'compression_method\', \'mem_level\', \'compression_strategy\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\'], "
+    argspec: "args=[\'self\', \'compression_type\', \'flush_mode\', \'input_buffer_size\', \'output_buffer_size\', \'window_bits\', \'compression_level\', \'compression_method\', \'mem_level\', \'compression_strategy\', \'lz4_input_buffer_size\', \'lz4_output_buffer_size\', \'lz4_flush_mode\', \'lz4_nb_workers\', \'lz4_compression_level\', \'lz4_compression_strategy\', \'lz4_window_log\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\', \'None\'], "
   }
   member_method {
     name: "get_compression_type_string"

--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -162,6 +162,7 @@ genrule(
         "@png//:LICENSE",
         "@snappy//:COPYING",
         "@zlib//:zlib.h",
+        "@lz4//:LICENSE",
     ] + select({
         "//tensorflow:android": [],
         "//tensorflow:ios": [],
@@ -234,6 +235,7 @@ genrule(
         "@png//:LICENSE",
         "@snappy//:COPYING",
         "@zlib//:zlib.h",
+        "@lz4//:LICENSE",
     ] + select({
         "//tensorflow:android": [],
         "//tensorflow:ios": [],

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -230,6 +230,7 @@ filegroup(
         "@termcolor_archive//:COPYING.txt",
         "@typing_extensions_archive//:LICENSE",
         "@zlib//:zlib.h",
+        "@lz4//:LICENSE",
     ] + select({
         "//tensorflow:android": [],
         "//tensorflow:ios": [],

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -560,7 +560,15 @@ def _tf_repositories():
         urls = tf_mirror_urls("https://zlib.net/zlib-1.2.11.tar.gz"),
     )
 
-    # LINT.IfChange
+    tf_http_archive(
+        name = "lz4",
+        build_file = "//third_party:lz4.BUILD",
+        sha256 = "030644df4611007ff7dc962d981f390361e6c97a34e5cbc393ddfbe019ffe2c1",
+        strip_prefix = "lz4-1.9.3",
+        system_build_file = "//third_party/systemlibs:lz4.BUILD",
+        urls = tf_mirror_urls("https://github.com/lz4/lz4/archive/refs/tags/v1.9.3.tar.gz"),
+    )
+
     tf_http_archive(
         name = "fft2d",
         build_file = "//third_party/fft2d:fft2d.BUILD",

--- a/third_party/lz4.BUILD
+++ b/third_party/lz4.BUILD
@@ -1,0 +1,21 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["LICENSE"])
+
+licenses(["notice"])
+
+cc_library(
+    name = "lz4",
+    srcs = glob([
+        "lib/*.c",
+        "lib/*.h"
+    ]),
+    hdrs = ["lib/lz4.h"],
+    copts = [
+    ],
+    includes = ["lib/"],
+    linkopts = select({
+        "@org_tensorflow//tensorflow:windows": [],
+        "//conditions:default": [],
+    }),
+)

--- a/third_party/lz4.BUILD
+++ b/third_party/lz4.BUILD
@@ -10,7 +10,7 @@ cc_library(
         "lib/*.c",
         "lib/*.h"
     ]),
-    hdrs = ["lib/lz4.h"],
+    hdrs = ["lib/lz4frame.h"],
     copts = [
     ],
     includes = ["lib/"],

--- a/third_party/systemlibs/lz4.BUILD
+++ b/third_party/systemlibs/lz4.BUILD
@@ -1,6 +1,6 @@
 licenses(["notice"])  # BSD/MIT-like license (for lz4)
 
 cc_library(
-    name = "lz4.h",
+    name = "lz4frame.h",
     visibility = ["//visibility:public"],
 )

--- a/third_party/systemlibs/lz4.BUILD
+++ b/third_party/systemlibs/lz4.BUILD
@@ -1,0 +1,6 @@
+licenses(["notice"])  # BSD/MIT-like license (for lz4)
+
+cc_library(
+    name = "lz4.h",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Related to https://github.com/tensorflow/tensorflow/pull/53385

The current API of `TFRecordOptions` only supports:
- no compression
- GZIP compression
- ZLIB compression

With this PR, I have added support for a 4th compression algorithm, LZ4: https://github.com/lz4/lz4

The API for `TFRecordOptions` is therefore updated to accept the following parameters:

```
      compression_type: `"GZIP"`, `"ZLIB"`, `"LZ4"` or `""` (no compression).
      TODO
```

Maintaining backward compatibility with the current API.