### PR TITLE
fix cmake build error for tflite c library

### DIFF
--- a/tensorflow/lite/c/CMakeLists.txt
+++ b/tensorflow/lite/c/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 add_library(tensorflowlite_c ${TFLITE_C_LIBTYPE}
   builtin_op_data.h
   common.h
-  common.c
+  common.cc
   c_api_types.h
   c_api.h
   c_api.cc


### PR DESCRIPTION
Fix cmake error when building tflite C library:

```
CMake Error at CMakeLists.txt:63 (add_library):
  Cannot find source file:

    common.c

```