### PR TITLE
Use the attribute `_shape` in `ReadVariableOp` shape inference if found

### DIFF
--- a/tensorflow/core/ops/resource_variable_ops.cc
+++ b/tensorflow/core/ops/resource_variable_ops.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 // ============================================================================
 
+#include <algorithm>
+
 #include "tensorflow/core/framework/common_shape_fns.h"
 #include "tensorflow/core/framework/function.h"
 #include "tensorflow/core/framework/node_def_util.h"
@@ -30,15 +32,28 @@ namespace tensorflow {
 namespace {
 
 Status ReadVariableShapeFn(InferenceContext* c) {
-  std::vector<ShapeAndType> shape_and_type;
-  TF_RETURN_IF_ERROR(
-      shape_inference::ValidateVariableResourceHandle(c, &shape_and_type));
-  c->set_output(0, shape_and_type[0].shape);
-  if (shape_and_type[0].dtype == DT_VARIANT && shape_and_type.size() > 1) {
-    std::vector<ShapeAndType> variant_shape_and_type;
-    std::copy(shape_and_type.begin() + 1, shape_and_type.end(),
-              std::back_inserter(variant_shape_and_type));
-    c->set_output_handle_shapes_and_types(0, variant_shape_and_type);
+  // The user can add a "_shape" atribute to ReadVariableOp nodes. It is
+  // useful for inferring shapes in a function, when no shape information
+  // is passed about input resources. The user can annotate the graph using
+  // the variable capture list of the function.
+  // If the "_shape" attribute is found, it is used to set the output shape.
+  PartialTensorShape p;
+  Status annotation_found_status = c->GetAttr("_shape", &p);
+  if (annotation_found_status.ok()) {
+    ShapeHandle s;
+    TF_RETURN_IF_ERROR(c->MakeShapeFromPartialTensorShape(p, &s));
+    c->set_output(0, s);
+  } else {
+    std::vector<ShapeAndType> shape_and_type;
+    TF_RETURN_IF_ERROR(
+        shape_inference::ValidateVariableResourceHandle(c, &shape_and_type));
+    c->set_output(0, shape_and_type[0].shape);
+    if (shape_and_type[0].dtype == DT_VARIANT && shape_and_type.size() > 1) {
+      std::vector<ShapeAndType> variant_shape_and_type;
+      std::copy(shape_and_type.begin() + 1, shape_and_type.end(),
+                std::back_inserter(variant_shape_and_type));
+      c->set_output_handle_shapes_and_types(0, variant_shape_and_type);
+    }
   }
   return Status::OK();
 }


### PR DESCRIPTION
This PR is a workaround to fix shape inference of `ReadVariableOp` nodes when a graph gets resource inputs and we can't infer the shapes of the variables. The nodes need to be annotated beforehand with an attribute `shape`.

Context and code sample illustrating the problem in the comments.

This is only a temporary solution, ideally, shape inference should handle resource inputs (similarly to how it can get shapes of the inputs when `assume_valid_feeds == true`).