### PR TITLE
[TF:TRT] Elide log messages when qdq mode is off

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.cc
@@ -304,8 +304,6 @@ Status TRTOptimizationPass::Optimize(grappler::Cluster* cluster,
       precision_mode_ = TrtPrecisionMode::INT8;
       use_calibration_ = false;
     }
-  } else {
-    LOG(INFO) << "[TF-TRT] not using explicit QDQ mode";
   }
 
   std::vector<string> nodes_to_preserve;

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -434,11 +434,6 @@ TRTEngineOp::TRTEngineOp(OpKernelConstruction* context)
     use_explicit_precision_ = false;
   }
 
-  if (use_explicit_precision_) {
-    LOG(INFO) << "TRTEngineOp using explicit QDQ";
-  } else {
-    LOG(INFO) << "TRTEngineOp not using explicit QDQ";
-  }
 
   native_execution_func_handle_ = kInvalidHandle;
   if (!static_engine_) {


### PR DESCRIPTION
This change removes log messages notifying users that QDQ mode is not enabled. Since this is not surprising for the majority of users, and log messages appear to notify users that QDQ mode is enabled, the "not enabled" log messages are superfluous.