### PR TITLE
Allow constant folding to remove add instructions used by compares

### DIFF
--- a/tensorflow/compiler/xla/service/algebraic_simplifier.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier.cc
@@ -3215,6 +3215,24 @@ Status AlgebraicSimplifierVisitor::HandleCompare(HloInstruction* compare) {
         return ReplaceInstruction(compare, MakeScalarLike(compare, true));
     }
   }
+  {
+    // Replacing compare(X + C, K) => compare(X, K - C)
+    // This allows constant folding on the right hand side to remove
+    // the addition.
+    HloInstruction * add_operand;
+    HloInstruction * lhs_delta;
+    if (Match(compare,
+              m::Compare(m::Add(m::Op(&add_operand),
+                                m::Constant(&lhs_delta)),
+                         m::Constant()))) {
+      return ReplaceWithNewInstruction(
+          compare,
+          compare->CloneWithNewOperands(
+              compare->shape(),
+              {add_operand, computation_->AddInstruction(HloInstruction::CreateBinary(
+                        lhs->shape(), HloOpcode::kSubtract, rhs, lhs_delta))}));
+    }
+  }
   return Status::OK();
 }
 

--- a/tensorflow/compiler/xla/service/algebraic_simplifier.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier.cc
@@ -3230,7 +3230,7 @@ Status AlgebraicSimplifierVisitor::HandleCompare(HloInstruction* compare) {
               compare->shape(),
               {add_operand,
                computation_->AddInstruction(HloInstruction::CreateBinary(
-                   lhs->shape(), HloOpcode::kSubtract, rhs, lhs_delta))}));
+                   rhs->shape(), HloOpcode::kSubtract, rhs, lhs_delta))}));
     }
   }
   return Status::OK();

--- a/tensorflow/compiler/xla/service/algebraic_simplifier.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier.cc
@@ -3219,18 +3219,18 @@ Status AlgebraicSimplifierVisitor::HandleCompare(HloInstruction* compare) {
     // Replacing compare(X + C, K) => compare(X, K - C)
     // This allows constant folding on the right hand side to remove
     // the addition.
-    HloInstruction * add_operand;
-    HloInstruction * lhs_delta;
+    HloInstruction* add_operand;
+    HloInstruction* lhs_delta;
     if (Match(compare,
-              m::Compare(m::Add(m::Op(&add_operand),
-                                m::Constant(&lhs_delta)),
+              m::Compare(m::Add(m::Op(&add_operand), m::Constant(&lhs_delta)),
                          m::Constant()))) {
       return ReplaceWithNewInstruction(
           compare,
           compare->CloneWithNewOperands(
               compare->shape(),
-              {add_operand, computation_->AddInstruction(HloInstruction::CreateBinary(
-                        lhs->shape(), HloOpcode::kSubtract, rhs, lhs_delta))}));
+              {add_operand,
+               computation_->AddInstruction(HloInstruction::CreateBinary(
+                   lhs->shape(), HloOpcode::kSubtract, rhs, lhs_delta))}));
     }
   }
   return Status::OK();

--- a/tensorflow/compiler/xla/service/algebraic_simplifier.cc
+++ b/tensorflow/compiler/xla/service/algebraic_simplifier.cc
@@ -3223,7 +3223,8 @@ Status AlgebraicSimplifierVisitor::HandleCompare(HloInstruction* compare) {
     HloInstruction* lhs_delta;
     if (Match(compare,
               m::Compare(m::Add(m::Op(&add_operand), m::Constant(&lhs_delta)),
-                         m::Constant()))) {
+                         m::Constant())) &&
+        rhs->shape() == lhs_delta->shape()) {
       return ReplaceWithNewInstruction(
           compare,
           compare->CloneWithNewOperands(


### PR DESCRIPTION
If we have a compare with a constant on the RHS and and add(op, constant) on the left, then move the LHS constant to the right hand side so that constant folding can eliminate the add instruction.

We could do the removing of the addition manually by modifying the constants literal but for the sake of 
avoiding code duplication I think it's better to let the constant folding pass to remove the subtraction

Eliminating the this pattern allows the pattern matching in the while-loop-trip-count-annotator to hit some extra cases.