### PR TITLE
[TF:TRT] Add in-memory timing cache registry

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -679,6 +679,7 @@ tf_cuda_library(
         "convert/ops/slice_ops.cc",
         "convert/ops/tile.cc",
         "convert/ops/unary_ops.cc",
+        "convert/timing_cache.cc",
         "convert/trt_optimization_pass.cc",
     ],
     hdrs = [
@@ -687,6 +688,7 @@ tf_cuda_library(
         "convert/ops/layer_utils.h",
         "convert/ops/quantization_ops.h",
         "convert/ops/slice_ops.h",
+        "convert/timing_cache.h",
         "convert/trt_optimization_pass.h",
     ],
     copts = tf_copts() + select({

--- a/tensorflow/compiler/tf2tensorrt/convert/timing_cache.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/timing_cache.cc
@@ -1,0 +1,86 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+
+#include "tensorflow/compiler/tf2tensorrt/convert/timing_cache.h"
+
+#include <unordered_map>
+
+#include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/core/platform/errors.h"
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+StatusOr<TimingCacheRegistry::TimingCachePtr> TimingCacheRegistry::LookUp(
+    const string& name, nvinfer1::IBuilderConfig* builder_config) {
+#if IS_TRT_VERSION_GE(8, 0, 0, 0)
+  TRT_ENSURE(builder_config != nullptr);
+  mutex_lock scoped_lock(mu_);
+  if (map_.find(name) != map_.end()) {
+    const std::vector<uint8_t>& data = map_[name];
+    return std::unique_ptr<nvinfer1::ITimingCache>(
+        builder_config->createTimingCache(data.data(), data.size()));
+  }
+
+  // If no such timing cache exists, create a new timing cache.
+  return std::unique_ptr<nvinfer1::ITimingCache>(
+      builder_config->createTimingCache(nullptr, 0));
+#endif  // IS_TRT_VERSION_GE(8, 0, 0, 0)
+  return errors::Unimplemented(
+      "serializable timing cache does not exist in TensorRT versions < 8.0");
+}
+
+void TimingCacheRegistry::Upsert(const string& name, TimingCache* cache) {
+#if IS_TRT_VERSION_GE(8, 0, 0, 0)
+  nvinfer1::IHostMemory* memory = cache->serialize();
+  if (memory == nullptr) {
+    return;
+  }
+
+  if (map_.find(name) == map_.end()) {
+    // If the timing cache with the given name does not exist, emplace the
+    // serialized buffer.
+    std::vector<uint8_t> mem(memory->size());
+    std::copy_n(static_cast<uint8_t*>(memory->data()), memory->size(),
+                mem.begin());
+    {
+      mutex_lock scoped_lock(mu_);
+      map_.emplace(name, std::move(mem));
+    }
+  } else {
+    // If the timing cache does exist, use the existing buffer.
+    mutex_lock scoped_lock(mu_);
+    std::vector<uint8_t>& mem = map_[name];
+    mem.resize(memory->size());
+    std::copy_n(static_cast<uint8_t*>(memory->data()), memory->size(),
+                mem.begin());
+  }
+  memory->destroy();
+#endif  // IS_TRT_VERSION_GE(8, 0, 0, 0)
+}
+
+TimingCacheRegistry* GetTimingCacheRegistry() {
+  static TimingCacheRegistry* registry = new TimingCacheRegistry();
+  return registry;
+}
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT

--- a/tensorflow/compiler/tf2tensorrt/convert/timing_cache.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/timing_cache.h
@@ -1,0 +1,70 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TIMING_CACHE_H_
+#define TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TIMING_CACHE_H_
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+#include <unordered_map>
+
+#include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/core/framework/registration/registration.h"
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/platform/statusor.h"
+#include "third_party/tensorrt/NvInfer.h"
+
+namespace tensorflow {
+namespace tensorrt {
+namespace convert {
+
+// A registry for holding serialized TensorRT autotuner timing caches.
+// For TensorRT versions < 8.0, the timing cache is not serializable, so these
+// operations become no-ops.
+class TimingCacheRegistry {
+ public:
+  TimingCacheRegistry() = default;
+  ~TimingCacheRegistry() = default;
+
+#if IS_TRT_VERSION_GE(8, 0, 0, 0)
+  using TimingCache = nvinfer1::ITimingCache;
+  using TimingCachePtr = std::unique_ptr<TimingCache>;
+#else
+  struct TimingCache {};
+  using TimingCachePtr = std::unique_ptr<TimingCache>;
+#endif
+
+  // Insert or update a registry into the map using the given name. The cache
+  // will be serialized before being placed into the map.
+  void Upsert(const string& name, TimingCache* cache);
+
+  // Find a timing cache using the given name. The provided BuilderConfig is
+  // used to deserialize the cache. If no timing cache is found, a new timing
+  // cache is returned.
+  StatusOr<TimingCachePtr> LookUp(const string& name,
+                                  nvinfer1::IBuilderConfig* builder_config);
+
+ private:
+  using SerializedTimingCache = std::vector<uint8_t>;
+
+  mutex mu_;
+  std::unordered_map<std::string, SerializedTimingCache> map_;
+};
+
+TimingCacheRegistry* GetTimingCacheRegistry();
+
+}  // namespace convert
+}  // namespace tensorrt
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+#endif  // TENSORFLOW_COMPILER_TF2TENSORRT_CONVERT_TIMING_CACHE_H_


### PR DESCRIPTION
Adds the usage of TensorRT autotuner timing cache to TF-TRT. Serialized timing caches are tracked using a global registry using a string ID. This change updates the converter to use a single timing cache, `default_cache`, but we could qualify timing caches based on configuration attributes (dynamic shape mode, precision mode, etc). This change speeds up converter unit tests by about 20% and will likely speed up TF-TRT-based services performing multiple model builds by a larger factor.