### PR TITLE
Updated deprecated tf.gradients with tf.GradientTape in custom_gradient.py

### DIFF
--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -62,7 +62,10 @@ def custom_gradient(f=None):
   ```python
   x = tf.constant(100.)
   y = log1pexp(x)
-  dy_dx = tf.GradientTape(y, x) # Will be NaN when evaluated.
+  
+  with tf.GradientTape(persistent=True) as tape:   # Will be NaN when evaluated.
+    dy_dx = tape.gradient(y,x)
+  print(dy_dx) 
   ```
 
   The gradient expression can be analytically simplified to provide numerical

--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -62,7 +62,7 @@ def custom_gradient(f=None):
   ```python
   x = tf.constant(100.)
   y = log1pexp(x)
-  dy_dx = tf.gradients(y, x) # Will be NaN when evaluated.
+  dy_dx = tf.GradientTape(y, x) # Will be NaN when evaluated.
   ```
 
   The gradient expression can be analytically simplified to provide numerical


### PR DESCRIPTION
Updated tf.gradients with tf.GradientTape, as it was showing this error while executing code in TF 2.x "RuntimeError: tf.gradients is not supported when eager execution is enabled. Use tf.GradientTape instead."