### PR TITLE
Updated arguments of acos function

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -5541,7 +5541,7 @@ def acos(x, name=None):
   Args:
     x: A `Tensor`. Must be one of the following types: `bfloat16`, `half`,
       `float32`, `float64`, `uint8`, `int8`, `int16`, `int32`, `int64`,
-      `complex64`, `complex128`, `string`.
+      `complex64`, `complex128`.
     name: A name for the operation (optional).
 
   Returns:


### PR DESCRIPTION
String is not supported as an argument of `acos` function. So, removed it from the arguments.

Fixes https://github.com/tensorflow/tensorflow/issues/54545