### PR TITLE
[ROCm] fix triangular solve

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -1823,7 +1823,7 @@ cc_library(
         ":reduction_layout_normalizer",
         ":target_constants",
         ":tree_reduction_rewriter",
-	":triangular_solve_rewriter",
+        ":triangular_solve_rewriter",
         "//tensorflow/compiler/xla:statusor",
         "//tensorflow/compiler/xla/service:algebraic_simplifier",
         "//tensorflow/compiler/xla/service:call_inliner",

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -2624,6 +2624,8 @@ cc_library(
         "//tensorflow/stream_executor:stream_header",
         "//tensorflow/stream_executor/gpu:asm_compiler",
         "//tensorflow/stream_executor/gpu:gpu_asm_opts",
+    ]) + if_rocm_is_configured([
+        "//tensorflow/stream_executor/gpu:gpu_stream_header",
     ]),
 )
 

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -1823,6 +1823,7 @@ cc_library(
         ":reduction_layout_normalizer",
         ":target_constants",
         ":tree_reduction_rewriter",
+	":triangular_solve_rewriter",
         "//tensorflow/compiler/xla:statusor",
         "//tensorflow/compiler/xla/service:algebraic_simplifier",
         "//tensorflow/compiler/xla/service:call_inliner",

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -124,12 +124,12 @@ Status AMDGPUCompiler::OptimizeHloPostLayoutAssignment(
 
   HloPassPipeline post_pipeline("AMDGPU post-layout_assignment");
 
-  // BEF-mode GpuExecutable allocates temp memory, and so the custom-call
-  // implementation for TriangularSolve is not needed.
-#if !BEF_EXECUTABLE
-  // Transform TriangularSolve ops into custom-calls, so we can add temp memory.
-  post_pipeline.AddPass<TriangularSolveRewriter>();
-#endif
+  if (!IsBefEnabled(hlo_module->config())) {
+    // Transform TriangularSolve ops into custom-calls, so we can add temp
+    // memory. XLIR allocates temp memory, and so the custom-call implementation
+    // for TriangularSolve is not needed.
+    post_pipeline.AddPass<TriangularSolveRewriter>();
+  }
 
   TF_RETURN_IF_ERROR(post_pipeline.Run(hlo_module).status());
 

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/gpu/reduction_layout_normalizer.h"
 #include "tensorflow/compiler/xla/service/gpu/target_constants.h"
 #include "tensorflow/compiler/xla/service/gpu/tree_reduction_rewriter.h"
+#include "tensorflow/compiler/xla/service/gpu/triangular_solve_rewriter.h"
 #include "tensorflow/compiler/xla/service/hlo_constant_folding.h"
 #include "tensorflow/compiler/xla/service/hlo_cse.h"
 #include "tensorflow/compiler/xla/service/hlo_pass_fix.h"
@@ -110,6 +111,27 @@ Status AMDGPUCompiler::OptimizeHloConvolutionCanonicalization(
 
   pipeline.AddPass<HloConstantFolding>();
   TF_RETURN_IF_ERROR(pipeline.Run(hlo_module).status());
+
+  return Status::OK();
+}
+
+Status AMDGPUCompiler::OptimizeHloPostLayoutAssignment(
+    HloModule* hlo_module, se::StreamExecutor* stream_exec,
+    se::DeviceMemoryAllocator* device_allocator) {
+
+  TF_RETURN_IF_ERROR(GpuCompiler::OptimizeHloPostLayoutAssignment(
+      hlo_module, stream_exec, device_allocator));
+
+  HloPassPipeline post_pipeline("AMDGPU post-layout_assignment");
+
+  // BEF-mode GpuExecutable allocates temp memory, and so the custom-call
+  // implementation for TriangularSolve is not needed.
+#if !BEF_EXECUTABLE
+  // Transform TriangularSolve ops into custom-calls, so we can add temp memory.
+  post_pipeline.AddPass<TriangularSolveRewriter>();
+#endif
+
+  TF_RETURN_IF_ERROR(post_pipeline.Run(hlo_module).status());
 
   return Status::OK();
 }

--- a/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.h
+++ b/tensorflow/compiler/xla/service/gpu/amdgpu_compiler.h
@@ -37,6 +37,10 @@ class AMDGPUCompiler : public GpuCompiler {
       HloModule* hlo_module, se::StreamExecutor* stream_exec,
       se::DeviceMemoryAllocator* device_allocator) override;
 
+  Status OptimizeHloPostLayoutAssignment(
+      HloModule* hlo_module, se::StreamExecutor* stream_exec,
+      se::DeviceMemoryAllocator* device_allocator) override;
+
   GpuVersion GetGpuVersion(se::StreamExecutor* stream_exec) override;
 
   StatusOr<std::pair<std::string, std::vector<uint8_t>>> CompileTargetBinary(

--- a/tensorflow/compiler/xla/service/gpu/precompiled_kernels.cc
+++ b/tensorflow/compiler/xla/service/gpu/precompiled_kernels.cc
@@ -24,6 +24,16 @@ limitations under the License.
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/stream_executor/gpu/asm_compiler.h"
 
+#if TENSORFLOW_USE_ROCM
+#include "tensorflow/stream_executor/gpu/gpu_stream.h"
+namespace stream_executor {
+namespace gpu {
+
+extern void rocm_MakeBatchPointers(void* stream, char* base, int stride, int n, void** ptrs_out);
+
+}}
+#endif
+
 namespace xla {
 namespace gpu {
 namespace {
@@ -145,6 +155,13 @@ class LazyKernel {
 Status MakeBatchPointers(se::Stream* stream, const se::GpuAsmOpts& asm_opts,
                          se::DeviceMemoryBase base_ptr, int stride_bytes, int n,
                          se::DeviceMemoryBase ptrs_out) {
+#if TENSORFLOW_USE_ROCM
+    stream_executor::gpu::rocm_MakeBatchPointers(
+      se::gpu::AsGpuStreamValue(stream),
+      reinterpret_cast<char*>(base_ptr.opaque()),
+      stride_bytes, n,
+      reinterpret_cast<void**>(ptrs_out.opaque()));
+#else
   static auto* lazy_kernel =
       new LazyKernel<se::DeviceMemoryBase /*base_ptr*/, int /*stride_bytes*/,
                      int /*n*/, se::DeviceMemoryBase /*ptrs_out*/>(
@@ -156,6 +173,7 @@ Status MakeBatchPointers(se::Stream* stream, const se::GpuAsmOpts& asm_opts,
   stream->ThenLaunch(se::ThreadDim(kThreads, 1, 1),
                      se::BlockDim(CeilOfRatio(n, kThreads), 1, 1), *kernel,
                      base_ptr, stride_bytes, n, ptrs_out);
+#endif
   return Status::OK();
 }
 

--- a/tensorflow/stream_executor/rocm/BUILD
+++ b/tensorflow/stream_executor/rocm/BUILD
@@ -416,10 +416,11 @@ cc_library(
 cc_library(
         name = "rocm_helpers",
         srcs = ["rocm_helpers.cu.cc"],
+	copts = rocm_copts(),
         deps =
-        ["@local_config_rocm//rocm:rocm_headers",
+        [
+                "@local_config_rocm//rocm:rocm_headers",
         ],
-        copts = rocm_copts(),
         alwayslink = True,
     )
 
@@ -434,7 +435,7 @@ cc_library(
         ":rocrand_plugin",
         ":rocm_driver",
         ":rocm_platform",
-	":rocm_helpers",
+        ":rocm_helpers",
     ]),
     alwayslink = 1,
 )

--- a/tensorflow/stream_executor/rocm/BUILD
+++ b/tensorflow/stream_executor/rocm/BUILD
@@ -8,7 +8,7 @@ load(
 )
 load("//tensorflow:tensorflow.bzl", "tf_copts")
 load("//tensorflow:tensorflow.bzl", "filegroup")
-load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured", "rocm_copts")
 load("//tensorflow/core/platform:build_config_root.bzl", "if_static")
 
 package(
@@ -414,6 +414,16 @@ cc_library(
 )
 
 cc_library(
+        name = "rocm_helpers",
+        srcs = ["rocm_helpers.cu.cc"],
+        deps =
+        ["@local_config_rocm//rocm:rocm_headers",
+        ],
+        copts = rocm_copts(),
+        alwayslink = True,
+    )
+
+cc_library(
     name = "all_runtime",
     copts = tf_copts(),
     visibility = ["//visibility:public"],
@@ -424,6 +434,7 @@ cc_library(
         ":rocrand_plugin",
         ":rocm_driver",
         ":rocm_platform",
+	":rocm_helpers",
     ]),
     alwayslink = 1,
 )

--- a/tensorflow/stream_executor/rocm/BUILD
+++ b/tensorflow/stream_executor/rocm/BUILD
@@ -414,15 +414,15 @@ cc_library(
 )
 
 cc_library(
-        name = "rocm_helpers",
-        srcs = ["rocm_helpers.cu.cc"],
-	copts = rocm_copts(),
-        deps =
+    name = "rocm_helpers",
+    srcs = ["rocm_helpers.cu.cc"],
+    copts = rocm_copts(),
+    deps =
         [
-                "@local_config_rocm//rocm:rocm_headers",
+            "@local_config_rocm//rocm:rocm_headers",
         ],
-        alwayslink = True,
-    )
+    alwayslink = True,
+)
 
 cc_library(
     name = "all_runtime",

--- a/tensorflow/stream_executor/rocm/rocblas_wrapper.h
+++ b/tensorflow/stream_executor/rocm/rocblas_wrapper.h
@@ -257,6 +257,10 @@ using stream_executor::internal::CachedDsoLoader::GetRocblasDsoHandle;
   __macro(rocblas_zgemm_strided_batched)        \
   __macro(rocblas_gemm_ex)                      \
   __macro(rocblas_gemm_strided_batched_ex)      \
+  __macro(rocblas_strsm_batched)                \
+  __macro(rocblas_dtrsm_batched)                \
+  __macro(rocblas_ctrsm_batched)                \
+  __macro(rocblas_ztrsm_batched)                \
   __macro(rocblas_create_handle)                \
   __macro(rocblas_destroy_handle)               \
   __macro(rocblas_set_stream)

--- a/tensorflow/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/stream_executor/rocm/rocm_blas.cc
@@ -2259,8 +2259,11 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  float alpha, const DeviceMemory<float *> &as,
                                  int lda, DeviceMemory<float *> *bs, int ldb,
                                  int batch_count) {
-  // ROCM TODO: properly implement the interface
-  return false;
+  return DoBlasInternal(wrap::rocblas_strsm_batched, stream,
+                        true /* = pointer_mode_host */, ROCMBlasSide(side),
+                        ROCMBlasUpperLower(uplo), ROCMBlasTranspose(transa),
+                        ROCMBlasDiagonal(diag), m, n, &alpha, GpuMemory(as),
+                        lda, GpuMemoryMutable(bs), ldb, batch_count);
 }
 
 bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
@@ -2269,8 +2272,11 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  double alpha, const DeviceMemory<double *> &as,
                                  int lda, DeviceMemory<double *> *bs, int ldb,
                                  int batch_count) {
-  // ROCM TODO: properly implement the interface
-  return false;
+  return DoBlasInternal(wrap::rocblas_dtrsm_batched, stream,
+                        true /* = pointer_mode_host */, ROCMBlasSide(side),
+                        ROCMBlasUpperLower(uplo), ROCMBlasTranspose(transa),
+                        ROCMBlasDiagonal(diag), m, n, &alpha, GpuMemory(as),
+                        lda, GpuMemoryMutable(bs), ldb, batch_count);
 }
 
 bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
@@ -2281,8 +2287,12 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  int lda,
                                  DeviceMemory<std::complex<float> *> *bs,
                                  int ldb, int batch_count) {
-  // ROCM TODO: properly implement the interface
-  return false;
+  return DoBlasInternal(
+      wrap::rocblas_ctrsm_batched, stream, true /* = pointer_mode_host */,
+      ROCMBlasSide(side), ROCMBlasUpperLower(uplo), ROCMBlasTranspose(transa),
+      ROCMBlasDiagonal(diag), m, n, complex_cast(alpha),
+      static_cast<const rocblas_float_complex * const *>(as.opaque()), lda,
+      static_cast<rocblas_float_complex * const *>(bs->opaque()), ldb, batch_count);
 }
 
 bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
@@ -2293,8 +2303,12 @@ bool ROCMBlas::DoBlasTrsmBatched(Stream *stream, blas::Side side,
                                  int lda,
                                  DeviceMemory<std::complex<double> *> *bs,
                                  int ldb, int batch_count) {
-  // ROCM TODO: properly implement the interface
-  return false;
+  return DoBlasInternal(
+      wrap::rocblas_ztrsm_batched, stream, true /* = pointer_mode_host */,
+      ROCMBlasSide(side), ROCMBlasUpperLower(uplo), ROCMBlasTranspose(transa),
+      ROCMBlasDiagonal(diag), m, n, complex_cast(alpha),
+      static_cast<const rocblas_double_complex * const *>(as.opaque()), lda, 
+      static_cast<rocblas_double_complex * const *>(bs->opaque()), ldb, batch_count);
 }
 
 port::Status ROCMBlas::DoBlasGemmStridedBatched(

--- a/tensorflow/stream_executor/rocm/rocm_helpers.cu.cc
+++ b/tensorflow/stream_executor/rocm/rocm_helpers.cu.cc
@@ -1,0 +1,24 @@
+#include <hip/hip_runtime.h>
+#include <limits>
+namespace stream_executor {
+namespace gpu {
+
+// GPU kernel to populate an array of pointers:
+//
+//   [base + stride * i for i in range(n)].
+//
+
+__global__ void __xla_MakeBatchPointers(char* base, int stride, int n, void** ptrs_out) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (idx >= n) return;
+  ptrs_out[idx] = base + idx * stride;
+}
+
+void rocm_MakeBatchPointers(void* stream, char* base, int stride, int n, void** ptrs_out) {
+  const int threads_per_block = 256;
+  hipLaunchKernelGGL(__xla_MakeBatchPointers, dim3((n + threads_per_block - 1)/threads_per_block, 1, 1),
+                     dim3(threads_per_block, 1, 1), 0, (hipStream_t)stream, base, stride, n, ptrs_out);
+}
+
+};  // namespace gpu
+};  // namespace stream_executor


### PR DESCRIPTION
The following tests recently began failing for ROCm:

//tensorflow/compiler/tests:matrix_inverse_op_test_gpu
//tensorflow/compiler/tests:matrix_inverse_op_test_gpu_mlir_bridge_test
//tensorflow/compiler/tests:matrix_solve_op_test_gpu
//tensorflow/compiler/tests:matrix_solve_op_test_gpu_mlir_bridge_test
//tensorflow/compiler/tests:matrix_triangular_solve_op_test_gpu
//tensorflow/compiler/tests:matrix_triangular_solve_op_test_gpu_mlir_bridge_test
//tensorflow/compiler/xla/service/gpu/tests:bef_executable_test_gpu
//tensorflow/compiler/xla/tests:triangular_solve_test_gpu

This was due to the introduction of the batched version of the triangular solve operation in cublas in: https://github.com/tensorflow/tensorflow/commit/d797b6d5f09ebde355a58a48b1d8fb8f61f657e2

This PR adds the same thing for ROCm and rocblas.

One interesting difference is the MakeBatchPointers call, which is implemented in PTX in the CUDA implementation. For ROCm, we add a new helper file with the code for this kernel. This kernel will be usable for other batched operations as well (ex: cholesky).