### PR TITLE
[TF-TRT] Changing Engine Name to TRTEngineOp_ABC_XYZ

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/logger_registry.h"
@@ -812,12 +813,16 @@ Status ConvertAfterShapes(const ConversionParams& params,
   GetPostOrder(graph, &reverse_topo_order);
   segment::SegmentVector converted_segments;
   converted_segments.reserve(initial_segments.size());
-  string engine_name_prefix =
-      StrCat("TRTEngineOp_", GetNextGraphSequenceNumber(), "_");
+  string engine_name_prefix = StrCat(
+    "TRTEngineOp_",
+    absl::StrFormat("%0*d", 3, GetNextGraphSequenceNumber()),
+    "_"
+  );
   for (size_t t = 0; t < initial_segments.size(); t++) {
     auto& curr_segment = initial_segments.at(t);
     EngineInfo curr_engine;
-    curr_engine.engine_name = StrCat(engine_name_prefix, t);
+    curr_engine.engine_name = StrCat(
+      engine_name_prefix, absl::StrFormat("%0*d", 3, t));
 
     bool int8_no_calib = (params.use_calibration == false &&
                           params.precision_mode == TrtPrecisionMode::INT8);

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph_test.cc
@@ -203,13 +203,13 @@ TEST_F(ConvertAfterShapesTest, DirectlyConnectedEngines) {
     std::string node_name = node.name();
     if (node.op() != "TRTEngineOp") continue;
     node_name = remove_graph_sequence_number(node_name);
-    if (node_name == "TRTEngineOp_1") {
+    if (node_name == "TRTEngineOp_001") {
       EXPECT_EQ(1, node.input_size());
       EXPECT_EQ("input", node.input(0));
       ++num_trt_ops;
-    } else if (node_name == "TRTEngineOp_0") {
+    } else if (node_name == "TRTEngineOp_000") {
       EXPECT_EQ(2, node.input_size());
-      EXPECT_EQ("TRTEngineOp_1", remove_graph_sequence_number(node.input(0)));
+      EXPECT_EQ("TRTEngineOp_001", remove_graph_sequence_number(node.input(0)));
       EXPECT_EQ("reshape2", node.input(1));
       ++num_trt_ops;
     }

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -515,7 +515,7 @@ class ConverterTest : public ::testing::Test {
         std::move(Converter::Create(TrtPrecisionMode::FP32,
                                     /*use_calibration=*/false, &logger_,
                                     /*use_implicit_batch=*/true,
-                                    /*engine_name=*/"TRTEngineOp_0_0",
+                                    /*engine_name=*/"TRTEngineOp_000_000",
                                     /*use_explicit_precision=*/false)
                       .ValueOrDie());
     weight_store_ = &converter_->weight_store_;
@@ -712,7 +712,9 @@ TEST_F(ConverterTest, TransposeTensor) {
       input_tensor, {0, 3, 1, 2}, &output_tensor, dummy_node_def, "sub3"));
   EXPECT_THAT(output_tensor->getDimensions(), DimsAreArray({5, 2, 3}));
   EXPECT_THAT(converter_->network(),
-              LayerNamesAreArray({"TRTEngineOp_0_0/dummy_op-sub3:SHUFFLE"}));
+              LayerNamesAreArray({
+                "TRTEngineOp_000_000/dummy_op-sub3:SHUFFLE"
+              }));
 }
 
 void TestPrepareTensorForShape(
@@ -1046,7 +1048,7 @@ class ConvertGraphDefToEngineTest : public ::testing::Test {
         /*allocator=*/nullptr, /*calibrator=*/nullptr, &engine_,
         /*use_calibration=*/false, /*use_implicit_batch=*/true,
         /*convert_successfully=*/nullptr, /*profiles=*/nullptr,
-        "TRTEngineOp_0_0", /*use_explicit_precision=*/false);
+        "TRTEngineOp_000_000", /*use_explicit_precision=*/false);
   }
 
  protected:

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
@@ -94,7 +94,7 @@ class TRTEngineOpTestBase : public OpsTestBase {
       info.segment_graph_def.CopyFrom(graph_def);
       info.precision_mode = TrtPrecisionMode::FP32;
       info.max_workspace_size_bytes = 1 << 20;
-      info.engine_name = "TRTEngineOP_0_0";
+      info.engine_name = "TRTEngineOP_000_000";
       params.use_implicit_batch = use_implicit_batch;
       params.trt_logger_name = "DefaultLogger";
 

--- a/tensorflow/python/compiler/tensorrt/test/annotate_max_batch_sizes_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/annotate_max_batch_sizes_test.py
@@ -73,7 +73,7 @@ class MaxBatchSizesTestBase(trt_test.TfTrtIntegrationTestBase):
     There shall be engines generated for each maximum batch size.
     """
     return [
-        'TRTEngineOp_{}'.format(seq_id)
+        f"TRTEngineOp_{seq_id:03d}"
         for seq_id in range(len(self.max_batch_sizes))
     ]
 

--- a/tensorflow/python/compiler/tensorrt/test/base_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/base_test.py
@@ -60,7 +60,7 @@ class SimpleSingleEngineTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
     return {
-        "TRTEngineOp_0": [
+        "TRTEngineOp_000": [
             "weights", "conv", "bias", "bias_add", "relu", "identity",
             "max_pool"
         ]
@@ -109,11 +109,11 @@ class SimpleMultiEnginesTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
     return {
-        "TRTEngineOp_0": [
+        "TRTEngineOp_000": [
             "add", "add1", "c1", "div1", "mul", "mul1", "sub", "sub1", "one",
             "one_sub"
         ],
-        "TRTEngineOp_1": ["c2", "conv", "div", "weights"]
+        "TRTEngineOp_001": ["c2", "conv", "div", "weights"]
     }
 
   def setUp(self):
@@ -149,8 +149,8 @@ class SimpleMultiEnginesTest2(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
     return {
-        "TRTEngineOp_0": ["c0", "c1", "add0", "add1", "mul0", "mul1"],
-        "TRTEngineOp_1": ["c2", "c3", "add2", "add3", "mul2", "mul3"]
+        "TRTEngineOp_000": ["c0", "c1", "add0", "add1", "mul0", "mul1"],
+        "TRTEngineOp_001": ["c2", "c3", "add2", "add3", "mul2", "mul3"]
     }
 
   def ShouldRunTest(self, run_params):
@@ -191,8 +191,8 @@ class ConstInputTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
     return {
-        "TRTEngineOp_0": ["add", "add1", "mul"],
-        "TRTEngineOp_1": ["add2", "add3", "mul1"]
+        "TRTEngineOp_000": ["add", "add1", "mul"],
+        "TRTEngineOp_001": ["add2", "add3", "mul1"]
     }
 
   def ExpectedConnections(self, run_params):
@@ -201,10 +201,10 @@ class ConstInputTest(trt_test.TfTrtIntegrationTestBase):
         "input_0": set(),
         "c": set(),
         "incompatible": {"input_0", "c"},
-        "TRTEngineOp_0": {"incompatible"},
-        "incompatible1": {"TRTEngineOp_0"},
-        "TRTEngineOp_1": {"incompatible1"},
-        "output_0": {"TRTEngineOp_1"},
+        "TRTEngineOp_000": {"incompatible"},
+        "incompatible1": {"TRTEngineOp_000"},
+        "TRTEngineOp_001": {"incompatible1"},
+        "output_0": {"TRTEngineOp_001"},
     }
 
 
@@ -226,7 +226,7 @@ class ConstDataInputSingleEngineTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return {"TRTEngineOp_0": ["c", "add", "add1", "mul"]}
+    return {"TRTEngineOp_000": ["c", "add", "add1", "mul"]}
 
 
 class ConstDataInputMultipleEnginesTest(trt_test.TfTrtIntegrationTestBase):
@@ -252,12 +252,12 @@ class ConstDataInputMultipleEnginesTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
     return {
-        "TRTEngineOp_0": ["add2", "add3", "mul1"],
+        "TRTEngineOp_000": ["add2", "add3", "mul1"],
         # Why segment ["add", "add1", "mul"] was assigned segment id 1
         # instead of 0: the parent node of this segment is actually const
         # node 'c', but it's removed later since it's const output of the
         # segment which is not allowed.
-        "TRTEngineOp_1": ["add", "add1", "mul"]
+        "TRTEngineOp_001": ["add", "add1", "mul"]
     }
 
 
@@ -290,8 +290,8 @@ class ControlDependencyTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
     return {
-        "TRTEngineOp_0": ["c1", "add", "add1", "mul"],
-        "TRTEngineOp_1": ["c2", "add2", "add3", "mul1"]
+        "TRTEngineOp_000": ["c1", "add", "add1", "mul"],
+        "TRTEngineOp_001": ["c2", "add2", "add3", "mul1"]
     }
 
   def ExpectedConnections(self, run_params):
@@ -300,10 +300,10 @@ class ControlDependencyTest(trt_test.TfTrtIntegrationTestBase):
         "input_0": set(),
         "d1": {"input_0"},
         "d2": {"input_0"},
-        "TRTEngineOp_0": {"input_0", "^d1"},
-        "incompatible": {"TRTEngineOp_0"},
-        "TRTEngineOp_1": {"incompatible", "^d2"},
-        "incompatible1": {"TRTEngineOp_1", "d1"},
+        "TRTEngineOp_000": {"input_0", "^d1"},
+        "incompatible": {"TRTEngineOp_000"},
+        "TRTEngineOp_001": {"incompatible", "^d2"},
+        "incompatible1": {"TRTEngineOp_001", "d1"},
         "incompatible2": {"incompatible1", "d2"},
         "output_0": {"incompatible2"},
     }

--- a/tensorflow/python/compiler/tensorrt/test/batch_matmul_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/batch_matmul_test.py
@@ -65,7 +65,7 @@ class BatchMatMulTwoTensorTest(BatchMatMultTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return {"TRTEngineOp_0": ["matmul", "relu"]}
+    return {"TRTEngineOp_000": ["matmul", "relu"]}
 
 
 class BatchMatMulWeightBroadcastTest(BatchMatMultTestBase):
@@ -84,7 +84,7 @@ class BatchMatMulWeightBroadcastTest(BatchMatMultTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return {"TRTEngineOp_0": ["matmul", "kernel"]}
+    return {"TRTEngineOp_000": ["matmul", "kernel"]}
 
 
 class BatchMatMulWeightBroadcastDims2Test(BatchMatMultTestBase):
@@ -102,7 +102,7 @@ class BatchMatMulWeightBroadcastDims2Test(BatchMatMultTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return {"TRTEngineOp_0": ["matmul", "kernel"]}
+    return {"TRTEngineOp_000": ["matmul", "kernel"]}
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/biasadd_matmul_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/biasadd_matmul_test.py
@@ -123,9 +123,9 @@ class BiasaddMatMulTest(trt_test.TfTrtIntegrationTestBase):
       # Increased conversion rate in dynamic shape mode due to a few additional
       # conversions for MatMul, Reshape and Concat ops. This increases the size
       # of the candidate segments and results in two more TrtEngineOps.
-      return ["TRTEngineOp_0", "TRTEngineOp_1", "TRTEngineOp_2"]
+      return ["TRTEngineOp_000", "TRTEngineOp_001", "TRTEngineOp_002"]
     else:
-      return ["TRTEngineOp_0"]
+      return ["TRTEngineOp_000"]
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/binary_tensor_weight_broadcast_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/binary_tensor_weight_broadcast_test.py
@@ -59,7 +59,7 @@ class BinaryTensorWeightBroadcastTest(trt_test.TfTrtIntegrationTestBase):
     # The final reshape op is converted only in dynamic shape mode. This op is
     # placed into a new engine due to the preceding trt_incompatible_ops.
     num_engines = 17 if run_params.dynamic_shape else 16
-    return ["TRTEngineOp_%d" % i for i in range(num_engines)]
+    return [f"TRTEngineOp_{i:03d}" for i in range(num_engines)]
 
   # TODO(b/176540862): remove this routine to disallow native segment execution
   # for TensorRT 7+.

--- a/tensorflow/python/compiler/tensorrt/test/cast_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/cast_test.py
@@ -44,9 +44,9 @@ class CastInt32ToFp32Test(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Returns the expected engines to build."""
     if run_params.precision_mode == "FP16":
-      return {"TRTEngineOp_0": ["Cast", "Add", "Mul"]}
+      return {"TRTEngineOp_000": ["Cast", "Add", "Mul"]}
     else:
-      return {"TRTEngineOp_0": ["Add", "Mul"]}
+      return {"TRTEngineOp_000": ["Add", "Mul"]}
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/compiler/tensorrt/test/combined_nms_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/combined_nms_test.py
@@ -79,7 +79,7 @@ class CombinedNmsTest(trt_test.TfTrtIntegrationTestBase):
     """Return the expected engines to build."""
     if not run_params.dynamic_shape:
       return {
-          'TRTEngineOp_0': [
+          "TRTEngineOp_000": [
               'combined_nms/CombinedNonMaxSuppression', 'max_total_size',
               'iou_threshold', 'score_threshold'
           ]

--- a/tensorflow/python/compiler/tensorrt/test/concatenation_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/concatenation_test.py
@@ -66,7 +66,7 @@ class ConcatenationTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/const_broadcast_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/const_broadcast_test.py
@@ -46,7 +46,7 @@ class ConstBroadcastTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ['TRTEngineOp_0']
+    return ["TRTEngineOp_000"]
 
   def ExpectedAbsoluteTolerance(self, run_params):
     """The absolute tolerance to compare floating point results."""

--- a/tensorflow/python/compiler/tensorrt/test/conv2d_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/conv2d_test.py
@@ -96,7 +96,7 @@ class Conv2DNCHWTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
   def ExpectedAbsoluteTolerance(self, run_params):
     """The absolute tolerance to compare floating point results."""
@@ -131,7 +131,7 @@ class Conv2DNHWCTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
 
 class Conv2DStridedNCHWTest(trt_test.TfTrtIntegrationTestBase):
@@ -162,7 +162,7 @@ class Conv2DStridedNCHWTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
 
 class Conv2DTranposeTest(trt_test.TfTrtIntegrationTestBase):
@@ -192,7 +192,7 @@ class Conv2DTranposeTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/dynamic_input_shapes_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/dynamic_input_shapes_test.py
@@ -83,7 +83,7 @@ class DynamicInputShapesTest(trt_test.TfTrtIntegrationTestBase):
     self.DisableNonTrtOptimizers()
 
   def ExpectedEnginesToBuild(self, run_params):
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
   def ShouldRunTest(self, run_params):
     return (run_params.dynamic_engine and not trt_test.IsQuantizationMode(

--- a/tensorflow/python/compiler/tensorrt/test/identity_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/identity_output_test.py
@@ -45,7 +45,7 @@ class IdentityTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ['TRTEngineOp_0']
+    return ["TRTEngineOp_000"]
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/compiler/tensorrt/test/int32_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/int32_test.py
@@ -79,7 +79,7 @@ class CalibrationInt32Support(trt_test.TfTrtIntegrationTestBase):
         run_params), 'test calibration and INT8'
 
   def ExpectedEnginesToBuild(self, run_params):
-    return ['TRTEngineOp_0']
+    return ["TRTEngineOp_000"]
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/compiler/tensorrt/test/lru_cache_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/lru_cache_test.py
@@ -55,7 +55,7 @@ class LRUCacheTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
   def ShouldRunTest(self, run_params):
     return (run_params.dynamic_engine and not trt_test.IsQuantizationMode(

--- a/tensorflow/python/compiler/tensorrt/test/memory_alignment_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/memory_alignment_test.py
@@ -53,7 +53,7 @@ class MemoryAlignmentTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
   def ExpectedAbsoluteTolerance(self, run_params):
     """The absolute tolerance to compare floating point results."""

--- a/tensorflow/python/compiler/tensorrt/test/multi_connection_neighbor_engine_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/multi_connection_neighbor_engine_test.py
@@ -66,7 +66,7 @@ class MultiConnectionNeighborEngineTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0", "TRTEngineOp_1"]
+    return ["TRTEngineOp_000", "TRTEngineOp_001"]
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/neighboring_engine_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/neighboring_engine_test.py
@@ -53,8 +53,8 @@ class NeighboringEngineTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
     return {
-        "TRTEngineOp_0": ["bias", "mul", "sub"],
-        "TRTEngineOp_1": ["weights", "conv"]
+        "TRTEngineOp_000": ["bias", "mul", "sub"],
+        "TRTEngineOp_001": ["weights", "conv"]
     }
 
 

--- a/tensorflow/python/compiler/tensorrt/test/quantization_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/quantization_test.py
@@ -70,7 +70,7 @@ class QuantizationMissingAllRangesTest(trt_test.TfTrtIntegrationTestBase):
     # engine.
     # In static engine mode without calibration, the engine building will
     # succeed but fall back to non-quantized ops.
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
 
 class QuantizationWithRangesTest(trt_test.TfTrtIntegrationTestBase):
@@ -89,7 +89,7 @@ class QuantizationWithRangesTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
   def ExpectedAbsoluteTolerance(self, run_params):
     """The absolute tolerance to compare floating point results."""
@@ -118,7 +118,7 @@ class NonQuantizedPrecisionsWithRangesTest(trt_test.TfTrtIntegrationTestBase):
     """Return the expected engines to build."""
     # The fake quant ops are not supported in FP32/FP16 mode, and will split the
     # graph into two TRT segments.
-    return ["TRTEngineOp_0", "TRTEngineOp_1"]
+    return ["TRTEngineOp_000", "TRTEngineOp_001"]
 
   def ExpectedAbsoluteTolerance(self, run_params):
     """The absolute tolerance to compare floating point results."""

--- a/tensorflow/python/compiler/tensorrt/test/rank_two_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/rank_two_test.py
@@ -58,11 +58,11 @@ class RankTwoTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
     expected_engines = {
-        "TRTEngineOp_0": [
+        "TRTEngineOp_000": [
             "add0_1", "add0_2", "add0_3", "c0_1", "c0_2", "c0_3", "abs0_1",
             "abs0_2", "expand0_0", "expand0_1", "axis"
         ],
-        "TRTEngineOp_1": [
+        "TRTEngineOp_001": [
             "add1_1", "add1_2", "add1_3", "c1_1", "c1_2", "c1_3", "abs1_1",
             "abs1_2", "reciprocal1"
         ]
@@ -72,11 +72,11 @@ class RankTwoTest(trt_test.TfTrtIntegrationTestBase):
       # due to trt_incompatible_op. They can't be in the same cluster as the
       # ops in TRTEngineOP_1 because their batch size belongs to a different
       # equivalent class.
-      expected_engines["TRTEngineOp_2"] = ["add", "reciprocal0"]
+      expected_engines["TRTEngineOp_002"] = ["add", "reciprocal0"]
     else:
       # In dynamic shape mode the batch size of the ops can differ,
       # therefore the final ops will be merged to TRTEngineOP_1.
-      expected_engines["TRTEngineOp_1"] += ["add", "reciprocal0"]
+      expected_engines["TRTEngineOp_001"] += ["add", "reciprocal0"]
 
     return expected_engines
 

--- a/tensorflow/python/compiler/tensorrt/test/reshape_transpose_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/reshape_transpose_test.py
@@ -64,7 +64,7 @@ class ReshapeTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
     return {
-        "TRTEngineOp_0": ["reshape-%d" % i for i in range(7)] +
+        "TRTEngineOp_000": ["reshape-%d" % i for i in range(7)] +
                          ["reshape-%d/shape" % i for i in range(7)]
     }
 
@@ -91,7 +91,7 @@ class TransposeTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
     return {
-        "TRTEngineOp_0": [
+        "TRTEngineOp_000": [
             "transpose-1", "transpose-1/perm", "transposeback",
             "transposeback/perm"
         ]

--- a/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
@@ -60,11 +60,11 @@ class ShapeOutputTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Returns the expected engines to build."""
     if run_params.dynamic_shape:
-      return ["TRTEngineOp_0", "TRTEngineOp_1"]
+      return ["TRTEngineOp_000", "TRTEngineOp_001"]
     else:
       # Second segment not converted in implicit batch mode, because its
       # tensors have only one dimensions
-      return ["TRTEngineOp_0"]
+      return ["TRTEngineOp_000"]
 
 
 class ShapeOutputWithSingleInputProfile(ShapeOutputTest):
@@ -114,7 +114,7 @@ class ShapeOutputWithSingleInputAndReshape(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Returns the expected engines to build."""
-    return ["TRTEngineOp_0", "TRTEngineOp_1"]
+    return ["TRTEngineOp_000", "TRTEngineOp_001"]
 
 
 class PrunedInputTest(trt_test.TfTrtIntegrationTestBase):
@@ -146,7 +146,7 @@ class PrunedInputTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Returns the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
   def ShouldRunTest(self, run_params):
     # Shape op is only converted in dynamic shape mode.
@@ -180,7 +180,7 @@ class PrunedInputTest2(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Returns the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
   def ShouldRunTest(self, run_params):
     # Shape op is only converted in dynamic shape mode.
@@ -219,7 +219,7 @@ class ShapeValueMaskTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Returns the expected engines to build."""
     if run_params.dynamic_shape:
-      return ["TRTEngineOp_0"]
+      return ["TRTEngineOp_000"]
     else:
       return []
 

--- a/tensorflow/python/compiler/tensorrt/test/tf_function_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_function_test.py
@@ -136,7 +136,7 @@ class TfFunctionTest(trt_test.TfTrtIntegrationTestBase):
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
     return {
-        "TRTEngineOp_0": [
+        "TRTEngineOp_000": [
             "weights", "conv", "bias", "bias_add", "relu", "identity",
             "max_pool"
         ]

--- a/tensorflow/python/compiler/tensorrt/test/topk_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/topk_test.py
@@ -40,7 +40,7 @@ class TopKTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return {"TRTEngineOp_0": ["Const", "TopK"]}
+    return {"TRTEngineOp_000": ["Const", "TopK"]}
 
 
 class TopKOutputTypeTest(trt_test.TfTrtIntegrationTestBase):
@@ -65,7 +65,7 @@ class TopKOutputTypeTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return {"TRTEngineOp_0": ["Const", "TopK", "Reshape", "Reshape/shape"]}
+    return {"TRTEngineOp_000": ["Const", "TopK", "Reshape", "Reshape/shape"]}
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
@@ -82,7 +82,7 @@ class TRTEngineOpInputOutputShapeTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/trt_mode_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/trt_mode_test.py
@@ -88,9 +88,9 @@ class TrtModeTestBase(trt_test.TfTrtIntegrationTestBase):
     In explicit batch mode the whole graph is converted using a single engine.
     """
     if run_params.dynamic_shape:
-      return ["TRTEngineOp_0"]
+      return ["TRTEngineOp_000"]
     else:
-      return ["TRTEngineOp_0", "TRTEngineOp_1"]
+      return ["TRTEngineOp_000", "TRTEngineOp_001"]
 
 
 class StaticInputTest(TrtModeTestBase):

--- a/tensorflow/python/compiler/tensorrt/test/unary_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/unary_test.py
@@ -95,11 +95,11 @@ class UnaryTest(trt_test.TfTrtIntegrationTestBase):
     """Return the expected engines to build."""
     if run_params.dynamic_shape:
       # All the ops are converted into a single TRTEngineOp.
-      return ["TRTEngineOp_0"]
+      return ["TRTEngineOp_000"]
     else:
       # Final squeeze and div ops are not converted. The x1 and x2 branches
       # are segmented into separate TRTEngineOp.
-      return ["TRTEngineOp_0", "TRTEngineOp_1"]
+      return ["TRTEngineOp_000", "TRTEngineOp_001"]
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/vgg_block_nchw_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/vgg_block_nchw_test.py
@@ -65,7 +65,7 @@ class VGGBlockNCHWTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
   # TODO(b/159459919): remove this routine to disallow native segment execution.
   def setUp(self):

--- a/tensorflow/python/compiler/tensorrt/test/vgg_block_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/vgg_block_test.py
@@ -56,7 +56,7 @@ class VGGBlockTest(trt_test.TfTrtIntegrationTestBase):
 
   def ExpectedEnginesToBuild(self, run_params):
     """Return the expected engines to build."""
-    return ["TRTEngineOp_0"]
+    return ["TRTEngineOp_000"]
 
   # TODO(b/159459919): remove this routine to disallow native segment execution.
   def setUp(self):

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -286,7 +286,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
             {
                 "input1": "Placeholder",
                 "input2": "Placeholder",
-                "TRTEngineOp_0": "TRTEngineOp",
+                "TRTEngineOp_000": "TRTEngineOp",
                 "output": "Identity"
             }, node_name_to_op)
 


### PR DESCRIPTION
@bixia1 for review

Change TRTEngineOP name from `TRTEngineOP_X_Y` to `TRTEngineOp_ABC_XYZ`.
The main objective is to correct `TRTEngineOP_2_1  > TRTEngineOP_17_1`  => shall be false, effectively is true.