### PR TITLE
[TF:TRT] Fix shape values profile handling

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
@@ -137,7 +137,8 @@ struct OptimizationProfileConfig {
   bool IncludesShapes(const std::vector<TensorShape>& shapes,
                       bool has_shape_tensor,
                       const std::vector<nvinfer1::Dims>& shape_values,
-                      const std::vector<bool>& is_pruned_input) const {
+                      const std::vector<bool>& is_pruned_input,
+                      const std::vector<bool>& is_shape_tensor) const {
     // min, max, and opt must have the same size which is already verified in
     // SetDimensions.
     if (min.size() != shapes.size() * 2 ||
@@ -169,7 +170,7 @@ struct OptimizationProfileConfig {
     if (has_shape_tensor) {
       int offset = shapes.size();
       for (int i = 0; i < shape_values.size(); i++) {
-        if (is_pruned_input[i]) {
+        if (is_pruned_input[i] || !is_shape_tensor[i]) {
           continue;
         }
         auto shape_val = shape_values[i];

--- a/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
@@ -234,5 +234,41 @@ class ShapeValueMaskTest(trt_test.TfTrtIntegrationTestBase):
             run_params.precision_mode != "INT8", "no calibration dynamic shape")
 
 
+class InputProfile(trt_test.TfTrtIntegrationTestBase):
+  """ The shape profiles has to fit values of shape tensors, but for regular
+  tensors the values do not matter. Here we test shape profile managment with
+  an INT32 input tensor that is not a shape tensor. The extra inputs with
+  dim=10 would trigger an error if we mistakenly treat it as shape tensors."""
+
+  def setUp(self):
+    super().setUp()
+
+    self.DisableNonTrtOptimizers()
+
+  def GraphFn(self, x):
+    z = x * x + x + 1
+    z = array_ops.identity(z, name="output_0")
+    return z
+
+  def GetParams(self):
+    return self.BuildParamsWithMask(
+        self.GraphFn,
+        dtypes.int32, [[4]], [[4]],
+        extra_inputs=[[[5]], [[10]]],
+        extra_outputs=[[[5]], [[10]]],
+        input_mask=[[False]],
+        output_mask=[[False]])
+
+  def ExpectedEnginesToBuild(self, run_params):
+    """Returns the expected engines to build."""
+    return ["TRTEngineOp_000"]
+
+  def ShouldRunTest(self, run_params):
+    # Shape op is only converted in dynamic shape mode.
+    return (run_params.dynamic_shape and
+            run_params.is_v2 and
+            not trt_test.IsQuantizationMode(run_params.precision_mode),
+            "Test v2 dynamic_shapes without INT8")
+
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
This PR fixes two issues with TRT profile handling for shape tensors:
- Recognize if input tensor changes size, and mark it as non-shape tensor,
- Do not check shape value profiles for tensors that are not shape value.