### PR TITLE
Change Redzone space limit for XLA GPU

### DIFF
--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -86,6 +86,8 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_gpu_nccl_termination_timeout_seconds(-1);
   opts.set_xla_gpu_enable_shared_constants(true);
 
+  // Set 4GB space limit for redzone scratch allocator.
+  opts.set_xla_gpu_redzone_scratch_max_megabytes(1LL << 12);
   return opts;
 }
 
@@ -718,6 +720,12 @@ static void AllocateFlags() {
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_shared_constants),
       flag_values->xla_gpu_enable_shared_constants(),
       "Enable constant sharing between GPU executables"));
+  flag_objects->push_back(tensorflow::Flag(
+      "xla_gpu_redzone_scratch_max_megabytes",
+      int64_setter_for(
+          &DebugOptions::set_xla_gpu_redzone_scratch_max_megabytes),
+      flag_values->xla_gpu_redzone_scratch_max_megabytes(),
+      "Max size (in megabytes) for the GPU redzone scratch allocator."));
 
   ParseFlagsFromEnvAndDieIfUnknown("XLA_FLAGS", *flag_objects);
 }  // NOLINT(readability/fn_size)

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
@@ -481,9 +481,13 @@ GpuConvAlgorithmPicker::AutotuneOneConvRunner(
                         "Disqualified for implicit RELU.");
   }
 
+  const int64_t rz_space_limit = hlo_module_config.debug_options()
+                                     .xla_gpu_redzone_scratch_max_megabytes() *
+                                 (1LL << 20);
   se::RedzoneAllocator scratch_allocator(
       stream, allocator,
-      PtxOptsFromDebugOptions(hlo_module_config.debug_options()));
+      PtxOptsFromDebugOptions(hlo_module_config.debug_options()),
+      /*memory_limit=*/rz_space_limit);
   se::dnn::ProfileResult profile_result;
   VLOG(3) << "Trying algorithm " << alg.ToString() << " for "
           << instr->ToString();
@@ -659,7 +663,7 @@ GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheCuda(
   se::RedzoneAllocator input_output_allocator(
       stream, allocator,
       PtxOptsFromDebugOptions(hlo_module_config.debug_options()),
-      /*memory_limit=*/se::RedzoneAllocator::kDefaultMemoryLimit,
+      /*memory_limit=*/std::numeric_limits<int64_t>::max(),
       /*redzone_size=*/redzone_size);
   std::vector<se::DeviceMemoryBase> operand_buffers;
   for (const auto* operand : instr->operands()) {

--- a/tensorflow/compiler/xla/xla.proto
+++ b/tensorflow/compiler/xla/xla.proto
@@ -379,6 +379,11 @@ message DebugOptions {
 
   // Next id: 166
 
+  // Size threshold (in megabytes) for the GPU redzone scratch allocator.
+  int64 xla_gpu_redzone_scratch_max_megabytes = 166;
+
+  // Next id: 167
+
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.
   map<string, string> xla_backend_extra_options = 500;

--- a/tensorflow/stream_executor/cuda/redzone_allocator_test.cc
+++ b/tensorflow/stream_executor/cuda/redzone_allocator_test.cc
@@ -58,11 +58,10 @@ TEST(RedzoneAllocatorTest, WriteToRedzone) {
 
   Stream stream(stream_exec);
   stream.Init();
-  RedzoneAllocator allocator(
-      &stream, &se_allocator, opts,
-      /*memory_limit=*/(1LL << 32),
-      /*redzone_size=*/kRedzoneSize,
-      /*redzone_pattern=*/kRedzonePattern);
+  RedzoneAllocator allocator(&stream, &se_allocator, opts,
+                             /*memory_limit=*/(1LL << 32),
+                             /*redzone_size=*/kRedzoneSize,
+                             /*redzone_pattern=*/kRedzonePattern);
   TF_ASSERT_OK_AND_ASSIGN(DeviceMemory<uint8> buf,
                           allocator.AllocateBytes(/*byte_size=*/kAllocSize));
   EXPECT_REDZONE_OK(allocator.CheckRedzones());
@@ -132,11 +131,10 @@ TEST(RedzoneAllocatorTest, VeryLargeRedzone) {
   StreamExecutorMemoryAllocator se_allocator(platform, {stream_exec});
   Stream stream(stream_exec);
   stream.Init();
-  RedzoneAllocator allocator(
-      &stream, &se_allocator, opts,
-      /*memory_limit=*/(1LL << 32),
-      /*redzone_size=*/kRedzoneSize,
-      /*redzone_pattern=*/-1);
+  RedzoneAllocator allocator(&stream, &se_allocator, opts,
+                             /*memory_limit=*/(1LL << 32),
+                             /*redzone_size=*/kRedzoneSize,
+                             /*redzone_pattern=*/-1);
   (void)allocator.AllocateBytes(/*byte_size=*/1);
   EXPECT_REDZONE_OK(allocator.CheckRedzones());
 }

--- a/tensorflow/stream_executor/cuda/redzone_allocator_test.cc
+++ b/tensorflow/stream_executor/cuda/redzone_allocator_test.cc
@@ -60,7 +60,7 @@ TEST(RedzoneAllocatorTest, WriteToRedzone) {
   stream.Init();
   RedzoneAllocator allocator(
       &stream, &se_allocator, opts,
-      /*memory_limit=*/RedzoneAllocator::kDefaultMemoryLimit,
+      /*memory_limit=*/(1LL << 32),
       /*redzone_size=*/kRedzoneSize,
       /*redzone_pattern=*/kRedzonePattern);
   TF_ASSERT_OK_AND_ASSIGN(DeviceMemory<uint8> buf,
@@ -134,7 +134,7 @@ TEST(RedzoneAllocatorTest, VeryLargeRedzone) {
   stream.Init();
   RedzoneAllocator allocator(
       &stream, &se_allocator, opts,
-      /*memory_limit=*/RedzoneAllocator::kDefaultMemoryLimit,
+      /*memory_limit=*/(1LL << 32),
       /*redzone_size=*/kRedzoneSize,
       /*redzone_pattern=*/-1);
   (void)allocator.AllocateBytes(/*byte_size=*/1);

--- a/tensorflow/stream_executor/gpu/redzone_allocator.h
+++ b/tensorflow/stream_executor/gpu/redzone_allocator.h
@@ -39,13 +39,12 @@ namespace stream_executor {
 // memory for cudnn convolutions.
 class RedzoneAllocator : public ScratchAllocator {
  public:
-  static constexpr int64_t kDefaultMemoryLimit = 1LL << 32;  // 4GB
   static constexpr int64_t kDefaultRedzoneSize =
       1LL << 23;  // 8MiB per side, 16MiB total.
   static constexpr uint8 kDefaultRedzonePattern = -1;
   RedzoneAllocator(Stream* stream, DeviceMemoryAllocator* memory_allocator,
                    GpuAsmOpts gpu_compilation_opts_,
-                   int64_t memory_limit = kDefaultMemoryLimit,
+                   int64_t memory_limit = (1LL << 32),  // 4GB
                    int64_t redzone_size = kDefaultRedzoneSize,
                    uint8 redzone_pattern = kDefaultRedzonePattern);
 


### PR DESCRIPTION
This PR changes how the redzone space limit is set in the XLA gpu conv algorithm picker.
1. It sets the numeric max of int64 for the input/output allocator. So, we can have consistent behavior with the gemm picker.
2. It allows the adjustment of the space limit for the scratch allocator via an env var. So, users can adjust it via `XLA_FLAGS=--xla_gpu_redzone_scratch_max_megabytes=6144`.

cc. @nluehr 