### PR TITLE
Create workflow to automate RBE image updates

### DIFF
--- a/.github/workflows/update-rbe.yml
+++ b/.github/workflows/update-rbe.yml
@@ -1,0 +1,39 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+name: Update RBE Configs
+on:
+  workflow_dispatch:
+
+jobs:
+  rbe:
+    name: Update RBE Configs
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install Python dependencies
+      run: |
+        function map() {
+          digest=$(curl https://gcr.io/v2/tensorflow-sigs/build/manifests/$2 | jq .config.digest)
+          sed -i"" tensorflow/tools/toolchains/remote_config/configs.bzl "0,/\"$1\".*sha256/s/sha256:.*[^\"]+/$digest/"
+        }
+        map sigbuild-r2.9 latest-python3.9
+        map sigbuild-r2.9-python3.7 latest-python3.7
+        map sigbuild-r2.9-python3.8 latest-python3.8
+        map sigbuild-r2.9-python3.9 latest-python3.9
+        map sigbuild-r2.9-python3.10 latest-python3.10
+    - name: Create Pull Request with changes
+      uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/update-rbe.yml
+++ b/.github/workflows/update-rbe.yml
@@ -16,6 +16,11 @@
 name: Update RBE Configs
 on:
   workflow_dispatch:
+  schedule:
+    # Run once a week on Sunday at 3am. See http://crontab.guru
+    # Runs at 3am to make sure it picks up the latest images built every week.
+    # See https://github.com/tensorflow/build/blob/master/.github/workflows/docker.yml
+    - cron: '0 3 * * 0'
 
 jobs:
   rbe:
@@ -24,12 +29,15 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Install Python dependencies
+    - name: Update the RBE Configs
       run: |
         function map() {
           digest=$(curl -s "https://gcr.io/v2/tensorflow-sigs/build/manifests/$2" | jq -r .config.digest)
           sed -i"" "s/\(\"$1\".*build@\)sha256:.*\(\",\)/\1$digest\2/" tensorflow/tools/toolchains/remote_config/configs.bzl 
         }
+        # See https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/toolchains/remote_config/configs.bzl
+        # This is a mapping of name_container_map keys under sigbuild_tf_configs
+        # to tag names on gcr.io/tensorflow-sigs/build.
         map sigbuild-r2.9 latest-python3.9
         map sigbuild-r2.9-python3.7 latest-python3.7
         map sigbuild-r2.9-python3.8 latest-python3.8
@@ -37,3 +45,8 @@ jobs:
         map sigbuild-r2.9-python3.10 latest-python3.10
     - name: Create Pull Request with changes
       uses: peter-evans/create-pull-request@v3
+      with:
+        title: Update the RBE images to the latest container versions
+        body: |
+          Automated PR created once per week to get the latest Docker images.
+          See https://github.com/tensorflow/build/blob/master/.github/workflows/docker.yml

--- a/.github/workflows/update-rbe.yml
+++ b/.github/workflows/update-rbe.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         function map() {
           digest=$(curl https://gcr.io/v2/tensorflow-sigs/build/manifests/$2 | jq .config.digest)
-          sed -i"" tensorflow/tools/toolchains/remote_config/configs.bzl "0,/\"$1\".*sha256/s/sha256:.*[^\"]+/$digest/"
+          sed -i"" "0,/\"$1\".*sha256/s/sha256:.*[^\"]+/$digest/" tensorflow/tools/toolchains/remote_config/configs.bzl 
         }
         map sigbuild-r2.9 latest-python3.9
         map sigbuild-r2.9-python3.7 latest-python3.7

--- a/.github/workflows/update-rbe.yml
+++ b/.github/workflows/update-rbe.yml
@@ -49,4 +49,4 @@ jobs:
         title: Update the RBE images to the latest container versions
         body: |
           Automated PR created once per week to get the latest Docker images.
-          See https://github.com/tensorflow/build/blob/master/.github/workflows/docker.yml
+          See https://github.com/tensorflow/tensorflow/blob/master/.github/workflows/update-rbe.yml

--- a/.github/workflows/update-rbe.yml
+++ b/.github/workflows/update-rbe.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Install Python dependencies
       run: |
         function map() {
-          digest=$(curl https://gcr.io/v2/tensorflow-sigs/build/manifests/$2 | jq .config.digest)
-          sed -i"" "0,/\"$1\".*sha256/s/sha256:.*[^\"]+/$digest/" tensorflow/tools/toolchains/remote_config/configs.bzl 
+          digest=$(curl -s "https://gcr.io/v2/tensorflow-sigs/build/manifests/$2" | jq -r .config.digest)
+          sed -i"" "s/\(\"$1\".*build@\)sha256:.*\(\",\)/\1$digest\2/" tensorflow/tools/toolchains/remote_config/configs.bzl 
         }
         map sigbuild-r2.9 latest-python3.9
         map sigbuild-r2.9-python3.7 latest-python3.7

--- a/.github/workflows/update-rbe.yml
+++ b/.github/workflows/update-rbe.yml
@@ -26,6 +26,7 @@ jobs:
   rbe:
     name: Update RBE Configs
     runs-on: ubuntu-latest
+    if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
This creates a new workflow that runs once per week or can be triggered manually to create a PR that automatically updates the list of sha256 hashes for the RBE docker containers to the latest versions available (for the SIG Build containers.)
