### PR TITLE
Added additional compiler `-mfp16-format=ieee`

### DIFF
--- a/tensorflow/lite/g3doc/guide/build_cmake_arm.md
+++ b/tensorflow/lite/g3doc/guide/build_cmake_arm.md
@@ -124,7 +124,7 @@ target has lower glibc version, you need to use older GCC toolchain.
 #### Run CMake
 
 ```sh
-ARMCC_FLAGS="-march=armv7-a -mfpu=neon-vfpv4 -funsafe-math-optimizations"
+ARMCC_FLAGS="-march=armv7-a -mfpu=neon-vfpv4 -funsafe-math-optimizations -mfp16-format=ieee"
 ARMCC_PREFIX=${HOME}/toolchains/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf/bin/arm-linux-gnueabihf-
 cmake -DCMAKE_C_COMPILER=${ARMCC_PREFIX}gcc \
   -DCMAKE_CXX_COMPILER=${ARMCC_PREFIX}g++ \


### PR DESCRIPTION
For successful cross-compilation for ARM using CMake, we should add `-mfp16-format=ieee` an additional compiler option to fix `unknown type name 'float16x8_t'`. For more  details please refer [this issue](https://github.com/tensorflow/tensorflow/issues/54337#issuecomment-1057618003).Thanks!