### PR TITLE
[TF:TRT] Enable out-of-tree op converter registration

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -960,6 +960,7 @@ tf_cc_shared_object(
         "//tensorflow/c:ops",
         "//tensorflow/cc/saved_model:loader_lite_impl",
         "//tensorflow/cc/saved_model:metrics_impl",
+        "//tensorflow/compiler/tf2tensorrt:op_converter_registry_impl",
         "//tensorflow/core/common_runtime:core_cpu_impl",
         "//tensorflow/core:framework_internal_impl",
         "//tensorflow/core/common_runtime/gpu:gpu_runtime_impl",

--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -32,6 +32,12 @@ load(
 )
 load("@local_config_tensorrt//:build_defs.bzl", "if_tensorrt")
 
+# Platform specific build config
+load(
+    "//tensorflow/core/platform:build_config_root.bzl",
+    "if_static",
+)
+
 package(
     default_visibility = ["//visibility:public"],
     features = [
@@ -586,9 +592,29 @@ tf_cuda_library(
     ] + if_tensorrt([":tensorrt_lib"]),
 )
 
+# This rule contains static variables for the converter registry. Do not depend
+# on it directly; use :op_converter_registry, and link against
+# libtensorflow_framework.so for the registry symbols. The library
+# libtensorflow_framework.so depends on this target so that users can
+# register custom op converters without the need to incorporate Tensorflow into
+# their build system.
+tf_cuda_library(
+    name = "op_converter_registry_impl",
+    srcs = ["convert/op_converter_registry.cc"],
+    hdrs = [
+        "convert/op_converter_registry.h",
+    ],
+    visibility = ["//tensorflow:__subpackages__"],
+    deps = [
+        ":utils",
+        ":op_converter",
+        "@com_google_absl//absl/strings",
+        "//tensorflow/core:lib",
+    ] + if_tensorrt([":tensorrt_lib"]),
+)
+
 tf_cuda_library(
     name = "op_converter_registry",
-    srcs = ["convert/op_converter_registry.cc"],
     hdrs = [
         "convert/op_converter_registry.h",
     ],
@@ -596,9 +622,8 @@ tf_cuda_library(
     deps = [
         ":utils",
         ":op_converter",
-        "@com_google_absl//absl/strings",
         "//tensorflow/core:lib",
-    ] + if_tensorrt([":tensorrt_lib"]),
+    ] + if_static([":op_converter_registry_impl"]),
 )
 
 tf_cuda_cc_test(
@@ -939,11 +964,10 @@ tf_proto_library(
     protodeps = tf_additional_all_protos(),
 )
 
-cc_library(
+tf_cuda_library(
     name = "py_utils",
     srcs = ["utils/py_utils.cc"],
     hdrs = ["utils/py_utils.h"],
-    copts = tf_copts(),
     local_defines = select({
         "@local_config_tensorrt//:use_static_tensorrt": ["TF_USE_TENSORRT_STATIC=1"],
         "//conditions:default": [],
@@ -951,6 +975,7 @@ cc_library(
     deps = if_tensorrt([
         ":common_utils",
         ":tensorrt_lib",
+        ":op_converter_registry",
         "//tensorflow/stream_executor/platform:dso_loader",
     ]),
 )

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter.h
@@ -23,7 +23,6 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/trt_parameters.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/weights.h"
-#include "third_party/tensorrt/NvInfer.h"
 
 namespace tensorflow {
 namespace tensorrt {

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.cc
@@ -75,6 +75,16 @@ class OpConverterRegistry::Impl {
     registry_.erase(itr);
   }
 
+  std::vector<std::string> ListRegisteredOps() const {
+    mutex_lock lock(mu_);
+    std::vector<std::string> result;
+    result.reserve(registry_.size());
+    for (const auto& item : registry_) {
+      result.push_back(item.first);
+    }
+    return result;
+  }
+
  private:
   mutable mutex mu_;
   mutable std::unordered_map<std::string, OpConverterRegistration> registry_
@@ -91,6 +101,10 @@ InitOnStartupMarker OpConverterRegistry::Register(const string& name,
                                                   const int priority,
                                                   OpConverter converter) {
   return impl_->Register(name, priority, converter);
+}
+
+std::vector<std::string> OpConverterRegistry::ListRegisteredOps() const {
+  return impl_->ListRegisteredOps();
 }
 
 void OpConverterRegistry::Clear(const std::string& name) { impl_->Clear(name); }

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h
@@ -61,6 +61,8 @@ class OpConverterRegistry {
 
   StatusOr<OpConverter> LookUp(const string& name);
 
+  std::vector<std::string> ListRegisteredOps() const;
+
  private:
   class Impl;
   std::unique_ptr<Impl> impl_;

--- a/tensorflow/compiler/tf2tensorrt/utils/py_utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/py_utils.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
 #include "tensorflow/stream_executor/platform/dso_loader.h"
 #include "third_party/tensorrt/NvInfer.h"
 #endif
@@ -42,6 +43,15 @@ bool IsGoogleTensorRTEnabled() {
 #else   // GOOGLE_CUDA && GOOGLE_TENSORRT
   return false;
 #endif  // GOOGLE_CUDA && GOOGLE_TENSORRT
+}
+
+std::vector<std::string> GetRegisteredOpConverters() {
+#if GOOGLE_CUDA && GOOGLE_TENSORRT
+  auto* registry = tensorflow::tensorrt::convert::GetOpConverterRegistry();
+  return registry->ListRegisteredOps();
+#else
+  return {"undef"};
+#endif
 }
 
 }  // namespace tensorrt

--- a/tensorflow/compiler/tf2tensorrt/utils/py_utils.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/py_utils.h
@@ -16,10 +16,15 @@ limitations under the License.
 #ifndef TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_PY_UTILS_H_
 #define TENSORFLOW_COMPILER_TF2TENSORRT_UTILS_PY_UTILS_H_
 
+#include <string>
+#include <vector>
+
 namespace tensorflow {
 namespace tensorrt {
 
 bool IsGoogleTensorRTEnabled();
+
+std::vector<std::string> GetRegisteredOpConverters();
 
 }  // namespace tensorrt
 }  // namespace tensorflow

--- a/tensorflow/compiler/tf2tensorrt/utils/py_utils_wrapper.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/py_utils_wrapper.cc
@@ -13,9 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <string>
 #include <tuple>
+#include <vector>
 
 #include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/utils/py_utils.h"
 
@@ -37,4 +40,6 @@ PYBIND11_MODULE(_pywrap_py_utils, m) {
         "(Major, Minor, Patch).");
   m.def("is_tensorrt_enabled", tensorflow::tensorrt::IsGoogleTensorRTEnabled,
         "Returns True if TensorRT is enabled.");
+  m.def("get_registered_op_converters", tensorflow::tensorrt::GetRegisteredOpConverters,
+        "Return a list of registered op converters by operation name");
 }


### PR DESCRIPTION
This change moves the static registration system symbols for TF-TRT into `libtensorflow_framework.so`. This enables users to register custom op converters with TF-TRT without requiring TF to be integrated into their build system. Users will only need a C++ compiler and a `pip` installed Tensorflow package to register a custom converter. It also adds utilities to print out the list of op converters registered with TF-TRT.