### PR TITLE
Add float16 and bfloat16 support for tf.image.rgb_to_hsv/tf.image.hsv_to_rgb

### DIFF
--- a/tensorflow/core/kernels/image/colorspace_op.cc
+++ b/tensorflow/core/kernels/image/colorspace_op.cc
@@ -21,7 +21,6 @@ limitations under the License.
 #include <algorithm>
 #include <cmath>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -31,6 +30,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/types.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 
@@ -148,6 +148,5 @@ TF_CALL_double(DECLARE_GPU);
 TF_CALL_float(REGISTER_GPU);
 TF_CALL_double(REGISTER_GPU);
 #endif
-
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/image/colorspace_op.cc
+++ b/tensorflow/core/kernels/image/colorspace_op.cc
@@ -116,6 +116,8 @@ class HSVToRGBOp : public OpKernel {
   template class HSVToRGBOp<CPUDevice, T>;
 TF_CALL_float(REGISTER_CPU);
 TF_CALL_double(REGISTER_CPU);
+TF_CALL_half(REGISTER_CPU);
+TF_CALL_bfloat16(REGISTER_CPU);
 
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -95,6 +95,20 @@ class RGBToHSVTest(test_util.TensorFlowTestCase):
         rgb_tf = self.evaluate(rgb)
       self.assertAllClose(rgb_tf, rgb_np)
 
+  def testRGBToHSVDataTypes(self):
+    # Test case for GitHub issue 54855.
+    data = [0, 5, 13, 54, 135, 226, 37, 8, 234, 90, 255, 1]
+    for dtype in [
+        dtypes.float32, dtypes.float64,
+        dtypes.float16, dtypes.bfloat16]:
+      with self.cached_session(use_gpu=False):
+        rgb = math_ops.cast(
+            np.array(data, np.float32).reshape([2, 2, 3]) / 255., dtype = dtype)
+        hsv = image_ops.rgb_to_hsv(rgb)
+        val = image_ops.hsv_to_rgb(hsv)
+        out = self.evaluate(val)
+        self.assertAllClose(rgb, out, atol=1e-2)
+
 
 class RGBToYIQTest(test_util.TensorFlowTestCase):
 


### PR DESCRIPTION
This PR addresses the issue raised in #54855 where there was no float16
and bfloat16 support for tf.image.rgb_to_hsv/tf.image.hsv_to_rgb

This PR fixes #54855.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>