### PR TITLE
Replace insecure `tempfile.mktemp` with `tempfile.mkstemp`

### DIFF
--- a/tensorflow/python/debug/cli/curses_ui_test.py
+++ b/tensorflow/python/debug/cli/curses_ui_test.py
@@ -1217,7 +1217,7 @@ class CursesTest(test_util.TensorFlowTestCase):
     self.assertEqual("ERROR: Empty indices.", ui.toasts[6])
 
   def testWriteScreenOutputToFileWorks(self):
-    output_path = tempfile.mktemp()
+    output_path = tempfile.mkstemp()
 
     ui = MockCursesUI(
         40,
@@ -1254,7 +1254,7 @@ class CursesTest(test_util.TensorFlowTestCase):
     self.assertEqual(0, len(ui.unwrapped_outputs))
 
   def testAppendingRedirectErrors(self):
-    output_path = tempfile.mktemp()
+    output_path = tempfile.mkstemp()
 
     ui = MockCursesUI(
         40,


### PR DESCRIPTION
This PR replace insecure tempfile.mktemp with tempfile.mkstemp,
as the former are insecure and deprecated:
https://docs.python.org/3/library/tempfile.html#tempfile.mktemp

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>