### PR TITLE
Adding executable code for `tf.sparse.softmax`

### DIFF
--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -2675,13 +2675,21 @@ def sparse_softmax(sp_input, name=None):
   Example:
 
   ```python
-  import tensorflow as tf
-  shape = [2, 2, 2]  # 3-D SparseTensor
-  values = np.asarray([[[0., np.e], [1., 0.]], [[np.e, 0.], [np.e, np.e]]])
-  indices = np.vstack(np.where(values)).astype(np.int64).T
-  values = values[np.where(values)] # Flatten values
-  result = tf.sparse.softmax(tf.sparse.SparseTensor(indices, values, shape)) 
-  print(tf.sparse.to_dense(result))
+  >>> import tensorflow as tf
+  >>> shape = [2, 2, 2]  # 3-D SparseTensor
+  >>> values = np.asarray([[[0., np.e], [1., 0.]], [[np.e, 0.], [np.e, np.e]]])
+  >>> indices = np.vstack(np.where(values)).astype(np.int64).T
+  >>> values = values[np.where(values)] # Flatten values
+  >>> result = tf.sparse.softmax(tf.sparse.SparseTensor(indices, values, shape)) 
+  >>> print(tf.sparse.to_dense(result))
+  
+  <... output:
+  tf.Tensor(
+[[[0.  1. ]
+  [1.  0. ]]
+
+ [[1.  0. ]
+  [0.5 0.5]]], shape=(2, 2, 2), dtype=float64) ...>
   ```
 
   Args:

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -2675,13 +2675,10 @@ def sparse_softmax(sp_input, name=None):
   Example:
 
   ```python
-  >>> import tensorflow as tf
+  
   >>> shape = [2, 2, 2]  # 3-D SparseTensor
   >>> values = np.asarray([[[0., np.e], [1., 0.]], [[np.e, 0.], [np.e, np.e]]])
   >>> indices = np.vstack(np.where(values)).astype(np.int64).T
-  >>> values = values[np.where(values)] # Flatten values
-  >>> result = tf.sparse.softmax(tf.sparse.SparseTensor(indices, values, shape)) 
-  >>> print(tf.sparse.to_dense(result))
   
   <... output:
   tf.Tensor(

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -2675,21 +2675,13 @@ def sparse_softmax(sp_input, name=None):
   Example:
 
   ```python
-  # First batch:
-  # [?   e.]
-  # [1.  ? ]
-  # Second batch:
-  # [e   ? ]
-  # [e   e ]
+  import tensorflow as tf
   shape = [2, 2, 2]  # 3-D SparseTensor
   values = np.asarray([[[0., np.e], [1., 0.]], [[np.e, 0.], [np.e, np.e]]])
   indices = np.vstack(np.where(values)).astype(np.int64).T
-
-  result = tf.sparse.softmax(tf.sparse.SparseTensor(indices, values, shape))
-  # ...returning a 3-D SparseTensor, equivalent to:
-  # [?   1.]     [1    ?]
-  # [1.  ? ] and [.5  .5]
-  # where ? means implicitly zero.
+  values = values[np.where(values)] # Flatten values
+  result = tf.sparse.softmax(tf.sparse.SparseTensor(indices, values, shape)) 
+  print(tf.sparse.to_dense(result))
   ```
 
   Args:

--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -2674,21 +2674,15 @@ def sparse_softmax(sp_input, name=None):
 
   Example:
 
-  ```python
-  
   >>> shape = [2, 2, 2]  # 3-D SparseTensor
   >>> values = np.asarray([[[0., np.e], [1., 0.]], [[np.e, 0.], [np.e, np.e]]])
   >>> indices = np.vstack(np.where(values)).astype(np.int64).T
-  
-  <... output:
-  tf.Tensor(
-[[[0.  1. ]
-  [1.  0. ]]
-
- [[1.  0. ]
-  [0.5 0.5]]], shape=(2, 2, 2), dtype=float64) ...>
-  ```
-
+  <tf.Tensor(
+   [[[0.  1. ]
+   [1.  0. ]]
+   [[1.  0. ]
+   [0.5 0.5]]], shape=(2, 2, 2), dtype=float64)>
+   
   Args:
     sp_input: N-D `SparseTensor`, where `N >= 2`.
     name: optional name of the operation.


### PR DESCRIPTION
Changed the documentation of tf.sparse.softmax with executable example code.
The values passed to tf.sparse.SparseTensor must be a rank-1 tensor instead of a rank-3 tensor.

Fixes #[55035](https://github.com/tensorflow/tensorflow/issues/55035)