### PR TITLE
[oneDNN] Fix Windows build failure due to OpenMP linking error in Bazel 5

### DIFF
--- a/third_party/llvm_openmp/openmp.bzl
+++ b/third_party/llvm_openmp/openmp.bzl
@@ -77,9 +77,9 @@ def libiomp5_cc_binary(name, cppsources, srcdeps, common_includes):
                        ":openmp_asm",
                    ],
                ),
-        copts = select_os_specific_2(
-            LM = ["-Domp_EXPORTS -D_GNU_SOURCE -D_REENTRANT"],
-            W = ["/Domp_EXPORTS /D_M_AMD64 /DOMPT_SUPPORT=0 /D_WINDOWS /D_WINNT /D_USRDLL"],
+        defines = select_os_specific_2(
+            LM = ["omp_EXPORTS", "_GNU_SOURCE", "_REENTRANT"],
+            W = ["omp_EXPORTS", "_M_AMD64", "OMPT_SUPPORT=0", "_WINDOWS", "_WINNT", "_USRDLL"],
         ),
         includes = common_includes,
         linkopts = select_os_specific_2(


### PR DESCRIPTION
Prior to this PR, Windows builds were failing with this error:
omp_dll.def : error LNK2001: unresolved external symbol __kmp_invoke_microtask bazel-out/x64_windows-opt/bin/external/llvm_openmp/libiomp5md.dll.if.lib : fatal error LNK1120: 1 unresolved externals

It was root caused to a commit# 8871926 fails (needs bazel 5.0 to run).
The immediately previous commit# e135db1 passes (needs bazel 4.2.2).
We also noticed that Bazel 5.0 was not adding some symbol defines in the z_Windows_NT-586_asm.obj.params file when assembling the file z_Windows_NT-586_asm.S

It was further analyzed and it seems Bazel 5 behaves differently than Bazel 4 in this linking context. We made a successful build with Bazel 4.x on commit# e135db1. Changed to Bazel 5.x. Build failed. Then added a 'defines' field under cc_binary in the ...\third_party\llvm_openmp\openmp.bzl file. The assembler picked up the correct Windows specific defines. So it appears, in Bazel 5.x copts options are only used for C/C++ compilations, but not for assembler (unlike in Bazel 4.x).