### PR TITLE
[TF:TRT] INT8 calibration in dynamic shape mode

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -510,12 +510,6 @@ TRTEngineOp::TRTEngineOp(OpKernelConstruction* context)
       [](PartialTensorShape shape) { return !shape.IsFullyDefined(); });
   VLOG(2) << "TRTEngineOp has_dynamic_shape_input_: "
           << has_dynamic_shape_input_;
-
-  if (has_dynamic_shape_input_ && !use_implicit_batch_) {
-    OP_REQUIRES(context, !calibration_mode_,
-                errors::InvalidArgument(
-                    "Dynamic shape mode does not support calibration"));
-  }
 }
 
 // Copies input tensor ctx->input(i) (which is in device memory) to the host,
@@ -786,38 +780,6 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
                        dummy_async_helper);
   core::ScopedUnref unref_cache_res(cache_res);
 
-  // Run calibration if in int8+calibration mode.
-  // * Logic in TF 1.x:
-  //   - During conversion: calibration_mode_ is true and cache size is 0, so it
-  //     will run calibration.
-  //   - During inference: calibration_data will be set, so calibration_mode_ is
-  //     false and it won't trigger calibration.
-  // * Logic in TF 2.0:
-  //   - During conversion: similar to 1.x.
-  //   - During inference: calibration_data will still be empty, but cache will
-  //     contain the the calibrated engine, so it won't trigger calibration.
-  //
-  // TODO(laigd): consider the following alternatives:
-  // 1. Serialize the state (calibration or inference) using
-  //    TRTEngineInstance proto (or a new proto), so we know which mode we're
-  //    in and don't run calibration during inference (which is invalid).
-  // 2. Reuse the calibration_data attribute or use a new attribute in the
-  //    NodeDef to indicate whether it's in calibration mode.
-  if (calibration_mode_ && cache_res->cache_.size() == 0) {
-    if (!cache_res->calib_ctx_) {
-      // TODO(laigd): better encapsulation.
-      mutex_lock lock(engine_mutex_);
-      if (!cache_res->calib_ctx_) {
-        OP_REQUIRES_OK_ASYNC(ctx, AllocateCalibrationResources(ctx, cache_res),
-                             dummy_async_helper);
-      }
-    }
-    // TODO(laigd): check that the input shapes match the shapes of the
-    // persistent tensor in the calibration resource.
-    ExecuteCalibration(ctx, cache_res, async_helper);
-    return;
-  }
-
   // Get shapes of inputs to engine.
   std::vector<TensorShape> input_concrete_shapes;
   input_concrete_shapes.reserve(ctx->num_inputs());
@@ -864,6 +826,44 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
                                         profile_strategy_);
     }
   }
+
+  // Run calibration if in int8+calibration mode.
+  // * Logic in TF 1.x:
+  //   - During conversion: calibration_mode_ is true and cache size is 0, so it
+  //     will run calibration.
+  //   - During inference: calibration_data will be set, so calibration_mode_
+  //     is false and it won't trigger calibration.
+  // * Logic in TF 2.0:
+  //   - During conversion: similar to 1.x.
+  //   - During inference: calibration_data will still be empty, but cache will
+  //     contain the calibrated engine, so it won't trigger calibration.
+  //
+  // TODO(laigd): consider the following alternatives:
+  // 1. Serialize the state (calibration or inference) using
+  //    TRTEngineInstance proto (or a new proto), so we know which mode we're
+  //    in and don't run calibration during inference (which is invalid).
+  // 2. Reuse the calibration_data attribute or use a new attribute in the
+  //    NodeDef to indicate whether it's in calibration mode.
+  if (calibration_mode_ && cache_res->cache_.size() == 0) {
+    if (!cache_res->calib_ctx_) {
+      // TODO(laigd): better encapsulation.
+      mutex_lock lock(engine_mutex_);
+      if (!cache_res->calib_ctx_) {
+        // Add profiles if we are in dynamic shape mode.
+        if (!use_implicit_batch_ && (has_dynamic_shape_input_ ||
+                                     cache_res->profiles_.HasShapeTensor())) {
+          cache_res->profiles_.InitCalibProfile(input_concrete_shapes);
+        }
+        OP_REQUIRES_OK_ASYNC(ctx, AllocateCalibrationResources(ctx, cache_res),
+                             dummy_async_helper);
+      }
+    }
+    // TODO(laigd): check that the input shapes match the shapes of the
+    // persistent tensor in the calibration resource.
+    ExecuteCalibration(ctx, cache_res, async_helper);
+    return;
+  }
+
   StatusOr<std::pair<EngineContext*, int>> status =
       GetEngine(input_concrete_shapes, ctx, cache_res);
   OP_REQUIRES_OK_ASYNC(ctx, status.status(), dummy_async_helper);
@@ -1269,10 +1269,18 @@ Status TRTEngineOp::AllocateCalibrationResources(
         "Context->device doesn't contain device info!");
   }
 
+  bool use_concrete_shapes =
+      use_implicit_batch_ || cache_res->profiles_.IsStaticCompatible();
+  const std::vector<PartialTensorShape>& conversion_input_shapes =
+      use_concrete_shapes
+          ? std::vector<PartialTensorShape>(shapes.begin(), shapes.end())
+          : input_partial_shapes_;
+
   cache_res->Ref();
   string platform_device_name = ctx->device()->name();
-  cres->thr_.reset(new std::thread([this, cres, shapes, platform_device_id,
-                                    platform_device_name, cache_res]() {
+  cres->thr_.reset(new std::thread([this, cres, shapes, conversion_input_shapes,
+                                    platform_device_id, platform_device_name,
+                                    cache_res]() {
     core::ScopedUnref sc(cache_res);
 
     VLOG(1) << "Starting calibration thread on device " << platform_device_id
@@ -1283,8 +1291,6 @@ Status TRTEngineOp::AllocateCalibrationResources(
       LOG(ERROR) << "Couldn't set cuda device to " << platform_device_id
                  << " in calibration thread";
     }
-    std::vector<PartialTensorShape> partial_shapes(shapes.begin(),
-                                                   shapes.end());
 
     std::unordered_map<string, tensorflow::DeviceProperties> device_map;
     DeviceNameUtils::ParsedName full_parsed_name;
@@ -1304,10 +1310,11 @@ Status TRTEngineOp::AllocateCalibrationResources(
     auto s = convert::ConvertGraphDefToEngine(
         this->segment_graph_def_, TrtPrecisionMode::INT8,
         cres->calibrator_->getBatchSize(), this->workspace_size_,
-        partial_shapes, &cache_res->GetLogger(), cache_res->allocator_.get(),
-        cres->calibrator_.get(), &cres->engine_, /*use_calibration=*/true,
-        this->use_implicit_batch_, /*convert_successfully=*/nullptr,
-        /*profiles=*/nullptr, name(),
+        conversion_input_shapes, &cache_res->GetLogger(),
+        cache_res->allocator_.get(), cres->calibrator_.get(), &cres->engine_,
+        /*use_calibration=*/true, this->use_implicit_batch_,
+        /*convert_successfully=*/nullptr,
+        /*profiles=*/&cache_res->profiles_, name(),
         /*use_explicit_precision=*/use_explicit_precision_,
         /*cluster=*/&cluster);
     if (!s.ok()) {
@@ -1318,10 +1325,21 @@ Status TRTEngineOp::AllocateCalibrationResources(
       // dump it out during conversion for TF 2.0.
       mutex_lock lock(this->engine_mutex_);
       this->calibrator_ = std::move(cres->calibrator_);
-      ExecutionContext context = ExecutionContext::Create(cres->engine_.get());
-      cache_res->cache_.emplace(
-          shapes, absl::make_unique<EngineContext>(std::move(cres->engine_),
-                                                   std::move(context)));
+      if (!use_implicit_batch_ &&
+          (has_dynamic_shape_input_ || cache_res->profiles_.HasShapeTensor())) {
+        std::vector<ExecutionContext> exec_contexts;
+        auto calib_result = cache_res->profiles_.CreateExecutionContexts(
+            cres->engine_.get(), &exec_contexts);
+        cache_res->cache_.emplace(
+            shapes, absl::make_unique<EngineContext>(std::move(cres->engine_),
+                                                     std::move(exec_contexts)));
+      } else {
+        ExecutionContext context =
+            ExecutionContext::Create(cres->engine_.get());
+        cache_res->cache_.emplace(
+            shapes, absl::make_unique<EngineContext>(std::move(cres->engine_),
+                                                     std::move(context)));
+      }
     }
 
     VLOG(1) << "Calibration loop terminated " << this->name();

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
@@ -318,9 +318,52 @@ void TrtShapeOptimizationProfile::InitProfiles(
   }
 }
 
+void TrtShapeOptimizationProfile::InitCalibProfile(
+    const std::vector<TensorShape>& shapes) {
+  VLOG(1) << "Collected shape(s) " << DebugString(shapes) << " for "
+          << " calibration profile.";
+  auto shape_vec = shapes;
+  if (!shape_vec.empty()) {
+    std::vector<nvinfer1::Dims> dimvec = GetDimVec(shape_vec);
+    dimvec.insert(dimvec.end(), actual_shape_values_.begin(),
+                  actual_shape_values_.end());
+    VLOG(2) << "Initializing calibration optimization profile config with "
+            << "min=opt=max " << DebugString(dimvec);
+
+    OptimizationProfileConfig profConfig{dimvec, dimvec, dimvec};
+    calib_profiles_ = std::move(profConfig);
+  } else {
+    VLOG(2) << "Failed to initialize calibration optimization profile.";
+  }
+}
+
 Status TrtShapeOptimizationProfile::AddProfiles(
     nvinfer1::IBuilder* builder, nvinfer1::IBuilderConfig* config,
     const nvinfer1::INetworkDefinition* network) {
+  // Create optimization profile for calibration if necessary.
+  if (!calib_profiles_.min.empty()) {
+    VLOG(2) << "Setting up calibration profies";
+    auto* calibProfile = builder->createOptimizationProfile();
+    Status status = calib_profiles_.SetDimensions(network, calibProfile);
+    if (!status.ok()) {
+      return status;
+    }
+    bool result = false;
+    if (calibProfile->isValid()) {
+      result = config->setCalibrationProfile(calibProfile);
+    } else {
+      VLOG(2) << "Calibration profile is not valid";
+    }
+    if (result) {
+      VLOG(2) << "Added calibration optimization profile "
+              << calib_profiles_.DebugString() << " to builder config.";
+    } else {
+      VLOG(2) << "FAILED TO ADD PROFILE";
+      LOG(ERROR) << "Failed to add calibration optimization profile "
+                 << calib_profiles_.DebugString()
+                 << ". This usually happens when profile is invalid.";
+    }
+  }
   // Create a vector of optimization profiles.
   for (int i = 0; i < profiles_.size(); i++) {
     auto* optProfile = builder->createOptimizationProfile();

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
@@ -224,6 +224,8 @@ class TrtShapeOptimizationProfile {
   void InitProfiles(const std::vector<PartialTensorShape>& input_partial_shapes,
                     ProfileStrategy strategy);
 
+  void InitCalibProfile(const std::vector<TensorShape>& shapes);
+
   // Returns number of created profiles.
   int GetNumProfiles() const;
 
@@ -262,6 +264,9 @@ class TrtShapeOptimizationProfile {
 
   // The optimization profiles generated from input_shapes_.
   std::vector<OptimizationProfileConfig> profiles_;
+
+  // The optimization profile for calibration.
+  OptimizationProfileConfig calib_profiles_;
 
   // Whether the network has any shape tensors. Initially we assume that the
   // network might have a shape value input. This will be updated when the

--- a/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
@@ -66,6 +66,12 @@ class ShapeOutputTest(trt_test.TfTrtIntegrationTestBase):
       # tensors have only one dimensions
       return ["TRTEngineOp_000"]
 
+  def ShouldRunTest(self, run_params):
+    # We cannot calibrate without bulding the engine, we turn of INT8 test.
+    return (run_params.dynamic_shape and
+            run_params.precision_mode != 'INT8',
+            "no calibration dynamic shape")
+
 
 class ShapeOutputWithSingleInputProfile(ShapeOutputTest):
   """Same as the previous test, but with a single input profile."""
@@ -222,6 +228,12 @@ class ShapeValueMaskTest(trt_test.TfTrtIntegrationTestBase):
       return ["TRTEngineOp_000"]
     else:
       return []
+
+  def ShouldRunTest(self, run_params):
+    # We cannot calibrate without bulding the engine, we turn of INT8 test.
+    return (run_params.dynamic_shape and
+            run_params.precision_mode != 'INT8',
+            "no calibration dynamic shape")
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -474,14 +474,34 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
 
     converter = self._CreateConverter(run_params, saved_model_dir,
                                       conversion_params)
-    int8_gdef = converter.convert()
-    self._VerifyGraphDef(run_params, saved_model_dir, int8_gdef,
-                         GraphState.CALIBRATE)
+    if run_params.is_v2:
+      def calibration_input_fn():
+        for data_tensors in inputs_data:
+          yield data_tensors
+      converter.convert(calibration_input_fn=calibration_input_fn)
+    else:
+      int8_gdef = converter.convert()
+      self._VerifyGraphDef(run_params, saved_model_dir, int8_gdef,
+                          GraphState.CALIBRATE)
 
-    converter.calibrate(
-        fetch_names=self._GetFetchNames(),
-        num_runs=5,
-        feed_dict_fn=lambda: self._GetFeedDict(inputs_data[0]))
+      converter.calibrate(
+          fetch_names=self._GetFetchNames(),
+          num_runs=5,
+          feed_dict_fn=lambda: self._GetFeedDict(inputs_data[0]))
+
+    if run_params.dynamic_shape and self._ShouldConverterBuild(run_params):
+      logging.info("Using build mode")
+
+      def _BuildInputFn():
+        for shapes in self._GetParamsCached().input_dims:
+          yield [
+              array_ops.zeros(x, dtype=spec.dtype)
+              for (x, spec) in zip(shapes,
+                                   self._GetParamsCached().input_specs)
+          ]
+
+      converter.build(input_fn=_BuildInputFn)
+
     trt_saved_model_dir = self._GetSavedModelDir(run_params,
                                                  GraphState.CALIBRATE)
     converter.save(trt_saved_model_dir)
@@ -1047,6 +1067,7 @@ def _GetTestConfigsV2():
   dynamic_engine = True
   # TODO(laigd): add support for calibration.
   no_calibration = False
+  use_calibration = True
 
   # Add all possible test cases and let the derived test class to decide
   # whether to run specific ones with ShouldRunTest().
@@ -1058,11 +1079,11 @@ def _GetTestConfigsV2():
   #   Grappler config in default eager context.
   # - INT8 without calibration behaves like FP32/FP16.
   opts = list(
-      itertools.product([FP32, FP16, INT8], [convert_offline], [dynamic_engine],
+      itertools.product([FP32, FP16], [convert_offline], [dynamic_engine],
                         [no_calibration], [False, True]))
   # We always run calibration with offline tool.
-  # TODO(aaroey): INT8+calibration is not supported yet in V2.
-  # opts.append((INT8, convert_offline, dynamic_engine, use_calibration))
+  opts.append((INT8, convert_offline, dynamic_engine, use_calibration, False))
+  opts.append((INT8, convert_offline, dynamic_engine, use_calibration, True))
   return opts
 
 

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -910,6 +910,23 @@ def _get_engine_dtypes_from_node(node, key):
 def _get_engines_io_nodes_count(node, key):
   return len(node.attr[key].list.type)
 
+
+def _save_calibration_table(node):
+  calibration_table = gen_trt_ops.get_calibration_data_op(
+      _get_canonical_engine_name(node.name))
+  node.attr["calibration_data"].s = calibration_table.numpy()
+
+
+def _convert_to_tensor(inp):
+  if isinstance(inp, dict):
+    args = []
+    kwargs = {k: ops.convert_to_tensor(v) for k, v in inp.items()}
+  else:
+    args = map(ops.convert_to_tensor, inp)
+    kwargs = {}
+  return args, kwargs
+
+
 @tf_export("experimental.tensorrt.Converter", v1=[])
 class TrtGraphConverterV2(object):
   """An offline converter for TF-TRT transformation for TF 2.0 SavedModels.
@@ -1108,8 +1125,11 @@ class TrtGraphConverterV2(object):
         (conversion_params.precision_mode == TrtPrecisionMode.INT8.lower())) and
                               conversion_params.use_calibration)
 
+    self._calibration_input_fn = None
+
     self._converted = False
     self._build_called_once = False
+    self._calibrated = False
 
     if use_dynamic_shape is None:
       self._use_dynamic_shape = False
@@ -1177,6 +1197,18 @@ class TrtGraphConverterV2(object):
         func.structured_input_signature)
     return rebuilt_func
 
+  def _execute_calibration(self, calibration_input_fn):
+    for inp in calibration_input_fn():
+      args, kwargs = _convert_to_tensor(inp)
+      self._converted_func(*args, **kwargs)
+
+    self._for_each_trt_node(self._converted_graph_def,
+                            _save_calibration_table)
+
+    # Rebuild the function since calibration has changed the graph.
+    self._converted_func = self._rebuild_func(self._converted_func)
+    self._calibrated = True
+
   # TODO(laigd): provide a utility function to optimize a ConcreteFunction and
   # use it here (b/124792963).
   def convert(self, calibration_input_fn=None):
@@ -1187,6 +1219,15 @@ class TrtGraphConverterV2(object):
         list or tuple or dict, which will be used to execute the converted
         signature for calibration. All the returned input data should have the
         same shape. Example: `def input_fn(): yield input1, input2, input3`
+
+        If dynamic_shape_mode==False, (or if the graph has static input shapes)
+        then we run calibration and build the calibrated engine during
+        conversion.
+
+        If dynamic_shape_mode==True (and the graph has any unknown input
+        shape), then the reference to calibration_input_fn is stored, and the
+        calibration is actually performed when we build the engine (see
+        build()).
 
     Raises:
       ValueError: if the input combination is invalid.
@@ -1242,29 +1283,22 @@ class TrtGraphConverterV2(object):
         func.structured_input_signature)
 
     if self._need_calibration:
-      for inp in calibration_input_fn():
-        if isinstance(inp, dict):
-          self._converted_func(
-              **{k: ops.convert_to_tensor(v) for k, v in inp.items()})
-        else:
-          self._converted_func(*map(ops.convert_to_tensor, inp))
+      # Execute calibration here only if not in dynamic shape mode.
+      if not self._need_trt_profiles():
+        self._execute_calibration(calibration_input_fn)
+      else:
+        self._calibration_input_fn = calibration_input_fn
 
-      def _save_calibration_table(node):
-        calibration_table = gen_trt_ops.get_calibration_data_op(
-            _get_canonical_engine_name(node.name))
-        node.attr["calibration_data"].s = calibration_table.numpy()
-
-      self._for_each_trt_node(self._converted_graph_def,
-                              _save_calibration_table)
-
-      # Rebuild the function since calibration has changed the graph.
-      self._converted_func = self._rebuild_func(self._converted_func)
 
     self._converted = True
     return self._converted_func
 
   def build(self, input_fn):
     """Run inference with converted graph in order to build TensorRT engines.
+
+    If the conversion requires INT8 calibration, then a reference to the
+    calibration function was stored during the call to convert(). Calibration
+    will be performed while we build the TensorRT engines.
 
     Args:
       input_fn: a generator function that yields input data as a list or tuple
@@ -1288,6 +1322,12 @@ class TrtGraphConverterV2(object):
     if not input_fn:
       raise RuntimeError("input_fn is None. Method build() needs input_fn "
                          "to be specified in order to build TensorRT engines")
+    if not self._converted:
+      raise RuntimeError("Need to call convert() before build()")
+    if self._need_calibration and not self._calibrated and \
+        self._calibration_input_fn == None:
+      raise RuntimeError("Need to provide the calibration_input_fn arg while "
+                         "calling convert().")
 
     def _set_profile_generation_mode(value, node):
       node.attr["_profile_generation_mode"].b = value
@@ -1310,15 +1350,21 @@ class TrtGraphConverterV2(object):
     for inp in input_fn():
       if not first_input:
         first_input = inp
-      if isinstance(inp, dict):
-        func(**{k: ops.convert_to_tensor(v) for k, v in inp.items()})
-      else:
-        func(*map(ops.convert_to_tensor, inp))
+      args, kwargs = _convert_to_tensor(inp)
+      func(*args, **kwargs)
 
     if self._need_trt_profiles():
       # Disable profile generation.
       self._for_each_trt_node(self._converted_graph_def,
                               partial(_set_profile_generation_mode, False))
+
+
+    # Run calibration if required, this would have been skipped in
+    # the convert step
+    if self._need_calibration and not self._calibrated:
+      self._execute_calibration(self._calibration_input_fn)
+      # calibration also builds the engine
+    else:
       # Use the first input in explicit batch mode to build TensorRT engines
       # after generating all the profiles. The first input is used but any of
       # the inputs can be used because the shape of this input does not
@@ -1345,7 +1391,10 @@ class TrtGraphConverterV2(object):
         and saved on.
     """
     assert self._converted
-
+    if self._need_calibration and not self._calibrated:
+      raise RuntimeError("A model that requires INT8 calibration has to be "
+                         "built before saving it. Call build() to build and "
+                         "calibrate the TensorRT engines.")
     # Serialize the TRT engines in the cache if any, and create trackable
     # resource to track them.
     engine_asset_dir = tempfile.mkdtemp()


### PR DESCRIPTION
This PR enables INT8 conversion with calibration in dynamic shape mode.

- The profile collection logic is moved before the calibration step in TRTEngineOP, because TRT optimization profiles have to be defined before we can calibrate an engine.
- INT8 test are now enabled in V2 mode both with and without dynamic shapes.

Tracker: #45481