### PR TITLE
Fix out size eqn in atrous_conv2d doc

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -1865,8 +1865,8 @@ def atrous_conv2d(value, filters, rate, padding, name=None):
     A `Tensor` with the same type as `value`.
     Output shape with `'VALID'` padding is:
 
-        [batch, height - 2 * (filter_width - 1),
-         width - 2 * (filter_height - 1), out_channels].
+        [batch, height - rate * (filter_width - 1),
+         width - rate * (filter_height - 1), out_channels].
 
     Output shape with `'SAME'` padding is:
 


### PR DESCRIPTION
The following code can be found in [this colab notebook](https://colab.research.google.com/drive/1g9FNR-3g4KIxWdUw8q5hGJATFMAhKElU?usp=sharing). It shows that the equation for the height and width of the output of `tf.nn.atrous_conv2d` reported in the documentation is incorrect when `padding` is `'VALID'`, and demonstrates the correct equation, which this PR provides.

```python
import tensorflow as tf

def out_size(in_size, filter_size, rate, padding):
  value = tf.ones((1, in_size, in_size, 1))
  filters = tf.ones((filter_size, filter_size, 1, 1))
  actual_out = tf.nn.atrous_conv2d(value, filters, rate, padding)
  actual_out_size = tf.shape(actual_out)[1]
  if padding == 'VALID':
    current_doc = in_size - 2 * (filter_size - 1)
    proposed_doc = in_size - rate * (filter_size - 1)
  else: # padding == 'SAME'
    current_doc = in_size
    proposed_doc = in_size
  return actual_out_size, current_doc, proposed_doc
  
for padding in ('VALID', 'SAME'):
  for in_size in (8, 9, 10, 11):
    for filter_size in (1, 2, 3):
      for rate in (1, 2, 3):
        actual, current, proposed = out_size(in_size, filter_size, rate,
                                             padding)
        print("pad: %-5s, in: %2d, f: %d, r: %d / "
              "actual: %2d, current doc: %2d, proposed doc: %2d" %
              (padding, in_size, filter_size, rate, actual, current, proposed))
```

Output:
```
pad: VALID, in:  8, f: 1, r: 1 / actual:  8, current doc:  8, proposed doc:  8
pad: VALID, in:  8, f: 1, r: 2 / actual:  8, current doc:  8, proposed doc:  8
pad: VALID, in:  8, f: 1, r: 3 / actual:  8, current doc:  8, proposed doc:  8
pad: VALID, in:  8, f: 2, r: 1 / actual:  7, current doc:  6, proposed doc:  7
pad: VALID, in:  8, f: 2, r: 2 / actual:  6, current doc:  6, proposed doc:  6
pad: VALID, in:  8, f: 2, r: 3 / actual:  5, current doc:  6, proposed doc:  5
pad: VALID, in:  8, f: 3, r: 1 / actual:  6, current doc:  4, proposed doc:  6
pad: VALID, in:  8, f: 3, r: 2 / actual:  4, current doc:  4, proposed doc:  4
pad: VALID, in:  8, f: 3, r: 3 / actual:  2, current doc:  4, proposed doc:  2
pad: VALID, in:  9, f: 1, r: 1 / actual:  9, current doc:  9, proposed doc:  9
pad: VALID, in:  9, f: 1, r: 2 / actual:  9, current doc:  9, proposed doc:  9
pad: VALID, in:  9, f: 1, r: 3 / actual:  9, current doc:  9, proposed doc:  9
pad: VALID, in:  9, f: 2, r: 1 / actual:  8, current doc:  7, proposed doc:  8
pad: VALID, in:  9, f: 2, r: 2 / actual:  7, current doc:  7, proposed doc:  7
pad: VALID, in:  9, f: 2, r: 3 / actual:  6, current doc:  7, proposed doc:  6
pad: VALID, in:  9, f: 3, r: 1 / actual:  7, current doc:  5, proposed doc:  7
pad: VALID, in:  9, f: 3, r: 2 / actual:  5, current doc:  5, proposed doc:  5
pad: VALID, in:  9, f: 3, r: 3 / actual:  3, current doc:  5, proposed doc:  3
pad: VALID, in: 10, f: 1, r: 1 / actual: 10, current doc: 10, proposed doc: 10
pad: VALID, in: 10, f: 1, r: 2 / actual: 10, current doc: 10, proposed doc: 10
pad: VALID, in: 10, f: 1, r: 3 / actual: 10, current doc: 10, proposed doc: 10
pad: VALID, in: 10, f: 2, r: 1 / actual:  9, current doc:  8, proposed doc:  9
pad: VALID, in: 10, f: 2, r: 2 / actual:  8, current doc:  8, proposed doc:  8
pad: VALID, in: 10, f: 2, r: 3 / actual:  7, current doc:  8, proposed doc:  7
pad: VALID, in: 10, f: 3, r: 1 / actual:  8, current doc:  6, proposed doc:  8
pad: VALID, in: 10, f: 3, r: 2 / actual:  6, current doc:  6, proposed doc:  6
pad: VALID, in: 10, f: 3, r: 3 / actual:  4, current doc:  6, proposed doc:  4
pad: VALID, in: 11, f: 1, r: 1 / actual: 11, current doc: 11, proposed doc: 11
pad: VALID, in: 11, f: 1, r: 2 / actual: 11, current doc: 11, proposed doc: 11
pad: VALID, in: 11, f: 1, r: 3 / actual: 11, current doc: 11, proposed doc: 11
pad: VALID, in: 11, f: 2, r: 1 / actual: 10, current doc:  9, proposed doc: 10
pad: VALID, in: 11, f: 2, r: 2 / actual:  9, current doc:  9, proposed doc:  9
pad: VALID, in: 11, f: 2, r: 3 / actual:  8, current doc:  9, proposed doc:  8
pad: VALID, in: 11, f: 3, r: 1 / actual:  9, current doc:  7, proposed doc:  9
pad: VALID, in: 11, f: 3, r: 2 / actual:  7, current doc:  7, proposed doc:  7
pad: VALID, in: 11, f: 3, r: 3 / actual:  5, current doc:  7, proposed doc:  5
pad: SAME , in:  8, f: 1, r: 1 / actual:  8, current doc:  8, proposed doc:  8
pad: SAME , in:  8, f: 1, r: 2 / actual:  8, current doc:  8, proposed doc:  8
pad: SAME , in:  8, f: 1, r: 3 / actual:  8, current doc:  8, proposed doc:  8
pad: SAME , in:  8, f: 2, r: 1 / actual:  8, current doc:  8, proposed doc:  8
pad: SAME , in:  8, f: 2, r: 2 / actual:  8, current doc:  8, proposed doc:  8
pad: SAME , in:  8, f: 2, r: 3 / actual:  8, current doc:  8, proposed doc:  8
pad: SAME , in:  8, f: 3, r: 1 / actual:  8, current doc:  8, proposed doc:  8
pad: SAME , in:  8, f: 3, r: 2 / actual:  8, current doc:  8, proposed doc:  8
pad: SAME , in:  8, f: 3, r: 3 / actual:  8, current doc:  8, proposed doc:  8
pad: SAME , in:  9, f: 1, r: 1 / actual:  9, current doc:  9, proposed doc:  9
pad: SAME , in:  9, f: 1, r: 2 / actual:  9, current doc:  9, proposed doc:  9
pad: SAME , in:  9, f: 1, r: 3 / actual:  9, current doc:  9, proposed doc:  9
pad: SAME , in:  9, f: 2, r: 1 / actual:  9, current doc:  9, proposed doc:  9
pad: SAME , in:  9, f: 2, r: 2 / actual:  9, current doc:  9, proposed doc:  9
pad: SAME , in:  9, f: 2, r: 3 / actual:  9, current doc:  9, proposed doc:  9
pad: SAME , in:  9, f: 3, r: 1 / actual:  9, current doc:  9, proposed doc:  9
pad: SAME , in:  9, f: 3, r: 2 / actual:  9, current doc:  9, proposed doc:  9
pad: SAME , in:  9, f: 3, r: 3 / actual:  9, current doc:  9, proposed doc:  9
pad: SAME , in: 10, f: 1, r: 1 / actual: 10, current doc: 10, proposed doc: 10
pad: SAME , in: 10, f: 1, r: 2 / actual: 10, current doc: 10, proposed doc: 10
pad: SAME , in: 10, f: 1, r: 3 / actual: 10, current doc: 10, proposed doc: 10
pad: SAME , in: 10, f: 2, r: 1 / actual: 10, current doc: 10, proposed doc: 10
pad: SAME , in: 10, f: 2, r: 2 / actual: 10, current doc: 10, proposed doc: 10
pad: SAME , in: 10, f: 2, r: 3 / actual: 10, current doc: 10, proposed doc: 10
pad: SAME , in: 10, f: 3, r: 1 / actual: 10, current doc: 10, proposed doc: 10
pad: SAME , in: 10, f: 3, r: 2 / actual: 10, current doc: 10, proposed doc: 10
pad: SAME , in: 10, f: 3, r: 3 / actual: 10, current doc: 10, proposed doc: 10
pad: SAME , in: 11, f: 1, r: 1 / actual: 11, current doc: 11, proposed doc: 11
pad: SAME , in: 11, f: 1, r: 2 / actual: 11, current doc: 11, proposed doc: 11
pad: SAME , in: 11, f: 1, r: 3 / actual: 11, current doc: 11, proposed doc: 11
pad: SAME , in: 11, f: 2, r: 1 / actual: 11, current doc: 11, proposed doc: 11
pad: SAME , in: 11, f: 2, r: 2 / actual: 11, current doc: 11, proposed doc: 11
pad: SAME , in: 11, f: 2, r: 3 / actual: 11, current doc: 11, proposed doc: 11
pad: SAME , in: 11, f: 3, r: 1 / actual: 11, current doc: 11, proposed doc: 11
pad: SAME , in: 11, f: 3, r: 2 / actual: 11, current doc: 11, proposed doc: 11
pad: SAME , in: 11, f: 3, r: 3 / actual: 11, current doc: 11, proposed doc: 11
```