### PR TITLE
split and fix exception message corresponding to each condition

### DIFF
--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1235,7 +1235,8 @@ def assert_rank(x, rank, data=None, summarize=None, message=None, name=None):
             '%sTensor %s must have rank %d.  Received rank %d, shape %s' %
             (message, name, e.args[2], e.args[1], x.get_shape()))
       else:
-        raise
+        raise ValueError(e.args[0])
+
 
   return assert_op
 

--- a/tensorflow/tools/ci_build/builds/check_system_libs.py
+++ b/tensorflow/tools/ci_build/builds/check_system_libs.py
@@ -34,12 +34,13 @@ third_party_glob = os.path.join(third_party_path, '*', 'workspace.bzl')
 if not os.path.isdir(tf_source_path):
   raise ValueError('The path to the TensorFlow source must be passed as'
                    ' the first argument')
-  if not os.path.isfile(syslibs_configure_path):
-    raise ValueError('Could not find syslibs_configure.bzl at %s' %
-                     syslibs_configure_path)
-                
-  if not os.path.isfile(workspace0_path):
-    raise ValueError('Could not find workspace0.bzl at %s' % workspace0_path)
+                   
+if not os.path.isfile(syslibs_configure_path):
+  raise ValueError('Could not find syslibs_configure.bzl at %s' %
+                    syslibs_configure_path)
+              
+if not os.path.isfile(workspace0_path):
+  raise ValueError('Could not find workspace0.bzl at %s' % workspace0_path)
 
 def extract_valid_libs(filepath):
   """Evaluate syslibs_configure.bzl, return the VALID_LIBS set from that file."""

--- a/tensorflow/tools/ci_build/builds/check_system_libs.py
+++ b/tensorflow/tools/ci_build/builds/check_system_libs.py
@@ -31,11 +31,15 @@ workspace_glob = os.path.join(tf_source_path, 'tensorflow', 'workspace*.bzl')
 third_party_path = os.path.join(tf_source_path, 'third_party')
 third_party_glob = os.path.join(third_party_path, '*', 'workspace.bzl')
 
-if not (os.path.isdir(tf_source_path) and os.path.isfile(syslibs_configure_path)
-        and os.path.isfile(workspace0_path)):
+if not os.path.isdir(tf_source_path):
   raise ValueError('The path to the TensorFlow source must be passed as'
                    ' the first argument')
-
+  if not os.path.isfile(syslibs_configure_path):
+    raise ValueError('Could not find syslibs_configure.bzl at %s' %
+                     syslibs_configure_path)
+                
+  if not os.path.isfile(workspace0_path):
+    raise ValueError('Could not find workspace0.bzl at %s' % workspace0_path)
 
 def extract_valid_libs(filepath):
   """Evaluate syslibs_configure.bzl, return the VALID_LIBS set from that file."""


### PR DESCRIPTION
The message does not reflect the entire condition. Giving a more specific message to each part of the condition is more accurate.