### PR TITLE
Add a root cause arg to the fallback converter

### DIFF
--- a/tensorflow/python/ops/parallel_for/pfor.py
+++ b/tensorflow/python/ops/parallel_for/pfor.py
@@ -1615,7 +1615,7 @@ class PFor:
             try:
               if (converter.__name__ == "_fallback_converter"):
                 new_outputs = converter(pfor_inputs, root_cause=" has variant outputs")
-              else 
+              else: 
                 new_outputs = converter(pfor_inputs)
             except ConversionNotImplementedError as e:
               has_vectorized_variant_inputs = any(

--- a/tensorflow/python/ops/parallel_for/pfor.py
+++ b/tensorflow/python/ops/parallel_for/pfor.py
@@ -4651,6 +4651,7 @@ class WhileV2:
                 "While loop conversion is only supported for TensorLists. Got "
                 f"another variant {inp.t}, probably an optional. Please file "
                 "a bug.")
+
           # For TensorLists, the input format is:
           #
           #   List[user_list_len, Tensor[loop_len, ...]]
@@ -4663,7 +4664,7 @@ class WhileV2:
           # vectorization" format, so we want to keep it that way as much as
           # possible. We'll accumulate finished iterations (only relevant for
           # pfor-loop-variant while_loop conditions) in an accumulator with
-          # type:
+          # type : 
           #
           #   List[user_list_len, List[loop_len, Tensor[...]]]
           #

--- a/tensorflow/python/ops/parallel_for/pfor.py
+++ b/tensorflow/python/ops/parallel_for/pfor.py
@@ -1614,7 +1614,7 @@ class PFor:
           try:
             try:
               if (converter.__name__ == "_fallback_converter"):
-                new_outputs = converter(pfor_inputs, root_cause=" has variant outputs")
+                new_outputs = converter(pfor_inputs, root_cause="has variant outputs")
               else: 
                 new_outputs = converter(pfor_inputs)
             except ConversionNotImplementedError as e:
@@ -1623,7 +1623,7 @@ class PFor:
                   y_op.inputs)
               if (self._fallback_to_while_loop
                   and not has_vectorized_variant_inputs):
-                new_outputs = _fallback_converter(pfor_inputs, root_cause=" has not a vectorized variant inputs")
+                new_outputs = _fallback_converter(pfor_inputs, root_cause="has not a vectorized variant inputs")
               else:
                 raise ValueError(str(e)).with_traceback(sys.exc_info()[2])
           except Exception as e:  # pylint: disable=broad-except

--- a/tensorflow/python/ops/parallel_for/pfor.py
+++ b/tensorflow/python/ops/parallel_for/pfor.py
@@ -1623,7 +1623,7 @@ class PFor:
                   y_op.inputs)
               if (self._fallback_to_while_loop
                   and not has_vectorized_variant_inputs):
-                root_cause = "has no a vectorized variant inputs"
+                root_cause = "has no vectorized variant inputs"
                 new_outputs = _fallback_converter(pfor_inputs, 
                                                   root_cause=root_cause)
               else:

--- a/tensorflow/python/ops/parallel_for/pfor.py
+++ b/tensorflow/python/ops/parallel_for/pfor.py
@@ -1614,7 +1614,8 @@ class PFor:
           try:
             try:
               if (converter.__name__ == "_fallback_converter"):
-                new_outputs = converter(pfor_inputs, root_cause="has variant outputs")
+                new_outputs = converter(pfor_inputs, 
+                                        root_cause="has variant outputs")
               else: 
                 new_outputs = converter(pfor_inputs)
             except ConversionNotImplementedError as e:
@@ -1623,7 +1624,8 @@ class PFor:
                   y_op.inputs)
               if (self._fallback_to_while_loop
                   and not has_vectorized_variant_inputs):
-                new_outputs = _fallback_converter(pfor_inputs, root_cause="has not a vectorized variant inputs")
+                new_outputs = _fallback_converter(pfor_inputs, 
+                                                  root_cause="has not a vectorized variant inputs")
               else:
                 raise ValueError(str(e)).with_traceback(sys.exc_info()[2])
           except Exception as e:  # pylint: disable=broad-except

--- a/tensorflow/python/ops/parallel_for/pfor.py
+++ b/tensorflow/python/ops/parallel_for/pfor.py
@@ -1624,8 +1624,9 @@ class PFor:
                   y_op.inputs)
               if (self._fallback_to_while_loop
                   and not has_vectorized_variant_inputs):
+                root_cause = "has not a vectorized variant inputs"
                 new_outputs = _fallback_converter(pfor_inputs, 
-                                                  root_cause="has not a vectorized variant inputs")
+                                                  root_cause=root_cause)
               else:
                 raise ValueError(str(e)).with_traceback(sys.exc_info()[2])
           except Exception as e:  # pylint: disable=broad-except


### PR DESCRIPTION
Please check https://github.com/keras-team/keras-cv/pull/146#issuecomment-1063974863

Any improvement feedback on the `root_cause` message description and fix hints to the developer is appreciated.

Side note: I am going to "abuse" the CI here a little bit as I'am not compiling and testing this locally cause the build overhead on every PR with the daily [LLVM updates](https://discuss.tensorflow.org/t/llvm-updates-and-bazel-cache/2060) and cause [I cannot use the nightly remote cache](https://github.com/tensorflow/build/issues/72)