### PR TITLE
Test to cover the `import_meta_graph` error on MutableHashTable

### DIFF
--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -3354,9 +3354,9 @@ class MutableHashTableOpTest(test.TestCase):
     sorted_values = np.sort(self.evaluate(exported_values))
     self.assertAllEqual([b"brain", b"salad", b"surgery"], sorted_keys)
     self.assertAllEqual([0, 1, 2], sorted_values)
-  
-  @test_util.run_v2_only
+
   @unittest.expectedFailure
+  @test_util.run_v2_only
   def testImportedHashTable(self, is_anonymous):
     # (TODO #24439) 
     # Confirm unfixed https://github.com/tensorflow/tensorflow/issues/24439

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -15,6 +15,7 @@
 """Tests for lookup ops."""
 import os
 import tempfile
+import unittest
 
 from absl.testing import parameterized
 import numpy as np
@@ -3355,7 +3356,10 @@ class MutableHashTableOpTest(test.TestCase):
     self.assertAllEqual([0, 1, 2], sorted_values)
   
   @test_util.run_v2_only
+  @unittest.expectedFailure
   def testImportedHashTable(self, is_anonymous):
+    # (TODO #24439) 
+    # Confirm unfixed https://github.com/tensorflow/tensorflow/issues/24439
     g = ops.Graph()
     with g.as_default():
       default_val = -1
@@ -3371,12 +3375,7 @@ class MutableHashTableOpTest(test.TestCase):
       meta_graph = saver.export_meta_graph()
 
     def f():
-      # (TODO #24439) 
-      # Confirm unfixed https://github.com/tensorflow/tensorflow/issues/24439
-      with self.assertRaisesRegex(TypeError,
-                                  "can't convert Operation 'MutableHashTable' \
-                                  to Tensor"):
-        saver.import_meta_graph(meta_graph)
+      saver.import_meta_graph(meta_graph)
       return ops.get_default_graph().get_tensor_by_name(op.name)
 
     wrapped = wrap_function.wrap_function(f, [])

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -3355,8 +3355,7 @@ class MutableHashTableOpTest(test.TestCase):
     self.assertAllEqual([b"brain", b"salad", b"surgery"], sorted_keys)
     self.assertAllEqual([0, 1, 2], sorted_values)
 
-  # (TODO Bug #24439) 
-  # Confirm unfixed https://github.com/tensorflow/tensorflow/issues/24439
+  # TODO(https://github.com/tensorflow/tensorflow/issues/24439): remove when fixed
   @unittest.expectedFailure
   @test_util.run_v2_only
   def testImportedHashTable(self, is_anonymous):

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -3355,7 +3355,7 @@ class MutableHashTableOpTest(test.TestCase):
     self.assertAllEqual([b"brain", b"salad", b"surgery"], sorted_keys)
     self.assertAllEqual([0, 1, 2], sorted_values)
   
-  @unittest.expectedFailure
+  # @unittest.expectedFailure
   @test_util.run_v2_only
   def testImportedHashTable(self, is_anonymous):
     g = ops.Graph()

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -3373,7 +3373,8 @@ class MutableHashTableOpTest(test.TestCase):
     def f():
       # Cover https://github.com/tensorflow/tensorflow/issues/24439
       with self.assertRaisesRegex(TypeError,
-                                  "can't convert Operation 'MutableHashTable' to Tensor"):
+                                  "can't convert Operation 'MutableHashTable' \
+                                  to Tensor"):
         saver.import_meta_graph(meta_graph)
       return ops.get_default_graph().get_tensor_by_name(op.name)
 

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -15,7 +15,6 @@
 """Tests for lookup ops."""
 import os
 import tempfile
-import unittest
 
 from absl.testing import parameterized
 import numpy as np

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -3355,7 +3355,6 @@ class MutableHashTableOpTest(test.TestCase):
     self.assertAllEqual([b"brain", b"salad", b"surgery"], sorted_keys)
     self.assertAllEqual([0, 1, 2], sorted_values)
   
-  # @unittest.expectedFailure
   @test_util.run_v2_only
   def testImportedHashTable(self, is_anonymous):
     g = ops.Graph()
@@ -3373,7 +3372,10 @@ class MutableHashTableOpTest(test.TestCase):
       meta_graph = saver.export_meta_graph()
 
     def f():
-      saver.import_meta_graph(meta_graph)
+      # Cover https://github.com/tensorflow/tensorflow/issues/24439
+      with self.assertRaisesRegex(TypeError,
+                                  "can't convert Operation 'MutableHashTable' to Tensor"):
+        saver.import_meta_graph(meta_graph)
       return ops.get_default_graph().get_tensor_by_name(op.name)
 
     wrapped = wrap_function.wrap_function(f, [])

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -3361,13 +3361,13 @@ class MutableHashTableOpTest(test.TestCase):
       default_val = -1
       keys = constant_op.constant(["brain", "salad", "surgery", "tarkus"])
       values = constant_op.constant([0, 1, 2, 3], dtypes.int64)
-      t = lookup_ops.MutableHashTable(
-        dtypes.string,
-        dtypes.int64,
-        default_val,
-        experimental_is_anonymous=is_anonymous)
-      init_op = t._init_op
-      op = t.lookup(constant_op.constant(["brain", "salad", "tank"]))
+      self.evaluate(table.insert(keys, values))
+      table = lookup_ops.MutableHashTable(
+            dtypes.string,
+            dtypes.int64,
+            default_val,
+            experimental_is_anonymous=is_anonymous)
+      op = table.lookup(constant_op.constant(["brain", "salad", "tank"]))
       meta_graph = saver.export_meta_graph()
 
     def f():
@@ -3380,9 +3380,6 @@ class MutableHashTableOpTest(test.TestCase):
       return ops.get_default_graph().get_tensor_by_name(op.name)
 
     wrapped = wrap_function.wrap_function(f, [])
-    pruned_init_fn = wrapped.prune(
-        (), [wrapped.graph.get_operation_by_name(init_op.name)])
-    self.evaluate(pruned_init_fn())
     self.assertAllEqual([0, 1, -1], wrapped())
 
   @test_util.run_v1_only("SaverV1")

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -3361,12 +3361,12 @@ class MutableHashTableOpTest(test.TestCase):
       default_val = -1
       keys = constant_op.constant(["brain", "salad", "surgery", "tarkus"])
       values = constant_op.constant([0, 1, 2, 3], dtypes.int64)
-      self.evaluate(table.insert(keys, values))
       table = lookup_ops.MutableHashTable(
             dtypes.string,
             dtypes.int64,
             default_val,
             experimental_is_anonymous=is_anonymous)
+      self.evaluate(table.insert(keys, values))
       op = table.lookup(constant_op.constant(["brain", "salad", "tank"]))
       meta_graph = saver.export_meta_graph()
 

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -3371,7 +3371,8 @@ class MutableHashTableOpTest(test.TestCase):
       meta_graph = saver.export_meta_graph()
 
     def f():
-      # Cover https://github.com/tensorflow/tensorflow/issues/24439
+      # (TODO #24439) 
+      # Confirm unfixed https://github.com/tensorflow/tensorflow/issues/24439
       with self.assertRaisesRegex(TypeError,
                                   "can't convert Operation 'MutableHashTable' \
                                   to Tensor"):

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -3355,11 +3355,11 @@ class MutableHashTableOpTest(test.TestCase):
     self.assertAllEqual([b"brain", b"salad", b"surgery"], sorted_keys)
     self.assertAllEqual([0, 1, 2], sorted_values)
 
+  # (TODO Bug #24439) 
+  # Confirm unfixed https://github.com/tensorflow/tensorflow/issues/24439
   @unittest.expectedFailure
   @test_util.run_v2_only
   def testImportedHashTable(self, is_anonymous):
-    # (TODO #24439) 
-    # Confirm unfixed https://github.com/tensorflow/tensorflow/issues/24439
     g = ops.Graph()
     with g.as_default():
       default_val = -1

--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -3355,7 +3355,7 @@ class MutableHashTableOpTest(test.TestCase):
     self.assertAllEqual([b"brain", b"salad", b"surgery"], sorted_keys)
     self.assertAllEqual([0, 1, 2], sorted_values)
 
-  # TODO(https://github.com/tensorflow/tensorflow/issues/24439): remove when fixed
+  # TODO(https://github.com/tensorflow/tensorflow/issues/24439): remove exepectedFailure when fixed
   @unittest.expectedFailure
   @test_util.run_v2_only
   def testImportedHashTable(self, is_anonymous):


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/issues/24439

As this wasn't fixed since 2018 I think it is better to cover it with a test.