### PR TITLE
QAT model conversion adds extra RESHAPE layers compared to PTQ

### DIFF
--- a/tensorflow/compiler/mlir/lite/quantization/lite/quantize_model_test.cc
+++ b/tensorflow/compiler/mlir/lite/quantization/lite/quantize_model_test.cc
@@ -1112,13 +1112,10 @@ TEST_F(QuantizeFCTest, VerifyFC) {
   EXPECT_EQ(subgraph->tensors[op->outputs[0]].get()->type, TensorType_INT8);
 
   // check op and versioning.
-  EXPECT_EQ(model_.operator_codes.size(), 2);
+  EXPECT_EQ(model_.operator_codes.size(), 1);
   EXPECT_EQ(GetBuiltinCode(model_.operator_codes[0].get()),
             BuiltinOperator_FULLY_CONNECTED);
-  EXPECT_EQ(model_.operator_codes[0]->version, 4);
-  EXPECT_EQ(GetBuiltinCode(model_.operator_codes[1].get()),
-            BuiltinOperator_RESHAPE);
-  EXPECT_EQ(model_.operator_codes[1]->version, 1);
+  EXPECT_EQ(model_.operator_codes[0]->version, 5);
 }
 
 class QuantizeCustomOpTest

--- a/tensorflow/compiler/mlir/lite/tf_tfl_passes.cc
+++ b/tensorflow/compiler/mlir/lite/tf_tfl_passes.cc
@@ -72,7 +72,7 @@ void AddQuantizationPasses(const mlir::quant::QuantizationSpecs& quant_specs,
   // Run RemoveReshapeAfterFullyConnected, RemoveReshapeBeforeFullyConnected
   // passes once Quant/Dequant stat nodes have been removed, because patterns to
   // apply these optimizations have been changed once these ops are removed.
-  pass_manager.addNestedPass<mlir::FuncOp>(
+  pass_manager.addNestedPass<mlir::func::FuncOp>(
       mlir::TFL::CreateOptimizePass(/*enable_canonicalization=*/true));
 }
 

--- a/tensorflow/compiler/mlir/lite/tf_tfl_passes.cc
+++ b/tensorflow/compiler/mlir/lite/tf_tfl_passes.cc
@@ -69,6 +69,11 @@ void AddQuantizationPasses(const mlir::quant::QuantizationSpecs& quant_specs,
       mlir::TFL::CreatePostQuantizePass(emit_quant_adaptor_ops));
   pass_manager.addNestedPass<mlir::func::FuncOp>(
       mlir::TFL::CreateOptimizeOpOrderPass());
+  // Run RemoveReshapeAfterFullyConnected, RemoveReshapeBeforeFullyConnected
+  // passes once Quant/Dequant stat nodes have been removed, because patterns to
+  // apply these optimizations have been changed once these ops are removed.
+  pass_manager.addNestedPass<mlir::FuncOp>(
+      mlir::TFL::CreateOptimizePass(/*enable_canonicalization=*/true));
 }
 
 void AddDynamicRangeQuantizationPasses(

--- a/tensorflow/lite/python/lite_v2_test.py
+++ b/tensorflow/lite/python/lite_v2_test.py
@@ -2318,11 +2318,11 @@ class FromSavedModelTest(lite_v2_test_util.ModelTest):
     self.assertEqual(byte_model.operatorCodes[0].builtinCode,
                      schema_fb.BuiltinOperator.QUANTIZE)
     self.assertNotEqual(byte_model.operatorCodes[1].builtinCode,
-                     schema_fb.BuiltinOperator.RESHAPE)
+                        schema_fb.BuiltinOperator.RESHAPE)
     self.assertEqual(byte_model.operatorCodes[1].builtinCode,
                      schema_fb.BuiltinOperator.FULLY_CONNECTED)
     self.assertNotEqual(byte_model.operatorCodes[2].builtinCode,
-                     schema_fb.BuiltinOperator.RESHAPE)
+                        schema_fb.BuiltinOperator.RESHAPE)
     self.assertEqual(byte_model.operatorCodes[2].builtinCode,
                      schema_fb.BuiltinOperator.DEQUANTIZE)
 

--- a/tensorflow/lite/python/lite_v2_test.py
+++ b/tensorflow/lite/python/lite_v2_test.py
@@ -2438,7 +2438,8 @@ class FromSavedModelTest(lite_v2_test_util.ModelTest):
     quantized_converter.optimizations = [lite.Optimize.DEFAULT]
 
     if explicitly_set_bias:
-      quantized_converter._experimental_full_integer_quantization_bias_type = bias_type
+      quantized_converter._experimental_full_integer_quantization_bias_type = \
+       bias_type
 
     if is_int16_quantize:
       quantized_converter.target_spec.supported_ops = [
@@ -3215,7 +3216,8 @@ class ControlFlowTest(lite_v2_test_util.ModelTest):
 
     # Convert model.
     converter = lite.TFLiteConverterV2.from_keras_model(model)
-    converter._experimental_default_to_single_batch_in_tensor_list_ops = default_to_single_batch
+    converter._experimental_default_to_single_batch_in_tensor_list_ops = \
+     default_to_single_batch
     if not default_to_single_batch:
       converter.target_spec.supported_ops = [
           tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS
@@ -3266,7 +3268,8 @@ class ControlFlowTest(lite_v2_test_util.ModelTest):
 
     # Convert model.
     converter = lite.TFLiteConverterV2.from_keras_model(model)
-    converter._experimental_default_to_single_batch_in_tensor_list_ops = default_to_single_batch
+    converter._experimental_default_to_single_batch_in_tensor_list_ops = \
+     default_to_single_batch
     if not default_to_single_batch:
       converter.target_spec.supported_ops = [
           tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS
@@ -3292,7 +3295,8 @@ class ControlFlowTest(lite_v2_test_util.ModelTest):
 
     # Convert model.
     converter = lite.TFLiteConverterV2.from_keras_model(model)
-    converter._experimental_default_to_single_batch_in_tensor_list_ops = default_to_single_batch
+    converter._experimental_default_to_single_batch_in_tensor_list_ops = \
+     default_to_single_batch
     if not default_to_single_batch:
       converter.target_spec.supported_ops = [
           tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS


### PR DESCRIPTION
Hello,

When converting a QAT FullyConnected model to TFLite, the Reshape layers before and after the FullyConnected layer remain. This is due to the fact that there are Quant/Dequant stat nodes before and after the Reshapes therefore the patterns do not match.
The solution to this is to run  the CreateOptimizePass after the Quantization passes.
Added test to verify this.

Code to reproduce: 
```
import tensorflow as tf
import tensorflow_model_optimization as tfmot

inp = tf.keras.Input(shape=(8, 4), batch_size=1)
out = tf.keras.layers.Dense(16)(inp)
model = tf.keras.Model(inp,out)

def representative_dataset():
    for _ in range(100):
        yield [tf.random.uniform(shape=(1, 8, 4))]

converter = tf.lite.TFLiteConverter.from_keras_model(model)
converter.optimizations = [tf.lite.Optimize.DEFAULT]
converter.representative_dataset = representative_dataset
converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]
converter.inference_input_type = tf.int8
converter.inference_output_type = tf.int8
tflite_model = converter.convert()
with open('./dense_ptq.tflite', 'wb') as f:
    f.write(tflite_model)

tf.keras.backend.clear_session()

inp = tf.keras.Input(shape=(8, 4), batch_size=1)
out = tfmot.quantization.keras.quantize_annotate_layer(tf.keras.layers.Dense(16))(inp)
model = tfmot.quantization.keras.quantize_apply(tf.keras.Model(inp,out))

converter = tf.lite.TFLiteConverter.from_keras_model(model)
converter.optimizations = [tf.lite.Optimize.DEFAULT]
converter.inference_input_type = tf.int8
converter.inference_output_type = tf.int8
tflite_model = converter.convert()
with open('./dense_qat.tflite', 'wb') as f:
    f.write(tflite_model)
```
Model produced: 
![image-2021-12-08-09-57-17-159](https://user-images.githubusercontent.com/44364573/157916054-36d8404f-1e91-4f4d-8606-02db189b586d.png)