### PR TITLE
Saving Resource Variables without Copy

### DIFF
--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -378,10 +378,10 @@ void DisableCopyOnReadOp::Compute(OpKernelContext* ctx) {
   }
 }
 
-REGISTER_KERNEL_BUILDER(Name("DisableCopyOnReadOp").Device(DEVICE_CPU),
+REGISTER_KERNEL_BUILDER(Name("DisableCopyOnRead").Device(DEVICE_CPU),
                         DisableCopyOnReadOp);
 REGISTER_KERNEL_BUILDER(
-    Name("DisableCopyOnReadOp").Device(DEVICE_DEFAULT).HostMemory("resource"),
+    Name("DisableCopyOnRead").Device(DEVICE_DEFAULT).HostMemory("resource"),
     DisableCopyOnReadOp);
 
 template <typename Device, typename T>

--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -89,7 +89,11 @@ REGISTER_KERNEL_BUILDER(Name("_VarHandlesOp").Device(DEVICE_CPU),
 
 ReadVariableOp::ReadVariableOp(OpKernelConstruction* c) : OpKernel(c) {
   OP_REQUIRES_OK(c, c->GetAttr("dtype", &dtype_));
-  OP_REQUIRES_OK(c, c->GetAttr("no_copy", &no_copy_));
+}
+
+ReadVariableWithoutCopyOp::ReadVariableWithoutCopyOp(OpKernelConstruction* c)
+    : OpKernel(c) {
+  OP_REQUIRES_OK(c, c->GetAttr("dtype", &dtype_));
 }
 
 namespace {
@@ -146,16 +150,6 @@ void ReadVariableOp::Compute(OpKernelContext* ctx) {
                   "Debug info: container=", handle.container(),
                   ", status error message=", status.error_message()));
 
-  // If no_copy_ is true, prevent a copy of the variable
-  // by setting the access mode to copy-on-write
-  if (no_copy_) {
-    // If the variable is currently in copy-on-read mode, its refcount is 1
-    if (variable->copy_on_read_mode.load()) {
-      // Obtain an exclusive lock on the variable and change the access mode
-      mutex_lock ml(*variable->mu());
-      variable->copy_on_read_mode.store(false);
-    }
-  }
   tf_shared_lock ml(*variable->mu());
   // We're acquiring a reference to the underlying buffer while
   // holding a shared lock to guarantee ordering of reads and
@@ -225,10 +219,50 @@ void ReadVariablesOp::Compute(OpKernelContext* ctx) {
   }
 }
 
+void ReadVariableWithoutCopyOp::Compute(OpKernelContext* ctx) {
+  core::RefCountPtr<Var> variable;
+  const ResourceHandle& handle = HandleFromInput(ctx, 0);
+  const auto status = LookupResource(ctx, handle, &variable);
+  bool mode_conversion = false;
+  OP_REQUIRES(ctx, status.ok(),
+              errors::FailedPrecondition(
+                  "Could not find variable ", handle.name(), ". ",
+                  "This could mean that the variable has been deleted. ",
+                  "In TF1, it can also mean the variable is uninitialized. ",
+                  "Debug info: container=", handle.container(),
+                  ", status error message=", status.error_message()));
+
+  if (variable->copy_on_read_mode.load()) {
+    // If the variable is in copy-on-read mode, obtain an exclusive
+    // lock on the variable before reading it without making a copy
+    mutex_lock ml(*variable->mu());
+    const Tensor* t = variable->tensor();
+    OP_REQUIRES(
+        ctx, dtype_ == t->dtype(),
+        errors::InvalidArgument(
+            "Trying to read variable with wrong dtype. Expected ",
+            DataTypeString(dtype_), " got ", DataTypeString(t->dtype())));
+    ctx->set_output(0, *t);
+  } else {
+    // If the variable is in copy-on-write mode, obtain a shared
+    // lock on the variable before reading it without making a copy
+    tf_shared_lock ml(*variable->mu());
+    const Tensor* t = variable->tensor();
+    OP_REQUIRES(
+        ctx, dtype_ == t->dtype(),
+        errors::InvalidArgument(
+            "Trying to read variable with wrong dtype. Expected ",
+            DataTypeString(dtype_), " got ", DataTypeString(t->dtype())));
+    ctx->set_output(0, *t);
+  }
+}
+
 REGISTER_KERNEL_BUILDER(Name("ReadVariableOp").Device(DEVICE_CPU),
                         ReadVariableOp);
 REGISTER_KERNEL_BUILDER(Name("_ReadVariablesOp").Device(DEVICE_CPU),
                         ReadVariablesOp);
+REGISTER_KERNEL_BUILDER(Name("ReadVariableWithoutCopyOp").Device(DEVICE_CPU),
+                        ReadVariableWithoutCopyOp);
 
 REGISTER_KERNEL_BUILDER(
     Name("ReadVariableOp").Device(DEVICE_DEFAULT).HostMemory("resource"),
@@ -236,6 +270,10 @@ REGISTER_KERNEL_BUILDER(
 REGISTER_KERNEL_BUILDER(
     Name("_ReadVariablesOp").Device(DEVICE_DEFAULT).HostMemory("resources"),
     ReadVariablesOp);
+REGISTER_KERNEL_BUILDER(Name("ReadVariableWithoutCopyOp")
+                            .Device(DEVICE_DEFAULT)
+                            .HostMemory("resource"),
+                        ReadVariableWithoutCopyOp);
 
 VarHandleOp::VarHandleOp(OpKernelConstruction* context) : OpKernel(context) {
   OP_REQUIRES_OK(context, context->GetAttr("container", &container_));

--- a/tensorflow/core/kernels/resource_variable_ops.h
+++ b/tensorflow/core/kernels/resource_variable_ops.h
@@ -46,7 +46,6 @@ class ReadVariableOp : public OpKernel {
 
  private:
   DataType dtype_;
-  bool no_copy_;
 };
 
 class ReadVariablesOp : public OpKernel {
@@ -57,6 +56,15 @@ class ReadVariablesOp : public OpKernel {
 
  private:
   DataTypeVector dtypes_;
+};
+
+class ReadVariableWithoutCopyOp : public OpKernel {
+ public:
+  explicit ReadVariableWithoutCopyOp(OpKernelConstruction* c);
+  void Compute(OpKernelContext* ctx) override;
+
+ private:
+  DataType dtype_;
 };
 
 class DestroyResourceOp : public OpKernel {

--- a/tensorflow/core/kernels/resource_variable_ops.h
+++ b/tensorflow/core/kernels/resource_variable_ops.h
@@ -58,15 +58,6 @@ class ReadVariablesOp : public OpKernel {
   DataTypeVector dtypes_;
 };
 
-class ReadVariableWithoutCopyOp : public OpKernel {
- public:
-  explicit ReadVariableWithoutCopyOp(OpKernelConstruction* c);
-  void Compute(OpKernelContext* ctx) override;
-
- private:
-  DataType dtype_;
-};
-
 class DestroyResourceOp : public OpKernel {
  public:
   explicit DestroyResourceOp(OpKernelConstruction* ctx);
@@ -74,6 +65,12 @@ class DestroyResourceOp : public OpKernel {
 
  private:
   bool ignore_lookup_error_;
+};
+
+class DisableCopyOnReadOp : public OpKernel {
+ public:
+  explicit DisableCopyOnReadOp(OpKernelConstruction* c) : OpKernel(c) {}
+  void Compute(OpKernelContext* ctx) override;
 };
 
 template <typename T>

--- a/tensorflow/core/kernels/resource_variable_ops.h
+++ b/tensorflow/core/kernels/resource_variable_ops.h
@@ -46,6 +46,7 @@ class ReadVariableOp : public OpKernel {
 
  private:
   DataType dtype_;
+  bool no_copy_;
 };
 
 class ReadVariablesOp : public OpKernel {

--- a/tensorflow/core/ops/resource_variable_ops.cc
+++ b/tensorflow/core/ops/resource_variable_ops.cc
@@ -144,12 +144,6 @@ REGISTER_OP("_ReadVariablesOp")
     .Attr("dtypes: list(type)")
     .SetShapeFn(ReadVariablesShapeFn);
 
-REGISTER_OP("ReadVariableWithoutCopyOp")
-    .Input("resource: resource")
-    .Output("value: dtype")
-    .Attr("dtype: type")
-    .SetShapeFn(ReadVariableShapeFn);
-
 Status ReadGrad(const AttrSlice& attrs, FunctionDef* g) {
   // clang-format off
   *g = FunctionDefHelper::Define(
@@ -424,5 +418,9 @@ REGISTER_OP("ConsumeMutexLock")
     .Input("mutex_lock: variant")
     .SetIsStateful()
     .SetShapeFn([](InferenceContext* c) { return Status::OK(); });
+
+REGISTER_OP("DisableCopyOnReadOp")
+    .Input("resource: resource")
+    .SetShapeFn(shape_inference::NoOutputs);
 
 }  // namespace tensorflow

--- a/tensorflow/core/ops/resource_variable_ops.cc
+++ b/tensorflow/core/ops/resource_variable_ops.cc
@@ -135,7 +135,6 @@ REGISTER_OP("ReadVariableOp")
     .Input("resource: resource")
     .Output("value: dtype")
     .Attr("dtype: type")
-    .Attr("no_copy: bool = false")
     .SetShapeFn(ReadVariableShapeFn);
 
 REGISTER_OP("_ReadVariablesOp")
@@ -144,6 +143,12 @@ REGISTER_OP("_ReadVariablesOp")
     .Output("values: dtypes")
     .Attr("dtypes: list(type)")
     .SetShapeFn(ReadVariablesShapeFn);
+
+REGISTER_OP("ReadVariableWithoutCopyOp")
+    .Input("resource: resource")
+    .Output("value: dtype")
+    .Attr("dtype: type")
+    .SetShapeFn(ReadVariableShapeFn);
 
 Status ReadGrad(const AttrSlice& attrs, FunctionDef* g) {
   // clang-format off

--- a/tensorflow/core/ops/resource_variable_ops.cc
+++ b/tensorflow/core/ops/resource_variable_ops.cc
@@ -135,6 +135,7 @@ REGISTER_OP("ReadVariableOp")
     .Input("resource: resource")
     .Output("value: dtype")
     .Attr("dtype: type")
+    .Attr("no_copy: bool = false")
     .SetShapeFn(ReadVariableShapeFn);
 
 REGISTER_OP("_ReadVariablesOp")

--- a/tensorflow/core/ops/resource_variable_ops.cc
+++ b/tensorflow/core/ops/resource_variable_ops.cc
@@ -419,7 +419,7 @@ REGISTER_OP("ConsumeMutexLock")
     .SetIsStateful()
     .SetShapeFn([](InferenceContext* c) { return Status::OK(); });
 
-REGISTER_OP("DisableCopyOnReadOp")
+REGISTER_OP("DisableCopyOnRead")
     .Input("resource: resource")
     .SetShapeFn(shape_inference::NoOutputs);
 

--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -674,8 +674,12 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
     variable_accessed(self)
 
     def read_and_set_handle(no_copy):
-      result = gen_resource_variable_ops.read_variable_op(
-          self.handle, self._dtype, no_copy = no_copy)
+      if no_copy:
+        result = gen_resource_variable_ops.read_variable_without_copy_op(
+          self.handle, self._dtype)
+      else:
+        result = gen_resource_variable_ops.read_variable_op(
+          self.handle, self._dtype)
       _maybe_set_handle_data(self._dtype, self.handle, result)
       return result
 

--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -672,13 +672,20 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
 
   def _read_variable_op(self, no_copy = False):
     """Reads the value of the variable. If the variable is in copy-on-read mode
-    and no_copy is True, the variable is converted to copy-on-write mode before
-    it is read."""
+    and `no_copy` is True, the variable is converted to copy-on-write mode
+    before it is read.
+
+    Args:
+      no_copy: Whether to prevent a copy of the variable.
+
+    Returns:
+      The value of the variable.
+    """
     variable_accessed(self)
 
     def read_and_set_handle(no_copy):
       if no_copy:
-        gen_resource_variable_ops.disable_copy_on_read_op(self.handle)
+        gen_resource_variable_ops.disable_copy_on_read(self.handle)
       result = gen_resource_variable_ops.read_variable_op(
           self.handle, self._dtype)
       _maybe_set_handle_data(self._dtype, self.handle, result)

--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -675,10 +675,8 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
 
     def read_and_set_handle(no_copy):
       if no_copy:
-        result = gen_resource_variable_ops.read_variable_without_copy_op(
-          self.handle, self._dtype)
-      else:
-        result = gen_resource_variable_ops.read_variable_op(
+        gen_resource_variable_ops.disable_copy_on_read_op(self.handle)
+      result = gen_resource_variable_ops.read_variable_op(
           self.handle, self._dtype)
       _maybe_set_handle_data(self._dtype, self.handle, result)
       return result

--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -671,6 +671,9 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
     return obj_map, resource_map
 
   def _read_variable_op(self, no_copy = False):
+    """Reads the value of the variable. If the variable is in copy-on-read mode
+    and no_copy is True, the variable is converted to copy-on-write mode before
+    it is read."""
     variable_accessed(self)
 
     def read_and_set_handle(no_copy):
@@ -715,7 +718,8 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
   def read_value_no_copy(self):
     """Constructs an op which reads the value of this variable
     without making a copy even when the variable has been previously
-    sparsely accessed.
+    sparsely accessed. Variables that are in copy-on-read mode will
+    be converted to copy-on-write mode.
 
     Returns:
      the read operation.

--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -671,9 +671,10 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
     return obj_map, resource_map
 
   def _read_variable_op(self, no_copy = False):
-    """Reads the value of the variable. If the variable is in copy-on-read mode
-    and `no_copy` is True, the variable is converted to copy-on-write mode
-    before it is read.
+    """Reads the value of the variable.
+
+    If the variable is in copy-on-read mode and `no_copy` is True, the variable
+    is converted to copy-on-write mode before it is read.
 
     Args:
       no_copy: Whether to prevent a copy of the variable.
@@ -732,7 +733,7 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
      the read operation.
     """
     with ops.name_scope("Read"):
-      value = self._read_variable_op(no_copy = True)
+      value = self._read_variable_op(no_copy=True)
     # Return an identity so it can get placed on whatever device the context
     # specifies instead of the device where the variable is.
     return array_ops.identity(value)

--- a/tensorflow/python/ops/resource_variable_ops.py
+++ b/tensorflow/python/ops/resource_variable_ops.py
@@ -715,7 +715,7 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
     read the value only after some condition is true.
 
     Returns:
-     the read operation.
+      The value of the variable.
     """
     with ops.name_scope("Read"):
       value = self._read_variable_op()
@@ -724,13 +724,14 @@ class BaseResourceVariable(variables.VariableV1, core.Tensor):
     return array_ops.identity(value)
 
   def read_value_no_copy(self):
-    """Constructs an op which reads the value of this variable
-    without making a copy even when the variable has been previously
-    sparsely accessed. Variables that are in copy-on-read mode will
-    be converted to copy-on-write mode.
+    """Constructs an op which reads the value of this variable without copy.
+
+    The variable is read without making a copy even when it has been sparsely
+    accessed. Variables in copy-on-read mode will be converted to copy-on-write
+    mode.
 
     Returns:
-     the read operation.
+      The value of the variable.
     """
     with ops.name_scope("Read"):
       value = self._read_variable_op(no_copy=True)

--- a/tensorflow/python/training/saving/saveable_object_util.py
+++ b/tensorflow/python/training/saving/saveable_object_util.py
@@ -99,7 +99,8 @@ class ResourceVariableSaveable(saveable_object.SaveableObject):
               # A SaveSpec tensor value of `None` indicates that the variable is
               # uninitialized.
               return None
-            x = v.read_value()
+            # Read the variable without making a copy to limit memory usage.
+            x = v.read_value_no_copy()
             # To allow variables placed on non-CPU devices to be checkpointed,
             # we copy them to CPU on the same machine first.
             with ops.device("/device:CPU:0"):


### PR DESCRIPTION
Provides a solution for the increase in memory usage when saving models with large sparsely accessed resource variables by avoiding the copying of the variables. The kernel of `ReadVariableOp` is modified to convert variables that were sparsely accessed from copy-on-read mode to copy-on-write mode under an exclusive lock. The conversion is disabled in the default setting and only occurs when the Python function `_read_variable_op` is called from class `ResourceVariableSaveable` during the saving of resource variables.

See issue [#54104](https://github.com/tensorflow/tensorflow/issues/54105).