### PR TITLE
[ROCm] Fixes for vector data type collision in BEF thunk for ROCm.

### DIFF
--- a/tensorflow/compiler/mlir/tfrt/transforms/lmhlo_to_gpu/pattern_utils.cc
+++ b/tensorflow/compiler/mlir/tfrt/transforms/lmhlo_to_gpu/pattern_utils.cc
@@ -16,6 +16,10 @@ limitations under the License.
 #include "tensorflow/compiler/mlir/tfrt/transforms/lmhlo_to_gpu/pattern_utils.h"
 
 #include "tfrt/basic_kernels/opdefs/basic_kernels.h"  // from @tf_runtime
+#include "tfrt/gpu/wrapper/cublas_wrapper.h"          // from @tf_runtime
+#include "tfrt/gpu/wrapper/cudnn_wrapper.h"           // from @tf_runtime
+#include "tfrt/gpu/wrapper/miopen_wrapper.h"          // from @tf_runtime
+#include "tfrt/gpu/wrapper/rocblas_wrapper.h"         // from @tf_runtime
 
 namespace tensorflow {
 

--- a/tensorflow/compiler/mlir/tfrt/transforms/lmhlo_to_gpu/pattern_utils.h
+++ b/tensorflow/compiler/mlir/tfrt/transforms/lmhlo_to_gpu/pattern_utils.h
@@ -18,10 +18,8 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Types.h"
 #include "tensorflow/stream_executor/dnn.h"
-#include "tfrt/gpu/wrapper/cublas_wrapper.h"  // from @tf_runtime
-#include "tfrt/gpu/wrapper/cudnn_wrapper.h"  // from @tf_runtime
-#include "tfrt/gpu/wrapper/miopen_wrapper.h"  // from @tf_runtime
-#include "tfrt/gpu/wrapper/rocblas_wrapper.h"  // from @tf_runtime
+#include "tfrt/gpu/wrapper/blas_wrapper.h"  // from @tf_runtime
+#include "tfrt/gpu/wrapper/dnn_wrapper.h"   // from @tf_runtime
 
 namespace tensorflow {
 


### PR DESCRIPTION
/cc @chsigg @cheshire @jurahul 