### PR TITLE
Fix to enable mlir unit tests to run with BEF thunk/executable.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/mlir_gpu_test_base.cc
@@ -61,7 +61,7 @@ StatusOr<std::unique_ptr<Executable>> MlirGpuTestBase::CompileMlirModule(
       /*mlir_context=*/nullptr, llvm_module.get());
 
   HloModuleConfig module_config;
-  module_config.set_debug_options(DefaultDebugOptionsIgnoringFlags());
+  module_config.set_debug_options(GetDebugOptionsFromFlags());
   return CompileLmhloToExecutable(
       static_cast<GpuCompiler*>(backend_->compiler()), module, "TestModule",
       module_config, Compiler::CompileOptions(), "main", stream_exec,


### PR DESCRIPTION
The //tensorflow/compiler/xla/service/gpu/tests:mlir_gemm_test test was not running on BEF thunk when it was specified as such.

The reason is that it was ignoring XLA_FLAGS=--xla_gpu_bef_thunk.

These changes should fix that.

/cc @chsigg @hanbinyoon