### PR TITLE
[conv3d_transpose] Fix dim check for bias

### DIFF
--- a/tensorflow/lite/kernels/conv3d_transpose.cc
+++ b/tensorflow/lite/kernels/conv3d_transpose.cc
@@ -171,7 +171,7 @@ TfLiteStatus Prepare(KernelType kernel_type, TfLiteContext* context,
   const TfLiteTensor* bias = GetInput(context, node, 3);
   if (bias) {
     TF_LITE_ENSURE_TYPES_EQ(context, bias->type, input->type);
-    TF_LITE_ENSURE_EQ(context, NumElements(bias), SizeOfDimension(filter, 4));
+    TF_LITE_ENSURE_EQ(context, NumElements(bias), SizeOfDimension(filter, 3));
   }
 
   // GenericOptimized kernel currently doesn't support dilation.

--- a/tensorflow/lite/kernels/conv3d_transpose_test.cc
+++ b/tensorflow/lite/kernels/conv3d_transpose_test.cc
@@ -154,7 +154,7 @@ TEST_P(Conv3dTransposeOpTest, MismatchBiasSizeTest) {
           {1, 2, 3, 4, 5}, {TensorType_FLOAT32, {1, 3, 2, 2, 2}},
           {TensorType_FLOAT32, {1, 2, 2, 4, 2}}, {TensorType_FLOAT32, {3}},
           {TensorType_FLOAT32, {}}, Conv3dTransposeOpTest::GetParam()),
-      "NumElements.bias. != SizeOfDimension.filter, 4.");
+      "NumElements.bias. != SizeOfDimension.filter, 3.");
 }
 
 TEST_P(Conv3dTransposeOpTest, SimpleFloat32Test) {


### PR DESCRIPTION
Per discussion with @thaink in https://github.com/tensorflow/tensorflow/commit/38a77f4bc1c897c75560a0beb53426f20b883f6e#r68775543 , the previous way to do the dim check for bias is not correct. So, we need this change.