### PR TITLE
Allow some tolerance in equality test by using EXPECT_FLOAT_EQ

### DIFF
--- a/tensorflow/core/framework/model_test.cc
+++ b/tensorflow/core/framework/model_test.cc
@@ -459,7 +459,7 @@ TEST_P(AsyncUnknownRatioTest, Model) {
   async_unknown_many->record_element();
   // Estimated ratio is 2/3
   ratio = 2.0 / 3.0;
-  EXPECT_EQ(
+  EXPECT_FLOAT_EQ(
       async_unknown_many->TotalProcessingTime(/*processing_times=*/nullptr),
       ratio * (50 + 50) + 128 / 3.0);
   EXPECT_LE(async_unknown_many->OutputTime(&input_times, nullptr),


### PR DESCRIPTION
Float values on AARCH64 fail the plain EXPECT_EQ check with a difference of 1.42109e-14 which is negligible so use the more tolerant EXPECT_FLOAT_EQ form instead.