### PR TITLE
Remove calls to `rules_cc_toolchains`

### DIFF
--- a/tensorflow/workspace0.bzl
+++ b/tensorflow/workspace0.bzl
@@ -8,7 +8,6 @@ load("@build_bazel_rules_swift//swift:repositories.bzl", "swift_rules_dependenci
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 load("@local_config_android//:android.bzl", "android_workspace")
-load("@rules_cc//cc:repositories.bzl", "rules_cc_toolchains")
 
 def _tf_bind():
     """Bind targets for some external repositories"""
@@ -104,8 +103,6 @@ def workspace():
             "https://storage.googleapis.com/download.tensorflow.org/data/tf_lite_micro_person_data_grayscale_2020_05_24.zip",
         ],
     )
-
-    rules_cc_toolchains()
 
     bazel_toolchains_repositories()
 


### PR DESCRIPTION
There was a previous plan was to move Bazel toolchain configuration to
`@rules_cc`, but that plan isn't progressing and `@rules_cc` is
currently just an outdated copy of the toolchain configuration
mechanism. Amongst other issues, the outdated copy does not support
`layering_check`. The Bazel team recommended removing this override.
See https://github.com/bazelbuild/bazel/issues/15004