### PR TITLE
[INTEL oneDNN] Resubmitting scratch pad optimization for matmul primitive : PR number :54381

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
@@ -153,6 +153,8 @@ class BatchMatMulMkl : public OpKernel {
         MklMatMulPrimitiveFactory<float, Tlhs, Trhs, Toutput>::Get(
             *params, false /* value for do_not_cache */);
 
+    UserScratchPad<unsigned char> scratch_pad;
+    scratch_pad.AllocateSPTensor(matmul_prim, ctx);
     // Execute matmul primitive.
     std::shared_ptr<stream> cpu_stream;
     MklDnnThreadPool eigen_tp(ctx);
@@ -172,11 +174,11 @@ class BatchMatMulMkl : public OpKernel {
       }
       matmul_prim->Execute(cpu_stream, lhs.flat<Tlhs>().data(),
                            rhs.flat<Trhs>().data(), out->flat<Toutput>().data(),
-                           mul_data, add_data);
+                           scratch_pad.Get(), mul_data, add_data);
     } else {
       matmul_prim->Execute(cpu_stream, lhs.flat<Tlhs>().data(),
-                           rhs.flat<Trhs>().data(),
-                           out->flat<Toutput>().data());
+                           rhs.flat<Trhs>().data(), out->flat<Toutput>().data(),
+                           scratch_pad.Get());
     }
   }
 

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/util/mkl_util.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 using dnnl::inner_product_forward;
 using dnnl::primitive_attr;
@@ -588,8 +589,11 @@ class MklMatMulPrimitive : public MklPrimitive {
 
   ~MklMatMulPrimitive() {}
 
+  dnnl::memory::desc GetScratchPadDesc() {
+    return context_.prim_desc->scratchpad_desc();
+  }
   void Execute(const std::shared_ptr<stream>& stream, const Tlhs* a_data,
-               const Trhs* b_data, const Toutput* c_data,
+               const Trhs* b_data, const Toutput* c_data, void* sp_data,
                void* mul_data = nullptr, void* add_data = nullptr) {
 #ifndef ENABLE_ONEDNN_OPENMP
     context_.a_mem->set_data_handle(
@@ -598,6 +602,8 @@ class MklMatMulPrimitive : public MklPrimitive {
         static_cast<void*>(const_cast<Trhs*>(b_data)), *stream);
     context_.c_mem->set_data_handle(
         static_cast<void*>(const_cast<Toutput*>(c_data)), *stream);
+    context_.sp_mem->set_data_handle(sp_data, *stream);
+
     if (mul_data != nullptr)
       context_.mul_mem->set_data_handle(mul_data, *stream);
     if (add_data != nullptr)
@@ -609,6 +615,7 @@ class MklMatMulPrimitive : public MklPrimitive {
         static_cast<void*>(const_cast<Trhs*>(b_data)));
     context_.c_mem->set_data_handle(
         static_cast<void*>(const_cast<Toutput*>(c_data)));
+    context_.sp_mem->set_data_handle(sp_data);
     if (mul_data != nullptr) context_.mul_mem->set_data_handle(mul_data);
     if (add_data != nullptr) context_.add_mem->set_data_handle(add_data);
 #endif  // !ENABLE_ONEDNN_OPENMP
@@ -618,6 +625,7 @@ class MklMatMulPrimitive : public MklPrimitive {
     context_.a_mem->set_data_handle(DummyData);
     context_.b_mem->set_data_handle(DummyData);
     context_.c_mem->set_data_handle(DummyData);
+    context_.sp_mem->set_data_handle(DummyData);
     if (mul_data != nullptr) context_.mul_mem->set_data_handle(DummyData);
     if (add_data != nullptr) context_.add_mem->set_data_handle(DummyData);
   }
@@ -631,6 +639,7 @@ class MklMatMulPrimitive : public MklPrimitive {
     std::shared_ptr<dnnl::memory> c_mem;
     std::shared_ptr<dnnl::memory> mul_mem;
     std::shared_ptr<dnnl::memory> add_mem;
+    std::shared_ptr<dnnl::memory> sp_mem;
 
     // Descriptor and primitive-descriptor for MatMul.
     std::shared_ptr<matmul::desc> desc;
@@ -653,6 +662,7 @@ class MklMatMulPrimitive : public MklPrimitive {
           c_mem(nullptr),
           mul_mem(nullptr),
           add_mem(nullptr),
+          sp_mem(nullptr),
           desc(nullptr),
           prim_desc(nullptr),
           a_md(nullptr),
@@ -705,12 +715,10 @@ class MklMatMulPrimitive : public MklPrimitive {
         }
       }
       post_ops_attr.set_post_ops(post_ops);
-      context_.prim_desc.reset(new matmul::primitive_desc(
-          *context_.desc, post_ops_attr, cpu_engine_));
-    } else {
-      context_.prim_desc.reset(
-          new matmul::primitive_desc(*context_.desc, cpu_engine_));
     }
+    post_ops_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    context_.prim_desc.reset(
+        new matmul::primitive_desc(*context_.desc, post_ops_attr, cpu_engine_));
 
     // Create memory primitive based on dummy data.
     context_.a_mem.reset(
@@ -719,11 +727,15 @@ class MklMatMulPrimitive : public MklPrimitive {
         new dnnl::memory(*context_.b_md, cpu_engine_, DummyData));
     context_.c_mem.reset(
         new dnnl::memory(*context_.b_md, cpu_engine_, DummyData));
+    auto scratchpad_md = context_.prim_desc->scratchpad_desc();
+    context_.sp_mem.reset(
+        new dnnl::memory(scratchpad_md, cpu_engine_, DummyData));
 
     // Create matmul primitive.
     matmul_primitive.reset(new dnnl::matmul(*context_.prim_desc));
     context_.net_args.push_back({{DNNL_ARG_SRC, *context_.a_mem},
                                  {DNNL_ARG_WEIGHTS, *context_.b_mem},
+                                 {DNNL_ARG_SCRATCHPAD, *context_.sp_mem},
                                  {DNNL_ARG_DST, *context_.c_mem}});
     if (!post_op_params.empty()) {
       int count = 0;
@@ -857,12 +869,14 @@ void dnnl_gemm(char transa, char transb, int64_t m, int64_t n, int64_t k,
   MklMatMulPrimitive<T, T, T>* matmul_prim =
       MklMatMulPrimitiveFactory<T, T, T, T>::Get(params, 0);
 
+  UserScratchPad<unsigned char> scratch_pad;
+  scratch_pad.AllocateSPTensor(matmul_prim, ctx);
   // Execute matmul primitive.
   auto st = ExecuteSingleThreadedGemm(m, n, k, sizeof(T));
   std::shared_ptr<stream> cpu_stream;
   MklDnnThreadPool eigen_tp(ctx, st ? 1 : -1);
   cpu_stream.reset(CreateStream(&eigen_tp, matmul_prim->GetEngine()));
-  matmul_prim->Execute(cpu_stream, a, b, c);
+  matmul_prim->Execute(cpu_stream, a, b, c, scratch_pad.Get());
 }
 
 }  // anonymous namespace

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -668,9 +668,9 @@ inline Status ConvertMklToTF(OpKernelContext* context,
     }
     return Status::OK();
   } catch (dnnl::error& e) {
-    string error_msg = "Status: " + std::to_string(e.status) +
-                       ", message: " + string(e.message) + ", in file " +
-                       string(__FILE__) + ":" + std::to_string(__LINE__);
+    string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                       string(e.message) + ", in file " + string(__FILE__) +
+                       ":" + std::to_string(__LINE__);
     LOG(FATAL) << "Operation received an exception: " << error_msg;
   }
 }
@@ -801,6 +801,38 @@ inline void AllocTmpBuffer(OpKernelContext* context, Tensor* tensor_out,
   OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<T>::v(),
                                                  tf_shape, tensor_out));
 }
+
+template <typename T>
+struct UserScratchPad {
+  template <typename MklPrim>
+  // NOTE: if scratchpad is not required for a particular primitive the
+  //      spad_md.get_size() will return 0. It is fine to return
+  //      nullptr in this case
+  inline void AllocateSPTensor(MklPrim* mkl_prim, OpKernelContext* context) {
+    allocated_ = false;
+    auto spad_md = mkl_prim->GetScratchPadDesc();
+    size_t spad_size = spad_md.get_size();
+    if (spad_size == 0) return;
+
+    size_t allocate_size =
+        (spad_size / sizeof(T)) + ((spad_size % sizeof(T) > 0) ? 1 : 0);
+    TensorShape tf_shape;
+    tf_shape.AddDim(allocate_size);
+    AllocTmpBuffer<T>(context, &scratch_pad_, tf_shape);
+    allocated_ = true;
+  }
+  inline void* Get() {
+    if (allocated_) {
+      return static_cast<void*>(scratch_pad_.flat<T>().data());
+    } else {
+      return nullptr;
+    }
+  }
+
+ private:
+  Tensor scratch_pad_;
+  bool allocated_ = false;
+};
 
 inline void GetStridesFromSizes(MklTensorFormat data_format, size_t* strides,
                                 const size_t* sizes) {
@@ -1225,8 +1257,8 @@ inline Status CreateBlockedMemDescHelper(const memory::dims& dim,
     delete[] input_strides;
     return Status(error::Code::INTERNAL,
                   tensorflow::strings::StrCat(
-                      "Failed to create blocked memory descriptor.",
-                      "Status: ", e.status, ", message: ", e.message));
+                      "Failed to create blocked memory descriptor.", "Status: ",
+                      e.status, ", message: ", e.message));
   }
   return Status::OK();
 }


### PR DESCRIPTION
This PR has changes from PR [54381 ](https://github.com/tensorflow/tensorflow/pull/54381)(reverted back) + fix for Windows build failure.
Changes to add user scratch pad for matmul primitive to fix OOM issue in Transformer LT.

This reduces memory footprint of the primitive. It fixes an out of memory issue when running Transformer LT with multiple instances and total thread count is large. Managing scratch pad for the primitive from the framework, fixes the out of memory issue, reduces memory footprint and does not affect performance. The changes :
Creates a new struct that hold the Tensor for scratch pad arg.
Allocates memory based on scratch pad size queried from primitive description.
Sets user scratch pad in post ops for the primitive.