### PR TITLE
Update Compute Library to version 22.02

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -190,11 +190,11 @@ def _tf_repositories():
 
     tf_http_archive(
         name = "compute_library",
-        sha256 = "8322ed2e135999569082a95e7fbb2fa87786ffb1c67935b3ef71e00b53f2c887",
-        strip_prefix = "ComputeLibrary-21.11",
+        sha256 = "11244b05259fb1c4af7384d0c3391aeaddec8aac144774207582db4842726540",
+        strip_prefix = "ComputeLibrary-22.02",
         build_file = "//third_party/compute_library:BUILD",
         patch_file = ["//third_party/compute_library:compute_library.patch"],
-        urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v21.11.tar.gz"),
+        urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.02.tar.gz"),
     )
 
     tf_http_archive(

--- a/third_party/compute_library/BUILD
+++ b/third_party/compute_library/BUILD
@@ -91,6 +91,7 @@ cc_library(
             "src/cpu/utils/*.cpp",
             "src/cpu/kernels/internal/*.cpp",
             "src/cpu/kernels/**/neon/*.cpp",
+            "src/cpu/kernels/**/nchw/*.cpp",
             "src/core/NEON/kernels/arm_gemm/*.cpp",
             "**/*.h",
         ],
@@ -103,7 +104,6 @@ cc_library(
             "src/gpu/**",
         ],
     ) + [
-        "src/cpu/kernels/pool2d/neon/nchw/all.cpp",
         "src/core/CPP/CPPTypes.cpp",
         "src/c/operators/AclActivation.cpp",
         "src/core/NEON/kernels/arm_conv/pooling/kernels/cpp_nhwc_1x1_stride_any_depthfirst/generic.cpp",
@@ -119,7 +119,7 @@ cc_library(
     ]) + [
         "arm_compute_version.embed",
     ],
-    copts = ["-march=armv8.2-a"],
+    copts = ["-march=armv8-a"],
     defines = _COMPUTE_LIBRARY_DEFINES,
     includes = [
         "arm_compute/runtime",

--- a/third_party/compute_library/compute_library.patch
+++ b/third_party/compute_library/compute_library.patch
@@ -4,5 +4,5 @@ index 000000000..c986ad52a
 --- /dev/null
 +++ b/arm_compute_version.embed
 @@ -0,0 +1,1 @@
-+"arm_compute_version=v21.08 Build options: {} Git hash=b'N/A'"
++"arm_compute_version=v22.02 Build options: {} Git hash=b'8f587de9214dbc3aee4ff4eeb2ede66747769b19'"
 \ No newline at end of file


### PR DESCRIPTION
This PR updates the Compute Library verion from 21.11 to 22.02 and updates the build to supports Arm-v8 in addition to Arm-v8.2a and above.