### PR TITLE
[ROCm] Correcting the output size for the RFFT call in `//tensorflow/compiler/xla/service/gpu/tests:mlir_fft_test`

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/mlir_fft_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/mlir_fft_test.cc
@@ -29,16 +29,16 @@ TEST_F(FftTest, SimpleCase1) {
         func @main(%arg0: memref<4xf32> {
                        lmhlo.params = 0 : index
                    },
-                   %arg1: memref<4xcomplex<f32>> {
+                   %arg1: memref<3xcomplex<f32>> {
                        lmhlo.output_index = dense<[0]> : tensor<1xindex>
                    }
         ) attributes {
-            result_xla_shape = "(f32[8]) "
+            result_xla_shape = "(f32[6]) "
         } {
           "lmhlo.fft"(%arg0, %arg1) {
             fft_length = dense<4> : tensor<1xi64>,
             fft_type = #mhlo<"fft_type RFFT">
-          } : (memref<4xf32>, memref<4xcomplex<f32>>) -> ()
+          } : (memref<4xf32>, memref<3xcomplex<f32>>) -> ()
           "lmhlo.terminator"() : () -> ()
         }
       })";
@@ -47,7 +47,7 @@ TEST_F(FftTest, SimpleCase1) {
                      .ConsumeValueOrDie();
   ASSERT_EQ(1, outputs.size());
   EXPECT_THAT(FromUint8Span<float>(outputs[0]),
-              ElementsAreArray<float>({2, 0, 0, 0, 2, 0, 0, 0}));
+              ElementsAreArray<float>({2, 0, 0, 0, 2, 0}));
 }
 
 }  // namespace gpu


### PR DESCRIPTION
The `//tensorflow/compiler/xla/service/gpu/tests:mlir_fft_test` was added via this commit https://github.com/tensorflow/tensorflow/commit/58740928fff82a6193a6cc89f09b732e061764c7

The test
* calls RFFT transform on an input buffer of type `4 x f32` with values `[1,0,1,0]`
* expects the resulting output buffer to be of type `4 x complex<f32>` ... this is incorrect

The correct size for the output buffer should be `3 x complex<f32>`.  This can be verfied via numpy doc and example

From https://numpy.org/doc/stable/reference/generated/numpy.fft.rfft.html

```
...
Returns

    out : complex ndarray

        The truncated or zero-padded input, transformed along the axis indicated by axis,
	or the last one if axis is not specified.

	If n is even, the length of the transformed axis is (n/2)+1.
	If n is odd, the length is (n+1)/2.
...
```

In the testcase n is 4, and hence output size should be 4/2 + 1 = 3

np version on testcase

```
# python3 -c "import numpy as np; print (np.fft.rfft([1,0,1,0]))"
[2.+0.j 0.+0.j 2.+0.j]
```

The incorrect output size was causing this test to fail on ROCm (elems 7 & 8 had junk data and hence mismatching)

This commit updates to testcase to have the correct return size, and now the test passes on the ROCm platform

-----------------------


/cc @cheshire @chsigg 