### PR TITLE
Enabling Bazelisk to be used when Bazel is not present during install build from source

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -477,8 +477,12 @@ def check_bazel_version(min_version, max_version):
   """
   bazel_executable = which('bazel')
   if bazel_executable is None:
-    print('Cannot find bazel. Please install bazel.')
-    sys.exit(1)
+        bazel_executable = which('bazelisk')
+    if bazel_executable is None:
+      print('Cannot find bazel. Please install bazel.')
+      sys.exit(1)
+    else:
+      print('Using bazelisk, since bazel not found')
 
   stderr = open(os.devnull, 'wb')
   curr_version = run_shell([bazel_executable, '--version'],

--- a/configure.py
+++ b/configure.py
@@ -477,7 +477,7 @@ def check_bazel_version(min_version, max_version):
   """
   bazel_executable = which('bazel')
   if bazel_executable is None:
-        bazel_executable = which('bazelisk')
+    bazel_executable = which('bazelisk')
     if bazel_executable is None:
       print('Cannot find bazel. Please install bazel.')
       sys.exit(1)

--- a/configure.py
+++ b/configure.py
@@ -479,7 +479,7 @@ def check_bazel_version(min_version, max_version):
   if bazel_executable is None:
     bazel_executable = which('bazelisk')
     if bazel_executable is None:
-      print('Cannot find bazel. Please install bazel.')
+      print('Cannot find bazel. Please install bazel/bazelisk.')
       sys.exit(1)
     else:
       print('Using bazelisk, since bazel not found')

--- a/configure.py
+++ b/configure.py
@@ -481,8 +481,6 @@ def check_bazel_version(min_version, max_version):
     if bazel_executable is None:
       print('Cannot find bazel. Please install bazel/bazelisk.')
       sys.exit(1)
-    else:
-      print('Using bazelisk, since bazel not found')
 
   stderr = open(os.devnull, 'wb')
   curr_version = run_shell([bazel_executable, '--version'],


### PR DESCRIPTION
Update Configure.py @55218, Last commit failed at CICD for seemly unrelated issue. This patch is just to re run the same CICD and validate