### PR TITLE
Add necessary check in fft ops to fix crash

### DIFF
--- a/tensorflow/core/kernels/fft_ops.cc
+++ b/tensorflow/core/kernels/fft_ops.cc
@@ -66,6 +66,12 @@ class FFTBase : public OpKernel {
 
       auto fft_length_as_vec = fft_length.vec<int32>();
       for (int i = 0; i < fft_rank; ++i) {
+        OP_REQUIRES(
+            ctx,
+            fft_length_as_vec(i) >= 0,
+            errors::InvalidArgument(
+                "fft_length[" , i,
+                "] must >= 0, but got: ", fft_length_as_vec(i)));
         fft_shape[i] = fft_length_as_vec(i);
         // Each input dimension must have length of at least fft_shape[i]. For
         // IRFFTs, the inner-most input dimension must have length of at least

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -609,6 +609,16 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
         self._tf_ifft_for_rank(rank), re, im, result_is_complex=False,
         rtol=tol, atol=tol)
 
+  def test_invalid_args(self):
+    # Test case for GitHub issue 55263
+    a = np.empty([6, 0])
+    b = np.array([1, -1])
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError, "must >= 0"):
+      with self.session():
+        v = fft_ops.rfft2d(input_tensor=a,fft_length=b)
+        self.evaluate(v)
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class FFTShiftTest(test.TestCase, parameterized.TestCase):


### PR DESCRIPTION
This PR tries to address the issue raised in #55263 where
tf.single.rfft2d will crash when length contains negative value.

This PR fixes #55263

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>