### PR TITLE
Implemented RaggedTensor.from_sparse for multi-dimensional SparseTensor

### DIFF
--- a/tensorflow/python/ops/ragged/ragged_from_sparse_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_from_sparse_op_test.py
@@ -47,20 +47,15 @@ class RaggedTensorToSparseOpTest(test_util.TensorFlowTestCase):
 
   def testBadSparseTensorRank(self):
     st1 = sparse_tensor.SparseTensor(indices=[[0]], values=[0], dense_shape=[3])
-    self.assertRaisesRegex(ValueError, r'rank\(st_input\) must be 2',
+    self.assertRaisesRegex(ValueError, r'rank\(st_input\) must be at least 2',
                            RaggedTensor.from_sparse, st1)
-
-    st2 = sparse_tensor.SparseTensor(
-        indices=[[0, 0, 0]], values=[0], dense_shape=[3, 3, 3])
-    self.assertRaisesRegex(ValueError, r'rank\(st_input\) must be 2',
-                           RaggedTensor.from_sparse, st2)
 
     if not context.executing_eagerly():
       st3 = sparse_tensor.SparseTensor(
           indices=array_ops.placeholder(dtypes.int64),
           values=[0],
           dense_shape=array_ops.placeholder(dtypes.int64))
-      self.assertRaisesRegex(ValueError, r'rank\(st_input\) must be 2',
+      self.assertRaisesRegex(ValueError, r'rank\(st_input\) must be at least 2',
                              RaggedTensor.from_sparse, st3)
 
   def testGoodPartialSparseTensorRank(self):
@@ -102,6 +97,43 @@ class RaggedTensorToSparseOpTest(test_util.TensorFlowTestCase):
     with self.assertRaisesRegex(errors.InvalidArgumentError,
                                 r'.*SparseTensor is not right-ragged'):
       self.evaluate(RaggedTensor.from_sparse(st3))
+
+  def testGoodMultiDimensionalSparse(self):
+    st1 = sparse_tensor.SparseTensor(
+      indices=[
+        [0, 0, 0],
+        [0, 0, 1],
+        [0, 0, 2],
+        [0, 1, 0],
+        [1, 0, 0]
+      ],
+      values=[1, 2, 3, 4, 5],
+      dense_shape=[2, 1, 3]
+    )
+    
+    st2 = sparse_tensor.SparseTensor(
+      indices=[
+        [0, 0, 0, 0],
+        [0, 0, 0, 1],
+        [0, 0, 0, 2],
+        [0, 0, 1, 0],
+        [0, 1, 0, 0],
+        [1, 0, 0, 0],
+        [1, 0, 0, 1],
+        [1, 0, 0, 2],
+        [1, 0, 1, 0],
+        [1, 1, 0, 0],
+      ],
+      values=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      dense_shape=[2, 2, 1, 3]
+    )
+    res1 = RaggedTensor.from_sparse(st1)
+    res2 = RaggedTensor.from_sparse(st2)
+
+    self.assertAllEqual(res1.to_sparse().indices, st1.indices)
+    self.assertAllEqual(res2.to_sparse().indices, st2.indices)
+    self.assertAllEqual(res1.flat_values, st1.values)
+    self.assertAllEqual(res2.flat_values, st2.values)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/ops/ragged/ragged_tensor.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor.py
@@ -1908,7 +1908,10 @@ class RaggedTensor(composite_tensor.CompositeTensor,
             indices = math_ops.segment_max(indices, rowids)
           # Here we assume that the sparse indices are reordered
           # The start of each nested row is index 0
-          rowids = math_ops.cast(math_ops.equal(indices[:, -1], 0), row_splits_dtype)
+          rowids = math_ops.cast(
+            math_ops.equal(indices[:, -1], 0),
+            row_splits_dtype
+          )
           # This cumsum becomes the rowids of the last dimension
           rowids = math_ops.cumsum(rowids) - 1
           nrows = math_ops.reduce_max(rowids)+1

--- a/tensorflow/python/ops/ragged/ragged_tensor.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor.py
@@ -1858,8 +1858,8 @@ class RaggedTensor(composite_tensor.CompositeTensor,
     """Converts a `tf.sparse.SparseTensor` to a `RaggedTensor`.
 
     The `output` `RaggedTensor` will contain the explicit values
-    from that values of `st_input`.  `st_input` must be ragged-right in the last
-    dimension. If not it is not ragged-right, then an error will be generated.
+    from that values of `st_input`. `st_input` must be ragged-right in the last
+    dimension. If it is not ragged-right, then an error will be generated.
 
     Example:
 


### PR DESCRIPTION
Implemented a more general version of `RaggedTensor.from_sparse`, now allowing conversion from multi-dimensional `SparseTensor`s to `RaggedTensors`.

To compare the performance with the original implementation specifically for the case of 2D sparse matrices, I simulated a random (1000, 1000) sparse tensor, with 50% sparsity. Under eager mode, the run time for the original implementation is 17.1  ms +/- 589 us, and the new implementation is 15.4 ms +/- 420 us. The performance wasn't worse.