### PR TITLE
Fix eigen's headers to use 'std' instead of Eigen::internals

### DIFF
--- a/tensorflow/core/kernels/eigen_attention.h
+++ b/tensorflow/core/kernels/eigen_attention.h
@@ -184,8 +184,8 @@ struct GlimpseExtractionOp {
           } break;
           case UNIFORM: {
             // Initialize the glimpse with uniform noise.
-            typedef typename internal::remove_const<
-                typename internal::traits<Input>::Scalar>::type Scalar;
+            typedef std::remove_const_t<
+                typename internal::traits<Input>::Scalar> Scalar;
             TensorFixedSize<Scalar, Sizes<> > mini;
             mini.device(device) = input.template chip<3>(i).minimum();
             TensorFixedSize<float, Sizes<> > range;
@@ -206,8 +206,8 @@ struct GlimpseExtractionOp {
             // of each channel, and use them to shape the gaussian.
             DSizes<Index, 2> glimpse_size(width_, height_);
             DSizes<Index, 2> input_size(input_width, input_height);
-            typedef typename internal::remove_const<
-                typename internal::traits<Input>::Scalar>::type Scalar;
+            typedef std::remove_const_t<
+                typename internal::traits<Input>::Scalar> Scalar;
 
             for (int j = 0; j < num_channels; ++j) {
               TensorFixedSize<Scalar, Sizes<> > mean;

--- a/tensorflow/core/kernels/eigen_backward_cuboid_convolutions.h
+++ b/tensorflow/core/kernels/eigen_backward_cuboid_convolutions.h
@@ -44,7 +44,7 @@ namespace Eigen {
  */
 
 template <typename OutputBackward, typename Kernel>
-EIGEN_ALWAYS_INLINE static const typename internal::conditional<
+EIGEN_ALWAYS_INLINE static const std::conditional_t<
     internal::traits<OutputBackward>::Layout == ColMajor,
     TensorReshapingOp<
         const DSizes<typename internal::traits<OutputBackward>::Index,
@@ -83,7 +83,7 @@ EIGEN_ALWAYS_INLINE static const typename internal::conditional<
                     const array<
                         typename internal::traits<OutputBackward>::Index, 5>,
                     const TensorReverseOp<const Eigen::array<bool, 5>,
-                                          const Kernel>>>>>>>::type
+                                          const Kernel>>>>>>>
 CuboidConvolutionBackwardInput(
     const Kernel& kernel, const OutputBackward& output_backward,
     typename internal::traits<OutputBackward>::Index inputPlanes,
@@ -322,7 +322,7 @@ CuboidConvolutionBackwardInput(
  * for row-major.
  */
 template <typename OutputBackward, typename Input>
-EIGEN_ALWAYS_INLINE static const typename internal::conditional<
+EIGEN_ALWAYS_INLINE static const std::conditional_t<
     internal::traits<Input>::Layout == ColMajor,
     const TensorReverseOp<
         const Eigen::array<typename internal::traits<Input>::Index,
@@ -385,7 +385,7 @@ EIGEN_ALWAYS_INLINE static const typename internal::conditional<
                             const Eigen::array<
                                 typename internal::traits<Input>::Index,
                                 internal::traits<Input>::NumDimensions>,
-                            const OutputBackward>>>>>>>>::type
+                            const OutputBackward>>>>>>>>
 CuboidConvolutionBackwardKernel(
     const Input& input, const OutputBackward& output_backward,
     typename internal::traits<Input>::Index kernelPlanes,

--- a/tensorflow/core/kernels/eigen_backward_spatial_convolutions.h
+++ b/tensorflow/core/kernels/eigen_backward_spatial_convolutions.h
@@ -51,7 +51,7 @@ typedef IndexList<type2index<1>, type2index<1>, type2index<0>, type2index<0>>
     ReverseRowMajor;
 
 template <typename OutputBackward, typename Kernel>
-EIGEN_ALWAYS_INLINE static const typename internal::conditional<
+EIGEN_ALWAYS_INLINE static const std::conditional_t<
     internal::traits<OutputBackward>::Layout == ColMajor,
     TensorReshapingOp<
         const DSizes<typename internal::traits<OutputBackward>::Index,
@@ -91,7 +91,7 @@ EIGEN_ALWAYS_INLINE static const typename internal::conditional<
                     const array<
                         typename internal::traits<OutputBackward>::Index, 4>,
                     const Eigen::TensorForcedEvalOp<const TensorReverseOp<
-                        const ReverseRowMajor, const Kernel>>>>>>>>::type
+                        const ReverseRowMajor, const Kernel>>>>>>>>
 SpatialConvolutionBackwardInput(
     const Kernel& kernel, const OutputBackward& output_backward,
     typename internal::traits<OutputBackward>::Index inputRows,
@@ -168,8 +168,8 @@ SpatialConvolutionBackwardInput(
   // TODO(yangke): we can make things slightly faster by collapsing the
   // dimensions
   // where we don't reverse. Try that once we have a faster compiler.
-  typedef typename internal::conditional<isColMajor, ReverseColMajor,
-                                         ReverseRowMajor>::type Reverse;
+  typedef std::conditional_t<isColMajor, ReverseColMajor,
+                                         ReverseRowMajor> Reverse;
   Reverse kernel_reverse;
   // Reorder the dimensions to:
   //   filters x patch_rows x patch_cols x channels
@@ -311,7 +311,7 @@ SpatialConvolutionBackwardInput(
  */
 
 template <typename OutputBackward, typename Input>
-EIGEN_ALWAYS_INLINE static const typename internal::conditional<
+EIGEN_ALWAYS_INLINE static const std::conditional_t<
     internal::traits<Input>::Layout == ColMajor,
     const TensorReverseOp<
         const Eigen::array<typename internal::traits<Input>::Index,
@@ -376,7 +376,7 @@ EIGEN_ALWAYS_INLINE static const typename internal::conditional<
                                 const Eigen::array<
                                     typename internal::traits<Input>::Index,
                                     internal::traits<Input>::NumDimensions>,
-                                const Input>>>>>>>>>::type
+                                const Input>>>>>>>>>
 SpatialConvolutionBackwardKernel(
     const Input& input, const OutputBackward& output_backward,
     typename internal::traits<Input>::Index kernelRows,

--- a/tensorflow/core/kernels/eigen_cuboid_convolution.h
+++ b/tensorflow/core/kernels/eigen_cuboid_convolution.h
@@ -495,7 +495,7 @@ class TensorContractionInputMapper<
       // span[1]+1 : packetSize-1 - Zeross will be loaded for these indices
       const Index packetSize = internal::unpacket_traits<Packet>::size;
       EIGEN_ALIGN_MAX
-      typename internal::remove_const<Scalar>::type values[packetSize];
+      std::remove_const_t<Scalar> values[packetSize];
       for (int i = 0; i < span[0]; ++i) values[i] = Scalar(0);
       for (int i = span[0]; i < span[1] + 1; ++i)
         values[i] = loadCoeff(patchId - span[0] + i, planeIndex, rowIndex,
@@ -758,7 +758,7 @@ class TensorContractionInputMapper<
                          Index colIndex, Index otherIndex) const {
     const int packetSize = internal::unpacket_traits<Packet>::size;
     EIGEN_ALIGN_MAX
-    typename internal::remove_const<Scalar>::type values[packetSize];
+    std::remove_const_t<Scalar> values[packetSize];
     for (int i = 0; i < packetSize; ++i) {
       values[i] =
           loadCoeff(patchId + i, planeIndex, rowIndex, colIndex, otherIndex);
@@ -1812,7 +1812,7 @@ struct gemm_pack_colmajor_block<
  * output.
  */
 template <typename Input, typename Kernel>
-EIGEN_ALWAYS_INLINE static const typename internal::conditional<
+EIGEN_ALWAYS_INLINE static const std::conditional_t<
     internal::traits<Input>::Layout == ColMajor,
     TensorReshapingOp<
         const DSizes<typename internal::traits<Input>::Index,
@@ -1837,7 +1837,7 @@ EIGEN_ALWAYS_INLINE static const typename internal::conditional<
                                           const Input> >,
             const TensorReshapingOp<
                 const DSizes<typename internal::traits<Input>::Index, 2>,
-                const Kernel> > > >::type
+                const Kernel> > > >
 CuboidConvolution(const Input& input, const Kernel& kernel,
                   const Index stridePlanes = 1, const Index strideRows = 1,
                   const Index strideCols = 1,

--- a/tensorflow/core/kernels/eigen_pooling.h
+++ b/tensorflow/core/kernels/eigen_pooling.h
@@ -40,13 +40,13 @@ EIGEN_ALWAYS_INLINE static const TensorReshapingOp<
     const Eigen::DSizes<typename internal::traits<Input>::Index,
                         internal::traits<Input>::NumDimensions>,
     const TensorReductionOp<
-        internal::MaxReducer<typename internal::remove_const<
-            typename internal::traits<Input>::Scalar>::type>,
-        typename internal::conditional<
+        internal::MaxReducer<std::remove_const_t<
+            typename internal::traits<Input>::Scalar>>,
+        std::conditional_t<
             internal::traits<Input>::Layout == ColMajor,
             const Eigen::IndexList<Eigen::type2index<1>, Eigen::type2index<2> >,
             const Eigen::IndexList<Eigen::type2index<2>,
-                                   Eigen::type2index<3> > >::type,
+                                   Eigen::type2index<3> > >,
         const TensorImagePatchOp<Dynamic, Dynamic, const Input> > >
 SpatialMaxPooling(const Input& input, DenseIndex patchRows,
                   DenseIndex patchCols, DenseIndex strideRows,
@@ -96,18 +96,18 @@ SpatialMaxPooling(const Input& input, DenseIndex patchRows,
 
   // Take advantage of cxx11 to give the compiler information it can use to
   // optimize the code.
-  typename internal::conditional<
+  std::conditional_t<
       internal::traits<Input>::Layout == ColMajor,
       const Eigen::IndexList<Eigen::type2index<1>, Eigen::type2index<2> >,
       const Eigen::IndexList<Eigen::type2index<2>,
-                             Eigen::type2index<3> > >::type reduction_dims;
+                             Eigen::type2index<3> > > reduction_dims;
 
   return input
       .extract_image_patches(
           patchRows, patchCols, strideRows, strideCols, in_strideRows,
           in_strideCols, padding_type,
-          Eigen::NumTraits<typename internal::remove_const<
-              typename internal::traits<Input>::Scalar>::type>::lowest())
+          Eigen::NumTraits<std::remove_const_t<
+              typename internal::traits<Input>::Scalar>>::lowest())
       .maximum(reduction_dims)
       .reshape(post_reduce_dims);
 }
@@ -366,13 +366,13 @@ EIGEN_ALWAYS_INLINE static const TensorReshapingOp<
     const Eigen::DSizes<typename internal::traits<Input>::Index,
                         internal::traits<Input>::NumDimensions>,
     const TensorReductionOp<
-        internal::AvgPoolMeanReducer<typename internal::remove_const<
-            typename internal::traits<Input>::Scalar>::type>,
-        typename internal::conditional<
+        internal::AvgPoolMeanReducer<std::remove_const_t<
+            typename internal::traits<Input>::Scalar>>,
+        std::conditional_t<
             internal::traits<Input>::Layout == ColMajor,
             const Eigen::IndexList<Eigen::type2index<1>, Eigen::type2index<2> >,
             const Eigen::IndexList<Eigen::type2index<2>,
-                                   Eigen::type2index<3> > >::type,
+                                   Eigen::type2index<3> > >,
         const TensorImagePatchOp<Dynamic, Dynamic, const Input> > >
 SpatialAvgPooling(const Input& input, DenseIndex patchRows,
                   DenseIndex patchCols, DenseIndex strideRows,
@@ -420,17 +420,17 @@ SpatialAvgPooling(const Input& input, DenseIndex patchRows,
   }
   post_reduce_dims[3] = in.dimension(3);
 
-  typedef typename internal::remove_const<
-      typename internal::traits<Input>::Scalar>::type CoeffReturnType;
+  typedef std::remove_const_t<
+      typename internal::traits<Input>::Scalar> CoeffReturnType;
   internal::AvgPoolMeanReducer<CoeffReturnType> mean_with_nan;
 
   // Take advantage of cxx11 to give the compiler information it can use to
   // optimize the code.
-  typename internal::conditional<
+  std::conditional_t<
       internal::traits<Input>::Layout == ColMajor,
       const Eigen::IndexList<Eigen::type2index<1>, Eigen::type2index<2> >,
       const Eigen::IndexList<Eigen::type2index<2>,
-                             Eigen::type2index<3> > >::type reduction_dims;
+                             Eigen::type2index<3> > > reduction_dims;
   return input
       .extract_image_patches(patchRows, patchCols, strideRows, strideCols,
                              in_strideRows, in_strideCols, padding_type,
@@ -524,8 +524,8 @@ CuboidAvgPooling(const Input& input, DenseIndex patchPlanes,
     pre_reduce_dims[2] = post_reduce_dims[4];
   }
 
-  typedef typename internal::remove_const<
-      typename internal::traits<Input>::Scalar>::type CoeffReturnType;
+  typedef std::remove_const_t<
+      typename internal::traits<Input>::Scalar> CoeffReturnType;
   internal::AvgPoolMeanReducer<CoeffReturnType> mean_with_nan;
 
   // Take advantage of cxx11 to give the compiler information it can use to

--- a/tensorflow/core/kernels/eigen_spatial_convolutions-inl.h
+++ b/tensorflow/core/kernels/eigen_spatial_convolutions-inl.h
@@ -397,7 +397,7 @@ class TensorContractionInputMapper<
       // span[1]+1 : packetSize-1 - Zeross will be loaded for these indices
       const Index packetSize = internal::unpacket_traits<Packet>::size;
       EIGEN_ALIGN_MAX
-      typename internal::remove_const<Scalar>::type values[packetSize];
+      std::remove_const_t<Scalar> values[packetSize];
       for (int i = 0; i < span[0]; ++i) values[i] = Scalar(0);
       for (int i = span[0]; i < span[1] + 1; ++i)
         values[i] =
@@ -602,7 +602,7 @@ class TensorContractionInputMapper<
       Index patchId, Index rowIndex, Index colIndex, Index otherIndex) const {
     const int packetSize = internal::unpacket_traits<Packet>::size;
     EIGEN_ALIGN_MAX
-    typename internal::remove_const<Scalar>::type values[packetSize];
+    std::remove_const_t<Scalar> values[packetSize];
     for (int i = 0; i < packetSize; ++i) {
       values[i] = loadCoeff(patchId + i, rowIndex, colIndex, otherIndex);
     }
@@ -1570,7 +1570,7 @@ struct gemm_pack_rhs<
 template <typename Input, typename Kernel,
           typename OutputKernel = const NoOpOutputKernel>
 EIGEN_DEVICE_FUNC
-    EIGEN_ALWAYS_INLINE static const typename internal::conditional<
+    EIGEN_ALWAYS_INLINE static const std::conditional_t<
         internal::traits<Input>::Layout == ColMajor,
         TensorReshapingOp<
             const DSizes<typename internal::traits<Input>::Index,
@@ -1597,7 +1597,7 @@ EIGEN_DEVICE_FUNC
                 const TensorReshapingOp<
                     const DSizes<typename internal::traits<Input>::Index, 2>,
                     const Kernel>,
-                const OutputKernel> > >::type
+                const OutputKernel> > >
     SpatialConvolution(const Input& input, const Kernel& kernel,
                        const Index row_stride = 1, const Index col_stride = 1,
                        const PaddingType padding_type = PADDING_SAME,

--- a/tensorflow/core/kernels/image/mirror_pad_op.h
+++ b/tensorflow/core/kernels/image/mirror_pad_op.h
@@ -33,7 +33,7 @@ struct traits<TensorMirrorPadOp<PaddingDimensions, XprType>>
   typedef typename XprTraits::StorageKind StorageKind;
   typedef typename XprTraits::Index Index;
   typedef typename XprType::Nested Nested;
-  typedef typename remove_reference<Nested>::type _Nested;
+  typedef std::remove_reference_t<Nested> _Nested;
   static constexpr int NumDimensions = XprTraits::NumDimensions;
   static constexpr int Layout = XprTraits::Layout;
 };
@@ -229,7 +229,7 @@ struct TensorEvaluator<const TensorMirrorPadOp<PaddingDimensions, ArgType>,
     }
 
     // If the road is not contiguous, then fall back to coeff().
-    EIGEN_ALIGN_MAX typename internal::remove_const<CoeffReturnType>::type
+    EIGEN_ALIGN_MAX std::remove_const_t<CoeffReturnType>
         values[kPacketSize];
     values[0] = impl_.coeff(input_index);
     for (int i = 1; i < kPacketSize; ++i) {


### PR DESCRIPTION
A recent commit on Eigen replaced many type metaprogramming with corresponding std types.
https://gitlab.com/libeigen/eigen/-/commit/421cbf08660fdf9458ea64ca6ceb197e75c6e698

This patch prepares the code to build properly when the Eigen commit id is updated.