### PR TITLE
[TF-TRT] Remove dependency on einsum kernel

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -695,7 +695,6 @@ tf_cuda_library(
         "//tensorflow/core:framework_lite",
         "//tensorflow/core:gpu_runtime",
         "//tensorflow/core:graph",
-        "//tensorflow/core/kernels/linalg:einsum_op",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
         "//tensorflow/core:protos_all_cc",

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/einsum.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/einsum.cc
@@ -23,9 +23,9 @@ limitations under the License.
 #include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
-#include "tensorflow/core/kernels/linalg/einsum_op_impl.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/util/einsum_op_util.h"
 #include "third_party/tensorrt/NvInfer.h"
 
 #if IS_TRT_VERSION_GE(7, 1, 3, 0)
@@ -62,7 +62,7 @@ Status FindIndicesoOfAllValuesInSrc(absl::Span<const T> values,
 // Example: adbc,adce -> adbe. The first tensor has layout BFC, the second BCF.
 enum class EinsumLayout { BFC, BCF, MIX };
 
-using DimType = EinsumHelper::DimensionType;
+using DimType = EinsumDimensionType;
 constexpr auto kBatch = DimType::kBatch;
 constexpr auto kFree = DimType::kFree;
 constexpr auto kContract = DimType::kContract;
@@ -74,7 +74,7 @@ class EinsumDescriptor {
  private:
   // Checks whether input_labels[offset:offset+m] matches labels from other.
   static bool OrderMatches(const Labels& input_labels, int offset, int m,
-                           EinsumHelper::DimensionType dim_type,
+                           EinsumDimensionType dim_type,
                            const std::unique_ptr<EinsumDescriptor>& other) {
     if (other == nullptr) {
       return true;
@@ -90,18 +90,16 @@ class EinsumDescriptor {
                       other->permuted_labels.begin() + offset_other);
   }
 
-  using label_t_iterator =
-      std::vector<EinsumHelper::DimensionType>::const_iterator;
+  using label_t_iterator = std::vector<EinsumDimensionType>::const_iterator;
   static int32_t CountLabels(label_t_iterator begin, label_t_iterator end,
-                             EinsumHelper::DimensionType val) {
+                             EinsumDimensionType val) {
     return static_cast<int32_t>(std::count_if(
-        begin, end, [val](EinsumHelper::DimensionType t) { return t == val; }));
+        begin, end, [val](EinsumDimensionType t) { return t == val; }));
   }
 
   // Appends indices to the "permute" vector where types maches value.
   void AppendMatchingIndicesToPermute(
-      const std::vector<EinsumHelper::DimensionType>& types,
-      EinsumHelper::DimensionType val) {
+      const std::vector<EinsumDimensionType>& types, EinsumDimensionType val) {
     for (int i = 0; i < types.size(); i++) {
       if (types[i] == val) {
         permute.push_back(i);
@@ -110,7 +108,7 @@ class EinsumDescriptor {
   }
 
   Status DetermineLayout(const Labels& input_labels,
-                         const std::vector<EinsumHelper::DimensionType>& types,
+                         const std::vector<EinsumDimensionType>& types,
                          const std::unique_ptr<EinsumDescriptor>& other) {
     // Check if the current layout is BFC or BCF. In that case we could avoid
     // transpose.
@@ -141,7 +139,7 @@ class EinsumDescriptor {
 
   Status CalculateMixedLayoutPermutation(
       const EinsumLayout preferred_layout, const Labels& input_labels,
-      const std::vector<EinsumHelper::DimensionType>& types,
+      const std::vector<EinsumDimensionType>& types,
       const std::unique_ptr<EinsumDescriptor>& other) {
     // Input label types are mixed. Calculate a permutation that maps them
     // to the preferred layout (BCF or BFC).
@@ -187,14 +185,14 @@ class EinsumDescriptor {
   }
 
   Status Initialize(const TRT_TensorOrWeights& operand, Labels input_labels,
-                    std::vector<EinsumHelper::DimensionType>& label_types,
+                    std::vector<EinsumDimensionType>& label_types,
                     EinsumLayout preferred_layout,
                     const std::unique_ptr<EinsumDescriptor>& other = nullptr) {
     if (preferred_layout == EinsumLayout::MIX) {
       return errors::Internal("Preferred einsum layout cannot be MIX");
     }
     // Map label indices to label types.
-    std::vector<EinsumHelper::DimensionType> types;  // Input label types.
+    std::vector<EinsumDimensionType> types;  // Input label types.
     std::transform(input_labels.begin(), input_labels.end(),
                    std::back_inserter(types),
                    [&label_types](int i) { return label_types.at(i); });
@@ -252,7 +250,7 @@ class EinsumDescriptor {
   // that layout.
   static StatusOr<std::unique_ptr<EinsumDescriptor>> Create(
       const TRT_TensorOrWeights& operand, Labels input_labels,
-      std::vector<EinsumHelper::DimensionType>& label_types,
+      std::vector<EinsumDimensionType>& label_types,
       EinsumLayout preferred_layout,
       const std::unique_ptr<EinsumDescriptor>& other = nullptr) {
     auto desc = std::make_unique<EinsumDescriptor>();
@@ -601,15 +599,15 @@ Status ParseEquation(const std::string& equation,
   VLOG(2) << "Einsum equation " << equation;
   OperandLabels input_labels;
   Labels output_labels;
-  std::vector<EinsumHelper::DimensionType> label_types;
+  std::vector<EinsumDimensionType> label_types;
   OperandLabelCounts input_label_counts;
   LabelCounts output_label_counts;
   absl::InlinedVector<bool, 2> input_has_ellipsis;
   bool output_has_ellipsis;
-  TF_RETURN_IF_ERROR(EinsumHelper::ParseEquation(
-      equation, &input_labels, &output_labels, &label_types,
-      &input_label_counts, &output_label_counts, &input_has_ellipsis,
-      &output_has_ellipsis));
+  TF_RETURN_IF_ERROR(
+      ParseEinsumEquation(equation, &input_labels, &output_labels, &label_types,
+                          &input_label_counts, &output_label_counts,
+                          &input_has_ellipsis, &output_has_ellipsis));
 
   if (input_has_ellipsis[0] || input_has_ellipsis[1] || output_has_ellipsis) {
     // TODO(tfeher): Handle ellipsis like EinsumHelper::ProcessDimensions.
@@ -620,8 +618,8 @@ Status ParseEquation(const std::string& equation,
   }
 
   if (absl::c_any_of(label_types, [](auto l) {
-        return l == EinsumHelper::DimensionType::kReduce ||
-               l == EinsumHelper::DimensionType::kBroadcasting;
+        return l == EinsumDimensionType::kReduce ||
+               l == EinsumDimensionType::kBroadcasting;
       })) {
     VLOG(2) << "Einsum reductions not implemented";
     return errors::Unimplemented("No conversion for einsum equation.");

--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -161,7 +161,7 @@ Status EinsumShape(shape_inference::InferenceContext* c) {
   gtl::InlinedVector<string, 2> input_labels;
   string output_labels;
   TF_RETURN_IF_ERROR(
-      ParseEinsumEquation(equation, &input_labels, &output_labels));
+      ValidateEinsumEquation(equation, &input_labels, &output_labels));
 
   if (c->num_inputs() == 0 || c->num_inputs() > 2) {
     return errors::InvalidArgument("Expected either 1 or 2 inputs but got: ",

--- a/tensorflow/core/kernels/linalg/einsum_op_impl.h
+++ b/tensorflow/core/kernels/linalg/einsum_op_impl.h
@@ -23,7 +23,6 @@ limitations under the License.
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_split.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/kernel_def_builder.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
@@ -42,6 +41,7 @@ limitations under the License.
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/profiler/lib/traceme.h"
 #include "tensorflow/core/util/einsum_op_util.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/core/kernels/reduction_ops_common_gpu.h"
@@ -59,129 +59,7 @@ using LabelCounts = gtl::InlinedVector<int, 8>;
 using OperandLabelCounts = gtl::InlinedVector<LabelCounts, 2>;
 using LabelToDimSizes = gtl::InlinedVector<int64_t, 8>;
 
-// Dummy axis label used to denote an ellipsis in an input or output subscript.
-constexpr int kEllipsisLabel = -1;
-
 struct EinsumHelper {
-  // Each dimension is categorized into exactly one of five types based on
-  // whether its corresponding label is present in the input and/or the output
-  // subscripts.
-  enum DimensionType {
-    // Batch dimensions are those present in two inputs as well as the output.
-    // They are part of the batch dimensions during Tensor contraction.
-    // Such dimensions may be broadcasting dimensions (those mapping to
-    // ellipsis)
-    // or explicit batch dimensions corresponding to named axis labels.
-    kBroadcasting = 0,
-    kBatch = 1,
-    // Free dimensions are present in exactly one of the inputs, and also the
-    // output. These are non-contracted axes in the Tensor contraction.
-    kFree = 2,
-    // Contract dimensions are present in two inputs, but not the output. These
-    // dimensions are contracted in Tensor contraction.
-    kContract = 3,
-    // Reduce dimensions are present in exactly one input; and not in the output
-    // and are summed over prior to Tensor contraction.
-    kReduce = 4,
-  };
-
-  // Returns the DimensionType given whether the corresponding label is present
-  // in exactly one input subscript (is_unique) and whether it is absent from
-  // the output subscripts (is_removed). Does not handle broadcasting
-  // dimensions.
-  static DimensionType GetDimensionType(bool is_removed, bool is_unique) {
-    if (!is_removed && !is_unique)
-      return kBatch;
-    else if (!is_removed && is_unique)
-      return kFree;
-    else if (is_removed && !is_unique)
-      return kContract;
-    else  // is_removed && is_unique
-      return kReduce;
-  }
-
-  // Maps the character labels to consecutive integers.
-  static void MapToLabels(const string& subscript, Labels* labels,
-                          absl::flat_hash_map<char, int>* label_mapping) {
-    for (int i = 0; i < subscript.size(); ++i) {
-      const char label_char = subscript[i];
-      if (label_char == '.') {
-        labels->push_back(kEllipsisLabel);
-        i += 2;  // Skip next 2 characters as well.
-        continue;
-      }
-      if (!label_mapping->contains(label_char)) {
-        const int next_label = label_mapping->size();
-        (*label_mapping)[label_char] = next_label;
-      }
-      const int mapped_label = (*label_mapping)[label_char];
-      labels->push_back(mapped_label);
-    }
-  }
-
-  // Parses and validates the equation and the input shapes. Single character
-  // labels are integerized and we populate input and output label subscripts
-  // and corresponding counts. Also create the mapping from (named) labels to
-  // their DimensionType.
-  static Status ParseEquation(const string& equation,
-                              OperandLabels* input_labels,
-                              Labels* output_labels,
-                              std::vector<DimensionType>* label_types,
-                              OperandLabelCounts* input_label_counts,
-                              LabelCounts* output_label_counts,
-                              gtl::InlinedVector<bool, 2>* input_has_ellipsis,
-                              bool* output_has_ellipsis) {
-    gtl::InlinedVector<string, 2> input_str;
-    string output_str;
-    TF_RETURN_IF_ERROR(ParseEinsumEquation(equation, &input_str, &output_str));
-
-    // Temporary map from single character labels to (consecutive) integer
-    // labels.
-    absl::flat_hash_map<char, int> label_mapping;
-    int num_inputs = input_str.size();
-    input_labels->resize(num_inputs);
-
-    // Map from single characters to integer labels.
-    for (int i = 0; i < num_inputs; ++i) {
-      MapToLabels(input_str[i], &input_labels->at(i), &label_mapping);
-    }
-    MapToLabels(output_str, output_labels, &label_mapping);
-
-    // Compute counts for input and output labels.
-    int num_labels = label_mapping.size();
-    input_label_counts->resize(num_inputs);
-    input_has_ellipsis->resize(num_inputs);
-    for (int i = 0; i < num_inputs; ++i) {
-      input_label_counts->at(i).resize(num_labels);
-      input_has_ellipsis->at(i) = false;
-      for (const int label : input_labels->at(i)) {
-        if (label != kEllipsisLabel)
-          input_label_counts->at(i)[label] += 1;
-        else
-          input_has_ellipsis->at(i) = true;
-      }
-    }
-    output_label_counts->resize(num_labels);
-    *output_has_ellipsis = false;
-    for (const int label : *output_labels) {
-      if (label != kEllipsisLabel)
-        output_label_counts->at(label) += 1;
-      else
-        *output_has_ellipsis = true;
-    }
-
-    // Map each label to a unique DimensionType.
-    label_types->resize(num_labels);
-    for (int label = 0; label < num_labels; ++label) {
-      if (label == kEllipsisLabel) continue;
-      bool removed = (*output_label_counts)[label] == 0;
-      bool unique = num_inputs == 1 || (*input_label_counts)[0][label] == 0 ||
-                    (*input_label_counts)[1][label] == 0;
-      (*label_types)[label] = GetDimensionType(removed, unique);
-    }
-    return Status::OK();
-  }
-
   // Insert new (unnamed) broadcasting labels at the location of ellipsis.
   static void InsertBroadcastLabels(int num_bcast_dims, int num_named_labels,
                                     int ellipsis_axis, Labels* labels,
@@ -221,7 +99,7 @@ struct EinsumHelper {
       const OpInputList& inputs,
       const gtl::InlinedVector<bool, 2>& input_has_ellipsis,
       const bool output_has_ellipsis, OperandLabels* input_labels,
-      Labels* output_labels, std::vector<DimensionType>* label_types,
+      Labels* output_labels, std::vector<EinsumDimensionType>* label_types,
       OperandLabelCounts* input_label_counts, LabelCounts* output_label_counts,
       LabelToDimSizes* label_to_dim_sizes) {
     if (inputs.size() != input_labels->size()) {
@@ -297,8 +175,9 @@ struct EinsumHelper {
           " broadcasting dimension(s) but no ellipsis "
           "(...) was found in the output subscripts.");
     }
-    // Populate DimensionType for the new broadcasting labels.
-    label_types->resize(num_named_labels + max_bcast_dims, kBroadcasting);
+    // Populate EinsumDimensionType for the new broadcasting labels.
+    label_types->resize(num_named_labels + max_bcast_dims,
+                        EinsumDimensionType::kBroadcasting);
     return Status::OK();
   }
 
@@ -437,7 +316,8 @@ struct EinsumHelper {
   // [batch, contract, free, reduce]. Used to implement an optimization to avoid
   // an extra transpose and instead uses (adj_x and adj_y) in BatchMatMul.
   static bool ShouldSwapFreeAndContract(
-      const Labels& labels, const std::vector<DimensionType>& label_types) {
+      const Labels& labels,
+      const std::vector<EinsumDimensionType>& label_types) {
     // Check that ordering is according to dimension type, with the role of
     // free and contract dimensions swapped.
     gtl::InlinedVector<int, 5> remap = {0, 1, 3, 2, 4};
@@ -453,14 +333,14 @@ struct EinsumHelper {
   }
 
   template <typename Device, typename T>
-  static Status ReduceOperand(OpKernelContext* ctx, const Tensor& input,
-                              const std::vector<DimensionType>& label_types,
-                              const LabelCounts& label_counts, Labels* labels,
-                              Labels* free_labels, bool* swap_free_and_contract,
-                              Tensor* output) {
+  static Status ReduceOperand(
+      OpKernelContext* ctx, const Tensor& input,
+      const std::vector<EinsumDimensionType>& label_types,
+      const LabelCounts& label_counts, Labels* labels, Labels* free_labels,
+      bool* swap_free_and_contract, Tensor* output) {
     // Find the permutation to transpose the input dimensions in the order of
-    // DimensionType; i.e. batch, free, contract and reduce dimensions. This
-    // makes it more convenient to invoke Reduce/Contract operations.
+    // EinsumDimensionType; i.e. batch, free, contract and reduce dimensions.
+    // This makes it more convenient to invoke Reduce/Contract operations.
     std::vector<int> permutation(input.dims());
     absl::c_iota(permutation, 0);
     Tensor input_transposed;
@@ -477,7 +357,7 @@ struct EinsumHelper {
                std::tie(label_types[label_j], label_j);
       });
     }
-    // Transpose the input so that DimensionTypes are in order.
+    // Transpose the input so that EinsumDimensionTypes are in order.
     TF_RETURN_IF_ERROR(TransposeOperand<Device, T>(ctx, input, permutation,
                                                    &input_transposed));
     PermuteLabels(permutation, labels);
@@ -490,7 +370,7 @@ struct EinsumHelper {
                                    false /* should_inflate */, &input_deduped));
 
     // Reshape denotes the rank-5 shape [broadcast, batch, free, contract,
-    // reduce] where we've compacted the dimensions of each DimensionType.
+    // reduce] where we've compacted the dimensions of each EinsumDimensionType.
     gtl::InlinedVector<int64_t, 5> reshape(5, 1);
     // The output shape is [batch shape] + [free size, contract size]
     // That is, the batch shape is preserved (for broadcasting while
@@ -500,18 +380,22 @@ struct EinsumHelper {
     for (int label_idx = 0; label_idx < labels->size(); ++label_idx) {
       const int label = labels->at(label_idx);
       int64_t dim = input_deduped.dim_size(label_idx);
-      if (label_types[label] == kBroadcasting || label_types[label] == kBatch) {
+      if (label_types[label] == EinsumDimensionType::kBroadcasting ||
+          label_types[label] == EinsumDimensionType::kBatch) {
         output_shape.AddDim(dim);
-      } else if (label_types[label] == kFree) {
+      } else if (label_types[label] == EinsumDimensionType::kFree) {
         free_labels->push_back(label);
       }
       reshape[label_types[label]] *= dim;
     }
-    if (*swap_free_and_contract) std::swap(reshape[kFree], reshape[kContract]);
-    output_shape.AddDim(reshape[kFree]);
-    output_shape.AddDim(reshape[kContract]);
+    if (*swap_free_and_contract)
+      std::swap(reshape[EinsumDimensionType::kFree],
+                reshape[EinsumDimensionType::kContract]);
+    output_shape.AddDim(reshape[EinsumDimensionType::kFree]);
+    output_shape.AddDim(reshape[EinsumDimensionType::kContract]);
 
-    if (reshape[kReduce] == 1) {  // No need to actually reduce.
+    if (reshape[EinsumDimensionType::kReduce] ==
+        1) {  // No need to actually reduce.
       return CopyFrom(input_deduped, output_shape, output);
     }
     TF_RETURN_IF_ERROR(
@@ -594,10 +478,10 @@ class EinsumOp : public OpKernel {
   explicit EinsumOp(OpKernelConstruction* c) : OpKernel(c) {
     OP_REQUIRES_OK(c, c->GetAttr("equation", &equation_));
     OP_REQUIRES_OK(
-        c, EinsumHelper::ParseEquation(
-               equation_, &input_labels_, &output_labels_, &label_types_,
-               &input_label_counts_, &output_label_counts_,
-               &input_has_ellipsis_, &output_has_ellipsis_));
+        c, ParseEinsumEquation(equation_, &input_labels_, &output_labels_,
+                               &label_types_, &input_label_counts_,
+                               &output_label_counts_, &input_has_ellipsis_,
+                               &output_has_ellipsis_));
   }
 
   void Compute(OpKernelContext* ctx) override {
@@ -606,7 +490,7 @@ class EinsumOp : public OpKernel {
 
     OperandLabels input_labels(input_labels_);
     Labels output_labels(output_labels_);
-    std::vector<EinsumHelper::DimensionType> label_types(label_types_);
+    std::vector<EinsumDimensionType> label_types(label_types_);
     OperandLabelCounts input_label_counts(input_label_counts_);
     LabelCounts output_label_counts(output_label_counts_);
     LabelToDimSizes label_to_dim_sizes;
@@ -652,11 +536,11 @@ class EinsumOp : public OpKernel {
     // All batch dimensions should be present in the contracted result. First
     // the broadcasting dimensions, then the named batch dimensions.
     for (int label = 0; label < num_labels; ++label) {
-      if (label_types[label] == EinsumHelper::kBroadcasting)
+      if (label_types[label] == EinsumDimensionType::kBroadcasting)
         result_labels.push_back(label);
     }
     for (int label = 0; label < num_labels; ++label) {
-      if (label_types[label] == EinsumHelper::kBatch)
+      if (label_types[label] == EinsumDimensionType::kBatch)
         result_labels.push_back(label);
     }
     for (int i = 0; i < num_inputs; ++i) {
@@ -733,7 +617,7 @@ class EinsumOp : public OpKernel {
   string equation_;
   OperandLabels input_labels_;
   Labels output_labels_;
-  std::vector<EinsumHelper::DimensionType> label_types_;
+  std::vector<EinsumDimensionType> label_types_;
   OperandLabelCounts input_label_counts_;
   LabelCounts output_label_counts_;
   gtl::InlinedVector<bool, 2> input_has_ellipsis_;

--- a/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
@@ -135,7 +135,7 @@ class MklEinsum : public OpKernel {
  public:
   explicit MklEinsum(OpKernelConstruction* c) : OpKernel(c) {
     OP_REQUIRES_OK(c, c->GetAttr("equation", &mkl_equation_));
-    OP_REQUIRES_OK(c, EinsumHelper::ParseEquation(
+    OP_REQUIRES_OK(c, ParseEinsumEquation(
                           mkl_equation_, &mkl_input_labels_,
                           &mkl_output_labels_, &mkl_label_types_,
                           &mkl_input_label_counts_, &mkl_output_label_counts_,
@@ -150,7 +150,7 @@ class MklEinsum : public OpKernel {
 
     OperandLabels input_labels(mkl_input_labels_);
     Labels output_labels(mkl_output_labels_);
-    std::vector<EinsumHelper::DimensionType> label_types(mkl_label_types_);
+    std::vector<EinsumDimensionType> label_types(mkl_label_types_);
     OperandLabelCounts input_label_counts(mkl_input_label_counts_);
     LabelCounts output_label_counts(mkl_output_label_counts_);
     LabelToDimSizes label_to_dim_sizes;
@@ -195,11 +195,11 @@ class MklEinsum : public OpKernel {
     // All batch dimensions should be present in the contracted result. First
     // the broadcasting dimensions, then the named batch dimensions.
     for (int label = 0; label < num_labels; ++label) {
-      if (label_types[label] == EinsumHelper::kBroadcasting)
+      if (label_types[label] == EinsumDimensionType::kBroadcasting)
         result_labels.push_back(label);
     }
     for (int label = 0; label < num_labels; ++label) {
-      if (label_types[label] == EinsumHelper::kBatch)
+      if (label_types[label] == EinsumDimensionType::kBatch)
         result_labels.push_back(label);
     }
     for (int i = 0; i < num_inputs; ++i) {
@@ -261,7 +261,7 @@ class MklEinsum : public OpKernel {
   string mkl_equation_;
   OperandLabels mkl_input_labels_;
   Labels mkl_output_labels_;
-  std::vector<EinsumHelper::DimensionType> mkl_label_types_;
+  std::vector<EinsumDimensionType> mkl_label_types_;
   OperandLabelCounts mkl_input_label_counts_;
   LabelCounts mkl_output_label_counts_;
   gtl::InlinedVector<bool, 2> mkl_input_has_ellipsis_;

--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -590,6 +590,7 @@ cc_library(
         "//tensorflow/core/lib/core:errors",
         "//tensorflow/core/lib/core:status",
         "//tensorflow/core/lib/gtl:inlined_vector",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/tensorflow/core/util/einsum_op_util.cc
+++ b/tensorflow/core/util/einsum_op_util.cc
@@ -79,10 +79,6 @@ void MapToLabels(const string& subscript, Labels* labels,
   }
 }
 
-// Parses and validates the equation and the input shapes. Single character
-// labels are integerized and we populate input and output label subscripts
-// and corresponding counts. Also create the mapping from (named) labels to
-// their EinsumDimensionType.
 Status ParseEinsumEquation(const string& equation, OperandLabels* input_labels,
                            Labels* output_labels,
                            std::vector<EinsumDimensionType>* label_types,
@@ -94,8 +90,7 @@ Status ParseEinsumEquation(const string& equation, OperandLabels* input_labels,
   string output_str;
   TF_RETURN_IF_ERROR(ValidateEinsumEquation(equation, &input_str, &output_str));
 
-  // Temporary map from single character labels to (consecutive) integer
-  // labels.
+  // Temporary map from single character labels to (consecutive) integer labels.
   absl::flat_hash_map<char, int> label_mapping;
   int num_inputs = input_str.size();
   input_labels->resize(num_inputs);

--- a/tensorflow/core/util/einsum_op_util.cc
+++ b/tensorflow/core/util/einsum_op_util.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <string>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_split.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/lib/core/status.h"
@@ -24,9 +25,9 @@ limitations under the License.
 
 namespace tensorflow {
 
-Status ParseEinsumEquation(const string& equation,
-                           gtl::InlinedVector<string, 2>* input_subscripts,
-                           string* output_subscript) {
+Status ValidateEinsumEquation(const string& equation,
+                              gtl::InlinedVector<string, 2>* input_subscripts,
+                              string* output_subscript) {
   gtl::InlinedVector<string, 2> inputs_and_output_subscripts =
       absl::StrSplit(equation, "->");
   if (inputs_and_output_subscripts.size() != 2) {
@@ -40,6 +41,102 @@ Status ParseEinsumEquation(const string& equation,
     return errors::InvalidArgument(
         "Expecting 1 or 2 input subscripts in equation '", equation,
         "' but got: ", input_subscripts->size());
+  }
+  return Status::OK();
+}
+
+// Returns the EinsumDimensionType given whether the corresponding label is
+// present in exactly one input subscript (is_unique) and whether it is absent
+// from the output subscripts (is_removed). Does not handle broadcasting
+// dimensions.
+EinsumDimensionType GetDimensionType(bool is_removed, bool is_unique) {
+  if (!is_removed && !is_unique)
+    return kBatch;
+  else if (!is_removed && is_unique)
+    return kFree;
+  else if (is_removed && !is_unique)
+    return kContract;
+  else  // is_removed && is_unique
+    return kReduce;
+}
+
+// Maps the character labels to consecutive integers.
+void MapToLabels(const string& subscript, Labels* labels,
+                 absl::flat_hash_map<char, int>* label_mapping) {
+  for (int i = 0; i < subscript.size(); ++i) {
+    const char label_char = subscript[i];
+    if (label_char == '.') {
+      labels->push_back(kEllipsisLabel);
+      i += 2;  // Skip next 2 characters as well.
+      continue;
+    }
+    if (!label_mapping->contains(label_char)) {
+      const int next_label = label_mapping->size();
+      (*label_mapping)[label_char] = next_label;
+    }
+    const int mapped_label = (*label_mapping)[label_char];
+    labels->push_back(mapped_label);
+  }
+}
+
+// Parses and validates the equation and the input shapes. Single character
+// labels are integerized and we populate input and output label subscripts
+// and corresponding counts. Also create the mapping from (named) labels to
+// their EinsumDimensionType.
+Status ParseEinsumEquation(const string& equation, OperandLabels* input_labels,
+                           Labels* output_labels,
+                           std::vector<EinsumDimensionType>* label_types,
+                           OperandLabelCounts* input_label_counts,
+                           LabelCounts* output_label_counts,
+                           gtl::InlinedVector<bool, 2>* input_has_ellipsis,
+                           bool* output_has_ellipsis) {
+  gtl::InlinedVector<string, 2> input_str;
+  string output_str;
+  TF_RETURN_IF_ERROR(ValidateEinsumEquation(equation, &input_str, &output_str));
+
+  // Temporary map from single character labels to (consecutive) integer
+  // labels.
+  absl::flat_hash_map<char, int> label_mapping;
+  int num_inputs = input_str.size();
+  input_labels->resize(num_inputs);
+
+  // Map from single characters to integer labels.
+  for (int i = 0; i < num_inputs; ++i) {
+    MapToLabels(input_str[i], &input_labels->at(i), &label_mapping);
+  }
+  MapToLabels(output_str, output_labels, &label_mapping);
+
+  // Compute counts for input and output labels.
+  int num_labels = label_mapping.size();
+  input_label_counts->resize(num_inputs);
+  input_has_ellipsis->resize(num_inputs);
+  for (int i = 0; i < num_inputs; ++i) {
+    input_label_counts->at(i).resize(num_labels);
+    input_has_ellipsis->at(i) = false;
+    for (const int label : input_labels->at(i)) {
+      if (label != kEllipsisLabel)
+        input_label_counts->at(i)[label] += 1;
+      else
+        input_has_ellipsis->at(i) = true;
+    }
+  }
+  output_label_counts->resize(num_labels);
+  *output_has_ellipsis = false;
+  for (const int label : *output_labels) {
+    if (label != kEllipsisLabel)
+      output_label_counts->at(label) += 1;
+    else
+      *output_has_ellipsis = true;
+  }
+
+  // Map each label to a unique EinsumDimensionType.
+  label_types->resize(num_labels);
+  for (int label = 0; label < num_labels; ++label) {
+    if (label == kEllipsisLabel) continue;
+    bool removed = (*output_label_counts)[label] == 0;
+    bool unique = num_inputs == 1 || (*input_label_counts)[0][label] == 0 ||
+                  (*input_label_counts)[1][label] == 0;
+    (*label_types)[label] = GetDimensionType(removed, unique);
   }
   return Status::OK();
 }

--- a/tensorflow/core/util/einsum_op_util.h
+++ b/tensorflow/core/util/einsum_op_util.h
@@ -33,9 +33,8 @@ constexpr int kEllipsisLabel = -1;
 // subscripts.
 enum EinsumDimensionType {
   // Batch dimensions are those present in two inputs as well as the output.
-  // They are part of the batch dimensions during Tensor contraction.
-  // Such dimensions may be broadcasting dimensions (those mapping to
-  // ellipsis)
+  // They are part of the batch dimensions during Tensor contraction. Such
+  // dimensions may be broadcasting dimensions (those mapping to ellipsis)
   // or explicit batch dimensions corresponding to named axis labels.
   kBroadcasting = 0,
   kBatch = 1,
@@ -55,6 +54,10 @@ Status ValidateEinsumEquation(const string& equation,
                               gtl::InlinedVector<string, 2>* input_subscripts,
                               string* output_subscript);
 
+// Parses and validates the equation and the input shapes. Single character
+// labels are integerized and we populate input and output label subscripts
+// and corresponding counts. Also create the mapping from (named) labels to
+// their EinsumDimensionType.
 Status ParseEinsumEquation(const string& equation, OperandLabels* input_labels,
                            Labels* output_labels,
                            std::vector<EinsumDimensionType>* label_types,

--- a/tensorflow/core/util/einsum_op_util.h
+++ b/tensorflow/core/util/einsum_op_util.h
@@ -20,10 +20,49 @@ limitations under the License.
 
 namespace tensorflow {
 
+using Labels = gtl::InlinedVector<int, 8>;
+using OperandLabels = gtl::InlinedVector<Labels, 2>;
+using LabelCounts = gtl::InlinedVector<int, 8>;
+using OperandLabelCounts = gtl::InlinedVector<LabelCounts, 2>;
+
+// Dummy axis label used to denote an ellipsis in an input or output subscript.
+constexpr int kEllipsisLabel = -1;
+
+// Each dimension is categorized into exactly one of five types based on
+// whether its corresponding label is present in the input and/or the output
+// subscripts.
+enum EinsumDimensionType {
+  // Batch dimensions are those present in two inputs as well as the output.
+  // They are part of the batch dimensions during Tensor contraction.
+  // Such dimensions may be broadcasting dimensions (those mapping to
+  // ellipsis)
+  // or explicit batch dimensions corresponding to named axis labels.
+  kBroadcasting = 0,
+  kBatch = 1,
+  // Free dimensions are present in exactly one of the inputs, and also the
+  // output. These are non-contracted axes in the Tensor contraction.
+  kFree = 2,
+  // Contract dimensions are present in two inputs, but not the output. These
+  // dimensions are contracted in Tensor contraction.
+  kContract = 3,
+  // Reduce dimensions are present in exactly one input; and not in the output
+  // and are summed over prior to Tensor contraction.
+  kReduce = 4,
+};
+
 // Parses and validates an einsum equation in explicit form.
-Status ParseEinsumEquation(const string& equation,
-                           gtl::InlinedVector<string, 2>* input_subscripts,
-                           string* output_subscript);
+Status ValidateEinsumEquation(const string& equation,
+                              gtl::InlinedVector<string, 2>* input_subscripts,
+                              string* output_subscript);
+
+Status ParseEinsumEquation(const string& equation, OperandLabels* input_labels,
+                           Labels* output_labels,
+                           std::vector<EinsumDimensionType>* label_types,
+                           OperandLabelCounts* input_label_counts,
+                           LabelCounts* output_label_counts,
+                           gtl::InlinedVector<bool, 2>* input_has_ellipsis,
+                           bool* output_has_ellipsis);
+
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_CORE_UTIL_EINSUM_OP_UTIL_H_


### PR DESCRIPTION
Previously, TF-TRT op converter for einsum used a helper function from the actual einsum kernel implementation in `tensorflow/core/kernels/linalg/einsum_op_impl.h` and had a dependency on einsum_op. This PR moves the helper function (`ParseEquation`) to `tensorflow/core/util/einsum_op_util.h` and remove such a dependency.

This change makes both the einsum kernel and TF-TRT more modular, which is helpful if we want to move either of them to a separate binary (dynamic kernel library for example).

Summary of changes:
* Rename `ParseEinsumEquation()` to `ValidateEinsumEquation()` in  `tensorflow/core/utils/einsum_op_util.h`
* Rename `EinsumHelper::ParseEquation()` to  `ParseEinsumEquation()` and move from `tensorflow/core/kernels/linalg/einsum_kernel_impl.h` to `tensorflow/core/utils/einsum_op_util.h`.
* Update TF-TRT to use new `ParseEinsumEquation()` in `tensorflow/core/utils/einsum_op_util.h` and remove dependency on `tensorflow/core/kernels/linalg/einsum_kernel_impl.h`.
* Rename `EinsumHelper::DimensionType` to `EinsumDimensionType`.
