### PR TITLE
[TF-TRT] Adding `TF_TRT_EXPERIMENTAL_FEATURES` environment variable controller

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/test_utils.py
+++ b/tensorflow/python/compiler/tensorrt/test/test_utils.py
@@ -1,0 +1,49 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Utilities to test TF-TensorRT integration."""
+
+import os
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def experimental_feature_scope(feature_name):
+  """Creates a context manager to enable the given experimental feature.
+
+  This helper function creates a context manager setting up an experimental
+  feature temporarily.
+
+  Example:
+
+  ```python
+  with self._experimental_feature_scope("feature_1"):
+    do_smthg()
+  ```
+
+  Args:
+    feature_name: Name of the feature being tested for activation.
+  """
+
+  env_varname = "TF_TRT_EXPERIMENTAL_FEATURES"
+  env_value_bckp = os.environ.get(env_varname, default="")
+
+  exp_features = env_value_bckp.split(",")
+  os.environ[env_varname] = ",".join(list(set(exp_features + [feature_name])))
+
+  try:
+    yield
+  finally:
+    os.environ[env_varname] = env_value_bckp

--- a/tensorflow/python/compiler/tensorrt/utils.py
+++ b/tensorflow/python/compiler/tensorrt/utils.py
@@ -14,6 +14,8 @@
 # =============================================================================
 """Exposes the Python wrapper conversion to trt_graph."""
 
+import os
+
 from distutils import version
 
 from tensorflow.compiler.tf2tensorrt import _pywrap_py_utils
@@ -69,3 +71,19 @@ def is_linked_tensorrt_version_greater_equal(major, minor=0, patch=0):
 def is_loaded_tensorrt_version_greater_equal(major, minor=0, patch=0):
   ver = _pywrap_py_utils.get_loaded_tensorrt_version()
   return _is_tensorrt_version_greater_equal(ver, (major, minor, patch))
+
+
+def is_experimental_feature_activated(feature_name):
+  """Determines if a TF-TRT experimental feature is enabled.
+
+  This helper function checks if an experimental feature was enabled using
+  the environment variable `TF_TRT_EXPERIMENTAL_FEATURES=feature_1,feature_2`.
+
+  Args:
+    feature_name: Name of the feature being tested for activation.
+  """
+
+  return (
+    feature_name in
+    os.environ.get("TF_TRT_EXPERIMENTAL_FEATURES", default="").split(",")
+  )


### PR DESCRIPTION
This PR adds the APIs to query if an experimental feature is activated and the test utility necessary to test these features.
Example: `TF_TRT_EXPERIMENTAL_FEATURES=feature_name1,feature_name2`