### PR TITLE
[PluggableDevice] Add TF_IsRefInput

### DIFF
--- a/tensorflow/c/kernels_experimental.cc
+++ b/tensorflow/c/kernels_experimental.cc
@@ -381,3 +381,13 @@ void TF_OpKernelConstruction_GetAttrTensorShape(TF_OpKernelConstruction* ctx,
     dims[i] = static_cast<int64_t>(shape.dim_size(i));
   }
 }
+
+bool TF_IsRefInput(TF_OpKernelContext* ctx, int i, TF_Status* status) {
+  auto* cc_ctx = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
+  if (i < 0 || i >= cc_ctx->num_inputs()) {
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "input index out of range");
+    return false;
+  }
+  TF_SetStatus(status, TF_OK, "");
+  return cc_ctx->input_is_ref(i);
+}

--- a/tensorflow/c/kernels_experimental.h
+++ b/tensorflow/c/kernels_experimental.h
@@ -113,7 +113,7 @@ TF_CAPI_EXPORT extern void TF_OpKernelConstruction_GetAttrTensorShape(
     TF_OpKernelConstruction* ctx, const char* attr_name, int64_t* dims,
     size_t num_dims, TF_Status* status);
 
-TF_CAPI_EXPORT extern void TF_IsRefInput(TF_OpKernelContext* ctx, int i,
+TF_CAPI_EXPORT extern bool TF_IsRefInput(TF_OpKernelContext* ctx, int i,
                                          TF_Status* status);
 
 #ifdef __cplusplus

--- a/tensorflow/c/kernels_experimental.h
+++ b/tensorflow/c/kernels_experimental.h
@@ -113,6 +113,9 @@ TF_CAPI_EXPORT extern void TF_OpKernelConstruction_GetAttrTensorShape(
     TF_OpKernelConstruction* ctx, const char* attr_name, int64_t* dims,
     size_t num_dims, TF_Status* status);
 
+TF_CAPI_EXPORT extern void TF_IsRefInput(TF_OpKernelContext* ctx, int i,
+                                         TF_Status* status);
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif


### PR DESCRIPTION
This change attemps to fill some gaps in the [Kernel Extension for Variable Operations API](https://github.com/tensorflow/community/blob/master/rfcs/20210504-kernel-extension-variable-ops.md) by adding a `TF_IsRefInput` function to the pluggable device API in order to make it easier for plugins to implement operators that use ref variables. Since ref variables must be retrieved by the `TF_GetInputTensorFromVariable` function instead of `TF_GetInput`, being able to know whether an input is a normal tensor, a resource tensor or a ref tensor makes it easier for plugins to implement operators in a generic way and while reducing code duplication.