### PR TITLE
TFLite evaluation utils: Fix `elinux_armhf` build

### DIFF
--- a/tensorflow/lite/tools/evaluation/BUILD
+++ b/tensorflow/lite/tools/evaluation/BUILD
@@ -54,7 +54,6 @@ cc_library(
         ],
         "//conditions:default": [],
     }) + select({
-        "//tensorflow:linux_armhf": [],
         "//tensorflow:linux_s390x": [],
         "//conditions:default": [
             "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate",


### PR DESCRIPTION
On `master` building the evaluation utils for `elinux_armhf` using
```
bazel build tensorflow/lite/tools/delegates:hexagon_delegate_provider -c opt --config=elinux_armhf
```
fails with
```
ERROR: /code/tensorflow/lite/tools/delegates/BUILD:113:11: Compiling tensorflow/lite/tools/delegates/hexagon_delegate_provider.cc failed: undeclared inclusion(s) in rule '//tensorflow/lite/tools/delegates:hexagon_delegate_provider':
this rule is missing dependency declarations for the following files included by 'tensorflow/lite/tools/delegates/hexagon_delegate_provider.cc':
  'tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h'
Target //tensorflow/lite/tools/delegates:hexagon_delegate_provider failed to build
```

This PR fixes the issue by effectively reverting 44c05422ee00000472f1abc2611ea46b3093f93f. The workaround is not needed anymore since the `elinux_armhf` XNNPACK build has been properly fixed in 4ec84aa99372ca7899fb12715edd2bfe3c947c88.

/cc @terryheo