### PR TITLE
Fix training accuracy on AArch64 in FC layers

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -121,7 +121,7 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, T> {
     MklDnnMatMulFwdParams matmul_params(
         src_dims, weight_dims, bias_dims, dst_dims, src_format,
         (this->is_weight_const_) ? memory::format_tag::any : weight_format,
-        memory::format_tag::nc);
+        memory::format_tag::nc, this->is_weight_const_);
     // Extend the basic parameters for data types and fusions.
     ExtendMklDnnMatMulFwdParams(ctx, matmul_params);
 #ifdef DNNL_AARCH64_USE_ACL

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -61,6 +61,7 @@ struct MklDnnMatMulFwdParams {
   memory::format_tag weight_format;
   memory::format_tag dst_format;
   string dtypes = string("");
+  bool const_weight;
 #ifdef DNNL_AARCH64_USE_ACL
   void* weight_address = nullptr;
 #endif
@@ -75,14 +76,16 @@ struct MklDnnMatMulFwdParams {
       memory::dims dst_dims,
       memory::format_tag src_format = memory::format_tag::any,
       memory::format_tag weight_format = memory::format_tag::any,
-      memory::format_tag dst_format = memory::format_tag::any)
+      memory::format_tag dst_format = memory::format_tag::any,
+      bool const_weight = false)
       : src_dims(src_dims),
         weight_dims(weight_dims),
         bias_dims(bias_dims),
         dst_dims(dst_dims),
         src_format(src_format),
         weight_format(weight_format),
-        dst_format(dst_format) {}
+        dst_format(dst_format),
+        const_weight(const_weight) {}
 };
 
 // With quantization, input, weight, bias, and output can have different types.
@@ -206,7 +209,8 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
                                             memory::format_tag::any));
     // Create an inner-product.
     context_.fwd_desc.reset(new inner_product_forward::desc(
-        prop_kind::forward_inference, *context_.src_md, *context_.weight_md,
+        matmul_fwd_params.const_weight ? prop_kind::forward_inference : prop_kind::forward_training,
+        *context_.src_md, *context_.weight_md,
         *context_.bias_md, *context_.dst_md));
     context_.fwd_pd.reset(new inner_product_forward::primitive_desc(
         *context_.fwd_desc, cpu_engine_));

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -183,6 +183,7 @@ def _tf_repositories():
     tf_http_archive(
         name = "mkl_dnn_acl_compatible",
         build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
+        patch_file = ["//third_party/mkl_dnn:onednn_acl.patch"],
         sha256 = "89495899d7cc17bef14c5dbf72070d6dfda4769fe804f8e88d86f71ad7ae0d51",
         strip_prefix = "oneDNN-2.6-rc",
         urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/v2.6-rc.tar.gz"),

--- a/third_party/mkl_dnn/onednn_acl.patch
+++ b/third_party/mkl_dnn/onednn_acl.patch
@@ -1,0 +1,20 @@
+diff --git a/src/cpu/aarch64/acl_inner_product_utils.cpp b/src/cpu/aarch64/acl_inner_product_utils.cpp
+index c8fab86f2..0ebbc1cfa 100644
+--- a/src/cpu/aarch64/acl_inner_product_utils.cpp
++++ b/src/cpu/aarch64/acl_inner_product_utils.cpp
+@@ -127,7 +127,14 @@ status_t init_conf_ip(acl_ip_conf_t &aip, memory_desc_t &src_md,
+     // clang-format on
+ 
+     aip.fc_info.weights_trained_layout = wei_layout;
+-    if (is_2d && wei_tag != src_tag) { aip.fc_info.transpose_weights = false; }
++    if (is_2d && wei_tag != src_tag) {
++        aip.fc_info.transpose_weights = false;
++
++        if(prop_kind == dnnl_forward_training) {
++            aip.wei_info.set_are_values_constant(false);
++            aip.fc_info.are_weights_reshaped = true;
++      }
++    }
+ 
+     // Either activation or sum is supported as post-op at the moment
+     aip.fc_info.activation_info = acl_common_utils::get_acl_act(attr);


### PR DESCRIPTION
This patch fixes training accuracy on AArch64. When training on AArch64 using Compute Library as backend in oneDNN we need to inform Compute Library’s fully connected layer that weights are not constant so that they can be updated. This information now is propagated from MklDnnMatMulFwdPrimitive as a new parameter.