### PR TITLE
Increase timeout on join for preemption test

### DIFF
--- a/tensorflow/python/distribute/failure_handling/failure_handler_test.py
+++ b/tensorflow/python/distribute/failure_handling/failure_handler_test.py
@@ -210,7 +210,7 @@ class PreemptionCheckpointTest(test.TestCase, parameterized.TestCase):
       mpr.start_single_process('worker', worker_id, cluster_spec)
     logging.info('workers restarted')
 
-    stdout = mpr.join().stdout
+    stdout = mpr.join(timeout=300).stdout
     all_start_point = []
     for msg in stdout:
       matched_group = re.search(r'.*Restored training at (\d+)', msg)


### PR DESCRIPTION
The use of less powerful machines for testing can result in //tensorflow/python/distribute/failure_handling:failure_handler_test failing with an internal timeout while waiting for threads to join(). Add a timeout of 300s to override the default 200s in this case.