### PR TITLE
[oneDNN] Enable Softmax with oneDNN library

### DIFF
--- a/tensorflow/core/graph/mkl_graph_util.h
+++ b/tensorflow/core/graph/mkl_graph_util.h
@@ -92,9 +92,7 @@ bool inline DoesControlEdgeExist(const Node* src, const Node* dst) {
 // TODO(intel_tf): Cleanup shall be done in future:
 //                 (1) Remove this method;
 //                 (2) Update related code wherever it is called.
-bool inline NativeFormatEnabled() {
-  return true;
-}
+bool inline NativeFormatEnabled() { return true; }
 
 // Check if the data_format attribute in the node def represents 5D tensor
 bool inline Check5DFormat(const NodeDef& ndef) {
@@ -148,7 +146,8 @@ inline string GetMklNativeOpName(const string& name) {
        0 == name.compare("BatchMatMul") || 0 == name.compare("BatchMatMulV2") ||
        0 == name.compare("Einsum") || 0 == name.compare("MatMul") ||
        0 == name.compare("Transpose") || 0 == name.compare("QuantizeV2") ||
-       0 == name.compare("Dequantize") || 0 == name.rfind("Quantized", 0));
+       0 == name.compare("Dequantize") || 0 == name.compare("Softmax") ||
+       0 == name.rfind("Quantized", 0));
 
   if (result) {
     return string(kMklOpPrefix) + name;

--- a/tensorflow/core/graph/mkl_testlib.cc
+++ b/tensorflow/core/graph/mkl_testlib.cc
@@ -36,6 +36,15 @@ Node* oneDNNMatmul(Graph* g, Node* in0, Node* in1, bool transpose_a,
   return ret;
 }
 
+Node* oneDNNSoftmax(Graph* g, Node* input) {
+  Node* ret = nullptr;
+  TF_CHECK_OK(NodeBuilder(g->NewName("n"), "_MklSoftmax")
+                  .Input(input)
+                  .Attr("_kernel", mkl_op_registry::kMklNameChangeOpLabel)
+                  .Finalize(g, &ret));
+  return ret;
+}
+
 }  // namespace graph
 }  // namespace test
 }  // namespace tensorflow

--- a/tensorflow/core/graph/mkl_testlib.h
+++ b/tensorflow/core/graph/mkl_testlib.h
@@ -28,6 +28,8 @@ namespace graph {
 Node* oneDNNMatmul(Graph* g, Node* in0, Node* in1, bool transpose_a,
                    bool transpose_b);
 
+Node* oneDNNSoftmax(Graph* g, Node* input);
+
 }  // namespace graph
 }  // namespace test
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -529,3 +529,15 @@ tf_mkl_kernel_library(
         "//tensorflow/cc:scope",
     ],
 )
+
+tf_cc_test_mkl(
+    name = "onednn_nn_ops_benchmark",
+    size = "small",
+    srcs = ["onednn_nn_ops_benchmark.cc"],
+    linkstatic = 1,
+    deps = [
+        "//tensorflow/cc:cc_ops_internal",
+        "//tensorflow/core/kernels:softmax_op",
+        "//tensorflow/core/kernels/mkl:mkl_softmax_op",
+    ] + MKL_TEST_DEPS,
+)

--- a/tensorflow/core/kernels/mkl/mkl_softmax_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_softmax_op.cc
@@ -17,18 +17,19 @@ limitations under the License.
 
 #ifdef INTEL_MKL
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "dnnl.hpp"
 #include "tensorflow/core/framework/numeric_op.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/graph/mkl_graph_util.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/tensor_format.h"
 #ifdef DNNL_AARCH64_USE_ACL
 #include "tensorflow/core/platform/mutex.h"
 #endif
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 using dnnl::prop_kind;
 using dnnl::softmax_forward;
@@ -39,12 +40,12 @@ namespace tensorflow {
 class MklSoftmaxParams {
  public:
   memory::dims src_dims;
-  MklTensorFormat src_fmt;
+  memory::format_tag src_fmt;
   int axis;
 #ifdef DNNL_AARCH64_USE_ACL
   int aarch64_counter;
 #endif
-  MklSoftmaxParams(memory::dims src_dims, MklTensorFormat src_fmt, int axis)
+  MklSoftmaxParams(memory::dims src_dims, memory::format_tag src_fmt, int axis)
       : src_dims(src_dims), src_fmt(src_fmt), axis(axis) {}
 };
 
@@ -121,7 +122,7 @@ class MklSoftmaxPrimitive : public MklPrimitive {
   // Softmax forward primitive setup
   void Setup(const MklSoftmaxParams& fwdParams) {
     // Create memory descriptors for softmax data with specified format.
-    auto src_format = MklTensorFormatToMklDnnDataFormat(fwdParams.src_fmt);
+    auto src_format = fwdParams.src_fmt;
     context_.src_md.reset(
         new memory::desc({fwdParams.src_dims}, MklDnnType<T>(), src_format));
 
@@ -213,61 +214,26 @@ class MklSoftmaxOp : public OpKernel {
 
   void Compute(OpKernelContext* context) override {
     try {
-      auto cpu_engine = engine(engine::kind::cpu, 0);
-      // src_tensor points to the 0-th input of global data struct "context".
-      size_t src_idx = 0;
-      const Tensor& src_tensor = MklGetInput(context, src_idx);
-      MklDnnShape src_mkl_shape;
-      GetMklShape(context, src_idx, &src_mkl_shape);
-
-      // src_dims is the dimension of src_tensor.
-      // Dim of the dst will also be same as src_dims.
-      auto src_tf_shape = src_mkl_shape.IsMklTensor()
-                              ? src_mkl_shape.GetTfShape()
-                              : src_tensor.shape();
-      const int input_dims = src_tf_shape.dims();
-      memory::dims src_dims;
-      int axis;
-      if (src_mkl_shape.IsMklTensor()) {
-        src_dims = src_mkl_shape.GetSizesAsMklDnnDims();
-        axis = 1;
-      } else {
-        src_dims = TFShapeToMklDnnDims(src_tf_shape);
-        axis = input_dims - 1;
-      }
-      MklTensorFormat layout_type;
-      // In MKL, data format passed to mkl softmax op depends on dimension of
-      // the input tensor. Here "x" data format in MKL is used for 1 dim tensor,
-      // "nc" for 2 dim tensor, "tnc" for 3 dim tensor, "nchw" for 4 dim tensor,
-      // and "ncdhw" for 5 dim tensor. Each of the symbols has the following
-      // meaning: n = batch, c = channels, t = sequence length, h = height, w =
-      // width, d = depth. When src tensor is MKL, layout_type here is only used
-      // for setting TF layout type of output tensor. When input is TF Tensor,
-      // layout here is no special sense. We use axis to define on which
-      // dimension to do softmax.
+      const Tensor& src_tensor = context->input(0);
+      auto src_shape = src_tensor.shape();
+      const int input_dims = src_shape.dims();
+      memory::format_tag src_fmt;
+      // TODO(intel-tf): Add support for dimensions larger than 5.
       switch (input_dims) {
         case 1:
-          layout_type = MklTensorFormat::FORMAT_X;
+          src_fmt = memory::format_tag::a;
           break;
         case 2:
-          layout_type = MklTensorFormat::FORMAT_NC;
+          src_fmt = memory::format_tag::ab;
           break;
         case 3:
-          layout_type = MklTensorFormat::FORMAT_TNC;
+          src_fmt = memory::format_tag::abc;
           break;
         case 4:
-          if (src_mkl_shape.IsMklTensor()) {
-            layout_type = MklTensorFormat::FORMAT_NHWC;
-          } else {
-            layout_type = MklTensorFormat::FORMAT_NCHW;
-          }
+          src_fmt = memory::format_tag::abcd;
           break;
         case 5:
-          if (src_mkl_shape.IsMklTensor()) {
-            layout_type = MklTensorFormat::FORMAT_NDHWC;
-          } else {
-            layout_type = MklTensorFormat::FORMAT_NCDHW;
-          }
+          src_fmt = memory::format_tag::abcde;
           break;
         default:
           OP_REQUIRES_OK(context,
@@ -275,13 +241,9 @@ class MklSoftmaxOp : public OpKernel {
           return;
       }
 
-      // If input is in MKL layout, then simply get the format from input;
-      // otherwise, use TF layout defined before.
-      auto src_fmt = src_mkl_shape.IsMklTensor()
-                         ? MklTensorFormat::FORMAT_BLOCKED
-                         : layout_type;
-
       // Get a softmax fwd primitive from primitive pool.
+      auto src_dims = TFShapeToMklDnnDims(src_shape);
+      int axis = input_dims - 1;
       MklSoftmaxParams fwdParams(src_dims, src_fmt, axis);
 #ifdef DNNL_AARCH64_USE_ACL
       // ACL does not support reuse of primitives with different data.
@@ -295,29 +257,9 @@ class MklSoftmaxOp : public OpKernel {
       MklSoftmaxPrimitive<T>* softmax_fwd =
           MklSoftmaxPrimitiveFactory<T>::Get(fwdParams);
 
-      // Prepare for creating output tensor.
       Tensor* output_tensor = nullptr;
-      MklDnnShape output_mkl_shape;
-      TensorShape output_tf_shape;  // shape of output TF tensor.
-
-      auto dst_pd = softmax_fwd->GetSoftmaxFwdPd()->dst_desc();
-
-      // If input is MKL shape, output is also MKL shape.
-      // If input is TF shape, output is also TF shape.
-      if (src_mkl_shape.IsMklTensor()) {
-        output_mkl_shape.SetMklTensor(true);
-        output_mkl_shape.SetMklLayout(&dst_pd);
-        output_mkl_shape.SetElemType(MklDnnType<T>());
-        output_mkl_shape.SetTfLayout(src_dims.size(), src_dims, layout_type);
-        output_tf_shape.AddDim((dst_pd.get_size() / sizeof(T)));
-      } else {
-        output_mkl_shape.SetMklTensor(false);
-        output_tf_shape = MklDnnDimsToTFShape(src_dims);
-      }
-      // Allocate output tensor.
-      AllocateOutputSetMklShape(context, 0, &output_tensor, output_tf_shape,
-                                output_mkl_shape);
-
+      OP_REQUIRES_OK(context, context->forward_input_or_allocate_output(
+                                  {0}, 0, src_tensor.shape(), &output_tensor));
       const T* src_data = src_tensor.flat<T>().data();
       T* dst_data = reinterpret_cast<T*>(output_tensor->flat<T>().data());
       std::shared_ptr<stream> fwd_cpu_stream;
@@ -337,13 +279,12 @@ class MklSoftmaxOp : public OpKernel {
 
 /* Register DNN kernels for supported operations and supported types - right now
  * it is only Softmax and f32 */
-#define REGISTER_SOFTMAX_MKL_SUPPORTED_KERNELS_TYPES(type)     \
-  REGISTER_KERNEL_BUILDER(                                     \
-      Name("_MklSoftmax")                                      \
-          .Device(DEVICE_CPU)                                  \
-          .TypeConstraint<type>("T")                           \
-          .Label(mkl_op_registry::kMklLayoutDependentOpLabel), \
-      MklSoftmaxOp<CPUDevice, type>);
+#define REGISTER_SOFTMAX_MKL_SUPPORTED_KERNELS_TYPES(type)                    \
+  REGISTER_KERNEL_BUILDER(Name("_MklSoftmax")                                 \
+                              .Device(DEVICE_CPU)                             \
+                              .TypeConstraint<type>("T")                      \
+                              .Label(mkl_op_registry::kMklNameChangeOpLabel), \
+                          MklSoftmaxOp<CPUDevice, type>);
 
 TF_CALL_float(REGISTER_SOFTMAX_MKL_SUPPORTED_KERNELS_TYPES);
 TF_CALL_bfloat16(REGISTER_SOFTMAX_MKL_SUPPORTED_KERNELS_TYPES);

--- a/tensorflow/core/kernels/mkl/onednn_nn_ops_benchmark.cc
+++ b/tensorflow/core/kernels/mkl/onednn_nn_ops_benchmark.cc
@@ -1,0 +1,158 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifdef INTEL_MKL
+
+#include <initializer_list>
+
+#include "tensorflow/cc/ops/nn_ops.h"
+#include "tensorflow/cc/ops/nn_ops_internal.h"
+#include "tensorflow/core/common_runtime/kernel_benchmark_testlib.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/graph/mkl_testlib.h"
+#include "tensorflow/core/graph/testlib.h"
+#include "tensorflow/core/public/session_options.h"
+
+namespace tensorflow {
+namespace {
+
+template <typename T>
+static void BM_oneDNN_Softmax(::testing::benchmark::State& state,
+                              std::initializer_list<int64_t> dims,
+                              int num_threads, const string& label) {
+  DataType dtype = DataTypeToEnum<T>::v();
+  TensorShape shape = TensorShape(dims);
+  Tensor input(dtype, shape);
+  input.flat<T>().setRandom();
+  Graph* g = new Graph(OpRegistry::Global());
+  test::graph::oneDNNSoftmax(g, test::graph::Constant(g, input));
+
+  SessionOptions opts;
+  opts.config.set_inter_op_parallelism_threads(1);
+  opts.config.set_intra_op_parallelism_threads(num_threads);
+  opts.config.set_use_per_session_threads(true);
+  opts.config.mutable_graph_options()
+      ->mutable_optimizer_options()
+      ->set_opt_level(OptimizerOptions::L0);
+  test::Benchmark("cpu", g, &opts, nullptr, nullptr, "",
+                  /*old_benchmark_api*/ false)
+      .Run(state);
+  state.SetItemsProcessed(shape.num_elements() * state.iterations());
+  state.SetLabel(label);
+}
+
+template <typename T>
+static void BM_Eigen_Softmax(::testing::benchmark::State& state,
+                             std::initializer_list<int64_t> dims,
+                             int num_threads, const string& label) {
+  DataType dtype = DataTypeToEnum<T>::v();
+  TensorShape shape = TensorShape(dims);
+  Tensor input(dtype, shape);
+  input.flat<T>().setRandom();
+  auto root = Scope::NewRootScope().ExitOnError();
+  auto softmax = ops::Softmax(root, input);
+  TF_CHECK_OK(root.status());
+  Graph* g = new Graph(OpRegistry::Global());
+  TF_CHECK_OK(root.ToGraph(g));
+
+  SessionOptions opts;
+  opts.config.set_inter_op_parallelism_threads(1);
+  opts.config.set_intra_op_parallelism_threads(num_threads);
+  opts.config.set_use_per_session_threads(true);
+  opts.config.mutable_graph_options()
+      ->mutable_optimizer_options()
+      ->set_opt_level(OptimizerOptions::L0);
+  test::Benchmark("cpu", g, &opts, nullptr, nullptr, "",
+                  /*old_benchmark_api*/ false)
+      .Run(state);
+  state.SetItemsProcessed(shape.num_elements() * state.iterations());
+  state.SetLabel(label);
+}
+
+/*
+ * The following trick for number of variadic macro arguments is taken from:
+ * http://groups.google.com/group/comp.std.c/browse_thread/thread/77ee8c8f92e4a3fb/346fc464319b1ee5?pli=1
+ * The macro PP_NARG returns the number of arguments that have been passed to
+ * it.  Currrently, it is prepared to support upto 5 arguments. It is straight
+ * forward to extend to a higher number of arguments.
+ */
+#define PP_NARG(...) PP_NARG_(__VA_ARGS__, PP_RSEQ_N())
+#define PP_NARG_(...) PP_ARG_N(__VA_ARGS__)
+#define PP_ARG_N(_1, _2, _3, _4, _5, N, ...) N
+#define PP_RSEQ_N() 5, 4, 3, 2, 1, 0
+
+// For a tensor shape {a, b, c, d} we want to produce a token a_b_c_d
+#define CONCAT_DIMS1(a) _##a
+#define CONCAT_DIMS2(a, b) _##a##_##b
+#define CONCAT_DIMS3(a, b, c) _##a##_##b##_##c
+#define CONCAT_DIMS4(a, b, c, d) _##a##_##b##_##c##_##d
+#define CONCAT_DIMS5(a, b, c, d, e) _##a##_##b##_##c##_##d##_e
+#define JOIN(x, y) JOIN_AGAIN(x, y)
+#define JOIN_AGAIN(x, y) x##y
+
+// Wrapping BENCHMARK to get benchmark name appropriate, so that the argument
+// expansion takes place before the expansion of BENCHMARK.
+#define WRAP_BENCHMARK(FUNC) BENCHMARK(FUNC)
+
+#define BM_oneDNN_Softmax(dtype, num_threads, label, ...)                    \
+  static void JOIN(BM_oneDNN_Softmax_##dtype##_intraop_##num_threads##_dims, \
+                   JOIN(CONCAT_DIMS, PP_NARG(__VA_ARGS__))(__VA_ARGS__))(    \
+      ::testing::benchmark::State & state) {                                 \
+    BM_oneDNN_Softmax<dtype>(state, {__VA_ARGS__}, num_threads, label);      \
+  }                                                                          \
+  WRAP_BENCHMARK(                                                            \
+      JOIN(BM_oneDNN_Softmax_##dtype##_intraop_##num_threads##_dims,         \
+           JOIN(CONCAT_DIMS, PP_NARG(__VA_ARGS__))(__VA_ARGS__)))            \
+      ->UseRealTime()
+
+#define BM_Eigen_Softmax(dtype, num_threads, label, ...)                       \
+  static void JOIN(BM_Eigen_Softmax_##dtype##_intraop_##num_threads##_dims,    \
+                   JOIN(CONCAT_DIMS, PP_NARG(__VA_ARGS__))(__VA_ARGS__))(      \
+      ::testing::benchmark::State & state) {                                   \
+    BM_Eigen_Softmax<dtype>(state, {__VA_ARGS__}, num_threads, label);         \
+  }                                                                            \
+  WRAP_BENCHMARK(JOIN(BM_Eigen_Softmax_##dtype##_intraop_##num_threads##_dims, \
+                      JOIN(CONCAT_DIMS, PP_NARG(__VA_ARGS__))(__VA_ARGS__)))   \
+      ->UseRealTime()
+
+// Benchmark with oneDNN library.
+BM_oneDNN_Softmax(float, 4, "float32_BERT_batch_size_1", 1, 16, 384, 384);
+BM_oneDNN_Softmax(float, 4, "float32_BERT_batch_size_16", 16, 16, 384, 384);
+BM_oneDNN_Softmax(float, 1, "float32_ImageNet_batch_size_32", 32, 1008);
+BM_oneDNN_Softmax(float, 1, "float32_ImageNet_batch_size_128", 128, 1008);
+BM_oneDNN_Softmax(float, 4, "float32_ImageNet_batch_size_32", 32, 1008);
+BM_oneDNN_Softmax(float, 4, "float32_ImageNet_batch_size_128", 128, 1008);
+BM_oneDNN_Softmax(bfloat16, 4, "bfloat16_BERT_batch_size_1", 1, 16, 384, 384);
+BM_oneDNN_Softmax(bfloat16, 4, "bfloat16_BERT_batch_size_16", 16, 16, 384, 384);
+BM_oneDNN_Softmax(bfloat16, 1, "bfloat16_ImageNet_batch_size_32", 32, 1008);
+BM_oneDNN_Softmax(bfloat16, 1, "bfloat16_ImageNet_batch_size_128", 128, 1008);
+BM_oneDNN_Softmax(bfloat16, 4, "bfloat16_ImageNet_batch_size_32", 32, 1008);
+BM_oneDNN_Softmax(bfloat16, 4, "bfloat16_ImageNet_batch_size_128", 128, 1008);
+
+// Benchamark with Eigen library.
+BM_Eigen_Softmax(float, 4, "float32_BERT_batch_size_1", 1, 16, 384, 384);
+BM_Eigen_Softmax(float, 4, "float32_BERT_batch_size_16", 16, 16, 384, 384);
+BM_Eigen_Softmax(float, 1, "float32_ImageNet_batch_size_32", 32, 1008);
+BM_Eigen_Softmax(float, 1, "float32_ImageNet_batch_size_128", 128, 1008);
+BM_Eigen_Softmax(float, 4, "float32_ImageNet_batch_size_32", 32, 1008);
+BM_Eigen_Softmax(float, 4, "float32_ImageNet_batch_size_128", 128, 1008);
+BM_Eigen_Softmax(bfloat16, 4, "bfloat16_BERT_batch_size_1", 1, 16, 384, 384);
+BM_Eigen_Softmax(bfloat16, 4, "bfloat16_BERT_batch_size_16", 16, 16, 384, 384);
+BM_Eigen_Softmax(bfloat16, 1, "bfloat16_ImageNet_batch_size_32", 32, 1008);
+BM_Eigen_Softmax(bfloat16, 1, "bfloat16_ImageNet_batch_size_128", 128, 1008);
+BM_Eigen_Softmax(bfloat16, 4, "bfloat16_ImageNet_batch_size_32", 32, 1008);
+BM_Eigen_Softmax(bfloat16, 4, "bfloat16_ImageNet_batch_size_128", 128, 1008);
+}  // namespace
+}  // namespace tensorflow
+#endif  // INTEL_MKL

--- a/tensorflow/core/ops/mkl_nn_ops.cc
+++ b/tensorflow/core/ops/mkl_nn_ops.cc
@@ -1878,6 +1878,21 @@ REGISTER_OP("_MklLayerNorm")
     .Attr("epsilon: float = 0.001")
     .SetShapeFn(shape_inference::UnchangedShape);
 
+REGISTER_OP("_MklSoftmax")
+    .Input("logits: T")
+    .Output("softmax: T")
+    .Attr("T: {bfloat16, float} = DT_FLOAT")
+    .SetShapeFn([](InferenceContext* c) {
+      return shape_inference::UnchangedShapeWithRankAtLeast(c, 1);
+    })
+    .Doc(R"doc(
+oneDNN version of Softmax operator. Uses oneDNN APIs to perform softmax
+operation.
+
+*NOTE*: Do not invoke this operator directly in Python. Graph rewrite pass is
+expected to invoke these operators.
+)doc");
+
 }  // namespace tensorflow
 
 #endif  // INTEL_MKL

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -2369,20 +2369,6 @@ NOTE Do not invoke this operator directly in Python. Graph rewrite pass is
 expected to invoke these operators.
 )doc");
 
-REGISTER_OP("_MklSoftmax")
-    .Input("logits: T")
-    .Input("mkl_logits: uint8")
-    .Output("softmax: T")
-    .Output("mkl_softmax: uint8")
-    .Attr("T: {bfloat16, half, float, double}")
-    .SetShapeFn([](InferenceContext* c) {
-      return shape_inference::UnchangedShapeWithRankAtLeast(c, 1);
-    })
-    .Doc(R"doc(
-MKL version of ReluGrad operator. Uses MKL DNN APIs to compute rectified
-linear gradients for Relu operation.
-)doc");
-
 REGISTER_OP("_MklTanh")
     .Input("features: T")
     .Input("mkl_features: uint8")


### PR DESCRIPTION
This PR enables softmax forward op using oneDNN library. It uses in-place computation whenever possible. It improves performance of some models wherein the softmax takes up significant time.

The following are performance data on some micro-benchmarks. The performance data were collected on Intel Xeon CPUs using Eigen ThreadPool.

## Microbenchmarks

Tensor Dims | Numeric Type | Intra-op Threads | HW | oneDNN (ns) | Eigen (ns) | Speedup
-- | -- | -- | -- | -- | -- | --
1x16x384x384 | FLOAT32 | 4 | Xeon 28 core | 435505 | 849837 | 1.95x
16x16x384x384 | FLOAT32 | 4 | Xeon 28 core | 30608250 | 39503349 | 1.29x
32x1008 | FLOAT32 | 1 | Xeon 28 core | 28455 | 33078 | 1.16x
128x1008 | FLOAT32 | 1 | Xeon 28 core | 83065 | 123516 | 1.49x
32x1008 | FLOAT32 | 4 | Xeon 28 core | 30585 | 32165 | 1.05x
128x1008 | FLOAT32 | 4 | Xeon 28 core | 41348 | 127743 | 3.09x
1x16x384x384 | BFLOAT16 | 4 | Xeon 26 core | 430448 | 867489 | 2.02x
16x16x384x384 | BFLOAT16 | 4 | Xeon 26 core | 17430198 | 25598959 | 1.47x
32x1008 | BFLOAT16 | 1 | Xeon 26 core | 31498 | 49853 | 1.58x
128x1008 | BFLOAT16 | 1 | Xeon 26 core | 91812 | 159045 | 1.73x
32x1008 | BFLOAT16 | 4 | Xeon 26 core | 29836 | 49224 | 1.65x
128x1008 | BFLOAT16 | 4 | Xeon 26 core | 43047 | 122662 | 2.85x

This PR improves inference performance by 12% on some models that use softmax.