### PR TITLE
[TF-TRT] Fix two problems in python tests.

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/binary_tensor_weight_broadcast_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/binary_tensor_weight_broadcast_test.py
@@ -22,6 +22,7 @@ from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.platform import test
+from tensorflow.python.platform import tf_logging as logging
 
 
 class BinaryTensorWeightBroadcastTest(trt_test.TfTrtIntegrationTestBase):
@@ -66,6 +67,12 @@ class BinaryTensorWeightBroadcastTest(trt_test.TfTrtIntegrationTestBase):
   def setUp(self):
     super(trt_test.TfTrtIntegrationTestBase, self).setUp()  # pylint: disable=bad-super-call
     os.environ["TF_TRT_ALLOW_ENGINE_NATIVE_SEGMENT_EXECUTION"] = "True"
+    gpus = config.list_physical_devices('GPU')
+
+    logging.info('Found the following GPUs:')
+    for gpu in gpus:
+      logging.info(f"\t- {gpu}")
+      config.set_memory_growth(gpu, True)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/trt_engine_op_shape_test.py
@@ -52,7 +52,11 @@ class TRTEngineOpInputOutputShapeTest(trt_test.TfTrtIntegrationTestBase):
                                 self)._GetInferGraph(*args, **kwargs)
 
     def get_func_from_saved_model(saved_model_dir):
-      saved_model_loaded = saved_model.load.load(
+      try:  # Necessary for `bazel run ...`
+        saved_model_load_fn = saved_model.load.load
+      except AttributeError:  # All the other cases
+        saved_model_load_fn = saved_model.load
+      saved_model_loaded = saved_model_load_fn(
           saved_model_dir, tags=[tag_constants.SERVING])
       graph_func = saved_model_loaded.signatures[
           signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY]


### PR DESCRIPTION
This PR fixes two problems in the test.

1. `saved_model.load.load` only exists with `bazel run ...`
2. Enable multi GPU support for `binary_tensor_weight_broadcast_test.py`