### PR TITLE
Add dct_method argument to tf.image.adjust_jpeg_quality

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -15,6 +15,7 @@
 """Implementation of image ops."""
 
 import functools
+
 import numpy as np
 
 from tensorflow.python.eager import context
@@ -2917,9 +2918,10 @@ def adjust_jpeg_quality(image, jpeg_quality, dct_method='', name=None):
   Args:
     image: 3D image. The size of the last dimension must be None, 1 or 3.
     jpeg_quality: Python int or Tensor of type int32. jpeg encoding quality.
-    dct_method: An optional string. Specifies the DCT method to use for JPEG decompression.
-      Currently available options are ["INTEGER_FAST", "INTEGER_ACCURATE"].
-      Defaults to "INTEGER_FAST", sacrificing image quality for speed.
+    dct_method: An optional string. Specifies the DCT method to use for JPEG
+      decompression. Currently available options are ["INTEGER_FAST",
+      "INTEGER_ACCURATE"]. Defaults to "" which maps to "INTEGER_FAST",
+      sacrificing image quality for speed.
     name: A name for this operation (optional).
 
   Returns:

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -2892,7 +2892,7 @@ def stateless_random_jpeg_quality(image,
 
 @tf_export('image.adjust_jpeg_quality')
 @dispatch.add_dispatch_support
-def adjust_jpeg_quality(image, jpeg_quality, name=None):
+def adjust_jpeg_quality(image, jpeg_quality, dct_method='', name=None):
   """Adjust jpeg encoding quality of an image.
 
   This is a convenience method that converts an image to uint8 representation,
@@ -2917,6 +2917,9 @@ def adjust_jpeg_quality(image, jpeg_quality, name=None):
   Args:
     image: 3D image. The size of the last dimension must be None, 1 or 3.
     jpeg_quality: Python int or Tensor of type int32. jpeg encoding quality.
+    dct_method: An optional string. Specifies the DCT method to use for JPEG decompression.
+      Currently available options are ["INTEGER_FAST", "INTEGER_ACCURATE"].
+      Defaults to "INTEGER_FAST", sacrificing image quality for speed.
     name: A name for this operation (optional).
 
   Returns:
@@ -2937,7 +2940,7 @@ def adjust_jpeg_quality(image, jpeg_quality, name=None):
       jpeg_quality = ops.convert_to_tensor(jpeg_quality, dtype=dtypes.int32)
     image = gen_image_ops.encode_jpeg_variable_quality(image, jpeg_quality)
 
-    image = gen_image_ops.decode_jpeg(image, channels=channels)
+    image = gen_image_ops.decode_jpeg(image, channels=channels, dct_method=dct_method)
     return convert_image_dtype(image, orig_dtype, saturate=True)
 
 


### PR DESCRIPTION
Partially fixes issue #55138.
In particular, this pull request adds an argument `dct_method`, which allows the user to select between accuracy and speed of the DCT method used for decompression.