### PR TITLE
Removing the static tpu initializer for JAX altogether, and returning Status when it is not successful.

### DIFF
--- a/tensorflow/compiler/xla/pjrt/BUILD
+++ b/tensorflow/compiler/xla/pjrt/BUILD
@@ -289,6 +289,7 @@ cc_library(
         "//tensorflow/compiler/xla/service:tpu_computation_placer",
         "//tensorflow/core:lib",
         "//tensorflow/core/tpu:tpu_on_demand_compiler",
+	"//tensorflow/core/tpu:tpu_initializer_helper",
         "//tensorflow/stream_executor:device_memory",
         "//tensorflow/stream_executor:stream",
         "//tensorflow/stream_executor/lib",

--- a/tensorflow/compiler/xla/pjrt/tpu_client.cc
+++ b/tensorflow/compiler/xla/pjrt/tpu_client.cc
@@ -36,6 +36,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/core/platform/casts.h"
 #include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/tpu/tpu_initializer_helper.h"
 #include "tensorflow/stream_executor/device_memory.h"
 #include "tensorflow/stream_executor/lib/statusor.h"
 #include "tensorflow/stream_executor/stream.h"
@@ -246,6 +247,11 @@ GetTpuDevices(
 
 StatusOr<std::shared_ptr<PjRtClient>> GetTpuClient(
     int max_inflight_computations, absl::Duration init_retry_timeout) {
+  Status tpu_library_finder = tensorflow::tpu::FindAndLoadTpuLibrary();
+  if (tpu_library_finder != Status::OK()){
+    LOG(INFO) << tpu_library_finder;
+    return tpu_library_finder;
+  }
   tf_tpu::TpuPlatformInterface* platform =
       tf_tpu::TpuPlatformInterface::GetRegisteredPlatform(
           /*initialize_platform=*/true, /*num_tries=*/1);

--- a/tensorflow/compiler/xla/pjrt/tpu_client.cc
+++ b/tensorflow/compiler/xla/pjrt/tpu_client.cc
@@ -248,7 +248,7 @@ GetTpuDevices(
 StatusOr<std::shared_ptr<PjRtClient>> GetTpuClient(
     int max_inflight_computations, absl::Duration init_retry_timeout) {
   Status tpu_library_finder = tensorflow::tpu::FindAndLoadTpuLibrary();
-  if (tpu_library_finder != Status::OK()){
+  if (tpu_library_finder != Status::OK()) {
     LOG(INFO) << tpu_library_finder;
     return tpu_library_finder;
   }

--- a/tensorflow/compiler/xla/pjrt/tpu_client.cc
+++ b/tensorflow/compiler/xla/pjrt/tpu_client.cc
@@ -248,7 +248,7 @@ GetTpuDevices(
 StatusOr<std::shared_ptr<PjRtClient>> GetTpuClient(
     int max_inflight_computations, absl::Duration init_retry_timeout) {
   Status tpu_library_finder = tensorflow::tpu::FindAndLoadTpuLibrary();
-  if (tpu_library_finder != Status::OK()) {
+  if (!tpu_library_finder.ok()) {
     LOG(INFO) << tpu_library_finder;
     return tpu_library_finder;
   }

--- a/tensorflow/compiler/xla/pjrt/tpu_client.cc
+++ b/tensorflow/compiler/xla/pjrt/tpu_client.cc
@@ -247,11 +247,7 @@ GetTpuDevices(
 
 StatusOr<std::shared_ptr<PjRtClient>> GetTpuClient(
     int max_inflight_computations, absl::Duration init_retry_timeout) {
-  Status tpu_library_finder = tensorflow::tpu::FindAndLoadTpuLibrary();
-  if (!tpu_library_finder.ok()) {
-    LOG(INFO) << tpu_library_finder;
-    return tpu_library_finder;
-  }
+  TF_RETURN_IF_ERROR(tensorflow::tpu::FindAndLoadTpuLibrary());
   tf_tpu::TpuPlatformInterface* platform =
       tf_tpu::TpuPlatformInterface::GetRegisteredPlatform(
           /*initialize_platform=*/true, /*num_tries=*/1);

--- a/tensorflow/compiler/xla/pjrt/tpu_client.cc
+++ b/tensorflow/compiler/xla/pjrt/tpu_client.cc
@@ -247,7 +247,9 @@ GetTpuDevices(
 
 StatusOr<std::shared_ptr<PjRtClient>> GetTpuClient(
     int max_inflight_computations, absl::Duration init_retry_timeout) {
+  #if !defined(PLATFORM_GOOGLE)
   TF_RETURN_IF_ERROR(tensorflow::tpu::FindAndLoadTpuLibrary());
+  #endif
   tf_tpu::TpuPlatformInterface* platform =
       tf_tpu::TpuPlatformInterface::GetRegisteredPlatform(
           /*initialize_platform=*/true, /*num_tries=*/1);

--- a/tensorflow/compiler/xla/python/BUILD
+++ b/tensorflow/compiler/xla/python/BUILD
@@ -708,7 +708,6 @@ pybind_extension(
     ] + select({
         ":enable_gpu": ["//tensorflow/compiler/xla/service:gpu_plugin"],
         "//tensorflow:with_tpu_support": [
-            "//tensorflow/core/tpu:tpu_api_dlsym_initializer",
         ],
         "//conditions:default": [],
     }),

--- a/tensorflow/compiler/xla/python/BUILD
+++ b/tensorflow/compiler/xla/python/BUILD
@@ -707,8 +707,6 @@ pybind_extension(
         "//tensorflow/python:bfloat16_lib",
     ] + select({
         ":enable_gpu": ["//tensorflow/compiler/xla/service:gpu_plugin"],
-        "//tensorflow:with_tpu_support": [
-        ],
         "//conditions:default": [],
     }),
 )

--- a/tensorflow/core/profiler/backends/tpu/tpu_tracer.cc
+++ b/tensorflow/core/profiler/backends/tpu/tpu_tracer.cc
@@ -130,7 +130,7 @@ std::unique_ptr<ProfilerInterface> CreateTpuTracer(
 }
 
 auto register_tpu_tracer_factory = [] {
-  if (tensorflow::tpu::TryAcquireTpuLock() == tensorflow::Status::OK()) {
+  if (tensorflow::tpu::TryAcquireTpuLock().ok()) {
     RegisterProfilerFactory(&CreateTpuTracer);
   }
   return 0;

--- a/tensorflow/core/profiler/backends/tpu/tpu_tracer.cc
+++ b/tensorflow/core/profiler/backends/tpu/tpu_tracer.cc
@@ -130,7 +130,7 @@ std::unique_ptr<ProfilerInterface> CreateTpuTracer(
 }
 
 auto register_tpu_tracer_factory = [] {
-  if (tensorflow::tpu::TryAcquireTpuLock()) {
+  if (tensorflow::tpu::TryAcquireTpuLock() == tensorflow::Status::OK()) {
     RegisterProfilerFactory(&CreateTpuTracer);
   }
   return 0;

--- a/tensorflow/core/tpu/tpu_api_dlsym_initializer.cc
+++ b/tensorflow/core/tpu/tpu_api_dlsym_initializer.cc
@@ -22,7 +22,7 @@ namespace tensorflow {
 namespace tpu {
 namespace {
 #if !defined(PLATFORM_GOOGLE)
-static bool tpu_library_finder = FindAndLoadTpuLibrary();
+static Status tpu_library_finder = FindAndLoadTpuLibrary();
 #endif
 }  // namespace
 }  // namespace tpu

--- a/tensorflow/core/tpu/tpu_initializer_helper.cc
+++ b/tensorflow/core/tpu/tpu_initializer_helper.cc
@@ -113,9 +113,12 @@ std::string FindAndLogLibtpuProcess() {
 
     pid = strtol(ent->d_name, nullptr, 10);
     if (IsTpuUsed(pid)) {
-      std::string error_message = "libtpu.so is already in use by process with pid " + std::to_string(pid) + ". Not attempting to load libtpu.so in this process.";
+      std::string error_message =
+          "libtpu.so is already in use by process with pid " +
+          std::to_string(pid) +
+          ". Not attempting to load libtpu.so in this process.";
       return error_message;
-   }
+    }
   }
   return "";
 }
@@ -159,13 +162,17 @@ Status TryAcquireTpuLock() {
       // This lock is held until the process exits intentionally. The underlying
       // TPU device will be held on until it quits.
       if (lockf(fd, F_TLOCK, 0) != 0) {
-	std::string error_message = FindAndLogLibtpuProcess();
+        std::string error_message = FindAndLogLibtpuProcess();
         if (error_message == "") {
-	  error_message = "libtpu.so already in use by another process probably  owned by another user. Run \"$ sudo lsof -w /dev/accel0\" to figure out which process is using the TPU. Not attempting to load libtpu.so in this process.";
-       }
-       return errors::Aborted(error_message);	
-     } else {
-	return Status::OK();
+          error_message =
+              "libtpu.so already in use by another process probably  owned by "
+              "another user. Run \"$ sudo lsof -w /dev/accel0\" to figure out "
+              "which process is using the TPU. Not attempting to load "
+              "libtpu.so in this process.";
+        }
+        return errors::Aborted(error_message);
+      } else {
+        return Status::OK();
       }
     } else {
       VLOG(1) << "TPU_CHIPS_PER_PROCESS_BOUNDS is not empty or "
@@ -243,8 +250,7 @@ void InitializeCreateGcsFileSystemFnPtr() {
     shm_unlink(absl::StrCat("/tmp_tf_gcs_fs_pointer_", getpid()).data());
   });
 }
-}  // namespace
-
+}  //namespace
 Status FindAndLoadTpuLibrary() {
   const char* env_value = getenv("TPU_LIBRARY_PATH");
   const char* libtpu_path =
@@ -257,11 +263,10 @@ Status FindAndLoadTpuLibrary() {
     Status tpu_lock_status = TryAcquireTpuLock();
     if (tpu_lock_status == Status::OK()) {
       Status initialize_library_status = InitializeTpuLibrary(library);
-      if (initialize_library_status != Status::OK()){
+      if (initialize_library_status != Status::OK()) {
         return initialize_library_status;
       }
-    }
-    else{
+    } else {
       return tpu_lock_status;
     }
   }

--- a/tensorflow/core/tpu/tpu_initializer_helper.cc
+++ b/tensorflow/core/tpu/tpu_initializer_helper.cc
@@ -157,8 +157,7 @@ Status TryAcquireTpuLock() {
       auto pid = FindLibtpuProcess();
       if (pid.ok()) {
         return errors::Aborted(absl::StrCat(
-            "libtpu.so is already in use by process"
-            " with pid ",
+            "libtpu.so is already in use by process with pid ",
             pid.ValueOrDie(),
             ". Not attempting to load libtpu.so in this process."));
       } else {

--- a/tensorflow/core/tpu/tpu_initializer_helper.h
+++ b/tensorflow/core/tpu/tpu_initializer_helper.h
@@ -27,9 +27,10 @@ namespace tpu {
 // This will acquire a system-wide lock on behalf of the whole process. Follow
 // up calls to this function will return true if the lock has been acquired and
 // false if we failed to acquire the lock.
-bool TryAcquireTpuLock();
-// This will check the lock and then load the library.
-bool FindAndLoadTpuLibrary();
+// This will initialize the TPU library.
+Status InitializeTpuLibrary(void* library_handle);
+// This will check the lock and then load the library. 
+Status FindAndLoadTpuLibrary();
 // Returns arguments (e.g. flags) set in the LIBTPU_INIT_ARGS environment
 // variable. The first return value is the arguments, the second return value is
 // pointers to the arguments suitable for passing into the C API.

--- a/tensorflow/core/tpu/tpu_initializer_helper.h
+++ b/tensorflow/core/tpu/tpu_initializer_helper.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include <vector>
 
 #include "tensorflow/core/platform/status.h"
+#include "tensorflow/core/platform/statusor.h"
 
 namespace tensorflow {
 namespace tpu {

--- a/tensorflow/core/tpu/tpu_initializer_helper.h
+++ b/tensorflow/core/tpu/tpu_initializer_helper.h
@@ -27,9 +27,8 @@ namespace tpu {
 // This will acquire a system-wide lock on behalf of the whole process. Follow
 // up calls to this function will return true if the lock has been acquired and
 // false if we failed to acquire the lock.
-// This will initialize the TPU library.
-Status InitializeTpuLibrary(void* library_handle);
-// This will check the lock and then load the library. 
+Status TryAcquireTpuLock();
+// This will check the lock and then load the library.
 Status FindAndLoadTpuLibrary();
 // Returns arguments (e.g. flags) set in the LIBTPU_INIT_ARGS environment
 // variable. The first return value is the arguments, the second return value is


### PR DESCRIPTION
Removing the static initializer for JAX tpu use. We only call libtpu initializer when there is a need for it. Here is the third PR dependent on the previous two PRs: [PR1](https://github.com/tensorflow/tensorflow/pull/55413) and [PR2](https://github.com/tensorflow/tensorflow/pull/55415)