### PR TITLE
Add ndmin check

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -169,6 +169,11 @@ def _array_internal(val, dtype=None, copy=True, ndmin=0):  # pylint: disable=red
   if copy:
     result_t = array_ops.identity(result_t)
 
+  max_ndmin = 32
+  if ndmin > max_ndmin:
+    raise ValueError('ndmin bigger than allowable number of dimensions: '
+                     f'{max_ndmin}.')
+  
   if ndmin == 0:
     return result_t
 


### PR DESCRIPTION
Added ndmin check to allow maximum 32 ndmin to make same behavior as numpy.
Currently it is crashing when very large ndmin is passed.
Closes:  https://github.com/tensorflow/tensorflow/issues/55292