### PR TITLE
[TF-TRT] Cast Converter Re-Engineered

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -3975,46 +3975,49 @@ Status ConvertUnpack(OpConverterParams* params) {
   return ConvertSplitHelper(params, inputs.at(0), tf_axis, num, true);
 }
 
-// Supports cast fp16=>fp32 through IIdentityLayer.
 Status ConvertCast(OpConverterParams* params) {
-  const NodeDef& node_def = params->node_def;
-  TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"x", false}}));
   auto unsupport_cast_error = [&](string msg) {
     return errors::Unimplemented("Cast op is not supported - ", msg);
   };
 
+  if (isExperimentalFeatureActivated("reject_all_fp_cast_ops")) {
+    LOG(WARNING) << "`TF_TRT_EXPERIMENTAL_FEATURES=reject_all_fp_cast_ops`is "
+                 << "meant as a workaround. If the Cast converter leads to any "
+                 << "performance or accuracy regression, please open an issue "
+                 <<  "on GitHub.";
+    return unsupport_cast_error(
+      "TF_TRT_EXPERIMENTAL_FEATURES=reject_all_fp_cast_ops has been defined"
+    );
+  }
+
+  std::set<DataType> allowed_types{DataType::DT_FLOAT, DataType::DT_HALF};
+
   DataType input_type;
   TF_RETURN_IF_ERROR(GetInputTfType(*params, &input_type, 0));
-  if (input_type != DataType::DT_HALF) {
+
+  if(allowed_types.find(input_type) == allowed_types.end()){
     return unsupport_cast_error(
-        StrCat("input dtype != ", DataTypeString(DataType::DT_HALF),
-               ", received: ", DataTypeString(input_type)));
+      StrCat("Allowed input dtypes: [", DataTypeString(DataType::DT_FLOAT),
+             ", ", DataTypeString(DataType::DT_HALF), "]. Received: ",
+             DataTypeString(input_type)
+      )
+    );
   }
 
   DataType output_type;
   TF_RETURN_IF_ERROR(GetNodeDefTfType(params->node_def, &output_type,
                                       kCastOutputTypeAttrName));
 
-  if (output_type != DataType::DT_FLOAT) {
+  if(allowed_types.find(output_type) == allowed_types.end()){
     return unsupport_cast_error(
-        StrCat("output dtype != ", DataTypeString(DataType::DT_FLOAT),
-               ", received: ", DataTypeString(output_type)));
+      StrCat("Allowed output dtypes: [", DataTypeString(DataType::DT_FLOAT),
+             ", ", DataTypeString(DataType::DT_HALF), "]. Received: ",
+             DataTypeString(output_type)
+      )
+    );
   }
 
-  if (params->validation_only) return Status::OK();
-
-  ITensorProxyPtr input = params->inputs.at(0).tensor();
-  nvinfer1::IIdentityLayer* layer =
-      params->converter->network()->addIdentity(*input->trt_tensor());
-  params->converter->SetLayerName(layer, node_def);
-  layer->setPrecision(nvinfer1::DataType::kFLOAT);
-
-  if (layer->getOutput(0)->getType() != nvinfer1::DataType::kFLOAT) {
-    return errors::Internal("IIdentityLayer doesn't work as expected");
-  }
-
-  params->outputs->push_back(TRT_TensorOrWeights(layer->getOutput(0)));
-  return Status::OK();
+  return ConvertIdentity(params);
 }
 
 Status ConvertConcat(OpConverterParams* params) {

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -249,6 +249,13 @@ absl::optional<DeviceNameUtils::ParsedName> MergeIfCompatible(
   return MergeIfCompatible(a, b_parsed_name);
 }
 
+bool isExperimentalFeatureActivated(string feature_name) {
+  string envvar_str;
+  TF_CHECK_OK(
+      ReadStringFromEnvVar("TF_TRT_EXPERIMENTAL_FEATURES", "", &envvar_str));
+  return envvar_str.find(feature_name) != string::npos;
+}
+
 }  // namespace tensorrt
 }  // namespace tensorflow
 

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.h
@@ -32,6 +32,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/lib/strings/strcat.h"
+#include "tensorflow/core/util/env_var.h"
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 #include "third_party/tensorrt/NvInfer.h"
@@ -390,6 +391,8 @@ absl::optional<DeviceNameUtils::ParsedName> MergeIfCompatible(
 // by a string_view.
 absl::optional<DeviceNameUtils::ParsedName> MergeIfCompatible(
     const DeviceNameUtils::ParsedName& a, absl::string_view b);
+
+bool isExperimentalFeatureActivated(string feature_name);
 
 }  // namespace tensorrt
 }  // namespace tensorflow

--- a/tensorflow/python/compiler/tensorrt/test/cast_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/cast_test.py
@@ -31,22 +31,30 @@ class CastInt32ToFp32Test(trt_test.TfTrtIntegrationTestBase):
     return constant_op.constant(np.random.randn(*shape), dtype=dtype)
 
   def GraphFn(self, x):
+    b_f = self._ConstOp((1, 10), dtypes.float16)
+    x_f = math_ops.cast(x, dtypes.float16)
+    x_f = math_ops.mul(x_f, b_f)  # FP16 Multiply
+
+    x_f = math_ops.cast(x_f, dtypes.float32)
     b_f = self._ConstOp((1, 10), dtypes.float32)
-    x_f = math_ops.cast(x, dtypes.float32)
-    x_f = math_ops.mul(x_f, b_f)
-    b_f = self._ConstOp((1, 10), dtypes.float32)
-    x_f = math_ops.add(x_f, b_f)
+    x_f = math_ops.add(x_f, b_f)  # FP32 Add
+
     return array_ops.identity(x_f, name="output_0")
 
   def GetParams(self):
-    return self.BuildParams(self.GraphFn, dtypes.int32, [[1, 10]], [[1, 10]])
+    return self.BuildParams(self.GraphFn, dtypes.float32, [[1, 10]], [[1, 10]])
 
   def ExpectedEnginesToBuild(self, run_params):
     """Returns the expected engines to build."""
-    if run_params.precision_mode == "FP16":
-      return {"TRTEngineOp_000": ["Cast", "Add", "Mul"]}
-    else:
-      return {"TRTEngineOp_000": ["Add", "Mul"]}
+    return {"TRTEngineOp_000": ["AddV2", "Cast", "Const", "Mul"]}
+
+  def ExpectedAbsoluteTolerance(self, run_params):
+    """The absolute tolerance to compare floating point results."""
+    return 1.e-03 if run_params.precision_mode == "FP32" else 1.e-02
+
+  def ExpectedRelativeTolerance(self, run_params):
+    """The relative tolerance to compare floating point results."""
+    return 1.e-03 if run_params.precision_mode == "FP32" else 1.e-02
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/compiler/tensorrt/test/quantization_mnist_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/quantization_mnist_test.py
@@ -350,6 +350,11 @@ class MNISTTestV2(QuantizationAwareTrainingMNISTTest):
             dynamic_shape_profile_strategy='ImplicitBatchModeCompatible',
             **conv_params._asdict())
         converter.convert()
+        try:
+          line_length = max(160, os.get_terminal_size().columns)
+        except OSError:
+          line_length = 160
+        converter.summary(line_length=line_length, detailed=True)
         func = converter._converted_func
       else:
         saved_model_loaded = saved_model_load(

--- a/tensorflow/python/compiler/tensorrt/test/testdata/gen_tftrt_model.py
+++ b/tensorflow/python/compiler/tensorrt/test/testdata/gen_tftrt_model.py
@@ -83,6 +83,11 @@ def GenerateModelV2(tf_saved_model_dir, tftrt_saved_model_dir):
   converter = trt_convert.TrtGraphConverterV2(
       input_saved_model_dir=tf_saved_model_dir)
   converter.convert()
+  try:
+    line_length = max(160, os.get_terminal_size().columns)
+  except OSError:
+    line_length = 160
+  converter.summary(line_length=line_length, detailed=True)
   converter.save(tftrt_saved_model_dir)
 
 

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -521,6 +521,13 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
                                       conversion_params)
     converter.convert()
 
+    if run_params.is_v2:
+      try:
+        line_length = max(160, os.get_terminal_size().columns)
+      except OSError:
+        line_length = 160
+      converter.summary(line_length=line_length, detailed=True)
+
     if run_params.dynamic_shape and self._ShouldConverterBuild(run_params):
       logging.info("Using build mode")
 


### PR DESCRIPTION
This PR changes the way TF-TRT deal with `Cast` nodes. TensorRT engineers advised us to treat `Cast` as an Identity node and let TensorRT decides on which compute precision to use according to `precision_mode=...`.

This behavior can be deactivated using `TF_TRT_EXPERIMENTAL_FEATURES=reject_fp32_fp16_cast` if needed to work around any unforeseen issue

This PR also adds `converter.summary()` to TF-TRT test files in order to ease test debugability