### PR TITLE
[TF:TRT] Improve dynamic shape INT8 calibration API

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -76,6 +76,11 @@
         and Tensorflow-native way to encode structured data such as protocol
         buffers or pandas dataframes.
 
+*    `tf.experimental.tensorrt`:
+    *   Added a new argument `calibration_fn` to the `.build()` function inside
+        `TrtGraphConverterV2`. This will replace `calibration_input_fn`
+        parameter of convert(), which is now deprecated.
+
 *   `tf.keras`:
 
     *   Added method `get_metrics_result()` to `tf.keras.models.Model`.

--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
@@ -8,7 +8,7 @@ tf_class {
   }
   member_method {
     name: "build"
-    argspec: "args=[\'self\', \'input_fn\'], varargs=None, keywords=None, defaults=None"
+    argspec: "args=[\'self\', \'input_fn\', \'calibration_fn\'], varargs=None, keywords=None, defaults=['\'None\', \'None\']"
   }
   member_method {
     name: "convert"


### PR DESCRIPTION
This PR moves the calibration function argument to the build function.

In dynamic shape mode we need to provide profile information before we can calibrate the TensorRT engine. The `build()` method of `TrtGraphConverterV2` can be used to provide the shape information. Previously, the calibration function had to be passed to `convert()`, where a reference was stored. But calibration actually happens in build, after the shape information is collected. This motivates to move the `calibration_fn` arg to `build()`, where it is actually used.