### PR TITLE
Enable XLA test of tf.tensor_scatter_nd_update

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/scatter_nd_ops_test.py
@@ -1000,7 +1000,6 @@ class ScatterNdTensorDeterminismTest(ScatterNdTensorTest):
     super().tearDown()
     config.disable_op_determinism()
 
-  @test_util.disable_xla("Scatter ND is not deterministic with XLA")
   def testDeterminism(self):
     a = array_ops.zeros([1])
     indices = array_ops.zeros([100000, 1], dtypes.int32)


### PR DESCRIPTION
See [this conversation](https://github.com/tensorflow/tensorflow/pull/55460#discussion_r842286085) with @reedwm. XLA JIT compiled functions that utilize the `Scatter` HLO are deterministic since 2.8.0, which I have confirmed for `array_ops.tensor_scatter_update`, the entry point used for this test.