### PR TITLE
[TF:TRT] Make default dynamic shape profile strategy to implicit batch compatible

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -1050,8 +1050,8 @@ class TrtGraphConverterV2(object):
       use_dynamic_shape: whether to enable dynamic shape support. None is
         equivalent to False in the current implementation.
       dynamic_shape_profile_strategy: one of the strings in
-        supported_profile_strategies(). None is equivalent to Range in the
-        current implementation.
+        supported_profile_strategies(). None is equivalent to
+        ImplicitBatchModeCompatible in the current implementation.
       max_workspace_size_bytes: the maximum GPU temporary memory that the TRT
         engine can use at execution time. This corresponds to the
         'workspaceSize' parameter of nvinfer1::IBuilder::setMaxWorkspaceSize().
@@ -1119,7 +1119,8 @@ class TrtGraphConverterV2(object):
     self._profile_strategy = "Unknown"
     if self._use_dynamic_shape:
       if dynamic_shape_profile_strategy is None:
-        self._profile_strategy = PROFILE_STRATEGY_RANGE
+        self._profile_strategy = \
+            PROFILE_STRATEGY_IMPLICIT_BATCH_MODE_COMPATIBLE
       else:
         self._verify_profile_strategy(dynamic_shape_profile_strategy)
         self._profile_strategy = dynamic_shape_profile_strategy


### PR DESCRIPTION
In implicit batch mode, a TRT engine can handle a range of batch sizes. If the model was built with shape [N, C, H, W], then any batch size between 1..N will be compatible with the engine. In contrast, in dynamic shape mode we use optimization profiles to define the expected input shapes for the engine.

The goal of this PR is to change the default profile generation strategy (which is enabled when the `dynamic_shape_profile_strategy` converter arg is `None`) to be `'ImplicitBatchModeCompatible'`.

This way, the shapes that a TRT engine accepts in dynamic shape mode will be the same as in implicit batch mode, unless the user explicitly specifies a different profile strategy.