### PR TITLE
[PluggableDevice] Make graph_buf argument in TF_NewFunctionLibraryDefinition constant

### DIFF
--- a/tensorflow/c/experimental/grappler/grappler.cc
+++ b/tensorflow/c/experimental/grappler/grappler.cc
@@ -340,7 +340,7 @@ void TF_GetOutputPropertiesList(TF_GraphProperties* graph_properties,
 }
 
 TF_FunctionLibraryDefinition* TF_NewFunctionLibraryDefinition(
-    TF_Buffer* graph_buf, TF_Status* status) {
+    const TF_Buffer* graph_buf, TF_Status* status) {
   TF_SetStatus(status, TF_OK, "");
   tensorflow::GraphDef graph_def;
   tensorflow::Status s = tensorflow::BufferToMessage(graph_buf, &graph_def);

--- a/tensorflow/c/experimental/grappler/grappler.h
+++ b/tensorflow/c/experimental/grappler/grappler.h
@@ -274,7 +274,7 @@ typedef struct TF_FunctionLibraryDefinition TF_FunctionLibraryDefinition;
 
 // Create NewFunctionLibraryDefinition.
 TF_CAPI_EXPORT extern TF_FunctionLibraryDefinition*
-TF_NewFunctionLibraryDefinition(TF_Buffer* graph_buf, TF_Status* status);
+TF_NewFunctionLibraryDefinition(const TF_Buffer* graph_buf, TF_Status* status);
 
 // Delete NewFunctionLibraryDefinition.
 TF_CAPI_EXPORT extern void TF_DeleteFunctionLibraryDefinition(


### PR DESCRIPTION
`TF_NewFunctionLibraryDefinition` doesn't modify anything in `graph_buf`, and having it as non-const makes it impossible to use the graph buffer passed to the `Optimize` function without making a copy.