### PR TITLE
Revert "[oneDNN] Windows CI Set python path env vars if not already set"

### DIFF
--- a/tensorflow/tools/ci_build/windows/bazel/common_env.sh
+++ b/tensorflow/tools/ci_build/windows/bazel/common_env.sh
@@ -41,9 +41,9 @@ export PYTHON_BASE_PATH="${PYTHON_DIRECTORY:-Program Files/Anaconda3}"
 # Set the path to find bazel.
 export PATH="/c/tools/bazel/:$PATH"
 
-# Set Python path (if not already set) for ./configure
-export PYTHON_BIN_PATH="${PYTHON_BIN_PATH:-C:/${PYTHON_BASE_PATH}/python.exe}"
-export PYTHON_LIB_PATH="${PYTHON_LIB_PATH:-C:/${PYTHON_BASE_PATH}/lib/site-packages}"
+# Set Python path for ./configure
+export PYTHON_BIN_PATH="C:/${PYTHON_BASE_PATH}/python.exe"
+export PYTHON_LIB_PATH="C:/${PYTHON_BASE_PATH}/lib/site-packages"
 
 # Add python into PATH, it's needed because gen_git_source.py uses
 # '/usr/bin/env python' as a shebang


### PR DESCRIPTION
Reverts tensorflow/tensorflow#55523

It was accidentally merged and now breaks everything in the sync between internal and external