### PR TITLE
[PluggableDevice] Add TF_KernelBuilder_Label

### DIFF
--- a/tensorflow/c/kernels.cc
+++ b/tensorflow/c/kernels.cc
@@ -128,6 +128,11 @@ void TF_KernelBuilder_Priority(TF_KernelBuilder* kernel_builder,
   kernel_builder->cc_builder->Priority(priority_number);
 }
 
+void TF_KernelBuilder_Label(TF_KernelBuilder* kernel_builder,
+                            const char* label) {
+  kernel_builder->cc_builder->Label(label);
+}
+
 namespace tensorflow {
 namespace {
 

--- a/tensorflow/c/kernels.h
+++ b/tensorflow/c/kernels.h
@@ -119,6 +119,10 @@ TF_CAPI_EXPORT extern void TF_KernelBuilder_HostMemory(
 TF_CAPI_EXPORT extern void TF_KernelBuilder_Priority(
     TF_KernelBuilder* kernel_builder, int32_t priority_number);
 
+// Specify a label for this kernel.
+TF_CAPI_EXPORT extern void TF_KernelBuilder_Label(
+    TF_KernelBuilder* kernel_builder, const char* label);
+
 // Register the given kernel builder with the TensorFlow runtime. If
 // registration fails, the given status will be populated.
 //


### PR DESCRIPTION
Setting a label on a kernel allows us to choose which version to choose at runtime and avoid GPU<->CPU copies, e.g. with `DataFormatPermute` or `DataFormatDimMap`.