### PR TITLE
Suppress the warning in rootless mode containers

### DIFF
--- a/tensorflow/tools/dockerfiles/bashrc
+++ b/tensorflow/tools/dockerfiles/bashrc
@@ -33,14 +33,13 @@ _  /   /  __/  / / /(__  )/ /_/ /  /   _  __/   _  / / /_/ /_ |/ |/ /
 TF
 echo -e "\e[0;33m"
 
-# If /proc/self/uid_map 4294967295 mappings, we are in the initial user namespace, i.e. the host.
 # From https://man7.org/linux/man-pages/man7/user_namespaces.7.html:
 # "As the initial user namespace has no parent namespace, but, for consistency, the kernel provides 
 # dummy user and group ID mapping files for this namespace ID 0 in this namespace maps to a range 
 # starting at 0 in the (nonexistent) parent namespace, and the length of the range is the largest
 # 32-bit unsigned integer"
-# Otherwise we are in a non-initial user namespace.
-# https://github.com/kubernetes-sigs/kind/blob/main/images/base/files/usr/local/bin/entrypoint#L21-L28
+# So, if we mach 4294967295 we are root-less, otherwise we are in a non-initial user namespace.
+# See also: https://github.com/kubernetes-sigs/kind/blob/main/images/base/files/usr/local/bin/entrypoint#L21-L28
 userns=""
 if grep -Eqv "0[[:space:]]+0[[:space:]]+4294967295" /proc/self/uid_map; then
   userns="1"

--- a/tensorflow/tools/dockerfiles/bashrc
+++ b/tensorflow/tools/dockerfiles/bashrc
@@ -34,6 +34,11 @@ TF
 echo -e "\e[0;33m"
 
 # If /proc/self/uid_map 4294967295 mappings, we are in the initial user namespace, i.e. the host.
+# From https://man7.org/linux/man-pages/man7/user_namespaces.7.html:
+# "As the initial user namespace has no parent namespace, but, for consistency, the kernel provides 
+# dummy user and group ID mapping files for this namespace ID 0 in this namespace maps to a range 
+# starting at 0 in the (nonexistent) parent namespace, and the length of the range is the largest
+# 32-bit unsigned integer"
 # Otherwise we are in a non-initial user namespace.
 # https://github.com/kubernetes-sigs/kind/blob/main/images/base/files/usr/local/bin/entrypoint#L21-L28
 userns=""

--- a/tensorflow/tools/dockerfiles/bashrc
+++ b/tensorflow/tools/dockerfiles/bashrc
@@ -33,7 +33,16 @@ _  /   /  __/  / / /(__  )/ /_/ /  /   _  __/   _  / / /_/ /_ |/ |/ /
 TF
 echo -e "\e[0;33m"
 
-if [[ $EUID -eq 0 ]]; then
+# If /proc/self/uid_map 4294967295 mappings, we are in the initial user namespace, i.e. the host.
+# Otherwise we are in a non-initial user namespace.
+# https://github.com/kubernetes-sigs/kind/blob/main/images/base/files/usr/local/bin/entrypoint#L21-L28
+userns=""
+if grep -Eqv "0[[:space:]]+0[[:space:]]+4294967295" /proc/self/uid_map; then
+  userns="1"
+fi
+
+
+if [[ $EUID -eq 0 && -z $userns ]]; then
   cat <<WARN
 WARNING: You are running this container as root, which can cause new files in
 mounted volumes to be created as the root user on your host machine.
@@ -42,6 +51,11 @@ To avoid this, run the container by specifying your user's userid:
 
 $ docker run -u \$(id -u):\$(id -g) args...
 WARN
+elif [[ -n $userns ]]; then
+  cat <<EXPL
+You are running this container in a user namesace (rootless),
+which should map to the ID and group for your user on the Docker host. Great!
+EXPL
 else
   cat <<EXPL
 You are running this container as user with ID $(id -u) and group $(id -g),

--- a/tensorflow/tools/dockerfiles/bashrc
+++ b/tensorflow/tools/dockerfiles/bashrc
@@ -53,7 +53,7 @@ $ docker run -u \$(id -u):\$(id -g) args...
 WARN
 elif [[ -n $userns ]]; then
   cat <<EXPL
-You are running this container in a user namesace (rootless),
+You are running this container in a user namespace (rootless),
 which should map to the ID and group for your user on the Docker host. Great!
 EXPL
 else


### PR DESCRIPTION
This is going to change the confusing feedback we give to users when they are working with our images in rootless mode.