### PR TITLE
Fix issue with tf.ragged.constant when empty pylist is provided

### DIFF
--- a/tensorflow/python/ops/ragged/ragged_factory_ops.py
+++ b/tensorflow/python/ops/ragged/ragged_factory_ops.py
@@ -164,6 +164,8 @@ def _constant_value(ragged_factory, inner_factory, pylist, dtype, ragged_rank,
     ValueError: If the scalar values in `pylist` have inconsistent nesting
       depth; or if ragged_rank or inner_shape are incompatible with `pylist`.
   """
+  if len(pylist) == 0:
+    raise TypeError("Invalid pylist: can not be empty")
   if ragged_tensor.is_ragged(pylist):
     raise TypeError("pylist may not be a RaggedTensor or RaggedTensorValue.")
   # np.ndim builds an array, so we short-circuit lists and tuples.

--- a/tensorflow/python/ops/ragged/ragged_factory_ops.py
+++ b/tensorflow/python/ops/ragged/ragged_factory_ops.py
@@ -164,7 +164,7 @@ def _constant_value(ragged_factory, inner_factory, pylist, dtype, ragged_rank,
     ValueError: If the scalar values in `pylist` have inconsistent nesting
       depth; or if ragged_rank or inner_shape are incompatible with `pylist`.
   """
-  if len(pylist) == 0:
+  if pylist.size == 0:
     raise TypeError("Invalid pylist: can not be empty")
   if ragged_tensor.is_ragged(pylist):
     raise TypeError("pylist may not be a RaggedTensor or RaggedTensorValue.")


### PR DESCRIPTION
`tf.ragged.constant` when provided empty `pylist` is provided as an input , all RAM is consumed, causing the notebook to crash. Below is the reference issue:

Fixes https://github.com/tensorflow/tensorflow/issues/55199