### PR TITLE
Remove TF_CAPI_EXPORT from TF_InitGraph

### DIFF
--- a/tensorflow/c/experimental/grappler/grappler.h
+++ b/tensorflow/c/experimental/grappler/grappler.h
@@ -166,8 +166,7 @@ typedef struct TP_OptimizerRegistrationParams {
 
 // TF_InitGraph is used to do graph optimizer registration.
 // Plugin should implement TF_InitGraph to register graph optimizers.
-TF_CAPI_EXPORT extern void TF_InitGraph(TP_OptimizerRegistrationParams* params,
-                                        TF_Status* status);
+void TF_InitGraph(TP_OptimizerRegistrationParams* params, TF_Status* status);
 
 // Get a set of node names that must be preserved. They can not be transformed
 // or removed during the graph transformation. This includes feed and fetch


### PR DESCRIPTION
`TF_InitGraph` should be implemented by the plugin, not by core TensorFlow. Removing `TF_CAPI_EXPORT` gets rid of warning `C4273`.