### PR TITLE
Fix wrong source file name when building Tensorflow Lite C using CMake

### DIFF
--- a/tensorflow/lite/c/CMakeLists.txt
+++ b/tensorflow/lite/c/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 add_library(tensorflowlite_c ${TFLITE_C_LIBTYPE}
   builtin_op_data.h
   common.h
-  common.c
+  common.cc
   c_api_types.h
   c_api.h
   c_api.cc


### PR DESCRIPTION
fix wrong source file name