### PR TITLE
adding the enable_gpu_compatible_memory pass

### DIFF
--- a/tensorflow/core/data/dataset_utils.cc
+++ b/tensorflow/core/data/dataset_utils.cc
@@ -118,6 +118,10 @@ void DefaultOptimizationGraphRewrites(
         OptimizationOptions::kParallelBatch) {
       optimization_default->insert(kParallelBatchOpt);
     }
+    if (optimization_options.optional_enable_gpu_compatible_memory_case() !=
+        OptimizationOptions::kEnableGpuCompatibleMemory) {
+      optimization_default->insert(kEnableGPUCompatibleMemoryOpt);
+    }
   }
   if (OpDeterminismRequired()) {
     optimization_enabled->insert(kMakeDeterministicOpt);

--- a/tensorflow/core/data/dataset_utils.cc
+++ b/tensorflow/core/data/dataset_utils.cc
@@ -89,6 +89,7 @@ constexpr char kSlackOpt[] = "slack";
 constexpr char kSlackPeriodOpt[] = "slack_period";
 constexpr char kMakeDeterministicOpt[] = "make_deterministic";
 constexpr char kFilterParallelizationOpt[] = "filter_parallelization";
+constexpr char kEnableGPUCompatibleMemoryOpt[] = "enable_gpu_compatible_memory";
 
 void DefaultOptimizationGraphRewrites(
     const Options& options, absl::flat_hash_set<tstring>* optimization_enabled,

--- a/tensorflow/core/framework/dataset_options.proto
+++ b/tensorflow/core/framework/dataset_options.proto
@@ -148,7 +148,7 @@ message OptimizationOptions {
   // if the last transformation is synchronous; otherwise does nothing.
   oneof optional_inject_prefetch {
     bool inject_prefetch = 19;
-
+  }
   // Whether to use gpu compatible memory prior to the 
   // prefetch_to_device call
   oneof optional_enable_gpu_compatible_memory {

--- a/tensorflow/core/framework/dataset_options.proto
+++ b/tensorflow/core/framework/dataset_options.proto
@@ -148,6 +148,11 @@ message OptimizationOptions {
   // if the last transformation is synchronous; otherwise does nothing.
   oneof optional_inject_prefetch {
     bool inject_prefetch = 19;
+
+  // Whether to use gpu compatible memory prior to the 
+  // prefetch_to_device call
+  oneof optional_enable_gpu_compatible_memory {
+    bool enable_gpu_compatible_memory = 20;
   }
 }
 

--- a/tensorflow/core/grappler/optimizers/data/BUILD
+++ b/tensorflow/core/grappler/optimizers/data/BUILD
@@ -25,6 +25,7 @@ cc_library(
         ":filter_fusion",
         ":filter_parallelization",
         ":inject_prefetch",
+        ":enable_gpu_compatible_memory",
         ":make_deterministic",
         ":make_sloppy",
         ":map_and_batch_fusion",
@@ -902,6 +903,44 @@ tf_cc_test(
         ":graph_test_utils",
         ":graph_utils",
         ":inject_prefetch",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
+        "//tensorflow/core/grappler:grappler_item",
+    ],
+)
+
+cc_library(
+    name = "enable_gpu_compatible_memory",
+    srcs = ["enable_gpu_compatible_memory.cc"],
+    hdrs = ["enable_gpu_compatible_memory.h"],
+    deps = [
+        ":graph_utils",
+        ":optimizer_base",
+        "//tensorflow/core/data:dataset_utils",
+        "//tensorflow/core/grappler:mutable_graph_view",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:framework_internal",
+        "//tensorflow/core:lib",
+        "//tensorflow/core/grappler:grappler_item",
+        "//tensorflow/core/grappler:op_types",
+        "//tensorflow/core/grappler:utils",
+        "//tensorflow/core/grappler/clusters:cluster",
+        "//tensorflow/core/grappler/optimizers:custom_graph_optimizer_registry",
+        "//tensorflow/core:lib_internal",
+    ] + tf_protos_all(),
+    alwayslink = 1,
+)
+
+tf_cc_test(
+    name = "enable_gpu_compatible_memory_test",
+    size = "small",
+    srcs = ["enable_gpu_compatible_memory_test.cc"],
+    deps = [
+        ":graph_test_utils",
+        ":graph_utils",
+        ":enable_gpu_compatible_memory",
         "//tensorflow/core:framework",
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
@@ -32,10 +32,10 @@ namespace grappler {
 namespace {
 
 constexpr char kPrefetchDataset[] = "PrefetchDataset";
-constexpr char UseGpuAllocatorAttr[] = "UseGpuAllocator";
+constexpr char UseGpuCompatAllocatorAttr[] = "UseGpuCompatAllocator";
 
-bool HasUseGpuAllocatorAttr(const NodeDef& node) {
-    return node.attr().contains(UseGpuAllocatorAttr);
+bool HasUseGpuCompatAllocatorAttr(const NodeDef& node) {
+    return node.attr().contains(UseGpuCompatAllocatorAttr);
 }
 
 std::unique_ptr<GPUTensorOpList> get_gpu_tensor_op_list() {
@@ -73,13 +73,13 @@ Status EnableGPUCompatibleMemory::OptimizeAndCollectStats(Cluster* cluster,
       return Status::OK();      
     }
 
-    if (!HasUseGpuAllocatorAttr(*node_prior))
+    if (!HasUseGpuCompatAllocatorAttr(*node_prior))
     {
       VLOG(2) << "the " << node_prior->op() << " does not have the "
-        << UseGpuAllocatorAttr << " attribute";
+        << UseGpuCompatAllocatorAttr << " attribute";
       return Status::OK();
     }
-    (*node_prior->mutable_attr())[UseGpuAllocatorAttr].set_b(true);
+    (*node_prior->mutable_attr())[UseGpuCompatAllocatorAttr].set_b(true);
     return Status::OK();  
   }
   return Status::OK();  

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
@@ -32,7 +32,7 @@ namespace grappler {
 namespace {
 
 constexpr char kPrefetchDataset[] = "PrefetchDataset";
-constexpr char UseGpuCompatAllocatorAttr[] = "UseGpuCompatAllocator";
+constexpr char UseGpuCompatAllocatorAttr[] = "use_gpu_compat_allocator";
 
 bool HasUseGpuCompatAllocatorAttr(const NodeDef& node) {
     return node.attr().contains(UseGpuCompatAllocatorAttr);

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
@@ -75,8 +75,9 @@ Status EnableGPUCompatibleMemory::OptimizeAndCollectStats(Cluster* cluster,
 
     if (!HasUseGpuCompatAllocatorAttr(*node_prior))
     {
-      VLOG(2) << "the " << node_prior->op() << " does not have the "
-        << UseGpuCompatAllocatorAttr << " attribute";
+      VLOG(2) << "The `" << node_prior->op() << "` op does not have the "
+        << UseGpuCompatAllocatorAttr << " attribute, hence the "
+        << "OptimizeAndCollectStats is skipped";
       return Status::OK();
     }
     (*node_prior->mutable_attr())[UseGpuCompatAllocatorAttr].set_b(true);

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
@@ -37,10 +37,6 @@ constexpr char UseGpuCompatAllocatorAttr[] = "UseGpuCompatAllocator";
 bool HasUseGpuCompatAllocatorAttr(const NodeDef& node) {
     return node.attr().contains(UseGpuCompatAllocatorAttr);
 }
-
-std::unique_ptr<GPUTensorOpList> get_gpu_tensor_op_list() {
-  return std::make_unique<GPUTensorOpList>();
-}
 }  // namespace
 
 Status EnableGPUCompatibleMemory::OptimizeAndCollectStats(Cluster* cluster,
@@ -59,17 +55,8 @@ Status EnableGPUCompatibleMemory::OptimizeAndCollectStats(Cluster* cluster,
     const NodeDef& prefetch_node = node;
     NodeDef* node_prior = graph_utils::GetInputNode(prefetch_node, graph);
 
-    std::unique_ptr<GPUTensorOpList> mp_lists =
-        get_gpu_tensor_op_list();
     if (node_prior == nullptr) {
       VLOG(2) << "No op was found prior to the prefetch op!";
-      return Status::OK();      
-    }
-
-    if (!mp_lists->AllowList().count(node_prior->op()))
-    {
-      VLOG(2) << "The " << node_prior->op() << " op was not listed in the "
-        << "allowlist of the EnableGPUCompatibleMemory op";
       return Status::OK();      
     }
 

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
@@ -35,7 +35,8 @@ constexpr char kPrefetchDataset[] = "PrefetchDataset";
 constexpr char UseGpuCompatAllocatorAttr[] = "use_gpu_compat_allocator";
 
 bool HasUseGpuCompatAllocatorAttr(const NodeDef& node) {
-    return node.attr().contains(UseGpuCompatAllocatorAttr);
+    return NodeIsOnGpu(&node) &&
+      node.attr().contains(UseGpuCompatAllocatorAttr);
 }
 }  // namespace
 

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.cc
@@ -1,0 +1,93 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.h"
+
+#include "tensorflow/core/data/dataset_utils.h"
+#include "tensorflow/core/framework/model.h"
+#include "tensorflow/core/framework/node_def.pb.h"
+#include "tensorflow/core/grappler/clusters/cluster.h"
+#include "tensorflow/core/grappler/grappler_item.h"
+#include "tensorflow/core/grappler/mutable_graph_view.h"
+#include "tensorflow/core/grappler/op_types.h"
+#include "tensorflow/core/grappler/optimizers/custom_graph_optimizer_registry.h"
+#include "tensorflow/core/grappler/optimizers/data/graph_utils.h"
+#include "tensorflow/core/grappler/utils.h"
+#include "tensorflow/core/platform/protobuf.h"
+
+namespace tensorflow {
+namespace grappler {
+namespace {
+
+constexpr char kPrefetchDataset[] = "PrefetchDataset";
+constexpr char UseGpuAllocatorAttr[] = "UseGpuAllocator";
+
+bool HasUseGpuAllocatorAttr(const NodeDef& node) {
+    return node.attr().contains(UseGpuAllocatorAttr);
+}
+
+std::unique_ptr<GPUTensorOpList> get_gpu_tensor_op_list() {
+  return std::make_unique<GPUTensorOpList>();
+}
+}  // namespace
+
+Status EnableGPUCompatibleMemory::OptimizeAndCollectStats(Cluster* cluster,
+                                               const GrapplerItem& item,
+                                               GraphDef* output,
+                                               OptimizationStats* stats) {
+
+  *output = item.graph;
+  MutableGraphView graph(output);
+
+  for (const NodeDef& node : item.graph.node()) {
+    // find the prefetch op
+    if (node.op() != kPrefetchDataset) {
+      continue;
+    }
+    const NodeDef& prefetch_node = node;
+    NodeDef* node_prior = graph_utils::GetInputNode(prefetch_node, graph);
+
+    std::unique_ptr<GPUTensorOpList> mp_lists =
+        get_gpu_tensor_op_list();
+    if (node_prior == nullptr) {
+      VLOG(2) << "No op was found prior to the prefetch op!";
+      return Status::OK();      
+    }
+
+    if (!mp_lists->AllowList().count(node_prior->op()))
+    {
+      VLOG(2) << "The " << node_prior->op() << " op was not listed in the "
+        << "allowlist of the EnableGPUCompatibleMemory op";
+      return Status::OK();      
+    }
+
+    if (!HasUseGpuAllocatorAttr(*node_prior))
+    {
+      VLOG(2) << "the " << node_prior->op() << " does not have the "
+        << UseGpuAllocatorAttr << " attribute";
+      return Status::OK();
+    }
+    (*node_prior->mutable_attr())[UseGpuAllocatorAttr].set_b(true);
+    return Status::OK();  
+  }
+  return Status::OK();  
+}
+
+
+REGISTER_GRAPH_OPTIMIZER_AS(EnableGPUCompatibleMemory, "enable_gpu_compatible_memory");
+
+
+}  // namespace grappler
+}  // namespace tensorflow

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.h
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.h
@@ -1,0 +1,97 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_GRAPPLER_OPTIMIZERS_DATA_ENABLE_GPU_COMPATIBLE_MEMORY_H_
+#define TENSORFLOW_CORE_GRAPPLER_OPTIMIZERS_DATA_ENABLE_GPU_COMPATIBLE_MEMORY_H_
+
+#include "tensorflow/core/lib/gtl/flatset.h"
+#include "tensorflow/core/lib/strings/str_util.h"
+#include "tensorflow/core/framework/attr_value.pb.h"
+#include "tensorflow/core/grappler/optimizers/data/optimizer_base.h"
+
+namespace tensorflow {
+namespace grappler {
+
+constexpr char kAutotune[] = "autotune";
+
+class GPUTensorOpList {
+ public:
+  gtl::FlatSet<string> AllowList() {
+    auto list = gtl::FlatSet<string>{
+        "map_and_batch_fusion",
+        "noop_elimination",
+        "map_parallelization",
+        "shuffle_and_repeat_fusion",
+        "filter_fusion",
+        "map_and_filter_fusion",
+        "map_fusion",
+        "parallel_batch",
+        "autotune_buffer_sizes",
+        "disable_prefetch_legacy_autotune",
+        "make_sloppy",
+        "use_choose_fastest",
+        "batch_parallelization",
+        "enable_gradient_descent",
+        "inject_prefetch",
+        "inject_prefetch_eligible",
+        "autotune",
+        "slack",
+        "slack_period",
+        "make_deterministic",
+        "enable_gpu_compatible_memory",
+    };
+    return list;
+  }
+};
+
+// If prefetch_to_device op exists, this op will try to set the set
+// the memory type to the gpu compatible type (pinned memory)
+class EnableGPUCompatibleMemory : public TFDataOptimizerBase {
+ public:
+  EnableGPUCompatibleMemory() = default;
+  ~EnableGPUCompatibleMemory() override = default;
+
+  std::string name() const override { return "enable_gpu_compatible_memory"; };
+
+  bool UsesFunctionLibrary() const override { return false; }
+
+  Status Init(
+      const tensorflow::RewriterConfig_CustomGraphOptimizer* config) override {
+    if (!config) return Status::OK();
+
+    const std::string& autotune = config->parameter_map().at(kAutotune).s();
+    if (autotune == "true") {
+      autotune_ = true;
+    } else if (autotune == "false") {
+      autotune_ = false;
+    } else {
+      return errors::InvalidArgument("Received an invalid value for parameter ",
+                                     kAutotune, ": ", autotune);
+    }
+    return Status::OK();
+  }
+
+  Status OptimizeAndCollectStats(Cluster* cluster, const GrapplerItem& item,
+                                 GraphDef* output,
+                                 OptimizationStats* stats) override;
+
+ protected:
+  bool autotune_ = true;
+};
+
+}  // namespace grappler
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_GRAPPLER_OPTIMIZERS_DATA_INJECT_PREFETCH_H_

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.h
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.h
@@ -26,36 +26,6 @@ namespace grappler {
 
 constexpr char kAutotune[] = "autotune";
 
-class GPUTensorOpList {
- public:
-  gtl::FlatSet<string> AllowList() {
-    auto list = gtl::FlatSet<string>{
-        "map_and_batch_fusion",
-        "noop_elimination",
-        "map_parallelization",
-        "shuffle_and_repeat_fusion",
-        "filter_fusion",
-        "map_and_filter_fusion",
-        "map_fusion",
-        "parallel_batch",
-        "autotune_buffer_sizes",
-        "disable_prefetch_legacy_autotune",
-        "make_sloppy",
-        "use_choose_fastest",
-        "batch_parallelization",
-        "enable_gradient_descent",
-        "inject_prefetch",
-        "inject_prefetch_eligible",
-        "autotune",
-        "slack",
-        "slack_period",
-        "make_deterministic",
-        "enable_gpu_compatible_memory",
-    };
-    return list;
-  }
-};
-
 // If prefetch_to_device op exists, this op will try to set the set
 // the memory type to the gpu compatible type (pinned memory)
 class EnableGPUCompatibleMemory : public TFDataOptimizerBase {

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.h
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.h
@@ -70,28 +70,15 @@ class EnableGPUCompatibleMemory : public TFDataOptimizerBase {
   Status Init(
       const tensorflow::RewriterConfig_CustomGraphOptimizer* config) override {
     if (!config) return Status::OK();
-
-    const std::string& autotune = config->parameter_map().at(kAutotune).s();
-    if (autotune == "true") {
-      autotune_ = true;
-    } else if (autotune == "false") {
-      autotune_ = false;
-    } else {
-      return errors::InvalidArgument("Received an invalid value for parameter ",
-                                     kAutotune, ": ", autotune);
-    }
     return Status::OK();
   }
 
   Status OptimizeAndCollectStats(Cluster* cluster, const GrapplerItem& item,
                                  GraphDef* output,
                                  OptimizationStats* stats) override;
-
- protected:
-  bool autotune_ = true;
 };
 
 }  // namespace grappler
 }  // namespace tensorflow
 
-#endif  // TENSORFLOW_CORE_GRAPPLER_OPTIMIZERS_DATA_INJECT_PREFETCH_H_
+#endif  // TENSORFLOW_CORE_GRAPPLER_OPTIMIZERS_DATA_ENABLE_GPU_COMPATIBLE_MEMORY_H_

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory_test.cc
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory_test.cc
@@ -34,7 +34,7 @@ constexpr char kOptionsDataset[] = "OptionsDataset";
 constexpr char kParallelMapDataset[] = "ParallelMapDatasetV2";
 constexpr char kPrefetchDataset[] = "PrefetchDataset";
 
-Status Optimize(InjectPrefetch &optimizer, const GrapplerItem &item,
+Status Optimize(EnableGPUCompatibleMemory &optimizer, const GrapplerItem &item,
                 GraphDef *output, bool autotune) {
   RewriterConfig_CustomGraphOptimizer config;
   if (autotune) {

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory_test.cc
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory_test.cc
@@ -77,11 +77,11 @@ TEST_P(RewriteTest, DisablePrefetchLegacyAutotune) {
   NodeDef prefetch_node1 =
       output.node(graph_utils::FindGraphNodeWithName("prefetch1", output));
   EXPECT_EQ(prefetch_node1.attr().at("legacy_autotune").b(), !autotune);
-  // TODO (kushanam): enable when the UseGpuAllocator attribute is added 
+  // TODO (kushanam): enable when the use_gpu_compat_allocator attribute is added 
   // to the Dataset ops
   // NodeDef range =
   //     output.node(graph_utils::FindGraphNodeWithName("range", output));
-  // EXPECT_TRUE(prefetch_node2.attr().at("UseGpuAllocator").b());
+  // EXPECT_TRUE(prefetch_node2.attr().at("use_gpu_compat_allocator").b());
 }
 
 }  // namespace

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory_test.cc
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory_test.cc
@@ -68,9 +68,6 @@ TEST_P(RewriteTest, DisablePrefetchLegacyAutotune) {
             {"output_types", gtl::ArraySlice<DataType>{}}}),
       NDef("prefetch1", "PrefetchDataset", {"range"},
            {{"legacy_autotune", true}}),
-      NDef("prefetch2", "PrefetchDataset", {"prefetch1"},
-           {{"legacy_autotune", false}}),
-      NDef("prefetch3", "PrefetchDataset", {"prefetch2"}, {}),
   });
 
   GraphDef output;

--- a/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory_test.cc
+++ b/tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory_test.cc
@@ -1,0 +1,92 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/grappler/optimizers/data/enable_gpu_compatible_memory.h"
+
+#include "tensorflow/core/framework/attr_value_util.h"
+#include "tensorflow/core/framework/function_testlib.h"
+#include "tensorflow/core/framework/tensor_testutil.h"
+#include "tensorflow/core/grappler/grappler_item.h"
+#include "tensorflow/core/grappler/optimizers/data/graph_test_utils.h"
+#include "tensorflow/core/grappler/optimizers/data/graph_utils.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+namespace grappler {
+namespace {
+
+using test::function::NDef;
+
+constexpr char kOptionsDataset[] = "OptionsDataset";
+constexpr char kParallelMapDataset[] = "ParallelMapDatasetV2";
+constexpr char kPrefetchDataset[] = "PrefetchDataset";
+
+Status Optimize(InjectPrefetch &optimizer, const GrapplerItem &item,
+                GraphDef *output, bool autotune) {
+  RewriterConfig_CustomGraphOptimizer config;
+  if (autotune) {
+    (*config.mutable_parameter_map())["autotune"].set_s("true");
+  } else {
+    (*config.mutable_parameter_map())["autotune"].set_s("false");
+  }
+  TF_RETURN_IF_ERROR(optimizer.Init(&config));
+  return optimizer.Optimize(nullptr, item, output);
+}
+
+Status OptimizeWithEnableGPUCompatibleMemory(const GrapplerItem &item, GraphDef *output,
+                                  bool autotune) {
+  EnableGPUCompatibleMemory optimizer;
+  return Optimize(optimizer, item, output, autotune);
+}
+
+class EnableGPUCompatibleMemoryParameterizedTest : public ::testing::TestWithParam<bool> {
+};
+
+TEST_P(RewriteTest, DisablePrefetchLegacyAutotune) {
+  const bool autotune = GetParam();
+  GrapplerItem item;
+
+  item.graph = test::function::GDef({
+      NDef("start", "Const", {}, {{"value", 0}, {"dtype", DT_INT32}}),
+      NDef("stop", "Const", {}, {{"value", 10}, {"dtype", DT_INT32}}),
+      NDef("step", "Const", {}, {{"value", 1}, {"dtype", DT_INT32}}),
+      NDef("range", "RangeDataset", {"start", "stop", "step"},
+           {{"output_shapes", gtl::ArraySlice<TensorShape>{}},
+            {"output_types", gtl::ArraySlice<DataType>{}}}),
+      NDef("prefetch1", "PrefetchDataset", {"range"},
+           {{"legacy_autotune", true}}),
+      NDef("prefetch2", "PrefetchDataset", {"prefetch1"},
+           {{"legacy_autotune", false}}),
+      NDef("prefetch3", "PrefetchDataset", {"prefetch2"}, {}),
+  });
+
+  GraphDef output;
+  TF_ASSERT_OK(
+      OptimizeWithEnableGPUCompatibleMemory(item, &output, autotune));
+
+  NodeDef prefetch_node1 =
+      output.node(graph_utils::FindGraphNodeWithName("prefetch1", output));
+  EXPECT_EQ(prefetch_node1.attr().at("legacy_autotune").b(), !autotune);
+  // TODO (kushanam): enable when the UseGpuAllocator attribute is added 
+  // to the Dataset ops
+  // NodeDef range =
+  //     output.node(graph_utils::FindGraphNodeWithName("range", output));
+  // EXPECT_TRUE(prefetch_node2.attr().at("UseGpuAllocator").b());
+}
+
+}  // namespace
+}  // namespace grappler
+}  // namespace tensorflow

--- a/tensorflow/core/grappler/optimizers/data/meta_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/data/meta_optimizer.cc
@@ -36,7 +36,7 @@ using ConfigMap =
     std::map<string, tensorflow::RewriterConfig_CustomGraphOptimizer>;
 
 // tf.data optimizations, in the order we want to perform them.
-constexpr std::array<const char*, 19> kTFDataOptimizations = {
+constexpr std::array<const char*, 20> kTFDataOptimizations = {
     "noop_elimination",
     "disable_intra_op_parallelism",
     "use_private_thread_pool",
@@ -55,7 +55,8 @@ constexpr std::array<const char*, 19> kTFDataOptimizations = {
     "inject_prefetch",
     "disable_prefetch_legacy_autotune",
     "enable_gradient_descent",
-    "make_deterministic"};
+    "make_deterministic",
+    "enable_gpu_compatible_memory"};
 
 // Parses a list of string optimizer configurations into a map from
 // optimizer name -> rewriter config for that optimizer.


### PR DESCRIPTION
The purpose for this PR is to add a data grappler pass to enable GPU compatible mode for tensors which will be staged downstream using prefetch_to_device. This is in accordance with recent efforts to parallelize the fetch and execute (commit #s: 9a8772d, ad60111, 2803dfc, 4111779, ecc3db7).
Note that the purpose for this PR would be to enable the pass. There would be a subsequent PR to implement the "UseGpuAllocator" potentially within the following data ops: RepeatDataset, MapDataset, ParallelMapDataset, ParallelMapDatasetV2, InterleaveDataset, ParallelInterleaveDatasetV2, ParallelInterleaveDatasetV3, ParallelInterleaveDatasetV4, FilterDataset, ParallelFilterDataset, BatchDataset, BatchDatasetV2, ParallelBatchDataset, ShardDataset, PaddedBatchDataset, PaddedBatchDatasetV2, RangeDataset
Attn: @changhuilin