### PR TITLE
Avoid redundant PTX generation during nvcc compilation

### DIFF
--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -224,11 +224,21 @@ def InvokeNvcc(argv, log=False):
   out = ' -o ' + out_file[0]
 
   nvccopts = '-D_FORCE_INLINES '
-  for capability in GetOptionValue(argv, "--cuda-gpu-arch"):
+  capabilities_sm = set(GetOptionValue(argv, "--cuda-gpu-arch"))
+  capabilities_compute = set(GetOptionValue(argv, '--cuda-include-ptx'))
+  # When both "code=sm_xy" and "code=compute_xy" are requested for a single
+  # arch, they can be combined using "code=xy,compute_xy" which avoids a
+  # redundant PTX generation during compilation.
+  capabilities_both = capabilities_sm.intersection(capabilities_compute)
+  for capability in capabilities_both:
+    capability = capability[len('sm_'):]
+    nvccopts += r'-gencode=arch=compute_%s,\"code=sm_%s,compute_%s\" ' % (
+        capability, capability, capability)
+  for capability in capabilities_sm - capabilities_both:
     capability = capability[len('sm_'):]
     nvccopts += r'-gencode=arch=compute_%s,\"code=sm_%s\" ' % (capability,
                                                                capability)
-  for capability in GetOptionValue(argv, '--cuda-include-ptx'):
+  for capability in capabilities_compute - capabilities_both:
     capability = capability[len('sm_'):]
     nvccopts += r'-gencode=arch=compute_%s,\"code=compute_%s\" ' % (capability,
                                                                     capability)

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -232,7 +232,7 @@ def InvokeNvcc(argv, log=False):
   capabilities_both = capabilities_sm.intersection(capabilities_compute)
   for capability in capabilities_both:
     capability = capability[len('sm_'):]
-    nvccopts += r'-gencode=arch=compute_%s,\"code=sm_%s,compute_%s\" ' % (
+    nvccopts += r'-gencode=arch=compute_%s,code=\"sm_%s,compute_%s\" ' % (
         capability, capability, capability)
   for capability in capabilities_sm - capabilities_both:
     capability = capability[len('sm_'):]

--- a/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
+++ b/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
@@ -147,7 +147,7 @@ def InvokeNvcc(argv, log=False):
   for capability in capabilities_both:
     capability = capability[len('sm_'):]
     nvccopts += [
-        r'-gencode=arch=compute_%s,code=\"sm_%s,compute_%s\"' % (
+        r'-gencode=arch=compute_%s,code=\\"sm_%s,compute_%s\\"' % (
             capability, capability, capability)
     ]
   for capability in capabilities_sm - capabilities_both:

--- a/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
+++ b/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
@@ -136,26 +136,14 @@ def InvokeNvcc(argv, log=False):
   m_options = ["-m64"]
 
   nvccopts = ['-D_FORCE_INLINES']
-  capabilities_sm, argv = GetOptionValue(argv, "--cuda-gpu-arch")
-  capabilities_compute, argv = GetOptionValue(argv, '--cuda-include-ptx')
-  capabilities_sm = set(capabilities_sm)
-  capabilities_compute = set(capabilities_compute)
-  # When both "code=sm_xy" and "code=compute_xy" are requested for a single
-  # arch, they can be combined using "code=xy,compute_xy" which avoids a
-  # redundant PTX generation during compilation.
-  capabilities_both = capabilities_sm.intersection(capabilities_compute)
-  for capability in capabilities_both:
-    capability = capability[len('sm_'):]
-    nvccopts += [
-        r'-gencode=arch=compute_%s,code="sm_%s,compute_%s"' % (
-            capability, capability, capability)
-    ]
-  for capability in capabilities_sm - capabilities_both:
+  compute_capabilities, argv = GetOptionValue(argv, "--cuda-gpu-arch")
+  for capability in compute_capabilities:
     capability = capability[len('sm_'):]
     nvccopts += [
         r'-gencode=arch=compute_%s,"code=sm_%s"' % (capability, capability)
     ]
-  for capability in capabilities_compute - capabilities_both:
+  compute_capabilities, argv = GetOptionValue(argv, '--cuda-include-ptx')
+  for capability in compute_capabilities:
     capability = capability[len('sm_'):]
     nvccopts += [
         r'-gencode=arch=compute_%s,"code=compute_%s"' % (capability, capability)

--- a/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
+++ b/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
@@ -147,7 +147,7 @@ def InvokeNvcc(argv, log=False):
   for capability in capabilities_both:
     capability = capability[len('sm_'):]
     nvccopts += [
-        r'-gencode=arch=compute_%s,"code=sm_%s,compute_%s"' % (
+        r'-gencode=arch=compute_%s,code=\"sm_%s,compute_%s\"' % (
             capability, capability, capability)
     ]
   for capability in capabilities_sm - capabilities_both:

--- a/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
+++ b/third_party/gpus/crosstool/windows/msvc_wrapper_for_nvcc.py.tpl
@@ -147,7 +147,7 @@ def InvokeNvcc(argv, log=False):
   for capability in capabilities_both:
     capability = capability[len('sm_'):]
     nvccopts += [
-        r'-gencode=arch=compute_%s,code=\\"sm_%s,compute_%s\\"' % (
+        r'-gencode=arch=compute_%s,code="sm_%s,compute_%s"' % (
             capability, capability, capability)
     ]
   for capability in capabilities_sm - capabilities_both:


### PR DESCRIPTION
In nvcc, we currently use the following two options to specify we want to store both PTX and cubin for arch xy in the resulting binary. This will cause PTX to be generated twice; first to store the PTX directly in the binary (backend = compute_xy) and then second to be compiled to cubin (backend = sm_xy). 

```
-gencode=arch=compute_xy,code=compute_xy
-gencode=arch=compute_xy,code=sm_xy
```

Instead, we can use the following which combines both steps, so that the PTX is only generated once.

```
-gencode=arch=compute_xy,code=\"compute_xy,sm_xy\"
```

This change should reduce compilation time.