### PR TITLE
[oneDNN] Fix for some unit test failures

### DIFF
--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -484,7 +484,7 @@ cc_library(
 cc_library(
     name = "port",
     srcs = ["port.cc"],
-    hdrs = ["port.h"],
+    hdrs = ["port.h", "onednn_env_vars.h"],
     copts = tf_copts(),
     visibility = [
         "//tensorflow/core:__pkg__",

--- a/tensorflow/core/util/onednn_env_vars.cc
+++ b/tensorflow/core/util/onednn_env_vars.cc
@@ -16,8 +16,8 @@ limitations under the License.
 #ifdef INTEL_MKL
 
 #include "tensorflow/core/util/onednn_env_vars.h"
-
 #include "absl/base/call_once.h"
+#include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/util/env_var.h"
 
 namespace tensorflow {
@@ -40,6 +40,55 @@ bool UseSystemAlloc() {
                                    /*default_value*/ false, &use_sys_alloc));
   });
   return use_sys_alloc;
+}
+
+bool IsMKLEnabled() {
+#ifndef INTEL_MKL
+  return false;
+#endif  // !INTEL_MKL
+  static absl::once_flag once;
+#ifdef ENABLE_MKL
+  // Keeping TF_DISABLE_MKL env variable for legacy reasons.
+  static bool oneDNN_disabled = false;
+  absl::call_once(once, [&] {
+    TF_CHECK_OK(ReadBoolFromEnvVar("TF_DISABLE_MKL", false, &oneDNN_disabled));
+    if (oneDNN_disabled) VLOG(2) << "TF-MKL: Disabling oneDNN";
+  });
+  return (!oneDNN_disabled);
+#else
+  // Linux: Turn oneDNN on by default for CPUs with neural network features.
+  // Windows: oneDNN is off by default.
+  // No need to guard for other platforms here because INTEL_MKL is only defined
+  // for non-mobile Linux or Windows.
+  static bool oneDNN_enabled =
+#ifdef __linux__
+      port::TestCPUFeature(port::CPUFeature::AVX512_VNNI) ||
+      port::TestCPUFeature(port::CPUFeature::AVX512_BF16) ||
+      port::TestCPUFeature(port::CPUFeature::AVX_VNNI) ||
+      port::TestCPUFeature(port::CPUFeature::AMX_TILE) ||
+      port::TestCPUFeature(port::CPUFeature::AMX_INT8) ||
+      port::TestCPUFeature(port::CPUFeature::AMX_BF16);
+#else
+      false;
+#endif  // __linux__
+  absl::call_once(once, [&] {
+    auto status = ReadBoolFromEnvVar("TF_ENABLE_ONEDNN_OPTS", oneDNN_enabled,
+                                     &oneDNN_enabled);
+    if (!status.ok()) {
+      LOG(WARNING) << "TF_ENABLE_ONEDNN_OPTS is not set to either '0', 'false',"
+                   << " '1', or 'true'. Using the default setting: "
+                   << oneDNN_enabled;
+    }
+    if (oneDNN_enabled) {
+      LOG(INFO) << "oneDNN custom operations are on. "
+                << "You may see slightly different numerical results due to "
+                << "floating-point round-off errors from different computation "
+                << "orders. To turn them off, set the environment variable "
+                << "`TF_ENABLE_ONEDNN_OPTS=0`.";
+    }
+  });
+  return oneDNN_enabled;
+#endif  // ENABLE_MKL
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/util/onednn_env_vars.h
+++ b/tensorflow/core/util/onednn_env_vars.h
@@ -20,6 +20,7 @@ limitations under the License.
 namespace tensorflow {
 bool AreWeightsFrozen();
 bool UseSystemAlloc();
+bool IsMKLEnabled();
 }  // namespace tensorflow
 #endif  // INTEL_MKL
 #endif  // TENSORFLOW_CORE_UTIL_ONEDNN_ENV_VARS_H_

--- a/tensorflow/core/util/port.cc
+++ b/tensorflow/core/util/port.cc
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/core/util/port.h"
-
+#include "tensorflow/core/util/onednn_env_vars.h"
 
 namespace tensorflow {
 
@@ -59,7 +59,5 @@ bool GpuSupportsHalfMatMulAndConv() {
 #endif
 }
 
-bool IsMklEnabled() {
-  return IsMKLEnabled();
-}
+bool IsMklEnabled() { return IsMKLEnabled(); }
 }  // end namespace tensorflow

--- a/tensorflow/core/util/port.cc
+++ b/tensorflow/core/util/port.cc
@@ -60,10 +60,6 @@ bool GpuSupportsHalfMatMulAndConv() {
 }
 
 bool IsMklEnabled() {
-#if defined(INTEL_MKL) && defined(ENABLE_MKL)
-  return true;
-#else
-  return false;
-#endif  // INTEL_MKL && ENABLE_MKL
+  return IsMKLEnabled();
 }
 }  // end namespace tensorflow

--- a/tensorflow/core/util/port.h
+++ b/tensorflow/core/util/port.h
@@ -18,6 +18,9 @@ limitations under the License.
 
 namespace tensorflow {
 
+// Returns true if oneDNN is enabled. Implementation is in util.cc.
+bool IsMKLEnabled();
+
 // Returns true if GOOGLE_CUDA is defined.
 bool IsGoogleCudaEnabled();
 

--- a/tensorflow/core/util/util.cc
+++ b/tensorflow/core/util/util.cc
@@ -22,7 +22,6 @@ limitations under the License.
 #include "tensorflow/core/framework/device_factory.h"
 #include "tensorflow/core/lib/gtl/inlined_vector.h"
 #include "tensorflow/core/lib/strings/strcat.h"
-#include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/util/env_var.h"
 
@@ -125,55 +124,6 @@ string SliceDebugString(const TensorShape& shape, const int64_t flat) {
   }
   strings::StrAppend(&result, "]");
   return result;
-}
-
-bool IsMKLEnabled() {
-#ifndef INTEL_MKL
-  return false;
-#endif  // !INTEL_MKL
-  static absl::once_flag once;
-#ifdef ENABLE_MKL
-  // Keeping TF_DISABLE_MKL env variable for legacy reasons.
-  static bool oneDNN_disabled = false;
-  absl::call_once(once, [&] {
-    TF_CHECK_OK(ReadBoolFromEnvVar("TF_DISABLE_MKL", false, &oneDNN_disabled));
-    if (oneDNN_disabled) VLOG(2) << "TF-MKL: Disabling oneDNN";
-  });
-  return (!oneDNN_disabled);
-#else
-  // Linux: Turn oneDNN on by default for CPUs with neural network features.
-  // Windows: oneDNN is off by default.
-  // No need to guard for other platforms here because INTEL_MKL is only defined
-  // for non-mobile Linux or Windows.
-  static bool oneDNN_enabled =
-#ifdef __linux__
-      port::TestCPUFeature(port::CPUFeature::AVX512_VNNI) ||
-      port::TestCPUFeature(port::CPUFeature::AVX512_BF16) ||
-      port::TestCPUFeature(port::CPUFeature::AVX_VNNI) ||
-      port::TestCPUFeature(port::CPUFeature::AMX_TILE) ||
-      port::TestCPUFeature(port::CPUFeature::AMX_INT8) ||
-      port::TestCPUFeature(port::CPUFeature::AMX_BF16);
-#else
-      false;
-#endif  // __linux__
-  absl::call_once(once, [&] {
-    auto status = ReadBoolFromEnvVar("TF_ENABLE_ONEDNN_OPTS", oneDNN_enabled,
-                                     &oneDNN_enabled);
-    if (!status.ok()) {
-      LOG(WARNING) << "TF_ENABLE_ONEDNN_OPTS is not set to either '0', 'false',"
-                   << " '1', or 'true'. Using the default setting: "
-                   << oneDNN_enabled;
-    }
-    if (oneDNN_enabled) {
-      LOG(INFO) << "oneDNN custom operations are on. "
-                << "You may see slightly different numerical results due to "
-                << "floating-point round-off errors from different computation "
-                << "orders. To turn them off, set the environment variable "
-                << "`TF_ENABLE_ONEDNN_OPTS=0`.";
-    }
-  });
-  return oneDNN_enabled;
-#endif  // ENABLE_MKL
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/util/util.h
+++ b/tensorflow/core/util/util.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/lib/core/stringpiece.h"
+#include "tensorflow/core/util/onednn_env_vars.h"
 
 namespace tensorflow {
 
@@ -55,9 +56,6 @@ std::string PrintMemory(const char* ptr, size_t n);
 // StrAppend("tensor", s) is a Python indexing expression.  E.g.,
 // "tensor", "tensor[i]", "tensor[i, j]", etc.
 std::string SliceDebugString(const TensorShape& shape, const int64_t flat);
-
-// Check if MKL is enabled in runtime
-bool IsMKLEnabled();
 
 }  // namespace tensorflow
 

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -359,8 +359,7 @@ def GpuSupportsHalfMatMulAndConv():
 
 
 def IsMklEnabled():
-  return (_pywrap_util_port.IsMklEnabled() or
-          os.getenv("TF_ENABLE_ONEDNN_OPTS", "False").lower() in ["true", "1"])
+  return (_pywrap_util_port.IsMklEnabled())
 
 
 def InstallStackTraceHandler():


### PR DESCRIPTION
This PR fixes some unit test failures

//tensorflow/python/client:timeline_test_cpu,

//tensorflow/c/eager:c_api_distributed_test_cpu,

//tensorflow/python/eager:context_test_cpu,

//tensorflow/python/framework:config_test_cpu,

//tensorflow/python/framework:config_test_tpu,

//tensorflow/python/framework:node_file_writer_test_cpu

This fix makes sure that python code can query correctly if oneDNN is enabled or not