### PR TITLE
Store PTX for highest compute capability only, when using old x.y format

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -423,6 +423,11 @@ def compute_capabilities(repository_ctx):
     ).split(",")
 
     # Map old 'x.y' capabilities to 'compute_xy'.
+    if len(capabilities) > 0 and all([len(x.split(".")) == 2 for x in capabilities]):
+        # If all capabilities are in 'x.y' format, only include PTX for the
+        # highest capability.
+        cc_list = sorted([x.replace(".", "") for x in capabilities])
+        capabilities = ["sm_%s" % x for x in cc_list[:-1]] + ["compute_%s" % cc_list[-1]]
     for i, capability in enumerate(capabilities):
         parts = capability.split(".")
         if len(parts) != 2:


### PR DESCRIPTION
It is common practice for CUDA applications to include native cubin for all arches, and PTX for the highest arch only (for forward combability). This PR makes this desirable behavior the default when using the old x.y format for `TF_CUDA_COMPUTE_CAPABILITIES`. Currently in TensorFlow, if a user sets `TF_CUDA_COMPUTE_CAPABILITIES=5.2,6.0,6.1,7.0,7.5,8.0,8.6`, both cubin and ptx is generated for ALL of the arches which results in a huge binary size.

This change reduces the size of the tensorflow binaries with no downsides.

If a user wanted to generate PTX for a different arch besides the highest, they can use the new format of sm_xy,compute_xy.