### PR TITLE
keep restore and save op for functaion_optimizer

### DIFF
--- a/tensorflow/core/grappler/optimizers/function_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/function_optimizer.cc
@@ -1230,6 +1230,12 @@ Status InlineFunctionCalls(const GrapplerItem& item,
     fetch_nodes.insert(ParseTensorName(fetch).node());
   }
   NodeNames keep_nodes(item.keep_ops.begin(), item.keep_ops.end());
+  if (item.save_op.size() > 0) {
+    keep_nodes.insert(item.save_op);
+  }
+  if (item.restore_op.size() > 0) {
+    keep_nodes.insert(item.restore_op);
+  }
 
   std::vector<string> inlined_function_names;
 


### PR DESCRIPTION
Keep save and restore op in function optimizer. 
Currently, function optimizer will make restore op inlined, if restore op is StatefulPartitionedCall.
if we use tf_optimizer.OptimizeGraph to optimize a saved_model, the restore op will be replaced.
When use session to restore this optimized saved model, it will report an error.