### PR TITLE
Use faster sort in TopK kernel when num_rows==1

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4345,7 +4345,10 @@ tf_kernel_library(
         "topk_op_gpu_int8.cu.cc",
         "topk_op_gpu_uint8.cu.cc",
     ],
-    deps = NN_DEPS + [":gpu_prim_hdrs"],
+    deps = NN_DEPS + [
+        ":gpu_prim_hdrs",
+        ":gpu_prim_helpers",
+    ],
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/gpu_prim_helpers.h
+++ b/tensorflow/core/kernels/gpu_prim_helpers.h
@@ -56,7 +56,8 @@ template <typename Tkey, typename Tindex>
 Status GpuRadixSort(OpKernelContext* context, int size, const Tkey* keys_in,
                     Tkey* keys_out,            // Optional
                     const Tindex* indices_in,  // Optional
-                    Tindex* indices_out, int num_bits = sizeof(Tkey) * 8) {
+                    Tindex* indices_out, int num_bits = sizeof(Tkey) * 8,
+                    bool descending = false) {
   if (size == 0) return Status::OK();
   if (num_bits == 0) {
     // Workaround for CUB failing when begin_bit = end_bit = 0 (e.g., when all
@@ -110,9 +111,16 @@ Status GpuRadixSort(OpKernelContext* context, int size, const Tkey* keys_in,
   Tensor temp_storage;
   size_t temp_storage_bytes = 0;
   const auto& cu_stream = GetGpuStream(context);
-  auto err = gpuprim::DeviceRadixSort::SortPairs(
-      nullptr, temp_storage_bytes, keys_in, keys_out, indices_in, indices_out,
-      size, /*begin_bit=*/0, /*end_bit=*/num_bits, cu_stream);
+  gpuError_t err;
+  if (descending) {
+    err = gpuprim::DeviceRadixSort::SortPairsDescending(
+        nullptr, temp_storage_bytes, keys_in, keys_out, indices_in, indices_out,
+        size, /*begin_bit=*/0, /*end_bit=*/num_bits, cu_stream);
+  } else {
+    err = gpuprim::DeviceRadixSort::SortPairs(
+        nullptr, temp_storage_bytes, keys_in, keys_out, indices_in, indices_out,
+        size, /*begin_bit=*/0, /*end_bit=*/num_bits, cu_stream);
+  }
   if (err != 0) {
     return errors::Internal(
         "Failed to launch gpuprim::DeviceRadixSort::SortPairs to calculate "
@@ -124,10 +132,17 @@ Status GpuRadixSort(OpKernelContext* context, int size, const Tkey* keys_in,
       DT_INT8, TensorShape({static_cast<int64_t>(temp_storage_bytes)}),
       &temp_storage));
   // Sort indices by keys.
-  err = gpuprim::DeviceRadixSort::SortPairs(
-      temp_storage.flat<int8>().data(), temp_storage_bytes, keys_in, keys_out,
-      indices_in, indices_out, size, /*begin_bit=*/0, /*end_bit=*/num_bits,
-      cu_stream);
+  if (descending) {
+    err = gpuprim::DeviceRadixSort::SortPairsDescending(
+        temp_storage.flat<int8>().data(), temp_storage_bytes, keys_in, keys_out,
+        indices_in, indices_out, size, /*begin_bit=*/0, /*end_bit=*/num_bits,
+        cu_stream);
+  } else {
+    err = gpuprim::DeviceRadixSort::SortPairs(
+        temp_storage.flat<int8>().data(), temp_storage_bytes, keys_in, keys_out,
+        indices_in, indices_out, size, /*begin_bit=*/0, /*end_bit=*/num_bits,
+        cu_stream);
+  }
   if (err != 0) {
     return errors::Internal(
         "Failed to launch gpuprim::DeviceRadixSort::SortPairs, "

--- a/tensorflow/core/kernels/topk_op_gpu.h
+++ b/tensorflow/core/kernels/topk_op_gpu.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/kernels/gpu_prim.h"
+#include "tensorflow/core/kernels/gpu_prim_helpers.h"
 #include "tensorflow/core/kernels/topk_op.h"
 #include "tensorflow/core/lib/gtl/top_n.h"
 #include "tensorflow/core/platform/logging.h"
@@ -480,51 +481,64 @@ Status LaunchSortKernel(OpKernelContext* ctx, const T* input, int num_rows,
     sorted_values_ptr = temp_values.flat<T>().data();
   }
 
-  auto err = gpuprim::DeviceSegmentedRadixSort::SortPairsDescending(
-      /* d_temp_storage */ nullptr,
-      /* temp_storage_bytes */ temp_storage_bytes,
-      /* d_keys_in */ input,
-      /* d_keys_out */ sorted_values_ptr,
-      /* d_values_in */ input_indices_t.data(),
-      /* d_values_out */ sorted_indices_ptr,
-      /* num_items */ num_cols * num_rows,
-      /* num_segments */ num_rows,
-      /* d_begin_offsets */ segment_offsets_t,
-      /* d_end_offsets */ segment_offsets_t + 1,
-      /* begin_bit */ 0,
-      /* end_bit */ sizeof(T) * 8,
-      /* stream */ cu_stream);
-  if (err != cudaSuccess) {
-    return errors::Internal(
-        "TopKOp: Could not launch "
-        "gpuprim::DeviceSegmentedRadixSort::SortPairsDescending to calculate "
-        "temp_storage_bytes, status: ",
-        cudaGetErrorString(err));
-  }
-  Tensor temp_storage;
-  TF_RETURN_IF_ERROR(ctx->allocate_temp(
-      DT_INT8, TensorShape({static_cast<int64_t>(temp_storage_bytes)}),
-      &temp_storage));
-  err = gpuprim::DeviceSegmentedRadixSort::SortPairsDescending(
-      /* d_temp_storage */ temp_storage.flat<int8>().data(),
-      /* temp_storage_bytes */ temp_storage_bytes,
-      /* d_keys_in */ input,
-      /* d_keys_out */ sorted_values_ptr,
-      /* d_values_in */ input_indices_t.data(),
-      /* d_values_out */ sorted_indices_ptr,
-      /* num_items */ num_cols * num_rows,
-      /* num_segments */ num_rows,
-      /* d_begin_offsets */ segment_offsets_t,
-      /* d_end_offsets */ segment_offsets_t + 1,
-      /* begin_bit */ 0,
-      /* end_bit */ sizeof(T) * 8,
-      /* stream */ cu_stream);
-  if (err != cudaSuccess) {
-    return errors::Internal(
-        "TopKOp: Could not launch "
-        "gpuprim::DeviceSegmentedRadixSort::SortPairsDescending to sort input, "
-        "temp_storage_bytes: ",
-        temp_storage_bytes, ", status: ", cudaGetErrorString(err));
+  if (num_rows == 1) {
+    // Note: DeviceSegmentedRadixSort is very slow when num_segments=1 because
+    // it only uses 1 SM per segment. Calling the un-segmented version is much
+    // faster in this case.
+    TF_RETURN_IF_ERROR(GpuRadixSort(ctx, num_cols, /*keys_in=*/input,
+                                    /*keys_out=*/sorted_values_ptr,
+                                    /*indices_in=*/input_indices_t.data(),
+                                    /*indices_out=*/sorted_indices_ptr,
+                                    /*num_bits=*/sizeof(T) * 8,
+                                    /*descending=*/true));
+  } else {
+    auto err = gpuprim::DeviceSegmentedRadixSort::SortPairsDescending(
+        /* d_temp_storage */ nullptr,
+        /* temp_storage_bytes */ temp_storage_bytes,
+        /* d_keys_in */ input,
+        /* d_keys_out */ sorted_values_ptr,
+        /* d_values_in */ input_indices_t.data(),
+        /* d_values_out */ sorted_indices_ptr,
+        /* num_items */ num_cols * num_rows,
+        /* num_segments */ num_rows,
+        /* d_begin_offsets */ segment_offsets_t,
+        /* d_end_offsets */ segment_offsets_t + 1,
+        /* begin_bit */ 0,
+        /* end_bit */ sizeof(T) * 8,
+        /* stream */ cu_stream);
+    if (err != cudaSuccess) {
+      return errors::Internal(
+          "TopKOp: Could not launch "
+          "gpuprim::DeviceSegmentedRadixSort::SortPairsDescending to calculate "
+          "temp_storage_bytes, status: ",
+          cudaGetErrorString(err));
+    }
+    Tensor temp_storage;
+    TF_RETURN_IF_ERROR(ctx->allocate_temp(
+        DT_INT8, TensorShape({static_cast<int64_t>(temp_storage_bytes)}),
+        &temp_storage));
+    err = gpuprim::DeviceSegmentedRadixSort::SortPairsDescending(
+        /* d_temp_storage */ temp_storage.flat<int8>().data(),
+        /* temp_storage_bytes */ temp_storage_bytes,
+        /* d_keys_in */ input,
+        /* d_keys_out */ sorted_values_ptr,
+        /* d_values_in */ input_indices_t.data(),
+        /* d_values_out */ sorted_indices_ptr,
+        /* num_items */ num_cols * num_rows,
+        /* num_segments */ num_rows,
+        /* d_begin_offsets */ segment_offsets_t,
+        /* d_end_offsets */ segment_offsets_t + 1,
+        /* begin_bit */ 0,
+        /* end_bit */ sizeof(T) * 8,
+        /* stream */ cu_stream);
+    if (err != cudaSuccess) {
+      return errors::Internal(
+          "TopKOp: Could not launch "
+          "gpuprim::DeviceSegmentedRadixSort::SortPairsDescending to sort "
+          "input, "
+          "temp_storage_bytes: ",
+          temp_storage_bytes, ", status: ", cudaGetErrorString(err));
+    }
   }
   if (k < num_cols) {
     // Need to copy subsets of sorted_indices and sorted_outputs to


### PR DESCRIPTION
`DeviceSegmentedRadixSort` is very slow when `num_segments=1` because it only uses 1 SM per segment. Calling the un-segmented version is much faster (3-5x) in this case (i.e., for 1D input).

No functional change besides the improved performance.

cc @nluehr 