### PR TITLE
Support GPU fusion of matmal+bias+(activation)

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -309,6 +309,8 @@ bool IsGpuCompatibleDataType(const NodeDef* contraction,
   DataType dtype = GetDataTypeFromAttr(*contraction, type_attr);
   if (IsConv2D(*contraction)) {
     return dtype == DT_FLOAT;
+  } else if (IsMatMul(*contraction)) {
+    return dtype == DT_FLOAT || dtype == DT_HALF;
   } else {
     return false;
   }
@@ -326,6 +328,16 @@ bool IsCpuCompatibleDataFormat(const RemapperContext& ctx,
   } else {
     return false;
   }
+}
+
+bool BlasLtMatmulEnabled() {
+  static bool is_enabled = [] {
+    bool is_enabled = false;
+    TF_CHECK_OK(tensorflow::ReadBoolFromEnvVar(
+        "TF_USE_CUBLASLT", /*default_val=*/false, &is_enabled));
+    return is_enabled;
+  }();
+  return is_enabled;
 }
 
 bool IsGpuCompatibleDataFormat(const RemapperContext& ctx,
@@ -351,6 +363,12 @@ bool IsGpuCompatibleConv2D(const RemapperContext& ctx, const NodeDef* conv2d) {
   DCHECK(IsConv2D(*conv2d)) << "Expected Conv2D op";
   return NodeIsOnGpu(conv2d) && IsGpuCompatibleDataType(conv2d) &&
          IsGpuCompatibleDataFormat(ctx, conv2d);
+}
+
+bool IsGpuCompatibleMatMul(const RemapperContext& ctx, const NodeDef* matmul) {
+  DCHECK(IsMatMul(*matmul)) << "Expected MatMul op";
+  return BlasLtMatmulEnabled() && NodeIsOnGpu(matmul) &&
+         IsGpuCompatibleDataType(matmul);
 }
 
 bool IsCpuCompatibleMatMul(const RemapperContext& ctx, const NodeDef* matmul) {
@@ -388,42 +406,62 @@ bool IsGpuCompatible(const RemapperContext& ctx,
   // ROCm does not support _FusedConv2D
   return false;
 #endif
-  // The TF->XLA bridge does not support `_FusedConv2D` so we avoid creating
-  // this op.  Furthermore, XLA already does this fusion internally so there
+  // The TF->XLA bridge does not support `_Fused[Conv2D|MatMul]` so we avoid
+  // creating this op. Furthermore, XLA already does this fusion internally so
+  // there is no true benefit from doing this optimization if XLA is going to
+  // compile the unfused operations anyway.
+  if (ctx.xla_auto_clustering_on) return false;
+
+  const GraphDef* graph = ctx.graph_view.graph();
+
+  // We rely on cuDNN for fused convolution and cublasLt for fused matmul.
+  const NodeDef& activation_node = graph->node(matched.activation);
+  if (!IsRelu(activation_node)) return false;
+
+  const NodeDef& contraction_node = graph->node(matched.contraction);
+  if (IsConv2D(contraction_node)) {
+    const std::vector<OpInfo::TensorProperties>& input_props =
+        ctx.graph_properties.GetInputProperties(contraction_node.name());
+    const TensorShapeProto& filter_shape =
+        input_props.size() >= 2 ? input_props[1].shape() : TensorShapeProto();
+
+    // FusedConv2D on GPU with 1x1 convolution is marginally faster than
+    // in-graph computation in micro benchmarks (see kernels/conv_ops_test.cc),
+    // and significantly slower in large scale benchmarks.
+    bool is_spatial_conv = Rank(filter_shape) == 4 &&          //
+                           IsKnown(filter_shape.dim(1)) &&     //
+                           IsKnown(filter_shape.dim(2)) &&     //
+                           filter_shape.dim(1).size() != 1 &&  //
+                           filter_shape.dim(2).size() != 1;
+
+    return is_spatial_conv && IsGpuCompatibleConv2D(ctx, &contraction_node);
+  } else if (IsMatMul(contraction_node)) {
+    return IsGpuCompatibleMatMul(ctx, &contraction_node);
+  }
+
+  return false;
+}
+
+// Checks if we can rewrite a pattern to the `_FusedMatMul` on GPU device.
+bool IsGpuCompatible(const RemapperContext& ctx,
+                     const ContractionWithBiasAdd& matched) {
+#if TENSORFLOW_USE_ROCM
+  // ROCm does not support _FusedMatMul
+  return false;
+#endif
+  // The TF->XLA bridge does not support `_FusedMatMul` so we avoid creating
+  // this op. Furthermore, XLA already does this fusion internally so there
   // is no true benefit from doing this optimization if XLA is going to compile
   // the unfused operations anyway.
   if (ctx.xla_auto_clustering_on) return false;
 
   const GraphDef* graph = ctx.graph_view.graph();
   const NodeDef& contraction_node = graph->node(matched.contraction);
-  if (!IsConv2D(contraction_node)) return false;
+  if (!IsMatMul(contraction_node)) return false;
 
-  const std::vector<OpInfo::TensorProperties>& input_props =
-      ctx.graph_properties.GetInputProperties(contraction_node.name());
-  const TensorShapeProto& filter_shape =
-      input_props.size() >= 2 ? input_props[1].shape() : TensorShapeProto();
-
-  // FusedConv2D on GPU with 1x1 convolution is marginally faster than
-  // in-graph computation in micro benchmarks (see kernels/conv_ops_test.cc),
-  // and significantly slower in large scale benchmarks.
-  bool is_spatial_conv = Rank(filter_shape) == 4 &&          //
-                         IsKnown(filter_shape.dim(1)) &&     //
-                         IsKnown(filter_shape.dim(2)) &&     //
-                         filter_shape.dim(1).size() != 1 &&  //
-                         filter_shape.dim(2).size() != 1;
-
-  // We rely on cuDNN for fused convolution, and it currently supports only Relu
-  // activation.
-  const NodeDef& activation_node = graph->node(matched.activation);
-  bool is_relu = IsRelu(activation_node);
-
-  return is_relu && is_spatial_conv &&
-         IsGpuCompatibleConv2D(ctx, &contraction_node);
+  return IsGpuCompatibleMatMul(ctx, &contraction_node);
 }
-bool IsGpuCompatible(const RemapperContext& ctx,
-                     const ContractionWithBiasAdd& matched) {
-  return false;
-}
+
 bool IsGpuCompatible(const RemapperContext& ctx,
                      const ContractionWithSqueezeAndBiasAdd& matched) {
   return false;

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3561,6 +3561,7 @@ tf_kernel_library(
         "//conditions:default": [],
     }) + mkl_deps() + if_cuda([
         "//tensorflow/core/platform/default/build_config:cublas_plugin",
+        "//tensorflow/stream_executor:matmul_util",
     ]) + if_cuda_or_rocm([":gpu_utils"]),
 )
 

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -54,8 +54,12 @@ limitations under the License.
 #include "tensorflow/core/kernels/matmul_op_impl.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/platform/tensor_float_32_utils.h"
+
+#if GOOGLE_CUDA
 #include "tensorflow/stream_executor/matmul_util.h"
 #endif  // GOOGLE_CUDA
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace tensorflow {
 

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -310,12 +310,11 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
     bool trans_a = dim_pair[0].first == 0 ? true : false;
     bool trans_b = dim_pair[0].second == 1 ? true : false;
 
-    const uint64 m = a.dim_size(trans_a ? 1 : 0);
-    const uint64 k = a.dim_size(trans_a ? 0 : 1);
-    const uint64 n = b.dim_size(trans_b ? 0 : 1);
+    const int64_t m = a.dim_size(trans_a ? 1 : 0);
+    const int64_t k = a.dim_size(trans_a ? 0 : 1);
+    const int64_t n = b.dim_size(trans_b ? 0 : 1);
 
     DataType dtype = DataTypeToEnum<T>::value;
-    bool allow_tf32 = tensor_float_32_execution_enabled();
     int device_id = stream->parent()->device_ordinal();
 
     BatchMatmulParameters matmul_params(trans_a, trans_b, false, false, m, n, k,

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -166,7 +166,7 @@ struct LaunchFusedMatMulOp<CPUDevice, T> {
   };
 };
 
-#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#if GOOGLE_CUDA
 namespace {
 
 se::port::StatusOr<se::blas::Epilogue> GetBlasLtEpilogOp(
@@ -377,7 +377,7 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
   }
 };
 
-#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#endif  // GOOGLE_CUDA
 
 template <typename Device, typename T>
 class FusedMatMulOp : public OpKernel {

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -28,6 +28,10 @@ limitations under the License.
 #define USE_EIGEN_TENSOR
 #define EIGEN_USE_THREADS
 
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#define EIGEN_USE_GPU
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
 #include <string>
 #include <vector>
 
@@ -44,9 +48,19 @@ limitations under the License.
 #include "tensorflow/core/kernels/eigen_contraction_kernel.h"
 #endif
 
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "tensorflow/core/kernels/gpu_utils.h"
+#include "tensorflow/core/kernels/matmul_op_impl.h"
+#include "tensorflow/core/platform/stream_executor.h"
+#include "tensorflow/core/platform/tensor_float_32_utils.h"
+#include "tensorflow/core/util/matmul_autotune.h"
+#include "tensorflow/stream_executor/matmul_util.h"
+#endif  // GOOGLE_CUDA
+
 namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
+typedef Eigen::GpuDevice GPUDevice;
 
 template <typename Device, typename T>
 struct LaunchFusedMatMulOp {
@@ -54,7 +68,7 @@ struct LaunchFusedMatMulOp {
       OpKernelContext* context, const Tensor& a, const Tensor& b,
       const Eigen::array<Eigen::IndexPair<Eigen::DenseIndex>, 1>& dim_pair,
       FusedComputationType fusion, const FusedComputationArgs& fusion_args,
-      Tensor* output);
+      Tensor* output, bool use_autotune);
 };
 
 template <typename T>
@@ -63,7 +77,10 @@ struct LaunchFusedMatMulOp<CPUDevice, T> {
       OpKernelContext* context, const Tensor& a, const Tensor& b,
       const Eigen::array<Eigen::IndexPair<Eigen::DenseIndex>, 1>& dim_pair,
       FusedComputationType fusion, const FusedComputationArgs& fusion_args,
-      Tensor* output) {
+      Tensor* output, bool use_autotune) {
+    OP_REQUIRES(context, DataTypeToEnum<T>::value != DT_HALF,
+                errors::InvalidArgument("_FusedMatMul doesn't support DT_HALF "
+                                        "data type on CPU devices."));
     auto lhs = a.matrix<T>();
     auto rhs = b.matrix<T>();
     auto out = output->matrix<T>();
@@ -145,6 +162,220 @@ struct LaunchFusedMatMulOp<CPUDevice, T> {
   };
 };
 
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+namespace {
+
+se::port::StatusOr<se::blas::Epilogue> GetBlasLtEpilogOp(
+    FusedComputationType fusion) {
+  se::blas::Epilogue epilog_op;
+  if (fusion == FusedComputationType::kBiasAdd) {
+    epilog_op = se::blas::Epilogue::kBias;
+  } else if (fusion == FusedComputationType::kBiasAddWithRelu) {
+    epilog_op = se::blas::Epilogue::kBiasThenReLU;
+  } else {
+    return se::port::InternalError("Unsupported fusion for BlasLt Matmul");
+  }
+  return epilog_op;
+}
+
+using ::stream_executor::BatchMatmulParameters;
+using ::stream_executor::BatchMatmulPlanMapSingleton;
+
+// A class for storing and retrieving algorithms in cublasLT autotuning
+class BlasPlansAutotuneCache {
+ public:
+  BlasPlansAutotuneCache() {}
+  bool Find(const se::BatchMatmulParameters& params,
+            se::blas::AlgorithmConfig* config) const {
+    absl::MutexLock lock(&mu_);
+    auto iter = blas_plans_algorithms_map_.find(params);
+    if (iter == blas_plans_algorithms_map_.end()) {
+      return false;
+    }
+    *config = iter->second;
+    return true;
+  }
+  void Insert(const se::BatchMatmulParameters& params,
+              const se::blas::AlgorithmConfig& config) {
+    absl::MutexLock lock(&mu_);
+    if (!blas_plans_algorithms_map_.contains(params)) {
+      blas_plans_algorithms_map_.insert({params, config});
+    }
+  }
+
+ private:
+  mutable absl::Mutex mu_;
+  absl::flat_hash_map<se::BatchMatmulParameters, se::blas::AlgorithmConfig>
+      blas_plans_algorithms_map_ ABSL_GUARDED_BY(mu_);
+  TF_DISALLOW_COPY_AND_ASSIGN(BlasPlansAutotuneCache);
+};
+
+struct BlasPlansAutotuneCacheSingleton {
+  static BlasPlansAutotuneCache* GetInstance() {
+    static BlasPlansAutotuneCache* instance = new BlasPlansAutotuneCache();
+    return instance;
+  }
+};
+
+template <typename LaunchFunc>
+se::blas::AlgorithmConfig AutotuneMatmul(
+    const std::vector<std::unique_ptr<se::blas::IBlasLtMatmulAlgorithm>>&
+        algorithms,
+    const BatchMatmulParameters& matmul_params, OpKernelContext* context,
+    const LaunchFunc& launch_func) {
+  // Note that algorithm_config.algorithm() here is used to refer
+  // to the index within the algorithms vector, not the algorithm
+  // itself.
+  se::blas::AlgorithmConfig algorithm_config(se::blas::kNoAlgorithm);
+  if (!BlasPlansAutotuneCacheSingleton::GetInstance()->Find(
+          matmul_params, &algorithm_config)) {
+    VLOG(4) << "Autotuning BlasLtMatmul over " << algorithms.size()
+            << " algorithms.";
+    se::blas::ProfileResult best_result;
+    se::blas::ProfileResult profile_result;
+
+    for (size_t i = 0; i != algorithms.size(); ++i) {
+      const auto& profile_algorithm = algorithms[i];
+
+      // Create a new scratch allocator with every autotuning run so that
+      // scratch space is deallocated between runs.
+      BlasScratchAllocator scratch_allocator(context);
+
+      bool cublaslt_launch_ok = launch_func(
+          &scratch_allocator, profile_algorithm.get(), &profile_result);
+
+      VLOG(4) << "  Autotune algorithm " << i
+              << " result: " << profile_result.elapsed_time_in_ms()
+              << " ms, valid=" << profile_result.is_valid()
+              << ", workspace_size=" << profile_algorithm->workspace_size();
+
+      if (cublaslt_launch_ok && profile_result.is_valid() &&
+          profile_result.elapsed_time_in_ms() <
+              best_result.elapsed_time_in_ms()) {
+        best_result = profile_result;
+      }
+    }
+
+    if (best_result.is_valid()) {
+      algorithm_config.set_algorithm(best_result.algorithm());
+    }
+    // We make sure that each matmul parameter set only gets one pass of
+    // autotune. If no algorithms works, we add kNoAlgorithm to the autotune
+    // map.
+    BlasPlansAutotuneCacheSingleton::GetInstance()->Insert(matmul_params,
+                                                           algorithm_config);
+  }
+  return algorithm_config;
+}
+
+}  // namespace
+
+template <typename T>
+struct LaunchFusedMatMulOp<GPUDevice, T> {
+  void operator()(
+      OpKernelContext* context, const Tensor& a, const Tensor& b,
+      const Eigen::array<Eigen::IndexPair<Eigen::DenseIndex>, 1>& dim_pair,
+      FusedComputationType fusion, const FusedComputationArgs& fusion_args,
+      Tensor* output, bool use_autotune) {
+    OP_REQUIRES(
+        context, DataTypeToEnum<T>::value != DT_BFLOAT16,
+        errors::InvalidArgument("_FusedMatMul doesn't support "
+                                "DT_BFLOAT16 data type on CPU devices."));
+    auto* stream = context->op_device_context()->stream();
+    OP_REQUIRES(context, stream, errors::Internal("No GPU stream available."));
+
+    // All fusion patterns supported by GPU are in the form of MatMul + BiasAdd
+    // + <other pointwise operations>. Therefore, the bias tensor is required.
+    const Tensor& bias = context->input(2);
+
+    if (bias.dims() != 1) {
+      OP_REQUIRES_OK(context,
+                     errors::InvalidArgument("bias must be 1-dimensional",
+                                             bias.shape().DebugString()));
+    }
+
+    auto a_ptr = AsDeviceMemory(a.template flat<T>().data(),
+                                a.template flat<T>().size());
+    auto b_ptr = AsDeviceMemory(b.template flat<T>().data(),
+                                b.template flat<T>().size());
+    auto bias_ptr = AsDeviceMemory(bias.template flat<T>().data(),
+                                   bias.template flat<T>().size());
+    auto c_ptr = AsDeviceMemory(output->template flat<T>().data(),
+                                output->template flat<T>().size());
+
+    auto epilog_op_or = GetBlasLtEpilogOp(fusion);
+    OP_REQUIRES_OK(context, epilog_op_or.status());
+    se::blas::Epilogue epilog_op = epilog_op_or.ValueOrDie();
+
+    bool trans_a = dim_pair[0].first == 0 ? true : false;
+    bool trans_b = dim_pair[0].second == 1 ? true : false;
+
+    const uint64 m = a.dim_size(trans_a ? 1 : 0);
+    const uint64 k = a.dim_size(trans_a ? 0 : 1);
+    const uint64 n = b.dim_size(trans_b ? 0 : 1);
+
+    DataType dtype = DataTypeToEnum<T>::value;
+    bool allow_tf32 = tensor_float_32_execution_enabled();
+    int device_id = stream->parent()->device_ordinal();
+
+    BatchMatmulParameters matmul_params(trans_a, trans_b, false, false, m, n, k,
+                                        1, false, false, dtype, dtype,
+                                        device_id, epilog_op);
+
+    se::blas::Transpose trans[] = {se::blas::Transpose::kNoTranspose,
+                                   se::blas::Transpose::kTranspose};
+    // The cublasLt views the matrix as column major. Considering A*B=C is
+    // equivalent to B.t*A.t=C.t (.t=transpose), we swap the A and B and view
+    // them in the column major dimensions.
+    se::blas::MatrixDescriptor lhs_matrix = {b_ptr, trans[trans_b ? 1 : 0], n,
+                                             k, n * k};
+    se::blas::MatrixDescriptor rhs_matrix = {a_ptr, trans[trans_a ? 1 : 0], k,
+                                             m, k * m};
+    se::blas::MatrixDescriptor output_matrix = {
+        c_ptr, se::blas::Transpose::kNoTranspose, n, m, n * m};
+    auto plan_and_algorithms_or = se::GetPlanAndAlgorithms(
+        stream, matmul_params, 1, dtype, lhs_matrix, rhs_matrix, output_matrix);
+    OP_REQUIRES_OK(context, plan_and_algorithms_or.status());
+    const auto* plan_and_algorithms =
+        plan_and_algorithms_or.ConsumeValueOrDie();
+
+    const auto& plan = plan_and_algorithms->plan;
+    const auto& algorithms = plan_and_algorithms->algorithms;
+
+    T alpha(1.0);
+    T beta(0.0);
+
+    auto launch_func = [&](BlasScratchAllocator* scratch_allocator,
+                           se::blas::IBlasLtMatmulAlgorithm* algorithm,
+                           se::blas::ProfileResult* profile_result) -> bool {
+      return stream
+          ->ThenBlasLtMatmul(plan.get(), alpha, b_ptr, a_ptr, beta, &c_ptr,
+                             scratch_allocator, algorithm, bias_ptr,
+                             profile_result)
+          .ok();
+    };
+
+    se::blas::AlgorithmConfig algorithm_config =
+        AutotuneMatmul(algorithms, matmul_params, context, launch_func);
+
+    se::blas::AlgorithmType algorithm_idx = algorithm_config.algorithm();
+    const auto& algorithm = algorithms[algorithm_idx];
+    BlasScratchAllocator scratch_allocator(context);
+
+    bool cublaslt_launch_ok =
+        launch_func(&scratch_allocator, algorithm.get(), nullptr);
+    if (!cublaslt_launch_ok) {
+      OP_REQUIRES_OK(context,
+                     errors::Internal("BlasLt Matmul launch failed : a.shape=",
+                                      a.shape().DebugString(),
+                                      ", b.shape=", b.shape().DebugString(),
+                                      ", m=", m, ", n=", n, ", k=", k));
+    }
+  }
+};
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
 template <typename Device, typename T>
 class FusedMatMulOp : public OpKernel {
  public:
@@ -163,11 +394,15 @@ class FusedMatMulOp : public OpKernel {
           {FCT::kBiasAddWithElu, {"BiasAdd", "Elu"}},
           {FCT::kBiasAddWithLeakyRelu, {"BiasAdd", "LeakyRelu"}},
       };
+    } else if (std::is_same<Device, GPUDevice>::value) {
+      patterns = {{FCT::kBiasAdd, {"BiasAdd"}},
+                  {FCT::kBiasAddWithRelu, {"BiasAdd", "Relu"}}};
     }
 
     OP_REQUIRES_OK(context, InitializeFusedComputation(
                                 context, "MatMul", patterns,
                                 &fused_computation_, &fused_computation_args_));
+    use_autotune_ = MatmulAutotuneEnable();
   }
 
   void Compute(OpKernelContext* ctx) override {
@@ -220,12 +455,13 @@ class FusedMatMulOp : public OpKernel {
 
     auto launch = LaunchFusedMatMulOp<Device, T>();
     launch(ctx, a, b, dim_pair, fused_computation_, fused_computation_args_,
-           out);
+           out, use_autotune_);
   }
 
  private:
   bool transpose_a_;
   bool transpose_b_;
+  bool use_autotune_;
 
   FusedComputationType fused_computation_ = FusedComputationType::kUndefined;
   FusedComputationArgs fused_computation_args_;
@@ -242,6 +478,21 @@ class FusedMatMulOp : public OpKernel {
 TF_CALL_float(REGISTER_FUSED_CPU_MATMUL);
 
 #undef REGISTER_FUSED_CPU_MATMUL
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+// Registration of the GPU implementations.
+#define REGISTER_FUSED_GPU_MATMUL(T)                                  \
+  REGISTER_KERNEL_BUILDER(                                            \
+      Name("_FusedMatMul").Device(DEVICE_GPU).TypeConstraint<T>("T"), \
+      FusedMatMulOp<GPUDevice, T>);
+
+TF_CALL_float(REGISTER_FUSED_GPU_MATMUL);
+TF_CALL_half(REGISTER_FUSED_GPU_MATMUL);
+
+#undef REGISTER_FUSED_GPU_MATMUL
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow
 #endif  // TENSORFLOW_CORE_KERNELS_MATMUL_OP_FUSED_H_

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -28,9 +28,9 @@ limitations under the License.
 #define USE_EIGEN_TENSOR
 #define EIGEN_USE_THREADS
 
-#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#if GOOGLE_CUDA
 #define EIGEN_USE_GPU
-#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#endif  // GOOGLE_CUDA
 
 #include <string>
 #include <vector>
@@ -49,17 +49,13 @@ limitations under the License.
 #include "tensorflow/core/kernels/eigen_contraction_kernel.h"
 #endif
 
-#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#if GOOGLE_CUDA
 #include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/kernels/matmul_op_impl.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/platform/tensor_float_32_utils.h"
-
-#if GOOGLE_CUDA
 #include "tensorflow/stream_executor/matmul_util.h"
 #endif  // GOOGLE_CUDA
-
-#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace tensorflow {
 
@@ -482,7 +478,7 @@ TF_CALL_float(REGISTER_FUSED_CPU_MATMUL);
 
 #undef REGISTER_FUSED_CPU_MATMUL
 
-#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#if GOOGLE_CUDA
 
 // Registration of the GPU implementations.
 #define REGISTER_FUSED_GPU_MATMUL(T)                                  \
@@ -495,7 +491,7 @@ TF_CALL_half(REGISTER_FUSED_GPU_MATMUL);
 
 #undef REGISTER_FUSED_GPU_MATMUL
 
-#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#endif  // GOOGLE_CUDA
 
 }  // namespace tensorflow
 #endif  // TENSORFLOW_CORE_KERNELS_MATMUL_OP_FUSED_H_

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -42,6 +42,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/kernels/fill_functor.h"
 #include "tensorflow/core/kernels/fused_eigen_output_kernels.h"
+#include "tensorflow/core/util/matmul_autotune.h"
 #include "tensorflow/core/util/tensor_format.h"
 
 #if defined(TENSORFLOW_USE_CUSTOM_CONTRACTION_KERNEL)
@@ -53,7 +54,6 @@ limitations under the License.
 #include "tensorflow/core/kernels/matmul_op_impl.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/platform/tensor_float_32_utils.h"
-#include "tensorflow/core/util/matmul_autotune.h"
 #include "tensorflow/stream_executor/matmul_util.h"
 #endif  // GOOGLE_CUDA
 

--- a/tensorflow/core/kernels/matmul_op_impl.h
+++ b/tensorflow/core/kernels/matmul_op_impl.h
@@ -285,6 +285,8 @@ se::DeviceMemory<T> AsDeviceMemory(const T* gpu_memory) {
   return typed;
 }
 
+}  // namespace
+
 class BlasScratchAllocator : public se::ScratchAllocator {
  public:
   using Stream = se::Stream;
@@ -317,7 +319,6 @@ class BlasScratchAllocator : public se::ScratchAllocator {
   OpKernelContext* context_;
   std::vector<Tensor> allocated_tensors_;
 };
-}  // namespace
 
 template <typename Scalar>
 struct LaunchBatchMatMul<GPUDevice, Scalar> {

--- a/tensorflow/core/kernels/matmul_op_test.cc
+++ b/tensorflow/core/kernels/matmul_op_test.cc
@@ -224,14 +224,15 @@ class FusedMatMulOpTest : public OpsTestBase {
         [&](const Tensor& input_data, const Tensor& filter_data,
             const Tensor& bias_data, Tensor* out) {
           RunMatMulWithBias(input_data, filter_data, bias_data, transpose_a,
-                            transpose_b, out);
+                            transpose_b, out, /*allow_gpu_device=*/true);
         };
 
     const BiasAddGraphRunner run_fused =
         [&](const Tensor& input_data, const Tensor& filter_data,
             const Tensor& bias_data, Tensor* out) {
           RunFusedMatMulOp(input_data, filter_data, {bias_data}, {"BiasAdd"},
-                           transpose_a, transpose_b, out);
+                           transpose_a, transpose_b, out,
+                           /*allow_gpu_device=*/true);
         };
 
     VerifyBiasAddTensorsNear(m, k, n, run_default, run_fused);
@@ -247,7 +248,8 @@ class FusedMatMulOpTest : public OpsTestBase {
                                                const Tensor& bias_data,
                                                Tensor* out) {
       RunMatMulWithBiasAndActivation(input_data, filter_data, bias_data,
-                                     transpose_a, transpose_b, activation, out);
+                                     transpose_a, transpose_b, activation, out,
+                                     /*allow_gpu_device=*/activation == "Relu");
     };
 
     const BiasAddGraphRunner run_fused = [&](const Tensor& input_data,
@@ -255,7 +257,8 @@ class FusedMatMulOpTest : public OpsTestBase {
                                              const Tensor& bias_data,
                                              Tensor* out) {
       RunFusedMatMulOp(input_data, filter_data, {bias_data},
-                       {"BiasAdd", activation}, transpose_a, transpose_b, out);
+                       {"BiasAdd", activation}, transpose_a, transpose_b, out,
+                       /*allow_gpu_device=*/activation == "Relu");
     };
 
     VerifyBiasAddTensorsNear(m, k, n, run_default, run_fused);

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -984,7 +984,7 @@ REGISTER_OP("_FusedMatMul")
     .Output("product: T")
     .Attr("transpose_a: bool = false")
     .Attr("transpose_b: bool = false")
-    .Attr("T: {bfloat16, float}")
+    .Attr("T: {bfloat16, half, float}")
     .Attr("num_args: int >= 0")
     .Attr("fused_ops: list(string) = []")
     // Attributes for the FusedBatchNorm ----------- //
@@ -1005,7 +1005,7 @@ the output of each fused_op must be of type T.
 Currently supported fused_op combinations are: ["BiasAdd"] and ["BiasAdd",A],
 where A is one of {"Elu","Relu","Relu6"}.
 
-* The first input to BiasAdd is the Conv2D result, and the additional BiasAdd
+* The first input to BiasAdd is the MatMul result, and the additional BiasAdd
 input is specified by `args`.
 * If there is an op A specified, the output of the BiasAdd is the input to op A,
 and op A produces the _FusedConv2D output. Otherwise, the BiasAdd produces the


### PR DESCRIPTION
This PR enables the remapping optimization for fusion patterns of matmal+bias and matmul+bias+relu on GPUs.

This optimization needs to be turned on by `TF_USE_CUBLASLT`.

cc. @nluehr 