### PR TITLE
add tensorrt 8.4 support

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/stub/nvinfer_plugin_stub.cc
+++ b/tensorflow/compiler/tf2tensorrt/stub/nvinfer_plugin_stub.cc
@@ -62,6 +62,8 @@ void LogFatalSymbolNotFound(const char* symbol_name) {
 #include "tensorflow/compiler/tf2tensorrt/stub/NvInferPlugin_8_0.inc"
 #elif NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR == 2
 #include "tensorflow/compiler/tf2tensorrt/stub/NvInferPlugin_8_2.inc"
+#elif NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR == 4
+#include "tensorflow/compiler/tf2tensorrt/stub/NvInferPlugin_8_2.inc"
 #else
 #error This version of TensorRT is not supported.
 #endif

--- a/tensorflow/compiler/tf2tensorrt/stub/nvinfer_stub.cc
+++ b/tensorflow/compiler/tf2tensorrt/stub/nvinfer_stub.cc
@@ -62,6 +62,8 @@ void LogFatalSymbolNotFound(const char* symbol_name) {
 #include "tensorflow/compiler/tf2tensorrt/stub/NvInfer_8_0.inc"
 #elif NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR == 2
 #include "tensorflow/compiler/tf2tensorrt/stub/NvInfer_8_2.inc"
+#elif NV_TENSORRT_MAJOR == 8 && NV_TENSORRT_MINOR == 4
+#include "tensorflow/compiler/tf2tensorrt/stub/NvInfer_8_2.inc"
 #else
 #error This version of TensorRT is not supported.
 #endif


### PR DESCRIPTION
nvidia Jetson JetPack 5.0 includes TensorRT 8.4 [1], which is not
supported now. Use TensorRT 8.2 interface for now.

[1] https://docs.nvidia.com/deeplearning/tensorrt/release-notes/tensorrt-8.html#rel-8-4-0-EA