### PR TITLE
[oneDNN] Fixing a failure in node_file_writer_test

### DIFF
--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -1286,7 +1286,7 @@ Status EagerLocalExecute(EagerOperation* op, TensorHandle** retvals,
   auto status = GetOrCreateKernelAndDevice(op, retvals, num_retvals, &kernel);
 
 #ifdef INTEL_MKL
-  if (IsMKLEnabled() && kernel != nullptr && !ctx.RunEagerOpAsFunction() &&
+  if (IsMKLEnabled() && kernel != nullptr &&
       op->Device() == kVariantDeviceNull) {
     // oneDNN optimization pass relies on the op's assigned device to determine
     // whether it can be rewritten.

--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite.cc
@@ -172,10 +172,6 @@ bool MklEagerOpRewrite::ShouldRewriteOp(EagerOperation* op) {
   if (!IsMKLEnabled()) {
     return false;
   }
-  // Don't rewrite the op if it should run as a function.
-  if (op->EagerContext().RunEagerOpAsFunction()) {
-    return false;
-  }
   DataType data_type;
   if (op->Attrs().Get("T", &data_type) != Status::OK()) {
     return false;


### PR DESCRIPTION
This PR fixes a failure in //tensorflow/python/framework/node_file_writer_test by removing [this workaround ](https://github.com/tensorflow/tensorflow/commit/fdf2cc845fdfbafe0395bf9b389e4a056dea4f84)and setting the op device properly. Test was failing because it expected different op name to be logged (_MklNativeConv2D vs Conv2D) based on whether the op gets rewritten. As this test runs multiple times with and without eager_op_as_function feature, op was not going through the rewrite in the first case.