### PR TITLE
Add a validate_shape argument to `TF_AssignVariable`

### DIFF
--- a/tensorflow/c/kernels_experimental.cc
+++ b/tensorflow/c/kernels_experimental.cc
@@ -177,7 +177,7 @@ void TF_AssignVariable(TF_OpKernelContext* ctx, int input_index,
   tensorflow::mutex_lock ml(*variable->mu());
 
   if (validate_shape) {
-    OP_REQUIRES(ctx,
+    OP_REQUIRES(cc_ctx,
                 (!variable->is_initialized ||
                  variable->tensor()->shape().IsSameSize(value.shape())),
                 InvalidArgument(

--- a/tensorflow/c/kernels_experimental.cc
+++ b/tensorflow/c/kernels_experimental.cc
@@ -159,7 +159,7 @@ tensorflow::mutex* GetTrainingVariableMutex(
 }
 
 void TF_AssignVariable(TF_OpKernelContext* ctx, int input_index,
-                       int value_index,
+                       int value_index, bool validate_shape,
                        void (*copyFunc)(TF_OpKernelContext* ctx,
                                         TF_Tensor* source, TF_Tensor* dest),
                        TF_Status* status) {
@@ -175,6 +175,17 @@ void TF_AssignVariable(TF_OpKernelContext* ctx, int input_index,
                                return tensorflow::Status::OK();
                              }));
   tensorflow::mutex_lock ml(*variable->mu());
+
+  if (validate_shape) {
+    OP_REQUIRES(ctx,
+                (!variable->is_initialized ||
+                 variable->tensor()->shape().IsSameSize(value.shape())),
+                errors::InvalidArgument(
+                    "Trying to assign to variable with tensor with wrong shape."
+                    " Expected ",
+                    variable->tensor()->shape().DebugString(), " got ",
+                    value.shape().DebugString()));
+  }
 
   if (variable->copy_on_read_mode.load()) {
     tensorflow::Tensor tmp;

--- a/tensorflow/c/kernels_experimental.cc
+++ b/tensorflow/c/kernels_experimental.cc
@@ -180,7 +180,7 @@ void TF_AssignVariable(TF_OpKernelContext* ctx, int input_index,
     OP_REQUIRES(ctx,
                 (!variable->is_initialized ||
                  variable->tensor()->shape().IsSameSize(value.shape())),
-                errors::InvalidArgument(
+                InvalidArgument(
                     "Trying to assign to variable with tensor with wrong shape."
                     " Expected ",
                     variable->tensor()->shape().DebugString(), " got ",

--- a/tensorflow/c/kernels_experimental.h
+++ b/tensorflow/c/kernels_experimental.h
@@ -54,9 +54,15 @@ typedef struct TF_VariableInputLockHolder TF_VariableInputLockHolder;
 // the input and value tensors. It also accepts the copy callback provided by
 // pluggable vendor to do the copying of the tensors. The caller takes ownership
 // of the `source` and `dest` tensors and is responsible for freeing them with
-// TF_DeleteTensor.
+// TF_DeleteTensor. This function will return an error when the following
+// conditions are met:
+//   1. `validate_shape` is set to `true`
+//   2. The variable is initialized
+//   3. The shape of the value tensor doesn't match the shape of the variable
+//      tensor.
 TF_CAPI_EXPORT extern void TF_AssignVariable(
     TF_OpKernelContext* ctx, int input_index, int value_index,
+    bool validate_shape,
     void (*copyFunc)(TF_OpKernelContext* ctx, TF_Tensor* source,
                      TF_Tensor* dest),
     TF_Status* status);


### PR DESCRIPTION
The `TF_AssignVariable` function is missing a `validate_shape` argument that is available for native devices. Adding this argument breaks backward compatibility of the API, but this is necessary since C doesn't support function overloads. Since the header is still in an experimental state, I believe now is the right time to add those kind of arguments.