### PR TITLE
Integrating cuBLASLt into TF

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3558,8 +3558,10 @@ tf_kernel_library(
         "//conditions:default": [],
     }) + mkl_deps() + if_cuda([
         "//tensorflow/core/platform/default/build_config:cublas_plugin",
+    ]) + if_cuda_or_rocm([
+        ":gpu_utils",
         "//tensorflow/stream_executor:matmul_util",
-    ]) + if_cuda_or_rocm([":gpu_utils"]),
+    ]),
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/gpu_utils.cc
+++ b/tensorflow/core/kernels/gpu_utils.cc
@@ -95,6 +95,17 @@ void CheckRedzones(const se::RedzoneAllocator& rz_allocator,
   }
 }
 
+bool EnableCublasLtGemm() {
+  static bool enable_cublaslt_gemm = [] {
+    bool cublaslt_gemm = false;
+    TF_CHECK_OK(tensorflow::ReadBoolFromEnvVar("TF_USE_CUBLASLT",
+                                               /*default_val=*/false,
+                                               &cublaslt_gemm));
+    return cublaslt_gemm;
+  }();
+  return enable_cublaslt_gemm;
+}
+
 namespace {
 
 tensorflow::CudnnVersion GetCudnnVersion(se::StreamExecutor* stream_executor) {

--- a/tensorflow/core/kernels/gpu_utils.h
+++ b/tensorflow/core/kernels/gpu_utils.h
@@ -69,6 +69,11 @@ inline se::DeviceMemory<T> AsDeviceMemory(const T* cuda_memory, uint64 size) {
   return typed;
 }
 
+// Returns whether cuBLASLt is enabled.
+//
+// Controlled by the TF_USE_CUBLASLT environment variable.
+bool EnableCublasLtGemm();
+
 // A helper class that looks up the best autotuned config from parameters.
 // Due to the noisy nature of autotune, especially with multiple devices, it
 // only accepts a config if its margin exceeds a threshold.

--- a/tensorflow/core/kernels/matmul_op_impl.h
+++ b/tensorflow/core/kernels/matmul_op_impl.h
@@ -609,7 +609,6 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
               ", k=", k, ", batch_size=", batch_size));
         }
       }
-      return;
     } else {
 #endif
       bool use_strided_batched =
@@ -978,7 +977,6 @@ struct LaunchBatchMatMul<GPUDevice, Eigen::half> {
               ", k=", k, ", batch_size=", batch_size));
         }
       }
-      return;
     } else {
 #endif
       bool use_strided_batched =

--- a/tensorflow/core/kernels/matmul_op_impl.h
+++ b/tensorflow/core/kernels/matmul_op_impl.h
@@ -222,18 +222,6 @@ struct SequentialMatMulKernel {
     }
   }
 };
-
-inline Status FromExecutorStatus(const se::port::Status& s) {
-  return s.ok() ? Status::OK()
-                : Status(static_cast<error::Code>(static_cast<int>(s.code())),
-                         s.error_message());
-}
-
-template <typename T>
-inline Status FromExecutorStatus(const se::port::StatusOr<T>& s) {
-  return FromExecutorStatus(s.status());
-}
-
 }  // namespace
 
 template <typename Device, typename Scalar>
@@ -480,16 +468,14 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
                   << "plan_params.stride_c " << plan_params.stride_c;
           auto status_or_plan =
               stream->parent()->CreateBlasLtMatmulPlan(plan_params);
-          OP_REQUIRES(context, status_or_plan.ok(),
-                      FromExecutorStatus(status_or_plan));
+          OP_REQUIRES_OK(context, status_or_plan.status());
           std::unique_ptr<se::blas::IBlasLtMatmulPlan> plan =
               status_or_plan.ConsumeValueOrDie();
 
           auto status_or_algorithms =
               stream->parent()->GetBlasLtMatmulAlgorithms(
                   plan.get(), max_scratch_size, max_algorithm_count);
-          OP_REQUIRES(context, status_or_algorithms.ok(),
-                      FromExecutorStatus(status_or_algorithms));
+          OP_REQUIRES_OK(context, status_or_algorithms.status());
           auto algorithms = status_or_algorithms.ConsumeValueOrDie();
           plan_and_algorithms =
               se::BatchMatmulPlanMapSingleton::GetInstance()->Insert(
@@ -848,16 +834,14 @@ struct LaunchBatchMatMul<GPUDevice, Eigen::half> {
                   << "plan_params.stride_c " << plan_params.stride_c;
           auto status_or_plan =
               stream->parent()->CreateBlasLtMatmulPlan(plan_params);
-          OP_REQUIRES(context, status_or_plan.ok(),
-                      FromExecutorStatus(status_or_plan));
+          OP_REQUIRES_OK(context, status_or_plan.status());
           std::unique_ptr<se::blas::IBlasLtMatmulPlan> plan =
               status_or_plan.ConsumeValueOrDie();
 
           auto status_or_algorithms =
               stream->parent()->GetBlasLtMatmulAlgorithms(
                   plan.get(), max_scratch_size, max_algorithm_count);
-          OP_REQUIRES(context, status_or_algorithms.ok(),
-                      FromExecutorStatus(status_or_algorithms));
+          OP_REQUIRES_OK(context, status_or_algorithms.status());
           auto algorithms = status_or_algorithms.ConsumeValueOrDie();
           plan_and_algorithms =
               se::BatchMatmulPlanMapSingleton::GetInstance()->Insert(

--- a/tensorflow/core/kernels/matmul_op_impl.h
+++ b/tensorflow/core/kernels/matmul_op_impl.h
@@ -22,8 +22,6 @@ limitations under the License.
 
 #include <vector>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
-#include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -35,16 +33,23 @@ limitations under the License.
 #include "tensorflow/core/lib/gtl/inlined_vector.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/types.h"
+#include "tensorflow/core/util/matmul_autotune.h"
 #include "tensorflow/core/util/matmul_bcast.h"
 #include "tensorflow/core/util/work_sharder.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 #if defined(TENSORFLOW_USE_CUSTOM_CONTRACTION_KERNEL)
 #include "tensorflow/core/kernels/eigen_contraction_kernel.h"
 #endif
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/platform/stream_executor.h"
+#include "tensorflow/stream_executor/matmul_util.h"
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#if GOOGLE_CUDA
+#include "third_party/gpus/cuda/include/cuda.h"
+#endif  // GOOGLE_CUDA
 
 namespace tensorflow {
 
@@ -218,6 +223,17 @@ struct SequentialMatMulKernel {
   }
 };
 
+inline Status FromExecutorStatus(const se::port::Status& s) {
+  return s.ok() ? Status::OK()
+                : Status(static_cast<error::Code>(static_cast<int>(s.code())),
+                         s.error_message());
+}
+
+template <typename T>
+inline Status FromExecutorStatus(const se::port::StatusOr<T>& s) {
+  return FromExecutorStatus(s.status());
+}
+
 }  // namespace
 
 template <typename Device, typename Scalar>
@@ -278,6 +294,15 @@ struct LaunchBatchMatMul<CPUDevice, Scalar> {
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace {
+// A dummy type to group matmul autotune results together.
+struct BatchMatmulAutoTuneGroup {
+  static string name() { return "MatmulLt"; }
+};
+
+typedef AutotuneSingleton<BatchMatmulAutoTuneGroup, se::BatchMatmulParameters,
+                          se::blas::AlgorithmConfig>
+    AutoTuneBatchMatmul;
+
 template <typename T>
 se::DeviceMemory<T> AsDeviceMemory(const T* gpu_memory) {
   se::DeviceMemoryBase wrapped(const_cast<T*>(gpu_memory));
@@ -292,19 +317,33 @@ class BlasScratchAllocator : public se::ScratchAllocator {
   using Stream = se::Stream;
   using DeviceMemoryBytes = se::DeviceMemory<uint8>;
 
-  BlasScratchAllocator(OpKernelContext* context) : context_(context) {}
+  BlasScratchAllocator(OpKernelContext* context)
+      : memory_limit_(0), total_byte_size_(0), context_(context) {}
 
-  int64_t GetMemoryLimitInBytes() override { return -1; }
+  BlasScratchAllocator(OpKernelContext* context, int64_t memory_limit)
+      : memory_limit_(memory_limit), total_byte_size_(0), context_(context) {}
+
+  int64_t GetMemoryLimitInBytes() override { return memory_limit_; }
 
   se::port::StatusOr<DeviceMemoryBytes> AllocateBytes(
       int64_t byte_size) override {
     Tensor temporary_memory;
 
+    if (memory_limit_ > 0 && byte_size > memory_limit_) {
+      return se::port::Status{
+          se::port::error::UNAVAILABLE,
+          absl::StrCat("Requested memory size (", byte_size,
+                       ") exceeds the memory limit (", memory_limit_, ").")};
+    }
+    AllocationAttributes allocation_attr;
+    allocation_attr.retry_on_failure = false;
     Status allocation_status(context_->allocate_temp(
         DT_UINT8, TensorShape({byte_size}), &temporary_memory));
     if (!allocation_status.ok()) {
-      return se::port::StatusOr<DeviceMemoryBytes>(
-          DeviceMemoryBytes::MakeFromByteSize(nullptr, 0));
+      return se::port::Status{
+          se::port::error::UNAVAILABLE,
+          absl::StrCat("Failed to allocate requested memory of (", byte_size,
+                       ").")};
     }
     // Hold the reference of the allocated tensors until the end of the
     // allocator.
@@ -316,6 +355,8 @@ class BlasScratchAllocator : public se::ScratchAllocator {
   }
 
  private:
+  int64_t memory_limit_;
+  int64_t total_byte_size_;
   OpKernelContext* context_;
   std::vector<Tensor> allocated_tensors_;
 };
@@ -325,6 +366,7 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
   static void Launch(OpKernelContext* context, const Tensor& in_x,
                      const Tensor& in_y, bool adj_x, bool adj_y, bool trans_x,
                      bool trans_y, const MatMulBCast& bcast, Tensor* out) {
+    static bool use_autotune = MatmulAutotuneEnable();
     se::blas::Transpose trans[] = {se::blas::Transpose::kNoTranspose,
                                    se::blas::Transpose::kTranspose,
                                    se::blas::Transpose::kConjugateTranspose};
@@ -360,115 +402,328 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
 
     bool is_full_broadcast =
         std::min(bcast.x_batch_size(), bcast.y_batch_size()) == 1;
-    bool use_strided_batched =
-        (!bcast.IsBroadcastingRequired() || is_full_broadcast) &&
-        batch_size > 1;
-    if (use_strided_batched) {
-      a_stride = bcast.x_batch_size() != 1 ? m * k : 0;
-      b_stride = bcast.y_batch_size() != 1 ? k * n : 0;
-      c_stride = m * n;
-      a_device_memory.push_back(AsDeviceMemory(a_base_ptr));
-      b_device_memory.push_back(AsDeviceMemory(b_base_ptr));
-      c_device_memory.push_back(AsDeviceMemory(c_base_ptr));
-      a_ptrs.push_back(&a_device_memory.back());
-      b_ptrs.push_back(&b_device_memory.back());
-      c_ptrs.push_back(&c_device_memory.back());
-    } else if (!bcast.IsBroadcastingRequired()) {
-      for (int64_t i = 0; i < batch_size; ++i) {
-        a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
-        b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
-        c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
+    typedef Scalar Coefficient;
+    // The BlasLtMatmul routines are supported from CUDA 11.0 onward.
+#if GOOGLE_CUDA && CUDA_VERSION >= 11000
+    if (EnableCublasLtGemm()) {
+      static const int64_t max_scratch_size =
+          se::GetWorkspaceLimit(1LL << 32);  // 4GB by default
+
+      bool requires_mixed_broadcasting =
+          bcast.IsBroadcastingRequired() && !is_full_broadcast;
+
+      if (!requires_mixed_broadcasting) {
+        bool broadcast_a = bcast.x_batch_size() == 1;
+        bool broadcast_b = bcast.y_batch_size() == 1;
+        a_stride = broadcast_a ? 0 : m * k;
+        b_stride = broadcast_b ? 0 : k * n;
+        c_stride = m * n;
+        a_device_memory.push_back(AsDeviceMemory(a_base_ptr));
+        b_device_memory.push_back(AsDeviceMemory(b_base_ptr));
+        c_device_memory.push_back(AsDeviceMemory(c_base_ptr));
         a_ptrs.push_back(&a_device_memory.back());
         b_ptrs.push_back(&b_device_memory.back());
         c_ptrs.push_back(&c_device_memory.back());
-      }
-    } else {
-      const std::vector<int64_t>& a_batch_indices = bcast.x_batch_indices();
-      const std::vector<int64_t>& b_batch_indices = bcast.y_batch_indices();
-      for (int64_t i = 0; i < bcast.x_batch_size(); ++i) {
-        a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
-      }
-      for (int64_t i = 0; i < bcast.y_batch_size(); ++i) {
-        b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
-      }
-      for (int64_t i = 0; i < batch_size; ++i) {
-        c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
-        a_ptrs.push_back(&a_device_memory[a_batch_indices[i]]);
-        b_ptrs.push_back(&b_device_memory[b_batch_indices[i]]);
-        c_ptrs.push_back(&c_device_memory.back());
-      }
-    }
 
-    typedef Scalar Coefficient;
+        DataType dtype = DataTypeToEnum<Scalar>::value;
+        int device_id = stream->parent()->device_ordinal();
+        se::BatchMatmulParameters matmul_parameters(
+            trans_x, trans_y, adj_x, adj_y, m, n, k, batch_size, broadcast_a,
+            broadcast_b, dtype, dtype, device_id);
 
-    // Blas does
-    // C = A x B
-    // where A, B and C are assumed to be in column major.
-    // We want the output to be in row-major, so we can compute
-    // C' = B' x A', where ' stands for transpose (not adjoint).
-    // TODO(yangzihao): Choose the best of the three strategies using autotune.
-    if (batch_size == 1) {
-      // This is a regular matrix*matrix or matrix*vector multiply. Avoid the
-      // overhead of the scratch allocator and the batch interface.
-      if (n == 1 &&
-          blas_transpose_b != se::blas::Transpose::kConjugateTranspose &&
-          blas_transpose_a != se::blas::Transpose::kConjugateTranspose) {
-        // This is a matrix*vector multiply so use GEMV to compute A * b.
-        // Here we are multiplying in the natural order, so we have to flip
-        // the transposition flag to compensate for the tensor being stored
-        // row-major. Since GEMV doesn't provide a way to just conjugate an
-        // argument, we have to defer those cases to GEMM below.
-        auto gemv_trans_a = blas_transpose_a == se::blas::Transpose::kTranspose
-                                ? se::blas::Transpose::kNoTranspose
-                                : se::blas::Transpose::kTranspose;
+        static const int64_t max_autotune_algorithm_count =
+            se::MatmulMaxAutotuneAlgorithmCount();
+        int max_algorithm_count =
+            use_autotune ? max_autotune_algorithm_count : 1;
+
+        const se::blas::PlanAndAlgorithms* plan_and_algorithms =
+            se::BatchMatmulPlanMapSingleton::GetInstance()->Find(
+                matmul_parameters);
+
+        if (!plan_and_algorithms) {
+          auto status_or_computation_type = se::GetBlasComputationType(dtype);
+          OP_REQUIRES(
+              context, status_or_computation_type.ok(),
+              errors::Internal("Unsupported dtype for batched matmul."));
+          se::blas::ComputationType computation_type =
+              status_or_computation_type.ConsumeValueOrDie();
+
+          se::blas::BlasLtMatmulPlanParams plan_params;
+          se::blas::DataType blas_dtype = se::blas::ToDataType<Scalar>::value;
+          plan_params.ab_type = blas_dtype;
+          plan_params.c_type = blas_dtype;
+          plan_params.computation_type = computation_type;
+          plan_params.pointer_mode = se::blas::PointerMode::kHost;
+          plan_params.epilogue = se::blas::Epilogue::kDefault;
+          plan_params.transa = blas_transpose_b;
+          plan_params.transb = blas_transpose_a;
+          plan_params.m = n;
+          plan_params.n = m;
+          plan_params.k = k;
+          plan_params.lda = in_y.dim_size(2);
+          plan_params.ldb = in_x.dim_size(2);
+          plan_params.ldc = n;
+          plan_params.batch_count = batch_size;
+          plan_params.stride_a = b_stride;
+          plan_params.stride_b = a_stride;
+          plan_params.stride_c = c_stride;
+
+          VLOG(4) << "plan_params.transa " << (adj_y || trans_y)
+                  << "plan_params.transb " << (adj_x || trans_x)
+                  << "plan_params.m " << plan_params.m << "plan_params.n "
+                  << plan_params.n << "plan_params.k " << plan_params.k
+                  << "plan_params.lda " << plan_params.lda << "plan_params.ldb "
+                  << plan_params.ldb << "plan_params.ldc " << plan_params.ldc
+                  << "plan_params.batch_count " << plan_params.batch_count
+                  << "plan_params.stride_a " << plan_params.stride_a
+                  << "plan_params.stride_b " << plan_params.stride_b
+                  << "plan_params.stride_c " << plan_params.stride_c;
+          auto status_or_plan =
+              stream->parent()->CreateBlasLtMatmulPlan(plan_params);
+          OP_REQUIRES(context, status_or_plan.ok(),
+                      FromExecutorStatus(status_or_plan));
+          std::unique_ptr<se::blas::IBlasLtMatmulPlan> plan =
+              status_or_plan.ConsumeValueOrDie();
+
+          auto status_or_algorithms =
+              stream->parent()->GetBlasLtMatmulAlgorithms(
+                  plan.get(), max_scratch_size, max_algorithm_count);
+          OP_REQUIRES(context, status_or_algorithms.ok(),
+                      FromExecutorStatus(status_or_algorithms));
+          auto algorithms = status_or_algorithms.ConsumeValueOrDie();
+          plan_and_algorithms =
+              se::BatchMatmulPlanMapSingleton::GetInstance()->Insert(
+                  matmul_parameters, {std::move(plan), std::move(algorithms)});
+        }
+        const auto& plan = plan_and_algorithms->plan;
+        const auto& algorithms = plan_and_algorithms->algorithms;
+
+        // The BlasLtMatmul routines (unlike BlasGemm, BlasGemmBatched etc.)
+        // take alpha and beta with the same type as the matrices.
+        Scalar alpha(1.0);
+        Scalar beta(0.0);
+
+        se::blas::AlgorithmConfig algorithm_config(se::blas::kNoAlgorithm);
+        if (max_algorithm_count == 1) {
+          algorithm_config.set_algorithm(0);
+        } else if (!AutoTuneBatchMatmul::GetInstance()->Find(
+                       matmul_parameters, &algorithm_config)) {
+          VLOG(4) << "Autotuning BlasLtMatmul over " << algorithms.size()
+                  << " algorithms.";
+          se::blas::ProfileResult best_result;
+          se::blas::ProfileResult profile_result;
+
+          for (size_t i = 0; i != algorithms.size(); ++i) {
+            const auto& profile_algorithm = algorithms[i];
+            // Create a new scratch allocator with every autotuning run so that
+            // scratch space is deallocated between runs.
+            BlasScratchAllocator scratch_allocator(context, max_scratch_size);
+            bool cublas_launch_status =
+                stream
+                    ->ThenBlasLtMatmul(
+                        plan.get(), alpha, *b_ptrs[0], *a_ptrs[0], beta,
+                        c_ptrs[0], &scratch_allocator, profile_algorithm.get(),
+                        /*bias = */ {}, &profile_result)
+                    .ok();
+
+            VLOG(4) << "  Autotune algorithm " << i
+                    << " result: " << profile_result.elapsed_time_in_ms()
+                    << " ms, valid=" << profile_result.is_valid()
+                    << ", workspace_size="
+                    << profile_algorithm->workspace_size();
+
+            if (cublas_launch_status && profile_result.is_valid() &&
+                profile_result.elapsed_time_in_ms() <
+                    best_result.elapsed_time_in_ms()) {
+              best_result = profile_result;
+            }
+          }
+
+          if (best_result.is_valid()) {
+            algorithm_config.set_algorithm(best_result.algorithm());
+          }
+          // Each matmul parameter set gets one pass of
+          // autotune. If no algorithms works, kNoAlgorithm is added to the
+          // autotune map.
+          AutoTuneBatchMatmul::GetInstance()->Insert(matmul_parameters,
+                                                     algorithm_config);
+        }
+        se::blas::AlgorithmType algorithm_idx = algorithm_config.algorithm();
+        OP_REQUIRES(context,
+                    0 <= algorithm_idx && algorithm_idx < algorithms.size(),
+                    errors::Internal("Missing/invalid BatchMatmul algorithm"));
+        const auto& algorithm = algorithms[algorithm_idx];
+        BlasScratchAllocator scratch_allocator(context, max_scratch_size);
+        VLOG(4) << "Calling BlasLtMatMul: a.shape=(" << bcast.x_batch_size()
+                << ", " << in_x.dim_size(1) << ", " << in_x.dim_size(2)
+                << "), b.shape=(" << bcast.y_batch_size() << ", "
+                << in_y.dim_size(1) << ", " << in_y.dim_size(2) << "), m=" << m
+                << ", n=" << n << ", k=" << k << ", batch_size=" << batch_size
+                << "trans_x = " << trans_x << "trans_y = " << trans_y
+                << "adj_x = " << adj_x << "adj_y = " << adj_y;
+        bool cublas_launch_status =
+            stream
+                ->ThenBlasLtMatmul(plan.get(), alpha, *b_ptrs[0], *a_ptrs[0],
+                                   beta, c_ptrs[0], &scratch_allocator,
+                                   algorithm.get())
+                .ok();
+        if (!cublas_launch_status) {
+          context->SetStatus(errors::Internal(
+              "Blas batched matmul launch failed: a.shape=(",
+              bcast.x_batch_size(), ", ", in_x.dim_size(0), ", ",
+              in_x.dim_size(1), "), b.shape=(", bcast.y_batch_size(), ", ",
+              in_y.dim_size(0), ", ", in_y.dim_size(1), "), m=", m, ", n=", n,
+              ", k=", k, ", batch_size=", batch_size));
+        }
+      } else {  // requires mixed broadcasting
+        const std::vector<int64_t>& a_batch_indices = bcast.x_batch_indices();
+        const std::vector<int64_t>& b_batch_indices = bcast.y_batch_indices();
+        for (int64_t i = 0; i < bcast.x_batch_size(); ++i) {
+          a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
+        }
+        for (int64_t i = 0; i < bcast.y_batch_size(); ++i) {
+          b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
+        }
+        for (int64_t i = 0; i < batch_size; ++i) {
+          c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
+          a_ptrs.push_back(&a_device_memory[a_batch_indices[i]]);
+          b_ptrs.push_back(&b_device_memory[b_batch_indices[i]]);
+          c_ptrs.push_back(&c_device_memory.back());
+        }
+
+        BlasScratchAllocator scratch_allocator(context, max_scratch_size);
         bool blas_launch_status =
             stream
-                ->ThenBlasGemv(gemv_trans_a, adj_x || trans_x ? m : k,
-                               adj_x || trans_x ? k : m,
-                               static_cast<Coefficient>(1.0), *(a_ptrs[0]),
-                               adj_x || trans_x ? m : k, *(b_ptrs[0]), 1,
-                               static_cast<Coefficient>(0.0), c_ptrs[0], 1)
+                ->ThenBlasGemmBatchedWithScratch(
+                    blas_transpose_b, blas_transpose_a, n, m, k,
+                    static_cast<Coefficient>(1.0), b_ptrs,
+                    adj_y || trans_y ? k : n, a_ptrs, adj_x || trans_x ? m : k,
+                    static_cast<Coefficient>(0.0), c_ptrs, n, batch_size,
+                    &scratch_allocator)
                 .ok();
         if (!blas_launch_status) {
           context->SetStatus(errors::Internal(
-              "Blas xGEMV launch failed : a.shape=", in_x.shape().DebugString(),
+              "Blas xGEMMBatched launch failed: a.shape=",
+              in_x.shape().DebugString(),
               ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
-              ", k=", k));
+              ", k=", k, ", batch_size=", batch_size));
+        }
+      }
+      return;
+    } else {
+#endif
+      bool use_strided_batched =
+          (!bcast.IsBroadcastingRequired() || is_full_broadcast) &&
+          batch_size > 1;
+      if (use_strided_batched) {
+        a_stride = bcast.x_batch_size() != 1 ? m * k : 0;
+        b_stride = bcast.y_batch_size() != 1 ? k * n : 0;
+        c_stride = m * n;
+        a_device_memory.push_back(AsDeviceMemory(a_base_ptr));
+        b_device_memory.push_back(AsDeviceMemory(b_base_ptr));
+        c_device_memory.push_back(AsDeviceMemory(c_base_ptr));
+        a_ptrs.push_back(&a_device_memory.back());
+        b_ptrs.push_back(&b_device_memory.back());
+        c_ptrs.push_back(&c_device_memory.back());
+      } else if (!bcast.IsBroadcastingRequired()) {
+        for (int64_t i = 0; i < batch_size; ++i) {
+          a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
+          b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
+          c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
+          a_ptrs.push_back(&a_device_memory.back());
+          b_ptrs.push_back(&b_device_memory.back());
+          c_ptrs.push_back(&c_device_memory.back());
         }
       } else {
-        OP_REQUIRES_OK(context,
-                       stream->ThenBlasGemm(
+        const std::vector<int64_t>& a_batch_indices = bcast.x_batch_indices();
+        const std::vector<int64_t>& b_batch_indices = bcast.y_batch_indices();
+        for (int64_t i = 0; i < bcast.x_batch_size(); ++i) {
+          a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
+        }
+        for (int64_t i = 0; i < bcast.y_batch_size(); ++i) {
+          b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
+        }
+        for (int64_t i = 0; i < batch_size; ++i) {
+          c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
+          a_ptrs.push_back(&a_device_memory[a_batch_indices[i]]);
+          b_ptrs.push_back(&b_device_memory[b_batch_indices[i]]);
+          c_ptrs.push_back(&c_device_memory.back());
+        }
+      }
+
+      // Blas does
+      // C = A x B
+      // where A, B and C are assumed to be in column major.
+      // We want the output to be in row-major, so we can compute
+      // C' = B' x A', where ' stands for transpose (not adjoint).
+      // TODO(yangzihao): Choose the best of the three strategies using
+      // autotune.
+      if (batch_size == 1) {
+        // This is a regular matrix*matrix or matrix*vector multiply. Avoid the
+        // overhead of the scratch allocator and the batch interface.
+        if (n == 1 &&
+            blas_transpose_b != se::blas::Transpose::kConjugateTranspose &&
+            blas_transpose_a != se::blas::Transpose::kConjugateTranspose) {
+          // This is a matrix*vector multiply so use GEMV to compute A * b.
+          // Here we are multiplying in the natural order, so we have to flip
+          // the transposition flag to compensate for the tensor being stored
+          // row-major. Since GEMV doesn't provide a way to just conjugate an
+          // argument, we have to defer those cases to GEMM below.
+          auto gemv_trans_a =
+              blas_transpose_a == se::blas::Transpose::kTranspose
+                  ? se::blas::Transpose::kNoTranspose
+                  : se::blas::Transpose::kTranspose;
+          bool blas_launch_status =
+              stream
+                  ->ThenBlasGemv(gemv_trans_a, adj_x || trans_x ? m : k,
+                                 adj_x || trans_x ? k : m,
+                                 static_cast<Coefficient>(1.0), *(a_ptrs[0]),
+                                 adj_x || trans_x ? m : k, *(b_ptrs[0]), 1,
+                                 static_cast<Coefficient>(0.0), c_ptrs[0], 1)
+                  .ok();
+          if (!blas_launch_status) {
+            context->SetStatus(errors::Internal(
+                "Blas xGEMV launch failed : a.shape=",
+                in_x.shape().DebugString(), ", b.shape=",
+                in_y.shape().DebugString(), ", m=", m, ", n=", n, ", k=", k));
+          }
+        } else {
+          OP_REQUIRES_OK(
+              context, stream->ThenBlasGemm(
                            blas_transpose_b, blas_transpose_a, n, m, k,
                            *(b_ptrs[0]), adj_y || trans_y ? k : n, *(a_ptrs[0]),
                            adj_x || trans_x ? m : k, c_ptrs[0], n));
+        }
+      } else if (use_strided_batched) {
+        OP_REQUIRES_OK(context, stream->ThenBlasGemmStridedBatched(
+                                    blas_transpose_b, blas_transpose_a, n, m, k,
+                                    static_cast<Coefficient>(1.0), *b_ptrs[0],
+                                    adj_y || trans_y ? k : n, b_stride,
+                                    *a_ptrs[0], adj_x || trans_x ? m : k,
+                                    a_stride, static_cast<Coefficient>(0.0),
+                                    c_ptrs[0], n, c_stride, batch_size));
+      } else {
+        BlasScratchAllocator scratch_allocator(context);
+        bool blas_launch_status =
+            stream
+                ->ThenBlasGemmBatchedWithScratch(
+                    blas_transpose_b, blas_transpose_a, n, m, k,
+                    static_cast<Coefficient>(1.0), b_ptrs,
+                    adj_y || trans_y ? k : n, a_ptrs, adj_x || trans_x ? m : k,
+                    static_cast<Coefficient>(0.0), c_ptrs, n, batch_size,
+                    &scratch_allocator)
+                .ok();
+        if (!blas_launch_status) {
+          context->SetStatus(errors::Internal(
+              "Blas xGEMMBatched launch failed : a.shape=",
+              in_x.shape().DebugString(),
+              ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
+              ", k=", k, ", batch_size=", batch_size));
+        }
       }
-    } else if (use_strided_batched) {
-      OP_REQUIRES_OK(context, stream->ThenBlasGemmStridedBatched(
-                                  blas_transpose_b, blas_transpose_a, n, m, k,
-                                  static_cast<Coefficient>(1.0), *b_ptrs[0],
-                                  adj_y || trans_y ? k : n, b_stride,
-                                  *a_ptrs[0], adj_x || trans_x ? m : k,
-                                  a_stride, static_cast<Coefficient>(0.0),
-                                  c_ptrs[0], n, c_stride, batch_size));
-    } else {
-      BlasScratchAllocator scratch_allocator(context);
-      bool blas_launch_status =
-          stream
-              ->ThenBlasGemmBatchedWithScratch(
-                  blas_transpose_b, blas_transpose_a, n, m, k,
-                  static_cast<Coefficient>(1.0), b_ptrs,
-                  adj_y || trans_y ? k : n, a_ptrs, adj_x || trans_x ? m : k,
-                  static_cast<Coefficient>(0.0), c_ptrs, n, batch_size,
-                  &scratch_allocator)
-              .ok();
-      if (!blas_launch_status) {
-        context->SetStatus(errors::Internal(
-            "Blas xGEMMBatched launch failed : a.shape=",
-            in_x.shape().DebugString(),
-            ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
-            ", k=", k, ", batch_size=", batch_size));
-      }
+#if GOOGLE_CUDA && CUDA_VERSION >= 11000
     }
+#endif  //  GOOGLE_CUDA && CUDA_VERSION < 11000
   }
 };
 
@@ -477,6 +732,7 @@ struct LaunchBatchMatMul<GPUDevice, Eigen::half> {
   static void Launch(OpKernelContext* context, const Tensor& in_x,
                      const Tensor& in_y, bool adj_x, bool adj_y, bool trans_x,
                      bool trans_y, const MatMulBCast& bcast, Tensor* out) {
+    static bool use_autotune = MatmulAutotuneEnable();
     typedef Eigen::half Scalar;
     se::blas::Transpose trans[] = {se::blas::Transpose::kNoTranspose,
                                    se::blas::Transpose::kTranspose,
@@ -514,99 +770,312 @@ struct LaunchBatchMatMul<GPUDevice, Eigen::half> {
 
     bool is_full_broadcast =
         std::min(bcast.x_batch_size(), bcast.y_batch_size()) == 1;
-    bool use_strided_batched =
-        (!bcast.IsBroadcastingRequired() || is_full_broadcast) &&
-        batch_size > 1;
-    if (use_strided_batched) {
-      a_stride = bcast.x_batch_size() != 1 ? m * k : 0;
-      b_stride = bcast.y_batch_size() != 1 ? k * n : 0;
-      c_stride = m * n;
-      a_device_memory.push_back(AsDeviceMemory(a_base_ptr));
-      b_device_memory.push_back(AsDeviceMemory(b_base_ptr));
-      c_device_memory.push_back(AsDeviceMemory(c_base_ptr));
-      a_ptrs.push_back(&a_device_memory.back());
-      b_ptrs.push_back(&b_device_memory.back());
-      c_ptrs.push_back(&c_device_memory.back());
-    } else if (!bcast.IsBroadcastingRequired()) {
-      for (int64_t i = 0; i < batch_size; ++i) {
-        a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
-        b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
-        c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
+    typedef float Coefficient;
+
+    // The BlasLtMatmul routines are supported from CUDA 11.0 onward.
+#if GOOGLE_CUDA && CUDA_VERSION >= 11000
+    if (EnableCublasLtGemm()) {
+      static const int64_t max_scratch_size =
+          se::GetWorkspaceLimit(1LL << 32);  // 4GB by default
+
+      bool requires_mixed_broadcasting =
+          bcast.IsBroadcastingRequired() && !is_full_broadcast;
+
+      if (!requires_mixed_broadcasting) {
+        bool broadcast_a = bcast.x_batch_size() == 1;
+        bool broadcast_b = bcast.y_batch_size() == 1;
+        a_stride = broadcast_a ? 0 : m * k;
+        b_stride = broadcast_b ? 0 : k * n;
+        c_stride = m * n;
+        a_device_memory.push_back(AsDeviceMemory(a_base_ptr));
+        b_device_memory.push_back(AsDeviceMemory(b_base_ptr));
+        c_device_memory.push_back(AsDeviceMemory(c_base_ptr));
         a_ptrs.push_back(&a_device_memory.back());
         b_ptrs.push_back(&b_device_memory.back());
         c_ptrs.push_back(&c_device_memory.back());
+
+        DataType dtype = DataTypeToEnum<Scalar>::value;
+        int device_id = stream->parent()->device_ordinal();
+        se::BatchMatmulParameters matmul_parameters(
+            trans_x, trans_y, adj_x, adj_y, m, n, k, batch_size, broadcast_a,
+            broadcast_b, dtype, dtype, device_id);
+
+        static const int64_t max_autotune_algorithm_count =
+            se::MatmulMaxAutotuneAlgorithmCount();
+        int max_algorithm_count =
+            use_autotune ? max_autotune_algorithm_count : 1;
+
+        const se::blas::PlanAndAlgorithms* plan_and_algorithms =
+            se::BatchMatmulPlanMapSingleton::GetInstance()->Find(
+                matmul_parameters);
+
+        if (!plan_and_algorithms) {
+          auto status_or_computation_type = se::GetBlasComputationType(dtype);
+          OP_REQUIRES(
+              context, status_or_computation_type.ok(),
+              errors::Internal("Unsupported dtype for batched matmul."));
+          se::blas::ComputationType computation_type =
+              status_or_computation_type.ConsumeValueOrDie();
+
+          se::blas::BlasLtMatmulPlanParams plan_params;
+          se::blas::DataType blas_dtype = se::blas::ToDataType<Scalar>::value;
+          plan_params.ab_type = blas_dtype;
+          plan_params.c_type = blas_dtype;
+          plan_params.computation_type = computation_type;
+          plan_params.pointer_mode = se::blas::PointerMode::kHost;
+          plan_params.epilogue = se::blas::Epilogue::kDefault;
+          plan_params.transa = blas_transpose_b;
+          plan_params.transb = blas_transpose_a;
+          plan_params.m = n;
+          plan_params.n = m;
+          plan_params.k = k;
+          plan_params.lda = in_y.dim_size(2);
+          plan_params.ldb = in_x.dim_size(2);
+          plan_params.ldc = n;
+          plan_params.batch_count = batch_size;
+          plan_params.stride_a = b_stride;
+          plan_params.stride_b = a_stride;
+          plan_params.stride_c = c_stride;
+
+          VLOG(4) << "plan_params.transa " << (adj_y || trans_y)
+                  << "plan_params.transb " << (adj_x || trans_x)
+                  << "plan_params.m " << plan_params.m << "plan_params.n "
+                  << plan_params.n << "plan_params.k " << plan_params.k
+                  << "plan_params.lda " << plan_params.lda << "plan_params.ldb "
+                  << plan_params.ldb << "plan_params.ldc " << plan_params.ldc
+                  << "plan_params.batch_count " << plan_params.batch_count
+                  << "plan_params.stride_a " << plan_params.stride_a
+                  << "plan_params.stride_b " << plan_params.stride_b
+                  << "plan_params.stride_c " << plan_params.stride_c;
+          auto status_or_plan =
+              stream->parent()->CreateBlasLtMatmulPlan(plan_params);
+          OP_REQUIRES(context, status_or_plan.ok(),
+                      FromExecutorStatus(status_or_plan));
+          std::unique_ptr<se::blas::IBlasLtMatmulPlan> plan =
+              status_or_plan.ConsumeValueOrDie();
+
+          auto status_or_algorithms =
+              stream->parent()->GetBlasLtMatmulAlgorithms(
+                  plan.get(), max_scratch_size, max_algorithm_count);
+          OP_REQUIRES(context, status_or_algorithms.ok(),
+                      FromExecutorStatus(status_or_algorithms));
+          auto algorithms = status_or_algorithms.ConsumeValueOrDie();
+          plan_and_algorithms =
+              se::BatchMatmulPlanMapSingleton::GetInstance()->Insert(
+                  matmul_parameters, {std::move(plan), std::move(algorithms)});
+        }
+        const auto& plan = plan_and_algorithms->plan;
+        const auto& algorithms = plan_and_algorithms->algorithms;
+
+        // The BlasLtMatmul routines (unlike BlasGemm, BlasGemmBatched etc.)
+        // take alpha and beta with the same type as the matrices.
+        Scalar alpha(1.0);
+        Scalar beta(0.0);
+
+        se::blas::AlgorithmConfig algorithm_config(se::blas::kNoAlgorithm);
+        if (max_algorithm_count == 1) {
+          algorithm_config.set_algorithm(0);
+        } else if (!AutoTuneBatchMatmul::GetInstance()->Find(
+                       matmul_parameters, &algorithm_config)) {
+          VLOG(4) << "Autotuning BlasLtMatmul over " << algorithms.size()
+                  << " algorithms.";
+          se::blas::ProfileResult best_result;
+          se::blas::ProfileResult profile_result;
+
+          for (size_t i = 0; i != algorithms.size(); ++i) {
+            const auto& profile_algorithm = algorithms[i];
+            // Create a new scratch allocator with every autotuning run so that
+            // scratch space is deallocated between runs.
+            BlasScratchAllocator scratch_allocator(context, max_scratch_size);
+            bool cublas_launch_status =
+                stream
+                    ->ThenBlasLtMatmul(
+                        plan.get(), alpha, *b_ptrs[0], *a_ptrs[0], beta,
+                        c_ptrs[0], &scratch_allocator, profile_algorithm.get(),
+                        /*bias = */ {}, &profile_result)
+                    .ok();
+
+            VLOG(4) << "  Autotune algorithm " << i
+                    << " result: " << profile_result.elapsed_time_in_ms()
+                    << " ms, valid=" << profile_result.is_valid()
+                    << ", workspace_size="
+                    << profile_algorithm->workspace_size();
+
+            if (cublas_launch_status && profile_result.is_valid() &&
+                profile_result.elapsed_time_in_ms() <
+                    best_result.elapsed_time_in_ms()) {
+              best_result = profile_result;
+            }
+          }
+
+          if (best_result.is_valid()) {
+            algorithm_config.set_algorithm(best_result.algorithm());
+          }
+          // Each matmul parameter set gets one pass of
+          // autotune. If no algorithms works, kNoAlgorithm is added to the
+          // autotune map.
+          AutoTuneBatchMatmul::GetInstance()->Insert(matmul_parameters,
+                                                     algorithm_config);
+        }
+        se::blas::AlgorithmType algorithm_idx = algorithm_config.algorithm();
+        OP_REQUIRES(context,
+                    0 <= algorithm_idx && algorithm_idx < algorithms.size(),
+                    errors::Internal("Missing/invalid BatchMatmul algorithm"));
+        const auto& algorithm = algorithms[algorithm_idx];
+        BlasScratchAllocator scratch_allocator(context, max_scratch_size);
+        VLOG(4) << "Calling BlasLtMatMul: a.shape=(" << bcast.x_batch_size()
+                << ", " << in_x.dim_size(1) << ", " << in_x.dim_size(2)
+                << "), b.shape=(" << bcast.y_batch_size() << ", "
+                << in_y.dim_size(1) << ", " << in_y.dim_size(2) << "), m=" << m
+                << ", n=" << n << ", k=" << k << ", batch_size=" << batch_size
+                << "trans_x = " << trans_x << "trans_y = " << trans_y
+                << "adj_x = " << adj_x << "adj_y = " << adj_y;
+        bool cublas_launch_status =
+            stream
+                ->ThenBlasLtMatmul(plan.get(), alpha, *b_ptrs[0], *a_ptrs[0],
+                                   beta, c_ptrs[0], &scratch_allocator,
+                                   algorithm.get())
+                .ok();
+        if (!cublas_launch_status) {
+          context->SetStatus(errors::Internal(
+              "Blas batched matmul launch failed: a.shape=(",
+              bcast.x_batch_size(), ", ", in_x.dim_size(0), ", ",
+              in_x.dim_size(1), "), b.shape=(", bcast.y_batch_size(), ", ",
+              in_y.dim_size(0), ", ", in_y.dim_size(1), "), m=", m, ", n=", n,
+              ", k=", k, ", batch_size=", batch_size));
+        }
+      } else {  // requires mixed broadcasting
+        const std::vector<int64_t>& a_batch_indices = bcast.x_batch_indices();
+        const std::vector<int64_t>& b_batch_indices = bcast.y_batch_indices();
+        for (int64_t i = 0; i < bcast.x_batch_size(); ++i) {
+          a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
+        }
+        for (int64_t i = 0; i < bcast.y_batch_size(); ++i) {
+          b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
+        }
+        for (int64_t i = 0; i < batch_size; ++i) {
+          c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
+          a_ptrs.push_back(&a_device_memory[a_batch_indices[i]]);
+          b_ptrs.push_back(&b_device_memory[b_batch_indices[i]]);
+          c_ptrs.push_back(&c_device_memory.back());
+        }
+
+        BlasScratchAllocator scratch_allocator(context, max_scratch_size);
+        bool blas_launch_status =
+            stream
+                ->ThenBlasGemmBatchedWithScratch(
+                    blas_transpose_b, blas_transpose_a, n, m, k,
+                    static_cast<Coefficient>(1.0), b_ptrs,
+                    adj_y || trans_y ? k : n, a_ptrs, adj_x || trans_x ? m : k,
+                    static_cast<Coefficient>(0.0), c_ptrs, n, batch_size,
+                    &scratch_allocator)
+                .ok();
+        if (!blas_launch_status) {
+          context->SetStatus(errors::Internal(
+              "Blas xGEMMBatched launch failed: a.shape=",
+              in_x.shape().DebugString(),
+              ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
+              ", k=", k, ", batch_size=", batch_size));
+        }
       }
+      return;
     } else {
-      const std::vector<int64_t>& a_batch_indices = bcast.x_batch_indices();
-      const std::vector<int64_t>& b_batch_indices = bcast.y_batch_indices();
-      for (int64_t i = 0; i < bcast.x_batch_size(); ++i) {
-        a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
-      }
-      for (int64_t i = 0; i < bcast.y_batch_size(); ++i) {
-        b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
-      }
-      for (int64_t i = 0; i < batch_size; ++i) {
-        c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
-        a_ptrs.push_back(&a_device_memory[a_batch_indices[i]]);
-        b_ptrs.push_back(&b_device_memory[b_batch_indices[i]]);
+#endif
+      bool use_strided_batched =
+          (!bcast.IsBroadcastingRequired() || is_full_broadcast) &&
+          batch_size > 1;
+      if (use_strided_batched) {
+        a_stride = bcast.x_batch_size() != 1 ? m * k : 0;
+        b_stride = bcast.y_batch_size() != 1 ? k * n : 0;
+        c_stride = m * n;
+        a_device_memory.push_back(AsDeviceMemory(a_base_ptr));
+        b_device_memory.push_back(AsDeviceMemory(b_base_ptr));
+        c_device_memory.push_back(AsDeviceMemory(c_base_ptr));
+        a_ptrs.push_back(&a_device_memory.back());
+        b_ptrs.push_back(&b_device_memory.back());
         c_ptrs.push_back(&c_device_memory.back());
+      } else if (!bcast.IsBroadcastingRequired()) {
+        for (int64_t i = 0; i < batch_size; ++i) {
+          a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
+          b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
+          c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
+          a_ptrs.push_back(&a_device_memory.back());
+          b_ptrs.push_back(&b_device_memory.back());
+          c_ptrs.push_back(&c_device_memory.back());
+        }
+      } else {
+        const std::vector<int64_t>& a_batch_indices = bcast.x_batch_indices();
+        const std::vector<int64_t>& b_batch_indices = bcast.y_batch_indices();
+        for (int64_t i = 0; i < bcast.x_batch_size(); ++i) {
+          a_device_memory.push_back(AsDeviceMemory(a_base_ptr + i * m * k));
+        }
+        for (int64_t i = 0; i < bcast.y_batch_size(); ++i) {
+          b_device_memory.push_back(AsDeviceMemory(b_base_ptr + i * k * n));
+        }
+        for (int64_t i = 0; i < batch_size; ++i) {
+          c_device_memory.push_back(AsDeviceMemory(c_base_ptr + i * m * n));
+          a_ptrs.push_back(&a_device_memory[a_batch_indices[i]]);
+          b_ptrs.push_back(&b_device_memory[b_batch_indices[i]]);
+          c_ptrs.push_back(&c_device_memory.back());
+        }
       }
-    }
 
-    typedef float Coefficient;
-
-    // Blas does
-    // C = A x B
-    // where A, B and C are assumed to be in column major.
-    // We want the output to be in row-major, so we can compute
-    // C' = B' x A', where ' stands for transpose (not adjoint).
-    // TODO(yangzihao): Choose the best of the three strategies using autotune.
-    if (batch_size == 1) {
-      // This is a regular matrix*matrix or matrix*vector multiply. Avoid the
-      // overhead of the scratch allocator and the batch interface.
-      // TODO(benbarsdell): Use fp16 Gemv if it becomes supported by CUBLAS
-      OP_REQUIRES_OK(context,
-                     stream->ThenBlasGemm(
-                         blas_transpose_b, blas_transpose_a, n, m, k,
-                         *(b_ptrs[0]), adj_y || trans_y ? k : n, *(a_ptrs[0]),
-                         adj_x || trans_x ? m : k, c_ptrs[0], n));
-    } else if (use_strided_batched) {
-      bool blas_launch_status =
-          stream
-              ->ThenBlasGemmStridedBatched(
-                  blas_transpose_b, blas_transpose_a, n, m, k,
-                  static_cast<Coefficient>(1.0), *b_ptrs[0],
-                  adj_y || trans_y ? k : n, b_stride, *a_ptrs[0],
-                  adj_x || trans_x ? m : k, a_stride,
-                  static_cast<Coefficient>(0.0), c_ptrs[0], n, c_stride,
-                  batch_size)
-              .ok();
-      if (!blas_launch_status) {
-        context->SetStatus(errors::Internal(
-            "Blas xGEMMStridedBatched launch failed : a.shape=",
-            in_x.shape().DebugString(),
-            ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
-            ", k=", k, ", batch_size=", batch_size));
+      // Blas does
+      // C = A x B
+      // where A, B and C are assumed to be in column major.
+      // We want the output to be in row-major, so we can compute
+      // C' = B' x A', where ' stands for transpose (not adjoint).
+      // TODO(yangzihao): Choose the best of the three strategies using
+      // autotune.
+      if (batch_size == 1) {
+        // This is a regular matrix*matrix or matrix*vector multiply. Avoid the
+        // overhead of the scratch allocator and the batch interface.
+        // TODO(benbarsdell): Use fp16 Gemv if it becomes supported by CUBLAS
+        OP_REQUIRES_OK(context,
+                       stream->ThenBlasGemm(
+                           blas_transpose_b, blas_transpose_a, n, m, k,
+                           *(b_ptrs[0]), adj_y || trans_y ? k : n, *(a_ptrs[0]),
+                           adj_x || trans_x ? m : k, c_ptrs[0], n));
+      } else if (use_strided_batched) {
+        bool blas_launch_status =
+            stream
+                ->ThenBlasGemmStridedBatched(
+                    blas_transpose_b, blas_transpose_a, n, m, k,
+                    static_cast<Coefficient>(1.0), *b_ptrs[0],
+                    adj_y || trans_y ? k : n, b_stride, *a_ptrs[0],
+                    adj_x || trans_x ? m : k, a_stride,
+                    static_cast<Coefficient>(0.0), c_ptrs[0], n, c_stride,
+                    batch_size)
+                .ok();
+        if (!blas_launch_status) {
+          context->SetStatus(errors::Internal(
+              "Blas xGEMMStridedBatched launch failed: a.shape=",
+              in_x.shape().DebugString(),
+              ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
+              ", k=", k, ", batch_size=", batch_size));
+        }
+      } else {
+        BlasScratchAllocator scratch_allocator(context);
+        bool blas_launch_status =
+            stream
+                ->ThenBlasGemmBatchedWithScratch(
+                    blas_transpose_b, blas_transpose_a, n, m, k,
+                    static_cast<Coefficient>(1.0), b_ptrs,
+                    adj_y || trans_y ? k : n, a_ptrs, adj_x || trans_x ? m : k,
+                    static_cast<Coefficient>(0.0), c_ptrs, n, batch_size,
+                    &scratch_allocator)
+                .ok();
+        if (!blas_launch_status) {
+          context->SetStatus(errors::Internal(
+              "Blas xGEMMBatched launch failed: a.shape=",
+              in_x.shape().DebugString(),
+              ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
+              ", k=", k, ", batch_size=", batch_size));
+        }
       }
-    } else {
-      BlasScratchAllocator scratch_allocator(context);
-      bool blas_launch_status =
-          stream
-              ->ThenBlasGemmBatchedWithScratch(
-                  blas_transpose_b, blas_transpose_a, n, m, k,
-                  static_cast<Coefficient>(1.0), b_ptrs,
-                  adj_y || trans_y ? k : n, a_ptrs, adj_x || trans_x ? m : k,
-                  static_cast<Coefficient>(0.0), c_ptrs, n, batch_size,
-                  &scratch_allocator)
-              .ok();
-      if (!blas_launch_status) {
-        context->SetStatus(errors::Internal(
-            "Blas xGEMMBatched launch failed : a.shape=",
-            in_x.shape().DebugString(),
-            ", b.shape=", in_y.shape().DebugString(), ", m=", m, ", n=", n,
-            ", k=", k, ", batch_size=", batch_size));
-      }
+#if GOOGLE_CUDA && CUDA_VERSION >= 11000
     }
+#endif  //  GOOGLE_CUDA && CUDA_VERSION < 11000
   }
 };
 

--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -67,6 +67,7 @@ tf_mkl_kernel_library(
     deps = [
         "//tensorflow/core/kernels:batch_matmul_op",
         "//tensorflow/core/kernels:matmul_op",
+        "//tensorflow/stream_executor:matmul_util",
     ] + MKL_DEPS,
 )
 

--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -78,7 +78,10 @@ tf_mkl_kernel_library(
         "mkl_batch_matmul_helper.h",
         "mkl_matmul_ops_common.h",
     ],
-    deps = ["//tensorflow/core/kernels/linalg:einsum_op"] + MKL_DEPS,
+    deps = [
+        "//tensorflow/core/kernels/linalg:einsum_op",
+        "//tensorflow/stream_executor:matmul_util",
+    ] + MKL_DEPS,
 )
 
 tf_mkl_kernel_library(
@@ -88,7 +91,9 @@ tf_mkl_kernel_library(
         "mkl_matmul_op_fused.cc",
     ],
     hdrs = ["mkl_matmul_ops_common.h"],
-    deps = MKL_DEPS,
+    deps = [
+        "//tensorflow/stream_executor:matmul_util",
+    ] + MKL_DEPS,
 )
 
 tf_cc_test_mkl(

--- a/tensorflow/stream_executor/matmul_util.cc
+++ b/tensorflow/stream_executor/matmul_util.cc
@@ -70,11 +70,12 @@ static inline port::StatusOr<blas::DataType> GetBlasDataType(
   }
 }
 
-static inline port::StatusOr<blas::ComputationType> GetBlasComputationType(
-    const tensorflow::DataType& dtype, bool allow_tf32) {
+port::StatusOr<blas::ComputationType> GetBlasComputationType(
+    const tensorflow::DataType& dtype) {
   using blas::ComputationType;
   static bool use_f32_for_f16_computation =
       tensorflow::MatmulDoFP32ComputationFP16Input();
+  bool allow_tf32 = tensorflow::tensor_float_32_execution_enabled();
   ComputationType f32_type =
       allow_tf32 ? ComputationType::kTF32AsF32 : ComputationType::kF32;
   switch (dtype) {
@@ -135,9 +136,8 @@ port::StatusOr<blas::BlasLtMatmulPlanParams> CreatePlanParams(
   TF_ASSIGN_OR_RETURN(blas::DataType blas_dtype, GetBlasDataType(dtype));
   plan_params.ab_type = blas_dtype;
   plan_params.c_type = blas_dtype;
-  bool allow_tf32 = tensorflow::tensor_float_32_execution_enabled();
   TF_ASSIGN_OR_RETURN(blas::ComputationType computation_type,
-                      GetBlasComputationType(dtype, allow_tf32));
+                      GetBlasComputationType(dtype));
 
   plan_params.computation_type = computation_type;
 

--- a/tensorflow/stream_executor/matmul_util.h
+++ b/tensorflow/stream_executor/matmul_util.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/lib/strings/str_util.h"
+#include "tensorflow/core/platform/hash.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/platform/tensor_float_32_utils.h"
 #include "tensorflow/core/util/matmul_autotune.h"
@@ -48,9 +49,9 @@ int64_t GetWorkspaceLimit(int64_t default_value_in_bytes);
 class BatchMatmulParameters {
  public:
   BatchMatmulParameters(bool trans_a, bool trans_b, bool adj_a, bool adj_b,
-                        uint64 m, uint64 n, uint64 k, uint64 batch_count,
-                        bool broadcast_a, bool broadcast_b,
-                        tensorflow::DataType dtype_ab,
+                        uint64_t m, uint64_t n, uint64_t k,
+                        uint64_t batch_count, bool broadcast_a,
+                        bool broadcast_b, tensorflow::DataType dtype_ab,
                         tensorflow::DataType dtype_cd, int device_id,
                         blas::Epilogue epilog = blas::Epilogue::kDefault)
       : trans_a_(trans_a),
@@ -68,6 +69,20 @@ class BatchMatmulParameters {
         device_id_(device_id),
         epilog_(epilog) {
     allow_tf32_ = tensorflow::tensor_float_32_execution_enabled();
+    hash_code_ = trans_a;
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, trans_b);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, adj_a);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, adj_b);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, m);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, n);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, k);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, batch_count);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, broadcast_a);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, broadcast_b);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, dtype_ab);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, dtype_cd);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, allow_tf32_);
+    hash_code_ = tensorflow::Hash64Combine(hash_code_, device_id);
   }
 
   bool operator==(const BatchMatmulParameters& other) const {
@@ -77,6 +92,7 @@ class BatchMatmulParameters {
   bool operator!=(const BatchMatmulParameters& other) const {
     return !(*this == other);
   }
+  uint64_t hash() const { return hash_code_; }
 
   std::string ToString() const {
     // clang-format off
@@ -116,10 +132,10 @@ class BatchMatmulParameters {
   bool trans_b_;
   bool adj_a_;
   bool adj_b_;
-  uint64 m_;
-  uint64 n_;
-  uint64 k_;
-  uint64 batch_count_;
+  uint64_t m_;
+  uint64_t n_;
+  uint64_t k_;
+  uint64_t batch_count_;
   bool broadcast_a_;
   bool broadcast_b_;
   tensorflow::DataType dtype_ab_;
@@ -127,6 +143,7 @@ class BatchMatmulParameters {
   bool allow_tf32_;
   int device_id_;
   blas::Epilogue epilog_;
+  uint64_t hash_code_;
 };
 
 // Thread-safe map from matmul parameters to their corresponding plan and
@@ -161,6 +178,9 @@ struct BatchMatmulPlanMapSingleton {
   }
 };
 
+port::StatusOr<blas::ComputationType> GetBlasComputationType(
+    const tensorflow::DataType& dtype);
+
 port::StatusOr<const blas::PlanAndAlgorithms*> GetPlanAndAlgorithms(
     Stream* stream, BatchMatmulParameters matmul_parameters, int64_t batch_size,
     tensorflow::DataType dtype, blas::MatrixDescriptor lhs_matrix,
@@ -171,6 +191,7 @@ port::StatusOr<blas::BlasLtMatmulPlanParams> CreatePlanParams(
     blas::MatrixDescriptor lhs_matrix, blas::MatrixDescriptor rhs_matrix,
     blas::MatrixDescriptor output_matrix);
 
-#endif  // TENSORFLOW_STREAM_EXECUTOR_MATMUL_UTIL_H_
 
 }  // namespace stream_executor
+
+#endif  // TENSORFLOW_STREAM_EXECUTOR_MATMUL_UTIL_H_


### PR DESCRIPTION
Adds support for the cuBLASLt library for GEMM operations to TF native. The library can be activated by setting the environment variable `TF_USE_CUBLASLT=1`.

Continuation of PR #55518 which integrated cuBLASLt into XLA.