### PR TITLE
[oneDNN] Blocking MatMul+Add(bias) fusion until it is properly tested

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -537,16 +537,35 @@ bool IsBiasSemanticAdd(const RemapperContext& ctx,
     return true;
   };
 
+  // This is used only for MatMul+Add fusion.
+  const auto is_matmul_supported_shape =
+      [](const TensorShapeProto& shape,
+         const TensorShapeProto& bcast_shape) -> bool {
+    if (shape.dim_size() < 2 || bcast_shape.dim_size() != 1) return false;
+    int channel_dim = shape.dim(shape.dim_size() - 1).size();
+    return (channel_dim == bcast_shape.dim(0).size());
+  };
+
   if (ShapesSymbolicallyEqual(prot0_shape, prot1_shape) ||
       !ShapesBroadcastable(prot0_shape, prot1_shape))
     return false;
 
+  // For now block MatMul+Add fusion if Bias dims are more than one.
+  // TODO(intel-tf): Enable this fusion once it is properly tested.
   if (IsConvOrMatMul(*node_def_0)) {
     bias_port = 1;
-    return (is_supported_shape(prot0_shape, prot1_shape));
+    if (IsMatMul(*node_def_0)) {
+      return (is_matmul_supported_shape(prot0_shape, prot1_shape));
+    } else {
+      return (is_supported_shape(prot0_shape, prot1_shape));
+    }
   } else if (IsConvOrMatMul(*node_def_1)) {
     bias_port = 0;
-    return (is_supported_shape(prot1_shape, prot0_shape));
+    if (IsMatMul(*node_def_1)) {
+      return (is_matmul_supported_shape(prot1_shape, prot0_shape));
+    } else {
+      return (is_supported_shape(prot1_shape, prot0_shape));
+    }
   }
   return false;
 }


### PR DESCRIPTION
This PR blocks the fusion of Matmul + Add when bias dims are more than one. This fusion was enabled earlier by a change that was meant to enable Conv3D + Add (PR https://github.com/tensorflow/tensorflow/pull/53299) which updated common code [here](https://github.com/tensorflow/tensorflow/pull/53299/files#diff-65c38c4abfc2cbfc01ab06f743b296203cc20a630919f65fd003b4e74632370cR518-R537) that enabled fusion for MatMul as well. we are blocking that fusion until it is properly tested.