### PR TITLE
Fix Windows build break in mhlo

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/legalize_to_linalg.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/transforms/legalize_to_linalg.cc
@@ -1001,7 +1001,7 @@ class RealDynamicSliceConverter
         loc, IntegerAttr::get(arith_type, 0));
     SmallVector<OpFoldResult, 4> offsets, sizes, strides;
     SmallVector<Type, 3> clamp_type(3, arith_type);
-    for (auto i : llvm::seq<uint>(0, arg_type.getRank())) {
+    for (auto i : llvm::seq<int64_t>(0, arg_type.getRank())) {
       Value dim = rewriter.create<arith::ConstantIndexOp>(loc, i);
       Value start =
           rewriter.create<tensor::ExtractOp>(loc, adaptor.start_indices(), dim);


### PR DESCRIPTION
`ShapedType::getRank()` returns an `int64_t`, so no reason to use `uint` which is not a supported type on Windows.