### PR TITLE
Make it explicit that TRTEngineOp names have three digits

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/rank_two_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/rank_two_test.py
@@ -68,7 +68,7 @@ class RankTwoTest(trt_test.TfTrtIntegrationTestBase):
         ]
     }
     if not run_params.dynamic_shape:
-      # The two ops can't be in the same cluster as the ops in TRTEngineOp_0
+      # The two ops can't be in the same cluster as the ops in TRTEngineOp_000
       # due to trt_incompatible_op. They can't be in the same cluster as the
       # ops in TRTEngineOP_1 because their batch size belongs to a different
       # equivalent class.

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -555,7 +555,7 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
   # The input value can be a string or a sequence of string.
   def _RemoveGraphSequenceNumberImpl(self, value, expecting_prefix):
     if isinstance(value, str):
-      match = re.search(r"TRTEngineOp_\d+_", value)
+      match = re.search(r"TRTEngineOp_\d{3,}_", value)
       has_prefix = match and value.startswith(match.group(0))
       assert (not expecting_prefix) or has_prefix
       if has_prefix:
@@ -837,7 +837,7 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
     all_op_names = [node.name for node in gdef_to_verify.node]
     trt_op_names = []
     for func in gdef_to_verify.library.function:
-      if not re.search(r"TRTEngineOp_\d+_\d+_native_segment",
+      if not re.search(r"TRTEngineOp_\d{3,}_\d{3,}_native_segment",
                        func.signature.name):
         for node in func.node_def:
           all_op_names.append(node.name)

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -230,7 +230,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
   # Remove the graph sequence number prefix from the name only if the name has
   # a prefix TRTEngineOp_n_.
   def _MayRemoveGraphSequenceNumber(self, name):
-    prefix = re.search(r"TRTEngineOp_\d+_", name)
+    prefix = re.search(r"TRTEngineOp_\d{3,}_", name)
     if prefix and name.startswith(prefix.group(0)):
       parts = name.split("_", maxsplit=2)
       assert len(parts) == 3


### PR DESCRIPTION
TRTEngineOp names have three digits. Change the tests to rely on this fact in looking for TRTEngineOp.