### PR TITLE
r2.9 cherry-pick: Fix tf.config.set_visible_device for PluggableDevice

### DIFF
--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -78,7 +78,8 @@ is_tfrt_enabled = tfrt_utils.enabled
 
 # This flag and the associated environment var are transient and will eventually
 # be removed, once this experiment is enabled by default.
-_RUN_EAGER_OP_AS_FUNCTION_ENABLED = os.getenv("TF_RUN_EAGER_OP_AS_FUNCTION", False)
+_RUN_EAGER_OP_AS_FUNCTION_ENABLED = os.getenv("TF_RUN_EAGER_OP_AS_FUNCTION",
+                                              "1") == "1"
 
 # This flag and the associated environment var are transient and will eventually
 # be removed, once this experiment is enabled by default.

--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -1437,8 +1437,8 @@ class Context(object):
       self._physical_device_to_index = {
           p: i for i, p in enumerate(self._physical_devices)
       }
-      #We maintain a seperate list just so we can check whether the device in
-      #_physical_devices is a PluggableDevice.
+      # We maintain a seperate list just so we can check whether the device in
+      # _physical_devices is a PluggableDevice.
       pluggable_devs = pywrap_tfe.TF_ListPluggablePhysicalDevices()
       self._pluggable_devices = [
           PhysicalDevice(name=d.decode(), device_type=d.decode().split(":")[1])

--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -1207,6 +1207,7 @@ class Context(object):
     memory_growths = set()
     gpu_devices = self.list_physical_devices("GPU")
     pluggable_devices = self._pluggable_devices
+    compatible_devices = gpu_devices
     for dev in pluggable_devices:
       if dev not in gpu_devices:
         compatible_devices.append(dev)

--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -1634,7 +1634,8 @@ class Context(object):
           "Cannot set memory growth on device when virtual devices configured")
 
     if dev.device_type != "GPU" and dev not in self._pluggable_devices:
-      raise ValueError("Cannot set memory growth on non-GPU and non-Pluggable devices")
+      raise ValueError(
+          "Cannot set memory growth on non-GPU and non-Pluggable devices")
 
     if self._memory_growth_map.get(dev) == enable:
       return

--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -1207,7 +1207,9 @@ class Context(object):
     memory_growths = set()
     gpu_devices = self.list_physical_devices("GPU")
     pluggable_devices = self._pluggable_devices
-    compatible_devices = list(set(gpu_devices + pluggable_devices))
+    for dev in pluggable_devices:
+      if dev not in gpu_devices:
+        compatible_devices.append(dev)
     for dev in compatible_devices:
       gpu_index += 1
 

--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -1437,6 +1437,8 @@ class Context(object):
       self._physical_device_to_index = {
           p: i for i, p in enumerate(self._physical_devices)
       }
+      #We maintain a seperate list just so we can check whether the device in
+      #_physical_devices is a PluggableDevice.
       pluggable_devs = pywrap_tfe.TF_ListPluggablePhysicalDevices()
       self._pluggable_devices = [
           PhysicalDevice(name=d.decode(), device_type=d.decode().split(":")[1])


### PR DESCRIPTION
`tf.config.set_visible_device()` currently doesn't work for PluggableDevice. This cherry-pick fixes it.

More details in the original PR: https://github.com/tensorflow/tensorflow/pull/55552 (merged into master on 4/19)