### PR TITLE
[compiler/mhlo] fix lib/CAPI cmake when using python binding

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/CAPI/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/CAPI/CMakeLists.txt
@@ -3,8 +3,16 @@ add_mlir_public_c_api_library(MLIRHLOCAPIDialects
   Dialects.cpp
   Types.cpp
   Passes.cpp
+
   LINK_LIBS PUBLIC
   ChloDialect
   MhloDialect
+  ChloPasses
+  MhloPasses
+  MhloToLhloConversion
+  MhloToArithmeticConversion
+  MhloToMemrefConversion
+  MhloToStandard
+  MhloToLinalg
+  MhloShapeOpsToStandard
 )
-target_link_libraries(MLIRHLOCAPIDialects PRIVATE AllMhLoPasses)


### PR DESCRIPTION
There are some problems which are import to discuss:
1. There is a spelling mistake `AllMhLoPasses ` => `AllMhloPasses`
2. `AllMhloPasses` is a library `interface` which not defined by `add_mlir_library`. This causes that `AllMhloPasses` doesn't has property `MLIR_AGGREGATE_DEPS`. Without  `MLIR_AGGREGATE_DEPS` property, the python binding compiling process will failed with many `undefined reference`.
3. I think this PR may not be the best fixing method. If you have more suitable method, tell me please.