### PR TITLE
Fix `size_t` vs int logic in `CHECK_OP`

### DIFF
--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -355,7 +355,7 @@ string* MakeCheckOpString(const T1& v1, const T2& v2, const char* exprtext) {
 // The (int, int) overload works around the issue that the compiler
 // will not instantiate the template version of the function on values of
 // unnamed enum type - see comment below.
-#define TF_DEFINE_CHECK_OP_IMPL(name, op)                            \
+#define TF_DEFINE_CHECK_OP_IMPL(name, op)                                 \
   template <typename T1, typename T2>                                     \
   inline string* name##Impl(const T1& v1, const T2& v2,                   \
                             const char* exprtext) {                       \
@@ -366,7 +366,7 @@ string* MakeCheckOpString(const T1& v1, const T2& v2, const char* exprtext) {
   }                                                                       \
   inline string* name##Impl(int v1, int v2, const char* exprtext) {       \
     return name##Impl<int, int>(v1, v2, exprtext);                        \
-  }                                                                       
+  }
 
 // The (size_t, int) and (int, size_t) specialization are to handle unsigned
 // comparison errors while still being thorough with the comparison.
@@ -375,46 +375,38 @@ TF_DEFINE_CHECK_OP_IMPL(Check_EQ, ==)
 // Compilation error with CHECK_EQ(NULL, x)?
 // Use CHECK(x == NULL) instead.
 
-inline string* Check_EQImpl(int v1, size_t v2,
-                            const char* exprtext) {
+inline string* Check_EQImpl(int v1, size_t v2, const char* exprtext) {
   if (TF_PREDICT_FALSE(v1 < 0))
     ::tensorflow::internal::MakeCheckOpString(v1, v2, exprtext);
 
   return Check_EQImpl(size_t(v1), v2, exprtext);
 }
 
-inline string* Check_EQImpl(size_t v1, int v2,
-                            const char* exprtext) {
+inline string* Check_EQImpl(size_t v1, int v2, const char* exprtext) {
   return Check_EQImpl(v2, v1, exprtext);
 }
 
 TF_DEFINE_CHECK_OP_IMPL(Check_NE, !=)
 
-inline string* Check_NEImpl(int v1, size_t v2,
-                            const char* exprtext) {
-  if (v1 < 0)
-    return NULL; 
-    
+inline string* Check_NEImpl(int v1, size_t v2, const char* exprtext) {
+  if (v1 < 0) return NULL;
+
   return Check_NEImpl(size_t(v1), v2, exprtext);
 }
 
-inline string* Check_NEImpl(size_t v1, int v2,
-                            const char* exprtext) {
+inline string* Check_NEImpl(size_t v1, int v2, const char* exprtext) {
   return Check_NEImpl(v2, v1, exprtext);
 }
 
 TF_DEFINE_CHECK_OP_IMPL(Check_LE, <=)
 
-inline string* Check_LEImpl(int v1, size_t v2,
-                            const char* exprtext) {
-  if (v1 <= 0)
-    return NULL;
+inline string* Check_LEImpl(int v1, size_t v2, const char* exprtext) {
+  if (v1 <= 0) return NULL;
 
   return Check_LEImpl(size_t(v1), v2, exprtext);
 }
 
-inline string* Check_LEImpl(size_t v1, int v2,
-                            const char* exprtext) {
+inline string* Check_LEImpl(size_t v1, int v2, const char* exprtext) {
   if (TF_PREDICT_FALSE(v2 < 0))
     return ::tensorflow::internal::MakeCheckOpString(v1, v2, exprtext);
   return Check_LEImpl(v1, size_t(v2), exprtext);
@@ -422,16 +414,13 @@ inline string* Check_LEImpl(size_t v1, int v2,
 
 TF_DEFINE_CHECK_OP_IMPL(Check_LT, <)
 
-inline string* Check_LTImpl(int v1, size_t v2,
-                            const char* exprtext) {
-  if (v1 < 0)
-    return NULL;
+inline string* Check_LTImpl(int v1, size_t v2, const char* exprtext) {
+  if (v1 < 0) return NULL;
 
   return Check_LTImpl(size_t(v1), v2, exprtext);
 }
 
-inline string* Check_LTImpl(size_t v1, int v2,
-                            const char* exprtext) {
+inline string* Check_LTImpl(size_t v1, int v2, const char* exprtext) {
   if (v2 < 0)
     return ::tensorflow::internal::MakeCheckOpString(v1, v2, exprtext);
   return Check_LTImpl(v1, size_t(v2), exprtext);

--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -348,12 +348,14 @@ string* MakeCheckOpString(const T1& v1, const T2& v2, const char* exprtext) {
 }
 
 // Helper functions for CHECK_OP macro.
-// The (int, int) specialization works around the issue that the compiler
+// We use the full name Check_EQ, Check_NE, etc. in case the file including
+// base/logging.h provides its own #defines for the simpler names EQ, NE, etc.
+// This happens if, for example, those are used as token names in a
+// yacc grammar.
+// The (int, int) overload works around the issue that the compiler
 // will not instantiate the template version of the function on values of
 // unnamed enum type - see comment below.
-// The (size_t, int) and (int, size_t) specialization are to handle unsigned
-// comparison errors while still being thorough with the comparison.
-#define TF_DEFINE_CHECK_OP_IMPL(name, op)                                 \
+#define TF_DEFINE_CHECK_OP_IMPL(name, op)                            \
   template <typename T1, typename T2>                                     \
   inline string* name##Impl(const T1& v1, const T2& v2,                   \
                             const char* exprtext) {                       \
@@ -364,34 +366,88 @@ string* MakeCheckOpString(const T1& v1, const T2& v2, const char* exprtext) {
   }                                                                       \
   inline string* name##Impl(int v1, int v2, const char* exprtext) {       \
     return name##Impl<int, int>(v1, v2, exprtext);                        \
-  }                                                                       \
-  inline string* name##Impl(const size_t v1, const int v2,                \
-                            const char* exprtext) {                       \
-    if (TF_PREDICT_FALSE(v2 < 0)) {                                       \
-      return ::tensorflow::internal::MakeCheckOpString(v1, v2, exprtext); \
-    }                                                                     \
-    return name##Impl<size_t, size_t>(v1, v2, exprtext);                  \
-  }                                                                       \
-  inline string* name##Impl(const int v1, const size_t v2,                \
-                            const char* exprtext) {                       \
-    if (TF_PREDICT_FALSE(v2 >= std::numeric_limits<int>::max())) {        \
-      return ::tensorflow::internal::MakeCheckOpString(v1, v2, exprtext); \
-    }                                                                     \
-    const size_t uval = (size_t)((unsigned)v2);                           \
-    return name##Impl<size_t, size_t>(v1, uval, exprtext);                \
-  }
+  }                                                                       
 
-// We use the full name Check_EQ, Check_NE, etc. in case the file including
-// base/logging.h provides its own #defines for the simpler names EQ, NE, etc.
-// This happens if, for example, those are used as token names in a
-// yacc grammar.
-TF_DEFINE_CHECK_OP_IMPL(Check_EQ,
-                        ==)  // Compilation error with CHECK_EQ(NULL, x)?
-TF_DEFINE_CHECK_OP_IMPL(Check_NE, !=)  // Use CHECK(x == NULL) instead.
+// The (size_t, int) and (int, size_t) specialization are to handle unsigned
+// comparison errors while still being thorough with the comparison.
+
+TF_DEFINE_CHECK_OP_IMPL(Check_EQ, ==)
+// Compilation error with CHECK_EQ(NULL, x)?
+// Use CHECK(x == NULL) instead.
+
+inline string* Check_EQImpl(int v1, size_t v2,
+                            const char* exprtext) {
+  if (TF_PREDICT_FALSE(v1 < 0))
+    ::tensorflow::internal::MakeCheckOpString(v1, v2, exprtext);
+
+  return Check_EQImpl(size_t(v1), v2, exprtext);
+}
+
+inline string* Check_EQImpl(size_t v1, int v2,
+                            const char* exprtext) {
+  return Check_EQImpl(v2, v1, exprtext);
+}
+
+TF_DEFINE_CHECK_OP_IMPL(Check_NE, !=)
+
+inline string* Check_NEImpl(int v1, size_t v2,
+                            const char* exprtext) {
+  if (v1 < 0)
+    return NULL; 
+    
+  return Check_NEImpl(size_t(v1), v2, exprtext);
+}
+
+inline string* Check_NEImpl(size_t v1, int v2,
+                            const char* exprtext) {
+  return Check_NEImpl(v2, v1, exprtext);
+}
+
 TF_DEFINE_CHECK_OP_IMPL(Check_LE, <=)
+
+inline string* Check_LEImpl(int v1, size_t v2,
+                            const char* exprtext) {
+  if (v1 <= 0)
+    return NULL;
+
+  return Check_LEImpl(size_t(v1), v2, exprtext);
+}
+
+inline string* Check_LEImpl(size_t v1, int v2,
+                            const char* exprtext) {
+  if (TF_PREDICT_FALSE(v2 < 0))
+    return ::tensorflow::internal::MakeCheckOpString(v1, v2, exprtext);
+  return Check_LEImpl(v1, size_t(v2), exprtext);
+}
+
 TF_DEFINE_CHECK_OP_IMPL(Check_LT, <)
-TF_DEFINE_CHECK_OP_IMPL(Check_GE, >=)
-TF_DEFINE_CHECK_OP_IMPL(Check_GT, >)
+
+inline string* Check_LTImpl(int v1, size_t v2,
+                            const char* exprtext) {
+  if (v1 < 0)
+    return NULL;
+
+  return Check_LTImpl(size_t(v1), v2, exprtext);
+}
+
+inline string* Check_LTImpl(size_t v1, int v2,
+                            const char* exprtext) {
+  if (v2 < 0)
+    return ::tensorflow::internal::MakeCheckOpString(v1, v2, exprtext);
+  return Check_LTImpl(v1, size_t(v2), exprtext);
+}
+
+// Implement GE,GT in terms of LE,LT
+template <typename T1, typename T2>
+inline string* Check_GEImpl(const T1& v1, const T2& v2, const char* exprtext) {
+  return Check_LEImpl(v2, v1, exprtext);
+}
+
+template <typename T1, typename T2>
+inline string* Check_GTImpl(const T1& v1, const T2& v2, const char* exprtext) {
+  return Check_LTImpl(v2, v1, exprtext);
+}
+
 #undef TF_DEFINE_CHECK_OP_IMPL
 
 // In optimized mode, use CheckOpString to hint to compiler that

--- a/tensorflow/core/platform/default/logging.h
+++ b/tensorflow/core/platform/default/logging.h
@@ -85,7 +85,7 @@ class LogMessage : public std::basic_ostringstream<char> {
 // that the ternary VLOG() implementation is balanced, type wise.
 struct Voidifier {
   template <typename T>
-  void operator&(const T&)const {}
+  void operator&(const T&) const {}
 };
 
 // LogMessageFatal ensures the process will exit in failure after


### PR DESCRIPTION
Previously, there was custom logic for `size_t` vs `int` instances of `CHECK_OP`.

However the logic was correct only for equality ops, not != or greater/less than.

Example: Before
```
bazel  test --jobs=40  --config=dbg --verbose_failures //tensorflow/core:__tensorflow_core_lib_math_math_util_test
...
-----------------------------------------------------------------------------
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from MathUtil
[ RUN      ] MathUtil.CeilOfRatio
2022-04-25 13:53:45.485294: F ./tensorflow/core/lib/math/math_util.h:123] Check failed: 0 != denominator (0 vs. 18446744073709551615)Division by zero is not supported.
*** Received signal 6 ***
```

After: test passes.

Fixes #55530