### PR TITLE
r2.9 cherry-pick: Update oneDNN for x86 build from v2.6-rc to v2.6

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -175,9 +175,9 @@ def _tf_repositories():
     tf_http_archive(
         name = "mkl_dnn_v1",
         build_file = "//third_party/mkl_dnn:mkldnn_v1.BUILD",
-        sha256 = "89495899d7cc17bef14c5dbf72070d6dfda4769fe804f8e88d86f71ad7ae0d51",
-        strip_prefix = "oneDNN-2.6-rc",
-        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/v2.6-rc.tar.gz"),
+        sha256 = "9695640f55acd833ddcef4776af15e03446c4655f9296e5074b1b178dd7a4fb2",
+        strip_prefix = "oneDNN-2.6",
+        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/v2.6.tar.gz"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
Update oneDNN for the x86 build from v2.6-rc to v2.6. v2.6 has [several additional fixes](https://github.com/oneapi-src/oneDNN/compare/v2.6-rc...v2.6).

Original PR: https://github.com/tensorflow/tensorflow/pull/55694