### PR TITLE
r2.9 cherry-pick: Fix `//tensorflow/python/distribute/failure_handling:failure_handler_test` failure on Linux aarch64

### DIFF
--- a/tensorflow/python/distribute/failure_handling/failure_handler_test.py
+++ b/tensorflow/python/distribute/failure_handling/failure_handler_test.py
@@ -210,7 +210,7 @@ class PreemptionCheckpointTest(test.TestCase, parameterized.TestCase):
       mpr.start_single_process('worker', worker_id, cluster_spec)
     logging.info('workers restarted')
 
-    stdout = mpr.join().stdout
+    stdout = mpr.join(timeout=300).stdout
     all_start_point = []
     for msg in stdout:
       matched_group = re.search(r'.*Restored training at (\d+)', msg)


### PR DESCRIPTION
Fix `//tensorflow/python/distribute/failure_handling:failure_handler_test` failure on Linux aarch64 by increasing timeout on join for preemption test.

Original PR: https://github.com/tensorflow/tensorflow/pull/55409