### PR TITLE
Improve cuDNN (and XLA) deterministic convolution testing

### DIFF
--- a/tensorflow/python/kernel_tests/nn_ops/BUILD
+++ b/tensorflow/python/kernel_tests/nn_ops/BUILD
@@ -281,6 +281,7 @@ py_library(
         "//tensorflow/python:constant_op",
         "//tensorflow/python:dtypes",
         "//tensorflow/python:nn_ops",
+        "//tensorflow/python/eager:backprop",
         "//third_party/py/numpy",
     ],
 )

--- a/tensorflow/python/kernel_tests/nn_ops/cudnn_deterministic_base.py
+++ b/tensorflow/python/kernel_tests/nn_ops/cudnn_deterministic_base.py
@@ -215,7 +215,7 @@ class ConvolutionTest(test.TestCase):
   # A configuration for this test could not be found that exercises
   # nondeterminism when using XLA with determinism not enabled.
   @test_util.run_cuda_only
-  def testConvTransposeBackwardFilterGradientWithDilations(self, rate=1):
+  def testConvTransposeBackwardFilterGradientWithDilations(self):
     self.testConvTransposeBackwardFilterGradient(rate=2)
 
   # A configuration for this test could not be found that exercises
@@ -248,5 +248,5 @@ class ConvolutionTest(test.TestCase):
   # A configuration for this test could not be found that exercises
   # nondeterminism when determinism is not enabled (for either XLA or non-XLA).
   @test_util.run_cuda_only
-  def testConvTransposeBackwardInputGradientWithDilations(self, rate=1):
+  def testConvTransposeBackwardInputGradientWithDilations(self):
     self.testConvTransposeBackwardInputGradient(rate=2)

--- a/tensorflow/python/kernel_tests/nn_ops/cudnn_deterministic_base.py
+++ b/tensorflow/python/kernel_tests/nn_ops/cudnn_deterministic_base.py
@@ -55,6 +55,8 @@ LayerShapeNHWC = collections.namedtuple('LayerShapeNHWC',
                                         'batch, height, width, channels')
 FilterShape2D = collections.namedtuple(
     'FilterShape2D', 'height, width, in_channels, out_channels')
+FilterShape2DTranspose = collections.namedtuple(
+    'FilterShape2DTranspose', 'height, width, out_channels, in_channels')
 
 LayerShapeNCDHW = collections.namedtuple(
     'LayerShapeNCDHW', 'batch, channels, depth, height, width')
@@ -71,21 +73,22 @@ class ConvolutionTest(test.TestCase):
     return constant_op.constant(
         2 * np.random.random_sample(shape) - 1, dtype=dtypes.float32)
 
-  def _random_out_op(self, in_shape, filter_shape, strides, padding):
+  def _random_out_op(self, in_shape, filter_shape, strides, padding, dilations):
     # Choosing not to use array_op.zeros() to prevent possible removal by
     # optimization
     in_op = self._random_data_op(in_shape)
     filter_op = self._random_data_op(filter_shape)
     # Use the forward op's shape-inference
-    conv_op = nn_ops.conv2d(in_op, filter_op, strides=strides, padding=padding)
+    conv_op = nn_ops.conv2d(
+        in_op, filter_op, strides=strides, padding=padding, dilations=dilations)
     out_shape = conv_op.get_shape()
     out_op = self._random_data_op(out_shape)
     return out_op
 
   def _assert_reproducible(self, operation):
-    with self.cached_session(force_gpu=True):
-      result_1 = self.evaluate(operation)
-      result_2 = self.evaluate(operation)
+    with test_util.force_gpu():
+      result_1 = operation()
+      result_2 = operation()
     self.assertAllEqual(result_1, result_2)
 
   # The default forward algorithm choice, when using cuDNN 7, does not support
@@ -93,76 +96,94 @@ class ConvolutionTest(test.TestCase):
   # an alternative algorithm is selected. Note that, in cuDNN 7, all forward
   # algorithms are determnistic.
   @test_util.run_cuda_only
-  def testForward(self):
+  def testConvForwardDefaultAlgorithmChoice(self):
     in_shape = LayerShapeNCDHW(batch=2, channels=3, depth=5, height=7, width=6)
     filter_shape = FilterShape3D(
         depth=3, height=3, width=3, in_channels=3, out_channels=2)
     in_op = self._random_data_op(in_shape)
     filter_op = self._random_data_op(filter_shape)
-    strides = [1, 1, 1, 1, 1]
-    padding = 'VALID'
-    dilations = [1, 1, 2, 2, 2]
-    out_op = nn_ops.conv3d(
-        in_op,
-        filter_op,
-        strides=strides,
-        padding=padding,
-        data_format='NCDHW',
-        dilations=dilations)
-    self._assert_reproducible(out_op)
+    self._assert_reproducible(lambda: nn_ops.conv3d(
+        in_op, filter_op, strides=[1, 1, 1, 1, 1], padding='VALID',
+        data_format='NCDHW', dilations=[1, 1, 2, 2, 2]))
+
+  # This test intends to exercise nondeterminism of convolution in the forward
+  # direction for XLA only. cuDNN does not have nondeterministic forward
+  # convolution algorithms.
+  @test_util.run_cuda_only
+  def testConvForwardXLA(self):
+    in_shape = LayerShapeNCDHW(
+        batch=2, channels=8, depth=5, height=12, width=15)
+    filter_shape = FilterShape3D(
+        depth=3, height=3, width=3, in_channels=8, out_channels=1)
+    in_op = self._random_data_op(in_shape)
+    filter_op = self._random_data_op(filter_shape)
+    self._assert_reproducible(lambda: nn_ops.conv3d(
+        in_op, filter_op, strides=[1, 1, 1, 1, 1], padding='VALID',
+        data_format='NCDHW', dilations=[1, 1, 2, 2, 2]))
 
   @test_util.run_cuda_only
-  def testBackwardFilterGradient(self):
-    in_shape = LayerShapeNHWC(batch=8, height=128, width=128, channels=8)
+  def testConvBackwardFilterGradient(self, rate=1):
+    in_shape = LayerShapeNHWC(batch=8, height=64, width=64, channels=8)
     filter_shape = FilterShape2D(
         height=3, width=3, in_channels=8, out_channels=8)
     in_op = self._random_data_op(in_shape)
     strides = [1, 1, 1, 1]
     padding = 'SAME'
-    out_op = self._random_out_op(in_shape, filter_shape, strides, padding)
-    filter_gradient_op = nn_ops.conv2d_backprop_filter(
-        in_op, filter_shape, out_op, strides=strides, padding=padding)
-    self._assert_reproducible(filter_gradient_op)
-
-  @test_util.run_cuda_only
-  def testBackwardFilterGradientWithDilations(self):
-    in_shape = LayerShapeNHWC(batch=8, height=128, width=128, channels=8)
-    filter_shape = FilterShape2D(
-        height=3, width=3, in_channels=8, out_channels=8)
-    in_op = self._random_data_op(in_shape)
-    strides = [1, 1, 1, 1]
-    padding = 'SAME'
-    dilations = [1, 2, 2, 1]
-    out_op = self._random_out_op(in_shape, filter_shape, strides, padding)
-    filter_gradient_op = nn_ops.conv2d_backprop_filter(
+    dilations = [1, rate, rate, 1]
+    out_op = self._random_out_op(
+        in_shape, filter_shape, strides, padding, dilations)
+    self._assert_reproducible(lambda: nn_ops.conv2d_backprop_filter(
         in_op, filter_shape, out_op, strides=strides, padding=padding,
-        dilations=dilations)
-    self._assert_reproducible(filter_gradient_op)
+        dilations=dilations))
+
+  # A configuration for this test could not be found that exercises
+  # nondeterminism on XLA.
+  @test_util.run_cuda_only
+  def testConvBackwardFilterGradientWithDilations(self):
+    self.testConvBackwardFilterGradient(rate=2)
 
   @test_util.run_cuda_only
-  def testBackwardInputGradient(self):
-    in_shape = LayerShapeNHWC(batch=8, height=32, width=32, channels=8)
+  def testConvBackwardInputGradient(self, rate=1):
+    in_shape = LayerShapeNHWC(batch=1, height=16, width=16, channels=1)
     filter_shape = FilterShape2D(
-        height=7, width=7, in_channels=8, out_channels=128)
+        height=7, width=7, in_channels=1, out_channels=3)
     filter_op = self._random_data_op(filter_shape)
     strides = [1, 1, 1, 1]
     padding = 'SAME'
-    out_op = self._random_out_op(in_shape, filter_shape, strides, padding)
-    input_gradient_op = nn_ops.conv2d_backprop_input(
-        in_shape, filter_op, out_op, strides=strides, padding=padding)
-    self._assert_reproducible(input_gradient_op)
-
-  @test_util.run_cuda_only
-  def testBackwardInputGradientWithDilations(self):
-    in_shape = LayerShapeNHWC(batch=8, height=32, width=32, channels=8)
-    filter_shape = FilterShape2D(
-        height=7, width=7, in_channels=8, out_channels=128)
-    filter_op = self._random_data_op(filter_shape)
-    strides = [1, 1, 1, 1]
-    padding = 'SAME'
-    dilations = [1, 2, 2, 1]
-    out_op = self._random_out_op(in_shape, filter_shape, strides, padding)
-    input_gradient_op = nn_ops.conv2d_backprop_input(
+    dilations = [1, rate, rate, 1]
+    out_op = self._random_out_op(
+        in_shape, filter_shape, strides, padding, dilations)
+    self._assert_reproducible(lambda: nn_ops.conv2d_backprop_input(
         in_shape, filter_op, out_op, strides=strides, padding=padding,
-        dilations=dilations)
-    self._assert_reproducible(input_gradient_op)
+        dilations=dilations))
+
+  # A configuration for this test could not be found that exercises
+  # nondeterminism on XLA.
+  @test_util.run_cuda_only
+  def testConvBackwardInputGradientWithDilations(self):
+    self.testConvBackwardInputGradient(rate=2)
+
+  # A 2D convolution configuration that exercises nondeterminism in the forward
+  # direction (i.e. tf.nn.conv2d) using XLA was not found and therefore no tests
+  # for the backprop of tf.nn.conv2d_transpose have been included.
+  @test_util.run_cuda_only
+  def testConvTransposeForward(self, rate=1):
+    in_channels = 3; out_channels = 1
+    in_shape = LayerShapeNHWC(
+        batch=1, height=16, width=16, channels=in_channels)
+    filter_shape = FilterShape2DTranspose(
+        height=7, width=7, out_channels=out_channels, in_channels=in_channels)
+    in_op = self._random_data_op(in_shape)
+    filter_op = self._random_data_op(filter_shape)
+    out_shape = LayerShapeNHWC(
+        batch=in_shape.batch, height=in_shape.height, width=in_shape.width,
+        channels=out_channels)
+    self._assert_reproducible(lambda: nn_ops.conv2d_transpose_v2(
+        in_op, filter_op, out_shape, strides=1, padding='SAME',
+        data_format='NHWC', dilations=[1, rate, rate, 1]))
+
+  # A configuration for this test could not be found that exercises
+  # nondeterminism on XLA.
+  @test_util.run_cuda_only
+  def testConvTransposeForwardWithDilations(self):
+    self.testConvTransposeForward(rate=2)


### PR DESCRIPTION
This PR improves the cuDNN (and XLA) deterministic convolution testing in the following ways:
* Because the existing tests evolved from TF1 API code but are now running on the TF2 eager API, they are operating such that they test nothing. They always pass, regardless of the state of the functionality that they intend to test. Specifically, code that would previously run a graph-op twice using the TF1 API and compare the results is instead running the op once using the TF2 eager API and then comparing the numerical result to itself, which always matches. This PR changes the test infrastructure to compare the result of a python function that is run twice in eager mode.
* The non-dilated convolution backprop tests are not exercising nondeterminism (when op-determinism is disabled) when using XLA JIT compilation. This PR adjusts the configurations such that nondeterminism is exercised (when op-determinism is disabled) both with and without XLA.
* This PR modifies some of the existing test cases to make them smaller, and therefore possibly makes them run faster, whilst robustly exercising nondeterminism (when op-determinism is disabled).
* This PR adds tests for `tf.nn.conv2d_transpose`.
* This PR adds a test that exercises forward nondeterminism (when op-determinism is disabled) for 3D convolution when using XLA JIT compilation.