### PR TITLE
Improve the depthwise Conv2DBackpropFilterNCHW GPU kernel

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4144,6 +4144,9 @@ tf_kernel_library(
         "@local_config_cuda//cuda:cudnn_header",
     ]) + if_rocm([
         "@local_config_rocm//rocm:rocprim",
+    ]) + if_cuda_or_rocm([
+        ":gpu_utils",
+        ":gpu_prim_hdrs",
     ]),
 )
 

--- a/tensorflow/core/kernels/depthwise_conv_op_gpu.h
+++ b/tensorflow/core/kernels/depthwise_conv_op_gpu.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/kernels/depthwise_conv_op.h"
+#include "tensorflow/core/kernels/gpu_prim.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/determinism.h"
 #include "tensorflow/core/util/gpu_kernel_helper.h"
@@ -1307,110 +1308,73 @@ __launch_bounds__(1024, 2) void DepthwiseConv2dBackpropFilterGPUKernelNHWCSmall(
 }
 
 // A GPU kernel to compute the depthwise convolution backprop w.r.t. filter.
-template <typename T, int kKnownFilterWidth, int kKnownFilterHeight,
-          int kKnownDepthMultiplier>
-__global__ void __launch_bounds__(640, 2)
-    DepthwiseConv2dBackpropFilterGPUKernelNCHW(
-        const DepthwiseArgs args, const T* __restrict__ out_backprop,
-        const T* __restrict__ input, T* __restrict__ filter_backprop,
-        int num_out_backprop) {
+template <typename T>
+__global__ void __launch_bounds__(512, 2)
+    DepthwiseConv2dBackpropFilterGPUKernelNCHW(const DepthwiseArgs args,
+                                               const T *__restrict__ out_backprop,
+                                               const T *__restrict__ input,
+                                               T *__restrict__ filter_backprop) {
+  const int batch_num = args.batch;
+  const int in_depth = args.in_depth;
   const int in_height = args.in_rows;
   const int in_width = args.in_cols;
-  const int in_depth = args.in_depth;
-  const int filter_height =
-      kKnownFilterHeight < 0 ? args.filter_rows : kKnownFilterHeight;
-  const int filter_width =
-      kKnownFilterWidth < 0 ? args.filter_cols : kKnownFilterWidth;
-  const int depth_multiplier =
-      kKnownDepthMultiplier < 0 ? args.depth_multiplier : kKnownDepthMultiplier;
-  const int stride = args.stride;
+  const int filter_width = args.filter_cols;
+  const int stride_height = args.stride;
+  const int stride_width = args.stride;
   const int pad_height = args.pad_rows;
   const int pad_width = args.pad_cols;
+  const int out_depth = args.out_depth;
   const int out_height = args.out_rows;
   const int out_width = args.out_cols;
-  const int out_depth = args.out_depth;
+  const int depth_multiplier = args.depth_multiplier;
+  assert(gridDim.x == filter_width);
+  assert(gridDim.z == out_depth);
 
-  GPU_1D_KERNEL_LOOP(thread_id, num_out_backprop) {
-    // Compute the indexes of this thread in the output.
-    const int out_col = thread_id % out_width;
-    const int out_row = (thread_id / out_width) % out_height;
-    const int out_channel = (thread_id / out_width / out_height) % out_depth;
+  typedef gpuprim::WarpReduce<T> WarpReduce;
+  typename WarpReduce::TempStorage temp_storage;
 
-    const int batch = thread_id / out_depth / out_width / out_height;
-    // Compute the input depth and the index of depth multiplier.
-    const int in_channel = out_channel / depth_multiplier;
-    const int dm = out_channel % depth_multiplier;
+  const int filter_w = blockIdx.x;
+  const int filter_h = blockIdx.y;
+  const int out_c = blockIdx.z;
 
-    // Decide if all input is valid, if yes, we can skip the boundary checks
-    // for each input.
-    const int in_row_start = out_row * stride - pad_height;
-    const int in_col_start = out_col * stride - pad_width;
-    const int in_row_end = in_row_start + filter_height;
-    const int in_col_end = in_col_start + filter_width;
+  const int in_c = out_c / depth_multiplier;
+  const int dm = out_c % depth_multiplier;
+  const int filter_backprop_offset =
+      (((filter_h * filter_width) + filter_w) * in_depth + in_c) *
+          depth_multiplier +
+      dm;
+  const int out_spatial_size = out_height * out_width;
 
-    const int out_backprop_offset =
-        (batch * out_depth * out_height * out_width) +
-        (out_channel * out_height * out_width) + (out_row * out_width) +
-        (out_col);
+  T partial_sum = static_cast<T>(0.f);
+  for (int batch = 0; batch < batch_num; batch++) {
+    const int input_offset_temp = (batch * in_depth + in_c) * in_height;
+    const int output_backprop_offset_temp =
+        (batch * out_depth + out_c) * out_height;
+    for (int i = threadIdx.x; i < out_spatial_size; i += blockDim.x) {
+      const int out_col = i % out_width;
+      const int out_row = i / out_width;
+      // We use the formula: `(in_row - filter_w + pad_left ) / stride =
+      // out_row` to compute corresponding in_row and out_row positions. Similar
+      // for in_col and out_col.
+      const int in_row = out_row * stride_height + filter_h - pad_height;
+      const int in_col = out_col * stride_width + filter_w - pad_width;
 
-    const T out_bp = ldg(out_backprop + out_backprop_offset);
-    if (in_row_start >= 0 && in_col_start >= 0 && in_row_end < in_height &&
-        in_col_end < in_width) {
-      UNROLL for (int filter_row = 0; filter_row < filter_height;
-                  ++filter_row) {
-        const int in_row = in_row_start + filter_row;
-        // Avoid repeated computation.
-        const int input_offset_temp =
-            (batch * in_depth * in_height * in_width) +
-            (in_channel * in_height * in_width) + (in_row * in_width);
-
-        UNROLL for (int filter_col = 0; filter_col < filter_width;
-                    ++filter_col) {
-          const int in_col = in_col_start + filter_col;
-          const int input_offset = input_offset_temp + in_col;
-          T partial_sum = ldg(input + input_offset) * out_bp;
-          T* addr =
-              filter_backprop +
-              (dm + depth_multiplier *
-                        (in_channel +
-                         in_depth * (filter_col + filter_width * filter_row)));
-          GpuAtomicAdd(addr, partial_sum);
-        }
+      if (in_row < 0 || in_col < 0 || in_row >= in_height ||
+          in_col >= in_width) {
+        continue;
       }
-    } else {
-      UNROLL for (int filter_row = 0; filter_row < filter_height;
-                  ++filter_row) {
-        const int in_row = in_row_start + filter_row;
-        // Avoid repeated computation.
-        const int input_offset_temp =
-            (batch * in_depth * in_height * in_width) +
-            (in_channel * in_height * in_width) + (in_row * in_width);
-        UNROLL for (int filter_col = 0; filter_col < filter_width;
-                    ++filter_col) {
-          const int in_col = in_col_start + filter_col;
-          const int addr_temp = filter_width * filter_row;
 
-          if (in_row >= 0 && in_row < in_height && in_col >= 0 &&
-              in_col < in_width) {
-            const int input_offset = input_offset_temp + in_col;
-            T partial_sum = ldg(input + input_offset) * out_bp;
-            T* addr =
-                filter_backprop +
-                (dm + depth_multiplier *
-                          (in_channel + in_depth * (filter_col + addr_temp)));
-            // Potentially many threads can add to the same address so we have
-            // to use atomic add here.
-            // TODO(jmchen): If atomic add turns out to be slow, we can:
-            // 1. allocate multiple buffers for the gradients (one for each
-            // example in a batch, for example). This can reduce the
-            // contention on the destination; 2. Have each thread compute one
-            // gradient for an element in the filters. This should work well
-            // when the input depth is big and filter size is not too small.
-            GpuAtomicAdd(addr, partial_sum);
-          }
-        }
-      }
+      int input_offset = (input_offset_temp + in_row) * in_width + in_col;
+      int output_backprop_offset =
+          (output_backprop_offset_temp + out_row) * out_width + out_col;
+      partial_sum += out_backprop[output_backprop_offset] * input[input_offset];
     }
+  }
+
+  T val = WarpReduce(temp_storage).Sum(partial_sum);
+  if (gpuprim::LaneId() == 0) {
+    T *addr = filter_backprop + filter_backprop_offset;
+    GpuAtomicAdd(addr, val);
   }
 }
 
@@ -1703,29 +1667,32 @@ template <typename T, int kKnownFilterWidth, int kKnownFilterHeight,
 Status LaunchDepthwiseConv2dBackpropFilterGPU(
     OpKernelContext* ctx, const DepthwiseArgs& args, const T* out_backprop,
     const T* input, T* filter_backprop, TensorFormat data_format) {
-  void (*kernel)(const DepthwiseArgs, const T*, const T*, T*, int);
-  switch (data_format) {
-    case FORMAT_NHWC:
-      kernel = DepthwiseConv2dBackpropFilterGPUKernelNHWC<
-          T, kKnownFilterWidth, kKnownFilterHeight, kKnownDepthMultiplier>;
-      break;
-    case FORMAT_NCHW:
-      kernel = DepthwiseConv2dBackpropFilterGPUKernelNCHW<
-          T, kKnownFilterWidth, kKnownFilterHeight, kKnownDepthMultiplier>;
-      break;
-    default:
-      return errors::InvalidArgument("FORMAT_", ToString(data_format),
-                                     " is not supported");
-  }
+  auto device = ctx->eigen_gpu_device();
   const int num_out_backprop =
       args.batch * args.out_rows * args.out_cols * args.out_depth;
-  auto device = ctx->eigen_gpu_device();
-  int launch_bounds_value = 640;
-  GpuLaunchConfig config = GetGpuLaunchConfig(num_out_backprop, device, kernel,
-                                              0, launch_bounds_value);
-  TF_CHECK_OK(GpuLaunchKernel(
-      kernel, config.block_count, config.thread_per_block, 0, device.stream(),
-      args, out_backprop, input, filter_backprop, num_out_backprop));
+  if (data_format == FORMAT_NHWC) {
+    auto kernel = DepthwiseConv2dBackpropFilterGPUKernelNHWC<
+        T, kKnownFilterWidth, kKnownFilterHeight, kKnownDepthMultiplier>;
+
+    int launch_bounds_value = 640;
+    GpuLaunchConfig config = GetGpuLaunchConfig(num_out_backprop, device, kernel,
+                                                0, launch_bounds_value);
+    TF_CHECK_OK(GpuLaunchKernel(
+        kernel, config.block_count, config.thread_per_block, 0, device.stream(),
+        args, out_backprop, input, filter_backprop, num_out_backprop));
+  } else if (data_format == FORMAT_NCHW) {
+    auto kernel = DepthwiseConv2dBackpropFilterGPUKernelNCHW<T>;
+    dim3 blocks = dim3(args.filter_cols, args.filter_rows, args.out_depth);
+    dim3 threads = dim3(512, 1, 1);
+
+    TF_CHECK_OK(GpuLaunchKernel(
+        kernel, blocks, threads, 0, device.stream(),
+        args, out_backprop, input, filter_backprop));
+  } else {
+    return errors::InvalidArgument("FORMAT_", ToString(data_format),
+                                   " is not supported");
+  }
+  
   return Status::OK();
 }
 

--- a/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_base.py
+++ b/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_base.py
@@ -1020,7 +1020,7 @@ class DepthwiseConv2DBase(test.TestCase):
       padding_nhwc = [(0, 0)] + padding + [(0, 0)]
       padding_nchw = [(0, 0)] + [(0, 0)] + padding
 
-    def _GetVal(use_gpu):
+    def _GetVal(use_gpu, data_format='NHWC'):
       with self.cached_session(use_gpu=use_gpu):
         t0 = constant_op.constant(x0, shape=input_sizes)
         t1 = constant_op.constant(filter_sizes, shape=[len(filter_sizes)])

--- a/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_base.py
+++ b/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_base.py
@@ -1014,23 +1014,34 @@ class DepthwiseConv2DBase(test.TestCase):
                              stride, padding, dtype):
     x0 = np.random.rand(*input_sizes).astype(dtype)
     x2 = np.random.rand(*output_sizes).astype(dtype)
+    padding_nhwc = padding
+    padding_nchw = padding
     if isinstance(padding, list):
-      padding = [(0, 0)] + padding + [(0, 0)]
+      padding_nhwc = [(0, 0)] + padding + [(0, 0)]
+      padding_nchw = [(0, 0)] + [(0, 0)] + padding
 
     def _GetVal(use_gpu):
       with self.cached_session(use_gpu=use_gpu):
         t0 = constant_op.constant(x0, shape=input_sizes)
         t1 = constant_op.constant(filter_sizes, shape=[len(filter_sizes)])
         t2 = constant_op.constant(x2, shape=output_sizes)
+        strides = [1, stride, stride, 1]
+        padding = padding_nhwc
+        if data_format == 'NCHW':
+          t0 = array_ops.transpose(t0, [0, 3, 1, 2])
+          t2 = array_ops.transpose(t2, [0, 3, 1, 2])
+          strides = [1, 1, stride, stride]
+          padding = padding_nchw
         backprop = nn_ops.depthwise_conv2d_native_backprop_filter(
-            t0, t1, t2, strides=[1, stride, stride, 1], padding=padding)
+            t0, t1, t2, strides=strides, padding=padding)
         ret = self.evaluate(backprop)
         self.assertShapeEqual(ret, backprop)
         return ret
 
-    gpu_value = _GetVal(use_gpu=True)
     cpu_value = _GetVal(use_gpu=False)
-    self.assertAllClose(cpu_value, gpu_value, rtol=1e-4, atol=1e-4)
+    for data_format in ['NHWC', 'NCHW']:
+      gpu_value = _GetVal(use_gpu=True, data_format=data_format)
+      self.assertAllClose(cpu_value, gpu_value, rtol=1e-4, atol=1e-4)
 
   def testDepthwiseConv2DFilterGradCompare(self):
     for index, (input_size, filter_size, output_size, stride, padding,


### PR DESCRIPTION
This PR redesigned the Conv2DBackpropFilterNCHW CUDA kernel to improve the perf by using a more reasonable task partition.

Below is some benchmarking results:

https://docs.google.com/spreadsheets/d/1xKv4QFh2_dzKvf-T2kCJ1qq_ZKd5LW-63Af2nAoS4fw/edit?usp=sharing

cc. @nluehr 