### PR TITLE
[TF:TRT] Binary op converter formatting and code style cleanup

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -509,17 +509,24 @@ Status GetTrtBroadcastShape(const TRT_TensorOrWeights& operand_l,
                             nvinfer1::Dims* operand_r_new_dims);
 
 template <typename T>
-using operationMap = std::unordered_map<std::string, T>;
-// Map of all supported UnaryOperations.
-typedef operationMap<nvinfer1::UnaryOperation> unaryOperationMap;
-const unaryOperationMap* UnaryOperationMap();
-const unaryOperationMap* UnaryBooleanOperationMap();
+using OperationMap = std::unordered_map<std::string, T>;
+
+// Map from Tensorflow operation names to TensorRT unary operations.
+using UnaryOperationMapType = OperationMap<nvinfer1::UnaryOperation>;
+const UnaryOperationMapType* UnaryOperationMap();
+
+// Map from Tensorflow boolean operation names to TensorRT unary operations.
+const UnaryOperationMapType* UnaryBooleanOperationMap();
+
 // Map of all supported ActivationTypes.
-const operationMap<nvinfer1::ActivationType>* ActivationTypeMap();
-// Map of all supported BinaryOperations.
-typedef operationMap<nvinfer1::ElementWiseOperation> binaryOperationMap;
-const binaryOperationMap* BinaryOperationMap();
-const binaryOperationMap* BinaryBooleanOperationMap();
+const OperationMap<nvinfer1::ActivationType>* ActivationTypeMap();
+
+// Map from Tensorflow binary operation names to TensorRT binary operations types.
+using BinaryOperationMapType = OperationMap<nvinfer1::ElementWiseOperation>;
+const BinaryOperationMapType* BinaryOperationMap();
+
+// Map from Tensorflow boolean binary operation names to TensorRT binary operations types.
+const BinaryOperationMapType* BinaryBooleanOperationMap();
 
 template <typename T>
 absl::InlinedVector<std::string, 10> GetOperationNames(const T& set) {

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1842,7 +1842,7 @@ class OpConverter_UnaryTest : public ParameterizedOpConverterTestBase {
  public:
   template <typename S>
   void RunTests(
-      const string& testName, const operationMap<S>& map,
+      const string& testName, const OperationMap<S>& map,
       std::map<std::string,
                std::pair<std::function<NodeDef(DataType)>, T (*)(T)>>& op_map,
       const std::vector<T> input_values, const std::string input_name = "input",
@@ -1924,7 +1924,7 @@ class OpConverter_BinaryTest : public ParameterizedOpConverterTestBase {
  public:
   template <typename S>
   void RunTests(
-      const operationMap<S>& map,
+      const OperationMap<S>& map,
       std::map<std::string,
                std::pair<std::function<NodeDef(DataType)>, std::vector<T>>>&
           op_test_info,

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/binary_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/binary_ops.cc
@@ -21,8 +21,9 @@ limitations under the License.
 namespace tensorflow {
 namespace tensorrt {
 namespace convert {
-const binaryOperationMap *BinaryOperationMap() {
-  static auto *const m = new binaryOperationMap({
+
+const BinaryOperationMapType* BinaryOperationMap() {
+  static const auto* map = new BinaryOperationMapType({
       {"Add", nvinfer1::ElementWiseOperation::kSUM},
       {"AddV2", nvinfer1::ElementWiseOperation::kSUM},
       {"Mul", nvinfer1::ElementWiseOperation::kPROD},
@@ -34,25 +35,27 @@ const binaryOperationMap *BinaryOperationMap() {
       {"Maximum", nvinfer1::ElementWiseOperation::kMAX},
       {"Pow", nvinfer1::ElementWiseOperation::kPOW},
   });
-  return m;
+  return map;
 }
 
-const binaryOperationMap *BinaryBooleanOperationMap() {
-  static auto *const m = new binaryOperationMap({
+const BinaryOperationMapType* BinaryBooleanOperationMap() {
+  static const auto *map = new BinaryOperationMapType({
       {"LogicalOr", nvinfer1::ElementWiseOperation::kOR},
       {"LogicalAnd", nvinfer1::ElementWiseOperation::kAND},
   });
-  return m;
+  return map;
 }
 
+namespace {
 class ConvertBinaryImpl {
  protected:
-  ConvertBinaryImpl(const binaryOperationMap *pOperMap) : pOperMap_(pOperMap) {}
+  ConvertBinaryImpl(const BinaryOperationMapType* pOperMap)
+      : pOperMap_(pOperMap) {}
 
-  Status ValidateImpl(const OpConverterParams &params,
+  Status ValidateImpl(const OpConverterParams& params,
                       bool both_tensors = false,
-                      const std::vector<string> &not_supported_ops = {}) {
-    const auto &node_def = params.node_def;
+                      const std::vector<string>& not_supported_ops = {}) {
+    const auto& node_def = params.node_def;
     const auto op = node_def.op();
     const auto op_pair = pOperMap_->find(op);
     if (op_pair == pOperMap_->end()) {
@@ -60,7 +63,7 @@ class ConvertBinaryImpl {
     }
 
     // Constant folding should have been done by TensorFlow.
-    const auto &inputs = params.inputs;
+    const auto& inputs = params.inputs;
     if (inputs.at(0).is_weights() && inputs.at(1).is_weights()) {
       return errors::Unimplemented(
           "Constant folding is falled back to TensorFlow, binary op '", op,
@@ -68,7 +71,7 @@ class ConvertBinaryImpl {
     }
 
     if (!not_supported_ops.empty() && params.use_implicit_batch) {
-      const auto &end = not_supported_ops.end();
+      const auto& end = not_supported_ops.end();
       if (std::find(not_supported_ops.begin(), end, op) != end) {
         return errors::Unimplemented(
             "Binary op: '", op, "' is not supported in implicit batch mode");
@@ -87,21 +90,20 @@ class ConvertBinaryImpl {
         inputs.at(0), inputs.at(1), true, params.use_implicit_batch,
         broadcasted_dims, broadcasted_dims + 1));
 
-    for (int i = 0; i < 2; i++) {
-      tensor_[i] = nullptr;
+    for (int i = 0; i < tensor_.size(); i++) {
       // This will also convert constants to tensors.
       TF_RETURN_IF_ERROR(PrepareTensorForShape(
           params.converter, inputs.at(i), broadcasted_dims[i],
-          params.validation_only, tensor_ + i, node_def, i));
+          params.validation_only, &tensor_[i], node_def, i));
     }
     operation_ = op_pair->second;
     return Status::OK();
   }
 
-  Status ConvertImpl(const OpConverterParams &params) {
-    const auto &node_def = params.node_def;
+  Status ConvertImpl(const OpConverterParams& params) {
+    const auto& node_def = params.node_def;
     // Add ElementWise layer.
-    nvinfer1::ILayer *layer = params.converter->network()->addElementWise(
+    nvinfer1::ILayer* layer = params.converter->network()->addElementWise(
         *tensor_[0]->trt_tensor(), *tensor_[1]->trt_tensor(), operation_);
     TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
 
@@ -121,15 +123,15 @@ class ConvertBinaryImpl {
   }
 
  private:
-  const binaryOperationMap *pOperMap_;
-  ITensorProxyPtr tensor_[2];
+  const BinaryOperationMapType* pOperMap_;
+  std::array<ITensorProxyPtr, 2> tensor_{nullptr, nullptr};
   nvinfer1::ElementWiseOperation operation_;
 };
 
 class ConvertBinary : public OpConverterBase<ConvertBinary>,
                       protected ConvertBinaryImpl {
  public:
-  explicit ConvertBinary(OpConverterParams *params)
+  explicit ConvertBinary(OpConverterParams* params)
       : OpConverterBase<ConvertBinary>(params),
         ConvertBinaryImpl(BinaryOperationMap()) {}
 
@@ -148,7 +150,7 @@ class ConvertBinary : public OpConverterBase<ConvertBinary>,
 class ConvertBooleanBinary : public OpConverterBase<ConvertBooleanBinary>,
                              public ConvertBinaryImpl {
  public:
-  explicit ConvertBooleanBinary(OpConverterParams *params)
+  explicit ConvertBooleanBinary(OpConverterParams* params)
       : OpConverterBase<ConvertBooleanBinary>(params),
         ConvertBinaryImpl(BinaryBooleanOperationMap()) {}
 
@@ -160,7 +162,7 @@ class ConvertBooleanBinary : public OpConverterBase<ConvertBooleanBinary>,
     return ConvertBinaryImpl::InputSpec();
   }
 
-  static constexpr const char *NodeDefDataTypeAttributeName() { return ""; }
+  static constexpr const char* NodeDefDataTypeAttributeName() { return ""; }
   Status Validate() {
 #if IS_TRT_VERSION_GE(8, 2, 0, 0)
     return ValidateImpl(*params_, true, {"LogicalOr", "LogicalAnd"});
@@ -171,6 +173,7 @@ class ConvertBooleanBinary : public OpConverterBase<ConvertBooleanBinary>,
   }
   Status Convert() { return ConvertImpl(*params_); }
 };
+}  // namespace
 
 REGISTER_DEFAULT_TRT_OP_CONVERTER(MakeConverterFunction<ConvertBinary>(),
                                   GetOperationNames(*BinaryOperationMap()));

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/unary_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/unary_ops.cc
@@ -22,7 +22,7 @@ namespace tensorflow {
 namespace tensorrt {
 namespace convert {
 
-const unaryOperationMap* UnaryOperationMap() {
+const UnaryOperationMapType* UnaryOperationMap() {
   static auto* const m =
       new std::unordered_map<string, nvinfer1::UnaryOperation>({
         {"Neg", nvinfer1::UnaryOperation::kNEG},
@@ -54,14 +54,14 @@ const unaryOperationMap* UnaryOperationMap() {
   return m;
 }
 
-const unaryOperationMap* UnaryBooleanOperationMap() {
-  static auto* const m = new unaryOperationMap({
+const UnaryOperationMapType* UnaryBooleanOperationMap() {
+  static auto* const m = new UnaryOperationMapType({
       {"LogicalNot", nvinfer1::UnaryOperation::kNOT},
   });
   return m;
 }
 
-const operationMap<nvinfer1::ActivationType>* ActivationTypeMap() {
+const OperationMap<nvinfer1::ActivationType>* ActivationTypeMap() {
   static auto* const m =
       new std::unordered_map<string, nvinfer1::ActivationType>({
           {"LeakyRelu", nvinfer1::ActivationType::kLEAKY_RELU},
@@ -80,7 +80,7 @@ const operationMap<nvinfer1::ActivationType>* ActivationTypeMap() {
 template <typename T>
 class ConvertUnaryImpl {
  protected:
-  ConvertUnaryImpl(const operationMap<T>* pOperMap) : pOperMap_(pOperMap) {}
+  ConvertUnaryImpl(const OperationMap<T>* pOperMap) : pOperMap_(pOperMap) {}
 
   Status ValidateImpl(const OpConverterParams& params,
                       const std::vector<string>& not_supported_ops = {}) {
@@ -129,7 +129,7 @@ class ConvertUnaryImpl {
   }
 
  protected:
-  const operationMap<T>* pOperMap_;
+  const OperationMap<T>* pOperMap_;
 };
 
 class ConvertUnary : public OpConverterBase<ConvertUnary>,


### PR DESCRIPTION
Converts various `typedef`s in `convert_nodes.h` to C++ type aliases.

Applies `clang-format` to `convert/ops/binary_ops.cc`.

Changes use of C-style array to C++ `std::array` in `convert/ops/binary_ops.cc`.