### PR TITLE
r2.9 cherry-pick: Fix bazel error when building mkl_aarch64 build on Arm

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -223,9 +223,7 @@ build:mkl_threadpool --define=build_with_mkl_opensource=true
 build:mkl_threadpool -c opt
 
 # Config setting to build oneDNN with Compute Library for the Arm Architecture (ACL).
-# This build is for the inference regime only.
 build:mkl_aarch64 --define=build_with_mkl_aarch64=true
-build:mkl_aarch64 --define=tensorflow_mkldnn_contraction_kernel=0
 build:mkl_aarch64 --define=build_with_openmp=true
 build:mkl_aarch64 -c opt
 


### PR DESCRIPTION
Fix bazel multiple-match error when building `//tensorflow/core/kernels:eigen_contraction_kernel` with `--config=mkl_aarch64` on aarch64. 

Root cause: 
`--config=mkl_aarch64` defines a build option that explicitly disable oneDNN usage in `eigen_contraction_kernel` when it doesn't need to because it's already disabled by default on Arm CPUs (the duplicate matches are from defining the flag and from being on Arm architecture).

Error message:
```
//tensorflow/core/kernels:no_mkldnn_contraction_kernel
Multiple matches are not allowed unless one is unambiguously more specialized.
```

Original PR: https://github.com/tensorflow/tensorflow/pull/55700