### PR TITLE
Support NHWC for Tensor_Float_32 + Ampere GPUs

### DIFF
--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -1165,10 +1165,12 @@ cc_library(
         "//tensorflow/core/grappler:grappler_item",
         "//tensorflow/core/grappler:op_types",
         "//tensorflow/core/grappler/clusters:cluster",
-        "//tensorflow/core/platform:tensor_float_32_hdr_lib",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
-    ],
+    ] + if_static(
+        ["//tensorflow/core/platform:tensor_float_32_utils"],
+        ["//tensorflow/core/platform:tensor_float_32_hdr_lib"],
+    ),
 )
 
 tf_cuda_cc_test(

--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -1165,6 +1165,7 @@ cc_library(
         "//tensorflow/core/grappler:grappler_item",
         "//tensorflow/core/grappler:op_types",
         "//tensorflow/core/grappler/clusters:cluster",
+        "//tensorflow/core/platform:tensor_float_32_hdr_lib",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
     ],

--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -1177,6 +1177,12 @@ filegroup(
     compatible_with = get_compatible_with_portable(),
 )
 
+cc_library(
+    name = "tensor_float_32_hdr_lib",
+    hdrs = [":tensor_float_32_hdr"],
+    compatible_with = get_compatible_with_portable(),
+)
+
 tf_cc_tests(
     name = "low_level_library_tests",
     size = "small",

--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -1177,12 +1177,6 @@ filegroup(
     compatible_with = get_compatible_with_portable(),
 )
 
-cc_library(
-    name = "tensor_float_32_hdr_lib",
-    hdrs = [":tensor_float_32_hdr"],
-    compatible_with = get_compatible_with_portable(),
-)
-
 tf_cc_tests(
     name = "low_level_library_tests",
     size = "small",


### PR DESCRIPTION
To better utilize the Tensor Cores of TF32 dtype on Ampere GPUs, NHWC data format is recommended. This PR allows the grappler layout optimizer to enforce a target=NHWC optimization when TF32 + Ampere is detected.

cc. @nluehr 