### PR TITLE
Refactoring of the converter for Activation operators

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -3182,30 +3182,6 @@ Status ConvertPool(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertLeakyRelu(OpConverterParams* params) {
-  const auto& inputs = params->inputs;
-  const auto& node_def = params->node_def;
-  TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"input", false}}));
-  TF_RETURN_IF_ERROR(
-      AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
-
-  float alpha{0.f};
-  TF_RETURN_IF_ERROR(GetNodeAttr(AttrSlice(node_def), "alpha", &alpha));
-
-  // Use IActivationLayer when available.
-  if (params->validation_only) return Status::OK();
-
-  nvinfer1::IActivationLayer* layer =
-      params->converter->network()->addActivation(
-          *inputs.at(0).tensor()->trt_tensor(),
-          nvinfer1::ActivationType::kLEAKY_RELU);
-  TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
-  params->converter->SetLayerName(layer, node_def, "activation");
-  layer->setAlpha(alpha);
-  params->outputs->push_back(TRT_TensorOrWeights(layer->getOutput(0)));
-  return Status::OK();
-}
-
 Status ConvertClipByValue(OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
@@ -3242,76 +3218,6 @@ Status ConvertClipByValue(OpConverterParams* params) {
   layer->setAlpha(clip_value_min);
   layer->setBeta(clip_value_max);
   TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
-  params->converter->SetLayerName(layer, node_def, "activation");
-  params->outputs->push_back(TRT_TensorOrWeights(layer->getOutput(0)));
-  return Status::OK();
-}
-
-const operationMap<nvinfer1::ActivationType>* ActivationTypeMap() {
-  static auto* const m =
-      new std::unordered_map<string, nvinfer1::ActivationType>({
-          {"Relu", nvinfer1::ActivationType::kRELU},
-          {"Sigmoid", nvinfer1::ActivationType::kSIGMOID},
-          {"Tanh", nvinfer1::ActivationType::kTANH},
-          {"Elu", nvinfer1::ActivationType::kELU},
-          {"Selu", nvinfer1::ActivationType::kSELU},
-          {"Softsign", nvinfer1::ActivationType::kSOFTSIGN},
-          {"Softplus", nvinfer1::ActivationType::kSOFTPLUS},
-      });
-  return m;
-}
-
-Status ConvertActivation(OpConverterParams* params) {
-  const auto& inputs = params->inputs;
-  const auto& node_def = params->node_def;
-  TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"input", false}}));
-  TF_RETURN_IF_ERROR(
-      AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
-  auto op_pair = ActivationTypeMap()->find(node_def.op());
-  if (op_pair == ActivationTypeMap()->end()) {
-    return errors::Unimplemented("Activation op: ", node_def.op(),
-                                 " not supported");
-  }
-  if (params->validation_only) return Status::OK();
-
-  // Start conversion.
-  nvinfer1::IActivationLayer* layer =
-      params->converter->network()->addActivation(
-          *inputs.at(0).tensor()->trt_tensor(), op_pair->second);
-  TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
-  params->converter->SetLayerName(layer, node_def, "activation");
-  // Set parameters.
-  if (node_def.op() == "Elu") {
-    layer->setAlpha(1.0f);
-  } else if (node_def.op() == "Selu") {
-    // From tensorflow/core/kernels/relu_op_functor.h
-    layer->setAlpha(1.7580993408473768599402175208123f);
-    layer->setBeta(1.0507009873554804934193349852946f);
-  } else if (node_def.op() == "Softplus") {
-    layer->setAlpha(1.0f);
-    layer->setBeta(1.0f);
-  }
-  params->outputs->push_back(TRT_TensorOrWeights(layer->getOutput(0)));
-  return Status::OK();
-}
-
-Status ConvertRelu6(OpConverterParams* params) {
-  const auto& inputs = params->inputs;
-  const auto& node_def = params->node_def;
-  TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"input", false}}));
-  TF_RETURN_IF_ERROR(
-      AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
-  if (params->validation_only) return Status::OK();
-
-  nvinfer1::IActivationLayer* layer =
-      params->converter->network()->addActivation(
-          *inputs.at(0).tensor()->trt_tensor(),
-          nvinfer1::ActivationType::kCLIP);
-  TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
-  layer->setAlpha(0.0f);
-  layer->setBeta(6.0f);
-  ITensorProxyPtr output_tensor = layer->getOutput(0);
-  params->converter->ProvideQuantizationRange(&output_tensor, 0.0f, 6.0f);
   params->converter->SetLayerName(layer, node_def, "activation");
   params->outputs->push_back(TRT_TensorOrWeights(layer->getOutput(0)));
   return Status::OK();
@@ -5783,11 +5689,9 @@ REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertExpandDims, "ExpandDims");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertFusedConv2DBiasActivation,
                                   "FusedConv2DBiasActivation");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertGather, "GatherV2");
-REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertLeakyRelu, "LeakyRelu");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertMatMul, "MatMul");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertPack, "Pack");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertPad, "Pad");
-REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertRelu6, "Relu6");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertReshape, "Reshape");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertConv3D, "Conv3D");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertConv3DBackpropInputV2,
@@ -5809,8 +5713,6 @@ REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertStridedSlice, "StridedSlice");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertTopK, "TopKV2");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertTranspose, "Transpose");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertUnpack, "Unpack");
-REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertActivation,
-                                  GetOperationNames(*ActivationTypeMap()));
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertPool, {"MaxPool", "AvgPool"});
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertFusedBatchNorm,
                                   {"FusedBatchNorm", "FusedBatchNormV2",

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -28,6 +28,7 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "absl/algorithm/container.h"
 #include "absl/base/call_once.h"
 #include "absl/strings/match.h"
@@ -36,8 +37,6 @@ limitations under the License.
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "third_party/gpus/cuda/include/cuda.h"
-#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 #include "tensorflow/cc/ops/nn_ops_internal.h"
@@ -67,6 +66,8 @@ limitations under the License.
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/protobuf/config.pb.h"  // NOLINT
 #include "tensorflow/core/public/session.h"
+#include "third_party/gpus/cuda/include/cuda.h"
+#include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/tensorrt/NvInfer.h"
 
 namespace tensorflow {
@@ -1372,7 +1373,7 @@ class OpConverterTest : public ::testing::Test {
 
   // Adds weights for both validation and conversion. The type of the weight is
   // determined by tf_type. The initial value vector (values) can have any
-  // type (T) that can be static casted to tf_type.
+  // type (T) that can be statically casted to tf_type.
   template <typename T = int32>
   void AddTestWeights(const string& name, const std::vector<int>& dims,
                       const std::vector<T>& values_inp, DataType tf_type,
@@ -1842,13 +1843,11 @@ class OpConverter_UnaryTest : public ParameterizedOpConverterTestBase {
  public:
   template <typename S>
   void RunTests(
-      const string& testName, std::vector<string>& ops_to_test,
-      const operationMap<S>& map,
+      const string& testName, const operationMap<S>& map,
       std::map<std::string,
                std::pair<std::function<NodeDef(DataType)>, T (*)(T)>>& op_map,
       const std::vector<T> input_values, const std::string input_name = "input",
-      float max_abs_error = 0.0001, bool nan_sensitive = true,
-      bool checkOutput = false) {
+      float max_abs_error = 0.0001, bool nan_sensitive = true) {
     // Prepare test parameters.
     auto p = TestParamBase{
         {1, 1, 2, 3},  // input dims
@@ -1856,11 +1855,12 @@ class OpConverter_UnaryTest : public ParameterizedOpConverterTestBase {
         {1, 1, 2, 3},  // expected output dims
     };
 
+    // Get list of ops to test.
+    std::vector<string> ops_to_test;
     for (auto& pair : map) {
       ops_to_test.push_back(pair.first);
     }
 
-    const auto& runtime_status = checkOutput ? Status::OK() : p.runtime_status;
     for (const string& op_name : ops_to_test) {
       SCOPED_TRACE(op_name);
       if (!op_map.count(op_name)) {
@@ -1869,8 +1869,7 @@ class OpConverter_UnaryTest : public ParameterizedOpConverterTestBase {
 
       const DataType tf_type = get_tf_type();
       const NodeDef& node_def = op_map[op_name].first(tf_type);
-      runExpectedToFailTest(node_def, input_name, input_values, op_name,
-                            checkOutput);
+      runExpectedToFailTest(node_def, input_name, input_values, op_name);
 
       Status conv_status = Status::OK();
       if (trt_mode_ == TrtTestMode::kImplicitBatch &&
@@ -1892,7 +1891,7 @@ class OpConverter_UnaryTest : public ParameterizedOpConverterTestBase {
                      std::back_inserter(output), op_map[op_name].second);
 
       TestOpConverter("my_unary", node_def, p.expected_output_dims, conv_status,
-                      runtime_status,
+                      Status::OK(),
                       ArrayFloatNear(output, max_abs_error, nan_sensitive),
                       {output_tf_type});
     }
@@ -1900,7 +1899,8 @@ class OpConverter_UnaryTest : public ParameterizedOpConverterTestBase {
   void runExpectedToFailTest(const NodeDef& node_def,
                              const std::string& input_name,
                              const std::vector<T>& input_values,
-                             const std::string& op_name, bool activation) {
+                             const std::string& op_name) {
+
     // Input is weights, should fail.
     Reset();
     std::string error =
@@ -1909,12 +1909,6 @@ class OpConverter_UnaryTest : public ParameterizedOpConverterTestBase {
     RunValidationAndConversion(node_def, error::UNIMPLEMENTED, error);
 
     // Input has 0 dimensions, should fail.
-    if (activation) {
-      // TODO (drivanov): activate this subtest for ConvertActivation after
-      // changes in the validation part of the corresponding converters
-      return;
-    }
-
     Reset();
     std::vector<int32> dims = {};
     if (trt_mode_ == TrtTestMode::kImplicitBatch) {
@@ -1923,6 +1917,7 @@ class OpConverter_UnaryTest : public ParameterizedOpConverterTestBase {
     error = "At least 1 dimension is required for UNARY operation '" + op_name +
             "'";
     AddTestTensor("input", dims);
+    RunValidationAndConversion(node_def, error::INVALID_ARGUMENT, error);
   }
 };
 
@@ -4219,12 +4214,6 @@ TEST_P(OpConverter_FP32_UnaryTest, ConvertActivation) {
          [](float x) { return std::log(std::exp(x) + 1); });
 #undef ADD_OP
 
-  // Get list of ops to test.
-  std::vector<string> ops_to_test;
-  // Add other activation ops to test.
-  ops_to_test.push_back("Relu6");
-  ops_to_test.push_back("LeakyRelu");
-
   // std::exp in Softplus will overflow for input > 88
   const std::vector<float> input = {-100, -2, -1, 0, 1, 88};
   const bool nan_sensitive = false;
@@ -4235,8 +4224,8 @@ TEST_P(OpConverter_FP32_UnaryTest, ConvertActivation) {
 #else
   const float max_abs_error = 0.;
 #endif
-  RunTests("Activation", ops_to_test, *ActivationTypeMap(), op_map, input,
-           "input", max_abs_error, nan_sensitive, true);
+  RunTests("Activation", *ActivationTypeMap(), op_map, input, "input",
+           max_abs_error, nan_sensitive);
 }
 
 TEST_P(OpConverter_FP32_Test, ConvertExpandDims) {
@@ -7083,14 +7072,9 @@ TEST_P(OpConverter_FP32_UnaryTest, ConvertUnary) {
   ADD_OP("Sqrt", ops::Sqrt, std::sqrt);
   ADD_OP("Tan", ops::Tan, std::tan);
 #undef ADD_OP
-  // Get list of ops to test.
-  std::vector<string> ops_to_test;
-  // Add other unary ops to test.
-  ops_to_test.push_back("Rsqrt");
 
   std::vector<float> input_values{-0.9f, 0.6f, 0.0f, -3.5f, 100.0f, 2.9f};
-  RunTests("Unary", ops_to_test, *UnaryOperationMap(), op_map, input_values,
-           "x");
+  RunTests("Unary", *UnaryOperationMap(), op_map, input_values, "x");
 }
 
 TEST_P(OpConverter_BOOL_Test, ConvertBoolean) {
@@ -7107,9 +7091,8 @@ TEST_P(OpConverter_BOOL_Test, ConvertBoolean) {
 
 #if IS_TRT_VERSION_GE(8, 2, 0, 0)
   // The test does not actually run for TPT versions less than 8.2
-  std::vector<string> ops_to_test;
-  RunTests("LogicalUnary", ops_to_test, *UnaryBooleanOperationMap(), op_map,
-           input_values, "x");
+  RunTests("LogicalUnary", *UnaryBooleanOperationMap(), op_map, input_values,
+           "x");
 #endif
 }
 

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/unary_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/unary_ops.cc
@@ -61,11 +61,28 @@ const unaryOperationMap* UnaryBooleanOperationMap() {
   return m;
 }
 
+const operationMap<nvinfer1::ActivationType>* ActivationTypeMap() {
+  static auto* const m =
+      new std::unordered_map<string, nvinfer1::ActivationType>({
+          {"LeakyRelu", nvinfer1::ActivationType::kLEAKY_RELU},
+          {"Relu", nvinfer1::ActivationType::kRELU},
+          {"Relu6", nvinfer1::ActivationType::kCLIP},
+          {"Sigmoid", nvinfer1::ActivationType::kSIGMOID},
+          {"Tanh", nvinfer1::ActivationType::kTANH},
+          {"Elu", nvinfer1::ActivationType::kELU},
+          {"Selu", nvinfer1::ActivationType::kSELU},
+          {"Softsign", nvinfer1::ActivationType::kSOFTSIGN},
+          {"Softplus", nvinfer1::ActivationType::kSOFTPLUS},
+      });
+  return m;
+}
+
+template <typename T>
 class ConvertUnaryImpl {
  protected:
-  ConvertUnaryImpl(const unaryOperationMap* pOperMap) : pOperMap_(pOperMap) {}
+  ConvertUnaryImpl(const operationMap<T>* pOperMap) : pOperMap_(pOperMap) {}
 
-  Status ImplValidate(const OpConverterParams& params,
+  Status ValidateImpl(const OpConverterParams& params,
                       const std::vector<string>& not_supported_ops = {}) {
     const auto& op = params.node_def.op();
     if (pOperMap_->find(op) == pOperMap_->end()) {
@@ -88,7 +105,8 @@ class ConvertUnaryImpl {
     return Status::OK();
   }
 
-  Status ImplConvert(const OpConverterParams& params) {
+
+  Status ConvertImpl(const OpConverterParams& params) {
     const auto& node_def = params.node_def;
     auto* converter = params.converter;
     const auto op_pair = pOperMap_->find(node_def.op());
@@ -111,12 +129,12 @@ class ConvertUnaryImpl {
         InputArgSpec::Create("x", TrtInputArg::kTensor)};
   }
 
- private:
-  const unaryOperationMap* pOperMap_;
+ protected:
+  const operationMap<T>* pOperMap_;
 };
 
 class ConvertUnary : public OpConverterBase<ConvertUnary>,
-                     protected ConvertUnaryImpl {
+                     protected ConvertUnaryImpl<nvinfer1::UnaryOperation> {
  public:
   explicit ConvertUnary(OpConverterParams* params)
       : OpConverterBase<ConvertUnary>(params),
@@ -131,12 +149,12 @@ class ConvertUnary : public OpConverterBase<ConvertUnary>,
   }
 
   static constexpr const char* NodeDefDataTypeAttributeName() { return ""; }
-  Status Validate() { return ImplValidate(*params_, {"Sign", "Round"}); }
-  Status Convert() { return ImplConvert(*params_); }
+  Status Validate() { return ValidateImpl(*params_, {"Sign", "Round"}); }
+  Status Convert() { return ConvertImpl(*params_); }
 };
 
 class ConvertBooleanUnary : public OpConverterBase<ConvertBooleanUnary>,
-                            public ConvertUnaryImpl {
+                            public ConvertUnaryImpl<nvinfer1::UnaryOperation> {
  public:
   explicit ConvertBooleanUnary(OpConverterParams* params)
       : OpConverterBase<ConvertBooleanUnary>(params),
@@ -153,13 +171,70 @@ class ConvertBooleanUnary : public OpConverterBase<ConvertBooleanUnary>,
   static constexpr const char* NodeDefDataTypeAttributeName() { return ""; }
   Status Validate() {
 #if IS_TRT_VERSION_GE(8, 2, 0, 0)
-    return ImplValidate(*params_, {"LogicalNot"});
+    return ValidateImpl(*params_, {"LogicalNot"});
 #else
     return errors::Unimplemented("Boolean op: ", params_->node_def.op(),
                                  " is not supported in TRT version < 8.2");
 #endif
   }
-  Status Convert() { return ImplConvert(*params_); }
+  Status Convert() { return ConvertImpl(*params_); }
+};
+
+class ConvertActivation : public OpConverterBase<ConvertActivation>,
+                          protected ConvertUnaryImpl<nvinfer1::ActivationType> {
+ public:
+  explicit ConvertActivation(OpConverterParams* params)
+      : OpConverterBase<ConvertActivation>(params),
+        ConvertUnaryImpl(ActivationTypeMap()) {}
+
+  static constexpr std::array<DataType, 2> AllowedDataTypes() {
+    return {DataType::DT_FLOAT, DataType::DT_HALF};
+  }
+
+  static constexpr std::array<InputArgSpec, 1> InputSpec() {
+    return std::array<InputArgSpec, 1>{
+        InputArgSpec::Create("input", TrtInputArg::kTensor)};
+  }
+
+  static constexpr const char* NodeDefDataTypeAttributeName() { return ""; }
+  Status Validate() {
+    TF_RETURN_IF_ERROR(ValidateImpl(*params_));
+    const auto& node_def = params_->node_def;
+    if (node_def.op() == "LeakyRelu") {
+      return GetNodeAttr(AttrSlice(node_def), "alpha", &alpha_);
+    }
+    alpha_ = 1.0f;
+    return Status::OK();
+  }
+  Status Convert() {
+    auto* converter = params_->converter;
+    const auto& inputs = params_->inputs;
+    const auto& node_def = params_->node_def;
+    const auto& op = node_def.op();
+    const auto op_pair = pOperMap_->find(op);
+    nvinfer1::IActivationLayer* layer =
+        converter->network()->addActivation(
+            *inputs.at(0).tensor()->trt_tensor(), op_pair->second);
+    TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
+    converter->SetLayerName(layer, node_def, "activation");
+    ITensorProxyPtr output_tensor = layer->getOutput(0);
+    // Set parameters.
+    if (op == "Selu") {
+      // From tensorflow/core/kernels/relu_op_functor.h
+      alpha_ = 1.7580993408473768599402175208123f;
+      layer->setBeta(1.0507009873554804934193349852946f);
+    } else if (op == "Softplus") {
+      layer->setBeta(1.0f);
+    } else if (op == "Relu6") {
+      layer->setBeta(6.0f);
+      converter->ProvideQuantizationRange(&output_tensor, alpha_ = 0.0f, 6.0f);
+    }
+    layer->setAlpha(alpha_);
+    params_->outputs->push_back(TRT_TensorOrWeights(output_tensor));
+    return Status::OK();
+  }
+ private:
+  float alpha_ = 0.f;
 };
 
 REGISTER_DEFAULT_TRT_OP_CONVERTER(MakeConverterFunction<ConvertUnary>(),
@@ -168,6 +243,8 @@ REGISTER_DEFAULT_TRT_OP_CONVERTER(
     MakeConverterFunction<ConvertBooleanUnary>(),
     GetOperationNames(*UnaryBooleanOperationMap()));
 
+REGISTER_DEFAULT_TRT_OP_CONVERTER(MakeConverterFunction<ConvertActivation>(),
+                                  GetOperationNames(*ActivationTypeMap()));
 }  // namespace convert
 }  // namespace tensorrt
 }  // namespace tensorflow


### PR DESCRIPTION
This PR refactors the converter for Activation operators. It also replaces the special implemented converters for Relu6 and LeakyRelu operator with the activation operator implementation.

A new check and corresponding sub-tests for Validation were added: at least 1 dimension is required for input of any Activation operation.