### PR TITLE
Fix some typos for is, for, have, one, from, to, ouput.

### DIFF
--- a/tensorflow/dtensor/cc/tensor_layout.h
+++ b/tensorflow/dtensor/cc/tensor_layout.h
@@ -212,7 +212,7 @@ class Mesh {
   // the core represented by global device ID of i in this mesh.
   //
   // The entry stored under the empty name key (the so-called "default mapping"
-  // in some comments) is special. Is is always set at the end of TPU
+  // in some comments) is special. It is always set at the end of TPU
   // initialization. It represents the mapping for any mesh whose global device
   // IDs follow TF task-device ordinals. Legacy and test meshes created without
   // using the `create_tpu_mesh` helper follow that rule and can use this entry.

--- a/tensorflow/dtensor/mlir/Passes.td
+++ b/tensorflow/dtensor/mlir/Passes.td
@@ -92,7 +92,7 @@ def DTensorUndoMergeConstAcrossMesh
 
 def DTensorSetDefaultSharding
     : Pass<"dtensor-set-default-sharding", "mlir::func::FuncOp"> {
-  let summary = "Sets default sharding of TPU computation inputs/ouputs to maximal.";
+  let summary = "Sets default sharding of TPU computation inputs/outputs to maximal.";
   let constructor = "CreateDTensorSetDefaultSharding()";
   let dependentDialects = [
   ];

--- a/tensorflow/dtensor/mlir/expansions/control_flow_spmd_expander.cc
+++ b/tensorflow/dtensor/mlir/expansions/control_flow_spmd_expander.cc
@@ -95,7 +95,7 @@ IfRegionSPMDExpander::ComputeLayoutForward(
 StatusOr<llvm::DenseMap<int, Layout>>
 IfRegionSPMDExpander::ComputeLayoutBackward(
     mlir::Operation* op, const llvm::DenseMap<int, Layout>& output_layouts) {
-  // Layout propagation for for TF::IfRegion op is no-op. Actual layout
+  // Layout propagation for TF::IfRegion op is no-op. Actual layout
   // propagation logic depends on layout propgation of ops inside the
   // then/else regions of the IfRegion op.
   TF_ASSIGN_OR_RETURN(const Mesh mesh, ExtractDeviceMeshEnclosingCluster(op));

--- a/tensorflow/dtensor/mlir/expansions/matmul_spmd_expander.cc
+++ b/tensorflow/dtensor/mlir/expansions/matmul_spmd_expander.cc
@@ -422,7 +422,7 @@ StatusOr<llvm::DenseMap<int, Layout>> MatMulSPMDExpander::ComputeLayoutBackward(
   // Make sure necessary dimensions are replicated.
   //
   // Due to broadcasting, each of the batch dimensions (i.e. from dimension 0
-  // to dim - 2), one of the two inputs may have have dimension 1 while the
+  // to dim - 2), one of the two inputs may have dimension 1 while the
   // other has dimension > 1 and equal to the dim of the output. Since a
   // tensor with dimension 1 cannot be sharded, we set this to unsharded.
   auto specs_matmul_operands = [](const llvm::ArrayRef<int64>& tensor_shape,

--- a/tensorflow/dtensor/mlir/layout_propagation_v2.cc
+++ b/tensorflow/dtensor/mlir/layout_propagation_v2.cc
@@ -1138,7 +1138,7 @@ mlir::LogicalResult InsertRelayoutForWhileLoops(
       return op->emitOpError() << "body terminator is not a Yield op.";
 
     for (int i = 0; i < op.body().getNumArguments(); ++i) {
-      // Inputs should only have one one, a DTensorLayout op.
+      // Inputs should only have one, a DTensorLayout op.
       mlir::Value argument = op.body().getArgument(i);
       if (!argument.hasOneUse())
         return op.emitOpError()

--- a/tensorflow/dtensor/mlir/mesh_propagation.cc
+++ b/tensorflow/dtensor/mlir/mesh_propagation.cc
@@ -95,7 +95,7 @@ mlir::LogicalResult ExtractMeshFromOpOutput(mlir::Value value,
       llvm::dyn_cast<mlir::tf_device::ClusterOp>(value.getDefiningOp());
   if (!operand_cluster) {
     return mlir::emitError(value.getLoc())
-           << "operand must be from from different device cluster.";
+           << "operand must be from different device cluster.";
   }
 
   auto mesh_or_status = ExtractDeviceMeshFromOp(operand_cluster);

--- a/tensorflow/dtensor/mlir/move_compilation_to_host.cc
+++ b/tensorflow/dtensor/mlir/move_compilation_to_host.cc
@@ -249,7 +249,7 @@ mlir::LogicalResult HandleCompilationOps(
     }
   }
 
-  // Identify TPUCompileOp to to host side mesh.
+  // Identify TPUCompileOp to host side mesh.
   llvm::SmallVector<mlir::TF::_TPUCompileMlirOp, 4> compile_ops;
   tpu_function.walk(
       [&](mlir::TF::_TPUCompileMlirOp op) { compile_ops.emplace_back(op); });


### PR DESCRIPTION
Fix some typos for is, for, have, one, from, to, ouput.