### PR TITLE
Fix device index issue with XLA + Horovod

### DIFF
--- a/tensorflow/compiler/xla/service/platform_util.cc
+++ b/tensorflow/compiler/xla/service/platform_util.cc
@@ -200,10 +200,8 @@ PlatformUtil::GetStreamExecutors(
     // shared hosts.
     if (allowed_devices) {
       int count = 0;
-      for (auto ai = allowed_devices->cbegin(); ai != allowed_devices->cend();
-           ai++) {
+      for (const auto& i : *allowed_devices) {
         if (count >= device_count) break;
-        int i = *ai;
         thread_pool.Schedule([i, count, &create_fn]() { create_fn(i, count); });
         count++;
       }

--- a/tensorflow/compiler/xla/service/platform_util.cc
+++ b/tensorflow/compiler/xla/service/platform_util.cc
@@ -176,33 +176,41 @@ PlatformUtil::GetStreamExecutors(
   {
     tensorflow::thread::ThreadPool thread_pool(
         tensorflow::Env::Default(), "device_initialization", device_count);
-    for (int i = 0; i < device_count; ++i) {
-      // Once a stream executor is instantiated it will cause allocations on
-      // the device, for example for GPUs cuda context, cudnn handles etc. will
-      // be constructed. By constructing stream executors only on the
-      // allowed_devices, we don't make any allocations on other devices.
-      // This helps in multi-process executions on the same host like horovod or
-      // shared hosts.
-      if (allowed_devices && allowed_devices->count(i) == 0) {
-        VLOG(1) << "Not initializing StreamExecutor for device " << i
-                << " since it is not in the visible device list";
-        continue;
-      }
-      thread_pool.Schedule([platform, i, &stream_executors]() {
-        VLOG(1) << "Started device init " << i;
-        auto executor_status = platform->ExecutorForDevice(i);
-        if (executor_status.ok()) {
-          se::StreamExecutor* executor = executor_status.ValueOrDie();
-          if (IsDeviceSupported(executor)) {
-            stream_executors[i] = executor;
-          }
-        } else {
-          LOG(WARNING) << "unable to create StreamExecutor for "
-                       << platform->Name() << ":" << i << ": "
-                       << executor_status.status().error_message();
+    auto create_fn = [platform, &stream_executors](int device_ordinal,
+                                                   int count) {
+      VLOG(1) << "Started device init " << device_ordinal;
+      auto executor_status = platform->ExecutorForDevice(device_ordinal);
+      if (executor_status.ok()) {
+        se::StreamExecutor* executor = executor_status.ValueOrDie();
+        if (IsDeviceSupported(executor)) {
+          stream_executors[count] = executor;
         }
-        VLOG(1) << "Finished device init " << i;
-      });
+      } else {
+        LOG(WARNING) << "unable to create StreamExecutor for "
+                     << platform->Name() << ":" << device_ordinal << ": "
+                     << executor_status.status().error_message();
+      }
+      VLOG(1) << "Finished device init " << device_ordinal;
+    };
+    // Once a stream executor is instantiated it will cause allocations on
+    // the device, for example for GPUs cuda context, cudnn handles etc. will
+    // be constructed. By constructing stream executors only on the
+    // allowed_devices, we don't make any allocations on other devices.
+    // This helps in multi-process executions on the same host like horovod or
+    // shared hosts.
+    if (allowed_devices) {
+      int count = 0;
+      for (auto ai = allowed_devices->cbegin(); ai != allowed_devices->cend();
+           ai++) {
+        if (count >= device_count) break;
+        int i = *ai;
+        thread_pool.Schedule([i, count, &create_fn]() { create_fn(i, count); });
+        count++;
+      }
+    } else {
+      for (int i = 0; i < device_count; ++i) {
+        thread_pool.Schedule([i, &create_fn]() { create_fn(i, i); });
+      }
     }
     // Block here in thread_pool destructor until all devices are initialized.
   }


### PR DESCRIPTION
The PR is to fix the issue that the XLA always iterates the devices from 0 when creating stream executor on the multi-GPU environment (e.g. Horovod), which might cause none of the devices is picked. For example:

GPU 0: allowed_device=0, device_count=1 => iterate 0 and pick device 0, exceed device_count and exit
GPU 1: allowed_device=1, device_count=1 => iterate 0 (not in allowed_device), exceed device_count and exit (This is wrong!)

We fix this issue by iterating the device indices from the allowed_devices if provided.

GPU 0: allowed_device=0, device_count=1 => iterate 0 and pick device 0, exceed device_count and exit
GPU 1: allowed_device=1, device_count=1 => iterate 1 and pick device 1, exceed device_count and exit

cc. @nluehr 