### PR TITLE
Ensure there are more elements in the dataset than twice CPU core count

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/service/fault_tolerance_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/service/fault_tolerance_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for tf.data service ops where servers are started late or preempted."""
+import multiprocessing
 import threading
 import time
 
@@ -197,7 +198,7 @@ class FaultToleranceTest(data_service_test_base.TestBase,
   @combinations.generate(test_base.eager_only_combinations())
   def testAddWorkerMidJob(self):
     cluster = data_service_test_base.TestCluster(num_workers=1)
-    num_elements = 100
+    num_elements = 2 * multiprocessing.cpu_count() + 100
     ds = self.make_distributed_range_dataset(num_elements, cluster)
     iterator = iter(ds)
     results = []
@@ -224,7 +225,7 @@ class FaultToleranceTest(data_service_test_base.TestBase,
         num_workers=1,
         work_dir=work_dir,
         fault_tolerant_mode=fault_tolerant_mode)
-    num_elements = 100
+    num_elements = 2 * multiprocessing.cpu_count() + 100
     ds = self.make_distributed_range_dataset(num_elements, cluster)
     iterator = iter(ds)
     # Read halfway through the dataset.


### PR DESCRIPTION
Fixes //tensorflow/python/data/experimental/kernel_tests/service:fault_tolerance_test on machines with more than 50 CPU cores
This test reads half of the elements and assumes that the amount left
is more than will be prefectched which can be equal to the number
of CPU cores. For high CPU core count machines (>50) this is not
true when there are only 100 elements in the dataset.
So instead set the size of the dataset based on the CPU core count
to ensure that the remaining elements in the dataset are always
more than will be prefetched.