### PR TITLE
Force ops without inputs to the start of the pseudo-topological order in `lift_to_graph`

### DIFF
--- a/tensorflow/python/eager/lift_to_graph.py
+++ b/tensorflow/python/eager/lift_to_graph.py
@@ -287,6 +287,13 @@ def lift_to_graph(tensors,
       # we'll do ugly post-hoc mutations instead.
       ops_to_visit.append(next(iter(unvisited_ops)))
 
+  # When the topological sort fails due to loops, it can result in exceptions
+  # later when copying a node which inputs haven't been copied yet. We can
+  # improve that pseudo-topological order slightly by putting the ops without
+  # inputs, such as constants, at the start of the topological order (i.e at
+  # the end of ops_to_copy).
+  ops_to_copy.sort(key=(lambda op: len(op_selector.graph_inputs(op)) == 0))
+
   # When lifting from one FuncGraph to another, we will need to capture the
   # relevant tensors as well.
   captures = []


### PR DESCRIPTION
This is a temporary fix to make some models affected by the bug described in #55736 work.
In models with loops, when the topological order isn't defined, I have observed cases where an op appeared before its inputs in the topological order, despite those inputs being constants. Performing a stable sort based on whether an op has inputs or not conserves a topological order, and can improve a non-topological order and in many cases prevent the exceptions I have observed. Note that this isn't a proper fix for the aforementioned issue.