### PR TITLE
Fix typo in MLIR-HLO's bazel BUILD file

### DIFF
--- a/tensorflow/compiler/mlir/hlo/BUILD
+++ b/tensorflow/compiler/mlir/hlo/BUILD
@@ -10,7 +10,7 @@ package(
 )
 
 exports_files([
-    "include/mlir-hlo/Dialect/mhlo/IR/clo_ops.td",
+    "include/mlir-hlo/Dialect/mhlo/IR/chlo_ops.td",
     "include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.td",
     "include/mlir-hlo/Dialect/lhlo/IR/lhlo_ops.td",
 ])


### PR DESCRIPTION
This fixes error from `bazel build //tensorflow/compiler/mlir/hlo:*`