### PR TITLE
[mhlo] Clean up C-API references to CPP

### DIFF
--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo-c/Attributes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo-c/Attributes.h
@@ -174,14 +174,14 @@ mlirMhloConvDimensionNumbersGetOutputSpatialDimensionsElem(MlirAttribute attr,
 // Creates a new ComparisonDirection attribute with the given
 // 'direction' string parameter.
 MLIR_CAPI_EXPORTED MlirAttribute
-mlirMhloComparisonDirectionAttrGet(MlirContext ctx, const char *direction);
+mlirMhloComparisonDirectionAttrGet(MlirContext ctx, MlirStringRef direction);
 
 // Returns true if the given attribute is a ComparisonDirection attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsAComparisonDirectionAttr(
     MlirAttribute attr);
 
 // Returns the direction string associated with ComparisonDirection attribute.
-MLIR_CAPI_EXPORTED const char *
+MLIR_CAPI_EXPORTED MlirStringRef
 mlirMhloComparisonDirectionAttrGetDirection(MlirAttribute attr);
 
 //
@@ -190,14 +190,14 @@ mlirMhloComparisonDirectionAttrGetDirection(MlirAttribute attr);
 // Creates a new ComparisonType attribute with the given 'type' string
 // parameter.
 MLIR_CAPI_EXPORTED MlirAttribute
-mlirMhloComparisonTypeAttrGet(MlirContext ctx, const char *type);
+mlirMhloComparisonTypeAttrGet(MlirContext ctx, MlirStringRef type);
 
 // Returns true if the given attribute is a ComparisonType attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsAComparisonTypeAttr(
     MlirAttribute attr);
 
 // Returns the type string associated with ComparisonType attribute.
-MLIR_CAPI_EXPORTED const char *
+MLIR_CAPI_EXPORTED MlirStringRef
 mlirMhloComparisonTypeAttrGetType(MlirAttribute attr);
 
 //
@@ -206,13 +206,13 @@ mlirMhloComparisonTypeAttrGetType(MlirAttribute attr);
 // Creates a new Precision attribute with the given 'type' string
 // parameter.
 MLIR_CAPI_EXPORTED MlirAttribute mlirMhloPrecisionAttrGet(MlirContext ctx,
-                                                          const char *type);
+                                                          MlirStringRef type);
 
 // Returns true if the given attribute is a Precision attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsAPrecisionAttr(MlirAttribute attr);
 
 // Returns the type string associated with Precision attribute.
-MLIR_CAPI_EXPORTED const char *
+MLIR_CAPI_EXPORTED MlirStringRef
 mlirMhloPrecisionAttrGetPrecision(MlirAttribute attr);
 
 //
@@ -220,13 +220,13 @@ mlirMhloPrecisionAttrGetPrecision(MlirAttribute attr);
 //
 // Creates a new FftType attribute with the given 'type' string parameter.
 MLIR_CAPI_EXPORTED MlirAttribute mlirMhloFftTypeAttrGet(MlirContext ctx,
-                                                        const char *type);
+                                                        MlirStringRef type);
 
 // Returns true if the given attribute is a FftType attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsAFftTypeAttr(MlirAttribute attr);
 
 // Returns the type string associated with FftType attribute.
-MLIR_CAPI_EXPORTED const char *
+MLIR_CAPI_EXPORTED MlirStringRef
 mlirMhloFftTypeAttrGetFftType(MlirAttribute attr);
 
 //
@@ -235,14 +235,14 @@ mlirMhloFftTypeAttrGetFftType(MlirAttribute attr);
 // Creates a new DequantizeMode attribute with the given 'mode' string
 // parameter.
 MLIR_CAPI_EXPORTED MlirAttribute
-mlirMhloDequantizeModeAttrGet(MlirContext ctx, const char *mode);
+mlirMhloDequantizeModeAttrGet(MlirContext ctx, MlirStringRef mode);
 
 // Returns true if the given attribute is a DequantizeMode attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsADequantizeModeAttr(
     MlirAttribute attr);
 
 // Returns the mode string associated with DequantizeMode attribute.
-MLIR_CAPI_EXPORTED const char *
+MLIR_CAPI_EXPORTED MlirStringRef
 mlirMhloDequantizeModeAttrGetDequantizeMode(MlirAttribute attr);
 
 //
@@ -250,13 +250,13 @@ mlirMhloDequantizeModeAttrGetDequantizeMode(MlirAttribute attr);
 //
 // Creates a new Transpose attribute with the given 'type' string parameter.
 MLIR_CAPI_EXPORTED MlirAttribute mlirMhloTransposeAttrGet(MlirContext ctx,
-                                                          const char *type);
+                                                          MlirStringRef type);
 
 // Returns true if the given attribute is a Transpose attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsATransposeAttr(MlirAttribute attr);
 
 // Returns the type string associated with Transpose attribute.
-MLIR_CAPI_EXPORTED const char *
+MLIR_CAPI_EXPORTED MlirStringRef
 mlirMhloTransposeAttrGetTranspose(MlirAttribute attr);
 
 //
@@ -264,13 +264,13 @@ mlirMhloTransposeAttrGetTranspose(MlirAttribute attr);
 //
 // Creates a new FusionKind attribute with the given 'kind' string parameter.
 MLIR_CAPI_EXPORTED MlirAttribute mlirMhloFusionKindAttrGet(MlirContext ctx,
-                                                           const char *kind);
+                                                           MlirStringRef kind);
 
 // Returns true if the given attribute is a FusionKind attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsAFusionKindAttr(MlirAttribute attr);
 
 // Returns the fusion-kind string associated with FusionKind attribute.
-MLIR_CAPI_EXPORTED const char *
+MLIR_CAPI_EXPORTED MlirStringRef
 mlirMhloFusionKindAttrGetFusionKind(MlirAttribute attr);
 
 #ifdef __cplusplus

--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo-c/Attributes.h
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo-c/Attributes.h
@@ -14,8 +14,6 @@ limitations under the License.
 
 #include <sys/types.h>
 
-#include <string>
-
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
 
@@ -175,16 +173,16 @@ mlirMhloConvDimensionNumbersGetOutputSpatialDimensionsElem(MlirAttribute attr,
 //
 // Creates a new ComparisonDirection attribute with the given
 // 'direction' string parameter.
-MLIR_CAPI_EXPORTED MlirAttribute mlirMhloComparisonDirectionAttrGet(
-    MlirContext ctx, const std::string &direction);
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirMhloComparisonDirectionAttrGet(MlirContext ctx, const char *direction);
 
 // Returns true if the given attribute is a ComparisonDirection attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsAComparisonDirectionAttr(
     MlirAttribute attr);
 
 // Returns the direction string associated with ComparisonDirection attribute.
-MLIR_CAPI_EXPORTED std::string mlirMhloComparisonDirectionAttrGetDirection(
-    MlirAttribute attr);
+MLIR_CAPI_EXPORTED const char *
+mlirMhloComparisonDirectionAttrGetDirection(MlirAttribute attr);
 
 //
 // ComparisonTypeAttr.
@@ -192,44 +190,44 @@ MLIR_CAPI_EXPORTED std::string mlirMhloComparisonDirectionAttrGetDirection(
 // Creates a new ComparisonType attribute with the given 'type' string
 // parameter.
 MLIR_CAPI_EXPORTED MlirAttribute
-mlirMhloComparisonTypeAttrGet(MlirContext ctx, const std::string &type);
+mlirMhloComparisonTypeAttrGet(MlirContext ctx, const char *type);
 
 // Returns true if the given attribute is a ComparisonType attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsAComparisonTypeAttr(
     MlirAttribute attr);
 
 // Returns the type string associated with ComparisonType attribute.
-MLIR_CAPI_EXPORTED std::string mlirMhloComparisonTypeAttrGetType(
-    MlirAttribute attr);
+MLIR_CAPI_EXPORTED const char *
+mlirMhloComparisonTypeAttrGetType(MlirAttribute attr);
 
 //
 // PrecisionAttr.
 //
 // Creates a new Precision attribute with the given 'type' string
 // parameter.
-MLIR_CAPI_EXPORTED MlirAttribute
-mlirMhloPrecisionAttrGet(MlirContext ctx, const std::string &type);
+MLIR_CAPI_EXPORTED MlirAttribute mlirMhloPrecisionAttrGet(MlirContext ctx,
+                                                          const char *type);
 
 // Returns true if the given attribute is a Precision attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsAPrecisionAttr(MlirAttribute attr);
 
 // Returns the type string associated with Precision attribute.
-MLIR_CAPI_EXPORTED std::string mlirMhloPrecisionAttrGetPrecision(
-    MlirAttribute attr);
+MLIR_CAPI_EXPORTED const char *
+mlirMhloPrecisionAttrGetPrecision(MlirAttribute attr);
 
 //
 // FftTypeAttr.
 //
 // Creates a new FftType attribute with the given 'type' string parameter.
-MLIR_CAPI_EXPORTED MlirAttribute
-mlirMhloFftTypeAttrGet(MlirContext ctx, const std::string &type);
+MLIR_CAPI_EXPORTED MlirAttribute mlirMhloFftTypeAttrGet(MlirContext ctx,
+                                                        const char *type);
 
 // Returns true if the given attribute is a FftType attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsAFftTypeAttr(MlirAttribute attr);
 
 // Returns the type string associated with FftType attribute.
-MLIR_CAPI_EXPORTED std::string mlirMhloFftTypeAttrGetFftType(
-    MlirAttribute attr);
+MLIR_CAPI_EXPORTED const char *
+mlirMhloFftTypeAttrGetFftType(MlirAttribute attr);
 
 //
 // DequantizeModeAttr.
@@ -237,43 +235,43 @@ MLIR_CAPI_EXPORTED std::string mlirMhloFftTypeAttrGetFftType(
 // Creates a new DequantizeMode attribute with the given 'mode' string
 // parameter.
 MLIR_CAPI_EXPORTED MlirAttribute
-mlirMhloDequantizeModeAttrGet(MlirContext ctx, const std::string &mode);
+mlirMhloDequantizeModeAttrGet(MlirContext ctx, const char *mode);
 
 // Returns true if the given attribute is a DequantizeMode attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsADequantizeModeAttr(
     MlirAttribute attr);
 
 // Returns the mode string associated with DequantizeMode attribute.
-MLIR_CAPI_EXPORTED std::string mlirMhloDequantizeModeAttrGetDequantizeMode(
-    MlirAttribute attr);
+MLIR_CAPI_EXPORTED const char *
+mlirMhloDequantizeModeAttrGetDequantizeMode(MlirAttribute attr);
 
 //
 // TransposeAttr.
 //
 // Creates a new Transpose attribute with the given 'type' string parameter.
-MLIR_CAPI_EXPORTED MlirAttribute
-mlirMhloTransposeAttrGet(MlirContext ctx, const std::string &type);
+MLIR_CAPI_EXPORTED MlirAttribute mlirMhloTransposeAttrGet(MlirContext ctx,
+                                                          const char *type);
 
 // Returns true if the given attribute is a Transpose attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsATransposeAttr(MlirAttribute attr);
 
 // Returns the type string associated with Transpose attribute.
-MLIR_CAPI_EXPORTED std::string mlirMhloTransposeAttrGetTranspose(
-    MlirAttribute attr);
+MLIR_CAPI_EXPORTED const char *
+mlirMhloTransposeAttrGetTranspose(MlirAttribute attr);
 
 //
 // FusionKindAttr.
 //
 // Creates a new FusionKind attribute with the given 'kind' string parameter.
-MLIR_CAPI_EXPORTED MlirAttribute
-mlirMhloFusionKindAttrGet(MlirContext ctx, const std::string &kind);
+MLIR_CAPI_EXPORTED MlirAttribute mlirMhloFusionKindAttrGet(MlirContext ctx,
+                                                           const char *kind);
 
 // Returns true if the given attribute is a FusionKind attribute.
 MLIR_CAPI_EXPORTED bool mlirMhloAttributeIsAFusionKindAttr(MlirAttribute attr);
 
 // Returns the fusion-kind string associated with FusionKind attribute.
-MLIR_CAPI_EXPORTED std::string mlirMhloFusionKindAttrGetFusionKind(
-    MlirAttribute attr);
+MLIR_CAPI_EXPORTED const char *
+mlirMhloFusionKindAttrGetFusionKind(MlirAttribute attr);
 
 #ifdef __cplusplus
 }

--- a/tensorflow/compiler/mlir/hlo/lib/CAPI/Attributes.cpp
+++ b/tensorflow/compiler/mlir/hlo/lib/CAPI/Attributes.cpp
@@ -14,6 +14,7 @@ limitations under the License.
 
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops_base_attrs.h"
 #include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Support.h"
 
 //
 // ScatterDimensionNumbersAttr.
@@ -352,9 +353,9 @@ int64_t mlirMhloConvDimensionNumbersGetOutputSpatialDimensionsElem(
 // ComparisonDirectionAttr.
 //
 MlirAttribute mlirMhloComparisonDirectionAttrGet(MlirContext ctx,
-                                                 const char *direction) {
+                                                 MlirStringRef direction) {
   llvm::Optional<mlir::mhlo::ComparisonDirection> compare_direction =
-      mlir::mhlo::symbolizeComparisonDirection(direction);
+      mlir::mhlo::symbolizeComparisonDirection(unwrap(direction));
   if (!compare_direction)
     llvm_unreachable("Invalid comparison-direction specified.");
   return wrap(mlir::mhlo::ComparisonDirectionAttr::get(
@@ -365,22 +366,19 @@ bool mlirMhloAttributeIsAComparisonDirectionAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::ComparisonDirectionAttr>();
 }
 
-const char *mlirMhloComparisonDirectionAttrGetDirection(MlirAttribute attr) {
-  return mlir::mhlo::stringifyComparisonDirection(
-             unwrap(attr)
-                 .cast<mlir::mhlo::ComparisonDirectionAttr>()
-                 .getValue())
-      .str()
-      .c_str();
+MlirStringRef mlirMhloComparisonDirectionAttrGetDirection(MlirAttribute attr) {
+  return wrap(mlir::mhlo::stringifyComparisonDirection(
+      unwrap(attr).cast<mlir::mhlo::ComparisonDirectionAttr>().getValue()));
 }
 
 //
 // ComparisonTypeAttr.
 //
 
-MlirAttribute mlirMhloComparisonTypeAttrGet(MlirContext ctx, const char *type) {
+MlirAttribute mlirMhloComparisonTypeAttrGet(MlirContext ctx,
+                                            MlirStringRef type) {
   llvm::Optional<mlir::mhlo::ComparisonType> compare_type =
-      mlir::mhlo::symbolizeComparisonType(type);
+      mlir::mhlo::symbolizeComparisonType(unwrap(type));
   if (!compare_type) llvm_unreachable("Invalid comparison-type specified.");
   return wrap(mlir::mhlo::ComparisonTypeAttr::get(unwrap(ctx),
                                                   compare_type.getValue()));
@@ -390,20 +388,18 @@ bool mlirMhloAttributeIsAComparisonTypeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::ComparisonTypeAttr>();
 }
 
-const char *mlirMhloComparisonTypeAttrGetType(MlirAttribute attr) {
-  return mlir::mhlo::stringifyComparisonType(
-             unwrap(attr).cast<mlir::mhlo::ComparisonTypeAttr>().getValue())
-      .str()
-      .c_str();
+MlirStringRef mlirMhloComparisonTypeAttrGetType(MlirAttribute attr) {
+  return wrap(mlir::mhlo::stringifyComparisonType(
+      unwrap(attr).cast<mlir::mhlo::ComparisonTypeAttr>().getValue()));
 }
 
 //
 // PrecisionAttr.
 //
 
-MlirAttribute mlirMhloPrecisionAttrGet(MlirContext ctx, const char *type) {
+MlirAttribute mlirMhloPrecisionAttrGet(MlirContext ctx, MlirStringRef type) {
   llvm::Optional<mlir::mhlo::Precision> precision_type =
-      mlir::mhlo::symbolizePrecision(type);
+      mlir::mhlo::symbolizePrecision(unwrap(type));
   if (!precision_type) llvm_unreachable("Invalid precision-type specified.");
   return wrap(
       mlir::mhlo::PrecisionAttr::get(unwrap(ctx), precision_type.getValue()));
@@ -413,20 +409,18 @@ bool mlirMhloAttributeIsAPrecisionAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::PrecisionAttr>();
 }
 
-const char *mlirMhloPrecisionAttrGetPrecision(MlirAttribute attr) {
-  return mlir::mhlo::stringifyPrecision(
-             unwrap(attr).cast<mlir::mhlo::PrecisionAttr>().getValue())
-      .str()
-      .c_str();
+MlirStringRef mlirMhloPrecisionAttrGetPrecision(MlirAttribute attr) {
+  return wrap(mlir::mhlo::stringifyPrecision(
+      unwrap(attr).cast<mlir::mhlo::PrecisionAttr>().getValue()));
 }
 
 //
 // FftTypeAttr.
 //
 
-MlirAttribute mlirMhloFftTypeAttrGet(MlirContext ctx, const char *type) {
+MlirAttribute mlirMhloFftTypeAttrGet(MlirContext ctx, MlirStringRef type) {
   llvm::Optional<mlir::mhlo::FftType> fft_type =
-      mlir::mhlo::symbolizeFftType(type);
+      mlir::mhlo::symbolizeFftType(unwrap(type));
   if (!fft_type) llvm_unreachable("Invalid fft-type specified.");
   return wrap(mlir::mhlo::FftTypeAttr::get(unwrap(ctx), fft_type.getValue()));
 }
@@ -435,20 +429,19 @@ bool mlirMhloAttributeIsAFftTypeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::FftTypeAttr>();
 }
 
-const char *mlirMhloFftTypeAttrGetFftType(MlirAttribute attr) {
-  return mlir::mhlo::stringifyFftType(
-             unwrap(attr).cast<mlir::mhlo::FftTypeAttr>().getValue())
-      .str()
-      .c_str();
+MlirStringRef mlirMhloFftTypeAttrGetFftType(MlirAttribute attr) {
+  return wrap(mlir::mhlo::stringifyFftType(
+      unwrap(attr).cast<mlir::mhlo::FftTypeAttr>().getValue()));
 }
 
 //
 // DequantizeModeAttr.
 //
 
-MlirAttribute mlirMhloDequantizeModeAttrGet(MlirContext ctx, const char *mode) {
+MlirAttribute mlirMhloDequantizeModeAttrGet(MlirContext ctx,
+                                            MlirStringRef mode) {
   llvm::Optional<mlir::mhlo::DequantizeMode> dequantize_mode =
-      mlir::mhlo::symbolizeDequantizeMode(mode);
+      mlir::mhlo::symbolizeDequantizeMode(unwrap(mode));
   if (!dequantize_mode) llvm_unreachable("Invalid dequantize-mode specified.");
   return wrap(mlir::mhlo::DequantizeModeAttr::get(unwrap(ctx),
                                                   dequantize_mode.getValue()));
@@ -458,20 +451,18 @@ bool mlirMhloAttributeIsADequantizeModeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::DequantizeModeAttr>();
 }
 
-const char *mlirMhloDequantizeModeAttrGetDequantizeMode(MlirAttribute attr) {
-  return mlir::mhlo::stringifyDequantizeMode(
-             unwrap(attr).cast<mlir::mhlo::DequantizeModeAttr>().getValue())
-      .str()
-      .c_str();
+MlirStringRef mlirMhloDequantizeModeAttrGetDequantizeMode(MlirAttribute attr) {
+  return wrap(mlir::mhlo::stringifyDequantizeMode(
+      unwrap(attr).cast<mlir::mhlo::DequantizeModeAttr>().getValue()));
 }
 
 //
 // TransposeAttr.
 //
 
-MlirAttribute mlirMhloTransposeAttrGet(MlirContext ctx, const char *type) {
+MlirAttribute mlirMhloTransposeAttrGet(MlirContext ctx, MlirStringRef type) {
   llvm::Optional<mlir::mhlo::Transpose> transpose_type =
-      mlir::mhlo::symbolizeTranspose(type);
+      mlir::mhlo::symbolizeTranspose(unwrap(type));
   if (!transpose_type) llvm_unreachable("Invalid transpose-type specified.");
   return wrap(
       mlir::mhlo::TransposeAttr::get(unwrap(ctx), transpose_type.getValue()));
@@ -481,20 +472,18 @@ bool mlirMhloAttributeIsATransposeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::TransposeAttr>();
 }
 
-const char *mlirMhloTransposeAttrGetTranspose(MlirAttribute attr) {
-  return mlir::mhlo::stringifyTranspose(
-             unwrap(attr).cast<mlir::mhlo::TransposeAttr>().getValue())
-      .str()
-      .c_str();
+MlirStringRef mlirMhloTransposeAttrGetTranspose(MlirAttribute attr) {
+  return wrap(mlir::mhlo::stringifyTranspose(
+      unwrap(attr).cast<mlir::mhlo::TransposeAttr>().getValue()));
 }
 
 //
 // FusionKindAttr.
 //
 
-MlirAttribute mlirMhloFusionKindAttrGet(MlirContext ctx, const char *kind) {
+MlirAttribute mlirMhloFusionKindAttrGet(MlirContext ctx, MlirStringRef kind) {
   llvm::Optional<mlir::mhlo::FusionKind> fusion_kind =
-      mlir::mhlo::symbolizeFusionKind(kind);
+      mlir::mhlo::symbolizeFusionKind(unwrap(kind));
   if (!fusion_kind) llvm_unreachable("Invalid fusion-kind specified.");
   return wrap(
       mlir::mhlo::FusionKindAttr::get(unwrap(ctx), fusion_kind.getValue()));
@@ -504,9 +493,7 @@ bool mlirMhloAttributeIsAFusionKindAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::FusionKindAttr>();
 }
 
-const char *mlirMhloFusionKindAttrGetFusionKind(MlirAttribute attr) {
-  return mlir::mhlo::stringifyFusionKind(
-             unwrap(attr).cast<mlir::mhlo::FusionKindAttr>().getValue())
-      .str()
-      .c_str();
+MlirStringRef mlirMhloFusionKindAttrGetFusionKind(MlirAttribute attr) {
+  return wrap(mlir::mhlo::stringifyFusionKind(
+      unwrap(attr).cast<mlir::mhlo::FusionKindAttr>().getValue()));
 }

--- a/tensorflow/compiler/mlir/hlo/lib/CAPI/Attributes.cpp
+++ b/tensorflow/compiler/mlir/hlo/lib/CAPI/Attributes.cpp
@@ -12,8 +12,6 @@ limitations under the License.
 
 #include "mlir-hlo-c/Attributes.h"
 
-#include <string>
-
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops_base_attrs.h"
 #include "mlir/CAPI/IR.h"
 
@@ -354,7 +352,7 @@ int64_t mlirMhloConvDimensionNumbersGetOutputSpatialDimensionsElem(
 // ComparisonDirectionAttr.
 //
 MlirAttribute mlirMhloComparisonDirectionAttrGet(MlirContext ctx,
-                                                 const std::string &direction) {
+                                                 const char *direction) {
   llvm::Optional<mlir::mhlo::ComparisonDirection> compare_direction =
       mlir::mhlo::symbolizeComparisonDirection(direction);
   if (!compare_direction)
@@ -367,20 +365,20 @@ bool mlirMhloAttributeIsAComparisonDirectionAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::ComparisonDirectionAttr>();
 }
 
-std::string mlirMhloComparisonDirectionAttrGetDirection(MlirAttribute attr) {
+const char *mlirMhloComparisonDirectionAttrGetDirection(MlirAttribute attr) {
   return mlir::mhlo::stringifyComparisonDirection(
              unwrap(attr)
                  .cast<mlir::mhlo::ComparisonDirectionAttr>()
                  .getValue())
-      .str();
+      .str()
+      .c_str();
 }
 
 //
 // ComparisonTypeAttr.
 //
 
-MlirAttribute mlirMhloComparisonTypeAttrGet(MlirContext ctx,
-                                            const std::string &type) {
+MlirAttribute mlirMhloComparisonTypeAttrGet(MlirContext ctx, const char *type) {
   llvm::Optional<mlir::mhlo::ComparisonType> compare_type =
       mlir::mhlo::symbolizeComparisonType(type);
   if (!compare_type) llvm_unreachable("Invalid comparison-type specified.");
@@ -392,18 +390,18 @@ bool mlirMhloAttributeIsAComparisonTypeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::ComparisonTypeAttr>();
 }
 
-std::string mlirMhloComparisonTypeAttrGetType(MlirAttribute attr) {
+const char *mlirMhloComparisonTypeAttrGetType(MlirAttribute attr) {
   return mlir::mhlo::stringifyComparisonType(
              unwrap(attr).cast<mlir::mhlo::ComparisonTypeAttr>().getValue())
-      .str();
+      .str()
+      .c_str();
 }
 
 //
 // PrecisionAttr.
 //
 
-MlirAttribute mlirMhloPrecisionAttrGet(MlirContext ctx,
-                                       const std::string &type) {
+MlirAttribute mlirMhloPrecisionAttrGet(MlirContext ctx, const char *type) {
   llvm::Optional<mlir::mhlo::Precision> precision_type =
       mlir::mhlo::symbolizePrecision(type);
   if (!precision_type) llvm_unreachable("Invalid precision-type specified.");
@@ -415,17 +413,18 @@ bool mlirMhloAttributeIsAPrecisionAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::PrecisionAttr>();
 }
 
-std::string mlirMhloPrecisionAttrGetPrecision(MlirAttribute attr) {
+const char *mlirMhloPrecisionAttrGetPrecision(MlirAttribute attr) {
   return mlir::mhlo::stringifyPrecision(
              unwrap(attr).cast<mlir::mhlo::PrecisionAttr>().getValue())
-      .str();
+      .str()
+      .c_str();
 }
 
 //
 // FftTypeAttr.
 //
 
-MlirAttribute mlirMhloFftTypeAttrGet(MlirContext ctx, const std::string &type) {
+MlirAttribute mlirMhloFftTypeAttrGet(MlirContext ctx, const char *type) {
   llvm::Optional<mlir::mhlo::FftType> fft_type =
       mlir::mhlo::symbolizeFftType(type);
   if (!fft_type) llvm_unreachable("Invalid fft-type specified.");
@@ -436,18 +435,18 @@ bool mlirMhloAttributeIsAFftTypeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::FftTypeAttr>();
 }
 
-std::string mlirMhloFftTypeAttrGetFftType(MlirAttribute attr) {
+const char *mlirMhloFftTypeAttrGetFftType(MlirAttribute attr) {
   return mlir::mhlo::stringifyFftType(
              unwrap(attr).cast<mlir::mhlo::FftTypeAttr>().getValue())
-      .str();
+      .str()
+      .c_str();
 }
 
 //
 // DequantizeModeAttr.
 //
 
-MlirAttribute mlirMhloDequantizeModeAttrGet(MlirContext ctx,
-                                            const std::string &mode) {
+MlirAttribute mlirMhloDequantizeModeAttrGet(MlirContext ctx, const char *mode) {
   llvm::Optional<mlir::mhlo::DequantizeMode> dequantize_mode =
       mlir::mhlo::symbolizeDequantizeMode(mode);
   if (!dequantize_mode) llvm_unreachable("Invalid dequantize-mode specified.");
@@ -459,18 +458,18 @@ bool mlirMhloAttributeIsADequantizeModeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::DequantizeModeAttr>();
 }
 
-std::string mlirMhloDequantizeModeAttrGetDequantizeMode(MlirAttribute attr) {
+const char *mlirMhloDequantizeModeAttrGetDequantizeMode(MlirAttribute attr) {
   return mlir::mhlo::stringifyDequantizeMode(
              unwrap(attr).cast<mlir::mhlo::DequantizeModeAttr>().getValue())
-      .str();
+      .str()
+      .c_str();
 }
 
 //
 // TransposeAttr.
 //
 
-MlirAttribute mlirMhloTransposeAttrGet(MlirContext ctx,
-                                       const std::string &type) {
+MlirAttribute mlirMhloTransposeAttrGet(MlirContext ctx, const char *type) {
   llvm::Optional<mlir::mhlo::Transpose> transpose_type =
       mlir::mhlo::symbolizeTranspose(type);
   if (!transpose_type) llvm_unreachable("Invalid transpose-type specified.");
@@ -482,18 +481,18 @@ bool mlirMhloAttributeIsATransposeAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::TransposeAttr>();
 }
 
-std::string mlirMhloTransposeAttrGetTranspose(MlirAttribute attr) {
+const char *mlirMhloTransposeAttrGetTranspose(MlirAttribute attr) {
   return mlir::mhlo::stringifyTranspose(
              unwrap(attr).cast<mlir::mhlo::TransposeAttr>().getValue())
-      .str();
+      .str()
+      .c_str();
 }
 
 //
 // FusionKindAttr.
 //
 
-MlirAttribute mlirMhloFusionKindAttrGet(MlirContext ctx,
-                                        const std::string &kind) {
+MlirAttribute mlirMhloFusionKindAttrGet(MlirContext ctx, const char *kind) {
   llvm::Optional<mlir::mhlo::FusionKind> fusion_kind =
       mlir::mhlo::symbolizeFusionKind(kind);
   if (!fusion_kind) llvm_unreachable("Invalid fusion-kind specified.");
@@ -505,8 +504,9 @@ bool mlirMhloAttributeIsAFusionKindAttr(MlirAttribute attr) {
   return unwrap(attr).isa<mlir::mhlo::FusionKindAttr>();
 }
 
-std::string mlirMhloFusionKindAttrGetFusionKind(MlirAttribute attr) {
+const char *mlirMhloFusionKindAttrGetFusionKind(MlirAttribute attr) {
   return mlir::mhlo::stringifyFusionKind(
              unwrap(attr).cast<mlir::mhlo::FusionKindAttr>().getValue())
-      .str();
+      .str()
+      .c_str();
 }

--- a/tensorflow/compiler/mlir/hlo/python/MlirHloModule.cpp
+++ b/tensorflow/compiler/mlir/hlo/python/MlirHloModule.cpp
@@ -322,7 +322,8 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &direction, MlirContext ctx) {
-            return cls(mlirMhloComparisonDirectionAttrGet(ctx, direction));
+            return cls(
+                mlirMhloComparisonDirectionAttrGet(ctx, direction.c_str()));
           },
           py::arg("cls"), py::arg("comparison_direction"),
           py::arg("context") = py::none(),
@@ -336,7 +337,7 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &type, MlirContext ctx) {
-            return cls(mlirMhloComparisonTypeAttrGet(ctx, type));
+            return cls(mlirMhloComparisonTypeAttrGet(ctx, type.c_str()));
           },
           py::arg("cls"), py::arg("comparison_type"),
           py::arg("context") = py::none(),
@@ -350,7 +351,7 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &type, MlirContext ctx) {
-            return cls(mlirMhloPrecisionAttrGet(ctx, type));
+            return cls(mlirMhloPrecisionAttrGet(ctx, type.c_str()));
           },
           py::arg("cls"), py::arg("precision_type"),
           py::arg("context") = py::none(),
@@ -364,7 +365,7 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &type, MlirContext ctx) {
-            return cls(mlirMhloFftTypeAttrGet(ctx, type));
+            return cls(mlirMhloFftTypeAttrGet(ctx, type.c_str()));
           },
           py::arg("cls"), py::arg("fft_type"), py::arg("context") = py::none(),
           "Creates a FftType attribute with the given type.")
@@ -377,7 +378,7 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &type, MlirContext ctx) {
-            return cls(mlirMhloDequantizeModeAttrGet(ctx, type));
+            return cls(mlirMhloDequantizeModeAttrGet(ctx, type.c_str()));
           },
           py::arg("cls"), py::arg("dequantize_mode"),
           py::arg("context") = py::none(),
@@ -391,7 +392,7 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &type, MlirContext ctx) {
-            return cls(mlirMhloTransposeAttrGet(ctx, type));
+            return cls(mlirMhloTransposeAttrGet(ctx, type.c_str()));
           },
           py::arg("cls"), py::arg("transpose_type"),
           py::arg("context") = py::none(),
@@ -405,7 +406,7 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &kind, MlirContext ctx) {
-            return cls(mlirMhloFusionKindAttrGet(ctx, kind));
+            return cls(mlirMhloFusionKindAttrGet(ctx, kind.c_str()));
           },
           py::arg("cls"), py::arg("fusion_kind"),
           py::arg("context") = py::none(),

--- a/tensorflow/compiler/mlir/hlo/python/MlirHloModule.cpp
+++ b/tensorflow/compiler/mlir/hlo/python/MlirHloModule.cpp
@@ -34,6 +34,11 @@ std::vector<int64_t> attributePropertyVector(
   }
   return result;
 }
+
+auto toPyString(MlirStringRef mlirStringRef) {
+  return py::str(mlirStringRef.data, mlirStringRef.length);
+}
+
 }  // namespace
 
 PYBIND11_MODULE(_mlirHlo, m) {
@@ -322,14 +327,14 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &direction, MlirContext ctx) {
-            return cls(
-                mlirMhloComparisonDirectionAttrGet(ctx, direction.c_str()));
+            return cls(mlirMhloComparisonDirectionAttrGet(
+                ctx, mlirStringRefCreate(direction.c_str(), direction.size())));
           },
           py::arg("cls"), py::arg("comparison_direction"),
           py::arg("context") = py::none(),
           "Creates a ComparisonDirection attribute with the given direction.")
       .def_property_readonly("comparison_direction", [](MlirAttribute self) {
-        return mlirMhloComparisonDirectionAttrGetDirection(self);
+        return toPyString(mlirMhloComparisonDirectionAttrGetDirection(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
@@ -337,13 +342,14 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &type, MlirContext ctx) {
-            return cls(mlirMhloComparisonTypeAttrGet(ctx, type.c_str()));
+            return cls(mlirMhloComparisonTypeAttrGet(
+                ctx, mlirStringRefCreate(type.c_str(), type.size())));
           },
           py::arg("cls"), py::arg("comparison_type"),
           py::arg("context") = py::none(),
           "Creates a ComparisonType attribute with the given type.")
       .def_property_readonly("comparison_type", [](MlirAttribute self) {
-        return mlirMhloComparisonTypeAttrGetType(self);
+        return toPyString(mlirMhloComparisonTypeAttrGetType(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
@@ -351,13 +357,14 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &type, MlirContext ctx) {
-            return cls(mlirMhloPrecisionAttrGet(ctx, type.c_str()));
+            return cls(mlirMhloPrecisionAttrGet(
+                ctx, mlirStringRefCreate(type.c_str(), type.size())));
           },
           py::arg("cls"), py::arg("precision_type"),
           py::arg("context") = py::none(),
           "Creates a Precision attribute with the given type.")
       .def_property_readonly("precision_type", [](MlirAttribute self) {
-        return mlirMhloPrecisionAttrGetPrecision(self);
+        return toPyString(mlirMhloPrecisionAttrGetPrecision(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
@@ -365,12 +372,13 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &type, MlirContext ctx) {
-            return cls(mlirMhloFftTypeAttrGet(ctx, type.c_str()));
+            return cls(mlirMhloFftTypeAttrGet(
+                ctx, mlirStringRefCreate(type.c_str(), type.size())));
           },
           py::arg("cls"), py::arg("fft_type"), py::arg("context") = py::none(),
           "Creates a FftType attribute with the given type.")
       .def_property_readonly("fft_type", [](MlirAttribute self) {
-        return mlirMhloFftTypeAttrGetFftType(self);
+        return toPyString(mlirMhloFftTypeAttrGetFftType(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
@@ -378,13 +386,14 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &type, MlirContext ctx) {
-            return cls(mlirMhloDequantizeModeAttrGet(ctx, type.c_str()));
+            return cls(mlirMhloDequantizeModeAttrGet(
+                ctx, mlirStringRefCreate(type.c_str(), type.size())));
           },
           py::arg("cls"), py::arg("dequantize_mode"),
           py::arg("context") = py::none(),
           "Creates a DequantizeMode attribute with the given mode.")
       .def_property_readonly("dequantize_mode", [](MlirAttribute self) {
-        return mlirMhloDequantizeModeAttrGetDequantizeMode(self);
+        return toPyString(mlirMhloDequantizeModeAttrGetDequantizeMode(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
@@ -392,13 +401,14 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &type, MlirContext ctx) {
-            return cls(mlirMhloTransposeAttrGet(ctx, type.c_str()));
+            return cls(mlirMhloTransposeAttrGet(
+                ctx, mlirStringRefCreate(type.c_str(), type.size())));
           },
           py::arg("cls"), py::arg("transpose_type"),
           py::arg("context") = py::none(),
           "Creates a Transpose attribute with the given type.")
       .def_property_readonly("transpose_type", [](MlirAttribute self) {
-        return mlirMhloTransposeAttrGetTranspose(self);
+        return toPyString(mlirMhloTransposeAttrGetTranspose(self));
       });
 
   mlir::python::adaptors::mlir_attribute_subclass(
@@ -406,12 +416,13 @@ PYBIND11_MODULE(_mlirHlo, m) {
       .def_classmethod(
           "get",
           [](py::object cls, const std::string &kind, MlirContext ctx) {
-            return cls(mlirMhloFusionKindAttrGet(ctx, kind.c_str()));
+            return cls(mlirMhloFusionKindAttrGet(
+                ctx, mlirStringRefCreate(kind.c_str(), kind.size())));
           },
           py::arg("cls"), py::arg("fusion_kind"),
           py::arg("context") = py::none(),
           "Creates a FusionKind attribute with the given kind.")
       .def_property_readonly("fusion_kind", [](MlirAttribute self) {
-        return mlirMhloFusionKindAttrGetFusionKind(self);
+        return toPyString(mlirMhloFusionKindAttrGetFusionKind(self));
       });
 }


### PR DESCRIPTION
remove std::string referencres in ```tensorflow/compiler/mlir/hlo/include/mlir-hlo-c/Attributes.h``` file.