### PR TITLE
Support NHWC for Tensor_Float_32 + Ampere GPUs (Part 3)

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.cc
@@ -94,6 +94,16 @@ HeuristicLayoutAssignment(const HloInstruction* instr,
     return kAllNHWC;
   }
 
+  bool valid_tf32 = input_ty == F32 &&
+                    stream_executor->GetDeviceDescription()
+                        .cuda_compute_capability()
+                        .IsAtLeast(se::CudaComputeCapability::AMPERE) &&
+                    tensorflow::tensor_float_32_execution_enabled();
+  if (valid_tf32) {
+    VLOG(2) << "Using NHWC for tf32 conv " << instr->ToString();
+    return kAllNHWC;
+  }
+
   // If we're not Volta or not fp16, or not conv2D, the decision is easy: Use
   // NCHW.
   if (input_ty != F16 ||

--- a/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/layout_assignment.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/stream_executor_no_cuda.h"
+#include "tensorflow/core/platform/tensor_float_32_utils.h"
 
 namespace xla {
 namespace gpu {


### PR DESCRIPTION
This PR enables the compute in NHWC/NDHWC for XLA. Should be the last PR for this serie.

Part 1: https://github.com/tensorflow/tensorflow/pull/55761
Part 2: https://github.com/tensorflow/tensorflow/pull/55806

cc. @nluehr 