### PR TITLE
Use global cache for MKL primitives

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
@@ -143,8 +143,8 @@ class BatchMatMulMkl : public OpKernel {
     // For matmul, the previous approach (PR #47775) of using Tensor addresses
     // does not work, as the addresses are re-used in matmul with different data
     // The counter  ensure we still benefit from caching via SetMklMatmul().
-    static int counter = 1;
-    params->aarch64_counter = counter++;
+    params->aarch64_counter =
+      MklMatMulPrimitiveFactory<float, Tlhs, Trhs, Toutput>::IncrementCounter();
 #endif
     this->ExtendMklMatMulParams(ctx, *params);
 

--- a/tensorflow/core/kernels/mkl/mkl_concat_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_concat_op.cc
@@ -32,6 +32,9 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/mkl_util.h"
+#ifdef DNNL_AARCH64_USE_ACL
+#include "tensorflow/core/platform/mutex.h"
+#endif
 
 using dnnl::concat;
 using dnnl::stream;
@@ -279,6 +282,9 @@ class MklConcatFwdPrimitive : public MklPrimitive {
                const dnnl::memory& dst_data,
                const MklConcatFwdParams& concat_fwd_dims,
                std::shared_ptr<stream> fwd_stream) {
+#ifdef DNNL_AARCH64_USE_ACL
+    mutex_lock lock(mu_);
+#endif
     DCHECK_EQ(in_data.size(), context_.data_mem.size());
     for (size_t i = 0; i < concat_fwd_dims.num_inputs; i++) {
 #ifndef ENABLE_ONEDNN_OPENMP
@@ -375,6 +381,10 @@ class MklConcatFwdPrimitive : public MklPrimitive {
   }
 
   struct ConcatFwdContext context_;
+
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex mu_;
+#endif
 };
 
 // Class to create/cache the mkl concat primitives based on the

--- a/tensorflow/core/kernels/mkl/mkl_concat_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_concat_op.cc
@@ -283,7 +283,7 @@ class MklConcatFwdPrimitive : public MklPrimitive {
                const MklConcatFwdParams& concat_fwd_dims,
                std::shared_ptr<stream> fwd_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
-    mutex_lock lock(mu_);
+    mutex_lock lock(primitive_execution_mu_);
 #endif
     DCHECK_EQ(in_data.size(), context_.data_mem.size());
     for (size_t i = 0; i < concat_fwd_dims.num_inputs; i++) {
@@ -383,7 +383,7 @@ class MklConcatFwdPrimitive : public MklPrimitive {
   struct ConcatFwdContext context_;
 
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
@@ -23,6 +23,9 @@ limitations under the License.
 #include "tensorflow/core/kernels/mkl/mkl_conv_ops.h"
 #include "tensorflow/core/util/use_cudnn.h"
 #include "tensorflow/core/util/work_sharder.h"
+#ifdef DNNL_AARCH64_USE_ACL
+#include "tensorflow/core/platform/mutex.h"
+#endif
 
 using dnnl::convolution_backward_weights;
 using dnnl::memory;
@@ -88,6 +91,9 @@ class MklConvBwdFilterPrimitive : public MklPrimitive {
   void Execute(const T* src_data, const T* diff_filter_data,
                const T* diff_bias_data, const T* diff_dst_data,
                std::shared_ptr<stream> bwd_filter_stream) {
+#ifdef DNNL_AARCH64_USE_ACL
+    mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
     // TODO(intel-tf): Create a common function and avoid the duplicate code
     context_.src_mem->set_data_handle(
@@ -273,6 +279,10 @@ class MklConvBwdFilterPrimitive : public MklPrimitive {
   }
 
   struct ConvBwdFilterContext context_;
+
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex mu_;
+#endif
 };
 
 template <typename T>

--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
@@ -92,7 +92,7 @@ class MklConvBwdFilterPrimitive : public MklPrimitive {
                const T* diff_bias_data, const T* diff_dst_data,
                std::shared_ptr<stream> bwd_filter_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
-    mutex_lock lock(mu_);
+    mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
     // TODO(intel-tf): Create a common function and avoid the duplicate code
@@ -281,7 +281,7 @@ class MklConvBwdFilterPrimitive : public MklPrimitive {
   struct ConvBwdFilterContext context_;
 
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
@@ -30,6 +30,9 @@ limitations under the License.
 #include "tensorflow/core/kernels/mkl/mkl_conv_ops.h"
 #include "tensorflow/core/util/use_cudnn.h"
 #include "tensorflow/core/util/work_sharder.h"
+#ifdef DNNL_AARCH64_USE_ACL
+#include "tensorflow/core/platform/mutex.h"
+#endif
 
 using dnnl::convolution_backward_data;
 using dnnl::prop_kind;
@@ -90,6 +93,9 @@ class MklConvBwdInputPrimitive : public MklPrimitive {
   void Execute(const T* diff_src_data, const T* filter_data,
                const T* diff_dst_data,
                std::shared_ptr<stream> bwd_input_stream) {
+#ifdef DNNL_AARCH64_USE_ACL
+    mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
     // TODO(intel-tf): Create a common function and avoid the duplicate code
     context_.diff_src_mem->set_data_handle(
@@ -219,6 +225,9 @@ class MklConvBwdInputPrimitive : public MklPrimitive {
   }
 
   struct ConvBwdInputContext context_;
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex mu_;
+#endif
 };
 
 template <typename T>

--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
@@ -94,7 +94,7 @@ class MklConvBwdInputPrimitive : public MklPrimitive {
                const T* diff_dst_data,
                std::shared_ptr<stream> bwd_input_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
-    mutex_lock lock(mu_);
+    mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
     // TODO(intel-tf): Create a common function and avoid the duplicate code
@@ -226,7 +226,7 @@ class MklConvBwdInputPrimitive : public MklPrimitive {
 
   struct ConvBwdInputContext context_;
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -26,6 +26,9 @@ limitations under the License.
 #include "absl/strings/str_join.h"
 #include "tensorflow/core/kernels/mkl/mkl_quantized_conv_ops.h"
 #include "tensorflow/core/kernels/no_op.h"
+#ifdef DNNL_AARCH64_USE_ACL
+#include "tensorflow/core/platform/mutex.h"
+#endif
 
 using dnnl::convolution_forward;
 using dnnl::prop_kind;
@@ -113,6 +116,12 @@ class MklConvFwdPrimitive : public MklPrimitive {
                const Tinput* bn_scale_data, const Tinput* bn_mean_data,
                const Tinput* bn_offset_data, const Tinput* bn_rsqrt_data,
                std::shared_ptr<stream> fwd_stream, void* sp_data) {
+#ifdef DNNL_AARCH64_USE_ACL
+    // when we are using single global cache then in this case
+    // we can have multiple threads running the same primitive
+    // that we created so this should happen under the lock
+    mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
     // TODO(intel-tf): Create a common function and avoid the duplicate code
     context_.src_mem->set_data_handle(
@@ -418,6 +427,11 @@ class MklConvFwdPrimitive : public MklPrimitive {
   }
 
   struct ConvFwdContext context_;
+
+#ifdef DNNL_AARCH64_USE_ACL
+  // Guards Execution()
+  mutex mu_;
+#endif
 };
 
 // TODO(intel-tf): We should not require passing a type to MklPrimitiveFactory.

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -117,10 +117,10 @@ class MklConvFwdPrimitive : public MklPrimitive {
                const Tinput* bn_offset_data, const Tinput* bn_rsqrt_data,
                std::shared_ptr<stream> fwd_stream, void* sp_data) {
 #ifdef DNNL_AARCH64_USE_ACL
-    // when we are using single global cache then in this case
-    // we can have multiple threads running the same primitive
-    // that we created so this should happen under the lock
-    mutex_lock lock(mu_);
+    // When we are using single global cache then in this case we can have
+    // multiple threads running the same primitive that we created so this
+    // should happen under the lock.
+    mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
     // TODO(intel-tf): Create a common function and avoid the duplicate code
@@ -430,7 +430,7 @@ class MklConvFwdPrimitive : public MklPrimitive {
 
 #ifdef DNNL_AARCH64_USE_ACL
   // Guards Execution()
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h
+++ b/tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h
@@ -80,7 +80,7 @@ class MklEltwiseFwdPrimitive : public MklPrimitive {
   //   dst_data:  output data buffer of dst
   void Execute(const T* src_data, T* dst_data, OpKernelContext* op_context) {
 #ifdef DNNL_AARCH64_USE_ACL
-    mutex_lock lock(mu_);
+    mutex_lock lock(primitive_execution_mu_);
 #endif
     context_.src_mem->set_data_handle(
         static_cast<void*>(const_cast<T*>(src_data)));
@@ -167,7 +167,7 @@ class MklEltwiseFwdPrimitive : public MklPrimitive {
   struct EltwiseFwdContext context_;
 
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op.cc
@@ -24,6 +24,9 @@ limitations under the License.
 #include "tensorflow/core/kernels/no_op.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/tensor_format.h"
+#ifdef DNNL_AARCH64_USE_ACL
+#include "tensorflow/core/platform/mutex.h"
+#endif
 
 #define GET_FLAG(bn_flag) static_cast<int>(dnnl::normalization_flags::bn_flag)
 #define IS_SET(cflag) (context_.flags & GET_FLAG(cflag))
@@ -82,6 +85,9 @@ class MklFusedBatchNormFwdPrimitive : public MklPrimitive {
   void Execute(const T* src_data, const U* weights_data, T* dst_data,
                U* mean_data, U* variance_data,
                std::shared_ptr<stream> fwd_stream, U* workspace_data) {
+#ifdef DNNL_AARCH64_USE_ACL
+    mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
     // TODO(intel-tf): Create a common function and avoid the duplicate code
     context_.src_mem->set_data_handle(
@@ -323,6 +329,10 @@ class MklFusedBatchNormFwdPrimitive : public MklPrimitive {
   }
 
   struct BatchNormFwdContext context_;
+
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex mu_;
+#endif
 };
 
 template <typename T, typename U>
@@ -428,6 +438,9 @@ class MklFusedBatchNormBwdPrimitive : public MklPrimitive {
                const T* diff_dst_data, const U* weights_data, T* diff_src_data,
                U* diff_weights_data, U* res_space_data,
                std::shared_ptr<stream> bwd_stream) {
+#ifdef DNNL_AARCH64_USE_ACL
+    mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
     // TODO(intel-tf): Create a common function and avoid the duplicate code
     context_.src_mem->set_data_handle(
@@ -584,6 +597,10 @@ class MklFusedBatchNormBwdPrimitive : public MklPrimitive {
   }
 
   struct BatchNormBwdContext context_;
+
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex mu_;
+#endif
 };
 
 template <typename T, typename U>

--- a/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op.cc
@@ -86,7 +86,7 @@ class MklFusedBatchNormFwdPrimitive : public MklPrimitive {
                U* mean_data, U* variance_data,
                std::shared_ptr<stream> fwd_stream, U* workspace_data) {
 #ifdef DNNL_AARCH64_USE_ACL
-    mutex_lock lock(mu_);
+    mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
     // TODO(intel-tf): Create a common function and avoid the duplicate code
@@ -331,7 +331,7 @@ class MklFusedBatchNormFwdPrimitive : public MklPrimitive {
   struct BatchNormFwdContext context_;
 
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 
@@ -439,7 +439,7 @@ class MklFusedBatchNormBwdPrimitive : public MklPrimitive {
                U* diff_weights_data, U* res_space_data,
                std::shared_ptr<stream> bwd_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
-    mutex_lock lock(mu_);
+    mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
     // TODO(intel-tf): Create a common function and avoid the duplicate code
@@ -599,7 +599,7 @@ class MklFusedBatchNormBwdPrimitive : public MklPrimitive {
   struct BatchNormBwdContext context_;
 
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -27,6 +27,9 @@ limitations under the License.
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/onednn_env_vars.h"
+#ifdef DNNL_AARCH64_USE_ACL
+#include "tensorflow/core/platform/mutex.h"
+#endif
 
 using dnnl::inner_product_forward;
 using dnnl::primitive_attr;
@@ -122,6 +125,12 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
   void Execute(const Tinput* src_data, const Tweight* weight_data,
                const Tbias* bias_data, Toutput* dst_data, void* sp_data,
                std::shared_ptr<stream> fwd_stream) {
+#ifdef DNNL_AARCH64_USE_ACL
+    // when we are using single global cache then in this case
+    // we can have multiple threads running the same primitive
+    // that we created so this should happen under the lock
+    mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
     context_.src_mem->set_data_handle(
         static_cast<void*>(const_cast<Tinput*>(src_data)), *fwd_stream);
@@ -339,6 +348,11 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
   }
 
   struct MklDnnMatMulFwdContext context_;
+
+#ifdef DNNL_AARCH64_USE_ACL
+  // Guards Execution()
+  mutex mu_;
+#endif
 };
 
 template <typename T, typename Tinput, typename Tweight, typename Tbias,
@@ -615,6 +629,9 @@ class MklMatMulPrimitive : public MklPrimitive {
   void Execute(const std::shared_ptr<stream>& stream, const Tlhs* a_data,
                const Trhs* b_data, const Toutput* c_data, void* sp_data,
                void* mul_data = nullptr, void* add_data = nullptr) {
+#ifdef DNNL_AARCH64_USE_ACL
+    mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
     context_.a_mem->set_data_handle(
         static_cast<void*>(const_cast<Tlhs*>(a_data)), *stream);
@@ -783,6 +800,9 @@ class MklMatMulPrimitive : public MklPrimitive {
   }
 
   struct MklMatMulContext context_;
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex mu_;
+#endif
 };
 
 template <typename T, typename Tlhs, typename Trhs, typename Toutput>
@@ -809,6 +829,13 @@ class MklMatMulPrimitiveFactory : public MklPrimitiveFactory<T> {
 
     return matmul_prim;
   }
+
+#ifdef DNNL_AARCH64_USE_ACL
+  static int IncrementCounter() {
+    static std::atomic_int counter{1};
+    return counter.fetch_add(1);
+  }
+#endif
 
  private:
   MklMatMulPrimitiveFactory() {}

--- a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc
+++ b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc
@@ -87,7 +87,7 @@ void MklPoolingFwdPrimitive<T>::Execute(const T* src_data, T* dst_data,
                                         void* ws_data,
                                         std::shared_ptr<stream> fwd_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex_lock lock(mu_);
+  mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
   context_.src_mem->set_data_handle(
@@ -190,7 +190,7 @@ void MklPoolingBwdPrimitive<T>::Execute(const T* diff_dst_data,
                                         T* diff_src_data, const void* ws_data,
                                         std::shared_ptr<stream> bwd_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex_lock lock(mu_);
+  mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
   context_.diff_dst_mem->set_data_handle(

--- a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc
+++ b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc
@@ -86,6 +86,9 @@ template <typename T>
 void MklPoolingFwdPrimitive<T>::Execute(const T* src_data, T* dst_data,
                                         void* ws_data,
                                         std::shared_ptr<stream> fwd_stream) {
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
   context_.src_mem->set_data_handle(
       static_cast<void*>(const_cast<T*>(src_data)), *fwd_stream);
@@ -186,6 +189,9 @@ template <typename T>
 void MklPoolingBwdPrimitive<T>::Execute(const T* diff_dst_data,
                                         T* diff_src_data, const void* ws_data,
                                         std::shared_ptr<stream> bwd_stream) {
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
   context_.diff_dst_mem->set_data_handle(
       static_cast<void*>(const_cast<T*>(diff_dst_data)), *bwd_stream);

--- a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
@@ -25,6 +25,9 @@ limitations under the License.
 #include "dnnl.hpp"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/padding.h"
+#ifdef DNNL_AARCH64_USE_ACL
+#include "tensorflow/core/platform/mutex.h"
+#endif
 
 namespace tensorflow {
 
@@ -147,6 +150,10 @@ class MklPoolingFwdPrimitive : public MklPrimitive {
   };
 
   struct PoolingFwdContext context_;
+
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex mu_;
+#endif
 };
 
 template <typename T>
@@ -292,6 +299,9 @@ class MklPoolingBwdPrimitive : public MklPrimitive {
   };
 
   struct PoolingBwdContext context_;
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex mu_;
+#endif
 };
 
 template <typename T>

--- a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
@@ -152,7 +152,7 @@ class MklPoolingFwdPrimitive : public MklPrimitive {
   struct PoolingFwdContext context_;
 
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 
@@ -300,7 +300,7 @@ class MklPoolingBwdPrimitive : public MklPrimitive {
 
   struct PoolingBwdContext context_;
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
@@ -25,6 +25,9 @@ limitations under the License.
 #include "tensorflow/core/graph/mkl_graph_util.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/util/mkl_util.h"
+#ifdef DNNL_AARCH64_USE_ACL
+#include "tensorflow/core/platform/mutex.h"
+#endif
 
 using dnnl::primitive_attr;
 using dnnl::prop_kind;
@@ -86,6 +89,9 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
 
   void Execute(void* src_data, void* dst_data,
                std::shared_ptr<stream> reorder_stream) {
+#ifdef DNNL_AARCH64_USE_ACL
+    mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
     context_.src_mem->set_data_handle(src_data, *reorder_stream);
     context_.dst_mem->set_data_handle(dst_data, *reorder_stream);
@@ -149,6 +155,10 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
     context_.prim_args.insert({DNNL_ARG_FROM, *context_.src_mem});
     context_.prim_args.insert({DNNL_ARG_TO, *context_.dst_mem});
   }
+
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex mu_;
+#endif
 };
 
 template <typename T>

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
@@ -90,7 +90,7 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
   void Execute(void* src_data, void* dst_data,
                std::shared_ptr<stream> reorder_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
-    mutex_lock lock(mu_);
+    mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
     context_.src_mem->set_data_handle(src_data, *reorder_stream);
@@ -157,7 +157,7 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
   }
 
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_relu_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_relu_op.cc
@@ -78,7 +78,7 @@ class MklEltwiseFwdPrimitive : public MklPrimitive {
   void Execute(const T* src_data, T* dst_data,
                std::shared_ptr<stream> fwd_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
-    mutex_lock lock(mu_);
+    mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
     context_.src_mem->set_data_handle(
@@ -161,7 +161,7 @@ class MklEltwiseFwdPrimitive : public MklPrimitive {
   struct EltwiseFwdContext context_;
 
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 
@@ -260,7 +260,7 @@ class MklEltwiseBwdPrimitive : public MklPrimitive {
   void Execute(const T* src_data, const T* diff_dst_data, T* diff_src_data,
                std::shared_ptr<stream> bwd_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
-    mutex_lock lock(mu_);
+    mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
     context_.src_mem->set_data_handle(
@@ -369,7 +369,7 @@ class MklEltwiseBwdPrimitive : public MklPrimitive {
   struct EltwiseBwdContext context_;
 
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_slice_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_slice_op.cc
@@ -27,6 +27,9 @@ limitations under the License.
 #include "tensorflow/core/lib/gtl/array_slice.h"
 #include "tensorflow/core/platform/prefetch.h"
 #include "tensorflow/core/util/mkl_util.h"
+#ifdef DNNL_AARCH64_USE_ACL
+#include "tensorflow/core/platform/mutex.h"
+#endif
 
 using dnnl::stream;
 
@@ -185,6 +188,9 @@ class MklSlicePrimitive : public MklPrimitive {
 
   void Execute(const MklSliceParams& sliceParams,
                std::shared_ptr<stream> slice_stream) {
+#ifdef DNNL_AARCH64_USE_ACL
+    mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
     context_.src_mem->set_data_handle(sliceParams.from->get_data_handle(),
                                       *slice_stream);
@@ -243,6 +249,10 @@ class MklSlicePrimitive : public MklPrimitive {
         {{DNNL_ARG_SRC, *context_.src_mem}, {DNNL_ARG_DST, *context_.dst_mem}});
     context_.slice_primitives.push_back(*context_.reorder_prim);
   }
+
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex mu_;
+#endif
 };
 
 template <typename T>

--- a/tensorflow/core/kernels/mkl/mkl_slice_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_slice_op.cc
@@ -189,7 +189,7 @@ class MklSlicePrimitive : public MklPrimitive {
   void Execute(const MklSliceParams& sliceParams,
                std::shared_ptr<stream> slice_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
-    mutex_lock lock(mu_);
+    mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
     context_.src_mem->set_data_handle(sliceParams.from->get_data_handle(),
@@ -251,7 +251,7 @@ class MklSlicePrimitive : public MklPrimitive {
   }
 
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_softmax_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_softmax_op.cc
@@ -64,7 +64,7 @@ class MklSoftmaxPrimitive : public MklPrimitive {
   void Execute(const T* src_data, T* dst_data,
                std::shared_ptr<stream> fwd_cpu_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
-    mutex_lock lock(mu_);
+    mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
     context_.src_mem->set_data_handle(
@@ -148,7 +148,7 @@ class MklSoftmaxPrimitive : public MklPrimitive {
   struct SoftmaxFwdContext context_;
 
 #ifdef DNNL_AARCH64_USE_ACL
-  mutex mu_;
+  mutex primitive_execution_mu_;
 #endif
 };
 
@@ -173,13 +173,6 @@ class MklSoftmaxPrimitiveFactory : public MklPrimitiveFactory<T> {
     static MklSoftmaxPrimitiveFactory instance_;
     return instance_;
   }
-
-#ifdef DNNL_AARCH64_USE_ACL
-  static int IncrementCounter() {
-    static std::atomic_int counter{1};
-    return counter.fetch_add(1);
-  }
-#endif
 
  private:
   MklSoftmaxPrimitiveFactory() {}

--- a/tensorflow/core/kernels/mkl/mkl_softmax_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_softmax_op.cc
@@ -26,6 +26,9 @@ limitations under the License.
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/tensor_format.h"
+#ifdef DNNL_AARCH64_USE_ACL
+#include "tensorflow/core/platform/mutex.h"
+#endif
 
 using dnnl::prop_kind;
 using dnnl::softmax_forward;
@@ -60,6 +63,9 @@ class MklSoftmaxPrimitive : public MklPrimitive {
   //   dst_data:  output data buffer of dst
   void Execute(const T* src_data, T* dst_data,
                std::shared_ptr<stream> fwd_cpu_stream) {
+#ifdef DNNL_AARCH64_USE_ACL
+    mutex_lock lock(mu_);
+#endif
 #ifndef ENABLE_ONEDNN_OPENMP
     context_.src_mem->set_data_handle(
         static_cast<void*>(const_cast<T*>(src_data)), *fwd_cpu_stream);
@@ -140,6 +146,10 @@ class MklSoftmaxPrimitive : public MklPrimitive {
   }
 
   struct SoftmaxFwdContext context_;
+
+#ifdef DNNL_AARCH64_USE_ACL
+  mutex mu_;
+#endif
 };
 
 template <typename T>
@@ -163,6 +173,13 @@ class MklSoftmaxPrimitiveFactory : public MklPrimitiveFactory<T> {
     static MklSoftmaxPrimitiveFactory instance_;
     return instance_;
   }
+
+#ifdef DNNL_AARCH64_USE_ACL
+  static int IncrementCounter() {
+    static std::atomic_int counter{1};
+    return counter.fetch_add(1);
+  }
+#endif
 
  private:
   MklSoftmaxPrimitiveFactory() {}
@@ -279,8 +296,8 @@ class MklSoftmaxOp : public OpKernel {
       // addresses does not work, as the addresses are re-used in matmul with
       // different data The counter ensures we still benefit from caching via
       // SetSoftmaxFwd().
-      static int counter = 1;
-      fwdParams.aarch64_counter = counter++;
+      fwdParams.aarch64_counter =
+          MklSoftmaxPrimitiveFactory<T>::IncrementCounter();
 #endif
       MklSoftmaxPrimitive<T>* softmax_fwd =
           MklSoftmaxPrimitiveFactory<T>::Get(fwdParams);


### PR DESCRIPTION
This pull request uses global cache for MKL primitives instead of cache per TesnroFlow inter-thread. This is achieved by making access to LRUCache thread safe by introducing locks around get and set and making sure that execution of primitives is synchronized. The code is guarded to be only compiled for AArch64.

Cc @penpornk 