### PR TITLE
Fix missed parameter of Keras AUC config

### DIFF
--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2437,7 +2437,8 @@ class AUC(Metric):
         # config has the same thresholds.
         'thresholds': self.thresholds[1:-1],
         'multi_label': self.multi_label,
-        'label_weights': label_weights
+        'label_weights': label_weights,
+        'from_logits': self._from_logits
     }
     base_config = super(AUC, self).get_config()
     return dict(list(base_config.items()) + list(config.items()))


### PR DESCRIPTION
Keras AUC metrics missed `from_logits` key in `get_config` method, which will cause a error when load from a saved model and `from_logits` is True.