### PR TITLE
r2.9 cherrypick: Restore the original r2.9 setting of `TF_RUN_EAGER_OP_AS_FUNCTION`

### DIFF
--- a/tensorflow/python/eager/context.py
+++ b/tensorflow/python/eager/context.py
@@ -78,8 +78,7 @@ is_tfrt_enabled = tfrt_utils.enabled
 
 # This flag and the associated environment var are transient and will eventually
 # be removed, once this experiment is enabled by default.
-_RUN_EAGER_OP_AS_FUNCTION_ENABLED = os.getenv("TF_RUN_EAGER_OP_AS_FUNCTION",
-                                              "1") == "1"
+_RUN_EAGER_OP_AS_FUNCTION_ENABLED = os.getenv("TF_RUN_EAGER_OP_AS_FUNCTION", False)
 
 # This flag and the associated environment var are transient and will eventually
 # be removed, once this experiment is enabled by default.


### PR DESCRIPTION
The r2.9 cherrypick commit 653347ec2dedaee0c80693b2f029e513794c0759 let the change to enable `TF_RUN_EAGER_OP_AS_FUNCTION` from master into r2.9 by accident. This PR reverts it.

cc: @atom00