### PR TITLE
[oneDNN] Fix conv3d_backprop_filter_v2_grad_test_cpu test failure when oneDNN …

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
@@ -370,6 +370,14 @@ class MklConvCustomBackpropFilterOp
       // a correct way to get filter shape. These operator-specific calls
       // allow this class to handle this case.
       TensorShape src_tf_shape = MakeInputTfShape(context, src_tensor);
+      const string& op_type = this->type_string();
+      if ((op_type.find("3D") != std::string::npos) &&
+          (op_type.find("V2") != std::string::npos)) {
+        OP_REQUIRES(context, TensorShapeUtils::IsVector(filter_tensor.shape()),
+                    errors::InvalidArgument(
+                        "filter_sizes shape must be rank 1 but is rank ",
+                        filter_tensor.shape().dims()));
+      }
       TensorShape filter_tf_shape = MakeFilterTfShape(context, filter_tensor);
       TensorShape diff_dst_tf_shape =
           GetTfShape(context, kDiffDstIdx, native_format);


### PR DESCRIPTION
…is enabled
The commit https://github.com/intel-innersource/frameworks.ai.tensorflow.private-tensorflow/commit/174c5096f303d5be7ed2ca2662b08371bff4ab88 introduced a new test case ( testBadFilterShape) in the conv3d_backprop_filter_v2_grad_test.py. This test case has a bad filter shape and expects the corresponding kernel to check for this condition. Update the mkl kernel to add the check for invalid filter shape.