### PR TITLE
Disable experimental_link_static_libraries_once to fix undefined reference issues due to symbols hidden by linker script

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -150,7 +150,7 @@ build --define=no_hdfs_support=true
 build --experimental_cc_shared_library
 
 # cc_shared_library ensures no library is linked statically more than once.
-build --experimental_link_static_libraries_once=true
+build --experimental_link_static_libraries_once=false
 
 # Default options should come above this line.
 

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -995,7 +995,6 @@ tf_cc_shared_library(
         "//tensorflow:tf_framework_version_script.lds",
         "//tensorflow:tf_private_symbols.lds",
     ],
-    exports_filter = PACKAGE_STATIC_DEPS,
     framework_so = [],
     linkopts = select({
         "//tensorflow:macos": [


### PR DESCRIPTION
Fixes #55942

`experimental_link_static_libraries_once` attempts to prevent duplication of static libraries by loading them dynamically, however the linker scripts for libtensorflow_framework are hiding the symbols from those static libraries so they cannot be seen by libtensorflow_cc or pywrap_tensorflow_internal. This PR fixes it by disabling `experimental_link_static_libraries_once`. 

Alternatively, we could edit the linker scripts to no longer hide `*mlir*` and `libjpeg*` symbols, but that might have negative consequences when using tensorflow in other applications.