### PR TITLE
r2.9 cherry-pick: Change pybind11 version to 2.8.1.

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -837,9 +837,9 @@ def _tf_repositories():
 
     tf_http_archive(
         name = "pybind11",
-        urls = tf_mirror_urls("https://github.com/pybind/pybind11/archive/v2.9.0.tar.gz"),
-        sha256 = "057fb68dafd972bc13afb855f3b0d8cf0fa1a78ef053e815d9af79be7ff567cb",
-        strip_prefix = "pybind11-2.9.0",
+        urls = tf_mirror_urls("https://github.com/pybind/pybind11/archive/v2.8.1.tar.gz"),
+        sha256 = "f1bcc07caa568eb312411dde5308b1e250bd0e1bc020fae855bf9f43209940cc",
+        strip_prefix = "pybind11-2.8.1",
         build_file = "//third_party:pybind11.BUILD",
         system_build_file = "//third_party/systemlibs:pybind11.BUILD",
     )


### PR DESCRIPTION
The reason for the downgrade is that v2.9.x is causing a segmentation fault in the TF Lite interpreter in TF Text conversion tests.

The original reason for the 2.9.0 upgrade was to include a thread-safety fix (https://github.com/pybind/pybind11/pull/3237, https://github.com/pybind/pybind11/commit/0e599589fe821f86d18635c13636f3042d4c06b9) for JAX that was added in 2.8.0 and above, so performing this downgrade is not problematic for its intention.

PiperOrigin-RevId: 442586909