### PR TITLE
[TF-TRT] Adding Mixed Precision Grappler Pass to TF-TRT Conversion

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -237,6 +237,9 @@ class AutoMixedPrecisionListsCuda : public AutoMixedPrecisionLists {
         "SoftmaxCrossEntropyWithLogits",
         "SparseSoftmaxCrossEntropyWithLogits",
         "Sum",
+        // `TRTEngineOp` needs to be added here to protect the OP in case the
+        // user executes another pass of mixed_precision after TF-TRT conversion
+        "TRTEngineOp"
     };
     UpdateList("DENYLIST", &list);
     // For backwards compatibility, keeping the original env variable here.

--- a/tensorflow/python/compiler/tensorrt/BUILD
+++ b/tensorflow/python/compiler/tensorrt/BUILD
@@ -5,9 +5,12 @@
 
 load("//tensorflow:tensorflow.default.bzl", "cuda_py_test")
 
-# cuda_py_test and cuda_py_tests enable XLA tests by default. We can't
+# cuda_py_test enable XLA tests by default. We can't
 # combine XLA with TensorRT currently and should set
 # xla_enable_strict_auto_jit to False to disable XLA tests.
+
+# Loading TFTRT_PY_TEST_TAGS - Common set of tags used accross TF-TRT modules & tests
+load("//tensorflow/python/compiler/tensorrt:tensorrt.bzl", "TFTRT_PY_TEST_TAGS")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -81,11 +84,7 @@ cuda_py_test(
         "//tensorflow/python/compiler/tensorrt/test:trt_convert_test_data",
     ],
     python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_pip",
-        "nomac",
-    ],
+    tags = ["no_pip"] + TFTRT_PY_TEST_TAGS,
     xla_enable_strict_auto_jit = False,
     deps = [
         ":trt_convert_py",
@@ -104,29 +103,5 @@ cuda_py_test(
         "//tensorflow/python/tools:freeze_graph_lib",
         "//tensorflow/python/tools:saved_model_utils",
         "@absl_py//absl/testing:parameterized",
-    ],
-)
-
-cuda_py_test(
-    name = "quantization_mnist_test",
-    srcs = ["//tensorflow/python/compiler/tensorrt/test:quantization_mnist_test_srcs"],
-    data = [
-        "//tensorflow/python/compiler/tensorrt/test:quantization_mnist_test_data",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_oss",  # TODO(b/125290478): allow running in at least some OSS configurations.
-        "no_pip",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        ":tf_trt_integration_test_base",
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/estimator",
     ],
 )

--- a/tensorflow/python/compiler/tensorrt/test/BUILD
+++ b/tensorflow/python/compiler/tensorrt/test/BUILD
@@ -3,7 +3,8 @@
 #   and provide TensorRT operators and converter package.
 #   APIs are meant to change over time.
 
-load("//tensorflow/python/compiler/tensorrt:tensorrt.bzl", "tensorrt_py_test")
+load("//tensorflow/python/compiler/tensorrt:tensorrt.bzl", "tftrt_py_tests")
+load("//tensorflow/python/compiler/tensorrt:tensorrt.bzl", "tftrt_py_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -61,7 +62,11 @@ filegroup(
     visibility = ["//tensorflow/python/compiler/tensorrt:__pkg__"],
 )
 
+# ============================= TESTS DEFINITION ============================= #
+
 oss_tests = [
+    "annotate_max_batch_sizes_test",
+    "base_test",
     "batch_matmul_test",
     "biasadd_matmul_test",
     "binary_tensor_weight_broadcast_test",
@@ -69,6 +74,7 @@ oss_tests = [
     "cast_test",
     "concatenation_test",
     "const_broadcast_test",
+    # "conv2d_test",  # b/198501457
     "data_dependent_shape_test",
     "dynamic_input_shapes_test",
     "identity_output_test",
@@ -80,6 +86,7 @@ oss_tests = [
     "quantization_test",
     "rank_two_test",
     "reshape_transpose_test",
+    "shape_output_test",
     "topk_test",
     "trt_engine_op_shape_test",
     "trt_mode_test",
@@ -88,46 +95,65 @@ oss_tests = [
     "vgg_block_test",
 ]
 
-no_oss_tests = [
-    "base_test",
-    "conv2d_test",  # "conv2d_test.py",  # b/198501457
-]
-# "base_test.py", # TODO(b/165611343): Need to address the failures for CUDA 11 in OSS build.
-
-base_tags = [
-    "no_cuda_on_cpu_tap",
-    "no_rocm",
-    "no_windows",
-    "nomac",
-]
-
-tensorrt_py_test(
+tftrt_py_tests(
     name = "oss_tests",
-    tags = base_tags,
     test_names = oss_tests,
 )
 
-tensorrt_py_test(
+no_oss_tests = [
+    "combined_nms_test",
+]
+
+tftrt_py_tests(
     name = "no_oss_tests",
-    tags = base_tags + ["no_oss"],
-    test_names = no_oss_tests + ["combined_nms_test"],
+    test_names = no_oss_tests,
+    extra_tags = ["no_oss"],
 )
 
-tensorrt_py_test(
+# no_oss_tests.append("quantization_mnist_test")
+# tftrt_py_test(
+#     name = "quantization_mnist_test",
+#     srcs = [
+#         "//tensorflow/python/compiler/tensorrt/test:quantization_mnist_test_srcs"
+#     ],
+#     data = [
+#         "//tensorflow/python/compiler/tensorrt/test:quantization_mnist_test_data",
+#     ],
+#     extra_tags = [
+#         "no_pip",
+#         "no_oss"
+#     ],
+#     deps = [
+#         "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
+#         "//tensorflow/python:client_testlib",
+#         "//tensorflow/python:framework_test_lib",
+#         "//tensorflow/python/estimator",
+#     ],
+# )
+
+no_oss_tests.append("tf_function_test")
+tftrt_py_test(
     name = "tf_function_test",
-    tags = base_tags + [
+    srcs = [
+        "tf_function_test.py",
+    ],
+    extra_tags = [
         "manual",  # TODO(b/231239602): re-enable once naming issue is resolved.
-        "notap",  # TODO(b/231239602): re-enable once naming issue is resolved.
         "no_oss",  # TODO(b/231239602): re-enable once naming issue is resolved.
+        "notap",  # TODO(b/231239602): re-enable once naming issue is resolved.
     ],
 )
+
+# ========================== TEST SUITES DEFINITION ========================== #
 
 test_suite(
     name = "tf_trt_integration_test",
-    tests = oss_tests + [
-        "combined_nms_test",
-        "tf_function_test",
-    ],
+    tests = oss_tests + no_oss_tests,
+)
+
+test_suite(
+    name = "tf_trt_integration_test_oss",
+    tests = oss_tests,
 )
 
 test_suite(

--- a/tensorflow/python/compiler/tensorrt/test/BUILD
+++ b/tensorflow/python/compiler/tensorrt/test/BUILD
@@ -66,6 +66,7 @@ filegroup(
 
 oss_tests = [
     "annotate_max_batch_sizes_test",
+    "auto_mixed_precision_test",
     "base_test",
     "batch_matmul_test",
     "biasadd_matmul_test",

--- a/tensorflow/python/compiler/tensorrt/test/auto_mixed_precision_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/auto_mixed_precision_test.py
@@ -1,0 +1,124 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Model script to test TF-TensorRT integration."""
+
+import numpy as np
+
+from tensorflow.python.compiler.tensorrt.test import \
+    tf_trt_integration_test_base as trt_test
+
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gen_nn_ops
+from tensorflow.python.platform import test
+
+
+def conv2d_layer(inputs,
+                 filters,
+                 kernel_size,
+                 strides=(1, 1),
+                 padding="valid",
+                 data_format="channels_last",
+                 dilation_rate=(1, 1)):
+  dtype = inputs.dtype
+  c_axis = -1 if data_format == "channels_last" else 1
+  nchan = inputs.shape[c_axis]
+  weights_shape = (kernel_size[0], kernel_size[1], nchan, filters)
+  weights = constant_op.constant(np.random.randn(*weights_shape), dtype=dtype)
+  padding = padding.upper()
+  if data_format == "channels_last":
+    strides = [1] + list(strides) + [1]
+    dilations = [1] + list(dilation_rate) + [1]
+    data_format = "NHWC"
+  else:
+    strides = [1, 1] + list(strides)
+    dilations = [1, 1] + list(dilation_rate)
+    data_format = "NCHW"
+  return gen_nn_ops.conv2d(
+      inputs,
+      weights,
+      strides=strides,
+      padding=padding,
+      dilations=dilations,
+      data_format=data_format)
+
+
+def build_graph(inp,
+                dtype,
+                num_filters,
+                data_format,
+                kernel_sizes,
+                dilation_rates,
+                padding="same"):
+  results = []
+  for kernel_size in kernel_sizes:
+    for dilation_rate in dilation_rates:
+      result = conv2d_layer(inp, num_filters, kernel_size, (1, 1), padding,
+                            data_format, dilation_rate)
+      results.append(result)
+  output = sum(results)
+  return array_ops.identity(output, name="output_0")
+
+
+class AutoMixedPrecisionTest(trt_test.TfTrtIntegrationTestBase):
+  """Testing TF-TRT conversion with `auto_mixed_precision` grappler pass."""
+
+  def GraphFn(self, inp):
+    np.random.seed(1234)
+    return build_graph(
+        inp=inp,
+        dtype=dtypes.float32,
+        num_filters=5,
+        data_format="channels_last",
+        kernel_sizes=[(3, 3), (3, 2)],
+        dilation_rates=[(1, 1), (2, 3)])
+
+  def GetParams(self):
+    return self.BuildParams(self.GraphFn, dtypes.float32, [[13, 7, 11, 3]],
+                            [[13, 7, 11, 5]])
+
+  def ExpectedEnginesToBuild(self, run_params):
+    """Returns the expected engines to build."""
+    expected_engines = {
+        "TRTEngineOp_000": [
+            "Conv2D_3",
+            "Conv2D_2",
+            "Conv2D_1",
+            "Conv2D",
+            "add_1",
+            "add_2",
+            "add_3",
+        ]
+    }
+
+    if run_params.precision_mode != "FP32":
+      expected_engines["TRTEngineOp_000"].extend([
+          "Conv2D_3-1-CastToFp16-AutoMixedPrecision",
+          "Conv2D_2-1-CastToFp16-AutoMixedPrecision",
+          "Conv2D_1-1-CastToFp16-AutoMixedPrecision",
+          "Conv2D-1-CastToFp16-AutoMixedPrecision",
+          "Conv2D-0-CastToFp16-AutoMixedPrecision",
+          "add_3-1-CastToFp32-AutoMixedPrecision",
+          "add_2-1-CastToFp32-AutoMixedPrecision",
+          "add_1-1-CastToFp32-AutoMixedPrecision",
+          "add-1-CastToFp32-AutoMixedPrecision",
+      ])
+
+    return expected_engines
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -300,7 +300,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
         self.assertEqual(
             {
                 "add": "AddV2",
-                "v1": "Const",
+                "add/ReadVariableOp": "Const",
                 "add_1": "AddV2",
                 "add_2": "AddV2",
                 "input1": "Placeholder",
@@ -893,7 +893,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     node_name_to_op = {node.name: node.op for node in output_graph_def.node}
     self.assertEqual(
         {
-            "v1": "Const",
+            "add/ReadVariableOp": "Const",
             "input1": "Placeholder",
             "input2": "Placeholder",
             "add": "AddV2",


### PR DESCRIPTION
This PR adds `auto_mixed_precision` grappler pass to the original TF Graph before TF-TRT segmentation. This allows to run and execute in FP16 where needed the non - converted operation and native segments.

This feature is only activated when `precision_mode != FP32`.

This behavior can be deactivated if needed with `export TF_TRT_EXPERIMENTAL_FEATURES=deactivate_mixed_precision`

Depends on #56497