### PR TITLE
Fused MatMul Op test shouldn't use GPU for AMD/ROCm

### DIFF
--- a/tensorflow/core/kernels/matmul_op_test.cc
+++ b/tensorflow/core/kernels/matmul_op_test.cc
@@ -181,6 +181,9 @@ class FusedMatMulOpTest : public OpsTestBase {
                      .Attr("transpose_b", transpose_b)
                      .Finalize(&fused_matmul));
 
+#if TENSORFLOW_USE_ROCM
+    allow_gpu_device = false;
+#endif
     RunAndFetch(root, fused_matmul.name(), output, allow_gpu_device,
                 &fused_matmul);
   }


### PR DESCRIPTION
A recent PR added fused matmul op for GPU and updated the unit test to use GPU
This op isn't supported on AMD/ROCm and unit test should not try to execute the fused matmul op unit test 