### PR TITLE
Support matmul+bias+gelu fusion on GPUs

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -1225,6 +1225,10 @@ bool FindMatMulBiasAddAndGelu(RemapperContext* ctx, int node_index,
     NodeDef* matmul_node =
         ctx->graph_view.GetNode(matched_nodes_map->at("matmul"))->node();
 
+    // matmul_node is already the _FusedMatMul and we don't need to check its
+    // data type again.
+    if (!IsMKLEnabled() && !NodeIsOnGpu(matmul_node)) return false;
+
     // Check if _FusedMatMul contains only BiasAdd
     auto fused_ops = matmul_node->attr().at("fused_ops").list().s();
     if (fused_ops.size() == 1) {

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -1237,7 +1237,6 @@ bool FindMatMulBiasAddAndGelu(RemapperContext* ctx, int node_index,
     } else {
       return false;
     }
-
     // Check if the matched constants have desired values.
     std::map<string, float> values_map = {{"square_root_two_over_pi", 0.797884},
                                           {"one", 1.0},

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -1205,6 +1205,7 @@ bool FindMatMulBiasAddAndGelu(RemapperContext* ctx, int node_index,
   // ops), we check if (i) MatMul op is CpuCompatible or GpuComptible, (ii)
   // const nodes have desired values.
   if (found_gelu_exact) {
+    if (!IsMKLEnabled()) return false;
     // Check if the MatMul to be fused is CPU compatible
     // TODO(kaixih@nvidia): Add GPU support when cublastLt supports the exact
     // form.

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -1041,15 +1041,15 @@ inline bool VerifyConstants(RemapperContext* ctx,
         const_tensor.FromProto(node_def->attr().at("value").tensor())) {
       if (const_tensor.NumElements() == 1) {
         DataType dtype = const_tensor.dtype();
-        if (!(dtype == DT_FLOAT || dtype == DT_BFLOAT16 || dtype == DT_HALF))
-          return false;
         float const_value;
         if (dtype == DT_FLOAT) {
           const_value = const_tensor.flat<float>()(0);
         } else if (dtype == DT_BFLOAT16) {
           const_value = const_tensor.flat<bfloat16>()(0);
-        } else {
+        } else if (dtype == DT_HALF) {
           const_value = const_tensor.flat<Eigen::half>()(0);
+        } else {
+          return false;
         }
         if (std::abs(const_value - it->second) > 1e-2) return false;
       } else {

--- a/tensorflow/core/kernels/conv_ops_fused_impl.h
+++ b/tensorflow/core/kernels/conv_ops_fused_impl.h
@@ -257,6 +257,9 @@ struct LaunchFusedConv2DOp<CPUDevice, T> {
       case FusedComputationType::kUndefined:
         OP_REQUIRES_OK(context, errors::Internal("Fusion type is undefined"));
         break;
+      case FusedComputationType::kBiasAddWithGeluApproximate:
+        OP_REQUIRES_OK(context, errors::Internal("Fusion type is unsupported"));
+        break;
       case FusedComputationType::kBiasAdd:
         conv2d(WithBiasAdd<T>(bias_add_args), context, input, filter, output);
         break;

--- a/tensorflow/core/kernels/fused_eigen_output_kernels.cc
+++ b/tensorflow/core/kernels/fused_eigen_output_kernels.cc
@@ -61,7 +61,8 @@ Status InitializeFusedComputation(
       *fused_computation == FusedComputationType::kBiasAddWithRelu ||
       *fused_computation == FusedComputationType::kBiasAddWithRelu6 ||
       *fused_computation == FusedComputationType::kBiasAddWithElu ||
-      *fused_computation == FusedComputationType::kBiasAddWithLeakyRelu) {
+      *fused_computation == FusedComputationType::kBiasAddWithLeakyRelu ||
+      *fused_computation == FusedComputationType::kBiasAddWithGeluApproximate) {
     if (num_args != 1) {
       return errors::InvalidArgument(
           "Fused ", kernel_name,

--- a/tensorflow/core/kernels/fused_eigen_output_kernels.h
+++ b/tensorflow/core/kernels/fused_eigen_output_kernels.h
@@ -40,6 +40,7 @@ enum class FusedComputationType {
   kBiasAddWithRelu6,
   kBiasAddWithElu,
   kBiasAddWithLeakyRelu,
+  kBiasAddWithGeluApproximate,
   kFusedBatchNorm,
   kFusedBatchNormWithRelu,
   kFusedBatchNormWithRelu6,

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -173,6 +173,8 @@ StatusOr<se::cuda::BlasLt::Epilogue> GetBlasLtEpilogOp(
     return se::cuda::BlasLt::Epilogue::kBias;
   } else if (fusion == FusedComputationType::kBiasAddWithRelu) {
     return se::cuda::BlasLt::Epilogue::kBiasThenReLU;
+  } else if (fusion == FusedComputationType::kBiasAddWithGeluApproximate) {
+    return se::cuda::BlasLt::Epilogue::kBiasThenGeLUApproximate;
   } else {
     return errors::Internal("Unsupported fusion for BlasLt Matmul");
   }
@@ -372,8 +374,10 @@ class FusedMatMulOp : public OpKernel {
           {FCT::kBiasAddWithLeakyRelu, {"BiasAdd", "LeakyRelu"}},
       };
     } else if (std::is_same<Device, GPUDevice>::value) {
-      patterns = {{FCT::kBiasAdd, {"BiasAdd"}},
-                  {FCT::kBiasAddWithRelu, {"BiasAdd", "Relu"}}};
+      patterns = {
+          {FCT::kBiasAdd, {"BiasAdd"}},
+          {FCT::kBiasAddWithRelu, {"BiasAdd", "Relu"}},
+          {FCT::kBiasAddWithGeluApproximate, {"BiasAdd", "GeluApproximate"}}};
     }
 
     OP_REQUIRES_OK(context, InitializeFusedComputation(

--- a/tensorflow/python/grappler/remapper_test.py
+++ b/tensorflow/python/grappler/remapper_test.py
@@ -36,6 +36,7 @@ from tensorflow.python.ops import nn
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import random_ops
 from tensorflow.python.ops import variables
+from tensorflow.python.platform import sysconfig
 from tensorflow.python.platform import test
 from tensorflow.python.util import _pywrap_utils
 
@@ -75,8 +76,14 @@ class RemapperTest(test.TestCase, parameterized.TestCase):
     os.environ['TF_USE_CUBLASLT'] = '1'
 
   def _maybe_skip(self, mode):
-    if mode == 'cuda' and not test.is_gpu_available(cuda_only=True):
-      self.skipTest('This test requires GPU.')
+    if mode == 'cuda':
+      if not test.is_gpu_available(cuda_only=True):
+        self.skipTest('This test requires GPU.')
+      cuda_version_str = sysconfig.get_build_info().get('cuda_version', '0.0')
+      cuda_version = tuple([int(x) for x in cuda_version_str.split('.')])
+      if cuda_version < (11, 4):
+        self.skipTest('This test requires CUDA >= 11.4.')
+
     if mode == 'mkl' and not test_util.IsMklEnabled():
       self.skipTest('MKL is not enabled.')
 

--- a/tensorflow/python/grappler/remapper_test.py
+++ b/tensorflow/python/grappler/remapper_test.py
@@ -77,6 +77,11 @@ class RemapperTest(test.TestCase, parameterized.TestCase):
 
   def _maybe_skip(self, mode):
     if mode == 'cuda':
+      # It seems the windows os cannot correctly query the cuda_version.
+      # TODO(kaixih@nvidia): Remove this when it works.
+      if os.name == "nt":
+        self.skipTest("This test doesn't support Windows")
+
       if not test.is_gpu_available(cuda_only=True):
         self.skipTest('This test requires GPU.')
       cuda_version_str = sysconfig.get_build_info().get('cuda_version', '0.0')

--- a/tensorflow/python/grappler/remapper_test.py
+++ b/tensorflow/python/grappler/remapper_test.py
@@ -82,6 +82,7 @@ class RemapperTest(test.TestCase, parameterized.TestCase):
       if os.name == "nt":
         self.skipTest("This test doesn't support Windows")
 
+      # The cublaslt matmul with gelu epilog is only supported since cuda 11.4.
       if not test.is_gpu_available(cuda_only=True):
         self.skipTest('This test requires GPU.')
       cuda_version_str = sysconfig.get_build_info().get('cuda_version', '0.0')
@@ -175,8 +176,8 @@ class RemapperTest(test.TestCase, parameterized.TestCase):
 
         gelu_type = b'GeluApproximate' if approximate else b'GeluExact'
         epilog_ops = [b'BiasAdd', gelu_type]
-        fused_op = ['_MklNativeFusedMatMul', '_MklFusedMatMul']
-        graph = self._VerifyValues(out, precision == 'bfloat16', fused_op,
+        fused_op = ['_MklNativeFusedMatMul', '_MklFusedMatMul', '_FusedMatMul']
+        graph = self._VerifyValues(out, precision != dtypes.float32, fused_op,
                                    epilog_ops)
 
   @test_util.run_deprecated_v1

--- a/tensorflow/stream_executor/cuda/cuda_blas_lt.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas_lt.cc
@@ -64,6 +64,13 @@ AsCublasLtEpilogue(BlasLt::Epilogue epilogue) {
       return CUBLASLT_EPILOGUE_BIAS;
     case BlasLt::Epilogue::kBiasThenReLU:
       return CUBLASLT_EPILOGUE_RELU_BIAS;
+    case BlasLt::Epilogue::kGeLU:
+#if CUDA_VERSION >= 11040
+      return CUBLASLT_EPILOGUE_GELU;
+#else
+      return port::InternalError(absl::StrCat(
+          "CUBLASLT_EPILOGUE_GELU epilog requires cublasLt >= 11.4"));
+#endif
     case BlasLt::Epilogue::kBiasThenGeLUApproximate:
 #if CUDA_VERSION >= 11040
       return CUBLASLT_EPILOGUE_GELU_BIAS;

--- a/tensorflow/stream_executor/cuda/cuda_blas_lt.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas_lt.cc
@@ -54,7 +54,7 @@ cublasLtPointerMode_t AsCublasLtPointerMode(BlasLt::PointerMode pointer_mode) {
 }
 
 port::StatusOr<cublasLtEpilogue_t>
-cublasLtEpilogue_t AsCublasLtEpilogue(BlasLt::Epilogue epilogue) {
+AsCublasLtEpilogue(BlasLt::Epilogue epilogue) {
   switch (epilogue) {
     case BlasLt::Epilogue::kDefault:
       return CUBLASLT_EPILOGUE_DEFAULT;
@@ -172,8 +172,8 @@ port::StatusOr<BlasLt::UniqueOpDesc> CreateCublasLtOperationDesc(
                      computation_type, ") failed: ", ToString(status)));
   }
   BlasLt::UniqueOpDesc unique_desc(desc);
-  TF_ASSIGN_OR_RETURN(cublasLtEpilogue_t epilog_op,
-                      AsCublasLtEpilogue(epilogue));
+  TF_ASSIGN_OR_RETURN(
+      cublasLtEpilogue_t epilog_op, AsCublasLtEpilogue(epilogue));
   SE_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_POINTER_MODE,
                                      AsCublasLtPointerMode(pointer_mode)));
   SE_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_EPILOGUE,

--- a/tensorflow/stream_executor/cuda/cuda_blas_lt.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas_lt.cc
@@ -63,6 +63,8 @@ cublasLtEpilogue_t AsCublasLtEpilogue(BlasLt::Epilogue epilogue) {
       return CUBLASLT_EPILOGUE_BIAS;
     case BlasLt::Epilogue::kBiasThenReLU:
       return CUBLASLT_EPILOGUE_RELU_BIAS;
+    case BlasLt::Epilogue::kBiasThenGeLUApproximate:
+      return CUBLASLT_EPILOGUE_GELU_BIAS;
   }
 }
 
@@ -438,8 +440,9 @@ bool BlasLt::DoMatmulInternal(
     return false;
   }
   if ((plan.params().epilogue == Epilogue::kBias ||
-       plan.params().epilogue == Epilogue::kBiasThenReLU) !=
-      (bias != nullptr)) {
+       plan.params().epilogue == Epilogue::kBiasThenReLU ||
+       plan.params().epilogue ==
+           Epilogue::kBiasThenGeLUApproximate) != (bias != nullptr)) {
     VLOG(2) << "DoBlasLtMatmul returning false because plan has wrong "
                "epilogue for the given bias pointer.";
     return false;

--- a/tensorflow/stream_executor/cuda/cuda_blas_lt.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas_lt.cc
@@ -174,11 +174,11 @@ port::StatusOr<BlasLt::UniqueOpDesc> CreateCublasLtOperationDesc(
   BlasLt::UniqueOpDesc unique_desc(desc);
   TF_ASSIGN_OR_RETURN(
       cublasLtEpilogue_t epilog_op, AsCublasLtEpilogue(epilogue));
-  SE_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_POINTER_MODE,
+  TF_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_POINTER_MODE,
                                      AsCublasLtPointerMode(pointer_mode)));
-  SE_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_EPILOGUE,
+  TF_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_EPILOGUE,
                                      epilog_op));
-  SE_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_TRANSA,
+  TF_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_TRANSA,
                                      AsCublasOperation(transa)));
   TF_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_TRANSB,
                                      AsCublasOperation(transb)));

--- a/tensorflow/stream_executor/cuda/cuda_blas_lt.h
+++ b/tensorflow/stream_executor/cuda/cuda_blas_lt.h
@@ -71,6 +71,9 @@ class BlasLt {
     kReLU = 2,                      // Apply point-wise ReLU function
     kBias = 4,                      // Add broadcasted bias vector
     kBiasThenReLU = kBias | kReLU,  // Apply bias and then ReLU transform
+    kGeLU = 32,  // Apply GELU point-wise transform to the results
+    kBiasThenGeLUApproximate =
+        kBias | kGeLU,  // Apply bias and then GeLU Tanh transform
   };
 
   // Describes the location of pointers for the scaling factors alpha and beta.


### PR DESCRIPTION
This PR enables the fusion pattern of MatMul+BiasAdd+Gelu on GPUs when CublasLt is enabled by `TF_USE_CUBLASLT=1`.

cc. @nluehr 