### PR TITLE
Bump zlib to 1.2.12.

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -699,15 +699,16 @@ def _tf_repositories():
         ],
     )
 
+    # Note: if you update this, you have to update libpng too. See cl/437813808
     tf_http_archive(
         name = "zlib",
         build_file = "//third_party:zlib.BUILD",
-        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-        strip_prefix = "zlib-1.2.11",
+        sha256 = "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9",
+        strip_prefix = "zlib-1.2.12",
         system_build_file = "//third_party/systemlibs:zlib.BUILD",
         urls = [
-            "https://storage.googleapis.com/mirror.tensorflow.org/zlib.net/zlib-1.2.11.tar.gz",
-            "https://zlib.net/zlib-1.2.11.tar.gz",
+            "https://storage.googleapis.com/mirror.tensorflow.org/zlib.net/zlib-1.2.12.tar.gz",
+            "https://zlib.net/zlib-1.2.12.tar.gz",
         ],
     )
 

--- a/third_party/png.BUILD
+++ b/third_party/png.BUILD
@@ -61,7 +61,7 @@ genrule(
     name = "snappy_stubs_public_h",
     srcs = ["scripts/pnglibconf.h.prebuilt"],
     outs = ["pnglibconf.h"],
-    cmd = "sed -e 's/PNG_ZLIB_VERNUM 0/PNG_ZLIB_VERNUM 0x12b0/' $< >$@",
+    cmd = "sed -e 's/PNG_ZLIB_VERNUM 0/PNG_ZLIB_VERNUM 0x12c0/' $< >$@",
 )
 
 config_setting(


### PR DESCRIPTION
Due to security issue (a deflate bug when using the `Z_FIXED` strategy can result in out-of-bound accesses), zlib 1.2.11 seems to be yanked, so builds not using TF mirror will break.

See https://www.zlib.net/, https://www.openwall.com/lists/oss-security/2022/03/28/1, https://twitter.com/taviso/status/1508438583484452866 and https://twitter.com/perfinion/status/1508448580226322432?t=e3RC0-DuXNKaEwPnldjzzw&s=03

PiperOrigin-RevId: 437843809