### PR TITLE
Include stdlib.h instead of malloc.h

### DIFF
--- a/tensorflow/lite/tensorflow_profiler_logger.cc
+++ b/tensorflow/lite/tensorflow_profiler_logger.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #include "tensorflow/lite/tensorflow_profiler_logger.h"
 
-#include <malloc.h>
+#include <stdlib.h>
 
 #include <algorithm>
 #include <string>


### PR DESCRIPTION
This fixes build error on macOS.

Signed-off-by: Cliffs Dover <cliffsdover90@gmail.com>