### PR TITLE
Bump up cudnn frontend to v0.6.2

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -158,9 +158,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "42199b34ad892c48202a567ff5b982a9c2cc6a2ddff7d7b48754aa4b8f4308a0",
-        strip_prefix = "cudnn-frontend-0.6.1",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.6.1.zip"),
+        sha256 = "314569f65d5c7d05fb7e90157a838549db3e2cfb464c80a6a399b39a004690fa",
+        strip_prefix = "cudnn-frontend-0.6.2",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.6.2.zip"),
     )
 
     tf_http_archive(

--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,4 +1,4 @@
-From 8954d1ddc5a4efaa564baa9e8b725dcf13d42716 Mon Sep 17 00:00:00 2001
+From 681ce638cbf9a115054071d7549f10cb0d3e37ac Mon Sep 17 00:00:00 2001
 From: Kaixi Hou <kaixih@nvidia.com>
 Date: Tue, 4 May 2021 15:21:11 -0700
 Subject: [PATCH] Update headers path to TF-compat
@@ -21,7 +21,7 @@ Subject: [PATCH] Update headers path to TF-compat
  14 files changed, 25 insertions(+), 25 deletions(-)
 
 diff --git a/include/cudnn_backend_base.h b/include/cudnn_backend_base.h
-index 1b95c63..a052881 100644
+index 56d8bec..8ceb19c 100644
 --- a/include/cudnn_backend_base.h
 +++ b/include/cudnn_backend_base.h
 @@ -24,7 +24,7 @@
@@ -79,7 +79,7 @@ index a9cdb7f..0bb47ae 100644
  #include "cudnn_frontend_Engine.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_EngineFallbackList.h b/include/cudnn_frontend_EngineFallbackList.h
-index 4238a85..4356704 100644
+index 323106a..d90a1ea 100644
 --- a/include/cudnn_frontend_EngineFallbackList.h
 +++ b/include/cudnn_frontend_EngineFallbackList.h
 @@ -22,7 +22,7 @@
@@ -92,7 +92,7 @@ index 4238a85..4356704 100644
  #include "cudnn_frontend_Heuristics.h"
  
 diff --git a/include/cudnn_frontend_ExecutionPlan.h b/include/cudnn_frontend_ExecutionPlan.h
-index 16bffb6..caa6bb9 100644
+index 42fd09b..f4a294f 100644
 --- a/include/cudnn_frontend_ExecutionPlan.h
 +++ b/include/cudnn_frontend_ExecutionPlan.h
 @@ -29,8 +29,8 @@
@@ -120,7 +120,7 @@ index b244766..3e9273b 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_Heuristics.h b/include/cudnn_frontend_Heuristics.h
-index c1afa23..9648f41 100644
+index 3d0dacd..fec5e31 100644
 --- a/include/cudnn_frontend_Heuristics.h
 +++ b/include/cudnn_frontend_Heuristics.h
 @@ -25,8 +25,8 @@
@@ -150,7 +150,7 @@ index 5f3161a..c357cc1 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Operation.h b/include/cudnn_frontend_Operation.h
-index e590d80..369031a 100644
+index 4d4e2dc..32fd1b1 100644
 --- a/include/cudnn_frontend_Operation.h
 +++ b/include/cudnn_frontend_Operation.h
 @@ -29,8 +29,8 @@
@@ -180,7 +180,7 @@ index b240496..756f67e 100644
  #include "cudnn_frontend_Operation.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_PointWiseDesc.h b/include/cudnn_frontend_PointWiseDesc.h
-index 688a02a..cb15bb5 100644
+index bf0ad54..869bbfd 100644
 --- a/include/cudnn_frontend_PointWiseDesc.h
 +++ b/include/cudnn_frontend_PointWiseDesc.h
 @@ -30,8 +30,8 @@


### PR DESCRIPTION
Cudnn frontend v0.6.2 fixes some compilation warnings:

https://github.com/NVIDIA/cudnn-frontend/releases/tag/v0.6.2

cc @nluehr 