### PR TITLE
[MHLO] add EliminateRedundantConvert canonicalize pattern

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
@@ -2140,9 +2140,57 @@ OpFoldResult ConvertOp::fold(ArrayRef<Attribute> operands) {
   return {};
 }
 
+namespace {
+
+struct EliminateRedundantConvert : public OpRewritePattern<ConvertOp> {
+  using OpRewritePattern<ConvertOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(ConvertOp op,
+                                PatternRewriter &rewriter) const override {
+    auto convert_op = op.operand().getDefiningOp<ConvertOp>();
+    if (!convert_op) {
+      return failure();
+    }
+    auto first_type =
+        convert_op.operand().getType().cast<TensorType>().getElementType();
+    auto second_type =
+        op.operand().getType().cast<TensorType>().getElementType();
+    auto third_type =
+        op.getResult().getType().cast<TensorType>().getElementType();
+    auto loc = rewriter.getFusedLoc({convert_op->getLoc(), op->getLoc()});
+    if (first_type.isa<FloatType>() && second_type.isa<FloatType>() &&
+        third_type.isa<FloatType>()) {
+      // fold when the second float type's width is longer than first,
+      // like fp16 -> fp32 -> fp64, bf16 -> fp32 -> fp16
+      if (second_type.cast<FloatType>().getWidth() >
+          first_type.cast<FloatType>().getWidth()) {
+        Value result = rewriter.create<ConvertOp>(loc, op.getResult().getType(),
+                                                  convert_op.operand());
+        rewriter.replaceOp(op, result);
+        return success();
+      }
+    } else if (first_type.isa<IntegerType>() &&
+               second_type.isa<IntegerType>() &&
+               third_type.isa<IntegerType>()) {
+      // fold when the second integer type's width is longer than first,
+      // like i16 -> i32 -> i64, u16 -> i32 -> u32
+      if (second_type.cast<IntegerType>().getWidth() >
+          first_type.cast<IntegerType>().getWidth()) {
+        Value result = rewriter.create<ConvertOp>(loc, op.getResult().getType(),
+                                                  convert_op.operand());
+        rewriter.replaceOp(op, result);
+        return success();
+      }
+    }
+    return failure();
+  }
+};
+
+} // namespace
+
 void ConvertOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                             MLIRContext* context) {
   results.add<EliminateIdentityConvert>(context);
+  results.add<EliminateRedundantConvert>(context);
 }
 
 //===----------------------------------------------------------------------===//

--- a/tensorflow/compiler/mlir/hlo/tests/Dialect/mhlo/canonicalize/convert.mlir
+++ b/tensorflow/compiler/mlir/hlo/tests/Dialect/mhlo/canonicalize/convert.mlir
@@ -12,6 +12,66 @@ func.func @same_type(%arg: tensor<f32>) -> tensor<f32> {
 
 // -----
 
+// CHECK-LABEL: func @non_const_chained_convert_unused_parent
+// CHECK-SAME: [[ARG:%[a-zA-Z0-9]+]]
+func.func @non_const_chained_convert_unused_parent(%arg: tensor<f16>) -> tensor<f64> {
+  // CHECK-NEXT: [[RES:%.+]] = mhlo.convert([[ARG]]) : (tensor<f16>) -> tensor<f64>
+  %0 = mhlo.convert(%arg) : (tensor<f16>) -> tensor<f32>
+  %1 = mhlo.convert(%0) : (tensor<f32>) -> tensor<f64>
+  // CHECK-NEXT: return [[RES]]
+  func.return %1 : tensor<f64>
+}
+
+// -----
+
+// CHECK-LABEL: func @non_const_chained_convert_unused_parent_integer
+// CHECK-SAME: [[ARG:%[a-zA-Z0-9]+]]
+func.func @non_const_chained_convert_unused_parent_integer(%arg: tensor<ui16>) -> tensor<i64> {
+  // CHECK-NEXT: [[RES:%.+]] = mhlo.convert([[ARG]]) : (tensor<ui16>) -> tensor<i64>
+  %0 = mhlo.convert(%arg) : (tensor<ui16>) -> tensor<i32>
+  %1 = mhlo.convert(%0) : (tensor<i32>) -> tensor<i64>
+  // CHECK-NEXT: return [[RES]]
+  func.return %1 : tensor<i64>
+}
+
+// -----
+
+// CHECK-LABEL: func @not_convert_float_lower_width
+// CHECK-SAME: [[ARG:%[a-zA-Z0-9]+]]
+func.func @not_convert_float_lower_width(%arg: tensor<f32>) -> tensor<f32> {
+  // CHECK-NEXT: [[VAL0:%.+]] = mhlo.convert([[ARG]]) : (tensor<f32>) -> tensor<f16>
+  // CHECK-NEXT: [[VAL1:%.+]] = mhlo.convert([[VAL0]]) : (tensor<f16>) -> tensor<f32>
+  %0 = mhlo.convert(%arg) : (tensor<f32>) -> tensor<f16>
+  %1 = mhlo.convert(%0) : (tensor<f16>) -> tensor<f32>
+  // CHECK-NEXT: return [[VAL1]]
+  func.return %1 : tensor<f32>
+}
+
+// -----
+
+// CHECK-LABEL: func @non_const_chained_convert_becomes_noop
+// CHECK-SAME: [[ARG:%[a-zA-Z0-9]+]]
+func.func @non_const_chained_convert_becomes_noop(%arg: tensor<f32>) -> tensor<f32> {
+  %0 = mhlo.convert(%arg) : (tensor<f32>) -> tensor<f64>
+  %1 = mhlo.convert(%0) : (tensor<f64>) -> tensor<f32>
+  // CHECK-NEXT: return [[ARG]]
+  func.return %1 : tensor<f32>
+}
+
+// -----
+// CHECK-LABEL: func @non_const_chained_convert
+// CHECK-SAME: [[ARG:%[a-zA-Z0-9]+]]
+func.func @non_const_chained_convert(%arg: tensor<f16>) -> (tensor<f32>, tensor<f64>) {
+  // CHECK-NEXT: [[RES0:%.+]] = mhlo.convert([[ARG]]) : (tensor<f16>) -> tensor<f32>
+  // CHECK-NEXT: [[RES1:%.+]] = mhlo.convert([[ARG]]) : (tensor<f16>) -> tensor<f64>
+  %0 = mhlo.convert(%arg) : (tensor<f16>) -> tensor<f32>
+  %1 = mhlo.convert(%0) : (tensor<f32>) -> tensor<f64>
+  // CHECK-NEXT: return [[RES0]], [[RES1]]
+  func.return %0, %1 : tensor<f32>, tensor<f64>
+}
+
+// -----
+
 // CHECK-LABEL: func @int_widening
 // CHECK-SAME: [[ARG:%[a-zA-Z0-9]+]]
 func.func @int_widening(%arg: tensor<i32>) -> tensor<i64> {
@@ -134,8 +194,8 @@ func.func @const_bool_f32() -> tensor<2xf32> {
 
 // -----
 
-// CHECK-LABEL: func @const_bf16_int
-func.func @const_bf16_int() -> tensor<i16> {
+// CHECK-LABEL: func @const_bf16_int16
+func.func @const_bf16_int16() -> tensor<i16> {
   // CHECK-NEXT: [[CST:%.+]] = mhlo.constant dense<42> : tensor<i16>
   %cst = mhlo.constant dense<42.0> : tensor<bf16>
   %0 = mhlo.convert(%cst) : (tensor<bf16>) -> tensor<i16>
@@ -222,8 +282,8 @@ func.func @const_bf16_f64() -> tensor<f64> {
 
 // -----
 
-// CHECK-LABEL: func @const_bf16_int
-func.func @const_bf16_int() -> tensor<i64> {
+// CHECK-LABEL: func @const_bf16_int64
+func.func @const_bf16_int64() -> tensor<i64> {
   // CHECK-NEXT: [[CST:%.+]] = mhlo.constant dense<42> : tensor<i64>
   %cst = mhlo.constant dense<42.0> : tensor<bf16>
   %0 = mhlo.convert(%cst) : (tensor<bf16>) -> tensor<i64>


### PR DESCRIPTION
add EliminateRedundantConvert canonicalize pattern: `convert(convert(x)) => convert(x)`