### PR TITLE
[TF:TRT] Add ability to persist timing cache to disk

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/timing_cache.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/timing_cache.cc
@@ -16,25 +16,82 @@ limitations under the License.
 
 #include "tensorflow/compiler/tf2tensorrt/convert/timing_cache.h"
 
+#include <memory>
+#include <string>
 #include <unordered_map>
 
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
+#include "tensorflow/core/lib/io/record_reader.h"
+#include "tensorflow/core/lib/io/record_writer.h"
+#include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/platform/file_system.h"
+#include "tensorflow/core/platform/path.h"
+#include "tensorflow/core/util/env_var.h"
 #include "third_party/tensorrt/NvInfer.h"
 
 namespace tensorflow {
 namespace tensorrt {
 namespace convert {
 
+constexpr absl::string_view kCachePathEnvVarName = "TF_TRT_TIMING_CACHE_DIR";
+
+TimingCacheRegistry::TimingCacheRegistry() {
+  string dir;
+  Status s = ReadStringFromEnvVar(kCachePathEnvVarName, "", &dir);
+  if (s.ok() && !dir.empty()) {
+    cache_dir_ = dir;
+  }
+}
+
+static string CreateCachePath(string dir, string cache_name) {
+  // TODO(cbate): since timing information is specific to hardware, this should
+  // be expanded to include information about the GPU (such as compute
+  // capability) in order to reduce liklihood that the user can re-use cache
+  // files inappropriately.
+  return io::JoinPath(dir, cache_name + ".trt.timing_cache");
+}
+
+static StatusOr<TimingCacheRegistry::TimingCachePtr> LoadCacheFromPath(
+    string filename, nvinfer1::IBuilderConfig* builder_config) {
+  std::unique_ptr<RandomAccessFile> file;
+  auto* env = Env::Default();
+
+  if (!env->FileExists(filename).ok()) {
+    return errors::Internal("path dooes not exist");
+  }
+
+  TF_RETURN_IF_ERROR(env->NewRandomAccessFile(filename, &file));
+  auto reader = std::make_unique<io::RecordReader>(file.get());
+  uint64 offset{0};
+  tstring record;
+  TF_RETURN_IF_ERROR(reader->ReadRecord(&offset, &record));
+  return std::unique_ptr<nvinfer1::ITimingCache>(
+      builder_config->createTimingCache(record.data(), record.size()));
+}
+
 StatusOr<TimingCacheRegistry::TimingCachePtr> TimingCacheRegistry::LookUp(
     const string& name, nvinfer1::IBuilderConfig* builder_config) {
 #if IS_TRT_VERSION_GE(8, 0, 0, 0)
   TRT_ENSURE(builder_config != nullptr);
   mutex_lock scoped_lock(mu_);
+
   if (map_.find(name) != map_.end()) {
     const std::vector<uint8_t>& data = map_[name];
     return std::unique_ptr<nvinfer1::ITimingCache>(
         builder_config->createTimingCache(data.data(), data.size()));
+  }
+
+  // Check if we have this cache on disk.
+  if (cache_dir_.has_value()) {
+    string filename = CreateCachePath(*cache_dir_, name);
+    StatusOr<TimingCacheRegistry::TimingCachePtr> cache =
+        LoadCacheFromPath(filename, builder_config);
+    // If we loaded the cache, return it. Otherwise, fallback to creating a new
+    // cache below.
+    if (cache.ok()) {
+      return cache;
+    }
   }
 
   // If no such timing cache exists, create a new timing cache.
@@ -46,9 +103,14 @@ StatusOr<TimingCacheRegistry::TimingCachePtr> TimingCacheRegistry::LookUp(
 }
 
 void TimingCacheRegistry::Upsert(const string& name, TimingCache* cache) {
+  if (cache == nullptr) {
+    LOG(WARNING) << "No timing cache to serialize";
+    return;
+  }
 #if IS_TRT_VERSION_GE(8, 0, 0, 0)
   nvinfer1::IHostMemory* memory = cache->serialize();
   if (memory == nullptr) {
+    LOG(WARNING) << "Could not serialize timing cache.";
     return;
   }
 
@@ -70,6 +132,27 @@ void TimingCacheRegistry::Upsert(const string& name, TimingCache* cache) {
     std::copy_n(static_cast<uint8_t*>(memory->data()), memory->size(),
                 mem.begin());
   }
+
+  // Write the data to disk.
+  if (cache_dir_.has_value()) {
+    auto* env = Env::Default();
+    string filename = CreateCachePath(*cache_dir_, name);
+    LOG(INFO) << "Saving timing cache to " << filename;
+    std::unique_ptr<WritableFile> file{nullptr};
+    auto s = env->NewWritableFile(filename, &file);
+    if (!s.ok()) {
+      LOG(WARNING) << "Failed to write cache to " << filename << ": "
+                   << s.error_message();
+    } else {
+      io::RecordWriter writer(file.get());
+      s = writer.WriteRecord(StringPiece(
+          reinterpret_cast<const char*>(memory->data()), memory->size()));
+      if (!s.ok()) {
+        LOG(WARNING) << "Failed to write to cache file: " << s.error_message();
+      }
+    }
+  }
+
   memory->destroy();
 #endif  // IS_TRT_VERSION_GE(8, 0, 0, 0)
 }

--- a/tensorflow/compiler/tf2tensorrt/convert/timing_cache.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/timing_cache.h
@@ -32,7 +32,7 @@ namespace convert {
 // operations become no-ops.
 class TimingCacheRegistry {
  public:
-  TimingCacheRegistry() = default;
+  TimingCacheRegistry();
   ~TimingCacheRegistry() = default;
 
 #if IS_TRT_VERSION_GE(8, 0, 0, 0)
@@ -58,6 +58,10 @@ class TimingCacheRegistry {
 
   mutex mu_;
   std::unordered_map<std::string, SerializedTimingCache> map_;
+
+  // An optional path specifying where the directory where the caches should be
+  // loaded/saved.
+  absl::optional<string> cache_dir_{absl::nullopt};
 };
 
 TimingCacheRegistry* GetTimingCacheRegistry();


### PR DESCRIPTION
Drops compile time of models significantly (e.g. 240 sec -> 40 sec on object detection with TRT 8.2)