### PR TITLE
Update curl to latest 7.83.1

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -482,10 +482,10 @@ def _tf_repositories():
     tf_http_archive(
         name = "curl",
         build_file = "//third_party:curl.BUILD",
-        sha256 = "c0e64302a33d2fb79e0fc4e674260a22941e92ee2f11b894bf94d32b8f5531af",
-        strip_prefix = "curl-7.83.0",
+        sha256 = "93fb2cd4b880656b4e8589c912a9fd092750166d555166370247f09d18f5d0c0",
+        strip_prefix = "curl-7.83.1",
         system_build_file = "//third_party/systemlibs:curl.BUILD",
-        urls = tf_mirror_urls("https://curl.haxx.se/download/curl-7.83.0.tar.gz"),
+        urls = tf_mirror_urls("https://curl.haxx.se/download/curl-7.83.1.tar.gz"),
     )
 
     # WARNING: make sure ncteisen@ and vpai@ are cc-ed on any CL to change the below rule


### PR DESCRIPTION
This PR updates curl to latest 7.83.1 to fix the following vulnerabilities in 7.83.0:
- 121	CVE-2022-30115: HSTS bypass via trailing dot
- 120	CVE-2022-27782: TLS and SSH connection too eager reuse
- 119	CVE-2022-27781: CERTINFO never-ending busy-loop
- 118	CVE-2022-27780: percent-encoded path separator in URL host
- 117	CVE-2022-27779: cookie for trailing dot TLD
- 116	CVE-2022-27778: curl removes wrong file on error

See https://curl.se/docs/security.html for details

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>