### PR TITLE
Force install `importlib-metadata` to fix build

### DIFF
--- a/tensorflow/tools/ci_build/release/requirements_mac.txt
+++ b/tensorflow/tools/ci_build/release/requirements_mac.txt
@@ -6,3 +6,6 @@ certifi ~= 2020.12.5
 # Test dependencies which don't exist on Windows
 jax ~= 0.2.26
 jaxlib ~= 0.1.75
+
+# See https://github.com/pypa/setuptools/issues/3293
+importlib-metadata > 4


### PR DESCRIPTION
See https://github.com/pypa/setuptools/issues/3293