### PR TITLE
[TF-TRT] Unittest Logging Double Print Fix

### DIFF
--- a/tensorflow/python/compiler/tensorrt/model_tests/BUILD
+++ b/tensorflow/python/compiler/tensorrt/model_tests/BUILD
@@ -28,7 +28,6 @@ py_library(
         "//tensorflow/python/saved_model:signature_constants",
         "//tensorflow/python/saved_model:tag_constants",
         "//third_party/py/numpy",
-        "@absl_py//absl/logging",
     ],
 )
 
@@ -61,6 +60,5 @@ py_binary(
         "//tensorflow/python/saved_model:tag_constants",
         "@absl_py//absl:app",
         "@absl_py//absl/flags",
-        "@absl_py//absl/logging",
     ],
 )

--- a/tensorflow/python/compiler/tensorrt/model_tests/model_handler.py
+++ b/tensorflow/python/compiler/tensorrt/model_tests/model_handler.py
@@ -22,7 +22,6 @@ import tempfile
 import time
 from typing import Callable, Iterable, List, Mapping, Optional, Sequence, Union
 
-from absl import logging
 import numpy as np
 
 from tensorflow.core.framework import graph_pb2
@@ -37,6 +36,7 @@ from tensorflow.python.framework import importer
 from tensorflow.python.framework import ops as framework_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import random_ops
+from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.saved_model import load as saved_model_load
 from tensorflow.python.saved_model import loader as saved_model_loader
 from tensorflow.python.saved_model import signature_constants

--- a/tensorflow/python/compiler/tensorrt/model_tests/result_analyzer.py
+++ b/tensorflow/python/compiler/tensorrt/model_tests/result_analyzer.py
@@ -18,11 +18,11 @@ import itertools
 import json
 from typing import Any, Callable, Optional, Sequence, Tuple, Union
 
-from absl import logging
 import numpy as np
 
 from tensorflow.python.compiler.tensorrt.model_tests import model_handler
 import tensorflow.python.compiler.tensorrt.trt_convert as trt
+from tensorflow.python.platform import tf_logging as logging
 
 
 # pylint: disable=bad-whitespace

--- a/tensorflow/python/compiler/tensorrt/model_tests/run_models.py
+++ b/tensorflow/python/compiler/tensorrt/model_tests/run_models.py
@@ -21,7 +21,6 @@ from typing import Callable, Iterable, Sequence
 
 from absl import app
 from absl import flags
-from absl import logging
 
 from tensorflow.python.compiler.tensorrt import trt_convert as trt
 from tensorflow.python.compiler.tensorrt.model_tests import model_handler
@@ -31,6 +30,7 @@ from tensorflow.python.framework import config as framework_config
 from tensorflow.python.framework import ops as framework_ops
 from tensorflow.python.platform import gfile
 from tensorflow.python.platform import test as platform_test
+from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.saved_model import signature_constants
 from tensorflow.python.saved_model import tag_constants
 

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -53,6 +53,8 @@ from tensorflow.python.tools import saved_model_utils
 from tensorflow.python.training.tracking import tracking
 from tensorflow.python.util import nest
 
+logging.get_logger().propagate = False
+
 TfTrtIntegrationTestParams = collections.namedtuple(
     "TfTrtIntegrationTestParams",
     [


### PR DESCRIPTION
This PR fixes double prints in TF-TRT logging messages by stopping the propagation through all the registered handlers and only using the first one available.

This PR also removes absl logging and replace it with TF logging to avoid conflicts.
