### PR TITLE
[XNNPACK] Support quantized reshape

### DIFF
--- a/tensorflow/lite/delegates/xnnpack/BUILD
+++ b/tensorflow/lite/delegates/xnnpack/BUILD
@@ -1403,6 +1403,36 @@ cc_test(
 )
 
 cc_test(
+    name = "signed_quantized_reshape_test",
+    srcs = ["signed_quantized_reshape_test.cc"],
+    linkopts = select({
+        "//tensorflow:emscripten": EMSCRIPTEN_LINKOPTS,
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":reshape_tester",
+        ":test_main",
+        ":xnnpack_delegate_test_mode",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "unsigned_quantized_reshape_test",
+    srcs = ["unsigned_quantized_reshape_test.cc"],
+    linkopts = select({
+        "//tensorflow:emscripten": EMSCRIPTEN_LINKOPTS,
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":reshape_tester",
+        ":test_main",
+        ":xnnpack_delegate_test_mode",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_test(
     name = "resize_bilinear_test",
     srcs = ["resize_bilinear_test.cc"],
     linkopts = select({

--- a/tensorflow/lite/delegates/xnnpack/README.md
+++ b/tensorflow/lite/delegates/xnnpack/README.md
@@ -803,6 +803,13 @@ Below is the list of currently supported quantized operators:
   as the outputs, and the ratio of input scale to output scale must be in the
   [2**-8, 2**7] range.
 
+#### `RESHAPE`
+
+* The first input and the output must be in 8-bit quantized format.
+* The second input (the input with the new shape specification) must be either
+  static (use `kTfLiteMmapRo` allocation type), or absent (with the new shape
+  specified via `ReshapeOptions` table).
+
 #### `RESIZE_BILINEAR`
 
 * The first input and the output must be 4D tensors in 8-bit quantized format.

--- a/tensorflow/lite/delegates/xnnpack/reshape_tester.cc
+++ b/tensorflow/lite/delegates/xnnpack/reshape_tester.cc
@@ -36,15 +36,71 @@ limitations under the License.
 namespace tflite {
 namespace xnnpack {
 
-void ReshapeTester::Test(TfLiteDelegate* delegate) const {
+template <class T>
+void ReshapeTester::Test(TensorType tensor_type,
+                         Interpreter* delegate_interpreter,
+                         Interpreter* default_interpreter) const {
   std::random_device random_device;
   auto rng = std::mt19937(random_device());
-  auto f32rng =
+  std::uniform_int_distribution<int32_t> input_distribution(
+      std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
+  auto input_rng = std::bind(input_distribution, std::ref(rng));
+
+  T* default_input_data = default_interpreter->typed_input_tensor<T>(0);
+  std::generate(default_input_data, default_input_data + InputSize(),
+                std::ref(input_rng));
+
+  T* delegate_input_data = delegate_interpreter->typed_input_tensor<T>(0);
+  std::copy(default_input_data, default_input_data + InputSize(),
+            delegate_input_data);
+
+  ASSERT_EQ(default_interpreter->Invoke(), kTfLiteOk);
+  ASSERT_EQ(delegate_interpreter->Invoke(), kTfLiteOk);
+
+  T* default_output_data = default_interpreter->typed_output_tensor<T>(0);
+  T* delegate_output_data = delegate_interpreter->typed_output_tensor<T>(0);
+
+  for (size_t i = 0; i < OutputSize(); i++) {
+    ASSERT_EQ(delegate_output_data[i], default_output_data[i]);
+  }
+}
+
+template <>
+void ReshapeTester::Test<float>(TensorType tensor_type,
+                                Interpreter* delegate_interpreter,
+                                Interpreter* default_interpreter) const {
+  std::random_device random_device;
+  auto rng = std::mt19937(random_device());
+  auto input_rng =
       std::bind(std::uniform_real_distribution<float>(), std::ref(rng));
 
+  float* default_input_data = default_interpreter->typed_input_tensor<float>(0);
+  std::generate(default_input_data, default_input_data + InputSize(),
+                std::ref(input_rng));
+
+  float* delegate_input_data =
+      delegate_interpreter->typed_input_tensor<float>(0);
+  std::copy(default_input_data, default_input_data + InputSize(),
+            delegate_input_data);
+
+  ASSERT_EQ(default_interpreter->Invoke(), kTfLiteOk);
+  ASSERT_EQ(delegate_interpreter->Invoke(), kTfLiteOk);
+
+  float* default_output_data =
+      default_interpreter->typed_output_tensor<float>(0);
+  float* delegate_output_data =
+      delegate_interpreter->typed_output_tensor<float>(0);
+
+  for (size_t i = 0; i < OutputSize(); i++) {
+    ASSERT_EQ(delegate_output_data[i], default_output_data[i]);
+  }
+}
+
+void ReshapeTester::Test(TensorType tensor_type,
+                         TfLiteDelegate* delegate) const {
   ASSERT_EQ(InputSize(), OutputSize());
 
-  std::vector<char> buffer = CreateTfLiteModel();
+  std::vector<char> buffer = CreateTfLiteModel(tensor_type);
   const Model* model = GetModel(buffer.data());
 
   std::unique_ptr<Interpreter> delegate_interpreter;
@@ -76,29 +132,26 @@ void ReshapeTester::Test(TfLiteDelegate* delegate) const {
 
   ASSERT_EQ(delegate_interpreter->ModifyGraphWithDelegate(delegate), kTfLiteOk);
 
-  float* default_input_data = default_interpreter->typed_input_tensor<float>(0);
-  std::generate(default_input_data, default_input_data + InputSize(),
-                std::ref(f32rng));
-
-  float* delegate_input_data =
-      delegate_interpreter->typed_input_tensor<float>(0);
-  std::copy(default_input_data, default_input_data + InputSize(),
-            delegate_input_data);
-
-  ASSERT_EQ(default_interpreter->Invoke(), kTfLiteOk);
-  ASSERT_EQ(delegate_interpreter->Invoke(), kTfLiteOk);
-
-  float* default_output_data =
-      default_interpreter->typed_output_tensor<float>(0);
-  float* delegate_output_data =
-      delegate_interpreter->typed_output_tensor<float>(0);
-
-  for (size_t i = 0; i < OutputSize(); i++) {
-    ASSERT_EQ(delegate_output_data[i], default_output_data[i]);
+  switch (tensor_type) {
+    case TensorType_FLOAT32:
+      Test<float>(TensorType_FLOAT32, delegate_interpreter.get(),
+                  default_interpreter.get());
+      break;
+    case TensorType_INT8:
+      Test<int8_t>(TensorType_INT8, delegate_interpreter.get(),
+                   default_interpreter.get());
+      break;
+    case TensorType_UINT8:
+      Test<uint8_t>(TensorType_UINT8, delegate_interpreter.get(),
+                    default_interpreter.get());
+      break;
+    default:
+      GTEST_FAIL();
   }
 }
 
-std::vector<char> ReshapeTester::CreateTfLiteModel() const {
+std::vector<char> ReshapeTester::CreateTfLiteModel(
+    TensorType tensor_type) const {
   flatbuffers::FlatBufferBuilder builder;
   flatbuffers::Offset<OperatorCode> operator_code =
       CreateOperatorCode(builder, BuiltinOperator_RESHAPE, 0);
@@ -117,11 +170,21 @@ std::vector<char> ReshapeTester::CreateTfLiteModel() const {
       CreateTensor(builder,
                    builder.CreateVector<int32_t>(InputShape().data(),
                                                  InputShape().size()),
-                   TensorType_FLOAT32),
+                   tensor_type,
+                   /*buffer=*/0, /*name=*/0,
+                   CreateQuantizationParameters(
+                       builder, /*min=*/0, /*max=*/0,
+                       builder.CreateVector<float>({/*scale=*/1.0f}),
+                       builder.CreateVector<int64_t>({/*zero_point=*/0}))),
       CreateTensor(builder,
                    builder.CreateVector<int32_t>(OutputShape().data(),
                                                  OutputShape().size()),
-                   TensorType_FLOAT32),
+                   tensor_type,
+                   /*buffer=*/0, /*name=*/0,
+                   CreateQuantizationParameters(
+                       builder, /*min=*/0, /*max=*/0,
+                       builder.CreateVector<float>({/*scale=*/1.0f}),
+                       builder.CreateVector<int64_t>({/*zero_point=*/0}))),
   }};
 
   if (OutputShapeAsInput()) {

--- a/tensorflow/lite/delegates/xnnpack/reshape_tester.h
+++ b/tensorflow/lite/delegates/xnnpack/reshape_tester.h
@@ -21,6 +21,8 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "tensorflow/lite/core/c/common.h"
+#include "tensorflow/lite/interpreter.h"
+#include "tensorflow/lite/schema/schema_generated.h"
 
 namespace tflite {
 namespace xnnpack {
@@ -67,10 +69,14 @@ class ReshapeTester {
 
   inline bool OutputShapeAsInput() const { return shape_as_input_; }
 
-  void Test(TfLiteDelegate* delegate) const;
+  template <class T>
+  void Test(TensorType tensor_type, Interpreter* delegate_interpreter,
+            Interpreter* default_interpreter) const;
+
+  void Test(TensorType tensor_type, TfLiteDelegate* delegate) const;
 
  private:
-  std::vector<char> CreateTfLiteModel() const;
+  std::vector<char> CreateTfLiteModel(TensorType tensor_type) const;
 
   static int32_t ComputeSize(const std::vector<int32_t>& shape);
 

--- a/tensorflow/lite/delegates/xnnpack/signed_quantized_reshape_test.cc
+++ b/tensorflow/lite/delegates/xnnpack/signed_quantized_reshape_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <functional>
 #include <memory>
 #include <random>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include "tensorflow/lite/delegates/xnnpack/reshape_tester.h"

--- a/tensorflow/lite/delegates/xnnpack/signed_quantized_reshape_test.cc
+++ b/tensorflow/lite/delegates/xnnpack/signed_quantized_reshape_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ limitations under the License.
 #include <functional>
 #include <memory>
 #include <random>
-#include <vector>
 
 #include <gtest/gtest.h>
 #include "tensorflow/lite/delegates/xnnpack/reshape_tester.h"
@@ -27,7 +26,7 @@ limitations under the License.
 namespace tflite {
 namespace xnnpack {
 
-TEST(Reshape, 4DShapeAsInput) {
+TEST(SignedQuantizedReshape, 4DShapeAsInput) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -45,10 +44,10 @@ TEST(Reshape, 4DShapeAsInput) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(true)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_INT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 4DShapeAsParam) {
+TEST(SignedQuantizedReshape, 4DShapeAsParam) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -66,10 +65,10 @@ TEST(Reshape, 4DShapeAsParam) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(false)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_INT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 3DShapeAsInput) {
+TEST(SignedQuantizedReshape, 3DShapeAsInput) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -87,10 +86,10 @@ TEST(Reshape, 3DShapeAsInput) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(true)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_INT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 3DShapeAsParam) {
+TEST(SignedQuantizedReshape, 3DShapeAsParam) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -108,10 +107,10 @@ TEST(Reshape, 3DShapeAsParam) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(false)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_INT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 2DShapeAsInput) {
+TEST(SignedQuantizedReshape, 2DShapeAsInput) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -128,10 +127,10 @@ TEST(Reshape, 2DShapeAsInput) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(true)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_INT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 2DShapeAsParam) {
+TEST(SignedQuantizedReshape, 2DShapeAsParam) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -148,10 +147,10 @@ TEST(Reshape, 2DShapeAsParam) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(false)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_INT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 1DShapeAsInput) {
+TEST(SignedQuantizedReshape, 1DShapeAsInput) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -166,10 +165,10 @@ TEST(Reshape, 1DShapeAsInput) {
       .InputShape(shape)
       .OutputShape(shape)
       .OutputShapeAsInput(true)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_INT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 1DShapeAsParam) {
+TEST(SignedQuantizedReshape, 1DShapeAsParam) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -184,10 +183,10 @@ TEST(Reshape, 1DShapeAsParam) {
       .InputShape(shape)
       .OutputShape(shape)
       .OutputShapeAsInput(false)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_INT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 0D) {
+TEST(SignedQuantizedReshape, 0D) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -195,10 +194,10 @@ TEST(Reshape, 0D) {
   ReshapeTester()
       .InputShape(std::vector<int32_t>())
       .OutputShape(std::vector<int32_t>())
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_INT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, MultiThreading) {
+TEST(SignedQuantizedReshape, MultiThreading) {
   TfLiteXNNPackDelegateOptions delegate_options =
       TfLiteXNNPackDelegateOptionsDefault();
   delegate_options.num_threads = 2;
@@ -219,7 +218,7 @@ TEST(Reshape, MultiThreading) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(true)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_INT8, xnnpack_delegate.get());
 }
 
 }  // namespace xnnpack

--- a/tensorflow/lite/delegates/xnnpack/unsigned_quantized_reshape_test.cc
+++ b/tensorflow/lite/delegates/xnnpack/unsigned_quantized_reshape_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <functional>
 #include <memory>
 #include <random>
+#include <vector>
 
 #include "tensorflow/lite/delegates/xnnpack/reshape_tester.h"
 #include "tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h"

--- a/tensorflow/lite/delegates/xnnpack/unsigned_quantized_reshape_test.cc
+++ b/tensorflow/lite/delegates/xnnpack/unsigned_quantized_reshape_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,21 +13,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <gtest/gtest.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <random>
-#include <vector>
 
-#include <gtest/gtest.h>
 #include "tensorflow/lite/delegates/xnnpack/reshape_tester.h"
 #include "tensorflow/lite/delegates/xnnpack/xnnpack_delegate.h"
 
 namespace tflite {
 namespace xnnpack {
 
-TEST(Reshape, 4DShapeAsInput) {
+TEST(UnsignedQuantizedReshape, 4DShapeAsInput) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -45,10 +45,10 @@ TEST(Reshape, 4DShapeAsInput) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(true)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_UINT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 4DShapeAsParam) {
+TEST(UnsignedQuantizedReshape, 4DShapeAsParam) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -66,10 +66,10 @@ TEST(Reshape, 4DShapeAsParam) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(false)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_UINT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 3DShapeAsInput) {
+TEST(UnsignedQuantizedReshape, 3DShapeAsInput) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -87,10 +87,10 @@ TEST(Reshape, 3DShapeAsInput) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(true)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_UINT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 3DShapeAsParam) {
+TEST(UnsignedQuantizedReshape, 3DShapeAsParam) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -108,10 +108,10 @@ TEST(Reshape, 3DShapeAsParam) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(false)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_UINT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 2DShapeAsInput) {
+TEST(UnsignedQuantizedReshape, 2DShapeAsInput) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -128,10 +128,10 @@ TEST(Reshape, 2DShapeAsInput) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(true)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_UINT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 2DShapeAsParam) {
+TEST(UnsignedQuantizedReshape, 2DShapeAsParam) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -148,10 +148,10 @@ TEST(Reshape, 2DShapeAsParam) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(false)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_UINT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 1DShapeAsInput) {
+TEST(UnsignedQuantizedReshape, 1DShapeAsInput) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -166,10 +166,10 @@ TEST(Reshape, 1DShapeAsInput) {
       .InputShape(shape)
       .OutputShape(shape)
       .OutputShapeAsInput(true)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_UINT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 1DShapeAsParam) {
+TEST(UnsignedQuantizedReshape, 1DShapeAsParam) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -184,10 +184,10 @@ TEST(Reshape, 1DShapeAsParam) {
       .InputShape(shape)
       .OutputShape(shape)
       .OutputShapeAsInput(false)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_UINT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, 0D) {
+TEST(UnsignedQuantizedReshape, 0D) {
   std::unique_ptr<TfLiteDelegate, decltype(&TfLiteXNNPackDelegateDelete)>
       xnnpack_delegate(TfLiteXNNPackDelegateCreate(nullptr),
                        TfLiteXNNPackDelegateDelete);
@@ -195,10 +195,10 @@ TEST(Reshape, 0D) {
   ReshapeTester()
       .InputShape(std::vector<int32_t>())
       .OutputShape(std::vector<int32_t>())
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_UINT8, xnnpack_delegate.get());
 }
 
-TEST(Reshape, MultiThreading) {
+TEST(UnsignedQuantizedReshape, MultiThreading) {
   TfLiteXNNPackDelegateOptions delegate_options =
       TfLiteXNNPackDelegateOptionsDefault();
   delegate_options.num_threads = 2;
@@ -219,7 +219,7 @@ TEST(Reshape, MultiThreading) {
       .InputShape(input_shape)
       .OutputShape(output_shape)
       .OutputShapeAsInput(true)
-      .Test(TensorType_FLOAT32, xnnpack_delegate.get());
+      .Test(TensorType_UINT8, xnnpack_delegate.get());
 }
 
 }  // namespace xnnpack

--- a/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc
+++ b/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc
@@ -4532,8 +4532,9 @@ class Subgraph {
     }
 
     const TfLiteTensor& input_tensor = tensors[node->inputs->data[0]];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, input_tensor, node->inputs->data[0], node_index));
+    TF_LITE_ENSURE_STATUS(
+        CheckTensorFloat32OrQUInt8Type(delegate, logging_context, input_tensor,
+                                       node->inputs->data[0], node_index));
     TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, input_tensor, 0,
                                            XNN_MAX_TENSOR_DIMS,
                                            node->inputs->data[0]));
@@ -4552,8 +4553,9 @@ class Subgraph {
     }
 
     const TfLiteTensor& output_tensor = tensors[node->outputs->data[0]];
-    TF_LITE_ENSURE_STATUS(CheckTensorFloat32Type(
-        logging_context, output_tensor, node->outputs->data[0], node_index));
+    TF_LITE_ENSURE_STATUS(
+        CheckTensorFloat32OrQUInt8Type(delegate, logging_context, output_tensor,
+                                       node->outputs->data[0], node_index));
     TF_LITE_ENSURE_STATUS(CheckTensorShape(logging_context, output_tensor, 0,
                                            XNN_MAX_TENSOR_DIMS,
                                            node->outputs->data[0]));


### PR DESCRIPTION
[XNNPACK already supports quantized reshapes](https://github.com/google/XNNPACK/blob/99834b9a518e8ee9fb2c1405a61d1a21bfbde3a7/src/subgraph/static-reshape.c#L133-L268) so this PR allows the TFLite to delegate quantized reshape operations to XNNPACK.

/cc @Maratyszcza