### PR TITLE
Fix (de)quantisation scale factor formula in MKL kernels

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -1473,7 +1473,9 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     Node* input = nullptr;
     TF_CHECK_OK(n->input_node(0, &input));
     string mode_string;
+    int axis = -1;
     TF_CHECK_OK(GetNodeAttr(n->def(), "mode", &mode_string));
+    TF_CHECK_OK(GetNodeAttr(n->def(), "axis", &axis));
     if (mode_string != "SCALED") {
       VLOG(1) << "DequantizeRewrite: Mode is not SCALED. "
               << "This case is not optimized by Intel MKL kernel, thus using "
@@ -1485,6 +1487,12 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
               << "could possibly be a filter. "
               << "This case is not supported by Intel MKL kernel, thus using "
                  "Eigen op for Dequantize op.";
+      return false;
+    }
+
+    if (axis != -1) {
+      VLOG(1) << "DequantizeRewrite: Using Eigen op for Dequantize op because "
+              << "dimension is specified for per slice dequantization. ";
       return false;
     }
     return true;

--- a/tensorflow/core/kernels/mkl/mkl_dequantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_dequantize_op.cc
@@ -94,7 +94,7 @@ class MklDequantizeOp : public OpKernel {
           break;
         default:
           OP_REQUIRES_OK(ctx,
-                         errors::Aborted("Input dims must be <= 5 and >= 1"));
+                         errors::InvalidArgument("Input dims must be <= 5 and >= 1"));
           return;
       }
 

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
@@ -457,7 +457,7 @@ class MklQuantizeV2Op : public OpKernel {
         // If it is signed, we try to keep 0.0 being 0 and drop one bucket. For
         // example, if it is 8 bits, we have the range [-127, 127]. So for input
         // range of [-x, x], the scale should be 254/(2*x).
-        target_range = static_cast<float>((uint64_t{1} << (num_bits - 1)) - 1);
+        target_range = static_cast<float>((uint64_t{1} << num_bits) - 1) / 2.;
       } else {
         max_range = max_abs;
         min_range = 0.0;

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op_test.cc
@@ -74,7 +74,7 @@ TEST_F(MklQuantizeV2OpTest, small_int8) {
   Tensor expected(allocator(), DT_QINT8, TensorShape({8}));
   Tensor expected_min(allocator(), DT_FLOAT, TensorShape({}));
   Tensor expected_max(allocator(), DT_FLOAT, TensorShape({}));
-  test::FillValues<qint8>(&expected, {0, -1, 1, -2, -24, -128, -80, 127});
+  test::FillValues<qint8>(&expected, {0, -1, 1, -2, -25, -128, -81, 127});
   test::ExpectTensorEqual<qint8>(expected, *GetOutput(0));
   test::FillValues<float>(&expected_min, {-127.0});
   test::FillValues<float>(&expected_max, {127.0});


### PR DESCRIPTION
This patch that fixes formula for calculating scale factor when MKL quantization and dequantization primitives are called from TF. This updated formulas match results from Eigen library and makes tests //tensorflow/python:quantized_ops_test and //tensorflow/python:dequantize_op_test pass when TF_ENABLE_ONEDNN_OPTS is 1 .

Additionally:
* it also adds correct memory layout when using tensor with different dimension to 4 in MKL dequantize operation, and
* reverts to Eigen op when per slice dequantization is specified