### PR TITLE
[oneDNN] Bug fix: /tensorflow/python/grappler:remapper_test_gpu on GPU with oneDNN enabled

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -3203,7 +3203,8 @@ bool RequiresInferredShapes(const RemapperContext& ctx, int node_index) {
 
   if (IsMKLEnabled())
     return is_batch_norm_candidate() || is_batch_norm_fusion_candidate() ||
-           IsContractionWithAdd(ctx, node_index);
+           IsContractionWithAdd(ctx, node_index) ||
+           is_relu_biasadd_conv_candidate();
 
   return is_relu_biasadd_conv_candidate() || is_batch_norm_candidate() ||
          is_batch_norm_fusion_candidate() ||


### PR DESCRIPTION
A new test was added by the [commit](https://github.com/tensorflow/tensorflow/commit/4dbecb7c26feff4fc6bfd7ddb470494f3e9ab220) which was failing when oneDNN and CUDA are both enabled.
This PR enables shape inference for Conv+BiasAdd+Relu fusion when oneDNN is enabled.
Without this the shape for filter [here](https://github.com/intel-innersource/frameworks.ai.tensorflow.private-tensorflow/blob/master/tensorflow/core/grappler/optimizers/remapper.cc#L431) is 0 and fusion does not happen.