### PR TITLE
Add fast int division for GPU kernels

### DIFF
--- a/tensorflow/core/kernels/depthwise_conv_op_gpu.h
+++ b/tensorflow/core/kernels/depthwise_conv_op_gpu.h
@@ -344,14 +344,14 @@ __global__ void __launch_bounds__(1024, 2)
       kKnownFilterHeight < 0 ? args.filter_rows : kKnownFilterHeight;
   const int filter_width =
       kKnownFilterWidth < 0 ? args.filter_cols : kKnownFilterWidth;
-  const int depth_multiplier =
+  const FastDividerUint32 depth_multiplier =
       kKnownDepthMultiplier < 0 ? args.depth_multiplier : kKnownDepthMultiplier;
   const int stride = args.stride;
   const int pad_height = args.pad_rows;
   const int pad_width = args.pad_cols;
-  const int out_height = args.out_rows;
   const int out_width = args.out_cols;
-  const int out_depth = args.out_depth;
+  const FastDividerUint32 out_height = args.out_rows;
+  const FastDividerUint32 out_depth = args.out_depth;
 
   GPU_1D_KERNEL_LOOP(thread_id, num_outputs) {
     // Compute the indexes of this thread in the output.
@@ -876,16 +876,16 @@ __global__ void __launch_bounds__(640, 2)
         const DepthwiseArgs args, const T* __restrict__ out_backprop,
         const T* __restrict__ filter, T* __restrict__ in_backprop,
         int num_in_backprop) {
-  const int in_height = args.in_rows;
-  const int in_width = args.in_cols;
-  const int in_depth = args.in_depth;
+  const FastDividerUint32 in_height = args.in_rows;
+  const FastDividerUint32 in_width = args.in_cols;
+  const FastDividerUint32 in_depth = args.in_depth;
   const int filter_height =
       kKnownFilterHeight < 0 ? args.filter_rows : kKnownFilterHeight;
   const int filter_width =
       kKnownFilterWidth < 0 ? args.filter_cols : kKnownFilterWidth;
   const int depth_multiplier =
       kKnownDepthMultiplier < 0 ? args.depth_multiplier : kKnownDepthMultiplier;
-  const int stride = args.stride;
+  const FastDividerUint32 stride = args.stride;
   const int pad_height = args.pad_rows;
   const int pad_width = args.pad_cols;
   const int out_height = args.out_rows;
@@ -908,11 +908,11 @@ __global__ void __launch_bounds__(640, 2)
     const int out_row_start =
         tf_max<int>(0, (in_row - filter_height + pad_height + stride) / stride);
     const int out_row_end =
-        tf_min(out_height - 1, (in_row + pad_height) / stride);
+        tf_min<int>(out_height - 1, (in_row + pad_height) / stride);
     const int out_col_start =
-        tf_max(0, (in_col - filter_width + pad_width + stride) / stride);
+        tf_max<int>(0, (in_col - filter_width + pad_width + stride) / stride);
     const int out_col_end =
-        tf_min(out_width - 1, (in_col + pad_width) / stride);
+        tf_min<int>(out_width - 1, (in_col + pad_width) / stride);
 
     UNROLL for (int out_channel = out_channel_start;
                 out_channel < out_channel_end; ++out_channel) {
@@ -1324,8 +1324,8 @@ __global__ void __launch_bounds__(512, 2)
   const int pad_width = args.pad_cols;
   const int out_depth = args.out_depth;
   const int out_height = args.out_rows;
-  const int out_width = args.out_cols;
-  const int depth_multiplier = args.depth_multiplier;
+  const FastDividerUint32 out_width = args.out_cols;
+  const FastDividerUint32 depth_multiplier = args.depth_multiplier;
   assert(gridDim.x == filter_width);
   assert(gridDim.z == out_depth);
 

--- a/tensorflow/core/kernels/depthwise_conv_op_gpu.h
+++ b/tensorflow/core/kernels/depthwise_conv_op_gpu.h
@@ -885,7 +885,7 @@ __global__ void __launch_bounds__(640, 2)
       kKnownFilterWidth < 0 ? args.filter_cols : kKnownFilterWidth;
   const int depth_multiplier =
       kKnownDepthMultiplier < 0 ? args.depth_multiplier : kKnownDepthMultiplier;
-  const FastDividerUint32 stride = args.stride;
+  const int stride = args.stride;
   const int pad_height = args.pad_rows;
   const int pad_width = args.pad_cols;
   const int out_height = args.out_rows;

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -418,6 +418,9 @@ namespace cuda_helper = gpu_helper;
 // division. For detailed information see:
 //   https://ridiculousfish.com/blog/posts/labor-of-division-episode-i.html
 //
+// Warning: This implementation only works when the divisor is [1, INT32_MAX]
+//          and the numerator has to be [0, INT32_MAX]. This is enough for our
+//          purpose for computing integer indices.
 // Basics: the typical int division can be written as:
 //   n / d = (m * n) / 2^(32 + s)
 // where 'n' is the numerator and 'd' is the divisor. For a given 'd', we
@@ -425,8 +428,6 @@ namespace cuda_helper = gpu_helper;
 struct FastDividerUint32 {
   EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC FastDividerUint32(uint32_t d)
       : divisor(d) {
-    // We assume that the divisor is at most INT32_MAX, which is enough for our
-    // purpose for computing int indices.
     assert(divisor >= 1 && divisor <= INT32_MAX);
     update_magic();
   }
@@ -456,6 +457,7 @@ struct FastDividerUint32 {
 
   EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC FastDividerUint32& operator=(
       uint32_t d) {
+    assert(divisor >= 1 && divisor <= INT32_MAX);
     this->divisor = d;
     update_magic();
     return *this;

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -414,6 +414,94 @@ __device__ OutType lower_bound(Iterator first, OutType count, T val) {
 namespace cuda_helper = gpu_helper;
 #endif
 
+// For int division, we can substitute the fast multiplication for slow
+// division. For detailed information see:
+//   https://ridiculousfish.com/blog/posts/labor-of-division-episode-i.html
+//
+// Basics: the typical int division can be written as:
+//   n / d = (m * n) / 2^(32 + s)
+// where 'n' is the numerator and 'd' is the divisor. For a given 'd', we
+// need to find a magic number 'm' and a shift 's'. See update_magic().
+struct FastDividerUint32 {
+  EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC FastDividerUint32(uint32_t d)
+      : divisor(d) {
+    // We assume that the divisor is at most INT32_MAX, which is enough for our
+    // purpose for computing int indices.
+    assert(divisor >= 1 && divisor <= INT32_MAX);
+    update_magic();
+  }
+
+  EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC void update_magic() {
+    // (1). The shift 's' is calculated by log2ceil(d).
+#if defined(__CUDA_ARCH__)
+    shift = 32 - __clz(divisor - 1);
+#else
+    for (shift = 0; shift < 32; shift++) {
+      if ((1U << shift) >= divisor) break;
+    }
+#endif
+
+    // (2). The magic number 'm' is calculated by:
+    //   m = 2^(32 + s) / d + 1
+    // Note, the digit '1' is to round up 'm * n', which will be rounded down
+    // later by dividing two. In practice, 'm' is a 33-bit value. To fit the
+    // 32-bit range, we introduce:
+    //   magic = m - 2^32
+    //         = 2^(32 + s) / d - 2^32 + 1
+    //         = 2^32 * 2^s / d - 2^32 * d / d + 1
+    //         = (2^32 * (2^s - d)) / d + 1, where 'magic' will be in 32-bit.
+    uint64_t m = (0x100000000ull * ((0x1ull << shift) - divisor)) / divisor + 1;
+    magic = static_cast<uint32_t>(m);
+  }
+
+  EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC FastDividerUint32& operator=(
+      uint32_t d) {
+    this->divisor = d;
+    update_magic();
+    return *this;
+  }
+
+  EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC operator uint32_t() const {
+    return divisor;
+  }
+
+  uint32_t divisor;
+  uint32_t magic;
+  uint32_t shift;
+};
+
+EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC uint32_t
+operator/(const uint32_t n, const FastDividerUint32& fdiv) {
+  // (3). We use the 32-bit 'magic' instead of 'm' in the formula:
+  //   n / d = (m * n) / 2^(32 + s)
+  //         = (magic + 2^32) * n / 2^(32 + s)
+  //         = (magic * n) / 2^(32 + s) + n / 2^s
+  //         = (magic * n) / 2^32 / 2^s + n / 2^s
+  //         = (magic * n / 2^32 + n) / 2^s
+#if defined(__CUDA_ARCH__)
+  uint32_t q = __umulhi(n, fdiv.magic);
+#else
+  uint32_t q =
+      static_cast<uint32_t>((static_cast<uint64_t>(n) * fdiv.magic) >> 32);
+#endif
+  return (n + q) >> fdiv.shift;
+}
+
+EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC uint32_t
+operator%(const uint32_t n, const FastDividerUint32& fdiv) {
+  return n - (n / fdiv) * fdiv.divisor;
+}
+
+EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC uint32_t
+operator/(const int n, const FastDividerUint32& fdiv) {
+  return static_cast<uint32_t>(n) / fdiv;
+}
+
+EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC uint32_t
+operator%(const int n, const FastDividerUint32& fdiv) {
+  return static_cast<uint32_t>(n) % fdiv;
+}
+
 }  // namespace tensorflow
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM


### PR DESCRIPTION
This PR introduces the fast integer division mainly for the GPU kernels, which substitutes the fast multiplication with the slow division instructions.

The implementation is based on the mathematical basis in this blog post:
https://ridiculousfish.com/blog/posts/labor-of-division-episode-i.html

The fast int div alone can deliver up to ~20% and ~40% speedups in our benchmark for V100 and A100 GPUs respectively.

Benchmark script: https://github.com/kaixih/depthwise_conv2d_benchmark
Benchmark results of V100 and A100:
https://docs.google.com/spreadsheets/d/14KPVP6ueN4Gkc3UEy94jGV2W9SN8VuVGA8S-gcKioU8/edit?usp=sharing

cc. @nluehr