### PR TITLE
Add data init funcs for TFLite Swift API

### DIFF
--- a/tensorflow/lite/swift/Sources/Interpreter.swift
+++ b/tensorflow/lite/swift/Sources/Interpreter.swift
@@ -81,8 +81,35 @@ public final class Interpreter {
   ///   - delegate: `Array` of `Delegate`s for the `Interpreter` to use to peform graph operations.
   ///       The default is `nil`.
   /// - Throws: An error if the model could not be loaded or the interpreter could not be created.
-  public init(modelPath: String, options: Options? = nil, delegates: [Delegate]? = nil) throws {
+  public convenience init(modelPath: String, options: Options? = nil, delegates: [Delegate]? = nil) throws {
     guard let model = Model(filePath: modelPath) else { throw InterpreterError.failedToLoadModel }
+    try self.init(model: model, options: options, delegates: delegates)
+  }
+
+  /// Creates a new instance with the given values.
+  ///
+  /// - Parameters:
+  ///   - modelData: Binary data representing the TensorFlow Lite model.
+  ///   - options: Configurations for the `Interpreter`. The default is `nil` indicating that the
+  ///       `Interpreter` will determine the configuration options.
+  ///   - delegate: `Array` of `Delegate`s for the `Interpreter` to use to peform graph operations.
+  ///       The default is `nil`.
+  /// - Throws: An error if the model could not be loaded or the interpreter could not be created.
+  public convenience init(modelData: Data, options: Options? = nil, delegates: [Delegate]? = nil) throws {
+    guard let model = Model(modelData: modelData) else { throw InterpreterError.failedToLoadModel }
+    try self.init(model: model, options: options, delegates: delegates)
+  }
+
+  /// Create a new instance with the given values.
+  ///
+  /// - Parameters:
+  ///   - model: An instantiated TensorFlow Lite model.
+  ///   - options: Configurations for the `Interpreter`. The default is `nil` indicating that the
+  ///       `Interpreter` will determine the configuration options.
+  ///   - delegate: `Array` of `Delegate`s for the `Interpreter` to use to peform graph operations.
+  ///       The default is `nil`.
+  /// - Throws: An error if the model could not be loaded or the interpreter could not be created.
+  private init(model: Model, options: Options? = nil, delegates: [Delegate]? = nil) throws {
     guard let cInterpreterOptions = TfLiteInterpreterOptionsCreate() else {
       throw InterpreterError.failedToCreateInterpreter
     }

--- a/tensorflow/lite/swift/Sources/Interpreter.swift
+++ b/tensorflow/lite/swift/Sources/Interpreter.swift
@@ -89,7 +89,7 @@ public final class Interpreter {
   /// Creates a new instance with the given values.
   ///
   /// - Parameters:
-  ///   - modelData: Binary data representing the TensorFlow Lite model.
+  ///   - modelData: Binary data representing a TensorFlow Lite model.
   ///   - options: Configurations for the `Interpreter`. The default is `nil` indicating that the
   ///       `Interpreter` will determine the configuration options.
   ///   - delegate: `Array` of `Delegate`s for the `Interpreter` to use to peform graph operations.

--- a/tensorflow/lite/swift/Sources/Model.swift
+++ b/tensorflow/lite/swift/Sources/Model.swift
@@ -46,7 +46,7 @@ final class Model {
   ///   - modelData: Binary data representing a TensorFlow Lite model.
   init?(modelData: Data) {
     self.data = modelData
-    self.cModel = self.data.withUnsafeBytes { TfLiteModelCreate($0, self.data.count) }
+    self.cModel = self.data!.withUnsafeBytes { TfLiteModelCreate($0, self.data!.count) }
   }
 
   deinit {

--- a/tensorflow/lite/swift/Sources/Model.swift
+++ b/tensorflow/lite/swift/Sources/Model.swift
@@ -23,6 +23,12 @@ final class Model {
   /// The underlying `TfLiteModel` C pointer.
   let cModel: CModel?
 
+  /// The underlying data if data init is used
+  /// From c_api.h: The caller retains ownership of the `model_data` and should ensure that
+  // the lifetime of the `model_data` must be at least as long as the lifetime
+  // of the `TfLiteModel`.
+  let data: Data?
+
   /// Creates a new instance with the given `filePath`.
   ///
   /// - Precondition: Initialization can fail if the given `filePath` is invalid.
@@ -34,7 +40,8 @@ final class Model {
   }
 
   init?(modelData: Data) {
-    self.cModel = modelData.withUnsafeBytes { TfLiteModelCreate($0, modelData.count) }
+    self.data = modelData
+    self.cModel = self.data.withUnsafeBytes { TfLiteModelCreate($0, self.data.count) }
   }
 
   deinit {

--- a/tensorflow/lite/swift/Sources/Model.swift
+++ b/tensorflow/lite/swift/Sources/Model.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Foundation
 import TensorFlowLiteC
 
 /// A TensorFlow Lite model used by the `Interpreter` to perform inference.
@@ -30,6 +31,10 @@ final class Model {
   init?(filePath: String) {
     guard !filePath.isEmpty, let cModel = TfLiteModelCreateFromFile(filePath) else { return nil }
     self.cModel = cModel
+  }
+
+  init?(modelData: Data) {
+    self.cModel = modelData.withUnsafeBytes { TfLiteModelCreate($0, modelData.count) }
   }
 
   deinit {

--- a/tensorflow/lite/swift/Sources/Model.swift
+++ b/tensorflow/lite/swift/Sources/Model.swift
@@ -39,6 +39,11 @@ final class Model {
     self.cModel = cModel
   }
 
+  /// Creates a new instance with the given `modelData`.
+  ///
+  /// - Precondition: Initialization can fail if the given `modelData` is invalid.
+  /// - Parameters:
+  ///   - modelData: Binary data representing a TensorFlow Lite model.
   init?(modelData: Data) {
     self.data = modelData
     self.cModel = self.data.withUnsafeBytes { TfLiteModelCreate($0, self.data.count) }

--- a/tensorflow/lite/swift/Tests/InterpreterTests.swift
+++ b/tensorflow/lite/swift/Tests/InterpreterTests.swift
@@ -50,6 +50,22 @@ class InterpreterTests: XCTestCase {
     XCTAssertNil(interpreter.delegates)
   }
 
+  func testInit_WithData_ValidModelPath() {
+    XCTAssertNoThrow(try Interpreter(modelData: Data(contentsOf: URL(fileURLWithPath: AddModel.path))))
+  }
+
+
+  func testInitWithDataWithOptions() throws {
+    var options = Interpreter.Options()
+    options.threadCount = 2
+    let interpreter = try Interpreter(
+      modelPath: Data(contentsOf: URL(fileURLWithPath: AddQuantizedModel.path)),
+      options: options
+    )
+    XCTAssertNotNil(interpreter.options)
+    XCTAssertNil(interpreter.delegates)
+  }
+
   func testInputTensorCount() {
     XCTAssertEqual(interpreter.inputTensorCount, AddModel.inputTensorCount)
   }

--- a/tensorflow/lite/swift/Tests/ModelTests.swift
+++ b/tensorflow/lite/swift/Tests/ModelTests.swift
@@ -51,6 +51,10 @@ class ModelTests: XCTestCase {
   func testInitWithInvalidFilePath_FailsInitialization() {
     XCTAssertNil(Model(filePath: "invalid/path"))
   }
+
+  func testInitWithData() {
+    XCTAssertNotNil(Model(modelData: Data(contentsOf: URL(fileURLWithPath: modelPath))))
+  }
 }
 
 // MARK: - Constants


### PR DESCRIPTION
As per #56144 it'd be nice if Interpreters could be initialized from `Data` instead of file paths like in the Android API. I added functions for this feature.

I'm having trouble building this locally so I'm PR'ing it in hopes that I can build via PR. Locally, I see many messages like 
```
error: output 'tensorflow/lite/swift/TensorFlowLiteAllDelegates_objs/Sources/CoreMLDelegate.swift.partial_swiftmodule' was not created
Compiling Swift module //tensorflow/lite/swift:TensorFlowLiteAllDelegates failed: not all outputs were created or valid
```
from Bazel. I'm using XCode 13.3.1  and Bazel 5.1.1

