### PR TITLE
[TF-TRT] Change default max workspace size to INT_MAX (fixed)

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/trt_convert_api.h
+++ b/tensorflow/compiler/tf2tensorrt/trt_convert_api.h
@@ -16,11 +16,13 @@ limitations under the License.
 #ifndef TENSORFLOW_COMPILER_TF2TENSORRT_TRT_CONVERT_H_
 #define TENSORFLOW_COMPILER_TF2TENSORRT_TRT_CONVERT_H_
 
+#include <climits>
 #include <string>
 #include <vector>
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 
+#include "tensorflow/compiler/tf2tensorrt/common/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/trt_parameters.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/platform/statusor.h"
@@ -35,7 +37,11 @@ namespace tensorrt {
 struct TfTrtConversionParams {
   // Corresponds 'workspaceSize' parameter of
   // nvinfer1::IBuilderConfig::setMaxWorkspaceSize.
+#if IS_TRT_VERSION_GE(8, 4, 0, 0)
+  size_t max_workspace_size_bytes = INT_MAX;
+#else
   size_t max_workspace_size_bytes = 1 << 30;
+#endif
 
   // Minimum precision used by the TRT Engine.
   TrtPrecisionMode precision_mode = TrtPrecisionMode::FP32;

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -106,7 +106,12 @@ class TrtPrecisionMode(object):
 
 # Use a large enough number as the default max_workspace_size for TRT engines,
 # so it can produce reasonable performance results with the default.
-DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES = 1 << 30
+# For TRT >= 8.4, the recommendation is MAX_INT.
+if (_pywrap_py_utils.is_tensorrt_enabled()
+        and trt_utils.is_loaded_tensorrt_version_greater_equal(8, 4, 0)):
+  DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES = np.iinfo(np.int32).max
+else:
+  DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES = 1 << 30
 
 PROFILE_STRATEGY_RANGE = "Range"
 PROFILE_STRATEGY_OPTIMAL = "Optimal"


### PR DESCRIPTION
#55665 had to be rolled back due to using `trt_utils.is_loaded_tensorrt_version_greater_equal` outside of any functions, which causes an error when importing TF without TRT.

The solution I found is to use a special value `None` for the default and call a function to get the default value for the loaded TRT. It's a bit redundant, if someone can think of a cleaner solution, please let me know.