### PR TITLE
Fix for incorrect type and size calculated in ctstring_test on s390x

### DIFF
--- a/tensorflow/core/platform/ctstring_internal.h
+++ b/tensorflow/core/platform/ctstring_internal.h
@@ -215,7 +215,7 @@ static inline const char *TF_TString_GetDataPointer(const TF_TString *str) {
     case TF_TSTR_LARGE:
       return str->u.large.ptr;
     case TF_TSTR_OFFSET:
-      return (const char *)str + str->u.offset.offset;  // NOLINT
+      return (const char *)str + TF_le32toh(str->u.offset.offset);  // NOLINT
     case TF_TSTR_VIEW:
       return str->u.view.ptr;
     default:


### PR DESCRIPTION
The `OffsetType` test fails on s390x as it returns 0 for type/size. This is happening because [TF_TString_ToInternalSizeT](https://github.com/tensorflow/tensorflow/blob/v2.8.0/tensorflow/core/platform/ctstring_internal.h#L158) returns 8 bytes(size_t is 8 bytes on s390x), however offset type has "size" which is uint32. Thus the data containing 'type' information is lost. This further causes wrong 'size' calculation [here](https://github.com/tensorflow/tensorflow/blob/v2.8.0/tensorflow/core/platform/ctstring_internal.h#L184).  

The mark and other calculations work for Large type strings as the 'size' is 8bytes.
Fixes #56046. More details in that issue.
