### PR TITLE
update skip test list for ARM64 CI/CD

### DIFF
--- a/.github/workflows/arm-cd.yml
+++ b/.github/workflows/arm-cd.yml
@@ -19,6 +19,8 @@ on:
   push:
     tags:
       - v2.**
+    branches:
+      - r2.9
   schedule:
     - cron: '0 8 * * *'
 

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -66,12 +66,10 @@ export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} \
     -//tensorflow/compiler/mlir/lite/tests:const-fold.mlir.test \
     -//tensorflow/compiler/mlir/lite/tests:prepare-tf.mlir.test \
     -//tensorflow/python:nn_grad_test \
-    -//tensorflow/python:dequantize_op_test \
-    -//tensorflow/python:quantized_ops_test \
-    -//tensorflow/python/data/experimental/kernel_tests/service:cross_trainer_cache_test \
     -//tensorflow/python/eager:forwardprop_test \
     -//tensorflow/python/framework:node_file_writer_test \
     -//tensorflow/python/grappler:memory_optimizer_test \
+    -//tensorflow/python/keras/engine:training_arrays_test \
     -//tensorflow/python/kernel_tests/linalg:linear_operator_householder_test \
     -//tensorflow/python/kernel_tests/linalg:linear_operator_inversion_test \
     -//tensorflow/python/kernel_tests/linalg:linear_operator_block_diag_test \


### PR DESCRIPTION
Tests added to skip list:
tensorflow/python/keras/engine:training_arrays_test (test was removed in master branch)

Tests removed from skip list:
tensorflow/python:dequantize_op_test (passes in r2.9 branch)
tensorflow/python:quantized_ops_test (passes in r2.9 branch)
tensorflow/python/data/experimental/kernel_tests/service:cross_trainer_cache_test (not in r2.9 branch)

Also added new commits in r2.9 branch to trigger CD pipeline to upload wheel to PyPI.