### PR TITLE
Fix CMake build of TFLite C Library

### DIFF
--- a/tensorflow/lite/c/CMakeLists.txt
+++ b/tensorflow/lite/c/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 add_library(tensorflowlite_c ${TFLITE_C_LIBTYPE}
   builtin_op_data.h
   common.h
-  common.c
+  common.cc
   c_api_types.h
   c_api.h
   c_api.cc


### PR DESCRIPTION
Following the [guide](https://www.tensorflow.org/lite/guide/build_cmake#build_tensorflow_lite_c_library) on how to build the TensorFlow Lite C library from source, I ran into an issue where the build was failing due to missing file `common.c`:

```
CMake Error at CMakeLists.txt:63 (add_library):
  Cannot find source file:

    common.c

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .h
  .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc


CMake Error at CMakeLists.txt:63 (add_library):
  No SOURCES given to target: tensorflowlite_c
```

I noticed that the file seems to have been renamed.

This PR updates the entry in `CMakeLists.txt` and fixes the issue with the build.