### PR TITLE
Use partial content of tensor as part of key to cache primitive

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -317,7 +317,9 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, T> {
   std::vector<string> fused_ops_;
   const int kInputIndex_Add = 3;
   const int kOutputIndex_Dst = 0;
+#ifdef DNNL_AARCH64_USE_ACL  
   const int kWeightTensorHashLength = 1024;
+#endif  
 };  // namespace tensorflow
 
 // Register mkl kernels for supported operations and types.

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -125,9 +125,12 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, T> {
     // Extend the basic parameters for data types and fusions.
     ExtendMklDnnMatMulFwdParams(ctx, matmul_params);
 #ifdef DNNL_AARCH64_USE_ACL
-    // Specifics of ACL: a primitive per constant weights ptr
-    matmul_params.weight_address = const_cast<void*>(
-        static_cast<const void*>(weight_tensor.flat<T>().data()));
+    // TODO(milpuz01): Remove once Arm Compute Library provides support for
+    // in-place updates
+    matmul_params.weight_hash =
+        Hash64(weight_tensor.tensor_data().data(),
+               std::min(kWeightTensorHashLength,
+                        static_cast<int>(weight_tensor.tensor_data().size())));
 #endif
     MklDnnMatMulFwdPrimitive<T, T, T, T, T>* matmul_prim =
         MklDnnMatMulFwdPrimitiveFactory<T, T, T, T, T>::Get(matmul_params, 0);
@@ -314,6 +317,7 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, T> {
   std::vector<string> fused_ops_;
   const int kInputIndex_Add = 3;
   const int kOutputIndex_Dst = 0;
+  const int kWeightTensorHashLength = 1024;
 };  // namespace tensorflow
 
 // Register mkl kernels for supported operations and types.

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/onednn_env_vars.h"
 #ifdef DNNL_AARCH64_USE_ACL
+#include "tensorflow/core/platform/hash.h"
 #include "tensorflow/core/platform/mutex.h"
 #endif
 
@@ -66,7 +67,7 @@ struct MklDnnMatMulFwdParams {
   string dtypes = string("");
   bool const_weight;
 #ifdef DNNL_AARCH64_USE_ACL
-  void* weight_address = nullptr;
+  uint64 weight_hash;
 #endif
   struct PostOpParam {
     string name;
@@ -405,7 +406,7 @@ class MklDnnMatMulFwdPrimitiveFactory : public MklPrimitiveFactory<T> {
     key_creator.AddAsKey(mkldnn_matmul_fwd_dims.dtypes);
     key_creator.AddAsKey(mkldnn_matmul_fwd_dims.weight_format);
 #ifdef DNNL_AARCH64_USE_ACL
-    key_creator.AddAsKey(mkldnn_matmul_fwd_dims.weight_address);
+    key_creator.AddAsKey(mkldnn_matmul_fwd_dims.weight_hash);
 #endif
 
     // Generate keys for post-ops


### PR DESCRIPTION
Since we cannot update tensors in-place when using Arm Compute Library once the Mkl primitive is created and to get benefit of reusing the primitive when it is called again as part of hash function for caching the primitive we are using memory address where the tensors whose content can be updated is stored. Unfortunately, when a new primitive needs to be created where the only difference is content of tensors that is stored at the same memory address (like in tests tensorflow/core/kernels:matmul_op_test_cpu and tensorflow/core/kernels/conv_ops_test_cpu or in running BERT) we will retrieve from the cache wrong primitive with stale tensors.

In order to avoid this problem this patch takes hash of partial content of tensor and use that as part of key for caching primitives. Once Arm Compute Library enables in-place updates (expected in 22.08 release) this patch will be removed.