### PR TITLE
Patch Compute Library to pass correctly arguments to activation function

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -193,7 +193,7 @@ def _tf_repositories():
         sha256 = "11244b05259fb1c4af7384d0c3391aeaddec8aac144774207582db4842726540",
         strip_prefix = "ComputeLibrary-22.02",
         build_file = "//third_party/compute_library:BUILD",
-        patch_file = ["//third_party/compute_library:compute_library.patch"],
+        patch_file = ["//third_party/compute_library:compute_library.patch", "//third_party/compute_library:activation_func_correct_args.patch"],
         urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.02.tar.gz"),
     )
 

--- a/third_party/compute_library/activation_func_correct_args.patch
+++ b/third_party/compute_library/activation_func_correct_args.patch
@@ -1,0 +1,14 @@
+diff --git a/src/cpu/operators/CpuGemmDirectConv2d.cpp b/src/cpu/operators/CpuGemmDirectConv2d.cpp
+index 75c057e45..4d4d0e272 100644
+--- a/src/cpu/operators/CpuGemmDirectConv2d.cpp
++++ b/src/cpu/operators/CpuGemmDirectConv2d.cpp
+@@ -193,6 +193,8 @@ void CpuGemmDirectConv2d::run(ITensorPack &tensors)
+     _gemm_asm_func->run(tensors);
+     if(_run_activation)
+     {
+-        _activation_func->run(tensors);
++        auto io = tensors.get_tensor(ACL_DST);
++        ITensorPack pack{ { ACL_SRC, io }, { ACL_DST, io } };
++        _activation_func->run(pack);
+     }
+ }


### PR DESCRIPTION
Fixes issue in Arm Compute Library when arguments are not passed correctly run activation function as post op after running GEMM through NEGEMMConv2D.