### PR TITLE
Remove debug logs from saver.py

### DIFF
--- a/tensorflow/python/training/saver.py
+++ b/tensorflow/python/training/saver.py
@@ -87,10 +87,8 @@ def _get_checkpoint_size(prefix):
   # Gather all files beginning with prefix (.index plus sharded data files).
   files = glob.glob("{}*".format(prefix))
   for file in files:
-    logging.info(file)
     # Use TensorFlow's C++ FileSystem API.
     size += metrics.CalculateFileSize(file)
-    logging.info(size)
   return size
 
 


### PR DESCRIPTION
These logs were added by [https://github.com/tensorflow/tensorflow/commit/2a3b691394adbb19b4665e187f16358295122ae9] and have no meaning for user.

I'm seeing now 
```
INFO:tensorflow:/tmp/xxx/model.ckpt-00000200.meta
INFO:tensorflow:2100
INFO:tensorflow:/tmp/xxx/model.ckpt-00000200.data-00000-of-00001
INFO:tensorflow:161900
INFO:tensorflow:/tmp/xxx/model.ckpt-00000200.index
INFO:tensorflow:161900
```
while saving checkpoint with TF 2.9.0. On TF 2.8.0 there was no such output.

CC @monicadsong 