### PR TITLE
Move `std::wstring_convert` under ifdef

### DIFF
--- a/tensorflow/lite/delegates/external/external_delegate.cc
+++ b/tensorflow/lite/delegates/external/external_delegate.cc
@@ -31,11 +31,11 @@ struct ExternalLib {
       void (*report_error)(const char*))>::type;
   using DestroyDelegatePtr = std::add_pointer<void(TfLiteDelegate*)>::type;
   struct wchar_codecvt : public std::codecvt<wchar_t, char, std::mbstate_t> {};
-  std::wstring_convert<wchar_codecvt> converter;
 
   // Open a given delegate library and load the create/destroy symbols
   bool load(const std::string library) {
 #if defined(_WIN32)
+    std::wstring_convert<wchar_codecvt> converter;
     void* handle = SharedLibrary::LoadLibrary(
         converter.from_bytes(library.c_str()).c_str());
 #else


### PR DESCRIPTION
This moves the `std::wstring_convert` under the `_WIN32` ifdef for three small reasons (small on itself but together I thought it makes sense to do it):
* It is only used within the `_WIN32` anyway, so this is cleaner.
* This function is [deprecated under C++17 standard](https://www.reddit.com/r/cpp/comments/es9gt1/since_stdwstring_convert_is_deprecated_what_is/) so would be good to get it out of the way.
* Clang cross-compilation with an older GCC (e.g. 4.9) could give the error `error: no template named 'wstring_convert' in namespace 'std'` (e.g. `clang++ --target=aarch64-linux-gnu --gcc-toolchain=/path/to/gcc-linaro-4.9.4-2017.01-x86_64_aarch64-linux-gnu -I. -c tensorflow/lite/delegates/external/external_delegate.cc`).