### PR TITLE
Make cuda header version check flexible w.r.t. whitespace.

### DIFF
--- a/third_party/gpus/find_cuda_config.py
+++ b/third_party/gpus/find_cuda_config.py
@@ -121,7 +121,7 @@ def _at_least_version(actual_version, required_version):
 def _get_header_version(path, name):
   """Returns preprocessor defines in C header file."""
   for line in io.open(path, "r", encoding="utf-8").readlines():
-    match = re.match("#define %s +(\d+)" % name, line)
+    match = re.match("\s*#\s*define %s\s+(\d+)" % name, line)
     if match:
       return match.group(1)
   return ""


### PR DESCRIPTION
Version macros in CUDA headers may include whitespace, which currently can cause cuda_configure to fail.
This PR makes the version regex in find_cuda_config more flexible.