### PR TITLE
Fix legalization of SplitV by handling negative axis values

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1198,6 +1198,18 @@ func.func @test_split_axis_0(%arg0: tensor<21x13x3xf32>) -> (tensor<7x13x3xf32>,
 
 // -----
 
+// CHECK-LABEL: test_split_v_neg_axis
+// CHECK-DAG: %[[VAR0:.*]] = "tosa.slice"(%arg0) {size = [2, 3, 3, 3], start = [0, 0, 0, 0]}
+// CHECK: %[[VAR1:.*]] = "tosa.slice"(%arg0) {size = [2, 3, 3, 5], start = [0, 0, 0, 3]}
+func.func @test_split_v_neg_axis(%arg0: tensor<2x3x3x8xf32>) -> (tensor<2x3x3x3xf32>, tensor<2x3x3x5xf32>) {
+  %split_size = arith.constant dense<[3, 5]> : tensor<2xi32>
+  %axis = arith.constant dense<-1> : tensor<i32>
+  %0, %1 = "tfl.split_v"(%arg0, %split_size, %axis)  {num_splits = 2 : i32}  : (tensor<2x3x3x8xf32>, tensor<2xi32>, tensor<i32>) -> (tensor<2x3x3x3xf32>, tensor<2x3x3x5xf32>)
+  func.return %0, %1 : tensor<2x3x3x3xf32>, tensor<2x3x3x5xf32>
+}
+
+// -----
+
 // CHECK-LABEL: test_tile
 // CHECK: tosa.tile
 func.func @test_tile(%arg0: tensor<13x21x3xf32>) -> tensor<*xf32> {


### PR DESCRIPTION
The legalization for SplitV would not take negative values as axis at
the moment. Because no error is thrown, the rewrite will just discard
the operator resulting in a wrong MLIR.

This patch fixes the issue by adjusting the axis with a wrap around
approach. Furthermore, if the axis value exceeds the size of the input
tensor, an error is thrown so that the legalization does not take place
allowing other rewrites to be performed.

Signed-off-by: Michele Di Giorgio <michele.digiorgio@arm.com>
Change-Id: I2b873ddce9685b9105a142c20fc032afc9863bf3