### PR TITLE
Cache TRT device memory size

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op_test.cc
@@ -277,7 +277,7 @@ TEST_F(TRTEngineOpTestBase, AllowBuildAtRuntime) {
   EXPECT_EQ(1, cache->size());
   ASSERT_EQ(1, cache->count({input_shape}));
   EngineContext* ectx = cache->at({input_shape}).get();
-  EXPECT_EQ(ectx->cuda_engine, nullptr);
+  EXPECT_EQ(ectx->GetCudaEngine(), nullptr);
 }
 
 TEST_P(TRTEngineOpTestWithParam, ExplicitBatch) {
@@ -304,7 +304,7 @@ TEST_P(TRTEngineOpTestWithParam, ExplicitBatch) {
   EXPECT_EQ(1, cache->size());
   ASSERT_EQ(1, cache->count({input_shape}));
   EngineContext* ectx = cache->at({input_shape}).get();
-  EXPECT_NE(ectx->cuda_engine, nullptr);
+  EXPECT_NE(ectx->GetCudaEngine(), nullptr);
 }
 
 TEST_P(TRTEngineOpTestWithParam, DynamicShapes) {
@@ -334,7 +334,7 @@ TEST_P(TRTEngineOpTestWithParam, DynamicShapes) {
   EXPECT_EQ(1, cache->size());
   ASSERT_EQ(1, cache->count({input_shape}));
   EngineContext* ectx = cache->at({input_shape}).get();
-  EXPECT_NE(ectx->cuda_engine, nullptr);
+  EXPECT_NE(ectx->GetCudaEngine(), nullptr);
 
   // Execute the op with an incompatible shape.
   ResetInputs();

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
@@ -214,7 +214,7 @@ class SerializeTRTResource : public OpKernel {
       for (const auto& pair : resource->cache_) {
         // Ignore engines that failed to build.
         const std::unique_ptr<EngineContext>& engine = pair.second;
-        if (!engine || !engine->cuda_engine) continue;
+        if (!engine || !engine->GetCudaEngine()) continue;
 
         TRTEngineInstance engine_instance;
         // Add input shapes.
@@ -224,7 +224,7 @@ class SerializeTRTResource : public OpKernel {
         }
         // Add the serialized engine.
         TrtUniquePtrType<nvinfer1::IHostMemory> engine_data(
-            engine->cuda_engine->serialize());
+            engine->GetCudaEngine()->serialize());
         engine_instance.set_serialized_engine(engine_data->data(),
                                               engine_data->size());
 

--- a/tensorflow/compiler/tf2tensorrt/trt_convert_api.cc
+++ b/tensorflow/compiler/tf2tensorrt/trt_convert_api.cc
@@ -302,9 +302,9 @@ Status ReadSerializedEngine(
     return errors::Internal("Engine not found for", node.name());
   }
 
-  if (engine->cuda_engine) {
+  if (engine->GetCudaEngine()) {
     // Serialize the engine.
-    engine_data->reset(engine->cuda_engine->serialize());
+    engine_data->reset(engine->GetCudaEngine()->serialize());
   } else {
     LOG(WARNING) << "Engine cache contains nullptr";
   }
@@ -462,7 +462,8 @@ Status FreezeGraph(SavedModelBundle& bundle, MetaGraphDef* frozen_meta_graph) {
 
 // Returns the name of nodes listed in the signature definition.
 std::vector<std::string> GetNodeNames(
-    const google::protobuf::Map<std::string, tensorflow::TensorInfo>& signature) {
+    const google::protobuf::Map<std::string, tensorflow::TensorInfo>&
+        signature) {
   std::vector<std::string> names;
   for (auto const& item : signature) {
     absl::string_view name = item.second.name();

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.cc
@@ -86,7 +86,7 @@ string TRTEngineCacheResource::DebugString() const {
   for (const auto& item : cache_) {
     mutex_lock lock(item.second->mu);
     oss << TensorShapeUtils::ShapeListString(item.first) << ": " << hex
-        << "ICudaEngine: " << item.second->cuda_engine.get() << ", "
+        << "ICudaEngine: " << item.second->GetCudaEngine() << ", "
         << "IExecutionContext: ";
     absl::c_for_each(
         item.second->execution_contexts,

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.h
@@ -122,16 +122,22 @@ struct EngineContext {
   EngineContext() {}  // Creates an empty context.
   EngineContext(TrtUniquePtrType<nvinfer1::ICudaEngine>&& cuda_engine,
                 ExecutionContext&& execution_context)
-      : cuda_engine(std::move(cuda_engine)) {
+      : cuda_engine_(std::move(cuda_engine)) {
     execution_contexts.push_back(std::move(execution_context));
+    device_memory_size_ =
+        cuda_engine_ ? cuda_engine_->getDeviceMemorySize() : 0;
   }
   EngineContext(TrtUniquePtrType<nvinfer1::ICudaEngine>&& cuda_engine,
                 std::vector<ExecutionContext>&& execution_contexts)
-      : cuda_engine(std::move(cuda_engine)),
-        execution_contexts(std::move(execution_contexts)) {}
+      : cuda_engine_(std::move(cuda_engine)),
+        execution_contexts(std::move(execution_contexts)) {
+    device_memory_size_ =
+        cuda_engine_ ? cuda_engine_->getDeviceMemorySize() : 0;
+  }
 
   mutex mu;
-  TrtUniquePtrType<nvinfer1::ICudaEngine> cuda_engine;
+
+  nvinfer1::ICudaEngine* GetCudaEngine() { return cuda_engine_.get(); }
 
   Status GetExecutionContext(int idx, nvinfer1::IExecutionContext** exec_ctx,
                              bool* has_device_memory)
@@ -151,6 +157,14 @@ struct EngineContext {
     return execution_contexts.size();
   }
 
+  size_t GetDeviceMemorySize() { return device_memory_size_; }
+
+ private:
+  // Note: declaration has to come before execution_contexts, to ensure proper
+  // order of destruction.
+  TrtUniquePtrType<nvinfer1::ICudaEngine> cuda_engine_;
+
+ public:
   // In explicit batch mode, we maintain a vector of contexts for each engine,
   // where each context is created for a specific profile. This is because it is
   // either not possible or non-trivial to change the profile of a context for
@@ -165,6 +179,11 @@ struct EngineContext {
   // Additional discussion about execution context management and thread safety
   // at https://github.com/tensorflow/tensorflow/issues/36959
   std::vector<ExecutionContext> execution_contexts TF_GUARDED_BY(mu);
+
+ private:
+  // Until TRT 8.4 ICudaEngine::getDeviceMemorySize() has a non-negligible
+  // latency. Since its value remains constant, we can cache it.
+  size_t device_memory_size_;
 };
 
 // Contains the context required to build the calibration data.


### PR DESCRIPTION
ICudaEngine::getDeviceMemorySize() has a non-negligible latency. Since its value remains constant, we can store this value when EngineContext object is constructed.