### PR TITLE
Converter for Comparison operators

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -549,6 +549,10 @@ StatusOr<ITensorProxyPtr> ConvertMatMulImpl(OpConverterParams* params,
 std::string convert_range_error_msg(float start, float limit, float delta);
 std::string convert_range_expected_msg(const NodeDef& node_def);
 
+inline bool find_name(const string& name, const std::vector<string> names) {
+  return std::find(names.begin(), names.end(), name) != names.end();
+};
+
 }  // namespace convert
 }  // namespace tensorrt
 }  // namespace tensorflow

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1819,15 +1819,10 @@ class ParameterizedOpConverterTestBase
                        const Status& expected_runtime_status,
                        const Matcher<std::vector<float>>& matcher,
                        const std::vector<DataType>& out_tf_types = {}) {
-    const auto& exp_dims =
-        std::vector<std::vector<int>>({expected_output_dims});
-    RunValidationAndConversion(node_def, expected_conversion_status, name,
-                               exp_dims);
-    if (expected_conversion_status.ok()) {
-      BuildAndRun(name, exp_dims, expected_runtime_status,
-                  std::vector<Matcher<std::vector<float>>>({matcher}),
-                  out_tf_types);
-    }
+    TestOpConverterMultiOut(
+        name, node_def, std::vector<std::vector<int>>({expected_output_dims}),
+        expected_conversion_status, expected_runtime_status,
+        std::vector<Matcher<std::vector<float>>>({matcher}), out_tf_types);
   }
 
  protected:
@@ -1925,41 +1920,56 @@ class OpConverter_BinaryTest : public ParameterizedOpConverterTestBase {
   template <typename S>
   void RunTests(
       const OperationMap<S>& map,
-      std::map<std::string,
-               std::pair<std::function<NodeDef(DataType)>, std::vector<T>>>&
-          op_test_info,
+      std::map<std::string, std::pair<std::function<NodeDef(DataType)>,
+                                      std::vector<T>>>& op_test_info,
       const std::vector<std::vector<T>>& data) {
-    // Test combinations of tensor vs weight inputs (except when both inputs are
-    // weights).
+    const std::vector<DataType> bool_types{DT_BOOL}, default_types{};
+    std::vector<string> logical_ops{"Greater", "Less", "Equal"};
+    std::vector<string> combined_ops{"GreaterEqual", "LessEqual"};
     const DataType tf_type = get_tf_type();
-    for (const bool operand_1_is_tensor : {true, false}) {
-      for (const bool operand_2_is_tensor : {true, false}) {
-        for (auto& iter : map) {
-          const string& op_name = iter.first;
+    AttrValue dtype;
+    dtype.set_type(tf_type);
+    std::map<std::string, NodeDef> nodes;
+    for (const auto op_name : combined_ops) {
+      nodes[op_name] = MakeNodeDef("my_binary", op_name, {"input1", "input2"},
+                                   {{"T", dtype}});
+    }
+
+    for (auto& iter : map) {
+      const string& op_name = iter.first;
+      if (!op_test_info.count(op_name)) {
+        FAIL() << "Binary op test map does not contain op " << op_name;
+      }
+      const auto comb_op = find_name(op_name, combined_ops);
+      const auto& node_def =
+          comb_op ? nodes[op_name] : op_test_info[op_name].first(tf_type);
+
+      for (const bool operand_1_is_tensor : {true, false}) {
+        for (const bool operand_2_is_tensor : {true, false}) {
           SCOPED_TRACE(StrCat(op_name, "_", operand_1_is_tensor ? "T" : "W",
                               operand_2_is_tensor ? "T" : "W"));
-
-          if (!op_test_info.count(op_name)) {
-            FAIL() << "Binary op test map does not contain op " << op_name;
-          }
-
+          Reset();
           if (!operand_1_is_tensor && !operand_2_is_tensor) {
-            runExpectedToFailTest(op_name);
+            // In that case the only test which should be launched is in
+            // runExpectedToFailTest
+            runExpectedToFailTest(op_name, node_def);
             continue;
           }
+
+          const bool logical_op = comb_op || find_name(op_name, logical_ops);
           auto conv_status = Status::OK();
-          if (tf_type == DT_BOOL) {
+          if (tf_type == DT_BOOL || logical_op) {
             if (trt_mode_ == TrtTestMode::kImplicitBatch) {
               conv_status = errors::Unimplemented(
                   "Binary op: '", op_name,
                   "' is not supported in implicit batch mode");
-            } else if (!operand_1_is_tensor || !operand_2_is_tensor) {
+            } else if (!logical_op &&
+                       (!operand_1_is_tensor || !operand_2_is_tensor)) {
               conv_status = errors::InvalidArgument(
                   "Both inputs  of '", op_name, "' are expected to be tensors");
             }
           }
 
-          Reset();
           if (operand_1_is_tensor) {
             AddTestTensor("input1", {2, 1, 2}, data[0]);
           } else {
@@ -1971,29 +1981,23 @@ class OpConverter_BinaryTest : public ParameterizedOpConverterTestBase {
             AddTestWeights("input2", {2, 1}, data[3], tf_type);
           }
 
-          const NodeDef& node_def = op_test_info[op_name].first(tf_type);
           TestOpConverter("my_binary", node_def, {2, 2, 2}, conv_status,
                           Status::OK(),
-                          ElementsAreArray(op_test_info[op_name].second));
+                          ElementsAreArray(op_test_info[op_name].second),
+                          logical_op ? bool_types : default_types);
         }
       }
     }
   }
 
-  void runExpectedToFailTest(const std::string& op_name) {
-    Reset();
-    AttrValue dtype;
-    dtype.set_type(tf_type_);
-
-    const auto& node_def = MakeNodeDef(
-        "my_oper", op_name, {"weights1", "weights2"}, {{"T", dtype}});
-    AddTestWeights("weights1", {1}, {1}, tf_type_);
-    AddTestWeights("weights2", {1}, {1}, tf_type_);
+  void runExpectedToFailTest(const std::string& op_name, const NodeDef& node) {
+    AddTestWeights("input1", {1}, {1}, tf_type_);
+    AddTestWeights("input2", {1}, {1}, tf_type_);
     const string error =
         "Constant folding is falled back to TensorFlow, "
         "binary op '" +
         op_name + "' received both input as constant";
-    RunValidationAndConversion(node_def, error::UNIMPLEMENTED, error);
+    RunValidationAndConversion(node, error::UNIMPLEMENTED, error);
   }
 };
 
@@ -3240,6 +3244,13 @@ TEST_P(OpConverter_FP32_FP16_BinaryTest, ConvertBinary) {
   ADD_OP("Minimum", ops::Minimum, {2, 2, 3, 3, 2, 2, 3, 3});
   ADD_OP("Maximum", ops::Maximum, {3, 6, 3, 6, 3, 6, 3, 6});
   ADD_OP("Pow", ops::Pow, {9, 36, 27, 216, 9, 36, 27, 216});
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
+  ADD_OP("Greater", ops::Greater, {1, 1, 0, 1, 1, 1, 0, 1});
+  ADD_OP("Less", ops::Less, {0, 0, 0, 0, 0, 0, 0, 0});
+  ADD_OP("Equal", ops::Equal, {0, 0, 1, 0, 0, 0, 1, 0});
+  ADD_OP("GreaterEqual", ops::Less, {1, 1, 1, 1, 1, 1, 1, 1});
+  ADD_OP("LessEqual", ops::Greater, {0, 0, 1, 0, 0, 0, 1, 0});
+#endif
 #undef ADD_OP
   std::vector<std::vector<float>> data = {
       {3, 6, 3, 6}, {3, 6}, {2, 3, 2, 3}, {2, 3}};

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/binary_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/binary_ops.cc
@@ -34,6 +34,14 @@ const BinaryOperationMapType* BinaryOperationMap() {
       {"Minimum", nvinfer1::ElementWiseOperation::kMIN},
       {"Maximum", nvinfer1::ElementWiseOperation::kMAX},
       {"Pow", nvinfer1::ElementWiseOperation::kPOW},
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
+      {"Greater", nvinfer1::ElementWiseOperation::kGREATER},
+      {"Less", nvinfer1::ElementWiseOperation::kLESS},
+      {"Equal", nvinfer1::ElementWiseOperation::kEQUAL},
+      // Operators are implemented as NOT Less and NOT Greater, respectively.
+      {"GreaterEqual", nvinfer1::ElementWiseOperation::kLESS},
+      {"LessEqual", nvinfer1::ElementWiseOperation::kGREATER},
+#endif
   });
   return map;
 }
@@ -52,9 +60,10 @@ class ConvertBinaryImpl {
   ConvertBinaryImpl(const BinaryOperationMapType* pOperMap)
       : pOperMap_(pOperMap) {}
 
-  Status ValidateImpl(const OpConverterParams& params,
-                      bool both_tensors = false,
-                      const std::vector<string>& not_supported_ops = {}) {
+  Status ValidateImpl(
+      const OpConverterParams& params,
+      const std::vector<string>& implicit_batch_not_supported_ops = {},
+      bool both_tensors = false) {
     const auto& node_def = params.node_def;
     const auto op = node_def.op();
     const auto op_pair = pOperMap_->find(op);
@@ -70,9 +79,8 @@ class ConvertBinaryImpl {
           "' received both input as constant");
     }
 
-    if (!not_supported_ops.empty() && params.use_implicit_batch) {
-      const auto& end = not_supported_ops.end();
-      if (std::find(not_supported_ops.begin(), end, op) != end) {
+    if (convertToBool_ = find_name(op, implicit_batch_not_supported_ops)) {
+      if (params.use_implicit_batch) {
         return errors::Unimplemented(
             "Binary op: '", op, "' is not supported in implicit batch mode");
       }
@@ -83,6 +91,8 @@ class ConvertBinaryImpl {
         return errors::InvalidArgument("Both inputs  of '", op,
                                        "' are expected to be tensors");
       }
+      // No need to convert the output of "LogicalOr" and "LogicalAnd"
+      convertToBool_ = false;
     }
 
     nvinfer1::Dims broadcasted_dims[2];
@@ -100,10 +110,12 @@ class ConvertBinaryImpl {
     return Status::OK();
   }
 
-  Status ConvertImpl(const OpConverterParams& params) {
+  Status ConvertImpl(const OpConverterParams& params,
+                     const std::vector<string>& revert_bool_ops = {}) {
     const auto& node_def = params.node_def;
     // Add ElementWise layer.
-    nvinfer1::ILayer* layer = params.converter->network()->addElementWise(
+    auto* network = params.converter->network();
+    nvinfer1::ILayer* layer = network->addElementWise(
         *tensor_[0]->trt_tensor(), *tensor_[1]->trt_tensor(), operation_);
     TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
 
@@ -112,7 +124,20 @@ class ConvertBinaryImpl {
     }
 
     params.converter->SetLayerName(layer, node_def);
-    params.outputs->push_back(TRT_TensorOrWeights(layer->getOutput(0)));
+    const auto& output = layer->getOutput(0);
+    if (convertToBool_) {
+      output->setType(nvinfer1::DataType::kBOOL);
+      if (find_name(node_def.op(), revert_bool_ops)) {
+        nvinfer1::IUnaryLayer* unary_layer =
+            network->addUnary(*output, nvinfer1::UnaryOperation::kNOT);
+        TFTRT_RETURN_ERROR_IF_NULLPTR(unary_layer, node_def.name());
+        params.outputs->push_back(
+            TRT_TensorOrWeights(unary_layer->getOutput(0)));
+        return Status::OK();
+      }
+    }
+
+    params.outputs->push_back(TRT_TensorOrWeights(output));
     return Status::OK();
   }
 
@@ -126,6 +151,7 @@ class ConvertBinaryImpl {
   const BinaryOperationMapType* pOperMap_;
   std::array<ITensorProxyPtr, 2> tensor_{nullptr, nullptr};
   nvinfer1::ElementWiseOperation operation_;
+  bool convertToBool_;
 };
 
 class ConvertBinary : public OpConverterBase<ConvertBinary>,
@@ -143,8 +169,22 @@ class ConvertBinary : public OpConverterBase<ConvertBinary>,
     return ConvertBinaryImpl::InputSpec();
   }
 
-  Status Validate() { return ValidateImpl(*params_); }
-  Status Convert() { return ConvertImpl(*params_); }
+  Status Validate() {
+    const std::vector<string> implicit_batch_not_supported_ops {
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
+      "Greater", "Less", "Equal", "GreaterEqual", "LessEqual"
+#endif
+    };
+    return ValidateImpl(*params_, implicit_batch_not_supported_ops);
+  }
+  Status Convert() {
+    const std::vector<string> implemented_with_reverted_ops {
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
+      "GreaterEqual", "LessEqual"
+#endif
+    };
+    return ConvertImpl(*params_, implemented_with_reverted_ops);
+  }
 };
 
 class ConvertBooleanBinary : public OpConverterBase<ConvertBooleanBinary>,
@@ -165,7 +205,7 @@ class ConvertBooleanBinary : public OpConverterBase<ConvertBooleanBinary>,
   static constexpr const char* NodeDefDataTypeAttributeName() { return ""; }
   Status Validate() {
 #if IS_TRT_VERSION_GE(8, 2, 0, 0)
-    return ValidateImpl(*params_, true, {"LogicalOr", "LogicalAnd"});
+    return ValidateImpl(*params_, {"LogicalOr", "LogicalAnd"}, true);
 #else
     return errors::Unimplemented("Boolean op: ", params_->node_def.op(),
                                  " is not supported in TRT version < 8.2");


### PR DESCRIPTION
The existing converter for binary operators was slightly modified to handle the elementwise operators `Greater`, `Less`, `Equal`, `GreaterEqual` and `LessEqual` which have output tensors of type BOOL.
The implementation of converters for `GreaterEqual` and `LessEqual` operators is done via the inversion of the results for  `Less` and `Greater` operators, respectively.