### PR TITLE
[TF-TRT] Lazy-load trt_convert

### DIFF
--- a/tensorflow/python/compiler/tensorrt/__init__.py
+++ b/tensorflow/python/compiler/tensorrt/__init__.py
@@ -14,6 +14,8 @@
 # =============================================================================
 """Exposes the python wrapper for TensorRT graph transforms."""
 
-# pylint: disable=unused-import,line-too-long
-from tensorflow.python.compiler.tensorrt import trt_convert as trt
-# pylint: enable=unused-import,line-too-long
+from tensorflow.python.util.lazy_loader import LazyLoader
+
+trt = LazyLoader(
+    "trt", globals(),
+    "tensorflow.python.compiler.tensorrt.trt_convert")

--- a/tensorflow/python/ops/standard_ops.py
+++ b/tensorflow/python/ops/standard_ops.py
@@ -105,7 +105,11 @@ from tensorflow.python.ops.variable_scope import *  # pylint: disable=redefined-
 from tensorflow.python.ops.variables import *
 from tensorflow.python.ops.parallel_for.control_flow_ops import vectorized_map
 
-from tensorflow.python.compiler.tensorrt import trt_convert as trt
+from tensorflow.python.util.lazy_loader import LazyLoader
+
+trt = LazyLoader(
+    "trt", globals(),
+    "tensorflow.python.compiler.tensorrt.trt_convert")
 
 # pylint: enable=wildcard-import
 # pylint: enable=g-bad-import-order


### PR DESCRIPTION
The goal of this PR is to avoid running any TF-TRT code when the user doesn't need TF-TRT. In particular, this has the effect that TF-TRT doesn't try to load `libnvinfer.so` when TF is imported.