### PR TITLE
Trigger ARM CI on push commits for easy debug

### DIFF
--- a/.github/workflows/arm-cd.yml
+++ b/.github/workflows/arm-cd.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Build and test pip wheel
         shell: bash
         run: |
-          tf_project_name=$((${{ github.event_name == 'schedule' }} ? 'tf_nightly_cpu_aws' : 'tensorflow_cpu_aws' )) && \
+          tf_project_name='tensorflow_cpu_aws' && ${{ github.event_name == 'schedule' }} && tf_project_name='tf_nightly_cpu_aws'
+          echo "PyPI project name:" $tf_project_name
           CI_DOCKER_BUILD_EXTRA_PARAMS='--build-arg py_major_minor_version=${{ matrix.pyver }} --build-arg pypi_project_name=${tf_project_name}' \
           ./tensorflow/tools/ci_build/ci_build.sh cpu.arm64 bash tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
       - name: Upload pip wheel to PyPI

--- a/.github/workflows/arm-ci.yml
+++ b/.github/workflows/arm-ci.yml
@@ -16,6 +16,10 @@
 name: ARM CI
 
 on:
+  push:
+    branches:
+      - master
+      - r2.**
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
@@ -27,7 +31,7 @@ jobs:
     runs-on: [self-hosted, linux, ARM64]
     strategy:
       matrix:
-        pyver: ['3.7', '3.8', '3.9', '3.10']
+        pyver: ['3.10']
     steps:
       - name: Stop old running containers (if any)
         shell: bash

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -71,6 +71,8 @@ export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} \
     -//tensorflow/python/client:session_list_devices_test \
     -//tensorflow/python/data/experimental/kernel_tests/service:cross_trainer_cache_test \
     -//tensorflow/python/data/kernel_tests:iterator_test_cpu \
+    -//tensorflow/python/data/kernel_tests:snapshot_test \
+    -//tensorflow/python/distribute:random_generator_test_cpu \
     -//tensorflow/python/eager:forwardprop_test \
     -//tensorflow/python/framework:node_file_writer_test \
     -//tensorflow/python/grappler:memory_optimizer_test \


### PR DESCRIPTION
Fix logic for PyPI project name's conditional assignment
Trigger ARM CI on push commits on master and release branches for easy debug
Limit to one python version (3.10) in CI to increase availability of runners
Add 2 flaky tests to skip list