### PR TITLE
Pin pylint in CI

### DIFF
--- a/.github/workflows/pylint-presubmit.yml
+++ b/.github/workflows/pylint-presubmit.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint numpy wheel
+        pip install pylint==2.13.9 numpy wheel
         pip install keras_preprocessing --no-deps
     - name: Run PyLint on changed files
       run: |


### PR DESCRIPTION
CI is broken with the last pylint release:

https://github.com/tensorflow/tensorflow/runs/6718349021?check_suite_focus=true