### PR TITLE
Fix filename on CMakeLists.txt

### DIFF
--- a/tensorflow/lite/c/CMakeLists.txt
+++ b/tensorflow/lite/c/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 add_library(tensorflowlite_c ${TFLITE_C_LIBTYPE}
   builtin_op_data.h
   common.h
-  common.c
+  common.cc
   c_api_types.h
   c_api.h
   c_api.cc


### PR DESCRIPTION
Fixed filename common.c to common.cc.

I got the following error on Windows 10 with Visual Studio 16 2019.

```
CMake Error at CMakeLists.txt:63 (add_library):
  Cannot find source file:

    common.c

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .h
  .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc
```

I executed the next command got from https://www.tensorflow.org/lite/guide/build_cmake?hl=en.

```
cmake -G "Visual Studio 16 2019" ..\tensorflow\tensorflow\lite\c\
```