### PR TITLE
Change allow_failure description to match its functionality

### DIFF
--- a/third_party/remote_config/common.bzl
+++ b/third_party/remote_config/common.bzl
@@ -220,8 +220,8 @@ def execute(
       cmdline: list of strings, the command to execute
       error_msg: string, a summary of the error if the command fails
       error_details: string, details about the error or steps to fix it
-      allow_failure: bool, if True, an empty stdout result and output to stderr
-        is fine, otherwise it's an error
+      allow_failure: bool, if True, an empty stdout result or output to stderr
+        is fine, otherwise either of these is an error
     Returns:
       The result of repository_ctx.execute(cmdline)
     """


### PR DESCRIPTION
The `allow_failure` parameter of [`remote_config/common.bzl:execute()`](https://github.com/tensorflow/tensorflow/blob/master/third_party/remote_config/common.bzl#L223-L224) appears to be incorrectly documented. The documentation says that _"if True, an empty stdout result **and** output to stderr is fine, otherwise it's an error_" (emphasis mine), but when this flag is not enabled, **either** of those conditions is an error, because the actual test is an [`or`](https://github.com/tensorflow/tensorflow/blob/master/third_party/remote_config/common.bzl#L229).

This PR changes the parameter's description to match the behavior of the function.