### PR TITLE
Allow non-empty stderr when locating numpy include path (closes #56373)

### DIFF
--- a/third_party/py/non_hermetic/python_configure.bzl
+++ b/third_party/py/non_hermetic/python_configure.bzl
@@ -198,6 +198,7 @@ def _get_numpy_include(repository_ctx, python_bin):
         ],
         error_msg = "Problem getting numpy include path.",
         error_details = "Is numpy installed?",
+        allow_failure = True,
     ).stdout.splitlines()[0]
 
 def _create_local_python_repository(repository_ctx):


### PR DESCRIPTION
This PR passes `allow_failure=True` in `_get_numpy_include()` to avoid incorrectly treating any output from numpy (or its dependencies, namely OpenBLAS) on stderr as fatal errors. There are at least some cases where benign warnings will cause the existing behavior to fail even though `numpy.get_include()` succeeds.

This change does mean that if `python3 -c "import numpy; print(numpy.get_include())"` were to return an empty stdout, an exception would occur when indexing the resulting empty list after calling `splitlines()`. I don't think there is any way the [`numpy` implementation](https://github.com/numpy/numpy/blob/main/numpy/lib/utils.py#L19-L45) (which appears to be the same for the last 15 years) can output an empty string, but it's worth mentioning for the reviewer's consideration.