### PR TITLE
resolve gcc_host_compiler_path in a symlink directory

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -619,7 +619,7 @@ def prompt_loop_or_load_from_env(environ_cp,
                          'Assuming to be a scripting mistake.' %
                          (var_name, n_ask_attempts))
 
-  if resolve_symlinks and os.path.islink(val):
+  if resolve_symlinks:
     val = os.path.realpath(val)
   environ_cp[var_name] = val
   return val


### PR DESCRIPTION
Resolves a missing dependency declarations error, when gcc_host_compiler_path is in a symlink directory resolving to other directories.

In my university's cluster, I got the following error when compiling TensorFlow 2.9.1:
```
ERROR: /scratch/jz748/packages/bazelcache/_bazel_jz748/437f513259d7a63d9ada0ccba4c220f0/external/zlib/BUILD.bazel:5:11: Compiling compress.c failed: undeclared inclusion(s) in rule '@zlib//:zlib':
this rule is missing dependency declarations for the following files included by 'compress.c':
  '/opt/sw/packages/gcc/11.2/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/stddef.h'
  '/opt/sw/packages/gcc/11.2/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include-fixed/limits.h'
  '/opt/sw/packages/gcc/11.2/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include-fixed/syslimits.h'
  '/opt/sw/packages/gcc/11.2/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/stdarg.h'
```
Here I set `GCC_HOST_COMPILER_PATH` to  `/opt/sw/packages/gcc/11.2/bin/gcc`. After I read [third_party/gpus/cuda_configure.bzl#L277](https://github.com/tensorflow/tensorflow/blob/72177a67c200c704c50982164bb0a52ccb10288d/third_party/gpus/cuda_configure.bzl#L277), I execute `gcc -E -x c - -v --sysroot .` to check includes directory and I got
```
#include "..." search starts here:
#include <...> search starts here:
 /cache/sw/packages/gcc/11.2/bin/../lib/gcc/x86_64-pc-linux-gnu/11.2.0/include
 /cache/sw/packages/gcc/11.2/bin/../lib/gcc/x86_64-pc-linux-gnu/11.2.0/include-fixed
 /cache/sw/packages/gcc/11.2/bin/../lib/gcc/../../include
End of search list.
```
I realized that `/opt/sw` is a symlink to `/cache/sw/` in this cluster and GCC only returns the real path.

In 58b236b235ce57808c917feb19b9f895f628710c, if `gcc` is a symlink, the real path will be resolved. But it does not work if GCC is not a symlink but the parent directory of GCC is the symlink. This commit resolves the issue.