### PR TITLE
Optimizing and improving accuracy of fp16 conv2d for new powervr gpu …

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/cl_device.cc
+++ b/tensorflow/lite/delegates/gpu/cl/cl_device.cc
@@ -63,6 +63,39 @@ void ParseQualcommOpenClCompilerVersion(
   result->patch = (main_part[6] - '0') * 10 + (main_part[7] - '0');
 }
 
+static void ParsePowerVRDriverVersion(const std::string& cl_driver_version,
+                                      PowerVRInfo::DriverVersion& result) {
+  size_t position = cl_driver_version.find('@');
+  if (position == std::string::npos) {
+    return;
+  }
+
+  // string format: "*.**@*******" where * is digit
+  int main = 0;
+  size_t curpos = 0;
+  while (curpos < position && absl::ascii_isdigit(cl_driver_version[curpos])) {
+    main = main * 10 + cl_driver_version[curpos] - '0';
+    ++curpos;
+  }
+
+  ++curpos;
+  int minor = 0;
+  while (curpos < position) {
+    minor = minor * 10 + cl_driver_version[curpos] - '0';
+    ++curpos;
+  }
+
+  curpos = position + 1;
+  int id = 0;
+  while (curpos < cl_driver_version.length()) {
+    id = id * 10 + cl_driver_version[curpos] - '0';
+    ++curpos;
+  }
+  result.branch_main = main;
+  result.branch_minor = minor;
+  result.id = id;
+}
+
 template <>
 std::string GetDeviceInfo<std::string>(cl_device_id id, cl_device_info info) {
   size_t size;
@@ -307,6 +340,9 @@ GpuInfo GpuInfoFromDeviceID(cl_device_id id, cl_platform_id platform_id) {
   if (info.IsAdreno()) {
     ParseQualcommOpenClCompilerVersion(info.opencl_info.driver_version,
                                        &info.adreno_info.cl_compiler_version);
+  } else if (info.IsPowerVR()) {
+    ParsePowerVRDriverVersion(info.opencl_info.driver_version,
+                              info.powervr_info.driver_version);
   }
   return info;
 }

--- a/tensorflow/lite/delegates/gpu/common/gpu_info.h
+++ b/tensorflow/lite/delegates/gpu/common/gpu_info.h
@@ -257,6 +257,36 @@ struct MaliInfo {
   int GetApproximateComputeUnitsCount() const;
 };
 
+enum class PowerVRGpu {
+  kUnknown,
+  kRogue,
+  // New generation of IMG gpus after 2019:
+  kAXE,
+  kAXM,
+  kAXT,
+  kBXE,
+  kBXM,
+  kBXS,
+  kBXT,
+};
+
+struct PowerVRInfo {
+  struct DriverVersion {
+    int branch_main = 0;
+    int branch_minor = 0;
+    int id = 0;
+  };
+  PowerVRInfo() = default;
+  explicit PowerVRInfo(const std::string& gpu_description);
+  PowerVRGpu gpu_version;
+  DriverVersion driver_version;
+
+  bool IsRogue() const;
+  bool IsImgAxx() const;
+  bool IsImgBxx() const;
+  bool hasDotF16() const;
+};
+
 struct OpenGlInfo {
   std::string renderer_name;
   std::string vendor_name;
@@ -482,6 +512,7 @@ struct GpuInfo {
   AMDInfo amd_info;
   AppleInfo apple_info;
   MaliInfo mali_info;
+  PowerVRInfo powervr_info;
 
   // OpenGL specific, gpu_api should be kOpenGl
   OpenGlInfo opengl_info;
@@ -507,6 +538,7 @@ struct GpuInfo {
 // AdrenoInfo if vendor is kQualcomm
 // AppleInfo if vendor is kApple
 // MaliInfo if vendor is kMali
+// PowerVRInfo if vendor is kPowerVR
 void GetGpuInfoFromDeviceDescription(const std::string& gpu_description,
                                      GpuApi gpu_api, GpuInfo* gpu_info);
 

--- a/tensorflow/lite/delegates/gpu/common/task/weights_conversion.h
+++ b/tensorflow/lite/delegates/gpu/common/task/weights_conversion.h
@@ -70,6 +70,10 @@ void RearrangeWeightsToOHWIOGroupI4O4(
   }
 }
 
+void RearrangeWeightsToImgConvF16OHWIOGroupI4O4(
+    const tflite::gpu::Tensor<OHWI, DataType::FLOAT32>& weights,
+    int out_group_size, absl::Span<half4> dst);
+
 template <DataType S, typename T>
 void RearrangeWeightsToODHWIOGroupI4O4(
     const tflite::gpu::Tensor<OHWDI, S>& weights, int out_group_size,

--- a/tensorflow/lite/delegates/gpu/common/task/weights_layout.h
+++ b/tensorflow/lite/delegates/gpu/common/task/weights_layout.h
@@ -33,6 +33,7 @@ enum class WeightsLayout {
   kOICustomSpatialO4I4,
   k2DX4I4YIsSpatialIAndXIsOOGroupO4,
   k2DX4O4YIsSpatialIAndXIsOOGroupI4,
+  kPowerVRConvF16OSpatialIOGroupI4O4,
 };
 
 struct WeightsDescription {

--- a/tensorflow/lite/delegates/gpu/common/tasks/conv_generic.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/conv_generic.cc
@@ -173,7 +173,7 @@ std::string GenerateBlockCoords(const int4& block_size,
 
 void GetPowerVRRecommendedWorkGroupAndBlockSizeForF16(
     const BHWC& dst_shape, int dst_depth, int src_depth,
-    ConvPowerVR::ConvParams& conv_params, int3& work_group_size) {
+    ConvGeneric::ConvParams& conv_params, int3& work_group_size) {
   conv_params.weights_layout =
       WeightsLayout::kPowerVRConvF16OSpatialIOGroupI4O4;
 
@@ -222,7 +222,7 @@ void GetPowerVRRecommendedWorkGroupAndBlockSizeForF16(
 }
 
 bool UsePowerVRDotF16(const GpuInfo& gpu_info,
-                      const ConvPowerVR::ConvParams& conv_params) {
+                      const ConvGeneric::ConvParams& conv_params) {
   return gpu_info.IsPowerVR() && gpu_info.powervr_info.hasDotF16() &&
          gpu_info.IsApiOpenCl() &&
          conv_params.weights_data_type == DataType::FLOAT16 &&

--- a/tensorflow/lite/delegates/gpu/common/tasks/conv_generic.h
+++ b/tensorflow/lite/delegates/gpu/common/tasks/conv_generic.h
@@ -42,28 +42,6 @@ namespace gpu {
 
 class ConvGeneric : public GPUOperation {
  public:
-  ConvPowerVR() = default;
-  void GetPossibleKernelWorkGroups(
-      TuningType tuning_type, const GpuInfo& gpu_info,
-      const KernelInfo& kernel_info,
-      std::vector<int3>* work_groups) const override;
-  absl::Status BindArguments(ArgumentsBinder* args) override;
-  int3 GetGridSize() const override;
-
-  WeightsDescription GetWeightsDescription() const {
-    WeightsDescription desc;
-    desc.type = conv_params_.weights_data_type;
-    desc.layout = conv_params_.weights_layout;
-    desc.output_group_size = conv_params_.block_size.w;
-    return desc;
-  }
-
-  // Move only
-  ConvPowerVR(ConvPowerVR&& operation);
-  ConvPowerVR& operator=(ConvPowerVR&& operation);
-  ConvPowerVR(const ConvPowerVR&) = delete;
-  ConvPowerVR& operator=(const ConvPowerVR&) = delete;
-
   enum class WeightsUploadType {
     LOCAL_MEM_ASYNC_SUBGROUP,  // we use it for PowerVR with workgroup size = 32
     LOCAL_MEM_BY_THREADS,
@@ -114,7 +92,6 @@ class ConvGeneric : public GPUOperation {
   absl::Status BindArguments(ArgumentsBinder* args) override;
   int3 GetGridSize() const override;
 
-<<<<<<< HEAD:tensorflow/lite/delegates/gpu/common/tasks/conv_generic.h
   WeightsDescription GetWeightsDescription() const {
     WeightsDescription desc;
     desc.type = conv_params_.weights_data_type;
@@ -131,11 +108,6 @@ class ConvGeneric : public GPUOperation {
 
  private:
   ConvGeneric(const OperationDef& definition,
-=======
-
- private:
-  ConvPowerVR(const OperationDef& definition,
->>>>>>> Optimizing and improving accuracy of fp16 conv2d for new powervr gpu generation.:tensorflow/lite/delegates/gpu/common/tasks/conv_powervr.h
               const Convolution2DAttributes& attr, const GpuInfo& gpu_info,
               const BHWC* dst_shape = nullptr);
   ConvGeneric(const OperationDef& definition,

--- a/tensorflow/lite/delegates/gpu/common/tasks/conv_generic.h
+++ b/tensorflow/lite/delegates/gpu/common/tasks/conv_generic.h
@@ -42,6 +42,28 @@ namespace gpu {
 
 class ConvGeneric : public GPUOperation {
  public:
+  ConvPowerVR() = default;
+  void GetPossibleKernelWorkGroups(
+      TuningType tuning_type, const GpuInfo& gpu_info,
+      const KernelInfo& kernel_info,
+      std::vector<int3>* work_groups) const override;
+  absl::Status BindArguments(ArgumentsBinder* args) override;
+  int3 GetGridSize() const override;
+
+  WeightsDescription GetWeightsDescription() const {
+    WeightsDescription desc;
+    desc.type = conv_params_.weights_data_type;
+    desc.layout = conv_params_.weights_layout;
+    desc.output_group_size = conv_params_.block_size.w;
+    return desc;
+  }
+
+  // Move only
+  ConvPowerVR(ConvPowerVR&& operation);
+  ConvPowerVR& operator=(ConvPowerVR&& operation);
+  ConvPowerVR(const ConvPowerVR&) = delete;
+  ConvPowerVR& operator=(const ConvPowerVR&) = delete;
+
   enum class WeightsUploadType {
     LOCAL_MEM_ASYNC_SUBGROUP,  // we use it for PowerVR with workgroup size = 32
     LOCAL_MEM_BY_THREADS,
@@ -92,6 +114,7 @@ class ConvGeneric : public GPUOperation {
   absl::Status BindArguments(ArgumentsBinder* args) override;
   int3 GetGridSize() const override;
 
+<<<<<<< HEAD:tensorflow/lite/delegates/gpu/common/tasks/conv_generic.h
   WeightsDescription GetWeightsDescription() const {
     WeightsDescription desc;
     desc.type = conv_params_.weights_data_type;
@@ -108,6 +131,11 @@ class ConvGeneric : public GPUOperation {
 
  private:
   ConvGeneric(const OperationDef& definition,
+=======
+
+ private:
+  ConvPowerVR(const OperationDef& definition,
+>>>>>>> Optimizing and improving accuracy of fp16 conv2d for new powervr gpu generation.:tensorflow/lite/delegates/gpu/common/tasks/conv_powervr.h
               const Convolution2DAttributes& attr, const GpuInfo& gpu_info,
               const BHWC* dst_shape = nullptr);
   ConvGeneric(const OperationDef& definition,


### PR DESCRIPTION
…generation.

The patch:
- Adds powervr gpu_info
- On the new powervr gpu generation, uses the fp16 matmul builtin for conv2d
- Uses better workgroup size and block size

We see 1.3 ~ 1.55 times speedup of inference time on IMG BXM-8-256 using our internal NN models.

benchmark_model option: --use_gpu=true --gpu_backend=cl --gpu_precision_loss_allowed=true