### PR TITLE
MklEltwiseFwdPrimitive implemented twice (same class name used)

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h
+++ b/tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h
@@ -44,6 +44,11 @@ using EltwiseFwdActivationPd = dnnl::eltwise_forward::primitive_desc;
 
 namespace tensorflow {
 
+// TODO(tf-onednn): Consolidate this class with `MklEltWiseFwdParams`
+// in `mkl_relu_op.cc`.
+//
+// The implementation of this class is very similar to it and it
+// should be consolidated to one class
 template <typename T>
 class MklEltwiseFwdActivationParams {
  public:


### PR DESCRIPTION
In files tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h and tensorflow/core/kernels/mkl/mkl_relu_op.cc there are two classes with the same name: MklEltwiseFwdPrimitive. We have noticed that this can lead to segmentation fault at runtime when method is called on different instantiation of the class then what is expected (i.e calling Execute() on implementation in mkl_eltwise_activation_base_op.h instead of one in mkl_relu_op.cc). Since implementation are slightly different this patch renames MklEltwiseFwdPrimitive in mkl_eltwise_activation_base_op.h to MklEltwiseFwdActivationPrimitive to avoid the issue.