### PR TITLE
Fixed tensorflow-lite label_image build error.

### DIFF
--- a/tensorflow/lite/examples/label_image/CMakeLists.txt
+++ b/tensorflow/lite/examples/label_image/CMakeLists.txt
@@ -25,6 +25,7 @@ list(APPEND TFLITE_LABEL_IMAGE_SRCS
   ${TFLITE_SOURCE_DIR}/profiling/memory_info.cc
   ${TFLITE_SOURCE_DIR}/profiling/profile_summarizer.cc
   ${TFLITE_SOURCE_DIR}/profiling/profile_summary_formatter.cc
+  ${TFLITE_SOURCE_DIR}/profiling/root_profiler.cc
   ${TFLITE_SOURCE_DIR}/profiling/time.cc
   ${TFLITE_SOURCE_DIR}/tools/command_line_flags.cc
   ${TFLITE_SOURCE_DIR}/tools/delegates/default_execution_provider.cc


### PR DESCRIPTION
Fixed #56384 .
Need to add `root_profiler.cc` to CMakeLists.txt
(Same modification as the commit of bbceca5761385ac0654db3f4448957e923a337f4c)