### PR TITLE
[55789] make_tensor_proto() now respects byte order of numpy input arrays

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -523,14 +523,14 @@ def make_tensor_proto(values, dtype=None, shape=None, verify_shape=False,
           "Cannot create a tensor proto whose content is larger than 2GB.")
     
     #ensure sys and dtype endianness match
-    """sys_is_le = sys.byteorder == 'little'
+    sys_is_le = sys.byteorder == 'little'
     numpy_is_le = numpy_dtype.byteorder == '<'
     if sys_is_le and not numpy_is_le:
       tensor_proto.tensor_content = nparray.astype('<i2').tobytes()
     elif not sys_is_le and numpy_is_le:
       tensor_proto.tensor_content = nparray.astype('>f4').tobytes()
-    else:"""
-    tensor_proto.tensor_content = nparray.tobytes()
+    else:
+      tensor_proto.tensor_content = nparray.tobytes()
 
     return tensor_proto
 

--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -15,6 +15,7 @@
 """Utilities to create TensorProtos."""
 import numpy as np
 import six
+import sys
 
 from tensorflow.core.framework import tensor_pb2
 from tensorflow.core.framework import tensor_shape_pb2
@@ -520,7 +521,17 @@ def make_tensor_proto(values, dtype=None, shape=None, verify_shape=False,
     if nparray.size * nparray.itemsize >= (1 << 31):
       raise ValueError(
           "Cannot create a tensor proto whose content is larger than 2GB.")
+    
+    #ensure sys and dtype endianness match
+    """sys_is_le = sys.byteorder == 'little'
+    numpy_is_le = numpy_dtype.byteorder == '<'
+    if sys_is_le and not numpy_is_le:
+      tensor_proto.tensor_content = nparray.astype('<i2').tobytes()
+    elif not sys_is_le and numpy_is_le:
+      tensor_proto.tensor_content = nparray.astype('>f4').tobytes()
+    else:"""
     tensor_proto.tensor_content = nparray.tobytes()
+
     return tensor_proto
 
   # If we were not given values as a numpy array, compute the proto_values

--- a/tensorflow/python/framework/tensor_util_test.py
+++ b/tensorflow/python/framework/tensor_util_test.py
@@ -752,6 +752,19 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
     self.assertEqual(np.float32, a.dtype)
     self.assertAllClose(np.array([10.0, 20.0, 30.0], dtype=np.float32), a)
 
+  def testNumpyArrayWithNonNativeByteOrder(self):
+    x = np.ones(shape=(1, 2), dtype=np.float32)
+    xbswap = x.astype('>f4') # if native byte order is little endian, set swap to big endian
+
+    if sys.byteorder == "big":
+      xbswap = x.astype('<f4') # if nbo is big, set swap to little for conflict
+
+    y = tensor_util.make_ndarray(tensor_util.make_tensor_proto(x))
+    ybswap = tensor_util.make_ndarray(tensor_util.make_tensor_proto(xbswap))
+
+    self.assertTrue(np.array_equal(x, y))
+    self.assertTrue(np.array_equal(x, ybswap))
+
   def testUnsupportedDTypes(self):
     with self.assertRaises(TypeError):
       tensor_util.make_tensor_proto(np.array([1]), 0)


### PR DESCRIPTION
Fixes Issue: https://github.com/tensorflow/tensorflow/issues/55789

Previously make_tensor_proto() did not respect byte order of numpy input arrays as demonstrated in this repro: 
https://colab.research.google.com/gist/tilakrayal/cef07cf718456b6b07526ea38d73fb52/55789.ipynb

Now with these updates, the function takes into consideration the byte order of the system and input array and coerces the input array to match prior to utilizing it within the function.