### PR TITLE
Updating the expected behavior in TF doc

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1874,6 +1874,10 @@ def resize_image_with_pad_v1(image,
 
   Raises:
     ValueError: if `target_height` or `target_width` are zero or negative.
+  Raises:
+    InvalidArgumentError: if `target_height` or `target_width` are certain positive values.
+    
+    
 
   Returns:
     Resized and padded image.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1874,7 +1874,7 @@ def resize_image_with_pad_v1(image,
 
   Raises:
     ValueError: if `target_height` or `target_width` are zero or negative.
-  Raises:
+    
     InvalidArgumentError: if `target_height` or `target_width` are certain positive values.
     
     

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1875,7 +1875,7 @@ def resize_image_with_pad_v1(image,
   Raises:
     ValueError: if `target_height` or `target_width` are zero or negative.
     
-    InvalidArgumentError: if `target_height` or `target_width` are certain positive values.
+    InvalidArgumentError: if certain positive value<100, is given for target_width.
     
     
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1874,7 +1874,6 @@ def resize_image_with_pad_v1(image,
 
   Raises:
     ValueError: if `target_height` or `target_width` are zero or negative.
-    
     InvalidArgumentError: if certain positive value<100, is given for target_width.
     
     

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1874,7 +1874,7 @@ def resize_image_with_pad_v1(image,
 
   Raises:
     ValueError: if `target_height` or `target_width` are zero or negative.
-    InvalidArgumentError: if certain positive value<100, is given for target_width.
+    InvalidArgumentError: if `target_width < 100`
 
   Returns:
     Resized and padded image.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1875,8 +1875,6 @@ def resize_image_with_pad_v1(image,
   Raises:
     ValueError: if `target_height` or `target_width` are zero or negative.
     InvalidArgumentError: if certain positive value<100, is given for target_width.
-    
-    
 
   Returns:
     Resized and padded image.


### PR DESCRIPTION
In tf.image.resize_with_pad, if the value is negative or zero for target width and target height, it is raising value error. It raises 'InvalidArgumentError' when a certain positive value that is given for (target_width<100).  
Fixes #56333