### PR TITLE
MSVC Compatibility Changes 

### DIFF
--- a/tensorflow/lite/delegates/external/external_delegate.cc
+++ b/tensorflow/lite/delegates/external/external_delegate.cc
@@ -155,12 +155,12 @@ ExternalDelegateWrapper::ExternalDelegateWrapper(
                                               ckeys.size(), nullptr);
     if (external_delegate_) {
       wrapper_delegate_ = {
-          .data_ = reinterpret_cast<void*>(this),
-          .Prepare = DelegatePrepare,
-          .CopyFromBufferHandle = nullptr,
-          .CopyToBufferHandle = nullptr,
-          .FreeBufferHandle = nullptr,
-          .flags = external_delegate_->flags,
+          reinterpret_cast<void*>(this),    // .data =
+          DelegatePrepare,                  // .Prepare =
+          nullptr,                          // .CopyFromBufferHandle =
+          nullptr,                          // .CopyToBufferHandle =
+          nullptr,                          // .FreeBufferHandle =
+          external_delegate_->flags,        // .flags =
       };
       if (external_delegate_->CopyFromBufferHandle) {
         wrapper_delegate_.CopyFromBufferHandle = DelegateCopyFromBufferHandle;

--- a/tensorflow/lite/kernels/internal/compatibility.h
+++ b/tensorflow/lite/kernels/internal/compatibility.h
@@ -87,7 +87,7 @@ using uint32 = std::uint32_t;
 #endif  // !defined(TF_LITE_STATIC_MEMORY)
 
 
-// Allow for cross-compiler usage of function signatures - used for specifying 
+// Allow for cross-compiler usage of function signatures - currently used for specifying 
 // named RUY profiler regions in templated methods.
 #if defined(_MSC_VER)
 #define TFLITE_PRETTY_FUNCTION __FUNCSIG__

--- a/tensorflow/lite/kernels/internal/compatibility.h
+++ b/tensorflow/lite/kernels/internal/compatibility.h
@@ -86,6 +86,17 @@ using int32 = std::int32_t;
 using uint32 = std::uint32_t;
 #endif  // !defined(TF_LITE_STATIC_MEMORY)
 
+
+// Allow for cross-compiler usage of function signatures - used for specifying 
+// named RUY profiler regions in templated methods.
+#if defined(_MSC_VER)
+#define TFLITE_PRETTY_FUNCTION __FUNCSIG__
+#elif defined(__GNUC__)
+#define TFLITE_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#else
+#define TFLITE_PRETTY_FUNCTION __func__
+#endif
+
 // TFLITE_DEPRECATED()
 //
 // Duplicated from absl/base/macros.h to avoid pulling in that library.

--- a/tensorflow/lite/kernels/internal/optimized/depthwiseconv_float.h
+++ b/tensorflow/lite/kernels/internal/optimized/depthwiseconv_float.h
@@ -768,7 +768,7 @@ void FloatDepthwiseConvAccumRow(int stride, int dilation_factor,
                                 const float* filter_data,
                                 int out_x_buffer_start, int out_x_buffer_end,
                                 int output_depth, float* acc_buffer) {
-  ruy::profiler::ScopeLabel label(__PRETTY_FUNCTION__);
+  ruy::profiler::ScopeLabel label(TFLITE_PRETTY_FUNCTION);
   // Consistency check parameters. This is important in particular to ensure
   // that we keep the number of template instantiations minimal, so we don't
   // increase binary size unnecessarily.

--- a/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8.h
+++ b/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8.h
@@ -1519,7 +1519,7 @@ void QuantizedDepthwiseConvAccumRow(int stride, int dilation_factor,
                                     int16 filter_offset, int out_x_buffer_start,
                                     int out_x_buffer_end, int output_depth,
                                     int32* acc_buffer) {
-  ruy::profiler::ScopeLabel label(TFLITE_PRETTY_FUNCTION);;
+  ruy::profiler::ScopeLabel label(TFLITE_PRETTY_FUNCTION);
   // Consistency check parameters. This is important in particular to ensure
   // that we keep the number of template instantiations minimal, so we don't
   // increase binary size unnecessarily.

--- a/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8.h
+++ b/tensorflow/lite/kernels/internal/optimized/depthwiseconv_uint8.h
@@ -1519,7 +1519,7 @@ void QuantizedDepthwiseConvAccumRow(int stride, int dilation_factor,
                                     int16 filter_offset, int out_x_buffer_start,
                                     int out_x_buffer_end, int output_depth,
                                     int32* acc_buffer) {
-  ruy::profiler::ScopeLabel label(__PRETTY_FUNCTION__);
+  ruy::profiler::ScopeLabel label(TFLITE_PRETTY_FUNCTION);;
   // Consistency check parameters. This is important in particular to ensure
   // that we keep the number of template instantiations minimal, so we don't
   // increase binary size unnecessarily.

--- a/tensorflow/lite/kernels/internal/optimized/integer_ops/depthwise_conv.h
+++ b/tensorflow/lite/kernels/internal/optimized/integer_ops/depthwise_conv.h
@@ -1429,7 +1429,7 @@ void QuantizedDepthwiseConvAccumRow(int stride, int dilation_factor,
                                     int out_x_buffer_start,
                                     int out_x_buffer_end, int output_depth,
                                     int32* acc_buffer) {
-  ruy::profiler::ScopeLabel label(__PRETTY_FUNCTION__);
+  ruy::profiler::ScopeLabel label(TFLITE_PRETTY_FUNCTION);
   // Consistency check parameters. This is important in particular to ensure
   // that we keep the number of template instantiations minimal, so we don't
   // increase binary size unnecessarily.


### PR DESCRIPTION
This PR addresses two issues: 
- [x] Remove usage of GCC specific compiler macro which was an issue while compiling on MSVC 2019 and other MSVC compilers.
- [x] Avoid use of designated initializer sytnax which is only supported in MSVC 2019+ and only when c++20 standard is enabled.