### PR TITLE
Fix type error of tf.experimental.BatchableExtensionType

### DIFF
--- a/tensorflow/python/framework/extension_type.py
+++ b/tensorflow/python/framework/extension_type.py
@@ -693,7 +693,7 @@ class BatchableExtensionType(ExtensionType):
   `BatchableExtensionType`s can be used with APIs that require batching or
   unbatching, including `Keras`, `tf.data.Dataset`, and `tf.map_fn`.  E.g.:
 
-  >>> class Vehicle(BatchableExtensionType):
+  >>> class Vehicle(tf.experimental.BatchableExtensionType):
   ...   top_speed: tf.Tensor
   ...   mpg: tf.Tensor
   >>> batch = Vehicle([120, 150, 80], [30, 40, 12])


### PR DESCRIPTION
Updated the documentation of `tf.experimental.BatchableExtensionType` with executable example code.

`class Vehicle(BatchableExtensionType):`

Replaced with
`class Vehicle( tf.experimental.BatchableExtensionType):`

Thank you.