### PR TITLE
Fix compilation failure that prevents JAX from building on ROCm.

### DIFF
--- a/tensorflow/compiler/xla/pjrt/pjrt_client.cc
+++ b/tensorflow/compiler/xla/pjrt/pjrt_client.cc
@@ -81,7 +81,7 @@ std::optional<PjRtChunk> CopyToDeviceStream::ConsumeNextChunk() {
       &buffered_chunks_));
   PjRtChunk chunk = std::move(buffered_chunks_.front());
   buffered_chunks_.pop_front();
-  return chunk;
+  return std::move(chunk);
 }
 
 }  // namespace xla


### PR DESCRIPTION
/cc @cheshire @chsigg