### PR TITLE
[Intel oneDNN] Enable BF16 support for binary ops: xdivy, xlogy, xlog1py

### DIFF
--- a/tensorflow/core/kernels/cwise_op_xdivy.cc
+++ b/tensorflow/core/kernels/cwise_op_xdivy.cc
@@ -17,8 +17,8 @@ limitations under the License.
 
 namespace tensorflow {
 
-REGISTER5(BinaryOp, CPU, "Xdivy", functor::xdivy, float, Eigen::half, double,
-          complex64, complex128);
+REGISTER6(BinaryOp, CPU, "Xdivy", functor::xdivy, Eigen::half, bfloat16, float,
+          double, complex64, complex128);
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)

--- a/tensorflow/core/kernels/cwise_op_xlog1py.cc
+++ b/tensorflow/core/kernels/cwise_op_xlog1py.cc
@@ -17,8 +17,8 @@ limitations under the License.
 
 namespace tensorflow {
 
-REGISTER5(BinaryOp, CPU, "Xlog1py", functor::xlog1py, float, Eigen::half,
-          double, complex64, complex128);
+REGISTER6(BinaryOp, CPU, "Xlog1py", functor::xlog1py, Eigen::half, bfloat16,
+          float, double, complex64, complex128);
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)

--- a/tensorflow/core/kernels/cwise_op_xlogy.cc
+++ b/tensorflow/core/kernels/cwise_op_xlogy.cc
@@ -17,8 +17,8 @@ limitations under the License.
 
 namespace tensorflow {
 
-REGISTER5(BinaryOp, CPU, "Xlogy", functor::xlogy, float, Eigen::half, double,
-          complex64, complex128);
+REGISTER6(BinaryOp, CPU, "Xlogy", functor::xlogy, Eigen::half, bfloat16, float,
+          double, complex64, complex128);
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -547,21 +547,21 @@ REGISTER_OP("Xlogy")
     .Input("x: T")
     .Input("y: T")
     .Output("z: T")
-    .Attr("T: {half, float, double, complex64, complex128}")
+    .Attr("T: {half, bfloat16, float, double, complex64, complex128}")
     .SetShapeFn(shape_inference::BroadcastBinaryOpShapeFn);
 
 REGISTER_OP("Xlog1py")
     .Input("x: T")
     .Input("y: T")
     .Output("z: T")
-    .Attr("T: {half, float, double, complex64, complex128}")
+    .Attr("T: {half, bfloat16, float, double, complex64, complex128}")
     .SetShapeFn(shape_inference::BroadcastBinaryOpShapeFn);
 
 REGISTER_OP("Xdivy")
     .Input("x: T")
     .Input("y: T")
     .Output("z: T")
-    .Attr("T: {half, float, double, complex64, complex128}")
+    .Attr("T: {half, bfloat16, float, double, complex64, complex128}")
     .SetShapeFn(shape_inference::BroadcastBinaryOpShapeFn);
 
 #undef BINARY_FEWER

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_binary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_binary_test.py
@@ -39,6 +39,10 @@ _TRUEDIV = lambda x, y: x / y
 _FLOORDIV = lambda x, y: x // y
 _MOD = lambda x, y: x % y
 
+# x and y must be numpy array object
+np_xlogy = lambda x, y: x * np.log(y)
+np_xlog1py = lambda x, y: x * np.log1p(y)
+
 
 # TODO(zongheng): it'd be great to factor out this function and various random
 # SparseTensor gen funcs.
@@ -259,6 +263,16 @@ class BinaryOpTest(test.TestCase):
     np_result = x * y
     self.assertAllEqual(np_result, left_result)
     self.assertAllEqual(np_result, right_result)
+
+  @test_util.run_deprecated_v1
+  def testBFloat16Basic(self):
+    bfloat16 = dtypes_lib.bfloat16.as_numpy_dtype
+    x = np.linspace(-20, 20, 10).reshape(1, 2, 5).astype(bfloat16) # pylint: disable=too-many-function-args
+    # y cannot be zero
+    y = np.linspace(-20, 20, 10).reshape(1, 2, 5).astype(bfloat16) # pylint: disable=too-many-function-args
+    self._compareCpu(x, y, np.true_divide, math_ops.xdivy)
+    self._compareCpu(x, y, np_xlogy, math_ops.xlogy)
+    self._compareCpu(x, y, np_xlog1py, math_ops.xlog1py)
 
   @test_util.run_deprecated_v1
   def testDoubleBasic(self):

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_binary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_binary_test.py
@@ -264,7 +264,6 @@ class BinaryOpTest(test.TestCase):
     self.assertAllEqual(np_result, left_result)
     self.assertAllEqual(np_result, right_result)
 
-  @test_util.run_deprecated_v1
   def testBFloat16Basic(self):
     bfloat16 = dtypes_lib.bfloat16.as_numpy_dtype
     x = np.linspace(-20, 20, 10).reshape(1, 2, 5).astype(bfloat16) # pylint: disable=too-many-function-args


### PR DESCRIPTION
This PR adds BF16 support for the following binary ops: _xdivy_, _xlogy_, _xlog1py_