### PR TITLE
[TF-TRT] Export TRT engines to filesystem

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
@@ -115,7 +115,7 @@ class InitializeTRTResource : public OpKernel {
     // Parse the serialized engines and add them to the cache.
     std::unique_ptr<RandomAccessFile> file;
     OP_REQUIRES_OK(ctx, ctx->env()->NewRandomAccessFile(filename, &file));
-    auto reader = absl::make_unique<io::RecordReader>(file.get());
+    auto reader = std::make_unique<io::RecordReader>(file.get());
 
     uint64 offset = 0;
     int num_loaded_engine = 0;
@@ -156,7 +156,7 @@ class InitializeTRTResource : public OpKernel {
         ctx_vec.push_back(ExecutionContext::Create(raw_engine));
       }
       resource->cache_.emplace(engine_input_shapes,
-                               absl::make_unique<EngineContext>(
+                               std::make_unique<EngineContext>(
                                    std::move(engine), std::move(ctx_vec)));
       ++num_loaded_engine;
     } while (1);
@@ -207,10 +207,18 @@ class SerializeTRTResource : public OpKernel {
     // Serialize the engines and write them to file.
     std::unique_ptr<WritableFile> file;
     OP_REQUIRES_OK(ctx, ctx->env()->NewWritableFile(filename, &file));
-    auto writer = absl::make_unique<io::RecordWriter>(file.get());
+    auto writer = std::make_unique<io::RecordWriter>(file.get());
 
     int num_serialized_engines = 0;
     if (save_gpu_specific_engines_) {
+      // If user requests TRT engines export, recursively create
+      // requisite directories.
+      const char* export_trt_engines_env = getenv("TF_TRT_EXPORT_TRT_ENGINES_PATH");
+      if (export_trt_engines_env) {
+        VLOG(1) << "Exporting TRT engines to directory: " << export_trt_engines_env;
+        OP_REQUIRES_OK(ctx, ctx->env()->RecursivelyCreateDir(export_trt_engines_env));
+      }
+
       for (const auto& pair : resource->cache_) {
         // Ignore engines that failed to build.
         const std::unique_ptr<EngineContext>& engine = pair.second;
@@ -227,6 +235,22 @@ class SerializeTRTResource : public OpKernel {
             engine->GetCudaEngine()->serialize());
         engine_instance.set_serialized_engine(engine_data->data(),
                                               engine_data->size());
+
+        if (export_trt_engines_env) {
+          const std::string engine_filename = std::string(export_trt_engines_env) + "/" + resource_name;
+          std::unique_ptr<WritableFile> engine_file;
+          OP_REQUIRES_OK(ctx, ctx->env()->NewWritableFile(engine_filename, &engine_file));
+          OP_REQUIRES_OK(ctx,
+            engine_file->Append(StringPiece(static_cast<char*>(engine_data->data()), engine_data->size())));
+
+          const std::string dims_filename = std::string(export_trt_engines_env) + "/dims-" + resource_name;
+          std::unique_ptr<WritableFile> dims_file;
+          OP_REQUIRES_OK(ctx, ctx->env()->NewWritableFile(dims_filename, &dims_file));
+
+          for (const TensorShape& shape : engine_input_shapes) {
+            OP_REQUIRES_OK(ctx, dims_file->Append(StringPiece(shape.DebugString())));
+          }
+        }
 
         OP_REQUIRES_OK(
             ctx, writer->WriteRecord(engine_instance.SerializeAsString()));


### PR DESCRIPTION
If the environment variable TF_TRT_EXPORT_TRT_ENGINES_PATH is set, then save generated TRT engines to this path. The dimensions of inputs to engines will also be saved along with the engines. These files can then be analyzed using TRT specific debug tools.

CC: @DEKHTIARJonathan @cliffwoolley @tfeher @bixia1 