### PR TITLE
Fix endless loop in DecodeLin16WaveAsFloatVector

### DIFF
--- a/tensorflow/core/lib/wav/wav_io.cc
+++ b/tensorflow/core/lib/wav/wav_io.cc
@@ -85,11 +85,15 @@ inline float Int16SampleToFloat(int16_t data) {
 
 // Handles moving the data index forward, validating the arguments, and avoiding
 // overflow or underflow.
-Status IncrementOffset(int old_offset, size_t increment, size_t max_size,
+Status IncrementOffset(int old_offset, int increment, size_t max_size,
                        int* new_offset) {
   if (old_offset < 0) {
     return errors::InvalidArgument("Negative offsets are not allowed: ",
                                    old_offset);
+  }
+  if (increment < 0) {
+    return errors::InvalidArgument("Negative increment is not allowed: ",
+                                   increment);
   }
   if (old_offset > max_size) {
     return errors::InvalidArgument("Initial offset is outside data range: ",

--- a/tensorflow/core/lib/wav/wav_io.h
+++ b/tensorflow/core/lib/wav/wav_io.h
@@ -72,7 +72,7 @@ Status DecodeLin16WaveAsFloatVector(const std::string& wav_string,
 
 // Handles moving the data index forward, validating the arguments, and avoiding
 // overflow or underflow.
-Status IncrementOffset(int old_offset, size_t increment, size_t max_size,
+Status IncrementOffset(int old_offset, int increment, size_t max_size,
                        int* new_offset);
 
 // This function is only exposed in the header for testing purposes, as a


### PR DESCRIPTION
Hi!
We were doing some fuzzing using libFuzzer and symbolic execution tool Sydr for fuzz targets from this [PR](https://github.com/google/oss-fuzz/pull/7704). And we found an interesting issue. Loop at [wav_io.cc:233]( https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/lib/wav/wav_io.cc#L233) could be endless under certain conditions. I'll try to explain: if variable _found_text_ is equal for one of keywords from  [if at wav_io.cc:240](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/lib/wav/wav_io.cc#L240) (for example found_text = "bext") and the next value of **size_of_chunk** is equal to -8 in sign representation there will be an endless loop.
So, how it works. Before line [wav_io.cc:246](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/lib/wav/wav_io.cc#L246) **offset** points to first byte of  **size_of_chunk** value to be read. After line 246 is executed **size_of_chunk** is -8 and offset is offset + 4. Then calling _IncrementOffset_ with this parameters changes **offset** to point on the first byte of **found_string**("bext") before **size_of_chunk** and here we go again...
I've fixed this problem adding a check for negative size of increment in  [IncrementOffset](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/lib/wav/wav_io.cc#L88) function. Also I changed type of increment parameter from size_t to int. I think it's ok, because  the only place it used is [line 98](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/lib/wav/wav_io.cc#L98) where implicit cast to int is happening.
If you want to reproduce this case, you could follow instructions from [here](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/tensorflow) or use docker container from oss-fuzz. I attach the buggy input:[timeout-9552d4db656b46794c5032c2ce463542f43b6970.txt](https://github.com/tensorflow/tensorflow/files/8898252/timeout-9552d4db656b46794c5032c2ce463542f43b6970.txt)
