### PR TITLE
Allow greater version for protobuf and grpcio

### DIFF
--- a/tensorflow/tools/ci_build/release/requirements_common.txt
+++ b/tensorflow/tools/ci_build/release/requirements_common.txt
@@ -10,7 +10,7 @@ h5py ~= 3.6.0  # NOTE: Earliest version for Python 3.10
 keras_preprocessing ~= 1.1.2
 numpy ~= 1.21.4  # NOTE: Earliest version for h5py in Python 3.10
 opt_einsum ~= 3.3.0
-protobuf ~= 3.19.3  # NOTE: Earliest version for Python 3.10
+protobuf >= 3.19.3, == 3.*  # NOTE: Earliest version for Python 3.10
 six ~= 1.16.0
 termcolor ~= 1.1.0
 typing_extensions ~= 3.10.0.0
@@ -29,7 +29,7 @@ tb-nightly ~= 2.9.0.a
 tf-estimator-nightly ~= 2.10.0.dev
 
 # Test dependencies
-grpcio ~= 1.43.0  # NOTE: Earliest version for Python 3.10
+grpcio ~= 1.43  # NOTE: Earliest version for Python 3.10
 portpicker ~= 1.4.0
 scipy ~= 1.7.2  # NOTE: Earliest version for Python 3.10
 


### PR DESCRIPTION
In the last version of Tensorflow, the required versions for protobuf and grpcio are defined as  

```
protobuf ~= 3.19.3
grpcio ~= 1.43.0
```

These requirements allow only bump of the patch version (according semantic versioning) and can lead to conflict with other lib that require more recent version of one of these lib.

This PR set the requirements more lenient by allowing bump to minor version (for example protobuf 3.20.0). It still restrict bump for the major version.

This behavior is more close to the requirements in tensorflow < 2.7 that was defined as 

```
protobuf >= 3.17.1
grpcio ~= 1.38.1
```