### PR TITLE
[TF-TRT] TraceMe instrumentation for TRTEngineOp

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -206,6 +206,7 @@ cc_library(
     deps = [
         "//tensorflow/core:framework",
         "//tensorflow/core/platform:logging",
+        "//tensorflow/core/profiler/lib:annotated_traceme",
     ] + if_tensorrt([":tensorrt_lib"]),
 )
 
@@ -417,6 +418,7 @@ tf_cuda_library(
         "//tensorflow/core:framework_headers_lib",
         "//tensorflow/core:lib",
         "//tensorflow/core/platform:status",
+        "//tensorflow/core/profiler/lib:annotated_traceme",
         "//tensorflow/core:stream_executor_headers_lib",
     ] + if_tensorrt([":tensorrt_lib"]),
 )

--- a/tensorflow/compiler/tf2tensorrt/common/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.cc
@@ -20,7 +20,9 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/profiler/lib/traceme.h"
 #include "third_party/tensorrt/NvInferPlugin.h"
+
 #endif
 
 namespace tensorflow {
@@ -58,6 +60,8 @@ namespace tensorrt {
 Status GetTrtBindingIndex(const char* tensor_name, int profile_index,
                           const nvinfer1::ICudaEngine* cuda_engine,
                           int* binding_index) {
+  tensorflow::profiler::TraceMe activity(
+      "GetTrtBindingIndex", tensorflow::profiler::TraceMeLevel::kInfo);
   // If the engine has been built for K profiles, the first getNbBindings() / K
   // bindings are used by profile number 0, the following getNbBindings() / K
   // bindings are used by profile number 1 etc.

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -97,8 +97,11 @@ class ContextDeviceMemory {
             "Out of GPU memory for execution context");
       }
     }
-    execution_context_->setDeviceMemory(device_memory_);
-
+    {
+      tensorflow::profiler::TraceMe activity(
+          "setDeviceMemory", tensorflow::profiler::TraceMeLevel::kInfo);
+      execution_context_->setDeviceMemory(device_memory_);
+    }
     return Status::OK();
   }
 
@@ -967,6 +970,9 @@ Status TRTEngineOp::ExecuteTrtEngine(
 
   ContextDeviceMemory context_device_memory;
   if (!has_device_memory) {
+    tensorflow::profiler::TraceMe activity(
+        "TRTEngineOp::AllocateDeviceMemory",
+        tensorflow::profiler::TraceMeLevel::kInfo);
     // Allocate device memory for the TensorRT engine execution. The device
     // memory will be released when context_device_memory goes out of scope.
     TF_RETURN_IF_ERROR(context_device_memory.AllocateDeviceMemory(
@@ -979,6 +985,9 @@ Status TRTEngineOp::ExecuteTrtEngine(
 
 Status TRTEngineOp::GetEngineCacheResource(OpKernelContext* ctx,
                                            TRTEngineCacheResource** cache_res) {
+  tensorflow::profiler::TraceMe activity(
+      "TRTEngineOp::GetEngineCachResource",
+      tensorflow::profiler::TraceMeLevel::kInfo);
   // Canonicalize the op name by removing the scopes if any. This is mainly
   // because in TFv2, the function graph can be instantiated in various ways and
   // it'll insert scope names to the name of the TRTEngineOps, which will result
@@ -1050,7 +1059,8 @@ StatusOr<std::pair<EngineContext*, int>> TRTEngineOp::GetEngine(
     const std::vector<TensorShape>& input_concrete_shapes, OpKernelContext* ctx,
     TRTEngineCacheResource* cache_res) {
   static EngineContext empty_context;
-
+  tensorflow::profiler::TraceMe activity(
+      "TRTEngineOp::GetEngine", tensorflow::profiler::TraceMeLevel::kInfo);
   mutex_lock lock(engine_mutex_);
   // Using first input to get batch size is reliable - VerifyInputShapes()
   // guarantees that the first input is not a scalar. As such we can always use

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
@@ -26,6 +26,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/profiler/lib/traceme.h"
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 #include "third_party/tensorrt/NvInfer.h"
@@ -60,6 +61,8 @@ Status GetTrtBindingShape(const nvinfer1::ICudaEngine* cuda_engine,
                           const nvinfer1::IExecutionContext* execution_context,
                           int binding_index, bool use_implicit_batch,
                           int batch_size, TensorShape& shape) {
+  tensorflow::profiler::TraceMe activity(
+      "getBindingDimensions", tensorflow::profiler::TraceMeLevel::kInfo);
   nvinfer1::Dims dims =
       use_implicit_batch
           ? cuda_engine->getBindingDimensions(binding_index)
@@ -79,6 +82,8 @@ Status GetTrtBindingShape(const nvinfer1::ICudaEngine* cuda_engine,
 
 Status SetupBindings(nvinfer1::ICudaEngine* cuda_engine, const Tensor& tensor,
                      std::vector<void*>& buffers, int binding_index) {
+  tensorflow::profiler::TraceMe activity(
+      "SetBindingPointers", tensorflow::profiler::TraceMeLevel::kInfo);
   const auto dtype = cuda_engine->getBindingDataType(binding_index);
   VLOG(2) << "<<<<<<<<< SetupBindings with dtype = " << (int)dtype;
   switch (dtype) {
@@ -114,6 +119,8 @@ Status SetTrtEngineInputs(nvinfer1::ICudaEngine* cuda_engine,
                           int num_batch,
                           const TrtShapeOptimizationProfile& profiles,
                           OpKernelContext* ctx, const DataVec* input_vec) {
+  tensorflow::profiler::TraceMe activity(
+      "SetTrtEngineInputs", tensorflow::profiler::TraceMeLevel::kInfo);
   int n_inputs = ctx ? ctx->num_inputs() : (input_vec ? input_vec->size() : 0);
   // Setup engine inputs.
   for (int i = 0; i < n_inputs; i++) {
@@ -150,6 +157,9 @@ Status SetTrtEngineInputs(nvinfer1::ICudaEngine* cuda_engine,
           i, binding_index, cuda_engine, execution_context));
 
       if (cuda_engine->isExecutionBinding(binding_index)) {
+        tensorflow::profiler::TraceMe activity(
+            "SetTrtEngineInputs::setBindingDimensions",
+            tensorflow::profiler::TraceMeLevel::kInfo);
         nvinfer1::Dims trt_dims;
         auto adap = DimsAdapter::Create(input_shape);
         TRT_ENSURE_OK(adap);
@@ -187,6 +197,8 @@ Status SetTrtEngineOutputs(nvinfer1::ICudaEngine* cuda_engine,
                            int trt_profile_idx, std::vector<void*>& buffers,
                            bool use_implicit_batch, int batch_size,
                            OpKernelContext* ctx, DataVec* outputs) {
+  tensorflow::profiler::TraceMe activity(
+      "SetTrtEngineOutputs", tensorflow::profiler::TraceMeLevel::kInfo);
   // Either one of ctx or outpus should be specified
   int n_outputs = ctx ? ctx->num_outputs() : (outputs ? outputs->size() : 0);
   for (int i = 0; i < n_outputs; i++) {
@@ -205,6 +217,8 @@ Status SetTrtEngineOutputs(nvinfer1::ICudaEngine* cuda_engine,
     // Allocate output tensor of TRTEngineOp.
     Tensor* output_tensor = nullptr;
     if (ctx) {
+      tensorflow::profiler::TraceMe activity(
+          "AllocateOutput", tensorflow::profiler::TraceMeLevel::kInfo);
       TF_RETURN_IF_ERROR(ctx->allocate_output(i, output_shape, &output_tensor));
     } else {
       // This path is used for unit tests. The tensor is already allocated.
@@ -231,6 +245,8 @@ Status SetTrtEngineOutputs(nvinfer1::ICudaEngine* cuda_engine,
 Status TrtEnqueue(nvinfer1::IExecutionContext* execution_context,
                   std::vector<void*>& buffers, cudaStream_t stream,
                   bool use_implicit_batch, int batch_size) {
+  tensorflow::profiler::TraceMe activity(
+      "TrtEnqueue", tensorflow::profiler::TraceMeLevel::kInfo);
   bool ret = false;
   if (use_implicit_batch) {
     ret = execution_context->enqueue(batch_size, &buffers[0], stream, nullptr);

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_lru_cache.h
@@ -185,7 +185,6 @@ struct EngineContext {
   // latency. Since its value remains constant, we can cache it.
   size_t device_memory_size_;
 };
-
 // Contains the context required to build the calibration data.
 class CalibrationContext {
  public:

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/compiler/tf2tensorrt/common/utils.h"
 #include "tensorflow/compiler/tf2tensorrt/convert/utils.h"
 #include "tensorflow/core/platform/stream_executor.h"
+#include "tensorflow/core/profiler/lib/traceme.h"
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 
@@ -139,6 +140,9 @@ void TrtShapeOptimizationProfile::OptimalStrategy(
 // Collects the values of tensors that are ShapeTensorCompatible to. The values
 // are stored in the actual_shape_values_ member variable.
 Status TrtShapeOptimizationProfile::CollectShapeValues(OpKernelContext* ctx) {
+  tensorflow::profiler::TraceMe activity(
+      "TrtShapeOptimizationProfile::CollectShapeValues",
+      tensorflow::profiler::TraceMeLevel::kInfo);
   const cudaStream_t* stream = CHECK_NOTNULL(
       reinterpret_cast<const cudaStream_t*>(ctx->op_device_context()
                                                 ->stream()
@@ -466,6 +470,9 @@ void TrtShapeOptimizationProfile::SetShapeTensorMask(
 
 int TrtShapeOptimizationProfile::GetProfileNumber(
     const std::vector<TensorShape>& shapes) {
+  tensorflow::profiler::TraceMe activity(
+      "TrtShapeOptimizationProfile::GetProfileNumber",
+      tensorflow::profiler::TraceMeLevel::kInfo);
   if (!need_profiles_) return 0;
   // TODO(tfeher): Return the best profile not just the first compatible.
   for (int i = 0; i < profiles_.size(); i++) {
@@ -509,6 +516,9 @@ Status TrtShapeOptimizationProfile::CreateExecutionContexts(
 Status TrtShapeOptimizationProfile::SetInputShapeBinding(
     int input_index, int binding_index, nvinfer1::ICudaEngine* cuda_engine,
     nvinfer1::IExecutionContext* exec_context) const {
+  tensorflow::profiler::TraceMe activity(
+      "TrtShapeOptimizationProfile::SetInputShapeBinding",
+      tensorflow::profiler::TraceMeLevel::kInfo);
   if (cuda_engine->isShapeBinding(binding_index)) {
     // Input shape binding data has to be in host memory. That is the reason
     // we can't use input_tensor.flat().data(). which contains the same


### PR DESCRIPTION
This PR adds some additional TraceMe ranges. This allows to better profile and debug TF-TRT execution and better identify bottlenecks.

It namely focus around:
- Instrument getDeviceMemorySize
- TraceMe for output bindings