### PR TITLE
Fix a potential variable misuse bug

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/split_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/split_op_test.py
@@ -224,7 +224,7 @@ class SplitOpTest(test.TestCase):
       tf_ans = array_ops.split(value=x, num_or_size_splits=num, axis=dim)
       out = self.evaluate(tf_ans)
     self.assertEqual(num, len(np_ans))
-    self.assertEqual(num, len(np_ans))
+    self.assertEqual(num, len(tf_ans))
     self.assertEqual(num, len(out))
     for i in range(num):
       self.assertAllEqual(np_ans[i], out[i])


### PR DESCRIPTION
Hi,

This pull request is a fix to a potential variable misuse bug at `tensorflow/python/kernel_tests/array_ops/split_op_test.py`. Please check the changes.

Best,
Jingxuan