### PR TITLE
Add missing dep to fusion interface

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/gml_st/IR/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/gml_st/IR/CMakeLists.txt
@@ -21,6 +21,7 @@ add_mlir_dialect_library(GmlStDialect
 
   DEPENDS
   MLIRgml_st_opsIncGen
+  MLIRGmlStFusionInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRControlFlowInterfaces


### PR DESCRIPTION
`gml_st_ops.cc` includes `gml_st_ops.h` which which includes
`fusion_interface.h` which includes `fusion_interface.h.inc`. This is
part of the `MLIRGmlStFusionInterfaceIncGen` CMake target to which the
dependecy was missing.