### PR TITLE
[TF-TRT] Disable TF32 for TF-TRT unittests that needs it

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/biasadd_matmul_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/biasadd_matmul_test.py
@@ -19,7 +19,6 @@ import numpy as np
 from tensorflow.python.compiler.tensorrt.test import tf_trt_integration_test_base as trt_test
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import math_ops
@@ -27,7 +26,6 @@ from tensorflow.python.ops import nn
 from tensorflow.python.platform import test
 
 
-@test_util.run_all_without_tensor_float_32("Avoid TF32 matmul on GPU")
 class BiasaddMatMulTest(trt_test.TfTrtIntegrationTestBase):
   """Testing conversion of BiasAdd MatMul in TF-TRT conversion."""
 

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -24,6 +24,8 @@ import shutil
 import tempfile
 import warnings
 
+from contextlib import contextmanager
+
 import numpy as np
 
 from tensorflow.compiler.tf2tensorrt._pywrap_py_utils import is_tensorrt_enabled
@@ -33,6 +35,7 @@ from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.python.compiler.tensorrt import trt_convert
 from tensorflow.python.compiler.tensorrt import utils as trt_utils
 from tensorflow.python.eager import def_function
+from tensorflow.python.framework import config
 from tensorflow.python.framework import graph_io
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_spec
@@ -104,6 +107,21 @@ def IsQuantizationWithCalibration(params):
 def IsQuantizationWithoutCalibration(params):
   return IsQuantizationMode(
       params.precision_mode) and not params.use_calibration
+
+
+@contextmanager
+def disable_tensorfloat32():
+  start_value = config.tensor_float_32_execution_enabled()
+
+  config.enable_tensor_float_32_execution(False)
+
+  logging.info("TensorFloat32 Arithmetic Disabled")
+
+  try:
+    yield
+   #  Finally block always gets executed either exception is generated or not
+  finally:
+    config.enable_tensor_float_32_execution(start_value)
 
 
 class GraphState(object):
@@ -1010,73 +1028,77 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
     return self._MakeSavedModelV1(run_params)
 
   def RunTest(self, run_params):
-    with trace.Trace(run_params.test_name):
-      should_run, reason_for_skipping = self.ShouldRunTest(run_params)
-      if not should_run:
-        return self.skipTest(reason_for_skipping)
 
-      saved_model_dir = self._MakeSavedModel(run_params)
+    with disable_tensorfloat32():
+      with trace.Trace(run_params.test_name):
+        should_run, reason_for_skipping = self.ShouldRunTest(run_params)
+        if not should_run:
+          return self.skipTest(reason_for_skipping)
 
-      np.random.seed(12345)  # Fix the seed so the test is deterministic.
-      inputs_data = []
-      input_specs = self._GetParamsCached().input_specs
-      for dim_list in self._GetParamsCached().input_dims:
-        assert len(input_specs) == len(dim_list), (
-            f"Inconsistent input_specs and dim_list: len({input_specs}) != "
-            f"len({dim_list}).")
-        current_input_data = []
-        for spec, np_shape in zip(input_specs, dim_list):
-          np_dtype = spec.dtype.as_numpy_dtype()
-          if not np.issubdtype(np_dtype, np.bool_):
-            # Multiply the input by some constant to avoid all zeros input for
-            # integer types.
-            scale = 10.0 if np.issubdtype(np_dtype, np.integer) else 1.0
-            data = (scale * np.random.random_sample(np_shape)).astype(np_dtype)
-          else:
-            data = np.random.choice(a=[False, True], size=np_shape)
+        saved_model_dir = self._MakeSavedModel(run_params)
 
-          if run_params.is_v2:
-            with ops.device("/GPU:0"):
-              data = ops.convert_to_tensor(data)
-          current_input_data.append(data)
-        inputs_data.append(current_input_data)
+        np.random.seed(12345)  # Fix the seed so the test is deterministic.
+        inputs_data = []
+        input_specs = self._GetParamsCached().input_specs
+        for dim_list in self._GetParamsCached().input_dims:
+          assert len(input_specs) == len(dim_list), (
+              f"Inconsistent input_specs and dim_list: len({input_specs}) != "
+              f"len({dim_list}).")
+          current_input_data = []
+          for spec, np_shape in zip(input_specs, dim_list):
+            np_dtype = spec.dtype.as_numpy_dtype()
+            if not np.issubdtype(np_dtype, np.bool_):
+              # Multiply the input by some constant to avoid all zeros input for
+              # integer types.
+              scale = 10.0 if np.issubdtype(np_dtype, np.integer) else 1.0
+              data = (scale * np.random.random_sample(np_shape)).astype(
+                np_dtype)
+            else:
+              data = np.random.choice(a=[False, True], size=np_shape)
 
-      # Verify the original graph.
-      self._VerifyGraphDef(run_params, saved_model_dir, saved_model_dir,
-                           GraphState.ORIGINAL)
+            if run_params.is_v2:
+              with ops.device("/GPU:0"):
+                data = ops.convert_to_tensor(data)
+            current_input_data.append(data)
+          inputs_data.append(current_input_data)
 
-      # Run the original graph without TensorRT to get the reference result.
-      logging.info("Running original graph w/o TensorRT\n")
-      ref_result = self._RunGraph(
-          run_params,
-          saved_model_dir,
-          inputs_data,
-          GraphState.ORIGINAL,
-          num_runs=1)
+        # Verify the original graph.
+        self._VerifyGraphDef(run_params, saved_model_dir, saved_model_dir,
+                             GraphState.ORIGINAL)
 
-      # Run calibration if necessary.
-      if IsQuantizationWithCalibration(run_params):
-        infer_saved_model_dir = self._GetCalibratedInferGraph(
-            run_params, saved_model_dir, inputs_data)
-        self._VerifyGraphDef(run_params, saved_model_dir, infer_saved_model_dir,
-                             GraphState.INFERENCE)
-      elif not run_params.convert_online:
-        infer_saved_model_dir = self._GetInferGraph(run_params, saved_model_dir)
-        self._VerifyGraphDef(run_params, saved_model_dir, infer_saved_model_dir,
-                             GraphState.INFERENCE)
-      else:
-        infer_saved_model_dir = saved_model_dir
+        # Run the original graph without TensorRT to get the reference result.
+        logging.info("Running original graph w/o TensorRT\n")
+        ref_result = self._RunGraph(
+            run_params,
+            saved_model_dir,
+            inputs_data,
+            GraphState.ORIGINAL,
+            num_runs=1)
 
-      # Run the inference graph, either using the converted graph or the
-      # original graph with convert_online == True.
-      logging.info("Running final inference graph\n")
-      result = self._RunGraph(run_params, infer_saved_model_dir, inputs_data,
-                              GraphState.INFERENCE)
-      self.assertAllClose(
-          ref_result,
-          result,
-          atol=self.ExpectedAbsoluteTolerance(run_params),
-          rtol=self.ExpectedRelativeTolerance(run_params))
+        # Run calibration if necessary.
+        if IsQuantizationWithCalibration(run_params):
+          infer_saved_model_dir = self._GetCalibratedInferGraph(
+              run_params, saved_model_dir, inputs_data)
+          self._VerifyGraphDef(run_params, saved_model_dir,
+                               infer_saved_model_dir, GraphState.INFERENCE)
+        elif not run_params.convert_online:
+          infer_saved_model_dir = self._GetInferGraph(run_params,
+                                                      saved_model_dir)
+          self._VerifyGraphDef(run_params, saved_model_dir,
+                               infer_saved_model_dir, GraphState.INFERENCE)
+        else:
+          infer_saved_model_dir = saved_model_dir
+
+        # Run the inference graph, either using the converted graph or the
+        # original graph with convert_online == True.
+        logging.info("Running final inference graph\n")
+        result = self._RunGraph(run_params, infer_saved_model_dir, inputs_data,
+                                GraphState.INFERENCE)
+        self.assertAllClose(
+            ref_result,
+            result,
+            atol=self.ExpectedAbsoluteTolerance(run_params),
+            rtol=self.ExpectedRelativeTolerance(run_params))
 
   def testIdempotence(self):
     # Test that applying tensorrt optimizer or offline conversion tools multiple


### PR DESCRIPTION
TF32 computation may require in some cases a higher threshold to pass some unittests. Instead of implementing some complex logic, the standard procedure for these few cases is to test in FP32 instead of TF32 and not modifying the threshold.

This PR corrects TF-TRT python unittests with this logic.