### PR TITLE
Fix typo error of @tf.experimental.dispatch_for_api

### DIFF
--- a/tensorflow/python/util/dispatch.py
+++ b/tensorflow/python/util/dispatch.py
@@ -477,7 +477,7 @@ def unregister_dispatch_for(dispatch_target):
   >>> # Define a type and register a dispatcher to override `tf.abs`:
   >>> class MyTensor(tf.experimental.ExtensionType):
   ...   value: tf.Tensor
-  >>> @dispatch_for_api(tf.abs)
+  >>> @tf.experimental.dispatch_for_api(tf.abs)
   ... def my_abs(x: MyTensor):
   ...   return MyTensor(tf.abs(x.value))
   >>> tf.abs(MyTensor(5))


### PR DESCRIPTION
Updated the example given for `tf.experimental.unregister_dispatch_for`. Thank you!

