### PR TITLE
Allow for explicit stop of WorkerServer and DispatchServer

### DIFF
--- a/tensorflow/python/data/experimental/service/server_lib.py
+++ b/tensorflow/python/data/experimental/service/server_lib.py
@@ -118,13 +118,25 @@ class DispatchServer:
   [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
   When starting a dedicated tf.data dispatch process, use join() to block
-  indefinitely after starting up the server.
+  after starting up the server, until the server terminates.
 
   ```
-  dispatcher = tf.data.experimental.service.DispatchServer(
-      tf.data.experimental.service.DispatcherConfig(port=5050))
+  config = tf.data.experimental.service.DispatcherConfig(port=5050)
+  dispatcher = tf.data.experimental.service.DispatchServer(config)
   dispatcher.join()
   ```
+
+  Call stop() to gracefully terminate the dispatcher. Alternatively, use
+  the dispatcher in a `with` context to automatically stop it when leaving
+  the context.
+
+  ```
+  config = tf.data.experimental.service.DispatcherConfig(port=5050)
+  with tf.data.experimental.service.DispatchServer(config) as dispatcher:
+      ...
+  ```
+
+  The server automatically stops when all reference to it have been deleted.
 
   To start a `DispatchServer` in fault-tolerant mode, set `work_dir` and
   `fault_tolerant_mode` like below:
@@ -189,8 +201,8 @@ class DispatchServer:
     This is useful when starting a dedicated dispatch process.
 
     ```
-    dispatcher = tf.data.experimental.service.DispatchServer(
-        tf.data.experimental.service.DispatcherConfig(port=5050))
+    config = tf.data.experimental.service.DispatcherConfig(port=5050)
+    dispatcher = tf.data.experimental.service.DispatchServer(config)
     dispatcher.join()
     ```
 
@@ -199,6 +211,15 @@ class DispatchServer:
         joining the server.
     """
     self._server.join()
+
+  def stop(self):
+      """Stops the server.
+
+      Raises:
+        tf.errors.OpError: Or one of its subclasses if an error occurs while
+          stopping the server.
+      """
+      self._stop()
 
   @property
   def target(self):
@@ -226,6 +247,9 @@ class DispatchServer:
 
   def __del__(self):
     self._stop()
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+      self._stop()
 
   @property
   def _address(self):
@@ -314,13 +338,25 @@ class WorkerServer:
   [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
   When starting a dedicated tf.data worker process, use join() to block
-  indefinitely after starting up the server.
+  after starting up the worker, until the worker terminates.
 
   ```
   worker = tf.data.experimental.service.WorkerServer(
       port=5051, dispatcher_address="localhost:5050")
   worker.join()
   ```
+
+  Call stop() to gracefully terminate the worker. Alternatively, use
+  the worker in a `with` context to automatically stop it when leaving
+  the context.
+
+  ```
+  with tf.data.experimental.service.WorkerServer(
+      port=5051, dispatcher_address="localhost:5050") as worker:
+      ...
+  ```
+
+  The worker automatically stops when all reference to it have been deleted.
   """
 
   def __init__(self, config, start=True):
@@ -379,6 +415,15 @@ class WorkerServer:
     """
     self._server.join()
 
+  def stop(self):
+    """Stops the server.
+
+    Raises:
+    tf.errors.OpError: Or one of its subclasses if an error occurs while
+    stopping the server.
+    """
+    self._stop()
+
   def _stop(self):
     """Stops the server.
 
@@ -390,6 +435,9 @@ class WorkerServer:
 
   def __del__(self):
     self._stop()
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+      self._stop()
 
   @property
   def _address(self):

--- a/tensorflow/python/data/experimental/service/server_lib.py
+++ b/tensorflow/python/data/experimental/service/server_lib.py
@@ -126,17 +126,8 @@ class DispatchServer:
   dispatcher.join()
   ```
 
-  Call stop() to gracefully terminate the dispatcher. Alternatively, use
-  the dispatcher in a `with` context to automatically stop it when leaving
-  the context.
-
-  ```
-  config = tf.data.experimental.service.DispatcherConfig(port=5050)
-  with tf.data.experimental.service.DispatchServer(config) as dispatcher:
-      ...
-  ```
-
-  The server automatically stops when all reference to it have been deleted.
+  Call stop() to gracefully terminate the dispatcher. The server automatically
+  stops when all reference to it have been deleted.
 
   To start a `DispatchServer` in fault-tolerant mode, set `work_dir` and
   `fault_tolerant_mode` like below:
@@ -248,9 +239,6 @@ class DispatchServer:
   def __del__(self):
     self._stop()
 
-  def __exit__(self, exc_type, exc_val, exc_tb):
-    self._stop()
-
   @property
   def _address(self):
     """Returns the address of the server.
@@ -346,17 +334,8 @@ class WorkerServer:
   worker.join()
   ```
 
-  Call stop() to gracefully terminate the worker. Alternatively, use
-  the worker in a `with` context to automatically stop it when leaving
-  the context.
-
-  ```
-  with tf.data.experimental.service.WorkerServer(
-      port=5051, dispatcher_address="localhost:5050") as worker:
-      ...
-  ```
-
-  The worker automatically stops when all reference to it have been deleted.
+  Call stop() to gracefully terminate the worker. The worker automatically stops
+  when all reference to it have been deleted.
   """
 
   def __init__(self, config, start=True):
@@ -434,9 +413,6 @@ class WorkerServer:
     self._server.stop()
 
   def __del__(self):
-    self._stop()
-
-  def __exit__(self, exc_type, exc_val, exc_tb):
     self._stop()
 
   @property

--- a/tensorflow/python/data/experimental/service/server_lib.py
+++ b/tensorflow/python/data/experimental/service/server_lib.py
@@ -213,13 +213,13 @@ class DispatchServer:
     self._server.join()
 
   def stop(self):
-      """Stops the server.
+    """Stops the server.
 
-      Raises:
-        tf.errors.OpError: Or one of its subclasses if an error occurs while
-          stopping the server.
-      """
-      self._stop()
+    Raises:
+    tf.errors.OpError: Or one of its subclasses if an error occurs while
+      stopping the server.
+    """
+    self._stop()
 
   @property
   def target(self):
@@ -249,7 +249,7 @@ class DispatchServer:
     self._stop()
 
   def __exit__(self, exc_type, exc_val, exc_tb):
-      self._stop()
+    self._stop()
 
   @property
   def _address(self):
@@ -437,7 +437,7 @@ class WorkerServer:
     self._stop()
 
   def __exit__(self, exc_type, exc_val, exc_tb):
-      self._stop()
+    self._stop()
 
   @property
   def _address(self):

--- a/tensorflow/python/data/experimental/service/server_lib_test.py
+++ b/tensorflow/python/data/experimental/service/server_lib_test.py
@@ -111,19 +111,19 @@ class ServerLibTest(test.TestCase):
 
   def testStopDispatcher(self):
     dispatcher = server_lib.DispatchServer()
-    dispatcher._stop()
-    dispatcher._stop()
+    dispatcher.stop()
+    dispatcher.stop()
 
   def testStopWorker(self):
     dispatcher = server_lib.DispatchServer()
     worker = server_lib.WorkerServer(
         server_lib.WorkerConfig(dispatcher._address))
-    worker._stop()
-    worker._stop()
+    worker.stop()
+    worker.stop()
 
   def testStopStartDispatcher(self):
     dispatcher = server_lib.DispatchServer()
-    dispatcher._stop()
+    dispatcher.stop()
     with self.assertRaisesRegex(
         RuntimeError, "Server cannot be started after it has been stopped"):
       dispatcher.start()
@@ -132,21 +132,33 @@ class ServerLibTest(test.TestCase):
     dispatcher = server_lib.DispatchServer()
     worker = server_lib.WorkerServer(
         server_lib.WorkerConfig(dispatcher._address))
-    worker._stop()
+    worker.stop()
     with self.assertRaisesRegex(
         RuntimeError, "Server cannot be started after it has been stopped"):
       worker.start()
 
   def testJoinDispatcher(self):
     dispatcher = server_lib.DispatchServer()
-    dispatcher._stop()
+    dispatcher.stop()
     dispatcher.join()
 
   def testJoinWorker(self):
     dispatcher = server_lib.DispatchServer()
     worker = server_lib.WorkerServer(
         server_lib.WorkerConfig(dispatcher._address))
-    worker._stop()
+    worker.stop()
+    worker.join()
+
+  def testWithDispatcher(self):
+    with server_lib.DispatchServer() as dispatcher:
+      pass
+    dispatcher.join()
+
+  def testWithWorker(self):
+    dispatcher = server_lib.DispatchServer()
+    with server_lib.WorkerServer(
+      server_lib.WorkerConfig(dispatcher._address)) as worker:
+      pass
     worker.join()
 
   def testDispatcherNumWorkers(self):

--- a/tensorflow/python/data/experimental/service/server_lib_test.py
+++ b/tensorflow/python/data/experimental/service/server_lib_test.py
@@ -149,18 +149,6 @@ class ServerLibTest(test.TestCase):
     worker.stop()
     worker.join()
 
-  def testWithDispatcher(self):
-    with server_lib.DispatchServer() as dispatcher:
-      pass
-    dispatcher.join()
-
-  def testWithWorker(self):
-    dispatcher = server_lib.DispatchServer()
-    with server_lib.WorkerServer(
-      server_lib.WorkerConfig(dispatcher._address)) as worker:
-      pass
-    worker.join()
-
   def testDispatcherNumWorkers(self):
     dispatcher = server_lib.DispatchServer()
     self.assertEqual(0, dispatcher._num_workers())


### PR DESCRIPTION
There is currently no documented way to stop a `WorkerServer` or `DispatchServer`. It gets automatically stopped on GC, but an explicit `stop` method provides better control on when the shutdown occurs.

This adds `stop` to `WorkerServer` or `DispatchServer`, as well as `__exit__`, both calling into existing `_stop`.