### PR TITLE
fixing the alloc dealloc behavior of jit execute

### DIFF
--- a/tensorflow/compiler/mlir/tools/kernel_gen/ir/tf_framework_ops.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/ir/tf_framework_ops.cc
@@ -99,6 +99,22 @@ Optional<Value> TFAllocOp::buildClone(OpBuilder &builder, Value alloc) {
       .getResult();
 }
 
+//===----------------------------------------------------------------------===//
+// JITExecuteOp
+//===----------------------------------------------------------------------===//
+Optional<Operation *> JITExecuteOp::buildDealloc(OpBuilder &builder, Value alloc) {
+  auto funcop = alloc.getParentRegion()->getParentOfType<func::FuncOp>();
+  return builder
+      .create<TFDeallocOp>(alloc.getLoc(), funcop.getArgument(0), alloc)
+      .getOperation();
+}
+
+Optional<Value> JITExecuteOp::buildClone(OpBuilder &builder, Value alloc) {
+  // TODO(herhut): We should have our own clone op if one of these survives.
+  return builder.create<mlir::bufferization::CloneOp>(alloc.getLoc(), alloc)
+      .getResult();
+}
+
 ::tensorflow::error::Code ConvertAttrToEnumValue(ErrorCode error_code) {
   using ::tensorflow::error::Code;
   switch (error_code) {

--- a/tensorflow/compiler/mlir/tools/kernel_gen/ir/tf_framework_ops.td
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/ir/tf_framework_ops.td
@@ -304,7 +304,10 @@ def TFFramework_JITCompileFromStrOp : TFFramework_Op<"jit_compile_from_str",
 //===----------------------------------------------------------------------===//
 
 def TFFramework_JITExecuteOp : TFFramework_Op<"jit_execute", [
-    AttrSizedOperandSegments]> {
+    AttrSizedOperandSegments,     
+    MemoryEffects<[MemAlloc<DefaultResource>]>,
+    DeclareOpInterfaceMethods<AllocationOpInterface,
+      ["buildDealloc", "buildClone"]>]> {
   let summary = "Executes a JIT-compiled function through the TF framework";
   let description = [{
     The op takes an optional TF context, so that it can be added at a later


### PR DESCRIPTION
Currently there is a bufferization issue with the kernel generator JIT for large tensors. With the introduction of control flow into the kernel gen to allow for large tensor kernels, the bufferization.clone operation throws error preventing the lowering. The implementation of alloc dealloc methods by extending the DeclareOpInterfaceMethods would hint the bufferize pass to ignore the insertion.

CC: @frgossen 