### PR TITLE
Fix cuDNN LSTM implementation selection with LoadSavedModel C++ API.

### DIFF
--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -167,6 +167,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":function_api_info",
         ":graph_optimizer",
         "//tensorflow/compiler/jit:common",
         "//tensorflow/core:core_cpu_base",

--- a/tensorflow/core/grappler/optimizers/implementation_selector.cc
+++ b/tensorflow/core/grappler/optimizers/implementation_selector.cc
@@ -287,7 +287,6 @@ absl::Status ImplementationSelector::MaybeOptimizeFunctionCall(
 
   auto select_device = [&](const string& function_name,
                            const std::vector<string>& equiv_func_names) {
-    StringPiece device_type;
     if (parsed_name.has_type) {
       return StringPiece(parsed_name.type);
     }

--- a/tensorflow/core/grappler/optimizers/implementation_selector.h
+++ b/tensorflow/core/grappler/optimizers/implementation_selector.h
@@ -34,6 +34,8 @@ limitations under the License.
 namespace tensorflow {
 namespace grappler {
 
+static constexpr const char* const kNoImplSelectionAttr = "_noimpl_selection";
+
 // Motivation: To achieve the same high level functionality, the underlying
 // implementations sometimes are different for various devices where the
 // function runs. In order to achieve the correct result and best performance,
@@ -111,7 +113,7 @@ class ImplementationSelector : public CustomGraphOptimizer {
  private:
   absl::Status LoadFunctions(const GraphDef& graph);
   absl::Status MaybeOptimizeFunctionCall(
-      utils::MutableNodeView* node_view) const;
+      const Cluster* cluster, utils::MutableNodeView* node_view) const;
 
   // Finds all call sites for functions, then replace with the appropriate
   // implementation.
@@ -124,7 +126,8 @@ class ImplementationSelector : public CustomGraphOptimizer {
   // may call into another function, so a function might have to be duplicated.
   // For simplicity, we do not change function bodies. Also, we do not change
   // gradients.
-  absl::Status SelectImplementation(GraphDef* graph) const;
+  absl::Status SelectImplementation(
+      const Cluster* cluster, GraphDef* graph) const;
 
   // Rewrites the DeviceIndex op with a Const op with value of the index of the
   // device the associcated Case op runs.

--- a/tensorflow/core/grappler/optimizers/meta_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.cc
@@ -1228,6 +1228,10 @@ absl::Status MetaOptimizer::OptimizeConsumeItem(Cluster* cluster,
       func_item.optimization_options().allow_pruning_stateful_and_dataset_ops =
           false;
 
+      // ImplementationSelector needs whole library when optimizing each
+      // function body graph.
+      *func_item.graph.mutable_library() = flib.ToProto();
+
       // Optimize function body graph.
       GraphDef optimized_func_graph;
       if (is_tpu_graph) {


### PR DESCRIPTION
If I save tf.keras.layers.LSTM layer with _could_use_gpu_kernel=True into the SavedModel format with tf.saved_model.save, then cuDNN kernel is used when I load this model with tf.saved_model.load and it works fast. But if I load this model from C++ with tensorflow::LoadSavedModel function, then cuDNN kernel isn't used and it is slow.

Here is colab demonstrating the issue https://colab.research.google.com/drive/16WN0sqOoL37M7-5XMhGb-irkRX7fh503?usp=sharing . If model is loaded with tf.saved_model.load, then tf.keras.layers.LSTM and tf.raw_ops.CudnnLSTM layers both takes about 100 ms. But if model is loaded with LoadSavedModel from C++, then tf.keras.layers.LSTM takes about 275 ms, while tf.raw_ops.CudnnLSTM takes 100 ms.

There were some problems in FunctionOptimizer, ImplementationSelector and MetaOptimizer optimizers:
1. When FunctionOptimizer specialized some function, it copied api_implements from origin function to specialization. It caused  an error "Function ... and ... both implment 'interface_name' but their signatures do not match" in FunctionLibraryApiInfo::Init
2. MetaOptimizer didn't pass whole FunctionDefLibrary along with a body of single function, which is needed for implementation selection.
3. ImplementationSelector couldn't parse empty device name if it isn't specified on a node.