### PR TITLE
Fix filter shape checking in grappler remapping pass

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -429,10 +429,10 @@ bool IsGpuCompatible(const RemapperContext& ctx,
     // in-graph computation in micro benchmarks (see kernels/conv_ops_test.cc),
     // and significantly slower in large scale benchmarks.
     bool is_spatial_conv = Rank(filter_shape) == 4 &&          //
+                           IsKnown(filter_shape.dim(0)) &&     //
                            IsKnown(filter_shape.dim(1)) &&     //
-                           IsKnown(filter_shape.dim(2)) &&     //
-                           filter_shape.dim(1).size() != 1 &&  //
-                           filter_shape.dim(2).size() != 1;
+                           filter_shape.dim(0).size() != 1 &&  //
+                           filter_shape.dim(1).size() != 1;
 
     return is_spatial_conv && IsGpuCompatibleConv2D(ctx, &contraction_node);
   } else if (IsMatMul(contraction_node)) {


### PR DESCRIPTION
This PR fixes the way the grappler remapping checks the filter shape. The code was intended to check the 1x1 convolution, which should be `filter_shape.dim(0)` and `filter_shape.dim(1)`, since the filter shape is in the format of `[filter_height, filter_width, in_channels, out_channels]`.

cc @nluehr 