### PR TITLE
[Tensorflow Lite] GPU selection support on Desktop

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -517,6 +517,7 @@ target_link_libraries(tensorflow-lite
     absl::flags
     absl::hash
     absl::status
+    absl::statusor
     absl::strings
     absl::synchronization
     absl::variant

--- a/tensorflow/lite/delegates/gpu/cl/cl_device.cc
+++ b/tensorflow/lite/delegates/gpu/cl/cl_device.cc
@@ -342,17 +342,17 @@ void CLDevice::DisableOneLayerTextureArray() {
 
 absl::Status CreateDefaultGPUDevice(CLDevice* result) {
 
-  auto [status_platform, platforms] = GetOpenCLPlatforms();
-  if(!status_platform.ok())
-    return status_platform;
+  auto platforms = GetOpenCLPlatforms();
+  if(!platforms.ok())
+    return platforms.status();
 
-  cl_platform_id platform_id = platforms[0];
+  cl_platform_id platform_id = (*platforms)[0];
 
-  auto [status_device, devices] = GetOpenCLDevicesForPlatform(platform_id);
-  if(!status_device.ok())
-    return status_device;
+  auto devices = GetOpenCLDevicesForPlatform(platform_id);
+  if(!devices.ok())
+    return devices.status();
 
-  *result = CLDevice(devices[0], platform_id);
+  *result = CLDevice((*devices)[0], platform_id);
   return absl::OkStatus();
 }
 

--- a/tensorflow/lite/delegates/gpu/cl/cl_device.cc
+++ b/tensorflow/lite/delegates/gpu/cl/cl_device.cc
@@ -341,16 +341,13 @@ void CLDevice::DisableOneLayerTextureArray() {
 }
 
 absl::Status CreateDefaultGPUDevice(CLDevice* result) {
-
   auto platforms = GetOpenCLPlatforms();
-  if(!platforms.ok())
-    return platforms.status();
+  if (!platforms.ok()) return platforms.status();
 
   cl_platform_id platform_id = (*platforms)[0];
 
   auto devices = GetOpenCLDevicesForPlatform(platform_id);
-  if(!devices.ok())
-    return devices.status();
+  if (!devices.ok()) return devices.status();
 
   *result = CLDevice((*devices)[0], platform_id);
   return absl::OkStatus();

--- a/tensorflow/lite/delegates/gpu/cl/util.cc
+++ b/tensorflow/lite/delegates/gpu/cl/util.cc
@@ -178,44 +178,45 @@ int ChannelTypeToSizeInBytes(cl_channel_type type) {
 
 bool OpenCLSupported() { return LoadOpenCL().ok(); }
 
-absl::optional<cl_platform_id> FindPlatformByVendor(std::vector<cl_platform_id> const& platform_ids, std::string const& vendor_id) {
-
+absl::optional<cl_platform_id> FindPlatformByVendor(
+    std::vector<cl_platform_id> const& platform_ids,
+    std::string const& vendor_id) {
   auto tolower = [](std::string const& original) {
     std::string str_copy = original;
     std::transform(str_copy.begin(), str_copy.end(), str_copy.begin(),
-      [](unsigned char c){ return std::tolower(c); });
+                   [](unsigned char c) { return std::tolower(c); });
     return str_copy;
   };
 
-  auto get_platform_info = [](std::vector<cl_platform_id> const& platform_ids, cl_platform_info info) {
+  auto get_platform_info = [](std::vector<cl_platform_id> const& platform_ids,
+                              cl_platform_info info) {
     std::vector<std::string> prop(platform_ids.size());
-    std::transform(platform_ids.begin(), platform_ids.end(), prop.begin(), 
-      [info](cl_platform_id id) {
-        return GetPlatformInfo(id, info);
-      }
-    );
+    std::transform(
+        platform_ids.begin(), platform_ids.end(), prop.begin(),
+        [info](cl_platform_id id) { return GetPlatformInfo(id, info); });
     return prop;
   };
 
-  auto find_platform_by_vendor = [&](std::vector<std::string> const& candidates) -> absl::optional<cl_platform_id> {
-    auto it = std::find_if(candidates.begin(), candidates.end(), 
-      [&](std::string const& candidate) {
-        if (tolower(candidate).find(vendor_id) == std::string::npos)
-          return false;
-        return true;
-      }
-    );
-    
-    if(it == candidates.end())
-      return {};
+  auto find_platform_by_vendor = [&](std::vector<std::string> const& candidates)
+      -> absl::optional<cl_platform_id> {
+    auto it = std::find_if(
+        candidates.begin(), candidates.end(),
+        [&](std::string const& candidate) {
+          if (tolower(candidate).find(vendor_id) == std::string::npos)
+            return false;
+          return true;
+        });
+
+    if (it == candidates.end()) return {};
     return platform_ids[std::distance(candidates.begin(), it)];
   };
 
-  auto platform_id_maybe = find_platform_by_vendor(get_platform_info(platform_ids, CL_PLATFORM_VENDOR));
-  if(platform_id_maybe.has_value())
-    return platform_id_maybe;
-  
-  return find_platform_by_vendor(get_platform_info(platform_ids, CL_PLATFORM_NAME));
+  auto platform_id_maybe = find_platform_by_vendor(
+      get_platform_info(platform_ids, CL_PLATFORM_VENDOR));
+  if (platform_id_maybe.has_value()) return platform_id_maybe;
+
+  return find_platform_by_vendor(
+      get_platform_info(platform_ids, CL_PLATFORM_NAME));
 }
 
 std::string GetPlatformInfo(cl_platform_id id, cl_platform_info info) {
@@ -237,7 +238,8 @@ absl::StatusOr<std::vector<cl_platform_id>> GetOpenCLPlatforms() {
   cl_uint num_platforms;
   cl_int status = clGetPlatformIDs(0, nullptr, &num_platforms);
   if (status != CL_SUCCESS) {
-    return absl::UnknownError(absl::StrFormat("clGetPlatformIDs returned %d", status));
+    return absl::UnknownError(
+        absl::StrFormat("clGetPlatformIDs returned %d", status));
   }
   if (num_platforms == 0) {
     return absl::UnknownError("No supported OpenCL platform.");
@@ -245,18 +247,21 @@ absl::StatusOr<std::vector<cl_platform_id>> GetOpenCLPlatforms() {
   std::vector<cl_platform_id> platforms(num_platforms);
   status = clGetPlatformIDs(num_platforms, platforms.data(), nullptr);
   if (status != CL_SUCCESS) {
-    return absl::UnknownError(absl::StrFormat("clGetPlatformIDs returned %d", status));
+    return absl::UnknownError(
+        absl::StrFormat("clGetPlatformIDs returned %d", status));
   }
 
   return platforms;
 }
 
-absl::StatusOr<std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(cl_platform_id platform_id) {
+absl::StatusOr<std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(
+    cl_platform_id platform_id) {
   cl_uint num_devices;
   cl_int status =
       clGetDeviceIDs(platform_id, CL_DEVICE_TYPE_GPU, 0, nullptr, &num_devices);
   if (status != CL_SUCCESS) {
-    return absl::UnknownError(absl::StrFormat("clGetDeviceIDs returned %d", status));
+    return absl::UnknownError(
+        absl::StrFormat("clGetDeviceIDs returned %d", status));
   }
   if (num_devices == 0) {
     return absl::UnknownError("No GPU on current platform.");
@@ -266,7 +271,8 @@ absl::StatusOr<std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(cl_platfor
   status = clGetDeviceIDs(platform_id, CL_DEVICE_TYPE_GPU, num_devices,
                           devices.data(), nullptr);
   if (status != CL_SUCCESS) {
-    return absl::UnknownError(absl::StrFormat("clGetDeviceIDs returned %d", status));
+    return absl::UnknownError(
+        absl::StrFormat("clGetDeviceIDs returned %d", status));
   }
 
   return devices;

--- a/tensorflow/lite/delegates/gpu/cl/util.cc
+++ b/tensorflow/lite/delegates/gpu/cl/util.cc
@@ -15,9 +15,6 @@ limitations under the License.
 
 #include "tensorflow/lite/delegates/gpu/cl/util.h"
 
-#include <string>
-
-#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "tensorflow/lite/delegates/gpu/common/status.h"
@@ -251,7 +248,7 @@ absl::StatusOr<std::vector<cl_platform_id>> GetOpenCLPlatforms() {
         absl::StrFormat("clGetPlatformIDs returned %d", status));
   }
 
-  return platforms;
+  return std::move(platforms);
 }
 
 absl::StatusOr<std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(
@@ -275,7 +272,7 @@ absl::StatusOr<std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(
         absl::StrFormat("clGetDeviceIDs returned %d", status));
   }
 
-  return devices;
+  return std::move(devices);
 }
 
 absl::Status CreateCLBuffer(cl_context context, int size_in_bytes,

--- a/tensorflow/lite/delegates/gpu/cl/util.cc
+++ b/tensorflow/lite/delegates/gpu/cl/util.cc
@@ -233,47 +233,43 @@ std::string GetPlatformInfo(cl_platform_id id, cl_platform_info info) {
   return result;
 }
 
-std::pair<absl::Status, std::vector<cl_platform_id>> GetOpenCLPlatforms() {
+absl::StatusOr<std::vector<cl_platform_id>> GetOpenCLPlatforms() {
   cl_uint num_platforms;
   cl_int status = clGetPlatformIDs(0, nullptr, &num_platforms);
   if (status != CL_SUCCESS) {
-    return {absl::UnknownError(
-        absl::StrFormat("clGetPlatformIDs returned %d", status)), {}};
+    return absl::UnknownError(absl::StrFormat("clGetPlatformIDs returned %d", status));
   }
   if (num_platforms == 0) {
-    return {absl::UnknownError("No supported OpenCL platform."), {}};
+    return absl::UnknownError("No supported OpenCL platform.");
   }
   std::vector<cl_platform_id> platforms(num_platforms);
   status = clGetPlatformIDs(num_platforms, platforms.data(), nullptr);
   if (status != CL_SUCCESS) {
-    return {absl::UnknownError(
-        absl::StrFormat("clGetPlatformIDs returned %d", status)), {}};
+    return absl::UnknownError(absl::StrFormat("clGetPlatformIDs returned %d", status));
   }
 
-  return {absl::OkStatus(), platforms};
+  return platforms;
 }
 
-std::pair<absl::Status, std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(cl_platform_id platform_id) {
+absl::StatusOr<std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(cl_platform_id platform_id) {
   cl_uint num_devices;
   cl_int status =
       clGetDeviceIDs(platform_id, CL_DEVICE_TYPE_GPU, 0, nullptr, &num_devices);
   if (status != CL_SUCCESS) {
-    return {absl::UnknownError(
-        absl::StrFormat("clGetDeviceIDs returned %d", status)),{}};
+    return absl::UnknownError(absl::StrFormat("clGetDeviceIDs returned %d", status));
   }
   if (num_devices == 0) {
-    return {absl::UnknownError("No GPU on current platform."), {}};
+    return absl::UnknownError("No GPU on current platform.");
   }
 
   std::vector<cl_device_id> devices(num_devices);
   status = clGetDeviceIDs(platform_id, CL_DEVICE_TYPE_GPU, num_devices,
                           devices.data(), nullptr);
   if (status != CL_SUCCESS) {
-    return {absl::UnknownError(
-        absl::StrFormat("clGetDeviceIDs returned %d", status)), {}};
+    return absl::UnknownError(absl::StrFormat("clGetDeviceIDs returned %d", status));
   }
 
-  return {absl::OkStatus(), devices};
+  return devices;
 }
 
 absl::Status CreateCLBuffer(cl_context context, int size_in_bytes,

--- a/tensorflow/lite/delegates/gpu/cl/util.h
+++ b/tensorflow/lite/delegates/gpu/cl/util.h
@@ -17,8 +17,9 @@ limitations under the License.
 #define TENSORFLOW_LITE_DELEGATES_GPU_CL_UTIL_H_
 
 #include <string>
-
+#include <utility>
 #include "absl/types/span.h"
+#include "absl/types/optional.h"
 #include "tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h"
 #include "tensorflow/lite/delegates/gpu/common/data_type.h"
 #include "tensorflow/lite/delegates/gpu/common/status.h"
@@ -59,6 +60,22 @@ absl::Status CreateCLSubBuffer(cl_context context, cl_mem parent,
 absl::Status CreateRGBAImage2D(cl_context context, int width, int height,
                                cl_channel_type channel_type, void* data,
                                cl_mem* result);
+
+std::pair<absl::Status, std::vector<cl_platform_id>> GetOpenCLPlatforms();
+std::pair<absl::Status, std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(cl_platform_id);
+
+template <typename T>
+T GetPlatformInfo(cl_platform_id id, cl_platform_info info) {
+  T result;
+  cl_int error = clGetPlatformInfo(id, info, sizeof(T), &result, nullptr);
+  if (error != CL_SUCCESS) {
+    return -1;
+  }
+  return result;
+}
+
+std::string GetPlatformInfo(cl_platform_id id, cl_platform_info info);
+absl::optional<cl_platform_id> FindPlatformByVendor(std::vector<cl_platform_id> const& platform_ids, std::string const& vendor_id);
 }  // namespace cl
 }  // namespace gpu
 }  // namespace tflite

--- a/tensorflow/lite/delegates/gpu/cl/util.h
+++ b/tensorflow/lite/delegates/gpu/cl/util.h
@@ -61,8 +61,8 @@ absl::Status CreateRGBAImage2D(cl_context context, int width, int height,
                                cl_channel_type channel_type, void* data,
                                cl_mem* result);
 
-std::pair<absl::Status, std::vector<cl_platform_id>> GetOpenCLPlatforms();
-std::pair<absl::Status, std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(cl_platform_id);
+absl::StatusOr<std::vector<cl_platform_id>> GetOpenCLPlatforms();
+absl::StatusOr<std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(cl_platform_id);
 
 template <typename T>
 T GetPlatformInfo(cl_platform_id id, cl_platform_info info) {

--- a/tensorflow/lite/delegates/gpu/cl/util.h
+++ b/tensorflow/lite/delegates/gpu/cl/util.h
@@ -17,8 +17,6 @@ limitations under the License.
 #define TENSORFLOW_LITE_DELEGATES_GPU_CL_UTIL_H_
 
 #include <string>
-#include <utility>
-
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include "tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h"

--- a/tensorflow/lite/delegates/gpu/cl/util.h
+++ b/tensorflow/lite/delegates/gpu/cl/util.h
@@ -18,8 +18,9 @@ limitations under the License.
 
 #include <string>
 #include <utility>
-#include "absl/types/span.h"
+
 #include "absl/types/optional.h"
+#include "absl/types/span.h"
 #include "tensorflow/lite/delegates/gpu/cl/opencl_wrapper.h"
 #include "tensorflow/lite/delegates/gpu/common/data_type.h"
 #include "tensorflow/lite/delegates/gpu/common/status.h"
@@ -62,7 +63,8 @@ absl::Status CreateRGBAImage2D(cl_context context, int width, int height,
                                cl_mem* result);
 
 absl::StatusOr<std::vector<cl_platform_id>> GetOpenCLPlatforms();
-absl::StatusOr<std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(cl_platform_id);
+absl::StatusOr<std::vector<cl_device_id>> GetOpenCLDevicesForPlatform(
+    cl_platform_id);
 
 template <typename T>
 T GetPlatformInfo(cl_platform_id id, cl_platform_info info) {
@@ -75,7 +77,9 @@ T GetPlatformInfo(cl_platform_id id, cl_platform_info info) {
 }
 
 std::string GetPlatformInfo(cl_platform_id id, cl_platform_info info);
-absl::optional<cl_platform_id> FindPlatformByVendor(std::vector<cl_platform_id> const& platform_ids, std::string const& vendor_id);
+absl::optional<cl_platform_id> FindPlatformByVendor(
+    std::vector<cl_platform_id> const& platform_ids,
+    std::string const& vendor_id);
 }  // namespace cl
 }  // namespace gpu
 }  // namespace tflite

--- a/tensorflow/lite/delegates/gpu/common/status.h
+++ b/tensorflow/lite/delegates/gpu/common/status.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_LITE_DELEGATES_GPU_COMMON_STATUS_H_
 
 #include "absl/status/status.h"  // IWYU pragma: export
+#include "absl/status/statusor.h"
 #include "tensorflow/lite/delegates/gpu/common/google/status_macros.h"  // IWYU pragma: export
 
 #endif  // TENSORFLOW_LITE_DELEGATES_GPU_COMMON_STATUS_H_

--- a/tensorflow/lite/delegates/gpu/delegate.cc
+++ b/tensorflow/lite/delegates/gpu/delegate.cc
@@ -336,38 +336,41 @@ class DelegateKernel {
     return absl::OkStatus();
   }
 
-  static absl::StatusOr<cl_device_id> GetDeviceFor(TargeCLDeviceVendor vendor_enum, int32_t device_ordinal) {
-      std::string vendor_string = [](auto vendor_enum) {
-        switch(vendor_enum) {
-          case NVIDIA:
-            return "nvidia";
-          case AMD:
-            return "amd";
-          case INTEL:
-            return "intel";
-          default:
-            return "";
-        }
-      }(vendor_enum);
+  static absl::StatusOr<cl_device_id> GetDeviceFor(
+      TargeCLDeviceVendor vendor_enum, int32_t device_ordinal) {
+    std::string vendor_string = [](auto vendor_enum) {
+      switch (vendor_enum) {
+        case NVIDIA:
+          return "nvidia";
+        case AMD:
+          return "amd";
+        case INTEL:
+          return "intel";
+        default:
+          return "";
+      }
+    }(vendor_enum);
 
-      if(vendor_string.empty())
-        return absl::UnknownError("Specified GPU vendor is unknown");
+    if (vendor_string.empty())
+      return absl::UnknownError("Specified GPU vendor is unknown");
 
-      auto platform_ids = tflite::gpu::cl::GetOpenCLPlatforms();
-      if(!platform_ids.ok())
-        return platform_ids.status();
-      auto platform_id_maybe = tflite::gpu::cl::FindPlatformByVendor(*platform_ids, vendor_string);
-      if(!platform_id_maybe.has_value())
-        return absl::UnknownError("Specified GPU vendor is not supported on current machine");
+    auto platform_ids = tflite::gpu::cl::GetOpenCLPlatforms();
+    if (!platform_ids.ok()) return platform_ids.status();
+    auto platform_id_maybe =
+        tflite::gpu::cl::FindPlatformByVendor(*platform_ids, vendor_string);
+    if (!platform_id_maybe.has_value())
+      return absl::UnknownError(
+          "Specified GPU vendor is not supported on current machine");
 
-      auto device_ids = tflite::gpu::cl::GetOpenCLDevicesForPlatform(platform_id_maybe.value());
-      if(!device_ids.ok())
-        return device_ids.status();
+    auto device_ids =
+        tflite::gpu::cl::GetOpenCLDevicesForPlatform(platform_id_maybe.value());
+    if (!device_ids.ok()) return device_ids.status();
 
-      if(device_ids->size() <= device_ordinal)
-        return absl::UnknownError("Specified device ordinal exceeds number of availabe GPUs");
+    if (device_ids->size() <= device_ordinal)
+      return absl::UnknownError(
+          "Specified device ordinal exceeds number of availabe GPUs");
 
-      return (*device_ids)[device_ordinal];
+    return (*device_ids)[device_ordinal];
   }
 
   absl::Status InitializeOpenClApi(GraphFloat32* graph,
@@ -399,10 +402,11 @@ class DelegateKernel {
     }
     options.usage = ToUsage(delegate_options.inference_preference);
 
-    if(delegate_options.target_vendor != DONTCARE && delegate_options.target_gpu_ordinal >= 0) {
-      auto dev_id = GetDeviceFor(delegate_options.target_vendor, delegate_options.target_gpu_ordinal);
-      if(!dev_id.ok())
-        return dev_id.status();
+    if (delegate_options.target_vendor != DONTCARE &&
+        delegate_options.target_gpu_ordinal >= 0) {
+      auto dev_id = GetDeviceFor(delegate_options.target_vendor,
+                                 delegate_options.target_gpu_ordinal);
+      if (!dev_id.ok()) return dev_id.status();
       env_options.device = *dev_id;
     }
 

--- a/tensorflow/lite/delegates/gpu/delegate.cc
+++ b/tensorflow/lite/delegates/gpu/delegate.cc
@@ -336,7 +336,7 @@ class DelegateKernel {
     return absl::OkStatus();
   }
 
-  static std::pair<absl::Status, cl_device_id> GetDeviceFor(GPUVendor vendor_enum, int32_t device_ordinal) {
+  static std::pair<absl::Status, cl_device_id> GetDeviceFor(TargeCLDeviceVendor vendor_enum, int32_t device_ordinal) {
       std::string vendor_string = [](auto vendor_enum) {
         switch(vendor_enum) {
           case NVIDIA:

--- a/tensorflow/lite/delegates/gpu/delegate.h
+++ b/tensorflow/lite/delegates/gpu/delegate.h
@@ -68,6 +68,16 @@ enum TfLiteGpuExperimentalFlags {
   TFLITE_GPU_EXPERIMENTAL_FLAGS_ENABLE_SERIALIZATION = 1 << 3,
 };
 
+//Used to select which GPU to run inference on.
+//On mobile devices, specify DONTCARE so that the 0th device on 
+//0th OpenCL platform is selected. 
+enum GPUVendor {
+  DONTCARE,
+  NVIDIA,
+  AMD,
+  INTEL
+};
+
 // IMPORTANT: Always use TfLiteGpuDelegateOptionsV2Default() method to create
 // new instance of TfLiteGpuDelegateOptionsV2, otherwise every new added option
 // may break inference.
@@ -131,6 +141,17 @@ typedef struct {
   // Set to nullptr in TfLiteGpuDelegateOptionsV2Default(), which implies the
   // delegate will not try serialization.
   const char* model_token;
+
+  //Used to select which GPU to run inference on.
+  //On mobile devices, specify DONTCARE so that the 0th device on 
+  //0th OpenCL platform is selected. 
+  //On desktop environment, 'vendor' can be used in conjunction with
+  //'gpu_ordinal' if multiple GPUs are present. For example, if the
+  //computer has 3 NVidia GPUs and 3 Intel GPUs, set vendor = INTEL
+  //and gpu_ordinal = 2 (0 indexed) to use the 2nd Intel GPU. 
+  GPUVendor target_vendor = DONTCARE;
+  int32_t target_gpu_ordinal = -1;
+
 } TfLiteGpuDelegateOptionsV2;
 
 // Populates TfLiteGpuDelegateOptionsV2 as follows:

--- a/tensorflow/lite/delegates/gpu/delegate.h
+++ b/tensorflow/lite/delegates/gpu/delegate.h
@@ -71,7 +71,7 @@ enum TfLiteGpuExperimentalFlags {
 //Used to select which GPU to run inference on.
 //On mobile devices, specify DONTCARE so that the 0th device on 
 //0th OpenCL platform is selected. 
-enum GPUVendor {
+enum TargeCLDeviceVendor {
   DONTCARE,
   NVIDIA,
   AMD,
@@ -149,7 +149,7 @@ typedef struct {
   //'gpu_ordinal' if multiple GPUs are present. For example, if the
   //computer has 3 NVidia GPUs and 3 Intel GPUs, set vendor = INTEL
   //and gpu_ordinal = 2 (0 indexed) to use the 2nd Intel GPU. 
-  GPUVendor target_vendor = DONTCARE;
+  TargeCLDeviceVendor target_vendor = DONTCARE;
   int32_t target_gpu_ordinal = -1;
 
 } TfLiteGpuDelegateOptionsV2;

--- a/tensorflow/lite/delegates/gpu/delegate.h
+++ b/tensorflow/lite/delegates/gpu/delegate.h
@@ -145,10 +145,10 @@ typedef struct {
   //Used to select which GPU to run inference on.
   //On mobile devices, specify DONTCARE so that the 0th device on 
   //0th OpenCL platform is selected. 
-  //On desktop environment, 'vendor' can be used in conjunction with
-  //'gpu_ordinal' if multiple GPUs are present. For example, if the
-  //computer has 3 NVidia GPUs and 3 Intel GPUs, set vendor = INTEL
-  //and gpu_ordinal = 2 (0 indexed) to use the 2nd Intel GPU. 
+  //On desktop environment, 'target_vendor' can be used in conjunction with
+  //'target_gpu_ordinal' if multiple GPUs are present. For example, if the
+  //computer has 3 NVidia GPUs and 3 Intel GPUs, set target_vendor = INTEL
+  //and target_gpu_ordinal = 2 (0 indexed) to use the 2nd Intel GPU. 
   TargeCLDeviceVendor target_vendor = DONTCARE;
   int32_t target_gpu_ordinal = -1;
 

--- a/tensorflow/lite/delegates/gpu/delegate.h
+++ b/tensorflow/lite/delegates/gpu/delegate.h
@@ -68,15 +68,10 @@ enum TfLiteGpuExperimentalFlags {
   TFLITE_GPU_EXPERIMENTAL_FLAGS_ENABLE_SERIALIZATION = 1 << 3,
 };
 
-//Used to select which GPU to run inference on.
-//On mobile devices, specify DONTCARE so that the 0th device on 
-//0th OpenCL platform is selected. 
-enum TargeCLDeviceVendor {
-  DONTCARE,
-  NVIDIA,
-  AMD,
-  INTEL
-};
+// Used to select which GPU to run inference on.
+// On mobile devices, specify DONTCARE so that the 0th device on
+// 0th OpenCL platform is selected.
+enum TargeCLDeviceVendor { DONTCARE, NVIDIA, AMD, INTEL };
 
 // IMPORTANT: Always use TfLiteGpuDelegateOptionsV2Default() method to create
 // new instance of TfLiteGpuDelegateOptionsV2, otherwise every new added option
@@ -142,13 +137,13 @@ typedef struct {
   // delegate will not try serialization.
   const char* model_token;
 
-  //Used to select which GPU to run inference on.
-  //On mobile devices, specify DONTCARE so that the 0th device on 
-  //0th OpenCL platform is selected. 
-  //On desktop environment, 'target_vendor' can be used in conjunction with
+  // Used to select which GPU to run inference on.
+  // On mobile devices, specify DONTCARE so that the 0th device on
+  // 0th OpenCL platform is selected.
+  // On desktop environment, 'target_vendor' can be used in conjunction with
   //'target_gpu_ordinal' if multiple GPUs are present. For example, if the
-  //computer has 3 NVidia GPUs and 3 Intel GPUs, set target_vendor = INTEL
-  //and target_gpu_ordinal = 2 (0 indexed) to use the 2nd Intel GPU. 
+  // computer has 3 NVidia GPUs and 3 Intel GPUs, set target_vendor = INTEL
+  // and target_gpu_ordinal = 2 (0 indexed) to use the 2nd Intel GPU.
   TargeCLDeviceVendor target_vendor = DONTCARE;
   int32_t target_gpu_ordinal = -1;
 


### PR DESCRIPTION
Adding the ability to select between multiple available GPUs (usually on Desktop environment) for running inference with the OpenCL delegate. By default, if the user does not specify a preference, OpenCL device 0 on platform 0 is still picked by default, so as to not break things on mobile devices where typically only a single OpenCL capable device is available.