### PR TITLE
[intel windows] Revert "Introduce a "StatusOr<bool> FileExists" helper, to help code …

### DIFF
--- a/tensorflow/cc/saved_model/loader.cc
+++ b/tensorflow/cc/saved_model/loader.cc
@@ -34,8 +34,6 @@ limitations under the License.
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/errors.h"
-#include "tensorflow/core/platform/file_system_helper.h"
-#include "tensorflow/core/platform/statusor.h"
 #include "tensorflow/core/protobuf/graph_debug_info.pb.h"
 #include "tensorflow/core/protobuf/meta_graph.pb.h"
 #include "tensorflow/core/protobuf/saver.pb.h"
@@ -235,10 +233,7 @@ Status RunRestore(const RunOptions& run_options, const string& export_dir,
   // variables are stored in the variables.data-?????-of-????? files.
   const string variables_index_path = io::JoinPath(
       variables_directory, MetaFilename(kSavedModelVariablesFilename));
-  TF_ASSIGN_OR_RETURN(
-      bool variables_index_exists,
-      internal::FileExists(Env::Default(), variables_index_path));
-  if (!variables_index_exists) {
+  if (!Env::Default()->FileExists(variables_index_path).ok()) {
     LOG(INFO) << "The specified SavedModel has no variables; no checkpoints "
                  "were restored. File does not exist: "
               << variables_index_path;

--- a/tensorflow/cc/saved_model/reader.cc
+++ b/tensorflow/cc/saved_model/reader.cc
@@ -30,8 +30,6 @@ limitations under the License.
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/lib/strings/strcat.h"
 #include "tensorflow/core/platform/env.h"
-#include "tensorflow/core/platform/file_system_helper.h"
-#include "tensorflow/core/platform/statusor.h"
 #include "tensorflow/core/protobuf/saved_model.pb.h"
 #include "tensorflow/core/util/tensor_bundle/byte_swap.h"
 
@@ -47,10 +45,7 @@ Status ReadSavedModel(absl::string_view export_dir,
   const std::string saved_model_pb_path =
       io::JoinPath(export_dir, kSavedModelFilenamePb);
 
-  TF_ASSIGN_OR_RETURN(
-      bool saved_model_pb_exists,
-      internal::FileExists(Env::Default(), saved_model_pb_path));
-  if (saved_model_pb_exists) {
+  if (Env::Default()->FileExists(saved_model_pb_path).ok()) {
     Status result =
         ReadBinaryProto(Env::Default(), saved_model_pb_path, saved_model_proto);
     if (result.ok()) {
@@ -61,10 +56,7 @@ Status ReadSavedModel(absl::string_view export_dir,
   }
   const std::string saved_model_pbtxt_path =
       io::JoinPath(export_dir, kSavedModelFilenamePbTxt);
-  TF_ASSIGN_OR_RETURN(
-      bool saved_model_pbtxt_exists,
-      internal::FileExists(Env::Default(), saved_model_pbtxt_path));
-  if (saved_model_pbtxt_exists) {
+  if (Env::Default()->FileExists(saved_model_pbtxt_path).ok()) {
     Status result = ReadTextProto(Env::Default(), saved_model_pbtxt_path,
                                   saved_model_proto);
     if (result.ok()) {
@@ -132,9 +124,7 @@ Status ReadSavedModelDebugInfoIfPresent(
 
   const string debug_info_pb_path =
       io::JoinPath(export_dir, "debug", "saved_model_debug_info.pb");
-  TF_ASSIGN_OR_RETURN(bool debug_info_pb_exists,
-                      internal::FileExists(Env::Default(), debug_info_pb_path));
-  if (debug_info_pb_exists) {
+  if (Env::Default()->FileExists(debug_info_pb_path).ok()) {
     GraphDebugInfo debug_info;
     TF_RETURN_IF_ERROR(
         ReadBinaryProto(Env::Default(), debug_info_pb_path, &debug_info));

--- a/tensorflow/core/platform/default/BUILD
+++ b/tensorflow/core/platform/default/BUILD
@@ -116,7 +116,6 @@ cc_library(
         "//tensorflow/core/platform:scanner",
         "//tensorflow/core/platform:setround",
         "//tensorflow/core/platform:status",
-        "//tensorflow/core/platform:statusor",
         "//tensorflow/core/platform:str_util",
         "//tensorflow/core/platform:strcat",
         "//tensorflow/core/platform:stringpiece",

--- a/tensorflow/core/platform/file_system_helper.cc
+++ b/tensorflow/core/platform/file_system_helper.cc
@@ -21,7 +21,6 @@ limitations under the License.
 
 #include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/platform/env.h"
-#include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/platform/file_system.h"
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/path.h"
@@ -264,15 +263,6 @@ Status GetMatchingPaths(FileSystem* fs, Env* env, const string& pattern,
   }
 
   return OkStatus();
-}
-
-StatusOr<bool> FileExists(Env* env, const string& fname) {
-  Status status = env->FileExists(fname);
-  if (errors::IsNotFound(status)) {
-    return false;
-  }
-  TF_RETURN_IF_ERROR(status);
-  return true;
 }
 
 }  // namespace internal

--- a/tensorflow/core/platform/file_system_helper.h
+++ b/tensorflow/core/platform/file_system_helper.h
@@ -19,9 +19,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/status.h"
-#include "tensorflow/core/platform/statusor.h"
 
 namespace tensorflow {
 
@@ -46,17 +44,6 @@ namespace internal {
 // Returns an error status if any call to 'fs' failed.
 Status GetMatchingPaths(FileSystem* fs, Env* env, const string& pattern,
                         std::vector<string>* results);
-
-// Given a file path, determines whether the file exists. This helper simplifies
-// the use of Env::FileExists.
-//
-// Arguments:
-//   env: may not be null.
-//   fname: the file path to look up
-//
-// Returns true if the file exists, false if it does not exist, or an error
-// Status.
-StatusOr<bool> FileExists(Env* env, const string& fname);
 
 }  // namespace internal
 }  // namespace tensorflow


### PR DESCRIPTION
…distinguish between "file does not exist" and "some other error"."

This reverts commit f19b0ba5fe619b8382166e1e7bd4bcbbbbe49601.
It was causing following build error:
ERROR: C:/jenkins/workspace/tf-test-win2/tensorflow/tensorflow/core/platform/windows/BUILD:20:11: Compiling tensorflow/core/platform/file_system_helper.cc failed: undeclared inclusion(s) in rule '//tensorflow/core/platform/windows:env':
this rule is missing dependency declarations for the following files included by 'tensorflow/core/platform/file_system_helper.cc':
  'tensorflow/core/platform/statusor.h'
  'tensorflow/core/platform/statusor_internals.h'
cl : Command line warning D9035 : option 'experimental:preprocessor' has been deprecated and will be removed in a future release
cl : Command line warning D9036 : use 'Zc:preprocessor' instead of 'experimental:preprocessor'
cl : Command line warning D9002 : ignoring unknown option '/arch=AVX'
Target //tensorflow/tools/pip_package:build_pip_package failed to build
INFO: Elapsed time: 99.060s, Critical Path: 46.30s
INFO: 945 processes: 33 internal, 912 local.
FAILED: Build did NOT complete successfully