### PR TITLE
[MLIR/XLA] not lowering tf.Reshape with non-HLOTensorType, like tf_ty…

### DIFF
--- a/tensorflow/compiler/mlir/xla/tests/legalize-tf.mlir
+++ b/tensorflow/compiler/mlir/xla/tests/legalize-tf.mlir
@@ -3029,6 +3029,15 @@ func.func @reshape(%arg0: tensor<2xf32>, %arg1: tensor<2xi32>) -> tensor<2x1xf32
 
 // -----
 
+// CHECK-LABEL: not_lowering_reshape
+func.func @not_lowering_reshape(%arg0: tensor<!tf_type.string>, %arg1: tensor<1xi32>) -> tensor<1x!tf_type.string> {
+  // CHECK:  "tf.Reshape"
+  %0 = "tf.Reshape"(%arg0, %arg1) : (tensor<!tf_type.string>, tensor<1xi32>) -> tensor<1x!tf_type.string>
+  func.return %0 : tensor<1x!tf_type.string>
+}
+
+// -----
+
 // CHECK-LABEL: reshape_dynamic
 func.func @reshape_dynamic(%arg0: tensor<?xf32>, %arg1: tensor<2xi32>) -> tensor<?x?xf32> {
   // CHECK:  "chlo.dynamic_reshape"

--- a/tensorflow/compiler/mlir/xla/transforms/legalize_tf_patterns.td
+++ b/tensorflow/compiler/mlir/xla/transforms/legalize_tf_patterns.td
@@ -683,17 +683,16 @@ def : Pat<(TF_CastOp $arg, ConstBoolAttrFalse), (HLO_ConvertOp $arg)>;
 def : Pat<(TF_TransposeOp:$res $arg, (ConstantLikeMatcher ElementsAttr:$permutation)),
           (HLO_TransposeOp $arg, (CastElementsToI64Elements $permutation))>;
 
-// Result of the following ops changing tensor shape needs to have static
-// shape as HLO doesn't yet support dynamic reshaping ops.
-//
-// TODO(hinsu): Update once HLO supports dynamic reshaping ops.
+
+// Lowering these ops with static shape to mhlo.reshape
 foreach TfOp = [TF_ExpandDimsOp, TF_ReshapeOp, TF_SqueezeOp, ] in {
-  def : Pat<(TfOp:$res $arg, $ignored),
+  def : Pat<(TfOp:$res HLO_Tensor:$arg, $ignored),
             (HLO_ReshapeOp $arg), [(AnyStaticShapeTensor $res)],
             (addBenefit 2)>;
 }
 
-def : Pat<(TF_ReshapeOp:$res $arg, $shape),
+// Lowering tf.Reshape with dynamic shape
+def : Pat<(TF_ReshapeOp:$res HLO_Tensor:$arg, $shape),
           (CHLO_DynamicReshapeOp $arg, $shape)>;
 
 // Returns NaN if x is NaN, 0 if x is 0, -1 if x < 0 and 1 if x > 0.


### PR DESCRIPTION
…pe.string

* not lowering `tf.Reshape` with non-HLOTensorType, like `!tf_type.string`