### PR TITLE
Fix typo in tf.data.experimental.DistributeOptions

### DIFF
--- a/tensorflow/python/data/ops/options.py
+++ b/tensorflow/python/data/ops/options.py
@@ -267,7 +267,7 @@ class DistributeOptions(options_lib.OptionsBase):
 
   ```python
   options = tf.data.Options()
-  options.experimental_distribute.auto_shard_policy = AutoShardPolicy.OFF
+  options.experimental_distribute.auto_shard_policy = tf.data.experimental.AutoShardPolicy.OFF
   dataset = dataset.with_options(options)
   ```
   """


### PR DESCRIPTION
Updated the Example given for `tf.data.experimental.DistributeOptions`.