### PR TITLE
Fix comment typo in collective_rma_distributed.cc

### DIFF
--- a/tensorflow/core/distributed_runtime/collective_rma_distributed.cc
+++ b/tensorflow/core/distributed_runtime/collective_rma_distributed.cc
@@ -245,7 +245,7 @@ void CollectiveRemoteAccessDistributed::CheckPeerHealth(
   WorkerInterface* wi = worker_cache_->GetOrCreateWorker(peer_task);
   if (wi == nullptr) {
     done(errors::InvalidArgument(peer_task,
-                                 " not found. It's probably in valid. The "
+                                 " not found. It's probably invalid. The "
                                  "valid form is /job:xxx/replica:0/task:N"));
     return;
   }


### PR DESCRIPTION
Fixing comment: 'invalid' in place of 'in valid'.