### PR TITLE
Fix several typos and grammar mistakes 

### DIFF
--- a/tensorflow/core/util/strided_slice_op.cc
+++ b/tensorflow/core/util/strided_slice_op.cc
@@ -496,7 +496,7 @@ StridedSliceAssignBCast::StridedSliceAssignBCast(
 bool StridedSliceAssignBCast::RemapDimensions(
     int64_t num_dims, const StridedSliceAssignBCast::Vec& dimension_map) {
   // Each element in the map corresponds to the original result shape, so
-  // the the sizes must be equal.
+  // the sizes must be equal.
   if (dimension_map.size() != result_shape_.size()) {
     return false;
   }

--- a/tensorflow/core/util/strided_slice_op.h
+++ b/tensorflow/core/util/strided_slice_op.h
@@ -105,7 +105,7 @@ class StridedSliceAssignBCast {
   //
   // This is to support remapping slice -> processing dimensions.  To relate
   // the sliced output dimensions back to processing dimensions (i.e. those
-  // relative to the the original unsliced input), we need to remove any axes
+  // relative to the original unsliced input), we need to remove any axes
   // that were added via the `new_axis_mask`, and add back any axes that were
   // removed via the `shrink_axis_mask`.  For example, an expression like
   //

--- a/tensorflow/lite/g3doc/android/quickstart.md
+++ b/tensorflow/lite/g3doc/android/quickstart.md
@@ -30,7 +30,7 @@ of these tools installed:
 * Android Studio 4.2.2 or higher
 * Android SDK version 31 or higher
 
-Note: This example uses the camera, so you should runs it on a physical Android
+Note: This example uses the camera, so you should run it on a physical Android
 device.
 
 ### Get the example code
@@ -74,7 +74,7 @@ completes, the Android Studio displays a `BUILD SUCCESSFUL` message in the
 
 Note: The example code is built with Android Studio 4.2.2, but works with
 earlier versions of Studio. If you are using an earlier version of Android
-Studio you can try adjust the version number of the Android plugin so that the
+Studio you can try to adjust the version number of the Android plugin so that the
 build completes, instead of upgrading Studio.
 
 **Optional:** To fix build errors by updating the Android plugin version:
@@ -106,7 +106,7 @@ TensorFlow Lite machine learning models, and access utility functions that
 convert data such as images, into a tensor data format that can be processed by
 the model you are using.
 
-The example app uses several TensorFlow Lite libraries to enable execution of
+The example app uses several TensorFlow Lite libraries to enable the execution of
 the object detection machine learning model:
 
 -   *TensorFlow Lite main library* - Provides the required data input
@@ -199,7 +199,7 @@ handle hardware acceleration of the model execution:
 Interpreter.Options().addDelegate(nnApiDelegate)
 ```
 
-TensorFlow Lite *delegates* are software modules that accelerate execution of
+TensorFlow Lite *delegates* are software modules that accelerate the execution of
 machine learning models using specialized processing hardware on a mobile
 device, such as GPUs, TPUs, or DSPs. Using delegates for running TensorFlow Lite
 models is recommended, but not required.
@@ -217,7 +217,7 @@ data format that can be processed by your model. The data in a Tensor must have
 specific dimensions, or shape, that matches the format of data used to train the
 model.
 
-To determine required tensor shape for a model:
+To determine the required tensor shape for a model:
 
 -   Use the initialized
     [Interpreter](https://www.tensorflow.org/lite/api_docs/java/org/tensorflow/lite/Interpreter)
@@ -318,7 +318,7 @@ objects are not created and then removed by the system for each prediction run.
 ## Handle model output
 
 In your Android app, after you run image data against the object detection
-model, it produces a list of predictions which your app code must handle
+model, it produces a list of predictions that your app code must handle
 by executing additional business logic, displaying results to the user, or
 taking other actions.
 
@@ -362,7 +362,7 @@ results is up to you and the needs of your application.
 Once the model has returned a prediction result, your application can act on
 that prediction by presenting the result to your user or executing additional
 logic. In the case of the example code, the application draws a bounding box
-around the identified object and displays the class name on screen. Review the
+around the identified object and displays the class name on the screen. Review the
 [`CameraActivity.reportPrediction()`](https://github.com/android/camera-samples/blob/b0f4ec3a81ec30e622bb1ccd55f30e54ddac223f/CameraXAdvanced/tflite/src/main/java/com/example/android/camerax/tflite/CameraActivity.kt#L236-L262)
 function in the example code for details.
 

--- a/tensorflow/python/eager/function.py
+++ b/tensorflow/python/eager/function.py
@@ -3305,7 +3305,7 @@ def class_method_to_instance_method(original_function, instance):
       jit_compile=original_function._jit_compile)
   # pylint: enable=protected-access
 
-  # We wrap the the bound method with tf_decorator so inspection works correctly
+  # We wrap the bound method with tf_decorator so inspection works correctly
   wrapped_instance_func = tf_decorator.make_decorator(bound_method,
                                                       instance_func)
   return wrapped_instance_func

--- a/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
+++ b/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
@@ -896,7 +896,7 @@ class LossScaleOptimizerV1(LossScaleOptimizer):
   examples of converting the use of the experimental class to the equivalent
   non-experimental class.
 
-  >>> # In all of the the examples below, `opt1` and `opt2` are identical
+  >>> # In all of the examples below, `opt1` and `opt2` are identical
   >>> opt1 = tf.keras.mixed_precision.experimental.LossScaleOptimizer(
   ...     tf.keras.optimizers.SGD(), loss_scale='dynamic')
   >>> opt2 = tf.keras.mixed_precision.LossScaleOptimizer(


### PR DESCRIPTION
I scanned over the tensorflow lite android quickstart.md file and found some typos and errors that should be addressed. 
Also, I fixed the repetitive occurrences of <code>the the</code> in some files.
These are all combined into a single pull request, and this is not a “one-liner” correcting one error.