### PR TITLE
Fix interleave_test in CGroup restricted CPU envs

### DIFF
--- a/tensorflow/python/data/kernel_tests/interleave_test.py
+++ b/tensorflow/python/data/kernel_tests/interleave_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 """Tests for `tf.data.Dataset.interleave()`."""
-import multiprocessing
 import os
 
 from absl.testing import parameterized
@@ -56,12 +55,13 @@ def _interleave(lists, cycle_length, block_length, num_parallel_calls=None):
   open_iterators = []
   if cycle_length is None:
     # The logic here needs to match interleave C++ kernels.
+    cpu_count = len(os.sched_getaffinity(0))
     if num_parallel_calls is None:
-      cycle_length = multiprocessing.cpu_count()
+      cycle_length = cpu_count
     elif num_parallel_calls == dataset_ops.AUTOTUNE:
-      cycle_length = (multiprocessing.cpu_count() + 2) // 3
+      cycle_length = (cpu_count + 2) // 3
     else:
-      cycle_length = min(num_parallel_calls, multiprocessing.cpu_count())
+      cycle_length = min(num_parallel_calls, cpu_count)
 
   for i in range(cycle_length):
     if all_iterators:


### PR DESCRIPTION
Use `len(os.sched_getaffinity(0))`, which returns the number cores available to the job,
rather than `multiprocessing.cpu_count()`, which returns the total number of cores in the node,
and which causes the interleave_test to fail when e.g. CGroups limit the
number of cores to less than the total core count.

Originally written by @smoors