### PR TITLE
CMake compilation fixes and enhancements

### DIFF
--- a/tensorflow/core/public/version.h
+++ b/tensorflow/core/public/version.h
@@ -19,7 +19,8 @@ limitations under the License.
 // TensorFlow uses semantic versioning, see http://semver.org/.
 
 // Also update tensorflow/tensorflow.bzl and
-// tensorflow/tools/pip_package/setup.py
+// tensorflow/tools/pip_package/setup.py and
+// tensorflow/lite/CMakeLists.txt
 #define TF_MAJOR_VERSION 2
 #define TF_MINOR_VERSION 11
 #define TF_PATCH_VERSION 0

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -37,7 +37,16 @@ endif()
 cmake_policy(SET CMP0028 NEW)
 # Enable MACOSX_RPATH (@rpath) for built dynamic libraries.
 cmake_policy(SET CMP0042 NEW)
-project(tensorflow-lite C CXX)
+# Set VERSION as documented by the project() command.
+cmake_policy(SET CMP0048 NEW)
+
+# Also update tensorflow/tensorflow.bzl and
+# tensorflow/core/public/version.h and
+# tensorflow/tools/pip_package/setup.py
+project(tensorflow-lite
+  VERSION 2.10.0
+  LANGUAGES C CXX
+)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(TENSORFLOW_SOURCE_DIR "" CACHE PATH
   "Directory that contains the TensorFlow project"
@@ -80,6 +89,7 @@ if(TFLITE_KERNEL_TEST AND ${CMAKE_CROSSCOMPILING})
                         Please specify it using -DTFLITE_HOST_TOOLS_DIR=<flatc_dir_path> launch argument.")
   endif()
 endif()
+option(TFLITE_BUILD_SHARED_LIB "Build shared library instead of static" OFF)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -476,6 +486,10 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "iOS")
   )
 endif()
 
+if(${TFLITE_BUILD_SHARED_LIB})
+  set(LIB_TYPE "SHARED")
+endif()
+
 # TFLite library
 set(_ALL_TFLITE_SRCS
   ${TFLITE_CORE_API_SRCS}
@@ -506,11 +520,28 @@ set(_ALL_TFLITE_SRCS
   ${TFLITE_SOURCE_DIR}/schema/schema_utils.cc
   ${TFLITE_SOURCE_DIR}/schema/schema_generated.h
 )
-add_library(tensorflow-lite
+add_library(tensorflow-lite ${LIB_TYPE}
   ${_ALL_TFLITE_SRCS}
 )
 set(_ALL_TFLITE_HDRS ${_ALL_TFLITE_SRCS})
 list(FILTER _ALL_TFLITE_HDRS INCLUDE REGEX ".*\\.h$")
+
+if (TFLITE_BUILD_SHARED_LIB)
+  #TODO: Add branch for windows (based on bazel - export all symbols)
+  if (APPLE)
+    target_link_options(tensorflow-lite PRIVATE "-Wl,-exported_symbols_list,${TENSORFLOW_SOURCE_DIR}/tensorflow/lite/tflite_exported_symbols.lds")
+  else ()
+    target_link_options(tensorflow-lite PRIVATE "-Wl,-z,defs")
+    target_link_options(tensorflow-lite PRIVATE "-Wl,--version-script,${TENSORFLOW_SOURCE_DIR}/tensorflow/lite/tflite_version_script.lds")
+  endif()
+endif()
+
+set_target_properties(tensorflow-lite
+  PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION  ${PROJECT_VERSION}
+)
+
 target_include_directories(tensorflow-lite
   PUBLIC $<BUILD_INTERFACE:${TENSORFLOW_SOURCE_DIR}> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -209,6 +209,9 @@ list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*tflite_with_xnnpack\\.cc$")
 # Exclude Flex related files.
 list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*with_selected_ops\\.cc$")
 
+# Exclude tensorflow profiler logger files
+list(FILTER TFLITE_SRCS EXCLUDE REGEX "tensorflow_profiler_logger\\.cc$")
+
 if(_TFLITE_ENABLE_MMAP)
   list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*mmap_allocation_disabled\\.cc$")
 else()

--- a/tensorflow/lite/delegates/flex/BUILD
+++ b/tensorflow/lite/delegates/flex/BUILD
@@ -122,6 +122,7 @@ tflite_flex_cc_library(
 #   - Windows: `tensorflowlite_flex.dll`
 tflite_flex_shared_library(
     name = "tensorflowlite_flex",
+    visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/tensorflow/lite/delegates/flex/build_def.bzl
+++ b/tensorflow/lite/delegates/flex/build_def.bzl
@@ -216,6 +216,7 @@ def tflite_flex_shared_library(
 
     tflite_cc_shared_object(
         name = name,
+        visibility = visibility,
         linkopts = select({
             "//tensorflow:macos": [
                 "-Wl,-exported_symbols_list,$(location //tensorflow/lite/delegates/flex:exported_symbols.lds)",

--- a/tensorflow/lite/examples/label_image/CMakeLists.txt
+++ b/tensorflow/lite/examples/label_image/CMakeLists.txt
@@ -55,6 +55,11 @@ if(TFLITE_ENABLE_GPU)
   )
 endif()  # TFLITE_ENABLE_GPU
 
+if(TFLITE_ENABLE_EXTERNAL_DELEGATE)
+  list(APPEND TFLITE_LABEL_IMAGE_SRCS
+          ${TFLITE_SOURCE_DIR}/tools/delegates/external_delegate_provider.cc)
+endif()
+
 add_executable(label_image
   EXCLUDE_FROM_ALL
   ${TFLITE_LABEL_IMAGE_SRCS}

--- a/tensorflow/lite/kernels/CMakeLists.txt
+++ b/tensorflow/lite/kernels/CMakeLists.txt
@@ -83,6 +83,7 @@ endif()
 set(TEST_FRAMEWORK_SRC
   ${TFLITE_SOURCE_DIR}/delegates/nnapi/acceleration_test_list.cc
   ${TFLITE_SOURCE_DIR}/delegates/nnapi/acceleration_test_util.cc
+  ${TFLITE_SOURCE_DIR}/nnapi/nnapi_implementation.cc
   ${TFLITE_SOURCE_DIR}/profiling/memory_info.cc
   ${TFLITE_SOURCE_DIR}/schema/schema_conversion_utils.cc
   ${TFLITE_SOURCE_DIR}/tools/command_line_flags.cc

--- a/tensorflow/lite/kernels/CMakeLists.txt
+++ b/tensorflow/lite/kernels/CMakeLists.txt
@@ -16,6 +16,7 @@
 find_package(googletest REQUIRED)
 find_package(nsync REQUIRED)
 find_package(re2 REQUIRED)
+find_package(benchmark REQUIRED)
 
 # Generate the mutable schema_generated.h header for tests.
 set(SCHEMA_FILE ${TFLITE_SOURCE_DIR}/schema/schema.fbs)
@@ -92,9 +93,9 @@ set(TEST_FRAMEWORK_SRC
   ${TFLITE_SOURCE_DIR}/tools/tool_params.cc
   ${TFLITE_SOURCE_DIR}/tools/versioning/op_version.cc
   ${TFLITE_SOURCE_DIR}/tools/versioning/op_signature.cc
-  ${TF_SOURCE_DIR}/core/platform/default/env_time.cc
-  ${TF_SOURCE_DIR}/core/platform/default/logging.cc
-  ${TF_SOURCE_DIR}/core/platform/default/mutex.cc
+  ${TF_SOURCE_DIR}/tsl/platform/default/env_time.cc
+  ${TF_SOURCE_DIR}/tsl/platform/default/logging.cc
+  ${TF_SOURCE_DIR}/tsl/platform/default/mutex.cc
   internal/test_util.cc
   acceleration_test_util.cc
   acceleration_test_util_internal.cc
@@ -114,6 +115,7 @@ target_link_libraries(tensorflow-lite-test-base
   gmock
   nsync_cpp
   re2
+  benchmark::benchmark
   tensorflow-lite
 )
 add_dependencies(tensorflow-lite-test-base mutable_schema_file)

--- a/tensorflow/lite/tools/benchmark/BUILD
+++ b/tensorflow/lite/tools/benchmark/BUILD
@@ -91,6 +91,34 @@ tf_cc_binary(
     ],
 )
 
+cc_import(
+    name = "libtensorflowlite_flex",
+    shared_library = "//tensorflow/lite/delegates/flex:tensorflowlite_flex",
+)
+
+tf_cc_binary(
+    name = "benchmark_model_plus_flex_dynamic",
+    srcs = [
+        "benchmark_plus_flex_main.cc",
+    ],
+    copts = common_copts,
+    linkopts = tflite_linkopts() + select({
+        "//tensorflow:android": [
+            "-pie",  # Android 5.0 and later supports only PIE
+            "-lm",  # some builtin ops, e.g., tanh, need -lm
+        ],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":benchmark_tflite_model_lib",
+        "//tensorflow/lite/testing:init_tensorflow",
+        "//tensorflow/lite/tools:logging",
+        ":libtensorflowlite_flex",
+    ],
+
+)
+
+
 cc_test(
     name = "benchmark_test",
     srcs = ["benchmark_test.cc"],

--- a/tensorflow/lite/tools/cmake/modules/Findbenchmark.cmake
+++ b/tensorflow/lite/tools/cmake/modules/Findbenchmark.cmake
@@ -1,0 +1,45 @@
+#
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# grpc uses find_package in CONFIG mode for this package, so override the
+# system installation and build from source instead.
+
+if(TARGET benchmark OR benchmark_POPULATED)
+  return()
+endif()
+
+include(OverridableFetchContent)
+
+OverridableFetchContent_Declare(
+  benchmark
+  GIT_REPOSITORY https://github.com/google/benchmark
+  # Sync with tensorflow/third_party/benchmark/workspace.bzl
+  GIT_TAG 0baacde3618ca617da95375e0af13ce1baadea47
+  GIT_PROGRESS TRUE
+  SOURCE_DIR "${CMAKE_BINARY_DIR}/benchmark"
+)
+OverridableFetchContent_GetProperties(benchmark)
+if(NOT benchmark_POPULATED)
+  OverridableFetchContent_Populate(benchmark)
+endif()
+
+set(BENCHMARK_SOURCE_DIR "${benchmark_SOURCE_DIR}" CACHE PATH "BENCHMARK source directory")
+
+add_subdirectory(
+  "${benchmark_SOURCE_DIR}"
+  "${benchmark_BINARY_DIR}"
+  EXCLUDE_FROM_ALL
+)
+

--- a/tensorflow/lite/tools/cmake/modules/flatbuffers.cmake
+++ b/tensorflow/lite/tools/cmake/modules/flatbuffers.cmake
@@ -38,10 +38,16 @@ option(FLATBUFFERS_BUILD_TESTS OFF)
 # Required for Windows, since it has macros called min & max which
 # clashes with std::min
 add_definitions(-DNOMINMAX=1)
-add_subdirectory(
-  "${flatbuffers_SOURCE_DIR}"
-  "${flatbuffers_BINARY_DIR}"
-)
+# Needed for cross-compilation: The flatbuffers package attempts to regenerate code with flatc if Python3 package is found.
+# The flatc is cross-built, hence not usable on host. To suppress the generation disable the FindPackage for Python3 for flatbuffers.
+function(tflite_flatbuffers_add_subdirectory_scopped)
+  set(CMAKE_DISABLE_FIND_PACKAGE_Python3 True)
+  add_subdirectory(
+    "${flatbuffers_SOURCE_DIR}"
+    "${flatbuffers_BINARY_DIR}"
+  )
+endfunction()
+tflite_flatbuffers_add_subdirectory_scopped()
 remove_definitions(-DNOMINMAX)
 
 # For BuildFlatBuffers.cmake
@@ -74,5 +80,6 @@ ExternalProject_Add(flatbuffers-flatc
              -DFLATBUFFERS_STATIC_FLATC=OFF
              -DFLATBUFFERS_BUILD_FLATHASH=OFF
              -DCMAKE_INSTALL_PREFIX=$CACHE{FLATC_INSTALL_PREFIX}
+             -DCMAKE_DISABLE_FIND_PACKAGE_Python3=TRUE
   EXCLUDE_FROM_ALL ${FLATC_EXCLUDE_FROM_ALL}
 )

--- a/tensorflow/lite/tools/cmake/native_tools/flatbuffers/CMakeLists.txt
+++ b/tensorflow/lite/tools/cmake/native_tools/flatbuffers/CMakeLists.txt
@@ -40,4 +40,4 @@ else()
   set(FLATC_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE PATH "Flatc installation directory")
 endif()
 
-find_package(flatbuffers)
+find_package(Flatbuffers)

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -61,6 +61,7 @@ def register_extension_info(**kwargs):
 # not contain rc or alpha, only numbers.
 # Also update tensorflow/core/public/version.h
 # and tensorflow/tools/pip_package/setup.py
+# and tensorflow/lite/CMakeLists.txt
 VERSION = "2.11.0"
 VERSION_MAJOR = VERSION.split(".")[0]
 two_gpu_tags = ["requires-gpu-nvidia:2", "notap", "manual", "no_pip"]

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -45,7 +45,8 @@ from setuptools.dist import Distribution
 # For pip, we will remove all '-' characters from this string, and use the
 # result for pip.
 # Also update tensorflow/tensorflow.bzl and
-# tensorflow/core/public/version.h
+# tensorflow/core/public/version.h and
+# tensorflow/lite/CMakeLists.txt
 _VERSION = '2.11.0'
 
 


### PR DESCRIPTION
This PR contains multiple fixes in CMake for TensorFlow Lite:
- kernel test build (missing benchmark dependency)
- fix native tools builds
- fix kernel test cross compilation after upgrade to flatbuffers 2.0.6, fixes #57391
- support shared library build as in Bazel 

Additionally there is one enhancement for Bazel, regarding the `flex_shared_library` target visibility.