### PR TITLE
Update float_t to float for consistent behavior across platforms

### DIFF
--- a/tensorflow/lite/delegates/flex/util_test.cc
+++ b/tensorflow/lite/delegates/flex/util_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 #include "tensorflow/lite/delegates/flex/util.h"
 
 #include <cstdarg>
+#include <iterator>
 #include <string>
 
 #include <gmock/gmock.h>
@@ -209,8 +210,8 @@ TEST(UtilTest, CreateTfTensorFromTfLiteTensorFloat) {
   dims->data[1] = 3;
   tflite_tensor.dims = dims;
   float data_arr[] = {1.1, 0.456, 0.322};
-  std::vector<float_t> data(std::begin(data_arr), std::end(data_arr));
-  size_t num_bytes = data.size() * sizeof(float_t);
+  std::vector<float> data(std::begin(data_arr), std::end(data_arr));
+  size_t num_bytes = data.size() * sizeof(float);
   tflite_tensor.data.raw = static_cast<char*>(malloc(num_bytes));
   memcpy(tflite_tensor.data.raw, data.data(), num_bytes);
   tflite_tensor.bytes = num_bytes;
@@ -219,7 +220,7 @@ TEST(UtilTest, CreateTfTensorFromTfLiteTensorFloat) {
   EXPECT_TRUE(tf_tensor_or.ok());
   tensorflow::Tensor tf_tensor = tf_tensor_or.ValueOrDie();
   EXPECT_EQ(tf_tensor.NumElements(), 3);
-  auto* tf_data = static_cast<float_t*>(tf_tensor.data());
+  auto* tf_data = static_cast<float*>(tf_tensor.data());
   for (float weight : data_arr) {
     EXPECT_EQ(*tf_data, weight);
     tf_data++;


### PR DESCRIPTION
`//tensorflow/lite/delegates/flex:util_test` fails on s390x with error: `TfLiteTensor's size doesn't match the TF tensor's size.`
The cause of this failure is that size of float_t on s390x is 8 and on amd it is 4. Size could vary as per [this](https://en.cppreference.com/w/c/numeric/math/float_t) , hence proposing a generic change in test case.