### PR TITLE
Link libdl in core/platform/default/stacktrace

### DIFF
--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -1098,7 +1098,10 @@ cc_library(
     copts = tf_copts(),
     linkopts = select({
         "//tensorflow:windows": [],
-        "//conditions:default": ["-lm", "-ldl"],
+        "//conditions:default": [
+            "-lm",
+            "-ldl",
+        ],
     }),
     deps = [
         ":platform",

--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -1098,10 +1098,7 @@ cc_library(
     copts = tf_copts(),
     linkopts = select({
         "//tensorflow:windows": [],
-        "//conditions:default": [
-            "-lm",
-            "-ldl",
-        ],
+        "//conditions:default": ["-lm"],
     }),
     deps = [
         ":platform",

--- a/tensorflow/core/platform/BUILD
+++ b/tensorflow/core/platform/BUILD
@@ -1098,7 +1098,7 @@ cc_library(
     copts = tf_copts(),
     linkopts = select({
         "//tensorflow:windows": [],
-        "//conditions:default": ["-lm"],
+        "//conditions:default": ["-lm", "-ldl"],
     }),
     deps = [
         ":platform",

--- a/tensorflow/tsl/platform/default/BUILD
+++ b/tensorflow/tsl/platform/default/BUILD
@@ -376,6 +376,7 @@ cc_library(
 cc_library(
     name = "stacktrace",
     hdrs = ["stacktrace.h"],
+    linkopts = ["-ldl"],
     deps = [
         "//tensorflow/core/platform",
         "//tensorflow/core/platform:abi",


### PR DESCRIPTION
~Required due to use of `dladdr` via the `stacktrace_handler` dependency~

Required due to use of `dladdr` in `stacktrace.h` which is e.g. a dependency of `test_main` via `stacktrace_handler`

Fixes #45013