### PR TITLE
[oneDNN] Unblocking Matmul+Add(Bias) fusion

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -575,35 +575,16 @@ bool IsBiasSemanticAdd(const RemapperContext& ctx,
     return true;
   };
 
-  // This is used only for MatMul+Add fusion.
-  const auto is_matmul_supported_shape =
-      [](const TensorShapeProto& shape,
-         const TensorShapeProto& bcast_shape) -> bool {
-    if (shape.dim_size() < 2 || bcast_shape.dim_size() != 1) return false;
-    int channel_dim = shape.dim(shape.dim_size() - 1).size();
-    return (channel_dim == bcast_shape.dim(0).size());
-  };
-
   if (ShapesSymbolicallyEqual(prot0_shape, prot1_shape) ||
       !ShapesBroadcastable(prot0_shape, prot1_shape))
     return false;
 
-  // For now block MatMul+Add fusion if Bias dims are more than one.
-  // TODO(intel-tf): Enable this fusion once it is properly tested.
   if (IsConvOrMatMul(*node_def_0)) {
     bias_port = 1;
-    if (IsMatMul(*node_def_0)) {
-      return (is_matmul_supported_shape(prot0_shape, prot1_shape));
-    } else {
-      return (is_supported_shape(prot0_shape, prot1_shape));
-    }
+    return (is_supported_shape(prot0_shape, prot1_shape));
   } else if (IsConvOrMatMul(*node_def_1)) {
     bias_port = 0;
-    if (IsMatMul(*node_def_1)) {
-      return (is_matmul_supported_shape(prot1_shape, prot0_shape));
-    } else {
-      return (is_supported_shape(prot1_shape, prot0_shape));
-    }
+    return (is_supported_shape(prot1_shape, prot0_shape));
   }
   return false;
 }

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -1209,6 +1209,68 @@ TEST_F(RemapperTest, FuseConv2DWithAdd) {
   test::ExpectTensorNear<float>(tensors[0], tensors_expected[0], 1e-6);
 }
 
+// Fuse  matmul + add {1,C}
+TEST_F(RemapperTest, FuseMatmulWithAdd) {
+  if (!IsMKLEnabled()) GTEST_SKIP() << "Test only applicable to MKL.";
+
+  using ::tensorflow::ops::Placeholder;
+  tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+
+  auto lhs_shape = ops::Placeholder::Shape({8, 32});
+  auto rhs_shape = ops::Placeholder::Shape({32, 64});
+
+  auto lhs = Placeholder(s.WithOpName("lhs"), DT_FLOAT, lhs_shape);
+  auto rhs = Placeholder(s.WithOpName("rhs"), DT_FLOAT, rhs_shape);
+
+  auto matmul = ops::MatMul(s.WithOpName("matmul"), lhs, rhs);
+  auto add_const = ops::Const(s.WithOpName("add_const"), 1.0f, {1, 64});
+  auto add = ops::Add(s.WithOpName("add"), matmul, add_const);
+  auto fetch = ops::Identity(s.WithOpName("fetch"), add);
+
+  auto lhs_t = GenerateTensorWithSetRandom<DT_FLOAT>({8, 32});
+  auto rhs_t = GenerateTensorWithSetRandom<DT_FLOAT>({32, 64});
+  auto add_t = GenerateTensorWithSetRandom<DT_FLOAT>({1, 64});
+
+  GrapplerItem item;
+  item.fetch = {"fetch"};
+  item.feed = {{"lhs", lhs_t}, {"rhs", rhs_t}};
+  TF_ASSERT_OK(s.ToGraphDef(&item.graph));
+
+  // Place all nodes on CPU.
+  for (int i = 0; i < item.graph.node_size(); ++i) {
+    item.graph.mutable_node(i)->set_device("/device:CPU:0");
+  }
+
+  Remapper optimizer(RewriterConfig::AGGRESSIVE);
+  GraphDef output;
+  TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+  int found = 0;
+  for (const NodeDef& node : output.node()) {
+    if (node.name() == "add") {
+      EXPECT_EQ(node.op(), "_FusedMatMul");
+      ASSERT_GE(node.input_size(), 3);
+      EXPECT_EQ(node.input(0), "lhs");
+      EXPECT_EQ(node.input(1), "rhs");
+
+      EXPECT_EQ(node.attr().at("num_args").i(), 1);
+      EXPECT_EQ(node.input(2), "add_const");
+
+      const auto fused_ops = node.attr().at("fused_ops").list().s();
+      ASSERT_EQ(fused_ops.size(), 1);
+      EXPECT_EQ(fused_ops[0], "BiasAdd");
+      found++;
+    }
+  }
+  EXPECT_EQ(1, found);
+
+  auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
+  ASSERT_EQ(tensors_expected.size(), 1);
+  auto tensors = EvaluateNodes(output, item.fetch, item.feed);
+  ASSERT_EQ(tensors.size(), 1);
+  test::ExpectClose(tensors[0], tensors_expected[0], 1e-6);
+}
+
 class RemapperFuseSoftplusTanhMul : public RemapperTest {
  public:
   template <DataType DTYPE>

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -81,8 +81,13 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, T> {
                 errors::InvalidArgument("In[0] is not a matrix"));
     OP_REQUIRES(ctx, TensorShapeUtils::IsMatrix(weight_tf_shape),
                 errors::InvalidArgument("In[1] is not a matrix"));
-    OP_REQUIRES(ctx, TensorShapeUtils::IsVector(bias_tensor.shape()),
-                errors::InvalidArgument("Biases must be 1D"));
+    for (int i = 0; i < bias_tensor.dims() - 1; i++) {
+      OP_REQUIRES(
+          ctx, bias_tensor.dim_size(i) == 1,
+          errors::InvalidArgument("For bias_dims > 1, all except the "
+                                  "last dimension (channel) must be 1, got: ",
+                                  bias_tensor.shape().DebugString()));
+    }
 
     // Expression: [batch, k] * [k, channel] + [channel] = [batch, channel]
     //
@@ -99,7 +104,7 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, T> {
         errors::InvalidArgument(
             "Matrix size-incompatible: In[0]: ", src_tf_shape.DebugString(),
             ", In[1]: ", weight_tf_shape.DebugString()));
-    OP_REQUIRES(ctx, bias_tensor.shape().dim_size(0) == channel,
+    OP_REQUIRES(ctx, bias_tensor.dim_size(bias_tensor.dims() - 1) == channel,
                 errors::InvalidArgument(
                     "Must provide as many biases as the channel size: ",
                     bias_tensor.shape().DebugString(), " vs. ", channel));


### PR DESCRIPTION
This PR unblocks Matmul + Add(Bias) fusion when bias dims are more than one and also adds a test.
The fusion was blocked by this PR https://github.com/tensorflow/tensorflow/pull/55687

co-authored by: @mahmoud-abuzaina 