### PR TITLE
[oneDNN] QuantizeV2 with bfloat16 Input

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_QuantizeV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_QuantizeV2.pbtxt
@@ -42,7 +42,13 @@ If the `axis` attribute is specified, this will be a 1-D tensor whose size
 matches the `axis` dimension of the input and output tensors.
 END
   }
-  summary: "Quantize the \'input\' tensor of type float to \'output\' tensor of type \'T\'."
+  attr {
+    name: "dtype"
+    description: <<END
+Type of the input tensor. Currently QuantizeV2 supports float and bfloat16.
+END
+  }
+  summary: "Quantize the \'input\' tensor of types float and bfloat16 to \'output\' tensor of type \'T\'."
   description: <<END
 [min_range, max_range] are scalar floats that specify the range for
 the 'input' data. The 'mode' attribute controls exactly which calculations are

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
@@ -263,9 +263,9 @@ class MklReorderWithScalePrimitiveFactory : public MklPrimitiveFactory<T> {
   }
 };
 
-// Quantizes a tensor from float to T, with user-specified min_range and
-// max_range.
-template <typename Device, typename T, bool native_format = false>
+// Quantizes a tensor from S(input) to T(output), with user-specified min_range
+// and max_range.
+template <typename Device, typename T, typename S, bool native_format = false>
 class MklQuantizeV2Op : public OpKernel {
  public:
   explicit MklQuantizeV2Op(OpKernelConstruction* ctx) : OpKernel(ctx) {
@@ -435,7 +435,7 @@ class MklQuantizeV2Op : public OpKernel {
     }
     // Create reorder memory for src, dst: both are defined in mkl_util.h,
     // they are wrapper
-    MklDnnData<float> src(&cpu_engine);
+    MklDnnData<S> src(&cpu_engine);
     MklDnnData<T> dst(&cpu_engine);
 #ifdef ENABLE_ONEDNN_V3
     MklDnnData<float> scale(&cpu_engine);
@@ -444,34 +444,9 @@ class MklQuantizeV2Op : public OpKernel {
     auto src_md =
         src_mkl_shape.IsMklTensor()
             ? src_mkl_shape.GetMklLayout()
-            : memory::desc(src_dims, MklDnnType<float>(), dst_layout_type);
+            : memory::desc(src_dims, MklDnnType<S>(), dst_layout_type);
 
-    // If the mode is min_first, input data has to be subtracted from
-    // min_range, before being scaled
-    auto flat_input = input.flat<float>().data();
-    Tensor min_shifted_input_tensor;
-    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, input.shape(),
-                                           &min_shifted_input_tensor));
-    if (mode_ == QUANTIZE_MODE_MIN_FIRST) {
-      auto minfirst_input = min_shifted_input_tensor.flat<float>().data();
-      const Eigen::TensorOpCost cost(
-          sizeof(float), /*load bytes*/
-          sizeof(float), /*saved bytes*/
-          Eigen::TensorOpCost::AddCost<float>() /*sub cost*/);
-
-      const CPUDevice& d = ctx->eigen_device<CPUDevice>();
-      auto ParallelSub = [&](int64 start, int64 end) {
-        for (int i = start; i < end; ++i) {
-          minfirst_input[i] = flat_input[i] - min_range;
-        }
-      };
-      d.parallelFor(input.NumElements(), cost, ParallelSub);
-
-      src.SetUsrMem(src_md, &min_shifted_input_tensor);
-    } else {
-      src.SetUsrMem(src_md, &src_tensor);
-    }
-
+    src.SetUsrMem(src_md, &src_tensor);
     memory::desc dst_md =
         memory::desc(src_dims, MklDnnType<T>(), dst_layout_type);
 
@@ -509,6 +484,13 @@ class MklQuantizeV2Op : public OpKernel {
     AllocateOutputSetMklShape(ctx, 2, &output_max_tensor, max_tf_shape,
                               max_mkl_shape, native_format);
 
+    // Create the oneDNN wrapper over Eigen threadpool and set max threads
+    // in oneDNN.
+    Eigen::ThreadPoolInterface* eigen_interface =
+        EigenThreadPoolFromTfContext(ctx);
+    tsl::OneDnnThreadPool eigen_tp(eigen_interface,
+                                   ThreadPoolUseCallerThread());
+
     float scale_factor = 0;
     if (mode_ == QUANTIZE_MODE_SCALED) {
       // Estimating scales for quantization.
@@ -532,44 +514,86 @@ class MklQuantizeV2Op : public OpKernel {
         target_range = static_cast<float>((uint64_t{1} << num_bits) - 1);
       }
       scale_factor = target_range / max_abs;
-    } else if (mode_ == QUANTIZE_MODE_MIN_FIRST) {
-      // Estimate scale for qunatization
-      const int number_of_bits = sizeof(T) * 8;
-      const int64 number_of_steps = static_cast<int64_t>(1) << number_of_bits;
-      scale_factor = (number_of_steps - 1.0) / (max_range - min_range);
-    }
+
 #ifdef ENABLE_ONEDNN_V3
-    auto scale_md =
-        memory::desc({1}, MklDnnType<float>(), memory::format_tag::x);
-    MklReorderWithScaleFwdParams fwdParams(src_dims, src_md, dst_md, scale_md);
-    Tensor scale_tensor;
-    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, {1}, &scale_tensor));
-    scale_tensor.flat<float>()(0) = scale_factor;
-    scale.SetUsrMem(scale_md, &scale_tensor);
+      auto scale_md =
+          memory::desc({1}, MklDnnType<float>(), memory::format_tag::x);
+      MklReorderWithScaleFwdParams fwdParams(src_dims, src_md, dst_md,
+                                             scale_md);
+      Tensor scale_tensor;
+      OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, {1}, &scale_tensor));
+      scale_tensor.flat<float>()(0) = scale_factor;
+      scale.SetUsrMem(scale_md, &scale_tensor);
 #else
-    MklReorderWithScaleFwdParams fwdParams(src_dims, src_md, dst_md);
-    fwdParams.dtypes.append(typeid(T).name());
+      MklReorderWithScaleFwdParams fwdParams(src_dims, src_md, dst_md);
 #endif  // ENABLE_ONEDNN_V3
-    fwdParams.post_op_params.name = "scale";
-    fwdParams.post_op_params.param.push_back(scale_factor);
+      fwdParams.dtypes.append(typeid(S).name());
+      fwdParams.dtypes.append(typeid(T).name());
+      fwdParams.post_op_params.name = "scale";
+      fwdParams.post_op_params.param.push_back(scale_factor);
 
-    // Create the oneDNN wrapper over Eigen threadpool and set max threads
-    // in oneDNN.
-    Eigen::ThreadPoolInterface* eigen_interface =
-        EigenThreadPoolFromTfContext(ctx);
-    tsl::OneDnnThreadPool eigen_tp(eigen_interface,
-                                   ThreadPoolUseCallerThread());
-    MklReorderWithScalePrimitive* reorder_prim =
-        MklReorderWithScalePrimitiveFactory<T>::Get(src.GetUsrMem(),
-                                                    dst.GetUsrMem(), fwdParams);
-    std::shared_ptr<stream> cpu_stream;
+      MklReorderWithScalePrimitive* reorder_prim =
+          MklReorderWithScalePrimitiveFactory<T>::Get(
+              src.GetUsrMem(), dst.GetUsrMem(), fwdParams);
 
-    cpu_stream.reset(CreateStream(&eigen_tp, reorder_prim->GetEngine()));
-    reorder_prim->Execute(src.GetUsrMemDataHandle(), dst.GetUsrMemDataHandle(),
+      std::shared_ptr<stream> cpu_stream;
+      cpu_stream.reset(CreateStream(&eigen_tp, reorder_prim->GetEngine()));
+      reorder_prim->Execute(src.GetUsrMemDataHandle(),
+                            dst.GetUsrMemDataHandle(),
 #ifdef ENABLE_ONEDNN_V3
-                          scale.GetUsrMemDataHandle(),
+                            scale.GetUsrMemDataHandle(),
 #endif  // ENABLE_ONEDNN_V3
-                          cpu_stream);
+                            cpu_stream);
+    } else if (mode_ == QUANTIZE_MODE_MIN_FIRST) {
+      using namespace dnnl;
+      std::shared_ptr<stream> cpu_stream;
+      cpu_stream.reset(CreateStream(&eigen_tp, cpu_engine));
+
+      auto shift = static_cast<S>(-min_range);
+      memory::dims shift_dims(src_tf_shape.dims(), 1);
+      auto shift_md =
+          memory::desc(shift_dims, MklDnnType<S>(), dst_layout_type);
+      memory shift_mem(shift_md, cpu_engine, (void*)(&shift));
+
+      primitive_attr attr;
+      std::vector<float> src_0_scale{255.0f / (max_range - min_range)};
+      std::vector<float> src_1_scale{255.0f / (max_range - min_range)};
+#ifdef ENABLE_ONEDNN_V3
+      attr.set_scales_mask(DNNL_ARG_SRC_0, 0);
+      attr.set_scales_mask(DNNL_ARG_SRC_1, 0);
+      auto binary_pd = binary::primitive_desc(cpu_engine, algorithm::binary_add,
+                                              src_md, shift_md, dst_md, attr);
+#else
+      attr.set_scales(DNNL_ARG_SRC_0, 0, src_0_scale);
+      attr.set_scales(DNNL_ARG_SRC_1, 0, src_1_scale);
+      auto binary_d =
+          binary::desc(algorithm::binary_add, src_md, shift_md, dst_md);
+      auto binary_pd = binary::primitive_desc(binary_d, attr, cpu_engine);
+#endif  // ENABLE_ONEDNN_V3
+
+      auto binary_prim = binary(binary_pd);
+      auto src_0_scale_mem =
+          memory({{1}, MklDnnType<float>(), memory::format_tag::x}, cpu_engine,
+                 src_0_scale.data());
+      auto src_1_scale_mem =
+          memory({{1}, MklDnnType<float>(), memory::format_tag::x}, cpu_engine,
+                 src_1_scale.data());
+      std::unordered_map<int, memory> net_args{
+          {DNNL_ARG_SRC_0, *src.GetUsrMem()},
+          {DNNL_ARG_SRC_1, shift_mem},
+          {DNNL_ARG_DST, *dst.GetUsrMem()},
+#ifdef ENABLE_ONEDNN_V3
+          {DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0, src_0_scale_mem},
+          { DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_1,
+            src_1_scale_mem }
+#endif
+      };
+      binary_prim.execute(*cpu_stream, net_args);
+    } else {
+      OP_REQUIRES(ctx, false,
+                  errors::Unimplemented(
+                      "Supported modes are MIN_FIRST and SCALED only."));
+    }
 
     output_min_tensor->scalar<float>()() = min_range;
     output_max_tensor->scalar<float>()() = max_range;
@@ -583,16 +607,16 @@ class MklQuantizeV2Op : public OpKernel {
   bool narrow_range_;
 };
 
-REGISTER_KERNEL_BUILDER(Name("_MklQuantizeV2")
-                            .Device(DEVICE_CPU)
-                            .TypeConstraint<quint8>("T")
-                            .Label(mkl_op_registry::kMklQuantizedOpLabel),
-                        MklQuantizeV2Op<CPUDevice, quint8, true>);
-REGISTER_KERNEL_BUILDER(Name("_MklQuantizeV2")
-                            .Device(DEVICE_CPU)
-                            .TypeConstraint<qint8>("T")
-                            .Label(mkl_op_registry::kMklQuantizedOpLabel),
-                        MklQuantizeV2Op<CPUDevice, qint8, true>);
+#define REGISTER_QUANTIZE(src_type, dst_type)            \
+  REGISTER_KERNEL_BUILDER(                               \
+      Name("_MklQuantizeV2")                             \
+          .Device(DEVICE_CPU)                            \
+          .TypeConstraint<dst_type>("T")                 \
+          .Label(mkl_op_registry::kMklQuantizedOpLabel), \
+      MklQuantizeV2Op<CPUDevice, dst_type, src_type, true>)
+
+REGISTER_QUANTIZE(float, qint8);
+REGISTER_QUANTIZE(float, quint8);
 
 #undef SET_MKL_LAYOUT
 

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
@@ -311,6 +311,20 @@ class MklQuantizeV2Op : public OpKernel {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("axis", &axis_));
     OP_REQUIRES_OK(
         ctx, ctx->GetAttr("ensure_minimum_range", &ensure_minimum_range_));
+    if (ctx->HasAttr("dtype")) {
+      OP_REQUIRES_OK(ctx, ctx->GetAttr("dtype", &dtype_));
+      if (dtype_ == DT_BFLOAT16) {
+        OP_REQUIRES(
+            ctx,
+            ctx->input_type(0) == DT_BFLOAT16 &&
+                (mode_ == QUANTIZE_MODE_MIN_FIRST ||
+                 mode_ == QUANTIZE_MODE_SCALED),
+            errors::InvalidArgument("Input type bfloat16 is supported only "
+                                    "with MIN_FIRST and SCLAED modes"));
+      }
+    } else {
+      dtype_ = DT_FLOAT;
+    }
   }
 
   void ComputeScalar(OpKernelContext* ctx, float min_range, float max_range) {
@@ -605,18 +619,22 @@ class MklQuantizeV2Op : public OpKernel {
   int round_mode_;
   int axis_;
   bool narrow_range_;
+  DataType dtype_;
 };
 
 #define REGISTER_QUANTIZE(src_type, dst_type)            \
   REGISTER_KERNEL_BUILDER(                               \
       Name("_MklQuantizeV2")                             \
           .Device(DEVICE_CPU)                            \
+          .TypeConstraint<src_type>("dtype")             \
           .TypeConstraint<dst_type>("T")                 \
           .Label(mkl_op_registry::kMklQuantizedOpLabel), \
       MklQuantizeV2Op<CPUDevice, dst_type, src_type, true>)
 
 REGISTER_QUANTIZE(float, qint8);
 REGISTER_QUANTIZE(float, quint8);
+REGISTER_QUANTIZE(bfloat16, qint8);
+REGISTER_QUANTIZE(bfloat16, quint8);
 
 #undef SET_MKL_LAYOUT
 

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
@@ -591,7 +591,7 @@ class MklQuantizeV2Op : public OpKernel {
       binary_prim.execute(*cpu_stream, net_args);
     } else {
       OP_REQUIRES(ctx, false,
-                  errors::Unimplemented(
+                  absl::UnimplementedError(
                       "Supported modes are MIN_FIRST and SCALED only."));
     }
 

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL)
 #include "tensorflow/core/framework/fake_input.h"
 #include "tensorflow/core/framework/node_def_builder.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -155,4 +155,4 @@ TEST_F(MklQuantizeV2OpTest, small_minfirst_int) {
 }
 
 }  // end namespace tensorflow
-#endif  // INTEL_MKL && ENABLE_MKL
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op_test.cc
@@ -25,11 +25,13 @@ limitations under the License.
 
 namespace tensorflow {
 
-class MklQuantizeV2OpTest : public OpsTestBase {};
+class MklQuantizeV2OpTest : public OpsTestBase,
+                            public ::testing::WithParamInterface<DataType> {};
 
-TEST_F(MklQuantizeV2OpTest, small_uint8) {
+TEST_P(MklQuantizeV2OpTest, small_uint8) {
+  const auto dtype = GetParam();
   TF_ASSERT_OK(NodeDefBuilder("quantize_op", "_MklQuantizeV2")
-                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(dtype))
                    .Input(FakeInput(DT_FLOAT))
                    .Input(FakeInput(DT_FLOAT))
                    .Attr("T", DataTypeToEnum<quint8>::v())
@@ -37,8 +39,16 @@ TEST_F(MklQuantizeV2OpTest, small_uint8) {
                    .Attr("_kernel", "QuantizedMklOp")
                    .Finalize(node_def()));
   TF_ASSERT_OK(InitOp());
-  AddInputFromArray<float>(TensorShape({8}),
-                           {0.0, 1.0, 1.25, 1.75, 127.0, 255.0, 500.0, 2.0});
+  switch (dtype) {
+    case DT_BFLOAT16:
+      AddInputFromList<bfloat16>(
+          TensorShape({8}), {0.0, 1.0, 1.25, 1.75, 127.0, 255.0, 500.0, 2.0});
+      break;
+
+    default:
+      AddInputFromArray<float>(
+          TensorShape({8}), {0.0, 1.0, 1.25, 1.75, 127.0, 255.0, 500.0, 2.0});
+  }
   // min_range = 0
   AddInputFromArray<float>(TensorShape({}), {0});
   // max_range = 255
@@ -56,9 +66,11 @@ TEST_F(MklQuantizeV2OpTest, small_uint8) {
   test::ExpectTensorEqual<float>(expected_min, *GetOutput(1));
   test::ExpectTensorEqual<float>(expected_max, *GetOutput(2));
 }
-TEST_F(MklQuantizeV2OpTest, small_int8) {
+
+TEST_P(MklQuantizeV2OpTest, small_int8) {
+  const auto dtype = GetParam();
   TF_ASSERT_OK(NodeDefBuilder("quantize_op", "_MklQuantizeV2")
-                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(dtype))
                    .Input(FakeInput(DT_FLOAT))
                    .Input(FakeInput(DT_FLOAT))
                    .Attr("T", DataTypeToEnum<qint8>::v())
@@ -66,10 +78,18 @@ TEST_F(MklQuantizeV2OpTest, small_int8) {
                    .Attr("_kernel", "QuantizedMklOp")
                    .Finalize(node_def()));
   TF_ASSERT_OK(InitOp());
-  AddInputFromArray<float>(TensorShape({8}), {0.0, -1.0, 1.25, -1.75, -24.5,
-                                              -255.0, -80.315, 256.0});
-  AddInputFromArray<float>(TensorShape({}), {-50.0});
-  AddInputFromArray<float>(TensorShape({}), {127.0});
+  switch (dtype) {
+    case DT_BFLOAT16:
+      AddInputFromList<bfloat16>(
+          TensorShape({8}),
+          {0.0, -1.0, 1.25, -1.75, -24.5, -255.0, -80.315, 256.0});
+      break;
+    default:
+      AddInputFromArray<float>(TensorShape({8}), {0.0, -1.0, 1.25, -1.75, -24.5,
+                                                  -255.0, -80.315, 256.0});
+  }
+  AddInputFromArray<float>(TensorShape({1}), {-50.0});
+  AddInputFromArray<float>(TensorShape({1}), {127.0});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_QINT8, TensorShape({8}));
   Tensor expected_min(allocator(), DT_FLOAT, TensorShape({}));
@@ -82,9 +102,10 @@ TEST_F(MklQuantizeV2OpTest, small_int8) {
   test::ExpectTensorEqual<float>(expected_max, *GetOutput(2));
 }
 
-TEST_F(MklQuantizeV2OpTest, small_minfirst) {
+TEST_P(MklQuantizeV2OpTest, small_minfirst) {
+  const auto dtype = GetParam();
   TF_ASSERT_OK(NodeDefBuilder("quantize_op", "_MklQuantizeV2")
-                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(dtype))
                    .Input(FakeInput(DT_FLOAT))
                    .Input(FakeInput(DT_FLOAT))
                    .Attr("T", DataTypeToEnum<quint8>::v())
@@ -92,10 +113,17 @@ TEST_F(MklQuantizeV2OpTest, small_minfirst) {
                    .Attr("_kernel", "QuantizedMklOp")
                    .Finalize(node_def()));
   TF_ASSERT_OK(InitOp());
-  AddInputFromArray<float>(TensorShape({8}),
-                           {1.0, 1.25, 1.75, 2, 3.15, 127.0, 255.0, 500.0});
-  AddInputFromArray<float>(TensorShape({}), {0});
-  AddInputFromArray<float>(TensorShape({}), {255.0f});
+  switch (dtype) {
+    case DT_BFLOAT16:
+      AddInputFromList<bfloat16>(
+          TensorShape({8}), {1.0, 1.25, 1.75, 2.0, 3.15, 127.0, 255.0, 500.0});
+      break;
+    default:
+      AddInputFromArray<float>(
+          TensorShape({8}), {1.0, 1.25, 1.75, 2.0, 3.15, 127.0, 255.0, 500.0});
+  }
+  AddInputFromArray<float>(TensorShape({1}), {0});
+  AddInputFromArray<float>(TensorShape({1}), {255.0f});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_QUINT8, TensorShape({8}));
   test::FillValues<quint8>(&expected, {1, 1, 2, 2, 3, 127, 255, 255});
@@ -106,9 +134,10 @@ TEST_F(MklQuantizeV2OpTest, small_minfirst) {
   EXPECT_NEAR(255.0f, output_max, 1e-5f);
 }
 
-TEST_F(MklQuantizeV2OpTest, small_minfirst_uint) {
+TEST_P(MklQuantizeV2OpTest, small_minfirst_uint) {
+  const auto dtype = GetParam();
   TF_ASSERT_OK(NodeDefBuilder("quantize_op", "_MklQuantizeV2")
-                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(dtype))
                    .Input(FakeInput(DT_FLOAT))
                    .Input(FakeInput(DT_FLOAT))
                    .Attr("T", DataTypeToEnum<quint8>::v())
@@ -116,10 +145,17 @@ TEST_F(MklQuantizeV2OpTest, small_minfirst_uint) {
                    .Attr("_kernel", "QuantizedMklOp")
                    .Finalize(node_def()));
   TF_ASSERT_OK(InitOp());
-  AddInputFromArray<float>(TensorShape({8}),
-                           {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8});
-  AddInputFromArray<float>(TensorShape({}), {0.1});
-  AddInputFromArray<float>(TensorShape({}), {0.8});
+  switch (dtype) {
+    case DT_BFLOAT16:
+      AddInputFromList<bfloat16>(TensorShape({8}),
+                                 {0.1, 0.2, 0.3, 0.4, 0.5, 0.599, 0.7, 0.8});
+      break;
+    default:
+      AddInputFromArray<float>(TensorShape({8}),
+                               {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8});
+  }
+  AddInputFromArray<float>(TensorShape({1}), {0.1});
+  AddInputFromArray<float>(TensorShape({1}), {0.8});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_QUINT8, TensorShape({8}));
   test::FillValues<quint8>(&expected, {32, 64, 96, 128, 159, 191, 223, 255});
@@ -130,9 +166,10 @@ TEST_F(MklQuantizeV2OpTest, small_minfirst_uint) {
   EXPECT_NEAR(0.8f, output_max, 1e-5f);
 }
 
-TEST_F(MklQuantizeV2OpTest, small_minfirst_int) {
+TEST_P(MklQuantizeV2OpTest, small_minfirst_int) {
+  const auto dtype = GetParam();
   TF_ASSERT_OK(NodeDefBuilder("quantize_op", "_MklQuantizeV2")
-                   .Input(FakeInput(DT_FLOAT))
+                   .Input(FakeInput(dtype))
                    .Input(FakeInput(DT_FLOAT))
                    .Input(FakeInput(DT_FLOAT))
                    .Attr("T", DataTypeToEnum<quint8>::v())
@@ -140,10 +177,18 @@ TEST_F(MklQuantizeV2OpTest, small_minfirst_int) {
                    .Attr("_kernel", "QuantizedMklOp")
                    .Finalize(node_def()));
   TF_ASSERT_OK(InitOp());
-  AddInputFromArray<float>(TensorShape({8}),
-                           {-0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8});
-  AddInputFromArray<float>(TensorShape({}), {-0.8});
-  AddInputFromArray<float>(TensorShape({}), {-0.1});
+  switch (dtype) {
+    case DT_BFLOAT16:
+      AddInputFromList<bfloat16>(
+          TensorShape({8}), {-0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8});
+
+      break;
+    default:
+      AddInputFromArray<float>(
+          TensorShape({8}), {-0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8});
+  }
+  AddInputFromArray<float>(TensorShape({1}), {-0.8});
+  AddInputFromArray<float>(TensorShape({1}), {-0.1});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_QUINT8, TensorShape({8}));
   test::FillValues<quint8>(&expected, {223, 191, 159, 128, 96, 64, 32, 0});
@@ -153,6 +198,9 @@ TEST_F(MklQuantizeV2OpTest, small_minfirst_int) {
   EXPECT_NEAR(-0.8f, output_min, 1e-5f);
   EXPECT_NEAR(0.0f, output_max, 1e-5f);
 }
+
+INSTANTIATE_TEST_SUITE_P(All, MklQuantizeV2OpTest,
+                         ::testing::Values(DT_FLOAT, DT_BFLOAT16));
 
 }  // end namespace tensorflow
 #endif  // INTEL_MKL

--- a/tensorflow/core/ops/array_ops.cc
+++ b/tensorflow/core/ops/array_ops.cc
@@ -3031,12 +3031,13 @@ REGISTER_OP("QuantizeAndDequantizeV3")
     });
 
 REGISTER_OP("QuantizeV2")
-    .Input("input: float")
+    .Input("input: dtype")
     .Input("min_range: float")
     .Input("max_range: float")
     .Output("output: T")
     .Output("output_min: float")
     .Output("output_max: float")
+    .Attr("dtype: {bfloat16, float} = DT_FLOAT")
     .Attr("T: quantizedtype")
     .Attr("mode: {'MIN_COMBINED', 'MIN_FIRST', 'SCALED'} = 'MIN_COMBINED'")
     .Attr(

--- a/tensorflow/core/ops/mkl_array_ops.cc
+++ b/tensorflow/core/ops/mkl_array_ops.cc
@@ -82,7 +82,7 @@ REGISTER_OP("_MklQuantizedConcatV2")
     });
 
 REGISTER_OP("_MklQuantizeV2")
-    .Input("input: float")
+    .Input("input: dtype")
     .Input("min_range: float")
     .Input("max_range: float")
     .Output("output: T")
@@ -96,6 +96,7 @@ REGISTER_OP("_MklQuantizeV2")
     .Attr("narrow_range: bool = false")
     .Attr("axis: int = -1")
     .Attr("ensure_minimum_range: float = 0.01")
+    .Attr("dtype: {bfloat16, float} = DT_FLOAT")
     .SetShapeFn(shape_inference::QuantizeV2Shape);
 
 REGISTER_OP("_MklDequantize")


### PR DESCRIPTION
Depends on #56776
This PR extends QuantizeV2 op for converting bfloat16 tensor to quantized tensor. It helps quantizing a model with bfloat16 and 8-bit integer mixed precisions, for example using Intel Neural Compressor (INC) tool (https://github.com/intel/neural-compressor).