### PR TITLE
Converter for Range operator with mixed type parameters.

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/layer_utils.h
@@ -341,6 +341,18 @@ class TRTNetworkBuilder {
     return const_layer;
   }
 
+  Status get_tensor4TensorOrWeights(const TRT_TensorOrWeights& input,
+                                    ITensorProxyPtr* pTensor) {
+    if (input.is_weights()) {
+      StatusOr<nvinfer1::IConstantLayer*> const_layer = WeightsToConstant(
+          input.weights().GetTrtWeights(), input.GetTrtDims());
+      if (!const_layer.status().ok()) return const_layer.status();
+      *pTensor = (*const_layer)->getOutput(0);
+    } else {
+      *pTensor = input.tensor();
+    }
+    return Status::OK();
+  }
   // Creates a nvinfer1::Weights object containing a single scalar.
   template <typename T,
             typename std::enable_if<std::is_pod<T>::value>::type* = nullptr>


### PR DESCRIPTION
This is an improvement for [PR#546040](https://github.com/tensorflow/tensorflow/pull/56040): "Converter for Range operator". which allows you to pass parameters (start, limit, delta) by using any combinations of weights and tensors. Previously, they could be passed either all three as weights or all three as tensors.

When at least one of these parameters is passed as a tensor, all three of them should be of type DT_INT32 and the parameter delta should be positive.