### PR TITLE
Enhance NumSchedulableCPUs to allow for nodes with more than 1024 cores

### DIFF
--- a/tensorflow/core/platform/default/port.cc
+++ b/tensorflow/core/platform/default/port.cc
@@ -88,9 +88,19 @@ int64_t JobUid() { return -1; }
 
 int NumSchedulableCPUs() {
 #if defined(__linux__) && !defined(__ANDROID__)
-  cpu_set_t cpuset;
-  if (sched_getaffinity(0, sizeof(cpu_set_t), &cpuset) == 0) {
-    return CPU_COUNT(&cpuset);
+  for(int ncpus = 1024; ncpus < std::numeric_limits<int>::max() / 2; ncpus *= 2) {
+    size_t setsize = CPU_ALLOC_SIZE(ncpus);
+    cpu_set_t* mask = CPU_ALLOC(ncpus);
+    if (!mask)
+      break;
+    if (sched_getaffinity(0, setsize, mask) == 0) {
+      int result = CPU_COUNT_S(setsize, mask);
+      CPU_FREE(mask);
+      return result;
+    }
+    CPU_FREE(mask);
+    if (errno != EINVAL)
+      break;
   }
   perror("sched_getaffinity");
 #endif


### PR DESCRIPTION
In systems with large core counts the default size of `cpu_set_t` is not large enough to hold a space for each of them.
Use the `CPU_ALLOC` macro to dynamically create space while doubling the number of possible CPUs (and hence required space) when `sched_getaffinity` fails with `EINVAL`.

Code based on CPythons implementation of `os.sched_getaffinity`
See https://github.com/python/cpython/blob/21cbdae90ffdac047d27d1b83a5442fabcf89f7c/Modules/posixmodule.c#L7197-L7214

Fixes #49833