### PR TITLE
Fix crash during shutdown in distributed training

### DIFF
--- a/tensorflow/python/client/tf_session_wrapper.cc
+++ b/tensorflow/python/client/tf_session_wrapper.cc
@@ -564,8 +564,11 @@ PYBIND11_MODULE(_pywrap_tf_session, m) {
 
   m.def("TF_NewGraph", TF_NewGraph, py::return_value_policy::reference,
         py::call_guard<py::gil_scoped_release>());
-  m.def("TF_DeleteGraph", TF_DeleteGraph,
-        py::call_guard<py::gil_scoped_release>());
+  // Note: Do not use gil_scoped_release here which eventually (re)aquires the GIL.
+  // As graphs may be (automatically) freed from threads still running after
+  // Python already started to finalize this will lead to force-termination.
+  // See https://github.com/tensorflow/tensorflow/issues/50853
+  m.def("TF_DeleteGraph", TF_DeleteGraph);
 
   m.def("TF_GraphGetOpDef",
         [](TF_Graph* graph, const char* op_name, TF_Buffer* output_op_def) {


### PR DESCRIPTION
Releasing and reaquiring the GIL during Python shutdown is not possible and leads to force termination.
Remove that.

Fixes #50853