### PR TITLE
[INTEL ONEDNN] - Added name of the primitive as key of mkl primitive …

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_helper.h
+++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_helper.h
@@ -49,8 +49,9 @@ struct MklBatchMatMulHelper {
   }
 
   std::unique_ptr<MklMatMulParams> CreateMatMulParams(
-      const TensorShape& lhs_shape, const TensorShape& rhs_shape,
-      const TensorShape& out_shape, bool& adj_x, bool& adj_y) {
+      string& prefix, const TensorShape& lhs_shape,
+      const TensorShape& rhs_shape, const TensorShape& out_shape, bool& adj_x,
+      bool& adj_y) {
     const auto ndims_lhs = lhs_shape.dims();
     const auto ndims_rhs = rhs_shape.dims();
     const auto ndims_out = out_shape.dims();
@@ -97,8 +98,9 @@ struct MklBatchMatMulHelper {
       rhs_strides[n_idx] = 1;
     }
 
-    return std::make_unique<MklMatMulParams>(
-        lhs_dims, rhs_dims, out_dims, lhs_strides, rhs_strides, out_strides);
+    return std::make_unique<MklMatMulParams>(prefix, lhs_dims, rhs_dims,
+                                             out_dims, lhs_strides, rhs_strides,
+                                             out_strides);
   }
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
@@ -72,10 +72,10 @@ class BatchMatMulMkl : public OpKernel {
           errors::InvalidArgument("lhs and rhs ndims must be >= 2: ", ndims));
       for (int i = 0; i < ndims - 2; ++i) {
         OP_REQUIRES(ctx, lhs.dim_size(i) == rhs.dim_size(i),
-                    errors::InvalidArgument(
-                        "lhs.dim(", i, ") and rhs.dim(", i,
-                        ") must be the same: ", lhs.shape().DebugString(),
-                        " vs ", rhs.shape().DebugString()));
+                    errors::InvalidArgument("lhs.dim(", i, ") and rhs.dim(", i,
+                                            ") must be the same: ",
+                                            lhs.shape().DebugString(), " vs ",
+                                            rhs.shape().DebugString()));
       }
     } else {
       OP_REQUIRES(
@@ -135,8 +135,9 @@ class BatchMatMulMkl : public OpKernel {
 
     // Compute parameters for DNNL matmul primitive.
     MklBatchMatMulHelper bmm;
-    auto params = bmm.CreateMatMulParams(lhs.shape(), rhs.shape(), out_shape,
-                                         adj_x_, adj_y_);
+    string prefix = "batchmatmul";
+    auto params = bmm.CreateMatMulParams(prefix, lhs.shape(), rhs.shape(),
+                                         out_shape, adj_x_, adj_y_);
 
 #ifdef DNNL_AARCH64_USE_ACL
     // ACL does not support reuse of primitives with different data.

--- a/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
@@ -106,8 +106,9 @@ struct MklEinsumHelper {
 
     // Compute parameters for DNNL matmul primitive.
     MklBatchMatMulHelper bmm;
-    auto params = bmm.CreateMatMulParams(lhs.shape(), rhs.shape(), out_shape,
-                                         trans_x, trans_y);
+    string prefix = "einsum";
+    auto params = bmm.CreateMatMulParams(prefix, lhs.shape(), rhs.shape(),
+                                         out_shape, trans_x, trans_y);
 
     // Create or retrieve matmul primitive from cache.
     MklMatMulPrimitive<T, T, T>* matmul_prim =

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -580,6 +580,7 @@ using dnnl::matmul;
 namespace {
 
 struct MklMatMulParams {
+  string prefix;
   memory::dims a_dims;
   memory::dims b_dims;
   memory::dims c_dims;
@@ -598,10 +599,11 @@ struct MklMatMulParams {
   };
   std::vector<PostOpParam> post_op_params;
 
-  MklMatMulParams(memory::dims a_dims, memory::dims b_dims, memory::dims c_dims,
-                  memory::dims a_strides, memory::dims b_strides,
-                  memory::dims c_strides)
-      : a_dims(a_dims),
+  MklMatMulParams(string prefix, memory::dims a_dims, memory::dims b_dims,
+                  memory::dims c_dims, memory::dims a_strides,
+                  memory::dims b_strides, memory::dims c_strides)
+      : prefix(prefix),
+        a_dims(a_dims),
         b_dims(b_dims),
         c_dims(c_dims),
         a_strides(a_strides),
@@ -837,9 +839,8 @@ class MklMatMulPrimitiveFactory : public MklPrimitiveFactory<T> {
   }
 
   static string CreateKey(const MklMatMulParams& params) {
-    string prefix = "matmul_";
     FactoryKeyCreator key_creator;
-    key_creator.AddAsKey(prefix);
+    key_creator.AddAsKey(params.prefix);
     key_creator.AddAsKey(params.a_dims);
     key_creator.AddAsKey(params.b_dims);
     key_creator.AddAsKey(params.c_dims);
@@ -901,8 +902,8 @@ void dnnl_gemm(char transa, char transb, int64_t m, int64_t n, int64_t k,
   DCHECK_EQ(alpha, 1.0f);
   DCHECK_EQ(beta, 0.f);
 
-  MklMatMulParams params(a_dims, b_dims, c_dims, a_strides, b_strides,
-                         c_strides);
+  MklMatMulParams params("dnnl_gemm", a_dims, b_dims, c_dims, a_strides,
+                         b_strides, c_strides);
   MklMatMulPrimitive<T, T, T>* matmul_prim =
       MklMatMulPrimitiveFactory<T, T, T, T>::Get(params, 0);
 


### PR DESCRIPTION
…cache in order to avoid collision in the cache. This change is to fix the issue https://github.com/tensorflow/tensorflow/issues/55933