### PR TITLE
[NVIDIA TF] Preload Cudnn Sub Libraries for Frontend APIs

### DIFF
--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -335,13 +335,12 @@ port::Status GetLoadedCudnnVersion(CudnnVersion* version) {
 
 enum class PreloadCudnnType { ConvFwd, ConvBwdFilter, ConvBwdData, Rnn };
 
-// Preload sub libs for cudnn 8.0.4+
+// Preload sub libs for cudnn 8.0.4+ to make sure that the loading time isn't
+// measured in the autotuning.
 void PreloadCudnnSubLibs(PreloadCudnnType type) {
 #if CUDNN_VERSION >= 8004
   switch (type) {
-    case PreloadCudnnType::ConvBwdFilter: {
-      [[clang::fallthrough]];
-    }
+    case PreloadCudnnType::ConvBwdFilter:
     case PreloadCudnnType::ConvBwdData: {
       cudnnOpsTrainVersionCheck();
       cudnnCnnTrainVersionCheck();
@@ -378,7 +377,8 @@ void PreloadCudnnSubLibsHelper(dnn::ConvolutionKind kind) {
       break;
     }
     default: {
-      LOG(WARNING) << "Unsupported dnn::ConvolutionKind for cuDNN preload.";
+      LOG(WARNING) << "Unsupported dnn::ConvolutionKind: "
+                   << static_cast<int>(kind) << " for cuDNN preload.";
       break;
     }
   }

--- a/tensorflow/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/stream_executor/cuda/cuda_dnn.cc
@@ -333,16 +333,56 @@ port::Status GetLoadedCudnnVersion(CudnnVersion* version) {
   return ::tensorflow::OkStatus();
 }
 
-#if CUDNN_MAJOR >= 8 && (CUDNN_MINOR > 0 || CUDNN_PATCHLEVEL >= 4)
-void PreloadCudnnLibrary(cudnnStatus_t (*version_check_fn)(),
-                         absl::string_view sub_library) {
-  cudnnStatus_t status = version_check_fn();
-  if (status != CUDNN_STATUS_SUCCESS) {
-    VLOG(1) << "Could not pre-initialize cuDNN sub-library " << sub_library
-            << ".  Error: " << cudnnGetErrorString(status) << ".";
+enum class PreloadCudnnType { ConvFwd, ConvBwdFilter, ConvBwdData, Rnn };
+
+// Preload sub libs for cudnn 8.0.4+
+void PreloadCudnnSubLibs(PreloadCudnnType type) {
+#if CUDNN_VERSION >= 8004
+  switch (type) {
+    case PreloadCudnnType::ConvBwdFilter: {
+      [[clang::fallthrough]];
+    }
+    case PreloadCudnnType::ConvBwdData: {
+      cudnnOpsTrainVersionCheck();
+      cudnnCnnTrainVersionCheck();
+      [[clang::fallthrough]];
+    }
+    case PreloadCudnnType::ConvFwd: {
+      cudnnOpsInferVersionCheck();
+      cudnnCnnInferVersionCheck();
+      break;
+    }
+    case PreloadCudnnType::Rnn: {
+      cudnnOpsInferVersionCheck();
+      cudnnAdvInferVersionCheck();
+      cudnnOpsTrainVersionCheck();
+      cudnnAdvTrainVersionCheck();
+      break;
+    }
+  }
+#endif  // CUDNN_VERSION >= 8004
+}
+
+void PreloadCudnnSubLibsHelper(dnn::ConvolutionKind kind) {
+  switch (kind) {
+    case dnn::ConvolutionKind::FORWARD: {
+      PreloadCudnnSubLibs(PreloadCudnnType::ConvFwd);
+      break;
+    }
+    case dnn::ConvolutionKind::BACKWARD_DATA: {
+      PreloadCudnnSubLibs(PreloadCudnnType::ConvBwdData);
+      break;
+    }
+    case dnn::ConvolutionKind::BACKWARD_FILTER: {
+      PreloadCudnnSubLibs(PreloadCudnnType::ConvBwdFilter);
+      break;
+    }
+    default: {
+      LOG(WARNING) << "Unsupported dnn::ConvolutionKind for cuDNN preload.";
+      break;
+    }
   }
 }
-#endif
 
 }  // namespace
 
@@ -3437,6 +3477,8 @@ GetCudnnOperationGraph(dnn::ConvolutionKind kind, dnn::DataType input_type,
                        const dnn::BatchDescriptor& output_descriptor,
                        const dnn::ConvolutionDescriptor& convolution_descriptor,
                        CudnnHandle& cudnn) {
+  PreloadCudnnSubLibsHelper(kind);
+
   cudnnBackendDescriptorType_t conv_mode = GetCudnnConvolutionType(kind);
 
   // x tensor.
@@ -3547,6 +3589,8 @@ GetCudnnFusedOperationGraph(
     const dnn::BatchDescriptor& output_descriptor,
     const dnn::ConvolutionDescriptor& convolution_descriptor,
     const dnn::ActivationMode activation_mode, CudnnHandle& cudnn) {
+  PreloadCudnnSubLibsHelper(kind);
+
   cudnnBackendDescriptorType_t conv_mode = GetCudnnConvolutionType(kind);
   dnn::DataType accumulator_type = GetConvAccumulatorType(input_type);
   dnn::DataType activation_type = GetConvActivationType(input_type);
@@ -5109,11 +5153,8 @@ port::Status CudnnSupport::GetFusedConvolveRunners(
 bool CudnnSupport::GetConvolveAlgorithms(
     CudaComputeCapability cuda_compute_capability,
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
-  // Preload sub libs for cudnn 8.0.4+
-#if CUDNN_MAJOR >= 8 && (CUDNN_MINOR > 0 || CUDNN_PATCHLEVEL >= 4)
-  cudnnOpsInferVersionCheck();
-  cudnnCnnInferVersionCheck();
-#endif
+  PreloadCudnnSubLibs(PreloadCudnnType::ConvFwd);
+
   bool tensor_op_math_available =
       TensorOpMathAvailable(cuda_compute_capability);
   out_algorithms->clear();
@@ -5150,13 +5191,8 @@ bool CudnnSupport::GetConvolveAlgorithms(
 
 bool CudnnSupport::GetRnnAlgorithms(
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
-  // Preload sub libs for cudnn 8.0.4+
-#if CUDNN_MAJOR >= 8 && (CUDNN_MINOR > 0 || CUDNN_PATCHLEVEL >= 4)
-  cudnnOpsInferVersionCheck();
-  cudnnOpsTrainVersionCheck();
-  cudnnAdvInferVersionCheck();
-  cudnnAdvTrainVersionCheck();
-#endif
+  PreloadCudnnSubLibs(PreloadCudnnType::Rnn);
+
   std::vector<dnn::AlgorithmDesc::Index> algo_types = {
       // clang-format off
     CUDNN_RNN_ALGO_STANDARD,
@@ -5176,13 +5212,8 @@ bool CudnnSupport::GetRnnAlgorithms(
 bool CudnnSupport::GetConvolveBackwardDataAlgorithms(
     CudaComputeCapability cuda_compute_capability,
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
-  // Preload sub libs for cudnn 8.0.4+
-#if CUDNN_MAJOR >= 8 && (CUDNN_MINOR > 0 || CUDNN_PATCHLEVEL >= 4)
-  cudnnOpsInferVersionCheck();
-  cudnnOpsTrainVersionCheck();
-  cudnnCnnInferVersionCheck();
-  cudnnCnnTrainVersionCheck();
-#endif
+  PreloadCudnnSubLibs(PreloadCudnnType::ConvBwdData);
+
   bool tensor_op_math_available =
       TensorOpMathAvailable(cuda_compute_capability);
   out_algorithms->clear();
@@ -5216,13 +5247,8 @@ bool CudnnSupport::GetConvolveBackwardDataAlgorithms(
 bool CudnnSupport::GetConvolveBackwardFilterAlgorithms(
     CudaComputeCapability cuda_compute_capability,
     std::vector<dnn::AlgorithmDesc>* out_algorithms) {
-  // Preload sub libs for cudnn 8.0.4+
-#if CUDNN_MAJOR >= 8 && (CUDNN_MINOR > 0 || CUDNN_PATCHLEVEL >= 4)
-  cudnnOpsInferVersionCheck();
-  cudnnOpsTrainVersionCheck();
-  cudnnCnnInferVersionCheck();
-  cudnnCnnTrainVersionCheck();
-#endif
+  PreloadCudnnSubLibs(PreloadCudnnType::ConvBwdFilter);
+
   bool tensor_op_math_available =
       TensorOpMathAvailable(cuda_compute_capability);
   out_algorithms->clear();


### PR DESCRIPTION
Before this PR, the cudnn sub libraries were only preloaded when the legacy APIs are used. This PR fixes this and ensures the preload for cudnn frontend APIs.

It would be difficult to create unit test for this, since it depends on the cudnn heuristics which differs among GPU architectures, cudnn versions, etc. We manually tested it using:

(1) Insert these lines in the XLA `GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheCuda` to display the profiling time for each autotuned conv engine:
```c++
  for (auto& runner_cache : runners) {
    TF_ASSIGN_OR_RETURN(
        auto result, AutotuneOneConvRunner(
                         config, instr, allocator, &input_output_allocator,
                         stream, &runner_cache, operand_buffers, result_buffer,
                         &reference_result, disabled_algos));
    auto a = tensorflow::proto_utils::FromDurationProto(result.run_time());
    double a_sec = absl::ToDoubleSeconds(a);
    printf("Run time: %lf\n", a_sec);

    profile_results.emplace_back(std::move(result));
  }
```
(2) Rebuild TF and run the script with cudnn frontend api enabled:
```python
import tensorflow as tf

x = tf.random.normal((512, 112, 112, 32), dtype=tf.float32)
p = tf.constant(0.)

conv2d = tf.keras.layers.Conv2D(filters=32, kernel_size=(3, 3), strides=(1, 1),
                                padding='same', use_bias=False, groups=32)

@tf.function(jit_compile=True)
def step(x):
  return conv2d(x)

y = step(x)
(p + 1.).numpy()  # Sync the GPU
```
On a V100 GPU, Before:
```
Run time: 0.541476 # This includes the overhead of loading cudnn lib.
Run time: 0.003376
Run time: 0.026523
Run time: 0.032151
Run time: 0.030736
Run time: 0.032210
Run time: 0.034119
Run time: 0.033691
Run time: 0.037900
```
After:
```
Run time: 0.002799 # This can more accurately reflect the kernel time.
Run time: 0.003250
Run time: 0.025338
Run time: 0.030755
Run time: 0.029313
Run time: 0.030758
Run time: 0.032752
Run time: 0.033699
Run time: 0.037834
```
After the PR, the overhead of loading cudnn sub libraries will not be included in the autotuning.

cc. @nluehr @pjannaty