### PR TITLE
[ROCm] Fix for JAX failure on ROCm due to commit ba57ae7f24743e684accef35214…

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -8,6 +8,7 @@ load(
 )
 load(
     "//tensorflow/core/platform:build_config_root.bzl",
+    "if_static",
     "tf_cuda_tests_tags",
 )
 load(
@@ -2109,7 +2110,7 @@ cc_library(
         "//tensorflow/core/platform:tensor_float_32_hdr_lib",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/types:span",
-    ],
+    ] + if_static(["//tensorflow/core/platform:tensor_float_32_utils"]),
 )
 
 tf_cc_test(


### PR DESCRIPTION
…85a24c1235186.

When running JAX unit tests on ROCm, the following error was observed:

ImportError: /usr/local/lib/python3.9/dist-packages/jaxlib/xla_extension.so: undefined symbol: _ZN10tensorflow33tensor_float_32_execution_enabledEv

This PR fixes the error.

/cc @cheshire @hawkinsp 