### PR TITLE
Bump JAX libs for CI

### DIFF
--- a/tensorflow/tools/ci_build/release/requirements_mac.txt
+++ b/tensorflow/tools/ci_build/release/requirements_mac.txt
@@ -8,5 +8,5 @@ twine ~= 3.6.0
 setuptools
 
 # Test dependencies which don't exist on Windows
-jax ~= 0.2.26
-jaxlib ~= 0.1.75
+jax ~= 0.3
+jaxlib ~= 0.3

--- a/tensorflow/tools/ci_build/release/requirements_mac.txt
+++ b/tensorflow/tools/ci_build/release/requirements_mac.txt
@@ -8,5 +8,5 @@ twine ~= 3.6.0
 setuptools
 
 # Test dependencies which don't exist on Windows
-jax ~= 0.3
-jaxlib ~= 0.3
+jax ~= 0.3.14
+jaxlib ~= 0.3.14

--- a/tensorflow/tools/ci_build/release/requirements_ubuntu.txt
+++ b/tensorflow/tools/ci_build/release/requirements_ubuntu.txt
@@ -5,5 +5,5 @@
 PyYAML ~= 6.0
 
 # Test dependencies which don't exist on Windows
-jax ~= 0.3
-jaxlib ~= 0.3
+jax ~= 0.3.14
+jaxlib ~= 0.3.14

--- a/tensorflow/tools/ci_build/release/requirements_ubuntu.txt
+++ b/tensorflow/tools/ci_build/release/requirements_ubuntu.txt
@@ -5,5 +5,5 @@
 PyYAML ~= 6.0
 
 # Test dependencies which don't exist on Windows
-jax ~= 0.2.26
-jaxlib ~= 0.1.75
+jax ~= 0.3
+jaxlib ~= 0.3


### PR DESCRIPTION
JAX libs are needed in CI as part of testing JAX <-> TFLite integration. This is only needed on Linux and Mac, as the corresponding tests are not run on Windows at this time.

There is no need for an equivalent change in `setup.py` as TF wheel does not depend on JAX. This is just a test-only dependency.

Fixes #56699