### PR TITLE
[NVIDIA TF:XLA:JAX] Add NVIDIA as a Trusted Partner and assign reviewers

### DIFF
--- a/.github/workflows/trusted-partners.yml
+++ b/.github/workflows/trusted-partners.yml
@@ -41,10 +41,13 @@ jobs:
             const domain = await script.get_email_domain({github, username});
             switch(domain) {
             case "intel.com":
-              console.log(await script.filter({github, context}));
+              console.log(await script.filter({github, context, domain}));
               break;
             case "apple.com":
-              console.log(await script.filter({github, context}));
+              console.log(await script.filter({github, context, domain}));
+              break;
+            case "nvidia.com":
+              console.log(await script.filter({github, context, domain}));
               break;
             case "google.com":
               console.log("Googler. No action necessary");

--- a/.github/workflows/trusted_partners.js
+++ b/.github/workflows/trusted_partners.js
@@ -49,7 +49,7 @@ const get_email_domain = async ({github, username}) => {
     context has the commit message details in the payload
   @return {string} Returns the message with labels attached and assignees added
 */
-const filter_action = async ({github, context}) => {
+const filter_action = async ({github, context, domain}) => {
   const labels = ['kokoro:force-run', 'ready to pull'];
 
   let assignees = [];
@@ -58,11 +58,22 @@ const filter_action = async ({github, context}) => {
   if (title && title.toLowerCase().includes("onednn"))
     assignees = onednn_assignees;
   const intel_windows_assignees = ['nitins17', 'learning-to-play'];
-  if (title && title.toLowerCase().includes("intel") && title.toLowerCase().includes("windows"))
+  if (title && title.toLowerCase().includes("intel") && title.toLowerCase().includes("windows")  && domain.includes("intel.com"))
     assignees = intel_windows_assignees;
   const apple_silicon_assignees = ['penpornk', 'nitins17'];
-  if (title && title.toLowerCase().includes("apple") && title.toLowerCase().includes("silicon"))
+  if (title && title.toLowerCase().includes("apple") && title.toLowerCase().includes("silicon") && domain.includes("apple.com"))
     assignees = apple_silicon_assignees;
+  if (title && title.toLowerCase().includes("nvidia") && domain.includes("nvidia.com")) {
+    if (title.toLowerCase().includes("jax")) {
+      assignees.push('hawkinsp', 'yashk2810', 'skye');
+    }
+    if (title.toLowerCase().includes("xla") || title.toLowerCase().includes("gpu")) {
+      assignees.push('cheshire', 'gcforster', 'reedwm', 'chsigg');
+    }
+    if (title.toLowerCase().includes("tf")) {
+      assignees.push('rohan100jain', 'bfontain', 'penpornk');
+    }
+  }
 
   const resp_label = await github.rest.issues.addLabels({
     issue_number: context.issue.number,


### PR DESCRIPTION
Add NVIDIA as a Trusted Partner and assign reviewers. Also add a domain check to prevent accidental cross-partner triggering of assignments.

Per-component designated reviewers:
- NVIDIA TF: Rohan Jain, Bruce Fontaine, Penporn Koanantakool
- NVIDIA XLA and GPU: George Karpenkov, Chris Forster, Reed Wanderman-Milne, Christian Sigg
- NVIDIA JAX: Peter Hawkins

The assignment logic retains the possibility of dispatching changes to more than one component, e.g. [NVIDIA TF XLA].

cc: @hawkinsp @yashk2810 @cheshire @gcforster @reedwm @chsigg @rohan100jain @bfontain @penpornk @skye