### PR TITLE
Fix duplicate kernel registration errors when using a Pluggable Device with the `GPU` type

### DIFF
--- a/tensorflow/core/framework/device_factory.cc
+++ b/tensorflow/core/framework/device_factory.cc
@@ -103,6 +103,15 @@ void DeviceFactory::Register(const string& device_type,
   } else {
     if (iter->second.priority < priority) {
       iter->second = {std::move(factory), priority, is_pluggable_device};
+
+      if (is_pluggable_device) {
+        // Pluggable devices are registered after all static kernels have been
+        // initialized, and they are allowed to override existing device types
+        // (e.g. "GPU"). To avoid duplicate kernel registrations issues, we
+        // remove all kernels that have already been registered on the lower
+        // priority device.
+        kernel_factory::UnregisterDeviceKernels(device_type);
+      }
     } else if (iter->second.priority == priority) {
       LOG(FATAL) << "Duplicate registration of device factory for type "
                  << device_type << " with the same priority " << priority;

--- a/tensorflow/core/framework/op_kernel.cc
+++ b/tensorflow/core/framework/op_kernel.cc
@@ -1296,6 +1296,23 @@ OpKernel* OpKernelRegistrar::PtrOpKernelFactory::Create(
   return (*create_func_)(context);
 }
 
+void UnregisterDeviceKernels(StringPiece device_type) {
+  auto global_registry =
+      reinterpret_cast<KernelRegistry*>(GlobalKernelRegistry());
+  mutex_lock l(global_registry->mu);
+
+  auto start = global_registry->registry.begin();
+  auto end = global_registry->registry.end();
+
+  for (auto iter = start; iter != end;) {
+    if (iter->second.def.device_type() == device_type) {
+      iter = global_registry->registry.erase(iter);
+    } else {
+      ++iter;
+    }
+  }
+}
+
 }  // namespace kernel_factory
 
 namespace {

--- a/tensorflow/core/framework/op_kernel.h
+++ b/tensorflow/core/framework/op_kernel.h
@@ -1530,6 +1530,8 @@ class OpKernelRegistrar {
                     std::unique_ptr<OpKernelFactory> factory);
 };
 
+void UnregisterDeviceKernels(StringPiece device_type);
+
 }  // namespace kernel_factory
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
One of the supported scenarios outlined in the Pluggable Device RFC is to be able to have a pluggable device with the type `GPU`, and have it completely override the built-in TensorFlow `GPU` device. However, since pluggable device kernels are registered at runtime, here's roughly what is happening:

1. TensorFlow is loaded
2. TensorFlow initializes the GPU device
3. TensorFlow registers all GPU kernels
4. TensorFlow loads the pluggable device DLL
5. TensorFlow overrides the built-in `GPU` device with the higher priority `GPU` device from the pluggable device
6. The pluggable device tries to register its own kernels by using the `GPU` type
7. TensorFlow throws an error since `GPU` kernels with the same priority have already been registered in step 3

Overriding the `GPU` device is not enough. Since the `GPU` kernels are statically registered, we need to unregister them as soon as a pluggable device with the same type comes online.