### PR TITLE
Fix unit tests that rely on unsupported behaviour

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -1062,7 +1062,7 @@ class GradSliceChecker(object):
     np_val_grad = (2 * self.varnp * self.varnp)
     np_sliceval_grad = np.zeros(self.var.get_shape())
     if isinstance(spec, ops.Tensor):
-      spec = self.test.evaluate([spec])
+      spec = self.test.evaluate(spec)
     np_sliceval_grad[spec] = np_val_grad[spec]
     # verify gradient
     self.test.assertAllEqual(slice_val_grad_evaled, np_sliceval_grad)

--- a/tensorflow/python/kernel_tests/array_ops/concat_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/concat_op_test.py
@@ -150,9 +150,9 @@ class ConcatOpTest(test.TestCase):
                               cur_offset + params[p[i]].shape[concat_dim])
       cur_offset += params[p[i]].shape[concat_dim]
       if dtype == dtype_feed:
-        self.assertAllEqual(result[ind], params[p[i]])
+        self.assertAllEqual(result[tuple(ind)], params[p[i]])
       else:
-        self.assertAllClose(result[ind], params[p[i]], 0.01)
+        self.assertAllClose(result[tuple(ind)], params[p[i]], 0.01)
 
   @test_util.run_deprecated_v1
   def testRandom(self):
@@ -554,7 +554,7 @@ class ConcatOpTest(test.TestCase):
           index[concat_dim] = slice(cur_offset,
                                     cur_offset + params[p[i]].shape[concat_dim])
           cur_offset += params[p[i]].shape[concat_dim]
-          self.assertAllEqual(result[index], params[p[i]])
+          self.assertAllEqual(result[tuple(index)], params[p[i]])
 
   def testConcatEmpty(self):
     with test_util.use_gpu():

--- a/tensorflow/python/kernel_tests/array_ops/slice_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/slice_op_test.py
@@ -338,7 +338,7 @@ class SliceTest(test.TestCase):
     slices = []
     for i in range(len(input_shape)):
       slices.append(slice(slice_begin[i], slice_begin[i] + slice_size[i]))
-    np_ans[slices] = grads
+    np_ans[tuple(slices)] = grads
 
     self.assertAllClose(np_ans, result)
 
@@ -363,7 +363,7 @@ class SliceTest(test.TestCase):
     slices = []
     for i in range(len(input_shape)):
       slices.append(slice(slice_begin[i], slice_begin[i] + slice_size[i]))
-    np_ans[slices] = grads
+    np_ans[tuple(slices)] = grads
 
     self.assertAllClose(np_ans, result)
 

--- a/tensorflow/python/kernel_tests/array_ops/split_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/split_op_test.py
@@ -139,7 +139,7 @@ class SplitOpTest(test.TestCase):
     for i in range(num_split):
       slices[split_dim] = slice(offset, offset + size_splits[i])
       offset += size_splits[i]
-      self.assertAllEqual(result[i], inp[slices])
+      self.assertAllEqual(result[i], inp[tuple(slices)])
 
   def _testSpecialCasesVariable(self):
     inp = np.random.rand(4, 4).astype("f")
@@ -165,7 +165,7 @@ class SplitOpTest(test.TestCase):
     for i in range(num_split):
       slices[split_dim] = slice(offset, offset + size_splits[i])
       offset += size_splits[i]
-      self.assertAllEqual(result[i], inp[slices])
+      self.assertAllEqual(result[i], inp[tuple(slices)])
 
   @test_util.run_in_graph_and_eager_modes
   def testSpecialCasesVariable(self):
@@ -299,7 +299,7 @@ class SplitOpTest(test.TestCase):
     for i in range(num_split):
       slices[split_dim] = slice(offset, offset + length)
       offset += length
-      self.assertAllEqual(result[i], inp[slices])
+      self.assertAllEqual(result[i], inp[tuple(slices)])
 
   @test_util.run_in_graph_and_eager_modes
   def testRandom(self):

--- a/tensorflow/python/kernel_tests/control_flow/scan_ops_test.py
+++ b/tensorflow/python/kernel_tests/control_flow/scan_ops_test.py
@@ -34,7 +34,7 @@ def numpy_reverse(x, axis):
   ix = [
       slice(None, None, -1) if i == axis else slice(None) for i in range(length)
   ]
-  return x[ix]
+  return x[tuple(ix)]
 
 
 def handle_options(func, x, axis, exclusive, reverse):
@@ -52,12 +52,12 @@ def handle_options(func, x, axis, exclusive, reverse):
         slice(0, -1) if i == axis else slice(None) for i in range(length)
     ]
     if func == np.cumsum:
-      init = np.zeros_like(x[ix_head])
+      init = np.zeros_like(x[tuple(ix_head)])
     elif func == np.cumprod:
-      init = np.ones_like(x[ix_head])
+      init = np.ones_like(x[tuple(ix_head)])
     else:
       raise ValueError("Unknown scan function.")
-    x = np.concatenate([init, func(x[ix_init], axis)], axis=axis)
+    x = np.concatenate([init, func(x[tuple(ix_init)], axis)], axis=axis)
   else:
     x = func(x, axis=axis)
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -3633,7 +3633,8 @@ def pad(tensor, paddings, mode="CONSTANT", name=None, constant_values=0):  # pyl
   if mode == "CONSTANT":
     # TODO(rjryan): Once the forward compatibility period (3 weeks) have passed
     # remove the "Pad" fallback here.
-    if not tensor_util.is_tf_type(constant_values) and constant_values == 0:
+    if not tensor_util.is_tf_type(constant_values) \
+        and np.isscalar(constant_values) and constant_values == 0:
       result = gen_array_ops.pad(tensor, paddings, name=name)
     else:
       result = gen_array_ops.pad_v2(


### PR DESCRIPTION
numpy 1.23.0 has removed some behaviours that have been
FutureWarn for some time now. Fix those unit tests that
still relied on that old unsupported behaviour

Fixes: https://github.com/tensorflow/tensorflow/issues/56713