### PR TITLE
[NVIDIA TF] Revert TF32+NHWC changes

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -2106,7 +2106,6 @@ cc_library(
         "//tensorflow/compiler/xla/service:layout_assignment",
         "//tensorflow/core:lib",
         "//tensorflow/core/platform:stream_executor_no_cuda",
-        "//tensorflow/core/platform:tensor_float_32_hdr_lib",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/types:span",
     ],

--- a/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.cc
@@ -99,19 +99,6 @@ HeuristicLayoutAssignment(const HloInstruction* instr,
     return kAllNHWC;
   }
 
-  // If we're on Ampere with fp32 and tf32 is on and conv2D, we will use NHWC to
-  // better use Tensor Cores.
-  bool valid_tf32 = input_ty == F32 &&
-                    stream_executor->GetDeviceDescription()
-                        .cuda_compute_capability()
-                        .IsAtLeast(se::CudaComputeCapability::AMPERE) &&
-                    tensorflow::tensor_float_32_execution_enabled() &&
-                    instr->shape().tuple_shapes(0).dimensions_size() == 4;
-  if (valid_tf32) {
-    VLOG(2) << "Using NHWC for tf32 conv " << instr->ToString();
-    return kAllNHWC;
-  }
-
   // If we're not Volta or not fp16, or not conv2D, the decision is easy: Use
   // NCHW.
   if (input_ty != F16 ||

--- a/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.h
@@ -21,7 +21,6 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/layout_assignment.h"
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/stream_executor_no_cuda.h"
-#include "tensorflow/core/platform/tensor_float_32_utils.h"
 
 namespace xla {
 namespace gpu {

--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -1169,10 +1169,7 @@ cc_library(
         "//tensorflow/core/grappler/clusters:cluster",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
-    ] + if_static(
-        ["//tensorflow/core/platform:tensor_float_32_utils"],
-        ["//tensorflow/core/platform:tensor_float_32_hdr_lib"],
-    ),
+    ],
 )
 
 tf_cuda_cc_test(

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -830,13 +830,12 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
       << "Negative row or col paddings: (" << common_padding_rows << ", "
       << common_padding_cols << ")";
 
-#if GOOGLE_CUDA
-  const bool compute_in_nhwc = ComputeInNhwcEnabled(DataTypeToEnum<T>::value,
-                                                    stream, /*is_conv2d=*/true);
-#else
-  // fast NHWC implementation is a CUDA only feature
-  const bool compute_in_nhwc = false;
-#endif
+  // The Tensor Core in NVIDIA Volta+ GPUs supports efficient convolution with
+  // fp16 in NHWC data layout. In all other configurations it's more efficient
+  // to run computation in NCHW data format.
+  const bool compute_in_nhwc = DataTypeToEnum<T>::value == DT_HALF &&
+                               stream->GetCudaComputeCapability().IsAtLeast(
+                                   se::CudaComputeCapability::VOLTA);
 
   // We only do one directional conversion: NHWC->NCHW. We never convert in the
   // other direction. Grappler layout optimizer selects the preferred layout and

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -211,8 +211,12 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
       << "Negative row or col paddings: (" << common_padding_rows << ", "
       << common_padding_cols << ")";
 
-  const bool compute_in_nhwc = ComputeInNhwcEnabled(DataTypeToEnum<T>::value,
-                                                    stream, /*is_conv2d=*/true);
+  // The Tensor Core in NVIDIA Volta+ GPUs supports efficient convolution with
+  // fp16 in NHWC data layout. In all other configurations it's more efficient
+  // to run computation in NCHW data format.
+  const bool compute_in_nhwc = DataTypeToEnum<T>::value == DT_HALF &&
+                               stream->GetCudaComputeCapability().IsAtLeast(
+                                   se::CudaComputeCapability::VOLTA);
 
   // We only do one directional conversion: NHWC->NCHW. We never convert in the
   // other direction. Grappler layout optimizer selects the preferred layout and

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1370,8 +1370,8 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
         << ", " << padding_planes << ")";
 
 #if GOOGLE_CUDA
-    const bool compute_in_nhwc = ComputeInNhwcEnabled(
-        DataTypeToEnum<T>::value, stream, /*is_conv2d=*/false);
+    const bool compute_in_nhwc =
+        CUDNN_VERSION >= 8000 && DataTypeToEnum<T>::value == DT_HALF;
 #else
     // fast NDHWC implementation is a CUDA only feature
     const bool compute_in_nhwc = false;
@@ -1766,8 +1766,8 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
         << ", " << padding_planes << ")";
 
 #if GOOGLE_CUDA
-    const bool compute_in_nhwc = ComputeInNhwcEnabled(
-        DataTypeToEnum<T>::value, stream, /*is_conv2d=*/false);
+    const bool compute_in_nhwc =
+        CUDNN_VERSION >= 8000 && DataTypeToEnum<T>::value == DT_HALF;
 #else
     // fast NDHWC implementation is a CUDA only feature
     const bool compute_in_nhwc = false;

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -873,8 +873,12 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
   }
 
 #if GOOGLE_CUDA
-  const bool compute_in_nhwc = ComputeInNhwcEnabled(DataTypeToEnum<T>::value,
-                                                    stream, /*is_conv2d=*/true);
+  // Tensor Core (NVIDIA Volta+ GPUs) supports efficient convolution with fp16
+  // in NHWC data layout. In all other configurations it's more efficient to
+  // run computation in NCHW data format.
+  const bool compute_in_nhwc = DataTypeToEnum<T>::value == DT_HALF &&
+                               stream->GetCudaComputeCapability().IsAtLeast(
+                                   se::CudaComputeCapability::VOLTA);
 #else
   // fast NHWC implementation is a CUDA only feature
   const bool compute_in_nhwc = false;

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -43,6 +43,7 @@ limitations under the License.
 using stream_executor::dnn::DimIndex;
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #if GOOGLE_CUDA
+#include "third_party/gpus/cudnn/cudnn.h"
 #include "tensorflow/stream_executor/gpu/asm_compiler.h"
 #include "tensorflow/stream_executor/gpu/redzone_allocator.h"
 #include "tensorflow/stream_executor/tf_allocator_adapter.h"
@@ -345,8 +346,8 @@ struct LaunchConvOp<GPUDevice, T> {
     }
 
 #if GOOGLE_CUDA
-    const bool compute_in_nhwc = ComputeInNhwcEnabled(
-        DataTypeToEnum<T>::value, stream, /*is_conv2d=*/false);
+    const bool compute_in_nhwc =
+        CUDNN_VERSION >= 8000 && DataTypeToEnum<T>::value == DT_HALF;
 #else
     // fast NHWC implementation is a CUDA only feature
     const bool compute_in_nhwc = false;

--- a/tensorflow/core/kernels/conv_ops_gpu.cc
+++ b/tensorflow/core/kernels/conv_ops_gpu.cc
@@ -97,7 +97,6 @@ StatusOr<std::vector<tensorflow::AutotuneResult>> AutotuneConvImpl(
 }
 }  // namespace
 #endif  // GOOGLE_CUDA
-}
 
 // Finds the best convolution algorithm for the given ConvLaunch (cuda
 // convolution on the stream) and parameters, by running all possible

--- a/tensorflow/core/kernels/conv_ops_gpu.cc
+++ b/tensorflow/core/kernels/conv_ops_gpu.cc
@@ -23,8 +23,6 @@ limitations under the License.
 #include "tensorflow/core/util/use_cudnn.h"
 
 #if GOOGLE_CUDA
-#include "third_party/gpus/cudnn/cudnn.h"
-#include "tensorflow/core/platform/tensor_float_32_utils.h"
 #include "tensorflow/stream_executor/gpu/gpu_asm_opts.h"
 #include "tensorflow/stream_executor/gpu/redzone_allocator.h"
 #include "tensorflow/stream_executor/tf_allocator_adapter.h"
@@ -98,27 +96,6 @@ StatusOr<std::vector<tensorflow::AutotuneResult>> AutotuneConvImpl(
   return results;
 }
 }  // namespace
-#endif  // GOOGLE_CUDA
-
-bool ComputeInNhwcEnabled(DataType data_type, se::Stream* stream,
-                          bool is_conv2d) {
-#if GOOGLE_CUDA
-  // Tensor Core supports efficient convolution with fp16 for NVIDIA Volta+
-  // GPUs and tf32 for Ampere+ GPUs in NHWC data layout. In all other
-  // configurations it's more efficient to run computation in NCHW data format.
-  bool use_nhwc_tf32 = data_type == DT_FLOAT &&
-                       stream->GetCudaComputeCapability().IsAtLeast(
-                           se::CudaComputeCapability::AMPERE) &&
-                       tensorflow::tensor_float_32_execution_enabled();
-  bool use_nhwc_fp16 =
-      data_type == DT_HALF && stream->GetCudaComputeCapability().IsAtLeast(
-                                  se::CudaComputeCapability::VOLTA);
-  if (is_conv2d) {
-    return use_nhwc_fp16 || use_nhwc_tf32;
-  }
-  return CUDNN_VERSION >= 8000 && (use_nhwc_fp16 || use_nhwc_tf32);
-#else
-  return false;
 #endif  // GOOGLE_CUDA
 }
 

--- a/tensorflow/core/kernels/conv_ops_gpu.h
+++ b/tensorflow/core/kernels/conv_ops_gpu.h
@@ -32,9 +32,6 @@ limitations under the License.
 
 namespace tensorflow {
 
-bool ComputeInNhwcEnabled(DataType data_type, se::Stream* stream,
-                          bool is_conv2d);
-
 // Get the Dnn workspace limit from the environment variable, which is in MB.
 // Return the workspace memory limit in bytes. If no value is set, return the
 // default value.


### PR DESCRIPTION
After some more extensive tests, we think we need to revert those PRs regarding the NHWC+TF32 changes:
https://github.com/tensorflow/tensorflow/pull/55761
https://github.com/tensorflow/tensorflow/pull/55806
https://github.com/tensorflow/tensorflow/pull/55920

During the tests, we noticed that in some cases the NCHW kernels are faster on Ampere. So, we think it is still a good practice to use NCHW by default for fp32/tf32 at this point.

cc. @nluehr @pjannaty 
