### PR TITLE
Unique mlir kernel names

### DIFF
--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -796,18 +796,18 @@ gpu_kernel_library(
     unroll_factors = "4",
 )
 
-# TODO: enable when supported in the pipeline
-# gpu_kernel_library(
-#     name = "gpu_atanh_kernels_experimental",
-#     op = "atanh",
-#     tile_size = "256",
-#     types = [
-#         "f32",
-#         "f64",
-#     ],
-#     unroll_factors = "4",
-#     jit_i64_indexed_for_large_tensors_types = ["f16"],
-# )
+#TODO: enable when supported in the pipeline
+gpu_kernel_library(
+    name = "gpu_atanh_kernels_experimental",
+    op = "atanh",
+    tile_size = "256",
+    types = [
+        "f32",
+        "f64",
+    ],
+    unroll_factors = "4",
+    jit_i64_indexed_for_large_tensors_types = ["f16"],
+)
 
 gpu_kernel_library(
     name = "gpu_conj_kernels",

--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -797,17 +797,17 @@ gpu_kernel_library(
 )
 
 #TODO: enable when supported in the pipeline
-gpu_kernel_library(
-    name = "gpu_atanh_kernels_experimental",
-    op = "atanh",
-    tile_size = "256",
-    types = [
-        "f32",
-        "f64",
-    ],
-    unroll_factors = "4",
-    jit_i64_indexed_for_large_tensors_types = ["f16"],
-)
+# gpu_kernel_library(
+#     name = "gpu_atanh_kernels_experimental",
+#     op = "atanh",
+#     tile_size = "256",
+#     types = [
+#         "f32",
+#         "f64",
+#     ],
+#     unroll_factors = "4",
+#     jit_i64_indexed_for_large_tensors_types = ["f16"],
+# )
 
 gpu_kernel_library(
     name = "gpu_conj_kernels",

--- a/tensorflow/core/kernels/mlir_generated/build_defs.bzl
+++ b/tensorflow/core/kernels/mlir_generated/build_defs.bzl
@@ -402,8 +402,9 @@ def _gen_kernel_library(
                 args = test_args,
                 size = test_size,
                 data = [
-                    ":{op}_{platform}_{type}_{output_type}.mlir".format(
+                    ":{op}_{name}_{platform}_{type}_{output_type}.mlir".format(
                         op = op,
+                        name = name,
                         platform = platform,
                         type = type,
                         output_type = output_type,

--- a/tensorflow/core/kernels/mlir_generated/build_defs.bzl
+++ b/tensorflow/core/kernels/mlir_generated/build_defs.bzl
@@ -89,16 +89,18 @@ _gen_mlir_op_rule = rule(
     implementation = _gen_mlir_op_impl,
 )
 
-def _gen_mlir_op(op, type, platform, output_type):
+def _gen_mlir_op(op, name, type, platform, output_type):
     _gen_mlir_op_rule(
-        name = "generate_{op}_{platform}_{type}_{output_type}_mlir".format(
+        name = "generate_{op}_{name}_{platform}_{type}_{output_type}_mlir".format(
             op = op,
+            name = name,
             platform = platform,
             type = type,
             output_type = output_type,
         ),
-        out = "{op}_{platform}_{type}_{output_type}.mlir".format(
+        out = "{op}_{name}_{platform}_{type}_{output_type}.mlir".format(
             op = op,
+            name = name,
             platform = platform,
             type = type,
             output_type = output_type,
@@ -338,13 +340,15 @@ def _gen_kernel_library(
             typed_tile_size = _get_shape(tile_size, type, tile_size_override)
             _gen_mlir_op(
                 op = op,
+                name = name,
                 output_type = output_type,
                 platform = platform,
                 type = type,
             )
             _gen_kernel_bin_rule(
-                name = "{op}_{platform}_{type}_{output_type}_kernel_generator".format(
+                name = "{op}_{name}_{platform}_{type}_{output_type}_kernel_generator".format(
                     op = op,
+                    name = name,
                     platform = platform,
                     type = type,
                     output_type = output_type,
@@ -355,8 +359,9 @@ def _gen_kernel_library(
                 gpu_archs = gpu_archs,
                 jit = jit,
                 max_supported_rank = max_supported_rank,
-                mlir_op = "{op}_{platform}_{type}_{output_type}.mlir".format(
+                mlir_op = "{op}_{name}_{platform}_{type}_{output_type}.mlir".format(
                     op = op,
+                    name = name,
                     platform = platform,
                     type = type,
                     output_type = output_type,
@@ -370,8 +375,9 @@ def _gen_kernel_library(
             gpu_arch_option = "sm_70,compute_75" if cuda_gpu_architectures() else ",".join(rocm_gpu_architectures())
             test_args = [
                 "$(location //tensorflow/compiler/mlir/tools/kernel_gen:tf_to_kernel)",
-                "$(location {op}_{platform}_{type}_{output_type}.mlir)".format(
+                "$(location {op}_{name}_{platform}_{type}_{output_type}.mlir)".format(
                     op = op,
+                    name = name,
                     platform = platform,
                     type = type,
                     output_type = output_type,
@@ -384,8 +390,9 @@ def _gen_kernel_library(
             if typed_unroll_factors:
                 test_args.append("--unroll_factors=%s" % typed_unroll_factors)
             native.sh_test(
-                name = "{op}_{platform}_{type}_{output_type}_gen_test".format(
+                name = "{op}_{name}_{platform}_{type}_{output_type}_gen_test".format(
                     op = op,
+                    name = name,
                     platform = platform,
                     type = type,
                     output_type = output_type,
@@ -406,8 +413,9 @@ def _gen_kernel_library(
             )
 
     kernel_deps = [
-        ":{op}_{platform}_{type}_{output_type}_kernel_generator".format(
+        ":{op}_{name}_{platform}_{type}_{output_type}_kernel_generator".format(
             op = op,
+            name = name,
             platform = platform,
             type = type,
             output_type = output_type,


### PR DESCRIPTION
This MR incorporates the name attribute for kernel get in MLIR. This is done to enable generation of the experimental kernels for int64 bit indexing.

CC: @frgossen 