### PR TITLE
Fix upstream rocm xla

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/runtime_intrinsics.cc
+++ b/tensorflow/compiler/xla/service/gpu/runtime_intrinsics.cc
@@ -72,7 +72,12 @@ static void AssertionCustomCall(void* stream_handle, void** buffers,
   }
 }
 
+#if GOOGLE_CUDA
 XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM(kXlaGpuAssertCustomCallTag,
                                          AssertionCustomCall, "CUDA");
+#else
+XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM(kXlaGpuAssertCustomCallTag,
+                                         AssertionCustomCall, "ROCM");
+#endif
 
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_atomic_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_atomic_test.cc
@@ -104,7 +104,7 @@ TEST_F(GpuAtomicTest, TestAddAtomicF32) {
 )";
 
   CompileAndVerifyIr(hlo_string, is_built_with_rocm_ ? R"(
-CHECK: atomicrmw fadd float addrspace{{.*}}, float {{.*}} seq_cst, align 4
+CHECK: atomicrmw fadd ptr addrspace(1) %[[ADDR:.*]], float %[[VALUE:.*]] syncscope("agent") seq_cst
 )"
                                                      : R"(
 CHECK: atomicrmw fadd ptr %[[ADDR:.*]], float %[[VALUE:.*]] seq_cst


### PR DESCRIPTION
1) ROCM registration for the custom ops for GPU assert 
2) Update a ROCm specific check in  gpu_atomic_test