### PR TITLE
[ROCM] Platform finder logic to substitute ROCM for CUDA when permitted

### DIFF
--- a/tensorflow/stream_executor/multi_platform_manager.cc
+++ b/tensorflow/stream_executor/multi_platform_manager.cc
@@ -128,7 +128,20 @@ port::StatusOr<Platform*> MultiPlatformManagerImpl::PlatformWithName(
     absl::string_view target, bool initialize_platform) {
   absl::MutexLock lock(&mu_);
 
-  TF_ASSIGN_OR_RETURN(Platform * platform, LookupByNameLocked(target));
+  //TF_ASSIGN_OR_RETURN(Platform * platform, LookupByNameLocked(target));
+  Platform * platform = 0;
+  if(target == "cuda" || target == "CUDA") {
+    port::StatusOr<Platform*> lookup = LookupByNameLocked("cuda");
+    if(lookup.ok())
+      platform = lookup.value();
+    else {
+      TF_ASSIGN_OR_RETURN(platform, LookupByNameLocked("rocm"));
+    }
+  } else {
+    if(target == "cuda_only")
+      target = "cuda";
+    TF_ASSIGN_OR_RETURN(platform, LookupByNameLocked(target));
+  }
   if (initialize_platform && !platform->Initialized()) {
     TF_RETURN_IF_ERROR(platform->Initialize({}));
   }


### PR DESCRIPTION
Looks up for "rocm" platform if lookup for platform by name "CUDA" or cuda fails