### PR TITLE
ROCm specific registration for custom ops

### DIFF
--- a/tensorflow/compiler/xla/python/BUILD
+++ b/tensorflow/compiler/xla/python/BUILD
@@ -330,6 +330,7 @@ cc_library(
         "//tensorflow/compiler/xla/pjrt:transpose",
         "//tensorflow/compiler/xla/service:custom_call_status",
         "//tensorflow/compiler/xla/service:custom_call_target_registry",
+        "//tensorflow/compiler/xla/service:platform_util",
         "//tensorflow/tsl/platform:statusor",
         "//tensorflow/tsl/profiler/lib:traceme",
         "//tensorflow/tsl/platform:fingerprint",

--- a/tensorflow/compiler/xla/python/py_client.cc
+++ b/tensorflow/compiler/xla/python/py_client.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/python/transfer_guard_lib.h"
 #include "tensorflow/compiler/xla/python/types.h"
 #include "tensorflow/compiler/xla/service/custom_call_target_registry.h"
+#include "tensorflow/compiler/xla/service/platform_util.h"
 #include "tensorflow/tsl/platform/statusor.h"
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -736,12 +737,7 @@ StatusOr<std::pair<XlaOp, pybind11::object>> PyClient::EmitPythonCallback(
 XLA_CPU_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM("xla_python_cpu_callback",
                                              &XlaPythonCpuCallback);
 
-#if TENSORFLOW_USE_ROCM
 XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM("xla_python_gpu_callback",
-                                         &XlaPythonGpuCallback, "ROCM");
-#elif defined(GOOGLE_CUDA)
-XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM("xla_python_gpu_callback",
-                                         &XlaPythonGpuCallback, "CUDA");
-#endif  // TENSORFLOW_USE_ROCM
+                                        AssertionCustomCall,absl::AsciiStrToUpper(PlatformUtil::CanonicalPlatformName("gpu").value()));
 
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -2888,6 +2888,7 @@ tf_cuda_library(
         "//tensorflow/compiler/xla:util",
         "//tensorflow/compiler/xla/service:custom_call_status",
         "//tensorflow/compiler/xla/service:custom_call_target_registry",
+        "//tensorflow/compiler/xla/service:platform_util",
         "//tensorflow/compiler/xla/stream_executor",
         "@com_google_absl//absl/cleanup",
     ],

--- a/tensorflow/compiler/xla/service/gpu/runtime_intrinsics.cc
+++ b/tensorflow/compiler/xla/service/gpu/runtime_intrinsics.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/statusor.h"
 #include "tensorflow/compiler/xla/stream_executor/multi_platform_manager.h"
 #include "tensorflow/compiler/xla/stream_executor/stream.h"
+#include "tensorflow/compiler/xla/service/platform_util.h"
 #include "tensorflow/compiler/xla/util.h"
 
 namespace xla {
@@ -36,7 +37,9 @@ extern const char* const kXlaGpuAssertCustomCallTag = "__xla_gpu_assert";
 static Status AssertOnGpu(void* stream_handle, void* buffer,
                           absl::string_view error_msg) {
   TF_ASSIGN_OR_RETURN(se::Platform * platform,
-                      se::MultiPlatformManager::PlatformWithName("CUDA"));
+                      se::MultiPlatformManager::PlatformWithName(
+                            absl::AsciiStrToUpper(PlatformUtil::CanonicalPlatformName("gpu").value())));
+
   se::StreamExecutorConfig config;
   config.gpu_stream = stream_handle;
   TF_ASSIGN_OR_RETURN(se::StreamExecutor * executor,
@@ -73,6 +76,6 @@ static void AssertionCustomCall(void* stream_handle, void** buffers,
 }
 
 XLA_REGISTER_CUSTOM_CALL_TARGET_WITH_SYM(kXlaGpuAssertCustomCallTag,
-                                         AssertionCustomCall, "CUDA");
+                                        AssertionCustomCall, absl::AsciiStrToUpper(PlatformUtil::CanonicalPlatformName("gpu").value()));
 
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/platform_util.cc
+++ b/tensorflow/compiler/xla/service/platform_util.cc
@@ -79,6 +79,11 @@ StatusOr<std::vector<se::Platform*>> GetSupportedPlatforms() {
 
 }  // namespace
 
+/*static */ StatusOr<std::string> 
+PlatformUtil::CanonicalPlatformName(const std::string& platform_name) {
+  return xla::CanonicalPlatformName(platform_name);
+}
+
 /* static */ StatusOr<std::vector<se::Platform*>>
 PlatformUtil::GetSupportedPlatforms() {
   // Gather all platforms which have an XLA compiler.
@@ -120,7 +125,7 @@ PlatformUtil::GetSupportedPlatforms() {
     const std::string& platform_name) {
   TF_ASSIGN_OR_RETURN(se::Platform * platform,
                       se::MultiPlatformManager::PlatformWithName(
-                          CanonicalPlatformName(platform_name)));
+                          xla::CanonicalPlatformName(platform_name)));
   TF_RETURN_IF_ERROR(Compiler::GetForPlatform(platform).status());
   return platform;
 }

--- a/tensorflow/compiler/xla/service/platform_util.h
+++ b/tensorflow/compiler/xla/service/platform_util.h
@@ -29,6 +29,12 @@ namespace xla {
 // Utilities for querying platforms and devices used by XLA.
 class PlatformUtil {
  public:
+  // Returns the canonical name of the underlying platform. 
+  //
+  // This is needed to differentiate if for given platform like GPU or CPU
+  // there are multiple implementations. For example, GPU platform may be cuda(Nvidia) or rocm(AMD)
+  static StatusOr<std::string> CanonicalPlatformName(const std::string& platform_name);
+
   // Returns the platforms present on the system and supported by XLA.
   //
   // Note that, even if a platform is present with zero devices, if we *do* have


### PR DESCRIPTION
1. ROCM registration for the custom ops for GPU assert
2. Adds code to use runtime function to determine GPU platform(CUDA or ROCm)

