### PR TITLE
[XLA] Keep the metadata during optimization for dot operation.

### DIFF
--- a/tensorflow/compiler/xla/service/dot_decomposer.cc
+++ b/tensorflow/compiler/xla/service/dot_decomposer.cc
@@ -162,7 +162,7 @@ Status CanonicalizeDot(HloInstruction* original_dot) {
   HloInstruction* dot = computation->AddInstruction(HloInstruction::CreateDot(
       ShapeUtil::MakeShape(original_dot->shape().element_type(), dot_dims),
       reshaped_lhs, reshaped_rhs, dot_dnums, original_dot->precision_config()));
-  dot->set_metadata(original_dot->metadata());
+  original_dot->SetupDerivedInstruction(dot);
 
   std::unique_ptr<HloInstruction> replacement =
       HloInstruction::CreateReshape(original_dot->shape(), dot);

--- a/tensorflow/compiler/xla/service/dot_decomposer.cc
+++ b/tensorflow/compiler/xla/service/dot_decomposer.cc
@@ -162,6 +162,7 @@ Status CanonicalizeDot(HloInstruction* original_dot) {
   HloInstruction* dot = computation->AddInstruction(HloInstruction::CreateDot(
       ShapeUtil::MakeShape(original_dot->shape().element_type(), dot_dims),
       reshaped_lhs, reshaped_rhs, dot_dnums, original_dot->precision_config()));
+  dot->set_metadata(original_dot->metadata());
 
   std::unique_ptr<HloInstruction> replacement =
       HloInstruction::CreateReshape(original_dot->shape(), dot);

--- a/tensorflow/compiler/xla/service/dot_merger.cc
+++ b/tensorflow/compiler/xla/service/dot_merger.cc
@@ -187,6 +187,13 @@ StatusOr<HloInstruction*> TryMergeSameOperand(HloInstruction* a,
   HloInstruction* new_dot = comp->AddInstruction(HloInstruction::CreateDot(
       new_dot_shape, dot_lhs, dot_rhs, dnums, a->precision_config()));
 
+  // We can't keep both. But one is better then none.
+  if (!a->metadata().op_name().empty()) {
+    new_dot->set_metadata(a->metadata());
+  } else if (!b->metadata().op_name().empty()){
+    new_dot->set_metadata(b->metadata());
+  }
+
   // Slice the outputs.
   DimensionVector start_indices(new_dot_shape.dimensions_size(), 0);
   DimensionVector limit_indices(new_dot_shape.dimensions().begin(),

--- a/tensorflow/compiler/xla/service/hlo_computation.h
+++ b/tensorflow/compiler/xla/service/hlo_computation.h
@@ -85,6 +85,10 @@ class HloComputation {
     std::unique_ptr<HloComputation> Build(
         HloInstruction* root_instruction = nullptr);
 
+    // Add the instruction to be part of this computation.
+    // If the new instruction is derived from another one,
+    // you probably want to do
+    // `original_inst->AddInstruction(new_inst)` instead.
     virtual HloInstruction* AddInstruction(
         std::unique_ptr<HloInstruction> instruction) {
       instructions_.push_back(std::move(instruction));

--- a/tensorflow/compiler/xla/service/hlo_instruction.h
+++ b/tensorflow/compiler/xla/service/hlo_instruction.h
@@ -515,6 +515,7 @@ class HloInstruction {
   void DetachFromOperandsAndUsers();
 
   // Adds a derived instruciton to the parent compuation of this instruction.
+  // Also update setup the new instruction as a derived instruction.
   HloInstruction* AddInstruction(
       std::unique_ptr<HloInstruction> derived_instruction);
 


### PR DESCRIPTION
Update the XLA optimization dot_decomposer and dot_merger to keep metadata for the dot operation.
This help get frequent metadata in the optimized graph.

Note, for the optimization dot_merger, we would need to add merge 2 metadata. So 2 source_line, 2 source_path, 2 op_name, ... This doesn't seem to be supported right now. So I add just one. One is better then none. But allowing multiple would be great.