### PR TITLE
Remove incorrect test tags so that all expected pip tests are run

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -66,13 +66,20 @@ export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} \
     -//tensorflow/python:nn_grad_test \
     -//tensorflow/python/client:session_list_devices_test \
     -//tensorflow/python/data/kernel_tests:iterator_test_cpu \
+    -//tensorflow/python/data/kernel_tests:iterator_test_gpu \
     -//tensorflow/python/eager:forwardprop_test \
     -//tensorflow/python/kernel_tests/array_ops:array_ops_test_cpu \
+    -//tensorflow/python/kernel_tests/array_ops:array_ops_test_gpu \
     -//tensorflow/python/kernel_tests/array_ops:concat_op_test_cpu \
+    -//tensorflow/python/kernel_tests/array_ops:concat_op_test_gpu \
     -//tensorflow/python/kernel_tests/array_ops:pad_op_test_cpu \
+    -//tensorflow/python/kernel_tests/array_ops:pad_op_test_gpu \
     -//tensorflow/python/kernel_tests/array_ops:slice_op_test_cpu \
+    -//tensorflow/python/kernel_tests/array_ops:slice_op_test_gpu \
     -//tensorflow/python/kernel_tests/array_ops:split_op_test_cpu \
+    -//tensorflow/python/kernel_tests/array_ops:split_op_test_gpu \
     -//tensorflow/python/kernel_tests/control_flow:scan_ops_test_cpu \
+    -//tensorflow/python/kernel_tests/control_flow:scan_ops_test_gpu \
     -//tensorflow/python/kernel_tests/linalg:linear_operator_householder_test \
     -//tensorflow/python/kernel_tests/linalg:linear_operator_inversion_test \
     -//tensorflow/python/kernel_tests/linalg:linear_operator_block_diag_test \
@@ -85,7 +92,7 @@ export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} \
     -//tensorflow/python/ops/parallel_for:math_test \
     -//tensorflow/python/training:server_lib_test"
 export TF_PIP_TESTS="test_pip_virtualenv_clean"
-export TF_TEST_FILTER_TAGS="-nopip,-no_pip,-no_oss,-oss_serial,-v1only,-requires-gpu,-gpu,-tpu,-benchmark-test,-no_aarch64"
+export TF_TEST_FILTER_TAGS="-nopip,-no_pip,-no_oss,-oss_serial,-v1only,-benchmark-test,-no_aarch64"
 export TF_PIP_TEST_ROOT="pip_test"
 export TF_AUDITWHEEL_TARGET_PLAT="manylinux2014"
 


### PR DESCRIPTION
These tags are not needed for pip tests on an installed wheel as is happening here.