### PR TITLE
Use FP32 in DepthwiseConv2D tests on TF32 capable devices

### DIFF
--- a/tensorflow/compiler/tests/depthwise_conv_op_test.py
+++ b/tensorflow/compiler/tests/depthwise_conv_op_test.py
@@ -19,6 +19,7 @@ import numpy as np
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import nn_impl
 from tensorflow.python.ops import nn_ops
@@ -215,6 +216,8 @@ class DepthwiseConv2DTest(xla_test.XLATestCase):
     self.assertAllClose(
         np.ravel(native_result), np.ravel(interface_result), rtol=tolerance)
 
+  @test_util.run_without_tensor_float_32(
+      "DepthwiseConv2D may use TF32 when available.")
   def testDepthwiseConv2D(self):
     for index, (input_size, filter_size, _, stride,
                 padding) in enumerate(ConfigsToTest()):
@@ -226,6 +229,8 @@ class DepthwiseConv2DTest(xla_test.XLATestCase):
           self._VerifyValues(
               input_size, filter_size, stride, padding, data_type)
 
+  @test_util.run_without_tensor_float_32(
+      "DepthwiseConv2D may use TF32 when available.")
   def testDepthwiseConv2DFormat(self):
     for index, (input_size, filter_size, _, stride,
                 padding) in enumerate(ConfigsToTest()):
@@ -531,6 +536,8 @@ class DepthwiseConv2DTest(xla_test.XLATestCase):
     cpu_value = _GetVal(use_xla=False)
     self.assertAllClose(cpu_value, gpu_value, rtol=1e-4, atol=1e-4)
 
+  @test_util.run_without_tensor_float_32(
+      "DepthwiseConv2DFilterGrad may use TF32 when available.")
   def testDepthwiseConv2DFilterGradCompare(self):
     for index, (input_size, filter_size, output_size, stride,
                 padding) in enumerate(ConfigsToTest()):
@@ -540,6 +547,8 @@ class DepthwiseConv2DTest(xla_test.XLATestCase):
       self._CompareBackpropFilter(input_size, filter_size, output_size,
                                   stride, padding)
 
+  @test_util.run_without_tensor_float_32(
+      "DepthwiseConv2DFilterGrad may use TF32 when available.")
   def testDepthwiseConv2DFilterGradFormatNCHWCompare(self):
     for index, (input_size, filter_size, output_size, stride,
                 padding) in enumerate(ConfigsToTest()):


### PR DESCRIPTION
Recent versions of CUDNN enable TF32 kernels for depthwise convolutions. This tweak configures tests to use true FP32 for these tests since that is what their numerical tolerances have been calibrated for.

Attn: @reedwm 