### PR TITLE
[NVIDIA TF] Part 3: Grappler graph pass supports matmul+bias+gelu_exact

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -1111,21 +1111,15 @@ inline bool VerifyConstants(RemapperContext* ctx,
   return true;
 }
 
-// Gelu in python api generates a number of nodes in the graph. Depending on the
-// parmeter `approximate={True/False}` different types of ops are generated. We
-// distinguish them as `GeluExact` that uses Erf and `GeluApproximate` that
-// uses Tanh.
-bool FindMatMulBiasAddAndGelu(RemapperContext* ctx, int node_index,
-                              std::map<string, int>* matched_nodes_map,
-                              std::set<int>* remove_node_indices,
-                              bool* is_gelu_approximate) {
-  // Gelu fusion is enabled with oneDNN or cublasLt library.
-  if (!IsMKLEnabled() && !BlasLtMatmulEnabled()) return false;
-
+bool IsMatchedMatMulBiasAddAndGeluExact(
+    RemapperContext& ctx, int node_index,
+    std::map<string, int>* matched_nodes_map = nullptr,
+    std::set<int>* remove_node_indices = nullptr) {
+  auto* node_view = ctx.graph_view.GetNode(node_index);
   using utils::MatchingDirection;
   using utils::NodeStatus;
   // clang-format off
-  utils::OpTypePattern gelu_exact_pattern =
+  static utils::OpTypePattern gelu_exact_pattern =
     {"Mul", "output", NodeStatus::kReplace,
       {
         {"Mul", "erf_plus_one_times_one_half", NodeStatus::kRemove,
@@ -1158,94 +1152,123 @@ bool FindMatMulBiasAddAndGelu(RemapperContext* ctx, int node_index,
     };
   // clang-format on
 
-  // Gelu approximate uses Pow(x, 3). On GPU, it is a single Pow() node, but on
-  // CPU, it is optimized by arithmetic optimizer as Mul(x, Square(x)) with an
-  // arifact of control dependency. So we try to match pattern at second pass of
-  // remapper which reccieves _FusedMatMul (MatMul + BiasAdd) with control
-  // dependency removed.
-  // clang-format off
-  utils::OpTypePattern subgraph_gpu =
-    {"Mul", "mul", NodeStatus::kRemove,
-      {
-        {"Pow", "pow", NodeStatus::kRemove,
-          {
-            {"_FusedMatMul", "matmul", NodeStatus::kRemove},
-            {"Const", "three", NodeStatus::kRemain}
-          }
-        },
-        {"Const", "empirical_const", NodeStatus::kRemain}
-      }
-    };
-  utils::OpTypePattern subgraph_cpu =
-    {"Mul", "mul", NodeStatus::kRemove,
-      {
-        {"Mul", "empirical_const_times_matmul", NodeStatus::kRemove,
-          {
-            {"Const", "empirical_const", NodeStatus::kRemain},
-            {"_FusedMatMul", "matmul", NodeStatus::kRemove}
-          }
-        },
-        {"Square", "square", NodeStatus::kRemove,
-          {
-            {"_FusedMatMul", "matmul", NodeStatus::kRemove}
-          }
-        }
-      }
-    };
-  // clang-format on
+  utils::SubGraphMatcher<MatchingDirection::kFollowInputs> graph_matcher(
+      &(ctx.graph_view));
+  // Find GeluExact
+  std::map<string, int> dummy_matched_nodes_map;
+  std::set<int> dummy_remove_node_indices;
+  return graph_matcher.GetMatchedNodes(
+      gelu_exact_pattern, ctx.nodes_to_preserve, node_view,
+      matched_nodes_map ? matched_nodes_map : &dummy_matched_nodes_map,
+      remove_node_indices ? remove_node_indices : &dummy_remove_node_indices);
+}
 
-  utils::MutableNodeView* node_view = ctx->graph_view.GetNode(node_index);
-  const NodeDef* node_def = node_view->node();
-  bool root_on_gpu = NodeIsOnGpu(node_def);
-  utils::OpTypePattern* subgraph_pattern =
-      root_on_gpu ? &subgraph_gpu : &subgraph_cpu;
+// Gelu in python api generates a number of nodes in the graph. Depending on the
+// parmeter `approximate={True/False}` different types of ops are generated. We
+// distinguish them as `GeluExact` that uses Erf and `GeluApproximate` that
+// uses Tanh.
+bool FindMatMulBiasAddAndGelu(RemapperContext* ctx, int node_index,
+                              const Cluster* cluster,
+                              std::map<string, int>* matched_nodes_map,
+                              std::set<int>* remove_node_indices,
+                              bool* is_gelu_approximate) {
+  // Gelu fusion is enabled with oneDNN or cublasLt or cuDNN library.
+  if (!IsMKLEnabled() && !BlasLtMatmulEnabled() &&
+      !RuntimeFusionEnabled(cluster))
+    return false;
 
-  // clang-format off
-  utils::OpTypePattern gelu_approximate_pattern =
-    {"Mul", "output", NodeStatus::kReplace,
-      {
-        {"Mul", "tanh_plus_one_times_one_half", NodeStatus::kRemove,
-          {
-            {"AddV2", "tanh_plus_one", NodeStatus::kRemove,
-              {
-                {"Tanh", "tanh", NodeStatus::kRemove,
-                  {
-                    {"Mul", "matmul_plus_mul_times_square_root_two_over_pi", NodeStatus::kRemove,
-                      {
-                        {"AddV2", "matmul_plus_mul", NodeStatus::kRemove,
-                          {
-                            {"_FusedMatMul", "matmul", NodeStatus::kRemove},
-                            *subgraph_pattern
-                          }
-                        },
-                        {"Const", "square_root_two_over_pi", NodeStatus::kRemain}
-                      }
-                    }
-                  }
-                },
-                {"Const", "one", NodeStatus::kRemain}
-              }
-            },
-            {"Const", "one_half", NodeStatus::kRemain}
-          }
-        },
-        {"_FusedMatMul", "matmul", NodeStatus::kRemove}
-      }
-    };
-  // clang-format on
+  using utils::MatchingDirection;
+  using utils::NodeStatus;
 
   bool found_gelu_exact = false;
   bool found_gelu_approximate = false;
-  utils::SubGraphMatcher<MatchingDirection::kFollowInputs> graph_matcher(
-      &(ctx->graph_view));
+
   // Find GeluExact
   matched_nodes_map->clear();
   remove_node_indices->clear();
-  found_gelu_exact = graph_matcher.GetMatchedNodes(
-      gelu_exact_pattern, ctx->nodes_to_preserve, node_view, matched_nodes_map,
-      remove_node_indices);
+  found_gelu_exact = IsMatchedMatMulBiasAddAndGeluExact(
+      *ctx, node_index, matched_nodes_map, remove_node_indices);
   // Find GeluApproximate
   if (!found_gelu_exact) {
+    // Gelu approximate uses Pow(x, 3). On GPU, it is a single Pow() node, but
+    // on CPU, it is optimized by arithmetic optimizer as Mul(x, Square(x)) with
+    // an arifact of control dependency. So we try to match pattern at second
+    // pass of remapper which reccieves _FusedMatMul (MatMul + BiasAdd) with
+    // control dependency removed.
+    // clang-format off
+    utils::OpTypePattern subgraph_gpu =
+      {"Mul", "mul", NodeStatus::kRemove,
+        {
+          {"Pow", "pow", NodeStatus::kRemove,
+            {
+              {"_FusedMatMul", "matmul", NodeStatus::kRemove},
+              {"Const", "three", NodeStatus::kRemain}
+            }
+          },
+          {"Const", "empirical_const", NodeStatus::kRemain}
+        }
+      };
+    utils::OpTypePattern subgraph_cpu =
+      {"Mul", "mul", NodeStatus::kRemove,
+        {
+          {"Mul", "empirical_const_times_matmul", NodeStatus::kRemove,
+            {
+              {"Const", "empirical_const", NodeStatus::kRemain},
+              {"_FusedMatMul", "matmul", NodeStatus::kRemove}
+            }
+          },
+          {"Square", "square", NodeStatus::kRemove,
+            {
+              {"_FusedMatMul", "matmul", NodeStatus::kRemove}
+            }
+          }
+        }
+      };
+    // clang-format on
+
+    utils::MutableNodeView* node_view = ctx->graph_view.GetNode(node_index);
+    const NodeDef* node_def = node_view->node();
+    bool root_on_gpu = NodeIsOnGpu(node_def);
+    utils::OpTypePattern* subgraph_pattern =
+        root_on_gpu ? &subgraph_gpu : &subgraph_cpu;
+
+    // clang-format off
+    utils::OpTypePattern gelu_approximate_pattern =
+      {"Mul", "output", NodeStatus::kReplace,
+        {
+          {"Mul", "tanh_plus_one_times_one_half", NodeStatus::kRemove,
+            {
+              {"AddV2", "tanh_plus_one", NodeStatus::kRemove,
+                {
+                  {"Tanh", "tanh", NodeStatus::kRemove,
+                    {
+                      {"Mul", "matmul_plus_mul_times_square_root_two_over_pi", NodeStatus::kRemove,
+                        {
+                          {"AddV2", "matmul_plus_mul", NodeStatus::kRemove,
+                            {
+                              {"_FusedMatMul", "matmul", NodeStatus::kRemove},
+                              *subgraph_pattern
+                            }
+                          },
+                          {"Const", "square_root_two_over_pi", NodeStatus::kRemain}
+                        }
+                      }
+                    }
+                  },
+                  {"Const", "one", NodeStatus::kRemain}
+                }
+              },
+              {"Const", "one_half", NodeStatus::kRemain}
+            }
+          },
+          {"_FusedMatMul", "matmul", NodeStatus::kRemove}
+        }
+      };
+    // clang-format on
+
+    utils::SubGraphMatcher<MatchingDirection::kFollowInputs> graph_matcher(
+        &(ctx->graph_view));
+
     matched_nodes_map->clear();
     remove_node_indices->clear();
     found_gelu_approximate = graph_matcher.GetMatchedNodes(
@@ -1262,23 +1285,37 @@ bool FindMatMulBiasAddAndGelu(RemapperContext* ctx, int node_index,
   // ops), we check if (i) MatMul op is CpuCompatible or GpuComptible, (ii)
   // const nodes have desired values.
   if (found_gelu_exact) {
-    if (!IsMKLEnabled()) return false;
-    // Check if the MatMul to be fused is CPU compatible
-    // TODO(kaixih@nvidia): Add GPU support when cublastLt supports the exact
-    // form.
+    // Check if the MatMul to be fused is device compatible.
     NodeDef* matmul_node =
         ctx->graph_view.GetNode(matched_nodes_map->at("matmul"))->node();
-    if (!IsCpuCompatibleMatMul(*ctx, matmul_node)) {
-      matched_nodes_map->clear();
-      remove_node_indices->clear();
-      return false;
+    DataType matmul_dtype = GetDataTypeFromAttr(*matmul_node, "T");
+
+    bool cpu_ok = IsMKLEnabled() && IsCpuCompatibleMatMul(*ctx, matmul_node);
+    bool gpu_ok = NodeIsOnGpu(matmul_node) && RuntimeFusionEnabled(cluster) &&
+                  matmul_dtype == DT_HALF;
+    if (!cpu_ok && !gpu_ok) return false;
+
+    // Check if the leading dims of input matrices are even numbers. The CuDNN
+    // runtime fusion kernels require 32-bit aligned data loading.
+    if (gpu_ok) {
+      const std::vector<OpInfo::TensorProperties>& input_props =
+          ctx->graph_properties.GetInputProperties(matmul_node->name());
+      const TensorShapeProto& a_shape =
+          input_props.size() >= 1 ? input_props[0].shape() : TensorShapeProto();
+      const TensorShapeProto& b_shape =
+          input_props.size() >= 1 ? input_props[1].shape() : TensorShapeProto();
+      bool valid_dims = Rank(a_shape) == 2 && Rank(b_shape) == 2 &&
+                        IsKnown(a_shape.dim(1)) &&         //
+                        IsKnown(b_shape.dim(1)) &&         //
+                        a_shape.dim(1).size() % 2 == 0 &&  //
+                        b_shape.dim(1).size() % 2 == 0;
+      if (!valid_dims) return false;
     }
+
     // Check if the matched constants have desired values.
-    if (found_gelu_exact) {
-      std::map<string, float> values_map = {
-          {"square_root_one_half", 0.707106}, {"one", 1.0}, {"one_half", 0.5}};
-      if (!VerifyConstants(ctx, matched_nodes_map, &values_map)) return false;
-    }
+    std::map<string, float> values_map = {
+        {"square_root_one_half", 0.707106}, {"one", 1.0}, {"one_half", 0.5}};
+    if (!VerifyConstants(ctx, matched_nodes_map, &values_map)) return false;
   } else if (found_gelu_approximate) {
     NodeDef* matmul_node =
         ctx->graph_view.GetNode(matched_nodes_map->at("matmul"))->node();
@@ -3440,6 +3477,15 @@ bool RequiresInferredShapes(const RemapperContext& ctx, int node_index,
     return false;
   };
 
+  // Candidate for a FusedMatmul fusion (MatMul + BiasAdd + GeluExact).
+  const auto is_matmul_gelu_exact_fusion_candidate = [&]() -> bool {
+    if (!RuntimeFusionEnabled(cluster)) return false;
+    DataType node_dtype = GetDataTypeFromAttr(*node_def, "T");
+    if (node_dtype != DT_HALF) return false;
+    return IsMatchedMatMulBiasAddAndGeluExact(const_cast<RemapperContext&>(ctx),
+                                              node_index);
+  };
+
   if (IsMKLEnabled())
     return is_batch_norm_candidate() || is_batch_norm_fusion_candidate() ||
            IsContractionWithAdd(ctx, node_index) ||
@@ -3447,7 +3493,8 @@ bool RequiresInferredShapes(const RemapperContext& ctx, int node_index,
 
   return is_act_biasadd_conv_candidate() || is_batch_norm_candidate() ||
          is_batch_norm_fusion_candidate() ||
-         is_batch_norm_grad_fusion_candidate();
+         is_batch_norm_grad_fusion_candidate() ||
+         is_matmul_gelu_exact_fusion_candidate();
 }
 }  // namespace
 
@@ -3585,7 +3632,7 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
     std::map<string, int> matched_nodes_map;
     std::set<int> remove_node_indices;
     bool is_gelu_approximate = false;
-    if (FindMatMulBiasAddAndGelu(&ctx, i, &matched_nodes_map,
+    if (FindMatMulBiasAddAndGelu(&ctx, i, cluster, &matched_nodes_map,
                                  &remove_node_indices, &is_gelu_approximate)) {
       TF_RETURN_IF_ERROR(AddFusedMatMulBiasAddAndGelu(
           &ctx, matched_nodes_map, remove_node_indices, &invalidated_nodes,

--- a/tensorflow/python/grappler/remapper_test.py
+++ b/tensorflow/python/grappler/remapper_test.py
@@ -74,9 +74,9 @@ class RemapperTest(test.TestCase, parameterized.TestCase):
 
   def setUp(self):
     super(RemapperTest, self).setUp()
-    # Gelu fusion on GPU requires cublasLt
+    # GeluApproximate fusion on GPU requires cublasLt.
     os.environ['TF_USE_CUBLASLT'] = '1'
-    # Conv runtime fusion on GPU requires cuDNN frontend APIs.
+    # GeluExact fusion and conv runtime fusion on GPU requires cuDNN frontend.
     os.environ['TF_CUDNN_USE_FRONTEND'] = '1'
     os.environ['TF_CUDNN_USE_RUNTIME_FUSION'] = '1'
 
@@ -138,50 +138,55 @@ class RemapperTest(test.TestCase, parameterized.TestCase):
   @parameterized.parameters(['cuda', 'mkl'])
   @test_util.run_deprecated_v1
   @test_util.disable_xla('This test does not pass with XLA')
-  def test_matmul_biasadd_gelu_fusion(self, mode):
+  def test_matmul_biasadd_activation_fusion(self, mode):
     """Test MatMul+BiasAdd+Gelu fusion."""
     self.maybe_skip_test(mode)
-    data_types = [dtypes.float32]
-    if mode == 'cuda':
-      data_types.append(dtypes.float16)
-    elif mode == 'mkl':
-      data_types.append(dtypes.bfloat16)
 
-    is_bf16_supported = _pywrap_utils.IsBF16SupportedByOneDNNOnThisCPU()
+    def gelu_approximate(x):
+      return nn.gelu(z, approximate=True)
+    def gelu_exact(x):
+      return nn.gelu(z, approximate=False)
 
-    m, n, k = (3, 3, 4)  # Matrix dimensions
-    for precision in data_types:
-      for approximate in (False, True):
-        # Gelu exact (approximate=False) is not supported with bfloat16
-        # precision since no support for Erf with bfloat16 data type.
-        # TODO(intel-tf): Enable gelu exact with bfloat16, when Erf op is
-        # supported with bfloat16.
-        if precision == dtypes.bfloat16:
-          if not (approximate and is_bf16_supported):
-            continue
+    device = '/device:GPU:0' if mode == 'cuda' else '/device:CPU:0'
+    config = []
+    if mode == 'mkl':
+      config.append((dtypes.float32, gelu_exact, b'GeluExact'))
+      config.append((dtypes.float32, gelu_approximate, b'GeluApproximate'))
+      # Gelu exact (approximate=False) is not supported with bfloat16 precision
+      # since no support for Erf with bfloat16 data type.
+      # TODO(intel-tf): Enable gelu exact with bfloat16, when Erf op is
+      # supported with bfloat16.
+      if _pywrap_utils.IsBF16SupportedByOneDNNOnThisCPU():
+        config.append((dtypes.bfloat16, gelu_approximate, b'GeluApproximate'))
+    elif mode == 'cuda':
+      config.append((dtypes.float32, gelu_approximate, b'GeluApproximate'))
+      config.append((dtypes.float16, gelu_approximate, b'GeluApproximate'))
+      # Gelu exact fusion is supported by cuDNN frontend APIs and performant
+      # with fp16 and on Ampere GPUs and later.
+      if (test_util.is_gpu_available(cuda_only=True,
+                                     min_cuda_compute_capability=(8, 0))):
+        config.append((dtypes.float16, gelu_exact, b'GeluExact'))
 
-        # TODO(kaixih@nvidia): Enable gelu exact when Erf op is supported with
-        # cublaslt.
-        if mode == 'cuda' and not approximate:
-          continue
+    m, n, k = (2, 4, 6)  # Matrix dimensions
+    fused_op = ['_MklNativeFusedMatMul', '_MklFusedMatMul', '_FusedMatMul']
 
-        device = '/device:GPU:0' if mode == 'cuda' else '/device:CPU:0'
-        # Create MatMul + BiasAdd + Gelu graph
+    for precision, act_fn, act_name in config:
+      for transpose in (False, True):
+        # Create MatMul + BiasAdd + Activation graph
         ops.reset_default_graph()
         with ops.device(device):
-          x = _input([m, k])
-          w = _weight([k, n])
+          x = _input([k, m] if transpose else [m, k])
+          w = _weight([n, k] if transpose else [k, n])
           b = _bias([n])
           x = math_ops.cast(x, precision)
           w = math_ops.cast(w, precision)
           b = math_ops.cast(b, precision)
-          y = math_ops.matmul(x, w)
+          y = math_ops.matmul(x, w, transpose_a=transpose,
+                              transpose_b=transpose)
           z = nn.bias_add(y, b)
-          out = nn.gelu(z, approximate=approximate)
+          out = act_fn(z)
 
-        gelu_type = b'GeluApproximate' if approximate else b'GeluExact'
-        epilog_ops = [b'BiasAdd', gelu_type]
-        fused_op = ['_MklNativeFusedMatMul', '_MklFusedMatMul', '_FusedMatMul']
+        epilog_ops = [b'BiasAdd', act_name]
         graph = self._VerifyValues(out, precision != dtypes.float32, fused_op,
                                    epilog_ops)
 


### PR DESCRIPTION
This PR enables the cudnn matmul fusion backend for supporting the generic matmul fusion patterns. Specifically, this PR focuses on the matmul+bias+gelu_exact pattern. (Note, the matmul+bias+gelu_approximate has already been supported by cublasLt backend. See https://github.com/tensorflow/tensorflow/pull/55966)

Part 1: Stream executor supports cudnn matmul fusion.
Part 2: Fused matmul op supports cudnn matmul fusion.
Part 3: Grappler graph pass supports matmul+bias+gelu_exact. (This one)

Note: This PR depends on the changes of a parent PR (https://github.com/tensorflow/tensorflow/pull/56826). Please see the change diff  [here](https://github.com/kaixih/tensorflow/compare/gelu_exact_upstream_part2...kaixih:tensorflow:gelu_exact_upstream_part3?expand=1).

cc. @nluehr @pjannaty 