### PR TITLE
[oneDNN]: Fixing pooling_ops_3d_test unit test failure

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
@@ -192,7 +192,7 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       auto shape_vec = orig_input_tensor.vec<int32>();
       TensorShape orig_input_shape;
       for (int i = 0; i < orig_input_tensor.NumElements(); i++) {
-        orig_input_shape.AddDim(shape_vec(i));
+        orig_input_shape.AddDimWithStatus(shape_vec(i));
       }
 
       bool is_pool2d = (this->ksize_.size() == 4);


### PR DESCRIPTION
This PR fixes a failure in `//tensorflow/python/kernel_tests/nn_ops:pooling_ops_3d_test` unit test introduced by [this](https://github.com/tensorflow/tensorflow/commit/9178ac9d6389bdc54638ab913ea0e419234d14eb) commit.