### PR TITLE
Fix compilation issue when building mhlo as an external project.

### DIFF
--- a/tensorflow/compiler/mlir/hlo/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/CMakeLists.txt
@@ -96,6 +96,7 @@ if(MHLO_EXTERNAL_PROJECT_BUILD)
   set(MLIR_INCLUDE_DIR ${MLIR_MAIN_SRC_DIR}/include ) # --includedir
   set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
   set(MLIR_TABLEGEN_EXE $<TARGET_FILE:mlir-tblgen>)
+  set(MLIR_PDLL_TABLEGEN_EXE $<TARGET_FILE:mlir-pdll>)
   include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
   include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})
   include_directories(SYSTEM ${MLIR_TABLEGEN_OUTPUT_DIR})


### PR DESCRIPTION
For the "MLIR_PDLL_TABLEGEN_EXE not set" issue that I met in this PR (https://github.com/llvm/torch-mlir/pull/1083) when building mhlo as an external project