### PR TITLE
Cache size is too small for machines with more than 49 CPU cores

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/service/cross_trainer_cache_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/service/cross_trainer_cache_test.py
@@ -24,6 +24,8 @@ from tensorflow.python.framework import combinations
 from tensorflow.python.framework import errors
 from tensorflow.python.platform import test
 
+import multiprocessing
+
 
 class CrossTrainerCacheTest(data_service_test_base.TestBase,
                             parameterized.TestCase):
@@ -71,8 +73,18 @@ class CrossTrainerCacheTest(data_service_test_base.TestBase,
       combinations.times(
           combinations.combine(tf_api_version=2, mode=["eager", "graph"])))
   def testConcurrentReaders(self):
+    # Fetching an element from the dataset will trigger prefetches of more
+    # elements, one per CPU core which will be placed in the cache.
+    # However if the number of prefetches exceeds the space available in
+    # the cache then the sliding window will be moved forward away from
+    # the element just read thus negating the use of the cache as other
+    # trainers will not get the correct element.
+    # Hence the need to calculate the size of the cache based on the
+    # number of CPU cores and the element size of 363. The extra 8
+    # entries are simply a bit of margin.
+    num_cpus = multiprocessing.cpu_count()
     cluster = self._create_cluster(
-        num_workers=1, cross_trainer_cache_size_bytes=18000)
+        num_workers=1, cross_trainer_cache_size_bytes=(num_cpus + 8) * 363)
     num_readers = 20
     num_elements = 50
     dataset = dataset_ops.Dataset.range(10000000).repeat()


### PR DESCRIPTION
The element size in this case is 363 bytes which only allows for
49 entries in the cache with a size of 18000. So instead make
the size of cache dependent on the number of CPU cores.
The count of CPU cores is relevant as the elements of the dataset
are pre-fetched, once per CPU core. This means that if the cache
is too small for the number of CPU cores then the sliding window
will have moved away from the original element read thus making
the cache pointless.

Fixes #56840 