### PR TITLE
[TF-TRT] Improve unit test of validation

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1493,11 +1493,11 @@ class OpConverterTest : public ::testing::Test {
     }
 
     status = RunValidation(node);
+    // If conversion fails, it should fail already during valiadation.
+    EXPECT_THAT(status,
+                StatusIs(expected_code, HasSubstr(expected_msg_substr)));
     if (should_run_conversion && status.ok()) {
       RunConversion(node, expected_code, expected_msg_substr);
-    } else {
-      EXPECT_THAT(status,
-                  StatusIs(expected_code, HasSubstr(expected_msg_substr)));
     }
   }
 


### PR DESCRIPTION
This PR fixes testing the validation mode of the converters. We compare the validation status always to the expected status.

The previous test did not handle the case correctly if the expected status is fail, but the actual validation status was passing.