### PR TITLE
[mhlo] Fix warnings emited by `-Wsign-compare`

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/include/mlir-hlo/Dialect/mhlo/transforms/map_mhlo_to_scalar_op.h
+++ b/tensorflow/compiler/xla/mlir_hlo/include/mlir-hlo/Dialect/mhlo/transforms/map_mhlo_to_scalar_op.h
@@ -452,7 +452,7 @@ inline Value mapReducePrecisionOpToStdScalarOp(
   APInt expBitsMask(nbits, 1);
   expBitsMask = ((expBitsMask << srcExponentBits) - 1) << srcMantissaBits;
 
-  if (destMantissaBits < srcMantissaBits) {
+  if (destMantissaBits < static_cast<int>(srcMantissaBits)) {
     // Last remaining mantissa bit.
     APInt lastMantissaBitMask(nbits, 1);
     lastMantissaBitMask <<= srcMantissaBits - destMantissaBits;

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/gml_st/IR/gml_st_ops.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/gml_st/IR/gml_st_ops.cc
@@ -1799,7 +1799,7 @@ LogicalResult TransposeDimsOp::verify() {
   SmallVector<int64_t> position(rank, -1);
   for (const auto &it : llvm::enumerate(permutation())) {
     int64_t dim = it.value();
-    if (dim < 0 || dim >= rank) {
+    if (dim < 0 || dim >= static_cast<int64_t>(rank)) {
       return emitOpError("permutation[")
              << it.index() << "] = " << dim << " is outside of range [0, "
              << rank - 1 << "]";
@@ -1861,7 +1861,8 @@ void SetYieldOp::build(
     return attr.cast<BoolAttr>().getValue();
   });
   (void)accumulatorCount;
-  assert(accumulatorCount == accumulatorBuilderFns.size() &&
+  assert(accumulatorCount ==
+             static_cast<int64_t>(accumulatorBuilderFns.size()) &&
          "the number of flags set in `accumulatorFlags` attribute should be "
          "equal to the number of `accumulatorBuilderFns`");
 
@@ -1895,7 +1896,7 @@ LogicalResult SetYieldOp::verify() {
   auto accumulatorCount = llvm::count_if(
       accumulatorFlags(),
       [](Attribute attr) { return attr.cast<BoolAttr>().getValue(); });
-  if (accumulatorCount != accumulators().size())
+  if (accumulatorCount != static_cast<int64_t>(accumulators().size()))
     return emitOpError("expected the number of accumulator regions ")
            << accumulators().size()
            << " to match the number of set accumulator flags "

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/gml_st/transforms/fusion_interface_impl.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/gml_st/transforms/fusion_interface_impl.cc
@@ -82,7 +82,7 @@ struct LinalgGenericFusionInterface
         unsigned int rank = map.getNumResults();
         SmallVector<int64_t> permutation;
         permutation.reserve(rank);
-        for (int i = 0; i < rank; ++i) {
+        for (int i = 0; i < static_cast<int>(rank); ++i) {
           permutation.push_back(map.getPermutedPosition(i));
         }
         operandSubset = builder.create<TransposeDimsOp>(

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/gml_st/transforms/legalize_mhlo_to_gml.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/gml_st/transforms/legalize_mhlo_to_gml.cc
@@ -34,8 +34,9 @@ namespace gml_st {
 namespace {
 
 bool isIotaArray(llvm::ArrayRef<int64_t> array, int expectedSize = -1) {
-  if (expectedSize != -1 && array.size() != expectedSize) return false;
-  for (int i = 0, e = array.size(); i < e; ++i) {
+  if (expectedSize != -1 && static_cast<int>(array.size()) != expectedSize)
+    return false;
+  for (int64_t i = 0, e = array.size(); i < e; ++i) {
     if (i != array[i]) return false;
   }
   return true;

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/gml_st/transforms/tiling.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/gml_st/transforms/tiling.cc
@@ -68,7 +68,7 @@ Value createTileSet(OpBuilder &b, Location loc, Value space, ValueRange ivs,
   SmallVector<int64_t> staticSizes;
   SmallVector<Value> dynamicSizes;
   staticSizes.reserve(rank);
-  for (int i = 0; i < rank; ++i) {
+  for (int64_t i = 0; i < static_cast<int64_t>(rank); ++i) {
     // Check if this dimension can be perfectly tiled.
     if (tileSizes[i] == 1 || (spaceShape[i] != ShapedType::kDynamicSize &&
                               spaceShape[i] % tileSizes[i] == 0)) {
@@ -110,7 +110,7 @@ Value createSet(OpBuilder &b, Location loc, Value space, ValueRange ivs,
 Value createParallelLoopTiling(OpBuilder &b, Location loc, Value target,
                                ArrayRef<int64_t> tileSizes) {
   auto ty = target.getType().cast<RankedTensorType>();
-  assert(ty.getRank() == tileSizes.size() &&
+  assert(ty.getRank() == static_cast<int64_t>(tileSizes.size()) &&
          "expect tile sizes to match rank of target value");
 
   // Create space.

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/lhlo/IR/lhlo_ops.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/lhlo/IR/lhlo_ops.cc
@@ -224,7 +224,7 @@ LogicalResult CustomCallOp::verify() {
     auto verifyMapping = [&](int64_t targetNum, size_t opNum,
                              ArrayRef<int64_t> mapping,
                              StringRef kind) -> LogicalResult {
-      if (targetNum < opNum)
+      if (targetNum < static_cast<int64_t>(opNum))
         return op.emitOpError("number of target " + kind + " (")
                << targetNum << ") cannot be less than the number of " << kind
                << "(" << opNum << ") for the operation";

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/IR/chlo_ops.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/IR/chlo_ops.cc
@@ -497,7 +497,7 @@ LogicalResult TopKOp::inferReturnTypeComponents(
     return emitOptionalError(location,
                              "operand's last dimension must be static");
   }
-  if (operandLastDim < k) {
+  if (operandLastDim < static_cast<int64_t>(k)) {
     return emitOptionalError(location,
                              "operand's last dimension must be at least ", k);
   }

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/IR/hlo_ops.cc
@@ -417,7 +417,7 @@ SmallVector<int64_t> inferWindowOutputShape(
          "Size of window dimensions must match the size of base shape.");
 
   SmallVector<int64_t> outputDimensions(window.size());
-  for (int64_t i = 0; i < window.size(); ++i) {
+  for (int64_t i = 0; i < static_cast<int64_t>(window.size()); ++i) {
     if (isDynamicDimSize(baseShape[i]) || isDynamicDimSize(window[i].size)) {
       outputDimensions[i] = ShapedType::kDynamicSize;
     } else {
@@ -469,7 +469,7 @@ LogicalResult verifyReducerShape(
     SmallVectorImpl<TensorType>& accumulatorSubShapes) {
   // Check that the number of reduction-region arguments matches with that of
   // reduce-op's arguments.
-  if (block.getArguments().size() != numInputs * 2)
+  if (static_cast<int64_t>(block.getArguments().size()) != numInputs * 2)
     return mlir::emitError(loc)
            << "Reduction-region must take " << numInputs * 2
            << " parameters, but takes " << block.getArguments().size()
@@ -482,7 +482,8 @@ LogicalResult verifyReducerShape(
 
   // Check that the reduction-region returns list- of tensors.
   // The number of result-tensors must match the `numInputs`.
-  if (block.getTerminator()->getOperands().size() != numInputs)
+  if (static_cast<int64_t>(block.getTerminator()->getOperands().size()) !=
+      numInputs)
     return mlir::emitError(loc)
            << "Reduction-region here must produce " << numInputs
            << " tensors, but produces "
@@ -589,13 +590,13 @@ LogicalResult verifyReducerShape(
 
     int64_t argShapeIdx = 0;
     for (int64_t outputShapeIdx = 0;
-         outputShapeIdx < allowedDimensions.size() &&
-         argShapeIdx < argShape.size();
+         outputShapeIdx < static_cast<int64_t>(allowedDimensions.size()) &&
+         argShapeIdx < static_cast<int64_t>(argShape.size());
          outputShapeIdx++)
       if (allowedDimensions[outputShapeIdx] == argShape[argShapeIdx])
         argShapeIdx++;
 
-    if (argShapeIdx != argShape.size())
+    if (argShapeIdx != static_cast<int64_t>(argShape.size()))
       return mlir::emitError(loc)
              << "The shape of reduction-region's argument at index "
              << numInputs + inputIdx
@@ -1209,7 +1210,7 @@ LogicalResult DotGeneralOp::reifyReturnTypeShapes(
 // P3. Element types agree with fft_type
 LogicalResult FftOp::verify() {
   // P1.
-  auto fftRank = fft_length().size();
+  int64_t fftRank = fft_length().size();
   if (fftRank > 3 || fftRank < 1) {
     return emitOpError() << "rank must be between 1 and 3, but got " << fftRank
                          << ".";
@@ -1219,7 +1220,7 @@ LogicalResult FftOp::verify() {
   auto operandType = operand().getType().dyn_cast<RankedTensorType>();
   if (!operandType) return success();
   auto operandShape = operandType.getShape();
-  if (operandShape.size() < fftRank) {
+  if (static_cast<int64_t>(operandShape.size()) < fftRank) {
     return emitOpError() << "operand rank must be greater than fft rank of "
                          << fftRank << " for operand of type " << operandType
                          << ".";
@@ -1308,7 +1309,8 @@ struct GatherSlice : public OpRewritePattern<GatherOp> {
 
     // TODO(tberghammer): Remove when the verifier catches this case what is
     // invalid if all previous condition holds.
-    if (index.getNumElements() != dnums.getStartIndexMap().size())
+    if (index.getNumElements() !=
+        static_cast<int64_t>(dnums.getStartIndexMap().size()))
       return failure();
 
     RankedTensorType operandType =
@@ -1452,14 +1454,14 @@ static LogicalResult verifyGather(
         effectiveDimSize = 1;
       else
         effectiveDimSize = startIndicesShape.getDimSize(indexVectorDim);
-
       // P4.
-      if (effectiveDimSize != startIndexMap.size())
-        return errorEmitter()
-               << "start_index_map size (" << startIndexMap.size()
-               << ") is not equal to size of index dimension ("
-               << indexVectorDim << ") of start_indices (" << effectiveDimSize
-               << ")";
+      if (effectiveDimSize !=
+          static_cast<int64_t>(dimensionNumbers.getStartIndexMap().size()))
+        return errorEmitter() << "start_index_map size ("
+                              << dimensionNumbers.getStartIndexMap().size()
+                              << ") is not equal to size of index dimension ("
+                              << indexVectorDim << ") of start_indices ("
+                              << effectiveDimSize << ")";
     }
   }
 
@@ -1586,7 +1588,7 @@ static void inferGatherShape(
     adjustedSliceSizePrefix.push_back(getSliceDim(dimIndex));
   }
   auto getAdjustedSliceDim = [&](int64_t index) -> dimTy {
-    if (index < adjustedSliceSizePrefix.size())
+    if (index < static_cast<int64_t>(adjustedSliceSizePrefix.size()))
       return adjustedSliceSizePrefix[index];
     return getSliceDim(index + collapsedSliceDims.size());
   };
@@ -1827,7 +1829,8 @@ LogicalResult IotaOp::verify() {
   if (shape.getRank() == 0) return emitOpError() << "does not support scalars.";
 
   auto iotaDimension = this->iota_dimension();
-  if (iotaDimension >= shape.getRank() || iotaDimension < 0)
+  if (static_cast<int64_t>(iotaDimension) >= shape.getRank() ||
+      iotaDimension < 0)
     return emitOpError()
            << "iota dimension cannot go beyond the output rank or be negative.";
   return success();
@@ -2310,12 +2313,12 @@ SmallVector<int64_t> inferConvolutionOpReturnShape(
   auto inputSpatialDims = op.dimension_numbers().getInputSpatialDimensions();
   auto numSpatialDims = inputSpatialDims.size();
   SmallVector<int64_t> inputSpatialDimVals(numSpatialDims);
-  for (int i = 0; i < numSpatialDims; ++i)
+  for (int64_t i = 0; i < static_cast<int64_t>(numSpatialDims); ++i)
     inputSpatialDimVals[i] = lhsType.getShape()[inputSpatialDims[i]];
 
   auto windowOutputShape = inferWindowOutputShape(inputSpatialDimVals, window);
 
-  for (int i = 0; i < window.size(); ++i)
+  for (int64_t i = 0; i < static_cast<int64_t>(window.size()); ++i)
     outputDimensions[op.dimension_numbers().getOutputSpatialDimensions()[i]] =
         windowOutputShape[i];
 
@@ -2657,7 +2660,8 @@ struct UnpackRepackSameTuple : public OpRewritePattern<TupleOp> {
     for (const auto& elementAndIdx : llvm::enumerate(op.val().drop_front(1))) {
       auto elementOp = elementAndIdx.value().getDefiningOp<GetTupleElementOp>();
       if (!elementOp ||
-          elementOp.indexAttr().getInt() != elementAndIdx.index() + 1 ||
+          elementOp.indexAttr().getInt() !=
+              static_cast<int64_t>(elementAndIdx.index() + 1) ||
           elementOp.getOperand() != tuplePredecessor)
         return failure();
     }
@@ -4445,7 +4449,7 @@ LogicalResult MapOp::verify() {
   DenseIntElementsAttr dimensions = this->dimensions();
   for (const auto& indexedValue :
        llvm::enumerate(dimensions.getValues<int64_t>())) {
-    if (indexedValue.value() != indexedValue.index())
+    if (indexedValue.value() != static_cast<int64_t>(indexedValue.index()))
       return emitOpError() << "requires monotonically increasing dimension "
                               "numbers, but got: "
                            << dimensions;
@@ -4456,7 +4460,8 @@ LogicalResult MapOp::verify() {
   // dimensions: i.e., scalar map functions.
   auto operandType = operands()[0].getType().cast<TensorType>();
   if (operandType.hasRank()) {
-    if (dimensions.size() != operandType.getShape().size())
+    if (dimensions.size() !=
+        static_cast<int64_t>(operandType.getShape().size()))
       return emitOpError()
              << "applied to a subset of dimensions currently not supported: "
                 "operand dimensions = "
@@ -4574,7 +4579,7 @@ LogicalResult ReduceWindowOp::verify() {
       convertDenseIntAttr(this->window_dimensions());
   for (const auto inputType : inputTypes) {
     if (!inputType.hasRank()) continue;
-    if (inputType.getRank() != windowDims.size())
+    if (inputType.getRank() != static_cast<int64_t>(windowDims.size()))
       return emitOpError()
              << "expects window-dimensions size == input rank, but got "
                 "window-dimensions size: "
@@ -4618,7 +4623,8 @@ LogicalResult ReduceWindowOp::verify() {
   // Check if the element-type of results match with the ones derived from
   // the reducer-block. Already ensured that  |accumulator_subshapes| ==
   // num_inputs == num_of_results.
-  for (int64_t shapeIdx = 0; shapeIdx < accumulatorSubshapes.size();
+  for (int64_t shapeIdx = 0;
+       shapeIdx < static_cast<int64_t>(accumulatorSubshapes.size());
        shapeIdx++) {
     if (accumulatorSubshapes[shapeIdx].getElementType() !=
         resultTensorTypes[shapeIdx].getElementType()) {
@@ -4662,9 +4668,9 @@ Operation* ReduceWindowOp::getReductionOp(int resultIndex) {
   auto arg0 = computeOp->getOperand(0).dyn_cast<BlockArgument>();
   auto arg1 = computeOp->getOperand(1).dyn_cast<BlockArgument>();
   if (!arg0 || !arg1) return nullptr;
-  int arg0Num = arg0.getArgNumber();
-  int arg1Num = arg1.getArgNumber();
-  size_t otherArgIndex = resultIndex + operands().size();
+  int64_t arg0Num = arg0.getArgNumber();
+  int64_t arg1Num = arg1.getArgNumber();
+  int64_t otherArgIndex = resultIndex + operands().size();
   if (arg0Num == resultIndex && arg1Num == otherArgIndex) return computeOp;
   if (arg0Num == otherArgIndex && arg1Num == resultIndex &&
       computeOp->hasTrait<mlir::OpTrait::IsCommutative>())
@@ -5174,7 +5180,8 @@ LogicalResult ReduceOp::verify() {
                        << getResults().size() << " vs "
                        << accumulatorSubShapes.size() << " (expected)";
 
-  for (int64_t shapeIdx = 0; shapeIdx < accumulatorSubShapes.size();
+  for (int64_t shapeIdx = 0;
+       shapeIdx < static_cast<int64_t>(accumulatorSubShapes.size());
        shapeIdx++) {
     // The result-type is enforced as "TensorType" by ODS.
     auto opResultType = getResult(shapeIdx).getType().cast<TensorType>();
@@ -5657,7 +5664,8 @@ OpFoldResult padOpFoldHelper(DenseElementsAttr input, DenseElementsAttr padding,
                       llvm::ArrayRef<int64_t> shape) {
     for (int64_t i = index.size() - 1; i >= 0; --i) {
       ++index[i];
-      if (index[i] < shape[i]) return;
+      if (static_cast<int64_t>(index[i]) < shape[i])
+        return;
       index[i] = 0;
     }
   };
@@ -7098,7 +7106,7 @@ static LogicalResult sortOpInferDefaultDimension(SortOp op,
   if (!ty) {
     return failure();
   }
-  if (op.dimension() != -1) {
+  if (static_cast<int64_t>(op.dimension()) != -1) {
     return failure();
   }
 
@@ -7365,7 +7373,8 @@ LogicalResult GetTupleElementOp::inferReturnTypes(
 
   auto indexAttr = attributes.get("index").cast<IntegerAttr>();
   auto index = indexAttr.getInt();
-  if (index < 0 || index >= tupleType.size()) return failure();
+  if (index < 0 || index >= static_cast<int64_t>(tupleType.size()))
+    return failure();
 
   inferredReturnTypes.push_back(tupleType.getType(index));
   return success();
@@ -7644,7 +7653,7 @@ LogicalResult SelectAndScatterOp::verify() {
   SmallVector<int64_t> windowDims =
       convertDenseIntAttr(this->window_dimensions());
   if (operandType.hasRank()) {
-    if (operandType.getRank() != windowDims.size())
+    if (operandType.getRank() != static_cast<int64_t>(windowDims.size()))
       return emitOpError()
              << "expects window-dimensions size == operand rank, but got "
                 "window-dimensions size: "
@@ -7749,7 +7758,7 @@ LogicalResult validateScatterDimensionNumbers(
   // P3.
   if (operandTypeRanked) {
     auto windowSize = updateWindowDims.size() + insertedWindowDims.size();
-    if (operandType.getRank() != windowSize)
+    if (operandType.getRank() != static_cast<int64_t>(windowSize))
       return mlir::emitError(loc)
              << "Expects rank-of operand to match "
                 "size-of('update_window_dims')  + "
@@ -7763,7 +7772,7 @@ LogicalResult validateScatterDimensionNumbers(
   auto indexVectorDim = dimNumbers.getIndexVectorDim();
   if (scatterIndicesTypeRanked) {
     if (!isDynamicDimSize(scatterIndicesShape[indexVectorDim]) &&
-        scatterDimsToOperandDims.size() !=
+        static_cast<int64_t>(scatterDimsToOperandDims.size()) !=
             scatterIndicesShape[dimNumbers.getIndexVectorDim()])
       return mlir::emitError(loc)
              << "Scatter op has " << scatterDimsToOperandDims.size()
@@ -7775,7 +7784,8 @@ LogicalResult validateScatterDimensionNumbers(
   }
 
   if (operandTypeRanked) {
-    for (int i = 0; i < scatterDimsToOperandDims.size(); ++i) {
+    for (int64_t i = 0;
+         i < static_cast<int64_t>(scatterDimsToOperandDims.size()); ++i) {
       int64_t scatterDimToOperandDim = scatterDimsToOperandDims[i];
       if (scatterDimToOperandDim < 0 ||
           scatterDimToOperandDim >= operandType.getRank())
@@ -7843,7 +7853,7 @@ LogicalResult ScatterOp::verify() {
   Block& block = update_computation().front();
   SmallVector<TensorType> accumulatorSubshapes;
   SmallVector<TensorType> inputTypes, initValueTypes;
-  for (int i = 0; i < numOperands; i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(numOperands); i++) {
     inputTypes.push_back(operandTypes[i]);
     initValueTypes.push_back(
         RankedTensorType::get({}, updatesTypes[i].getElementType()));
@@ -7860,11 +7870,12 @@ LogicalResult ScatterOp::verify() {
   if (scatterIndicesTypeRanked) {
     expandedScatterIndicesShape =
         llvm::to_vector(scatterIndicesType.getShape());
-    if (expandedScatterIndicesShape.size() == indexVectorDim)
+    if (static_cast<int64_t>(expandedScatterIndicesShape.size()) ==
+        indexVectorDim)
       expandedScatterIndicesShape.push_back(1);
   }
 
-  for (int i = 0; i < numOperands; i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(numOperands); i++) {
     if (scatterIndicesTypeRanked && updatesTypes[i].isa<RankedTensorType>()) {
       int64_t expectedUpdatesRank =
           expandedScatterIndicesShape.size() - 1 + updateWindowDims.size();
@@ -7881,7 +7892,7 @@ LogicalResult ScatterOp::verify() {
   }
 
   // P4.
-  for (int i = 0; i < numOperands; i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(numOperands); i++) {
     if (failed(validateScatterDimensionNumbers(
             operandTypes[i], expandedScatterIndicesShape, updatesTypes[i],
             operandTypes[i].isa<RankedTensorType>(), scatterIndicesTypeRanked,
@@ -7891,7 +7902,7 @@ LogicalResult ScatterOp::verify() {
   }
 
   // P5.
-  for (int i = 0; i < numOperands; i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(numOperands); i++) {
     if (updatesTypes[i].isa<RankedTensorType>()) {
       auto updatesShape = updatesTypes[i].getShape();
       if (operandTypes[i].isa<RankedTensorType>()) {
@@ -7904,7 +7915,8 @@ LogicalResult ScatterOp::verify() {
         const auto dimensionsSize = operandTypes[i].getRank();
         maxUpdateSliceSizes.reserve(dimensionsSize);
         for (int i = 0; i < dimensionsSize; ++i) {
-          if (insertedDimsSeen < insertedWindowDims.size() &&
+          if (insertedDimsSeen <
+                  static_cast<int64_t>(insertedWindowDims.size()) &&
               insertedWindowDims[insertedDimsSeen] == i) {
             ++insertedDimsSeen;
           } else {
@@ -7912,7 +7924,8 @@ LogicalResult ScatterOp::verify() {
           }
         }
 
-        for (int i = 0; i < updateWindowDims.size(); ++i) {
+        for (int64_t i = 0; i < static_cast<int64_t>(updateWindowDims.size());
+             ++i) {
           auto updateWindowDim = updateWindowDims[i];
 
           if (isDynamicDimSize(updatesShape[updateWindowDim]) ||
@@ -7935,7 +7948,8 @@ LogicalResult ScatterOp::verify() {
       // P6.
       if (scatterIndicesTypeRanked) {
         int64_t scatterDimsSeen = 0;
-        for (int64_t i = 0; i < updatesShape.size(); ++i) {
+        for (int64_t i = 0; i < static_cast<int64_t>(updatesShape.size());
+             ++i) {
           bool isUpdateWindowDim = std::binary_search(
               updateWindowDims.begin(), updateWindowDims.end(), i);
 
@@ -7964,7 +7978,7 @@ LogicalResult ScatterOp::verify() {
   }
 
   // P7.
-  for (int i = 0; i < numOperands; i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(numOperands); i++) {
     if (!compatibleShapeAndElementType(operandTypes[i], getResult(i).getType()))
       return emitOpError()
              << "expects the return type to be same as the operand type: "
@@ -8050,7 +8064,8 @@ LogicalResult ScatterOp::fold(
                       llvm::ArrayRef<int64_t> shape) {
     for (int64_t i = index.size() - 1; i >= 0; --i) {
       ++index[i];
-      if (index[i] < shape[i]) return true;
+      if (index[i] < static_cast<unsigned long>(shape[i]))
+        return true;
       index[i] = 0;
     }
     return false;
@@ -8066,18 +8081,19 @@ LogicalResult ScatterOp::fold(
   llvm::SmallVector<uint64_t, 8> updateIndex(updateType.getRank(), 0);
   llvm::SmallVector<uint64_t, 8> indexIndex;
   indexIndex.reserve(indexType.getRank());
-  llvm::SmallVector<uint64_t, 8> baseIndex;
+  llvm::SmallVector<int64_t, 8> baseIndex;
   baseIndex.reserve(baseType.getRank());
   do {
     // Compute the index for the slice of the indices tensor for this update
     // value.
     indexIndex.clear();
     if (indexVectorDim == 0) indexIndex.push_back(0);
-    for (int64_t i = 0; i < updateIndex.size(); ++i) {
+    for (int64_t i = 0; i < static_cast<int64_t>(updateIndex.size()); ++i) {
       if (llvm::count(scatter_dimension_numbers().getUpdateWindowDims(), i) ==
           0)
         indexIndex.push_back(updateIndex[i]);
-      if (indexIndex.size() == indexVectorDim) indexIndex.push_back(0);
+      if (static_cast<int64_t>(indexIndex.size()) == indexVectorDim)
+        indexIndex.push_back(0);
     }
 
     // Compute the index for the given update value in the base tensor.
@@ -8448,7 +8464,7 @@ static ParseResult parseDimsWithMinimumElements(AsmParser& parser,
                                                 SmallVector<int64_t>& dims,
                                                 int minElements) {
   if (failed(parseDims(parser, dims))) return failure();
-  if (dims.size() < minElements)
+  if (static_cast<int64_t>(dims.size()) < minElements)
     return parser.emitError(parser.getCurrentLocation())
            << "expected at least " << minElements << " element(s), found "
            << dims.size();
@@ -9067,7 +9083,8 @@ static Type getTypeFromTupleIndices(Type type, ArrayRef<int64_t> indices) {
   Type current = type;
   for (auto index : indices) {
     TupleType tupleType = current.dyn_cast<TupleType>();
-    if (!tupleType || index >= tupleType.size()) return {};
+    if (!tupleType || index >= static_cast<int64_t>(tupleType.size()))
+      return {};
     current = tupleType.getType(index);
   }
   return current;
@@ -9097,7 +9114,7 @@ static LogicalResult verifyArgResultAliasAttr(StringAttr attrName,
   FunctionOpInterface funcOp = cast<FunctionOpInterface>(op);
   ArrayRef<Type> argTypes = funcOp.getArgumentTypes();
   ArrayRef<Type> resultTypes = funcOp.getResultTypes();
-  if (aliasAttr.getResultIndex() >= resultTypes.size())
+  if (aliasAttr.getResultIndex() >= static_cast<int64_t>(resultTypes.size()))
     return op->emitOpError()
            << "attribute " << attrName
            << " result index is out of range, must be <" << resultTypes.size();

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/IR/hlo_ops_common.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/IR/hlo_ops_common.cc
@@ -69,7 +69,7 @@ LogicalResult verifyReduceScatter(Operation *op, TypeRange operandTypes,
     if (!operandType.hasRank() || !resultType.hasRank()) continue;
     if (operandType.getRank() != resultType.getRank())
       return op->emitOpError() << "operand and result should have same rank";
-    if (scatterDimension >= operandType.getRank())
+    if (static_cast<int64_t>(scatterDimension) >= operandType.getRank())
       return op->emitOpError()
              << "scatter dim should be less than operand/result rank";
     if (operandType.isDynamicDim(scatterDimension) ||

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/broadcast_propagation.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/broadcast_propagation.cc
@@ -155,7 +155,7 @@ void findBroadcastIntents(
 
   // We use result vector of broadcast intents as a worklist, the first `i`
   // intents of which have been processed.
-  for (int i = 0; i < bcastIntents.size(); ++i) {
+  for (int64_t i = 0; i < static_cast<int64_t>(bcastIntents.size()); ++i) {
     BroadcastIntent it = bcastIntents[i];
     Operation *producerOp = it.targetValue.getDefiningOp();
 

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/constraint_fusion_pass.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/constraint_fusion_pass.cc
@@ -118,7 +118,8 @@ void canonicalizeBroadcastabilityCstrs(
 
   // Remove broadcastability constraints if they are implied by stronger
   // constraints.
-  for (int i = 0; i < broadcastabilityCstrs.size(); i++) {
+  for (int64_t i = 0; i < static_cast<int64_t>(broadcastabilityCstrs.size());
+       i++) {
     CstrBroadcastableIntent &strongCstr = broadcastabilityCstrs[i];
     auto *newEnd = std::remove_if(
         broadcastabilityCstrs.begin() + i + 1, broadcastabilityCstrs.end(),

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/group_reduction_dimensions.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/group_reduction_dimensions.cc
@@ -192,11 +192,11 @@ LogicalResult tryLowerTo1DOr2DReduction(
                                         ? DimensionKind::kParallel
                                         : DimensionKind::kReduction;
     SmallVector<int64_t> perm;
-    for (int i = 0; i < dimGroups.size(); i++) {
+    for (int64_t i = 0; i < static_cast<int64_t>(dimGroups.size()); i++) {
       if (dimGroups[i].kind == leadingDimKind) perm.push_back(i);
     }
     int64_t numLeadingDims = perm.size();
-    for (int i = 0; i < dimGroups.size(); i++) {
+    for (int64_t i = 0; i < static_cast<int64_t>(dimGroups.size()); i++) {
       if (dimGroups[i].kind == trailingDimKind) perm.push_back(i);
     }
     auto permAttr = rewriter.getI64TensorAttr(perm);

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_control_flow.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_control_flow.cc
@@ -154,7 +154,7 @@ struct CaseOpPattern : public OpConversionPattern<mhlo::CaseOp> {
                                   scfIf.getThenRegion());
     int nextIdx = currentIdx + 1;
     // Don't recurse for the final default block.
-    if (currentIdx == finalIdx) {
+    if (currentIdx == static_cast<int64_t>(finalIdx)) {
       inlineMhloRegionIntoSCFRegion(outerBuilder, op.branches()[nextIdx],
                                     scfIf.getElseRegion());
     } else {

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_gather_to_torch_index_select.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_gather_to_torch_index_select.cc
@@ -73,14 +73,14 @@ struct GatherIsTorchIndexSelect : public OpRewritePattern<GatherOp> {
     }
 
     // Offset dimensions should be the defaults.
-    if (dimensionNumbers.getOffsetDims().size() !=
+    if (static_cast<int64_t>(dimensionNumbers.getOffsetDims().size()) !=
         resultTy.getRank() - indexVectorDim) {
       return rewriter.notifyMatchFailure(
           gather, "offset_dims.size not operand rank minus index_vector_dim");
     }
 
     for (const auto &it : llvm::enumerate(dimensionNumbers.getOffsetDims())) {
-      if ((it.index() + indexVectorDim) != it.value()) {
+      if (static_cast<int64_t>(it.index() + indexVectorDim) != it.value()) {
         return rewriter.notifyMatchFailure(
             gather, "offset_dims != [index_vector_dim, result.rank)");
       }

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_sort.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_sort.cc
@@ -126,7 +126,7 @@ struct SortOpPattern : public OpConversionPattern<mhlo::SortOp> {
       OpBuilder::InsertionGuard guard(b);
       auto& block = region.front();
       b.setInsertionPointToEnd(&block);
-      for (int i = 0; i < srcBlock.getNumArguments(); i += 2) {
+      for (int64_t i = 0; i < srcBlock.getNumArguments(); i += 2) {
         bvm.map(srcBlock.getArgument(i), sortArgs[i]);
         bvm.map(srcBlock.getArgument(i + 1), sortArgs[i + 1]);
 

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_to_standard.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_to_standard.cc
@@ -53,7 +53,7 @@ class CompareIConvert : public OpRewritePattern<mhlo::CompareOp> {
         !rhsType.getElementType().isSignlessInteger())
       return failure();
 
-    Optional<arith::CmpIPredicate> comparePredicate;
+    Optional<arith::CmpIPredicate> comparePredicate = llvm::None;
     switch (op.comparison_direction()) {
       case ComparisonDirection::EQ:
         comparePredicate = arith::CmpIPredicate::eq;
@@ -73,8 +73,6 @@ class CompareIConvert : public OpRewritePattern<mhlo::CompareOp> {
       case ComparisonDirection::GE:
         comparePredicate = arith::CmpIPredicate::sge;
         break;
-      default:
-        comparePredicate = llvm::None;
     }
 
     if (!comparePredicate.has_value()) return failure();
@@ -103,7 +101,7 @@ class CompareFConvert : public OpRewritePattern<mhlo::CompareOp> {
         !rhsType.getElementType().isa<FloatType>())
       return failure();
 
-    Optional<arith::CmpFPredicate> comparePredicate;
+    Optional<arith::CmpFPredicate> comparePredicate = llvm::None;
     switch (op.comparison_direction()) {
       case ComparisonDirection::EQ:
         comparePredicate = arith::CmpFPredicate::OEQ;
@@ -123,8 +121,6 @@ class CompareFConvert : public OpRewritePattern<mhlo::CompareOp> {
       case ComparisonDirection::GE:
         comparePredicate = arith::CmpFPredicate::OGE;
         break;
-      default:
-        comparePredicate = llvm::None;
     }
 
     if (!comparePredicate.has_value()) return failure();

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_trigonometric_to_approximation.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_trigonometric_to_approximation.cc
@@ -105,7 +105,7 @@ class ApproximateTanhLowering
     Value inputSquared = rewriter.create<arith::MulFOp>(loc, input, input);
     Value numerator = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getF32FloatAttr(numeratorCoeffs[0]));
-    for (int i = 1; i < numeratorCoeffs.size(); i++) {
+    for (int64_t i = 1; i < static_cast<int64_t>(numeratorCoeffs.size()); i++) {
       numerator = rewriter.create<arith::AddFOp>(
           loc, rewriter.create<arith::MulFOp>(loc, inputSquared, numerator),
           rewriter.create<arith::ConstantOp>(
@@ -114,7 +114,8 @@ class ApproximateTanhLowering
     numerator = rewriter.create<arith::MulFOp>(loc, input, numerator);
     Value denominator = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getF32FloatAttr(denominatorCoeffs[0]));
-    for (int i = 1; i < denominatorCoeffs.size(); i++) {
+    for (int64_t i = 1; i < static_cast<int64_t>(denominatorCoeffs.size());
+         i++) {
       denominator = rewriter.create<arith::AddFOp>(
           loc, rewriter.create<arith::MulFOp>(loc, inputSquared, denominator),
           rewriter.create<arith::ConstantOp>(

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/lower_general_dot.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/lower_general_dot.cc
@@ -230,8 +230,10 @@ struct GeneralDotConvert : public OpRewritePattern<DotGeneralOp> {
         results.front().cast<ShapedType>().clone(resultTy.getElementType());
     Value newDotOp =
         rewriter.create<DotOp>(op.getLoc(), newTy, lhs, rhs, precisionConfig);
-    if (lhsContractingDims.size() == (lhsTy.getRank() - 1) &&
-        rhsContractingDims.size() == (rhsTy.getRank() - 1)) {
+    if (static_cast<int64_t>(lhsContractingDims.size()) ==
+            lhsTy.getRank() - 1 &&
+        static_cast<int64_t>(rhsContractingDims.size()) ==
+            rhsTy.getRank() - 1) {
       rewriter.replaceOp(op, newDotOp);
       return success();
     }

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/optimize_mhlo.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/optimize_mhlo.cc
@@ -82,12 +82,13 @@ class GatherIsSlice : public OpRewritePattern<GatherOp> {
     if (!resultTy) {
       return rewriter.notifyMatchFailure(gather, "unranked result");
     }
-    if (dimensionNumbers.getOffsetDims().size() != resultTy.getRank()) {
+    if (static_cast<int64_t>(dimensionNumbers.getOffsetDims().size()) !=
+        resultTy.getRank()) {
       return rewriter.notifyMatchFailure(gather,
                                          "offset_dims.size != operand.rank");
     }
     for (const auto& it : llvm::enumerate(dimensionNumbers.getOffsetDims())) {
-      if (it.index() != it.value()) {
+      if (static_cast<int64_t>(it.index()) != it.value()) {
         return rewriter.notifyMatchFailure(gather,
                                            "offset_dims != [0, result.rank)");
       }
@@ -138,7 +139,8 @@ class GatherIsSlice : public OpRewritePattern<GatherOp> {
     auto zero = rewriter.create<ConstantOp>(
         gather.getLoc(), rewriter.getZeroAttr(RankedTensorType::get(
                              {}, gatherStartIndicesTy.getElementType())));
-    while (sliceStartIndices.size() < sliceSizesTy.getDimSize(0)) {
+    while (static_cast<int64_t>(sliceStartIndices.size()) <
+           sliceSizesTy.getDimSize(0)) {
       sliceStartIndices.push_back(zero);
     }
 

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/type_conversion.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/type_conversion.cc
@@ -24,7 +24,7 @@ limitations under the License.
 
 namespace mlir {
 
-struct Value;
+class Value;
 
 namespace mhlo {
 

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/bufferize.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/bufferize.cc
@@ -148,7 +148,7 @@ struct BufferizeAndConvertMinimumBroadcastShapesOp
     SmallVector<Value> initValues;
     initValues.reserve(k + 3);
     // Initially, all values are marked as not broadcasted.
-    for (int i = 0; i < k; ++i) {
+    for (int64_t i = 0; i < static_cast<int64_t>(k); ++i) {
       initValues.push_back(constantFalse);
     }
     // The running product is initially 1.

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/propagate_static_shapes_to_kernel.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/propagate_static_shapes_to_kernel.cc
@@ -180,7 +180,8 @@ LogicalResult PropagateStaticShapesPattern::matchAndRewrite(
       return arg.getType().isa<IntegerType>();
     };
     // Bail out if the next num_args are not the expected type.
-    if (arguments.size() < numArgs) break;
+    if (static_cast<int64_t>(arguments.size()) < numArgs)
+      break;
     ArrayRef<BlockArgument> memrefArgs = arguments.take_front(numArgs);
     if (!llvm::all_of(memrefArgs.take_front(2), isPtr)) break;
     if (!llvm::all_of(memrefArgs.drop_front(2), isInt)) break;

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/symbolic_shape_optimization.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/symbolic_shape_optimization.cc
@@ -191,7 +191,8 @@ struct AnnotateExpandingDimensionsInDynamicBroadcastInDim
     // Fail pattern application if there is nothing new to annotate.
     auto isEqual = [](llvm::SmallSetVector<int64_t, 4> &set,
                       DenseIntElementsAttr attr) {
-      return set.size() == attr.size() && llvm::all_of(attr, [&](auto it) {
+      return static_cast<int64_t>(set.size()) == attr.size() &&
+             llvm::all_of(attr, [&](auto it) {
                return set.count(it.getLimitedValue());
              });
     };
@@ -423,7 +424,7 @@ SymbolicProduct eliminateCommonFactors(SymbolicProduct &a, SymbolicProduct &b) {
 
   // Eliminate common symbolic factors.
   int64_t i = 0;
-  while (i < a.symbolic.size()) {
+  while (i < static_cast<int64_t>(a.symbolic.size())) {
     auto *it = llvm::find(b.symbolic, a.symbolic[i]);
     if (it != b.symbolic.end()) {
       gcd.symbolic.push_back(*it);

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/tile_loops_pass.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/tile_loops_pass.cc
@@ -74,7 +74,7 @@ void TileLoopsPass::runOnOperation() {
   SmallVector<int64_t> unrolledTile;
   if (tile_sizes_.size() == unroll_factors_.size()) {
     unrolledTile.reserve(tile_sizes_.size());
-    for (int i = 0; i < tile_sizes_.size(); ++i)
+    for (int64_t i = 0; i < static_cast<int64_t>(tile_sizes_.size()); ++i)
       unrolledTile.push_back(tile_sizes_[i] * unroll_factors_[i]);
   }
 
@@ -106,7 +106,7 @@ void TileLoopsPass::runOnOperation() {
     // unroll factor evenly divides the iteration size of the outer ploop.
     OpBuilder builder(ploop);
     Location loc = ploop.getLoc();
-    for (int i = 0; i < unrolledTile.size(); ++i) {
+    for (int64_t i = 0; i < static_cast<int64_t>(unrolledTile.size()); ++i) {
       if (!lower[i] || !upper[i] || !step[i]) continue;
       int64_t unrollFactor = unroll_factors_[i];
       int64_t difference = upper[i].value() - lower[i].value();


### PR DESCRIPTION
Building with clang (v14) produces numerous warnings about comparison
between signed and unsigned values.  This patch introduces explicit cast
operations to eliminate the warnings.  The unit tests run as part of the
`check-mlir-hlo` targets pass.