### PR TITLE
Add support to int64 input type for benchmark tool

### DIFF
--- a/tensorflow/tools/benchmark/benchmark_model.cc
+++ b/tensorflow/tools/benchmark/benchmark_model.cc
@@ -82,6 +82,10 @@ void CreateTensorsFromInputInfo(
         InitializeTensor<int32>(input.initialization_values, &input_tensor);
         break;
       }
+      case DT_INT64: {
+        InitializeTensor<int64>(input.initialization_values, &input_tensor);
+        break;
+      }
       case DT_FLOAT: {
         InitializeTensor<float>(input.initialization_values, &input_tensor);
         break;


### PR DESCRIPTION
The current benchmark tool does not support int64 tensor as input. In order to support int64, we need to add this kind of type to the input tensor generator.