### PR TITLE
Add AMD/ROCm build dependency for grapper/optimizer

### DIFF
--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -8,6 +8,10 @@ load(
     "//tensorflow/core/platform:build_config_root.bzl",
     "if_static",
 )
+load(
+    "@local_config_rocm//rocm:build_defs.bzl",
+    "if_rocm_is_configured",
+)
 
 package(
     features = ["-layering_check"],
@@ -1168,7 +1172,9 @@ cc_library(
     ] + if_static(
         ["//tensorflow/core/platform:tensor_float_32_utils"],
         ["//tensorflow/core/platform:tensor_float_32_hdr_lib"],
-    ),
+    ) + if_rocm_is_configured([
+        "//tensorflow/core/platform:stream_executor",
+    ]),
 )
 
 tf_cuda_cc_test(


### PR DESCRIPTION
 ROCm have some grappler/optmizer code that uses code from rocm_dnn.c. This commit updates the BUILD file to include that dependency