### PR TITLE
Removing the use of Tile Converter for multipliers passed as tensors

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -2691,11 +2691,11 @@ TEST_P(OpConverter_FP32_Test, ConvertTile) {
         std::vector<int> num_mults = {static_cast<int>(p.multiplier.size())};
         std::vector<std::vector<int>> partial_input_dims_options = {{}};
         if (multiplier_is_tensor) {
-          if (trt_mode_ == TrtTestMode::kImplicitBatch) {
+          if (true || trt_mode_ == TrtTestMode::kImplicitBatch) {
             p.status =
                 Status(error::INVALID_ARGUMENT,
                        "Conversion for Tile is not implemented for multipliers "
-                       "passed as a tensor in implicit batch mode");
+                       "passed as a tensor.");
             num_mults = {1, static_cast<int>(p.multiplier.size())};
           } else {
             if (p.test_ID == 1) {
@@ -2719,7 +2719,7 @@ TEST_P(OpConverter_FP32_Test, ConvertTile) {
         }
 
         for (auto partial_input_dims : partial_input_dims_options) {
-          if (multiplier_is_tensor &&
+          if (false && multiplier_is_tensor &&
               trt_mode_ != TrtTestMode::kImplicitBatch) {
             if (trt_mode_ == TrtTestMode::kDynamicShape) {
               if (p.test_ID != 1) {

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/tile.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/tile.cc
@@ -43,10 +43,10 @@ class ConvertTile : public OpConverterBase<ConvertTile> {
     const auto &inputs = params.inputs;
 
     const auto &repl = inputs.at(1);
-    if (params.use_implicit_batch && repl.is_tensor()) {
+    if (repl.is_tensor()) {
       return errors::InvalidArgument(
           "Conversion for Tile is not implemented for multipliers "
-          "passed as a tensor in implicit batch mode.");
+          "passed as a tensor.");
     }
 
     nvinfer1::DataType dtype;


### PR DESCRIPTION
Using the Tile Converter for multipliers passed as tensors is blocked until an issue found in our tests is fixed.