### PR TITLE
[mhlo] specify the include dirs are from build

### DIFF
--- a/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/CMakeLists.txt
+++ b/tensorflow/compiler/mlir/hlo/lib/Dialect/mhlo/IR/CMakeLists.txt
@@ -61,8 +61,8 @@ target_link_libraries(MhloDialect
 )
 target_include_directories(MhloDialect
   PUBLIC
-  ${MLIR_HLO_GEN_INCLUDE_DIR}
-  ${MLIR_HLO_MAIN_INCLUDE_DIR}
+  $<BUILD_INTERFACE:${MLIR_HLO_GEN_INCLUDE_DIR}>
+  $<BUILD_INTERFACE:${MLIR_HLO_MAIN_INCLUDE_DIR}>
 )
 
 add_mlir_dialect_library(MhloRegisterDialects


### PR DESCRIPTION
Otherwise, the cmake command will fail when the project is built within LLVM.