### PR TITLE
Make source compilable in debug with -Og flag

### DIFF
--- a/tensorflow/compiler/xla/python/pjit.cc
+++ b/tensorflow/compiler/xla/python/pjit.cc
@@ -133,6 +133,8 @@ class PjitFunctionCache {
   absl::flat_hash_map<Key, std::unique_ptr<Value>> functions_;
 };
 
+constexpr int PjitFunctionCache::kDefaultCapacity;
+
 PjitFunctionCache::PjitFunctionCache(int capacity) : lru_list_(capacity) {}
 
 std::shared_ptr<PjitFunctionCache::Cache> PjitFunctionCache::DefaultCache() {

--- a/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -211,8 +211,10 @@ def InvokeNvcc(argv, log=False):
   if len(out_file) != 1:
     return 1
 
-  opt = (' -O2' if (len(opt_option) > 0 and int(opt_option[0]) > 0)
-         else ' -g')
+  opt = (' -O2' if
+    (len(opt_option) > 0 and opt_option[0].isnumeric() and
+    int(opt_option[0]) > 0)
+    else ' -g')
 
   includes = (' -I ' + ' -I '.join(include_options)
               if len(include_options) > 0


### PR DESCRIPTION
Add missing definition for static constexpr member PjitFunctionCache::kDefaultCapacity.
In debug the value is not optimized out and you still need a definition to link.
