### PR TITLE
ppc64le: set 'gold' linker in the configure.py to fix ppc build

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1188,6 +1188,10 @@ def main():
     gcc_env = get_gcc_compiler(environ_cp)
     if gcc_env is not None:
 
+      # Use gold linker if 'gcc' and if 'ppc64le'
+      write_to_bazelrc(
+          'build --linkopt="-fuse-ld=gold"')
+
       # Get the linker version
       ld_version = run_shell([gcc_env, '-Wl,-version']).split()
 


### PR DESCRIPTION
The commit 3484416b49d4af6742e0e1290dd75364a276131d removed the
'rules_cc_toolchains' call from the bazel configuration. After that,
the build process is calling 'lld' to link several binaries, causing
problems on ppc64le arch.

This patch set the 'gold' linker as default in the configure script.