### PR TITLE
Updates cpu_arm64_pip.sh to build with Eigen Threadpool support.

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -56,8 +56,8 @@ source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh
 py_ver=$(python -c 'import sys; print(str(sys.version_info.major)+str(sys.version_info.minor))')
 
 # Export optional variables for running pip_new.sh
-export TF_BUILD_FLAGS="--config=mkl_aarch64 --copt=-mtune=generic --copt=-march=armv8-a \
-    --copt=-O3 --copt=-fopenmp --copt=-flax-vector-conversions --linkopt=-lgomp"
+export TF_BUILD_FLAGS="--config=mkl_aarch64_threadpool --copt=-mtune=generic --copt=-march=armv8-a \
+    --copt=-O3 --copt=-flax-vector-conversions"
 export TF_TEST_FLAGS="${TF_BUILD_FLAGS} \
     --test_env=TF_ENABLE_ONEDNN_OPTS=1 --test_env=TF2_BEHAVIOR=1 --define=no_tensorflow_py_deps=true \
     --test_lang_filters=py --flaky_test_attempts=3 --test_size_filters=small,medium --verbose_failures=true --test_keep_going"


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/56790 adds support for
Eigen threadpool with oneDNN and Compute Library on AArch64.

This patch sets the --config=mkl_aarch64_threadpool option in place
of mkl_aarch64 in the CI build script.

The OpenMP flags are also removed accordingly (note, these are set in
tensorflow/third_party/compute_library/BUILD when required for an
OpenMP (i.e. --config=mkl_aarch64) build.