### PR TITLE
Allow re-init on same stream in cudamallocasync allocator.

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc
@@ -386,7 +386,8 @@ bool GpuCudaMallocAsyncAllocator::ClearStats() {
 
 void GpuCudaMallocAsyncAllocator::SetStreamAndPreallocateMemory(void* stream) {
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
-  if (cuda_stream_ != nullptr) {
+  CUstream passed_cuda_stream = *(reinterpret_cast<CUstream*>(stream));
+  if (cuda_stream_ != nullptr && cuda_stream_ != passed_cuda_stream) {
     LOG(FATAL) <<  // Crash OK.
         "Trying to set the stream twice. This isn't supported. ";
   }
@@ -397,7 +398,7 @@ void GpuCudaMallocAsyncAllocator::SetStreamAndPreallocateMemory(void* stream) {
     LOG(FATAL) <<  // Crash OK.
         "Failed to get CUDA pool attribute: " << GetCudaErrorMessage(status);
   }
-  cuda_stream_ = *(reinterpret_cast<CUstream*>(stream));
+  cuda_stream_ = passed_cuda_stream;
   int64 prealloc_size = 0;
   // TF_CUDA_MALLOC_ASYNC_SUPPORTED_PREALLOC=-1 is a special value that
   // preallocates the total pool size.


### PR DESCRIPTION
This fixes a bug in which destroying and re-creating a session causes the cuda_malloc_async allocator to fail.

For example, when `TF_GPU_ALLOCATOR` is set to `cuda_malloc_async` without this patch
```python
import tensorflow as tf
tf.compat.v1.disable_eager_execution()
for i in [0, 1]:
    print("i={}".format(i))
    with tf.compat.v1.Session() as sess:
        pass
```
results in the error
```
F tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.cc:390] Trying to set the stream twice. This isn't supported.
```