### PR TITLE
Register more types to DEVICE_DEFAULT for AssignVariableOp

### DIFF
--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -572,10 +572,10 @@ TF_CALL_uint32(REGISTER_GPU_KERNELS);
 
 #define REGISTER_KERNELS(type)                               \
   REGISTER_KERNEL_BUILDER(Name("AssignVariableOp")           \
-                            .Device(DEVICE_DEFAULT)          \
-                            .TypeConstraint<type>("dtype")   \
-                            .HostMemory("resource"),         \
-                        AssignVariableOp<CPUDevice, type>);
+                              .Device(DEVICE_DEFAULT)        \
+                              .TypeConstraint<type>("dtype") \
+                              .HostMemory("resource"),       \
+                          AssignVariableOp<CPUDevice, type>);
 
 TF_CALL_ALL_TYPES(REGISTER_KERNELS);
 TF_CALL_QUANTIZED_TYPES(REGISTER_KERNELS);

--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -570,11 +570,16 @@ TF_CALL_uint32(REGISTER_GPU_KERNELS);
 #undef REGISTER_GPU_KERNELS
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
-REGISTER_KERNEL_BUILDER(Name("AssignVariableOp")
-                            .Device(DEVICE_DEFAULT)
-                            .TypeConstraint<Variant>("dtype")
-                            .HostMemory("resource"),
-                        AssignVariableOp<CPUDevice, Variant>);
+#define REGISTER_KERNELS(type)                               \
+  REGISTER_KERNEL_BUILDER(Name("AssignVariableOp")           \
+                            .Device(DEVICE_DEFAULT)          \
+                            .TypeConstraint<type>("dtype")   \
+                            .HostMemory("resource"),         \
+                        AssignVariableOp<CPUDevice, type>);
+
+TF_CALL_ALL_TYPES(REGISTER_KERNELS);
+TF_CALL_QUANTIZED_TYPES(REGISTER_KERNELS);
+#undef REGISTER_KERNELS
 
 template <typename Device, typename T, DenseUpdateType Op>
 class AssignUpdateVariableOp : public OpKernel {


### PR DESCRIPTION
I ran into the same issue in this forum post (https://discuss.tensorflow.org/t/how-does-assignvarop-work/8335/5) when making a Pluggable Device.