### PR TITLE
Enable C++ profiles to be exported to TensorBoard

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -116,6 +116,7 @@ load(
     "tf_protos_all_impl",
     "tf_protos_grappler_impl",
     "tf_protos_profiler_impl",
+    "tf_protos_profiler_service",
     "tf_tpu_dependencies",
 )
 load(
@@ -1615,6 +1616,7 @@ filegroup(
         "//tensorflow/core/framework:tensor_reference.h",
         "//tensorflow/core/framework:tracking_allocator.h",  # only needed for tests
         "//tensorflow/core/framework:variant.h",
+        "//tensorflow/core/profiler/rpc/client:tensorboard_export.h",
         "//tensorflow/core/util:framework_internal_public_hdrs",
     ],
     visibility = ["//visibility:private"],
@@ -1723,6 +1725,7 @@ tf_cuda_library(
         "//tensorflow/core/profiler/lib:annotated_traceme",
         "//tensorflow/core/profiler/lib:scoped_memory_debug_annotation",
         "//tensorflow/core/profiler/lib:traceme",
+        "//tensorflow/core/profiler/rpc/client:tensorboard_export",
         "//tensorflow/core/util:determinism",
         "//tensorflow/core/util:managed_stack_trace",
         "//tensorflow/core/util:einsum_op_util",
@@ -1737,7 +1740,7 @@ tf_cuda_library(
     ]) + if_static(
         extra_deps = ["@com_google_protobuf//:protobuf"],
         otherwise = ["@com_google_protobuf//:protobuf_headers"],
-    ),
+    ) + tf_protos_profiler_service(),
     alwayslink = 1,
 )
 

--- a/tensorflow/core/platform/default/build_config.bzl
+++ b/tensorflow/core/platform/default/build_config.bzl
@@ -688,6 +688,24 @@ def tf_protos_profiler_impl():
     return [
         clean_dep("//tensorflow/core/profiler/protobuf:xplane_proto_cc_impl"),
         clean_dep("//tensorflow/core/profiler:profiler_options_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:memory_profile_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:hardware_types_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:trace_events_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:diagnostics_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:kernel_stats_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:op_metrics_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:steps_db_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:op_profile_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:op_stats_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:tf_function_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:tf_stats_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:tfstreamz_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:tf_data_stats_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:memory_viewer_preprocess_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:input_pipeline_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:overview_page_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:pod_stats_proto_cc_impl"),
+        clean_dep("//tensorflow/core/profiler/protobuf:pod_viewer_proto_cc_impl"),
     ]
 
 def tf_protos_profiler_service():

--- a/tensorflow/core/profiler/protobuf/BUILD
+++ b/tensorflow/core/profiler/protobuf/BUILD
@@ -42,6 +42,7 @@ tf_proto_library(
     name = "diagnostics_proto",
     srcs = ["diagnostics.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [
         ":friends",
     ],
@@ -51,6 +52,7 @@ tf_proto_library(
     name = "input_pipeline_proto",
     srcs = ["input_pipeline.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     protodeps = [":diagnostics_proto"],
     visibility = [
         ":friends",
@@ -61,6 +63,7 @@ tf_proto_library(
     name = "overview_page_proto",
     srcs = ["overview_page.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     protodeps = [
         ":diagnostics_proto",
         ":input_pipeline_proto",
@@ -74,6 +77,7 @@ tf_proto_library(
     name = "op_metrics_proto",
     srcs = ["op_metrics.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [":friends"],
 )
 
@@ -81,6 +85,7 @@ tf_proto_library(
     name = "pod_stats_proto",
     srcs = ["pod_stats.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     protodeps = [
         ":diagnostics_proto",
     ],
@@ -91,6 +96,7 @@ tf_proto_library(
     name = "pod_viewer_proto",
     srcs = ["pod_viewer.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     protodeps = [
         ":diagnostics_proto",
         ":pod_stats_proto",
@@ -102,6 +108,7 @@ tf_proto_library(
     name = "steps_db_proto",
     srcs = ["steps_db.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     protodeps = [":op_metrics_proto"],
     visibility = [
         ":friends",
@@ -112,6 +119,7 @@ tf_proto_library(
     name = "op_profile_proto",
     srcs = ["op_profile.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [":friends"],
 )
 
@@ -119,6 +127,7 @@ tf_proto_library(
     name = "op_stats_proto",
     srcs = ["op_stats.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     protodeps = [
         ":diagnostics_proto",
         ":kernel_stats_proto",
@@ -135,6 +144,7 @@ tf_proto_library(
     name = "kernel_stats_proto",
     srcs = ["kernel_stats.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [":friends"],
 )
 
@@ -142,6 +152,7 @@ tf_proto_library(
     name = "tf_function_proto",
     srcs = ["tf_function.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [":friends"],
 )
 
@@ -151,6 +162,7 @@ tf_proto_library(
     name = "tf_stats_proto",
     srcs = ["tf_stats.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [":friends"],
 )
 
@@ -158,6 +170,7 @@ tf_proto_library(
     name = "trace_events_proto",
     srcs = ["trace_events.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [":friends"],
 )
 
@@ -165,6 +178,7 @@ tf_proto_library(
     name = "hardware_types_proto",
     srcs = ["hardware_types.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [":friends"],
 )
 
@@ -172,6 +186,7 @@ tf_proto_library(
     name = "tfstreamz_proto",
     srcs = ["tfstreamz.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [":friends"],
 )
 
@@ -179,6 +194,7 @@ tf_proto_library(
     name = "memory_profile_proto",
     srcs = ["memory_profile.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [":friends"],
 )
 
@@ -186,6 +202,7 @@ tf_proto_library(
     name = "tf_data_stats_proto",
     srcs = ["tf_data_stats.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [":friends"],
 )
 
@@ -193,6 +210,7 @@ tf_proto_library(
     name = "memory_viewer_preprocess_proto",
     srcs = ["memory_viewer_preprocess.proto"],
     cc_api_version = 2,
+    make_default_target_header_only = True,
     visibility = [":memory_viewer_friends"],
 )
 

--- a/tensorflow/core/profiler/rpc/client/BUILD
+++ b/tensorflow/core/profiler/rpc/client/BUILD
@@ -17,6 +17,35 @@ package(
     licenses = ["notice"],
 )
 
+exports_files(
+    srcs = ["tensorboard_export.h"],
+    visibility = ["//tensorflow/core:__pkg__"],
+)
+
+cc_library(
+    name = "populate_request",
+    hdrs = ["populate_request.h"],
+    deps = [
+        ":remote_profiler_session_manager",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "tensorboard_export",
+    srcs = ["tensorboard_export.cc"],
+    hdrs = ["tensorboard_export.h"],
+    copts = tf_profiler_copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":save_profile",
+        ":profiler_client",
+        ":populate_request",
+        "//tensorflow/core/profiler/convert:xplane_to_profile_response",
+        "//tensorflow/core/profiler/protobuf:xplane_proto_cc",
+    ],
+)
+
 cc_library(
     name = "capture_profile",
     srcs = ["capture_profile.cc"],
@@ -28,15 +57,14 @@ cc_library(
     ],
     deps = [
         ":profiler_client_for_pybind",
-        ":remote_profiler_session_manager",
         ":save_profile",
+        ":populate_request",
+        ":tensorboard_export",
         "//tensorflow/core:lib",
         "//tensorflow/core:lib_internal",
         "//tensorflow/core/profiler:profiler_analysis_proto_cc",
         "//tensorflow/core/profiler:profiler_options_proto_cc",
         "//tensorflow/core/profiler:profiler_service_proto_cc",
-        "//tensorflow/core/profiler/convert:xplane_to_profile_response",
-        "//tensorflow/core/profiler/protobuf:xplane_proto_cc",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
     ],

--- a/tensorflow/core/profiler/rpc/client/capture_profile.h
+++ b/tensorflow/core/profiler/rpc/client/capture_profile.h
@@ -22,13 +22,10 @@ limitations under the License.
 #include "tensorflow/core/platform/status.h"
 #include "tensorflow/core/profiler/profiler_options.pb.h"
 #include "tensorflow/core/profiler/profiler_service.pb.h"
-#include "tensorflow/core/profiler/protobuf/xplane.pb.h"
+#include "tensorflow/core/profiler/rpc/client/tensorboard_export.h"
 
 namespace tensorflow {
 namespace profiler {
-
-// Convert XSpace to tool data and saves under <logdir>/plugins/profile/.
-Status ExportToTensorBoard(const XSpace& xspace, const std::string& logdir);
 
 // Collects one sample of monitoring profile and shows user-friendly metrics.
 // If timestamp flag is true, timestamp will be displayed in "%H:%M:%S" format.

--- a/tensorflow/core/profiler/rpc/client/populate_request.h
+++ b/tensorflow/core/profiler/rpc/client/populate_request.h
@@ -1,0 +1,92 @@
+/* Copyright 2017 The TensorFlow Authors All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_PROFILER_RPC_CLIENT_POPULATE_REQUEST_H_
+#define TENSORFLOW_CORE_PROFILER_RPC_CLIENT_POPULATE_REQUEST_H_
+
+#include <vector>
+
+#include "absl/strings/str_split.h"
+#include "tensorflow/core/profiler/rpc/client/remote_profiler_session_manager.h"
+
+namespace tensorflow {
+namespace profiler {
+namespace {
+
+using ::tensorflow::profiler::RemoteProfilerSessionManager;
+
+constexpr uint64 kMaxEvents = 1000000;
+const absl::string_view kXPlanePb = "xplane.pb";
+
+MonitorRequest PopulateMonitorRequest(int duration_ms, int monitoring_level,
+                                      bool timestamp) {
+  MonitorRequest request;
+  request.set_duration_ms(duration_ms);
+  request.set_monitoring_level(monitoring_level);
+  request.set_timestamp(timestamp);
+  return request;
+}
+
+ProfileRequest PopulateProfileRequest(
+    absl::string_view repository_root, absl::string_view session_id,
+    absl::string_view host_name,
+    const RemoteProfilerSessionManagerOptions& options) {
+  ProfileRequest request;
+  // TODO(b/169976117) Remove duration from request.
+  request.set_duration_ms(options.profiler_options().duration_ms());
+  request.set_max_events(kMaxEvents);
+  request.set_repository_root(repository_root.data(), repository_root.size());
+  request.set_session_id(session_id.data(), session_id.size());
+  request.set_host_name(host_name.data(), host_name.size());
+  // These tools are only used by TPU profiler.
+  request.add_tools("trace_viewer");
+  request.add_tools("op_profile");
+  request.add_tools("input_pipeline");
+  request.add_tools("kernel_stats");
+  request.add_tools("memory_viewer");
+  request.add_tools("memory_profile");
+  request.add_tools("overview_page");
+  request.add_tools("pod_viewer");
+  request.add_tools("tensorflow_stats");
+  // XPlane tool is only used by OSS profiler and safely ignored by TPU
+  // profiler.
+  request.add_tools(kXPlanePb.data(), kXPlanePb.size());
+  *request.mutable_opts() = options.profiler_options();
+  return request;
+}
+
+NewProfileSessionRequest PopulateNewProfileSessionRequest(
+    absl::string_view repository_root, absl::string_view session_id,
+    const RemoteProfilerSessionManagerOptions& opts) {
+  NewProfileSessionRequest request;
+  std::vector<absl::string_view> parts =
+      absl::StrSplit(opts.service_addresses(0), ':');
+  DCHECK(!parts.empty());
+
+  *request.mutable_request() =
+      PopulateProfileRequest(repository_root, session_id, parts[0], opts);
+  request.set_repository_root(repository_root.data(), repository_root.size());
+  request.set_session_id(session_id.data(), session_id.size());
+  for (const auto& hostname : opts.service_addresses()) {
+    request.add_hosts(hostname);
+  }
+  return request;
+}
+
+}  // namespace
+}  // namespace profiler
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_PROFILER_RPC_CLIENT_POPULATE_REQUEST_H_

--- a/tensorflow/core/profiler/rpc/client/tensorboard_export.cc
+++ b/tensorflow/core/profiler/rpc/client/tensorboard_export.cc
@@ -1,0 +1,47 @@
+/* Copyright 2017 The TensorFlow Authors All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/core/profiler/rpc/client/tensorboard_export.h"
+
+#include <iostream>
+
+#include "tensorflow/core/platform/errors.h"
+#include "tensorflow/core/platform/host_info.h"
+#include "tensorflow/core/platform/status.h"
+#include "tensorflow/core/profiler/convert/xplane_to_profile_response.h"
+#include "tensorflow/core/profiler/rpc/client/save_profile.h"
+#include "tensorflow/core/profiler/rpc/client/populate_request.h"
+
+namespace tensorflow {
+namespace profiler {
+
+Status ExportToTensorBoard(const XSpace& xspace, const std::string& logdir) {
+  TF_RETURN_IF_ERROR(MaybeCreateEmptyEventFile(logdir));
+
+  ProfileResponse response;
+  ProfileRequest request = PopulateProfileRequest(
+      GetTensorBoardProfilePluginDir(logdir), GetCurrentTimeStampAsString(),
+      port::Hostname(), /*options=*/{});
+  TF_RETURN_IF_ERROR(
+      ConvertXSpaceToProfileResponse(xspace, request, &response));
+  std::stringstream ss;  // Record LOG messages.
+  TF_RETURN_IF_ERROR(SaveProfile(request.repository_root(),
+                                 request.session_id(), request.host_name(),
+                                 response, &ss));
+  LOG(INFO) << ss.str();
+  return Status::OK();
+}
+
+}  // namespace profiler
+}  // namespace tensorflow

--- a/tensorflow/core/profiler/rpc/client/tensorboard_export.h
+++ b/tensorflow/core/profiler/rpc/client/tensorboard_export.h
@@ -1,0 +1,33 @@
+/* Copyright 2017 The TensorFlow Authors All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_PROFILER_RPC_CLIENT_TENSORBOARD_EXPORT_H_
+#define TENSORFLOW_CORE_PROFILER_RPC_CLIENT_TENSORBOARD_EXPORT_H_
+
+#include <string>
+
+#include "tensorflow/core/platform/status.h"
+#include "tensorflow/core/profiler/protobuf/xplane.pb.h"
+
+namespace tensorflow {
+namespace profiler {
+
+// Convert XSpace to tool data and saves under <logdir>/plugins/profile/.
+Status ExportToTensorBoard(const XSpace& xspace, const std::string& logdir);
+
+}  // namespace profiler
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_PROFILER_RPC_CLIENT_TENSORBOARD_EXPORT_H_


### PR DESCRIPTION
Makes `ExportToTensorBoard()` publicly visibility to allow C++ applications to export profiles to TensorBoard. Also adds the symbol to `libtensorflow_framework.so` for C++ applications that link to the shared object.
- Moves `ExportToTensorBoard()` to `tensorboard_export.h` and `tensorboard_export.cc`
- Moves `PopulateNewProfileSessionRequest()`, `PopulateProfileRequest()`, and `PopulateMonitorRequest()` to `populate_request.h`, which is depended on by `tensorboard_export` and `capture_profile`

cc: @DEKHTIARJonathan @meena-at-work @bixia1 