### PR TITLE
Fix NodeDefDataTypeAttributeName for Unary and Binary op converters.

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -382,7 +382,8 @@ Status GetTrtBroadcastShape(const TRT_TensorOrWeights& operand_l,
 }
 
 // Prepares a dynamic shape tensor for broadcast by adding leading 1 dimensions.
-Status DynamicBroadcast(ITensorProxyPtr operand, OpConverterParams* params,
+Status DynamicBroadcast(ITensorProxyPtr operand,
+                        const OpConverterParams* params,
                         ITensorProxyPtr* output, int broadcasted_nbDims,
                         std::optional<int> op_instance) {
   int operand_nbDims = operand->getDimensions().nbDims;
@@ -416,7 +417,7 @@ Status BroadcastWeights(std::unique_ptr<TRT_TensorOrWeights>& p,
 
 Status ApplyBroadcast(std::unique_ptr<TRT_TensorOrWeights>& operand,
                       const DimsAdapter& broadcasted_dims,
-                      OpConverterParams* params,
+                      const OpConverterParams* params,
                       std::optional<int> op_instance) {
   if (operand->is_weights()) {
     TF_RETURN_IF_ERROR(BroadcastWeights(operand, broadcasted_dims));
@@ -451,7 +452,8 @@ Status ApplyBroadcast(std::unique_ptr<TRT_TensorOrWeights>& operand,
 // GetTrtBroadcastShape should only be used by this routine.
 Status BroadcastTensors(std::unique_ptr<TRT_TensorOrWeights>& operand_l,
                         std::unique_ptr<TRT_TensorOrWeights>& operand_r,
-                        bool check_feasibility, OpConverterParams* params) {
+                        bool check_feasibility,
+                        const OpConverterParams* params) {
   nvinfer1::Dims broadcasted_dims_l, broadcasted_dims_r;
   TF_RETURN_IF_ERROR(GetTrtBroadcastShape(
       *operand_l, *operand_r, check_feasibility, params->use_implicit_batch,
@@ -489,7 +491,7 @@ ITensorProxyPtr Converter::CreateConstantLayer(const TRT_ShapedWeights& weights,
 // Creates a scalar constant and fills with value.
 template <typename T>
 Status CreateScalarConstant(
-    OpConverterParams* params, T value, ITensorProxyPtr* tensor,
+    const OpConverterParams* params, T value, ITensorProxyPtr* tensor,
     nvinfer1::DataType trt_type = nvinfer1::DataType::kINT32,
     const nvinfer1::Dims& dims = {1, {1}}) {
   StatusOr<TRT_ShapedWeights> weights =
@@ -503,7 +505,8 @@ Status CreateScalarConstant(
 
 // Creates a constant with the same rank as dims, where each dimension has
 // size = 1.
-Status CreateBroadcastableScalarConstant(OpConverterParams* params, float value,
+Status CreateBroadcastableScalarConstant(const OpConverterParams* params,
+                                         float value,
                                          const nvinfer1::Dims& dims,
                                          ITensorProxyPtr* tensor,
                                          const char* dtype_attr_name = "T") {
@@ -527,7 +530,8 @@ Status CreateBroadcastableScalarConstant(OpConverterParams* params, float value,
 // The function concatenates tensors on the first axis. This can be used to
 // create a shape tensor from individual dimension sizes.
 StatusOr<ITensorProxyPtr> ConcatenateTensors(
-    OpConverterParams* params, const std::vector<ITensorProxyPtr> input_tensors,
+    const OpConverterParams* params,
+    const std::vector<ITensorProxyPtr> input_tensors,
     std::optional<int> op_instance = std::nullopt) {
   std::vector<nvinfer1::ITensor*> trt_input_tensors;
   for (const auto& t : input_tensors) {
@@ -1103,9 +1107,8 @@ Status Converter::ConvertNode(const NodeDef& node_def) {
     Status status = AddTensorOrWeights(output_name, output);
     if (!status.ok()) {
       return errors::Create(
-          status.code(),
-          StrCat("Failed to add output for node: ", node_def.name(), ": ",
-                 status.error_message()),
+          status.code(), StrCat("Failed to add output for node: ",
+                                node_def.name(), ": ", status.error_message()),
           errors::GetPayloads(status));
     }
   }
@@ -1756,13 +1759,9 @@ Status AllowDataTypes(const OpConverterParams& params,
   DataType tf_type;
   TF_RETURN_IF_ERROR(GetNodeDefTfType(node_def, &tf_type, type_attr_name));
   if (!allowed_types.count(tf_type)) {
-    string allowed_types_string = absl::StrJoin(
-        allowed_types, ", ", [](string* out, const DataType& type) {
-          absl::StrAppendFormat(out, "%s", DataTypeString(type));
-        });
-    return errors::Unimplemented(
-        "Data type ", DataTypeString(tf_type), " is not supported for ",
-        node_def.op(), ", must be one of [", allowed_types_string, "]");
+    const auto error =
+        convert_not_supported_dtype_msg(allowed_types, tf_type, node_def);
+    return errors::Unimplemented(error);
   }
   return Status::OK();
 }
@@ -1785,7 +1784,7 @@ std::vector<int64_t> GetSpatialDimsFromOutputSizes(
 }
 }  // namespace
 
-Status ConvertConv2DHelper(OpConverterParams* params, int group,
+Status ConvertConv2DHelper(const OpConverterParams* params, int group,
                            bool is_conv2d_backprop_input) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
@@ -2079,7 +2078,7 @@ bool AllowInefficientTranspose() {
   return result;
 }
 
-Status ConvertTranspose(OpConverterParams* params) {
+Status ConvertTranspose(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   TF_RETURN_IF_ERROR(
       CheckInputsWeights(*params, {{"x", false}, {"perm", true}}));
@@ -2123,7 +2122,7 @@ Status ConvertTranspose(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertShape(OpConverterParams* params) {
+Status ConvertShape(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   TF_RETURN_IF_ERROR(
       CheckInputsWeights(*params, {{"input", TrtInputArg::kBoth}}));
@@ -2165,7 +2164,7 @@ Status ExpectShapeTensor(const TRT_TensorOrWeights& tensor) {
 }
 
 // Converts Reshape op if the input has dynamic (unknown) dims.
-Status ConvertDynamicReshape(OpConverterParams* params) {
+Status ConvertDynamicReshape(const OpConverterParams* params) {
   if (params->use_implicit_batch) {
     return errors::InvalidArgument(
         "The input \"shape\" for Reshape must be a constant in implicit batch"
@@ -2202,7 +2201,7 @@ Status ConvertDynamicReshape(OpConverterParams* params) {
 
 // Converts Reshape in explicit batch mode if the input has static (known) dims.
 Status ConvertStaticReshapeForExplicitBatchMode(
-    OpConverterParams* params, DimsAdapter output_dims,
+    const OpConverterParams* params, DimsAdapter output_dims,
     ITensorProxyPtr* output_tensor) {
   return PrepareTensorForShape(params->converter, params->inputs.at(0),
                                output_dims, params->validation_only,
@@ -2211,7 +2210,7 @@ Status ConvertStaticReshapeForExplicitBatchMode(
 
 // Converts Reshape in implicit batch mode. The input has static (known) dims.
 Status ConvertStaticReshapeForImplicitBatchMode(
-    OpConverterParams* params, DimsAdapter output_dims,
+    const OpConverterParams* params, DimsAdapter output_dims,
     ITensorProxyPtr* output_tensor) {
   const auto& inputs = params->inputs;
   const TRT_TensorOrWeights& input_tensor = inputs.at(0);
@@ -2245,7 +2244,7 @@ Status ConvertStaticReshapeForImplicitBatchMode(
                                output_tensor, params->node_def);
 }
 
-Status ConvertReshape(OpConverterParams* params) {
+Status ConvertReshape(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   TF_RETURN_IF_ERROR(CheckInputsWeights(
       *params,
@@ -2285,7 +2284,7 @@ Status ConvertReshape(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertExpandDims(OpConverterParams* params) {
+Status ConvertExpandDims(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(
@@ -2331,7 +2330,7 @@ Status ConvertExpandDims(OpConverterParams* params) {
 
 Status Converter::DynamicReshape(ITensorProxyPtr input,
                                  std::vector<std::pair<int, int>> slices,
-                                 OpConverterParams* params,
+                                 const OpConverterParams* params,
                                  ITensorProxyPtr* output,
                                  std::vector<int> size_for_added_dims,
                                  std::optional<int> op_instance) {
@@ -2392,7 +2391,7 @@ Status Converter::DynamicReshape(ITensorProxyPtr input,
 
 Status Converter::DynamicExpandDims(ITensorProxyPtr input,
                                     const nvinfer1::Dims& dims, int axis,
-                                    OpConverterParams* params,
+                                    const OpConverterParams* params,
                                     ITensorProxyPtr* output,
                                     std::optional<int> op_instance) {
   if (params->validation_only) {
@@ -2421,7 +2420,7 @@ Status Converter::DynamicExpandDims(ITensorProxyPtr input,
 
 Status Converter::SqueezeTensor(ITensorProxyPtr input,
                                 std::vector<int>* input_dims,
-                                OpConverterParams* params,
+                                const OpConverterParams* params,
                                 ITensorProxyPtr* output,
                                 std::optional<int> op_instance) {
   // If the remaining dimensions of a squeeze operation have dynamic sizes, we
@@ -2453,7 +2452,7 @@ Status Converter::SqueezeTensor(ITensorProxyPtr input,
   return Status::OK();
 }
 
-Status ConvertSqueeze(OpConverterParams* params) {
+Status ConvertSqueeze(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"input", false}}));
@@ -2514,7 +2513,7 @@ Status ConvertSqueeze(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertSlice(OpConverterParams* params) {
+Status ConvertSlice(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   TF_RETURN_IF_ERROR(CheckInputsWeights(
       *params, {{"input", false}, {"begin", true}, {"size", true}}));
@@ -2647,7 +2646,7 @@ Status ConvertSlice(OpConverterParams* params) {
                                    strided_slice_spec);
 }
 
-Status ConvertStridedSlice(OpConverterParams* params) {
+Status ConvertStridedSlice(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
 
@@ -2774,19 +2773,19 @@ Status ConvertStridedSlice(OpConverterParams* params) {
                                    strided_slice_spec);
 }
 
-Status ConvertConv2D(OpConverterParams* params) {
+Status ConvertConv2D(const OpConverterParams* params) {
   return ConvertConv2DHelper(params, 1, /*is_conv2d_backprop_input=*/false);
 }
 
-Status ConvertConv2DDepthwise(OpConverterParams* params) {
+Status ConvertConv2DDepthwise(const OpConverterParams* params) {
   return ConvertConv2DHelper(params, 0, /*is_conv2d_backprop_input=*/false);
 }
 
-Status ConvertConv2DBackpropInput(OpConverterParams* params) {
+Status ConvertConv2DBackpropInput(const OpConverterParams* params) {
   return ConvertConv2DHelper(params, 1, /*is_conv2d_backprop_input=*/true);
 }
 
-Status ConvertConv3DHelper(OpConverterParams* params, int group,
+Status ConvertConv3DHelper(const OpConverterParams* params, int group,
                            bool is_conv3d_backprop_input = false) {
   const int kNumDims = 5;
   const auto& inputs = params->inputs;
@@ -2975,15 +2974,15 @@ Status ConvertConv3DHelper(OpConverterParams* params, int group,
   return Status::OK();
 }
 
-Status ConvertConv3D(OpConverterParams* params) {
+Status ConvertConv3D(const OpConverterParams* params) {
   return ConvertConv3DHelper(params, 1, /*is_conv3d_backprop_input=*/false);
 }
 
-Status ConvertConv3DBackpropInputV2(OpConverterParams* params) {
+Status ConvertConv3DBackpropInputV2(const OpConverterParams* params) {
   return ConvertConv3DHelper(params, 1, /*is_conv3d_backprop_input=*/true);
 }
 
-Status ConvertPool3D(OpConverterParams* params) {
+Status ConvertPool3D(const OpConverterParams* params) {
   const int kNumDims = 5;
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
@@ -3071,7 +3070,7 @@ Status ConvertPool3D(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertFusedConv2DBiasActivation(OpConverterParams* params) {
+Status ConvertFusedConv2DBiasActivation(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
 
@@ -3215,7 +3214,7 @@ Status ConvertFusedConv2DBiasActivation(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertPool(OpConverterParams* params) {
+Status ConvertPool(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"input", false}}));
@@ -3278,7 +3277,7 @@ Status ConvertPool(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertClipByValue(OpConverterParams* params) {
+Status ConvertClipByValue(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   // TODO(tmorris): We can also allow the case where min and max are tensors by
@@ -3319,7 +3318,7 @@ Status ConvertClipByValue(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertBiasAdd(OpConverterParams* params) {
+Status ConvertBiasAdd(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TFTRT_CHECK_INPUT_SIZE(inputs.size(), 2, node_def);
@@ -3503,7 +3502,7 @@ Status TfTensorToTrtWeights(const Tensor& tensor, TrtWeightStore* weight_store,
 // weights to params->outputs. We did this since TrtNodeValidator needs the
 // weights as input to other nodes, and use it to determine whether those nodes
 // are supported by TRT.
-Status ConvertConst(OpConverterParams* params) {
+Status ConvertConst(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   if (!inputs.empty()) {
@@ -3538,7 +3537,7 @@ Status ConvertConst(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertIdentity(OpConverterParams* params) {
+Status ConvertIdentity(const OpConverterParams* params) {
   // TODO(tmorris): TRT's Identity layer does not get optimized away as of TRT
   // 5.0, however once we know that it does it would be nice to use that
   // instead.
@@ -3550,7 +3549,7 @@ Status ConvertIdentity(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertSquare(OpConverterParams* params) {
+Status ConvertSquare(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"x", false}}));
@@ -3576,7 +3575,7 @@ Status ConvertSquare(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertReduce(OpConverterParams* params) {
+Status ConvertReduce(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(
@@ -3640,7 +3639,7 @@ Status ConvertReduce(OpConverterParams* params) {
 // converted by first expanding input tensors by adding a new dimension of size
 // one at the specified axis and then concatenating the tensors at the same
 // axis.
-Status ConvertPack(OpConverterParams* params) {
+Status ConvertPack(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
 
@@ -3757,7 +3756,7 @@ Status ConvertPack(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertPad(OpConverterParams* params) {
+Status ConvertPad(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(
@@ -3895,7 +3894,7 @@ Status ConvertPad(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertSplitHelper(OpConverterParams* params,
+Status ConvertSplitHelper(const OpConverterParams* params,
                           const TRT_TensorOrWeights& input, int tf_axis,
                           int num_splits, bool squeeze_after) {
   const auto& node_def = params->node_def;
@@ -4002,16 +4001,13 @@ Status ConvertSplitHelper(OpConverterParams* params,
   return Status::OK();
 }
 
-Status ConvertSplit(OpConverterParams* params) {
+Status ConvertSplit(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(
       CheckInputsWeights(*params, {{"axis", true}, {"value", false}}));
-  TF_RETURN_IF_ERROR(AllowDataTypes(*params, {
-                                                 DataType::DT_FLOAT,
-                                                 DataType::DT_HALF,
-                                                 DataType::DT_INT32,
-                                             }));
+  TF_RETURN_IF_ERROR(AllowDataTypes(
+      *params, {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}));
   int tf_axis = inputs.at(0).weights().GetSpan<int>()[0];
 
   int num_split;
@@ -4020,15 +4016,12 @@ Status ConvertSplit(OpConverterParams* params) {
   return ConvertSplitHelper(params, inputs.at(1), tf_axis, num_split, false);
 }
 
-Status ConvertUnpack(OpConverterParams* params) {
+Status ConvertUnpack(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"value", false}}));
-  TF_RETURN_IF_ERROR(AllowDataTypes(*params, {
-                                                 DataType::DT_FLOAT,
-                                                 DataType::DT_HALF,
-                                                 DataType::DT_INT32,
-                                             }));
+  TF_RETURN_IF_ERROR(AllowDataTypes(
+      *params, {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}));
   // Input must be rank 1 or higher, since we can't unpack on axis 0.
   if (inputs.at(0).GetTrtDims().nbDims == 0) {
     return errors::Unimplemented(
@@ -4043,7 +4036,7 @@ Status ConvertUnpack(OpConverterParams* params) {
   return ConvertSplitHelper(params, inputs.at(0), tf_axis, num, true);
 }
 
-Status ConvertCast(OpConverterParams* params) {
+Status ConvertCast(const OpConverterParams* params) {
   auto unsupport_cast_error = [&](string msg) {
     return errors::Unimplemented("Cast op is not supported - ", msg);
   };
@@ -4083,7 +4076,7 @@ Status ConvertCast(OpConverterParams* params) {
   return ConvertIdentity(params);
 }
 
-Status ConvertConcat(OpConverterParams* params) {
+Status ConvertConcat(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
 
@@ -4151,7 +4144,7 @@ Status ConvertConcat(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertFusedBatchNorm(OpConverterParams* params) {
+Status ConvertFusedBatchNorm(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"x", false},
@@ -4322,7 +4315,7 @@ Status ConvertFusedBatchNorm(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertGather(OpConverterParams* params) {
+Status ConvertGather(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   // TODO(tmorris): Use CheckInputsWeights by changing bool to enum with an
@@ -4472,11 +4465,9 @@ Status ConvertGather(OpConverterParams* params) {
 // Returns the output ITensor* if the node is converted or nullptr if conversion
 // is not possible. An error status indicates internal problems during
 // conversion.
-StatusOr<ITensorProxyPtr> ConvertFullyConnectedImpl(OpConverterParams* params,
-                                                    TRT_TensorOrWeights input_a,
-                                                    TRT_TensorOrWeights input_b,
-                                                    bool transpose_a,
-                                                    bool transpose_b) {
+StatusOr<ITensorProxyPtr> ConvertFullyConnectedImpl(
+    const OpConverterParams* params, TRT_TensorOrWeights input_a,
+    TRT_TensorOrWeights input_b, bool transpose_a, bool transpose_b) {
   if (!(!transpose_a && input_a.is_tensor() && input_b.is_weights())) {
     VLOG(2) << "Not FC compatible, A must be non transposed tensor, and B "
                "must be constant.";
@@ -4581,7 +4572,7 @@ StatusOr<ITensorProxyPtr> ConvertFullyConnectedImpl(OpConverterParams* params,
   return output_tensor;
 }
 
-StatusOr<ITensorProxyPtr> ConvertMatMulImpl(OpConverterParams* params,
+StatusOr<ITensorProxyPtr> ConvertMatMulImpl(const OpConverterParams* params,
                                             TRT_TensorOrWeights input_a,
                                             TRT_TensorOrWeights input_b,
                                             bool transpose_a,
@@ -4656,7 +4647,7 @@ StatusOr<ITensorProxyPtr> ConvertMatMulImpl(OpConverterParams* params,
   return ITensorProxyPtr(layer->getOutput(0));
 }
 
-Status ConvertMatMulHelper(OpConverterParams* params,
+Status ConvertMatMulHelper(const OpConverterParams* params,
                            TRT_TensorOrWeights input_a,
                            TRT_TensorOrWeights input_b, bool transpose_a,
                            bool transpose_b) {
@@ -4670,7 +4661,7 @@ Status ConvertMatMulHelper(OpConverterParams* params,
 }
 
 // inputs are both two dimensional (ops::MatMul)
-Status ConvertMatMul(OpConverterParams* params) {
+Status ConvertMatMul(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TFTRT_CHECK_INPUT_SIZE(inputs.size(), 2, node_def);
@@ -4687,7 +4678,7 @@ Status ConvertMatMul(OpConverterParams* params) {
                              transpose_b);
 }
 
-Status ConvertBatchMatMul(OpConverterParams* params) {
+Status ConvertBatchMatMul(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TFTRT_CHECK_INPUT_SIZE(inputs.size(), 2, node_def);
@@ -4752,7 +4743,7 @@ Status ConvertBatchMatMul(OpConverterParams* params) {
                              transpose_b);
 }
 
-Status ConvertSoftmax(OpConverterParams* params) {
+Status ConvertSoftmax(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"logits", false}}));
@@ -4779,7 +4770,7 @@ Status ConvertSoftmax(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertArgMinMax(OpConverterParams* params) {
+Status ConvertArgMinMax(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(
@@ -4844,7 +4835,7 @@ Status ConvertArgMinMax(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertTopK(OpConverterParams* params) {
+Status ConvertTopK(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(
@@ -4893,7 +4884,7 @@ Status ConvertTopK(OpConverterParams* params) {
 }
 
 StatusOr<std::pair<ITensorProxyPtr, ITensorProxyPtr>>
-CalcDepthSpaceDynamicShape(OpConverterParams* params, int block_size,
+CalcDepthSpaceDynamicShape(const OpConverterParams* params, int block_size,
                            string data_format) {
   // Instead we use a shape layer and shape arithmetic to calculate the reshape
   // dimensions.
@@ -5013,7 +5004,7 @@ CalcDepthSpaceDynamicShape(OpConverterParams* params, int block_size,
   return std::make_pair(first_shuffle_shape, second_shuffle_shape);
 }
 
-Status ConvertDepthSpaceShuffle(OpConverterParams* params) {
+Status ConvertDepthSpaceShuffle(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"input", false}}));
@@ -5176,7 +5167,7 @@ Status ConvertDepthSpaceShuffle(OpConverterParams* params) {
   return Status::OK();
 }
 
-Status ConvertSquaredDifference(OpConverterParams* params) {
+Status ConvertSquaredDifference(const OpConverterParams* params) {
   TF_RETURN_IF_ERROR(CheckInputsWeights(*params, {{"x", false}, {"y", false}}));
   TF_RETURN_IF_ERROR(
       AllowDataTypes(*params, {DataType::DT_FLOAT, DataType::DT_HALF}));
@@ -5219,7 +5210,7 @@ Status ConvertSquaredDifference(OpConverterParams* params) {
 
 #if IS_TRT_VERSION_GE(8, 2, 1, 6) || defined(TF_TRT_USE_EFFICIENT_NMS_PLUGIN)
 
-Status ConvertCombinedNMS(OpConverterParams* params) {
+Status ConvertCombinedNMS(const OpConverterParams* params) {
   TF_RETURN_IF_ERROR(CheckInputsWeights(
       *params, {{"boxes", TrtInputArg::kTensor},
                 {"scores", TrtInputArg::kTensor},
@@ -5382,7 +5373,7 @@ bool AllowNmsTopkOverride() {
   return result;
 }
 
-Status ConvertCombinedNMS(OpConverterParams* params) {
+Status ConvertCombinedNMS(const OpConverterParams* params) {
   TF_RETURN_IF_ERROR(
       CheckInputsWeights(*params, {{"boxes", false},
                                    {"scores", false},
@@ -5564,7 +5555,7 @@ Status ConvertCombinedNMS(OpConverterParams* params) {
 
 #endif  // IS_TRT_VERSION_GE(7, 1, 3, 0)
 
-Status ConvertResize(OpConverterParams* params) {
+Status ConvertResize(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(CheckInputsWeights(
@@ -5716,7 +5707,7 @@ Status ConvertResize(OpConverterParams* params) {
   return Status::OK();
 }  // ConvertResize
 
-Status ConvertAddN(OpConverterParams* params) {
+Status ConvertAddN(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
   TF_RETURN_IF_ERROR(
@@ -6165,6 +6156,15 @@ bool OutputEdgeValidator::operator()(const Edge* out_edge) const {
     return false;
   }
   return true;
+}
+
+std::string convert_not_supported_implicit(const std::string& pOpName,
+                                           const std::string& pNodeName,
+                                           const char* pOpType) {
+  const auto oper = pOpType ? absl::StrCat(pOpType, " ") : string("");
+  return absl::StrCat("Convertion for ", oper, "op: '", pOpName,
+                      "' is not supported in implicit batch mode, at ",
+                      pNodeName);
 }
 
 }  // namespace convert

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -384,13 +384,14 @@ class Converter {
   //   only insert a new dim if size_for_added_dims[i] >= 0.
   Status DynamicReshape(ITensorProxyPtr input,
                         std::vector<std::pair<int, int>> slices,
-                        OpConverterParams* params, ITensorProxyPtr* output,
+                        const OpConverterParams* params,
+                        ITensorProxyPtr* output,
                         std::vector<int> size_for_added_dims = {},
                         std::optional<int> op_instance = std::nullopt);
 
   // Inserts a singleton dimension at axis for a dynamic shape tensor.
   Status DynamicExpandDims(ITensorProxyPtr input, const nvinfer1::Dims& dims,
-                           int axis, OpConverterParams* params,
+                           int axis, const OpConverterParams* params,
                            ITensorProxyPtr* output,
                            std::optional<int> op_instance = std::nullopt);
 
@@ -399,7 +400,7 @@ class Converter {
   // The input_dims argument stores the TRT dimensions of the input tensor,
   // where the dimensions to be squeezed are replaced by 0.
   Status SqueezeTensor(ITensorProxyPtr input, std::vector<int>* input_dims,
-                       OpConverterParams* params, ITensorProxyPtr* output,
+                       const OpConverterParams* params, ITensorProxyPtr* output,
                        std::optional<int> op_instance = std::nullopt);
 
   // Creates an IConstantLayer using 'weights' whose dimensions are specified by
@@ -540,7 +541,8 @@ const UnaryOperationMapType* UnaryOperationMap();
 const UnaryOperationMapType* UnaryBooleanOperationMap();
 
 // Map of all supported ActivationTypes.
-const OperationMap<nvinfer1::ActivationType>* ActivationTypeMap();
+using ActivationTypeMapType = OperationMap<nvinfer1::ActivationType>;
+const ActivationTypeMapType* ActivationTypeMap();
 
 // Map from Tensorflow binary operation names to TensorRT binary operations
 // types.
@@ -562,7 +564,7 @@ absl::InlinedVector<std::string, 10> GetOperationNames(const T& set) {
 // Adds a matrix multiplication operation to the TensorRT graph. The "params"
 // pointer is only used to access the TRT network builder. The inputs and
 // parameters for the op are fully specified by input_[a|b] and transpose_[a|b].
-StatusOr<ITensorProxyPtr> ConvertMatMulImpl(OpConverterParams* params,
+StatusOr<ITensorProxyPtr> ConvertMatMulImpl(const OpConverterParams* params,
                                             TRT_TensorOrWeights input_a,
                                             TRT_TensorOrWeights input_b,
                                             bool transpose_a, bool transpose_b);

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -400,8 +400,8 @@ TEST_F(ValidatorTest, IsTensorRTCandidate_Basics) {
   // Override the Add converter.
   bool start_conversion = false;
   bool should_fail = false;
-  auto op_converter = [&start_conversion,
-                       &should_fail](OpConverterParams* params) -> Status {
+  auto op_converter = [&start_conversion, &should_fail](
+      const OpConverterParams* params) -> Status {
     if (should_fail) return errors::InvalidArgument("");
     if (!params->validation_only) start_conversion = true;
     return Status::OK();
@@ -575,7 +575,8 @@ class ConverterTest : public ::testing::Test {
 
 TEST_F(ConverterTest, ConvertNode) {
   ITensorProxyPtr output_tensors[2];
-  auto op_converter = [&output_tensors](OpConverterParams* params) -> Status {
+  auto op_converter =
+      [&output_tensors](const OpConverterParams* params) -> Status {
     nvinfer1::Dims dims = params->inputs[0].tensor()->getDimensions();
     for (int i = 0; i < 2; ++i) {
       dims.d[0] += 1;
@@ -652,7 +653,8 @@ TEST_F(ConverterTest, RenameAndMarkOutputTensors) {
   // Register a custom converter which shuffles the input. We use it to build a
   // TRT network whose output will be later marked.
   std::vector<ITensorProxyPtr> output_tensors;
-  auto op_converter = [&output_tensors](OpConverterParams* params) -> Status {
+  auto op_converter =
+      [&output_tensors](const OpConverterParams* params) -> Status {
     nvinfer1::Permutation perm;
     perm.order[0] = 1;
     perm.order[1] = 0;
@@ -1986,16 +1988,16 @@ class OpConverter_UnaryTest : public ParameterizedOpConverterTestBase {
       }
 
       const DataType tf_type = get_tf_type();
-      const NodeDef& node_def = op_map[op_name].first(tf_type);
-      runExpectedToFailTest(node_def, input_name, input_values, op_name);
+      const NodeDef& node = op_map[op_name].first(tf_type);
+      runExpectedToFailTest(node, input_name, input_values, op_name);
 
       Status conv_status = Status::OK();
       if (trt_mode_ == TrtTestMode::kImplicitBatch &&
           (op_name == "Sign" || op_name == "Round" ||
            op_name == "LogicalNot")) {
-        conv_status =
-            errors::Unimplemented("Unary op: '", op_name,
-                                  "' is not supported in implicit batch mode");
+        const auto& err =
+            convert_not_supported_implicit(op_name, node.name(), "Unary");
+        conv_status = errors::Unimplemented(err);
       }
 
       Reset();
@@ -2008,7 +2010,7 @@ class OpConverter_UnaryTest : public ParameterizedOpConverterTestBase {
       std::transform(input_values.begin(), input_values.end(),
                      std::back_inserter(output), op_map[op_name].second);
 
-      TestOpConverter("my_unary", node_def, p.expected_output_dims, conv_status,
+      TestOpConverter(node.name(), node, p.expected_output_dims, conv_status,
                       Status::OK(),
                       ArrayFloatNear(output, max_abs_error, nan_sensitive),
                       {output_tf_type});
@@ -2027,7 +2029,7 @@ class OpConverter_UnaryTest : public ParameterizedOpConverterTestBase {
 
     // Input has 0 dimensions, should fail.
     Reset();
-    std::vector<int32> dims = {};
+    std::vector<int32> dims{};
     if (trt_mode_ == TrtTestMode::kImplicitBatch) {
       dims = {1};
     }
@@ -2044,9 +2046,8 @@ class OpConverter_BinaryTest : public ParameterizedOpConverterTestBase {
   template <typename S>
   void RunTests(
       const OperationMap<S>& map,
-      std::map<std::string,
-               std::pair<std::function<NodeDef(DataType)>, std::vector<T>>>&
-          op_test_info,
+      std::map<std::string, std::pair<std::function<NodeDef(DataType)>,
+                                      std::vector<T>>>& op_test_info,
       const std::vector<std::vector<T>>& data) {
     const std::vector<DataType> bool_types{DT_BOOL}, default_types{};
     std::vector<string> logical_ops{"Greater", "Less", "Equal"};
@@ -2085,9 +2086,9 @@ class OpConverter_BinaryTest : public ParameterizedOpConverterTestBase {
           auto conv_status = Status::OK();
           if (tf_type == DT_BOOL || logical_op) {
             if (trt_mode_ == TrtTestMode::kImplicitBatch) {
-              conv_status = errors::Unimplemented(
-                  "Binary op: '", op_name,
-                  "' is not supported in implicit batch mode");
+              conv_status =
+                  errors::Unimplemented(convert_not_supported_implicit(
+                      op_name, node_def.name(), "Binary"));
             } else if (!logical_op &&
                        (!operand_1_is_tensor || !operand_2_is_tensor)) {
               conv_status = errors::InvalidArgument(
@@ -3085,10 +3086,10 @@ void TestMatMulHelper(
     NodeDef node_def = get_matmul(DT_INT32, false, false);
     test->AddTestTensor("input", {1, 2}, DT_INT32, {});
     test->AddTestWeights<int32>("weights", {2, 1}, {3, 5});
+    const std::vector<DataType> allowed_types{DT_FLOAT, DT_HALF};
     test->RunValidationAndConversion(
         node_def, error::UNIMPLEMENTED,
-        StrCat("Data type int32 is not supported for ", node_def.op(),
-               ", must be one of [float, half]"));
+        convert_not_supported_dtype_msg(allowed_types, DT_INT32, node_def));
   }
 
   // FC conversion depends on whether the last dim of A is known or not. In
@@ -3395,12 +3396,11 @@ TEST_P(OpConverter_FP32_Test, ConvertEinsum) {
 
   if (trt_mode_ == TrtTestMode::kImplicitBatch) {
     Reset();
-    NodeDef node_def = get_einsum_nodedef(tf_type_, "ab,cb->ac");
+    NodeDef node = get_einsum_nodedef(tf_type_, "ab,cb->ac");
     AddTestTensor("input_a", {2, 3});
     AddTestTensor("input_b", {2, 3});
-    TestOpConverter(
-        "my_einsum", node_def, {2, 2},
-        errors::Unimplemented("Einsum converter requires dynamic shape mode"),
+    const auto& err = convert_not_supported_implicit(node.op(), node.name());
+    TestOpConverter(node.name(), node, {2, 2}, errors::Unimplemented(err),
         Status::OK(), ElementsAreArray({13, 16, 40, 52}));
     // No further tests.
     return;
@@ -3612,7 +3612,7 @@ TEST_P(OpConverter_FP32_Test, ConvertEinsum) {
             AddTestWeights("input_b", p.shape_b, p.values_b, tf_type_);
           }
         }
-        TestOpConverter("my_einsum", node_def, p.expected_shape, p.conv_status,
+        TestOpConverter(node_def.name(), node_def, p.expected_shape, p.conv_status,
                         Status::OK(), ElementsAreArray(p.expected_output));
       }
     }
@@ -4028,9 +4028,9 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertFill) {
     // random data
     AddTestWeights("dims", {2}, {2, 2}, DT_INT32);
     AddTestWeights("value", {1}, {42.0}, tf_type_);
-    RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
-                               "Conversion for Fill is not implemented in "
-                               "implicit batch mode");
+    RunValidationAndConversion(
+        node_def, error::UNIMPLEMENTED,
+        convert_not_supported_implicit(node_def.op(), node_def.name()));
     return;
   }
 
@@ -4134,17 +4134,16 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertRange) {
   // ConverterRange is not implemented for Implicite batch mode.
   std::vector<int> config(3, 0);
   if (trt_mode_ == TrtTestMode::kImplicitBatch) {
+    const auto& err = convert_not_supported_implicit(ndef.op(), ndef.name());
     do {
       set_parameters(param_name, param_value, param_type, config);
-      RunValidationAndConversion(ndef, error::UNIMPLEMENTED,
-                                 "Conversion for Range is not implemented in "
-                                 "implicit batch mode");
+      RunValidationAndConversion(ndef, error::UNIMPLEMENTED, err);
     } while (nextTensorWeigtConfiguration(config));
 
     return;
   }
 
-  const std::string expect_msg = convert_range_expected_msg(ndef);
+  const auto& expect_msg = convert_range_expected_msg(ndef);
   bool all_weights = true;
   do {
     for (auto limit_type : param_types) {
@@ -4322,9 +4321,9 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertLikeOps) {
     if (trt_mode_ == TrtTestMode::kImplicitBatch) {
       std::vector<float> input_data(8, 42.0f);
       AddTestTensor("input", {8}, tf_type_, input_data);
-      RunValidationAndConversion(node_def, error::UNIMPLEMENTED,
-                                 "Conversion for " + name + "Like is not " +
-                                     "implemented in implicit batch mode");
+      const auto& err = convert_not_supported_implicit(string(name) + "Like",
+                                                       node_def.name());
+      RunValidationAndConversion(node_def, error::UNIMPLEMENTED, err);
       continue;
     }
 
@@ -7052,9 +7051,11 @@ NodeDef GetDataFormatVecPermuteNodeDef(string dst_format, string src_format,
 }
 
 TEST_P(OpConverter_INT32_Test, ConvertDataFormatVecPermute) {
-  Status implicit_error = Status{
-      error::UNIMPLEMENTED, "Implicit batch mode not supported, at my_dfvp"};
-
+  const auto& error = convert_not_supported_implicit(string("DataFormatVecPermute"), string("my_dfvp"));
+  const Status implicit_error = Status{error::UNIMPLEMENTED, error};
+  const auto conversion_status = trt_mode_ == TrtTestMode::kImplicitBatch
+                                  ? implicit_error
+                                  : Status::OK();
   std::vector<DataFormatVecPermuteTestParams> test_params = {
       // 1D case with tensor.
       DataFormatVecPermuteTestParams{
@@ -7064,9 +7065,7 @@ TEST_P(OpConverter_INT32_Test, ConvertDataFormatVecPermute) {
           /*x=*/{1, 2, 3, 4},
           /*x_is_tensor=*/true,
           /*expected_output=*/{1, 4, 2, 3},
-          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
-              ? implicit_error
-              : Status::OK()},
+          /*conversion_status=*/conversion_status},
       // 1D case with weights.
       DataFormatVecPermuteTestParams{
           /*dst_format=*/"NCHW",
@@ -7075,9 +7074,7 @@ TEST_P(OpConverter_INT32_Test, ConvertDataFormatVecPermute) {
           /*x=*/{1, 2, 3, 4},
           /*x_is_tensor=*/false,
           /*expected_output=*/{1, 4, 2, 3},
-          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
-              ? implicit_error
-              : Status::OK()},
+          /*conversion_status=*/conversion_status},
       // 2D case with tensor.
       DataFormatVecPermuteTestParams{
           /*dst_format=*/"NCHW",
@@ -7086,9 +7083,7 @@ TEST_P(OpConverter_INT32_Test, ConvertDataFormatVecPermute) {
           /*x=*/{1, 2, 3, 4, 5, 6, 7, 8},
           /*x_is_tensor=*/true,
           /*expected_output=*/{1, 2, 7, 8, 3, 4, 5, 6},
-          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
-              ? implicit_error
-              : Status::OK()},
+          /*conversion_status=*/conversion_status},
       // 2D case with weights.
       DataFormatVecPermuteTestParams{
           /*dst_format=*/"NCHW",
@@ -7097,9 +7092,7 @@ TEST_P(OpConverter_INT32_Test, ConvertDataFormatVecPermute) {
           /*x=*/{1, 2, 3, 4, 5, 6, 7, 8},
           /*x_is_tensor=*/false,
           /*expected_output=*/{1, 2, 7, 8, 3, 4, 5, 6},
-          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
-              ? implicit_error
-              : Status::OK()},
+          /*conversion_status=*/conversion_status},
       // Format of size 5.
       DataFormatVecPermuteTestParams{
           /*dst_format=*/"NCDHW",
@@ -7108,9 +7101,7 @@ TEST_P(OpConverter_INT32_Test, ConvertDataFormatVecPermute) {
           /*x=*/{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
           /*x_is_tensor=*/true,
           /*expected_output=*/{1, 2, 9, 10, 3, 4, 5, 6, 7, 8},
-          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
-              ? implicit_error
-              : Status::OK()},
+          /*conversion_status=*/conversion_status},
       // Input of size 2: treat the elements as spatial dimensions.
       DataFormatVecPermuteTestParams{
           /*dst_format=*/"NCWH",
@@ -7119,9 +7110,7 @@ TEST_P(OpConverter_INT32_Test, ConvertDataFormatVecPermute) {
           /*x=*/{1, 2, 3, 4},
           /*x_is_tensor=*/true,
           /*expected_output=*/{3, 4, 1, 2},
-          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
-              ? implicit_error
-              : Status::OK()},
+          /*conversion_status=*/conversion_status},
       // Input of size 3: treat the elements as spatial dimensions.
       DataFormatVecPermuteTestParams{
           /*dst_format=*/"NCHWD",
@@ -7130,9 +7119,7 @@ TEST_P(OpConverter_INT32_Test, ConvertDataFormatVecPermute) {
           /*x=*/{1, 2, 3},
           /*x_is_tensor=*/true,
           /*expected_output=*/{2, 3, 1},
-          /*conversion_status=*/trt_mode_ == TrtTestMode::kImplicitBatch
-              ? implicit_error
-              : Status::OK()},
+          /*conversion_status=*/conversion_status},
       // Invalid rank, should fail.
       DataFormatVecPermuteTestParams{
           /*dst_format=*/"NCHW",

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter.h
@@ -66,7 +66,7 @@ struct OpConverterParams {
 };
 
 // Operation converter function specification.
-using OpConverter = std::function<Status(OpConverterParams*)>;
+using OpConverter = std::function<Status(const OpConverterParams*)>;
 
 struct InputArgSpec {
   absl::string_view name;
@@ -77,23 +77,39 @@ struct InputArgSpec {
   }
 };
 
+template <typename T>
+std::string convert_not_supported_dtype_msg(const T& allowed_types,
+                                            DataType tf_type,
+                                            const NodeDef& node) {
+  string allowed_types_string =
+      absl::StrJoin(allowed_types, ", ", [](string* out, const DataType& type) {
+        absl::StrAppendFormat(out, "%s", DataTypeString(type));
+      });
+
+  return absl::StrCat("Data type ", DataTypeString(tf_type),
+                      " is not supported for ", node.op(), ", must be one of [",
+                      allowed_types_string, "]");
+}
+
+std::string convert_not_supported_implicit(const std::string& pOpName,
+                                           const std::string& pNodeName,
+                                           const char* pOpType = NULL);
+
 // A Curiously recurring template pattern (CRTP) template class for operation
 // converters.
 template <typename Impl>
 class OpConverterBase {
  public:
-  explicit OpConverterBase(OpConverterParams* params)
-      : params_(params), node_def_attrs_(params->node_def) {}
+  explicit OpConverterBase(const OpConverterParams* params,
+                           const std::vector<DataType>& data_types =
+                               {DataType::DT_FLOAT, DataType::DT_HALF})
+      : params_(params),
+        node_def_attrs_(params->node_def),
+        allowed_dtypes_(data_types) {}
 
   // Default NodeDef attribute name to inspect in order to determine node data
   // type. The Impl class can override this by implementing the same function.
   static constexpr const char* NodeDefDataTypeAttributeName() { return "T"; }
-
-  // Default allowed data types for the NodeDef data type attribute. The Impl
-  // class can override this by implementing the same function.
-  static constexpr std::array<DataType, 2> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF};
-  }
 
   // Validate data type of the given NodeDef against allowed types.
   Status ValidateNodeDefDataType() {
@@ -110,19 +126,11 @@ class OpConverterBase {
                                      " not found.");
     }
 
-    // Check allowed data types.
-    const auto& node_def = params_->node_def;
-    const auto& allowed_dtypes = Impl::AllowedDataTypes();
-    if (std::find(allowed_dtypes.begin(), allowed_dtypes.end(), *dtype) ==
-        allowed_dtypes.end()) {
-      std::string allowed_types_string = absl::StrJoin(
-          allowed_dtypes, ", ", [](std::string* out, const DataType& type) {
-            absl::StrAppendFormat(out, "%s", DataTypeString(type));
-          });
-      return errors::Unimplemented("Data type ", DataTypeString(*dtype),
-                                   " is not supported for ", node_def.op(),
-                                   ", must be one of [", allowed_types_string,
-                                   "], at ", node_def.name());
+    // Check allowed data types.;
+    if (std::find(allowed_dtypes_.begin(), allowed_dtypes_.end(), *dtype) ==
+        allowed_dtypes_.end()) {
+      return errors::Unimplemented(convert_not_supported_dtype_msg(
+          allowed_dtypes_, *dtype, params_->node_def));
     }
     return Status::OK();
   }
@@ -172,6 +180,16 @@ class OpConverterBase {
   }
 
  protected:
+  Status NotSupportedInImplicitBatch(const char* pOpType = nullptr) {
+    if (params_->use_implicit_batch) {
+      const auto& op = params_->node_def.op();
+      const auto& nodeName = params_->node_def.name();
+      const auto& error = convert_not_supported_implicit(op, nodeName, pOpType);
+      return errors::Unimplemented(error);
+    }
+    return Status::OK();
+  }
+
   void AddOutput(const TRT_TensorOrWeights& out) {
     params_->outputs->push_back(out);
   }
@@ -183,15 +201,16 @@ class OpConverterBase {
     return result;
   }
 
-  OpConverterParams* const params_;
-  AttrSlice node_def_attrs_;
+  const OpConverterParams* const params_;
+  const AttrSlice node_def_attrs_;
+  const std::vector<DataType> allowed_dtypes_;
 };
 
 // Constructs and returns a converter function for a given operation converter
 // class T. This requires T to be a derived class of StructuredOpConverter.
 template <typename T>
 OpConverter MakeConverterFunction() {
-  return [](OpConverterParams* params) -> Status {
+  return [](const OpConverterParams* params) -> Status {
     T converter(params);
     return converter();
   };

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry_test.cc
@@ -25,12 +25,12 @@ namespace convert {
 TEST(TestOpConverterRegistry, TestOpConverterRegistry) {
   bool flag{false};
 
-  auto set_true_func = [&flag](OpConverterParams*) -> Status {
+  auto set_true_func = [&flag](const OpConverterParams*) -> Status {
     flag = true;
     return Status::OK();
   };
 
-  auto set_false_func = [&flag](OpConverterParams*) -> Status {
+  auto set_false_func = [&flag](const OpConverterParams*) -> Status {
     flag = false;
     return Status::OK();
   };

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter_test.cc
@@ -33,15 +33,11 @@ using ::testing::HasSubstr;
 
 class ExampleOpConverter : public OpConverterBase<ExampleOpConverter> {
  public:
-  explicit ExampleOpConverter(OpConverterParams* params)
-      : OpConverterBase<ExampleOpConverter>(params) {}
+  explicit ExampleOpConverter(const OpConverterParams* params)
+      : OpConverterBase<ExampleOpConverter>(params, {DataType::DT_FLOAT}) {}
 
   static constexpr const char* NodeDefDataTypeAttributeName() {
     return "data_type";
-  }
-
-  static constexpr std::array<DataType, 2> AllowedDataTypes() {
-    return {DataType::DT_FLOAT};
   }
 
   static constexpr std::array<InputArgSpec, 2> InputSpec() {

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/binary_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/binary_ops.cc
@@ -25,22 +25,22 @@ namespace convert {
 const BinaryOperationMapType* BinaryOperationMap() {
   static const auto* map = new BinaryOperationMapType({
     {"Add", nvinfer1::ElementWiseOperation::kSUM},
-        {"AddV2", nvinfer1::ElementWiseOperation::kSUM},
-        {"Mul", nvinfer1::ElementWiseOperation::kPROD},
-        {"Sub", nvinfer1::ElementWiseOperation::kSUB},
-        {"Div", nvinfer1::ElementWiseOperation::kDIV},
-        {"FloorDiv", nvinfer1::ElementWiseOperation::kFLOOR_DIV},
-        {"RealDiv", nvinfer1::ElementWiseOperation::kDIV},
-        {"Minimum", nvinfer1::ElementWiseOperation::kMIN},
-        {"Maximum", nvinfer1::ElementWiseOperation::kMAX},
-        {"Pow", nvinfer1::ElementWiseOperation::kPOW},
+    {"AddV2", nvinfer1::ElementWiseOperation::kSUM},
+    {"Mul", nvinfer1::ElementWiseOperation::kPROD},
+    {"Sub", nvinfer1::ElementWiseOperation::kSUB},
+    {"Div", nvinfer1::ElementWiseOperation::kDIV},
+    {"FloorDiv", nvinfer1::ElementWiseOperation::kFLOOR_DIV},
+    {"RealDiv", nvinfer1::ElementWiseOperation::kDIV},
+    {"Minimum", nvinfer1::ElementWiseOperation::kMIN},
+    {"Maximum", nvinfer1::ElementWiseOperation::kMAX},
+    {"Pow", nvinfer1::ElementWiseOperation::kPOW},
 #if IS_TRT_VERSION_GE(8, 2, 0, 0)
-        {"Greater", nvinfer1::ElementWiseOperation::kGREATER},
-        {"Less", nvinfer1::ElementWiseOperation::kLESS},
-        {"Equal", nvinfer1::ElementWiseOperation::kEQUAL},
-        // Operators are implemented as NOT Less and NOT Greater, respectively.
-        {"GreaterEqual", nvinfer1::ElementWiseOperation::kLESS},
-        {"LessEqual", nvinfer1::ElementWiseOperation::kGREATER},
+    {"Greater", nvinfer1::ElementWiseOperation::kGREATER},
+    {"Less", nvinfer1::ElementWiseOperation::kLESS},
+    {"Equal", nvinfer1::ElementWiseOperation::kEQUAL},
+    // Operators are implemented as NOT Less and NOT Greater, respectively.
+    {"GreaterEqual", nvinfer1::ElementWiseOperation::kLESS},
+    {"LessEqual", nvinfer1::ElementWiseOperation::kGREATER},
 #endif
   });
   return map;
@@ -48,8 +48,8 @@ const BinaryOperationMapType* BinaryOperationMap() {
 
 const BinaryOperationMapType* BinaryBooleanOperationMap() {
   static const auto* map = new BinaryOperationMapType({
-      {"LogicalOr", nvinfer1::ElementWiseOperation::kOR},
-      {"LogicalAnd", nvinfer1::ElementWiseOperation::kAND},
+    {"LogicalOr", nvinfer1::ElementWiseOperation::kOR},
+    {"LogicalAnd", nvinfer1::ElementWiseOperation::kAND},
   });
   return map;
 }
@@ -65,7 +65,7 @@ class ConvertBinaryImpl {
       const std::vector<string>& implicit_batch_not_supported_ops = {},
       bool both_tensors = false) {
     const auto& node_def = params.node_def;
-    const auto op = node_def.op();
+    const auto& op = node_def.op();
     const auto op_pair = pOperMap_->find(op);
     if (op_pair == pOperMap_->end()) {
       return errors::Unimplemented("Binary op: ", op, " not supported");
@@ -82,7 +82,7 @@ class ConvertBinaryImpl {
     if ((convertToBool_ = find_name(op, implicit_batch_not_supported_ops))) {
       if (params.use_implicit_batch) {
         return errors::Unimplemented(
-            "Binary op: '", op, "' is not supported in implicit batch mode");
+            convert_not_supported_implicit(op, node_def.name(), "Binary"));
       }
     }
 
@@ -157,13 +157,11 @@ class ConvertBinaryImpl {
 class ConvertBinary : public OpConverterBase<ConvertBinary>,
                       protected ConvertBinaryImpl {
  public:
-  explicit ConvertBinary(OpConverterParams* params)
-      : OpConverterBase<ConvertBinary>(params),
+  explicit ConvertBinary(const OpConverterParams* params)
+      : OpConverterBase<ConvertBinary>(
+            params,
+            {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}),
         ConvertBinaryImpl(BinaryOperationMap()) {}
-
-  static constexpr std::array<DataType, 3> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32};
-  }
 
   static constexpr std::array<InputArgSpec, 2> InputSpec() {
     return ConvertBinaryImpl::InputSpec();
@@ -190,19 +188,29 @@ class ConvertBinary : public OpConverterBase<ConvertBinary>,
 class ConvertBooleanBinary : public OpConverterBase<ConvertBooleanBinary>,
                              public ConvertBinaryImpl {
  public:
-  explicit ConvertBooleanBinary(OpConverterParams* params)
-      : OpConverterBase<ConvertBooleanBinary>(params),
+  explicit ConvertBooleanBinary(const OpConverterParams* params)
+      : OpConverterBase<ConvertBooleanBinary>(params, {DataType::DT_BOOL}),
         ConvertBinaryImpl(BinaryBooleanOperationMap()) {}
-
-  static constexpr std::array<DataType, 1> AllowedDataTypes() {
-    return {DataType::DT_BOOL};
-  }
 
   static constexpr std::array<InputArgSpec, 2> InputSpec() {
     return ConvertBinaryImpl::InputSpec();
   }
 
-  static constexpr const char* NodeDefDataTypeAttributeName() { return ""; }
+  static constexpr const char* NodeDefDataTypeAttributeName() {
+    /*
+    node {
+      name: "..."
+      op: "LogicalOr"
+      input: "..."
+      input: "..."
+      attr {
+        key: "_output_shapes"
+        ...
+      }
+    }
+    */
+    return "";
+  }
   Status Validate() {
 #if IS_TRT_VERSION_GE(8, 2, 0, 0)
     return ValidateImpl(*params_, {"LogicalOr", "LogicalAnd"}, true);

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/data_format_vec_permute.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/data_format_vec_permute.cc
@@ -36,8 +36,9 @@ int get_spatial_dim_count(string format) {
 class ConvertDataFormatVecPermute
     : public OpConverterBase<ConvertDataFormatVecPermute> {
  public:
-  ConvertDataFormatVecPermute(OpConverterParams* params)
-      : OpConverterBase<ConvertDataFormatVecPermute>(params) {}
+  ConvertDataFormatVecPermute(const OpConverterParams* params)
+      : OpConverterBase<ConvertDataFormatVecPermute>(params,
+                                                     {DataType::DT_INT32}) {}
 
   struct DataFormatVecPermuteAttributes {
     string dst_format;
@@ -49,18 +50,10 @@ class ConvertDataFormatVecPermute
     return {InputArgSpec::Create("x", TrtInputArg::kBoth)};
   }
 
-  static constexpr std::array<DataType, 1> AllowedDataTypes() {
-    return {DataType::DT_INT32};
-  }
-
   Status Validate() {
+    TF_RETURN_IF_ERROR(NotSupportedInImplicitBatch());
     const auto& inputs = params_->inputs;
-    const auto& node_def = params_->node_def;
-
-    if (params_->use_implicit_batch) {
-      return errors::Unimplemented("Implicit batch mode not supported, at ",
-                                   node_def.name());
-    }
+    const auto& nodeName = params_->node_def.name();
 
     x_input_ = inputs.at(0);
 
@@ -70,7 +63,7 @@ class ConvertDataFormatVecPermute
     if (input_rank != 1 && input_rank != 2) {
       return errors::InvalidArgument(
           "Input must be a vector or matrix, but got rank ", input_rank,
-          ", at ", node_def.name());
+          ", at ", nodeName);
     }
 
     // Verify and consume node attributes.
@@ -87,19 +80,19 @@ class ConvertDataFormatVecPermute
         return errors::InvalidArgument("1D input must be of size ",
                                        spatial_dim_count, " or ",
                                        full_dim_count, ", but got size ",
-                                       x_dims.d[0], ", at ", node_def.name());
+                                       x_dims.d[0], ", at ", nodeName);
       }
     } else if (input_rank == 2) {
       if (x_dims.d[0] != spatial_dim_count && x_dims.d[0] != full_dim_count) {
         return errors::InvalidArgument(
             "First dimension of 2D input must be of size ", spatial_dim_count,
             " or ", full_dim_count, ", but got shape (", x_dims.d[0], ", ",
-            x_dims.d[1], "), at ", node_def.name());
+            x_dims.d[1], "), at ", nodeName);
       }
       if (x_dims.d[1] != 2) {
         return errors::InvalidArgument(
             "Second dimension of 2D input must be of size 2, but got shape (",
-            x_dims.d[0], ", ", x_dims.d[1], "), at ", node_def.name());
+            x_dims.d[0], ", ", x_dims.d[1], "), at ", nodeName);
       }
     }
 
@@ -112,8 +105,6 @@ class ConvertDataFormatVecPermute
   }
 
   Status Convert() {
-    const auto& node_def = params_->node_def;
-
     // Copy format strings in case they need to be modified.
     string dst_format = attrs_.dst_format;
     string src_format = attrs_.src_format;
@@ -163,7 +154,7 @@ class ConvertDataFormatVecPermute
     nvinfer1::IGatherLayer* layer = params_->converter->network()->addGather(
         *x_tensor->trt_tensor(), *indices_tensor->trt_tensor(), 0);
     TRT_ENSURE(layer);
-    params_->converter->SetLayerName(layer, node_def);
+    params_->converter->SetLayerName(layer, params_->node_def);
 
     ITensorProxyPtr output_tensor = layer->getOutput(0);
 

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/einsum.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/einsum.cc
@@ -510,7 +510,8 @@ void AssembleOutput(InputIterator begin_a, InputIterator begin_b,
 // to expand x into and y the original free dims, e.g. C is reshaped to
 // [B, f_a1, f_a2, f_a3, f_b1, f_b2]. Finally, a permutation is applied to
 // transform the shape to the shape of the original Einsum output.
-Status ShuffleEinsumOutput(OpConverterParams* params, EinsumDescriptor desc_a,
+Status ShuffleEinsumOutput(const OpConverterParams* params,
+                           EinsumDescriptor desc_a,
                            EinsumDescriptor desc_b,
                            const std::vector<int>& permutation,
                            ITensorProxyPtr* output) {
@@ -664,12 +665,8 @@ Status ParseEquation(const std::string& equation,
 
 class ConvertEinsum : public OpConverterBase<ConvertEinsum> {
  public:
-  explicit ConvertEinsum(OpConverterParams* params)
+  explicit ConvertEinsum(const OpConverterParams* params)
       : OpConverterBase<ConvertEinsum>(params) {}
-
-  static constexpr std::array<DataType, 3> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF};
-  }
 
   static constexpr std::array<InputArgSpec, 2> InputSpec() {
     return {InputArgSpec::Create("input_a", TrtInputArg::kBoth),
@@ -677,12 +674,8 @@ class ConvertEinsum : public OpConverterBase<ConvertEinsum> {
   }
 
   Status Validate() {
+    TF_RETURN_IF_ERROR(NotSupportedInImplicitBatch());
     const auto& inputs = params_->inputs;
-    if (params_->use_implicit_batch) {
-      return errors::Unimplemented(
-          "Einsum converter requires dynamic shape mode");
-    }
-
     input_a = std::make_unique<TRT_TensorOrWeights>(inputs.at(0));
     input_b = std::make_unique<TRT_TensorOrWeights>(inputs.at(1));
 
@@ -690,7 +683,6 @@ class ConvertEinsum : public OpConverterBase<ConvertEinsum> {
     TRT_ENSURE_OK(eq);
     TF_RETURN_IF_ERROR(ParseEquation(*eq, &input_a, &input_b, &descriptor_a,
                                      &descriptor_b, &final_transpose));
-
     return Status::OK();
   }
 
@@ -786,12 +778,8 @@ class ReIndexer {
 
 class ConvertEinsum : public OpConverterBase<ConvertEinsum> {
  public:
-  explicit ConvertEinsum(OpConverterParams* params)
+  explicit ConvertEinsum(const OpConverterParams* params)
       : OpConverterBase<ConvertEinsum>(params) {}
-
-  static constexpr std::array<DataType, 3> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF};
-  }
 
   Status ValidateInputs() {
     TRT_ENSURE(params_->inputs.size() <= 2);
@@ -860,11 +848,7 @@ class ConvertEinsum : public OpConverterBase<ConvertEinsum> {
   Status Validate() {
     VLOG(2) << "Running validation using the new einsum "
                "converter";
-    if (params_->use_implicit_batch) {
-      return errors::Unimplemented(
-          "Einsum converter requires dynamic shape mode");
-    }
-
+    TF_RETURN_IF_ERROR(NotSupportedInImplicitBatch());
     StatusOr<std::string> eq = GetAttrValue<std::string>("equation");
     TRT_ENSURE_OK(eq);
 

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/fill_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/fill_ops.cc
@@ -28,26 +28,14 @@ namespace convert {
 template <typename Impl>
 class ConvertFillBase : public OpConverterBase<Impl> {
  public:
-  explicit ConvertFillBase(OpConverterParams* params)
-      : OpConverterBase<Impl>(params) {}
-
-  static constexpr std::array<DataType, 3> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32};
-  }
-
-  Status ValidateFillBase(const OpConverterParams& params) {
-    if (params.use_implicit_batch) {
-      return errors::Unimplemented("Conversion for ", params.node_def.op(),
-                                   " is not implemented in"
-                                   " implicit batch mode");
-    }
-    return Status::OK();
-  }
+  explicit ConvertFillBase(const OpConverterParams* params)
+      : OpConverterBase<Impl>(params, {DataType::DT_FLOAT, DataType::DT_HALF,
+                                       DataType::DT_INT32}) {}
 };
 
 class ConvertFill : public ConvertFillBase<ConvertFill> {
  public:
-  explicit ConvertFill(OpConverterParams* params)
+  explicit ConvertFill(const OpConverterParams* params)
       : ConvertFillBase<ConvertFill>(params) {}
 
   static constexpr std::array<InputArgSpec, 2> InputSpec() {
@@ -58,7 +46,7 @@ class ConvertFill : public ConvertFillBase<ConvertFill> {
 
   Status Validate() {
     const auto& params = *this->params_;
-    TF_RETURN_IF_ERROR(this->ValidateFillBase(params));
+    TF_RETURN_IF_ERROR(NotSupportedInImplicitBatch());
 
     const auto& inputs = params.inputs;
     const auto& node_def = params.node_def;
@@ -114,7 +102,7 @@ class ConvertFill : public ConvertFillBase<ConvertFill> {
 
 class ConvertRange : public ConvertFillBase<ConvertRange> {
  public:
-  explicit ConvertRange(OpConverterParams* params)
+  explicit ConvertRange(const OpConverterParams* params)
       : ConvertFillBase<ConvertRange>(params) {}
 
   static constexpr std::array<InputArgSpec, 3> InputSpec() {
@@ -124,11 +112,25 @@ class ConvertRange : public ConvertFillBase<ConvertRange> {
         InputArgSpec::Create("delta", TrtInputArg::kBoth)};
   }
 
-  static constexpr const char* NodeDefDataTypeAttributeName() { return ""; }
+  static constexpr const char* NodeDefDataTypeAttributeName() {
+    /*
+    node {
+      name: "..."
+      op: "Range"
+      ...
+      attr {
+        key: "Tidx"
+        value {
+          type: DT_INT32
+        }
+      }
+    }
+    */
+    return "Tidx";
+  }
   Status Validate() {
+    TF_RETURN_IF_ERROR(NotSupportedInImplicitBatch());
     const auto& params = *this->params_;
-    TF_RETURN_IF_ERROR(this->ValidateFillBase(params));
-
     const auto& inputs = params.inputs;
     const auto& node_def = params.node_def;
 

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/like_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/like_ops.cc
@@ -28,34 +28,17 @@ namespace convert {
 template <int V>
 class ConvertLikeOps : public OpConverterBase<ConvertLikeOps<V>> {
  public:
-  explicit ConvertLikeOps(OpConverterParams *params)
-      : OpConverterBase<ConvertLikeOps<V>>(params) {}
-
-  static constexpr std::array<DataType, 3> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32};
-  }
+  explicit ConvertLikeOps(const OpConverterParams *params)
+      : OpConverterBase<ConvertLikeOps<V>>(
+            params,
+            {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}) {}
 
   static constexpr std::array<InputArgSpec, 1> InputSpec() {
     return std::array<InputArgSpec, 1>{
         InputArgSpec::Create("input", TrtInputArg::kBoth),
     };
   }
-  Status Validate() {
-    const auto &params = *this->params_;
-
-    const std::string op_name = V == 0 ? "ZerosLike" : "OnesLike";
-    if (params.use_implicit_batch) {
-      return errors::Unimplemented("Conversion for " + op_name +
-                                   " is not implemented in"
-                                   " implicit batch mode");
-    }
-    const auto &inputs = params.inputs;
-    if (inputs.size() != 1) {
-      return errors::InvalidArgument(op_name, " expects 1 input, but received ",
-                                     inputs.size());
-    }
-    return Status::OK();
-  }
+  Status Validate() { return ConvertLikeOps<V>::NotSupportedInImplicitBatch(); }
 
   Status Convert() {
     const auto &params = *this->params_;

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/log_softmax.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/log_softmax.cc
@@ -25,12 +25,8 @@ namespace convert {
 
 class ConvertLogSoftmax : public OpConverterBase<ConvertLogSoftmax> {
  public:
-  explicit ConvertLogSoftmax(OpConverterParams *params)
+  explicit ConvertLogSoftmax(const OpConverterParams *params)
       : OpConverterBase<ConvertLogSoftmax>(params) {}
-
-  static constexpr std::array<DataType, 3> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF};
-  }
 
   static constexpr std::array<InputArgSpec, 1> InputSpec() {
     return std::array<InputArgSpec, 1>{

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops.cc
@@ -82,7 +82,7 @@ QuantizationScales<T, 1> ComputeQuantizationRange(bool signed_input,
 // ITensor pointer. If the input is weights, we convert it to a ITensor by
 // adding a constant layer.
 StatusOr<nvinfer1::ITensor*> ExlicitQDQInputToTensor(
-    TRTNetworkBuilder* builder, OpConverterParams* params,
+    TRTNetworkBuilder* builder, const OpConverterParams* params,
     const TRT_TensorOrWeights& input) {
   if (input.is_tensor()) {
     return input.tensor()->trt_tensor();
@@ -161,7 +161,7 @@ struct QDQOpSpec<ops::QuantizeAndDequantizeV2> {
   // Converts in explicit precision mode. In this mode, QDQ operations are
   // directly converted into TensorRT quantizing and dequantizing scale
   // operations.
-  static Status ConvertExplicit(OpConverterParams* params, const Attrs& args) {
+  static Status ConvertExplicit(const OpConverterParams* params, const Attrs& args) {
     const auto& node_def = params->node_def;
 
     StatusOr<TRTNetworkBuilder> builder = TRTNetworkBuilder::Create(
@@ -249,7 +249,7 @@ struct QDQOpSpec<ops::QuantizeAndDequantizeV3> {
                                                                        args);
   }
 
-  static Status ConvertExplicit(OpConverterParams* params, const Attrs& args) {
+  static Status ConvertExplicit(const OpConverterParams* params, const Attrs& args) {
     return QDQOpSpec<ops::QuantizeAndDequantizeV2>::ConvertExplicit(params,
                                                                     args);
   }
@@ -276,7 +276,7 @@ struct QDQOpSpec<ops::FakeQuantWithMinMaxVars> {
     return errors::Unimplemented("");
   }
 
-  static Status ConvertExplicit(OpConverterParams* params, const Attrs& args) {
+  static Status ConvertExplicit(const OpConverterParams* params, const Attrs& args) {
     return errors::Unimplemented("");
   }
 };
@@ -303,7 +303,7 @@ struct QDQOpSpec<ops::FakeQuantWithMinMaxArgs> {
     return errors::Unimplemented("");
   }
 
-  static Status ConvertExplicit(OpConverterParams* params, const Attrs& args) {
+  static Status ConvertExplicit(const OpConverterParams* params, const Attrs& args) {
     return errors::Unimplemented("");
   }
 };
@@ -311,21 +311,20 @@ struct QDQOpSpec<ops::FakeQuantWithMinMaxArgs> {
 // Converts QDQ operations in non-explicit precision mode. This is the original
 // "ConvertQuantize" function. In this mode, Q/DQ operations are no-ops and are
 // instead used to set the dynamic range of the input tensor.
-Status ConvertDynamicRangeMode(OpConverterParams* params) {
+Status ConvertDynamicRangeMode(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
-
   float min_range = 0.0f;
   float max_range = 0.0f;
-  AttrSlice attrs(params->node_def);
-
-  if (node_def.op() == "FakeQuantWithMinMaxArgs") {
+  const auto& op_name = node_def.op();
+  if (op_name == "FakeQuantWithMinMaxArgs") {
+    AttrSlice attrs(node_def);
     // Get ranges via node attributes.
     TF_RETURN_IF_ERROR(GetNodeAttr(attrs, "min", &min_range));
     TF_RETURN_IF_ERROR(GetNodeAttr(attrs, "max", &max_range));
-  } else if (node_def.op() == "FakeQuantWithMinMaxVars" ||
-             node_def.op() == "QuantizeAndDequantizeV2" ||
-             node_def.op() == "QuantizeAndDequantizeV3") {
+  } else if (op_name == "FakeQuantWithMinMaxVars" ||
+             op_name == "QuantizeAndDequantizeV2" ||
+             op_name == "QuantizeAndDequantizeV3") {
     // Get ranges via inputs.
     auto get_weights_value = [&inputs](int index) {
       const auto* raw_weights = inputs.at(index).weights().GetPointer<float>();
@@ -334,7 +333,7 @@ Status ConvertDynamicRangeMode(OpConverterParams* params) {
     min_range = get_weights_value(1);
     max_range = get_weights_value(2);
   } else {
-    return errors::InvalidArgument("Unknown quantization op ", node_def.op(),
+    return errors::InvalidArgument("Unknown quantization op ", op_name,
                                    ", at ", node_def.name());
   }
   if (params->validation_only) {
@@ -361,7 +360,7 @@ Status ConvertDynamicRangeMode(OpConverterParams* params) {
 template <typename TFOpType>
 class ConvertQDQ : public OpConverterBase<ConvertQDQ<TFOpType>> {
  public:
-  explicit ConvertQDQ(OpConverterParams* params)
+  explicit ConvertQDQ(const OpConverterParams* params)
       : OpConverterBase<ConvertQDQ<TFOpType>>(params) {}
 
   static constexpr auto InputSpec() { return QDQOpSpec<TFOpType>::InputSpec(); }

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.cc
@@ -49,7 +49,7 @@ Status HandleDynamicStridedSliceInput(
     nvinfer1::Dims end_dims);
 
 Status ConvertStridedSliceHelper(
-    OpConverterParams* params, const TRT_TensorOrWeights& input,
+    const OpConverterParams* params, const TRT_TensorOrWeights& input,
     const PartialTensorShape& input_dims, const SliceDims& begin,
     const SliceDims& stride, const SliceDims& end,
     std::optional<nvinfer1::Dims> final_shape, std::optional<int> op_instance,

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.h
@@ -55,7 +55,7 @@ using SliceDims = absl::InlinedVector<int64, 4>;
 // through to the Converter functions optionally accept it (SetLayerName,
 // PrepareTensorForShape).
 Status ConvertStridedSliceHelper(
-    OpConverterParams* params, const TRT_TensorOrWeights& input,
+    const OpConverterParams* params, const TRT_TensorOrWeights& input,
     const PartialTensorShape& input_dims, const SliceDims& begin,
     const SliceDims& stride, const SliceDims& end,
     std::optional<nvinfer1::Dims> final_shape = std::nullopt,

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/tile.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/tile.cc
@@ -25,12 +25,10 @@ namespace convert {
 
 class ConvertTile : public OpConverterBase<ConvertTile> {
  public:
-  explicit ConvertTile(OpConverterParams *params)
-      : OpConverterBase<ConvertTile>(params) {}
-
-  static constexpr std::array<DataType, 3> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32};
-  }
+  explicit ConvertTile(const OpConverterParams *params)
+      : OpConverterBase<ConvertTile>(
+            params,
+            {DataType::DT_FLOAT, DataType::DT_HALF, DataType::DT_INT32}) {}
 
   static constexpr std::array<InputArgSpec, 2> InputSpec() {
     return std::array<InputArgSpec, 2>{
@@ -60,10 +58,11 @@ class ConvertTile : public OpConverterBase<ConvertTile> {
       multiplies = nullptr;
     }
 
+    const auto& node = params.node_def;
     if (dtype != nvinfer1::DataType::kINT32) {
       return errors::InvalidArgument(
-          "The replication parameter of the ", params.node_def.op(),
-          " operation in ", params.node_def.name(), " is expected to be of ",
+          "The replication parameter of the ", node.op(),
+          " operation in ", node.name(), " is expected to be of ",
           DebugString(nvinfer1::DataType::kINT32), " type, got ",
           DebugString(dtype), ".");
     }
@@ -77,7 +76,7 @@ class ConvertTile : public OpConverterBase<ConvertTile> {
       if (mult_numb != nb_dims) {
         return errors::InvalidArgument(
             "The length of the replication vector (", mult_numb,
-            ") of the Tile operation in '", params.node_def.name(),
+            ") of the Tile operation in '", node.name(),
             "' is expected to be equal to the rank of the input vector (",
             nb_dims, ").");
       }
@@ -87,13 +86,13 @@ class ConvertTile : public OpConverterBase<ConvertTile> {
         const auto &mul = absl::StrJoin(multiplies, multiplies + nb_dims, ", ");
         return errors::InvalidArgument(
             "All replications of the Tile operation in '",
-            params.node_def.name(), "' should be positive, got (", mul, ").");
+            node.name(), "' should be positive, got (", mul, ").");
       }
 
       if (params.use_implicit_batch && multiplies[0] > 1) {
         return errors::Unimplemented(
             "The Tile operation along the batch dimension in '",
-            params.node_def.name(), "' is not implemented.");
+            node.name(), "' is not implemented.");
       }
     } else {
       const auto &repl_dims = repl.GetTrtDims();

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/unary_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/unary_ops.cc
@@ -23,34 +23,33 @@ namespace tensorrt {
 namespace convert {
 
 const UnaryOperationMapType* UnaryOperationMap() {
-  static auto* const m =
-      new std::unordered_map<string, nvinfer1::UnaryOperation>({
-        {"Neg", nvinfer1::UnaryOperation::kNEG},
-            {"Exp", nvinfer1::UnaryOperation::kEXP},
-            {"Log", nvinfer1::UnaryOperation::kLOG},
-            {"Rsqrt", nvinfer1::UnaryOperation::kSQRT},
-            {"Sqrt", nvinfer1::UnaryOperation::kSQRT},
-            {"Abs", nvinfer1::UnaryOperation::kABS},
-            {"Reciprocal", nvinfer1::UnaryOperation::kRECIP},
-            {"Sin", nvinfer1::UnaryOperation::kSIN},
-            {"Cos", nvinfer1::UnaryOperation::kCOS},
-            {"Tan", nvinfer1::UnaryOperation::kTAN},
-            {"Sinh", nvinfer1::UnaryOperation::kSINH},
-            {"Cosh", nvinfer1::UnaryOperation::kCOSH},
-            {"Asin", nvinfer1::UnaryOperation::kASIN},
-            {"Acos", nvinfer1::UnaryOperation::kACOS},
-            {"Atan", nvinfer1::UnaryOperation::kATAN},
-            {"Asinh", nvinfer1::UnaryOperation::kASINH},
-            {"Acosh", nvinfer1::UnaryOperation::kACOSH},
-            {"Atanh", nvinfer1::UnaryOperation::kATANH},
-            {"Ceil", nvinfer1::UnaryOperation::kCEIL},
-            {"Floor", nvinfer1::UnaryOperation::kFLOOR},
-            {"Erf", nvinfer1::UnaryOperation::kERF},
+  static auto* const m = new UnaryOperationMapType({
+      {"Exp", nvinfer1::UnaryOperation::kEXP},
+      {"Log", nvinfer1::UnaryOperation::kLOG},
+      {"Sqrt", nvinfer1::UnaryOperation::kSQRT},
+      {"Rsqrt", nvinfer1::UnaryOperation::kSQRT},
+      {"Reciprocal", nvinfer1::UnaryOperation::kRECIP},
+      {"Abs", nvinfer1::UnaryOperation::kABS},
+      {"Neg", nvinfer1::UnaryOperation::kNEG},
+      {"Sin", nvinfer1::UnaryOperation::kSIN},
+      {"Cos", nvinfer1::UnaryOperation::kCOS},
+      {"Tan", nvinfer1::UnaryOperation::kTAN},
+      {"Sinh", nvinfer1::UnaryOperation::kSINH},
+      {"Cosh", nvinfer1::UnaryOperation::kCOSH},
+      {"Asin", nvinfer1::UnaryOperation::kASIN},
+      {"Acos", nvinfer1::UnaryOperation::kACOS},
+      {"Atan", nvinfer1::UnaryOperation::kATAN},
+      {"Asinh", nvinfer1::UnaryOperation::kASINH},
+      {"Acosh", nvinfer1::UnaryOperation::kACOSH},
+      {"Atanh", nvinfer1::UnaryOperation::kATANH},
+      {"Ceil", nvinfer1::UnaryOperation::kCEIL},
+      {"Floor", nvinfer1::UnaryOperation::kFLOOR},
+      {"Erf", nvinfer1::UnaryOperation::kERF},
 #if IS_TRT_VERSION_GE(8, 2, 0, 0)
-            {"Round", nvinfer1::UnaryOperation::kROUND},
-            {"Sign", nvinfer1::UnaryOperation::kSIGN},
+      {"Round", nvinfer1::UnaryOperation::kROUND},
+      {"Sign", nvinfer1::UnaryOperation::kSIGN},
 #endif
-      });
+  });
   return m;
 }
 
@@ -61,19 +60,18 @@ const UnaryOperationMapType* UnaryBooleanOperationMap() {
   return m;
 }
 
-const OperationMap<nvinfer1::ActivationType>* ActivationTypeMap() {
-  static auto* const m =
-      new std::unordered_map<string, nvinfer1::ActivationType>({
-          {"LeakyRelu", nvinfer1::ActivationType::kLEAKY_RELU},
-          {"Relu", nvinfer1::ActivationType::kRELU},
-          {"Relu6", nvinfer1::ActivationType::kCLIP},
-          {"Sigmoid", nvinfer1::ActivationType::kSIGMOID},
-          {"Tanh", nvinfer1::ActivationType::kTANH},
-          {"Elu", nvinfer1::ActivationType::kELU},
-          {"Selu", nvinfer1::ActivationType::kSELU},
-          {"Softsign", nvinfer1::ActivationType::kSOFTSIGN},
-          {"Softplus", nvinfer1::ActivationType::kSOFTPLUS},
-      });
+const ActivationTypeMapType* ActivationTypeMap() {
+  static auto* const m = new ActivationTypeMapType({
+      {"LeakyRelu", nvinfer1::ActivationType::kLEAKY_RELU},
+      {"Relu", nvinfer1::ActivationType::kRELU},
+      {"Relu6", nvinfer1::ActivationType::kCLIP},
+      {"Sigmoid", nvinfer1::ActivationType::kSIGMOID},
+      {"Tanh", nvinfer1::ActivationType::kTANH},
+      {"Elu", nvinfer1::ActivationType::kELU},
+      {"Selu", nvinfer1::ActivationType::kSELU},
+      {"Softsign", nvinfer1::ActivationType::kSOFTSIGN},
+      {"Softplus", nvinfer1::ActivationType::kSOFTPLUS},
+  });
   return m;
 }
 
@@ -84,7 +82,8 @@ class ConvertUnaryImpl {
 
   Status ValidateImpl(const OpConverterParams& params,
                       const std::vector<string>& not_supported_ops = {}) {
-    const auto& op = params.node_def.op();
+    const auto& node = params.node_def;
+    const auto& op = node.op();
     if (pOperMap_->find(op) == pOperMap_->end()) {
       return errors::Unimplemented("Unary op: ", op, " not supported");
     }
@@ -97,8 +96,9 @@ class ConvertUnaryImpl {
     if (!not_supported_ops.empty() && params.use_implicit_batch) {
       const auto& end = not_supported_ops.end();
       if (std::find(not_supported_ops.begin(), end, op) != end) {
-        return errors::Unimplemented(
-            "Unary op: '", op, "' is not supported in implicit batch mode");
+        const auto& err =
+            convert_not_supported_implicit(op, node.name(), "Unary");
+        return errors::Unimplemented(err);
       }
     }
 
@@ -135,19 +135,20 @@ class ConvertUnaryImpl {
 class ConvertUnary : public OpConverterBase<ConvertUnary>,
                      protected ConvertUnaryImpl<nvinfer1::UnaryOperation> {
  public:
-  explicit ConvertUnary(OpConverterParams* params)
-      : OpConverterBase<ConvertUnary>(params),
+  explicit ConvertUnary(const OpConverterParams* params)
+      : OpConverterBase<ConvertUnary>(
+            params,
+            params->node_def.op() == "Sign"
+                ? std::vector<DataType>{DataType::DT_FLOAT, DataType::DT_HALF,
+                                        DataType::DT_INT8, DT_INT32}
+                : std::vector<DataType>{DataType::DT_FLOAT, DataType::DT_HALF,
+                                        DataType::DT_INT8}),
         ConvertUnaryImpl(UnaryOperationMap()) {}
-
-  static constexpr std::array<DataType, 2> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF};
-  }
 
   static constexpr std::array<InputArgSpec, 1> InputSpec() {
     return ConvertUnaryImpl::InputSpec();
   }
 
-  static constexpr const char* NodeDefDataTypeAttributeName() { return ""; }
   Status Validate() { return ValidateImpl(*params_, {"Sign", "Round"}); }
   Status Convert() { return ConvertImpl(*params_); }
 };
@@ -155,19 +156,24 @@ class ConvertUnary : public OpConverterBase<ConvertUnary>,
 class ConvertBooleanUnary : public OpConverterBase<ConvertBooleanUnary>,
                             public ConvertUnaryImpl<nvinfer1::UnaryOperation> {
  public:
-  explicit ConvertBooleanUnary(OpConverterParams* params)
-      : OpConverterBase<ConvertBooleanUnary>(params),
+  explicit ConvertBooleanUnary(const OpConverterParams* params)
+      : OpConverterBase<ConvertBooleanUnary>(params, {DataType::DT_BOOL}),
         ConvertUnaryImpl(UnaryBooleanOperationMap()) {}
-
-  static constexpr std::array<DataType, 1> AllowedDataTypes() {
-    return {DataType::DT_BOOL};
-  }
 
   static constexpr std::array<InputArgSpec, 1> InputSpec() {
     return ConvertUnaryImpl::InputSpec();
   }
 
-  static constexpr const char* NodeDefDataTypeAttributeName() { return ""; }
+  static constexpr const char* NodeDefDataTypeAttributeName() {
+    /*
+    node {
+      name: "..."
+      op: "LogicalNot"
+      input: "..."
+    }
+    */
+    return "";
+  }
   Status Validate() {
 #if IS_TRT_VERSION_GE(8, 2, 0, 0)
     return ValidateImpl(*params_, {"LogicalNot"});
@@ -182,20 +188,15 @@ class ConvertBooleanUnary : public OpConverterBase<ConvertBooleanUnary>,
 class ConvertActivation : public OpConverterBase<ConvertActivation>,
                           protected ConvertUnaryImpl<nvinfer1::ActivationType> {
  public:
-  explicit ConvertActivation(OpConverterParams* params)
+  explicit ConvertActivation(const OpConverterParams* params)
       : OpConverterBase<ConvertActivation>(params),
         ConvertUnaryImpl(ActivationTypeMap()) {}
-
-  static constexpr std::array<DataType, 2> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF};
-  }
 
   static constexpr std::array<InputArgSpec, 1> InputSpec() {
     return std::array<InputArgSpec, 1>{
         InputArgSpec::Create("input", TrtInputArg::kTensor)};
   }
 
-  static constexpr const char* NodeDefDataTypeAttributeName() { return ""; }
   Status Validate() {
     TF_RETURN_IF_ERROR(ValidateImpl(*params_));
     const auto& node_def = params_->node_def;

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/variable_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/variable_ops.cc
@@ -145,16 +145,26 @@ Status ReadVariableHelper(const OpConverterParams* params,
 
 class ConvertVariableV2 : public OpConverterBase<ConvertVariableV2> {
  public:
-  ConvertVariableV2(OpConverterParams* params)
+  ConvertVariableV2(const OpConverterParams* params)
       : OpConverterBase<ConvertVariableV2>(params) {}
 
   static constexpr std::array<InputArgSpec, 0> InputSpec() { return {}; }
 
-  static constexpr std::array<DataType, 2> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF};
-  }
-
   static constexpr const char* NodeDefDataTypeAttributeName() {
+    /*
+    node {
+      name: "..."
+      op: "VariableV2"
+      ...
+      attr {
+        key: "dtype"
+        value {
+          type: DT_FLOAT
+        }
+      }
+      ...
+    }
+    */
     return "dtype";
   }
 
@@ -247,15 +257,11 @@ REGISTER_DEFAULT_TRT_OP_CONVERTER(MakeConverterFunction<ConvertVariableV2>(),
 
 class ConvertReadVariableOp : public OpConverterBase<ConvertReadVariableOp> {
  public:
-  ConvertReadVariableOp(OpConverterParams* params)
+  ConvertReadVariableOp(const OpConverterParams* params)
       : OpConverterBase<ConvertReadVariableOp>(params) {}
 
   static constexpr std::array<InputArgSpec, 1> InputSpec() {
     return {InputArgSpec::Create("resource", TrtInputArg::kResource)};
-  }
-
-  static constexpr std::array<DataType, 2> AllowedDataTypes() {
-    return {DataType::DT_FLOAT, DataType::DT_HALF};
   }
 
   static constexpr const char* NodeDefDataTypeAttributeName() {


### PR DESCRIPTION
- To check the input data type, we need to know which attribute of the node defines it. The op converter defines [NodeDefDataTypeAttributeName()](https://github.com/tensorflow/tensorflow/blob/c1ed80d5e26c54bae9ff54eeaf9810fe744fab15/tensorflow/compiler/tf2tensorrt/convert/op_converter.h#L87) to return the name of the attribute.
- The actual converters can override this. If an empty string is returned by NodeDefDataTypeAttributeName then [type checking is skipped](https://github.com/tensorflow/tensorflow/blob/c1ed80d5e26c54bae9ff54eeaf9810fe744fab15/tensorflow/compiler/tf2tensorrt/convert/op_converter.h#L98).
- Previously the unary and binary op converters returned [empty string](https://github.com/tensorflow/tensorflow/blob/c1ed80d5e26c54bae9ff54eeaf9810fe744fab15/tensorflow/compiler/tf2tensorrt/convert/ops/unary_ops.cc#L198).
This bug is corrected in this PR.