### PR TITLE
Update version numbers for TensorFlow 2.10.0-rc0

### DIFF
--- a/tensorflow/core/public/version.h
+++ b/tensorflow/core/public/version.h
@@ -26,7 +26,7 @@ limitations under the License.
 
 // TF_VERSION_SUFFIX is non-empty for pre-releases (e.g. "-alpha", "-alpha.1",
 // "-beta", "-rc", "-rc.1")
-#define TF_VERSION_SUFFIX ""
+#define TF_VERSION_SUFFIX "-rc0"
 
 #define TF_STR_HELPER(x) #x
 #define TF_STR(x) TF_STR_HELPER(x)

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -45,7 +45,7 @@ from setuptools.dist import Distribution
 # result for pip.
 # Also update tensorflow/tensorflow.bzl and
 # tensorflow/core/public/version.h
-_VERSION = '2.10.0'
+_VERSION = '2.10.0-rc0'
 
 
 # We use the same setup.py for all tensorflow_* packages and for the nightly

--- a/tensorflow/tools/pip_package/setup_partner_builds.py
+++ b/tensorflow/tools/pip_package/setup_partner_builds.py
@@ -40,7 +40,7 @@ from setuptools import setup
 # result for pip.
 # Also update tensorflow/tensorflow.bzl and
 # tensorflow/core/public/version.h
-_VERSION = '2.10.0'
+_VERSION = '2.10.0-rc0'
 
 
 # We use the same setup.py for all tensorflow_* packages and for the nightly


### PR DESCRIPTION
Same as #56949 but with the version change also in `tensorflow/tools/pip_package/setup_partner_builds.py`