### PR TITLE
Disable the flaky random_generator_test for upcoming Docker tests

### DIFF
--- a/tensorflow/python/distribute/BUILD
+++ b/tensorflow/python/distribute/BUILD
@@ -677,6 +677,7 @@ distribute_py_test(
     tags = [
         "multi_and_single_gpu",
         "no_cuda_asan",  # b/213388775
+        "no_oss",  # b/241013307
     ],
     tpu_tags = [
         "no_oss",


### PR DESCRIPTION
DevInfra is working on TF 2.10.0 release builds, and docker release builds are failing because of the 'random_generator_test_cpu' test changes.
I'm disabling the test for TF's oss tests.