### PR TITLE
tensorflow/python/kernel_tests/image_ops/extract_image_patches_grad_t…

### DIFF
--- a/tensorflow/python/kernel_tests/image_ops/BUILD
+++ b/tensorflow/python/kernel_tests/image_ops/BUILD
@@ -121,6 +121,7 @@ cuda_py_test(
     srcs = ["extract_image_patches_grad_test.py"],
     shard_count = 15,
     tags = [
+        "no_oss",  # b/241024908
         "no_rocm",
         "nomac",  # b/181799478
         "notap",  # b/31080670


### PR DESCRIPTION
…est_gpu.runfiles/org_tensorflow/bazel_pip/tensorflow/python/kernel_tests/image_ops/extract_image_patches_grad_test.py flaky in docker

DevInfra is working on TF 2.10.0 release builds, and docker release builds are failing because of the 'extract_image_patches_grad_test_gpu' changes. I'm disabling the test for TF's oss tests.