### PR TITLE
[TF C API] Add TF_SetShape C API

### DIFF
--- a/tensorflow/c/tf_tensor.cc
+++ b/tensorflow/c/tf_tensor.cc
@@ -148,6 +148,11 @@ TF_DataType TF_TensorType(const TF_Tensor* t) {
   return static_cast<TF_DataType>(t->tensor->Type());
 }
 
+void TF_SetShape(TF_Tensor* t, const int64_t* dims, int num_dims) {
+  tensorflow::down_cast<tensorflow::TensorInterface*>(t->tensor)->SetShape(
+      dims, num_dims);
+}
+
 int TF_NumDims(const TF_Tensor* t) { return t->tensor->NumDims(); }
 
 int64_t TF_Dim(const TF_Tensor* t, int dim_index) {
@@ -228,6 +233,14 @@ size_t TensorInterface::ByteSize() const {
 
 void* TensorInterface::Data() const {
   return tensorflow::TensorCApi::Buffer(tensor_)->data();
+}
+
+void TensorInterface::SetShape(const int64_t* dims, int num_dims) {
+  tensorflow::TensorShape s;
+  for (int i = 0; i < num_dims; ++i) {
+    s.AddDim(dims[i]);
+  }
+  tensor_.set_shape(s);
 }
 
 Status TensorInterface::BitcastFrom(const TensorInterface& from, DataType type,

--- a/tensorflow/c/tf_tensor.h
+++ b/tensorflow/c/tf_tensor.h
@@ -113,6 +113,10 @@ TF_CAPI_EXPORT extern void TF_DeleteTensor(TF_Tensor*);
 // Return the type of a tensor element.
 TF_CAPI_EXPORT extern TF_DataType TF_TensorType(const TF_Tensor*);
 
+// Set a new shape for the Tensor.
+TF_CAPI_EXPORT extern void TF_SetShape(TF_Tensor* tensor, const int64_t* dims,
+                                       int num_dims);
+
 // Return the number of dimensions that the tensor has.
 TF_CAPI_EXPORT extern int TF_NumDims(const TF_Tensor*);
 

--- a/tensorflow/c/tf_tensor_internal.h
+++ b/tensorflow/c/tf_tensor_internal.h
@@ -107,6 +107,7 @@ class TensorInterface : public AbstractTensorInterface {
   bool CanMove() const override;
   std::string SummarizeValue() const override;
 
+  void SetShape(const int64_t* dims, int num_dims);
   Status ToTensor(tensorflow::Tensor* dst) const;
   Status BitcastFrom(const TensorInterface& from, DataType type,
                      const int64_t* new_dims, int num_new_dims);

--- a/tensorflow/core/framework/tensor.h
+++ b/tensorflow/core/framework/tensor.h
@@ -44,6 +44,7 @@ class OpKernelContext;
 class Tensor;
 class TensorBuffer;
 class TensorCApi;
+class TensorInterface;
 class TensorCord;
 class TensorDescription;
 class TensorProto;
@@ -693,6 +694,7 @@ class Tensor {
   friend class VariableOp;            // For access to set_shape.
   friend class AutoReloadVariableOp;  // For access to set_shape.
   friend class TensorTestHelper;      // For access to set_shape.
+  friend class TensorInterface;       // For access to set_shape.
   friend class CastOpBase;            // For access to set_dtype.
   friend class ScopedAllocator;       // For access to buf_.
   friend Status batch_util::CopyElementToSlice(


### PR DESCRIPTION
C API to set shape of tensor is missing. This API is required by TF Plugin to modify shapes of existing tensors.

Signed-off-by: Aakar Dwivedi <Aakar.Dwivedi@amd.com>
Reviewed-by: Chandra Kumar Ramasamy <ChandraKumar.Ramasamy@amd.com>