### PR TITLE
[XLA:GPU] HorizontalLoopFusion now generates a cleaner graph

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
@@ -393,21 +393,25 @@ Status HorizontalLoopFusionImpl::CreateFusedComputation(
   size_t fused_instr_output_size =
       GetOutputSizeOfFusible(*fused_fusion_instrs[0]);
   for (size_t i = 0; i < fused_instr_output_size; ++i) {
-    std::vector<HloInstruction*> reshapes(fused_fusion_instrs.size());
+    std::vector<HloInstruction*> instr_outputs(fused_fusion_instrs.size());
     for (size_t j = 0; j < fused_fusion_instrs.size(); ++j) {
       const HloInstruction* old_output =
           GetOutputsOfFusible(*fused_fusion_instrs[j])[i];
       HloInstruction* new_output = clone_map[old_output];
-      TF_ASSIGN_OR_RETURN(
-          reshapes[j],
-          MakeReshapeHlo(ShapeUtil::MakeShapeWithLayout(
-                             new_output->shape().element_type(),
-                             {ShapeUtil::ElementsIn(new_output->shape())},
-                             /*minor_to_major=*/std::vector<int64_t>(1, 0)),
-                         new_output));
+      if (new_output->shape().dimensions_size() == 1) {
+        instr_outputs[j] = new_output;
+      } else {
+	Shape new_shape = ShapeUtil::MakeShapeWithLayout(
+                               new_output->shape().element_type(),
+                               {ShapeUtil::ElementsIn(new_output->shape())},
+                               /*minor_to_major=*/std::vector<int64_t>(1, 0));
+        TF_ASSIGN_OR_RETURN(
+            instr_outputs[j],
+            MakeReshapeHlo(new_shape, new_output));
+      }
     }
     TF_ASSIGN_OR_RETURN(HloInstruction * concated_output,
-                        MakeConcatHlo(reshapes, 0));
+                        MakeConcatHlo(instr_outputs, 0));
     concated_outputs.push_back(concated_output);
   }
 
@@ -462,7 +466,7 @@ Status HorizontalLoopFusionImpl::Fuse(
   // computation creates no performance cost.
   size_t total_output_id = 0;
   for (size_t i = 0; i < fused_fusion_instrs.size(); ++i) {
-    std::vector<HloInstruction*> bitcasts;
+    std::vector<HloInstruction*> bitcasts_or_gte;
     HloInstruction* fused_instr = fused_fusion_instrs[i];
     size_t num_outputs = GetOutputSizeOfFusible(*fused_instr);
     for (size_t j = 0; j < num_outputs; ++j) {
@@ -470,17 +474,27 @@ Status HorizontalLoopFusionImpl::Fuse(
       TF_ASSIGN_OR_RETURN(
           HloInstruction * gep,
           MakeGetTupleElementHlo(hori_fusion_instr, total_output_id++));
-      bitcasts.push_back(computation_->AddInstruction(
-          HloInstruction::CreateBitcast(output->shape(), gep)));
+      // This pass runs late, so useless bitcast won't be cleaned up.
+      if (output->shape().dimensions_size() == 1) {
+        bitcasts_or_gte.push_back(gep);
+      } else {
+        bitcasts_or_gte.push_back(computation_->AddInstruction(
+            HloInstruction::CreateBitcast(output->shape(), gep)));
+      }
     }
     HloInstruction* bitcast_or_tuple =
-        (bitcasts.size() == 1) ? bitcasts.at(0)
+        (bitcasts_or_gte.size() == 1) ? bitcasts_or_gte.at(0)
                                : computation_->AddInstruction(
-                                     HloInstruction::CreateTuple(bitcasts));
+                                     HloInstruction::CreateTuple(bitcasts_or_gte));
+    HloComputation* old_computation = fused_instr->fused_instructions_computation();
+    HloModule* module = old_computation->parent();
     TF_RETURN_IF_ERROR(
         computation_->ReplaceInstruction(fused_instr, bitcast_or_tuple));
+    TF_RETURN_IF_ERROR(module->RemoveEmbeddedComputation(old_computation));
   }
 
+  VLOG(1) << "Fused " << fused_fusion_instrs.size() << " instructions into: "
+          << hori_fusion_instr->ToString();
   return OkStatus();
 }
 

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.h
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.h
@@ -93,6 +93,8 @@ namespace gpu {
 // output dims of the concatenate will be used as the kernel launch dims.
 // Instruction bitcasts can be used for Reshape2 and Reshape3 as long as the
 // outputs of Mul and Add are row-major.
+//
+// Note, reshapes are added only if the tensors isn't already a vector.
 class GpuHorizontalLoopFusion : public HloModulePass {
  public:
   GpuHorizontalLoopFusion() {}

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion_test.cc
@@ -71,20 +71,20 @@ TEST_F(HorizontalLoopFusionTest, BasicTest) {
                     .ValueOrDie();
 
   EXPECT_TRUE(GpuHorizontalLoopFusion().Run(module.get()).ValueOrDie());
-  EXPECT_TRUE(HloDCE().Run(module.get()).ValueOrDie());
+  EXPECT_FALSE(HloDCE().Run(module.get()).ValueOrDie());
 
   const HloInstruction* entry_root =
       module->entry_computation()->root_instruction();
   EXPECT_THAT(entry_root,
-              op::Tuple(op::Bitcast(op::GetTupleElement(op::Fusion())),
-                        op::Bitcast(op::GetTupleElement(op::Fusion()))));
+              op::Tuple(op::GetTupleElement(op::Fusion()),
+                        op::GetTupleElement(op::Fusion())));
 
-  const HloInstruction* fusion = entry_root->operand(0)->operand(0)->operand(0);
+  const HloInstruction* fusion = entry_root->operand(0)->operand(0);
   ASSERT_TRUE(fusion->IsMultiOutputFusion());
   EXPECT_THAT(
       fusion->fused_expression_root(),
-      op::Tuple(op::Slice(op::Concatenate(op::Reshape(), op::Reshape())),
-                op::Slice(op::Concatenate(op::Reshape(), op::Reshape()))));
+      op::Tuple(op::Slice(op::Concatenate()),
+                op::Slice(op::Concatenate())));
 }
 
 // Horizontal fusion should not be triggered as fusion will create cycles.
@@ -194,6 +194,20 @@ TEST_F(HorizontalLoopFusionTest, HorizontalLoopFusionAfterVerticalFusion) {
 
   VLOG(2) << "Dump after horizontal fusion:";
   VLOG(2) << module->ToString();
+
+  const HloInstruction* entry_root =
+      module->entry_computation()->root_instruction();
+  // Check that we add bitcast when needed.
+  EXPECT_THAT(entry_root,
+              op::Tuple(op::Bitcast(op::GetTupleElement(op::Fusion())),
+                        op::Bitcast(op::GetTupleElement(op::Fusion()))));
+  const HloInstruction* fusion_instr = entry_root->operand(0)->operand(0)->operand(0);
+    ASSERT_TRUE(fusion_instr->IsMultiOutputFusion());
+
+  EXPECT_THAT(
+      fusion_instr->fused_expression_root(),
+      op::Tuple(op::Slice(op::Concatenate(op::Reshape(), op::Reshape())),
+                op::Slice(op::Concatenate(op::Reshape(), op::Reshape()))));
 
   EXPECT_TRUE(RunAndCompareNoHloPasses(std::move(module), ErrorSpec{0, 0}));
 }
@@ -412,7 +426,7 @@ TEST_F(HorizontalLoopFusionTest, DynamicUpdateSlice) {
                     .ValueOrDie();
 
   EXPECT_TRUE(GpuHorizontalLoopFusion().Run(module.get()).ValueOrDie());
-  EXPECT_TRUE(HloDCE().Run(module.get()).ValueOrDie());
+  EXPECT_FALSE(HloDCE().Run(module.get()).ValueOrDie());
 
   VLOG(2) << "Dump after horizontal fusion:";
   VLOG(2) << module->ToString();
@@ -500,9 +514,9 @@ TEST_F(HorizontalLoopFusionTest, IterativeHorizontalFusion) {
   const HloInstruction* entry_root =
       module->entry_computation()->root_instruction();
   EXPECT_THAT(entry_root,
-              op::Tuple(op::Bitcast(op::GetTupleElement(op::Fusion())),
-                        op::Bitcast(op::GetTupleElement(op::Fusion()))));
-  const HloInstruction* fusion = entry_root->operand(0)->operand(0)->operand(0);
+              op::Tuple(op::GetTupleElement(op::Fusion()),
+                        op::GetTupleElement(op::Fusion())));
+  const HloInstruction* fusion = entry_root->operand(0)->operand(0);
   EXPECT_TRUE(fusion->IsMultiOutputFusion());
 
   // Verify that the total number of fusion instructions is 2 so that we


### PR DESCRIPTION
This ask less works by other optimization pass.
This is a safe subset of another PR. 
In case of revert, it will revert less changes.
The main changes are:
- Only insert bitcast when needed.
- Only insert reshape when needed.
- Remove old HloComputation when not needed.

This also update the tests for the above change.