### PR TITLE
Attempted workaround for reduce_mean with Hexagon delegates

### DIFF
--- a/tensorflow/lite/delegates/hexagon/builders/reduce_builder.cc
+++ b/tensorflow/lite/delegates/hexagon/builders/reduce_builder.cc
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/delegates/hexagon/hexagon_nn/hexagon_nn.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/util.h"
 
@@ -38,12 +39,65 @@ TfLiteStatus ReduceOpBuilder::PopulateSubGraph(const TfLiteIntArray* inputs,
   // Axes tensor should be constant.
   tensor_id = inputs->data[1];
   const auto& axes_tensor = context->tensors[tensor_id];
+
+
   if (axes_tensor.allocation_type == kTfLiteMmapRo) {
+
+    // TfLiteTensor* new_axes_tensor = new TfLiteTensor();
+    // TF_LITE_ENSURE_STATUS(TfLiteTensorCopy(&axes_tensor, new_axes_tensor));
+    // context->ReportError(context, "Axes tensor has type %d", axes_tensor.type);
+    // TF_LITE_ASSERT(axes_tensor.type == kTfLiteInt32);
+
+    auto axes_orig = GetTensorData<int32_t>(&axes_tensor);
+    auto axes_tensor_size = axes_tensor.dims->size;
+    // context->ReportError(context, "Axes tensor has size %d", axes_tensor_size);
+    // for (int i = 0; i < axes_tensor_size; i++){
+    //   context->ReportError(context, "Axes tensor at dim %d is %d", i, axes_orig[i]);
+    // }
+    auto num_axes = axes_tensor.dims->size;
+
+    // Increase the constant axis by the number of dimensions we're padding
+    int num_dimensions_padding = 4 - input_tensor.dims->size;
+    // context->ReportError(context, "Input tensor has %d dims", input_tensor.dims->size);
+    // context->ReportError(context, "Therefore will pad by %d (4 - num_dims)",
+    //                      num_dimensions_padding);
+
+    TfLiteTensor* new_tensor = new TfLiteTensor();
+    // context->ReportError(context, "initialized new tensor");
+
+    new_tensor->type = axes_tensor.type;
+    new_tensor->bytes = axes_tensor.bytes;
+    new_tensor->data = TfLitePtrUnion{};
+    new_tensor->dims = TfLiteIntArrayCopy(axes_tensor.dims);
+    new_tensor->buffer_handle = axes_tensor.buffer_handle;
+    new_tensor->data_is_stale = axes_tensor.data_is_stale;
+    new_tensor->delegate = axes_tensor.delegate;
+
+    new_tensor->data.data = (void *) new int32_t[axes_tensor_size];
+
+    auto axes = const_cast<int32_t*>(GetTensorData<int32_t>(new_tensor));
+
+    for (int i = 0; i < axes_tensor_size; i++) {
+      axes[i] = axes_orig[i];
+      // context->ReportError(context, "Padding axes at index %d of total %d", i, axes_tensor_size);
+      // context->ReportError(context, "Before padding: %d", axes[i]);
+      // We always left-pad by ones so these should be valid.
+      axes[i] += num_dimensions_padding;
+      // context->ReportError(context, "After padding: %d", axes[i]);
+    }
+
+    // context->tensors[tensor_id] = *new_tensor;
+
     // If the axes input is a constant, bake it into the Hexagon graph as a
     // Const node.
     auto* const_axes_node =
-        graph_builder_->AddConstNodeWithData(tensor_id, axes_tensor);
+        graph_builder_->AddConstNodeWithData(tensor_id, *new_tensor);
+
     AddInput(TensorID(const_axes_node->GetID(), 0));
+
+    // TfLiteTensorDataFree(&axes_tensor.data);
+    // TfLiteTensorFree(const_cast<TfLiteTensor*>(&axes_tensor));
+
   } else {
     TF_LITE_KERNEL_LOG(context, "Reduction op doesn't have constant axis");
     return kTfLiteError;


### PR DESCRIPTION
Attempted workaround for reduce_mean - bump the index for axes reducing over by the number of 'padding' dimensions of size one we add when the input tensor is rank < 4.

I've tesetd this using the benchmarking program and the Hexagon delegate, but I need some help cleaning it up.  Currently, it leaks memory, and there is an error relating to trying to add a duplicate tensor (`ERROR: Trying to add duplicate tensor without overwrite, tflite_tensor_id 1, hexagon_node_id 16, hexagon_node_output_id 0`).

I can't mutate the `axes_tensor` directly (I think because the allocation type is `kTfLiteMmapRo`) and get a segmentation fault if I try.

### The problem (#57026)

When feeding a model with a `reduce_foo` op and a fixed axis to reduce on, we get:
    
Input tensor shape -> [1, 48, 768]
Axis = 2
Output tensor shape -> [1, 48, 1]
    
but in the hexagon delegate we pad the dimensions to make it 4D for nnlib, so we
have:
    
Input tensor shape -> [1, 1, 48, 768]
Axis = 2
Output tensor shape -> [1, 1, 1, 768]

and so get messages like:

```
Log
hexagon/ops/src/op_reducing_mean.c:268:Output tensor is of size 48, but expected output tensor of size 768
hexagon/src/execute.c:167:execute() failed on node id=1b err=-1
hexagon/src/interface.c:1297:fail in execute_inner()
```
from nnlib when trying to run.
