### PR TITLE
fix build of tensorflow/tensorflow/lite/c with cmake

### DIFF
--- a/tensorflow/lite/c/CMakeLists.txt
+++ b/tensorflow/lite/c/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 add_library(tensorflowlite_c ${TFLITE_C_LIBTYPE}
   builtin_op_data.h
   common.h
-  common.c
+  common.cc
   c_api_types.h
   c_api.h
   c_api.cc


### PR DESCRIPTION
Hi,

This PR is fixing compilation of tensorflow/tensorflow/lite/c using cmake.
This is broken in v2.9.1 and was working with v2.8.0

After this modification it is possible to run : 
```
mkdir build && cd build && cmake ../tensorflow/lite/c
```

Best Regards,
Michel.