### PR TITLE
Don't set MLIR_TABLEGEN_EXE

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/CMakeLists.txt
@@ -95,7 +95,6 @@ if(MHLO_EXTERNAL_PROJECT_BUILD)
   set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir ) # --src-root
   set(MLIR_INCLUDE_DIR ${MLIR_MAIN_SRC_DIR}/include ) # --includedir
   set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
-  set(MLIR_TABLEGEN_EXE $<TARGET_FILE:mlir-tblgen>)
   set(MLIR_PDLL_TABLEGEN_EXE $<TARGET_FILE:mlir-pdll>)
   include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
   include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})


### PR DESCRIPTION
With llvm/llvm-project@112499f landed, `MLIR_TABLEGEN_EXE` is given as a
cache variable in the MLIR core project. Other external projects, such
as MLIR-HLO, should not set the variable as this breaks cross-compilation.

It might be necessary to wait for the integrate commit that lands commit
llvm/llvm-project@112499f, before this one can be merged.