### PR TITLE
Fix endianness issue in static_range_quantize process on s390x

### DIFF
--- a/tensorflow/compiler/mlir/quantization/tensorflow/python/quantize_model.py
+++ b/tensorflow/compiler/mlir/quantization/tensorflow/python/quantize_model.py
@@ -651,7 +651,8 @@ def _static_range_quantize(
           for node in node_def:
             if node.op == "Const":
               tensor = node.attr["value"].tensor
-              saved_model_utils.byte_swap_tensor_content(tensor, "little", "big")
+              saved_model_utils.byte_swap_tensor_content(
+                  tensor, "little", "big")
       importer.import_graph_def(graph_def, name='')
       working_graph = ops.get_default_graph()
       graph_def = working_graph.as_graph_def()


### PR DESCRIPTION
Test case `//tensorflow/compiler/mlir/quantization/tensorflow/python:quantize_model_test` would fail on s390x (BE machines) due to endianness issue in `static range quantization` process.

This PR is to swap the tensor content in `graph_def` after the calibration step in `_static_range_quantize()` function, so that this issue could be addressed on BE machines.

This code change would not cause any regressions on existing test cases and it won't affect LE machines.

Signed-off-by: Kun-Lu <kun.lu@ibm.com>