### PR TITLE
Fix endianness issue in un-quantized quant_model on s390x

### DIFF
--- a/tensorflow/compiler/mlir/lite/quantization/lite/quantize_weights_test.cc
+++ b/tensorflow/compiler/mlir/lite/quantization/lite/quantize_weights_test.cc
@@ -181,6 +181,12 @@ const Tensor* FindMatchingExpectedTensor(
         // Otherwise, do additional checks for data type and buffer contents.
         const std::vector<uint8_t> quantized_buffer =
             quant_model->buffers[quantized_tensor->buffer()].get()->data;
+        if (!FLATBUFFERS_LITTLEENDIAN) {
+          const auto* buffer = &(quantized_buffer);
+          int32_t *p = reinterpret_cast<int32_t*>(const_cast<uint8_t*>(buffer->data()));
+          for (size_t i = 0; i < buffer->size(); i+=4, ++p)
+            *p = flatbuffers::EndianSwap(*p);
+        }
         const std::vector<uint8_t> float_buffer =
             float_model->buffers[float_tensor->buffer()].get()->data;
         if ((quantized_buffer == float_buffer) &&


### PR DESCRIPTION
Test case `//tensorflow/compiler/mlir/lite/quantization/lite:quantize_weights_test` would fail on s390x (BE machines). The cause is that the un-quantized output `quant_model` built with `FlatBufferBuilder` has endianness issue in tensor contents.

This PR is to swap the buffer data of the un-quantized tensor in `FindMatchingExpectedTensor()` function, so that the above issue could be addressed.

This code change would not cause any regressions on existing test cases and it won't affect LE machines.

Signed-off-by: Kun-Lu <kun.lu@ibm.com>