### PR TITLE
r2.10 cherry-pick: [oneDNN] Fix memory corruption issues

### DIFF
--- a/third_party/mkl_dnn/mkldnn_v1.BUILD
+++ b/third_party/mkl_dnn/mkldnn_v1.BUILD
@@ -149,6 +149,7 @@ _COPTS_LIST = select({
     "-UUSE_MKL",
     "-UUSE_CBLAS",
     "-DDNNL_ENABLE_MAX_CPU_ISA",
+    "-DDNNL_DISABLE_PRIMITIVE_CACHE",
 ] + tf_openmp_copts()
 
 _INCLUDES_LIST = [


### PR DESCRIPTION
Avoid memory corruption issues by disabling onednn side primitive cache.

Original PR: https://github.com/tensorflow/tensorflow/pull/57044