### PR TITLE
Fix Python 3.11 compatibility problems for JAX/XLA.

### DIFF
--- a/tensorflow/compiler/xla/python/traceback.cc
+++ b/tensorflow/compiler/xla/python/traceback.cc
@@ -35,12 +35,21 @@ bool Traceback::enabled_ = true;
 
 Traceback::Traceback() {
   DCHECK(PyGILState_Check());
-  const PyThreadState* thread_state = PyThreadState_GET();
+  PyThreadState* thread_state = PyThreadState_GET();
+
+#if PY_VERSION_HEX < 0x030b0000
   for (PyFrameObject* py_frame = thread_state->frame; py_frame != nullptr;
        py_frame = py_frame->f_back) {
     Py_INCREF(py_frame->f_code);
     frames_.emplace_back(py_frame->f_code, py_frame->f_lasti);
   }
+#else  // PY_VERSION_HEX < 0x030b0000
+  for (PyFrameObject* py_frame = PyThreadState_GetFrame(thread_state); py_frame != nullptr;
+       py_frame = PyFrame_GetBack(py_frame)) {
+    frames_.emplace_back(PyFrame_GetCode(py_frame), PyFrame_GetLasti(py_frame));
+    Py_XDECREF(py_frame);
+  }
+#endif  // PY_VERSION_HEX < 0x030b0000
 }
 
 Traceback::~Traceback() {
@@ -183,6 +192,7 @@ void BuildTracebackSubmodule(py::module& m) {
       },
       "Python wrapper around the Python C API function PyCode_Addr2Line");
 
+#if PY_VERSION_HEX < 0x030b0000
   // This function replaces the exception traceback associated with the current
   // Python thread.
   m.def(
@@ -204,6 +214,7 @@ void BuildTracebackSubmodule(py::module& m) {
         Py_XDECREF(old_exc_traceback);
       },
       py::arg("traceback"));
-}
+#endif  // PY_VERSION_HEX < 0x30b0000
 
+}
 }  // namespace xla

--- a/tensorflow/python/lib/core/bfloat16.cc
+++ b/tensorflow/python/lib/core/bfloat16.cc
@@ -1642,7 +1642,11 @@ bool RegisterNumpyDtype(PyObject* numpy) {
   arr_funcs.argmax = NPyCustomFloat_ArgMaxFunc<T>;
   arr_funcs.argmin = NPyCustomFloat_ArgMinFunc<T>;
 
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_TYPE)
   Py_TYPE(&CustomFloatTypeDescriptor<T>::npy_descr) = &PyArrayDescr_Type;
+#else
+  Py_SET_TYPE(&CustomFloatTypeDescriptor<T>::npy_descr, &PyArrayDescr_Type);
+#endif
   TypeDescriptor<T>::npy_type =
       PyArray_RegisterDataType(&CustomFloatTypeDescriptor<T>::npy_descr);
   TypeDescriptor<T>::type_ptr = &TypeDescriptor<T>::type;

--- a/tensorflow/python/profiler/internal/python_hooks.cc
+++ b/tensorflow/python/profiler/internal/python_hooks.cc
@@ -284,8 +284,14 @@ void PythonHookContext::ProfileFast(PyFrameObject* frame, int what,
 
   switch (what) {
     case PyTrace_CALL: {
+#if PY_VERSION_HEX < 0x030b0000
       PyCodeObject* f_code = frame->f_code;
       thread_traces.active.emplace(now, 0, f_code);
+#else  // PY_VERSION_HEX < 0x030b0000
+      PyCodeObject* f_code = PyFrame_GetCode(frame);
+      thread_traces.active.emplace(now, 0, f_code);
+      Py_XDECREF(f_code);
+#endif  // PY_VERSION_HEX < 0x030b0000
       break;
     }
     case PyTrace_RETURN:
@@ -296,8 +302,14 @@ void PythonHookContext::ProfileFast(PyFrameObject* frame, int what,
         thread_traces.completed.emplace_back(std::move(entry));
         thread_traces.active.pop();
       } else if (options_.include_incomplete_events) {
+#if PY_VERSION_HEX < 0x030b0000
         PyCodeObject* f_code = frame->f_code;
         thread_traces.completed.emplace_back(start_timestamp_ns_, now, f_code);
+#else  // PY_VERSION_HEX < 0x030b0000
+        PyCodeObject* f_code = PyFrame_GetCode(frame);
+        thread_traces.completed.emplace_back(start_timestamp_ns_, now, f_code);
+        Py_XDECREF(f_code);
+#endif  // PY_VERSION_HEX < 0x030b0000
       }
       break;
     }


### PR DESCRIPTION
* We must use `PyThreadState_GetFrame` to obtain a traceback of the current thread, and we must use `PyFrame_GetBack` to obtain the previous frame. Both of these functions return strong references.
* We must use `Py_SET_TYPE` to set types.
* `exc_traceback` no longer exists, but we no longer need a C++ helper to set the exception traceback.