### PR TITLE
[XLA:GPU] Fuse copy added by copy-insertion

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -31,6 +31,8 @@ load(
     "if_cuda_is_configured",
 )
 
+load("//tensorflow/compiler/xla/tests:build_defs.bzl", "xla_test")
+
 # buildifier: disable=same-origin-load
 load("//tensorflow:tensorflow.bzl", "filegroup")
 
@@ -1744,6 +1746,19 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
+)
+
+xla_test(
+    name = "gpu_compiler_test",
+    srcs = ["gpu_compiler_test.cc"],
+    tags = tf_cuda_tests_tags(),
+    disabled_backends = [ "cpu" ],
+    deps = [
+        ":horizontal_loop_fusion",
+        "//tensorflow/compiler/xla/service:hlo_matchers",
+        "//tensorflow/compiler/xla/tests:hlo_test_base",
+        "//tensorflow/compiler/xla/tests:xla_internal_test_main",
+    ],
 )
 
 cc_library(

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -720,6 +720,11 @@ Status GpuCompiler::PrepareHloModuleForIrEmitting(HloModule* hlo_module) {
   }
   pipeline.AddPass<LoopScheduleLinearizer>(GetCanShareBuffer());
   pipeline.AddPass<CopyInsertion>(GetCanShareBuffer());
+  // To fuse the copy.
+  pipeline.AddPass<GpuHorizontalLoopFusion>("copy_");
+  // To remove temporary fused_computation created by GpuHorizontalLoopFusion
+  pipeline.AddPass<HloDCE>();
+
   pipeline.AddPass<GpuSanitizeConstantNames>();
   return pipeline.Run(hlo_module).status();
 }

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler_test.cc
@@ -1,0 +1,72 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.h"
+#include "tensorflow/compiler/xla/service/hlo_matchers.h"
+#include "tensorflow/compiler/xla/tests/hlo_test_base.h"
+
+namespace xla {
+namespace gpu {
+namespace {
+
+namespace op = xla::testing::opcode_matchers;
+
+class GpuCompilerTest : public HloTestBase {};
+
+
+TEST_F(GpuCompilerTest, CopyInsertionFusion) {
+  const char* hlo_text = R"(
+HloModule cluster
+
+ENTRY main {
+  cst = f32[1]{0} constant({0})
+  ROOT tuple_out = (f32[1]{0}, f32[1]{0}, f32[1]{0}, f32[1]{0}) tuple(cst, cst, cst, cst)
+}
+)";
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{0,0}));
+
+  auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
+  std::unique_ptr<HloModule> compiled_module =
+      backend()
+          .compiler()
+          ->RunHloPasses(module->Clone(), backend().default_stream_executor(),
+                         /*device_allocator=*/nullptr)
+          .value();
+  VLOG(2) << compiled_module->ToString();
+
+  // Verify that the total number of fusion instructions is 1.
+  size_t total_fusion_instrs = 0;
+  for (const HloInstruction* instr :
+       compiled_module->entry_computation()->instructions()) {
+    if (instr->opcode() == HloOpcode::kFusion) {
+      ++total_fusion_instrs;
+    }
+  }
+  EXPECT_EQ(total_fusion_instrs, 1);
+
+  const HloInstruction* entry_root =
+    compiled_module->entry_computation()->root_instruction();
+  // Check that we add bitcast when needed.
+  EXPECT_THAT(entry_root,
+              op::Tuple(op::GetTupleElement(op::Fusion()),
+                        op::GetTupleElement(op::Fusion()),
+                        op::GetTupleElement(op::Fusion()),
+                        op::GetTupleElement(op::Fusion())));
+
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler_test.cc
@@ -27,6 +27,10 @@ class GpuCompilerTest : public HloTestBase {};
 
 
 TEST_F(GpuCompilerTest, CopyInsertionFusion) {
+  if (GetTestPlatform()->Name() != "CUDA") {
+    GTEST_SKIP_("Only work on CUDA platform");
+  }
+
   const char* hlo_text = R"(
 HloModule cluster
 

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
@@ -505,6 +505,13 @@ StatusOr<bool> HorizontalLoopFusionImpl::Run() {
   bool changed = false;
   XLA_VLOG_LINES(3, computation_->ToString());
 
+  for (HloInstruction* instr: computation_->instructions()) {
+    if (!instr->control_successors().empty()) {
+      VLOG(1) << "Skipping HorizontalLoopFusion as there is control flow in the graph";
+      return false;
+    }
+  }
+
   // Traverse from use to def. Bitcasts are placed after h-fusions to resolve
   // shape mismatch but bitcasts could prevent future h-fusion from happening.
   // So, a bottom-up, use-to-def order should be more favorable. It also helps

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion_test.cc
@@ -598,46 +598,6 @@ TEST_F(HorizontalLoopFusionTest, TraversalOrder) {
   EXPECT_EQ(total_fusion_instrs, 2);
 }
 
-TEST_F(HorizontalLoopFusionTest, CopyInsertionFusion) {
-  const char* hlo_text = R"(
-HloModule cluster
-
-ENTRY main {
-  cst = f32[1]{0} constant({0})
-  ROOT tuple_out = (f32[1]{0}, f32[1]{0}, f32[1]{0}, f32[1]{0}) tuple(cst, cst, cst, cst)
-}
-)";
-  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{0,0}));
-
-  auto module = ParseAndReturnVerifiedModule(hlo_text).ValueOrDie();
-  std::unique_ptr<HloModule> compiled_module =
-      backend()
-          .compiler()
-          ->RunHloPasses(module->Clone(), backend().default_stream_executor(),
-                         /*device_allocator=*/nullptr)
-          .value();
-  VLOG(2) << compiled_module->ToString();
-
-  // Verify that the total number of fusion instructions is 1.
-  size_t total_fusion_instrs = 0;
-  for (const HloInstruction* instr :
-       compiled_module->entry_computation()->instructions()) {
-    if (instr->opcode() == HloOpcode::kFusion) {
-      ++total_fusion_instrs;
-    }
-  }
-  EXPECT_EQ(total_fusion_instrs, 1);
-
-  const HloInstruction* entry_root =
-    compiled_module->entry_computation()->root_instruction();
-  // Check that we add bitcast when needed.
-  EXPECT_THAT(entry_root,
-              op::Tuple(op::GetTupleElement(op::Fusion()),
-                        op::GetTupleElement(op::Fusion()),
-                        op::GetTupleElement(op::Fusion()),
-                        op::GetTupleElement(op::Fusion())));
-
-}
 }  // namespace
 }  // namespace gpu
 }  // namespace xla


### PR DESCRIPTION
@cheshire @thomasjoerg 
A follow up to https://github.com/tensorflow/tensorflow/pull/57020/

This add the h-loop-fusion optimization pass after the copy-insertion pass.
This is to be able to fuse the introduced copies.

An example HLO before optimizations when copy-insertion add copies:
 ```
HloModule d2d_copy, entry_computation_layout={()->(f32[1]{0}, f32[1]{0}, f32[1]{0}, f32[1]{0})}
 
ENTRY main.22543 {
  constant.535 = f32[1]{0} constant({0})
  ROOT tuple_out = (f32[1]{0}, f32[1]{0}, f32[1]{0}, f32[1]{0}) tuple(constant.535, constant.535, constant.535, constant.535)
}
```

Current after_optimizations:
```
HloModule d2d_copy, entry_computation_layout={()->(f32[1]{0}, f32[1]{0}, f32[1]{0}, f32[1]{0})}
 
ENTRY main.22543 {
  constant_535 = f32[1]{0} constant({0})
  copy = f32[1]{0} copy(constant_535)
  copy.1 = f32[1]{0} copy(constant_535)
  copy.2 = f32[1]{0} copy(constant_535)
  copy.3 = f32[1]{0} copy(constant_535)
  ROOT tuple = (f32[1]{0}, f32[1]{0}, f32[1]{0}, f32[1]{0}) tuple(copy, copy.1, copy.2, copy.3)
}
```

New hlo after this PR:
```
HloModule d2d_copy, entry_computation_layout={()->(f32[1]{0}, f32[1]{0}, f32[1]{0}, f32[1]{0})}

copy_horizontally_fused_computation {
  param_0_0 = f32[1]{0} parameter(0)
  copy.8 = f32[1]{0} copy(param_0_0)
  param_1_0 = f32[1]{0} parameter(1)
  copy.9 = f32[1]{0} copy(param_1_0)
  param_2_0 = f32[1]{0} parameter(2)
  copy.10 = f32[1]{0} copy(param_2_0)
  param_3_0 = f32[1]{0} parameter(3)
  copy.11 = f32[1]{0} copy(param_3_0)
  concatenate = f32[4]{0} concatenate(copy.8, copy.9, copy.10, copy.11), dimensions={0}
  slice = f32[1]{0} slice(concatenate), slice={[0:1]}
  slice.1 = f32[1]{0} slice(concatenate), slice={[1:2]}
  slice.2 = f32[1]{0} slice(concatenate), slice={[2:3]}
  slice.3 = f32[1]{0} slice(concatenate), slice={[3:4]}
  ROOT tuple.1 = (f32[1]{0}, f32[1]{0}, f32[1]{0}, f32[1]{0}) tuple(slice, slice.1, slice.2, slice.3)
}

ENTRY main.22543 {
  constant_535 = f32[1]{0} constant({0})
  copy_fusion = (f32[1]{0}, f32[1]{0}, f32[1]{0}, f32[1]{0}) fusion(constant_535, constant_535, constant_535, constant_535), kind=kInput, calls=copy_horizontally_fused_computation
  get-tuple-element.4 = f32[1]{0} get-tuple-element(copy_fusion), index=0
  get-tuple-element.5 = f32[1]{0} get-tuple-element(copy_fusion), index=1
  get-tuple-element.6 = f32[1]{0} get-tuple-element(copy_fusion), index=2
  get-tuple-element.7 = f32[1]{0} get-tuple-element(copy_fusion), index=3
  ROOT tuple = (f32[1]{0}, f32[1]{0}, f32[1]{0}, f32[1]{0}) tuple(get-tuple-element.4, get-tuple-element.5, get-tuple-element.6, get-tuple-element.7)
}
```

I disable that optimization pass when there is control flow in the graph. This pass doesn't know how to handle that. I do not need that case now, so I do not plan to make it works when control-flow is used.