### PR TITLE
[TF-TRT] DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES fixed to `LLONG_MAX - 512`

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/trt_convert_api.h
+++ b/tensorflow/compiler/tf2tensorrt/trt_convert_api.h
@@ -38,9 +38,10 @@ struct TfTrtConversionParams {
   // Corresponds 'workspaceSize' parameter of
   // nvinfer1::IBuilderConfig::setMaxWorkspaceSize.
 #if IS_TRT_VERSION_GE(8, 4, 0, 0)
-  size_t max_workspace_size_bytes = INT_MAX;
+  // Must use `LLONG_MAX - 512` to avoid overflow during casting.
+  size_t max_workspace_size_bytes = LLONG_MAX - 512;
 #else
-  size_t max_workspace_size_bytes = 1 << 30;
+  size_t max_workspace_size_bytes = 1 << 30;  // 1,073,741,824
 #endif
 
   // Minimum precision used by the TRT Engine.

--- a/tensorflow/python/compiler/tensorrt/test/quantization_mnist_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/quantization_mnist_test.py
@@ -175,10 +175,9 @@ class QuantizationAwareTrainingMNISTTest(test_util.TensorFlowTestCase):
           nodes_denylist=[OUTPUT_NODE_NAME],
           max_batch_size=max_batch_size,
           precision_mode='INT8',
-          # There is a 2GB GPU memory limit for each test, so we set
-          # max_workspace_size_bytes to 256MB to leave enough room for TF
-          # runtime to allocate GPU memory.
-          max_workspace_size_bytes=1 << 28,
+          max_workspace_size_bytes=(
+            trt_convert.DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES
+          ),
           minimum_segment_size=2,
           use_calibration=False)
       graph_def = converter.convert()
@@ -342,7 +341,9 @@ class MNISTTestV2(QuantizationAwareTrainingMNISTTest):
         conv_params = trt_convert.TrtConversionParams(
             precision_mode='FP16',
             minimum_segment_size=2,
-            max_workspace_size_bytes=1 << 28,
+            max_workspace_size_bytes=(
+              trt_convert.DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES
+            ),
             maximum_cached_engines=1)
         converter = trt_convert.TrtGraphConverterV2(
             input_saved_model_dir=saved_model_dir,

--- a/tensorflow/python/compiler/tensorrt/test/tf_function_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_function_test.py
@@ -19,6 +19,7 @@ import os
 
 from tensorflow.core.framework import attr_value_pb2
 from tensorflow.core.protobuf import saved_model_pb2
+from tensorflow.python.compiler.tensorrt import trt_convert
 from tensorflow.python.compiler.tensorrt.test import tf_trt_integration_test_base as trt_test
 from tensorflow.python.compiler.tensorrt.test.tf_trt_integration_test_base import GraphState
 from tensorflow.python.compiler.tensorrt.test.tf_trt_integration_test_base import IsQuantizationWithCalibration
@@ -47,7 +48,9 @@ class TfFunctionTest(trt_test.TfTrtIntegrationTestBase):
         "_tftrt_convert_function": True,
         "_tftrt_trt_logger_name": "DefaultLogger",
         "_tftrt_max_batch_size": 10,
-        "_tftrt_max_workspace_size_bytes": 1 << 25,
+        "_tftrt_max_workspace_size_bytes": (
+          trt_convert.DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES
+        ),
         "_tftrt_precision_mode": "FP16",
         "_tftrt_minimum_segment_size": 2,
         "_tftrt_is_dyn_op": True,

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -271,7 +271,9 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
         # We use the minimum of all the batch sizes, so when multiple different
         # input shapes are provided it'll always create new engines in the
         # cache, and we can therefore test the cache behavior.
-        max_workspace_size_bytes=1 << 25,
+        max_workspace_size_bytes=(
+          trt_convert.DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES
+        ),
         precision_mode=run_params.precision_mode,
         minimum_segment_size=2,
         maximum_cached_engines=1,
@@ -1113,11 +1115,12 @@ def _GetTest(run_params):
 
   def _Test(self):
     logging.info(
-        "Running test %s with parameters: convert_online=%s, "
-        "precision_mode=%s, dynamic_engine=%s, dynamic_shape_mode%s",
-        run_params.test_name, run_params.convert_online,
-        run_params.precision_mode, run_params.dynamic_engine,
-        run_params.dynamic_shape)
+        f"Running test `{run_params.test_name}` with parameters: "
+        f"convert_online={run_params.convert_online}, "
+        f"precision_mode={run_params.precision_mode}, "
+        f"dynamic_engine={run_params.dynamic_engine}, "
+        f"dynamic_shape={run_params.dynamic_shape}"
+    )
     self.RunTest(run_params)
 
   return _Test

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -18,6 +18,7 @@ import collections
 from functools import partial  # pylint: disable=g-importing-member
 import os
 import platform
+import sys
 import tempfile
 
 import numpy as np
@@ -111,9 +112,10 @@ class TrtPrecisionMode(object):
 # For TRT >= 8.4, the recommendation is MAX_INT.
 if (_pywrap_py_utils.is_tensorrt_enabled() and
     trt_utils.is_loaded_tensorrt_version_greater_equal(8, 4, 0)):
-  DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES = np.iinfo(np.int32).max
+  # We must use `sys.maxsize - 512` to avoid overflow during casting.
+  DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES = sys.maxsize - 512
 else:
-  DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES = 1 << 30
+  DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES = 1 << 30  # 1,073,741,824
 
 PROFILE_STRATEGY_RANGE = "Range"
 PROFILE_STRATEGY_OPTIMAL = "Optimal"

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -70,7 +70,7 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
 
   # Use a small max_workspace_size for tests so they don't consume too much GPU
   # memory.
-  _TRT_MAX_WORKSPACE_SIZE_BYTES = 2 << 20
+  _TRT_MAX_WORKSPACE_SIZE_BYTES = trt_convert.DEFAULT_TRT_MAX_WORKSPACE_SIZE_BYTES
 
   def mkdtemp(self):
     return tempfile.mkdtemp(dir=self.get_temp_dir())


### PR DESCRIPTION
This PR fixes a minor bug where default `max_workspace_size` was set to 2GB instead of LLONG_MAX as recommended by TensorRT.

This PR fixes this problem