### PR TITLE
Add dep to MLIRGmlStComposeSetInterfaceIncGen

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/thlo/IR/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/thlo/IR/CMakeLists.txt
@@ -21,6 +21,7 @@ add_mlir_dialect_library(THLODialect
 
   DEPENDS
   MLIRthlo_opsIncGen
+  MLIRGmlStComposeSetInterfaceIncGen
   MLIRGmlStFusionInterfaceIncGen
 
   LINK_LIBS PUBLIC


### PR DESCRIPTION
`thlo_ops.cc` includes `gml_st_ops.h` which includes
`compose_set_interface.h` and the latter requires
`compose_set_interface.h.inc` which belongs to the CMake target
`MLIRGmlStComposeSetInterfaceIncGen`.

The missing dep on `MLIRGmlStComposeSetInterfaceIncGen` caused the
mlir-emitc CI to fail when bumping the mlir-hlo submodule:
https://github.com/iml130/mlir-emitc/runs/7783649359?check_suite_focus=true