### PR TITLE
[XLA:GPU] Fix performance regression when enabling multi-threading for compilation

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -2616,6 +2616,7 @@ test_suite(
         "//tensorflow/compiler/xla/service/gpu/tests:gemm_rewrite_test",
         "//tensorflow/compiler/xla/service/gpu/tests:gpu_alignment_test",
         "//tensorflow/compiler/xla/service/gpu/tests:gpu_atomic_test",
+        "//tensorflow/compiler/xla/service/gpu/tests:gpu_comilation_parallelism_test",
         "//tensorflow/compiler/xla/service/gpu/tests:gpu_convolution_regression_test",
         "//tensorflow/compiler/xla/service/gpu/tests:gpu_copy_alone_test",
         "//tensorflow/compiler/xla/service/gpu/tests:gpu_copy_test",

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -1188,14 +1188,11 @@ GpuCompiler::CompileToTargetBinary(const HloModuleConfig& module_config,
       if (auto* caz =
               llvm::dyn_cast<llvm::ConstantAggregateZero>(initializer)) {
         num_elements = caz->getElementCount().getFixedValue();
-      }
-      else if (auto* cds =
-              llvm::dyn_cast<llvm::ConstantDataSequential>(initializer)) {
+      } else if (auto* cds = llvm::dyn_cast<llvm::ConstantDataSequential>(
+                     initializer)) {
         num_elements = cds->getNumElements();
       }
-      // Here we only select constant global variables with small number of
-      // elements
-      if (num_elements > 0 && num_elements <= 128) {
+      if (num_elements > 0) {
         const_initializer_map[gv.getName()] = initializer;
       }
     }

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -1176,11 +1176,44 @@ GpuCompiler::CompileToTargetBinary(const HloModuleConfig& module_config,
     }
   }
 
+  // Record the name of some constant global variables and their initializers.
+  // We'll change the linkage type of these variables from external to internal
+  // to ensuare constant-folding works properly after calling llvm::SplitModule.
+  llvm::DenseMap<llvm::StringRef, llvm::Constant*> const_initializer_map;
+  for (llvm::GlobalVariable& gv : llvm_module->globals()) {
+    if (gv.hasName() && gv.isConstant() && gv.hasInitializer() &&
+        gv.hasExternalLinkage()) {
+      llvm::Constant* initializer = gv.getInitializer();
+      unsigned int num_elements = 0;
+      if (auto* caz =
+              llvm::dyn_cast<llvm::ConstantAggregateZero>(initializer)) {
+        num_elements = caz->getElementCount().getFixedValue();
+      }
+      if (auto* cds =
+              llvm::dyn_cast<llvm::ConstantDataSequential>(initializer)) {
+        num_elements = cds->getNumElements();
+      }
+      // Here we only select constant global variables with small number of
+      // elements
+      if (num_elements > 0 && num_elements <= 128) {
+        const_initializer_map[gv.getName()] = initializer;
+      }
+    }
+  }
+
   llvm::SplitModule(
       *llvm_module,
       std::max<unsigned>(
           1, std::min<unsigned>(thread_pool->NumThreads(), num_functions)),
       [&](std::unique_ptr<llvm::Module> module) {
+        // Change the linkage type of some global constant variables to internal
+        for (llvm::GlobalVariable& gv : module->globals()) {
+          if (gv.hasName() && gv.isConstant() && !gv.hasInitializer() &&
+              const_initializer_map.count(gv.getName()) != 0) {
+            gv.setInitializer(const_initializer_map[gv.getName()]);
+            gv.setLinkage(llvm::GlobalValue::InternalLinkage);
+          }
+        }
         llvm_modules.push_back(std::move(module));
       },
       /*PreserveLocals=*/true);

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -1178,7 +1178,7 @@ GpuCompiler::CompileToTargetBinary(const HloModuleConfig& module_config,
 
   // Record the name of some constant global variables and their initializers.
   // We'll change the linkage type of these variables from external to internal
-  // to ensuare constant-folding works properly after calling llvm::SplitModule.
+  // to ensure constant-folding works properly after calling llvm::SplitModule.
   llvm::DenseMap<llvm::StringRef, llvm::Constant*> const_initializer_map;
   for (llvm::GlobalVariable& gv : llvm_module->globals()) {
     if (gv.hasName() && gv.isConstant() && gv.hasInitializer() &&
@@ -1189,7 +1189,7 @@ GpuCompiler::CompileToTargetBinary(const HloModuleConfig& module_config,
               llvm::dyn_cast<llvm::ConstantAggregateZero>(initializer)) {
         num_elements = caz->getElementCount().getFixedValue();
       }
-      if (auto* cds =
+      else if (auto* cds =
               llvm::dyn_cast<llvm::ConstantDataSequential>(initializer)) {
         num_elements = cds->getNumElements();
       }

--- a/tensorflow/compiler/xla/service/gpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/tests/BUILD
@@ -436,6 +436,20 @@ tf_cc_test(
 )
 
 tf_cc_test(
+    name = "gpu_compilation_parallelism_test",
+    srcs = [
+        "gpu_compilation_parallelism_test.cc",
+    ],
+    tags = tf_cuda_tests_tags(),
+    deps = [
+        ":gpu_codegen_test",
+        "//tensorflow/compiler/xla/service:hlo",
+        "//tensorflow/compiler/xla/service:hlo_module_config",
+        "//tensorflow/core:test_main",
+    ],
+)
+
+tf_cc_test(
     name = "gpu_copy_test",
     srcs = ["gpu_copy_test.cc"],
     tags = tf_cuda_tests_tags(),

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_compilation_parallelism_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_compilation_parallelism_test.cc
@@ -1,0 +1,69 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <utility>
+
+#include "tensorflow/compiler/xla/service/gpu/tests/gpu_codegen_test.h"
+#include "tensorflow/compiler/xla/service/hlo_instruction.h"
+#include "tensorflow/compiler/xla/service/hlo_module_config.h"
+
+namespace xla {
+namespace gpu {
+
+namespace {
+
+class CompilationParallelismTest : public GpuCodegenTest {
+  DebugOptions GetDebugOptionsForTest() override {
+    DebugOptions debug_options = GpuCodegenTest::GetDebugOptionsForTest();
+    // Use multiple threads for compilation
+    debug_options.set_xla_gpu_force_compilation_parallelism(4);
+    return debug_options;
+  }
+};
+
+TEST_F(CompilationParallelismTest, SharedConstantInMultipleReduce) {
+  const char* hlo_text = R"(
+HloModule Module
+
+%add_computation (x: f32[], y: f32[]) -> f32[] {
+  %x = f32[] parameter(0)
+  %y = f32[] parameter(1)
+  ROOT %add0 = f32[] add(f32[] %x, f32[] %y)
+}
+
+ENTRY %fused_computation.371 {
+  %param_0 = f32[4,8,32]{2,1,0} parameter(0)
+  %param_1 = f32[4,10,32]{2,1,0} parameter(1)
+  %constant_0 = f32[] constant(0.0)
+  %reduce_0 = f32[4,8]{1,0} reduce(f32[4,8,32]{2,1,0} %param_0, f32[] %constant_0), dimensions={2}, to_apply=%add_computation
+  %reduce_1 = f32[4,10]{1,0} reduce(f32[4,10,32]{2,1,0} %param_1, f32[] %constant_0), dimensions={2}, to_apply=%add_computation
+  ROOT %tule = (f32[4,8]{1,0}, f32[4,10]{1,0}) tuple(%reduce_0, %reduce_1)
+}
+)";
+  TF_ASSERT_OK_AND_ASSIGN(std::unique_ptr<VerifiedHloModule> optimized_module,
+                          ParseAndReturnVerifiedModule(hlo_text));
+
+  EXPECT_TRUE(RunAndCompare(hlo_text, ErrorSpec{1e-5, 1e-5}));
+
+  // Make sure constant folding works correctly
+  CompileAndOptionallyVerifyPtx(std::move(optimized_module),
+                                R"(
+CHECK-NOT: ld.global.nc.f32 	%f2, [buffer_for_constant_0];
+)");
+}
+
+}  // namespace
+}  // namespace gpu
+}  // namespace xla


### PR DESCRIPTION
This PR fixed the XLA GPU performance regression when enabling multi-threading for compilation. For a few models we have tested, some global constants like `constant_190 = u64[] constant(32)` may be shared by multiple fused computations. After calling `llvm::SplitModule`, these variables will have external linkage type in those submodules that don't actually own the data and thus cannot be constant-folded properly during llvm optimization. This PR fixed this issue by making those global constants private to each submodule after split.

We tested a few NLP models using pytorch/xla:
| Model      | thrpt (num_threads=1) | thrpt (num_threads=16) | thrpt (num_threads=16 with this PR) |
| ----------- | ----------- | ----------- | ----------- |
| bert-base-uncased | 83.79 | 80.30 | 84.07 |
| roberta-base | 76.87 | 73.76 | 76.74 |
| facebook/bart-base | 63.26 | 59.39 | 62.51 |
| gpt2 | 86.76 | 83.63 | 85.57 |
* throughput unit: sequences/sec
* measured with fake data (batch size=24, sequence length=512)

We considered other methods, but eventually adopted the current approach due to its simplicity:
1. Fuse global constant variables into fused_computations by writing a HLO pass. We tested this method and it works.
2. Add llvm link time optimization. We didn't verify this method but it's likely to be more complicated and the additional benefits are unclear.

Co-authored by: @ducdoan510