### PR TITLE
Reduce verbose logging

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/grpc_channel.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_channel.cc
@@ -269,7 +269,7 @@ class SparseGrpcChannelCache : public CachingGrpcChannelCache {
         job_id_(job_id),
         host_ports_(host_ports),
         channel_func_(std::move(channel_func)) {
-    LOG(INFO) << "Initialize GrpcChannelCache for job " << ToString();
+    VLOG(2) << "Initialize GrpcChannelCache for job " << ToString();
   }
   ~SparseGrpcChannelCache() override {}
 


### PR DESCRIPTION
Reduce verbose logging for `grpc_channel.cc` by changing one of `LOG(INFO)` to `VLOG(2)`.