### PR TITLE
r2.10 cherry-pick: Add oneDNN changes to v2.10 release notes.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,6 +64,15 @@
 *   XLA:
     *   MWMS is now compilable with XLA.
 
+*   [oneDNN CPU performance optimizations](https://github.com/tensorflow/community/blob/master/rfcs/20210930-enable-onednn-ops.md):
+    *   **x86 CPUs**: oneDNN bfloat16 auto-mixed precision grappler graph optimization pass has been renamed from `auto_mixed_precision_mkl` to `auto_mixed_precision_onednn_bfloat16`. See example usage [here](https://www.intel.com/content/www/us/en/developer/articles/guide/getting-started-with-automixedprecisionmkl.html).  
+    *   **aarch64 CPUs:** Experimental oneDNN optimizations are available in the default Linux aarch64 package (`pip install tensorflow`).
+        *   The optimizations are disabled by default. 
+        *   Set the environment variable `TF_ENABLE_ONEDNN_OPTS=1` to enable the optimizations. Setting the variable to 0 or unsetting it will disable the optimizations.
+        *   These optimizations can yield slightly different numerical results from when they are off due to floating-point round-off errors from different computation approaches and orders.
+        *   To verify that the optimizations are on, look for a message with "*oneDNN custom operations are on*" in the log. If the exact phrase is not there, it means they are off.
+        
+
 ## Bug Fixes and Other Changes
 
 *  New argument `experimental_device_ordinal` in `LogicalDeviceConfiguration` to control the order of logical devices. (GPU only)


### PR DESCRIPTION
The content in the oneDNN auto-mixed-precision grappler pass article hasn't been updated to reflect the renaming yet. It will be updated before the final release comes out.