### PR TITLE
[oneDNN] Skip appending kernel registration to log message for MKL ops

### DIFF
--- a/tensorflow/core/framework/op_kernel.cc
+++ b/tensorflow/core/framework/op_kernel.cc
@@ -1444,10 +1444,13 @@ Status FindKernelDef(
     }
 
     // Do not print kernel registrations for other devices when using _JIT
-    // devices for compilation.
-    if (!absl::StrContains(device_str, "JIT")) {
-      errors::AppendToMessage(
-          &s, ".  Registered:", KernelsRegisteredForOp(node_op));
+    // devices for compilation or for MKL ops.
+    // TODO (intel-tf) : Remove the check for MKL ops when support for
+    // block format is removed.
+    if (!absl::StrContains(device_str, "JIT") &&
+        !absl::StartsWith(node_name, "_Mkl")) {
+      errors::AppendToMessage(&s, ".  Registered:",
+                              KernelsRegisteredForOp(node_op));
     }
 
     return s;


### PR DESCRIPTION
This PR skips printing kernel registrations for MKL ops since it leads to performance drop for some eager models caused by this commit https://github.com/tensorflow/tensorflow/commit/c04f65da3e7937b6be01d844a26bf9fd58a27a2d# This is a temporary fix and the condition will be removed when support for block format is removed as a more permanent fix.