### PR TITLE
Refactoring TRT tests for Python.

### DIFF
--- a/tensorflow/python/compiler/tensorrt/tensorrt.bzl
+++ b/tensorflow/python/compiler/tensorrt/tensorrt.bzl
@@ -1,0 +1,43 @@
+"""Functions to initialize tensorrt python tests."""
+
+# buildifier: disable=same-origin-load
+load("//tensorflow:tensorflow.bzl", "cuda_py_test")
+
+# buildifier: disable=unnamed-macro
+def tensorrt_py_test(name, tags, test_names = []):
+    """A helper function that creates the Python TF-TRT unittests
+
+    Args:
+      name: str, the name of the group of tests.
+      tags: a list of tags that will be used by each test.
+      test_names: a list of tests OR a string representing the name of the test.
+                  If test_names is an empty list, test_names = [name]
+                  will be used.
+    """
+
+    if type(test_names) != "list":
+        if type(test_names) != "string":
+            fail("Parameter 'test_names' of tensorrt_py_test(name = '" + name \
+                  + "', test_names = ...) should be a list or a string, got " \
+                  + "'" + type(test_names) + "'")
+        test_names = [test_names]
+    elif test_names == []:
+        test_names = [name]
+
+    for test_name in test_names:
+        # cuda_py_test enable XLA tests by default. TensorRT can't combine XLA with
+        # TensorRT currently and should set xla_enable_strict_auto_jit to False to
+        # disable XLA tests.
+        cuda_py_test(
+            name = test_name,
+            srcs = [test_name + ".py",],
+            python_version = "PY3",
+            tags = tags,
+            xla_enable_strict_auto_jit = False,
+            deps = [
+                "//tensorflow/python:client_testlib",
+                "//tensorflow/python:framework_test_lib",
+                "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
+            ],
+        )
+

--- a/tensorflow/python/compiler/tensorrt/test/BUILD
+++ b/tensorflow/python/compiler/tensorrt/test/BUILD
@@ -4,11 +4,7 @@
 #   APIs are meant to change over time.
 
 # buildifier: disable=same-origin-load
-load("//tensorflow:tensorflow.bzl", "cuda_py_test")
-
-# cuda_py_test enable XLA tests by default. We can't
-# combine XLA with TensorRT currently and should set
-# xla_enable_strict_auto_jit to False to disable XLA tests.
+load("//tensorflow/python/compiler/tensorrt:tensorrt.bzl", "tensorrt_py_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -63,566 +59,62 @@ filegroup(
     visibility = ["//tensorflow/python/compiler/tensorrt:__pkg__"],
 )
 
-cuda_py_test(
-    name = "batch_matmul_test",
-    srcs = [
-        "batch_matmul_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
+oss_tests = [
+    "batch_matmul_test",
+    "biasadd_matmul_test",
+    "binary_tensor_weight_broadcast_test",
+    "cast_test",
+    "concatenation_test",
+    "const_broadcast_test",
+    "dynamic_input_shapes_test",
+    "identity_output_test",
+    "int32_test",
+    "lru_cache_test",
+    "memory_alignment_test",
+    "multi_connection_neighbor_engine_test",
+    "neighboring_engine_test",
+    "quantization_test",
+    "rank_two_test",
+    "reshape_transpose_test",
+    "topk_test",
+    "trt_engine_op_shape_test",
+    "trt_mode_test",
+    "unary_test",
+    "vgg_block_nchw_test",
+    "vgg_block_test",
+]
 
-cuda_py_test(
-    name = "biasadd_matmul_test",
-    srcs = [
-        "biasadd_matmul_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
+no_oss_tests = [
+    "base_test",
+    "conv2d_test" # "conv2d_test.py",  # b/198501457
+]
+# "base_test.py", # TODO(b/165611343): Need to address the failures for CUDA 11 in OSS build.
 
-cuda_py_test(
-    name = "binary_tensor_weight_broadcast_test",
-    srcs = [
-        "binary_tensor_weight_broadcast_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
+base_tags = [
+    "no_cuda_on_cpu_tap",
+    "no_rocm",
+    "no_windows",
+    "nomac",
+]
 
-cuda_py_test(
-    name = "cast_test",
-    srcs = [
-        "cast_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "combined_nms_test",
-    srcs = [
-        "combined_nms_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_oss",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "concatenation_test",
-    srcs = [
-        "concatenation_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "const_broadcast_test",
-    srcs = [
-        "const_broadcast_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "dynamic_input_shapes_test",
-    srcs = [
-        "dynamic_input_shapes_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "identity_output_test",
-    srcs = [
-        "identity_output_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "int32_test",
-    srcs = [
-        "int32_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "lru_cache_test",
-    srcs = [
-        "lru_cache_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "memory_alignment_test",
-    srcs = [
-        "memory_alignment_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "multi_connection_neighbor_engine_test",
-    srcs = [
-        "multi_connection_neighbor_engine_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "neighboring_engine_test",
-    srcs = [
-        "neighboring_engine_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "quantization_test",
-    srcs = [
-        "quantization_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "rank_two_test",
-    srcs = [
-        "rank_two_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "reshape_transpose_test",
-    srcs = [
-        "reshape_transpose_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "tf_function_test",
-    srcs = [
-        "tf_function_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "manual",  # TODO(b/231239602): re-enable once naming issue is resolved.
-        "no_cuda_on_cpu_tap",
-        "no_oss",  # TODO(b/231239602): re-enable once naming issue is resolved.
-        "no_rocm",
-        "no_windows",
-        "nomac",
-        "notap",  # TODO(b/231239602): re-enable once naming issue is resolved.
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "topk_test",
-    srcs = [
-        "topk_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "trt_engine_op_shape_test",
-    srcs = [
-        "trt_engine_op_shape_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "trt_mode_test",
-    srcs = [
-        "trt_mode_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "unary_test",
-    srcs = [
-        "unary_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "vgg_block_nchw_test",
-    srcs = [
-        "vgg_block_nchw_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "vgg_block_test",
-    srcs = [
-        "vgg_block_test.py",
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
+tensorrt_py_test(name = 'oss_tests', test_names = oss_tests, tags = base_tags)
+tensorrt_py_test(name = 'no_oss_tests',
+                 test_names = no_oss_tests + ["combined_nms_test"],
+                 tags = base_tags + ["no_oss"])
+tensorrt_py_test(name = 'tf_function_test',
+                 tags = base_tags + [
+                    "manual",  # TODO(b/231239602): re-enable once naming issue is resolved.
+                    "notap",   # TODO(b/231239602): re-enable once naming issue is resolved.
+                    "no_oss",  # TODO(b/231239602): re-enable once naming issue is resolved.
+                ]
 )
 
 test_suite(
     name = "tf_trt_integration_test",
-    tests = [
-        "batch_matmul_test",
-        "biasadd_matmul_test",
-        "binary_tensor_weight_broadcast_test",
-        "cast_test",
-        "combined_nms_test",
-        "concatenation_test",
-        "const_broadcast_test",
-        "dynamic_input_shapes_test",
-        "identity_output_test",
-        "int32_test",
-        "lru_cache_test",
-        "memory_alignment_test",
-        "multi_connection_neighbor_engine_test",
-        "neighboring_engine_test",
-        "quantization_test",
-        "rank_two_test",
-        "reshape_transpose_test",
-        "tf_function_test",
-        "topk_test",
-        "trt_engine_op_shape_test",
-        "trt_mode_test",
-        "unary_test",
-        "vgg_block_nchw_test",
-        "vgg_block_test",
-    ],
-)
-
-cuda_py_test(
-    name = "base_test",
-    srcs = [
-        "base_test.py",  # TODO(b/165611343): Need to address the failures for CUDA 11 in OSS build.
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_oss",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
-)
-
-cuda_py_test(
-    name = "conv2d_test",
-    srcs = [
-        "conv2d_test.py",  # b/198501457
-    ],
-    python_version = "PY3",
-    tags = [
-        "no_cuda_on_cpu_tap",
-        "no_oss",
-        "no_rocm",
-        "no_windows",
-        "nomac",
-    ],
-    xla_enable_strict_auto_jit = False,
-    deps = [
-        "//tensorflow/python:client_testlib",
-        "//tensorflow/python:framework_test_lib",
-        "//tensorflow/python/compiler/tensorrt:tf_trt_integration_test_base",
-    ],
+    tests = oss_tests + ["combined_nms_test", "tf_function_test"]
 )
 
 test_suite(
     name = "tf_trt_integration_test_no_oss",
-    tests = [
-        "base_test",
-        "conv2d_test",
-    ],
+    tests = no_oss_tests
 )


### PR DESCRIPTION
Refactoring of the TRT tests for Python removes a lot of duplicate code from`tensorflow/python/compiler/tensorrt/test/BUILD` and makes this file 5.3x times shorter. The new and old versions of that file have 117 and 620 lines, respectively.