### PR TITLE
Switch on Py_SET_TYPE

### DIFF
--- a/tensorflow/python/lib/core/bfloat16.cc
+++ b/tensorflow/python/lib/core/bfloat16.cc
@@ -1642,7 +1642,11 @@ bool RegisterNumpyDtype(PyObject* numpy) {
   arr_funcs.argmax = NPyCustomFloat_ArgMaxFunc<T>;
   arr_funcs.argmin = NPyCustomFloat_ArgMinFunc<T>;
 
+#if PY_VERSION_HEX >= 0x030900A4
+  Py_SET_TYPE(&NPyBfloat16_Descr, &PyArrayDescr_Type);
+#else
   Py_TYPE(&CustomFloatTypeDescriptor<T>::npy_descr) = &PyArrayDescr_Type;
+#endif
   TypeDescriptor<T>::npy_type =
       PyArray_RegisterDataType(&CustomFloatTypeDescriptor<T>::npy_descr);
   TypeDescriptor<T>::type_ptr = &TypeDescriptor<T>::type;


### PR DESCRIPTION
Since Py_TYPE() is changed to a inline static function, `Py_TYPE(obj) = new_type`
must be replaced with `Py_SET_TYPE(obj, new_type)` (available since Python 3.9)

This fix build with Python 3.11