### PR TITLE
Don't set MLIR_PDLL_TABLEGEN_EXE

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/CMakeLists.txt
@@ -95,7 +95,6 @@ if(MHLO_EXTERNAL_PROJECT_BUILD)
   set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir ) # --src-root
   set(MLIR_INCLUDE_DIR ${MLIR_MAIN_SRC_DIR}/include ) # --includedir
   set(MLIR_GENERATED_INCLUDE_DIR ${LLVM_BINARY_DIR}/tools/mlir/include)
-  set(MLIR_PDLL_TABLEGEN_EXE $<TARGET_FILE:mlir-pdll>)
   include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
   include_directories(SYSTEM ${MLIR_GENERATED_INCLUDE_DIR})
   include_directories(SYSTEM ${MLIR_TABLEGEN_OUTPUT_DIR})


### PR DESCRIPTION
With llvm/llvm-project@91b6f76 landed, external projects no longer need
to set `MLIR_PDLL_TABLEGEN_EXE`. The variable is now set as a cache
variable in MLIR upstream. Setting it in an external project breaks
cross-compilation.

This patch is similar to tensorflow/mlir-hlo@77bd8ec.