### PR TITLE
Link tensorflow.dll to kernels_experimental on Windows

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -1190,7 +1190,10 @@ tf_cc_shared_object(
         "//tensorflow/c/eager:c_api_experimental",
         "//tensorflow/core:distributed_tensorflow_dependencies",
         "//tensorflow/core:tensorflow",
-    ],
+    ] + select({
+        "//tensorflow:windows": ["//tensorflow/c:kernels_experimental"],
+        "//conditions:default": [],
+    }),
 )
 
 tf_cc_shared_library(


### PR DESCRIPTION
Windows doesn't have an equivalent to `libtensorflow_framework.so` as part of its C API library, so it needs to include everything as a part of `tensorflow.dll`. Linking `kernels_experimental` to `tensorflow.dll` will allow pluggable devices to be used with the TensorFlow C API on Windows.