### PR TITLE
int32 is not working

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -5382,7 +5382,7 @@ def ceil(x, name=None):
 
   Args:
     x: A `tf.Tensor`. Must be one of the following types: `bfloat16`, `half`,
-      `float32`, `float64`. `int32`
+      `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:


### PR DESCRIPTION
The dtype section in the documentation says `int32` is supported  `tf.math.ceil` but it is `failing`. Kindly find the [gist](https://colab.research.google.com/gist/tilakrayal/81abf656028290a58a536dd238d8728d/untitled488.ipynb). Fixes #57123