### PR TITLE
Fix LLVM target detection when cross-compiling.

### DIFF
--- a/third_party/llvm/toolchains.patch
+++ b/third_party/llvm/toolchains.patch
@@ -1,18 +1,8 @@
-From 7b4ce5b36f6fc0e35c3614861d394b9f48d950a4 Mon Sep 17 00:00:00 2001
-From: Dan F-M <foreman.mackey@gmail.com>
-Date: Wed, 27 Oct 2021 21:44:40 -0400
-Subject: [PATCH] Adding macos darwin config
-
----
- utils/bazel/llvm-project-overlay/llvm/BUILD.bazel | 8 ++++++++
- utils/bazel/llvm-project-overlay/llvm/config.bzl  | 4 ++--
- 2 files changed, 10 insertions(+), 2 deletions(-)
-
 diff --git a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
-index 3e8bbe8a1cc1..8883b16b7350 100644
+index 72558360228a..76fe5e5d939e 100644
 --- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
 +++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
-@@ -16,6 +16,14 @@ package(
+@@ -16,6 +16,29 @@ package(
  
  exports_files(["LICENSE.TXT"])
  
@@ -24,23 +14,42 @@ index 3e8bbe8a1cc1..8883b16b7350 100644
 +    },
 +)
 +
++config_setting(
++    name = "linux_aarch64",
++    values = {"cpu": "aarch64"},
++)
++
++config_setting(
++    name = "linux_ppc64le",
++    values = {"cpu": "ppc"},
++)
++
++config_setting(
++    name = "linux_s390x",
++    values = {"cpu": "s390x"},
++)
++
  # It may be tempting to add compiler flags here, but that should be avoided.
  # The necessary warnings and other compile flags should be provided by the
  # toolchain or the `.bazelrc` file. This is just a workaround until we have a
 diff --git a/utils/bazel/llvm-project-overlay/llvm/config.bzl b/utils/bazel/llvm-project-overlay/llvm/config.bzl
-index 5beb3cc7c410..b22f7c5660dd 100644
+index 5beb3cc7c410..698476e74e00 100644
 --- a/utils/bazel/llvm-project-overlay/llvm/config.bzl
 +++ b/utils/bazel/llvm-project-overlay/llvm/config.bzl
-@@ -82,8 +82,8 @@ os_defines = select({
+@@ -82,11 +82,11 @@ os_defines = select({
  # TODO: We should split out host vs. target here.
  llvm_config_defines = os_defines + select({
      "@bazel_tools//src/conditions:windows": native_arch_defines("X86", "x86_64-pc-win32"),
 -    "@bazel_tools//src/conditions:darwin_arm64": native_arch_defines("AArch64", "arm64-apple-darwin"),
 -    "@bazel_tools//src/conditions:darwin_x86_64": native_arch_defines("X86", "x86_64-unknown-darwin"),
+-    "@bazel_tools//src/conditions:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
+-    "@bazel_tools//src/conditions:linux_ppc64le": native_arch_defines("PowerPC", "powerpc64le-unknown-linux-gnu"),
+-    "@bazel_tools//src/conditions:linux_s390x": native_arch_defines("SystemZ", "systemz-unknown-linux_gnu"),
 +    "//llvm:macos_arm64": native_arch_defines("AArch64", "arm64-apple-darwin"),
 +    "@bazel_tools//src/conditions:darwin": native_arch_defines("X86", "x86_64-unknown-darwin"),
-     "@bazel_tools//src/conditions:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
-     "@bazel_tools//src/conditions:linux_ppc64le": native_arch_defines("PowerPC", "powerpc64le-unknown-linux-gnu"),
-     "@bazel_tools//src/conditions:linux_s390x": native_arch_defines("SystemZ", "systemz-unknown-linux_gnu"),
--- 
-2.30.1 (Apple Git-130)
++    "//llvm:linux_aarch64": native_arch_defines("AArch64", "aarch64-unknown-linux-gnu"),
++    "//llvm:linux_ppc64le": native_arch_defines("PowerPC", "powerpc64le-unknown-linux-gnu"),
++    "//llvm:linux_s390x": native_arch_defines("SystemZ", "systemz-unknown-linux_gnu"),
+     "//conditions:default": native_arch_defines("X86", "x86_64-unknown-linux-gnu"),
+ }) + [
+     # These shouldn't be needed by the C++11 standard, but are for some

--- a/third_party/llvm/workspace.bzl
+++ b/third_party/llvm/workspace.bzl
@@ -19,7 +19,7 @@ def repo(name):
         patch_file = [
             "//third_party/llvm:infer_type.patch",  # TODO(b/231285230): remove once resolved
             "//third_party/llvm:build.patch",
-            "//third_party/llvm:macos_build_fix.patch",
+            "//third_party/llvm:toolchains.patch",
         ],
         link_files = {"//third_party/llvm:run_lit.sh": "mlir/run_lit.sh"},
     )


### PR DESCRIPTION
Conditions like @bazel_tools//src/conditions:linux_aarch64 do not
appear to be triggered correctly when cross-compiling on Linux. I'm
guessing this is because TensorFlow does not yet use Bazel platforms and
instead uses the older --cpu and --crosstool_top features.

This means that we fall through to the default condition and end up
building an x86-targeting LLVM even though we intended to target, say,
aarch64. The symptom this causes is errors like:
'neoverse-n1' is not a recognized processor for this target (ignoring
processor)
'+neon' is not a recognized feature for this target (ignoring feature)
'+fp-armv8' is not a recognized feature for this target (ignoring
feature)
'+crypto' is not a recognized feature for this target (ignoring feature)
'+lse' is not a recognized feature for this target (ignoring feature)
'+crc' is not a recognized feature for this target (ignoring feature)
from XLA:CPU compilation.

Take the same approach that has previously been used for Darwin ARM64
builds and add a new config_setting() for LLVM architecture detection
that mirrors the definitions in //tensorflow/BUILD.

Change tested both under x86->aarch64 cross compilation and aarch64
self-hosted compilation.