### PR TITLE
Print a useful warning if we can't find a directory for temporary files.

### DIFF
--- a/tensorflow/tsl/platform/default/env.cc
+++ b/tensorflow/tsl/platform/default/env.cc
@@ -271,11 +271,11 @@ void PosixEnv::GetLocalTempDirectories(std::vector<string>* list) {
     getenv("TMP"),
 
 #if defined(__ANDROID__)
-    "/data/local/tmp",
+    "/data/local/tmp/",
 #endif
 
     // If all else fails
-    "/tmp",
+    "/tmp/",
   };
 
   std::vector<std::string> paths;  // Only in case of errors.

--- a/tensorflow/tsl/platform/default/env.cc
+++ b/tensorflow/tsl/platform/default/env.cc
@@ -278,13 +278,10 @@ void PosixEnv::GetLocalTempDirectories(std::vector<string>* list) {
     "/tmp",
   };
 
-  std::string paths; // Only in case of errors.
+  std::vector<std::string> paths;  // Only in case of errors.
   for (const char* d : candidates) {
     if (!d || d[0] == '\0') continue;  // Empty env var
-    if (!paths.empty()) {
-      paths += ", ";
-    }
-    paths += std::string(d);
+    paths.emplace_back(d);
     // Make sure we don't surprise anyone who's expecting a '/'
     string dstr = d;
     if (dstr[dstr.size() - 1] != '/') {
@@ -301,7 +298,7 @@ void PosixEnv::GetLocalTempDirectories(std::vector<string>* list) {
   }
   LOG(WARNING) << "We are not able to find a directory for temporary files.\n"
                << "Verify the directory access and available space under: "
-               << paths << ". "
+               << absl::StrJoin(paths, ",") << ". "
                << "You can also provide a directory for temporary files with"
                << " the environment variable TMP or TMPDIR. "
                << "Example under bash: `export TMP=/my_new_temp_directory;`";

--- a/tensorflow/tsl/platform/default/env.cc
+++ b/tensorflow/tsl/platform/default/env.cc
@@ -278,9 +278,13 @@ void PosixEnv::GetLocalTempDirectories(std::vector<string>* list) {
     "/tmp",
   };
 
+  std::string paths; // Only in case of errors.
   for (const char* d : candidates) {
     if (!d || d[0] == '\0') continue;  // Empty env var
-
+    if (!paths.empty()) {
+      paths += ", ";
+    }
+    paths += std::string(d);
     // Make sure we don't surprise anyone who's expecting a '/'
     string dstr = d;
     if (dstr[dstr.size() - 1] != '/') {
@@ -295,6 +299,12 @@ void PosixEnv::GetLocalTempDirectories(std::vector<string>* list) {
       return;
     }
   }
+  LOG(WARNING) << "We are not able to find a directory for temporary files.\n"
+               << "Verify the directory access and available space under: "
+               << paths << ". "
+               << "You can also provide a directory for temporary files with"
+               << " the environment variable TMP or TMPDIR. "
+               << "Example under bash: `export TMP=/my_new_temp_directory;`";
 }
 
 int setenv(const char* name, const char* value, int overwrite) {


### PR DESCRIPTION
This should help cases like: https://github.com/google/jax/issues/11190