### PR TITLE
Remove `tf_copts` that were added by XLA ACL changes

### DIFF
--- a/tensorflow/compiler/xla/BUILD
+++ b/tensorflow/compiler/xla/BUILD
@@ -3,7 +3,7 @@ load("//tensorflow:tensorflow.bzl", "filegroup")
 # buildifier: disable=same-origin-load
 load("//tensorflow:tensorflow.bzl", "get_compatible_with_portable")
 load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
-load("//tensorflow:tensorflow.bzl", "cc_header_only_library", "tf_cc_test", "tf_copts")
+load("//tensorflow:tensorflow.bzl", "cc_header_only_library", "tf_cc_test")
 load(
     "//tensorflow/core/platform:build_config.bzl",
     "tf_proto_library",

--- a/tensorflow/compiler/xla/BUILD
+++ b/tensorflow/compiler/xla/BUILD
@@ -964,7 +964,7 @@ cc_library(
         "debug_options_parsers.h",
     ],
     hdrs = ["debug_options_flags.h"],
-    copts = if_enable_acl(["-DXLA_CPU_USE_ACL=1", "-fexceptions"]),
+    copts = if_enable_acl(["-DXLA_CPU_USE_ACL=1"]),
     visibility = [":friends"],
     deps =
         [

--- a/tensorflow/compiler/xla/BUILD
+++ b/tensorflow/compiler/xla/BUILD
@@ -8,6 +8,7 @@ load(
     "//tensorflow/core/platform:build_config.bzl",
     "tf_proto_library",
 )
+load("//third_party/compute_library:build_defs.bzl", "if_enable_acl")
 
 package(
     default_visibility = ["//tensorflow:internal"],
@@ -963,7 +964,7 @@ cc_library(
         "debug_options_parsers.h",
     ],
     hdrs = ["debug_options_flags.h"],
-    copts = tf_copts(),
+    copts = if_enable_acl(["-DXLA_CPU_USE_ACL=1", "-fexceptions"]),
     visibility = [":friends"],
     deps =
         [

--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -11,6 +11,7 @@ load("//tensorflow:tensorflow.bzl", "tf_cc_binary", "tf_cc_test", "tf_copts", "t
 load(
     "//third_party/compute_library:build_defs.bzl",
     "acl_deps",
+    "if_enable_acl",
 )
 
 # buildifier: disable=same-origin-load
@@ -350,7 +351,7 @@ cc_library(
         "windows_compatibility.h",
     ],
     hdrs = ["simple_orc_jit.h"],
-    copts = tf_copts(),
+    copts = if_enable_acl(["-DXLA_CPU_USE_ACL=1", "-fexceptions"]),
     deps = [
         ":compiler_functor",
         ":cpu_runtime",
@@ -602,7 +603,7 @@ cc_library(
     hdrs = [
         "dot_op_emitter.h",
     ],
-    copts = tf_copts(),
+    copts = if_enable_acl(["-DXLA_CPU_USE_ACL=1", "-fexceptions"]),
     deps = [
         ":cpu_options",
         ":cpu_runtime",

--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -351,7 +351,7 @@ cc_library(
         "windows_compatibility.h",
     ],
     hdrs = ["simple_orc_jit.h"],
-    copts = if_enable_acl(["-DXLA_CPU_USE_ACL=1", "-fexceptions"]),
+    copts = if_enable_acl(["-DXLA_CPU_USE_ACL=1"]),
     deps = [
         ":compiler_functor",
         ":cpu_runtime",
@@ -603,7 +603,6 @@ cc_library(
     hdrs = [
         "dot_op_emitter.h",
     ],
-    copts = if_enable_acl(["-DXLA_CPU_USE_ACL=1", "-fexceptions"]),
     deps = [
         ":cpu_options",
         ":cpu_runtime",


### PR DESCRIPTION
Replace `tf_copts` in `simple_orc_jit` and `dot_op_emitter` with only necessary flags for ACL.

`tf_copts` was recently added to the two targets in https://github.com/tensorflow/tensorflow/pull/56715. Its addition broke the x86 oneDNN OpenMP build so we are reverting back to just add aarch64 ACL copts directly to these targets for the time being.

Credit: @snadampal for finding the flags and testing on aarch64
cc: @TensorFlow-MKL, @agramesh1 

Edited to add: Also replace `tf_copts` in `debug_options_flags`. Credit: @agramesh1 