### PR TITLE
[INTEL oneDNN] Disable MKL ML related functionality in xla/service/cpu

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/cpu_runtime_test.cc
+++ b/tensorflow/compiler/xla/service/cpu/cpu_runtime_test.cc
@@ -20,7 +20,6 @@ limitations under the License.
 #include <tuple>
 
 #include "absl/strings/str_format.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/compiler/xla/array2d.h"
 #include "tensorflow/compiler/xla/client/local_client.h"
 #include "tensorflow/compiler/xla/service/cpu/runtime_custom_call_status.h"
@@ -33,6 +32,7 @@ limitations under the License.
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/test.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace xla {
 namespace {
@@ -170,7 +170,8 @@ INSTANTIATE_TEST_SUITE_P(EigenMatMulTestInstantiaion, EigenMatMulTest,
                                             ::testing::Bool()),
                          EigenMatMulTest::Name);
 
-#ifdef ENABLE_MKL
+// TODO(intel-tf): remove this workaround once MKL ML calls are cleaned.
+#if defined(ENABLE_MKL) && defined(DNNL_AARCH64_USE_ACL)
 class MKLMatMulTest : public CpuRuntimeTest,
                       public ::testing::WithParamInterface<MatMulTestParam> {
  public:

--- a/tensorflow/compiler/xla/service/cpu/dot_op_emitter.cc
+++ b/tensorflow/compiler/xla/service/cpu/dot_op_emitter.cc
@@ -802,6 +802,10 @@ Status DotOpEmitter::EmitCallToRuntime() {
 
   bool multi_threaded = ShouldUseMultiThreadedEigen(hlo_module_config_);
   bool use_mkl_dnn = hlo_module_config_.debug_options().xla_cpu_use_mkl_dnn();
+  // Currently MKL ML cblas_* functions are called, but they
+  // are not supported . Thus we temporarily disable it.
+  // TODO(intel-tf): remove this restriction by using oneDNN APIs.
+  use_mkl_dnn = false;
   bool use_acl = hlo_module_config_.debug_options().xla_cpu_use_acl();
   PrimitiveType type = target_array_.GetShape().element_type();
   llvm::Function* function = b_->GetInsertBlock()->getParent();

--- a/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
@@ -997,6 +997,10 @@ Status IrEmitter::HandleConvolution(HloInstruction* convolution) {
           hlo_module_config_.debug_options().xla_cpu_use_mkl_dnn() &&
           convolution->feature_group_count() == 1;
       bool use_acl = hlo_module_config_.debug_options().xla_cpu_use_acl();
+      // Currently MKL ML cblas_* functions are called, but they
+      // are not supported . Thus we temporarily disable it.
+      // TODO(intel-tf): remove this restriction by using oneDNN APIs.
+      use_mkl_dnn = false;
 
       auto valid_num_dims = [](absl::Span<const int64_t> xs) {
         return xs.size() >= 2 && xs.size() <= 3;

--- a/tensorflow/compiler/xla/service/cpu/runtime_matmul_mkl.cc
+++ b/tensorflow/compiler/xla/service/cpu/runtime_matmul_mkl.cc
@@ -13,7 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(ENABLE_MKL) && !defined(INTEL_MKL_DNN_ONLY)
+// Currently MKL ML cblas_* functions are called, but they
+// are not supported . Thus we temporarily disable it.
+// TODO(intel-tf): remove this restriction by using oneDNN APIs.
+#if defined(ENABLE_MKL) && !defined(INTEL_MKL_DNN_ONLY) && \
+    defined(DNNL_AARCH64_USE_ACL)
 #include "tensorflow/compiler/xla/service/cpu/runtime_matmul_mkl.h"
 
 #include "third_party/intel_mkl_ml/include/mkl_cblas.h"

--- a/tensorflow/compiler/xla/service/cpu/runtime_matmul_mkl.h
+++ b/tensorflow/compiler/xla/service/cpu/runtime_matmul_mkl.h
@@ -18,7 +18,12 @@ limitations under the License.
 
 #include <iostream>
 
-#ifdef ENABLE_MKL
+// Currently MKL ML cblas_* functions are called, but they
+// are not supported . Thus we temporarily disable it.
+// TODO(intel-tf): remove this restriction by using oneDNN APIs.
+#if defined(ENABLE_MKL) && !defined(INTEL_MKL_DNN_ONLY) && \
+    defined(DNNL_AARCH64_USE_ACL)
+
 #include "third_party/intel_mkl_ml/include/mkl_cblas.h"
 
 extern void __xla_cpu_runtime_MKLMatMulF32(


### PR DESCRIPTION
This is an alternative workaround for this PR

     https://github.com/tensorflow/tensorflow/pull/57186

(by Penporn et al.) by disabling MKL ML related source code which causes build issue in master branch and TF 2.10 (with
--config=mkl option)

If PR  https://github.com/tensorflow/tensorflow/pull/57186 is merged to TF 2.10, there is no 
need to merged this one.
     