### PR TITLE
[TF-TRT]: Fix tile converter for dynamic shape mode

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/ops/tile.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/tile.cc
@@ -128,18 +128,18 @@ class ConvertTile : public OpConverterBase<ConvertTile> {
     const auto dims = tensor.GetTrtDims();
     const auto nb_dims = dims.nbDims;
 
-    nvinfer1::Dims size{nb_dims, {1}};
-    bool dynamic_flag = replics.is_tensor();
+    nvinfer1::Dims output_size{nb_dims, {1}};
+    bool dynamic_flag = replics.is_tensor() || !HasStaticShape(dims);
+
     if (!dynamic_flag) {
-      const auto dim_adj =
-          params.use_implicit_batch && tensor.is_tensor() ? 1 : 0;
-      const auto *pSize = dims.d;
-      dynamic_flag = std::any_of(pSize + 1 - dim_adj, pSize + nb_dims,
-                                 [](int i) { return i < 0; });
-      const int *pMultiplies = replics.weights().GetPointer<int>() + dim_adj;
-      size.d[0] = pMultiplies[0];
-      for (int i = 1 - dim_adj; i < nb_dims; i++)
-        size.d[i] = pMultiplies[i] * pSize[i];
+      // If input0 is a tensor, and we're in implicit batch mode, then we need
+      // dim_offset.
+      const auto dim_offset =
+          params.use_implicit_batch && tensor.is_tensor()? 1 : 0;
+      const auto *input_size = dims.d;
+      const int *pReplics = replics.weights().GetPointer<int>() + dim_offset;
+      for (int i = 0; i < nb_dims; i++)
+        output_size.d[i] = pReplics[i] * input_size[i];
     }
 
     StatusOr<TRTNetworkBuilder> builder;
@@ -185,7 +185,8 @@ class ConvertTile : public OpConverterBase<ConvertTile> {
     nvinfer1::Dims start{nb_dims, {}};
     DimsAdapter stride(std::vector<int>(nb_dims, 1));
     auto layer =
-        network->addSlice(input_trt_tensor, start, size, stride.AsTrtDims());
+        network->addSlice(input_trt_tensor,
+                          start, output_size, stride.AsTrtDims());
     layer->setMode(nvinfer1::SliceMode::kWRAP);
     if (target_shape) layer->setInput(2, *target_shape);
 


### PR DESCRIPTION
In dynamic shape mode, when all input tensors to the Tile op are constants, the batch dimension was not being propagated correctly. Fix this.