### PR TITLE
[ROCm] For RoundNearestEven op use LLVM rint intrinsic instead of nearbyint …

### DIFF
--- a/tensorflow/compiler/xla/service/elemental_ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/elemental_ir_emitter.cc
@@ -523,7 +523,12 @@ StatusOr<llvm::Value*> ElementalIrEmitter::EmitFloatUnaryOp(
     // as TF and JAX default to FE_TONEAREST. Call llvm::Intrinsic::roundeven
     // instead once GPU emitter supports lowering LLVM.
     case HloOpcode::kRoundNearestEven:
-      return llvm_ir::EmitCallToIntrinsic(llvm::Intrinsic::nearbyint,
+      return llvm_ir::EmitCallToIntrinsic(
+#if TENSORFLOW_USE_ROCM
+                                          llvm::Intrinsic::rint,
+#else
+                                          llvm::Intrinsic::nearbyint,
+#endif
                                           {operand_value},
                                           {operand_value->getType()}, b_);
     case HloOpcode::kSign: {


### PR DESCRIPTION
…because nearbyint is not currently supported by ROCm/HIP for fp16.

/cc @cheshire 