### PR TITLE
[TF:TRT] Refactor IBuilder holder in convert_node_test.

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -818,7 +818,6 @@ tf_cuda_cc_test(
         "//tensorflow/core/kernels:identity_op",
         "//tensorflow/core/kernels:resource_variable_ops",
         "//tensorflow/core:test",
-        "//tensorflow/core:test_main",
         "//tensorflow/core/platform:status_matchers",
     ] + if_tensorrt([
         ":tensorrt_lib",

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -155,27 +155,6 @@ void ValidateWeights(const TRT_ShapedWeights& weights,
   }
 }
 
-// TRT >= 8.2 optimizes memory management in the builder. When all builders
-// are destroyed, it unloads many resources. This test fixture will create and
-// destroy hundreds of builders when run sequentially for parameterized
-// tests. We can hold open an IBuilder in order to prevent TRT from unloading
-// shared resources between engine builds when using TRT shared library. This
-// greatly speeds up unit tests and is safe to do.
-void PreventUnloadBuilderResources() {
-#if IS_TRT_VERSION_GE(8, 2, 0, 0)
-  static thread_local absl::once_flag once;
-  static TrtUniquePtrType<nvinfer1::IBuilder> hold_builder = nullptr;
-  absl::call_once(
-      once,
-      [](TrtUniquePtrType<nvinfer1::IBuilder>& builder) {
-        if (!builder) {
-          builder.reset(nvinfer1::createInferBuilder(*Logger::GetLogger()));
-        }
-      },
-      hold_builder);
-#endif
-}
-
 TEST(TRT_ShapedWeights_Test, Basic) {
   // Test constructor with no arguments.
   {
@@ -307,7 +286,7 @@ TEST(TRT_TensorOrWeights_Test, Basic) {
 
 class ValidatorTest : public ::testing::Test {
  public:
-  ValidatorTest() { PreventUnloadBuilderResources(); }
+  ValidatorTest() { }
   Status ConvertToTensorOrWeights(const Scope& scope, const Node* node,
                                   int output_port,
                                   TRT_TensorOrWeights* tensor_or_weights) {
@@ -513,7 +492,6 @@ TEST(TrtNodeValidator, IsTensorRTCandidate) {
 class ConverterTest : public ::testing::Test {
  public:
   ConverterTest() {
-    PreventUnloadBuilderResources();
     Reset();
   }
 
@@ -1129,7 +1107,6 @@ class OpConverterTest : public ::testing::Test {
   OpConverterTest()
       : tensor_buffer_allocator_(new GpuManagedAllocator()),
         scope_(Scope::NewRootScope()) {
-    PreventUnloadBuilderResources();
     QCHECK_EQ(0, cudaStreamCreate(&stream_));
     Reset();
   }
@@ -9676,5 +9653,21 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertSelectV2) {
 }  // namespace convert
 }  // namespace tensorrt
 }  // namespace tensorflow
+
+int main(int argc, char **argv) {
+// TRT >= 8.2 optimizes memory management in the builder. When all builders
+// are destroyed, it unloads many resources. This test fixture will create and
+// destroy hundreds of builders when run sequentially for parameterized
+// tests. We can hold open an IBuilder in order to prevent TRT from unloading
+// shared resources between engine builds when using TRT shared library. This
+// greatly speeds up unit tests and is safe to do.
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
+  // This builder holds a copy of cask::KernelLibrary, which is shared with other builders.
+  // Other builders used during testing won't trigger costly loading of cask::KernelLibrary.
+  std::unique_ptr<nvinfer1::IBuilder> const holder{nvinfer1::createInferBuilder(*tensorflow::tensorrt::Logger::GetLogger())};
+#endif
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
 
 #endif  // GOOGLE_CUDA && GOOGLE_TENSORRT


### PR DESCRIPTION
Create holder nvinfer1::IBuilder in a custom main funciton.
Remove //tensorflow/core:test_main from convert_nodes_test.

TRT allows multiple builders to share the same cache, having a placeholder builder can reduce the time of cache creation and destroy and thus, speed up the tests
The original code in tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc defines the holder nvinfer1::IBuilder to be static, which caused the destructor to be called at an unexpected time (not by the main function). We now create the holder in a custom main function. 