### PR TITLE
Fix empty inputs for Upper/LowerBound. - r2.7 Cherry-Pick

### DIFF
--- a/tensorflow/core/kernels/searchsorted_op.cc
+++ b/tensorflow/core/kernels/searchsorted_op.cc
@@ -22,7 +22,10 @@ limitations under the License.
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/kernels/fill_functor.h"
+#include "tensorflow/core/lib/core/bits.h"
 #include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/threadpool.h"
 #include "tensorflow/core/platform/types.h"
 
 namespace tensorflow {
@@ -115,6 +118,14 @@ class UpperBoundOp : public OpKernel {
     auto output = output_t->template flat<OutType>();
     const auto sorted_inputs = sorted_inputs_t.template flat<T>();
     const auto values = values_t.template flat<T>();
+
+    // For empty inputs, all values will be placed at the zeroth position.
+    if (sorted_inputs.size() == 0) {
+      functor::SetZeroFunctor<Device, OutType> set_zero;
+      set_zero(ctx->eigen_device<Device>(), output);
+      return;
+    }
+
     OP_REQUIRES_OK(
         ctx, functor::UpperBoundFunctor<Device, T, OutType>::Compute(
                  ctx, sorted_inputs, values, sorted_inputs_t.dim_size(0),
@@ -160,6 +171,14 @@ class LowerBoundOp : public OpKernel {
     auto output = output_t->template flat<OutType>();
     const auto sorted_inputs = sorted_inputs_t.template flat<T>();
     const auto values = values_t.template flat<T>();
+
+    // For empty inputs, all values will be placed at the zeroth position.
+    if (sorted_inputs.size() == 0) {
+      functor::SetZeroFunctor<Device, OutType> set_zero;
+      set_zero(ctx->eigen_device<Device>(), output);
+      return;
+    }
+
     OP_REQUIRES_OK(
         ctx, functor::LowerBoundFunctor<Device, T, OutType>::Compute(
                  ctx, sorted_inputs, values, sorted_inputs_t.dim_size(0),

--- a/tensorflow/python/kernel_tests/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops_test.py
@@ -1959,6 +1959,37 @@ class SortedSearchTest(test_util.TensorFlowTestCase):
                 side=side,
                 out_type=dtype), array_ops.zeros([2, 0], dtype))
 
+  def testZeroInputSize(self):
+    dtype = dtypes.int32
+    for side in ("left", "right"):
+      with self.subTest(side=side):
+        self.assertAllEqual(
+            array_ops.searchsorted(
+                array_ops.ones([2, 0]),
+                array_ops.ones([2, 3]),
+                side=side,
+                out_type=dtype), array_ops.zeros([2, 3], dtype))
+
+  def testInt64(self):
+
+    @def_function.function
+    def g():
+      x = random_ops.random_normal(shape=[int(1e10)])
+      y = array_ops.ones(shape=[int(1e10)])
+      return array_ops.searchsorted(x, y, out_type=dtypes.int64)
+
+    _ = g.get_concrete_function()
+
+  def testInt64UnspecifiedOutType(self):
+
+    @def_function.function
+    def g():
+      x = random_ops.random_normal(shape=[int(1e10)])
+      y = array_ops.ones(shape=[int(1e10)])
+      return array_ops.searchsorted(x, y)
+
+    _ = g.get_concrete_function()
+
 
 class BatchGatherNdTest(test_util.TensorFlowTestCase):
 


### PR DESCRIPTION
Merge Conflict Resolution - cl/460971165 - For upper/lower-bound searches via `tf.searchsorted`, if the sorted input is empty,
the previous code resulted in a `nullptr` dereference.  For emtpy inputs, any
sorted search should return a value of 0, meaning that a value would be inserted
into the first slot of the array.