### PR TITLE
Fixes model export issue in #57386, #56970

### DIFF
--- a/tensorflow/lite/g3doc/models/modify/model_maker/object_detection.ipynb
+++ b/tensorflow/lite/g3doc/models/modify/model_maker/object_detection.ipynb
@@ -123,7 +123,8 @@
         "!pip install -q --use-deprecated=legacy-resolver tflite-model-maker\n",
         "!pip install -q pycocotools\n",
         "!pip install -q opencv-python-headless==4.1.2.30\n",
-        "!pip uninstall -y tensorflow \u0026\u0026 pip install -q tensorflow==2.8.0"
+        "!pip uninstall -y tensorflow \u0026\u0026 pip install -q tensorflow==2.8.0\n",
+        "!pip install -U flatbuffers"
       ]
     },
     {


### PR DESCRIPTION
Fixes model export issue by upgrading flatbuffers to 2.0 from 1.12 (default version in Colab)
Attached resolved [gist](https://colab.sandbox.google.com/gist/mohantym/20aef7edda23af1fdb655350c1d96de6/model-maker-object-detection-tutorial.ipynb#scrollTo=qhl8lqVamEty) as proof for reference.