### PR TITLE
[XLA:GPU] Replace LOG(ERROR) with VLOG in cublas_pad_for_gemms

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/cublas_pad_for_gemms.cc
+++ b/tensorflow/compiler/xla/service/gpu/cublas_pad_for_gemms.cc
@@ -126,8 +126,10 @@ bool CheckCanonical(HloDotInstruction* dot) {
           dot->operand(0)->shape().rank() ||
       dimension_numbers.rhs_batch_dimensions_size() + 2 !=
           dot->operand(1)->shape().rank()) {
-    LOG(ERROR) << "Dot is not canonical: Expected all dimensions but 2 to be "
-                  "batch_dimensions.";
+    VLOG(2)
+        << dot->ToString()
+        << " is not canonical: Expected all dimensions but 2 to be "
+           "batch_dimensions. Hence, this dot is not a candidate for padding.";
     return false;
   }
 
@@ -138,8 +140,11 @@ bool CheckCanonical(HloDotInstruction* dot) {
                      canonical_batch_dims) ||
       !absl::c_equal(dimension_numbers.rhs_batch_dimensions(),
                      canonical_batch_dims)) {
-    LOG(ERROR) << "Dot is not canonical: Expected batch dimensions to be all "
-                  "dimensions except for the last 2 ones.";
+    VLOG(2)
+        dot->ToString()
+        << " is not canonical: Expected batch dimensions to be all "
+           "dimensions except for the last 2 ones. Hence, this dot is not a "
+           "candidate for padding.";
     return false;
   }
 

--- a/tensorflow/compiler/xla/service/gpu/cublas_pad_for_gemms.cc
+++ b/tensorflow/compiler/xla/service/gpu/cublas_pad_for_gemms.cc
@@ -141,7 +141,7 @@ bool CheckCanonical(HloDotInstruction* dot) {
       !absl::c_equal(dimension_numbers.rhs_batch_dimensions(),
                      canonical_batch_dims)) {
     VLOG(2)
-        dot->ToString()
+        << dot->ToString()
         << " is not canonical: Expected batch dimensions to be all "
            "dimensions except for the last 2 ones. Hence, this dot is not a "
            "candidate for padding.";


### PR DESCRIPTION
The error here is misleading to the user. Incase the gemm is not cannonical, it would not be a candidate for padding but that would not be an error. cuBLAS can still handle the non-canonical gemms.
Hence, changing this `LOG(ERROR)` to a `VLOG`.