### PR TITLE
r2.10 cherry-pick: Move TF-oneDNN RFC link to the x86 bullet

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -66,7 +66,7 @@
 
 *   CPU performance optimizations:
     *   **x86 CPUs**: [oneDNN](https://github.com/tensorflow/community/blob/master/rfcs/20210930-enable-onednn-ops.md) bfloat16 auto-mixed precision grappler graph optimization pass has been renamed from `auto_mixed_precision_mkl` to `auto_mixed_precision_onednn_bfloat16`. See example usage [here](https://www.intel.com/content/www/us/en/developer/articles/guide/getting-started-with-automixedprecisionmkl.html).  
-    *   **aarch64 CPUs:** Experimental Arm Compute Library (ACL) CPU performance optimizations through oneDNN are available in the default Linux aarch64 package (`pip install tensorflow`).
+    *   **aarch64 CPUs:** Experimental performance optimizations from Compute Library for the Arm® Architecture (ACL) are available through oneDNN in the default Linux aarch64 package (`pip install tensorflow`).
         *   The optimizations are disabled by default. 
         *   Set the environment variable `TF_ENABLE_ONEDNN_OPTS=1` to enable the optimizations. Setting the variable to 0 or unsetting it will disable the optimizations.
         *   These optimizations can yield slightly different numerical results from when they are off due to floating-point round-off errors from different computation approaches and orders.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -63,10 +63,11 @@
 
 *   XLA:
     *   MWMS is now compilable with XLA.
+    *   [Compute Library for the Arm® Architecture (ACL)](https://github.com/ARM-software/ComputeLibrary) is supported for aarch64 CPU XLA runtime
 
 *   CPU performance optimizations:
     *   **x86 CPUs**: [oneDNN](https://github.com/tensorflow/community/blob/master/rfcs/20210930-enable-onednn-ops.md) bfloat16 auto-mixed precision grappler graph optimization pass has been renamed from `auto_mixed_precision_mkl` to `auto_mixed_precision_onednn_bfloat16`. See example usage [here](https://www.intel.com/content/www/us/en/developer/articles/guide/getting-started-with-automixedprecisionmkl.html).  
-    *   **aarch64 CPUs:** Experimental performance optimizations from Compute Library for the Arm® Architecture (ACL) are available through oneDNN in the default Linux aarch64 package (`pip install tensorflow`).
+    *   **aarch64 CPUs:** Experimental performance optimizations from [Compute Library for the Arm® Architecture (ACL)](https://github.com/ARM-software/ComputeLibrary) are available through oneDNN in the default Linux aarch64 package (`pip install tensorflow`).
         *   The optimizations are disabled by default. 
         *   Set the environment variable `TF_ENABLE_ONEDNN_OPTS=1` to enable the optimizations. Setting the variable to 0 or unsetting it will disable the optimizations.
         *   These optimizations can yield slightly different numerical results from when they are off due to floating-point round-off errors from different computation approaches and orders.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,8 +64,8 @@
 *   XLA:
     *   MWMS is now compilable with XLA.
 
-*   [oneDNN CPU performance optimizations](https://github.com/tensorflow/community/blob/master/rfcs/20210930-enable-onednn-ops.md):
-    *   **x86 CPUs**: oneDNN bfloat16 auto-mixed precision grappler graph optimization pass has been renamed from `auto_mixed_precision_mkl` to `auto_mixed_precision_onednn_bfloat16`. See example usage [here](https://www.intel.com/content/www/us/en/developer/articles/guide/getting-started-with-automixedprecisionmkl.html).  
+*   CPU performance optimizations:
+    *   **x86 CPUs**: [oneDNN](https://github.com/tensorflow/community/blob/master/rfcs/20210930-enable-onednn-ops.md) bfloat16 auto-mixed precision grappler graph optimization pass has been renamed from `auto_mixed_precision_mkl` to `auto_mixed_precision_onednn_bfloat16`. See example usage [here](https://www.intel.com/content/www/us/en/developer/articles/guide/getting-started-with-automixedprecisionmkl.html).  
     *   **aarch64 CPUs:** Experimental Arm Compute Library (ACL) CPU performance optimizations through oneDNN are available in the default Linux aarch64 package (`pip install tensorflow`).
         *   The optimizations are disabled by default. 
         *   Set the environment variable `TF_ENABLE_ONEDNN_OPTS=1` to enable the optimizations. Setting the variable to 0 or unsetting it will disable the optimizations.


### PR DESCRIPTION
Based on feedback from @snadampal.