### PR TITLE
r2.10 cherry-pick: Add missing clean_dep() to dependency

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1366,7 +1366,7 @@ def tf_cc_test(
                 "-lpthread",
                 "-lm",
             ],
-            "//third_party/compute_library:build_with_acl": ["-fopenmp"],
+            clean_dep("//third_party/compute_library:build_with_acl"): ["-fopenmp"],
         }) + linkopts + _rpath_linkopts(name),
         deps = deps + tf_binary_dynamic_kernel_deps(kernels) + if_mkl_ml(
             [


### PR DESCRIPTION
Fix breakages in packages that depends on TensorFlow.

"Without clean_dep, the dependency introduced in https://github.com/tensorflow/tensorflow/pull/57088 breaks libraries depending on Tensorflow (such as Tensorflow Decision Forests)"

PiperOrigin-RevId: 469490042