### PR TITLE
Refactor all op->emitOpError with notifyMatchFailure

### DIFF
--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
@@ -135,7 +135,8 @@ llvm::Optional<Value> convertPackOp(PatternRewriter& rewriter, Operation* op,
 
   // Check for ranked tensor type.
   if (!result_type) {
-    op->emitOpError("PackOp: result type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op,
+        "result type not ranked tensor");
     return llvm::None;
   }
 
@@ -145,13 +146,14 @@ llvm::Optional<Value> convertPackOp(PatternRewriter& rewriter, Operation* op,
   RankedTensorType input_type =
       op->getOperand(0).getType().dyn_cast<RankedTensorType>();
   if (!input_type) {
-    op->emitOpError("PackOp: input type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op,
+        "input type not ranked tensor");
     return llvm::None;
   }
 
   input_type = inputs[0].getType().dyn_cast<RankedTensorType>();
   if (!input_type) {
-    op->emitOpError("Input 0 type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op, "input 0 type not ranked tensor");
     return llvm::None;
   }
   ArrayRef<int64_t> input0_tensor_shape = input_type.getShape();
@@ -160,19 +162,22 @@ llvm::Optional<Value> convertPackOp(PatternRewriter& rewriter, Operation* op,
   for (int i = 1; i < inputs.size(); i++) {
     input_type = inputs[0].getType().dyn_cast<RankedTensorType>();
     if (!input_type) {
-      op->emitOpError(llvm::formatv(
+    (void)rewriter.notifyMatchFailure(op,
+        llvm::formatv(
           "reduce axis {} is not in valid range [-rank(input), rank(input))",
           i));
       return llvm::None;
     }
     ArrayRef<int64_t> next_tensor_shape = input_type.getShape();
     if (next_tensor_shape.size() != input_tensor_rank) {
-      op->emitOpError("PackOp: input tensor rank mismatch.");
+      (void)rewriter.notifyMatchFailure(op,
+          "input tensor rank mismatch");
       return llvm::None;
     }
     for (int d = 0; d < input0_tensor_shape.size(); d++) {
       if (input0_tensor_shape[d] != next_tensor_shape[d]) {
-        op->emitOpError("PackOp: input tensor shape mismatch.");
+        (void)rewriter.notifyMatchFailure(op,
+            "input tensor shape mismatch");
         return llvm::None;
       }
     }
@@ -200,7 +205,8 @@ llvm::Optional<Value> convertPackOp(PatternRewriter& rewriter, Operation* op,
   // where the axis "wraps around".
   if (axis < 0) axis += input_tensor_rank;
   if ((axis < 0) || (axis > (input_tensor_rank + 1))) {
-    op->emitOpError("PackOp: axis out of valid range.");
+    (void)rewriter.notifyMatchFailure(op,
+        "axis out of valid range");
     return llvm::None;
   }
 
@@ -210,12 +216,14 @@ llvm::Optional<Value> convertPackOp(PatternRewriter& rewriter, Operation* op,
   SmallVector<int64_t> output_shape_vals(result_type.getShape().begin(),
                                          result_type.getShape().end());
   if (output_shape_vals.size() != (input_tensor_rank + 1)) {
-    op->emitOpError("PackOp: output tensor rank mismatch.");
+    (void)rewriter.notifyMatchFailure(op,
+        "output tensor rank mismatch");
     return llvm::None;
   }
   // 2.b check output rank 0 is N
   if (output_shape_vals[axis] != inputs.size()) {
-    op->emitOpError("PackOp: output tensor shape mismatch.");
+    (void)rewriter.notifyMatchFailure(op,
+        "output tensor shape mismatch");
     return llvm::None;
   }
   // Most of the cases when PackOp.axis() is within [0, rank(input) - 1].
@@ -322,7 +330,8 @@ llvm::Optional<SmallVector<Value>> convertUnpackOp(PatternRewriter& rewriter,
   // Negative axis allowed as long as it's within [-input_rank, input_rank).
   if (axis < 0) axis += input_rank;
   if ((axis < 0) || (axis > input_rank)) {
-    op->emitOpError("UnpackOp: axis out of valid range.");
+    (void)rewriter.notifyMatchFailure(op,
+        "axis out of valid range");
     return llvm::None;
   }
 
@@ -413,7 +422,8 @@ llvm::Optional<Value> convertSelectOp(PatternRewriter& rewriter, Operation* op,
   RankedTensorType y_type = y_value.getType().dyn_cast<RankedTensorType>();
 
   if (!result_type || !condition_type || !x_type || !y_type) {
-    op->emitOpError("Select: failed ranked tensor type check");
+    (void)rewriter.notifyMatchFailure(op,
+        "failed ranked tensor type check");
     return llvm::None;
   }
 
@@ -451,13 +461,15 @@ llvm::Optional<Value> convertZerosLikeOp(PatternRewriter& rewriter,
                                          Value input) {
   RankedTensorType result_type = result.getType().dyn_cast<RankedTensorType>();
   if (!result_type) {
-    op->emitOpError("Zeroslike: result not ranked tensor type");
+    (void)rewriter.notifyMatchFailure(op,
+        "result not ranked tensor type");
     return llvm::None;
   }
 
   RankedTensorType input_type = input.getType().dyn_cast<RankedTensorType>();
   if (!input_type) {
-    op->emitOpError("Zeroslike: input not ranked tensor type");
+    (void)rewriter.notifyMatchFailure(op,
+        "input not ranked tensor type");
     return llvm::None;
   }
 
@@ -493,9 +505,8 @@ llvm::Optional<Value> convertMultiplyOp(PatternRewriter& rewriter,
 
   if (input_lhs_is_qtype != output_is_qtype ||
       input_rhs_is_qtype != output_is_qtype) {
-    op->emitOpError(
-        "ConvertMultiplyOp: input/output tensor should "
-        "be all quantized or all floating-point");
+    (void)rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
     return llvm::None;
   }
 
@@ -545,14 +556,16 @@ llvm::Optional<Value> convertSquaredDifferenceOp(PatternRewriter& rewriter,
   // This lowering calculates the difference and multiplies.
   ShapedType result_type = result.getType().dyn_cast<ShapedType>();
   if (!result_type) {
-    op->emitOpError("SquaredDifference: result not ranked tensor type");
+    (void)rewriter.notifyMatchFailure(op,
+        "result not ranked tensor type");
     return llvm::None;
   }
 
   ShapedType x_type = x.getType().dyn_cast<ShapedType>();
   ShapedType y_type = y.getType().dyn_cast<ShapedType>();
   if (!x_type || !y_type) {
-    op->emitOpError("SquaredDifference: inputs not ranked tensor type");
+    (void)rewriter.notifyMatchFailure(op,
+        "inputs not ranked tensor type");
     return llvm::None;
   }
 
@@ -570,13 +583,15 @@ llvm::Optional<Value> convertRoundOp(PatternRewriter& rewriter, Operation* op,
   // Implements banker's rounding by calculating floor(input + 0.5).
   ShapedType result_type = result.getType().dyn_cast<ShapedType>();
   if (!result_type) {
-    op->emitOpError("Round: result not shaped tensor type");
+    (void)rewriter.notifyMatchFailure(op,
+        "result not shaped tensor type");
     return llvm::None;
   }
 
   ShapedType input_type = input.getType().dyn_cast<ShapedType>();
   if (!input_type) {
-    op->emitOpError("Round: input not shaped tensor type");
+    (void)rewriter.notifyMatchFailure(op,
+        "input not shaped tensor type");
     return llvm::None;
   }
 
@@ -597,14 +612,16 @@ llvm::Optional<Value> convertConcatV2Op(PatternRewriter& rewriter,
   // Check all inputs are RankedTensorType
   for (auto v : values) {
     if (!v.getType().dyn_cast<RankedTensorType>()) {
-      op->emitOpError("ConcatV2Op: value type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op,
+        "value type not ranked tensor");
       return llvm::None;
     }
   }
 
   // Check output is Ranked tensor type
   if (!result_value.getType().dyn_cast<RankedTensorType>()) {
-    op->emitOpError("ConcatV2Op: output value type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op,
+        "output value type not ranked tensor");
     return llvm::None;
   }
 
@@ -654,7 +671,7 @@ llvm::Optional<Value> convertConcatV2Op(PatternRewriter& rewriter,
 
   if (axis < 0) axis += tensor_rank;
   if ((axis < 0) || (axis > tensor_rank)) {
-    op->emitOpError("ConcatV2Op: axis out of valid range.");
+    (void)rewriter.notifyMatchFailure(op, "axis out of valid range");
     return llvm::None;
   }
 
@@ -735,19 +752,19 @@ llvm::Optional<Value> convertSpaceToBatchNDOp(PatternRewriter& rewriter,
 
   // Not a ranked tensor output.
   if (!result_type) {
-    op->emitOpError("SpaceToBatchND: result type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "result type not ranked tensor");
     return llvm::None;
   }
   if (!input_type) {
-    op->emitOpError("SpaceToBatchND: input type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return llvm::None;
   }
   if (!block_shape_type) {
-    op->emitOpError("SpaceToBatchND: block shape type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "block shape type not ranked tensor");
     return llvm::None;
   }
   if (!paddings_type) {
-    op->emitOpError("SpaceToBatchND: paddings type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "paddings type not ranked tensor");
     return llvm::None;
   }
 
@@ -997,19 +1014,19 @@ llvm::Optional<Value> convertBatchToSpaceNDOp(PatternRewriter& rewriter,
       crops_value.getType().dyn_cast<RankedTensorType>();
 
   if (!result_type) {
-    op->emitOpError("BatchToSpaceND: result type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "result type not ranked tensor");
     return llvm::None;
   }
   if (!input_type) {
-    op->emitOpError("BatchToSpaceND: input type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return llvm::None;
   }
   if (!block_shape_type) {
-    op->emitOpError("BatchToSpaceND: block shape type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "block shape type not ranked tensor");
     return llvm::None;
   }
   if (!crops_type) {
-    op->emitOpError("BatchToSpaceND: crops type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "crops type not ranked tensor");
     return llvm::None;
   }
 
@@ -1024,12 +1041,12 @@ llvm::Optional<Value> convertBatchToSpaceNDOp(PatternRewriter& rewriter,
   ElementsAttr crops_elems;
 
   if (!matchPattern(block_shape_value, m_Constant(&block_shape_elems))) {
-    op->emitOpError("BatchToSpaceND: block_shape not a constant");
+    (void)rewriter.notifyMatchFailure(op, "block_shape not a constant");
     return llvm::None;
   }
 
   if (!matchPattern(crops_value, m_Constant(&crops_elems))) {
-    op->emitOpError("BatchToSpaceND: crops not a constant");
+    (void)rewriter.notifyMatchFailure(op, "crops not a constant");
     return llvm::None;
   }
 
@@ -1186,14 +1203,14 @@ llvm::Optional<Value> convertExpandDimsOp(PatternRewriter& rewriter,
       result_value.getType().dyn_cast<RankedTensorType>();
   // Not a ranked tensor output
   if (!output_type) {
-    op->emitOpError("ExpandDims: output type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
     return llvm::None;
   }
 
   RankedTensorType input_type =
       input_value.getType().dyn_cast<RankedTensorType>();
   if (!input_type) {
-    op->emitOpError("ExpandDims: input type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return llvm::None;
   }
 
@@ -1203,7 +1220,8 @@ llvm::Optional<Value> convertExpandDimsOp(PatternRewriter& rewriter,
   if (!matchPattern(dim_value, m_Constant(&dim_elem))) return llvm::None;
 
   if (dim_elem.getNumElements() > 1) {
-    op->emitOpError("ExpandDims: expected single dimension to expand");
+    (void)rewriter.notifyMatchFailure(op,
+        "expected single dimension to expand");
     return llvm::None;
   }
   int32_t dim = dim_elem.getValues<IntegerAttr>()[0].getInt();
@@ -1219,8 +1237,8 @@ llvm::Optional<Value> convertExpandDimsOp(PatternRewriter& rewriter,
     if (dim < 0) {
       dim += input_size;
       if (dim < 0) {
-        op->emitOpError(
-            "ExpandDims: dimension to expand + size of input shape < 0");
+        (void)rewriter.notifyMatchFailure(op,
+            "dimension to expand + size of input shape < 0");
         return llvm::None;
       }
     }
@@ -1249,14 +1267,14 @@ llvm::Optional<Value> convertSqueezeOp(PatternRewriter& rewriter, Operation* op,
       result_value.getType().dyn_cast<RankedTensorType>();
   // Not a ranked tensor output
   if (!output_type) {
-    op->emitOpError("Squeeze: output type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
     return llvm::None;
   }
 
   RankedTensorType input_type =
       input_value.getType().dyn_cast<RankedTensorType>();
   if (!input_type) {
-    op->emitOpError("Squeeze: input type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return llvm::None;
   }
 
@@ -1319,7 +1337,7 @@ llvm::Optional<Value> convertEluOp(PatternRewriter& rewriter, Operation* op,
       result_value.getType().dyn_cast<RankedTensorType>();
   // Not a ranked tensor output
   if (!output_type) {
-    op->emitOpError("Elu: output type not ranked tensor");
+    (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
     return llvm::None;
   }
 
@@ -1372,7 +1390,8 @@ llvm::Optional<Value> convertSoftmaxOp(PatternRewriter& rewriter, Operation* op,
 
   // Not a ranked tensor input/output
   if (!output_type || !input_type) {
-    op->emitOpError("Softmax: input and result not ranked tensors");
+    (void)rewriter.notifyMatchFailure(op,
+        "input and result not ranked tensors");
     return llvm::None;
   }
 
@@ -1733,7 +1752,7 @@ llvm::Optional<Value> convertSoftmaxOp(PatternRewriter& rewriter, Operation* op,
                           (1.0 / out_quant_type.getScale()) * (1.0 / 32768.0),
                           0, out_quant_type.getZeroPoint(), false, true);
     } else {
-      op->emitOpError("Softmax: unknown quantization bitwidth");
+      (void)rewriter.notifyMatchFailure(op, "unknown quantization bitwidth");
       return llvm::None;
     }
   } else {
@@ -1782,14 +1801,14 @@ llvm::Optional<Value> convertLogSoftmaxOp(PatternRewriter& rewriter,
   TensorType output_type = result_value.getType().dyn_cast<TensorType>();
   // Not a tensor output
   if (!output_type) {
-    op->emitOpError("LogSoftmax: output type not tensor.");
+    (void)rewriter.notifyMatchFailure(op, "output type not tensor");
     return llvm::None;
   }
 
   RankedTensorType input_type =
       op->getOperand(0).getType().dyn_cast<RankedTensorType>();
   if (!input_type) {
-    op->emitOpError("LogSoftmax: input type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return llvm::None;
   }
 
@@ -1800,7 +1819,8 @@ llvm::Optional<Value> convertLogSoftmaxOp(PatternRewriter& rewriter,
       output_type.getElementType()
           .dyn_cast_or_null<mlir::quant::UniformQuantizedType>();
   if (in_quant_type || out_quant_type) {
-    op->emitOpError("Quantized log_softmax lowering not implemented yet");
+    (void)rewriter.notifyMatchFailure(op,
+        "quantized log_softmax lowering not implemented yet");
     return llvm::None;
   }
 
@@ -1845,26 +1865,26 @@ llvm::Optional<Value> convertSpaceToDepthOp(PatternRewriter& rewriter,
 
   // Not a ranked tensor output.
   if (!output_type) {
-    op->emitOpError("SpaceToDepth: output type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
     return llvm::None;
   }
 
   RankedTensorType input_type =
       input_value.getType().dyn_cast<RankedTensorType>();
   if (!input_type) {
-    op->emitOpError("SpaceToDepth: input type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return llvm::None;
   }
 
   if (input_type.getRank() != 4) {
-    op->emitOpError("SpaceToDepth: input rank not 4.");
+    (void)rewriter.notifyMatchFailure(op, "input rank not 4");
     return llvm::None;
   }
 
   auto input_shape = input_type.getShape();
 
   if (!block_size_attr) {  // This is a required parameter
-    op->emitOpError("SpaceToDepth: block size attribute not set.");
+    (void)rewriter.notifyMatchFailure(op, "block size attribute not set");
     return llvm::None;
   }
 
@@ -1874,7 +1894,7 @@ llvm::Optional<Value> convertSpaceToDepthOp(PatternRewriter& rewriter,
   if (!data_format) data_format = rewriter.getStringAttr("NHWC");
 
   if (data_format.getValue().str() != "NHWC") {
-    op->emitOpError("SpaceToDepth: data format not NHWC.");
+    (void)rewriter.notifyMatchFailure(op, "data format not NHWC");
     return llvm::None;
   }
 
@@ -1937,14 +1957,14 @@ llvm::Optional<Value> convertDepthToSpaceOp(PatternRewriter& rewriter,
 
   // Not a ranked tensor output
   if (!output_type) {
-    op->emitOpError("DepthToSpace: output type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
     return llvm::None;
   }
 
   RankedTensorType input_type =
       input_value.getType().dyn_cast<RankedTensorType>();
   if (!input_type) {
-    op->emitOpError("DepthToSpace: input type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return llvm::None;
   }
 
@@ -1952,7 +1972,7 @@ llvm::Optional<Value> convertDepthToSpaceOp(PatternRewriter& rewriter,
   auto input_shape = input_type.getShape();
 
   if (!block_size_attr) {  // This is a required parameter
-    op->emitOpError("DepthToSpace: block size attribute not set.");
+    (void)rewriter.notifyMatchFailure(op, "block size attribute not set");
     return llvm::None;
   }
 
@@ -1961,7 +1981,7 @@ llvm::Optional<Value> convertDepthToSpaceOp(PatternRewriter& rewriter,
 
   if (!data_format) data_format = rewriter.getStringAttr("NHWC");
   if (data_format.getValue().str() != "NHWC") {
-    op->emitOpError("DepthToSpace: data format not NHWC.");
+    (void)rewriter.notifyMatchFailure(op, "data format not NHWC");
     return llvm::None;
   }
 
@@ -2016,14 +2036,14 @@ llvm::Optional<SmallVector<Value>> convertSplitOp(
       result_value.getType().dyn_cast<RankedTensorType>();
   // Not a ranked tensor output
   if (!result_type) {
-    op->emitOpError("Split: output type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
     return llvm::None;
   }
 
   RankedTensorType input_type =
       input_value.getType().dyn_cast<RankedTensorType>();
   if (!input_type) {
-    op->emitOpError("Split: input type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return llvm::None;
   }
 
@@ -2103,14 +2123,14 @@ llvm::Optional<SmallVector<Value>> convertSplitVOp(
       result_value.getType().dyn_cast<RankedTensorType>();
   // Not a ranked tensor output
   if (!result_type) {
-    op->emitOpError("SplitV: output type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
     return llvm::None;
   }
 
   RankedTensorType input_type =
       input_value.getType().dyn_cast<RankedTensorType>();
   if (!input_type) {
-    op->emitOpError("SplitV: input type not ranked tensor.");
+    (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return llvm::None;
   }
 
@@ -2120,7 +2140,7 @@ llvm::Optional<SmallVector<Value>> convertSplitVOp(
 
   if ((axis >= 0 && axis >= input_shape.size()) ||
       (axis < 0 && axis < -input_shape.size())) {
-    op->emitOpError("SplitV: invalid axis value.");
+    (void)rewriter.notifyMatchFailure(op, "invalid axis value");
     return llvm::None;
   }
   axis = adjust_axis(axis, input_shape.size());
@@ -2282,7 +2302,7 @@ llvm::Optional<Value> convertStridedSliceOp(
 
   if (!input_type.hasRank()) {
     return (void)rewriter.notifyMatchFailure(op,
-                                             "input type not ranked tensor."),
+                                             "input type not ranked tensor"),
            llvm::None;
   }
 
@@ -2315,7 +2335,7 @@ llvm::Optional<Value> convertStridedSliceOp(
 
     if (a1_begin[i] < 0 && ShapedType::isDynamic(input_shape[i])) {
       (void)rewriter.notifyMatchFailure(
-          op, "begin offset is negative on dynamic size.");
+          op, "begin offset is negative on dynamic size");
       return llvm::None;
     }
 
@@ -2330,7 +2350,7 @@ llvm::Optional<Value> convertStridedSliceOp(
     } else if (end[i] < 0 && ShapedType::isDynamic(input_shape[i])) {
       // Other dynamic cases cannot be handled.
       (void)rewriter.notifyMatchFailure(
-          op, "input dim is dynamic and slice end depends on the length.");
+          op, "input dim is dynamic and slice end depends on the length");
       return llvm::None;
     } else {
       a1_size[i] = end[i] - a1_begin[i];
@@ -2559,7 +2579,7 @@ llvm::Optional<Value> convertFusedActivation(PatternRewriter& rewriter,
     } else {
       // For non-quantized type, only support F32.
       if (!input_type.getElementType().isF32()) {
-        op->emitOpError("ConvertTFLeakyReluOp: only support F32");
+        (void)rewriter.notifyMatchFailure(op, "only support F32");
         return llvm::None;
       }
 
@@ -2800,9 +2820,8 @@ llvm::Optional<Value> convertReduceProdOp(PatternRewriter& rewriter,
       output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
 
   if (input_is_qtype || output_is_qtype) {
-    op->emitOpError(
-        "ConvertReduceProdOp: input/output tensor should "
-        "be all floating-point.");
+    (void)rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all floating-point");
     return llvm::None;
   }
 
@@ -2827,9 +2846,8 @@ llvm::Optional<Value> convertReduceSumOp(PatternRewriter& rewriter,
       output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
 
   if (input_is_qtype != output_is_qtype) {
-    op->emitOpError(
-        "ConvertReduceSumOp: input/output tensor should "
-        "be all quantized or all floating-point.");
+    (void)rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
     return llvm::None;
   }
 
@@ -2882,17 +2900,15 @@ llvm::Optional<Value> convertReduceMeanOp(PatternRewriter& rewriter,
       output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
 
   if (input_is_qtype != output_is_qtype) {
-    op->emitOpError(
-        "ConvertReduceSumOp: input/output tensor should "
-        "be all quantized or all floating-point.");
+    (void)rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
     return llvm::None;
   }
 
   // Only supports float type mean() if it's non-quantized
   if (!input_is_qtype && !output_type.getElementType().isa<mlir::FloatType>()) {
     op->emitWarning(
-        "Failed convertReduceMean: input unquantized type but output element "
-        "not FloatType!");
+        "input unquantized type but output element not FloatType");
     return llvm::None;
   }
 
@@ -2952,7 +2968,7 @@ llvm::Optional<Value> convertResizeOp(PatternRewriter& rewriter, Operation* op,
   if (!input_type) return llvm::None;
 
   if (input_type.getRank() != 4 || output_type.getRank() != 4) {
-    op->emitOpError("convertResizeOp: input/output must be rank 4");
+    (void)rewriter.notifyMatchFailure(op, "input/output must be rank 4");
     return llvm::None;
   }
 
@@ -2962,16 +2978,15 @@ llvm::Optional<Value> convertResizeOp(PatternRewriter& rewriter, Operation* op,
       output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
 
   if (input_is_qtype != output_is_qtype) {
-    op->emitOpError(
-        "ConvertResizeOp: input/output tensor should "
-        "be all quantized or all floating-point.");
+    (void)rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
     return llvm::None;
   }
 
   if (!input_is_qtype) {
     if (!input_type.getElementType().isa<mlir::FloatType>()) {
-      op->emitOpError(
-          "ConvertResizeOp: only quantized or float types supported.");
+      (void)rewriter.notifyMatchFailure(op,
+          "only quantized or float types supported");
       return llvm::None;
     }
   }
@@ -2980,12 +2995,14 @@ llvm::Optional<Value> convertResizeOp(PatternRewriter& rewriter, Operation* op,
   auto output_shape = output_type.getShape();
 
   if (input_type.isDynamicDim(1) || input_type.isDynamicDim(2)) {
-    op->emitOpError("ConvertResizeOp: resize dynamic input not supported.");
+    (void)rewriter.notifyMatchFailure(op,
+        "resize dynamic input not supported");
     return llvm::None;
   }
 
   if (output_type.isDynamicDim(1) || output_type.isDynamicDim(2)) {
-    op->emitOpError("ConvertResizeOp: resize dynamic output not supported.");
+    (void)rewriter.notifyMatchFailure(op,
+        "resize dynamic output not supported");
     return llvm::None;
   }
 
@@ -3048,7 +3065,8 @@ llvm::Optional<Value> convertResizeOp(PatternRewriter& rewriter, Operation* op,
         offset_x > std::numeric_limits<int16_t>::max() ||
         offset_y < std::numeric_limits<int16_t>::min() ||
         offset_x < std::numeric_limits<int16_t>::min()) {
-      op->emitOpError("OpResize: stride or offset out of 16 bits");
+      (void)rewriter.notifyMatchFailure(op,
+          "stride or offset out of 16 bit range");
       return llvm::None;
     }
 
@@ -3075,7 +3093,8 @@ llvm::Optional<Value> convertResizeOp(PatternRewriter& rewriter, Operation* op,
         output_acc_type = RankedTensorType::get(output_type.getShape(),
                                                 rewriter.getI32Type());
       } else {
-        op->emitOpError("OpResize: support 16-bit and 8-bit quantized input");
+        (void)rewriter.notifyMatchFailure(op,
+            "support 16-bit and 8-bit quantized input");
         return llvm::None;
       }
 
@@ -3133,8 +3152,8 @@ llvm::Optional<Value> convertResizeOp(PatternRewriter& rewriter, Operation* op,
           rewriter.getF32ArrayAttr({0.0, 0.0}), resize_mode);
       return resize_op.getResult();
     } else {
-      op->emitOpError(
-          "OpResize: only support BILINEAR or NEAREST_NEIGHBOR mode");
+      (void)rewriter.notifyMatchFailure(op,
+          "only support BILINEAR or NEAREST_NEIGHBOR mode");
       return llvm::None;
     }
   } else {
@@ -3164,8 +3183,8 @@ llvm::Optional<Value> convertQuantizeOp(PatternRewriter& rewriter,
 
   // output element type could only be quantized integer
   if (!output_element_type.isa<mlir::quant::QuantizedType>()) {
-    op->emitWarning(
-        "Lowering quantizeOp but output element type not quantized!");
+    (void)rewriter.notifyMatchFailure(op,
+        "lowering quantizeOp but output element type not quantized");
     return llvm::None;
   }
 
@@ -3464,12 +3483,14 @@ llvm::Optional<Value> convertGatherOp(PatternRewriter& rewriter, Operation* op,
   int indices_rank = indices_type.getShape().size();
 
   if (!(batch_dims <= indices_rank)) {
-    op->emitOpError("Batch_dims must be <= indices_rank for a valid gather op");
+    (void)rewriter.notifyMatchFailure(op,
+        "batch_dims must be <= indices_rank for a valid gather op");
     return llvm::None;
   }
 
   if (!(axis >= batch_dims)) {
-    op->emitOpError("axis must be >= batch_dims for a valid gather op");
+    (void)rewriter.notifyMatchFailure(op,
+        "axis must be >= batch_dims for a valid gather op");
     return llvm::None;
   }
 
@@ -3742,7 +3763,8 @@ llvm::Optional<Value> convertGatherNdOp(PatternRewriter& rewriter,
   ND = indices_type.getShape()[indices_rank - 1];
 
   if (ND > params_rank) {
-    op->emitOpError("Size of last dimension on indices must be <= params rank");
+    (void)rewriter.notifyMatchFailure(op,
+        "size of last dimension of indices must be <= params rank");
     return llvm::None;
   }
 
@@ -3874,12 +3896,14 @@ llvm::Optional<Value> convertOneHotOp(PatternRewriter& rewriter, Operation* op,
   // 7. reshaped to result.shape
 
   if (on_value_type.getRank() != 0 || off_value_type.getRank() != 0) {
-    op->emitOpError("OneHotOp: on_value/off_value needs to be scalar");
+    (void)rewriter.notifyMatchFailure(op,
+        "on_value/off_value needs to be scalar");
     return llvm::None;
   }
 
   if (axis < -1 || axis > indices_type.getRank()) {
-    op->emitOpError("OneHotOp: axis out of valie range [-1, indices.rank]");
+    (void)rewriter.notifyMatchFailure(op,
+        "axis out of valid range [-1, indices.rank]");
     return llvm::None;
   }
 

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
@@ -353,7 +353,7 @@ LogicalResult ConvertTFRoundOp::matchAndRewrite(
 
   TensorType input_type = tf_round_op.x().getType().dyn_cast<TensorType>();
   if (!input_type) {
-    return op->emitOpError("Round: input not tensor type");
+    return rewriter.notifyMatchFailure(op, "input not tensor type");
   }
 
   if (input_type.getElementType().isa<FloatType>()) {
@@ -485,7 +485,7 @@ LogicalResult ConvertTFArgMaxOp::matchAndRewrite(
   }
 
   if (axis < 0 || axis >= input_type.getRank()) {
-    return op->emitOpError("TFArgMax: invalid axis value");
+    return rewriter.notifyMatchFailure(op, "invalid axis value");
   }
 
   IntegerAttr axis_attr = rewriter.getI64IntegerAttr(axis);
@@ -860,7 +860,7 @@ LogicalResult ConvertTFDepthwiseConv2dNativeOp::matchAndRewrite(
 
   // Set up a zero attr for subsequent pattern replacement if required
   if (!filter_type) {
-    return op->emitOpError("DepthwiseConv2d: filter type unranked tensor");
+    return rewriter.notifyMatchFailure(op, "filter type unranked tensor");
   }
 
   auto tmpAttr = tf_dwconv2d_op.data_formatAttr();
@@ -1423,7 +1423,7 @@ LogicalResult ConvertTFSliceOp::matchAndRewrite(
 
   // Assuming begin is always compile-time constant
   if (!matchPattern(tf_slice_op.begin(), m_Constant(&begin_elems))) {
-    return op->emitOpError("TF::Slice error: begin is not constant");
+    return rewriter.notifyMatchFailure(op, "begin is not constant");
   }
 
   for (int i = 0; i < begin_elems.getNumElements(); i++)
@@ -1583,7 +1583,7 @@ LogicalResult ConvertTFSplitVOp::matchAndRewrite(
   // Get the axis
   ElementsAttr axisAttrElems;
   if (!matchPattern(tf_splitv_op.split_dim(), m_Constant(&axisAttrElems))) {
-    return op->emitOpError("Cannot read split_dim elems");
+    return rewriter.notifyMatchFailure(op, "cannot read split_dim elems");
   }
 
   int32_t axis = axisAttrElems.getValues<IntegerAttr>()[0].getInt();
@@ -1711,19 +1711,19 @@ LogicalResult ConvertTFMatMulOp::matchAndRewrite(
       tf_matmul_op.getResult().getType().dyn_cast<RankedTensorType>();
 
   if (!(a_type && b_type && output_type)) {
-    return op->emitOpError("MatMul: a/b/output not ranked tensors");
+    return rewriter.notifyMatchFailure(op, "a/b/output not ranked tensors");
   }
 
   if (a_type.getRank() != b_type.getRank() ||
       a_type.getRank() != output_type.getRank()) {
-    return op->emitOpError("MatMul: a/b/output rank must match");
+    return rewriter.notifyMatchFailure(op, "a/b/output rank must match");
   }
 
   // Can only handle rank 2 tensors for tf.MatMul.
   // Cases with rank > 2 tensors should be handled by tf.BatchMatMul or
   // tf.BatchMatMulV2
   if (a_type.getRank() != 2) {
-    return op->emitOpError("MatMul: a/b/output rank must be 2");
+    return rewriter.notifyMatchFailure(op, "a/b/output rank must be 2");
   }
 
   SmallVector<int64_t, 3> batch_a_shape(
@@ -1976,8 +1976,7 @@ LogicalResult ConvertTFLeakyReluOp::matchAndRewrite(
   // But this alternative is not robust unless alpha meets those constraints.
 
   if (!output_type.getElementType().isF32()) {
-    op->emitOpError("ConvertTFLeakyReluOp: only support F32");
-    return failure();
+    return rewriter.notifyMatchFailure(op, "only support F32");
   }
 
   FloatAttr tmpAttr = tf_leakyrelu_op.alphaAttr();
@@ -2205,16 +2204,16 @@ LogicalResult ConvertTFBatchMatMulV2Op::matchAndRewrite(
       tf_batch_matmul_op.getResult().getType().dyn_cast<RankedTensorType>();
 
   if (!(x_type && y_type && output_type)) {
-    return op->emitOpError("BatchMatMulV2: x/y/output not ranked tensors");
+    return rewriter.notifyMatchFailure(op, "x/y/output not ranked tensors");
   }
 
   if (x_type.getRank() != y_type.getRank() ||
       x_type.getRank() != output_type.getRank()) {
-    return op->emitOpError("BatchMatMulV2: x/y/output rank must match");
+    return rewriter.notifyMatchFailure(op, "x/y/output rank must match");
   }
 
   if (x_type.getRank() <= 2) {
-    return op->emitOpError("BatchMatMulV2: x/y/output rank must > 2");
+    return rewriter.notifyMatchFailure(op, "x/y/output rank must > 2");
   }
 
   // Rank 3 batch matmul can be directly mapped to tosa.matmul trivially.

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -190,9 +190,8 @@ LogicalResult ConvertTFLReluOp::matchAndRewrite(
       output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
 
   if (input_is_qtype != output_is_qtype) {
-    return op->emitOpError(
-        "ConvertTFLReluOp: input/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
   }
 
   int64_t clamp_min = 0;
@@ -240,9 +239,8 @@ LogicalResult ConvertTFLRelu1Op::matchAndRewrite(
       output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
 
   if (input_is_qtype != output_is_qtype) {
-    return op->emitOpError(
-        "ConvertTFLRelu1Op: input/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
   }
 
   int64_t clamp_min = -1;
@@ -295,9 +293,8 @@ LogicalResult ConvertTFLRelu6Op::matchAndRewrite(
       output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
 
   if (input_is_qtype != output_is_qtype) {
-    return op->emitOpError(
-        "ConvertTFLRelu6Op: input/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
   }
 
   int64_t clamp_min = 0;
@@ -354,9 +351,8 @@ static LogicalResult prepareMatchAndRewriteComparison(
 
   if (input_x_is_qtype != input_y_is_qtype ||
       input_y_is_qtype != output_is_qtype) {
-    return op->emitOpError(
-        "ConvertTFLEqualOp: input/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
   }
 
   if (!output_is_qtype && !input_x_is_qtype && !input_y_is_qtype) {
@@ -374,9 +370,8 @@ static LogicalResult prepareMatchAndRewriteComparison(
 
   if (input_x_qtype.getScale() != input_y_qtype.getScale() ||
       input_x_qtype.getZeroPoint() != input_y_qtype.getZeroPoint()) {
-    return op->emitOpError(
-        "ConvertTFLEqualOp: input_x and input_y scale/zp "
-        "must be the same");
+    return rewriter.notifyMatchFailure(op,
+        "input_x and input_y scale/zp must be the same");
   }
 
   x = buildRescaleToInt32(rewriter, op, x, 1.0f, input_x_qtype.getZeroPoint());
@@ -493,9 +488,8 @@ static LogicalResult matchAndRewriteAddSub(Operation* op,
 
   if (input_lhs_is_qtype != output_is_qtype ||
       input_rhs_is_qtype != output_is_qtype) {
-    return op->emitOpError(
-        "ConvertTFLAddOp: input/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
   }
 
   Value output;
@@ -643,7 +637,7 @@ LogicalResult ConvertTFLRoundOp::matchAndRewrite(
 
   ShapedType input_type = tfl_round_op.x().getType().dyn_cast<ShapedType>();
   if (!input_type) {
-    return op->emitOpError("Round: input not shaped tensor type");
+    return rewriter.notifyMatchFailure(op, "input not shaped tensor type");
   }
 
   if (input_type.getElementType().isa<FloatType>()) {
@@ -725,9 +719,8 @@ LogicalResult ConvertTFLMaximumOp::matchAndRewrite(
 
   if (input_lhs_is_qtype != output_is_qtype ||
       input_rhs_is_qtype != output_is_qtype) {
-    return op->emitOpError(
-        "ConvertTFLMaximumOp: input/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
   }
 
   Value output;
@@ -777,9 +770,8 @@ LogicalResult ConvertTFLMinimumOp::matchAndRewrite(
 
   if (input_lhs_is_qtype != output_is_qtype ||
       input_rhs_is_qtype != output_is_qtype) {
-    return op->emitOpError(
-        "ConvertTFLMinimumOp: input/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
   }
 
   Value output;
@@ -1020,9 +1012,9 @@ LogicalResult ConvertTFLConv2DOp::matchAndRewrite(
 
   if ((input_is_qtype != filter_is_qtype) ||
       (input_is_qtype != output_is_qtype)) {
-    return op->emitOpError(
-        "ConvertTFLConv2DOp: input/filter/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/filter/output tensor should "
+        "be all quantized or all floating-point");
   }
 
   ArrayAttr pad;
@@ -1112,9 +1104,9 @@ LogicalResult ConvertTFLTransposeConvOp::matchAndRewrite(
 
   if ((input_is_qtype != filter_is_qtype) ||
       (input_is_qtype != output_is_qtype)) {
-    return op->emitOpError(
-        "ConvertTFLConv2DOp: input/filter/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/filter/output tensor should "
+        "be all quantized or all floating-point");
   }
 
   ArrayAttr stride;
@@ -1235,9 +1227,9 @@ LogicalResult ConvertTFLDepthwiseConv2DOp::matchAndRewrite(
 
   if ((input_is_qtype != filter_is_qtype) ||
       (input_is_qtype != output_is_qtype)) {
-    return op->emitOpError(
-        "ConvertTFLConv2DOp: input/filter/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/filter/output tensor should "
+        "be all quantized or all floating-point");
   }
 
   // We need the filter shape to compute the transpose.
@@ -1369,9 +1361,9 @@ LogicalResult ConvertTFLBatchMatMulOp::matchAndRewrite(
       result_ty.getElementType().isa<mlir::quant::QuantizedType>();
 
   if ((lhs_is_qtype != rhs_is_qtype) || (lhs_is_qtype != result_is_qtype)) {
-    return op->emitOpError(
-        "ConvertTFLBatchMatMulOp: lhs/rhs/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "lhs/rhs/output tensor should "
+        "be all quantized or all floating-point");
   }
 
   auto batch_dims = lhs_ty.getShape().drop_back(2);
@@ -1481,9 +1473,9 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
 
   if ((input_is_qtype != filter_is_qtype) ||
       (input_is_qtype != output_is_qtype)) {
-    return op->emitOpError(
-        "ConvertTFLFullyConnectedOp: input/filter/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/filter/output tensor should "
+        "be all quantized or all floating-point");
   }
 
   Value input_val = tfl_fc_op.input();
@@ -1536,9 +1528,8 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
         bias_arr[i] = 0;
       }
       if (!input_is_qtype) {
-        return op->emitOpError(
-            "ConvertTFLFullyConnectedOp: input must be quantized type if it's "
-            "not float type.");
+        return rewriter.notifyMatchFailure(op,
+            "input must be quantized type if it's not float type");
       }
       auto input_qtype =
           input_type.getElementType().cast<mlir::quant::QuantizedType>();
@@ -2164,7 +2155,7 @@ LogicalResult ConvertTFLSplitOp::matchAndRewrite(
   // Get the axis
   ElementsAttr axisAttrElems;
   if (!matchPattern(tfl_split_op.split_dim(), m_Constant(&axisAttrElems))) {
-    return op->emitOpError("Cannot read split_dim elems");
+    return rewriter.notifyMatchFailure(op, "cannot read split_dim elems");
   }
 
   // The axis/split_dim parameter is stored as a 0D tensor instead of
@@ -2202,7 +2193,7 @@ LogicalResult ConvertTFLSplitVOp::matchAndRewrite(
   // Get the axis
   ElementsAttr axisAttrElems;
   if (!matchPattern(tfl_splitv_op.split_dim(), m_Constant(&axisAttrElems))) {
-    return op->emitOpError("Cannot read split_dim elems");
+    return rewriter.notifyMatchFailure(op, "cannot read split_dim elems");
   }
 
   // The axis/split_dim parameter is stored as a 0D tensor instead of
@@ -2508,15 +2499,14 @@ LogicalResult ConvertTFLSinOp::matchAndRewrite(
 
   if (input_ety != output_ety) {
     return rewriter.notifyMatchFailure(
-        op, "ConvertTFLSinOp: input/output element type must match");
+        op, "input/output element type must match");
   }
 
   bool input_is_fp = input_ty.getElementType().isF32();
   bool output_is_fp = output_ty.getElementType().isF32();
 
   if (!input_is_fp || !output_is_fp) {
-    return rewriter.notifyMatchFailure(
-        op, "ConvertTFLSinOp: input/result must be fp32.");
+    return rewriter.notifyMatchFailure(op, "input/result must be fp32");
   }
 
   // To perform a sin operation we remap the sin domain to be over a single
@@ -2612,7 +2602,7 @@ LogicalResult ConvertTFLCosOp::matchAndRewrite(
 
   if (!input_is_fp || !output_is_fp) {
     return rewriter.notifyMatchFailure(
-        op, "ConvertTFLCosOp: input/result must be fp.");
+        op, "input/result must be fp");
   }
 
   // Replace with the equivalent sin operation:
@@ -2643,9 +2633,8 @@ LogicalResult ConvertTFLLogisticOp::matchAndRewrite(
       output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
 
   if (input_is_qtype != output_is_qtype) {
-    return op->emitOpError(
-        "ConvertTFLLogisticOp: input/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
   }
 
   if (input_is_qtype) {
@@ -2670,10 +2659,8 @@ LogicalResult ConvertTFLLogisticOp::matchAndRewrite(
                                              tfl_logistic_op.x(), table_const);
     } else {  // int16
       if (input_qtype.getZeroPoint() != 0 || output_qtype.getZeroPoint() != 0) {
-        op->emitOpError(
-            "ConvertTFLLogistic: input/output zeropoint should be 0 in 16-bit "
-            "mode");
-        return failure();
+        return rewriter.notifyMatchFailure(op,
+            "input/output zeropoint should be 0 in 16-bit mode");
       }
       double input_min = -32768 * input_qtype.getScale();
       double input_max = 32767 * input_qtype.getScale();
@@ -2715,9 +2702,8 @@ LogicalResult ConvertTFLTanhOp::matchAndRewrite(
       output_type.getElementType().isa<mlir::quant::UniformQuantizedType>();
 
   if (input_is_qtype != output_is_qtype) {
-    return op->emitOpError(
-        "ConvertTFLTanhOp: input/output tensor should "
-        "be all quantized or all floating-point.");
+    return rewriter.notifyMatchFailure(op,
+        "input/output tensor should be all quantized or all floating-point");
   }
 
   if (input_is_qtype) {
@@ -2743,10 +2729,8 @@ LogicalResult ConvertTFLTanhOp::matchAndRewrite(
                                              tfl_tanh_op.input(), table_const);
     } else {  // int16
       if (input_qtype.getZeroPoint() != 0 || output_qtype.getZeroPoint() != 0) {
-        op->emitOpError(
-            "ConvertTFLLogistic: input/output zeropoint should be 0 in 16-bit "
-            "mode");
-        return failure();
+        return rewriter.notifyMatchFailure(op,
+            "input/output zeropoint should be 0 in 16-bit mode");
       }
       double input_min = -32768 * input_qtype.getScale();
       double input_max = 32767 * input_qtype.getScale();


### PR DESCRIPTION
This is an refactoring patch which comes from the discussion here: [link](https://github.com/tensorflow/tensorflow/pull/56926#discussion_r932678395). 

Signed-off-by: Jerry Ge <jerry.ge@arm.com>