### PR TITLE
[tfg][functiondef_import] Emit error on empty function attributes

### DIFF
--- a/tensorflow/core/ir/importexport/functiondef_import.cc
+++ b/tensorflow/core/ir/importexport/functiondef_import.cc
@@ -324,6 +324,8 @@ Status ImportGenericFunction(
   // Import the function attributes with a `tf.` prefix to match the current
   // infrastructure expectations.
   for (const auto& namedAttr : func.attr()) {
+    if (namedAttr.first.empty())
+      return InvalidArgument("Invalid function attribute name");
     const std::string& name = "tf." + namedAttr.first;
     const AttrValue& tf_attr = namedAttr.second;
     TF_ASSIGN_OR_RETURN(Attribute attr,

--- a/tensorflow/core/ir/importexport/tests/graphdef-to-mlir/invalid_generic_function_attr_name.pbtxt
+++ b/tensorflow/core/ir/importexport/tests/graphdef-to-mlir/invalid_generic_function_attr_name.pbtxt
@@ -1,0 +1,52 @@
+# RUN: not tfg-translate -graphdef-to-mlir %s 2>&1 | FileCheck %s
+
+# CHECK: Invalid function attribute name
+
+library {
+  function {
+    signature {
+      name: "foo"
+      input_arg {
+        name: "a"
+      }
+      output_arg {
+        name: "d"
+      }
+    }
+    node_def {
+      op: "Const"
+      attr {
+        key: "_b"
+        value {
+          placeholder: "T"
+        }
+      }
+      attr {
+        key: "dtype"
+        value {
+          type: DT_INT32
+        }
+      }
+      attr {
+        key: "value"
+        value {
+          tensor {
+            dtype: DT_INT32
+            tensor_shape {
+            }
+          }
+        }
+      }
+    }
+    ret {
+      key: "d"
+      value: "a"
+    }
+    attr {
+      key: ""
+      value {
+        s: "a"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Disallow empty function attributes. Emit an error when one is encountered.

PiperOrigin-RevId: 448629968