### PR TITLE
Revert "r2.10 cherry-pick: e9863e9a9cb "Fix tf.raw_ops.EmptyTensorList vulnerability from non scalar `num_elements`.""

### DIFF
--- a/tensorflow/core/kernels/list_kernels.cc
+++ b/tensorflow/core/kernels/list_kernels.cc
@@ -31,11 +31,9 @@ limitations under the License.
 #include "tensorflow/core/framework/allocator.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
-#include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/framework/variant.h"
 #include "tensorflow/core/framework/variant_op_registry.h"
-#include "tensorflow/core/platform/errors.h"
 
 namespace tensorflow {
 
@@ -324,11 +322,6 @@ class TensorListReserve : public OpKernel {
   void Compute(OpKernelContext* c) override {
     PartialTensorShape element_shape;
     OP_REQUIRES_OK(c, TensorShapeFromTensor(c->input(0), &element_shape));
-    OP_REQUIRES(
-        c, TensorShapeUtils::IsScalar(c->input(1).shape()),
-        errors::InvalidArgument(
-            "The num_elements to reserve must be a tensor size 1, but got ",
-            c->input(1).shape()));
     int32_t num_elements = c->input(1).scalar<int32>()();
     OP_REQUIRES(c, num_elements >= 0,
                 errors::InvalidArgument("The num_elements to reserve must be a "

--- a/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
@@ -94,16 +94,6 @@ class ListOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       l = list_ops.tensor_list_pop_back(l, element_dtype=dtypes.float32)
       self.evaluate(l)
 
-  def testTensorListReserveWithNonScalarNumElements(self):
-    with self.assertRaisesRegex(
-        errors.InvalidArgumentError,
-        r"The num_elements to reserve must be a tensor size 1, but got \[2\]"):
-      l = list_ops.tensor_list_reserve(
-          element_dtype=dtypes.float32,
-          element_shape=[2, 3],
-          num_elements=constant_op.constant([1, 1]))
-      self.evaluate(l)
-
   def testPopUninitializedTensorUseListElementShape(self):
     l = list_ops.tensor_list_reserve(
         element_dtype=dtypes.float32, element_shape=[2, 3], num_elements=3)


### PR DESCRIPTION
Reverts tensorflow/tensorflow#57075