### PR TITLE
[NVIDIA TF] Bump up cuDNN frontend to v0.7

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
@@ -3491,7 +3491,7 @@ port::StatusOr<cudnn_frontend::Tensor> CreateCudnnTensor(
     bool is_virtual = false) {
   auto tensor = cudnn_frontend::TensorBuilder()
                     .setDim(dims.size(), dims.data())
-                    .setStrides(strides.size(), strides.data())
+                    .setStride(strides.size(), strides.data())
                     .setId(uid)
                     .setAlignment(32)
                     .setDataType(ToCudnnDataType(dtype))
@@ -3570,10 +3570,10 @@ GetCudnnOperationGraph(dnn::ConvolutionKind kind, dnn::DataType input_type,
 
   auto conv_desc =
       cudnn_frontend::ConvDescBuilder()
-          .setComputePrecision(accumulator_type)
+          .setComputeType(accumulator_type)
           .setMathMode(mode)
-          .setNDims(conv_dim)
-          .setStrides(conv_dim, convolution_descriptor.strides().data())
+          .setSpatialDimCount(conv_dim)
+          .setSpatialStride(conv_dim, convolution_descriptor.strides().data())
           .setPrePadding(conv_dim, convolution_descriptor.padding().data())
           .setPostPadding(conv_dim, convolution_descriptor.padding().data())
           .setDilation(conv_dim, convolution_descriptor.dilations().data())
@@ -3745,10 +3745,10 @@ GetCudnnFusedOperationGraph(
   cudnnDataType_t cudnn_activation_type = ToCudnnDataType(activation_type);
   auto conv_desc =
       cudnn_frontend::ConvDescBuilder()
-          .setComputePrecision(cudnn_convolution_type)
+          .setComputeType(cudnn_convolution_type)
           .setMathMode(mode)
-          .setNDims(conv_dim)
-          .setStrides(conv_dim, convolution_descriptor.strides().data())
+          .setSpatialDimCount(conv_dim)
+          .setSpatialStride(conv_dim, convolution_descriptor.strides().data())
           .setPrePadding(conv_dim, convolution_descriptor.padding().data())
           .setPostPadding(conv_dim, convolution_descriptor.padding().data())
           .setDilation(conv_dim, convolution_descriptor.dilations().data())

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -168,9 +168,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "314569f65d5c7d05fb7e90157a838549db3e2cfb464c80a6a399b39a004690fa",
-        strip_prefix = "cudnn-frontend-0.6.2",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.6.2.zip"),
+        sha256 = "6ca6e7d4affdff59c749865d6d0428c849968b0873a1d1b849f56d7be624f27b",
+        strip_prefix = "cudnn-frontend-0.7.1",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.7.1.zip"),
     )
 
     tf_http_archive(

--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,4 +1,4 @@
-From 681ce638cbf9a115054071d7549f10cb0d3e37ac Mon Sep 17 00:00:00 2001
+From 8c4aece07c6993587198de3f626cd7b885a7fed1 Mon Sep 17 00:00:00 2001
 From: Kaixi Hou <kaixih@nvidia.com>
 Date: Tue, 4 May 2021 15:21:11 -0700
 Subject: [PATCH] Update headers path to TF-compat
@@ -17,8 +17,9 @@ Subject: [PATCH] Update headers path to TF-compat
  include/cudnn_frontend_OperationGraph.h     | 4 ++--
  include/cudnn_frontend_PointWiseDesc.h      | 4 ++--
  include/cudnn_frontend_ReductionDesc.h      | 4 ++--
+ include/cudnn_frontend_Resample.h           | 4 ++--
  include/cudnn_frontend_VariantPack.h        | 4 ++--
- 14 files changed, 25 insertions(+), 25 deletions(-)
+ 15 files changed, 27 insertions(+), 27 deletions(-)
 
 diff --git a/include/cudnn_backend_base.h b/include/cudnn_backend_base.h
 index 56d8bec..8ceb19c 100644
@@ -34,7 +35,7 @@ index 56d8bec..8ceb19c 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_ConvDesc.h b/include/cudnn_frontend_ConvDesc.h
-index 871822b..115d542 100644
+index ded7e67..68341e1 100644
 --- a/include/cudnn_frontend_ConvDesc.h
 +++ b/include/cudnn_frontend_ConvDesc.h
 @@ -29,8 +29,8 @@
@@ -92,10 +93,10 @@ index 323106a..d90a1ea 100644
  #include "cudnn_frontend_Heuristics.h"
  
 diff --git a/include/cudnn_frontend_ExecutionPlan.h b/include/cudnn_frontend_ExecutionPlan.h
-index 42fd09b..f4a294f 100644
+index 7bed4b4..d79cfff 100644
 --- a/include/cudnn_frontend_ExecutionPlan.h
 +++ b/include/cudnn_frontend_ExecutionPlan.h
-@@ -29,8 +29,8 @@
+@@ -30,8 +30,8 @@
  #include <sstream>
  #include <utility>
  
@@ -107,7 +108,7 @@ index 42fd09b..f4a294f 100644
  #include "cudnn_frontend_Engine.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_Filters.h b/include/cudnn_frontend_Filters.h
-index b244766..3e9273b 100644
+index aac4086..ed1f343 100644
 --- a/include/cudnn_frontend_Filters.h
 +++ b/include/cudnn_frontend_Filters.h
 @@ -22,7 +22,7 @@
@@ -120,7 +121,7 @@ index b244766..3e9273b 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_Heuristics.h b/include/cudnn_frontend_Heuristics.h
-index 3d0dacd..fec5e31 100644
+index 376f654..2ff07c9 100644
 --- a/include/cudnn_frontend_Heuristics.h
 +++ b/include/cudnn_frontend_Heuristics.h
 @@ -25,8 +25,8 @@
@@ -135,7 +136,7 @@ index 3d0dacd..fec5e31 100644
  #include "cudnn_frontend_OperationGraph.h"
  #include "cudnn_frontend_EngineConfig.h"
 diff --git a/include/cudnn_frontend_MatMulDesc.h b/include/cudnn_frontend_MatMulDesc.h
-index 5f3161a..c357cc1 100644
+index a7d0714..c5ccb90 100644
 --- a/include/cudnn_frontend_MatMulDesc.h
 +++ b/include/cudnn_frontend_MatMulDesc.h
 @@ -29,8 +29,8 @@
@@ -150,10 +151,10 @@ index 5f3161a..c357cc1 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Operation.h b/include/cudnn_frontend_Operation.h
-index 4d4e2dc..32fd1b1 100644
+index b084046..dc3c840 100644
 --- a/include/cudnn_frontend_Operation.h
 +++ b/include/cudnn_frontend_Operation.h
-@@ -29,8 +29,8 @@
+@@ -30,8 +30,8 @@
  #include <sstream>
  #include <utility>
  
@@ -165,7 +166,7 @@ index 4d4e2dc..32fd1b1 100644
  #include "cudnn_frontend_ConvDesc.h"
  #include "cudnn_frontend_PointWiseDesc.h"
 diff --git a/include/cudnn_frontend_OperationGraph.h b/include/cudnn_frontend_OperationGraph.h
-index b240496..756f67e 100644
+index 1478ce8..1903102 100644
 --- a/include/cudnn_frontend_OperationGraph.h
 +++ b/include/cudnn_frontend_OperationGraph.h
 @@ -30,8 +30,8 @@
@@ -180,7 +181,7 @@ index b240496..756f67e 100644
  #include "cudnn_frontend_Operation.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_PointWiseDesc.h b/include/cudnn_frontend_PointWiseDesc.h
-index bf0ad54..869bbfd 100644
+index b62cd27..8b56eeb 100644
 --- a/include/cudnn_frontend_PointWiseDesc.h
 +++ b/include/cudnn_frontend_PointWiseDesc.h
 @@ -30,8 +30,8 @@
@@ -195,9 +196,24 @@ index bf0ad54..869bbfd 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_ReductionDesc.h b/include/cudnn_frontend_ReductionDesc.h
-index 046af46..f82a643 100644
+index 21c4ee3..e77e4ef 100644
 --- a/include/cudnn_frontend_ReductionDesc.h
 +++ b/include/cudnn_frontend_ReductionDesc.h
+@@ -29,8 +29,8 @@
+ #include <sstream>
+ #include <utility>
+ 
+-#include <cudnn.h>
+-#include <cudnn_backend.h>
++#include "third_party/gpus/cudnn/cudnn.h"
++#include "third_party/gpus/cudnn/cudnn_backend.h"
+ 
+ #include "cudnn_frontend_utils.h"
+ 
+diff --git a/include/cudnn_frontend_Resample.h b/include/cudnn_frontend_Resample.h
+index 2174509..d0d7e3b 100644
+--- a/include/cudnn_frontend_Resample.h
++++ b/include/cudnn_frontend_Resample.h
 @@ -29,8 +29,8 @@
  #include <sstream>
  #include <utility>


### PR DESCRIPTION
This PR bumps up the cuDNN frontend to the latest v0.7.1 ([release note](https://github.com/NVIDIA/cudnn-frontend/releases/tag/v0.7.1)). The v0.7.1 can better support the latest cuDNN v8.5 and has improved its forward compatibility support for 8.x.

Also, v0.7.1 has applied a unified API names to improve the user experience. And we substitute new APIs for the deprecated ones in this PR.

cc. @nluehr @pjannaty 