### PR TITLE
[lite] Fix shared library build on Windows

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -201,6 +201,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Android")
 endif()
 # Build a list of source files to compile into the TF Lite library.
 populate_tflite_source_vars("." TFLITE_SRCS)
+if(CMAKE_SYSTEM_NAME MATCHES "Windows" AND BUILD_SHARED_LIBS)
+  list(FILTER TFLITE_SRCS EXCLUDE REGEX ".*simple_memory_arena_debug_dump\\.cc$")
+endif()
 
 # This particular file is excluded because the more explicit approach to enable
 # XNNPACK delegate is preferred to the weak-symbol one.


### PR DESCRIPTION
Building a shared TensorFlow Lite library with CMake on Windows
currently fails with
>simple_memory_arena_debug_dump.obj : error LNK2005: "void __cdecl tflite::DumpArenaInfo(...) already defined in simple_memory_arena.obj

This is because MSVC doesn't have the notion of weak linking required to solve the conflict between the two implementations of
`tflite::DumpArenaInfo()`. Resolve the conflict by removing the excluding the conflicting implementation in `CMakeLists.txt` for now.