### PR TITLE
[mhlo] build: fix missing dependencies on Chlo and Stablehlo

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/lib/Analysis/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Analysis/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_library(MLIRHLOAnalysis
 
   DEPENDS
   mlir-headers
+  StablehloBaseIncGen
 
   LINK_LIBS PUBLIC
   MLIRAnalysis

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/gml_st/transforms/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/gml_st/transforms/CMakeLists.txt
@@ -100,7 +100,9 @@ add_mlir_library(GmlStPasses
   vectorization.cc
 
   DEPENDS
+  ChloOpsIncGen
   MLIRGmlStPassIncGen
+  StablehloBaseIncGen
 
   LINK_COMPONENTS
   Core

--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/IR/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/IR/CMakeLists.txt
@@ -36,9 +36,11 @@ add_mlir_dialect_library(MhloDialect
   hlo_ops.cc
 
   DEPENDS
+  ChloOpsIncGen
   MLIRhlo_opsIncGen
   MLIRMhloCanonicalizeIncGen
   MLIRMhloRewriterIncGen
+  StablehloBaseIncGen
 )
 target_link_libraries(MhloDialect
   PUBLIC
@@ -58,7 +60,9 @@ target_include_directories(MhloDialect
 add_mlir_dialect_library(MhloRegisterDialects
   init.cc
 DEPENDS
+  ChloOpsIncGen
   MLIRhlo_opsIncGen
+  StablehloBaseIncGen
 )
 target_link_libraries(MhloRegisterDialects
   PUBLIC

--- a/tensorflow/compiler/xla/mlir_hlo/lib/utils/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/utils/CMakeLists.txt
@@ -20,6 +20,10 @@ add_mlir_library(MLIRMhloUtils
   cycle_detector.cc
   hlo_utils.cc
 
+  DEPENDS
+  ChloOpsIncGen
+  StablehloBaseIncGen
+
   LINK_LIBS PUBLIC
   MLIRArithmeticDialect
   MLIRFuncDialect


### PR DESCRIPTION
These dependencies are not necessarily exposed in a parallel build.