### PR TITLE
[oneDNN][grappler:remapper] Bug fix: LeakyRelu in the fusion: Pad + Conv3D + <BiasAdd> + Activation

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -2503,25 +2503,16 @@ Status AddFusedConv3DNode(RemapperContext* ctx, const PadWithConv3D& matched,
           << " contraction=" << contraction.name();
 
   NodeDef fused_node;
-  fused_node.set_name(contraction.name());
-  fused_node.set_device(contraction.device());
-  fused_node.add_input(pad_node_def.input(0));  // 0: input
-  fused_node.add_input(contraction.input(1));   // 1: filter
+  // Note: Currently, the attributes of fused op are superset of contraction
+  // node. So copy it from contraction node before mutation.
+  fused_node.CopyFrom(contraction);
+  // 0-th input is the 0-th input of pad node, while the remainder inputs are
+  // same as the contraction node.
+  fused_node.set_input(0, pad_node_def.input(0));
   fused_node.set_op(kFusedConv3D);
-
   auto* attr = fused_node.mutable_attr();
-  auto& src_attr = contraction.attr();
-  (*attr)["T"] = src_attr.at("T");
-  (*attr)["strides"] = src_attr.at("strides");
-  (*attr)["data_format"] = src_attr.at("data_format");
-  (*attr)["padding"] = src_attr.at("padding");
-  (*attr)["dilations"] = src_attr.at("dilations");
-
-  if (contraction.op() == kFusedConv3D) {
-    fused_node.add_input(contraction.input(2));  // 2: bias
-    (*attr)["fused_ops"] = src_attr.at("fused_ops");
-    (*attr)["num_args"] = src_attr.at("num_args");
-  } else {
+  // Set num_args attr explicitly, since there is no default value.
+  if (!attr->contains("num_args")) {
     SetAttrValue(0, &(*attr)["num_args"]);
   }
 
@@ -2535,6 +2526,10 @@ Status AddFusedConv3DNode(RemapperContext* ctx, const PadWithConv3D& matched,
       paddings.push_back(const_value(i));
       SetAttrValue(paddings, &(*attr)["padding_list"]);
     }
+  } else {
+    VLOG(2) << "Pad fusion with " << contraction.op() << " is invalidated, "
+            << "it requires padding dim sizes to be constant.";
+    return OkStatus();
   }
 
   utils::Mutation* mutation = ctx->graph_view.GetMutationBuilder();

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -2321,73 +2321,109 @@ class RemapperFusePadWithFusedConv3D : public RemapperTest {
  public:
   template <DataType DTYPE>
   void RunTest() {
-    if (!IsMKLEnabled()) GTEST_SKIP() << "Test only applicable to MKL.";
-    using ::tensorflow::ops::Placeholder;
-    tensorflow::Scope s = tensorflow::Scope::NewRootScope();
     if (!IsMKLEnabled()) GTEST_SKIP() << "Test only applicable to oneDNN.";
-    auto input_shape = ops::Placeholder::Shape({8, 4, 32, 32, 3});
-    auto filter_shape = ops::Placeholder::Shape({1, 1, 1, 3, 128});
-    auto bias_shape = ops::Placeholder::Shape({128});
-    auto paddings_shape = ops::Placeholder::Shape({5, 2});
-    auto strides = {1, 1, 1, 1, 1};
+    using ::tensorflow::ops::Placeholder;
 
-    auto input_t = GenerateTensorWithSetRandom<DTYPE>({8, 4, 32, 32, 3});
-    auto filter_t = GenerateTensorWithSetRandom<DTYPE>({1, 1, 1, 3, 128});
-    auto bias_t = GenerateTensorWithSetRandom<DTYPE>({128});
+    // Empty string denotes no activation.
+    for (const string& activation : {"", "Relu", "Relu6", "Elu", "LeakyRelu"}) {
+      tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+      auto input_shape = ops::Placeholder::Shape({8, 4, 32, 32, 3});
+      auto filter_shape = ops::Placeholder::Shape({1, 1, 1, 3, 128});
+      auto bias_shape = ops::Placeholder::Shape({128});
+      auto paddings_shape = ops::Placeholder::Shape({5, 2});
+      auto strides = {1, 1, 1, 1, 1};
 
-    auto input = Placeholder(s.WithOpName("input"), DTYPE, input_shape);
-    auto filter = Placeholder(s.WithOpName("filter"), DTYPE, filter_shape);
-    auto bias = Placeholder(s.WithOpName("bias"), DTYPE, bias_shape);
+      auto input_t = GenerateTensorWithSetRandom<DTYPE>({8, 4, 32, 32, 3});
+      auto filter_t = GenerateTensorWithSetRandom<DTYPE>({1, 1, 1, 3, 128});
+      auto bias_t = GenerateTensorWithSetRandom<DTYPE>({128});
 
-    auto padding_const = ops::Const(s.WithOpName("padding"),
-                                    {0, 0, 1, 1, 1, 1, 1, 1, 0, 0}, {5, 2});
-    auto pad = ops::Pad(s.WithOpName("pad"), input, padding_const);
-    auto conv = ops::Conv3D(s.WithOpName("conv"), pad, filter, strides, "SAME");
-    auto bias_add = ops::BiasAdd(s.WithOpName("bias_add"), conv, bias);
-    auto fetch = ops::Identity(s.WithOpName("fetch"), bias_add);
+      auto input = Placeholder(s.WithOpName("input"), DTYPE, input_shape);
+      auto filter = Placeholder(s.WithOpName("filter"), DTYPE, filter_shape);
+      auto bias = Placeholder(s.WithOpName("bias"), DTYPE, bias_shape);
 
-    GrapplerItem item;
-    item.fetch = {"fetch"};
-    item.feed = {{"input", input_t}, {"filter", filter_t}, {"bias", bias_t}};
-    TF_ASSERT_OK(s.ToGraphDef(&item.graph));
+      auto padding_const = ops::Const(s.WithOpName("padding"),
+                                      {0, 0, 1, 1, 1, 1, 1, 1, 0, 0}, {5, 2});
+      auto pad = ops::Pad(s.WithOpName("pad"), input, padding_const);
+      auto conv =
+          ops::Conv3D(s.WithOpName("conv"), pad, filter, strides, "SAME");
+      auto bias_add = ops::BiasAdd(s.WithOpName("bias_add"), conv, bias);
 
-    // Place all nodes on CPU.
-    for (int i = 0; i < item.graph.node_size(); ++i) {
-      item.graph.mutable_node(i)->set_device("/device:CPU:0");
-    }
+      float leakyrelu_alpha = 0.5;
+      ops::Identity fetch = [&]() -> ops::Identity {
+        auto activate = s.WithOpName("activation");
+        auto fetch = s.WithOpName("fetch");
 
-    Remapper optimizer(RewriterConfig::ON);
-    GraphDef output_1;
-    TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output_1));
-    item.graph = std::move(output_1);
-    GraphDef output;
-    TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+        if (activation == "Relu") {
+          return ops::Identity(fetch, ops::Relu(activate, bias_add));
+        } else if (activation == "Relu6") {
+          return ops::Identity(fetch, ops::Relu6(activate, bias_add));
+        } else if (activation == "Elu") {
+          return ops::Identity(fetch, ops::Elu(activate, bias_add));
+        } else if (activation == "LeakyRelu") {
+          auto attr = ops::internal::LeakyRelu::Alpha(leakyrelu_alpha);
+          return ops::Identity(
+              fetch, ops::internal::LeakyRelu(activate, bias_add, attr));
+        }
 
-    int found = 0;
-    for (const NodeDef& node : output.node()) {
-      if (node.name() == "bias_add") {
-        EXPECT_EQ(node.op(), "_FusedConv3D");
-        ASSERT_GE(node.input_size(), 3);
-        EXPECT_EQ(node.input(0), "input");
-        EXPECT_EQ(node.input(1), "filter");
-        EXPECT_EQ(node.attr().at("num_args").i(), 1);
-        EXPECT_EQ(node.input(2), "bias");
-        const auto fused_ops = node.attr().at("fused_ops").list().s();
-        ASSERT_EQ(fused_ops.size(), 1);
-        EXPECT_EQ(fused_ops[0], "BiasAdd");
-        found++;
+        return ops::Identity(fetch, bias);
+      }();
+
+      GrapplerItem item;
+      item.fetch = {"fetch"};
+      item.feed = {{"input", input_t}, {"filter", filter_t}, {"bias", bias_t}};
+      TF_ASSERT_OK(s.ToGraphDef(&item.graph));
+
+      // Place all nodes on CPU.
+      for (int i = 0; i < item.graph.node_size(); ++i) {
+        item.graph.mutable_node(i)->set_device("/device:CPU:0");
       }
-    }
-    EXPECT_EQ(found, 1);
 
-    auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
-    ASSERT_EQ(tensors_expected.size(), 1);
-    auto tensors = EvaluateNodes(output, item.fetch, item.feed);
-    ASSERT_EQ(tensors.size(), 1);
-    if (DTYPE == DT_BFLOAT16)
-      test::ExpectClose(tensors[0], tensors_expected[0], 1e-2, 1e-2);
-    else
-      test::ExpectClose(tensors[0], tensors_expected[0], 1e-6);
+      Remapper optimizer(RewriterConfig::ON);
+      GraphDef output_1;
+      TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output_1));
+      item.graph = std::move(output_1);
+      GraphDef output;
+      TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+      string fused_node_name;
+      std::vector<string> expected_fused_ops = {"BiasAdd"};
+      if (activation.empty()) {
+        fused_node_name = "bias_add";
+      } else {
+        fused_node_name = "activation";
+        expected_fused_ops.push_back(activation);
+      }
+      int found = 0;
+      for (const NodeDef& node : output.node()) {
+        if (node.name() == fused_node_name) {
+          EXPECT_EQ(node.op(), "_FusedConv3D");
+          ASSERT_GE(node.input_size(), 3);
+          EXPECT_EQ(node.input(0), "input");
+          EXPECT_EQ(node.input(1), "filter");
+          EXPECT_EQ(node.attr().at("num_args").i(), 1);
+          EXPECT_EQ(node.input(2), "bias");
+          const auto fused_ops = node.attr().at("fused_ops").list().s();
+          ASSERT_EQ(fused_ops.size(), expected_fused_ops.size());
+          for (int i = 0; i < fused_ops.size(); ++i) {
+            EXPECT_EQ(fused_ops[i], expected_fused_ops[i]);
+          }
+          if (activation == "LeakyRelu") {
+            EXPECT_EQ(node.attr().at("leakyrelu_alpha").f(), leakyrelu_alpha);
+          }
+          found++;
+        }
+      }
+      EXPECT_EQ(found, 1);
+
+      auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
+      ASSERT_EQ(tensors_expected.size(), 1);
+      auto tensors = EvaluateNodes(output, item.fetch, item.feed);
+      ASSERT_EQ(tensors.size(), 1);
+      if (DTYPE == DT_BFLOAT16)
+        test::ExpectClose(tensors[0], tensors_expected[0], 1e-2, 1e-2);
+      else
+        test::ExpectClose(tensors[0], tensors_expected[0], 1e-6);
+    }
   }
 };
 


### PR DESCRIPTION
This PR fixes a bug in grappler remapper fusion (Pad + Conv3D + BiasAdd + Activation). The fusion happens in two stages:

1. Conv3D + BiasAdd + Activation --> _FusedConv3D
2. Pad + _FusedConv3D --> _FusedConv3D

At the second stage, we need to copy all attributes from _FusedConv3D obtained from the first stage. However, currently it misses some of the attributes (for example, leaky-relu has leakyrelu_alpha attribute). This PR fixes this bug copying all the attributes from the first stage.