### PR TITLE
[tosa] Add legalization for TF/TFL conv3d

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
@@ -42,6 +42,35 @@ func.func @test_transpose_conv2d(%arg0: tensor<1x32x32x8xf32>, %arg1: tensor<1x1
 
 // -----
 
+// CHECK-LABEL: test_conv3d
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<2x4x128x128x8xf32>
+// CHECK-SAME: %[[VAL_1:.*]]: tensor<2x3x3x2x4xf32>
+// CHECK-DAG: %[[VAL_2:.*]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<4xf32>}
+// CHECK-DAG: %[[VAL_3:.*]] = "tosa.const"() {value = dense<[4, 0, 1, 2, 3]> : tensor<5xi32>}
+// CHECK: %[[VAL_4:.*]] = "tosa.transpose"(%[[VAL_1]], %[[VAL_3]])
+// CHECK: %[[VAL_5:.*]] = "tosa.conv3d"(%[[VAL_0]], %[[VAL_4]], %[[VAL_2]]) {dilation = [1, 1, 1], pad = [0, 1, 0, 1, 0, 1], stride = [1, 2, 2]}
+func.func @test_conv3d(%arg0: tensor<2x4x128x128x8xf32>, %arg1: tensor<2x3x3x2x4xf32>) -> tensor<2x4x64x64x4xf32> {
+  %0 = "tf.Conv3D"(%arg0, %arg1) {data_format = "NDHWC", device = "", dilations = [1, 1, 1, 1, 1], padding = "SAME", strides = [1, 1, 2, 2, 1]} : (tensor<2x4x128x128x8xf32>, tensor<2x3x3x2x4xf32>) -> tensor<2x4x64x64x4xf32>
+  return %0 : tensor<2x4x64x64x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_conv3d_bias
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<3x32x16x16x5xf32>
+// CHECK-SAME: %[[VAL_1:.*]]: tensor<2x3x3x5x10xf32>
+// CHECK-SAME: %[[VAL_2:.*]]: tensor<10xf32>) -> tensor<3x32x16x16x10xf32>
+// CHECK-DAG: %[[VAL_3:.*]] = "tosa.const"() {value = dense<[4, 0, 1, 2, 3]> : tensor<5xi32>}
+// CHECK: %[[VAL_4:.*]] = "tosa.transpose"(%[[VAL_1]], %[[VAL_3]])
+// CHECK: %[[VAL_5:.*]] = "tosa.conv3d"(%[[VAL_0]], %[[VAL_4]], %[[VAL_2]]) {dilation = [1, 1, 1], pad = [0, 1, 1, 1, 1, 1], stride = [1, 1, 1]}
+func.func @test_conv3d_bias(%arg0: tensor<3x32x16x16x5xf32>, %arg1: tensor<2x3x3x5x10xf32>, %bias: tensor<10xf32>) -> tensor<3x32x16x16x10xf32> {
+  %0 = "tf.Conv3D"(%arg0, %arg1) {data_format = "NDHWC", device = "", dilations = [1, 1, 1, 1, 1], padding = "SAME", strides = [1, 1, 1, 1, 1]} : (tensor<3x32x16x16x5xf32>, tensor<2x3x3x5x10xf32>) -> tensor<3x32x16x16x10xf32>
+  %1 = "tf.BiasAdd"(%0, %bias) {data_format = "NHWC", device = ""} : (tensor<3x32x16x16x10xf32>, tensor<10xf32>) -> tensor<3x32x16x16x10xf32>
+  return %1 : tensor<3x32x16x16x10xf32>
+}
+
+// -----
+
 // CHECK-LABEL: test_add
 // CHECK: %[[VAR0:.*]] = "tosa.add"(%arg0, %arg1)
 func.func @test_add(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x3xf32>) -> tensor<*xf32> {

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -111,6 +111,77 @@ func.func @test_depthwise_conv2d_bias_inferred(%arg0: tensor<?x32x32x8xf32>, %ar
 
 // -----
 
+// CHECK-LABEL: test_conv3d
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<2x2x7x7x2xf32>
+// CHECK-SAME: %[[VAL_1:.*]]: tensor<2x3x3x2x4xf32>
+// CHECK-DAG: %[[VAL_2:.*]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<4xf32>}
+// CHECK-DAG: %[[VAL_3:.*]] = "tosa.const"() {value = dense<[4, 0, 1, 2, 3]> : tensor<5xi32>}
+// CHECK: %[[VAL_4:.*]] = "tosa.transpose"(%[[VAL_1]], %[[VAL_3]])
+// CHECK: %[[VAL_5:.*]] = "tosa.conv3d"(%[[VAL_0]], %[[VAL_4]], %[[VAL_2]]) {dilation = [1, 1, 1], pad = [0, 1, 1, 1, 1, 1], stride = [1, 1, 1]}
+func.func @test_conv3d(%arg0: tensor<2x2x7x7x2xf32>, %arg1: tensor<2x3x3x2x4xf32>) -> tensor<2x2x7x7x4xf32> {
+  %cst = "tfl.no_value"() {value} : () -> none
+  %0 = "tfl.conv_3d"(%arg0, %arg1, %cst) {dilation_d_factor = 1 : i32, dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_d = 1 : i32, stride_h = 1 : i32, stride_w = 1 : i32} : (tensor<2x2x7x7x2xf32>, tensor<2x3x3x2x4xf32>, none) -> tensor<2x2x7x7x4xf32>
+  func.return %0 : tensor<2x2x7x7x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_conv3d_dynamic
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<?x11x32x32x8xf32>
+// CHECK-SAME: %[[VAL_1:.*]]: tensor<3x1x1x8x16xf32>
+// CHECK-DAG: %[[VAL_2:.*]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<16xf32>}
+// CHECK-DAG: %[[VAL_3:.*]] = "tosa.const"() {value = dense<[4, 0, 1, 2, 3]> : tensor<5xi32>}
+// CHECK: %[[VAL_4:.*]] = "tosa.transpose"(%[[VAL_1]], %[[VAL_3]])
+// CHECK: %[[VAL_5:.*]] = "tosa.conv3d"(%[[VAL_0]], %[[VAL_4]], %[[VAL_2]]) {dilation = [1, 1, 1], pad = [1, 1, 0, 0, 0, 0], stride = [1, 1, 1]}
+func.func @test_conv3d_dynamic(%arg0: tensor<?x11x32x32x8xf32>, %arg1: tensor<3x1x1x8x16xf32>) -> tensor<*xf32> {
+  %cst = "tfl.no_value"() {value} : () -> none
+  %0 = "tfl.conv_3d"(%arg0, %arg1, %cst) {dilation_d_factor = 1 : i32, dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_d = 1 : i32, stride_h = 1 : i32, stride_w = 1 : i32} : (tensor<?x11x32x32x8xf32>, tensor<3x1x1x8x16xf32>, none) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_conv3d_bias
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<10x3x64x64x12xf32>
+// CHECK-SAME: %[[VAL_1:.*]]: tensor<16x2x2x12x8xf32>
+// CHECK-SAME: %[[VAL_2:.*]]: tensor<8xf32>
+// CHECK-DAG: %[[VAL_3:.*]] = "tosa.const"() {value = dense<[4, 0, 1, 2, 3]>
+// CHECK: %[[VAL_4:.*]] = "tosa.transpose"(%[[VAL_1]], %[[VAL_3]])
+// CHECK: %[[VAL_5:.*]] = "tosa.conv3d"(%[[VAL_0]], %[[VAL_4]], %[[VAL_2]]) {dilation = [1, 1, 1], pad = [7, 8, 0, 1, 0, 1], stride = [1, 1, 1]}
+func.func @test_conv3d_bias(%arg0: tensor<10x3x64x64x12xf32>, %arg1: tensor<16x2x2x12x8xf32>, %cst: tensor<8xf32>) -> tensor<10x3x64x64x8xf32> {
+  %0 = "tfl.conv_3d"(%arg0, %arg1, %cst) {dilation_d_factor = 1 : i32, dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_d = 1 : i32, stride_h = 1 : i32, stride_w = 1 : i32} : (tensor<10x3x64x64x12xf32>, tensor<16x2x2x12x8xf32>, tensor<8xf32>) -> tensor<10x3x64x64x8xf32>
+  func.return %0 : tensor<10x3x64x64x8xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_conv3d_qi8(
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<1x4x8x21x17x!quant.uniform<i8:f32, 0.015686264261603355>>
+// CHECK-SAME: %[[VAL_1:.*]]: tensor<2x3x3x17x34xf32>) -> tensor<1x4x8x11x34x!quant.uniform<i8:f32, 0.8929935097694397:-4>>
+// CHECK-DAG: %[[VAL_2:.*]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<1x1x1x1x1xf32>}
+// CHECK-DAG: %[[VAL_3:.*]] = "tosa.const"() {value = dense<0.0156862643> : tensor<1x1x1x1x1xf32>}
+// CHECK-DAG: %[[VAL_4:.*]] = "tosa.const"() {value = dense<1.11982894> : tensor<1x1x1x1x1xf32>}
+// CHECK-DAG: %[[VAL_5:.*]] = "tosa.const"() {value = dense<-4.000000e+00> : tensor<1x1x1x1x1xf32>}
+// CHECK-DAG: %[[VAL_6:.*]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<34xf32>}
+// CHECK-DAG: %[[VAL_7:.*]] = "tosa.const"() {value = dense<[4, 0, 1, 2, 3]> : tensor<5xi32>}
+// CHECK: %[[VAL_8:.*]] = "tosa.cast"(%[[VAL_0]])
+// CHECK: %[[VAL_9:.*]] = "tosa.sub"(%[[VAL_8]], %[[VAL_2]])
+// CHECK: %[[VAL_10:.*]] = "tosa.mul"(%[[VAL_9]], %[[VAL_3]]) {shift = 0 : i32}
+// CHECK: %[[VAL_11:.*]] = "tosa.transpose"(%[[VAL_1]], %[[VAL_7]])
+// CHECK: %[[VAL_12:.*]] = "tosa.conv3d"(%[[VAL_10]], %[[VAL_11]], %[[VAL_6]]) {dilation = [1, 1, 1], pad = [0, 1, 1, 1, 1, 1], stride = [1, 1, 2]}
+// CHECK: %[[VAL_13:.*]] = "tosa.mul"(%[[VAL_12]], %[[VAL_4]]) {shift = 0 : i32}
+// CHECK: %[[VAL_14:.*]] = "tosa.add"(%[[VAL_13]], %[[VAL_5]])
+// CHECK: %[[VAL_15:.*]] = "tosa.cast"(%[[VAL_14]])
+func.func @test_conv3d_qi8(%arg0: tensor<1x4x8x21x17x!quant.uniform<i8:f32, 0.015686264261603355>>, %arg1: tensor<2x3x3x17x34xf32>) -> (tensor<1x4x8x11x34x!quant.uniform<i8:f32, 0.8929935097694397:-4>>) {
+  %0 = "tfl.dequantize"(%arg0) : (tensor<1x4x8x21x17x!quant.uniform<i8:f32, 0.015686264261603355>>) -> tensor<1x4x8x21x17xf32>
+  %2 = "tfl.no_value"() {value} : () -> none
+  %3 = "tfl.conv_3d"(%0, %arg1, %2) {dilation_d_factor = 1 : i32, dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_d = 1 : i32, stride_h = 1 : i32, stride_w = 2 : i32} : (tensor<1x4x8x21x17xf32>, tensor<2x3x3x17x34xf32>, none) -> tensor<1x4x8x11x34xf32>
+  %4 = "tfl.quantize"(%3) {qtype = tensor<1x4x8x11x34x!quant.uniform<i8:f32, 0.8929935097694397:-4>>} : (tensor<1x4x8x11x34xf32>) -> tensor<1x4x8x11x34x!quant.uniform<i8:f32, 0.8929935097694397:-4>>
+  return %4 : tensor<1x4x8x11x34x!quant.uniform<i8:f32, 0.8929935097694397:-4>>
+}
+
+// -----
+
 // CHECK-LABEL: test_add
 // CHECK: %[[VAR0:.*]] = "tosa.add"(%arg0, %arg1)
 func.func @test_add(%arg0: tensor<13x21x1xf32>, %arg1: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {

--- a/tensorflow/compiler/mlir/tosa/transforms/fuse_bias_tf.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/fuse_bias_tf.cc
@@ -21,10 +21,10 @@ limitations under the License.
 #include <iterator>
 #include <numeric>
 
-#include "mlir/Dialect/Tosa/IR/TosaOps.h"  // from @llvm-project
-#include "mlir/IR/MLIRContext.h"  // from @llvm-project
-#include "mlir/Pass/Pass.h"  // from @llvm-project
-#include "mlir/Support/LogicalResult.h"  // from @llvm-project
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"                // from @llvm-project
+#include "mlir/IR/MLIRContext.h"                         // from @llvm-project
+#include "mlir/Pass/Pass.h"                              // from @llvm-project
+#include "mlir/Support/LogicalResult.h"                  // from @llvm-project
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
 #include "tensorflow/compiler/mlir/lite/quantization/ir/QuantOps.h"
 #include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops.h"
@@ -54,7 +54,7 @@ struct ConvertTFBiasAddOp : public RewritePattern {
                                 PatternRewriter& rewriter) const override;
 };
 
-// Replaces the following pattern:
+// Replaces the following pattern, take conv2d as an example:
 //   %1 = tf.Conv2D (%ifm, %filter)
 //   %2 = tf.BiasAdd(%1, %bias)
 //   with
@@ -68,46 +68,70 @@ struct ConvertTFBiasAddOp : public RewritePattern {
 LogicalResult ConvertTFBiasAddOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tf_biasadd_op = cast<TF::BiasAddOp>(op);
-
   auto output_type =
       tf_biasadd_op.getResult().getType().dyn_cast<RankedTensorType>();
-  // Not a ranked tensor output
-  if (!output_type) return failure();
+
+  if (!output_type) {
+    return rewriter.notifyMatchFailure(op, "output not a ranked tensor");
+  }
 
   auto value = tf_biasadd_op.value();
   auto bias = tf_biasadd_op.bias();
-
-  TF::Conv2DOp tf_conv2d_op =
-      dyn_cast_or_null<TF::Conv2DOp>(value.getDefiningOp());
-
-  if (!tf_conv2d_op) {
-    return failure();
+  auto bias_shape = bias.getType().cast<RankedTensorType>().getShape();
+  if (bias_shape.size() != 1) {
+    return rewriter.notifyMatchFailure(op, "bias tensor must be rank 1");
   }
 
-  // Sanity check to confirm rhs() has the expected shape of bias
-  auto filter_shape =
-      tf_conv2d_op.filter().getType().dyn_cast<RankedTensorType>().getShape();
+  if (TF::Conv2DOp tf_conv2d_op =
+          llvm::dyn_cast_if_present<TF::Conv2DOp>(value.getDefiningOp())) {
+    // Sanity check to confirm rhs() has the expected shape of bias
+    auto filter_shape =
+        tf_conv2d_op.filter().getType().cast<RankedTensorType>().getShape();
 
-  auto bias_shape = bias.getType().dyn_cast<RankedTensorType>().getShape();
+    // Assume the filter shape is [H, W, I, O]
+    if (filter_shape.back() != bias_shape.back()) {
+      return rewriter.notifyMatchFailure(
+          op, "bias dimension must match filter output channels");
+    }
 
-  // Bias dimension must match filter output channels, where tf.conv2d's filter
-  // is [H, W, I, O]
-  if (filter_shape.back() != bias_shape.back()) return failure();
+    auto result = convertTFConv2DCommon(
+        rewriter, op, output_type, tf_conv2d_op.input(), tf_conv2d_op.filter(),
+        bias, tf_conv2d_op.strides(), tf_conv2d_op.dilations(),
+        tf_conv2d_op.explicit_paddings(), tf_conv2d_op.padding(),
+        tf_conv2d_op.data_format());
 
-  // Bias tensor that feeds into tosa.conv2d must be rank 1
-  if (bias_shape.size() != 1) return failure();
+    if (!result) return failure();
 
-  auto result = convertTFConv2DCommon(
-      rewriter, op, output_type, tf_conv2d_op.input(), tf_conv2d_op.filter(),
-      bias, tf_conv2d_op.strides(), tf_conv2d_op.dilations(),
-      tf_conv2d_op.explicit_paddings(), tf_conv2d_op.padding(),
-      tf_conv2d_op.data_format());
+    rewriter.replaceOp(op, {result.value()});
 
-  if (!result) return failure();
+    return success();
+  }
 
-  rewriter.replaceOp(op, {result.getValue()});
+  if (TF::Conv3DOp tf_conv3d_op =
+          llvm::dyn_cast_if_present<TF::Conv3DOp>(value.getDefiningOp())) {
+    // Sanity check to confirm rhs() has the expected shape of bias
+    auto filter_shape =
+        tf_conv3d_op.filter().getType().cast<RankedTensorType>().getShape();
 
-  return success();
+    // Assume the filter shape is [D, H, W, I, O]
+    if (filter_shape.back() != bias_shape.back()) {
+      return rewriter.notifyMatchFailure(
+          op, "bias dimension must match filter output channels");
+    }
+
+    llvm::Optional<Value> result = convertTFConv3DCommon(
+        rewriter, op, output_type, tf_conv3d_op.input(), tf_conv3d_op.filter(),
+        bias, tf_conv3d_op.strides(), tf_conv3d_op.dilations(),
+        tf_conv3d_op.padding(), tf_conv3d_op.data_format());
+
+    if (!result) return failure();
+
+    rewriter.replaceOp(op, {result.value()});
+
+    return success();
+  }
+
+  return failure();
 }
 
 void FuseBiasTF::runOnOperation() {

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
@@ -3491,6 +3491,105 @@ llvm::Optional<Value> convertTFConv2DCommon(
       .getResult();
 }
 
+llvm::Optional<Value> convertConv3DCommon(PatternRewriter& rewriter,
+                                          Operation* op, ShapedType output_type,
+                                          Value input, Value filter, Value bias,
+                                          ArrayRef<int64_t> strides, ArrayRef<int64_t> dilations,
+                                          StringRef padding_ref,
+                                          StringRef data_format_ref) {
+  if (data_format_ref.str() != "NDHWC") {
+    (void)rewriter.notifyMatchFailure(op, "currently only supports NDHWC");
+    return llvm::None;
+  }
+
+  tensorflow::Padding tf_pad;
+  if (!GetPaddingFromString(padding_ref.str(), &tf_pad).ok()) {
+    (void)rewriter.notifyMatchFailure(
+        op, "could not get padding data from padding string term");
+    return llvm::None;
+  }
+
+  // Since NDHWC/NCDHW aren't presented in TensorFormat, here these are
+  // represented by mapping NDHWC to NHWC, and NCDHW to NCHW, with the knowledge
+  // of rank of input tensor.
+  tensorflow::TensorFormat data_format_tf;
+  if (!FormatFromString("NHWC", &data_format_tf)) return llvm::None;
+
+  if (tf_pad == tensorflow::Padding::EXPLICIT) {
+    (void)rewriter.notifyMatchFailure(op, "doesn't support explicit padding");
+    return llvm::None;
+  }
+
+  ArrayAttr strides_attr = rewriter.getI64ArrayAttr(strides);
+  ArrayAttr dilations_attr = rewriter.getI64ArrayAttr(dilations);
+  RankedTensorType input_type = input.getType().cast<RankedTensorType>();
+  RankedTensorType filter_type = filter.getType().cast<RankedTensorType>();
+
+  ArrayAttr pads_attr;
+  if (!getPaddingValuesFromPadType(tf_pad, data_format_tf, 0, input_type,
+                                   filter_type, strides_attr, dilations_attr, rewriter,
+                                   pads_attr)) {
+    (void)rewriter.notifyMatchFailure(op, "can't get padding values from type");
+    return llvm::None;
+  }
+
+  // Note that the kernel shape of tfl.conv_3d isn't [O, D, H, W, I] but
+  // [D, H, W, I, O] which is the same as in TF.
+  // Transpose filter shape from [D, H, W, I, O] to [O, D, H, W, C]
+  auto filter_shape = filter_type.getShape();
+  SmallVector<int64_t, 5> a1_transpose_dims;
+  a1_transpose_dims.push_back(filter_shape[4]);
+  a1_transpose_dims.push_back(filter_shape[0]);
+  a1_transpose_dims.push_back(filter_shape[1]);
+  a1_transpose_dims.push_back(filter_shape[2]);
+  a1_transpose_dims.push_back(filter_shape[3]);
+  llvm::Optional<Value> a1_filter_transpose_perm = getConstTensor<int32_t>(
+      rewriter, op, /*vec=*/{4, 0, 1, 2, 3}, /*shape=*/{5});
+
+  if (!a1_filter_transpose_perm) return llvm::None;
+
+  auto a1_filter_transpose_op = CreateOpAndInfer<tosa::TransposeOp>(
+      rewriter, op->getLoc(),
+      RankedTensorType::get(a1_transpose_dims, filter_type.getElementType()),
+      filter, a1_filter_transpose_perm.value());
+
+  return CreateOpAndInfer<tosa::Conv3DOp>(
+             rewriter, op->getLoc(), output_type, input,
+             a1_filter_transpose_op.getResult(), bias, pads_attr, strides_attr, dilations_attr)
+      .getResult();
+}
+
+llvm::Optional<Value> convertTFConv3DCommon(
+    PatternRewriter& rewriter, Operation* op, ShapedType output_type,
+    Value input, Value filter, Value bias, ArrayAttr strides_attr,
+    ArrayAttr dilations_attr, StringRef padding_ref,
+    StringRef data_format_ref) {
+  SmallVector<int64_t, 3> strides;
+  if (!strides_attr) {
+    // Defaults to [1, 1, 1].
+    strides = {1, 1, 1};
+  } else {
+    int64_t stride_d = strides_attr[1].cast<IntegerAttr>().getInt();
+    int64_t stride_h = strides_attr[2].cast<IntegerAttr>().getInt();
+    int64_t stride_w = strides_attr[3].cast<IntegerAttr>().getInt();
+    strides = {stride_d, stride_h, stride_w};
+  }
+
+  SmallVector<int64_t, 3> dilations;
+  if (!dilations_attr) {
+    // Defaults to [1, 1, 1].
+    dilations = {1, 1, 1};
+  } else {
+    int64_t dilation_d = dilations_attr[1].cast<IntegerAttr>().getInt();
+    int64_t dilation_h = dilations_attr[2].cast<IntegerAttr>().getInt();
+    int64_t dilation_w = dilations_attr[3].cast<IntegerAttr>().getInt();
+    dilations = {dilation_d, dilation_h, dilation_w};
+  }
+
+  return convertConv3DCommon(rewriter, op, output_type, input, filter, bias,
+                             strides, dilations, padding_ref, data_format_ref);
+}
+
 // Lowers Gather operators to a sequence of TOSA ops.
 llvm::Optional<Value> convertGatherOp(PatternRewriter& rewriter, Operation* op,
                                       Value result_value, Value params_value,

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.h
@@ -17,7 +17,7 @@ limitations under the License.
 #define TENSORFLOW_COMPILER_MLIR_TOSA_TRANSFORMS_LEGALIZE_COMMON_H_
 
 #include "mlir/IR/PatternMatch.h"  // from @llvm-project
-#include "mlir/Support/LLVM.h"  // from @llvm-project
+#include "mlir/Support/LLVM.h"     // from @llvm-project
 
 // This file contains legalizations common to mapping both TensorFlow and
 // TensorFlow Lite to TOSA.
@@ -250,6 +250,20 @@ llvm::Optional<Value> convertTFConv2DCommon(
     Value input, Value filter, Value bias, ArrayAttr strides_attr,
     ArrayAttr dilations_attr, ArrayAttr explicit_padding_attr,
     StringRef padding_ref, StringRef data_format_ref);
+
+// Lowers TensorFlow and TensorFlow Lite Conv3D to a sequence of TOSA
+// quantization ops.
+llvm::Optional<Value> convertConv3DCommon(
+    PatternRewriter& rewriter, Operation* op, ShapedType output_type,
+    Value input, Value filter, Value bias, ArrayRef<int64_t> strides,
+    ArrayRef<int64_t> dilations, StringRef padding_ref, StringRef data_format_ref);
+
+// Preprocess TensorFlow Conv3D attributes prior to calling
+// `convertConv3DCommon`
+llvm::Optional<Value> convertTFConv3DCommon(
+    PatternRewriter& rewriter, Operation* op, ShapedType output_type,
+    Value input, Value filter, Value bias, ArrayAttr strides_attr,
+    ArrayAttr dilations_attr, StringRef padding_ref, StringRef data_format_ref);
 
 // Lowers Gather operator to a sequence of TOSA ops.
 llvm::Optional<Value> convertGatherOp(PatternRewriter& rewriter, Operation* op,

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
@@ -21,9 +21,9 @@ limitations under the License.
 #include <iterator>
 #include <numeric>
 
-#include "mlir/Dialect/Quant/QuantOps.h"  // from @llvm-project
-#include "mlir/Dialect/Tosa/IR/TosaOps.h"  // from @llvm-project
-#include "mlir/Support/LLVM.h"  // from @llvm-project
+#include "mlir/Dialect/Quant/QuantOps.h"                 // from @llvm-project
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"                // from @llvm-project
+#include "mlir/Support/LLVM.h"                           // from @llvm-project
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"  // from @llvm-project
 #include "tensorflow/compiler/mlir/lite/quantization/ir/QuantOps.h"
 #include "tensorflow/compiler/mlir/tensorflow/ir/tf_ops.h"
@@ -93,6 +93,7 @@ DECL_CONVERT_OP(ExpandDims);
 DECL_CONVERT_OP(Squeeze);
 DECL_CONVERT_OP(Fill);
 DECL_CONVERT_OP(Conv2D);
+DECL_CONVERT_OP(Conv3D);
 DECL_CONVERT_OP(DepthwiseConv2dNative);
 DECL_CONVERT_OP(Conv2DBackpropInput);
 DECL_CONVERT_OP(Elu);
@@ -844,6 +845,40 @@ LogicalResult ConvertTFConv2DOp::matchAndRewrite(
   if (!result) return failure();
 
   rewriter.replaceOp(op, {result.getValue()});
+
+  return success();
+}
+
+LogicalResult ConvertTFConv3DOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  auto tf_conv3d_op = cast<TF::Conv3DOp>(op);
+
+  RankedTensorType filter_type =
+      tf_conv3d_op.filter().getType().dyn_cast<RankedTensorType>();
+  RankedTensorType output_type =
+      tf_conv3d_op.getResult().getType().dyn_cast<RankedTensorType>();
+
+  if (!filter_type || !output_type) {
+    return rewriter.notifyMatchFailure(
+        op, "filter/output are not all a ranked tensor");
+  }
+
+  // Set up a zero attr for subsequent pattern replacement if required
+  auto bias_dim = filter_type.getShape().back();
+  RankedTensorType bias_type =
+      RankedTensorType::get({bias_dim}, filter_type.getElementType());
+  auto bias_attr = rewriter.getZeroAttr(bias_type);
+  auto bias = CreateOpAndInfer<tosa::ConstOp>(rewriter, op->getLoc(), bias_type,
+                                              bias_attr.cast<ElementsAttr>());
+
+  llvm::Optional<Value> result = convertTFConv3DCommon(
+      rewriter, op, output_type, tf_conv3d_op.input(), tf_conv3d_op.filter(),
+      bias, tf_conv3d_op.strides(), tf_conv3d_op.dilations(),
+      tf_conv3d_op.padding(), tf_conv3d_op.data_format());
+
+  if (!result) return failure();
+
+  rewriter.replaceOp(op, {result.value()});
 
   return success();
 }
@@ -2320,6 +2355,7 @@ void populateLegalizeTFPatterns(MLIRContext* ctx, RewritePatternSet& patterns) {
   patterns.add<ConvertTFSqueezeOp>(ctx);
   patterns.add<ConvertTFFillOp>(ctx);
   patterns.add<ConvertTFConv2DOp>(ctx);
+  patterns.add<ConvertTFConv3DOp>(ctx);
   patterns.add<ConvertTFDepthwiseConv2dNativeOp>(ctx);
   patterns.add<ConvertTFConv2DBackpropInputOp>(ctx);
   patterns.add<ConvertTFEluOp>(ctx);

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -27,14 +27,14 @@ limitations under the License.
 #include <unordered_set>
 
 #include "llvm/ADT/ArrayRef.h"
-#include "mlir/Dialect/Quant/QuantTypes.h"  // from @llvm-project
-#include "mlir/Dialect/Tosa/IR/TosaOps.h"  // from @llvm-project
-#include "mlir/Dialect/Traits.h"  // from @llvm-project
-#include "mlir/IR/BuiltinAttributes.h"  // from @llvm-project
-#include "mlir/IR/BuiltinTypes.h"  // from @llvm-project
-#include "mlir/IR/Matchers.h"  // from @llvm-project
-#include "mlir/IR/PatternMatch.h"  // from @llvm-project
-#include "mlir/Support/LLVM.h"  // from @llvm-project
+#include "mlir/Dialect/Quant/QuantTypes.h"      // from @llvm-project
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"       // from @llvm-project
+#include "mlir/Dialect/Traits.h"                // from @llvm-project
+#include "mlir/IR/BuiltinAttributes.h"          // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"               // from @llvm-project
+#include "mlir/IR/Matchers.h"                   // from @llvm-project
+#include "mlir/IR/PatternMatch.h"               // from @llvm-project
+#include "mlir/Support/LLVM.h"                  // from @llvm-project
 #include "mlir/Transforms/DialectConversion.h"  // from @llvm-project
 #include "tensorflow/compiler/mlir/lite/ir/tfl_ops.h"
 #include "tensorflow/compiler/mlir/lite/quantization/ir/QuantOps.h"
@@ -129,6 +129,7 @@ DECL_CONVERT_OP(Mean);
 DECL_CONVERT_OP(ReduceProd);
 DECL_CONVERT_OP(Sum);
 DECL_CONVERT_OP(Conv2D);
+DECL_CONVERT_OP(Conv3D);
 DECL_CONVERT_OP(TransposeConv);
 DECL_CONVERT_OP(DepthwiseConv2D);
 DECL_CONVERT_OP(FullyConnected);
@@ -1191,6 +1192,84 @@ LogicalResult ConvertTFLConv2DOp::matchAndRewrite(
   }
 
   rewriter.replaceOp(op, {conv2d_output});
+
+  return success();
+}
+
+LogicalResult ConvertTFLConv3DOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  auto tfl_conv3d_op = cast<TFL::Conv3DOp>(op);
+  RankedTensorType input_type =
+      tfl_conv3d_op.input().getType().dyn_cast<RankedTensorType>();
+  RankedTensorType filter_type =
+      tfl_conv3d_op.filter().getType().dyn_cast<RankedTensorType>();
+  ShapedType output_type =
+      tfl_conv3d_op.getResult().getType().dyn_cast<ShapedType>();
+
+  if (!input_type | !filter_type || !output_type) {
+    return rewriter.notifyMatchFailure(
+        op, "input/filter/output are not all a ranked tensor");
+  }
+
+  bool input_is_qtype =
+      input_type.getElementType().isa<mlir::quant::QuantizedType>();
+  bool filter_is_qtype =
+      filter_type.getElementType().isa<mlir::quant::QuantizedType>();
+  bool output_is_qtype =
+      output_type.getElementType().isa<mlir::quant::QuantizedType>();
+
+  if ((input_is_qtype != filter_is_qtype) ||
+      (input_is_qtype != output_is_qtype)) {
+    return rewriter.notifyMatchFailure(op,
+                                       "input/filter/output tensor should be "
+                                       "all quantized or all floating-point");
+  }
+
+  Value unquantized_bias = tfl_conv3d_op.bias();
+  if (!unquantized_bias.getType().dyn_cast<RankedTensorType>()) {
+    // The bias may actually be typed "None" which has no value. TOSA requires
+    // bias to be an array of output_channel_count values, so create a constant
+    // of the appropriate number and type of zeros.
+    auto bias_dim = filter_type.getShape().back();
+    RankedTensorType bias_type =
+        RankedTensorType::get({bias_dim}, filter_type.getElementType());
+    auto bias_attr = rewriter.getZeroAttr(bias_type);
+    unquantized_bias = CreateOpAndInfer<tosa::ConstOp>(
+        rewriter, op->getLoc(), bias_type, bias_attr.cast<ElementsAttr>());
+  }
+
+  SmallVector<int64_t, 3> strides({tfl_conv3d_op.stride_d(),
+                                   tfl_conv3d_op.stride_h(),
+                                   tfl_conv3d_op.stride_w()});
+  SmallVector<int64_t, 3> dilations({tfl_conv3d_op.dilation_d_factor(),
+                                     tfl_conv3d_op.dilation_h_factor(),
+                                     tfl_conv3d_op.dilation_w_factor()});
+  Type bias_ety =
+      unquantized_bias.getType().cast<ShapedType>().getElementType();
+  llvm::Optional<Value> a1_conv3d_op = convertConv3DCommon(
+      rewriter, op, output_type.clone(bias_ety), tfl_conv3d_op.input(),
+      tfl_conv3d_op.filter(), unquantized_bias, strides, dilations,
+      tfl_conv3d_op.padding().str(), StringRef("NDHWC"));
+
+  if (!a1_conv3d_op) return failure();
+
+  Value conv3d_output =
+      input_is_qtype
+          ? buildRescaleOpConvOutput(rewriter, op, a1_conv3d_op.getValue(),
+                                     input_type, filter_type, output_type)
+          : a1_conv3d_op.getValue();
+
+  if (auto fused_activation_fn = tfl_conv3d_op.fused_activation_functionAttr()) {
+    llvm::Optional<Value> fused_activation_val = convertFusedActivation(
+        rewriter, op, conv3d_output, fused_activation_fn);
+
+    if (!fused_activation_val) return failure();
+
+    rewriter.replaceOp(op, {fused_activation_val.value()});
+    return success();
+  }
+
+  rewriter.replaceOp(op, {conv3d_output});
 
   return success();
 }
@@ -3532,6 +3611,7 @@ void populateLegalizeTFLPatterns(MLIRContext* ctx,
   DEF_PATTERN_INSERT(TFLReduceProd);
   DEF_PATTERN_INSERT(TFLSum);
   DEF_PATTERN_INSERT(TFLConv2D);
+  DEF_PATTERN_INSERT(TFLConv3D);
   DEF_PATTERN_INSERT(TFLTransposeConv);
   DEF_PATTERN_INSERT(TFLDepthwiseConv2D);
   DEF_PATTERN_INSERT(TFLFullyConnected);


### PR DESCRIPTION
TFL doesn't have quantized implementation support for conv3d at the moment, only floating is supported in this patch.
