### PR TITLE
[mhlo] fix segfault from dereferencing a non-existent value

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_to_linalg.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/transforms/legalize_to_linalg.cc
@@ -2031,7 +2031,7 @@ struct ConvolutionOpGeneralConversion
 
     // Decompose the reversal dims into its own step
     auto reversals = op.window_reversal();
-    if (reversals.value()) {
+    if (reversals.has_value()) {
       llvm::SmallVector<int64_t> reversedDims;
       for (auto& idxAndBool :
            llvm::enumerate(reversals.value().getValues<bool>()))
@@ -2206,7 +2206,7 @@ struct ConvolutionOpGeneralConversion
       auto dim1 = mlir::getAffineDimExpr(nextDim++, ctx);
 
       auto stride = dim0;
-      if (op.window_strides().value())
+      if (op.window_strides().has_value())
         stride = stride * op.window_strides().value().getValues<int64_t>()[i];
       AffineExpr srcExpr = stride + dim1;
 

--- a/tensorflow/compiler/xla/mlir_hlo/tests/Dialect/mhlo/hlo-legalize-to-linalg.mlir
+++ b/tensorflow/compiler/xla/mlir_hlo/tests/Dialect/mhlo/hlo-legalize-to-linalg.mlir
@@ -4962,3 +4962,24 @@ func.func @feature_group_count_convolution(%arg0: tensor<2x14x12x2xf64>, %arg1: 
     : (tensor<2x14x12x2xf64>, tensor<7x7x1x2xf64>) -> tensor<2x6x8x2xf64>
   return %0 : tensor<2x6x8x2xf64>
 }
+
+// -----
+// The following test is identical to the previous one, except that the
+// `mhlo.convolution` op lacks the (optional) `window_stride` and
+// `window_reverse` attributes. The goal of this test is to make sure that the
+// compiler does not segfault, so we simply check for the existence of the
+// function in the output IR.
+
+// CHECK-LABEL: @convolution_without_reversing_and_stride
+// CHECK-SAME: %[[ARG0:.*]]: tensor<2x14x12x2xf64>
+// CHECK-SAME: %[[ARG1:.*]]: tensor<7x7x1x2xf64>)
+// CHECK-SAME -> tensor<2x12x16x2xf64>
+
+func.func @convolution_without_reversing_and_stride(%arg0: tensor<2x14x12x2xf64>, %arg1: tensor<7x7x1x2xf64>) -> tensor<2x12x16x2xf64> {
+  %0 = mhlo.convolution(%arg0, %arg1)
+    dim_numbers = [b, 1, 0, f]x[0, 1, i, o]->[b, 0, 1, f],
+    window = {pad = [[1, 0], [0, 1]], lhs_dilate = [2, 2], rhs_dilate = [2, 2]}
+    {batch_group_count = 1 : i64, feature_group_count = 2 : i64, precision_config = [#mhlo<precision HIGHEST>, #mhlo<precision HIGHEST>]}
+    : (tensor<2x14x12x2xf64>, tensor<7x7x1x2xf64>) -> tensor<2x12x16x2xf64>
+  return %0 : tensor<2x12x16x2xf64>
+}


### PR DESCRIPTION
This patch fixes a runtime segfault caused by calling `value()` on
optional types in the predicate of `if` statements.  This patch replaces
the predicates with `has_value()` so that dereferencing the values later
is safe.

Thanks to @fortianyou for diagnosing the problem!

cc: @burmako