### PR TITLE
Add index check to ValidateSparseTensor.

### DIFF
--- a/tensorflow/core/kernels/sparse_utils.cc
+++ b/tensorflow/core/kernels/sparse_utils.cc
@@ -144,8 +144,12 @@ bool ContainsEmptyRows(const std::vector<Tindices>& row_start_indices) {
   return false;
 }
 
-Status ValidateSparseTensor(const Tensor& indices, const Tensor& values,
-                            const Tensor& shape) {
+namespace {
+
+// Ensures indices, values, shape are all of the proper ranks and are
+// compatible.
+Status ValidateSparseTensorShape(const Tensor& indices, const Tensor& values,
+                                 const Tensor& shape) {
   // Indices must be a matrix, and values/shape must be a vector.
   if (!TensorShapeUtils::IsMatrix(indices.shape())) {
     return errors::InvalidArgument("Sparse indices must be rank 2 but is rank ",
@@ -175,6 +179,45 @@ Status ValidateSparseTensor(const Tensor& indices, const Tensor& values,
   return Status::OK();
 }
 
+// Ensures all sparse indices are within correct bounds.
+template <typename Tindices>
+Status ValidateSparseTensorIndices(const Tensor& indices, const Tensor& shape) {
+  // Ensure no index is out-of-bounds.
+  const auto indices_mat = indices.flat_inner_dims<Tindices>();
+  const auto shape_vec = shape.flat<Tindices>();
+  int64_t nnz = indices.dim_size(0);
+  int64_t ndims = indices.dim_size(1);
+
+  for (int64_t i = 0; i < nnz; ++i) {
+    for (int64_t dim = 0; dim < ndims; ++dim) {
+      const Tindices idx = indices_mat(i, dim);
+      if (TF_PREDICT_FALSE(idx < 0 || idx >= shape_vec(dim))) {
+        string index_str = strings::StrCat("indices[", i, ", :] = [");
+        for (int64_t dim = 0; dim < ndims; ++dim) {
+          strings::StrAppend(&index_str, indices_mat(i, dim),
+                             dim < ndims - 1 ? ", " : "]");
+        }
+        return errors::InvalidArgument("Sparse index tuple ", index_str,
+                                       " is out of bounds");
+      }
+    }
+  }
+
+  return Status::OK();
+}
+
+}  // namespace
+
+template <typename Tindices>
+Status ValidateSparseTensor(const Tensor& indices, const Tensor& values,
+                            const Tensor& shape, bool validate_indices) {
+  TF_RETURN_IF_ERROR(ValidateSparseTensorShape(indices, values, shape));
+  if (validate_indices) {
+    return ValidateSparseTensorIndices<Tindices>(indices, shape);
+  }
+  return Status::OK();
+}
+
 #define REGISTER_SPARSE_UTIL_FUNCTIONS(TypeIndex)                           \
   template TypeIndex FindNextDenseRowStartIndex<TypeIndex>(                 \
       const TypeIndex sparse_index_begin,                                   \
@@ -186,7 +229,10 @@ Status ValidateSparseTensor(const Tensor& indices, const Tensor& values,
       const std::vector<TypeIndex>& row_start_indices);                     \
   template std::vector<TypeIndex> ParseRowStartIndices<TypeIndex>(          \
       const tensorflow::Tensor& tensor,                                     \
-      const TypeIndex num_nonzero_entries_in_sparse_mat)
+      const TypeIndex num_nonzero_entries_in_sparse_mat);                   \
+  template Status ValidateSparseTensor<TypeIndex>(                          \
+      const Tensor& indices, const Tensor& values, const Tensor& shape,     \
+      bool validate_indices)
 
 REGISTER_SPARSE_UTIL_FUNCTIONS(int32);
 REGISTER_SPARSE_UTIL_FUNCTIONS(int64);

--- a/tensorflow/core/kernels/sparse_utils.h
+++ b/tensorflow/core/kernels/sparse_utils.h
@@ -66,9 +66,11 @@ template <typename Tindices>
 bool ContainsEmptyRows(const std::vector<Tindices>& row_start_indices);
 
 // Validates the three component tensors of a sparse tensor have the proper
-// shapes.
+// shapes.  If validate_indices is true, also checks that all indices are within
+// correct bounds (i.e. are safe to access).
+template <typename Tindices>
 Status ValidateSparseTensor(const Tensor& indices, const Tensor& values,
-                            const Tensor& shape);
+                            const Tensor& shape, bool validate_indices);
 
 }  // namespace sparse_utils
 }  // namespace tensorflow


### PR DESCRIPTION
The validation check now verifies all index entries are within correct bounds.
This is to prevent memory access errors.

PiperOrigin-RevId: 450695916