### PR TITLE
Update curl to 7.85.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -307,9 +307,10 @@ build:linux --copt="-Wno-extra"
 build:linux --copt="-Wno-deprecated"
 build:linux --copt="-Wno-deprecated-declarations"
 build:linux --copt="-Wno-ignored-attributes"
-build:linux --copt="-Wno-error=array-parameter"
-build:linux --copt="-Wno-error=stringop-overflow"
-build:linux --copt="-Wno-error=array-bounds"
+build:linux --copt="-Wno-unknown-warning"
+build:linux --copt="-Wno-array-parameter"
+build:linux --copt="-Wno-stringop-overflow"
+build:linux --copt="-Wno-array-bounds"
 
 # Add unused-result as an error on Linux.
 build:linux --copt="-Wunused-result"

--- a/.bazelrc
+++ b/.bazelrc
@@ -307,6 +307,9 @@ build:linux --copt="-Wno-extra"
 build:linux --copt="-Wno-deprecated"
 build:linux --copt="-Wno-deprecated-declarations"
 build:linux --copt="-Wno-ignored-attributes"
+build:linux --copt="-Wno-error=array-parameter"
+build:linux --copt="-Wno-error=stringop-overflow"
+build:linux --copt="-Wno-error=array-bounds"
 
 # Add unused-result as an error on Linux.
 build:linux --copt="-Wunused-result"

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -491,10 +491,10 @@ def _tf_repositories():
     tf_http_archive(
         name = "curl",
         build_file = "//third_party:curl.BUILD",
-        sha256 = "3c6893d38d054d4e378267166858698899e9d87258e8ff1419d020c395384535",
-        strip_prefix = "curl-7.84.0",
+        sha256 = "78a06f918bd5fde3c4573ef4f9806f56372b32ec1829c9ec474799eeee641c27",
+        strip_prefix = "curl-7.85.0",
         system_build_file = "//third_party/systemlibs:curl.BUILD",
-        urls = tf_mirror_urls("https://curl.haxx.se/download/curl-7.84.0.tar.gz"),
+        urls = tf_mirror_urls("https://curl.haxx.se/download/curl-7.85.0.tar.gz"),
     )
 
     # WARNING: make sure ncteisen@ and vpai@ are cc-ed on any CL to change the below rule


### PR DESCRIPTION

This PR updates curl to 7.85.0 (7.85.0 covers the following vulnerabilities):

CVE-2022-35252: control code in cookie denial of service

See https://curl.se/docs/security.html for details

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>