### PR TITLE
[TFTRT]: Remove shape optimization profile WAR for new TRT versions

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.cc
@@ -311,7 +311,9 @@ void TrtShapeOptimizationProfile::InitProfiles(
   if (input_partial_shapes.size() > 0) {
     for (OptimizationProfileConfig& prof : profiles_) {
       // TODO: Remove this when the bug is fixed.
-      FixShapeValueProfile(&prof, is_shape_tensor_);
+      #if !IS_TRT_VERSION_GE(8, 0, 0, 0)
+        FixShapeValueProfile(&prof, is_shape_tensor_);
+      #endif
       for (int i = 0; i < input_partial_shapes.size(); i++) {
         auto network_input = input_partial_shapes[i];
         EnforceCompatibility(&prof.min[i], network_input);

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_shape_optimization_profiles.h
@@ -271,8 +271,11 @@ class TrtShapeOptimizationProfile {
   // Whether the optimization profiles describe input that can be handled with
   // a static engine (only 1 profile with min=max).
   bool IsStaticCompatible() {
-    return strategy_ == ProfileStrategy::kOptimal && profiles_.size() == 1 &&
-           !HasShapeTensor();
+    return strategy_ == ProfileStrategy::kOptimal && profiles_.size() == 1
+    #if !IS_TRT_VERSION_GE(8, 0, 0, 0)
+      && !HasShapeTensor()
+    #endif
+    ;
     // TODO(tfeher): remove !HasShapeTensor() condition once the
     // FixShapeValueProfile workaround is turned off.
   }


### PR DESCRIPTION
In dynamic shape mode, if an input shape value tensor has min=opt=max profiles, then TRT 7 prunes this tensor from the network (since its value could be deduced from the profile). TF-TRT introduced `FixShapeValueProfile` to modify the profiles which prevented TRT from pruning these inputs.

This workaround is not necessary in TRT8, and actually can be harmful, because it can lead to inconsistent input profiles. Remove this WAR for newer versions of TRT.
