### PR TITLE
Fix compilation and linking of compiler/xla/runtime:custom_call_test

### DIFF
--- a/tensorflow/compiler/xla/runtime/BUILD
+++ b/tensorflow/compiler/xla/runtime/BUILD
@@ -198,6 +198,8 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
+        "@llvm-project//llvm:AArch64AsmParser",
+        "@llvm-project//llvm:AArch64CodeGen",
         "@llvm-project//llvm:ARMAsmParser",
         "@llvm-project//llvm:ARMCodeGen",
         "@llvm-project//llvm:Core",


### PR DESCRIPTION
Failure was
`ERROR: /home/builder/1/tensorflow_build/tensorflow-git/tensorflow/compiler/xla/runtime/BUILD:45:11: Compiling tensorflow/compiler/xla/runtime/async_runtime.cc failed: undeclared inclusion(s) in rule '//tensorflow/compiler/xla/runtime:async_runtime':
this rule is missing dependency declarations for the following files included by 'tensorflow/compiler/xla/runtime/async_runtime.cc':
  'external/com_google_absl/absl/status/status.h'
  'external/com_google_absl/absl/status/internal/status_internal.h'
Target //tensorflow/compiler/xla/runtime:custom_call_test failed to build
`
After fixing that it failed with
`ERROR: /home/builder/1/tensorflow_build/tensorflow-git/tensorflow/compiler/xla/runtime/BUILD:102:11: Linking tensorflow/compiler/xla/runtime/custom_call_test failed: (Exit 1): gcc failed: error executing command 
  (cd /home/builder/.cache/bazel/_bazel_builder/9dc2dbd69dc3512cedb530e1521082e7/execroot/org_tensorflow && \
  exec env - \
    LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib \
    PATH=/home/builder/.cache/bazelisk/downloads/bazelbuild/bazel-5.3.0-linux-arm64/bin:/home/builder/1/tensorflow_build/venv_py38/bin:/home/builder/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin \
    PWD=/proc/self/cwd \
    PYTHON_BIN_PATH=/home/builder/1/tensorflow_build/venv_py38/bin/python3 \
    PYTHON_LIB_PATH=/home/builder/1/tensorflow_build/venv_py38/lib/python3.8/site-packages \
    TF2_BEHAVIOR=1 \
  /usr/local/bin/gcc @bazel-out/aarch64-opt/bin/tensorflow/compiler/xla/runtime/custom_call_test-2.params)
# Configuration: 6a157ea5430c4f8c0216a3c013aa8930b2449e788f4e52217225891817f5290a
# Execution platform: @local_execution_config_platform//:platform
bazel-out/aarch64-opt/bin/_solib_aarch64/libtensorflow_Scompiler_Sxla_Smlir_Stransforms_Sruntime_Slibjit_Ucompiler.so: error: undefined reference to 'LLVMInitializeAArch64AsmParser'
bazel-out/aarch64-opt/bin/_solib_aarch64/libtensorflow_Scompiler_Sxla_Smlir_Stransforms_Sruntime_Slibjit_Ucompiler.so: error: undefined reference to 'LLVMInitializeAArch64AsmPrinter'
bazel-out/aarch64-opt/bin/_solib_aarch64/libtensorflow_Scompiler_Sxla_Smlir_Stransforms_Sruntime_Slibjit_Ucompiler.so: error: undefined reference to 'LLVMInitializeAArch64TargetMC'
bazel-out/aarch64-opt/bin/_solib_aarch64/libtensorflow_Scompiler_Sxla_Smlir_Stransforms_Sruntime_Slibjit_Ucompiler.so: error: undefined reference to 'LLVMInitializeAArch64Target'
bazel-out/aarch64-opt/bin/_solib_aarch64/libtensorflow_Scompiler_Sxla_Smlir_Stransforms_Sruntime_Slibjit_Ucompiler.so: error: undefined reference to 'LLVMInitializeAArch64TargetInfo'
collect2: error: ld returned 1 exit status
Target //tensorflow/compiler/xla/runtime:custom_call_test failed to build
`