### PR TITLE
Prevent actions from running in forks

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   validate:
+    if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks
     name: "validate"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sigbuild-docker-branch.yml
+++ b/.github/workflows/sigbuild-docker-branch.yml
@@ -27,6 +27,7 @@ on:
 
 jobs:
   docker:
+    if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/sigbuild-docker-presubmit.yml
+++ b/.github/workflows/sigbuild-docker-presubmit.yml
@@ -25,6 +25,7 @@ on:
 
 jobs:
   docker:
+    if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/sigbuild-docker.yml
+++ b/.github/workflows/sigbuild-docker.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   docker:
+    if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Forks of the main repo do not have the resources or
credentials for running the Actions, so bail when
that is attempted