### PR TITLE
Refactoring of the CombinedNMS converter.

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -5181,8 +5181,7 @@ Status ConvertSquaredDifference(const OpConverterParams* params) {
   return Status::OK();
 }
 
-#if IS_TRT_VERSION_GE(8, 2, 1, 6) || defined(TF_TRT_USE_EFFICIENT_NMS_PLUGIN)
-
+#if IS_TRT_VERSION_GE(7, 1, 3, 0) || defined(TF_TRT_USE_EFFICIENT_NMS_PLUGIN)
 Status ConvertCombinedNMS(const OpConverterParams* params) {
   TF_RETURN_IF_ERROR(CheckInputsWeights(
       *params, {{"boxes", TrtInputArg::kTensor},
@@ -5193,239 +5192,117 @@ Status ConvertCombinedNMS(const OpConverterParams* params) {
                 {"score_threshold", TrtInputArg::kWeight}}));
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
-  ITensorProxyPtr boxes_tensor = inputs.at(0).tensor();
-  ITensorProxyPtr scores_tensor = inputs.at(1).tensor();
-  if (params->use_implicit_batch) {
-    return errors::Unimplemented(
-        "Implict batch mode not supported with CombinedNMS", node_def.name());
+  const auto& node_name = node_def.name();
+
+  const ITensorProxyPtr boxes_tensor = inputs.at(0).tensor();
+  const ITensorProxyPtr scores_tensor = inputs.at(1).tensor();
+  const auto boxes_dims = boxes_tensor->getDimensions();
+  const auto scores_dims = scores_tensor->getDimensions();
+
+#if IS_TRT_VERSION_GE(8, 2, 1, 6) || defined(TF_TRT_USE_EFFICIENT_NMS_PLUGIN)
+  const auto flag = true;
+  const auto* plugin_name = "NMS TRT Plugin ";
+  const auto* pluginName = "EfficientNMS_TFTRT_TRT";
+#else  // IS_TRT_VERSION_GE(7, 1, 3, 0)
+  const auto flag = false;
+  const auto* plugin_name = "TensorRT BatchedNMS Plugin ";
+  const auto* pluginName = "BatchedNMS_TRT";
+
+  auto AllowNmsTopkOverride = []() {
+    static bool result = [] {
+      bool value;
+      const Status status = ReadBoolFromEnvVar("TF_TRT_ALLOW_NMS_TOPK_OVERRIDE",
+                                               /*default_value=*/false, &value);
+      if (!status.ok()) {
+        LOG(ERROR) << status;
+      }
+      return value;
+    }();
+    return result;
+  };
+#endif
+
+  if (params->use_implicit_batch == flag) {
+    if (flag) {
+      return errors::Unimplemented(
+          convert_not_supported_implicit(node_def.op(), node_name));
+    } else {
+      if (!HasStaticShape(boxes_dims) || !HasStaticShape(scores_dims)) {
+        return errors::Unimplemented(plugin_name,
+                                     "requires input with static shape");
+      }
+    }
   }
 
-  TRT_ShapedWeights output_size_per_class = inputs.at(2).weights();
-  TRT_ShapedWeights total_size = inputs.at(3).weights();
-  TRT_ShapedWeights iou_threshold = inputs.at(4).weights();
-  TRT_ShapedWeights score_threshold = inputs.at(5).weights();
-  const int max_size_per_class = *(output_size_per_class.GetPointer<int>());
-  int max_total_size = *(total_size.GetPointer<int>());
-  const float iou_thresh = *(iou_threshold.GetPointer<float>());
-  const float score_thresh = *(score_threshold.GetPointer<float>());
+  const auto& output_size_per_class = inputs.at(2).weights();
+  const auto& total_size = inputs.at(3).weights();
+  const auto& iou_threshold = inputs.at(4).weights();
+  const auto& score_threshold = inputs.at(5).weights();
+
+  const int offset = params->use_implicit_batch ? 0 : 1;
+  if (boxes_dims.nbDims != 3 + offset) {
+    return errors::InvalidArgument(
+        plugin_name, "input boxes must be 4-D including batch, at ", node_name);
+  }
 
   AttrSlice attrs(node_def);
   bool clip_boxes = false, pad_per_class = false;
   TF_RETURN_IF_ERROR(GetNodeAttr(attrs, "clip_boxes", &clip_boxes));
   TF_RETURN_IF_ERROR(GetNodeAttr(attrs, "pad_per_class", &pad_per_class));
 
-  // Validate tensors and weights
-  const auto boxes_dims = boxes_tensor->getDimensions();
-  const auto scores_dims = scores_tensor->getDimensions();
-  if (boxes_dims.nbDims != 4) {
-    return errors::InvalidArgument(
-        "NMS TRT Plugin input boxes must be 4-D including batch ",
-        node_def.name());
-  }
-  const int num_classes = scores_dims.d[2];
-  bool box_check = boxes_dims.d[2] == 1 || boxes_dims.d[2] == num_classes;
-  if (!box_check) {
-    return errors::InvalidArgument(
-        "NMS TRT Plugin third dimension of boxes must be either 1 "
-        "or match the num_classes dimension of scores ",
-        node_def.name());
-  }
-
-  if (output_size_per_class.count() != 1) {
-    return errors::InvalidArgument(
-        "NMS TRT Plugin max_output_size_per_class must be scalar ",
-        node_def.name());
-  }
-  if (max_size_per_class <= 0) {
-    return errors::InvalidArgument(
-        "NMS TRT Plugin max_output_size_per_class should be > 0",
-        node_def.name());
-  }
-  if (total_size.count() != 1) {
-    return errors::InvalidArgument(
-        "NMS TRT Plugin max_total_size must be scalar ", node_def.name());
-  }
-  if (max_total_size <= 0) {
-    return errors::InvalidArgument(
-        "NMS TRT Plugin max_total_size should be > 0", node_def.name());
-  }
-  if (iou_threshold.count() != 1) {
-    return errors::InvalidArgument(
-        "NMS TRT Plugin iou_threshold must be scalar ", node_def.name());
-  }
-  if (iou_thresh < 0.0 || iou_thresh > 1.0) {
-    return errors::InvalidArgument(
-        "NMS TRT Plugin iou_threshold must be in [0, 1]", node_def.name());
-  }
-  if (score_threshold.count() != 1) {
-    return errors::InvalidArgument(
-        "NMS TRT Plugin score_threshold must be scalar ", node_def.name());
-  }
-
-  if (params->validation_only) return Status::OK();
-
-  // Create plugin
-  nvinfer1::PluginField fields[6] = {
-      nvinfer1::PluginField{"max_output_size_per_class", &max_size_per_class,
-                            nvinfer1::PluginFieldType::kINT32, 1},
-      nvinfer1::PluginField{"max_total_size", &max_total_size,
-                            nvinfer1::PluginFieldType::kINT32, 1},
-      nvinfer1::PluginField{"iou_threshold", &iou_thresh,
-                            nvinfer1::PluginFieldType::kFLOAT32, 1},
-      nvinfer1::PluginField{"score_threshold", &score_thresh,
-                            nvinfer1::PluginFieldType::kFLOAT32, 1},
-      nvinfer1::PluginField{"pad_per_class", &pad_per_class,
-                            nvinfer1::PluginFieldType::kINT32, 1},
-      nvinfer1::PluginField{"clip_boxes", &clip_boxes,
-                            nvinfer1::PluginFieldType::kINT32, 1},
-  };
-  nvinfer1::PluginFieldCollection fc{6, fields};
-
-  auto creator =
-      getPluginRegistry()->getPluginCreator("EfficientNMS_TFTRT_TRT", "1", "");
-  TFTRT_RETURN_ERROR_IF_NULLPTR(creator, node_def.name());
-
-  TrtUniquePtrType<nvinfer1::IPluginV2> plugin(
-      creator->createPlugin(node_def.name().c_str(), &fc));
-  TFTRT_RETURN_ERROR_IF_NULLPTR(plugin, node_def.name());
-
-  // Set plugin inputs
-  std::vector<nvinfer1::ITensor*> trt_plugin_inputs;
-  trt_plugin_inputs.push_back(boxes_tensor->trt_tensor());
-  trt_plugin_inputs.push_back(scores_tensor->trt_tensor());
-
-  // Add plugin to network
-  nvinfer1::IPluginV2Layer* layer = params->converter->network()->addPluginV2(
-      &trt_plugin_inputs[0], static_cast<int>(trt_plugin_inputs.size()),
-      *plugin);
-  TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
-  params->converter->SetLayerName(layer, node_def, "plugin");
-
-  // Set plugin outputs
-  ITensorProxyPtr output_num_detections = layer->getOutput(0);
-  ITensorProxyPtr output_detection_boxes = layer->getOutput(1);
-  ITensorProxyPtr output_detection_scores = layer->getOutput(2);
-  ITensorProxyPtr output_detection_classes = layer->getOutput(3);
-
-  // Cast the classes output from int32 to float32
-  nvinfer1::IIdentityLayer* layer_detection_classes =
-      params->converter->network()->addIdentity(
-          *output_detection_classes->trt_tensor());
-  layer_detection_classes->setOutputType(0, nvinfer1::DataType::kFLOAT);
-  output_detection_classes = layer_detection_classes->getOutput(0);
-
-  // The plugin produces a [N, 1] tensor for the num output, squeeze it to [N]
-  std::vector<int> input_dims{output_num_detections->getDimensions().d[0], 0};
-  TF_RETURN_IF_ERROR(params->converter->SqueezeTensor(
-      /*input=*/output_num_detections,
-      /*input_dims=*/&input_dims,
-      /*params=*/params,
-      /*output=*/&output_num_detections));
-
-  // Final outputs
-  params->outputs->push_back(TRT_TensorOrWeights(output_detection_boxes));
-  params->outputs->push_back(TRT_TensorOrWeights(output_detection_scores));
-  params->outputs->push_back(TRT_TensorOrWeights(output_detection_classes));
-  params->outputs->push_back(TRT_TensorOrWeights(output_num_detections));
-
-  return Status::OK();
-}
-
-#elif IS_TRT_VERSION_GE(7, 1, 3, 0)
-
-bool AllowNmsTopkOverride() {
-  static bool result = [] {
-    bool value;
-    Status status = ReadBoolFromEnvVar("TF_TRT_ALLOW_NMS_TOPK_OVERRIDE",
-                                       /*default_value=*/false, &value);
-    if (!status.ok()) {
-      LOG(ERROR) << status;
-    }
-    return value;
-  }();
-  return result;
-}
-
-Status ConvertCombinedNMS(const OpConverterParams* params) {
-  TF_RETURN_IF_ERROR(
-      CheckInputsWeights(*params, {{"boxes", false},
-                                   {"scores", false},
-                                   {"max_output_size_per_class", true},
-                                   {"max_total_size", true},
-                                   {"iou_threshold", true},
-                                   {"score_threshold", true}}));
-  const auto& inputs = params->inputs;
-  const auto& node_def = params->node_def;
-
-  ITensorProxyPtr boxes_tensor = inputs.at(0).tensor();
-  ITensorProxyPtr scores_tensor = inputs.at(1).tensor();
-  TRT_ShapedWeights output_size_per_class = inputs.at(2).weights();
-  TRT_ShapedWeights total_size = inputs.at(3).weights();
-  TRT_ShapedWeights iou_threshold = inputs.at(4).weights();
-  TRT_ShapedWeights score_threshold = inputs.at(5).weights();
-
-  // Validate tensors and weights (also set some of the needed plugin fields)
-  const auto boxes_dims = boxes_tensor->getDimensions();
-  const auto scores_dims = scores_tensor->getDimensions();
-  if (!params->use_implicit_batch &&
-      (!HasStaticShape(boxes_dims) || !HasStaticShape(scores_dims))) {
-    return errors::Unimplemented(
-        "TensorRT BatchedNMS Plugin requires input with static shape");
-  }
-  const int offset = params->use_implicit_batch ? 0 : 1;
-  if (boxes_dims.nbDims != 3 + offset) {
-    return errors::InvalidArgument(
-        "TensorRT BatchedNMS Plugin input boxes must be 4-D including batch");
-  }
   const int class_idx = 1 + offset;
   const int num_classes = scores_dims.d[class_idx];
-  const int num_boxes = boxes_dims.d[0 + offset];
-  bool box_check =
+  const bool box_check =
       boxes_dims.d[class_idx] == 1 || boxes_dims.d[class_idx] == num_classes;
   if (!box_check) {
     return errors::InvalidArgument(
-        "TensorRT BatchedNMS Plugin third dimension of boxes must be either 1 "
-        "or num_classes");
+        plugin_name,
+        "third dimension of boxes must be either 1"
+        "or match the num_classes dimension of scores, at ",
+        node_name);
   }
 
   if (output_size_per_class.count() != 1) {
     return errors::InvalidArgument(
-        "TensorRT BatchedNMS Plugin max_output_size_per_class must be scalar");
+        plugin_name, "max_output_size_per_class must be scalar, at ",
+        node_name);
   }
-  int max_size_per_class = *(output_size_per_class.GetPointer<int>());
+
+  const int max_size_per_class = *(output_size_per_class.GetPointer<int>());
   if (max_size_per_class <= 0) {
     return errors::InvalidArgument(
-        "TensorRT BatchedNMS Plugin max_output_size_per_class should be > 0");
+        plugin_name, "max_output_size_per_class should be > 0, at ", node_name);
   }
+
   if (total_size.count() != 1) {
     return errors::InvalidArgument(
-        "TensorRT BatchedNMS Plugin max_total_size must be scalar");
+        plugin_name, "max_total_size must be scalar, at ", node_name);
   }
+
   int max_total_size = *(total_size.GetPointer<int>());
   if (max_total_size <= 0) {
     return errors::InvalidArgument(
-        "TensorRT BatchedNMS Plugin max_total_size should be > 0");
+        plugin_name, "max_total_size should be > 0, at ", node_name);
   }
+
   if (iou_threshold.count() != 1) {
     return errors::InvalidArgument(
-        "TensorRT BatchedNMS Plugin iou_threshold must be scalar");
+        plugin_name, "iou_threshold must be scalar, at ", node_name);
   }
-  float iou_thresh = *(iou_threshold.GetPointer<float>());
+
+  const auto iou_thresh = *(iou_threshold.GetPointer<float>());
   if (iou_thresh < 0.0 || iou_thresh > 1.0) {
     return errors::InvalidArgument(
-        "TensorRT BatchedNMS Plugin iou_threshold must be in [0, 1]");
+        plugin_name, "iou_threshold must be in [0, 1], at", node_name);
   }
+
   if (score_threshold.count() != 1) {
     return errors::InvalidArgument(
-        "TensorRT BatchedNMS Plugin score_threshold must be scalar");
+        plugin_name, "score_threshold must be scalar, at ", node_name);
   }
 
-  bool pad_per_class = false, clip_boxes = false;
-  AttrSlice attrs(node_def);
-  TF_RETURN_IF_ERROR(GetNodeAttr(attrs, "pad_per_class", &pad_per_class));
-  TF_RETURN_IF_ERROR(GetNodeAttr(attrs, "clip_boxes", &clip_boxes));
-
-  // TRT op is_normalized=False treats input corrdinates as pixels and
+#if !IS_TRT_VERSION_GE(8, 2, 1, 6) && !defined(TF_TRT_USE_EFFICIENT_NMS_PLUGIN)
+  // TRT op is_normalized=False treats input coordinates as pixels and
   // calculates width/height as (max - min + 1).
   //
   // TF op CombinedNonMaxSuppression doesn't care about the normalization and
@@ -5433,14 +5310,11 @@ Status ConvertCombinedNMS(const OpConverterParams* params) {
   //
   // We set is_normalized = true to be consistent with TF IOU calculaton.
   const bool is_normalized = true;
-
-  bool share_location = (boxes_dims.d[class_idx] == 1);
-  int keep_top_k = 0;
-  if (pad_per_class) {
-    keep_top_k = std::min(max_size_per_class * num_classes, max_total_size);
-  } else {
-    keep_top_k = max_total_size;
-  }
+  const int backgrnd_id = -1;
+  const bool share_location = (boxes_dims.d[class_idx] == 1);
+  int keep_top_k = pad_per_class ? std::min(max_size_per_class * num_classes,
+                                            max_total_size)
+                             : max_total_size;
 
   // According to the batchedNMS plugin description we need to set top_k so that
   // keep_top_k <= top_k
@@ -5449,6 +5323,7 @@ Status ConvertCombinedNMS(const OpConverterParams* params) {
   // discards the rest. The NMS step is performed only among the top_k
   // candidates. To be strictly compatible with the TF op, we need that top_k is
   // greater equal to num_boxes.
+  const int num_boxes = boxes_dims.d[offset];
   int top_k = std::max(num_boxes, keep_top_k);
   // TRT has a limitation: top_k <=4096.
   if (top_k > 4096) {
@@ -5463,70 +5338,88 @@ Status ConvertCombinedNMS(const OpConverterParams* params) {
           "result in a loss of accuracy.");
     }
   }
+#endif
 
   if (params->validation_only) return Status::OK();
+
+  // Create plugin.
   float score_thresh = *(score_threshold.GetPointer<float>());
-  const int background_id = -1;
-  nvinfer1::PluginField fields[9] = {
-      nvinfer1::PluginField{"shareLocation", &share_location,
-                            nvinfer1::PluginFieldType::kINT32, 1},
-      nvinfer1::PluginField{"backgroundLabelId", &background_id,
-                            nvinfer1::PluginFieldType::kINT32, 1},
-      nvinfer1::PluginField{"numClasses", &num_classes,
-                            nvinfer1::PluginFieldType::kINT32, 1},
-      nvinfer1::PluginField{"topK", &top_k, nvinfer1::PluginFieldType::kINT32,
-                            1},
-      nvinfer1::PluginField{"keepTopK", &keep_top_k,
-                            nvinfer1::PluginFieldType::kINT32, 1},
-      nvinfer1::PluginField{"scoreThreshold", &score_thresh,
-                            nvinfer1::PluginFieldType::kFLOAT32, 1},
-      nvinfer1::PluginField{"iouThreshold", &iou_thresh,
-                            nvinfer1::PluginFieldType::kFLOAT32, 1},
-      nvinfer1::PluginField{"isNormalized", &is_normalized,
-                            nvinfer1::PluginFieldType::kINT32, 1},
-      nvinfer1::PluginField{"clipBoxes", &clip_boxes,
-                            nvinfer1::PluginFieldType::kINT32, 1}};
-  nvinfer1::PluginFieldCollection fc{9, fields};
+  nvinfer1::PluginField fields[] = {
+#if IS_TRT_VERSION_GE(8, 2, 1, 6) || defined(TF_TRT_USE_EFFICIENT_NMS_PLUGIN)
+    {"max_output_size_per_class", &max_size_per_class,
+     nvinfer1::PluginFieldType::kINT32, 1},
+    {"max_total_size", &max_total_size, nvinfer1::PluginFieldType::kINT32, 1},
+    {"iou_threshold", &iou_thresh, nvinfer1::PluginFieldType::kFLOAT32, 1},
+    {"score_threshold", &score_thresh, nvinfer1::PluginFieldType::kFLOAT32, 1},
+    {"pad_per_class", &pad_per_class, nvinfer1::PluginFieldType::kINT32, 1},
+    {"clip_boxes", &clip_boxes, nvinfer1::PluginFieldType::kINT32, 1},
+#else  // IS_TRT_VERSION_GE(7, 1, 3, 0)
+    {"shareLocation", &share_location, nvinfer1::PluginFieldType::kINT32, 1},
+    {"backgroundLabelId", &backgrnd_id, nvinfer1::PluginFieldType::kINT32, 1},
+    {"numClasses", &num_classes, nvinfer1::PluginFieldType::kINT32, 1},
+    {"topK", &top_k, nvinfer1::PluginFieldType::kINT32, 1},
+    {"keepTopK", &keep_top_k, nvinfer1::PluginFieldType::kINT32, 1},
+    {"scoreThreshold", &score_thresh, nvinfer1::PluginFieldType::kFLOAT32, 1},
+    {"iouThreshold", &iou_thresh, nvinfer1::PluginFieldType::kFLOAT32, 1},
+    {"isNormalized", &is_normalized, nvinfer1::PluginFieldType::kINT32, 1},
+    {"clipBoxes", &clip_boxes, nvinfer1::PluginFieldType::kINT32, 1},
+#endif
+  };
 
-  // Get plugin creator
-  auto creator =
-      getPluginRegistry()->getPluginCreator("BatchedNMS_TRT", "1", "");
-  TFTRT_RETURN_ERROR_IF_NULLPTR(creator, node_def.name());
+  nvinfer1::PluginFieldCollection fc{sizeof(fields) / sizeof(fields[0]),
+                                     fields};
 
-  // Create plugin
+  // Get plugin creator.
+  auto creator = getPluginRegistry()->getPluginCreator(pluginName, "1", "");
+  TFTRT_RETURN_ERROR_IF_NULLPTR(creator, node_name);
+
   TrtUniquePtrType<nvinfer1::IPluginV2> plugin(
-      creator->createPlugin(node_def.name().c_str(), &fc));
-  TFTRT_RETURN_ERROR_IF_NULLPTR(plugin, node_def.name());
+      creator->createPlugin(node_name.c_str(), &fc));
+  TFTRT_RETURN_ERROR_IF_NULLPTR(plugin, node_name);
 
-  // Set plugin inputs
+  // Set plugin inputs.
   std::vector<nvinfer1::ITensor*> trt_plugin_inputs;
   trt_plugin_inputs.push_back(boxes_tensor->trt_tensor());
   trt_plugin_inputs.push_back(scores_tensor->trt_tensor());
 
-  // Add plugin to network
+  // Add plugin to network.
   nvinfer1::IPluginV2Layer* layer = params->converter->network()->addPluginV2(
       &trt_plugin_inputs[0], static_cast<int>(trt_plugin_inputs.size()),
       *plugin);
-  TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_def.name());
+  TFTRT_RETURN_ERROR_IF_NULLPTR(layer, node_name);
   params->converter->SetLayerName(layer, node_def, "plugin");
 
-  // Set plugin outputs
-  ITensorProxyPtr output_nmsed_boxes = layer->getOutput(1);
-
-  // TensorRT fixes (removes) the extra last dimension in CombinedNMS outputs
+  // Set plugin outputs.
+  const ITensorProxyPtr output_detection_boxes = layer->getOutput(1);
+  const ITensorProxyPtr output_detection_scores = layer->getOutput(2);
   ITensorProxyPtr output_num_detections = layer->getOutput(0);
-  ITensorProxyPtr output_nmsed_scores = layer->getOutput(2);
-  ITensorProxyPtr output_nmsed_classes = layer->getOutput(3);
+  ITensorProxyPtr output_detection_classes = layer->getOutput(3);
 
-  params->outputs->push_back(TRT_TensorOrWeights(output_nmsed_boxes));
-  params->outputs->push_back(TRT_TensorOrWeights(output_nmsed_scores));
-  params->outputs->push_back(TRT_TensorOrWeights(output_nmsed_classes));
+#if IS_TRT_VERSION_GE(8, 2, 1, 6) || defined(TF_TRT_USE_EFFICIENT_NMS_PLUGIN)
+  // Cast the classes output from int32 to float32.
+  nvinfer1::IIdentityLayer* layer_detection_classes =
+      params->converter->network()->addIdentity(
+          *output_detection_classes->trt_tensor());
+  layer_detection_classes->setOutputType(0, nvinfer1::DataType::kFLOAT);
+  output_detection_classes = layer_detection_classes->getOutput(0);
+
+  // The plugin produces a [N, 1] tensor for the num output, squeeze it to [N]
+  std::vector<int> input_dims{output_num_detections->getDimensions().d[0], 0};
+  TF_RETURN_IF_ERROR(params->converter->SqueezeTensor(
+      /*input=*/output_num_detections,
+      /*input_dims=*/&input_dims,
+      /*params=*/params,
+      /*output=*/&output_num_detections));
+#endif
+
+  // Final outputs.
+  params->outputs->push_back(TRT_TensorOrWeights(output_detection_boxes));
+  params->outputs->push_back(TRT_TensorOrWeights(output_detection_scores));
+  params->outputs->push_back(TRT_TensorOrWeights(output_detection_classes));
   params->outputs->push_back(TRT_TensorOrWeights(output_num_detections));
-
   return Status::OK();
 }
-
-#endif  // IS_TRT_VERSION_GE(7, 1, 3, 0)
+#endif
 
 Status ConvertResize(const OpConverterParams* params) {
   const auto& inputs = params->inputs;


### PR DESCRIPTION
Combining two pairs of converters and test procedures:
```
Status ConvertCombinedNMS(const OpConverterParams* params)
TEST_P(OpConverter_FP32_Test, ConvertCombinedNMS)
```
which were written, respectively, for
```
#if IS_TRT_VERSION_GE(8, 2, 1, 6) || defined(TF_TRT_USE_EFFICIENT_NMS_PLUGIN)
....
#elif IS_TRT_VERSION_GE(7, 1, 3, 0)
```
The new code is almost 200 lines shorter, easier to maintain and to rewrite via  `OpConverterBase`.
