### PR TITLE
[TF-TRT]: Revert default dynamic shape strategy to Range

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -1164,8 +1164,8 @@ class TrtGraphConverterV2(object):
       use_dynamic_shape: whether to enable dynamic shape support. None is
         equivalent to False in the current implementation.
       dynamic_shape_profile_strategy: one of the strings in
-        supported_profile_strategies(). None is equivalent to
-        ImplicitBatchModeCompatible in the current implementation.
+        supported_profile_strategies(). None is equivalent to Range in the
+        current implementation.
       max_workspace_size_bytes: the maximum GPU temporary memory that the TRT
         engine can use at execution time. This corresponds to the
         'workspaceSize' parameter of nvinfer1::IBuilder::setMaxWorkspaceSize().
@@ -1245,8 +1245,7 @@ class TrtGraphConverterV2(object):
     self._profile_strategy = "Unknown"
     if self._use_dynamic_shape:
       if dynamic_shape_profile_strategy is None:
-        self._profile_strategy = \
-            PROFILE_STRATEGY_IMPLICIT_BATCH_MODE_COMPATIBLE
+        self._profile_strategy = PROFILE_STRATEGY_RANGE
       else:
         self._verify_profile_strategy(dynamic_shape_profile_strategy)
         self._profile_strategy = dynamic_shape_profile_strategy


### PR DESCRIPTION
Revert "Make default dynamic shape profile strategy to implicit batch compatible"

Currently, the ImplicitBatchModeCompatible strategy creates profiles with the
assumption that the first dim is always the batch dim. This does not necessarily
hold for TRTEngineOps deeper in the graph, therefore we cannot simply override
dim 0 for all the min values. We have a case where this leads to inconsistent
profiles and engine creation failure in certain BERT networks.

The Range profile strategy does not have this issue, so revert to using
Range as the default.

This reverts commit 0737efbe374b2bc89134f153d54a45af6811592a.

cc: @tfeher @bixia1 @DEKHTIARJonathan 