### PR TITLE
[TFTRT] Additional ConvertPool validation

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -88,6 +88,9 @@ limitations under the License.
                 " inputs but expected ", (exp_size));                    \
   }
 
+// Max kernel volume copied from TRT's limits.
+#define MAX_KERNEL_DIMS_PRODUCT(x) (int64_t(std::pow(100000.0F, (x) *0.5F)))
+
 namespace tensorflow {
 namespace tensorrt {
 namespace convert {
@@ -3033,6 +3036,17 @@ Status ConvertPool3D(const OpConverterParams* params) {
     return errors::Unimplemented(
         "ksize must be 1 for batch and channel dimensions");
   }
+
+  const nvinfer1::Dims3 stride(tf_stride[d_index], tf_stride[h_index],
+                               tf_stride[w_index]);
+  const nvinfer1::Dims3 ksize(tf_kernel[d_index], tf_kernel[h_index],
+                              tf_kernel[w_index]);
+
+  if (!(ksize.nbDims >= 3
+      && (ksize.d[0] >= 1 && ksize.d[1] >= 1 && ksize.d[2] >= 1)
+      && (ksize.d[0] * ksize.d[1] * ksize.d[2] < MAX_KERNEL_DIMS_PRODUCT(3)))) {
+    return errors::InvalidArgument("Window dimensions are not within bounds");
+  }
   if (params->validation_only) return Status::OK();
 
   ITensorProxyPtr tensor = inputs.at(0).tensor();
@@ -3041,11 +3055,6 @@ Status ConvertPool3D(const OpConverterParams* params) {
     TF_RETURN_IF_ERROR(params->converter->TransposeTensor(
         tensor, {0, 4, 1, 2, 3}, &tensor, node_def, "to_NCDHW"));
   }
-
-  const nvinfer1::Dims3 stride(tf_stride[d_index], tf_stride[h_index],
-                               tf_stride[w_index]);
-  const nvinfer1::Dims3 ksize(tf_kernel[d_index], tf_kernel[h_index],
-                              tf_kernel[w_index]);
 
   nvinfer1::IPoolingLayer* layer = params->converter->network()->addPoolingNd(
       *tensor->trt_tensor(), type, ksize);
@@ -3241,7 +3250,6 @@ Status ConvertPool(const OpConverterParams* params) {
   if ((padding_type != "SAME") && (padding_type != "VALID")) {
     return errors::Unimplemented("Unsupported padding type: ", padding_type);
   }
-  if (params->validation_only) return Status::OK();
 
   ITensorProxyPtr tensor = inputs.at(0).tensor();
   int h_index = 2;
@@ -3249,12 +3257,22 @@ Status ConvertPool(const OpConverterParams* params) {
   if (data_format == "NHWC") {
     h_index = 1;
     w_index = 2;
-    TF_RETURN_IF_ERROR(params->converter->TransposeTensor(
-        tensor, {0, 3, 1, 2}, &tensor, node_def, "to_NCHW"));
   }
 
   const nvinfer1::DimsHW stride(tf_stride[h_index], tf_stride[w_index]);
   const nvinfer1::DimsHW ksize(tf_kernel[h_index], tf_kernel[w_index]);
+
+  if (!((ksize.h() >= 1 && ksize.w() >= 1)
+      && (ksize.h() * ksize.w() < MAX_KERNEL_DIMS_PRODUCT(2)))) {
+    return errors::InvalidArgument("Window dimensions are not within bounds");
+  }
+
+  if (params->validation_only) return Status::OK();
+
+  if (data_format == "NHWC") {
+    TF_RETURN_IF_ERROR(params->converter->TransposeTensor(
+        tensor, {0, 3, 1, 2}, &tensor, node_def, "to_NCHW"));
+  }
 
   nvinfer1::IPoolingLayer* layer = params->converter->network()->addPooling(
       *tensor->trt_tensor(), type, ksize);

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -6817,6 +6817,8 @@ TEST_P(OpConverter_FP32_Test, ConvertPool) {
     // The expected outputs for the following operations: MaxPool2D, AvgPool2D,
     // MaxPool3D, AvgPool3D
     std::vector<std::vector<float>> expected_outputs;
+    Status status;
+    std::set<int> skip_dims;
   };
 
   // We use common_input as the input to test both 2D and 3D pooling operations,
@@ -6828,7 +6830,64 @@ TEST_P(OpConverter_FP32_Test, ConvertPool) {
   // The output of 2D ops for the case where the op is equivalent to the
   // identity op.
   const std::vector<float> common_2d_output{-4, 2, 15, 3, 6, -3, 22, 1, 88};
-  std::vector<TestParams> ok_params = {
+  std::vector<TestParams> test_params = {
+      // Validation failure - kernel size too large for TRT
+      TestParams{
+          /*input_dims=*/{1, 1, 3, 3, 3},
+          /*input=*/common_input,
+          /*ksize=*/{1, 1, 1000, 1000, 1000},
+          /*strides=*/{1, 1, 1, 1, 1},
+          /*padding=*/"VALID",
+          /*data_format=*/"NCDHW",
+          /*expected_output_dims=*/{1, 1, 3, 3, 3},
+          /*expected_outputs=*/
+          {common_2d_output, common_2d_output, common_input, common_input},
+          /*status=*/
+          Status(error::INVALID_ARGUMENT,
+                 "Window dimensions are not within bounds")},
+      // Validation failure for 3D ops - negative kernel depth
+      TestParams{
+          /*input_dims=*/{1, 1, 3, 3, 3},
+          /*input=*/common_input,
+          /*ksize=*/{1, 1, -1, 1, 1},
+          /*strides=*/{1, 1, 1, 1, 1},
+          /*padding=*/"VALID",
+          /*data_format=*/"NCDHW",
+          /*expected_output_dims=*/{1, 1, 3, 3, 3},
+          /*expected_outputs=*/
+          {common_2d_output, common_2d_output, common_input, common_input},
+          /*status=*/
+          Status(error::INVALID_ARGUMENT,
+                 "Window dimensions are not within bounds"),
+          /*skip_dims=*/{2}},
+      // Validation failure - negative kernel height
+      TestParams{
+          /*input_dims=*/{1, 1, 3, 3, 3},
+          /*input=*/common_input,
+          /*ksize=*/{1, 1, 1, -1, 1},
+          /*strides=*/{1, 1, 1, 1, 1},
+          /*padding=*/"VALID",
+          /*data_format=*/"NCDHW",
+          /*expected_output_dims=*/{1, 1, 3, 3, 3},
+          /*expected_outputs=*/
+          {common_2d_output, common_2d_output, common_input, common_input},
+          /*status=*/
+          Status(error::INVALID_ARGUMENT,
+                 "Window dimensions are not within bounds")},
+      // Validation failure - negative kernel width
+      TestParams{
+          /*input_dims=*/{1, 1, 3, 3, 3},
+          /*input=*/common_input,
+          /*ksize=*/{1, 1, 1, 1, -1},
+          /*strides=*/{1, 1, 1, 1, 1},
+          /*padding=*/"VALID",
+          /*data_format=*/"NCDHW",
+          /*expected_output_dims=*/{1, 1, 3, 3, 3},
+          /*expected_outputs=*/
+          {common_2d_output, common_2d_output, common_input, common_input},
+          /*status=*/
+          Status(error::INVALID_ARGUMENT,
+                 "Window dimensions are not within bounds")},
       // Basic - just 1x1 max pooling - input = output
       TestParams{
           /*input_dims=*/{1, 1, 3, 3, 3},
@@ -6885,9 +6944,12 @@ TEST_P(OpConverter_FP32_Test, ConvertPool) {
                   {1, 2, 3, 4, 5, 6, 7, 8}}},
   };
 
-  for (auto p : ok_params) {
+  for (auto p : test_params) {
     int test_counter = 0;
     for (int nDim : test_nDims) {
+      if (p.skip_dims.find(nDim) != p.skip_dims.end()) {
+        continue;
+      }
       auto input = p.input;
       auto input_dims = p.input_dims;
       auto ksize = p.ksize;
@@ -6908,7 +6970,7 @@ TEST_P(OpConverter_FP32_Test, ConvertPool) {
         NodeDef node = get_pool_nodedef(tf_type_, nDim, ksize, strides,
                                         p.padding, data_format, is_max_pooling);
         AddTestTensor("input", input_dims, input);
-        TestOpConverter(node, expected_output_dims, Status::OK(), Status::OK(),
+        TestOpConverter(node, expected_output_dims, p.status, Status::OK(),
                         ElementsAreArray(p.expected_outputs.at(test_counter)));
         test_counter++;
       }


### PR DESCRIPTION
Add additional validation for TRT failure cases for `ConvertPool` and `ConvertPool3D`, so that failing nodes will not be converted.