### PR TITLE
Build nighlty with GCS cache

### DIFF
--- a/.github/workflows/compile-nightly-gcs-cache.yml
+++ b/.github/workflows/compile-nightly-gcs-cache.yml
@@ -28,10 +28,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: nightly
-          path: /tf/tensorflow
       -
         name: Configure and build TF CPU with GCS remote cache
-        working-directory: /tf/tensorflow
         run: |
           bash -c "bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc build \
           --config=sigbuild_remote_cache tensorflow/tools/pip_package:build_pip_package"

--- a/.github/workflows/compile-nightly-gcs-cache.yml
+++ b/.github/workflows/compile-nightly-gcs-cache.yml
@@ -25,9 +25,10 @@ jobs:
     steps:
       -
         name: Checkout tensorflow nightly branch sources
-        run: |
-          git clone -b nightly --single-branch --depth 1  https://github.com/tensorflow/tensorflow.git /tf/tensorflow
-          cd /tf/tensorflow
+        uses: actions/checkout@v3
+        with:
+          ref: nightly
+          path: /tf/tensorflow
       -
         name: Configure and build TF CPU with GCS remote cache
         working-directory: /tf/tensorflow

--- a/.github/workflows/compile-nightly-gcs-cache.yml
+++ b/.github/workflows/compile-nightly-gcs-cache.yml
@@ -20,7 +20,6 @@ on:
 name: Compile nightly brach with the bazel public remote GCS cache 
 jobs: 
   compile-nigihtly-with-gcs-cache:
-    needs: docker
     runs-on: ubuntu-latest
     container: tensorflow/build:latest-python3.10
     steps:

--- a/.github/workflows/compile-nightly-gcs-cache.yml
+++ b/.github/workflows/compile-nightly-gcs-cache.yml
@@ -32,5 +32,5 @@ jobs:
         name: Configure and build TF CPU with GCS remote cache
         working-directory: /tf/tensorflow
         run: |
-          bash -c "bazel --bazelrc=/usertools/cpu.bazelrc build \
+          bash -c "bazel --bazelrc=tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/cpu.bazelrc build \
           --config=sigbuild_remote_cache tensorflow/tools/pip_package:build_pip_package"

--- a/.github/workflows/compile-nightly-gcs-cache.yml
+++ b/.github/workflows/compile-nightly-gcs-cache.yml
@@ -16,7 +16,7 @@
 on:
   workflow_dispatch:  # Allow manual triggers
   schedule:
-    - cron: 0 5 * * *  # 4am UTC is 9pm PDT and 8pm PST (1 hour after nightly push job)
+    - cron: 0 5 * * *  # 5am UTC is 10pm PDT and 9pm PST (1 hour after nightly push job)
 name: Compile nightly brach with the bazel public remote GCS cache 
 jobs: 
   compile-nigihtly-with-gcs-cache:

--- a/.github/workflows/compile-nightly-gcs-cache.yml
+++ b/.github/workflows/compile-nightly-gcs-cache.yml
@@ -1,0 +1,37 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+on:
+  workflow_dispatch:  # Allow manual triggers
+  schedule:
+    - cron: 0 5 * * *  # 4am UTC is 9pm PDT and 8pm PST (1 hour after nightly push job)
+name: Compile nightly brach with the bazel public remote GCS cache 
+jobs: 
+  compile-nigihtly-with-gcs-cache:
+    needs: docker
+    runs-on: ubuntu-latest
+    container: tensorflow/build:latest-python3.10
+    steps:
+      -
+        name: Checkout tensorflow nightly branch sources
+        run: |
+          git clone -b nightly --single-branch --depth 1  https://github.com/tensorflow/tensorflow.git /tf/tensorflow
+          cd /tf/tensorflow
+      -
+        name: Configure and build TF CPU with GCS remote cache
+        working-directory: /tf/tensorflow
+        run: |
+          bash -c "bazel --bazelrc=/usertools/cpu.bazelrc build \
+          --config=sigbuild_remote_cache tensorflow/tools/pip_package:build_pip_package"


### PR DESCRIPTION
Test if we are able to compile (and monitor the required time) to build TF CPU on the GitHub Action free resources using the nightly GCS cache.

This a good proxy to verify the setup a contributor could use to prepare and test locally a PR.

This is a follow-up of https://github.com/tensorflow/build/pull/48 as the CI files was removed from that repository.

/cc @angerson  @perfinion @learning-to-play @mihaimaruseac @theadactyl 