### PR TITLE
Improving handling of data passed from input_fn.

### DIFF
--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -1034,6 +1034,7 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
             data = (scale * np.random.random_sample(np_shape)).astype(np_dtype)
           else:
             data = np.random.choice(a=[False, True], size=np_shape)
+
           if run_params.is_v2:
             with ops.device("/GPU:0"):
               data = ops.convert_to_tensor(data)

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -99,6 +99,27 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     out = array_ops.identity(add, name="output")
     return out
 
+  def _GetShapeOpModel(self):
+    class ShapeOpModel(autotrackable.AutoTrackable):
+
+      def __init__(self):
+        self.v = None
+
+      @def_function.function(input_signature=[
+           tensor_spec.TensorSpec(shape=[None, None], dtype=dtypes.float32)
+      ])
+      def run(self, x):
+        q = x + 1
+        q_shape = array_ops.shape(q)
+        # Add an OP that is not supported by TF-TRT. This allows TF-TRT to build
+        # two engines. The first engine produces an int32 output and the second
+        # engines has an int32 input and an int32 output.
+        q = math_ops.cumsum(q_shape)
+        q = q * 2
+        return array_ops.identity(q, name="output")
+
+    return ShapeOpModel()
+
   def _GetModelForV2(self):
 
     class SimpleModel(autotrackable.AutoTrackable):
@@ -409,18 +430,46 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     inp2 = np.random.random_sample(shape).astype(dtype)
     return inp1, inp2
 
-  @test_util.run_v2_only
-  def testTrtGraphConverter_DynamicConversion_v2(self):
-    """Test case for trt_convert.TrtGraphConverter()."""
+  def _GetAssetFile(self, output_saved_model_dir, trt_engine_name):
+    asset_file = os.path.join(
+      output_saved_model_dir,
+      "assets/trt-serialized-engine." + trt_engine_name)
+    return asset_file
 
-    np_input1, np_input2 = self._RandomInput([4, 1, 1])
+  def _BuildGraphWithInputGenerator(self, InputFunc, np_input = None):
+    # Create the SavedModel.
+    root = self._GetShapeOpModel()
+    expected_output = None if np_input is None else root.run(np_input)
+    input_saved_model_dir = self.mkdtemp()
+    save.save(root, input_saved_model_dir, signatures=root.run)
 
+    # Convert the graph to TF-TRT.
+    conv_params = trt_convert.TrtConversionParams(minimum_segment_size=2)
+    converter = trt_convert.TrtGraphConverterV2(
+        input_saved_model_dir=input_saved_model_dir,
+        use_dynamic_shape=True,
+        **conv_params._asdict())
+    converter.convert()
+
+    # Build the graph with the input generator. This runs the TRTEngineOp native
+    # segment.
+    converter.build(InputFunc)
+    output_saved_model_dir = self.mkdtemp()
+    converter.save(output_saved_model_dir)
+    del converter
+    return output_saved_model_dir, expected_output
+
+  def _BuildGraphWithInputGeneratorTwoInputs(self, InputFunc, np_input = None):
     # Create a model and save it.
     input_saved_model_dir = self.mkdtemp()
     root = self._GetModelForV2()
-    expected_output = root.run(np_input1, np_input2)
+    if np_input is None:
+      expected_output = None
+    else:
+      expected_output = root.run(np_input[0], np_input[1])
+
     save.save(root, input_saved_model_dir,
-              {_SAVED_MODEL_SIGNATURE_KEY: root.run})
+                {_SAVED_MODEL_SIGNATURE_KEY: root.run})
 
     # Run TRT conversion.
     converter = self._CreateConverterV2(input_saved_model_dir)
@@ -435,27 +484,98 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     # Save the converted model without any TRT engine cache.
     output_saved_model_dir = self.mkdtemp()
     converter.save(output_saved_model_dir)
-    unexpected_asset_file = os.path.join(
-        output_saved_model_dir,
-        "assets/trt-serialized-engine." + trt_engine_name)
+    unexpected_asset_file = \
+        self._GetAssetFile(output_saved_model_dir, trt_engine_name)
     self.assertFalse(os.path.exists(unexpected_asset_file))
 
     # Run the converted function to populate the engine cache.
-    def _InputFn():
-      yield np_input1, np_input2
-
-    converter.build(input_fn=_InputFn)
+    converter.build(input_fn=InputFunc)
 
     # Save the converted model again with serialized engine cache.
     output_saved_model_dir = self.mkdtemp()
     converter.save(output_saved_model_dir)
-    expected_asset_file = os.path.join(
-        output_saved_model_dir,
-        "assets/trt-serialized-engine." + trt_engine_name)
+    expected_asset_file = \
+        self._GetAssetFile(output_saved_model_dir, trt_engine_name)
     self.assertTrue(os.path.exists(expected_asset_file))
     self.assertTrue(os.path.getsize(expected_asset_file))
 
     del converter
+    return output_saved_model_dir, expected_output
+
+  @test_util.run_v2_only
+  def testTrtGraphBuild(self):
+    """Testing the construction of a graph with an input data generator
+       that takes one or two input parameters passed in different formats."""
+    # One input parameter:
+    np_input = np.random.random_sample([5, 3]).astype(np.float32)
+
+    def _Func_1():
+      yield (np_input,)       # tuple with one element
+
+    def _Func_2():
+      yield [np_input]        # list with one element
+
+    def _Func_3():
+      yield np_input          # array
+
+    def _Func_4():
+      yield {"x": np_input}   # dictionary
+
+    def _Func_5():
+      # multiple yields: different types
+      yield (np_input)        # tuple with one element
+      yield [np_input]        # list with one element
+      yield np_input          # array
+      yield {"x": np_input}   # dictionary
+
+    def _Func_6():
+      # multiple yields: all arrays
+      for shape in [(1, 128), (16, 128), (256, 128)]:
+        yield np.random.random_sample(shape).astype(np.float32)
+
+    for input_fn in [_Func_1, _Func_2, _Func_3, _Func_4, _Func_5, _Func_6]:
+      self._BuildGraphWithInputGenerator(input_fn)
+
+    # Two input parameters:
+    np_input1, np_input2 = self._RandomInput([4, 1, 1])
+
+    def _Func_A():
+      yield np_input1, np_input2     # tuple
+
+    def _Func_B():
+      yield [np_input1, np_input2]   # list
+
+    def _Func_C():
+      yield {"inp1": np_input1,
+             "inp2": np_input2}      # dictionary
+
+    def _Func_D():
+      # multiple yields: different types
+      yield np_input1, np_input2     # tuple
+      yield [np_input1, np_input2]   # list
+      yield {"inp1": np_input1,
+             "inp2": np_input2}      # dictionary
+
+    def _Func_E():
+      # multiple yields: tuples
+      for shape in [[4, 1, 1], [4, 2, 1], [4, 4, 1]]:
+        yield self._RandomInput(shape)
+
+    for input_fn in [_Func_A, _Func_B, _Func_C, _Func_D, _Func_E]:
+      self._BuildGraphWithInputGeneratorTwoInputs(input_fn)
+
+  @test_util.run_v2_only
+  def testTrtGraphConverter_DynamicConversion_v2(self):
+    """Test case for trt_convert.TrtGraphConverter()."""
+
+    np_input1, np_input2 = self._RandomInput([4, 1, 1])
+
+    def _InputFn():
+      yield np_input1, np_input2
+
+    np_inputs = [np_input1, np_input2]
+    output_saved_model_dir, expected_output = \
+        self._BuildGraphWithInputGeneratorTwoInputs(_InputFn, np_inputs)
     gc.collect()  # Force GC to destroy the TRT engine cache.
 
     # Load and verify the converted model.
@@ -486,49 +606,14 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
   @test_util.run_v2_only
   def testTrtGraphConverter_ShapeOp_Int32InputOutput_v2(self):
     """Testing ShapeOp and int32 values as engine input and output."""
-
-    class ShapeOpModel(autotrackable.AutoTrackable):
-
-      def __init__(self):
-        self.v = None
-
-      @def_function.function(input_signature=[
-          tensor_spec.TensorSpec(shape=[None, None], dtype=dtypes.float32)
-      ])
-      def run(self, x):
-        q = x + 1
-        q_shape = array_ops.shape(q)
-        # Add an OP that is not supported by TF-TRT. This allows TF-TRT to build
-        # two engines. The first engine produces an int32 output and the second
-        # engines has an int32 input and an int32 output.
-        q = math_ops.cumsum(q_shape)
-        q = q * 2
-        return array_ops.identity(q, name="output")
-
     np_input = np.random.random_sample([5, 3]).astype(np.float32)
 
     def _InputFunc():
+      # Passing single input parameter as a tuple with one element
       yield (np_input,)
 
-    # Create the SavedModel.
-    root = ShapeOpModel()
-    expected_output = root.run(np_input)
-    input_saved_model_dir = self.mkdtemp()
-    save.save(root, input_saved_model_dir, signatures=root.run)
-
-    # Convert the graph to TF-TRT.
-    conv_params = trt_convert.TrtConversionParams(minimum_segment_size=2)
-    converter = trt_convert.TrtGraphConverterV2(
-        input_saved_model_dir=input_saved_model_dir,
-        use_dynamic_shape=True,
-        **conv_params._asdict())
-    converter.convert()
-
-    # Build the graph with the input generator. This runs the TRTEngineOp native
-    # segment.
-    converter.build(_InputFunc)
-    output_saved_model_dir = self.mkdtemp()
-    converter.save(output_saved_model_dir)
+    output_saved_model_dir, expected_output = \
+        self._BuildGraphWithInputGenerator(_InputFunc, np_input)
 
     root_with_trt = load.load(output_saved_model_dir)
     converted_signature = root_with_trt.signatures["serving_default"]
@@ -582,9 +667,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     # TODO(laigd): check that it should contain two engines.
     output_saved_model_dir = self.mkdtemp()
     converter.save(output_saved_model_dir)
-    expected_asset_file = os.path.join(
-        output_saved_model_dir,
-        "assets/trt-serialized-engine." + trt_engine_name)
+    expected_asset_file = \
+        self._GetAssetFile(output_saved_model_dir, trt_engine_name)
     self.assertTrue(os.path.exists(expected_asset_file))
     self.assertTrue(os.path.getsize(expected_asset_file))
 
@@ -1027,9 +1111,8 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     converter.save(
         output_saved_model_dir, save_gpu_specific_engines=save_engine_flag)
 
-    expected_asset_file = os.path.join(
-        output_saved_model_dir,
-        "assets/trt-serialized-engine." + trt_engine_name)
+    expected_asset_file = \
+        self._GetAssetFile(output_saved_model_dir, trt_engine_name)
 
     self.assertTrue(os.path.exists(expected_asset_file))
     if save_engine_flag:


### PR DESCRIPTION
The improvement of `TrtGraphConverterV2::_convert_to_tensor()` allows you to pass a single object that will be converted to a tensor. Before that function expected the input parameters to be a list, tuple, or dictionary.

A related example has been added to the docstring `TrtGraphConverterV2::build(self, input_fn)`
