### PR TITLE
TFLite documentation fix

### DIFF
--- a/tensorflow/lite/g3doc/performance/measurement.md
+++ b/tensorflow/lite/g3doc/performance/measurement.md
@@ -96,13 +96,13 @@ for more performance parameters that you could run with the benchmark app.
 View the results using the `logcat` command:
 
 ```shell
-adb logcat | grep "Average inference"
+adb logcat | grep "Inference timings"
 ```
 
 The benchmark results are reported as:
 
 ```
-... tflite  : Average inference timings in us: Warmup: 91471, Init: 4108, Inference: 80660.1
+... tflite  : Inference timings in us: Init: 5685, First inference: 18535, Warmup (avg): 14462.3, Inference (avg): 14575.2
 ```
 
 ### Native benchmark binary


### PR DESCRIPTION
The text printed along with results was changed in commit 48598dddf7a35471fb9dff431652df56306e1ad0.

The string that this document tells users to grep for will no longer work. This change fixes that problem, and replaces the grep string with one that will work with the new result message.