### PR TITLE
[XLA] When dumping the html files, also dump a version without the fusion details.

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/cpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/cpu/cpu_compiler.cc
@@ -1229,7 +1229,7 @@ CpuCompiler::CompileLegacyCpuExecutable(std::unique_ptr<HloModule> module) {
                           std::make_unique<SequentialHloOrdering>(schedule),
                           BufferSizeBytesFunction(), memory_alignment,
                           /*allocate_buffers_for_constants=*/true));
-  DumpHloModuleIfEnabled(*module, *assignment, "cpu_after_optimizations");
+  DumpHloModuleIfEnabled(*module, *assignment, "cpu_" + kAfterOptimizationsDumpName);
 
   // Each computation is a single function.  Emit all embedded computations
   // before the entry computation. The order of computations returned from
@@ -1564,7 +1564,7 @@ CpuCompiler::CompileAheadOfTime(std::unique_ptr<HloModuleGroup> module_group,
       DumpToFileInDirOrStdout(*module, "", "buffer_assignment",
                               assignment->ToString());
     }
-    DumpHloModuleIfEnabled(*module, *assignment, "cpu_after_optimizations");
+    DumpHloModuleIfEnabled(*module, *assignment, "cpu_" + kAfterOptimizationsDumpName);
 
     absl::flat_hash_map<const HloInstruction*, int64_t>
         instruction_to_profile_idx;

--- a/tensorflow/compiler/xla/service/dump.cc
+++ b/tensorflow/compiler/xla/service/dump.cc
@@ -418,10 +418,14 @@ static std::vector<std::string> DumpHloModuleImpl(
         pb, opts, opts.dump_compress_protos));
   }
 
-  auto render_graph = [&](RenderedGraphFormat format) {
+  auto render_graph = [&](RenderedGraphFormat format,
+                          bool show_fusion_subcomputations = true) {
+    HloRenderOptions hlo_render_options;
+    hlo_render_options.show_fusion_subcomputations = show_fusion_subcomputations;
     StatusOr<std::string> rendered_graph = RenderGraph(
         *module.entry_computation(),
-        /*label=*/filename, module.config().debug_options(), format);
+        /*label=*/filename, module.config().debug_options(), format,
+        hlo_render_options);
     if (rendered_graph.ok()) {
       return std::move(rendered_graph).value();
     }
@@ -439,6 +443,12 @@ static std::vector<std::string> DumpHloModuleImpl(
     file_paths.push_back(
         DumpToFileInDirImpl(StrFormat("%s.html", filename),
                             render_graph(RenderedGraphFormat::kHtml), opts));
+    if (absl::StrContains(filename, kAfterOptimizationsDumpName)) {
+      file_paths.push_back(
+	  DumpToFileInDirImpl(StrFormat("%s.top_level.html", filename),
+			      render_graph(RenderedGraphFormat::kHtml, false),
+			      opts));
+    }
   }
 
   if (opts.dump_fusion_visualization) {

--- a/tensorflow/compiler/xla/service/dump.h
+++ b/tensorflow/compiler/xla/service/dump.h
@@ -30,6 +30,11 @@ limitations under the License.
 
 namespace xla {
 
+// Argument used when calling DumpHloModuleIfEnabled before optimizations are
+// performed on an HloModule.
+constexpr char kBeforeOptimizationsDumpName[] = "before_optimizations";
+constexpr char kAfterOptimizationsDumpName[] = "after_optimizations";
+
 class BufferAssignment;
 class HloSnapshot;
 

--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -1071,7 +1071,7 @@ static Status CompileModuleToLlvmIrImpl(
           << results->buffer_assignment->GetStats().ToString();
   DumpHloModuleIfEnabled(*hlo_module, *results->buffer_assignment,
                          absl::StrCat("sm_", cuda_compute_capability.ToString(),
-                                      "_gpu_after_optimizations"));
+                                      "_gpu_", kAfterOptimizationsDumpName));
 
   uint64_t start_usecs = tsl::Env::Default()->NowMicros();
   mlir::DialectRegistry registry;

--- a/tensorflow/compiler/xla/service/service.cc
+++ b/tensorflow/compiler/xla/service/service.cc
@@ -70,10 +70,6 @@ namespace {
 using absl::StrCat;
 using absl::StrFormat;
 
-// Argument used when calling DumpHloModuleIfEnabled before optimizations are
-// performed on an HloModule.
-constexpr char kBeforeOptimizationsDumpName[] = "before_optimizations";
-
 // Records the arguments used to invoke a computation in an HloSnapshot proto.
 Status RecordArguments(const absl::Span<const ShapedBuffer* const> arguments,
                        se::Stream* stream, TransferManager* transfer_manager,


### PR DESCRIPTION
It allows to not dump the fusion internal.

This WAR the issue that "too big" HTML files aren't rendered by the browser.
We can manually look at the txt hlo to see the inside of the fusion.

@cheshire 