### PR TITLE
[mhlo] add missing dependency

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/lib/utils/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/utils/CMakeLists.txt
@@ -21,6 +21,7 @@ add_mlir_dialect_library(MLIRMhloUtils
   hlo_utils.cc
 
   LINK_LIBS PUBLIC
+  ChloOps
   MLIRArithmeticDialect
   MLIRFuncDialect
   MLIRIR


### PR DESCRIPTION
hlo_utils.cc creates `chlo::ConstantLikeOp` ops, thus requiring that
ChloOps be linked into the MLIRMhloUtils library.