### PR TITLE
[XLA] Speed up col reduction for dtype smaller then 32 bits.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -4614,8 +4614,27 @@ StatusOr<ReductionCodegenInfo> IrEmitterUnnested::ComputeReductionCodegenInfo(
       CanVectorizeReduction(cc, fusion, fused_computation, reduction_dimensions,
                             num_threads_x, reduction_tiling, input_shape);
   int vector_size = vectorize ? 2 : 1;
-  int num_partial_results =
-      !reduction_dimensions.is_row_reduction && vectorize ? 2 : 1;
+  int num_partial_results = 1;
+  if (!reduction_dimensions.is_row_reduction && vectorize) {
+    if (smallest_input_dtype_bits <= 32) {
+      // Make sure to use all the data read at once.
+      // Instead of hardcoding the granularity, we can query the granularity we need like this:
+      //   size_t granularity = 0;
+      //   CUresult res = cuCtxGetLimit(&granularity, CU_LIMIT_MAX_L2_FETCH_GRANULARITY); // 0x05
+      // But we need a context to be active. Which isn't the case here.
+      num_partial_results = std::min(64 / smallest_input_dtype_bits, 8);
+
+      // Limit register presure, PRED dtype is only one bit.
+      num_partial_results = std::min(num_partial_results, 8);
+      // Limit register presure for MOF, but still use a minimum of 2.
+      int64_t fan_out = fusion.getFusionRoots().size();
+      num_partial_results /= fan_out;
+      num_partial_results = std::max(num_partial_results, 2);
+    } else {
+      num_partial_results = 2;
+    }
+  }
+
   VLOG(3) << "Each threads will produce " << num_partial_results
           << " output(s)";
   reduction_tiling[kDimX] *= num_partial_results;

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -661,6 +661,45 @@ TEST_F(GpuKernelTilingTest, ColumnReductionSmallTileSizeX) {
 }
 
 TEST_F(GpuKernelTilingTest,
+       ColReductionWithSmallDtype) {
+  const char *const kHloString = R"(
+HloModule mod
+region_0 {
+  Arg_0 = f32[] parameter(0)
+  Arg_1 = f32[] parameter(1)
+  ROOT add = f32[] add(Arg_0, Arg_1)
+}
+fused_computation {
+  param_0.4 = bf16[32,16,512,512]{3,2,1,0} parameter(0)
+  convert.31 = f32[32,16,512,512]{3,2,1,0} convert(param_0.4)
+  constant_1 = f32[] constant(0)
+  ROOT reduce = f32[16,512,512]{2,1,0} reduce(convert.31, constant_1), dimensions={0}, to_apply=region_0
+}
+ENTRY main {
+ Arg_3.4 = bf16[32,16,512,512]{3,2,1,0} parameter(0)
+ ROOT fusion = f32[16,512,512]{2,1,0} fusion(Arg_3.4), kind=kInput, calls=fused_computation
+})";
+
+  // Check that the kernel is not tiled by looking for llvm.nvvm.shfl.sync.down.
+  auto hlo_module =
+      ParseAndReturnVerifiedModule(kHloString, ConfigWithoutLayoutAssignment())
+          .value();
+  auto expected_ir = R"(
+; CHECK-LABEL: define void @fusion
+; CHECK: load <4 x i16>
+; CHECK-COUNT-4: load float
+; CHECK-NOT: load
+; CHECK: }
+)";
+  CompileAndVerifyIr(std::move(hlo_module),
+                     MakePlatformSpecificLlvm(expected_ir),
+                     /*match_optimized_ir=*/true);
+
+  // Check that the kernel runs correctly.
+  EXPECT_TRUE(RunAndCompareNoHloPasses(kHloString, ErrorSpec{0.001}));
+}
+
+TEST_F(GpuKernelTilingTest,
        RowReductionWithSmallNonPowerOfTwoDimensionNotTiled) {
   const char *const kHloString = R"(
     HloModule reduction


### PR DESCRIPTION
It was optimized for float32. Now that we frequently use f16, bf16 and sometimes int8, we need to update it.
This speed up the following kernel on V100 from 860us to 631us.

```
region_0.18.clone {
  Arg_0.0 = f32[] parameter(0)
  Arg_1.0 = f32[] parameter(1)
  ROOT add.0 = f32[] add(Arg_0.0, Arg_1.0)
}
fused_computation.1 {
  param_0.4 = bf16[32,16,512,512]{3,2,1,0} parameter(0)
  convert.31 = f32[32,16,512,512]{3,2,1,0} convert(param_0.4)
  constant_1 = f32[] constant(0)
  ROOT reduce.0 = f32[16,512,512]{2,1,0} reduce(convert.31, constant_1), dimensions={0}, to_apply=region_0.18.clone
}
ENTRY main {
 Arg_3.4 = bf16[32,16,512,512]{3,2,1,0} parameter(0)
 ROOT fusion.1 = f32[16,512,512]{2,1,0} fusion(Arg_3.4), kind=kInput, calls=fused_computation.1
}
```

@cheshire 