### PR TITLE
[TF-TRT] Fix calibration with data dependent shapes

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -660,6 +660,7 @@ void TRTEngineOp::ExecuteCalibration(OpKernelContext* ctx,
   // TODO(laigd): need to check that input shape matches.
   // Pass input data to calibrator
   std::unordered_map<string, void*> input_data;
+  bool input_size_ok = true;
   for (int i = 0; i < num_inputs; i++) {
     const Tensor& t = ctx->input(i);
     void* data_address = GetTensorAddress(&t);
@@ -669,34 +670,42 @@ void TRTEngineOp::ExecuteCalibration(OpKernelContext* ctx,
                       dummy_async_helper);
     // Check the allocated buffer is sufficient for input
     const auto device_tensor = &calib_ctx->device_tensors_.at(i);
-    CHECK_EQ(t.TotalBytes(), device_tensor->TotalBytes());
+    if (t.TotalBytes() != device_tensor->TotalBytes()) {
+      // This can happen if the network has data dependent shapes.
+      input_size_ok = false;
+      VLOG(2) << "Size differs for input " << i
+              << ", skipping calibration for this input.";
+      break;
+    }
     input_data.emplace(StrCat(IONamePrefixes::kInputPHName, i), data_address);
   }
-  VLOG(2) << "Filled map for sending";
-  // Copied from gpu_kernel_helper.h as the header can only be used in *.cu.cc
-  // files.
-  const cudaStream_t* stream = CHECK_NOTNULL(
-      reinterpret_cast<const cudaStream_t*>(ctx->op_device_context()
-                                                ->stream()
-                                                ->implementation()
-                                                ->GpuStreamMemberHack()));
-  // TRTInt8Calibrator::setBatch will wait until TRTInt8Calibrator::getBatch is
-  // called before proceeding with feeding the calibration data to the
-  // calibrator. It returns true if the calibration data is accepted and
-  // returns false if calibration is terminated due to errors.
-  //
-  // If TRTInt8Calibrator::getBatch is never called, which could happen if
-  // there is any problem in building the cuda engine for calibration inside
-  // TensorRT, then the TRTInt8Calibrator::setBatch call here will hang until
-  // TRTInt8Calibrator::setDone is called by the calibration thread in
-  // AllocateCalibrationResources.
-  //
-  // In both of the above cases, setBatch here returns a boolean value to
-  // indicate the result of the calibration process.
-  if (!calib_ctx->calibrator_->setBatch(input_data, *stream)) {
-    VLOG(2) << "Failed to feed calibration data";
-  } else {
-    VLOG(2) << "Passed calibration data";
+  if (input_size_ok) {
+    VLOG(2) << "Filled map for sending";
+    // Copied from gpu_kernel_helper.h as the header can only be used in *.cu.cc
+    // files.
+    const cudaStream_t* stream = CHECK_NOTNULL(
+        reinterpret_cast<const cudaStream_t*>(ctx->op_device_context()
+                                                  ->stream()
+                                                  ->implementation()
+                                                  ->GpuStreamMemberHack()));
+    // TRTInt8Calibrator::setBatch will wait until TRTInt8Calibrator::getBatch
+    // is called before proceeding with feeding the calibration data to the
+    // calibrator. It returns true if the calibration data is accepted and
+    // returns false if calibration is terminated due to errors.
+    //
+    // If TRTInt8Calibrator::getBatch is never called, which could happen if
+    // there is any problem in building the cuda engine for calibration inside
+    // TensorRT, then the TRTInt8Calibrator::setBatch call here will hang until
+    // TRTInt8Calibrator::setDone is called by the calibration thread in
+    // AllocateCalibrationResources.
+    //
+    // In both of the above cases, setBatch here returns a boolean value to
+    // indicate the result of the calibration process.
+    if (!calib_ctx->calibrator_->setBatch(input_data, *stream)) {
+      VLOG(2) << "Failed to feed calibration data";
+    } else {
+      VLOG(2) << "Passed calibration data";
+    }
   }
   ExecuteNativeSegment(ctx, async_helper);
 }

--- a/tensorflow/python/compiler/tensorrt/test/BUILD
+++ b/tensorflow/python/compiler/tensorrt/test/BUILD
@@ -69,6 +69,7 @@ oss_tests = [
     "cast_test",
     "concatenation_test",
     "const_broadcast_test",
+    "data_dependent_shape_test",
     "dynamic_input_shapes_test",
     "identity_output_test",
     "int32_test",

--- a/tensorflow/python/compiler/tensorrt/test/data_dependent_shape_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/data_dependent_shape_test.py
@@ -1,0 +1,73 @@
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Model script to test TF-TensorRT integration with data dependent shapes"""
+
+import os
+
+from unittest import SkipTest  # pylint: disable=g-importing-member
+
+from tensorflow.python.compiler.tensorrt.test import tf_trt_integration_test_base as trt_test
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.platform import test
+
+
+class TrtModeTestBase(trt_test.TfTrtIntegrationTestBase):
+  """Creates a network that has data dependent shapes. """
+
+  def GraphFn(self, x):
+    # With the unique() op we create a tensor with data dependent shape.
+    x = math_ops.floor(x*10)
+    y, idx = array_ops.unique(x)
+    y = y * 2 + y
+
+    # The rest is only needed to ensure that the output has the same size as
+    # the input (expected by the test harness).
+    padding = array_ops.constant([0])
+    n = array_ops.shape(x) - array_ops.shape(y)
+    padding = array_ops.concat([padding, n], 0)
+    padding = array_ops.expand_dims(padding, 0)
+    y = array_ops.pad(y, padding)
+    
+    return array_ops.identity(y, name="output_0")
+
+  def ShouldRunTest(self, run_params):
+    # We have a single dimension, and that is changed, therefore the graph can
+    # only be converted in dynamic shape mode.
+    return (run_params.dynamic_engine and run_params.is_v2 and
+            run_params.dynamic_shape and
+            run_params.use_calibration, "test v2 dynamic engine and "
+            "calibration")
+
+  def setUp(self):
+    super().setUp()
+    # The input shape depends on random input data. It can happen that we do
+    # not have engine for the actual shape. Therefore we enable native segment
+    # execution.
+    os.environ['TF_TRT_ALLOW_ENGINE_NATIVE_SEGMENT_EXECUTION'] = 'True'
+
+  def tearDown(self):
+    super().tearDown()
+    os.environ['TF_TRT_ALLOW_ENGINE_NATIVE_SEGMENT_EXECUTION'] = 'False'
+
+  def GetParams(self):
+    return self.BuildParams(self.GraphFn, dtypes.float32, [[12]], [[12]])
+
+  def ExpectedEnginesToBuild(self, run_params):
+    return ["TRTEngineOp_000", "TRTEngineOp_001"]
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
A network can have tensors with data dependent shapes, and these can be also inputs for a TensorRT engine. During calibration TensorRT expects that the input data has constant shape. Previously such network crashed during calibration.

This PR implements a workaround for this case: we skip over inputs whose shape is inconsistent with the calibration profile (defined by the first input used for calibration).