### PR TITLE
[NVIDIA TF] Enable BF16 Conv Ops

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -274,6 +274,7 @@ tf_kernel_library(
         "conv_2d_gpu_double.cu.cc",
         "conv_2d_gpu_float.cu.cc",
         "conv_2d_gpu_half.cu.cc",
+        "conv_2d_gpu_bfloat16.cu.cc",
         "conv_2d_gpu_int.cu.cc",
         "conv_2d_gpu_int_spatial_convolution.cu.cc",
         "conv_2d_gpu_int_spatial_convolution_backward.cu.cc",
@@ -4122,6 +4123,7 @@ tf_kernel_library(
     gpu_srcs = [
         "depthwise_conv_op.h",
         "depthwise_conv_op_gpu.h",
+        "depthwise_conv_op_gpu_bfloat16.cu.cc",
         "depthwise_conv_op_gpu_double.cu.cc",
         "depthwise_conv_op_gpu_float.cu.cc",
         "depthwise_conv_op_gpu_half.cu.cc",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4058,6 +4058,7 @@ tf_kernel_library(
     ],
     prefix = "conv_ops",
     deps = [
+        ":cast_op",
         ":conv_grad_shape_utils",
         ":conv_2d",
         ":conv_3d",

--- a/tensorflow/core/kernels/conv_2d_gpu_bfloat16.cu.cc
+++ b/tensorflow/core/kernels/conv_2d_gpu_bfloat16.cu.cc
@@ -1,0 +1,51 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <utility>
+
+#include "tensorflow/core/kernels/conv_2d.h"
+#include "tensorflow/core/kernels/conv_2d_gpu.h"
+
+namespace tensorflow {
+
+namespace functor {
+
+template struct SwapDimension1And2InTensor3<Eigen::GpuDevice, Eigen::bfloat16>;
+
+// For 2d ops.
+template struct TransformFilter<Eigen::GpuDevice, Eigen::bfloat16, int, 4>;
+template struct ReverseTransformFilter<Eigen::GpuDevice, Eigen::bfloat16, 4>;
+template struct NHWCToNCHW<Eigen::GpuDevice, Eigen::bfloat16, 4>;
+template struct NCHWToNHWC<Eigen::GpuDevice, Eigen::bfloat16, 4>;
+template struct PadInput<Eigen::GpuDevice, Eigen::bfloat16, int, 4>;
+
+// For 3d ops.
+template struct TransformFilter<Eigen::GpuDevice, Eigen::bfloat16, int, 5>;
+template struct ReverseTransformFilter<Eigen::GpuDevice, Eigen::bfloat16, 5>;
+template struct NHWCToNCHW<Eigen::GpuDevice, Eigen::bfloat16, 5>;
+template struct NCHWToNHWC<Eigen::GpuDevice, Eigen::bfloat16, 5>;
+template struct PadInput<Eigen::GpuDevice, Eigen::bfloat16, int, 5>;
+
+}  // namespace functor
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -49,6 +49,7 @@ limitations under the License.
 #endif
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "tensorflow/core/kernels/cast_op.h"
 #include "tensorflow/core/kernels/conv_ops_gpu.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/protobuf/autotuning.pb.h"
@@ -580,7 +581,7 @@ typedef AutotuneSingleton<ConvBackwardFilterAutotuneGroup, ConvParameters,
     AutotuneConvBwdFilter;
 
 template <typename T>
-void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
+void LaunchConv2DBackpropFilterOpImpl(
     OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
     const Tensor& out_backprop, const Tensor& input, int row_dilation,
     int col_dilation, int row_stride, int col_stride, const Padding& padding,
@@ -921,6 +922,70 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
       filter_backprop->tensor<T, 4>());
 }
 
+template <typename T>
+void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
+    OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
+    const Tensor& out_backprop, const Tensor& input, int row_dilation,
+    int col_dilation, int row_stride, int col_stride, const Padding& padding,
+    const std::vector<int64_t>& explicit_paddings, Tensor* filter_backprop,
+    TensorFormat data_format) {
+  LaunchConv2DBackpropFilterOpImpl<T>(
+      ctx, use_cudnn, cudnn_use_autotune, out_backprop, input, row_dilation,
+      col_dilation, row_stride, col_stride, padding, explicit_paddings,
+      filter_backprop, data_format);
+}
+
+template <>
+void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, Eigen::bfloat16>::
+operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
+           const Tensor& out_backprop, const Tensor& input, int row_dilation,
+           int col_dilation, int row_stride, int col_stride,
+           const Padding& padding,
+           const std::vector<int64_t>& explicit_paddings,
+           Tensor* filter_backprop, TensorFormat data_format) {
+  // Performant bfloat16 operations are supported for Ampere+ GPUs. For
+  // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
+  auto* stream = ctx->op_device_context()->stream();
+  const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
+      se::CudaComputeCapability::AMPERE);
+  Tensor casted_input = input;
+  Tensor casted_out_backprop = out_backprop;
+  Tensor casted_filter_backprop = *filter_backprop;
+
+  if (cast_to_float) {
+    const GPUDevice& device = ctx->eigen_device<GPUDevice>();
+    functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
+    OP_REQUIRES_OK(ctx,
+                   ctx->allocate_temp(DT_FLOAT, input.shape(), &casted_input));
+    cast(device, casted_input.template flat<float>(),
+         input.template flat<Eigen::bfloat16>());
+
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, out_backprop.shape(),
+                                           &casted_out_backprop));
+    cast(device, casted_out_backprop.template flat<float>(),
+         out_backprop.template flat<Eigen::bfloat16>());
+
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, filter_backprop->shape(),
+                                           &casted_filter_backprop));
+
+    LaunchConv2DBackpropFilterOpImpl<float>(
+        ctx, use_cudnn, cudnn_use_autotune, casted_out_backprop, casted_input,
+        row_dilation, col_dilation, row_stride, col_stride, padding,
+        explicit_paddings, &casted_filter_backprop, data_format);
+
+    functor::CastFunctor<GPUDevice, Eigen::bfloat16, float> cast_back;
+    const Tensor& casted_filter_backprop_const = casted_filter_backprop;
+    cast_back(device, filter_backprop->template flat<Eigen::bfloat16>(),
+              casted_filter_backprop_const.template flat<float>());
+    return;
+  }
+
+  LaunchConv2DBackpropFilterOpImpl<Eigen::bfloat16>(
+      ctx, use_cudnn, cudnn_use_autotune, casted_out_backprop, casted_input,
+      row_dilation, col_dilation, row_stride, col_stride, padding,
+      explicit_paddings, &casted_filter_backprop, data_format);
+}
+
 // Forward declarations of the functor specializations for GPU.
 namespace functor {
 #define DECLARE_GPU_SPEC(T)                                             \
@@ -941,6 +1006,7 @@ namespace functor {
 
 DECLARE_GPU_SPEC(float);
 DECLARE_GPU_SPEC(Eigen::half);
+DECLARE_GPU_SPEC(Eigen::bfloat16);
 DECLARE_GPU_SPEC(double);
 #undef DECLARE_GPU_SPEC
 }  // namespace functor
@@ -960,6 +1026,11 @@ REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropFilter")
                             .TypeConstraint<Eigen::half>("T")
                             .HostMemory("filter_sizes"),
                         Conv2DBackpropFilterOp<GPUDevice, Eigen::half>);
+REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropFilter")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<Eigen::bfloat16>("T")
+                            .HostMemory("filter_sizes"),
+                        Conv2DBackpropFilterOp<GPUDevice, Eigen::bfloat16>);
 
 // To be used inside depthwise_conv_grad_op.cc.
 // TODO(reedwm): Move this and the definition to depthwise_conv_grad_op.cc.

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/core/profiler/lib/scoped_annotation.h"
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "tensorflow/core/kernels/cast_op.h"
 #include "tensorflow/core/protobuf/autotuning.pb.h"
 #include "tensorflow/core/util/autotune_maps/conv_parameters.h"
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -70,7 +71,7 @@ struct LaunchConv2DBackpropInputOp<GPUDevice, int32> {
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 template <typename T>
-void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
+void LaunchConv2DBackpropInputOpGpuImpl(
     OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
     const Tensor& out_backprop, const Tensor& filter, int row_dilation,
     int col_dilation, int row_stride, int col_stride, const Padding& padding,
@@ -430,6 +431,69 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
   }
 }
 
+template <typename T>
+void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
+    OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
+    const Tensor& out_backprop, const Tensor& filter, int row_dilation,
+    int col_dilation, int row_stride, int col_stride, const Padding& padding,
+    const std::vector<int64_t>& explicit_paddings, Tensor* in_backprop,
+    TensorFormat data_format) {
+  LaunchConv2DBackpropInputOpGpuImpl<T>(
+      ctx, use_cudnn, cudnn_use_autotune, out_backprop, filter, row_dilation,
+      col_dilation, row_stride, col_stride, padding, explicit_paddings,
+      in_backprop, data_format);
+}
+
+template <>
+void LaunchConv2DBackpropInputOp<GPUDevice, Eigen::bfloat16>::operator()(
+    OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
+    const Tensor& out_backprop, const Tensor& filter, int row_dilation,
+    int col_dilation, int row_stride, int col_stride, const Padding& padding,
+    const std::vector<int64_t>& explicit_paddings, Tensor* in_backprop,
+    TensorFormat data_format) {
+  // Performant bfloat16 operations are supported for Ampere+ GPUs. For
+  // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
+  auto* stream = ctx->op_device_context()->stream();
+  const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
+      se::CudaComputeCapability::AMPERE);
+  Tensor casted_out_backprop = out_backprop;
+  Tensor casted_filter = filter;
+  Tensor casted_in_backprop = *in_backprop;
+
+  if (cast_to_float) {
+    const GPUDevice& device = ctx->eigen_device<GPUDevice>();
+    functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, out_backprop.shape(),
+                                           &casted_out_backprop));
+    cast(device, casted_out_backprop.template flat<float>(),
+         out_backprop.template flat<Eigen::bfloat16>());
+
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_FLOAT, filter.shape(), &casted_filter));
+    cast(device, casted_filter.template flat<float>(),
+         filter.template flat<Eigen::bfloat16>());
+
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, in_backprop->shape(),
+                                           &casted_in_backprop));
+
+    LaunchConv2DBackpropInputOpGpuImpl<float>(
+        ctx, use_cudnn, cudnn_use_autotune, casted_out_backprop, casted_filter,
+        row_dilation, col_dilation, row_stride, col_stride, padding,
+        explicit_paddings, &casted_in_backprop, data_format);
+
+    functor::CastFunctor<GPUDevice, Eigen::bfloat16, float> cast_back;
+    const Tensor& casted_in_backprop_const = casted_in_backprop;
+    cast_back(device, in_backprop->template flat<Eigen::bfloat16>(),
+              casted_in_backprop_const.template flat<float>());
+    return;
+  }
+
+  LaunchConv2DBackpropInputOpGpuImpl<Eigen::bfloat16>(
+      ctx, use_cudnn, cudnn_use_autotune, casted_out_backprop, casted_filter,
+      row_dilation, col_dilation, row_stride, col_stride, padding,
+      explicit_paddings, &casted_in_backprop, data_format);
+}
+
 // Forward declarations of the functor specializations for GPU.
 namespace functor {
 #define DECLARE_GPU_SPEC(T)                                             \
@@ -450,6 +514,7 @@ namespace functor {
 
 DECLARE_GPU_SPEC(float);
 DECLARE_GPU_SPEC(Eigen::half);
+DECLARE_GPU_SPEC(Eigen::bfloat16);
 DECLARE_GPU_SPEC(double);
 #undef DECLARE_GPU_SPEC
 
@@ -491,6 +556,11 @@ REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropInput")
                             .TypeConstraint<Eigen::half>("T")
                             .HostMemory("input_sizes"),
                         Conv2DBackpropInputOp<GPUDevice, Eigen::half>);
+REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropInput")
+                            .Device(DEVICE_GPU)
+                            .TypeConstraint<Eigen::bfloat16>("T")
+                            .HostMemory("input_sizes"),
+                        Conv2DBackpropInputOp<GPUDevice, Eigen::bfloat16>);
 REGISTER_KERNEL_BUILDER(Name("Conv2DBackpropInput")
                             .Device(DEVICE_GPU)
                             .TypeConstraint<int32>("T")

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -44,6 +44,7 @@ limitations under the License.
 #endif
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "tensorflow/core/kernels/cast_op.h"
 #include "tensorflow/core/platform/stream_executor.h"
 using stream_executor::dnn::DimIndex;
 #include "tensorflow/core/protobuf/autotuning.pb.h"
@@ -1233,6 +1234,7 @@ namespace functor {
       const T& padding_value);
 
 DECLARE_GPU_SPEC(Eigen::half);
+DECLARE_GPU_SPEC(Eigen::bfloat16);
 DECLARE_GPU_SPEC(float);
 DECLARE_GPU_SPEC(double);
 #undef DECLARE_GPU_SPEC
@@ -1247,6 +1249,367 @@ typedef AutotuneSingleton<Conv3dBackwardDataAutotuneGroup, ConvParameters,
                           AutotuneEntry<se::dnn::ConvOp>>
 
     AutotuneConv3dBwdData;
+
+template <typename T>
+void LaunchConvBackpropInputOpImpl(
+    OpKernelContext* context, bool cudnn_use_autotune,
+    const Tensor& out_backprop, const Tensor& filter,
+    const std::vector<int32>& dilation, const std::vector<int32>& stride,
+    const Padding& padding, Tensor* in_backprop, TensorFormat data_format) {
+  const TensorShape& filter_shape = filter.shape();
+  const TensorShape& out_backprop_shape = out_backprop.shape();
+  const TensorShape& input_shape = in_backprop->shape();
+
+  ConvBackpropDimensions dims;
+  OP_REQUIRES_OK(
+      context, ConvBackpropComputeDimensionsV2(
+                   "Conv3DBackpropInputOp", /*num_spatial_dims=*/3, input_shape,
+                   filter_shape, out_backprop_shape, dilation, stride, padding,
+                   /*explicit_paddings=*/{}, data_format, &dims));
+
+  auto* stream = context->op_device_context()->stream();
+  OP_REQUIRES(context, stream, errors::Internal("No GPU stream available."));
+
+  bool is_grouped_convolution = filter_shape.dim_size(3) != dims.in_depth;
+  if (!is_grouped_convolution && dims.filter_size(0) == 1 &&
+      dims.filter_size(1) == 1 && dims.filter_size(2) == 1 &&
+      dims.dilation(0) == 1 && dims.dilation(1) == 1 && dims.dilation(2) == 1 &&
+      dims.stride(0) == 1 && dims.stride(1) == 1 && dims.stride(2) == 1 &&
+      data_format == FORMAT_NHWC) {
+    const uint64 m = dims.batch_size * dims.input_size(0) * dims.input_size(1) *
+                     dims.input_size(2);
+    const uint64 k = dims.out_depth;
+    const uint64 n = dims.in_depth;
+
+    auto a_ptr = AsDeviceMemory(out_backprop.template flat<T>().data(),
+                                out_backprop.template flat<T>().size());
+    auto b_ptr = AsDeviceMemory(filter.template flat<T>().data(),
+                                filter.template flat<T>().size());
+    auto c_ptr = AsDeviceMemory(in_backprop->template flat<T>().data(),
+                                in_backprop->template flat<T>().size());
+
+    auto transpose = se::blas::Transpose::kTranspose;
+    auto no_transpose = se::blas::Transpose::kNoTranspose;
+
+    OP_REQUIRES_OK(
+        context,
+        stream->ThenBlasGemm(transpose, no_transpose, n, m, k, b_ptr, k, a_ptr,
+                             k, &c_ptr, n, se::blas::kDefaultComputePrecision));
+    return;
+  } else if (!is_grouped_convolution &&
+             dims.filter_size(0) == dims.input_size(0) &&
+             dims.filter_size(1) == dims.input_size(1) &&
+             dims.filter_size(2) == dims.input_size(2) &&
+             padding == Padding::VALID && data_format == FORMAT_NHWC) {
+    const uint64 m = dims.batch_size;
+    const uint64 k = dims.out_depth;
+    const uint64 n = dims.input_size(0) * dims.input_size(1) *
+                     dims.input_size(2) * dims.in_depth;
+
+    auto a_ptr = AsDeviceMemory(out_backprop.template flat<T>().data(),
+                                out_backprop.template flat<T>().size());
+    auto b_ptr = AsDeviceMemory(filter.template flat<T>().data(),
+                                filter.template flat<T>().size());
+    auto c_ptr = AsDeviceMemory(in_backprop->template flat<T>().data(),
+                                in_backprop->template flat<T>().size());
+
+    auto transpose = se::blas::Transpose::kTranspose;
+    auto no_transpose = se::blas::Transpose::kNoTranspose;
+
+    OP_REQUIRES_OK(
+        context,
+        stream->ThenBlasGemm(transpose, no_transpose, n, m, k, b_ptr, k, a_ptr,
+                             k, &c_ptr, n, se::blas::kDefaultComputePrecision));
+    return;
+  }
+
+  int padding_planes = dims.SpatialPadding(padding, 0);
+  int padding_rows = dims.SpatialPadding(padding, 1);
+  int padding_cols = dims.SpatialPadding(padding, 2);
+  const bool planes_odd = (padding_planes % 2 != 0);
+  const bool rows_odd = (padding_rows % 2 != 0);
+  const bool cols_odd = (padding_cols % 2 != 0);
+
+  TensorShape compatible_input_shape;
+  if (rows_odd || cols_odd || planes_odd) {
+    // cuDNN only supports the same amount of padding on both sides.
+    compatible_input_shape = {
+        dims.batch_size,
+        dims.in_depth,
+        dims.input_size(0) + planes_odd,
+        dims.input_size(1) + rows_odd,
+        dims.input_size(2) + cols_odd,
+    };
+  } else {
+    compatible_input_shape = {dims.batch_size, dims.in_depth,
+                              dims.input_size(0), dims.input_size(1),
+                              dims.input_size(2)};
+  }
+
+  CHECK(padding_rows >= 0 && padding_cols >= 0 && padding_planes >= 0)
+      << "Negative paddings: (" << padding_rows << ", " << padding_cols << ", "
+      << padding_planes << ")";
+
+  const bool compute_in_nhwc = ComputeInNhwcEnabled(
+      DataTypeToEnum<T>::value, stream, /*use_4d_tensor=*/false);
+
+  const TensorFormat compute_data_format =
+      (compute_in_nhwc && data_format == FORMAT_NHWC) ? FORMAT_NHWC
+                                                      : FORMAT_NCHW;
+
+  VLOG(3) << "Compute Conv3DBackpropInput with cuDNN:"
+          << " data_format=" << ToString(data_format)
+          << " compute_data_format=" << ToString(compute_data_format);
+
+  constexpr auto kComputeInNHWC =
+      std::make_tuple(se::dnn::DataLayout::kBatchYXDepth,
+                      se::dnn::FilterLayout::kOutputYXInput);
+  constexpr auto kComputeInNCHW =
+      std::make_tuple(se::dnn::DataLayout::kBatchDepthYX,
+                      se::dnn::FilterLayout::kOutputInputYX);
+
+  se::dnn::DataLayout compute_data_layout;
+  se::dnn::FilterLayout filter_layout;
+
+  std::tie(compute_data_layout, filter_layout) =
+      compute_data_format == FORMAT_NHWC ? kComputeInNHWC : kComputeInNCHW;
+
+  se::dnn::BatchDescriptor input_desc(3);
+  input_desc.set_count(dims.batch_size)
+      .set_spatial_dim(DimIndex::X, compatible_input_shape.dim_size(4))
+      .set_spatial_dim(DimIndex::Y, compatible_input_shape.dim_size(3))
+      .set_spatial_dim(DimIndex::Z, compatible_input_shape.dim_size(2))
+      .set_feature_map_count(dims.in_depth)
+      .set_layout(compute_data_layout);
+  se::dnn::BatchDescriptor output_desc(3);
+  output_desc.set_count(dims.batch_size)
+      .set_spatial_dim(DimIndex::X, dims.output_size(2))
+      .set_spatial_dim(DimIndex::Y, dims.output_size(1))
+      .set_spatial_dim(DimIndex::Z, dims.output_size(0))
+      .set_feature_map_count(dims.out_depth)
+      .set_layout(compute_data_layout);
+  se::dnn::FilterDescriptor filter_desc(3);
+  filter_desc.set_spatial_dim(DimIndex::X, dims.filter_size(2))
+      .set_spatial_dim(DimIndex::Y, dims.filter_size(1))
+      .set_spatial_dim(DimIndex::Z, dims.filter_size(0))
+      .set_input_feature_map_count(filter_shape.dim_size(3))
+      .set_output_feature_map_count(filter_shape.dim_size(4))
+      .set_layout(filter_layout);
+  se::dnn::ConvolutionDescriptor conv_desc(3);
+  conv_desc.set_dilation_rate(DimIndex::X, dims.dilation(2))
+      .set_dilation_rate(DimIndex::Y, dims.dilation(1))
+      .set_dilation_rate(DimIndex::Z, dims.dilation(0))
+      .set_filter_stride(DimIndex::X, dims.stride(2))
+      .set_filter_stride(DimIndex::Y, dims.stride(1))
+      .set_filter_stride(DimIndex::Z, dims.stride(0))
+      .set_zero_padding(DimIndex::X, padding_cols / 2)
+      .set_zero_padding(DimIndex::Y, padding_rows / 2)
+      .set_zero_padding(DimIndex::Z, padding_planes / 2)
+      .set_group_count(dims.in_depth / filter_shape.dim_size(3));
+
+  // Shape: out, in, z, y, x.
+  Tensor transformed_filter;
+  auto dst_format =
+      compute_data_format == FORMAT_NCHW ? FORMAT_OIHW : FORMAT_OHWI;
+  TensorShape dst_shape =
+      dst_format == FORMAT_OIHW
+          ? TensorShape({filter_shape.dim_size(4), filter_shape.dim_size(3),
+                         dims.filter_size(0), dims.filter_size(1),
+                         dims.filter_size(2)})
+          : TensorShape({filter_shape.dim_size(4), dims.filter_size(0),
+                         dims.filter_size(1), dims.filter_size(2),
+                         filter_shape.dim_size(3)});
+  OP_REQUIRES_OK(context,
+                 context->allocate_temp(DataTypeToEnum<T>::value, dst_shape,
+                                        &transformed_filter));
+
+  functor::TransformFilter<GPUDevice, T, int, 5>()(
+      context->eigen_device<GPUDevice>(), dst_format,
+      To32Bit(filter.tensor<T, 5>()),
+      To32Bit(transformed_filter.tensor<T, 5>()));
+
+  // Shape: batch, filters, z, y, x.
+  Tensor transformed_out_backprop;
+  if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
+    TensorShape nchw_shape = {dims.batch_size, dims.out_depth,
+                              dims.output_size(0), dims.output_size(1),
+                              dims.output_size(2)};
+    if (dims.out_depth > 1) {
+      OP_REQUIRES_OK(
+          context, context->allocate_temp(DataTypeToEnum<T>::value, nchw_shape,
+                                          &transformed_out_backprop));
+      functor::NHWCToNCHW<GPUDevice, T, 5>()(
+          context->eigen_device<GPUDevice>(), out_backprop.tensor<T, 5>(),
+          transformed_out_backprop.tensor<T, 5>());
+    } else {
+      CHECK(transformed_out_backprop.CopyFrom(out_backprop, nchw_shape));
+    }
+  } else {
+    transformed_out_backprop = out_backprop;
+  }
+  // Shape: batch, filters, z, y, x.
+  Tensor pre_transformed_in_backprop;
+  OP_REQUIRES_OK(context,
+                 context->allocate_temp(
+                     DataTypeToEnum<T>::value,
+                     ShapeFromFormat(compute_data_format,
+                                     compatible_input_shape.dim_size(0),
+                                     {{compatible_input_shape.dim_size(2),
+                                       compatible_input_shape.dim_size(3),
+                                       compatible_input_shape.dim_size(4)}},
+                                     compatible_input_shape.dim_size(1)),
+                     &pre_transformed_in_backprop));
+
+  auto out_backprop_ptr =
+      AsDeviceMemory(transformed_out_backprop.template flat<T>().data(),
+                     transformed_out_backprop.template flat<T>().size());
+  auto filter_ptr =
+      AsDeviceMemory(transformed_filter.template flat<T>().data(),
+                     transformed_filter.template flat<T>().size());
+  auto in_backprop_ptr =
+      AsDeviceMemory(pre_transformed_in_backprop.template flat<T>().data(),
+                     pre_transformed_in_backprop.template flat<T>().size());
+
+  static int64_t ConvolveBackwardDataScratchSize = GetDnnWorkspaceLimit(
+      "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 33);  // 8GB by default
+
+  // To make sure the Conv3DBackpropInputV2 get the correct dtype, we infer
+  // the dtype from 2nd input, i.e., out_backprop.
+  DataType dtype = context->input(2).dtype();
+  const ConvParameters conv_parameters = {
+      stream->parent(),
+      dims.batch_size,
+      dims.in_depth,
+      {{dims.input_size(0), dims.input_size(1), dims.input_size(2)}},
+      compute_data_format,
+      dims.out_depth,
+      {{dims.filter_size(0), dims.filter_size(1), dims.filter_size(2)}},
+      {{dims.dilation(0), dims.dilation(1), dims.dilation(2)}},
+      {{dims.stride(0), dims.stride(1), dims.stride(2)}},
+      {{padding_planes, padding_rows, padding_cols}},
+      dtype,
+      conv_desc.group_count(),
+  };
+
+  using se::dnn::AlgorithmConfig;
+  using se::dnn::AlgorithmDesc;
+  using se::dnn::ProfileResult;
+
+  auto entry_or = AutotuneUnfusedConv(
+      cudnn_use_autotune, AutotuneConv3dBwdData::GetInstance(), conv_parameters,
+      context, se::dnn::ConvolutionKind::BACKWARD_DATA, input_desc,
+      in_backprop_ptr, filter_desc, filter_ptr, conv_desc, output_desc,
+      out_backprop_ptr, ConvolveBackwardDataScratchSize);
+  OP_REQUIRES_OK(context, entry_or.status());
+  auto autotune_entry = std::move(entry_or).value();
+
+  DnnScratchAllocator scratch_allocator(ConvolveBackwardDataScratchSize,
+                                        context);
+  Status cudnn_launch_status =
+      LaunchAutotunedConv(autotune_entry, &scratch_allocator,
+                          se::dnn::ConvolutionKind::BACKWARD_DATA, stream,
+                          input_desc, in_backprop_ptr, filter_desc, filter_ptr,
+                          conv_desc, output_desc, out_backprop_ptr);
+  if (!cudnn_launch_status.ok()) {
+    context->SetStatus(cudnn_launch_status);
+    return;
+  }
+
+  if (rows_odd || cols_odd || planes_odd) {
+    Tensor in_backprop_remove_padding;
+    OP_REQUIRES_OK(context,
+                   context->allocate_temp(
+                       DataTypeToEnum<T>::value,
+                       ShapeFromFormat(compute_data_format, dims.batch_size,
+                                       {{dims.input_size(0), dims.input_size(1),
+                                         dims.input_size(2)}},
+                                       dims.in_depth),
+                       &in_backprop_remove_padding));
+
+    // Remove the padding for odd spatial dimensions.
+    functor::PadInput<GPUDevice, T, int, 5>()(
+        context->eigen_device<GPUDevice>(),
+        To32Bit(const_cast<const Tensor&>(pre_transformed_in_backprop)
+                    .tensor<T, 5>()),
+        {{0, 0, 0}}, {{-planes_odd, -rows_odd, -cols_odd}},
+        To32Bit(in_backprop_remove_padding.tensor<T, 5>()), compute_data_format,
+        T{});
+
+    pre_transformed_in_backprop = in_backprop_remove_padding;
+  }
+
+  if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
+    auto toConstTensor = [](const Tensor& x) -> const Tensor { return x; };
+    functor::NCHWToNHWC<GPUDevice, T, 5>()(
+        context->eigen_device<GPUDevice>(),
+        toConstTensor(pre_transformed_in_backprop).template tensor<T, 5>(),
+        in_backprop->tensor<T, 5>());
+  } else {
+    *in_backprop = pre_transformed_in_backprop;
+  }
+}
+
+template <typename T>
+struct LaunchConvBackpropInputOp {
+  static void launch(OpKernelContext* context, bool cudnn_use_autotune,
+                     const Tensor& out_backprop, const Tensor& filter,
+                     const std::vector<int32>& dilation,
+                     const std::vector<int32>& stride, const Padding& padding,
+                     Tensor* in_backprop, TensorFormat data_format) {
+    LaunchConvBackpropInputOpImpl<T>(context, cudnn_use_autotune, out_backprop,
+                                     filter, dilation, stride, padding,
+                                     in_backprop, data_format);
+  }
+};
+
+template <>
+struct LaunchConvBackpropInputOp<Eigen::bfloat16> {
+  static void launch(OpKernelContext* ctx, bool cudnn_use_autotune,
+                     const Tensor& out_backprop, const Tensor& filter,
+                     const std::vector<int32>& dilation,
+                     const std::vector<int32>& strides, const Padding& padding,
+                     Tensor* in_backprop, TensorFormat data_format) {
+    // Performant bfloat16 operations are supported for Ampere+ GPUs. For
+    // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
+    auto* stream = ctx->op_device_context()->stream();
+    const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
+        se::CudaComputeCapability::AMPERE);
+    Tensor casted_out_backprop = out_backprop;
+    Tensor casted_filter = filter;
+    Tensor casted_in_backprop = *in_backprop;
+
+    if (cast_to_float) {
+      const GPUDevice& device = ctx->eigen_device<GPUDevice>();
+      functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
+      OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, out_backprop.shape(),
+                                             &casted_out_backprop));
+      cast(device, casted_out_backprop.template flat<float>(),
+           out_backprop.template flat<Eigen::bfloat16>());
+
+      OP_REQUIRES_OK(
+          ctx, ctx->allocate_temp(DT_FLOAT, filter.shape(), &casted_filter));
+      cast(device, casted_filter.template flat<float>(),
+           filter.template flat<Eigen::bfloat16>());
+
+      OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, in_backprop->shape(),
+                                             &casted_in_backprop));
+
+      LaunchConvBackpropInputOpImpl<float>(
+          ctx, cudnn_use_autotune, casted_out_backprop, casted_filter, dilation,
+          strides, padding, &casted_in_backprop, data_format);
+
+      functor::CastFunctor<GPUDevice, Eigen::bfloat16, float> cast_back;
+      const Tensor& casted_in_backprop_const = casted_in_backprop;
+      cast_back(device, in_backprop->template flat<Eigen::bfloat16>(),
+                casted_in_backprop_const.template flat<float>());
+      return;
+    }
+
+    LaunchConvBackpropInputOpImpl<Eigen::bfloat16>(
+        ctx, cudnn_use_autotune, casted_out_backprop, casted_filter, dilation,
+        strides, padding, &casted_in_backprop, data_format);
+  }
+};
 
 template <typename T>
 class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
@@ -1299,10 +1662,8 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
   }
   void Compute(OpKernelContext* context) override {
     const Tensor& filter = context->input(1);
-    const TensorShape& filter_shape = filter.shape();
 
     const Tensor& out_backprop = context->input(2);
-    const TensorShape& out_backprop_shape = out_backprop.shape();
 
     TensorShape input_shape;
     if (takes_shape_) {
@@ -1311,13 +1672,6 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
     } else {
       input_shape = context->input(0).shape();
     }
-
-    ConvBackpropDimensions dims;
-    OP_REQUIRES_OK(context, ConvBackpropComputeDimensionsV2(
-                                "Conv3DBackpropInputOp", /*num_spatial_dims=*/3,
-                                input_shape, filter_shape, out_backprop_shape,
-                                dilation_, stride_, padding_,
-                                /*explicit_paddings=*/{}, data_format_, &dims));
 
     Tensor* in_backprop;
     OP_REQUIRES_OK(context,
@@ -1328,97 +1682,162 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
       }
     }
 
-    auto* stream = context->op_device_context()->stream();
-    OP_REQUIRES(context, stream, errors::Internal("No GPU stream available."));
+    LaunchConvBackpropInputOp<T>::launch(
+        context, cudnn_use_autotune_, out_backprop, filter, dilation_, stride_,
+        padding_, in_backprop, data_format_);
+  }
 
-    bool is_grouped_convolution = filter_shape.dim_size(3) != dims.in_depth;
-    if (!is_grouped_convolution && dims.filter_size(0) == 1 &&
-        dims.filter_size(1) == 1 && dims.filter_size(2) == 1 &&
-        dims.dilation(0) == 1 && dims.dilation(1) == 1 &&
-        dims.dilation(2) == 1 && dims.stride(0) == 1 && dims.stride(1) == 1 &&
-        dims.stride(2) == 1 && data_format_ == FORMAT_NHWC) {
-      const uint64 m = dims.batch_size * dims.input_size(0) *
-                       dims.input_size(1) * dims.input_size(2);
-      const uint64 k = dims.out_depth;
-      const uint64 n = dims.in_depth;
+ private:
+  std::vector<int32> dilation_;
+  std::vector<int32> stride_;
+  Padding padding_;
+  TensorFormat data_format_;
+  bool takes_shape_;
+  bool cudnn_use_autotune_;
+};
 
-      auto a_ptr = AsDeviceMemory(out_backprop.template flat<T>().data(),
-                                  out_backprop.template flat<T>().size());
-      auto b_ptr = AsDeviceMemory(filter.template flat<T>().data(),
-                                  filter.template flat<T>().size());
-      auto c_ptr = AsDeviceMemory(in_backprop->template flat<T>().data(),
-                                  in_backprop->template flat<T>().size());
+// A dummy type to group backward filter autotune results together.
+struct Conv3dBackwardFilterAutotuneGroup {
+  static string name() { return "Conv3dBwdFilter"; }
+};
 
-      auto transpose = se::blas::Transpose::kTranspose;
-      auto no_transpose = se::blas::Transpose::kNoTranspose;
+typedef AutotuneSingleton<Conv3dBackwardFilterAutotuneGroup, ConvParameters,
+                          AutotuneEntry<se::dnn::ConvOp>>
+    AutotuneConv3dBwdFilter;
 
-      OP_REQUIRES_OK(
-          context, stream->ThenBlasGemm(transpose, no_transpose, n, m, k, b_ptr,
-                                        k, a_ptr, k, &c_ptr, n,
-                                        se::blas::kDefaultComputePrecision));
-      return;
-    } else if (!is_grouped_convolution &&
-               dims.filter_size(0) == dims.input_size(0) &&
-               dims.filter_size(1) == dims.input_size(1) &&
-               dims.filter_size(2) == dims.input_size(2) &&
-               padding_ == Padding::VALID && data_format_ == FORMAT_NHWC) {
-      const uint64 m = dims.batch_size;
-      const uint64 k = dims.out_depth;
-      const uint64 n = dims.input_size(0) * dims.input_size(1) *
-                       dims.input_size(2) * dims.in_depth;
+template <typename T>
+void LaunchConvBackpropFilterOpImpl(
+    OpKernelContext* context, bool cudnn_use_autotune, const Tensor& input,
+    const Tensor& out_backprop, const std::vector<int32>& dilation,
+    const std::vector<int32>& stride, const Padding& padding,
+    Tensor* filter_backprop, TensorFormat data_format) {
+  const TensorShape& input_shape = input.shape();
+  const TensorShape& out_backprop_shape = out_backprop.shape();
+  const TensorShape& filter_shape = filter_backprop->shape();
 
-      auto a_ptr = AsDeviceMemory(out_backprop.template flat<T>().data(),
-                                  out_backprop.template flat<T>().size());
-      auto b_ptr = AsDeviceMemory(filter.template flat<T>().data(),
-                                  filter.template flat<T>().size());
-      auto c_ptr = AsDeviceMemory(in_backprop->template flat<T>().data(),
-                                  in_backprop->template flat<T>().size());
+  ConvBackpropDimensions dims;
+  OP_REQUIRES_OK(context, ConvBackpropComputeDimensionsV2(
+                              "Conv3DBackpropFilterOp", /*num_spatial_dims=*/3,
+                              input_shape, filter_shape, out_backprop_shape,
+                              dilation, stride, padding,
+                              /*explicit_paddings=*/{}, data_format, &dims));
 
-      auto transpose = se::blas::Transpose::kTranspose;
-      auto no_transpose = se::blas::Transpose::kNoTranspose;
+  auto* stream = context->op_device_context()->stream();
+  OP_REQUIRES(context, stream, errors::Internal("No GPU stream available."));
 
-      OP_REQUIRES_OK(
-          context, stream->ThenBlasGemm(transpose, no_transpose, n, m, k, b_ptr,
-                                        k, a_ptr, k, &c_ptr, n,
-                                        se::blas::kDefaultComputePrecision));
-      return;
-    }
+  if (DataTypeToEnum<T>::value == DT_BFLOAT16 &&
+      !stream->GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::AMPERE)) {
+    context->SetStatus(errors::Unimplemented(
+        "Conv3DBackpropFilter for GPU with bfloat16 is only supported "
+        "with cuDNN on Ampere GPUs or later."));
+    return;
+  }
 
-    int padding_planes = dims.SpatialPadding(padding_, 0);
-    int padding_rows = dims.SpatialPadding(padding_, 1);
-    int padding_cols = dims.SpatialPadding(padding_, 2);
-    const bool planes_odd = (padding_planes % 2 != 0);
-    const bool rows_odd = (padding_rows % 2 != 0);
-    const bool cols_odd = (padding_cols % 2 != 0);
+  bool is_grouped_convolution = filter_shape.dim_size(3) != dims.in_depth;
+  if (!is_grouped_convolution && dims.filter_size(1) == 1 &&
+      dims.filter_size(2) == 1 && dims.filter_size(0) == 1 &&
+      dims.dilation(2) == 1 && dims.dilation(1) == 1 && dims.dilation(0) == 1 &&
+      dims.stride(2) == 1 && dims.stride(1) == 1 && dims.stride(0) == 1 &&
+      data_format == FORMAT_NHWC) {
+    const uint64 m = dims.in_depth;
+    const uint64 k = dims.batch_size * dims.input_size(1) * dims.input_size(2) *
+                     dims.input_size(0);
+    const uint64 n = dims.out_depth;
 
-    TensorShape compatible_input_shape;
-    if (rows_odd || cols_odd || planes_odd) {
-      // cuDNN only supports the same amount of padding on both sides.
-      compatible_input_shape = {
-          dims.batch_size,
-          dims.in_depth,
-          dims.input_size(0) + planes_odd,
-          dims.input_size(1) + rows_odd,
-          dims.input_size(2) + cols_odd,
-      };
-    } else {
-      compatible_input_shape = {dims.batch_size, dims.in_depth,
-                                dims.input_size(0), dims.input_size(1),
-                                dims.input_size(2)};
-    }
+    // The shape of output backprop is
+    //   [batch, out_z, out_y, out_x, out_depth]
+    // From cublas's perspective, it is: n x k
+    auto a_ptr = AsDeviceMemory(out_backprop.template flat<T>().data(),
+                                out_backprop.template flat<T>().size());
 
-    CHECK(padding_rows >= 0 && padding_cols >= 0 && padding_planes >= 0)
-        << "Negative paddings: (" << padding_rows << ", " << padding_cols
-        << ", " << padding_planes << ")";
+    // The shape of input is:
+    //   [batch, in_z, in_y, in_x, in_depth],
+    // From cublas's perspective, it is: m x k
+    auto b_ptr = AsDeviceMemory(input.template flat<T>().data(),
+                                input.template flat<T>().size());
 
+    // The shape of the filter backprop is:
+    //   [1, 1, 1, in_depth, out_depth]
+    // From cublas's perspective, it is: n x m
+    auto c_ptr = AsDeviceMemory(filter_backprop->template flat<T>().data(),
+                                filter_backprop->template flat<T>().size());
+
+    OP_REQUIRES_OK(
+        context, stream->ThenBlasGemm(se::blas::Transpose::kNoTranspose,
+                                      se::blas::Transpose::kTranspose, n, m, k,
+                                      a_ptr, n, b_ptr, m, &c_ptr, n,
+                                      se::blas::kDefaultComputePrecision));
+    return;
+  } else if (!is_grouped_convolution &&
+             dims.filter_size(0) == dims.input_size(0) &&
+             dims.filter_size(1) == dims.input_size(1) &&
+             dims.filter_size(2) == dims.input_size(2) &&
+             padding == Padding::VALID && data_format == FORMAT_NHWC) {
+    const uint64 m = dims.input_size(0) * dims.input_size(1) *
+                     dims.input_size(2) * dims.in_depth;
+    const uint64 k = dims.batch_size;
+    const uint64 n = dims.out_depth;
+
+    auto a_ptr = AsDeviceMemory(input.template flat<T>().data(),
+                                input.template flat<T>().size());
+    auto b_ptr = AsDeviceMemory(out_backprop.template flat<T>().data(),
+                                out_backprop.template flat<T>().size());
+    auto c_ptr = AsDeviceMemory(filter_backprop->template flat<T>().data(),
+                                filter_backprop->template flat<T>().size());
+
+    OP_REQUIRES_OK(
+        context, stream->ThenBlasGemm(se::blas::Transpose::kNoTranspose,
+                                      se::blas::Transpose::kTranspose, n, m, k,
+                                      b_ptr, n, a_ptr, m, &c_ptr, n,
+                                      se::blas::kDefaultComputePrecision));
+    return;
+  }
+
+  int padding_planes = dims.SpatialPadding(padding, 0);
+  int padding_rows = dims.SpatialPadding(padding, 1);
+  int padding_cols = dims.SpatialPadding(padding, 2);
+  const bool planes_odd = (padding_planes % 2 != 0);
+  const bool rows_odd = (padding_rows % 2 != 0);
+  const bool cols_odd = (padding_cols % 2 != 0);
+
+  Tensor compatible_input;
+  if (rows_odd || cols_odd || planes_odd) {
+    OP_REQUIRES_OK(context,
+                   context->allocate_temp(
+                       DataTypeToEnum<T>::value,
+                       ShapeFromFormat(data_format, dims.batch_size,
+                                       {{dims.input_size(0) + planes_odd,
+                                         dims.input_size(1) + rows_odd,
+                                         dims.input_size(2) + cols_odd}},
+                                       dims.in_depth),
+                       &compatible_input));
+    functor::PadInput<GPUDevice, T, int, 5>()(
+        context->template eigen_device<GPUDevice>(),
+        To32Bit(input.tensor<T, 5>()), {{0, 0, 0}},
+        {{planes_odd, rows_odd, cols_odd}},
+        To32Bit(compatible_input.tensor<T, 5>()), data_format, T{});
+  } else {
+    compatible_input = input;
+  }
+
+  CHECK(padding_rows >= 0 && padding_cols >= 0 && padding_planes >= 0)
+      << "Negative paddings: (" << padding_rows << ", " << padding_cols << ", "
+      << padding_planes << ")";
+
+#if GOOGLE_CUDA
     const bool compute_in_nhwc = ComputeInNhwcEnabled(
         DataTypeToEnum<T>::value, stream, /*use_4d_tensor=*/false);
+#else
+    // fast NDHWC implementation is a CUDA only feature
+    const bool compute_in_nhwc = false;
+#endif
     const TensorFormat compute_data_format =
-        (compute_in_nhwc && data_format_ == FORMAT_NHWC) ? FORMAT_NHWC
-                                                         : FORMAT_NCHW;
+        (compute_in_nhwc && data_format == FORMAT_NHWC) ? FORMAT_NHWC
+                                                        : FORMAT_NCHW;
 
-    VLOG(3) << "Compute Conv3DBackpropInput with cuDNN:"
-            << " data_format=" << ToString(data_format_)
+    VLOG(3) << "Compute Conv3DBackpropFilter with cuDNN:"
+            << " data_format=" << ToString(data_format)
             << " compute_data_format=" << ToString(compute_data_format);
 
     constexpr auto kComputeInNHWC =
@@ -1436,9 +1855,12 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
 
     se::dnn::BatchDescriptor input_desc(3);
     input_desc.set_count(dims.batch_size)
-        .set_spatial_dim(DimIndex::X, compatible_input_shape.dim_size(4))
-        .set_spatial_dim(DimIndex::Y, compatible_input_shape.dim_size(3))
-        .set_spatial_dim(DimIndex::Z, compatible_input_shape.dim_size(2))
+        .set_spatial_dim(DimIndex::X,
+                         GetTensorDim(compatible_input, data_format, '2'))
+        .set_spatial_dim(DimIndex::Y,
+                         GetTensorDim(compatible_input, data_format, '1'))
+        .set_spatial_dim(DimIndex::Z,
+                         GetTensorDim(compatible_input, data_format, '0'))
         .set_feature_map_count(dims.in_depth)
         .set_layout(compute_data_layout);
     se::dnn::BatchDescriptor output_desc(3);
@@ -1467,8 +1889,7 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
         .set_zero_padding(DimIndex::Z, padding_planes / 2)
         .set_group_count(dims.in_depth / filter_shape.dim_size(3));
 
-    // Shape: out, in, z, y, x.
-    Tensor transformed_filter;
+    Tensor pre_transformed_filter_backprop;
     auto dst_format =
         compute_data_format == FORMAT_NCHW ? FORMAT_OIHW : FORMAT_OHWI;
     TensorShape dst_shape =
@@ -1481,23 +1902,18 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
                            filter_shape.dim_size(3)});
     OP_REQUIRES_OK(context,
                    context->allocate_temp(DataTypeToEnum<T>::value, dst_shape,
-                                          &transformed_filter));
+                                          &pre_transformed_filter_backprop));
 
-    functor::TransformFilter<GPUDevice, T, int, 5>()(
-        context->eigen_device<GPUDevice>(), dst_format,
-        To32Bit(filter.tensor<T, 5>()),
-        To32Bit(transformed_filter.tensor<T, 5>()));
-
-    // Shape: batch, filters, z, y, x.
     Tensor transformed_out_backprop;
-    if (data_format_ == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
+    if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
+      VLOG(4) << "Convert the `out_backprop` tensor from NDHWC to NCDHW.";
       TensorShape nchw_shape = {dims.batch_size, dims.out_depth,
                                 dims.output_size(0), dims.output_size(1),
                                 dims.output_size(2)};
+      OP_REQUIRES_OK(
+          context, context->allocate_temp(DataTypeToEnum<T>::value, nchw_shape,
+                                          &transformed_out_backprop));
       if (dims.out_depth > 1) {
-        OP_REQUIRES_OK(context, context->allocate_temp(
-                                    DataTypeToEnum<T>::value, nchw_shape,
-                                    &transformed_out_backprop));
         functor::NHWCToNCHW<GPUDevice, T, 5>()(
             context->eigen_device<GPUDevice>(), out_backprop.tensor<T, 5>(),
             transformed_out_backprop.tensor<T, 5>());
@@ -1507,35 +1923,40 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
     } else {
       transformed_out_backprop = out_backprop;
     }
-    // Shape: batch, filters, z, y, x.
-    Tensor pre_transformed_in_backprop;
-    OP_REQUIRES_OK(context,
-                   context->allocate_temp(
-                       DataTypeToEnum<T>::value,
-                       ShapeFromFormat(compute_data_format,
-                                       compatible_input_shape.dim_size(0),
-                                       {{compatible_input_shape.dim_size(2),
-                                         compatible_input_shape.dim_size(3),
-                                         compatible_input_shape.dim_size(4)}},
-                                       compatible_input_shape.dim_size(1)),
-                       &pre_transformed_in_backprop));
+    Tensor transformed_input;
+    if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
+      VLOG(4) << "Convert the `input` tensor from NDHWC to NCDHW.";
+      TensorShape nchw_shape = {
+          dims.batch_size, dims.in_depth, compatible_input.dim_size(1),
+          compatible_input.dim_size(2), compatible_input.dim_size(3)};
+      if (dims.in_depth > 1) {
+        OP_REQUIRES_OK(context,
+                       context->allocate_temp(DataTypeToEnum<T>::value,
+                                              nchw_shape, &transformed_input));
+        functor::NHWCToNCHW<GPUDevice, T, 5>()(
+            context->eigen_device<GPUDevice>(),
+            const_cast<const Tensor&>(compatible_input).tensor<T, 5>(),
+            transformed_input.tensor<T, 5>());
+      } else {
+        CHECK(transformed_input.CopyFrom(compatible_input, nchw_shape));
+      }
+    } else {
+      transformed_input = compatible_input;
+    }
 
     auto out_backprop_ptr =
         AsDeviceMemory(transformed_out_backprop.template flat<T>().data(),
                        transformed_out_backprop.template flat<T>().size());
-    auto filter_ptr =
-        AsDeviceMemory(transformed_filter.template flat<T>().data(),
-                       transformed_filter.template flat<T>().size());
-    auto in_backprop_ptr =
-        AsDeviceMemory(pre_transformed_in_backprop.template flat<T>().data(),
-                       pre_transformed_in_backprop.template flat<T>().size());
+    auto filter_backprop_ptr = AsDeviceMemory(
+        pre_transformed_filter_backprop.template flat<T>().data(),
+        pre_transformed_filter_backprop.template flat<T>().size());
+    auto input_ptr =
+        AsDeviceMemory(transformed_input.template flat<T>().data(),
+                       transformed_input.template flat<T>().size());
 
-    static int64_t ConvolveBackwardDataScratchSize = GetDnnWorkspaceLimit(
-        "TF_CUDNN_WORKSPACE_LIMIT_IN_MB", 1LL << 33);  // 8GB by default
+    static int64_t ConvolveBackwardFilterScratchSize =
+        GetDnnWorkspaceLimitOrDefault();
 
-    // To make sure the Conv3DBackpropInputV2 get the correct dtype, we infer
-    // the dtype from 2nd input, i.e., out_backprop.
-    DataType dtype = context->input(2).dtype();
     const ConvParameters conv_parameters = {
         stream->parent(),
         dims.batch_size,
@@ -1547,7 +1968,7 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
         {{dims.dilation(0), dims.dilation(1), dims.dilation(2)}},
         {{dims.stride(0), dims.stride(1), dims.stride(2)}},
         {{padding_planes, padding_rows, padding_cols}},
-        dtype,
+        input.dtype(),
         conv_desc.group_count(),
     };
 
@@ -1556,76 +1977,93 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
     using se::dnn::ProfileResult;
 
     auto entry_or = AutotuneUnfusedConv(
-        cudnn_use_autotune_, AutotuneConv3dBwdData::GetInstance(),
-        conv_parameters, context, se::dnn::ConvolutionKind::BACKWARD_DATA,
-        input_desc, in_backprop_ptr, filter_desc, filter_ptr, conv_desc,
-        output_desc, out_backprop_ptr, ConvolveBackwardDataScratchSize);
+        cudnn_use_autotune, AutotuneConv3dBwdFilter::GetInstance(),
+        conv_parameters, context, se::dnn::ConvolutionKind::BACKWARD_FILTER,
+        input_desc, input_ptr, filter_desc, filter_backprop_ptr, conv_desc,
+        output_desc, out_backprop_ptr, ConvolveBackwardFilterScratchSize);
     OP_REQUIRES_OK(context, entry_or.status());
     auto autotune_entry = std::move(entry_or).value();
 
-    DnnScratchAllocator scratch_allocator(ConvolveBackwardDataScratchSize,
+    DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
                                           context);
     Status cudnn_launch_status = LaunchAutotunedConv(
         autotune_entry, &scratch_allocator,
-        se::dnn::ConvolutionKind::BACKWARD_DATA, stream, input_desc,
-        in_backprop_ptr, filter_desc, filter_ptr, conv_desc, output_desc,
+        se::dnn::ConvolutionKind::BACKWARD_FILTER, stream, input_desc,
+        input_ptr, filter_desc, filter_backprop_ptr, conv_desc, output_desc,
         out_backprop_ptr);
     if (!cudnn_launch_status.ok()) {
       context->SetStatus(cudnn_launch_status);
       return;
     }
 
-    if (rows_odd || cols_odd || planes_odd) {
-      Tensor in_backprop_remove_padding;
-      OP_REQUIRES_OK(
-          context, context->allocate_temp(
-                       DataTypeToEnum<T>::value,
-                       ShapeFromFormat(compute_data_format, dims.batch_size,
-                                       {{dims.input_size(0), dims.input_size(1),
-                                         dims.input_size(2)}},
-                                       dims.in_depth),
-                       &in_backprop_remove_padding));
+    auto toConstTensor = [](const Tensor& x) -> const Tensor { return x; };
+    functor::ReverseTransformFilter<GPUDevice, T, 5>()(
+        context->eigen_device<GPUDevice>(), /*src_filter_format=*/dst_format,
+        toConstTensor(pre_transformed_filter_backprop).template tensor<T, 5>(),
+        filter_backprop->tensor<T, 5>());
+}
 
-      // Remove the padding for odd spatial dimensions.
-      functor::PadInput<GPUDevice, T, int, 5>()(
-          context->eigen_device<GPUDevice>(),
-          To32Bit(const_cast<const Tensor&>(pre_transformed_in_backprop)
-                      .tensor<T, 5>()),
-          {{0, 0, 0}}, {{-planes_odd, -rows_odd, -cols_odd}},
-          To32Bit(in_backprop_remove_padding.tensor<T, 5>()),
-          compute_data_format, T{});
-
-      pre_transformed_in_backprop = in_backprop_remove_padding;
-    }
-
-    if (data_format_ == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
-      auto toConstTensor = [](const Tensor& x) -> const Tensor { return x; };
-      functor::NCHWToNHWC<GPUDevice, T, 5>()(
-          context->eigen_device<GPUDevice>(),
-          toConstTensor(pre_transformed_in_backprop).template tensor<T, 5>(),
-          in_backprop->tensor<T, 5>());
-    } else {
-      *in_backprop = pre_transformed_in_backprop;
-    }
+template <typename T>
+struct LaunchConvBackpropFilterOp {
+  static void launch(OpKernelContext* context, bool cudnn_use_autotune,
+                     const Tensor& input, const Tensor& out_backprop,
+                     const std::vector<int32>& dilation,
+                     const std::vector<int32>& stride, const Padding& padding,
+                     Tensor* filter_backprop, TensorFormat data_format) {
+    LaunchConvBackpropFilterOpImpl<T>(context, cudnn_use_autotune, input,
+                                      out_backprop, dilation, stride, padding,
+                                      filter_backprop, data_format);
   }
-
- private:
-  std::vector<int32> dilation_;
-  std::vector<int32> stride_;
-  Padding padding_;
-  TensorFormat data_format_;
-  bool takes_shape_;
-  bool cudnn_use_autotune_;
 };
 
-// A dummy type to group backward filter autotune results together.
-struct Conv3dBackwardFilterAutotuneGroup {
-  static string name() { return "Conv3dBwdFilter"; }
-};
+template <>
+struct LaunchConvBackpropFilterOp<Eigen::bfloat16> {
+  static void launch(OpKernelContext* ctx, bool cudnn_use_autotune,
+                     const Tensor& input, const Tensor& out_backprop,
+                     const std::vector<int32>& dilation,
+                     const std::vector<int32>& stride, const Padding& padding,
+                     Tensor* filter_backprop, TensorFormat data_format) {
+    // Performant bfloat16 operations are supported for Ampere+ GPUs. For
+    // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
+    auto* stream = ctx->op_device_context()->stream();
+    const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
+        se::CudaComputeCapability::AMPERE);
+    Tensor casted_input = input;
+    Tensor casted_out_backprop = out_backprop;
+    Tensor casted_filter_backprop = *filter_backprop;
 
-typedef AutotuneSingleton<Conv3dBackwardFilterAutotuneGroup, ConvParameters,
-                          AutotuneEntry<se::dnn::ConvOp>>
-    AutotuneConv3dBwdFilter;
+    if (cast_to_float) {
+      const GPUDevice& device = ctx->eigen_device<GPUDevice>();
+      functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
+      OP_REQUIRES_OK(
+          ctx, ctx->allocate_temp(DT_FLOAT, input.shape(), &casted_input));
+      cast(device, casted_input.template flat<float>(),
+           input.template flat<Eigen::bfloat16>());
+
+      OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, out_backprop.shape(),
+                                             &casted_out_backprop));
+      cast(device, casted_out_backprop.template flat<float>(),
+           out_backprop.template flat<Eigen::bfloat16>());
+
+      OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, filter_backprop->shape(),
+                                             &casted_filter_backprop));
+
+      LaunchConvBackpropFilterOpImpl<float>(
+          ctx, cudnn_use_autotune, casted_input, casted_out_backprop, dilation,
+          stride, padding, &casted_filter_backprop, data_format);
+
+      functor::CastFunctor<GPUDevice, Eigen::bfloat16, float> cast_back;
+      const Tensor& casted_filter_backprop_const = casted_filter_backprop;
+      cast_back(device, filter_backprop->template flat<Eigen::bfloat16>(),
+                casted_filter_backprop_const.template flat<float>());
+      return;
+    }
+
+    LaunchConvBackpropFilterOpImpl<Eigen::bfloat16>(
+        ctx, cudnn_use_autotune, casted_input, casted_out_backprop, dilation,
+        stride, padding, &casted_filter_backprop, data_format);
+  }
+};
 
 template <typename T>
 class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
@@ -1679,10 +2117,7 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
 
   void Compute(OpKernelContext* context) override {
     const Tensor& input = context->input(0);
-    const TensorShape& input_shape = input.shape();
-
     const Tensor& out_backprop = context->input(2);
-    const TensorShape& out_backprop_shape = out_backprop.shape();
 
     TensorShape filter_shape;
     if (takes_shape_) {
@@ -1696,288 +2131,13 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
       filter_shape = context->input(1).shape();
     }
 
-    ConvBackpropDimensions dims;
-    OP_REQUIRES_OK(
-        context,
-        ConvBackpropComputeDimensionsV2(
-            "Conv3DBackpropFilterOp", /*num_spatial_dims=*/3, input_shape,
-            filter_shape, out_backprop_shape, dilation_, stride_, padding_,
-            /*explicit_paddings=*/{}, data_format_, &dims));
-
     Tensor* filter_backprop;
     OP_REQUIRES_OK(context,
                    context->allocate_output(0, filter_shape, &filter_backprop));
 
-    auto* stream = context->op_device_context()->stream();
-    OP_REQUIRES(context, stream, errors::Internal("No GPU stream available."));
-
-    bool is_grouped_convolution = filter_shape.dim_size(3) != dims.in_depth;
-    if (!is_grouped_convolution && dims.filter_size(1) == 1 &&
-        dims.filter_size(2) == 1 && dims.filter_size(0) == 1 &&
-        dims.dilation(2) == 1 && dims.dilation(1) == 1 &&
-        dims.dilation(0) == 1 && dims.stride(2) == 1 && dims.stride(1) == 1 &&
-        dims.stride(0) == 1 && data_format_ == FORMAT_NHWC) {
-      const uint64 m = dims.in_depth;
-      const uint64 k = dims.batch_size * dims.input_size(1) *
-                       dims.input_size(2) * dims.input_size(0);
-      const uint64 n = dims.out_depth;
-
-      // The shape of output backprop is
-      //   [batch, out_z, out_y, out_x, out_depth]
-      // From cublas's perspective, it is: n x k
-      auto a_ptr = AsDeviceMemory(out_backprop.template flat<T>().data(),
-                                  out_backprop.template flat<T>().size());
-
-      // The shape of input is:
-      //   [batch, in_z, in_y, in_x, in_depth],
-      // From cublas's perspective, it is: m x k
-      auto b_ptr = AsDeviceMemory(input.template flat<T>().data(),
-                                  input.template flat<T>().size());
-
-      // The shape of the filter backprop is:
-      //   [1, 1, 1, in_depth, out_depth]
-      // From cublas's perspective, it is: n x m
-      auto c_ptr = AsDeviceMemory(filter_backprop->template flat<T>().data(),
-                                  filter_backprop->template flat<T>().size());
-
-      OP_REQUIRES_OK(context,
-                     stream->ThenBlasGemm(se::blas::Transpose::kNoTranspose,
-                                          se::blas::Transpose::kTranspose, n, m,
-                                          k, a_ptr, n, b_ptr, m, &c_ptr, n,
-                                          se::blas::kDefaultComputePrecision));
-      return;
-    } else if (!is_grouped_convolution &&
-               dims.filter_size(0) == dims.input_size(0) &&
-               dims.filter_size(1) == dims.input_size(1) &&
-               dims.filter_size(2) == dims.input_size(2) &&
-               padding_ == Padding::VALID && data_format_ == FORMAT_NHWC) {
-      const uint64 m = dims.input_size(0) * dims.input_size(1) *
-                       dims.input_size(2) * dims.in_depth;
-      const uint64 k = dims.batch_size;
-      const uint64 n = dims.out_depth;
-
-      auto a_ptr = AsDeviceMemory(input.template flat<T>().data(),
-                                  input.template flat<T>().size());
-      auto b_ptr = AsDeviceMemory(out_backprop.template flat<T>().data(),
-                                  out_backprop.template flat<T>().size());
-      auto c_ptr = AsDeviceMemory(filter_backprop->template flat<T>().data(),
-                                  filter_backprop->template flat<T>().size());
-
-      OP_REQUIRES_OK(context,
-                     stream->ThenBlasGemm(se::blas::Transpose::kNoTranspose,
-                                          se::blas::Transpose::kTranspose, n, m,
-                                          k, b_ptr, n, a_ptr, m, &c_ptr, n,
-                                          se::blas::kDefaultComputePrecision));
-      return;
-    }
-
-    int padding_planes = dims.SpatialPadding(padding_, 0);
-    int padding_rows = dims.SpatialPadding(padding_, 1);
-    int padding_cols = dims.SpatialPadding(padding_, 2);
-    const bool planes_odd = (padding_planes % 2 != 0);
-    const bool rows_odd = (padding_rows % 2 != 0);
-    const bool cols_odd = (padding_cols % 2 != 0);
-
-    Tensor compatible_input;
-    if (rows_odd || cols_odd || planes_odd) {
-      OP_REQUIRES_OK(context,
-                     context->allocate_temp(
-                         DataTypeToEnum<T>::value,
-                         ShapeFromFormat(data_format_, dims.batch_size,
-                                         {{dims.input_size(0) + planes_odd,
-                                           dims.input_size(1) + rows_odd,
-                                           dims.input_size(2) + cols_odd}},
-                                         dims.in_depth),
-                         &compatible_input));
-      functor::PadInput<GPUDevice, T, int, 5>()(
-          context->template eigen_device<GPUDevice>(),
-          To32Bit(input.tensor<T, 5>()), {{0, 0, 0}},
-          {{planes_odd, rows_odd, cols_odd}},
-          To32Bit(compatible_input.tensor<T, 5>()), data_format_, T{});
-    } else {
-      compatible_input = input;
-    }
-
-    CHECK(padding_rows >= 0 && padding_cols >= 0 && padding_planes >= 0)
-        << "Negative paddings: (" << padding_rows << ", " << padding_cols
-        << ", " << padding_planes << ")";
-
-#if GOOGLE_CUDA
-    const bool compute_in_nhwc = ComputeInNhwcEnabled(
-        DataTypeToEnum<T>::value, stream, /*use_4d_tensor=*/false);
-#else
-    // fast NDHWC implementation is a CUDA only feature
-    const bool compute_in_nhwc = false;
-#endif
-    const TensorFormat compute_data_format =
-        (compute_in_nhwc && data_format_ == FORMAT_NHWC) ? FORMAT_NHWC
-                                                         : FORMAT_NCHW;
-
-    VLOG(3) << "Compute Conv3DBackpropFilter with cuDNN:"
-            << " data_format=" << ToString(data_format_)
-            << " compute_data_format=" << ToString(compute_data_format);
-
-    constexpr auto kComputeInNHWC =
-        std::make_tuple(se::dnn::DataLayout::kBatchYXDepth,
-                        se::dnn::FilterLayout::kOutputYXInput);
-    constexpr auto kComputeInNCHW =
-        std::make_tuple(se::dnn::DataLayout::kBatchDepthYX,
-                        se::dnn::FilterLayout::kOutputInputYX);
-
-    se::dnn::DataLayout compute_data_layout;
-    se::dnn::FilterLayout filter_layout;
-
-    std::tie(compute_data_layout, filter_layout) =
-        compute_data_format == FORMAT_NHWC ? kComputeInNHWC : kComputeInNCHW;
-
-    se::dnn::BatchDescriptor input_desc(3);
-    input_desc.set_count(dims.batch_size)
-        .set_spatial_dim(DimIndex::X,
-                         GetTensorDim(compatible_input, data_format_, '2'))
-        .set_spatial_dim(DimIndex::Y,
-                         GetTensorDim(compatible_input, data_format_, '1'))
-        .set_spatial_dim(DimIndex::Z,
-                         GetTensorDim(compatible_input, data_format_, '0'))
-        .set_feature_map_count(dims.in_depth)
-        .set_layout(compute_data_layout);
-    se::dnn::BatchDescriptor output_desc(3);
-    output_desc.set_count(dims.batch_size)
-        .set_spatial_dim(DimIndex::X, dims.output_size(2))
-        .set_spatial_dim(DimIndex::Y, dims.output_size(1))
-        .set_spatial_dim(DimIndex::Z, dims.output_size(0))
-        .set_feature_map_count(dims.out_depth)
-        .set_layout(compute_data_layout);
-    se::dnn::FilterDescriptor filter_desc(3);
-    filter_desc.set_spatial_dim(DimIndex::X, dims.filter_size(2))
-        .set_spatial_dim(DimIndex::Y, dims.filter_size(1))
-        .set_spatial_dim(DimIndex::Z, dims.filter_size(0))
-        .set_input_feature_map_count(filter_shape.dim_size(3))
-        .set_output_feature_map_count(filter_shape.dim_size(4))
-        .set_layout(filter_layout);
-    se::dnn::ConvolutionDescriptor conv_desc(3);
-    conv_desc.set_dilation_rate(DimIndex::X, dims.dilation(2))
-        .set_dilation_rate(DimIndex::Y, dims.dilation(1))
-        .set_dilation_rate(DimIndex::Z, dims.dilation(0))
-        .set_filter_stride(DimIndex::X, dims.stride(2))
-        .set_filter_stride(DimIndex::Y, dims.stride(1))
-        .set_filter_stride(DimIndex::Z, dims.stride(0))
-        .set_zero_padding(DimIndex::X, padding_cols / 2)
-        .set_zero_padding(DimIndex::Y, padding_rows / 2)
-        .set_zero_padding(DimIndex::Z, padding_planes / 2)
-        .set_group_count(dims.in_depth / filter_shape.dim_size(3));
-
-    Tensor pre_transformed_filter_backprop;
-    auto dst_format =
-        compute_data_format == FORMAT_NCHW ? FORMAT_OIHW : FORMAT_OHWI;
-    TensorShape dst_shape =
-        dst_format == FORMAT_OIHW
-            ? TensorShape({filter_shape.dim_size(4), filter_shape.dim_size(3),
-                           dims.filter_size(0), dims.filter_size(1),
-                           dims.filter_size(2)})
-            : TensorShape({filter_shape.dim_size(4), dims.filter_size(0),
-                           dims.filter_size(1), dims.filter_size(2),
-                           filter_shape.dim_size(3)});
-    OP_REQUIRES_OK(context,
-                   context->allocate_temp(DataTypeToEnum<T>::value, dst_shape,
-                                          &pre_transformed_filter_backprop));
-
-    Tensor transformed_out_backprop;
-    if (data_format_ == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
-      VLOG(4) << "Convert the `out_backprop` tensor from NDHWC to NCDHW.";
-      TensorShape nchw_shape = {dims.batch_size, dims.out_depth,
-                                dims.output_size(0), dims.output_size(1),
-                                dims.output_size(2)};
-      OP_REQUIRES_OK(
-          context, context->allocate_temp(DataTypeToEnum<T>::value, nchw_shape,
-                                          &transformed_out_backprop));
-      if (dims.out_depth > 1) {
-        functor::NHWCToNCHW<GPUDevice, T, 5>()(
-            context->eigen_device<GPUDevice>(), out_backprop.tensor<T, 5>(),
-            transformed_out_backprop.tensor<T, 5>());
-      } else {
-        CHECK(transformed_out_backprop.CopyFrom(out_backprop, nchw_shape));
-      }
-    } else {
-      transformed_out_backprop = out_backprop;
-    }
-    Tensor transformed_input;
-    if (data_format_ == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
-      VLOG(4) << "Convert the `input` tensor from NDHWC to NCDHW.";
-      TensorShape nchw_shape = {
-          dims.batch_size, dims.in_depth, compatible_input.dim_size(1),
-          compatible_input.dim_size(2), compatible_input.dim_size(3)};
-      if (dims.in_depth > 1) {
-        OP_REQUIRES_OK(context,
-                       context->allocate_temp(DataTypeToEnum<T>::value,
-                                              nchw_shape, &transformed_input));
-        functor::NHWCToNCHW<GPUDevice, T, 5>()(
-            context->eigen_device<GPUDevice>(),
-            const_cast<const Tensor&>(compatible_input).tensor<T, 5>(),
-            transformed_input.tensor<T, 5>());
-      } else {
-        CHECK(transformed_input.CopyFrom(compatible_input, nchw_shape));
-      }
-    } else {
-      transformed_input = compatible_input;
-    }
-
-    auto out_backprop_ptr =
-        AsDeviceMemory(transformed_out_backprop.template flat<T>().data(),
-                       transformed_out_backprop.template flat<T>().size());
-    auto filter_backprop_ptr = AsDeviceMemory(
-        pre_transformed_filter_backprop.template flat<T>().data(),
-        pre_transformed_filter_backprop.template flat<T>().size());
-    auto input_ptr =
-        AsDeviceMemory(transformed_input.template flat<T>().data(),
-                       transformed_input.template flat<T>().size());
-
-    static int64_t ConvolveBackwardFilterScratchSize =
-        GetDnnWorkspaceLimitOrDefault();
-
-    const ConvParameters conv_parameters = {
-        stream->parent(),
-        dims.batch_size,
-        dims.in_depth,
-        {{dims.input_size(0), dims.input_size(1), dims.input_size(2)}},
-        compute_data_format,
-        dims.out_depth,
-        {{dims.filter_size(0), dims.filter_size(1), dims.filter_size(2)}},
-        {{dims.dilation(0), dims.dilation(1), dims.dilation(2)}},
-        {{dims.stride(0), dims.stride(1), dims.stride(2)}},
-        {{padding_planes, padding_rows, padding_cols}},
-        input.dtype(),
-        conv_desc.group_count(),
-    };
-
-    using se::dnn::AlgorithmConfig;
-    using se::dnn::AlgorithmDesc;
-    using se::dnn::ProfileResult;
-
-    auto entry_or = AutotuneUnfusedConv(
-        cudnn_use_autotune_, AutotuneConv3dBwdFilter::GetInstance(),
-        conv_parameters, context, se::dnn::ConvolutionKind::BACKWARD_FILTER,
-        input_desc, input_ptr, filter_desc, filter_backprop_ptr, conv_desc,
-        output_desc, out_backprop_ptr, ConvolveBackwardFilterScratchSize);
-    OP_REQUIRES_OK(context, entry_or.status());
-    auto autotune_entry = std::move(entry_or).value();
-
-    DnnScratchAllocator scratch_allocator(ConvolveBackwardFilterScratchSize,
-                                          context);
-    Status cudnn_launch_status = LaunchAutotunedConv(
-        autotune_entry, &scratch_allocator,
-        se::dnn::ConvolutionKind::BACKWARD_FILTER, stream, input_desc,
-        input_ptr, filter_desc, filter_backprop_ptr, conv_desc, output_desc,
-        out_backprop_ptr);
-    if (!cudnn_launch_status.ok()) {
-      context->SetStatus(cudnn_launch_status);
-      return;
-    }
-
-    auto toConstTensor = [](const Tensor& x) -> const Tensor { return x; };
-    functor::ReverseTransformFilter<GPUDevice, T, 5>()(
-        context->eigen_device<GPUDevice>(), /*src_filter_format=*/dst_format,
-        toConstTensor(pre_transformed_filter_backprop).template tensor<T, 5>(),
-        filter_backprop->tensor<T, 5>());
+    LaunchConvBackpropFilterOp<T>::launch(
+        context, cudnn_use_autotune_, input, out_backprop, dilation_, stride_,
+        padding_, filter_backprop, data_format_);
   }
 
  private:
@@ -2007,6 +2167,7 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
                               .HostMemory("filter_sizes"),                    \
                           Conv3DBackpropFilterOp<GPUDevice, T>);
 TF_CALL_half(REGISTER_GPU_KERNEL);
+TF_CALL_bfloat16(REGISTER_GPU_KERNEL);
 TF_CALL_float(REGISTER_GPU_KERNEL);
 TF_CALL_double(REGISTER_GPU_KERNEL);
 #undef REGISTER_GPU_KERNEL

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -58,6 +58,7 @@ limitations under the License.
 #include "tensorflow/core/util/use_cudnn.h"
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "tensorflow/core/kernels/cast_op.h"
 #include "tensorflow/core/kernels/conv_ops_gpu.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/protobuf/autotuning.pb.h"
@@ -725,12 +726,13 @@ int64_t GetDnnWorkspaceLimitOrDefault() {
 }
 
 template <typename T>
-void LaunchConv2DOp<GPUDevice, T>::operator()(
-    OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
-    const Tensor& input_param, const Tensor& filter, int row_dilation,
-    int col_dilation, int row_stride, int col_stride, const Padding& padding,
-    const std::vector<int64_t>& explicit_paddings, Tensor* output,
-    TensorFormat data_format) {
+void LaunchConv2DOpImpl(OpKernelContext* ctx, bool use_cudnn,
+                        bool cudnn_use_autotune, const Tensor& input_param,
+                        const Tensor& filter, int row_dilation,
+                        int col_dilation, int row_stride, int col_stride,
+                        const Padding& padding,
+                        const std::vector<int64_t>& explicit_paddings,
+                        Tensor* output, TensorFormat data_format) {
   using se::dnn::AlgorithmConfig;
   using se::dnn::AlgorithmDesc;
   using se::dnn::ProfileResult;
@@ -1077,6 +1079,68 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
   }
 }
 
+template <typename T>
+void LaunchConv2DOp<GPUDevice, T>::operator()(
+    OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
+    const Tensor& input_param, const Tensor& filter, int row_dilation,
+    int col_dilation, int row_stride, int col_stride, const Padding& padding,
+    const std::vector<int64_t>& explicit_paddings, Tensor* output,
+    TensorFormat data_format) {
+  LaunchConv2DOpImpl<T>(ctx, use_cudnn, cudnn_use_autotune, input_param, filter,
+                        row_dilation, col_dilation, row_stride, col_stride,
+                        padding, explicit_paddings, output, data_format);
+}
+
+template <>
+void LaunchConv2DOp<GPUDevice, Eigen::bfloat16>::operator()(
+    OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
+    const Tensor& input_param, const Tensor& filter, int row_dilation,
+    int col_dilation, int row_stride, int col_stride, const Padding& padding,
+    const std::vector<int64_t>& explicit_paddings, Tensor* output,
+    TensorFormat data_format) {
+  // Performant bfloat16 operations are supported for Ampere+ GPUs. For
+  // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
+  auto* stream = ctx->op_device_context()->stream();
+  const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
+      se::CudaComputeCapability::AMPERE);
+  Tensor casted_input = input_param;
+  Tensor casted_filter = filter;
+  Tensor casted_out = *output;
+
+  if (cast_to_float) {
+    const GPUDevice& device = ctx->eigen_device<GPUDevice>();
+    functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_FLOAT, input_param.shape(), &casted_input));
+    cast(device, casted_input.template flat<float>(),
+         input_param.template flat<Eigen::bfloat16>());
+
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(DT_FLOAT, filter.shape(), &casted_filter));
+    cast(device, casted_filter.template flat<float>(),
+         filter.template flat<Eigen::bfloat16>());
+
+    OP_REQUIRES_OK(ctx,
+                   ctx->allocate_temp(DT_FLOAT, output->shape(), &casted_out));
+
+    LaunchConv2DOpImpl<float>(ctx, use_cudnn, cudnn_use_autotune, casted_input,
+                              casted_filter, row_dilation, col_dilation,
+                              row_stride, col_stride, padding,
+                              explicit_paddings, &casted_out, data_format);
+
+    functor::CastFunctor<GPUDevice, Eigen::bfloat16, float> cast_back;
+    const Tensor& casted_out_const = casted_out;
+    cast_back(device, output->template flat<Eigen::bfloat16>(),
+              casted_out_const.template flat<float>());
+    return;
+  }
+
+  LaunchConv2DOpImpl<Eigen::bfloat16>(
+      ctx, use_cudnn, cudnn_use_autotune, casted_input, casted_filter,
+      row_dilation, col_dilation, row_stride, col_stride, padding,
+      explicit_paddings, &casted_out, data_format);
+}
+
 // Forward declarations of the functor specializations for GPU.
 namespace functor {
 #define DECLARE_GPU_SPEC(T)                                                 \
@@ -1122,6 +1186,7 @@ namespace functor {
 
 DECLARE_GPU_SPEC(float);
 DECLARE_GPU_SPEC(Eigen::half);
+DECLARE_GPU_SPEC(Eigen::bfloat16);
 DECLARE_GPU_SPEC(double);
 DECLARE_GPU_SPEC(int32);
 #undef DECLARE_GPU_SPEC
@@ -1132,6 +1197,9 @@ DECLARE_GPU_SPEC(int32);
 REGISTER_KERNEL_BUILDER(
     Name("Conv2D").Device(DEVICE_GPU).TypeConstraint<Eigen::half>("T"),
     Conv2DOp<GPUDevice, Eigen::half>);
+REGISTER_KERNEL_BUILDER(
+    Name("Conv2D").Device(DEVICE_GPU).TypeConstraint<Eigen::bfloat16>("T"),
+    Conv2DOp<GPUDevice, Eigen::bfloat16>);
 REGISTER_KERNEL_BUILDER(
     Name("Conv2D").Device(DEVICE_GPU).TypeConstraint<float>("T"),
     Conv2DOp<GPUDevice, float>);

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -36,6 +36,7 @@ limitations under the License.
 #include "tensorflow/core/util/use_cudnn.h"
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "tensorflow/core/kernels/cast_op.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/protobuf/autotuning.pb.h"
 #include "tensorflow/core/util/autotune_maps/conv_parameters.h"
@@ -226,303 +227,363 @@ typedef AutotuneSingleton<Conv3dAutotuneGroup, ConvParameters,
 
 // TODO(mjanusz): Share logic with 2d implementation as much as possible.
 template <typename T>
+void LaunchConvOpImpl(OpKernelContext* ctx, bool cudnn_use_autotune,
+                      const Tensor& input_param, const Tensor& filter,
+                      const std::array<int64, 3>& dilations,
+                      const std::array<int64, 3>& strides,
+                      const Padding padding, TensorFormat data_format,
+                      Tensor* output) {
+  auto* stream = ctx->op_device_context()->stream();
+  OP_REQUIRES(ctx, stream, errors::Internal("No GPU stream available."));
+
+  Tensor input = input_param;
+
+  const int64_t in_batch = GetTensorDim(input, data_format, 'N');
+  int64_t in_planes = GetTensorDim(input, data_format, '0');
+  int64_t in_rows = GetTensorDim(input, data_format, '1');
+  int64_t in_cols = GetTensorDim(input, data_format, '2');
+  const int64_t in_depth = GetTensorDim(input, data_format, 'C');
+
+  const int64_t filter_planes = filter.dim_size(0);
+  const int64_t filter_rows = filter.dim_size(1);
+  const int64_t filter_cols = filter.dim_size(2);
+  const int64_t filter_depth = filter.dim_size(3);
+  const int64_t out_depth = filter.dim_size(4);
+
+  int64_t pad_planes = 0, pad_rows = 0, pad_cols = 0;
+  int64_t out_planes = GetTensorDim(*output, data_format, '0');
+  int64_t out_rows = GetTensorDim(*output, data_format, '1');
+  int64_t out_cols = GetTensorDim(*output, data_format, '2');
+
+  if (padding == Padding::SAME) {
+    pad_planes = std::max<int64_t>(
+        0, (out_planes - 1) * strides[0] + filter_planes - in_planes);
+    pad_rows = std::max<int64_t>(
+        0, (out_rows - 1) * strides[1] + filter_rows - in_rows);
+    pad_cols = std::max<int64_t>(
+        0, (out_cols - 1) * strides[2] + filter_cols - in_cols);
+  }
+
+  bool is_grouped_convolution = filter_depth != in_depth;
+
+  // NOTE: This only works in NHWC.
+  if (!is_grouped_convolution && filter_planes == 1 && filter_rows == 1 &&
+      filter_cols == 1 && dilations[0] == 1 && dilations[1] == 1 &&
+      dilations[2] == 1 && strides[0] == 1 && strides[1] == 1 &&
+      strides[2] == 1 && data_format == FORMAT_NHWC) {
+    // 1x1 filter, so call cublas directly.
+    const uint64 m = in_batch * in_planes * in_rows * in_cols;
+    const uint64 k = in_depth;
+    const uint64 n = out_depth;
+
+    auto a_ptr = AsDeviceMemory(input.template flat<T>().data(),
+                                input.template flat<T>().size());
+    auto b_ptr = AsDeviceMemory(filter.template flat<T>().data(),
+                                filter.template flat<T>().size());
+    auto c_ptr = AsDeviceMemory(output->template flat<T>().data(),
+                                output->template flat<T>().size());
+
+    auto no_transpose = se::blas::Transpose::kNoTranspose;
+    OP_REQUIRES_OK(
+        ctx, stream->ThenBlasGemm(no_transpose, no_transpose, n, m, k, b_ptr, n,
+                                  a_ptr, k, &c_ptr, n,
+                                  se::blas::kDefaultComputePrecision));
+    return;
+  } else if (!is_grouped_convolution && filter_planes == in_planes &&
+             filter_rows == in_rows && filter_cols == in_cols &&
+             padding == Padding::VALID && data_format == FORMAT_NHWC) {
+    // The input data and filter have the same planes/height/width, so call
+    // cublas directly.
+    const uint64 m = in_batch;
+    const uint64 k = in_planes * in_rows * in_cols * in_depth;
+    const uint64 n = out_depth;
+
+    auto a_ptr = AsDeviceMemory(input.template flat<T>().data(),
+                                input.template flat<T>().size());
+    auto b_ptr = AsDeviceMemory(filter.template flat<T>().data(),
+                                filter.template flat<T>().size());
+    auto c_ptr = AsDeviceMemory(output->template flat<T>().data(),
+                                output->template flat<T>().size());
+
+    auto no_transpose = se::blas::Transpose::kNoTranspose;
+    OP_REQUIRES_OK(
+        ctx, stream->ThenBlasGemm(no_transpose, no_transpose, n, m, k, b_ptr, n,
+                                  a_ptr, k, &c_ptr, n,
+                                  se::blas::kDefaultComputePrecision));
+    return;
+  }
+
+  if (padding == Padding::SAME) {
+    const bool rows_odd = (pad_rows % 2 != 0);
+    const bool cols_odd = (pad_cols % 2 != 0);
+    const bool planes_odd = (pad_planes % 2 != 0);
+
+    // Necessary because cuDNN only supports symmetric padding.
+    // TODO(mjanusz): Consider making this optional? This would save some
+    // overhead and would work as long as an op trained this way is only
+    // used on GPU.
+    if (rows_odd || cols_odd || planes_odd) {
+      const int64_t new_in_rows = in_rows + rows_odd;
+      const int64_t new_in_cols = in_cols + cols_odd;
+      const int64_t new_in_planes = in_planes + planes_odd;
+
+      Tensor transformed_input;
+      TensorShape transformed_shape = ShapeFromFormat(
+          data_format, in_batch, {{new_in_planes, new_in_rows, new_in_cols}},
+          in_depth);
+      OP_REQUIRES_OK(
+          ctx, ctx->allocate_temp(DataTypeToEnum<T>::value, transformed_shape,
+                                  &transformed_input));
+
+      functor::PadInput<GPUDevice, T, int, 5>()(
+          ctx->eigen_device<GPUDevice>(), To32Bit(input_param.tensor<T, 5>()),
+          {{0, 0, 0}}, {{planes_odd, rows_odd, cols_odd}},
+          To32Bit(transformed_input.tensor<T, 5>()), data_format, T{});
+      input = transformed_input;
+      in_rows = new_in_rows;
+      in_cols = new_in_cols;
+      in_planes = new_in_planes;
+    }
+  }
+
+  const bool compute_in_nhwc = ComputeInNhwcEnabled(
+      DataTypeToEnum<T>::value, stream, /*use_4d_tensor=*/false);
+
+  const TensorFormat compute_data_format =
+      (compute_in_nhwc && data_format == FORMAT_NHWC) ? FORMAT_NHWC
+                                                      : FORMAT_NCHW;
+
+  VLOG(3) << "Compute Conv3D with cuDNN:"
+          << " data_format=" << ToString(data_format)
+          << " compute_data_format=" << ToString(compute_data_format);
+
+  if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
+    VLOG(4) << "Convert the input tensor from NDHWC to NCDHW.";
+    const TensorShape nchw_shape = ShapeFromFormat(
+        FORMAT_NCHW, in_batch, {{in_planes, in_rows, in_cols}}, in_depth);
+    if (in_depth > 1) {
+      Tensor transformed_input;
+      OP_REQUIRES_OK(ctx, ctx->allocate_temp(DataTypeToEnum<T>::value,
+                                             nchw_shape, &transformed_input));
+      // input: [b, x, y, z, d]
+      // t_input: [b, d, x, y, z]
+      // NCDHW is the only format universally supported by cuDNN.
+      functor::NHWCToNCHW<GPUDevice, T, 5>()(
+          ctx->eigen_device<GPUDevice>(),
+          const_cast<const Tensor&>(input).tensor<T, 5>(),
+          transformed_input.tensor<T, 5>());
+      input = transformed_input;
+    } else {
+      CHECK(input.CopyFrom(input, nchw_shape));
+    }
+  } else {
+    CHECK(data_format == compute_data_format)  // Crash OK
+        << "Illegal data and compute format pair:"
+        << " data_format=" << ToString(data_format)
+        << " compute_data_format=" << ToString(compute_data_format);
+  }
+
+  constexpr auto kComputeInNHWC =
+      std::make_tuple(se::dnn::DataLayout::kBatchYXDepth,
+                      se::dnn::FilterLayout::kOutputYXInput);
+  constexpr auto kComputeInNCHW =
+      std::make_tuple(se::dnn::DataLayout::kBatchDepthYX,
+                      se::dnn::FilterLayout::kOutputInputYX);
+
+  se::dnn::DataLayout compute_data_layout;
+  se::dnn::FilterLayout filter_layout;
+
+  std::tie(compute_data_layout, filter_layout) =
+      compute_data_format == FORMAT_NHWC ? kComputeInNHWC : kComputeInNCHW;
+
+  CHECK(pad_rows >= 0 && pad_cols >= 0 && pad_planes >= 0)
+      << "Negative paddings: (" << pad_rows << ", " << pad_cols << ", "
+      << pad_planes << ")";
+  se::dnn::BatchDescriptor input_desc(3);
+  input_desc.set_count(in_batch)
+      .set_feature_map_count(in_depth)
+      .set_spatial_dim(DimIndex::X, in_cols)
+      .set_spatial_dim(DimIndex::Y, in_rows)
+      .set_spatial_dim(DimIndex::Z, in_planes)
+      .set_layout(compute_data_layout);
+  se::dnn::BatchDescriptor output_desc(3);
+  output_desc.set_count(in_batch)
+      .set_spatial_dim(DimIndex::X, out_cols)
+      .set_spatial_dim(DimIndex::Y, out_rows)
+      .set_spatial_dim(DimIndex::Z, out_planes)
+      .set_feature_map_count(out_depth)
+      .set_layout(compute_data_layout);
+  se::dnn::FilterDescriptor filter_desc(3);
+  filter_desc.set_spatial_dim(DimIndex::X, filter_cols)
+      .set_spatial_dim(DimIndex::Y, filter_rows)
+      .set_spatial_dim(DimIndex::Z, filter_planes)
+      .set_input_feature_map_count(filter_depth)
+      .set_output_feature_map_count(out_depth)
+      .set_layout(filter_layout);
+  se::dnn::ConvolutionDescriptor conv_desc(3);
+  conv_desc.set_dilation_rate(DimIndex::X, dilations[2])
+      .set_dilation_rate(DimIndex::Y, dilations[1])
+      .set_dilation_rate(DimIndex::Z, dilations[0])
+      .set_filter_stride(DimIndex::X, strides[2])
+      .set_filter_stride(DimIndex::Y, strides[1])
+      .set_filter_stride(DimIndex::Z, strides[0])
+      .set_zero_padding(DimIndex::X, pad_cols / 2)
+      .set_zero_padding(DimIndex::Y, pad_rows / 2)
+      .set_zero_padding(DimIndex::Z, pad_planes / 2)
+      .set_group_count(in_depth / filter_depth);
+
+  Tensor transformed_filter;
+  auto dst_format =
+      compute_data_format == FORMAT_NCHW ? FORMAT_OIHW : FORMAT_OHWI;
+  VLOG(4) << "Transform filter tensor from " << ToString(FORMAT_HWIO) << " to "
+          << ToString(dst_format);
+  TensorShape dst_shape =
+      dst_format == FORMAT_OIHW
+          ? TensorShape({filter.dim_size(4), filter.dim_size(3),
+                         filter.dim_size(0), filter.dim_size(1),
+                         filter.dim_size(2)})
+          : TensorShape({filter.dim_size(4), filter.dim_size(0),
+                         filter.dim_size(1), filter.dim_size(2),
+                         filter.dim_size(3)});
+  OP_REQUIRES_OK(ctx, ctx->allocate_temp(DataTypeToEnum<T>::value, dst_shape,
+                                         &transformed_filter));
+  // filter: [x, y, z, in, out]
+  // t_filter: [out, in, x, y, z] (NCDHW) or
+  // t_filter: [out, x, y, z, in] (NDHWC)
+  functor::TransformFilter<GPUDevice, T, int, 5>()(
+      ctx->eigen_device<GPUDevice>(), dst_format,
+      To32Bit(filter.tensor<T, 5>()),
+      To32Bit(transformed_filter.tensor<T, 5>()));
+
+  Tensor transformed_output;
+  if (data_format != compute_data_format) {
+    VLOG(4) << "Allocate temporary memory for output in compute data format";
+    OP_REQUIRES_OK(
+        ctx, ctx->allocate_temp(
+                 DataTypeToEnum<T>::value,
+                 ShapeFromFormat(FORMAT_NCHW, in_batch,
+                                 {{out_planes, out_rows, out_cols}}, out_depth),
+                 &transformed_output));
+  } else {
+    transformed_output = *output;
+  }
+
+  auto input_ptr = AsDeviceMemory(input.template flat<T>().data(),
+                                  input.template flat<T>().size());
+  auto filter_ptr =
+      AsDeviceMemory(transformed_filter.template flat<T>().data(),
+                     transformed_filter.template flat<T>().size());
+  auto output_ptr =
+      AsDeviceMemory(transformed_output.template flat<T>().data(),
+                     transformed_output.template flat<T>().size());
+
+  static int64_t ConvolveScratchSize = GetDnnWorkspaceLimitOrDefault();
+
+  ConvParameters conv_parameters = {
+      stream->parent(),
+      in_batch,
+      in_depth,
+      {{in_planes, in_rows, in_cols}},
+      compute_data_format,
+      out_depth,
+      {{filter_planes, filter_rows, filter_cols}},
+      {{dilations[0], dilations[1], dilations[2]}},
+      {{strides[0], strides[1], strides[2]}},
+      {{pad_planes, pad_rows, pad_cols}},
+      input.dtype(),
+      conv_desc.group_count(),
+  };
+
+  using se::dnn::AlgorithmConfig;
+  using se::dnn::AlgorithmDesc;
+  using se::dnn::ProfileResult;
+
+  auto config_or = AutotuneUnfusedConv(
+      cudnn_use_autotune, AutotuneConv3d::GetInstance(), conv_parameters, ctx,
+      se::dnn::ConvolutionKind::FORWARD, input_desc, input_ptr, filter_desc,
+      filter_ptr, conv_desc, output_desc, output_ptr, ConvolveScratchSize);
+  OP_REQUIRES_OK(ctx, config_or.status());
+  auto autotune_entry = std::move(config_or).value();
+
+  DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
+  Status cudnn_launch_status = LaunchAutotunedConv(
+      autotune_entry, &scratch_allocator, se::dnn::ConvolutionKind::FORWARD,
+      stream, input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
+      output_desc, output_ptr);
+  if (!cudnn_launch_status.ok()) {
+    ctx->SetStatus(cudnn_launch_status);
+    return;
+  }
+
+  if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
+    VLOG(4) << "Convert the output tensor back from NCDHW to NDHWC.";
+    // t_output: [b, out, x, y, z]
+    // output: [b, x, y, z, out]
+    functor::NCHWToNHWC<GPUDevice, T, 5>()(
+        ctx->eigen_device<GPUDevice>(),
+        const_cast<const Tensor&>(transformed_output).tensor<T, 5>(),
+        output->tensor<T, 5>());
+  }
+}
+
+template <typename T>
 struct LaunchConvOp<GPUDevice, T> {
   static void launch(OpKernelContext* ctx, bool cudnn_use_autotune,
                      const Tensor& input_param, const Tensor& filter,
                      const std::array<int64, 3>& dilations,
                      const std::array<int64, 3>& strides, const Padding padding,
                      TensorFormat data_format, Tensor* output) {
+    LaunchConvOpImpl<T>(ctx, cudnn_use_autotune, input_param, filter, dilations,
+                        strides, padding, data_format, output);
+  }
+};
+
+template <>
+struct LaunchConvOp<GPUDevice, Eigen::bfloat16> {
+  static void launch(OpKernelContext* ctx, bool cudnn_use_autotune,
+                     const Tensor& input_param, const Tensor& filter,
+                     const std::array<int64, 3>& dilations,
+                     const std::array<int64, 3>& strides, const Padding padding,
+                     TensorFormat data_format, Tensor* output) {
+    // Performant bfloat16 operations are supported for Ampere+ GPUs. For
+    // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
     auto* stream = ctx->op_device_context()->stream();
-    OP_REQUIRES(ctx, stream, errors::Internal("No GPU stream available."));
+    const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
+        se::CudaComputeCapability::AMPERE);
+    Tensor casted_input = input_param;
+    Tensor casted_filter = filter;
+    Tensor casted_out = *output;
 
-    Tensor input = input_param;
+    if (cast_to_float) {
+      const GPUDevice& device = ctx->eigen_device<GPUDevice>();
+      functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
+      OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, input_param.shape(),
+                                             &casted_input));
+      cast(device, casted_input.template flat<float>(),
+           input_param.template flat<Eigen::bfloat16>());
 
-    const int64_t in_batch = GetTensorDim(input, data_format, 'N');
-    int64_t in_planes = GetTensorDim(input, data_format, '0');
-    int64_t in_rows = GetTensorDim(input, data_format, '1');
-    int64_t in_cols = GetTensorDim(input, data_format, '2');
-    const int64_t in_depth = GetTensorDim(input, data_format, 'C');
-
-    const int64_t filter_planes = filter.dim_size(0);
-    const int64_t filter_rows = filter.dim_size(1);
-    const int64_t filter_cols = filter.dim_size(2);
-    const int64_t filter_depth = filter.dim_size(3);
-    const int64_t out_depth = filter.dim_size(4);
-
-    int64_t pad_planes = 0, pad_rows = 0, pad_cols = 0;
-    int64_t out_planes = GetTensorDim(*output, data_format, '0');
-    int64_t out_rows = GetTensorDim(*output, data_format, '1');
-    int64_t out_cols = GetTensorDim(*output, data_format, '2');
-
-    if (padding == Padding::SAME) {
-      pad_planes = std::max<int64_t>(
-          0, (out_planes - 1) * strides[0] + filter_planes - in_planes);
-      pad_rows = std::max<int64_t>(
-          0, (out_rows - 1) * strides[1] + filter_rows - in_rows);
-      pad_cols = std::max<int64_t>(
-          0, (out_cols - 1) * strides[2] + filter_cols - in_cols);
-    }
-
-    bool is_grouped_convolution = filter_depth != in_depth;
-
-    // NOTE: This only works in NHWC.
-    if (!is_grouped_convolution && filter_planes == 1 && filter_rows == 1 &&
-        filter_cols == 1 && dilations[0] == 1 && dilations[1] == 1 &&
-        dilations[2] == 1 && strides[0] == 1 && strides[1] == 1 &&
-        strides[2] == 1 && data_format == FORMAT_NHWC) {
-      // 1x1 filter, so call cublas directly.
-      const uint64 m = in_batch * in_planes * in_rows * in_cols;
-      const uint64 k = in_depth;
-      const uint64 n = out_depth;
-
-      auto a_ptr = AsDeviceMemory(input.template flat<T>().data(),
-                                  input.template flat<T>().size());
-      auto b_ptr = AsDeviceMemory(filter.template flat<T>().data(),
-                                  filter.template flat<T>().size());
-      auto c_ptr = AsDeviceMemory(output->template flat<T>().data(),
-                                  output->template flat<T>().size());
-
-      auto no_transpose = se::blas::Transpose::kNoTranspose;
       OP_REQUIRES_OK(
-          ctx, stream->ThenBlasGemm(no_transpose, no_transpose, n, m, k, b_ptr,
-                                    n, a_ptr, k, &c_ptr, n,
-                                    se::blas::kDefaultComputePrecision));
-      return;
-    } else if (!is_grouped_convolution && filter_planes == in_planes &&
-               filter_rows == in_rows && filter_cols == in_cols &&
-               padding == Padding::VALID && data_format == FORMAT_NHWC) {
-      // The input data and filter have the same planes/height/width, so call
-      // cublas directly.
-      const uint64 m = in_batch;
-      const uint64 k = in_planes * in_rows * in_cols * in_depth;
-      const uint64 n = out_depth;
+          ctx, ctx->allocate_temp(DT_FLOAT, filter.shape(), &casted_filter));
+      cast(device, casted_filter.template flat<float>(),
+           filter.template flat<Eigen::bfloat16>());
 
-      auto a_ptr = AsDeviceMemory(input.template flat<T>().data(),
-                                  input.template flat<T>().size());
-      auto b_ptr = AsDeviceMemory(filter.template flat<T>().data(),
-                                  filter.template flat<T>().size());
-      auto c_ptr = AsDeviceMemory(output->template flat<T>().data(),
-                                  output->template flat<T>().size());
-
-      auto no_transpose = se::blas::Transpose::kNoTranspose;
       OP_REQUIRES_OK(
-          ctx, stream->ThenBlasGemm(no_transpose, no_transpose, n, m, k, b_ptr,
-                                    n, a_ptr, k, &c_ptr, n,
-                                    se::blas::kDefaultComputePrecision));
+          ctx, ctx->allocate_temp(DT_FLOAT, output->shape(), &casted_out));
+
+      LaunchConvOpImpl<float>(ctx, cudnn_use_autotune, casted_input,
+                              casted_filter, dilations, strides, padding,
+                              data_format, &casted_out);
+
+      functor::CastFunctor<GPUDevice, Eigen::bfloat16, float> cast_back;
+      const Tensor& casted_out_const = casted_out;
+      cast_back(device, output->template flat<Eigen::bfloat16>(),
+                casted_out_const.template flat<float>());
       return;
     }
 
-    if (padding == Padding::SAME) {
-      const bool rows_odd = (pad_rows % 2 != 0);
-      const bool cols_odd = (pad_cols % 2 != 0);
-      const bool planes_odd = (pad_planes % 2 != 0);
-
-      // Necessary because cuDNN only supports symmetric padding.
-      // TODO(mjanusz): Consider making this optional? This would save some
-      // overhead and would work as long as an op trained this way is only
-      // used on GPU.
-      if (rows_odd || cols_odd || planes_odd) {
-        const int64_t new_in_rows = in_rows + rows_odd;
-        const int64_t new_in_cols = in_cols + cols_odd;
-        const int64_t new_in_planes = in_planes + planes_odd;
-
-        Tensor transformed_input;
-        TensorShape transformed_shape = ShapeFromFormat(
-            data_format, in_batch, {{new_in_planes, new_in_rows, new_in_cols}},
-            in_depth);
-        OP_REQUIRES_OK(
-            ctx, ctx->allocate_temp(DataTypeToEnum<T>::value, transformed_shape,
-                                    &transformed_input));
-
-        functor::PadInput<GPUDevice, T, int, 5>()(
-            ctx->eigen_device<GPUDevice>(), To32Bit(input_param.tensor<T, 5>()),
-            {{0, 0, 0}}, {{planes_odd, rows_odd, cols_odd}},
-            To32Bit(transformed_input.tensor<T, 5>()), data_format, T{});
-        input = transformed_input;
-        in_rows = new_in_rows;
-        in_cols = new_in_cols;
-        in_planes = new_in_planes;
-      }
-    }
-
-    const bool compute_in_nhwc = ComputeInNhwcEnabled(
-        DataTypeToEnum<T>::value, stream, /*use_4d_tensor=*/false);
-    const TensorFormat compute_data_format =
-        (compute_in_nhwc && data_format == FORMAT_NHWC) ? FORMAT_NHWC
-                                                        : FORMAT_NCHW;
-
-    VLOG(3) << "Compute Conv3D with cuDNN:"
-            << " data_format=" << ToString(data_format)
-            << " compute_data_format=" << ToString(compute_data_format);
-
-    if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
-      VLOG(4) << "Convert the input tensor from NDHWC to NCDHW.";
-      const TensorShape nchw_shape = ShapeFromFormat(
-          FORMAT_NCHW, in_batch, {{in_planes, in_rows, in_cols}}, in_depth);
-      if (in_depth > 1) {
-        Tensor transformed_input;
-        OP_REQUIRES_OK(ctx, ctx->allocate_temp(DataTypeToEnum<T>::value,
-                                               nchw_shape, &transformed_input));
-        // input: [b, x, y, z, d]
-        // t_input: [b, d, x, y, z]
-        // NCDHW is the only format universally supported by cuDNN.
-        functor::NHWCToNCHW<GPUDevice, T, 5>()(
-            ctx->eigen_device<GPUDevice>(),
-            const_cast<const Tensor&>(input).tensor<T, 5>(),
-            transformed_input.tensor<T, 5>());
-        input = transformed_input;
-      } else {
-        CHECK(input.CopyFrom(input, nchw_shape));
-      }
-    } else {
-      CHECK(data_format == compute_data_format)  // Crash OK
-          << "Illegal data and compute format pair:"
-          << " data_format=" << ToString(data_format)
-          << " compute_data_format=" << ToString(compute_data_format);
-    }
-
-    constexpr auto kComputeInNHWC =
-        std::make_tuple(se::dnn::DataLayout::kBatchYXDepth,
-                        se::dnn::FilterLayout::kOutputYXInput);
-    constexpr auto kComputeInNCHW =
-        std::make_tuple(se::dnn::DataLayout::kBatchDepthYX,
-                        se::dnn::FilterLayout::kOutputInputYX);
-
-    se::dnn::DataLayout compute_data_layout;
-    se::dnn::FilterLayout filter_layout;
-
-    std::tie(compute_data_layout, filter_layout) =
-        compute_data_format == FORMAT_NHWC ? kComputeInNHWC : kComputeInNCHW;
-
-    CHECK(pad_rows >= 0 && pad_cols >= 0 && pad_planes >= 0)
-        << "Negative paddings: (" << pad_rows << ", " << pad_cols << ", "
-        << pad_planes << ")";
-    se::dnn::BatchDescriptor input_desc(3);
-    input_desc.set_count(in_batch)
-        .set_feature_map_count(in_depth)
-        .set_spatial_dim(DimIndex::X, in_cols)
-        .set_spatial_dim(DimIndex::Y, in_rows)
-        .set_spatial_dim(DimIndex::Z, in_planes)
-        .set_layout(compute_data_layout);
-    se::dnn::BatchDescriptor output_desc(3);
-    output_desc.set_count(in_batch)
-        .set_spatial_dim(DimIndex::X, out_cols)
-        .set_spatial_dim(DimIndex::Y, out_rows)
-        .set_spatial_dim(DimIndex::Z, out_planes)
-        .set_feature_map_count(out_depth)
-        .set_layout(compute_data_layout);
-    se::dnn::FilterDescriptor filter_desc(3);
-    filter_desc.set_spatial_dim(DimIndex::X, filter_cols)
-        .set_spatial_dim(DimIndex::Y, filter_rows)
-        .set_spatial_dim(DimIndex::Z, filter_planes)
-        .set_input_feature_map_count(filter_depth)
-        .set_output_feature_map_count(out_depth)
-        .set_layout(filter_layout);
-    se::dnn::ConvolutionDescriptor conv_desc(3);
-    conv_desc.set_dilation_rate(DimIndex::X, dilations[2])
-        .set_dilation_rate(DimIndex::Y, dilations[1])
-        .set_dilation_rate(DimIndex::Z, dilations[0])
-        .set_filter_stride(DimIndex::X, strides[2])
-        .set_filter_stride(DimIndex::Y, strides[1])
-        .set_filter_stride(DimIndex::Z, strides[0])
-        .set_zero_padding(DimIndex::X, pad_cols / 2)
-        .set_zero_padding(DimIndex::Y, pad_rows / 2)
-        .set_zero_padding(DimIndex::Z, pad_planes / 2)
-        .set_group_count(in_depth / filter_depth);
-
-    Tensor transformed_filter;
-    auto dst_format =
-        compute_data_format == FORMAT_NCHW ? FORMAT_OIHW : FORMAT_OHWI;
-    VLOG(4) << "Transform filter tensor from " << ToString(FORMAT_HWIO)
-            << " to " << ToString(dst_format);
-    TensorShape dst_shape =
-        dst_format == FORMAT_OIHW
-            ? TensorShape({filter.dim_size(4), filter.dim_size(3),
-                           filter.dim_size(0), filter.dim_size(1),
-                           filter.dim_size(2)})
-            : TensorShape({filter.dim_size(4), filter.dim_size(0),
-                           filter.dim_size(1), filter.dim_size(2),
-                           filter.dim_size(3)});
-    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DataTypeToEnum<T>::value, dst_shape,
-                                           &transformed_filter));
-    // filter: [x, y, z, in, out]
-    // t_filter: [out, in, x, y, z] (NCDHW) or
-    // t_filter: [out, x, y, z, in] (NDHWC)
-    functor::TransformFilter<GPUDevice, T, int, 5>()(
-        ctx->eigen_device<GPUDevice>(), dst_format,
-        To32Bit(filter.tensor<T, 5>()),
-        To32Bit(transformed_filter.tensor<T, 5>()));
-
-    Tensor transformed_output;
-    if (data_format != compute_data_format) {
-      VLOG(4) << "Allocate temporary memory for output in compute data format";
-      OP_REQUIRES_OK(
-          ctx,
-          ctx->allocate_temp(
-              DataTypeToEnum<T>::value,
-              ShapeFromFormat(FORMAT_NCHW, in_batch,
-                              {{out_planes, out_rows, out_cols}}, out_depth),
-              &transformed_output));
-    } else {
-      transformed_output = *output;
-    }
-
-    auto input_ptr = AsDeviceMemory(input.template flat<T>().data(),
-                                    input.template flat<T>().size());
-    auto filter_ptr =
-        AsDeviceMemory(transformed_filter.template flat<T>().data(),
-                       transformed_filter.template flat<T>().size());
-    auto output_ptr =
-        AsDeviceMemory(transformed_output.template flat<T>().data(),
-                       transformed_output.template flat<T>().size());
-
-    static int64_t ConvolveScratchSize = GetDnnWorkspaceLimitOrDefault();
-
-    ConvParameters conv_parameters = {
-        stream->parent(),
-        in_batch,
-        in_depth,
-        {{in_planes, in_rows, in_cols}},
-        compute_data_format,
-        out_depth,
-        {{filter_planes, filter_rows, filter_cols}},
-        {{dilations[0], dilations[1], dilations[2]}},
-        {{strides[0], strides[1], strides[2]}},
-        {{pad_planes, pad_rows, pad_cols}},
-        input.dtype(),
-        conv_desc.group_count(),
-    };
-
-    using se::dnn::AlgorithmConfig;
-    using se::dnn::AlgorithmDesc;
-    using se::dnn::ProfileResult;
-
-    auto config_or = AutotuneUnfusedConv(
-        cudnn_use_autotune, AutotuneConv3d::GetInstance(), conv_parameters, ctx,
-        se::dnn::ConvolutionKind::FORWARD, input_desc, input_ptr, filter_desc,
-        filter_ptr, conv_desc, output_desc, output_ptr, ConvolveScratchSize);
-    OP_REQUIRES_OK(ctx, config_or.status());
-    auto autotune_entry = std::move(config_or).value();
-
-    DnnScratchAllocator scratch_allocator(ConvolveScratchSize, ctx);
-    Status cudnn_launch_status = LaunchAutotunedConv(
-        autotune_entry, &scratch_allocator, se::dnn::ConvolutionKind::FORWARD,
-        stream, input_desc, input_ptr, filter_desc, filter_ptr, conv_desc,
-        output_desc, output_ptr);
-    if (!cudnn_launch_status.ok()) {
-      ctx->SetStatus(cudnn_launch_status);
-      return;
-    }
-
-    if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
-      VLOG(4) << "Convert the output tensor back from NCDHW to NDHWC.";
-      // t_output: [b, out, x, y, z]
-      // output: [b, x, y, z, out]
-      functor::NCHWToNHWC<GPUDevice, T, 5>()(
-          ctx->eigen_device<GPUDevice>(),
-          const_cast<const Tensor&>(transformed_output).tensor<T, 5>(),
-          output->tensor<T, 5>());
-    }
+    LaunchConvOpImpl<Eigen::bfloat16>(ctx, cudnn_use_autotune, casted_input,
+                                      casted_filter, dilations, strides,
+                                      padding, data_format, &casted_out);
   }
 };
 
@@ -558,6 +619,7 @@ namespace functor {
       typename TTypes<T, 5>::Tensor out);
 
 DECLARE_GPU_SPEC(Eigen::half);
+DECLARE_GPU_SPEC(Eigen::bfloat16);
 DECLARE_GPU_SPEC(float);
 DECLARE_GPU_SPEC(double);
 #undef DECLARE_GPU_SPEC
@@ -568,6 +630,9 @@ DECLARE_GPU_SPEC(double);
 REGISTER_KERNEL_BUILDER(
     Name("Conv3D").Device(DEVICE_GPU).TypeConstraint<Eigen::half>("T"),
     Conv3DOp<GPUDevice, Eigen::half>);
+REGISTER_KERNEL_BUILDER(
+    Name("Conv3D").Device(DEVICE_GPU).TypeConstraint<Eigen::bfloat16>("T"),
+    Conv3DOp<GPUDevice, Eigen::bfloat16>);
 REGISTER_KERNEL_BUILDER(
     Name("Conv3D").Device(DEVICE_GPU).TypeConstraint<float>("T"),
     Conv3DOp<GPUDevice, float>);

--- a/tensorflow/core/kernels/conv_ops_gpu.cc
+++ b/tensorflow/core/kernels/conv_ops_gpu.cc
@@ -37,7 +37,7 @@ bool ComputeInNhwcEnabled(DataType data_type, se::Stream* stream,
                           bool use_4d_tensor) {
 #if GOOGLE_CUDA
   // Tensor Core supports efficient convolution with fp16 for NVIDIA Volta+
-  // GPUs and tf32 for Ampere+ GPUs in NHWC data layout. In all other
+  // GPUs and bf16/tf32 for Ampere+ GPUs in NHWC data layout. In all other
   // configurations it's more efficient to run computation in NCHW data format.
   bool use_nhwc_tf32 = data_type == DT_FLOAT &&
                        stream->GetCudaComputeCapability().IsAtLeast(
@@ -46,10 +46,14 @@ bool ComputeInNhwcEnabled(DataType data_type, se::Stream* stream,
   bool use_nhwc_fp16 =
       data_type == DT_HALF && stream->GetCudaComputeCapability().IsAtLeast(
                                   se::CudaComputeCapability::VOLTA);
+  bool use_nhwc_bf16 =
+      data_type == DT_BFLOAT16 && stream->GetCudaComputeCapability().IsAtLeast(
+                                      se::CudaComputeCapability::AMPERE);
   if (use_4d_tensor) {
-    return use_nhwc_fp16 || use_nhwc_tf32;
+    return use_nhwc_fp16 || use_nhwc_tf32 || use_nhwc_bf16;
   }
-  return CUDNN_VERSION >= 8000 && (use_nhwc_fp16 || use_nhwc_tf32);
+  return CUDNN_VERSION >= 8000 &&
+         (use_nhwc_fp16 || use_nhwc_tf32 || use_nhwc_bf16);
 #else
   // fast NHWC implementation is a CUDA only feature
   return false;
@@ -397,42 +401,27 @@ StatusOr<AutotuneEntry<se::dnn::ConvOp>> AutotuneUnfusedConv(
   return autotune_entry;
 }
 
-template StatusOr<AutotuneEntry<se::dnn::ConvOp>> AutotuneUnfusedConv<double>(
-    bool cudnn_use_autotune,
-    AutotuneMap<ConvParameters, AutotuneEntry<se::dnn::ConvOp>>* autotune_map,
-    const ConvParameters& conv_parameters, OpKernelContext* ctx,
-    se::dnn::ConvolutionKind kind, const se::dnn::BatchDescriptor& input_desc,
-    se::DeviceMemory<double> input_ptr,
-    const se::dnn::FilterDescriptor& filter_desc,
-    se::DeviceMemory<double> filter_ptr,
-    const se::dnn::ConvolutionDescriptor& conv_desc,
-    const se::dnn::BatchDescriptor& output_desc,
-    se::DeviceMemory<double> output_ptr, int64_t scratch_size_limit);
+#define DECLARE_GPU_SPEC(T)                                                 \
+  template StatusOr<AutotuneEntry<se::dnn::ConvOp>> AutotuneUnfusedConv<T>( \
+      bool cudnn_use_autotune,                                              \
+      AutotuneMap<ConvParameters, AutotuneEntry<se::dnn::ConvOp>>*          \
+          autotune_map,                                                     \
+      const ConvParameters& conv_parameters, OpKernelContext* ctx,          \
+      se::dnn::ConvolutionKind kind,                                        \
+      const se::dnn::BatchDescriptor& input_desc,                           \
+      se::DeviceMemory<T> input_ptr,                                        \
+      const se::dnn::FilterDescriptor& filter_desc,                         \
+      se::DeviceMemory<T> filter_ptr,                                       \
+      const se::dnn::ConvolutionDescriptor& conv_desc,                      \
+      const se::dnn::BatchDescriptor& output_desc,                          \
+      se::DeviceMemory<T> output_ptr, int64_t scratch_size_limit);
 
-template StatusOr<AutotuneEntry<se::dnn::ConvOp>> AutotuneUnfusedConv<float>(
-    bool cudnn_use_autotune,
-    AutotuneMap<ConvParameters, AutotuneEntry<se::dnn::ConvOp>>* autotune_map,
-    const ConvParameters& conv_parameters, OpKernelContext* ctx,
-    se::dnn::ConvolutionKind kind, const se::dnn::BatchDescriptor& input_desc,
-    se::DeviceMemory<float> input_ptr,
-    const se::dnn::FilterDescriptor& filter_desc,
-    se::DeviceMemory<float> filter_ptr,
-    const se::dnn::ConvolutionDescriptor& conv_desc,
-    const se::dnn::BatchDescriptor& output_desc,
-    se::DeviceMemory<float> output_ptr, int64_t scratch_size_limit);
+DECLARE_GPU_SPEC(double);
+DECLARE_GPU_SPEC(float);
+DECLARE_GPU_SPEC(Eigen::half);
+DECLARE_GPU_SPEC(Eigen::bfloat16);
 
-template StatusOr<AutotuneEntry<se::dnn::ConvOp>>
-AutotuneUnfusedConv<Eigen::half>(
-    bool cudnn_use_autotune,
-    AutotuneMap<ConvParameters, AutotuneEntry<se::dnn::ConvOp>>* autotune_map,
-    const ConvParameters& conv_parameters, OpKernelContext* ctx,
-    se::dnn::ConvolutionKind kind, const se::dnn::BatchDescriptor& input_desc,
-    se::DeviceMemory<Eigen::half> input_ptr,
-    const se::dnn::FilterDescriptor& filter_desc,
-    se::DeviceMemory<Eigen::half> filter_ptr,
-    const se::dnn::ConvolutionDescriptor& conv_desc,
-    const se::dnn::BatchDescriptor& output_desc,
-    se::DeviceMemory<Eigen::half> output_ptr, int64_t scratch_size_limit);
+#undef DECLARE_GPU_SPEC
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -41,14 +41,9 @@ limitations under the License.
 #include "tensorflow/core/util/use_cudnn.h"
 #include "tensorflow/core/util/work_sharder.h"
 
-#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-
 #if GOOGLE_CUDA
 #include "third_party/gpus/cudnn/cudnn.h"
 #endif
-
-#include "tensorflow/core/platform/stream_executor.h"
-#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace tensorflow {
 
@@ -61,6 +56,20 @@ namespace tensorflow {
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
+
+bool UseCudnnWith16BitFloat(OpKernelContext* ctx, DataType dtype) {
+#if GOOGLE_CUDA
+  if (dtype == DT_HALF) {
+    return true;
+  } else if (dtype == DT_BFLOAT16) {
+    auto* stream = ctx->op_device_context()->stream();
+    if (!stream) return false;
+    return stream->GetCudaComputeCapability().IsAtLeast(
+        se::CudaComputeCapability::AMPERE);
+  }
+#endif
+  return false;
+}
 
 // Computes the vectorized product of 'input_buffer' and 'filter' and stores
 // result in 'output' at location specified by 'out_r' and 'out_c'.
@@ -258,11 +267,13 @@ extern template struct LaunchConv2DOp<CPUDevice, double>;
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 // Extern template instantiated in conv_ops.cc.
+extern template struct LaunchConv2DOp<GPUDevice, Eigen::bfloat16>;
 extern template struct LaunchConv2DOp<GPUDevice, Eigen::half>;
 extern template struct LaunchConv2DOp<GPUDevice, float>;
 extern template struct LaunchConv2DOp<GPUDevice, double>;
 
 // Extern template instantiated in depthwise_conv_op_gpu.cc.
+extern template struct LaunchDepthwiseConvOp<GPUDevice, Eigen::bfloat16>;
 extern template struct LaunchDepthwiseConvOp<GPUDevice, Eigen::half>;
 extern template struct LaunchDepthwiseConvOp<GPUDevice, float>;
 extern template struct LaunchDepthwiseConvOp<GPUDevice, double>;
@@ -329,7 +340,7 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // good performance. (https://docs.nvidia.com/deeplearning/sdk/cudnn-
     // release-notes/rel_8.html#rel_8)
     use_cudnn_grouped_conv_ =
-        dtype_ == DT_HALF &&
+        (dtype_ == DT_HALF || dtype_ == DT_BFLOAT16) &&
         (data_format_ == FORMAT_NCHW ||
          (data_format_ == FORMAT_NHWC && stride_ == stride_w &&
           (stride_ == 1 || stride_ == 2)));
@@ -428,9 +439,10 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     // Depthwise convolution is a special case of cuDNN's grouped convolution.
     bool use_cudnn =
         std::is_same<Device, GPUDevice>::value &&
-        (in_depth == 1 || (use_cudnn_grouped_conv_ &&
-                           ShouldCudnnGroupedConvolutionBeUsed(
-                               filter_rows, filter_cols, in_depth, out_depth)));
+        (in_depth == 1 ||
+         (use_cudnn_grouped_conv_ && UseCudnnWith16BitFloat(context, dtype_) &&
+          ShouldCudnnGroupedConvolutionBeUsed(filter_rows, filter_cols,
+                                              in_depth, out_depth)));
 
     VLOG(2) << "DepthwiseConv2dNative: "
             << " Input: [" << batch << ", " << input_rows << ", " << input_cols
@@ -527,6 +539,7 @@ TF_CALL_double(REGISTER_CPU_KERNEL);
       Name("DepthwiseConv2dNative").Device(DEVICE_GPU).TypeConstraint<T>("T"), \
       DepthwiseConv2dNativeOp<GPUDevice, T>)
 
+TF_CALL_bfloat16(REGISTER_GPU_KERNEL);
 TF_CALL_half(REGISTER_GPU_KERNEL);
 TF_CALL_float(REGISTER_GPU_KERNEL);
 TF_CALL_double(REGISTER_GPU_KERNEL);
@@ -549,6 +562,7 @@ class DepthwiseConv2dGroupedConvOp
                               .Label("cudnn_grouped_convolution"), \
                           DepthwiseConv2dGroupedConvOp<T>)
 
+TF_CALL_bfloat16(REGISTER_GROUPED_CONV_KERNEL);
 TF_CALL_half(REGISTER_GROUPED_CONV_KERNEL);
 TF_CALL_float(REGISTER_GROUPED_CONV_KERNEL);
 TF_CALL_double(REGISTER_GROUPED_CONV_KERNEL);

--- a/tensorflow/core/kernels/depthwise_conv_op.h
+++ b/tensorflow/core/kernels/depthwise_conv_op.h
@@ -20,6 +20,10 @@ limitations under the License.
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/util/tensor_format.h"
 
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "tensorflow/core/platform/stream_executor.h"
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
 namespace tensorflow {
 
 struct DepthwiseArgs {
@@ -79,6 +83,8 @@ struct LaunchDepthwiseConvBackpropFilterOp {
                   const T* out_backprop, const T* input, T* filter_backprop,
                   TensorFormat data_format);
 };
+
+bool UseCudnnWith16BitFloat(OpKernelContext* ctx, DataType dtype);
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 template <typename T>

--- a/tensorflow/core/kernels/depthwise_conv_op_gpu.h
+++ b/tensorflow/core/kernels/depthwise_conv_op_gpu.h
@@ -47,6 +47,10 @@ template <>
 struct PseudoHalfType<Eigen::half> {
   using Type = float;
 };
+template <>
+struct PseudoHalfType<Eigen::bfloat16> {
+  using Type = float;
+};
 }  // namespace detail
 
 using Eigen::GpuDevice;

--- a/tensorflow/core/kernels/depthwise_conv_op_gpu_bfloat16.cu.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op_gpu_bfloat16.cu.cc
@@ -1,0 +1,30 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#define EIGEN_USE_GPU
+
+#include "tensorflow/core/kernels/depthwise_conv_op.h"
+#include "tensorflow/core/kernels/depthwise_conv_op_gpu.h"
+
+namespace tensorflow {
+using Eigen::GpuDevice;
+
+template struct LaunchDepthwiseConvOp<GpuDevice, Eigen::bfloat16>;
+template struct LaunchDepthwiseConvBackpropInputOp<GpuDevice, Eigen::bfloat16>;
+template struct LaunchDepthwiseConvBackpropFilterOp<GpuDevice, Eigen::bfloat16>;
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
@@ -172,6 +172,7 @@ class Conv2DTest(test.TestCase):
         out.append(dtypes.float16)
       if not test.is_built_with_rocm():
         out.append(dtypes.float64)
+        out.append(dtypes.bfloat16)
       return out
 
     return [dtypes.float32, dtypes.float64, dtypes.float16, dtypes.bfloat16]

--- a/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
@@ -171,8 +171,7 @@ class Conv2DTest(test.TestCase):
       if test_util.GpuSupportsHalfMatMulAndConv():
         out.append(dtypes.float16)
       if not test.is_built_with_rocm():
-        out.append(dtypes.float64)
-        out.append(dtypes.bfloat16)
+        out.extend([dtypes.float64, dtypes.bfloat16])
       return out
 
     return [dtypes.float32, dtypes.float64, dtypes.float16, dtypes.bfloat16]

--- a/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_base.py
+++ b/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_base.py
@@ -416,16 +416,17 @@ class DepthwiseConv2DBase(test.TestCase):
       tf_logging.info(
           "Testing DepthwiseConv2DCudnn, %dth config: %r * %r, stride: %d, "
           "padding: %s", index, input_size, filter_size, stride, padding)
-      data_type = dtypes.float16
-      self._VerifyValues(
-          input_size,
-          filter_size,
-          stride,
-          padding,
-          data_type,
-          use_gpu=True,
-          data_format="NCHW",
-          dilations=dilations)
+      data_types = [dtypes.float16, dtypes.bfloat16]
+      for data_type in data_types:
+        self._VerifyValues(
+            input_size,
+            filter_size,
+            stride,
+            padding,
+            data_type,
+            use_gpu=True,
+            data_format="NCHW",
+            dilations=dilations)
 
   @test_util.run_v1_only("b/120545219")
   def testDepthwiseConv2D(self):
@@ -509,10 +510,12 @@ class DepthwiseConv2DBase(test.TestCase):
           "Testing DepthwiseConv2D, %dth config: %r * %r, stride: %d, padding: "
           "%s", index, input_size, filter_size, stride, padding)
       # double datatype is currently not supported for convolution ops
-      # on the ROCm platform
-      optional_float64 = [] if test.is_built_with_rocm() else [dtypes.float64]
+      # on the ROCm platform and its support for bfloat16 is unknown.
+      data_types = [dtypes.float16, dtypes.float32]
+      if not test.is_built_with_rocm():
+        data_types.extend([dtypes.float64, dtypes.bfloat16])
       data_formats = ["NHWC", "NCHW"] if test.is_gpu_available() else ["NHWC"]
-      for data_type in [dtypes.float16, dtypes.float32] + optional_float64:
+      for data_type in data_types:
         for data_format in data_formats:
           self._VerifyValues(
               input_size,
@@ -662,6 +665,7 @@ class DepthwiseConv2DBase(test.TestCase):
           dtypes.float16: 4e-0,
           dtypes.float32: 8e-4,
           dtypes.float64: 1e-12,
+          dtypes.bfloat16: 1e-0,
       }[data_type]
 
       input_tensor = constant_op.constant(
@@ -743,18 +747,19 @@ class DepthwiseConv2DBase(test.TestCase):
           "Testing DepthwiseConv2DInputGradCudnn, %dth config: %r * %r, "
           "stride: %d, padding: %s", index, input_size, filter_size, stride,
           padding)
-      data_type = dtypes.float16
-      self._ConstructAndTestGradient(
-          input_size,
-          filter_size,
-          output_size,
-          stride,
-          padding,
-          data_type,
-          test_input=True,
-          use_gpu=True,
-          data_format="NCHW",
-          dilations=dilations)
+      data_types = [dtypes.float16, dtypes.bfloat16]
+      for data_type in data_types:
+        self._ConstructAndTestGradient(
+            input_size,
+            filter_size,
+            output_size,
+            stride,
+            padding,
+            data_type,
+            test_input=True,
+            use_gpu=True,
+            data_format="NCHW",
+            dilations=dilations)
 
   @test_util.run_v1_only("b/120545219")
   def testDepthwiseConv2DInputGrad(self):
@@ -825,10 +830,12 @@ class DepthwiseConv2DBase(test.TestCase):
           "stride: %d, padding: %s", index, input_size, filter_size, stride,
           padding)
       # double datatype is currently not supported for convolution ops
-      # on the ROCm platform
-      optional_float64 = [] if test.is_built_with_rocm() else [dtypes.float64]
+      # on the ROCm platform and its support for bfloat16 is unknown.
+      data_types = [dtypes.float16, dtypes.float32]
+      if not test.is_built_with_rocm():
+        data_types.extend([dtypes.float64, dtypes.bfloat16])
       data_formats = ["NHWC", "NCHW"] if test.is_gpu_available() else ["NHWC"]
-      for data_type in [dtypes.float16, dtypes.float32] + optional_float64:
+      for data_type in data_types:
         for data_format in data_formats:
           self._ConstructAndTestGradient(
               input_size,
@@ -853,29 +860,30 @@ class DepthwiseConv2DBase(test.TestCase):
           "Testing DepthwiseConv2DFilterGradCudnn, %dth config: %r * %r, "
           "stride: %d, padding: %s", index, input_size, filter_size, stride,
           padding)
-      data_type = dtypes.float16
-      self._ConstructAndTestGradient(
-          input_size,
-          filter_size,
-          output_size,
-          stride,
-          padding,
-          data_type,
-          test_input=False,
-          use_gpu=True,
-          data_format="NCHW",
-          dilations=dilations)
-      self._ConstructAndTestGradient(
-          input_size,
-          filter_size,
-          output_size,
-          stride,
-          padding,
-          data_type,
-          test_input=False,
-          use_gpu=True,
-          data_format="NHWC",
-          dilations=dilations)
+      data_types = [dtypes.float16, dtypes.bfloat16]
+      for data_type in data_types:
+        self._ConstructAndTestGradient(
+            input_size,
+            filter_size,
+            output_size,
+            stride,
+            padding,
+            data_type,
+            test_input=False,
+            use_gpu=True,
+            data_format="NCHW",
+            dilations=dilations)
+        self._ConstructAndTestGradient(
+            input_size,
+            filter_size,
+            output_size,
+            stride,
+            padding,
+            data_type,
+            test_input=False,
+            use_gpu=True,
+            data_format="NHWC",
+            dilations=dilations)
 
   @test_util.run_v1_only("b/120545219")
   def testDepthwiseConv2DFilterGrad(self):
@@ -935,10 +943,12 @@ class DepthwiseConv2DBase(test.TestCase):
           "stride: %d, padding: %s", index, input_size, filter_size, stride,
           padding)
       # double datatype is currently not supported for convolution ops
-      # on the ROCm platform
-      optional_float64 = [] if test.is_built_with_rocm() else [dtypes.float64]
+      # on the ROCm platform and its support for bfloat16 is unknown.
+      data_types = [dtypes.float16, dtypes.float32]
+      if not test.is_built_with_rocm():
+        data_types.extend([dtypes.float64, dtypes.bfloat16])
       data_formats = ["NHWC", "NCHW"] if test.is_gpu_available() else ["NHWC"]
-      for data_type in [dtypes.float16, dtypes.float32] + optional_float64:
+      for data_type in data_types:
         for data_format in data_formats:
           self._ConstructAndTestGradient(
               input_size,
@@ -954,25 +964,26 @@ class DepthwiseConv2DBase(test.TestCase):
 
   def _CompareBackpropInput(self, input_sizes, filter_sizes, output_sizes,
                             stride, padding, dtype):
-    x1 = np.random.rand(*filter_sizes).astype(dtype)
-    x2 = np.random.rand(*output_sizes).astype(dtype)
+    x1 = np.random.rand(*filter_sizes)
+    x2 = np.random.rand(*output_sizes)
     if isinstance(padding, list):
       padding = [(0, 0)] + padding + [(0, 0)]
 
-    def _GetVal(use_gpu):
+    def _GetVal(use_gpu, dtype):
       with self.cached_session(use_gpu=use_gpu):
         t0 = constant_op.constant(input_sizes, shape=[len(input_sizes)])
-        t1 = constant_op.constant(x1, shape=filter_sizes)
-        t2 = constant_op.constant(x2, shape=output_sizes)
+        t1 = constant_op.constant(x1, shape=filter_sizes, dtype=dtype)
+        t2 = constant_op.constant(x2, shape=output_sizes, dtype=dtype)
         backprop = nn_ops.depthwise_conv2d_native_backprop_input(
             t0, t1, t2, strides=[1, stride, stride, 1], padding=padding)
         ret = self.evaluate(backprop)
         self.assertShapeEqual(ret, backprop)
         return ret
 
-    gpu_value = _GetVal(use_gpu=True)
-    cpu_value = _GetVal(use_gpu=False)
-    self.assertAllClose(cpu_value, gpu_value, rtol=1e-4, atol=1e-4)
+    rtol, atol = (1e-1, 1e-1) if dtype == "bfloat16" else (1e-4, 1e-4)
+    gpu_value = _GetVal(use_gpu=True, dtype=dtype)
+    cpu_value = _GetVal(use_gpu=False, dtype=dtype)
+    self.assertAllClose(cpu_value, gpu_value, rtol=rtol, atol=atol)
 
   @test_util.run_gpu_only
   def testDepthwiseConv2DInputGradCompare(self):
@@ -986,12 +997,14 @@ class DepthwiseConv2DBase(test.TestCase):
           padding)
       self._CompareBackpropInput(input_size, filter_size, output_size, stride,
                                  padding, "float32")
-      # double datatype is currently not supported for convolution ops
-      # on the ROCm platform
+      # Convolutions on the ROCm platform don't support double dtype. And its
+      # support for bf16 is unknown. So, we skip these tests.
       if test.is_built_with_rocm():
         continue
       self._CompareBackpropInput(input_size, filter_size, output_size, stride,
                                  padding, "float64")
+      self._CompareBackpropInput(input_size, filter_size, output_size, stride,
+                                 padding, "bfloat16")
 
   @test_util.run_gpu_only
   def testDepthwiseConv2DInputGradExplicitCompare(self):
@@ -1005,28 +1018,30 @@ class DepthwiseConv2DBase(test.TestCase):
           padding)
       self._CompareBackpropInput(input_size, filter_size, output_size, stride,
                                  padding, "float32")
-      # double datatype is currently not supported for convolution ops
-      # on the ROCm platform
+      # Convolutions on the ROCm platform don't support double dtype. And its
+      # support for bf16 is unknown. So, we skip these tests.
       if test.is_built_with_rocm():
         continue
       self._CompareBackpropInput(input_size, filter_size, output_size, stride,
                                  padding, "float64")
+      self._CompareBackpropInput(input_size, filter_size, output_size, stride,
+                                 padding, "bfloat16")
 
   def _CompareBackpropFilter(self, input_sizes, filter_sizes, output_sizes,
                              stride, padding, dtype):
-    x0 = np.random.rand(*input_sizes).astype(dtype)
-    x2 = np.random.rand(*output_sizes).astype(dtype)
+    x0 = np.random.rand(*input_sizes)
+    x2 = np.random.rand(*output_sizes)
     padding_nhwc = padding
     padding_nchw = padding
     if isinstance(padding, list):
       padding_nhwc = [(0, 0)] + padding + [(0, 0)]
       padding_nchw = [(0, 0)] + [(0, 0)] + padding
 
-    def _GetVal(use_gpu, data_format="NHWC"):
+    def _GetVal(use_gpu, dtype, data_format="NHWC"):
       with self.cached_session(use_gpu=use_gpu):
-        t0 = constant_op.constant(x0, shape=input_sizes)
+        t0 = constant_op.constant(x0, shape=input_sizes, dtype=dtype)
         t1 = constant_op.constant(filter_sizes, shape=[len(filter_sizes)])
-        t2 = constant_op.constant(x2, shape=output_sizes)
+        t2 = constant_op.constant(x2, shape=output_sizes, dtype=dtype)
         strides = [1, stride, stride, 1]
         padding = padding_nhwc
         if data_format == "NCHW":
@@ -1045,10 +1060,11 @@ class DepthwiseConv2DBase(test.TestCase):
         self.assertShapeEqual(ret, backprop)
         return ret
 
-    cpu_value = _GetVal(use_gpu=False)
+    cpu_value = _GetVal(use_gpu=False, dtype=dtype)
     for data_format in ["NHWC", "NCHW"]:
-      gpu_value = _GetVal(use_gpu=True, data_format=data_format)
-      self.assertAllClose(cpu_value, gpu_value, rtol=1e-4, atol=1e-4)
+      gpu_value = _GetVal(use_gpu=True, dtype=dtype, data_format=data_format)
+      self.assertAllCloseAccordingToType(
+          cpu_value, gpu_value, rtol=1e-4, atol=1e-4, bfloat16_rtol=1e-0)
 
   @test_util.run_gpu_only
   def testDepthwiseConv2DFilterGradCompare(self):
@@ -1062,12 +1078,15 @@ class DepthwiseConv2DBase(test.TestCase):
           padding)
       self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
                                   padding, "float32")
-      # double datatype is currently not supported for convolution ops
-      # on the ROCm platform
+      # Convolutions on the ROCm platform don't support double dtype. And its
+      # support for bf16 is unknown. So, we skip these tests.
       if test.is_built_with_rocm():
         continue
       self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
                                   padding, "float64")
+
+      self._CompareBackpropFilter(input_size, filter_size, output_size,
+                                  stride, padding, "bfloat16")
 
   @test_util.run_gpu_only
   def testDepthwiseConv2DFilterGradExplicitCompare(self):
@@ -1081,9 +1100,78 @@ class DepthwiseConv2DBase(test.TestCase):
           padding)
       self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
                                   padding, "float32")
-      # double datatype is currently not supported for convolution ops
-      # on the ROCm platform
+      # Convolutions on the ROCm platform don't support double dtype. And its
+      # support for bf16 is unknown. So, we skip these tests.
       if test.is_built_with_rocm():
         continue
       self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
                                   padding, "float64")
+
+      self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
+                                  padding, "bfloat16")
+
+  def _CompareForward(self, input_sizes, filter_sizes, output_sizes, stride,
+                      padding, dtype):
+    x1 = np.random.rand(*input_sizes)
+    x2 = np.random.rand(*filter_sizes)
+    if isinstance(padding, list):
+      padding = [(0, 0)] + padding + [(0, 0)]
+
+    def _GetVal(use_gpu, dtype):
+      with self.cached_session(use_gpu=use_gpu):
+        t1 = constant_op.constant(x1, shape=input_sizes, dtype=dtype)
+        t2 = constant_op.constant(x2, shape=filter_sizes, dtype=dtype)
+        output = nn_ops.depthwise_conv2d_native(
+            t1, t2, strides=[1, stride, stride, 1], padding=padding)
+        ret = self.evaluate(output)
+        self.assertShapeEqual(ret, output)
+        return ret
+
+    gpu_value = _GetVal(use_gpu=True, dtype=dtype)
+    cpu_value = _GetVal(use_gpu=False, dtype=dtype)
+    self.assertAllCloseAccordingToType(
+        cpu_value, gpu_value, rtol=1e-4, atol=1e-4, bfloat16_rtol=1e-1)
+
+  @test_util.run_gpu_only
+  def testDepthwiseConv2DForwardCompare(self):
+    for index, (input_size, filter_size, output_size, stride, padding,
+                dilations) in enumerate(ConfigsToTest()):
+      if dilations:
+        continue
+      tf_logging.info(
+          "Testing DepthwiseConv2DForwardCompare, %dth config: %r * %r, "
+          "stride: %d, padding: %s", index, input_size, filter_size, stride,
+          padding)
+      self._CompareForward(input_size, filter_size, output_size, stride,
+                           padding, "float32")
+      # Convolutions on the ROCm platform don't support double dtype. And its
+      # support for bf16 is unknown. So, we skip these tests.
+      if test.is_built_with_rocm():
+        continue
+      self._CompareForward(input_size, filter_size, output_size, stride,
+                           padding, "float64")
+
+      self._CompareForward(input_size, filter_size, output_size, stride,
+                           padding, "bfloat16")
+
+  @test_util.run_gpu_only
+  def testDepthwiseConv2DForwardExplicitCompare(self):
+    for index, (input_size, filter_size, output_size, stride, padding,
+                dilations) in enumerate(ConfigsToTestExplicit()):
+      if dilations:
+        continue
+      tf_logging.info(
+          "Testing DepthwiseConv2DForwardCompare, %dth config: %r * %r, "
+          "stride: %d, padding: %s", index, input_size, filter_size, stride,
+          padding)
+      # Convolutions on the ROCm platform don't support double dtype. And its
+      # support for bf16 is unknown. So, we skip these tests.
+      if test.is_built_with_rocm():
+        continue
+      self._CompareForward(input_size, filter_size, output_size, stride,
+                           padding, "float64")
+      self._CompareForward(input_size, filter_size, output_size, stride,
+                           padding, "float32")
+
+      self._CompareForward(input_size, filter_size, output_size, stride,
+                           padding, "bfloat16")


### PR DESCRIPTION
This PR enables BF16 Conv ops via cuDNN or cuBLASLt.

This includes the fwd and bwd ops for the Conv2D/3D and the Depthwise Conv.

cc. @nluehr @pjannaty @kushanam 