### PR TITLE
Fix hang bug with cuda_malloc_async allocator

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.h
@@ -40,6 +40,9 @@ class GPUcudaMallocAllocator : public Allocator {
     return AllocatorMemoryType::kDevice;
   }
 
+  // cuMemFree cannot be called from within a stream callback.
+  bool IsSafeInGpuCallback() const override { return false; }
+
  private:
   se::StreamExecutor* stream_exec_;  // Not owned.
 

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamallocasync_allocator.h
@@ -97,6 +97,11 @@ class GpuCudaMallocAsyncAllocator : public Allocator {
     return AllocatorMemoryType::kDevice;
   }
 
+  // cuMemFreeAsync cannot be called from within a stream callback.
+  bool IsSafeInGpuCallback() const override { return false; }
+
+  bool IsGpuStreamOrdered() const override { return true; }
+
  private:
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
   se::StreamExecutor* stream_exec_;  // Not owned.

--- a/tensorflow/core/common_runtime/gpu/gpu_managed_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_managed_allocator.h
@@ -29,6 +29,9 @@ class GpuManagedAllocator : public Allocator {
   string Name() override { return "GpuManagedAllocator"; }
   void* AllocateRaw(size_t alignment, size_t num_bytes) override;
   void DeallocateRaw(void* ptr) override;
+
+  // cudaFree cannot be called from within a stream callback.
+  bool IsSafeInGpuCallback() const override { return false; }
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/framework/allocator.h
+++ b/tensorflow/core/framework/allocator.h
@@ -230,6 +230,14 @@ class Allocator {
   virtual AllocatorMemoryType GetMemoryType() const {
     return AllocatorMemoryType::kUnknown;
   }
+
+  // Returns whether allocations and deallocations can be made from within a GPU
+  // stream callback.
+  virtual bool IsSafeInGpuCallback() const { return true; }
+
+  // Returns whether allocations and deallocations are ordered with respect to
+  // the compute stream.
+  virtual bool IsGpuStreamOrdered() const { return false; }
 };
 
 // An implementation of Allocator that delegates all calls to another Allocator.


### PR DESCRIPTION
- Allocator::DeallocateRaw is called from within a stream callback to ensure stream-aware behavior. However, it is unsafe to call CUDA APIs from inside a stream callback. While BFCAllocator does not call any CUDA APIs in DeallocateRaw, the cuda_malloc and cuda_malloc_async allocators do (cuMemFree and cuMemFreeAsync), and this was observed cause hangs in several models.
- This PR identifies callback-unsafe allocators and calls their DeallocateRaw method directly instead of from the stream callback (the effect is the same, but this way is safe).

cc @nluehr @pjannaty 