### PR TITLE
[ROCm] Disable mhlo llvm.roundeven op for ROCm.

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/gpu_fusion_rewrite.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Transforms/gpu_fusion_rewrite.cc
@@ -338,7 +338,10 @@ ConversionTarget FusionRewritePattern::getRewritableTarget(MLIRContext* ctx) {
       mhlo::AddOp, mhlo::AbsOp, mhlo::CbrtOp, mhlo::CeilOp, mhlo::CosineOp,
       mhlo::DivOp, mhlo::ExpOp, mhlo::Expm1Op, mhlo::FloorOp, mhlo::LogOp,
       mhlo::Log1pOp, mhlo::LogisticOp, mhlo::MulOp, mhlo::NegOp, mhlo::RoundOp,
-      mhlo::RoundNearestEvenOp, mhlo::RsqrtOp, mhlo::SignOp, mhlo::SineOp,
+#if !TENSORFLOW_USE_ROCM
+      mhlo::RoundNearestEvenOp,
+#endif
+      mhlo::RsqrtOp, mhlo::SignOp, mhlo::SineOp,
       mhlo::SqrtOp, mhlo::SubtractOp, mhlo::TanhOp>();
   return target;
 }


### PR DESCRIPTION
The llvm.roundeven op does not work on ROCm due to LLVM issues with the AMDGPU backend related to that op.

/cc @cheshire 