### PR TITLE
Fix aligned alloc on C++14 compiler as it is only C++17

### DIFF
--- a/tensorflow/lite/interpreter_builder.cc
+++ b/tensorflow/lite/interpreter_builder.cc
@@ -46,8 +46,8 @@ limitations under the License.
 #include "tensorflow/lite/util.h"
 #include "tensorflow/lite/version.h"
 
-// aligned_alloc is available (via cstdlib/stdlib.h) with C++17/C11.
-#if __cplusplus >= 201703L || __STDC_VERSION__ >= 201112L
+// aligned_alloc is available (via cstdlib/stdlib.h) with C++17/C11 (introduced in stdc11 but realized in C++17).
+#if __cplusplus >= 201703L && __STDC_VERSION__ >= 201112L
 #if !defined(__ANDROID__) || __ANDROID_API__ >= 28
 // Neither Apple nor Windows provide aligned_alloc.
 #if !defined(__APPLE__) && !defined(_WIN32)

--- a/tensorflow/lite/kernels/internal/optimized/neon_tensor_utils.cc
+++ b/tensorflow/lite/kernels/internal/optimized/neon_tensor_utils.cc
@@ -35,8 +35,8 @@ limitations under the License.
 
 #ifdef USE_NEON
 
-// aligned_alloc is available (via cstdlib/stdlib.h) with C++17/C11.
-#if __cplusplus >= 201703L || __STDC_VERSION__ >= 201112L
+// aligned_alloc is available (via cstdlib/stdlib.h) with C++17/C11 (introduced in stdc11 but realized in C++17).
+#if __cplusplus >= 201703L && __STDC_VERSION__ >= 201112L
 #if !defined(__ANDROID__) || __ANDROID_API__ >= 28
 // Neither Apple nor Windows provide aligned_alloc.
 #if !defined(__APPLE__) && !defined(_WIN32)


### PR DESCRIPTION
See #57706 but the gist is aligned_alloc was introduced in the std c11 but was fully implemented in C++17 however a C++14 might be C11 compliant without that feature (eg GCC 7.1.0)

I just forced the condition to be both std c11 and C++17 to ensure at 100% the feature is here and fall back to the less effective method otherwise.