### PR TITLE
[MHLO] add simplifyDynamicConv pattern

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/mhlo/IR/hlo_ops.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/mhlo/IR/hlo_ops.cc
@@ -2625,6 +2625,12 @@ struct DynamicConvIsConv : public OpRewritePattern<mhlo::DynamicConvOp> {
     for (APInt pad : padAttr.getValues<APInt>()) {
       padArray.push_back(pad.getZExtValue());
     }
+    if (op.getPadding().has_value()) {
+      for (const auto &it :
+           llvm::enumerate(op.getPaddingAttr().getValues<APInt>())) {
+        padArray[it.index()] += it.value().getZExtValue();
+      }
+    }
 
     int64_t paddedDimCount = padArray.size() / 2;
     auto newPadAttr = DenseIntElementsAttr::get(
@@ -7872,6 +7878,10 @@ void WhileOp::getCanonicalizationPatterns(RewritePatternSet& results,
                                           MLIRContext* context) {
   results.add(&whileCanonicalization);
 }
+
+//===----------------------------------------------------------------------===//
+// UniformDequantizeOp
+//===----------------------------------------------------------------------===//
 
 LogicalResult UniformDequantizeOp::inferReturnTypeComponents(
     MLIRContext*, Optional<Location> /*location*/, ValueShapeRange operands,

--- a/tensorflow/compiler/xla/mlir_hlo/tests/Dialect/mhlo/canonicalize/convolution.mlir
+++ b/tensorflow/compiler/xla/mlir_hlo/tests/Dialect/mhlo/canonicalize/convolution.mlir
@@ -106,10 +106,10 @@ func.func @conv_grouped_is_dot_transpose_out(%arg0: tensor<5x4xf32>, %arg1: tens
 // -----
 
 // CHECK-LABEL: @dynamic_conv2d_padding
-func.func @dynamic_conv2d_padding(%arg0: tensor<1x8x8x32x207xf32>, %arg1: tensor<3x3x32x207x16xf32>) -> tensor<32x1x8x8x16xf32> {
+func.func @dynamic_conv2d_padding(%arg0: tensor<1x8x8x32x207xf32>, %arg1: tensor<3x3x32x207x16xf32>) -> tensor<32x1x10x10x16xf32> {
   %pad = arith.constant dense<[2, 0, 1, 1]> : tensor<4xi64>
   // CHECK: %[[CONV:.+]] = mhlo.convolution
-  // CHECK-SAME: pad = {{\[\[}}2, 0], [1, 1]]
+  // CHECK-SAME: pad = {{\[\[}}3, 1], [2, 2]]
   %0 = "mhlo.dynamic_conv"(%arg0, %arg1, %pad) {batch_group_count = 1 : i64,
     dimension_numbers = #mhlo.conv<raw
       input_batch_dimension = 0,
@@ -122,7 +122,7 @@ func.func @dynamic_conv2d_padding(%arg0: tensor<1x8x8x32x207xf32>, %arg1: tensor
       output_feature_dimension = 4,
       output_spatial_dimensions = [2, 3]
     >, feature_group_count = 1 : i64, lhs_dilation = dense<1> : tensor<2xi64>, padding = dense<1> : tensor<2x2xi64>, precision_config = [#mhlo<precision DEFAULT>, #mhlo<precision DEFAULT>], rhs_dilation = dense<1> : tensor<2xi64>, window_strides = dense<1> : tensor<2xi64>} :
-       (tensor<1x8x8x32x207xf32>, tensor<3x3x32x207x16xf32>, tensor<4xi64>) -> tensor<32x1x8x8x16xf32>
+       (tensor<1x8x8x32x207xf32>, tensor<3x3x32x207x16xf32>, tensor<4xi64>) -> tensor<32x1x10x10x16xf32>
   // CHECK: return %[[CONV]]
-  func.return %0 : tensor<32x1x8x8x16xf32>
+  func.return %0 : tensor<32x1x10x10x16xf32>
 }


### PR DESCRIPTION
Simplify `mhlo.dynamic_conv` to `mhlo.convolution` when `d_padding` is constant.