### PR TITLE
Modify function def that was invalid for python < 3.9

### DIFF
--- a/tensorflow/core/function/capture/free_vars_detect.py
+++ b/tensorflow/core/function/capture/free_vars_detect.py
@@ -16,6 +16,8 @@
 
 import types
 
+from typing import List, Tuple
+
 from tensorflow.python.autograph.pyct import anno
 from tensorflow.python.autograph.pyct import naming
 from tensorflow.python.autograph.pyct import parser
@@ -42,7 +44,7 @@ def _parse_and_analyze(func):
 
 
 def detect_function_free_vars(
-    func: types.FunctionType) -> tuple[list[str], list[str], list[int]]:
+    func: types.FunctionType) -> Tuple[List[str], List[str], List[int]]:
   """Detect free vars in any Python function."""
   assert isinstance(
       func, types.FunctionType


### PR DESCRIPTION
The function def was invalid syntax for python <= 3.8 so modify it to be compatible