### PR TITLE
Update libpng to libpng-1.6.38

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -302,10 +302,10 @@ def _tf_repositories():
         name = "png",
         build_file = "//third_party:png.BUILD",
         patch_file = ["//third_party:png_fix_rpi.patch"],
-        sha256 = "ca74a0dace179a8422187671aee97dd3892b53e168627145271cad5b5ac81307",
-        strip_prefix = "libpng-1.6.37",
+        sha256 = "d4160037fa5d09fa7cff555037f2a7f2fefc99ca01e21723b19bfcda33015234",
+        strip_prefix = "libpng-1.6.38",
         system_build_file = "//third_party/systemlibs:png.BUILD",
-        urls = tf_mirror_urls("https://github.com/glennrp/libpng/archive/v1.6.37.tar.gz"),
+        urls = tf_mirror_urls("https://github.com/glennrp/libpng/archive/v1.6.38.tar.gz"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
libpng is one of the libraries that has not been updated for a long time. The old version 1.6.37 used by tensorflow was from 04/14/2019 (more than 3 years ago). Since then quite some issues have been fixed.
https://github.com/glennrp/libpng/tags
It is worth to update to the latest version (1.6.38) which has been released last week to cover any fixed issues and vulnerabilities.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>