### PR TITLE
Update sqlite to 3.39.3

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -311,10 +311,10 @@ def _tf_repositories():
     tf_http_archive(
         name = "org_sqlite",
         build_file = "//third_party:sqlite.BUILD",
-        sha256 = "87775784f8b22d0d0f1d7811870d39feaa7896319c7c20b849a4181c5a50609b",
-        strip_prefix = "sqlite-amalgamation-3390200",
+        sha256 = "a89db3030d229d860ae56a8bac50ac9761434047ae886e47e7c8f9f428fa98ad",
+        strip_prefix = "sqlite-amalgamation-3390300",
         system_build_file = "//third_party/systemlibs:sqlite.BUILD",
-        urls = tf_mirror_urls("https://www.sqlite.org/2022/sqlite-amalgamation-3390200.zip"),
+        urls = tf_mirror_urls("https://www.sqlite.org/2022/sqlite-amalgamation-3390300.zip"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
This PR updates sqlite to the latest release of 3.39.3 which fixed CVE-2022-35737 in 3.39.2 (the version used in tensorflow).

See https://www.sqlite.org/cves.html for details of CVE-2022-35737

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>