### PR TITLE
[mlir/lite] fuse dilated conv2d with fp16

### DIFF
--- a/tensorflow/compiler/mlir/lite/transforms/dilated_conv.h
+++ b/tensorflow/compiler/mlir/lite/transforms/dilated_conv.h
@@ -99,9 +99,13 @@ LogicalResult ConvertTFDilatedConvOp<Conv2dOpTy>::matchAndRewrite(
     return rewriter.notifyMatchFailure(op, "dilations should be all 1");
   }
 
-  if (!TFTypeIsFloat32Tensor(op.input()) || !TFDataFormatIsNHWC(op)) {
+  if (!TFL::TFTypeIsFloat32Tensor(op.input()) &&
+      !TFL::TFTypeIsBFloat16OrHalfTensor(op.input())) {
     return rewriter.notifyMatchFailure(
-        op, "op's input is not float or the data format isn't NHWC");
+        op, "op's input is not float or half or bfloat16");
+  }
+  if (!TFL::TFDataFormatIsNHWC(op)) {
+    return rewriter.notifyMatchFailure(op, "op's data format isn't NHWC");
   }
 
   // Allow dynamic width and height dimensions only.


### PR DESCRIPTION
Fuse dilated conv2d with fp16.  

BTW, I have two questions to ask:
1. Why the Batch dimension should not be dynamic?
2. Why the padding mode set to `SAME` when not `VALID`, I think there are some corner cases which are neither `SAME` nor `VALID`?