### PR TITLE
[ROCm] Add stream_executor/stream.h header to pip package

### DIFF
--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -64,6 +64,7 @@ transitive_hdrs(
         "//tensorflow/python/framework:python_op_gen",
         "//tensorflow/python/client:tf_session_helper",
         "//third_party/eigen3",
+        "//tensorflow/stream_executor:stream_executor_headers",
     ] + if_cuda([
         "@local_config_cuda//cuda:cuda_headers",
     ]),


### PR DESCRIPTION
With stream executor code moving over to XLA, the build_pip_package( //tensorflow/tools/pip_package:build_pip_package.) bazel rule doesn't create  header in this path tensorflow/include/stream_executor/stream.h in the pip/wheel package. It only ends in tensorflow/compiler/xla/stream_executor/stream.h. This is a problem because some other libraries(example horovod) still include header from the original path and can't build

**Horovod** 
https://github.com/horovod/horovod/blob/master/horovod/tensorflow/mpi_ops.cc#L59-L66

**Stream.h in the original path now redirects to xla path**
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/stream_executor/stream.h#L19


