### PR TITLE
[TFTRT] Avoid saving unused variables after conversion

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -49,6 +49,7 @@ from tensorflow.python.saved_model import save
 from tensorflow.python.saved_model import signature_constants
 from tensorflow.python.saved_model import tag_constants
 from tensorflow.python.trackable import asset
+from tensorflow.python.trackable import autotrackable
 from tensorflow.python.trackable import resource
 from tensorflow.python.training import saver
 from tensorflow.python.util import deprecation
@@ -1551,12 +1552,9 @@ class TrtGraphConverterV2(object):
 
     self._for_each_trt_node(self._converted_graph_def,
                             _serialize_and_track_engine)
-    self._saved_model.trt_engine_resources = resource_map
-
-    # Rewrite the signature map using the optimized ConcreteFunction.
-    signatures = {
-        key: value for key, value in self._saved_model.signatures.items()
-    }
+    # If the graph is frozen, tracked variables are not needed by the converted model.
+    trackable = autotrackable.AutoTrackable() if self.freeze else self._saved_model
+    trackable.trt_engine_resources = resource_map
 
     # Set allow_build_at_runtime=False if asked by user.
     #
@@ -1581,9 +1579,10 @@ class TrtGraphConverterV2(object):
           self._converted_func.structured_input_signature)
       self._converted_func = reset_converted_func
 
-    signatures[self._input_saved_model_signature_key] = self._converted_func
+    # Rewrite the signature map using the optimized ConcreteFunction.
+    signatures = {self._input_saved_model_signature_key: self._converted_func}
     save.save(
-        self._saved_model, output_saved_model_dir, signatures, options=options)
+        trackable, output_saved_model_dir, signatures, options=options)
 
   def summary(self, line_length=160, detailed=True, print_fn=None):
     """This method describes the results of the conversion by TF-TRT.


### PR DESCRIPTION
Regarding issue [#305](https://github.com/tensorflow/tensorrt/issues/305) - clears tracked dependencies prior to saving the converted model. As the graph is frozen prior to conversion, tracked variables are not needed by the converted model.

Notably, this change also saves only the converted signature.