### PR TITLE
Fix crash in tf.image.crop_and_resize caused by invalid box_indices

### DIFF
--- a/tensorflow/core/kernels/image/crop_and_resize_op.cc
+++ b/tensorflow/core/kernels/image/crop_and_resize_op.cc
@@ -148,8 +148,8 @@ class CropAndResizeOp : public AsyncOpKernel {
     OP_REQUIRES_ASYNC(
         context, image_height > 0 && image_width > 0,
         errors::InvalidArgument("image dimensions must be positive"), done);
-    OP_REQUIRES_ASYNC(context, box_index.dims() == 1,
-                      errors::InvalidArgument("box_indices must be 1-D",
+    OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsVector(box_index.shape()),
+                      errors::InvalidArgument("box_indices must be rank 1 but is shape ",
                                               box_index.shape().DebugString()),
                       done);
     int num_boxes = 0;

--- a/tensorflow/core/kernels/image/crop_and_resize_op.cc
+++ b/tensorflow/core/kernels/image/crop_and_resize_op.cc
@@ -148,6 +148,10 @@ class CropAndResizeOp : public AsyncOpKernel {
     OP_REQUIRES_ASYNC(
         context, image_height > 0 && image_width > 0,
         errors::InvalidArgument("image dimensions must be positive"), done);
+    OP_REQUIRES_ASYNC(context, box_index.dims() == 1,
+                      errors::InvalidArgument("box_indices must be 1-D",
+                                              box_index.shape().DebugString()),
+                      done);
     int num_boxes = 0;
     OP_REQUIRES_OK_ASYNC(
         context, ParseAndCheckBoxSizes(boxes, box_index, &num_boxes), done);

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -6288,6 +6288,16 @@ class DecodeImageTest(test_util.TensorFlowTestCase, parameterized.TestCase):
             crop_size=[2065374891, 1145309325])
         self.evaluate(op)
 
+  def testImageCropAndResizeWithNon1DBoxes(self):
+    with self.session():
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        op = image_ops_impl.crop_and_resize_v2(
+            image=np.ones((2, 2, 2, 2)),
+            boxes=np.ones((0, 4)),
+            box_indices=np.ones((0, 1)),
+            crop_size=[1, 1])
+        self.evaluate(op)
+
   @parameterized.named_parameters(
       ("_jpeg", "JPEG", "jpeg_merge_test1.jpg"),
       ("_png", "PNG", "lena_rgba.png"),

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -6289,14 +6289,14 @@ class DecodeImageTest(test_util.TensorFlowTestCase, parameterized.TestCase):
         self.evaluate(op)
 
   def testImageCropAndResizeWithNon1DBoxes(self):
-    with self.session():
-      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
-        op = image_ops_impl.crop_and_resize_v2(
-            image=np.ones((2, 2, 2, 2)),
-            boxes=np.ones((0, 4)),
-            box_indices=np.ones((0, 1)),
-            crop_size=[1, 1])
-        self.evaluate(op)
+    with self.assertRaisesRegex(
+        (errors.InvalidArgumentError, ValueError), "must be rank 1"):
+      op = image_ops_impl.crop_and_resize_v2(
+          image=np.ones((2, 2, 2, 2)),
+          boxes=np.ones((0, 4)),
+          box_indices=np.ones((0, 1)),
+          crop_size=[1, 1])
+      self.evaluate(op)
 
   @parameterized.named_parameters(
       ("_jpeg", "JPEG", "jpeg_merge_test1.jpg"),


### PR DESCRIPTION
This PR tries to address the issue in #57754 where tf.image.crop_and_resize
will crach when box_indices is invalid (should be 1-D, as was specified in doc).

This PR fixes #57754.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>