### PR TITLE
Fix crash in tf.math.unsorted_segment_min/max/sum caused by invalid num_segments

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -490,9 +490,9 @@ class UnsortedSegmentReductionOp : public OpKernel {
                 errors::InvalidArgument("Input num_segments == ", output_rows,
                                         " must not be negative."));
     TensorShape output_shape;
-    output_shape.AddDim(output_rows);
+    OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(output_rows));
     for (int i = segment_ids.dims(); i < data.dims(); i++) {
-      output_shape.AddDim(data.dim_size(i));
+      OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(data.dim_size(i)));
     }
     Tensor* output = nullptr;
     OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));

--- a/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
@@ -528,6 +528,18 @@ class UnsortedSegmentTest(SegmentReductionHelper):
       unsorted = math_ops.unsorted_segment_sum(data, segment_ids, 2)
       self.assertAllClose(unsorted.eval(), np.zeros((2, 1), dtype=np.float32))
 
+  @test_util.run_deprecated_v1
+  def testBadNumSegments(self):
+    with self.session(use_gpu=False):
+      num_segments = 8327099846119777499
+      unsorted = math_ops.unsorted_segment_sum(
+          np.ones((3)),
+          segment_ids=898042203,
+          num_segments=num_segments)
+      with self.assertRaisesOpError(
+          "Encountered overflow when multiplying"):
+        self.evaluate(unsorted)
+
 
 class SparseSegmentReductionHelper(SegmentReductionHelper):
 


### PR DESCRIPTION
This PR tries to address the issue raised in #57716 where tf.math.unsorted_segment_min/max/sum
will crash when num_segments is not valid.

This PR fixes #57716.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>