### PR TITLE
Fix crash in tf.nn.conv2d_transpose when shape is negative

### DIFF
--- a/tensorflow/core/kernels/conv_grad_shape_utils.cc
+++ b/tensorflow/core/kernels/conv_grad_shape_utils.cc
@@ -191,6 +191,11 @@ Status Conv2DBackpropComputeInputShape(const Tensor& input_sizes,
     const int output_height = input_sizes.vec<int32>()(0);
     const int output_width = input_sizes.vec<int32>()(1);
     const int output_depth = filter_shape.dim_size(2);
+    if (output_height < 0 || output_width < 0) {
+      return errors::InvalidArgument(
+          "Conv2DBackpropInput: elements of input_sizes must be >= 0, not ",
+          output_height, "x", output_width);
+    }
     *input_shape = ShapeFromFormat(data_format, batch_size, output_height,
                                    output_width, output_depth);
     return OkStatus();

--- a/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradient_checker
@@ -308,6 +309,15 @@ class Conv2DTransposeTest(test.TestCase):
         x, f, f_shape, strides=[1, 1, 1, 1], padding="SAME")
     self.assertEqual(output.get_shape().as_list(), [3, 10, 5, 5])
 
+  def testConv2DTransposeInvalidOutputShape(self):
+    with self.session():
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        op = nn_ops.conv2d_transpose(
+            input=np.ones((1, 1, 1, 1)),
+            filters=np.ones((1, 1, 1, 1)),
+            output_shape=[2, -2],
+            strides=[1])
+        self.evaluate(op)
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
This PR tries to address the issue raised in #57715 where
tf.nn.conv2d_transpose will crash if any elements in shape is negative.

This PR fixes #57715.
This PR fixes #57709.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>