### PR TITLE
Fix crash in tf.linalg.diag when input is too large

### DIFF
--- a/tensorflow/core/kernels/linalg/matrix_diag_op.cc
+++ b/tensorflow/core/kernels/linalg/matrix_diag_op.cc
@@ -265,7 +265,7 @@ class MatrixDiagOp : public OpKernel {
     TensorShape output_shape = diagonal_shape;
     if (num_diags == 1) {  // Output has rank `rank+1`.
       output_shape.set_dim(diag_rank - 1, num_rows);
-      output_shape.AddDim(num_cols);
+      OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(num_cols));
     } else {  // Output has rank `rank`.
       output_shape.set_dim(diag_rank - 2, num_rows);
       output_shape.set_dim(diag_rank - 1, num_cols);

--- a/tensorflow/python/kernel_tests/array_ops/diag_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/diag_op_test.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes as dtypes_lib
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
@@ -1064,6 +1065,13 @@ class DiagTest(test.TestCase):
   def testInvalidRank(self):
     with self.assertRaisesRegex(ValueError, "must be at least rank 1"):
       array_ops.diag(0.0)
+
+  def testInvalidInput(self):
+    with self.session():
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        op = array_ops.matrix_diag(
+            k=1070828000000, diagonal=np.ones((2, 2, 2, 2)))
+        self.evaluate(op)
 
 
 class DiagPartOpTest(test.TestCase):


### PR DESCRIPTION
This PR fixes issues raise in #57713 where tf.linalg.diag will crash if the input is invalid.

This PR fixes #57713.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>