### PR TITLE
Fix crash in tf.eye when input is large

### DIFF
--- a/tensorflow/core/kernels/linalg/matrix_diag_op.cc
+++ b/tensorflow/core/kernels/linalg/matrix_diag_op.cc
@@ -264,7 +264,7 @@ class MatrixDiagOp : public OpKernel {
 
     TensorShape output_shape = diagonal_shape;
     if (num_diags == 1) {  // Output has rank `rank+1`.
-      output_shape.set_dim(diag_rank - 1, num_rows);
+      OP_REQUIRES_OK(context, output_shape.SetDimWithStatus(diag_rank - 1, num_rows));
       output_shape.AddDim(num_cols);
     } else {  // Output has rank `rank`.
       output_shape.set_dim(diag_rank - 2, num_rows);

--- a/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
@@ -261,6 +261,12 @@ class EyeTest(parameterized.TestCase, test.TestCase):
     self.assertAllEqual(eye_np, eye_tf)
 
   def testInvalidInput(self):
+    # Test case for GitHub issue 57790.
+    # Note in case of non-eager mode, the input value validation
+    # is going through a different path and will not hit the crash
+    # described in GitHub issue 57790.
+    if not context.executing_eagerly():
+      return
     with self.session():
       with self.assertRaises((errors.InvalidArgumentError, ValueError)):
         op = linalg_ops.eye(2752212975)

--- a/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
@@ -22,6 +22,7 @@ import scipy.linalg
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
@@ -258,6 +259,12 @@ class EyeTest(parameterized.TestCase, test.TestCase):
               batch_shape_placeholder: batch_shape
           })
     self.assertAllEqual(eye_np, eye_tf)
+
+  def testInvalidInput(self):
+    with self.session():
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        op = linalg_ops.eye(2752212975)
+        self.evaluate(op)
 
 
 class _MatrixRankTest(object):


### PR DESCRIPTION
This PR tries to fix the issue raised in #57711 where tf.eye will crash when input is large.
This PR fixes #57711.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>