### PR TITLE
Fix invalid input for tf.gather_nd with batch_dims

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/gather_nd_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/gather_nd_op_test.py
@@ -380,6 +380,17 @@ class GatherNdTest(test.TestCase):
         self.assertEqual("ResourceGatherNd", gather.op.inputs[0].op.type)
       self.assertAllEqual([2, 5], gather)
 
+  def testInvalidBatchDims(self):
+    with self.session():
+      indices = [[0, 0], [1, 1]]
+      params = [[0, 1], [2, 3]]
+      with self.assertRaisesOpError(r"but is a bool tensor"):
+        gather_nd = array_ops.gather_nd(
+            indices=[[1], [0], [4], [2], [1]],
+            params=array_ops.zeros([5, 7, 3]),
+            batch_dims=True)
+        self.evaluate(gather_nd)
+
 
 class GatherNdOpBenchmark(test.Benchmark):
 

--- a/tensorflow/python/kernel_tests/array_ops/gather_nd_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/gather_nd_op_test.py
@@ -22,6 +22,7 @@ from tensorflow.python.client import session
 from tensorflow.python.eager import context
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import indexed_slices
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor_shape
@@ -382,9 +383,9 @@ class GatherNdTest(test.TestCase):
 
   def testInvalidBatchDims(self):
     with self.session():
-      indices = [[0, 0], [1, 1]]
-      params = [[0, 1], [2, 3]]
-      with self.assertRaisesOpError(r"but is a bool tensor"):
+      with self.assertRaises((errors.InvalidArgumentError, ValueError, TypeError)):
+        indices = [[0, 0], [1, 1]]
+        params = [[0, 1], [2, 3]]
         gather_nd = array_ops.gather_nd(
             indices=[[1], [0], [4], [2], [1]],
             params=array_ops.zeros([5, 7, 3]),

--- a/tensorflow/python/kernel_tests/array_ops/gather_nd_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/gather_nd_op_test.py
@@ -383,7 +383,8 @@ class GatherNdTest(test.TestCase):
 
   def testInvalidBatchDims(self):
     with self.session():
-      with self.assertRaises((errors.InvalidArgumentError, ValueError, TypeError)):
+      with self.assertRaises(
+          (errors.InvalidArgumentError, ValueError, TypeError)):
         indices = [[0, 0], [1, 1]]
         params = [[0, 1], [2, 3]]
         gather_nd = array_ops.gather_nd(

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5714,7 +5714,7 @@ def gather_nd(params, indices, name=None, batch_dims=0):
   """
   batch_dims_ = tensor_util.constant_value(batch_dims)
   if batch_dims_ is not None:
-    batch_dims = int(batch_dims_)
+    batch_dims = batch_dims_
   if batch_dims == 0:
     try:
       # TODO(apassos) find a less bad way of detecting resource variables


### PR DESCRIPTION

This PR tries to address the issue raised in #55203 where
invalid batch_dim (bool) was passed to  tf.gather_nd
with error output returned silently.
This PR fixes #55203.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>