### PR TITLE
[NVIDIA XLA] Support Conv-Bias-Elu fusion in XLA using cuDNN runtime fusion

### DIFF
--- a/tensorflow/compiler/mlir/xla/transforms/mhlo_to_lhlo_with_xla.cc
+++ b/tensorflow/compiler/mlir/xla/transforms/mhlo_to_lhlo_with_xla.cc
@@ -959,6 +959,8 @@ static StatusOr<mlir::lmhlo_gpu::Activation> GetLHLOActivation(
       return mlir::lmhlo_gpu::Activation::Tanh;
     case stream_executor::dnn::kBandPass:
       return mlir::lmhlo_gpu::Activation::BandPass;
+    case stream_executor::dnn::kElu:
+      return mlir::lmhlo_gpu::Activation::Elu;
     default:
       return xla::InternalError("Unknown activation");
   }

--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -42,6 +42,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_cpu_multi_thread_eigen(true);
   opts.set_xla_gpu_cuda_data_dir("./cuda_sdk_lib");
   opts.set_xla_gpu_asm_extra_flags("");
+  opts.set_xla_gpu_use_runtime_fusion(true);
   opts.set_xla_eliminate_hlo_implicit_broadcast(true);
   opts.set_xla_dump_hlo_as_html(false);
   opts.set_xla_dump_fusion_visualization(false);

--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -662,6 +662,11 @@ static void AllocateFlags() {
       "An AlgorithmDenylist text proto file as a denylist of convolutions to "
       "avoid to use."));
   flag_objects->push_back(tsl::Flag(
+      "xla_gpu_use_runtime_fusion",
+      bool_setter_for(&DebugOptions::set_xla_gpu_use_runtime_fusion),
+      flag_values->xla_gpu_use_runtime_fusion(),
+      "For using cuDNN runtime compiled fusion kernels."));
+  flag_objects->push_back(tsl::Flag(
       "xla_tpu_detect_nan",
       bool_setter_for(&DebugOptions::set_xla_tpu_detect_nan),
       flag_values->xla_tpu_detect_nan(),

--- a/tensorflow/compiler/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops_enums.td
+++ b/tensorflow/compiler/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops_enums.td
@@ -29,12 +29,13 @@ def ActivationModeRelu : I32EnumAttrCase<"Relu", 3>;
 def ActivationModeRelu6 : I32EnumAttrCase<"Relu6", 4>;
 def ActivationModeReluX : I32EnumAttrCase<"ReluX", 5>;
 def ActivationModeBandPass : I32EnumAttrCase<"BandPass", 6>;
+def ActivationModeElu: I32EnumAttrCase<"Elu", 7>;
 
 def Activation: I32EnumAttr<"Activation",
     "Activation applied with fused convolution",
     [ActivationModeNone,  ActivationModeSigmoid, ActivationModeTanh,
      ActivationModeRelu, ActivationModeRelu6, ActivationModeReluX,
-     ActivationModeBandPass]> {
+     ActivationModeBandPass, ActivationModeElu]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::lmhlo_gpu";
 }

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter.cc
@@ -493,7 +493,7 @@ StatusOr<bool> FuseElu(HloComputation* comp) {
     }
 
     if (!ConsumeFuel("cudnn-fused-convolution-rewriter", [&] {
-          return absl::StrCat("FuseRelu: ", conv->ToString());
+          return absl::StrCat("FuseElu: ", conv->ToString());
         })) {
       continue;
     }

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter.cc
@@ -871,6 +871,7 @@ StatusOr<bool> CudnnFusedConvRewriter::Run(
     // Relu might appear before or after convert-to-f16/s8, so we check in both
     // cases.
     TF_ASSIGN_OR_RETURN(changed, FuseRelu(comp));
+    any_changed |= changed;
     TF_ASSIGN_OR_RETURN(changed, FuseElu(comp, compute_capability_));
     any_changed |= changed;
 
@@ -889,6 +890,7 @@ StatusOr<bool> CudnnFusedConvRewriter::Run(
     any_changed |= changed;
 
     TF_ASSIGN_OR_RETURN(changed, FuseRelu(comp));
+    any_changed |= changed;
     TF_ASSIGN_OR_RETURN(changed, FuseElu(comp, compute_capability_));
     any_changed |= changed;
 

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter.h
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter.h
@@ -94,6 +94,9 @@ namespace gpu {
 // pass returns an error -- cudnn will not be able to run it.
 class CudnnFusedConvRewriter : public HloModulePass {
  public:
+  explicit CudnnFusedConvRewriter(se::CudaComputeCapability cc)
+      : compute_capability_(cc) {}
+
   absl::string_view name() const override {
     return "cudnn-fused-convolution-rewriter";
   }
@@ -102,6 +105,9 @@ class CudnnFusedConvRewriter : public HloModulePass {
   StatusOr<bool> Run(
       HloModule* module,
       const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+
+ private:
+  const se::CudaComputeCapability compute_capability_;
 };
 
 }  // namespace gpu

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
@@ -852,8 +852,8 @@ TEST_F(CudnnFusedConvRewriterHloTest, DontFuseEluIfMultipleUses) {
     HloModule Test
 
     ENTRY Test {
-      inputs = f16[1,17,9,9] parameter(0)
-      filters = f16[3,3,17,32] parameter(1)
+      inputs = f16[1,16,9,9] parameter(0)
+      filters = f16[3,3,16,32] parameter(1)
       bias = f16[32] parameter(2)
       bias_broadcast = f16[1,32,9,9] broadcast(bias), dimensions={1}
       zero = f16[] constant(0)

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
@@ -186,7 +186,8 @@ TEST_F(CudnnFusedConvRewriterTest, TestElu) {
     GTEST_SKIP() << "Conv-Bias-Elu fusion is supported and recommended with "
                     "the Nvidia Ampere+ GPUs.";
   }
-  // max(0, conv(x, w) + bias);
+  // sum = conv(x, w) + bias
+  // select(compare(sum, 0, GT), sum, exponential-minus-one(sum));
   TestMatchWithAllTypes(R"(
     HloModule Test
 

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
@@ -807,6 +807,11 @@ TEST_F(CudnnFusedConvRewriterHloTest, DontFuseReluIfMultipleUses) {
 }
 
 TEST_F(CudnnFusedConvRewriterHloTest, FuseElu) {
+  if (!GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::AMPERE)) {
+    GTEST_SKIP() << "Conv-Bias-Elu fusion is supported and recommended with "
+                    "the Nvidia Ampere+ GPUs.";
+  }
   const std::string module_str = R"(
     HloModule Test
 

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
@@ -811,8 +811,8 @@ TEST_F(CudnnFusedConvRewriterHloTest, FuseElu) {
     HloModule Test
 
     ENTRY Test {
-      inputs = f16[1,17,9,9] parameter(0)
-      filters = f16[3,3,17,32] parameter(1)
+      inputs = f16[1,16,9,9] parameter(0)
+      filters = f16[3,3,16,32] parameter(1)
       bias = f16[32] parameter(2)
       bias_broadcast = f16[1,32,9,9] broadcast(bias), dimensions={1}
       zero = f16[] constant(0)

--- a/tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/nvptx_compiler.cc
@@ -75,7 +75,8 @@ Status NVPTXCompiler::OptimizeHloConvolutionCanonicalization(
       /*allow_mixed_precision=*/false);
   pipeline.AddPass<GpusolverRewriter>();
   pipeline.AddPass<GpuConvRewriter>();
-  pipeline.AddPass<CudnnFusedConvRewriter>();
+  pipeline.AddPass<CudnnFusedConvRewriter>(
+      stream_exec->GetDeviceDescription().cuda_compute_capability());
   pipeline.AddPass<GpuConvPaddingLegalization>();
   pipeline.AddPass<CudnnPadForConvolutions>(
       stream_exec->GetDeviceDescription().cuda_compute_capability());

--- a/tensorflow/compiler/xla/stream_executor/dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/dnn.cc
@@ -246,6 +246,8 @@ std::string ActivationModeString(ActivationMode mode) {
       return "tanh";
     case ActivationMode::kBandPass:
       return "bandpass";
+    case ActivationMode::kElu:
+      return "elu";
     default:
       return absl::StrCat("unknown: ", static_cast<int32_t>(mode));
   }

--- a/tensorflow/compiler/xla/translate/mhlo_to_hlo/attribute_exporter.cc
+++ b/tensorflow/compiler/xla/translate/mhlo_to_hlo/attribute_exporter.cc
@@ -72,6 +72,8 @@ StatusOr<stream_executor::dnn::ActivationMode> ConvertConvActivationMode(
       return stream_executor::dnn::kReluX;
     case mlir::lmhlo_gpu::Activation::BandPass:
       return stream_executor::dnn::kBandPass;
+    case mlir::lmhlo_gpu::Activation::Elu:
+      return stream_executor::dnn::kElu;
     default:
       return InternalError("Unexpected activation");
   }

--- a/tensorflow/compiler/xla/xla.proto
+++ b/tensorflow/compiler/xla/xla.proto
@@ -431,7 +431,11 @@ message DebugOptions {
   // (much) faster on our hardware.  Set this flag to disable this behavior.
   bool xla_cpu_strict_dot_conv_math = 175;
 
-  // Next id: 181
+  // An option to enable using cuDNN runtime compiled fusion kernels which is
+  // available and recommended for Ampere+ GPUs.
+  bool xla_gpu_use_runtime_fusion = 181;
+
+  // Next id: 182
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.


### PR DESCRIPTION
This PR enables the Conv-Bias-Elu fusion in XLA, which can take advantage of the cuDNN runtime compiled fusion kernels.

XLA users need to set `xla_gpu_use_runtime_fusion` to enable this behavior as we use `TF_CUDNN_USE_RUNTIME_FUSION` in the native TF.

cc. @nluehr @pjannaty 