### PR TITLE
Fix tf.math.sobol_sample vulnerability with non-scalar inputs.

### DIFF
--- a/tensorflow/core/kernels/sobol_op.cc
+++ b/tensorflow/core/kernels/sobol_op.cc
@@ -138,10 +138,10 @@ class SobolSampleOp : public OpKernel {
     OP_REQUIRES(context, TensorShapeUtils::IsScalar(context->input(0).shape()),
                 errors::InvalidArgument("dim must be a scalar"));
     int32_t dim = context->input(0).scalar<int32_t>()();
-    OP_REQUIRES(context, TensorShapeUtils::IsScalar(context->input(0).shape()),
+    OP_REQUIRES(context, TensorShapeUtils::IsScalar(context->input(1).shape()),
                 errors::InvalidArgument("num_results must be a scalar"));
     int32_t num_results = context->input(1).scalar<int32_t>()();
-    OP_REQUIRES(context, TensorShapeUtils::IsScalar(context->input(0).shape()),
+    OP_REQUIRES(context, TensorShapeUtils::IsScalar(context->input(2).shape()),
                 errors::InvalidArgument("skip must be a scalar"));
     int32_t skip = context->input(2).scalar<int32_t>()();
 

--- a/tensorflow/python/ops/sobol_ops_test.py
+++ b/tensorflow/python/ops/sobol_ops_test.py
@@ -20,9 +20,12 @@ from __future__ import print_function
 import numpy as np
 
 from tensorflow.python.eager import def_function
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import test_util
+from tensorflow.python.ops import gen_math_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.platform import googletest
 
@@ -129,6 +132,16 @@ class SobolSampleOpTest(test_util.TensorFlowTestCase):
     # this case.
     s = math_ops.sobol_sample(10, 100)
     self.assertEqual(dtypes.float32, s.dtype)
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_non_scalar_input(self):
+    with self.assertRaisesRegex((ValueError, errors.InvalidArgumentError),
+                                r'Shape must be rank 0 but is rank 1|'
+                                r'\w+ must be a scalar'):
+      self.evaluate(gen_math_ops.sobol_sample(
+          dim=7,
+          num_results=constant_op.constant([1, 0]),
+          skip=constant_op.constant([1])))
 
 if __name__ == '__main__':
   googletest.main()


### PR DESCRIPTION
Check that given inputs are valid.
Add graph/eager unit tests. Graph mode was already ok but eager mode was not.

PiperOrigin-RevId: 476117492