### PR TITLE
[ROCm]: Update ROCm Dockerfile to Ubuntu 20.04

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -1,6 +1,6 @@
 # This Dockerfile provides a starting point for a ROCm installation of
 # MIOpen and tensorflow.
-FROM ubuntu:bionic
+FROM ubuntu:focal
 MAINTAINER Jeff Poznanovic <jeffrey.poznanovic@amd.com>
 
 ARG ROCM_DEB_REPO=https://repo.radeon.com/rocm/apt/5.1/


### PR DESCRIPTION
Update ROCm docker file to point to Ubuntu 20.04. This is needed to get ROCm Community CI passing again along with the PR
https://github.com/tensorflow/tensorflow/pull/56762