### PR TITLE
 [XLA:GPU] Consider big fusion as expensive during fusion merger. 

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/fusion_merger.cc
+++ b/tensorflow/compiler/xla/service/gpu/fusion_merger.cc
@@ -350,6 +350,18 @@ FusionDecision FusionInstructionMerger::HandleFusion(HloInstruction* fusion) {
                                 << instruction->name() << "|";
       }
     }
+    // Check if the produer is costly. The threshold wasn't tuned.
+    // One use cases has 250 instructions, so a threshold of 250 would
+    // work. I'm using 100 as it looks a better threshold. 100 is
+    // already much higher then the number of instructions needed per
+    // IO to be compute bound.
+    const int nb_instructions_for_expensive_fusion = 100;
+    if (fusion->fused_instruction_count() >
+	nb_instructions_for_expensive_fusion) {
+      return FusionDecision{} << "fusion is big and at least one user will "
+                              << "duplicate computation |"
+                              << fusion->name() << "|";
+    }
   }
 
   // Skip 'fusion' instruction if merging it into at least one of the users


### PR DESCRIPTION
The large T5 model in T5X has a \~30% slowdown when we enable dropout. The core of the issue is that one fusion cause too much re-computation due to a broadcast by 512. There is already a mechanism that prevent fusion that trigger re-computation of costly instructions. In this case, no single instruction are costly, so it doesn't kick in. But there is \~250 cheap instruction. So this re-computation end up being costly.

The fix is simple, check that the fusion we are merging isn't big when re-computation would be triggered in addition to the check for costly instruction.

Time in kernels:
* without dropout: 3519681664 ns
* with dropout current: 4130066503 ns (1.17x slowdown)
* with dropout with this PR: 3534917713 ns (1.004x slowdown)


Full model HLO without dropout (forget filename):
[t5x_slow_dropout_unit_test_unsafe_rbg.DR0.0.txt](https://github.com/tensorflow/tensorflow/files/9711840/t5x_slow_dropout_unit_test_unsafe_rbg.DR0.0.txt) (Full model, forget the filename) 
Full model HLO with dropout (forget filename)
[t5x_slow_dropout_unit_test_unsafe_rbg.DR0.1.txt](https://github.com/tensorflow/tensorflow/files/9711841/t5x_slow_dropout_unit_test_unsafe_rbg.DR0.1.txt) (Full model, forget the filename) 
Unit test HLO with dropout:
[t5x_slow_dropout_unit_test_unsafe_rbg.txt](https://github.com/tensorflow/tensorflow/files/9760136/t5x_slow_dropout_unit_test_unsafe_rbg.txt)

@cheshire 