### PR TITLE
Remove references to malloc.h

### DIFF
--- a/tensorflow/lite/profiling/memory_info.cc
+++ b/tensorflow/lite/profiling/memory_info.cc
@@ -15,9 +15,10 @@ limitations under the License.
 #include "tensorflow/lite/profiling/memory_info.h"
 
 #ifdef __linux__
-#include <malloc.h>
 #include <sys/resource.h>
 #include <sys/time.h>
+
+#include <cstdio>
 #endif
 
 namespace tflite {

--- a/tensorflow/lite/tensorflow_profiler_logger.cc
+++ b/tensorflow/lite/tensorflow_profiler_logger.cc
@@ -15,9 +15,8 @@ limitations under the License.
 
 #include "tensorflow/lite/tensorflow_profiler_logger.h"
 
-#include <malloc.h>
-
 #include <algorithm>
+#include <cstdio>
 #include <string>
 
 #include "tensorflow/core/profiler/lib/traceme.h"


### PR DESCRIPTION
malloc.h is deprecated: https://stackoverflow.com/questions/12973311/difference-between-stdlib-h-and-malloc-h. Tensorflow does not build on my friend's M1 Mac because of this  (@carlthome, he is very sad about this).
