### PR TITLE
Fix mem alloc bug in SparseSplit GPU kernel

### DIFF
--- a/tensorflow/core/kernels/sparse_split_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/sparse_split_op_gpu.cu.cc
@@ -266,7 +266,7 @@ struct SparseSplitFunctor<GPUDevice, T> {
       Tensor sorted_slice_indexes;
       OP_REQUIRES_OK_ASYNC(
           context,
-          context->allocate_temp(DT_INT32, TensorShape({num_split}),
+          context->allocate_temp(DT_INT32, TensorShape({input_nnz}),
                                  &sorted_slice_indexes),
           done);
       int* sorted_slice_indexes_ptr = sorted_slice_indexes.vec<int>().data();

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_split_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_split_op_test.py
@@ -288,6 +288,24 @@ class SparseSplitOpTest(test.TestCase):
           sparse_ops.sparse_split(
               sp_input=self._SparseTensor_4x6(), num_split=3, axis=axis))
 
+  def testBig(self):
+    # This test was added after discovering a memory allocation bug in the GPU
+    # kernel that the existing tests did not catch due to being too small.
+    for n in [250, 2500, 25000]:
+      indices = np.zeros([n, 2], dtype=np.int64)
+      indices[:, 0] = np.arange(n)
+      values = np.zeros([n], dtype=np.float32)
+      dense_shape = np.array([n, 3], dtype=np.int64)
+      sp_input = sparse_tensor.SparseTensor(indices, values, dense_shape)
+      sp_tensors = self.evaluate(
+          sparse_ops.sparse_split(sp_input=sp_input, num_split=2, axis=0))
+      self.assertAllEqual(sp_tensors[0].indices, indices[:n // 2])
+      self.assertAllEqual(sp_tensors[1].indices, indices[n // 2:] - [n // 2, 0])
+      self.assertAllEqual(sp_tensors[0].values, values[:n // 2])
+      self.assertAllEqual(sp_tensors[1].values, values[n // 2:])
+      self.assertAllEqual(sp_tensors[0].dense_shape, [n // 2, 3])
+      self.assertAllEqual(sp_tensors[1].dense_shape, [n // 2, 3])
+
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
- The temporary allocation used the wrong size, making it too small.
- This was not caught by the existing tests due to their data being too small (and the BFCAllocator not checking out-of-bounds accesses).

cc @nluehr @pjannaty 