### PR TITLE
Updates oneDNN and Compute Library bulds on AArch64

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -194,18 +194,18 @@ def _tf_repositories():
     tf_http_archive(
         name = "mkl_dnn_acl_compatible",
         build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
-        sha256 = "990fdce84197d68064e615d91c182c5bc6baa446348c3c1fe71b7e9a345badc2",
-        strip_prefix = "oneDNN-70d1198de554e61081147c199d661df049233279",
-        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/70d1198de554e61081147c199d661df049233279.tar.gz"),
+        sha256 = "fc2b617ec8dbe907bb10853ea47c46f7acd8817bc4012748623d911aca43afbb",
+        strip_prefix = "oneDNN-2.7",
+        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/v2.7.tar.gz"),
     )
 
     tf_http_archive(
         name = "compute_library",
-        sha256 = "94e2e9ff87c261a9c9987bc9024c449c48014f7fe707311bdfa76b87f3dda5c5",
-        strip_prefix = "ComputeLibrary-22.05",
+        sha256 = "ac2ce7b5636e99f175b084362f83fe24d72e6ceb0bd62ee5866772f7355d024d",
+        strip_prefix = "ComputeLibrary-22.08",
         build_file = "//third_party/compute_library:BUILD",
-        patch_file = ["//third_party/compute_library:compute_library.patch", "//third_party/compute_library:activation_func_correct_args.patch"],
-        urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.05.tar.gz"),
+        patch_file = ["//third_party/compute_library:compute_library.patch"],
+        urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.08.tar.gz"),
     )
 
     tf_http_archive(

--- a/third_party/compute_library/BUILD
+++ b/third_party/compute_library/BUILD
@@ -13,7 +13,7 @@ cc_library(
 )
 
 _COMPUTE_LIBRARY_DEFINES = [
-    "ARM_COMPUTE_CPP_SCHEDULER",
+    "ARM_COMPUTE_OPENMP_SCHEDULER",
     "ARM_COMPUTE_CPU_ENABLED",
     "ENABLE_NEON",
     "ARM_COMPUTE_ENABLE_NEON",
@@ -41,7 +41,7 @@ cc_library(
             "**/*.inl",
         ],
     ),
-    copts = ["-march=armv8.6-a+sve2"],
+    copts = ["-march=armv8.6-a+sve2", "-fopenmp"],
     defines = _COMPUTE_LIBRARY_DEFINES + ["ARM_COMPUTE_ENABLE_SVE2"],
     includes = [
         "src/core/NEON/kernels/arm_conv",
@@ -50,7 +50,7 @@ cc_library(
         "src/core/cpu/kernels/assembly",
         "src/cpu/kernels/assembly",
     ],
-    linkopts = ["-lpthread"],
+    linkopts = ["-fopenmp"],
     deps = ["include"],
 )
 
@@ -62,6 +62,7 @@ cc_library(
             "src/core/NEON/kernels/arm_conv/**/kernels/sve_*/*.cpp",
             "src/core/NEON/kernels/arm_conv/depthwise/interleaves/sve_*.cpp",
             "src/core/NEON/kernels/batchnormalization/impl/SVE/*.cpp",
+            "src/core/NEON/kernels/convolution/winograd/input_transforms/sve_fp32_6x6.cpp",
             "src/cpu/kernels/**/sve/*.cpp",
             "**/*.h",
             "**/*.hpp",
@@ -71,7 +72,7 @@ cc_library(
         "src/core/NEON/kernels/arm_gemm/transform-sve.cpp",
         "src/core/NEON/kernels/arm_gemm/mergeresults-sve.cpp",
     ],
-    copts = ["-march=armv8.2-a+sve"],
+    copts = ["-march=armv8.2-a+sve", "-fopenmp"],
     defines = _COMPUTE_LIBRARY_DEFINES,
     includes = [
         "src/core/NEON/kernels/arm_conv",
@@ -80,7 +81,7 @@ cc_library(
         "src/core/cpu/kernels/assembly",
         "src/cpu/kernels/assembly",
     ],
-    linkopts = ["-lpthread"],
+    linkopts = ["-fopenmp"],
     deps = ["include"],
 )
 
@@ -106,6 +107,7 @@ cc_library(
             "src/core/NEON/kernels/batchnormalization/impl/NEON/*.cpp",
             "src/cpu/*.cpp",
             "src/cpu/kernels/*.cpp",
+            "src/cpu/kernels/fuse_batch_normalization/**/*.cpp",
             "src/cpu/kernels/*/generic/*.cpp",
             "src/cpu/operators/**/*.cpp",
             "src/cpu/utils/*.cpp",
@@ -122,6 +124,7 @@ cc_library(
             "src/core/TracePoint.cpp",
             "src/core/NEON/kernels/arm_gemm/mergeresults-sve.cpp",
             "src/core/NEON/kernels/arm_gemm/transform-sve.cpp",
+            "src/core/NEON/kernels/convolution/winograd/input_transforms/sve_fp32_6x6.cpp",
             "src/runtime/CL/**",
             "src/gpu/**",
         ],
@@ -142,7 +145,7 @@ cc_library(
     ]) + [
         "arm_compute_version.embed",
     ],
-    copts = ["-march=armv8-a"],
+    copts = ["-march=armv8-a", "-fopenmp"],
     defines = _COMPUTE_LIBRARY_DEFINES,
     includes = [
         "arm_compute/runtime",
@@ -152,7 +155,7 @@ cc_library(
         "src/core/cpu/kernels/assembly",
         "src/cpu/kernels/assembly",
     ],
-    linkopts = ["-lpthread"],
+    linkopts = ["-fopenmp"],
     visibility = ["//visibility:public"],
     deps = [
         "arm_compute_sve",

--- a/third_party/compute_library/compute_library.patch
+++ b/third_party/compute_library/compute_library.patch
@@ -4,5 +4,5 @@ index 000000000..c986ad52a
 --- /dev/null
 +++ b/arm_compute_version.embed
 @@ -0,0 +1,1 @@
-+"arm_compute_version=v22.05 Build options: {} Git hash=b'a175e887d64450decf80ea47d4049832c5805565'"
++"arm_compute_version=v22.08 Build options: {} Git hash=b'aabef6c0584f06f4c0f4b61fb787d80374240619'"
 \ No newline at end of file


### PR DESCRIPTION
- Updates oneDNN to v2.7-rc
- Updates Compute Library to 22.08 release
- Updates Compute Library BUILD for 22.08 release
-- changes to a small number of source files
-- support for OpenMP in place of CPP scheduler