### PR TITLE
[TFTRT]: Deprecate ImplicitBatchModeCompatible dynamic shape strategy

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -1145,6 +1145,10 @@ class TrtGraphConverterV2(object):
       raise ValueError(
           ("profile_strategy '{}' is not supported. It should be one of {}"
           ).format(strategy, supported_profile_strategies()))
+    if strategy is "ImplicitBatchModeCompatible":
+      logging.warn("ImplicitBatchModeCompatible strategy is deprecated, and"
+          " using it may result in errors during engine building. Please"
+          " consider using a different profile strategy.")
 
   @deprecation.deprecated_args(None,
                                "Use individual converter parameters instead",


### PR DESCRIPTION
This strategy is intended for ease of use for people familiar with the implicit batch mode profile, in that it does not require the user to specifically call build() before trying to run an inference with TFTRT converted graph. Since this is actually a dynamic shape mode, and input shapes are required in dynamic shape mode for TensorRT profile generation; this mode makes some educated guesses for minimum and maximum shapes for inputs the TensorRT engine.

This has proven to be buggy for models that include transpose and reshape operations, among others.

Due to the above, and since dynamic shape mode requires users to call build() with the correct input shapes to generate TensorRT profiles correctly, this mode is being deprecated.

cc: @tfeher @bixia1 @DEKHTIARJonathan 