### PR TITLE
Fix crash of tf.random.poisson when total shards is larger than 2^31

### DIFF
--- a/tensorflow/core/kernels/random_poisson_op.cc
+++ b/tensorflow/core/kernels/random_poisson_op.cc
@@ -71,7 +71,7 @@ namespace functor {
 template <typename T, typename U>
 struct PoissonFunctor<CPUDevice, T, U> {
   void operator()(OpKernelContext* ctx, const CPUDevice& d, const T* rate_flat,
-                  int num_rate, int num_samples,
+                  int64_t num_rate, int64_t num_samples,
                   const random::PhiloxRandom& rng, U* samples_flat) {
     // Two different algorithms are employed, depending on the size of
     // rate.

--- a/tensorflow/core/kernels/random_poisson_op.h
+++ b/tensorflow/core/kernels/random_poisson_op.h
@@ -27,7 +27,7 @@ namespace functor {
 template <typename Device, typename T /* rate */, typename U /* output */>
 struct PoissonFunctor {
   void operator()(OpKernelContext* ctx, const Device& d, const T* rate_flat,
-                  int num_rate, int num_samples,
+                  int64_t num_rate, int64_t num_samples,
                   const random::PhiloxRandom& rng, U* samples_flat);
 };
 


### PR DESCRIPTION
This PR tries to address the issue raised in #57728 where tf.random.poisson will crash when total shards is larger than 2^31.

The issue was that the defined type was incorrectly casted into int (down from int64) when passed to function, resulting in CHECK failure and crash. This PR correct the type to be int64.

This PR fixes #57728.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>