### PR TITLE
Fix crash in tf.nn.atrous_conv2d with large rate

### DIFF
--- a/tensorflow/core/kernels/spacetobatch_op.cc
+++ b/tensorflow/core/kernels/spacetobatch_op.cc
@@ -144,16 +144,16 @@ Status SpaceToBatchOpCompute(OpKernelContext* context,
         "Negative output dimension size caused by overflow when multiplying ",
         orig_input_tensor.dim_size(0), " and ", block_shape_product);
   }
-  external_output_shape.AddDim(output_shape);
+  TF_RETURN_IF_ERROR(external_output_shape.AddDimWithStatus(output_shape));
 
   int64_t input_batch_size = orig_input_tensor.dim_size(0);
   for (int block_dim = 0; block_dim < removed_prefix_block_dims; ++block_dim) {
     const int64_t size = orig_input_tensor.dim_size(block_dim + 1);
     input_batch_size *= size;
-    external_output_shape.AddDim(size);
+    TF_RETURN_IF_ERROR(external_output_shape.AddDimWithStatus(size));
   }
-  internal_input_shape.AddDim(input_batch_size);
-  internal_output_shape.AddDim(input_batch_size * block_shape_product);
+  TF_RETURN_IF_ERROR(internal_input_shape.AddDimWithStatus(input_batch_size));
+  TF_RETURN_IF_ERROR(internal_output_shape.AddDimWithStatus(input_batch_size * block_shape_product));
 
   for (int block_dim = removed_prefix_block_dims;
        block_dim < block_dims - removed_suffix_block_dims; ++block_dim) {
@@ -171,21 +171,21 @@ Status SpaceToBatchOpCompute(OpKernelContext* context,
                                      " is not divisible by block_shape[",
                                      block_dim, "]=", block_shape_value);
     }
-    internal_input_shape.AddDim(input_size);
+    TF_RETURN_IF_ERROR(internal_input_shape.AddDimWithStatus(input_size));
     const int64_t output_size = padded_size / block_shape_value;
-    internal_output_shape.AddDim(output_size);
-    external_output_shape.AddDim(output_size);
+    TF_RETURN_IF_ERROR(internal_output_shape.AddDimWithStatus(output_size));
+    TF_RETURN_IF_ERROR(external_output_shape.AddDimWithStatus(output_size));
   }
 
   int64_t depth = 1;
   for (int dim = block_dims - removed_suffix_block_dims + 1; dim < input_dims;
        ++dim) {
     const int64_t size = orig_input_tensor.dim_size(dim);
-    external_output_shape.AddDim(size);
+    TF_RETURN_IF_ERROR(external_output_shape.AddDimWithStatus(size));
     depth *= size;
   }
-  internal_input_shape.AddDim(depth);
-  internal_output_shape.AddDim(depth);
+  TF_RETURN_IF_ERROR(internal_input_shape.AddDimWithStatus(depth));
+  TF_RETURN_IF_ERROR(internal_output_shape.AddDimWithStatus(depth));
 
   // Allocate output tensor.
   Tensor* output_tensor = nullptr;

--- a/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradient_checker
@@ -156,6 +157,17 @@ class AtrousConv2DTest(test.TestCase):
         print("atrous_conv2d gradient err = %g " % err)
         err_tolerance = 4e-3 if test_util.is_xla_enabled() else 1e-3
         self.assertLess(err, err_tolerance)
+
+  @test_util.run_deprecated_v1
+  def testAtrousConv2DInvalid(self):
+    with self.session():
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        op = nn_ops.atrous_conv2d(
+            value=np.ones((1, 1, 1, 5)),
+            filters=np.ones((1, 1, 5, 1)),
+            rate=2147483647,
+            padding='SAME')
+        self.evaluate(op)
 
 
 class AtrousConv2DTransposeTest(test.TestCase):

--- a/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
@@ -208,7 +208,6 @@ class AtrousConv2DTransposeTest(test.TestCase):
                     x, f_up, y_shape, strides=[1, 1, 1, 1], padding=padding)
                 self.assertAllClose(y1, y2, rtol=1e-3, atol=1e-3)
 
-  @test_util.run_deprecated_v1
   def testAtrousConv2DTransposeInvalid(self):
     with self.session():
       with self.assertRaises((errors.InvalidArgumentError, ValueError)):

--- a/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/atrous_conv2d_test.py
@@ -208,6 +208,18 @@ class AtrousConv2DTransposeTest(test.TestCase):
                     x, f_up, y_shape, strides=[1, 1, 1, 1], padding=padding)
                 self.assertAllClose(y1, y2, rtol=1e-3, atol=1e-3)
 
+  @test_util.run_deprecated_v1
+  def testAtrousConv2DTransposeInvalid(self):
+    with self.session():
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        op = nn_ops.atrous_conv2d_transpose(
+            value=np.ones((10, 1, 1, 1)),
+            filters=np.ones((1, 1, 1, 1)),
+            rate=1356819205,
+            padding='SAME',
+            output_shape=[1, 1, 1, 1])
+        self.evaluate(op)
+
 
 class AtrousDepthwiseConv2DTest(test.TestCase):
 


### PR DESCRIPTION
This PR tries to address the issue raised in #46915 where
tf.nn.atrous_conv2d will crash when rate is larger than 2^31.

This PR fixes #46915.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>