### PR TITLE
Enable deterministic segment reductions on Windows

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_gpu.cu.h
@@ -716,19 +716,12 @@ void SegmentReductionFunctor<
   const Index num_segments = output.size() / input_inner_dim_size;
 
   bool use_deterministic_kernels =
-#if defined(PLATFORM_WINDOWS)
-      // See comment in segment_reduction_ops_gpu_0.cu.cc regarding Windows CI
-      // build error.
-      false;
-#else
       UseDeterministicSegmentReductions() ||
       (OpDeterminismRequired() && !ReduceOpIsAssociative<ReductionF, T>::value);
-#endif
 
   // TODO(benbarsdell): If there are no performance concerns with the new
-  // deterministic kernels, remove this runtime check and only compile the old
-  // non-deterministic kernels on Windows (as a workaround for the build failure
-  // issue).
+  // deterministic kernels, remove this runtime check and the old
+  // non-deterministic kernels.
   if (!use_deterministic_kernels) {
     // Set 'output' to initial value.
     GpuLaunchConfig config = GetGpuLaunchConfig(output.size(), d);
@@ -774,9 +767,6 @@ void SegmentReductionFunctor<
                               segment_offsets_ptr, output.data()));
     }
   } else {
-    // See comment in segment_reduction_ops_gpu_0.cu.cc regarding Windows CI
-    // build error.
-#if !defined(PLATFORM_WINDOWS)
     using Treduce = typename ReduceType<ReductionF, T>::type;
     OP_REQUIRES_OK(
         ctx,
@@ -786,13 +776,6 @@ void SegmentReductionFunctor<
             /*is_mean=*/is_mean, /*is_sqrtn=*/false, data, segment_ids.data(),
             /*indices=*/static_cast<const Index*>(nullptr),
             /*weights=*/static_cast<T*>(nullptr), output.data()));
-#else
-    // Note: Shouldn't reach here because use_deterministic_kernels is always
-    // false on Windows.
-    OP_REQUIRES(ctx, false,
-                errors::Unimplemented("Deterministic segment reductions are "
-                                      "not implemented on Windows."));
-#endif
   }
 }
 
@@ -808,15 +791,9 @@ struct UnsortedSegmentFunctor<GPUDevice, T, Index, InitialValueF, ReductionF> {
     }
 
     bool use_deterministic_kernels =
-#if defined(PLATFORM_WINDOWS)
-        // See comment in segment_reduction_ops_gpu_0.cu.cc regarding Windows CI
-        // build error.
-        false;
-#else
         UseDeterministicSegmentReductions() ||
         (!ReduceOpIsAssociative<ReductionF, T>::value &&
          OpDeterminismRequired());
-#endif
 
     bool determinism_requirement_met =
         use_deterministic_kernels ||
@@ -840,9 +817,8 @@ struct UnsortedSegmentFunctor<GPUDevice, T, Index, InitialValueF, ReductionF> {
     const Index num_segments = output.size() / input_inner_dim_size;
 
     // TODO(benbarsdell): If there are no performance concerns with the new
-    // deterministic kernels, remove this runtime check and only compile the old
-    // non-deterministic kernels on Windows (as a workaround for the build
-    // failure issue).
+    // deterministic kernels, remove this runtime check and the old
+    // non-deterministic kernels.
     if (!use_deterministic_kernels) {
       // Set 'output' to initial value.
       GPUDevice d = ctx->template eigen_device<GPUDevice>();
@@ -862,9 +838,6 @@ struct UnsortedSegmentFunctor<GPUDevice, T, Index, InitialValueF, ReductionF> {
           input_outer_dim_size, input_inner_dim_size, output_outer_dim_size,
           unsorted_segment_ids.data(), data.data(), output.data()));
     } else {
-      // See comment in segment_reduction_ops_gpu_0.cu.cc regarding Windows CI
-      // build error.
-#if !defined(PLATFORM_WINDOWS)
       // Allocate temporary space and sort segment_ids, then call the sorted
       // implem.
       Tensor segment_ids;
@@ -899,14 +872,6 @@ struct UnsortedSegmentFunctor<GPUDevice, T, Index, InitialValueF, ReductionF> {
               /*is_sqrtn=*/false, /*input=*/data.data(),
               /*segment_ids=*/segment_ids_ptr, /*indices=*/sorted_indices_ptr,
               /*weights=*/static_cast<T*>(nullptr), output.data()));
-#else
-      // Note: Shouldn't reach here because use_deterministic_kernels is always
-      // false on Windows.
-      OP_REQUIRES(
-          ctx, false,
-          errors::Unimplemented("Deterministic unsorted segment reductions are "
-                                "not implemented on Windows."));
-#endif
     }
   }
 };

--- a/tensorflow/core/kernels/segment_reduction_ops_gpu_0.cu.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_gpu_0.cu.cc
@@ -21,8 +21,6 @@ limitations under the License.
 namespace tensorflow {
 
 bool UseDeterministicSegmentReductions() {
-  // See comment below regarding CI build error on Windows.
-#if !defined(PLATFORM_WINDOWS)
   static bool cached_result = [] {
     bool result = false;
     TF_CHECK_OK(tensorflow::ReadBoolFromEnvVar(
@@ -31,9 +29,6 @@ bool UseDeterministicSegmentReductions() {
     return result;
   }();
   return cached_result;
-#else
-  return false;
-#endif
 }
 
 bool DisableSegmentReductionOpDeterminismExceptions() {
@@ -94,14 +89,6 @@ TF_CALL_GPU_NUMBER_TYPES(DEFINE_SUM_GPU_SPECS);
 #undef DEFINE_REAL_GPU_SPECS
 #undef DEFINE_SUM_GPU_SPECS
 
-// TODO(benbarsdell): These kernels are disabled on Windows as a workaround for
-// a CI build error: "formal parameter with requested alignment of 128 won't be
-// aligned". The root cause is suspected to be an aligned type (AlignedVector)
-// being passed to a function by value, possibly inside the CUB library
-// somewhere, but I have not yet been able to reproduce it in isolation outside
-// of the GitHub CI.
-#if !defined(PLATFORM_WINDOWS)
-
 #define DEFINE_SPARSE_SEGMENT_REDUCTION_FUNCTOR(T)                \
   template struct SparseSegmentReductionFunctor<T, int32, int32>; \
   template struct SparseSegmentReductionFunctor<T, int32, int64_t>;
@@ -113,8 +100,6 @@ TF_CALL_GPU_NUMBER_TYPES(DEFINE_SPARSE_SEGMENT_REDUCTION_FUNCTOR);
   template struct SparseSegmentGradFunctor<GPUDevice, T, int32, int64_t>;
 TF_CALL_GPU_NUMBER_TYPES(DEFINE_SPARSE_SEGMENT_GRAD_FUNCTOR);
 #undef DEFINE_SPARSE_SEGMENT_GRAD_FUNCTOR
-
-#endif  // !defined(PLATFORM_WINDOWS)
 
 }  // namespace functor
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/segment_reduction_ops_gpu_1.cu.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_gpu_1.cu.cc
@@ -67,14 +67,6 @@ TF_CALL_GPU_NUMBER_TYPES(DEFINE_SUM_GPU_SPECS);
 #undef DEFINE_REAL_GPU_SPECS
 #undef DEFINE_SUM_GPU_SPECS
 
-// TODO(benbarsdell): These kernels are disabled on Windows as a workaround for
-// a CI build error: "formal parameter with requested alignment of 128 won't be
-// aligned". The root cause is suspected to be an aligned type (AlignedVector)
-// being passed to a function by value, possibly inside the CUB library
-// somewhere, but I have not yet been able to reproduce it in isolation outside
-// of the GitHub CI.
-#if !defined(PLATFORM_WINDOWS)
-
 #define DEFINE_SPARSE_SEGMENT_REDUCTION_FUNCTOR(T)                  \
   template struct SparseSegmentReductionFunctor<T, int64_t, int32>; \
   template struct SparseSegmentReductionFunctor<T, int64_t, int64_t>;
@@ -86,8 +78,6 @@ TF_CALL_GPU_NUMBER_TYPES(DEFINE_SPARSE_SEGMENT_REDUCTION_FUNCTOR);
   template struct SparseSegmentGradFunctor<GPUDevice, T, int64_t, int64_t>;
 TF_CALL_GPU_NUMBER_TYPES(DEFINE_SPARSE_SEGMENT_GRAD_FUNCTOR);
 #undef DEFINE_SPARSE_SEGMENT_GRAD_FUNCTOR
-
-#endif  // !defined(PLATFORM_WINDOWS)
 
 }  // namespace functor
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -299,15 +299,9 @@ class SegmentReductionGPUOp : public AsyncOpKernel {
           context, context->allocate_output(0, output_shape, &output), done);
 
       bool use_deterministic_kernels =
-#if defined(PLATFORM_WINDOWS)
-          // See comment in segment_reduction_ops_gpu_0.cu.cc regarding Windows
-          // CI build error.
-          false;
-#else
           UseDeterministicSegmentReductions() ||
           (!SegmentReductionFunctor::atomic_reduction_is_associative &&
            OpDeterminismRequired());
-#endif
 
       // The determinism check is here, rather than inside the functor (as it is
       // for the unsorted segment reduction ops) because the done callback

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
@@ -85,13 +85,7 @@ TF_CALL_FLOAT_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
 TF_CALL_FLOAT_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
 #undef REGISTER_CPU_SPARSE_KERNELS
 
-// TODO(benbarsdell): These kernels are disabled on Windows as a workaround for
-// a CI build error: "formal parameter with requested alignment of 128 won't be
-// aligned". The root cause is suspected to be an aligned type (AlignedVector)
-// being passed to a function by value, possibly inside the CUB library
-// somewhere, but I have not yet been able to reproduce it in isolation outside
-// of the GitHub CI.
-#if GOOGLE_CUDA && !defined(PLATFORM_WINDOWS)
+#if GOOGLE_CUDA
 
 #define REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_SEGMENT_ID_TYPE(type, index_type) \
   REGISTER_GPU_SPARSE_KERNELS(type, index_type, int32)                         \
@@ -163,7 +157,7 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
 TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
 #undef REGISTER_GPU_SPARSE_KERNELS
 
-#endif  // GOOGLE_CUDA && !defined(PLATFORM_WINDOWS)
+#endif  // GOOGLE_CUDA
 
 #define REGISTER_CPU_SPARSE_KERNELS(type, index_type, segment_ids_type) \
   REGISTER_KERNEL_BUILDER(                                              \
@@ -202,8 +196,7 @@ TF_CALL_FLOAT_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
 #undef REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE
 #undef REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_SEGMENT_ID_TYPE
 
-// TODO(benbarsdell): See comment above.
-#if GOOGLE_CUDA && !defined(PLATFORM_WINDOWS)
+#if GOOGLE_CUDA
 
 #define REGISTER_GPU_SPARSE_KERNELS(type, index_type, segment_ids_type) \
   REGISTER_KERNEL_BUILDER(                                              \
@@ -245,6 +238,6 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
 #undef REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE
 #undef REGISTER_GPU_SPARSE_KERNELS_FOR_EACH_SEGMENT_ID_TYPE
 
-#endif  // GOOGLE_CUDA && !defined(PLATFORM_WINDOWS)
+#endif  // GOOGLE_CUDA
 
 }  // namespace tensorflow

--- a/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_d9m_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_d9m_test.py
@@ -14,13 +14,10 @@
 # ==============================================================================
 """Tests for deterministic functionality of segment reduction ops."""
 
-import os
-
 from tensorflow.python.eager import backprop
 from tensorflow.python.framework import config
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import indexed_slices
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
@@ -28,16 +25,6 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
-
-
-def PlatformIsWindows():
-  return os.name == "nt"
-
-
-def DeterministicSegmentReductionsSupported():
-  # See comment in segment_reduction_ops_gpu_0.cu.cc for why deterministic
-  # segment reduction kernels are disabled on Windows.
-  return not PlatformIsWindows()
 
 
 class SegmentReductionDeterminismExceptionsTest(test.TestCase):
@@ -71,17 +58,8 @@ class SegmentReductionDeterminismExceptionsTest(test.TestCase):
         for data_type in [dtypes.float16, dtypes.float32, dtypes.float64]:
           with self.cached_session(force_gpu=True):
             data, segment_ids, _ = self._input(data_type, segment_ids_type)
-            if (not DeterministicSegmentReductionsSupported() and
-                should_throw_for_float):
-              with self.assertRaisesRegex(
-                  errors_impl.UnimplementedError,
-                  "Deterministic GPU implementation of sorted segment " +
-                  "reduction op not available."):
-                result = op(data, segment_ids)
-                self.evaluate(result)
-            else:
-              result = op(data, segment_ids)
-              self.evaluate(result)
+            result = op(data, segment_ids)
+            self.evaluate(result)
 
   _UNSORTED_ERROR_MESSAGE = ("Deterministic GPU implementation of unsorted " +
                              "segment reduction op not available.")
@@ -108,15 +86,8 @@ class SegmentReductionDeterminismExceptionsTest(test.TestCase):
               continue
             data, segment_ids, num_segments = self._input(
                 data_type, segment_ids_type)
-            if (not DeterministicSegmentReductionsSupported() and
-                (data_type != dtypes.int32) and should_throw_for_float):
-              with self.assertRaisesRegex(errors_impl.UnimplementedError,
-                                          self._UNSORTED_ERROR_MESSAGE):
-                result = op(data, segment_ids, num_segments)
-                self.evaluate(result)
-            else:
-              result = op(data, segment_ids, num_segments)
-              self.evaluate(result)
+            result = op(data, segment_ids, num_segments)
+            self.evaluate(result)
 
   @test.disable_with_predicate(
       pred=test.is_built_with_rocm,
@@ -131,14 +102,8 @@ class SegmentReductionDeterminismExceptionsTest(test.TestCase):
           with self.cached_session(force_gpu=True):
             data, segment_ids, num_segments = self._input(
                 data_type, segment_ids_type)
-            if not DeterministicSegmentReductionsSupported():
-              with self.assertRaisesRegex(errors_impl.UnimplementedError,
-                                          self._UNSORTED_ERROR_MESSAGE):
-                result = op(data, segment_ids, num_segments)
-                self.evaluate(result)
-            else:
-              result = op(data, segment_ids, num_segments)
-              self.evaluate(result)
+            result = op(data, segment_ids, num_segments)
+            self.evaluate(result)
 
   @test_util.run_cuda_only
   @test_util.run_in_graph_and_eager_modes
@@ -152,15 +117,8 @@ class SegmentReductionDeterminismExceptionsTest(test.TestCase):
           values, indices, _ = self._input(data_type, segment_ids_type)
           sparse_value = indexed_slices.IndexedSlices(
               values, indices, dense_shape=values.shape)
-          if not DeterministicSegmentReductionsSupported():
-            with self.assertRaisesRegex(errors_impl.UnimplementedError,
-                                        self._UNSORTED_ERROR_MESSAGE):
-              # convert_to_tensor with IndexedSlices uses unsorted_segment_sum
-              result = ops.convert_to_tensor(sparse_value)
-              self.evaluate(result)
-          else:
-            result = ops.convert_to_tensor(sparse_value)
-            self.evaluate(result)
+          result = ops.convert_to_tensor(sparse_value)
+          self.evaluate(result)
 
   @test_util.run_cuda_only
   def testGatherBackprop(self):
@@ -176,13 +134,7 @@ class SegmentReductionDeterminismExceptionsTest(test.TestCase):
             tape.watch(params)
             op_output = array_ops.gather(params, indices)
           gradient = tape.gradient(op_output, params)
-          if not DeterministicSegmentReductionsSupported():
-            with self.assertRaisesRegex(errors_impl.UnimplementedError,
-                                        self._UNSORTED_ERROR_MESSAGE):
-              # convert_to_tensor on IndexedSlices
-              self.evaluate(params.assign(gradient))
-          else:
-            self.evaluate(params.assign(gradient))
+          self.evaluate(params.assign(gradient))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is an attempt to see if the Windows build error that previously blocked this has been or can be resolved.

Marking as Draft until the Windows CI looks good.

If this works, I believe it fixes https://github.com/tensorflow/tensorflow/issues/54276

cc @nluehr @pjannaty 