### PR TITLE
[TF-TRT] Change profile strategy for unit tests

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -1296,8 +1296,7 @@ class OpConverterTest : public ::testing::Test {
       std::vector<PartialTensorShape> input_partial_shapes;
       TF_RETURN_IF_ERROR(
           GetNetworkInputShapes(converter_->network(), &input_partial_shapes));
-      profiles.InitProfiles(input_partial_shapes,
-                            ProfileStrategy::kImplicitBatchModeCompatible);
+      profiles.InitProfiles(input_partial_shapes, ProfileStrategy::kRange);
     }
     TF_RETURN_IF_ERROR(
         converter_->BuildCudaEngine(&engine_,

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
@@ -199,8 +199,7 @@ class TRTEngineResourceOpsTest
       }
       std::vector<PartialTensorShape> input_partial_shapes;
       TF_CHECK_OK(GetNetworkInputShapes(network.get(), &input_partial_shapes));
-      profile.InitProfiles(input_partial_shapes,
-                           ProfileStrategy::kImplicitBatchModeCompatible);
+      profile.InitProfiles(input_partial_shapes, ProfileStrategy::kOptimal);
       // Configure and build engine
       TF_CHECK_OK(profile.ConfigureBuilder(builder.get(), builder_config.get(),
                                            network.get()));


### PR DESCRIPTION
The DynamicShapeModeCompatible profile strategy can lead to invalid optimization profiles for the converted TensorRT network. This PR replaces the now deprecated DynamicShapeModeCompatible strategy with a correct optimization strategy for unit tests.