### PR TITLE
Move tensorflow/c/tf_status... to TSL

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -44,6 +44,7 @@ filegroup(
         "tf_tensor.h",
         "tf_tstring.h",
         "//tensorflow/core/platform:ctstring",
+        "//tensorflow/tsl/c:headers",
     ] + if_tensorrt([
         "//tensorflow/compiler/tf2tensorrt:headers",
     ]),
@@ -65,6 +66,7 @@ filegroup(
             "*test*",
         ],
     ) + [
+        "//tensorflow/tsl/c:srcs",
         "//tensorflow/core/platform:ctstring",
         "//tensorflow/cc:srcs_no_runtime",
         "//tensorflow/core/distributed_runtime:server_lib.h",
@@ -84,6 +86,7 @@ cc_library(
         "tf_buffer_internal.h",
         "tf_status_internal.h",
         "tf_tensor_internal.h",
+        "//tensorflow/tsl/c:tsl_status_internal_headers",
     ],
     visibility = [
         "//tensorflow/core:__pkg__",
@@ -188,6 +191,7 @@ tf_cuda_library(
         ":tf_status_internal",
         ":tf_tensor_internal",
         ":tf_tstring",
+        "//tensorflow/tsl/c:tsl_status",
         "//tensorflow/core/platform:tstring",
     ] + select({
         "//tensorflow:with_xla_support": [
@@ -278,6 +282,7 @@ tf_cuda_library(
     hdrs = [
         "tf_status.h",
         "tf_status_internal.h",
+        "//tensorflow/tsl/c:tsl_status_internal_headers",
     ],
     visibility = [
         "//tensorflow/c:__subpackages__",
@@ -290,7 +295,11 @@ tf_cuda_library(
         "//tensorflow/compiler/mlir/tensorflow/c:__subpackages__",
         "//tensorflow/core/transforms:__subpackages__",
     ],
-    deps = select({
+    deps = [
+        "//tensorflow/tsl/platform:status",
+        "//tensorflow/tsl/c:tsl_status",
+        "//tensorflow/tsl/c:tsl_status_internal",
+    ] + select({
         "//tensorflow:android": [
             "//tensorflow/core:portable_tensorflow_lib_lite",  # TODO(annarev): exclude runtime srcs
         ],
@@ -302,7 +311,10 @@ tf_cuda_library(
 
 filegroup(
     name = "tf_status_internal_headers",
-    srcs = ["tf_status_internal.h"],
+    srcs = [
+        "tf_status_internal.h",
+        "//tensorflow/tsl/c:tsl_status_internal_headers",
+    ],
     visibility = [
         "//tensorflow/python:__subpackages__",
     ],
@@ -339,6 +351,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":tf_status_internal",
+        "//tensorflow/tsl/c:tsl_status",
     ] + select({
         "//tensorflow:android": [
             "//tensorflow/core:portable_tensorflow_lib_lite",  # TODO(annarev): exclude runtime srcs
@@ -365,6 +378,9 @@ cc_library(
     name = "tf_status_headers",
     hdrs = ["tf_status.h"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//tensorflow/tsl/c:tsl_status",
+    ],
 )
 
 cc_library(
@@ -383,6 +399,7 @@ cc_library(
     deps = [
         "//tensorflow/core/platform:status",
         "//tensorflow/core/platform:tstring",
+        "//tensorflow/tsl/c:tsl_status",
     ],
 )
 
@@ -575,6 +592,7 @@ tf_cuda_library(
     deps = [
         ":tf_status",
         ":tf_status_internal",
+        "//tensorflow/tsl/c:tsl_status_helper",
     ] + select({
         "//tensorflow:android": [
             "//tensorflow/core:portable_tensorflow_lib_lite",  # TODO(annarev): exclude runtime srcs

--- a/tensorflow/c/tf_status.cc
+++ b/tensorflow/c/tf_status.cc
@@ -16,39 +16,21 @@ limitations under the License.
 #include "tensorflow/c/tf_status.h"
 
 #include "tensorflow/c/tf_status_internal.h"
-#include "tensorflow/core/platform/errors.h"
-#include "tensorflow/core/platform/status.h"
 
-using ::tensorflow::Status;
-using ::tensorflow::error::Code;
-using ::tensorflow::errors::IOError;
+// Trampoline implementation to redirect to TSL. Kept here for backward
+// compatibility only.
 
-TF_Status* TF_NewStatus() { return new TF_Status; }
-
-void TF_DeleteStatus(TF_Status* s) { delete s; }
-
+TF_Status* TF_NewStatus() { return TSL_NewStatus(); }
+void TF_DeleteStatus(TF_Status* s) { TSL_DeleteStatus(s); }
 void TF_SetStatus(TF_Status* s, TF_Code code, const char* msg) {
-  if (code == TF_OK) {
-    s->status = ::tensorflow::OkStatus();
-    return;
-  }
-  s->status = Status(static_cast<Code>(code), tensorflow::StringPiece(msg));
+  TSL_SetStatus(s, TSL_Code(code), msg);
 }
-
 void TF_SetPayload(TF_Status* s, const char* key, const char* value) {
-  s->status.SetPayload(key, value);
+  TSL_SetPayload(s, key, value);
 }
-
 void TF_SetStatusFromIOError(TF_Status* s, int error_code,
                              const char* context) {
-  // TODO(b/139060984): Handle windows when changing its filesystem
-  s->status = IOError(context, error_code);
+  TSL_SetStatusFromIOError(s, error_code, context);
 }
-
-TF_Code TF_GetCode(const TF_Status* s) {
-  return static_cast<TF_Code>(s->status.code());
-}
-
-const char* TF_Message(const TF_Status* s) {
-  return s->status.error_message().c_str();
-}
+TF_Code TF_GetCode(const TF_Status* s) { return TF_Code(TSL_GetCode(s)); }
+const char* TF_Message(const TF_Status* s) { return TSL_Message(s); }

--- a/tensorflow/c/tf_status.h
+++ b/tensorflow/c/tf_status.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_C_TF_STATUS_H_
 #define TENSORFLOW_C_TF_STATUS_H_
 
+#include "tensorflow/tsl/c/tsl_status.h"
+
 #ifdef SWIG
 #define TF_CAPI_EXPORT
 #else
@@ -34,30 +36,29 @@ limitations under the License.
 extern "C" {
 #endif
 
-typedef struct TF_Status TF_Status;
+typedef struct TSL_Status TF_Status;
 
 // --------------------------------------------------------------------------
 // TF_Code holds an error code.  The enum values here are identical to
 // corresponding values in error_codes.proto.
-typedef enum TF_Code {
-  TF_OK = 0,
-  TF_CANCELLED = 1,
-  TF_UNKNOWN = 2,
-  TF_INVALID_ARGUMENT = 3,
-  TF_DEADLINE_EXCEEDED = 4,
-  TF_NOT_FOUND = 5,
-  TF_ALREADY_EXISTS = 6,
-  TF_PERMISSION_DENIED = 7,
-  TF_UNAUTHENTICATED = 16,
-  TF_RESOURCE_EXHAUSTED = 8,
-  TF_FAILED_PRECONDITION = 9,
-  TF_ABORTED = 10,
-  TF_OUT_OF_RANGE = 11,
-  TF_UNIMPLEMENTED = 12,
-  TF_INTERNAL = 13,
-  TF_UNAVAILABLE = 14,
-  TF_DATA_LOSS = 15,
-} TF_Code;
+typedef TSL_Code TF_Code;
+#define TF_OK TSL_OK
+#define TF_CANCELLED TSL_CANCELLED
+#define TF_UNKNOWN TSL_UNKNOWN
+#define TF_INVALID_ARGUMENT TSL_INVALID_ARGUMENT
+#define TF_DEADLINE_EXCEEDED TSL_DEADLINE_EXCEEDED
+#define TF_NOT_FOUND TSL_NOT_FOUND
+#define TF_ALREADY_EXISTS TSL_ALREADY_EXISTS
+#define TF_PERMISSION_DENIED TSL_PERMISSION_DENIED
+#define TF_UNAUTHENTICATED TSL_UNAUTHENTICATED
+#define TF_RESOURCE_EXHAUSTED TSL_RESOURCE_EXHAUSTED
+#define TF_FAILED_PRECONDITION TSL_FAILED_PRECONDITION
+#define TF_ABORTED TSL_ABORTED
+#define TF_OUT_OF_RANGE TSL_OUT_OF_RANGE
+#define TF_UNIMPLEMENTED TSL_UNIMPLEMENTED
+#define TF_INTERNAL TSL_INTERNAL
+#define TF_UNAVAILABLE TSL_UNAVAILABLE
+#define TF_DATA_LOSS TSL_DATA_LOSS
 
 // --------------------------------------------------------------------------
 

--- a/tensorflow/c/tf_status_helper.cc
+++ b/tensorflow/c/tf_status_helper.cc
@@ -17,75 +17,16 @@ limitations under the License.
 
 #include "tensorflow/c/tf_status_internal.h"
 #include "tensorflow/core/platform/errors.h"
+#include "tensorflow/tsl/c/tsl_status_helper.h"
 
 namespace tsl {
 
 void Set_TF_Status_from_Status(TF_Status* tf_status, const Status& status) {
-  tensorflow::error::Code code = status.code();
-  const char* message(status.error_message().c_str());
-
-  switch (code) {
-    case tensorflow::error::OK:
-      assert(TF_GetCode(tf_status) == TF_OK);
-      break;
-    case tensorflow::error::CANCELLED:
-      TF_SetStatus(tf_status, TF_CANCELLED, message);
-      break;
-    case tensorflow::error::UNKNOWN:
-      TF_SetStatus(tf_status, TF_UNKNOWN, message);
-      break;
-    case tensorflow::error::INVALID_ARGUMENT:
-      TF_SetStatus(tf_status, TF_INVALID_ARGUMENT, message);
-      break;
-    case tensorflow::error::DEADLINE_EXCEEDED:
-      TF_SetStatus(tf_status, TF_DEADLINE_EXCEEDED, message);
-      break;
-    case tensorflow::error::NOT_FOUND:
-      TF_SetStatus(tf_status, TF_NOT_FOUND, message);
-      break;
-    case tensorflow::error::ALREADY_EXISTS:
-      TF_SetStatus(tf_status, TF_ALREADY_EXISTS, message);
-      break;
-    case tensorflow::error::PERMISSION_DENIED:
-      TF_SetStatus(tf_status, TF_PERMISSION_DENIED, message);
-      break;
-    case tensorflow::error::UNAUTHENTICATED:
-      TF_SetStatus(tf_status, TF_UNAUTHENTICATED, message);
-      break;
-    case tensorflow::error::RESOURCE_EXHAUSTED:
-      TF_SetStatus(tf_status, TF_RESOURCE_EXHAUSTED, message);
-      break;
-    case tensorflow::error::FAILED_PRECONDITION:
-      TF_SetStatus(tf_status, TF_FAILED_PRECONDITION, message);
-      break;
-    case tensorflow::error::ABORTED:
-      TF_SetStatus(tf_status, TF_ABORTED, message);
-      break;
-    case tensorflow::error::OUT_OF_RANGE:
-      TF_SetStatus(tf_status, TF_OUT_OF_RANGE, message);
-      break;
-    case tensorflow::error::UNIMPLEMENTED:
-      TF_SetStatus(tf_status, TF_UNIMPLEMENTED, message);
-      break;
-    case tensorflow::error::INTERNAL:
-      TF_SetStatus(tf_status, TF_INTERNAL, message);
-      break;
-    case tensorflow::error::UNAVAILABLE:
-      TF_SetStatus(tf_status, TF_UNAVAILABLE, message);
-      break;
-    case tensorflow::error::DATA_LOSS:
-      TF_SetStatus(tf_status, TF_DATA_LOSS, message);
-      break;
-    default:
-      assert(0);
-      break;
-  }
-
-  errors::CopyPayloads(status, tf_status->status);
+  Set_TSL_Status_from_Status(tf_status, status);
 }
 
 Status StatusFromTF_Status(const TF_Status* tf_status) {
-  return tf_status->status;
+  return StatusFromTSL_Status(tf_status);
 }
 
 }  // namespace tsl

--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -367,6 +367,7 @@ def get_win_copts(is_external = False):
         # Also see build:windows lines in tensorflow/opensource_only/.bazelrc
         # where we set some other options globally.
     ]
+
     if is_external:
         return WINDOWS_COPTS + ["/UTF_COMPILE_LIBRARY"]
     else:

--- a/tensorflow/tsl/c/BUILD
+++ b/tensorflow/tsl/c/BUILD
@@ -1,0 +1,134 @@
+# Description:
+# C API for TensorFlow, for use by client language bindings.
+
+load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
+load(
+    "//tensorflow:tensorflow.bzl",
+    "tf_cc_test",
+    "tf_copts",
+    "tf_cuda_library",
+)
+
+# buildifier: disable=same-origin-load
+load("//tensorflow:tensorflow.bzl", "filegroup")
+
+package(
+    licenses = ["notice"],
+)
+
+# -----------------------------------------------------------------------------
+# Public targets
+
+filegroup(
+    name = "headers",
+    srcs = [
+        "tsl_status.h",
+    ],
+    visibility = ["//tensorflow:__subpackages__"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob(
+        [
+            "*.cc",
+            "*.h",
+        ],
+        exclude = [
+            "*test*",
+        ],
+    ),
+    visibility = [
+        "//tensorflow/c:__subpackages__",
+    ],
+)
+
+tf_cuda_library(
+    name = "c_api",
+    hdrs = [
+        "tsl_status.h",
+    ],
+    copts = tf_copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":tsl_status_internal",
+    ],
+)
+
+tf_cuda_library(
+    name = "tsl_status_internal",
+    hdrs = [
+        "tsl_status.h",
+        "tsl_status_internal.h",
+    ],
+    visibility = [
+        "//tensorflow/c:__subpackages__",
+    ],
+    deps = [
+        "//tensorflow/tsl/platform:status",
+    ],
+)
+
+cc_library(
+    name = "tsl_status",
+    srcs = ["tsl_status.cc"],
+    hdrs = ["tsl_status.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":tsl_status_internal",
+        "//tensorflow/tsl/platform:errors",
+        "//tensorflow/tsl/platform:status",
+    ],
+)
+
+tf_cc_test(
+    name = "tsl_status_test",
+    srcs = ["tsl_status_test.cc"],
+    deps = [
+        ":tsl_status",
+        ":tsl_status_internal",
+        "//tensorflow/tsl/platform:errors",
+        "//tensorflow/tsl/platform:status",
+        "//tensorflow/tsl/platform:test",
+        "//tensorflow/tsl/platform:test_main",
+    ],
+)
+
+cc_library(
+    name = "tsl_status_headers",
+    hdrs = ["tsl_status.h"],
+    visibility = ["//visibility:public"],
+)
+
+tf_cuda_library(
+    name = "tsl_status_helper",
+    srcs = ["tsl_status_helper.cc"],
+    hdrs = ["tsl_status_helper.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":tsl_status",
+        ":tsl_status_internal",
+        "//tensorflow/tsl/platform:errors",
+        "//tensorflow/tsl/platform:status",
+    ],
+)
+
+tf_cc_test(
+    name = "tsl_status_helper_test",
+    srcs = ["tsl_status_helper_test.cc"],
+    deps = [
+        ":tsl_status_helper",
+        "//tensorflow/tsl/platform:errors",
+        "//tensorflow/tsl/platform:status",
+        "//tensorflow/tsl/platform:test",
+        "//tensorflow/tsl/platform:test_main",
+    ],
+)
+
+filegroup(
+    name = "tsl_status_internal_headers",
+    srcs = ["tsl_status_internal.h"],
+    visibility = [
+        "//tensorflow/c:__subpackages__",
+    ],
+)

--- a/tensorflow/tsl/c/tsl_status.cc
+++ b/tensorflow/tsl/c/tsl_status.cc
@@ -1,0 +1,54 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/tsl/c/tsl_status.h"
+
+#include "tensorflow/tsl/c/tsl_status_internal.h"
+#include "tensorflow/tsl/platform/errors.h"
+#include "tensorflow/tsl/platform/status.h"
+
+using ::tsl::Status;
+using ::tsl::error::Code;
+using ::tsl::errors::IOError;
+
+TSL_Status* TSL_NewStatus() { return new TSL_Status; }
+
+void TSL_DeleteStatus(TSL_Status* s) { delete s; }
+
+void TSL_SetStatus(TSL_Status* s, TSL_Code code, const char* msg) {
+  if (code == TSL_OK) {
+    s->status = ::tsl::OkStatus();
+    return;
+  }
+  s->status = Status(static_cast<Code>(code), tsl::StringPiece(msg));
+}
+
+void TSL_SetPayload(TSL_Status* s, const char* key, const char* value) {
+  s->status.SetPayload(key, value);
+}
+
+void TSL_SetStatusFromIOError(TSL_Status* s, int error_code,
+                              const char* context) {
+  // TODO(b/139060984): Handle windows when changing its filesystem
+  s->status = IOError(context, error_code);
+}
+
+TSL_Code TSL_GetCode(const TSL_Status* s) {
+  return static_cast<TSL_Code>(s->status.code());
+}
+
+const char* TSL_Message(const TSL_Status* s) {
+  return s->status.error_message().c_str();
+}

--- a/tensorflow/tsl/c/tsl_status.h
+++ b/tensorflow/tsl/c/tsl_status.h
@@ -1,0 +1,84 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_TSL_C_TSL_STATUS_H_
+#define TENSORFLOW_TSL_C_TSL_STATUS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct TSL_Status TSL_Status;
+
+// --------------------------------------------------------------------------
+// TSL_Code holds an error code.  The enum values here are identical to
+// corresponding values in error_codes.proto.
+typedef enum TSL_Code {
+  TSL_OK = 0,
+  TSL_CANCELLED = 1,
+  TSL_UNKNOWN = 2,
+  TSL_INVALID_ARGUMENT = 3,
+  TSL_DEADLINE_EXCEEDED = 4,
+  TSL_NOT_FOUND = 5,
+  TSL_ALREADY_EXISTS = 6,
+  TSL_PERMISSION_DENIED = 7,
+  TSL_UNAUTHENTICATED = 16,
+  TSL_RESOURCE_EXHAUSTED = 8,
+  TSL_FAILED_PRECONDITION = 9,
+  TSL_ABORTED = 10,
+  TSL_OUT_OF_RANGE = 11,
+  TSL_UNIMPLEMENTED = 12,
+  TSL_INTERNAL = 13,
+  TSL_UNAVAILABLE = 14,
+  TSL_DATA_LOSS = 15,
+} TSL_Code;
+
+// --------------------------------------------------------------------------
+
+// Return a new status object.
+extern TSL_Status* TSL_NewStatus(void);
+
+// Delete a previously created status object.
+extern void TSL_DeleteStatus(TSL_Status*);
+
+// Record <code, msg> in *s.  Any previous information is lost.
+// A common use is to clear a status: TSL_SetStatus(s, TSL_OK, "");
+extern void TSL_SetStatus(TSL_Status* s, TSL_Code code, const char* msg);
+
+// Record <key, value> as a payload in *s. The previous payload having the
+// same key (if any) is overwritten. Payload will not be added if the Status
+// is OK.
+void TSL_SetPayload(TSL_Status* s, const char* key, const char* value);
+
+// Convert from an I/O error code (e.g., errno) to a TSL_Status value.
+// Any previous information is lost. Prefer to use this instead of TSL_SetStatus
+// when the error comes from I/O operations.
+extern void TSL_SetStatusFromIOError(TSL_Status* s, int error_code,
+                                     const char* context);
+
+// Return the code record in *s.
+extern TSL_Code TSL_GetCode(const TSL_Status* s);
+
+// Return a pointer to the (null-terminated) error message in *s.  The
+// return value points to memory that is only usable until the next
+// mutation to *s.  Always returns an empty string if TSL_GetCode(s) is
+// TSL_OK.
+extern const char* TSL_Message(const TSL_Status* s);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif  // TENSORFLOW_TSL_C_TSL_STATUS_H_

--- a/tensorflow/tsl/c/tsl_status_helper.cc
+++ b/tensorflow/tsl/c/tsl_status_helper.cc
@@ -1,0 +1,91 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/tsl/c/tsl_status_helper.h"
+
+#include "tensorflow/tsl/c/tsl_status_internal.h"
+#include "tensorflow/tsl/platform/errors.h"
+
+namespace tsl {
+
+void Set_TSL_Status_from_Status(TSL_Status* tsl_status, const Status& status) {
+  tensorflow::error::Code code = status.code();
+  const char* message(status.error_message().c_str());
+
+  switch (code) {
+    case tensorflow::error::OK:
+      assert(TSL_GetCode(tsl_status) == TSL_OK);
+      break;
+    case tensorflow::error::CANCELLED:
+      TSL_SetStatus(tsl_status, TSL_CANCELLED, message);
+      break;
+    case tensorflow::error::UNKNOWN:
+      TSL_SetStatus(tsl_status, TSL_UNKNOWN, message);
+      break;
+    case tensorflow::error::INVALID_ARGUMENT:
+      TSL_SetStatus(tsl_status, TSL_INVALID_ARGUMENT, message);
+      break;
+    case tensorflow::error::DEADLINE_EXCEEDED:
+      TSL_SetStatus(tsl_status, TSL_DEADLINE_EXCEEDED, message);
+      break;
+    case tensorflow::error::NOT_FOUND:
+      TSL_SetStatus(tsl_status, TSL_NOT_FOUND, message);
+      break;
+    case tensorflow::error::ALREADY_EXISTS:
+      TSL_SetStatus(tsl_status, TSL_ALREADY_EXISTS, message);
+      break;
+    case tensorflow::error::PERMISSION_DENIED:
+      TSL_SetStatus(tsl_status, TSL_PERMISSION_DENIED, message);
+      break;
+    case tensorflow::error::UNAUTHENTICATED:
+      TSL_SetStatus(tsl_status, TSL_UNAUTHENTICATED, message);
+      break;
+    case tensorflow::error::RESOURCE_EXHAUSTED:
+      TSL_SetStatus(tsl_status, TSL_RESOURCE_EXHAUSTED, message);
+      break;
+    case tensorflow::error::FAILED_PRECONDITION:
+      TSL_SetStatus(tsl_status, TSL_FAILED_PRECONDITION, message);
+      break;
+    case tensorflow::error::ABORTED:
+      TSL_SetStatus(tsl_status, TSL_ABORTED, message);
+      break;
+    case tensorflow::error::OUT_OF_RANGE:
+      TSL_SetStatus(tsl_status, TSL_OUT_OF_RANGE, message);
+      break;
+    case tensorflow::error::UNIMPLEMENTED:
+      TSL_SetStatus(tsl_status, TSL_UNIMPLEMENTED, message);
+      break;
+    case tensorflow::error::INTERNAL:
+      TSL_SetStatus(tsl_status, TSL_INTERNAL, message);
+      break;
+    case tensorflow::error::UNAVAILABLE:
+      TSL_SetStatus(tsl_status, TSL_UNAVAILABLE, message);
+      break;
+    case tensorflow::error::DATA_LOSS:
+      TSL_SetStatus(tsl_status, TSL_DATA_LOSS, message);
+      break;
+    default:
+      assert(0);
+      break;
+  }
+
+  errors::CopyPayloads(status, tsl_status->status);
+}
+
+Status StatusFromTSL_Status(const TSL_Status* tsl_status) {
+  return tsl_status->status;
+}
+
+}  // namespace tsl

--- a/tensorflow/tsl/c/tsl_status_helper.h
+++ b/tensorflow/tsl/c/tsl_status_helper.h
@@ -1,0 +1,44 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_TSL_C_TSL_STATUS_HELPER_H_
+#define TENSORFLOW_TSL_C_TSL_STATUS_HELPER_H_
+
+#include <memory>
+
+#include "tensorflow/tsl/c/tsl_status.h"
+#include "tensorflow/tsl/platform/status.h"
+
+namespace tsl {
+// Set the attribute of "tsl_status" from the attributes of "status".
+void Set_TSL_Status_from_Status(TSL_Status* TSL_status,
+                                const tsl::Status& status);
+
+// Returns a "status" from "tsl_status".
+Status StatusFromTSL_Status(const TSL_Status* tsl_status);
+
+namespace internal {
+struct TSL_StatusDeleter {
+  void operator()(TSL_Status* tsl_status) const {
+    TSL_DeleteStatus(tsl_status);
+  }
+};
+}  // namespace internal
+
+using TSL_StatusPtr = std::unique_ptr<TSL_Status, internal::TSL_StatusDeleter>;
+
+}  // namespace tsl
+
+#endif  // TENSORFLOW_TSL_C_TSL_STATUS_HELPER_H_

--- a/tensorflow/tsl/c/tsl_status_helper_test.cc
+++ b/tensorflow/tsl/c/tsl_status_helper_test.cc
@@ -1,0 +1,44 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/tsl/c/tsl_status_helper.h"
+
+#include "tensorflow/tsl/platform/errors.h"
+#include "tensorflow/tsl/platform/test.h"
+
+namespace tsl {
+namespace {
+
+TEST(StatusHelper, TestStatusHelper) {
+  TSL_Status* s = TSL_NewStatus();
+  Status cc_status(errors::InvalidArgument("some error"));
+  cc_status.SetPayload("key1", "value1");
+  cc_status.SetPayload("key2", "value2");
+  Set_TSL_Status_from_Status(s, cc_status);
+  ASSERT_EQ(TSL_INVALID_ARGUMENT, TSL_GetCode(s));
+  ASSERT_EQ(std::string("some error"), TSL_Message(s));
+
+  Status another_cc_status(StatusFromTSL_Status(s));
+  ASSERT_FALSE(another_cc_status.ok());
+  ASSERT_EQ(std::string("some error"), another_cc_status.error_message());
+  ASSERT_EQ(error::INVALID_ARGUMENT, another_cc_status.code());
+  // Ensure the payloads are not lost during conversions
+  ASSERT_EQ(cc_status.GetPayload("key1"), another_cc_status.GetPayload("key1"));
+  ASSERT_EQ(cc_status.GetPayload("key2"), another_cc_status.GetPayload("key2"));
+  TSL_DeleteStatus(s);
+}
+
+}  // namespace
+}  // namespace tsl

--- a/tensorflow/tsl/c/tsl_status_internal.h
+++ b/tensorflow/tsl/c/tsl_status_internal.h
@@ -13,9 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef TENSORFLOW_C_TF_STATUS_INTERNAL_H_
-#define TENSORFLOW_C_TF_STATUS_INTERNAL_H_
+#ifndef TENSORFLOW_TSL_C_TSL_STATUS_INTERNAL_H_
+#define TENSORFLOW_TSL_C_TSL_STATUS_INTERNAL_H_
 
-#include "tensorflow/tsl/c/tsl_status_internal.h"
+#include "tensorflow/tsl/platform/status.h"
 
-#endif  // TENSORFLOW_C_TF_STATUS_INTERNAL_H_
+// Internal structures used by the status C API. These are likely to change
+// and should not be depended on.
+
+struct TSL_Status {
+  tsl::Status status;
+};
+
+#endif  // TENSORFLOW_TSL_C_TSL_STATUS_INTERNAL_H_

--- a/tensorflow/tsl/c/tsl_status_test.cc
+++ b/tensorflow/tsl/c/tsl_status_test.cc
@@ -1,0 +1,44 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/tsl/c/tsl_status.h"
+
+#include <utility>
+
+#include "tensorflow/tsl/c/tsl_status_internal.h"
+#include "tensorflow/tsl/platform/errors.h"
+#include "tensorflow/tsl/platform/test.h"
+
+namespace tsl {
+namespace {
+
+TEST(TSL_Status, PayloadsSet) {
+  TSL_Status* tsl_status = TSL_NewStatus();
+  TSL_SetStatus(tsl_status, TSL_CANCELLED, "Error Message");
+  TSL_SetPayload(tsl_status, "a", "1");
+  TSL_SetPayload(tsl_status, "b", "2");
+  TSL_SetPayload(tsl_status, "c", "3");
+
+  const std::unordered_map<std::string, std::string> payloads =
+      errors::GetPayloads(tsl_status->status);
+  EXPECT_EQ(payloads.size(), 3);
+  EXPECT_EQ(payloads.at("a"), "1");
+  EXPECT_EQ(payloads.at("b"), "2");
+  EXPECT_EQ(payloads.at("c"), "3");
+  TSL_DeleteStatus(tsl_status);
+}
+
+}  // namespace
+}  // namespace tsl


### PR DESCRIPTION
This is done by forwarding as many function calls as possible. This will allow to cut some more dependencies from XLA to TensorFlow.
