### PR TITLE
Fix crash in tf.quantization.quantize_and_dequantize_v2

### DIFF
--- a/tensorflow/core/kernels/quantize_and_dequantize_op.cc
+++ b/tensorflow/core/kernels/quantize_and_dequantize_op.cc
@@ -90,6 +90,10 @@ class QuantizeAndDequantizeV2Op : public OpKernel {
       input_min_tensor = ctx->input(1);
       input_max_tensor = ctx->input(2);
       if (axis_ == -1) {
+        OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(input_min_tensor.shape()),
+                InvalidArgument("input_min_tensor should be scalar, got ", input_min_tensor.shape()));
+        OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(input_max_tensor.shape()),
+                InvalidArgument("input_max_tensor should be scalar, got ", input_max_tensor.shape()));
         auto min_val = input_min_tensor.scalar<T>()();
         auto max_val = input_max_tensor.scalar<T>()();
         OP_REQUIRES(ctx, min_val <= max_val,

--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -1923,7 +1923,7 @@ class QuantizeAndDequantizeTest(test_util.TensorFlowTestCase):
       test_quantize_and_dequantize_v4_grad()
 
 
-class QuantizeAndDequantizeV2TestTest(test_util.TensorFlowTestCase):
+class QuantizeAndDequantizeV2Test(test_util.TensorFlowTestCase):
 
   def testInvalidArgs(self):
     with self.assertRaisesRegex((errors.InvalidArgumentError, ValueError),

--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -1923,6 +1923,19 @@ class QuantizeAndDequantizeTest(test_util.TensorFlowTestCase):
       test_quantize_and_dequantize_v4_grad()
 
 
+class QuantizeAndDequantizeV2TestTest(test_util.TensorFlowTestCase):
+
+  def testInvalidArgs(self):
+    with self.assertRaisesRegex((errors.InvalidArgumentError, ValueError),
+                                r".*should be scalar.*"):
+      q, _, _ = array_ops.quantize_and_dequantize_v2(
+          input=np.ones((10)),
+          input_min=-1,
+          input_max=[-1, 1],
+          range_given=True)
+      self.evaluate(q)
+
+
 @test_util.run_all_in_graph_and_eager_modes
 class SortedSearchTest(test_util.TensorFlowTestCase):
 

--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -1930,7 +1930,7 @@ class QuantizeAndDequantizeV2Test(test_util.TensorFlowTestCase):
                                 r".*should be scalar.*"):
       q, _, _ = array_ops.quantize_and_dequantize_v2(
           input=np.ones((10)),
-          input_min=-1,
+          input_min=[-1, 1],
           input_max=[-1, 1],
           range_given=True)
       self.evaluate(q)

--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -1927,7 +1927,7 @@ class QuantizeAndDequantizeV2Test(test_util.TensorFlowTestCase):
 
   def testInvalidArgs(self):
     with self.assertRaisesRegex((errors.InvalidArgumentError, ValueError),
-                                r".*should be scalar.*"):
+                                r"(.*should be scalar.*|.*Broadcast dimension -1 is out of bound.*)"):
       q, _, _ = array_ops.quantize_and_dequantize_v2(
           input=np.ones((10)),
           input_min=[-1, 1],

--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -1927,7 +1927,7 @@ class QuantizeAndDequantizeV2Test(test_util.TensorFlowTestCase):
 
   def testInvalidArgs(self):
     with self.assertRaisesRegex((errors.InvalidArgumentError, ValueError),
-                                r"(.*should be scalar.*|.*Broadcast dimension -1 is out of bound.*)"):
+                                r"(.*should be scalar.*|.*out of bound.*)"):
       q, _, _ = array_ops.quantize_and_dequantize_v2(
           input=np.ones((10)),
           input_min=[-1, 1],


### PR DESCRIPTION
This PR tries to fix the issue raised in #57714 where
tf.quantization.quantize_and_dequantize_v2 will crash
with invalid values.

This PR fixes #57714.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>