### PR TITLE
Fix bugs found by static analysis

### DIFF
--- a/tensorflow/c/c_api_function.cc
+++ b/tensorflow/c/c_api_function.cc
@@ -185,7 +185,7 @@ TF_Function* TF_GraphToFunctionWithControlOutputs(
   if (control_output_names) {
     control_output_names_vec.reserve(ncontrol_outputs);
     for (int i = 0; i < ncontrol_outputs; ++i) {
-      control_output_names_vec.push_back(string(output_names[i]));
+      control_output_names_vec.push_back(string(control_output_names[i]));
     }
   }
 

--- a/tensorflow/compiler/jit/xla_launch_util.cc
+++ b/tensorflow/compiler/jit/xla_launch_util.cc
@@ -512,7 +512,7 @@ Status XlaComputationLaunchContext::PopulateOutputs(
   }
 
   std::shared_ptr<se::Event> definition_event;
-  if (use_multiple_streams_) {
+  if (use_multiple_streams_ && stream) {
     definition_event = std::make_shared<se::Event>(stream->parent());
     if (!definition_event->Init()) {
       return errors::Internal("Failed to initialize tensor definition event.");

--- a/tensorflow/compiler/mlir/lite/quantization/quantization_utils.h
+++ b/tensorflow/compiler/mlir/lite/quantization/quantization_utils.h
@@ -636,7 +636,7 @@ class QuantizationPattern : public RewritePattern {
                 *quantized_op->getResult(i).getUsers().begin())) {
           result = quantize_op->getResult(0);
         } else {
-          quantize_op->emitError()
+          quantized_op->emitError()
               << "Output[" << i
               << "] is expected to have only one user [QUANTIZE]";
           return;

--- a/tensorflow/compiler/mlir/tensorflow/transforms/promote_resources_to_args.cc
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/promote_resources_to_args.cc
@@ -247,7 +247,7 @@ LogicalResult PromoteResourcesToArguments(
         resource_info.write = true;
         resource_info.live_value = write_op.getValue();
       } else {
-        return read_op.emitOpError(kInvalidResourceMsg);
+        return write_op.emitOpError(kInvalidResourceMsg);
       }
 
       write_op.erase();

--- a/tensorflow/compiler/xla/mlir_hlo/mhlo/transforms/hlo_legalize_to_lhlo/hlo_legalize_to_lhlo.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/mhlo/transforms/hlo_legalize_to_lhlo/hlo_legalize_to_lhlo.cc
@@ -63,6 +63,7 @@ Value insertDynamicAlloc(Location loc, Value result, Value shapeOperand,
   if (!resultType) {
     result.getDefiningOp()->emitOpError()
         << "tensor to buffer conversion expects ranked results";
+    return NULL;
   }
   auto memrefType =
       MemRefType::get(resultType.getShape(), resultType.getElementType());
@@ -91,6 +92,7 @@ Value insertAlloc(Location loc, OpResult result,
   if (!resultType || !resultType.hasStaticShape()) {
     result.getDefiningOp()->emitOpError()
         << "tensor to buffer conversion expects statically shaped results";
+    return NULL;
   }
   auto memrefType =
       MemRefType::get(resultType.getShape(), resultType.getElementType());

--- a/tensorflow/compiler/xla/service/hlo_module_util.cc
+++ b/tensorflow/compiler/xla/service/hlo_module_util.cc
@@ -129,8 +129,11 @@ StatusOr<std::unique_ptr<HloModuleConfig>> CreateModuleConfig(
         DeviceAssignment::Deserialize(execution_options->device_assignment()));
     config->set_static_device_assignment(*device_assignment);
   }
-  config->set_alias_passthrough_params(
-      execution_options->alias_passthrough_params());
+
+  if (execution_options != nullptr) {
+    config->set_alias_passthrough_params(
+        execution_options->alias_passthrough_params());
+  }
 
   if (aot_options != nullptr) {
     config->set_matrix_unit_operand_precision(

--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -3659,6 +3659,10 @@ bool HloParserImpl::ParseDenseLiteral(Literal* literal, const Shape& shape) {
         break;
       }
       case TokKind::kRbrace: {
+        if (nest_level == 0) {
+          return TokenError(absl::StrFormat(
+              "unexpected '}' in a literal. No '{' was parsed before"));
+        }
         nest_level--;
         if (elems_seen_per_dim[nest_level] != shape.dimensions(nest_level)) {
           return TokenError(absl::StrFormat(

--- a/tensorflow/core/distributed_runtime/rpc/grpc_worker_service.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_worker_service.cc
@@ -652,11 +652,12 @@ void GrpcWorker::RecvBufAsync(CallOptions* opts, const RecvBufRequest* request,
       if (hook == nullptr) {
         s = errors::Internal("Invalid null hook for key ",
                              request->buf_rendezvous_key());
-      }
-      if (!DMAHelper::CanUseDMA(hook->prod_value)) {
-        s = errors::Internal("Tensor value for key ",
-                             request->buf_rendezvous_key(),
-                             " is not of a type supported by RecvBuf");
+      } else {
+        if (!DMAHelper::CanUseDMA(hook->prod_value)) {
+          s = errors::Internal("Tensor value for key ",
+                               request->buf_rendezvous_key(),
+                               " is not of a type supported by RecvBuf");
+        }
       }
     } else {
       if (hook != nullptr) {

--- a/tensorflow/core/framework/node_def_builder.cc
+++ b/tensorflow/core/framework/node_def_builder.cc
@@ -235,6 +235,12 @@ Status NodeDefBuilder::Finalize(NodeDef* node_def, bool consume) {
           (*errors_ptr)[0], " while building NodeDef '", node_def_.name(),
           "' using ", SummarizeOpDef(*op_def_));
     } else {
+      if (op_def_ == nullptr) {
+        return errors::InvalidArgument(errors_ptr->size(),
+                                       " errors while building NodeDef '",
+                                       node_def_.name(), "':\n",
+                                       absl::StrJoin(*errors_ptr, "\n"));
+      }
       return errors::InvalidArgument(
           errors_ptr->size(), " errors while building NodeDef '",
           node_def_.name(), "' using ", SummarizeOpDef(*op_def_), ":\n",

--- a/tensorflow/core/graph/graph.cc
+++ b/tensorflow/core/graph/graph.cc
@@ -944,8 +944,11 @@ std::unordered_map<std::string, Node*> Graph::BuildNodeNameIndex() const {
 }
 
 std::string Edge::DebugString() const {
-  return strings::Printf("[id=%d %s:%d -> %s:%d]", id_, src_->name().c_str(),
-                         src_output_, dst_->name().c_str(), dst_input_);
+  if (src_ && dst_) {
+    return strings::Printf("[id=%d %s:%d -> %s:%d]", id_, src_->name().c_str(),
+                           src_output_, dst_->name().c_str(), dst_input_);
+  }
+  return strings::Printf("id=%d %d -> %d]", id_, src_output_, dst_input_);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/summary/summary_db_writer.cc
+++ b/tensorflow/core/summary/summary_db_writer.cc
@@ -58,7 +58,7 @@ const uint64 kIdTiers[] = {
     0x7fffffffffffULL,  // 47-bit (5 bytes on disk)
                         // remaining bits for future use
 };
-const int kMaxIdTier = sizeof(kIdTiers) / sizeof(uint64);
+const int kMaxIdTier = sizeof(kIdTiers) / sizeof(uint64) - 1;
 const int kIdCollisionDelayMicros = 10;
 const int kMaxIdCollisions = 21;  // sum(2**i*10µs for i in range(21))~=21s
 const int64_t kAbsent = 0LL;

--- a/tensorflow/lite/kernels/conv.cc
+++ b/tensorflow/lite/kernels/conv.cc
@@ -596,6 +596,8 @@ TfLiteStatus Prepare(KernelType kernel_type, TfLiteContext* context,
       const auto* affine_quantization =
           reinterpret_cast<TfLiteAffineQuantization*>(
               filter->quantization.params);
+      TF_LITE_ENSURE(context, affine_quantization);
+      TF_LITE_ENSURE(context, affine_quantization->scale);
       TF_LITE_ENSURE_EQ(
           context, affine_quantization->scale->size,
           filter->dims->data[affine_quantization->quantized_dimension]);

--- a/tensorflow/lite/optional_debug_tools.cc
+++ b/tensorflow/lite/optional_debug_tools.cc
@@ -499,19 +499,23 @@ void PrintInterpreterState(const Interpreter* interpreter) {
       }
       printf("  %d Input Tensors:",
              node.inputs != nullptr ? node.inputs->size : 0);
-      PrintTfLiteIntVector(
-          node.inputs,
-          /*collapse_consecutives=*/(node.delegate != nullptr));
-      PrintTotalBytesOfTensors(
-          subgraph, is_node_delegated ? TfLiteIntArrayView(&empty_int_array)
-                                      : TfLiteIntArrayView(node.inputs));
+      if (node.inputs) {
+        PrintTfLiteIntVector(
+            node.inputs,
+            /*collapse_consecutives=*/(node.delegate != nullptr));
+        PrintTotalBytesOfTensors(
+            subgraph, is_node_delegated ? TfLiteIntArrayView(&empty_int_array)
+                                        : TfLiteIntArrayView(node.inputs));
+      }
 
       printf("  %d Output Tensors:",
              node.outputs != nullptr ? node.outputs->size : 0);
-      PrintTfLiteIntVector(node.outputs);
-      PrintTotalBytesOfTensors(
-          subgraph, is_node_delegated ? TfLiteIntArrayView(&empty_int_array)
-                                      : TfLiteIntArrayView(node.outputs));
+      if (node.outputs) {
+        PrintTfLiteIntVector(node.outputs);
+        PrintTotalBytesOfTensors(
+            subgraph, is_node_delegated ? TfLiteIntArrayView(&empty_int_array)
+                                        : TfLiteIntArrayView(node.outputs));
+      }
 
       if (node.intermediates && node.intermediates->size) {
         printf("  %d Intermediate Tensors:", node.intermediates->size);


### PR DESCRIPTION
These PR fixes a number of bugs found by Svace static analyzer:

1. BUFFER_OVERFLOW at summary_db_writer.cc:
Function 'tensorflow::(anonymous namespace)::IdAllocator::MakeRandomId' generates id using 'tier_' as index for 'kIdTiers[]' array which of size 3. The value of 'tier_' starts from 0 and increments in a loop while 'tier_ < kMaxIdTier', and kMaxIdTier = 3. So there is possible out of bounds acces to 'kIdTiers[]' by index 3.
2. BUFFER_UNDERFLOW at hlo_parser.cc:
Value 'nest_level' is of type int64_t and initialized with 0. The value may become negative If '}' is parsed on the first iteration of do-while loop. That would lead to the out of bounds access of both 'elems_seen_per_dim' and 'shape'.
3. DEREF_AFTER_NULL at grpc_worker_service.cc:
After having been compared to NULL value at grpc_worker_service.cc:647, pointer 'hook' is dereferenced at grpc_worker_service.cc:651.
4. DEREF_AFTER_NULL at hlo_module_util.cc
After having been compared to NULL value at hlo_module_util.cc:111, pointer 'execution_options' is dereferenced at hlo_module_util.cc:119.
5. DEREF_AFTER_NULL at hlo_legalize_to_lhlo.cc:
After having been compared to NULL value at hlo_legalize_to_lhlo.cc:59, pointer 'result_type.impl' is passed in call to function 'mlir::RankedTensorType::getShape' at hlo_legalize_to_lhlo.cc:64, where it is dereferenced at BuiltinTypes.cpp.inc:232.
6. DEREF_OF_NULL at xla_launch_util.cc:
After having been assigned to NULL value at xla_launch_util.cc:461, pointer 'stream' is dereferenced at xla_launch_util.cc:487.