### PR TITLE
[oneDNN] Add cpu BF16 kernel registration for Eigen FusedBatchNormV2

### DIFF
--- a/tensorflow/core/kernels/fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cc
@@ -1716,6 +1716,18 @@ REGISTER_KERNEL_BUILDER(Name("FusedBatchNormGradV2")
                             .TypeConstraint<float>("U"),
                         FusedBatchNormGradOp<CPUDevice, Eigen::half, float>);
 
+REGISTER_KERNEL_BUILDER(Name("FusedBatchNormV2")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<bfloat16>("T")
+                            .TypeConstraint<float>("U"),
+                        FusedBatchNormOp<CPUDevice, bfloat16, float>);
+
+REGISTER_KERNEL_BUILDER(Name("FusedBatchNormGradV2")
+                            .Device(DEVICE_CPU)
+                            .TypeConstraint<bfloat16>("T")
+                            .TypeConstraint<float>("U"),
+                        FusedBatchNormGradOp<CPUDevice, bfloat16, float>);
+
 REGISTER_KERNEL_BUILDER(Name("FusedBatchNormV3")
                             .Device(DEVICE_CPU)
                             .TypeConstraint<float>("T")


### PR DESCRIPTION
Currently in auto_mixed_precision.cc, FusedBatchNorm is replaced by FusedBatchNormV2.
But FusedBatchNormV2 does not have a BFloat16 registration, so after AMP pass, we get an error and then FusedBatchNormV2 runs in FP32. Thus there are too many Cast ops introduced. And eventually in remapper it gets broken down to Mul + Add, but it still runs in FP32.
With this change, FusedBatchNormV2 will execute in BF16 and number of Casts will reduce, thus improving overall model performance.