### PR TITLE
[oneDNN]: Adding support for sigmoid activation as a fused op in quantized-conv2D

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
@@ -828,6 +828,9 @@ class QuantizedConvTest : public OpsTestBase {
       if (fused_ops[i] == "Relu") {
         last_op = "with_relu";
         out_op = ops::Relu(root.WithOpName(last_op), out_op);
+      } else if (fused_ops[i] == "Sigmoid") {
+        last_op = "with_sigmoid";
+        out_op = ops::Sigmoid(root.WithOpName(last_op), out_op);
       }
     }
 
@@ -1061,6 +1064,14 @@ TEST_F(QuantizedConvTest, BiasAddSumReluRequantizeFusionSignedSummand) {
 
 TEST_F(QuantizedConvTest, BiasAddSumReluFusionFloatSummand) {
   TestBiasAddSumActivationFusion<float, qint32>("Relu");
+}
+
+TEST_F(QuantizedConvTest, BiasAddSigmoidRequantizeFusion) {
+  TestBiasAddFusion<qint8, qint8>(true, false, "Sigmoid");
+}
+
+TEST_F(QuantizedConvTest, DWBiasAddSigmoidRequantizeFusion) {
+  TestBiasAddFusion<qint8, qint8>(true, true, "Sigmoid");
 }
 
 }  // namespace tensorflow


### PR DESCRIPTION
This PR adds support for `sigmoid` activation as a fused op in quantized-conv2D.