### PR TITLE
Fix crash in tf.image.resize when antialias is True and size is large

### DIFF
--- a/tensorflow/core/kernels/image/scale_and_translate_op.cc
+++ b/tensorflow/core/kernels/image/scale_and_translate_op.cc
@@ -323,10 +323,13 @@ class ScaleAndTranslateOp : public OpKernel {
     GetValues(context, 3, &row_translation, &col_translation);
 
     Tensor* output = nullptr;
+    TensorShape output_shape;
+    OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(input.dim_size(0)));
+    OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(output_height));
+    OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(output_width));
+    OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(input.dim_size(3)));
     OP_REQUIRES_OK(context, context->allocate_output(
-                                0,
-                                TensorShape({input.dim_size(0), output_height,
-                                             output_width, input.dim_size(3)}),
+                                0, output_shape,
                                 &output));
     if (!context->status().ok()) return;
 

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -4031,6 +4031,15 @@ class ResizeImageWithPadV1Test(test_util.TensorFlowTestCase):
 
     self._assertReturns(x, x_shape, y, y_shape)
 
+  def testImageResizeAntialiasWithInvalidInput(self):
+    with self.session():
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        op = image_ops.resize_images_v2(
+            images=np.ones((2, 2, 2, 2)),
+            size=[1801181592, 1846789676],
+            antialias=True)
+        self.evaluate(op)
+
 
 # half_pixel_centers not supported by XLA
 @test_util.for_all_test_methods(test_util.disable_xla, "b/127616992")


### PR DESCRIPTION
This PR tries to fix the issue raised in #57897 where tf.image.resize
will crash when antialias is True and size is large.

This PR fixes #57897.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>