### PR TITLE
Fix std::bad_alloc exception (followed by crash) when loading a SavedModel containing a tensor of unknown rank

### DIFF
--- a/tensorflow/core/util/strided_slice_op.cc
+++ b/tensorflow/core/util/strided_slice_op.cc
@@ -79,6 +79,10 @@ struct StridedSliceDenseSpec {
 template <class T>
 static Status TF_MUST_USE_RESULT BuildDenseSpec(
     const StridedSliceSparseSpec& sparse, StridedSliceDenseSpec* dense) {
+  if (dense->dims < 0) {
+    return errors::InvalidArgument("Unexpected negative dense.dims");
+  }
+
   // Build expanded begin, end, strides, begin_mask, end_mask
   // to remove any ellipsis
   dense->begin.resize(dense->dims);
@@ -176,6 +180,11 @@ Status ValidateStridedSliceOp(
     gtl::InlinedVector<int64_t, 4>* begin, gtl::InlinedVector<int64_t, 4>* end,
     gtl::InlinedVector<int64_t, 4>* strides,
     StridedSliceShapeSpec* shape_spec) {
+  if (input_shape.unknown_rank()) {
+    // Note: If the rank is unknown, "input_shape.dims()" is -1.
+    return errors::InvalidArgument("Unexpected input_shape with unknown rank");
+  }
+
   const bool begin_is_wrong =
       begin_tensor != nullptr &&
       !(TensorShapeUtils::IsVector(begin_tensor->shape()) &&

--- a/tensorflow/core/util/strided_slice_op.h
+++ b/tensorflow/core/util/strided_slice_op.h
@@ -53,6 +53,9 @@ struct StridedSliceShapeSpec {
 // <processing_shape> are valid; <is_identity>, <is_simple_slice> and other
 // output parameters will not be accurate.
 //
+// If the rank of <input_shape> is unknown (i.e., "input_shape.unknown_rank()"
+// is true)), the method returns an invalid status.
+//
 // If <begin_tensor> or <end_tensor> are nullptr, <begin> and <end> will not be
 // valid. In this case, <slice_dim0> and <is_identity> will be true only if a
 // determination can be made based on the information given. A best effort is


### PR DESCRIPTION
Examples of reported issues:
- https://github.com/tensorflow/serving/issues/2061
- https://github.com/tensorflow/serving/issues/2048
- https://github.com/tensorflow/decision-forests/issues/124

PiperOrigin-RevId: 475317100