### PR TITLE
Changes to add patch to openmp build, to fix build failure

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -535,6 +535,7 @@ def _tf_repositories():
     tf_http_archive(
         name = "llvm_openmp",
         build_file = "//third_party/llvm_openmp:BUILD",
+        patch_file = ["//third_party/llvm_openmp:openmp_switch_default_patch.patch"],
         sha256 = "d19f728c8e04fb1e94566c8d76aef50ec926cd2f95ef3bf1e0a5de4909b28b44",
         strip_prefix = "openmp-10.0.1.src",
         urls = tf_mirror_urls("https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.1/openmp-10.0.1.src.tar.xz"),

--- a/third_party/llvm_openmp/openmp_switch_default_patch.patch
+++ b/third_party/llvm_openmp/openmp_switch_default_patch.patch
@@ -1,0 +1,46 @@
+diff --git a/runtime/src/kmp_settings.cpp b/runtime/src/kmp_settings.cpp
+index 692ca26..b9dca42 100644
+--- a/runtime/src/kmp_settings.cpp
++++ b/runtime/src/kmp_settings.cpp
+@@ -806,6 +806,7 @@ static void __kmp_stg_print_wait_policy(kmp_str_buf_t *buffer, char const *name,
+     case library_throughput: {
+       value = "PASSIVE";
+     } break;
++    default : { } break;
+     }
+   } else {
+     switch (__kmp_library) {
+@@ -818,6 +819,7 @@ static void __kmp_stg_print_wait_policy(kmp_str_buf_t *buffer, char const *name,
+     case library_throughput: {
+       value = "throughput";
+     } break;
++    default : { } break;
+     }
+   }
+   if (value != NULL) {
+@@ -2428,6 +2430,7 @@ static void __kmp_stg_print_affinity(kmp_str_buf_t *buffer, char const *name,
+       __kmp_str_buf_print(buffer, "%s", "granularity=group,");
+       break;
+ #endif /* KMP_GROUP_AFFINITY */
++    default : break;
+     }
+   }
+   if (!KMP_AFFINITY_CAPABLE()) {
+@@ -3819,6 +3822,8 @@ static void __kmp_stg_print_omp_schedule(kmp_str_buf_t *buffer,
+     case kmp_sch_auto:
+       __kmp_str_buf_print(buffer, "%s,%d'\n", "auto", __kmp_chunk);
+       break;
++    default:
++      break;
+     }
+   } else {
+     switch (sched) {
+@@ -3844,6 +3849,8 @@ static void __kmp_stg_print_omp_schedule(kmp_str_buf_t *buffer,
+     case kmp_sch_auto:
+       __kmp_str_buf_print(buffer, "%s'\n", "auto");
+       break;
++    default:
++      break;
+     }
+   }
+ } // __kmp_stg_print_omp_schedule


### PR DESCRIPTION
New constraints for switch stmt added to tensorflow , causes build error in openmp. (with --config=mkl)
One of the openmp files does not handle all cases within switch stmt.
This is a patch that fixes it.

The changes that causes the build failure.
https://github.com/tensorflow/tensorflow/commit/16e2157e9279541e99dd8fdeb3d5b9e80dcc90b8

#Add switch as an error on Linux.
build:linux --copt="-Wswitch"
build:linux --copt="-Werror=switch"