### PR TITLE
Fix fail to build of aot_compiled_test on aarch64

### DIFF
--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -253,6 +253,7 @@ cc_library(
         ":xla_compiled_cpu_runtime_hdrs",
     ],
     copts = runtime_copts() + tf_openmp_copts(),
+    defines = ["EIGEN_NEON_GEBP_NR=4"],
     features = [
         "fully_static_link",
         "-parse_headers",


### PR DESCRIPTION
Build fails with static assertion that NR=4, so, as elsewhere, add the define to make NR=4

Fixes #57968 