### PR TITLE
[TFTRT]: Add converter for QuantizeAndDequantizeV4

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops.cc
@@ -328,7 +328,8 @@ Status ConvertDynamicRangeMode(const OpConverterParams* params) {
     TF_RETURN_IF_ERROR(GetNodeAttr(attrs, "max", &max_range));
   } else if (op_name == "FakeQuantWithMinMaxVars" ||
              op_name == "QuantizeAndDequantizeV2" ||
-             op_name == "QuantizeAndDequantizeV3") {
+             op_name == "QuantizeAndDequantizeV3" ||
+             op_name == "QuantizeAndDequantizeV4") {
     // Get ranges via inputs.
     auto get_weights_value = [&inputs](int index) {
       const auto* raw_weights = inputs.at(index).weights().GetPointer<float>();
@@ -407,6 +408,9 @@ REGISTER_DEFAULT_TRT_OP_CONVERTER(
 REGISTER_DEFAULT_TRT_OP_CONVERTER(
     MakeConverterFunction<ConvertQDQ<ops::QuantizeAndDequantizeV3>>(),
     "QuantizeAndDequantizeV3");
+REGISTER_DEFAULT_TRT_OP_CONVERTER(
+    MakeConverterFunction<ConvertQDQ<ops::QuantizeAndDequantizeV2>>(),
+    "QuantizeAndDequantizeV4");
 REGISTER_DEFAULT_TRT_OP_CONVERTER(
     MakeConverterFunction<ConvertQDQ<ops::FakeQuantWithMinMaxVars>>(),
     "FakeQuantWithMinMaxVars");

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops.h
@@ -25,17 +25,19 @@ namespace tensorflow {
 namespace tensorrt {
 namespace convert {
 
-constexpr std::array<const char*, 4> kQuantizationOpNames = {
+constexpr std::array<const char*, 5> kQuantizationOpNames = {
     "QuantizeAndDequantizeV2",
     "QuantizeAndDequantizeV3",
+    "QuantizeAndDequantizeV4",
     "FakeQuantWithMinMaxVars",
     "FakeQuantWithMinMaxArgs",
 };
 
 // Operations with supported conversion to Q/DQ ops in TensorRT explicit
 // precision mode.
-constexpr std::array<const char*, 1> kExplicitQuantizationOpNames = {
+constexpr std::array<const char*, 2> kExplicitQuantizationOpNames = {
     "QuantizeAndDequantizeV2",
+    "QuantizeAndDequantizeV4",
 };
 
 // Contains two scaling factors for quantization and dequantization


### PR DESCRIPTION
Per TF docs, this op behaves exactly the same as QuantizeAndDequantizeV2 for inference, so the converter for QDQv4 leverages existing infrastructure.

CC: @tfeher @christopherbate @DEKHTIARJonathan @pjannaty 