### PR TITLE
[ROCm] Fix 2 more unit tests for gpu_kernel_tiling_test on ROCm

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_codegen_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_codegen_test.cc
@@ -71,11 +71,11 @@ std::string GpuCodegenTest::MakePlatformSpecificLlvm(absl::string_view input) {
        {"TIDX", is_built_with_rocm_ ? "@llvm.amdgcn.workitem.id.x"
                                     : "@llvm.nvvm.read.ptx.sreg.tid.x"},
        {"LCAL", is_built_with_rocm_ ? "%[[LOGICAL_T1:.*]] = call { i1, i64 } @llvm.amdgcn.if.i64(i1 %[[LOGICAL_T0]])"
-                                    : ""},
+                                    : "0"},
        {"EXTV", is_built_with_rocm_ ? "%[[LOGICAL_T2:.*]] = extractvalue { i1, i64 } %[[LOGICAL_T1]], 0"
-                                    : ""},
-       {"BR_LCAL", is_built_with_rocm_ ? "br i1 %[[LOGICAL_T2]]"
-                                       : "br i1 %[[LOGICAL_T0]]"}});
+                                    : "0"},
+       {"BR_CAL", is_built_with_rocm_ ? "br i1 %[[LOGICAL_T2]]," 
+                                      : "br i1 %[[LOGICAL_T0]]"}});
 }
 
 }  // namespace gpu

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_codegen_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_codegen_test.cc
@@ -68,8 +68,14 @@ std::string GpuCodegenTest::MakePlatformSpecificLlvm(absl::string_view input) {
         is_built_with_rocm_ ? "@llvm.amdgcn.s.barrier" : "@llvm.nvvm.barrier0"},
        {"SHUFFLE", is_built_with_rocm_ ? "i32 @llvm.amdgcn.ds.bpermute"
                                        : "float @llvm.nvvm.shfl.sync.down.f32"},
-       {"TIDX", is_built_with_rocm_ ? "llvm.amdgcn.workitem.id.x"
-                                    : "@llvm.nvvm.read.ptx.sreg.tid.x"}});
+       {"TIDX", is_built_with_rocm_ ? "@llvm.amdgcn.workitem.id.x"
+                                    : "@llvm.nvvm.read.ptx.sreg.tid.x"},
+       {"LCAL", is_built_with_rocm_ ? "%[[LOGICAL_T1:.*]] = call { i1, i64 } @llvm.amdgcn.if.i64(i1 %[[LOGICAL_T0]])"
+                                    : ""},
+       {"EXTV", is_built_with_rocm_ ? "%[[LOGICAL_T2:.*]] = extractvalue { i1, i64 } %[[LOGICAL_T1]], 0"
+                                    : ""},
+       {"BR_LCAL", is_built_with_rocm_ ? "br i1 %[[LOGICAL_T2]]"
+                                       : "br i1 %[[LOGICAL_T0]]"}});
 }
 
 }  // namespace gpu

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -537,7 +537,7 @@ TEST_F(GpuKernelTilingTest, RowReductionTwoRowsPerWarp) {
 ; CHECK: %[[LOGICAL_T0:.*]] = icmp eq i32 %[[TID_LOGICAL]], 0
 ; CHECK: LCAL
 ; CHECK: EXTV
-; CHECK: BR_LCAL
+; CHECK: BR_CAL
 )";
   CompileAndVerifyIr(std::move(hlo_module),
                      MakePlatformSpecificLlvm(expected_ir),
@@ -568,7 +568,7 @@ TEST_F(GpuKernelTilingTest, RowReductionFourRowsPerWarp) {
   auto hlo_module =
       ParseAndReturnVerifiedModule(kHloString, ConfigWithoutLayoutAssignment())
           .value();
-  auto expected_ir =  R"(
+  auto expected_ir = R"(
 ; CHECK-LABEL: define KERNEL_ANNOTATION @reduce
 ; CHECK: %[[TID_X:.*]] = tail call i32 TIDX()
 ; CHECK: %[[TID_LOGICAL:.*]] = and i32 %[[TID_X]], 7
@@ -576,7 +576,7 @@ TEST_F(GpuKernelTilingTest, RowReductionFourRowsPerWarp) {
 ; CHECK: %[[LOGICAL_T0:.*]] = icmp eq i32 %[[TID_LOGICAL]], 0
 ; CHECK: LCAL
 ; CHECK: EXTV
-; CHECK: BR_LCAL
+; CHECK: BR_CAL
 )";
 
   CompileAndVerifyIr(std::move(hlo_module),

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -535,7 +535,9 @@ TEST_F(GpuKernelTilingTest, RowReductionTwoRowsPerWarp) {
 ; CHECK: %[[TID_LOGICAL:.*]] = and i32 %[[TID_X]], 15
 ; CHECK: call SHUFFLE
 ; CHECK: %[[LOGICAL_T0:.*]] = icmp eq i32 %[[TID_LOGICAL]], 0
-; CHECK: br i1 %[[LOGICAL_T0]],
+; CHECK: LCAL
+; CHECK: EXTV
+; CHECK: BR_LCAL
 )";
   CompileAndVerifyIr(std::move(hlo_module),
                      MakePlatformSpecificLlvm(expected_ir),
@@ -566,14 +568,17 @@ TEST_F(GpuKernelTilingTest, RowReductionFourRowsPerWarp) {
   auto hlo_module =
       ParseAndReturnVerifiedModule(kHloString, ConfigWithoutLayoutAssignment())
           .value();
-  auto expected_ir = R"(
+  auto expected_ir =  R"(
 ; CHECK-LABEL: define KERNEL_ANNOTATION @reduce
 ; CHECK: %[[TID_X:.*]] = tail call i32 TIDX()
 ; CHECK: %[[TID_LOGICAL:.*]] = and i32 %[[TID_X]], 7
 ; CHECK: call SHUFFLE
 ; CHECK: %[[LOGICAL_T0:.*]] = icmp eq i32 %[[TID_LOGICAL]], 0
-; CHECK: br i1 %[[LOGICAL_T0]],
+; CHECK: LCAL
+; CHECK: EXTV
+; CHECK: BR_LCAL
 )";
+
   CompileAndVerifyIr(std::move(hlo_module),
                      MakePlatformSpecificLlvm(expected_ir),
                      /*match_optimized_ir=*/true);


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/57948 has fixed one unit test on ColReductionWithSmallDtype.

This PR has fixed rest two (RowReductionTwoRowsPerWarp and RowReductionFourRowsPerWarp) on gpu_kernel_tiling_test at ROCm.

/cc @cheshire