### PR TITLE
 Fix crash in tf.nn.conv2d_transpose when output shape is invalid

### DIFF
--- a/tensorflow/core/kernels/avgpooling_op.cc
+++ b/tensorflow/core/kernels/avgpooling_op.cc
@@ -106,8 +106,10 @@ class AvgPoolingOp : public UnaryOp<T> {
                 errors::InvalidArgument("tensor_in must be 4-dimensional"));
 
     Tensor* output = nullptr;
+    TensorShape params_forward_output_shape;
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
     OP_REQUIRES_OK(context, context->allocate_output(
-                                0, params.forward_output_shape(), &output));
+                                0, params_forward_output_shape, &output));
 
     SpatialAvgPool<Device, T>(context, output, tensor_in, params, padding_);
   }

--- a/tensorflow/core/kernels/avgpooling_op.cc
+++ b/tensorflow/core/kernels/avgpooling_op.cc
@@ -187,7 +187,8 @@ class AvgPoolingOp<GPUDevice, T> : public UnaryOp<T> {
     OP_REQUIRES(context, tensor_in.dims() == 4,
                 errors::InvalidArgument("tensor_in must be 4-dimensional"));
 
-    TensorShape output_shape = params.forward_output_shape();
+    TensorShape output_shape;
+    OP_REQUIRES_OK(context, params.forward_output_shape(&output_shape));
     if (output_shape.num_elements() == 0) {
       Tensor* output = nullptr;
       OP_REQUIRES_OK(context,

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -723,11 +723,16 @@ void LaunchConv2DBackpropFilterOpImpl(
     const int64_t input_pad_bottom = padding_bottom - common_padding_rows;
     const int64_t input_pad_left = padding_left - common_padding_cols;
     const int64_t input_pad_right = padding_right - common_padding_cols;
+    TensorShape compatible_input_shape;
+    OP_REQUIRES_OK(
+        ctx,
+        ShapeFromFormatWithStatus(data_format, dims.batch_size, new_in_rows,
+                                  new_in_cols, dims.in_depth,
+                                  &compatible_input_shape));
     OP_REQUIRES_OK(
         ctx, ctx->allocate_temp(
                  DataTypeToEnum<T>::value,
-                 ShapeFromFormat(data_format, dims.batch_size, new_in_rows,
-                                 new_in_cols, dims.in_depth),
+                 compatible_input_shape,
                  &compatible_input));
 
     functor::PadInput<GPUDevice, T, int, 4>()(
@@ -818,9 +823,13 @@ void LaunchConv2DBackpropFilterOpImpl(
   Tensor transformed_out_backprop;
   if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
     VLOG(4) << "Convert the `out_backprop` tensor from NHWC to NCHW.";
-    TensorShape compute_shape = ShapeFromFormat(
-        compute_data_format, dims.batch_size, dims.spatial_dims[0].output_size,
-        dims.spatial_dims[1].output_size, dims.out_depth);
+    TensorShape compute_shape;
+    OP_REQUIRES_OK(
+        ctx,
+        ShapeFromFormatWithStatus(
+            compute_data_format, dims.batch_size, dims.spatial_dims[0].output_size,
+            dims.spatial_dims[1].output_size, dims.out_depth,
+            &compute_shape));
     if (dims.out_depth > 1) {
       OP_REQUIRES_OK(ctx,
                      ctx->allocate_temp(DataTypeToEnum<T>::value, compute_shape,
@@ -839,11 +848,15 @@ void LaunchConv2DBackpropFilterOpImpl(
   Tensor transformed_input;
   if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
     VLOG(4) << "Convert the `input` tensor from NHWC to NCHW.";
-    TensorShape compute_shape = ShapeFromFormat(
-        compute_data_format, GetTensorDim(compatible_input, data_format, 'N'),
-        GetTensorDim(compatible_input, data_format, 'H'),
-        GetTensorDim(compatible_input, data_format, 'W'),
-        GetTensorDim(compatible_input, data_format, 'C'));
+    TensorShape compute_shape;
+    OP_REQUIRES_OK(
+        ctx,
+        ShapeFromFormatWithStatus(
+            compute_data_format, GetTensorDim(compatible_input, data_format, 'N'),
+            GetTensorDim(compatible_input, data_format, 'H'),
+            GetTensorDim(compatible_input, data_format, 'W'),
+            GetTensorDim(compatible_input, data_format, 'C'),
+            &compute_shape));
     if (compute_shape.dim_size(1) > 1) {
       OP_REQUIRES_OK(ctx,
                      ctx->allocate_temp(DataTypeToEnum<T>::value, compute_shape,

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -203,7 +203,7 @@ void LaunchConv2DBackpropInputOpGpuImpl(
     const int64_t new_in_cols =
         dims.spatial_dims[1].input_size + padding_cols_diff;
     OP_REQUIRES_OK(
-        context,
+        ctx,
         ShapeFromFormatWithStatus(
             data_format, dims.batch_size, new_in_rows, new_in_cols, dims.in_depth,
             &compatible_input_shape));
@@ -412,7 +412,7 @@ void LaunchConv2DBackpropInputOpGpuImpl(
             GetTensorDim(input_shape, data_format, 'H'),
             GetTensorDim(input_shape, data_format, 'W'),
             GetTensorDim(input_shape, data_format, 'C'),
-            &in_backprop_remove_padding_shape);
+            &in_backprop_remove_padding_shape));
     OP_REQUIRES_OK(
         ctx, ctx->allocate_temp(
                  DataTypeToEnum<T>::value,

--- a/tensorflow/core/kernels/conv_grad_shape_utils.cc
+++ b/tensorflow/core/kernels/conv_grad_shape_utils.cc
@@ -196,9 +196,8 @@ Status Conv2DBackpropComputeInputShape(const Tensor& input_sizes,
           "Conv2DBackpropInput: elements of input_sizes must be >= 0, not ",
           output_height, "x", output_width);
     }
-    *input_shape = ShapeFromFormat(data_format, batch_size, output_height,
-                                   output_width, output_depth);
-    return OkStatus();
+    return ShapeFromFormatWithStatus(data_format, batch_size, output_height,
+                                     output_width, output_depth, input_shape);
   }
 
   return errors::InvalidArgument(

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -617,9 +617,12 @@ class Conv2DOp : public BinaryOp<T> {
     OP_REQUIRES_OK(context,
                    ComputeConv2DDimension(params_, input, filter, &dimensions));
 
-    TensorShape out_shape = ShapeFromFormat(
-        params_.data_format, dimensions.batch, dimensions.out_rows,
-        dimensions.out_cols, dimensions.out_depth);
+    TensorShape out_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            params_.data_format, dimensions.batch, dimensions.out_rows,
+            dimensions.out_cols, dimensions.out_depth, &out_shape));
 
     // Output tensor is of the following dimensions:
     // [ in_batch, out_rows, out_cols, out_depth ]
@@ -875,10 +878,15 @@ void LaunchConv2DOpImpl(OpKernelContext* ctx, bool use_cudnn,
     const int64_t padding_cols_diff = std::abs(padding_right - padding_left);
     const int64_t new_in_rows = in_rows + padding_rows_diff;
     const int64_t new_in_cols = in_cols + padding_cols_diff;
+    TensorShape transformed_input_shape;
+    OP_REQUIRES_OK(
+        ctx,
+        ShapeFromFormatWithStatus(
+            data_format, in_batch, new_in_rows,
+            new_in_cols, in_depths, &transformed_input_shape));
     OP_REQUIRES_OK(ctx, ctx->allocate_temp(
                             DataTypeToEnum<T>::value,
-                            ShapeFromFormat(data_format, in_batch, new_in_rows,
-                                            new_in_cols, in_depths),
+                            transformed_input_shape,
                             &transformed_input));
 
     const int64_t input_pad_top = padding_top - common_padding_rows;
@@ -910,8 +918,12 @@ void LaunchConv2DOpImpl(OpKernelContext* ctx, bool use_cudnn,
   if (data_format == FORMAT_NHWC && compute_data_format == FORMAT_NCHW) {
     VLOG(4) << "Convert the input tensor from NHWC to NCHW.";
 
-    TensorShape nchw_shape =
-        ShapeFromFormat(FORMAT_NCHW, in_batch, in_rows, in_cols, in_depths);
+    TensorShape nchw_shape;
+    OP_REQUIRES_OK(
+        ctx,
+        ShapeFromFormatWithStatus(
+            FORMAT_NCHW, in_batch, in_rows, in_cols, in_depths,
+            &nchw_shape));
     if (in_depths > 1) {
       Tensor transformed_input;
       OP_REQUIRES_OK(ctx, ctx->allocate_temp(DataTypeToEnum<T>::value,
@@ -1012,10 +1024,15 @@ void LaunchConv2DOpImpl(OpKernelContext* ctx, bool use_cudnn,
   Tensor transformed_output;
   if (data_format != compute_data_format) {
     VLOG(4) << "Allocate temporary memory for output in compute data format";
+    TensorShape transformed_output_shape;
+    OP_REQUIRES_OK(
+        ctx,
+        ShapeFromFormatWithStatus(
+            compute_data_format, out_batch,
+            out_rows, out_cols, out_depths, &transformed_output_shape));
     OP_REQUIRES_OK(
         ctx, ctx->allocate_temp(DataTypeToEnum<T>::value,
-                                ShapeFromFormat(compute_data_format, out_batch,
-                                                out_rows, out_cols, out_depths),
+                                transformed_output_shape,
                                 &transformed_output));
   } else {
     transformed_output = *output;

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -370,7 +370,7 @@ void LaunchConvOpImpl(OpKernelContext* ctx, bool cudnn_use_autotune,
     OP_REQUIRES_OK(
         ctx,
         ShapeFromFormatWithStatus(
-            FORMAT_NCHW, in_batch, {{in_planes, in_rows, in_cols}}, in_depth, &nchw_shape);
+            FORMAT_NCHW, in_batch, {{in_planes, in_rows, in_cols}}, in_depth, &nchw_shape));
     if (in_depth > 1) {
       Tensor transformed_input;
       OP_REQUIRES_OK(ctx, ctx->allocate_temp(DataTypeToEnum<T>::value,

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -183,8 +183,12 @@ class Conv3DOp : public BinaryOp<T> {
     OP_REQUIRES_OK(
         context, Get3dOutputSizeV2(input_size, filter_size, dilations, strides,
                                    padding_, &out, &padding));
-    TensorShape out_shape = ShapeFromFormat(
-        data_format_, in_batch, {{out[0], out[1], out[2]}}, out_depth);
+    TensorShape out_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            data_format_, in_batch, {{out[0], out[1], out[2]}}, out_depth,
+            &out_shape));
     Tensor* output;
     OP_REQUIRES_OK(context, context->allocate_output(0, out_shape, &output));
 

--- a/tensorflow/core/kernels/conv_ops_fused_image_transform.cc
+++ b/tensorflow/core/kernels/conv_ops_fused_image_transform.cc
@@ -830,8 +830,11 @@ class FusedResizeConv2DUsingGemmOp : public OpKernel {
     OP_REQUIRES_OK(context,
                    GetWindowedOutputSize(padded_cols, filter_cols, stride_cols,
                                          padding_, &out_cols, &pad_cols));
-    TensorShape out_shape =
-        ShapeFromFormat(FORMAT_NHWC, batch, out_rows, out_cols, out_depth);
+    TensorShape out_shape;
+    OP_REQUIRES_OK(
+        context, 
+        ShapeFromFormatWithStatus(
+            FORMAT_NHWC, batch, out_rows, out_cols, out_depth, &out_shape));
     OP_REQUIRES(context, (out_shape.num_elements() > 0),
                 errors::InvalidArgument("Output tensor can't be empty"));
 

--- a/tensorflow/core/kernels/conv_ops_fused_impl.h
+++ b/tensorflow/core/kernels/conv_ops_fused_impl.h
@@ -401,11 +401,16 @@ struct LaunchFusedConv2DOp<GPUDevice, T> {
           std::abs(dimensions.pad_cols_after - dimensions.pad_cols_before);
       const int64_t new_in_rows = in_rows + padding_rows_diff;
       const int64_t new_in_cols = in_cols + padding_cols_diff;
+      TensorShape transformed_input_shape;
+      OP_REQUIRES_OK(context,
+                     ShapeFromFormatWithStatus(
+                         params.data_format, in_batch,
+                         new_in_rows, new_in_cols, in_depths,
+                         &transformed_input_shape));
       OP_REQUIRES_OK(context,
                      context->allocate_temp(
                          DataTypeToEnum<T>::value,
-                         ShapeFromFormat(params.data_format, in_batch,
-                                         new_in_rows, new_in_cols, in_depths),
+                         transformed_input_shape,
                          &transformed_input));
       const int64_t input_pad_top =
           dimensions.pad_rows_before - common_padding_rows;
@@ -441,8 +446,12 @@ struct LaunchFusedConv2DOp<GPUDevice, T> {
                                      se::CudaComputeCapability::VOLTA);
     if (!compute_in_nhwc && params.data_format == FORMAT_NHWC) {
       // Convert the input tensor from NHWC to NCHW.
-      TensorShape nchw_shape =
-          ShapeFromFormat(FORMAT_NCHW, in_batch, in_rows, in_cols, in_depths);
+      TensorShape nchw_shape;
+      OP_REQUIRES_OK(
+          context,
+          ShapeFromFormatWithStatus(
+              FORMAT_NCHW, in_batch, in_rows, in_cols, in_depths,
+              &nchw_shape));
       if (in_depths > 1) {
         Tensor transformed_input;
         OP_REQUIRES_OK(context,
@@ -557,11 +566,15 @@ struct LaunchFusedConv2DOp<GPUDevice, T> {
     Tensor transformed_output;
     if (!compute_in_nhwc && params.data_format == FORMAT_NHWC) {
       // Only allocate temporary memory when a layout transformation is needed.
+      TensorShape transformed_output_shape;
+      OP_REQUIRES_OK(context,
+                     ShapeFromFormatWithStatus(
+                         FORMAT_NCHW, out_batch, out_rows,
+                         out_cols, out_depths, &transformed_output_shape));
       OP_REQUIRES_OK(context,
                      context->allocate_temp(
                          DataTypeToEnum<T>::value,
-                         ShapeFromFormat(FORMAT_NCHW, out_batch, out_rows,
-                                         out_cols, out_depths),
+                         transformed_output_shape,
                          &transformed_output));
     } else {
       transformed_output = *output;
@@ -755,9 +768,10 @@ class FusedConv2DOp : public OpKernel {
     OP_REQUIRES_OK(context,
                    ComputeConv2DDimension(params_, input, filter, &dimensions));
 
-    TensorShape out_shape = ShapeFromFormat(
+    TensorShape out_shape;
+    OP_REQUIRES_OK(context, ShapeFromFormatWithStatus(
         params_.data_format, dimensions.batch, dimensions.out_rows,
-        dimensions.out_cols, dimensions.out_depth);
+        dimensions.out_cols, dimensions.out_depth, &out_shape));
 
     // Output tensor is of the following dimensions:
     // [ in_batch, out_rows, out_cols, out_depth ]

--- a/tensorflow/core/kernels/conv_ops_fused_int8.cc
+++ b/tensorflow/core/kernels/conv_ops_fused_int8.cc
@@ -443,12 +443,17 @@ void operator()(
         using VectT = int32;
         auto pad_data_format = FORMAT_NCHW;
 
+	TensorShape maybe_padded_conv_input_shape;
+	OP_REQUIRES_OK(
+            ctx,
+            ShapeFromFormatWithStatus(
+                data_format, batch_size, new_conv_input_rows,
+                new_conv_input_cols, conv_input_depth, &maybe_padded_conv_input_shape));
         OP_REQUIRES_OK(
             ctx,
             ctx->allocate_temp(
                 DataTypeToEnum<T>::value,
-                ShapeFromFormat(data_format, batch_size, new_conv_input_rows,
-                                new_conv_input_cols, conv_input_depth),
+                maybe_padded_conv_input_shape,
                 &maybe_padded_conv_input));
 
         auto conv_input_eigen_tensor =

--- a/tensorflow/core/kernels/conv_ops_test.cc
+++ b/tensorflow/core/kernels/conv_ops_test.cc
@@ -745,8 +745,9 @@ class FusedConv2DOpTest : public OpsTestBase {
 
     if (v > 1) {
       {
-        Tensor input_data_nchwv(
-            dtype, ShapeFromFormat(FORMAT_NCHW_VECT_C, n, h, w, ic));
+        TensorShape shape;
+        TF_EXPECT_OK(ShapeFromFormatWithStatus(FORMAT_NCHW_VECT_C, n, h, w, ic, &shape));
+        Tensor input_data_nchwv(dtype, shape);
         input_data_nchwv.tensor<T, 5>() =
             input_data.shaped<T, 5>({n, h, w, ic / v, v})
                 .shuffle(Eigen::array<int, 5>{0, 3, 1, 2, 4});
@@ -810,8 +811,9 @@ class FusedConv2DOpTest : public OpsTestBase {
       ASSERT_TRUE(
           GetWindowedOutputSize(w, kw, stride, padding_type, &ow, &ow_padding)
               .ok());
-      side_input =
-          Tensor(dtype, ShapeFromFormat(FORMAT_NCHW_VECT_C, n, oh, ow, oc));
+      TensorShape shape;
+      TF_EXPECT_OK(ShapeFromFormatWithStatus(FORMAT_NCHW_VECT_C, n, oh, ow, oc, &shape));
+      side_input = Tensor(dtype, shape);
       side_input.flat<T>() = side_input.flat<T>().setConstant(0);
     }
 
@@ -863,7 +865,9 @@ class FusedConv2DOpTest : public OpsTestBase {
       // Convert the output from NCHW_VECT_C to NHWC
       const int oh = GetTensorDim(*output, FORMAT_NCHW_VECT_C, 'H');
       const int ow = GetTensorDim(*output, FORMAT_NCHW_VECT_C, 'W');
-      Tensor output_nhwc(dtype, ShapeFromFormat(FORMAT_NHWC, n, oh, ow, oc));
+      TensorShape shape;
+      TF_EXPECT_OK(ShapeFromFormatWithStatus(FORMAT_NHWC, n, oh, ow, oc, &shape));
+      Tensor output_nhwc(dtype, shape);
       output_nhwc.tensor<T, 4>() =
           output->tensor<T, 5>()
               .shuffle(Eigen::array<int, 5>{0, 2, 3, 1, 4})

--- a/tensorflow/core/kernels/conv_ops_using_gemm.cc
+++ b/tensorflow/core/kernels/conv_ops_using_gemm.cc
@@ -526,8 +526,11 @@ class Conv2DUsingGemmOp : public BinaryOp<T> {
     OP_REQUIRES_OK(context,
                    GetWindowedOutputSize(input_cols, filter_cols, stride_cols,
                                          padding_, &out_cols, &pad_cols));
-    TensorShape out_shape =
-        ShapeFromFormat(data_format_, batch, out_rows, out_cols, out_depth);
+    TensorShape out_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            data_format_, batch, out_rows, out_cols, out_depth, &out_shape));
 
     // Output tensor is of the following dimensions:
     // [ in_batch, out_rows, out_cols, out_depth ]

--- a/tensorflow/core/kernels/cudnn_pooling_gpu.cc
+++ b/tensorflow/core/kernels/cudnn_pooling_gpu.cc
@@ -47,10 +47,15 @@ void DnnPooling3dOp<T>::Compute(OpKernelContext* context,
 
   Tensor transformed_input;
   if (data_format == FORMAT_NHWC) {
+    TensorShape transformed_input_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            FORMAT_NCHW, tensor_in.shape(),
+            data_format, &transformed_input_shape));
     OP_REQUIRES_OK(context, context->allocate_temp(
                                 DataTypeToEnum<T>::value,
-                                ShapeFromFormat(FORMAT_NCHW, tensor_in.shape(),
-                                                data_format),
+                                transformed_input_shape,
                                 &transformed_input));
     functor::NHWCToNCHW<GPUDevice, T, 5>()(context->eigen_device<GPUDevice>(),
                                            tensor_in.tensor<T, 5>(),
@@ -60,10 +65,15 @@ void DnnPooling3dOp<T>::Compute(OpKernelContext* context,
   }
   Tensor transformed_output;
   if (data_format == FORMAT_NHWC) {
+    TensorShape transformed_output_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            FORMAT_NCHW, out_shape, data_format, &transformed_output_shape));
     OP_REQUIRES_OK(context,
                    context->allocate_temp(
                        DataTypeToEnum<T>::value,
-                       ShapeFromFormat(FORMAT_NCHW, out_shape, data_format),
+                       transformed_output_shape,
                        &transformed_output));
   } else {
     transformed_output = *output;
@@ -148,8 +158,10 @@ void DnnPooling3dGradOp<T>::Compute(
   Tensor transformed_input;
   TensorShape transformed_input_shape;
   if (data_format == FORMAT_NHWC || tensor_in == nullptr) {
-    transformed_input_shape =
-        ShapeFromFormat(FORMAT_NCHW, tensor_in_shape, data_format);
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            FORMAT_NCHW, tensor_in_shape, data_format, &transformed_input_shape));
     OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<T>::value,
                                                    transformed_input_shape,
                                                    &transformed_input));
@@ -159,8 +171,10 @@ void DnnPooling3dGradOp<T>::Compute(
   Tensor transformed_output;
   TensorShape transformed_output_shape;
   if (data_format == FORMAT_NHWC || tensor_out == nullptr) {
-    transformed_output_shape =
-        ShapeFromFormat(FORMAT_NCHW, out_backprop.shape(), data_format);
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            FORMAT_NCHW, out_backprop.shape(), data_format, &transformed_output_shape));
     OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<T>::value,
                                                    transformed_output_shape,
                                                    &transformed_output));

--- a/tensorflow/core/kernels/depthtospace_op.cc
+++ b/tensorflow/core/kernels/depthtospace_op.cc
@@ -103,11 +103,16 @@ class DepthToSpaceOp : public OpKernel {
 
     // Allocate output tensor.
     Tensor* outputs_tensor = nullptr;
+    TensorShape outputs_tensor_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            data_format_, batch_size, output_height,
+            output_width, output_depth, &outputs_tensor_shape));
     OP_REQUIRES_OK(context,
                    context->allocate_output(
                        0,
-                       ShapeFromFormat(data_format_, batch_size, output_height,
-                                       output_width, output_depth),
+                       outputs_tensor_shape,
                        &outputs_tensor));
     auto Tinput = input.tensor<T, kDims>();
     auto Toutput = outputs_tensor->tensor<T, kDims>();

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -417,8 +417,11 @@ class DepthwiseConv2dNativeOp : public BinaryOp<T> {
     OP_REQUIRES_OK(context, GetWindowedOutputSizeVerbose(
                                 input_cols, filter_cols, stride_, padding_,
                                 &out_cols, &pad_left, &pad_right));
-    TensorShape out_shape =
-        ShapeFromFormat(data_format_, batch, out_rows, out_cols, out_depth);
+    TensorShape out_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            data_format_, batch, out_rows, out_cols, out_depth, &out_shape));
     OP_REQUIRES(
         context,
         (!std::is_same<Device, GPUDevice>::value ||

--- a/tensorflow/core/kernels/fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cc
@@ -1335,8 +1335,11 @@ class FusedBatchNormOpBase : public OpKernel {
       int64_t in_rows = GetTensorDim(x, tensor_format_, '1');
       int64_t in_cols = GetTensorDim(x, tensor_format_, '2');
       const int64_t in_depth = GetTensorDim(x, tensor_format_, 'C');
-      dest_shape = ShapeFromFormat(tensor_format_, in_batch,
-                                   {{in_planes, in_rows * in_cols}}, in_depth);
+      OP_REQUIRES_OK(
+          context,
+          ShapeFromFormatWithStatus(tensor_format_, in_batch,
+                                   {{in_planes, in_rows * in_cols}}, in_depth,
+                                   &dest_shape));
       OP_REQUIRES(context, x.CopyFrom(x, dest_shape),
                   errors::InvalidArgument("Error during tensor copy."));
     }
@@ -1580,8 +1583,11 @@ class FusedBatchNormGradOpBase : public OpKernel {
       int64_t in_rows = GetTensorDim(x, tensor_format_, '1');
       int64_t in_cols = GetTensorDim(x, tensor_format_, '2');
       const int64_t in_depth = GetTensorDim(x, tensor_format_, 'C');
-      dest_shape = ShapeFromFormat(tensor_format_, in_batch,
-                                   {{in_planes, in_rows * in_cols}}, in_depth);
+      OP_REQUIRES_OK(
+          context,
+          ShapeFromFormatWithStatus(
+              tensor_format_, in_batch,
+              {{in_planes, in_rows * in_cols}}, in_depth, &dest_shape));
       OP_REQUIRES(context, x.CopyFrom(x, dest_shape),
                   errors::InvalidArgument("Error during tensor copy."));
       OP_REQUIRES(context, y_backprop.CopyFrom(y_backprop, dest_shape),

--- a/tensorflow/core/kernels/lrn_op.cc
+++ b/tensorflow/core/kernels/lrn_op.cc
@@ -237,20 +237,31 @@ struct LaunchLRN<GPUDevice, T> {
     const int depth = static_cast<int>(in.dim_size(3));
 
     Tensor transformed_input;
+    TensorShape transformed_input_shape;
+    OP_REQUIRES_OK(context,
+                   ShapeFromFormatWithStatus(
+                       FORMAT_NCHW, in.shape(), FORMAT_NHWC,
+                       &transformed_input_shape));
     OP_REQUIRES_OK(context,
                    context->allocate_temp(
                        DataTypeToEnum<T>::value,
-                       ShapeFromFormat(FORMAT_NCHW, in.shape(), FORMAT_NHWC),
+                       transformed_input_shape,
                        &transformed_input));
     functor::NHWCToNCHW<GPUDevice, T, 4>()(context->eigen_device<GPUDevice>(),
                                            in.tensor<T, 4>(),
                                            transformed_input.tensor<T, 4>());
 
     Tensor transformed_output;
+    TensorShape transformed_output_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            FORMAT_NCHW, output->shape(), FORMAT_NHWC,
+            &transformed_output_shape));
     OP_REQUIRES_OK(
         context, context->allocate_temp(
                      DataTypeToEnum<T>::value,
-                     ShapeFromFormat(FORMAT_NCHW, output->shape(), FORMAT_NHWC),
+                     transformed_output_shape,
                      &transformed_output));
 
     perftools::gputools::dnn::BatchDescriptor dimensions_desc;
@@ -531,40 +542,61 @@ struct LaunchLRNGrad<GPUDevice, T> {
     const int64 depth = in_grads.dim_size(3);
 
     Tensor transformed_in_grads;
+    TensorShape transformed_in_grads_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            FORMAT_NCHW, in_grads.shape(),
+            FORMAT_NHWC, &transformed_in_grads_shape));
     OP_REQUIRES_OK(context, context->allocate_temp(
                                 DataTypeToEnum<T>::value,
-                                ShapeFromFormat(FORMAT_NCHW, in_grads.shape(),
-                                                FORMAT_NHWC),
+                                transformed_in_grads_shape,
                                 &transformed_in_grads));
     functor::NHWCToNCHW<GPUDevice, T, 4>()(context->eigen_device<GPUDevice>(),
                                            in_grads.tensor<T, 4>(),
                                            transformed_in_grads.tensor<T, 4>());
 
     Tensor transformed_in_image;
+    TensorShape transformed_in_image_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            FORMAT_NCHW, in_image.shape(),
+            FORMAT_NHWC, &transformed_in_image_shape));
     OP_REQUIRES_OK(context, context->allocate_temp(
                                 DataTypeToEnum<T>::value,
-                                ShapeFromFormat(FORMAT_NCHW, in_image.shape(),
-                                                FORMAT_NHWC),
+                                transformed_in_image_shape,
                                 &transformed_in_image));
     functor::NHWCToNCHW<GPUDevice, T, 4>()(context->eigen_device<GPUDevice>(),
                                            in_image.tensor<T, 4>(),
                                            transformed_in_image.tensor<T, 4>());
 
     Tensor transformed_out_image;
+    TensorShape transformed_out_image_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            FORMAT_NCHW, out_image.shape(),
+            FORMAT_NHWC, &transformed_out_image_shape));
     OP_REQUIRES_OK(context, context->allocate_temp(
                                 DataTypeToEnum<T>::value,
-                                ShapeFromFormat(FORMAT_NCHW, out_image.shape(),
-                                                FORMAT_NHWC),
+                                transformed_out_image_shape,
                                 &transformed_out_image));
     functor::NHWCToNCHW<GPUDevice, T, 4>()(
         context->eigen_device<GPUDevice>(), out_image.tensor<T, 4>(),
         transformed_out_image.tensor<T, 4>());
 
     Tensor transformed_output;
+    TensorShape transformed_output_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            FORMAT_NCHW, output->shape(),
+            FORMAT_NHWC, &transformed_output_shape));
     OP_REQUIRES_OK(
         context, context->allocate_temp(
                      DataTypeToEnum<T>::value,
-                     ShapeFromFormat(FORMAT_NCHW, output->shape(), FORMAT_NHWC),
+                     transformed_output_shape,
                      &transformed_output));
 
     perftools::gputools::dnn::BatchDescriptor dimensions_desc;

--- a/tensorflow/core/kernels/maxpooling_op.cc
+++ b/tensorflow/core/kernels/maxpooling_op.cc
@@ -1274,9 +1274,12 @@ class MaxPoolingNoMaskOp<GPUDevice, T> : public OpKernel {
       return;
     }
 
-    TensorShape out_shape =
-        ShapeFromFormat(data_format_, params.tensor_in_batch, params.out_height,
-                        params.out_width, params.depth);
+    TensorShape out_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            data_format_, params.tensor_in_batch, params.out_height,
+            params.out_width, params.depth, &out_shape));
 
     // Degenerate pooling output should return an empty tensor.
     if (out_shape.num_elements() == 0) {
@@ -1409,9 +1412,12 @@ class MaxPoolingNoMaskV2Op<GPUDevice, T> : public OpKernel {
       return;
     }
 
-    TensorShape out_shape =
-        ShapeFromFormat(data_format_, params.tensor_in_batch, params.out_height,
-                        params.out_width, params.depth);
+    TensorShape out_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            data_format_, params.tensor_in_batch, params.out_height,
+            params.out_width, params.depth, &out_shape));
     if (data_format_ == FORMAT_NCHW) {
       DnnPoolingOp<T>::Compute(context, se::dnn::PoolingMode::kMaximum, ksize,
                                stride, padding_, explicit_paddings_,

--- a/tensorflow/core/kernels/maxpooling_op.cc
+++ b/tensorflow/core/kernels/maxpooling_op.cc
@@ -770,9 +770,11 @@ class MaxPoolingGradGradOp<Eigen::GpuDevice, T> : public OpKernel {
     if (!context->status().ok()) {
       return;
     }
-    OP_REQUIRES(context, tensor_out.shape() == params.forward_output_shape(),
+    TensorShape params_forward_output_shape;
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
+    OP_REQUIRES(context, tensor_out.shape() == params_forward_output_shape,
                 errors::InvalidArgument("Expected orig_output shape to be ",
-                                        params.forward_output_shape(),
+                                        params_forward_output_shape,
                                         ", but got ", tensor_out.shape()));
     OP_REQUIRES(
         context, out_grad_backprop.shape() == tensor_in.shape(),

--- a/tensorflow/core/kernels/maxpooling_op.cc
+++ b/tensorflow/core/kernels/maxpooling_op.cc
@@ -325,13 +325,16 @@ class MaxPoolingGradOp : public OpKernel {
     if (!context->status().ok()) {
       return;
     }
-    OP_REQUIRES(context, tensor_out.shape() == params.forward_output_shape(),
+    TensorShape params_forward_output_shape;
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
+    OP_REQUIRES(context, tensor_out.shape() == params_forward_output_shape,
                 errors::InvalidArgument("Expected orig_output shape to be ",
-                                        params.forward_output_shape(),
+                                        params_forward_output_shape,
                                         ", but got ", tensor_out.shape()));
-    OP_REQUIRES(context, out_backprop.shape() == params.forward_output_shape(),
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
+    OP_REQUIRES(context, out_backprop.shape() == params_forward_output_shape,
                 errors::InvalidArgument("Expected grad shape to be ",
-                                        params.forward_output_shape(),
+                                        params_forward_output_shape,
                                         ", but got ", out_backprop.shape()));
 
     Tensor* output = nullptr;
@@ -549,9 +552,11 @@ class MaxPoolingGradGradOp : public OpKernel {
     if (!context->status().ok()) {
       return;
     }
-    OP_REQUIRES(context, tensor_out.shape() == params.forward_output_shape(),
+    TensorShape params_forward_output_shape;
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
+    OP_REQUIRES(context, tensor_out.shape() == params_forward_output_shape,
                 errors::InvalidArgument("Expected orig_output shape to be ",
-                                        params.forward_output_shape(),
+                                        params_forward_output_shape,
                                         ", but got ", tensor_out.shape()));
     OP_REQUIRES(
         context, out_grad_backprop.shape() == tensor_in.shape(),
@@ -1127,13 +1132,16 @@ class MaxPoolingGradWithArgmaxOp : public OpKernel {
     if (!context->status().ok()) {
       return;
     }
-    OP_REQUIRES(context, grad_in.shape() == params.forward_output_shape(),
+    TensorShape params_forward_output_shape;
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
+    OP_REQUIRES(context, grad_in.shape() == params_forward_output_shape,
                 errors::InvalidArgument("Expected grad shape to be ",
-                                        params.forward_output_shape(),
+                                        params_forward_output_shape,
                                         ", but got ", grad_in.shape()));
-    OP_REQUIRES(context, argmax.shape() == params.forward_output_shape(),
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
+    OP_REQUIRES(context, argmax.shape() == params_forward_output_shape,
                 errors::InvalidArgument("Expected argmax shape to be ",
-                                        params.forward_output_shape(),
+                                        params_forward_output_shape,
                                         ", but got ", argmax.shape()));
 
     TensorShape out_shape({params.tensor_in_batch, params.tensor_in_rows,
@@ -1199,9 +1207,11 @@ class MaxPoolingGradGradWithArgmaxOp : public OpKernel {
         context, grad_in.shape() == tensor_in.shape(),
         errors::InvalidArgument("Expected grad shape to be ", tensor_in.shape(),
                                 ", but got ", grad_in.shape()));
-    OP_REQUIRES(context, argmax.shape() == params.forward_output_shape(),
+    TensorShape params_forward_output_shape;
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
+    OP_REQUIRES(context, argmax.shape() == params_forward_output_shape,
                 errors::InvalidArgument("Expected argmax shape to be ",
-                                        params.forward_output_shape(),
+                                        params_forward_output_shape,
                                         ", but got ", argmax.shape()));
 
     TensorShape out_shape({params.tensor_in_batch, params.out_height,

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.h
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.h
@@ -494,12 +494,20 @@ class MklDnnConvUtil {
     //     Conv2D: NHWC or NCHW
     //     Conv3D: NDHWC or NCDHW
     // oneDNN uses asymmetric padding.
-    TensorShape out_shape =
-        is_conv2d
-            ? ShapeFromFormat(data_format_, out_batch, out_rows, out_cols,
-                              out_depth)
-            : ShapeFromFormat(data_format_, out_batch,
-                              {{out_planes, out_rows, out_cols}}, out_depth);
+    TensorShape out_shape;
+    if (is_conv2d) {
+      OP_REQUIRES_OK(
+          context_,
+          ShapeFromFormatWithStatus(
+              data_format_, out_batch, out_rows, out_cols,
+              out_depth, &out_shape));
+    } else {
+      OP_REQUIRES_OK(
+          context_,
+          ShapeFromFormatWithStatus(
+              data_format_, out_batch,
+              {{out_planes, out_rows, out_cols}}, out_depth, &out_shape));
+    }
     *output_dims_tf_order = TFShapeToMklDnnDims(out_shape);
     if (is_grouped_convolution) {
       int out_depth = GetTensorDim(out_shape, data_format_, 'C');

--- a/tensorflow/core/kernels/pooling_ops_3d.cc
+++ b/tensorflow/core/kernels/pooling_ops_3d.cc
@@ -87,9 +87,9 @@ Pool3dParameters::Pool3dParameters(OpKernelContext* context,
                                        padding, &out_width, &pad_cols));
 }
 
-TensorShape Pool3dParameters::forward_output_shape() {
-  return ShapeFromFormat(data_format, tensor_in_batch,
-                         {{out_plane, out_height, out_width}}, depth);
+Status Pool3dParameters::forward_output_shape(TensorShape *shape) {
+  return ShapeFromFormatWithStatus(data_format, tensor_in_batch,
+                                   {{out_plane, out_height, out_width}}, depth, shape);
 }
 
 template <typename T>
@@ -187,8 +187,11 @@ class Pooling3DOp : public UnaryOp<T> {
     OP_REQUIRES_OK(context, Get3dOutputSize(input_size, window, stride,
                                             padding_, &out, &padding));
 
-    TensorShape out_shape = ShapeFromFormat(data_format_, in_batch,
-                                            {{out[2], out[1], out[0]}}, depth);
+    TensorShape out_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(data_format_, in_batch,
+                                  {{out[2], out[1], out[0]}}, depth, &out_shape));
     Tensor* output;
     OP_REQUIRES_OK(context, context->allocate_output(0, out_shape, &output));
     if (out_shape.num_elements() == 0) return;
@@ -365,8 +368,12 @@ class MaxPooling3dGradOp : public OpKernel {
 
     const int64_t depth = GetTensorDim(tensor_in, data_format_, 'C');
     const int64_t in_batch = GetTensorDim(tensor_in, data_format_, 'N');
-    TensorShape out_shape = ShapeFromFormat(data_format_, in_batch,
-                                            {{out[2], out[1], out[0]}}, depth);
+    TensorShape out_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            data_format_, in_batch,
+            {{out[2], out[1], out[0]}}, depth, &out_shape));
     OP_REQUIRES(
         context, tensor_out.shape() == out_shape,
         errors::InvalidArgument("Expected orig_output shape to be ", out_shape,
@@ -717,9 +724,11 @@ class MaxPooling3dGradGradOp : public OpKernel {
     Pool3dParameters params{context,  ksize_,       stride_,
                             padding_, data_format_, tensor_in.shape()};
     if (!context->status().ok()) return;  // params is invalid
-    OP_REQUIRES(context, tensor_out.shape() == params.forward_output_shape(),
+    TensorShape params_forward_output_shape;
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
+    OP_REQUIRES(context, tensor_out.shape() == params_forward_output_shape,
                 errors::InvalidArgument("Expected orig_output shape to be ",
-                                        params.forward_output_shape(),
+                                        params_forward_output_shape,
                                         ", but got ", tensor_out.shape()));
     OP_REQUIRES(
         context, out_grad_backprop.shape() == tensor_in.shape(),

--- a/tensorflow/core/kernels/pooling_ops_3d.h
+++ b/tensorflow/core/kernels/pooling_ops_3d.h
@@ -45,7 +45,7 @@ struct Pool3dParameters {
                    const TensorShape& tensor_in_shape);
 
   // Returns the shape of the output for "forward" pooling operations.
-  TensorShape forward_output_shape();
+  Status forward_output_shape(TensorShape *shape);
 
   int depth;
 

--- a/tensorflow/core/kernels/pooling_ops_common.cc
+++ b/tensorflow/core/kernels/pooling_ops_common.cc
@@ -209,7 +209,7 @@ Status PoolParameters::forward_output_shape(TensorShape *shape) {
     *shape = TensorShape(
         {tensor_in_batch, tensor_in_rows, tensor_in_cols, out_depth});
   }
-  return Status::OK();
+  return OkStatus();
 }
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/pooling_ops_common.cc
+++ b/tensorflow/core/kernels/pooling_ops_common.cc
@@ -465,17 +465,17 @@ void DnnPoolingGradOp<T>::Compute(
   }
   if (tensor_out) {
     TensorShape params_forward_output_shape;
-    OP_REQUIRES(context, params.forward_output_shape(&params_forward_output_shape));
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
     OP_REQUIRES(context, tensor_out->shape() == params_forward_output_shape,
                 errors::InvalidArgument("Expected orig_output shape to be ",
-                                        params.forward_output_shape(),
+                                        params_forward_output_shape,
                                         ", but got ", tensor_out->shape()));
   }
   TensorShape params_forward_output_shape;
-  OP_REQUIRES(context, params.forward_output_shape(&params_forward_output_shape));
+  OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
   OP_REQUIRES(context, out_backprop.shape() == params_forward_output_shape,
               errors::InvalidArgument("Expected grad shape to be ",
-                                      params.forward_output_shape(),
+                                      params_forward_output_shape,
                                       ", but got ", out_backprop.shape()));
 
   TensorFormat transformed_input_data_format = data_format;

--- a/tensorflow/core/kernels/pooling_ops_common.h
+++ b/tensorflow/core/kernels/pooling_ops_common.h
@@ -53,7 +53,7 @@ struct PoolParameters {
                  TensorFormat data_format, const TensorShape& tensor_in_shape);
 
   // Returns the shape of the output for "forward" pooling operations.
-  TensorShape forward_output_shape();
+  Status forward_output_shape(TensorShape *shape);
 
   int depth;
 
@@ -136,8 +136,10 @@ class MaxPoolingOp : public OpKernel {
     }
 
     Tensor* output = nullptr;
+    TensorShape params_forward_output_shape;
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
     OP_REQUIRES_OK(context, context->allocate_output(
-                                0, params.forward_output_shape(), &output));
+                                0, params_forward_output_shape, &output));
 
     if (params.depth_window > 1) {
       // Validate spec against the current implementation.  A
@@ -405,8 +407,10 @@ class MaxPoolingV2Op : public OpKernel {
     }
 
     Tensor* output = nullptr;
+    TensorShape params_forward_output_shape;
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
     OP_REQUIRES_OK(context, context->allocate_output(
-                                0, params.forward_output_shape(), &output));
+                                0, params_forward_output_shape, &output));
 
     if (params.depth_window > 1) {
       // Validate spec against the current implementation.  A

--- a/tensorflow/core/kernels/quantized_pooling_ops.cc
+++ b/tensorflow/core/kernels/quantized_pooling_ops.cc
@@ -90,14 +90,17 @@ class QuantizedAvgPoolingOp : public OpKernel {
                 errors::InvalidArgument("tensor_in must be 4-dimensional"));
 
     Tensor* output = nullptr;
+    TensorShape params_forward_output_shape;
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
     OP_REQUIRES_OK(context, context->allocate_output(
-                                0, params.forward_output_shape(), &output));
+                                0, params_forward_output_shape, &output));
     const int32_t highest = static_cast<int32>(Eigen::NumTraits<T>::highest());
     const int32_t lowest = static_cast<int32>(Eigen::NumTraits<T>::lowest());
 
     // TODO(vrv): Switch this to the Eigen::Tensor version of
     // SpatialAvgPooling once that version is running quickly.
-    Tensor int32_output(DT_INT32, params.forward_output_shape());
+    OP_REQUIRES_OK(context, params.forward_output_shape(&params_forward_output_shape));
+    Tensor int32_output(DT_INT32, params_forward_output_shape);
     // Cast input to int32 tensor and call SpatialAvgPool.
     Tensor int32_input(DT_INT32, tensor_in.shape());
     int32_input.flat<int32>() = tensor_in.flat<T>().template cast<int32>();

--- a/tensorflow/core/kernels/spacetodepth_op.cc
+++ b/tensorflow/core/kernels/spacetodepth_op.cc
@@ -119,11 +119,16 @@ class SpaceToDepthOp : public OpKernel {
 
     // Allocate output tensor.
     Tensor* outputs_tensor = nullptr;
+    TensorShape outputs_tensor_shape;
+    OP_REQUIRES_OK(
+        context,
+        ShapeFromFormatWithStatus(
+            data_format_, batch_size, output_height,
+            output_width, output_depth, &outputs_tensor_shape));
     OP_REQUIRES_OK(context,
                    context->allocate_output(
                        0,
-                       ShapeFromFormat(data_format_, batch_size, output_height,
-                                       output_width, output_depth),
+                       outputs_tensor_shape,
                        &outputs_tensor));
 
     if (std::is_same<Device, GPUDevice>::value) {

--- a/tensorflow/core/util/tensor_format.h
+++ b/tensorflow/core/util/tensor_format.h
@@ -519,9 +519,9 @@ std::string GetConvnetDataFormat2D3DAttrString();
 // FORMAT_NCHW:        (N, C, spatial); rank = spatial.size() + 2
 // FORMAT_NCHW_VECT_C: (N, C, spatial, InnerC); rank = spatial.size() + 3
 // FORMAT_NHWC_VECT_W: (N, spatial, C, InnerW); rank = spatial.size() + 3
-inline TensorShape ShapeFromFormat(TensorFormat format, int64_t N,
-                                   gtl::ArraySlice<int64_t> spatial,
-                                   int64_t C) {
+inline Status ShapeFromFormatWithStatus(TensorFormat format, int64_t N,
+                                        gtl::ArraySlice<int64_t> spatial,
+                                        int64_t C, TensorShape *shape) {
   const int dims = GetTensorDimsFromSpatialDims(spatial.size(), format);
   gtl::InlinedVector<int64_t, 6> dim_sizes(dims);
   dim_sizes[GetTensorBatchDimIndex(dims, format)] = N;
@@ -546,7 +546,16 @@ inline TensorShape ShapeFromFormat(TensorFormat format, int64_t N,
     dim_sizes[GetTensorInnerFeatureDimIndex(dims, format)] = 4;
   }
   dim_sizes[feature_index] = C;
-  return TensorShape(dim_sizes);
+  return TensorShapeUtils::MakeShape(dim_sizes, shape);
+}
+
+inline TensorShape ShapeFromFormat(TensorFormat format, int64_t N,
+                                   gtl::ArraySlice<int64_t> spatial,
+                                   int64_t C) {
+  TensorShape shape;
+  Status status = ShapeFromFormatWithStatus(format, N, spatial, C, &shape);
+  CHECK(status.ok());
+  return shape;
 }
 
 // Return a tensor shape of the specified 'format', and dimensions.
@@ -574,9 +583,17 @@ inline TensorShape ShapeFromFilterTensorFormat(FilterTensorFormat format,
 }
 
 // Return a tensor shape of the specified 'format', and dimensions.
+inline Status ShapeFromFormatWithStatus(TensorFormat format, int64_t N, int64_t H,
+                                         int64_t W, int64_t C, TensorShape *shape) {
+  return ShapeFromFormatWithStatus(format, N, {H, W}, C, shape);
+}
+
 inline TensorShape ShapeFromFormat(TensorFormat format, int64_t N, int64_t H,
                                    int64_t W, int64_t C) {
-  return ShapeFromFormat(format, N, {H, W}, C);
+  TensorShape shape;
+  Status status = ShapeFromFormatWithStatus(format, N, H, W, C, &shape);
+  CHECK(status.ok());
+  return shape;
 }
 
 // Return a filter tensor shape of the specified 'format', and dimensions.

--- a/tensorflow/core/util/tensor_format.h
+++ b/tensorflow/core/util/tensor_format.h
@@ -605,11 +605,13 @@ inline TensorShape ShapeFromFilterTensorFormat(FilterTensorFormat format,
 
 // Returns a copy of the specified tensor 'src_shape' converted from
 // 'src_format' to 'dst_format'.
-inline TensorShape ShapeFromFormat(TensorFormat dst_format,
-                                   const TensorShape& src_shape,
-                                   TensorFormat src_format) {
+inline Status ShapeFromFormatWithStatus(TensorFormat dst_format,
+                                        const TensorShape& src_shape,
+                                        TensorFormat src_format,
+                                        TensorShape *shape) {
   if (src_format == dst_format) {
-    return src_shape;
+    *shape = src_shape;
+    return Status::OK();
   }
 
   const int64_t batch = GetTensorDim(src_shape, src_format, 'N');
@@ -626,7 +628,16 @@ inline TensorShape ShapeFromFormat(TensorFormat dst_format,
   if (src_format == FORMAT_NHWC_VECT_W) {
     spatial_dims[num_src_spatial_dims - 1] *= 4;
   }
-  return ShapeFromFormat(dst_format, batch, {spatial_dims}, channels);
+  return ShapeFromFormatWithStatus(dst_format, batch, {spatial_dims}, channels, shape);
+}
+
+inline TensorShape ShapeFromFormat(TensorFormat dst_format,
+                                   const TensorShape& src_shape,
+                                   TensorFormat src_format) {
+  TensorShape shape;
+  Status status = ShapeFromFormatWithStatus(dst_format, src_shape, src_format, &shape);
+  CHECK(status.ok());
+  return shape;
 }
 
 // Returns a copy of the specified filter tensor 'src_shape' converted from

--- a/tensorflow/core/util/tensor_format.h
+++ b/tensorflow/core/util/tensor_format.h
@@ -549,15 +549,6 @@ inline Status ShapeFromFormatWithStatus(TensorFormat format, int64_t N,
   return TensorShapeUtils::MakeShape(dim_sizes, shape);
 }
 
-inline TensorShape ShapeFromFormat(TensorFormat format, int64_t N,
-                                   gtl::ArraySlice<int64_t> spatial,
-                                   int64_t C) {
-  TensorShape shape;
-  Status status = ShapeFromFormatWithStatus(format, N, spatial, C, &shape);
-  CHECK(status.ok());
-  return shape;
-}
-
 // Return a tensor shape of the specified 'format', and dimensions.
 // Works for both 2D and 3D operations. If 'format' is OIHW_VECT_I,
 // the output TensorShape has spatial.size() + 3 dimensions, otherwise
@@ -586,14 +577,6 @@ inline TensorShape ShapeFromFilterTensorFormat(FilterTensorFormat format,
 inline Status ShapeFromFormatWithStatus(TensorFormat format, int64_t N, int64_t H,
                                          int64_t W, int64_t C, TensorShape *shape) {
   return ShapeFromFormatWithStatus(format, N, {H, W}, C, shape);
-}
-
-inline TensorShape ShapeFromFormat(TensorFormat format, int64_t N, int64_t H,
-                                   int64_t W, int64_t C) {
-  TensorShape shape;
-  Status status = ShapeFromFormatWithStatus(format, N, H, W, C, &shape);
-  CHECK(status.ok());
-  return shape;
 }
 
 // Return a filter tensor shape of the specified 'format', and dimensions.
@@ -629,15 +612,6 @@ inline Status ShapeFromFormatWithStatus(TensorFormat dst_format,
     spatial_dims[num_src_spatial_dims - 1] *= 4;
   }
   return ShapeFromFormatWithStatus(dst_format, batch, {spatial_dims}, channels, shape);
-}
-
-inline TensorShape ShapeFromFormat(TensorFormat dst_format,
-                                   const TensorShape& src_shape,
-                                   TensorFormat src_format) {
-  TensorShape shape;
-  Status status = ShapeFromFormatWithStatus(dst_format, src_shape, src_format, &shape);
-  CHECK(status.ok());
-  return shape;
 }
 
 // Returns a copy of the specified filter tensor 'src_shape' converted from

--- a/tensorflow/core/util/tensor_format.h
+++ b/tensorflow/core/util/tensor_format.h
@@ -594,7 +594,7 @@ inline Status ShapeFromFormatWithStatus(TensorFormat dst_format,
                                         TensorShape *shape) {
   if (src_format == dst_format) {
     *shape = src_shape;
-    return Status::OK();
+    return OkStatus();
   }
 
   const int64_t batch = GetTensorDim(src_shape, src_format, 'N');

--- a/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv2d_transpose_test.py
@@ -319,5 +319,15 @@ class Conv2DTransposeTest(test.TestCase):
             strides=[1])
         self.evaluate(op)
 
+  def testConv2DTransposeLargeOutputShape(self):
+    with self.session():
+      with self.assertRaises((errors.InvalidArgumentError, ValueError)):
+        op = nn_ops.conv2d_transpose(
+            input=np.ones((2, 2, 2, 2)),
+            output_shape=[114078056, 179835296],
+            strides=[10],
+            filters=1)
+        self.evaluate(op)
+
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
This PR tries to address the issue in #57958 where tf.nn.conv2d_transpose will crash when output shape is invalid.

This PR adds a warpper ShapeFromFormatWithStatus (previously ShapeFromFormat) so that it is possible to return status.

Note the change can be applied to other places to address similar crashs. Will create follow up PRs to cover other places once this PR is merged.

This PR fixes #57958.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>