### PR TITLE
Fix crash of Conv2DBackpropFilter

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
@@ -388,7 +388,8 @@ class MklConvCustomBackpropFilterOp
                         "filter_sizes shape must be rank 1 but is rank ",
                         filter_tensor.shape().dims()));
       }
-      TensorShape filter_tf_shape = MakeFilterTfShape(context, filter_tensor);
+      TensorShape filter_tf_shape;
+      OP_REQUIRES_OK(context, MakeFilterTfShape(context, filter_tensor, &filter_tf_shape));
       TensorShape diff_dst_tf_shape =
           GetTfShape(context, kDiffDstIdx, native_format);
 
@@ -664,15 +665,12 @@ class MklConvCustomBackpropFilterOp
   }
 
   // Get TensorFlow shape of filter tensor.
-  TensorShape MakeFilterTfShape(OpKernelContext* context,
-                                const Tensor& filter_tensor) {
-    TensorShape filter_tf_shape;
-    CHECK_EQ(TensorShapeUtils::IsVector(filter_tensor.shape()), true);
-    CHECK_EQ(TensorShapeUtils::MakeShape(filter_tensor.vec<int32>(),
-                                         &filter_tf_shape)
-                 .ok(),
-             true);
-    return filter_tf_shape;
+  Status MakeFilterTfShape(OpKernelContext* context,
+                           const Tensor& filter_tensor, TensorShape *filter_tf_shape) {
+    if (!TensorShapeUtils::IsVector(filter_tensor.shape())) {
+        return errors::InvalidArgument("filter_tensor must be a vecotr, got ", filter_tensor.shape());
+    }
+    return TensorShapeUtils::MakeShape(filter_tensor.vec<int32>(), filter_tf_shape);
   }
 
   // Get Tensorflow shape of output tensor (diff_filter),


### PR DESCRIPTION
This PR tries to address the issue raised in #57980 where Conv2DBackpropFilter (MKL) will crash in certain situations.

This PR fixes #57980.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>