### PR TITLE
Various Google C++ style guide fixes

### DIFF
--- a/tensorflow/cc/client/client_session_test.cc
+++ b/tensorflow/cc/client/client_session_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include "tensorflow/cc/client/client_session.h"
 
 #include <vector>
+#include <utility>
 
 #include "absl/synchronization/barrier.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"

--- a/tensorflow/cc/framework/cc_op_gen.cc
+++ b/tensorflow/cc/framework/cc_op_gen.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/cc/framework/cc_op_gen.h"
 
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/tensorflow/cc/framework/cc_op_gen.h
+++ b/tensorflow/cc/framework/cc_op_gen.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_CC_FRAMEWORK_CC_OP_GEN_H_
 #define TENSORFLOW_CC_FRAMEWORK_CC_OP_GEN_H_
 
+#include <string>
+
 #include "tensorflow/core/framework/op_def.pb.h"
 #include "tensorflow/core/framework/op_gen_lib.h"
 #include "tensorflow/core/platform/types.h"

--- a/tensorflow/cc/framework/cc_op_gen_util.h
+++ b/tensorflow/cc/framework/cc_op_gen_util.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef TENSORFLOW_CC_FRAMEWORK_CC_OP_GEN_UTIL_H_
 #define TENSORFLOW_CC_FRAMEWORK_CC_OP_GEN_UTIL_H_
 
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/tensorflow/cc/framework/grad_op_registry.h
+++ b/tensorflow/cc/framework/grad_op_registry.h
@@ -16,7 +16,9 @@ limitations under the License.
 #ifndef TENSORFLOW_CC_FRAMEWORK_GRAD_OP_REGISTRY_H_
 #define TENSORFLOW_CC_FRAMEWORK_GRAD_OP_REGISTRY_H_
 
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"

--- a/tensorflow/cc/framework/gradient_checker.cc
+++ b/tensorflow/cc/framework/gradient_checker.cc
@@ -15,6 +15,9 @@ limitations under the License.
 
 #include "tensorflow/cc/framework/gradient_checker.h"
 
+#include <utility>
+#include <algorithm>
+
 #include "tensorflow/cc/client/client_session.h"
 #include "tensorflow/cc/framework/gradients.h"
 #include "tensorflow/cc/ops/standard_ops.h"

--- a/tensorflow/cc/framework/gradient_checker.h
+++ b/tensorflow/cc/framework/gradient_checker.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_CC_FRAMEWORK_GRADIENT_CHECKER_H_
 #define TENSORFLOW_CC_FRAMEWORK_GRADIENT_CHECKER_H_
 
+#include <vector>
+
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 #include "tensorflow/core/framework/tensor.h"

--- a/tensorflow/cc/framework/gradients.cc
+++ b/tensorflow/cc/framework/gradients.cc
@@ -16,6 +16,11 @@ limitations under the License.
 #include "tensorflow/cc/framework/gradients.h"
 
 #include <deque>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "tensorflow/cc/framework/grad_op_registry.h"
@@ -35,9 +40,7 @@ namespace tensorflow {
 namespace {
 
 struct OutputHash {
-  uint64 operator()(const Output& x) const {
-    return x.hash();
-  }
+  uint64 operator()(const Output& x) const { return x.hash(); }
 };
 
 struct OutputEq {
@@ -343,8 +346,8 @@ Status SymbolicGradientBuilder::Initialize() {
 Status SymbolicGradientBuilder::SumGradients(const Output& src, Output* grad) {
   auto iter = backprops_.find(src);
   if (iter == backprops_.end()) {
-    return errors::Internal(
-        "Unable to find backprop list for node.id ", src.node()->name());
+    return errors::Internal("Unable to find backprop list for node.id ",
+                            src.node()->name());
   }
   const auto& grads = iter->second;
   // Filter any backpropped 'NoGradient' Outputs from 'grads' (if needed).
@@ -378,8 +381,7 @@ bool SymbolicGradientBuilder::IsPrimitiveOpWithNoGrad(const string& opname) {
 }
 
 Status SymbolicGradientBuilder::CallGradFunction(
-    const Operation& op,
-    const std::vector<Output>& grad_inputs,
+    const Operation& op, const std::vector<Output>& grad_inputs,
     std::vector<Output>* grad_outputs) {
   ops::GradFunc grad_fn;
   TF_RETURN_IF_ERROR(registry_->Lookup(op.node()->type_string(), &grad_fn));
@@ -526,8 +528,8 @@ Status SymbolicGradientBuilder::AddGradients() {
       if (e->IsControlEdge()) continue;
       size_t dx_index = e->dst_input();
       if (dx_index >= dx.size()) {
-        return errors::Internal(
-            "Invalid gradient output index: ", dx_index, " size: ", dx.size());
+        return errors::Internal("Invalid gradient output index: ", dx_index,
+                                " size: ", dx.size());
       }
       TF_RETURN_IF_ERROR(
           BackpropAlongEdge(dx[dx_index], {e->src(), e->src_output()}));

--- a/tensorflow/cc/framework/gradients.h
+++ b/tensorflow/cc/framework/gradients.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_CC_FRAMEWORK_GRADIENTS_H_
 #define TENSORFLOW_CC_FRAMEWORK_GRADIENTS_H_
 
+#include <vector>
+
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 

--- a/tensorflow/cc/framework/ops.h
+++ b/tensorflow/cc/framework/ops.h
@@ -17,6 +17,9 @@ limitations under the License.
 #define TENSORFLOW_CC_FRAMEWORK_OPS_H_
 
 #include <type_traits>
+#include <utility>
+#include <string>
+#include <vector>
 
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor.pb.h"

--- a/tensorflow/cc/framework/scope_internal.h
+++ b/tensorflow/cc/framework/scope_internal.h
@@ -16,6 +16,12 @@ limitations under the License.
 #ifndef TENSORFLOW_CC_FRAMEWORK_SCOPE_INTERNAL_H_
 #define TENSORFLOW_CC_FRAMEWORK_SCOPE_INTERNAL_H_
 
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
 #include "tensorflow/cc/framework/scope.h"
 
 namespace tensorflow {

--- a/tensorflow/cc/framework/testutil.h
+++ b/tensorflow/cc/framework/testutil.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_CC_FRAMEWORK_TESTUTIL_H_
 #define TENSORFLOW_CC_FRAMEWORK_TESTUTIL_H_
 
+#include <vector>
+
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 

--- a/tensorflow/cc/framework/while_gradients.cc
+++ b/tensorflow/cc/framework/while_gradients.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "tensorflow/cc/framework/while_gradients.h"
 
+#include <string>
+
 #include "tensorflow/cc/framework/gradients.h"
 #include "tensorflow/cc/framework/scope_internal.h"
 #include "tensorflow/cc/ops/control_flow_ops_internal.h"

--- a/tensorflow/cc/framework/while_gradients.h
+++ b/tensorflow/cc/framework/while_gradients.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_CC_FRAMEWORK_WHILE_GRADIENTS_H_
 #define TENSORFLOW_CC_FRAMEWORK_WHILE_GRADIENTS_H_
 
+#include <vector>
+
 #include "tensorflow/cc/framework/ops.h"
 #include "tensorflow/cc/framework/scope.h"
 #include "tensorflow/core/graph/while_context.h"


### PR DESCRIPTION
I want to contribute to this wonderful project and picked up some low hanging fruit in the C++ section.
I found some inconsistencies with the style guide on some files, and therefore submitted this PR.

Specifically, I have edited some files so that they comply to the "include what you use" rule (https://google.github.io/styleguide/cppguide.html#Include_What_You_Use) from the style guide.