### PR TITLE
[oneDNN] Enable fusion of Elu and Swish activation into Quantized Convolution

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -518,6 +518,7 @@ class MklConvFwdPrimitiveFactory : public MklPrimitiveFactory<float> {
     for (auto const& post_op_param : convFwdDims.post_op_params) {
       key_creator.AddAsKey(post_op_param.name);
       if (post_op_param.name == "activation") {
+        key_creator.AddAsKey(post_op_param.alg);
         DCHECK_EQ(post_op_param.param.size(), 3);
         for (auto& param : post_op_param.param) {
           key_creator.AddAsKey(param);
@@ -1630,7 +1631,14 @@ class MklFusedDepthwiseConvOp
 
 // The enum below contains the list of available fused ops. We are storing
 // shifted values for each fused op in order to save bit-shift times.
-enum class oneDNNFusedOps { kBias = 1, kSum = 2, kRelu = 4, kRequantize = 8 };
+enum class oneDNNFusedOps {
+  kBias = 1,
+  kSum = 2,
+  kRelu = 4,
+  kRequantize = 8,
+  kElu = 16,
+  kFusedSwish = 32
+};
 
 template <typename Device, typename Tinput, typename Tbias, typename Toutput,
           typename Ttemp_output, bool is_depthwise, string legacy_fused_ops[],
@@ -1668,9 +1676,13 @@ class MklQuantizedConvOp
         {"Relu"},
         {"Requantize"},
         {"BiasAdd", "Relu"},
+        {"BiasAdd", "Elu"},
+        {"BiasAdd", "_FusedSwish"},
         {"BiasAdd", "Requantize"},
         {"Relu", "Requantize"},
         {"BiasAdd", "Relu", "Requantize"},
+        {"BiasAdd", "Elu", "Requantize"},
+        {"BiasAdd", "_FusedSwish", "Requantize"},
         {"BiasAdd", "Sum", "Relu"},
         {"BiasAdd", "Sum", "Relu", "Requantize"}};
 
@@ -1752,7 +1764,8 @@ class MklQuantizedConvOp
         post_op_to_idx_["output_scale"] = 0;
       } else if (fused_ops_[i] == "Sum") {
         post_op_to_idx_["sum"] = idx++;
-      } else if (fused_ops_[i] == "Relu") {
+      } else if (fused_ops_[i] == "Relu" || fused_ops_[i] == "Elu" ||
+                 fused_ops_[i] == "_FusedSwish") {
         post_op_to_idx_["activation"] = idx++;
       }
     }
@@ -2002,6 +2015,12 @@ class MklQuantizedConvOp
     if (IsFused(oneDNNFusedOps::kRelu)) {
       params.post_op_params[post_op_to_idx_["activation"]] = {
           "activation", dnnl::algorithm::eltwise_relu, {1.0, 0.0, 0.0}, ""};
+    } else if (IsFused(oneDNNFusedOps::kElu)) {
+      params.post_op_params[post_op_to_idx_["activation"]] = {
+          "activation", dnnl::algorithm::eltwise_elu, {1.0, 0.0, 0.0}, ""};
+    } else if (IsFused(oneDNNFusedOps::kFusedSwish)) {
+      params.post_op_params[post_op_to_idx_["activation"]] = {
+          "activation", dnnl::algorithm::eltwise_swish, {1.0, 1.0, 0.0}, ""};
     }
   }
 
@@ -2198,6 +2217,8 @@ class MklQuantizedConvOp
       {"BiasAdd", oneDNNFusedOps::kBias},
       {"Sum", oneDNNFusedOps::kSum},
       {"Relu", oneDNNFusedOps::kRelu},
+      {"Elu", oneDNNFusedOps::kElu},
+      {"_FusedSwish", oneDNNFusedOps::kFusedSwish},
       {"Requantize", oneDNNFusedOps::kRequantize}};
   std::shared_ptr<dnnl::memory> summand_;
   std::shared_ptr<dnnl::memory> dst_;

--- a/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
@@ -828,6 +828,13 @@ class QuantizedConvTest : public OpsTestBase {
       if (fused_ops[i] == "Relu") {
         last_op = "with_relu";
         out_op = ops::Relu(root.WithOpName(last_op), out_op);
+      } else if (fused_ops[i] == "Elu") {
+        last_op = "with_elu";
+        out_op = ops::Elu(root.WithOpName(last_op), out_op);
+      } else if (fused_ops[i] == "_FusedSwish") {
+        last_op = "with_swish";
+        auto sigmoid = ops::Sigmoid(root.WithOpName("sigmoid"), out_op);
+        out_op = ops::Mul(root.WithOpName(last_op), sigmoid, out_op);
       }
     }
 
@@ -1049,6 +1056,22 @@ TEST_F(QuantizedConvTest, DWBiasAddReluRequantizeFusion) {
 TEST_F(QuantizedConvTest, DWUnsignedInputBiasAddReluRequantizeFusion) {
   // We need higher tolerance for quint8 input/output
   TestBiasAddFusion<quint8, quint8>(true, true, "Relu", 4.0);
+}
+
+TEST_F(QuantizedConvTest, BiasAddEluRequantizeFusion) {
+  TestBiasAddFusion<qint8, qint8>(true, false, "Elu");
+}
+
+TEST_F(QuantizedConvTest, DWBiasAddEluRequantizeFusion) {
+  TestBiasAddFusion<qint8, qint8>(true, true, "Elu");
+}
+
+TEST_F(QuantizedConvTest, BiasAddSwishRequantizeFusion) {
+  TestBiasAddFusion<qint8, qint8>(true, false, "_FusedSwish");
+}
+
+TEST_F(QuantizedConvTest, DWBiasAddSwishRequantizeFusion) {
+  TestBiasAddFusion<qint8, qint8>(true, true, "_FusedSwish");
 }
 
 TEST_F(QuantizedConvTest, BiasAddSumReluRequantizeFusion) {


### PR DESCRIPTION
This PR adds supports for Elu and Swish activation functions as fused ops into Quantized Convolution.