### PR TITLE
[ROCm] fixed unit test for gpu_compiler_test on ROCm

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler_test.cc
@@ -28,7 +28,7 @@ namespace op = xla::testing::opcode_matchers;
 class GpuCompilerTest : public HloTestBase {
  public:
   GpuCompilerTest()
-      : HloTestBase(PlatformUtil::GetPlatform("CUDA").value(),
+      : HloTestBase(PlatformUtil::GetDefaultPlatform().value(),
                     GetReferencePlatform()) {}
 };
 


### PR DESCRIPTION
GpuCompilerTest doesn't include ROCm platform and it will cause the uniti test failed on ROCm gpu.

/cc @cheshire