### PR TITLE
Remove empty glob

### DIFF
--- a/tensorflow/tools/docs/BUILD
+++ b/tensorflow/tools/docs/BUILD
@@ -149,7 +149,6 @@ py_library(
 py_test(
     name = "fenced_doctest_test",
     srcs = ["fenced_doctest_test.py"],
-    data = glob(["**/create_model.md"]),
     tags = [
         "no_oss",
         "no_pip",


### PR DESCRIPTION
This glob is not globbing anything.
This prevents flipping the flag incompatible_disallow_empty_glob