### PR TITLE
Count of all fused MLA ops in conv microbenchmark

### DIFF
--- a/tensorflow/core/kernels/conv_ops_benchmark_test.cc
+++ b/tensorflow/core/kernels/conv_ops_benchmark_test.cc
@@ -340,9 +340,10 @@ static Graph* FusedConv2DWithBatchNorm(
 // The following benchmarks are always using 'float' data type with NHWC layout.
 // -------------------------------------------------------------------------- //
 
-#define BM_SET_INFO(N, H, W, C, type, LABEL, NAME)                         \
+// The number of items is equal to number of fused multiply and accumlate operations
+#define BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, NAME)             \
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * (N) * \
-                          (H) * (W) * (C));                                \
+                          (H) * (W) * (FC) * (C) * (FW) * (FH));           \
   state.SetLabel(LABEL);
 
 #define BM_NAME(name, type, N, H, W, C, FW, FH, FC) \
@@ -354,11 +355,11 @@ static Graph* FusedConv2DWithBatchNorm(
     test::Benchmark(#type, Conv2D<float>(N, H, W, C, FW, FH, FC).graph, \
                     /*old_benchmark_api=*/false)                        \
         .Run(state);                                                    \
-    BM_SET_INFO(N, H, W, C, type, LABEL, Conv2D);                       \
+    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, Conv2D);           \
   }                                                                     \
   BENCHMARK(BM_NAME(BM_Conv2D, type, N, H, W, C, FW, FH, FC))           \
       ->Arg(/*unused arg*/ 1)                                           \
-      ->MeasureProcessCPUTime();
+      ->MeasureProcessCPUTime()->UseRealTime();
 
 #define BM_Conv2DWithBias(N, H, W, C, FW, FH, FC, type, LABEL)           \
   static void BM_NAME(BM_Conv2DWithBias, type, N, H, W, C, FW, FH,       \
@@ -367,11 +368,11 @@ static Graph* FusedConv2DWithBatchNorm(
                     Conv2DWithBias<float>(N, H, W, C, FW, FH, FC).graph, \
                     /*old_benchmark_api=*/false)                         \
         .Run(state);                                                     \
-    BM_SET_INFO(N, H, W, C, type, LABEL, Conv2D);                        \
+    BM_SET_INFO(N, H, W, C, FW, FH, FC, type,, Conv2D);                  \
   }                                                                      \
   BENCHMARK(BM_NAME(BM_Conv2DWithBias, type, N, H, W, C, FW, FH, FC))    \
       ->Arg(/*unused arg*/ 1)                                            \
-      ->MeasureProcessCPUTime();
+      ->MeasureProcessCPUTime()->UseRealTime();
 
 #define BM_Conv2DWithBiasAndRelu(N, H, W, C, FW, FH, FC, type, LABEL)        \
   static void BM_NAME(BM_Conv2DWithBiasAndRelu, type, N, H, W, C, FW, FH,    \
@@ -382,11 +383,11 @@ static Graph* FusedConv2DWithBatchNorm(
             .graph,                                                          \
         /*old_benchmark_api=*/false)                                         \
         .Run(state);                                                         \
-    BM_SET_INFO(N, H, W, C, type, LABEL, Conv2D);                            \
+    BM_SET_INFO(N, H, W, C, FW, FH, FC, type,, Conv2D);                      \
   }                                                                          \
   BENCHMARK(BM_NAME(BM_Conv2DWithBiasAndRelu, type, N, H, W, C, FW, FH, FC)) \
       ->Arg(/*unused arg*/ 1)                                                \
-      ->MeasureProcessCPUTime();
+      ->MeasureProcessCPUTime()->UseRealTime();
 
 #define BM_FusedConv2DWithBias(N, H, W, C, FW, FH, FC, type, LABEL)        \
   static void BM_NAME(BM_FusedConv2DWithBias, type, N, H, W, C, FW, FH,    \
@@ -396,11 +397,11 @@ static Graph* FusedConv2DWithBatchNorm(
         FusedConv2DWithBias<float>(N, H, W, C, FW, FH, FC, {"BiasAdd"}),   \
         /*old_benchmark_api=*/false)                                       \
         .Run(state);                                                       \
-    BM_SET_INFO(N, H, W, C, type, LABEL, Conv2D);                          \
+    BM_SET_INFO(N, H, W, C, FW, FH, FC, type,, Conv2D);                    \
   }                                                                        \
   BENCHMARK(BM_NAME(BM_FusedConv2DWithBias, type, N, H, W, C, FW, FH, FC)) \
       ->Arg(/*unused arg*/ 1)                                              \
-      ->MeasureProcessCPUTime();
+      ->MeasureProcessCPUTime()->UseRealTime();
 
 #define BM_FusedConv2DWithBiasAndRelu(N, H, W, C, FW, FH, FC, type, LABEL)     \
   static void BM_NAME(BM_FusedConv2DWithBiasAndRelu, type, N, H, W, C, FW, FH, \
@@ -410,12 +411,12 @@ static Graph* FusedConv2DWithBatchNorm(
                                                {"BiasAdd", "Relu"}),           \
                     /*old_benchmark_api=*/false)                               \
         .Run(state);                                                           \
-    BM_SET_INFO(N, H, W, C, type, LABEL, Conv2D);                              \
+    BM_SET_INFO(N, H, W, C, FW, FH, FC, type,, Conv2D);                        \
   }                                                                            \
   BENCHMARK(                                                                   \
       BM_NAME(BM_FusedConv2DWithBiasAndRelu, type, N, H, W, C, FW, FH, FC))    \
       ->Arg(/*unused arg*/ 1)                                                  \
-      ->MeasureProcessCPUTime();
+      ->MeasureProcessCPUTime()->UseRealTime();
 
 #define BM_Conv2DWithBatchNorm(N, H, W, C, FW, FH, FC, type, LABEL)           \
   static void BM_NAME(BM_Conv2DWithBatchNorm, type, N, H, W, C, FW, FH,       \
@@ -424,11 +425,11 @@ static Graph* FusedConv2DWithBatchNorm(
                     Conv2DWithBatchNorm<float>(N, H, W, C, FW, FH, FC).graph, \
                     /*old_benchmark_api=*/false)                              \
         .Run(state);                                                          \
-    BM_SET_INFO(N, H, W, C, type, LABEL, Conv2D);                             \
+    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, Conv2D);                 \
   }                                                                           \
   BENCHMARK(BM_NAME(BM_Conv2DWithBatchNorm, type, N, H, W, C, FW, FH, FC))    \
       ->Arg(/*unused arg*/ 1)                                                 \
-      ->MeasureProcessCPUTime();
+      ->MeasureProcessCPUTime()->UseRealTime();
 
 #define BM_Conv2DWithBatchNormAndRelu(N, H, W, C, FW, FH, FC, type, LABEL)     \
   static void BM_NAME(BM_Conv2DWithBatchNormAndRelu, type, N, H, W, C, FW, FH, \
@@ -439,12 +440,12 @@ static Graph* FusedConv2DWithBatchNorm(
                         .graph,                                                \
                     /*old_benchmark_api=*/false)                               \
         .Run(state);                                                           \
-    BM_SET_INFO(N, H, W, C, type, LABEL, Conv2D);                              \
+    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, Conv2D);                  \
   }                                                                            \
   BENCHMARK(                                                                   \
       BM_NAME(BM_Conv2DWithBatchNormAndRelu, type, N, H, W, C, FW, FH, FC))    \
       ->Arg(/*unused arg*/ 1)                                                  \
-      ->MeasureProcessCPUTime();
+      ->MeasureProcessCPUTime()->UseRealTime();
 
 #define BM_FusedConv2DWithBatchNorm(N, H, W, C, FW, FH, FC, type, LABEL)     \
   static void BM_NAME(BM_FusedConv2DWithBatchNorm, type, N, H, W, C, FW, FH, \
@@ -454,12 +455,12 @@ static Graph* FusedConv2DWithBatchNorm(
                                                     {"FusedBatchNorm"}),     \
                     /*old_benchmark_api=*/false)                             \
         .Run(state);                                                         \
-    BM_SET_INFO(N, H, W, C, type, LABEL, Conv2D);                            \
+    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, Conv2D);                \
   }                                                                          \
   BENCHMARK(                                                                 \
       BM_NAME(BM_FusedConv2DWithBatchNorm, type, N, H, W, C, FW, FH, FC))    \
       ->Arg(/*unused arg*/ 1)                                                \
-      ->MeasureProcessCPUTime();
+      ->MeasureProcessCPUTime()->UseRealTime();
 
 #define BM_FusedConv2DWithBatchNormAndRelu(N, H, W, C, FW, FH, FC, type,      \
                                            LABEL)                             \
@@ -470,12 +471,12 @@ static Graph* FusedConv2DWithBatchNorm(
                         N, H, W, C, FW, FH, FC, {"FusedBatchNorm", "Relu"}),  \
                     /*old_benchmark_api=*/false)                              \
         .Run(state);                                                          \
-    BM_SET_INFO(N, H, W, C, type, LABEL, Conv2D);                             \
+    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, Conv2D);                 \
   }                                                                           \
   BENCHMARK(BM_NAME(BM_FusedConv2DWithBatchNormAndRelu, type, N, H, W, C, FW, \
                     FH, FC))                                                  \
       ->Arg(/*unused arg*/ 1)                                                 \
-      ->MeasureProcessCPUTime();
+      ->MeasureProcessCPUTime()->UseRealTime();
 
 // -------------------------------------------------------------------------- //
 // Pixel CNN convolutions.
@@ -632,11 +633,11 @@ BM_FusedConv2DWithBiasAndRelu(32, 32, 32, 128, 3, 3, 1024, gpu, "3x3 /b 32");
                     Conv2D<T>(N, H, W, C, FW, FH, FC, FORMAT_##FORMAT).graph, \
                     /*old_benchmark_api=*/false)                              \
         .Run(state);                                                          \
-    BM_SET_INFO(N, H, W, C, type, "", Conv2D);                                \
+    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, "", Conv2D);                    \
   }                                                                           \
   BENCHMARK(BM_LONG_NAME(BM_Conv2D, type, T, FORMAT, N, H, W, C, FW, FH, FC)) \
       ->Arg(/*unused arg*/ 1)                                                 \
-      ->MeasureProcessCPUTime();
+      ->MeasureProcessCPUTime()->UseRealTime();
 
 #if GOOGLE_CUDA
 using fp32 = float;

--- a/tensorflow/core/kernels/conv_ops_benchmark_test.cc
+++ b/tensorflow/core/kernels/conv_ops_benchmark_test.cc
@@ -113,6 +113,14 @@ static Conv2DGraph Conv2D(int batch, int height, int width, int in_depth,
   return {graph, conv2d};
 }
 
+static int64_t Conv2DFlops(int64_t batch, int64_t height, int64_t width,
+                           int64_t in_depth, int64_t filter_w, int64_t filter_h,
+                           int64_t out_depth) {
+  int64_t flops =
+      2 * batch * height * width * in_depth * filter_w * filter_h * out_depth;
+  return flops;
+}
+
 // Creates a Tensorflow graph with a Conv2D node followed by BiasAdd.
 template <typename T>
 static Conv2DWithBiasGraph Conv2DWithBias(
@@ -136,6 +144,18 @@ static Conv2DWithBiasGraph Conv2DWithBias(
                   .Finalize(graph, &out));
 
   return {graph, conv2d, out};
+}
+
+static int64_t Conv2DWithPostOpsFlops(int batch, int height, int width,
+                                      int in_depth, int filter_w, int filter_h,
+                                      int out_depth, int post_ops_num) {
+  int64_t conv_flops = Conv2DFlops(batch, height, width, in_depth, filter_w,
+                                   filter_h, out_depth);
+  int64_t output_height = height - filter_h + 1;
+  int64_t output_width = width - filter_w + 1;
+  int64_t post_op_flops = batch * out_depth * output_width * output_height;
+
+  return conv_flops + post_ops_num * post_op_flops;
 }
 
 // Creates a Tensorflow graph with a Conv2D node followed by BiasAdd and
@@ -341,9 +361,8 @@ static Graph* FusedConv2DWithBatchNorm(
 // -------------------------------------------------------------------------- //
 
 // The number of items is equal to number of fused multiply and accumlate operations
-#define BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, NAME)             \
-  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * (N) * \
-                          (H) * (W) * (FC) * (C) * (FW) * (FH));           \
+#define BM_SET_INFO(FLOPS, LABEL, NAME)                                        \
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * (FLOPS)); \
   state.SetLabel(LABEL);
 
 #define BM_NAME(name, type, N, H, W, C, FW, FH, FC) \
@@ -355,11 +374,12 @@ static Graph* FusedConv2DWithBatchNorm(
     test::Benchmark(#type, Conv2D<float>(N, H, W, C, FW, FH, FC).graph, \
                     /*old_benchmark_api=*/false)                        \
         .Run(state);                                                    \
-    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, Conv2D);           \
+    int64_t flops = Conv2DFlops(N, H, W, C, FW, FH, FC);                \
+    BM_SET_INFO(flops, LABEL, Conv2D);                                  \
   }                                                                     \
   BENCHMARK(BM_NAME(BM_Conv2D, type, N, H, W, C, FW, FH, FC))           \
       ->Arg(/*unused arg*/ 1)                                           \
-      ->MeasureProcessCPUTime()->UseRealTime();
+      ->MeasureProcessCPUTime();
 
 #define BM_Conv2DWithBias(N, H, W, C, FW, FH, FC, type, LABEL)           \
   static void BM_NAME(BM_Conv2DWithBias, type, N, H, W, C, FW, FH,       \
@@ -368,11 +388,12 @@ static Graph* FusedConv2DWithBatchNorm(
                     Conv2DWithBias<float>(N, H, W, C, FW, FH, FC).graph, \
                     /*old_benchmark_api=*/false)                         \
         .Run(state);                                                     \
-    BM_SET_INFO(N, H, W, C, FW, FH, FC, type,, Conv2D);                  \
+    int64_t flops = Conv2DWithPostOpsFlops(N, H, W, C, FW, FH, FC, 1);   \
+    BM_SET_INFO(flops, LABEL, Conv2D);                                   \
   }                                                                      \
   BENCHMARK(BM_NAME(BM_Conv2DWithBias, type, N, H, W, C, FW, FH, FC))    \
       ->Arg(/*unused arg*/ 1)                                            \
-      ->MeasureProcessCPUTime()->UseRealTime();
+      ->MeasureProcessCPUTime();
 
 #define BM_Conv2DWithBiasAndRelu(N, H, W, C, FW, FH, FC, type, LABEL)        \
   static void BM_NAME(BM_Conv2DWithBiasAndRelu, type, N, H, W, C, FW, FH,    \
@@ -383,11 +404,12 @@ static Graph* FusedConv2DWithBatchNorm(
             .graph,                                                          \
         /*old_benchmark_api=*/false)                                         \
         .Run(state);                                                         \
-    BM_SET_INFO(N, H, W, C, FW, FH, FC, type,, Conv2D);                      \
+    int64_t flops = Conv2DWithPostOpsFlops(N, H, W, C, FW, FH, FC, 2);       \
+    BM_SET_INFO(flops, LABEL, Conv2D);                                       \
   }                                                                          \
   BENCHMARK(BM_NAME(BM_Conv2DWithBiasAndRelu, type, N, H, W, C, FW, FH, FC)) \
       ->Arg(/*unused arg*/ 1)                                                \
-      ->MeasureProcessCPUTime()->UseRealTime();
+      ->MeasureProcessCPUTime();
 
 #define BM_FusedConv2DWithBias(N, H, W, C, FW, FH, FC, type, LABEL)        \
   static void BM_NAME(BM_FusedConv2DWithBias, type, N, H, W, C, FW, FH,    \
@@ -397,11 +419,12 @@ static Graph* FusedConv2DWithBatchNorm(
         FusedConv2DWithBias<float>(N, H, W, C, FW, FH, FC, {"BiasAdd"}),   \
         /*old_benchmark_api=*/false)                                       \
         .Run(state);                                                       \
-    BM_SET_INFO(N, H, W, C, FW, FH, FC, type,, Conv2D);                    \
+    int64_t flops = Conv2DWithPostOpsFlops(N, H, W, C, FW, FH, FC, 1);     \
+    BM_SET_INFO(flops, LABEL, Conv2D);                                     \
   }                                                                        \
   BENCHMARK(BM_NAME(BM_FusedConv2DWithBias, type, N, H, W, C, FW, FH, FC)) \
       ->Arg(/*unused arg*/ 1)                                              \
-      ->MeasureProcessCPUTime()->UseRealTime();
+      ->MeasureProcessCPUTime();
 
 #define BM_FusedConv2DWithBiasAndRelu(N, H, W, C, FW, FH, FC, type, LABEL)     \
   static void BM_NAME(BM_FusedConv2DWithBiasAndRelu, type, N, H, W, C, FW, FH, \
@@ -411,12 +434,13 @@ static Graph* FusedConv2DWithBatchNorm(
                                                {"BiasAdd", "Relu"}),           \
                     /*old_benchmark_api=*/false)                               \
         .Run(state);                                                           \
-    BM_SET_INFO(N, H, W, C, FW, FH, FC, type,, Conv2D);                        \
+    int64_t flops = Conv2DWithPostOpsFlops(N, H, W, C, FW, FH, FC, 2);         \
+    BM_SET_INFO(flops, LABEL, Conv2D);                                         \
   }                                                                            \
   BENCHMARK(                                                                   \
       BM_NAME(BM_FusedConv2DWithBiasAndRelu, type, N, H, W, C, FW, FH, FC))    \
       ->Arg(/*unused arg*/ 1)                                                  \
-      ->MeasureProcessCPUTime()->UseRealTime();
+      ->MeasureProcessCPUTime();
 
 #define BM_Conv2DWithBatchNorm(N, H, W, C, FW, FH, FC, type, LABEL)           \
   static void BM_NAME(BM_Conv2DWithBatchNorm, type, N, H, W, C, FW, FH,       \
@@ -425,11 +449,12 @@ static Graph* FusedConv2DWithBatchNorm(
                     Conv2DWithBatchNorm<float>(N, H, W, C, FW, FH, FC).graph, \
                     /*old_benchmark_api=*/false)                              \
         .Run(state);                                                          \
-    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, Conv2D);                 \
+    int64_t flops = Conv2DWithPostOpsFlops(N, H, W, C, FW, FH, FC, 4);        \
+    BM_SET_INFO(flops, LABEL, Conv2D);                                        \
   }                                                                           \
   BENCHMARK(BM_NAME(BM_Conv2DWithBatchNorm, type, N, H, W, C, FW, FH, FC))    \
       ->Arg(/*unused arg*/ 1)                                                 \
-      ->MeasureProcessCPUTime()->UseRealTime();
+      ->MeasureProcessCPUTime();
 
 #define BM_Conv2DWithBatchNormAndRelu(N, H, W, C, FW, FH, FC, type, LABEL)     \
   static void BM_NAME(BM_Conv2DWithBatchNormAndRelu, type, N, H, W, C, FW, FH, \
@@ -440,12 +465,13 @@ static Graph* FusedConv2DWithBatchNorm(
                         .graph,                                                \
                     /*old_benchmark_api=*/false)                               \
         .Run(state);                                                           \
-    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, Conv2D);                  \
+    int64_t flops = Conv2DWithPostOpsFlops(N, H, W, C, FW, FH, FC, 5);         \
+    BM_SET_INFO(flops, LABEL, Conv2D);                                         \
   }                                                                            \
   BENCHMARK(                                                                   \
       BM_NAME(BM_Conv2DWithBatchNormAndRelu, type, N, H, W, C, FW, FH, FC))    \
       ->Arg(/*unused arg*/ 1)                                                  \
-      ->MeasureProcessCPUTime()->UseRealTime();
+      ->MeasureProcessCPUTime();
 
 #define BM_FusedConv2DWithBatchNorm(N, H, W, C, FW, FH, FC, type, LABEL)     \
   static void BM_NAME(BM_FusedConv2DWithBatchNorm, type, N, H, W, C, FW, FH, \
@@ -455,12 +481,13 @@ static Graph* FusedConv2DWithBatchNorm(
                                                     {"FusedBatchNorm"}),     \
                     /*old_benchmark_api=*/false)                             \
         .Run(state);                                                         \
-    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, Conv2D);                \
+    int64_t flops = Conv2DFlops(N, H, W, C, FW, FH, FC);                     \
+    BM_SET_INFO(flops, LABEL, Conv2D);                                       \
   }                                                                          \
   BENCHMARK(                                                                 \
       BM_NAME(BM_FusedConv2DWithBatchNorm, type, N, H, W, C, FW, FH, FC))    \
       ->Arg(/*unused arg*/ 1)                                                \
-      ->MeasureProcessCPUTime()->UseRealTime();
+      ->MeasureProcessCPUTime();
 
 #define BM_FusedConv2DWithBatchNormAndRelu(N, H, W, C, FW, FH, FC, type,      \
                                            LABEL)                             \
@@ -471,12 +498,13 @@ static Graph* FusedConv2DWithBatchNorm(
                         N, H, W, C, FW, FH, FC, {"FusedBatchNorm", "Relu"}),  \
                     /*old_benchmark_api=*/false)                              \
         .Run(state);                                                          \
-    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, LABEL, Conv2D);                 \
+    int64_t flops = Conv2DWithPostOpsFlops(N, H, W, C, FW, FH, FC, 1);        \
+    BM_SET_INFO(flops, LABEL, Conv2D);                                        \
   }                                                                           \
   BENCHMARK(BM_NAME(BM_FusedConv2DWithBatchNormAndRelu, type, N, H, W, C, FW, \
                     FH, FC))                                                  \
       ->Arg(/*unused arg*/ 1)                                                 \
-      ->MeasureProcessCPUTime()->UseRealTime();
+      ->MeasureProcessCPUTime();
 
 // -------------------------------------------------------------------------- //
 // Pixel CNN convolutions.
@@ -633,11 +661,12 @@ BM_FusedConv2DWithBiasAndRelu(32, 32, 32, 128, 3, 3, 1024, gpu, "3x3 /b 32");
                     Conv2D<T>(N, H, W, C, FW, FH, FC, FORMAT_##FORMAT).graph, \
                     /*old_benchmark_api=*/false)                              \
         .Run(state);                                                          \
-    BM_SET_INFO(N, H, W, C, FW, FH, FC, type, "", Conv2D);                    \
+    int64_t flops = Conv2DFlops(N, H, W, C, FW, FG, FC);                      \
+    BM_SET_INFO(flops, "", Conv2D);                                           \
   }                                                                           \
   BENCHMARK(BM_LONG_NAME(BM_Conv2D, type, T, FORMAT, N, H, W, C, FW, FH, FC)) \
       ->Arg(/*unused arg*/ 1)                                                 \
-      ->MeasureProcessCPUTime()->UseRealTime();
+      ->MeasureProcessCPUTime();
 
 #if GOOGLE_CUDA
 using fp32 = float;


### PR DESCRIPTION
This patch updates how we count number of items that convolution microbenchmarks operates on. The number of items reported now it total number of fused multiply and accumulate that convolution executes.

Also added to use the wall clock to decide for how log to run the benchmark loop as we have noticed on higher number of cores total CPU consumption is not a good deciding factor and benchmark loop only runs couple of times or at worst only once.