### PR TITLE
Adding large jit kernels

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/common/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.cc
@@ -219,9 +219,16 @@ std::ostream& operator<<(std::ostream& os, const nvinfer1::DataType& v) {
     case nvinfer1::DataType::kINT32:
       os << "kINT32";
       break;
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
     case nvinfer1::DataType::kBOOL:
       os << "kBOOL";
       break;
+#endif
+#if IS_TRT_VERSION_GE(8, 5, 0, 0)
+    case nvinfer1::DataType::kUINT8:
+      os << "kUINT8";
+      break;
+#endif
   }
   return os;
 }

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -123,6 +123,9 @@ const char* LayerTypeToString(nvinfer1::LayerType layer_type) {
     ADD_LAYER(REDUCE)
     ADD_LAYER(TOPK)
     ADD_LAYER(GATHER)
+#if IS_TRT_VERSION_GE(8, 5, 0, 0)
+    ADD_LAYER(GRID_SAMPLE)
+#endif
     ADD_LAYER(MATRIX_MULTIPLY)
     ADD_LAYER(RAGGED_SOFTMAX)
     ADD_LAYER(CONSTANT)
@@ -142,7 +145,24 @@ const char* LayerTypeToString(nvinfer1::LayerType layer_type) {
 #if IS_TRT_VERSION_GE(8, 0, 0, 0)
     ADD_LAYER(QUANTIZE)
     ADD_LAYER(DEQUANTIZE)
-#else
+#endif
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
+    ADD_LAYER(CONDITION)
+    ADD_LAYER(CONDITIONAL_INPUT)
+    ADD_LAYER(CONDITIONAL_OUTPUT)
+    ADD_LAYER(SCATTER)
+    ADD_LAYER(EINSUM)
+    ADD_LAYER(ASSERTION)
+#endif
+#if IS_TRT_VERSION_GE(8, 5, 0, 0)
+    ADD_LAYER(ONE_HOT)
+    ADD_LAYER(NON_ZERO)
+    ADD_LAYER(NMS)
+#endif
+#if IS_TRT_VERSION_GE(8, 6, 0, 0)
+    ADD_LAYER(REVERSE_SEQUENCE)
+#endif
+#if !IS_TRT_VERSION_GE(8, 0, 0, 0)
     // The TRT IRNNv2Layer has been deprecated in favor of the loop API.
     ADD_LAYER(RNN)
 #endif

--- a/tensorflow/compiler/tf2tensorrt/convert/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/utils.cc
@@ -47,6 +47,8 @@ string DebugString(const DataType tf_type) {
       return "DT_INT8";
     case DT_BOOL:
       return "DT_BOOL";
+    case DT_UINT8:
+      return "DT_UINT8";
     default:
       return "Unknow TF DataType";
   }
@@ -62,8 +64,14 @@ string DebugString(const nvinfer1::DataType trt_dtype) {
       return "kINT8";
     case nvinfer1::DataType::kINT32:
       return "kINT32";
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
     case nvinfer1::DataType::kBOOL:
       return "kBOOL";
+#endif
+#if IS_TRT_VERSION_GE(8, 5, 0, 0)
+    case nvinfer1::DataType::kUINT8:
+      return "kUINT8";
+#endif
     default:
       return "Invalid TRT data type";
   }
@@ -166,6 +174,11 @@ Status TfTypeToTrtType(DataType tf_type, nvinfer1::DataType* trt_type) {
       *trt_type = nvinfer1::DataType::kBOOL;
       break;
 #endif
+#if IS_TRT_VERSION_GE(8, 5, 0, 0)
+    case DT_UINT8:
+      *trt_type = nvinfer1::DataType::kUINT8;
+      break;
+#endif
     default:
       return errors::InvalidArgument("Unsupported tensorflow data type ",
                                      DataTypeString(tf_type));
@@ -187,6 +200,11 @@ Status TrtTypeToTfType(nvinfer1::DataType trt_type, DataType* tf_type) {
 #if IS_TRT_VERSION_GE(8, 2, 0, 0)
     case nvinfer1::DataType::kBOOL:
       *tf_type = DT_BOOL;
+      break;
+#endif
+#if IS_TRT_VERSION_GE(8, 5, 0, 0)
+    case nvinfer1::DataType::kUINT8:
+      *tf_type = DT_UINT8;
       break;
 #endif
     default:

--- a/tensorflow/compiler/tf2tensorrt/convert/weights.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/weights.cc
@@ -66,8 +66,13 @@ size_t TRT_ShapedWeights::size_bytes() const {
     case nvinfer1::DataType::kHALF:
       data_type_size = 2;
       break;
+#if IS_TRT_VERSION_GE(8, 5, 0, 0)
+    case nvinfer1::DataType::kUINT8:
+#endif
     case nvinfer1::DataType::kINT8:
+#if IS_TRT_VERSION_GE(8, 2, 0, 0)
     case nvinfer1::DataType::kBOOL:
+#endif
       data_type_size = 1;
       break;
   }

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -290,6 +290,9 @@ void* GetTensorAddress(const Tensor* tensor_ptr) {
 #if IS_TRT_VERSION_GE(8, 2, 0, 0)
     TYPECASE(DT_BOOL, tensor_ptr);
 #endif
+#if IS_TRT_VERSION_GE(8, 5, 0, 0)
+    TYPECASE(DT_UINT8, tensor_ptr);
+#endif
     default: {
       LOG(ERROR) << "Unsupported Data type " << DataTypeString(tensor_type);
       return nullptr;
@@ -1296,7 +1299,8 @@ Status TRTEngineOp::AllocateCalibrationResources(
     void* device_address = GetTensorAddress(input);
     if (device_address == nullptr) {
       return errors::InvalidArgument(
-          "Unsupported data type encountered in input ", i);
+          "Unsupported data type [", DebugString(t.dtype()),
+          "] encountered in input ", i);
     }
     cres->device_buffers_.emplace(
         StrCat(IONamePrefixes::kInputPHName, i),

--- a/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_engine_utils.cc
@@ -104,6 +104,11 @@ Status SetupBindings(nvinfer1::ICudaEngine* cuda_engine, const Tensor& tensor,
       buffers[binding_index] = const_cast<bool*>(tensor.flat<bool>().data());
       break;
 #endif
+#if IS_TRT_VERSION_GE(8, 5, 0, 0)
+    case nvinfer1::DataType::kUINT8:
+      buffers[binding_index] = const_cast<uint8*>(tensor.flat<uint8>().data());
+      break;
+#endif
     default:
       return errors::Internal("Unknown TRT data type: ",
                               static_cast<int>(dtype));

--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -470,6 +470,28 @@ tf_cuda_cc_test(
     ],
 )
 
+tf_cuda_cc_test(
+    name = "gpu_unary_ops_large_tensor_test",
+    size = "medium",
+    srcs = ["gpu_unary_ops_large_tensor_test.cc"],
+    extra_copts = if_mlir_generated_experimental_kernels_enabled([
+        "-DMLIR_GENERATED_EXPERIMENTAL_KERNELS_ENABLED",
+    ]) + if_mlir_generated_gpu_kernels_enabled(
+        ["-DMLIR_GENERATED_GPU_KERNELS_ENABLED"],
+    ),
+    shard_count = 20,
+    tags = tf_cuda_tests_tags() + [
+        "no_cuda_asan",  # TODO(b/171341759): re-enable.
+        "no_cuda",  # TODO(b/196608406): re-enable
+    ],
+    deps = [
+        ":base_ops_test",
+        ":base_unary_ops_test",
+        "//tensorflow/core/common_runtime:device",
+        "//tensorflow/core/common_runtime:device_factory",
+    ],
+)
+
 cc_library(
     name = "base_binary_ops_test",
     testonly = 1,
@@ -692,16 +714,13 @@ gpu_kernel_library(
 
 gpu_kernel_library(
     name = "gpu_atanh_kernels_experimental",
-    jit_i64_indexed_for_large_tensors_types = ["f16"],
+    jit_i64_indexed_for_large_tensors_types = ["f16", "f32", "f64",],
     op = "atanh",
     test_tags = [
         "noasan",  # TODO(b/248071004): JIT-compiled code will not be instrumented.
     ],
     tile_size = "256",
-    types = [
-        "f32",
-        "f64",
-    ],
+    types = [],
     unroll_factors = "4",
 )
 

--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -128,51 +128,81 @@ tf_kernel_library(
     tags = ["manual"],
     deps = if_mlir_generated_gpu_kernels_enabled([
         ":base_gpu_op",
-        ":gpu_abs_kernels",
-        ":gpu_acos_kernels",
-        ":gpu_acosh_kernels",
-        ":gpu_angle_kernels",
-        ":gpu_asin_kernels",
-        ":gpu_asinh_kernels",
-        ":gpu_atan_kernels",
         ":gpu_ceil_kernels",
-        ":gpu_complex_abs_kernels",
-        ":gpu_conj_kernels",
         ":gpu_cos_kernels",
-        ":gpu_cosh_kernels",
-        ":gpu_digamma_kernels",
-        ":gpu_erf_kernels",
-        ":gpu_erfc_kernels",
-        ":gpu_exp_kernels",
         ":gpu_expm1_kernels",
         ":gpu_floor_kernels",
-        ":gpu_imag_kernels",
         ":gpu_invert_kernels",
         ":gpu_is_finite_kernels",
         ":gpu_is_inf_kernels",
         ":gpu_is_nan_kernels",
-        ":gpu_lgamma_kernels",
         ":gpu_log1p_kernels",
         ":gpu_log_kernels",
-        ":gpu_logical_not_kernels",
-        ":gpu_neg_kernels",
-        ":gpu_real_kernels",
-        ":gpu_reciprocal_kernels",
-        ":gpu_rint_kernels",
-        ":gpu_round_kernels",
         ":gpu_rsqrt_kernels",
-        ":gpu_sigmoid_kernels",
-        ":gpu_sign_kernels",
         ":gpu_sin_kernels",
-        ":gpu_sinh_kernels",
         ":gpu_sqrt_kernels",
-        ":gpu_square_kernels",
         ":gpu_tan_kernels",
         ":gpu_tanh_kernels",
         "//third_party/eigen3",
     ]) + if_mlir_generated_experimental_kernels_enabled(
-        [":gpu_atanh_kernels_experimental"],
-        [":gpu_atanh_kernels"],
+        [
+            ":gpu_atanh_kernels_experimental",
+            ":gpu_abs_kernels_experimental",
+            ":gpu_acos_kernels_experimental",
+            ":gpu_acosh_kernels_experimental",
+            ":gpu_angle_kernels_experimental",
+            ":gpu_asin_kernels_experimental",
+            ":gpu_asinh_kernels_experimental",
+            ":gpu_atan_kernels_experimental",
+            ":gpu_complex_abs_kernels_experimental",
+            ":gpu_conj_kernels_experimental",
+            ":gpu_cosh_kernels_experimental",
+            ":gpu_digamma_kernels_experimental",
+            ":gpu_erf_kernels_experimental",
+            ":gpu_erfc_kernels_experimental",
+            ":gpu_exp_kernels_experimental",
+            ":gpu_imag_kernels_experimental",
+            ":gpu_lgamma_kernels_experimental",
+            ":gpu_logical_not_kernels_experimental",
+            ":gpu_neg_kernels_experimental",
+            ":gpu_real_kernels_experimental",
+            ":gpu_reciprocal_kernels_experimental",
+            ":gpu_rint_kernels_experimental",
+            ":gpu_round_kernels_experimental",
+            ":gpu_sigmoid_kernels_experimental",
+            ":gpu_sign_kernels_experimental",
+            ":gpu_sinh_kernels_experimental",
+            ":gpu_square_kernels_experimental",
+        ],
+        [
+            ":gpu_atanh_kernels",
+            ":gpu_abs_kernels",
+            ":gpu_acos_kernels",
+            ":gpu_acosh_kernels",
+            ":gpu_angle_kernels",
+            ":gpu_asin_kernels",
+            ":gpu_asinh_kernels",
+            ":gpu_atan_kernels",
+            ":gpu_complex_abs_kernels",
+            ":gpu_conj_kernels",
+            ":gpu_cosh_kernels",
+            ":gpu_digamma_kernels",
+            ":gpu_erf_kernels",
+            ":gpu_erfc_kernels",
+            ":gpu_exp_kernels",
+            ":gpu_imag_kernels",
+            ":gpu_lgamma_kernels",
+            ":gpu_logical_not_kernels",
+            ":gpu_neg_kernels",
+            ":gpu_real_kernels",
+            ":gpu_reciprocal_kernels",
+            ":gpu_rint_kernels",
+            ":gpu_round_kernels",
+            ":gpu_sigmoid_kernels",
+            ":gpu_sign_kernels",
+            ":gpu_sinh_kernels",
+            ":gpu_square_kernels",
+        ],
     ),
 )
 
@@ -606,6 +636,18 @@ gpu_kernel_library(
     ],
 )
 
+gpu_kernel_library(
+    name = "gpu_sigmoid_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "sigmoid",
+    tile_size = "256",
+    types = [],
+)
+
 # TODO(b/25387198): Add an int32 kernel.
 gpu_kernel_library(
     name = "gpu_abs_kernels",
@@ -625,6 +667,25 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_abs_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "i8",
+        "i16",
+        "f16",
+        "f32",
+        "f64",
+        "i64",
+    ],
+    op = "abs",
+    test_tags = [
+        "noasan",  # TODO(b/248071004): JIT-compiled code will not be instrumented.
+    ],
+    tile_size = "256",
+    types = [],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
     name = "gpu_acos_kernels",
     op = "acos",
     tile_size = "256",
@@ -634,6 +695,18 @@ gpu_kernel_library(
         "f64",
     ],
     # Cannot vectorize.
+)
+
+gpu_kernel_library(
+    name = "gpu_acos_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "acos",
+    tile_size = "256",
+    types = [],
 )
 
 gpu_kernel_library(
@@ -647,6 +720,18 @@ gpu_kernel_library(
     ],
     # May be compute-bound.
     # unroll_factors = "4",
+)
+
+gpu_kernel_library(
+    name = "gpu_acosh_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "acosh",
+    tile_size = "256",
+    types = [],
 )
 
 gpu_kernel_library(
@@ -665,6 +750,22 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_angle_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "c64",
+        "c128",
+    ],
+    op = "angle",
+    output_types = [
+        "f32",
+        "f64",
+    ],
+    tile_size = "256",
+    types = [],
+    unroll_factors = "2",
+)
+
+gpu_kernel_library(
     name = "gpu_asin_kernels",
     op = "asin",
     tile_size = "256",
@@ -674,6 +775,18 @@ gpu_kernel_library(
         "f64",
     ],
     # Cannot vectorize.
+)
+
+gpu_kernel_library(
+    name = "gpu_asin_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "asin",
+    tile_size = "256",
+    types = [],
 )
 
 gpu_kernel_library(
@@ -689,6 +802,19 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_asinh_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "asinh",
+    tile_size = "256",
+    types = [],
+    # Cannot vectorize.
+)
+
+gpu_kernel_library(
     name = "gpu_atan_kernels",
     op = "atan",
     tile_size = "256",
@@ -697,6 +823,19 @@ gpu_kernel_library(
         "f32",
         "f64",
     ],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
+    name = "gpu_atan_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "atan",
+    tile_size = "256",
+    types = [],
     unroll_factors = "4",
 )
 
@@ -714,7 +853,11 @@ gpu_kernel_library(
 
 gpu_kernel_library(
     name = "gpu_atanh_kernels_experimental",
-    jit_i64_indexed_for_large_tensors_types = ["f16", "f32", "f64",],
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
     op = "atanh",
     test_tags = [
         "noasan",  # TODO(b/248071004): JIT-compiled code will not be instrumented.
@@ -736,6 +879,18 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_conj_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "c64",
+        "c128",
+    ],
+    op = "conj",
+    tile_size = "256",
+    types = [],
+    unroll_factors = "2",
+)
+
+gpu_kernel_library(
     name = "gpu_cosh_kernels",
     jit_types = [
         "c64",
@@ -753,6 +908,20 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_cosh_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "c64",
+        "c128",
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "cosh",
+    tile_size = "256",
+    types = [],
+)
+
+gpu_kernel_library(
     name = "gpu_erf_kernels",
     op = "erf",
     tile_size = "256",
@@ -765,6 +934,19 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_erf_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "erf",
+    tile_size = "256",
+    types = [],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
     name = "gpu_erfc_kernels",
     op = "erfc",
     tile_size = "256",
@@ -773,6 +955,19 @@ gpu_kernel_library(
         "f32",
         "f64",
     ],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
+    name = "gpu_erfc_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "erfc",
+    tile_size = "256",
+    types = [],
     unroll_factors = "4",
 )
 
@@ -791,10 +986,33 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_imag_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "c64",
+        "c128",
+    ],
+    op = "imag",
+    output_types = [
+        "f32",
+        "f64",
+    ],
+    tile_size = "256",
+    types = [],
+)
+
+gpu_kernel_library(
     name = "gpu_logical_not_kernels",
     op = "logical_not",
     tile_size = "256",
     types = ["i1"],
+)
+
+gpu_kernel_library(
+    name = "gpu_logical_not_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = ["i1"],
+    op = "logical_not",
+    tile_size = "256",
+    types = [],
 )
 
 gpu_kernel_library(
@@ -809,6 +1027,21 @@ gpu_kernel_library(
         "c64",
         "c128",
     ],
+)
+
+gpu_kernel_library(
+    name = "gpu_real_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "c64",
+        "c128",
+    ],
+    op = "real",
+    output_types = [
+        "f32",
+        "f64",
+    ],
+    tile_size = "256",
+    types = [],
 )
 
 gpu_kernel_library(
@@ -827,6 +1060,22 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_reciprocal_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "c64",
+        "c128",
+        "f16",
+        "f32",
+        "f64",
+        "i64",
+    ],
+    op = "reciprocal",
+    tile_size = "256",
+    types = [],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
     name = "gpu_polygamma_kernels",
     op = "polygamma",
     tile_size = "256",
@@ -834,6 +1083,17 @@ gpu_kernel_library(
         "f32",
         "f64",
     ],
+)
+
+gpu_kernel_library(
+    name = "gpu_polygamma_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f32",
+        "f64",
+    ],
+    op = "polygamma",
+    tile_size = "256",
+    types = [],
 )
 
 gpu_kernel_library(
@@ -848,6 +1108,18 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_digamma_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "digamma",
+    tile_size = "256",
+    types = [],
+)
+
+gpu_kernel_library(
     name = "gpu_lgamma_kernels",
     op = "lgamma",
     tile_size = "256",
@@ -856,6 +1128,18 @@ gpu_kernel_library(
         "f32",
         "f64",
     ],
+)
+
+gpu_kernel_library(
+    name = "gpu_lgamma_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "lgamma",
+    tile_size = "256",
+    types = [],
 )
 
 gpu_kernel_library(
@@ -879,6 +1163,25 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_sign_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "i8",
+        "i16",
+        "f16",
+        "f32",
+        "f64",
+        "i32",
+        "i64",
+        "c64",
+        "c128",
+    ],
+    op = "sign",
+    tile_size = "256",
+    types = [],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
     name = "gpu_sinh_kernels",
     jit_types = [
         "c64",
@@ -893,6 +1196,20 @@ gpu_kernel_library(
     ],
     # May be compute-bound.
     # unroll_factors = "4",
+)
+
+gpu_kernel_library(
+    name = "gpu_sinh_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "c64",
+        "c128",
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "sinh",
+    tile_size = "256",
+    types = [],
 )
 
 gpu_kernel_library(
@@ -913,6 +1230,26 @@ gpu_kernel_library(
         "f64",
         "i64",
     ],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
+    name = "gpu_square_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "i64",
+        "i8",
+        "i16",
+        "ui8",
+        "ui16",
+        "ui32",
+        "ui64",
+    ],
+    op = "square",
+    tile_size = "1024",
+    types = [],
     unroll_factors = "4",
 )
 
@@ -996,6 +1333,21 @@ gpu_kernel_library(
         "c64",
         "c128",
     ],
+)
+
+gpu_kernel_library(
+    name = "gpu_complex_abs_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "c64",
+        "c128",
+    ],
+    op = "complex_abs",
+    output_types = [
+        "f32",
+        "f64",
+    ],
+    tile_size = "256",
+    types = [],
 )
 
 gpu_kernel_library(
@@ -1245,6 +1597,25 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_neg_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "i8",
+        "i16",
+        "i32",
+        "i64",
+        "c64",
+        "c128",
+    ],
+    op = "neg",
+    tile_size = "256",
+    types = [],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
     name = "gpu_floor_div_kernels",
     jit_types = [
         "i8",
@@ -1322,6 +1693,21 @@ gpu_kernel_library(
         "c64",
         "c128",
     ],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
+    name = "gpu_exp_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "c64",
+        "c128",
+    ],
+    op = "exp",
+    tile_size = "256",
+    types = [],
     unroll_factors = "4",
 )
 
@@ -1535,6 +1921,18 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_rint_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+    ],
+    op = "rint",
+    tile_size = "1024",
+    types = [],
+)
+
+gpu_kernel_library(
     name = "gpu_round_kernels",
     op = "round",
     tile_size = "1024",
@@ -1545,6 +1943,20 @@ gpu_kernel_library(
         "i32",
         "i64",
     ],
+)
+
+gpu_kernel_library(
+    name = "gpu_round_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "i32",
+        "i64",
+    ],
+    op = "round",
+    tile_size = "1024",
+    types = [],
 )
 
 gpu_kernel_library(

--- a/tensorflow/core/kernels/mlir_generated/base_ops_test.h
+++ b/tensorflow/core/kernels/mlir_generated/base_ops_test.h
@@ -199,6 +199,16 @@ absl::InlinedVector<T, 10> DefaultInputNonZero() {
                                          0.2, 0.3, 0.5, 0.7, 0.9, 9.0, 18.0});
 }
 
+template <typename T, std::enable_if_t<
+                          llvm::is_one_of<T, Eigen::half, float, double>::value,
+                          bool> = true>
+absl::InlinedVector<T, 10> VeryLargeVector() {
+  auto max_val = pow(2,32) + 1;
+  absl::InlinedVector<T, 10> v;
+  for (auto i = 0; i < max_val; ++i) v.push_back(0.1);
+  return v;
+}
+
 template <typename T, std::enable_if_t<is_integer<T>::value, bool> = true>
 absl::InlinedVector<T, 10> DefaultInputNonZero() {
   return test::InputAsVector<T, int>({-18, -9, -1, 1, 3, 4, 5, 7, 9, 10, 18});

--- a/tensorflow/core/kernels/mlir_generated/gpu_unary_ops_large_tensor_test.cc
+++ b/tensorflow/core/kernels/mlir_generated/gpu_unary_ops_large_tensor_test.cc
@@ -1,0 +1,50 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <limits>
+
+#include "tensorflow/core/kernels/mlir_generated/base_ops_test.h"
+#include "tensorflow/core/kernels/mlir_generated/base_unary_ops_test.h"
+
+namespace tensorflow {
+namespace {
+// Test fixture `UnaryOpsTest` that sets the TF device is expected by the TEST
+// macros below.
+class UnaryOpsTest : public UnaryOpsTestBase {
+ protected:
+  void SetUp() override {
+    std::unique_ptr<tensorflow::Device> device_gpu(
+        tensorflow::DeviceFactory::NewDevice("GPU", {},
+                                             "/job:a/replica:0/task:0"));
+    SetDevice(tensorflow::DEVICE_GPU, std::move(device_gpu));
+  }
+};
+/// Test `tf.Atanh`.
+
+// GENERATE_DEFAULT_TEST_WITH_SPECIFIC_INPUT_VALUES_2(
+//     Atanh, DT_HALF, DT_FLOAT, DT_HALF, DT_FLOAT,
+//     test::VeryLargeVector<Eigen::half>(), std::atanh,
+//     test::OpsTestConfig())
+    
+GENERATE_DEFAULT_TEST_WITH_SPECIFIC_INPUT_VALUES_2(
+    Atanh, DT_HALF, DT_FLOAT, DT_HALF, DT_FLOAT,
+    test::DefaultInputBetweenZeroAndOne<Eigen::half>(), std::atanh,
+    test::OpsTestConfig())
+
+}  // namespace
+}  // namespace tensorflow


### PR DESCRIPTION
Activating jit_i64_indexed_for_large_tensors_types path for unary kernels.
CC: @frgossen 