### PR TITLE
Add Raises section to the documentation of tf.nn.max_pool and tf.nn.max_pool2d

### DIFF
--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4796,6 +4796,11 @@ def max_pool_v2(input, ksize, strides, padding, data_format=None, name=None):
   Returns:
     A `Tensor` of format specified by `data_format`.
     The max pooled output tensor.
+  
+  Raises:
+    ValueError: If
+      - explicit padding is used with an input tensor of rank 5.
+      - explicit padding is used with data_format='NCHW_VECT_C'.
   """
   if input.shape is not None:
     n = len(input.shape) - 2
@@ -5050,6 +5055,9 @@ def max_pool2d(input, ksize, strides, padding, data_format="NHWC", name=None):
   Returns:
     A `Tensor` of format specified by `data_format`.
     The max pooled output tensor.
+  
+  Raises:
+    ValueError: If explicit padding is used with data_format='NCHW_VECT_C'.
   """
   with ops.name_scope(name, "MaxPool2d", [input]) as name:
     if data_format is None:

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4796,7 +4796,6 @@ def max_pool_v2(input, ksize, strides, padding, data_format=None, name=None):
   Returns:
     A `Tensor` of format specified by `data_format`.
     The max pooled output tensor.
-  
   Raises:
     ValueError: If
       - explicit padding is used with an input tensor of rank 5.

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -5054,7 +5054,6 @@ def max_pool2d(input, ksize, strides, padding, data_format="NHWC", name=None):
   Returns:
     A `Tensor` of format specified by `data_format`.
     The max pooled output tensor.
-  
   Raises:
     ValueError: If explicit padding is used with data_format='NCHW_VECT_C'.
   """

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -5055,6 +5055,7 @@ def max_pool2d(input, ksize, strides, padding, data_format="NHWC", name=None):
   Returns:
     A `Tensor` of format specified by `data_format`.
     The max pooled output tensor.
+
   Raises:
     ValueError: If explicit padding is used with data_format='NCHW_VECT_C'.
   """

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -4796,6 +4796,7 @@ def max_pool_v2(input, ksize, strides, padding, data_format=None, name=None):
   Returns:
     A `Tensor` of format specified by `data_format`.
     The max pooled output tensor.
+
   Raises:
     ValueError: If
       - explicit padding is used with an input tensor of rank 5.


### PR DESCRIPTION
Address issue[#57978](https://github.com/tensorflow/tensorflow/issues/57978). Add Raises section to the docstring of tf.nn.max_pool and tf.nn.max_pool2d.

For max_pool, raises ValueError if
- explicit padding is used with an input tensor of rank 5.
- explicit padding is used with data_format='NCHW_VECT_C'.

For max_pool2d, raises ValueError: If explicit padding is used with data_format='NCHW_VECT_C'.
