### PR TITLE
[oneDNN] Reset inter to 1 if it's negative

### DIFF
--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -139,9 +139,9 @@ Status NewThreadPoolFromThreadPoolOptions(
 }
 
 thread::ThreadPool* GlobalThreadPool(const SessionOptions& options,
-                                     bool run_in_caller = false) {
+                                     int32_t expected) {
   static thread::ThreadPool* const thread_pool =
-      NewThreadPoolFromSessionOptions(options, run_in_caller);
+      NewThreadPoolFromSessionOptions(options, expected);
   return thread_pool;
 }
 
@@ -347,8 +347,9 @@ DirectSession::DirectSession(const SessionOptions& options,
          env_num_threads < 0)) {
       run_in_caller_thread_ = true;
     }
-    thread_pools_.emplace_back(GlobalThreadPool(options, run_in_caller_thread_),
-                               false /* owned */);
+    thread_pools_.emplace_back(
+        GlobalThreadPool(options, run_in_caller_thread_ ? 1 : 0),
+        false /* owned */);
   }
   // The default value of sync_on_finish will be flipped soon and this
   // environment variable will be removed as well.

--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -138,10 +138,13 @@ Status NewThreadPoolFromThreadPoolOptions(
   return OkStatus();
 }
 
+// Function to create a global thread pool for sessions. The thread number is
+// set as `num_threads` if `num_threads` > 0, otherwise it will be parsed from
+// SessionOptions.
 thread::ThreadPool* GlobalThreadPool(const SessionOptions& options,
-                                     int32_t expected) {
+                                     int32_t num_threads) {
   static thread::ThreadPool* const thread_pool =
-      NewThreadPoolFromSessionOptions(options, expected);
+      NewThreadPoolFromSessionOptions(options, num_threads);
   return thread_pool;
 }
 
@@ -347,6 +350,10 @@ DirectSession::DirectSession(const SessionOptions& options,
          env_num_threads < 0)) {
       run_in_caller_thread_ = true;
     }
+
+    // `run_in_caller_thread_` means the session is expected to run with single
+    // thread, but it will be dispatched to global thread pool if there're
+    // multiple executors. To keep consistent behavior, set thread number to 1.
     thread_pools_.emplace_back(
         GlobalThreadPool(options, run_in_caller_thread_ ? 1 : 0),
         false /* owned */);

--- a/tensorflow/core/common_runtime/process_util.cc
+++ b/tensorflow/core/common_runtime/process_util.cc
@@ -156,7 +156,8 @@ int32 NumInterOpThreadsFromSessionOptions(const SessionOptions& options) {
 thread::ThreadPool* NewThreadPoolFromSessionOptions(
     const SessionOptions& options, int32_t num_threads) {
   const int32_t num_threads_real =
-      expected > 0 ? expected : NumInterOpThreadsFromSessionOptions(options);
+      num_threads > 0 ? num_threads
+                      : NumInterOpThreadsFromSessionOptions(options);
   VLOG(1) << "Session inter op parallelism threads: " << num_threads_real;
   return new thread::ThreadPool(
       options.env, ThreadOptions(), "Compute", num_threads_real,

--- a/tensorflow/core/common_runtime/process_util.cc
+++ b/tensorflow/core/common_runtime/process_util.cc
@@ -154,12 +154,9 @@ int32 NumInterOpThreadsFromSessionOptions(const SessionOptions& options) {
 }
 
 thread::ThreadPool* NewThreadPoolFromSessionOptions(
-    const SessionOptions& options, bool run_in_caller) {
-  // `run_in_caller` means the session is expected to run with single thread,
-  // but it will be dispatched to global thread pool if there're multiple
-  // executors. To keep consistent behavior, set thread number to 1 here.
+    const SessionOptions& options, int32_t expected) {
   const int32_t num_threads =
-      run_in_caller ? 1 : NumInterOpThreadsFromSessionOptions(options);
+      expected > 0 ? expected : NumInterOpThreadsFromSessionOptions(options);
   VLOG(1) << "Session inter op parallelism threads: " << num_threads;
   return new thread::ThreadPool(
       options.env, ThreadOptions(), "Compute", num_threads,

--- a/tensorflow/core/common_runtime/process_util.cc
+++ b/tensorflow/core/common_runtime/process_util.cc
@@ -154,12 +154,12 @@ int32 NumInterOpThreadsFromSessionOptions(const SessionOptions& options) {
 }
 
 thread::ThreadPool* NewThreadPoolFromSessionOptions(
-    const SessionOptions& options, int32_t expected) {
-  const int32_t num_threads =
+    const SessionOptions& options, int32_t num_threads) {
+  const int32_t num_threads_real =
       expected > 0 ? expected : NumInterOpThreadsFromSessionOptions(options);
-  VLOG(1) << "Session inter op parallelism threads: " << num_threads;
+  VLOG(1) << "Session inter op parallelism threads: " << num_threads_real;
   return new thread::ThreadPool(
-      options.env, ThreadOptions(), "Compute", num_threads,
+      options.env, ThreadOptions(), "Compute", num_threads_real,
       !options.config.experimental().disable_thread_spinning(),
       /*allocator=*/nullptr);
 }

--- a/tensorflow/core/common_runtime/process_util.cc
+++ b/tensorflow/core/common_runtime/process_util.cc
@@ -128,6 +128,9 @@ int32 NumInterOpThreadsFromSessionOptions(const SessionOptions& options) {
   const int32_t env_inter_op = GetEnvNumInterOpThreads();
   if (env_inter_op > 0) return env_inter_op;
 
+  // Reset inter to 1 since negative value means running in caller thread.
+  if (inter_op < 0 || env_inter_op < 0) return 1;
+
 #if defined(ENABLE_ONEDNN_OPENMP) && defined(ENABLE_MKL)
   if (IsMKLEnabled()) {
     // MKL library executes ops in parallel using OMP threads.

--- a/tensorflow/core/common_runtime/process_util.h
+++ b/tensorflow/core/common_runtime/process_util.h
@@ -45,10 +45,10 @@ int32 NumIntraOpThreadsFromEnvironment();
 int32 NumInterOpThreadsFromSessionOptions(const SessionOptions& options);
 
 // Creates a thread pool with number of inter op threads.
-// The number is set if `expected` > 0, otherwise it will be configured by
+// The number is set if `num_threads` > 0, otherwise it will be configured by
 // SessionOptions.
 thread::ThreadPool* NewThreadPoolFromSessionOptions(
-    const SessionOptions& options, int32_t expected = 0);
+    const SessionOptions& options, int32_t num_threads = 0);
 
 // Schedule "closure" in the default thread queue.
 void SchedClosure(std::function<void()> closure);

--- a/tensorflow/core/common_runtime/process_util.h
+++ b/tensorflow/core/common_runtime/process_util.h
@@ -46,7 +46,7 @@ int32 NumInterOpThreadsFromSessionOptions(const SessionOptions& options);
 
 // Creates a thread pool with number of inter op threads.
 thread::ThreadPool* NewThreadPoolFromSessionOptions(
-    const SessionOptions& options);
+    const SessionOptions& options, bool run_in_caller = false);
 
 // Schedule "closure" in the default thread queue.
 void SchedClosure(std::function<void()> closure);

--- a/tensorflow/core/common_runtime/process_util.h
+++ b/tensorflow/core/common_runtime/process_util.h
@@ -45,8 +45,10 @@ int32 NumIntraOpThreadsFromEnvironment();
 int32 NumInterOpThreadsFromSessionOptions(const SessionOptions& options);
 
 // Creates a thread pool with number of inter op threads.
+// The number is set if `expected` > 0, otherwise it will be configured by
+// SessionOptions.
 thread::ThreadPool* NewThreadPoolFromSessionOptions(
-    const SessionOptions& options, bool run_in_caller = false);
+    const SessionOptions& options, int32_t expected = 0);
 
 // Schedule "closure" in the default thread queue.
 void SchedClosure(std::function<void()> closure);


### PR DESCRIPTION
This PR is to ensure inter thread number is always 1 after user enabled `run_in_caller_thread_ `.

### Background
`run_in_caller_thread_` means TF can take current python thread as C++ inter thread. User can enable `run_in_caller_thread_` mode by setting negative inter [here](https://github.com/tensorflow/tensorflow/blob/r2.9/tensorflow/core/common_runtime/direct_session.cc#L344-L348).
But in [later code](https://github.com/tensorflow/tensorflow/blob/r2.9/tensorflow/core/common_runtime/direct_session.cc#L582-L593) TF will create new inter thread pool if `executors_and_keys->items.size() > 1`:
```c++
    // We allow using the caller thread only when having a single executor
    // specified.
    if (executors_and_keys->items.size() > 1) {
      pool = thread_pools_[0].first;
    } else {
      VLOG(1) << "Executing Session::Run() synchronously!";
      pool = nullptr;
```
And TF will adjust the number of new inter pool to be 2 [here](https://github.com/intel-innersource/frameworks.ai.tensorflow.private-tensorflow/blob/r2.9/tensorflow/core/common_runtime/process_util.cc#L132-L151) at least, then user didn't get single thread execution of `run_in_caller_thread_`.

The most affected scenarios is weight sharing usage:
```python
      threads = []
      for i in range(1, num_instances+1):
        thread = threading.Thread(target=run_model, args=(data_sess,infer_sess, i))
        threads.append(thread)
        thread.start()

      for index, thread in enumerate(threads):
        thread.join()
```
We hope each new python thread will be regarded as master inter thread, but sometimes it will create `N*2` inter threads at least if we have `N` python threads.

### What does this PR do
This PR didn't change any process, it only changed the inter thread pool initialization value when inter config < 0. In this moment, reset negative inter to 1 and do not trigger the default initialization process.


Signed-off-by: Lu Teng [teng.lu@intel.com](mailto:teng.lu@intel.com)