### PR TITLE
[NVIDIA TF] Use NHWC for TF32 (Inference only)

### DIFF
--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -1164,7 +1164,10 @@ cc_library(
         "//tensorflow/core/grappler/clusters:cluster",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
-    ],
+    ] + if_static(
+        ["//tensorflow/core/platform:tensor_float_32_utils"],
+        ["//tensorflow/core/platform:tensor_float_32_hdr_lib"],
+    ),
 )
 
 tf_cuda_cc_test(

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h"
 #include "tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer_factory.h"
 #include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/platform/tensor_float_32_utils.h"
 
 namespace tensorflow {
 namespace grappler {
@@ -37,8 +38,8 @@ namespace {
 
 constexpr char kNHWC[] = "NHWC";
 constexpr char kNCHW[] = "NCHW";
-constexpr float kVoltaGPURatioThreshold = 0.5;
-constexpr float kConvGPUFP16Threshold = 0.5;
+constexpr float kGPURatioThreshold = 0.5;
+constexpr float kConvGPUExpectedDtypeThreshold = 0.5;
 
 struct MutableNodeViewFormatter {
   void operator()(std::string* out, utils::MutableNodeView* node_view) const {
@@ -46,34 +47,39 @@ struct MutableNodeViewFormatter {
   }
 };
 
-inline std::pair<int, int> GetNumGPUs(const Cluster& cluster) {
+struct GpuStats {
+  int num_gpus;
+  int num_voltas;
+  int num_amperes;
+};
+
+inline GpuStats GetNumGPUs(const Cluster& cluster) {
   auto devices = cluster.GetDevices();
-  int num_gpus = 0;
-  int num_volta = 0;
+  GpuStats gpu_stats{};
   for (const auto& device : devices) {
     if (device.second.type() != kGPU) {
       continue;
     }
-    num_gpus++;
+    gpu_stats.num_gpus++;
     auto compute_capability_it =
         device.second.environment().find("architecture");
     if (compute_capability_it == device.second.environment().end()) {
       continue;
     }
     double compute_capability = 0.0;
-    if (absl::SimpleAtod(compute_capability_it->second, &compute_capability) &&
-        compute_capability >= 7.0) {
-      num_volta++;
+    if (absl::SimpleAtod(compute_capability_it->second, &compute_capability)) {
+      if (compute_capability >= 7.0) gpu_stats.num_voltas++;
+      if (compute_capability >= 8.0) gpu_stats.num_amperes++;
     }
   }
-  return {num_gpus, num_volta};
+  return gpu_stats;
 }
 
 inline bool NumConvOnDeviceWithDataTypeOverThreshold(
     const TransposeContext& context, absl::string_view device,
     const DataType& data_type) {
   int num_conv_gpu = 0;
-  int num_conv_gpu_fp16 = 0;
+  int num_conv_gpu_expected_dtype = 0;
 
   for (const auto& node : context.graph_view->GetNodes()) {
     const auto* node_def = node.node();
@@ -94,32 +100,79 @@ inline bool NumConvOnDeviceWithDataTypeOverThreshold(
       continue;
     }
     if (t_attr->type() == data_type) {
-      num_conv_gpu_fp16++;
+      num_conv_gpu_expected_dtype++;
     }
   }
 
   if (num_conv_gpu == 0) return false;
 
-  return (static_cast<float>(num_conv_gpu_fp16) /
-          static_cast<float>(num_conv_gpu)) >= kConvGPUFP16Threshold;
+  return (static_cast<float>(num_conv_gpu_expected_dtype) /
+          static_cast<float>(num_conv_gpu)) >= kConvGPUExpectedDtypeThreshold;
+}
+
+inline bool ConvBackpropExists(
+    const TransposeContext& context, absl::string_view device,
+    const DataType& data_type) {
+  for (const auto& node : context.graph_view->GetNodes()) {
+    const auto* node_def = node.node();
+    if (!IsConv2DBackpropFilter(*node_def) &&
+        !IsConv2DBackpropInput(*node_def) &&
+        !IsConv3DBackpropFilterV2(*node_def) &&
+        !IsConv3DBackpropInputV2(*node_def)) {
+      continue;
+    }
+
+    const string& device_name = GetDeviceName(*node_def);
+    string device_type;
+    string task;
+    if (!DeviceNameUtils::SplitDeviceName(device_name, &task, &device_type) ||
+        !absl::StrContains(absl::AsciiStrToLower(device_type),
+                           absl::AsciiStrToLower(device))) {
+      continue;
+    }
+
+    const auto* t_attr = node.GetAttr("T");
+    if (t_attr == nullptr) {
+      continue;
+    }
+    if (t_attr->type() == data_type) {
+      return true;
+    }
+  }
+  return false;
 }
 
 inline std::pair<string, string> GetSrcAndDstDataFormats(
-    const TransposeContext& context, int num_gpus, int num_voltas) {
+    const TransposeContext& context, GpuStats gpu_stats) {
   string src_format = kNHWC;
   string dst_format = kNCHW;
 
   const bool is_NHWC_enforced =
       (!context.enforced_layout.empty() && context.enforced_layout == "NHWC");
+  const bool volta_ready =
+      (static_cast<float>(gpu_stats.num_voltas) /
+       static_cast<float>(gpu_stats.num_gpus)) >= kGPURatioThreshold;
+  const bool ampere_ready =
+      (static_cast<float>(gpu_stats.num_amperes) /
+       static_cast<float>(gpu_stats.num_gpus)) >= kGPURatioThreshold;
+
+  // We swap the src_format and dst_format when:
+  //   (1): Volta+ GPUs AND half-dtype conv nodes >= 50% of total conv nodes.
+  //   (2): Ampere+ GPUs AND TF32-dtype conv nodes >= 50% AND no backprop nodes.
   const bool should_swap =
-      ((static_cast<float>(num_voltas) / static_cast<float>(num_gpus)) >=
-       kVoltaGPURatioThreshold) &&
-      NumConvOnDeviceWithDataTypeOverThreshold(context, kGPU, DT_HALF);
+      volta_ready &&
+      (NumConvOnDeviceWithDataTypeOverThreshold(context, kGPU, DT_HALF) ||
+       (ampere_ready && tensor_float_32_execution_enabled() &&
+        NumConvOnDeviceWithDataTypeOverThreshold(context, kGPU, DT_FLOAT) &&
+        !ConvBackpropExists(context, kGPU, DT_FLOAT)));
   // We swap only if NHWC is enforced or no layout is enforced and the devices
   // config meet the thresholds
   if (is_NHWC_enforced || (context.enforced_layout.empty() && should_swap)) {
     std::swap(src_format, dst_format);
   }
+
+  VLOG(2) << "Layout conversion of " << src_format << " to " << dst_format
+          << " will take place.";
 
   return {src_format, dst_format};
 }
@@ -422,20 +475,18 @@ Status GenericLayoutOptimizer::Optimize(Cluster* cluster,
         absl::StrCat("Invalid value for enforced_layout: ", enforced_layout_,
                      ". Supported layouts: 'NHWC', 'NCHW'."));
   }
-  const auto num_gpus_and_num_volta = GetNumGPUs(*cluster);
-  const int num_gpus = num_gpus_and_num_volta.first;
+  const auto gpu_stats = GetNumGPUs(*cluster);
 
   const bool is_aggressive = opt_level_ == RewriterConfig::AGGRESSIVE;
 
   TransposeContext context;
   context.enforced_layout = enforced_layout_;
 
-  if (num_gpus > 0) {
+  if (gpu_stats.num_gpus > 0) {
     TF_RETURN_IF_ERROR(TransposeContext::InitializeTransposeContext(
         /*assume_valid_feeds=*/is_aggressive, item, cluster, &context));
 
-    const auto src_dst_formats = GetSrcAndDstDataFormats(
-        context, num_gpus, num_gpus_and_num_volta.second);
+    const auto src_dst_formats = GetSrcAndDstDataFormats(context, gpu_stats);
     context.AssignDeviceAndDataFormats(kGPU, src_dst_formats.first,
                                        src_dst_formats.second);
   } else {

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -831,12 +831,8 @@ void LaunchConv2DBackpropFilterOp<Eigen::GpuDevice, T>::operator()(
       << "Negative row or col paddings: (" << common_padding_rows << ", "
       << common_padding_cols << ")";
 
-  // The Tensor Core in NVIDIA Volta+ GPUs supports efficient convolution with
-  // fp16 in NHWC data layout. In all other configurations it's more efficient
-  // to run computation in NCHW data format.
-  const bool compute_in_nhwc = DataTypeToEnum<T>::value == DT_HALF &&
-                               stream->GetCudaComputeCapability().IsAtLeast(
-                                   se::CudaComputeCapability::VOLTA);
+  const bool compute_in_nhwc = ComputeInNhwcEnabled(DataTypeToEnum<T>::value,
+                                                    stream);
 
   // We only do one directional conversion: NHWC->NCHW. We never convert in the
   // other direction. Grappler layout optimizer selects the preferred layout and

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -211,12 +211,8 @@ void LaunchConv2DBackpropInputOp<GPUDevice, T>::operator()(
       << "Negative row or col paddings: (" << common_padding_rows << ", "
       << common_padding_cols << ")";
 
-  // The Tensor Core in NVIDIA Volta+ GPUs supports efficient convolution with
-  // fp16 in NHWC data layout. In all other configurations it's more efficient
-  // to run computation in NCHW data format.
-  const bool compute_in_nhwc = DataTypeToEnum<T>::value == DT_HALF &&
-                               stream->GetCudaComputeCapability().IsAtLeast(
-                                   se::CudaComputeCapability::VOLTA);
+  const bool compute_in_nhwc = ComputeInNhwcEnabled(DataTypeToEnum<T>::value,
+                                                    stream);
 
   // We only do one directional conversion: NHWC->NCHW. We never convert in the
   // other direction. Grappler layout optimizer selects the preferred layout and

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1407,8 +1407,8 @@ class Conv3DBackpropInputOp<GPUDevice, T> : public OpKernel {
         << ", " << padding_planes << ")";
 
 #if GOOGLE_CUDA
-    const bool compute_in_nhwc =
-        CUDNN_VERSION >= 8000 && DataTypeToEnum<T>::value == DT_HALF;
+    const bool compute_in_nhwc = ComputeInNhwcEnabled(
+        DataTypeToEnum<T>::value, stream, /*use_4d_tensor=*/false);
 #else
     // fast NDHWC implementation is a CUDA only feature
     const bool compute_in_nhwc = false;
@@ -1803,8 +1803,8 @@ class Conv3DBackpropFilterOp<GPUDevice, T> : public OpKernel {
         << ", " << padding_planes << ")";
 
 #if GOOGLE_CUDA
-    const bool compute_in_nhwc =
-        CUDNN_VERSION >= 8000 && DataTypeToEnum<T>::value == DT_HALF;
+    const bool compute_in_nhwc = ComputeInNhwcEnabled(
+        DataTypeToEnum<T>::value, stream, /*use_4d_tensor=*/false);
 #else
     // fast NDHWC implementation is a CUDA only feature
     const bool compute_in_nhwc = false;

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -896,12 +896,8 @@ void LaunchConv2DOp<GPUDevice, T>::operator()(
   }
 
 #if GOOGLE_CUDA
-  // Tensor Core (NVIDIA Volta+ GPUs) supports efficient convolution with fp16
-  // in NHWC data layout. In all other configurations it's more efficient to
-  // run computation in NCHW data format.
-  const bool compute_in_nhwc = DataTypeToEnum<T>::value == DT_HALF &&
-                               stream->GetCudaComputeCapability().IsAtLeast(
-                                   se::CudaComputeCapability::VOLTA);
+  const bool compute_in_nhwc = ComputeInNhwcEnabled(DataTypeToEnum<T>::value,
+                                                    stream);
 #else
   // fast NHWC implementation is a CUDA only feature
   const bool compute_in_nhwc = false;

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -346,8 +346,8 @@ struct LaunchConvOp<GPUDevice, T> {
     }
 
 #if GOOGLE_CUDA
-    const bool compute_in_nhwc =
-        CUDNN_VERSION >= 8000 && DataTypeToEnum<T>::value == DT_HALF;
+    const bool compute_in_nhwc = ComputeInNhwcEnabled(
+        DataTypeToEnum<T>::value, stream, /*use_4d_tensor=*/false);
 #else
     // fast NHWC implementation is a CUDA only feature
     const bool compute_in_nhwc = false;

--- a/tensorflow/core/kernels/conv_ops_gpu.cc
+++ b/tensorflow/core/kernels/conv_ops_gpu.cc
@@ -27,9 +27,31 @@ limitations under the License.
 #include "tensorflow/compiler/xla/stream_executor/gpu/redzone_allocator.h"
 #include "tensorflow/compiler/xla/stream_executor/tf_allocator_adapter.h"
 #include "tensorflow/core/kernels/autotune_conv_impl.h"
+#include "tensorflow/core/platform/tensor_float_32_utils.h"
+#include "third_party/gpus/cudnn/cudnn.h"
 #endif  // GOOGLE_CUDA
 
 namespace tensorflow {
+
+#if GOOGLE_CUDA
+bool ComputeInNhwcEnabled(DataType data_type, se::Stream* stream,
+                          bool use_4d_tensor) {
+  // Tensor Core supports efficient convolution with fp16 for NVIDIA Volta+
+  // GPUs and tf32 for Ampere+ GPUs in NHWC data layout. In all other
+  // configurations it's more efficient to run computation in NCHW data format.
+  bool use_nhwc_tf32 = data_type == DT_FLOAT &&
+                       stream->GetCudaComputeCapability().IsAtLeast(
+                           se::CudaComputeCapability::AMPERE) &&
+                       tensorflow::tensor_float_32_execution_enabled();
+  bool use_nhwc_fp16 =
+      data_type == DT_HALF && stream->GetCudaComputeCapability().IsAtLeast(
+                                  se::CudaComputeCapability::VOLTA);
+  if (use_4d_tensor) {
+    return use_nhwc_fp16 || use_nhwc_tf32;
+  }
+  return CUDNN_VERSION >= 8000 && (use_nhwc_fp16 || use_nhwc_tf32);
+}
+#endif  // GOOGLE_CUDA
 
 // Finds the best convolution algorithm for the given ConvLaunch (cuda
 // convolution on the stream) and parameters, by running all possible

--- a/tensorflow/core/kernels/conv_ops_gpu.h
+++ b/tensorflow/core/kernels/conv_ops_gpu.h
@@ -32,6 +32,10 @@ limitations under the License.
 
 namespace tensorflow {
 
+#if GOOGLE_CUDA
+bool ComputeInNhwcEnabled(DataType data_type, se::Stream* stream,
+                          bool use_4d_tensor = true);
+#endif  // GOOGLE_CUDA
 // Get the Dnn workspace limit from the environment variable, which is in MB.
 // Return the workspace memory limit in bytes. If no value is set, return the
 // default value.


### PR DESCRIPTION
This PR enables the NHWC data layout for the inference op graphs when the underlying GPUs are Ampere+ and input dtype is TF32. Using NHWC is recommended in such cases to better utilize the 3rd generation Tensor Core.

For now, the cuDNN can provide improved performance only for the fwd and bwd_data convolutions and will improve the bwd_filter convolution in the future release. Therefore, we enable this enhancement only for inference in this PR.

We have conducted some perf evaluation across a range of convnets (image classification and object detection tasks) and observed a ~20% perf improvement in most cases.

cc. @nluehr @pjannaty for viz. 