### PR TITLE
Deprecate ImplicitBatchModeCompatible dynamic shape strategy

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -1136,8 +1136,6 @@ class TrtGraphConverterV2(object):
        inputs with the same dimensions as the input it is created for. The GPU
        engine will be run with optimal performance with such inputs.
      * `Range+Optimal`: create the profiles for both `Range` and `Optimal`.
-     * `ImplicitBatchModeCompatible`: create the profiles that will produce the
-       same GPU engines as the implicit_batch_mode would produce.
   """
 
   def _verify_profile_strategy(self, strategy):
@@ -1146,6 +1144,10 @@ class TrtGraphConverterV2(object):
       raise ValueError(
           ("profile_strategy '{}' is not supported. It should be one of {}"
           ).format(strategy, supported_profile_strategies()))
+    if strategy == "ImplicitBatchModeCompatible":
+      logging.warn("ImplicitBatchModeCompatible strategy is deprecated, and"
+          " using it may result in errors during engine building. Please"
+          " consider using a different profile strategy.")
 
   @deprecation.deprecated_args(None,
                                "Use individual converter parameters instead",


### PR DESCRIPTION
This strategy is intended for ease of use for people familiar with the implicit batch mode profile, in that it does not require the user to specifically call build() before trying to run an inference with TFTRT converted graph. Since this is actually a dynamic shape mode, and input shapes are required in dynamic shape mode for TensorRT profile generation; this mode makes some educated guesses for minimum and maximum shapes for inputs the TensorRT engine.

This has proven to be buggy for models that include transpose and reshape operations, among others.

Due to the above, and since dynamic shape mode requires users to call build() with the correct input shapes to generate TensorRT profiles correctly, this mode is being deprecated.

CC: @DEKHTIARJonathan @bixia1 

Signed-off-by: Meenakshi Venkataraman <meenakshiv@nvidia.com>