### PR TITLE
TRTEngineOP name conflict fix.

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/common/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.cc
@@ -22,7 +22,7 @@ limitations under the License.
 #include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/profiler/lib/traceme.h"
 #include "third_party/tensorrt/NvInferPlugin.h"
-
+#include "tensorflow/core/public/version.h"
 #endif
 
 namespace tensorflow {
@@ -138,6 +138,16 @@ void InitializeTrtPlugins(nvinfer1::ILogger* trt_logger) {
 void MaybeInitializeTrtPlugins(nvinfer1::ILogger* trt_logger) {
   static absl::once_flag once;
   absl::call_once(once, InitializeTrtPlugins, trt_logger);
+}
+
+// Function to generate a containerID.
+string GetContainerID(const string& model, const string& convParam) {
+  const string containerID = string("TF") + TF_VERSION_STRING + "_TRT" +
+                       absl::StrJoin(GetLoadedTensorRTVersion(), ".");
+  std::stringstream ss;
+  ss << containerID << "_model" << std::hash<std::string>{}(model)
+     << "_param" << std::hash<std::string>{}(convParam);
+  return ss.str();
 }
 
 }  // namespace tensorrt

--- a/tensorflow/compiler/tf2tensorrt/common/utils.h
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.h
@@ -116,6 +116,10 @@ Status GetTrtBindingIndex(const char* tensor_name, int profile_index,
 Status GetTrtBindingIndex(int network_input_idx, int profile_index,
                           const nvinfer1::ICudaEngine* cuda_engine,
                           int* binding_index);
+
+// Function defining container ID used for resources lookups.
+string GetContainerID(const string& model = "",
+                      const string& convParam = "NO_PARAM");
 }  // namespace tensorrt
 }  // namespace tensorflow
 

--- a/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/trt_optimization_pass.h
@@ -55,6 +55,16 @@ class TRTOptimizationPass : public grappler::CustomGraphOptimizer {
     ProfileStrategy profile_strategy = ProfileStrategy::kRange;
     bool allow_build_at_runtime = true;
     bool use_explicit_precision = false;
+    void SerializeToString(std::string* myString) const {
+        std::stringstream ss;
+        ss << trt_logger_name << max_batch_size << max_workspace_size_bytes
+           << (int)precision_mode << minimum_segment_size << is_dynamic_op
+           << max_cached_engines << use_calibration << use_implicit_batch
+           << (int)profile_strategy << allow_build_at_runtime
+           << use_explicit_precision;
+
+        *myString = ss.str();
+    }
   };
 
   TRTOptimizationPass(const string& name = "TRTOptimizationPass")

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops_test.cc
@@ -238,10 +238,11 @@ TEST_P(TRTEngineResourceOpsTest, Basic) {
   SetDevice(DEVICE_GPU, std::move(device));
 
   // Create a resource handle.
-  const string container(kTfTrtContainerName);
+  const auto container = GetContainerID("mymodel");
   const string resource_name = "myresource";
   Reset();
   TF_ASSERT_OK(NodeDefBuilder("op", "CreateTRTResourceHandle")
+                   .Attr("container_ID", container)
                    .Attr("resource_name", resource_name)
                    .Finalize(node_def()));
   TF_ASSERT_OK(InitOp());
@@ -297,6 +298,7 @@ TEST_P(TRTEngineResourceOpsTest, Basic) {
   // resource manager.
   Reset();
   TF_ASSERT_OK(NodeDefBuilder("op", "SerializeTRTResource")
+                   .Attr("container_ID", container)
                    .Attr("delete_resource", true)
                    .Input(FakeInput(DT_STRING))
                    .Input(FakeInput(DT_STRING))

--- a/tensorflow/compiler/tf2tensorrt/ops/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/ops/trt_engine_op.cc
@@ -43,6 +43,7 @@ REGISTER_OP("TRTEngineOp")
     .Attr("precision_mode: {'FP32', 'FP16', 'INT8'}")
     .Attr("calibration_data: string = ''")
     .Attr("use_calibration: bool = true")
+    .Attr("container_ID: string = ''")
     .Input("in_tensor: InT")
     .Output("out_tensor: OutT")
     .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {

--- a/tensorflow/compiler/tf2tensorrt/ops/trt_engine_resource_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/ops/trt_engine_resource_ops.cc
@@ -25,6 +25,7 @@ namespace tensorflow {
 
 REGISTER_OP("CreateTRTResourceHandle")
     .Attr("resource_name: string")
+    .Attr("container_ID: string")
     .Output("resource_handle: resource")
     .SetIsStateful()
     .SetShapeFn(shape_inference::ScalarShape);
@@ -39,6 +40,7 @@ REGISTER_OP("InitializeTRTResource")
 REGISTER_OP("SerializeTRTResource")
     .Attr("delete_resource: bool = false")
     .Attr("save_gpu_specific_engines: bool = True")
+    .Attr("container_ID: string")
     .Input("resource_name: string")
     .Input("filename: string")
     .SetIsStateful()


### PR DESCRIPTION
Fix the `TRTEngineOp` naming conflicts that could occur in some situations.
To fix such conflicts we are using a randomly generated 5-character's `converter_ID` which is stored as an attribute of the node. Now the resource manager is looking for such nodes using `converter_ID` and `TRTEngineOp_X_Y` instead of the previously used `TF-TRT` and `TRTEngineOp_X_Y`. 
