### PR TITLE
[TF-TRT] Fix some compilation warnings in TF-TRT

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -146,8 +146,9 @@ const char* LayerTypeToString(nvinfer1::LayerType layer_type) {
     // The TRT IRNNv2Layer has been deprecated in favor of the loop API.
     ADD_LAYER(RNN)
 #endif
+    default:
+      return "UNKNOWN_LAYER";
   }
-  return "UNKNOWN_LAYER";
 }
 
 #undef ADD_LAYER

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops_test.cc
@@ -366,7 +366,7 @@ class QDQExplicitTest : public ::testing::Test,
     std::vector<const NodeDef*> outputs;
 
     GraphDef gdef;
-    scope->ToGraphDef(&gdef);
+    TF_RETURN_IF_ERROR(scope->ToGraphDef(&gdef));
 
     std::unique_ptr<Graph> graph(new Graph(OpRegistry::Global()));
     TF_RETURN_IF_ERROR(scope->ToGraph(graph.get()));


### PR DESCRIPTION
Fixes warnings related to -Wswitch and -Wunused-result.