### PR TITLE
[TF-TRT] Improvements of the TRTConverterV2 summary

### DIFF
--- a/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.experimental.tensorrt.-converter.pbtxt
@@ -4,7 +4,7 @@ tf_class {
   is_instance: "<type \'object\'>"
   member_method {
     name: "__init__"
-    argspec: "args=[\'self\', \'input_saved_model_dir\', \'input_saved_model_tags\', \'input_saved_model_signature_key\', \'use_dynamic_shape\', \'dynamic_shape_profile_strategy\', \'max_workspace_size_bytes\', \'precision_mode\', \'minimum_segment_size\', \'maximum_cached_engines\', \'use_calibration\', \'allow_build_at_runtime\', \'conversion_params\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\', \'None\', \'1073741824\', \'FP32\', \'3\', \'1\', \'True\', \'True\', \'None\'], "
+    argspec: "args=[\'self\', \'input_saved_model_dir\', \'input_saved_model_tags\', \'input_saved_model_signature_key\', \'use_dynamic_shape\', \'dynamic_shape_profile_strategy\', \'max_workspace_size_bytes\', \'precision_mode\', \'minimum_segment_size\', \'maximum_cached_engines\', \'use_calibration\', \'allow_build_at_runtime\', \'conversion_params\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\', \'None\', \'None\', \'9223372036854775295\', \'FP32\', \'3\', \'1\', \'True\', \'True\', \'None\'], "
   }
   member_method {
     name: "build"
@@ -20,6 +20,6 @@ tf_class {
   }
   member_method {
     name: "summary"
-    argspec: "args=[\'self\', \'line_length\', \'detailed\', \'print_fn\'], varargs=None, keywords=None, defaults=[\'160\', \'True\', \'None\'], "
+    argspec: "args=[\'self\', \'line_length\', \'detailed\', \'verbosity_lvl\', \'print_fn\'], varargs=None, keywords=None, defaults=[\'160\', \'False\', \'1\', \'None\'], "
   }
 }


### PR DESCRIPTION
Minor improvements of the `TRTConverterV2.summary()` method.
- Deprecating `detailed=True` in favor of `verbosity_lvl=[0..2]`
- Prints more details according to the verbosity level requested.
- Default behavior unchanged