### PR TITLE
Unify functions to check whether oneDNN is enabled

### DIFF
--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -489,6 +489,11 @@ cc_library(
         "//tensorflow/python:__pkg__",
         "//tensorflow/python/util:__pkg__",
     ],
+    deps = [
+        "//tensorflow/core/platform:platform_port",
+        "//tensorflow/core/util:env_var",
+        "@com_google_absl//absl/base",
+    ],
     alwayslink = 1,
 )
 

--- a/tensorflow/core/util/port.cc
+++ b/tensorflow/core/util/port.cc
@@ -15,6 +15,9 @@ limitations under the License.
 
 #include "tensorflow/core/util/port.h"
 
+#include "absl/base/call_once.h"
+#include "tensorflow/core/platform/cpu_info.h"
+#include "tensorflow/core/util/env_var.h"
 
 namespace tensorflow {
 
@@ -60,10 +63,57 @@ bool GpuSupportsHalfMatMulAndConv() {
 }
 
 bool IsMklEnabled() {
-#if defined(INTEL_MKL) && defined(ENABLE_MKL)
-  return true;
-#else
+#ifndef INTEL_MKL
   return false;
-#endif  // INTEL_MKL && ENABLE_MKL
+#endif  // !INTEL_MKL
+  static absl::once_flag once;
+#ifdef ENABLE_MKL
+  // Keeping TF_DISABLE_MKL env variable for legacy reasons.
+  static bool oneDNN_disabled = false;
+  absl::call_once(once, [&] {
+    TF_CHECK_OK(ReadBoolFromEnvVar("TF_DISABLE_MKL", false, &oneDNN_disabled));
+    if (oneDNN_disabled) VLOG(2) << "TF-MKL: Disabling oneDNN";
+  });
+  return (!oneDNN_disabled);
+#else
+  // Linux: Turn oneDNN on by default for CPUs with neural network features.
+  // Windows: oneDNN is off by default.
+  // No need to guard for other platforms here because INTEL_MKL is only defined
+  // for non-mobile Linux or Windows.
+  static bool oneDNN_enabled =
+#ifdef __linux__
+      port::TestCPUFeature(port::CPUFeature::AVX512_VNNI) ||
+      port::TestCPUFeature(port::CPUFeature::AVX512_BF16) ||
+      port::TestCPUFeature(port::CPUFeature::AVX_VNNI) ||
+      port::TestCPUFeature(port::CPUFeature::AMX_TILE) ||
+      port::TestCPUFeature(port::CPUFeature::AMX_INT8) ||
+      port::TestCPUFeature(port::CPUFeature::AMX_BF16);
+#else
+      false;
+#endif  // __linux__
+  absl::call_once(once, [&] {
+    auto status = ReadBoolFromEnvVar("TF_ENABLE_ONEDNN_OPTS", oneDNN_enabled,
+                                     &oneDNN_enabled);
+    if (!status.ok()) {
+      LOG(WARNING) << "TF_ENABLE_ONEDNN_OPTS is not set to either '0', 'false',"
+                   << " '1', or 'true'. Using the default setting: "
+                   << oneDNN_enabled;
+    }
+    if (oneDNN_enabled) {
+#ifndef DNNL_AARCH64_USE_ACL
+      LOG(INFO) << "oneDNN custom operations are on. "
+                << "You may see slightly different numerical results due to "
+                << "floating-point round-off errors from different computation "
+                << "orders. To turn them off, set the environment variable "
+                << "`TF_ENABLE_ONEDNN_OPTS=0`.";
+#else
+      LOG(INFO) << "Experimental oneDNN custom operations are on. "
+                << "If you experience issues, please turn them off by setting "
+                << "the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.";
+#endif  // !DNNL_AARCH64_USE_ACL
+    }
+  });
+  return oneDNN_enabled;
+#endif  // ENABLE_MKL
 }
 }  // end namespace tensorflow

--- a/tensorflow/core/util/util.cc
+++ b/tensorflow/core/util/util.cc
@@ -15,16 +15,10 @@ limitations under the License.
 
 #include "tensorflow/core/util/util.h"
 
-#include <string>
-#include <vector>
-
-#include "absl/base/call_once.h"
-#include "tensorflow/core/framework/device_factory.h"
 #include "tensorflow/core/lib/gtl/inlined_vector.h"
 #include "tensorflow/core/lib/strings/strcat.h"
-#include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/platform/logging.h"
-#include "tensorflow/core/util/env_var.h"
+#include "tensorflow/core/util/port.h"
 
 namespace tensorflow {
 
@@ -127,59 +121,9 @@ string SliceDebugString(const TensorShape& shape, const int64_t flat) {
   return result;
 }
 
+// TODO(penporn): Remove this function from util.cc
 bool IsMKLEnabled() {
-#ifndef INTEL_MKL
-  return false;
-#endif  // !INTEL_MKL
-  static absl::once_flag once;
-#ifdef ENABLE_MKL
-  // Keeping TF_DISABLE_MKL env variable for legacy reasons.
-  static bool oneDNN_disabled = false;
-  absl::call_once(once, [&] {
-    TF_CHECK_OK(ReadBoolFromEnvVar("TF_DISABLE_MKL", false, &oneDNN_disabled));
-    if (oneDNN_disabled) VLOG(2) << "TF-MKL: Disabling oneDNN";
-  });
-  return (!oneDNN_disabled);
-#else
-  // Linux: Turn oneDNN on by default for CPUs with neural network features.
-  // Windows: oneDNN is off by default.
-  // No need to guard for other platforms here because INTEL_MKL is only defined
-  // for non-mobile Linux or Windows.
-  static bool oneDNN_enabled =
-#ifdef __linux__
-      port::TestCPUFeature(port::CPUFeature::AVX512_VNNI) ||
-      port::TestCPUFeature(port::CPUFeature::AVX512_BF16) ||
-      port::TestCPUFeature(port::CPUFeature::AVX_VNNI) ||
-      port::TestCPUFeature(port::CPUFeature::AMX_TILE) ||
-      port::TestCPUFeature(port::CPUFeature::AMX_INT8) ||
-      port::TestCPUFeature(port::CPUFeature::AMX_BF16);
-#else
-      false;
-#endif  // __linux__
-  absl::call_once(once, [&] {
-    auto status = ReadBoolFromEnvVar("TF_ENABLE_ONEDNN_OPTS", oneDNN_enabled,
-                                     &oneDNN_enabled);
-    if (!status.ok()) {
-      LOG(WARNING) << "TF_ENABLE_ONEDNN_OPTS is not set to either '0', 'false',"
-                   << " '1', or 'true'. Using the default setting: "
-                   << oneDNN_enabled;
-    }
-    if (oneDNN_enabled) {
-#ifndef DNNL_AARCH64_USE_ACL
-      LOG(INFO) << "oneDNN custom operations are on. "
-                << "You may see slightly different numerical results due to "
-                << "floating-point round-off errors from different computation "
-                << "orders. To turn them off, set the environment variable "
-                << "`TF_ENABLE_ONEDNN_OPTS=0`.";
-#else
-      LOG(INFO) << "Experimental oneDNN custom operations are on. "
-                << "If you experience issues, please turn them off by setting "
-                << "the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.";
-#endif  // !DNNL_AARCH64_USE_ACL
-    }
-  });
-  return oneDNN_enabled;
-#endif  // ENABLE_MKL
+  return IsMklEnabled();
 }
 
 }  // namespace tensorflow

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -358,8 +358,7 @@ def GpuSupportsHalfMatMulAndConv():
 
 
 def IsMklEnabled():
-  return (_pywrap_util_port.IsMklEnabled() or
-          os.getenv("TF_ENABLE_ONEDNN_OPTS", "False").lower() in ["true", "1"])
+  return _pywrap_util_port.IsMklEnabled()
 
 
 def InstallStackTraceHandler():


### PR DESCRIPTION
Unify functions to check whether oneDNN is enabled: [Python test_util checker](https://github.com/tensorflow/tensorflow/blob/76b9fa22857148a562f3d9b5af6843402a93c15b/tensorflow/python/framework/test_util.py#L360-L362), [Pywrapped checker](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/util/port.cc#L62-L67) and [C++ checker](https://github.com/tensorflow/tensorflow/blob/76b9fa22857148a562f3d9b5af6843402a93c15b/tensorflow/core/util/util.cc#L130-L183).

Move the main function to port.cc to avoid cyclic dependency. Keeping the fix minimal to cherry-pick into TF 2.11.

Inconsistencies could cause bugs because Python layer may assume oneDNN is disabled when it's not. For example, `//tensorflow/python/framework:config_test` will fail when run on Cascade Lake or newer CPUs because:
* The test is [supposed to be skipped](https://github.com/tensorflow/tensorflow/blob/76b9fa22857148a562f3d9b5af6843402a93c15b/tensorflow/python/framework/config_test.py#L682-L684) when oneDNN is turned on.
* Python `test_util` `IsMklEnabled` only checks for [static defines](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/util/port.cc#L62-L67) and [`TF_ENABLE_ONEDNN_OPTS` environment variable](https://github.com/tensorflow/tensorflow/blob/76b9fa22857148a562f3d9b5af6843402a93c15b/tensorflow/python/framework/test_util.py#L362). When the var is unset, the Python checker will just think oneDNN is disabled. But oneDNN is turned on by default on Cascade Lake and newer Intel CPUs (even when the env var is unset).
* The test was not skipped when it should have been skipped.