### PR TITLE
[ROCm] Absorb fix for the LLVM AMDGPU backend addition of fp16 support of ne…

### DIFF
--- a/tensorflow/compiler/xla/service/elemental_ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/elemental_ir_emitter.cc
@@ -524,11 +524,7 @@ StatusOr<llvm::Value*> ElementalIrEmitter::EmitFloatUnaryOp(
     // instead once GPU emitter supports lowering LLVM.
     case HloOpcode::kRoundNearestEven:
       return llvm_ir::EmitCallToIntrinsic(
-#if TENSORFLOW_USE_ROCM
-          llvm::Intrinsic::rint,
-#else
           llvm::Intrinsic::nearbyint,
-#endif
           {operand_value}, {operand_value->getType()}, b_);
     case HloOpcode::kSign: {
       auto type = operand_value->getType();


### PR DESCRIPTION
…arbyint.

The following LLVM commit adds fp16 support for the nearbyint intrinsic on the AMDGPU backend:

https://github.com/llvm/llvm-project/commit/6370bc2435a8406898eee7338ae7d795a252ad04