### PR TITLE
[TF-TRT] Adding `TF_TRT_OP_FAKELIST` env var to allow TF-TRT segmentation experimentation

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/BUILD
+++ b/tensorflow/compiler/tf2tensorrt/BUILD
@@ -627,6 +627,11 @@ tf_cuda_library(
         ":utils",
         ":op_converter",
         "//tensorflow/core:lib",
+        "//tensorflow/core/platform:env",
+        "//tensorflow/core/platform:logging",
+        "//tensorflow/core/platform:status",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/strings",
     ] + if_static([":op_converter_registry_impl"]),
 )
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_graph.cc
@@ -785,13 +785,16 @@ Status ConvertGraph(const TRTOptimizationPass::ConversionParams& params,
                              params.use_calibration, params.use_implicit_batch,
                              params.use_explicit_precision);
   TF_RETURN_IF_ERROR(segment::SegmentGraph(
-      &graph, &static_graph_properties,
-      std::bind(&TrtNodeValidator::IsTensorRTCandidate, &validator,
-                std::placeholders::_1),
+      /*tf_graph=*/&graph,
+      /*graph_properties=*/&static_graph_properties,
+      /*candidate_fn=*/std::bind(&TrtNodeValidator::IsTensorRTCandidate,
+                                 &validator, std::placeholders::_1),
       // Input validation is already done by TrtNodeValidator, so we don't
       // need to check the input edges.
-      [](const Edge* edge) { return true; }, OutputEdgeValidator(),
-      segment_options, &initial_segments));
+      /*input_candidate_fn=*/[](const Edge* edge) { return true; },
+      /*output_candidate_fn=*/OutputEdgeValidator(),
+      /*options=*/segment_options,
+      /*segments=*/&initial_segments));
   LOG(INFO) << "Number of TensorRT candidate segments: "
             << initial_segments.size();
 

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -3567,6 +3567,23 @@ Status ConvertIdentity(const OpConverterParams* params) {
   return OkStatus();
 }
 
+// This converter is a debug-only feature designed to allow graph segmentation
+// experiments. Its use is being controled by
+// `TF_TRT_OP_FAKELIST=OpName1,OpName2,...`.
+// See `op_converter_registry.cc` for further details.
+//
+// This converter is designed as followed:
+//   - always succeed at graph segmentation time.
+//   - always fail at TRT Engine build time.
+Status ConvertFake(const OpConverterParams* params) {
+  if (params->validation_only) return OkStatus();
+
+  return errors::Unimplemented("This converter is not valid after graph "
+                               "segmentation. Building an engine using this "
+                               "converter will trigger a native segment "
+                               "fallback.");
+}
+
 Status ConvertSquare(const OpConverterParams* params) {
   const auto& inputs = params->inputs;
   const auto& node_def = params->node_def;
@@ -5713,6 +5730,8 @@ REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertIdentity,
                                    "StopGradient", "_CopyFromHostToGpu"});
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertBatchMatMul,
                                   {"BatchMatMul", "BatchMatMulV2"});
+// Debug converter only accessible via `TF_TRT_OP_FAKELIST=OpName1,OpName2,...`
+REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertFake, "FakeOp");
 
 Status ConvertGraphDefToEngine(
     const GraphDef& gdef, OpKernelContext* ctx, TrtPrecisionMode precision_mode,

--- a/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.cc
@@ -15,9 +15,15 @@ limitations under the License.
 #include "tensorflow/compiler/tf2tensorrt/convert/op_converter_registry.h"
 
 #include <set>
+#include <string>
 #include <utility>
 
+#include "absl/container/flat_hash_set.h"
+#include "absl/strings/str_cat.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/util/env_var.h"
 
 #if GOOGLE_CUDA && GOOGLE_TENSORRT
 
@@ -57,7 +63,37 @@ class OpConverterRegistry::Impl {
     return {};
   }
 
-  StatusOr<OpConverter> LookUp(const string& name) {
+  StatusOr<OpConverter> LookUp(string name) {
+
+    // Fetch the user-provide TF operations denylisted for conversion by TF-TRT.
+    static const absl::flat_hash_set<string> tftrt_op_fakelist = [] {
+      string tftrt_op_fakelist_str;
+      TF_CHECK_OK(ReadStringFromEnvVar("TF_TRT_OP_FAKELIST",
+                                       /*default_value=*/"",
+                                       &tftrt_op_fakelist_str));
+      absl::flat_hash_set<string> tftrt_op_fakelist{};
+      for (const auto& x : str_util::Split(tftrt_op_fakelist_str, ",")) {
+        tftrt_op_fakelist.insert(x);
+      }
+      // Force a rehash of the flat hash set
+      tftrt_op_fakelist.rehash(0);
+      return tftrt_op_fakelist;
+    }();
+
+    // In case the TensorFlow OP `name` matches any of the names passed to
+    // TF_TRT_OP_FAKELIST environment variable, force ::LookUp to resolves to
+    // ConvertFake OP converter.
+    if (tftrt_op_fakelist.contains(name)) {
+      LOG_FIRST_N(INFO, 2) << "Emulating OP Converter: `" << name << "`. It "
+                           << "will cause TRT engine building to fail. This "
+                           << "feature is only intended to be used for "
+                           << "TF-TRT graph segmentation experiments. This "
+                           << "feature is controlled using: "
+                           << "`TF_TRT_OP_FAKELIST=OpName1,OpName2`.";
+      // Forces ::LookUp to resolve to `ConvertFake` registred to `FakeOp`.
+      return registry_.find("FakeOp")->second.converter;
+    }
+
     mutex_lock lock(mu_);
     auto found = registry_.find(name);
     if (found != registry_.end()) {


### PR DESCRIPTION
This PR introduces the env var `TF_TRT_OP_FAKELIST=OpName1,OpName2,...`.

The motivation of this change is to allow to experiment with the impact on graph segmentation of adding converter X, Y or Z.
This API is not designed for users, but rather TF-TRT team to evaluate the importance / impact of the different fearture requests.

 It works by intercepting the call to `OpConverterRegistry::Impl::LookUp` and return the `FakeOp` converter in case the OpName matches any of the names passed in `TF_TRT_OP_FAKELIST`.
 
 This is expected to have zero impact on any of the current workflows.