### PR TITLE
[TF-TRT] `quantization_ops_test.cc` fix an error reported by `-Werror=unused-result`

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops_test.cc
@@ -366,7 +366,7 @@ class QDQExplicitTest : public ::testing::Test,
     std::vector<const NodeDef*> outputs;
 
     GraphDef gdef;
-    scope->ToGraphDef(&gdef);
+    TF_RETURN_IF_ERROR(scope->ToGraphDef(&gdef));
 
     std::unique_ptr<Graph> graph(new Graph(OpRegistry::Global()));
     TF_RETURN_IF_ERROR(scope->ToGraph(graph.get()));


### PR DESCRIPTION
This PR just adds a fix for a recent bazel change adding `-Werror=unused-result` during testing.
This fixes the bug.