### PR TITLE
[TF-TRT] Fix native fallback issue in StridedSlice with dynamic input indices and shrink_axis_mask

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes_test.cc
@@ -5034,8 +5034,8 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
   };
 
   // Same input is used for all tests.
-  const std::vector<float> ok_input = {1, 2, 3, 4, 5, 6};
-
+  const std::vector<float> ok_input = {1, 2, 3, 4, 5, 6,
+                                       7, 8, 9, 10, 11, 12};
   Status modified_batch_dim_status =
       (trt_mode_ == TrtTestMode::kImplicitBatch)
           ? errors::Unimplemented(
@@ -5712,7 +5712,53 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
                      "new_axis_mask is not supported for StridedSlice"),
                  /*runtime_status=*/OkStatus(),
                  /*partial_input_dims=*/{1, 6}},
-  };
+      // Test all axes dynamic inputs with shrink_axis_mask
+      TestParams{/*input_dims=*/{1, 3, 2},
+                 /*begin=*/{0, 0, 0},
+                 /*end=*/{0, 0, 3},
+                 /*strides=*/{1, 1, 1},
+                 /*begin_mask=*/get_mask({ 0,1,1}),
+                 /*end_mask=*/get_mask({0,1,1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/1,
+                 /*expected_output_dims=*/{3,2},
+                 /*expected_output=*/{1,2,3,4,5,6},
+                 /*conversion_status=*/modified_batch_dim_status,
+                 Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, -1}},
+        // Test dynamic input with shrink_axis_mask along axis=0
+        TestParams{/*input_dims=*/{2, 3, 2},
+                 /*begin=*/{0, 0, 0},
+                 /*end=*/{0, 0, 3},
+                 /*strides=*/{1, 1, 1},
+                 /*begin_mask=*/get_mask({ 0,1,1}),
+                 /*end_mask=*/get_mask({0,1,1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/1,
+                 /*expected_output_dims=*/{3,2},
+                 /*expected_output=*/{1,2,3,4,5,6},
+                 /*conversion_status=*/modified_batch_dim_status,
+                 Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, 2}},
+        // Test dynamic input sizes with multiple axes shrinking
+         TestParams{
+                 /*input_dims=*/{2, 3, 2},
+                 /*begin=*/{0, 0, 0},
+                 /*end=*/{0, 0, 3},
+                 /*strides=*/{1, 1, 1},
+                 /*begin_mask=*/get_mask({ 0,1,1}),
+                 /*end_mask=*/get_mask({0,1,1}),
+                 /*ellipsis_mask=*/0,
+                 /*new_axis_mask=*/0,
+                 /*shrink_axis_mask=*/3,
+                 /*expected_output_dims=*/{2},
+                 /*expected_output=*/{1,2},
+                 /*conversion_status=*/modified_batch_dim_status,
+                 Status::OK(),
+                 /*partial_input_dims=*/{-1, -1, 2}},
+   };
 
   int i = 0;
   for (auto p : params) {
@@ -5735,12 +5781,12 @@ TEST_P(OpConverter_FP32_FP16_INT32_Test, ConvertStridedSlice) {
       }
       case TrtTestMode::kDynamicShape: {
         if (p.partial_input_dims.size() > 0) {
-          AddTestTensor("input", p.input_dims, tf_type_, ok_input,
-                        p.partial_input_dims);
-
-        } else {
-          AddTestTensor("input", p.input_dims, tf_type_, ok_input,
-                        p.input_dims);
+            AddTestTensor("input", p.input_dims, tf_type_, ok_input,
+                            p.partial_input_dims);
+        } 
+        else {
+            AddTestTensor("input", p.input_dims, tf_type_, ok_input,
+                          p.input_dims);
         }
         break;
       }

--- a/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/slice_ops.cc
@@ -72,7 +72,11 @@ Status ConvertStridedSliceHelper(
     size_dims.d[i] = (std::abs(end_dims->dim(i) - begin_dims->dim(i)) +
                       std::abs(stride_dims->dim(i)) - 1) /
                      std::abs(stride_dims->dim(i));
-
+    // When begin tensor has negative values, currently range can't be computed.
+    if(begin_dims->dim(i) < 0) {
+      return errors::Unimplemented(
+             "Negative values in begin weight tensor are unsupported");
+    }
     if (input_dims.dim_size(i) < 0) {
       // end_dims and begin_dims do not have valid information yet.
       dynamic_input_size_indices.push_back(i);
@@ -103,14 +107,6 @@ Status ConvertStridedSliceHelper(
       params->converter->network(), params->weight_store);
   TRT_ENSURE_OK(builder);
 
-  // VLOG(2) << "strided slice helper:"
-  //         << " begin:" << DebugString(begin_dims)
-  //         << "\n stride: " << DebugString(stride_dims)
-  //         << "\n end: " << DebugString(end_dims)
-  //         << "\n size: " << DebugString(size_dims)
-  //         << "\n Dynamic indices: " <<
-  //         DebugString(dynamic_input_size_indices)
-  //         << "\n Static indices: " << DebugString(static_input_size_indices);
   // Create the slice operation. For dynamic dims, the inputs of the operations
   // may be reassigned later.
   StatusOr<nvinfer1::ISliceLayer*> slice =
@@ -130,11 +126,33 @@ Status ConvertStridedSliceHelper(
                                   op_instance);
   ITensorProxyPtr tensor = (*slice)->getOutput(0);
 
-  // Reshape for shrink_axis.
+  // Reshape for shrink axis, ellipsis masks based on the shape computed by
+  // ValidateStridedSliceOp or HandleDynamicStridedSliceInput.
+  nvinfer1::Dims dims = tensor->trt_tensor()->getDimensions();
+  std::vector<int> slice_input_dims(dims.d, dims.d + dims.nbDims);
+  StridedSliceShapeSpec empty_spec;
+  empty_spec.shrink_axis_dense_mask = 0;
+  auto shrink_axis_mask = strided_slice_spec.value_or(empty_spec).shrink_axis_dense_mask;
   if (final_shape) {
-    TF_RETURN_IF_ERROR(PrepareTensorForShape(
-        params->converter, TRT_TensorOrWeights(tensor), *final_shape,
-        /*validation_only=*/false, &tensor, node_def, op_instance));
+    if(shrink_axis_mask)  {
+      int shrink_idx = params->use_implicit_batch ? 1 : 0;
+      const auto bShrink_axis_mask = std::bitset<32>(shrink_axis_mask);
+      for(int idx = 0; idx < slice_input_dims.size(); ++idx, ++shrink_idx) {
+        const bool shrink_axis = bShrink_axis_mask[shrink_idx];
+        if(shrink_axis){
+          slice_input_dims[idx] = 0;
+        }
+      }
+      TF_RETURN_IF_ERROR(params->converter->SqueezeTensor(tensor,&slice_input_dims,
+                      params, &tensor, op_instance));
+    }
+    else {
+    /* To do: pmajety:
+          Remove the else condition when shrink_axis_mask is always defined */
+        TF_RETURN_IF_ERROR(PrepareTensorForShape(
+                params->converter, TRT_TensorOrWeights(tensor), *final_shape,
+                /*validation_only=*/false, &tensor, node_def, op_instance));
+    }
   }
   params->outputs->push_back(TRT_TensorOrWeights(tensor));
   return OkStatus();
@@ -152,6 +170,36 @@ Status HandleDynamicStridedSliceInput(
   nvinfer1::ITensor* input_tensor = slice_layer->getInput(0);
   TRT_ENSURE(input_tensor);
 
+  // When begin_mask or end_mask are set, we have to disregard the begin_tensor
+  // and end_tensor values. In static indices cases, ValidateStridedSliceOp
+  // returns the correct begin_tensor and end_tensor values, however with
+  // dynamic indices the correct shape has to be computed.
+
+  VLOG(3) << "begin_dims before: " <<  DebugString(begin_dims);
+  VLOG(3) << "end_dims before: " <<  DebugString(end_dims);
+  const auto begin_mask = std::bitset<32>(strided_slice_spec.begin_dense_mask);
+  const auto end_mask = std::bitset<32>(strided_slice_spec.end_dense_mask);
+  const auto shrink_axis_mask = std::bitset<32>(strided_slice_spec.shrink_axis_dense_mask);
+  nvinfer1::Dims dims = input_tensor->getDimensions();
+
+  for (int idx = 0; idx < dims.nbDims; ++idx){
+    VLOG(3) << "begin_mask[" << idx << "]: "<< begin_mask[idx];
+    VLOG(3) << "end_mask[" << idx << "]: "<< end_mask[idx];
+    VLOG(3) << "shrink_mask[" << idx << "]: "<< shrink_axis_mask[idx];
+    if (begin_mask[idx]) {
+      begin_dims.d[idx] = 0;
+    }
+    if (end_mask[idx]){
+      end_dims.d[idx] = dims.d[idx];
+    }
+    if(shrink_axis_mask[idx]){
+       end_dims.d[idx] = begin_dims.d[idx] + 1;
+    }
+  }
+
+  VLOG(2) << "begin_dims after shrink_axis_mask correction: " <<  DebugString(begin_dims);
+  VLOG(2) << "end_dims after shrink_axis_mask correction: " <<  DebugString(end_dims);
+
   // For each dynamic input dimension of the input, do some preprocessing based
   // on whether this dimension is set in "begin_mask" or "end_mask" and the sign
   // of the dimension's stride value.
@@ -167,8 +215,7 @@ Status HandleDynamicStridedSliceInput(
   //     dynamic size of dimension "dynamic_idx".
   absl::InlinedVector<int64, 4> dynamic_begin_indices;
   absl::InlinedVector<int64, 4> dynamic_end_indices;
-  const auto begin_mask = std::bitset<32>(strided_slice_spec.begin_dense_mask);
-  const auto end_mask = std::bitset<32>(strided_slice_spec.end_dense_mask);
+
   for (int i = 0; i < dynamic_input_size_indices.size(); i++) {
     auto dynamic_idx = dynamic_input_size_indices[i];
     if (begin_mask[dynamic_idx]) {
@@ -177,7 +224,7 @@ Status HandleDynamicStridedSliceInput(
         dynamic_begin_indices.push_back(dynamic_idx);
       }
     }
-    if (end_mask[dynamic_idx]) {
+    if (end_mask[dynamic_idx] && !shrink_axis_mask[dynamic_idx]) {
       end_dims.d[dynamic_idx] = stride_dims.d[dynamic_idx] > 0 ? 0 : -1;
       if (stride_dims.d[dynamic_idx] > 0) {
         dynamic_end_indices.push_back(dynamic_idx);
@@ -185,8 +232,8 @@ Status HandleDynamicStridedSliceInput(
     }
   }
 
-  // VLOG(2) << " Dynamic begin indices: " << DebugString(dynamic_begin_indices)
-  //         << " Dynamic end indices: " << DebugString(dynamic_end_indices);
+  VLOG(2) << " Dynamic begin indices: " << DebugString(dynamic_begin_indices)
+          << " Dynamic end indices: " << DebugString(dynamic_end_indices);
 
   // Create ITensors for each of the begin/stride/end constants.
   StatusOr<nvinfer1::IConstantLayer*> begin_const = builder->Constant(


### PR DESCRIPTION
This PR introduces two changes: 

1. Returns unimplemented error when begin tensor has negative values.
2. Fixes the logic when shrink_axis mask is used with unknown input dimensions. 