### PR TITLE
Remove empty glob

### DIFF
--- a/tensorflow/core/BUILD
+++ b/tensorflow/core/BUILD
@@ -824,17 +824,7 @@ filegroup(
         "//tensorflow/tsl/framework:mobile_srcs_no_runtime",
         "//tensorflow/tsl/framework/fixedpoint:mobile_srcs_no_runtime",
         "//tensorflow/tsl/platform:mobile_srcs_no_runtime",
-    ] + glob(
-        [
-            "client/**/*.cc",
-        ],
-        exclude = [
-            "**/*test.*",
-            "**/*testutil*",
-            "**/*testlib*",
-            "**/*main.cc",
-        ],
-    ),
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
This glob is not globbing anything.
This prevents flipping the flag incompatible_disallow_empty_glob
https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1301#0183e377-b3bf-4648-8470-e7a0d37f4a04/582