### PR TITLE
Add missing link library for MhloDialect

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/IR/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/lib/Dialect/mhlo/IR/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(MhloDialect
   MLIRIR
   MLIRMhloUtils
   MLIRQuantDialect
+  MLIRSparseTensorDialect
   HloOpsCommon
   StablehloBase
 )


### PR DESCRIPTION
Code in MhloDialect uses MLIRSparseTensorDialect, so it needs to be linked against for shared library build to work. This was causing builds to fail for onnx-mlir when updating versions.