### PR TITLE
Fix duplicated dylibs in Mac pip wheel

### DIFF
--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -217,6 +217,12 @@ function prepare_src() {
   rm -f ${TMPDIR}/tensorflow/libtensorflow_framework.so
   rm -f ${TMPDIR}/tensorflow/libtensorflow_framework.so.[0-9].*
 
+  # Copying symlinks with -L duplicates these libraries.
+  rm -f ${TMPDIR}/tensorflow/libtensorflow_framework.dylib
+  rm -f ${TMPDIR}/tensorflow/libtensorflow_framework.[0-9].*.dylib
+  rm -f ${TMPDIR}/tensorflow/libtensorflow_cc.dylib
+  rm -f ${TMPDIR}/tensorflow/libtensorflow_cc.[0-9].*.dylib
+
   # TODO(annarev): copy over API files from tensorflow/api/_vN to tensorflow/
   #   except tensorflow/api/_vN/lite/.
 


### PR DESCRIPTION
Fixes #58164

On Mac, copying the runfiles with `-L` duplicates the symlinked dylibs. On Linux, the duplicate copies are removed during the wheel build, so this PR does the same for Mac.

Before
```
-rwxr-xr-x   1 tester  wheel   473M Oct 19  2022 libtensorflow_cc.2.12.0.dylib
-rwxr-xr-x   1 tester  wheel   473M Oct 19  2022 libtensorflow_cc.2.dylib
-rwxr-xr-x   1 tester  wheel    32M Oct 19  2022 libtensorflow_framework.2.12.0.dylib
-rwxr-xr-x   1 tester  wheel    32M Oct 19  2022 libtensorflow_framework.2.dylib
-rwxr-xr-x   1 tester  wheel    32M Oct 19  2022 libtensorflow_framework.dylib
```

After
```
-rwxr-xr-x   1 tester  wheel   473M Oct 19  2022 libtensorflow_cc.2.dylib
-rwxr-xr-x   1 tester  wheel    32M Oct 19  2022 libtensorflow_framework.2.dylib
```

cc @learning-to-play 