### PR TITLE
Dev n1to1 a

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/BUILD
+++ b/tensorflow/lite/delegates/gpu/cl/BUILD
@@ -123,6 +123,7 @@ cc_test(
     ],
     deps = [
         ":buffer",
+        ":cl_test",
         ":cl_arguments",
         ":gpu_object",
         "//tensorflow/lite/delegates/gpu/common:gpu_info",

--- a/tensorflow/lite/delegates/gpu/cl/cl_arguments_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/cl_arguments_test.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/delegates/gpu/cl/buffer.h"
 #include "tensorflow/lite/delegates/gpu/cl/gpu_object.h"
 #include "tensorflow/lite/delegates/gpu/common/gpu_info.h"
+#include "tensorflow/lite/delegates/gpu/cl/cl_test.h"
 
 namespace tflite {
 namespace gpu {
@@ -45,7 +46,7 @@ __kernel void main_function($0) {
 
   CLArguments cl_args;
   GpuInfo gpu_info;
-  ASSERT_OK(cl_args.Init(gpu_info, {}, nullptr, &args, &sample_code));
+  ASSERT_OK(cl_args.Init(gpu_info, nullptr, &args, &sample_code));
   EXPECT_TRUE(absl::StrContains(sample_code, "value = weights_buffer[id];"));
   EXPECT_TRUE(
       absl::StrContains(sample_code, "__global float4* weights_buffer"));
@@ -67,7 +68,7 @@ TEST(CLArgumentsTest, TestNoSelector) {
 )";
   CLArguments cl_args;
   GpuInfo gpu_info;
-  EXPECT_FALSE(cl_args.Init(gpu_info, {}, nullptr, &args, &sample_code).ok());
+  EXPECT_FALSE(cl_args.Init(gpu_info, nullptr, &args, &sample_code).ok());
 }
 
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/cl/kernels/BUILD
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/BUILD
@@ -40,8 +40,14 @@ cc_test(
         "//tensorflow/lite/delegates/gpu/common:operations",
         "//tensorflow/lite/delegates/gpu/common:status",
         "//tensorflow/lite/delegates/gpu/common/tasks:cast_test_util",
-        "@com_google_googletest//:gtest_main",
-    ],
+    ] + select({
+        "//tensorflow:android": [
+            "@com_google_googletest//:gtest_main",
+        ],
+        "//conditions:default": [
+            "@com_google_googletest//:gtest_main_no_heapcheck",  # constant buffers leak on nvidia
+        ],
+    })
 )
 
 cc_library(
@@ -56,8 +62,14 @@ cc_library(
         "//tensorflow/lite/delegates/gpu/cl:tensor",
         "//tensorflow/lite/delegates/gpu/common:status",
         "//tensorflow/lite/delegates/gpu/common/task:testing_util",
-        "@com_google_googletest//:gtest",
-    ],
+        ] + select({
+            "//tensorflow:android": [
+                "@com_google_googletest//:gtest_main",
+            ],
+            "//conditions:default": [
+                "@com_google_googletest//:gtest_main_no_heapcheck",  # constant buffers leak on nvidia
+            ],
+        }),
 )
 
 cc_test(
@@ -74,8 +86,14 @@ cc_test(
         "//tensorflow/lite/delegates/gpu/common:operations",
         "//tensorflow/lite/delegates/gpu/common:status",
         "//tensorflow/lite/delegates/gpu/common/tasks:concat_test_util",
-        "@com_google_googletest//:gtest_main",
-    ],
+        ] + select({
+            "//tensorflow:android": [
+                "@com_google_googletest//:gtest_main",
+            ],
+            "//conditions:default": [
+                "@com_google_googletest//:gtest_main_no_heapcheck",  # constant buffers leak on nvidia
+            ],
+        }),
 )
 
 cc_test(
@@ -92,8 +110,14 @@ cc_test(
         "//tensorflow/lite/delegates/gpu/common:operations",
         "//tensorflow/lite/delegates/gpu/common:status",
         "//tensorflow/lite/delegates/gpu/common/tasks:conv_constants_test_util",
-        "@com_google_googletest//:gtest_main_no_heapcheck",  # constant buffers leak on nvidia
-    ],
+    ] + select({
+        "//tensorflow:android": [
+            "@com_google_googletest//:gtest_main",
+        ],
+        "//conditions:default": [
+            "@com_google_googletest//:gtest_main_no_heapcheck",  # constant buffers leak on nvidia
+        ],
+    })
 )
 
 cc_test(
@@ -207,8 +231,14 @@ cc_test(
         "//tensorflow/lite/delegates/gpu/common:operations",
         "//tensorflow/lite/delegates/gpu/common:status",
         "//tensorflow/lite/delegates/gpu/common/tasks:convolution_transposed_3x3_thin_test_util",
-        "@com_google_googletest//:gtest_main_no_heapcheck",  # constant buffers leak on nvidia
-    ],
+        ] + select({
+            "//tensorflow:android": [
+                "@com_google_googletest//:gtest_main",
+            ],
+            "//conditions:default": [
+                "@com_google_googletest//:gtest_main_no_heapcheck",  # constant buffers leak on nvidia
+            ],
+        })
 )
 
 cc_test(
@@ -243,8 +273,14 @@ cc_test(
         "//tensorflow/lite/delegates/gpu/common:operations",
         "//tensorflow/lite/delegates/gpu/common:status",
         "//tensorflow/lite/delegates/gpu/common/tasks:convolution_transposed_thin_test_util",
-        "@com_google_googletest//:gtest_main_no_heapcheck",  # constant buffers leak on nvidia
-    ],
+        ] + select({
+            "//tensorflow:android": [
+                "@com_google_googletest//:gtest_main",
+            ],
+            "//conditions:default": [
+                "@com_google_googletest//:gtest_main_no_heapcheck",  # constant buffers leak on nvidia
+            ],
+        })
 )
 
 cc_test(

--- a/tensorflow/lite/delegates/gpu/cl/kernels/add_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/add_test.cc
@@ -29,17 +29,17 @@ namespace {
 
 TEST_F(OpenCLOperationTest, AddTwoEqualTensors) {
   auto status = AddTwoEqualTensorsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, AddFirstTensorHasMoreChannelsThanSecond) {
   auto status = AddFirstTensorHasMoreChannelsThanSecondTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, AddFirstTensorHasLessChannelsThanSecond) {
   auto status = AddFirstTensorHasLessChannelsThanSecond(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/cast_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/cast_test.cc
@@ -27,17 +27,17 @@ namespace {
 
 TEST_F(OpenCLOperationTest, Cast) {
   auto status = CastTests(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, CastToBool) {
   auto status = CastToBoolTests(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, CastFromBool) {
   auto status = CastFromBoolTests(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/cl_test.h
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/cl_test.h
@@ -30,6 +30,10 @@ namespace tflite {
 namespace gpu {
 namespace cl {
 
+#ifndef ASSERT_OK
+#define ASSERT_OK(x) ASSERT_TRUE(x.ok());
+#endif
+
 class ClExecutionEnvironment : public TestExecutionEnvironment {
  public:
   ClExecutionEnvironment() = default;

--- a/tensorflow/lite/delegates/gpu/cl/kernels/concat_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/concat_test.cc
@@ -29,22 +29,22 @@ namespace {
 
 TEST_F(OpenCLOperationTest, ConcatWidth) {
   auto status = ConcatWidthTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConcatHeight) {
   auto status = ConcatHeightTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConcatChannels) {
   auto status = ConcatChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConcatChannelsAlignedx4) {
   auto status = ConcatChannelsAlignedx4Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/conv_constants_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/conv_constants_test.cc
@@ -26,12 +26,12 @@ namespace cl {
 
 TEST_F(OpenCLOperationTest, ConvConstantsSimpleWeights) {
   const auto status = ConvConstantsSimpleWeightsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConvConstants) {
   const auto status = ConvConstantsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/cl/kernels/conv_generic_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/conv_generic_test.cc
@@ -28,27 +28,27 @@ namespace cl {
 
 TEST_F(OpenCLOperationTest, ConvGeneric1x1SimpleWeights) {
   const auto status = ConvGeneric1x1SimpleWeightsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConvGeneric1x1) {
   const auto status = ConvGeneric1x1Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConvGenericSimpleWeights) {
   const auto status = ConvGenericSimpleWeightsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConvGeneric) {
   const auto status = ConvGenericTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConvGenericGrouped) {
   const auto status = ConvGenericGroupedTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/cl/kernels/conv_weights_converter_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/conv_weights_converter_test.cc
@@ -28,32 +28,32 @@ namespace cl {
 
 TEST_F(OpenCLOperationTest, ConverterToConvWeights1x1OutX4) {
   const auto status = ConverterToConvWeights1x1OutX4Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConverterToConvWeights1x1OutX4Unaligned) {
   const auto status = ConverterToConvWeights1x1OutX4UnalignedTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConverterToConvWeights1x1OutX2) {
   const auto status = ConverterToConvWeights1x1OutX2Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConverterToConvWeightsOutX2) {
   const auto status = ConverterToConvWeightsOutX2Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConverterToConvTransposedWeights4x4) {
   const auto status = ConverterToConvTransposedWeights4x4Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConverterToConvWeights4xTextures) {
   const auto status = ConverterToConvWeights4xTexturesTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/cl/kernels/convolution_transposed_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/convolution_transposed_test.cc
@@ -29,12 +29,12 @@ namespace {
 
 TEST_F(OpenCLOperationTest, ConvolutionTransposedSimpleWeights) {
   auto status = ConvolutionTransposedSimpleWeightsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ConvolutionTransposed) {
   auto status = ConvolutionTransposedTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/cumsum_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/cumsum_test.cc
@@ -24,12 +24,12 @@ namespace {
 
 TEST_F(OpenCLOperationTest, CumsumHWCTest) {
   absl::Status status = CumsumHWCTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, CumsumBHWCTest) {
   absl::Status status = CumsumBHWCTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 }  // namespace
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/cl/kernels/depthwise_conv_3x3_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/depthwise_conv_3x3_test.cc
@@ -30,17 +30,17 @@ namespace {
 
 TEST_F(OpenCLOperationTest, DepthwiseConv3x3SimpleWeights) {
   auto status = DepthwiseConv3x3SimpleWeightsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, DepthwiseConv3x3) {
   auto status = DepthwiseConv3x3Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, DepthWiseConv3x3StrideH2SimpleWeights) {
   auto status = DepthWiseConv3x3StrideH2SimpleWeightsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/depthwise_conv_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/depthwise_conv_test.cc
@@ -29,17 +29,17 @@ namespace {
 
 TEST_F(OpenCLOperationTest, DepthwiseConvSimpleWeights) {
   auto status = DepthwiseConvSimpleWeightsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, DepthwiseConvNoMultiplier) {
   auto status = DepthwiseConvNoMultiplierTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, DepthwiseConvMultiplier2) {
   auto status = DepthwiseConvMultiplier2Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/elementwise_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/elementwise_test.cc
@@ -29,217 +29,217 @@ namespace {
 
 TEST_F(OpenCLOperationTest, Abs) {
   auto status = AbsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Cos) {
   auto status = CosTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Copy) {
   auto status = CopyTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Elu) {
   auto status = EluTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Exp) {
   auto status = ExpTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Floor) {
   auto status = FloorTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, FloorDiv) {
   auto status = FloorDivTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, FloorMod) {
   auto status = FloorModTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, HardSwish) {
   auto status = HardSwishTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Log) {
   auto status = LogTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Neg) {
   auto status = NegTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Rsqrt) {
   auto status = RsqrtTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Sigmoid) {
   auto status = SigmoidTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Sin) {
   auto status = SinTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Sqrt) {
   auto status = SqrtTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Square) {
   auto status = SquareTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Tanh) {
   auto status = TanhTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Sub) {
   auto status = SubTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SquaredDiff) {
   auto status = SquaredDiffTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Div) {
   auto status = DivTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Pow) {
   auto status = PowTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Add) {
   auto status = AddTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Maximum) {
   auto status = MaximumTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MaximumWithScalar) {
   auto status = MaximumWithScalarTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MaximumWithConstantLinearTensor) {
   auto status = MaximumWithConstantLinearTensorTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MaximumWithConstantHWCTensor) {
   auto status = MaximumWithConstantHWCTensorTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MaximumWithConstantHWCTensorBroadcastChannels) {
   auto status = MaximumWithConstantHWCTensorBroadcastChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Minimum) {
   auto status = MinimumTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MinimumWithScalar) {
   auto status = MinimumWithScalarTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Mul) {
   auto status = MulTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MulBroadcastHW) {
   auto status = MulBroadcastHWTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MulBroadcastChannels) {
   auto status = MulBroadcastChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SubWithScalarAtFirstPosition) {
   auto status = SubWithScalarAtFirstPositionTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Less) {
   auto status = LessTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, LessEqual) {
   auto status = LessEqualTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Greater) {
   auto status = GreaterTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, GreaterEqual) {
   auto status = GreaterEqualTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Equal) {
   auto status = EqualTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, NotEqual) {
   auto status = NotEqualTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, CosBroadcast) {
   auto status = CosBroadcastTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MaximumScalarBroadcastInput) {
   auto status = MaximumScalarBroadcastInputTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MulLinearBroadcastInput) {
   auto status = MulLinearBroadcastInputTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MulBroadcastBothInputs) {
   auto status = MulBroadcastBothInputsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/fully_connected_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/fully_connected_test.cc
@@ -37,22 +37,22 @@ namespace {
 
 TEST_F(OpenCLOperationTest, FullyConnected) {
   auto status = FullyConnectedTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, FullyConnectedLarge) {
   auto status = FullyConnectedLargeTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, FullyConnectedExtraLarge) {
   auto status = FullyConnectedExtraLargeTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, FullyConnectedInt8) {
   auto status = FullyConnectedInt8Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, RearrageWeights) {

--- a/tensorflow/lite/delegates/gpu/cl/kernels/gather_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/gather_test.cc
@@ -26,7 +26,7 @@ namespace cl {
 
 TEST_F(OpenCLOperationTest, GatherWidth) {
   auto status = GatherWidthTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/cl/kernels/lstm_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/lstm_test.cc
@@ -30,7 +30,7 @@ namespace cl {
 
 TEST_F(OpenCLOperationTest, LSTM) {
   auto status = LstmTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/cl/kernels/max_unpooling_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/max_unpooling_test.cc
@@ -29,7 +29,7 @@ namespace {
 
 TEST_F(OpenCLOperationTest, MaxUnpooling) {
   auto status = MaxUnpoolingTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/mean_stddev_normalization_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/mean_stddev_normalization_test.cc
@@ -31,54 +31,54 @@ namespace {
 TEST_F(OpenCLOperationTest, MeanStddevNormSeparateBatches) {
   // zero mean, zero variance
   auto status = MeanStddevNormSeparateBatchesTest(0.0f, 0.0f, 0.0f, &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 
   // zero mean, small variance
   status = MeanStddevNormSeparateBatchesTest(0.0f, 0.01f, 2.63e-4f, &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 
   // zero mean, large variance
   status =
       MeanStddevNormSeparateBatchesTest(0.0f, 100.0f, 2.63e-4f, &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 
   // small mean, zero variance
   status = MeanStddevNormSeparateBatchesTest(0.01f, 0.0f, 0.0f, &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 
   // small mean, small variance
   status =
       MeanStddevNormSeparateBatchesTest(0.01f, 0.01f, 3.57e-4f, &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 
   // small mean, large variance
   status =
       MeanStddevNormSeparateBatchesTest(1.0f, 100.0f, 2.63e-4f, &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 
   // large mean, zero variance
   status = MeanStddevNormSeparateBatchesTest(100.0f, 0.0f, 0.0f, &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 
   // large mean, small variance
   status =
       MeanStddevNormSeparateBatchesTest(100.0f, 1.0f, 2.63e-4f, &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 
   // large mean, large variance
   status =
       MeanStddevNormSeparateBatchesTest(100.0f, 100.0f, 2.63e-4f, &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MeanStddevNormalizationAllBatches) {
   auto status = MeanStddevNormalizationAllBatchesTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MeanStddevNormalizationLargeVector) {
   auto status = MeanStddevNormalizationLargeVectorTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/one_hot_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/one_hot_test.cc
@@ -27,12 +27,12 @@ namespace {
 
 TEST_F(OpenCLOperationTest, OneHot) {
   auto status = OneHotTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, OneHotBatch) {
   auto status = OneHotBatchTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/padding_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/padding_test.cc
@@ -29,52 +29,52 @@ namespace {
 
 TEST_F(OpenCLOperationTest, PaddingAppendWidth) {
   auto status = PaddingAppendWidthTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, PaddingPrependWidth) {
   auto status = PaddingPrependWidthTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, PaddingAppendHeight) {
   auto status = PaddingAppendHeightTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, PaddingPrependHeight) {
   auto status = PaddingPrependHeightTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, PaddingAppendChannels) {
   auto status = PaddingAppendChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, PaddingPrependChannels) {
   auto status = PaddingPrependChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, PaddingPrependChannelsX4) {
   auto status = PaddingPrependChannelsX4Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, PaddingComplex) {
   auto status = PaddingComplexTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, PaddingReflectWidth) {
   auto status = PaddingReflectWidthTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, PaddingReflectChannels) {
   auto status = PaddingReflectChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/pooling_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/pooling_test.cc
@@ -29,22 +29,22 @@ namespace {
 
 TEST_F(OpenCLOperationTest, AveragePooling) {
   auto status = AveragePoolingTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, AveragePoolingNonEmptyPadding) {
   auto status = AveragePoolingNonEmptyPaddingTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MaxPooling) {
   auto status = MaxPoolingTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, MaxPoolingIndices) {
   auto status = MaxPoolingIndicesTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/prelu_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/prelu_test.cc
@@ -29,12 +29,12 @@ namespace {
 
 TEST_F(OpenCLOperationTest, PReLUAlpha) {
   auto status = PReLUAlphaTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, PReLUHWCAlpha) {
   auto status = PReLUHWCAlphaTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/quantize_and_dequantize_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/quantize_and_dequantize_test.cc
@@ -29,22 +29,22 @@ namespace {
 
 TEST_F(OpenCLOperationTest, QuantAndDequant_Dim2Bits8) {
   auto status = QuantAndDequant_Dim2Bits8Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, QuantAndDequant_Dim3Bits8_NegativeRange) {
   auto status = QuantAndDequant_Dim3Bits8_NegativeRangeTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, QuantAndDequant_Dim3Bits16) {
   auto status = QuantAndDequant_Dim3Bits16Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, QuantAndDequant_Dim2Bits16_NegativeRange) {
   auto status = QuantAndDequant_Dim2Bits16_NegativeRangeTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/reduce_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/reduce_test.cc
@@ -29,27 +29,27 @@ namespace {
 
 TEST_F(OpenCLOperationTest, MeanHW) {
   auto status = MeanHWTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ReduceSumChannels) {
   auto status = ReduceSumChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ReduceProductChannels) {
   auto status = ReduceProductChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ReduceMaxChannels) {
   auto status = ReduceMaxChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ReduceMinChannels) {
   auto status = ReduceMinChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/relu_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/relu_test.cc
@@ -28,22 +28,22 @@ namespace cl {
 
 TEST_F(OpenCLOperationTest, ReLUNoClipNoAlpha) {
   auto status = ReLUNoClipNoAlphaTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ReLUClip) {
   auto status = ReLUClipTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ReLUAlpha) {
   auto status = ReLUAlphaTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ReLUAlphaClip) {
   auto status = ReLUAlphaClipTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/cl/kernels/relu_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/relu_test.cc
@@ -46,6 +46,26 @@ TEST_F(OpenCLOperationTest, ReLUAlphaClip) {
   ASSERT_TRUE(status.ok()) << status;
 }
 
+TEST_F(OpenCLOperationTest, ReLULClipNoAlphaNoClip) {
+  auto status = ReLULClipNoAlphaNoClipTest(&exec_env_);
+  ASSERT_TRUE(status.ok()) << status;
+}
+
+TEST_F(OpenCLOperationTest, ReLUAlphaLClipNoClip) {
+  auto status = ReLUAlphaLClipNoClipTest(&exec_env_);
+  ASSERT_TRUE(status.ok()) << status;
+}
+
+TEST_F(OpenCLOperationTest, ReLULClipClipNoAlpha) {
+  auto status = ReLULClipClipNoAlphaTest(&exec_env_);
+  ASSERT_TRUE(status.ok()) << status;
+}
+
+TEST_F(OpenCLOperationTest, ReLUAlphaLClipClip) {
+  auto status = ReLUAlphaLClipClipTest(&exec_env_);
+  ASSERT_TRUE(status.ok()) << status;
+}
+
 }  // namespace cl
 }  // namespace gpu
 }  // namespace tflite

--- a/tensorflow/lite/delegates/gpu/cl/kernels/resampler_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/resampler_test.cc
@@ -28,13 +28,13 @@ namespace cl {
 
 TEST_F(OpenCLOperationTest, ResamplerIdentity) {
   auto status = ResamplerIdentityTest(BHWC(1, 2, 2, 1), &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 
   status = ResamplerIdentityTest(BHWC(1, 3, 5, 3), &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 
   status = ResamplerIdentityTest(BHWC(1, 6, 1, 7), &exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/cl/kernels/reshape_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/reshape_test.cc
@@ -29,7 +29,7 @@ namespace {
 
 TEST_F(OpenCLOperationTest, Reshape) {
   auto status = ReshapeTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/reshapex4_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/reshapex4_test.cc
@@ -29,7 +29,7 @@ namespace {
 
 TEST_F(OpenCLOperationTest, Reshapex4) {
   auto status = Reshapex4Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/resize_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/resize_test.cc
@@ -29,37 +29,37 @@ namespace {
 
 TEST_F(OpenCLOperationTest, ResizeBilinearAligned) {
   auto status = ResizeBilinearAlignedTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ResizeBilinearNonAligned) {
   auto status = ResizeBilinearNonAlignedTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ResizeBilinearWithoutHalfPixel) {
   auto status = ResizeBilinearWithoutHalfPixelTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ResizeBilinearWithHalfPixel) {
   auto status = ResizeBilinearWithHalfPixelTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ResizeNearest) {
   auto status = ResizeNearestTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ResizeNearestAlignCorners) {
   auto status = ResizeNearestAlignCornersTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, ResizeNearestHalfPixelCenters) {
   auto status = ResizeNearestHalfPixelCentersTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/select_v2_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/select_v2_test.cc
@@ -24,42 +24,42 @@ namespace {
 
 TEST_F(OpenCLOperationTest, SelectV2) {
   auto status = SelectV2Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SelectV2Batch) {
   auto status = SelectV2BatchTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SelectV2Channels) {
   auto status = SelectV2ChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SelectV2ChannelsBatch) {
   auto status = SelectV2ChannelsBatchTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SelectV2BroadcastTrue) {
   auto status = SelectV2BroadcastTrueTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SelectV2BroadcastFalse) {
   auto status = SelectV2BroadcastFalseTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SelectV2BroadcastBoth) {
   auto status = SelectV2BroadcastBothTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SelectV2ChannelsBroadcastFalse) {
   auto status = SelectV2ChannelsBroadcastFalseTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/softmax1x1_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/softmax1x1_test.cc
@@ -29,12 +29,12 @@ namespace {
 
 TEST_F(OpenCLOperationTest, Softmax1x1) {
   auto status = Softmax1x1Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Softmax1x1BigNumber) {
   auto status = Softmax1x1BigNumberTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/softmax_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/softmax_test.cc
@@ -29,12 +29,12 @@ namespace {
 
 TEST_F(OpenCLOperationTest, Softmax) {
   auto status = SoftmaxTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SoftmaxBigNumber) {
   auto status = SoftmaxBigNumberTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/space_to_depth_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/space_to_depth_test.cc
@@ -29,22 +29,22 @@ namespace {
 // 5xxs.
 TEST_F(OpenCLOperationTest, SpaceToDepthTensorShape1x2x2x1BlockSize2) {
   auto status = SpaceToDepthTensorShape1x2x2x1BlockSize2Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SpaceToDepthTensorShape1x2x2x2BlockSize2) {
   auto status = SpaceToDepthTensorShape1x2x2x2BlockSize2Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SpaceToDepthTensorShape1x2x2x3BlockSize2) {
   auto status = SpaceToDepthTensorShape1x2x2x3BlockSize2Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SpaceToDepthTensorShape1x4x4x1BlockSize2) {
   auto status = SpaceToDepthTensorShape1x4x4x1BlockSize2Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/split_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/split_test.cc
@@ -28,32 +28,32 @@ namespace cl {
 
 TEST_F(OpenCLOperationTest, SplitChannels) {
   auto status = SplitChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SplitChannelsX4) {
   auto status = SplitChannelsX4Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SplitWidth) {
   auto status = SplitWidthTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SplitHeight) {
   auto status = SplitHeightTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SplitBatch) {
   auto status = SplitBatchTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, SplitDepth) {
   auto status = SplitDepthTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/cl/kernels/strided_slice_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/strided_slice_test.cc
@@ -29,7 +29,7 @@ namespace {
 
 TEST_F(OpenCLOperationTest, StridedSlice) {
   auto status = StridedSliceTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/tile_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/tile_test.cc
@@ -26,27 +26,27 @@ namespace cl {
 
 TEST_F(OpenCLOperationTest, TileChannels) {
   auto status = TileChannelsTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, TileChannelsX4) {
   auto status = TileChannelsX4Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, TileWidth) {
   auto status = TileWidthTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, TileHeight) {
   auto status = TileHeightTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, TileHWC) {
   auto status = TileHWCTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/cl/kernels/transpose_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/transpose_test.cc
@@ -29,7 +29,7 @@ namespace {
 
 TEST_F(OpenCLOperationTest, Transpose) {
   auto status = TransposeTest(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace

--- a/tensorflow/lite/delegates/gpu/cl/kernels/winograd_test.cc
+++ b/tensorflow/lite/delegates/gpu/cl/kernels/winograd_test.cc
@@ -26,22 +26,22 @@ namespace cl {
 
 TEST_F(OpenCLOperationTest, Winograd4x4To36TileX6) {
   auto status = Winograd4x4To36TileX6Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Winograd36To4x4Tile4x1) {
   auto status = Winograd36To4x4Tile4x1Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Winograd4x4To36) {
   auto status = Winograd4x4To36Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST_F(OpenCLOperationTest, Winograd36To4x4) {
   auto status = Winograd36To4x4Test(&exec_env_);
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace cl

--- a/tensorflow/lite/delegates/gpu/common/BUILD
+++ b/tensorflow/lite/delegates/gpu/common/BUILD
@@ -8,6 +8,15 @@ package(
 )
 
 cc_library(
+    name = "gpu_common_wrapper",
+    linkopts = select({
+        "//tensorflow:android": [
+            "-lm",
+        ],
+    }),
+)
+
+cc_library(
     name = "convert",
     srcs = ["convert.cc"],
     hdrs = ["convert.h"],
@@ -119,6 +128,7 @@ cc_test(
     name = "data_type_test",
     srcs = ["data_type_test.cc"],
     deps = [
+        ":gpu_common_wrapper",
         ":data_type",
         "@com_google_googletest//:gtest_main",
     ],
@@ -185,6 +195,7 @@ cc_test(
     name = "model_test",
     srcs = ["model_test.cc"],
     deps = [
+        ":gpu_common_wrapper",
         ":model",
         "@com_google_absl//absl/status",
         "@com_google_googletest//:gtest_main",
@@ -397,6 +408,7 @@ cc_test(
     name = "shape_test",
     srcs = ["shape_test.cc"],
     deps = [
+        ":gpu_common_wrapper",
         ":shape",
         "@com_google_googletest//:gtest_main",
     ],
@@ -440,6 +452,7 @@ cc_test(
     name = "memory_management_test",
     srcs = ["memory_management_test.cc"],
     deps = [
+        ":gpu_common_wrapper",
         ":memory_management",
         ":shape",
         ":types",
@@ -452,6 +465,7 @@ cc_test(
     name = "memory_management_internal_test",
     srcs = ["memory_management/internal_test.cc"],
     deps = [
+        ":gpu_common_wrapper",
         ":memory_management",
         "@com_google_googletest//:gtest_main",
     ],
@@ -461,6 +475,7 @@ cc_test(
     name = "memory_management_types_test",
     srcs = ["memory_management/types_test.cc"],
     deps = [
+        ":gpu_common_wrapper",
         ":memory_management",
         "@com_google_googletest//:gtest_main",
     ],
@@ -498,6 +513,7 @@ cc_test(
     name = "util_test",
     srcs = ["util_test.cc"],
     deps = [
+        ":gpu_common_wrapper",
         ":util",
         "@com_google_googletest//:gtest_main",
     ],
@@ -508,6 +524,7 @@ cc_library(
     srcs = ["winograd_util.cc"],
     hdrs = ["winograd_util.h"],
     deps = [
+        ":gpu_common_wrapper",
         ":data_type",
         ":operations",
         ":shape",
@@ -519,6 +536,7 @@ cc_test(
     name = "winograd_util_test",
     srcs = ["winograd_util_test.cc"],
     deps = [
+        ":gpu_common_wrapper",
         ":winograd_util",
         "@com_google_googletest//:gtest_main",
     ],

--- a/tensorflow/lite/delegates/gpu/common/model_builder_helper.cc
+++ b/tensorflow/lite/delegates/gpu/common/model_builder_helper.cc
@@ -400,6 +400,7 @@ absl::Status MaybeFuseActivation(TfLiteFusedActivation fused_activation,
       attr.clip = fused_activation == kTfLiteActRelu
                       ? 0.0f
                       : (fused_activation == kTfLiteActReluN1To1 ? 1.0f : 6.0f);
+      attr.lclip = fused_activation == kTfLiteActReluN1To1 ? -1.0f : 0.0f;
       Node* activation_node;
       RETURN_IF_ERROR(
           NewPassthroughNode(graph, node, outputs[0], &activation_node));

--- a/tensorflow/lite/delegates/gpu/common/operations.h
+++ b/tensorflow/lite/delegates/gpu/common/operations.h
@@ -388,18 +388,23 @@ Padding3D CalculateSamePadding(const BHWDC& input,
                                const DepthwiseConvolution3DAttributes& attr);
 
 // f(x):= {
-//   if x < 0  : x -> alpha * x
-//   if x >= 0 : x -> min(clip, x)
+//   if x < lclip  : x -> min(lclip, alpha * x)
+//   if x >= lclip : x -> min(clip, x)
 // }
 //
 // Examples:
-//   - ReLU: clip = 0, alpha = 0
-//   - ReLU6: clip = 6, alpha = 0
-//   - Leaky ReLU: clip = 0, alpha = a
+//   - ReLU: clip = 0, alpha = 0, lclip = 0
+//   - ReLU6: clip = 6, alpha = 0, lclip = 0
+//   - Leaky ReLU: clip = 0, alpha = a, lclip = 0
+//   - ReLUN1To1: clip = 1, alpha = 0, lclip = -1
 struct ReLUAttributes {
   // clip <= 0 mean it is not set.
   float clip = 0;
 
+  // lclip must be < clip
+  float lclip = 0;
+
+  // alpha must be <= 1
   float alpha = 0;
 };
 

--- a/tensorflow/lite/delegates/gpu/common/tasks/fully_connected_test_util.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/fully_connected_test_util.cc
@@ -52,8 +52,7 @@ absl::Status FullyConnectedTest(TestExecutionEnvironment* env) {
       RETURN_IF_ERROR(env->ExecuteGPUOperation(
           src_tensor, std::make_unique<FullyConnected>(std::move(operation)),
           BHWC(1, 1, 1, 2), &dst_tensor));
-      RETURN_IF_ERROR(PointWiseNear({14.5f, 37.5f}, dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+      RETURN_IF_ERROR(PointWiseNear({14.5f, 37.5f}, dst_tensor.data, eps));
     }
   }
   return absl::OkStatus();
@@ -101,8 +100,7 @@ absl::Status FullyConnectedLargeTest(TestExecutionEnvironment* env) {
       RETURN_IF_ERROR(
           PointWiseNear({139.4f, 363.5f, 587.6f, 811.7f, 1035.8f, 1259.9f,
                          1484.1f, 1708.2f, 1932.3f, 2156.4f, 2380.5f, 2604.6f},
-                        dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+                        dst_tensor.data, eps));
     }
   }
   return absl::OkStatus();
@@ -159,8 +157,7 @@ absl::Status FullyConnectedExtraLargeTest(TestExecutionEnvironment* env) {
       RETURN_IF_ERROR(env->ExecuteGPUOperation(
           src_tensor, std::make_unique<FullyConnected>(std::move(operation)),
           BHWC(1, 1, 1, kOutputSize), &dst_tensor));
-      RETURN_IF_ERROR(PointWiseNear(expected, dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+      RETURN_IF_ERROR(PointWiseNear(expected, dst_tensor.data, eps));
     }
   }
   return absl::OkStatus();
@@ -194,8 +191,7 @@ absl::Status FullyConnectedInt8Test(TestExecutionEnvironment* env) {
       RETURN_IF_ERROR(env->ExecuteGPUOperation(
           src_tensor, std::make_unique<FullyConnected>(std::move(operation)),
           BHWC(1, 1, 1, 2), &dst_tensor));
-      RETURN_IF_ERROR(PointWiseNear({20.5f, 15.5f}, dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+      RETURN_IF_ERROR(PointWiseNear({20.5f, 15.5f}, dst_tensor.data, eps));
     }
   }
   return absl::OkStatus();

--- a/tensorflow/lite/delegates/gpu/common/tasks/lstm_test_util.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/lstm_test_util.cc
@@ -66,15 +66,13 @@ absl::Status LstmTest(TestExecutionEnvironment* env) {
           {BHWC(1, 1, 1, 4), BHWC(1, 1, 1, 4)}, {&new_state, &new_activ}));
       RETURN_IF_ERROR(
           PointWiseNear({7.0 / 15.0, 10.0 / 15.0, 13.0 / 15.0, 16.0 / 15.0},
-                        new_state.data, eps))
-          << ToString(storage) << ", " << ToString(precision);
+                        new_state.data, eps));
       RETURN_IF_ERROR(PointWiseNear(
           {static_cast<float>((1.0 / 6.0) * std::tanh(7.0 / 15.0)),
            static_cast<float>((1.0 / 6.0) * std::tanh(10.0 / 15.0)),
            static_cast<float>((1.0 / 6.0) * std::tanh(13.0 / 15.0)),
            static_cast<float>((1.0 / 6.0) * std::tanh(16.0 / 15.0))},
-          new_activ.data, eps))
-          << ToString(storage) << ", " << ToString(precision);
+          new_activ.data, eps));
     }
   }
   return absl::OkStatus();

--- a/tensorflow/lite/delegates/gpu/common/tasks/mean_stddev_normalization_test_util.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/mean_stddev_normalization_test_util.cc
@@ -126,8 +126,7 @@ absl::Status MeanStddevNormalizationAllBatchesTest(
           -ksqrt16, -ksqrt04, ksqrt04, ksqrt16,  // large mean, small variance
           -ksqrt16, -ksqrt04, ksqrt04, ksqrt16,  // large mean, large variance
       };
-      RETURN_IF_ERROR(PointWiseNear(expected_output, dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+      RETURN_IF_ERROR(PointWiseNear(expected_output, dst_tensor.data, eps));
 
       TensorFloat32 dst_tensor_single_step;
       auto operation_single_step = CreateMeanStdDevNormalization(
@@ -139,8 +138,7 @@ absl::Status MeanStddevNormalizationAllBatchesTest(
                                        std::move(operation_single_step)),
                                    BHWC(9, 1, 1, 4), &dst_tensor_single_step));
       RETURN_IF_ERROR(
-          PointWiseNear(expected_output, dst_tensor_single_step.data, eps))
-          << "Failed using precision " << ToString(precision);
+          PointWiseNear(expected_output, dst_tensor_single_step.data, eps));
     }
   }
   return absl::OkStatus();
@@ -198,8 +196,7 @@ absl::Status MeanStddevNormalizationLargeVectorTest(
         expected_output[kVectorSize + i + 0] = +expected_elem;
         expected_output[kVectorSize + i + 1] = -expected_elem;
       }
-      RETURN_IF_ERROR(PointWiseNear(expected_output, dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+      RETURN_IF_ERROR(PointWiseNear(expected_output, dst_tensor.data, eps));
 
       if (precision != CalculationsPrecision::F32) {
         TensorFloat32 dst_tensor_single_step;
@@ -212,8 +209,7 @@ absl::Status MeanStddevNormalizationLargeVectorTest(
                 std::move(operation_single_step)),
             BHWC(1, 1, 2, kVectorSize), &dst_tensor_single_step));
         RETURN_IF_ERROR(
-            PointWiseNear(expected_output, dst_tensor_single_step.data, eps))
-            << "Failed using precision " << ToString(precision);
+            PointWiseNear(expected_output, dst_tensor_single_step.data, eps));
       }
     }
   }

--- a/tensorflow/lite/delegates/gpu/common/tasks/relu.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/relu.cc
@@ -28,14 +28,21 @@ ElementwiseDescriptor CreateReLU(const ReLUAttributes& attr,
   ElementwiseDescriptor result;
   std::string min_func;
   if (attr.alpha != 0.0f) {
-    min_func = "min(in_value * args.alpha, INIT_FLT(0.0f))";
+    min_func = "min(in_value * args.alpha, INIT_FLT4(args.lclip))";
     if (precision == CalculationsPrecision::F32) {
       result.args.AddFloat("alpha", attr.alpha);
+      result.args.AddFloat("lclip", attr.lclip);
     } else {
       result.args.AddHalf("alpha", half(attr.alpha));
+      result.args.AddHalf("lclip", half(attr.lclip));
     }
   } else {
-    min_func = "INIT_FLT4(0.0f)";
+    min_func = "INIT_FLT4(args.lclip)";
+    if (precision == CalculationsPrecision::F32) {
+      result.args.AddFloat("lclip", attr.lclip);
+    } else {
+      result.args.AddHalf("lclip", half(attr.lclip));
+    }
   }
   if (attr.clip != 0.0f) {
     if (precision == CalculationsPrecision::F32) {

--- a/tensorflow/lite/delegates/gpu/common/tasks/relu_test_util.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/relu_test_util.cc
@@ -142,5 +142,130 @@ absl::Status ReLUAlphaClipTest(TestExecutionEnvironment* env) {
   return absl::OkStatus();
 }
 
+absl::Status ReLULClipNoAlphaNoClipTest(TestExecutionEnvironment* env) {
+  TensorFloat32 src_tensor;
+  src_tensor.shape = BHWC(1, 2, 1, 4);
+  src_tensor.data = {-12.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f};
+
+  ReLUAttributes attr;
+  attr.alpha = 0.0f;
+  attr.lclip = -1.0f;
+  attr.clip = 0.0f;
+
+  for (auto precision : env->GetSupportedPrecisions()) {
+    auto data_type = DeduceDataTypeFromPrecision(precision);
+    for (auto storage : env->GetSupportedStorages(data_type)) {
+      const float eps = precision == CalculationsPrecision::F32 ? 1e-6f : 1e-3f;
+      OperationDef op_def;
+      op_def.precision = precision;
+      auto data_type = DeduceDataTypeFromPrecision(precision);
+      op_def.src_tensors.push_back({data_type, storage, Layout::HWC});
+      op_def.dst_tensors.push_back({data_type, storage, Layout::HWC});
+      TensorFloat32 dst_tensor;
+      GPUOperation operation = CreateReLU(op_def, attr);
+      RETURN_IF_ERROR(env->ExecuteGPUOperation(
+          src_tensor, absl::make_unique<GPUOperation>(std::move(operation)),
+          BHWC(1, 2, 1, 4), &dst_tensor));
+      RETURN_IF_ERROR(
+          PointWiseNear({-1.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f},
+              dst_tensor.data, eps));
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status ReLUAlphaLClipNoClipTest(TestExecutionEnvironment* env) {
+  TensorFloat32 src_tensor;
+  src_tensor.shape = BHWC(1, 2, 1, 4);
+  src_tensor.data = {-12.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f};
+
+  ReLUAttributes attr;
+  attr.alpha = 0.5f;
+  attr.lclip = -1.0f;
+  attr.clip = 0.0f;
+
+  for (auto precision : env->GetSupportedPrecisions()) {
+    auto data_type = DeduceDataTypeFromPrecision(precision);
+    for (auto storage : env->GetSupportedStorages(data_type)) {
+      const float eps = precision == CalculationsPrecision::F32 ? 1e-6f : 1e-3f;
+      OperationDef op_def;
+      op_def.precision = precision;
+      auto data_type = DeduceDataTypeFromPrecision(precision);
+      op_def.src_tensors.push_back({data_type, storage, Layout::HWC});
+      op_def.dst_tensors.push_back({data_type, storage, Layout::HWC});
+      TensorFloat32 dst_tensor;
+      GPUOperation operation = CreateReLU(op_def, attr);
+      RETURN_IF_ERROR(env->ExecuteGPUOperation(
+          src_tensor, absl::make_unique<GPUOperation>(std::move(operation)),
+          BHWC(1, 2, 1, 4), &dst_tensor));
+      RETURN_IF_ERROR(PointWiseNear({-6.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f},
+          dst_tensor.data, eps));
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status ReLULClipClipNoAlphaTest(TestExecutionEnvironment* env) {
+  TensorFloat32 src_tensor;
+  src_tensor.shape = BHWC(1, 2, 1, 4);
+  src_tensor.data = {-12.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f};
+
+  ReLUAttributes attr;
+  attr.alpha = 0.0f;
+  attr.lclip = -1.0f;
+  attr.clip = 1.0f;
+
+  for (auto precision : env->GetSupportedPrecisions()) {
+    auto data_type = DeduceDataTypeFromPrecision(precision);
+    for (auto storage : env->GetSupportedStorages(data_type)) {
+      const float eps = precision == CalculationsPrecision::F32 ? 1e-6f : 1e-3f;
+      OperationDef op_def;
+      op_def.precision = precision;
+      auto data_type = DeduceDataTypeFromPrecision(precision);
+      op_def.src_tensors.push_back({data_type, storage, Layout::HWC});
+      op_def.dst_tensors.push_back({data_type, storage, Layout::HWC});
+      TensorFloat32 dst_tensor;
+      GPUOperation operation = CreateReLU(op_def, attr);
+      RETURN_IF_ERROR(env->ExecuteGPUOperation(
+          src_tensor, absl::make_unique<GPUOperation>(std::move(operation)),
+          BHWC(1, 2, 1, 4), &dst_tensor));
+      RETURN_IF_ERROR(PointWiseNear({-1.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 1.0f},
+          dst_tensor.data, eps));
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status ReLUAlphaLClipClipTest(TestExecutionEnvironment* env) {
+  TensorFloat32 src_tensor;
+  src_tensor.shape = BHWC(1, 2, 1, 4);
+  src_tensor.data = {-12.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f};
+
+  ReLUAttributes attr;
+  attr.alpha = 0.5f;
+  attr.lclip = -1.0f;
+  attr.clip = 3.0f;
+
+  for (auto precision : env->GetSupportedPrecisions()) {
+    auto data_type = DeduceDataTypeFromPrecision(precision);
+    for (auto storage : env->GetSupportedStorages(data_type)) {
+      const float eps = precision == CalculationsPrecision::F32 ? 1e-6f : 1e-3f;
+      OperationDef op_def;
+      op_def.precision = precision;
+      auto data_type = DeduceDataTypeFromPrecision(precision);
+      op_def.src_tensors.push_back({data_type, storage, Layout::HWC});
+      op_def.dst_tensors.push_back({data_type, storage, Layout::HWC});
+      TensorFloat32 dst_tensor;
+      GPUOperation operation = CreateReLU(op_def, attr);
+      RETURN_IF_ERROR(env->ExecuteGPUOperation(
+          src_tensor, absl::make_unique<GPUOperation>(std::move(operation)),
+          BHWC(1, 2, 1, 4), &dst_tensor));
+      RETURN_IF_ERROR(PointWiseNear({-6.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.0f},
+          dst_tensor.data, eps));
+    }
+  }
+  return absl::OkStatus();
+}
+
 }  // namespace gpu
 }  // namespace tflite

--- a/tensorflow/lite/delegates/gpu/common/tasks/relu_test_util.h
+++ b/tensorflow/lite/delegates/gpu/common/tasks/relu_test_util.h
@@ -26,6 +26,10 @@ absl::Status ReLUNoClipNoAlphaTest(TestExecutionEnvironment* env);
 absl::Status ReLUClipTest(TestExecutionEnvironment* env);
 absl::Status ReLUAlphaTest(TestExecutionEnvironment* env);
 absl::Status ReLUAlphaClipTest(TestExecutionEnvironment* env);
+absl::Status ReLULClipNoAlphaNoClipTest(TestExecutionEnvironment* env);
+absl::Status ReLUAlphaLClipNoClipTest(TestExecutionEnvironment* env);
+absl::Status ReLULClipClipNoAlphaTest(TestExecutionEnvironment* env);
+absl::Status ReLUAlphaLClipClipTest(TestExecutionEnvironment* env);
 
 }  // namespace gpu
 }  // namespace tflite

--- a/tensorflow/lite/delegates/gpu/gl/BUILD
+++ b/tensorflow/lite/delegates/gpu/gl/BUILD
@@ -212,7 +212,12 @@ cc_test(
     linkopts = [
         "-lEGL",
         "-lGLESv2",
-    ],
+    ] + select({
+        "//tensorflow:android": [
+            "-ldl",
+            "-lm",
+        ],
+    }),
     tags = tf_gpu_tests_tags() + [
         "local",
         "nobuilder",
@@ -445,6 +450,11 @@ cc_library(
 cc_test(
     name = "serialization_test",
     srcs = ["serialization_test.cc"],
+    linkopts = select({
+        "//tensorflow:android": [
+            "-lm",
+        ],
+    }),
     tags = [
         "local",
         "nobuilder",

--- a/tensorflow/lite/delegates/gpu/gl/kernels/BUILD
+++ b/tensorflow/lite/delegates/gpu/gl/kernels/BUILD
@@ -44,6 +44,7 @@ cc_test(
     ],
     deps = [
         ":converter",
+        ":test_util",
         "//tensorflow/lite/delegates/gpu/common:convert",
         "//tensorflow/lite/delegates/gpu/common:shape",
         "//tensorflow/lite/delegates/gpu/common:status",
@@ -719,7 +720,12 @@ cc_library(
     linkopts = [
         "-lEGL",
         "-lGLESv3",
-    ],
+    ] + select({
+        "//tensorflow:android": [
+            "-ldl",
+            "-lm",
+        ],
+    }),
     deps = [
         "//tensorflow/lite/delegates/gpu/common:model",
         "//tensorflow/lite/delegates/gpu/common:operations",

--- a/tensorflow/lite/delegates/gpu/gl/kernels/relu.cc
+++ b/tensorflow/lite/delegates/gpu/gl/kernels/relu.cc
@@ -43,10 +43,12 @@ class ReLU : public NodeShader {
     std::vector<Variable> params;
     std::string min;
     if (attr.alpha == 0) {
-      min = "vec4(0.0)";
+      min = "vec4($lclip$)";
+      params.push_back({"lclip", attr.lclip});
     } else {
-      min = "min($alpha$ * value_0, 0.0)";
+      min = "min($alpha$ * value_0, $lclip$)";
       params.push_back({"alpha", attr.alpha});
+      params.push_back({"lclip", attr.lclip});
     }
     std::string code;
     if (attr.clip == 0) {

--- a/tensorflow/lite/delegates/gpu/gl/kernels/relu_test.cc
+++ b/tensorflow/lite/delegates/gpu/gl/kernels/relu_test.cc
@@ -94,6 +94,62 @@ TEST_F(ReluTest, ClipAndAlpha) {
               Pointwise(FloatNear(1e-6), {-3.0, 0.0, 2.0, 6.0}));
 }
 
+TEST_F(ReluTest, ReLULClipNoAlphaNoClip) {
+  OperationType op_type = OperationType::RELU;
+  ReLUAttributes attr;
+  attr.lclip = -1;
+  attr.clip = 0;
+  attr.alpha = 0;
+  SingleOpModel model({ToString(op_type), attr}, {GetTensorRef(0)},
+                      {GetTensorRef(1)});
+  ASSERT_TRUE(model.PopulateTensor(0, {-12.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f}));
+  ASSERT_OK(model.Invoke(*NewReLUNodeShader()));
+  EXPECT_THAT(model.GetOutput(0),
+              Pointwise(FloatNear(1e-6), {-1.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f}));
+}
+
+TEST_F(ReluTest, ReLUAlphaLClipNoClip) {
+  OperationType op_type = OperationType::RELU;
+  ReLUAttributes attr;
+  attr.lclip = -1;
+  attr.clip = 0;
+  attr.alpha = 0.5;
+  SingleOpModel model({ToString(op_type), attr}, {GetTensorRef(0)},
+                      {GetTensorRef(1)});
+  ASSERT_TRUE(model.PopulateTensor(0, {-12.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f}));
+  ASSERT_OK(model.Invoke(*NewReLUNodeShader()));
+  EXPECT_THAT(model.GetOutput(0),
+              Pointwise(FloatNear(1e-6), {-6.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f}));
+}
+
+TEST_F(ReluTest, ReLULClipClipNoAlpha) {
+  OperationType op_type = OperationType::RELU;
+  ReLUAttributes attr;
+  attr.lclip = -1;
+  attr.clip = 1;
+  attr.alpha = 0;
+  SingleOpModel model({ToString(op_type), attr}, {GetTensorRef(0)},
+                      {GetTensorRef(1)});
+  ASSERT_TRUE(model.PopulateTensor(0, {-12.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f}));
+  ASSERT_OK(model.Invoke(*NewReLUNodeShader()));
+  EXPECT_THAT(model.GetOutput(0),
+              Pointwise(FloatNear(1e-6), {-1.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 1.0f}));
+}
+
+TEST_F(ReluTest, ReLUAlphaLClipClip) {
+  OperationType op_type = OperationType::RELU;
+  ReLUAttributes attr;
+  attr.lclip = -1;
+  attr.clip = 3;
+  attr.alpha = 0.5;
+  SingleOpModel model({ToString(op_type), attr}, {GetTensorRef(0)},
+                      {GetTensorRef(1)});
+  ASSERT_TRUE(model.PopulateTensor(0, {-12.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.2f}));
+  ASSERT_OK(model.Invoke(*NewReLUNodeShader()));
+  EXPECT_THAT(model.GetOutput(0),
+              Pointwise(FloatNear(1e-6), {-6.0f, -1.0f, -0.5f, 0.0f, 0.8f, -0.6f, 1.0f, 3.0f}));
+}
+
 }  // namespace
 }  // namespace gl
 }  // namespace gpu

--- a/tensorflow/lite/delegates/gpu/gl/kernels/resampler_test.cc
+++ b/tensorflow/lite/delegates/gpu/gl/kernels/resampler_test.cc
@@ -74,17 +74,17 @@ absl::Status ResamplerIdentityTest(const BHWC& shape) {
 
 TEST(ResamplerTest, Identity_2_2_1) {
   auto status = ResamplerIdentityTest(BHWC(1, 2, 2, 1));
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST(ResamplerTest, Identity_3_5_3) {
   auto status = ResamplerIdentityTest(BHWC(1, 3, 5, 3));
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 TEST(ResamplerTest, Identity_6_1_7) {
   auto status = ResamplerIdentityTest(BHWC(1, 6, 1, 7));
-  ASSERT_TRUE(status.ok()) << status.error_message();
+  ASSERT_TRUE(status.ok()) << status;
 }
 
 }  // namespace


### PR DESCRIPTION
 Fix ReLUN1To1 fused activation for OpenCL and OpenGL

The ReLUN1To1 op was repurposed from the a ReLU1 op. However it was not fully reimplemented. As a result it clipped to a minimum of 0 instead of -1.

Add a left clip attribute, lclip, to the ReLU implementation. Set to -1 for ReLUN1To1 and 0 for all other ReLUs.