### PR TITLE
Remove outdated docs re: Arduino Library Manager installation

### DIFF
--- a/tensorflow/lite/g3doc/microcontrollers/library.md
+++ b/tensorflow/lite/g3doc/microcontrollers/library.md
@@ -60,7 +60,7 @@ instructions in this section.
 ### Use the Arduino library
 
 If you are using Arduino, the *Hello World* example is included in the
-`Arduino_TensorFlowLite` Arduino library, which you can download from the
+`Arduino_TensorFlowLite` Arduino library, which you can manually install in the
 Arduino IDE and in [Arduino Create](https://create.arduino.cc/).
 
 Once the library has been added, go to `File -> Examples`. You should see an
@@ -168,9 +168,6 @@ You can add your own optimizations by creating a new subfolder for them. We
 encourage pull requests for new optimized implementations.
 
 ## Generate the Arduino library
-
-A nightly build of the Arduino library is available via the Arduino IDE's
-library manager.
 
 If you need to generate a new build of the library, you can run the following
 script from the TensorFlow repository:


### PR DESCRIPTION
For some years, Arduino maintained a TensorFlow Lite Micro mirror packaged as a standalone Arduino library named "**Arduino_TensorFlowLite**". This allowed the library to be distributed via [the Arduino Library Manager system](https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-installing-a-library#installing-a-library).

The maintainers of [the official `tensorflow/tflite-micro-arduino-examples` repository](https://github.com/tensorflow/tflite-micro-arduino-examples) recently requested that library be removed from the Arduino Library Manager (https://github.com/arduino/library-registry/pull/1748). For this reason, it is no longer possible to install the library via Library Manager. The library should now be installed following the official instructions here:

https://github.com/tensorflow/tflite-micro-arduino-examples#how-to-install