### PR TITLE
Removed merge conflict marker

### DIFF
--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -321,7 +321,6 @@ bool IsHostMemoryArg(const EagerOperation& op, const NodeDef* node_def,
 Status GetDeviceForInput(const EagerOperation& op, const EagerContext& ctx,
                          const bool is_host_memory_arg,
                          TensorHandle* tensor_handle, Device** result) {
->>>>>>> f5381e0e10b (Fix OOB error when op input sizes do not match.)
   Device* cpu_device = ctx.HostCPU();
   string device_name;
   if (tensor_handle->Type() != TensorHandle::LOCAL) {


### PR DESCRIPTION
Hi!

I was trying to compile r2.9 from source and the compiler found this merge conflict marker still in `execute.cc` which was causing compilation to fail. As far as I can see the other merge conflict markers had been removed but this one was still there.

Any questions or comments please let me know!
    
Jamie