### PR TITLE
Add CustomCallWithComputation to the xla_client ops.

### DIFF
--- a/tensorflow/compiler/xla/client/xla_builder.h
+++ b/tensorflow/compiler/xla/client/xla_builder.h
@@ -2199,7 +2199,7 @@ XlaOp CustomCallWithComputation(
     absl::Span<const std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>
         output_operand_aliasing = {},
     const Literal* literal = nullptr,
-    CustomCallSchedule = CustomCallSchedule::SCHEDULE_NONE,
+    CustomCallSchedule schedule = CustomCallSchedule::SCHEDULE_NONE,
     CustomCallApiVersion api_version = API_VERSION_ORIGINAL);
 
 // Overload which constructs a custom call with fixed layouts. The operands will

--- a/tensorflow/compiler/xla/python/ops.cc
+++ b/tensorflow/compiler/xla/python/ops.cc
@@ -209,6 +209,28 @@ void BuildOpsSubmodule(py::module* m) {
       py::arg("output_operand_aliasing"), py::arg("literal") = nullptr,
       py::arg("schedule") = CustomCallSchedule::SCHEDULE_NONE,
       py::arg("api_version") = CustomCallApiVersion::API_VERSION_ORIGINAL);
+  ops.def(
+      "CustomCallWithComputation",
+      [](XlaBuilder* builder, const std::string& call_target_name,
+         absl::Span<const XlaOp> operands, const XlaComputation& computation,
+         const Shape& shape, const std::string& opaque,
+         bool has_side_effect,
+         absl::Span<const std::pair<ShapeIndex, std::pair<int64_t, ShapeIndex>>>
+                output_operand_aliasing,
+         const Literal* literal,
+         CustomCallSchedule schedule,
+         CustomCallApiVersion api_version) -> XlaOp {
+        return CustomCallWithComputation(
+            builder, call_target_name, operands, computation,
+            shape, opaque, has_side_effect,
+            output_operand_aliasing, literal, schedule, api_version);
+      },
+      py::arg("builder"), py::arg("call_target_name"), py::arg("operands"),
+      py::arg("computation"), py::arg("shape"),
+      py::arg("opaque") = py::bytes(""), py::arg("has_side_effect") = false,
+      py::arg("output_operand_aliasing"), py::arg("literal") = nullptr,
+      py::arg("schedule") = CustomCallSchedule::SCHEDULE_NONE,
+      py::arg("api_version") = CustomCallApiVersion::API_VERSION_ORIGINAL);
   ops.def("Dot", &Dot, py::arg("lhs"), py::arg("rhs"),
           py::arg("precision_config") = nullptr,
           py::arg("preferred_element_type") = std::nullopt);


### PR DESCRIPTION
This change allows users of the `xla_client` to create custom calls that also have an attached computation.