### PR TITLE
[oneDNN] Quantized batch-matmul and fusions

### DIFF
--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -535,3 +535,17 @@ tf_cc_test_mkl(
         "//tensorflow/core/kernels/mkl:mkl_softmax_op",
     ] + MKL_TEST_DEPS,
 )
+
+tf_cc_test_mkl(
+    name = "onednn_fused_batchmatmul_op_test",
+    size = "medium",
+    srcs = ["onednn_fused_batchmatmul_op_test.cc"],
+    linkstatic = 1,
+    deps = [
+        ":mkl_batch_matmul_op",
+        ":mkl_kernel_util",
+        "//tensorflow/core:direct_session",
+        "//tensorflow/core/kernels:quantization_utils",
+        "@com_google_absl//absl/strings",
+    ] + MKL_TEST_DEPS,
+)

--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
@@ -21,9 +21,9 @@ limitations under the License.
 // dimensions (rank) for output tensor is DNNL_MAX_NDIMS = 12 in oneDNN.
 // If output tensor rank exceeds 12, we exit with reporting an error message.
 
-#define EIGEN_USE_THREADS
-
 #if defined(INTEL_MKL)
+
+#define EIGEN_USE_THREADS
 
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "tensorflow/core/framework/register_types.h"
@@ -35,6 +35,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/matmul_op_impl.h"
 #include "tensorflow/core/kernels/mkl/mkl_batch_matmul_helper.h"
 #include "tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h"
+#include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/matmul_bcast.h"
 
@@ -199,25 +200,14 @@ class BatchMatMulMkl : public OpKernel {
     // Execute matmul primitive.
     std::shared_ptr<stream> cpu_stream;
     cpu_stream.reset(CreateStream(&eigen_tp, matmul_prim->GetEngine()));
-    if (fused_ops_.size() > 0) {
-      void* mul_data = nullptr;
-      void* add_data = nullptr;
-      if (fused_ops_.at(0) == "Mul") {
-        const Tensor& mul_tensor = ctx->input(2);
-        mul_data = static_cast<void*>(
-            const_cast<Toutput*>(mul_tensor.flat<Toutput>().data()));
-      }
-      if (fused_ops_.size() > 1 && fused_ops_.at(1) == "Add") {
-        const Tensor& add_tensor = ctx->input(3);
-        add_data = static_cast<void*>(
-            const_cast<Toutput*>(add_tensor.flat<Toutput>().data()));
-      }
+    if (this->fusion_data_.size() > 0) {
       matmul_prim->Execute(cpu_stream, lhs.flat<Tlhs>().data(), weight_data,
-                           out->flat<Toutput>().data(), scratch_pad.Get(),
-                           mul_data, add_data);
+                           out->flat<Toutput>().data(), *params,
+                           scratch_pad.Get(), this->fusion_data_);
     } else {
       matmul_prim->Execute(cpu_stream, lhs.flat<Tlhs>().data(), weight_data,
-                           out->flat<Toutput>().data(), scratch_pad.Get());
+                           out->flat<Toutput>().data(), *params,
+                           scratch_pad.Get());
     }
   }
 
@@ -226,89 +216,449 @@ class BatchMatMulMkl : public OpKernel {
  protected:
   virtual void ExtendMklMatMulParams(OpKernelContext* ctx,
                                      MklMatMulParams& params) {}
-  std::vector<string> fused_ops_;
+  std::vector<void*> fusion_data_;
 
  private:
   bool adj_x_;
   bool adj_y_;
 };
 
+// OneDNN uses post-ops to implement different kind of fusions. The category of
+// each individual post-op can be inferred from the fused_ops attribute. The
+// following enum is used to identify list of required post-ops.
+namespace {
+
+enum class FusedComputationType {
+  kUndefined,
+  kMul,
+  kAdd,
+  kMulAdd,
+  kDequantize,
+  kMul_Dequantize,
+  kAdd_Dequantize,
+  kMulAdd_Dequantize,
+  kRequantize,
+  kMul_Requantize,
+  kAdd_Requantize,
+  kMulAdd_Requantize,
+};
+
+struct FusedComputationPattern {
+  FusedComputationType fused_computation;
+  std::vector<string> fused_ops;
+};
+
+}  // namespace
+enum class PostOpKind { kNone, kOutputScale, kMul, kAdd, kLinear };
+
+// FusedBatchMatMul has additional inputs, currently forcing all the operands
+// of fusion to have same type `U`.
 template <typename Device, typename Tlhs, typename Trhs, typename Toutput,
-          bool v2_bcast>
+          /*type of additional tensors*/ typename U, bool v2_bcast>
 class FusedBatchMatMulMkl
     : public BatchMatMulMkl<Device, Tlhs, Trhs, Toutput, v2_bcast> {
  public:
   explicit FusedBatchMatMulMkl(OpKernelConstruction* context)
       : BatchMatMulMkl<Device, Tlhs, Trhs, Toutput, v2_bcast>(context) {
-    OP_REQUIRES_OK(context, context->GetAttr("fused_ops", &this->fused_ops_));
-    OP_REQUIRES(context, !this->fused_ops_.empty(),
-                absl::InvalidArgumentError(
-                    "Fused BatchMatMul must have at least one fused op."));
-
-    int num_args;
-    OP_REQUIRES_OK(context, context->GetAttr("num_args", &num_args));
-
-    if (this->fused_ops_ == std::vector<string>{"Mul"} ||
-        this->fused_ops_ == std::vector<string>{"Mul", "Add"}) {
-      OP_REQUIRES(context, num_args == this->fused_ops_.size(),
-                  absl::InvalidArgumentError(
-                      "Fused BatchMatmul should have same number of additional "
-                      "inputs as the number of fusions"));
-    } else {
-      OP_REQUIRES(context, false,
-                  absl::UnimplementedError(
-                      absl::StrCat("Fusion is not implemented: [",
-                                   absl::StrJoin(this->fused_ops_, ","), "]")));
-    }
+    InitializeFusion(context);
   }
 
   virtual ~FusedBatchMatMulMkl() {}
 
  protected:
+  struct PostOpInfo {
+    PostOpKind post_op_kind;
+    int input_idx = -1;  // Operand tensor index if needed by a post-op.
+  };
+
+  std::vector<PostOpInfo> post_op_info_list_;
+
+  // This function is called from constructor.
+  void InitializeFusion(OpKernelConstruction* context) {
+    std::vector<string> fused_ops;
+    OP_REQUIRES_OK(context, context->GetAttr("fused_ops", &fused_ops));
+    OP_REQUIRES(context, !fused_ops.empty(),
+                absl::InvalidArgumentError(
+                    "Fused BatchMatMul must have at least one fused op."));
+
+    using FCT = FusedComputationType;
+    // TODO(intel-tf): Add more patterns when implemented. Refactor for
+    // arbitrary fusion sequence when oneDNN is performant.
+    std::vector<FusedComputationPattern> patterns{
+        {FCT::kMul, {"Mul"}},
+        {FCT::kAdd, {"Add"}},
+        {FCT::kMulAdd, {"Mul", "Add"}},
+    };
+    FusedComputationType fused_computation = FusedComputationType::kUndefined;
+    for (const auto& pattern : patterns) {
+      if (fused_ops == pattern.fused_ops) {
+        fused_computation = pattern.fused_computation;
+        break;
+      }
+    }
+
+    // Configure oneDNN post-ops. Refactor for arbitrary fusion sequence when
+    // oneDNN is performant.
+    switch (fused_computation) {
+      case FCT::kMul:
+        post_op_info_list_ = {{PostOpKind::kMul, 2}};
+        break;
+      case FCT::kAdd:
+        post_op_info_list_ = {{PostOpKind::kAdd, 2}};
+        break;
+      case FCT::kMulAdd:
+        post_op_info_list_ = {{PostOpKind::kMul, 2}, {PostOpKind::kAdd, 3}};
+        break;
+      default:
+        OP_REQUIRES_OK(context, absl::UnimplementedError(absl::StrCat(
+                                    "Fusion is not implemented: [",
+                                    absl::StrJoin(fused_ops, ","), "]")));
+    }
+
+    int num_args = 0;
+    OP_REQUIRES_OK(context, context->GetAttr("num_args", &num_args));
+    this->fusion_data_.resize(num_args);
+  }
+
   virtual void ExtendMklMatMulParams(OpKernelContext* ctx,
                                      MklMatMulParams& params) {
-    if (this->fused_ops_.size() > 0) {
-      const Tensor& scale_tensor = ctx->input(2);
-      OP_REQUIRES(ctx, scale_tensor.NumElements() == 1,
-                  absl::InvalidArgumentError("Scale tensor must be a scalar"));
-
-      memory::data_type data_type = MklDnnType<Toutput>();
-      memory::format_tag format_tag;
-      switch (params.c_dims.size()) {
-        case 3:
-          format_tag = memory::format_tag::abc;
-          break;
-        case 4:
-          format_tag = memory::format_tag::abcd;
-          break;
+    int idx = 0;
+    for (const auto& post_op_info : this->post_op_info_list_) {
+      switch (post_op_info.post_op_kind) {
+        case PostOpKind::kMul: {
+          const Tensor& multiplicand_tensor =
+              ctx->input(post_op_info.input_idx);
+          // TODO(intel-tf): Relax restriction when oneDNN is performant for
+          // arbitrary shapes.
+          bool is_supported = multiplicand_tensor.NumElements() == 1 &&
+                              params.c_dims.size() == 4;
+          OP_REQUIRES(ctx, is_supported,
+                      absl::UnimplementedError(absl::StrCat(
+                          "Unimplemented multiplicand shape for Mul fusion: ",
+                          multiplicand_tensor.shape().DebugString())));
+          auto format_tag = memory::format_tag::abcd;
+          memory::data_type data_type = MklDnnType<U>();
+          memory::dims mul_dims(params.c_dims.size(), 1);
+          params.post_op_params.push_back(
+              {"mul", {}, mul_dims, data_type, format_tag});
+          void* multiplicand_data = static_cast<void*>(
+              const_cast<U*>(multiplicand_tensor.flat<U>().data()));
+          this->fusion_data_[idx++] = multiplicand_data;
+        } break;
+        case PostOpKind::kAdd: {
+          const Tensor& addend_tensor = ctx->input(post_op_info.input_idx);
+          // TODO(intel-tf): Relax restriction when oneDNN is performant for
+          // arbitrary shapes.
+          bool is_supported = params.c_dims.size() == 4 &&
+                              addend_tensor.dims() == params.c_dims.size();
+          OP_REQUIRES(ctx, is_supported,
+                      absl::UnimplementedError(absl::StrCat(
+                          "Unimplemented addend shape for Add fusion: ",
+                          addend_tensor.shape().DebugString())));
+          auto format_tag = memory::format_tag::abcd;
+          memory::data_type data_type = MklDnnType<U>();
+          memory::dims addend_dims = TFShapeToMklDnnDims(addend_tensor.shape());
+          params.post_op_params.push_back(
+              {"add", {}, addend_dims, data_type, format_tag});
+          void* addend_data = static_cast<void*>(
+              const_cast<U*>(addend_tensor.flat<U>().data()));
+          this->fusion_data_[idx++] = addend_data;
+        } break;
         default:
-          OP_REQUIRES(ctx, false, absl::UnimplementedError("Unimplemented"));
+          OP_REQUIRES_OK(ctx,
+                         absl::UnimplementedError("Unsupported post-op-kind."));
       }
-      if (this->fused_ops_.at(0) == "Mul") {
-        memory::dims mul_dims(params.c_dims.size(), 1);
-        params.post_op_params.push_back(
-            {"mul", {}, mul_dims, data_type, format_tag});
+    }
+  }
+};
+
+template <typename Device, typename Tlhs, typename Trhs, typename Toutput,
+          typename U>
+class QuantizedBatchMatMulOp
+    : public BatchMatMulMkl<Device, Tlhs, Trhs, Toutput, /*v2_bcast*/ true> {
+ public:
+  explicit QuantizedBatchMatMulOp(OpKernelConstruction* context)
+      : BatchMatMulMkl<Device, Tlhs, Trhs, Toutput, true>(context) {
+    InitializeFusion(context);
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    BatchMatMulMkl<Device, Tlhs, Trhs, Toutput, true>::Compute(ctx);
+    if (std::is_same<Toutput, qint8>::value ||
+        std::is_same<Toutput, quint8>::value) {
+      Tensor* min_output = nullptr;
+      Tensor* max_output = nullptr;
+      // When output type is qint8 or quint8, the kernel is registered for
+      // Requantize fusion.
+      OP_REQUIRES_OK(ctx, ctx->allocate_output(1, {}, &min_output));
+      OP_REQUIRES_OK(ctx, ctx->allocate_output(2, {}, &max_output));
+      int output_min_idx = ctx->num_inputs() - 2;
+      int output_max_idx = ctx->num_inputs() - 1;
+      const float requested_min = ctx->input(output_min_idx).flat<float>()(0);
+      const float requested_max = ctx->input(output_max_idx).flat<float>()(0);
+      if (output_quant_mode_ == "SCALED") {
+        const float range_output =
+            std::max(std::abs(requested_min), std::abs(requested_max));
+        if (std::is_same<Toutput, qint8>::value) {
+          min_output->flat<float>()(0) = -range_output;
+          max_output->flat<float>()(0) = range_output;
+        } else {
+          min_output->flat<float>()(0) = 0;
+          max_output->flat<float>()(0) = range_output;
+        }
       } else {
-        OP_REQUIRES(ctx, false,
-                    absl::InvalidArgumentError(absl::StrCat(
-                        "Currently first fusion is supported only for Mul",
-                        ", but it is ", this->fused_ops_.at(0), " op.")));
+        min_output->flat<float>()(0) = requested_min;
+        max_output->flat<float>()(0) = requested_max;
       }
-      if (this->fused_ops_.size() > 1 && this->fused_ops_.at(1) == "Add") {
-        auto add_shape = ctx->input(3).shape();
-        OP_REQUIRES(ctx, add_shape.dims() == 4,
-                    absl::InvalidArgumentError(absl::StrCat(
-                        "Add fusion expects add shape to have 4 dims, but got ",
-                        add_shape.dims())));
-        memory::dims add_dims = {add_shape.dim_size(0), add_shape.dim_size(1),
-                                 add_shape.dim_size(2), add_shape.dim_size(3)};
-        params.post_op_params.push_back(
-            {"add", {}, add_dims, data_type, format_tag});
-      } else {
-        OP_REQUIRES(ctx, false,
-                    absl::InvalidArgumentError(absl::StrCat(
-                        "Currently second fusion is supported only for Add",
-                        ", but it is ", this->fused_ops_.at(1), " op.")));
+    } else if (std::is_same<Toutput, float>::value ||
+               std::is_same<Toutput, bfloat16>::value) {
+      // Kernel is registered for Dequantization fusion. Nothing to do.
+    } else {
+      OP_REQUIRES_OK(ctx,
+                     absl::InvalidArgumentError("Unsupported output type."));
+    }
+  }
+
+  virtual ~QuantizedBatchMatMulOp() {}
+
+ protected:
+  string input_quant_mode_;  // Both lhs and rhs are quantized with same mode.
+  string output_quant_mode_;
+
+  // Initialize minmax tensor indices with default values for the most common
+  // cases.
+  int lhs_min_idx_ = 2;
+  int lhs_max_idx_ = 3;
+  int rhs_min_idx_ = 4;
+  int rhs_max_idx_ = 5;
+
+  struct PostOpInfo {
+    PostOpKind post_op_kind;
+    struct OperandInfo {
+      int idx = -1;  // Operand tensor index if needed by a post-op.
+      // Indices of min and max value tensors, if the operand is quantized.
+      std::vector<int> min_max_indices;
+    } operand_info;
+    // Indices of output min and max value tensors. It is used when requantize
+    // is fused.
+    std::vector<int> min_max_indices;
+  };
+
+  std::vector<PostOpInfo> post_op_info_list_;
+
+  int num_operands_;  // Number of regular operands without minmax tensors.
+
+  void UpdateInputMinMaxIndices(int offset) {
+    lhs_min_idx_ += offset;
+    lhs_max_idx_ += offset;
+    rhs_min_idx_ += offset;
+    rhs_max_idx_ += offset;
+  }
+
+  void InitializeFusion(OpKernelConstruction* context) {
+    // Currently, tensor quantized with only SCALED mode is supported.
+    OP_REQUIRES_OK(context, context->GetAttr("input_quant_mode",
+                                             &this->input_quant_mode_));
+    OP_REQUIRES(context, input_quant_mode_ == "SCALED",
+                absl::UnimplementedError(
+                    "Input tensors are not quantized with SCALED mode."));
+    OP_REQUIRES_OK(context, context->GetAttr("output_quant_mode",
+                                             &this->output_quant_mode_));
+
+    std::vector<string> fused_ops;
+    OP_REQUIRES_OK(context, context->GetAttr("fused_ops", &fused_ops));
+    if (fused_ops.empty())
+      OP_REQUIRES_OK(context,
+                     absl::InvalidArgumentError(
+                         "Fused BatchMatMul must have at least one fused op."));
+
+    using FCT = FusedComputationType;
+    // TODO(intel-tf): Add more patterns when implemented.
+    std::vector<FusedComputationPattern> patterns{
+        {FCT::kDequantize, {"Dequantize"}},
+        {FCT::kMul_Dequantize, {"Mul", "Dequantize"}},
+        {FCT::kAdd_Dequantize, {"Add", "Dequantize"}},
+        {FCT::kMulAdd_Dequantize, {"Mul", "Add", "Dequantize"}},
+        {FCT::kRequantize, {"Requantize"}},
+        {FCT::kMul_Requantize, {"Mul", "Requantize"}},
+        {FCT::kAdd_Requantize, {"Add", "Requantize"}},
+        {FCT::kMulAdd_Requantize, {"Mul", "Add", "Requantize"}},
+    };
+
+    FusedComputationType fused_computation = FusedComputationType::kUndefined;
+    for (const auto& pattern : patterns) {
+      if (fused_ops == pattern.fused_ops) {
+        fused_computation = pattern.fused_computation;
+        break;
+      }
+    }
+
+    // Configure oneDNN post ops
+    switch (fused_computation) {
+      case FCT::kDequantize: {
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}}};
+      } break;
+      case FCT::kRequantize: {
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}},
+                              {PostOpKind::kLinear, {}, {6, 7}}};
+      } break;
+      case FCT::kMul_Dequantize: {
+        this->UpdateInputMinMaxIndices(1);
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}},
+                              {PostOpKind::kMul, {2, {}}, {}}};
+        this->fusion_data_.resize(1);
+      } break;
+      case FCT::kMul_Requantize: {
+        this->UpdateInputMinMaxIndices(1);
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}},
+                              {PostOpKind::kMul, {2, {}}, {}},
+                              {PostOpKind::kLinear, {}, {7, 8}}};
+        this->fusion_data_.resize(1);
+      } break;
+      case FCT::kAdd_Dequantize: {
+        this->UpdateInputMinMaxIndices(1);
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}},
+                              {PostOpKind::kAdd, {2, {}}, {}}};
+        this->fusion_data_.resize(1);
+      } break;
+      case FCT::kAdd_Requantize: {
+        this->UpdateInputMinMaxIndices(1);
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}},
+                              {PostOpKind::kAdd, {2, {}}, {}},
+                              {PostOpKind::kLinear, {}, {7, 8}}};
+        this->fusion_data_.resize(1);
+      } break;
+      case FCT::kMulAdd_Dequantize: {
+        this->UpdateInputMinMaxIndices(2);
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}},
+                              {PostOpKind::kMul, {2, {}}, {}},
+                              {PostOpKind::kAdd, {3, {}}, {}}};
+        this->fusion_data_.resize(2);
+      } break;
+      case FCT::kMulAdd_Requantize: {
+        this->UpdateInputMinMaxIndices(2);
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}},
+                              {PostOpKind::kMul, {2, {}}, {}},
+                              {PostOpKind::kAdd, {3, {}}, {}},
+                              {PostOpKind::kLinear, {}, {8, 9}}};
+        this->fusion_data_.resize(2);
+      } break;
+      default:
+        OP_REQUIRES(context, false,
+                    absl::UnimplementedError(
+                        absl::StrCat("Fusion is not implemented: [",
+                                     absl::StrJoin(fused_ops, ","), "]")));
+    }
+  }
+
+  void ExtendMklMatMulParams(OpKernelContext* ctx,
+                             MklMatMulParams& params) override {
+    int idx = 0;
+    for (const auto& post_op_info : post_op_info_list_) {
+      switch (post_op_info.post_op_kind) {
+        case PostOpKind::kMul: {
+          const Tensor& multiplicand_tensor =
+              ctx->input(post_op_info.operand_info.idx);
+          // TODO(intel-tf): Relax restriction when oneDNN is performant for
+          // arbitrary shapes.
+          bool is_supported = multiplicand_tensor.NumElements() == 1 &&
+                              params.c_dims.size() == 4;
+          OP_REQUIRES(ctx, is_supported,
+                      absl::UnimplementedError("Unimplemented"));
+          auto format_tag = memory::format_tag::abcd;
+          memory::data_type data_type = MklDnnType<U>();
+          memory::dims mul_dims(params.c_dims.size(), 1);
+          params.post_op_params.push_back(
+              {"mul", {}, mul_dims, data_type, format_tag});
+          void* multiplicand_data = static_cast<void*>(
+              const_cast<U*>(multiplicand_tensor.flat<U>().data()));
+          this->fusion_data_[idx++] = multiplicand_data;
+        } break;
+        case PostOpKind::kAdd: {
+          const Tensor& addend_tensor =
+              ctx->input(post_op_info.operand_info.idx);
+          // TODO(intel-tf): Relax restriction when oneDNN is performant for
+          // arbitrary shapes.
+          bool is_supported = params.c_dims.size() == 4 &&
+                              addend_tensor.dims() == params.c_dims.size();
+          OP_REQUIRES(ctx, is_supported,
+                      absl::UnimplementedError("Unimplemented."));
+          auto format_tag = memory::format_tag::abcd;
+          memory::data_type data_type = MklDnnType<U>();
+          memory::dims addend_dims = TFShapeToMklDnnDims(addend_tensor.shape());
+          params.post_op_params.push_back(
+              {"add", {}, addend_dims, data_type, format_tag});
+          void* addend_data = static_cast<void*>(
+              const_cast<U*>(addend_tensor.flat<U>().data()));
+          this->fusion_data_[idx++] = addend_data;
+        } break;
+        case PostOpKind::kOutputScale: {
+          const Tensor& lhs_min_tensor = ctx->input(lhs_min_idx_);
+          const Tensor& lhs_max_tensor = ctx->input(lhs_max_idx_);
+          const Tensor& rhs_min_tensor = ctx->input(rhs_min_idx_);
+          const Tensor& rhs_max_tensor = ctx->input(rhs_max_idx_);
+          // Currently, only per tensor quantization supported.
+          OP_REQUIRES(ctx,
+                      lhs_min_tensor.NumElements() == 1 &&
+                          lhs_max_tensor.NumElements() == 1 &&
+                          rhs_min_tensor.NumElements() == 1 &&
+                          rhs_max_tensor.NumElements() == 1,
+                      absl::UnimplementedError(
+                          "Only supported is per-tensor quantization."));
+
+          const float min_lhs = lhs_min_tensor.flat<float>()(0);
+          const float max_lhs = lhs_max_tensor.flat<float>()(0);
+          const float min_rhs = rhs_min_tensor.flat<float>()(0);
+          const float max_rhs = rhs_max_tensor.flat<float>()(0);
+
+          const float range_lhs =
+              (input_quant_mode_ == "MIN_FIRST")
+                  ? (max_lhs - min_lhs)
+                  : std::max(std::abs(min_lhs), std::abs(max_lhs));
+          const float range_rhs =
+              (input_quant_mode_ == "MIN_FIRST")
+                  ? (max_rhs - min_rhs)
+                  : std::max(std::abs(min_rhs), std::abs(max_rhs));
+          const float max_int8_lhs =
+              (std::is_same<Tlhs, quint8>::value) ? 255.0f : 127.0f;
+          const float max_int8_rhs =
+              (std::is_same<Trhs, quint8>::value) ? 255.0f : 127.0f;
+          const float lhs_scale = range_lhs / max_int8_lhs;
+          const float rhs_scale = range_rhs / max_int8_rhs;
+#ifndef ENABLE_ONEDNN_V3
+          const float output_scale = lhs_scale * rhs_scale;
+          params.post_op_params.push_back({"output_scale", {output_scale}});
+#else
+          const float dst_scale = 1.0;
+          params.post_op_params.push_back({"lhs_scale", {lhs_scale}});
+          params.post_op_params.push_back({"rhs_scale", {rhs_scale}});
+          params.post_op_params.push_back({"dst_scale", {dst_scale}});
+#endif  // !ENABLE_ONEDNN_V3
+        } break;
+        case PostOpKind::kLinear: {
+          auto output_min_idx = post_op_info.min_max_indices[0];
+          auto output_max_idx = post_op_info.min_max_indices[1];
+          const float min_output =
+              ctx->input(output_min_idx).template flat<float>()(0);
+          const float max_output =
+              ctx->input(output_max_idx).template flat<float>()(0);
+          const float max_int8_output =
+              (std::is_same<Toutput, quint8>::value) ? 255.0f : 127.0f;
+          const float range_output =
+              (output_quant_mode_ == "MIN_FIRST")
+                  ? max_output - min_output
+                  : std::max(std::abs(min_output), std::abs(max_output));
+          float req_scale = max_int8_output / range_output;
+          float req_shift = 0.0f;
+          if (output_quant_mode_ == "MIN_FIRST") {
+            req_shift = -min_output * max_int8_output / range_output;
+          }
+          params.post_op_params.push_back(
+              {"linear", {1.0, req_scale, req_shift}});
+        } break;
+        default:
+          OP_REQUIRES(ctx, false,
+                      absl::UnimplementedError("Unsupported post-op-kind."));
       }
     }
   }
@@ -356,7 +706,7 @@ class MklMatMulOp : public BatchMatMulMkl<Device, T, T, T, USE_CUBLAS> {
       Name("_MklFusedBatchMatMulV2")          \
           .Device(DEVICE_CPU)                 \
           .TypeConstraint<TYPE>("T"),         \
-      FusedBatchMatMulMkl<CPUDevice, TYPE, TYPE, TYPE, true>)
+      FusedBatchMatMulMkl<CPUDevice, TYPE, TYPE, TYPE, TYPE, true>)
 
 TF_CALL_float(REGISTER_BATCH_MATMUL_MKL);
 TF_CALL_float(REGISTER_BATCH_MATMUL_MKL_V2);
@@ -372,6 +722,23 @@ TF_CALL_half(REGISTER_FUSED_BATCH_MATMUL_MKL);
 TF_CALL_float(REGISTER_MATMUL_MKL);
 TF_CALL_bfloat16(REGISTER_MATMUL_MKL);
 #endif  // DNNL_AARCH64_USE_ACL
+
+#define REGISTER_QUANTIZED_KERNEL(U, T) \
+  REGISTER_KERNEL_BUILDER(              \
+      Name("_QuantizedBatchMatMul")     \
+          .Device(DEVICE_CPU)           \
+          .TypeConstraint<qint8>("T1")  \
+          .TypeConstraint<qint8>("T2")  \
+          .TypeConstraint<U>("U")       \
+          .TypeConstraint<T>("Tout"),   \
+      QuantizedBatchMatMulOp<CPUDevice, qint8, qint8, T, U>);
+
+REGISTER_QUANTIZED_KERNEL(float, float);
+REGISTER_QUANTIZED_KERNEL(float, qint8);
+REGISTER_QUANTIZED_KERNEL(float, quint8);
+REGISTER_QUANTIZED_KERNEL(bfloat16, bfloat16);
+REGISTER_QUANTIZED_KERNEL(bfloat16, qint8);
+REGISTER_QUANTIZED_KERNEL(bfloat16, quint8);
 
 }  // end namespace tensorflow
 #endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
@@ -174,7 +174,8 @@ struct MklEinsumHelper {
     cpu_stream.reset(CreateStream(&eigen_tp, matmul_prim->GetEngine()));
 
     matmul_prim->Execute(cpu_stream, lhs.flat<T>().data(), weight_data,
-                         output->flat<T>().data(), *params, scratch_pad.Get());
+                         output->flat<T>().data(), *params, scratch_pad.Get(),
+                         {} /*empty fusion*/);
 
     Tensor output_reshaped;
     if (output->dims() != 3) {

--- a/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
@@ -174,7 +174,7 @@ struct MklEinsumHelper {
     cpu_stream.reset(CreateStream(&eigen_tp, matmul_prim->GetEngine()));
 
     matmul_prim->Execute(cpu_stream, lhs.flat<T>().data(), weight_data,
-                         output->flat<T>().data(), scratch_pad.Get());
+                         output->flat<T>().data(), *params, scratch_pad.Get());
 
     Tensor output_reshaped;
     if (output->dims() != 3) {

--- a/tensorflow/core/kernels/mkl/mkl_kernel_util.cc
+++ b/tensorflow/core/kernels/mkl/mkl_kernel_util.cc
@@ -40,13 +40,15 @@ void MklTestingUtil::RunMklQuantizeOp(const Tensor& input,
   Node* max_node = test::graph::Constant(&*graph, Tensor(max), "max");
 
   Node* quantize_op;
+  string round_mode =
+      (mode == "SCALE") ? "HALF_TO_EVEN" : "HALF_AWAY_FROM_ZERO";
   TF_CHECK_OK(NodeBuilder("mkl_quantizeV2", "_MklQuantizeV2")
                   .Input(input_node)
                   .Input(min_node)
                   .Input(max_node)
                   .Attr("T", type)
                   .Attr("mode", mode)
-                  .Attr("round_mode", "HALF_TO_EVEN")
+                  .Attr("round_mode", round_mode)
                   .Attr("_kernel", "QuantizedMklOp")
                   .Finalize(&*graph, &quantize_op));
 

--- a/tensorflow/core/kernels/mkl/mkl_kernel_util.h
+++ b/tensorflow/core/kernels/mkl/mkl_kernel_util.h
@@ -19,7 +19,6 @@ limitations under the License.
 #ifdef INTEL_MKL
 
 #include "dnnl.hpp"
-#include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/graph/testlib.h"
 #include "tensorflow/core/public/session.h"
 #include "tsl/platform/status.h"

--- a/tensorflow/core/kernels/mkl/mkl_kernel_util.h
+++ b/tensorflow/core/kernels/mkl/mkl_kernel_util.h
@@ -1,4 +1,4 @@
-/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ limitations under the License.
 #ifdef INTEL_MKL
 
 #include "dnnl.hpp"
+#include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/graph/testlib.h"
 #include "tensorflow/core/public/session.h"
 #include "tsl/platform/status.h"
@@ -48,6 +49,33 @@ class MklTestingUtil {
     Eigen::Tensor<T, 0, Eigen::RowMajor> max = eigen_tensor.maximum();
     *tensor_min = min();
     *tensor_max = max();
+  }
+
+  // This utlity function mimics Quantization of float/bfloat16 tensor with
+  // oneDNN backend QuantizeV2 operation. Since the op signature requires min
+  // and max values to be in float type, min_tensor and max_tensor should have
+  // their dtype set to DT_FLOAT.
+  template <typename T>
+  static void GetQuantizationTensors(const Tensor& input, Tensor* output,
+                                     DataType out_type, const string mode,
+                                     Tensor* min_tensor, Tensor* max_tensor) {
+    DCHECK_EQ(min_tensor->dtype(), DT_FLOAT);
+    DCHECK_EQ(max_tensor->dtype(), DT_FLOAT);
+    T min;
+    T max;
+    ComputeMinMax<T>(input, &min, &max);
+
+    float adjusted_min = static_cast<float>(min);
+    float adjusted_max = static_cast<float>(max);
+    if (mode == "SCALED") {
+      DCHECK_EQ(output->dtype(), DT_QINT8);
+      float range = std::max(std::abs(adjusted_min), std::abs(adjusted_max));
+      adjusted_min = -range;
+      adjusted_max = range;
+    }
+    RunMklQuantizeOp(input, adjusted_min, adjusted_max, out_type, mode, output);
+    min_tensor->flat<float>()(0) = adjusted_min;
+    max_tensor->flat<float>()(0) = adjusted_max;
   }
 };
 

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -21,7 +21,6 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "dnnl.hpp"
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -29,9 +28,10 @@ limitations under the License.
 #include "tensorflow/core/kernels/mkl/mkl_kernel_util.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/onednn_env_vars.h"
+#include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
-#endif
+#endif  // DNNL_AARCH64_USE_ACL && ENABLE_ONEDNN_OPENMP
 
 using dnnl::inner_product_forward;
 using dnnl::primitive_attr;
@@ -812,11 +812,14 @@ class MklMatMulPrimitive : public MklPrimitive {
     return context_.prim_desc->scratchpad_desc();
   }
   void Execute(const std::shared_ptr<stream>& stream, const Tlhs* a_data,
-               const Trhs* b_data, const Toutput* c_data, void* sp_data,
-               void* mul_data = nullptr, void* add_data = nullptr) {
+               const Trhs* b_data, const Toutput* c_data,
+               const MklMatMulParams& matmul_params, void* sp_data,
+               const std::vector<void*>& binary_op_fusions_data = {}) {
 #if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
+    size_t num_post_ops_data = context_.post_ops_mem.size();
+    DCHECK(num_post_ops_data == binary_op_fusions_data.size());
 #if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)
     context_.a_mem->set_data_handle(
         static_cast<void*>(const_cast<Tlhs*>(a_data)), *stream);
@@ -826,10 +829,10 @@ class MklMatMulPrimitive : public MklPrimitive {
         static_cast<void*>(const_cast<Toutput*>(c_data)), *stream);
     context_.sp_mem->set_data_handle(sp_data, *stream);
 
-    if (mul_data != nullptr)
-      context_.mul_mem->set_data_handle(mul_data, *stream);
-    if (add_data != nullptr)
-      context_.add_mem->set_data_handle(add_data, *stream);
+    for (int i = 0; i < num_post_ops_data; ++i) {
+      context_.post_ops_mem[i]->set_data_handle(binary_op_fusions_data[i],
+                                                *stream);
+    }
 #else
     context_.a_mem->set_data_handle(
         static_cast<void*>(const_cast<Tlhs*>(a_data)));
@@ -838,8 +841,24 @@ class MklMatMulPrimitive : public MklPrimitive {
     context_.c_mem->set_data_handle(
         static_cast<void*>(const_cast<Toutput*>(c_data)));
     context_.sp_mem->set_data_handle(sp_data);
-    if (mul_data != nullptr) context_.mul_mem->set_data_handle(mul_data);
-    if (add_data != nullptr) context_.add_mem->set_data_handle(add_data);
+    for (int i = 0; i < num_post_ops_data; ++i) {
+      context_.post_ops_mem[i]->set_data_handle(binary_op_fusions_data[i]);
+    }
+    auto const& post_op_params = matmul_params.post_op_params;
+    if (!post_op_params.empty()) {
+      for (auto const& post_op_param : post_op_params) {
+        if (post_op_param.name == "lhs_scale") {
+          context_.lhs_scale_mem->set_data_handle(static_cast<void*>(
+              const_cast<float*>(post_op_param.param.data())));
+        } else if (post_op_param.name == "rhs_scale") {
+          context_.rhs_scale_mem->set_data_handle(static_cast<void*>(
+              const_cast<float*>(post_op_param.param.data())));
+        } else if (post_op_param.name == "dst_scale") {
+          context_.dst_scale_mem->set_data_handle(static_cast<void*>(
+              const_cast<float*>(post_op_param.param.data())));
+        }
+      }
+    }
 #endif  // !ENABLE_ONEDNN_OPENMP && !ENABLE_ONEDNN_V3
     execute_primitives(context_.matmul_primitives, stream, context_.net_args);
 
@@ -848,8 +867,9 @@ class MklMatMulPrimitive : public MklPrimitive {
     context_.b_mem->set_data_handle(DummyData);
     context_.c_mem->set_data_handle(DummyData);
     context_.sp_mem->set_data_handle(DummyData);
-    if (mul_data != nullptr) context_.mul_mem->set_data_handle(DummyData);
-    if (add_data != nullptr) context_.add_mem->set_data_handle(DummyData);
+    for (int i = 0; i < num_post_ops_data; ++i) {
+      context_.post_ops_mem[i]->set_data_handle(DummyData);
+    }
   }
 
   std::shared_ptr<dnnl::matmul::primitive_desc> GetPrimitiveDesc() const {
@@ -863,9 +883,14 @@ class MklMatMulPrimitive : public MklPrimitive {
     std::shared_ptr<dnnl::memory> a_mem;
     std::shared_ptr<dnnl::memory> b_mem;
     std::shared_ptr<dnnl::memory> c_mem;
-    std::shared_ptr<dnnl::memory> mul_mem;
-    std::shared_ptr<dnnl::memory> add_mem;
     std::shared_ptr<dnnl::memory> sp_mem;
+
+    // Quantization scale related memory.
+    std::shared_ptr<dnnl::memory> lhs_scale_mem;
+    std::shared_ptr<dnnl::memory> rhs_scale_mem;
+    std::shared_ptr<dnnl::memory> dst_scale_mem;
+
+    std::vector<std::shared_ptr<dnnl::memory>> post_ops_mem;
 
     // Descriptor and primitive-descriptor for MatMul.
 #ifndef ENABLE_ONEDNN_V3
@@ -877,8 +902,11 @@ class MklMatMulPrimitive : public MklPrimitive {
     std::shared_ptr<dnnl::memory::desc> a_md;
     std::shared_ptr<dnnl::memory::desc> b_md;
     std::shared_ptr<dnnl::memory::desc> c_md;
-    std::shared_ptr<dnnl::memory::desc> mul_md;
-    std::shared_ptr<dnnl::memory::desc> add_md;
+
+    // Quantization scale related memory descriptors.
+    std::shared_ptr<dnnl::memory::desc> lhs_scale_md;
+    std::shared_ptr<dnnl::memory::desc> rhs_scale_md;
+    std::shared_ptr<dnnl::memory::desc> dst_scale_md;
 
     // MatMul primitive.
     std::vector<dnnl::primitive> matmul_primitives;
@@ -888,18 +916,20 @@ class MklMatMulPrimitive : public MklPrimitive {
         : a_mem(nullptr),
           b_mem(nullptr),
           c_mem(nullptr),
-          mul_mem(nullptr),
-          add_mem(nullptr),
           sp_mem(nullptr),
+          lhs_scale_mem(nullptr),
+          rhs_scale_mem(nullptr),
+          dst_scale_mem(nullptr),
 #ifndef ENABLE_ONEDNN_V3
           desc(nullptr),
-#endif  // !ENABLE_ONEDNN_V3
+#endif  // ENABLE_ONEDNN_V3
           prim_desc(nullptr),
           a_md(nullptr),
           b_md(nullptr),
           c_md(nullptr),
-          mul_md(nullptr),
-          add_md(nullptr) {
+          lhs_scale_md(nullptr),
+          rhs_scale_md(nullptr),
+          dst_scale_md(nullptr) {
     }
   };
 
@@ -919,6 +949,22 @@ class MklMatMulPrimitive : public MklPrimitive {
     context_.c_md.reset(new memory::desc({params.c_dims}, MklDnnType<Toutput>(),
                                          params.c_strides));
 
+    // Create memory primitive based on dummy data.
+    context_.a_mem.reset(
+        new dnnl::memory(*context_.a_md, cpu_engine_, DummyData));
+#ifdef DNNL_AARCH64_USE_ACL
+    context_.b_mem.reset(new dnnl::memory(
+        context_.prim_desc.get()->weights_desc(), cpu_engine_, DummyData));
+#else
+    context_.b_mem.reset(
+        new dnnl::memory(*context_.b_md, cpu_engine_, DummyData));
+#endif
+    context_.c_mem.reset(
+        new dnnl::memory(*context_.c_md, cpu_engine_, DummyData));
+    context_.net_args.push_back({{DNNL_ARG_SRC, *context_.a_mem},
+                                 {DNNL_ARG_WEIGHTS, *context_.b_mem},
+                                 {DNNL_ARG_DST, *context_.c_mem}});
+
     // Create matmul.
 #ifndef ENABLE_ONEDNN_V3
     context_.desc.reset(
@@ -929,29 +975,75 @@ class MklMatMulPrimitive : public MklPrimitive {
     auto const& post_op_params = params.post_op_params;
     dnnl::primitive_attr post_ops_attr;
     dnnl::post_ops post_ops;
+    std::unordered_map<string, bool> is_scale_set;
+    int binary_post_ops_count = 0;  // Keep track op binary fusions.
     if (!post_op_params.empty()) {
       for (auto const& post_op_param : post_op_params) {
-        if (post_op_param.name == "output_scale") {
 #ifndef ENABLE_ONEDNN_V3
-          // TODO(intel-tf): Verify if this code is needed. If not, it needs to
-          // be removed.
+        if (post_op_param.name == "output_scale") {
           DCHECK_EQ(post_op_param.param.size(), 1);
-          std::vector<float> scales;
-          scales.push_back(post_op_param.param[0]);
-          post_ops_attr.set_output_scales(0, scales);
+          post_ops_attr.set_output_scales(0, post_op_param.param);
+#else
+        if (post_op_param.name == "lhs_scale") {
+          is_scale_set.insert({"lhs", true});
+          post_ops_attr.set_scales_mask(DNNL_ARG_SRC, 0);
+          context_.lhs_scale_md.reset(new memory::desc({1}, MklDnnType<float>(),
+                                                       memory::format_tag::x));
+          context_.lhs_scale_mem.reset(
+              new memory(*context_.lhs_scale_md, cpu_engine_, DummyData));
+        } else if (post_op_param.name == "rhs_scale") {
+          is_scale_set.insert({"rhs", true});
+          post_ops_attr.set_scales_mask(DNNL_ARG_WEIGHTS, 0);
+          context_.rhs_scale_md.reset(new memory::desc({1}, MklDnnType<float>(),
+                                                       memory::format_tag::x));
+          context_.rhs_scale_mem.reset(
+              new memory(*context_.rhs_scale_md, cpu_engine_, DummyData));
+        } else if (post_op_param.name == "dst_scale") {
+          is_scale_set.insert({"dst", true});
+          post_ops_attr.set_scales_mask(DNNL_ARG_DST, 0);
+          context_.dst_scale_md.reset(new memory::desc({1}, MklDnnType<float>(),
+                                                       memory::format_tag::x));
+          context_.dst_scale_mem.reset(
+              new memory(*context_.dst_scale_md, cpu_engine_, DummyData));
 #endif  // !ENABLE_ONEDNN_V3
+        } else if (post_op_param.name == "linear") {
+          DCHECK_EQ(post_op_param.param.size(), 3);
+          float op_scale = post_op_param.param[0];
+          float op_alpha = post_op_param.param[1];
+          float op_beta = post_op_param.param[2];
+          post_ops.APPEND_ELTWISE(op_scale, dnnl::algorithm::eltwise_linear,
+                                  op_alpha, op_beta);
         } else if (post_op_param.name == "mul") {
-          context_.mul_md.reset(new memory::desc({post_op_param.dims},
-                                                 post_op_param.data_type,
-                                                 post_op_param.format_tag));
-          post_ops.append_binary(dnnl::algorithm::binary_mul, *context_.mul_md);
+          auto operand_md =
+              memory::desc({post_op_param.dims}, post_op_param.data_type,
+                           post_op_param.format_tag);
+          post_ops.append_binary(dnnl::algorithm::binary_mul, operand_md);
+          auto operand_mem_ptr = std::make_shared<dnnl::memory>(
+              operand_md, cpu_engine_, DummyData);
+          context_.net_args[0].insert(
+              {DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_ops_count) |
+                   DNNL_ARG_SRC_1,
+               *operand_mem_ptr});
+          context_.post_ops_mem.push_back(std::move(operand_mem_ptr));
+          binary_post_ops_count++;
         } else if (post_op_param.name == "add") {
-          context_.add_md.reset(new memory::desc({post_op_param.dims},
-                                                 post_op_param.data_type,
-                                                 post_op_param.format_tag));
-          post_ops.append_binary(dnnl::algorithm::binary_add, *context_.add_md);
+          auto operand_md =
+              memory::desc({post_op_param.dims}, post_op_param.data_type,
+                           post_op_param.format_tag);
+          post_ops.append_binary(dnnl::algorithm::binary_add, operand_md);
+          auto operand_mem_ptr = std::make_shared<dnnl::memory>(
+              operand_md, cpu_engine_, DummyData);
+          context_.net_args[0].insert(
+              {DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_ops_count) |
+                   DNNL_ARG_SRC_1,
+               *operand_mem_ptr});
+          context_.post_ops_mem.push_back(std::move(operand_mem_ptr));
+          binary_post_ops_count++;
         } else {
-          DCHECK((post_op_param.name == "output_scale"));
+          OUTPUT_SCALE_DCHECK;
+          DCHECK((post_op_param.name == "linear"));
+          DCHECK((post_op_param.name == "mul"));
+          DCHECK((post_op_param.name == "add"));
         }
       }
       post_ops_attr.set_post_ops(post_ops);
@@ -966,49 +1058,21 @@ class MklMatMulPrimitive : public MklPrimitive {
                                    *context_.c_md, post_ops_attr));
 #endif  // !ENABLE_ONEDNN_V3
 
-    // Create memory primitive based on dummy data.
-    context_.a_mem.reset(
-        new dnnl::memory(*context_.a_md, cpu_engine_, DummyData));
-#ifdef DNNL_AARCH64_USE_ACL
-    context_.b_mem.reset(new dnnl::memory(
-        context_.prim_desc.get()->weights_desc(), cpu_engine_, DummyData));
-#else
-    context_.b_mem.reset(
-        new dnnl::memory(*context_.b_md, cpu_engine_, DummyData));
-#endif
-    context_.c_mem.reset(
-        new dnnl::memory(*context_.c_md, cpu_engine_, DummyData));
     auto scratchpad_md = context_.prim_desc->scratchpad_desc();
     context_.sp_mem.reset(
         new dnnl::memory(scratchpad_md, cpu_engine_, DummyData));
-
+    context_.net_args[0].insert({DNNL_ARG_SCRATCHPAD, *context_.sp_mem});
+#ifdef ENABLE_ONEDNN_V3
+    if (is_scale_set["lhs"] && is_scale_set["rhs"] && is_scale_set["dst"]) {
+      context_.net_args[0].insert(
+          {{DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, *context_.lhs_scale_mem},
+           {DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, *context_.rhs_scale_mem},
+           { DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST,
+             *context_.dst_scale_mem }});
+    }
+#endif  // ENABLE_ONEDNN_V3
     // Create matmul primitive.
     matmul_primitive.reset(new dnnl::matmul(*context_.prim_desc));
-    context_.net_args.push_back({{DNNL_ARG_SRC, *context_.a_mem},
-                                 {DNNL_ARG_WEIGHTS, *context_.b_mem},
-                                 {DNNL_ARG_SCRATCHPAD, *context_.sp_mem},
-                                 {DNNL_ARG_DST, *context_.c_mem}});
-    if (!post_op_params.empty()) {
-      int count = 0;
-      for (auto const& post_op_param : post_op_params) {
-        if (post_op_param.name == "mul") {
-          context_.mul_mem.reset(
-              new dnnl::memory(*context_.mul_md, cpu_engine_, DummyData));
-          context_.net_args[0].insert(
-              {DNNL_ARG_ATTR_MULTIPLE_POST_OP(count) | DNNL_ARG_SRC_1,
-               *context_.mul_mem});
-          count++;
-        } else if (post_op_param.name == "add") {
-          context_.add_mem.reset(
-              new dnnl::memory(*context_.add_md, cpu_engine_, DummyData));
-          context_.net_args[0].insert(
-              {DNNL_ARG_ATTR_MULTIPLE_POST_OP(count) | DNNL_ARG_SRC_1,
-               *context_.add_mem});
-          count++;
-        }
-      }
-    }
-
     context_.matmul_primitives.push_back(*matmul_primitive);
     return;
   }
@@ -1069,10 +1133,21 @@ class MklMatMulPrimitiveFactory : public MklPrimitiveFactory<T> {
 
     // Generate keys for post-ops
     for (auto const& post_op_param : params.post_op_params) {
+#ifndef ENABLE_ONEDNN_V3
       if (post_op_param.name == "output_scale") {
+#else
+      if (post_op_param.name == "lhs_scale" ||
+          post_op_param.name == "rhs_scale" ||
+          post_op_param.name == "dst_scale") {
+#endif  // !ENABLE_ONEDNN_V3
         DCHECK_EQ(post_op_param.param.size(), 1);
         key_creator.AddAsKey(post_op_param.name);
         key_creator.AddAsKey(post_op_param.param[0]);
+      } else if (post_op_param.name == "linear") {
+        key_creator.AddAsKey(post_op_param.name);
+        key_creator.AddAsKey(post_op_param.param[0]);
+        key_creator.AddAsKey(post_op_param.param[1]);
+        key_creator.AddAsKey(post_op_param.param[2]);
       } else if (post_op_param.name == "mul" || post_op_param.name == "add") {
         key_creator.AddAsKey(post_op_param.name);
         key_creator.AddAsKey(post_op_param.dims);
@@ -1133,7 +1208,7 @@ void dnnl_gemm(char transa, char transb, int64_t m, int64_t n, int64_t k,
   std::shared_ptr<stream> cpu_stream;
 
   cpu_stream.reset(CreateStream(&eigen_tp, matmul_prim->GetEngine()));
-  matmul_prim->Execute(cpu_stream, a, b, c, scratch_pad.Get());
+  matmul_prim->Execute(cpu_stream, a, b, c, params, scratch_pad.Get());
 }
 
 }  // anonymous namespace

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -814,7 +814,7 @@ class MklMatMulPrimitive : public MklPrimitive {
   void Execute(const std::shared_ptr<stream>& stream, const Tlhs* a_data,
                const Trhs* b_data, const Toutput* c_data,
                const MklMatMulParams& matmul_params, void* sp_data,
-               const std::vector<void*>& binary_op_fusions_data = {}) {
+               const std::vector<void*>& binary_op_fusions_data) {
 #if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
@@ -1208,7 +1208,8 @@ void dnnl_gemm(char transa, char transb, int64_t m, int64_t n, int64_t k,
   std::shared_ptr<stream> cpu_stream;
 
   cpu_stream.reset(CreateStream(&eigen_tp, matmul_prim->GetEngine()));
-  matmul_prim->Execute(cpu_stream, a, b, c, params, scratch_pad.Get());
+  matmul_prim->Execute(cpu_stream, a, b, c, params, scratch_pad.Get(),
+                       {} /*empty fusion*/);
 }
 
 }  // anonymous namespace

--- a/tensorflow/core/kernels/mkl/onednn_fused_batchmatmul_op_test.cc
+++ b/tensorflow/core/kernels/mkl/onednn_fused_batchmatmul_op_test.cc
@@ -1,0 +1,565 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if defined(INTEL_MKL)
+
+#define EIGEN_USE_THREADS
+
+#include "absl/algorithm/container.h"
+#include "absl/strings/match.h"
+#include "tensorflow/cc/ops/standard_ops.h"
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/graph/node_builder.h"
+#include "tensorflow/core/kernels/mkl/mkl_kernel_util.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/kernels/quantization_utils.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/protobuf/rewriter_config.pb.h"
+#include "tensorflow/core/public/session.h"
+
+namespace tensorflow {
+
+// T: float or bfloat16 used as tensor type of the MatMul and fusion operation.
+template <typename T>
+class FusedBatchMatMulOpTestBase : public OpsTestBase {
+ protected:
+  struct FusedOpsAndDims {
+    // List of fusions.
+    std::vector<string> fused_ops;
+    // Tensor dimension associated with the fusions. Currently assuming that
+    // each fusion requires no more than one tensor. If some fusion does not
+    // require a tensor, e.g., Relu, the tensor dimensions will be {0} implying
+    // an an empty tensor.
+    std::vector<std::vector<int64_t>> fused_dims;
+    // TODO(intel-tf): Add additional field if some fusion needs additional
+    // parameters.
+  };
+
+  struct FusedOpsAndTensors {
+    // List of fusions.
+    std::vector<string> fused_ops;
+    // Tensors associated with the fusions. Currently assuming that each fusion
+    // requires no more than one tensor. If some fusion does not require a
+    // tensor, e.g., Relu, the tensor will be an empty tensor.
+    std::vector<Tensor> fusion_tensors;
+    // TODO(intel-tf): Add additional field if some fusion needs additional
+    // parameters.
+  };
+
+  using GraphRunner =
+      std::function<void(const Tensor& x, const Tensor& y,
+                         const FusedOpsAndTensors& fused_ops_and_tensors,
+                         Tensor* result, bool adj_x, bool adj_y)>;
+
+  using QuantizedGraphRunner = std::function<void(
+      const Tensor& x, const Tensor& y,
+      const FusedOpsAndTensors& fused_ops_and_tensors, Tensor* result,
+      bool adj_x, bool adj_y, string input_quant_mode, string output_quant_mode,
+      bool requantize, float output_min, float output_max)>;
+
+  // Runs a Tensorflow graph defined by the root scope, and fetches the result
+  // of 'fetch' node into the outputs. Optional `add_nodes` parameter
+  // allows to define nodes directly using a NodeDef for the ops that are
+  // not supported by the C++ Api.
+  // TODO(intel-tf): Move RunAndFetch function to a common header file for
+  // better reuse in the future.
+  void RunAndFetch(const tensorflow::Scope& root,
+                   const std::vector<string>& fetch,
+                   std::vector<Tensor>* outputs,
+                   const std::vector<const NodeDef*> add_nodes = {}) {
+    tensorflow::GraphDef graph;
+    TF_ASSERT_OK(root.ToGraphDef(&graph));
+
+    for (const NodeDef* add_node : add_nodes) {
+      *graph.add_node() = *add_node;
+    }
+
+    // We really want to make sure that graph executed exactly as we passed it
+    // to the session, so we disable various optimizations.
+    tensorflow::SessionOptions session_options;
+
+    // Disable common runtime constant folding.
+    session_options.config.mutable_graph_options()
+        ->mutable_optimizer_options()
+        ->set_opt_level(OptimizerOptions::L0);
+
+    // Disable Grappler optimizations for tests.
+    tensorflow::RewriterConfig* cfg =
+        session_options.config.mutable_graph_options()
+            ->mutable_rewrite_options();
+    cfg->set_constant_folding(tensorflow::RewriterConfig::OFF);
+    cfg->set_layout_optimizer(tensorflow::RewriterConfig::OFF);
+    cfg->set_remapping(tensorflow::RewriterConfig::OFF);
+
+    std::unique_ptr<tensorflow::Session> session(
+        tensorflow::NewSession(session_options));
+
+    const string device = "/device:CPU:0";
+    for (NodeDef& mutable_node : *graph.mutable_node()) {
+      mutable_node.set_device(device);
+    }
+
+    TF_ASSERT_OK(session->Create(graph));
+    TF_ASSERT_OK(session->Run({}, fetch, {}, outputs));
+  }
+
+  void RunBatchMatMulAndFusedOps(
+      const Tensor& x, const Tensor& y,
+      const FusedOpsAndTensors& fused_ops_and_tensors, Tensor* result,
+      bool adj_x, bool adj_y) {
+    Scope root = tensorflow::Scope::NewRootScope();
+
+    Output x_input =
+        ops::Const(root.WithOpName("x_input"), Input::Initializer(x));
+    Output y_input =
+        ops::Const(root.WithOpName("y_input"), Input::Initializer(y));
+    Output last_output =
+        ops::BatchMatMulV2(root.WithOpName("batch_matmul"), x_input, y_input,
+                           ops::BatchMatMulV2::Attrs().AdjX(adj_x).AdjY(adj_y));
+    auto& fused_ops = fused_ops_and_tensors.fused_ops;
+    auto& fusion_tensors = fused_ops_and_tensors.fusion_tensors;
+    for (int i = 0; i < fused_ops.size(); ++i) {
+      const string& op = fused_ops[i];
+      if (op == "Mul") {
+        Output arg = ops::Const(root.WithOpName(absl::StrCat("arg", i)),
+                                Input::Initializer(fusion_tensors[i]));
+        last_output = ops::Multiply(root.WithOpName(absl::StrCat("mul_at_", i)),
+                                    last_output, arg);
+      } else if (op == "Add") {
+        Output arg = ops::Const(root.WithOpName(absl::StrCat("arg", i)),
+                                Input::Initializer(fusion_tensors[i]));
+        last_output = ops::AddV2(root.WithOpName(absl::StrCat("add_at_", i)),
+                                 last_output, arg);
+      }
+    }
+    std::vector<Tensor> outputs;
+    RunAndFetch(root, {last_output.name()}, &outputs);
+    *result = outputs[0];
+  }
+
+  void RunFusedBatchMatMul(const Tensor& x, const Tensor& y,
+                           const FusedOpsAndTensors& fused_ops_and_tensors,
+                           Tensor* result, bool adj_x, bool adj_y) {
+    Scope root = tensorflow::Scope::NewRootScope();
+
+    DataType t_dtype = DataTypeToEnum<T>::v();
+
+    Output x_input =
+        ops::Const(root.WithOpName("x_input"), Input::Initializer(x));
+    Output y_input =
+        ops::Const(root.WithOpName("y_input"), Input::Initializer(y));
+    auto& fused_ops = fused_ops_and_tensors.fused_ops;
+    auto& fusion_tensors = fused_ops_and_tensors.fusion_tensors;
+    int num_fused_inputs = 0;
+    std::vector<NodeDefBuilder::NodeOut> fused_inputs;
+    for (int i = 0; i < fused_ops.size(); ++i) {
+      const string& op = fused_ops[i];
+      if (op == "Mul" || op == "Add") {
+        Output arg = ops::Const(root.WithOpName(absl::StrCat("arg", i)),
+                                Input::Initializer(fusion_tensors[i]));
+        fused_inputs.push_back({arg.name(), 0, t_dtype});
+        num_fused_inputs++;
+      }
+    }
+    NodeDef fused_batch_matmul;
+    std::vector<const NodeDef*> add_nodes;
+    TF_EXPECT_OK(NodeDefBuilder("fused_batch_matmul", "_MklFusedBatchMatMulV2")
+                     .Input({x_input.name(), 0, t_dtype})
+                     .Input({y_input.name(), 0, t_dtype})
+                     .Input(fused_inputs)
+                     .Attr("adj_x", adj_x)
+                     .Attr("adj_y", adj_y)
+                     .Attr("num_args", num_fused_inputs)
+                     .Attr("fused_ops", fused_ops)
+                     .Finalize(&fused_batch_matmul));
+    add_nodes = {&fused_batch_matmul};
+    std::vector<Tensor> outputs;
+    RunAndFetch(root, {fused_batch_matmul.name()}, &outputs, add_nodes);
+    *result = outputs[0];
+  }
+
+  void RunQuantizedBatchMatMul(const Tensor& x, const Tensor& y,
+                               const FusedOpsAndTensors& fused_ops_and_tensors,
+                               Tensor* result, bool adj_x, bool adj_y,
+                               string input_quant_mode,
+                               string output_quant_mode, bool requantize,
+                               float output_min, float output_max) {
+    DataType real_dtype = DataTypeToEnum<T>::v();
+    // Quantize x and y
+    Tensor x_qtensor(DT_QINT8, x.shape());
+    Tensor x_min_tensor(DT_FLOAT, TensorShape({}));
+    Tensor x_max_tensor(DT_FLOAT, TensorShape({}));
+    Tensor y_qtensor(DT_QINT8, y.shape());
+    Tensor y_min_tensor(DT_FLOAT, TensorShape({}));
+    Tensor y_max_tensor(DT_FLOAT, TensorShape({}));
+
+    MklTestingUtil::GetQuantizationTensors<T>(x, &x_qtensor, DT_QINT8,
+                                              input_quant_mode, &x_min_tensor,
+                                              &x_max_tensor);
+    MklTestingUtil::GetQuantizationTensors<T>(y, &y_qtensor, DT_QINT8,
+                                              input_quant_mode, &y_min_tensor,
+                                              &y_max_tensor);
+
+    Scope root = tensorflow::Scope::NewRootScope();
+
+    Output x_input =
+        ops::Const(root.WithOpName("x_input"), Input::Initializer(x_qtensor));
+    Output x_min =
+        ops::Const(root.WithOpName("x_min"), Input::Initializer(x_min_tensor));
+    Output x_max =
+        ops::Const(root.WithOpName("x_max"), Input::Initializer(x_max_tensor));
+    Output y_input =
+        ops::Const(root.WithOpName("y_input"), Input::Initializer(y_qtensor));
+    Output y_min =
+        ops::Const(root.WithOpName("y_min"), Input::Initializer(y_min_tensor));
+    Output y_max =
+        ops::Const(root.WithOpName("y_max"), Input::Initializer(y_max_tensor));
+    auto& fused_ops = fused_ops_and_tensors.fused_ops;
+    auto& fusion_tensors = fused_ops_and_tensors.fusion_tensors;
+    int num_fused_inputs = 0;
+    std::vector<NodeDefBuilder::NodeOut> fused_inputs;
+    for (int i = 0; i < fused_ops.size(); ++i) {
+      const string& op = fused_ops[i];
+      if (op == "Mul" || op == "Add") {
+        Output arg = ops::Const(root.WithOpName(absl::StrCat("arg", i)),
+                                Input::Initializer(fusion_tensors[i]));
+        fused_inputs.push_back({arg.name(), 0, real_dtype});
+        num_fused_inputs++;
+      }
+    }
+    NodeDef fused_batch_matmul;
+    std::vector<const NodeDef*> add_nodes;
+    std::vector<Tensor> outputs;
+    std::vector<NodeDefBuilder::NodeOut> inputs;
+    inputs.push_back({"x_input", 0, DT_QINT8});
+    inputs.push_back({"y_input", 0, DT_QINT8});
+    inputs.insert(std::end(inputs), std::begin(fused_inputs),
+                  std::end(fused_inputs));
+    inputs.push_back({"x_min", 0, DT_FLOAT});
+    inputs.push_back({"x_max", 0, DT_FLOAT});
+    inputs.push_back({"y_min", 0, DT_FLOAT});
+    inputs.push_back({"y_max", 0, DT_FLOAT});
+
+    std::vector<string> extended_fused_ops(fused_ops);
+    DataType out_dtype;
+    if (requantize) {
+      if (output_quant_mode == "SCALED") {
+        out_dtype = DT_QINT8;
+      } else {
+        out_dtype = DT_QUINT8;
+      }
+    } else {
+      out_dtype = real_dtype;
+    }
+    std::vector<DataType> output_dtypes;
+    if (requantize) {
+      Output out_min = ops::Const(root.WithOpName("output_min"), output_min);
+      Output out_max = ops::Const(root.WithOpName("output_max"), output_max);
+      inputs.push_back({"output_min", 0, DT_FLOAT});
+      inputs.push_back({"output_max", 0, DT_FLOAT});
+      extended_fused_ops.push_back("Requantize");
+      output_dtypes = {out_dtype, DT_FLOAT, DT_FLOAT};
+    } else {
+      extended_fused_ops.push_back("Dequantize");
+      output_dtypes = {out_dtype};
+    }
+    TF_EXPECT_OK(
+        NodeDefBuilder("quantized_batch_matmul", "_QuantizedBatchMatMul")
+            .Attr("Tdevice_inputs", std::vector<DataType>())
+            .Input(FakeInput())
+            .Input(inputs)
+            .Attr("Tdevice_outputs", std::vector<DataType>())
+            .Attr("Thost_outputs", output_dtypes)
+            .Attr("T1", DT_QINT8)
+            .Attr("T2", DT_QINT8)
+            .Attr("Tout", out_dtype)
+            .Attr("U", real_dtype)
+            .Attr("adj_x", adj_x)
+            .Attr("adj_y", adj_y)
+            .Attr("fused_ops", extended_fused_ops)
+            .Attr("input_quant_mode", input_quant_mode)
+            .Attr("output_quant_mode", output_quant_mode)
+            .Finalize(&fused_batch_matmul));
+    if (requantize) {
+      NodeDef dequantize;
+      TF_EXPECT_OK(NodeDefBuilder("dequantize", "Dequantize")
+                       .Input({"quantized_batch_matmul", 0, out_dtype})
+                       .Input({"quantized_batch_matmul", 1, DT_FLOAT})
+                       .Input({"quantized_batch_matmul", 2, DT_FLOAT})
+                       .Attr("dtype", real_dtype)
+                       .Attr("mode", output_quant_mode)
+                       .Finalize(&dequantize));
+      add_nodes = {&fused_batch_matmul, &dequantize};
+      RunAndFetch(root, {dequantize.name()}, &outputs, add_nodes);
+    } else {
+      add_nodes = {&fused_batch_matmul};
+      RunAndFetch(root, {fused_batch_matmul.name()}, &outputs, add_nodes);
+    }
+    *result = outputs[0];
+  }
+
+  template <typename FusedGraphRunner>
+  void VerifyTensorsNear(const std::initializer_list<int64_t>& x_dims,
+                         const std::initializer_list<int64_t>& y_dims,
+                         const FusedOpsAndDims& fused_ops_and_dims,
+                         const GraphRunner& run_default,
+                         const FusedGraphRunner& run_fused, bool adj_x,
+                         bool adj_y, const double atol = 1e-5,
+                         // The following arguments are used by quantized fusion
+                         string input_quant_mode = "SCALED",
+                         string output_quant_mode = "SCALED",
+                         bool requantize = false) {
+    DataType t_dtype = DataTypeToEnum<T>::v();
+    TensorShape x_shape = TensorShape(x_dims);
+    TensorShape y_shape = TensorShape(y_dims);
+
+    Tensor x_tensor(t_dtype, x_shape);
+    x_tensor.flat<T>().setRandom();
+    x_tensor.flat<T>() -= x_tensor.flat<T>().constant(static_cast<T>(0.5));
+
+    Tensor y_tensor(t_dtype, y_shape);
+    y_tensor.flat<T>().setRandom();
+    y_tensor.flat<T>() -= y_tensor.flat<T>().constant(static_cast<T>(0.5));
+
+    FusedOpsAndTensors fused_ops_and_tensors;
+    // Copy fused_ops
+    fused_ops_and_tensors.fused_ops = fused_ops_and_dims.fused_ops;
+    const auto& fused_ops = fused_ops_and_tensors.fused_ops;  // Alias to field
+    const auto& fused_dims = fused_ops_and_dims.fused_dims;   // Alias to field
+    auto& fusion_tensors =
+        fused_ops_and_tensors.fusion_tensors;  // Initially empty
+    for (int i = 0; i < fused_ops.size(); ++i) {
+      TensorShape arg_shape = TensorShape(fused_dims[i]);
+      Tensor arg_tensor(t_dtype, arg_shape);
+      arg_tensor.flat<T>().setRandom();
+      arg_tensor.flat<T>() -=
+          arg_tensor.flat<T>().constant(static_cast<T>(0.5));
+      fusion_tensors.push_back(arg_tensor);
+    }
+    Tensor default_result;
+    run_default(x_tensor, y_tensor, fused_ops_and_tensors, &default_result,
+                adj_x, adj_y);
+
+    Tensor fused_result;
+    if constexpr (std::is_same<FusedGraphRunner, QuantizedGraphRunner>::value) {
+      float output_min = 1.0;
+      float output_max = 1.0 + std::numeric_limits<float>::epsilon();
+      if (requantize) {
+        T min;
+        T max;
+        MklTestingUtil::ComputeMinMax<T>(default_result, &min, &max);
+        output_min = static_cast<float>(min);
+        output_max = static_cast<float>(max);
+      }
+      // Run quantized fusion
+      run_fused(x_tensor, y_tensor, fused_ops_and_tensors, &fused_result, adj_x,
+                adj_y, input_quant_mode, output_quant_mode, requantize,
+                output_min, output_max);
+    } else {
+      // Run realnumber type fusion
+      run_fused(x_tensor, y_tensor, fused_ops_and_tensors, &fused_result, adj_x,
+                adj_y);
+    }
+    std::vector<std::pair<Tensor, Tensor>> tensor_pairs = {
+        {default_result, fused_result}};
+    for (auto& pair : tensor_pairs) {
+      const Tensor& expected = pair.first;
+      const Tensor& evaluated = pair.second;
+
+      ASSERT_EQ(expected.dtype(), evaluated.dtype());
+      ASSERT_EQ(expected.shape(), evaluated.shape());
+
+      test::ExpectClose(expected, evaluated, atol);
+    }
+  }
+
+  void GetFusionConfiguration(const std::vector<string>& fused_ops,
+                              const int batch_dim0, const int batch_dim1,
+                              const int row, const int col,
+                              FusedOpsAndDims* fused_ops_and_dims) {
+    if (fused_ops.empty()) {
+      *fused_ops_and_dims = {fused_ops, {}};
+    } else if (fused_ops == std::vector<string>{"Mul"}) {
+      *fused_ops_and_dims = {fused_ops, {{} /* scalar multiplicand*/}};
+    } else if (fused_ops == std::vector<string>{"Add"}) {
+      *fused_ops_and_dims = {fused_ops,
+                             {std::vector<int64_t>{batch_dim0, 1, row, col}}};
+    } else if (fused_ops == std::vector<string>{"Mul", "Add"}) {
+      *fused_ops_and_dims = {
+          fused_ops, {{}, std::vector<int64_t>{batch_dim0, 1, row, col}}};
+    } else {
+      EXPECT_TRUE(false) << absl::StrCat("The fusion: [",
+                                         absl::StrJoin(fused_ops, ","),
+                                         "] is not supported in this test.");
+    }
+  }
+
+  void VerifyFusedBatchMatMul(const std::initializer_list<int64_t> x_dims,
+                              const std::initializer_list<int64_t> y_dims,
+                              const FusedOpsAndDims fused_ops_and_dims,
+                              bool adj_x, bool adj_y) {
+    const GraphRunner run_default =
+        [&](const Tensor& x, const Tensor& y,
+            const FusedOpsAndTensors& fused_ops_and_tensors, Tensor* result,
+            bool adj_x, bool adj_y) {
+          this->RunBatchMatMulAndFusedOps(x, y, fused_ops_and_tensors, result,
+                                          adj_x, adj_y);
+        };
+
+    const GraphRunner run_fused =
+        [&](const Tensor& x, const Tensor& y,
+            const FusedOpsAndTensors& fused_ops_and_tensors, Tensor* result,
+            bool adj_x, bool adj_y) {
+          this->RunFusedBatchMatMul(x, y, fused_ops_and_tensors, result, adj_x,
+                                    adj_y);
+        };
+    const double atol = std::is_same<T, bfloat16>::value ? 1e-2 : 1e-5;
+    VerifyTensorsNear<GraphRunner>(x_dims, y_dims, fused_ops_and_dims,
+                                   run_default, run_fused, adj_x, adj_y, atol);
+  }
+
+  void VerifyQuantizedBatchMatMul(std::vector<string> fused_ops) {
+    const GraphRunner run_default =
+        [&](const Tensor& x, const Tensor& y,
+            const FusedOpsAndTensors& fused_ops_and_tensors, Tensor* result,
+            bool adj_x, bool adj_y) {
+          this->RunBatchMatMulAndFusedOps(x, y, fused_ops_and_tensors, result,
+                                          adj_x, adj_y);
+        };
+
+    const QuantizedGraphRunner run_quantized =
+        [&](const Tensor& x, const Tensor& y,
+            const FusedOpsAndTensors& fused_ops_and_tensors, Tensor* result,
+            bool adj_x, bool adj_y, string input_quant_mode,
+            string output_quant_mode, bool requantize, float output_min,
+            float output_max) {
+          this->RunQuantizedBatchMatMul(x, y, fused_ops_and_tensors, result,
+                                        adj_x, adj_y, input_quant_mode,
+                                        output_quant_mode, requantize,
+                                        output_min, output_max);
+        };
+    const double atol = 1e-2;
+    constexpr int M = 3;
+    constexpr int K = 4;
+    constexpr int N = 5;
+    constexpr int b0 = 2;
+    constexpr int b1 = 2;
+    FusedOpsAndDims fused_ops_and_dims;
+    GetFusionConfiguration(fused_ops, b0, b1, M, N, &fused_ops_and_dims);
+    std::vector<bool> requantization_config;
+    for (bool adj_x : {false, true}) {
+      for (bool adj_y : {false, true}) {
+        std::initializer_list<int64_t> x_dims = {b0, b1, adj_x ? K : M,
+                                                 adj_x ? M : K};
+        std::initializer_list<int64_t> y_dims = {b0, b1, adj_y ? N : K,
+                                                 adj_y ? K : N};
+        for (bool requantize : {false, true}) {
+          for (string output_quant_mode : {"SCALED", "MIN_FIRST"}) {
+            VerifyTensorsNear<QuantizedGraphRunner>(
+                x_dims, y_dims, fused_ops_and_dims, run_default, run_quantized,
+                adj_x, adj_y, atol, "SCALED", output_quant_mode, requantize);
+          }
+        }
+      }
+    }
+  }
+};
+
+template <typename T>
+using FusedBatchMatMulOpTest =
+    FusedBatchMatMulOpTestBase<T>;  // additional parameters are float
+
+TYPED_TEST_SUITE_P(FusedBatchMatMulOpTest);
+
+TYPED_TEST_P(FusedBatchMatMulOpTest, MulFusion) {
+  const int M = 3;
+  const int K = 5;
+  const int N = 3;
+  for (const bool adj_x : {false, true})
+    for (const bool adj_y : {false, true}) {
+      std::initializer_list<int64_t> x_dims = {5, 4, adj_x ? K : M,
+                                               adj_x ? M : K};
+      std::initializer_list<int64_t> y_dims = {5, 4, adj_y ? N : K,
+                                               adj_y ? K : N};
+      this->VerifyFusedBatchMatMul(x_dims, y_dims,
+                                   {{"Mul"}, {{} /*scalar multiplicand*/}},
+                                   adj_x, adj_y);
+    }
+}
+
+TYPED_TEST_P(FusedBatchMatMulOpTest, AddFusion) {
+  const int M = 3;
+  const int K = 5;
+  const int N = 3;
+  for (const bool adj_x : {false, true})
+    for (const bool adj_y : {false, true}) {
+      std::initializer_list<int64_t> x_dims = {5, 4, adj_x ? K : M,
+                                               adj_x ? M : K};
+      std::initializer_list<int64_t> y_dims = {5, 4, adj_y ? N : K,
+                                               adj_y ? K : N};
+      this->VerifyFusedBatchMatMul(x_dims, y_dims, {{"Add"}, {{5, 1, M, N}}},
+                                   adj_x, adj_y);
+    }
+}
+
+TYPED_TEST_P(FusedBatchMatMulOpTest, MulAddFusion) {
+  const int M = 3;
+  const int K = 5;
+  const int N = 3;
+  for (const bool adj_x : {false, true})
+    for (const bool adj_y : {false, true}) {
+      std::initializer_list<int64_t> x_dims = {5, 4, adj_x ? K : M,
+                                               adj_x ? M : K};
+      std::initializer_list<int64_t> y_dims = {5, 4, adj_y ? N : K,
+                                               adj_y ? K : N};
+      this->VerifyFusedBatchMatMul(
+          x_dims, y_dims,
+          {{"Mul", "Add"}, {{} /*scalar multiplicand*/, {5, 1, M, N}}}, adj_x,
+          adj_y);
+    }
+}
+
+TYPED_TEST_P(FusedBatchMatMulOpTest, QuantizedNoFusion) {
+  this->VerifyQuantizedBatchMatMul({});
+}
+
+TYPED_TEST_P(FusedBatchMatMulOpTest, QuantizedMulFusion) {
+  this->VerifyQuantizedBatchMatMul({"Mul"});
+}
+
+TYPED_TEST_P(FusedBatchMatMulOpTest, QuantizedAddFusion) {
+  this->VerifyQuantizedBatchMatMul({"Add"});
+}
+
+TYPED_TEST_P(FusedBatchMatMulOpTest, QuantizedMulAddFusion) {
+  this->VerifyQuantizedBatchMatMul({"Mul", "Add"});
+}
+
+REGISTER_TYPED_TEST_SUITE_P(FusedBatchMatMulOpTest, MulFusion, AddFusion,
+                            MulAddFusion, QuantizedNoFusion, QuantizedMulFusion,
+                            QuantizedAddFusion, QuantizedMulAddFusion);
+
+using FusedBatchMatMulDataTypes = ::testing::Types<float>;
+INSTANTIATE_TYPED_TEST_SUITE_P(Test, FusedBatchMatMulOpTest,
+                               FusedBatchMatMulDataTypes);
+
+}  // namespace tensorflow
+
+#endif  // INTEL_MKL

--- a/tensorflow/core/ops/mkl_nn_ops.cc
+++ b/tensorflow/core/ops/mkl_nn_ops.cc
@@ -1922,6 +1922,39 @@ REGISTER_OP("_MklLayerNorm")
     .Attr("epsilon: float = 0.001")
     .SetShapeFn(shape_inference::UnchangedShape);
 
+REGISTER_OP("_QuantizedBatchMatMul")
+    // Variable number of inputs depending on fusion. The inputs contain
+    // quantized or real tensors. Some of the inputs carry min-max values for
+    // quantized tensors.
+    .Input("device_inputs: Tdevice_inputs")
+    .Input("host_inputs: Thost_inputs")
+    // Variable number of outputs depending on the main output type. For
+    // example, quantized output will need additional tensors to carry min-max
+    // values. If the output type is real tensor (e.g. Dequantize fusion), the
+    // op should produce only single output tensor.
+    .Output("device_outputs: Tdevice_outputs")
+    .Output("host_outputs: Thost_outputs")
+    .Attr("Tdevice_inputs: list(type) >= 0 = []")
+    .Attr("Thost_inputs: list(type) >= 0 = []")
+    .Attr("Tdevice_outputs: list(type) >= 0 = []")
+    .Attr("Thost_outputs: list(type) >= 0 = []")
+    // The following attributes T1, T2, Tfusion, and Tout are members of Tinputs
+    // and Toutputs, used here for type constraints in the templatized OpKernel
+    // registrations.
+    .Attr("T1: quantizedtype")  // 0-th input    
+    .Attr("T2: quantizedtype")  // 1st input
+    // Currently, restricting all additional inputs of same type.
+    .Attr("U: {bfloat16, float, quantizedtype} = DT_FLOAT")
+    .Attr("Tout: {bfloat16, float, quantizedtype} = DT_FLOAT")  // 0-th output  
+    .Attr("adj_x: bool = false")
+    .Attr("adj_y: bool = false")
+    .Attr("fused_ops: list(string) = []")
+    // Attribute for quantization mode of all quantized input tensors.
+    // Currently restricting all operands using same quantization mode.
+    .Attr("input_quant_mode: {'MIN_FIRST', 'SCALED'} = 'SCALED'")
+    // Attribute for activation (0-th output) requnatization mode
+    .Attr("output_quant_mode: {'MIN_FIRST', 'SCALED'} = 'SCALED'")
+    .SetShapeFn(shape_inference::BatchMatMulV2Shape);
 REGISTER_OP("_MklSoftmax")
     .Input("logits: T")
     .Output("softmax: T")

--- a/tensorflow/core/ops/mkl_nn_ops.cc
+++ b/tensorflow/core/ops/mkl_nn_ops.cc
@@ -1941,11 +1941,11 @@ REGISTER_OP("_QuantizedBatchMatMul")
     // The following attributes T1, T2, Tfusion, and Tout are members of Tinputs
     // and Toutputs, used here for type constraints in the templatized OpKernel
     // registrations.
-    .Attr("T1: quantizedtype")  // 0-th input    
+    .Attr("T1: quantizedtype")  // 0-th input
     .Attr("T2: quantizedtype")  // 1st input
     // Currently, restricting all additional inputs of same type.
     .Attr("U: {bfloat16, float, quantizedtype} = DT_FLOAT")
-    .Attr("Tout: {bfloat16, float, quantizedtype} = DT_FLOAT")  // 0-th output  
+    .Attr("Tout: {bfloat16, float, quantizedtype} = DT_FLOAT")  // 0-th output
     .Attr("adj_x: bool = false")
     .Attr("adj_y: bool = false")
     .Attr("fused_ops: list(string) = []")


### PR DESCRIPTION
This PR enables support for quantized batched matrices in the BatchMatMul op. A few binary ops can also be fused to it. Transformers based models frequently uses it and the fusions (e.g., BatchMatMul + Mul + Add) in their self-attention.