### PR TITLE
Fix benchmark_model compilation for Windows

### DIFF
--- a/tensorflow/lite/tools/benchmark/benchmark_model.cc
+++ b/tensorflow/lite/tools/benchmark/benchmark_model.cc
@@ -15,7 +15,9 @@ limitations under the License.
 
 #include "tensorflow/lite/tools/benchmark/benchmark_model.h"
 
+#ifdef __linux__
 #include <unistd.h>
+#endif  // __linux__
 
 #include <iostream>
 #include <memory>


### PR DESCRIPTION
Adding #ifdef block around unistd.h header.