### PR TITLE
Updated Ops compatibility list with new api

### DIFF
--- a/tensorflow/lite/g3doc/guide/ops_compatibility.md
+++ b/tensorflow/lite/g3doc/guide/ops_compatibility.md
@@ -87,12 +87,6 @@ requires "fake-quantization" during model training, getting range information
 via a calibration data set, or doing "on-the-fly" range estimation. See
 [quantization](../performance/model_optimization.md) for more details.
 
-## Supported operations and restrictions
-
-TensorFlow Lite supports a subset of TensorFlow operations with some
-limitations. For full list of operations and limitations see
-[TF Lite Ops page](https://www.tensorflow.org/mlir/tfl_ops).
-
 ## Straight-forward conversions, constant-folding and fusing
 
 A number of TensorFlow operations can be processed by TensorFlow Lite even

--- a/tensorflow/lite/g3doc/guide/ops_compatibility.md
+++ b/tensorflow/lite/g3doc/guide/ops_compatibility.md
@@ -74,7 +74,6 @@ requires you to
 which limits you from taking advantage of standard runtime services such as
 the [Google Play services](../android/play_services).
 
-
 ## Supported types
 
 Most TensorFlow Lite operations target both floating-point (`float32`) and
@@ -86,8 +85,13 @@ between floating-point and quantized models is the way they are converted.
 Quantized conversion requires dynamic range information for tensors. This
 requires "fake-quantization" during model training, getting range information
 via a calibration data set, or doing "on-the-fly" range estimation. See
-[quantization](../performance/model_optimization.md) for more details.
+[quantization](../performance/model_optimization.md).
 
+## Supported operations and restrictions
+
+TensorFlow Lite supports a subset of TensorFlow operations with some
+limitations. For full list of operations and limitations see
+[TF Lite Ops page](https://www.tensorflow.org/mlir/tfl_ops).
 
 ## Straight-forward conversions, constant-folding and fusing
 
@@ -102,7 +106,7 @@ Here is a non-exhaustive list of TensorFlow operations that are usually removed
 from the graph:
 
 *   `tf.add`
-*   `tf.check_numerics`
+*   `tf.debugging.check_numerics`
 *   `tf.constant`
 *   `tf.div`
 *   `tf.divide`
@@ -146,3 +150,4 @@ models:
 *   `LSH_PROJECTION`
 *   `SKIP_GRAM`
 *   `SVDF`
+

--- a/tensorflow/lite/g3doc/guide/ops_compatibility.md
+++ b/tensorflow/lite/g3doc/guide/ops_compatibility.md
@@ -85,7 +85,7 @@ between floating-point and quantized models is the way they are converted.
 Quantized conversion requires dynamic range information for tensors. This
 requires "fake-quantization" during model training, getting range information
 via a calibration data set, or doing "on-the-fly" range estimation. See
-[quantization](../performance/model_optimization.md).
+[quantization](../performance/model_optimization.md) for more details.
 
 ## Supported operations and restrictions
 

--- a/tensorflow/lite/g3doc/guide/ops_compatibility.md
+++ b/tensorflow/lite/g3doc/guide/ops_compatibility.md
@@ -24,7 +24,6 @@ model that can be used with
 TensorFlow Lite is to carefully consider how operations are converted and
 optimized, along with the limitations imposed by this process.
 
-
 ## Supported operators
 
 TensorFlow Lite built-in operators are a subset of the operators
@@ -134,7 +133,6 @@ from the graph:
 
 Note: Many of those operations don't have TensorFlow Lite equivalents, and the
 corresponding model will not be convertible if they can't be elided or fused.
-
 
 ## Experimental Operations
 The following TensorFlow Lite operations are present, but not ready for custom

--- a/tensorflow/lite/g3doc/guide/ops_compatibility.md
+++ b/tensorflow/lite/g3doc/guide/ops_compatibility.md
@@ -24,6 +24,7 @@ model that can be used with
 TensorFlow Lite is to carefully consider how operations are converted and
 optimized, along with the limitations imposed by this process.
 
+
 ## Supported operators
 
 TensorFlow Lite built-in operators are a subset of the operators
@@ -74,6 +75,7 @@ requires you to
 which limits you from taking advantage of standard runtime services such as
 the [Google Play services](../android/play_services).
 
+
 ## Supported types
 
 Most TensorFlow Lite operations target both floating-point (`float32`) and
@@ -86,6 +88,7 @@ Quantized conversion requires dynamic range information for tensors. This
 requires "fake-quantization" during model training, getting range information
 via a calibration data set, or doing "on-the-fly" range estimation. See
 [quantization](../performance/model_optimization.md) for more details.
+
 
 ## Straight-forward conversions, constant-folding and fusing
 
@@ -131,6 +134,7 @@ from the graph:
 
 Note: Many of those operations don't have TensorFlow Lite equivalents, and the
 corresponding model will not be convertible if they can't be elided or fused.
+
 
 ## Experimental Operations
 The following TensorFlow Lite operations are present, but not ready for custom


### PR DESCRIPTION
Replaced  old api 
 tf.check_numerics
with new api
 tf.debugging.check_numerics

in ops compatibility list.