### PR TITLE
[NVIDIA TF] Unit tests for bf16 random ops on GPU

### DIFF
--- a/tensorflow/python/kernel_tests/random/random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/random_ops_test.py
@@ -29,11 +29,12 @@ from tensorflow.python.ops import random_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
-
-FLOATS = [dtypes.float16, dtypes.float32, dtypes.float64]
-if test_util.is_gpu_available(
-      cuda_only=True, min_cuda_compute_capability=(8, 0)):
-  FLOATS += [dtypes.bfloat16]
+def get_float_types():
+  float_types = [dtypes.float16, dtypes.float32, dtypes.float64]
+  if test_util.is_gpu_available(
+        cuda_only=True, min_cuda_compute_capability=(8, 0)):
+    float_types += [dtypes.bfloat16]
+  return float_types
 
 class RandomOpTestCommon(test.TestCase):
 
@@ -82,7 +83,7 @@ class RandomNormalTest(RandomOpTestCommon):
   # to see the same sequence of values. Will catch buggy
   # implementations which uses the same random number seed.
   def testDistinct(self):
-    for dt in FLOATS:
+    for dt in get_float_types():
       sampler = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=True)
       x = sampler()
       y = sampler()
@@ -98,7 +99,7 @@ class RandomNormalTest(RandomOpTestCommon):
   # given the same random seed
   @test_util.run_deprecated_v1
   def testCPUGPUMatch(self):
-    for dt in FLOATS:
+    for dt in get_float_types():
       results = {}
       for use_gpu in [False, True]:
         sampler = self._Sampler(
@@ -113,7 +114,7 @@ class RandomNormalTest(RandomOpTestCommon):
 
   @test_util.run_deprecated_v1
   def testSeed(self):
-    for dt in FLOATS:
+    for dt in get_float_types():
       sx = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=True, seed=345)
       sy = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=True, seed=345)
       self.assertAllEqual(sx(), sy())
@@ -131,14 +132,14 @@ class RandomNormalTest(RandomOpTestCommon):
   @test_util.run_deprecated_v1
   def testSingleSessionNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in FLOATS:
+      for dt in get_float_types():
         self._testSingleSessionNotConstant(
             random_ops.random_normal, 100, dt, 0.0, 1.0, use_gpu=use_gpu)
 
   @test_util.run_deprecated_v1
   def testSingleSessionOpSeedNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in FLOATS:
+      for dt in get_float_types():
         self._testSingleSessionNotConstant(
             random_ops.random_normal,
             100,
@@ -151,7 +152,7 @@ class RandomNormalTest(RandomOpTestCommon):
   @test_util.run_deprecated_v1
   def testSingleSessionGraphSeedNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in FLOATS:
+      for dt in get_float_types():
         self._testSingleSessionNotConstant(
             random_ops.random_normal,
             100,
@@ -184,7 +185,7 @@ class TruncatedNormalTest(test.TestCase):
   def testDistinct(self):
     # NOTE: TruncatedNormal on GPU is not supported.
     if not test.is_gpu_available():
-      for dt in FLOATS:
+      for dt in get_float_types():
         sampler = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=False)
         x = sampler()
         y = sampler()
@@ -204,7 +205,7 @@ class TruncatedNormalTest(test.TestCase):
     if not test.is_gpu_available():
       return
 
-    for dt in FLOATS:
+    for dt in get_float_types():
       results = {}
       for use_gpu in [False, True]:
         # We need a particular larger number of samples to test multiple rounds
@@ -221,7 +222,7 @@ class TruncatedNormalTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def testSeed(self):
-    for dt in FLOATS:
+    for dt in get_float_types():
       sx = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=True, seed=345)
       sy = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=True, seed=345)
       self.assertAllEqual(sx(), sy())
@@ -229,7 +230,7 @@ class TruncatedNormalTest(test.TestCase):
   # The effective standard deviation of truncated normal is 85% of the
   # requested one.
   def testStdDev(self):
-    for dt in FLOATS:
+    for dt in get_float_types():
       stddev = 3.0
       sampler = self._Sampler(100000, 0.0, stddev, dt, use_gpu=True)
       x = sampler()
@@ -296,7 +297,7 @@ class RandomUniformTest(RandomOpTestCommon):
     return func
 
   def testRange(self):
-    for dt in FLOATS + [dtypes.int32, dtypes.int64]:
+    for dt in get_float_types() + [dtypes.int32, dtypes.int64]:
       sampler = self._Sampler(1000, minv=-2, maxv=8, dtype=dt, use_gpu=True)
       x = sampler()
       self.assertTrue(-2 <= np.min(x))
@@ -306,7 +307,7 @@ class RandomUniformTest(RandomOpTestCommon):
   # to see the same sequence of values. Will catch buggy
   # implementations which uses the same random number seed.
   def testDistinct(self):
-    for dt in FLOATS + [dtypes.int32, dtypes.int64]:
+    for dt in get_float_types() + [dtypes.int32, dtypes.int64]:
       maxv = 1.0 if dt.is_floating else 1 << 30
       sampler = self._Sampler(1000, minv=0, maxv=maxv, dtype=dt, use_gpu=True)
       x = sampler()
@@ -371,7 +372,7 @@ class RandomUniformTest(RandomOpTestCommon):
   # given the same random seed
   @test_util.run_deprecated_v1
   def testCPUGPUMatch(self):
-    for dt in FLOATS + [dtypes.int32, dtypes.int64]:
+    for dt in get_float_types() + [dtypes.int32, dtypes.int64]:
       maxv = 1.0 if dt.is_floating else 17
       results = {}
       for use_gpu in False, True:
@@ -382,7 +383,7 @@ class RandomUniformTest(RandomOpTestCommon):
 
   @test_util.run_deprecated_v1
   def testSeed(self):
-    for dt in FLOATS + [dtypes.int32, dtypes.int64]:
+    for dt in get_float_types() + [dtypes.int32, dtypes.int64]:
       for seed in [345, 2**100, -2**100]:
         sx = self._Sampler(1000, 0, 17, dtype=dt, use_gpu=True, seed=seed)
         sy = self._Sampler(1000, 0, 17, dtype=dt, use_gpu=True, seed=seed)
@@ -401,14 +402,14 @@ class RandomUniformTest(RandomOpTestCommon):
   @test_util.run_deprecated_v1
   def testSingleSessionNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in FLOATS + [dtypes.int32, dtypes.int64]:
+      for dt in get_float_types() + [dtypes.int32, dtypes.int64]:
         self._testSingleSessionNotConstant(
             random_ops.random_uniform, 100, dt, 0, 17, use_gpu=use_gpu)
 
   @test_util.run_deprecated_v1
   def testSingleSessionOpSeedNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in FLOATS + [dtypes.int32, dtypes.int64]:
+      for dt in get_float_types() + [dtypes.int32, dtypes.int64]:
         self._testSingleSessionNotConstant(
             random_ops.random_uniform,
             100,
@@ -421,7 +422,7 @@ class RandomUniformTest(RandomOpTestCommon):
   @test_util.run_deprecated_v1
   def testSingleSessionGraphSeedNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in FLOATS + [dtypes.int32, dtypes.int64]:
+      for dt in get_float_types() + [dtypes.int32, dtypes.int64]:
         self._testSingleSessionNotConstant(
             random_ops.random_uniform,
             100,

--- a/tensorflow/python/kernel_tests/random/random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/random_ops_test.py
@@ -30,6 +30,10 @@ from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
 
+FLOATS = [dtypes.float16, dtypes.float32, dtypes.float64]
+if test_util.is_gpu_available(cuda_only=True, min_cuda_compute_capability=(8, 0)):
+  FLOATS += [dtypes.bfloat16]
+
 class RandomOpTestCommon(test.TestCase):
 
   # Checks that executing the same rng_func multiple times rarely produces the
@@ -77,7 +81,7 @@ class RandomNormalTest(RandomOpTestCommon):
   # to see the same sequence of values. Will catch buggy
   # implementations which uses the same random number seed.
   def testDistinct(self):
-    for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+    for dt in FLOATS:
       sampler = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=True)
       x = sampler()
       y = sampler()
@@ -93,20 +97,22 @@ class RandomNormalTest(RandomOpTestCommon):
   # given the same random seed
   @test_util.run_deprecated_v1
   def testCPUGPUMatch(self):
-    for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+    for dt in FLOATS:
       results = {}
       for use_gpu in [False, True]:
         sampler = self._Sampler(
             1000000, 0.0, 1.0, dt, use_gpu=use_gpu, seed=12345)
         results[use_gpu] = sampler()
+      rtol = atol = 1e-6
       if dt == dtypes.float16:
-        self.assertAllClose(results[False], results[True], rtol=1e-3, atol=1e-3)
-      else:
-        self.assertAllClose(results[False], results[True], rtol=1e-6, atol=1e-6)
+        rtol = atol = 1e-3
+      elif  dt == dtypes.bfloat16:
+        rtol = atol = 1e-1
+      self.assertAllClose(results[False], results[True], rtol=rtol, atol=atol)
 
   @test_util.run_deprecated_v1
   def testSeed(self):
-    for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+    for dt in FLOATS:
       sx = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=True, seed=345)
       sy = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=True, seed=345)
       self.assertAllEqual(sx(), sy())
@@ -124,14 +130,14 @@ class RandomNormalTest(RandomOpTestCommon):
   @test_util.run_deprecated_v1
   def testSingleSessionNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+      for dt in FLOATS:
         self._testSingleSessionNotConstant(
             random_ops.random_normal, 100, dt, 0.0, 1.0, use_gpu=use_gpu)
 
   @test_util.run_deprecated_v1
   def testSingleSessionOpSeedNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+      for dt in FLOATS:
         self._testSingleSessionNotConstant(
             random_ops.random_normal,
             100,
@@ -144,7 +150,7 @@ class RandomNormalTest(RandomOpTestCommon):
   @test_util.run_deprecated_v1
   def testSingleSessionGraphSeedNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+      for dt in FLOATS:
         self._testSingleSessionNotConstant(
             random_ops.random_normal,
             100,
@@ -177,7 +183,7 @@ class TruncatedNormalTest(test.TestCase):
   def testDistinct(self):
     # NOTE: TruncatedNormal on GPU is not supported.
     if not test.is_gpu_available():
-      for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+      for dt in FLOATS:
         sampler = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=False)
         x = sampler()
         y = sampler()
@@ -197,7 +203,7 @@ class TruncatedNormalTest(test.TestCase):
     if not test.is_gpu_available():
       return
 
-    for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+    for dt in FLOATS:
       results = {}
       for use_gpu in [False, True]:
         # We need a particular larger number of samples to test multiple rounds
@@ -205,14 +211,16 @@ class TruncatedNormalTest(test.TestCase):
         sampler = self._Sampler(
             1000000, 0.0, 1.0, dt, use_gpu=use_gpu, seed=12345)
         results[use_gpu] = sampler()
+      atol = rtol = 1e-6
       if dt == dtypes.float16:
-        self.assertAllClose(results[False], results[True], rtol=1e-3, atol=1e-3)
-      else:
-        self.assertAllClose(results[False], results[True], rtol=1e-6, atol=1e-6)
+         atol = rtol = 1e-3
+      if dt == dtypes.bfloat16:
+         atol = rtol = 1e-1
+      self.assertAllClose(results[False], results[True], rtol=rtol, atol=atol)
 
   @test_util.run_deprecated_v1
   def testSeed(self):
-    for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+    for dt in FLOATS:
       sx = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=True, seed=345)
       sy = self._Sampler(1000, 0.0, 1.0, dt, use_gpu=True, seed=345)
       self.assertAllEqual(sx(), sy())
@@ -220,7 +228,7 @@ class TruncatedNormalTest(test.TestCase):
   # The effective standard deviation of truncated normal is 85% of the
   # requested one.
   def testStdDev(self):
-    for dt in dtypes.float16, dtypes.float32, dtypes.float64:
+    for dt in FLOATS:
       stddev = 3.0
       sampler = self._Sampler(100000, 0.0, stddev, dt, use_gpu=True)
       x = sampler()
@@ -287,8 +295,7 @@ class RandomUniformTest(RandomOpTestCommon):
     return func
 
   def testRange(self):
-    for dt in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes.int32,
-               dtypes.int64):
+    for dt in FLOATS + [dtypes.int32, dtypes.int64]:
       sampler = self._Sampler(1000, minv=-2, maxv=8, dtype=dt, use_gpu=True)
       x = sampler()
       self.assertTrue(-2 <= np.min(x))
@@ -298,14 +305,17 @@ class RandomUniformTest(RandomOpTestCommon):
   # to see the same sequence of values. Will catch buggy
   # implementations which uses the same random number seed.
   def testDistinct(self):
-    for dt in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes.int32,
-               dtypes.int64):
+    for dt in FLOATS + [dtypes.int32, dtypes.int64]:
       maxv = 1.0 if dt.is_floating else 1 << 30
       sampler = self._Sampler(1000, minv=0, maxv=maxv, dtype=dt, use_gpu=True)
       x = sampler()
       y = sampler()
       count = (x == y).sum()
-      count_limit = 50 if dt == dtypes.float16 else 10
+      count_limit = 10
+      if dt == dtypes.float16:
+        count_limit = 50
+      elif dt == dtypes.bfloat16:
+        count_limit = 90
       if count >= count_limit:
         print("x = ", x)
         print("y = ", y)
@@ -360,8 +370,7 @@ class RandomUniformTest(RandomOpTestCommon):
   # given the same random seed
   @test_util.run_deprecated_v1
   def testCPUGPUMatch(self):
-    for dt in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes.int32,
-               dtypes.int64):
+    for dt in FLOATS + [dtypes.int32, dtypes.int64]:
       maxv = 1.0 if dt.is_floating else 17
       results = {}
       for use_gpu in False, True:
@@ -372,8 +381,7 @@ class RandomUniformTest(RandomOpTestCommon):
 
   @test_util.run_deprecated_v1
   def testSeed(self):
-    for dt in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes.int32,
-               dtypes.int64):
+    for dt in FLOATS + [dtypes.int32, dtypes.int64]:
       for seed in [345, 2**100, -2**100]:
         sx = self._Sampler(1000, 0, 17, dtype=dt, use_gpu=True, seed=seed)
         sy = self._Sampler(1000, 0, 17, dtype=dt, use_gpu=True, seed=seed)
@@ -392,16 +400,14 @@ class RandomUniformTest(RandomOpTestCommon):
   @test_util.run_deprecated_v1
   def testSingleSessionNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes.int32,
-                 dtypes.int64):
+      for dt in FLOATS + [dtypes.int32, dtypes.int64]:
         self._testSingleSessionNotConstant(
             random_ops.random_uniform, 100, dt, 0, 17, use_gpu=use_gpu)
 
   @test_util.run_deprecated_v1
   def testSingleSessionOpSeedNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes.int32,
-                 dtypes.int64):
+      for dt in FLOATS + [dtypes.int32, dtypes.int64]:
         self._testSingleSessionNotConstant(
             random_ops.random_uniform,
             100,
@@ -414,8 +420,7 @@ class RandomUniformTest(RandomOpTestCommon):
   @test_util.run_deprecated_v1
   def testSingleSessionGraphSeedNotConstant(self):
     for use_gpu in [False, True]:
-      for dt in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes.int32,
-                 dtypes.int64):
+      for dt in FLOATS + [dtypes.int32, dtypes.int64]:
         self._testSingleSessionNotConstant(
             random_ops.random_uniform,
             100,

--- a/tensorflow/python/kernel_tests/random/random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/random_ops_test.py
@@ -31,7 +31,8 @@ from tensorflow.python.platform import test
 
 
 FLOATS = [dtypes.float16, dtypes.float32, dtypes.float64]
-if test_util.is_gpu_available(cuda_only=True, min_cuda_compute_capability=(8, 0)):
+if test_util.is_gpu_available(
+      cuda_only=True, min_cuda_compute_capability=(8, 0)):
   FLOATS += [dtypes.bfloat16]
 
 class RandomOpTestCommon(test.TestCase):
@@ -213,9 +214,9 @@ class TruncatedNormalTest(test.TestCase):
         results[use_gpu] = sampler()
       atol = rtol = 1e-6
       if dt == dtypes.float16:
-         atol = rtol = 1e-3
+        atol = rtol = 1e-3
       if dt == dtypes.bfloat16:
-         atol = rtol = 1e-1
+        atol = rtol = 1e-1
       self.assertAllClose(results[False], results[True], rtol=rtol, atol=atol)
 
   @test_util.run_deprecated_v1

--- a/tensorflow/python/kernel_tests/random/stateful_random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/stateful_random_ops_test.py
@@ -43,7 +43,9 @@ g_unseeded = None
 
 
 GPU_FLOATS = [dtypes.float16, dtypes.float32, dtypes.float64]
-CPU_FLOATS = GPU_FLOATS + [dtypes.bfloat16]
+if test_util.is_gpu_available(cuda_only=True, min_cuda_compute_capability=(8, 0)):
+  GPU_FLOATS += [dtypes.bfloat16]
+CPU_FLOATS = [dtypes.bfloat16, dtypes.float16, dtypes.float32, dtypes.float64]
 FLOATS = GPU_FLOATS
 INTS = [dtypes.int32, dtypes.int64]
 
@@ -543,7 +545,7 @@ class StatefulRandomOpsTest(test.TestCase, parameterized.TestCase):
   def testDistributionOfUniform(self, dtype):
     """Use Pearson's Chi-squared test to test for uniformity."""
     n = 1000
-    seed = 12
+    seed = 123
     gen = random.Generator.from_seed(seed)
     maxval = 1
     if dtype.is_integer:

--- a/tensorflow/python/kernel_tests/random/stateful_random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/stateful_random_ops_test.py
@@ -43,7 +43,8 @@ g_unseeded = None
 
 
 GPU_FLOATS = [dtypes.float16, dtypes.float32, dtypes.float64]
-if test_util.is_gpu_available(cuda_only=True, min_cuda_compute_capability=(8, 0)):
+if test_util.is_gpu_available(
+      cuda_only=True, min_cuda_compute_capability=(8, 0)):
   GPU_FLOATS += [dtypes.bfloat16]
 CPU_FLOATS = [dtypes.bfloat16, dtypes.float16, dtypes.float32, dtypes.float64]
 FLOATS = GPU_FLOATS

--- a/tensorflow/python/kernel_tests/random/stateful_random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/stateful_random_ops_test.py
@@ -41,14 +41,7 @@ from tensorflow.python.platform import test
 g_seeded = None
 g_unseeded = None
 
-def get_gpu_float_types():
-  float_types = [dtypes.float16, dtypes.float32, dtypes.float64]
-  if test_util.is_gpu_available(
-        cuda_only=True, min_cuda_compute_capability=(8, 0)):
-    float_types += [dtypes.bfloat16]
-  return float_types
-
-CPU_FLOATS = [dtypes.bfloat16, dtypes.float16, dtypes.float32, dtypes.float64]
+FLOATS = [dtypes.bfloat16, dtypes.float16, dtypes.float32, dtypes.float64]
 INTS = [dtypes.int32, dtypes.int64]
 
 
@@ -497,7 +490,7 @@ class StatefulRandomOpsTest(test.TestCase, parameterized.TestCase):
 
     The CPU version.
     """
-    self._sameAsOldRandomOps("/device:CPU:0", CPU_FLOATS)
+    self._sameAsOldRandomOps("/device:CPU:0", FLOATS)
 
   @test_util.run_v2_only
   @test_util.run_cuda_only
@@ -506,7 +499,11 @@ class StatefulRandomOpsTest(test.TestCase, parameterized.TestCase):
 
     The GPU version.
     """
-    self._sameAsOldRandomOps(test_util.gpu_device_name(), get_gpu_float_types())
+    floats = [dtypes.float16, dtypes.float32, dtypes.float64]
+    if test_util.is_gpu_available(
+          cuda_only=True, min_cuda_compute_capability=(8, 0)):
+      floats += [dtypes.bfloat16]
+    self._sameAsOldRandomOps(test_util.gpu_device_name(), floats)
 
   @parameterized.parameters(INTS + [dtypes.uint32, dtypes.uint64])
   @test_util.run_v2_only
@@ -523,9 +520,12 @@ class StatefulRandomOpsTest(test.TestCase, parameterized.TestCase):
           shape=shape, dtype=dtype)
     self.assertAllEqual(cpu, gpu)
 
-  @parameterized.parameters(get_gpu_float_types() + INTS)
+  @parameterized.parameters(FLOATS + INTS)
   @test_util.run_v2_only
   def testUniformIsInRange(self, dtype):
+    if dtype == dtypes.bfloat16 and not test_util.is_gpu_available(
+          cuda_only=True, min_cuda_compute_capability=(8, 0)):
+      self.skipTest("Bfloat16 requires compute capability 8.0")
     minval = 2
     maxval = 33
     size = 1000
@@ -535,17 +535,23 @@ class StatefulRandomOpsTest(test.TestCase, parameterized.TestCase):
     self.assertTrue(np.all(x >= minval))
     self.assertTrue(np.all(x < maxval))
 
-  @parameterized.parameters(get_gpu_float_types())
+  @parameterized.parameters(FLOATS)
   @test_util.run_v2_only
   def testNormalIsFinite(self, dtype):
+    if dtype == dtypes.bfloat16 and not test_util.is_gpu_available(
+          cuda_only=True, min_cuda_compute_capability=(8, 0)):
+      self.skipTest("Bfloat16 requires compute capability 8.0")
     gen = random.Generator.from_seed(1234)
     x = gen.normal(shape=[10000], dtype=dtype).numpy()
     self.assertTrue(np.all(np.isfinite(x)))
 
-  @parameterized.parameters(get_gpu_float_types() + INTS)
+  @parameterized.parameters(FLOATS + INTS)
   @test_util.run_v2_only
   def testDistributionOfUniform(self, dtype):
     """Use Pearson's Chi-squared test to test for uniformity."""
+    if dtype == dtypes.bfloat16 and not test_util.is_gpu_available(
+          cuda_only=True, min_cuda_compute_capability=(8, 0)):
+      self.skipTest("Bfloat16 requires compute capability 8.0")
     n = 1000
     seed = 123
     gen = random.Generator.from_seed(seed)
@@ -563,10 +569,13 @@ class StatefulRandomOpsTest(test.TestCase, parameterized.TestCase):
     val = random_test_util.chi_squared(x, 10)
     self.assertLess(val, 16.92)
 
-  @parameterized.parameters(get_gpu_float_types())
+  @parameterized.parameters(FLOATS)
   @test_util.run_v2_only
   def testDistributionOfNormal(self, dtype):
     """Use Anderson-Darling test to test distribution appears normal."""
+    if dtype == dtypes.bfloat16 and not test_util.is_gpu_available(
+          cuda_only=True, min_cuda_compute_capability=(8, 0)):
+      self.skipTest("Bfloat16 requires compute capability 8.0")
     n = 1000
     gen = random.Generator.from_seed(1234)
     x = gen.normal(shape=[n], dtype=dtype).numpy()

--- a/tensorflow/python/kernel_tests/random/stateless_random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/stateless_random_ops_test.py
@@ -105,7 +105,7 @@ def float_cases(shape_dtypes=(None,)):
     device_type = get_device().device_type
     # Some dtypes are not supported on some devices
     if (dtype == dtypes.float16 and device_type in ('XLA_GPU', 'XLA_CPU') or
-        dtype == dtypes.bfloat16 and device_type == 'GPU'):
+        dtype == dtypes.bfloat16 and device_type == 'GPU' and not test_util.is_gpu_available(cuda_only=True, min_cuda_compute_capability=(8, 0))):
       dtype = dtypes.float32
     shape_ = (constant_op.constant(shape, dtype=shape_dtype)
               if shape_dtype is not None else shape)

--- a/tensorflow/python/kernel_tests/random/stateless_random_ops_test.py
+++ b/tensorflow/python/kernel_tests/random/stateless_random_ops_test.py
@@ -105,7 +105,9 @@ def float_cases(shape_dtypes=(None,)):
     device_type = get_device().device_type
     # Some dtypes are not supported on some devices
     if (dtype == dtypes.float16 and device_type in ('XLA_GPU', 'XLA_CPU') or
-        dtype == dtypes.bfloat16 and device_type == 'GPU' and not test_util.is_gpu_available(cuda_only=True, min_cuda_compute_capability=(8, 0))):
+        dtype == dtypes.bfloat16 and device_type == 'GPU' and 
+        not test_util.is_gpu_available(
+            cuda_only=True, min_cuda_compute_capability=(8, 0))):
       dtype = dtypes.float32
     shape_ = (constant_op.constant(shape, dtype=shape_dtype)
               if shape_dtype is not None else shape)


### PR DESCRIPTION
Follow-up to https://github.com/tensorflow/tensorflow/pull/58203
Tests are currently gated to only run on Ampere GPUs or newer.

cc @reedwm 