### PR TITLE
Update libjpeg_turbo

### DIFF
--- a/third_party/jpeg/jpeg.BUILD
+++ b/third_party/jpeg/jpeg.BUILD
@@ -1,7 +1,7 @@
 # Description:
 #   libjpeg-turbo is a drop in replacement for jpeglib optimized with SIMD.
 
-load("@org_tensorflow//third_party:common.bzl", "template_rule")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 
 licenses(["notice"])  # custom notice-style license, see LICENSE.md
 
@@ -312,9 +312,9 @@ genrule(
     tools = ["@nasm"],
 )
 
-template_rule(
+expand_template(
     name = "neon-compat_gen",
-    src = "simd/arm/neon-compat.h.in",
+    template = "simd/arm/neon-compat.h.in",
     out = "simd/arm/neon-compat.h",
     substitutions = {
         "#cmakedefine HAVE_VLD1_S16_X3": "#define HAVE_VLD1_S16_X3",
@@ -526,18 +526,28 @@ cc_library(
         "jsimd.h",
         "jsimd_none.c",
         "jsimddct.h",
+        "jconfigint.h",
     ],
     copts = libjpegturbo_copts,
 )
 
-template_rule(
+expand_template(
+    name = "jversion",
+    template = "jversion.h.in",
+    out = "jversion.h",
+    substitutions = {
+        "@COPYRIGHT_YEAR@": "1991-2022",
+    },
+)
+
+expand_template(
     name = "jconfig_win",
-    src = "win/jconfig.h.in",
+    template = "win/jconfig.h.in",
     out = "jconfig_win.h",
     substitutions = {
         "@JPEG_LIB_VERSION@": "62",
-        "@VERSION@": "2.0.0",
-        "@LIBJPEG_TURBO_VERSION_NUMBER@": "2000000",
+        "@VERSION@": "2.1.4",
+        "@LIBJPEG_TURBO_VERSION_NUMBER@": "2001004",
         "@BITS_IN_JSAMPLE@": "8",
         "#cmakedefine C_ARITH_CODING_SUPPORTED": "#define C_ARITH_CODING_SUPPORTED",
         "#cmakedefine D_ARITH_CODING_SUPPORTED": "#define D_ARITH_CODING_SUPPORTED",
@@ -548,8 +558,8 @@ template_rule(
 
 JCONFIG_NOWIN_COMMON_SUBSTITUTIONS = {
     "@JPEG_LIB_VERSION@": "62",
-    "@VERSION@": "2.0.0",
-    "@LIBJPEG_TURBO_VERSION_NUMBER@": "2000000",
+    "@VERSION@": "2.1.4",
+    "@LIBJPEG_TURBO_VERSION_NUMBER@": "2001004",
     "#cmakedefine C_ARITH_CODING_SUPPORTED 1": "#define C_ARITH_CODING_SUPPORTED 1",
     "#cmakedefine D_ARITH_CODING_SUPPORTED 1": "#define D_ARITH_CODING_SUPPORTED 1",
     "#cmakedefine MEM_SRCDST_SUPPORTED 1": "#define MEM_SRCDST_SUPPORTED 1",
@@ -580,23 +590,23 @@ JCONFIG_NOWIN_SIMD_SUBSTITUTIONS.update(JCONFIG_NOWIN_COMMON_SUBSTITUTIONS)
 
 JCONFIG_NOWIN_NOSIMD_SUBSTITUTIONS.update(JCONFIG_NOWIN_COMMON_SUBSTITUTIONS)
 
-template_rule(
+expand_template(
     name = "jconfig_nowin_nosimd",
-    src = "jconfig.h.in",
+    template  = "jconfig.h.in",
     out = "jconfig_nowin_nosimd.h",
     substitutions = JCONFIG_NOWIN_NOSIMD_SUBSTITUTIONS,
 )
 
-template_rule(
+expand_template(
     name = "jconfig_nowin_simd",
-    src = "jconfig.h.in",
+    template  = "jconfig.h.in",
     out = "jconfig_nowin_simd.h",
     substitutions = JCONFIG_NOWIN_SIMD_SUBSTITUTIONS,
 )
 
 JCONFIGINT_COMMON_SUBSTITUTIONS = {
-    "@BUILD@": "20210424",
-    "@VERSION@": "2.1.0",
+    "@BUILD@": "20221022",
+    "@VERSION@": "2.1.4",
     "@CMAKE_PROJECT_NAME@": "libjpeg-turbo",
     "#undef inline": "",
     "#cmakedefine HAVE_INTRIN_H": "",
@@ -632,16 +642,16 @@ JCONFIGINT_NOWIN_SUBSTITUTIONS.update(JCONFIGINT_COMMON_SUBSTITUTIONS)
 
 JCONFIGINT_WIN_SUBSTITUTIONS.update(JCONFIGINT_COMMON_SUBSTITUTIONS)
 
-template_rule(
+expand_template(
     name = "jconfigint_nowin",
-    src = "jconfigint.h.in",
+    template = "jconfigint.h.in",
     out = "jconfigint_nowin.h",
     substitutions = JCONFIGINT_NOWIN_SUBSTITUTIONS,
 )
 
-template_rule(
+expand_template(
     name = "jconfigint_win",
-    src = "jconfigint.h.in",
+    template = "jconfigint.h.in",
     out = "jconfigint_win.h",
     substitutions = JCONFIGINT_WIN_SUBSTITUTIONS,
 )

--- a/third_party/jpeg/workspace.bzl
+++ b/third_party/jpeg/workspace.bzl
@@ -5,9 +5,9 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 def repo():
     tf_http_archive(
         name = "libjpeg_turbo",
-        urls = tf_mirror_urls("https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.1.0.tar.gz"),
-        sha256 = "d6b7790927d658108dfd3bee2f0c66a2924c51ee7f9dc930f62c452f4a638c52",
-        strip_prefix = "libjpeg-turbo-2.1.0",
+        urls = tf_mirror_urls("https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/2.1.4.tar.gz"),
+        sha256 = "a78b05c0d8427a90eb5b4eb08af25309770c8379592bb0b8a863373128e6143f",
+        strip_prefix = "libjpeg-turbo-2.1.4",
         build_file = "//third_party/jpeg:jpeg.BUILD",
         system_build_file = "//third_party/jpeg:BUILD.system",
     )


### PR DESCRIPTION
Update libjpeg-turbo from 2.1.0 to 2.1.4

- Refactoring: Switching from `template_rule` to `expand_template` (from Skylib) - in the long term all occurrences should be replaced
- In 2.1.4 there is a new template file "jversion.h.in" that needs to be "configured"