### PR TITLE
Fix zlib download URL

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -574,7 +574,7 @@ def _tf_repositories():
         sha256 = "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30",
         strip_prefix = "zlib-1.2.13",
         system_build_file = "//third_party/systemlibs:zlib.BUILD",
-        urls = tf_mirror_urls("https://zlib.net/zlib-1.2.13.tar.gz"),
+        urls = tf_mirror_urls("https://zlib.net/fossils/zlib-1.2.13.tar.gz"),
     )
 
     # LINT.IfChange


### PR DESCRIPTION
Using `zlib.net/zlib-${version}.tar.gz` only works if `${version}` is the last released version. So we would need to keep updating this file in a rush each time a new release of `zlib` occurs.

However, all previous releases are at https://zlib.net/fossils/ so we won't need to do changes in a crunch (though it would still be good to bump dependencies as needed).