### PR TITLE
[NVIDIA TF] Use new heuristics query from v0.7.3

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
@@ -3419,13 +3419,6 @@ dnn::DataType GetConvAccumulatorType(dnn::DataType data_type) {
 #if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 
 namespace {
-cudnnBackendHeurMode_t GetCudnnFrontendHeurMode() {
-#if CUDNN_VERSION >= 8300
-  return CUDNN_HEUR_MODE_B;
-#else
-  return CUDNN_HEUR_MODE_INSTANT;
-#endif  // CUDNN_VERSION >= 8300
-}
 
 cudnnBackendDescriptorType_t GetCudnnConvolutionType(
     dnn::ConvolutionKind kind) {
@@ -4749,60 +4742,12 @@ port::Status CreateOpRunners(
         /*disable_tensor_core*/ !IsTensorMathEnabled(stream, input_type));
   };
 
-  if (!use_fallback) {
-    // In theory, mode GetCudnnFrontendHeurMode() is supposed to fall back to
-    // HEUR_MODE_INSTANT if it can't find any working engines. But there's a
-    // known cudnn issue where it doesn't when dealing with runtime compiled
-    // fusion engines. So we do it manually here.
-    // TODO(kaixih@nvidia): remove this when the cudnn fixes it.
-    cudnn_frontend::EngineHeuristics heuristics = [&] {
-      auto heuristics = cudnn_frontend::EngineHeuristicsBuilder()
-                            .setOperationGraph(*op_graph)
-                            .setHeurMode(GetCudnnFrontendHeurMode())
-                            .build();
-      if (heuristics.get_status() == CUDNN_STATUS_SUCCESS) return heuristics;
-      return cudnn_frontend::EngineHeuristicsBuilder()
-          .setOperationGraph(*op_graph)
-          .setHeurMode(CUDNN_HEUR_MODE_INSTANT)
-          .build();
-    }();
-    RETURN_MSG_IF_CUDNN_ERROR(heuristics);
-
-    // cuDNN frontend sneakily puts error messages on the object and returns
-    // partially-initialized results when there's an error; make sure to check
-    // them.
-    int64_t engine_count = heuristics.getEngineConfigCount();
-    RETURN_MSG_IF_CUDNN_ERROR(heuristics);
-    auto& heuristics_configs = heuristics.getEngineConfig(engine_count);
-    RETURN_MSG_IF_CUDNN_ERROR(heuristics);
-    VLOG(4) << "\nHeuristics engine configs size: "
-            << heuristics_configs.size();
-
-    cudnn_frontend::filter(heuristics_configs, filtered_configs,
-                           generic_filter_fn);
-  } else {
-#if CUDNN_VERSION < 8300
-    auto fallback = cudnn_frontend::EngineFallbackListBuilder()
-                        .setOperationGraph(*op_graph)
-                        .setOperation(GetCudnnConvolutionType(kind))
-                        .build();
-    RETURN_MSG_IF_CUDNN_ERROR(fallback);
-    auto& fallback_configs = fallback.getFallbackList();
-#else
-    auto fallback = cudnn_frontend::EngineHeuristicsBuilder()
-                        .setOperationGraph(*op_graph)
-                        .setHeurMode(CUDNN_HEUR_MODE_FALLBACK)
-                        .build();
-    RETURN_MSG_IF_CUDNN_ERROR(fallback);
-    int64_t engine_count = fallback.getEngineConfigCount();
-    RETURN_MSG_IF_CUDNN_ERROR(fallback);
-    auto& fallback_configs = fallback.getEngineConfig(engine_count);
-    RETURN_MSG_IF_CUDNN_ERROR(fallback);
-#endif
-    VLOG(4) << "\nFallback engine configs size: " << fallback_configs.size();
-
-    cudnn_frontend::filter(fallback_configs, filtered_configs,
-                           generic_filter_fn);
+  std::array<std::string, 1> heur_mode = {
+      use_fallback ? "heuristics_fallback" : "heuristics_mode_b"};
+  std::vector<cudnnStatus_t> ret = cudnn_frontend::get_heuristics_list(
+      heur_mode, *op_graph, generic_filter_fn, filtered_configs);
+  for (auto status : ret) {
+    RETURN_IF_CUDNN_ERROR(status);
   }
   VLOG(4) << "\nFiltered engine configs size: " << filtered_configs.size();
 

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -170,7 +170,7 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "e95f2353b3e03d98fada657552025e89cf26e429306c1548b412fa98c5b0600a",
+        sha256 = "3c7b842cd67989810955b220fa1116e7e2ed10660a8cfb632118146a64992c30",
         strip_prefix = "cudnn-frontend-0.7.3",
         urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.7.3.zip"),
     )

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -170,9 +170,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "6ca6e7d4affdff59c749865d6d0428c849968b0873a1d1b849f56d7be624f27b",
-        strip_prefix = "cudnn-frontend-0.7.1",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.7.1.zip"),
+        sha256 = "e95f2353b3e03d98fada657552025e89cf26e429306c1548b412fa98c5b0600a",
+        strip_prefix = "cudnn-frontend-0.7.3",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.7.3.zip"),
     )
 
     tf_http_archive(

--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,4 +1,4 @@
-From 8c4aece07c6993587198de3f626cd7b885a7fed1 Mon Sep 17 00:00:00 2001
+From 5c4069558d42fd61d083878335a704eb6f888ca9 Mon Sep 17 00:00:00 2001
 From: Kaixi Hou <kaixih@nvidia.com>
 Date: Tue, 4 May 2021 15:21:11 -0700
 Subject: [PATCH] Update headers path to TF-compat
@@ -50,7 +50,7 @@ index ded7e67..68341e1 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Engine.h b/include/cudnn_frontend_Engine.h
-index 83d3f80..a1b0301 100644
+index 7e18cd7..d26f4ee 100644
 --- a/include/cudnn_frontend_Engine.h
 +++ b/include/cudnn_frontend_Engine.h
 @@ -30,8 +30,8 @@
@@ -65,7 +65,7 @@ index 83d3f80..a1b0301 100644
  #include "cudnn_frontend_OperationGraph.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_EngineConfig.h b/include/cudnn_frontend_EngineConfig.h
-index a9cdb7f..0bb47ae 100644
+index ea68554..0888858 100644
 --- a/include/cudnn_frontend_EngineConfig.h
 +++ b/include/cudnn_frontend_EngineConfig.h
 @@ -29,8 +29,8 @@
@@ -93,7 +93,7 @@ index 323106a..d90a1ea 100644
  #include "cudnn_frontend_Heuristics.h"
  
 diff --git a/include/cudnn_frontend_ExecutionPlan.h b/include/cudnn_frontend_ExecutionPlan.h
-index 7bed4b4..d79cfff 100644
+index e361821..88f5790 100644
 --- a/include/cudnn_frontend_ExecutionPlan.h
 +++ b/include/cudnn_frontend_ExecutionPlan.h
 @@ -30,8 +30,8 @@
@@ -121,7 +121,7 @@ index aac4086..ed1f343 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_Heuristics.h b/include/cudnn_frontend_Heuristics.h
-index 376f654..2ff07c9 100644
+index b1c5e98..2ccd737 100644
 --- a/include/cudnn_frontend_Heuristics.h
 +++ b/include/cudnn_frontend_Heuristics.h
 @@ -25,8 +25,8 @@
@@ -151,7 +151,7 @@ index a7d0714..c5ccb90 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Operation.h b/include/cudnn_frontend_Operation.h
-index b084046..dc3c840 100644
+index d69decd..15c32d2 100644
 --- a/include/cudnn_frontend_Operation.h
 +++ b/include/cudnn_frontend_Operation.h
 @@ -30,8 +30,8 @@
@@ -166,7 +166,7 @@ index b084046..dc3c840 100644
  #include "cudnn_frontend_ConvDesc.h"
  #include "cudnn_frontend_PointWiseDesc.h"
 diff --git a/include/cudnn_frontend_OperationGraph.h b/include/cudnn_frontend_OperationGraph.h
-index 1478ce8..1903102 100644
+index 8c708b7..ce5b000 100644
 --- a/include/cudnn_frontend_OperationGraph.h
 +++ b/include/cudnn_frontend_OperationGraph.h
 @@ -30,8 +30,8 @@
@@ -226,7 +226,7 @@ index 2174509..d0d7e3b 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_VariantPack.h b/include/cudnn_frontend_VariantPack.h
-index 0fe4f2f..41a2552 100644
+index dc68207..8b47fce 100644
 --- a/include/cudnn_frontend_VariantPack.h
 +++ b/include/cudnn_frontend_VariantPack.h
 @@ -30,8 +30,8 @@


### PR DESCRIPTION
cuDNN frontend v0.7.3 has improved the `get_heuristics_list` so that it can correctly handle different modes and their fallbacks with different cuDNN versions. See more in https://github.com/NVIDIA/cudnn-frontend/releases/tag/v0.7.3. This can greatly reduce the burden from the caller side to track the support matrix of heuristics modes.

cc. @nluehr @pjannaty 