### PR TITLE
Disable rocBLAS atomics when asked

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/rocm/BUILD
+++ b/tensorflow/compiler/xla/stream_executor/rocm/BUILD
@@ -163,6 +163,7 @@ cc_library(
         "//tensorflow/compiler/xla/stream_executor/lib",
         "//tensorflow/compiler/xla/stream_executor/platform",
         "//tensorflow/compiler/xla/stream_executor/platform:dso_loader",
+        "//tensorflow/core:framework",
     ]),
     alwayslink = True,
 )

--- a/tensorflow/compiler/xla/stream_executor/rocm/BUILD
+++ b/tensorflow/compiler/xla/stream_executor/rocm/BUILD
@@ -163,7 +163,7 @@ cc_library(
         "//tensorflow/compiler/xla/stream_executor/lib",
         "//tensorflow/compiler/xla/stream_executor/platform",
         "//tensorflow/compiler/xla/stream_executor/platform:dso_loader",
-        "//tensorflow/core:framework",
+        "//tensorflow/tsl/util:determinism_for_kernels",
     ]),
     alwayslink = True,
 )

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocblas_wrapper.h
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocblas_wrapper.h
@@ -263,7 +263,8 @@ using stream_executor::internal::CachedDsoLoader::GetRocblasDsoHandle;
   __macro(rocblas_ztrsm_batched)                \
   __macro(rocblas_create_handle)                \
   __macro(rocblas_destroy_handle)               \
-  __macro(rocblas_set_stream)
+  __macro(rocblas_set_stream)                   \
+  __macro(rocblas_set_atomics_mode)
 
 // clang-format on
 

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.cc
@@ -43,7 +43,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/stream_executor/scratch_allocator.h"
 #include "tensorflow/compiler/xla/stream_executor/stream_executor.h"
 
-#include "tensorflow/core/util/determinism.h"
+#include "tensorflow/tsl/util/determinism.h"
 using tsl::OpDeterminismRequired;
 
 namespace stream_executor {

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.cc
@@ -201,7 +201,7 @@ bool ROCMBlas::DoBlasInternalImpl(FuncT rocblas_func, Stream *stream,
   bool allow_atomics = !OpDeterminismRequired();
   rocblas_status ret;
   if (!allow_atomics) {
-    ret = rocblas_set_atomics_mode(blas_, rocblas_atomics_not_allowed);
+    ret = wrap::rocblas_set_atomics_mode(blas_, rocblas_atomics_not_allowed);
     if (err_on_failure && ret != rocblas_status_success) {
       LOG(ERROR) << "failed to to set atomics mode before " << rocblas_func.kName << ": "
                  << ToString(ret);


### PR DESCRIPTION
For some reason, rocBLAS matrix ops (on AMD GPUs) are non-deterministic by default (as opposed to cuBLAS ones). Among other things, this causes covariance matrices to lose the positive semidefinite property.

This PR makes the rocBLAS backend opt-in to Tensorflow's determinism flag, restoring deterministic behavior.

I used the following code to test on gfx90a (requires jax, transformers, torch):

```
import jax.numpy as np
import jax
#jax.config.update('jax_platform_name', 'cpu')

from transformers import FlaxAutoModel, BertConfig

model_name = 'mossaic-candle/regex-gb-2021'
config = BertConfig.from_pretrained(model_name)
config.attention_probs_dropout_prob = 0.0
config.hidden_dropout_prob = 0.0
m = FlaxAutoModel.from_pretrained(model_name, config=config, from_pt=True)
m.params = m.to_fp32(m.params)
a = m(input_ids=np.array([[1],[0]]))['last_hidden_state']
b = m(input_ids=np.array([[0],[1]]))['last_hidden_state']
print(a[0] == b[1])
```

It should print an array with all elements equal to `True`  if the execution is deterministic. Execute with `TF_DETERMINISTIC_OPS=1` environment variable set.

```
pip list | grep jax
jax                          0.3.23
jaxlib                       0.3.23
```
