### PR TITLE
[tosa] [refactor] Remove DenseElementAttr with DenseArrayAttr

### DIFF
--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -1878,7 +1878,7 @@ LogicalResult ConvertTFLRankOp::matchAndRewrite(
 
   RankedTensorType rank_type =
       RankedTensorType::get({1}, rewriter.getIntegerType(32));
-  auto rank_attr = DenseElementsAttr::get(rank_type, {rank});
+  auto rank_attr = DenseI32ArrayAttr::get(rewriter.getContext(), {rank});
   auto rank_const = CreateOpAndInfer<tosa::ConstOp>(rewriter, op->getLoc(),
                                                     rank_type, rank_attr);
 
@@ -1910,8 +1910,8 @@ LogicalResult ConvertTFLShapeOp::matchAndRewrite(
 
   RankedTensorType shape_type = RankedTensorType::get(
       {static_cast<int32_t>(shape_arr.size())}, rewriter.getIntegerType(32));
-  auto shape_attr =
-      DenseElementsAttr::get(shape_type, llvm::makeArrayRef(shape_arr));
+  auto shape_attr = DenseI32ArrayAttr::get(rewriter.getContext(),
+                                           llvm::makeArrayRef(shape_arr));
   auto shape_const = CreateOpAndInfer<tosa::ConstOp>(rewriter, op->getLoc(),
                                                      shape_type, shape_attr);
 
@@ -1982,17 +1982,19 @@ LogicalResult ConvertTFLFillOp::matchAndRewrite(
 
   RankedTensorType fill_type = RankedTensorType::get(
       ArrayRef<int64_t>(dims_vals), value_elem.getType().getElementType());
-  DenseElementsAttr fill_attr;
+  DenseArrayAttr fill_attr;
 
   // Convert to a compatible zero type.
   if (value_elem.getType().getElementType().isa<FloatType>()) {
     SmallVector<float> fill_arr(
         total_size, value_elem.getValues<APFloat>()[0].convertToFloat());
-    fill_attr = DenseElementsAttr::get(fill_type, llvm::makeArrayRef(fill_arr));
+    fill_attr = DenseF32ArrayAttr::get(rewriter.getContext(),
+                                       llvm::makeArrayRef(fill_arr));
   } else {
     SmallVector<int32_t> fill_arr(
         total_size, value_elem.getValues<APInt>()[0].getLimitedValue());
-    fill_attr = DenseElementsAttr::get(fill_type, llvm::makeArrayRef(fill_arr));
+    fill_attr = DenseI32ArrayAttr::get(rewriter.getContext(),
+                                       llvm::makeArrayRef(fill_arr));
   }
   auto fill_const_op = CreateOpAndInfer<tosa::ConstOp>(rewriter, op->getLoc(),
                                                        fill_type, fill_attr);


### PR DESCRIPTION
Updated the usage of DenseElementAttr with DenseArrayAttr. 

### The following Op legalization has been updated: 
- TFRankOp, TFLRankOp
- TFShapeOp, TFLShapeOp
- TFFillOp, TFLFillOp

### DenseArrayAttr reference: 
- https://discourse.llvm.org/t/rfc-introduce-a-new-dense-array-attribute/63279
- https://github.com/llvm/llvm-project/commit/508eb41d82ca

Signed-off-by: Jerry Ge <jerry.ge@arm.com>