### PR TITLE
Declare strides when ACL objects init and activation in ACL depthwise

### DIFF
--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -24,14 +24,4 @@ ARM_SKIP_TESTS="-//tensorflow/lite/... \
 -//tensorflow/python/kernel_tests/nn_ops:conv_ops_test \
 -//tensorflow/python/kernel_tests/nn_ops:conv2d_backprop_filter_grad_test \
 -//tensorflow/python/kernel_tests/nn_ops:atrous_conv2d_test \
--//tensorflow/python/training:server_lib_test \
--//tensorflow/python/kernel_tests/linalg:linalg_grad_test_gpu \
--//tensorflow/python/kernel_tests/linalg:linalg_grad_test_cpu \
--//tensorflow/python/kernel_tests/linalg:linear_operator_block_diag_test_gpu \
--//tensorflow/python/kernel_tests/linalg:linear_operator_block_diag_test_cpu \
--//tensorflow/python/kernel_tests/linalg:linear_operator_block_lower_triangular_test_gpu \
--//tensorflow/python/kernel_tests/linalg:linear_operator_block_lower_triangular_test_cpu \
--//tensorflow/python/kernel_tests/linalg:linalg_ops_test_gpu \
--//tensorflow/python/kernel_tests/linalg:linalg_ops_test_cpu \
--//tensorflow/python/kernel_tests/linalg:linear_operator_composition_test_gpu \
--//tensorflow/python/kernel_tests/linalg:linear_operator_composition_test_cpu"
+-//tensorflow/python/training:server_lib_test"

--- a/third_party/compute_library/acl_fixed_format_kernels_striding.patch
+++ b/third_party/compute_library/acl_fixed_format_kernels_striding.patch
@@ -16,33 +16,55 @@
  *******************************************************************************
 
 diff --git a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
-index 77da83070..44aef28c6 100644
+index 77da83070..985f96761 100644
 --- a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
 +++ b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
-@@ -506,7 +506,7 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::run(ITensorPack &tensors)
-             ITensorInfo      *tensor_info     = b->info();
-             const DataLayout  data_layout     = tensor_info->data_layout();
-             const TensorShape tensor_shape    = tensor_info->tensor_shape();
+@@ -495,48 +495,6 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::run(ITensorPack &tensors)
+     {
+         ldb                                = b->info()->strides_in_bytes().y() / sizeof(TypeInput);
+         multi_stride_b                     = b->info()->strides_in_bytes().z() / sizeof(TypeInput);
+-        const arm_compute::WeightFormat wf = assembly_utils::map_to_arm_compute_weight_format(_gemm_kernel_asm->get_config().weight_format);
+-        if(is_fixed_format(wf))
+-        {
+-            // The 4D tensor of dimension O'HWI' created for the
+-            // OHWIo<interleave_by>i<block_by> format is in reality seen
+-            // as a 2D tensor at arm_gemm level, where the rows are
+-            // O'/<interleave_by> and the columns are <interleave_by> *
+-            // H * W * I'.
+-            ITensorInfo      *tensor_info     = b->info();
+-            const DataLayout  data_layout     = tensor_info->data_layout();
+-            const TensorShape tensor_shape    = tensor_info->tensor_shape();
 -            const int         tensor_height   = tensor_shape[get_data_layout_dimension_index(data_layout, DataLayoutDimension::HEIGHT)];
-+            int               tensor_height   = tensor_shape[get_data_layout_dimension_index(data_layout, DataLayoutDimension::HEIGHT)];
-             const int         tensor_width    = tensor_shape[get_data_layout_dimension_index(data_layout, DataLayoutDimension::WIDTH)];
-             int               tensor_channels = tensor_shape[get_data_layout_dimension_index(data_layout, DataLayoutDimension::CHANNEL)];
-             const int         interleave_by   = arm_compute::interleave_by(wf);
-@@ -528,6 +528,17 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::run(ITensorPack &tensors)
-             {
-                 // In this case dimension that is packed is only height
-                 // so we need to stride only height by interleave_by
-+                if(tensor_height % blocked_by != 0) {
-+                    tensor_height = arm_gemm::iceildiv(tensor_height, blocked_by) * blocked_by;
-+                    if(multi_stride_b != 0) {
-+                        multi_stride_b = tensor_height * tensor_width;
-+                    }
-+                }
-+
-+                if(tensor_width % interleave_by != 0) {
-+                    multi_stride_b = arm_gemm::iceildiv(tensor_width, interleave_by) * interleave_by * tensor_height;
-+                }
-+
-                 ldb = interleave_by * tensor_height;
-             }
-             else
+-            const int         tensor_width    = tensor_shape[get_data_layout_dimension_index(data_layout, DataLayoutDimension::WIDTH)];
+-            int               tensor_channels = tensor_shape[get_data_layout_dimension_index(data_layout, DataLayoutDimension::CHANNEL)];
+-            const int         interleave_by   = arm_compute::interleave_by(wf);
+-            const int         blocked_by      = arm_compute::block_by(wf);
+-            // We need to find a new stride that is distance from the data for one
+-            // set of output channels to the next
+-            if(ldb == tensor_channels && multi_stride_b == tensor_channels * tensor_width)
+-            {
+-                // In this case dimensions that are packed are height, width and channel
+-                // so we need to stride it by interleave_by
+-                if(tensor_channels % blocked_by != 0)
+-                {
+-                    // We need to pad
+-                    tensor_channels = arm_gemm::iceildiv(tensor_channels, blocked_by) * blocked_by;
+-                }
+-                ldb = interleave_by * tensor_height * tensor_width * tensor_channels;
+-            }
+-            else if(multi_stride_b == 0 || (ldb == tensor_width && multi_stride_b == tensor_height * tensor_width))
+-            {
+-                // In this case dimension that is packed is only height
+-                // so we need to stride only height by interleave_by
+-                ldb = interleave_by * tensor_height;
+-            }
+-            else
+-            {
+-                // If dimensions are not packed as above error is thrown
+-                // as at the moment other forms of packing are not supported
+-                ARM_COMPUTE_ERROR("Unsupported packing for fixed format kernel");
+-            }
+-        }
+         in1_ptr = reinterpret_cast<const TypeInput *>(b->buffer() + b->info()->offset_first_element_in_bytes());
+     }
+ 

--- a/third_party/mkl_dnn/onednn_acl_depthwise_convolution.patch
+++ b/third_party/mkl_dnn/onednn_acl_depthwise_convolution.patch
@@ -14,9 +14,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  *******************************************************************************
- 
+
 diff --git a/src/cpu/aarch64/acl_convolution_utils.cpp b/src/cpu/aarch64/acl_convolution_utils.cpp
-index 6a840b973..47a3a4a92 100644
+index fc93d2aa9..6ebac0d17 100644
 --- a/src/cpu/aarch64/acl_convolution_utils.cpp
 +++ b/src/cpu/aarch64/acl_convolution_utils.cpp
 @@ -54,10 +54,12 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
@@ -73,7 +73,7 @@ index 6a840b973..47a3a4a92 100644
      acp.weights_info = arm_compute::WeightsInfo(
          false,
          kw,
-@@ -297,6 +311,10 @@ status_t init_conf_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+@@ -302,6 +316,10 @@ status_t init_conf_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
          const primitive_attr_t &attr) {
      acp.is_indirect = false;
  
@@ -84,7 +84,7 @@ index 6a840b973..47a3a4a92 100644
      // General Compute Library checks, memory tags are also set there
      CHECK(acl_init_conf(acp, src_md, weights_md, dst_md, bias_md, cd, attr));
  
-@@ -325,7 +343,8 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+@@ -330,7 +348,8 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
      auto math_mode = get_fpmath_mode();
      // Indirect convolution results in slowdown for low thread count or 1x1
      // kernels, so fall back to GEMM-based convolution in these cases
@@ -94,7 +94,7 @@ index 6a840b973..47a3a4a92 100644
                  weights_md.dims[3] == 1, // kw
                  (!math_mode && dnnl_get_max_threads() < 28))) {
          return status::unimplemented;
-@@ -350,6 +369,27 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+@@ -355,6 +374,27 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
      return status::success;
  }
  
@@ -122,7 +122,7 @@ index 6a840b973..47a3a4a92 100644
  status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
          memory_desc_t &weights_md, memory_desc_t &dst_md,
          memory_desc_t &bias_md, const convolution_desc_t &cd,
-@@ -359,7 +399,8 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+@@ -364,7 +404,8 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
      // Under these conditions, fallback to faster GEMM-based convolution
      // unless the user explicitly specifies Winograd algorithm
      // clang-format off
@@ -217,10 +217,10 @@ index 000000000..1beb8b8af
 +}
 diff --git a/src/cpu/aarch64/acl_depthwise_convolution.hpp b/src/cpu/aarch64/acl_depthwise_convolution.hpp
 new file mode 100644
-index 000000000..97e0a3a30
+index 000000000..d84fc4fb5
 --- /dev/null
 +++ b/src/cpu/aarch64/acl_depthwise_convolution.hpp
-@@ -0,0 +1,137 @@
+@@ -0,0 +1,139 @@
 +/*******************************************************************************
 +* Copyright 2022 Arm Ltd. and affiliates
 +*
@@ -266,7 +266,9 @@ index 000000000..97e0a3a30
 +            &acl_obj_->wei_tensor,
 +            acp.with_bias ? &acl_obj_->bia_tensor : nullptr,
 +            &acl_obj_->dst_tensor,
-+            acp.padstride_info);
++            acp.padstride_info,
++            1, // depth multiplier default value
++            acp.act_info);
 +
 +        // clang-format on
 +        return status::success;

--- a/third_party/mkl_dnn/onednn_acl_fixed_format_kernels.patch
+++ b/third_party/mkl_dnn/onednn_acl_fixed_format_kernels.patch
@@ -14,12 +14,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  *******************************************************************************
- 
+
 diff --git a/src/cpu/aarch64/acl_convolution_utils.cpp b/src/cpu/aarch64/acl_convolution_utils.cpp
-index c46d69757..6a840b973 100644
+index c46d69757..fc93d2aa9 100644
 --- a/src/cpu/aarch64/acl_convolution_utils.cpp
 +++ b/src/cpu/aarch64/acl_convolution_utils.cpp
-@@ -212,6 +212,82 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+@@ -212,6 +212,87 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
                  arm_compute::QuantizationInfo(1.0f / scales[0], 0));
      }
  
@@ -82,6 +82,11 @@ index c46d69757..6a840b973 100644
 +    want_wei_md.format_desc.blocking.strides[2] = interleaved_by*ic_multiply*kw;
 +    want_wei_md.format_desc.blocking.strides[3] = interleaved_by*ic_multiply;
 +
++    acl_utils::update_strides_y_and_z(
++        acp.wei_info,
++        want_wei_md.format_desc.blocking.strides[0] * wei_d.data_type_size(),
++        acp.wei_info.strides_in_bytes().z());
++
 +    // Set blocking
 +    want_wei_md.format_desc.blocking.inner_nblks = (block_by > 1) + 1;
 +    want_wei_md.format_desc.blocking.inner_idxs[0] = 0; // second to last dimension in abcd format
@@ -102,7 +107,7 @@ index c46d69757..6a840b973 100644
      return status::success;
  }
  
-@@ -219,6 +295,7 @@ status_t init_conf_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+@@ -219,6 +300,7 @@ status_t init_conf_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
          memory_desc_t &weights_md, memory_desc_t &dst_md,
          memory_desc_t &bias_md, const convolution_desc_t &cd,
          const primitive_attr_t &attr) {
@@ -110,7 +115,7 @@ index c46d69757..6a840b973 100644
  
      // General Compute Library checks, memory tags are also set there
      CHECK(acl_init_conf(acp, src_md, weights_md, dst_md, bias_md, cd, attr));
-@@ -244,11 +321,13 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+@@ -244,11 +326,13 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
          memory_desc_t &weights_md, memory_desc_t &dst_md,
          memory_desc_t &bias_md, const convolution_desc_t &cd,
          const primitive_attr_t &attr) {
@@ -125,7 +130,7 @@ index c46d69757..6a840b973 100644
          return status::unimplemented;
      }
  
-@@ -275,6 +354,7 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+@@ -275,6 +359,7 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
          memory_desc_t &weights_md, memory_desc_t &dst_md,
          memory_desc_t &bias_md, const convolution_desc_t &cd,
          const primitive_attr_t &attr) {
@@ -169,7 +174,7 @@ index bcf031a77..4ddc8cf91 100644
  
          return status::success;
 diff --git a/src/cpu/aarch64/acl_inner_product.hpp b/src/cpu/aarch64/acl_inner_product.hpp
-index c5e507085..15ea61173 100644
+index c5e507085..163ff066e 100644
 --- a/src/cpu/aarch64/acl_inner_product.hpp
 +++ b/src/cpu/aarch64/acl_inner_product.hpp
 @@ -45,6 +45,7 @@ struct acl_ip_conf_t {
@@ -238,7 +243,7 @@ index c5e507085..15ea61173 100644
  
              // Fast math mode
              auto math_mode = get_fpmath_mode();
-@@ -214,6 +212,74 @@ struct acl_inner_product_fwd_t : public primitive_t {
+@@ -214,6 +212,80 @@ struct acl_inner_product_fwd_t : public primitive_t {
                      aip.fc_info.activation_info));
              aip.use_dst_acc = post_ops.has_sum();
  
@@ -296,6 +301,12 @@ index c5e507085..15ea61173 100644
 +                want_wei_md.padded_dims[0] = padded_dim;
 +            }
 +
++            int data_type_size = memory_desc_wrapper(want_wei_md).data_type_size();
++            acl_utils::update_strides_y_and_z(
++                aip.wei_info,
++                want_wei_md.format_desc.blocking.strides[0] * data_type_size,
++                want_wei_md.format_desc.blocking.strides[1] * data_type_size);
++
 +            want_wei_md.format_desc.blocking.inner_nblks = (block_by > 1) + 1;
 +            want_wei_md.format_desc.blocking.inner_idxs[0] = 0;
 +            want_wei_md.format_desc.blocking.inner_blks[0] = interleaved_by;
@@ -313,8 +324,55 @@ index c5e507085..15ea61173 100644
              // clang-format off
              // Validate fully connected layer manually to check for return status
              ACL_CHECK_VALID(arm_compute::NEFullyConnectedLayer::validate(
+diff --git a/src/cpu/aarch64/acl_utils.cpp b/src/cpu/aarch64/acl_utils.cpp
+index 79ea775d6..7ee4c7398 100644
+--- a/src/cpu/aarch64/acl_utils.cpp
++++ b/src/cpu/aarch64/acl_utils.cpp
+@@ -157,6 +157,28 @@ status_t tensor_info(
+     return status::success;
+ }
+ 
++status_t update_strides_y_and_z(
++    arm_compute::TensorInfo &info, const int y, const int z) {
++
++    arm_compute::TensorShape shape = info.tensor_shape();
++    arm_compute::Strides old_strides_in_bytes = info.strides_in_bytes();
++
++    arm_compute::Strides new_strides_in_bytes;
++    for(size_t i = 0; i < shape.num_dimensions(); ++i) {
++        new_strides_in_bytes.set(i, old_strides_in_bytes[i]);
++    }
++
++    // set y
++    new_strides_in_bytes.set(1, y);
++    // set z
++    new_strides_in_bytes.set(2, z);
++
++    info.init(info.tensor_shape(), info.num_channels(), info.data_type(),
++            new_strides_in_bytes, info.offset_first_element_in_bytes(), info.total_size());
++
++    return status::success;
++}
++
+ status_t insert_singleton_dimension(arm_compute::TensorInfo &ti, size_t dim_i) {
+ 
+     // Max 6 dims in ACL, so we can't insert another
+diff --git a/src/cpu/aarch64/acl_utils.hpp b/src/cpu/aarch64/acl_utils.hpp
+index 28693bb16..c7c9e1278 100644
+--- a/src/cpu/aarch64/acl_utils.hpp
++++ b/src/cpu/aarch64/acl_utils.hpp
+@@ -62,6 +62,9 @@ status_t tensor_info(arm_compute::TensorInfo &info, const memory_desc_t &md);
+ status_t tensor_info(
+         arm_compute::TensorInfo &info, const memory_desc_wrapper &md);
+ 
++// Update y and z strides in arm_compute::TensorInfo
++status_t update_strides_y_and_z(arm_compute::TensorInfo &info, const int y, const int z);
++
+ // Insert a dimension of size 1 at the index dim_i of TensorInfo
+ status_t insert_singleton_dimension(arm_compute::TensorInfo &ti, size_t dim_i);
+ 
 diff --git a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
-index 679baec3a..4aa219376 100644
+index 679baec3a..853277e37 100644
 --- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
 +++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
 @@ -66,15 +66,12 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
@@ -335,7 +393,7 @@ index 679baec3a..4aa219376 100644
  
      amp.src_info = arm_compute::TensorInfo(
              arm_compute::TensorShape(K, M, 1, src_batch), 1,
-@@ -103,6 +100,125 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+@@ -103,6 +100,140 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
          ACL_CHECK_VALID(arm_compute::NETranspose::validate(
                  &amp.wei_acc_info, &amp.wei_info));
  
@@ -389,6 +447,11 @@ index 679baec3a..4aa219376 100644
 +                want_wei_md.padded_dims[1] = utils::div_up(want_wei_md.dims[1], interleaved_by) * interleaved_by;
 +            }
 +
++            acl_utils::update_strides_y_and_z(
++                amp.wei_info,
++                want_wei_md.format_desc.blocking.strides[1] * wei_d.data_type_size(),
++                want_wei_md.format_desc.blocking.strides[0] * wei_d.data_type_size());
++
 +            blocked_first_dimension = 1;
 +            blocked_second_dimension = 0;
 +
@@ -407,6 +470,11 @@ index 679baec3a..4aa219376 100644
 +                want_wei_md.padded_dims[2] = utils::div_up(want_wei_md.dims[2], interleaved_by) * interleaved_by;
 +           }
 +           want_wei_md.format_desc.blocking.strides[0] = want_wei_md.padded_dims[2] * want_wei_md.padded_dims[1];
++
++           acl_utils::update_strides_y_and_z(
++                amp.wei_info,
++                want_wei_md.format_desc.blocking.strides[2] * wei_d.data_type_size(),
++                want_wei_md.format_desc.blocking.strides[0] * wei_d.data_type_size());
 +
 +           blocked_first_dimension = 2;
 +           blocked_second_dimension = 1;
@@ -433,6 +501,11 @@ index 679baec3a..4aa219376 100644
 +            want_wei_md.format_desc.blocking.strides[1] = D_padded*C_padded;
 +            want_wei_md.format_desc.blocking.strides[2] = interleaved_by*block_by;
 +            want_wei_md.format_desc.blocking.strides[3] = interleaved_by*C_padded;
++
++            acl_utils::update_strides_y_and_z(
++                amp.wei_info,
++                want_wei_md.format_desc.blocking.strides[3] * wei_d.data_type_size(),
++                want_wei_md.format_desc.blocking.strides[1] * wei_d.data_type_size());
 +
 +            blocked_first_dimension = 3;
 +            blocked_second_dimension = 2;


### PR DESCRIPTION
The following fixes are in PR:

(1) Since when we are configuring ACL objects we know exactly what is expected formats for weights so we should set strides at that point and not leave it to ACL to estimate based on weights dimensions,

(2) If depthwise convolution comes with post op that converts to ACL’s activation layer operation we were not executing that activation function because the convolution was not configured with it.