### PR TITLE
stateful random ops, fix crash for empty output

### DIFF
--- a/tensorflow/core/kernels/stateful_random_ops.cc
+++ b/tensorflow/core/kernels/stateful_random_ops.cc
@@ -116,6 +116,10 @@ Status UpdateVariableAndFill(
     OpKernelContext* ctx, Distribution dist, int state_input_idx,
     bool read_alg_from_state, ConcreteRngAlgorithm alg, int64_t output_size,
     typename Distribution::ResultElementType* output_data) {
+  if (output_size == 0)
+    // Some CUDA kernels might crash otherwise (#51803):
+    //   Check failed: work_element_count > 0
+    return OkStatus();
   Var* var = nullptr;
   TF_RETURN_IF_ERROR(
       LookupResource(ctx, HandleFromInput(ctx, state_input_idx), &var));


### PR DESCRIPTION
Fix #51803 for stateful random ops.