### PR TITLE
[oneDNN] Update AMP lists : add Sum and Square ops to Infer list

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -429,7 +429,9 @@ class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {
                                      "Softsign",
                                      "SoftsignGrad",
                                      "Sqrt",
+                                     "Square",
                                      "SquaredDifference",
+                                     "Sum"
                                      "Tanh",
                                      "TanhGrad"};
     UpdateList("INFERLIST", &list);
@@ -448,7 +450,6 @@ class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {
         "SaveV2",
         "SoftmaxCrossEntropyWithLogits",
         "SparseSoftmaxCrossEntropyWithLogits",
-        "Sum",
     };
     UpdateList("DENYLIST", &list);
     // For backwards compatibility, keeping the original env variable here.

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -528,6 +528,7 @@ class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {
         "ReverseSequence",
         "ReverseV2",
         "Round",
+        "ScatterNd",
         "Select",
         "SelectV2",
         "Shape",


### PR DESCRIPTION
Eigen kernel for Sum now has a specialization for bfloat16 where the accumulation is done in FP32. Thus, there is no precision loss. Hence moving it from Deny list to Infer list. It reduces Cast ops around these ops and improves perf by 2x for some models