### PR TITLE
[ROCm] xla_gpu_enable_cublaslst and matrix_ops_simple_test is cuda only

### DIFF
--- a/tensorflow/compiler/xla/tests/dot_operation_test.cc
+++ b/tensorflow/compiler/xla/tests/dot_operation_test.cc
@@ -686,8 +686,11 @@ template <typename T>
 class DotOperationTestWithCublasLt_F16F32F64CF64 : public DotOperationTest {
  public:
   DotOperationTestWithCublasLt_F16F32F64CF64() {
-    execution_options_.mutable_debug_options()->set_xla_gpu_enable_cublaslt(
-        true);
+    bool enable_cublas_lt = false;
+#if GOOGLE_CUDA
+    enable_cublas_lt = true;    
+#endif
+    execution_options_.mutable_debug_options()->set_xla_gpu_enable_cublaslt(enable_cublas_lt);
   }
 };
 TYPED_TEST_CASE(DotOperationTestWithCublasLt_F16F32F64CF64, TypesF16F32F64CF64);

--- a/tensorflow/compiler/xla/tests/matrix_ops_simple_test.cc
+++ b/tensorflow/compiler/xla/tests/matrix_ops_simple_test.cc
@@ -185,6 +185,9 @@ class MatOpsDotAddTest
     bool add_lhs = std::get<1>(GetParam());
     bool transpose = std::get<2>(GetParam());
     bool use_cublaslt = std::get<3>(GetParam());
+#ifndef GOOGLE_CUDA
+    use_cublaslt = false;
+#endif    
     execution_options_.mutable_debug_options()->set_xla_gpu_enable_cublaslt(
         use_cublaslt);
     Array2D<T> lhs({{1.0f, 2.0f}, {3.0f, 4.0f}});
@@ -281,6 +284,9 @@ class MatOpsDotAddTest
     bool row_major = std::get<0>(GetParam());
     bool transpose = std::get<2>(GetParam());
     bool use_cublaslt = std::get<3>(GetParam());
+#ifndef  GOOGLE_CUDA
+    use_cublaslt = false;
+#endif      
     execution_options_.mutable_debug_options()->set_xla_gpu_enable_cublaslt(
         use_cublaslt);
     Array2D<T> lhs({{1.0f, 2.0f}, {3.0f, 4.0f}});
@@ -327,6 +333,10 @@ class MatOpsDotAddTest
     bool row_major = std::get<0>(GetParam());
     bool transpose = std::get<2>(GetParam());
     bool use_cublaslt = std::get<3>(GetParam());
+#if GOOGLE_CUDA
+#else
+    use_cublaslt = false;
+#endif          
     execution_options_.mutable_debug_options()->set_xla_gpu_enable_cublaslt(
         use_cublaslt);
     Array2D<T> lhs({{-1.0f, 2.0f}, {3.0f, 4.0f}});
@@ -368,6 +378,9 @@ class MatOpsDotAddTest
     bool row_major = std::get<0>(GetParam());
     bool transpose = std::get<2>(GetParam());
     bool use_cublaslt = std::get<3>(GetParam());
+#ifndef GOOGLE_CUDA
+    use_cublaslt = false;
+#endif      
     execution_options_.mutable_debug_options()->set_xla_gpu_enable_cublaslt(
         use_cublaslt);
     Array2D<T> lhs({{-1.0f, 2.0f}, {3.0f, 4.0f}});


### PR DESCRIPTION
This new merged PR (https://github.com/tensorflow/tensorflow/pull/56761) only for cuda gpu so far. We hope it be more generical.

@cheshire
