### PR TITLE
Support python 3.11 changes.

### DIFF
--- a/tensorflow/python/keras/utils/tf_inspect.py
+++ b/tensorflow/python/keras/utils/tf_inspect.py
@@ -20,7 +20,10 @@ import inspect as _inspect
 
 from tensorflow.python.util import tf_decorator
 
-ArgSpec = _inspect.ArgSpec
+try:
+  ArgSpec = _inspect.ArgSpec
+except:
+  pass
 
 
 if hasattr(_inspect, 'FullArgSpec'):
@@ -64,11 +67,21 @@ if hasattr(_inspect, 'getfullargspec'):
       from FullArgSpec.
     """
     fullargspecs = getfullargspec(target)
-    argspecs = ArgSpec(
-        args=fullargspecs.args,
-        varargs=fullargspecs.varargs,
-        keywords=fullargspecs.varkw,
-        defaults=fullargspecs.defaults)
+    if hasattr(_inspect, 'ArgSpec'):
+      argspecs = ArgSpec(
+          args=fullargspecs.args,
+          varargs=fullargspecs.varargs,
+          keywords=fullargspecs.varkw,
+          defaults=fullargspecs.defaults)
+    else:
+      argspecs = FullArgSpec(
+          args=fullargspecs.args,
+          varargs=fullargspecs.varargs,
+          varkw=fullargspecs.varkw,
+          defaults=fullargspecs.defaults,
+          kwonlyargs=[],
+          kwonlydefaults=None,
+          annotations={})
     return argspecs
 else:
   _getargspec = _inspect.getargspec

--- a/tensorflow/python/util/dispatch.py
+++ b/tensorflow/python/util/dispatch.py
@@ -441,7 +441,12 @@ def _add_name_scope_wrapper(func, api_signature):
 
   func_signature = tf_inspect.signature(func)
   func_argspec = tf_inspect.getargspec(func)
-  if "name" in func_signature.parameters or func_argspec.keywords is not None:
+  kw = None
+  if hasattr(func_argspec, 'keywords'):
+    kw = func_argspec.keywords
+  elif hasattr(func_argspec, 'varkw'):
+    kw = func_argspec.varkw
+  if "name" in func_signature.parameters or kw is not None:
     return func  # No wrapping needed (already has name parameter).
 
   name_index = list(api_signature.parameters).index("name")
@@ -551,7 +556,12 @@ def add_type_based_api_dispatcher(target):
 
   _, unwrapped = tf_decorator.unwrap(target)
   target_argspec = tf_inspect.getargspec(unwrapped)
-  if target_argspec.varargs or target_argspec.keywords:
+  kw = None
+  if hasattr(target_argspec, 'keywords'):
+    kw = target_argspec.keywords
+  elif hasattr(target_argspec, 'varkw'):
+    kw = target_argspec.varkw
+  if target_argspec.varargs or kw:
     # @TODO(b/194903203) Add v2 dispatch support for APIs that take varargs
     # and keywords.  Examples of APIs that take varargs and kwargs: meshgrid,
     # einsum, map_values, map_flat_values.
@@ -581,7 +591,12 @@ def _check_signature(api_signature, func):
   """
   # Special case: if func_signature is (*args, **kwargs), then assume it's ok.
   func_argspec = tf_inspect.getargspec(func)
-  if (func_argspec.varargs is not None and func_argspec.keywords is not None
+  kw = None
+  if hasattr(func_argspec, 'keywords'):
+    kw = func_argspec.keywords
+  elif hasattr(func_argspec, 'varkw'):
+    kw = func_argspec.varkw
+  if (func_argspec.varargs is not None and kw is not None
       and not func_argspec.args):
     return
 

--- a/tensorflow/python/util/stack_trace.h
+++ b/tensorflow/python/util/stack_trace.h
@@ -61,10 +61,19 @@ class StackTrace final {
     if (limit == -1) limit = std::numeric_limits<int>::max();
 
     StackTrace result;
+#if PY_VERSION_HEX >= 0x030B0000
+    PyFrameObject* frame = PyThreadState_GetFrame(PyThreadState_GET());
+#else
     const PyFrameObject* frame = PyThreadState_GET()->frame;
+#endif
     int i = 0;
+#if PY_VERSION_HEX >= 0x030B0000
+    for (; i < limit && frame != nullptr; PyFrame_GetBack(frame), ++i) {
+      PyCodeObject* code_obj = PyFrame_GetCode(frame);
+#else
     for (; i < limit && frame != nullptr; frame = frame->f_back, ++i) {
       PyCodeObject* code_obj = frame->f_code;
+#endif
       DCHECK(code_obj != nullptr);
 
       Py_INCREF(code_obj);

--- a/tensorflow/python/util/tf_inspect.py
+++ b/tensorflow/python/util/tf_inspect.py
@@ -35,7 +35,10 @@ def signature(obj, *, follow_wrapped=True):
 Parameter = _inspect.Parameter
 Signature = _inspect.Signature
 
-ArgSpec = _inspect.ArgSpec
+try:
+  ArgSpec = _inspect.ArgSpec
+except:
+  pass
 
 
 if hasattr(_inspect, 'FullArgSpec'):
@@ -79,11 +82,21 @@ if hasattr(_inspect, 'getfullargspec'):
       from FullArgSpec.
     """
     fullargspecs = getfullargspec(target)
-    argspecs = ArgSpec(
-        args=fullargspecs.args,
-        varargs=fullargspecs.varargs,
-        keywords=fullargspecs.varkw,
-        defaults=fullargspecs.defaults)
+    if hasattr(_inspect, 'ArgSpec'):
+      argspecs = ArgSpec(
+          args=fullargspecs.args,
+          varargs=fullargspecs.varargs,
+          keywords=fullargspecs.varkw,
+          defaults=fullargspecs.defaults)
+    else:
+      argspecs = FullArgSpec(
+          args=fullargspecs.args,
+          varargs=fullargspecs.varargs,
+          varkw=fullargspecs.varkw,
+          defaults=fullargspecs.defaults,
+          kwonlyargs=[],
+          kwonlydefaults=None,
+          annotations={})
     return argspecs
 else:
   _getargspec = _inspect.getargspec


### PR DESCRIPTION
This PR adds support for building tensorflow with python >= 3.11

The proposed PR did not drop or touch any backward functionality.
Tensorflow builds fully with this patch, mentioning here the [#58032](https://github.com/tensorflow/tensorflow/issues/58032) issue tracker.
Guided from here: https://docs.python.org/3.11/whatsnew/3.11.html#pyframeobject-3-11-hiding

cc @mihaimaruseac 

----

```
{...}
# Execution platform: @local_execution_config_platform//:platform
Target //tensorflow/tools/pip_package:build_pip_package up-to-date:
  bazel-bin/tensorflow/tools/pip_package/build_pip_package
INFO: Elapsed time: 10.954s, Critical Path: 6.60s
INFO: 8 processes: 5 internal, 3 local.
INFO: Build completed successfully, 8 total actions

$ rpm -q python3
python3-3.11.0-1.fc38.x86_64
```
Only build tests are done, no functionality tests yet.


Thanks,
~Cristian.

---

Update:
For complete description,  this PR was using external protobuf, internal [**might need bump**](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/workspace2.bzl#L451-L461) for py3_11.
```
$ readelf -a libtensorflow_framework.so.2 | grep NEED | grep protobuf
 0x0000000000000001 (NEEDED)             Shared library: [libprotobuf.so.30]
$ rpm -q protobuf
protobuf-3.19.4-6.fc38.x86_64
```

The full build flow having some **external_libs** cand be found here:
* https://copr-dist-git.fedorainfracloud.org/cgit/rezso/ML/tensorflow.git/tree/tensorflow.spec?id=31634968da08bd1e875190801df11d0c27d50511#n224

