### PR TITLE
[Intel oneDNN] Show warning for Windows GPU build

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1221,8 +1221,16 @@ def main():
   if (environ_cp.get('TF_NEED_ROCM') == '1' and environ_cp.get('HIP_PLATFORM')):
     write_action_env_to_bazelrc('HIP_PLATFORM', environ_cp.get('HIP_PLATFORM'))
 
-  environ_cp['TF_NEED_CUDA'] = str(
-      int(get_var(environ_cp, 'TF_NEED_CUDA', 'CUDA', False)))
+  if is_windows():
+    print(
+      '\nWARNING: Cannot build with CUDA support on Windows.\n'
+      'Starting in TF 2.11, CUDA build is not supported for Windows. '
+      'For using TensorFlow GPU on Windows, you will need to build/install '
+      'TensorFlow in WSL2.\n')
+    environ_cp['TF_NEED_CUDA'] = '0'
+  else:
+    environ_cp['TF_NEED_CUDA'] = str(
+        int(get_var(environ_cp, 'TF_NEED_CUDA', 'CUDA', False)))
   if (environ_cp.get('TF_NEED_CUDA') == '1' and
       'TF_CUDA_CONFIG_REPO' not in environ_cp):
 


### PR DESCRIPTION
Starting in TF 2.11, CUDA build is not supported in Windows. See reported issue https://github.com/tensorflow/tensorflow/issues/58323 and https://github.com/tensorflow/tensorflow/blob/v2.11.0-rc1/RELEASE.md#major-features-and-improvements