### PR TITLE
Fix aarch64 build.

### DIFF
--- a/third_party/absl/com_google_absl_fix_mac_and_nvcc_build.patch
+++ b/third_party/absl/com_google_absl_fix_mac_and_nvcc_build.patch
@@ -252,3 +252,16 @@ index 7304d40d..75d8e086 100644
      visibility = ["//visibility:public"],
      deps = [
          ":civil_time",
+diff --git a/absl/base/config.h b/absl/base/config.h
+index 8533aea..07b4e80 100644
+--- a/absl/base/config.h.orig
++++ b/absl/base/config.h
+@@ -906,7 +906,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
+ // SIMD).
+ #ifdef ABSL_INTERNAL_HAVE_ARM_NEON
+ #error ABSL_INTERNAL_HAVE_ARM_NEON cannot be directly set
+-#elif defined(__ARM_NEON)
++#elif defined(__ARM_NEON) && !defined(__CUDACC__)
+ #define ABSL_INTERNAL_HAVE_ARM_NEON 1
+ #endif
+ 


### PR DESCRIPTION
This PR fixes the ```aarch64``` builds.

* It simply patches ```absl``` to avoid ```neon``` related inclusions over ```nvcc```.
* With this PR all ```{x86_64,aarch64} x {fc37,fc38}``` builds are fine: https://copr.fedorainfracloud.org/coprs/rezso/ML/build/4996828

Cc  @mihaimaruseac 

---

The error message:
```
{...}
-nvcc_options=ftz=true
-c tensorflow/core/kernels/parameterized_truncated_normal_op_gpu.cu.cc 
{...}
/usr/lib64/gcc/aarch64-redhat-linux/11.2.1/include/arm_neon.h(38): 
  error: identifier "__Int8x8_t" is undefined
/usr/lib64/gcc/aarch64-redhat-linux/11.2.1/include/arm_neon.h(39): 
  error: identifier "__Int16x4_t" is undefined

```
Tools used:
```
$ rpm -q cuda-nvcc-11-8
cuda-nvcc-11-8-11.8.89-1.x86_64
$ rpm -q cuda-gcc
cuda-gcc-11.2.1-2.fc37.x86_64
$ rpm -q gcc
gcc-12.2.1-2.fc38.x86_64
$ rpm -q python3
python3-3.11.0-1.fc38.x86_64
$ rpm -q bazel5
bazel5-5.3.2-1.fc38.x86_64
```


Thanks,
~Cristian.