### PR TITLE
Update floorDiv

### DIFF
--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
@@ -2499,7 +2499,7 @@ llvm::Optional<Value> convertFloorModOp(PatternRewriter& rewriter,
   // a2 = mul(lhs, a1);
   // a3 = floor(a2);
   // a4 = sub(a2, a3);
-  // a5 = mul(a4,rhs)
+  // a5 = mul(a4, rhs)
   // return a5;
 
   RankedTensorType output_type =

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
@@ -2516,8 +2516,7 @@ llvm::Optional<Value> convertFloorModOp(PatternRewriter& rewriter,
       rewriter, op->getLoc(), output_type, a2_mul_lhs_a1_op.getResult());
   auto a4_sub_a2_a3_op = CreateOpAndInfer<tosa::SubOp>(
       rewriter, op->getLoc(), output_type,
-      a2_mul_lhs_a1_op.getResult(), a3_floor_a2_op.getResult())
-      .getResult();
+      a2_mul_lhs_a1_op.getResult(), a3_floor_a2_op.getResult());
   
   return CreateOpAndInfer<tosa::MulOp>(rewriter, op->getLoc(), output_type,
                                        a4_sub_a2_a3_op.getResult(),


### PR DESCRIPTION
Updated the implementation of floordiv to align floordiv document https://tensorflow.google.cn/api_docs/python/tf/raw_ops/FloorMod?version=nightly. 

The existing implementation can be rewritten to a below logic to avoid precision errors.
Fixes: https://github.com/tensorflow/tensorflow/issues/57520

```
  // FloorMod lowering:
  // lhs - floor(1/rhs * lhs) * rhs
  // a1 = reciprocal(rhs);
  // a2 = mul(lhs, a1);
  // a3 = floor(a2);
  // a4 = sub(lhs, a3);
  // a5 = mul(a4,rhs)
  // return a5;
```