### PR TITLE
Enable h-loop-fusion when control flow in the graph. 

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -738,8 +738,6 @@ Status GpuCompiler::PrepareHloModuleForIrEmitting(HloModule* hlo_module) {
   pipeline.AddPass<CopyInsertion>(GetCanShareBuffer());
   // To fuse the copy.
   pipeline.AddPass<GpuHorizontalLoopFusion>("copy_");
-  // To remove temporary fused_computation created by GpuHorizontalLoopFusion
-  pipeline.AddPass<HloDCE>();
 
   pipeline.AddPass<GpuSanitizeConstantNames>();
   return pipeline.Run(hlo_module).status();

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion_test.cc
@@ -650,6 +650,49 @@ ENTRY e {
   EXPECT_TRUE(RunAndCompare(hlo_text, std::nullopt));
 }
 
+  TEST_F(HorizontalLoopFusionTest, CopyInsertionFusionControlFlow) {
+  if (GetTestPlatform()->Name() != "CUDA") {
+    GTEST_SKIP_("Only work on CUDA platform");
+  }
+
+  const char* hlo_text = R"(
+HloModule cluster
+
+ENTRY main {
+  cst = f32[1]{0} constant({0})
+  cp1 = f32[1]{0} copy(cst)
+  cp2 = f32[1]{0} copy(cst)
+  cp3 = f32[1]{0} copy(cst)
+  cp4 = f32[1]{0} copy(cst), control-predecessors={cp1}
+  ROOT tuple_out = (f32[1]{0}, f32[1]{0}, f32[1]{0}, f32[1]{0}) tuple(cp1, cp2, cp3, cp4)
+}
+)";
+
+  auto module = ParseAndReturnUnverifiedModule(hlo_text).value();
+  EXPECT_TRUE(GpuHorizontalLoopFusion().Run(module.get()).value());
+
+  VLOG(2) << module->ToString();
+
+  // Verify that the total number of fusion instructions is 1.
+  size_t total_fusion_instrs = 0;
+  for (const HloInstruction* instr :
+	 module->entry_computation()->instructions()) {
+    if (instr->opcode() == HloOpcode::kFusion) {
+      ++total_fusion_instrs;
+    }
+  }
+  EXPECT_EQ(total_fusion_instrs, 1);
+
+  const HloInstruction* entry_root =
+    module->entry_computation()->root_instruction();
+  // Check that we fuse when supported.
+  EXPECT_THAT(entry_root,
+	      op::Tuple(op::Copy(),
+			op::GetTupleElement(op::Fusion()),
+			op::GetTupleElement(op::Fusion()),
+			op::Copy()));
+}
+
 }  // namespace
 }  // namespace gpu
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion_test.cc
@@ -650,11 +650,7 @@ ENTRY e {
   EXPECT_TRUE(RunAndCompare(hlo_text, std::nullopt));
 }
 
-  TEST_F(HorizontalLoopFusionTest, CopyInsertionFusionControlFlow) {
-  if (GetTestPlatform()->Name() != "CUDA") {
-    GTEST_SKIP_("Only work on CUDA platform");
-  }
-
+TEST_F(HorizontalLoopFusionTest, CopyInsertionFusionControlFlow) {
   const char* hlo_text = R"(
 HloModule cluster
 


### PR DESCRIPTION
This is a follow up from https://github.com/tensorflow/tensorflow/pull/57087
When using multi-GPU, control flow end up being added in the graph. So the optimization wasn't used in that case.
This PR make that optimization work when there is control flow in the graph.
But it ignore nodes that hare any control flow marker (being the predecessor or the successor).

@cheshire @akuegel 