### PR TITLE
.

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1656,7 +1656,7 @@ def tf_java_test(
         **kwargs):
     cc_library_name = name + "_cclib"
     cc_library(
-        # TODO(b/183579145): Remove when cc_shared_library supports CcInfo or JavaInfo providers .
+        # TODO(b/183579145): Remove when cc_shared_library supports CcInfo or JavaInfo providers.
         name = cc_library_name,
         srcs = tf_binary_additional_srcs(fullversion = True) + tf_binary_dynamic_kernel_dsos() + tf_binary_dynamic_kernel_deps(kernels),
     )

--- a/tensorflow/tools/ci_build/pylintrc
+++ b/tensorflow/tools/ci_build/pylintrc
@@ -27,7 +27,7 @@ accept-no-param-doc=no
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
-# file where it should appear only once).You can also use "--disable=all" to
+# file where it should appear only once). You can also use "--disable=all" to
 # disable everything first and then reenable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have


### PR DESCRIPTION
Fix some grammar error in comments of [tensorflow/tensorflow.bzl](https://github.com/tensorflow/tensorflow/compare/master...Hip-po:tensorflow:master#diff-7e9b6c00ccad2c40e6d73561087f76a8ac70fc1e5af326849953a52ade696113) (ln 1659) and [tensorflow/tools/ci_build/pylintrc](https://github.com/tensorflow/tensorflow/compare/master...Hip-po:tensorflow:master#diff-f8f90f4d55bd318eb7e944907728798b1cff18129b68e80818302cd07892f270) (ln 30).