### PR TITLE
Doc Negative Sysfs numa node

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_gpu_executor.cc
@@ -995,7 +995,8 @@ static int TryToReadNumaNode(const std::string& pci_bus_id,
       LOG(INFO) << "successful NUMA node read from SysFS had negative value ("
                 << value
                 << "), but there must be at least one NUMA node"
-                   ", so returning NUMA node zero";
+                   ", so returning NUMA node zero."
+                   " See more at https://github.com/torvalds/linux/blob/v6.0/Documentation/ABI/testing/sysfs-bus-pci#L344-L355";
       fclose(file);
       return 0;
     }


### PR DESCRIPTION
Add a point to the Linux kernel documentation (with the override workaround) when SysFS NUMA node is negative.

Fixes: https://github.com/tensorflow/tensorflow/issues/58428
and https://github.com/tensorflow/tensorflow/issues/56456