### PR TITLE
[TFTRT] Add device info to nodes in graphdef before building TRT engine

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.cc
@@ -5800,6 +5800,14 @@ REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertIdentity,
 REGISTER_DEFAULT_TRT_OP_CONVERTER(ConvertBatchMatMul,
                                   {"BatchMatMul", "BatchMatMulV2"});
 
+static Status SetDeviceInfoInNodes(GraphDef* graph_def, const string& device)
+{
+  for (auto& node : *(graph_def->mutable_node())) {
+      *node.mutable_device() = device;
+  }
+  return OkStatus();
+}
+
 Status ConvertGraphDefToEngine(
     const GraphDef& gdef, OpKernelContext* ctx, TrtPrecisionMode precision_mode,
     int max_batch_size, size_t max_workspace_size_bytes,
@@ -5809,7 +5817,8 @@ Status ConvertGraphDefToEngine(
     TrtUniquePtrType<nvinfer1::ICudaEngine>* engine, bool use_calibration,
     const bool use_implicit_batch, bool* convert_successfully,
     TrtShapeOptimizationProfile* profiles, absl::string_view engine_name,
-    bool use_explicit_precision, tensorflow::grappler::Cluster* cluster) {
+    bool use_explicit_precision, tensorflow::grappler::Cluster* cluster,
+    const string& device) {
   engine->reset();
   if (convert_successfully) *convert_successfully = false;
 
@@ -5833,6 +5842,11 @@ Status ConvertGraphDefToEngine(
     if (apply_layout_optim) {
       tensorflow::grappler::GrapplerItem grappler_item;
       grappler_item.graph = gdef;
+
+      // Add device information to each node in the graphdef for successful execution
+      // of the layout optimizer
+      TF_RETURN_IF_ERROR(SetDeviceInfoInNodes(&grappler_item.graph, device));
+
       // TensorRT API requires the input for convolution to be in NCHW.
       tensorflow::grappler::GenericLayoutOptimizer layout_optimizer("NCHW");
       TF_RETURN_IF_ERROR(
@@ -5887,6 +5901,11 @@ Status ConvertGraphDefToEngine(
       DataType tf_dtype = node_def.attr().at(type_key).type();
       if (tf_dtype == DT_RESOURCE) {
         VLOG(2) << "Adding engine input resource " << node_name;
+        if (ctx == nullptr) {
+          return errors::InvalidArgument(
+            "Variable resource type conversion requires a valid ctx");
+        }
+
         TF_RETURN_IF_ERROR(converter->AddInputResource(
             node_name, ctx->input(slot_number).flat<ResourceHandle>()(0)));
       } else {

--- a/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/convert_nodes.h
@@ -162,7 +162,7 @@ Status ConvertGraphDefToEngine(
     const bool use_implicit_batch, bool* convert_successfully,
     TrtShapeOptimizationProfile* profiles, absl::string_view engine_name,
     bool use_explicit_precision,
-    tensorflow::grappler::Cluster* cluster = nullptr);
+    tensorflow::grappler::Cluster* cluster = nullptr, const string& device="");
 
 // Helper class for the segmenter to determine whether an output edge from the
 // TRT segment is valid.

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -1099,7 +1099,8 @@ StatusOr<TrtUniquePtrType<nvinfer1::ICudaEngine>> TRTEngineOp::BuildEngine(
       segment_graph_def_, ctx, precision_mode_, batch_size, workspace_size_,
       conversion_input_shapes, &logger, cache_resource->allocator_.get(),
       calibrator, &engine, use_calibration, use_implicit_batch_, nullptr,
-      &cache_resource->profiles_, name(), use_explicit_precision_, &cluster);
+      &cache_resource->profiles_, name(), use_explicit_precision_, &cluster,
+      ctx->device()->name());
   if (!status.ok()) {
     LOG_FIRST_FEW_WARNING_WITH_PREFIX
         << "Engine creation for " << name() << " failed. "
@@ -1388,7 +1389,8 @@ Status TRTEngineOp::AllocateCalibrationResources(
         /*convert_successfully=*/nullptr,
         /*profiles=*/&cache_res->profiles_, name(),
         /*use_explicit_precision=*/use_explicit_precision_,
-        /*cluster=*/&cluster);
+        /*cluster=*/&cluster,
+        platform_device_name);
     if (!s.ok()) {
       LOG(ERROR) << "Calibration failed: " << s;
       cres->calibrator_->setDone();  // Ignore further pushes


### PR DESCRIPTION
TFTRT invokes the layout optimizer to force the NCHW layout before building TRT engines, as TensorRT prefers the NCHW layout.

Changes to the layout optimizer in commit 612a531c9bc now require every node in the graph to store device informatio.

This patch adds device info to every node in the segment being converted to a TRT engine.

CC: @bixia1 @pjannaty @DEKHTIARJonathan @tfeher @kaixih 