### PR TITLE
r.2.11 Remove Werror=switch for release

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -317,9 +317,6 @@ build:linux --copt="-Wno-array-bounds"
 # Add unused-result as an error on Linux.
 build:linux --copt="-Wunused-result"
 build:linux --copt="-Werror=unused-result"
-# Add switch as an error on Linux.
-build:linux --copt="-Wswitch"
-build:linux --copt="-Werror=switch"
 
 # On Windows, `__cplusplus` is wrongly defined without this switch
 # See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/


### PR DESCRIPTION
Remove the promotion of the switch warning to error for the r2.11 release.  

Due to the regression found in https://github.com/tensorflow/tensorflow/issues/58419, remove the change to the bazelrc file while code fixes are investigated on main branch.
