### PR TITLE
Add missing link library for MhloDialect

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/mhlo/IR/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/mhlo/IR/CMakeLists.txt
@@ -62,7 +62,9 @@ target_link_libraries(MhloDialect
   MLIRQuantDialect
   MLIRSparseTensorDialect
   HloOpsCommon
+  StablehloAssemblyFormat
   StablehloBase
+  StablehloTypeInference
 )
 target_include_directories(MhloDialect
   PUBLIC


### PR DESCRIPTION
Code in `MhloDialect` uses `StablehloAssemblyFormat` and `StablehloTypeInference `, so they need to be linked against for shared library build to work. This was causing builds to fail for onnx-mlir when updating versions.

Example of missing:
- `hlo_ops.cc` (in `MhloDialect` target) uses `parseVariadicSameOperandsAndResultType` which is defined in `StablehloAssemblyFormat`.
- `hlo_ops.cc` (in `MhloDialect` target) calls `verifyReducerShape` which is defined in `StablehloTypeInference`.