### PR TITLE
Bug Fixed in tf.custom_gradient API Document

### DIFF
--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -62,9 +62,10 @@ def custom_gradient(f=None):
   is NaN.  For example:
 
   ```python
-  x = tf.constant(100.)
-  y = log1pexp(x)
-  dy_dx = tf.gradients(y, x) # Will be NaN when evaluated.
+  with tf.GradientTape() as tape:
+    tape.watch(x)
+    y=log1pexp(x)
+  dy_dx = tape.gradient(y, x) # Will be NaN when evaluated.
   ```
 
   The gradient expression can be analytically simplified to provide numerical


### PR DESCRIPTION
tf.custom_gradient documentation have the below code snippet from line nos.63 to 65 which is throwing Runtime Error:tf.gradients is not supported when eager execution is enabled. Use tf.GradientTape instead.
```
 x = tf.constant(100.)
 y = log1pexp(x)
 dy_dx = tf.gradients(y, x) # Will be NaN when evaluated.
```

The above code snippet needs to be replaced with the one attached below to avoid the runtime error in 2.X versions. 
```
with tf.GradientTape() as tape:
  tape.watch(x)
  y=log1pexp(x)
dy_dx = tape.gradient(y, x) # Will be NaN when evaluated.
```

Please refer to the attached [gist](https://colab.research.google.com/gist/SuryanarayanaY/e692b30c318c42e86819bc153ab2ee77/tf_gradient.ipynb#scrollTo=YQoLZkmVgUok) below for same.