### PR TITLE
[XLA:GPU] Add back the profiling information

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -4920,7 +4920,7 @@ Status IrEmitterUnnested::EmitUnnestedReduction(
   }
   TF_ASSIGN_OR_RETURN(
       std::vector<llvm_ir::IrArray> ir_arrays,
-      BuildKernelThunk(fusion, Thunk::ThunkInfo(fusion), launch_dimensions));
+      BuildKernelThunk(fusion, GetThunkInfo(fusion), launch_dimensions));
 
   FusedIrEmitter fused_emitter(elemental_emitter_);
   CHECK_LT(fused_computation->num_parameters(), ir_arrays.size());

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
@@ -690,11 +690,10 @@ class IrEmitterUnnested : public IrEmitter {
 
   StatusOr<std::vector<llvm_ir::IrArray>> BuildKernelThunk(
       mlir::Operation* op, mlir::ValueRange operands,
-      Thunk::ThunkInfo thunk_info, const LaunchDimensions& launch_dimensions);
+      const LaunchDimensions& launch_dimensions);
 
   StatusOr<std::vector<llvm_ir::IrArray>> BuildKernelThunk(
-      mlir::Operation* op, Thunk::ThunkInfo thunk_info,
-      const LaunchDimensions& launch_dimensions);
+      mlir::Operation* op, const LaunchDimensions& launch_dimensions);
 
   // Returns a thunk that, given a reduce or select-and-scatter op,
   // initializes its memory to the appropriate initial value.


### PR DESCRIPTION
This commit removed the profiling information for some thunks including fused thunks with reduction:
```
commit 9ac28f43e180e0db65bf7872fcd828680e3d2e92
Author: George Karpenkov <cheshire@google.com>
Date:   Wed Oct 26 06:05:31 2022 -0700
```

Instead of converting many call of ThunkInfo(op) to GetThunkInfo(op), I changed the API to be simpler. So less chance of breaking this in the future.

This has the side effect that initializer now have profiling information. I consider this a good thing.

@cheshire 