### PR TITLE
Broken test failing the release builds - TF 2.9.3

### DIFF
--- a/tensorflow/python/kernel_tests/nn_ops/BUILD
+++ b/tensorflow/python/kernel_tests/nn_ops/BUILD
@@ -149,6 +149,7 @@ cuda_py_test(
     shard_count = 2,
     tags = [
         "optonly",  # flaky timeouts unless optimized
+        "no_oss",  # TODO(b/258503209): Disable the test. 
     ],
     deps = [
         "//tensorflow/python:array_ops",


### PR DESCRIPTION
//bazel_pip/tensorflow/python/kernel_tests/nn_ops:conv2d_backprop_filter_grad_test_cpu - b/258503209