### PR TITLE
Broken test failing the release builds - TF 2.9.3

### DIFF
--- a/tensorflow/python/data/experimental/kernel_tests/BUILD
+++ b/tensorflow/python/data/experimental/kernel_tests/BUILD
@@ -211,6 +211,7 @@ tf_py_test(
     size = "small",
     srcs = ["group_by_reducer_test.py"],
     shard_count = 12,
+    tags = ["no_oss"], # TODO(b/258503209): Disable the test. 
     deps = [
         "//tensorflow/python:array_ops",
         "//tensorflow/python:client_testlib",


### PR DESCRIPTION
//bazel_pip/tensorflow/python/data/experimental/kernel_tests:group_by_reducer_test - b/258503209