### PR TITLE
[oneDNN] UT failure fix: //tensorflow/python/kernel_tests/nn_ops:pooling_ops_3d_test_cpu

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
@@ -193,6 +193,11 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       const Tensor& grad_tensor =
           MklGetInput(context, kInputTensorIndexInputGradient);
 
+      // For empty tensor, avg_pool_3d_grad in oneDNN doesn't handle this case
+      if (orig_input_tensor.NumElements() == 0 ||
+          grad_tensor.NumElements() == 0)
+        return;
+      
       MklDnnShape orig_input_mkl_shape, grad_mkl_shape;
       GetMklShape(context, kInputTensorIndexInputShape, &orig_input_mkl_shape,
                   this->native_format_);

--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -20,5 +20,4 @@ ARM_SKIP_TESTS="-//tensorflow/lite/... \
 -//tensorflow/python/data/kernel_tests:iterator_test \
 -//tensorflow/python/kernel_tests/nn_ops:atrous_conv2d_test \
 -//tensorflow/python/kernel_tests/nn_ops:conv_ops_test \
--//tensorflow/python/kernel_tests/nn_ops:pooling_ops_3d_test \
 -//tensorflow/python/training:server_lib_test"


### PR DESCRIPTION
With oneDNN enabled //tensorflow/python/kernel_tests/nn_ops:pooling_ops_3d_test_cpu got triggered, a sanity check of empty tensor on avgpool3d_grad is needed. This PR will resolve //tensorflow/python/kernel_tests/nn_ops:pooling_ops_3d_test_cpu test failure 