### PR TITLE
Replace CHECK with returning an InternalError on failing to create py…

### DIFF
--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -119,17 +119,14 @@ Status MakeArgTuple(const PyCall* call, TFE_Context* ctx, PyObject** tuple) {
     PyList_SetItem(lst, i, arg);
   }
   *tuple = Py_BuildValue("(ssN)", call->token.c_str(), device_name, lst);
-<<<<<<< HEAD
   CHECK(*tuple);
   return Status::OK();
-=======
   if (*tuple == nullptr) {
     return errors::Internal(
         "Failed to create python tuple. Please make sure `token` is a "
         "well-formed UTF-8 string.");
   }
   return OkStatus();
->>>>>>> 9f03a9d3baf (Replace CHECK with returning an InternalError on failing to create python tuple)
 }
 
 bool IsSingleNone(PyObject* obj) {

--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -119,8 +119,6 @@ Status MakeArgTuple(const PyCall* call, TFE_Context* ctx, PyObject** tuple) {
     PyList_SetItem(lst, i, arg);
   }
   *tuple = Py_BuildValue("(ssN)", call->token.c_str(), device_name, lst);
-  CHECK(*tuple);
-  return Status::OK();
   if (*tuple == nullptr) {
     return errors::Internal(
         "Failed to create python tuple. Please make sure `token` is a "

--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -83,8 +83,8 @@ bool IsCPUDevice(const Device* d) {
   return d == nullptr || d->tensorflow_gpu_device_info() == nullptr;
 }
 
-// Givens the 'call', prepares the token and inputs as a python tuple
-// that is appropriate for calling the trampoline.
+// Given the 'call', prepares the token and inputs as a python tuple that is
+// appropriate for calling the trampoline.
 Status MakeArgTuple(const PyCall* call, TFE_Context* ctx, PyObject** tuple) {
   int64_t n = call->ins.size();
   PyObject* lst = PyList_New(n);
@@ -119,8 +119,17 @@ Status MakeArgTuple(const PyCall* call, TFE_Context* ctx, PyObject** tuple) {
     PyList_SetItem(lst, i, arg);
   }
   *tuple = Py_BuildValue("(ssN)", call->token.c_str(), device_name, lst);
+<<<<<<< HEAD
   CHECK(*tuple);
   return Status::OK();
+=======
+  if (*tuple == nullptr) {
+    return errors::Internal(
+        "Failed to create python tuple. Please make sure `token` is a "
+        "well-formed UTF-8 string.");
+  }
+  return OkStatus();
+>>>>>>> 9f03a9d3baf (Replace CHECK with returning an InternalError on failing to create python tuple)
 }
 
 bool IsSingleNone(PyObject* obj) {

--- a/tensorflow/python/ops/script_ops_test.py
+++ b/tensorflow/python/ops/script_ops_test.py
@@ -15,8 +15,11 @@
 """Tests for script operations."""
 
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
 from tensorflow.python.framework import constant_op
+from tensorflow.python.ops import gen_script_ops
+from tensorflow.python.ops import resource_variable_ops
 from tensorflow.python.ops import script_ops
 from tensorflow.python.platform import test
 
@@ -32,6 +35,82 @@ class NumpyFunctionTest(test.TestCase):
     actual_result = script_ops.numpy_function(plus, [1, 2], dtypes.int32)
     expect_result = constant_op.constant(3, dtypes.int32)
     self.assertAllEqual(actual_result, expect_result)
+
+  def test_stateless(self):
+    call_count = 0
+
+    def plus(a, b):
+      nonlocal call_count
+      call_count += 1
+      return a + b
+
+    @def_function.function
+    def numpy_func_stateless(a, b):
+      return numpy_function(plus, [a, b], dtypes.int32, stateful=False)
+
+    @def_function.function
+    def func_stateless(a, b):
+      sum1 = numpy_func_stateless(a, b)
+      sum2 = numpy_func_stateless(a, b)
+      return sum1 + sum2
+
+    self.evaluate(func_stateless(
+        constant_op.constant(1),
+        constant_op.constant(2),
+    ))
+
+    self.assertIn(call_count, (1, 2))  # as stateless, func may be deduplicated
+
+  def test_stateful(self):
+    call_count = 0
+
+    def plus(a, b):
+      nonlocal call_count
+      call_count += 1
+      return a + b
+
+    @def_function.function
+    def numpy_func_stateful(a, b):
+      return numpy_function(plus, [a, b], dtypes.int32, stateful=True)
+
+    @def_function.function
+    def func_stateful(a, b):
+      sum1 = numpy_func_stateful(a, b)
+      sum2 = numpy_func_stateful(a, b)
+      return sum1 + sum2
+
+    self.evaluate(func_stateful(
+        constant_op.constant(1),
+        constant_op.constant(2),
+    ))
+
+    self.assertEqual(call_count,
+                     2)  # as stateful, func is guaranteed to execute twice
+
+
+class PyFunctionTest(test.TestCase):
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_variable_arguments(self):
+
+    def plus(a, b):
+      return a + b
+
+    v1 = resource_variable_ops.ResourceVariable(1)
+    self.evaluate(v1.initializer)
+
+    actual_result = script_ops.eager_py_func(plus, [v1, 2], dtypes.int32)
+    expect_result = constant_op.constant(3, dtypes.int32)
+    self.assertAllEqual(actual_result, expect_result)
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_fail_on_non_utf8_token(self):
+    value = constant_op.constant(value=[1, 2])
+    token = b"\xb0"
+    data_type = [dtypes.int32]
+    with self.assertRaises((errors.InternalError, UnicodeDecodeError)):
+      self.evaluate(
+          gen_script_ops.py_func(input=[value], token=token, Tout=data_type))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…thon tuple

Returns InternalError if a non UTF-8 string is passed in as token, instead of crashing.

PiperOrigin-RevId: 478123498