### PR TITLE
[TFLite] Fix of issue 58050. Give user the option to silence the logging of TfLite completely

### DIFF
--- a/tensorflow/lite/logger.h
+++ b/tensorflow/lite/logger.h
@@ -28,6 +28,8 @@ enum LogSeverity {
   TFLITE_LOG_WARNING = 2,
   /// Log error events that are likely to cause problems.
   TFLITE_LOG_ERROR = 3,
+  /// Silence logging
+  TFLITE_LOG_SILENT = 4,
 };
 
 /// TFLite logger specific configurations.

--- a/tensorflow/lite/minimal_logging.cc
+++ b/tensorflow/lite/minimal_logging.cc
@@ -37,6 +37,8 @@ const char* MinimalLogger::GetSeverityName(LogSeverity severity) {
       return "WARNING";
     case TFLITE_LOG_ERROR:
       return "ERROR";
+    case TFLITE_LOG_SILENT:
+      return "SILENT";
   }
   return "<Unknown severity>";
 }

--- a/tensorflow/lite/minimal_logging_android.cc
+++ b/tensorflow/lite/minimal_logging_android.cc
@@ -32,6 +32,8 @@ int GetPlatformSeverity(LogSeverity severity) {
       return ANDROID_LOG_WARN;
     case TFLITE_LOG_ERROR:
       return ANDROID_LOG_ERROR;
+    case TFLITE_LOG_SILENT:
+      return ANDROID_LOG_SILENT;
     default:
       return ANDROID_LOG_DEBUG;
   }

--- a/tensorflow/lite/minimal_logging_android.cc
+++ b/tensorflow/lite/minimal_logging_android.cc
@@ -45,19 +45,21 @@ LogSeverity MinimalLogger::minimum_log_severity_ = TFLITE_LOG_VERBOSE;
 
 void MinimalLogger::LogFormatted(LogSeverity severity, const char* format,
                                  va_list args) {
-  // First log to Android's explicit log(cat) API.
-  va_list args_copy;
-  va_copy(args_copy, args);
-  __android_log_vprint(GetPlatformSeverity(severity), "tflite", format,
-                       args_copy);
-  va_end(args_copy);
+  if (severity >= MinimalLogger::minimum_log_severity_) {
+    // First log to Android's explicit log(cat) API.
+    va_list args_copy;
+    va_copy(args_copy, args);
+    __android_log_vprint(GetPlatformSeverity(severity), "tflite", format,
+                         args_copy);
+    va_end(args_copy);
 
-  // Also print to stderr for standard console applications.
-  fprintf(stderr, "%s: ", GetSeverityName(severity));
-  va_copy(args_copy, args);
-  vfprintf(stderr, format, args_copy);
-  va_end(args_copy);
-  fputc('\n', stderr);
+    // Also print to stderr for standard console applications.
+    fprintf(stderr, "%s: ", GetSeverityName(severity));
+    va_copy(args_copy, args);
+    vfprintf(stderr, format, args_copy);
+    va_end(args_copy);
+    fputc('\n', stderr);
+  }
 }
 
 }  // namespace logging_internal

--- a/tensorflow/lite/minimal_logging_default.cc
+++ b/tensorflow/lite/minimal_logging_default.cc
@@ -32,12 +32,14 @@ LogSeverity MinimalLogger::minimum_log_severity_ = TFLITE_LOG_INFO;
 
 void MinimalLogger::LogFormatted(LogSeverity severity, const char* format,
                                  va_list args) {
-  fprintf(stderr, "%s: ", GetSeverityName(severity));
+  if (severity >= MinimalLogger::minimum_log_severity_) {
+    fprintf(stderr, "%s: ", GetSeverityName(severity));
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
-  vfprintf(stderr, format, args);
+    vfprintf(stderr, format, args);
 #pragma clang diagnostic pop
-  fputc('\n', stderr);
+    fputc('\n', stderr);
+  }
 }
 
 }  // namespace logging_internal

--- a/tensorflow/lite/minimal_logging_ios.cc
+++ b/tensorflow/lite/minimal_logging_ios.cc
@@ -33,6 +33,8 @@ int GetPlatformSeverity(LogSeverity severity) {
       return LOG_WARNING;
     case TFLITE_LOG_ERROR:
       return LOG_ERR;
+    case TFLITE_LOG_SILENT:
+      return LOG_SILENT;
     default:
       return LOG_DEBUG;
   }

--- a/tensorflow/lite/minimal_logging_ios.cc
+++ b/tensorflow/lite/minimal_logging_ios.cc
@@ -52,19 +52,21 @@ LogSeverity MinimalLogger::minimum_log_severity_ = TFLITE_LOG_INFO;
 
 void MinimalLogger::LogFormatted(LogSeverity severity, const char* format,
                                  va_list args) {
-  // First log to iOS system logging API.
-  va_list args_copy;
-  va_copy(args_copy, args);
-  // TODO(b/123704468): Use os_log when available.
-  vsyslog(GetPlatformSeverity(severity), format, args_copy);
-  va_end(args_copy);
+  if (severity >= MinimalLogger::minimum_log_severity_) {
+    // First log to iOS system logging API.
+    va_list args_copy;
+    va_copy(args_copy, args);
+    // TODO(b/123704468): Use os_log when available.
+    vsyslog(GetPlatformSeverity(severity), format, args_copy);
+    va_end(args_copy);
 
-  // Also print to stderr for standard console applications.
-  fprintf(stderr, "%s: ", GetSeverityName(severity));
-  va_copy(args_copy, args);
-  vfprintf(stderr, format, args_copy);
-  va_end(args_copy);
-  fputc('\n', stderr);
+    // Also print to stderr for standard console applications.
+    fprintf(stderr, "%s: ", GetSeverityName(severity));
+    va_copy(args_copy, args);
+    vfprintf(stderr, format, args_copy);
+    va_end(args_copy);
+    fputc('\n', stderr);
+  }
 }
 
 }  // namespace logging_internal


### PR DESCRIPTION
`tflite::LoggerOptions::SetMinimumLogSeverity(tflite::TFLITE_LOG_ERROR)` will not silence error event.
I added enum case `tflite::TFLITE_LOG_SILENT` for `tflite::LoggerOptions::SetMinimumLogSeverity()` to give the user the option to silence TfLite's logging completely.
Why? Our software (using TfLite) is part of a bigger customer system. The customer controls what is printed on the terminal, our software is therefore not allowed to print to the terminal.
This fixes https://github.com/tensorflow/tensorflow/issues/58050
