### PR TITLE
Support writing non conversion report to more filesystems

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/segment/segment.cc
+++ b/tensorflow/compiler/tf2tensorrt/segment/segment.cc
@@ -694,15 +694,17 @@ Status ExportNonConversionReportToCSV(
   tensorflow::profiler::TraceMe activity(
       "ExportNonConversionReportToCSV",
       tensorflow::profiler::TraceMeLevel::kInfo);
-  std::fstream csv_file(filename, std::fstream::out | std::fstream::trunc);
+  std::unique_ptr<WritableFile> csv_file;
+  auto open_status = Env::Default()->NewWritableFile(filename, &csv_file);
 
-  if (!csv_file || !csv_file.good()) {
+  if (!open_status.ok()) {
     return errors::Internal("Failed to open output file: `", filename, "`");
   }
 
   LOG(WARNING) << "TF-TRT Non-Conversion Report saved at: `" << filename << "`";
 
-  csv_file << "OP Name" << sep << "Reason" << sep << "Count" << std::endl;
+  std::ostringstream sstream;
+  sstream << "OP Name" << sep << "Reason" << sep << "Count" << std::endl;
 
   for (auto& op_details : nonconverted_ops_map) {
     auto op_name = op_details.first;
@@ -711,13 +713,15 @@ Status ExportNonConversionReportToCSV(
     for (auto& reject_data : op_data) {
       auto reason = reject_data.first;
       auto count = reject_data.second;
-      csv_file << op_name << sep << reason << sep << count << std::endl;
+      sstream << op_name << sep << reason << sep << count << std::endl;
     }
   }
 
-  csv_file.close();
+  csv_file->Append(sstream.str());
 
-  if (csv_file.bad() || csv_file.fail()) {
+  auto close_status = csv_file->Close();
+
+  if (!close_status.ok()) {
     return errors::Internal("Error closing the file `", filename,
                             "`. The file might be corrupted.");
   }


### PR DESCRIPTION
This PR allows tf trt non conversion report to save in all filesystems supported by tensorflow. This is especially useful when user has a use case to convert a remotely saved model.

Regarding unit test: I didn't find corresponding unit test for this function in `segment_test.cc`. For this kind of functionality maybe an integration test is more suitable? Please let me know and I could work on that.