### PR TITLE
[NVIDIA TF] Enable BF16 L2Loss

### DIFF
--- a/tensorflow/core/kernels/l2loss_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/l2loss_op_gpu.cu.cc
@@ -68,6 +68,7 @@ class L2LossOp<GPUDevice, T> : public OpKernel {
 REGISTER_GPU_KERNEL(float);
 REGISTER_GPU_KERNEL(double);
 REGISTER_GPU_KERNEL(Eigen::half);
+REGISTER_GPU_KERNEL(Eigen::bfloat16);
 #undef REGISTER_GPU_KERNEL
 
 }  // namespace tensorflow

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -231,7 +231,9 @@ class LogSoftmaxTest(test_lib.TestCase, parameterized.TestCase):
 class L2LossTest(test_lib.TestCase):
 
   def testL2Loss(self):
-    for dtype in [dtypes.float32, dtypes.float64]:
+    for dtype in [dtypes.float32, dtypes.float64] + \
+                 [dtypes.bfloat16] if test_util.is_gpu_available(
+                                          cuda_only=True) else []:
       x = constant_op.constant([1.0, 0.0, 3.0, 2.0],
                                shape=[2, 2],
                                name="x",


### PR DESCRIPTION
GPU support for bfloat16 L2Loss op.