### PR TITLE
[FIX] Fix integer overflow in XLA nccl thunks (cont.)

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_reduce_thunk.cc
@@ -394,7 +394,7 @@ Status RunReduceScatter(ReductionKind reduction_kind,
                         ToNcclDataTypeAndCountMultiplier(
                             buffer.element_type, Thunk::kNcclReduceScatter));
     ncclDataType_t dtype = dtype_and_multiplier.first;
-    int element_count = buffer.element_count * dtype_and_multiplier.second;
+    int64_t element_count = buffer.element_count * dtype_and_multiplier.second;
 
     // buffer.element_count is the source buffers element count. For
     // ncclReduceScatter, we need the destination buffers element count.

--- a/tensorflow/compiler/xla/service/gpu/nccl_all_to_all_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/nccl_all_to_all_thunk.cc
@@ -136,7 +136,7 @@ Status RunAllToAll(bool has_split_dimension,
                           ToNcclDataTypeAndCountMultiplier(
                               buffer.element_type, Thunk::kNcclAllToAll));
       ncclDataType_t dtype = dtype_and_multiplier.first;
-      int element_count = buffer.element_count * dtype_and_multiplier.second;
+      int64_t element_count = buffer.element_count * dtype_and_multiplier.second;
 
       XLA_CUDA_RETURN_IF_ERROR(ncclSend(send_buffer, element_count, dtype,
                                         /*rank=*/i, comm, gpu_stream));


### PR DESCRIPTION
Change `int` to `int64_t` to prevent integer overflow in XLA NCCL thunks.

This PR is the same as #57616. I am sorry that I didn't fix all of them in the first PR. Now I checked all types of `element_count` and confirmed all of them are fixed.