### PR TITLE
Change per-process mem to use total memory as base

### DIFF
--- a/tensorflow/compiler/xla/pjrt/gpu/gpu_helpers.cc
+++ b/tensorflow/compiler/xla/pjrt/gpu/gpu_helpers.cc
@@ -100,7 +100,7 @@ StatusOr<std::unique_ptr<tsl::BFCAllocator>> CreateBFCAllocator(
   // setting memory_fraction > 1.
   size_t allocator_memory = enable_unified_memory
                                 ? total_memory * fmax(1.0, memory_fraction)
-                                : free_memory * memory_fraction;
+                                : total_memory * memory_fraction;
   if (preallocate) {
     LOG(INFO) << "XLA backend allocating " << allocator_memory
               << " bytes on device " << device_ordinal << " for BFCAllocator.";

--- a/tensorflow/compiler/xla/pjrt/gpu/se_gpu_pjrt_client.cc
+++ b/tensorflow/compiler/xla/pjrt/gpu/se_gpu_pjrt_client.cc
@@ -81,7 +81,7 @@ StatusOr<std::unique_ptr<se::MultiDeviceAdapter>> CreateCudaAsyncAllocator(
     // unified memory.
     // When unified memory is enabled, allow GPU memory oversubscription by
     // setting memory_fraction > 1.
-    size_t allocator_memory = free_memory * memory_fraction;
+    size_t allocator_memory = total_memory * memory_fraction;
     if (preallocate) {
       LOG(INFO) << "XLA backend allocating " << allocator_memory
                 << " bytes on device " << device_ordinal

--- a/tensorflow/core/protobuf/config.proto
+++ b/tensorflow/core/protobuf/config.proto
@@ -18,9 +18,9 @@ option java_package = "org.tensorflow.framework";
 option go_package = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto";
 
 message GPUOptions {
-  // Fraction of the available GPU memory to allocate for each process.
+  // Fraction of the total GPU memory to allocate for each process.
   // 1 means to allocate all of the GPU memory, 0.5 means the process
-  // allocates up to ~50% of the available GPU memory.
+  // allocates up to ~50% of the total GPU memory.
   //
   // GPU memory is pre-allocated unless the allow_growth option is enabled.
   //


### PR DESCRIPTION
This is to address [this issue](https://github.com/google/jax/issues/4310).
Instead of using free_memory to calculate the amount of memory to assign to the process, we need to use total_memory to be consistent with tf core.
Doc is also updated to reflect it.
This needs to be included in the release doc too.