### PR TITLE
Support the quantization of fused custom ops

### DIFF
--- a/tensorflow/compiler/mlir/lite/transforms/post_quantize.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/post_quantize.cc
@@ -349,14 +349,14 @@ struct PruneUnusedOpsWithSideEffect : public OpRewritePattern<OpTy> {
       }
     }
     // Remove if the custom op is in the provided map and is NoSideEffect.
-    auto custom_op = llvm::isa<CustomOp>(op);
-    if (custom_op) {
-      auto q = llvm::cast<CustomOp>(op);
-      std::string op_name = q.getCustomCode().str();
-      if ((custom_op_map.find(op_name) == custom_op_map.end()) ||
-          !custom_op_map.find(op_name)->second.no_side_effect)
-        return failure();
-    }
+    // auto custom_op = llvm::isa<CustomOp>(op);
+    // if (custom_op) {
+    //   auto q = llvm::cast<CustomOp>(op);
+    //   std::string op_name = q.getCustomCode().str();
+    //   if ((custom_op_map.find(op_name) == custom_op_map.end()) ||
+    //       !custom_op_map.find(op_name)->second.no_side_effect)
+    //     return failure();
+    // }
     rewriter.eraseOp(op);
     return success();
   }


### PR DESCRIPTION
Propagates the _tfl_quant_trait as attribute into the newly created custom op instead of as custom_option. It also forces the pruning of unused custom ops in the PostQuantizePass by assuming all custom ops have no side effect. This is a temporary solution due to the difficulty to set the enable-no-side-effect option through the Python API.
