### PR TITLE
[XLA:GPU] Skip a test on Maxwell GPUs

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/reduction_vectorization_test.cc
@@ -43,9 +43,21 @@ class ReductionVectorizationNoOptTest : public GpuCodegenTest {
     debug_options.set_xla_disable_all_hlo_passes(true);
     return debug_options;
   }
+
+ public:
+  se::CudaComputeCapability GetCudaComputeCapability() {
+    return backend()
+        .default_stream_executor()
+        ->GetDeviceDescription()
+        .cuda_compute_capability();
+  }
 };
 
 TEST_F(ReductionVectorizationNoOptTest, MultiOutputStore) {
+  if (!GetCudaComputeCapability().IsAtLeast(se::CudaComputeCapability::PASCAL_)) {
+    GTEST_SKIP()
+      << "Maxwell GPUs are less vectorized";
+  }
   const char* hlo_text = R"(
 HloModule MultiOutputStore
 


### PR DESCRIPTION
@cheshire 
I have no idea why it now fail on Maxwell. I think it was passing at some point.
I won't investigate more. We should at least have the test not fail.

Here is the full error on M60 GPUs:
```
[ RUN      ] ReductionVectorizationNoOptTest.MultiOutputStore
2022-11-22 22:11:50.366285: I tensorflow/compiler/xla/service/platform_util.cc:72] platform Host present but no XLA compiler available: could not find registered compiler for platform Host -- was support for that platform linked in?
2022-11-22 22:11:50.705024: E tensorflow/compiler/xla/tests/filecheck.cc:69] Tried to execute FileCheck at /root/.cache/bazel/_bazel_root/a8fc6d0749b4f3c43761726a36e8ec4c/execroot/org_tensorflow/bazel-out/k8-opt/bin/external/llvm-project/llvm/FileCheck
2022-11-22 22:11:50.705137: E tensorflow/compiler/xla/tests/filecheck.cc:75] FileCheck stderr:
/root/.cache/bazel/_bazel_root/a8fc6d0749b4f3c43761726a36e8ec4c/execroot/org_tensorflow/_tmp/643bbe9f24b329a1a66b648db94da196/tempfile-133765d5a6b8-9d969c41-31734-5ee1675728a04:2:8: error: CHECK: expected string not found in input
CHECK: ld.global.nc.v2.f32
       ^
<stdin>:1:1: note: scanning from here
//
^
<stdin>:46:2: note: possible intended match here
 ld.global.nc.f32 %f3, [%rd13];
 ^

Input file: <stdin>
Check file: /root/.cache/bazel/_bazel_root/a8fc6d0749b4f3c43761726a36e8ec4c/execroot/org_tensorflow/_tmp/643bbe9f24b329a1a66b648db94da196/tempfile-133765d5a6b8-9d969c41-31734-5ee1675728a04

-dump-input=help explains the following input dump.

Input was:
<<<<<<
           1: // 
check:2'0     X~~ error: no match found
           2: // Generated by LLVM NVPTX Back-End 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           3: // 
check:2'0     ~~~
           4:  
check:2'0     ~
           5: .version 6.0 
check:2'0     ~~~~~~~~~~~~~
           6: .target sm_52 
check:2'0     ~~~~~~~~~~~~~~
           7: .address_size 64 
check:2'0     ~~~~~~~~~~~~~~~~~
           8:  
check:2'0     ~
           9:  // .globl fusion 
check:2'0     ~~~~~~~~~~~~~~~~~~
          10: .shared .align 4 .b8 shared_cache[8]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          11:  
check:2'0     ~
          12: .visible .entry fusion( 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~
          13:  .param .u64 fusion_param_0, 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          14:  .param .u64 fusion_param_1, 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          15:  .param .u64 fusion_param_2, 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          16:  .param .u64 fusion_param_3, 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          17:  .param .u64 fusion_param_4 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          18: ) 
check:2'0     ~~
          19: .reqntid 64, 1, 1 
check:2'0     ~~~~~~~~~~~~~~~~~~
          20: { 
check:2'0     ~~
          21:  .local .align 4 .b8 __local_depot0[4]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          22:  .reg .b64 %SP; 
check:2'0     ~~~~~~~~~~~~~~~~
          23:  .reg .b64 %SPL; 
check:2'0     ~~~~~~~~~~~~~~~~~
          24:  .reg .pred %p<5>; 
check:2'0     ~~~~~~~~~~~~~~~~~~~
          25:  .reg .b16 %rs<6>; 
check:2'0     ~~~~~~~~~~~~~~~~~~~
          26:  .reg .b32 %r<10>; 
check:2'0     ~~~~~~~~~~~~~~~~~~~
          27:  .reg .f32 %f<88>; 
check:2'0     ~~~~~~~~~~~~~~~~~~~
          28:  .reg .b64 %rd<30>; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~
          29:  
check:2'0     ~
          30:  mov.u64 %SPL, __local_depot0; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          31:  cvta.local.u64 %SP, %SPL; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
          32:  ld.param.u64 %rd3, [fusion_param_0]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          33:  ld.param.u64 %rd5, [fusion_param_1]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          34:  ld.param.u64 %rd6, [fusion_param_3]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          35:  cvta.to.global.u64 %rd7, %rd6; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          36:  ld.param.u64 %rd8, [fusion_param_2]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          37:  cvta.to.global.u64 %rd9, %rd8; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          38:  cvta.to.global.u64 %rd10, %rd5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          39:  cvta.to.global.u64 %rd11, %rd3; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          40:  mov.u32 %r1, %tid.x; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~
          41:  mov.u32 %r2, %ctaid.x; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~
          42:  shl.b32 %r4, %r2, 10; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~
          43:  or.b32 %r5, %r4, %r1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~
          44:  mul.wide.u32 %rd12, %r5, 4; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          45:  add.s64 %rd13, %rd11, %rd12; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          46:  ld.global.nc.f32 %f3, [%rd13]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
check:2'1      ?                               possible intended match
          47:  mul.wide.u32 %rd14, %r2, 4; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          48:  add.s64 %rd15, %rd10, %rd14; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          49:  ld.global.nc.f32 %f4, [%rd15]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          50:  mul.rn.f32 %f5, %f4, 0f3A800000; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          51:  sub.rn.f32 %f6, %f3, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
          52:  mul.rn.f32 %f7, %f6, %f6; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
          53:  add.rn.f32 %f8, %f7, 0f00000000; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          54:  add.s64 %rd16, %rd7, %rd12; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          55:  st.global.f32 [%rd16], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          56:  add.s64 %rd17, %rd9, %rd12; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          57:  st.global.f32 [%rd17], %f6; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          58:  ld.global.nc.f32 %f9, [%rd13+256]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          59:  sub.rn.f32 %f10, %f9, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          60:  mul.rn.f32 %f11, %f10, %f10; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          61:  add.rn.f32 %f12, %f8, %f11; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          62:  st.global.f32 [%rd16+256], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          63:  st.global.f32 [%rd17+256], %f10; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          64:  ld.global.nc.f32 %f13, [%rd13+512]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          65:  sub.rn.f32 %f14, %f13, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          66:  mul.rn.f32 %f15, %f14, %f14; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          67:  add.rn.f32 %f16, %f12, %f15; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          68:  st.global.f32 [%rd16+512], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          69:  st.global.f32 [%rd17+512], %f14; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          70:  ld.global.nc.f32 %f17, [%rd13+768]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          71:  sub.rn.f32 %f18, %f17, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          72:  mul.rn.f32 %f19, %f18, %f18; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          73:  add.rn.f32 %f20, %f16, %f19; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          74:  st.global.f32 [%rd16+768], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          75:  st.global.f32 [%rd17+768], %f18; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          76:  ld.global.nc.f32 %f21, [%rd13+1024]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          77:  sub.rn.f32 %f22, %f21, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          78:  mul.rn.f32 %f23, %f22, %f22; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          79:  add.rn.f32 %f24, %f20, %f23; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          80:  st.global.f32 [%rd16+1024], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          81:  st.global.f32 [%rd17+1024], %f22; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          82:  ld.global.nc.f32 %f25, [%rd13+1280]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          83:  sub.rn.f32 %f26, %f25, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          84:  mul.rn.f32 %f27, %f26, %f26; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          85:  add.rn.f32 %f28, %f24, %f27; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          86:  st.global.f32 [%rd16+1280], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          87:  st.global.f32 [%rd17+1280], %f26; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          88:  ld.global.nc.f32 %f29, [%rd13+1536]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          89:  sub.rn.f32 %f30, %f29, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          90:  mul.rn.f32 %f31, %f30, %f30; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          91:  add.rn.f32 %f32, %f28, %f31; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          92:  st.global.f32 [%rd16+1536], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          93:  st.global.f32 [%rd17+1536], %f30; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          94:  ld.global.nc.f32 %f33, [%rd13+1792]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          95:  sub.rn.f32 %f34, %f33, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          96:  mul.rn.f32 %f35, %f34, %f34; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          97:  add.rn.f32 %f36, %f32, %f35; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          98:  st.global.f32 [%rd16+1792], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          99:  st.global.f32 [%rd17+1792], %f34; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         100:  ld.global.nc.f32 %f37, [%rd13+2048]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         101:  sub.rn.f32 %f38, %f37, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         102:  mul.rn.f32 %f39, %f38, %f38; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         103:  add.rn.f32 %f40, %f36, %f39; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         104:  st.global.f32 [%rd16+2048], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         105:  st.global.f32 [%rd17+2048], %f38; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         106:  ld.global.nc.f32 %f41, [%rd13+2304]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         107:  sub.rn.f32 %f42, %f41, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         108:  mul.rn.f32 %f43, %f42, %f42; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         109:  add.rn.f32 %f44, %f40, %f43; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         110:  st.global.f32 [%rd16+2304], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         111:  st.global.f32 [%rd17+2304], %f42; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         112:  ld.global.nc.f32 %f45, [%rd13+2560]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         113:  sub.rn.f32 %f46, %f45, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         114:  mul.rn.f32 %f47, %f46, %f46; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         115:  add.rn.f32 %f48, %f44, %f47; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         116:  st.global.f32 [%rd16+2560], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         117:  st.global.f32 [%rd17+2560], %f46; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         118:  ld.global.nc.f32 %f49, [%rd13+2816]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         119:  sub.rn.f32 %f50, %f49, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         120:  mul.rn.f32 %f51, %f50, %f50; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         121:  add.rn.f32 %f52, %f48, %f51; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         122:  st.global.f32 [%rd16+2816], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         123:  st.global.f32 [%rd17+2816], %f50; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         124:  ld.global.nc.f32 %f53, [%rd13+3072]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         125:  sub.rn.f32 %f54, %f53, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         126:  mul.rn.f32 %f55, %f54, %f54; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         127:  add.rn.f32 %f56, %f52, %f55; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         128:  st.global.f32 [%rd16+3072], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         129:  st.global.f32 [%rd17+3072], %f54; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         130:  ld.global.nc.f32 %f57, [%rd13+3328]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         131:  sub.rn.f32 %f58, %f57, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         132:  mul.rn.f32 %f59, %f58, %f58; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         133:  add.rn.f32 %f60, %f56, %f59; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         134:  st.global.f32 [%rd16+3328], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         135:  st.global.f32 [%rd17+3328], %f58; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         136:  ld.global.nc.f32 %f61, [%rd13+3584]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         137:  sub.rn.f32 %f62, %f61, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         138:  mul.rn.f32 %f63, %f62, %f62; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         139:  add.rn.f32 %f64, %f60, %f63; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         140:  st.global.f32 [%rd16+3584], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         141:  st.global.f32 [%rd17+3584], %f62; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         142:  ld.global.nc.f32 %f65, [%rd13+3840]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         143:  sub.rn.f32 %f66, %f65, %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         144:  mul.rn.f32 %f67, %f66, %f66; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         145:  add.rn.f32 %f68, %f64, %f67; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         146:  st.global.f32 [%rd16+3840], %f5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         147:  st.global.f32 [%rd17+3840], %f66; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         148:  and.b32 %r3, %r1, 31; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~
         149:  shfl.sync.down.b32 %f69, %f68, 16, 31, -1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         150:  add.rn.f32 %f70, %f68, %f69; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         151:  shfl.sync.down.b32 %f71, %f70, 8, 31, -1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         152:  add.rn.f32 %f72, %f70, %f71; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         153:  shfl.sync.down.b32 %f73, %f72, 4, 31, -1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         154:  add.rn.f32 %f74, %f72, %f73; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         155:  shfl.sync.down.b32 %f75, %f74, 2, 31, -1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         156:  add.rn.f32 %f76, %f74, %f75; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         157:  shfl.sync.down.b32 %f77, %f76, 1, 31, -1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         158:  setp.eq.s32 %p1, %r3, 0; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
         159:  mov.u64 %rd19, shared_cache; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         160:  @%p1 bra $L__BB0_3; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~
         161:  bra.uni $L__BB0_1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~
         162: $L__BB0_3: 
check:2'0     ~~~~~~~~~~~
         163:  shr.u32 %r6, %r1, 5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~
         164:  mul.wide.u32 %rd18, %r6, 4; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         165:  add.s64 %rd2, %rd19, %rd18; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         166:  add.rn.f32 %f1, %f76, %f77; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         167:  st.shared.f32 [%rd2], %f1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         168: $L__BB0_1: 
check:2'0     ~~~~~~~~~~~
         169:  bar.sync 0; 
check:2'0     ~~~~~~~~~~~~~
         170:  setp.lt.u32 %p2, %r1, 32; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         171:  @%p2 bra $L__BB0_4; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~
         172:  bra.uni $L__BB0_2; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~
         173: $L__BB0_4: 
check:2'0     ~~~~~~~~~~~
         174:  mul.wide.u32 %rd20, %r3, 4; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         175:  add.s64 %rd22, %rd19, %rd20; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         176:  cvta.shared.u64 %rd23, %rd22; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         177:  mov.u32 %r7, 0; 
check:2'0     ~~~~~~~~~~~~~~~~~
         178:  st.u32 [%SP+0], %r7; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~
         179:  setp.lt.u32 %p3, %r1, 2; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
         180:  add.u64 %rd24, %SP, 0; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~
         181:  selp.b64 %rd25, %rd23, %rd24, %p3; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         182:  ld.f32 %f78, [%rd25]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~
         183:  shfl.sync.down.b32 %f79, %f78, 16, 31, -1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         184:  add.rn.f32 %f80, %f78, %f79; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         185:  shfl.sync.down.b32 %f81, %f80, 8, 31, -1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         186:  add.rn.f32 %f82, %f80, %f81; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         187:  shfl.sync.down.b32 %f83, %f82, 4, 31, -1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         188:  add.rn.f32 %f84, %f82, %f83; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         189:  shfl.sync.down.b32 %f85, %f84, 2, 31, -1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         190:  add.rn.f32 %f86, %f84, %f85; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         191:  shfl.sync.down.b32 %f87, %f86, 1, 31, -1; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         192:  add.rn.f32 %f2, %f86, %f87; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         193:  st.f32 [%rd25], %f2; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~
         194:  setp.ne.s32 %p4, %r1, 0; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~
         195:  @%p4 bra $L__BB0_2; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~
         196:  ld.param.u64 %rd4, [fusion_param_4]; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         197:  cvta.to.global.u64 %rd1, %rd4; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         198:  cvt.u16.u32 %rs1, %r2; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~
         199:  mul.hi.u16 %rs2, %rs1, -21845; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         200:  shr.u16 %rs3, %rs2, 8; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~
         201:  mul.lo.s16 %rs4, %rs3, 384; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         202:  sub.s16 %rs5, %rs1, %rs4; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
         203:  cvt.u32.u16 %r8, %rs3; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~
         204:  mul.wide.u32 %rd26, %r8, 1536; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         205:  add.s64 %rd27, %rd1, %rd26; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         206:  cvt.u32.u16 %r9, %rs5; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~
         207:  mul.wide.u32 %rd28, %r9, 4; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         208:  add.s64 %rd29, %rd27, %rd28; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         209:  st.global.f32 [%rd29], %f2; 
check:2'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         210: $L__BB0_2: 
check:2'0     ~~~~~~~~~~~
         211:  ret; 
check:2'0     ~~~~~~
         212:  
check:2'0     ~
         213: } 
check:2'0     ~~
>>>>>>

2022-11-22 22:11:50.705200: E tensorflow/compiler/xla/tests/filecheck.cc:76] FileCheck input was:
//
// Generated by LLVM NVPTX Back-End
//

.version 6.0
.target sm_52
.address_size 64

	// .globl	fusion
.shared .align 4 .b8 shared_cache[8];

.visible .entry fusion(
	.param .u64 fusion_param_0,
	.param .u64 fusion_param_1,
	.param .u64 fusion_param_2,
	.param .u64 fusion_param_3,
	.param .u64 fusion_param_4
)
.reqntid 64, 1, 1
{
	.local .align 4 .b8 	__local_depot0[4];
	.reg .b64 	%SP;
	.reg .b64 	%SPL;
	.reg .pred 	%p<5>;
	.reg .b16 	%rs<6>;
	.reg .b32 	%r<10>;
	.reg .f32 	%f<88>;
	.reg .b64 	%rd<30>;

	mov.u64 	%SPL, __local_depot0;
	cvta.local.u64 	%SP, %SPL;
	ld.param.u64 	%rd3, [fusion_param_0];
	ld.param.u64 	%rd5, [fusion_param_1];
	ld.param.u64 	%rd6, [fusion_param_3];
	cvta.to.global.u64 	%rd7, %rd6;
	ld.param.u64 	%rd8, [fusion_param_2];
	cvta.to.global.u64 	%rd9, %rd8;
	cvta.to.global.u64 	%rd10, %rd5;
	cvta.to.global.u64 	%rd11, %rd3;
	mov.u32 	%r1, %tid.x;
	mov.u32 	%r2, %ctaid.x;
	shl.b32 	%r4, %r2, 10;
	or.b32  	%r5, %r4, %r1;
	mul.wide.u32 	%rd12, %r5, 4;
	add.s64 	%rd13, %rd11, %rd12;
	ld.global.nc.f32 	%f3, [%rd13];
	mul.wide.u32 	%rd14, %r2, 4;
	add.s64 	%rd15, %rd10, %rd14;
	ld.global.nc.f32 	%f4, [%rd15];
	mul.rn.f32 	%f5, %f4, 0f3A800000;
	sub.rn.f32 	%f6, %f3, %f5;
	mul.rn.f32 	%f7, %f6, %f6;
	add.rn.f32 	%f8, %f7, 0f00000000;
	add.s64 	%rd16, %rd7, %rd12;
	st.global.f32 	[%rd16], %f5;
	add.s64 	%rd17, %rd9, %rd12;
	st.global.f32 	[%rd17], %f6;
	ld.global.nc.f32 	%f9, [%rd13+256];
	sub.rn.f32 	%f10, %f9, %f5;
	mul.rn.f32 	%f11, %f10, %f10;
	add.rn.f32 	%f12, %f8, %f11;
	st.global.f32 	[%rd16+256], %f5;
	st.global.f32 	[%rd17+256], %f10;
	ld.global.nc.f32 	%f13, [%rd13+512];
	sub.rn.f32 	%f14, %f13, %f5;
	mul.rn.f32 	%f15, %f14, %f14;
	add.rn.f32 	%f16, %f12, %f15;
	st.global.f32 	[%rd16+512], %f5;
	st.global.f32 	[%rd17+512], %f14;
	ld.global.nc.f32 	%f17, [%rd13+768];
	sub.rn.f32 	%f18, %f17, %f5;
	mul.rn.f32 	%f19, %f18, %f18;
	add.rn.f32 	%f20, %f16, %f19;
	st.global.f32 	[%rd16+768], %f5;
	st.global.f32 	[%rd17+768], %f18;
	ld.global.nc.f32 	%f21, [%rd13+1024];
	sub.rn.f32 	%f22, %f21, %f5;
	mul.rn.f32 	%f23, %f22, %f22;
	add.rn.f32 	%f24, %f20, %f23;
	st.global.f32 	[%rd16+1024], %f5;
	st.global.f32 	[%rd17+1024], %f22;
	ld.global.nc.f32 	%f25, [%rd13+1280];
	sub.rn.f32 	%f26, %f25, %f5;
	mul.rn.f32 	%f27, %f26, %f26;
	add.rn.f32 	%f28, %f24, %f27;
	st.global.f32 	[%rd16+1280], %f5;
	st.global.f32 	[%rd17+1280], %f26;
	ld.global.nc.f32 	%f29, [%rd13+1536];
	sub.rn.f32 	%f30, %f29, %f5;
	mul.rn.f32 	%f31, %f30, %f30;
	add.rn.f32 	%f32, %f28, %f31;
	st.global.f32 	[%rd16+1536], %f5;
	st.global.f32 	[%rd17+1536], %f30;
	ld.global.nc.f32 	%f33, [%rd13+1792];
	sub.rn.f32 	%f34, %f33, %f5;
	mul.rn.f32 	%f35, %f34, %f34;
	add.rn.f32 	%f36, %f32, %f35;
	st.global.f32 	[%rd16+1792], %f5;
	st.global.f32 	[%rd17+1792], %f34;
	ld.global.nc.f32 	%f37, [%rd13+2048];
	sub.rn.f32 	%f38, %f37, %f5;
	mul.rn.f32 	%f39, %f38, %f38;
	add.rn.f32 	%f40, %f36, %f39;
	st.global.f32 	[%rd16+2048], %f5;
	st.global.f32 	[%rd17+2048], %f38;
	ld.global.nc.f32 	%f41, [%rd13+2304];
	sub.rn.f32 	%f42, %f41, %f5;
	mul.rn.f32 	%f43, %f42, %f42;
	add.rn.f32 	%f44, %f40, %f43;
	st.global.f32 	[%rd16+2304], %f5;
	st.global.f32 	[%rd17+2304], %f42;
	ld.global.nc.f32 	%f45, [%rd13+2560];
	sub.rn.f32 	%f46, %f45, %f5;
	mul.rn.f32 	%f47, %f46, %f46;
	add.rn.f32 	%f48, %f44, %f47;
	st.global.f32 	[%rd16+2560], %f5;
	st.global.f32 	[%rd17+2560], %f46;
	ld.global.nc.f32 	%f49, [%rd13+2816];
	sub.rn.f32 	%f50, %f49, %f5;
	mul.rn.f32 	%f51, %f50, %f50;
	add.rn.f32 	%f52, %f48, %f51;
	st.global.f32 	[%rd16+2816], %f5;
	st.global.f32 	[%rd17+2816], %f50;
	ld.global.nc.f32 	%f53, [%rd13+3072];
	sub.rn.f32 	%f54, %f53, %f5;
	mul.rn.f32 	%f55, %f54, %f54;
	add.rn.f32 	%f56, %f52, %f55;
	st.global.f32 	[%rd16+3072], %f5;
	st.global.f32 	[%rd17+3072], %f54;
	ld.global.nc.f32 	%f57, [%rd13+3328];
	sub.rn.f32 	%f58, %f57, %f5;
	mul.rn.f32 	%f59, %f58, %f58;
	add.rn.f32 	%f60, %f56, %f59;
	st.global.f32 	[%rd16+3328], %f5;
	st.global.f32 	[%rd17+3328], %f58;
	ld.global.nc.f32 	%f61, [%rd13+3584];
	sub.rn.f32 	%f62, %f61, %f5;
	mul.rn.f32 	%f63, %f62, %f62;
	add.rn.f32 	%f64, %f60, %f63;
	st.global.f32 	[%rd16+3584], %f5;
	st.global.f32 	[%rd17+3584], %f62;
	ld.global.nc.f32 	%f65, [%rd13+3840];
	sub.rn.f32 	%f66, %f65, %f5;
	mul.rn.f32 	%f67, %f66, %f66;
	add.rn.f32 	%f68, %f64, %f67;
	st.global.f32 	[%rd16+3840], %f5;
	st.global.f32 	[%rd17+3840], %f66;
	and.b32  	%r3, %r1, 31;
	shfl.sync.down.b32	%f69, %f68, 16, 31, -1;
	add.rn.f32 	%f70, %f68, %f69;
	shfl.sync.down.b32	%f71, %f70, 8, 31, -1;
	add.rn.f32 	%f72, %f70, %f71;
	shfl.sync.down.b32	%f73, %f72, 4, 31, -1;
	add.rn.f32 	%f74, %f72, %f73;
	shfl.sync.down.b32	%f75, %f74, 2, 31, -1;
	add.rn.f32 	%f76, %f74, %f75;
	shfl.sync.down.b32	%f77, %f76, 1, 31, -1;
	setp.eq.s32 	%p1, %r3, 0;
	mov.u64 	%rd19, shared_cache;
	@%p1 bra 	$L__BB0_3;
	bra.uni 	$L__BB0_1;
$L__BB0_3:
	shr.u32 	%r6, %r1, 5;
	mul.wide.u32 	%rd18, %r6, 4;
	add.s64 	%rd2, %rd19, %rd18;
	add.rn.f32 	%f1, %f76, %f77;
	st.shared.f32 	[%rd2], %f1;
$L__BB0_1:
	bar.sync 	0;
	setp.lt.u32 	%p2, %r1, 32;
	@%p2 bra 	$L__BB0_4;
	bra.uni 	$L__BB0_2;
$L__BB0_4:
	mul.wide.u32 	%rd20, %r3, 4;
	add.s64 	%rd22, %rd19, %rd20;
	cvta.shared.u64 	%rd23, %rd22;
	mov.u32 	%r7, 0;
	st.u32 	[%SP+0], %r7;
	setp.lt.u32 	%p3, %r1, 2;
	add.u64 	%rd24, %SP, 0;
	selp.b64 	%rd25, %rd23, %rd24, %p3;
	ld.f32 	%f78, [%rd25];
	shfl.sync.down.b32	%f79, %f78, 16, 31, -1;
	add.rn.f32 	%f80, %f78, %f79;
	shfl.sync.down.b32	%f81, %f80, 8, 31, -1;
	add.rn.f32 	%f82, %f80, %f81;
	shfl.sync.down.b32	%f83, %f82, 4, 31, -1;
	add.rn.f32 	%f84, %f82, %f83;
	shfl.sync.down.b32	%f85, %f84, 2, 31, -1;
	add.rn.f32 	%f86, %f84, %f85;
	shfl.sync.down.b32	%f87, %f86, 1, 31, -1;
	add.rn.f32 	%f2, %f86, %f87;
	st.f32 	[%rd25], %f2;
	setp.ne.s32 	%p4, %r1, 0;
	@%p4 bra 	$L__BB0_2;
	ld.param.u64 	%rd4, [fusion_param_4];
	cvta.to.global.u64 	%rd1, %rd4;
	cvt.u16.u32 	%rs1, %r2;
	mul.hi.u16 	%rs2, %rs1, -21845;
	shr.u16 	%rs3, %rs2, 8;
	mul.lo.s16 	%rs4, %rs3, 384;
	sub.s16 	%rs5, %rs1, %rs4;
	cvt.u32.u16 	%r8, %rs3;
	mul.wide.u32 	%rd26, %r8, 1536;
	add.s64 	%rd27, %rd1, %rd26;
	cvt.u32.u16 	%r9, %rs5;
	mul.wide.u32 	%rd28, %r9, 4;
	add.s64 	%rd29, %rd27, %rd28;
	st.global.f32 	[%rd29], %f2;
$L__BB0_2:
	ret;

}

tensorflow/compiler/xla/service/gpu/tests/gpu_codegen_test.cc:57: Failure
Value of: filecheck_result.value()
  Actual: false
Expected: true
[  FAILED  ] ReductionVectorizationNoOptTest.MultiOutputStore (727 ms)
```