### PR TITLE
Don't link tensorflow-lite against gemmlowp

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -560,7 +560,6 @@ target_link_libraries(tensorflow-lite
     farmhash
     fft2d_fftsg2d
     flatbuffers::flatbuffers
-    gemmlowp
     ruy::ruy
     pthreadpool
     ${CMAKE_DL_LIBS}


### PR DESCRIPTION
We can't link against gemmlowp as it is a header only library.

Fixes:
```
/bin/ld: cannot find -lgemmlowp: No such file or directory
```