### PR TITLE
Add tensorflow io support

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -122,7 +122,8 @@ REQUIRED_PACKAGES = [
     # version name.
     # These are all updated during the TF release process.
     standard_or_nightly('tensorboard >= 2.11, < 2.12',
-                        'tb-nightly ~= 2.12.0.a'),
+                        'tb-nightly ~= 2.12.0.a',
+                        'tensorflow-io >= 0.28.0'),
     standard_or_nightly('tensorflow_estimator >= 2.11.0rc0, < 2.12',
                         'tf-estimator-nightly ~= 2.12.0.dev'),
     standard_or_nightly('keras >= 2.11.0rc1, < 2.12',

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -122,8 +122,9 @@ REQUIRED_PACKAGES = [
     # version name.
     # These are all updated during the TF release process.
     standard_or_nightly('tensorboard >= 2.11, < 2.12',
-                        'tb-nightly ~= 2.12.0.a',
-                        'tensorflow-io >= 0.28.0'),
+                        'tb-nightly ~= 2.12.0.a'),
+    standard_or_nightly('tensorflow-io >= 0.28.0',
+                        'tensorflow-io-nightly ~= 0.28.0.dev'),
     standard_or_nightly('tensorflow_estimator >= 2.11.0rc0, < 2.12',
                         'tf-estimator-nightly ~= 2.12.0.dev'),
     standard_or_nightly('keras >= 2.11.0rc1, < 2.12',


### PR DESCRIPTION
Add tensorflow-io package to the pip-packages that gets picked in tensorflow docker images, to provide object storage support for tensorflow images out of the box as seen in [this](https://github.com/tensorflow/tensorflow/issues/58710) issue