### PR TITLE
[NVIDIA TF]  Enable BF16 Softmax, SoftmaxCrossEntropyWithLogits

### DIFF
--- a/tensorflow/core/kernels/softmax_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/softmax_op_gpu.cu.cc
@@ -53,9 +53,21 @@ __device__ __host__ EIGEN_STRONG_INLINE float strict_cast<float, Eigen::half>(
 }
 
 template <>
+__device__ __host__ EIGEN_STRONG_INLINE float strict_cast<float, Eigen::bfloat16>(
+    Eigen::bfloat16 t) {
+  return functor::HalfToFloat<Eigen::bfloat16>()(t);
+}
+
+template <>
 __device__ __host__ EIGEN_STRONG_INLINE Eigen::half
 strict_cast<Eigen::half, float>(float t) {
   return functor::FloatToHalf<Eigen::half>()(t);
+}
+
+template <>
+__device__ __host__ EIGEN_STRONG_INLINE Eigen::bfloat16
+strict_cast<Eigen::bfloat16, float>(float t) {
+  return functor::FloatToHalf<Eigen::bfloat16>()(t);
 }
 
 template <typename T>
@@ -65,6 +77,11 @@ struct softmax_traits {
 
 template <>
 struct softmax_traits<Eigen::half> {
+  using accumulator_type = float;
+};
+
+template <>
+struct softmax_traits<Eigen::bfloat16> {
   using accumulator_type = float;
 };
 
@@ -286,6 +303,7 @@ class SoftmaxOpGPU : public OpKernel {
       Name("Softmax").Device(DEVICE_GPU).TypeConstraint<T>("T"), \
       SoftmaxOpGPU<T>);
 TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU);
+TF_CALL_bfloat16(REGISTER_GPU);
 
 #undef REGISTER_GPU
 #define REGISTER_GPU(T)                                             \
@@ -293,6 +311,7 @@ TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU);
       Name("LogSoftmax").Device(DEVICE_GPU).TypeConstraint<T>("T"), \
       SoftmaxOpGPU<T>);
 TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU);
+TF_CALL_bfloat16(REGISTER_GPU);
 
 #undef REGISTER_GPU
 

--- a/tensorflow/core/kernels/softmax_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/softmax_op_gpu.cu.cc
@@ -34,42 +34,6 @@ namespace tensorflow {
 
 namespace {
 
-template <typename U, typename T>
-__device__ __host__ EIGEN_STRONG_INLINE
-    typename std::enable_if<!std::is_same<T, U>::value, U>::type
-    strict_cast(T t);
-
-template <typename U, typename T>
-__device__ __host__ EIGEN_STRONG_INLINE
-    typename std::enable_if<std::is_same<T, U>::value, U>::type
-    strict_cast(T t) {
-  return t;
-}
-
-template <>
-__device__ __host__ EIGEN_STRONG_INLINE float strict_cast<float, Eigen::half>(
-    Eigen::half t) {
-  return functor::HalfToFloat<Eigen::half>()(t);
-}
-
-template <>
-__device__ __host__ EIGEN_STRONG_INLINE float strict_cast<float, Eigen::bfloat16>(
-    Eigen::bfloat16 t) {
-  return functor::HalfToFloat<Eigen::bfloat16>()(t);
-}
-
-template <>
-__device__ __host__ EIGEN_STRONG_INLINE Eigen::half
-strict_cast<Eigen::half, float>(float t) {
-  return functor::FloatToHalf<Eigen::half>()(t);
-}
-
-template <>
-__device__ __host__ EIGEN_STRONG_INLINE Eigen::bfloat16
-strict_cast<Eigen::bfloat16, float>(float t) {
-  return functor::FloatToHalf<Eigen::bfloat16>()(t);
-}
-
 template <typename T>
 struct softmax_traits {
   using accumulator_type = T;
@@ -101,8 +65,8 @@ __global__ void GenerateNormalizedProb(const T* logits, const U* sum_probs,
     row = tid / num_cols;
     col = tid % num_cols;
     if (row < num_rows && col < num_cols) {
-      input[i] = strict_cast<U>(logits[tid]);
-      max_val[i] = strict_cast<U>(ldg(max_logits + row));
+      input[i] = static_cast<U>(logits[tid]);
+      max_val[i] = static_cast<U>(ldg(max_logits + row));
     }
     tid += gridDim.x * blockDim.x;
   }
@@ -117,7 +81,7 @@ __global__ void GenerateNormalizedProb(const T* logits, const U* sum_probs,
       } else {
         result[i] = exp(input[i] - max_val[i]) / ldg(sum_probs + row);
       }
-      output[tid] = strict_cast<T>(result[i]);
+      output[tid] = static_cast<T>(result[i]);
     }
     tid += gridDim.x * blockDim.x;
   }
@@ -147,14 +111,14 @@ __global__ void GenerateNormalizedProb<Eigen::half, float, 8>(
     for (int i = 0; i < kUnroll; i++) {
       idx[i] = tid * kUnroll + i;
       row[i] = idx[i] / num_cols;
-      input[i] = strict_cast<float>(logits_h[i]);
-      max_val[i] = strict_cast<float>(ldg(max_logits + row[i]));
+      input[i] = static_cast<float>(logits_h[i]);
+      max_val[i] = static_cast<float>(ldg(max_logits + row[i]));
       if (in_log_space) {
         result[i] = input[i] - max_val[i] - log(ldg(sum_probs + row[i]));
       } else {
         result[i] = exp(input[i] - max_val[i]) / ldg(sum_probs + row[i]);
       }
-      output_h[i] = strict_cast<Eigen::half>(result[i]);
+      output_h[i] = static_cast<Eigen::half>(result[i]);
     }
 
     *reinterpret_cast<ulonglong2*>(output + tid * kUnroll) = output_d;
@@ -163,14 +127,14 @@ __global__ void GenerateNormalizedProb<Eigen::half, float, 8>(
       if (tid * kUnroll + i < num_rows * num_cols) {
         idx[i] = tid * kUnroll + i;
         row[i] = idx[i] / num_cols;
-        input[i] = strict_cast<float>(logits[idx[i]]);
-        max_val[i] = strict_cast<float>(ldg(max_logits + row[i]));
+        input[i] = static_cast<float>(logits[idx[i]]);
+        max_val[i] = static_cast<float>(ldg(max_logits + row[i]));
         if (in_log_space) {
           result[i] = input[i] - max_val[i] - log(ldg(sum_probs + row[i]));
         } else {
           result[i] = exp(input[i] - max_val[i]) / ldg(sum_probs + row[i]);
         }
-        output[idx[i]] = strict_cast<Eigen::half>(result[i]);
+        output[idx[i]] = static_cast<Eigen::half>(result[i]);
       }
     }
   }
@@ -186,7 +150,7 @@ struct SubtractAndExpFunctor {
   __host__ __device__ U operator()(const int gid) const {
     // TODO(jamesqin): change to half2 load when inputs are Eigen::half.
     const U diff =
-        strict_cast<U>(logits_[gid] - ldg(max_logits_ + gid / num_cols_));
+        static_cast<U>(logits_[gid] - ldg(max_logits_ + gid / num_cols_));
     return exp(diff);
   }
 

--- a/tensorflow/core/kernels/sparse_xent_op.cc
+++ b/tensorflow/core/kernels/sparse_xent_op.cc
@@ -145,6 +145,8 @@ REGISTER(GPU, float, int32)
 REGISTER(GPU, float, int64_t)
 REGISTER(GPU, Eigen::half, int32)
 REGISTER(GPU, Eigen::half, int64_t)
+REGISTER(GPU, Eigen::bfloat16, int32)
+REGISTER(GPU, Eigen::bfloat16, int64_t)
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #undef REGISTER

--- a/tensorflow/core/kernels/sparse_xent_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/sparse_xent_op_gpu.cu.cc
@@ -70,11 +70,13 @@ struct SparseXentFunctor<GPUDevice, T, Index> {
 }  // end namespace functor
 
 // Instantiate the GPU implementation for float.
-#define REGISTER(Index)                                                      \
-  template struct functor::SparseXentFunctor<GPUDevice, float, Index>;       \
-  template class generator::SparseXentGradGenerator<float, Index>;           \
-  template struct functor::SparseXentFunctor<GPUDevice, Eigen::half, Index>; \
-  template class generator::SparseXentGradGenerator<Eigen::half, Index>;
+#define REGISTER(Index)                                                          \
+  template struct functor::SparseXentFunctor<GPUDevice, float, Index>;           \
+  template class generator::SparseXentGradGenerator<float, Index>;               \
+  template struct functor::SparseXentFunctor<GPUDevice, Eigen::half, Index>;     \
+  template class generator::SparseXentGradGenerator<Eigen::half, Index>;         \
+  template struct functor::SparseXentFunctor<GPUDevice, Eigen::bfloat16, Index>; \
+  template class generator::SparseXentGradGenerator<Eigen::bfloat16, Index>;
 REGISTER(int32)
 REGISTER(int64)
 #undef REGISTER

--- a/tensorflow/core/kernels/xent_op.cc
+++ b/tensorflow/core/kernels/xent_op.cc
@@ -135,18 +135,16 @@ TF_CALL_bfloat16(REGISTER_CPU);
 
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
-REGISTER_KERNEL_BUILDER(Name("SoftmaxCrossEntropyWithLogits")
-                            .Device(DEVICE_GPU)
-                            .TypeConstraint<Eigen::half>("T"),
-                        SoftmaxXentWithLogitsOp<GPUDevice, Eigen::half>);
-REGISTER_KERNEL_BUILDER(Name("SoftmaxCrossEntropyWithLogits")
-                            .Device(DEVICE_GPU)
-                            .TypeConstraint<float>("T"),
-                        SoftmaxXentWithLogitsOp<GPUDevice, float>);
-REGISTER_KERNEL_BUILDER(Name("SoftmaxCrossEntropyWithLogits")
-                            .Device(DEVICE_GPU)
-                            .TypeConstraint<double>("T"),
-                        SoftmaxXentWithLogitsOp<GPUDevice, double>);
+
+#define REGISTER_GPU(T)                                         \
+  REGISTER_KERNEL_BUILDER(Name("SoftmaxCrossEntropyWithLogits") \
+                               .Device(DEVICE_GPU)              \
+                               .TypeConstraint<T>("T"),         \
+                          SoftmaxXentWithLogitsOp<GPUDevice, T>);
+
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU);
+TF_CALL_bfloat16(REGISTER_GPU);
+
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/xent_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/xent_op_gpu.cu.cc
@@ -48,8 +48,9 @@ struct XentFunctor<GPUDevice, T> {
 };
 }  // end namespace functor
 
-// Instantiate the GPU implementation for half, float and double.
+// Instantiate the GPU implementation for half, bfloat16, float and double.
 template struct functor::XentFunctor<GPUDevice, Eigen::half>;
+template struct functor::XentFunctor<GPUDevice, Eigen::bfloat16>;
 template struct functor::XentFunctor<GPUDevice, float>;
 template struct functor::XentFunctor<GPUDevice, double>;
 

--- a/tensorflow/python/kernel_tests/nn_ops/softmax_op_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/softmax_op_test.py
@@ -179,6 +179,18 @@ class SoftmaxTest(test.TestCase):
         np.array([[1., 1., 1., 1.], [1., 2., 3., 4.]]).astype(np.float32),
         dtype=dtypes.bfloat16)
 
+  @unittest.skipUnless(test.is_built_with_gpu_support(),
+                       "Test only applicable when running on GPUs")
+  def testBfloat16GPU(self):
+    if test.is_gpu_available(cuda_only=True):
+      rows = [2**x + np.random.randint(0, 16) for x in range(1, 4)]
+      cols = [2**x + np.random.randint(0, 16) for x in range(1, 4)]
+      for row, col in zip(rows, cols):
+        logging.info(
+            "Testing softmax bfloat16 dtype in shape [%d, %d]", row, col)
+        data = np.random.rand(row, col)
+        self._testAll(data.astype(dtypes.bfloat16.as_numpy_dtype))
+
   def test1DTensorAsInput(self):
     self._testSoftmax(
         np.array([3., 2., 3., 9.]).astype(np.float64), use_gpu=False)

--- a/tensorflow/python/kernel_tests/nn_ops/xent_op_test_base.py
+++ b/tensorflow/python/kernel_tests/nn_ops/xent_op_test_base.py
@@ -88,7 +88,7 @@ class XentOpTestBase(test.TestCase):
     self.assertAllCloseAccordingToType(np_loss, tf_loss)
 
   def _testSingleClass(self, expected_gradient=[[2.0], [1.0], [0.0], [0.0]]):
-    for dtype in np.float16, np.float32:
+    for dtype in np.float16, np.float32, dtypes.bfloat16.as_numpy_dtype:
       loss, gradient = self._opFwdBwd(
           labels=np.array([[-1.], [0.], [1.], [1.]]).astype(dtype),
           logits=np.array([[1.], [-1.], [0.], [1.]]).astype(dtype))
@@ -170,6 +170,13 @@ class XentOpTestBase(test.TestCase):
   def testHalf(self):
     labels = np.array([[0., 0., 0., 1.], [0., .5, .5, 0.]]).astype(np.float16)
     logits = np.array([[1., 1., 1., 1.], [1., 2., 3., 4.]]).astype(np.float16)
+    self._testXent2D(labels, logits)
+
+  def testBfloat16(self):
+    labels = np.array([[0., 0., 0., 1.], [0., .5, .5, 0.]]).astype(
+        dtypes.bfloat16.as_numpy_dtype)
+    logits = np.array([[1., 1., 1., 1.], [1., 2., 3., 4.]]).astype(
+        dtypes.bfloat16.as_numpy_dtype)
     self._testXent2D(labels, logits)
 
   def testFloat(self):

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_xent_op_test_base.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_xent_op_test_base.py
@@ -194,6 +194,14 @@ class SparseXentOpTestBase(test.TestCase):
           np_logits=np.array([[1., 1., 1., 1.], [1., 2., 3.,
                                                  4.]]).astype(np.float16))
 
+  def testBfloat16(self):
+    for label_dtype in np.int32, np.int64:
+      self._testXent(
+          np_labels=np.array([3, 0]).astype(label_dtype),
+          np_logits=np.array([[1., 1., 1., 1.],
+                              [1., 2., 3., 4.]]).astype(
+                                 dtypes.bfloat16.as_numpy_dtype))
+
   def testEmpty(self):
     self._testXent(
         np_labels=np.zeros((0,), dtype=np.int32), np_logits=np.zeros((0, 3)))


### PR DESCRIPTION
Add gpu bfloat16 support and tests for Softmax, LogSoftmax, SparseSoftmaxCrossEntropyWithLogits, and SoftmaxCrossEntropyWithLogits