### PR TITLE
r2.10 cherry-pick: fix the build error for libtensorflow_cc.so

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -89,6 +89,7 @@ PACKAGE_STATIC_DEPS = [
     "@local_execution_config_platform//:__subpackages__",
     "@mkl_dnn_acl_compatible//:__subpackages__",
     "@mkl_dnn_v1//:__subpackages__",
+    "@nccl_archive//:__subpackages__",
     "@org_sqlite//:__subpackages__",
     "@platforms//:__subpackages__",
     "@snappy//:__subpackages__",


### PR DESCRIPTION
Cherry-pick from commit da2606aaf152055dd1996f374dd541aa9bc4a479 to fix #57826.
Without this patch, `libtensorflow_cc.so.2.10.0` cannot be built.