### PR TITLE
[NVIDIA XLA] Add new pattern for horizontal fusing instructions whose output tensor has same output shape into kLoop fusion kernel. 

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_compiler.cc
@@ -821,7 +821,7 @@ Status GpuCompiler::PrepareHloModuleForIrEmitting(HloModule* hlo_module) {
   pipeline.AddPass<CopyInsertion>(GetCanShareBuffer());
   // To fuse the copy.
   pipeline.AddPass<GpuHorizontalLoopFusion>("copy_");
-
+  pipeline.AddPass<HloDCE>();
   pipeline.AddPass<GpuSanitizeConstantNames>();
   return pipeline.Run(hlo_module).status();
 }

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.cc
@@ -62,28 +62,41 @@ class HorizontalLoopFusionImpl {
   StatusOr<bool> Run();
 
  private:
-  Status Fuse(absl::Span<HloInstruction*> fused_fusion_instrs);
+  Status Fuse(absl::Span<HloInstruction*> fused_fusion_instrs, bool sliced_input_fusion,
+              std::vector<HloInstruction*>& to_fuse_candidates);
 
-  // Horizontally fuses `fused_fusion_instrs`. It is required that each of
-  // `fused_fusion_instrs` is a kLoop fusion. Also, we require their numbers of
-  // outputs to be the same, so that each output will be fused/concatenated with
-  // the same number of outputs from other fused fusion instrs. Then, all the
-  // fused outputs still have the same shapes for kernel generation.
+  // If `sliced_input_fusion` is true, Horizontally fuses `fused_fusion_instrs` 
+  // into kInput computation, else fuses `fused_fusion_instrs` into kLoop computation. 
+  // 
+  // It is required that each of `fused_fusion_instrs` is a kLoop fusion. Also, 
+  // we require their numbers of outputs to be the same, so that each output will 
+  // be fused/concatenated with the same number of outputs from other fused 
+  // fusion instrs. Then, all the fused outputs still have the same shapes for 
+  // kernel generation.
   //
   // Returns the fused computation in `uniq_computation` and the operands that
   // are used by `uniq_computation`.
   Status CreateFusedComputation(
       absl::Span<HloInstruction*> fused_fusion_instrs,
       std::unique_ptr<HloComputation>* uniq_computation,
-      std::vector<HloInstruction*>* bound_operands);
+      std::vector<HloInstruction*>* bound_operands, 
+      bool sliced_input_fusion);
+
+  // Horizontally fuses the operands of consumer instruction, `sliced_input_fusion` 
+  // controls whether kInput or kLoop type fused instruction want to be created. 
+  // `to_fuse_candidates` is the instruction stack that we want to 
+  // try horizontally fuse its operands, when we create a new fusion instruction,
+  // we push it to the stack in hope to further fuse its operands.
+  StatusOr<bool> FuseConsumerOperands(HloInstruction* consumer, bool sliced_input_fusion,
+                                      std::vector<HloInstruction*>& to_fuse_candidates);
 
   // FusionCandidates collects profitable candidates for a given consumer
   // instruction. GetNextSpanOfFusions() can then be iteratively invoked to
   // acquire the next set of fusion candidates based on some heuristics.
   class FusionCandidates {
    public:
-    explicit FusionCandidates(HloInstruction* consumer)
-        : fusible_instrs_(), pos_(0) {
+    explicit FusionCandidates(HloInstruction* consumer, bool sliced_input_fusion)
+        : fusible_instrs_(), pos_(0), sliced_input_fusion_(sliced_input_fusion) {
       Initialize(consumer);
     }
 
@@ -96,6 +109,9 @@ class HorizontalLoopFusionImpl {
     std::vector<HloInstruction*> fusible_instrs_;
     // `pos_` points to the start position of the next span.
     size_t pos_;
+    // `sliced_input_fusion_` flag controls whether we want to fuse 
+    // into kLoop (false) or kInput (True) type kernel 
+    bool sliced_input_fusion_;
   };
 
   HloComputation* computation_;
@@ -149,9 +165,12 @@ bool IsFusibleCandidate(const HloInstruction& instr) {
 // fusion instruction has shapes smaller than `kShapeThreshold` and has fewer
 // instructions than `kInstrCountThreshold`, it is launch-latency-bound and
 // profitable by horizontal fusion.
-bool IsProfitableFusionCandidate(const HloInstruction& instr) {
-  constexpr int64_t kShapeThreshold = 128 * 2048;
-  constexpr int64_t kInstrCountThreshold = 30;
+bool IsProfitableFusionCandidate(const HloInstruction& instr, bool sliced_input_fusion) {
+  // For kLoop fused kernel, each GPU thread will process 1 or more elements from each 
+  // horizontal fused operands, while for kInput fused kernel, each GPU thread can only 
+  // process 1 element. From experience, we enable larger tensor size threshold for kLoop fusion.
+  const int64_t kShapeThreshold = sliced_input_fusion ? 128 * 2048 : 8192 * 8192;
+  const int64_t kInstrCountThreshold = sliced_input_fusion ? 30 : 128;
   const HloInstruction* root = (instr.opcode() == HloOpcode::kFusion)
                                    ? instr.fused_expression_root()
                                    : &instr;
@@ -162,11 +181,15 @@ bool IsProfitableFusionCandidate(const HloInstruction& instr) {
     // representative.
     Shape shape = root->operand(0)->shape();
     if (ShapeUtil::ElementsIn(shape) > kShapeThreshold) {
+      VLOG(2) << "Profitable check failed due to element count with sliced_input_fusion=" 
+              << sliced_input_fusion;
       return false;
     }
   } else {
     Shape shape = root->shape();
     if (ShapeUtil::ElementsIn(shape) > kShapeThreshold) {
+      VLOG(2) << "Profiltable check failed due to element size with sliced_input_fusion=" 
+              << sliced_input_fusion;
       return false;
     }
   }
@@ -234,21 +257,25 @@ void HorizontalLoopFusionImpl::FusionCandidates::Initialize(
 
   for (HloInstruction* instr : ordered_fusible_candidates) {
     if (!IsConsumerTheOnlyNonRootUser(*instr, *consumer)) {
-      VLOG(2) << "Reject maybe illegal instr " << instr->ToString()
+      VLOG(2) << "sliced_input_fusion=" << sliced_input_fusion_  
+              << " rejects maybe illegal instr " << instr->ToString()
               << "; including it may create cycles in HLO.";
       continue;
-    } else if (!IsProfitableFusionCandidate(*instr)) {
-      VLOG(2) << "Reject may-not-be profitable fusion instr "
+    } else if (!IsProfitableFusionCandidate(*instr, sliced_input_fusion_)) {
+      VLOG(2) << "sliced_input_fusion=" << sliced_input_fusion_  
+              << " rejects may-not-be profitable fusion instr"
               << instr->ToString();
       continue;
     } else if (!HasOnlyRowMajorLayout(*instr)) {
-      VLOG(2) << "Reject non-row-major fusion instr " << instr->ToString();
+      VLOG(2) << "sliced_input_fusion=" << sliced_input_fusion_  
+              << " rejects non-row-major fusion instr " << instr->ToString();
       continue;
     } else if (AnyOpndIsParamSharedAmongFusions(instr, fusible_candidates)) {
       // Don't fuse fusions whose operands are parameter instructions that are
       // shared among fusions because we cannot i/o alias the produced
       // horizontal fusion due to the concat insertion.
-      VLOG(2) << "Reject the fusion instr because it shares parameter with"
+      VLOG(2) << "sliced_input_fusion=" << sliced_input_fusion_  
+              << " rejects the fusion instr because it shares parameter with"
               << " other fusion candidates, instr: " << instr->ToString();
       continue;
     } else {
@@ -260,9 +287,11 @@ void HorizontalLoopFusionImpl::FusionCandidates::Initialize(
   }
 
   // Sort `fusible_instrs_` according to output types, the number of outputs,
-  // and instruction counts, because we only fuse instructions with the same
-  // number/type of outputs and whose computations have the same instruction
-  // count.
+  // instruction counts, output tensor element count. For sliced input fusion,  we only 
+  // fuse instructions with the same number/type of outputs and whose computations 
+  // have the same instruction count. For kLoop fusion, we requires the fused
+  // instructions to have the same number/type of outputs and also the same output shape.
+  // We did a sort here so the fusion candidates is populating a continuous span.
   std::sort(
       fusible_instrs_.begin(), fusible_instrs_.end(),
       [&](const HloInstruction* a, const HloInstruction* b) {
@@ -272,14 +301,17 @@ void HorizontalLoopFusionImpl::FusionCandidates::Initialize(
                  GetUniqueOutputTypeOfFusible(*b);
         } else if (GetOutputSizeOfFusible(*a) != GetOutputSizeOfFusible(*b)) {
           return GetOutputSizeOfFusible(*a) < GetOutputSizeOfFusible(*b);
+        } else if (GetInstrCountOfFusible(*a) != GetInstrCountOfFusible(*b)) {
+            return GetInstrCountOfFusible(*a) < GetInstrCountOfFusible(*b);
         } else {
-          return GetInstrCountOfFusible(*a) < GetInstrCountOfFusible(*b);
-        }
+          return ShapeUtil::ElementsIn(GetOutputsOfFusible(*a)[0]->shape()) <
+                 ShapeUtil::ElementsIn(GetOutputsOfFusible(*b)[0]->shape());
+        }          
       });
 }
 
 // Gets a next span of fusion instructions to be fused.
-absl::Span<HloInstruction*>
+absl::Span<HloInstruction*> 
 HorizontalLoopFusionImpl::FusionCandidates::GetNextSpanOfFusions() {
   if (pos_ >= fusible_instrs_.size()) {
     return absl::Span<HloInstruction*>();
@@ -287,7 +319,34 @@ HorizontalLoopFusionImpl::FusionCandidates::GetNextSpanOfFusions() {
 
   // Fusing too many computations at a time may not be easily profitable and
   // may increase compile time due to large kernels. Set a limit to it.
-  constexpr int64_t kMaxFusionBatchSize = 32;
+  // From profiling results, we found an issue that large fused horizontal kernel could have 
+  // lower E2E perf, though the pure GPU kernel time is shorter. TODO task for understanding 
+  // why E2E perf regression for large horiizontal fused kernel.
+  // Use the experience max fusion batch size based on the fused instruction count of the operand
+  const auto kMaxFusionBatchSize = [&]() -> int64_t {
+    if (sliced_input_fusion_) {
+      return 32;
+    } else {
+      if (fusible_instrs_[pos_]->opcode() == HloOpcode::kFusion) {
+        auto fused_instruction_count = fusible_instrs_[pos_]->fused_instruction_count();
+        if (fused_instruction_count < 8) {
+          return 32;
+        } else if (fused_instruction_count < 16) {
+          return 16;
+        } else if (fused_instruction_count < 32) {
+          return 8;
+        } else if (fused_instruction_count < 64){
+          return 4;
+        } else {
+          return 2;
+        }
+      }
+      else {
+        return 64;
+      }
+    } 
+  }();
+
   // CUDA has a parameter size limit of ~4k bytes.
   constexpr int64_t kMaxCudaParamSize = 4000;
   size_t accum_io_size = 0;
@@ -328,20 +387,64 @@ HorizontalLoopFusionImpl::FusionCandidates::GetNextSpanOfFusions() {
       // fusing computations with too much discrepancy and we may improve it
       // when the needs arise.
       break;
+    } else if (!sliced_input_fusion_ &&
+               !ShapeUtil::EqualIgnoringElementType(
+                GetOutputsOfFusible(*fusible_instrs_[left])[0]->shape(),
+                GetOutputsOfFusible(*fusible_instrs_[right])[0]->shape())) {
+      // This is for fusing into kLoop type kernel, so we requires that each fusion
+      // operand have the same shape
+      break;
     } else if (reach_max_fusion_batch_size(left, right)) {
       // Hit max fusion batch size.
       break;
     }
   }
-
+  VLOG(2) << "horizontal fuse get instruction span with " << (right - left) 
+          << " instructions for sliced_input_fusion=" << sliced_input_fusion_ 
+          << " fusion";
   pos_ = right;
   return absl::MakeSpan(fusible_instrs_).subspan(left, right - left);
+}
+
+StatusOr<bool> HorizontalLoopFusionImpl::FuseConsumerOperands(
+  HloInstruction* consumer, bool sliced_input_fusion, 
+  std::vector<HloInstruction*>& to_fuse_candidates) {
+  bool changed = false;
+  FusionCandidates loop_fusion_candidates(consumer, sliced_input_fusion);
+  while (true) {
+    auto fusibles = loop_fusion_candidates.GetNextSpanOfFusions();
+    if (fusibles.empty()) {
+      break;
+    } else if (fusibles.size() == 1) {
+      // Skip; there is just one fused_instr.
+      continue;
+    }
+
+    changed = true;
+    // Convert fusible into fusion_instrs to simplify the implementation of
+    // `Fuse()`.
+    std::vector<HloInstruction*> fusion_instrs;
+    for (HloInstruction* instr : fusibles) {
+      if (instr->opcode() == HloOpcode::kFusion) {
+        fusion_instrs.push_back(instr);
+      } else {
+        TF_ASSIGN_OR_RETURN(
+            HloInstruction * fusion_instr,
+            MakeFusionInstruction(instr, HloInstruction::FusionKind::kLoop));
+        fusion_instrs.push_back(fusion_instr);
+      }
+    }
+
+    TF_RETURN_IF_ERROR(Fuse(absl::MakeSpan(fusion_instrs), sliced_input_fusion, to_fuse_candidates));
+  }
+  return changed;
 }
 
 Status HorizontalLoopFusionImpl::CreateFusedComputation(
     absl::Span<HloInstruction*> fused_fusion_instrs,
     std::unique_ptr<HloComputation>* uniq_computation,
-    std::vector<HloInstruction*>* bound_operands) {
+    std::vector<HloInstruction*>* bound_operands, 
+    bool sliced_input_fusion) {
   // First, build a computation with only params.
   HloComputation::Builder b(prefix_ + "horizontally_fused_computation");
   size_t fused_comp_param_id = 0;
@@ -384,7 +487,8 @@ Status HorizontalLoopFusionImpl::CreateFusedComputation(
                                 ->MakeInstructionPostOrder();
     for (HloInstruction* old_instr : def_to_use_order) {
       if (old_instr->opcode() == HloOpcode::kParameter ||
-          (old_instr->opcode() == HloOpcode::kTuple &&
+          (sliced_input_fusion &&
+           old_instr->opcode() == HloOpcode::kTuple &&
            old_instr == fused_fusion_instrs[i]->fused_expression_root())) {
         // Parameters have been created, and we don't need tuples from
         // multi-output fusions, as we will directly reference the tuple
@@ -406,77 +510,110 @@ Status HorizontalLoopFusionImpl::CreateFusedComputation(
     }
   }
 
-  std::vector<HloInstruction*> concated_outputs;
   // Since we require each fusion to have the same number of outputs, we can
   // simply use the first fusion as the representative for output size.
   size_t fused_instr_output_size =
       GetOutputSizeOfFusible(*fused_fusion_instrs[0]);
-  for (size_t i = 0; i < fused_instr_output_size; ++i) {
-    std::vector<HloInstruction*> instr_outputs(fused_fusion_instrs.size());
-    for (size_t j = 0; j < fused_fusion_instrs.size(); ++j) {
-      const HloInstruction* old_output =
-          GetOutputsOfFusible(*fused_fusion_instrs[j])[i];
-      HloInstruction* new_output = clone_map[old_output];
-      if (new_output->shape().dimensions_size() == 1) {
-        instr_outputs[j] = new_output;
-      } else {
-        Shape new_shape = ShapeUtil::MakeShapeWithDenseLayout(
-            new_output->shape().element_type(),
-            {ShapeUtil::ElementsIn(new_output->shape())},
-            /*minor_to_major=*/std::vector<int64_t>(1, 0));
-        TF_ASSIGN_OR_RETURN(instr_outputs[j],
-                            MakeReshapeHlo(new_shape, new_output));
+ 
+  if (sliced_input_fusion) {
+    // Fusing into kInput fusion
+    std::vector<HloInstruction*> concated_outputs;
+    for (size_t i = 0; i < fused_instr_output_size; ++i) {
+      std::vector<HloInstruction*> instr_outputs(fused_fusion_instrs.size());
+      for (size_t j = 0; j < fused_fusion_instrs.size(); ++j) {
+        const HloInstruction* old_output =
+            GetOutputsOfFusible(*fused_fusion_instrs[j])[i];
+        HloInstruction* new_output = clone_map[old_output];
+        if (new_output->shape().dimensions_size() == 1) {
+          instr_outputs[j] = new_output;
+        } else {
+          Shape new_shape = ShapeUtil::MakeShapeWithDenseLayout(
+              new_output->shape().element_type(),
+              {ShapeUtil::ElementsIn(new_output->shape())},
+              /*minor_to_major=*/std::vector<int64_t>(1, 0));
+          TF_ASSIGN_OR_RETURN(instr_outputs[j],
+                              MakeReshapeHlo(new_shape, new_output));
+        }
+      }
+      TF_ASSIGN_OR_RETURN(HloInstruction * concated_output,
+                          MakeConcatHlo(instr_outputs, 0));
+      concated_outputs.push_back(concated_output);
+    }
+
+    // Make slices of outputs.
+    std::vector<HloInstruction*> output_slices(concated_outputs.size() *
+                                               fused_fusion_instrs.size());
+    for (size_t i = 0; i < concated_outputs.size(); ++i) {
+      HloInstruction* concated_output = concated_outputs[i];
+      int64_t slice_start = 0;
+      // Create a slice per fused computation.
+      for (size_t j = 0; j < fused_fusion_instrs.size(); ++j) {
+        const HloInstruction* old_output =
+            GetOutputsOfFusible(*fused_fusion_instrs[j])[i];
+        Shape shape = old_output->shape();
+        int64_t slice_limit = slice_start + ShapeUtil::ElementsIn(shape);
+        TF_ASSIGN_OR_RETURN(
+            output_slices[concated_outputs.size() * j + i],
+            MakeSliceHlo(concated_output, {slice_start}, {slice_limit},
+                         /*strides=*/{1}));
+        slice_start = slice_limit;
       }
     }
-    TF_ASSIGN_OR_RETURN(HloInstruction * concated_output,
-                        MakeConcatHlo(instr_outputs, 0));
-    concated_outputs.push_back(concated_output);
-  }
 
-  // Make slices of outputs.
-  std::vector<HloInstruction*> output_slices(concated_outputs.size() *
-                                             fused_fusion_instrs.size());
-  for (size_t i = 0; i < concated_outputs.size(); ++i) {
-    HloInstruction* concated_output = concated_outputs[i];
-    int64_t slice_start = 0;
-    // Create a slice per fused computation.
-    for (size_t j = 0; j < fused_fusion_instrs.size(); ++j) {
-      const HloInstruction* old_output =
-          GetOutputsOfFusible(*fused_fusion_instrs[j])[i];
-      Shape shape = old_output->shape();
-      int64_t slice_limit = slice_start + ShapeUtil::ElementsIn(shape);
-      TF_ASSIGN_OR_RETURN(
-          output_slices[concated_outputs.size() * j + i],
-          MakeSliceHlo(concated_output, {slice_start}, {slice_limit},
-                       /*strides=*/{1}));
-      slice_start = slice_limit;
+    // Make a tuple of output_slices.
+    HloInstruction* tuple = comp->AddInstruction(
+        HloInstruction::CreateTuple(output_slices), metadata);
+    comp->set_root_instruction(tuple, /*accept_different_shape=*/true);
+    TF_RETURN_IF_ERROR(comp->RemoveInstruction(dummy_root));
+
+  } else {
+    // Fusing into kLoop fusion
+    std::vector<HloInstruction*> tuple_operands(fused_instr_output_size * 
+                                                fused_fusion_instrs.size());
+    // If fusing into kLoop fusion, the new fusion root is tuple of fused 
+    // fusion computaton's root. 
+    for (size_t i = 0; i < fused_instr_output_size; ++i) {
+      for (size_t j = 0; j < fused_fusion_instrs.size(); ++j) {
+        const HloInstruction* old_output =
+            GetOutputsOfFusible(*fused_fusion_instrs[j])[i];
+        HloInstruction* new_output = clone_map[old_output];
+        tuple_operands[fused_instr_output_size * j + i] = new_output;
+      }
     }
+    // Make a tuple instruction of fused instruction outputs as 
+    // the root of fused computation.
+    HloInstruction* tuple =
+        comp->AddInstruction(HloInstruction::CreateTuple(tuple_operands));
+    comp->set_root_instruction(tuple, /*accept_different_shape=*/true);
+    TF_RETURN_IF_ERROR(comp->RemoveInstruction(dummy_root));
   }
-
-  // Make a tuple of output_slices.
-  HloInstruction* tuple = comp->AddInstruction(
-      HloInstruction::CreateTuple(output_slices), metadata);
-  comp->set_root_instruction(tuple, /*accept_different_shape=*/true);
-  TF_RETURN_IF_ERROR(comp->RemoveInstruction(dummy_root));
 
   return OkStatus();
 }
 
 Status HorizontalLoopFusionImpl::Fuse(
-    absl::Span<HloInstruction*> fused_fusion_instrs) {
+    absl::Span<HloInstruction*> fused_fusion_instrs, bool sliced_input_fusion,
+    std::vector<HloInstruction*>& to_fuse_candidates) {
   // Fuse fused_fusion_instrs and replace them with the new fused computation.
   std::unique_ptr<HloComputation> uniq_computation;
   std::vector<HloInstruction*> bound_operands;
+
   TF_RETURN_IF_ERROR(CreateFusedComputation(
-      fused_fusion_instrs, &uniq_computation, &bound_operands));
+      fused_fusion_instrs, &uniq_computation, &bound_operands, sliced_input_fusion));
+
   HloComputation* fused_comp = computation_->parent()->AddEmbeddedComputation(
       std::move(uniq_computation));
   HloInstruction* hori_fusion_instr = computation_->AddInstruction(
       HloInstruction::CreateFusion(fused_comp->root_instruction()->shape(),
-                                   HloInstruction::FusionKind::kInput,
+                                   sliced_input_fusion ? HloInstruction::FusionKind::kInput : 
+                                                         HloInstruction::FusionKind::kLoop, 
                                    bound_operands, fused_comp, prefix_),
       &fused_comp->root_instruction()->metadata());
   fused_comp->SetFusionInstruction(hori_fusion_instr);
+
+  // we push the newly fused instruction into fusion candidate stack, because the operands
+  // of the newly fused instruction could now be possible to be horizontally fused. 
+  to_fuse_candidates.push_back(hori_fusion_instr);
 
   // Insert bitcasts and replace corresponding users. Note that we do not insert
   // the bitcasts in the fused computation as it does not fit into the slice
@@ -529,39 +666,30 @@ StatusOr<bool> HorizontalLoopFusionImpl::Run() {
   // shape mismatch but bitcasts could prevent future h-fusion from happening.
   // So, a bottom-up, use-to-def order should be more favorable. It also helps
   // to save compiler iterations to reach the fixed point.
-  std::vector<HloInstruction*> use_to_def_order =
-      computation_->MakeInstructionPostOrder();
-  absl::c_reverse(use_to_def_order);
-  for (size_t i = 0; i < use_to_def_order.size(); ++i) {
-    HloInstruction* consumer = use_to_def_order[i];
-    HorizontalLoopFusionImpl::FusionCandidates fusion_candidates(consumer);
-    while (true) {
-      auto fusibles = fusion_candidates.GetNextSpanOfFusions();
-      if (fusibles.empty()) {
-        break;
-      } else if (fusibles.size() == 1) {
-        // Skip; there is just one fused_instr.
-        continue;
-      }
+  std::vector<HloInstruction*> to_fuse_candidates = computation_->MakeInstructionPostOrder();
 
-      changed = true;
-      // Convert fusible into fusion_instrs to simplify the implementation of
-      // `Fuse()`.
-      std::vector<HloInstruction*> fusion_instrs;
-      for (HloInstruction* instr : fusibles) {
-        if (instr->opcode() == HloOpcode::kFusion) {
-          fusion_instrs.push_back(instr);
-        } else {
-          TF_ASSIGN_OR_RETURN(
-              HloInstruction * fusion_instr,
-              MakeFusionInstruction(instr, HloInstruction::FusionKind::kLoop));
-          fusion_instrs.push_back(fusion_instr);
-        }
-      }
-      TF_RETURN_IF_ERROR(Fuse(absl::MakeSpan(fusion_instrs)));
+  while (to_fuse_candidates.size() > 0 ) {
+    HloInstruction* consumer = to_fuse_candidates.back();
+    to_fuse_candidates.pop_back();
+
+    // the consumer may be the operands of previously fused instruction, so 
+    // it will no longer valid, skip this instruction.
+    if (consumer->IsDead()) {
+      continue;
     }
-  }
 
+    // we first try to fuse into kLoop fusion instruction for those operands 
+    // that have the same shape.
+    TF_ASSIGN_OR_RETURN(bool loop_fusion_changed, 
+                        FuseConsumerOperands(consumer, false, to_fuse_candidates));
+
+    // for the remaining operands with diffent shape, we further try fuse them 
+    // into kInput fusion instruction. 
+    TF_ASSIGN_OR_RETURN(bool sliced_input_fusion_changed, 
+                        FuseConsumerOperands(consumer, true, to_fuse_candidates));
+
+    changed = changed || loop_fusion_changed || sliced_input_fusion_changed;
+  }
   return changed;
 }
 
@@ -576,11 +704,10 @@ StatusOr<bool> GpuHorizontalLoopFusion::RunOnComputation(
 StatusOr<bool> GpuHorizontalLoopFusion::Run(
     HloModule* module,
     const absl::flat_hash_set<absl::string_view>& execution_threads) {
-  bool changed = false;
   VLOG(2) << "Run horizontal fusion.";
 
   // Run on the entry computation is actually enough.
-  TF_ASSIGN_OR_RETURN(changed, RunOnComputation(module->entry_computation()));
+  TF_ASSIGN_OR_RETURN(bool changed, RunOnComputation(module->entry_computation()));
 
   return changed;
 }

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.h
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion.h
@@ -59,8 +59,23 @@ namespace gpu {
 //   v       v
 //  (ROOT) tuple
 //
-// We horizontally fuse them into the below pattern.
+// We fuse into one of two possible patterns, depending on whether all the 
+// fused operations have the same shape or not.
 //
+// case 1: if Mul and Add's output shape and type are the same, then we fuse them into 
+// the below pattern:
+// i0 i1   i2 i3
+//  | |     | |
+//  v v     v v
+//  Mul     Add
+//   |       |
+//   v       v
+//  (ROOT) tuple
+// the fused kernel will be kLoop type, i.e, GPU code is emitted through
+// IrEmitterUnnested::EmitLoopFusion 
+//
+// case 2: if Mul and Add's output shape are diffent, then we fuse them into 
+// the below pattern that adds extra indexing: 
 // i0 i1   i2 i3       +++ (Slice) Input Fusion
 //  | |     | |          +
 //  v v     v v          +
@@ -81,7 +96,14 @@ namespace gpu {
 //   v       v
 //  (ROOT) tuple
 //
-// Note that this fusion style provides an important advantage that kernels of
+// the fused kernel will be kInput type, and, the GPU code is emitted through 
+// IrEmitterUnnested::EmitInputFusibleNonStridedSlices
+//
+// In theory, the pattern in case 1 could also be fused into the case2 target graph,
+// but we prefer to fuse into kLoop type, because the codegen for it does not have the
+// slicing range check cost introduced by case 2 pattern.
+// 
+// Note that the fusion style by case 2 provides an important advantage that kernels of
 // different shapes can be horizontally fused. The first pair of reshapes
 // (i.e., Reshape0 and Reshape1) reshape the dims to 1 dimension, so that the
 // outputs of the fused kernels can (always) be concatenated. The second pair

--- a/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/horizontal_loop_fusion_test.cc
@@ -164,6 +164,104 @@ TEST_F(HorizontalLoopFusionTest, NegativeTestForIncompatibleTypes) {
   EXPECT_FALSE(GpuHorizontalLoopFusion().Run(module.get()).value());
 }
 
+TEST_F(HorizontalLoopFusionTest, FusingIntoKLoopAndKInputTogether) {
+  auto module = ParseAndReturnVerifiedModule(R"(
+ HloModule FusingIntoKLoopAndKInputTogether
+
+ fused_computation.1 {
+   arg.1 = f16[129, 2048]{1, 0} parameter(0)
+   arg.2 = f16[129, 2048]{1, 0} parameter(1)
+   ROOT mul.1 = f16[129,2048]{1, 0} multiply(arg.1, arg.2)
+ }
+
+ fused_computation.2 {
+   arg.1 = f16[129, 2048]{1, 0} parameter(0)
+   arg.2 = f16[129, 2048]{1, 0} parameter(1)
+   ROOT mul.1 = f16[129,2048]{1, 0} multiply(arg.1, arg.2)
+ }
+
+ fused_computation.3 {
+   arg.1 = f16[130, 2048]{1, 0} parameter(0)
+   arg.2 = f16[130, 2048]{1, 0} parameter(1)
+   ROOT mul.1 = f16[130,2048]{1, 0} multiply(arg.1, arg.2)
+ }
+
+ fused_computation.4 {
+   arg.1 = f16[130, 2048]{1, 0} parameter(0)
+   arg.2 = f16[130, 2048]{1, 0} parameter(1)
+   ROOT mul.1 = f16[130,2048]{1, 0} multiply(arg.1, arg.2)
+ }
+
+ fused_computation.5 {
+   arg.1 = f16[123]{0} parameter(0)
+   arg.2 = f16[123]{0} parameter(1)
+   ROOT add.1 = f16[123]{0} add(arg.1, arg.2)
+ }
+
+ fused_computation.6 {
+   arg.1 = f16[128]{0} parameter(0)
+   arg.2 = f16[128]{0} parameter(1)
+   ROOT add.1 = f16[128]{0} add(arg.1, arg.2)
+ }
+
+ ENTRY entry_computation {
+   arg.1 = f16[129, 2048]{1, 0} parameter(0)
+   arg.2 = f16[129, 2048]{1, 0} parameter(1)
+   arg.3 = f16[129, 2048]{1, 0} parameter(2)
+   arg.4 = f16[129, 2048]{1, 0} parameter(3)
+   arg.5 = f16[130, 2048]{1, 0} parameter(4)
+   arg.6 = f16[130, 2048]{1, 0} parameter(5)
+   arg.7 = f16[130, 2048]{1, 0} parameter(6)
+   arg.8 = f16[130, 2048]{1, 0} parameter(7)
+   arg.9 = f16[123]{0} parameter(8)
+   arg.10 = f16[123]{0} parameter(9)
+   arg.11 = f16[128]{0} parameter(10)
+   arg.12 = f16[128]{0} parameter(11)
+
+   // fusion.1 and fusion.2 will be fused into kLoop fusion
+   // fusion.3 and fusion.4 will be fused into another kLoop fusion
+   // fusion.5 and fusion.6 will be fused into kInput fusion
+
+   fusion.1 = f16[129,2048]{1, 0}
+      fusion(arg.1, arg.2), kind=kLoop, calls=fused_computation.1
+
+   fusion.2 = f16[129,2048]{1, 0}
+      fusion(arg.3, arg.4), kind=kLoop, calls=fused_computation.2
+
+   fusion.3 = f16[130,2048]{1, 0}
+      fusion(arg.5, arg.6), kind=kLoop, calls=fused_computation.3
+
+   fusion.4 = f16[130,2048]{1, 0}
+      fusion(arg.7, arg.8), kind=kLoop, calls=fused_computation.4
+
+   fusion.5 = f16[123]{0}
+      fusion(arg.9, arg.10), kind=kLoop, calls=fused_computation.5
+
+   fusion.6 = f16[128]{0}
+      fusion(arg.11, arg.12), kind=kLoop, calls=fused_computation.6
+
+   ROOT tuple.1 = (f16[129,2048]{1, 0}, f16[129,2048]{1, 0},
+                   f16[130,2048]{1, 0}, f16[130,2048]{1, 0},
+                   f16[123]{0}, f16[128]{0})
+      tuple(fusion.1, fusion.2, fusion.3, fusion.4, fusion.5, fusion.6)
+ }
+)")
+                    .value();
+
+  EXPECT_TRUE(GpuHorizontalLoopFusion().Run(module.get()).value());
+
+  int input_fusion_count = 0;
+  int loop_fusion_count = 0;
+  for (auto inst: module.get()->entry_computation()->MakeInstructionPostOrder()) {
+    if (inst->opcode() == HloOpcode::kFusion) {
+      input_fusion_count += (inst->fusion_kind() == HloInstruction::FusionKind::kInput) ? 1 : 0;
+      loop_fusion_count += (inst->fusion_kind() == HloInstruction::FusionKind::kLoop) ? 1 : 0;
+    }
+  }
+  EXPECT_EQ(input_fusion_count, 1);
+  EXPECT_EQ(loop_fusion_count, 2);
+}
+
 TEST_F(HorizontalLoopFusionTest, HorizontalLoopFusionAfterVerticalFusion) {
   auto module = ParseAndReturnVerifiedModule(R"(
  HloModule MergeSharedFusionInstruction


### PR DESCRIPTION
This PR add another horizontal fusion choice which fuses operands with the same output shape into kLoop fused computation, which should be faster in most cases than current kInput fusion pattern.

The below Case1 is the newly added pattern, because the kernel generated from kLoop instruction is much more efficient.

Detailed pattern are like:

```
// The following illustrates the mechanism of the horizontal fusion. Before
// fusion, there are two trivial kernels in the illustrating example. One has
// only a Mul op, while the other consists of only an Add op. Since they are
// only consumed by the same (ROOT) tuple instruction, horizontal fusion is
// triggered.
//
// i0 i1   i2 i3
//  | |     | |
//  v v     v v
//  Mul     Add
//   |       |
//   v       v
//  (ROOT) tuple
//
// We fuse into two possible pattern, depending on whether all the 
// fused operations have the same shape or not.
//
// case 1: if Mul and Add's output shape and type are the same, then we fuse them into 
// the below pattern:
// i0 i1   i2 i3
//  | |     | |
//  v v     v v
//  Mul     Add
//   |       |
//   v       v
//  (ROOT) tuple
// the fused kernel will be kLoop type, i.e, GPU code is emitted through
// IrEmitterUnnested::EmitLoopFusion 
//
// case 2: if Mul and Add's output shape are diffent, then we fuse them into 
// the below pattern that add extra indexing: 
// i0 i1   i2 i3       +++ (Slice) Input Fusion
//  | |     | |          +
//  v v     v v          +
//  Mul     Add          +
//   |       |           +
//   v       v           +
// Reshape0  Reshape1    +
//   |       |           +
//   v       v           +
//  Concatenate          +
//   |       |           +
//   v       v           +
//  Slice0  Slice1     +++
//   |       |
//   v       v
// Reshape2  Reshape3
//   |       |
//   v       v
//  (ROOT) tuple
//
// the fused kernel will be kInput type, and, the GPU code is emitted through 
// IrEmitterUnnested::EmitInputFusibleNonStridedSlices
//
// In theory, the pattern in case 1 could also be fused into the case2 target graph,
// but we prefer to fuse into kLoop type, because the codegen for it does not have the
// slicing range check cost introduced by case 2 pattern.
// 
```