### PR TITLE
Modify the data type of the operator parameter under tf.math.

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -288,7 +288,10 @@ def argmax_v2(input, axis=None, output_type=dtypes.int64, name=None):
   <tf.Tensor: shape=(), dtype=int64, numpy=0>
 
   Args:
-    input: A `Tensor`.
+    input: A `Tensor`. Must be one of the following types: `float32`, `float64`,
+      `int32`, `uint8`, `int16`, `int8`, `complex64`, `int64`, `qint8`,
+      `quint8`, `qint32`, `bfloat16`, `uint16`, `complex128`, `half`, `uint32`,
+      `uint64`,`bool`.
     axis: An integer, the axis to reduce across. Default to 0.
     output_type: An optional output dtype (`tf.int32` or `tf.int64`). Defaults
       to `tf.int64`.
@@ -330,7 +333,7 @@ def argmin_v2(input, axis=None, output_type=dtypes.int64, name=None):
     input: A `Tensor`. Must be one of the following types: `float32`, `float64`,
       `int32`, `uint8`, `int16`, `int8`, `complex64`, `int64`, `qint8`,
       `quint8`, `qint32`, `bfloat16`, `uint16`, `complex128`, `half`, `uint32`,
-      `uint64`.
+      `uint64`,`bool`.
     axis: A `Tensor`. Must be one of the following types: `int32`, `int64`.
       int32 or int64, must be in the range `-rank(input), rank(input))`.
       Describes which axis of the input Tensor to reduce across. For vectors,

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -396,8 +396,8 @@ def abs(x, name=None):  # pylint: disable=redefined-builtin
          [6.60492241]])>
 
   Args:
-    x: A `Tensor` or `SparseTensor` of type `float16`, `float32`, `float64`,
-      `int32`, `int64`, `complex64` or `complex128`.
+    x: A `Tensor` or `SparseTensor` of type `bfloat16`, `half`, `float32`, `float64`,
+      `int8`,`int16`,`int32` or `int64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -770,8 +770,7 @@ def sign(x, name=None):
   numpy=array([0.70710678+0.70710678j, 0.        +0.j        ])>
 
   Args:
-   x: A Tensor. Must be one of the following types: bfloat16, half, float32,
-     float64, int32, int64, complex64, complex128.
+   x: A Tensor. Must be one of the following types: bfloat16, half, float, double, int8, int16, int32, int64, complex64, complex128.
    name: A name for the operation (optional).
 
   Returns:
@@ -924,7 +923,7 @@ def round(x, name=None):  # pylint: disable=redefined-builtin
   ```
 
   Args:
-    x: A `Tensor` of type `float16`, `float32`, `float64`, `int32`, or `int64`.
+    x: A `Tensor` of type : `bfloat16`, `half`, `float32`, `float64`, `int8`, `int16`, `int32`, `int64`, `complex64`, `complex128`.
     name: A name for the operation (optional).
 
   Returns:
@@ -4041,8 +4040,7 @@ def add(x, y, name=None):
 
   Args:
     x: A `tf.Tensor`. Must be one of the following types: bfloat16, half,
-      float32, float64, uint8, int8, int16, int32, int64, complex64, complex128,
-      string.
+      float32, float64, uint8, uint16, int8, int16, int32, int64, complex64, complex128.
     y: A `tf.Tensor`. Must have the same type as x.
     name: A name for the operation (optional)
   """
@@ -4239,8 +4237,7 @@ def sigmoid(x, name=None):
         dtype=float32)>
 
   Args:
-    x: A Tensor with type `float16`, `float32`, `float64`, `complex64`, or
-      `complex128`.
+    x: A Tensor with type `bfloat16`, `half`, `float32`, `float64`, `complex64`, `complex128`.
     name: A name for the operation (optional).
 
   Returns:
@@ -4273,7 +4270,7 @@ def log_sigmoid(x, name=None):
   we use `y = -tf.nn.softplus(-x)`.
 
   Args:
-    x: A Tensor with type `float32` or `float64`.
+    x: A Tensor with type :`bfloat16`, `half`, `float32`, `float64`, `int8`, `int16`, `int32`, `int64`, `complex64`, `complex128`.
     name: A name for the operation (optional).
 
   Returns:
@@ -4361,9 +4358,9 @@ def cumsum(x, axis=0, exclusive=False, reverse=False, name=None):
   numpy=array([18, 14,  8,  0], dtype=int32)>
 
   Args:
-    x: A `Tensor`. Must be one of the following types: `float32`, `float64`,
-      `int64`, `int32`, `uint8`, `uint16`, `int16`, `int8`, `complex64`,
-      `complex128`, `qint8`, `quint8`, `qint32`, `half`.
+    x: A `Tensor`. Must be one of the following types: `float32`, `float64`, `int32`,
+    `uint8`, `int16`, `int8`, `complex64`, `int64`, `qint8`, `quint8`, `qint32`, `bfloat16`,
+    `uint16`, `complex128`, `half`, `uint32`, `uint64`.
     axis: A `Tensor` of type `int32` (default: 0). Must be in the range
       `[-rank(x), rank(x))`.
     exclusive: If `True`, perform exclusive cumsum.
@@ -5370,9 +5367,8 @@ def xlog1py(x, y, name=None):
   <tf.Tensor: shape=(), dtype=float32, numpy=0.>
 
   Args:
-    x: A `tf.Tensor` of type `half`, `float32`, `float64`, `complex64`,
-      `complex128`
-    y: A `tf.Tensor` of type `half`, `float32`, `float64`, `complex64`,
+    x: A `tf.Tensor` of type `half`, `float32`, `float64`, `complex64`, `complex128`.
+    y: A `tf.Tensor` of type `half`, `float32`, `float64`, `complex64`, `complex128`.
       `complex128`
     name: A name for the operation (optional).
 
@@ -5467,7 +5463,7 @@ def ceil(x, name=None):
 
   Args:
     x: A `tf.Tensor`. Must be one of the following types: `bfloat16`, `half`,
-      `float32`, `float64`. `int32`
+      `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -5612,8 +5608,7 @@ def rsqrt(x, name=None):
   numpy=array([0.707, inf, nan], dtype=float32)>
 
   Args:
-    x: A `tf.Tensor`. Must be one of the following types: `bfloat16`, `half`,
-      `float32`, `float64`.
+    x: A `tf.Tensor`. Must be one of the following types: `bfloat16`, `half`, `float`, `double`, `complex64`, `complex128`.
     name: A name for the operation (optional).
 
   Returns:
@@ -5644,7 +5639,7 @@ def acos(x, name=None):
 
   Args:
     x: A `Tensor`. Must be one of the following types: `bfloat16`, `half`,
-      `float32`, `float64`, `complex64`, `complex128`.
+      `float32`, `float64`,`int8`,`int16`,`int32`, `int64`, `complex64`, `complex128`.
     name: A name for the operation (optional).
 
   Returns:

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -144,7 +144,7 @@ def expint(x, name=None):
 
   Args:
     x: A `Tensor` or `SparseTensor`. Must be one of the following types:
-      `float32`, `float64`.
+      `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -175,7 +175,7 @@ def fresnel_cos(x, name=None):
 
   Args:
     x: A `Tensor` or `SparseTensor`. Must be one of the following types:
-      `float32`, `float64`.
+      `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -205,7 +205,7 @@ def fresnel_sin(x, name=None):
 
   Args:
     x: A `Tensor` or `SparseTensor`. Must be one of the following types:
-      `float32`, `float64`.
+      `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -235,7 +235,7 @@ def spence(x, name=None):
 
   Args:
     x: A `Tensor` or `SparseTensor`. Must be one of the following types:
-      `float32`, `float64`.
+      `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -263,8 +263,7 @@ def bessel_i0(x, name=None):
   array([1.26606588, 1.06348337, 1.06348337, 1.26606588], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -290,8 +289,7 @@ def bessel_i0e(x, name=None):
   array([0.46575961, 0.64503527, 0.64503527, 0.46575961], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -319,8 +317,7 @@ def bessel_i1(x, name=None):
   array([-0.5651591 , -0.25789431,  0.25789431,  0.5651591 ], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -346,8 +343,7 @@ def bessel_i1e(x, name=None):
   array([-0.20791042, -0.15642083,  0.15642083,  0.20791042], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -375,8 +371,7 @@ def bessel_k0(x, name=None):
   array([0.92441907, 0.42102444, 0.11389387, 0.01115968], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -402,8 +397,7 @@ def bessel_k0e(x, name=None):
   array([1.52410939, 1.14446308, 0.84156822, 0.60929767], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -431,8 +425,7 @@ def bessel_k1(x, name=None):
   array([1.65644112, 0.60190723, 0.13986588, 0.0124835 ], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -458,8 +451,7 @@ def bessel_k1e(x, name=None):
   array([2.73100971, 1.63615349, 1.03347685, 0.68157595], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -485,8 +477,7 @@ def bessel_j0(x, name=None):
   array([ 0.93846981,  0.76519769,  0.22389078, -0.39714981], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -512,8 +503,7 @@ def bessel_j1(x, name=None):
   array([ 0.24226846,  0.44005059,  0.57672481, -0.06604333], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -539,8 +529,7 @@ def bessel_y0(x, name=None):
   array([-0.44451873,  0.08825696,  0.51037567, -0.01694074], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:
@@ -566,8 +555,7 @@ def bessel_y1(x, name=None):
   array([-1.47147239, -0.78121282, -0.10703243,  0.39792571], dtype=float32)
 
   Args:
-    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `half`,
-      `float32`, `float64`.
+    x: A `Tensor` or `SparseTensor`. Must be one of the following types: `bfloat16`, `half`, `float32`, `float64`.
     name: A name for the operation (optional).
 
   Returns:


### PR DESCRIPTION
Modify the official document information of the operator under tf.math, specifically, modify the data type of the operator parameter.
For details, please refer to https://github.com/tensorflow/tensorflow/issues/58739