### PR TITLE
Fix bug in bi-directional RNN

### DIFF
--- a/tensorflow/lite/kernels/bidirectional_sequence_rnn.cc
+++ b/tensorflow/lite/kernels/bidirectional_sequence_rnn.cc
@@ -359,8 +359,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
     TF_LITE_ENSURE_OK(
         context, GetOutputSafe(context, node, kBwOutputTensor, &bw_output));
     TfLiteIntArray* bw_output_size_array = TfLiteIntArrayCreate(3);
-    bw_output_size_array->data[0] = batch_size;
-    bw_output_size_array->data[1] = max_time;
+    bw_output_size_array->data[0] = (time_major) ? max_time : batch_size;
+    bw_output_size_array->data[1] = (time_major) ? batch_size : max_time;
     bw_output_size_array->data[2] = bw_num_units;
     TF_LITE_ENSURE_OK(context, context->ResizeTensor(context, bw_output,
                                                      bw_output_size_array));


### PR DESCRIPTION
setup batchsize and timestamp according to the time major config

Signed-off-by: xiang.zhang <xiang.zhang@verisilicon.com>