### PR TITLE
Fix the endianness issue in lite/kernels:bucketize_test on s390x

### DIFF
--- a/tensorflow/lite/kernels/bucketize.cc
+++ b/tensorflow/lite/kernels/bucketize.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/internal/tensor.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
+#include "flatbuffers/flatbuffers.h"  // from @flatbuffers
 
 namespace tflite {
 namespace ops {
@@ -41,6 +42,12 @@ struct OpData {
 void* Init(TfLiteContext* context, const char* buffer, size_t length) {
   auto* op_data = new OpData();
   const auto* params = reinterpret_cast<const TfLiteBucketizeParams*>(buffer);
+
+  if(!FLATBUFFERS_LITTLEENDIAN){
+    int32_t *p = reinterpret_cast<int32_t*>(const_cast<float*>(params->boundaries));
+    for (size_t i = 0; i < params->num_boundaries; i++, p++)
+      *p = flatbuffers::EndianSwap(*p);
+  }
 
   op_data->boundaries = params->boundaries;
   op_data->num_boundaries = params->num_boundaries;

--- a/tensorflow/lite/tools/evaluation/BUILD
+++ b/tensorflow/lite/tools/evaluation/BUILD
@@ -70,18 +70,12 @@ cc_library_with_stable_tflite_abi(
         "//tensorflow/lite/tools/delegates:delegate_provider_lib",
     ],
     tflite_deps_selects = [{
-        # XNNPACK does not support s390x
-        # (see <https://github.com/tensorflow/tensorflow/pull/51655>).
-        "//tensorflow:linux_s390x": [],
         "//tensorflow/lite:tflite_with_xnnpack_explicit_false": [],
         "//conditions:default": [
             "//tensorflow/lite/core/shims:xnnpack_plugin",
         ],
     }],
     deps = select({
-        # XNNPACK does not support s390x
-        # (see <https://github.com/tensorflow/tensorflow/pull/51655>).
-        "//tensorflow:linux_s390x": [],
         "//tensorflow/lite:tflite_with_xnnpack_explicit_false": [],
         "//conditions:default": [
             "//tensorflow/lite/delegates/xnnpack:xnnpack_delegate_hdrs_only",


### PR DESCRIPTION
Test case `//tensorflow/lite/kernels:bucketize_test` fails on s390x due to the endianness issue. The cause is that the boundaries value of the `BucketizeOpModel` is in little-endian format after the model initialization, even on s390x (big-endian arch) machines.
 
This PR fixes this issue by byte swapping the boundaries value in `Init()` function when the host arch is big-endian. The code change will not cause any regressions.

Signed-off-by: Kun-Lu <kun.lu@ibm.com>