### PR TITLE
Xla exception changes

### DIFF
--- a/tensorflow/c/tf_status.h
+++ b/tensorflow/c/tf_status.h
@@ -57,6 +57,7 @@ typedef enum TF_Code {
   TF_INTERNAL = 13,
   TF_UNAVAILABLE = 14,
   TF_DATA_LOSS = 15,
+  TF_XLA_INTERNAL = 21,
 } TF_Code;
 
 // --------------------------------------------------------------------------

--- a/tensorflow/compiler/xla/runtime/errors.h
+++ b/tensorflow/compiler/xla/runtime/errors.h
@@ -16,11 +16,12 @@ limitations under the License.
 #ifndef TENSORFLOW_COMPILER_XLA_RUNTIME_ERRORS_H_
 #define TENSORFLOW_COMPILER_XLA_RUNTIME_ERRORS_H_
 
+#include <exception>
 #include <string>
 
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
-
+#include <iostream>
 namespace xla {
 namespace runtime {
 
@@ -35,6 +36,26 @@ absl::Status InternalError(const absl::FormatSpec<Args...>& format,
                            const Args&... args) {
   return absl::InternalError(absl::StrFormat(format, args...));
 }
+
+/*
+class XlaError : public std::exception {
+protected:
+    char *message;
+public:
+    XlaError(char *msg) : message(msg) {}
+    virtual const char * what () {
+        return message;
+    }
+};
+
+class XlaInvalidArgumentError : public XlaError {
+public:
+    XlaInvalidArgumentError(char *msg) : XlaError(msg) {}
+    virtual const char * what () {
+        return message;
+    }
+};
+*/
 
 }  // namespace runtime
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/cpu/cpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/cpu/cpu_compiler.cc
@@ -226,7 +226,6 @@ void LoadMLIRDialects(mlir::MLIRContext& context) {
 }  // namespace
 
 namespace xla {
-
 namespace {
 
 bool UseMlirHloLowering(bool use_mlir, HloModule* module) {
@@ -1193,6 +1192,7 @@ std::vector<ComputationToEmit> SubcomputationEmissionOrder(
 
 StatusOr<std::unique_ptr<CpuExecutable>>
 CpuCompiler::CompileLegacyCpuExecutable(std::unique_ptr<HloModule> module) {
+  return stream_executor::port::XLAInternalError("Vinay Induce Error in tensorflow/compiler/xla/service/cpu/cpu_compiler.cc:1196. End of error.\n");
   ModuleHook pre_optimization_ir_hook;
   ModuleHook post_optimization_ir_hook;
   std::tie(pre_optimization_ir_hook, post_optimization_ir_hook) =

--- a/tensorflow/compiler/xla/stream_executor/lib/status.h
+++ b/tensorflow/compiler/xla/stream_executor/lib/status.h
@@ -40,6 +40,12 @@ inline Status InvalidArgumentError(absl::string_view message) {
 inline Status InternalError(absl::string_view message) {
   return Status(error::INTERNAL, message);
 }
+
+inline Status XLAInternalError(absl::string_view message) {
+  std::cout << "This error created by Vinay!!!!!!" << std::endl;
+  return Status(error::XLAINTERNAL, message);
+}
+
 inline Status FailedPreconditionError(absl::string_view message) {
   return Status(error::FAILED_PRECONDITION, message);
 }

--- a/tensorflow/python/lib/core/py_exception_registry.cc
+++ b/tensorflow/python/lib/core/py_exception_registry.cc
@@ -55,7 +55,8 @@ void PyExceptionRegistry::Init(PyObject* code_to_exc_type_map) {
                                       TF_UNIMPLEMENTED,
                                       TF_INTERNAL,
                                       TF_UNAVAILABLE,
-                                      TF_DATA_LOSS};
+                                      TF_DATA_LOSS,
+                                      TF_XLA_INTERNAL};
   for (TF_Code code : kAllCodes) {
     CHECK(singleton_->exc_types_.find(code) != singleton_->exc_types_.end())
         << error::Code_Name(static_cast<error::Code>(code))

--- a/tensorflow/tsl/protobuf/error_codes.proto
+++ b/tensorflow/tsl/protobuf/error_codes.proto
@@ -141,7 +141,7 @@ enum Code {
 
   // Unrecoverable data loss or corruption.
   DATA_LOSS = 15;
-
+  XLAINTERNAL = 21;
   // An extra enum entry to prevent people from writing code that
   // fails to compile when a new code is added.
   //


### PR DESCRIPTION
To add new error codes to be used in Status objects arising from XLA specific code. I would like to create new custom Python exceptions according to the new error codes being used. What additional changes do I need to do to achieve this?