### PR TITLE
Fix for building failure due to wrong icu sha256

### DIFF
--- a/third_party/icu/workspace.bzl
+++ b/third_party/icu/workspace.bzl
@@ -11,7 +11,7 @@ def repo():
     third_party_http_archive(
         name = "icu",
         strip_prefix = "icu-release-62-1",
-        sha256 = "e15ffd84606323cbad5515bf9ecdf8061cc3bf80fb883b9e6aa162e485aa9761",
+        sha256 = "86b85fbf1b251d7a658de86ce5a0c8f34151027cc60b01e1b76f167379acf181",
         urls = [
             "https://mirror.bazel.build/github.com/unicode-org/icu/archive/release-62-1.tar.gz",
             "https://github.com/unicode-org/icu/archive/release-62-1.tar.gz",


### PR DESCRIPTION
Build r1.13 from source, error logs as below

```zsh
ERROR: Analysis of target '//tensorflow/tools/pip_package:build_pip_package' failed; build aborted: no such package '@icu//': java.io.IOException: Error downloading [https://mirror.bazel.build/github.com/unicode-org/icu/archive/release-62-1.tar.gz, https://github.com/unicode-org/icu/archive/release-62-1.tar.gz] to /data/qiaojunlong/.cache/bazel/_bazel_qiaojunlong/10608086353116d1a788ecfb9cbd8e25/external/icu/release-62-1.tar.gz: Checksum was 86b85fbf1b251d7a658de86ce5a0c8f34151027cc60b01e1b76f167379acf181 but wanted e15ffd84606323cbad5515bf9ecdf8061cc3bf80fb883b9e6aa162e485aa9761
INFO: Elapsed time: 60.073s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (229 packages loaded, 8097 targets configured)
```

Change hard-coded sha256 will fix this.