### PR TITLE
[mlir] Revise GetMlirOpNameFromOpCode for custom/while

### DIFF
--- a/tensorflow/compiler/mlir/lite/flatbuffer_operator.cc
+++ b/tensorflow/compiler/mlir/lite/flatbuffer_operator.cc
@@ -65,14 +65,8 @@ StatusOr<mlir::StringAttr> GetPaddingAttr(TfLitePadding pad_params,
 std::string mlir::GetMlirOpNameFromOpCode(
     const tflite::OperatorCodeT& op_code) {
   auto builtin_code = tflite::GetBuiltinCode(&op_code);
-  if (builtin_code == tflite::BuiltinOperator_CUSTOM) {
-    return std::string("tfl.custom");
-  }
   if (builtin_code == tflite::BuiltinOperator_IF) {
     return std::string("tf.If");
-  }
-  if (builtin_code == tflite::BuiltinOperator_WHILE) {
-    return std::string("tfl.while");
   }
 
   llvm::StringRef op_name(tflite::EnumNameBuiltinOperator(builtin_code));


### PR DESCRIPTION
This will revise GetMlirOpNameFromOpCode method to follow default name from EnumNameBuiltinOperator for custom and while as tfl dialect supports them.