### PR TITLE
Fix for building failure due to lacking of io_bazel_rules_docker

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,13 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
+    strip_prefix = "rules_docker-0.7.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
+)
+
 # Load tf_repositories() before loading dependencies for other repository so
 # that dependencies like com_google_protobuf won't be overridden.
 load("//tensorflow:workspace.bzl", "tf_repositories")


### PR DESCRIPTION
Fix for building failure due to lacking of io_bazel_rules_docker