### PR TITLE
Flip --incompatible_enforce_config_setting_visibility in .bazelrc to prevent regression

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -149,6 +149,11 @@ build --experimental_cc_shared_library
 # cc_shared_library ensures no library is linked statically more than once.
 build --experimental_link_static_libraries_once=false
 
+# Prevent regressions on those two incompatible changes
+# TODO: remove those flags when they are flipped in the default Bazel version TF uses.
+build --incompatible_enforce_config_setting_visibility
+build --incompatible_config_setting_private_default_visibility
+
 # Default options should come above this line.
 
 # Allow builds using libc++ as a linker library

--- a/.bazelrc
+++ b/.bazelrc
@@ -152,7 +152,8 @@ build --experimental_link_static_libraries_once=false
 # Prevent regressions on those two incompatible changes
 # TODO: remove those flags when they are flipped in the default Bazel version TF uses.
 build --incompatible_enforce_config_setting_visibility
-build --incompatible_config_setting_private_default_visibility
+# TODO: also enable this flag after fixing the visbility violations
+# build --incompatible_config_setting_private_default_visibility
 
 # Default options should come above this line.
 

--- a/tensorflow/tsl/BUILD
+++ b/tensorflow/tsl/BUILD
@@ -79,6 +79,7 @@ selects.config_setting_group(
         ":macos_x86_64_with_framework_shared_object",
         ":macos_arm64_with_framework_shared_object",
     ],
+    visibility = ["//visibility:public"],
 )
 
 # This should be removed after Tensorflow moves to cc_shared_library
@@ -356,6 +357,7 @@ selects.config_setting_group(
         ":linux_aarch64",
         ":linux_armhf",
     ],
+    visibility = ["//visibility:public"],
 )
 
 # TODO(jakeharmon): Remove equivalent from tensorflow/BUILD

--- a/tensorflow/tsl/BUILD
+++ b/tensorflow/tsl/BUILD
@@ -31,6 +31,7 @@ alias(
         "@local_config_cuda//:is_cuda_enabled",
         "@local_config_cuda//cuda:using_clang",
     ),
+    visibility = ["//visibility:public"],
 )
 
 selects.config_setting_group(
@@ -39,6 +40,7 @@ selects.config_setting_group(
         ":is_cuda_enabled",
         ":oss",
     ],
+    visibility = ["//visibility:public"],
 )
 
 # Crosses between framework_shared_object and a bunch of other configurations


### PR DESCRIPTION
Related: https://github.com/bazelbuild/bazel/issues/12932 and https://github.com/bazelbuild/bazel/issues/12933