### PR TITLE
[Linaro:ARM_CI] Enable running of tests tagged with oss_serial

### DIFF
--- a/tensorflow/python/eager/benchmarks/resnet50/BUILD
+++ b/tensorflow/python/eager/benchmarks/resnet50/BUILD
@@ -43,6 +43,7 @@ cuda_py_test(
     shard_count = 4,
     tags = [
         "no_windows",  # TODO(b/141617449): needs investigation
+	"no_pip",
         "optonly",
         "oss_serial",
         "v1only",
@@ -61,6 +62,7 @@ cuda_py_test(
     shard_count = 7,
     tags = [
         "no_windows",  # TODO(b/141617449): needs investigation
+	"no_pip",
         "optonly",
         "oss_serial",
         "v1only",
@@ -82,6 +84,7 @@ cuda_py_test(
     shard_count = 4,
     tags = [
         "no_windows",  # TODO(b/141617449): needs investigation
+	"no_pip",
         "noasan",
         "nomsan",
         "notsan",

--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -20,4 +20,5 @@ ARM_SKIP_TESTS="-//tensorflow/lite/... \
 -//tensorflow/python/data/kernel_tests:iterator_test \
 -//tensorflow/python/kernel_tests/nn_ops:atrous_conv2d_test \
 -//tensorflow/python/kernel_tests/nn_ops:conv_ops_test \
--//tensorflow/python/training:server_lib_test"
+-//tensorflow/python/training:server_lib_test \
+-//tensorflow/python/debug/lib:source_remote_test"

--- a/tensorflow/tools/ci_build/builds/pip_new.sh
+++ b/tensorflow/tools/ci_build/builds/pip_new.sh
@@ -523,6 +523,7 @@ run_test_with_bazel() {
 
   if [[ "${IS_OSS_SERIAL}" == "1" ]]; then
     remove_test_filter_tag -no_oss
+    remove_test_filter_tag -oss_serial
     add_test_filter_tag oss_serial
   else
     add_test_filter_tag -oss_serial

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -63,8 +63,8 @@ export TF_TEST_FLAGS="${TF_BUILD_FLAGS} \
     --test_lang_filters=py --flaky_test_attempts=3 --test_size_filters=small,medium \
     --test_output=errors --verbose_failures=true --test_keep_going"
 export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} ${ARM_SKIP_TESTS}"
-export TF_PIP_TESTS="test_pip_virtualenv_clean"
-export TF_TEST_FILTER_TAGS="-no_oss,-oss_serial,-v1only,-benchmark-test,-no_aarch64"
+export TF_PIP_TESTS="test_pip_virtualenv_clean test_pip_virtualenv_oss_serial"
+export TF_TEST_FILTER_TAGS="-no_oss,-v1only,-benchmark-test,-no_aarch64"
 export TF_PIP_TEST_ROOT="pip_test"
 export TF_AUDITWHEEL_TARGET_PLAT="manylinux2014"
 


### PR DESCRIPTION
Some tests are tagged with oss_serial because they need to be run serially ie one after the other. This is to prevent any potential conflicts particularly over use of network ports.

See https://github.com/tensorflow/tensorflow/issues/46602