### PR TITLE
[NVIDIA XLA] Use 256x256 matmul to more robustly trigger TF32 in relevant tests.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/mlir_gemm_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/mlir_gemm_test.cc
@@ -48,6 +48,29 @@ class GemmTest : public MlirGpuTestBase {
                                       {ToUint8Span(&arg0), ToUint8Span(&arg1)})
         .value();
   }
+
+  std::vector<std::vector<uint8_t>> Run256x256Gemm(
+      std::vector<float> arg0, std::vector<float> arg1,
+      std::string matmul_options = "") {
+    std::string mlir_text = absl::StrCat(
+        R"(
+      module attributes {hlo.unique_id = 0 : i32} {
+        func.func @main(%arg0: memref<256x256xf32> {lmhlo.params = 0 : index},
+                   %arg1: memref<256x256xf32> {lmhlo.params = 1 : index},
+                   %arg2: memref<256x256xf32> {lmhlo.output_index = dense<[0]> : tensor<1xindex>}) attributes {
+                       result_xla_shape = "(f32[65536]) "
+                   } {
+          "lmhlo_gpu.gemm"(%arg0, %arg1, %arg2) {alpha_imag = 0.000000e+00 : f64, alpha_real = 1.000000e+00 : f64, beta = 0.000000e+00 : f64, batch_size = 1 : i64, lhs_stride = 65536 : i64, rhs_stride = 65536 : i64, op_type = "", op_name = "", dot_dimension_numbers = #mhlo.dot<lhs_contracting_dimensions = [1], rhs_contracting_dimensions = [0]>)",
+        matmul_options,
+        R"(} : (memref<256x256xf32>, memref<256x256xf32>, memref<256x256xf32>) -> ()
+          "lmhlo.terminator"() : () -> ()
+        }
+      })");
+
+    return RunMlirTextWithHostBuffers(mlir_text,
+                                      {ToUint8Span(&arg0), ToUint8Span(&arg1)})
+        .value();
+  }
 };
 
 TEST_F(GemmTest, SimpleCase1) {
@@ -59,33 +82,39 @@ TEST_F(GemmTest, SimpleCase1) {
               ElementsAreArray<float>({11, 16, 19, 28}));
 }
 
+std::vector<float> diag_matrix(size_t dim, float diag_value) {
+  std::vector<float> r(dim * dim);
+  for (size_t i = 0; i < dim; ++i) {
+    for (size_t j = 0; j < dim; ++j) {
+      size_t index = i * dim + j;
+      r[index] = (i == j) ? diag_value : 0.0f;
+    }
+  }
+  return r;
+}
+
 TEST_F(GemmTest, GemmPrecisionDefault) {
-  std::vector<float> arg0 = {0x1.fffffep+0, 0, 0, 0x1.fffffep+0};
-  std::vector<float> arg1 = {0x1.fffffep+0, 0, 0, 0x1.fffffep+0};
-  auto outputs = Run2x2Gemm(
-      arg0, arg1,
+  auto outputs = Run256x256Gemm(
+      diag_matrix(256, 0x1.fffffep+0), diag_matrix(256, 0x1.fffffep+0),
       R"(, precision_config = [#mhlo<precision DEFAULT>, #mhlo<precision DEFAULT>])");
   ASSERT_EQ(1, outputs.size());
   auto stream = BorrowStream();
   if (stream->GetCudaComputeCapability().IsAtLeast(
           stream_executor::CudaComputeCapability::AMPERE)) {
-    EXPECT_THAT(FromUint8Span<float>(outputs[0]),
-                ElementsAreArray<float>({4, 0, 0, 4}));
+    EXPECT_THAT(FromUint8Span<float>(outputs[0]), diag_matrix(256, 4.0f));
   } else {
     EXPECT_THAT(FromUint8Span<float>(outputs[0]),
-                ElementsAreArray<float>({0x1.fffffcp+1, 0, 0, 0x1.fffffcp+1}));
+                diag_matrix(256, 0x1.fffffcp+1));
   }
 }
 
 TEST_F(GemmTest, GemmPrecisionHighest) {
-  std::vector<float> arg0 = {0x1.fffffep+0, 0, 0, 0x1.fffffep+0};
-  std::vector<float> arg1 = {0x1.fffffep+0, 0, 0, 0x1.fffffep+0};
-  auto outputs = Run2x2Gemm(
-      arg0, arg1,
+  auto outputs = Run256x256Gemm(
+      diag_matrix(256, 0x1.fffffep+0), diag_matrix(256, 0x1.fffffep+0),
       R"(, precision_config = [#mhlo<precision HIGH>, #mhlo<precision HIGHEST>])");
   ASSERT_EQ(1, outputs.size());
   EXPECT_THAT(FromUint8Span<float>(outputs[0]),
-              ElementsAreArray<float>({0x1.fffffcp+1, 0, 0, 0x1.fffffcp+1}));
+              diag_matrix(256, 0x1.fffffcp+1));
 }
 
 TEST_F(GemmTest, GemmBatchedPrecisionHighest) {

--- a/tensorflow/compiler/xla/service/gpu/tests/mlir_gemm_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/mlir_gemm_test.cc
@@ -83,11 +83,9 @@ TEST_F(GemmTest, SimpleCase1) {
 }
 
 std::vector<float> diag_matrix(size_t dim, float diag_value) {
-  std::vector<float> r(dim * dim);
+  std::vector<float> r(dim * dim, 0.0f);
   for (size_t i = 0; i < dim; ++i) {
-    for (size_t j = 0; j < dim; ++j) {
-      size_t index = i * dim + j;
-      r[index] = (i == j) ? diag_value : 0.0f;
+      r[i * dim + i] = diag_value;
     }
   }
   return r;


### PR DESCRIPTION
The 2x2 matmul used in the mlir_gemm_test would not result in TF32 evaluation on some Ampere-class GPUs (such as A16). Unfortunately, the cublas APIs do not guarantee that TF32 will be used in any particular case. Here we increase the dimension of the TF32-specific tests cases to 256x256, which empirically results in TF32 evaluation on all TF32-capable GPUs.