### PR TITLE
Documentation: Fix broken Classify CIFAR-10 with XLA build

### DIFF
--- a/tensorflow/compiler/xla/g3doc/tutorials/autoclustering_xla.ipynb
+++ b/tensorflow/compiler/xla/g3doc/tutorials/autoclustering_xla.ipynb
@@ -70,7 +70,7 @@
       "source": [
         "This tutorial trains a TensorFlow model to classify the [CIFAR-10](https://en.wikipedia.org/wiki/CIFAR-10) dataset, and we compile it using XLA.\n",
         "\n",
-        "Load and normalize the dataset using the [TensorFlow Datasets](https://tensorflow.org/datasets) API:"
+        "You will load and normalize the dataset using the [TensorFlow Datasets (TFDS)](https://tensorflow.org/datasets) API. First, install/upgrade TensorFlow and TFDS:"
       ]
     },
     {
@@ -81,7 +81,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install tensorflow_datasets"
+        "!pip install -U -q tensorflow tensorflow_datasets"
       ]
     },
     {
@@ -190,7 +190,7 @@
       "outputs": [],
       "source": [
         "def compile_model(model):\n",
-        "  opt = tf.keras.optimizers.RMSprop(learning_rate=0.0001, decay=1e-6)\n",
+        "  opt = tf.keras.optimizers.RMSprop(learning_rate=0.0001)\n",
         "  model.compile(loss='categorical_crossentropy',\n",
         "                optimizer=opt,\n",
         "                metrics=['accuracy'])\n",


### PR DESCRIPTION
- Upgrade TF to 2.11 (Colab uses 2.9.2)
- Use the new Keras Optimizer API (TF 2.10+)
  - This fixes the broken build on https://www.tensorflow.org/xla/tutorials/autoclustering_xla
  - fyi Not recommending users to use keras.optimizers.legacy