### PR TITLE
Refusal to convert segments with a large number of inputs.

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/utils/trt_int8_calibrator.cc
+++ b/tensorflow/compiler/tf2tensorrt/utils/trt_int8_calibrator.cc
@@ -66,13 +66,15 @@ bool TRTInt8Calibrator::setBatch(const std::unordered_map<string, void*>& data,
     }
     const auto& d = devptr->second;
 
-    // TODO(sami,aaroey): Need to figure out a way to ensure synchronization
-    // between stream, perhaps using a tensor?
-    auto status = cudaMemcpyAsync(d.first, it.second, d.second,
-                                  cudaMemcpyDeviceToDevice, stream);
-    if (status != cudaSuccess) {
-      LOG(FATAL) << "cudaMemcpy " << engine_name_ << " for '" << it.first
-                 << "' failed with " << status;
+    if (it.second != nullptr) {
+      // TODO(sami,aaroey): Need to figure out a way to ensure synchronization
+      // between stream, perhaps using a tensor?
+      auto status = cudaMemcpyAsync(d.first, it.second, d.second,
+                                    cudaMemcpyDeviceToDevice, stream);
+      if (status != cudaSuccess) {
+        LOG(FATAL) << "cudaMemcpy " << engine_name_ << " for '" << it.first
+                   << "' failed with " << status;
+      }
     }
   }
 


### PR DESCRIPTION
TF-TRT disables the conversion of segments that have more than the specified number of input nodes. Its value is determined by the **TF_TRT_MAX_NUM_INPUT_NODES** environment variable, which has a default value of 500.

Converting segments with a large amount of input nodes requires a huge amount of memory, especially when calibrating. In some cases, it could lead to the crashes due to lack of memory.

This PR also contains the fix for [NVBug3815811](https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/3815811) **Unsupported data type encountered in input 0 during calibration** by @DEKHTIARJonathan 