### PR TITLE
[NVIDIA XLA] add a new mode that hlo_parser can parse computations without module header.

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -304,7 +304,11 @@ class HloParserImpl : public HloParser {
   bool ParseSingleInstruction(HloModule* module);
 
   // Parses a module, returning false if an error occurred.
-  bool ParseHloModule(HloModule* module);
+  // if `parse_module_without_header` is true, the parsed text is sequence of 
+  // computations, and assume computation with `ENTRY` annotation or the last computation
+  // as module's entry computation, also using the entry computation's parameter and `ROOT`
+  // instruction's layout as module's layout. 
+  bool ParseHloModule(HloModule* module, bool parse_module_without_header = false);
 
   bool ParseComputations(HloModule* module);
   bool ParseComputation(HloComputation** entry_computation);
@@ -650,9 +654,14 @@ bool HloParserImpl::TokenError(absl::string_view msg) {
 
 Status HloParserImpl::Run(HloModule* module) {
   lexer_.Lex();
-  if (lexer_.GetKind() == TokKind::kw_HloModule) {
+  if ((lexer_.GetKind() == TokKind::kw_HloModule) ||
+      (lexer_.GetKind() == TokKind::kw_ENTRY) ||
+      (lexer_.LookAhead() == TokKind::kLbrace)) {
     // This means that the text contains a full HLO module.
-    if (!ParseHloModule(module)) {
+    bool parse_module_without_header = 
+      (lexer_.GetKind() == TokKind::kw_HloModule) ? 
+      false : true;
+    if (!ParseHloModule(module, parse_module_without_header)) {
       return InvalidArgument(
           "Syntax error when trying to parse the text as a HloModule:\n%s",
           GetError());
@@ -918,18 +927,9 @@ bool HloParserImpl::ParseCustomCallApiVersion(CustomCallApiVersion* result) {
 }
 
 // ::= 'HloModule' name computations
-bool HloParserImpl::ParseHloModule(HloModule* module) {
-  if (lexer_.GetKind() != TokKind::kw_HloModule) {
-    return TokenError("expects HloModule");
-  }
-  // Eat 'HloModule'
-  lexer_.Lex();
-
+bool HloParserImpl::ParseHloModule(HloModule* module, 
+                                   bool parse_module_without_header) {
   std::string name;
-  if (!ParseName(&name)) {
-    return false;
-  }
-
   std::optional<bool> is_scheduled;
   std::optional<AliasingData> aliasing_data;
   std::optional<bool> alias_passthrough_params;
@@ -944,13 +944,34 @@ bool HloParserImpl::ParseHloModule(HloModule* module) {
   attrs["entry_computation_layout"] = {/*required=*/false,
                                        AttrTy::kComputationLayout,
                                        &entry_computation_layout};
-  if (!ParseAttributes(attrs)) {
-    return false;
+
+  if (!parse_module_without_header) {
+    if (lexer_.GetKind() != TokKind::kw_HloModule) {
+      return TokenError("expects HloModule");
+    }
+    // Eat 'HloModule'
+    lexer_.Lex();
+
+    if (!ParseName(&name)) {
+      return false;
+    }
+    if (!ParseAttributes(attrs)) {
+      return false;
+    }
+    module->set_name(name);
   }
-  module->set_name(name);
+
   if (!ParseComputations(module)) {
     return false;
   }
+
+  if (parse_module_without_header) {
+    name = "module_" + module->entry_computation()->name();
+    entry_computation_layout = ComputationLayout(
+      module->entry_computation()->ComputeProgramShape(), /*ignore_layouts*/false);
+  } 
+
+  module->set_name(name);
 
   if (is_scheduled.has_value() && *is_scheduled) {
     TF_CHECK_OK(module->set_schedule(ScheduleFromInstructionOrder(module)));

--- a/tensorflow/compiler/xla/service/hlo_parser_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser_test.cc
@@ -4208,5 +4208,71 @@ ENTRY test {
               "Layout has physical shape, but is not for a sparse array")));
 }
 
+TEST_F(HloParserTest, ParseSingleComputation) {
+  const std::string original = R"(
+test {
+  ROOT root =  f32[1,64,10,128]{1,0,2,3} parameter(0)
+})";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnUnverifiedModule(original));
+  EXPECT_TRUE(module->entry_computation()->ComputeProgramShape().parameters()[0].has_layout());
+  EXPECT_TRUE(module->entry_computation()->ComputeProgramShape().result().has_layout());
+  EXPECT_EQ(module->entry_computation()->ComputeProgramShape().parameters()[0].layout(),
+            Layout({1, 0, 2, 3}));
+  EXPECT_EQ(module->entry_computation()->ComputeProgramShape().result().layout(),
+            Layout({1, 0, 2, 3}));
+}
+
+TEST_F(HloParserTest, ParseSingleEntryComputation) {
+  const std::string original = R"(
+ENTRY test {
+  ROOT root =  f32[1,64,10,128]{1,0,2,3} parameter(0)
+})";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnUnverifiedModule(original));
+  EXPECT_TRUE(module->entry_computation()->ComputeProgramShape().parameters()[0].has_layout());
+  EXPECT_TRUE(module->entry_computation()->ComputeProgramShape().result().has_layout());
+  EXPECT_EQ(module->entry_computation()->ComputeProgramShape().parameters()[0].layout(),
+            Layout({1, 0, 2, 3}));
+  EXPECT_EQ(module->entry_computation()->ComputeProgramShape().result().layout(),
+            Layout({1, 0, 2, 3}));
+}
+
+TEST_F(HloParserTest, ParseMultiComputations) {
+  const std::string original = R"(
+comp1 {
+  ROOT root =  f32[1,64,10,128]{3,2,1,0} parameter(0)
+}
+comp2 {
+  ROOT root =  f32[1,64,10,128]{1,0,2,3} parameter(0)
+})";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnUnverifiedModule(original));
+  EXPECT_TRUE(module->entry_computation()->ComputeProgramShape().parameters()[0].has_layout());
+  EXPECT_TRUE(module->entry_computation()->ComputeProgramShape().result().has_layout());
+  EXPECT_EQ(module->entry_computation()->ComputeProgramShape().parameters()[0].layout(),
+            Layout({1, 0, 2, 3}));
+  EXPECT_EQ(module->entry_computation()->ComputeProgramShape().result().layout(),
+            Layout({1, 0, 2, 3}));
+}
+
+TEST_F(HloParserTest, ParseMultiComputationsWithEntry) {
+  const std::string original = R"(
+ENTRY comp1 {
+  ROOT root =  f32[1,64,10,128]{1,0,2,3} parameter(0)
+}
+comp2 {
+  ROOT root =  f32[1,64,10,128]{3,2,1,0} parameter(0)
+})";
+  TF_ASSERT_OK_AND_ASSIGN(auto module,
+                          ParseAndReturnUnverifiedModule(original));
+  EXPECT_TRUE(module->entry_computation()->ComputeProgramShape().parameters()[0].has_layout());
+  EXPECT_TRUE(module->entry_computation()->ComputeProgramShape().result().has_layout());
+  EXPECT_EQ(module->entry_computation()->ComputeProgramShape().parameters()[0].layout(),
+            Layout({1, 0, 2, 3}));
+  EXPECT_EQ(module->entry_computation()->ComputeProgramShape().result().layout(),
+            Layout({1, 0, 2, 3}));
+}
+
 }  // namespace
 }  // namespace xla

--- a/tensorflow/compiler/xla/tools/replay_computation.cc
+++ b/tensorflow/compiler/xla/tools/replay_computation.cc
@@ -136,6 +136,8 @@ StatusOr<std::unique_ptr<LocalExecutable>> CompileExecutable(
   }
   ExecutableBuildOptions exec_build_options;
   *exec_build_options.mutable_debug_options() = GetDebugOptionsFromFlags();
+  exec_build_options.set_result_layout(
+    Shape(computation.proto().host_program_shape().result()));
   TF_ASSIGN_OR_RETURN(
       auto executables,
       client->Compile(computation, argument_layout_ptrs, exec_build_options));


### PR DESCRIPTION
This PR add a new mode in hlo_parser that can parse a HloModule from sequence of computation text without module header, the computation annotated with `ENTRY` or the last computation if no `ENTRY` annotation will be used as the entry computation of the module.  Also, will force the module's input/output layout as entry computation's parameter and ROOT instruction layout. 

With this updates, XLA tool `replay_computation` can just run a computation by just specifying the computation dump out.  It is useful/convient when we just want `replay_computation` to focus on the perf of a specific computation, or fused kernel (use fused computation as replay_computation input), so just need to copy the target computation HLO texts and run with `replay_computation`  

