### PR TITLE
build: tell CMake about dependency on MhloToArithmeticConversion

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/mhlo/transforms/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/mhlo/transforms/CMakeLists.txt
@@ -104,6 +104,7 @@ add_mlir_library(MhloToThloConversion
 
   LINK_LIBS PUBLIC
   MhloDialect
+  MhloToArithmeticConversion
   MhloTypeConversion
   THLODialect
   MLIRIR
@@ -238,6 +239,7 @@ add_mlir_library(MhloToLinalg
   HloToLinalgUtils
   LmhloDialect
   MhloDialect
+  MhloToArithmeticConversion
   MhloTypeConversion
   MLIRBufferizationDialect
   MLIRComplexDialect


### PR DESCRIPTION
Both legalize_mhlo_to_thlo.cc (i.e. the `MhloToThloConversion` library)
and legalize_to_linalg.cc (i.e. the `MhloToLinalg` library) call 
`populateScalarHloToArithmeticConversionPatterns()` in
hlo_legalize_to_arithmetic.cc (in the `MhloToArithmeticConversion`
library), but these dependencies were not expressed in the CMake rules,
causing build errors in downstream consumers of MHLO.  This patch
updates the build rules to make the dependencies explicit.