### PR TITLE
[NVIDIA TF] Fix an issue of empty output tensor when using bf16

### DIFF
--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -990,7 +990,7 @@ operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
   LaunchConv2DBackpropFilterOpImpl<Eigen::bfloat16>(
       ctx, use_cudnn, cudnn_use_autotune, casted_out_backprop, casted_input,
       row_dilation, col_dilation, row_stride, col_stride, padding,
-      explicit_paddings, &casted_filter_backprop, data_format);
+      explicit_paddings, filter_backprop, data_format);
 }
 
 // Forward declarations of the functor specializations for GPU.

--- a/tensorflow/core/kernels/conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops.cc
@@ -955,11 +955,12 @@ operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
   auto* stream = ctx->op_device_context()->stream();
   const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
       se::CudaComputeCapability::AMPERE);
-  Tensor casted_input = input;
-  Tensor casted_out_backprop = out_backprop;
-  Tensor casted_filter_backprop = *filter_backprop;
 
   if (cast_to_float) {
+    Tensor casted_input = input;
+    Tensor casted_out_backprop = out_backprop;
+    Tensor casted_filter_backprop = *filter_backprop;
+
     const GPUDevice& device = ctx->eigen_device<GPUDevice>();
     functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
     OP_REQUIRES_OK(ctx,
@@ -988,9 +989,9 @@ operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
   }
 
   LaunchConv2DBackpropFilterOpImpl<Eigen::bfloat16>(
-      ctx, use_cudnn, cudnn_use_autotune, casted_out_backprop, casted_input,
-      row_dilation, col_dilation, row_stride, col_stride, padding,
-      explicit_paddings, filter_backprop, data_format);
+      ctx, use_cudnn, cudnn_use_autotune, out_backprop, input, row_dilation,
+      col_dilation, row_stride, col_stride, padding, explicit_paddings,
+      filter_backprop, data_format);
 }
 
 // Forward declarations of the functor specializations for GPU.

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -497,10 +497,13 @@ void LaunchConv2DBackpropInputOp<GPUDevice, Eigen::bfloat16>::operator()(
     return;
   }
 
+  // Need to use the address of in_backprop rather than casted_in_backprop,
+  // because the in_backprop might be replaced by a new allocated tensor during
+  // the function call.
   LaunchConv2DBackpropInputOpGpuImpl<Eigen::bfloat16>(
       ctx, use_cudnn, cudnn_use_autotune, casted_out_backprop, casted_filter,
       row_dilation, col_dilation, row_stride, col_stride, padding,
-      explicit_paddings, &casted_in_backprop, data_format);
+      explicit_paddings, in_backprop, data_format);
 }
 
 // Forward declarations of the functor specializations for GPU.

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -465,11 +465,12 @@ void LaunchConv2DBackpropInputOp<GPUDevice, Eigen::bfloat16>::operator()(
   auto* stream = ctx->op_device_context()->stream();
   const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
       se::CudaComputeCapability::AMPERE);
-  Tensor casted_out_backprop = out_backprop;
-  Tensor casted_filter = filter;
-  Tensor casted_in_backprop = *in_backprop;
 
   if (cast_to_float) {
+    Tensor casted_out_backprop = out_backprop;
+    Tensor casted_filter = filter;
+    Tensor casted_in_backprop = *in_backprop;
+
     const GPUDevice& device = ctx->eigen_device<GPUDevice>();
     functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
     OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, out_backprop.shape(),
@@ -497,13 +498,10 @@ void LaunchConv2DBackpropInputOp<GPUDevice, Eigen::bfloat16>::operator()(
     return;
   }
 
-  // Need to use the address of in_backprop rather than casted_in_backprop,
-  // because the in_backprop might be replaced by a new allocated tensor during
-  // the function call.
   LaunchConv2DBackpropInputOpGpuImpl<Eigen::bfloat16>(
-      ctx, use_cudnn, cudnn_use_autotune, casted_out_backprop, casted_filter,
-      row_dilation, col_dilation, row_stride, col_stride, padding,
-      explicit_paddings, in_backprop, data_format);
+      ctx, use_cudnn, cudnn_use_autotune, out_backprop, filter, row_dilation,
+      col_dilation, row_stride, col_stride, padding, explicit_paddings,
+      in_backprop, data_format);
 }
 
 // Forward declarations of the functor specializations for GPU.

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1580,11 +1580,12 @@ struct LaunchConvBackpropInputOp<Eigen::bfloat16> {
     auto* stream = ctx->op_device_context()->stream();
     const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
         se::CudaComputeCapability::AMPERE);
-    Tensor casted_out_backprop = out_backprop;
-    Tensor casted_filter = filter;
-    Tensor casted_in_backprop = *in_backprop;
 
     if (cast_to_float) {
+      Tensor casted_out_backprop = out_backprop;
+      Tensor casted_filter = filter;
+      Tensor casted_in_backprop = *in_backprop;
+
       const GPUDevice& device = ctx->eigen_device<GPUDevice>();
       functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
       OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, out_backprop.shape(),
@@ -1612,8 +1613,8 @@ struct LaunchConvBackpropInputOp<Eigen::bfloat16> {
     }
 
     LaunchConvBackpropInputOpImpl<Eigen::bfloat16>(
-        ctx, cudnn_use_autotune, casted_out_backprop, casted_filter, dilation,
-        strides, padding, in_backprop, data_format);
+        ctx, cudnn_use_autotune, out_backprop, filter, dilation, strides,
+        padding, in_backprop, data_format);
   }
 };
 
@@ -2035,40 +2036,42 @@ struct LaunchConvBackpropFilterOp<Eigen::bfloat16> {
       auto* stream = ctx->op_device_context()->stream();
       const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
           se::CudaComputeCapability::AMPERE);
-      Tensor casted_input = input;
-      Tensor casted_out_backprop = out_backprop;
-      Tensor casted_filter_backprop = *filter_backprop;
 
       if (cast_to_float) {
-      const GPUDevice& device = ctx->eigen_device<GPUDevice>();
-      functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
-      OP_REQUIRES_OK(
-          ctx, ctx->allocate_temp(DT_FLOAT, input.shape(), &casted_input));
-      cast(device, casted_input.template flat<float>(),
-           input.template flat<Eigen::bfloat16>());
+        Tensor casted_input = input;
+        Tensor casted_out_backprop = out_backprop;
+        Tensor casted_filter_backprop = *filter_backprop;
 
-      OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, out_backprop.shape(),
-                                             &casted_out_backprop));
-      cast(device, casted_out_backprop.template flat<float>(),
-           out_backprop.template flat<Eigen::bfloat16>());
+        const GPUDevice& device = ctx->eigen_device<GPUDevice>();
+        functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
+        OP_REQUIRES_OK(
+            ctx, ctx->allocate_temp(DT_FLOAT, input.shape(), &casted_input));
+        cast(device, casted_input.template flat<float>(),
+             input.template flat<Eigen::bfloat16>());
 
-      OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, filter_backprop->shape(),
-                                             &casted_filter_backprop));
+        OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, out_backprop.shape(),
+                                               &casted_out_backprop));
+        cast(device, casted_out_backprop.template flat<float>(),
+             out_backprop.template flat<Eigen::bfloat16>());
 
-      LaunchConvBackpropFilterOpImpl<float>(
-          ctx, cudnn_use_autotune, casted_input, casted_out_backprop, dilation,
-          stride, padding, &casted_filter_backprop, data_format);
+        OP_REQUIRES_OK(ctx,
+                       ctx->allocate_temp(DT_FLOAT, filter_backprop->shape(),
+                                          &casted_filter_backprop));
 
-      functor::CastFunctor<GPUDevice, Eigen::bfloat16, float> cast_back;
-      const Tensor& casted_filter_backprop_const = casted_filter_backprop;
-      cast_back(device, filter_backprop->template flat<Eigen::bfloat16>(),
-                casted_filter_backprop_const.template flat<float>());
-      return;
+        LaunchConvBackpropFilterOpImpl<float>(
+            ctx, cudnn_use_autotune, casted_input, casted_out_backprop,
+            dilation, stride, padding, &casted_filter_backprop, data_format);
+
+        functor::CastFunctor<GPUDevice, Eigen::bfloat16, float> cast_back;
+        const Tensor& casted_filter_backprop_const = casted_filter_backprop;
+        cast_back(device, filter_backprop->template flat<Eigen::bfloat16>(),
+                  casted_filter_backprop_const.template flat<float>());
+        return;
       }
 
       LaunchConvBackpropFilterOpImpl<Eigen::bfloat16>(
-          ctx, cudnn_use_autotune, casted_input, casted_out_backprop, dilation,
-          stride, padding, filter_backprop, data_format);
+          ctx, cudnn_use_autotune, input, out_backprop, dilation, stride,
+          padding, filter_backprop, data_format);
     }
 };
 

--- a/tensorflow/core/kernels/conv_grad_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_ops_3d.cc
@@ -1613,7 +1613,7 @@ struct LaunchConvBackpropInputOp<Eigen::bfloat16> {
 
     LaunchConvBackpropInputOpImpl<Eigen::bfloat16>(
         ctx, cudnn_use_autotune, casted_out_backprop, casted_filter, dilation,
-        strides, padding, &casted_in_backprop, data_format);
+        strides, padding, in_backprop, data_format);
   }
 };
 
@@ -2068,7 +2068,7 @@ struct LaunchConvBackpropFilterOp<Eigen::bfloat16> {
 
       LaunchConvBackpropFilterOpImpl<Eigen::bfloat16>(
           ctx, cudnn_use_autotune, casted_input, casted_out_backprop, dilation,
-          stride, padding, &casted_filter_backprop, data_format);
+          stride, padding, filter_backprop, data_format);
     }
 };
 

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -1146,7 +1146,7 @@ void LaunchConv2DOp<GPUDevice, Eigen::bfloat16>::operator()(
   LaunchConv2DOpImpl<Eigen::bfloat16>(
       ctx, use_cudnn, cudnn_use_autotune, casted_input, casted_filter,
       row_dilation, col_dilation, row_stride, col_stride, padding,
-      explicit_paddings, &casted_out, data_format);
+      explicit_paddings, output, data_format);
 }
 
 // Forward declarations of the functor specializations for GPU.

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -1111,11 +1111,12 @@ void LaunchConv2DOp<GPUDevice, Eigen::bfloat16>::operator()(
   auto* stream = ctx->op_device_context()->stream();
   const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
       se::CudaComputeCapability::AMPERE);
-  Tensor casted_input = input_param;
-  Tensor casted_filter = filter;
-  Tensor casted_out = *output;
 
   if (cast_to_float) {
+    Tensor casted_input = input_param;
+    Tensor casted_filter = filter;
+    Tensor casted_out = *output;
+
     const GPUDevice& device = ctx->eigen_device<GPUDevice>();
     functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
     OP_REQUIRES_OK(
@@ -1144,9 +1145,9 @@ void LaunchConv2DOp<GPUDevice, Eigen::bfloat16>::operator()(
   }
 
   LaunchConv2DOpImpl<Eigen::bfloat16>(
-      ctx, use_cudnn, cudnn_use_autotune, casted_input, casted_filter,
-      row_dilation, col_dilation, row_stride, col_stride, padding,
-      explicit_paddings, output, data_format);
+      ctx, use_cudnn, cudnn_use_autotune, input_param, filter, row_dilation,
+      col_dilation, row_stride, col_stride, padding, explicit_paddings, output,
+      data_format);
 }
 
 // Forward declarations of the functor specializations for GPU.

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -560,11 +560,12 @@ struct LaunchConvOp<GPUDevice, Eigen::bfloat16> {
     auto* stream = ctx->op_device_context()->stream();
     const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
         se::CudaComputeCapability::AMPERE);
-    Tensor casted_input = input_param;
-    Tensor casted_filter = filter;
-    Tensor casted_out = *output;
 
     if (cast_to_float) {
+      Tensor casted_input = input_param;
+      Tensor casted_filter = filter;
+      Tensor casted_out = *output;
+
       const GPUDevice& device = ctx->eigen_device<GPUDevice>();
       functor::CastFunctor<GPUDevice, float, Eigen::bfloat16> cast;
       OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, input_param.shape(),
@@ -591,9 +592,9 @@ struct LaunchConvOp<GPUDevice, Eigen::bfloat16> {
       return;
     }
 
-    LaunchConvOpImpl<Eigen::bfloat16>(ctx, cudnn_use_autotune, casted_input,
-                                      casted_filter, dilations, strides,
-                                      padding, data_format, output);
+    LaunchConvOpImpl<Eigen::bfloat16>(ctx, cudnn_use_autotune, input_param,
+                                      filter, dilations, strides, padding,
+                                      data_format, output);
   }
 };
 

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -593,7 +593,7 @@ struct LaunchConvOp<GPUDevice, Eigen::bfloat16> {
 
     LaunchConvOpImpl<Eigen::bfloat16>(ctx, cudnn_use_autotune, casted_input,
                                       casted_filter, dilations, strides,
-                                      padding, data_format, &casted_out);
+                                      padding, data_format, output);
   }
 };
 


### PR DESCRIPTION
While testing the conv+bf16, we noticed many tests would fail on the A100 GPUs with errors like `AssertionError: 1.0 not less than 0.003`. After some digging, it turns out that we should have passed the original address of the output tensor to the helper function where the address might be updated to point to a new allocated tensor. Instead, we mistakenly passed the address of a local cast tensor and this will leave the original output address unchanged no matter what.

This PR fixed this issue.

cc. @nluehr @pjannaty 

