### PR TITLE
[ROCm] fixed gpu_kernel_tiling_test on RowReductionCorrectShmemUsage's fusion part

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_codegen_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_codegen_test.cc
@@ -77,7 +77,10 @@ std::string GpuCodegenTest::MakePlatformSpecificLlvm(absl::string_view input) {
             ? "%[[LOGICAL_T2:.*]] = extractvalue { i1, i64 } %[[LOGICAL_T1]], 0"
             : "0"},
        {"BR_CAL", is_built_with_rocm_ ? "br i1 %[[LOGICAL_T2]],"
-                                      : "br i1 %[[LOGICAL_T0]]"}});
+                                      : "br i1 %[[LOGICAL_T0]]"},
+       {
+        "FUSION_LDS" , is_built_with_rocm_ ? "llvm.amdgcn.kernel.fusion.lds"
+                                               : "0"}});
 }
 
 }  // namespace gpu

--- a/tensorflow/compiler/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gpu_kernel_tiling_test.cc
@@ -815,12 +815,14 @@ TEST_F(GpuKernelTilingTest, RowReductionCorrectShmemUsage) {
   )";
   auto hlo_module = ParseAndReturnVerifiedModule(kHloString).value();
   auto expected_ir = is_built_with_rocm_ ? R"(
-; CHECK: initial_value_addr = internal unnamed_addr addrspace({{[0-9]*}}) global [1024 x float] poison, align 4
+; CHECK: %FUSION_LDS.t = type { [1 x [1 x [2 x float]]] }
+; CHECK: @FUSION_LDS = internal addrspace(3) global %FUSION_LDS.t undef, align 8
   )"
                                          : R"(
 ; CHECK: shared_cache = private unnamed_addr addrspace({{[0-9]*}}) global [1 x [1 x [2 x float]]]
   )";
-  CompileAndVerifyIr(std::move(hlo_module), expected_ir,
+  CompileAndVerifyIr(std::move(hlo_module), 
+                      MakePlatformSpecificLlvm(expected_ir),
                      /*match_optimized_ir=*/true);
 }
 


### PR DESCRIPTION
LLVM upstream has updated the fusion part, the original one doesn't correct.

@cheshire 

Thanks
