### PR TITLE
Detect AVX512 on Windows

### DIFF
--- a/tensorflow/core/platform/cpu_feature_guard.cc
+++ b/tensorflow/core/platform/cpu_feature_guard.cc
@@ -31,7 +31,7 @@ namespace port {
 namespace {
 
 // If the CPU feature isn't present, log a fatal error.
-void CheckFeatureOrDie(CPUFeature feature, const std::string& feature_name) {
+void CheckFeatureOrDie(CPUFeature feature, const string& feature_name) {
   if (!TestCPUFeature(feature)) {
     const auto error_msg =
         "The TensorFlow library was compiled to use " + feature_name +
@@ -52,8 +52,8 @@ void CheckFeatureOrDie(CPUFeature feature, const std::string& feature_name) {
 }
 
 // Check if CPU feature is included in the TensorFlow binary.
-void CheckIfFeatureUnused(CPUFeature feature, const std::string& feature_name,
-                          std::string& missing_instructions) {
+void CheckIfFeatureUnused(CPUFeature feature, const string& feature_name,
+                          string& missing_instructions) {
   if (TestCPUFeature(feature)) {
     missing_instructions.append(" ");
     missing_instructions.append(feature_name);
@@ -125,17 +125,7 @@ absl::once_flag g_cpu_feature_guard_warn_once_flag;
 
 void InfoAboutUnusedCPUFeatures() {
   absl::call_once(g_cpu_feature_guard_warn_once_flag, [] {
-    std::string missing_instructions;
-#if defined(_MSC_VER) && !defined(__clang__)
-
-#ifndef __AVX__
-    CheckIfFeatureUnused(CPUFeature::AVX, "AVX", missing_instructions);
-#endif  // __AVX__
-#ifndef __AVX2__
-    CheckIfFeatureUnused(CPUFeature::AVX2, "AVX2", missing_instructions);
-#endif  // __AVX2__
-
-#else  // if defined(_MSC_VER) && !defined(__clang__)
+    string missing_instructions;
 
 #ifndef __SSE__
     CheckIfFeatureUnused(CPUFeature::SSE, "SSE", missing_instructions);
@@ -188,7 +178,6 @@ void InfoAboutUnusedCPUFeatures() {
 #ifndef __FMA__
     CheckIfFeatureUnused(CPUFeature::FMA, "FMA", missing_instructions);
 #endif  // __FMA__
-#endif  // else of if defined(_MSC_VER) && !defined(__clang__)
     if (!missing_instructions.empty()) {
       LOG(INFO) << "This TensorFlow binary is optimized with "
                 << "oneAPI Deep Neural Network Library (oneDNN) "

--- a/tensorflow/core/platform/cpu_feature_guard.cc
+++ b/tensorflow/core/platform/cpu_feature_guard.cc
@@ -53,7 +53,7 @@ void CheckFeatureOrDie(CPUFeature feature, const std::string& feature_name) {
 
 // Check if CPU feature is included in the TensorFlow binary.
 void CheckIfFeatureUnused(CPUFeature feature, const std::string& feature_name,
-                          string& missing_instructions) {
+                          std::string& missing_instructions) {
   if (TestCPUFeature(feature)) {
     missing_instructions.append(" ");
     missing_instructions.append(feature_name);
@@ -125,7 +125,7 @@ absl::once_flag g_cpu_feature_guard_warn_once_flag;
 
 void InfoAboutUnusedCPUFeatures() {
   absl::call_once(g_cpu_feature_guard_warn_once_flag, [] {
-    string missing_instructions;
+    std::string missing_instructions;
 
 #ifndef __SSE__
     CheckIfFeatureUnused(CPUFeature::SSE, "SSE", missing_instructions);

--- a/tensorflow/core/platform/cpu_feature_guard.cc
+++ b/tensorflow/core/platform/cpu_feature_guard.cc
@@ -31,7 +31,7 @@ namespace port {
 namespace {
 
 // If the CPU feature isn't present, log a fatal error.
-void CheckFeatureOrDie(CPUFeature feature, const string& feature_name) {
+void CheckFeatureOrDie(CPUFeature feature, const std::string& feature_name) {
   if (!TestCPUFeature(feature)) {
     const auto error_msg =
         "The TensorFlow library was compiled to use " + feature_name +
@@ -52,7 +52,7 @@ void CheckFeatureOrDie(CPUFeature feature, const string& feature_name) {
 }
 
 // Check if CPU feature is included in the TensorFlow binary.
-void CheckIfFeatureUnused(CPUFeature feature, const string& feature_name,
+void CheckIfFeatureUnused(CPUFeature feature, const std::string& feature_name,
                           string& missing_instructions) {
   if (TestCPUFeature(feature)) {
     missing_instructions.append(" ");


### PR DESCRIPTION
Detect ISA for Windows

It was found that tf 2.10 on windows would not detect the AVX512, and only the AVX, AVX2, but when run with the same machine, using WSL(Windows subsystem Linux), the system would detect AVX512.

Fix:
To detect Intel Supported Architectures, previously windows code was not checking for AVX512. Now, both Windows and Linux share the same code and check for all architectures