### PR TITLE
Updating Flatbuffer version to 2.0.8  in flatbuffers.cmake

### DIFF
--- a/tensorflow/lite/tools/cmake/modules/flatbuffers.cmake
+++ b/tensorflow/lite/tools/cmake/modules/flatbuffers.cmake
@@ -23,7 +23,7 @@ OverridableFetchContent_Declare(
   flatbuffers
   GIT_REPOSITORY https://github.com/google/flatbuffers
   # Sync with tensorflow/third_party/flatbuffers/workspace.bzl
-  GIT_TAG v2.0.6
+  GIT_TAG v2.0.8
   GIT_SHALLOW TRUE
   GIT_PROGRESS TRUE
   SOURCE_DIR "${CMAKE_BINARY_DIR}/flatbuffers"


### PR DESCRIPTION
Fixes #58884
Bumping Flatbuffer version to 2.0.8 to Support New NDK versions including 25b, as 19c is outdated and It would give more flexibility to new NDK tool chain android developers by updating Flatbuffer version to 2.0.8

Attached [colab gist](https://colab.sandbox.google.com/gist/mohantym/72111bf65cbc62627bbd3de3de8db7a8/tensorflow-ranking.ipynb#scrollTo=_IQp1_gflTaC) as proof of work for reference.