### PR TITLE
Added Autoparallel optimizer in config.py

### DIFF
--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -237,7 +237,7 @@ def set_optimizer_experimental_options(options):
       - disable_meta_optimizer: Disable the entire meta optimizer.
       - min_graph_nodes: The minimum number of nodes in a graph to optimizer.
         For smaller graphs, optimization is skipped.
-      - Autoparallel optimizer - Automatically parallelizes graphs by splitting along the batch dimension
+      - auto_parallel : Automatically parallelizes graphs by splitting along the batch dimension
   """
   context.context().set_optimizer_experimental_options(options)
 

--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -237,6 +237,7 @@ def set_optimizer_experimental_options(options):
       - disable_meta_optimizer: Disable the entire meta optimizer.
       - min_graph_nodes: The minimum number of nodes in a graph to optimizer.
         For smaller graphs, optimization is skipped.
+      - Autoparallel optimizer - Automatically parallelizes graphs by splitting along the batch dimension
   """
   context.context().set_optimizer_experimental_options(options)
 

--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -237,7 +237,8 @@ def set_optimizer_experimental_options(options):
       - disable_meta_optimizer: Disable the entire meta optimizer.
       - min_graph_nodes: The minimum number of nodes in a graph to optimizer.
         For smaller graphs, optimization is skipped.
-      - auto_parallel : Automatically parallelizes graphs by splitting along the batch dimension
+      - auto_parallel: Automatically parallelizes graphs by splitting along 
+        the batch dimension
   """
   context.context().set_optimizer_experimental_options(options)
 


### PR DESCRIPTION
 Autoparallel optimizer available as one of the Graph Optimizer as per [documentation](https://www.tensorflow.org/guide/graph_optimization#available_graph_optimizers) but for `tf.config.optimizer.set_experimental_options` it is not listed in the Arg options.But as the per this [comment](https://discuss.tensorflow.org/t/enable-grapplers-autoparallel-pass/1084/2) it is already available but not documented
Hence made a PR as Doc Bug.
Fixes #49507