### PR TITLE
Handle error properly in NodeDefBuilder::Finalize

### DIFF
--- a/tensorflow/core/framework/node_def_builder.cc
+++ b/tensorflow/core/framework/node_def_builder.cc
@@ -235,6 +235,12 @@ Status NodeDefBuilder::Finalize(NodeDef* node_def, bool consume) {
           (*errors_ptr)[0], " while building NodeDef '", node_def_.name(),
           "' using ", SummarizeOpDef(*op_def_));
     } else {
+      if (op_def_ == nullptr) {
+        return errors::InvalidArgument(errors_ptr->size(),
+                                       " errors while building NodeDef '",
+                                       node_def_.name(), "':\n",
+                                       absl::StrJoin(*errors_ptr, "\n"));
+      }
       return errors::InvalidArgument(
           errors_ptr->size(), " errors while building NodeDef '",
           node_def_.name(), "' using ", SummarizeOpDef(*op_def_), ":\n",


### PR DESCRIPTION
Possible null dereference of `op_def_`. This case should be handled like in the if-statement higher.
This PR is part of https://github.com/tensorflow/tensorflow/pull/57892
Bug was found by [Svace static analyzer](https://www.ispras.ru/en/technologies/svace/) (more [info](https://svace.pages.ispras.ru/svace-website/en/)).