### PR TITLE
Fix null dereference from sharding_util

### DIFF
--- a/tensorflow/core/graph/graph.cc
+++ b/tensorflow/core/graph/graph.cc
@@ -944,8 +944,10 @@ std::unordered_map<std::string, Node*> Graph::BuildNodeNameIndex() const {
 }
 
 std::string Edge::DebugString() const {
-  return strings::Printf("[id=%d %s:%d -> %s:%d]", id_, src_->name().c_str(),
-                         src_output_, dst_->name().c_str(), dst_input_);
+  auto src_name = src_ ? src_->name().c_str() : "<NULL>";
+  auto dst_name = dst_ ? dst_->name().c_str() : "<NULL>";
+  return strings::Printf("[id=%d %s:%d -> %s:%d]", id_, src_name,
+                         src_output_, dst_name, dst_input_);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/graph/graph.h
+++ b/tensorflow/core/graph/graph.h
@@ -64,6 +64,7 @@ namespace tensorflow {
 class Edge;
 class EdgeSetTest;
 class Graph;
+class GraphTest;
 class GraphDef;
 class Node;
 struct OutputTensor;
@@ -446,6 +447,7 @@ class Edge {
   Edge() {}
 
   friend class EdgeSetTest;
+  friend class GraphTest;
   friend class Graph;
   Node* src_;
   Node* dst_;

--- a/tensorflow/core/graph/graph_test.cc
+++ b/tensorflow/core/graph/graph_test.cc
@@ -34,7 +34,6 @@ limitations under the License.
 #include "tensorflow/core/platform/test_benchmark.h"
 
 namespace tensorflow {
-namespace {
 
 REGISTER_OP("OneInput").Input("x: float");
 
@@ -68,6 +67,16 @@ class GraphTest : public ::testing::Test {
       out.push_back(e->dst());
     }
     EXPECT_EQ(Stringify(expected_out), Stringify(out));
+  }
+
+  Edge* BuildEdge(int id=0, Node* src=0, Node* dst=0, int x=0, int y=0) {
+    Edge* e = new Edge;
+    e->id_ = id;
+    e->src_ = src;
+    e->dst_ = dst;
+    e->src_output_ = x;
+    e->dst_input_ = y;
+    return e;
   }
 
   void VerifyGraphStats() {
@@ -153,6 +162,8 @@ class GraphTest : public ::testing::Test {
     return result;
   }
 };
+
+namespace {
 
 TEST_F(GraphTest, Constructor) {
   Node* source = graph_.source_node();
@@ -589,6 +600,30 @@ TEST_F(GraphTest, InputEdges) {
   EXPECT_EQ(error::INVALID_ARGUMENT, b->input_edges(&edges).code());
   graph_.AddEdge(a, 0, b, 1);
   TF_EXPECT_OK(b->input_edges(&edges));
+}
+
+TEST_F(GraphTest, EdgeDebugString) {
+  // Print valid edge
+  Node* a = FromNodeDef("A", "OneOutput", 0);
+  Node* b = FromNodeDef("B", "OneInput", 1);
+  auto e = graph_.AddEdge(a, 0, b, 0);
+  auto s = e->DebugString();
+  EXPECT_EQ(s, "[id=1 A:0 -> B:0]");
+
+  // Print empty edge
+  auto e1 = BuildEdge();
+  auto s1 = e1->DebugString();
+  EXPECT_EQ(s1, "[id=0 <NULL>:0 -> <NULL>:0]");
+
+  // Print edge with null src node
+  auto e2 = BuildEdge(2, 0, b, 1, 1);
+  auto s2 = e2->DebugString();
+  EXPECT_EQ(s2, "[id=2 <NULL>:1 -> B:1]");
+
+  // Print edge with null dst node
+  auto e3 = BuildEdge(3, a, 0, 2, 1);
+  auto s3 = e3->DebugString();
+  EXPECT_EQ(s3, "[id=3 A:2 -> <NULL>:1]");
 }
 
 TEST_F(GraphTest, AddFunctionLibrary) {


### PR DESCRIPTION
`Edge::DebugString` with null `src` is called from https://github.com/tensorflow/tensorflow/blob/60e879cfee1ed3601e8ee4923dda4dcc4e88deee/tensorflow/compiler/tf2xla/sharding_util.cc#L120

In `Edge::DebugString` it dereferences `src` and `dst` without any check.
This PR is part of https://github.com/tensorflow/tensorflow/pull/57892

Bug was found by [Svace static analyzer](https://www.ispras.ru/en/technologies/svace/) (more [info](https://svace.pages.ispras.ru/svace-website/en/)).