### PR TITLE
Fix buffer overflow in summary_db_writer

### DIFF
--- a/tensorflow/core/summary/summary_db_writer.cc
+++ b/tensorflow/core/summary/summary_db_writer.cc
@@ -58,7 +58,7 @@ const uint64 kIdTiers[] = {
     0x7fffffffffffULL,  // 47-bit (5 bytes on disk)
                         // remaining bits for future use
 };
-const int kMaxIdTier = sizeof(kIdTiers) / sizeof(uint64);
+const int kMaxIdTier = sizeof(kIdTiers) / sizeof(uint64) - 1;
 const int kIdCollisionDelayMicros = 10;
 const int kMaxIdCollisions = 21;  // sum(2**i*10µs for i in range(21))~=21s
 const int64_t kAbsent = 0LL;


### PR DESCRIPTION
Variable `kMaxIdTier` is set to size of `kIdTiers[]` which is 3. At loop (https://github.com/apach301/tensorflow/blob/88f1d0042b3f495a2a721e806f0f03aca0022dd7/tensorflow/core/summary/summary_db_writer.cc#L183) `tier_` could become equal to `kMaxIdTier`, and then access to `kIdTiers[tier_]` occurs. At that moment `tier_` is 3, but max index of  `kIdTiers[]` is 2.

This PR is part of https://github.com/tensorflow/tensorflow/pull/57892

Bug was found by [Svace static analyzer](https://www.ispras.ru/en/technologies/svace/) (more [info](https://svace.pages.ispras.ru/svace-website/en/)).