### PR TITLE
Add checkers before derefence in conv Prepare()

### DIFF
--- a/tensorflow/lite/kernels/conv.cc
+++ b/tensorflow/lite/kernels/conv.cc
@@ -596,6 +596,8 @@ TfLiteStatus Prepare(KernelType kernel_type, TfLiteContext* context,
       const auto* affine_quantization =
           reinterpret_cast<TfLiteAffineQuantization*>(
               filter->quantization.params);
+      TF_LITE_ENSURE(context, affine_quantization);
+      TF_LITE_ENSURE(context, affine_quantization->scale);
       TF_LITE_ENSURE_EQ(
           context, affine_quantization->scale->size,
           filter->dims->data[affine_quantization->quantized_dimension]);


### PR DESCRIPTION
Add security checks for `affine_quantization` and `affine_quantization->scale` before dereference, because there are checks at the similar code (https://github.com/apach301/tensorflow/blob/1e7fd2f447e37761b6f6c673de77d392b6d0650d/tensorflow/lite/kernels/conv.cc#L467)

This PR is part of https://github.com/tensorflow/tensorflow/pull/57892

Bug was found by [Svace static analyzer](https://www.ispras.ru/en/technologies/svace/) (more [info](https://svace.pages.ispras.ru/svace-website/en/)).