### PR TITLE
Fix null dereference in optional_debug_tools

### DIFF
--- a/tensorflow/lite/optional_debug_tools.cc
+++ b/tensorflow/lite/optional_debug_tools.cc
@@ -499,19 +499,23 @@ void PrintInterpreterState(const Interpreter* interpreter) {
       }
       printf("  %d Input Tensors:",
              node.inputs != nullptr ? node.inputs->size : 0);
-      PrintTfLiteIntVector(
-          node.inputs,
-          /*collapse_consecutives=*/(node.delegate != nullptr));
-      PrintTotalBytesOfTensors(
-          subgraph, is_node_delegated ? TfLiteIntArrayView(&empty_int_array)
-                                      : TfLiteIntArrayView(node.inputs));
+      if (node.inputs) {
+        PrintTfLiteIntVector(
+            node.inputs,
+            /*collapse_consecutives=*/(node.delegate != nullptr));
+        PrintTotalBytesOfTensors(
+            subgraph, is_node_delegated ? TfLiteIntArrayView(&empty_int_array)
+                                        : TfLiteIntArrayView(node.inputs));
+      }
 
       printf("  %d Output Tensors:",
              node.outputs != nullptr ? node.outputs->size : 0);
-      PrintTfLiteIntVector(node.outputs);
-      PrintTotalBytesOfTensors(
-          subgraph, is_node_delegated ? TfLiteIntArrayView(&empty_int_array)
-                                      : TfLiteIntArrayView(node.outputs));
+      if (node.outputs) {
+        PrintTfLiteIntVector(node.outputs);
+        PrintTotalBytesOfTensors(
+            subgraph, is_node_delegated ? TfLiteIntArrayView(&empty_int_array)
+                                        : TfLiteIntArrayView(node.outputs));
+      }
 
       if (node.intermediates && node.intermediates->size) {
         printf("  %d Intermediate Tensors:", node.intermediates->size);


### PR DESCRIPTION
Check `inputs` and `outputs` for null before dereference, because from previous line it seems that they could be `nullptr`

This PR is part of https://github.com/tensorflow/tensorflow/pull/57892

Bug was found by [Svace static analyzer](https://www.ispras.ru/en/technologies/svace/) (more [info](https://svace.pages.ispras.ru/svace-website/en/)).