### PR TITLE
Fix copy-paste error with possible null dereference

### DIFF
--- a/tensorflow/c/c_api_function.cc
+++ b/tensorflow/c/c_api_function.cc
@@ -185,7 +185,7 @@ TF_Function* TF_GraphToFunctionWithControlOutputs(
   if (control_output_names) {
     control_output_names_vec.reserve(ncontrol_outputs);
     for (int i = 0; i < ncontrol_outputs; ++i) {
-      control_output_names_vec.push_back(string(output_names[i]));
+      control_output_names_vec.push_back(string(control_output_names[i]));
     }
   }
 


### PR DESCRIPTION
`output_names` -> `control_output_names`

This PR is part of https://github.com/tensorflow/tensorflow/pull/57892

Bug was found by [Svace static analyzer](https://www.ispras.ru/en/technologies/svace/) (more [info](https://svace.pages.ispras.ru/svace-website/en/)).