### PR TITLE
Fix null dereference in grpc_worker_service

### DIFF
--- a/tensorflow/core/distributed_runtime/rpc/grpc_worker_service.cc
+++ b/tensorflow/core/distributed_runtime/rpc/grpc_worker_service.cc
@@ -652,11 +652,12 @@ void GrpcWorker::RecvBufAsync(CallOptions* opts, const RecvBufRequest* request,
       if (hook == nullptr) {
         s = errors::Internal("Invalid null hook for key ",
                              request->buf_rendezvous_key());
-      }
-      if (!DMAHelper::CanUseDMA(hook->prod_value)) {
-        s = errors::Internal("Tensor value for key ",
-                             request->buf_rendezvous_key(),
-                             " is not of a type supported by RecvBuf");
+      } else {
+        if (!DMAHelper::CanUseDMA(hook->prod_value)) {
+          s = errors::Internal("Tensor value for key ",
+                               request->buf_rendezvous_key(),
+                               " is not of a type supported by RecvBuf");
+        }
       }
     } else {
       if (hook != nullptr) {


### PR DESCRIPTION
Call of `errors::Internal()` does not interrupt execution, so after line https://github.com/apach301/tensorflow/blob/e398ab7b776e015bd930fca7a7fc3c81864b224e/tensorflow/core/distributed_runtime/rpc/grpc_worker_service.cc#L652 `hook`  may be nullptr and is dereferenced.

This PR is part of https://github.com/tensorflow/tensorflow/pull/57892

Bug was found by [Svace static analyzer](https://www.ispras.ru/en/technologies/svace/) (more [info](https://svace.pages.ispras.ru/svace-website/en/)).