### PR TITLE
Fix possible null dereference in hlo_module_util

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_module_util.cc
+++ b/tensorflow/compiler/xla/service/hlo_module_util.cc
@@ -113,6 +113,14 @@ StatusOr<std::unique_ptr<HloModuleConfig>> CreateModuleConfig(
     config->set_seed(execution_options->seed());
     config->set_launch_id(execution_options->launch_id());
     config->set_debug_options(execution_options->debug_options());
+    if (execution_options->has_device_assignment()) {
+      TF_ASSIGN_OR_RETURN(
+          auto device_assignment,
+          DeviceAssignment::Deserialize(execution_options->device_assignment()));
+      config->set_static_device_assignment(*device_assignment);
+    }
+    config->set_alias_passthrough_params(
+        execution_options->alias_passthrough_params());
   } else {
     config->set_replica_count(default_num_replicas);
     config->set_debug_options(GetDebugOptionsFromFlags());
@@ -121,16 +129,6 @@ StatusOr<std::unique_ptr<HloModuleConfig>> CreateModuleConfig(
   if (num_threads.has_value()) {
     config->set_intra_op_parallelism_threads(*num_threads);
   }
-
-  if (execution_options != nullptr &&
-      execution_options->has_device_assignment()) {
-    TF_ASSIGN_OR_RETURN(
-        auto device_assignment,
-        DeviceAssignment::Deserialize(execution_options->device_assignment()));
-    config->set_static_device_assignment(*device_assignment);
-  }
-  config->set_alias_passthrough_params(
-      execution_options->alias_passthrough_params());
 
   if (aot_options != nullptr) {
     config->set_matrix_unit_operand_precision(


### PR DESCRIPTION
At hlo_module_util.cc:
Possible null dereference of `execution_options`. Should be checked as in the line https://github.com/apach301/tensorflow/blob/356bc3788b40b2240244262758f7ca13dd73de64/tensorflow/compiler/xla/service/hlo_module_util.cc#L125

This PR is part of https://github.com/tensorflow/tensorflow/pull/57892

Bug was found by [Svace static analyzer](https://www.ispras.ru/en/technologies/svace/) (more [info](https://svace.pages.ispras.ru/svace-website/en/)).