### PR TITLE
Fix possible null dereference in xla_launch_util.cc

### DIFF
--- a/tensorflow/compiler/jit/xla_launch_util.cc
+++ b/tensorflow/compiler/jit/xla_launch_util.cc
@@ -512,7 +512,7 @@ Status XlaComputationLaunchContext::PopulateOutputs(
   }
 
   std::shared_ptr<se::Event> definition_event;
-  if (use_multiple_streams_) {
+  if (use_multiple_streams_ && stream) {
     definition_event = std::make_shared<se::Event>(stream->parent());
     if (!definition_event->Init()) {
       return errors::Internal("Failed to initialize tensor definition event.");


### PR DESCRIPTION
Should check `stream` before dereference because it could be assigned nullptr at https://github.com/tensorflow/tensorflow/pull/57892

https://github.com/tensorflow/tensorflow/blob/db79bb42a790dfa372a953757ee00fbb83a7137b/tensorflow/compiler/jit/xla_launch_util.cc#L490

This PR is part of https://github.com/tensorflow/tensorflow/pull/57892

Bug was found by [Svace static analyzer](https://www.ispras.ru/en/technologies/svace/) (more [info](https://svace.pages.ispras.ru/svace-website/en/)).