### PR TITLE
Fix the endianness issue in `prepare-composite-functions-tf.mlir.test` on s390x

### DIFF
--- a/tensorflow/compiler/mlir/lite/utils/perception_ops_utils.cc
+++ b/tensorflow/compiler/mlir/lite/utils/perception_ops_utils.cc
@@ -187,7 +187,7 @@ LogicalResult ConvertMaxUnpoolingFunc::CreateCustomOptions(
   int32_t *p = reinterpret_cast<int32_t*>(&pool_params);
   for (size_t i = 0; i < sizeof(TfLitePoolParams)/4; i++, p++)
     *p = flatbuffers::EndianSwap(*p);
-  #endif
+#endif
 
   custom_option_buffer.assign(reinterpret_cast<char*>(&pool_params),
                               sizeof(TfLitePoolParams));

--- a/tensorflow/compiler/mlir/lite/utils/perception_ops_utils.cc
+++ b/tensorflow/compiler/mlir/lite/utils/perception_ops_utils.cc
@@ -183,7 +183,7 @@ LogicalResult ConvertMaxUnpoolingFunc::CreateCustomOptions(
   pool_params.activation = kTfLiteActNone;
   pool_params.computed.padding = TfLitePaddingValues{0, 0, 0, 0};
 
-  #if FLATBUFFERS_LITTLEENDIAN == 0
+#if FLATBUFFERS_LITTLEENDIAN == 0
   int32_t *p = reinterpret_cast<int32_t*>(&pool_params);
   for (size_t i = 0; i < sizeof(TfLitePoolParams)/4; i++, p++)
     *p = flatbuffers::EndianSwap(*p);

--- a/tensorflow/compiler/mlir/lite/utils/perception_ops_utils.cc
+++ b/tensorflow/compiler/mlir/lite/utils/perception_ops_utils.cc
@@ -183,6 +183,12 @@ LogicalResult ConvertMaxUnpoolingFunc::CreateCustomOptions(
   pool_params.activation = kTfLiteActNone;
   pool_params.computed.padding = TfLitePaddingValues{0, 0, 0, 0};
 
+  #if FLATBUFFERS_LITTLEENDIAN == 0
+  int32_t *p = reinterpret_cast<int32_t*>(&pool_params);
+  for (size_t i = 0; i < sizeof(TfLitePoolParams)/4; i++, p++)
+    *p = flatbuffers::EndianSwap(*p);
+  #endif
+
   custom_option_buffer.assign(reinterpret_cast<char*>(&pool_params),
                               sizeof(TfLitePoolParams));
   return success();


### PR DESCRIPTION
Test case `tensorflow/compiler/mlir/lite/tests:prepare-composite-functions-tf.mlir.test` fails on s390x (big-endian arch) because function `ConvertMaxUnpoolingFunc::CreateCustomOptions()` will fill the content of string `custom_option_buffer` with the cast `TfLitePoolParams` data which is in big-endian format, thus the CHECK step for the value of `custom_option` string in `MaxUnpooling2D` op will fail.
 
On the other hand, other `CreateXXXCustomOptions` functions in TensorFlow code base use `flexbuffers` which automatically stores data in little-endian format, such as the below `CreateTflFusableOpCustomOptions()` function: https://github.com/tensorflow/tensorflow/blob/15a6d0de4cb48150a7adb4984d593bdaa7b2c6c3/tensorflow/compiler/mlir/lite/transforms/prepare_composite_functions_tf.cc#L72-L99.
 
This PR fixes the test failure by byte swapping the content of string `custom_option_buffer` on big-endian platforms after it's filled to ensure it's always in little-endian format. The changes won't affect little-endian platforms.

Signed-off-by: Kun-Lu <kun.lu@ibm.com>