### PR TITLE
Fix TIMEOUT issue in `label_image_test` on s390x

### DIFF
--- a/tensorflow/lite/examples/label_image/BUILD
+++ b/tensorflow/lite/examples/label_image/BUILD
@@ -54,6 +54,7 @@ cc_library(
         "log.h",
     ],
     deps = [
+        "//tensorflow/core/platform:tstring",
         "//tensorflow/lite:builtin_op_data",
         "//tensorflow/lite:framework",
         "//tensorflow/lite:string",

--- a/tensorflow/lite/examples/label_image/bitmap_helpers.cc
+++ b/tensorflow/lite/examples/label_image/bitmap_helpers.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include <iostream>
 #include <string>
 
+#include "tensorflow/core/platform/ctstring_internal.h"
 #include "tensorflow/lite/examples/label_image/log.h"
 
 namespace tflite {
@@ -92,11 +93,15 @@ std::vector<uint8_t> read_bmp(const std::string& input_bmp_name, int* width,
   file.seekg(0, std::ios::beg);
   file.read(reinterpret_cast<char*>(img_bytes.data()), len);
   const int32_t header_size =
-      *(reinterpret_cast<const int32_t*>(img_bytes.data() + 10));
-  *width = *(reinterpret_cast<const int32_t*>(img_bytes.data() + 18));
-  *height = *(reinterpret_cast<const int32_t*>(img_bytes.data() + 22));
+      TF_le32toh(*(reinterpret_cast<const int32_t*>(
+        img_bytes.data() + 10)));
+  *width = TF_le32toh(*(reinterpret_cast<const int32_t*>(
+      img_bytes.data() + 18)));
+  *height = TF_le32toh(*(reinterpret_cast<const int32_t*>(
+      img_bytes.data() + 22)));
   const int32_t bpp =
-      *(reinterpret_cast<const int32_t*>(img_bytes.data() + 28));
+      TF_le32toh(*(reinterpret_cast<const int32_t*>(
+        img_bytes.data() + 28)));
   *channels = bpp / 8;
 
   if (s->verbose)


### PR DESCRIPTION
Test case `//tensorflow/lite/examples/label_image:label_image_test` will time out on s390x (big-endian arch) because the image meta info (such as `header_size`) parsed from `img_bytes.data()` is in little-endian format, thus the value of loop control variables becomes incorrect on s390x.
 
This PR fixes this issue by invoking macro `TF_le32toh()` for these data to convert them to big-endian format when needed.

This PR won't cause any regressions on either little-endian platforms or big-endian platforms.

Signed-off-by: Kun-Lu <kun.lu@ibm.com>