### PR TITLE
Re-fix nvidia; remove "devel" images

### DIFF
--- a/tensorflow/tools/dockerfiles/dockerfiles/gpu-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/gpu-jupyter.Dockerfile
@@ -43,8 +43,11 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub && \
     apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
-        cuda-drivers-520 \
-        cuda-11-8 \
+        cuda-cudart-dev-${CUDA/./-} \
+        cuda-nvcc-${CUDA/./-} \
+        cuda-cupti-${CUDA/./-} \
+        cuda-nvprune-${CUDA/./-} \
+        cuda-libraries-${CUDA/./-} \
         cuda-command-line-tools-${CUDA/./-} \
         libcublas-${CUDA/./-} \
         cuda-nvrtc-${CUDA/./-} \
@@ -54,9 +57,6 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
         libcusparse-${CUDA/./-} \
         curl \
         libcudnn8=${CUDNN}+cuda${CUDA} \
-        libfreetype6-dev \
-        libhdf5-serial-dev \
-        libzmq3-dev \
         pkg-config \
         software-properties-common \
         unzip

--- a/tensorflow/tools/dockerfiles/dockerfiles/gpu.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/gpu.Dockerfile
@@ -43,8 +43,11 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub && \
     apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
-        cuda-drivers-520 \
-        cuda-11-8 \
+        cuda-cudart-dev-${CUDA/./-} \
+        cuda-nvcc-${CUDA/./-} \
+        cuda-cupti-${CUDA/./-} \
+        cuda-nvprune-${CUDA/./-} \
+        cuda-libraries-${CUDA/./-} \
         cuda-command-line-tools-${CUDA/./-} \
         libcublas-${CUDA/./-} \
         cuda-nvrtc-${CUDA/./-} \
@@ -54,9 +57,6 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
         libcusparse-${CUDA/./-} \
         curl \
         libcudnn8=${CUDNN}+cuda${CUDA} \
-        libfreetype6-dev \
-        libhdf5-serial-dev \
-        libzmq3-dev \
         pkg-config \
         software-properties-common \
         unzip

--- a/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/gpu-ppc64le-jupyter.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/gpu-ppc64le-jupyter.Dockerfile
@@ -43,8 +43,11 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub && \
     apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
-        cuda-drivers-520 \
-        cuda-11-8 \
+        cuda-cudart-dev-${CUDA/./-} \
+        cuda-nvcc-${CUDA/./-} \
+        cuda-cupti-${CUDA/./-} \
+        cuda-nvprune-${CUDA/./-} \
+        cuda-libraries-${CUDA/./-} \
         cuda-command-line-tools-${CUDA/./-} \
         libcublas-${CUDA/./-} \
         cuda-nvrtc-${CUDA/./-} \
@@ -54,9 +57,6 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
         libcusparse-${CUDA/./-} \
         curl \
         libcudnn8=${CUDNN}+cuda${CUDA} \
-        libfreetype6-dev \
-        libhdf5-serial-dev \
-        libzmq3-dev \
         pkg-config \
         software-properties-common \
         unzip

--- a/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/gpu-ppc64le.Dockerfile
+++ b/tensorflow/tools/dockerfiles/dockerfiles/ppc64le/gpu-ppc64le.Dockerfile
@@ -43,8 +43,11 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub && \
     apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
-        cuda-drivers-520 \
-        cuda-11-8 \
+        cuda-cudart-dev-${CUDA/./-} \
+        cuda-nvcc-${CUDA/./-} \
+        cuda-cupti-${CUDA/./-} \
+        cuda-nvprune-${CUDA/./-} \
+        cuda-libraries-${CUDA/./-} \
         cuda-command-line-tools-${CUDA/./-} \
         libcublas-${CUDA/./-} \
         cuda-nvrtc-${CUDA/./-} \
@@ -54,9 +57,6 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
         libcusparse-${CUDA/./-} \
         curl \
         libcudnn8=${CUDNN}+cuda${CUDA} \
-        libfreetype6-dev \
-        libhdf5-serial-dev \
-        libzmq3-dev \
         pkg-config \
         software-properties-common \
         unzip

--- a/tensorflow/tools/dockerfiles/partials/ubuntu/nvidia.partial.Dockerfile
+++ b/tensorflow/tools/dockerfiles/partials/ubuntu/nvidia.partial.Dockerfile
@@ -20,8 +20,11 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub && \
     apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
-        cuda-drivers-520 \
-        cuda-11-8 \
+        cuda-cudart-dev-${CUDA/./-} \
+        cuda-nvcc-${CUDA/./-} \
+        cuda-cupti-${CUDA/./-} \
+        cuda-nvprune-${CUDA/./-} \
+        cuda-libraries-${CUDA/./-} \
         cuda-command-line-tools-${CUDA/./-} \
         libcublas-${CUDA/./-} \
         cuda-nvrtc-${CUDA/./-} \
@@ -31,9 +34,6 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
         libcusparse-${CUDA/./-} \
         curl \
         libcudnn8=${CUDNN}+cuda${CUDA} \
-        libfreetype6-dev \
-        libhdf5-serial-dev \
-        libzmq3-dev \
         pkg-config \
         software-properties-common \
         unzip

--- a/tensorflow/tools/dockerfiles/spec.yml
+++ b/tensorflow/tools/dockerfiles/spec.yml
@@ -31,7 +31,6 @@ releases:
     nightly:
         tag_specs:
             - "{nightly}{jupyter}"
-            - "{_TAG_PREFIX}{ubuntu-devel}"
     # Built per-release and pushed to tensorflow/tensorflow
     # --arg _TAG_PREFIX=<val> should be set to "1.11" (for example) or "latest".
     versioned:


### PR DESCRIPTION
Devel images are deprecated: use tensorflow/build instead.
