### PR TITLE
[xla:gpu:runtime] Fix integer overflow in GetDeviceBufferPairs

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/runtime/collectives.cc
+++ b/tensorflow/compiler/xla/service/gpu/runtime/collectives.cc
@@ -78,8 +78,8 @@ StatusOr<std::vector<DeviceBufferPair>> GetDeviceBufferPairs(
       return InvalidArgument("Unsupported device buffer pair type");
     }
 
-    int element_count = 1;
-    for (int size : source->sizes) element_count *= size;
+    int64_t element_count = 1;
+    for (int64_t size : source->sizes) element_count *= size;
     device_buffers.emplace_back(DeviceBufferPair{
         source->dtype, element_count, GetDeviceAddress(*source),
         GetDeviceAddress(*destination)});


### PR DESCRIPTION
This fixes a 32-bit integer overflow in `collectives.cc:GetDeviceBufferPairs`.
When buffers are very large, `int size` and `int element_count` might both overflow. 
Using `int64_t` instead of `int` fixes this problem.