### PR TITLE
Fix memory leak in xla::SlowOperationAlarm

### DIFF
--- a/tensorflow/compiler/xla/service/slow_operation_alarm.cc
+++ b/tensorflow/compiler/xla/service/slow_operation_alarm.cc
@@ -85,7 +85,7 @@ void SlowOperationAlarm::ScheduleAlarm(SlowOperationAlarm* alarm) {
   absl::call_once(init_flag, [] {
     ready = new absl::CondVar();
     outstanding_alarms = new std::list<SlowOperationAlarm*>();
-    (void)!tsl::Env::Default()->StartThread(
+    [[maybe_unused]] static tsl::Thread* t = tsl::Env::Default()->StartThread(
         tsl::ThreadOptions(), "SlowOperationAlarm", [] { AlarmLoop(); });
   });
 


### PR DESCRIPTION
Currently TSL threads (`tsl::Thread` and derived classes) can only be joined and it's done automatically in the destructor.

There's some threads that are essentially infinite loops (`xla::SlowOperationAlarm::AlarmLoop()` is an example), and as such these threads can't be joined (hence destructors for such thread objects can't be called)

Current way of dealing with this is to forget about the pointer returned from `tsl::Env::Default()->StartThread` (as is done for `xla::SlowOperationAlarm::AlarmLoop()` thread) but this approach produces memory leaks that are detected by AddressSanitizer. At the moment at least 75 tests from `//tensorflow/compiler/xla/tests:` fail due to exactly that cause.

The proposed solution is to add possibility to detach threads, and to join the thread in the destructor only if it's not detached. This also supports the design idea that every thread created should be either joined or detached and should not be left dangled.