### PR TITLE
[NVIDIA TF] Fix missing cuda headers in pip wheel

### DIFF
--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -207,6 +207,7 @@ function prepare_src() {
 
   mkdir -p ${TMPDIR}/third_party
   cp -R $RUNFILES/third_party/eigen3 ${TMPDIR}/third_party
+  cp -LR $RUNFILES/../local_config_cuda/cuda/_virtual_includes/cuda_headers_virtual/third_party/gpus ${TMPDIR}/third_party
 
   reorganize_includes "${TMPDIR}"
 

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -303,6 +303,7 @@ headers = (
     list(find_files('*.h', 'google/com_google_protobuf/src')) +
     list(find_files('*.inc', 'google/com_google_protobuf/src')) +
     list(find_files('*', 'third_party/eigen3')) +
+    list(find_files('*', 'third_party/gpus')) +
     list(find_files('*.h', 'tensorflow/include/external/com_google_absl')) +
     list(find_files('*.inc', 'tensorflow/include/external/com_google_absl')) +
     list(find_files('*', 'tensorflow/include/external/eigen_archive')))


### PR DESCRIPTION
We noticed that recently the cuda headers were not being included in the pip wheel, whereas previously they could be found at `/usr/local/lib/python3.8/dist-packages/tensorflow/include/third_party/gpus`. Many third party TensorFlow addons rely on these headers to build.

I couldn't find out exactly when or why they stopped getting included in the wheel, but I was able to come up with these changes to fix the issue. If anyone has an idea of what could've happened or a better solution, I would be greatly interested.