### PR TITLE
[Linaro:ARM_CI] Drop Python 3.7 build as not supported

### DIFF
--- a/.github/workflows/arm-cd.yml
+++ b/.github/workflows/arm-cd.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: [self-hosted, linux, ARM64]
     strategy:
       matrix:
-        pyver: ['3.7', '3.8', '3.9', '3.10']
+        pyver: ['3.8', '3.9', '3.10']
     steps:
       - name: Stop old running containers (if any)
         shell: bash


### PR DESCRIPTION
ARM_CD is failing because it attempts to test TensorFlow on Python 3.7 but it fails to install as it now requires at least Python 3.8 so drop the Python 3.7 build and test.