### PR TITLE
build: fix CMake rules for the MHLOTOSATransforms target

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/tosa/lib/Transforms/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/lib/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@
 
 add_mlir_library(MHLOTOSATransforms
   legalize_mhlo.cc
+  prepare_mhlo.cc
 
   DEPENDS
   MHLOTOSATransformsPassIncGen
@@ -27,4 +28,5 @@ add_mlir_library(MHLOTOSATransforms
   MLIRIR
   MLIRPass
   MLIRTransforms
+  MhloPasses
   )


### PR DESCRIPTION
A consumer of the MHLOTOSATransforms library (mhlo_tosa_opt.cc) calls
the `registerTosaPrepareMhloPassPass()` function, but this function is
absent from the MHLOTOSATransforms library since the source file
(prepare_mhlo.cc) that contains the function is not included when
building the library target.

Additionally, prepare_mhlo.cc calls the
`populateGeneralDotOpLoweringPatterns()` function, but the library
(MhloPasses) that contains this function is not linked when compiling
prepare_mhlo.cc.

This patch adds the necessary build rules to fix the above problems.