### PR TITLE
Use NHWC format for Conv with bfloat16 for NVIDIA GPU targets

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -2147,6 +2147,7 @@ xla_cc_test(
         "//tensorflow/compiler/xla/service:hlo_parser",
         "//tensorflow/compiler/xla/stream_executor/lib",
         "//tensorflow/compiler/xla/tests:hlo_test_base",
+        "//tensorflow/compiler/xla/service/gpu/tests:gpu_codegen_test",
         "//tensorflow/compiler/xla/tests:xla_internal_test_main",  # build_cleaner: keep
         "//tensorflow/tsl/platform:status_matchers",
         "@com_google_absl//absl/strings",

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -2145,9 +2145,9 @@ xla_cc_test(
         "//tensorflow/compiler/xla/service:computation_layout",
         "//tensorflow/compiler/xla/service:hlo_matchers",
         "//tensorflow/compiler/xla/service:hlo_parser",
-        "//tensorflow/compiler/xla/stream_executor/lib",
-        "//tensorflow/compiler/xla/tests:hlo_test_base",
         "//tensorflow/compiler/xla/service/gpu/tests:gpu_codegen_test",
+        "//tensorflow/compiler/xla/stream_executor/lib",        
+        "//tensorflow/compiler/xla/tests:hlo_test_base",
         "//tensorflow/compiler/xla/tests:xla_internal_test_main",  # build_cleaner: keep
         "//tensorflow/tsl/platform:status_matchers",
         "@com_google_absl//absl/strings",

--- a/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.cc
@@ -98,8 +98,8 @@ HeuristicLayoutAssignment(const HloInstruction* instr,
     return kAllNHWC;
   }
 
-  // If we're not Volta or not fp16/bfloat16, or not conv2D, the decision is easy: Use
-  // NCHW.
+  // If we're not Volta or not fp16/bfloat16, or not conv2D, the decision is
+  // easy: Use NCHW.
   const bool isFloat16 = (input_ty == F16) || (input_ty == BF16);
   if (!isFloat16 ||
       !stream_executor->GetDeviceDescription()

--- a/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment.cc
@@ -98,9 +98,10 @@ HeuristicLayoutAssignment(const HloInstruction* instr,
     return kAllNHWC;
   }
 
-  // If we're not Volta or not fp16, or not conv2D, the decision is easy: Use
+  // If we're not Volta or not fp16/bfloat16, or not conv2D, the decision is easy: Use
   // NCHW.
-  if (input_ty != F16 ||
+  const bool isFloat16 = (input_ty == F16) || (input_ty == BF16);
+  if (!isFloat16 ||
       !stream_executor->GetDeviceDescription()
            .cuda_compute_capability()
            .IsAtLeast(se::CudaComputeCapability::VOLTA) ||

--- a/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment_test.cc
@@ -356,7 +356,6 @@ ENTRY entry {
 }
 
 TEST_F(LayoutAssignmentTest, ConvCuDNNBF16) {
-  
   if (!GetCudaComputeCapability().IsAtLeast(se::CudaComputeCapability::VOLTA)) {
     GTEST_SKIP() << "Conv with Bfloat16 uses NHWC layout for "
                     "architectures with Tensor Cores.";

--- a/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_layout_assignment_test.cc
@@ -41,7 +41,15 @@ namespace op = xla::testing::opcode_matchers;
 using ::testing::AllOf;
 using ::tsl::testing::IsOkAndHolds;
 
-using LayoutAssignmentTest = HloTestBase;
+class LayoutAssignmentTest : public HloTestBase {
+ public:
+  se::CudaComputeCapability GetCudaComputeCapability() {
+    return backend()
+        .default_stream_executor()
+        ->GetDeviceDescription()
+        .cuda_compute_capability();
+  }
+};
 
 TEST_F(LayoutAssignmentTest, Elementwise) {
   Shape ashape = ShapeUtil::MakeShape(F32, {42, 12});
@@ -345,6 +353,32 @@ ENTRY entry {
   expect_layout(ShapeUtil::GetSubshape(call_0->shape(), {0}), {1, 2, 0});
   expect_layout(call_0->operand(0)->shape(), {1, 2, 0});
   expect_layout(call_0->operand(1)->shape(), {1, 2, 0});
+}
+
+TEST_F(LayoutAssignmentTest, ConvCuDNNBF16) {
+  
+  if (!GetCudaComputeCapability().IsAtLeast(se::CudaComputeCapability::VOLTA)) {
+    GTEST_SKIP() << "Conv with Bfloat16 uses NHWC layout for "
+                    "architectures with Tensor Cores.";
+  }
+
+  const char* hlo = R"(
+
+  HloModule jit_conv_general_dilated
+
+  ENTRY main.4 {
+    Arg_0.1 = bf16[1,64,64,16]{3,2,1,0} parameter(0), sharding={replicated}
+    Arg_1.2 = bf16[3,3,16,32]{3,2,1,0} parameter(1), sharding={replicated}
+    ROOT convolution.3 = bf16[1,64,64,32]{3,2,1,0} convolution(Arg_0.1, Arg_1.2), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_01io->b01f, metadata={op_name="jit(conv_general_dilated)/jit(main)/conv_general_dilated[window_strides=(1, 1) padding=((1, 1), (1, 1)) lhs_dilation=(1, 1) rhs_dilation=(1, 1) dimension_numbers=ConvDimensionNumbers(lhs_spec=(0, 3, 1, 2), rhs_spec=(3, 2, 0, 1), out_spec=(0, 3, 1, 2)) feature_group_count=1 batch_group_count=1 lhs_shape=(1, 64, 64, 16) rhs_shape=(3, 3, 16, 32) precision=None preferred_element_type=None]" source_file="/usr/local/lib/python3.8/dist-packages/flax/linen/linear.py" source_line=438}
+  }
+)";
+
+  MatchOptimizedHlo(hlo, R"(
+  // CHECK: [[P0:%[^ ]+]] = bf16[1,64,64,16]{3,2,1,0} parameter(0), sharding={replicated}
+  // CHECK: [[P1:%[^ ]+]] = bf16[3,3,16,32]{3,2,1,0} parameter(1), sharding={replicated}
+  // CHECK-NEXT: [[P2:%[^ ]+]] = bf16[32,3,3,16]{3,2,1,0} transpose([[P1]]), dimensions={3,0,1,2}
+  // CHECK-NEXT: %cudnn-conv.1 = (bf16[1,64,64,32]{3,2,1,0}, u8[0]{0}) custom-call([[P0]], [[P2]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForward"
+  )");
 }
 
 }  // namespace


### PR DESCRIPTION
NHWC is the optimal format for cuDNN Conv with BFloat16 data types. Fix the heuristic to use this layout. I tested this with a unit test with just a conv layer and observed a 20% speedup with BFloat16 data type. 
