### PR TITLE
Update GitHub Actions to avoid `set-output` deprecation

### DIFF
--- a/.github/workflows/release-branch-cherrypick.yml
+++ b/.github/workflows/release-branch-cherrypick.yml
@@ -52,8 +52,8 @@ jobs:
           git config --global user.email "jenkins@tensorflow.org"
           git fetch origin master
           git cherry-pick ${{ github.event.inputs.git_commit }}
-          echo SHORTSHA=$(git log -1 ${{ github.event.inputs.git_commit }} --format="%h") >> $GITHUB_OUTPUT
-          echo TITLE=$(git log -1 ${{ github.event.inputs.git_commit }} --format="%s") >> $GITHUB_OUTPUT
+          echo "SHORTSHA=$(git log -1 ${{ github.event.inputs.git_commit }} --format="%h")" >> "$GITHUB_OUTPUT"
+          echo "TITLE=$(git log -1 ${{ github.event.inputs.git_commit }} --format="%s")" >> "$GITHUB_OUTPUT"
     - name: Create Pull Request with changes
       uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
       with:

--- a/.github/workflows/release-branch-cherrypick.yml
+++ b/.github/workflows/release-branch-cherrypick.yml
@@ -52,8 +52,8 @@ jobs:
           git config --global user.email "jenkins@tensorflow.org"
           git fetch origin master
           git cherry-pick ${{ github.event.inputs.git_commit }}
-          echo ::set-output name=SHORTSHA::$(git log -1 ${{ github.event.inputs.git_commit }} --format="%h")
-          echo ::set-output name=TITLE::$(git log -1 ${{ github.event.inputs.git_commit }} --format="%s")
+          echo SHORTSHA=$(git log -1 ${{ github.event.inputs.git_commit }} --format="%h") >> $GITHUB_OUTPUT
+          echo TITLE=$(git log -1 ${{ github.event.inputs.git_commit }} --format="%s") >> $GITHUB_OUTPUT
     - name: Create Pull Request with changes
       uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
       with:

--- a/.github/workflows/sigbuild-docker-branch.yml
+++ b/.github/workflows/sigbuild-docker-branch.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
           # Converts r2.9 to just 2.9
-          echo "REF=$(echo $GITHUB_REF_NAME | sed 's/r//g')" >> $GITHUB_OUTPUT
+          echo "REF=$(echo $GITHUB_REF_NAME | sed 's/r//g')" >> "$GITHUB_OUTPUT"
         id: vars
       -
         name: Build and push

--- a/.github/workflows/sigbuild-docker-branch.yml
+++ b/.github/workflows/sigbuild-docker-branch.yml
@@ -55,9 +55,9 @@ jobs:
       -
         name: Generate variables for cache busting and tag naming
         run: |
-          echo "::set-output name=DATE::$(date +'%Y-%m-%d')"
+          echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
           # Converts r2.9 to just 2.9
-          echo "::set-output name=REF::$(echo $GITHUB_REF_NAME | sed 's/r//g')"
+          echo "REF=$(echo $GITHUB_REF_NAME | sed 's/r//g')" >> $GITHUB_OUTPUT
         id: vars
       -
         name: Build and push

--- a/.github/workflows/sigbuild-docker-branch.yml
+++ b/.github/workflows/sigbuild-docker-branch.yml
@@ -55,7 +55,7 @@ jobs:
       -
         name: Generate variables for cache busting and tag naming
         run: |
-          echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
           # Converts r2.9 to just 2.9
           echo "REF=$(echo $GITHUB_REF_NAME | sed 's/r//g')" >> $GITHUB_OUTPUT
         id: vars

--- a/.github/workflows/sigbuild-docker-presubmit.yml
+++ b/.github/workflows/sigbuild-docker-presubmit.yml
@@ -48,7 +48,7 @@ jobs:
       -
         name: Grab the date to do cache busting (assumes same day OK to keep)
         run: |
-          echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
         id: date
       -
         name: Build containers, and push to GCR only if the 'build and push to gcr.io for staging' label is applied

--- a/.github/workflows/sigbuild-docker-presubmit.yml
+++ b/.github/workflows/sigbuild-docker-presubmit.yml
@@ -48,7 +48,7 @@ jobs:
       -
         name: Grab the date to do cache busting (assumes same day OK to keep)
         run: |
-          echo "::set-output name=DATE::$(date +'%Y-%m-%d')"
+          echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         id: date
       -
         name: Build containers, and push to GCR only if the 'build and push to gcr.io for staging' label is applied

--- a/.github/workflows/sigbuild-docker.yml
+++ b/.github/workflows/sigbuild-docker.yml
@@ -61,7 +61,7 @@ jobs:
           # [[:digit:]] searches for numbers and \+ joins them together
           major_version=$(grep "^#define TF_MAJOR_VERSION" ./tensorflow/core/public/version.h | grep -o "[[:digit:]]\+")
           minor_version=$(grep "^#define TF_MINOR_VERSION" ./tensorflow/core/public/version.h | grep -o "[[:digit:]]\+")
-          echo TF_VERSION=${major_version}.${minor_version} >> $GITHUB_OUTPUT
+          echo "TF_VERSION=${major_version}.${minor_version}" >> "$GITHUB_OUTPUT"
           # Also get the current date to do cache busting. Assumes one day
           # is an ok range for rebuilds
           echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT

--- a/.github/workflows/sigbuild-docker.yml
+++ b/.github/workflows/sigbuild-docker.yml
@@ -64,7 +64,7 @@ jobs:
           echo "TF_VERSION=${major_version}.${minor_version}" >> "$GITHUB_OUTPUT"
           # Also get the current date to do cache busting. Assumes one day
           # is an ok range for rebuilds
-          echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
         id: tf-version
       -
         name: Build and push

--- a/.github/workflows/sigbuild-docker.yml
+++ b/.github/workflows/sigbuild-docker.yml
@@ -61,10 +61,10 @@ jobs:
           # [[:digit:]] searches for numbers and \+ joins them together
           major_version=$(grep "^#define TF_MAJOR_VERSION" ./tensorflow/core/public/version.h | grep -o "[[:digit:]]\+")
           minor_version=$(grep "^#define TF_MINOR_VERSION" ./tensorflow/core/public/version.h | grep -o "[[:digit:]]\+")
-          echo ::set-output name=TF_VERSION::${major_version}.${minor_version}
+          echo TF_VERSION=${major_version}.${minor_version} >> $GITHUB_OUTPUT
           # Also get the current date to do cache busting. Assumes one day
           # is an ok range for rebuilds
-          echo "::set-output name=DATE::$(date +'%Y-%m-%d')"
+          echo "DATE=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         id: tf-version
       -
         name: Build and push


### PR DESCRIPTION
Starting 1st June 2023 (planned) workflows, `::set-output name...::` syntax cannot be used. You can see the example warnings here: https://github.com/tensorflow/tensorflow/actions/runs/3752114734

ref. [GitHub Actions: Deprecating save-state and set-output commands | GitHub Changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This PR fixes the issue by using the `GITHUB_OUTPUT` environment variable as instructed in the above article.
