### PR TITLE
Revert "Excises VirtualPlacer from layout optimizer transposer."

### DIFF
--- a/tensorflow/core/grappler/optimizers/BUILD
+++ b/tensorflow/core/grappler/optimizers/BUILD
@@ -1215,6 +1215,7 @@ cc_library(
         "//tensorflow/core/grappler:op_types",
         "//tensorflow/core/grappler:utils",
         "//tensorflow/core/grappler/costs:graph_properties",
+        "//tensorflow/core/grappler/costs:virtual_placer",
         "//tensorflow/core/grappler/utils:frame",
         "//tensorflow/core/grappler/utils:graph_view",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer.cc
@@ -86,7 +86,8 @@ inline bool NumConvOnDeviceWithDataTypeOverThreshold(
     if (!IsConv2D(*node_def) && !IsConv3D(*node_def)) {
       continue;
     }
-    const string& device_name = GetDeviceName(*node_def);
+    const string& device_name =
+        GetDeviceName(context.virtual_placer.get(), *node_def);
     string device_type;
     string task;
     if (!DeviceNameUtils::SplitDeviceName(device_name, &task, &device_type) ||
@@ -122,7 +123,8 @@ inline bool ConvBackpropExists(const TransposeContext& context,
       continue;
     }
 
-    const string& device_name = GetDeviceName(*node_def);
+    const string& device_name =
+        GetDeviceName(context.virtual_placer.get(), *node_def);
     string device_type;
     string task;
     if (!DeviceNameUtils::SplitDeviceName(device_name, &task, &device_type) ||

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_test.cc
@@ -242,16 +242,34 @@ TEST_F(GenericLayoutOptimizerTest, OptimizeSimpleConv2DGraph) {
   Status status;
   utils::GraphView graph_view(&output, &status);
   TF_ASSERT_OK(status);
+  // The expected optimized graph contains 2 extra sets of Transpose nodes and
+  // has the Conv2D's data_format set to "NCHW" on GPU, while "NHWC" on CPU.
+  auto* input_transpose_node = graph_view.GetNode(
+      absl::StrCat("Conv2D-0-Transpose", SRC_DATA_FORMAT, "To", DST_DATA_FORMAT,
+                   "-LayoutOptimizer"));
+
+  ASSERT_NE(input_transpose_node, nullptr);
+  ASSERT_EQ(input_transpose_node->NumRegularFanins(), 2);
+  VerifyRegularFaninMatch(input_transpose_node, 0, "Input", 0);
 
   auto* conv2d_node = graph_view.GetNode("Conv2D");
   ASSERT_NE(conv2d_node, nullptr);
   ASSERT_EQ(conv2d_node->NumRegularFanins(), 2);
+  VerifyRegularFaninMatch(conv2d_node, 0, input_transpose_node->GetName(), 0);
   VerifyRegularFaninMatch(conv2d_node, 1, "Filter", 0);
-  VerifyDataFormatAttributeMatch(conv2d_node, SRC_DATA_FORMAT);
+  VerifyDataFormatAttributeMatch(conv2d_node, DST_DATA_FORMAT);
+
+  auto* output_transpose_node = graph_view.GetNode(
+      absl::StrCat("Conv2D-0-0-Transpose", DST_DATA_FORMAT, "To",
+                   SRC_DATA_FORMAT, "-LayoutOptimizer"));
+  ASSERT_NE(output_transpose_node, nullptr);
+  ASSERT_EQ(output_transpose_node->NumRegularFanins(), 2);
+  VerifyRegularFaninMatch(output_transpose_node, 0, conv2d_node->GetName(), 0);
 
   auto* output_node = graph_view.GetNode("Output");
   ASSERT_NE(output_node, nullptr);
   ASSERT_EQ(output_node->NumRegularFanins(), 1);
+  VerifyRegularFaninMatch(output_node, 0, output_transpose_node->GetName(), 0);
 }
 
 TEST_F(GenericLayoutOptimizerTest, PreserveFetch) {
@@ -290,7 +308,7 @@ TEST_F(GenericLayoutOptimizerTest, EmptyDevice) {
   TF_ASSERT_OK(status);
   auto* conv_node = graph_view.GetNode("Conv2D");
   ASSERT_NE(conv_node, nullptr);
-  VerifyDataFormatAttributeMatch(conv_node, SRC_DATA_FORMAT);
+  VerifyDataFormatAttributeMatch(conv_node, DST_DATA_FORMAT);
 }
 
 TEST_F(GenericLayoutOptimizerTest, GPUDevice) {
@@ -412,7 +430,19 @@ TEST_F(GenericLayoutOptimizerTest, Conv2DBackpropInputNonConstInputSizes) {
     auto* conv2d_backprop_node = graph_view.GetNode("Conv2DBackpropInput");
     ASSERT_NE(conv2d_backprop_node, nullptr);
     ASSERT_EQ(conv2d_backprop_node->NumRegularFanins(), 3);
-    VerifyRegularFaninMatch(conv2d_backprop_node, 0, "InputSizesIdentity", 0);
+    VerifyRegularFaninMatch(
+        conv2d_backprop_node, 0,
+        absl::StrCat("Conv2DBackpropInput-0-DataFormatVecPermute",
+                     SRC_DATA_FORMAT, "To", DST_DATA_FORMAT,
+                     "-LayoutOptimizer"),
+        0);
+    auto* input_sizes_node = graph_view.GetNode(absl::StrCat(
+        "Conv2DBackpropInput-0-DataFormatVecPermute", SRC_DATA_FORMAT, "To",
+        DST_DATA_FORMAT, "-LayoutOptimizer"));
+    ASSERT_NE(input_sizes_node, nullptr);
+    EXPECT_EQ(input_sizes_node->GetOp(), "DataFormatVecPermute");
+    ASSERT_EQ(input_sizes_node->NumRegularFanins(), 1);
+    VerifyRegularFaninMatch(input_sizes_node, 0, "InputSizesIdentity", 0);
   }
 }
 

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.cc
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.cc
@@ -241,6 +241,10 @@ Status TransposeContext::InitializeTransposeContext(bool assume_valid_feeds,
   context->nodes_to_preserve = absl::flat_hash_set<string>(
       nodes_to_preserve.begin(), nodes_to_preserve.end());
   TF_RETURN_IF_ERROR(context->frames.InferFromGraph(context->graph));
+  if (cluster != nullptr) {
+    context->virtual_placer =
+        absl::make_unique<const VirtualPlacer>(cluster->GetDevices());
+  }
   return OkStatus();
 }
 
@@ -262,7 +266,8 @@ void TransposeContext::AssignDeviceAndDataFormats(
 bool Transposer::ShouldProcess(const TransposeContext& context,
                                const utils::MutableNodeView& node) const {
   const auto* node_def = node.node();
-  const string& device_name = GetDeviceName(*node_def);
+  const string& device_name =
+      GetDeviceName(context.virtual_placer.get(), *node_def);
   string device;
   string task;
   const bool is_on_target_device =
@@ -492,6 +497,7 @@ Status Transposer::UpdateEdge(
 
   // TODO(lyandy): Minimize device parsing/fetching.
   const string device = GetDeviceName(
+      context->virtual_placer.get(),
       is_src_format_to_dst_format ? *dst_node_def : *src_node_def);
   DataType data_type =
       is_src_format_to_dst_format
@@ -524,10 +530,11 @@ Status Transposer::UpdateEdge(
         control_node_name, &added_node, &added_node_name));
   } else if (op == kOpDataFormatVecPermute || op == kOpDataFormatDimMap) {
     DeviceNameUtils::ParsedName parsed_name;
-    bool is_fanin_on_host = DeviceNameUtils::ParseFullName(
-                                GetDeviceName(*src_node_def), &parsed_name) &&
-                            parsed_name.type != "CPU" &&
-                            IsHostMemory(*src_node_def, src_port);
+    bool is_fanin_on_host =
+        DeviceNameUtils::ParseFullName(
+            GetDeviceName(context->virtual_placer.get(), *src_node_def),
+            &parsed_name) &&
+        parsed_name.type != "CPU" && IsHostMemory(*src_node_def, src_port);
     const string node_name = absl::Substitute(name_format, op);
     TF_RETURN_IF_ERROR(CreateDataFormatNode(
         context, node_name, op, device, data_type, is_fanin_on_host,
@@ -1946,7 +1953,11 @@ Status UnaryGradTransposer::TransposeNode(TransposeContext* context,
 
 // Utils.
 
-string GetDeviceName(const NodeDef& node) { return node.device(); }
+string GetDeviceName(const VirtualPlacer* virtual_placer, const NodeDef& node) {
+  return (node.device().empty() && virtual_placer != nullptr)
+             ? virtual_placer->get_canonical_device_name(node)
+             : node.device();
+}
 
 bool IsDefaultLayoutSensitiveOp(const NodeDef& node) {
   static absl::flat_hash_set<string>* default_layout_sensitive_ops =

--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/core/framework/graph.pb.h"
 #include "tensorflow/core/framework/node_def.pb.h"
 #include "tensorflow/core/grappler/costs/graph_properties.h"
+#include "tensorflow/core/grappler/costs/virtual_placer.h"
 #include "tensorflow/core/grappler/utils.h"
 #include "tensorflow/core/grappler/utils/frame.h"
 #include "tensorflow/core/grappler/utils/graph_view.h"
@@ -75,6 +76,7 @@ struct TransposeContext {
   absl::flat_hash_set<string> nodes_to_preserve;
   std::unique_ptr<GraphProperties> graph_properties;
   std::unique_ptr<utils::MutableGraphView> graph_view;
+  std::unique_ptr<const VirtualPlacer> virtual_placer;
 
   string target_device;
   string src_format;
@@ -611,7 +613,7 @@ Status PermuteDouble(absl::string_view location,
   return OkStatus();
 }
 
-string GetDeviceName(const NodeDef& node);
+string GetDeviceName(const VirtualPlacer* virtual_placer, const NodeDef& node);
 
 bool IsDefaultLayoutSensitiveOp(const NodeDef& node);
 


### PR DESCRIPTION
This reverts commit 612a531c9bc729329470e778dfc014d2d978e587.

I found that commit [612a531](https://github.com/tensorflow/tensorflow/commit/612a531c9bc729329470e778dfc014d2d978e587) causes significant performance degradation for TF-TRT 2.10.x and 2.11.x. This commit was added to master after 2.9.0 release on Apr 19, 2022.

Performance tests below show TF-TRT 2.10.x and 2.11.x performance with and without the fix.
```
g4dn: TU104GL [Tesla T4]
-------------------------------------------------------------------------------
                     TensorRT Converted Model exec time in ms
-------------------------------------------------------------------------------
                      |                    Tensorflow Version                 |
    Model             | 2.9.3 | 2.10.1 | 2.10.1 fixed | 2.11.0 | 2.11.0 fixed |
                      |  fast |  slow  |    fast      |  slow  |    fast      |
-------------------------------------------------------------------------------
imagenet_inception_v1    0.65    1.86       0.64         1.51       0.56
imagenet_inception_v3    1.59    3.47       1.58         2.91       1.43
imagenet_mobilenet_v1    0.45    1.17       0.46         1.00       0.41
imagenet_mobilenet_v2    0.86    1.87       0.85         1.64       0.94
imagenet_resnet_v2_50    1.03    1.91       1.05         1.72       0.85
```

Related issue: https://github.com/tensorflow/tensorflow/issues/58248