### PR TITLE
[Docs] CONTRIBUTING.md: Fix incorrect description of the single component unit test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,7 @@ There are two ways to run TensorFlow unit tests.
     For a single component e.g. softmax op:
 
     ```bash
-    bazel test ${flags} tensorflow/python/kernel_tests:softmax_op_test
+    bazel test ${flags} tensorflow/python/kernel_tests/nn_ops:softmax_op_test
     ```
 
     For a single/parameterized test e.g. `test_capture_variables` in


### PR DESCRIPTION
Hi all,

The description of single component unit test of `softmax_op_test` is wrong in CONTRIBUTING.md.

This is because after the following patch, the test had been moved under `kernel_tests/nn_ops`.
```
commit ab7c873202574b3cd549a93ccbfd881d659186ca
Author: Rohan Jain <rohanj@google.com>
Date:   Sun Oct 31 21:35:07 2021 -0700

    Factoring out nn_ops tests into its own folder as per go/tf-ops-breakdown

    PiperOrigin-RevId: 406745996
    Change-Id: If331ccb474188dd8bb749843f1728ae0f23d5d8d

```

So the test should be described as `tensorflow/python/kernel_tests/nn_ops:softmax_op_test`.

Thanks.
Best regards,
Jie

