### PR TITLE
Register 'MklEinsum' kernel for aarch64 platform

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -379,9 +379,7 @@ class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {
                                      "MatMul",
                                      "BatchMatMul",
                                      "BatchMatMulV2",
-#ifndef DNNL_AARCH64_USE_ACL
                                      "Einsum"
-#endif  // DNNL_AARCH64_USE_ACL
     };
 
     UpdateList("ALLOWLIST", &list);

--- a/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_einsum_op.cc
@@ -272,7 +272,6 @@ class MklEinsum : public OpKernel {
   bool mkl_output_has_ellipsis_ = false;
 };
 
-#ifndef DNNL_AARCH64_USE_ACL
 #define REGISTER_EINSUM_MKL(TYPE)                                             \
   REGISTER_KERNEL_BUILDER(Name("_MklEinsum")                                  \
                               .Device(DEVICE_CPU)                             \
@@ -281,6 +280,5 @@ class MklEinsum : public OpKernel {
                           MklEinsum<CPUDevice, TYPE>)
 TF_CALL_float(REGISTER_EINSUM_MKL);
 TF_CALL_bfloat16(REGISTER_EINSUM_MKL);
-#endif  // !DNNL_AARCH64_USE_ACL
 }  // namespace tensorflow
 #endif  // INTEL_MKL


### PR DESCRIPTION
MklEinsum is an MKL implementation for Einsum operator.
