### PR TITLE
[NVIDIA XLA] Add a new debug flag to turn off mlir pretty print form

### DIFF
--- a/tensorflow/compiler/xla/debug_options_flags.cc
+++ b/tensorflow/compiler/xla/debug_options_flags.cc
@@ -50,6 +50,7 @@ DebugOptions DefaultDebugOptionsIgnoringFlags() {
   opts.set_xla_dump_max_hlo_modules(-1);
   opts.set_xla_dump_module_metadata(false);
   opts.set_xla_dump_hlo_as_long_text(false);
+  opts.set_xla_dump_enable_mlir_pretty_form(true);
 #ifdef ENABLE_MKL
   opts.set_xla_cpu_use_mkl_dnn(true);
 #endif  // ENABLE_MKL
@@ -775,6 +776,13 @@ void MakeDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,
       debug_options->xla_dump_hlo_pipeline_re(),
       "If specified, dumps HLO before and after optimization passes in the "
       "pass pipelines that match this regular expression."));
+  flag_list->push_back(
+      tsl::Flag("xla_dump_enable_mlir_pretty_form",
+                bool_setter_for(&DebugOptions::set_xla_dump_enable_mlir_pretty_form),
+                debug_options->xla_dump_enable_mlir_pretty_form(),
+                "Enable dumping MLIR using pretty print form. If set to false, the dumped "
+                "MLIR will be in the llvm-parsable format and can be processed by mlir-opt tools. "
+                "Pretty print form is not legal MLIR."));
   flag_list->push_back(tsl::Flag(
       "xla_gpu_enable_xla_runtime_executable",
       bool_setter_for(&DebugOptions::set_xla_gpu_enable_xla_runtime_executable),

--- a/tensorflow/compiler/xla/service/dump.cc
+++ b/tensorflow/compiler/xla/service/dump.cc
@@ -62,7 +62,8 @@ struct CanonicalDebugOptions {
         dump_module_metadata(opts.xla_dump_module_metadata()),
         dump_compress_protos(opts.xla_dump_compress_protos()),
         dump_hlo_metadata(!opts.xla_dump_disable_metadata()),
-        dump_as_long_text(opts.xla_dump_hlo_as_long_text()) {
+        dump_as_long_text(opts.xla_dump_hlo_as_long_text()),
+        dump_mlir_pretty_form(opts.xla_dump_enable_mlir_pretty_form()) {
     // This constructor examines the values in `opts` and turns on other flags
     // based on what we think is the user's intent.  To reduce confusion about
     // what was a user-specified value versus an extrapolated value, within this
@@ -178,6 +179,7 @@ struct CanonicalDebugOptions {
   bool dump_compress_protos;
   bool dump_hlo_metadata;
   bool dump_as_long_text;
+  bool dump_mlir_pretty_form;
 };
 
 // Helper class to hold a list of functions that produces data to be written to
@@ -627,7 +629,7 @@ void DumpToFileInDirOrStdout(const HloModule& module, string_view file_prefix,
   mlir::OpPrintingFlags print_flags = mlir::OpPrintingFlags().useLocalScope();
   // Enable debug info so that it is easier to see the corresponding HLO node.
   if (file_prefix == "lmhlo") {
-    print_flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/true);
+    print_flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/opts.dump_mlir_pretty_form);
   }
   op->print(outputFile->os(), print_flags);
   outputFile->keep();

--- a/tensorflow/compiler/xla/xla.proto
+++ b/tensorflow/compiler/xla/xla.proto
@@ -322,7 +322,7 @@ message DebugOptions {
   bool xla_gpu_dump_llvmir = 155;
 
   // Whether to dump mlir using pretty print form.
-  bool xla_dump_enable_mlir_pretty_form = 184;
+  bool xla_dump_enable_mlir_pretty_form = 185;
 
   // Denylist for cuDNN convolutions.
   string xla_gpu_algorithm_denylist_path = 128;
@@ -452,7 +452,7 @@ message DebugOptions {
   // instead.
   bool xla_cpu_enable_mlir_tiling_and_fusion = 184;
 
-  // Next id: 185
+  // Next id: 186
 
   // Extra options to pass to the compilation backend (e.g. LLVM); specific
   // interpretation of these values is left to the backend.

--- a/tensorflow/compiler/xla/xla.proto
+++ b/tensorflow/compiler/xla/xla.proto
@@ -321,6 +321,9 @@ message DebugOptions {
   // Whether to dump llvm ir when compiling to ptx.
   bool xla_gpu_dump_llvmir = 155;
 
+  // Whether to dump mlir using pretty print form.
+  bool xla_dump_enable_mlir_pretty_form = 184;
+
   // Denylist for cuDNN convolutions.
   string xla_gpu_algorithm_denylist_path = 128;
 

--- a/tensorflow/compiler/xrt/xrt_util.cc
+++ b/tensorflow/compiler/xrt/xrt_util.cc
@@ -194,6 +194,8 @@ xla::DebugOptions BuildXlaDebugOptions(const xla::DebugOptions& ref_options) {
   options.set_xla_dump_include_timestamp(
       ref_options.xla_dump_include_timestamp());
   options.set_xla_dump_max_hlo_modules(ref_options.xla_dump_max_hlo_modules());
+  options.set_xla_dump_disable_mlir_pretty_form(ref_options.xla_dump_disable_mlir_pretty_form());
+
   for (auto& pass : ref_options.xla_disable_hlo_passes()) {
     options.add_xla_disable_hlo_passes(pass);
   }

--- a/tensorflow/compiler/xrt/xrt_util.cc
+++ b/tensorflow/compiler/xrt/xrt_util.cc
@@ -194,7 +194,7 @@ xla::DebugOptions BuildXlaDebugOptions(const xla::DebugOptions& ref_options) {
   options.set_xla_dump_include_timestamp(
       ref_options.xla_dump_include_timestamp());
   options.set_xla_dump_max_hlo_modules(ref_options.xla_dump_max_hlo_modules());
-  options.set_xla_dump_disable_mlir_pretty_form(ref_options.xla_dump_disable_mlir_pretty_form());
+  options.set_xla_dump_enable_mlir_pretty_form(ref_options.xla_dump_enable_mlir_pretty_form());
 
   for (auto& pass : ref_options.xla_disable_hlo_passes()) {
     options.add_xla_disable_hlo_passes(pass);


### PR DESCRIPTION
Introduce a debug flag "xla_dump_enable_mlir_pretty_form" to control pretty print form when dumping mlir. 
Disabling pretty form will make the dumped mlir parsable. LLVM states the pretty form is not parsable by any optimizer tool.
With pretty form:
`func.func @main.3(%arg0: memref<4xi8> {lmhlo.params = 0 : index} "Arg_0.1"`
The string at the end is not parsable
With `xla_dump_enable_mlir_pretty_form=false`:
`func.func @main.3(%arg0: memref<4xi8> {lmhlo.params = 0 : index} loc("Arg_0.1")`