### PR TITLE
[oneDNN] Increasing mkl mem alloc threshold

### DIFF
--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h
+++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h
@@ -316,7 +316,7 @@ class MklCPUAllocator : public Allocator {
 
   // Size in bytes that defines the upper-bound for "small" allocations.
   // Any allocation below this threshold is "small" allocation.
-  static constexpr const size_t kSmallAllocationsThreshold = 4096;
+  static constexpr const size_t kSmallAllocationsThreshold = 262144;
 
   // Prevent copying and assignment
   TF_DISALLOW_COPY_AND_ASSIGN(MklCPUAllocator);


### PR DESCRIPTION
This PR increases the threshold to use default allocator from 4K to 256K based on internal benchmarking.