### PR TITLE
[ROCm] Enable roundeven LLVM op for AMDGPU.

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/transforms/gpu_fusion_rewrite.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/transforms/gpu_fusion_rewrite.cc
@@ -203,9 +203,7 @@ static ConversionTarget getRewritableTarget(MLIRContext* ctx) {
       mhlo::AddOp, mhlo::AbsOp, mhlo::CbrtOp, mhlo::CeilOp, mhlo::CosineOp,
       mhlo::DivOp, mhlo::ExpOp, mhlo::Expm1Op, mhlo::FloorOp, mhlo::LogOp,
       mhlo::Log1pOp, mhlo::LogisticOp, mhlo::MulOp, mhlo::NegOp, mhlo::RoundOp,
-#if !TENSORFLOW_USE_ROCM
       mhlo::RoundNearestEvenOp,
-#endif
       mhlo::RsqrtOp, mhlo::SignOp, mhlo::SineOp, mhlo::SqrtOp, mhlo::SubtractOp,
       mhlo::TanhOp>([&](Operation* op) { return op->hasOneUse(); });
   return target;


### PR DESCRIPTION
LLVM support for roundeven is now available for AMDGPU, so this functionality can now be enabled.

/cc @cheshire 