### PR TITLE
Don't run some GPU tests redundantly

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1461,22 +1461,23 @@ def tf_gpu_cc_test(
         linkopts = [],
         **kwargs):
     targets = []
-    tf_cc_test(
-        name = name,
-        size = size,
-        srcs = srcs,
-        args = args,
-        data = data,
-        extra_copts = extra_copts + if_cuda(["-DNV_CUDNN_DISABLE_EXCEPTION"]),
-        kernels = kernels,
-        linkopts = linkopts,
-        linkstatic = linkstatic,
-        suffix = "_cpu",
-        tags = tags,
-        deps = deps,
-        **kwargs
-    )
-    targets.append(name + "_cpu")
+    if 'gpu' not in tags:
+        tf_cc_test(
+            name = name,
+            size = size,
+            srcs = srcs,
+            args = args,
+            data = data,
+            extra_copts = extra_copts + if_cuda(["-DNV_CUDNN_DISABLE_EXCEPTION"]),
+            kernels = kernels,
+            linkopts = linkopts,
+            linkstatic = linkstatic,
+            suffix = "_cpu",
+            tags = tags,
+            deps = deps,
+            **kwargs
+        )
+        targets.append(name + "_cpu")
     tf_cc_test(
         name = name,
         size = size,


### PR DESCRIPTION
E.g. `gpu_unary_ops_test` is added with `tf_cuda_cc_test` which will add a CPU and one (or more) GPU tests.
However the test itself is already for GPU as indicated by the passed tags and the prefix.
Fix that in the function to only add the CPU test if "gpu" is not in the tags.

Fixes #47081

cc @mohantym as you commented at https://github.com/tensorflow/tensorflow/issues/47081#issuecomment-1280550370 and @sanjoy as the assignee