### PR TITLE
Fix Collapse example in XLA Operation Semantics

### DIFF
--- a/tensorflow/compiler/xla/g3doc/operation_semantics.md
+++ b/tensorflow/compiler/xla/g3doc/operation_semantics.md
@@ -585,14 +585,7 @@ then v012 == f32[24] {10, 11, 12, 15, 16, 17,
 
 // Collapse the two lower dimensions, leaving two dimensions.
 let v01 = Collapse(v, {0,1});
-then v01 == f32[4x6] {{10, 11, 12, 15, 16, 17},
-{20, 21, 22, 25, 26, 27},
-{30, 31, 32, 35, 36, 37},
-{40, 41, 42, 45, 46, 47}};
-
-// Collapse the two higher dimensions, leaving two dimensions.
-let v12 = Collapse(v, {1,2});
-then v12 == f32[8x3] {{10, 11, 12},
+then v01 == f32[8x3] {{10, 11, 12},
 {15, 16, 17},
 {20, 21, 22},
 {25, 26, 27},
@@ -601,6 +594,12 @@ then v12 == f32[8x3] {{10, 11, 12},
 {40, 41, 42},
 {45, 46, 47}};
 
+// Collapse the two higher dimensions, leaving two dimensions.
+let v12 = Collapse(v, {1,2});
+then v12 == f32[4x6] {{10, 11, 12, 15, 16, 17},
+{20, 21, 22, 25, 26, 27},
+{30, 31, 32, 35, 36, 37},
+{40, 41, 42, 45, 46, 47}};
 ```
 
 ## CollectivePermute


### PR DESCRIPTION
I believe, the dimensions of the examples of the Collapse operator are wrong.

Given `let v = f32[4x2x3]`, it is:

```
// Collapse the two lower dimensions, leaving two dimensions.
let v01 = Collapse(v, {0,1});
then v01 == f32[4x6]
```

and 

```
// Collapse the two higher dimensions, leaving two dimensions.
let v12 = Collapse(v, {1,2});
then v12 == f32[8x3]
```

but should be

```
// Collapse the two lower dimensions, leaving two dimensions.
let v01 = Collapse(v, {0,1});
then v01 == f32[8x3]
```

and 

```
// Collapse the two higher dimensions, leaving two dimensions.
let v12 = Collapse(v, {1,2});
then v12 == f32[4x6]
```