### PR TITLE
TensorFloat32 Test Fixes for TensorFlow core and python tests

### DIFF
--- a/tensorflow/compiler/xla/tests/BUILD
+++ b/tensorflow/compiler/xla/tests/BUILD
@@ -1260,7 +1260,14 @@ xla_test(
         "//tensorflow/compiler/xla/tests:xla_internal_test_main",
         "//tensorflow/tsl/platform:logging",
         "//tensorflow/tsl/platform:test",
-    ],
+    ] + select({
+        "//tensorflow/tsl:is_cuda_enabled": [
+            "//tensorflow/tsl/platform:tensor_float_32_hdr_lib",
+        ],
+        "//conditions:default": [
+            "//tensorflow/tsl/platform:tensor_float_32_utils",
+        ],
+    }),
 )
 
 xla_test(

--- a/tensorflow/compiler/xla/tests/convolution_variants_test.cc
+++ b/tensorflow/compiler/xla/tests/convolution_variants_test.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/tests/literal_test_util.h"
 #include "tensorflow/compiler/xla/tests/test_macros.h"
 #include "tensorflow/compiler/xla/xla_data.pb.h"
+#include "tensorflow/tsl/platform/tensor_float_32_utils.h"
 #include "tensorflow/tsl/platform/test.h"
 
 namespace xla {
@@ -48,6 +49,17 @@ class ConvolutionVariantsTest : public ClientLibraryTestBase {
 #else
   ErrorSpec error_spec_ = ErrorSpec(1e-4, 1e-2);
 #endif
+
+  void SetUp() override {
+    init_tf32_status_ = tsl::tensor_float_32_execution_enabled();
+    tsl::enable_tensor_float_32_execution(false);
+  }
+  void TearDown() override {
+    tsl::enable_tensor_float_32_execution(init_tf32_status_);
+  }
+
+ private:
+  bool init_tf32_status_;
 };
 
 XLA_TEST_F(ConvolutionVariantsTest, Minimal) {

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
@@ -1221,7 +1221,7 @@ TEST_F(AutoMixedPrecisionTest, SoftmaxOp) {
 
 TEST_F(AutoMixedPrecisionTest, SoftplusOp) {
   TestSimpleUnaryInferOp(
-      -5, 5, 1.0e-3, 1.0e-3,
+      -5, 5, 2.0e-3, 2.0e-3,
       [](const tensorflow::Scope& scope, Output input) -> Output {
         return ops::Softplus(scope, input);
       });

--- a/tensorflow/python/kernel_tests/array_ops/slice_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/slice_op_test.py
@@ -145,6 +145,7 @@ class SliceTest(test.TestCase):
         slice_val = self.evaluate(slice_t)
         self.assertAllEqual(slice_val, inp[lo:hi])
 
+  @test_util.run_without_tensor_float_32("Use FP32 in conv3d.")
   def test3Dimension(self):
     with self.cached_session():
       input_shape = [8, 16, 16, 16, 8]

--- a/tensorflow/python/kernel_tests/linalg/matrix_exponential_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/matrix_exponential_op_test.py
@@ -43,6 +43,7 @@ def np_expm(x):  # pylint: disable=invalid-name
   return y
 
 
+@test_util.run_all_without_tensor_float_32("Avoid TF32-based matmuls.")
 class ExponentialOpTest(test.TestCase):
 
   def _verifyExponential(self, x, np_type):

--- a/tensorflow/python/ops/linalg/linear_operator_test_util.py
+++ b/tensorflow/python/ops/linalg/linear_operator_test_util.py
@@ -380,6 +380,7 @@ def _test_log_abs_det(use_placeholder, shapes_info, dtype):
   return test_log_abs_det
 
 
+@test_util.run_without_tensor_float_32("Use FP32 in matmul")
 def _test_operator_matmul_with_same_type(use_placeholder, shapes_info, dtype):
   """op_a.matmul(op_b), in the case where the same type is returned."""
   def test_operator_matmul_with_same_type(self):
@@ -491,6 +492,7 @@ def _test_matmul_base(
     self.assertAC(op_matmul_v, mat_matmul_v)
 
 
+@test_util.run_without_tensor_float_32("Use FP32 in matmul")
 def _test_matmul(
     use_placeholder,
     shapes_info,
@@ -511,6 +513,7 @@ def _test_matmul(
   return test_matmul
 
 
+@test_util.run_without_tensor_float_32("Use FP32 in matmul")
 def _test_matmul_with_broadcast(
     use_placeholder,
     shapes_info,
@@ -810,6 +813,7 @@ def _test_diag_part(use_placeholder, shapes_info, dtype):
   return test_diag_part
 
 
+@test_util.run_without_tensor_float_32("Use FP32 in matmul")
 def _test_composite_tensor(use_placeholder, shapes_info, dtype):
   def test_composite_tensor(self):
     with self.session(graph=ops.Graph()) as sess:
@@ -850,6 +854,7 @@ def _test_composite_tensor(use_placeholder, shapes_info, dtype):
   return test_composite_tensor
 
 
+@test_util.run_without_tensor_float_32("Use FP32 in matmul")
 def _test_saved_model(use_placeholder, shapes_info, dtype):
   def test_saved_model(self):
     with self.session(graph=ops.Graph()) as sess:


### PR DESCRIPTION
Configure tests to use float32 compute type as expected by the thresholds as currently calibrated.

Attn: @reedwm 