### PR TITLE
Corrects DNNL_VERSION_MINOR set in mkldnn_acl.BUILD

### DIFF
--- a/third_party/mkl_dnn/mkldnn_acl.BUILD
+++ b/third_party/mkl_dnn/mkldnn_acl.BUILD
@@ -129,7 +129,7 @@ template_rule(
     out = "include/oneapi/dnnl/dnnl_version.h",
     substitutions = {
         "@DNNL_VERSION_MAJOR@": "2",
-        "@DNNL_VERSION_MINOR@": "6",
+        "@DNNL_VERSION_MINOR@": "7",
         "@DNNL_VERSION_PATCH@": "0",
         "@DNNL_VERSION_HASH@": "N/A",
     },


### PR DESCRIPTION
PR https://github.com/tensorflow/tensorflow/pull/57842 neglected to update the oneDNN version in mkldnn_acl.BUILD to match the version set in workspace2.bzl