### PR TITLE
[NVIDIA TF] Incrase default GPU HOST MEM LIMIT to 128GB

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_process_state.cc
@@ -346,7 +346,7 @@ Allocator* GPUProcessState::GetGpuHostAllocator(const GPUOptions& options,
     int64_t limit_mb = -1;
     Status status =
         tsl::ReadInt64FromEnvVar("TF_GPU_HOST_MEM_LIMIT_IN_MB",
-                                 1LL << 16 /*2^16 MB == 64GB*/, &limit_mb);
+                                 1LL << 17 /*2^17 MB == 128GB*/, &limit_mb);
     if (!status.ok()) {
       LOG(ERROR) << "GetGpuHostAllocator: " << status.error_message();
     }

--- a/tensorflow/core/common_runtime/pluggable_device/pluggable_device_process_state.cc
+++ b/tensorflow/core/common_runtime/pluggable_device/pluggable_device_process_state.cc
@@ -189,7 +189,7 @@ Allocator* PluggableDeviceProcessState::GetPluggableDeviceHostAllocator(
         pluggable_device_host_free_visitors_[numa_node]);
     int64_t pluggable_device_host_mem_limit_in_mb = -1;
     Status status = ReadInt64FromEnvVar("TF_GPU_HOST_MEM_LIMIT_IN_MB",
-                                        1LL << 16 /*64GB max by default*/,
+                                        1LL << 17 /*128GB max by default*/,
                                         &pluggable_device_host_mem_limit_in_mb);
     if (!status.ok()) {
       LOG(ERROR) << "GetPluggableDeviceHostAllocator: "


### PR DESCRIPTION
The previous limit of 64GB was set some years ago when GPU memories were ~16GB.
Some models will fail due to exhausting the 64GB limit when run on machines with multiple large-memory GPUs.
Here we raise the limit to 128 GB, which seems to be sufficient for the cases we are familiar with.