### PR TITLE
[NVIDIA TF] Relax protobuf version requirement

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -104,7 +104,7 @@ REQUIRED_PACKAGES = [
     # See also: https://github.com/protocolbuffers/protobuf/issues/9954
     # See also: https://github.com/tensorflow/tensorflow/issues/56077
     # This is a temporary patch for now, to patch previous TF releases.
-    'protobuf >= 3.9.2, < 3.20',
+    'protobuf >= 3.9.2, < 4',
     'setuptools',
     'six >= 1.12.0',
     'termcolor >= 1.1.0',


### PR DESCRIPTION
Relax protobuf python package requirement to allow 3.x versions above 3.20.
This brings the requirement into line with other packages such as tensorboard.