### PR TITLE
Fix stats bug in cuda_malloc_async allocator

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
+++ b/tensorflow/compiler/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
@@ -100,6 +100,8 @@ class GpuCudaMallocAsyncAllocator : public tsl::Allocator {
   }
 
  private:
+  void PrintAllocatorStatisticsNoLock();
+
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
   StreamExecutor* stream_exec_;  // Not owned.
 


### PR DESCRIPTION
There was a race condition between calling `cuMemAllocFromPoolAsync` or `cuMemFreeAsync` and updating the corresponding stats. This caused inconsistent stats, and a failure of the `DCHECK` in `DeallocateRaw` in debug builds.

This PR moves the lock around the alloc/free calls as well as the stats update so that they remain consistent.

cc @nluehr @pjannaty 