### PR TITLE
mhlo: fix build errors and warnings in tosa pipeline

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/tosa/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_custom_target(check-mhlo-tosa)
 
+add_subdirectory(transforms)
 add_subdirectory(tests)
 
 add_mlir_pdll_library(MHLOTOSAPDLLPatternsIncGen
@@ -39,6 +40,7 @@ set(LIBS
         )
 add_llvm_executable(mhlo-tosa-opt mhlo_tosa_opt.cc
 )
+add_dependencies(mhlo-tosa-opt MHLOTOSATransformsPassIncGen)
 llvm_update_compile_flags(mhlo-tosa-opt)
 target_link_libraries(mhlo-tosa-opt PRIVATE ${LIBS})
 

--- a/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/legalize_mhlo/legalize_mhlo.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/legalize_mhlo/legalize_mhlo.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <utility>
 
 #include "mhlo/IR/hlo_ops.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Parser/Parser.h"
@@ -24,7 +25,7 @@ limitations under the License.
 #include "transforms/passes.h"
 
 #define GEN_PASS_DEF_TOSALEGALIZEMHLOPASS
-#include "transforms/passes.h.inc"
+#include "tosa/transforms/passes.h.inc"
 
 #define PASS_NAME "tosa-legalize-mhlo"
 #define DEBUG_TYPE PASS_NAME
@@ -293,7 +294,7 @@ struct ConvertMhloGatherOp : public OpRewritePattern<mhlo::GatherOp> {
 
     auto startIndexMap = op.getDimensionNumbers().getStartIndexMap();
     for (const auto& startIndex : llvm::enumerate(startIndexMap)) {
-      if (startIndex.value() != startIndex.index()) {
+      if (startIndex.value() != static_cast<int64_t>(startIndex.index())) {
         return rewriter.notifyMatchFailure(op,
                                            "start_index_map must be in order");
       }

--- a/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/passes.h
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/passes.h
@@ -29,7 +29,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createPrepareMhloPass();
 
 #define GEN_PASS_REGISTRATION
 #define GEN_PASS_DECL_TOSALEGALIZEMHLOPASS
-#include "transforms/passes.h.inc"
+#include "tosa/transforms/passes.h.inc"
 
 }  // namespace tosa
 }  // namespace mlir

--- a/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/prepare_mhlo/prepare_mhlo.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/prepare_mhlo/prepare_mhlo.cc
@@ -18,13 +18,14 @@ limitations under the License.
 
 #include "mhlo/IR/hlo_ops.h"
 #include "mhlo/transforms/rewriters.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "transforms/passes.h"
 
 #define GEN_PASS_DEF_TOSAPREPAREMHLOPASS
-#include "transforms/passes.h.inc"
+#include "tosa/transforms/passes.h.inc"
 
 #define PASS_NAME "tosa-prepare-mhlo"
 #define DEBUG_TYPE PASS_NAME


### PR DESCRIPTION
Prior to this patch, the MHLO tosa directory was skipped in the CMake
builds, and some of the include directives pointed to incorrect header
files.  This patch fixes the build rules and the header paths so that
the mhlo-tosa-opt binary can be built using CMake.