### PR TITLE
Fix crash in BlockLSTM

### DIFF
--- a/tensorflow/core/kernels/rnn/lstm_ops.cc
+++ b/tensorflow/core/kernels/rnn/lstm_ops.cc
@@ -901,6 +901,9 @@ class BlockLSTMOp : public OpKernel {
   void Compute(OpKernelContext* ctx) override {
     const Tensor* seq_len_max_tensor = nullptr;
     OP_REQUIRES_OK(ctx, ctx->input("seq_len_max", &seq_len_max_tensor));
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(seq_len_max_tensor->shape()),
+                errors::InvalidArgument("`seq_len_max_tensor` must be rank 0 but is rank ",
+                                        seq_len_max_tensor->dims()));
 
     const Tensor* x;
     OP_REQUIRES_OK(ctx, ctx->input("x", &x));
@@ -1135,6 +1138,9 @@ class BlockLSTMGradOp : public OpKernel {
   void Compute(OpKernelContext* ctx) override {
     const Tensor* seq_len_max_tensor = nullptr;
     OP_REQUIRES_OK(ctx, ctx->input("seq_len_max", &seq_len_max_tensor));
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(seq_len_max_tensor->shape()),
+                errors::InvalidArgument("`seq_len_max_tensor` must be rank 0 but is rank ",
+                                        seq_len_max_tensor->dims()));
 
     const Tensor* x;
     OP_REQUIRES_OK(ctx, ctx->input("x", &x));

--- a/tensorflow/python/kernel_tests/nn_ops/BUILD
+++ b/tensorflow/python/kernel_tests/nn_ops/BUILD
@@ -568,6 +568,7 @@ cuda_py_test(
         "//tensorflow/python:init_ops",
         "//tensorflow/python:math_ops",
         "//tensorflow/python:platform",
+        "//tensorflow/python:random_ops",
         "//tensorflow/python:rnn",
         "//tensorflow/python:rnn_cell",
         "//tensorflow/python:tensor_array_ops",

--- a/tensorflow/python/kernel_tests/nn_ops/rnn_cell_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/rnn_cell_test.py
@@ -38,6 +38,7 @@ from tensorflow.python.ops import gen_rnn_ops
 from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import init_ops
 from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import random_ops
 from tensorflow.python.ops import rnn
 from tensorflow.python.ops import rnn_cell
 from tensorflow.python.ops import rnn_cell_impl
@@ -1405,6 +1406,42 @@ class LSTMTest(test.TestCase):
               cs_grad=cs_grad,
               h_grad=h_grad,
               use_peephole=use_peephole))
+
+  def testLSTMBlockInvalidArgument(self):
+    # Test case for GitHub issue 58175
+    forget_bias = -121.22699269620765
+    cell_clip = -106.82307555235684
+    use_peephole = False
+    seq_len_max = math_ops.saturate_cast(
+        random_ops.random_uniform(
+            [13, 11, 0],
+            minval=0,
+            maxval=64,
+            dtype=dtypes.int64), dtype=dtypes.int64)
+    x = random_ops.random_uniform([1, 3, 15], dtype=dtypes.float32)
+    cs_prev = random_ops.random_uniform([3, 0], dtype=dtypes.float32)
+    h_prev = random_ops.random_uniform([3, 0], dtype=dtypes.float32)
+    w = random_ops.random_uniform([15, 0], dtype=dtypes.float32)
+    wci = random_ops.random_uniform([0], dtype=dtypes.float32)
+    wcf = random_ops.random_uniform([0], dtype=dtypes.float32)
+    wco = random_ops.random_uniform([0], dtype=dtypes.float32)
+    b = random_ops.random_uniform([0], dtype=dtypes.float32)
+    with self.assertRaises(errors_impl.InvalidArgumentError):
+      self.evaluate(
+          gen_rnn_ops.BlockLSTM(
+              forget_bias=forget_bias,
+              cell_clip=cell_clip,
+              use_peephole=use_peephole,
+              seq_len_max=seq_len_max,
+              x=x,
+              cs_prev=cs_prev,
+              h_prev=h_prev,
+              w=w,
+              wci=wci,
+              wcf=wcf,
+              wco=wco,
+              b=b,
+          ))
 
 
 class BidirectionalRNNTest(test.TestCase):


### PR DESCRIPTION
This PR tries to address the issue raised in 58175 in addressing the crash of BlockLSTM when invalid input is provided.

This PR fixes #58175.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>