### PR TITLE
Make Aarch64 not a legacy platform

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
@@ -278,6 +278,11 @@ class MklConvBwdInputPrimitiveFactory : public MklPrimitiveFactory<T> {
     if (convBwdInputDims.native_format) {
       key_creator.AddAsKey(convBwdInputDims.tf_fmt);
     }
+#ifdef DNNL_AARCH64_USE_ACL
+    // Scratchpad memory for this primitive is cached per thread.
+    // Make sure each thread creates its own primitive.
+    key_creator.AddAsKey(std::this_thread::get_id());
+#endif
     return key_creator.GetKey();
   }
 

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1947,10 +1947,14 @@ class MklPrimitiveFactory {
   /// For those legacy device(w/o AVX512 and AVX2),
   /// MKL-DNN GEMM will be used.
   static inline bool IsLegacyPlatform() {
+#ifdef DNNL_AARCH64_USE_ACL
+    return false;
+#else
     static const bool is_legacy_platform =
         (!port::TestCPUFeature(port::CPUFeature::AVX512F) &&
          !port::TestCPUFeature(port::CPUFeature::AVX2));
     return is_legacy_platform;
+#endif  // DNNL_AARCH64_USE_ACL
   }
 
   /// Function to check whether primitive memory optimization is enabled


### PR DESCRIPTION
This allows for MKL convolution primitives to always be cached on Aarch64.