### PR TITLE
[mhlo] fix build rules for the MhloPasses target

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/mhlo/transforms/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/mhlo/transforms/CMakeLists.txt
@@ -82,6 +82,7 @@ add_mlir_library(MhloPasses
 
   LINK_LIBS PUBLIC
   ChloOps
+  MhloAnalysis
   MhloDialect
   MhloScatterUtils
   MhloTypeConversion

--- a/tensorflow/compiler/xla/mlir_hlo/tools/mlir-hlo-opt/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/tools/mlir-hlo-opt/CMakeLists.txt
@@ -25,7 +25,6 @@ set(LIBS
         GmlStPasses
         LmhloDialect
         LmhloGPUDialect
-        MhloAnalysis
         MhloRegisterDialects
         MhloTestAnalysis
         LmhloPasses


### PR DESCRIPTION
The MhloPasses library, which contains code from
symbolic_shape_optimization.cc, refers to
`ShapeComponentAnalysis::GetValueInfo()`, which is defined in
shape_component_analysis.cc, which is a part of the MhloAnalysis target.
However, the CMake rules for building MhloPasses do not add MhloAnalysis
as a dependency, causing undefined reference errors in downstream
targets.

As an ancillary change, this patch also removes the MhloAnalysis
dependency in the rule for building mlir-hlo-opt, since the now-fixed
dependency in MhloPasses carries over to the mlir-hlo-opt target.