### PR TITLE
keep colocated identity node in remove_training_nodes

### DIFF
--- a/tensorflow/python/framework/graph_util_impl.py
+++ b/tensorflow/python/framework/graph_util_impl.py
@@ -375,15 +375,24 @@ def remove_training_nodes(input_graph, protected_nodes=None):
   types_to_splice = {"Identity": True}
   control_input_names = set()
   node_names_with_control_input = set()
+  node_in_colocated = set()
+
   for node in nodes_after_removal:
     for node_input in node.input:
       if "^" in node_input:
         control_input_names.add(node_input.replace("^", ""))
         node_names_with_control_input.add(node.name)
+    # Prevent colocated nodes from being lost.
+    if "_class" in node.attr:
+      for colocated_node_name in node.attr["_class"].list.s:
+        node_in_colocated.add(
+            _get_colocated_node_name(colocated_node_name))
 
   names_to_splice = {}
   for node in nodes_after_removal:
     if node.op in types_to_splice and node.name not in protected_nodes:
+      if node.name in node_in_colocated:
+        continue
       # We don't want to remove nodes that have control edge inputs, because
       # they might be involved in subtle dependency issues that removing them
       # will jeopardize.

--- a/tensorflow/python/framework/graph_util_test.py
+++ b/tensorflow/python/framework/graph_util_test.py
@@ -28,6 +28,7 @@ from tensorflow.python.framework import test_util
 from tensorflow.python.ops import gen_state_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import variables
+from tensorflow.python.util import compat
 from tensorflow.python.platform import test
 
 
@@ -212,6 +213,11 @@ class GraphUtilTest(test.TestCase):
   def set_attr_dtype(self, node, key, value):
     node.attr[key].CopyFrom(
         attr_value_pb2.AttrValue(type=value.as_datatype_enum))
+  
+  def set_attr_list(self, node, key, value_list):
+    node.attr[key].CopyFrom(
+        attr_value_pb2.AttrValue(
+              list=attr_value_pb2.AttrValue.ListValue(s=value_list)))
 
   def set_attr_tensor(self, node, key, value, dtype, shape=None):
     node.attr[key].CopyFrom(
@@ -222,11 +228,14 @@ class GraphUtilTest(test.TestCase):
   def testRemoveTrainingNodes(self):
     a_constant_name = "a_constant"
     b_constant_name = "b_constant"
+    c_constant_name = "c_constant"
     a_check_name = "a_check"
     b_check_name = "b_check"
     a_identity_name = "a_identity"
     b_identity_name = "b_identity"
+    c_identity_name = "c_identity"
     add_name = "add"
+    sub_name = "sub"
     graph_def = graph_pb2.GraphDef()
     a_constant = self.create_constant_node_def(
         a_constant_name, value=1, dtype=dtypes.float32, shape=[])
@@ -250,6 +259,17 @@ class GraphUtilTest(test.TestCase):
                                     [a_identity_name, b_identity_name])
     self.set_attr_dtype(add_node, "T", dtypes.float32)
     graph_def.node.extend([add_node])
+    c_constant = self.create_constant_node_def(
+        c_constant_name, value=1, dtype=dtypes.float32, shape=[])
+    graph_def.node.extend([c_constant])
+    c_identity_node = self.create_node_def(
+        "Identity", c_identity_name, [c_constant_name])
+    graph_def.node.extend([c_identity_node])
+
+    sub_node = self.create_node_def("Sub", sub_name,
+                                    [c_constant_name, c_identity_name])
+    self.set_attr_list(sub_node, "_class", [compat.as_bytes(c_identity_name)])
+    graph_def.node.extend([sub_node])
 
     expected_output = graph_pb2.GraphDef()
     a_constant = self.create_constant_node_def(
@@ -262,6 +282,17 @@ class GraphUtilTest(test.TestCase):
                                     [a_constant_name, b_constant_name])
     self.set_attr_dtype(add_node, "T", dtypes.float32)
     expected_output.node.extend([add_node])
+    c_constant = self.create_constant_node_def(
+        c_constant_name, value=1, dtype=dtypes.float32, shape=[])
+    expected_output.node.extend([c_constant])
+    c_identity_node = self.create_node_def(
+        "Identity", c_identity_name, [c_constant_name])
+    expected_output.node.extend([c_identity_node])
+
+    sub_node = self.create_node_def("Sub", sub_name,
+                                    [c_constant_name, c_identity_name])
+    self.set_attr_list(sub_node, "_class", [compat.as_bytes(c_identity_name)])
+    expected_output.node.extend([sub_node])
 
     output = graph_util.remove_training_nodes(graph_def)
     self.assertProtoEquals(expected_output, output)


### PR DESCRIPTION
If we simply remove identity nodes, there will be an error 
"Node 'xxx' expects to be colocated with unknown node 'xxx'(identity node)".

So we keep identity nodes which are colocated with other nodes.