### PR TITLE
Fix leak in extract_stacktrace.

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -2119,7 +2119,8 @@ class Operation(object):
 
     # Removes this frame from the Python traceback.
     # We adjust stacklevel directly to avoid triggering serialization.
-    self.traceback._stacklevel += 1  # pylint: disable=protected-access
+    if self.traceback:
+      self.traceback._stacklevel += 1  # pylint: disable=protected-access
 
   @classmethod
   def _from_c_op(cls, c_op, g):

--- a/tensorflow/python/util/stack_trace.h
+++ b/tensorflow/python/util/stack_trace.h
@@ -62,25 +62,31 @@ class StackTrace final {
 
     StackTrace result;
 #if PY_VERSION_HEX >= 0x030B0000
+    PyFrameObject* oldframe;
     PyFrameObject* frame = PyThreadState_GetFrame(PyThreadState_GET());
 #else
     const PyFrameObject* frame = PyThreadState_GET()->frame;
 #endif
     int i = 0;
 #if PY_VERSION_HEX >= 0x030B0000
-    for (; i < limit && frame != nullptr; frame = PyFrame_GetBack(frame), ++i) {
+    for (; i < limit && frame != nullptr; oldframe = frame,
+                                          frame = PyFrame_GetBack(frame),
+                                          Py_DECREF(oldframe), ++i) {
       PyCodeObject* code_obj = PyFrame_GetCode(frame);
 #else
     for (; i < limit && frame != nullptr; frame = frame->f_back, ++i) {
       PyCodeObject* code_obj = frame->f_code;
+      Py_XINCREF(code_obj);
 #endif
       DCHECK(code_obj != nullptr);
 
-      Py_INCREF(code_obj);
       int line_number =
           PyFrame_GetLineNumber(const_cast<PyFrameObject*>(frame));
       result.code_objs_.push_back(std::make_pair(code_obj, line_number));
     }
+#if PY_VERSION_HEX >= 0x030B0000
+    Py_XDECREF(frame);
+#endif
     return result;
   }
 


### PR DESCRIPTION
These are strong references, so we need to unref them.
 Without the fix in Py3.11 op_test.GraphTest.testGarbageCollected fails.