### PR TITLE
Fix crash in stateless_random_binomial when shape type is int64

### DIFF
--- a/tensorflow/core/kernels/random_binomial_op.cc
+++ b/tensorflow/core/kernels/random_binomial_op.cc
@@ -494,7 +494,8 @@ class StatelessRandomBinomialOp : public OpKernel {
     const int64_t num_sample_dims =
         (shape_tensor.dim_size(0) - bcast.output_shape().size());
     for (int64_t i = 0; i < num_sample_dims; ++i) {
-      samples_per_batch *= shape_tensor.flat<int32>()(i);
+      samples_per_batch *= shape_tensor.dtype() == DT_INT32 ?
+          shape_tensor.scalar<int32>()(i) : shape_tensor.scalar<int64_t>()(i);
     }
     int64_t num_batches = 1;
     for (int64_t i = num_sample_dims; i < shape_tensor.dim_size(0); ++i) {

--- a/tensorflow/python/kernel_tests/random/random_binomial_test.py
+++ b/tensorflow/python/kernel_tests/random/random_binomial_test.py
@@ -15,6 +15,7 @@
 """Tests for tensorflow.ops.stateful_random_ops.binomial."""
 import numpy as np
 
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import test_util
 from tensorflow.python.kernel_tests.random import util
@@ -206,6 +207,24 @@ class RandomBinomialTest(test.TestCase):
             stride=stride,
         )
         self.assertAllLess(z_scores, z_limit)
+
+  def testStatelessDtypes(self):
+    # Test case for GitHub issue 59160
+    shape_0 = constant_op.constant(1, dtype=dtypes.int64) #125091515651
+    shape = [shape_0,]
+    seed_0 = 12
+    seed_1 = 34
+    seed = [seed_0,seed_1,]
+    counts = 10.0
+    probs = 0.4
+    output_dtype = dtypes.float16
+    out = stateless_random_ops.stateless_random_binomial(
+        shape=shape,
+        seed=seed,
+        counts=counts,
+        probs=probs,
+        output_dtype=output_dtype)
+    self.evaluate(out)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/random/random_binomial_test.py
+++ b/tensorflow/python/kernel_tests/random/random_binomial_test.py
@@ -208,9 +208,8 @@ class RandomBinomialTest(test.TestCase):
         )
         self.assertAllLess(z_scores, z_limit)
 
-  def testStatelessDtypes(self):
-    # Test case for GitHub issue 59160
-    shape_0 = constant_op.constant(1, dtype=dtypes.int64) #125091515651
+  def testStatelessDtypeInt64(self):
+    shape_0 = constant_op.constant(1, dtype=dtypes.int64)
     shape = [shape_0,]
     seed_0 = 12
     seed_1 = 34


### PR DESCRIPTION
This PR tries to address the issue raised in 59160 where stateless_random_binomial will crash when shape type is int64.

This PR fixes #59160.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>