### PR TITLE
Add the external delegate to the tflite c shared library

### DIFF
--- a/tensorflow/lite/c/BUILD
+++ b/tensorflow/lite/c/BUILD
@@ -42,6 +42,7 @@ tflite_cc_shared_object(
         ":c_api_experimental",
         ":exported_symbols.lds",
         ":version_script.lds",
+        "//tensorflow/lite/delegates/external:external_delegate",
     ],
 )
 

--- a/tensorflow/lite/delegates/external/external_delegate.h
+++ b/tensorflow/lite/delegates/external/external_delegate.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_LITE_DELEGATES_EXTERNAL_EXTERNAL_DELEGATE_H_
 
 #include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/c/c_api_types.h"  // IWYU pragma: export
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,20 +36,20 @@ typedef struct TfLiteExternalDelegateOptions {
 } TfLiteExternalDelegateOptions;
 
 // Insert key/value to the options.
-TfLiteStatus TfLiteExternalDelegateOptionsInsert(
+TFL_CAPI_EXPORT TfLiteStatus TfLiteExternalDelegateOptionsInsert(
     TfLiteExternalDelegateOptions* options, const char* key, const char* value);
 
 // Populates TfLiteExternalDelegateOptions with the given shared library path.
-TfLiteExternalDelegateOptions TfLiteExternalDelegateOptionsDefault(
+TFL_CAPI_EXPORT TfLiteExternalDelegateOptions TfLiteExternalDelegateOptionsDefault(
     const char* lib_path);
 
 // Creates a new delegate instance that need to be destroyed with
 // `TfLiteExternalDelegateDelete` when delegate is no longer used by TFLite.
-TfLiteDelegate* TfLiteExternalDelegateCreate(
+TFL_CAPI_EXPORT TfLiteDelegate* TfLiteExternalDelegateCreate(
     const TfLiteExternalDelegateOptions* options);
 
 // Destroys a delegate created with `TfLiteExternalDelegateCreate` call.
-void TfLiteExternalDelegateDelete(TfLiteDelegate* delegate);
+TFL_CAPI_EXPORT void TfLiteExternalDelegateDelete(TfLiteDelegate* delegate);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds the [external delegate](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/delegates/external) cc_library to the tflite C api's `tflite_cc_shared_object` so it can be used from the `//tensorflow/lite/c:libtensorflowlite_c.so` shared object.

~This does not appear to increase the binary size at all (using `wc -c` to check), so I assume it may already have been linked but not exposed.~ It is not included. I'm investigating why. I'd convert this PR to a draft, but I can't seem to do that.

If this doesn't seem like the right approach, I can instead add a new `tflite_cc_shared_object` target to `tensorflow/lite/delegates/external/BUILD` just for the external delegate.