### PR TITLE
[NVIDIA TF] Avoid cudaSetDevice to "invisible" GPU in CreateDevices

### DIFF
--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -1382,7 +1382,12 @@ Status BaseGPUDeviceFactory::CreateDevices(
                          std::make_pair(priority_low, priority_high)));
 #endif
     }
-    // Reset to the original device.
+    // Reset to the original device, if it is a valid visible gpu. Otherwise use
+    // the first visible device.
+    if (std::find(visible_gpu_order.begin(), visible_gpu_order.end(),
+                  original_device) == visible_gpu_order.end()) {
+      original_device = visible_gpu_order[0].value();
+    }
 #if GOOGLE_CUDA
     err = cudaSetDevice(original_device);
     if (err != cudaSuccess) {

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -1383,10 +1383,11 @@ Status BaseGPUDeviceFactory::CreateDevices(
 #endif
     }
     // Reset to the original device, if it is a valid visible gpu. Otherwise use
-    // the first visible device.
-    if (std::find(visible_gpu_order.begin(), visible_gpu_order.end(),
-                  original_device) == visible_gpu_order.end()) {
-      original_device = visible_gpu_order[0].value();
+    // the first valid device.
+    if (std::find(valid_platform_device_ids.begin(),
+                  valid_platform_device_ids.end(),
+                  original_device) == valid_platform_device_ids.end()) {
+      original_device = valid_platform_device_ids[0].value();
     }
 #if GOOGLE_CUDA
     err = cudaSetDevice(original_device);


### PR DESCRIPTION
CreateDevices caches and re-stores the current device with cudaGetDevice and cudaSetDevice. Before any CUDA devices have been initialized, cudaGetDevice returns a default value of zero. So, if device zero is not among the visible devices, the function will "restore" (call cudaSetDevice on) an ineligible GPU. This was previously harmless, but in some cases (e.g., CUDA 12 with CUDA lazy module laoding enabled) it can now result in a spurious CUDA context being created on device zero.

This PR fixes the problem by restoring the original device only if it is among the set of visible GPUs. Otherwise, the first listed visible GPU is set.