### PR TITLE
Fix bincount crash when value < 0

### DIFF
--- a/tensorflow/core/kernels/bincount_op.cc
+++ b/tensorflow/core/kernels/bincount_op.cc
@@ -185,7 +185,7 @@ struct BincountReduceFunctor<CPUDevice, Tidx, T, binary_output> {
               Tidx value = in(i, j);
               if (value < 0) {
                 status.Update(errors::InvalidArgument(
-                    "value must be positive, got value[", i, ", ",
+                    "Value must be non-negative, got value[", i, ", ",
                     j, "] = ",value));
                 return;
               }

--- a/tensorflow/python/kernel_tests/math_ops/bincount_op_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/bincount_op_test.py
@@ -178,6 +178,22 @@ class BincountTest(test_util.TensorFlowTestCase):
               weights=weights,
               binary_output=binary_output))
 
+  def test_negative_value(self):
+    with self.assertRaises(errors.InvalidArgumentError):
+      arg_0_tensor = random_ops.random_uniform(
+          [3, 1], minval=-256, maxval=257, dtype=dtypes.int32)
+      arg_0 = array_ops.identity(arg_0_tensor)
+      weights = None
+      minlength = 2
+      maxlength = 0
+      dtype = "float32"
+      axis = -1
+      binary_output = True
+      out = bincount_ops.bincount(
+          arg_0, weights=weights, minlength=minlength, maxlength=maxlength,
+          dtype=dtype, axis=axis, binary_output=binary_output)
+      self.evaluate(out)
+
 
 class BincountOpTest(test_util.TensorFlowTestCase, parameterized.TestCase):
 

--- a/tensorflow/python/kernel_tests/math_ops/bincount_op_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/bincount_op_test.py
@@ -180,9 +180,9 @@ class BincountTest(test_util.TensorFlowTestCase):
 
   def test_negative_value(self):
     with self.assertRaises(errors.InvalidArgumentError):
-      arg_0_tensor = random_ops.random_uniform(
+      value_tensor = random_ops.random_uniform(
           [3, 1], minval=-256, maxval=257, dtype=dtypes.int32)
-      arg_0 = array_ops.identity(arg_0_tensor)
+      value = array_ops.identity(value_tensor)
       weights = None
       minlength = 2
       maxlength = 0
@@ -190,7 +190,7 @@ class BincountTest(test_util.TensorFlowTestCase):
       axis = -1
       binary_output = True
       out = bincount_ops.bincount(
-          arg_0, weights=weights, minlength=minlength, maxlength=maxlength,
+          value, weights=weights, minlength=minlength, maxlength=maxlength,
           dtype=dtype, axis=axis, binary_output=binary_output)
       self.evaluate(out)
 

--- a/tensorflow/python/kernel_tests/math_ops/bincount_op_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/bincount_op_test.py
@@ -183,15 +183,9 @@ class BincountTest(test_util.TensorFlowTestCase):
       value_tensor = random_ops.random_uniform(
           [3, 1], minval=-256, maxval=257, dtype=dtypes.int32)
       value = array_ops.identity(value_tensor)
-      weights = None
-      minlength = 2
-      maxlength = 0
-      dtype = "float32"
-      axis = -1
-      binary_output = True
       out = bincount_ops.bincount(
-          value, weights=weights, minlength=minlength, maxlength=maxlength,
-          dtype=dtype, axis=axis, binary_output=binary_output)
+          value, weights=None, minlength=2, maxlength=0,
+          dtype=dtypes.float32, axis=-1, binary_output=True)
       self.evaluate(out)
 
 


### PR DESCRIPTION
This PR tries to address the issue raised in #59130 where bincount will crash when value is less than zero.

This PR fixes #59130.


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>