### PR TITLE
Correct index check for Tensor::SubSlice() method accordingly to documentation and SubBuffer() checks

### DIFF
--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -1016,13 +1016,13 @@ Tensor Tensor::SubSlice(int64_t index) const {
   CHECK_GE(dims(), 1);  // Crash ok.
   CHECK_LE(0, index);   // Crash ok.
   int64_t dim0_size = shape_.dim_size(0);
-  CHECK_LE(index, dim0_size);  // Crash ok.
   Tensor ret;
   ret.shape_ = shape_;
   ret.shape_.RemoveDim(0);
   ret.set_dtype(dtype());
   ret.buf_ = nullptr;
   if (dim0_size > 0) {
+    CHECK_LT(index, dim0_size);  // Crash ok.
     const int64_t elems_per_dim0 = NumElements() / dim0_size;
     const int64_t delta = index * elems_per_dim0;
     const int64_t num_elems = elems_per_dim0;


### PR DESCRIPTION
Found during fuzz testing Tensor::SubSlice() function - it allows to pass 'index' that is equal to dimension(0) size.
Instead of failing on
`CHECK_LE(index, dim0_size);  // Crash ok.` (line 1019)
it fails here:
`CHECK_LE(this->base<T>() + n, root_limit);` (line 964)
line in the SubBuffer constructor for all types, except signed and unsigned char (where it triggers ASAN violation - this will be fixed separately).

P.S. What should be done for tensor with dim_size(0) = 0? Before this change it allows operation for index == 0 and failed for others.
With this fix 'index' will be entirely ignored for this case. Is it the intended behaviour?