### PR TITLE
Rewrite check in SubBuffer() constructor to satisfy ASAN checks

### DIFF
--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -961,8 +961,7 @@ class SubBuffer : public TensorBuffer {
     CHECK_LE(root_->base<T>(), this->base<T>());
     T* root_limit = root_->base<T>() + root_->size() / sizeof(T);
     CHECK_LE(this->base<T>(), root_limit);
-    size_t max_n = root_limit - this->base<T>();
-    CHECK_LE(n, max_n);
+    CHECK_LE(n, root_limit - this->base<T>());
     // Hold a ref of the underlying root buffer.
     // NOTE: 'buf' is a sub-buffer inside the 'root_' buffer.
     root_->Ref();

--- a/tensorflow/core/framework/tensor.cc
+++ b/tensorflow/core/framework/tensor.cc
@@ -961,7 +961,8 @@ class SubBuffer : public TensorBuffer {
     CHECK_LE(root_->base<T>(), this->base<T>());
     T* root_limit = root_->base<T>() + root_->size() / sizeof(T);
     CHECK_LE(this->base<T>(), root_limit);
-    CHECK_LE(this->base<T>() + n, root_limit);
+    size_t max_n = root_limit - this->base<T>();
+    CHECK_LE(n, max_n);
     // Hold a ref of the underlying root buffer.
     // NOTE: 'buf' is a sub-buffer inside the 'root_' buffer.
     root_->Ref();


### PR DESCRIPTION
Compare elements count instead of pointers to omit default ostream<<(signed char*) behaviour and fix undefined behaviour - pointer should point into the allocated memory or one element past it while in this check it may point far past allocated memory.

Found during fuzz testing of Tensor::SubSlice() method, the original problem was fixed [here](https://github.com/tensorflow/tensorflow/pull/59266).