### PR TITLE
Cache the reordered weight tensors to avoid redundant reorders for MklEinsum

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -489,10 +489,10 @@ class MklDnnMatMulOpBase : public OpKernel {
 
   // Cache the converted weight in a tensor.
   // Only one thread can execute this method at any given time.
+  template <typename T>
   void CacheWeight(
       OpKernelContext* context,
-      const std::shared_ptr<dnnl::inner_product_forward::primitive_desc>&
-          matmul_fwd_pd,
+      const std::shared_ptr<T>& matmul_fwd_pd,
       Tweight* weight_data, const Tensor& weight_tensor,
       MklDnnData<Tweight>& weight, const memory::desc& weight_md)
       TF_LOCKS_EXCLUDED(mu_) {


### PR DESCRIPTION
This PR adds caching support for the additional weight reorders. The weight reorders are required for some backend kernels for efficient gemm operations, for e.g. ACL gemm kernels need the weights in a blocked format. We tested Bert Sentiment Analysis [model](https://tfhub.dev/google/experts/bert/wiki_books/sst2/2) inference on AWS c7g platform with oneDNN backend. At TFServing level we observed
(i) ~20% improvement for latency for the optimized reorder kernels, and
(ii)  ~3x improvement for the unoptimized reorder kernels