### PR TITLE
Fix possible buffer underflow in hlo_parser

### DIFF
--- a/tensorflow/compiler/xla/service/hlo_parser.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser.cc
@@ -3701,6 +3701,9 @@ bool HloParserImpl::ParseDenseLiteral(Literal* literal, const Shape& shape) {
         break;
       }
       case TokKind::kRbrace: {
+        if (nest_level == 0) {
+          return TokenError("unexpected '}' token");
+        }
         nest_level--;
         if (elems_seen_per_dim[nest_level] != shape.dimensions(nest_level)) {
           return TokenError(absl::StrFormat(

--- a/tensorflow/compiler/xla/service/hlo_parser_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser_test.cc
@@ -2616,6 +2616,20 @@ ENTRY %configuration_test() -> s32[] {
                            ->raw_backend_config_string());
 }
 
+TEST_F(HloParserTest, LiteralDimensionsError) {
+  const std::string original = R"(HloModule some_2x3_module
+
+ENTRY %some_2x3 () -> f32[2,3] {
+  ROOT %constant = f32[2,3]{1,0} constant(}{1, 2, 3}, {4, 5, 6}})
+}
+
+)";
+  auto result = ParseAndReturnUnverifiedModule(original);
+  EXPECT_NE(OkStatus(), result.status());
+  ExpectHasSubstr(result.status().error_message(),
+                  "unexpected '}' token");
+}
+
 TEST_F(HloParserTest, LiteralDimensionsMismatch_1) {
   const std::string original = R"(HloModule some_2_module
 


### PR DESCRIPTION
Possible buffer underflow if `nest_level` becomes negative.

This PR is part of https://github.com/tensorflow/tensorflow/pull/57892

Bug was found by [Svace static analyzer](https://www.ispras.ru/en/technologies/svace/) (more [info](https://svace.pages.ispras.ru/svace-website/en/)).