### PR TITLE
[oneDNN] A new pattern for _MklFusedBatchMatMulV2 with preceding Mul op

### DIFF
--- a/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
@@ -822,9 +822,103 @@ class MklFusedBatchMatMul : public MklRemapperTest {
 
     auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
     auto tensors = EvaluateNodes(output, item.fetch, item.feed);
-    std::is_same<T, float>::value
-        ? test::ExpectClose(tensors_expected[0], tensors[0], 1e-6, 1e-6)
-        : test::ExpectClose(tensors_expected[0], tensors[0], 1e-2, 1e-2);
+    float atol = 1e-6, rtol = 1e-6;
+    if (std::is_same<T, bfloat16>::value) {
+      atol = 1e-2;
+      rtol = 1e-2;
+    }
+    test::ExpectClose(tensors_expected[0], tensors[0], atol, rtol);
+  }
+
+  template <typename T>
+  void VerifyPreceedingScalarMul(bool adjx, bool adjy) {
+    using ::tensorflow::ops::Placeholder;
+    using normal_generator = Eigen::internal::NormalRandomGenerator<T>;
+
+    int b0 = 2;
+    int b1 = 2;
+    int m = 32;
+    int k = 16;
+    int n = 64;
+
+    tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+
+    auto input_shape =
+        adjx ? TensorShape({b0, b1, k, m}) : TensorShape({b0, b1, m, k});
+    auto weight_shape =
+        adjy ? TensorShape({b0, b1, n, k}) : TensorShape({b0, b1, k, n});
+    auto add_shape = TensorShape({b0, 1, m, n});
+
+    auto input_placeholder_shape = ops::Placeholder::Shape(input_shape);
+    auto weight_placeholder_shape = ops::Placeholder::Shape(weight_shape);
+    auto add_placeholder_shape = ops::Placeholder::Shape(add_shape);
+
+    const DataType dtype = DataTypeToEnum<T>::v();
+    auto input =
+        Placeholder(s.WithOpName("input"), dtype, input_placeholder_shape);
+    auto weight =
+        Placeholder(s.WithOpName("weight"), dtype, weight_placeholder_shape);
+    auto addend =
+        Placeholder(s.WithOpName("addend"), dtype, add_placeholder_shape);
+
+    auto scale_const = ops::Const(s.WithOpName("scale_const"), {0.1f});
+    auto scale = ops::Cast(s.WithOpName("scale"), scale_const, dtype);
+    auto mul = ops::Multiply(s.WithOpName("mul"), input, scale);
+    auto batchmatmul =
+        ops::BatchMatMulV2(s.WithOpName("batchmatmul"), mul, weight,
+                           ops::BatchMatMulV2::Attrs().AdjX(adjx).AdjY(adjy));
+    auto add = ops::Add(s.WithOpName("add"), batchmatmul, addend);
+    auto fetch = ops::Identity(s.WithOpName("fetch"), add);
+
+    Tensor input_t = Tensor(dtype, input_shape);
+    Tensor weight_t = Tensor(dtype, weight_shape);
+    Tensor add_t = Tensor(dtype, add_shape);
+    input_t.flat<T>() =
+        input_t.flat<T>().template setRandom<normal_generator>();
+    weight_t.flat<T>() =
+        weight_t.flat<T>().template setRandom<normal_generator>();
+    add_t.flat<T>() = add_t.flat<T>().template setRandom<normal_generator>();
+
+    GrapplerItem item;
+    item.fetch = {"fetch"};
+    item.feed = {{"input", input_t}, {"weight", weight_t}, {"addend", add_t}};
+    TF_CHECK_OK(s.ToGraphDef(&item.graph));
+
+    // Place all nodes on CPU.
+    for (int i = 0; i < item.graph.node_size(); ++i) {
+      item.graph.mutable_node(i)->set_device("/device:CPU:0");
+    }
+
+    Remapper optimizer(RewriterConfig::ON);
+    GraphDef output;
+    TF_CHECK_OK(optimizer.Optimize(nullptr, item, &output));
+
+    int found = 0;
+    for (const NodeDef& node : output.node()) {
+      if (node.name() == "add") {
+        EXPECT_EQ("_MklFusedBatchMatMulV2", node.op());
+        EXPECT_EQ("input", node.input(0));
+        EXPECT_EQ("weight", node.input(1));
+        EXPECT_EQ("scale", node.input(2));
+        EXPECT_EQ("addend", node.input(3));
+        const auto fused_ops = node.attr().at("fused_ops").list().s();
+        EXPECT_EQ(2, fused_ops.size());
+        EXPECT_EQ("Mul", fused_ops[0]);
+        found++;
+        EXPECT_EQ("Add", fused_ops[1]);
+        found++;
+      }
+    }
+    EXPECT_EQ(2, found);
+
+    auto tensors_expected = EvaluateNodes(item.graph, item.fetch, item.feed);
+    auto tensors = EvaluateNodes(output, item.fetch, item.feed);
+    float atol = 1e-6, rtol = 1e-6;
+    if (std::is_same<T, bfloat16>::value) {
+      atol = 1e-2;
+      rtol = 1e-2;
+    }
+    test::ExpectClose(tensors_expected[0], tensors[0], atol, rtol);
   }
 };
 
@@ -833,6 +927,14 @@ TEST_F(MklFusedBatchMatMul, MulAndAdd) {
     for (const auto adjy : {false, true}) {
       this->VerifyFused<float>(adjx, adjy);
       this->VerifyFused<bfloat16>(adjx, adjy);
+    }
+}
+
+TEST_F(MklFusedBatchMatMul, MulAndAdd2) {
+  for (const auto adjx : {false, true})
+    for (const auto adjy : {false, true}) {
+      this->VerifyPreceedingScalarMul<float>(adjx, adjy);
+      this->VerifyPreceedingScalarMul<bfloat16>(adjx, adjy);
     }
 }
 

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -2259,14 +2259,16 @@ bool FindTensorToHashBucket(const RemapperContext& ctx, int node_index,
 
 bool FindFusedBatchMatMul(RemapperContext* ctx, int node_index,
                           std::map<string, int>* matched_nodes_map,
-                          std::set<int>* remove_node_indices) {
+                          std::set<int>* remove_node_indices,
+                          std::vector<string>* input_node_names) {
   if (!IsMKLEnabled()) return false;
 
   using utils::MatchingDirection;
   using utils::NodeStatus;
+  int pattern = 0;
   // clang-format off
   utils::OpTypePattern fusion_pattern1 =
-    {"AddV2", "output", NodeStatus::kReplace,
+    {"Add|AddV2", "output", NodeStatus::kReplace,
       {
         {"Mul", "mul", NodeStatus::kRemove,
           {
@@ -2279,15 +2281,20 @@ bool FindFusedBatchMatMul(RemapperContext* ctx, int node_index,
     };
 
   utils::OpTypePattern fusion_pattern2 =
-    {"AddV2", "output", NodeStatus::kReplace,
+    {"Add|AddV2", "output", NodeStatus::kReplace,
       {
-        {"*", "addend", NodeStatus::kRemain},
-        {"Mul", "mul", NodeStatus::kRemove,
+        {"BatchMatMulV2", "batch_matmul", NodeStatus::kRemove,
           {
-            {"BatchMatMulV2", "batch_matmul", NodeStatus::kRemove},
-            {"*", "multiplicand", NodeStatus::kRemain}
+            {"Mul", "mul", NodeStatus::kRemove,
+              {
+                {"*", "mul_input0", NodeStatus::kRemain},
+                {"Const|Cast", "multiplicand", NodeStatus::kRemain}
+              }
+            },
+            {"*", "bmm_input1", NodeStatus::kRemain}
           }
-        }
+        },
+        {"*", "addend", NodeStatus::kRemain}
       }
     };
   // clang-format on
@@ -2301,6 +2308,7 @@ bool FindFusedBatchMatMul(RemapperContext* ctx, int node_index,
       graph_matcher.GetMatchedNodes(fusion_pattern1, ctx->nodes_to_preserve,
                                     ctx->graph_view.GetNode(node_index),
                                     matched_nodes_map, remove_node_indices);
+  if (found_op_type_match) pattern = 1;
 
   if (!found_op_type_match) {
     matched_nodes_map->clear();
@@ -2309,6 +2317,7 @@ bool FindFusedBatchMatMul(RemapperContext* ctx, int node_index,
         graph_matcher.GetMatchedNodes(fusion_pattern2, ctx->nodes_to_preserve,
                                       ctx->graph_view.GetNode(node_index),
                                       matched_nodes_map, remove_node_indices);
+    if (found_op_type_match) pattern = 2;
   }
 
   // OneDNN is not optimized for all shapes with regard to binary-post ops
@@ -2344,8 +2353,24 @@ bool FindFusedBatchMatMul(RemapperContext* ctx, int node_index,
   auto addend_props =
       ctx->graph_properties.GetOutputProperties(addend_node_def->name());
   auto addend_shape = addend_props[0].shape();
-  if (!(Rank(addend_shape) == 4 && addend_shape.dim(1).size() == 1))
+  if (!(Rank(addend_shape) == 4 && addend_shape.dim(1).size() == 1)) {
     return false;
+  }
+  input_node_names->clear();
+  input_node_names->resize(4);
+  if (pattern == 1) {
+    input_node_names->at(0) = batch_matmul_node_def->input(0);
+    input_node_names->at(1) = batch_matmul_node_def->input(1);
+    input_node_names->at(2) = multiplicand_node_def->name();
+    input_node_names->at(3) = addend_node_def->name();
+  } else if (pattern == 2) {
+    auto* mul_input0_node_def =
+        ctx->graph_view.GetNode(matched_nodes_map->at("mul_input0"))->node();
+    input_node_names->at(0) = mul_input0_node_def->name();
+    input_node_names->at(1) = batch_matmul_node_def->input(1);
+    input_node_names->at(2) = multiplicand_node_def->name();
+    input_node_names->at(3) = addend_node_def->name();
+  }
   return found_op_type_match;
 }
 
@@ -3484,25 +3509,19 @@ Status AddTensorToHashBucketNode(RemapperContext* ctx,
 Status AddFusedBatchMatMul(RemapperContext* ctx,
                            const std::map<string, int>& matched_nodes_map,
                            const std::set<int>& remove_node_indices,
+                           const std::vector<string>& input_node_names,
                            std::vector<bool>* invalidated_nodes,
                            std::vector<bool>* nodes_to_delete) {
   auto* output_node =
       ctx->graph_view.GetNode(matched_nodes_map.at("output"))->node();
   auto* batch_matmul_node =
       ctx->graph_view.GetNode(matched_nodes_map.at("batch_matmul"))->node();
-  auto* multiplicand_node =
-      ctx->graph_view.GetNode(matched_nodes_map.at("multiplicand"))->node();
-  auto* addend_node =
-      ctx->graph_view.GetNode(matched_nodes_map.at("addend"))->node();
 
   NodeDef fused_node;
   fused_node.set_name(output_node->name());
   fused_node.set_op("_MklFusedBatchMatMulV2");
   fused_node.set_device(batch_matmul_node->device());
-  fused_node.add_input(batch_matmul_node->input(0));
-  fused_node.add_input(batch_matmul_node->input(1));
-  fused_node.add_input(multiplicand_node->name());
-  fused_node.add_input(addend_node->name());
+  for (const auto& name : input_node_names) fused_node.add_input(name);
 
   CopyBatchMatMulAttributes(*batch_matmul_node, &fused_node);
   SetFusedOpAttributes(&fused_node, {"Mul", "Add"}, /*num_args=*/2);
@@ -3910,6 +3929,7 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
 
       std::map<string, int> matched_nodes_map;
       std::set<int> remove_node_indices;
+      std::vector<string> input_node_names;
 
       // Softplus + Tanh + Mul to Mish conversion
       matched_nodes_map.clear();
@@ -3925,11 +3945,12 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
       // Remap BatchMatMul+Mul+AddV2 into the _FusedBatchMatMul.
       matched_nodes_map.clear();
       remove_node_indices.clear();
+      input_node_names.clear();
       if (FindFusedBatchMatMul(&ctx, i, &matched_nodes_map,
-                               &remove_node_indices)) {
-        TF_RETURN_IF_ERROR(
-            AddFusedBatchMatMul(&ctx, matched_nodes_map, remove_node_indices,
-                                &invalidated_nodes, &nodes_to_delete));
+                               &remove_node_indices, &input_node_names)) {
+        TF_RETURN_IF_ERROR(AddFusedBatchMatMul(
+            &ctx, matched_nodes_map, remove_node_indices, input_node_names,
+            &invalidated_nodes, &nodes_to_delete));
         continue;
       }
 


### PR DESCRIPTION
This PR adds a new pattern for _MklFusedBatchMatMulV2  seen in DistilBert with preceding Mul op 
i.e. Mul -> BatchMatMulV2 -> Add and a test for the same.
co-authored by : @syedshahbaaz 