### PR TITLE
[oneDNN] Fix the collective_test python failure with tensorflow:devel container

### DIFF
--- a/tensorflow/dtensor/python/tests/test_util.py
+++ b/tensorflow/dtensor/python/tests/test_util.py
@@ -275,7 +275,7 @@ class DTensorBaseTest(tf_test.TestCase, parameterized.TestCase):
       self.assertEqual(
           api.fetch_layout(result_dtensor),
           expected_layout,
-          msg='========\nexpected layout is\n  {}\n\nwhile got layout is\n  {}\n'
+          msg='=======\nexpected layout is\n  {}\n\nwhile got layout is\n  {}\n'
           .format(expected_str, got_str))
 
     layout = api.fetch_layout(result_dtensor)

--- a/tensorflow/dtensor/python/tests/test_util.py
+++ b/tensorflow/dtensor/python/tests/test_util.py
@@ -281,13 +281,14 @@ class DTensorBaseTest(tf_test.TestCase, parameterized.TestCase):
     layout = api.fetch_layout(result_dtensor)
     unpacked = [t.numpy() for t in api.unpack(result_dtensor)]
 
-    # Check dtype.
-    self.assertEqual(expected_result.dtype, result_dtensor.dtype,
-                     result_dtensor)
     # Check global shape.
     self.assertAllEqual(expected_result.shape, result_dtensor.shape)
 
     result_dtensor = numpy_util.to_numpy(result_dtensor)
+
+    # Check dtype.
+    self.assertEqual(expected_result.dtype, result_dtensor.dtype,
+                     result_dtensor)
 
     # Check value on concatenated result DTensor.
     self.assertAllClose(expected_result, result_dtensor, atol=tol, rtol=tol)

--- a/tensorflow/dtensor/python/tests/test_util.py
+++ b/tensorflow/dtensor/python/tests/test_util.py
@@ -287,6 +287,8 @@ class DTensorBaseTest(tf_test.TestCase, parameterized.TestCase):
     result_dtensor = numpy_util.to_numpy(result_dtensor)
 
     # Check dtype.
+    # Note: This check needs be after result_dtensor is converted
+    # into numpy, due to failure with Numpy version 1.18.5.
     self.assertEqual(expected_result.dtype, result_dtensor.dtype,
                      result_dtensor)
 


### PR DESCRIPTION
This PR fixes collective_combine_all_reduce_test_cpu and collective_test_cpu python tests, which fail when run in tensorflow:devel docker container, due to the older version of numpy.
Numpy version used in container is 1.18.5, which shows above test failures. The tests are fixed by moving the dtype check after the result_dtensor is converted to numpy array from dtensor.