### PR TITLE
adding tests for binary ops over large tensors

### DIFF
--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -236,7 +236,6 @@ tf_kernel_library(
     tags = ["manual"],
     deps = if_mlir_generated_gpu_kernels_enabled([
         ":base_gpu_op",
-        ":gpu_add_v2_kernels",
         ":gpu_atan2_kernels",
         ":gpu_bitwise_and_kernels",
         ":gpu_bitwise_or_kernels",
@@ -265,13 +264,21 @@ tf_kernel_library(
         ":gpu_right_shift_kernels",
         ":gpu_select_v2_kernels",
         ":gpu_squared_difference_kernels",
-        ":gpu_sub_kernels",
         ":gpu_xdivy_kernels",
         ":gpu_xlog1py_kernels",
         ":gpu_xlogy_kernels",
         ":gpu_zeta_kernels",
         "//third_party/eigen3",
-    ]),
+    ]) + if_mlir_generated_experimental_kernels_enabled(
+        [
+            ":gpu_add_v2_kernels_experimental",
+            ":gpu_sub_kernels_experimental",
+        ],
+        [
+            ":gpu_add_v2_kernels",
+            ":gpu_sub_kernels",
+        ],
+    ),
 )
 
 tf_kernel_library(
@@ -1296,6 +1303,25 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_add_v2_kernels_experimental",
+    op = "add_v2",
+    tile_size = "1024",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "i8",
+        "i16",
+        "i32",
+        "i64",
+        "c64",
+        "c128",
+    ],
+    types = [],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
     name = "gpu_div_kernels",
     jit_types = [
         "i8",
@@ -1524,6 +1550,29 @@ gpu_kernel_library(
         "c64",
         "c128",
     ],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
+    name = "gpu_sub_kernels_experimental",
+    op = "sub",
+    tile_size = "1024",
+    jit_types = [
+        "i8",
+        "i16",
+        "ui8",
+        "ui16",
+    ],
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "i32",
+        "i64",
+        "c64",
+        "c128",
+    ],
+    types = [],
     unroll_factors = "4",
 )
 

--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -555,8 +555,28 @@ tf_cuda_cc_test(
     ],
 )
 
-# Trigonometric kernels
+tf_cuda_cc_test(
+    name = "gpu_binary_ops_large_tensor_test",
+    size = "large",
+    srcs = ["gpu_binary_ops_large_tensor_test.cc"],
+    extra_copts = if_mlir_generated_experimental_kernels_enabled([
+        "-DMLIR_GENERATED_EXPERIMENTAL_KERNELS_ENABLED",
+    ]) + if_mlir_generated_gpu_kernels_enabled(
+        ["-DMLIR_GENERATED_GPU_KERNELS_ENABLED"],
+    ),
+    tags = tf_cuda_tests_tags() + [
+        "no_cuda_asan",  # TODO(b/171341759): re-enable.
+        "no_cuda",  # TODO(b/196608406): re-enable
+    ],
+    deps = [
+        ":base_binary_ops_test",
+        ":base_ops_test",
+        "//tensorflow/core/common_runtime:device",
+        "//tensorflow/core/common_runtime:device_factory",
+    ],
+)
 
+# Trigonometric kernels.
 gpu_kernel_library(
     name = "gpu_acos_kernels",
     op = "acos",

--- a/tensorflow/core/kernels/mlir_generated/base_binary_ops_test.h
+++ b/tensorflow/core/kernels/mlir_generated/base_binary_ops_test.h
@@ -132,7 +132,7 @@ class BinaryOpsTestBase : public OpsTestBase {
                        BaselineOutT (*baseline_callback)(BaselineT, BaselineT),
                        const test::OpsTestConfig& config) {
     // Prepare inputs.
-    int input_size = shape.num_elements();
+    int64_t input_size = shape.num_elements();
     CHECK(lhs_input.size() <= input_size && rhs_input.size() <= input_size &&
           "expect input shape to hold all input values");
     auto repeated_lhs_input =
@@ -375,7 +375,7 @@ class BinaryOpsTestBase : public OpsTestBase {
       std::vector<int> rhs_indices, absl::InlinedVector<T, 10> rhs_input,
       BaselineOutT (*baseline_callback)(BaselineT, BaselineT)) {
     absl::InlinedVector<OutT, 10> expected_output;
-    for (int i = 0; i < lhs_indices.size(); i++) {
+    for (int64_t i = 0; i < lhs_indices.size(); i++) {
       auto lhs = static_cast<BaselineT>(lhs_input[lhs_indices[i]]);
       auto rhs = static_cast<BaselineT>(rhs_input[rhs_indices[i]]);
       auto result = static_cast<OutT>(baseline_callback(lhs, rhs));

--- a/tensorflow/core/kernels/mlir_generated/gpu_binary_ops_large_tensor_test.cc
+++ b/tensorflow/core/kernels/mlir_generated/gpu_binary_ops_large_tensor_test.cc
@@ -1,0 +1,74 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/mlir_generated/base_ops_test.h"
+#include "tensorflow/core/kernels/mlir_generated/base_binary_ops_test.h"
+
+namespace tensorflow {
+namespace {
+// Test fixture `BianryOpsLargeTensorTest` that sets the TF device is expected by
+// the TEST macros below.
+class BinaryOpsLargeTensorTest : public BinaryOpsTestBase {
+ protected:
+  void SetUp() override {
+    std::unique_ptr<tensorflow::Device> device_gpu(
+        tensorflow::DeviceFactory::NewDevice("GPU", {},
+                                             "/job:a/replica:0/task:0"));
+    SetDevice(tensorflow::DEVICE_GPU, std::move(device_gpu));
+  }
+};
+
+template <typename T>
+T baseline_add(T lhs, T rhs) {
+  return lhs + rhs;
+}
+
+template <typename T>
+T baseline_sub(T lhs, T rhs) {
+  return lhs - rhs;
+}
+
+/// Test `tf.Addv2`.
+
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED) && \
+    defined(MLIR_GENERATED_EXPERIMENTAL_KERNELS_ENABLED)
+
+TEST_F(BinaryOpsLargeTensorTest, AddV2LargeTensors) {
+  TestEqualShapes<float, float, float, float>(
+      "AddV2", /*shape=*/test::DefaultInputShapeExceedingInt32(),
+      test::DefaultInput<float>(),
+      test::DefaultInput<float>(), baseline_add,
+      test::OpsTestConfig().ExpectStrictlyEqual());
+}
+
+#endif
+
+/// Test `tf.Sub`.
+
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED) && \
+    defined(MLIR_GENERATED_EXPERIMENTAL_KERNELS_ENABLED)
+
+TEST_F(BinaryOpsLargeTensorTest, SubLargeTensors) {
+  TestEqualShapes<float, float, float, float>(
+      "Sub", /*shape=*/test::DefaultInputShapeExceedingInt32(),
+      test::DefaultInput<float>(),
+      test::DefaultInput<float>(), baseline_sub,
+      test::OpsTestConfig().ExpectStrictlyEqual());
+}
+
+#endif
+
+}  // namespace
+}  // namespace tensorflow


### PR DESCRIPTION
This PR is aimed to enable the binary MLIR generated kernel tests. We shall proceed with this PR after integration of the binary op PR. 
@frgossen 