### PR TITLE
[oneDNN][tfg] NOT a PR - PDLL type expression test.

### DIFF
--- a/tensorflow/core/transforms/remapper/pdll/mkl_patterns.pdll
+++ b/tensorflow/core/transforms/remapper/pdll/mkl_patterns.pdll
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "mlir/IR/OpBase.td"
+#include "tensorflow/core/ir/types/types.td"
+#include "tensorflow/core/ir/ops.td"
 #include "tensorflow/core/transforms/utils/pdll/utils.pdll"
 
 Constraint AttrIsF32OrBF16(attr: Attr) [{
@@ -50,4 +52,11 @@ Pattern SigmoidAndMul1 {
   let root = op<tfg.Mul>(arg, sigmoid_arg.0, controls: ValueRange) { "T" = x: AttrIsF32OrBF16};
   OpHasCpuDevice(root);
   replace root with ReplaceMulWith_MklSwish(root, arg, controls);
+}
+
+// Testing type-expression for type belonging to a dialect.
+Pattern {
+  let res_type: TypeRange;
+  let ctl_type = type<"!tf_type.control">;
+  erase op<tfg.non_existing_op> -> (res_type, ctl_type);
 }


### PR DESCRIPTION
@ChiaHungDuan  Could you please give me a favor getting around build error?

**Reproducer:**
`bazel build -c opt //tensorflow/core/transforms:tfg-transforms-opt`

**Error:**
```
tensorflow/core/transforms/remapper/BUILD:14:18: TdGenerate tensorflow/core/transforms/remapper/pdll/MklPDLLPatterns.h.inc failed: (Segmentation fault): mlir-pdll failed: error executing command bazel-out/k8-opt-exec-50AE0418/bin/external/llvm-project/mlir/mlir-pdll '-x=cpp' tensorflow/core/transforms/remapper/pdll/mkl_patterns.pdll -I ./tensorflow/core/transforms/include -I ... (remaining 15 arguments skipped)
<mlir_parser_buffer>:1:10: error: `!"tf_type"<"control">` type created with unregistered dialect. If this is intended, please call allowUnregisteredDialects() on the MLIRContext, or use -allow-unregistered-dialect with the MLIR opt tool used
!tf_type.control
         ^
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
```