### PR TITLE
[MacOS][Pluggable Device] Fixes for macos pluggable device.

### DIFF
--- a/tensorflow/core/common_runtime/eager/execute.cc
+++ b/tensorflow/core/common_runtime/eager/execute.cc
@@ -439,6 +439,10 @@ Status HasTPUReplication(const EagerOperation& op, const EagerContext& ctx,
 
 Status MustCompileWithXLA(const EagerOperation* op, const EagerContext& ctx,
                           bool* compile_with_xla) {
+
+#if defined( PLUGGABLE_DEVICE_SUPPORTED_MACOS )
+  *compile_with_xla = false;
+#else
   if (!op->is_function()) {
     *compile_with_xla = false;
     return OkStatus();
@@ -468,6 +472,7 @@ Status MustCompileWithXLA(const EagerOperation* op, const EagerContext& ctx,
   } else {
     *compile_with_xla = false;
   }
+#endif
 
   return OkStatus();
 }

--- a/tensorflow/core/framework/tensor.h
+++ b/tensorflow/core/framework/tensor.h
@@ -36,8 +36,7 @@ limitations under the License.
 #include "tensorflow/core/platform/types.h"
 
 #if !defined(PLUGGABLE_DEVICE_SUPPORTED_MACOS) &&  \
-    defined(__APPLE__) && !defined(ANDROID) &&     \
-    !defined(__ANDROID__) && !TARGET_OS_IOS
+    defined(__APPLE__) && !defined(ANDROID) && !TARGET_OS_IOS
 #define PLUGGABLE_DEVICE_SUPPORTED_MACOS 1
 #endif
 

--- a/tensorflow/core/framework/tensor.h
+++ b/tensorflow/core/framework/tensor.h
@@ -35,6 +35,12 @@ limitations under the License.
 #include "tensorflow/core/platform/mem.h"
 #include "tensorflow/core/platform/types.h"
 
+#if !defined(PLUGGABLE_DEVICE_SUPPORTED_MACOS) &&  \
+    defined(__APPLE__) && !defined(ANDROID) &&     \
+    !defined(__ANDROID__) && !TARGET_OS_IOS
+#define PLUGGABLE_DEVICE_SUPPORTED_MACOS 1
+#endif
+
 namespace tensorflow {
 
 // Forward declarations.  In particular, we forward declare protos so that their
@@ -314,7 +320,7 @@ class Tensor {
 
   /// Returns true iff this tensor is aligned.
   bool IsAligned() const {
-#if EIGEN_MAX_ALIGN_BYTES == 0
+#if EIGEN_MAX_ALIGN_BYTES == 0 || PLUGGABLE_DEVICE_SUPPORTED_MACOS
     return true;
 #else
     void* ptr = base<void>();

--- a/tensorflow/core/kernels/list_kernels.cc
+++ b/tensorflow/core/kernels/list_kernels.cc
@@ -711,6 +711,7 @@ REGISTER_LIST_COPY(VariantDeviceCopyDirection::DEVICE_TO_DEVICE);
 
 REGISTER_UNARY_VARIANT_DECODE_FUNCTION(TensorList, TensorList::kTypeName);
 
+#if !defined( PLUGGABLE_DEVICE_SUPPORTED_MACOS )
 #define REGISTER_TENSOR_LIST_OPS_DEFAULT(T)                                \
   REGISTER_KERNEL_BUILDER(Name("TensorListStack")                          \
                               .TypeConstraint<T>("element_dtype")          \
@@ -785,4 +786,5 @@ TF_CALL_int64(REGISTER_TENSOR_LIST_OPS_DEFAULT);
 TF_CALL_GPU_NUMBER_TYPES(REGISTER_TENSOR_LIST_OPS_DEFAULT);
 
 #undef REGISTER_TENSOR_LIST_OPS_DEFAULT
+#endif
 }  // namespace tensorflow


### PR DESCRIPTION
1. Disable the Eigen max align check as we use custom device memory
   allocator in Metal plugin
2. Disable list kernels on Pluggable devices as Device memory on MacOS
   pluggable device doesn't allow us to index at a offset from the base
   MTLBuufer location.
3. Disable XLA compilation path as its not supported in pluggable
   architecture
cc. @penpornk , @learning-to-play , @nitins17