### PR TITLE
Move MHLO transforms to own BUILD file & fix cmake

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/tosa/BUILD
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/BUILD
@@ -1,7 +1,4 @@
 # MHLO -> TOSA bridge.
-load("//tensorflow/tsl:tsl.default.bzl", "get_compatible_with_cloud")
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
-
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
     default_visibility = [
@@ -16,73 +13,11 @@ package_group(
     packages = [],
 )
 
-gentbl_cc_library(
-    name = "MHLOTOSAPDLLPatternsIncGen",
-    tbl_outs = [
-        (
-            ["-x=cpp"],
-            "transforms/legalize_mhlo/legalize_mhlo.pdll.h.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-pdll",
-    td_file = "transforms/legalize_mhlo/legalize_mhlo.pdll",
-    deps = [
-        "//tensorflow/compiler/xla/mlir_hlo:hlo_ops_td_files",
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:TosaDialectTdFiles",
-    ],
-)
-
-gentbl_cc_library(
-    name = "MHLOTOSATransformsPassIncGen",
-    compatible_with = get_compatible_with_cloud(),
-    strip_include_prefix = ".",
-    tbl_outs = [
-        (
-            [
-                "-gen-pass-decls",
-                "-name=MHLOTOSATransforms",
-            ],
-            "transforms/passes.h.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "transforms/passes.td",
-    deps = [
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
-)
-
-cc_library(
-    name = "MHLOTOSATransforms",
-    srcs = [
-        "transforms/legalize_mhlo/legalize_mhlo.cc",
-        "transforms/prepare_mhlo/prepare_mhlo.cc",
-    ],
-    hdrs = [
-        "transforms/passes.h",
-    ],
-    includes = ["."],
-    deps = [
-        ":MHLOTOSAPDLLPatternsIncGen",
-        ":MHLOTOSATransformsPassIncGen",
-        "//tensorflow/compiler/xla/mlir_hlo",
-        "//tensorflow/compiler/xla/mlir_hlo:mhlo_passes",
-        "@llvm-project//mlir:FuncDialect",
-        "@llvm-project//mlir:IR",
-        "@llvm-project//mlir:Parser",
-        "@llvm-project//mlir:Pass",
-        "@llvm-project//mlir:QuantOps",
-        "@llvm-project//mlir:TosaDialect",
-        "@llvm-project//mlir:Transforms",
-    ],
-)
-
 cc_binary(
     name = "mhlo-tosa-opt",
     srcs = ["mhlo_tosa_opt.cc"],
     deps = [
-        ":MHLOTOSATransforms",
+        "//tensorflow/compiler/xla/mlir_hlo/tosa/transforms:MHLOTOSATransforms",
         "//tensorflow/compiler/xla/mlir_hlo:hlo_dialect_registration",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AllPassesAndDialects",

--- a/tensorflow/compiler/xla/mlir_hlo/tosa/BUILD
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/BUILD
@@ -17,8 +17,8 @@ cc_binary(
     name = "mhlo-tosa-opt",
     srcs = ["mhlo_tosa_opt.cc"],
     deps = [
-        "//tensorflow/compiler/xla/mlir_hlo/tosa/transforms:MHLOTOSATransforms",
         "//tensorflow/compiler/xla/mlir_hlo:hlo_dialect_registration",
+        "//tensorflow/compiler/xla/mlir_hlo/tosa/transforms:MHLOTOSATransforms",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:IR",

--- a/tensorflow/compiler/xla/mlir_hlo/tosa/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_custom_target(check-mhlo-tosa)
 
+add_subdirectory(transforms)
 add_subdirectory(tests)
 
 add_mlir_pdll_library(MHLOTOSAPDLLPatternsIncGen
@@ -40,6 +41,7 @@ set(LIBS
 add_llvm_executable(mhlo-tosa-opt mhlo_tosa_opt.cc
 )
 llvm_update_compile_flags(mhlo-tosa-opt)
+add_dependencies(mhlo-tosa-opt MHLOTOSATransformsPassIncGen)
 target_link_libraries(mhlo-tosa-opt PRIVATE ${LIBS})
 
 mlir_check_all_link_libraries(mhlo-tosa-opt)

--- a/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/BUILD
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/BUILD
@@ -17,7 +17,6 @@ package_group(
     packages = [],
 )
 
-
 gentbl_cc_library(
     name = "MHLOTOSAPDLLPatternsIncGen",
     tbl_outs = [
@@ -79,4 +78,3 @@ cc_library(
         "@llvm-project//mlir:Transforms",
     ],
 )
-

--- a/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/BUILD
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/BUILD
@@ -1,0 +1,82 @@
+# Legalizations and transforms for MHLO -> TOSA.
+
+load("//tensorflow/tsl:tsl.default.bzl", "get_compatible_with_cloud")
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = [
+        ":internal",
+        "//tensorflow/compiler/xla/mlir_hlo/tosa:__subpackages__",
+    ],
+    licenses = ["notice"],
+)
+
+package_group(
+    name = "internal",
+    packages = [],
+)
+
+
+gentbl_cc_library(
+    name = "MHLOTOSAPDLLPatternsIncGen",
+    tbl_outs = [
+        (
+            ["-x=cpp"],
+            "legalize_mhlo/legalize_mhlo.pdll.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-pdll",
+    td_file = "legalize_mhlo/legalize_mhlo.pdll",
+    deps = [
+        "//tensorflow/compiler/xla/mlir_hlo:hlo_ops_td_files",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:TosaDialectTdFiles",
+    ],
+)
+
+gentbl_cc_library(
+    name = "MHLOTOSATransformsPassIncGen",
+    compatible_with = get_compatible_with_cloud(),
+    strip_include_prefix = ".",
+    tbl_outs = [
+        (
+            [
+                "-gen-pass-decls",
+                "-name=MHLOTOSATransforms",
+            ],
+            "passes.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "passes.td",
+    deps = [
+        "@llvm-project//mlir:PassBaseTdFiles",
+    ],
+)
+
+cc_library(
+    name = "MHLOTOSATransforms",
+    srcs = [
+        "legalize_mhlo/legalize_mhlo.cc",
+        "prepare_mhlo/prepare_mhlo.cc",
+    ],
+    hdrs = [
+        "passes.h",
+    ],
+    includes = ["."],
+    deps = [
+        ":MHLOTOSAPDLLPatternsIncGen",
+        ":MHLOTOSATransformsPassIncGen",
+        "//tensorflow/compiler/xla/mlir_hlo",
+        "//tensorflow/compiler/xla/mlir_hlo:mhlo_passes",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Parser",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:QuantOps",
+        "@llvm-project//mlir:TosaDialect",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+

--- a/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/legalize_mhlo/legalize_mhlo.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/legalize_mhlo/legalize_mhlo.cc
@@ -17,19 +17,20 @@ limitations under the License.
 #include <utility>
 
 #include "mhlo/IR/hlo_ops.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "transforms/passes.h"
+#include "passes.h"
 
 #define GEN_PASS_DEF_TOSALEGALIZEMHLOPASS
-#include "transforms/passes.h.inc"
+#include "passes.h.inc"
 
 #define PASS_NAME "tosa-legalize-mhlo"
 #define DEBUG_TYPE PASS_NAME
 
-#include "transforms/legalize_mhlo/legalize_mhlo.pdll.h.inc"
+#include "legalize_mhlo/legalize_mhlo.pdll.h.inc"
 
 namespace mlir {
 namespace tosa {
@@ -293,7 +294,7 @@ struct ConvertMhloGatherOp : public OpRewritePattern<mhlo::GatherOp> {
 
     auto startIndexMap = op.getDimensionNumbers().getStartIndexMap();
     for (const auto& startIndex : llvm::enumerate(startIndexMap)) {
-      if (startIndex.value() != startIndex.index()) {
+      if (startIndex.value() != static_cast<int64_t>(startIndex.index())) {
         return rewriter.notifyMatchFailure(op,
                                            "start_index_map must be in order");
       }

--- a/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/passes.h
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/passes.h
@@ -29,7 +29,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createPrepareMhloPass();
 
 #define GEN_PASS_REGISTRATION
 #define GEN_PASS_DECL_TOSALEGALIZEMHLOPASS
-#include "transforms/passes.h.inc"
+#include "passes.h.inc"
 
 }  // namespace tosa
 }  // namespace mlir

--- a/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/prepare_mhlo/prepare_mhlo.cc
+++ b/tensorflow/compiler/xla/mlir_hlo/tosa/transforms/prepare_mhlo/prepare_mhlo.cc
@@ -21,10 +21,10 @@ limitations under the License.
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "transforms/passes.h"
+#include "passes.h"
 
 #define GEN_PASS_DEF_TOSAPREPAREMHLOPASS
-#include "transforms/passes.h.inc"
+#include "passes.h.inc"
 
 #define PASS_NAME "tosa-prepare-mhlo"
 #define DEBUG_TYPE PASS_NAME


### PR DESCRIPTION
Move so that we can avoid differences between CMake and bazel here (and
lack of include dir that would allow using include directive).

Iteration of https://github.com/tensorflow/tensorflow/pull/59187
