### PR TITLE
enable a oneDNN ITT feature

### DIFF
--- a/third_party/mkl_dnn/mkldnn_v1.BUILD
+++ b/third_party/mkl_dnn/mkldnn_v1.BUILD
@@ -101,6 +101,7 @@ _COPTS_LIST = select({
     "-UUSE_MKL",
     "-UUSE_CBLAS",
     "-DDNNL_ENABLE_MAX_CPU_ISA",
+    "-DDNNL_ENABLE_ITT_TASKS",
 ] + tf_openmp_copts()
 
 _INCLUDES_LIST = [


### PR DESCRIPTION
There is an oneDNN feature to enable ITT tagging for oneDNN primitives on Intel VTune Profiler.
Here is the RFCS for this feature.
https://github.com/oneapi-src/oneDNN/tree/rfcs/rfcs/20201014-VTune-ITT-tagging

[Intel VTune Profiler](https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html) is a performance analysis tool for x86 based machines and Intel Data Center GPUs.
VTune helps on finding your performance bottlenecks and provide details Intel platform information.
We work with VTune Team to have some BKMs and tensorboard pluging for the feature.

We would like to enable this feature by default on TensorFlow, so users could identify platform bottlenecks with details information such as L1 caches misses or level of AVX512 vectorization.

We manually built the TF pkg with ITT features, and then benchmark with [Intel Model Zoo](https://github.com/IntelAI/models) w/ & w/o this feature.
This feature has no impact on performance based on our perf benchmarking on different Intel Model Zoo models.
If users don't want this feature, they could also disable it on runtime via an environment flag "[DNNL_ITT_TASK_LEVEL"](https://oneapi-src.github.io/oneDNN/v2.4/dev_guide_profilers.html#id2)