### PR TITLE
Fix missing symbols on PPC caused by jit_compiler

### DIFF
--- a/tensorflow/compiler/xla/mlir/runtime/transforms/BUILD
+++ b/tensorflow/compiler/xla/mlir/runtime/transforms/BUILD
@@ -231,7 +231,23 @@ cc_library(
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:ToLLVMIRTranslation",
-    ],
+    ] + select({
+        "//tensorflow:arm_any": [
+            "@llvm-project//llvm:AArch64AsmParser",
+        ],
+        "//tensorflow:linux_ppc64le": [
+            "@llvm-project//llvm:PowerPCAsmParser",
+        ],
+        "//tensorflow:macos_arm64": [
+            "@llvm-project//llvm:AArch64AsmParser",
+        ],
+        "//tensorflow:linux_s390x": [
+            "@llvm-project//llvm:SystemZAsmParser",
+        ],
+        "//conditions:default": [
+            "@llvm-project//llvm:X86AsmParser",
+        ],
+    }),
 )
 
 cc_library(


### PR DESCRIPTION
Inside `jit_compiler.cc` the function `llvm::InitializeNativeTargetAsmParser` is called which on PPC calls `LLVMInitializePowerPCAsmParser` via an architecture-dependend define.
Hence the architecture-dependent AsmParser target is a dependency. So this is added here fixing errors when later using e.g. `_pywrap_tensorflow_internal.so` e.g. by importing tensorflow from Python.

See also https://github.com/llvm/llvm-project/issues/59590.