### PR TITLE
[aarch64] enable acl linking for cpu xla for mkl_aarch64_threadpool config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -242,6 +242,7 @@ build:mkl_aarch64 -c opt
 # Config setting to build oneDNN with Compute Library for the Arm Architecture (ACL).
 # with Eigen threadpool support
 build:mkl_aarch64_threadpool --define=build_with_mkl_aarch64=true
+build:mkl_aarch64_threadpool --define=build_with_acl=true
 build:mkl_aarch64_threadpool -c opt
 
 # This config refers to building CUDA op kernels with nvcc.


### PR DESCRIPTION
this option is already present for "mkl_aarch64" but missing from "mkl_aarch64_threadpool". 