### PR TITLE
[mlir-hlo][cmake] Add dependencies missing for building shared libraries

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/mhlo/analysis/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/mhlo/analysis/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_library(MhloAnalysis
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRIR
+  LmhloDialect
 )
 
 add_mlir_library(MhloTestAnalysis

--- a/tensorflow/compiler/xla/mlir_hlo/mhlo/transforms/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/mhlo/transforms/CMakeLists.txt
@@ -82,12 +82,16 @@ add_mlir_library(MhloPasses
 
   LINK_LIBS PUBLIC
   ChloOps
+  MhloAnalysis
   MhloDialect
   MhloScatterUtils
   MhloTypeConversion
   MLIRIR
+  MLIRLinalgDialect
+  MLIRMathDialect
   MLIRMhloUtils
   MLIRPass
+  MLIRSCFDialect
   MLIRSideEffectInterfaces
   MLIRTransformUtils
   StablehloBroadcastUtils
@@ -151,6 +155,7 @@ add_mlir_library(MhloToMemrefConversion
   Core
 
   LINK_LIBS PUBLIC
+  LmhloDialect
   MhloDialect
   MhloTypeConversion
   MLIRIR
@@ -176,6 +181,7 @@ add_mlir_library(MhloToArithmeticConversion
   MLIRIR
   MLIRPass
   MLIRMathDialect
+  MLIRSCFDialect
   MLIRTransforms
   MLIRTransformUtils
 )
@@ -198,7 +204,9 @@ add_mlir_library(MhloToStandard
   LINK_LIBS PUBLIC
   MhloDialect
   MLIRIR
+  MLIRMathDialect
   MLIRPass
+  MLIRSCFDialect
   MLIRTensorDialect
   MLIRTransformUtils
 )
@@ -307,6 +315,7 @@ add_mlir_library(StablehloToMhlo
   LINK_LIBS PUBLIC
   MhloDialect
   MhloTypeConversion
+  MLIRAsmParser
   MLIRIR
   MLIRPass
   MLIRSupport


### PR DESCRIPTION
This commit adds CMake dependencies that are required for building the MLIR HLO library with -DBUILD_SHARED_LIBS and currently missing. I am doing this here https://github.com/iree-org/iree-llvm-sandbox/blob/b1c16a5/configure.py#L229 through IREE (https://github.com/iree-org/iree).

The reason why I believe the problems did not show up is because everybody including CI seem to use static linking and not all required symbols are required for linking static libraries -- they only need to be present when linking the final executable, where they presumable get linked in "by chance".

I have only tested building this library through the [standalone copy repository](https://github.com/tensorflow/mlir-hlo) and as a dependency of IREE, not as a stand-alone project.