### PR TITLE
tflite-runtime wheels for Python 3.10

### DIFF
--- a/tensorflow/lite/tools/pip_package/Dockerfile.py3
+++ b/tensorflow/lite/tools/pip_package/Dockerfile.py3
@@ -15,11 +15,13 @@
 ARG IMAGE
 FROM ${IMAGE}
 ARG PYTHON_VERSION
+ARG NUMPY_VERSION
 
 COPY update_sources.sh /
 RUN /update_sources.sh
 
 RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC \
     apt-get install -y \
       build-essential \
       software-properties-common \
@@ -29,8 +31,6 @@ RUN apt-get update && \
       unzip \
       git && \
     apt-get clean
-
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 
 # Install Bazel.
 RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64 \
@@ -54,7 +54,7 @@ RUN curl -OL https://bootstrap.pypa.io/get-pip.py
 RUN python3 get-pip.py
 RUN rm get-pip.py
 RUN pip3 install --upgrade pip
-RUN pip3 install numpy~=1.19.2 setuptools pybind11
+RUN pip3 install numpy~=$NUMPY_VERSION setuptools pybind11
 RUN ln -sf /usr/include/python$PYTHON_VERSION /usr/include/python3
 RUN ln -sf /usr/local/lib/python$PYTHON_VERSION/dist-packages/numpy/core/include/numpy /usr/include/python3/numpy
 RUN curl -OL https://github.com/Kitware/CMake/releases/download/v3.16.8/cmake-3.16.8-Linux-x86_64.sh

--- a/tensorflow/lite/tools/pip_package/Makefile
+++ b/tensorflow/lite/tools/pip_package/Makefile
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 # Values: debian:<version>, ubuntu:<version>
-BASE_IMAGE ?= ubuntu:18.04
-PYTHON_VERSION ?= 3.9
+BASE_IMAGE ?= ubuntu:20.04
+PYTHON_VERSION ?= 3.10
+NUMPY_VERSION ?= 1.21.2
+
 # Values: rpi, aarch64, native
 TENSORFLOW_TARGET ?= native
 WHEEL_PROJECT_NAME ?= tflite_runtime
@@ -53,7 +55,11 @@ help:
 	@echo "make clean        -- remove wheel and deb files"
 
 docker-image:
-	docker build -t $(TAG_IMAGE) --build-arg IMAGE=$(BASE_IMAGE) --build-arg PYTHON_VERSION=$(PYTHON_VERSION) -f $(MAKEFILE_DIR)/Dockerfile.py3 $(MAKEFILE_DIR)/.
+	docker build -t $(TAG_IMAGE) \
+		--build-arg IMAGE=$(BASE_IMAGE) \
+		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+		--build-arg NUMPY_VERSION=$(NUMPY_VERSION) \
+		-f $(MAKEFILE_DIR)/Dockerfile.py3 $(MAKEFILE_DIR)/.
 
 docker-shell: docker-image
 	mkdir -p $(TENSORFLOW_DIR)/bazel-ci_build-cache

--- a/tensorflow/lite/tools/pip_package/setup_with_binary.py
+++ b/tensorflow/lite/tools/pip_package/setup_with_binary.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
@@ -61,6 +62,6 @@ setup(
     package_dir={'': '.'},
     package_data={'': ['*.so', '*.pyd']},
     install_requires=[
-        'numpy >= 1.19.2',  # Better to keep sync with both TF ci_build
+        'numpy >= 1.21.2',  # Better to keep sync with both TF ci_build
                             # and OpenCV-Python requirement.
     ])


### PR DESCRIPTION
Closes #56137 and #58264

This is a follow on PR to https://github.com/tensorflow/tensorflow/issues/56137#issuecomment-1397351028 that updates the Ubuntu to 20.04 supporting a Python 3.10 wheel while still retaining a minimum of glibc 2.31 runtime.

~~This PR is using Option 2 from the comment, meaning that `/usr/include/python3` is now set explicitly in [build_pip_package_with_cmake.sh](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/tools/pip_package/build_pip_package_with_cmake.sh).~~

Edit (01/28/2023): This PR is using Option 1 from the comment given that the upstream issues with `/usr/include/python3` were resolved by deadsnakes.

The minimum Numpy versions was increased to `1.21.2` following [opencv-python](https://github.com/opencv/opencv-python/blob/4.x/setup.py) like [setup_with_binary.py](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/tools/pip_package/setup_with_binary.py) suggested to do.