### PR TITLE
Fix segfault caused by registering duplicate numpy float8 to bfloat16 casts

### DIFF
--- a/tensorflow/tsl/python/lib/core/bfloat16.cc
+++ b/tensorflow/tsl/python/lib/core/bfloat16.cc
@@ -190,12 +190,19 @@ bool Initialize() {
   if (!custom_float_internal::RegisterNumpyDtype<bfloat16>(numpy.get())) {
     return false;
   }
-  if (!custom_float_internal::RegisterNumpyDtype<float8_e4m3b11>(numpy.get())) {
+  bool float8_already_registered;
+  if (!custom_float_internal::RegisterNumpyDtype<float8_e4m3b11>(
+          numpy.get(), &float8_already_registered)) {
     return false;
   }
 
-  // Casts between bfloat16 and float8_e4m3b11.
-  if (!custom_float_internal::RegisterCustomFloatCast<float8_e4m3b11,
+  // Casts between bfloat16 and float8_e4m3b11. Only perform the cast if
+  // float8_e4m3b11 hasn't been previously registered, presumably by a different
+  // library. In this case, we assume the cast has also already been registered,
+  // and registering it again can cause segfaults due to accessing an
+  // uninitialized type descriptor in this library.
+  if (!float8_already_registered &&
+      !custom_float_internal::RegisterCustomFloatCast<float8_e4m3b11,
                                                       bfloat16>()) {
     return false;
   }


### PR DESCRIPTION
This was causing segfaults in JAX, since both the main jaxlib .so and the tpu_driver .so call RegisterNumpyBfloat16, which eventually tries to register this cast. This was causing segfaults with the current code due to a missing float8 type descriptor, since the type descriptor was populated and registered by the first library to call RegisterNumpyBfloat16, and then the second library would detect that the type was already registered by still try to access it from its own (unregistered) descriptor.

The fix is to not attempt the cast if a different library already registered the float8 type.

I manually tested that this fixes the segfault.