### PR TITLE
parallel_for control flow ops - change for_loop output to match pfor when run with 0 iters

### DIFF
--- a/tensorflow/python/eager/backprop_test.py
+++ b/tensorflow/python/eager/backprop_test.py
@@ -1936,6 +1936,29 @@ class JacobianTest(test.TestCase):
     jacobian_pfor = tape.jacobian(grad, x, experimental_use_pfor=True)
     self.assertAllClose(6., jacobian_pfor)
 
+  def test_empty_tensor_consistent_jacobian(self):
+    variable = variables.Variable(1.0)
+    inputs = (
+        constant_op.constant(np.random.uniform(size=(0, 4))),
+        constant_op.constant(np.random.uniform(size=(0, 3))),
+    )
+    with backprop.GradientTape(persistent=True) as tape:
+      outputs = variable * math_ops.cast(
+          array_ops.concat(inputs, axis=-1), 
+          dtypes.float32
+      )
+    
+    jacobians_pfor = tape.jacobian(
+        outputs,
+        variable,
+        experimental_use_pfor=True,
+    )
+    jacobians_loop = tape.jacobian(
+        outputs,
+        variable,
+        experimental_use_pfor=False,
+    )
+    self.assertAllClose(jacobians_pfor, jacobians_loop)
 
 @test_util.run_all_in_graph_and_eager_modes
 class BatchJacobianTest(test.TestCase, parameterized.TestCase):

--- a/tensorflow/python/ops/parallel_for/control_flow_ops.py
+++ b/tensorflow/python/ops/parallel_for/control_flow_ops.py
@@ -28,7 +28,6 @@ from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import tensor_util
 from tensorflow.python.framework import type_spec
-from tensorflow.python.framework.errors_impl import InvalidArgumentError
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import math_ops
@@ -109,13 +108,12 @@ def for_loop(loop_fn, loop_fn_dtypes, iters, parallel_iterations=None):
     loop_var = array_ops.placeholder_with_default(0, shape=[])
     try:
       loop_fn_out = loop_fn(loop_var)
-    except InvalidArgumentError: 
-      loop_fn_out = array_ops.placeholder_with_default(0, shape=[])
-    out_shapes = [[0]+ops.convert_to_tensor(x).shape
+      out_shapes = [[0]+ops.convert_to_tensor(x).shape
             for x in nest.flatten(loop_fn_out)]
-    output = [array_ops.zeros(out_shapes[i], dt)
+      output = [array_ops.zeros(out_shapes[i], dt)
             for i,dt in enumerate(flat_loop_fn_dtypes)]
-
+    except Exception: 
+      output = [array_ops.zeros([0])]
   return nest.pack_sequence_as(loop_fn_dtypes, output)
 
 

--- a/tensorflow/python/ops/parallel_for/control_flow_ops.py
+++ b/tensorflow/python/ops/parallel_for/control_flow_ops.py
@@ -111,7 +111,8 @@ def for_loop(loop_fn, loop_fn_dtypes, iters, parallel_iterations=None):
       loop_fn_out = loop_fn(loop_var)
     except InvalidArgumentError: 
       loop_fn_out = array_ops.placeholder_with_default(0, shape=[])
-    out_shapes = [[0]+ops.convert_to_tensor(x).shape for x in nest.flatten(loop_fn_out)]
+    out_shapes = [[0]+ops.convert_to_tensor(x).shape
+            for x in nest.flatten(loop_fn_out)]
     output = [array_ops.zeros(out_shapes[i], dt)
             for i,dt in enumerate(flat_loop_fn_dtypes)]
 

--- a/tensorflow/python/ops/parallel_for/control_flow_ops.py
+++ b/tensorflow/python/ops/parallel_for/control_flow_ops.py
@@ -107,8 +107,8 @@ def for_loop(loop_fn, loop_fn_dtypes, iters, parallel_iterations=None):
     # Pack a list of empty tensors with the proper ranks to match pfor output on 0 iters
     loop_var = array_ops.placeholder_with_default(0, shape=[])
     loop_fn_out = nest.flatten(loop_fn(loop_var))
-    ranks = [ops.convert_to_tensor(x).shape.rank for x in loop_fn_out]
-    output = [array_ops.zeros([0]*(ranks[i]+1), dt) 
+    out_shapes = [[0]+ops.convert_to_tensor(x).shape for x in loop_fn_out]
+    output = [array_ops.zeros(out_shapes[i], dt)
               for i,dt in enumerate(flat_loop_fn_dtypes)]
 
   return nest.pack_sequence_as(loop_fn_dtypes, output)

--- a/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
+++ b/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
@@ -132,8 +132,11 @@ class PForTest(PForTestCase):
     with self.assertRaisesRegex(ValueError, "Use `for_loop` instead"):
       pfor_control_flow_ops.pfor(lambda i: 1, 8, parallel_iterations=1)
 
-  def test_zero_loop_iters(self):
+  def test_zero_loop_iters_basic(self):
     self._test_loop_fn(lambda i: 1, 0)
+
+  def test_zero_loop_iters_tensor(self):
+    self._test_loop_fn(lambda i: array_ops.zeros([10, 3], dtype=dtypes.int32), 0)
 
   def test_vectorized_map(self):
 

--- a/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
+++ b/tensorflow/python/ops/parallel_for/control_flow_ops_test.py
@@ -132,6 +132,9 @@ class PForTest(PForTestCase):
     with self.assertRaisesRegex(ValueError, "Use `for_loop` instead"):
       pfor_control_flow_ops.pfor(lambda i: 1, 8, parallel_iterations=1)
 
+  def test_zero_loop_iters(self):
+    self._test_loop_fn(lambda i: 1, 0)
+
   def test_vectorized_map(self):
 
     def compute(x):
@@ -1193,6 +1196,19 @@ class TensorListTest(PForTestCase):
               list_ops.tensor_list_element_shape(handle, dtypes.int64))
 
     self._test_loop_fn(loop_fn, 2)
+
+  def test_create_outside_and_read_zero_loop_iters(self):
+    handle = list_ops.tensor_list_reserve([], 2, dtypes.int32)
+    handle = list_ops.tensor_list_set_item(handle, 0, 0)
+    handle = list_ops.tensor_list_set_item(handle, 1, 1)
+
+    def loop_fn(i):
+      return (list_ops.tensor_list_get_item(handle, i, dtypes.int32),
+              list_ops.tensor_list_get_item(handle, 0, dtypes.int32),
+              list_ops.tensor_list_length(handle),
+              list_ops.tensor_list_element_shape(handle, dtypes.int32),
+              list_ops.tensor_list_element_shape(handle, dtypes.int64))
+    self._test_loop_fn(loop_fn, 0)
 
   def test_create_inside_and_read(self):
 


### PR DESCRIPTION
When run with zero iterations, tensorflow.python.ops.parallel_for.control_flow_ops.pfor returns a tensor with a shape of 0 in the first dimension (with the corresponding return shape in the others). However, running tensorflow.python.ops.parallel_for.control_flow_ops.for_loop on the same inputs with zero iterations would return `None`.

This manifests itself in issues such as #37795, where using experimental_use_pfor=True for computing Jacobians (with GradientTape) on inputs with dimension 0 would 'work', and return a tensor with shape 0, however running with experimental_use_pfor=False would throw a Type Error. 

This PR changes the for_loop handling to return an object identical to that of pfor when run with zero iterations, rather than `None`.

--
Resolves #37795.