### PR TITLE
[Linaro:ARM_CI] Exclude tests that fail due to mismatch with tf-io

### DIFF
--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -16,8 +16,15 @@
 set -x
 
 ARM_SKIP_TESTS="-//tensorflow/lite/... \
+-//tensorflow/core/platform:ram_file_system_test \
 -//tensorflow/python/client:session_list_devices_test \
+-//tensorflow/python/compiler/xla:xla_test_cpu \
+-//tensorflow/python/compiler/xla:xla_test_gpu \
+-//tensorflow/python/data/experimental/kernel_tests:checkpoint_input_pipeline_hook_test \
 -//tensorflow/python/data/kernel_tests:iterator_test \
+-//tensorflow/python/distribute:parameter_server_strategy_test_cpu \
+-//tensorflow/python/distribute:parameter_server_strategy_test_gpu \
+-//tensorflow/python/distribute/failure_handling:gce_failure_handler_test \
 -//tensorflow/python/kernel_tests/nn_ops:atrous_conv2d_test \
 -//tensorflow/python/kernel_tests/nn_ops:conv_ops_test \
 -//tensorflow/python/training:server_lib_test \


### PR DESCRIPTION
These tests currently cannot run as the API to TensorFlow has been updated and does not match the current release of tensorflow-io