### PR TITLE
[Linaro:ARM_CI] Fix unit test numeric_utils_test fails to build

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -1491,7 +1491,10 @@ def tf_cc_test(
                 "-lpthread",
                 "-lm",
             ],
-            clean_dep("//third_party/compute_library:build_with_acl"): ["-fopenmp"],
+            clean_dep("//third_party/compute_library:build_with_acl"): [
+                "-fopenmp",
+                "-lm",
+            ],
         }) + linkopts + _rpath_linkopts(name),
         deps = deps + tf_binary_dynamic_kernel_deps(kernels) + if_mkl_ml(
             [
@@ -1531,7 +1534,10 @@ def tf_cc_shared_test(
                 "-lpthread",
                 "-lm",
             ],
-            clean_dep("//third_party/compute_library:build_with_acl"): ["-fopenmp"],
+            clean_dep("//third_party/compute_library:build_with_acl"): [
+                "-fopenmp",
+                "-lm",
+            ],
         }) + linkopts + _rpath_linkopts(name),
         deps = deps + tf_binary_dynamic_kernel_deps(kernels) + if_mkl_ml(
             [


### PR DESCRIPTION
The unit test //tensorflow/compiler/mlir/lite/quantization:numerical_utils_test fails to build for mkl_aarch64_threadpool since build_with_acl was enabled recently. Fix the libraries required.
Introduced by https://github.com/tensorflow/tensorflow/commit/6bc78c3e5019385effdb2aab70cd4a088ece7e0a