### PR TITLE
[NVIDIA TF] NCCL implementation for all-to-all collective

### DIFF
--- a/tensorflow/core/common_runtime/BUILD
+++ b/tensorflow/core/common_runtime/BUILD
@@ -143,6 +143,7 @@ cc_library(
         "//tensorflow/core/framework:allocator",
         "//tensorflow/core/framework:device_attributes_proto_cc",
         "//tensorflow/core/framework:types_proto_cc",
+        "//tensorflow/core/nccl:collective_communicator",
         "//tensorflow/core/platform:refcount",
         "//tensorflow/core/platform:status",
     ],

--- a/tensorflow/core/common_runtime/collective_param_resolver_local.cc
+++ b/tensorflow/core/common_runtime/collective_param_resolver_local.cc
@@ -76,7 +76,7 @@ const char* GetCollectiveName(const CollectiveParams* cp, bool nccl) {
       return "Permute";
 
     case ALL_TO_ALL_COLLECTIVE:
-      return "AllToAll";
+      return nccl ? "NcclAllToAll" : "AllToAll";
 
     case REDUCE_SCATTER_COLLECTIVE:
       return nccl ? "NcclReduceScatter" : "undef";

--- a/tensorflow/core/common_runtime/collective_test_util.h
+++ b/tensorflow/core/common_runtime/collective_test_util.h
@@ -80,6 +80,7 @@ struct CollectiveTestEnv {
   std::shared_ptr<UnboundedWorkQueue> work_queue;
   std::unique_ptr<tensorflow::DeviceMgr> device_mgr;
   std::unique_ptr<DeviceResolverInterface> device_resolver;
+  std::unique_ptr<NcclCommunicatorInterface> nccl_communicator;
   core::RefCountPtr<CollectiveExecutor> col_exec;
   FailTestRMA* remote_access;
 
@@ -87,7 +88,8 @@ struct CollectiveTestEnv {
 };
 
 std::unique_ptr<CollectiveTestEnv> CreateCollectiveTestEnv(
-    int num_workers, int num_devices_per_worker, DeviceType device_type);
+    int num_workers, int num_devices_per_worker, DeviceType device_type,
+    bool use_nccl = false);
 
 core::RefCountPtr<CollectiveParams> CreateCollectiveParams(
     const CollectiveTestEnv& test_env, int rank, const string& collective_name,

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -173,6 +173,8 @@ tf_kernel_library(
     srcs = if_nccl([
         "collective_nccl.h",
         "collective_nccl.cc",
+        "collective_nccl_all_to_all.h",
+        "collective_nccl_all_to_all.cc",
         "collective_nccl_broadcaster.h",
         "collective_nccl_broadcaster.cc",
         "collective_nccl_gatherer.h",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -210,6 +210,8 @@ tf_cuda_cc_test(
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
         "//tensorflow/core:testlib",
+        "//tensorflow/core/common_runtime:collective_test_util",
+        "//tensorflow/core/framework:tensor_testutil",
         "//tensorflow/core/nccl:collective_communicator",
     ],
 )

--- a/tensorflow/core/kernels/collective_nccl.cc
+++ b/tensorflow/core/kernels/collective_nccl.cc
@@ -47,6 +47,9 @@ Status NcclBase::InitializeCollectiveParams(CollectiveParams* col_params) {
     case REDUCE_SCATTER_COLLECTIVE:
       expected_name = "NcclReduceScatter";
       break;
+    case ALL_TO_ALL_COLLECTIVE:
+      expected_name = "NcclAllToAll";
+      break;
     default:
       return errors::Internal("Unexpected CollectiveType ", type_);
   }

--- a/tensorflow/core/kernels/collective_nccl_all_to_all.cc
+++ b/tensorflow/core/kernels/collective_nccl_all_to_all.cc
@@ -1,0 +1,34 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/core/kernels/collective_nccl_all_to_all.h"
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#include "tensorflow/core/common_runtime/collective_util.h"
+#include "tensorflow/core/nccl/nccl_manager.h"
+#include "tensorflow/core/platform/tracing.h"
+#include "tensorflow/core/profiler/lib/traceme.h"
+
+namespace tensorflow {
+
+void NcclAllToAll::Run(StatusCallback done) {
+  col_ctx_->nccl_communicator->Enqueue(col_ctx_, std::move(done));
+}
+
+REGISTER_COLLECTIVE(NcclAllToAll, NcclAllToAll);
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/collective_nccl_all_to_all.h
+++ b/tensorflow/core/kernels/collective_nccl_all_to_all.h
@@ -1,0 +1,35 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_CORE_KERNELS_COLLECTIVE_NCCL_ALL_TO_ALL_H_
+#define TENSORFLOW_CORE_KERNELS_COLLECTIVE_NCCL_ALL_TO_ALL_H_
+
+#include "tensorflow/core/kernels/collective_nccl.h"
+
+namespace tensorflow {
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+class NcclAllToAll : public NcclBase {
+ public:
+  NcclAllToAll() : NcclBase(ALL_TO_ALL_COLLECTIVE, "NcclAllToAll") {}
+  ~NcclAllToAll() override = default;
+
+  // Hands off all-to-all to NcclManager.
+  void Run(StatusCallback done) override;
+};
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_COLLECTIVE_NCCL_ALL_TO_ALL_H_

--- a/tensorflow/core/kernels/collective_nccl_test.cc
+++ b/tensorflow/core/kernels/collective_nccl_test.cc
@@ -13,17 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "tensorflow/core/framework/device_attributes.pb.h"
 #ifdef GOOGLE_CUDA
-
-#include "tensorflow/core/kernels/collective_nccl.h"
 
 #include <algorithm>
 
 #include "absl/memory/memory.h"
 #include "tensorflow/core/common_runtime/base_collective_executor.h"
+#include "tensorflow/core/common_runtime/collective_test_util.h"
 #include "tensorflow/core/common_runtime/device.h"
-#include "tensorflow/core/common_runtime/device_factory.h"
 #include "tensorflow/core/common_runtime/device_mgr.h"
 #include "tensorflow/core/common_runtime/device_resolver_local.h"
 #include "tensorflow/core/common_runtime/dma_helper.h"
@@ -34,13 +31,10 @@ limitations under the License.
 #include "tensorflow/core/framework/node_def_builder.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/tensor.h"
-#include "tensorflow/core/kernels/collective_nccl_broadcaster.h"
-#include "tensorflow/core/kernels/collective_nccl_gatherer.h"
-#include "tensorflow/core/kernels/collective_nccl_reducer.h"
+#include "tensorflow/core/framework/tensor_testutil.h"
 #include "tensorflow/core/lib/core/notification.h"
 #include "tensorflow/core/lib/core/status_test_util.h"
 #include "tensorflow/core/lib/strings/strcat.h"
-#include "tensorflow/core/nccl/collective_communicator.h"
 #include "tensorflow/core/platform/env.h"
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/platform/unbounded_work_queue.h"
@@ -84,71 +78,17 @@ class NcclTestBase : public ::testing::Test {
   class DeviceInstance;
 
   NcclTestBase(CollectiveType collective_type, const string& collective_name)
-      : collective_type_(collective_type),
-        collective_name_(collective_name),
-        nccl_communicator_(MaybeCreateNcclCommunicator(config_proto_)),
-        work_queue_(std::make_shared<UnboundedWorkQueue>(
-            Env::Default(), "collective_executor")),
-        col_exec_(nullptr),
-        col_params_(nullptr) {}
+      : collective_type_(collective_type), collective_name_(collective_name) {}
 
-  ~NcclTestBase() override {
-    if (col_exec_) col_exec_->Unref();
-    if (col_params_) col_params_->Unref();
-  }
-
-  void SetUp() {
-    std::vector<std::unique_ptr<Device>> all_devices;
-    TF_CHECK_OK(DeviceFactory::GetFactory(DEVICE_GPU)
-                    ->AddDevices(SessionOptions(), "", &all_devices));
-    for (std::unique_ptr<Device>& d : all_devices) {
-      if (d->device_type() == "GPU") {
-        gpus_.emplace_back(std::move(d));
-      }
-    }
-  }
-
-  void Init(const int num_ranks, const int instance_key) {
+  void Init(const int num_ranks) {
     setenv("NCCL_DEBUG", "INFO", 1 /* replace */);
     setenv("NCCL_LAUNCH_MODE", "PARALLEL", 1 /* replace */);
-    std::vector<std::unique_ptr<Device>> local_devices;
-    std::vector<string> device_names;
-    CHECK_LE(num_ranks, gpus_.size());
-    for (int rank = 0; rank < num_ranks; ++rank) {
-      local_devices.emplace_back(std::move(gpus_[rank]));
-    }
-    int num_gpus = local_devices.size();
-    for (const auto& device : local_devices) {
-      device_names.push_back(device->name());
-      VLOG(2) << device->name();
-    }
-    if (!dev_mgr_)
-      dev_mgr_ = std::make_unique<StaticDeviceMgr>(std::move(local_devices));
-    col_exec_ =
-        new BaseCollectiveExecutor(&col_exec_mgr_, /*remote_access=*/nullptr,
-                                   kStepId, dev_mgr_.get(), work_queue_);
-
-    // Initialize collective params.
-    col_params_ = new CollectiveParams();
-    col_params_->name = "test_nccl_collective_op";
-    const int group_key = num_ranks;
-    col_params_->group.group_key = group_key;
-    col_params_->group.device_type = DEVICE_GPU;
-    col_params_->group.group_size = num_ranks;
-    col_params_->instance.instance_key = instance_key;
-    col_params_->instance.type = collective_type_;
-    col_params_->instance.data_type = DT_FLOAT;
-    col_params_->instance.impl_details.collective_name = collective_name_;
-    const string task_name = "/job:worker/replica:0/task:0";
-    col_params_->group.num_devices_per_task[task_name] = num_ranks;
-    for (int rank = 0; rank < num_ranks; ++rank) {
-      CollGroupMember member;
-      member.device.set_name(device_names[rank % num_gpus]);
-      col_params_->group.members.push_back(member);
-    }
+    test_env_ = CreateCollectiveTestEnv(/*num_workers*/ 1,
+                                        /*num_devices_per_worker*/ num_ranks,
+                                        DEVICE_GPU, /*use_nccl=*/true);
     for (int rank = 0; rank < num_ranks; ++rank) {
       instances_.push_back(std::make_unique<DeviceInstance>(
-          rank, col_params_->group.members[rank].device.name(), this));
+          rank, collective_name_, collective_type_, test_env_.get()));
     }
   }
 
@@ -167,38 +107,34 @@ class NcclTestBase : public ::testing::Test {
   virtual void RunCollectiveOnDevice(DeviceInstance* di) = 0;
 
   void RunCollective() {
-    int done = 0;
-    mutex done_mu;
-    condition_variable done_cv;
+    std::atomic<int> done(0);
     for (const auto& instance : instances_) {
       DeviceInstance* di = instance.get();
       InitDevice(di);
-      SchedClosure([this, di, &done, &done_mu, &done_cv] {
+      SchedClosure([this, di, &done] {
         RunCollectiveOnDevice(di);
-        mutex_lock l(done_mu);
         ++done;
-        done_cv.notify_all();
       });
     }
-
-    mutex_lock l(done_mu);
-    while (done < instances_.size()) done_cv.wait(l);
+    while (done < static_cast<int>(instances_.size())) {
+      Env::Default()->SleepForMicroseconds(1000);
+    }
   }
 
-  void RunTest(int num_ranks, int input_length, int instance_key) {
-    if (num_ranks > gpus_.size()) {
+  void RunTest(int num_ranks, int input_length) {
+    Init(num_ranks);
+    if (num_ranks > test_env_->device_mgr->NumDevices()) {
       LOG(WARNING) << "Skipping test because required " << num_ranks
-                   << " GPUs but found " << gpus_.size();
+                   << " GPUs but found " << test_env_->device_mgr->NumDevices();
       return;
     }
-    Init(num_ranks, instance_key);
     for (int rank = 0; rank < num_ranks; ++rank) {
-      DeviceInstance* instance = instances_[rank].get();
-      instance->InitTensor(DT_FLOAT, TensorShape({input_length}),
-                           [this, rank](Tensor* t) { InitInput(t, rank); });
+      instances_[rank]->InitTensor(
+          DT_FLOAT, TensorShape({input_length}),
+          [this, rank](Tensor* t) { InitInput(t, rank); });
     }
     RunCollective();
-    // Confirm that every rank computed the same correct value.
+    // Check output.
     for (int rank = 0; rank < instances_.size(); ++rank) {
       std::vector<float> expected;
       InitExpected(&expected, input_length, rank, num_ranks);
@@ -211,312 +147,82 @@ class NcclTestBase : public ::testing::Test {
       }
 
       TF_ASSERT_OK(instances_[rank]->status_);
-      Tensor* output = &instances_[rank]->output_;
-      const int output_length = output->NumElements();
-      VLOG(2) << "rank " << rank << " output " << output << " buf "
-              << DMAHelper::base(output);
-      Tensor actual(DT_FLOAT, TensorShape({output_length}));
-      Device* dev = instances_[rank]->device_;
-      auto* dev_info = dev->tensorflow_accelerator_device_info();
-      TF_CHECK_OK(dev_info->default_context->CopyDeviceTensorToCPUSync(
-          output, /*tensor_name=*/"", dev, &actual));
+      VLOG(2) << "rank " << rank << " output " << &instances_[rank]->output_
+              << " buf " << DMAHelper::base(&instances_[rank]->output_);
       VLOG(3) << "rank " << rank << " got output tensor "
-              << actual.DebugString(output_length);
-      for (int i = 0; i < output_length; ++i) {
-        EXPECT_FLOAT_EQ(expected[i], actual.template flat<float>()(i))
-            << "Mismatch at rank " << rank << " index " << i;
-      }
+              << instances_[rank]->output_.DebugString(
+                     instances_[rank]->output_.NumElements());
+      test::ExpectTensorEqual<float>(test::AsTensor<float>(expected),
+                                     instances_[rank]->output_);
     }
-  }
-
-  std::unique_ptr<OpKernel> GetCollectiveReduceOpKernel(
-      const CollectiveParams& params, Tensor* input, DeviceBase* device) {
-    mutex_lock l(mu_);
-    NodeDef node_def;
-    NodeDefBuilder builder(strings::StrCat("collective_reduce_", op_counter_++),
-                           "CollectiveReduce");
-    TF_CHECK_OK(
-        builder.Attr("T", params.instance.data_type)
-            .Attr("merge_op", "Add")
-            .Attr("final_op", "Div")
-            .Attr("group_size", params.group.group_size)
-            .Attr("group_key", params.group.group_key)
-            .Attr("instance_key", params.instance.instance_key)
-            .Attr("subdiv_offsets", params.instance.impl_details.subdiv_offsets)
-            .Input(FakeInput(params.instance.data_type))
-            .Finalize(&node_def));
-    return GetKernel(node_def, device);
-  }
-
-  std::unique_ptr<OpKernel> GetCollectiveReduceScatterV2OpKernel(
-      const CollectiveParams& params, Tensor* input, DeviceBase* device) {
-    mutex_lock l(mu_);
-    NodeDef node_def;
-    NodeDefBuilder builder(
-        strings::StrCat("collective_reduce_scatter_", op_counter_++),
-        "CollectiveReduceScatterV2");
-    TF_CHECK_OK(
-        builder.Attr("T", params.instance.data_type)
-            .Attr("merge_op", "Add")
-            .Attr("final_op", "Div")
-            .Attr("subdiv_offsets", params.instance.impl_details.subdiv_offsets)
-            .Attr("communication_hint", "nccl")
-            .Input(FakeInput(params.instance.data_type))
-            .Input(FakeInput(DT_INT32))
-            .Input(FakeInput(DT_INT32))
-            .Input(FakeInput(DT_INT32))
-            .Finalize(&node_def));
-    return GetKernel(node_def, device);
   }
 
   class DeviceInstance {
    public:
-    DeviceInstance(int rank, const string& device_name, NcclTestBase* parent)
-        : parent_(parent),
-          device_name_(device_name),
-          rank_(rank),
-          col_params_(new CollectiveParams()) {
-      TF_CHECK_OK(parent_->dev_mgr_->LookupDevice(device_name_, &device_))
-          << "Could not find device " << device_name_ << " existing devices "
-          << parent_->dev_mgr_->DebugString();
+    DeviceInstance(int rank, const string& collective_name,
+                   CollectiveType collective_type, CollectiveTestEnv* test_env)
+        : test_env_(test_env) {  // TODO(tmorris): tensor_?
+      col_params_ =
+          CreateCollectiveParams(*test_env_, rank, collective_name,
+                                 collective_type, DT_FLOAT, TensorShape());
+      string device_name = col_params_->group.members[rank].device.name();
+      TF_CHECK_OK(test_env_->device_mgr->LookupDevice(device_name, &device_))
+          << "Could not find device " << device_name << " existing devices "
+          << test_env_->device_mgr->DebugString();
       merge_op_ = GetAdd(device_);
       final_op_ = GetDiv(device_);
-      col_params_->name = parent_->col_params_->name;
-      col_params_->default_rank = rank;
-      col_params_->group = parent_->col_params_->group;
-      col_params_->instance = parent->col_params_->instance;
     }
-
-    ~DeviceInstance() { col_params_->Unref(); }
 
     void InitTensor(DataType dtype, const TensorShape& shape,
                     const std::function<void(Tensor*)>& init_f) {
-      input_ =
-          Tensor(device_->GetAllocator(AllocatorAttributes()), dtype, shape);
-      Tensor cpu_tensor(dtype, shape);
-      init_f(&cpu_tensor);
+      input_ = Tensor(dtype, shape);
+      init_f(&input_);
       if (VLOG_IS_ON(3)) {
-        VLOG(3) << "input tensor "
-                << cpu_tensor.DebugString(shape.num_elements());
+        VLOG(3) << "input tensor " << input_.DebugString(shape.num_elements());
       } else {
-        VLOG(2) << "input tensor " << cpu_tensor.DebugString();
+        VLOG(2) << "input tensor " << input_.DebugString();
       }
-      auto* dev_info = device_->tensorflow_accelerator_device_info();
-      TF_CHECK_OK(dev_info->default_context->CopyCPUTensorToDeviceSync(
-          &cpu_tensor, device_, &input_));
-    }
-
-    void PrepareDeviceContext(OpKernelContext::Params* params) {
-      params->step_id = kStepId;
-      params->device = device_;
-      DeviceContext* dev_ctx = nullptr;
-      auto* dev_info = device_->tensorflow_accelerator_device_info();
-      if (dev_info) {
-        dev_ctx = dev_info->default_context;
-        dev_ctx->Ref();
-      } else {
-        dev_ctx = new DeviceContext;
-      }
-      params->op_device_context = dev_ctx;
     }
 
     void RunReduce() {
-      // Prepare an OpKernelContext.
-      OpKernelContext::Params op_params;
-      PrepareDeviceContext(&op_params);
-
-      // Prepare inputs and outputs to OpKernel.
-      gtl::InlinedVector<TensorValue, 4> inputs;
-      inputs.push_back(TensorValue(&input_));
-      op_params.inputs = inputs;
-      gtl::InlinedVector<AllocatorAttributes, 4> input_aa(
-          {AllocatorAttributes()});
-      op_params.input_alloc_attrs = input_aa;
-      int forward_from = 0;
-      op_params.forward_from_array = &forward_from;
-      AllocatorAttributes generic_alloc_attr;
-      op_params.output_attr_array = &generic_alloc_attr;
-      std::unique_ptr<OpKernel> op =
-          parent_->GetCollectiveReduceOpKernel(*col_params_, &input_, device_);
-      op_params.op_kernel = op.get();
-      OpKernelContext ctx(&op_params, 1);
-      // We never actually execute the kernel, so we need to do the output
-      // allocation it would do, ourselves.
-      Tensor* output_tensor_ptr = nullptr;
-      TF_CHECK_OK(ctx.forward_input_or_allocate_output({0}, 0, input_.shape(),
-                                                       &output_tensor_ptr));
-      CHECK_EQ(output_tensor_ptr, ctx.mutable_output(0));
-
-      // Run the all-reduce.
-      string exec_key =
-          strings::StrCat(col_params_->instance.instance_key, ":0:0");
-      auto* reducer = new NcclReducer();
-      auto col_ctx = std::make_shared<CollectiveContext>(
-          parent_->col_exec_, parent_->nccl_communicator_.get(),
-          parent_->dev_mgr_.get(),
-          /*OpKernelContext=*/&ctx, &op_params, col_params_, exec_key, kStepId,
-          /*input=*/&input_, /*output=*/&input_);
-      TF_CHECK_OK(reducer->InitializeCollectiveContext(col_ctx));
-      Notification note;
-      reducer->Run([this, &note](Status s) {
-        status_ = s;
-        note.Notify();
-      });
-      note.WaitForNotification();
-      if (status_.ok()) {
-        CHECK(output_.CopyFrom(*ctx.mutable_output(0), input_.shape()));
-      }
-
-      reducer->Unref();
-      op_params.op_device_context->Unref();
+      output_ = input_;
+      status_ = tensorflow::RunCollective(test_env_, col_params_.get(), device_,
+                                          &input_, &output_);
     }
 
     void RunReduceScatter() {
-      // Prepare an OpKernelContext.
-      OpKernelContext::Params op_params;
-      PrepareDeviceContext(&op_params);
-
-      // Prepare inputs and outputs to OpKernel.
-      gtl::InlinedVector<TensorValue, 4> inputs;
-      inputs.push_back(TensorValue(&input_));
-
-      Tensor group_size(DT_INT32, TensorShape({1}));
-      group_size.flat<int>()(0) = col_params_->group.group_size;
-      inputs.push_back(TensorValue(&group_size));
-
-      Tensor group_key(DT_INT32, TensorShape({1}));
-      group_key.flat<int>()(0) = col_params_->group.group_key;
-      inputs.push_back(TensorValue(&group_key));
-
-      Tensor instance_key(DT_INT32, TensorShape({1}));
-      instance_key.flat<int>()(0) = col_params_->instance.instance_key;
-      inputs.push_back(TensorValue(&instance_key));
-
-      op_params.inputs = inputs;
-      gtl::InlinedVector<AllocatorAttributes, 4> input_aa(
-          {AllocatorAttributes()});
-      op_params.input_alloc_attrs = input_aa;
-      int forward_from = 0;
-      op_params.forward_from_array = &forward_from;
-      AllocatorAttributes generic_alloc_attr;
-      op_params.output_attr_array = &generic_alloc_attr;
-      std::unique_ptr<OpKernel> op =
-          parent_->GetCollectiveReduceScatterV2OpKernel(*col_params_, &input_,
-                                                        device_);
-      op_params.op_kernel = op.get();
-      OpKernelContext ctx(&op_params, 1);
-      // We never actually execute the kernel, so we need to do the output
-      // allocation it would do, ourselves.
-      Tensor* output_tensor_ptr = nullptr;
-      auto output_shape = ctx.input(0).shape();
+      // Allocate output. We can't reuse the input because output has a
+      // different shape.
+      auto output_shape = input_.shape();
       output_shape.set_dim(
           0, output_shape.dim_size(0) / col_params_->group.group_size);
-      col_params_->instance.shape = output_shape;
-      TF_CHECK_OK(ctx.allocate_output(0, output_shape, &output_tensor_ptr));
-      CHECK_EQ(output_tensor_ptr, ctx.mutable_output(0));
-
-      // Run the reduce-scatter.
-      string exec_key =
-          strings::StrCat(col_params_->instance.instance_key, ":0:0");
-      auto* reducer = new NcclReduceScatterer();
-      auto col_ctx = std::make_shared<CollectiveContext>(
-          parent_->col_exec_, parent_->nccl_communicator_.get(),
-          parent_->dev_mgr_.get(),
-          /*OpKernelContext=*/&ctx, &op_params, col_params_, exec_key, kStepId,
-          /*input=*/&input_, /*output=*/&input_);
-      TF_CHECK_OK(reducer->InitializeCollectiveContext(col_ctx));
-      Notification note;
-      reducer->Run([this, &note](Status s) {
-        status_ = s;
-        note.Notify();
-      });
-      note.WaitForNotification();
-      if (status_.ok()) {
-        CHECK(output_.CopyFrom(*ctx.mutable_output(0), input_.shape()));
-      }
-
-      reducer->Unref();
-      op_params.op_device_context->Unref();
+      output_ = Tensor(DT_FLOAT, output_shape);
+      status_ = tensorflow::RunCollective(test_env_, col_params_.get(), device_,
+                                          &input_, &output_);
     }
 
     void RunBroadcast() {
-      VLOG(2) << "RunBroadcast name " << parent_->collective_name_ << " rank "
-              << col_params_->default_rank;
-      // Prepare an OpKernelContext.
-      OpKernelContext::Params op_params;
-      PrepareDeviceContext(&op_params);
-      OpKernelContext ctx(&op_params, 1);
-
-      // Run broadcast.
-      string exec_key =
-          strings::StrCat(col_params_->instance.instance_key, ":0:0");
-      auto* broadcaster = new NcclBroadcaster();
-      auto col_ctx = std::make_shared<CollectiveContext>(
-          parent_->col_exec_, parent_->nccl_communicator_.get(),
-          parent_->dev_mgr_.get(),
-          /*OpKernelContext=*/&ctx, &op_params, col_params_, exec_key, kStepId,
-          /*input=*/col_params_->is_source ? &input_ : nullptr,
-          /*output=*/&input_);
-      TF_CHECK_OK(broadcaster->InitializeCollectiveContext(col_ctx));
-      Notification note;
-      broadcaster->Run([this, &note](Status s) {
-        status_ = s;
-        note.Notify();
-      });
-      note.WaitForNotification();
-      if (status_.ok()) {
-        CHECK(output_.CopyFrom(input_, input_.shape()));
-      }
-
-      broadcaster->Unref();
-      op_params.op_device_context->Unref();
+      output_ = input_;
+      status_ = tensorflow::RunCollective(test_env_, col_params_.get(), device_,
+                                          &input_, &output_);
     }
 
     void RunGather() {
-      VLOG(2) << "RunGather name " << parent_->collective_name_ << " rank "
-              << col_params_->default_rank;
-      // Prepare an OpKernelContext.
-      OpKernelContext::Params op_params;
-      PrepareDeviceContext(&op_params);
-      OpKernelContext ctx(&op_params, 1);
-
-      // Allocate output.  We can't reuse the input because output has a
+      // Allocate output. We can't reuse the input because output has a
       // different shape.
       auto output_shape = input_.shape();
       output_shape.set_dim(
           0, output_shape.dim_size(0) * col_params_->group.group_size);
-      output_ = Tensor(device_->GetAllocator(AllocatorAttributes()), DT_FLOAT,
-                       output_shape);
-
-      // Run gather.
-      string exec_key =
-          strings::StrCat(col_params_->instance.instance_key, ":0:0");
-      auto* gatherer = new NcclGatherer();
-      auto col_ctx = std::make_shared<CollectiveContext>(
-          parent_->col_exec_, parent_->nccl_communicator_.get(),
-          parent_->dev_mgr_.get(),
-          /*OpKernelContext=*/&ctx, &op_params, col_params_, exec_key, kStepId,
-          /*input=*/&input_,
-          /*output=*/&output_);
-      TF_CHECK_OK(gatherer->InitializeCollectiveContext(col_ctx));
-      Notification note;
-      gatherer->Run([this, &note](Status s) {
-        status_ = s;
-        note.Notify();
-      });
-      note.WaitForNotification();
-
-      gatherer->Unref();
-      op_params.op_device_context->Unref();
+      output_ = Tensor(DT_FLOAT, output_shape);
+      status_ = tensorflow::RunCollective(test_env_, col_params_.get(), device_,
+                                          &input_, &output_);
     }
 
-    NcclTestBase* parent_;
-    string device_name_;
-    int rank_;
+    CollectiveTestEnv* test_env_;
     Tensor input_;
     Tensor output_;
     Device* device_;
-    CollectiveParams* col_params_;
+    core::RefCountPtr<CollectiveParams> col_params_;
     std::unique_ptr<OpKernel> merge_op_;
     std::unique_ptr<OpKernel> final_op_;
     Status status_;
@@ -524,17 +230,10 @@ class NcclTestBase : public ::testing::Test {
 
   CollectiveType collective_type_;
   const string collective_name_;
-  std::vector<std::unique_ptr<tensorflow::Device>> gpus_;
-  TestCollectiveExecutorMgr col_exec_mgr_;
-  ConfigProto config_proto_;
-  std::unique_ptr<NcclCommunicatorInterface> nccl_communicator_;
-  std::shared_ptr<UnboundedWorkQueue> work_queue_;
-  CollectiveExecutor* col_exec_;
-  std::unique_ptr<DeviceMgr> dev_mgr_;
   std::vector<std::unique_ptr<DeviceInstance>> instances_;
-  CollectiveParams* col_params_;
   mutex mu_;
   int32 op_counter_ TF_GUARDED_BY(mu_) = 0;
+  std::unique_ptr<CollectiveTestEnv> test_env_;
 };
 
 class NcclReducerTest : public NcclTestBase {
@@ -676,69 +375,69 @@ class NcclGathererTest : public NcclTestBase {
 };
 
 TEST_F(NcclReducerTest, Test2Dev16Len) {
-  RunTest(/*num_ranks=*/2, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/2, /*tensor_length=*/16);
 }
 TEST_F(NcclReducerTest, Test4Dev16Len) {
-  RunTest(/*num_ranks=*/4, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/4, /*tensor_length=*/16);
 }
 TEST_F(NcclReducerTest, Test8Dev16Len) {
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/16);
 }
 TEST_F(NcclReducerTest, Test8Dev128Len) {
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/128, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/128);
 }
 TEST_F(NcclReducerTest, Test8Dev1045991Len) {
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/1048576, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/1048576);
 }
 
 TEST_F(NcclBroadcasterTest, Test2Dev16LenSrc0) {
-  RunTest(/*num_ranks=*/2, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/2, /*tensor_length=*/16);
 }
 TEST_F(NcclBroadcasterTest, Test4Dev16LenSrc1) {
   source_rank_ = 1;
-  RunTest(/*num_ranks=*/4, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/4, /*tensor_length=*/16);
 }
 TEST_F(NcclBroadcasterTest, Test8Dev16LenSrc7) {
   source_rank_ = 7;
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/16);
 }
 TEST_F(NcclBroadcasterTest, Test8Dev128LenSrc0) {
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/128, /*instance_key=*/24);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/128);
 }
 TEST_F(NcclBroadcasterTest, Test8Dev1045991LenSrc0) {
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/1048576, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/1048576);
 }
 
 TEST_F(NcclGathererTest, Test2Dev16Len) {
-  RunTest(/*num_ranks=*/2, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/2, /*tensor_length=*/16);
 }
 TEST_F(NcclGathererTest, Test4Dev16Len) {
-  RunTest(/*num_ranks=*/4, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/4, /*tensor_length=*/16);
 }
 TEST_F(NcclGathererTest, Test8Dev16Len) {
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/16);
 }
 TEST_F(NcclGathererTest, Test8Dev128Len) {
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/128, /*instance_key=*/24);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/128);
 }
 TEST_F(NcclGathererTest, Test8Dev1045991Len) {
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/1048576, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/1048576);
 }
 
 TEST_F(NcclReduceScattererTest, Test2Dev16Len) {
-  RunTest(/*num_ranks=*/2, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/2, /*tensor_length=*/16);
 }
 TEST_F(NcclReduceScattererTest, Test4Dev16Len) {
-  RunTest(/*num_ranks=*/4, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/4, /*tensor_length=*/16);
 }
 TEST_F(NcclReduceScattererTest, Test8Dev16Len) {
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/16, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/16);
 }
 TEST_F(NcclReduceScattererTest, Test8Dev128Len) {
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/128, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/128);
 }
 TEST_F(NcclReduceScattererTest, Test8Dev1045991Len) {
-  RunTest(/*num_ranks=*/8, /*tensor_length=*/1048576, /*instance_key=*/23);
+  RunTest(/*num_ranks=*/8, /*tensor_length=*/1048576);
 }
 
 }  // namespace tensorflow

--- a/tensorflow/core/nccl/collective_communicator.cc
+++ b/tensorflow/core/nccl/collective_communicator.cc
@@ -172,6 +172,10 @@ void NcclCommunicator::Enqueue(std::shared_ptr<CollectiveContext> col_ctx,
                                        reduction_op);
       break;
     }
+    case ALL_TO_ALL_COLLECTIVE: {
+      nccl_manager_.AddToAllToAll(std::move(participant), context);
+      break;
+    }
     default: {
       participant->done_callback(errors::Internal("Unexpected CollectiveType ",
                                                   col_params->instance.type));

--- a/tensorflow/core/nccl/nccl_manager.h
+++ b/tensorflow/core/nccl/nccl_manager.h
@@ -192,6 +192,10 @@ class NcclManager {
   void AddReduceRecv(std::unique_ptr<Participant> participant,
                      const Context& context, ncclRedOp_t reduction_op);
 
+  // Adds one participant to an all-to-all.
+  void AddToAllToAll(std::unique_ptr<Participant> participant,
+                     const Context& context);
+
   // Signals that the `Collective` corresponding to `key` is ready to launch
   // across all nodes participating in this multi-node collective operation.
   //
@@ -215,6 +219,7 @@ class NcclManager {
     kReduce = 3,
     kAllGather = 4,
     kReduceScatter = 5,
+    kAllToAll = 6,
   };
   struct Collective;
   struct Communicator;


### PR DESCRIPTION
* Add NCCL implementation for all-to-all collective via NcclManager
* Refactors `collective_nccl_test` to use the collective_test_util infrastructure. This fixes some occasional crashes with the tests and greatly simplfies the code

This PR is the first step to adding all-to-all GPU support in DTensor. cc @rainwoodman 