### PR TITLE
Revert "[aarch64] acl linking for mkl_aarch64_threadpool config"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -242,7 +242,6 @@ build:mkl_aarch64 -c opt
 # Config setting to build oneDNN with Compute Library for the Arm Architecture (ACL).
 # with Eigen threadpool support
 build:mkl_aarch64_threadpool --define=build_with_mkl_aarch64=true
-build:mkl_aarch64_threadpool --define=build_with_acl=true
 build:mkl_aarch64_threadpool -c opt
 
 # This config refers to building CUDA op kernels with nvcc.


### PR DESCRIPTION
Revert "[aarch64] enable acl linking for cpu xla for mkl_aarch64_threadpool configuration"
Reason: The config has not been well-tested yet.

This reverts commit 6bc78c3e5019385effdb2aab70cd4a088ece7e0a.