### PR TITLE
[OneDNN] Optimize unsorted segment sum on 1 dim

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -362,7 +362,7 @@ struct UnsortedSegmentFunctor<CPUDevice, T, Index, InitialValueF, ReductionF> {
     T* out_ptr = output.data();
     ReductionF reduction;
 
-    bool data_is_1D = data.dimensions()[1] == 1;
+    bool data_is_1D = inner_dim == 1;
 
     // `num_real_segment` counts the rows actually reduced from input,
     // the rows with negative segment index will be excluded.

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -362,7 +362,7 @@ struct UnsortedSegmentFunctor<CPUDevice, T, Index, InitialValueF, ReductionF> {
     T* out_ptr = output.data();
     ReductionF reduction;
 
-    bool data_is_1D = inner_dim == 1;
+    bool is_inner_dim_1d = inner_dim == 1;
 
     // `num_real_segment` counts the rows actually reduced from input,
     // the rows with negative segment index will be excluded.
@@ -430,7 +430,7 @@ struct UnsortedSegmentFunctor<CPUDevice, T, Index, InitialValueF, ReductionF> {
     const int64_t input_bytes = sizeof(T) * inner_dim * kAverTaskSize;
     const int64_t output_bytes = sizeof(T) * inner_dim * kAverTaskSize;
     const Eigen::TensorOpCost cost(input_bytes, output_bytes, compute_cycles);
-    if(data_is_1D) {
+    if(is_inner_dim_1d) {
         cpu_device.parallelFor(num_segments, cost, reductionWorker1D);
     }
     else {

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -419,7 +419,7 @@ struct UnsortedSegmentFunctor<CPUDevice, T, Index, InitialValueF, ReductionF> {
         Index j = internal::SubtleMustCopy(segment_ids(i));
         // If `j` is in work scope of this worker, do the reduction.
         if (j >= begin && j < end) {
-            reduction(data_ptr[i], out_ptr[j]);
+          reduction(data_ptr[i], out_ptr[j]);
         }
       }
     };
@@ -430,13 +430,11 @@ struct UnsortedSegmentFunctor<CPUDevice, T, Index, InitialValueF, ReductionF> {
     const int64_t input_bytes = sizeof(T) * inner_dim * kAverTaskSize;
     const int64_t output_bytes = sizeof(T) * inner_dim * kAverTaskSize;
     const Eigen::TensorOpCost cost(input_bytes, output_bytes, compute_cycles);
-    if(is_inner_dim_1d) {
-        cpu_device.parallelFor(num_segments, cost, reductionWorker1D);
+    if (is_inner_dim_1d) {
+      cpu_device.parallelFor(num_segments, cost, reductionWorker1D);
+    } else {
+      cpu_device.parallelFor(num_segments, cost, reductionWorker);
     }
-    else {
-        cpu_device.parallelFor(num_segments, cost, reductionWorker);
-    }
-    
   }
 };
 

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -362,7 +362,7 @@ struct UnsortedSegmentFunctor<CPUDevice, T, Index, InitialValueF, ReductionF> {
     T* out_ptr = output.data();
     ReductionF reduction;
 
-    bool is_inner_dim_1d = inner_dim == 1;
+    const bool is_inner_dim_1d = inner_dim == 1;
 
     // `num_real_segment` counts the rows actually reduced from input,
     // the rows with negative segment index will be excluded.


### PR DESCRIPTION
Optimize unsorted segment sum calculations on 1-dim by removing tensor class overheads.

Performance numbers:
| Reduction | Num rows | Num cols | Segment size | Before (ns) | After (ns) | Speed up |
| --------- | -------- | -------- | ------------ | ----------- | ---------- | -------- |
| Sum       | 4,096    | 1        | 128          | 60,812      | 5,899      | 10.31x    |
| Max       | 4,096    | 1        | 128          | 52,164      | 5,524      | 9.44x     |
| Min       | 4,096    | 1        | 128          | 52,052      | 5,957      | 8.74x     |
| Prod      | 4,096    | 1        | 128          | 66,103      | 9,573      | 6.91x     |