### PR TITLE
Disable ARC for signpost_profiler

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -503,6 +503,7 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "iOS")
   list(APPEND TFLITE_PROFILER_SRCS
     ${TFLITE_SOURCE_DIR}/profiling/signpost_profiler.mm
   )
+  set_source_files_properties(${TFLITE_SOURCE_DIR}/profiling/signpost_profiler.mm PROPERTIES COMPILE_FLAGS -fno-objc-arc)
 endif()
 
 # TFLite library


### PR DESCRIPTION
This makes bazel and cmake build consistent. Also this fixes the problem, if one compiles Metal or CoreML delegate which require ARC enabled.