### PR TITLE
Revert "r2.11 cherry-pick: 7a3d9601d6a "Support forceBackend option in GPU Delegate Options.""

### DIFF
--- a/tensorflow/lite/delegates/gpu/java/src/main/java/org/tensorflow/lite/gpu/GpuDelegate.java
+++ b/tensorflow/lite/delegates/gpu/java/src/main/java/org/tensorflow/lite/gpu/GpuDelegate.java
@@ -44,8 +44,7 @@ public class GpuDelegate implements Delegate {
             options.areQuantizedModelsAllowed(),
             options.getInferencePreference(),
             options.getSerializationDir(),
-            options.getModelToken(),
-            options.getForceBackend().value());
+            options.getModelToken());
   }
 
   @UsedByReflection("TFLiteSupport/model/GpuDelegateProxy")
@@ -84,8 +83,7 @@ public class GpuDelegate implements Delegate {
       boolean quantizedModelsAllowed,
       int preference,
       String serializationDir,
-      String modelToken,
-      int forceBackend);
+      String modelToken);
 
   private static native void deleteDelegate(long delegateHandle);
 }

--- a/tensorflow/lite/delegates/gpu/java/src/main/java/org/tensorflow/lite/gpu/GpuDelegateFactory.java
+++ b/tensorflow/lite/delegates/gpu/java/src/main/java/org/tensorflow/lite/gpu/GpuDelegateFactory.java
@@ -42,26 +42,6 @@ public class GpuDelegateFactory implements DelegateFactory {
      */
     public static final int INFERENCE_PREFERENCE_SUSTAINED_SPEED = 1;
 
-    /** Which GPU backend to select. */
-    public enum GpuBackend {
-      /** Try OpenCL first. Fall back to OpenGL if it's not available. */
-      UNSET(0),
-      /** Enforces execution with Open CL. */
-      OPENCL(1),
-      /** Enforces execution with Open GL. */
-      OPENGL(2);
-      private final int value;
-
-      GpuBackend(int value) {
-        this.value = value;
-      }
-
-      /** int value of this enum. */
-      public int value() {
-        return value;
-      }
-    }
-
     /**
      * Sets whether precision loss is allowed.
      *
@@ -116,14 +96,6 @@ public class GpuDelegateFactory implements DelegateFactory {
       return this;
     }
 
-    /**
-     * Sets the GPU Backend.
-     */
-    public Options setForceBackend(GpuBackend forceBackend) {
-      this.forceBackend = forceBackend;
-      return this;
-    }
-
     public boolean isPrecisionLossAllowed() {
       return precisionLossAllowed;
     }
@@ -144,16 +116,11 @@ public class GpuDelegateFactory implements DelegateFactory {
       return modelToken;
     }
 
-    public GpuBackend getForceBackend() {
-      return forceBackend;
-    }
-
     private boolean precisionLossAllowed = true;
     boolean quantizedModelsAllowed = true;
     int inferencePreference = INFERENCE_PREFERENCE_FAST_SINGLE_ANSWER;
     String serializationDir = null;
     String modelToken = null;
-    GpuBackend forceBackend = GpuBackend.UNSET;
   }
 
   public GpuDelegateFactory() {

--- a/tensorflow/lite/delegates/gpu/java/src/main/native/BUILD
+++ b/tensorflow/lite/delegates/gpu/java/src/main/native/BUILD
@@ -50,7 +50,6 @@ cc_library_with_tflite(
     ],
     deps = [
         "//tensorflow/lite/delegates/gpu:delegate",
-        "//tensorflow/lite/delegates/gpu:delegate_options",
         "//tensorflow/lite/delegates/gpu/common:gpu_info",
         "//tensorflow/lite/delegates/gpu/gl:egl_environment",
         "//tensorflow/lite/delegates/gpu/gl:request_gpu_info",

--- a/tensorflow/lite/java/src/test/java/org/tensorflow/lite/gpu/GpuDelegateTest.java
+++ b/tensorflow/lite/java/src/test/java/org/tensorflow/lite/gpu/GpuDelegateTest.java
@@ -17,8 +17,6 @@ package org.tensorflow.lite.gpu;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
-import static org.junit.Assert.assertThrows;
-import static org.tensorflow.lite.gpu.GpuDelegateFactory.Options.GpuBackend.OPENCL;
 
 import com.google.common.base.Stopwatch;
 import java.io.File;
@@ -119,22 +117,6 @@ public final class GpuDelegateTest {
       assertThat(interpreter.getOutputTensor(0).shape()).isEqualTo(new int[] {1, 1001});
       // 653 == "military uniform"
       assertThat(getTopKLabels(output, 3)).contains(653);
-    }
-  }
-
-  @Test
-  public void testInterpreterWithGpu_forceOpenCl_throwsException() {
-    Interpreter.Options options = new Interpreter.Options();
-    try (GpuDelegate delegate =
-        new GpuDelegate(new GpuDelegateFactory.Options().setForceBackend(OPENCL))) {
-      IllegalArgumentException e =
-          assertThrows(
-              IllegalArgumentException.class,
-              // Create interpreter fails because OpenCL is not available on device.
-              () ->
-                  new Interpreter(MOBILENET_QUANTIZED_MODEL_BUFFER, options.addDelegate(delegate)));
-
-      assertThat(e).hasMessageThat().contains("Can not open OpenCL library");
     }
   }
 


### PR DESCRIPTION
Reverts tensorflow/tensorflow#59480

This cherrypick is requested on to r2.12 but not onto r2.11. So reverting the cherrypick. 