### PR TITLE
Fix missing symbols on S390x caused by jit_compiler

### DIFF
--- a/tensorflow/compiler/xla/mlir/runtime/transforms/BUILD
+++ b/tensorflow/compiler/xla/mlir/runtime/transforms/BUILD
@@ -242,6 +242,9 @@ cc_library(
         "//tensorflow/tsl:macos_arm64": [
             "@llvm-project//llvm:AArch64AsmParser",
         ],
+        "//tensorflow/tsl:linux_s390x": [
+            "@llvm-project//llvm:SystemZAsmParser",
+        ],
         "//conditions:default": [
             "@llvm-project//llvm:X86AsmParser",
         ],


### PR DESCRIPTION
Inside `jit_compiler.cc` the function `llvm::InitializeNativeTargetAsmParser` is called which uses an architecture-dependend define. Add SystemZAsmParser similar to #59326

See also https://github.com/llvm/llvm-project/issues/59590.