### PR TITLE
[TF-TRT] Introduce `_remove_native_segments` function to remove native segments in TF-TRT Graph

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -244,6 +244,9 @@ class TRTEngineOp : public AsyncOpKernel {
   // Maximum number of cached engines.
   int max_cached_engines_;
 
+  // Flag to detect whether native segment nodes have been deleted from graph
+  bool native_segment_absent_;
+
   int64 workspace_size_;
   mutex engine_mutex_;
   FunctionLibraryRuntime::Handle native_execution_func_handle_;
@@ -357,7 +360,7 @@ StatusOr<FunctionLibraryRuntime::Handle> TRTEngineOp::ConstructFunctionHandle(
   FunctionLibraryRuntime::InstantiateOptions inst_ops;
   inst_ops.state_handle = "";
   inst_ops.target = device_name;
-  if (allow_soft_placement) {
+  if (!native_segment_absent_ && allow_soft_placement) {
     const FunctionDef* fdef =
         lib->GetFunctionLibraryDefinition()->Find(func_.name());
     if (!fdef) {
@@ -421,9 +424,6 @@ TRTEngineOp::TRTEngineOp(OpKernelConstruction* context)
   OP_REQUIRES_OK(context,
                  context->GetAttr("calibration_data", &calibration_data));
   OP_REQUIRES_OK(context, context->GetAttr("segment_func", &func_));
-  OP_REQUIRES(context, !func_.name().empty(),
-              errors::InvalidArgument(
-                  "The TF function for the TRT segment could not be empty"));
   OP_REQUIRES_OK(context,
                  TrtPrecisionModeFromName(precision_string, &precision_mode_));
   OP_REQUIRES_OK(context,
@@ -468,11 +468,17 @@ TRTEngineOp::TRTEngineOp(OpKernelConstruction* context)
     use_explicit_precision_ = false;
   }
 
+  // When a TF-TRT converted model without native segments is loaded,
+  // func_ can be empty.
+  native_segment_absent_ = (func_.name() == "");
   native_execution_func_handle_ = kInvalidHandle;
-  if (!static_engine_) {
-    OP_REQUIRES_OK(context, ImportSegmentGraphDef(context->function_library(),
-                                                  context->device()->name()));
+  if (!native_segment_absent_) {
+    if (!static_engine_) {
+      OP_REQUIRES_OK(context, ImportSegmentGraphDef(context->function_library(),
+                                                    context->device()->name()));
+    }
   }
+
   // TODO(laigd): calibration_data is used in TF v1.x and we keep it only for
   // backward compatibility reasons. Remove it once all known users switch to
   // 2.0.
@@ -721,7 +727,12 @@ void TRTEngineOp::ExecuteCalibration(OpKernelContext* ctx,
       VLOG(2) << "Passed calibration data";
     }
   }
-  ExecuteNativeSegment(ctx, async_helper);
+  if (!native_segment_absent_) {
+    ExecuteNativeSegment(ctx, async_helper);
+  } else {
+    LOG(ERROR)
+        << "Calibration requires native segment, but is not found in the graph.";
+  }
 }
 
 Status TRTEngineOp::VerifyInputShapes(
@@ -843,7 +854,7 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
   Status verify_input_shape_status =
       VerifyInputShapes(input_concrete_shapes_filtered);
   // TODO(bixia): Fix the segmentation.
-  if (!verify_input_shape_status.ok()) {
+  if (!verify_input_shape_status.ok() && !native_segment_absent_) {
     LOG_FIRST_FEW_WARNING_WITH_PREFIX
         << "Running native segment for" << name()
         << " due to failure in verifying input shapes: "
@@ -868,8 +879,13 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
       // Just collect the input shape info and return. The shapes are used to
       // generate optimization profiles during engine creation.
       cache_res->profiles_.AddShape(input_concrete_shapes);
-      VLOG(1) << "Native segment is used during collecting shapes for profiles";
-      ExecuteNativeSegment(ctx, async_helper);
+      VLOG(1) << "Native segment is used during collecting shapes for profiles.";
+      if (!native_segment_absent_) {
+        ExecuteNativeSegment(ctx, async_helper);
+      } else {
+        LOG(ERROR) << "Native segment is required for profile generation,  "
+                      "but is not found in the graph.";
+      }
       return;
     } else if (cache_res->profiles_.GetNumProfiles() == 0 && !static_engine_) {
       // Add current shape if we did not collect any shapes so far.
@@ -926,9 +942,14 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
   EngineContext* engine_context = status.value().first;
   int trt_context_idx = status.value().second;
   auto may_execute_native_segment = [&] {
-    if (!AllowEngineNativeSegmentExecution()) {
+    if (!native_segment_absent_ && !AllowEngineNativeSegmentExecution()) {
       ctx->CtxFailure(
-          errors::Aborted("User disallowed engine native segment execution"));
+          errors::Aborted("User disallowed engine native segment execution."));
+      return false;
+    } else if (native_segment_absent_) {
+      ctx->CtxFailure(
+          errors::Aborted("Native segment execution is enabled but "
+                          " native segment is not found in the graph."));
       return false;
     }
     return true;
@@ -954,14 +975,20 @@ void TRTEngineOp::ComputeAsync(OpKernelContext* ctx,
   if (!may_execute_native_segment()) {
     return;
   }
-  // Release any outputs that are allocated, ExecuteNativeSegment will
-  // re-allocate them and fail if they are currently allocated.
+  // When Native Segment execution is enabled, release any outputs that
+  // are allocated. ExecuteNativeSegment will re-allocate them and
+  // fail if they are currently allocated.
   // The Tensor pointer in the returned TensorValue must be explicitly
   // deleted.
   for (int i = 0; i < ctx->num_outputs(); i++) {
     delete ctx->release_output(i).tensor;
   }
-  ExecuteNativeSegment(ctx, async_helper);
+  if (!native_segment_absent_) {
+    ExecuteNativeSegment(ctx, async_helper);
+  } else {
+    LOG(ERROR) << "Native segment execution is enabled, "
+                  "but native segment is not found in the graph.";
+  }
 }
 
 Status TRTEngineOp::ExecuteTrtEngine(

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -841,11 +841,46 @@ class TrtGraphConverter(object):
     # Ignore other meta graphs from the input SavedModel.
     saved_model_builder.save()
 
-
 def _get_resource_handle(name, device):
   with ops.device(device):
-    return gen_trt_ops.create_trt_resource_handle(resource_name=name)
+    return gen_trt_ops.create_trt_resource_handle(resource_name=name) 
 
+def _remove_native_segments(input_func):
+  """ Remove native segments from the input TF-TRT Converted Function.
+  Args:
+    input_func: provide the concrete function with native segment nodes. 
+     The transformed output func will not contain any native segment nodes. All
+     the TRTEngineOp references will be deleted and reset to default empty func.
+  """
+  input_graph_def = input_func.graph.as_graph_def()
+  # Deleting the Native Segment node in each TRTEngineOp node.
+  nodes_deleted = 0
+  for func_id in reversed(range(len(input_graph_def.library.function))):
+    f = input_graph_def.library.function[func_id]
+    if "native_segment" in f.signature.name:
+      nodes_deleted += 1
+      while context.context().has_function(f.signature.name):
+        context.context().remove_function(f.signature.name)
+      del input_graph_def.library.function[func_id]
+
+  logging.info(f"Found and deleted native segments from "
+                f"{nodes_deleted} TRTEngineOp nodes.")
+  
+  # Deleting the references to `<EngineName>_native_segment`s.
+  # This helps TRTEngineOp constructor to not look for native segment handles
+  # during construction of graph for inference. 
+  for node in input_graph_def.node:
+    if node.op == "TRTEngineOp":
+      del node.attr["segment_func"]
+  for func in input_graph_def.library.function: 
+    for node in func.node_def:
+      if node.op == "TRTEngineOp":
+        del node.attr["segment_func"]
+  # Reconstruct the converted_func with the new graph
+  new_func = _construct_function_from_graph_def(
+    input_func, input_graph_def)
+  
+  return new_func
 
 class _TRTEngineResource(resource.TrackableResource):
   """Class to track the serialized engines resource."""
@@ -1532,6 +1567,21 @@ class TrtGraphConverterV2(object):
       RuntimeError: if the needed calibration hasn't been done.
     """
     assert self._converted
+
+    # 'remove_native_segments': setting this value to True removes native segments 
+    # associated with each TRT engine. This option can be used to reduce the size 
+    # of the converted model. Please note that a converted model without native
+    # segments can't be used for collecting profiles, building or re-converting.
+    # The reduced model can only be used for inference when no native segments
+    # are required for computation. When remove_native_segments flag is set to 
+    # True, the converted_graph_def needs to be reduced before saved_model 
+    # function serialization.
+    if trt_utils.is_experimental_feature_activated('remove_native_segments'):
+      logging.info("\'remove_native_segments\' experimental feature is enabled"
+                   " during saving of converted SavedModel.")
+      self._converted_func = _remove_native_segments(self._converted_func)
+      self._converted_graph_def = self._converted_func.graph.as_graph_def()
+
     if self._need_calibration and not self._calibrated:
       raise RuntimeError("A model that requires INT8 calibration has to be "
                          "built before saving it. Call build() to build and "
@@ -1599,7 +1649,7 @@ class TrtGraphConverterV2(object):
       reset_converted_func.graph.structured_input_signature = (
           self._converted_func.structured_input_signature)
       self._converted_func = reset_converted_func
-
+     
     # Rewrite the signature map using the optimized ConcreteFunction.
     signatures = {self._input_saved_model_signature_key: self._converted_func}
     save.save(trackable, output_saved_model_dir, signatures, options=options)

--- a/tensorflow/python/compiler/tensorrt/trt_convert_test.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert_test.py
@@ -703,6 +703,43 @@ class TrtConvertTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     gc.collect()  # Force GC to destroy the TRT engine cache.
 
   @test_util.run_v2_only
+  def testTrtGraphConverter_RemoveNativeSegments(self):
+    """Test case for trt_convert._remove_native_segment()."""
+    np_input = np.random.random_sample([5, 3]).astype(np.float32)
+    # Create a model and save it.
+    input_saved_model_dir = tempfile.mkdtemp(dir=self.get_temp_dir())
+    root = self._GetShapeOpModel()
+    expected_output = root.run(np_input)
+    save.save(root, input_saved_model_dir, signatures=root.run)
+
+    # Run TRT conversion.
+    converter = trt_convert.TrtGraphConverterV2(
+        input_saved_model_dir,
+        precision_mode=trt_convert.TrtPrecisionMode.FP32,
+        allow_build_at_runtime=False,
+        minimum_segment_size=1)
+
+    def _input_fn():
+      yield (np_input,)
+    graph_func = converter.convert()
+    converter.build(_input_fn)
+    # Load and verify the reduced converted model.
+    output_saved_model_dir2 = self.mkdtemp()
+    with test_utils.experimental_feature_scope("remove_native_segments"):
+      converter.save(output_saved_model_dir2)
+    saved_model_loaded = load.load(output_saved_model_dir2)
+    graph_func_after = saved_model_loaded.signatures["serving_default"]
+    actual_output = graph_func_after(x=np_input)["output_0"]
+    self.assertAllClose(
+        expected_output,
+        actual_output,
+        atol=1e-6,
+        rtol=1e-6)
+    del graph_func
+    del root
+    gc.collect()  # Force GC to destroy the TRT engine cache.
+
+  @test_util.run_v2_only
   def testTrtGraphConverter_DestroyEngineCache(self):
     """Test case for trt_convert.TrtGraphConverter()."""
 


### PR DESCRIPTION
This function parses through the TF-TRT graph and deletes native segment nodes constructed for falling back. Changes have also been made to `TRTEngineOp` to recognize when the loaded graph doesn't have `_native_segment` nodes and disallow loading the graph associated with the native segments. 

To do: When native segment execution is disabled, we don't generate the native_segment nodes in the first place.


@tfeher and @DEKHTIARJonathan  please review.