### PR TITLE
Allow RowPartition to cache row_lengths and value_rowids

### DIFF
--- a/tensorflow/python/ops/ragged/row_partition.py
+++ b/tensorflow/python/ops/ragged/row_partition.py
@@ -746,14 +746,14 @@ class RowPartition(composite_tensor.CompositeTensor):
     """
     return self._row_splits
 
-  def value_rowids(self, allow_persist=True):
+  def value_rowids(self, cache=True):
     """Returns the row indices for this row partition.
 
     `value_rowids` specifies the row index fo reach value.  In particular,
     `value_rowids[i]` is the row index for `values[i]`.
 
     Args:
-      allow_persist: If True, the generated value_rowids tensor will be 
+      cache: If True, the generated value_rowids tensor will be 
       stored internally and reused if needed again. Defaults to True.
 
     Returns:
@@ -763,7 +763,7 @@ class RowPartition(composite_tensor.CompositeTensor):
     if self._value_rowids is not None:
       return self._value_rowids
     value_rowids = segment_id_ops.row_splits_to_segment_ids(self._row_splits)
-    if allow_persist:
+    if cache:
       self._value_rowids = value_rowids
     return value_rowids
 
@@ -834,11 +834,11 @@ class RowPartition(composite_tensor.CompositeTensor):
     """
     return self._row_splits[1:]
 
-  def row_lengths(self, allow_persist=True):
+  def row_lengths(self, cache=True):
     """Returns the lengths of rows in this `RowPartition`.
 
     Args:
-      allow_persist: If True, the generated row_lengths tensor will be
+      cache: If True, the generated row_lengths tensor will be
       stored internally and reused if needed again. Defaults to True.
 
     Returns:
@@ -850,7 +850,7 @@ class RowPartition(composite_tensor.CompositeTensor):
       return self._row_lengths
     splits = self._row_splits
     row_lengths = splits[1:] - splits[:-1]
-    if allow_persist:
+    if cache:
       self._row_lengths = row_lengths
     return row_lengths
 

--- a/tensorflow/python/ops/ragged/row_partition.py
+++ b/tensorflow/python/ops/ragged/row_partition.py
@@ -762,10 +762,10 @@ class RowPartition(composite_tensor.CompositeTensor):
     """
     if self._value_rowids is not None:
       return self._value_rowids
-    result = segment_id_ops.row_splits_to_segment_ids(self._row_splits)
+    value_rowids = segment_id_ops.row_splits_to_segment_ids(self._row_splits)
     if allow_persist:
-      self._value_rowids = result
-    return result
+      self._value_rowids = value_rowids
+    return value_rowids
 
   def nvals(self):
     """Returns the number of values partitioned by this `RowPartition`.
@@ -849,10 +849,10 @@ class RowPartition(composite_tensor.CompositeTensor):
     if self._row_lengths is not None:
       return self._row_lengths
     splits = self._row_splits
-    result = splits[1:] - splits[:-1]
+    row_lengths = splits[1:] - splits[:-1]
     if allow_persist:
-      self._row_lengths = result
-    return result
+      self._row_lengths = row_lengths
+    return row_lengths
 
   @property
   def static_nrows(self):

--- a/tensorflow/python/ops/ragged/row_partition.py
+++ b/tensorflow/python/ops/ragged/row_partition.py
@@ -838,7 +838,7 @@ class RowPartition(composite_tensor.CompositeTensor):
     """Returns the lengths of rows in this `RowPartition`.
 
     Args:
-      allow_persist: If True, the generated value_rowids tensor will be 
+      allow_persist: If True, the generated row_lengths tensor will be
       stored internally and reused if needed again. Defaults to True.
 
     Returns:

--- a/tensorflow/python/ops/ragged/row_partition.py
+++ b/tensorflow/python/ops/ragged/row_partition.py
@@ -746,11 +746,15 @@ class RowPartition(composite_tensor.CompositeTensor):
     """
     return self._row_splits
 
-  def value_rowids(self):
+  def value_rowids(self, allow_persist=True):
     """Returns the row indices for this row partition.
 
     `value_rowids` specifies the row index fo reach value.  In particular,
     `value_rowids[i]` is the row index for `values[i]`.
+
+    Args:
+      allow_persist: If True, the generated value_rowids tensor will be 
+      stored internally and reused if needed again. Defaults to True.
 
     Returns:
       A 1-D integer `Tensor` with shape `[self.nvals()]`.
@@ -758,7 +762,10 @@ class RowPartition(composite_tensor.CompositeTensor):
     """
     if self._value_rowids is not None:
       return self._value_rowids
-    return segment_id_ops.row_splits_to_segment_ids(self._row_splits)
+    result = segment_id_ops.row_splits_to_segment_ids(self._row_splits)
+    if allow_persist:
+      self._value_rowids = result
+    return result
 
   def nvals(self):
     """Returns the number of values partitioned by this `RowPartition`.
@@ -827,8 +834,12 @@ class RowPartition(composite_tensor.CompositeTensor):
     """
     return self._row_splits[1:]
 
-  def row_lengths(self):
+  def row_lengths(self, allow_persist=True):
     """Returns the lengths of rows in this `RowPartition`.
+
+    Args:
+      allow_persist: If True, the generated value_rowids tensor will be 
+      stored internally and reused if needed again. Defaults to True.
 
     Returns:
       A 1-D integer Tensor with shape `[self.nrows]`.
@@ -838,7 +849,10 @@ class RowPartition(composite_tensor.CompositeTensor):
     if self._row_lengths is not None:
       return self._row_lengths
     splits = self._row_splits
-    return splits[1:] - splits[:-1]
+    result = splits[1:] - splits[:-1]
+    if allow_persist:
+      self._row_lengths = result
+    return result
 
   @property
   def static_nrows(self):

--- a/tensorflow/python/ops/ragged/row_partition.py
+++ b/tensorflow/python/ops/ragged/row_partition.py
@@ -604,7 +604,8 @@ class RowPartition(composite_tensor.CompositeTensor):
 
       checks = []
 
-      if const_nvals is None and const_nrows is not None and const_uniform_row_length is not None:
+      if (const_nvals is None and const_nrows is not None and
+          const_uniform_row_length is not None):
         const_nvals = const_nrows * const_uniform_row_length
         if nvals is not None and validate:
           checks.append(check_ops.assert_equal(nvals, const_nvals))


### PR DESCRIPTION
Modifies `row_lengths()` and `value_rowids()` methods of the RowPartition class to store their outputs by default when first called if they have not already been precomputed; the stored value will be returned instead of re-computing when called again (~9x speedup for `row_lengths()` and ~37x speedup for `value_rowids()` in a quick test). This behavior can be suppressed by passing `cache=False`.

This change improves consistency between performance when using RowPartitions (and RaggedTensors) created with different methods. The `from_value_rowids` and `from_row_lengths` methods already cache whichever of row_lengths and value_rowids are available. With this change, repeated calls to `row_lengths()` and `value_rowids()` are equally fast for RowPartitions / RaggedTensors created with `from_row_splits` and other methods.