### PR TITLE
Typo Error

### DIFF
--- a/tensorflow/compiler/mlir/lite/transforms/legalize_jax_random.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/legalize_jax_random.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-// The full pipline of converting jax random include 2 steps.
+// The full pipeline of converting jax random include 2 steps.
 // 1. Rename the jax random functions to tflite wrapped functions with the aid
 //    of "jax.named_call". For example, in the dumped hlo, the
 //    jax.random.uniform will have name "tfl_wrapped_jax_random_uniform".

--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -1624,7 +1624,7 @@ class TFLiteFrozenGraphConverterV2(TFLiteConverterBaseV2):
 
     # Without the provided trackable obj, it is not able to serialize the given
     # concrete functions as a saved model format. Also when trackable obj is
-    # a function, use the original concrete function conversion pipline.
+    # a function, use the original concrete function conversion pipeline.
     if not self._trackable_obj or isinstance(
         self._trackable_obj,
         (_function.ConcreteFunction, _def_function.Function),

--- a/tensorflow/lite/schema/schema_utils.cc
+++ b/tensorflow/lite/schema/schema_utils.cc
@@ -21,7 +21,7 @@ limitations under the License.
 namespace tflite {
 
 // The following GetBuiltinCode methods are the utility methods for reading
-// builtin operatore code, ensuring compatibility issues between v3 and v3a
+// builtin operator code, ensuring compatibility issues between v3 and v3a
 // schema. Always the maximum value of the two fields always will be the correct
 // value as follows:
 //
@@ -29,7 +29,7 @@ namespace tflite {
 //
 // The `builtin_code` field is not available in the v3 models. Flatbuffer
 // library will feed zero value, which is the default value in the v3a schema.
-// The actual builtin operatore code value will exist in the
+// The actual builtin operator code value will exist in the
 // `deprecated_builtin_code` field. At the same time, it implies that
 // `deprecated_builtin_code` >= `builtin_code` and the maximum value of the two
 // fields will be same with `deprecated_builtin_code'.


### PR DESCRIPTION
in tensorflow/lite/schema/schema_utils.cc
in tensorflow/lite/python/lite.py
in tensorflow/compiler/mlir/lite/transforms/legalize_jax_random.cc

There is typo error (trivial)