### PR TITLE
[XLA] Support big-endian in numpy-style type descriptor

### DIFF
--- a/tensorflow/compiler/xla/python/types.cc
+++ b/tensorflow/compiler/xla/python/types.cc
@@ -176,39 +176,42 @@ StatusOr<std::string> FormatDescriptorForPrimitiveType(PrimitiveType type) {
 }
 
 StatusOr<py::str> TypeDescriptorForPrimitiveType(PrimitiveType type) {
-  static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
-                "Big endian support not implemented");
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define ENDIAN_PREFIX "<"
+#else
+#define ENDIAN_PREFIX ">"
+#endif
   switch (type) {
     case PRED:
       return py::str("|b1");
     case S8:
       return py::str("|i1");
     case S16:
-      return py::str("<i2");
+      return py::str(ENDIAN_PREFIX "i2");
     case S32:
-      return py::str("<i4");
+      return py::str(ENDIAN_PREFIX "i4");
     case S64:
-      return py::str("<i8");
+      return py::str(ENDIAN_PREFIX "i8");
     case U8:
       return py::str("|u1");
     case U16:
-      return py::str("<u2");
+      return py::str(ENDIAN_PREFIX "u2");
     case U32:
-      return py::str("<u4");
+      return py::str(ENDIAN_PREFIX "u4");
     case U64:
-      return py::str("<u8");
+      return py::str(ENDIAN_PREFIX "u8");
     case BF16:
-      return py::str("<V2");
+      return py::str(ENDIAN_PREFIX "V2");
     case F16:
-      return py::str("<f2");
+      return py::str(ENDIAN_PREFIX "f2");
     case F32:
-      return py::str("<f4");
+      return py::str(ENDIAN_PREFIX "f4");
     case F64:
-      return py::str("<f8");
+      return py::str(ENDIAN_PREFIX "f8");
     case C64:
-      return py::str("<c8");
+      return py::str(ENDIAN_PREFIX "c8");
     case C128:
-      return py::str("<c16");
+      return py::str(ENDIAN_PREFIX "c16");
     default:
       return Unimplemented("Unimplemented primitive type %s",
                            PrimitiveType_Name(type));


### PR DESCRIPTION
This PR supports [big-endian byte order](https://numpy.org/doc/stable/reference/arrays.dtypes.html#specifying-and-constructing-data-types) in numpy-style type descriptor. This order is determined by the order of a machine to build xla library.