### PR TITLE
[BUG FIX] Fix tensor_or_memref.h build error

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter/framework/tensor_or_memref.h
+++ b/tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter/framework/tensor_or_memref.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include <optional>
 #include <type_traits>
 #include <utility>
+#include <math.h>
 
 #include "llvm/ADT/ArrayRef.h"
 #include "mlir/Support/LLVM.h"
@@ -259,8 +260,8 @@ struct TensorOrMemref {
     for (const auto& indices : view.indices(true)) {
       // Treat NaNs as equal.
       if constexpr (std::is_floating_point_v<T>) {
-        bool thisnan = isnan(at(indices));
-        bool othernan = isnan(other.at(indices));
+        bool thisnan = std::isnan(at(indices));
+        bool othernan = std::isnan(other.at(indices));
         if (thisnan || othernan) {
           if (thisnan && othernan) continue;
           return false;


### PR DESCRIPTION
We found the build error on tensor_or_memref as the following, this PR has fixed it.

```
opt/bin/tensorflow/compiler/xla/mlir_hlo/_virtual_includes/mlir_interpreter_framework/tools/mlir_interpreter/framework/tensor_or_memref.h:243:29: error: 'isnan' was not declared in this scope; did you mean 'std::isnan'?
  243 |         bool thisnan = isnan(at(indices));
      |                        ~~~~~^~~~~~~~~~~~~
      |                        std::isnan
In file included from /usr/include/c++/9/complex:44,
                 from bazel-out/k8-opt/bin/tensorflow/compiler/xla/mlir_hlo/_virtual_includes/mlir_interpreter_framework/tools/mlir_interpreter/framework/interpreter_value.h:19,
                 from tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter/framework/tests/interpreter_value_test.cc:16:
/usr/include/c++/9/cmath:632:5: note: 'std::isnan' declared here
  632 |     isnan(_Tp __x)
      |     ^~~~~


opt/bin/tensorflow/compiler/xla/mlir_hlo/_virtual_includes/mlir_interpreter_framework/tools/mlir_interpreter/framework/interpreter_value.h:108:31:   required from here
bazel-out/k8-opt/bin/tensorflow/compiler/xla/mlir_hlo/_virtual_includes/mlir_interpreter_framework/tools/mlir_interpreter/framework/tensor_or_memref.h:243:29: error: 'isnan' was not declared in this scope; did you mean 'std::isnan'?
  243 |         bool thisnan = isnan(at(indices));
      |                        ~~~~~^~~~~~~~~~~~~
      |                        std::isnan
In file included from /usr/include/c++/9/complex:44,
                 from bazel-out/k8-opt/bin/tensorflow/compiler/xla/mlir_hlo/_virtual_includes/mlir_interpreter_framework/tools/mlir_interpreter/framework/interpreter_value.h:19,
                 from tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter/framework/tests/interpreter_value_test.cc:16:
/usr/include/c++/9/cmath:632:5: note: 'std::isnan' declared here
  632 |     isnan(_Tp __x)
      |     ^~~~~
In file included from bazel-out/k8-opt/bin/tensorflow/compiler/xla/mlir_hlo/_virtual_includes/mlir_interpreter_framework/tools/mlir_interpreter/framework/interpreter_value.h:34,
                 from tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter/framework/tests/interpreter_value_test.cc:16:
bazel-out/k8-opt/bin/tensorflow/compiler/xla/mlir_hlo/_virtual_includes/mlir_interpreter_framework/tools/mlir_interpreter/framework/tensor_or_memref.h:244:30: error: 'isnan' was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
  244 |         bool othernan = isnan(other.at(indices));

```