### PR TITLE
Add `Tensorflow Forum` as a support group

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,8 @@ uphold this code.**
 
 **We use [GitHub issues](https://github.com/tensorflow/tensorflow/issues) for
 tracking requests and bugs, please see
-[TensorFlow Discuss](https://groups.google.com/a/tensorflow.org/forum/#!forum/discuss)
+[TensorFlow Forum](https://discuss.tensorflow.org/)
 for general questions and discussion, and please direct specific questions to
-[TensorFlow Forum](https://discuss.tensorflow.org/) or
 [Stack Overflow](https://stackoverflow.com/questions/tagged/tensorflow).**
 
 The TensorFlow project strives to abide by generally accepted best practices in

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ uphold this code.**
 tracking requests and bugs, please see
 [TensorFlow Discuss](https://groups.google.com/a/tensorflow.org/forum/#!forum/discuss)
 for general questions and discussion, and please direct specific questions to
+[TensorFlow Forum](https://discuss.tensorflow.org/) or
 [Stack Overflow](https://stackoverflow.com/questions/tagged/tensorflow).**
 
 The TensorFlow project strives to abide by generally accepted best practices in


### PR DESCRIPTION
Add Tensorflow Forum to support groups in the `Contribution guidelines` section