### PR TITLE
stale-pr.yaml

### DIFF
--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -21,8 +21,7 @@ jobs:
         
           #comment on PR if stale for more then 14 days. 
           close-pr-message: "Closing as stale. Please reopen if you'd like to work on this further"
-        
-       
+              
           # Number of days of inactivity before a stale PR is closed
           days-before-pr-close: 14
        

--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -1,7 +1,7 @@
 name: 'Stale and Close PR'
 on:
   schedule:
-    - cron: '*/6 * * * *'
+    - cron: '0 */1 * * *'
     
 permissions:
   contents: read
@@ -24,13 +24,13 @@ jobs:
         
        
           # Number of days of inactivity before a stale PR is closed
-          days-before-pr-close: 0
+          days-before-pr-close: 14
        
           # Number of days of inactivity before an PR Request becomes stale
-          days-before-pr-stale: 0
+          days-before-pr-stale: 14
          
           #Check for label to stale or close the issue/PR
-          any-of-labels: 'awaiting response'
+          any-of-labels: 'stat:awaiting response'
          
           #override stale to stalled for PR
           stale-pr-label: 'Stalled'

--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -1,3 +1,9 @@
+# This workflow alerts and then closes the stale PRs  after specific time
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+
+
 name: 'Stale and Close PR'
 on:
   schedule:
@@ -16,7 +22,7 @@ jobs:
         with:
          
          
-          # comment on PR if not active for more then 14 days.
+           # comment on PR if not active for more then 14 days.
           stale-pr-message: 'This PR has been automatically marked as stale because it has no recent activity. It will be closed if no further activity occurs. Thank you.'
         
           #comment on PR if stale for more then 14 days. 

--- a/.github/workflows/stalePR.yaml
+++ b/.github/workflows/stalePR.yaml
@@ -1,0 +1,37 @@
+name: 'Stale and Close PR'
+on:
+  schedule:
+    - cron: '*/6 * * * *'
+    
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+         
+         
+          # comment on PR if not active for more then 14 days.
+          stale-pr-message: 'This PR has been automatically marked as stale because it has no recent activity. It will be closed if no further activity occurs. Thank you.'
+        
+          #comment on PR if stale for more then 14 days. 
+          close-pr-message: "Closing as stale. Please reopen if you'd like to work on this further"
+        
+       
+          # Number of days of inactivity before a stale PR is closed
+          days-before-pr-close: 0
+       
+          # Number of days of inactivity before an PR Request becomes stale
+          days-before-pr-stale: 0
+         
+          #Check for label to stale or close the issue/PR
+          any-of-labels: 'awaiting response'
+         
+          #override stale to stalled for PR
+          stale-pr-label: 'Stalled'
+


### PR DESCRIPTION
I've added the workflow to replace 'stale-master' probot. It will add 'stalled' label to inactive PRs if contains 'stat:awaiting response' label in case of further inactivity it will close the PR with proper comment.