### PR TITLE
[NVIDIA TF] Add CollectiveAllToAllV2 op

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_CollectiveAllToAllV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_CollectiveAllToAllV2.pbtxt
@@ -1,0 +1,5 @@
+op {
+  graph_op_name: "CollectiveAllToAllV2"
+  summary: "Mutually exchanges multiple tensors of identical type and shape."
+  visibility: HIDDEN
+}

--- a/tensorflow/core/kernels/collective_ops.cc
+++ b/tensorflow/core/kernels/collective_ops.cc
@@ -1240,6 +1240,51 @@ REGISTER_KERNEL_BUILDER(Name("CollectiveReduceV3").Device(DEVICE_CPU),
 REGISTER_KERNEL_BUILDER(Name("CollectiveReduceV3").Device(DEVICE_GPU),
                         CollectiveReduceV3OpKernel);
 
+class CollectiveAllToAllV2OpKernel : public CollectiveOpV2Kernel {
+ public:
+  explicit CollectiveAllToAllV2OpKernel(OpKernelConstruction* c)
+      : CollectiveOpV2Kernel(c) {
+        
+    name_ = strings::StrCat(c->def().name(), ": AllToAllV2");
+    VLOG(2) << "CollectiveAllToAllV2 " << this << " name " << name_
+            << " communication_hint " << communication_hint_;
+  }
+
+  void ComputeAsync(OpKernelContext* c, DoneCallback done) override {
+    auto col_params = new CollectiveParams();
+    auto done_with_cleanup = [col_params, done = std::move(done)]() {
+      done();
+      col_params->Unref();
+    };
+    OP_REQUIRES_OK_ASYNC(c,
+                         FillCollectiveParams(col_params, ALL_TO_ALL_COLLECTIVE,
+                                              /*group_size*/ c->input(1),
+                                              /*group_key*/ c->input(2),
+                                              /*instance_key*/ c->input(3)),
+                         done_with_cleanup);
+    col_params->instance.shape = c->input(0).shape();
+    VLOG(1) << "CollectiveAllToAllV2 group_size " << col_params->group.group_size
+            << " group_key " << col_params->group.group_key << " instance_key "
+            << col_params->instance.instance_key;
+    // Allocate the output tensor.
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK_ASYNC(c,
+                         c->forward_input_or_allocate_output(
+                             {0}, 0, col_params->instance.shape, &output),
+                         done_with_cleanup);
+    Run(c, col_params, std::move(done_with_cleanup));
+  }
+};
+
+REGISTER_KERNEL_BUILDER(Name("CollectiveAllToAllV2").Device(DEVICE_CPU),
+                        CollectiveAllToAllV2OpKernel);
+REGISTER_KERNEL_BUILDER(Name("CollectiveAllToAllV2")
+                            .Device(DEVICE_DEFAULT)
+                            .HostMemory("group_size")
+                            .HostMemory("group_key")
+                            .HostMemory("instance_key"),
+                        CollectiveAllToAllV2OpKernel);
+
 class CollectiveAllToAllV3OpKernel : public CollectiveOpV3Kernel {
  public:
   explicit CollectiveAllToAllV3OpKernel(OpKernelConstruction* c)

--- a/tensorflow/core/ops/collective_ops.cc
+++ b/tensorflow/core/ops/collective_ops.cc
@@ -254,6 +254,21 @@ REGISTER_OP("CollectiveReduceV3")
     .SetIsDistributedCommunication()
     .SetShapeFn(shape_inference::UnchangedShape);
 
+REGISTER_OP("CollectiveAllToAllV2")
+    .Input("input: T")
+    .Output("data: T")
+    .Attr("T: {bfloat16, float, float16, float64, int32, int64}")
+    .Input("group_size: int32")
+    .Input("group_key: int32")
+    .Input("instance_key: int32")
+    .Input("ordering_token: Nordering_token * resource")
+    .Attr("communication_hint: string = 'auto'")
+    .Attr("timeout_seconds: float = 0")
+    .Attr("Nordering_token: int >= 0 = 0")
+    .SetIsStateful()
+    .SetIsDistributedCommunication()
+    .SetShapeFn(shape_inference::UnchangedShape);
+
 REGISTER_OP("CollectiveAllToAllV3")
     .Input("input: T")
     .Input("communicator: resource")

--- a/tensorflow/core/ops/compat/ops_history_v2/CollectiveAllToAllV2.pbtxt
+++ b/tensorflow/core/ops/compat/ops_history_v2/CollectiveAllToAllV2.pbtxt
@@ -1,0 +1,66 @@
+op {
+  name: "CollectiveAllToAllV2"
+  input_arg {
+    name: "input"
+    type_attr: "T"
+  }
+  input_arg {
+    name: "group_size"
+    type: DT_INT32
+  }
+  input_arg {
+    name: "group_key"
+    type: DT_INT32
+  }
+  input_arg {
+    name: "instance_key"
+    type: DT_INT32
+  }
+  input_arg {
+    name: "ordering_token"
+    type: DT_RESOURCE
+    number_attr: "Nordering_token"
+  }
+  output_arg {
+    name: "data"
+    type_attr: "T"
+  }
+  attr {
+    name: "T"
+    type: "type"
+    allowed_values {
+      list {
+        type: DT_BFLOAT16
+        type: DT_FLOAT
+        type: DT_HALF
+        type: DT_DOUBLE
+        type: DT_INT32
+        type: DT_INT64
+      }
+    }
+  }
+  attr {
+    name: "communication_hint"
+    type: "string"
+    default_value {
+      s: "auto"
+    }
+  }
+  attr {
+    name: "timeout_seconds"
+    type: "float"
+    default_value {
+      f: 0
+    }
+  }
+  attr {
+    name: "Nordering_token"
+    type: "int"
+    default_value {
+      i: 0
+    }
+    has_minimum: true
+  }
+  is_stateful: true
+  is_distributed_communication: true
+}

--- a/tensorflow/core/ops/ops.pbtxt
+++ b/tensorflow/core/ops/ops.pbtxt
@@ -8137,6 +8137,72 @@ op {
   is_stateful: true
 }
 op {
+  name: "CollectiveAllToAllV2"
+  input_arg {
+    name: "input"
+    type_attr: "T"
+  }
+  input_arg {
+    name: "group_size"
+    type: DT_INT32
+  }
+  input_arg {
+    name: "group_key"
+    type: DT_INT32
+  }
+  input_arg {
+    name: "instance_key"
+    type: DT_INT32
+  }
+  input_arg {
+    name: "ordering_token"
+    type: DT_RESOURCE
+    number_attr: "Nordering_token"
+  }
+  output_arg {
+    name: "data"
+    type_attr: "T"
+  }
+  attr {
+    name: "T"
+    type: "type"
+    allowed_values {
+      list {
+        type: DT_BFLOAT16
+        type: DT_FLOAT
+        type: DT_HALF
+        type: DT_DOUBLE
+        type: DT_INT32
+        type: DT_INT64
+      }
+    }
+  }
+  attr {
+    name: "communication_hint"
+    type: "string"
+    default_value {
+      s: "auto"
+    }
+  }
+  attr {
+    name: "timeout_seconds"
+    type: "float"
+    default_value {
+      f: 0
+    }
+  }
+  attr {
+    name: "Nordering_token"
+    type: "int"
+    default_value {
+      i: 0
+    }
+    has_minimum: true
+  }
+  is_stateful: true
+  is_distributed_communication: true
+}
+op {
   name: "CollectiveAllToAllV3"
   input_arg {
     name: "input"

--- a/tensorflow/python/kernel_tests/collective_ops_test.py
+++ b/tensorflow/python/kernel_tests/collective_ops_test.py
@@ -97,6 +97,13 @@ class CollectiveOpsV2(object):
                                              group_key, instance_key, *args,
                                              **kwargs)
 
+  @staticmethod
+  def all_to_all(t, group_size, group_key, instance_key, *args, **kwargs):
+    group_size = array_ops.identity(group_size)
+    group_key = array_ops.identity(group_key)
+    instance_key = array_ops.identity(instance_key)
+    return _collective_ops.all_to_all_v2(t, group_size, group_key, instance_key,
+                                         *args, **kwargs)
 
 device_combination = (
     combinations.combine(device='CPU', communication='RING', required_gpus=0) +
@@ -297,6 +304,53 @@ class CollectiveOpsTest(test.TestCase, parameterized.TestCase):
 
     for result in run_broadcast_2devices():
       self.assertAllClose(result, [1., 2., 3.], rtol=1e-5, atol=1e-5)
+
+  def testAllToAll(self, collective_ops, device, communication):
+    if str(collective_ops) == "v1":
+      self.skipTest('CollectiveAllToAllV1 is not implemented.')
+    devices = ['/device:%s:0' % device, '/device:%s:1' % device]
+
+    tokens = {}
+    for dev in devices:
+      with ops.device(dev):
+        tokens[dev] = create_ordering_token()
+
+    @def_function.function
+    def run_all_to_all_1device():
+      with ops.device(devices[0]):
+        in_value = constant_op.constant([1.])
+        group_size = 1
+        group_key = 1
+        instance_key = 1
+        return collective_ops.all_to_all(
+            in_value,
+            group_size,
+            group_key,
+            instance_key,
+            communication_hint=communication,
+            ordering_token=tokens[devices[0]])
+
+    @def_function.function
+    def run_all_to_all_2devices():
+      group_size = 2
+      group_key = 2
+      instance_key = 2
+      collectives = []
+      for i in range(2):
+        with ops.device(devices[i]):
+          collectives.append(
+              collective_ops.all_to_all(
+                  constant_op.constant([i, i]),
+                  group_size,
+                  group_key,
+                  instance_key,
+                  ordering_token=tokens[devices[i]],
+                  communication_hint=communication))
+      return collectives
+
+    self.assertAllClose(run_all_to_all_1device(), [1.])
+    for result in run_all_to_all_2devices():
+      self.assertAllClose(result, [0., 1.])
 
   def testInstanceKeyScopedUnderGroupKey(self, collective_ops, device,
                                          communication):

--- a/tensorflow/python/ops/collective_ops.py
+++ b/tensorflow/python/ops/collective_ops.py
@@ -496,6 +496,55 @@ def all_reduce_v3(communicator,
       timeout_seconds=timeout_seconds)
 
 
+def all_to_all_v2(t,
+                  group_size,
+                  group_key,
+                  instance_key,
+                  communication_hint='auto',
+                  timeout=0,
+                  ordering_token=None,
+                  name=None):
+  """Exchanges tensors mutually.
+
+  Args:
+    t: a `tf.Tensor`. The first dimension should have the length as the size of
+      the group. `t[i]` is sent to `rank i` within the group.
+    group_size: an int32 tensor, the total number of tensors to be mutually
+      exchanged. Each must reside on a different device. Should be a positive
+      integer.
+    group_key: an int32 tensor identifying the group of devices.
+    instance_key: an int32 tensor identifying the participating group of Ops.
+    communication_hint: preferred collective communication. The implementation
+      may fall back to another mechanism. Options include `auto` and `nccl`.
+    timeout: a float. If set to a non zero, set a completion timeout to detect
+      staleness. If the timer goes off, a DeadlineExceededError is raised. The
+      timeout value in seconds. This feature is experimental.
+    ordering_token: a resource tensor on the same device as the op to order
+      the collectives in a per-device manner by auto control dependency.
+      This argument can be omited when there is one collective Op per
+      `tf.function`, or when explicit control dependency is used instead of
+      auto control dependency.
+    name: name of the Op.
+
+  Returns:
+    An Op implementing the distributed operation.
+  """
+  if ordering_token is not None:
+    ordering_token = [ordering_token]
+  else:
+    ordering_token = []
+
+  return gen_collective_ops.collective_all_to_all_v2(
+      t,
+      group_size=group_size,
+      group_key=group_key,
+      instance_key=instance_key,
+      communication_hint=communication_hint.lower(),
+      timeout_seconds=timeout,
+      ordering_token=ordering_token,
+      name=name)
+
+
 def all_to_all_v3(communicator, t, group_assignment=None, timeout_seconds=None):
   """Exchanges tensors mutually.
 

--- a/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
@@ -789,6 +789,10 @@ tf_module {
     argspec: "args=[\'writer\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "CollectiveAllToAllV2"
+    argspec: "args=[\'input\', \'group_size\', \'group_key\', \'instance_key\', \'ordering_token\', \'communication_hint\', \'timeout_seconds\', \'name\'], varargs=None, keywords=None, defaults=[\'auto\', \'0\', \'None\'], "
+  }
+  member_method {
     name: "CollectiveAllToAllV3"
     argspec: "args=[\'input\', \'communicator\', \'group_assignment\', \'timeout_seconds\', \'name\'], varargs=None, keywords=None, defaults=[\'0\', \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
@@ -789,6 +789,10 @@ tf_module {
     argspec: "args=[\'writer\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "CollectiveAllToAllV2"
+    argspec: "args=[\'input\', \'group_size\', \'group_key\', \'instance_key\', \'ordering_token\', \'communication_hint\', \'timeout_seconds\', \'name\'], varargs=None, keywords=None, defaults=[\'auto\', \'0\', \'None\'], "
+  }
+  member_method {
     name: "CollectiveAllToAllV3"
     argspec: "args=[\'input\', \'communicator\', \'group_assignment\', \'timeout_seconds\', \'name\'], varargs=None, keywords=None, defaults=[\'0\', \'None\'], "
   }


### PR DESCRIPTION
Adds `CollectiveAllToAllV2` op. This op is similar to `CollectiveAllToAllV3` but uses tensor inputs for the collective parameters instead of a resource.

In a future PR, I will add a `DTensorAllToAll` op which will be lowered to this `CollectiveAllToAllV2` op.

cc @rainwoodman @bfontain 