### PR TITLE
[tosa] Legalize tfl.rfft2d to tosa.rfft2d

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/lower-complex-types.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/lower-complex-types.mlir
@@ -40,26 +40,3 @@ func.func @test_mixed_output(%arg0: tensor<1x4x4x2xf32>, %arg1: tensor<1x4x4xf32
   %0 = builtin.unrealized_conversion_cast %arg0 : tensor<1x4x4x2xf32> to tensor<1x4x4xcomplex<f32>>
   return %0, %arg1 : tensor<1x4x4xcomplex<f32>>, tensor<1x4x4xf32>
 }
-
-// -----
-
-// CHECK-LABEL: test_complex_input_output_op
-// CHECK-SAME: %[[VAL_0:.*]]: tensor<1x4x4x2xf32>
-// CHECK: %[[VAL_1:.*]] = "tosa.slice"(%[[VAL_0]]) {size = array<i64: 1, 4, 4, 1>, start = array<i64: 0, 0, 0, 0>} : (tensor<1x4x4x2xf32>) -> tensor<1x4x4x1xf32>
-// CHECK: %[[VAL_2:.*]] = "tosa.reshape"(%[[VAL_1]]) {new_shape = array<i64: 1, 4, 4>} : (tensor<1x4x4x1xf32>) -> tensor<1x4x4xf32>
-// CHECK: %[[VAL_3:.*]], %[[VAL_4:.*]] = "tosa.rfft2d"(%[[VAL_2]]) : (tensor<1x4x4xf32>) -> (tensor<1x4x3xf32>, tensor<1x4x3xf32>)
-// CHECK: %[[VAL_5:.*]] = "tosa.reshape"(%[[VAL_3]]) {new_shape = array<i64: 1, 4, 3, 1>} : (tensor<1x4x3xf32>) -> tensor<1x4x3x1xf32>
-// CHECK: %[[VAL_6:.*]] = "tosa.reshape"(%[[VAL_4]]) {new_shape = array<i64: 1, 4, 3, 1>} : (tensor<1x4x3xf32>) -> tensor<1x4x3x1xf32>
-// CHECK: %[[VAL_7:.*]] = "tosa.concat"(%[[VAL_5]], %[[VAL_6]]) {axis = 3 : i64} : (tensor<1x4x3x1xf32>, tensor<1x4x3x1xf32>) -> tensor<1x4x3x2xf32>
-// CHECK: return %[[VAL_7]] : tensor<1x4x3x2xf32>
-func.func @test_complex_input_output_op(%arg0: tensor<1x4x4xcomplex<f32>>) -> (tensor<1x4x3xcomplex<f32>>) {
-    %0 = builtin.unrealized_conversion_cast %arg0 : tensor<1x4x4xcomplex<f32>> to tensor<1x4x4x2xf32>
-    %1 = "tosa.slice"(%0) {size = array<i64: 1, 4, 4, 1>, start = array<i64: 0, 0, 0, 0>} : (tensor<1x4x4x2xf32>) -> tensor<1x4x4x1xf32>
-    %2 = "tosa.reshape"(%1) {new_shape = array<i64: 1, 4, 4>} : (tensor<1x4x4x1xf32>) -> tensor<1x4x4xf32>
-    %3, %4 = "tosa.rfft2d"(%2) : (tensor<1x4x4xf32>) -> (tensor<1x4x3xf32>, tensor<1x4x3xf32>)
-    %5 = "tosa.reshape"(%3) {new_shape = array<i64: 1, 4, 3, 1>} : (tensor<1x4x3xf32>) -> tensor<1x4x3x1xf32>
-    %6 = "tosa.reshape"(%4) {new_shape = array<i64: 1, 4, 3, 1>} : (tensor<1x4x3xf32>) -> tensor<1x4x3x1xf32>
-    %7 = "tosa.concat"(%5, %6) {axis = 3 : i64} : (tensor<1x4x3x1xf32>, tensor<1x4x3x1xf32>) -> tensor<1x4x3x2xf32>
-    %8 = builtin.unrealized_conversion_cast %7 : tensor<1x4x3x2xf32> to tensor<1x4x3xcomplex<f32>>
-    return %8 : tensor<1x4x3xcomplex<f32>>
-}

--- a/tensorflow/compiler/mlir/tosa/tests/lower-complex-types.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/lower-complex-types.mlir
@@ -40,3 +40,26 @@ func.func @test_mixed_output(%arg0: tensor<1x4x4x2xf32>, %arg1: tensor<1x4x4xf32
   %0 = builtin.unrealized_conversion_cast %arg0 : tensor<1x4x4x2xf32> to tensor<1x4x4xcomplex<f32>>
   return %0, %arg1 : tensor<1x4x4xcomplex<f32>>, tensor<1x4x4xf32>
 }
+
+// -----
+
+// CHECK-LABEL: test_complex_input_output_op
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<1x4x4x2xf32>
+// CHECK: %[[VAL_1:.*]] = "tosa.slice"(%[[VAL_0]]) {size = array<i64: 1, 4, 4, 1>, start = array<i64: 0, 0, 0, 0>} : (tensor<1x4x4x2xf32>) -> tensor<1x4x4x1xf32>
+// CHECK: %[[VAL_2:.*]] = "tosa.reshape"(%[[VAL_1]]) {new_shape = array<i64: 1, 4, 4>} : (tensor<1x4x4x1xf32>) -> tensor<1x4x4xf32>
+// CHECK: %[[VAL_3:.*]], %[[VAL_4:.*]] = "tosa.rfft2d"(%[[VAL_2]]) : (tensor<1x4x4xf32>) -> (tensor<1x4x3xf32>, tensor<1x4x3xf32>)
+// CHECK: %[[VAL_5:.*]] = "tosa.reshape"(%[[VAL_3]]) {new_shape = array<i64: 1, 4, 3, 1>} : (tensor<1x4x3xf32>) -> tensor<1x4x3x1xf32>
+// CHECK: %[[VAL_6:.*]] = "tosa.reshape"(%[[VAL_4]]) {new_shape = array<i64: 1, 4, 3, 1>} : (tensor<1x4x3xf32>) -> tensor<1x4x3x1xf32>
+// CHECK: %[[VAL_7:.*]] = "tosa.concat"(%[[VAL_5]], %[[VAL_6]]) {axis = 3 : i64} : (tensor<1x4x3x1xf32>, tensor<1x4x3x1xf32>) -> tensor<1x4x3x2xf32>
+// CHECK: return %[[VAL_7]] : tensor<1x4x3x2xf32>
+func.func @test_complex_input_output_op(%arg0: tensor<1x4x4xcomplex<f32>>) -> (tensor<1x4x3xcomplex<f32>>) {
+    %0 = builtin.unrealized_conversion_cast %arg0 : tensor<1x4x4xcomplex<f32>> to tensor<1x4x4x2xf32>
+    %1 = "tosa.slice"(%0) {size = array<i64: 1, 4, 4, 1>, start = array<i64: 0, 0, 0, 0>} : (tensor<1x4x4x2xf32>) -> tensor<1x4x4x1xf32>
+    %2 = "tosa.reshape"(%1) {new_shape = array<i64: 1, 4, 4>} : (tensor<1x4x4x1xf32>) -> tensor<1x4x4xf32>
+    %3, %4 = "tosa.rfft2d"(%2) : (tensor<1x4x4xf32>) -> (tensor<1x4x3xf32>, tensor<1x4x3xf32>)
+    %5 = "tosa.reshape"(%3) {new_shape = array<i64: 1, 4, 3, 1>} : (tensor<1x4x3xf32>) -> tensor<1x4x3x1xf32>
+    %6 = "tosa.reshape"(%4) {new_shape = array<i64: 1, 4, 3, 1>} : (tensor<1x4x3xf32>) -> tensor<1x4x3x1xf32>
+    %7 = "tosa.concat"(%5, %6) {axis = 3 : i64} : (tensor<1x4x3x1xf32>, tensor<1x4x3x1xf32>) -> tensor<1x4x3x2xf32>
+    %8 = builtin.unrealized_conversion_cast %7 : tensor<1x4x3x2xf32> to tensor<1x4x3xcomplex<f32>>
+    return %8 : tensor<1x4x3xcomplex<f32>>
+}

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -2634,6 +2634,78 @@ func.func private @result_body(%arg0: tensor<1x4x4x4xf32>) -> tensor<1x4x4x4xf32
 
 // -----
 
+// CHECK-LABEL: test_rfft2d
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<1x8x16xf32>
+// CHECK: %[[VAL_1:.*]], %[[VAL_2:.*]] = "tosa.rfft2d"(%[[VAL_0]]) : (tensor<1x8x16xf32>) -> (tensor<1x8x9xf32>, tensor<1x8x9xf32>)
+// CHECK: %[[VAL_3:.*]] = "tosa.reshape"(%[[VAL_1]]) {new_shape = array<i64: 1, 8, 9, 1>} : (tensor<1x8x9xf32>) -> tensor<1x8x9x1xf32>
+// CHECK: %[[VAL_4:.*]] = "tosa.reshape"(%[[VAL_2]]) {new_shape = array<i64: 1, 8, 9, 1>} : (tensor<1x8x9xf32>) -> tensor<1x8x9x1xf32>
+// CHECK: %[[VAL_5:.*]] = "tosa.concat"(%[[VAL_3]], %[[VAL_4]]) {axis = 3 : i64} : (tensor<1x8x9x1xf32>, tensor<1x8x9x1xf32>) -> tensor<1x8x9x2xf32>
+// CHECK: return %[[VAL_5]] : tensor<1x8x9x2xf32>
+func.func @test_rfft2d(%arg0: tensor<1x8x16xf32>) -> tensor<1x8x9xcomplex<f32>> {
+  %0 = "tfl.pseudo_const"() {value = dense<[8, 16]> : tensor<2xi32>} : () -> tensor<2xi32>
+  %1 = "tfl.rfft2d"(%arg0, %0) : (tensor<1x8x16xf32>, tensor<2xi32>) -> tensor<1x8x9xcomplex<f32>>
+  return %1 : tensor<1x8x9xcomplex<f32>>
+}
+
+// -----
+
+// CHECK-LABEL: test_rfft2d_crop_input
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<13x21x3xf32>
+// CHECK: %[[VAL_1:.*]] = "tosa.slice"(%[[VAL_0]]) {size = array<i64: 13, 2, 2>, start = array<i64: 0, 0, 0>} : (tensor<13x21x3xf32>) -> tensor<13x2x2xf32>
+// CHECK: %[[VAL_2:.*]], %[[VAL_3:.*]] = "tosa.rfft2d"(%[[VAL_1]]) : (tensor<13x2x2xf32>) -> (tensor<13x2x2xf32>, tensor<13x2x2xf32>)
+// CHECK: %[[VAL_4:.*]] = "tosa.reshape"(%[[VAL_2]]) {new_shape = array<i64: 13, 2, 2, 1>} : (tensor<13x2x2xf32>) -> tensor<13x2x2x1xf32>
+// CHECK: %[[VAL_5:.*]] = "tosa.reshape"(%[[VAL_3]]) {new_shape = array<i64: 13, 2, 2, 1>} : (tensor<13x2x2xf32>) -> tensor<13x2x2x1xf32>
+// CHECK: %[[VAL_6:.*]] = "tosa.concat"(%[[VAL_4]], %[[VAL_5]]) {axis = 3 : i64} : (tensor<13x2x2x1xf32>, tensor<13x2x2x1xf32>) -> tensor<13x2x2x2xf32>
+// CHECK: return %[[VAL_6]] : tensor<13x2x2x2xf32>
+func.func @test_rfft2d_crop_input(%arg0: tensor<13x21x3xf32>) -> tensor<13x2x2xcomplex<f32>> {
+  %0 = "tfl.pseudo_const"() {value = dense<2> : tensor<2xi32>} : () -> tensor<2xi32>
+  %1 = "tfl.rfft2d"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<2xi32>) -> tensor<13x2x2xcomplex<f32>>
+  return %1 : tensor<13x2x2xcomplex<f32>>
+}
+
+// -----
+
+// CHECK-LABEL: test_rfft2d_pad_input
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<13x21x3xf32>
+// CHECK-DAG: %[[VAL_1:.*]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<f32>} : () -> tensor<f32>
+// CHECK-DAG: %[[VAL_2:.*]] = "tosa.const"() {value = dense<{{\[\[}}0, 0], [0, 11], [0, 5]]> : tensor<3x2xi32>} : () -> tensor<3x2xi32>
+// CHECK: %[[VAL_3:.*]] = "tosa.pad"(%[[VAL_0]], %[[VAL_2]], %[[VAL_1]]) : (tensor<13x21x3xf32>, tensor<3x2xi32>, tensor<f32>) -> tensor<13x32x8xf32>
+// CHECK: %[[VAL_4:.*]], %[[VAL_5:.*]] = "tosa.rfft2d"(%[[VAL_3]]) : (tensor<13x32x8xf32>) -> (tensor<13x32x5xf32>, tensor<13x32x5xf32>)
+// CHECK: %[[VAL_6:.*]] = "tosa.reshape"(%[[VAL_4]]) {new_shape = array<i64: 13, 32, 5, 1>} : (tensor<13x32x5xf32>) -> tensor<13x32x5x1xf32>
+// CHECK: %[[VAL_7:.*]] = "tosa.reshape"(%[[VAL_5]]) {new_shape = array<i64: 13, 32, 5, 1>} : (tensor<13x32x5xf32>) -> tensor<13x32x5x1xf32>
+// CHECK: %[[VAL_8:.*]] = "tosa.concat"(%[[VAL_6]], %[[VAL_7]]) {axis = 3 : i64} : (tensor<13x32x5x1xf32>, tensor<13x32x5x1xf32>) -> tensor<13x32x5x2xf32>
+// CHECK: return %[[VAL_8]] : tensor<13x32x5x2xf32>
+func.func @test_rfft2d_pad_input(%arg0: tensor<13x21x3xf32>) -> (tensor<13x32x5xcomplex<f32>>) {
+  %0 = "tfl.pseudo_const"() {value = dense<[[0, 0], [0, 11], [0, 5]]> : tensor<3x2xi32>} : () -> tensor<3x2xi32>
+  %1 = "tfl.pad"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<3x2xi32>) -> tensor<13x32x8xf32>
+  %2 = "tfl.pseudo_const"() {value = dense<[32, 8]> : tensor<2xi32>} : () -> tensor<2xi32>
+  %3 = "tfl.rfft2d"(%1, %2) : (tensor<13x32x8xf32>, tensor<2xi32>) -> tensor<13x32x5xcomplex<f32>>
+  return %3 : tensor<13x32x5xcomplex<f32>>
+}
+
+// -----
+
+// CHECK-LABEL: test_rfft2d_crop_height_pad_width
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<13x21x3xf32>
+// CHECK-DAG: %[[VAL_1:.*]] = "tosa.const"() {value = dense<0.000000e+00> : tensor<f32>} : () -> tensor<f32>
+// CHECK-DAG: %[[VAL_2:.*]] = "tosa.const"() {value = dense<{{\[\[}}0, 0], [0, 0], [0, 13]]> : tensor<3x2xi32>} : () -> tensor<3x2xi32>
+// CHECK: %[[VAL_3:.*]] = "tosa.pad"(%[[VAL_0]], %[[VAL_2]], %[[VAL_1]]) : (tensor<13x21x3xf32>, tensor<3x2xi32>, tensor<f32>) -> tensor<13x21x16xf32>
+// CHECK: %[[VAL_4:.*]] = "tosa.slice"(%[[VAL_3]]) {size = array<i64: 13, 2, 16>, start = array<i64: 0, 0, 0>} : (tensor<13x21x16xf32>) -> tensor<13x2x16xf32>
+// CHECK: %[[VAL_5:.*]], %[[VAL_6:.*]] = "tosa.rfft2d"(%[[VAL_4]]) : (tensor<13x2x16xf32>) -> (tensor<13x2x9xf32>, tensor<13x2x9xf32>)
+// CHECK: %[[VAL_7:.*]] = "tosa.reshape"(%[[VAL_5]]) {new_shape = array<i64: 13, 2, 9, 1>} : (tensor<13x2x9xf32>) -> tensor<13x2x9x1xf32>
+// CHECK: %[[VAL_8:.*]] = "tosa.reshape"(%[[VAL_6]]) {new_shape = array<i64: 13, 2, 9, 1>} : (tensor<13x2x9xf32>) -> tensor<13x2x9x1xf32>
+// CHECK: %[[VAL_9:.*]] = "tosa.concat"(%[[VAL_7]], %[[VAL_8]]) {axis = 3 : i64} : (tensor<13x2x9x1xf32>, tensor<13x2x9x1xf32>) -> tensor<13x2x9x2xf32>
+// CHECK: return %[[VAL_9]] : tensor<13x2x9x2xf32>
+func.func @test_rfft2d_crop_height_pad_width(%arg0: tensor<13x21x3xf32>) -> (tensor<13x2x9xcomplex<f32>>) {
+  %0 = "tfl.pseudo_const"() {value = dense<[[0, 0], [0, 0], [0, 13]]> : tensor<3x2xi32>} : () -> tensor<3x2xi32>
+  %1 = "tfl.pad"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<3x2xi32>) -> tensor<13x21x16xf32>
+  %2 = "tfl.pseudo_const"() {value = dense<[2, 16]> : tensor<2xi32>} : () -> tensor<2xi32>
+  %3 = "tfl.rfft2d"(%1, %2) : (tensor<13x21x16xf32>, tensor<2xi32>) -> tensor<13x2x9xcomplex<f32>>
+  return %3 : tensor<13x2x9xcomplex<f32>>
+}
+
+// -----
+
 // CHECK-LABEL: test_real
 // CHECK-SAME: %[[VAL_0:.*]]: tensor<1x8x9x2xf32>
 // CHECK: %[[VAL_1:.*]] = "tosa.slice"(%[[VAL_0]]) {size = array<i64: 1, 8, 9, 1>, start = array<i64: 0, 0, 0, 0>} : (tensor<1x8x9x2xf32>) -> tensor<1x8x9x1xf32>

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -4411,11 +4411,8 @@ LogicalResult ConvertTFLRFFT2dOp::matchAndRewrite(
   auto concat = CreateOpAndInfer<tosa::ConcatOp>(rewriter, loc, fp32_ty, values,
                                                  rewriter.getI64IntegerAttr(3));
 
-  Value cast = rewriter
-                   .create<mlir::UnrealizedConversionCastOp>(loc, output_type,
-                                                             concat.getResult())
-                   ->getResult(0);
-  rewriter.replaceOp(op, cast);
+  CreateReplaceOpAndInfer<mlir::UnrealizedConversionCastOp>(
+      rewriter, op, output_type, concat.getResult());
 
   return success();
 }


### PR DESCRIPTION
In the case the provided fft_length > the input height or width, a tfl.pad operation is automatically inserted. When fft_length < the input height or width, a slice is manually inserted to crop the input.

~Note: this PR relies on commits from #59606 and therefore also contains the contents of #59606.~

Signed-off-by: Luke Hutton <luke.hutton@arm.com>