### PR TITLE
[ROCm] fix gpu_conv_algorithm_picker on ROCm build

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_algorithm_picker.cc
@@ -395,6 +395,7 @@ bool ShouldCheckConv(const HloModuleConfig& hlo_module_config) {
   return conv_autotune_level >= 4;
 }
 
+#if (defined(GOOGLE_CUDA) && GOOGLE_CUDA)
 StatusOr<GpuConvAlgorithmPicker::AutotuneRuntimeArguments>
 GpuConvAlgorithmPicker::AutotuneRuntimeArguments::FromInstruction(
     const HloCustomCallInstruction* instr, se::DeviceMemoryAllocator* allocator,
@@ -444,6 +445,7 @@ GpuConvAlgorithmPicker::AutotuneRuntimeArguments::FromInstruction(
 
   return runtime_arguments;
 }
+#endif 
 
 StatusOr<AutotuneResult> GpuConvAlgorithmPicker::PickBestAlgorithm(
     const HloCustomCallInstruction* instr) {


### PR DESCRIPTION
This new added PR https://github.com/tensorflow/tensorflow/commit/9b616058967513340d882623c489b25398849373 has broken ROCm build and it is for CUDA only, as ROCm implementation has not used redzone. 

This PR fixes it.

@cheshire Thanks in advance! 