### PR TITLE
Update tensorboard 2.12.0 dependency

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -123,7 +123,7 @@ REQUIRED_PACKAGES = [
     # current release version. These also usually have "alpha" or "dev" in their
     # version name.
     # These are all updated during the TF release process.
-    standard_or_nightly('tensorboard >= 2.11, < 2.12',
+    standard_or_nightly('tensorboard >= 2.12, < 2.13',
                         'tb-nightly ~= 2.12.0.a'),
     standard_or_nightly('tensorflow_estimator >= 2.12.0rc0, < 2.13',
                         'tf-estimator-nightly ~= 2.13.0.dev'),


### PR DESCRIPTION
Re : Updating Tensorboard's protobuf

Updating the TB 2.12.0 dependency  in r2.12 release branch from TF side.