### PR TITLE
Fix debug build failure in SnapshotStreamWriter::SnapshotStreamWriter

### DIFF
--- a/tensorflow/core/data/service/snapshot/snapshot_stream_writer.cc
+++ b/tensorflow/core/data/service/snapshot/snapshot_stream_writer.cc
@@ -64,7 +64,7 @@ constexpr int64_t SnapshotWriterParams::kDefaultMaxChunkSizeBytes;
 SnapshotStreamWriter::SnapshotStreamWriter(
     const SnapshotWriterParams& params, std::unique_ptr<TaskIterator> iterator)
     : params_(params), iterator_(std::move(iterator)) {
-  DCHECK_NE(iterator_, nullptr);
+  DCHECK_NE(iterator_.get(), nullptr);
   snapshot_thread_ = absl::WrapUnique(params_.env->StartThread(
       /*thread_options=*/{}, /*name=*/"tf_data_service_snapshot_thread",
       [this]() { WriteSnapshotAndLog(); }));


### PR DESCRIPTION
Hi all,

The debug build is broken with the following error msg.

```
# Execution platform: @local_execution_config_platform//:platform
In file included from ./tensorflow/tsl/platform/logging.h:26,
                 from ./tensorflow/tsl/platform/errors.h:26,
                 from ./tensorflow/tsl/platform/statusor.h:72,
                 from ./tensorflow/core/data/service/snapshot/path_utils.h:22,
                 from ./tensorflow/core/data/service/snapshot/snapshot_stream_writer.h:25,
                 from tensorflow/core/data/service/snapshot/snapshot_stream_writer.cc:15:
./tensorflow/tsl/platform/default/logging.h: In instantiation of 'void tsl::internal::MakeCheckOpValueString(std::ostream*, const T&) [with T = std::unique_ptr<tensorflow::data::TaskIterator>; std::ostream = std::basic_ostream<char>]':
./tensorflow/tsl/platform/default/logging.h:372:25:   required from 'std::string* tsl::internal::MakeCheckOpString(const T1&, const T2&, const char*) [with T1 = std::unique_ptr<tensorflow::data::TaskIterator>; T2 = std::nullptr_t; std::string = std::basic_string<char>]'
./tensorflow/tsl/platform/default/logging.h:416:1:   required from 'std::string* tsl::internal::Check_NEImpl(const T1&, const T2&, const char*) [with T1 = std::unique_ptr<tensorflow::data::TaskIterator>; T2 = std::nullptr_t; std::string = std::basic_string<char>]'
tensorflow/core/data/service/snapshot/snapshot_stream_writer.cc:67:3:   required from here
./tensorflow/tsl/platform/default/logging.h:313:9: error: no match for 'operator<<' (operand types are 'std::ostream' {aka 'std::basic_ostream<char>'} and 'const std::unique_ptr<tensorflow::data::TaskIterator>')
  313 |   (*os) << v;
      |   ~~~~~~^~~~
./tensorflow/tsl/platform/default/logging.h:313:9: note: candidate: 'operator<<(int, int)' (built-in)
./tensorflow/tsl/platform/default/logging.h:313:9: note:   no known conversion for argument 2 from 'const std::unique_ptr<tensorflow::data::TaskIterator>' to 'int'
```

Let's fix it.

Thanks.
Best regards,
Jie