### PR TITLE
[oneDNN]Fix to close the file before exiting load_weights()

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -2311,7 +2311,6 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
       raise ValueError(
           'When calling model.load_weights, skip_mismatch can only be set to '
           'True when by_name is True.')
-
     filepath, save_format = _detect_save_format(filepath)
     if save_format == 'tf':
       status = self._checkpoint.read(filepath, options)
@@ -2345,6 +2344,11 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
               f, self.layers, skip_mismatch=skip_mismatch)
         else:
           hdf5_format.load_weights_from_hdf5_group(f, self.layers)
+
+        if hasattr(f, 'close'):
+          f.close()
+        elif hasattr(f.file, 'close'):
+          f.file.close()
 
     # Perform any layer defined finalization of the layer state.
     for layer in self.layers:


### PR DESCRIPTION
The method 'load_weights()' which loads all layer weights, either from a TensorFlow or an HDF5 weight file, kept the file open due to which the next action of saving the checkpoints was failing on windows server 2019. The code change will now make sure that the weight files are closed before exiting the 'load_weights()' method.
The solution fixes https://github.com/tensorflow/tensorflow/issues/58740