### PR TITLE
[XLA] Add parser and codegen for more CPU architectures

### DIFF
--- a/tensorflow/compiler/xla/runtime/BUILD
+++ b/tensorflow/compiler/xla/runtime/BUILD
@@ -258,10 +258,14 @@ cc_library(
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:ExecutionEngine",
         "@llvm-project//llvm:OrcJIT",
+        "@llvm-project//llvm:PowerPCAsmParser",
+        "@llvm-project//llvm:PowerPCCodeGen",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:TransformUtils",
         "@llvm-project//llvm:X86AsmParser",
         "@llvm-project//llvm:X86CodeGen",
+        "@llvm-project//llvm:SystemZAsmParser",
+        "@llvm-project//llvm:SystemZCodeGen",
     ],
 )
 

--- a/tensorflow/compiler/xla/runtime/BUILD
+++ b/tensorflow/compiler/xla/runtime/BUILD
@@ -261,11 +261,11 @@ cc_library(
         "@llvm-project//llvm:PowerPCAsmParser",
         "@llvm-project//llvm:PowerPCCodeGen",
         "@llvm-project//llvm:Support",
+        "@llvm-project//llvm:SystemZAsmParser",
+        "@llvm-project//llvm:SystemZCodeGen",
         "@llvm-project//llvm:TransformUtils",
         "@llvm-project//llvm:X86AsmParser",
         "@llvm-project//llvm:X86CodeGen",
-        "@llvm-project//llvm:SystemZAsmParser",
-        "@llvm-project//llvm:SystemZCodeGen",
     ],
 )
 


### PR DESCRIPTION
This PR adds parser and codegen for PowerPC and SystemZ to execution engine in XLA runtime.

I saw the following error w/o this PR when I ran Jax on s390x
```
$ python tests/core_test.py 
Traceback (most recent call last):
  File "/home/ishizaki/Jax/jax/tests/core_test.py", line 26, in <module>
    import jax
  File "/home/ishizaki/Jax/jax/jax/__init__.py", line 35, in <module>
    from jax import config as _config_module
  File "/home/ishizaki/Jax/jax/jax/config.py", line 17, in <module>
    from jax._src.config import config  # noqa: F401
  File "/home/ishizaki/Jax/jax/jax/_src/config.py", line 28, in <module>
    from jax._src import lib
  File "/home/ishizaki/Jax/jax/jax/_src/lib/__init__.py", line 87, in <module>
    import jaxlib.xla_client as xla_client
  File "/home/ishizaki/Jax/.venv/lib/python3.10/site-packages/jaxlib/xla_client.py", line 26, in <module>
    from . import xla_extension as _xla
ImportError: /home/ishizaki/Jax/.venv/lib/python3.10/site-packages/jaxlib/xla_extension.so: undefined symbol: LLVMInitializeSystemZAsmParser
```