### PR TITLE
[Linaro:ARM_CI] Revert adding install of tensorflow-io

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -67,7 +67,6 @@ export TF_PIP_TESTS="test_pip_virtualenv_clean test_pip_virtualenv_oss_serial"
 export TF_TEST_FILTER_TAGS="-no_oss,-v1only,-benchmark-test,-no_aarch64"
 export TF_PIP_TEST_ROOT="pip_test"
 export TF_AUDITWHEEL_TARGET_PLAT="manylinux2014"
-export TF_BUILD_INSTALL_EXTRA_PIP_PACKAGES="tensorflow-io"
 
 if [ ${IS_NIGHTLY} == 1 ]; then
   ./tensorflow/tools/ci_build/update_version.py --nightly


### PR DESCRIPTION
Do not install tensorflow-io as an extra package, it is not needed and can cause additional problems and failed to achieve the original intent as it attempted to fix a problem that was actually in the building of the tensorflow-io-gcs-filesystem package for AARCH64