### PR TITLE
[OpenCL][Testing] Fix shell dir definition

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/testing/run_delegate_testing.sh
+++ b/tensorflow/lite/delegates/gpu/cl/testing/run_delegate_testing.sh
@@ -56,7 +56,7 @@ echo "$description"
 exit
 fi
 
-SHELL_DIR=$(dirname "$0")
+SHELL_DIR=$(dirname "$0" | sed 's/^\.\///')
 BINARY_NAME=delegate_testing
 declare -a BUILD_CONFIG
 

--- a/tensorflow/lite/delegates/gpu/cl/testing/run_internal_api_samples.sh
+++ b/tensorflow/lite/delegates/gpu/cl/testing/run_internal_api_samples.sh
@@ -55,7 +55,7 @@ echo "$description"
 exit
 fi
 
-SHELL_DIR=$(dirname "$0")
+SHELL_DIR=$(dirname "$0" | sed 's/^\.\///')
 BINARY_NAME=internal_api_samples
 declare -a BUILD_CONFIG
 

--- a/tensorflow/lite/delegates/gpu/cl/testing/run_memory_sharing_sample.sh
+++ b/tensorflow/lite/delegates/gpu/cl/testing/run_memory_sharing_sample.sh
@@ -67,7 +67,7 @@ echo "$description"
 exit
 fi
 
-SHELL_DIR=$(dirname "$0")
+SHELL_DIR=$(dirname "$0" | sed 's/^\.\///')
 BINARY_NAME=memory_sharing_sample
 declare -a BUILD_CONFIG
 

--- a/tensorflow/lite/delegates/gpu/cl/testing/run_performance_profiling.sh
+++ b/tensorflow/lite/delegates/gpu/cl/testing/run_performance_profiling.sh
@@ -61,7 +61,7 @@ echo "$description"
 exit
 fi
 
-SHELL_DIR=$(dirname "$0")
+SHELL_DIR=$(dirname "$0" | sed 's/^\.\///')
 BINARY_NAME=performance_profiling
 declare -a BUILD_CONFIG
 


### PR DESCRIPTION
It was a problem when `run_performance_profiling.sh` was running with `./` in the beginning of the command, e.g.:
```
./tensorflow/lite/delegates/gpu/cl/testing/run_performance_profiling.sh -m ...
```

I got the following error:
```
ERROR: Skipping '//./tensorflow/lite/delegates/gpu/cl/testing:performance_profiling': invalid target format '//./tensorflow/lite/delegates/gpu/cl/testing:performance_profiling': invalid package name './tensorflow/lite/delegates/gpu/cl/testing': package name component contains only '.' characters
```

The same situation was mentioned here:
https://github.com/tensorflow/tensorflow/issues/56463#issuecomment-1185389950

This PR fixes this issue.