### PR TITLE
[Linaro:ARM_CI] Prevent use of protobuf 4 on python 3.8

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -104,7 +104,8 @@ REQUIRED_PACKAGES = [
     # See also: https://github.com/protocolbuffers/protobuf/issues/9954
     # See also: https://github.com/tensorflow/tensorflow/issues/56077
     # This is a temporary patch for now, to patch previous TF releases.
-    'protobuf>=3.20.3,<5.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5',
+    'protobuf~=3.20.3;python_version<"3.9"',
+    'protobuf>=3.20.3,<5.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5;python_version>="3.9"',
     'setuptools',
     'six >= 1.12.0',
     'termcolor >= 1.1.0',


### PR DESCRIPTION
protobuf 4 can lead to segmentation faults on Python 3.8 so prevent that from happening by using protobuf 3 but only for Python 3.8

Fixes #59643 