### PR TITLE
[Linaro:ARM_CI] Fix use of updated protobuf

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip_new.sh
+++ b/tensorflow/tools/ci_build/builds/pip_new.sh
@@ -326,8 +326,10 @@ if [[ -z "$PYTHON_BIN_PATH" ]]; then
 fi
 
 ${PYTHON_BIN_PATH} -m pip install tb-nightly
-${PYTHON_BIN_PATH} -m pip uninstall -y protobuf
-${PYTHON_BIN_PATH} -m pip install "protobuf < 4"
+if [[ "x${PY_MAJOR_MINOR_VER}x" == "x3.8x" ]]; then
+  ${PYTHON_BIN_PATH} -m pip uninstall -y protobuf
+  ${PYTHON_BIN_PATH} -m pip install "protobuf < 4"
+fi
 
 # Bazel build the file.
 PIP_BUILD_TARGET="//tensorflow/tools/pip_package:build_pip_package"


### PR DESCRIPTION
Remove the code to force protobuf < 4 now that protobuf 4 is supported