### PR TITLE
Fix MapPeek crash when key is not a scaler

### DIFF
--- a/tensorflow/core/kernels/map_stage_op.cc
+++ b/tensorflow/core/kernels/map_stage_op.cc
@@ -633,6 +633,9 @@ class MapPeekOp : public OpKernel {
     const Tensor* indices_tensor;
 
     OP_REQUIRES_OK(ctx, ctx->input("key", &key_tensor));
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(key_tensor->shape()),
+                errors::InvalidArgument("key must be an int64 scalar: ",
+                                        key_tensor->shape().DebugString()));
     OP_REQUIRES_OK(ctx, ctx->input("indices", &indices_tensor));
     OP_REQUIRES_OK(ctx, map->get(key_tensor, indices_tensor, &tuple));
 

--- a/tensorflow/python/kernel_tests/data_structures/map_stage_op_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/map_stage_op_test.py
@@ -624,5 +624,19 @@ class MapStageTest(test.TestCase):
         sess.run(t, feed_dict={x: 1})
 
 
+  def testNonScalarKeyMapPeek(self):
+    with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                'key must be an int64 scalar'):
+      v = data_flow_ops.gen_data_flow_ops.map_peek(
+        key=constant_op.constant(value=[1], shape=(1, 3), dtype=dtypes.int64),
+        indices=np.array([[6]]),
+        dtypes=[dtypes.int64],
+        capacity=0,
+        memory_limit=0,
+        container='container1',
+        shared_name='',
+        name=None)
+      self.evaluate(v)
+
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
This PR tries to address the issue raised in #58271 where MapPeek
will crash when key is not a scaler.

This PR fixes #58271.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>