### PR TITLE
Softmax fix in Mixed Precision

### DIFF
--- a/tensorflow/python/keras/layers/advanced_activations.py
+++ b/tensorflow/python/keras/layers/advanced_activations.py
@@ -286,6 +286,9 @@ def _large_compatible_negative(tensor_type):
   Returns:
     a large negative number.
   """
+  # In case of dtype=float16 (e.g., for mixed-precision), the largest
+  # negative number (dtypes.float16.min) is divided by 2, in order to
+  # avoid overflows when summing negative inputs.
   if tensor_type == dtypes.float16:
     return dtypes.float16.min / 2.0
   return -1e9

--- a/tensorflow/python/keras/layers/advanced_activations.py
+++ b/tensorflow/python/keras/layers/advanced_activations.py
@@ -287,7 +287,7 @@ def _large_compatible_negative(tensor_type):
     a large negative number.
   """
   if tensor_type == dtypes.float16:
-    return dtypes.float16.min
+    return dtypes.float16.min / 2.0
   return -1e9
 
 


### PR DESCRIPTION
## Contributors:
* Gaetano Signorelli (https://github.com/gaetano-signorelli)
* Daniele Sirocchi (https://github.com/dsr-lab)

## Description
We found a possible bug in the implementation of the *Softmax* activation.
In particular, we noticed learning issues when we trained a model with Mixed Precision (https://www.tensorflow.org/guide/mixed_precision) coupled with MultiHeadAttention (https://www.tensorflow.org/api_docs/python/tf/keras/layers/MultiHeadAttention).

The potential problem is located in the following lines of code (see line 338 in module *advanced_activations.py*):

```
adder = (1.0 - math_ops.cast(mask, inputs.dtype)) * (
          _large_compatible_negative(inputs.dtype))

...

inputs += adder
```

Specifically, the method **_large_compatible_negative** returns a value that is **too negatively large** when the data type is float16 (i.e., the mixed precision is enabled), and it causes **overflows** when the *adder* variable is combined with the *inputs*. Therefore, our model was unable to learn during the training procedure.

Our fix consisted in moving this value away from the overflow edge, scaling it, but without changing the role of the **_large_compatible_negative** method, namely to return a big negative value to mask some parts of the inputs.
After this fix, our model trained smoothly, and it was eventually able to learn how to solve our task.
