### PR TITLE
Updated Install libffi7 package step

### DIFF
--- a/tensorflow/lite/examples/minimal/README.md
+++ b/tensorflow/lite/examples/minimal/README.md
@@ -14,13 +14,23 @@ sudo apt-get install cmake
 Or you can follow
 [the official cmake installation guide](https://cmake.org/install/)
 
-#### Step 2. Clone TensorFlow repository
+#### Step 2. Install libffi7 package(Optional)
+
+It requires libffi7. On Ubuntu 20.10 or later, you can simply run the following
+command.
+
+```sh
+wget http://es.archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi7_3.3-4_amd64.deb
+sudo dpkg -i libffi7_3.3-4_amd64.deb
+```
+
+#### Step 3. Clone TensorFlow repository
 
 ```sh
 git clone https://github.com/tensorflow/tensorflow.git tensorflow_src
 ```
 
-#### Step 3. Create CMake build directory and run CMake tool
+#### Step 4. Create CMake build directory and run CMake tool
 
 ```sh
 mkdir minimal_build
@@ -28,7 +38,7 @@ cd minimal_build
 cmake ../tensorflow_src/tensorflow/lite/examples/minimal
 ```
 
-#### Step 4. Build TensorFlow Lite
+#### Step 5. Build TensorFlow Lite
 
 In the minimal_build directory,
 


### PR DESCRIPTION
While following the [TensorFlow Lite C++ minimal example](https://github.com/tensorflow/tensorflow/edit/master/tensorflow/lite/examples/minimal/README.md) instructions I encountered issue with `libffi7` package ([libffi.so.7: cannot open shared object file: No such file or directory](https://askubuntu.com/questions/1286772/libffi-so-7-cannot-open-shared-object-file-no-such-file-or-directory)) because since `Ubuntu 20.10` comes with `libff8` instead of `libffi7` and in TensorFlow Lite C++ minimal example it's still using `libffi7` package so we have to install `libffi7` by manually downloading the deb package from ubuntu focal (20.04) By following below steps so It's better to add below steps for Ubuntu users who are using `Ubuntu 20.10 or later `version to handle `libffi.so.7: cannot open shared object file: No such file or directory` error in our official documentation of [TensorFlow Lite C++ minimal example](https://github.com/tensorflow/tensorflow/edit/master/tensorflow/lite/examples/minimal/README.md) so please do the needful. Thank you!

```
1. wget http://es.archive.ubuntu.com/ubuntu/pool/main/libf/libffi/libffi7_3.3-4_amd64.deb
2. sudo dpkg -i libffi7_3.3-4_amd64.deb
```