### PR TITLE
Fix crash when invalid input was provided to ragged_tensor_to_variant

### DIFF
--- a/tensorflow/core/kernels/ragged_tensor_to_variant_op.cc
+++ b/tensorflow/core/kernels/ragged_tensor_to_variant_op.cc
@@ -97,7 +97,7 @@ Status UnbatchRaggedZerothDim(
       auto start = batched_splits_top_vec(i);
       auto limit = batched_splits_top_vec(i + 1);
       auto num_values = limit - start;
-      values_shape.set_dim(0, num_values);
+      TF_RETURN_IF_ERROR(values_shape.SetDimWithStatus(0, num_values));
       (*ragged_components)[i].set_values(
           Tensor(DataTypeToEnum<VALUE_TYPE>::value, values_shape));
       auto ragged_component_values_flat =
@@ -154,7 +154,7 @@ Status UnbatchRaggedZerothDim(
   int64_t value_index = 0;
   for (auto i = decltype(num_components){}; i < num_components; i++) {
     SPLIT_TYPE num_values = ragged_component_values_size[i];
-    values_shape.set_dim(0, num_values);
+    TF_RETURN_IF_ERROR(values_shape.SetDimWithStatus(0, num_values));
     (*ragged_components)[i].set_values(
         Tensor(DataTypeToEnum<VALUE_TYPE>::value, values_shape));
     auto ragged_component_values_flat =

--- a/tensorflow/python/ops/ragged/ragged_tensor_test.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor_test.py
@@ -2014,6 +2014,15 @@ class RaggedTensorTest(test_util.TensorFlowTestCase, parameterized.TestCase):
     with self.assertRaises(ValueError):
       rt._set_shape([5, None, None])
 
+  def testToVariantInvalidInputs(self):
+    self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError),
+        'must be less than 0, got 0|Shape must be at least rank 1 but is rank 0',
+        gen_ragged_conversion_ops.ragged_tensor_to_variant,
+        rt_nested_splits=[[150, 38, -243]],
+        rt_dense_values=198,
+        batched_input=True)
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class RaggedTensorSpecTest(test_util.TensorFlowTestCase,


### PR DESCRIPTION
This PR fixes #59084 by return error in case invalid shape set_dim is called.
    
Signed-off-by: Yong Tang <yong.tang.github@outlook.com>