### PR TITLE
[Linaro:ARM_CI] Use IS_NIGHTLY to determine which tensorboard to install

### DIFF
--- a/tensorflow/tools/ci_build/builds/pip_new.sh
+++ b/tensorflow/tools/ci_build/builds/pip_new.sh
@@ -325,7 +325,12 @@ if [[ -z "$PYTHON_BIN_PATH" ]]; then
   die "PYTHON_BIN_PATH was not provided. Did you run configure?"
 fi
 
-${PYTHON_BIN_PATH} -m pip install tb-nightly
+if [[ "$IS_NIGHTLY" == 1 ]]; then
+  ${PYTHON_BIN_PATH} -m pip install tb-nightly
+else
+  ${PYTHON_BIN_PATH} -m pip install tensorboard
+fi
+
 if [[ "x${PY_MAJOR_MINOR_VER}x" == "x3.8x" ]]; then
   ${PYTHON_BIN_PATH} -m pip uninstall -y protobuf
   ${PYTHON_BIN_PATH} -m pip install "protobuf < 4"


### PR DESCRIPTION
Only install tb-nightly on nightly builds otherwise tensorboard, this keeps the build and the test consistent using the same package