### PR TITLE
Fix debug build failure in math_approximation.cc due to 'isnan' was not declared

### DIFF
--- a/tensorflow/compiler/xla/mlir/math/transforms/math_approximation.cc
+++ b/tensorflow/compiler/xla/mlir/math/transforms/math_approximation.cc
@@ -128,8 +128,8 @@ Value f32FromBits(ImplicitLocOpBuilder &builder, uint32_t bits) {
 Value ClampWithNormals(ImplicitLocOpBuilder &builder,
                        const llvm::SmallVector<int64_t, 2> &shape, Value value,
                        float lower_bound, float upper_bound) {
-  assert(!isnan(lower_bound));
-  assert(!isnan(upper_bound));
+  assert(!std::isnan(lower_bound));
+  assert(!std::isnan(upper_bound));
 
   auto bcast = [&](Value value) -> Value {
     return broadcast(builder, value, shape);


### PR DESCRIPTION
Hi all,

The debug build failed.
```
tensorflow/compiler/xla/mlir/math/transforms/math_approximation.cc: In function 'mlir::Value xla::{anonymous}::ClampWithNormals(mlir::ImplicitLocOpBuilder&, const llvm::SmallVector<long int, 2>&, mlir::Value, float, float)':
tensorflow/compiler/xla/mlir/math/transforms/math_approximation.cc:131:11: error: 'isnan' was not declared in this scope; did you mean 'std::isnan'?
  131 |   assert(!isnan(lower_bound));
      |           ^~~~~
In file included from external/llvm-project/llvm/include/llvm/Support/MathExtras.h:20,
                 from external/llvm-project/llvm/include/llvm/Support/Alignment.h:24,
                 from external/llvm-project/llvm/include/llvm/Support/Allocator.h:21,
                 from external/llvm-project/mlir/include/mlir/Support/TypeID.h:21,
                 from external/llvm-project/mlir/include/mlir/IR/MLIRContext.h:13,
                 from external/llvm-project/mlir/include/mlir/IR/DialectRegistry.h:16,
                 from external/llvm-project/mlir/include/mlir/IR/Dialect.h:16,
                 from external/llvm-project/mlir/include/mlir/Dialect/Arith/IR/Arith.h:12,
                 from tensorflow/compiler/xla/mlir/math/transforms/math_approximation.cc:20:
/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/cmath:632:5: note: 'std::isnan' declared here
  632 |     isnan(_Tp __x)
      |     ^~~~~
Target //tensorflow/tools/pip_package:build_pip_package failed to build
```

Let's fix it.

Thanks.
Best regards,
Jie