### PR TITLE
[NVIDIA TF] Update cudnn frontend to v0.8

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -172,9 +172,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "//third_party:cudnn_frontend.BUILD",
         patch_file = ["//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "3c7b842cd67989810955b220fa1116e7e2ed10660a8cfb632118146a64992c30",
-        strip_prefix = "cudnn-frontend-0.7.3",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.7.3.zip"),
+        sha256 = "bfcf778030831f325cfc13ae5995388cc834fbff2995a297ba580d9ec65ca3b6",
+        strip_prefix = "cudnn-frontend-0.8",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v0.8.zip"),
     )
 
     tf_http_archive(

--- a/third_party/cudnn_frontend_header_fix.patch
+++ b/third_party/cudnn_frontend_header_fix.patch
@@ -1,4 +1,4 @@
-From 5c4069558d42fd61d083878335a704eb6f888ca9 Mon Sep 17 00:00:00 2001
+From 6e44c563e7d71e5a8988ac0d0f3259c4e3405b7d Mon Sep 17 00:00:00 2001
 From: Kaixi Hou <kaixih@nvidia.com>
 Date: Tue, 4 May 2021 15:21:11 -0700
 Subject: [PATCH] Update headers path to TF-compat
@@ -18,8 +18,9 @@ Subject: [PATCH] Update headers path to TF-compat
  include/cudnn_frontend_PointWiseDesc.h      | 4 ++--
  include/cudnn_frontend_ReductionDesc.h      | 4 ++--
  include/cudnn_frontend_Resample.h           | 4 ++--
+ include/cudnn_frontend_Rng.h                | 4 ++--
  include/cudnn_frontend_VariantPack.h        | 4 ++--
- 15 files changed, 27 insertions(+), 27 deletions(-)
+ 16 files changed, 29 insertions(+), 29 deletions(-)
 
 diff --git a/include/cudnn_backend_base.h b/include/cudnn_backend_base.h
 index 56d8bec..8ceb19c 100644
@@ -121,7 +122,7 @@ index aac4086..ed1f343 100644
  namespace cudnn_frontend {
  
 diff --git a/include/cudnn_frontend_Heuristics.h b/include/cudnn_frontend_Heuristics.h
-index b1c5e98..2ccd737 100644
+index 680906a..3df8924 100644
 --- a/include/cudnn_frontend_Heuristics.h
 +++ b/include/cudnn_frontend_Heuristics.h
 @@ -25,8 +25,8 @@
@@ -136,7 +137,7 @@ index b1c5e98..2ccd737 100644
  #include "cudnn_frontend_OperationGraph.h"
  #include "cudnn_frontend_EngineConfig.h"
 diff --git a/include/cudnn_frontend_MatMulDesc.h b/include/cudnn_frontend_MatMulDesc.h
-index a7d0714..c5ccb90 100644
+index 0b15295..cae5323 100644
 --- a/include/cudnn_frontend_MatMulDesc.h
 +++ b/include/cudnn_frontend_MatMulDesc.h
 @@ -29,8 +29,8 @@
@@ -151,7 +152,7 @@ index a7d0714..c5ccb90 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Operation.h b/include/cudnn_frontend_Operation.h
-index d69decd..15c32d2 100644
+index 097e970..fca04ea 100644
 --- a/include/cudnn_frontend_Operation.h
 +++ b/include/cudnn_frontend_Operation.h
 @@ -30,8 +30,8 @@
@@ -166,7 +167,7 @@ index d69decd..15c32d2 100644
  #include "cudnn_frontend_ConvDesc.h"
  #include "cudnn_frontend_PointWiseDesc.h"
 diff --git a/include/cudnn_frontend_OperationGraph.h b/include/cudnn_frontend_OperationGraph.h
-index 8c708b7..ce5b000 100644
+index 2a68c41..50162bd 100644
 --- a/include/cudnn_frontend_OperationGraph.h
 +++ b/include/cudnn_frontend_OperationGraph.h
 @@ -30,8 +30,8 @@
@@ -181,7 +182,7 @@ index 8c708b7..ce5b000 100644
  #include "cudnn_frontend_Operation.h"
  #include "cudnn_frontend_utils.h"
 diff --git a/include/cudnn_frontend_PointWiseDesc.h b/include/cudnn_frontend_PointWiseDesc.h
-index b62cd27..8b56eeb 100644
+index 7a69b66..cfc9559 100644
 --- a/include/cudnn_frontend_PointWiseDesc.h
 +++ b/include/cudnn_frontend_PointWiseDesc.h
 @@ -30,8 +30,8 @@
@@ -196,7 +197,7 @@ index b62cd27..8b56eeb 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_ReductionDesc.h b/include/cudnn_frontend_ReductionDesc.h
-index 21c4ee3..e77e4ef 100644
+index e22a0fb..d69e8c6 100644
 --- a/include/cudnn_frontend_ReductionDesc.h
 +++ b/include/cudnn_frontend_ReductionDesc.h
 @@ -29,8 +29,8 @@
@@ -211,9 +212,24 @@ index 21c4ee3..e77e4ef 100644
  #include "cudnn_frontend_utils.h"
  
 diff --git a/include/cudnn_frontend_Resample.h b/include/cudnn_frontend_Resample.h
-index 2174509..d0d7e3b 100644
+index 4d2d197..1b7c24d 100644
 --- a/include/cudnn_frontend_Resample.h
 +++ b/include/cudnn_frontend_Resample.h
+@@ -29,8 +29,8 @@
+ #include <sstream>
+ #include <utility>
+ 
+-#include <cudnn.h>
+-#include <cudnn_backend.h>
++#include "third_party/gpus/cudnn/cudnn.h"
++#include "third_party/gpus/cudnn/cudnn_backend.h"
+ 
+ #include "cudnn_frontend_utils.h"
+ 
+diff --git a/include/cudnn_frontend_Rng.h b/include/cudnn_frontend_Rng.h
+index 0001ac6..80a623b 100644
+--- a/include/cudnn_frontend_Rng.h
++++ b/include/cudnn_frontend_Rng.h
 @@ -29,8 +29,8 @@
  #include <sstream>
  #include <utility>


### PR DESCRIPTION
This PR is to update the cudnn frontend version to v0.8. The release note is [here](https://github.com/NVIDIA/cudnn-frontend/releases/tag/v0.8).


cc. @pjannaty @nluehr 