### PR TITLE
Fix broken relnotes.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release 2.12.0
 
-# Breaking Changes
+## Breaking Changes
 
 *   Build, Compilation and Packaging
 
@@ -32,7 +32,7 @@
     * Introduced new class `tf.saved_model.experimental.Fingerprint` that contains the fingerprint of the SavedModel. See the [SavedModel Fingerprinting RFC](https://github.com/tensorflow/community/pull/415) for details.
     * Introduced API `tf.saved_model.experimental.read_fingerprint(export_dir)` for reading the fingerprint of a SavedModel.
 
-# Major Features and Improvements
+## Major Features and Improvements
 
 *   `tf.lite`:
 
@@ -75,7 +75,7 @@
 
     *   Added experimental support to ReduceScatter fuse on GPU (NCCL).
 
-# Bug Fixes and Other Changes
+## Bug Fixes and Other Changes
 
 * `tf.random`
   * Added non-experimental aliases for `tf.random.split` and `tf.random.fold_in`, the experimental endpoints are still available so no code changes are necessary.
@@ -90,7 +90,7 @@
 *  `tf.config.experimental.mlir_bridge_rollout`
     *   Removed enums `MLIR_BRIDGE_ROLLOUT_SAFE_MODE_ENABLED` and `MLIR_BRIDGE_ROLLOUT_SAFE_MODE_FALLBACK_ENABLED` which are no longer used by the tf2xla bridge
 
-# Thanks to our Contributors
+## Thanks to our Contributors
 
 This release contains contributions from many people at Google, as well as:
 


### PR DESCRIPTION
There should be only one level 1 heading (`#` / `<h1>`) in each release section and the rest should be L2 (`##`/`<h2>`) but when the stub got created at the last release time it got created badly and review was nonexistent so we see the breakage ~3 months after