### PR TITLE
Fix GRUCellBlockOp message for invalid rank of x

### DIFF
--- a/tensorflow/core/kernels/rnn/gru_ops.cc
+++ b/tensorflow/core/kernels/rnn/gru_ops.cc
@@ -16,8 +16,9 @@ limitations under the License.
 #define EIGEN_USE_THREADS
 
 #include "tensorflow/core/kernels/rnn/gru_ops.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
 #include "tensorflow/core/framework/op_kernel.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 

--- a/tensorflow/core/kernels/rnn/gru_ops.cc
+++ b/tensorflow/core/kernels/rnn/gru_ops.cc
@@ -53,8 +53,8 @@ class GRUCellBlockOp : public OpKernel {
 
     // Shape of 'x' must be [batch_size, input_size]
     OP_REQUIRES(ctx, TensorShapeUtils::IsMatrix(x_tensor->shape()),
-                errors::InvalidArgument("Rank of x must be 2", x_tensor->dims(),
-                                        " vs. 2"));
+                errors::InvalidArgument("Rank of x must be 2, got ",
+                                        x_tensor->dims()));
     const int64_t batch_size = x_tensor->dim_size(0);
     const int64_t input_size = x_tensor->dim_size(1);
 

--- a/tensorflow/core/kernels/rnn/gru_ops.cc
+++ b/tensorflow/core/kernels/rnn/gru_ops.cc
@@ -16,7 +16,7 @@ limitations under the License.
 #define EIGEN_USE_THREADS
 
 #include "tensorflow/core/kernels/rnn/gru_ops.h"
-
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 

--- a/tensorflow/core/kernels/rnn/gru_ops.cc
+++ b/tensorflow/core/kernels/rnn/gru_ops.cc
@@ -18,7 +18,6 @@ limitations under the License.
 #include "tensorflow/core/kernels/rnn/gru_ops.h"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op_kernel.h"
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 


### PR DESCRIPTION
The validation checks that `x` is a matrix, so rank must be 2. ff45913 fixed the crash in https://github.com/tensorflow/tensorflow/issues/58261 but left this typo in an exception message.

Fixes https://github.com/tensorflow/tensorflow/issues/58261

@mihaimaruseac 