### PR TITLE
Fix resource names used for annotation of variable ops

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -983,9 +983,11 @@ def _annotate_variable_ops(func, graph_def):
   Raises:
     RuntimeError: if some shapes cannot be annotated.
   """
+  resource_names = [ph.name for ph in func.graph.internal_captures if ph.dtype == dtypes.resource]
+
   ph_shape_map = {}
-  for ph, var in zip(func.graph.internal_captures, func.variables):
-    ph_shape_map[ph.name] = var.shape
+  for ph, var in zip(resource_names, func.variables):
+    ph_shape_map[ph] = var.shape
   # Construct a mapping of node names to nodes
   name_to_node = {node.name: node for node in graph_def.node}
   # Go through all the ReadVariableOp nodes in the graph def


### PR DESCRIPTION
To facilitate conversion of variable ops (used in the experimental `disable_graph_freezing` mode) the converter annotates the graph with the shape of the variable ops. 

This PR fixes the mapping between captured input names and variables, so that the graph can be annotated correctly.