### PR TITLE
Update image_ops_impl.convert_image_dtype.py

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -2531,7 +2531,7 @@ def convert_image_dtype(image, dtype, saturate=False, name=None):
         return math_ops.multiply(cast, scale, name=name)
       else:
         # Converting from float: first scale, then cast
-        scale = dtype.max + 0.5  # avoid rounding problems in the cast
+        scale = 1./(dtype.max + 0.5)  # avoid rounding problems in the cast
         scaled = math_ops.multiply(image, scale)
         if saturate:
           return math_ops.saturate_cast(scaled, dtype, name=name)


### PR DESCRIPTION
Images that are represented using floating point values are expected to have values in the range [0,1) for the function `convert_image_dtype()`.  But this is not scaled when the case `image `argument is of `float ` and `dtype` argument is `int` arises.  Hence modified the code to bring the input values within [0,1). This also shall fix the issue #58749 .