### PR TITLE
Fix dtype in code comment in constants_test.cc

### DIFF
--- a/tensorflow/compiler/xla/tests/constants_test.cc
+++ b/tensorflow/compiler/xla/tests/constants_test.cc
@@ -82,7 +82,7 @@ TEST_F(ConstantsTest, OneCellF16) {
 
   XlaBuilder builder(TestName());
   auto c = ConstantR1<half>(&builder, constant);
-  // F8 outputs are not yet supported so convert to F32
+  // F16 outputs are not yet supported so convert to F32
   ConvertElementType(c, F32);
 
   ComputeAndCompareR1<float>(&builder, {2.0f}, {}, error_spec_);


### PR DESCRIPTION
The dtype to be changed to F16 from F8 at line number 85 as the function converts F16 to F32.  Merging this closes the issue #59748