### PR TITLE
Fix the endianness issue in `//tensorflow/python/framework:tensor_util_test` on s390x

### DIFF
--- a/tensorflow/python/framework/tensor_util_test.py
+++ b/tensorflow/python/framework/tensor_util_test.py
@@ -226,12 +226,20 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
 
   def testHalf(self):
     t = tensor_util.make_tensor_proto(np.array([10.0, 20.0], dtype=np.float16))
-    self.assertProtoEquals(
-        """
-      dtype: DT_HALF
-      tensor_shape { dim { size: 2 } }
-      tensor_content: "\000I\000M"
-      """, t)
+    if sys.byteorder == "big":
+      self.assertProtoEquals(
+          """
+        dtype: DT_HALF
+        tensor_shape { dim { size: 2 } }
+        tensor_content: "I\000M\000"
+        """, t)
+    else:
+      self.assertProtoEquals(
+          """
+        dtype: DT_HALF
+        tensor_shape { dim { size: 2 } }
+        tensor_content: "\000I\000M"
+        """, t)
 
     a = tensor_util.MakeNdarray(t)
     self.assertEqual(np.float16, a.dtype)


### PR DESCRIPTION
Test case `//tensorflow/python/framework:tensor_util_test` failed on s390x (big-endian arch) because in `testHalf()` function the `tensor_content` data which is used for comparison with the tensor proto string is hard-coded in little-endian format.

This PR followed the existing pattern in `testFloatMutateArray()` function to add an endianness check in `testHalf()` function and choose the corresponding `tensor_content` data which is in consistent with the platform endianness.

The above mentioned test case will pass on both little-endian and big-endian systems after applying the code change.