### PR TITLE
Fix tensor_or_memref build error without math.h

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter/framework/tensor_or_memref.h
+++ b/tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter/framework/tensor_or_memref.h
@@ -23,6 +23,7 @@ limitations under the License.
 #include <optional>
 #include <type_traits>
 #include <utility>
+#include <math.h>
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/pull/59536#issuecomment-1439039311

Since pevious PR has been rolled back, this one adopted reviewer's feedback to fix Mac build error.

Thanks @reedwm for the feedback and suggestion!