### PR TITLE
[Linaro:ARM_CI] Skip failing test until it can be resolved

### DIFF
--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -27,5 +27,6 @@ ARM_SKIP_TESTS="-//tensorflow/lite/... \
 -//tensorflow/python/distribute/failure_handling:gce_failure_handler_test \
 -//tensorflow/python/kernel_tests/nn_ops:atrous_conv2d_test \
 -//tensorflow/python/kernel_tests/nn_ops:conv_ops_test \
+-//tensorflow/python/kernel_tests/nn_ops:pooling_ops_test \
 -//tensorflow/python/training:server_lib_test \
 -//tensorflow/python/debug/lib:source_remote_test"


### PR DESCRIPTION
//tensorflow/python/kernel_tests/nn_ops:pooling_ops_test is a known fail