### PR TITLE
Update devel.requirements.txt

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
@@ -15,7 +15,7 @@ numpy ~= 1.22.0; python_version < '3.11'
 numpy ~= 1.23.2; python_version >= '3.11' # Earliest version for Python 3.11
 opt_einsum ~= 3.3.0
 packaging ~= 21.3
-protobuf ~= 3.20.1
+protobuf >= 3.20.3
 six ~= 1.16.0
 termcolor ~= 2.1.1
 typing_extensions ~= 3.10.0.0

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
@@ -15,7 +15,7 @@ numpy ~= 1.22.0; python_version < '3.11'
 numpy ~= 1.23.2; python_version >= '3.11' # Earliest version for Python 3.11
 opt_einsum ~= 3.3.0
 packaging ~= 21.3
-protobuf >= 3.20.3
+protobuf ~= 3.20.3
 six ~= 1.16.0
 termcolor ~= 2.1.1
 typing_extensions ~= 3.10.0.0


### PR DESCRIPTION
Changed protobuf ~= 3.20.1 to protobuf >= 3.20.3  since https://github.com/tensorflow/tensorflow/blob/20e0beaeebc1bd96c8eca40bed0e7b0d065d8e0b/tensorflow/tools/pip_package/setup.py#L100 has protobuf >= 3.20.3 in it and both versions should match.  This fixes https://github.com/tensorflow/tensorflow/issues/59774