### PR TITLE
Add s390x support in ParseTensorOp and SerializeTensorOp

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4570,7 +4570,7 @@ tf_kernel_library(
     name = "parse_tensor_op",
     prefix = "parse_tensor_op",
     deps = [
-       "//tensorflow/core/util/tensor_bundle:byteswaptensor",
+        "//tensorflow/core/util/tensor_bundle:byteswaptensor",
     ] + PARSING_DEPS,
 )
 

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4569,7 +4569,9 @@ tf_kernel_library(
 tf_kernel_library(
     name = "parse_tensor_op",
     prefix = "parse_tensor_op",
-    deps = PARSING_DEPS,
+    deps = [
+       "//tensorflow/core/util/tensor_bundle:byteswaptensor",
+    ] + PARSING_DEPS,
 )
 
 tf_cc_test(

--- a/tensorflow/core/kernels/parse_tensor_op.cc
+++ b/tensorflow/core/kernels/parse_tensor_op.cc
@@ -60,7 +60,7 @@ class ParseTensorOp : public OpKernel {
                                 DataTypeString(out_type_), ")"));
     
     if (!port::kLittleEndian)
-      auto byteswap_status = ByteSwapTensor(&output);
+      OP_REQUIRES_OK(ctx, ByteSwapTensor(&output));
 
     ctx->set_output(0, output);
   }
@@ -84,7 +84,7 @@ class SerializeTensorOp : public OpKernel {
     } else {
       if (!port::kLittleEndian) {
         Tensor ts_ = tensor::DeepCopy(tensor);
-        auto byteswap_status = ByteSwapTensor(&ts_);
+        OP_REQUIRES_OK(context, ByteSwapTensor(&ts_));
         ts_.AsProtoTensorContent(&proto);
       } else
         tensor.AsProtoTensorContent(&proto);

--- a/tensorflow/core/kernels/parse_tensor_op.cc
+++ b/tensorflow/core/kernels/parse_tensor_op.cc
@@ -20,8 +20,10 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor.pb.h"
 #include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/tensor_util.h"
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/util/tensor_bundle/byte_swap_tensor.h"
 
 namespace tensorflow {
 
@@ -56,6 +58,9 @@ class ParseTensorOp : public OpKernel {
         errors::InvalidArgument("Type mismatch between parsed tensor (",
                                 DataTypeString(output.dtype()), ") and dtype (",
                                 DataTypeString(out_type_), ")"));
+    
+    if (!port::kLittleEndian)
+      auto byteswap_status = ByteSwapTensor(&output);
 
     ctx->set_output(0, output);
   }
@@ -77,7 +82,12 @@ class SerializeTensorOp : public OpKernel {
     if (tensor.dtype() == DT_STRING) {
       tensor.AsProtoField(&proto);
     } else {
-      tensor.AsProtoTensorContent(&proto);
+      if (!port::kLittleEndian) {
+        Tensor ts_ = tensor::DeepCopy(tensor);
+        auto byteswap_status = ByteSwapTensor(&ts_);
+        ts_.AsProtoTensorContent(&proto);
+      } else
+        tensor.AsProtoTensorContent(&proto);
     }
     Tensor* proto_string = nullptr;
     OP_REQUIRES_OK(context,

--- a/tensorflow/core/kernels/parse_tensor_op.cc
+++ b/tensorflow/core/kernels/parse_tensor_op.cc
@@ -59,7 +59,7 @@ class ParseTensorOp : public OpKernel {
                                 DataTypeString(output.dtype()), ") and dtype (",
                                 DataTypeString(out_type_), ")"));
     
-    if (!port::kLittleEndian)
+    if (!port::kLittleEndian && IsByteSwappable(output.dtype()))
       OP_REQUIRES_OK(ctx, ByteSwapTensor(&output));
 
     ctx->set_output(0, output);
@@ -82,7 +82,7 @@ class SerializeTensorOp : public OpKernel {
     if (tensor.dtype() == DT_STRING) {
       tensor.AsProtoField(&proto);
     } else {
-      if (!port::kLittleEndian) {
+      if (!port::kLittleEndian && IsByteSwappable(tensor.dtype())) {
         Tensor ts_ = tensor::DeepCopy(tensor);
         OP_REQUIRES_OK(context, ByteSwapTensor(&ts_));
         ts_.AsProtoTensorContent(&proto);

--- a/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
+++ b/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
@@ -135,12 +135,6 @@ bool IsByteSwappable(DataType dtype) {
     case DT_COMPLEX128:
       return true;
     
-    // Types that ought to be supported in the future
-    case DT_RESOURCE:
-    case DT_VARIANT:
-      VLOG(1) << "Byte-swapping not yet implemented for tensors with dtype " << dtype;
-      return false;
-    
     default:
       return false;
   }

--- a/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
+++ b/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
@@ -109,6 +109,43 @@ Status ByteSwapBuffer(char* buff, size_t size, DataType dtype,
 
 }  // namespace
 
+bool IsByteSwappable(DataType dtype) {
+  switch (dtype) {
+    // 16-bit types
+    case DT_BFLOAT16:
+    case DT_HALF:
+    case DT_QINT16:
+    case DT_QUINT16:
+    case DT_UINT16:
+    case DT_INT16:
+
+    // 32-bit types
+    case DT_FLOAT:
+    case DT_INT32:
+    case DT_QINT32:
+    case DT_UINT32:
+
+    // 64-bit types
+    case DT_INT64:
+    case DT_DOUBLE:
+    case DT_UINT64:
+
+    // Complex types
+    case DT_COMPLEX64:
+    case DT_COMPLEX128:
+      return true;
+    
+    // Types that ought to be supported in the future
+    case DT_RESOURCE:
+    case DT_VARIANT:
+      VLOG(1) << "Byte-swapping not yet implemented for tensors with dtype " << dtype;
+      return false;
+    
+    default:
+      return false;
+  }
+}
+
 Status ByteSwapTensor(Tensor* t) {
   char* buff = const_cast<char*>((t->tensor_data().data()));
   return ByteSwapBuffer(buff, t->tensor_data().size(), t->dtype(),

--- a/tensorflow/core/util/tensor_bundle/byte_swap_tensor.h
+++ b/tensorflow/core/util/tensor_bundle/byte_swap_tensor.h
@@ -24,6 +24,9 @@ limitations under the License.
 
 namespace tensorflow {
 
+// Check if a data type is byte swappable.
+bool IsByteSwappable(DataType dtype);
+
 // Byte-swap a tensor's backing buffer in place.
 //
 // Args:

--- a/tensorflow/python/kernel_tests/io_ops/parsing_ops_test.py
+++ b/tensorflow/python/kernel_tests/io_ops/parsing_ops_test.py
@@ -18,6 +18,7 @@ import copy
 import itertools
 
 import numpy as np
+import sys
 
 from google.protobuf import json_format
 
@@ -2501,7 +2502,10 @@ class ParseTensorOpTest(test.TestCase):
   def testToFloat32(self):
     with self.cached_session():
       expected = np.random.rand(3, 4, 5).astype(np.float32)
-      tensor_proto = tensor_util.make_tensor_proto(expected)
+      if sys.byteorder == 'big':
+        tensor_proto = tensor_util.make_tensor_proto(expected.byteswap())
+      else:
+        tensor_proto = tensor_util.make_tensor_proto(expected)
 
       serialized = array_ops.placeholder(dtypes.string)
       tensor = parsing_ops.parse_tensor(serialized, dtypes.float32)

--- a/tensorflow/python/ops/io_ops.py
+++ b/tensorflow/python/ops/io_ops.py
@@ -139,15 +139,15 @@ def serialize_tensor(tensor, name=None):
   r"""Transforms a Tensor into a serialized TensorProto proto.
 
   This operation transforms data in a `tf.Tensor` into a `tf.Tensor` of type
-  `tf.string` containing the data in a binary string format. This operation can
-  transform scalar data and linear arrays, but it is most useful in converting
-  multidimensional arrays into a format accepted by binary storage formats such
-  as a `TFRecord` or `tf.train.Example`.
+  `tf.string` containing the data in a binary string in little-endian format. 
+  This operation can transform scalar data and linear arrays, but it is most 
+  useful in converting multidimensional arrays into a format accepted by binary 
+  storage formats such as a `TFRecord` or `tf.train.Example`.
 
   See also:
   - `tf.io.parse_tensor`: inverse operation of `tf.io.serialize_tensor` that
-  transforms a scalar string containing a serialized Tensor into a Tensor of a
-  specified type.
+  transforms a scalar string containing a serialized Tensor in little-endian
+  format into a Tensor of a specified type.
   - `tf.ensure_shape`: `parse_tensor` cannot statically determine the shape of
   the parsed tensor. Use `tf.ensure_shape` to set the static shape when running
   under a `tf.function`


### PR DESCRIPTION
Sub-test `tensorflow.python.ops.io_ops.serialize_tensor` in test case `//tensorflow/tools/docs:tf_doctest` failed on s390x (big-endian arch), because the serialized binary strings which represent the tensor data are different between little-endian and big-endian platforms.
 
This PR adds the endianness conversion procedure for big-endian systems in the implementation of ParseTensorOp and SerializeTensorOp (in `tensorflow/core/kernels/parse_tensor_op.cc`), so that the serialized binary strings generated on big-endian systems will be in little-endian format as well and identical to the ones generated on little-endian systems.
 
The code change in `tensorflow/python/kernel_tests/io_ops/parsing_ops_test.py` ensures the serialized proto string in `ParseTensorOpTest.testToFloat32()` would be in little-endian format on big-endian platforms, which is consistent with the updated code flow in `SerializeTensorOp`.
 
`//tensorflow/tools/docs:tf_doctest` will pass on big-endian systems after applying the code change. It won't affect the functionality and performance on little-endian systems. 

This PR also updated the api documentation for `tf.io.serialize_tensor` and `tf.io.parse_tensor` to indicate the serialized binary strings are in little-endian format.

Signed-off-by: Kun-Lu <kun.lu@ibm.com>