### PR TITLE
Cache the result of cuModuleGetFunction

### DIFF
--- a/tensorflow/compiler/mlir/tools/kernel_gen/tf_gpu_runtime_wrappers.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/tf_gpu_runtime_wrappers.cc
@@ -101,6 +101,24 @@ GPURuntimeCache::GPUModule GPURuntimeCache::LookupOrLoadModule(void *data) {
   return module;
 }
 
+GPURuntimeCache::GPUFunction GPURuntimeCache::LookupOrGetFunction(
+    GPUModule module, const char* kernel_name) {
+  tensorflow::mutex_lock lock(mu_);
+  GPUFunction& function =
+      gpu_function_by_module_and_name_[{module, kernel_name}];
+
+  if (!function) {
+#if GOOGLE_CUDA
+    GPU_REPORT_IF_ERROR(cuModuleGetFunction(&function, module, kernel_name));
+#endif
+#if TENSORFLOW_USE_ROCM
+    GPU_REPORT_IF_ERROR(hipModuleGetFunction(&function, module, kernel_name));
+#endif
+  }
+
+  return function;
+}
+
 // Implements a C wrapper around the TensorFlow runtime and CUDA (or ROCm)
 // library that allows launching a kernel on the current device and stream from
 // a binary blob for the module and function name.
@@ -135,11 +153,10 @@ extern "C" void _mlir_ciface_tf_launch_kernel(void *ctx, void *module_blob,
       op_kernel_ctx->op_device_context()->stream();
   void *stream = se_stream->implementation()->GpuStreamHack();
   GPURuntimeCache::GPUModule module = cache->LookupOrLoadModule(module_blob);
+  GPURuntimeCache::GPUFunction function =
+      cache->LookupOrGetFunction(module, kernel_name);
 
 #if GOOGLE_CUDA
-  CUfunction function;
-  GPU_REPORT_IF_ERROR_WITH_CTX(
-      cuModuleGetFunction(&function, module, kernel_name), op_kernel_ctx);
   GPU_REPORT_IF_ERROR_WITH_CTX(
       cuLaunchKernel(function, gridX, gridY, gridZ, blockX, blockY, blockZ,
                      /*sharedMemBytes=*/0, reinterpret_cast<CUstream>(stream),
@@ -147,9 +164,6 @@ extern "C" void _mlir_ciface_tf_launch_kernel(void *ctx, void *module_blob,
       op_kernel_ctx);
 #endif
 #if TENSORFLOW_USE_ROCM
-  hipFunction_t function;
-  GPU_REPORT_IF_ERROR_WITH_CTX(
-      hipModuleGetFunction(&function, module, kernel_name), op_kernel_ctx);
   GPU_REPORT_IF_ERROR_WITH_CTX(
       hipModuleLaunchKernel(
           function, gridX, gridY, gridZ, blockX, blockY, blockZ,


### PR DESCRIPTION
This function has measurable overhead due to locks inside the GPU driver. Caching the result was observed to improve perf by up to 15% in some models.

Note that we believe TF used to cache the value, so this is considered to be a regression fix.

cc @nluehr @pjannaty 