### PR TITLE
[Linaro:ARM_CI] Switch to using Docker container with Dual ABI

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.cpu.arm64
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu.arm64
@@ -1,46 +1,20 @@
-FROM quay.io/pypa/manylinux2014_aarch64
-
-RUN yum -y check-update || true && \
-    yum install -y \
-        sudo \
-        wget \
-        openssl-devel \
-        libffi-devel \
-        java-1.8.0-openjdk-devel \
-        bzip2-devel \
-        gdbm-devel \
-        ncurses-devel \
-        nss-devel \
-        readline-devel \
-        sqlite-devel \
-        epel-release && \
-    yum install -y hdf5-devel && \
-    yum clean all
-
-COPY install/install_bazel.sh /install/
-RUN /install/install_bazel.sh
+FROM linaro/tensorflow-arm64-build:2.12-multipython
 
 ARG py_major_minor_version='3.10'
 
 ENV TF_PYTHON_VERSION=python${py_major_minor_version}
-ENV PYTHON_BIN_PATH=/usr/local/bin/${TF_PYTHON_VERSION}
+ENV PYTHON_BIN_PATH=/usr/bin/${TF_PYTHON_VERSION}
 
 RUN ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python && \
     ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python3
 
-RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
-    python /tmp/get-pip.py && \
-    rm -f /tmp/get-pip.py
-
-RUN export PYTHON_VERSION=$(python -c 'import platform; print(platform.python_version())') && \
-    ln -s /opt/_internal/cpython-$PYTHON_VERSION/bin/pip3 /usr/local/bin/pip${py_major_minor_version} && \
-    ln -s /opt/_internal/cpython-$PYTHON_VERSION/bin/pip3 /usr/local/bin/pip3 && \
-    ln -s /opt/_internal/cpython-$PYTHON_VERSION/bin/pip /usr/local/bin/pip
-
-RUN pip3 install packaging
+RUN ${PYTHON_BIN_PATH} -m pip install packaging
 
 ARG is_nightly=0
 ARG tf_project_name='tf_ci_cpu' # PyPI project name passed by CD GitHub workflow
 
 ENV IS_NIGHTLY=${is_nightly}
 ENV TF_PROJECT_NAME=${tf_project_name}
+
+# Set up the master bazelrc configuration file.
+COPY install/.bazelrc /etc/bazel.bazelrc

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -19,6 +19,11 @@ set -x
 
 source tensorflow/tools/ci_build/release/common.sh
 
+sudo mkdir /tmpfs
+sudo chown ${CI_BUILD_USER}:${CI_BUILD_USER} /tmpfs
+sudo mkdir /tensorflow
+sudo chown ${CI_BUILD_USER}:${CI_BUILD_USER} /tensorflow
+
 # Update bazel
 install_bazelisk
 
@@ -49,6 +54,12 @@ export TF_NEED_TENSORRT=0
 export OS_TYPE="UBUNTU"
 export CONTAINER_TYPE="CPU"
 
+sudo ${TF_PYTHON_VERSION} -m pip install --upgrade pip wheel
+sudo ${TF_PYTHON_VERSION} -m pip install --upgrade setuptools
+sudo ${TF_PYTHON_VERSION} -m pip install -r tensorflow/tools/ci_build/release/requirements_ubuntu.txt
+sudo touch /custom_sponge_config.csv
+sudo chown ${CI_BUILD_USER}:${CI_BUILD_USER} /custom_sponge_config.csv
+
 # Get the default test targets for bazel
 source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh
 
@@ -56,8 +67,7 @@ source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh
 source tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
 
 # Export optional variables for running pip_new.sh
-export TF_BUILD_FLAGS="--config=mkl_aarch64_threadpool --copt=-mtune=generic --copt=-march=armv8-a \
-    --copt=-O3 --copt=-flax-vector-conversions"
+export TF_BUILD_FLAGS="--config=ambe --config=mkl_aarch64_threadpool --copt=-flax-vector-conversions"
 export TF_TEST_FLAGS="${TF_BUILD_FLAGS} \
     --test_env=TF_ENABLE_ONEDNN_OPTS=1 --test_env=TF2_BEHAVIOR=1 --define=no_tensorflow_py_deps=true \
     --test_lang_filters=py --flaky_test_attempts=3 --test_size_filters=small,medium \
@@ -71,6 +81,10 @@ export TF_AUDITWHEEL_TARGET_PLAT="manylinux2014"
 if [ ${IS_NIGHTLY} == 1 ]; then
   ./tensorflow/tools/ci_build/update_version.py --nightly
 fi
+
+sudo sed -i '/^build --profile/d' /usertools/aarch64.bazelrc
+sudo sed -i '\@^build.*=\"/usr/local/bin/python3\"$@d' /usertools/aarch64.bazelrc
+sed -i '$ aimport /usertools/aarch64.bazelrc' .bazelrc
 
 source tensorflow/tools/ci_build/builds/pip_new.sh
 


### PR DESCRIPTION
Use the Docker container with the toolset built with CXX11 Dual ABI enabled in it for AARCH64 builds to bring them into line with other CPU architectures.