### PR TITLE
[ROCM] Add ROCM option to tensorflow-build

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/Dockerfile.rocm
@@ -16,7 +16,7 @@ COPY builder.devtoolset/glibc2.17-inline.patch /glibc2.17-inline.patch
 RUN /build_devtoolset.sh devtoolset-9 /dt9
 
 ################################################################################
-FROM nvidia/cuda:11.8.0-base-ubuntu20.04 as devel
+FROM ubuntu:20.04 as devel
 ################################################################################
 COPY --from=builder /dt9 /dt9
 
@@ -24,13 +24,13 @@ COPY --from=builder /dt9 /dt9
 # CUDA must be cleaned up in the same command to prevent Docker layer bloating
 COPY setup.sources.sh /setup.sources.sh
 COPY setup.packages.sh /setup.packages.sh
-COPY setup.cuda.sh /setup.cuda.sh
-COPY devel.packages.txt /devel.packages.cuda.txt
+COPY setup.rocm.sh /setup.rocm.sh
 COPY devel.packages.txt /devel.packages.txt
-RUN /setup.sources.sh CUDA && \
-    /setup.packages.sh /devel.packages.cuda.txt && \
+COPY devel.packages.rocm.txt /devel.packages.rocm.txt
+RUN /setup.sources.sh ROCM && \
+    /setup.packages.sh /devel.packages.rocm.txt && \
     /setup.packages.sh /devel.packages.txt && \
-    /setup.cuda.sh
+    /setup.rocm.sh
 
 # Install various tools.
 # - bats: bash unit testing framework

--- a/tensorflow/tools/tf_sig_build_dockerfiles/README.md
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/README.md
@@ -42,9 +42,15 @@ workflow deploys the containers to Docker Hub.
 To rebuild the containers locally after making changes, use this command from
 this directory:
 
+For CUDA
 ```bash
 DOCKER_BUILDKIT=1 docker build \
   --build-arg PYTHON_VERSION=python3.9 --target=devel -t my-tf-devel .
+```
+For ROCM
+```
+DOCKER_BUILDKIT=1 docker build -f Dockerfile.rocm \
+  --build-arg ROCM_VERSION=5.4.0 --build-arg PYTHON_VERSION=python3.9 -t my-tf-devel .
 ```
 
 It will take a long time to build devtoolset and install CUDA packages. After
@@ -98,17 +104,34 @@ Now let's build `tf-nightly`.
    Hub](https://hub.docker.com/r/tensorflow/build/tags). The options for the
    `master` branch are:
 
+For CUDA
+
     - `tensorflow/build:latest-python3.11`
     - `tensorflow/build:latest-python3.10`
     - `tensorflow/build:latest-python3.9`
     - `tensorflow/build:latest-python3.8`
 
+For ROCM
+
+    - `rocm/tensorflow-build:latest-python3.11`
+    - `rocm/tensorflow-build:latest-python3.10`
+    - `rocm/tensorflow-build:latest-python3.9`
+    - `rocm/tensorflow-build:latest-python3.8`
+
     For this example we'll use `tensorflow/build:latest-python3.9`.
 
 3. Pull the container you decided to use.
 
+For CUDA
+
     ```bash
     docker pull tensorflow/build:latest-python3.9
+    ```
+
+For ROCM
+
+    ```bash
+    docker pull rocm/tensorflow-build:latest-python3.9
     ```
 
 4. Start a backgrounded Docker container with the three folders mounted.
@@ -129,6 +152,7 @@ Now let's build `tf-nightly`.
 
     And `-v` is for mounting directories into the container.
 
+    For CUDA
     ```bash
     docker run --name tf -w /tf/tensorflow -it -d \
       -v "/tmp/packages:/tf/pkg" \
@@ -136,6 +160,18 @@ Now let's build `tf-nightly`.
       -v "/tmp/bazelcache:/tf/cache" \
       tensorflow/build:latest-python3.9 \
       bash
+    ```
+
+    For ROCM
+    ```
+    docker run --name tf -w /tf/tensorflow -it -d --network=host \
+    --device=/dev/kfd --device=/dev/dri \
+    --ipc=host --shm-size 16G --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+    -v "/tmp/packages:/tf/pkg" \
+    -v "/tmp/tensorflow:/tf/tensorflow" \
+    -v "/tmp/bazelcache:/tf/cache" \
+    rocm/tensorflow-build:latest-python3.9 \
+    bash
     ```
 
     Note: if you wish to use your own Google Cloud Platform credentials for
@@ -201,7 +237,7 @@ Now you can continue on to any of:
 
     ```
     docker exec tf bazel --bazelrc=/usertools/gpu.bazelrc \
-    build --config=sigbuild_remote_cache \
+    build --config=sigbuild_remote_cache --config=cuda \
     tensorflow/tools/pip_package:build_pip_package
     ```
 
@@ -244,12 +280,13 @@ Now you can continue on to any of:
 
     Make sure you have a directory mounted to the container in `/tf/cache`!
 
-    Build the sources with Bazel:
+    For CUDA:
+    Build the sources with Bazel and the cuda config:
 
     ```
     docker exec tf \
     bazel --bazelrc=/usertools/gpu.bazelrc \
-    build --config=sigbuild_local_cache \
+    build --config=sigbuild_local_cache --config=cuda \
     tensorflow/tools/pip_package:build_pip_package
     ```
 
@@ -262,13 +299,52 @@ Now you can continue on to any of:
       --nightly_flag
     ```
 
+    For ROCM:
+
+    Build the sources with Bazel and the rocm config:
+
+    ```
+    docker exec tf \
+    bazel --bazelrc=/usertools/gpu.bazelrc \
+    build --config=sigbuild_local_cache --config=rocm \
+    tensorflow/tools/pip_package:build_pip_package --verbose_failures
+
+    ```
+
+    And then construct the nightly pip package:
+
+    ```
+    docker exec tf \
+	./bazel-bin/tensorflow/tools/pip_package/build_pip_package \
+	/tf/pkg \
+	--rocm \
+	--nightly_flag
+    ```
+
+    Note: if you are creating a release (non-nightly) pip package:
+    ```
+    docker exec tf \
+	./bazel-bin/tensorflow/tools/pip_package/build_pip_package \
+	/tf/pkg \
+	--rocm \
+	--project_name tensorflow_rocm
+    ```
+
     </details>
 
 3. Run the helper script that checks for manylinux compliance, renames the
    wheels, and then checks the size of the packages.
 
+    For CUDA
+
     ```
     docker exec tf /usertools/rename_and_verify_wheels.sh
+    ```
+
+    For ROCM
+
+    ```
+    docker exec tf /usertools/rename_and_verify_ROCM_wheels.sh
     ```
 
 4. Take a look at the new wheel packages you built! They may be owned by `root`

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.cuda.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.cuda.txt
@@ -1,0 +1,21 @@
+# All required CUDA packages
+cuda-command-line-tools-11-8
+cuda-cudart-dev-11-8
+cuda-nvcc-11-8
+cuda-cupti-11-8
+cuda-nvprune-11-8
+cuda-libraries-11-8
+cuda-libraries-dev-11-8
+libcufft-11-8
+libcurand-11-8
+libcusolver-dev-11-8
+libcusparse-dev-11-8
+libcublas-dev-11-8
+# CuDNN: https://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#ubuntu-network-installation
+libcudnn8-dev=8.6.0.163-1+cuda11.8
+libcudnn8=8.6.0.163-1+cuda11.8
+# TensorRT: See https://docs.nvidia.com/deeplearning/sdk/tensorrt-install-guide/index.html#maclearn-net-repo-install-rpm
+libnvinfer-plugin8=8.4.3-1+cuda11.6
+libnvinfer8=8.4.3-1+cuda11.6
+libnvinfer-dev=8.4.3-1+cuda11.6
+libnvinfer-plugin-dev=8.4.3-1+cuda11.6

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.rocm.txt
@@ -1,0 +1,18 @@
+# rocm packagaes
+libdrm-amdgpu
+rocm-dev
+miopen-hip
+miopen-hip-dev
+miopengemm
+rocblas
+rocblas-dev
+rocsolver-dev
+rocrand-dev
+rocfft-dev
+hipfft-dev
+hipblas-dev
+rocprim-dev
+hipcub-dev
+rccl-dev
+hipsparse-dev
+hipsolver-dev

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.txt
@@ -1,25 +1,3 @@
-# All required CUDA packages
-cuda-command-line-tools-11-8
-cuda-cudart-dev-11-8
-cuda-nvcc-11-8
-cuda-cupti-11-8
-cuda-nvprune-11-8
-cuda-libraries-11-8
-cuda-libraries-dev-11-8
-libcufft-11-8
-libcurand-11-8
-libcusolver-dev-11-8
-libcusparse-dev-11-8
-libcublas-dev-11-8
-# CuDNN: https://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#ubuntu-network-installation
-libcudnn8-dev=8.6.0.163-1+cuda11.8
-libcudnn8=8.6.0.163-1+cuda11.8
-# TensorRT: See https://docs.nvidia.com/deeplearning/sdk/tensorrt-install-guide/index.html#maclearn-net-repo-install-rpm
-libnvinfer-plugin8=8.4.3-1+cuda11.6
-libnvinfer8=8.4.3-1+cuda11.6
-libnvinfer-dev=8.4.3-1+cuda11.6
-libnvinfer-plugin-dev=8.4.3-1+cuda11.6
-
 # Other build-related tools
 apt-transport-https
 autoconf

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/gpu.bazelrc
@@ -37,29 +37,38 @@ build --copt=-mavx --host_copt=-mavx
 build --profile=/tf/pkg/profile.json.gz
 
 # CUDA: Set up compilation CUDA version and paths
-build --@local_config_cuda//:enable_cuda
-build --repo_env TF_NEED_CUDA=1
-build --action_env=TF_CUDA_VERSION="11"
-build --action_env=TF_CUDNN_VERSION="8"
-build --action_env=CUDA_TOOLKIT_PATH="/usr/local/cuda-11.8"
-build --action_env=GCC_HOST_COMPILER_PATH="/dt9/usr/bin/gcc"
-build --action_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/tensorrt/lib"
-build --crosstool_top="@sigbuild-r2.12_config_cuda//crosstool:toolchain"
+build:cuda --@local_config_cuda//:enable_cuda
+build:cuda --repo_env TF_NEED_CUDA=1
+build:cuda --action_env=TF_CUDA_VERSION="11"
+build:cuda --action_env=TF_CUDNN_VERSION="8"
+build:cuda --action_env=CUDA_TOOLKIT_PATH="/usr/local/cuda-11.8"
+build:cuda --action_env=GCC_HOST_COMPILER_PATH="/dt9/usr/bin/gcc"
+build:cuda --action_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/tensorrt/lib"
+build:cuda --crosstool_top="@sigbuild-r2.12_config_cuda//crosstool:toolchain"
 
 # CUDA: Enable TensorRT optimizations
 # https://developer.nvidia.com/tensorrt
-build --repo_env TF_NEED_TENSORRT=1
+build:cuda --repo_env TF_NEED_TENSORRT=1
 
 # CUDA: Select supported compute capabilities (supported graphics cards).
 # This is the same as the official TensorFlow builds.
 # See https://developer.nvidia.com/cuda-gpus#compute
 # TODO(angerson, perfinion): What does sm_ vs compute_ mean?
 # TODO(angerson, perfinion): How can users select a good value for this?
-build --repo_env=TF_CUDA_COMPUTE_CAPABILITIES="sm_35,sm_50,sm_60,sm_70,sm_75,compute_80"
+build:cuda --repo_env=TF_CUDA_COMPUTE_CAPABILITIES="sm_35,sm_50,sm_60,sm_70,sm_75,compute_80"
+
+# ROCM: Set up compilation ROCM version and paths
+build:rocm --crosstool_top=@local_config_rocm//crosstool:toolchain
+build:rocm --define=using_rocm_hipcc=true
+build:rocm --define=tensorflow_mkldnn_contraction_kernel=0
+build:rocm --repo_env TF_NEED_ROCM=1
+# Disable unused-result on rocm builds.
+build:rocm --copt="-Wno-error=unused-result"
 
 # Test-related settings below this point.
 test --build_tests_only --keep_going --test_output=errors --verbose_failures=true
-test --test_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+test:cuda --test_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64"
+test:rocm --test_env=HSA_TOOLS_LIB=libroctracer64.so
 # Local test jobs has to be 4 because parallel_gpu_execute is fragile, I think
 test --test_timeout=300,450,1200,3600 --local_test_jobs=4 --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute
 # Give only the list of failed tests at the end of the log

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rename_and_verify_ROCM_wheels.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rename_and_verify_ROCM_wheels.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Check and rename wheels manually since auditwheel repair currently isn't aware of
+# ROCM and will stip references from the binaries.
+# Only rename wheels that need it.
+set -euxo pipefail
+
+for wheel in /tf/pkg/*.whl; do
+  echo "Checking and renaming $wheel..."
+  if [[ "${wheel}" != *"manylinux"* ]]; then
+      NEW_TF_WHEEL=${wheel/linux/"manylinux2014"}
+      echo "Rename ${wheel} to ${NEW_TF_WHEEL}"
+      mv $wheel $NEW_TF_WHEEL
+  else
+      echo "${wheel} already renamed"
+      NEW_TF_WHEEL=${wheel}
+  fi
+
+  # Verify the wheel, but only if it matches the current verison of python
+  PYTRIM=$( \
+          python3 --version | \
+          awk '{print$2}' | \
+          cut -d "." -f1,2 | \
+	  tr -d ".")
+  if [[ "${NEW_TF_WHEEL}" == *"cp${PYTRIM}"* ]]; then
+      CURRENT_PY_VERS=`python3 --version`
+      echo "Verifying $NEW_TF_WHEEL for ${CURRENT_PY_VERS%.*} ..."
+      TF_WHEEL="$NEW_TF_WHEEL" bats /usertools/wheel_verification.bats --timing
+  fi
+done

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.usertools/rocm.bazelrc
@@ -1,0 +1,1 @@
+gpu.bazelrc

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
@@ -33,13 +33,13 @@ else
 fi
 
 # Use devtoolset env
-export PATH=/opt/rh/devtoolset-10/root/usr/bin:${ROCM_PATH}/llvm/bin:${ROCM_PATH}/hip/bin:${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:${PATH:+:${PATH}}
-export MANPATH=/opt/rh/devtoolset-10/root/usr/share/man:${MANPATH}
-export INFOPATH=/opt/rh/devtoolset-10/root/usr/share/info${INFOPATH:+:${INFOPATH}}
-export PCP_DIR=/opt/rh/devtoolset-10/root
-export PERL5LIB=/opt/rh/devtoolset-10/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-10/root/usr/lib/perl5:/opt/rh/devtoolset-10/root//usr/share/perl5/
-export LD_LIBRARY_PATH=${ROCM_PATH}/lib:/usr/local/lib:/opt/rh/devtoolset-10/root$rpmlibdir$rpmlibdir32${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-export LDFLAGS="-Wl,-rpath=/opt/rh/devtoolset-10/root/usr/lib64 -Wl,-rpath=/opt/rh/devtoolset-10/root/usr/lib"
+export PATH=/opt/rh/devtoolset-9/root/usr/bin:${ROCM_PATH}/llvm/bin:${ROCM_PATH}/hip/bin:${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:${PATH:+:${PATH}}
+export MANPATH=/opt/rh/devtoolset-9/root/usr/share/man:${MANPATH}
+export INFOPATH=/opt/rh/devtoolset-9/root/usr/share/info${INFOPATH:+:${INFOPATH}}
+export PCP_DIR=/opt/rh/devtoolset-9/root
+export PERL5LIB=/opt/rh/devtoolset-9/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-9/root/usr/lib/perl5:/opt/rh/devtoolset-9/root//usr/share/perl5/
+export LD_LIBRARY_PATH=${ROCM_PATH}/lib:/usr/local/lib:/opt/rh/devtoolset-9/root$rpmlibdir$rpmlibdir32${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+export LDFLAGS="-Wl,-rpath=/opt/rh/devtoolset-9/root/usr/lib64 -Wl,-rpath=/opt/rh/devtoolset-9/root/usr/lib"
 GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS:-"gfx900 gfx906 gfx908 gfx90a gfx1030"}
 
 echo $ROCM_VERSION
@@ -48,7 +48,7 @@ echo $ROCM_PATH
 echo $GPU_DEVICE_TARGETS
 
 # install rocm
-/setup.packages.rocm.cs7.sh /devel.packages.rocm.cs7.txt
+/setup.packages.sh /devel.packages.rocm.txt
 
 # Ensure the ROCm target list is set up
 printf '%s\n' ${GPU_DEVICE_TARGETS} | tee -a "$ROCM_PATH/bin/target.lst"

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.rocm.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# setup.rocm.sh: Prepare the ROCM installation on the container.
+# Usage: setup.rocm.sh <ROCM_VERSION>
+set -x
+
+# # Add the ROCm package repo location
+ROCM_VERSION=$1 # e.g. 5.2.0
+ROCM_PATH=${ROCM_PATH:-/opt/rocm-${ROCM_VERSION}}
+
+if [ ! -f "/${CUSTOM_INSTALL}" ]; then
+ROCM_VERSION_REPO=$(echo $ROCM_VERSION | grep -o "\w.\w") # e.g 5.2
+RPM_ROCM_REPO=http://repo.radeon.com/rocm/yum/$(echo $ROCM_VERSION | grep -o "\w.\w")/main
+echo -e "[ROCm]\nname=ROCm\nbaseurl=$RPM_ROCM_REPO\nenabled=1\ngpgcheck=0" >>/etc/yum.repos.d/rocm.repo
+echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/latest/rhel/7.9/main/x86_64/\nenabled=1\ngpgcheck=0" >>/etc/yum.repos.d/amdgpu.repo
+else
+    bash "/${CUSTOM_INSTALL}"
+fi
+
+# Use devtoolset env
+export PATH=/opt/rh/devtoolset-10/root/usr/bin:${ROCM_PATH}/llvm/bin:${ROCM_PATH}/hip/bin:${ROCM_PATH}/bin:${ROCM_PATH}/llvm/bin:${PATH:+:${PATH}}
+export MANPATH=/opt/rh/devtoolset-10/root/usr/share/man:${MANPATH}
+export INFOPATH=/opt/rh/devtoolset-10/root/usr/share/info${INFOPATH:+:${INFOPATH}}
+export PCP_DIR=/opt/rh/devtoolset-10/root
+export PERL5LIB=/opt/rh/devtoolset-10/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-10/root/usr/lib/perl5:/opt/rh/devtoolset-10/root//usr/share/perl5/
+export LD_LIBRARY_PATH=${ROCM_PATH}/lib:/usr/local/lib:/opt/rh/devtoolset-10/root$rpmlibdir$rpmlibdir32${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+export LDFLAGS="-Wl,-rpath=/opt/rh/devtoolset-10/root/usr/lib64 -Wl,-rpath=/opt/rh/devtoolset-10/root/usr/lib"
+GPU_DEVICE_TARGETS=${GPU_DEVICE_TARGETS:-"gfx900 gfx906 gfx908 gfx90a gfx1030"}
+
+echo $ROCM_VERSION
+echo $ROCM_REPO
+echo $ROCM_PATH
+echo $GPU_DEVICE_TARGETS
+
+# install rocm
+/setup.packages.rocm.cs7.sh /devel.packages.rocm.cs7.txt
+
+# Ensure the ROCm target list is set up
+printf '%s\n' ${GPU_DEVICE_TARGETS} | tee -a "$ROCM_PATH/bin/target.lst"
+touch "${ROCM_PATH}/.info/version"
+

--- a/tensorflow/tools/tf_sig_build_dockerfiles/setup.sources.sh
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/setup.sources.sh
@@ -16,9 +16,10 @@
 # ==============================================================================
 #
 # setup.python.sh: Install a specific Python version and packages for it.
-# Usage: setup.python.sh <pyversion> <requirements.txt>
+# Usage: setup.sources.sh <GPU_platform>
 
 # Sets up custom apt sources for our TF images.
+GPU_PLATFORM=$1
 
 # Prevent apt install tzinfo from asking our location (assumes UTC)
 export DEBIAN_FRONTEND=noninteractive
@@ -30,19 +31,11 @@ apt-get install -y gnupg ca-certificates
 # Deadsnakes: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776
 
-# Explicitly request Nvidia repo keys
-# See: https://forums.developer.nvidia.com/t/invalid-public-key-for-cuda-apt-repository/212901/11
-apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
-apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
-
 # LLVM/Clang: https://apt.llvm.org/
 apt-key adv --fetch-keys https://apt.llvm.org/llvm-snapshot.gpg.key
 
 # Set up custom sources
 cat >/etc/apt/sources.list.d/custom.list <<SOURCES
-# Nvidia CUDA packages: 18.04 has more available than 20.04, and we use those
-deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /
-
 # More Python versions: Deadsnakes
 deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main
 deb-src http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main
@@ -51,3 +44,18 @@ deb-src http://ppa.launchpad.net/deadsnakes/ppa/ubuntu focal main
 deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main
 deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main
 SOURCES
+
+if [ $GPU_PLATFORM == "ROCM" ]; then
+    # No additional repos to set up for ROCM.
+else
+    # Explicitly request Nvidia repo keys
+    # See: https://forums.developer.nvidia.com/t/invalid-public-key-for-cuda-apt-repository/212901/11
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+
+    cat >/etc/apt/sources.list.d/custom.list <<SOURCES
+
+    # Nvidia CUDA packages: 18.04 has more available than 20.04, and we use those
+    deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /
+SOURCES
+fi


### PR DESCRIPTION
This PR adds ROCM support to the tensorflow-build container framework.
The idea is to slot ROCM along side the CUDA container in an unobtrusive way. 
The only change on the CUDA side will be needing to explicitly set the --config=cuda for the bazel build command, which is probably more proper anyway and matches the main .bazelrc.

Setting this as draft so I can to do more testing on the CUDA side to make sure I didn't break anything

FYI @angerson 
I'm interested in your thoughts here. thx!