### PR TITLE
Fix endianness issues in arithmetic_optimizer_test.cc tests

### DIFF
--- a/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
+++ b/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
@@ -161,6 +161,11 @@ absl::Status ByteSwapTensor(Tensor* t) {
                         t->NumElements());
 }
 
+absl::Status ByteSwapTensorProto(TensorProto* tp) {
+  char* buff = const_cast<char*>((tp->tensor_content().data()));
+  return ByteSwapBuffer(buff, tp->tensor_content().size(), tp->dtype(), -1);
+}
+
 absl::Status ByteSwapTensorContentInNode(NodeDef& node) {
   if (node.op() == "Const") {
     auto node_iterator = node.mutable_attr()->find("value");

--- a/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
+++ b/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
@@ -162,8 +162,11 @@ absl::Status ByteSwapTensor(Tensor* t) {
 }
 
 absl::Status ByteSwapTensorProto(TensorProto* tp) {
-  char* buff = const_cast<char*>((tp->tensor_content().data()));
-  return ByteSwapBuffer(buff, tp->tensor_content().size(), tp->dtype(), -1);
+  char* buff = const_cast<char*>(std::string(tp->tensor_content()).data());
+  auto content_size = tp->tensor_content().size();
+  TF_RETURN_IF_ERROR(ByteSwapBuffer(buff, content_size, tp->dtype(), -1));
+  tp->set_tensor_content(std::string(std::move(buff), content_size));
+  return absl::OkStatus();
 }
 
 absl::Status ByteSwapTensorContentInNode(NodeDef& node) {

--- a/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
+++ b/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
@@ -162,10 +162,10 @@ absl::Status ByteSwapTensor(Tensor* t) {
 }
 
 absl::Status ByteSwapTensorProto(TensorProto* tp) {
-  char* buff = const_cast<char*>(std::string(tp->tensor_content()).data());
-  auto content_size = tp->tensor_content().size();
-  TF_RETURN_IF_ERROR(ByteSwapBuffer(buff, content_size, tp->dtype(), -1));
-  tp->set_tensor_content(std::string(std::move(buff), content_size));
+  std:string content_str = std::string(tp->tensor_content());
+  char* buff = const_cast<char*>(content_str.data());
+  TF_RETURN_IF_ERROR(ByteSwapBuffer(buff, content_str.size(), tp->dtype(), -1));
+  tp->set_tensor_content(content_str);
   return absl::OkStatus();
 }
 

--- a/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
+++ b/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
@@ -162,7 +162,7 @@ absl::Status ByteSwapTensor(Tensor* t) {
 }
 
 absl::Status ByteSwapTensorProto(TensorProto* tp) {
-  std:string content_str = std::string(tp->tensor_content());
+  std::string content_str = std::string(tp->tensor_content());
   char* buff = const_cast<char*>(content_str.data());
   TF_RETURN_IF_ERROR(ByteSwapBuffer(buff, content_str.size(), tp->dtype(), -1));
   tp->set_tensor_content(content_str);

--- a/tensorflow/core/util/tensor_bundle/byte_swap_tensor.h
+++ b/tensorflow/core/util/tensor_bundle/byte_swap_tensor.h
@@ -36,6 +36,13 @@ bool IsByteSwappable(DataType dtype);
 // TODO(frreiss): Should this be a member of the Tensor class?
 absl::Status ByteSwapTensor(Tensor* t);
 
+// Byte-swap a tensor proto's backing buffer in place.
+//
+// Args:
+//  t: TensorProto to be modified IN PLACE.
+// Returns: OkStatus() on success, -1 otherwise
+absl::Status ByteSwapTensorProto(TensorProto *tp);
+
 // Swap tensor_content field of Const Op Tensors in the named functions
 // in NodeDef
 absl::Status ByteSwapTensorContentInNode(NodeDef& node);


### PR DESCRIPTION
Some tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc tests check for expected tensor content values that are in little-endian format. This commit adds supporting functions so that big-endian platforms will convert to little-endian before checking.