### PR TITLE
use list intialization for AsynSubgraph::next_buffer_handle_

### DIFF
--- a/tensorflow/lite/core/async/async_subgraph.h
+++ b/tensorflow/lite/core/async/async_subgraph.h
@@ -162,7 +162,7 @@ class AsyncSubgraph {
   Subgraph* subgraph_ = nullptr;
 
   // Next buffer handle to assign in Register* calls.
-  std::atomic<TfLiteBufferHandle> next_buffer_handle_ = 0;
+  std::atomic<TfLiteBufferHandle> next_buffer_handle_ = {0};
 
   // Supported buffer and sync types.
   std::map<TfLiteIoType, std::vector<const char*>> supported_buffer_types_;


### PR DESCRIPTION
List intialization fixes error of `copying member subobject of type 'std::atomic<TfLiteBufferHandle>' (aka 'atomic<int>') invokes deleted constructor` at `std::atomic<TfLiteBufferHandle> next_buffer_handle_ = 0;` at `tensorflow/lite/core/async/async_subgraph.h` line:165