### PR TITLE
Fix the image recognition tutorial links in README.md

### DIFF
--- a/tensorflow/examples/label_image/README.md
+++ b/tensorflow/examples/label_image/README.md
@@ -63,14 +63,14 @@ $ bazel-bin/tensorflow/examples/label_image/label_image --image=my_image.png
 ```
 
 For a more detailed look at this code, you can check out the C++ section of the
-[Inception tutorial](https://www.tensorflow.org/tutorials/image_recognition/).
+[Inception tutorial](https://github.com/tensorflow/docs/blob/master/site/en/r1/tutorials/images/image_recognition.md).
 
 ## Python implementation
 
 label_image.py is a python implementation that provides code corresponding
 to the C++ code here. This gives more intuitive mapping between C++ and
 Python than the Python code mentioned in the
-[Inception tutorial](https://www.tensorflow.org/tutorials/image_recognition/).
+[Inception tutorial](https://github.com/tensorflow/docs/blob/master/site/en/r1/tutorials/images/image_recognition.md).
 and could be easier to add visualization or debug code.
 
 


### PR DESCRIPTION
The links for inception tutorial are broken. Updated them to right links that point to 1.x image recognition tutorial. Please do the needful.