### PR TITLE
[Linaro:ARM_CI] Fix bad interpreter from update_version.py

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.cpu.arm64
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu.arm64
@@ -6,7 +6,8 @@ ENV TF_PYTHON_VERSION=python${py_major_minor_version}
 ENV PYTHON_BIN_PATH=/usr/bin/${TF_PYTHON_VERSION}
 
 RUN ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python && \
-    ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python3
+    ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python3 && \
+    ln -s ${PYTHON_BIN_PATH} /usr/bin/python
 
 RUN ${PYTHON_BIN_PATH} -m pip install packaging
 


### PR DESCRIPTION
update_version.py expects there to be a valid Python interpreter that can be used as /usr/bin/python so ensure that this path exists as a link to a valid binary