### PR TITLE
r2.12 cherry-pick: [INTEL oneDNN][Bug Fix] Add index-validity check for min-max tensors for quantized oneDNN ops and related tests #59581

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
@@ -161,13 +161,13 @@ class MklAvgPoolingOp : public MklPoolingForwardOpBase<T> {
                                   output_min_mkl_shape, this->native_format_);
         AllocateOutputSetMklShape(context, 2, &output_max, {},
                                   output_max_mkl_shape, this->native_format_);
-        output_min->flat<float>()(0) = min_input;
-        output_max->flat<float>()(0) = max_input;
+        output_min->scalar<float>()() = min_input;
+        output_max->scalar<float>()() = max_input;
       }
     } catch (dnnl::error& e) {
-      string error_msg = "Status: " + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ", in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ", in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(
           context,
           errors::Aborted("Operation received an exception:", error_msg));
@@ -230,9 +230,10 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       memory::dims orig_input_dims_mkl_order =
           orig_input_mkl_shape.IsMklTensor()
               ? orig_input_mkl_shape.GetSizesAsMklDnnDims()
-          : is_pool2d
-              ? TFShapeToMklDnnDimsInNCHW(output_shape, this->data_format_tf_)
-              : TFShapeToMklDnnDimsInNCDHW(output_shape, this->data_format_tf_);
+              : is_pool2d ? TFShapeToMklDnnDimsInNCHW(output_shape,
+                                                      this->data_format_tf_)
+                          : TFShapeToMklDnnDimsInNCDHW(output_shape,
+                                                       this->data_format_tf_);
 
       memory::dims diff_dst_dims =
           grad_mkl_shape.IsMklTensor()
@@ -297,9 +298,9 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       pooling_bwd->Execute(diff_dst_data, diff_src_data, nullptr,
                            bwd_cpu_stream);
     } catch (dnnl::error& e) {
-      string error_msg = "Status: " + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ", in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ", in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(context, errors::Aborted("Compute received an exception:",
                                               error_msg));
     }

--- a/tensorflow/core/kernels/mkl/mkl_concat_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_concat_op.cc
@@ -17,7 +17,6 @@ limitations under the License.
 #include <unordered_map>
 #include <vector>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "dnnl.hpp"
 #include "tensorflow/core/framework/bounds_check.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -32,6 +31,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/mkl_util.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #ifdef DNNL_AARCH64_USE_ACL
 #include "tensorflow/core/platform/mutex.h"
 #endif
@@ -108,8 +108,8 @@ class EigenConcatBaseOp : public OpKernel {
     float overall_min = std::numeric_limits<float>::max();
     float overall_max = std::numeric_limits<float>::lowest();
     for (int i = 0; i < N; ++i) {
-      const float input_min = input_mins[i].flat<float>()(0);
-      const float input_max = input_maxes[i].flat<float>()(0);
+      const float input_min = input_mins[i].scalar<float>()();
+      const float input_max = input_maxes[i].scalar<float>()();
       input_mins_and_maxes->emplace_back(input_min, input_max);
       overall_min = std::min(overall_min, input_min);
       overall_max = std::max(overall_max, input_max);
@@ -187,13 +187,12 @@ class EigenConcatBaseOp : public OpKernel {
       const auto in = values[i];
       const bool in_is_scalar = TensorShapeUtils::IsScalar(input_shapes[i]);
       OP_REQUIRES(
-          c,
-          (input_shapes[i].dims() == input_dims) ||
-              (input_is_scalar && in_is_scalar),
+          c, (input_shapes[i].dims() == input_dims) ||
+                 (input_is_scalar && in_is_scalar),
           errors::InvalidArgument(
               "ConcatOp : Ranks of all input tensors should match: shape[0] = ",
-              input_shape.DebugString(), " vs. shape[", i,
-              "] = ", input_shapes[i].DebugString()));
+              input_shape.DebugString(), " vs. shape[", i, "] = ",
+              input_shapes[i].DebugString()));
       if (in.NumElements() > 0) {
         int64 inputs_flat_dim1 = in.NumElements() / inputs_flat_dim0;
         inputs_flat.emplace_back(new typename TTypes<T, 2>::ConstMatrix(
@@ -227,11 +226,11 @@ class EigenConcatBaseOp : public OpKernel {
     if (quantized_input) {
       Tensor* output_min_tensor = nullptr;
       OP_REQUIRES_OK(c, c->allocate_output(1, {}, &output_min_tensor));
-      output_min_tensor->flat<float>()(0) = output_min;
+      output_min_tensor->scalar<float>()() = output_min;
 
       Tensor* output_max_tensor = nullptr;
       OP_REQUIRES_OK(c, c->allocate_output(2, {}, &output_max_tensor));
-      output_max_tensor->flat<float>()(0) = output_max;
+      output_max_tensor->scalar<float>()() = output_max;
     }
   }
 };
@@ -568,12 +567,25 @@ class MklConcatOp : public OpKernel {
                     errors::InvalidArgument(
                         "QuantizedConcatOp : Expected maxes input list length ",
                         input_maxes.size(), " to equal values length ", N));
-        float input_min = input_mins[0].flat<float>()(0);
-        float input_max = input_maxes[0].flat<float>()(0);
+
+        for (int i = 0; i < N; i++) {
+          OP_REQUIRES(context,
+                      TensorShapeUtils::IsScalar(input_mins[i].shape()),
+                      errors::InvalidArgument("`input_mins[", i,
+                                              "]` must be rank 0 but is rank ",
+                                              input_mins[i].dims()));
+          OP_REQUIRES(context,
+                      TensorShapeUtils::IsScalar(input_maxes[i].shape()),
+                      errors::InvalidArgument("`input_maxes[", i,
+                                              "]` must be rank 0 but is rank ",
+                                              input_maxes[i].dims()));
+        }
+        float input_min = input_mins[0].scalar<float>()();
+        float input_max = input_maxes[0].scalar<float>()();
         const float eps = 1.0e-6;
         for (int i = 1; i < N; ++i) {
-          float min = input_mins[i].flat<float>()(0);
-          float max = input_maxes[i].flat<float>()(0);
+          float min = input_mins[i].scalar<float>()();
+          float max = input_maxes[i].scalar<float>()();
 
           if (fabs(input_min - min) > eps || fabs(input_max - max) > eps) {
             invoke_eigen = true;
@@ -805,8 +817,8 @@ class MklConcatOp : public OpKernel {
                                     output_max_mkl_shape, native_format);
           // All input tensors should have the same range, just use the
           // first one
-          output_min->flat<float>()(0) = input_mins[0].flat<float>()(0);
-          output_max->flat<float>()(0) = input_maxes[0].flat<float>()(0);
+          output_min->scalar<float>()() = input_mins[0].scalar<float>()();
+          output_max->scalar<float>()() = input_maxes[0].scalar<float>()();
         }
       } else {
         MklDnnShape dnn_shape_dst;

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -1845,11 +1845,10 @@ class MklQuantizedConvOp
               /*native_format*/ true>::Compute(context);
 
     // Compute additional outputs: min/max scalars.
-
     const float min_input =
-        context->input(min_input_idx_).template flat<float>()(0);
+        context->input(min_input_idx_).template scalar<float>()();
     const float max_input =
-        context->input(max_input_idx_).template flat<float>()(0);
+        context->input(max_input_idx_).template scalar<float>()();
 
     Tensor* output_min = nullptr;
     Tensor* output_max = nullptr;
@@ -1859,9 +1858,9 @@ class MklQuantizedConvOp
       OP_REQUIRES_OK(context, context->allocate_output(2, {}, &output_max));
       // This is the case the convolution and requantization are fused.
       output_min->flat<float>()(0) =
-          context->input(min_freezed_output_idx_).template flat<float>()(0);
+          context->input(min_freezed_output_idx_).template scalar<float>()();
       output_max->flat<float>()(0) =
-          context->input(max_freezed_output_idx_).template flat<float>()(0);
+          context->input(max_freezed_output_idx_).template scalar<float>()();
     } else {
       const Tensor& min_filter = context->input(min_filter_idx_);
       const Tensor& max_filter = context->input(max_filter_idx_);
@@ -1869,8 +1868,8 @@ class MklQuantizedConvOp
         float min_output_value;
         float max_output_value;
         MklQuantizationRangeForMultiplication<Tinput, qint8, qint32>(
-            min_input, max_input, min_filter.flat<float>()(0),
-            max_filter.flat<float>()(0), &min_output_value, &max_output_value);
+            min_input, max_input, min_filter.scalar<float>()(),
+            max_filter.scalar<float>()(), &min_output_value, &max_output_value);
         OP_REQUIRES_OK(context, context->allocate_output(1, {}, &output_min));
         OP_REQUIRES_OK(context, context->allocate_output(2, {}, &output_max));
         output_min->flat<float>()(0) = min_output_value;
@@ -1903,18 +1902,25 @@ class MklQuantizedConvOp
     if (std::is_same<Toutput, quint8>::value ||
         std::is_same<Toutput, qint8>::value) {
       const float min_input =
-          context->input(min_input_idx_).template flat<float>()(0);
+          context->input(min_input_idx_).template scalar<float>()(0);
       const float max_input =
-          context->input(max_input_idx_).template flat<float>()(0);
+          context->input(max_input_idx_).template scalar<float>()(0);
       const Tensor& min_filter_vector = context->input(min_filter_idx_);
       const Tensor& max_filter_vector = context->input(max_filter_idx_);
+      OP_REQUIRES(
+          context,
+          ((min_filter_vector.NumElements() > 0) &&
+           (max_filter_vector.NumElements() > 0) &&
+           (min_filter_vector.shape() == max_filter_vector.shape())),
+          errors::InvalidArgument("`min_ and max_filter` must have same"
+                                  "shape and contain at least one element."));
 
       // min_freezed_output and max_freezed_output are the actual range
       // for the output.
       const float min_freezed_output =
-          context->input(min_freezed_output_idx_).template flat<float>()(0);
+          context->input(min_freezed_output_idx_).template scalar<float>()();
       const float max_freezed_output =
-          context->input(max_freezed_output_idx_).template flat<float>()(0);
+          context->input(max_freezed_output_idx_).template scalar<float>()();
 
       float int_output_limit =
           std::is_same<Toutput, quint8>::value ? 255.0f : 127.0f;
@@ -1959,14 +1965,47 @@ class MklQuantizedConvOp
         bool summand_condition =
             (summand_dt == DT_QINT8) || (summand_dt == DT_QUINT8);
         DCHECK((summand_condition));
+
+        const Tensor& min_freezed_output_tensor =
+            context->input(min_freezed_output_idx_);
+        const Tensor& max_freezed_output_tensor =
+            context->input(max_freezed_output_idx_);
+        OP_REQUIRES(
+            context,
+            TensorShapeUtils::IsScalar(min_freezed_output_tensor.shape()),
+            errors::InvalidArgument(
+                "`min_freezed_output` must be rank 0 but is rank ",
+                min_freezed_output_tensor.dims()));
+        OP_REQUIRES(
+            context,
+            TensorShapeUtils::IsScalar(max_freezed_output_tensor.shape()),
+            errors::InvalidArgument(
+                "`max_freezed_output` must be rank 0 but is rank ",
+                max_freezed_output_tensor.dims()));
+        const Tensor& min_freezed_summand_tensor =
+            context->input(min_summand_idx_);
+        const Tensor& max_freezed_summand_tensor =
+            context->input(max_summand_idx_);
+        OP_REQUIRES(
+            context,
+            TensorShapeUtils::IsScalar(min_freezed_summand_tensor.shape()),
+            errors::InvalidArgument(
+                "`min_freezed_summand` must be rank 0 but is rank ",
+                min_freezed_summand_tensor.dims()));
+        OP_REQUIRES(
+            context,
+            TensorShapeUtils::IsScalar(max_freezed_summand_tensor.shape()),
+            errors::InvalidArgument(
+                "`max_freezed_summand` must be rank 0 but is rank ",
+                max_freezed_summand_tensor.dims()));
         const float min_freezed_output =
-            context->input(min_freezed_output_idx_).template flat<float>()(0);
+            min_freezed_output_tensor.template scalar<float>()();
         const float max_freezed_output =
-            context->input(max_freezed_output_idx_).template flat<float>()(0);
+            max_freezed_output_tensor.template scalar<float>()();
         const float min_freezed_summand =
-            context->input(min_summand_idx_).template flat<float>()(0);
+            min_freezed_summand_tensor.template scalar<float>()();
         const float max_freezed_summand =
-            context->input(max_summand_idx_).template flat<float>()(0);
+            max_freezed_summand_tensor.template scalar<float>()();
 
         float output_range = std::max(std::abs(min_freezed_output),
                                       std::abs(max_freezed_output));
@@ -2052,9 +2091,9 @@ class MklQuantizedConvOp
                            "Current fusion requires summand to be float"));
       // We need to compute scale for the summand
       const float min_input =
-          context->input(min_input_idx_).template flat<float>()(0);
+          context->input(min_input_idx_).template scalar<float>()();
       const float max_input =
-          context->input(max_input_idx_).template flat<float>()(0);
+          context->input(max_input_idx_).template scalar<float>()();
       const Tensor& min_filter_vector = context->input(min_filter_idx_);
       const Tensor& max_filter_vector = context->input(max_filter_idx_);
       const float* min_filter = min_filter_vector.flat<float>().data();
@@ -2105,9 +2144,9 @@ class MklQuantizedConvOp
     }
 
     const float min_input =
-        context->input(min_input_idx_).template flat<float>()(0);
+        context->input(min_input_idx_).template scalar<float>()();
     const float max_input =
-        context->input(max_input_idx_).template flat<float>()(0);
+        context->input(max_input_idx_).template scalar<float>()();
     const Tensor& min_filter_vector = context->input(min_filter_idx_);
     const Tensor& max_filter_vector = context->input(max_filter_idx_);
     const float* min_filter = min_filter_vector.flat<float>().data();

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -1902,9 +1902,9 @@ class MklQuantizedConvOp
     if (std::is_same<Toutput, quint8>::value ||
         std::is_same<Toutput, qint8>::value) {
       const float min_input =
-          context->input(min_input_idx_).template scalar<float>()(0);
+          context->input(min_input_idx_).template scalar<float>()();
       const float max_input =
-          context->input(max_input_idx_).template scalar<float>()(0);
+          context->input(max_input_idx_).template scalar<float>()();
       const Tensor& min_filter_vector = context->input(min_filter_idx_);
       const Tensor& max_filter_vector = context->input(max_filter_idx_);
       OP_REQUIRES(

--- a/tensorflow/core/kernels/mkl/mkl_dequantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_dequantize_op.cc
@@ -56,8 +56,8 @@ class MklDequantizeOp : public OpKernel {
 
       // Get the inputs
       const Tensor& src_tensor = ctx->input(kSrcIndex);
-      const float min_range = ctx->input(kMinIndex).template flat<float>()(0);
-      const float max_range = ctx->input(kMaxIndex).template flat<float>()(0);
+      const float min_range = ctx->input(kMinIndex).template scalar<float>()();
+      const float max_range = ctx->input(kMaxIndex).template scalar<float>()();
 
       // Get MklShape
       auto src_tf_shape = src_tensor.shape();

--- a/tensorflow/core/kernels/mkl/mkl_dequantize_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_dequantize_op_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL)
+#if defined(INTEL_MKL) && defined(ENABLE_MKL)
 
 #include "tensorflow/core/framework/fake_input.h"
 #include "tensorflow/core/framework/node_def_builder.h"
@@ -96,4 +96,4 @@ TEST_F(MklDequantizeOpTest, MKLInput) {
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL
+#endif  // INTEL_MKL && ENABLE_MKL

--- a/tensorflow/core/kernels/mkl/mkl_dequantize_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_dequantize_op_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL)
 
 #include "tensorflow/core/framework/fake_input.h"
 #include "tensorflow/core/framework/node_def_builder.h"
@@ -42,9 +42,9 @@ TEST_F(MklDequantizeOpTest, small) {
   AddInputFromArray<quint8>(TensorShape({1, 2, 2, 2}),
                             {0, 10, 50, 40, 25, 115, 190, 255});
   // min_range = 0
-  AddInputFromArray<float>(TensorShape({1}), {0});
+  AddInputFromArray<float>(TensorShape({}), {0});
   // max_range = 200
-  AddInputFromArray<float>(TensorShape({1}), {200.0f});
+  AddInputFromArray<float>(TensorShape({}), {200.0f});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_FLOAT, TensorShape({1, 2, 2, 2}));
   test::FillValues<float>(&expected,
@@ -84,9 +84,9 @@ TEST_F(MklDequantizeOpTest, MKLInput) {
   AddInputFromArray<quint8>(TensorShape({1, 2, 2, 2}),
                             {0, 10, 50, 40, 25, 115, 190, 255});
   // min_range = 0
-  AddInputFromArray<float>(TensorShape({1}), {0});
+  AddInputFromArray<float>(TensorShape({}), {0});
   // max_range = 200
-  AddInputFromArray<float>(TensorShape({1}), {200.0f});
+  AddInputFromArray<float>(TensorShape({}), {200.0f});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_FLOAT, TensorShape({1, 2, 2, 2}));
   test::FillValues<float>(&expected,
@@ -96,4 +96,4 @@ TEST_F(MklDequantizeOpTest, MKLInput) {
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && ENABLE_MKL
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
@@ -180,8 +180,8 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
                                   output_min_mkl_shape, this->native_format_);
         AllocateOutputSetMklShape(context, 2, &output_max, {},
                                   output_max_mkl_shape, this->native_format_);
-        output_min->flat<float>()(0) = min_input;
-        output_max->flat<float>()(0) = max_input;
+        output_min->scalar<float>()() = min_input;
+        output_max->scalar<float>()() = max_input;
       } else {
         MklDnnData<uint8> dnn_data_wksp(&cpu_engine_);
         AllocateWorkspaceTensor(context, *(pooling_fwd->GetPoolingFwdPd()),
@@ -193,9 +193,9 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
         pooling_fwd->Execute(src_data, dst_data, ws_data, fwd_cpu_stream);
       }
     } catch (dnnl::error& e) {
-      string error_msg = "Status: " + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ", in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status: " + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ", in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(context, errors::Aborted("Compute received an exception:",
                                               error_msg));
     }
@@ -356,9 +356,9 @@ class MklMaxPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       pooling_bwd->Execute(diff_dst_data, diff_src_data, ws_data,
                            bwd_cpu_stream);
     } catch (dnnl::error& e) {
-      string error_msg = "Status:" + std::to_string(e.status) +
-                         ", message: " + string(e.message) + ". in file " +
-                         string(__FILE__) + ":" + std::to_string(__LINE__);
+      string error_msg = "Status:" + std::to_string(e.status) + ", message: " +
+                         string(e.message) + ". in file " + string(__FILE__) +
+                         ":" + std::to_string(__LINE__);
       OP_REQUIRES_OK(context, errors::Aborted("Compute received an exception:",
                                               error_msg));
     }

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
@@ -225,9 +225,8 @@ class MklQuantizeV2Op : public OpKernel {
   explicit MklQuantizeV2Op(OpKernelConstruction* ctx) : OpKernel(ctx) {
     string mode_string;
     OP_REQUIRES_OK(ctx, ctx->GetAttr("mode", &mode_string));
-    OP_REQUIRES(ctx,
-                (mode_string == "MIN_COMBINED" || mode_string == "MIN_FIRST" ||
-                 mode_string == "SCALED"),
+    OP_REQUIRES(ctx, (mode_string == "MIN_COMBINED" ||
+                      mode_string == "MIN_FIRST" || mode_string == "SCALED"),
                 errors::InvalidArgument("Mode string must be 'MIN_COMBINED',"
                                         " 'MIN_FIRST', or 'SCALED', is '" +
                                         mode_string + "'"));
@@ -241,9 +240,8 @@ class MklQuantizeV2Op : public OpKernel {
 
     string round_mode_string;
     OP_REQUIRES_OK(ctx, ctx->GetAttr("round_mode", &round_mode_string));
-    OP_REQUIRES(ctx,
-                (round_mode_string == "HALF_AWAY_FROM_ZERO" ||
-                 round_mode_string == "HALF_TO_EVEN"),
+    OP_REQUIRES(ctx, (round_mode_string == "HALF_AWAY_FROM_ZERO" ||
+                      round_mode_string == "HALF_TO_EVEN"),
                 errors::InvalidArgument("Round mode string must be "
                                         "'HALF_AWAY_FROM_ZERO' or "
                                         "'HALF_TO_EVEN', is '" +
@@ -270,6 +268,18 @@ class MklQuantizeV2Op : public OpKernel {
                 errors::InvalidArgument(
                     "Scalar calculation in MKL is supported only for"
                     "MIN_FIRST mode for now."));
+
+    // Min and max values of input range should be scalar.
+    const Tensor& min_tensor = ctx->input(1);
+    const Tensor& max_tensor = ctx->input(2);
+    OP_REQUIRES(
+        ctx, TensorShapeUtils::IsScalar(min_tensor.shape()),
+        errors::InvalidArgument("`min_input` must be rank 0 but is rank ",
+                                min_tensor.dims()));
+    OP_REQUIRES(
+        ctx, TensorShapeUtils::IsScalar(max_tensor.shape()),
+        errors::InvalidArgument("`max_input` must be rank 0 but is rank ",
+                                max_tensor.dims()));
 
     auto cpu_engine = engine(engine::kind::cpu, 0);
     const unsigned int src_idx = 0;
@@ -304,8 +314,8 @@ class MklQuantizeV2Op : public OpKernel {
     T* out_data = output_tensor->flat<T>().data();
 
     out_data[0] = (src_data[0] - min_range) * scale_factor;
-    output_min_tensor->flat<float>()(0) = min_range;
-    output_max_tensor->flat<float>()(0) = max_range;
+    output_min_tensor->scalar<float>()() = min_range;
+    output_max_tensor->scalar<float>()() = max_range;
 
     return;
   }
@@ -313,8 +323,8 @@ class MklQuantizeV2Op : public OpKernel {
   void Compute(OpKernelContext* ctx) override {
     const unsigned int src_idx = 0;
     const Tensor& input = ctx->input(src_idx);
-    const float input_min_range = ctx->input(1).flat<float>()(0);
-    const float input_max_range = ctx->input(2).flat<float>()(0);
+    const float input_min_range = ctx->input(1).scalar<float>()();
+    const float input_max_range = ctx->input(2).scalar<float>()();
     float min_range = std::min(0.0f, input_min_range);
     float max_range;
     OP_REQUIRES(ctx, (input_max_range >= input_min_range),
@@ -488,8 +498,8 @@ class MklQuantizeV2Op : public OpKernel {
     reorder_prim->Execute(src.GetUsrMemDataHandle(), dst.GetUsrMemDataHandle(),
                           cpu_stream);
 
-    output_min_tensor->flat<float>()(0) = min_range;
-    output_max_tensor->flat<float>()(0) = max_range;
+    output_min_tensor->scalar<float>()() = min_range;
+    output_max_tensor->scalar<float>()() = max_range;
   }
 
  private:

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op_test.cc
@@ -40,9 +40,9 @@ TEST_F(MklQuantizeV2OpTest, small_uint8) {
   AddInputFromArray<float>(TensorShape({8}),
                            {0.0, 1.0, 1.25, 1.75, 127.0, 255.0, 500.0, 2.0});
   // min_range = 0
-  AddInputFromArray<float>(TensorShape({1}), {0});
+  AddInputFromArray<float>(TensorShape({}), {0});
   // max_range = 255
-  AddInputFromArray<float>(TensorShape({1}), {255.0f});
+  AddInputFromArray<float>(TensorShape({}), {255.0f});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_QUINT8, TensorShape({8}));
   Tensor expected_min(allocator(), DT_FLOAT, TensorShape({}));
@@ -68,8 +68,8 @@ TEST_F(MklQuantizeV2OpTest, small_int8) {
   TF_ASSERT_OK(InitOp());
   AddInputFromArray<float>(TensorShape({8}), {0.0, -1.0, 1.25, -1.75, -24.5,
                                               -255.0, -80.315, 256.0});
-  AddInputFromArray<float>(TensorShape({1}), {-50.0});
-  AddInputFromArray<float>(TensorShape({1}), {127.0});
+  AddInputFromArray<float>(TensorShape({}), {-50.0});
+  AddInputFromArray<float>(TensorShape({}), {127.0});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_QINT8, TensorShape({8}));
   Tensor expected_min(allocator(), DT_FLOAT, TensorShape({}));
@@ -94,14 +94,14 @@ TEST_F(MklQuantizeV2OpTest, small_minfirst) {
   TF_ASSERT_OK(InitOp());
   AddInputFromArray<float>(TensorShape({8}),
                            {1.0, 1.25, 1.75, 2, 3.15, 127.0, 255.0, 500.0});
-  AddInputFromArray<float>(TensorShape({1}), {0});
-  AddInputFromArray<float>(TensorShape({1}), {255.0f});
+  AddInputFromArray<float>(TensorShape({}), {0});
+  AddInputFromArray<float>(TensorShape({}), {255.0f});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_QUINT8, TensorShape({8}));
   test::FillValues<quint8>(&expected, {1, 1, 2, 2, 3, 127, 255, 255});
   test::ExpectTensorEqual<quint8>(expected, *GetOutput(0));
-  const float output_min = GetOutput(1)->flat<float>()(0);
-  const float output_max = GetOutput(2)->flat<float>()(0);
+  const float output_min = GetOutput(1)->scalar<float>()();
+  const float output_max = GetOutput(2)->scalar<float>()();
   EXPECT_NEAR(0.0f, output_min, 1e-5f);
   EXPECT_NEAR(255.0f, output_max, 1e-5f);
 }
@@ -118,14 +118,14 @@ TEST_F(MklQuantizeV2OpTest, small_minfirst_uint) {
   TF_ASSERT_OK(InitOp());
   AddInputFromArray<float>(TensorShape({8}),
                            {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8});
-  AddInputFromArray<float>(TensorShape({1}), {0.1});
-  AddInputFromArray<float>(TensorShape({1}), {0.8});
+  AddInputFromArray<float>(TensorShape({}), {0.1});
+  AddInputFromArray<float>(TensorShape({}), {0.8});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_QUINT8, TensorShape({8}));
   test::FillValues<quint8>(&expected, {32, 64, 96, 128, 159, 191, 223, 255});
   test::ExpectTensorEqual<quint8>(expected, *GetOutput(0));
-  const float output_min = GetOutput(1)->flat<float>()(0);
-  const float output_max = GetOutput(2)->flat<float>()(0);
+  const float output_min = GetOutput(1)->scalar<float>()();
+  const float output_max = GetOutput(2)->scalar<float>()();
   EXPECT_NEAR(0.0f, output_min, 1e-5f);
   EXPECT_NEAR(0.8f, output_max, 1e-5f);
 }
@@ -142,14 +142,14 @@ TEST_F(MklQuantizeV2OpTest, small_minfirst_int) {
   TF_ASSERT_OK(InitOp());
   AddInputFromArray<float>(TensorShape({8}),
                            {-0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7, -0.8});
-  AddInputFromArray<float>(TensorShape({1}), {-0.8});
-  AddInputFromArray<float>(TensorShape({1}), {-0.1});
+  AddInputFromArray<float>(TensorShape({}), {-0.8});
+  AddInputFromArray<float>(TensorShape({}), {-0.1});
   TF_ASSERT_OK(RunOpKernel());
   Tensor expected(allocator(), DT_QUINT8, TensorShape({8}));
   test::FillValues<quint8>(&expected, {223, 191, 159, 128, 96, 64, 32, 0});
   test::ExpectTensorEqual<quint8>(expected, *GetOutput(0));
-  const float output_min = GetOutput(1)->flat<float>()(0);
-  const float output_max = GetOutput(2)->flat<float>()(0);
+  const float output_min = GetOutput(1)->scalar<float>()();
+  const float output_max = GetOutput(2)->scalar<float>()();
   EXPECT_NEAR(-0.8f, output_min, 1e-5f);
   EXPECT_NEAR(0.0f, output_max, 1e-5f);
 }

--- a/tensorflow/core/kernels/mkl/mkl_quantized_concat_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_concat_op_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL)
 
 #define EIGEN_USE_THREADS
 
@@ -115,8 +115,8 @@ void QuantizedConcatTest::TestSmall8Bit(float first_min, float first_max,
   AddInputFromArray<float>(TensorShape({}), {second_max});
   TF_ASSERT_OK(RunOpKernel());
   const Tensor& output_quantized = *GetOutput(0);
-  const float output_min = GetOutput(1)->flat<float>()(0);
-  const float output_max = GetOutput(2)->flat<float>()(0);
+  const float output_min = GetOutput(1)->scalar<float>()();
+  const float output_max = GetOutput(2)->scalar<float>()();
   Tensor output_float =
       QuantizedTensorToFloat<quint8>(output_quantized, output_min, output_max);
   test::ExpectTensorNear<float>(expected_float, output_float, 0.2);
@@ -181,8 +181,8 @@ void QuantizedConcatTest::TestSecondDim8Bit(float first_min, float first_max,
   AddInputFromArray<float>(TensorShape({}), {second_max});
   TF_ASSERT_OK(RunOpKernel());
   const Tensor& output_quantized = *GetOutput(0);
-  const float output_min = GetOutput(1)->flat<float>()(0);
-  const float output_max = GetOutput(2)->flat<float>()(0);
+  const float output_min = GetOutput(1)->scalar<float>()();
+  const float output_max = GetOutput(2)->scalar<float>()();
   Tensor output_float =
       QuantizedTensorToFloat<quint8>(output_quantized, output_min, output_max);
   // Using the same error tolerance as in Eigen QuantizedConcat test
@@ -191,4 +191,4 @@ void QuantizedConcatTest::TestSecondDim8Bit(float first_min, float first_max,
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && ENABLE_MKL
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_quantized_concat_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_concat_op_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL)
+#if defined(INTEL_MKL) && defined(ENABLE_MKL)
 
 #define EIGEN_USE_THREADS
 
@@ -191,4 +191,4 @@ void QuantizedConcatTest::TestSecondDim8Bit(float first_min, float first_max,
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL
+#endif  // INTEL_MKL && ENABLE_MKL

--- a/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_perchannel_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_perchannel_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL)
 #define EIGEN_USE_THREADS
 
 #include <functional>
@@ -191,4 +191,4 @@ TEST_F(QuantizedConv2DPerChannelTest, SmallOldAPI) { TestSmall(true); }
 TEST_F(QuantizedConv2DPerChannelTest, SmallNewAPI) { TestSmall(false); }
 
 }  // namespace tensorflow
-#endif  // INTEL_MKL && ENABLE_MKL
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_perchannel_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_perchannel_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL)
+#if defined(INTEL_MKL) && defined(ENABLE_MKL)
 #define EIGEN_USE_THREADS
 
 #include <functional>
@@ -191,4 +191,4 @@ TEST_F(QuantizedConv2DPerChannelTest, SmallOldAPI) { TestSmall(true); }
 TEST_F(QuantizedConv2DPerChannelTest, SmallNewAPI) { TestSmall(false); }
 
 }  // namespace tensorflow
-#endif  // INTEL_MKL
+#endif  // INTEL_MKL && ENABLE_MKL

--- a/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL)
 #define EIGEN_USE_THREADS
 
 #include <functional>
@@ -112,12 +112,12 @@ class QuantizedConv2DTest : public OpsTestBase {
     }
 
     // Image -> uint8
-    AddInputFromArray<float>(TensorShape({1}), {0.0f});
-    AddInputFromArray<float>(TensorShape({1}), {255.0f});
+    AddInputFromArray<float>(TensorShape({}), {0.0f});
+    AddInputFromArray<float>(TensorShape({}), {255.0f});
 
     // Filter -> int8 with symmetric range
-    AddInputFromArray<float>(TensorShape({1}), {-127.0f});
-    AddInputFromArray<float>(TensorShape({1}), {127.0f});
+    AddInputFromArray<float>(TensorShape({}), {-127.0f});
+    AddInputFromArray<float>(TensorShape({}), {127.0f});
 
     TF_ASSERT_OK(RunOpKernel());
 
@@ -195,10 +195,10 @@ class QuantizedConv2DTest : public OpsTestBase {
                               image_quantized.flat<quint8>());
     AddInputFromArray<qint8>(filter_quantized.shape(),
                              filter_quantized.flat<qint8>());
-    AddInputFromArray<float>(TensorShape({1}), {image_min});
-    AddInputFromArray<float>(TensorShape({1}), {image_max});
-    AddInputFromArray<float>(TensorShape({1}), {filter_min});
-    AddInputFromArray<float>(TensorShape({1}), {filter_max});
+    AddInputFromArray<float>(TensorShape({}), {image_min});
+    AddInputFromArray<float>(TensorShape({}), {image_max});
+    AddInputFromArray<float>(TensorShape({}), {filter_min});
+    AddInputFromArray<float>(TensorShape({}), {filter_max});
 
     TF_ASSERT_OK(RunOpKernel());
 
@@ -232,8 +232,8 @@ class QuantizedConv2DTest : public OpsTestBase {
                                               178, 187, 234, 261, 121});
 
     const Tensor& output = *GetOutput(0);
-    const float output_min = GetOutput(1)->flat<float>()(0);
-    const float output_max = GetOutput(2)->flat<float>()(0);
+    const float output_min = GetOutput(1)->scalar<float>()();
+    const float output_max = GetOutput(2)->scalar<float>()();
     Tensor output_float =
         QuantizedTensorToFloat<qint32>(output, output_min, output_max);
     test::ExpectTensorNear<float>(expected_float, output_float, 1.0);
@@ -284,10 +284,10 @@ class QuantizedConv2DTest : public OpsTestBase {
                              image_quantized.flat<qint8>());
     AddInputFromArray<qint8>(filter_quantized.shape(),
                              filter_quantized.flat<qint8>());
-    AddInputFromArray<float>(TensorShape({1}), {image_min});
-    AddInputFromArray<float>(TensorShape({1}), {image_max});
-    AddInputFromArray<float>(TensorShape({1}), {filter_min});
-    AddInputFromArray<float>(TensorShape({1}), {filter_max});
+    AddInputFromArray<float>(TensorShape({}), {image_min});
+    AddInputFromArray<float>(TensorShape({}), {image_max});
+    AddInputFromArray<float>(TensorShape({}), {filter_min});
+    AddInputFromArray<float>(TensorShape({}), {filter_max});
 
     TF_ASSERT_OK(RunOpKernel());
 
@@ -300,8 +300,8 @@ class QuantizedConv2DTest : public OpsTestBase {
     test::FillValues<float>(&expected_float, {1});
 
     const Tensor& output = *GetOutput(0);
-    const float output_min = GetOutput(1)->flat<float>()(0);
-    const float output_max = GetOutput(2)->flat<float>()(0);
+    const float output_min = GetOutput(1)->scalar<float>()();
+    const float output_max = GetOutput(2)->scalar<float>()();
     Tensor output_float =
         QuantizedTensorToFloat<qint32>(output, output_min, output_max);
 
@@ -330,12 +330,12 @@ class QuantizedConv2DTest : public OpsTestBase {
         {10, 40, 70, 20, 50, 80, 30, 60, 90});
 
     // Image -> uint8
-    AddInputFromArray<float>(TensorShape({1}), {0.0f});
-    AddInputFromArray<float>(TensorShape({1}), {255.0f});
+    AddInputFromArray<float>(TensorShape({}), {0.0f});
+    AddInputFromArray<float>(TensorShape({}), {255.0f});
 
     // Filter -> int8 with symmetric range
-    AddInputFromArray<float>(TensorShape({1}), {-127.0f});
-    AddInputFromArray<float>(TensorShape({1}), {127.0f});
+    AddInputFromArray<float>(TensorShape({}), {-127.0f});
+    AddInputFromArray<float>(TensorShape({}), {127.0f});
 
     TF_ASSERT_OK(RunOpKernel());
 
@@ -374,12 +374,12 @@ class QuantizedConv2DTest : public OpsTestBase {
         {10, 40, 70, 20, 50, 80, 30, 60, 90});
 
     // Image -> uint8
-    AddInputFromArray<float>(TensorShape({1}), {0.0f});
-    AddInputFromArray<float>(TensorShape({1}), {255.0f});
+    AddInputFromArray<float>(TensorShape({}), {0.0f});
+    AddInputFromArray<float>(TensorShape({}), {255.0f});
 
     // Filter -> int8 with symmetric range
-    AddInputFromArray<float>(TensorShape({1}), {-127.0f});
-    AddInputFromArray<float>(TensorShape({1}), {127.0f});
+    AddInputFromArray<float>(TensorShape({}), {-127.0f});
+    AddInputFromArray<float>(TensorShape({}), {127.0f});
 
     TF_ASSERT_OK(RunOpKernel());
 
@@ -416,12 +416,12 @@ class QuantizedConv2DTest : public OpsTestBase {
         {1, 2, 3, 4, 5, 6, 7, 8, 9});
 
     // Image -> uint8
-    AddInputFromArray<float>(TensorShape({1}), {0.0f});
-    AddInputFromArray<float>(TensorShape({1}), {255.0f});
+    AddInputFromArray<float>(TensorShape({}), {0.0f});
+    AddInputFromArray<float>(TensorShape({}), {255.0f});
 
     // Filter -> int8 with symmetric range
-    AddInputFromArray<float>(TensorShape({1}), {-127.0f});
-    AddInputFromArray<float>(TensorShape({1}), {127.0f});
+    AddInputFromArray<float>(TensorShape({}), {-127.0f});
+    AddInputFromArray<float>(TensorShape({}), {127.0f});
 
     TF_ASSERT_OK(RunOpKernel());
 
@@ -458,12 +458,12 @@ class QuantizedConv2DTest : public OpsTestBase {
         {1, 2, 3, 4, 5, 6, 7, 8, 9});
 
     // Image -> uint8
-    AddInputFromArray<float>(TensorShape({1}), {0.0f});
-    AddInputFromArray<float>(TensorShape({1}), {255.0f});
+    AddInputFromArray<float>(TensorShape({}), {0.0f});
+    AddInputFromArray<float>(TensorShape({}), {255.0f});
 
     // Filter -> int8 with symmetric range
-    AddInputFromArray<float>(TensorShape({1}), {-127.0f});
-    AddInputFromArray<float>(TensorShape({1}), {127.0f});
+    AddInputFromArray<float>(TensorShape({}), {-127.0f});
+    AddInputFromArray<float>(TensorShape({}), {127.0f});
 
     TF_ASSERT_OK(RunOpKernel());
 
@@ -764,7 +764,7 @@ class QuantizedConvTest : public OpsTestBase {
     const Tensor& output = *GetOutput(0);
     const Tensor& output_min = *GetOutput(1);
     const Tensor& output_max = *GetOutput(2);
-    const float output_max_value = output_max.flat<float>()(0);
+    const float output_max_value = output_max.scalar<float>()();
 
     Tensor output_float;
     MklTestingUtil::RunDequantizeOp(output, output_min, output_max, "SCALED",
@@ -1062,4 +1062,4 @@ TEST_F(QuantizedConvTest, BiasAddSumReluFusionFloatSummand) {
 }
 
 }  // namespace tensorflow
-#endif  // INTEL_MKL && ENABLE_MKL
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_conv_ops_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL)
+#if defined(INTEL_MKL) && defined(ENABLE_MKL)
 #define EIGEN_USE_THREADS
 
 #include <functional>
@@ -1062,4 +1062,4 @@ TEST_F(QuantizedConvTest, BiasAddSumReluFusionFloatSummand) {
 }
 
 }  // namespace tensorflow
-#endif  // INTEL_MKL
+#endif  // INTEL_MKL && ENABLE_MKL

--- a/tensorflow/core/kernels/mkl/mkl_quantized_pooling_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_pooling_ops_test.cc
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#if defined(INTEL_MKL)
+#if defined(INTEL_MKL) && defined(ENABLE_MKL)
 #define EIGEN_USE_THREADS
 
 #include "tensorflow/core/framework/allocator.h"
@@ -148,4 +148,4 @@ TEST_F(QuantizedPoolingTest, SmallMaxPooling) {
 
 }  // namespace tensorflow
 
-#endif  // defined(INTEL_MKL)
+#endif  // defined(INTEL_MKL) && defined(ENABLE_MKL)

--- a/tensorflow/core/kernels/mkl/mkl_quantized_pooling_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_pooling_ops_test.cc
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#if defined(INTEL_MKL) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL)
 #define EIGEN_USE_THREADS
 
 #include "tensorflow/core/framework/allocator.h"
@@ -82,8 +82,8 @@ TEST_F(QuantizedPoolingTest, SmallAveragePooling) {
   TF_ASSERT_OK(RunOpKernel());
 
   const Tensor& output = *GetOutput(0);
-  const float output_min = GetOutput(1)->flat<float>()(0);
-  const float output_max = GetOutput(2)->flat<float>()(0);
+  const float output_min = GetOutput(1)->scalar<float>()();
+  const float output_max = GetOutput(2)->scalar<float>()();
   Tensor output_float =
       QuantizedTensorToFloat<quint8>(output, output_min, output_max);
 
@@ -138,8 +138,8 @@ TEST_F(QuantizedPoolingTest, SmallMaxPooling) {
   TF_ASSERT_OK(RunOpKernel());
 
   const Tensor& output = *GetOutput(0);
-  const float output_min = GetOutput(1)->flat<float>()(0);
-  const float output_max = GetOutput(2)->flat<float>()(0);
+  const float output_min = GetOutput(1)->scalar<float>()();
+  const float output_max = GetOutput(2)->scalar<float>()();
   Tensor output_float =
       QuantizedTensorToFloat<quint8>(output, output_min, output_max);
 
@@ -148,4 +148,4 @@ TEST_F(QuantizedPoolingTest, SmallMaxPooling) {
 
 }  // namespace tensorflow
 
-#endif  // defined(INTEL_MKL) && defined(ENABLE_MKL)
+#endif  // defined(INTEL_MKL)

--- a/tensorflow/core/kernels/mkl/mkl_requantization_range_per_channel_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_requantization_range_per_channel_op.cc
@@ -18,10 +18,8 @@ limitations under the License.
 #define EIGEN_USE_THREADS
 
 #include <math.h>
-
 #include <limits>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/type_traits.h"
@@ -31,6 +29,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/util/mkl_threadpool.h"
 #include "tensorflow/core/util/mkl_util.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 namespace tensorflow {
 
@@ -128,8 +127,8 @@ class MklRequantizationRangePerChannelOp : public OpKernel {
     Tensor* output_max = nullptr;
     OP_REQUIRES_OK(ctx, ctx->allocate_output(kOutputMinIndex, {}, &output_min));
     OP_REQUIRES_OK(ctx, ctx->allocate_output(kOutputMaxIndex, {}, &output_max));
-    output_min->flat<float>()(0) = is_non_negative ? 0.0f : -out_min_max;
-    output_max->flat<float>()(0) = out_min_max;
+    output_min->scalar<float>()() = is_non_negative ? 0.0f : -out_min_max;
+    output_max->scalar<float>()() = out_min_max;
   }
 
  private:

--- a/tensorflow/core/kernels/mkl/mkl_requantize_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_requantize_ops_test.cc
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#if defined(INTEL_MKL)
+#if defined(INTEL_MKL) && defined(ENABLE_MKL)
 
 #include <cmath>
 
@@ -296,4 +296,4 @@ TEST_F(MklRequantizatedOpsTest, RequantizePerChannelTest_Basic) {
 }
 
 }  // namespace tensorflow
-#endif  // INTEL_MKL
+#endif  // INTEL_MKL && ENABLE_MKL

--- a/tensorflow/core/kernels/mkl/mkl_requantize_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_requantize_ops_test.cc
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#if defined(INTEL_MKL) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL)
 
 #include <cmath>
 
@@ -159,8 +159,8 @@ TEST_F(MklRequantizatedOpsTest, RequantizationRangePerChannelTest_Basic) {
   // --------------------------------------------------------------------
 
   // Verify the Expected Outputs
-  const float output_min = GetOutput(0)->flat<float>()(0);
-  const float output_max = GetOutput(1)->flat<float>()(0);
+  const float output_min = GetOutput(0)->scalar<float>()();
+  const float output_max = GetOutput(1)->scalar<float>()();
   EXPECT_NEAR(-14.8217, output_min, 0.002);
   EXPECT_NEAR(14.8217, output_max, 0.002);
 
@@ -220,8 +220,8 @@ TEST_F(MklRequantizatedOpsTest, RequantizationRangePerChannelTest_ClipMax) {
   // --------------------------------------------------------------------
 
   // Verify the expected outputs
-  const float output_min = GetOutput(0)->flat<float>()(0);
-  const float output_max = GetOutput(1)->flat<float>()(0);
+  const float output_min = GetOutput(0)->scalar<float>()();
+  const float output_max = GetOutput(1)->scalar<float>()();
   EXPECT_NEAR(-6.0, output_min, 0.002);  // Values are aligned with clip_value.
   EXPECT_NEAR(6.0, output_max, 0.002);   // Values are aligned with clip_value.
 }
@@ -281,19 +281,19 @@ TEST_F(MklRequantizatedOpsTest, RequantizePerChannelTest_Basic) {
   float range_op_output_max = 14.8217;
 
   // Add the requested_min and requested_max stored from Step 6.
-  AddInputFromArray<float>(TensorShape({1}), {range_op_output_min});
-  AddInputFromArray<float>(TensorShape({1}), {range_op_output_max});
+  AddInputFromArray<float>(TensorShape({}), {range_op_output_min});
+  AddInputFromArray<float>(TensorShape({}), {range_op_output_max});
 
   // Run the kernel
   TF_ASSERT_OK(RunOpKernel());
 
   // Verify the output with the expected output
   Tensor output = *GetOutput(0);
-  const float output_min = GetOutput(1)->flat<float>()(0);
-  const float output_max = GetOutput(2)->flat<float>()(0);
+  const float output_min = GetOutput(1)->scalar<float>()();
+  const float output_max = GetOutput(2)->scalar<float>()();
   EXPECT_NEAR(range_op_output_min, output_min, 0.002);
   EXPECT_NEAR(range_op_output_max, output_max, 0.002);
 }
 
 }  // namespace tensorflow
-#endif  // INTEL_MKL && ENABLE_MKL
+#endif  // INTEL_MKL


### PR DESCRIPTION
[INTEL oneDNN][Bug Fix] Add index-validity check for min-max tensors for quantized oneDNN ops and related tests #59581