### PR TITLE
Updated Broken link for lib_interpreter

### DIFF
--- a/tensorflow/lite/g3doc/examples/object_detection/overview.md
+++ b/tensorflow/lite/g3doc/examples/object_detection/overview.md
@@ -60,7 +60,7 @@ build your own custom inference pipeline using the
 The Android example below demonstrates the implementation for both methods as
 [lib_task_api](https://github.com/tensorflow/examples/tree/master/lite/examples/object_detection/android/lib_task_api)
 and
-[lib_interpreter](https://github.com/tensorflow/examples/tree/master/lite/examples/object_detection/android/lib_interpreter),
+[lib_interpreter](https://github.com/tensorflow/examples/tree/eb925e460f761f5ed643d17f0c449e040ac2ac45/lite/examples/object_detection/android/lib_interpreter),
 respectively.
 
 <a class="button button-primary" href="https://github.com/tensorflow/examples/tree/master/lite/examples/object_detection/android">View


### PR DESCRIPTION
I have updated broken link for hyperlink(lib_interpreter) on this page `https://www.tensorflow.org/lite/examples/object_detection/overview`, from (https://github.com/tensorflow/examples/tree/master/lite/examples/object_detection/android/lib_interpreter) to new working link (https://github.com/tensorflow/examples/tree/eb925e460f761f5ed643d17f0c449e040ac2ac45/lite/examples/object_detection/android/lib_interpreter) so please do the needful. Thank you!