### PR TITLE
Prevent stale issues action from running in forks

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -20,6 +20,8 @@ on:
 
 jobs:
   close-issues:
+    # Don't do this in forks
+    if: github.repository == 'tensorflow/tensorflow'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
The action will fail when not run in the main repo causing unnecessary failure messages to be sent to fork owners so add the same protection as used in the other actions