### PR TITLE
[NVIDIA TF] Optimize mixed-precision finite check for sparse tensors.

### DIFF
--- a/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
+++ b/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
@@ -63,8 +63,12 @@ class _UnwrapPreventer(object):
 
 def _is_all_finite(grads):
   """Returns a scalar boolean tensor indicating if all gradients are finite."""
+  def raw_values(g):
+    return g.values if isinstance(g, tf.IndexedSlices) else g
+
   is_finite_per_grad = [
-      math_ops.reduce_all(math_ops.is_finite(g)) for g in grads if g is not None
+      math_ops.reduce_all(math_ops.is_finite(raw_values(g)))
+      for g in grads if g is not None
   ]
   return math_ops.reduce_all(is_finite_per_grad)
 

--- a/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
+++ b/tensorflow/python/keras/mixed_precision/loss_scale_optimizer.py
@@ -64,7 +64,7 @@ class _UnwrapPreventer(object):
 def _is_all_finite(grads):
   """Returns a scalar boolean tensor indicating if all gradients are finite."""
   def raw_values(g):
-    return g.values if isinstance(g, tf.IndexedSlices) else g
+    return g.values if isinstance(g, indexed_slices.IndexedSlices) else g
 
   is_finite_per_grad = [
       math_ops.reduce_all(math_ops.is_finite(raw_values(g)))

--- a/tensorflow/python/training/experimental/loss_scale.py
+++ b/tensorflow/python/training/experimental/loss_scale.py
@@ -256,8 +256,12 @@ class FixedLossScale(LossScale):
 
 def _is_all_finite(grads):
   """Returns a scalar boolean tensor indicating if all gradients are finite."""
+  def raw_values(g):
+    return g.values if isinstance(g, tf.IndexedSlices) else g
+
   is_finite_per_grad = [
-      math_ops.reduce_all(math_ops.is_finite(g)) for g in grads if g is not None
+      math_ops.reduce_all(math_ops.is_finite(raw_values(g)))
+      for g in grads if g is not None
   ]
   return math_ops.reduce_all(is_finite_per_grad)
 

--- a/tensorflow/python/training/experimental/loss_scale.py
+++ b/tensorflow/python/training/experimental/loss_scale.py
@@ -19,6 +19,7 @@ from tensorflow.python.distribute import distribution_strategy_context
 from tensorflow.python.distribute import reduce_util
 from tensorflow.python.eager import context
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import indexed_slices
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import math_ops
@@ -257,7 +258,7 @@ class FixedLossScale(LossScale):
 def _is_all_finite(grads):
   """Returns a scalar boolean tensor indicating if all gradients are finite."""
   def raw_values(g):
-    return g.values if isinstance(g, tf.IndexedSlices) else g
+    return g.values if isinstance(g, indexed_slices.IndexedSlices) else g
 
   is_finite_per_grad = [
       math_ops.reduce_all(math_ops.is_finite(raw_values(g)))


### PR DESCRIPTION
Mixed precision can be very slow and memory inefficient with sparse tensors, common, for example, in recommender-type models.

The largest inefficiencies come from checking sparse tensors for NaN values when dynamic loss scaling is enabled.

This PR implements a simple optimization to use the dense values of IndexedSlices directly during NaN checks.

c.f., Keras PR https://github.com/keras-team/keras/pull/17638
Atten: @reedwm 