### PR TITLE
[TFLite] Add support for int8 quantized DivOp

### DIFF
--- a/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
+++ b/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
@@ -1583,8 +1583,7 @@ def TFL_NotEqualOp : TFL_Op<"not_equal", [
 }
 
 def TFL_DivOp : TFL_Op<"div", [
-    // TODO(fengliuai): NoQuantizableResult is only correct for int8
-    // quantization. update to handle Uint8 quantization.
+    QuantizableResult,
     BinaryOpSameElementTypeConstraint,
     TFL_OperandsHaveSameShapesOrBroadcastableShape<[0, 1], 5>,
     ResultsBroadcastableShape,
@@ -1597,11 +1596,11 @@ def TFL_DivOp : TFL_Op<"div", [
   }];
 
   let arguments = (
-      ins TFL_TensorOf<[F32, I32, QUI8]>:$lhs,
-      TFL_TensorOf<[F32, I32, QUI8]>:$rhs,
+      ins TFL_TensorOf<[F32, I32, QI8, QUI8]>:$lhs,
+      TFL_TensorOf<[F32, I32, QI8, QUI8]>:$rhs,
       TFL_AFAttr:$fused_activation_function);
 
-  let results = (outs TFL_TensorOf<[F32, I32, QUI8]>:$output);
+  let results = (outs TFL_TensorOf<[F32, I32, QI8, QUI8]>:$output);
 
   let builders = [TFL_FusedBroadcastableBinaryBuilder];
 

--- a/tensorflow/compiler/mlir/lite/tests/ops.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/ops.mlir
@@ -500,6 +500,14 @@ func.func @testDiv(tensor<? x i32>, tensor<? x i32>) -> tensor<? x i32> {
   func.return %0#0 : tensor<? x i32>
 }
 
+// CHECK-LABEL: testDivQuantized
+func.func @testDivQuantized(tensor<? x !quant.any<i8:f32>>, tensor<? x !quant.any<i8:f32>>) -> tensor<? x !quant.any<i8:f32>> {
+^bb0(%arg0: tensor<? x !quant.any<i8:f32>>, %arg1: tensor<? x !quant.any<i8:f32>>):
+  // CHECK: tfl.div %arg0, %arg1 {fused_activation_function = "RELU6"}
+  %0 = "tfl.div"(%arg0, %arg1) {fused_activation_function = "RELU6"}: (tensor<? x !quant.any<i8:f32>>, tensor<? x !quant.any<i8:f32>>) -> tensor<? x !quant.any<i8:f32>>
+  func.return %0#0 : tensor<? x !quant.any<i8:f32>>
+}
+
 // CHECK-LABEL: testLess
 func.func @testLess(tensor<? x i32>, tensor<? x i32>) -> tensor<? x i1> {
 ^bb0(%arg0: tensor<? x i32>, %arg1: tensor<? x i32>):

--- a/tensorflow/lite/kernels/div.cc
+++ b/tensorflow/lite/kernels/div.cc
@@ -97,7 +97,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
     output_size = TfLiteIntArrayCopy(input1->dims);
   }
 
-  if (output->type == kTfLiteUInt8) {
+  if (output->type == kTfLiteInt8 || output->type == kTfLiteUInt8) {
     TF_LITE_ENSURE_STATUS(CalculateActivationRangeQuantized(
         context, params->activation, output, &data->output_activation_min,
         &data->output_activation_max));
@@ -162,8 +162,8 @@ TfLiteStatus EvalQuantized(TfLiteContext* context, TfLiteNode* node,
                            TfLiteDivParams* params, const OpData* data,
                            const TfLiteTensor* input1,
                            const TfLiteTensor* input2, TfLiteTensor* output) {
-  if (input1->type == kTfLiteUInt8 && input2->type == kTfLiteUInt8 &&
-      output->type == kTfLiteUInt8) {
+  if (input1->type == input2->type && input1->type == output->type &&
+      (input1->type == kTfLiteUInt8 || input1->type == kTfLiteInt8)) {
     tflite::ArithmeticParams op_params;
     SetActivationParams(data->output_activation_min,
                         data->output_activation_max, &op_params);
@@ -179,17 +179,34 @@ TfLiteStatus EvalQuantized(TfLiteContext* context, TfLiteNode* node,
                GetTensorData<dtype>(input1), GetTensorShape(input2), \
                GetTensorData<dtype>(input2), GetTensorShape(output), \
                GetTensorData<dtype>(output))
-    if (kernel_type == kReference) {
-      if (need_broadcast) {
-        TF_LITE_DIV(reference_ops, BroadcastDivSlow, uint8_t);
+    if (input1->type == kTfLiteInt8) {
+      if (kernel_type == kReference) {
+        if (need_broadcast) {
+          TF_LITE_DIV(reference_ops, BroadcastDivSlow, int8_t);
+        } else {
+          TF_LITE_DIV(reference_ops, Div, int8_t);
+        }
       } else {
-        TF_LITE_DIV(reference_ops, Div, uint8_t);
+        if (need_broadcast) {
+          TF_LITE_DIV(optimized_ops, BroadcastDivSlow, int8_t);
+        } else {
+          TF_LITE_DIV(optimized_ops, Div, int8_t);
+        }
       }
     } else {
-      if (need_broadcast) {
-        TF_LITE_DIV(optimized_ops, BroadcastDivSlow, uint8_t);
+      // type == kTfLiteUInt8
+      if (kernel_type == kReference) {
+        if (need_broadcast) {
+          TF_LITE_DIV(reference_ops, BroadcastDivSlow, uint8_t);
+        } else {
+          TF_LITE_DIV(reference_ops, Div, uint8_t);
+        }
       } else {
-        TF_LITE_DIV(optimized_ops, Div, uint8_t);
+        if (need_broadcast) {
+          TF_LITE_DIV(optimized_ops, BroadcastDivSlow, uint8_t);
+        } else {
+          TF_LITE_DIV(optimized_ops, Div, uint8_t);
+        }
       }
     }
 #undef TF_LITE_DIV
@@ -226,7 +243,6 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context,
                     GetOutputSafe(context, node, kOutputTensor, &output));
 
-
   if (output->type == kTfLiteFloat32) {
     // Div by zero seems ok in this case, we don't do a check at this point.
     // However, unlike in TF where infinities are returned, here we return an
@@ -235,6 +251,11 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   } else if (output->type == kTfLiteInt32) {
     CheckNonZero<int32_t>(context, input2);
     EvalDiv<kernel_type>(context, node, params, data, input1, input2, output);
+  } else if (output->type == kTfLiteInt8) {
+    CheckNonZero<int8_t>(context, input2);
+    TF_LITE_ENSURE_OK(
+        context, EvalQuantized<kernel_type>(context, node, params, data, input1,
+                                            input2, output));
   } else if (output->type == kTfLiteUInt8) {
     CheckNonZero<uint8_t>(context, input2);
     TF_LITE_ENSURE_OK(
@@ -243,7 +264,8 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   } else {
     TF_LITE_KERNEL_LOG(
         context,
-        "Div only supports FLOAT32, INT32 and quantized UINT8 now, got %d.",
+        "Div only supports FLOAT32, INT32, quantized INT8 and quantized "
+        "UINT8 now, got %d.",
         output->type);
     return kTfLiteError;
   }

--- a/tensorflow/lite/kernels/div_test.cc
+++ b/tensorflow/lite/kernels/div_test.cc
@@ -260,6 +260,10 @@ TEST(QuantizedDivOpTest, QuantizedNoActivationUInt8) {
   QuantizedNoActivation<TensorType_UINT8, uint8_t>();
 }
 
+TEST(QuantizedDivOpTest, QuantizedNoActivationInt8) {
+  QuantizedNoActivation<TensorType_INT8, int8_t>();
+}
+
 template <TensorType tensor_type, typename integer_dtype>
 void QuantizedActivationRELU_N1_TO_1() {
   const float kQuantizedTolerance = GetTolerance(-1.0, 1.0);
@@ -286,6 +290,10 @@ void QuantizedActivationRELU_N1_TO_1() {
 
 TEST(QuantizedDivOpTest, QuantizedActivationRELU_N1_TO_1UInt8) {
   QuantizedActivationRELU_N1_TO_1<TensorType_UINT8, uint8_t>();
+}
+
+TEST(QuantizedDivOpTest, QuantizedActivationRELU_N1_TO_1Int8) {
+  QuantizedActivationRELU_N1_TO_1<TensorType_INT8, int8_t>();
 }
 
 template <TensorType tensor_type, typename integer_dtype>
@@ -315,6 +323,10 @@ TEST(QuantizedDivOpTest, QuantizedVariousInputShapesUInt8) {
   QuantizedVariousInputShapes<TensorType_UINT8, uint8_t>();
 }
 
+TEST(QuantizedDivOpTest, QuantizedVariousInputShapesInt8) {
+  QuantizedVariousInputShapes<TensorType_INT8, int8_t>();
+}
+
 template <TensorType tensor_type, typename integer_dtype>
 void QuantizedWithBroadcast() {
   const float kQuantizedTolerance = GetTolerance(-3.0, 3.0);
@@ -338,6 +350,10 @@ void QuantizedWithBroadcast() {
 
 TEST(QuantizedDivOpTest, QuantizedWithBroadcastUInt8) {
   QuantizedWithBroadcast<TensorType_UINT8, uint8_t>();
+}
+
+TEST(QuantizedDivOpTest, QuantizedWithBroadcastInt8) {
+  QuantizedWithBroadcast<TensorType_INT8, int8_t>();
 }
 
 }  // namespace


### PR DESCRIPTION
This PR adds support for quantized int8 inputs and outputs to the `div` op. TFLite Micro added support for int8 quantized divides in https://github.com/tensorflow/tflite-micro/pull/1196, but until now the MLIR based converter would force the op to stay in float due to missing TFLite support for it. This PR fixes this and adds support for int8 quantized divide ops to TFLite and the converter.