### PR TITLE
Use llvm-raw override for build w/ local LLVM repo

### DIFF
--- a/tensorflow/compiler/mlir/README.md
+++ b/tensorflow/compiler/mlir/README.md
@@ -30,6 +30,6 @@ touch ${LLVM_SRC}/BUILD.bazel ${LLVM_SRC}/WORKSPACE
 You can then use this overlay to build TensorFlow:
 
 ```
-bazel build --override_repository=llvm-raw=$LLVM_BAZEL_OVERLAY \
+bazel build --override_repository="llvm-raw=${LLVM_SRC}" \
   -c opt tensorflow/compiler/mlir:tf-opt
 ```

--- a/tensorflow/compiler/mlir/README.md
+++ b/tensorflow/compiler/mlir/README.md
@@ -19,27 +19,17 @@ Building dialects and utilities here follow the standard approach using
 
 To develop across MLIR core and TensorFlow, it is useful to override the repo
 to use a local version instead of fetching from head. This can be achieved by
-setting up your local repository for Bazel build. For this you will need a
-temporary directory that will be "overlaid" with you LLVM source directory and
-the Bazel files:
+setting up your local repository for Bazel build. For this you will need to
+create bazel workspace and build files:
 
 ```sh
 LLVM_SRC=... # this the path to the LLVM local source directory you intend to use.
-LLVM_BAZEL_OVERLAY=${LLVM_SRC}/bazel # Note: this can be anywhere
-mkdir -p ${LLVM_BAZEL_OVERLAY}
-# This will symlink your LLVM sources with the BUILD files to be usable by Bazel.
-python ${LLVM_SRC}/utils/bazel/overlay_directories.py \
-    --src ${LLVM_SRC} \
-    --overlay ${LLVM_SRC}/utils/bazel/llvm-project-overlay/ \
-    --target ${LLVM_BAZEL_OVERLAY}
-touch ${LLVM_BAZEL_OVERLAY}/BUILD.bazel ${LLVM_BAZEL_OVERLAY}/WORKSPACE
-# The complete list is "AArch64", "AMDGPU", "ARM", "NVPTX", "PowerPC", "RISCV", "SystemZ", "X86"
-echo 'llvm_targets = ["X86"]' > ${LLVM_BAZEL_OVERLAY}/llvm/targets.bzl
+touch ${LLVM_SRC}/BUILD.bazel ${LLVM_SRC}/WORKSPACE
 ```
 
 You can then use this overlay to build TensorFlow:
 
 ```
-bazel build --override_repository=llvm-project=$LLVM_BAZEL_OVERLAY \
+bazel build --override_repository=llvm-raw=$LLVM_BAZEL_OVERLAY \
   -c opt tensorflow/compiler/mlir:tf-opt
 ```


### PR DESCRIPTION
Building with a llvm-project override to use a local LLVM repo as instructed by tensorflow/compiler/mlir/README.md fails due to missing vars.bzl. Instead of adding one more step to create this file in the Readme, this commit instead instruct to override llvm-raw target. This let llvm_configure() set up the bazel overlay and set it up and also saves on pointless LLVM download.

Fixes #59739 