### PR TITLE
include cstdint

### DIFF
--- a/tensorflow/lite/kernels/internal/spectrogram.cc
+++ b/tensorflow/lite/kernels/internal/spectrogram.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <assert.h>
 #include <math.h>
+#include <cstdint>
 
 #include "third_party/fft2d/fft.h"
 


### PR DESCRIPTION
Building with gcc 13, there is this error
tensorflow/tensorflow/lite/kernels/internal/spectrogram.cc:46:22: error: ‘uint32_t’ was not declared in this scope
   46 | inline int Log2Floor(uint32_t n) {
      |                      ^~~~~~~~
tensorflow/tensorflow/lite/kernels/internal/spectrogram.cc:20:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   19 | #include <math.h>
  +++ |+#include <cstdint>

So include cstdint