### PR TITLE
[NVIDIA TF] Add remaining GPU BF16 cwise ops

### DIFF
--- a/tensorflow/core/kernels/cwise_op_ceil.cc
+++ b/tensorflow/core/kernels/cwise_op_ceil.cc
@@ -24,6 +24,7 @@ REGISTER4(UnaryOp, CPU, "Ceil", functor::ceil, float, Eigen::half, bfloat16,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Ceil", functor::ceil, float, Eigen::half, double);
 #endif
+REGISTER(UnaryOp, GPU, "Ceil", functor::ceil, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_clip.cc
+++ b/tensorflow/core/kernels/cwise_op_clip.cc
@@ -286,6 +286,7 @@ REGISTER_CPU_KERNEL(std::complex<double>);
       Name("ClipByValue").Device(DEVICE_GPU).TypeConstraint<type>("T"), \
       ClipOp<GPUDevice, type>);
 REGISTER_GPU_KERNEL(Eigen::half);
+REGISTER_GPU_KERNEL(bfloat16);
 REGISTER_GPU_KERNEL(float);
 REGISTER_GPU_KERNEL(double);
 REGISTER_GPU_KERNEL(int8);

--- a/tensorflow/core/kernels/cwise_op_clip_gpu.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_clip_gpu.cu.cc
@@ -126,6 +126,7 @@ struct TernaryClipOp<GPUDevice, T> {
   template struct BinaryLeftClipOp<GPUDevice, T>;  \
   template struct TernaryClipOp<GPUDevice, T>;
 INSTANTIATE_GPU(Eigen::half);
+INSTANTIATE_GPU(bfloat16);
 INSTANTIATE_GPU(float);
 INSTANTIATE_GPU(double);
 INSTANTIATE_GPU(int8);

--- a/tensorflow/core/kernels/cwise_op_cos.cc
+++ b/tensorflow/core/kernels/cwise_op_cos.cc
@@ -24,6 +24,7 @@ REGISTER6(UnaryOp, CPU, "Cos", functor::cos, float, Eigen::half, bfloat16,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Cos", functor::cos, float, Eigen::half, double);
 #endif
+REGISTER(UnaryOp, GPU, "Cos", functor::cos, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_div.cc
+++ b/tensorflow/core/kernels/cwise_op_div.cc
@@ -51,6 +51,7 @@ REGISTER5(BinaryOp, GPU, "DivNoNan", functor::div_no_nan, Eigen::half, float,
 #endif
 REGISTER(BinaryOp, GPU, "Div", functor::div, bfloat16);
 REGISTER(BinaryOp, GPU, "RealDiv", functor::div, bfloat16);
+REGISTER(BinaryOp, GPU, "DivNoNan", functor::div_no_nan, bfloat16);
 
 // A special GPU kernel for int32.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel

--- a/tensorflow/core/kernels/cwise_op_equal_to_1.cc
+++ b/tensorflow/core/kernels/cwise_op_equal_to_1.cc
@@ -40,6 +40,7 @@ REGISTER_KERNEL_BUILDER(Name("Equal")
 REGISTER4(BinaryOp, GPU, "Equal", functor::equal_to, float, Eigen::half, double,
           uint8);
 #endif
+REGISTER(BinaryOp, GPU, "Equal", functor::equal_to, bfloat16);
 REGISTER_KERNEL_BUILDER(
     Name("ApproximateEqual").Device(DEVICE_GPU).TypeConstraint<float>("T"),
     ApproximateEqualOp<GPUDevice, float>);

--- a/tensorflow/core/kernels/cwise_op_erf.cc
+++ b/tensorflow/core/kernels/cwise_op_erf.cc
@@ -24,6 +24,7 @@ REGISTER4(UnaryOp, CPU, "Erf", functor::erf, float, Eigen::half, double,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Erf", functor::erf, Eigen::half, float, double);
 #endif
+REGISTER(UnaryOp, GPU, "Erf", functor::erf, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_erfc.cc
+++ b/tensorflow/core/kernels/cwise_op_erfc.cc
@@ -24,6 +24,7 @@ REGISTER4(UnaryOp, CPU, "Erfc", functor::erfc, float, Eigen::half, double,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Erfc", functor::erfc, double, float, Eigen::half);
 #endif
+REGISTER(UnaryOp, GPU, "Erfc", functor::erfc, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_exp.cc
+++ b/tensorflow/core/kernels/cwise_op_exp.cc
@@ -24,6 +24,7 @@ REGISTER6(UnaryOp, CPU, "Exp", functor::exp, float, Eigen::half, bfloat16,
 REGISTER5(UnaryOp, GPU, "Exp", functor::exp, float, Eigen::half, double,
           complex64, complex128);
 #endif
+REGISTER(UnaryOp, GPU, "Exp", functor::exp, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_expm1.cc
+++ b/tensorflow/core/kernels/cwise_op_expm1.cc
@@ -22,5 +22,6 @@ REGISTER6(UnaryOp, CPU, "Expm1", functor::expm1, float, Eigen::half, bfloat16,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Expm1", functor::expm1, float, Eigen::half, double);
 #endif
+REGISTER(UnaryOp, GPU, "Expm1", functor::expm1, bfloat16);
 #endif
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_floor.cc
+++ b/tensorflow/core/kernels/cwise_op_floor.cc
@@ -24,5 +24,6 @@ REGISTER4(UnaryOp, CPU, "Floor", functor::floor, float, Eigen::half, bfloat16,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Floor", functor::floor, float, Eigen::half, double);
 #endif
+REGISTER(UnaryOp, GPU, "Floor", functor::floor, bfloat16);
 #endif
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_floor_div.cc
+++ b/tensorflow/core/kernels/cwise_op_floor_div.cc
@@ -29,6 +29,7 @@ REGISTER4(BinaryOp, GPU, "FloorDiv", functor::floor_div, uint8, uint16, int16,
 REGISTER3(BinaryOp, GPU, "FloorDiv", functor::floor_div_real, float,
           Eigen::half, double);
 #endif
+REGISTER(BinaryOp, GPU, "FloorDiv", functor::floor_div_real, bfloat16);
 #endif
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/cwise_op_gpu_ceil.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_ceil.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(ceil, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(ceil, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_cos.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_cos.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(cos, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(cos, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_equal_to.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_equal_to.cu.cc
@@ -23,6 +23,7 @@ namespace functor {
 DEFINE_BINARY10(equal_to, float, Eigen::half, double, uint8, int8, int16, int64,
                 complex64, complex128, bool);
 #endif
+DEFINE_BINARY1(equal_to, bfloat16);
 
 DEFINE_APPROXIMATE_EQUAL2(float, double);
 }  // namespace functor

--- a/tensorflow/core/kernels/cwise_op_gpu_erf.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_erf.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(erf, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(erf, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_erfc.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_erfc.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(erfc, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(erfc, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_exp.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_exp.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY5(exp, Eigen::half, float, double, complex64, complex128);
 #endif
+DEFINE_UNARY1(exp, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_expm1.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_expm1.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(expm1, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(expm1, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_floor.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_floor.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(floor, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(floor, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_floor_div.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_floor_div.cu.cc
@@ -26,6 +26,7 @@ DEFINE_BINARY1(floor_div, int32);
 DEFINE_BINARY4(floor_div, uint8, uint16, int16, int64);
 DEFINE_BINARY3(floor_div_real, Eigen::half, float, double);
 #endif
+DEFINE_BINARY1(floor_div_real, bfloat16);
 
 }  // namespace functor
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_gpu_greater.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_greater.cu.cc
@@ -23,6 +23,7 @@ namespace functor {
 DEFINE_BINARY10(greater, Eigen::half, float, double, int64, uint8, uint16,
                 uint32, uint64, int8, int16);
 #endif
+DEFINE_BINARY1(greater, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_greater_equal.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_greater_equal.cu.cc
@@ -23,6 +23,7 @@ namespace functor {
 DEFINE_BINARY10(greater_equal, Eigen::half, float, double, int64, uint8, uint16,
                 uint32, uint64, int8, int16);
 #endif
+DEFINE_BINARY1(greater_equal, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_isfinite.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_isfinite.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(isfinite, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(isfinite, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_isinf.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_isinf.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(isinf, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(isinf, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_isnan.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_isnan.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(isnan, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(isnan, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_less.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_less.cu.cc
@@ -23,6 +23,7 @@ namespace functor {
 DEFINE_BINARY10(less, Eigen::half, float, double, int64, uint8, uint16, uint32,
                 uint64, int8, int16);
 #endif
+DEFINE_BINARY1(less, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_less_equal.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_less_equal.cu.cc
@@ -23,6 +23,7 @@ namespace functor {
 DEFINE_BINARY10(less_equal, Eigen::half, float, double, int64, uint8, uint16,
                 uint32, uint64, int8, int16);
 #endif
+DEFINE_BINARY1(less_equal, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_log.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_log.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(log, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(log, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_log1p.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_log1p.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(log1p, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(log1p, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_not_equal_to.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_not_equal_to.cu.cc
@@ -23,6 +23,7 @@ namespace functor {
 DEFINE_BINARY10(not_equal_to, float, Eigen::half, double, uint8, int8, int16,
                 int64, bool, complex64, complex128);
 #endif
+DEFINE_BINARY1(not_equal_to, bfloat16);
 
 }  // namespace functor
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_gpu_pow.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_pow.cu.cc
@@ -23,6 +23,7 @@ namespace functor {
 DEFINE_BINARY3(pow, Eigen::half, float, double);
 DEFINE_BINARY1(safe_pow_ignore_error, int64);
 #endif
+DEFINE_BINARY1(pow, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_round.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_round.cu.cc
@@ -23,6 +23,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY5(round, Eigen::half, float, double, int32, int64);
 #endif
+DEFINE_UNARY1(round, bfloat16);
 
 }  // namespace functor
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_gpu_rsqrt.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_rsqrt.cu.cc
@@ -23,7 +23,8 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(rsqrt, Eigen::half, float, double);
 #endif
-DEFINE_SIMPLE_BINARY3(rsqrt_grad, Eigen::half, float, double);
+DEFINE_UNARY1(rsqrt, bfloat16);
+DEFINE_SIMPLE_BINARY4(rsqrt_grad, Eigen::half, bfloat16, float, double);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_select.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_select.cu.cc
@@ -23,7 +23,8 @@ limitations under the License.
 namespace tensorflow {
 namespace functor {
 
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+// Used by bfloat16 even when MLIR_GENERATED_GPU_KERNELS_ENABLED are enabled
+//#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 template <typename T, int NDIMS>
 struct BCastSelectFunctor<GPUDevice, T, NDIMS> {
   void operator()(const GPUDevice& d,
@@ -39,7 +40,7 @@ struct BCastSelectFunctor<GPUDevice, T, NDIMS> {
                                           else_tensor.broadcast(else_bcast));
   }
 };
-#endif
+//#endif
 
 template <typename T>
 struct SelectFunctor<GPUDevice, T> {
@@ -140,6 +141,7 @@ SELECT_AND_BCAST_SELECT_FUNCTOR(int64);
 SELECT_AND_BCAST_SELECT_FUNCTOR(complex64);
 SELECT_AND_BCAST_SELECT_FUNCTOR(complex128);
 #endif
+SELECT_AND_BCAST_SELECT_FUNCTOR(bfloat16);
 
 #undef SELECT_FUNCTOR
 

--- a/tensorflow/core/kernels/cwise_op_gpu_sigmoid.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_sigmoid.cu.cc
@@ -23,7 +23,8 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(sigmoid, Eigen::half, float, double);
 #endif
-DEFINE_SIMPLE_BINARY3(sigmoid_grad, Eigen::half, float, double);
+DEFINE_UNARY1(sigmoid, bfloat16);
+DEFINE_SIMPLE_BINARY4(sigmoid_grad, Eigen::half, bfloat16, float, double);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_sin.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_sin.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(sin, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(sin, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_sqrt.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_sqrt.cu.cc
@@ -23,7 +23,8 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(sqrt, Eigen::half, float, double);
 #endif
-DEFINE_SIMPLE_BINARY3(sqrt_grad, Eigen::half, float, double);
+DEFINE_UNARY1(sqrt, bfloat16);
+DEFINE_SIMPLE_BINARY4(sqrt_grad, Eigen::half, bfloat16, float, double);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_tan.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_tan.cu.cc
@@ -22,6 +22,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_UNARY3(tan, Eigen::half, float, double);
 #endif
+DEFINE_UNARY1(tan, bfloat16);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_tanh.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_tanh.cu.cc
@@ -24,7 +24,7 @@ namespace functor {
 DEFINE_UNARY3(tanh, Eigen::half, float, double);
 #endif
 DEFINE_UNARY1(tanh, bfloat16);
-DEFINE_SIMPLE_BINARY3(tanh_grad, Eigen::half, float, double);
+DEFINE_SIMPLE_BINARY4(tanh_grad, Eigen::half, bfloat16, float, double);
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/cwise_op_gpu_xlog1py.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_xlog1py.cu.cc
@@ -24,6 +24,7 @@ namespace functor {
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 DEFINE_BINARY5(xlog1py, Eigen::half, float, double, complex64, complex128);
 #endif
+DEFINE_BINARY1(xlog1py, bfloat16);
 #endif
 
 }  // namespace functor

--- a/tensorflow/core/kernels/cwise_op_gpu_xlogy.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_gpu_xlogy.cu.cc
@@ -24,6 +24,7 @@ namespace functor {
 DEFINE_BINARY3(xlogy, Eigen::half, float, double);
 DEFINE_BINARY2(xlogy, complex64, complex128);
 #endif
+DEFINE_BINARY1(xlogy, bfloat16);
 
 }  // namespace functor
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_greater.cc
+++ b/tensorflow/core/kernels/cwise_op_greater.cc
@@ -26,6 +26,7 @@ REGISTER6(BinaryOp, GPU, "Greater", functor::greater, float, Eigen::half,
 REGISTER4(BinaryOp, GPU, "Greater", functor::greater, uint8, uint16, uint32,
           uint64);
 #endif
+REGISTER(BinaryOp, GPU, "Greater", functor::greater, bfloat16);
 
 // A special GPU kernel for int32.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel

--- a/tensorflow/core/kernels/cwise_op_greater_equal.cc
+++ b/tensorflow/core/kernels/cwise_op_greater_equal.cc
@@ -26,6 +26,7 @@ REGISTER9(BinaryOp, GPU, "GreaterEqual", functor::greater_equal, float,
           Eigen::half, double, int64, uint8, uint16, uint32, uint64, int8);
 REGISTER(BinaryOp, GPU, "GreaterEqual", functor::greater_equal, int16);
 #endif
+REGISTER(BinaryOp, GPU, "GreaterEqual", functor::greater_equal, bfloat16);
 
 // A special GPU kernel for int32.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel

--- a/tensorflow/core/kernels/cwise_op_isfinite.cc
+++ b/tensorflow/core/kernels/cwise_op_isfinite.cc
@@ -24,6 +24,7 @@ REGISTER4(UnaryOp, CPU, "IsFinite", functor::isfinite, float, Eigen::half,
 REGISTER3(UnaryOp, GPU, "IsFinite", functor::isfinite, float, Eigen::half,
           double);
 #endif
+REGISTER(UnaryOp, GPU, "IsFinite", functor::isfinite, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_isinf.cc
+++ b/tensorflow/core/kernels/cwise_op_isinf.cc
@@ -23,6 +23,7 @@ REGISTER4(UnaryOp, CPU, "IsInf", functor::isinf, float, Eigen::half, bfloat16,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "IsInf", functor::isinf, float, Eigen::half, double);
 #endif
+REGISTER(UnaryOp, GPU, "IsInf", functor::isinf, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_isnan.cc
+++ b/tensorflow/core/kernels/cwise_op_isnan.cc
@@ -23,6 +23,7 @@ REGISTER4(UnaryOp, CPU, "IsNan", functor::isnan, float, Eigen::half, double,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "IsNan", functor::isnan, float, Eigen::half, double);
 #endif
+REGISTER(UnaryOp, GPU, "IsNan", functor::isnan, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_less.cc
+++ b/tensorflow/core/kernels/cwise_op_less.cc
@@ -27,6 +27,7 @@ REGISTER9(BinaryOp, GPU, "Less", functor::less, float, Eigen::half, double,
           int64, uint8, uint16, uint32, uint64, int8);
 REGISTER(BinaryOp, GPU, "Less", functor::less, int16);
 #endif
+REGISTER(BinaryOp, GPU, "Less", functor::less, bfloat16);
 
 // A special GPU kernel for int32.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel

--- a/tensorflow/core/kernels/cwise_op_less_equal.cc
+++ b/tensorflow/core/kernels/cwise_op_less_equal.cc
@@ -27,6 +27,7 @@ REGISTER9(BinaryOp, GPU, "LessEqual", functor::less_equal, float, Eigen::half,
           double, int64, uint8, uint16, uint32, uint64, int8);
 REGISTER(BinaryOp, GPU, "LessEqual", functor::less_equal, int16);
 #endif
+REGISTER(BinaryOp, GPU, "LessEqual", functor::less_equal, bfloat16);
 
 // A special GPU kernel for int32.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel

--- a/tensorflow/core/kernels/cwise_op_log.cc
+++ b/tensorflow/core/kernels/cwise_op_log.cc
@@ -23,6 +23,7 @@ REGISTER6(UnaryOp, CPU, "Log", functor::log, float, Eigen::half, double,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Log", functor::log, float, Eigen::half, double);
 #endif
+REGISTER(UnaryOp, GPU, "Log", functor::log, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_log1p.cc
+++ b/tensorflow/core/kernels/cwise_op_log1p.cc
@@ -23,6 +23,7 @@ REGISTER6(UnaryOp, CPU, "Log1p", functor::log1p, float, Eigen::half, bfloat16,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Log1p", functor::log1p, float, Eigen::half, double);
 #endif
+REGISTER(UnaryOp, GPU, "Log1p", functor::log1p, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_not_equal_to_1.cc
+++ b/tensorflow/core/kernels/cwise_op_not_equal_to_1.cc
@@ -34,6 +34,8 @@ REGISTER_KERNEL_BUILDER(Name("NotEqual")
 REGISTER4(BinaryOp, GPU, "NotEqual", functor::not_equal_to, float, Eigen::half,
           double, uint8);
 #endif
+REGISTER(BinaryOp, GPU, "NotEqual", functor::not_equal_to, bfloat16);
+
 // A special GPU kernel for int32.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel
 // registration requires all int32 inputs and outputs to be in host memory.

--- a/tensorflow/core/kernels/cwise_op_pow.cc
+++ b/tensorflow/core/kernels/cwise_op_pow.cc
@@ -25,5 +25,6 @@ REGISTER4(BinaryOp, CPU, "Pow", functor::safe_pow, int8, int16, int32, int64_t);
 REGISTER3(BinaryOp, GPU, "Pow", functor::pow, float, Eigen::half, double);
 REGISTER(BinaryOp, GPU, "Pow", functor::safe_pow_ignore_error, int64);
 #endif
+REGISTER(BinaryOp, GPU, "Pow", functor::pow, bfloat16);
 #endif
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_round.cc
+++ b/tensorflow/core/kernels/cwise_op_round.cc
@@ -25,6 +25,7 @@ REGISTER6(UnaryOp, CPU, "Round", functor::round, Eigen::half, float, double,
 REGISTER5(UnaryOp, GPU, "Round", functor::round, Eigen::half, float, double,
           int32, int64);
 #endif
+REGISTER(UnaryOp, GPU, "Round", functor::round, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_rsqrt.cc
+++ b/tensorflow/core/kernels/cwise_op_rsqrt.cc
@@ -24,12 +24,13 @@ REGISTER6(UnaryOp, CPU, "Rsqrt", functor::rsqrt, float, Eigen::half, bfloat16,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Rsqrt", functor::rsqrt, float, Eigen::half, double);
 #endif
+REGISTER(UnaryOp, GPU, "Rsqrt", functor::rsqrt, bfloat16);
 #endif
 
 REGISTER6(SimpleBinaryOp, CPU, "RsqrtGrad", functor::rsqrt_grad, float,
           Eigen::half, bfloat16, double, complex64, complex128);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-REGISTER3(SimpleBinaryOp, GPU, "RsqrtGrad", functor::rsqrt_grad, float,
-          Eigen::half, double);
+REGISTER4(SimpleBinaryOp, GPU, "RsqrtGrad", functor::rsqrt_grad, float,
+          Eigen::half, bfloat16, double);
 #endif
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_select.cc
+++ b/tensorflow/core/kernels/cwise_op_select.cc
@@ -295,6 +295,13 @@ REGISTER_SELECT_GPU(complex128);
 #undef REGISTER_SELECT_GPU
 #endif
 
+REGISTER_KERNEL_BUILDER(
+    Name("Select").Device(DEVICE_GPU).TypeConstraint<bfloat16>("T"),
+    SelectOp<GPUDevice, bfloat16>);
+REGISTER_KERNEL_BUILDER(
+    Name("SelectV2").Device(DEVICE_GPU).TypeConstraint<bfloat16>("T"),
+    SelectV2Op<GPUDevice, bfloat16>);
+
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 

--- a/tensorflow/core/kernels/cwise_op_sigmoid.cc
+++ b/tensorflow/core/kernels/cwise_op_sigmoid.cc
@@ -24,13 +24,14 @@ REGISTER6(UnaryOp, CPU, "Sigmoid", functor::sigmoid, bfloat16, float,
 REGISTER3(UnaryOp, GPU, "Sigmoid", functor::sigmoid, float, Eigen::half,
           double);
 #endif
+REGISTER(UnaryOp, GPU, "Sigmoid", functor::sigmoid, bfloat16);
 #endif
 
 REGISTER6(SimpleBinaryOp, CPU, "SigmoidGrad", functor::sigmoid_grad, bfloat16,
           float, Eigen::half, double, complex64, complex128);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-REGISTER3(SimpleBinaryOp, GPU, "SigmoidGrad", functor::sigmoid_grad, float,
-          Eigen::half, double);
+REGISTER4(SimpleBinaryOp, GPU, "SigmoidGrad", functor::sigmoid_grad, bfloat16,
+          float, Eigen::half, double);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_sin.cc
+++ b/tensorflow/core/kernels/cwise_op_sin.cc
@@ -24,6 +24,7 @@ REGISTER6(UnaryOp, CPU, "Sin", functor::sin, float, Eigen::half, bfloat16,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Sin", functor::sin, float, Eigen::half, double);
 #endif
+REGISTER(UnaryOp, GPU, "Sin", functor::sin, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_sqrt.cc
+++ b/tensorflow/core/kernels/cwise_op_sqrt.cc
@@ -24,13 +24,14 @@ REGISTER6(UnaryOp, CPU, "Sqrt", functor::sqrt, float, Eigen::half, double,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Sqrt", functor::sqrt, float, Eigen::half, double);
 #endif
+REGISTER(UnaryOp, GPU, "Sqrt", functor::sqrt, bfloat16);
 #endif
 
 REGISTER6(SimpleBinaryOp, CPU, "SqrtGrad", functor::sqrt_grad, float,
           Eigen::half, bfloat16, double, complex64, complex128);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-REGISTER3(SimpleBinaryOp, GPU, "SqrtGrad", functor::sqrt_grad, float,
-          Eigen::half, double);
+REGISTER4(SimpleBinaryOp, GPU, "SqrtGrad", functor::sqrt_grad, float,
+          Eigen::half, bfloat16, double);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_tan.cc
+++ b/tensorflow/core/kernels/cwise_op_tan.cc
@@ -24,6 +24,7 @@ REGISTER6(UnaryOp, CPU, "Tan", functor::tan, Eigen::half, bfloat16, float,
 #if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 REGISTER3(UnaryOp, GPU, "Tan", functor::tan, Eigen::half, float, double);
 #endif
+REGISTER(UnaryOp, GPU, "Tan", functor::tan, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_tanh.cc
+++ b/tensorflow/core/kernels/cwise_op_tanh.cc
@@ -31,7 +31,7 @@ REGISTER(UnaryOp, GPU, "Tanh", functor::tanh, bfloat16)
 REGISTER6(SimpleBinaryOp, CPU, "TanhGrad", functor::tanh_grad, float,
           Eigen::half, bfloat16, double, complex64, complex128);
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-REGISTER3(SimpleBinaryOp, GPU, "TanhGrad", functor::tanh_grad, float,
-          Eigen::half, double);
+REGISTER4(SimpleBinaryOp, GPU, "TanhGrad", functor::tanh_grad, float,
+          Eigen::half, bfloat16, double);
 #endif
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_xlog1py.cc
+++ b/tensorflow/core/kernels/cwise_op_xlog1py.cc
@@ -25,6 +25,7 @@ REGISTER6(BinaryOp, CPU, "Xlog1py", functor::xlog1py, Eigen::half, bfloat16,
 REGISTER5(BinaryOp, GPU, "Xlog1py", functor::xlog1py, float, Eigen::half,
           double, complex64, complex128);
 #endif
+REGISTER(BinaryOp, GPU, "Xlog1py", functor::xlog1py, bfloat16);
 #endif
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/cwise_op_xlogy.cc
+++ b/tensorflow/core/kernels/cwise_op_xlogy.cc
@@ -25,6 +25,7 @@ REGISTER6(BinaryOp, CPU, "Xlogy", functor::xlogy, Eigen::half, bfloat16, float,
 REGISTER3(BinaryOp, GPU, "Xlogy", functor::xlogy, float, Eigen::half, double);
 REGISTER2(BinaryOp, GPU, "Xlogy", functor::xlogy, complex64, complex128);
 #endif
+REGISTER(BinaryOp, GPU, "Xlogy", functor::xlogy, bfloat16);
 #endif
 
 }  // namespace tensorflow


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/issues/59743

Previously, we added support for most BF16 ops in TF except for the cwise ops which were not used by various initializers or created by grappler. This PR enables the remaining cwise ops which have CPU bf16 implementations already.

Tested `tensorflow/python/kernel_tests/math_ops/cwise_ops_test.py` and `tensorflow/python/kernel_tests/math_ops/cwise_ops_binary_test.py`