### PR TITLE
Fixed the broken link in audio_classification/overview.md

### DIFF
--- a/tensorflow/lite/g3doc/examples/audio_classification/overview.md
+++ b/tensorflow/lite/g3doc/examples/audio_classification/overview.md
@@ -26,10 +26,10 @@ If you are new to TensorFlow Lite and are working with Android, we recommend
 exploring the following example applications that can help you get started.
 
 You can leverage the out-of-box API from
-[TensorFlow Lite Task Library](../../inference_with_metadata/task_library/audio_classifier)
+[TensorFlow Lite Task Library](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/inference_with_metadata/task_library/audio_classifier.md)
 to integrate audio classification models in just a few lines of code. You can
 also build your own custom inference pipeline using the
-[TensorFlow Lite Support Library](../../inference_with_metadata/lite_support).
+[TensorFlow Lite Support Library](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/inference_with_metadata/lite_support.md).
 
 The Android example below demonstrates the implementation using the
 [TFLite Task Library](https://github.com/tensorflow/examples/tree/master/lite/examples/audio_classification/android)

--- a/tensorflow/lite/g3doc/examples/audio_classification/overview.md
+++ b/tensorflow/lite/g3doc/examples/audio_classification/overview.md
@@ -26,7 +26,7 @@ If you are new to TensorFlow Lite and are working with Android, we recommend
 exploring the following example applications that can help you get started.
 
 You can leverage the out-of-box API from
-[TensorFlow Lite Task Library](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/inference_with_metadata/task_library/audio_classifier.md)
+[TensorFlow Lite Task Library](../../inference_with_metadata/task_library/audio_classifier.md)
 to integrate audio classification models in just a few lines of code. You can
 also build your own custom inference pipeline using the
 [TensorFlow Lite Support Library](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/inference_with_metadata/lite_support.md).


### PR DESCRIPTION
Fixed the broken link for TensorFlow Lite Task Library in line 29 and TensorFlow Lite Support Library in line 32