### PR TITLE
Add tf_gpu_tests_tags to gpu-related tests.

### DIFF
--- a/tensorflow/lite/core/experimental/acceleration/configuration/BUILD
+++ b/tensorflow/lite/core/experimental/acceleration/configuration/BUILD
@@ -1,3 +1,4 @@
+load("//tensorflow/core/platform:build_config_root.bzl", "tf_gpu_tests_tags")
 load("//tensorflow/lite/core:special_rules.bzl", "delegate_registry_visibility_allowlist")
 load("//tensorflow/lite/core/c:special_rules.bzl", "experimental_acceleration_api_allowlist")
 load("//tensorflow:tensorflow.default.bzl", "get_compatible_with_portable")
@@ -39,6 +40,7 @@ cc_library(
 cc_test(
     name = "stable_delegate_registry_test",
     srcs = ["stable_delegate_registry_test.cc"],
+    tags = tf_gpu_tests_tags(),
     deps = [
         ":stable_delegate_registry",
         "@com_google_googletest//:gtest_main",

--- a/tensorflow/lite/core/experimental/acceleration/configuration/BUILD
+++ b/tensorflow/lite/core/experimental/acceleration/configuration/BUILD
@@ -1,4 +1,3 @@
-load("//tensorflow/core/platform:build_config_root.bzl", "tf_gpu_tests_tags")
 load("//tensorflow/lite/core:special_rules.bzl", "delegate_registry_visibility_allowlist")
 load("//tensorflow/lite/core/c:special_rules.bzl", "experimental_acceleration_api_allowlist")
 load("//tensorflow:tensorflow.default.bzl", "get_compatible_with_portable")

--- a/tensorflow/lite/core/experimental/acceleration/configuration/BUILD
+++ b/tensorflow/lite/core/experimental/acceleration/configuration/BUILD
@@ -40,7 +40,6 @@ cc_library(
 cc_test(
     name = "stable_delegate_registry_test",
     srcs = ["stable_delegate_registry_test.cc"],
-    tags = tf_gpu_tests_tags(),
     deps = [
         ":stable_delegate_registry",
         "@com_google_googletest//:gtest_main",

--- a/tensorflow/lite/core/experimental/acceleration/configuration/c/BUILD
+++ b/tensorflow/lite/core/experimental/acceleration/configuration/c/BUILD
@@ -99,7 +99,6 @@ tflite_cc_library_with_c_headers_test(
 cc_test(
     name = "nnapi_plugin_test",
     srcs = ["nnapi_plugin_test.cc"],
-    tags = tf_gpu_tests_tags(),
     deps = [
         ":nnapi_plugin",
         "//tensorflow/lite/core/c:common",
@@ -126,7 +125,6 @@ tflite_cc_library_with_c_headers_test(
 cc_test(
     name = "xnnpack_plugin_test",
     srcs = ["xnnpack_plugin_test.cc"],
-    tags = tf_gpu_tests_tags(),
     deps = [
         ":xnnpack_plugin",
         "//tensorflow/lite/core/c:common",

--- a/tensorflow/lite/core/experimental/acceleration/configuration/c/BUILD
+++ b/tensorflow/lite/core/experimental/acceleration/configuration/c/BUILD
@@ -71,8 +71,8 @@ cc_test(
         "//tensorflow/lite/delegates/gpu:supports_gpu_delegate": ["gpu_plugin_test.cc"],
         "//conditions:default": [],
     }),
-    tags = tf_gpu_tests_tags(),
     linkopts = gpu_delegate_linkopts(),
+    tags = tf_gpu_tests_tags(),
     deps = select({
         "//tensorflow/lite/delegates/gpu:supports_gpu_delegate": [":gpu_plugin"],
         "//conditions:default": [],

--- a/tensorflow/lite/core/experimental/acceleration/configuration/c/BUILD
+++ b/tensorflow/lite/core/experimental/acceleration/configuration/c/BUILD
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 # C API for delegate plugins.
-
+load("//tensorflow/core/platform:build_config_root.bzl", "tf_gpu_tests_tags")
 load("//tensorflow:tensorflow.default.bzl", "get_compatible_with_portable")
 load("//tensorflow/lite:build_def.bzl", "tflite_cc_library_with_c_headers_test")
 load("//tensorflow/lite/delegates/gpu:build_defs.bzl", "gpu_delegate_linkopts")
@@ -71,6 +71,7 @@ cc_test(
         "//tensorflow/lite/delegates/gpu:supports_gpu_delegate": ["gpu_plugin_test.cc"],
         "//conditions:default": [],
     }),
+    tags = tf_gpu_tests_tags(),
     linkopts = gpu_delegate_linkopts(),
     deps = select({
         "//tensorflow/lite/delegates/gpu:supports_gpu_delegate": [":gpu_plugin"],
@@ -98,6 +99,7 @@ tflite_cc_library_with_c_headers_test(
 cc_test(
     name = "nnapi_plugin_test",
     srcs = ["nnapi_plugin_test.cc"],
+    tags = tf_gpu_tests_tags(),
     deps = [
         ":nnapi_plugin",
         "//tensorflow/lite/core/c:common",
@@ -124,6 +126,7 @@ tflite_cc_library_with_c_headers_test(
 cc_test(
     name = "xnnpack_plugin_test",
     srcs = ["xnnpack_plugin_test.cc"],
+    tags = tf_gpu_tests_tags(),
     deps = [
         ":xnnpack_plugin",
         "//tensorflow/lite/core/c:common",


### PR DESCRIPTION
Locally tested with:

```
bazelisk test -c opt --cxxopt=--std=c++17 \
 --test_tag_filters=-no_oss,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only \
 --build_tag_filters=-no_oss,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only \
 --test_lang_filters=cc,py --config=android_arm64 --flaky_test_attempts=3 \
 -- //tensorflow/lite/core/experimental/acceleration/...
```