### PR TITLE
Add flag to select enabled CPU targets

### DIFF
--- a/tensorflow/compiler/aot/BUILD
+++ b/tensorflow/compiler/aot/BUILD
@@ -1,7 +1,7 @@
 load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
 load("//tensorflow/compiler/aot:tfcompile.bzl", "tf_library")
 load("//tensorflow:tensorflow.bzl", "if_google", "if_oss", "tf_cc_binary", "tf_cc_test")
-load("//tensorflow/core/platform:build_config.bzl", "if_llvm_aarch64_available", "if_llvm_system_z_available")
+load("//tensorflow/core/platform:build_config.bzl", "if_llvm_aarch64_available", "if_llvm_arm_available", "if_llvm_powerpc_available", "if_llvm_system_z_available", "if_llvm_x86_available")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -42,9 +42,11 @@ cc_library(
         "quantize.h",
     ],
     compatible_with = [],
-    defines = if_llvm_aarch64_available(["TF_LLVM_AARCH64_AVAILABLE=1"]) + if_llvm_system_z_available([
-        "TF_LLVM_S390X_AVAILABLE=1",
-    ]),
+    defines = if_llvm_aarch64_available(["TF_LLVM_AARCH64_AVAILABLE=1"]) +
+              if_llvm_arm_available(["TF_LLVM_ARM_AVAILABLE=1"]) +
+              if_llvm_powerpc_available(["TF_LLVM_POWERPC_AVAILABLE=1"]) +
+              if_llvm_system_z_available(["TF_LLVM_S390X_AVAILABLE=1"]) +
+              if_llvm_x86_available(["TF_LLVM_X86_AVAILABLE=1"]),
     visibility = [
         "//tensorflow:__pkg__",
         "//tensorflow/python:__pkg__",
@@ -105,8 +107,9 @@ tf_cc_test(
         "//tensorflow/core/platform:resource_loader",
         "@com_google_absl//absl/strings",
         "@llvm-project//llvm:Support",  # fixdeps: keep
+    ] + if_llvm_x86_available([
         "@llvm-project//llvm:X86CodeGen",  # fixdeps: keep
-    ],
+    ]),
 )
 
 tf_cc_binary(
@@ -119,18 +122,21 @@ cc_library(
     name = "llvm_targets",
     visibility = ["//tensorflow/python:__pkg__"],
     deps = [
-        "@llvm-project//llvm:ARMAsmParser",  # fixdeps: keep
-        "@llvm-project//llvm:ARMCodeGen",  # fixdeps: keep
-        "@llvm-project//llvm:PowerPCAsmParser",  # fixdeps: keep
-        "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
-        "@llvm-project//llvm:X86AsmParser",  # fixdeps: keep
-        "@llvm-project//llvm:X86CodeGen",  # fixdeps: keep
-    ] + if_llvm_system_z_available([
-        "@llvm-project//llvm:SystemZAsmParser",  # fixdeps: keep
-        "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep
-    ]) + if_llvm_aarch64_available([
+    ] + if_llvm_aarch64_available([
         "@llvm-project//llvm:AArch64AsmParser",  # fixdeps: keep
         "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
+    ]) + if_llvm_arm_available([
+        "@llvm-project//llvm:ARMAsmParser",  # fixdeps: keep
+        "@llvm-project//llvm:ARMCodeGen",  # fixdeps: keep
+    ]) + if_llvm_powerpc_available([
+        "@llvm-project//llvm:PowerPCAsmParser",  # fixdeps: keep
+        "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
+    ]) + if_llvm_system_z_available([
+        "@llvm-project//llvm:SystemZAsmParser",  # fixdeps: keep
+        "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep
+    ]) + if_llvm_x86_available([
+        "@llvm-project//llvm:X86AsmParser",  # fixdeps: keep
+        "@llvm-project//llvm:X86CodeGen",  # fixdeps: keep
     ]),
 )
 

--- a/tensorflow/compiler/aot/codegen_test.cc
+++ b/tensorflow/compiler/aot/codegen_test.cc
@@ -178,14 +178,46 @@ static void CompareWithGoldenFile(
 TEST(CodegenTest, Golden) {
   // Normally CpuCompiler::CpuCompiler does this, but in this test we've
   // bypassed the Cpu compiler so we have to do this manually.
+#if defined(TF_LLVM_AARCH64_AVAILABLE)
+  LLVMInitializeAArch64Target();
+  LLVMInitializeAArch64TargetInfo();
+  LLVMInitializeAArch64TargetMC();
+  LLVMInitializeAArch64AsmPrinter();
+#elif defined(TF_LLVM_ARM_AVAILABLE)
+  LLVMInitializeARMTarget();
+  LLVMInitializeARMTargetInfo();
+  LLVMInitializeARMTargetMC();
+  LLVMInitializeARMAsmPrinter();
+#elif defined(TF_LLVM_POWERPC_AVAILABLE)
+  LLVMInitializePowerPCTarget();
+  LLVMInitializePowerPCTargetInfo();
+  LLVMInitializePowerPCTargetMC();
+  LLVMInitializePowerPCAsmPrinter();
+#elif defined(TF_LLVM_S390X_AVAILABLE)
+  LLVMInitializeSystemZTarget();
+  LLVMInitializeSystemZTargetInfo();
+  LLVMInitializeSystemZTargetMC();
+  LLVMInitializeSystemZAsmPrinter();
+#elif defined(TF_LLVM_X86_AVAILABLE)
   LLVMInitializeX86Target();
   LLVMInitializeX86TargetInfo();
   LLVMInitializeX86TargetMC();
   LLVMInitializeX86AsmPrinter();
+#endif
 
   CodegenOpts opts;
   opts.class_name = "MyClass";
+#if defined(TF_LLVM_AARCH64_AVAILABLE)
+  opts.target_triple = "aarch64-linux-gnu";
+#elif defined(TF_LLVM_ARM_AVAILABLE)
+  opts.target_triple = "arm-linux-gnueabihf";
+#elif defined(TF_LLVM_POWERPC_AVAILABLE)
+  opts.target_triple = "powerpc64-linux-gnu";
+#elif defined(TF_LLVM_S390X_AVAILABLE)
+  opts.target_triple = "s390x-linux-gnu";
+#elif defined(TF_LLVM_X86_AVAILABLE)
   opts.target_triple = "x86_64-pc-linux";
+#endif
   opts.namespaces = {"foo", "bar"};
   opts.gen_name_to_index = true;
   opts.gen_program_shape = true;

--- a/tensorflow/compiler/aot/compile.cc
+++ b/tensorflow/compiler/aot/compile.cc
@@ -187,29 +187,31 @@ static void InitializeTargets() {
   LLVMInitializeAArch64TargetMC();
   LLVMInitializeAArch64AsmParser();
   LLVMInitializeAArch64AsmPrinter();
-#endif
-#if TF_LLVM_S390X_AVAILABLE
-  LLVMInitializeSystemZTarget();
-  LLVMInitializeSystemZTargetInfo();
-  LLVMInitializeSystemZTargetMC();
-  LLVMInitializeSystemZAsmParser();
-  LLVMInitializeSystemZAsmPrinter();
-#endif
+#elif TF_LLVM_ARM_AVAILABLE
   LLVMInitializeARMTarget();
   LLVMInitializeARMTargetInfo();
   LLVMInitializeARMTargetMC();
   LLVMInitializeARMAsmParser();
   LLVMInitializeARMAsmPrinter();
+#elif TF_LLVM_POWERPC_AVAILABLE
   LLVMInitializePowerPCTarget();
   LLVMInitializePowerPCTargetInfo();
   LLVMInitializePowerPCTargetMC();
   LLVMInitializePowerPCAsmParser();
   LLVMInitializePowerPCAsmPrinter();
+#elif TF_LLVM_S390X_AVAILABLE
+  LLVMInitializeSystemZTarget();
+  LLVMInitializeSystemZTargetInfo();
+  LLVMInitializeSystemZTargetMC();
+  LLVMInitializeSystemZAsmParser();
+  LLVMInitializeSystemZAsmPrinter();
+#elif TF_LLVM_X86_AVAILABLE
   LLVMInitializeX86Target();
   LLVMInitializeX86TargetInfo();
   LLVMInitializeX86TargetMC();
   LLVMInitializeX86AsmParser();
   LLVMInitializeX86AsmPrinter();
+#endif
 }
 
 // Replaces {{tag.type tag.name}} in the error message with tag_name.

--- a/tensorflow/compiler/mlir/tfrt/jit/transforms/BUILD
+++ b/tensorflow/compiler/mlir/tfrt/jit/transforms/BUILD
@@ -94,8 +94,9 @@ cc_library(
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorDialect",
         "@llvm-project//mlir:VectorTransforms",
+    ] + if_llvm_x86_available([
         "@llvm-project//mlir:X86VectorTransforms",
-    ],
+    ]),
     alwayslink = 1,
 )
 

--- a/tensorflow/compiler/mlir/tools/kernel_gen/BUILD
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/BUILD
@@ -17,7 +17,10 @@ load(
 load(
     "//tensorflow/core/platform:build_config.bzl",
     "if_llvm_aarch64_available",
+    "if_llvm_arm_available",
+    "if_llvm_powerpc_available",
     "if_llvm_system_z_available",
+    "if_llvm_x86_available",
     "tf_proto_library",
 )
 
@@ -102,23 +105,26 @@ tf_cc_binary(
         "//tensorflow/core:lib",
         "@com_google_absl//absl/strings",
         "@llvm-project//llvm:Analysis",
-        "@llvm-project//llvm:ARMCodeGen",  # fixdeps: keep
         "@llvm-project//llvm:CodeGen",
         "@llvm-project//llvm:Core",
         "@llvm-project//llvm:MC",
-        "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:Target",
-        "@llvm-project//llvm:X86CodeGen",  # fixdeps: keep
-        "@llvm-project//llvm:X86Disassembler",  # fixdeps: keep
         "@llvm-project//mlir:ExecutionEngineUtils",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:LLVMToLLVMIRTranslation",
         "@llvm-project//mlir:ToLLVMIRTranslation",
-    ] + if_llvm_system_z_available([
-        "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep
-    ]) + if_llvm_aarch64_available([
+    ] + if_llvm_aarch64_available([
         "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
+    ]) + if_llvm_arm_available([
+        "@llvm-project//llvm:ARMCodeGen",  # fixdeps: keep
+    ]) + if_llvm_powerpc_available([
+        "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
+    ]) + if_llvm_system_z_available([
+        "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep
+    ]) + if_llvm_x86_available([
+        "@llvm-project//llvm:X86CodeGen",  # fixdeps: keep
+        "@llvm-project//llvm:X86Disassembler",  # fixdeps: keep
     ]),
 )
 

--- a/tensorflow/compiler/xla/mlir/math/transforms/BUILD
+++ b/tensorflow/compiler/xla/mlir/math/transforms/BUILD
@@ -1,5 +1,6 @@
 load("//tensorflow/tsl/platform:rules_cc.bzl", "cc_library")
 load("//tensorflow/tsl:tsl.default.bzl", "get_compatible_with_cloud")
+load("//tensorflow/tsl/platform:build_config.bzl", "if_llvm_x86_available")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
 
 package(
@@ -47,6 +48,7 @@ cc_library(
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorDialect",
+    ] + if_llvm_x86_available([
         "@llvm-project//mlir:X86VectorDialect",
-    ],
+    ]),
 )

--- a/tensorflow/compiler/xla/mlir/runtime/transforms/BUILD
+++ b/tensorflow/compiler/xla/mlir/runtime/transforms/BUILD
@@ -2,7 +2,7 @@ load("//tensorflow/compiler/xla:xla.bzl", "xla_cc_test")
 load("//tensorflow/tsl/platform:rules_cc.bzl", "cc_library")
 load("//tensorflow/tsl:tsl.default.bzl", "get_compatible_with_cloud")
 load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library")
-load("//tensorflow/tsl/platform:build_config.bzl", "if_llvm_system_z_available")
+load("//tensorflow/tsl/platform:build_config.bzl", "if_llvm_aarch64_available", "if_llvm_arm_available", "if_llvm_powerpc_available", "if_llvm_system_z_available", "if_llvm_x86_available")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -107,13 +107,10 @@ cc_library(
         "//tensorflow/compiler/xla/mlir/math/transforms:passes",
         "//tensorflow/compiler/xla/mlir/memref/transforms:passes",
         "//tensorflow/compiler/xla/runtime:compiler",
-        "@llvm-project//mlir:AMXToLLVMIRTranslation",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineToStandard",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithTransforms",
-        "@llvm-project//mlir:ArmNeonToLLVMIRTranslation",
-        "@llvm-project//mlir:ArmSVEToLLVMIRTranslation",
         "@llvm-project//mlir:AsyncDialect",
         "@llvm-project//mlir:AsyncToLLVM",
         "@llvm-project//mlir:AsyncTransforms",
@@ -137,8 +134,15 @@ cc_library(
         "@llvm-project//mlir:SparseTensorDialect",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorToLLVM",
+    ] + if_llvm_aarch64_available([
+        "@llvm-project//mlir:ArmNeonToLLVMIRTranslation",
+        "@llvm-project//mlir:ArmSVEToLLVMIRTranslation",
+    #]) + if_llvm_arm_available([
+    #    "@llvm-project//mlir:ArmNeonToLLVMIRTranslation",
+    ]) + if_llvm_x86_available([
+        "@llvm-project//mlir:AMXToLLVMIRTranslation",
         "@llvm-project//mlir:X86VectorToLLVMIRTranslation",
-    ],
+    ]),
     alwayslink = 1,  # has pipeline registration
 )
 
@@ -234,21 +238,14 @@ cc_library(
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:ToLLVMIRTranslation",
-    ] + select({
-        "//tensorflow/tsl:arm_any": [
-            "@llvm-project//llvm:AArch64AsmParser",
-        ],
-        "//tensorflow/tsl:linux_ppc64le": [
-            "@llvm-project//llvm:PowerPCAsmParser",
-        ],
-        "//tensorflow/tsl:macos_arm64": [
-            "@llvm-project//llvm:AArch64AsmParser",
-        ],
-        "//conditions:default": [
-            "@llvm-project//llvm:X86AsmParser",
-        ],
-    }) + if_llvm_system_z_available([
+    ] + if_llvm_aarch64_available([
+        "@llvm-project//llvm:AArch64AsmParser",
+    ]) + if_llvm_powerpc_available([
+        "@llvm-project//llvm:PowerPCAsmParser",
+    ]) + if_llvm_system_z_available([
         "@llvm-project//llvm:SystemZAsmParser",
+    ]) + if_llvm_x86_available([
+        "@llvm-project//llvm:X86AsmParser",
     ]),
 )
 

--- a/tensorflow/compiler/xla/mlir/runtime/transforms/compilation_pipeline_cpu.cc
+++ b/tensorflow/compiler/xla/mlir/runtime/transforms/compilation_pipeline_cpu.cc
@@ -70,11 +70,17 @@ void RegisterDefaultXlaCpuRuntimeDialects(DialectRegistry& dialects) {
       mlir::vector::VectorDialect, RuntimeDialect>();
 
   // Register MLIR dialects that can be translated to LLVM IR.
-  mlir::registerArmNeonDialectTranslation(*dialects);
-  mlir::registerAMXDialectTranslation(*dialects);
+#ifdef TF_LLVM_AARCH64_AVAILABLE
   mlir::registerArmSVEDialectTranslation(*dialects);
-  mlir::registerLLVMDialectTranslation(*dialects);
+#endif
+#if defined(TF_LLVM_AARCH64_AVAILABLE) || defined(TF_LLVM_ARM_AVAILABLE)
+  mlir::registerArmNeonDialectTranslation(*dialects);
+#endif
+#ifdef TF_LLVM_X86_AVAILABLE
+  mlir::registerAMXDialectTranslation(*dialects);
   mlir::registerX86VectorDialectTranslation(*dialects);
+#endif
+  mlir::registerLLVMDialectTranslation(*dialects);
 }
 
 static void CreateXlaCpuCompilationPipeline(mlir::OpPassManager& pm,

--- a/tensorflow/compiler/xla/runtime/BUILD
+++ b/tensorflow/compiler/xla/runtime/BUILD
@@ -1,6 +1,6 @@
 load("//tensorflow/compiler/xla:xla.bzl", "xla_cc_test")
 load("//tensorflow/tsl:tsl.default.bzl", "get_compatible_with_cloud")
-load("//tensorflow/tsl/platform:build_config.bzl", "if_llvm_system_z_available", "tf_platform_deps")
+load("//tensorflow/tsl/platform:build_config.bzl", "if_llvm_system_z_available", "if_llvm_aarch64_available", "if_llvm_arm_available", "if_llvm_x86_available", "tf_platform_deps")
 load("//tensorflow/tsl/platform:rules_cc.bzl", "cc_library")
 
 package(
@@ -256,26 +256,15 @@ cc_library(
         "@llvm-project//llvm:OrcJIT",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:TransformUtils",
+    ] + if_llvm_aarch64_available([
+        "@llvm-project//llvm:AArch64AsmParser",
+        "@llvm-project//llvm:AArch64CodeGen",
+    ]) + if_llvm_arm_available([
+        "@llvm-project//llvm:ARMAsmParser",
+        "@llvm-project//llvm:ARMCodeGen",
+    ]) + if_llvm_x86_available([
         "@llvm-project//llvm:X86AsmParser",
         "@llvm-project//llvm:X86CodeGen",
-    ] + select({
-        "//tensorflow/tsl:arm_any": [
-            "@llvm-project//llvm:AArch64AsmParser",  # fixdeps: keep
-            "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
-        ],
-        "//tensorflow/tsl:linux_ppc64le": [
-            "@llvm-project//llvm:PowerPCAsmParser",  # fixdeps: keep
-            "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
-        ],
-        "//tensorflow/tsl:macos_arm64": [
-            "@llvm-project//llvm:AArch64AsmParser",  # fixdeps: keep
-            "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
-        ],
-        "//conditions:default": [
-        ],
-    }) + if_llvm_system_z_available([
-        "@llvm-project//llvm:SystemZAsmParser",  # fixdeps: keep
-        "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep
     ]),
 )
 

--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -19,7 +19,7 @@ load(
     "if_enable_acl",
 )
 load(":build_defs.bzl", "runtime_copts")
-load("//tensorflow/tsl/platform:build_config.bzl", "if_llvm_system_z_available", "tf_proto_library")
+load("//tensorflow/tsl/platform:build_config.bzl", "if_llvm_aarch64_available", "if_llvm_powerpc_available", "if_llvm_system_z_available", "if_llvm_x86_available", "tf_proto_library")
 load("//tensorflow/tsl/platform:rules_cc.bzl", "cc_library")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
@@ -341,21 +341,14 @@ cc_library(
         "@llvm-project//llvm:MC",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:Target",
-        "@llvm-project//llvm:X86CodeGen",  # fixdeps: keep
-    ] + select({
-        "//tensorflow/tsl:arm_any": [
-            "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
-        ],
-        "//tensorflow/tsl:linux_ppc64le": [
-            "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
-        ],
-        "//tensorflow/tsl:macos_arm64": [
-            "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
-        ],
-        "//conditions:default": [
-        ],
-    }) + if_llvm_system_z_available([
+    ] + if_llvm_aarch64_available([
+        "@llvm-project//llvm:AArch64CodeGen",  # fixdeps: keep
+    ]) + if_llvm_powerpc_available([
+        "@llvm-project//llvm:PowerPCCodeGen",  # fixdeps: keep
+    ]) + if_llvm_system_z_available([
         "@llvm-project//llvm:SystemZCodeGen",  # fixdeps: keep
+    ]) + if_llvm_x86_available([
+        "@llvm-project//llvm:X86CodeGen",  # fixdeps: keep
     ]),
     alwayslink = True,  # Contains compiler registration
 )

--- a/tensorflow/core/platform/build_config.bzl
+++ b/tensorflow/core/platform/build_config.bzl
@@ -3,7 +3,10 @@
 load(
     "//tensorflow/tsl/platform:build_config.bzl",
     _if_llvm_aarch64_available = "if_llvm_aarch64_available",
+    _if_llvm_arm_available = "if_llvm_arm_available",
+    _if_llvm_powerpc_available = "if_llvm_powerpc_available",
     _if_llvm_system_z_available = "if_llvm_system_z_available",
+    _if_llvm_x86_available = "if_llvm_x86_available",
     _pyx_library = "pyx_library",
     _tf_additional_all_protos = "tf_additional_all_protos",
     _tf_additional_core_deps = "tf_additional_core_deps",
@@ -47,7 +50,10 @@ load(
 )
 
 if_llvm_aarch64_available = _if_llvm_aarch64_available
+if_llvm_arm_available = _if_llvm_arm_available
+if_llvm_powerpc_available = _if_llvm_powerpc_available
 if_llvm_system_z_available = _if_llvm_system_z_available
+if_llvm_x86_available = _if_llvm_x86_available
 pyx_library = _pyx_library
 tf_additional_all_protos = _tf_additional_all_protos
 tf_additional_binary_deps = _tf_additional_binary_deps

--- a/tensorflow/tsl/platform/build_config.bzl
+++ b/tensorflow/tsl/platform/build_config.bzl
@@ -3,7 +3,10 @@
 load(
     "//tensorflow/tsl/platform/default:build_config.bzl",
     _if_llvm_aarch64_available = "if_llvm_aarch64_available",
+    _if_llvm_arm_available = "if_llvm_arm_available",
+    _if_llvm_powerpc_available = "if_llvm_powerpc_available",
     _if_llvm_system_z_available = "if_llvm_system_z_available",
+    _if_llvm_x86_available = "if_llvm_x86_available",
     _pyx_library = "pyx_library",
     _tf_additional_all_protos = "tf_additional_all_protos",
     _tf_additional_core_deps = "tf_additional_core_deps",
@@ -43,7 +46,10 @@ load(
 )
 
 if_llvm_aarch64_available = _if_llvm_aarch64_available
+if_llvm_arm_available = _if_llvm_arm_available
+if_llvm_powerpc_available = _if_llvm_powerpc_available
 if_llvm_system_z_available = _if_llvm_system_z_available
+if_llvm_x86_available = _if_llvm_x86_available
 pyx_library = _pyx_library
 tf_additional_all_protos = _tf_additional_all_protos
 tf_additional_core_deps = _tf_additional_core_deps

--- a/tensorflow/tsl/platform/default/build_config.bzl
+++ b/tensorflow/tsl/platform/default/build_config.bzl
@@ -859,11 +859,32 @@ def tf_google_mobile_srcs_only_runtime():
     return []
 
 def if_llvm_aarch64_available(then, otherwise = []):
-    return then
+    return select({
+        clean_dep("//tensorflow/tsl:linux_aarch64"): then,
+        "//conditions:default": otherwise,
+    })
+
+def if_llvm_arm_available(then, otherwise = []):
+    return select({
+        clean_dep("//tensorflow/tsl:linux_armhf"): then,
+        "//conditions:default": otherwise,
+    })
+
+def if_llvm_powerpc_available(then, otherwise = []):
+    return select({
+        clean_dep("//tensorflow/tsl:linux_ppc64le"): then,
+        "//conditions:default": otherwise,
+    })
 
 def if_llvm_system_z_available(then, otherwise = []):
     return select({
         clean_dep("//tensorflow/tsl:linux_s390x"): then,
+        "//conditions:default": otherwise,
+    })
+
+def if_llvm_x86_available(then, otherwise = []):
+    return select({
+        clean_dep("//tensorflow/tsl:linux_x86_64"): then,
         "//conditions:default": otherwise,
     })
 


### PR DESCRIPTION
Default flag to current set of support targets to keep the default of enabling all CPU targets. This fixes issue [#59595](https://github.com/tensorflow/tensorflow/issues/59595) as well as some confusiong around Host Vs Target.