### PR TITLE
[oneDNN] Fixing a failure in mkl_fused_batch_norm_op_test

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op_test.cc
@@ -159,7 +159,8 @@ class CommonTestUtilities : public OpsTestBase {
     ASSERT_EQ(offset_backprop.shape(), mkl_offset_backprop.shape());
 
     test::ExpectClose(output, mkl_output, 1e-5);
-    test::ExpectClose(scale_backprop, mkl_scale_backprop, 1e-5, /*rtol*/ 1e-5);
+    test::ExpectClose(scale_backprop, mkl_scale_backprop, /*atol=*/1e-5,
+                      /*rtol=*/1e-5);
     test::ExpectClose(offset_backprop, mkl_offset_backprop, 1e-5);
   }
 

--- a/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op_test.cc
@@ -159,7 +159,7 @@ class CommonTestUtilities : public OpsTestBase {
     ASSERT_EQ(offset_backprop.shape(), mkl_offset_backprop.shape());
 
     test::ExpectClose(output, mkl_output, 1e-5);
-    test::ExpectClose(scale_backprop, mkl_scale_backprop, 1e-5);
+    test::ExpectClose(scale_backprop, mkl_scale_backprop, 1e-5, /*rtol*/ 1e-5);
     test::ExpectClose(offset_backprop, mkl_offset_backprop, 1e-5);
   }
 


### PR DESCRIPTION
This PR fixes a failure in a test that was enabled recently by this [PR](https://github.com/tensorflow/tensorflow/commit/155b34bad741124f778978f806d82551f9d35a66). The reference values are slightly changed due to use of different gemm-api. That resulted in a one value mismatch. So we are updating the test by adding relative error tolerance.