### PR TITLE
[NVIDIA TF] CollectiveAllToAllV2 + NCCL all-to-all fixes

### DIFF
--- a/tensorflow/core/kernels/collective_nccl_test.cc
+++ b/tensorflow/core/kernels/collective_nccl_test.cc
@@ -219,7 +219,9 @@ class NcclTestBase : public ::testing::Test {
     }
 
     void RunAllToAll() {
-      output_ = input_;
+      // Allocate output. We can't reuse the input because NCCL does not support
+      // in-place all-to-all.
+      output_ = Tensor(DT_FLOAT, input_.shape());
       status_ = tensorflow::RunCollective(test_env_, col_params_.get(), device_,
                                           &input_, &output_);
     }

--- a/tensorflow/core/nccl/nccl_manager.cc
+++ b/tensorflow/core/nccl/nccl_manager.cc
@@ -879,9 +879,9 @@ void NcclManager::LoopKernelLaunches(NcclStream* nccl_stream) {
         VLOG(2) << "call Nccl All to All collective_key "
                 << collective->collective_key << " participant " << p_idx
                 << " num_participants " << collective->participants.size()
-                << " sendbuff " << static_cast<const char*>(sendbuff)
-                << " recvbuff " << static_cast<char*>(recvbuff) << " nccl_comm "
-                << nccl_comm << " comm_stream " << comm_stream
+                << " sendbuff " << static_cast<const void*>(sendbuff)
+                << " recvbuff " << static_cast<void*>(recvbuff)
+                << " nccl_comm " << nccl_comm << " comm_stream " << comm_stream
                 << " cuda_stream " << cu_stream;
         profiler::AnnotatedTraceMe traceme([&] {
           return profiler::TraceMeEncode(
@@ -890,11 +890,13 @@ void NcclManager::LoopKernelLaunches(NcclStream* nccl_stream) {
                {"collective_type", "all_to_all"}});
         });
         ncclGroupStart();
-        for (int r = 0; r < collective->participants.size(); ++r) {
-          ncclSend(sendbuff + r * rank_offset, count, data_type, r, nccl_comm,
-                   *cu_stream);
-          ncclRecv(recvbuff + r * rank_offset, count, data_type, r, nccl_comm,
-                   *cu_stream);
+        for (int i = 0; i < collective->participants.size(); ++i) {
+          ncclSend(
+              sendbuff + i * rank_offset, count, data_type,
+              collective->participants[i]->global_rank, nccl_comm, *cu_stream);
+          ncclRecv(
+              recvbuff + i * rank_offset, count, data_type,
+              collective->participants[i]->global_rank, nccl_comm, *cu_stream);
         }
         nccl_result = ncclGroupEnd();
         break;


### PR DESCRIPTION
This PR fixes a few small bugs with `CollectiveAllToAllV2` and NCCL all-to-all:

* NCCL does not support in-place all-to-all, so don't reuse the input tensor in `CollectiveAllToAllV2`. We could potentially keep `forward_input_or_allocate_output` and allocate a temporary buffer inside the NCCL backend only when the input is reused. This would allow other backends to still perform an in-place all-to-all. It looks like the ring algorithm uses temporary output buffers anyway.
* Update calls to `ncclSend` and `ncclRecv` to follow the mapping by using `global_rank`. The TF runtime can sometimes [reorder the GPUs](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/common_runtime/collective_param_resolver_local.cc#L577-L580) to optimize the ring algorithms. While this PR fixes nccl all-to-all to follow the ordering, the ring algorithm is also affected and gives incorrect results.
* VLOG outputs in `nccl_manager.cc` would cause a crash due to interpretting the data buffer as a string.