### PR TITLE
build: use LINK_COMPONENTS for linking LLVMSupport

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/mhlo/utils/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/mhlo/utils/CMakeLists.txt
@@ -26,9 +26,9 @@ add_mlir_library(MhloRngUtils
 
   LINK_COMPONENTS
   Core
+  Support
 
   LINK_LIBS PUBLIC
-  LLVMSupport
   MhloDialect
   MLIRArithDialect
   MLIRIR


### PR DESCRIPTION
Without this patch, in-tree builds of LLVM+MHLO fail with the following
message:

```
MhloRngUtils specifies LINK_LIBS LLVMSupport, but LINK_LIBS cannot be used
for LLVM libraries.  Please use LINK_COMPONENTS instead.
```