### PR TITLE
Update label_image.py to be compatible with TF 2.x

### DIFF
--- a/tensorflow/examples/label_image/label_image.py
+++ b/tensorflow/examples/label_image/label_image.py
@@ -17,11 +17,11 @@ import argparse
 
 import numpy as np
 import tensorflow as tf
-
+tf.compat.v1.disable_eager_execution()
 
 def load_graph(model_file):
   graph = tf.Graph()
-  graph_def = tf.GraphDef()
+  graph_def = tf.compat.v1.GraphDef()
 
   with open(model_file, "rb") as f:
     graph_def.ParseFromString(f.read())
@@ -38,7 +38,7 @@ def read_tensor_from_image_file(file_name,
                                 input_std=255):
   input_name = "file_reader"
   output_name = "normalized"
-  file_reader = tf.read_file(file_name, input_name)
+  file_reader = tf.io.read_file(file_name, input_name)
   if file_name.endswith(".png"):
     image_reader = tf.io.decode_png(file_reader, channels=3, name="png_reader")
   elif file_name.endswith(".gif"):
@@ -50,14 +50,14 @@ def read_tensor_from_image_file(file_name,
         file_reader, channels=3, name="jpeg_reader")
   float_caster = tf.cast(image_reader, tf.float32)
   dims_expander = tf.expand_dims(float_caster, 0)
-  resized = tf.image.resize_bilinear(dims_expander, [input_height, input_width])
+  resized = tf.compat.v1.image.resize_bilinear(dims_expander, [input_height, input_width])
   normalized = tf.divide(tf.subtract(resized, [input_mean]), [input_std])
   sess = tf.compat.v1.Session()
   return sess.run(normalized)
 
 
 def load_labels(label_file):
-  proto_as_ascii_lines = tf.gfile.GFile(label_file).readlines()
+  proto_as_ascii_lines = tf.io.gfile.GFile(label_file).readlines()
   return [l.rstrip() for l in proto_as_ascii_lines]
 
 


### PR DESCRIPTION
The label_image.py is outdated. Added necessary changes to be able to run in TF 2.x version.  Please do the needful.

Fixes #59900

Thanks.