### PR TITLE
lite: Add config option to enable label_image example

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -61,6 +61,7 @@ set(CMAKE_PREFIX_PATH
 include(GNUInstallDirs)
 include(CMakeDependentOption)
 option(TFLITE_ENABLE_INSTALL "Enable install rule" OFF)
+option(TFLITE_ENABLE_LABEL_IMAGE "Enable label_image example" OFF)
 option(TFLITE_ENABLE_RUY "Enable experimental RUY integration" OFF)
 option(TFLITE_ENABLE_RESOURCE "Enable experimental support for resources" ON)
 option(TFLITE_ENABLE_NNAPI "Enable NNAPI (Android only)." ON)

--- a/tensorflow/lite/examples/label_image/CMakeLists.txt
+++ b/tensorflow/lite/examples/label_image/CMakeLists.txt
@@ -56,9 +56,16 @@ if(TFLITE_ENABLE_GPU)
 endif()  # TFLITE_ENABLE_GPU
 
 add_executable(label_image
-  EXCLUDE_FROM_ALL
   ${TFLITE_LABEL_IMAGE_SRCS}
 )
+if(TFLITE_ENABLE_LABEL_IMAGE)
+  set_target_properties(label_image PROPERTIES EXCLUDE_FROM_ALL FALSE)
+  if(TFLITE_ENABLE_INSTALL)
+    install(TARGETS label_image)
+  endif()  # TFLITE_ENABLE_INSTALL
+else()
+  set_target_properties(label_image PROPERTIES EXCLUDE_FROM_ALL TRUE)
+endif()  # TFLITE_ENABLE_LABEL_IMAGE
 target_compile_options(label_image
   PRIVATE
     ${TFLITE_LABEL_IMAGE_CC_OPTIONS}


### PR DESCRIPTION
It's handy to have an option to enable the label_image example so that it can be built and installed using the all target which is preferable in some cases when packaging tensorflow-lite.