### PR TITLE
Reduce MKL overheads on small shapes by not rewriting node to use MKL

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -432,7 +432,7 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     rinfothr_.push_back(
         {{csinfo_.conv2d, mkl_op_registry::GetMklOpName(csinfo_.conv2d),
           CopyAttrsConvCheckConstFilter,
-          std::function<bool(const Node*)>(),  // we set this function to empty
+          std::function<bool(const Node*)>(),  // We set this function to empty.
           GetRewriteCause()},
          Conv2DRewrite});
     rinfo_.push_back({csinfo_.conv2d_with_bias,

--- a/tensorflow/core/common_runtime/mkl_layout_pass.h
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.h
@@ -25,26 +25,6 @@ limitations under the License.
 #include "tensorflow/core/graph/graph.h"
 
 namespace tensorflow {
-
-struct RewriteThreshold {
-  string op;
-  int cpu_family;
-  int cpu_model_num;
-  // The model that is used to decide whether it is worth
-  // accelerating operations using oneDNN is:
-  //
-  // threshold = thread_synchronisation * thread_num + framework_tax
-  //
-  // This finds threshold when framework overhead and thread synchronisations
-  // are amortized with amount of computation that has to be performed.
-  // If we are below this threshold then we will not rewrite the operation to
-  // to be run using oneDNN primitive.
-  struct PerformanceParameters {
-    double thread_sync_cost;
-    double framework_cost;
-  } params;
-};
-
 // Interface to invoke the pass for unit test
 //
 // Returns true if and only if 'g' is mutated.

--- a/tensorflow/core/common_runtime/mkl_layout_pass.h
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.h
@@ -32,8 +32,10 @@ struct RewriteThreshold {
   int cpu_model_num;
   // The model that is used to decide whether it is worth
   // accelerating operations using oneDNN is:
+  //
   // threshold = thread_synchronisation*thread_num + framework_tax
-  // which finds threshold when framework overhead and thread synchronisations
+  //
+  // This finds threshold when framework overhead and thread synchronisations
   // are amortized with amount of computation that has to be performed.
   // If we are below this threshold then we will not rewrite the operation to
   // to be run using oneDNN primitive.

--- a/tensorflow/core/common_runtime/mkl_layout_pass.h
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.h
@@ -25,6 +25,24 @@ limitations under the License.
 #include "tensorflow/core/graph/graph.h"
 
 namespace tensorflow {
+
+struct RewriteThreshold {
+  string op;
+  int cpu_family;
+  int cpu_model_num;
+  // The model that is used to decide whether it is worth
+  // accelerating operations using oneDNN is:
+  // threshold = thread_synchronisation*thread_num + framework_tax
+  // which finds threshold when framework overhead and thread synchronisations
+  // are amortized with amount of computation that has to be performed.
+  // If we are below this threshold then we will not rewrite the operation to
+  // to be run using oneDNN primitive.
+  struct PerformanceParameters {
+    double thread_sync_cost;
+    double framework_cost;
+  } params;
+};
+
 // Interface to invoke the pass for unit test
 //
 // Returns true if and only if 'g' is mutated.

--- a/tensorflow/core/common_runtime/mkl_layout_pass.h
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.h
@@ -33,7 +33,7 @@ struct RewriteThreshold {
   // The model that is used to decide whether it is worth
   // accelerating operations using oneDNN is:
   //
-  // threshold = thread_synchronisation*thread_num + framework_tax
+  // threshold = thread_synchronisation * thread_num + framework_tax
   //
   // This finds threshold when framework overhead and thread synchronisations
   // are amortized with amount of computation that has to be performed.

--- a/tensorflow/core/common_runtime/optimize_function_graph_utils.cc
+++ b/tensorflow/core/common_runtime/optimize_function_graph_utils.cc
@@ -553,6 +553,13 @@ StatusOr<OptimizedFunctionGraphInfo> OptimizeFunctionGraph(
       options.shape_inference_on_tfe_dialect_import;
   optimization_options.debug_filename_prefix = function_name;
 
+  if (cpu_device->tensorflow_cpu_worker_threads() != nullptr) {
+    // Pass to the optimisation pass number of intra threads that are used to
+    // parallelise operations
+    session_options.config.set_intra_op_parallelism_threads(
+        cpu_device->tensorflow_cpu_worker_threads()->num_threads);
+  }
+
   DEBUG_DATA_DUMPER()->DumpGraph(function_name, kDebugGroupMain,
                                  "before_pre_placement_passes", graph.get(),
                                  &reachable_lib_def, false);

--- a/tensorflow/core/common_runtime/optimize_function_graph_utils.cc
+++ b/tensorflow/core/common_runtime/optimize_function_graph_utils.cc
@@ -554,8 +554,8 @@ StatusOr<OptimizedFunctionGraphInfo> OptimizeFunctionGraph(
   optimization_options.debug_filename_prefix = function_name;
 
   if (cpu_device->tensorflow_cpu_worker_threads() != nullptr) {
-    // Pass to the optimisation pass number of intra threads that are used to
-    // parallelise operations
+    // Forward to the optimisation pass number of intra threads that are used to
+    // parallelise operations.
     session_options.config.set_intra_op_parallelism_threads(
         cpu_device->tensorflow_cpu_worker_threads()->num_threads);
   }

--- a/tensorflow/core/common_runtime/optimize_function_graph_utils.h
+++ b/tensorflow/core/common_runtime/optimize_function_graph_utils.h
@@ -93,7 +93,8 @@ PreprocessAndPartitionGraph(
     OptimizedFunctionGraphInfo& input_optimized_graph,
     const FunctionLibraryRuntime::InstantiateOptions& options,
     const DeviceSet& dev_set, const FunctionLibraryDefinition* input_lib_def,
-    const std::vector<CompositeDevice*>& composite_devices, Env* env);
+    const std::vector<CompositeDevice*>& composite_devices, Env* env,
+    Device* cpu_device);
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/common_runtime/process_function_library_runtime.cc
+++ b/tensorflow/core/common_runtime/process_function_library_runtime.cc
@@ -587,10 +587,10 @@ Status ProcessFunctionLibraryRuntime::InstantiateMultiDevice(
   optimized_graph_info->function_graph->mutable_flib_def()
       ->set_default_registry(&(optimized_graph_info->lib_def));
 
-  TF_ASSIGN_OR_RETURN(
-      auto subgraphs,
-      PreprocessAndPartitionGraph(function_name, *optimized_graph_info, options,
-                                  *dev_set, lib_def_, composite_devices, env_));
+  TF_ASSIGN_OR_RETURN(auto subgraphs, PreprocessAndPartitionGraph(
+                                          function_name, *optimized_graph_info,
+                                          options, *dev_set, lib_def_,
+                                          composite_devices, env_, cpu_device));
   const uint64 optimization_end_time_usecs = Env::Default()->NowMicros();
   const uint64 graph_optimization_duration =
       optimization_end_time_usecs - optimization_start_time_usecs;

--- a/tensorflow/core/graph/mkl_graph_util.h
+++ b/tensorflow/core/graph/mkl_graph_util.h
@@ -288,6 +288,7 @@ static inline bool IsMklElementWiseOp(const string& op_name, DataType T) {
                  0 == op_name.compare(GetMklOpName("Sub")) ||
                  0 == op_name.compare(GetMklOpName("Mul")) ||
                  0 == op_name.compare(GetMklOpName("Maximum")) ||
+                 0 == op_name.compare(GetMklOpName("Sigmoid")) ||
                  0 == op_name.compare(GetMklOpName("SquaredDifference")));
 
   return result;

--- a/tensorflow/core/grappler/grappler_item.h
+++ b/tensorflow/core/grappler/grappler_item.h
@@ -27,6 +27,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/variable.pb.h"
 #include "tensorflow/core/protobuf/queue_runner.pb.h"
+#include "tensorflow/tsl/platform/cpu_info.h"
 
 namespace tensorflow {
 namespace grappler {
@@ -102,6 +103,9 @@ struct GrapplerItem {
 
     // Mark the grapper optimization run in eager mode or not.
     bool is_eager_mode = false;
+
+    // Number of intra threads used to run operation.
+    int intra_op_parallelism_threads = tsl::port::MaxParallelism();
   };
 
   const std::unordered_set<string>& devices() const;

--- a/tensorflow/core/grappler/optimizers/meta_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.cc
@@ -1383,6 +1383,12 @@ Status OptimizeGraph(
   tensorflow::grappler::GrapplerItem item;
   item.id = grappler_item_id;
   item.optimization_options() = optimization_options;
+  if (cpu_device->tensorflow_cpu_worker_threads() != nullptr) {
+    // Forward to the optimisation pass number of intra threads that are used to
+    // parallelise operations.
+    item.optimization_options().intra_op_parallelism_threads =
+        cpu_device->tensorflow_cpu_worker_threads()->num_threads;
+  }
 
   // Add all available devices so that inlined function can be placed.
   for (const Device* d : device_set.devices()) {

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -2736,7 +2736,7 @@ void CopyConv2DAttributes(const NodeDef& conv2d, NodeDef* fused_conv2d,
   (*attr)["data_format"] = src_attr.at("data_format");
   (*attr)["use_cudnn_on_gpu"] = src_attr.at("use_cudnn_on_gpu");
   // When copying attributes check whether this convolution has
-  // attribute that describes the shapes on which it is working
+  // attribute that describes the shapes on which it is working.
   if (IsMKLEnabled()) {
     (*attr)["_input_shapes"] = src_attr.at("_input_shapes");
   }
@@ -4409,7 +4409,7 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
     ContractionWithBiasAndAddActivation contract_with_bias_and_add_activation;
 
     // Store dimensions so that they can be retrieved later in
-    // mkl_layout_rewrite_pass when deciding whether to rewrite node
+    // mkl_layout_rewrite_pass when deciding whether to rewrite node.
     if (IsConv2D(ctx.graph_view.graph()->node(i)) ||
         IsFusedBatchNorm(ctx.graph_view.graph()->node(i)) ||
         IsDepthwiseConv2dNative(ctx.graph_view.graph()->node(i)) ||

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -4401,7 +4401,9 @@ bool RequiresInferredShapes(const RemapperContext& ctx, int node_index,
   if (IsMKLEnabled())
     return is_batch_norm_candidate() || is_batch_norm_fusion_candidate() ||
            IsContractionWithAdd(ctx, node_index) ||
-           is_act_biasadd_conv_candidate();
+           is_act_biasadd_conv_candidate() ||
+           IsBiasAdd(*node_def) ||
+           IsTranspose(*node_def);
 
   return is_act_biasadd_conv_candidate() || is_batch_norm_candidate() ||
          is_batch_norm_fusion_candidate() ||
@@ -4463,6 +4465,8 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
     if (IsConv2D(ctx.graph_view.graph()->node(i)) ||
         IsFusedBatchNorm(ctx.graph_view.graph()->node(i)) ||
         IsDepthwiseConv2dNative(ctx.graph_view.graph()->node(i)) ||
+        IsBiasAdd(ctx.graph_view.graph()->node(i)) ||
+        IsTranspose(ctx.graph_view.graph()->node(i)) ||
         IsSigmoid(ctx.graph_view.graph()->node(i))) {
       AddInputShapesAttr(ctx, i);
     }

--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -11,6 +11,7 @@ load(
     "check_deps",
     "tf_cc_test",
     "tf_cc_tests",
+    "tf_cc_test_mkl",
     "tf_copts",
     "tf_cuda_library",
     "tf_cuda_only_cc_test",
@@ -163,6 +164,7 @@ filegroup(
         "matmul_autotune.h",
         "matmul_bcast.h",
         "mirror_pad_mode.h",
+        "mkl_heuristics.h",
         "mkl_util.h",
         "onednn_env_vars.h",
         "overflow.h",
@@ -295,6 +297,7 @@ filegroup(
 filegroup(
     name = "mkl_util_hdrs",
     srcs = [
+        "mkl_heuristics.h",
         "mkl_util.h",
         "onednn_env_vars.h",
         "//tensorflow/tsl/util:onednn_util_hdrs",
@@ -954,6 +957,21 @@ tf_cc_test(
         "//tensorflow/core/platform",
         "@com_google_absl//absl/functional:bind_front",
         "@com_google_absl//absl/time",
+    ],
+)
+
+tf_cc_test_mkl(
+    name = "mkl_heuristics_test",
+    size = "small",
+    srcs = ["mkl_heuristics_test.cc"],
+    linkstatic = 1,  # Fixes dyld error on MacOS.
+    deps = [
+        "//tensorflow/core:framework_lite",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:graph",
+        "//tensorflow/core:framework",
+        "//tensorflow/core/kernels:ops_testutil",
     ],
 )
 

--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -10,8 +10,8 @@ load(
     "//tensorflow:tensorflow.bzl",
     "check_deps",
     "tf_cc_test",
-    "tf_cc_tests",
     "tf_cc_test_mkl",
+    "tf_cc_tests",    
     "tf_copts",
     "tf_cuda_library",
     "tf_cuda_only_cc_test",
@@ -966,11 +966,11 @@ tf_cc_test_mkl(
     srcs = ["mkl_heuristics_test.cc"],
     linkstatic = 1,  # Fixes dyld error on MacOS.
     deps = [
+        "//tensorflow/core:framework",    
         "//tensorflow/core:framework_lite",
+        "//tensorflow/core:graph",	
         "//tensorflow/core:test",
         "//tensorflow/core:test_main",
-        "//tensorflow/core:graph",
-        "//tensorflow/core:framework",
         "//tensorflow/core/kernels:ops_testutil",
     ],
 )

--- a/tensorflow/core/util/mkl_heuristics.h
+++ b/tensorflow/core/util/mkl_heuristics.h
@@ -1,0 +1,123 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file contains heuristics data and methods that are used to
+// decide whether to rewrite node to use oneDNN kernels
+
+#ifndef TENSORFLOW_CORE_UTIL_MKL_HEURISTICS_H
+#define TENSORFLOW_CORE_UTIL_MKL_HEURISTICS_H_
+#ifdef INTEL_MKL
+
+#include "tensorflow/tsl/platform/cpu_info.h"
+
+namespace tensorflow {
+
+struct RewriteThreshold {
+  string op;
+  int cpu_family;
+  int cpu_model_num;
+  // The model that is used to decide whether it is worth
+  // accelerating operations using oneDNN is:
+  //
+  // threshold = thread_synchronisation * thread_num + framework_tax
+  //
+  // This finds threshold when framework overhead and thread synchronisations
+  // are amortized with amount of computation that has to be performed.
+  // If we are below this threshold then we will not rewrite the operation to
+  // to be run using oneDNN primitive.
+  struct PerformanceParameters {
+    double thread_sync_cost;
+    double framework_cost;
+  } params;
+};
+
+// Table storing thread synchronization and framework overhead costs on each CPU
+// architecture for each oneNN-eligible operation. Our heuristics use these
+// costs to determine whether we should rewrite the operation to use oneDNN.
+static const RewriteThreshold rewrite_thresholds[] = {
+#ifdef DNNL_AARCH64_USE_ACL
+    {"Conv2D", 0x41, 0xd40, {0.9349, 22.603}},
+    {"_FusedConv2D", 0x41, 0xd40, {0.9349, 22.603}},
+    {"FusedBatchNormV3", 0x41, 0xd40, {0.3223, -0.8822}},
+    {"Sigmoid", 0x41, 0xd40, {0.0, 0.064736}},
+#endif  // DNNL_AARCH64_USE_ACL
+    {"", 0x0, 0x0, {0, 0}}};
+
+static double FindRewriteThreshold(const string node_name, int threads) {
+  int cpu_family_ = tsl::port::CPUFamily();
+  int cpu_model_num_ = tsl::port::CPUModelNum();
+
+  if (threads == 0) {
+    // if we do not have information how many threads are used
+    // to parallelise operation we revert to the old behaviour
+    return 0;
+  }
+
+  for (const RewriteThreshold* i = rewrite_thresholds;
+       i->op != "" && threads > 0; i++) {
+    if (node_name == i->op && cpu_family_ == i->cpu_family &&
+        cpu_model_num_ == i->cpu_model_num) {
+      return i->params.thread_sync_cost * threads + i->params.framework_cost;
+    }
+  }
+
+  return 0;
+}
+
+static double CalculateNodeMFlops(const AttrSlice& attrs,
+                                  const string node_name) {
+  // Check if we can obtained dimensions for this node.
+  std::vector<const TensorShapeProto*> shape_attrs;
+  if (!TryGetNodeAttr(attrs, "_input_shapes", &shape_attrs)) {
+    // We can't obtain shape so we will revert to default behaviour
+    // to rewrite node.
+    return -1;
+  }
+
+  if ((node_name == "Conv2D" || node_name == "_FusedConv2D") &&
+      shape_attrs.size() == 2) {
+    TensorShape input_shape, filter_shape;
+    if (TensorShape::BuildTensorShape(*shape_attrs[0], &input_shape) !=
+        tsl::OkStatus()) {
+      return -1;
+    }
+    if (TensorShape::BuildTensorShape(*shape_attrs[1], &filter_shape) !=
+        tsl::OkStatus()) {
+      return -1;
+    }
+
+    // MFLOPS = N * H * W * C * FH * FW * FC / 1e6.
+    return input_shape.dim_size(0) * input_shape.dim_size(1) *
+           input_shape.dim_size(2) * input_shape.dim_size(3) *
+           filter_shape.dim_size(0) * filter_shape.dim_size(1) *
+           filter_shape.dim_size(3) / (double)1e6;
+  } else if ((node_name == "FusedBatchNormV3" || node_name == "Sigmoid") &&
+             shape_attrs.size() >= 1) {
+    TensorShape input_shape;
+    if (TensorShape::BuildTensorShape(*shape_attrs[0], &input_shape) !=
+        tsl::OkStatus()) {
+      return -1;
+    }
+    return input_shape.dim_size(0) * input_shape.dim_size(1) *
+           input_shape.dim_size(2) * input_shape.dim_size(3) / (double)1e6;
+  }
+
+  return -1;
+}
+
+}  // namespace tensorflow
+
+#endif  // INTEL_MKL
+#endif  // TENSORFLOW_CORE_UTIL_MKL_HEURISTICS_H_

--- a/tensorflow/core/util/mkl_heuristics.h
+++ b/tensorflow/core/util/mkl_heuristics.h
@@ -20,12 +20,16 @@ limitations under the License.
 #define TENSORFLOW_CORE_UTIL_MKL_HEURISTICS_H_
 #ifdef INTEL_MKL
 
+#include <vector>
+
+#include "tensorflow/core/framework/node_def.pb.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
 #include "tensorflow/tsl/platform/cpu_info.h"
 
 namespace tensorflow {
 
 struct RewriteThreshold {
-  string op;
+  std::string op;
   int cpu_family;
   int cpu_model_num;
   // The model that is used to decide whether it is worth

--- a/tensorflow/core/util/mkl_heuristics.h
+++ b/tensorflow/core/util/mkl_heuristics.h
@@ -22,8 +22,7 @@ limitations under the License.
 
 #include <vector>
 
-#include "tensorflow/core/framework/node_def.pb.h"
-#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/framework/node_def_util.h"
 #include "tensorflow/tsl/platform/cpu_info.h"
 
 namespace tensorflow {

--- a/tensorflow/core/util/mkl_heuristics_test.cc
+++ b/tensorflow/core/util/mkl_heuristics_test.cc
@@ -1,0 +1,120 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifdef INTEL_MKL
+#define EIGEN_USE_THREADS
+
+#include "tensorflow/core/util/mkl_heuristics.h"
+
+#include "tensorflow/core/framework/node_def.pb.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+
+namespace {
+
+TEST(MklHeuristicsTest, MklCalculateMFlops) {
+  int batch = 8;
+  int width = 32;
+  int height = 32;
+  int in_depth = 3;
+
+  int filter_h = 3;
+  int filter_w = 3;
+  int out_depth = 64;
+
+  // Test calculation for number of MFLOPs for convolution
+  AttrValue attr_input_shape;
+  TensorShapeProto* proto = attr_input_shape.mutable_list()->add_shape();
+  proto->add_dim()->set_size(batch);
+  proto->add_dim()->set_size(width);
+  proto->add_dim()->set_size(height);
+  proto->add_dim()->set_size(in_depth);
+  proto = attr_input_shape.mutable_list()->add_shape();
+  proto->add_dim()->set_size(filter_h);
+  proto->add_dim()->set_size(filter_w);
+  proto->add_dim()->set_size(in_depth);
+  proto->add_dim()->set_size(out_depth);
+
+  NodeDef ndef;
+
+  // If node doesn't have any _input_shapes it should return -1
+  double calculated_empty_mflops =
+      CalculateNodeMFlops(AttrSlice(ndef), "Conv2D");
+  EXPECT_EQ(calculated_empty_mflops, -1);
+
+  (*ndef.mutable_attr())["_input_shapes"] = attr_input_shape;
+
+  double conv_calculated_mflops =
+      CalculateNodeMFlops(AttrSlice(ndef), "Conv2D");
+  double expected_conv_mflops = batch * width * height * in_depth * filter_h *
+                                filter_w * out_depth / double(1e6);
+  EXPECT_EQ(conv_calculated_mflops, expected_conv_mflops);
+
+  // We should get the same calculation for fused convolution too
+  double fused_calculated_mflops =
+      CalculateNodeMFlops(AttrSlice(ndef), "_FusedConv2D");
+  EXPECT_EQ(conv_calculated_mflops, expected_conv_mflops);
+
+  // Finally calculate for sigmoid number of MFLOPS
+  double sigmoid_calculated_mflops =
+      CalculateNodeMFlops(AttrSlice(ndef), "Sigmoid");
+  double expected_sigmoid_mflops =
+      batch * width * height * in_depth / double(1e6);
+  EXPECT_EQ(sigmoid_calculated_mflops, expected_sigmoid_mflops);
+}
+
+#ifdef DNNL_AARCH64_USE_ACL
+TEST(MklHeuristicsTest, MklThresholds) {
+  int cpu_family = tsl::port::CPUFamily();
+  int cpu_model_num = tsl::port::CPUModelNum();
+
+  int neoverse_v1_family = 0x41;
+  int neoverse_v1_model = 0xd40;
+
+  string op_type = "Conv2D";
+
+  if (neoverse_v1_family == cpu_family && neoverse_v1_model == cpu_model_num) {
+    double thread_sync_cost = -1;
+    double framework_cost = -1;
+    for (const RewriteThreshold* i = rewrite_thresholds; i->op != ""; i++) {
+      if (i->op == op_type) {
+        thread_sync_cost = i->params.thread_sync_cost;
+        framework_cost = i->params.framework_cost;
+        break;
+      }
+    }
+
+    EXPECT_NE(thread_sync_cost, -1);
+    EXPECT_NE(thread_sync_cost, -1);
+
+    int no_threads = 0;
+    double calculated_threshold_zero_threads =
+        FindRewriteThreshold(op_type, no_threads);
+    EXPECT_EQ(calculated_threshold_zero_threads, 0);
+
+    int threads = 8;
+    double calculated_threshold = FindRewriteThreshold(op_type, threads);
+    double expected_threshold = threads * thread_sync_cost + framework_cost;
+    EXPECT_EQ(expected_threshold, calculated_threshold);
+  }
+}
+#endif  // DNNL_AARCG64_USE_ACL
+
+}  // namespace
+}  // namespace tensorflow
+
+#endif  // INTEL_MKL

--- a/tensorflow/core/util/mkl_heuristics_test.cc
+++ b/tensorflow/core/util/mkl_heuristics_test.cc
@@ -18,6 +18,8 @@ limitations under the License.
 
 #include "tensorflow/core/util/mkl_heuristics.h"
 
+#include <vector>
+
 #include "tensorflow/core/framework/node_def.pb.h"
 #include "tensorflow/core/kernels/ops_testutil.h"
 #include "tensorflow/core/platform/test.h"

--- a/tensorflow/core/util/mkl_heuristics_test.cc
+++ b/tensorflow/core/util/mkl_heuristics_test.cc
@@ -18,9 +18,6 @@ limitations under the License.
 
 #include "tensorflow/core/util/mkl_heuristics.h"
 
-#include <vector>
-
-#include "tensorflow/core/framework/node_def.pb.h"
 #include "tensorflow/core/kernels/ops_testutil.h"
 #include "tensorflow/core/platform/test.h"
 

--- a/tensorflow/tsl/platform/cpu_info.cc
+++ b/tensorflow/tsl/platform/cpu_info.cc
@@ -357,14 +357,17 @@ void InitCPUIDInfo();
 
 CPUIDInfo* cpuid = nullptr;
 
-// Structure for basic CPUID info
+// Structure for basic CPUID info.
 class CPUIDInfo {
  public:
   CPUIDInfo() : implementer_(0), variant_(0), cpunum_(0) {}
 
   static void Initialize() {
-    // Initialize cpuid struct
-    CHECK(cpuid == nullptr) << __func__ << " ran more than once";
+    // Initialize cpuid struct.
+    if (cpuid != nullptr) {
+      return;
+    }
+
     cpuid = new CPUIDInfo;
 
     if (!(getauxval(AT_HWCAP) & HWCAP_CPUID)) {
@@ -379,7 +382,7 @@ class CPUIDInfo {
       if (bool(getline(CPUspresent, line))) {
         // We just need to find one CPU that is active
         // from which we can read MIDR register to find
-        // implement, variant and revision information
+        // implement, variant and revision information.
         auto ending = line.end();
         for (auto i = line.begin(); i < line.end(); ++i) {
           if (*i == '-' || *i == ',') {
@@ -388,7 +391,7 @@ class CPUIDInfo {
           }
         }
         line.erase(ending, line.end());
-        // That should be the fist number
+        // That should be the fist number.
         present_cpu = std::stoi(line);
       }
     }
@@ -406,7 +409,7 @@ class CPUIDInfo {
       if (bool(getline(midr_el1_file, line))) {
         uint32 midr_el1 = std::stoul(line, nullptr, 16);
 
-        // Unpack variant and CPU ID
+        // Unpack variant and CPU ID.
         cpuid->implementer_ = (midr_el1 >> 24) & 0xFF;
         cpuid->variant_ = (midr_el1 >> 20) & 0xF;
         cpuid->cpunum_ = (midr_el1 >> 4) & 0xFFF;

--- a/tensorflow/tsl/platform/cpu_info.cc
+++ b/tensorflow/tsl/platform/cpu_info.cc
@@ -376,9 +376,10 @@ class CPUIDInfo {
       return;
     }
 
+    int present_cpu = -1;
+#if !defined(PLATFORM_WINDOWS) && !defined(__APPLE__) && !defined(__OpenBSD__)
     std::ifstream CPUspresent;
     CPUspresent.open("/sys/devices/system/cpu/present", std::ios::in);
-    int present_cpu = -1;
     if (CPUspresent.is_open()) {
       std::string line;
       if (bool(getline(CPUspresent, line))) {
@@ -397,11 +398,13 @@ class CPUIDInfo {
         present_cpu = std::stoi(line);
       }
     }
+#endif
 
     if (present_cpu == -1) {
       return;
     }
 
+#if !defined(PLATFORM_WINDOWS) && !defined(__APPLE__) && !defined(__OpenBSD__)
     std::stringstream str;
     str << "/sys/devices/system/cpu/cpu" << present_cpu
         << "/regs/identification/midr_el1";
@@ -417,6 +420,7 @@ class CPUIDInfo {
         cpuid->cpunum_ = (midr_el1 >> 4) & 0xFFF;
       }
     }
+#endif
   }
 
   int implementer() const { return implementer_; }

--- a/tensorflow/tsl/platform/cpu_info.cc
+++ b/tensorflow/tsl/platform/cpu_info.cc
@@ -24,7 +24,9 @@ limitations under the License.
 #endif
 #if defined(PLATFORM_IS_ARM64)
 #include <sys/auxv.h>
-
+#ifndef HWCAP_CPUID
+#define HWCAP_CPUID (1 << 11)
+#endif
 #include <fstream>
 #endif
 

--- a/tensorflow/tsl/platform/cpu_info.cc
+++ b/tensorflow/tsl/platform/cpu_info.cc
@@ -22,6 +22,11 @@ limitations under the License.
 #if defined(PLATFORM_IS_X86)
 #include <mutex>  // NOLINT
 #endif
+#if defined(PLATFORM_IS_ARM64)
+#include <sys/auxv.h>
+
+#include <fstream>
+#endif
 
 // SIMD extension querying is only available on x86.
 #ifdef PLATFORM_IS_X86
@@ -345,6 +350,86 @@ void InitCPUIDInfo() {
 
 #endif  // PLATFORM_IS_X86
 
+#ifdef PLATFORM_IS_ARM64
+
+class CPUIDInfo;
+void InitCPUIDInfo();
+
+CPUIDInfo* cpuid = nullptr;
+
+// Structure for basic CPUID info
+class CPUIDInfo {
+ public:
+  CPUIDInfo() : implementer_(0), variant_(0), cpunum_(0) {}
+
+  static void Initialize() {
+    // Initialize cpuid struct
+    CHECK(cpuid == nullptr) << __func__ << " ran more than once";
+    cpuid = new CPUIDInfo;
+
+    if (!(getauxval(AT_HWCAP) & HWCAP_CPUID)) {
+      return;
+    }
+
+    std::ifstream CPUspresent;
+    CPUspresent.open("/sys/devices/system/cpu/present", std::ios::in);
+    int present_cpu = -1;
+    if (CPUspresent.is_open()) {
+      std::string line;
+      if (bool(getline(CPUspresent, line))) {
+        // We just need to find one CPU that is active
+        // from which we can read MIDR register to find
+        // implement, variant and revision information
+        auto ending = line.end();
+        for (auto i = line.begin(); i < line.end(); ++i) {
+          if (*i == '-' || *i == ',') {
+            ending = i;
+            break;
+          }
+        }
+        line.erase(ending, line.end());
+        // That should be the fist number
+        present_cpu = std::stoi(line);
+      }
+    }
+
+    if (present_cpu == -1) {
+      return;
+    }
+
+    std::stringstream str;
+    str << "/sys/devices/system/cpu/cpu" << present_cpu
+        << "/regs/identification/midr_el1";
+    std::ifstream midr_el1_file(str.str(), std::ios::in);
+    if (midr_el1_file.is_open()) {
+      std::string line;
+      if (bool(getline(midr_el1_file, line))) {
+        uint32 midr_el1 = std::stoul(line, nullptr, 16);
+
+        // Unpack variant and CPU ID
+        cpuid->implementer_ = (midr_el1 >> 24) & 0xFF;
+        cpuid->variant_ = (midr_el1 >> 20) & 0xF;
+        cpuid->cpunum_ = (midr_el1 >> 4) & 0xFFF;
+      }
+    }
+  }
+
+  int implementer() const { return implementer_; }
+  int cpunum() const { return cpunum_; }
+
+ private:
+  int implementer_;
+  int variant_;
+  int cpunum_;
+};
+
+absl::once_flag cpuid_once_flag;
+
+void InitCPUIDInfo() {
+  absl::call_once(cpuid_once_flag, CPUIDInfo::Initialize);
+}
+
+#endif
 }  // namespace
 
 bool TestCPUFeature(CPUFeature feature) {
@@ -368,6 +453,9 @@ int CPUFamily() {
 #ifdef PLATFORM_IS_X86
   InitCPUIDInfo();
   return cpuid->family();
+#elif defined(PLATFORM_IS_ARM64)
+  InitCPUIDInfo();
+  return cpuid->implementer();
 #else
   return 0;
 #endif
@@ -377,6 +465,9 @@ int CPUModelNum() {
 #ifdef PLATFORM_IS_X86
   InitCPUIDInfo();
   return cpuid->model_num();
+#elif defined(PLATFORM_IS_ARM64)
+  InitCPUIDInfo();
+  return cpuid->cpunum();
 #else
   return 0;
 #endif


### PR DESCRIPTION
We observed that when you run networks that have layers with smaller input and overall lower compute density overhead into MKL path dominates useful compute so in that case it is better to call default, Eigen, path.
 
This patch introduces changes to MKL layout pass where a liner analytical model is used to decide based on compute density and number of threads to either rewrite node to use MKL code path or leave it as it is. It propagates input shapes of the operation by decorating node with _input_shapes attribute number of threads used to parallelise operation by reading it from device on which operation is expected to execute (in this case CPUDevice) which, are then retrived in MKL layout pass and passed to the analytical model.
 
With this approach we have observed speedup for models available on TF-Hub as shown in the two attached graphs when running with 8 and 16 cores on Neoverse-V1 platform. Before shows results without this patch and after shows results with the patch relative when same models are ran with TF_ENABLE_ONEDNN_OPTS=0. Overall for 8 cores we see ~1.2x average speedup over TF_ENABLE_ONEDNN_OPTS=0 for 8 cores and ~1.12x for 16 cores.

![8cores_results](https://user-images.githubusercontent.com/79916358/225777461-0962b80c-4923-4b50-bb55-b65874ee3da9.png)

![16cores_results](https://user-images.githubusercontent.com/79916358/225777470-3fea315f-d78c-447b-9bbc-4f09202400da.png)

In addition to analytical model improvements for convolution, fused convolution, fused batch normalisation and swish, this patch also moves code for merging sigmoid and multiplication from remapper.cc to mkl_layout_pass.cc as it is MKL merge operation.

cc: @penpornk @cantonios 