### PR TITLE
Remove tags from end-to-end fuzzer

### DIFF
--- a/tensorflow/security/fuzzing/cc/end_to_end_fuzz.cc
+++ b/tensorflow/security/fuzzing/cc/end_to_end_fuzz.cc
@@ -40,8 +40,8 @@ void FuzzEndToEnd(
   TF_CHECK_OK(tsl::WriteBinaryProto(tensorflow::Env::Default(),
                                     export_dir + kSavedModelFilenamePb, model));
 
-  Status status = LoadSavedModel(session_options, run_options, export_dir,
-                                 {kSavedModelTagServe}, &bundle);
+  Status status =
+      LoadSavedModel(session_options, run_options, export_dir, {}, &bundle);
   if (!status.ok()) {
     return;
   }


### PR DESCRIPTION
The matching of tags is a bit of a blocker. Leaving the tag list empty will allow the status check to pass faster for the fuzzer.