### PR TITLE
[NVIDIA TF] Add DTensorAllToAll and relayout implementation

### DIFF
--- a/tensorflow/core/common_runtime/graph_execution_state.cc
+++ b/tensorflow/core/common_runtime/graph_execution_state.cc
@@ -67,7 +67,7 @@ namespace {
 bool IsCollectiveV2(const string& op) {
   return op == "CollectiveReduceV2" || op == "CollectiveGatherV2" ||
          op == "CollectiveBcastRecvV2" || op == "CollectiveBcastSendV2" ||
-         op == "ColectiveReduceScatterV2";
+         op == "ColectiveReduceScatterV2" || op == "ColectiveAllToAllV2";
 }
 }  // namespace
 

--- a/tensorflow/dtensor/cc/BUILD
+++ b/tensorflow/dtensor/cc/BUILD
@@ -41,6 +41,7 @@ cc_library(
     hdrs = ["dtensor_utils.h"],
     deps = [
         "//tensorflow/core:lib",
+        "//tensorflow/tsl/util:env_var",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/tensorflow/dtensor/cc/dtensor_meta_ops.cc
+++ b/tensorflow/dtensor/cc/dtensor_meta_ops.cc
@@ -197,14 +197,12 @@ REGISTER_OP("DTensorAllToAll")
           out_dims.emplace_back(dim);
         } else if (Layout::IsUnshardedDimension(
                        input_layout.sharding_spec(i)) &&
-                   Layout::IsShardedDimension(
-                       output_layout.sharding_spec(i))) {
+                   Layout::IsShardedDimension(output_layout.sharding_spec(i))) {
           shape_inference::DimensionHandle out_dim;
           TF_RETURN_IF_ERROR(c->Divide(dim, output_sharding[i],
                                        /*evenly_divisible=*/true, &out_dim));
           out_dims.push_back(out_dim);
-        } else if (Layout::IsShardedDimension(
-                       input_layout.sharding_spec(i)) &&
+        } else if (Layout::IsShardedDimension(input_layout.sharding_spec(i)) &&
                    Layout::IsUnshardedDimension(
                        output_layout.sharding_spec(i))) {
           shape_inference::DimensionHandle out_dim;

--- a/tensorflow/dtensor/cc/dtensor_meta_ops.cc
+++ b/tensorflow/dtensor/cc/dtensor_meta_ops.cc
@@ -155,5 +155,66 @@ REGISTER_OP("DTensorAllGather")
       return OkStatus();
     });
 
+REGISTER_OP("DTensorAllToAll")
+    .Input("input: T")
+    .Output("output: T")
+    .Attr("T: {half, bfloat16, float, float64, int32, uint32, int64, bool}")
+    .Attr("input_layout: string")
+    .Attr("output_layout: string")
+    .SetShapeFn([](shape_inference::InferenceContext* c) -> Status {
+      shape_inference::ShapeHandle in = c->input(0);
+      if (!c->RankKnown(in)) {
+        // Input shape unknown, so set unknown output shape.
+        c->set_output(0, in);
+        return OkStatus();
+      }
+
+      std::string input_layout_string;
+      std::string output_layout_string;
+      TF_RETURN_IF_ERROR(c->GetAttr("input_layout", &input_layout_string));
+      TF_RETURN_IF_ERROR(c->GetAttr("output_layout", &output_layout_string));
+      TF_ASSIGN_OR_RETURN(Layout input_layout,
+                          Layout::FromString(input_layout_string));
+      TF_ASSIGN_OR_RETURN(Layout output_layout,
+                          Layout::FromString(output_layout_string));
+      if (c->Rank(in) != input_layout.rank() ||
+          c->Rank(in) != output_layout.rank()) {
+        return errors::InvalidArgument(
+            "Input tensor rank and layout ranks do not agree: input rank ",
+            c->Rank(in), " input layout rank ", input_layout.rank(),
+            " output "
+            "layout rank ",
+            output_layout.rank());
+      }
+      const std::vector<int32> input_sharding = input_layout.num_shards();
+      const std::vector<int32> output_sharding = output_layout.num_shards();
+      std::vector<shape_inference::DimensionHandle> out_dims;
+      out_dims.reserve(c->Rank(in));
+      for (int i = 0; i < c->Rank(in); ++i) {
+        shape_inference::DimensionHandle dim = c->Dim(in, i);
+        if (!c->ValueKnown(dim) ||
+            input_layout.sharding_spec(i) == output_layout.sharding_spec(i)) {
+          out_dims.emplace_back(dim);
+        } else if (Layout::IsUnshardedDimension(
+                       input_layout.sharding_spec(i)) &&
+                   Layout::IsShardedDimension(
+                       output_layout.sharding_spec(i))) {
+          shape_inference::DimensionHandle out_dim;
+          TF_RETURN_IF_ERROR(c->Divide(dim, output_sharding[i],
+                                       /*evenly_divisible=*/true, &out_dim));
+          out_dims.push_back(out_dim);
+        } else if (Layout::IsShardedDimension(
+                       input_layout.sharding_spec(i)) &&
+                   Layout::IsUnshardedDimension(
+                       output_layout.sharding_spec(i))) {
+          shape_inference::DimensionHandle out_dim;
+          TF_RETURN_IF_ERROR(c->Multiply(dim, input_sharding[i], &out_dim));
+          out_dims.push_back(out_dim);
+        }
+      }
+      c->set_output(0, c->MakeShape(out_dims));
+      return OkStatus();
+    });
+
 }  // namespace dtensor
 }  // namespace tensorflow

--- a/tensorflow/dtensor/cc/dtensor_utils.cc
+++ b/tensorflow/dtensor/cc/dtensor_utils.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "absl/strings/ascii.h"
 #include "absl/strings/numbers.h"
 #include "tensorflow/core/platform/logging.h"
+#include "tensorflow/tsl/util/env_var.h"
 
 namespace tensorflow {
 namespace dtensor {
@@ -125,6 +126,17 @@ bool EnableReplicatedSpmdAsDefault(const std::string& op_name) {
   char* dtensor_enable_replicated_spmd_as_default =
       std::getenv(env_name.c_str());
   return dtensor_enable_replicated_spmd_as_default != nullptr;
+}
+
+bool EnableAllToAllForRelayout() {
+  // Whether to use all-to-all collective for relayout when possible.
+  static bool is_enabled = [] {
+    bool ret = true;
+    TF_CHECK_OK(tsl::ReadBoolFromEnvVar("DTENSOR_USE_ALL_TO_ALL_RELAYOUT",
+                                        /*default_val=*/true, &ret));
+    return ret;
+  }();
+  return is_enabled;
 }
 
 }  // namespace dtensor

--- a/tensorflow/dtensor/cc/dtensor_utils.h
+++ b/tensorflow/dtensor/cc/dtensor_utils.h
@@ -60,6 +60,9 @@ bool LowerCollectiveGatherToCollectiveGatherV2();
 // implementation to default to the ReplicatedOpSpmdExpander.
 bool EnableReplicatedSpmdAsDefault(const std::string& op_name);
 
+// Returns whether to use all-to-all collective for relayout when possible.
+bool EnableAllToAllForRelayout();
+
 }  // namespace dtensor
 }  // namespace tensorflow
 

--- a/tensorflow/dtensor/mlir/BUILD
+++ b/tensorflow/dtensor/mlir/BUILD
@@ -100,6 +100,7 @@ cc_library(
         "//tensorflow/compiler/mlir/tensorflow:tensorflow_passes",
         "//tensorflow/core:lib",
         "//tensorflow/dtensor/cc:dstatus",
+        "//tensorflow/dtensor/cc:dtensor_utils",
         "//tensorflow/dtensor/cc:tensor_layout",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/strings",

--- a/tensorflow/dtensor/mlir/Passes.td
+++ b/tensorflow/dtensor/mlir/Passes.td
@@ -194,6 +194,14 @@ def DTensorAllScatterLowering
   ];
 }
 
+def DTensorAllToAllLowering
+    : Pass<"dtensor-all-to-all-lowering", "mlir::ModuleOp"> {
+  let summary = "Converts logical AllToAll ops into physical AllToAll ops.";
+  let constructor = "CreateDTensorAllToAllLoweringPass()";
+  let dependentDialects = [
+  ];
+}
+
 def DTensorClusterFunctionConversion
     : Pass<"dtensor-cluster-function-conversion", "mlir::ModuleOp"> {
   let summary = "Converts tf_device.cluster_func ops into TF StatefulPartitioned call op with mesh attribute.";

--- a/tensorflow/dtensor/mlir/collectives.cc
+++ b/tensorflow/dtensor/mlir/collectives.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "tensorflow/compiler/mlir/tensorflow/transforms/collection_ops_util.h"
 #include "tensorflow/core/platform/errors.h"
 #include "tensorflow/dtensor/cc/dstatus.h"
+#include "tensorflow/dtensor/cc/dtensor_utils.h"
 #include "tensorflow/dtensor/cc/tensor_layout.h"
 #include "tensorflow/dtensor/mlir/collectives_common.h"
 #include "tensorflow/dtensor/mlir/dtensor_location.h"
@@ -318,7 +319,8 @@ StatusOr<mlir::Value> EmitRelayout(
   mlir::OpBuilder builder(input.getContext());
   TF_RETURN_IF_ERROR(SetBuilderInsertionAfterValue(input, builder));
 
-  if (CanUseAllToAll(src_layout, tgt_layout) && !is_sparse) {
+  if (EnableAllToAllForRelayout() && !is_sparse &&
+      CanUseAllToAll(src_layout, tgt_layout)) {
     // TODO(tmorris): support sparse case
     TF_ASSIGN_OR_RETURN(mlir::Value all_to_all_result,
                         EmitAllToAll(builder, input, src_layout, tgt_layout,

--- a/tensorflow/dtensor/mlir/collectives.cc
+++ b/tensorflow/dtensor/mlir/collectives.cc
@@ -311,11 +311,6 @@ StatusOr<mlir::Value> EmitRelayout(
         "Attempted to relayout to a different global shape.");
   }
 
-  absl::flat_hash_set<std::string> src_sharding_dims;
-  for (int i = 0; i < src_layout.rank(); ++i) {
-    src_sharding_dims.emplace(src_layout.sharding_spec(i));
-  }
-
   mlir::OpBuilder builder(input.getContext());
   TF_RETURN_IF_ERROR(SetBuilderInsertionAfterValue(input, builder));
 
@@ -327,6 +322,10 @@ StatusOr<mlir::Value> EmitRelayout(
                                      newly_created_ops));
     return all_to_all_result;
   }
+
+  absl::flat_hash_set<std::string> src_sharding_dims;
+  for (int i = 0; i < src_layout.rank(); ++i)
+    src_sharding_dims.emplace(src_layout.sharding_spec(i));
 
   std::vector<ShardingSpec> intermediate_specs_1(src_layout.rank());
   for (int i = 0; i < src_layout.rank(); ++i) {

--- a/tensorflow/dtensor/mlir/collectives.cc
+++ b/tensorflow/dtensor/mlir/collectives.cc
@@ -151,8 +151,8 @@ StatusOr<const mlir::Value> EmitAllScatter(
   return all_scatter.getOutput();
 }
 
-bool CanUseAllToAll(
-    const dtensor::Layout& src_layout, const dtensor::Layout& tgt_layout) {
+bool CanUseAllToAll(const dtensor::Layout& src_layout,
+                    const dtensor::Layout& tgt_layout) {
   // All-to-all can be used for relayout if one dimension is becoming more
   // sharded while another is becoming less sharded, for example x,unsharded ->
   // unsharded,x.
@@ -169,7 +169,7 @@ bool CanUseAllToAll(
       num_split_dims++;
       split_spec = tgt_layout.dim(i);
     } else if (Layout::IsShardedDimension(src_layout.sharding_spec(i)) &&
-                Layout::IsUnshardedDimension(tgt_layout.sharding_spec(i))) {
+               Layout::IsUnshardedDimension(tgt_layout.sharding_spec(i))) {
       num_concat_dims++;
       concat_spec = src_layout.dim(i);
     }
@@ -320,10 +320,9 @@ StatusOr<mlir::Value> EmitRelayout(
 
   if (CanUseAllToAll(src_layout, tgt_layout) && !is_sparse) {
     // TODO(tmorris): support sparse case
-    TF_ASSIGN_OR_RETURN(
-        mlir::Value all_to_all_result,
-        EmitAllToAll(builder, input, src_layout,
-                      tgt_layout, newly_created_ops));
+    TF_ASSIGN_OR_RETURN(mlir::Value all_to_all_result,
+                        EmitAllToAll(builder, input, src_layout, tgt_layout,
+                                     newly_created_ops));
     return all_to_all_result;
   }
 

--- a/tensorflow/dtensor/mlir/create_dtensor_mlir_passes.h
+++ b/tensorflow/dtensor/mlir/create_dtensor_mlir_passes.h
@@ -113,6 +113,9 @@ std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 CreateDTensorAllReduceLoweringPass();
 
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+CreateDTensorAllToAllLoweringPass();
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 CreateDTensorReduceScatterLoweringPass();
 
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>

--- a/tensorflow/dtensor/mlir/dtensor_mlir_passes.cc
+++ b/tensorflow/dtensor/mlir/dtensor_mlir_passes.cc
@@ -229,6 +229,8 @@ void CreateDTensorMLIRPass(const mlir::TF::StandardPipelineOptions &options,
 
   pm->addPass(CreateDTensorAllScatterLoweringPass());
 
+  pm->addPass(CreateDTensorAllToAllLoweringPass());
+
   // Group together multiple device clusters assigned to the same mesh. Repeat
   // this for every mesh to support multi-mesh. Collective lowering may have
   // created multiple CPU mesh clusters for executing collective operations on

--- a/tensorflow/dtensor/mlir/ir/tf_dtensor.cc
+++ b/tensorflow/dtensor/mlir/ir/tf_dtensor.cc
@@ -212,21 +212,26 @@ mlir::LogicalResult DTensorAllToAllOp::verify() {
   tensorflow::dtensor::ShardingSpec split_spec;
   tensorflow::dtensor::ShardingSpec concat_spec;
   for (int32_t i = 0; i < input_layout.rank(); ++i) {
-    if (input_layout.sharding_spec(i) == output_layout.sharding_spec(i)) continue;
-    if (tensorflow::dtensor::Layout::IsUnshardedDimension(input_layout.sharding_spec(i)) &&
-        tensorflow::dtensor::Layout::IsShardedDimension(output_layout.sharding_spec(i))) {
+    if (input_layout.sharding_spec(i) == output_layout.sharding_spec(i))
+      continue;
+    if (tensorflow::dtensor::Layout::IsUnshardedDimension(
+            input_layout.sharding_spec(i)) &&
+        tensorflow::dtensor::Layout::IsShardedDimension(
+            output_layout.sharding_spec(i))) {
       num_split_dims++;
       split_spec = output_layout.dim(i);
-    } else if (tensorflow::dtensor::Layout::IsShardedDimension(input_layout.sharding_spec(i)) &&
-                tensorflow::dtensor::Layout::IsUnshardedDimension(output_layout.sharding_spec(i))) {
+    } else if (tensorflow::dtensor::Layout::IsShardedDimension(
+                   input_layout.sharding_spec(i)) &&
+               tensorflow::dtensor::Layout::IsUnshardedDimension(
+                   output_layout.sharding_spec(i))) {
       num_concat_dims++;
       concat_spec = input_layout.dim(i);
     }
   }
   if (num_split_dims != 1 || num_concat_dims != 1 ||
       split_spec.sharding_spec() != concat_spec.sharding_spec()) {
-     return op.emitOpError()
-            << "must have one mesh dimension which is being unsharded in one axis and sharded in another";
+    return op.emitOpError() << "must have one mesh dimension which is being "
+                               "unsharded in one axis and sharded in another";
   }
 
   RankedTensorType input_type =

--- a/tensorflow/dtensor/mlir/ir/tf_dtensor.td
+++ b/tensorflow/dtensor/mlir/ir/tf_dtensor.td
@@ -668,8 +668,9 @@ def TF_DTensorAllToAllOp : TF_Op<"DTensorAllToAll", [Pure]> {
   let summary = "Mutually exchanges the input to match the given layout.";
 
   let description = [{
-This op takes both an input and an output layout. The output layout must be equally
-sharded as the input layout.
+This op takes both an input and an output layout. There can be one mesh
+dimension which is becoming unsharded in one axis while becoming sharded 
+in another axis."
   }];
 
   let arguments = (ins

--- a/tensorflow/dtensor/mlir/ir/tf_dtensor.td
+++ b/tensorflow/dtensor/mlir/ir/tf_dtensor.td
@@ -664,4 +664,27 @@ sharded than the input layout.
   let hasVerifier = 1;
 }
 
+def TF_DTensorAllToAllOp : TF_Op<"DTensorAllToAll", [Pure]> {
+  let summary = "Mutually exchanges the input to match the given layout.";
+
+  let description = [{
+This op takes both an input and an output layout. The output layout must be equally
+sharded as the input layout.
+  }];
+
+  let arguments = (ins
+    TensorOf<[TF_Bfloat16, TF_Float16, TF_Float32, TF_Int32, TF_Uint32, TF_Int64, TF_Bool]>:$input,
+    DTensor_LayoutAttr:$input_layout,
+    DTensor_LayoutAttr:$output_layout
+  );
+
+  let results = (outs
+    TensorOf<[TF_Bfloat16, TF_Float16, TF_Float32, TF_Int32, TF_Uint32, TF_Int64, TF_Bool]>:$output
+  );
+
+  TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
+
+  let hasVerifier = 1;
+}
+
 #endif // TENSORFLOW_DTENSOR_MLIR_IR_TF_DTENSOR_OPS

--- a/tensorflow/dtensor/mlir/tests/dtensor_alltoall_lowering.mlir
+++ b/tensorflow/dtensor/mlir/tests/dtensor_alltoall_lowering.mlir
@@ -1,0 +1,33 @@
+// RUN: dtensor-opt %s -split-input-file -dtensor-all-to-all-lowering -verify-diagnostics | FileCheck %s --dump-input=fail
+
+// CHECK-LABEL: func @lower_alltoall_tpu_mesh
+func.func @lower_alltoall_tpu_mesh(%arg0: tensor<i32>,
+           %arg1: tensor<4x2xf32> {tf._layout = "sharding_specs:x,y, mesh:TPU|x=2,y=2|0,1,2,3|0,1,2,3|/job:localhost/task:0/device:TPU:0,/job:localhost/task:0/device:TPU:1,/job:localhost/task:0/device:TPU:2,/job:localhost/task:0/device:TPU:3"}) -> tensor<2x4xf32> {
+  // CHECK:      "tf_device.cluster"
+  // CHECK:      %[[ALLTOALL_OUT:.*]] = "tf.AllToAll"(%arg1
+  // CHECK:      tf_device.return %[[ALLTOALL_OUT]]
+  %0 = "tf_device.cluster"() ({
+    %1 = "tf.DTensorAllToAll"(%arg1) {input_layout = #dtensor.layout<sharding_specs:unsharded,x, mesh:TPU|x=2,y=2|0,1,2,3|0,1,2,3|/job:localhost/task:0/device:TPU:0,/job:localhost/task:0/device:TPU:1,/job:localhost/task:0/device:TPU:2,/job:localhost/task:0/device:TPU:3>, output_layout = #dtensor.layout<sharding_specs:x,unsharded, mesh:TPU|x=2,y
+=2|0,1,2,3|0,1,2,3|/job:localhost/task:0/device:TPU:0,/job:localhost/task:0/device:TPU:1,/job:localhost/task:0/device:TPU:2,/job:localhost/task:0/device:TPU:3>} : (tensor<4x2xf32>) -> tensor<2x4xf32>
+    tf_device.return %1 : tensor<2x4xf32>
+  }) {_mesh = "TPU|x=2,y=2|0,1,2,3|0,1,2,3|/job:localhost/task:0/device:TPU:0,/job:localhost/task:0/device:TPU:1,/job:localhost/task:0/device:TPU:2,/job:localhost/task:0/device:TPU:3"} : () -> tensor<2x4xf32>
+  func.return %0 : tensor<2x4xf32>
+}
+
+// CHECK-LABEL: func @lower_alltoall_gpu_mesh
+func.func @lower_alltoall_gpu_mesh(%arg0: tensor<i32>,
+           %arg1: tensor<4x2xf32> {tf._layout = "sharding_specs:x,y, mesh:GPU|x=2,y=2|0,1,2,3|0,1,2,3|/job:localhost/task:0/device:GPU:0,/job:localhost/task:0/device:GPU:1,/job:localhost/task:0/device:GPU:2,/job:localhost/task:0/device:GPU:3"}) -> tensor<2x4xf32> {
+  // CHECK:  "tf_device.cluster"
+  // CHECK:  %[[FLATTEN_OUT:.*]] = "tf.Reshape"(%arg1
+  // CHECK:  %[[ALLTOALL_OUT:.*]] = "tf.CollectiveAllToAllV2"(%[[FLATTEN_OUT]]
+  // CHECK:  %[[RESHAPE_1_OUT:.*]] = "tf.Reshape"(%[[ALLTOALL_OUT]]
+  // CHECK:  %[[TRANSPOSE_OUT:.*]] = "tf.Transpose"(%[[RESHAPE_1_OUT]]
+  // CHECK:  %[[RESHAPE_2_OUT:.*]] = "tf.Reshape"(%[[TRANSPOSE_OUT]]
+  // CHECK:  tf_device.return %[[RESHAPE_2_OUT]]
+  %0 = "tf_device.cluster"() ({
+    %1 = "tf.DTensorAllToAll"(%arg1) {input_layout = #dtensor.layout<sharding_specs:unsharded,x, mesh:GPU|x=2,y=2|0,1,2,3|0,1,2,3|/job:localhost/task:0/device:GPU:0,/job:localhost/task:0/device:GPU:1,/job:localhost/task:0/device:GPU:2,/job:localhost/task:0/device:GPU:3>, output_layout = #dtensor.layout<sharding_specs:x,unsharded, mesh:GPU|x=2,y
+=2|0,1,2,3|0,1,2,3|/job:localhost/task:0/device:GPU:0,/job:localhost/task:0/device:GPU:1,/job:localhost/task:0/device:GPU:2,/job:localhost/task:0/device:GPU:3>} : (tensor<4x2xf32>) -> tensor<2x4xf32>
+    tf_device.return %1 : tensor<2x4xf32>
+  }) {_mesh = "GPU|x=2,y=2|0,1,2,3|0,1,2,3|/job:localhost/task:0/device:GPU:0,/job:localhost/task:0/device:GPU:1,/job:localhost/task:0/device:GPU:2,/job:localhost/task:0/device:GPU:3"} : () -> tensor<2x4xf32>
+  func.return %0 : tensor<2x4xf32>
+}

--- a/tensorflow/dtensor/mlir/utils/collective_lowering.cc
+++ b/tensorflow/dtensor/mlir/utils/collective_lowering.cc
@@ -1383,9 +1383,6 @@ struct DTensorAllReduceLowering
 struct DTensorReduceScatterLowering
     : public impl::DTensorReduceScatterLoweringBase<
           DTensorReduceScatterLowering> {
-  void getDependentDialects(mlir::DialectRegistry& registry) const override {
-    registry.insert<mlir::dtensor::DTensorDialect>();
-  }
 
   void runOnOperation() override {
     mlir::ModuleOp module = getOperation();
@@ -1439,9 +1436,6 @@ struct DTensorAllScatterLowering
 
 struct DTensorAllToAllLowering
     : public impl::DTensorAllToAllLoweringBase<DTensorAllToAllLowering> {
-  void getDependentDialects(mlir::DialectRegistry& registry) const override {
-    registry.insert<mlir::dtensor::DTensorDialect>();
-  }
 
   void runOnOperation() override {
     mlir::ModuleOp module = getOperation();

--- a/tensorflow/dtensor/python/tests/spmd_test.py
+++ b/tensorflow/dtensor/python/tests/spmd_test.py
@@ -302,6 +302,52 @@ class DTensorSPMDTest(test_util.DTensorBaseTest):
         dtensor_scattered_result,
     )
 
+  @parameterized.named_parameters(
+    ('xu_ux', [_MESH_DIM_X, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, _MESH_DIM_X]),
+    ('ux_xu', [layout_lib.UNSHARDED, _MESH_DIM_X], [_MESH_DIM_X, layout_lib.UNSHARDED]),
+    ('yu_uy', [_MESH_DIM_Y, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, _MESH_DIM_Y]),
+    ('uy_yu', [layout_lib.UNSHARDED, _MESH_DIM_Y], [_MESH_DIM_Y, layout_lib.UNSHARDED]),
+  )
+  def testAllToAll2D(self, src_spec, tgt_spec):
+    a = constant_op.constant(np.arange(8*8,).reshape((8, 8)), dtype=dtypes.float32)
+    sharded_a = numpy_util.pack_numpy(a, layout=Layout(src_spec, self.mesh))
+
+    @polymorphic_function.function
+    def func(a):
+      return api.relayout(a, Layout(tgt_spec, self.mesh))
+
+    dtensor_result = func(sharded_a)
+    self.assertDTensorEqual(a, Layout(tgt_spec, self.mesh), dtensor_result)
+
+  @parameterized.named_parameters(
+    ('yuu_uuy', [_MESH_DIM_Y, layout_lib.UNSHARDED, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_Y]),
+    ('xuu_uux', [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X]),
+    ('uux_xuu', [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X], [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED]),
+    ('xuu_uxu', [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED]),
+    ('uxu_xuu', [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED], [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED]),
+    ('xuy_uxy', [_MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y], [layout_lib.UNSHARDED, _MESH_DIM_X, _MESH_DIM_Y]),
+    ('uxy_xuy', [layout_lib.UNSHARDED, _MESH_DIM_X,  _MESH_DIM_Y], [_MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y]),
+    ('xyu_uyx', [_MESH_DIM_X, _MESH_DIM_Y, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, _MESH_DIM_Y, _MESH_DIM_X]),
+    # Requires additional transpose
+    ('uxu_uux', [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X]),
+    ('uux_uxu', [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X], [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED]),
+    ('xyu_xuy', [_MESH_DIM_X, _MESH_DIM_Y, layout_lib.UNSHARDED], [ _MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y]),
+    ('xuy_xyu', [_MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y], [ _MESH_DIM_X, _MESH_DIM_Y, layout_lib.UNSHARDED]),
+    ('yxu_yux', [_MESH_DIM_Y, _MESH_DIM_X, layout_lib.UNSHARDED], [_MESH_DIM_Y, layout_lib.UNSHARDED, _MESH_DIM_X]),
+    ('yux_yxu', [_MESH_DIM_Y, layout_lib.UNSHARDED, _MESH_DIM_X], [_MESH_DIM_Y, _MESH_DIM_X, layout_lib.UNSHARDED]),
+  )
+  def testAllToAll3D(self, src_spec, tgt_spec):
+    a = constant_op.constant(np.arange(8*8*8).reshape((8, 8, 8)), dtype=dtypes.float32)
+    sharded_a = numpy_util.pack_numpy(a, layout=Layout(src_spec, self.mesh))
+
+    @polymorphic_function.function
+    def func(a):
+      return api.relayout(a, Layout(tgt_spec, self.mesh))
+
+    dtensor_result = func(sharded_a)
+
+    self.assertDTensorEqual(a, Layout(tgt_spec, self.mesh), dtensor_result)
+
   def testExpandDimsDifferentInputAndOutputLayouts(self,):
     src_numpy = np.random.uniform(size=[10, 10])
     src = constant_op.constant(src_numpy, dtype=dtypes.float32)

--- a/tensorflow/dtensor/python/tests/spmd_test.py
+++ b/tensorflow/dtensor/python/tests/spmd_test.py
@@ -303,13 +303,18 @@ class DTensorSPMDTest(test_util.DTensorBaseTest):
     )
 
   @parameterized.named_parameters(
-    ('xu_ux', [_MESH_DIM_X, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, _MESH_DIM_X]),
-    ('ux_xu', [layout_lib.UNSHARDED, _MESH_DIM_X], [_MESH_DIM_X, layout_lib.UNSHARDED]),
-    ('yu_uy', [_MESH_DIM_Y, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, _MESH_DIM_Y]),
-    ('uy_yu', [layout_lib.UNSHARDED, _MESH_DIM_Y], [_MESH_DIM_Y, layout_lib.UNSHARDED]),
+    ('xu_ux', [_MESH_DIM_X, layout_lib.UNSHARDED],
+              [layout_lib.UNSHARDED, _MESH_DIM_X]),
+    ('ux_xu', [layout_lib.UNSHARDED, _MESH_DIM_X],
+              [_MESH_DIM_X, layout_lib.UNSHARDED]),
+    ('yu_uy', [_MESH_DIM_Y, layout_lib.UNSHARDED],
+              [layout_lib.UNSHARDED, _MESH_DIM_Y]),
+    ('uy_yu', [layout_lib.UNSHARDED, _MESH_DIM_Y],
+              [_MESH_DIM_Y, layout_lib.UNSHARDED]),
   )
   def testAllToAll2D(self, src_spec, tgt_spec):
-    a = constant_op.constant(np.arange(8*8,).reshape((8, 8)), dtype=dtypes.float32)
+    a = constant_op.constant(
+        np.arange(8*8,).reshape((8, 8)), dtype=dtypes.float32)
     sharded_a = numpy_util.pack_numpy(a, layout=Layout(src_spec, self.mesh))
 
     @polymorphic_function.function
@@ -320,24 +325,39 @@ class DTensorSPMDTest(test_util.DTensorBaseTest):
     self.assertDTensorEqual(a, Layout(tgt_spec, self.mesh), dtensor_result)
 
   @parameterized.named_parameters(
-    ('yuu_uuy', [_MESH_DIM_Y, layout_lib.UNSHARDED, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_Y]),
-    ('xuu_uux', [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X]),
-    ('uux_xuu', [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X], [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED]),
-    ('xuu_uxu', [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED]),
-    ('uxu_xuu', [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED], [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED]),
-    ('xuy_uxy', [_MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y], [layout_lib.UNSHARDED, _MESH_DIM_X, _MESH_DIM_Y]),
-    ('uxy_xuy', [layout_lib.UNSHARDED, _MESH_DIM_X,  _MESH_DIM_Y], [_MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y]),
-    ('xyu_uyx', [_MESH_DIM_X, _MESH_DIM_Y, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, _MESH_DIM_Y, _MESH_DIM_X]),
+    ('yuu_uuy', [_MESH_DIM_Y, layout_lib.UNSHARDED, layout_lib.UNSHARDED],
+                [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_Y]),
+    ('xuu_uux', [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED],
+                [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X]),
+    ('uux_xuu', [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X],
+                [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED]),
+    ('xuu_uxu', [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED],
+                [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED]),
+    ('uxu_xuu', [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED],
+                [_MESH_DIM_X, layout_lib.UNSHARDED, layout_lib.UNSHARDED]),
+    ('xuy_uxy', [_MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y],
+                [layout_lib.UNSHARDED, _MESH_DIM_X, _MESH_DIM_Y]),
+    ('uxy_xuy', [layout_lib.UNSHARDED, _MESH_DIM_X,  _MESH_DIM_Y],
+                [_MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y]),
+    ('xyu_uyx', [_MESH_DIM_X, _MESH_DIM_Y, layout_lib.UNSHARDED],
+                [layout_lib.UNSHARDED, _MESH_DIM_Y, _MESH_DIM_X]),
     # Requires additional transpose
-    ('uxu_uux', [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED], [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X]),
-    ('uux_uxu', [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X], [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED]),
-    ('xyu_xuy', [_MESH_DIM_X, _MESH_DIM_Y, layout_lib.UNSHARDED], [ _MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y]),
-    ('xuy_xyu', [_MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y], [ _MESH_DIM_X, _MESH_DIM_Y, layout_lib.UNSHARDED]),
-    ('yxu_yux', [_MESH_DIM_Y, _MESH_DIM_X, layout_lib.UNSHARDED], [_MESH_DIM_Y, layout_lib.UNSHARDED, _MESH_DIM_X]),
-    ('yux_yxu', [_MESH_DIM_Y, layout_lib.UNSHARDED, _MESH_DIM_X], [_MESH_DIM_Y, _MESH_DIM_X, layout_lib.UNSHARDED]),
+    ('uxu_uux', [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED],
+                [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X]),
+    ('uux_uxu', [layout_lib.UNSHARDED, layout_lib.UNSHARDED, _MESH_DIM_X],
+                [layout_lib.UNSHARDED, _MESH_DIM_X, layout_lib.UNSHARDED]),
+    ('xyu_xuy', [_MESH_DIM_X, _MESH_DIM_Y, layout_lib.UNSHARDED],
+                [ _MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y]),
+    ('xuy_xyu', [_MESH_DIM_X, layout_lib.UNSHARDED, _MESH_DIM_Y],
+                [ _MESH_DIM_X, _MESH_DIM_Y, layout_lib.UNSHARDED]),
+    ('yxu_yux', [_MESH_DIM_Y, _MESH_DIM_X, layout_lib.UNSHARDED],
+                [_MESH_DIM_Y, layout_lib.UNSHARDED, _MESH_DIM_X]),
+    ('yux_yxu', [_MESH_DIM_Y, layout_lib.UNSHARDED, _MESH_DIM_X],
+                [_MESH_DIM_Y, _MESH_DIM_X, layout_lib.UNSHARDED]),
   )
   def testAllToAll3D(self, src_spec, tgt_spec):
-    a = constant_op.constant(np.arange(8*8*8).reshape((8, 8, 8)), dtype=dtypes.float32)
+    a = constant_op.constant(
+        np.arange(8*8*8).reshape((8, 8, 8)), dtype=dtypes.float32)
     sharded_a = numpy_util.pack_numpy(a, layout=Layout(src_spec, self.mesh))
 
     @polymorphic_function.function


### PR DESCRIPTION
This PR adds a new high-level op, `DTensorAllToAll` along with lowering to  `CollectiveAllToAllV2`.
To start, I've implemented a relayout using this new all-to-all for certain cases only. There should be many more applications for all-to-all that we can implement in the future.

## Supported relayout cases
I've added support for the cases where one axis is becoming sharded to a certain mesh dimension while another axis is becoming unsharded from that mesh dimension. For example, `[x,unsharded] -> [unsharded, x]` or `[unsharded, y, x] -> [x, y, unsharded]`. You can look at the unit tests in `spmd_test.py` for more (non-exhaustive) examples.

Before this PR, these relayouts would be implemented using all-gather to fully replicate the tensor, followed by slice. With all-to-all, the communication overhead is reduced since only the minimal slices of data that need to be moved are exchanged across the devices.

## Summary of changes
* DTensorAllToAll op
* DTensorAllToAllLowering pass which can lower to `CollectiveAllToAllV2` for cpu and gpu, or XLA AllToAll for TPU. **I did not test the TPU path at all.**
* Use DTensorAllToAll for certain relayouts
* MLIR test
* Python unit tests