### PR TITLE
Fixing bug in the annotation of variable ops.

### DIFF
--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -1023,7 +1023,8 @@ def _annotate_variable_ops(func, graph_def):
     RuntimeError: if some shapes cannot be annotated.
   """
   ph_shape_map = {}
-  for ph, var in zip(func.graph.internal_captures, func.variables):
+  for ph, var in zip((ph for ph in func.graph.internal_captures
+                      if ph.dtype == dtypes.resource), func.variables):
     ph_shape_map[ph.name] = var.shape
   # Construct a mapping of node names to nodes
   name_to_node = {node.name: node for node in graph_def.node}


### PR DESCRIPTION
To facilitate the conversion of variable ops (used in the experimental `disable_graph_freezing` mode) the converter annotates the graph with the shape of the variable ops.

This PR fixes the mapping between captured input names and variables so that the graph can be annotated correctly.
the problem with the previously used mapping appeared when the list `graph.internal_captures` contains the non-resource type elements. 

The unit test is provided.