### PR TITLE
Fix endless loop in tensorflow::wav::DecodeLin16WaveAsFloatVector

### DIFF
--- a/tensorflow/core/lib/wav/wav_io.cc
+++ b/tensorflow/core/lib/wav/wav_io.cc
@@ -99,16 +99,16 @@ Status IncrementOffset(int old_offset, int64_t increment, size_t max_size,
     return errors::InvalidArgument("Initial offset is outside data range: ",
                                    old_offset);
   }
-  *new_offset = old_offset + increment;
-  if (*new_offset > max_size) {
+  int64_t sum = old_offset + increment;
+  if (sum > max_size) {
     return errors::InvalidArgument("Data too short when trying to read string");
   }
   // See above for the check that the input offset is positive. If it's negative
   // here then it means that there's been an overflow in the arithmetic.
-  if (*new_offset < 0) {
-    return errors::InvalidArgument("Offset too large, overflowed: ",
-                                   *new_offset);
+  if (sum < 0) {
+    return errors::InvalidArgument("Offset too large, overflowed: ", sum);
   }
+  *new_offset = sum;
   return OkStatus();
 }
 


### PR DESCRIPTION
This bug was originally fixed by #56455

Regression was introduced in 50b4baf where addition result is truncated to smaller type. Thus, overflow checks do not work.

We performed continuous hybrid fuzzing with Sydr + libFuzzer/AFL++, and found an endless cycle in `decode_wav` fuzz target.

Seed: [timeout-26f66b056cebe711184a4ac9c508185972e48cb7.txt](https://github.com/tensorflow/tensorflow/files/11050056/timeout-26f66b056cebe711184a4ac9c508185972e48cb7.txt)

@mihaimaruseac, could you review, please?