### PR TITLE
Install suitable version of protobuf in order to build

### DIFF
--- a/.github/workflows/arm-ci.yml
+++ b/.github/workflows/arm-ci.yml
@@ -30,9 +30,10 @@ jobs:
   build:
     if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks
     runs-on: [self-hosted, linux, ARM64]
+    continue-on-error: true
     strategy:
       matrix:
-        pyver: ['3.10']
+        pyver: ['3.7','3.8','3.9','3.10']
     steps:
       - name: Stop old running containers (if any)
         shell: bash

--- a/tensorflow/tools/ci_build/builds/pip_new.sh
+++ b/tensorflow/tools/ci_build/builds/pip_new.sh
@@ -325,9 +325,9 @@ if [[ -z "$PYTHON_BIN_PATH" ]]; then
   die "PYTHON_BIN_PATH was not provided. Did you run configure?"
 fi
 
-${PYTHON_BIN_PATH} -m pip install tb-nightly
-${PYTHON_BIN_PATH} -m pip uninstall -y protobuf
-${PYTHON_BIN_PATH} -m pip install "protobuf < 4"
+${PYTHON_BIN_PATH} -m pip install protobuf~=3.19.6
+${PYTHON_BIN_PATH} -m pip install numpy~=1.21.4
+${PYTHON_BIN_PATH} -m pip install tensorboard~=2.11.2
 
 # Bazel build the file.
 PIP_BUILD_TARGET="//tensorflow/tools/pip_package:build_pip_package"
@@ -390,6 +390,7 @@ test_pip_virtualenv() {
     return 1
   fi
 
+  ${PIP_BIN_PATH} install numpy~=1.21.4
   # Install extra pip packages, if specified.
   for PACKAGE in ${INSTALL_EXTRA_PIP_PACKAGES}; do
     echo "Installing extra pip package required by test-on-install: ${PACKAGE}"


### PR DESCRIPTION
Allowing unrestrained versions of protobuf to be installed during build leads to test failures later. So ensure that only a supported version is installed during build. Also for tensorboard although this may not be necessary but is at least correct.