### PR TITLE
Corrected Bug involving M_PI Variable

### DIFF
--- a/tensorflow/core/lib/random/random_distributions_utils.h
+++ b/tensorflow/core/lib/random/random_distributions_utils.h
@@ -22,6 +22,11 @@ limitations under the License.
 
 #include "tensorflow/core/lib/random/philox_random.h"
 
+// Some platforms don't have M_PI
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 namespace tensorflow {
 namespace random {
 


### PR DESCRIPTION
I corrected a bug involving the M_PI variable that stops Tensorflow-lite from compiling