### PR TITLE
[NVIDIA TF] Enable GPU bfloat16 casts

### DIFF
--- a/tensorflow/core/kernels/cast_op.cc
+++ b/tensorflow/core/kernels/cast_op.cc
@@ -45,6 +45,7 @@ typedef Eigen::GpuDevice GPUDevice;
   FN(arg0, int32);               \
   FN(arg0, int64_t);             \
   FN(arg0, Eigen::half);         \
+  FN(arg0, bfloat16);            \
   FN(arg0, float);               \
   FN(arg0, double);              \
   FN(arg0, std::complex<float>); \
@@ -252,15 +253,27 @@ CURRY_TYPES2(REGISTER_CAST_GPU, float);
 CURRY_TYPES2(REGISTER_CAST_GPU, double);
 CURRY_TYPES2(REGISTER_CAST_GPU, std::complex<float>);
 CURRY_TYPES2(REGISTER_CAST_GPU, std::complex<double>);
-#endif
-
-REGISTER_CAST_GPU(bfloat16, int32);
+#else
+REGISTER_CAST_GPU(bool, bfloat16);
+REGISTER_CAST_GPU(int8, bfloat16);
+REGISTER_CAST_GPU(int16, bfloat16);
 REGISTER_CAST_GPU(int32, bfloat16);
+REGISTER_CAST_GPU(int64, bfloat16);
+REGISTER_CAST_GPU(uint8, bfloat16);
+REGISTER_CAST_GPU(uint16, bfloat16);
+REGISTER_CAST_GPU(uint32, bfloat16);
+REGISTER_CAST_GPU(uint64, bfloat16);
+REGISTER_CAST_GPU(Eigen::half, bfloat16);
+REGISTER_CAST_GPU(float, bfloat16);
+REGISTER_CAST_GPU(double, bfloat16);
+REGISTER_CAST_GPU(std::complex<float>, bfloat16);
+REGISTER_CAST_GPU(std::complex<double>, bfloat16);
+#endif 
+CURRY_TYPES2(REGISTER_CAST_GPU, bfloat16);
 
 REGISTER_CAST_GPU(float, float8_e5m2);
 REGISTER_CAST_GPU(float, float8_e4m3fn);
 
-REGISTER_CAST_GPU(bfloat16, float);
 REGISTER_CAST_GPU(bfloat16, float8_e5m2);
 REGISTER_CAST_GPU(bfloat16, float8_e4m3fn);
 

--- a/tensorflow/core/kernels/cast_op.cc
+++ b/tensorflow/core/kernels/cast_op.cc
@@ -254,7 +254,9 @@ CURRY_TYPES2(REGISTER_CAST_GPU, std::complex<float>);
 CURRY_TYPES2(REGISTER_CAST_GPU, std::complex<double>);
 #endif
 
-REGISTER_CAST_GPU(float, bfloat16);
+REGISTER_CAST_GPU(bfloat16, int32);
+REGISTER_CAST_GPU(int32, bfloat16);
+
 REGISTER_CAST_GPU(float, float8_e5m2);
 REGISTER_CAST_GPU(float, float8_e4m3fn);
 

--- a/tensorflow/core/kernels/cast_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/cast_op_gpu.cu.cc
@@ -47,29 +47,10 @@ CAST_FUNCTORS(GPUDevice);
   DEFINE(in_type, int32);               \
   DEFINE(in_type, int64);               \
   DEFINE(in_type, Eigen::half);         \
-  DEFINE(in_type, bfloat16);            \
   DEFINE(in_type, float);               \
   DEFINE(in_type, double);              \
   DEFINE(in_type, std::complex<float>); \
   DEFINE(in_type, std::complex<double>)
-
-DEFINE(bool, bfloat16);
-DEFINE(uint8, bfloat16);
-DEFINE(uint16, bfloat16);
-DEFINE(uint32, bfloat16);
-DEFINE(uint64, bfloat16);
-DEFINE(int8, bfloat16);
-DEFINE(int16, bfloat16);
-DEFINE(int32, bfloat16);
-DEFINE(int64, bfloat16);
-DEFINE(float, bfloat16);
-DEFINE(double, bfloat16);
-DEFINE(Eigen::half, bfloat16);
-DEFINE(std::complex<float>, bfloat16);
-DEFINE(std::complex<double>, bfloat16);
-DEFINE(bfloat16, std::complex<double>);
-DEFINE(bfloat16, std::complex<float>);
-DEFINE(bfloat16, double);
 
 // Required functors not previously specialized for truncation.
 DEFINE(double, float8_e5m2);
@@ -133,6 +114,20 @@ DEFINE_ALL_FROM(std::complex<double>);
   DEFINE(out_type, bfloat16)
 
 DEFINE_ALL_TO_HALF(bfloat16);
+DEFINE(bool, bfloat16);
+DEFINE(uint8, bfloat16);
+DEFINE(uint16, bfloat16);
+DEFINE(uint32, bfloat16);
+DEFINE(uint64, bfloat16);
+DEFINE(int8, bfloat16);
+DEFINE(int16, bfloat16);
+DEFINE(int32, bfloat16);
+DEFINE(int64, bfloat16);
+DEFINE(std::complex<double>, bfloat16);
+DEFINE(double, bfloat16);
+DEFINE(bfloat16, std::complex<float>);
+DEFINE(bfloat16, std::complex<double>);
+DEFINE(bfloat16, double);
 
 #if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
 // The cast from Eigen::half is still needed for depthwise_conv_grad_op.cc.
@@ -143,6 +138,10 @@ DEFINE(float, float);
 // self_adjoint_eig_v2_op_gpu.cc
 DEFINE(std::complex<float>, float);
 DEFINE(std::complex<double>, double);
+
+DEFINE(float, bfloat16);
+DEFINE(Eigen::half, bfloat16);
+DEFINE(std::complex<float>, bfloat16);
 #else
 DEFINE_ALL_TO_HALF(Eigen::half);
 DEFINE_ALL_TO_FLOAT(float);

--- a/tensorflow/core/kernels/cast_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/cast_op_gpu.cu.cc
@@ -47,13 +47,29 @@ CAST_FUNCTORS(GPUDevice);
   DEFINE(in_type, int32);               \
   DEFINE(in_type, int64);               \
   DEFINE(in_type, Eigen::half);         \
+  DEFINE(in_type, bfloat16);            \
   DEFINE(in_type, float);               \
   DEFINE(in_type, double);              \
   DEFINE(in_type, std::complex<float>); \
   DEFINE(in_type, std::complex<double>)
 
-DEFINE(float, bfloat16);
+DEFINE(bool, bfloat16);
+DEFINE(uint8, bfloat16);
+DEFINE(uint16, bfloat16);
+DEFINE(uint32, bfloat16);
+DEFINE(uint64, bfloat16);
+DEFINE(int8, bfloat16);
+DEFINE(int16, bfloat16);
 DEFINE(int32, bfloat16);
+DEFINE(int64, bfloat16);
+DEFINE(float, bfloat16);
+DEFINE(double, bfloat16);
+DEFINE(Eigen::half, bfloat16);
+DEFINE(std::complex<float>, bfloat16);
+DEFINE(std::complex<double>, bfloat16);
+DEFINE(bfloat16, std::complex<double>);
+DEFINE(bfloat16, std::complex<float>);
+DEFINE(bfloat16, double);
 
 // Required functors not previously specialized for truncation.
 DEFINE(double, float8_e5m2);
@@ -99,6 +115,7 @@ DEFINE_ALL_FROM(std::complex<double>);
   DEFINE(out_type, int32);            \
   DEFINE(out_type, int64);            \
   DEFINE(out_type, Eigen::half);      \
+  DEFINE(out_type, bfloat16);         \
   DEFINE(out_type, float);            \
   DEFINE(out_type, std::complex<float>)
 
@@ -112,7 +129,8 @@ DEFINE_ALL_FROM(std::complex<double>);
   DEFINE(out_type, int16);           \
   DEFINE(out_type, int32);           \
   DEFINE(out_type, int64);           \
-  DEFINE(out_type, Eigen::half)
+  DEFINE(out_type, Eigen::half);     \
+  DEFINE(out_type, bfloat16)
 
 DEFINE_ALL_TO_HALF(bfloat16);
 

--- a/tensorflow/core/kernels/cast_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/cast_op_gpu.cu.cc
@@ -53,6 +53,7 @@ CAST_FUNCTORS(GPUDevice);
   DEFINE(in_type, std::complex<double>)
 
 DEFINE(float, bfloat16);
+DEFINE(int32, bfloat16);
 
 // Required functors not previously specialized for truncation.
 DEFINE(double, float8_e5m2);

--- a/tensorflow/core/kernels/cast_op_impl.h
+++ b/tensorflow/core/kernels/cast_op_impl.h
@@ -72,7 +72,7 @@ CAST_FUNCTORS(Eigen::ThreadPoolDevice);
 
 }  // namespace functor
 
-#define CURRY_TYPES3_NO_HALF(FN, arg0, arg1) \
+#define CURRY_TYPES3(FN, arg0, arg1) \
   FN(arg0, arg1, bool);                      \
   FN(arg0, arg1, uint8);                     \
   FN(arg0, arg1, uint16);                    \
@@ -85,14 +85,8 @@ CAST_FUNCTORS(Eigen::ThreadPoolDevice);
   FN(arg0, arg1, float);                     \
   FN(arg0, arg1, double);                    \
   FN(arg0, arg1, std::complex<float>);       \
-  FN(arg0, arg1, std::complex<double>)
-
-#define CURRY_TYPES3_NO_BF16(FN, arg0, arg1) \
-  CURRY_TYPES3_NO_HALF(FN, arg0, arg1)       \
-  FN(arg0, arg1, Eigen::half);
-
-#define CURRY_TYPES3(FN, arg0, arg1)   \
-  CURRY_TYPES3_NO_BF16(FN, arg0, arg1) \
+  FN(arg0, arg1, std::complex<double>)       \
+  FN(arg0, arg1, Eigen::half);               \
   FN(arg0, arg1, bfloat16);
 
 #define CAST_CASE(DEVICE, IN, OUT)                                        \

--- a/tensorflow/core/kernels/cast_op_impl_bfloat.cc
+++ b/tensorflow/core/kernels/cast_op_impl_bfloat.cc
@@ -32,8 +32,7 @@ CastFunctorType GetCpuCastFromBfloat(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromBfloat(DataType dst_dtype) {
-  CAST_CASE(GPUDevice, bfloat16, int32);
-  CAST_CASE(GPUDevice, bfloat16, float);
+  CURRY_TYPES3(CAST_CASE, GPUDevice, bfloat16);
   CAST_CASE(GPUDevice, bfloat16, float8_e5m2);
   CAST_CASE(GPUDevice, bfloat16, float8_e4m3fn);
   return nullptr;

--- a/tensorflow/core/kernels/cast_op_impl_bfloat.cc
+++ b/tensorflow/core/kernels/cast_op_impl_bfloat.cc
@@ -32,6 +32,7 @@ CastFunctorType GetCpuCastFromBfloat(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromBfloat(DataType dst_dtype) {
+  CAST_CASE(GPUDevice, bfloat16, int32);
   CAST_CASE(GPUDevice, bfloat16, float);
   CAST_CASE(GPUDevice, bfloat16, float8_e5m2);
   CAST_CASE(GPUDevice, bfloat16, float8_e4m3fn);

--- a/tensorflow/core/kernels/cast_op_impl_bool.cc
+++ b/tensorflow/core/kernels/cast_op_impl_bool.cc
@@ -28,8 +28,10 @@ CastFunctorType GetCpuCastFromBool(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromBool(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, bool);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, bool, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, bool);
 #endif
   return nullptr;
 }

--- a/tensorflow/core/kernels/cast_op_impl_complex128.cc
+++ b/tensorflow/core/kernels/cast_op_impl_complex128.cc
@@ -28,8 +28,10 @@ CastFunctorType GetCpuCastFromComplex128(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromComplex128(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, std::complex<double>);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, std::complex<double>, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, std::complex<double>);
 #endif
   return nullptr;
 }

--- a/tensorflow/core/kernels/cast_op_impl_complex64.cc
+++ b/tensorflow/core/kernels/cast_op_impl_complex64.cc
@@ -28,8 +28,10 @@ CastFunctorType GetCpuCastFromComplex64(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromComplex64(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, std::complex<float>);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, std::complex<float>, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, std::complex<float>);
 #endif
   return nullptr;
 }

--- a/tensorflow/core/kernels/cast_op_impl_double.cc
+++ b/tensorflow/core/kernels/cast_op_impl_double.cc
@@ -30,8 +30,10 @@ CastFunctorType GetCpuCastFromDouble(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromDouble(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, double);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, double, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, double);
 #endif
   CAST_CASE(GPUDevice, double, float8_e5m2);
   CAST_CASE(GPUDevice, double, float8_e4m3fn);

--- a/tensorflow/core/kernels/cast_op_impl_half.cc
+++ b/tensorflow/core/kernels/cast_op_impl_half.cc
@@ -30,8 +30,10 @@ CastFunctorType GetCpuCastFromHalf(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromHalf(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, Eigen::half);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, Eigen::half, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, Eigen::half);
 #endif
   CAST_CASE(GPUDevice, Eigen::half, float8_e5m2);
   CAST_CASE(GPUDevice, Eigen::half, float8_e4m3fn);

--- a/tensorflow/core/kernels/cast_op_impl_int16.cc
+++ b/tensorflow/core/kernels/cast_op_impl_int16.cc
@@ -28,8 +28,10 @@ CastFunctorType GetCpuCastFromInt16(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromInt16(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, int16);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, int16, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, int16);
 #endif
   return nullptr;
 }

--- a/tensorflow/core/kernels/cast_op_impl_int32.cc
+++ b/tensorflow/core/kernels/cast_op_impl_int32.cc
@@ -28,8 +28,10 @@ CastFunctorType GetCpuCastFromInt32(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromInt32(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, int32);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, int32, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, int32);
 #endif
   return nullptr;
 }

--- a/tensorflow/core/kernels/cast_op_impl_int64.cc
+++ b/tensorflow/core/kernels/cast_op_impl_int64.cc
@@ -28,8 +28,10 @@ CastFunctorType GetCpuCastFromInt64(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromInt64(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, int64);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, int64, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, int64);
 #endif
   return nullptr;
 }

--- a/tensorflow/core/kernels/cast_op_impl_int8.cc
+++ b/tensorflow/core/kernels/cast_op_impl_int8.cc
@@ -28,8 +28,10 @@ CastFunctorType GetCpuCastFromInt8(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromInt8(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, int8);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, int8, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, int8);
 #endif
   return nullptr;
 }

--- a/tensorflow/core/kernels/cast_op_impl_uint16.cc
+++ b/tensorflow/core/kernels/cast_op_impl_uint16.cc
@@ -28,8 +28,10 @@ CastFunctorType GetCpuCastFromUint16(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromUint16(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, uint16);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, uint16, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, uint16);
 #endif
   return nullptr;
 }

--- a/tensorflow/core/kernels/cast_op_impl_uint32.cc
+++ b/tensorflow/core/kernels/cast_op_impl_uint32.cc
@@ -28,8 +28,10 @@ CastFunctorType GetCpuCastFromUint32(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromUint32(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, uint32);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, uint32, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, uint32);
 #endif
   return nullptr;
 }

--- a/tensorflow/core/kernels/cast_op_impl_uint64.cc
+++ b/tensorflow/core/kernels/cast_op_impl_uint64.cc
@@ -28,8 +28,10 @@ CastFunctorType GetCpuCastFromUint64(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromUint64(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, uint64);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, uint64, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, uint64);
 #endif
   return nullptr;
 }

--- a/tensorflow/core/kernels/cast_op_impl_uint8.cc
+++ b/tensorflow/core/kernels/cast_op_impl_uint8.cc
@@ -28,8 +28,10 @@ CastFunctorType GetCpuCastFromUint8(DataType dst_dtype) {
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)
 CastFunctorType GetGpuCastFromUint8(DataType dst_dtype) {
-#if !defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
-  CURRY_TYPES3_NO_BF16(CAST_CASE, GPUDevice, uint8);
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED)
+  CAST_CASE(GPUDevice, uint8, bfloat16);
+#else
+  CURRY_TYPES3(CAST_CASE, GPUDevice, uint8);
 #endif
   return nullptr;
 }


### PR DESCRIPTION
Register and define GPU Cast kernels for all types <-> bfloat16. Previously, we only had float and fp8 casts.

Fixes https://github.com/tensorflow/tensorflow/issues/59728

@reedwm