### PR TITLE
Replace float_t with float in C++ source

### DIFF
--- a/tensorflow/compiler/xla/literal_test.cc
+++ b/tensorflow/compiler/xla/literal_test.cc
@@ -2384,9 +2384,9 @@ TEST_F(LiteralUtilTest, PopulateR2DynamicDim1) {
 TEST_F(LiteralUtilTest, PopulateFrom1DArray) {
   auto literal = Literal(ShapeUtil::MakeShape(F32, {20}));
   literal.SetDynamicSize(0, 10);
-  xla::Array<float_t> array({10});
+  xla::Array<float> array({10});
   for (int i = 0; i < 10; i++) {
-    array(i) = static_cast<float_t>(i);
+    array(i) = static_cast<float>(i);
   }
   literal.PopulateFromArray(array);
   std::string expected = "f32[<=20](10) {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}";
@@ -2398,10 +2398,10 @@ TEST_F(LiteralUtilTest, PopulateFromArrayDynamicDim0) {
   const uint32_t rows = 3;
   const uint32_t cols = 5;
   literal.SetDynamicSize(0, rows);
-  xla::Array<float_t> array({rows, cols});
+  xla::Array<float> array({rows, cols});
   for (int i = 0; i < rows; i++) {
     for (int j = 0; j < cols; j++) {
-      array(i, j) = static_cast<float_t>(j);
+      array(i, j) = static_cast<float>(j);
     }
   }
   literal.PopulateFromArray(array);
@@ -2418,10 +2418,10 @@ TEST_F(LiteralUtilTest, PopulateFromArrayDynamicDim1) {
   const uint32_t rows = 5;
   const uint32_t cols = 3;
   literal.SetDynamicSize(1, cols);
-  xla::Array<float_t> array({rows, cols});
+  xla::Array<float> array({rows, cols});
   for (int i = 0; i < rows; i++) {
     for (int j = 0; j < cols; j++) {
-      array(i, j) = static_cast<float_t>(j);
+      array(i, j) = static_cast<float>(j);
     }
   }
   literal.PopulateFromArray(array);
@@ -2440,10 +2440,10 @@ TEST_F(LiteralUtilTest, PopulateR2FromArray2DDynamicDim0) {
   const uint32_t rows = 3;
   const uint32_t cols = 5;
   literal.SetDynamicSize(0, rows);
-  xla::Array2D<float_t> array({rows, cols});
+  xla::Array2D<float> array({rows, cols});
   for (int i = 0; i < rows; i++) {
     for (int j = 0; j < cols; j++) {
-      array(i, j) = static_cast<float_t>(j);
+      array(i, j) = static_cast<float>(j);
     }
   }
   literal.PopulateR2FromArray2D(array);
@@ -2460,10 +2460,10 @@ TEST_F(LiteralUtilTest, PopulateR2FromArray2DDynamicDim1) {
   const uint32_t rows = 5;
   const uint32_t cols = 3;
   literal.SetDynamicSize(1, cols);
-  xla::Array2D<float_t> array({rows, cols});
+  xla::Array2D<float> array({rows, cols});
   for (int i = 0; i < rows; i++) {
     for (int j = 0; j < cols; j++) {
-      array(i, j) = static_cast<float_t>(j);
+      array(i, j) = static_cast<float>(j);
     }
   }
   literal.PopulateR2FromArray2D(array);
@@ -2483,10 +2483,10 @@ TEST_F(LiteralUtilTest, PopulateR2FromArray2DDynamicDim0Dim1) {
   const uint32_t cols = 2;
   literal.SetDynamicSize(0, rows);
   literal.SetDynamicSize(1, cols);
-  xla::Array2D<float_t> array({rows, cols});
+  xla::Array2D<float> array({rows, cols});
   for (int i = 0; i < rows; i++) {
     for (int j = 0; j < cols; j++) {
-      array(i, j) = static_cast<float_t>(j);
+      array(i, j) = static_cast<float>(j);
     }
   }
   literal.PopulateR2FromArray2D(array);

--- a/tensorflow/lite/kernels/internal/tensor_utils_test.cc
+++ b/tensorflow/lite/kernels/internal/tensor_utils_test.cc
@@ -464,7 +464,7 @@ TEST(uKernels, HybridMatrixBatchVectorMultiplyAccumulate8x8_16Test) {
       input_offsets.data(), scratch.data(), row_sums, &compute_row_sums,
       &context);
 
-  const std::vector<float_t> expected_output = {
+  const std::vector<float> expected_output = {
       -228, 1548,  937, -166, -1164, -1578, -278,  303, 839,  -820,  132,
       1733, -1858, 58,  -425, -587,  -228,  1548,  937, -166, -1164, -1578,
       -278, 303,   839, -820, 132,   1733,  -1858, 58,  -425, -587,

--- a/tensorflow/lite/tools/strip_buffers/stripping_lib.cc
+++ b/tensorflow/lite/tools/strip_buffers/stripping_lib.cc
@@ -286,11 +286,11 @@ TfLiteStatus ReconstituteConstantTensorsIntoFlatbuffer(
             sizeof(int8_t) * data.size());
         output_buffers.push_back(CreateBuffer(*new_model_builder, data_buffer));
       } else if (type == kTfLiteFloat32) {
-        std::vector<float_t> data;
+        std::vector<float> data;
         GenerateRandomGaussianData(num_elements, -1, 1, &data);
         auto data_buffer = new_model_builder->CreateVector(
             reinterpret_cast<const uint8_t*>(data.data()),
-            sizeof(float_t) * data.size());
+            sizeof(float) * data.size());
         output_buffers.push_back(CreateBuffer(*new_model_builder, data_buffer));
       } else if (type == kTfLiteInt32) {
         std::vector<int32_t> data;


### PR DESCRIPTION
All current instances of float_t in C++ source files expect them to be a 32-bit floating point type but on s390x systems with glibc < 2.33 (eg. Ubuntu 20.04) float_t is a 64-bit floating point type. Change float_t to float which is 32-bit on all known platforms.

Fixes //tensorflow/compiler/xla:literal_test on Ubuntu 20.04 s390x.