### PR TITLE
[NVIDIA XLA:GPU] Fused MHA Support in XLA GPU: SE

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
@@ -27,7 +27,6 @@ limitations under the License.
 #include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include "third_party/eigen3/Eigen/Core"
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_activation.h"
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_diagnostics.h"
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_driver.h"
@@ -48,11 +47,13 @@ limitations under the License.
 #include "tensorflow/tsl/platform/tensor_float_32_utils.h"
 #include "tensorflow/tsl/util/determinism.h"
 #include "tensorflow/tsl/util/env_var.h"
+#include "third_party/eigen3/Eigen/Core"
 
 // clang-format off
 #include "third_party/gpus/cudnn/cudnn.h"
 #if CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 #include "third_party/cudnn_frontend/include/cudnn_frontend.h"
+#include "third_party/cudnn_frontend/include/cudnn_frontend_utils.h"
 #endif  // CUDNN_VERSION >= 8100 && TF_ENABLE_CUDNN_FRONTEND
 #include "absl/strings/string_view.h"
 // clang-format on
@@ -3491,6 +3492,29 @@ std::tuple<int, int> GetTensorVectorSizeAndDim(
   return std::make_tuple(vector_size, vector_dim);
 }
 
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
+tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnTensor(
+    absl::Span<const int64_t> dims, absl::Span<const int64_t> strides,
+    int64_t uid, dnn::DataType dtype, int64_t vec_count, int64_t vec_dim,
+    bool is_virtual = false,
+    cudnnBackendTensorReordering_t cudnn_tensor_order_type =
+        CUDNN_TENSOR_REORDERING_NONE,
+    bool is_value = false) {
+  auto tensor = cudnn_frontend::TensorBuilder()
+                    .setDim(dims.size(), dims.data())
+                    .setStride(strides.size(), strides.data())
+                    .setId(uid)
+                    .setAlignment(32)
+                    .setDataType(ToCudnnDataType(dtype))
+                    .setVectorCountAndDimension(vec_count, vec_dim)
+                    .setVirtual(is_virtual)
+                    .setReorderType(cudnn_tensor_order_type)
+                    .setByValue(is_value)
+                    .build();
+  RETURN_MSG_IF_CUDNN_ERROR(tensor);
+  return tensor;
+}
+#else
 tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnTensor(
     absl::Span<const int64_t> dims, absl::Span<const int64_t> strides,
     int64_t uid, dnn::DataType dtype, int64_t vec_count, int64_t vec_dim,
@@ -3519,6 +3543,335 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnTensor(
   RETURN_MSG_IF_CUDNN_ERROR(tensor);
   return tensor;
 }
+#endif
+
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
+// Returns a cudnn tensor that's the output of the mask op
+tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnMaskTensor(
+    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
+    absl::Span<const int64_t> strides, dnn::DataType dtype,
+    std::shared_ptr<cudnn_frontend::Tensor> input_tensor, double scale) {
+  std::vector<int64_t> mask_dim(dims.size(), 1);
+  std::vector<int64_t> mask_stride(strides.size(), 1);
+
+  // Create the masked out value tensor.
+  TF_ASSIGN_OR_RETURN(
+      auto masked_val_tensor,
+      CreateCudnnTensor(
+          mask_dim, mask_stride, 'A', dnn::DataType::kFloat, 1, -1,
+          /*is_virtual*/ false,
+          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE,
+          /*is_value*/ true));
+
+  // Create the mask tensor
+  TF_ASSIGN_OR_RETURN(auto mask_tensor,
+                      CreateCudnnTensor(dims, strides, 'P', dtype, 1, -1,
+                                        /*is_virtual=*/false));
+  // Create the mask output tensor
+  TF_ASSIGN_OR_RETURN(
+      auto mask_out_tensor,
+      CreateCudnnTensor(dims, strides, 'm' + 500, dnn::DataType::kFloat, 1, -1,
+                        /*is_virtual=*/true));
+
+  auto mask_desc = cudnn_frontend::PointWiseDescBuilder()
+                       .setMode(CUDNN_POINTWISE_MUL)
+                       .setComputeType(CUDNN_DATA_FLOAT)
+                       .build();
+
+  // Create the mask op.
+  auto mask_op = cudnn_frontend::OperationBuilder(
+                     CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                     .setxDesc((*input_tensor))
+                     .setbDesc(mask_tensor)
+                     .setAlpha(scale)
+                     .setyDesc(mask_out_tensor)
+                     .setpwDesc(mask_desc)
+                     .build();
+
+  RETURN_MSG_IF_CUDNN_ERROR(mask_op);
+
+  RETURN_MSG_IF_CUDNN_ERROR(mask_out_tensor);
+  // Add mask to op list
+  ops.push_back(std::move(mask_op));
+
+  return mask_out_tensor;
+}
+
+// Returns a cudnn tensor that's the output of the bias addition op
+tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnBiasTensor(
+    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
+    absl::Span<const int64_t> strides, dnn::DataType dtype,
+    std::shared_ptr<cudnn_frontend::Tensor> input_tensor, double alpha_scale,
+    bool use_mask) {
+  // Create the bias tensor.
+  TF_ASSIGN_OR_RETURN(auto bias_tensor,
+                      CreateCudnnTensor(dims, strides, 'B', dtype, 1, -1));
+
+  // Create the bias output tensor
+  dnn::DataType bias_out_type = use_mask ? dtype : dnn::DataType::kFloat;
+  TF_ASSIGN_OR_RETURN(
+      auto bias_out_tensor,
+      CreateCudnnTensor(dims, strides, 'B' + 200, bias_out_type, 1, -1,
+                        /*is_virtual=*/true));
+
+  // Define the bias descriptor
+  auto bias_desc = cudnn_frontend::PointWiseDescBuilder()
+                       .setMode(CUDNN_POINTWISE_ADD)
+                       .setComputeType(CUDNN_DATA_FLOAT)
+                       .build();
+  // Create the bias op.
+  auto bias_op = cudnn_frontend::OperationBuilder(
+                     CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                     .setxDesc((*input_tensor))
+                     .setbDesc(bias_tensor)
+                     .setyDesc(bias_out_tensor)
+                     .setAlpha(alpha_scale)
+                     .setpwDesc(bias_desc)
+                     .build();
+
+  RETURN_MSG_IF_CUDNN_ERROR(bias_op);
+
+  RETURN_MSG_IF_CUDNN_ERROR(bias_out_tensor);
+  // Add bias to op list
+  ops.push_back(std::move(bias_op));
+
+  return bias_out_tensor;
+}
+
+// Returns a cudnn tensor that's the output of the softmax op
+tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnSoftmaxFwdTensor(
+    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
+    absl::Span<const int64_t> strides, dnn::DataType dtype,
+    std::shared_ptr<cudnn_frontend::Tensor> input_tensor, bool use_dropout,
+    bool is_virtual = false) {
+  // softmax's typical computation is:
+  // exp(input - reduce_max(input)) / reduce_sum(exp(input - reduce_max(input)))
+  // We need to create each op and add it to the op list sequentially.
+
+  // Copy all dims except the last dim since it's reduced to 1.
+  std::vector<int64_t> reduction_output_dim(dims.begin(), dims.end() - 1);
+  reduction_output_dim.push_back(1);
+
+  // Divide every stride by the last dim value.
+  std::vector<int64_t> reduction_output_stride;
+  int64_t reduced_dim_len = dims.back();
+  for (auto stride : strides) {
+    reduction_output_stride.push_back(stride / reduced_dim_len);
+  }
+
+  // Softmax output should be float
+  cudnnDataType_t softmax_output_type = CUDNN_DATA_FLOAT;
+
+  // Create output tensor of the first max reduction.
+  TF_ASSIGN_OR_RETURN(
+      auto max_reduction_output_tensor,
+      CreateCudnnTensor(reduction_output_dim, reduction_output_stride, 'm',
+                        dnn::DataType::kFloat, 1, -1, /*is_virtual=*/true));
+
+  // Create the reduction descriptor
+  auto max_reduction_desc = cudnn_frontend::ReductionDescBuilder()
+                                .setComputeType(softmax_output_type)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_MAX)
+                                .build();
+
+  // Create a reduction max node.
+  auto max_reduction_op = cudnn_frontend::OperationBuilder(
+                              CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                              .setxDesc((*input_tensor))
+                              .setyDesc(max_reduction_output_tensor)
+                              .setreductionDesc(max_reduction_desc)
+                              .build();
+  RETURN_MSG_IF_CUDNN_ERROR(max_reduction_op);
+
+  // Create output tensor of the subtraction op.
+  TF_ASSIGN_OR_RETURN(
+      auto subtract_output_tensor,
+      CreateCudnnTensor(dims, strides, 'S', dnn::DataType::kFloat, 1, -1,
+                        /*is_virtual=*/true));
+  // Create the subtraction descriptor
+  auto subtract_desc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_SUB)
+                           .setComputeType(softmax_output_type)
+                           .build();
+
+  // Create a subtraction node.
+  auto subtract_op = cudnn_frontend::OperationBuilder(
+                         CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                         .setxDesc((*input_tensor))
+                         .setbDesc(max_reduction_output_tensor)
+                         .setyDesc(subtract_output_tensor)
+                         .setpwDesc(subtract_desc)
+                         .build();
+  RETURN_MSG_IF_CUDNN_ERROR(subtract_op);
+  // Create output tensor of the exp op.
+  TF_ASSIGN_OR_RETURN(
+      auto exp_output_tensor,
+      CreateCudnnTensor(dims, strides, 'e', dnn::DataType::kFloat, 1, -1,
+                        /*is_virtual=*/true));
+  // Create the exponetial descriptor
+  auto exp_desc = cudnn_frontend::PointWiseDescBuilder()
+                      .setMode(CUDNN_POINTWISE_EXP)
+                      .setComputeType(softmax_output_type)
+                      .build();
+
+  // Create a exponetial node.
+  auto exp_op = cudnn_frontend::OperationBuilder(
+                    CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                    .setxDesc(subtract_output_tensor)
+                    .setyDesc(exp_output_tensor)
+                    .setpwDesc(exp_desc)
+                    .build();
+  RETURN_MSG_IF_CUDNN_ERROR(exp_op);
+
+  // Create output tensor of the sum reduction.
+  TF_ASSIGN_OR_RETURN(
+      auto sum_reduction_output_tensor,
+      CreateCudnnTensor(reduction_output_dim, reduction_output_stride, 'u',
+                        dnn::DataType::kFloat, 1, -1, /*is_virtual=*/true));
+  // Create the reduction descriptor
+  auto sum_reduction_desc = cudnn_frontend::ReductionDescBuilder()
+                                .setComputeType(softmax_output_type)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
+                                .build();
+
+  // Create a reduction sum node.
+  auto sum_reduction_op = cudnn_frontend::OperationBuilder(
+                              CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                              .setxDesc(exp_output_tensor)
+                              .setyDesc(sum_reduction_output_tensor)
+                              .setreductionDesc(sum_reduction_desc)
+                              .build();
+  RETURN_MSG_IF_CUDNN_ERROR(sum_reduction_op);
+
+  // Create output tensor of the divide op.
+  cudnnBackendTensorReordering_t tensor_ordering = CUDNN_TENSOR_REORDERING_NONE;
+  if (use_dropout) {
+    tensor_ordering = CUDNN_TENSOR_REORDERING_F16x16;
+  }
+  TF_ASSIGN_OR_RETURN(
+      auto divide_output_tensor,
+      CreateCudnnTensor(dims, strides, 'd', dtype, 1, -1,
+                        /*is_virtual*/ is_virtual,
+                        /*cudnn_tensor_order_type*/ tensor_ordering));
+  // Create the divide descriptor
+  auto divide_desc = cudnn_frontend::PointWiseDescBuilder()
+                         .setMode(CUDNN_POINTWISE_DIV)
+                         .setComputeType(softmax_output_type)
+                         .build();
+
+  // Create a divide node.
+  auto divide_op = cudnn_frontend::OperationBuilder(
+                       CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                       .setxDesc(exp_output_tensor)
+                       .setbDesc(sum_reduction_output_tensor)
+                       .setyDesc(divide_output_tensor)
+                       .setpwDesc(divide_desc)
+                       .build();
+  RETURN_MSG_IF_CUDNN_ERROR(divide_op);
+
+  RETURN_MSG_IF_CUDNN_ERROR(divide_output_tensor);
+
+  // Add max reduction to op list
+  ops.push_back(std::move(max_reduction_op));
+  // Add subtract to op list
+  ops.push_back(std::move(subtract_op));
+  // Add exponetial to op list
+  ops.push_back(std::move(exp_op));
+  // Add sum reduction to op list
+  ops.push_back(std::move(sum_reduction_op));
+  // Add divide to op list
+  ops.push_back(std::move(divide_op));
+
+  return divide_output_tensor;
+}
+
+// Returns a cudnn tensor that's the output of the dropout op
+tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnDropoutTensor(
+    std::vector<cudnn_frontend::Operation>& ops, absl::Span<const int64_t> dims,
+    absl::Span<const int64_t> strides, dnn::DataType dtype,
+    std::shared_ptr<cudnn_frontend::Tensor> input_tensor, double dropout_rate,
+    int64_t seed) {
+  // Create tensor for dropout's mask.
+  TF_ASSIGN_OR_RETURN(
+      auto mask_tensor,
+      CreateCudnnTensor(dims, strides, 'K', dnn::DataType::kFloat, 1, -1,
+                        /*is_virtual*/ true));
+  // Create output tensor of dropout node
+  TF_ASSIGN_OR_RETURN(
+      auto dropout_out_tensor,
+      CreateCudnnTensor(
+          dims, strides, 'D', dtype, 1, -1, /*is_virtual*/ true,
+          /*cudnn_tensor_order_type*/
+          cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16));
+
+  // Create description for rng node
+  auto rng_desc = cudnn_frontend::RngDescBuilder()
+                      .setRngDistribution(CUDNN_RNG_DISTRIBUTION_BERNOULLI)
+                      .setBernoulliDistProbability(1.0 - dropout_rate)
+                      .build();
+  // Create the rng Node.
+  auto rng_op =
+      cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RNG_DESCRIPTOR)
+          .setyDesc(mask_tensor)
+          .setSeed(seed)
+          .setRngDesc(rng_desc)
+          .build();
+  RETURN_MSG_IF_CUDNN_ERROR(rng_op);
+
+  // Create the masking node desc after mask tensor
+  auto masking_desc = cudnn_frontend::PointWiseDescBuilder()
+                          .setMode(CUDNN_POINTWISE_MUL)
+                          .setComputeType(CUDNN_DATA_FLOAT)
+                          .build();
+
+  auto masking_op = cudnn_frontend::OperationBuilder(
+                        CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                        .setxDesc((*input_tensor))
+                        .setbDesc(mask_tensor)
+                        .setyDesc(dropout_out_tensor)
+                        .setpwDesc(masking_desc)
+                        .build();
+  RETURN_MSG_IF_CUDNN_ERROR(masking_op);
+
+  // Create scale tensor
+  std::vector<int64_t> scale_dims(dims.size(), 1);
+  std::vector<int64_t> scale_strides(strides.size(), 1);
+  TF_ASSIGN_OR_RETURN(
+      auto dropout_scale_tensor,
+      CreateCudnnTensor(
+          scale_dims, scale_strides, 'l', dtype, 1, -1, /*is_virtual*/ false,
+          /*cudnn_tensor_order_type*/ CUDNN_TENSOR_REORDERING_NONE));
+
+  // Create output of scale node
+  TF_ASSIGN_OR_RETURN(
+      auto dropout_scale_out_tensor,
+      CreateCudnnTensor(dims, strides, 'r', dtype, 1, -1, /*is_virtual*/ true));
+  // Create the scaling desc
+  auto scale_desc = cudnn_frontend::PointWiseDescBuilder()
+                        .setMode(CUDNN_POINTWISE_MUL)
+                        .setComputeType(CUDNN_DATA_FLOAT)
+                        .build();
+  // Create the scaling op
+  auto scale_op = cudnn_frontend::OperationBuilder(
+                      CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                      .setxDesc(dropout_out_tensor)
+                      .setbDesc(dropout_scale_tensor)
+                      .setyDesc(dropout_scale_out_tensor)
+                      .setpwDesc(scale_desc)
+                      .build();
+  RETURN_MSG_IF_CUDNN_ERROR(scale_op);
+
+  RETURN_MSG_IF_CUDNN_ERROR(dropout_scale_out_tensor);
+  // Add rng op to op list
+  ops.push_back(std::move(rng_op));
+  // Add masking op to op list
+  ops.push_back(std::move(masking_op));
+  // Add scaling op to op list
+  ops.push_back(std::move(scale_op));
+
+  return dropout_scale_out_tensor;
+}
+#endif
 
 tsl::StatusOr<std::unique_ptr<cudnn_frontend::OperationGraph>>
 GetCudnnOperationGraph(dnn::ConvolutionKind kind, dnn::DataType input_type,
@@ -3565,14 +3918,28 @@ GetCudnnOperationGraph(dnn::ConvolutionKind kind, dnn::DataType input_type,
   std::vector<int64_t> filter_strides = filter_descriptor.vectorized_strides(
       dnn::FilterLayout::kOutputInputYX, vector_size, vector_dim);
 
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
+  cudnnBackendTensorReordering_t tensor_ordering_type =
+      filter_descriptor.layout() ==
+              dnn::FilterLayout::kOutputInputYX32_CudnnReordered
+          ? CUDNN_TENSOR_REORDERING_INT8x32
+          : CUDNN_TENSOR_REORDERING_NONE;
+#else
   bool is_reordered_nchw_vect =
       filter_descriptor.layout() ==
       dnn::FilterLayout::kOutputInputYX32_CudnnReordered;
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_w,
-      CreateCudnnTensor(filter_dims, filter_strides, 'w', input_type,
-                        vector_size, vector_dim,
-                        /*is_virtual=*/false, is_reordered_nchw_vect));
+#endif
+
+  TF_ASSIGN_OR_RETURN(auto tensor_w,
+                      CreateCudnnTensor(filter_dims, filter_strides, 'w',
+                                        input_type, vector_size, vector_dim,
+                                        /*is_virtual=*/false,
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
+                                        tensor_ordering_type
+#else
+                                        is_reordered_nchw_vect
+#endif
+                                        ));
 
   // conv_desc.
   auto mode = convolution_descriptor.convolution_not_crosscorr()
@@ -3701,14 +4068,28 @@ GetCudnnFusedOperationGraph(
   std::vector<int64_t> filter_strides = filter_descriptor.vectorized_strides(
       dnn::FilterLayout::kOutputInputYX, vector_size, vector_dim);
 
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
+  cudnnBackendTensorReordering_t tensor_ordering_type =
+      filter_descriptor.layout() ==
+              dnn::FilterLayout::kOutputInputYX32_CudnnReordered
+          ? CUDNN_TENSOR_REORDERING_INT8x32
+          : CUDNN_TENSOR_REORDERING_NONE;
+#else
   bool is_reordered_nchw_vect =
       filter_descriptor.layout() ==
       dnn::FilterLayout::kOutputInputYX32_CudnnReordered;
-  TF_ASSIGN_OR_RETURN(
-      auto tensor_w,
-      CreateCudnnTensor(filter_dims, filter_strides, 'w', input_type,
-                        vector_size, vector_dim,
-                        /*is_virtual=*/false, is_reordered_nchw_vect));
+#endif
+
+  TF_ASSIGN_OR_RETURN(auto tensor_w,
+                      CreateCudnnTensor(filter_dims, filter_strides, 'w',
+                                        input_type, vector_size, vector_dim,
+                                        /*is_virtual=*/false,
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
+                                        tensor_ordering_type
+#else
+                                        is_reordered_nchw_vect
+#endif
+                                        )); // cuDNN 8.3 fails here
 
   // For the purposes of the cudnn graph, say that the bias tensor has the same
   // layout as the output tensor.  It doesn't actually matter, because bias is a
@@ -3742,9 +4123,15 @@ GetCudnnFusedOperationGraph(
   // kFloat). If it's not, then cuDNN silently does the reordering under the
   // hood, which yields incorrect results as we already do the reordering
   // ourselves.
-  auto maybe_tensor_b = CreateCudnnTensor(
-      bias_dims, bias_strides, 'b', bias_type, vector_size, vector_dim,
-      /*is_virtual=*/false, is_reordered_nchw_vect);  // cuDNN 8.3 fails here
+  auto maybe_tensor_b = CreateCudnnTensor(bias_dims, bias_strides, 'b',
+                                          bias_type, vector_size, vector_dim,
+                                          /*is_virtual=*/false,
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
+                                          tensor_ordering_type
+#else
+                                          is_reordered_nchw_vect
+#endif
+  );  // cuDNN 8.3 fails here
   if (!maybe_tensor_b.ok()) {
     maybe_tensor_b = CreateCudnnTensor(bias_dims, bias_strides, 'b', bias_type,
                                        vector_size, vector_dim);
@@ -4076,6 +4463,213 @@ GetCudnnFusedMatmulGraph(dnn::DataType input_type, dnn::DataType bias_type,
 
   return std::make_unique<cudnn_frontend::OperationGraph>(std::move(op_graph));
 }
+
+#if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
+tsl::StatusOr<std::unique_ptr<cudnn_frontend::OperationGraph>>
+GetCudnnFusedMHAOperationGraph(
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& mask_descriptor,
+    const dnn::TensorDescriptor& bias_descriptor,
+    const dnn::TensorDescriptor& output_descriptor, dnn::FusedMHAKind kind,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed,
+    CudnnHandle& cudnn, double scale, bool use_dropout = false,
+    bool use_mask = false, bool use_bias = false) {
+  if (VLOG_IS_ON(4)) {
+    VLOG(4) << "\n bmm1_lhs(q): " << bmm1_lhs_descriptor.ToString()
+            << "\n bmm1_rhs(k): " << bmm1_rhs_descriptor.ToString()
+            << "\n bmm2_lhs(s): " << intermediate_bmm2_lhs_descriptor.ToString()
+            << "\n bmm2_rhs(v): " << bmm2_rhs_descriptor.ToString()
+            << "\n out(o): " << output_descriptor.ToString();
+  }
+  // cnn_infer needs to be preloaded for fMHA as well. Reusing the function
+  // created for convolution for fMHA.
+  PreloadCudnnSubLibsHelper(dnn::ConvolutionKind::FORWARD);
+
+  std::vector<cudnn_frontend::Operation const*> ops;
+  std::vector<cudnn_frontend::Operation> intermdiate_ops;
+
+  // Batched Matmul: bmm1_lhs: tensor_q, bmm1_rhs:tensor_k; output: tensor_s
+  // (virtual)
+  // Batched Matmul: bmm2_lhs: tensor_s, bmm2_rhs:tensor_v; output: tensor_o
+  std::vector<int64_t> bmm1_lhs_dims =
+      bmm1_lhs_descriptor.GetCudnnCompatibleDimensions(true);
+  std::vector<int64_t> bmm1_lhs_strides =
+      bmm1_lhs_descriptor.GetCudnnCompatibleStrides(true);
+
+  VLOG(2) << "\n cuDNN compatible bmm1_lhs_dims: "
+          << absl::StrJoin(bmm1_lhs_dims, ",")
+          << "\n cuDNN compatible bmm1_lhs_strides: "
+          << absl::StrJoin(bmm1_lhs_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(auto tensor_q,
+                      CreateCudnnTensor(bmm1_lhs_dims, bmm1_lhs_strides, 'q',
+                                        bmm1_lhs_descriptor.type(), 1, -1));
+
+  std::vector<int64_t> bmm1_rhs_dims =
+      bmm1_rhs_descriptor.GetCudnnCompatibleDimensions(false);
+  std::vector<int64_t> bmm1_rhs_strides =
+      bmm1_rhs_descriptor.GetCudnnCompatibleStrides(false);
+
+  VLOG(2) << "\n cuDNN compatible bmm1_rhs_dims: "
+          << absl::StrJoin(bmm1_rhs_dims, ",")
+          << "\n cuDNN compatible bmm1_rhs_strides: "
+          << absl::StrJoin(bmm1_rhs_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(auto tensor_k,
+                      CreateCudnnTensor(bmm1_rhs_dims, bmm1_rhs_strides, 'k',
+                                        bmm1_rhs_descriptor.type(), 1, -1));
+
+  std::vector<int64_t> intermediate_bmm2_lhs_dims =
+      intermediate_bmm2_lhs_descriptor.GetCudnnCompatibleDimensions(true);
+  std::vector<int64_t> intermediate_bmm2_lhs_strides =
+      intermediate_bmm2_lhs_descriptor.GetCudnnCompatibleStrides(true);
+
+  VLOG(2) << "\n cuDNN compatible intermediate_bmm2_lhs_dims: "
+          << absl::StrJoin(intermediate_bmm2_lhs_dims, ",")
+          << "\n cuDNN compatible intermediate_bmm2_lhs_strides: "
+          << absl::StrJoin(intermediate_bmm2_lhs_strides, ",");
+  dnn::DataType s_tensor_type = kind == dnn::FusedMHAKind::BMM1_OUTPUT_FLOAT
+                                    ? dnn::DataType::kFloat
+                                    : intermediate_bmm2_lhs_descriptor.type();
+  TF_ASSIGN_OR_RETURN(
+      auto tensor_s,
+      CreateCudnnTensor(intermediate_bmm2_lhs_dims,
+                        intermediate_bmm2_lhs_strides, 's', s_tensor_type, 1,
+                        -1, /*is_virtual=*/true));
+
+  auto bmm1_desc = cudnn_frontend::MatMulDescBuilder()
+                       .setComputeType(CUDNN_DATA_FLOAT)
+                       .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm1_desc);
+  auto bmm1_op = cudnn_frontend::OperationBuilder(
+                     CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                     .setaMatDesc(tensor_q)
+                     .setbMatDesc(tensor_k)
+                     .setcMatDesc(tensor_s)
+                     .setmatmulDesc(bmm1_desc)
+                     .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm1_op);
+  intermdiate_ops.push_back(std::move(bmm1_op));
+
+  std::shared_ptr<cudnn_frontend::Tensor> bmm2_input_tensor =
+      std::make_shared<cudnn_frontend::Tensor>(std::move(tensor_s));
+  if (use_dropout || use_mask || kind == dnn::FusedMHAKind::BMM1_OUTPUT_FLOAT ||
+      use_bias) {
+    double alpha_scale = scale;
+    if (use_bias) {
+      // Create bias op and tensor
+      TF_ASSIGN_OR_RETURN(
+          auto bias_out,
+          CreateCudnnBiasTensor(intermdiate_ops, intermediate_bmm2_lhs_dims,
+                                intermediate_bmm2_lhs_strides,
+                                bias_descriptor.type(), bmm2_input_tensor,
+                                alpha_scale, use_mask));
+      bmm2_input_tensor =
+          std::make_shared<cudnn_frontend::Tensor>(std::move(bias_out));
+      // Scaling is done, reset the scale back to 1.
+      alpha_scale = 1.0f;
+    }
+    if (use_mask) {
+      // Create mask op and tensor
+      TF_ASSIGN_OR_RETURN(
+          auto mask_out,
+          CreateCudnnMaskTensor(intermdiate_ops, intermediate_bmm2_lhs_dims,
+                                intermediate_bmm2_lhs_strides,
+                                intermediate_bmm2_lhs_descriptor.type(),
+                                bmm2_input_tensor, alpha_scale));
+      bmm2_input_tensor =
+          std::make_shared<cudnn_frontend::Tensor>(std::move(mask_out));
+    }
+    // Create Softmax tensor
+    // The output is always a virtual for inference mode.
+    TF_ASSIGN_OR_RETURN(auto softmax_fwd_out,
+                        CreateCudnnSoftmaxFwdTensor(
+                            intermdiate_ops, intermediate_bmm2_lhs_dims,
+                            intermediate_bmm2_lhs_strides,
+                            intermediate_bmm2_lhs_descriptor.type(),
+                            /*input_tensor*/ bmm2_input_tensor, use_dropout,
+                            /*is_virtual*/ true));
+
+    bmm2_input_tensor =
+        std::make_shared<cudnn_frontend::Tensor>(std::move(softmax_fwd_out));
+
+    if (use_dropout) {
+      // Create dropout tensor
+      TF_ASSIGN_OR_RETURN(
+          auto dropout_out,
+          CreateCudnnDropoutTensor(intermdiate_ops, intermediate_bmm2_lhs_dims,
+                                   intermediate_bmm2_lhs_strides,
+                                   intermediate_bmm2_lhs_descriptor.type(),
+                                   /*input_tensor*/ bmm2_input_tensor,
+                                   *dropout_rate, *seed));
+      bmm2_input_tensor =
+          std::make_shared<cudnn_frontend::Tensor>(std::move(dropout_out));
+    }
+  }
+  std::vector<int64_t> bmm2_rhs_dims =
+      bmm2_rhs_descriptor.GetCudnnCompatibleDimensions(false);
+  std::vector<int64_t> bmm2_rhs_strides =
+      bmm2_rhs_descriptor.GetCudnnCompatibleStrides(false);
+
+  VLOG(2) << "\n cuDNN compatible bmm2_rhs_dims: "
+          << absl::StrJoin(bmm2_rhs_dims, ",")
+          << "\n cuDNN compatible bmm2_rhs_strides: "
+          << absl::StrJoin(bmm2_rhs_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(auto tensor_v,
+                      CreateCudnnTensor(bmm2_rhs_dims, bmm2_rhs_strides, 'v',
+                                        bmm2_rhs_descriptor.type(), 1, -1));
+
+  std::vector<int64_t> output_dims = output_descriptor.dimensions();
+  std::vector<int64_t> output_strides = output_descriptor.GetLogicalStrides();
+
+  VLOG(2) << "\n Out Dims: " << absl::StrJoin(output_dims, ",")
+          << "\n Out Strides: " << absl::StrJoin(output_strides, ",");
+
+  TF_ASSIGN_OR_RETURN(auto tensor_o,
+                      CreateCudnnTensor(output_dims, output_strides, 'o',
+                                        output_descriptor.type(), 1, -1));
+  auto bmm2_desc = cudnn_frontend::MatMulDescBuilder()
+                       .setComputeType(CUDNN_DATA_FLOAT)
+                       .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm2_desc);
+  auto bmm2_op = cudnn_frontend::OperationBuilder(
+                     CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                     .setaMatDesc((*bmm2_input_tensor))
+                     .setbMatDesc(tensor_v)
+                     .setcMatDesc(tensor_o)
+                     .setmatmulDesc(bmm2_desc)
+                     .build();
+  RETURN_MSG_IF_CUDNN_ERROR(bmm2_op);
+  // Create an Operation Graph. In this case it is gemm-gemm
+  intermdiate_ops.push_back(std::move(bmm2_op));
+  for (auto& intermediate_op : intermdiate_ops) {
+    ops.push_back(&intermediate_op);
+  }
+
+  auto op_graph = cudnn_frontend::OperationGraphBuilder()
+                      .setHandle(cudnn.handle())
+                      .setOperationGraph(ops.size(), ops.data())
+                      .build();
+  RETURN_MSG_IF_CUDNN_ERROR(op_graph);
+
+  VLOG(4) << "\nTensor_q: " << tensor_q.describe()
+          << "\nTensor_k: " << tensor_k.describe()
+          << "\nTensor_s: " << tensor_s.describe()
+          << "\nTensor_v: " << tensor_v.describe()
+          << "\nTensor_o: " << tensor_o.describe()
+          << "\nBMM1: " << bmm1_desc.describe()
+          << "\nBMM1_op: " << bmm1_op.describe()
+          << "\nBMM2: " << bmm2_desc.describe()
+          << "\nBMM2_op: " << bmm2_op.describe()
+          << "\nOpGraph: " << op_graph.describe();
+  return std::unique_ptr<cudnn_frontend::OperationGraph>(
+      new cudnn_frontend::OperationGraph(std::move(op_graph)));
+}
+#endif
 
 }  // namespace
 
@@ -5513,6 +6107,167 @@ bool CudnnSupport::GetConvolveAlgorithms(
   }
 
   return true;
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
+CudnnSupport::FusedMHASoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+#if CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
+  auto cudnn = cudnn_->GetHandle(parent_, stream);
+
+  // Create empty descriptors for bias and mask tensors
+  dnn::TensorDescriptor empty_mask_desc;
+  dnn::TensorDescriptor empty_bias_desc;
+  bool use_dropout = dropout_rate && *dropout_rate > 0.0;
+  TF_ASSIGN_OR_RETURN(auto op_graph,
+                      GetCudnnFusedMHAOperationGraph(
+                          bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+                          bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+                          empty_mask_desc, empty_bias_desc, output_descriptor,
+                          kind, dropout_rate, seed, cudnn, 1.0f, use_dropout));
+
+  TF_ASSIGN_OR_RETURN(auto execution_plan,
+                      RebuildExecutionPlan(cudnn, algorithm_desc, *op_graph));
+
+  TF_ASSIGN_OR_RETURN(
+      auto runner,
+      CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxSignature>::Create(
+          parent_, cudnn_.get(), std::move(execution_plan),
+          {'q', 'k', 'v', 'o'}, false));
+  return {
+      std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHASoftmaxSignature>>(
+          std::move(runner))};
+#else
+  return tsl::errors::Unimplemented(
+      "Cudnn execution plans are only supported with Cudnn >= 8.8.");
+#endif
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
+CudnnSupport::FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    const dnn::TensorDescriptor& mask_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+#if CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
+  auto cudnn = cudnn_->GetHandle(parent_, stream);
+
+  bool use_dropout = dropout_rate && *dropout_rate > 0.0;
+  // Create empty bias decriptor
+  dnn::TensorDescriptor empty_bias_desc;
+  TF_ASSIGN_OR_RETURN(auto op_graph,
+                      GetCudnnFusedMHAOperationGraph(
+                          bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+                          bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+                          mask_descriptor, empty_bias_desc, output_descriptor,
+                          kind, dropout_rate, seed, cudnn, scale, use_dropout,
+                          /*use_mask*/ true));
+
+  TF_ASSIGN_OR_RETURN(auto execution_plan,
+                      RebuildExecutionPlan(cudnn, algorithm_desc, *op_graph));
+  TF_ASSIGN_OR_RETURN(
+      auto runner, CudnnExecutionPlanRunner<dnn::FusedMHAMaskSignature>::Create(
+                       parent_, cudnn_.get(), std::move(execution_plan),
+                       {'q', 'k', 'P', 'v', 'o'}, true));
+  return {
+      std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHAMaskSignature>>(
+          std::move(runner))};
+#else
+  return tsl::errors::Unimplemented(
+      "Cudnn execution plans are only supported with Cudnn >= 8.8.");
+#endif
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
+CudnnSupport::FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    const dnn::TensorDescriptor& mask_descriptor,
+    const dnn::TensorDescriptor& bias_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+#if CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
+  auto cudnn = cudnn_->GetHandle(parent_, stream);
+  bool use_dropout = dropout_rate && *dropout_rate > 0.0;
+  TF_ASSIGN_OR_RETURN(auto op_graph,
+                      GetCudnnFusedMHAOperationGraph(
+                          bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+                          bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+                          mask_descriptor, bias_descriptor, output_descriptor,
+                          kind, dropout_rate, seed, cudnn, scale, use_dropout,
+                          /*use_mask*/ true, /*use_bias*/ true));
+
+  TF_ASSIGN_OR_RETURN(auto execution_plan,
+                      RebuildExecutionPlan(cudnn, algorithm_desc, *op_graph));
+
+  TF_ASSIGN_OR_RETURN(
+      auto runner,
+      CudnnExecutionPlanRunner<dnn::FusedMHABiasMaskSignature>::Create(
+          parent_, cudnn_.get(), std::move(execution_plan),
+          {'q', 'k', 'P', 'B', 'v', 'o'}, true));
+  return {std::make_unique<
+      CudnnExecutionPlanRunner<dnn::FusedMHABiasMaskSignature>>(
+      std::move(runner))};
+#else
+  return tsl::errors::Unimplemented(
+      "Cudnn execution plans are only supported with Cudnn >= 8.8.");
+#endif
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
+CudnnSupport::FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    const dnn::TensorDescriptor& bias_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+#if CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND
+  auto cudnn = cudnn_->GetHandle(parent_, stream);
+  // Create empty descriptors for mask tensors
+  dnn::TensorDescriptor empty_mask_desc;
+  bool use_dropout = dropout_rate && *dropout_rate > 0.0;
+  TF_ASSIGN_OR_RETURN(auto op_graph,
+                      GetCudnnFusedMHAOperationGraph(
+                          bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+                          bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+                          empty_mask_desc, bias_descriptor, output_descriptor,
+                          kind, dropout_rate, seed, cudnn, scale, use_dropout,
+                          /*use_mask*/ false, /*use_bias*/ true));
+
+  TF_ASSIGN_OR_RETURN(auto execution_plan,
+                      RebuildExecutionPlan(cudnn, algorithm_desc, *op_graph));
+
+  TF_ASSIGN_OR_RETURN(
+      auto runner, CudnnExecutionPlanRunner<dnn::FusedMHABiasSignature>::Create(
+                       parent_, cudnn_.get(), std::move(execution_plan),
+                       {'q', 'k', 'B', 'v', 'o'}, true));
+  return {
+      std::make_unique<CudnnExecutionPlanRunner<dnn::FusedMHABiasSignature>>(
+          std::move(runner))};
+#else
+  return tsl::errors::Unimplemented(
+      "Cudnn execution plans are only supported with Cudnn >= 8.8.");
+#endif
 }
 
 bool CudnnSupport::GetRnnAlgorithms(

--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.h
@@ -276,6 +276,54 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       dnn::ActivationMode activation_mode) override;
 
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
+  FusedMHASoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
+  FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& mask_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
+  FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& mask_descriptor,
+      const dnn::TensorDescriptor& bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
+  FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
   bool GetRnnAlgorithms(
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 

--- a/tensorflow/compiler/xla/stream_executor/dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/dnn.cc
@@ -191,6 +191,66 @@ DnnSupport::FusedConvolveRunnerFromDesc(
       "FusedConvolveRunnerFromDesc not implemented.");
 }
 
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
+DnnSupport::FusedMHASoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+  return tsl::errors::Unimplemented(
+      "FusedMHASoftmaxRunnerFromDesc not implemented.");
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
+DnnSupport::FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    const dnn::TensorDescriptor& mask_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+  return tsl::errors::Unimplemented(
+      "FusedMHAScaleMaskSoftmaxRunnerFromDesc not implemented.");
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
+DnnSupport::FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    const dnn::TensorDescriptor& mask_descriptor,
+    const dnn::TensorDescriptor& bias_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+  return tsl::errors::Unimplemented(
+      "FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc not implemented.");
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
+DnnSupport::FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    const dnn::TensorDescriptor& bias_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+  return tsl::errors::Unimplemented(
+      "FusedMHAScaleBiasSoftmaxRunnerFromDesc not implemented.");
+}
+
 bool DnnSupport::GetMIOpenConvolveAlgorithms(
     dnn::ConvolutionKind /*kind*/, dnn::DataType /*element_type*/,
     Stream* /*stream*/, const dnn::BatchDescriptor& /*input_descriptor*/,
@@ -481,6 +541,169 @@ std::string AlgorithmConfig::ToString() const {
   }
   return absl::StrCat(algo, ", ", algo_no_scratch);
 }
+
+// -- TensorDescriptor
+
+int TensorDescriptor::ndims() const {
+  CHECK_EQ(dimensions_.size(), minor_to_major_.size());
+  return dimensions_.size();
+}
+
+tsl::StatusOr<std::vector<int64_t>>
+TensorDescriptor::GetPhysicalDimensionsMajorToMinor() const {
+  std::vector<int64_t> logical_to_physical(minor_to_major_.size());
+  for (int64_t physical = 0; physical < logical_to_physical.size();
+       ++physical) {
+    int64_t logical = minor_to_major_.at(minor_to_major_.size() - 1 - physical);
+    logical_to_physical[logical] = physical;
+  }
+  if (dimensions_.size() != minor_to_major_.size())
+    return tsl::errors::Internal(
+        "Dimensions size should match the layout size.");
+
+  std::vector<int64_t> physical_dims(dimensions_.size());
+  for (int64_t i = 0; i < physical_dims.size(); ++i) {
+    physical_dims[logical_to_physical[i]] = dimensions_[i];
+  }
+  return physical_dims;
+}
+
+std::vector<int64_t> TensorDescriptor::GetPhysicalStridesMajorToMinor() const {
+  std::vector<int64_t> phys_dims = GetPhysicalDimensionsMajorToMinor().value();
+  std::vector<int64_t> phys_strides(ndims());
+  phys_strides[ndims() - 1] = 1;
+  for (int i = ndims() - 2; i >= 0; i--) {
+    phys_strides[i] = phys_strides[i + 1] * phys_dims[i + 1];
+  }
+  return phys_strides;
+}
+
+std::vector<int64_t> TensorDescriptor::GetLogicalStrides() const {
+  std::vector<int64_t> physical_strides = GetPhysicalStridesMajorToMinor();
+  std::reverse(physical_strides.begin(), physical_strides.end());
+  std::vector<int64_t> logical_strides(physical_strides.size());
+  for (int i = 0; i < ndims(); i++) {
+    logical_strides[minor_to_major_[i]] = physical_strides[i];
+  }
+  return logical_strides;
+}
+
+/*static*/ TensorDescriptor TensorDescriptor::For(
+    DataType type, absl::Span<const int64_t> dimensions,
+    absl::Span<const int64_t> minor_to_major) {
+  std::vector<int64_t> dims(dimensions.size());
+  std::vector<int64_t> minor_to_major_vec(minor_to_major.size());
+  CHECK_EQ(dimensions.size(), minor_to_major.size());
+  for (int i = 0; i < dimensions.size(); i++) {
+    dims[i] = dimensions[i];
+    minor_to_major_vec[i] = minor_to_major[i];
+  }
+  return TensorDescriptor(type, dims, minor_to_major_vec);
+}
+
+const std::string TensorDescriptor::ToString() const {
+  return absl::StrFormat("{dimensions: %s minor_to_major: %s}",
+                         absl::StrJoin(dimensions(), ","),
+                         absl::StrJoin(minor_to_major(), ","));
+};
+
+// -- MatmulTensorDescriptor
+
+tsl::StatusOr<std::vector<int64_t>>
+MatmulTensorDescriptor::GetNonContractingDims() const {
+  std::vector<int64_t> non_contracting_dims;
+  for (int64_t dim = 0; dim < tensor_.dimensions().size(); ++dim) {
+    bool is_batch = absl::c_count(batch_dimension_numbers_, dim) != 0;
+    bool is_contracting = absl::c_count(contracting_dim_, dim) != 0;
+    if (is_batch && is_contracting)
+      return tsl::errors::Internal(
+          "A dimension cannot be both a batch dimension and a contracting "
+          "dimension.");
+    if (!(is_batch || is_contracting)) non_contracting_dims.push_back(dim);
+  }
+
+  if (batch_dimension_numbers_.size() + contracting_dim_.size() +
+          non_contracting_dims.size() !=
+      tensor_.dimensions().size())
+    return tsl::errors::Internal(
+        "Batch_dimension_numbers, contracting_dim and non_contracting_dims "
+        "should sum up to the total number of dimensions.");
+  return non_contracting_dims;
+}
+
+tsl::StatusOr<std::vector<int64_t>> MatmulTensorDescriptor::MakeCudnnCompatible(
+    const std::vector<int64_t>& vec, bool is_lhs) const {
+  std::vector<int64_t> cudnn_compatible(vec.size());
+  int batch_dim_size = batch_dimension_numbers_.size();
+  CHECK_LT(batch_dim_size, vec.size());
+  for (int i = 0; i < batch_dim_size; i++) {
+    cudnn_compatible[i] = vec.at(batch_dimension_numbers_.at(i));
+  }
+  std::vector<int64_t> non_contracting_dims = GetNonContractingDims().value();
+  if (batch_dimension_numbers_.size() + contracting_dim_.size() +
+          non_contracting_dims.size() !=
+      vec.size())
+    return tsl::errors::Internal(
+        "Batch_dimension_numbers, contracting_dim and non_contracting_dims "
+        "should sum up to the total number of dimensions.");
+  if (is_lhs) /* lhs -> {b0, b1,....bk, m, k} */ {
+    for (int i = 0; i < non_contracting_dims.size(); i++) {
+      cudnn_compatible[batch_dim_size + i] = vec.at(non_contracting_dims.at(i));
+    }
+    for (int i = 0; i < contracting_dim_.size(); i++) {
+      cudnn_compatible[batch_dim_size + non_contracting_dims.size() + i] =
+          vec.at(contracting_dim_.at(i));
+    }
+  } else /* rhs -> {b0, b1, ... bk, k, n} */ {
+    for (int i = 0; i < contracting_dim_.size(); i++) {
+      cudnn_compatible[batch_dim_size + i] = vec.at(contracting_dim_.at(i));
+    }
+    for (int i = 0; i < non_contracting_dims.size(); i++) {
+      cudnn_compatible[batch_dim_size + contracting_dim_.size() + i] =
+          vec.at(non_contracting_dims.at(i));
+    }
+  }
+  return cudnn_compatible;
+}
+
+std::vector<int64_t> MatmulTensorDescriptor::GetCudnnCompatibleDimensions(
+    bool is_lhs) const {
+  std::vector<int64_t> cudnn_compatible_dims =
+      MakeCudnnCompatible(tensor_.dimensions(), is_lhs).value();
+  return cudnn_compatible_dims;
+}
+
+std::vector<int64_t> MatmulTensorDescriptor::GetCudnnCompatibleStrides(
+    bool is_lhs) const {
+  std::vector<int64_t> cudnn_compatible_strides =
+      MakeCudnnCompatible(tensor_.GetLogicalStrides(), is_lhs).value();
+  return cudnn_compatible_strides;
+}
+
+/*static*/ MatmulTensorDescriptor MatmulTensorDescriptor::For(
+    DataType type, absl::Span<const int64_t> dimensions,
+    absl::Span<const int64_t> minor_to_major,
+    absl::Span<const int64_t> batch_dims,
+    absl::Span<const int64_t> contracting_dims) {
+  std::vector<int64_t> batch_dims_vec(batch_dims.size());
+  std::vector<int64_t> contracting_dims_vec(contracting_dims.size());
+  for (int i = 0; i < batch_dims.size(); i++) {
+    batch_dims_vec[i] = batch_dims[i];
+  }
+  for (int i = 0; i < contracting_dims.size(); i++) {
+    contracting_dims_vec[i] = contracting_dims[i];
+  }
+  return MatmulTensorDescriptor(
+      TensorDescriptor::For(type, dimensions, minor_to_major), batch_dims_vec,
+      contracting_dims_vec);
+}
+
+const std::string MatmulTensorDescriptor::ToString() const {
+  return absl::StrFormat(
+      "{%s, batch_dimension_numbers: %s contracting_dim: %s}",
+      tensor_.ToString(), absl::StrJoin(batch_dimension_numbers_, ","),
+      absl::StrJoin(contracting_dim_, ","));
+};
 
 // -- BatchDescriptor
 

--- a/tensorflow/compiler/xla/stream_executor/dnn.h
+++ b/tensorflow/compiler/xla/stream_executor/dnn.h
@@ -31,9 +31,9 @@ limitations under the License.
 #include <type_traits>
 #include <utility>
 
-#include "google/protobuf/wrappers.pb.h"
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
+#include "google/protobuf/wrappers.pb.h"
 #include "tensorflow/compiler/xla/stream_executor/data_type.h"
 #include "tensorflow/compiler/xla/stream_executor/device_description.h"
 #include "tensorflow/compiler/xla/stream_executor/device_description.pb.h"
@@ -151,6 +151,75 @@ enum class RnnDirectionMode {
 // depth. In C array format, it looks like [depth][height][width]. See
 // DepthToSpace comment for more information.
 enum class DepthToSpaceLayout { DepthHeightWidth };
+
+class TensorDescriptor {
+ public:
+  TensorDescriptor() {}
+  tsl::StatusOr<std::vector<int64_t>> GetPhysicalDimensionsMajorToMinor() const;
+  std::vector<int64_t> GetPhysicalStridesMajorToMinor() const;
+  std::vector<int64_t> GetLogicalStrides() const;
+
+  static TensorDescriptor For(DataType type,
+                              absl::Span<const int64_t> dimensions,
+                              absl::Span<const int64_t> minor_to_major);
+  int ndims() const;
+  std::vector<int64_t> dimensions() const { return dimensions_; }
+  std::vector<int64_t> minor_to_major() const { return minor_to_major_; }
+  DataType type() const { return d_type_; }
+  const std::string ToString() const;
+
+ protected:
+  TensorDescriptor(DataType type, std::vector<int64_t> dimensions,
+                   std::vector<int64_t> minor_to_major)
+      : d_type_(type),
+        dimensions_(dimensions),
+        minor_to_major_(minor_to_major) {}
+
+ private:
+  DataType d_type_;
+  std::vector<int64_t> dimensions_;
+  std::vector<int64_t> minor_to_major_;
+};
+
+class MatmulTensorDescriptor {
+ public:
+  MatmulTensorDescriptor() {}
+  tsl::StatusOr<std::vector<int64_t>> GetNonContractingDims() const;
+  std::vector<int64_t> GetCudnnCompatibleDimensions(
+      bool is_lhs
+      /*if not lhs, then rhs*/) const;
+  std::vector<int64_t> GetCudnnCompatibleStrides(
+      bool is_lhs
+      /*if not lhs, then rhs*/) const;
+  tsl::StatusOr<std::vector<int64_t>> MakeCudnnCompatible(
+      const std::vector<int64_t>&, bool is_lhs) const;
+
+  static MatmulTensorDescriptor For(DataType type,
+                                    absl::Span<const int64_t> dimensions,
+                                    absl::Span<const int64_t> minor_to_major,
+                                    absl::Span<const int64_t> batch_dims,
+                                    absl::Span<const int64_t> contracting_dims);
+  std::vector<int64_t> dimensions() const { return tensor_.dimensions(); }
+  std::vector<int64_t> minor_to_major() const {
+    return tensor_.minor_to_major();
+  }
+  DataType type() const { return tensor_.type(); }
+
+  const std::string ToString() const;
+
+ protected:
+  MatmulTensorDescriptor(TensorDescriptor tensor,
+                         std::vector<int64_t> batch_dims,
+                         std::vector<int64_t> contracting_dims)
+      : tensor_(tensor),
+        batch_dimension_numbers_(batch_dims),
+        contracting_dim_(contracting_dims) {}
+
+ private:
+  TensorDescriptor tensor_;
+  std::vector<int64_t> batch_dimension_numbers_;
+  std::vector<int64_t> contracting_dim_;
+};
 
 // Specifies the descriptor for a RNN model.
 //
@@ -912,6 +981,34 @@ using FusedMatmulSignature = void(DeviceMemoryBase /* a_data */,
                                   DeviceMemoryBase /* c_data */);
 using FusedMatmulRunner = OpRunner<FusedMatmulSignature>;
 
+using FusedMHASoftmaxSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
+                                      DeviceMemoryBase /* BMM1_inputB_data */,
+                                      DeviceMemoryBase /* BMM2_inputA_data */,
+                                      DeviceMemoryBase /* output_data */);
+using FusedMHASoftmaxRunner = OpRunner<FusedMHASoftmaxSignature>;
+
+using FusedMHAMaskSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
+                                   DeviceMemoryBase /* BMM1_inputB_data */,
+                                   DeviceMemoryBase /* mask_data */,
+                                   DeviceMemoryBase /* BMM2_inputA_data */,
+                                   DeviceMemoryBase /* output_data */);
+using FusedMHAMaskRunner = OpRunner<FusedMHAMaskSignature>;
+
+using FusedMHABiasMaskSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
+                                       DeviceMemoryBase /* BMM1_inputB_data */,
+                                       DeviceMemoryBase /* mask_data */,
+                                       DeviceMemoryBase /* bias_data */,
+                                       DeviceMemoryBase /* BMM2_inputA_data */,
+                                       DeviceMemoryBase /* output_data */);
+using FusedMHABiasMaskRunner = OpRunner<FusedMHABiasMaskSignature>;
+
+using FusedMHABiasSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
+                                   DeviceMemoryBase /* BMM1_inputB_data */,
+                                   DeviceMemoryBase /* bias_data */,
+                                   DeviceMemoryBase /* BMM2_inputA_data */,
+                                   DeviceMemoryBase /* output_data */);
+using FusedMHABiasRunner = OpRunner<FusedMHABiasSignature>;
+
 // Describes the configuration for the algorithms that will used.
 //
 // Arguments:
@@ -1535,6 +1632,54 @@ class DnnSupport {
       const dnn::BatchDescriptor& output_descriptor,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       dnn::ActivationMode activation_mode);
+
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
+  FusedMHASoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
+  FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& mask_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
+  FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& mask_descriptor,
+      const dnn::TensorDescriptor& bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
+  FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
 
   virtual bool GetMIOpenConvolveAlgorithms(
       dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,

--- a/tensorflow/compiler/xla/stream_executor/lazy_op_runner.h
+++ b/tensorflow/compiler/xla/stream_executor/lazy_op_runner.h
@@ -202,6 +202,114 @@ struct FusedMatmulOp {
   }
 };
 
+struct FusedMHASoftmaxOp {
+  using Signature = FusedMHASoftmaxSignature;
+
+  struct Config {
+    FusedMHAKind kind;
+    const MatmulTensorDescriptor& bmm1_lhs_descriptor;
+    const MatmulTensorDescriptor& bmm1_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_rhs_descriptor;
+    const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
+    const TensorDescriptor& output_descriptor;
+    std::optional<double> dropout_rate;
+    std::optional<int64_t> seed;
+  };
+
+  static tsl::StatusOr<
+      std::unique_ptr<const OpRunner<FusedMHASoftmaxSignature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->FusedMHASoftmaxRunnerFromDesc(
+        desc, config.kind, config.bmm1_lhs_descriptor,
+        config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
+        config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
+        config.dropout_rate, config.seed);
+  }
+};
+
+struct FusedMHAScaleMaskSoftmaxOp {
+  using Signature = FusedMHAMaskSignature;
+
+  struct Config {
+    FusedMHAKind kind;
+    double scale;
+    const MatmulTensorDescriptor& bmm1_lhs_descriptor;
+    const MatmulTensorDescriptor& bmm1_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_rhs_descriptor;
+    const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
+    const TensorDescriptor& output_descriptor;
+    const TensorDescriptor& mask_descriptor;
+    std::optional<double> dropout_rate;
+    std::optional<int64_t> seed;
+  };
+
+  static tsl::StatusOr<std::unique_ptr<const OpRunner<FusedMHAMaskSignature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+        desc, config.kind, config.bmm1_lhs_descriptor,
+        config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
+        config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
+        config.mask_descriptor, config.scale, config.dropout_rate, config.seed);
+  }
+};
+
+struct FusedMHAScaleBiasMaskSoftmaxOp {
+  using Signature = FusedMHABiasMaskSignature;
+  struct Config {
+    FusedMHAKind kind;
+    double scale;
+    const MatmulTensorDescriptor& bmm1_lhs_descriptor;
+    const MatmulTensorDescriptor& bmm1_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_rhs_descriptor;
+    const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
+    const TensorDescriptor& output_descriptor;
+    const TensorDescriptor& bias_descriptor;
+    const TensorDescriptor& mask_descriptor;
+    std::optional<double> dropout_rate;
+    std::optional<int64_t> seed;
+  };
+
+  static tsl::StatusOr<
+      std::unique_ptr<const OpRunner<FusedMHABiasMaskSignature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+        desc, config.kind, config.bmm1_lhs_descriptor,
+        config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
+        config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
+        config.mask_descriptor, config.bias_descriptor, config.scale,
+        config.dropout_rate, config.seed);
+  }
+};
+
+struct FusedMHAScaleBiasSoftmaxOp {
+  using Signature = FusedMHABiasSignature;
+  struct Config {
+    FusedMHAKind kind;
+    double scale;
+    const MatmulTensorDescriptor& bmm1_lhs_descriptor;
+    const MatmulTensorDescriptor& bmm1_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_rhs_descriptor;
+    const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
+    const TensorDescriptor& output_descriptor;
+    const TensorDescriptor& bias_descriptor;
+    std::optional<double> dropout_rate;
+    std::optional<int64_t> seed;
+  };
+
+  static tsl::StatusOr<std::unique_ptr<const OpRunner<FusedMHABiasSignature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+        desc, config.kind, config.bmm1_lhs_descriptor,
+        config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
+        config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
+        config.bias_descriptor, config.scale, config.dropout_rate, config.seed);
+  }
+};
+
 }  // namespace dnn
 }  // namespace stream_executor
 

--- a/tensorflow/compiler/xla/stream_executor/stream.h
+++ b/tensorflow/compiler/xla/stream_executor/stream.h
@@ -476,6 +476,87 @@ class Stream {
         convolution_descriptor, activation_mode);
   }
 
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
+  FusedMHASoftmaxRunnerFromDesc(
+      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor &output_descriptor,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+    dnn::DnnSupport *dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->FusedMHASoftmaxRunnerFromDesc(
+        this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+        bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+        output_descriptor, dropout_rate, seed);
+  }
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
+  FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor &output_descriptor,
+      const dnn::TensorDescriptor &mask_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+    dnn::DnnSupport *dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+        this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+        bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+        output_descriptor, mask_descriptor, scale, dropout_rate, seed);
+  }
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
+  FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor &output_descriptor,
+      const dnn::TensorDescriptor &mask_descriptor,
+      const dnn::TensorDescriptor &bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+    dnn::DnnSupport *dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+        this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+        bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+        output_descriptor, mask_descriptor, bias_descriptor, scale,
+        dropout_rate, seed);
+  }
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
+  FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor &output_descriptor,
+      const dnn::TensorDescriptor &bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+    dnn::DnnSupport *dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+        this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+        bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+        output_descriptor, bias_descriptor, scale, dropout_rate, seed);
+  }
+
   Stream &ThenSeparableConvolve(
       const dnn::BatchDescriptor &input_descriptor,
       const DeviceMemory<float> &input_data,

--- a/tensorflow/tsl/protobuf/dnn.proto
+++ b/tensorflow/tsl/protobuf/dnn.proto
@@ -174,3 +174,9 @@ message ConvolutionDescriptorProto {
   // Tensorflow node name, same as in NodeDef, for debugging purposes.
   string name = 7;
 }
+
+// FusedMHAKind kind
+enum FusedMHAKind {
+  BMM1_OUTPUT_INPUT_TYPE = 0;
+  BMM1_OUTPUT_FLOAT = 1;
+}


### PR DESCRIPTION
cuDNN currently supports the following patterns for Multi-headed attention:

BMM1 - BMM2
BMM1 - Scale - Bias - Mask - Softmax - BMM2
BMM1 - Scale - Bias - Mask - Softmax - Dropout - BMM2
BMM1 - Scale - Mask - Softmax - BMM2
BMM1 - Scale - Mask - Softmax - Dropout - BMM2
BMM1 - Softmax - Dropout - BMM2

This PR adds support for the stream executor for these patterns.