### PR TITLE
[NVIDIA TFTRT] Add kFP8 to nvinfer1::DataType enums for TRT 8.6.x

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/common/utils.cc
+++ b/tensorflow/compiler/tf2tensorrt/common/utils.cc
@@ -213,6 +213,11 @@ std::ostream& operator<<(std::ostream& os, const nvinfer1::DataType& v) {
     case nvinfer1::DataType::kHALF:
       os << "kHalf";
       break;
+#if IS_TRT_VERSION_GE(8, 6, 0, 0)
+    case nvinfer1::DataType::kFP8:
+      os << "kFP8";
+      break;
+#endif
     case nvinfer1::DataType::kINT8:
       os << "kINT8";
       break;

--- a/tensorflow/compiler/tf2tensorrt/convert/weights.cc
+++ b/tensorflow/compiler/tf2tensorrt/convert/weights.cc
@@ -69,6 +69,9 @@ size_t TRT_ShapedWeights::size_bytes() const {
 #if IS_TRT_VERSION_GE(8, 5, 0, 0)
     case nvinfer1::DataType::kUINT8:
 #endif
+#if IS_TRT_VERSION_GE(8, 6, 0, 0)
+    case nvinfer1::DataType::kFP8:
+#endif
     case nvinfer1::DataType::kINT8:
     case nvinfer1::DataType::kBOOL:
       data_type_size = 1;


### PR DESCRIPTION
This is an NFC, but is needed to build with TRT 8.6.