### PR TITLE
[NVIDIA XLA:GPU] Fused MHA Support in XLA GPU: SE

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.h
@@ -276,6 +276,54 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       dnn::ActivationMode activation_mode) override;
 
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
+  FusedMHASoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
+  FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& mask_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
+  FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& mask_descriptor,
+      const dnn::TensorDescriptor& bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
+  FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) override;
+
   bool GetRnnAlgorithms(
       std::vector<dnn::AlgorithmDesc>* out_algorithms) override;
 

--- a/tensorflow/compiler/xla/stream_executor/dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/dnn.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/compiler/xla/stream_executor/dnn.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <iterator>
 
@@ -189,6 +190,66 @@ DnnSupport::FusedConvolveRunnerFromDesc(
     dnn::ActivationMode activation_mode) {
   return tsl::errors::Unimplemented(
       "FusedConvolveRunnerFromDesc not implemented.");
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
+DnnSupport::FusedMHASoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+  return tsl::errors::Unimplemented(
+      "FusedMHASoftmaxRunnerFromDesc not implemented.");
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
+DnnSupport::FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    const dnn::TensorDescriptor& mask_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+  return tsl::errors::Unimplemented(
+      "FusedMHAScaleMaskSoftmaxRunnerFromDesc not implemented.");
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
+DnnSupport::FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    const dnn::TensorDescriptor& mask_descriptor,
+    const dnn::TensorDescriptor& bias_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+  return tsl::errors::Unimplemented(
+      "FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc not implemented.");
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
+DnnSupport::FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::FusedMHAKind kind,
+    const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+    const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+    const dnn::TensorDescriptor& output_descriptor,
+    const dnn::TensorDescriptor& bias_descriptor, double scale,
+    std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+  return tsl::errors::Unimplemented(
+      "FusedMHAScaleBiasSoftmaxRunnerFromDesc not implemented.");
 }
 
 bool DnnSupport::GetMIOpenConvolveAlgorithms(
@@ -480,6 +541,169 @@ std::string AlgorithmConfig::ToString() const {
     algo_no_scratch = algorithm_no_scratch()->ToString();
   }
   return absl::StrCat(algo, ", ", algo_no_scratch);
+}
+
+// -- TensorDescriptor
+
+int TensorDescriptor::ndims() const {
+  CHECK_EQ(dimensions_.size(), minor_to_major_.size());
+  return dimensions_.size();
+}
+
+tsl::StatusOr<std::vector<int64_t>>
+TensorDescriptor::GetPhysicalDimensionsMajorToMinor() const {
+  std::vector<int64_t> logical_to_physical(minor_to_major_.size());
+  for (int64_t physical = 0; physical < logical_to_physical.size();
+       ++physical) {
+    int64_t logical = minor_to_major_.at(minor_to_major_.size() - 1 - physical);
+    logical_to_physical[logical] = physical;
+  }
+  if (dimensions_.size() != minor_to_major_.size())
+    return tsl::errors::Internal(
+        "Dimensions size should match the layout size.");
+
+  std::vector<int64_t> physical_dims(dimensions_.size());
+  for (int64_t i = 0; i < physical_dims.size(); ++i) {
+    physical_dims[logical_to_physical[i]] = dimensions_[i];
+  }
+  return physical_dims;
+}
+
+std::vector<int64_t> TensorDescriptor::GetPhysicalStridesMajorToMinor() const {
+  std::vector<int64_t> phys_dims = GetPhysicalDimensionsMajorToMinor().value();
+  std::vector<int64_t> phys_strides(ndims());
+  phys_strides[ndims() - 1] = 1;
+  for (int i = ndims() - 2; i >= 0; i--) {
+    phys_strides[i] = phys_strides[i + 1] * phys_dims[i + 1];
+  }
+  return phys_strides;
+}
+
+std::vector<int64_t> TensorDescriptor::GetLogicalStrides() const {
+  std::vector<int64_t> physical_strides = GetPhysicalStridesMajorToMinor();
+  std::reverse(physical_strides.begin(), physical_strides.end());
+  std::vector<int64_t> logical_strides(physical_strides.size());
+  for (int i = 0; i < ndims(); i++) {
+    logical_strides[minor_to_major_[i]] = physical_strides[i];
+  }
+  return logical_strides;
+}
+
+/*static*/ TensorDescriptor TensorDescriptor::For(
+    DataType type, absl::Span<const int64_t> dimensions,
+    absl::Span<const int64_t> minor_to_major) {
+  std::vector<int64_t> dims(dimensions.size());
+  std::vector<int64_t> minor_to_major_vec(minor_to_major.size());
+  CHECK_EQ(dimensions.size(), minor_to_major.size());
+  for (int i = 0; i < dimensions.size(); i++) {
+    dims[i] = dimensions[i];
+    minor_to_major_vec[i] = minor_to_major[i];
+  }
+  return TensorDescriptor(type, dims, minor_to_major_vec);
+}
+
+std::string TensorDescriptor::ToString() const {
+  return absl::StrFormat("{dimensions: %s minor_to_major: %s}",
+                         absl::StrJoin(dimensions(), ","),
+                         absl::StrJoin(minor_to_major(), ","));
+}
+
+// -- MatmulTensorDescriptor
+
+tsl::StatusOr<std::vector<int64_t>>
+MatmulTensorDescriptor::GetNonContractingDims() const {
+  std::vector<int64_t> non_contracting_dims;
+  for (int64_t dim = 0; dim < tensor_.dimensions().size(); ++dim) {
+    bool is_batch = absl::c_count(batch_dimension_numbers_, dim) != 0;
+    bool is_contracting = absl::c_count(contracting_dim_, dim) != 0;
+    if (is_batch && is_contracting)
+      return tsl::errors::Internal(
+          "A dimension cannot be both a batch dimension and a contracting "
+          "dimension.");
+    if (!(is_batch || is_contracting)) non_contracting_dims.push_back(dim);
+  }
+
+  if (batch_dimension_numbers_.size() + contracting_dim_.size() +
+          non_contracting_dims.size() !=
+      tensor_.dimensions().size())
+    return tsl::errors::Internal(
+        "Batch_dimension_numbers, contracting_dim and non_contracting_dims "
+        "should sum up to the total number of dimensions.");
+  return non_contracting_dims;
+}
+
+tsl::StatusOr<std::vector<int64_t>> MatmulTensorDescriptor::MakeCudnnCompatible(
+    const std::vector<int64_t>& vec, bool is_lhs) const {
+  std::vector<int64_t> cudnn_compatible(vec.size());
+  int batch_dim_size = batch_dimension_numbers_.size();
+  CHECK_LT(batch_dim_size, vec.size());
+  for (int i = 0; i < batch_dim_size; i++) {
+    cudnn_compatible[i] = vec.at(batch_dimension_numbers_.at(i));
+  }
+  std::vector<int64_t> non_contracting_dims = GetNonContractingDims().value();
+  if (batch_dimension_numbers_.size() + contracting_dim_.size() +
+          non_contracting_dims.size() !=
+      vec.size())
+    return tsl::errors::Internal(
+        "Batch_dimension_numbers, contracting_dim and non_contracting_dims "
+        "should sum up to the total number of dimensions.");
+  if (is_lhs) /* lhs -> {b0, b1,....bk, m, k} */ {
+    for (int i = 0; i < non_contracting_dims.size(); i++) {
+      cudnn_compatible[batch_dim_size + i] = vec.at(non_contracting_dims.at(i));
+    }
+    for (int i = 0; i < contracting_dim_.size(); i++) {
+      cudnn_compatible[batch_dim_size + non_contracting_dims.size() + i] =
+          vec.at(contracting_dim_.at(i));
+    }
+  } else /* rhs -> {b0, b1, ... bk, k, n} */ {
+    for (int i = 0; i < contracting_dim_.size(); i++) {
+      cudnn_compatible[batch_dim_size + i] = vec.at(contracting_dim_.at(i));
+    }
+    for (int i = 0; i < non_contracting_dims.size(); i++) {
+      cudnn_compatible[batch_dim_size + contracting_dim_.size() + i] =
+          vec.at(non_contracting_dims.at(i));
+    }
+  }
+  return cudnn_compatible;
+}
+
+std::vector<int64_t> MatmulTensorDescriptor::GetCudnnCompatibleDimensions(
+    bool is_lhs) const {
+  std::vector<int64_t> cudnn_compatible_dims =
+      MakeCudnnCompatible(tensor_.dimensions(), is_lhs).value();
+  return cudnn_compatible_dims;
+}
+
+std::vector<int64_t> MatmulTensorDescriptor::GetCudnnCompatibleStrides(
+    bool is_lhs) const {
+  std::vector<int64_t> cudnn_compatible_strides =
+      MakeCudnnCompatible(tensor_.GetLogicalStrides(), is_lhs).value();
+  return cudnn_compatible_strides;
+}
+
+/*static*/ MatmulTensorDescriptor MatmulTensorDescriptor::For(
+    DataType type, absl::Span<const int64_t> dimensions,
+    absl::Span<const int64_t> minor_to_major,
+    absl::Span<const int64_t> batch_dims,
+    absl::Span<const int64_t> contracting_dims) {
+  std::vector<int64_t> batch_dims_vec(batch_dims.size());
+  std::vector<int64_t> contracting_dims_vec(contracting_dims.size());
+  for (int i = 0; i < batch_dims.size(); i++) {
+    batch_dims_vec[i] = batch_dims[i];
+  }
+  for (int i = 0; i < contracting_dims.size(); i++) {
+    contracting_dims_vec[i] = contracting_dims[i];
+  }
+  return MatmulTensorDescriptor(
+      TensorDescriptor::For(type, dimensions, minor_to_major), batch_dims_vec,
+      contracting_dims_vec);
+}
+
+std::string MatmulTensorDescriptor::ToString() const {
+  return absl::StrFormat(
+      "{%s, batch_dimension_numbers: %s contracting_dim: %s}",
+      tensor_.ToString(), absl::StrJoin(batch_dimension_numbers_, ","),
+      absl::StrJoin(contracting_dim_, ","));
 }
 
 // -- BatchDescriptor

--- a/tensorflow/compiler/xla/stream_executor/dnn.h
+++ b/tensorflow/compiler/xla/stream_executor/dnn.h
@@ -26,10 +26,13 @@ limitations under the License.
 #include <functional>
 #include <limits>
 #include <memory>
+#include <optional>
+#include <ostream>
 #include <string>
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "google/protobuf/wrappers.pb.h"
 #include "absl/types/optional.h"
@@ -152,6 +155,75 @@ enum class RnnDirectionMode {
 // DepthToSpace comment for more information.
 enum class DepthToSpaceLayout { DepthHeightWidth };
 
+class TensorDescriptor {
+ public:
+  TensorDescriptor() = default;
+  tsl::StatusOr<std::vector<int64_t>> GetPhysicalDimensionsMajorToMinor() const;
+  std::vector<int64_t> GetPhysicalStridesMajorToMinor() const;
+  std::vector<int64_t> GetLogicalStrides() const;
+
+  static TensorDescriptor For(DataType type,
+                              absl::Span<const int64_t> dimensions,
+                              absl::Span<const int64_t> minor_to_major);
+  int ndims() const;
+  std::vector<int64_t> dimensions() const { return dimensions_; }
+  std::vector<int64_t> minor_to_major() const { return minor_to_major_; }
+  DataType type() const { return d_type_; }
+  std::string ToString() const;
+
+ protected:
+  TensorDescriptor(DataType type, std::vector<int64_t> dimensions,
+                   std::vector<int64_t> minor_to_major)
+      : d_type_(type),
+        dimensions_(dimensions),
+        minor_to_major_(minor_to_major) {}
+
+ private:
+  DataType d_type_;
+  std::vector<int64_t> dimensions_;
+  std::vector<int64_t> minor_to_major_;
+};
+
+class MatmulTensorDescriptor {
+ public:
+  MatmulTensorDescriptor() = default;
+  tsl::StatusOr<std::vector<int64_t>> GetNonContractingDims() const;
+  std::vector<int64_t> GetCudnnCompatibleDimensions(
+      bool is_lhs
+      /*if not lhs, then rhs*/) const;
+  std::vector<int64_t> GetCudnnCompatibleStrides(
+      bool is_lhs
+      /*if not lhs, then rhs*/) const;
+  tsl::StatusOr<std::vector<int64_t>> MakeCudnnCompatible(
+      const std::vector<int64_t>&, bool is_lhs) const;
+
+  static MatmulTensorDescriptor For(DataType type,
+                                    absl::Span<const int64_t> dimensions,
+                                    absl::Span<const int64_t> minor_to_major,
+                                    absl::Span<const int64_t> batch_dims,
+                                    absl::Span<const int64_t> contracting_dims);
+  std::vector<int64_t> dimensions() const { return tensor_.dimensions(); }
+  std::vector<int64_t> minor_to_major() const {
+    return tensor_.minor_to_major();
+  }
+  DataType type() const { return tensor_.type(); }
+
+  std::string ToString() const;
+
+ protected:
+  MatmulTensorDescriptor(TensorDescriptor tensor,
+                         std::vector<int64_t> batch_dims,
+                         std::vector<int64_t> contracting_dims)
+      : tensor_(tensor),
+        batch_dimension_numbers_(batch_dims),
+        contracting_dim_(contracting_dims) {}
+
+ private:
+  TensorDescriptor tensor_;
+  std::vector<int64_t> batch_dimension_numbers_;
+  std::vector<int64_t> contracting_dim_;
+};
+
 // Specifies the descriptor for a RNN model.
 //
 // An example use case:
@@ -170,7 +242,7 @@ class RnnDescriptor {
     int64_t size;
   };
   typedef std::vector<ParamsRegion> ParamsRegions;
-  virtual ~RnnDescriptor() {}
+  virtual ~RnnDescriptor() = default;
   virtual int64_t ParamsSizeInBytes() const { return -1; }
   virtual ParamsRegions ParamsWeightRegions() const { return ParamsRegions(); }
   virtual ParamsRegions ParamsBiasRegions() const { return ParamsRegions(); }
@@ -182,7 +254,7 @@ class RnnDescriptor {
 // in use. The destructor releases the underlying descriptors.
 class RnnSequenceTensorDescriptor {
  public:
-  virtual ~RnnSequenceTensorDescriptor() {}
+  virtual ~RnnSequenceTensorDescriptor() = default;
 };
 
 // Specifies either the input and hidden state in a RNN model.
@@ -191,7 +263,7 @@ class RnnSequenceTensorDescriptor {
 // in use. The destructor releases the underlying descriptors.
 class RnnStateTensorDescriptor {
  public:
-  virtual ~RnnStateTensorDescriptor() {}
+  virtual ~RnnStateTensorDescriptor() = default;
 };
 
 // Returns a string representation of the given quantization mode.
@@ -870,7 +942,7 @@ class OpRunner;
 template <typename... Args>
 class OpRunner<void(Args...)> {
  public:
-  virtual ~OpRunner() {}
+  virtual ~OpRunner() = default;
 
   // Get a description of the runner, for uniqueness of autotune entries.
   //
@@ -912,6 +984,34 @@ using FusedMatmulSignature = void(DeviceMemoryBase /* a_data */,
                                   DeviceMemoryBase /* c_data */);
 using FusedMatmulRunner = OpRunner<FusedMatmulSignature>;
 
+using FusedMHASoftmaxSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
+                                      DeviceMemoryBase /* BMM1_inputB_data */,
+                                      DeviceMemoryBase /* BMM2_inputA_data */,
+                                      DeviceMemoryBase /* output_data */);
+using FusedMHASoftmaxRunner = OpRunner<FusedMHASoftmaxSignature>;
+
+using FusedMHAMaskSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
+                                   DeviceMemoryBase /* BMM1_inputB_data */,
+                                   DeviceMemoryBase /* mask_data */,
+                                   DeviceMemoryBase /* BMM2_inputA_data */,
+                                   DeviceMemoryBase /* output_data */);
+using FusedMHAMaskRunner = OpRunner<FusedMHAMaskSignature>;
+
+using FusedMHABiasMaskSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
+                                       DeviceMemoryBase /* BMM1_inputB_data */,
+                                       DeviceMemoryBase /* mask_data */,
+                                       DeviceMemoryBase /* bias_data */,
+                                       DeviceMemoryBase /* BMM2_inputA_data */,
+                                       DeviceMemoryBase /* output_data */);
+using FusedMHABiasMaskRunner = OpRunner<FusedMHABiasMaskSignature>;
+
+using FusedMHABiasSignature = void(DeviceMemoryBase /*BMM1_inputA_data*/,
+                                   DeviceMemoryBase /* BMM1_inputB_data */,
+                                   DeviceMemoryBase /* bias_data */,
+                                   DeviceMemoryBase /* BMM2_inputA_data */,
+                                   DeviceMemoryBase /* output_data */);
+using FusedMHABiasRunner = OpRunner<FusedMHABiasSignature>;
+
 // Describes the configuration for the algorithms that will used.
 //
 // Arguments:
@@ -930,7 +1030,7 @@ using FusedMatmulRunner = OpRunner<FusedMatmulSignature>;
 // one without scratch memory, and scratch_size field is used to track it.
 class AlgorithmConfig {
  public:
-  AlgorithmConfig() {}
+  AlgorithmConfig() = default;
   explicit AlgorithmConfig(AlgorithmDesc algorithm) : algorithm_(algorithm) {}
   AlgorithmConfig(AlgorithmDesc algorithm, size_t scratch_size)
       : algorithm_(algorithm), scratch_size_(scratch_size) {}
@@ -1159,8 +1259,8 @@ class VersionInfo {
 // PrepareForConvolution is an example for how new APIs should be written.
 class DnnSupport {
  public:
-  DnnSupport() {}
-  virtual ~DnnSupport() {}
+  DnnSupport() = default;
+  virtual ~DnnSupport() = default;
 
   virtual tsl::Status Init() = 0;
 
@@ -1535,6 +1635,54 @@ class DnnSupport {
       const dnn::BatchDescriptor& output_descriptor,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
       dnn::ActivationMode activation_mode);
+
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
+  FusedMHASoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
+  FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& mask_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
+  FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& mask_descriptor,
+      const dnn::TensorDescriptor& bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
+
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
+  FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor& bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor& output_descriptor,
+      const dnn::TensorDescriptor& bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed);
 
   virtual bool GetMIOpenConvolveAlgorithms(
       dnn::ConvolutionKind kind, dnn::DataType element_type, Stream* stream,

--- a/tensorflow/compiler/xla/stream_executor/lazy_op_runner.h
+++ b/tensorflow/compiler/xla/stream_executor/lazy_op_runner.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <atomic>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -199,6 +200,114 @@ struct FusedMatmulOp {
   RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
                           Stream* stream) {
     return tsl::errors::Unimplemented("Unimplemented");
+  }
+};
+
+struct FusedMHASoftmaxOp {
+  using Signature = FusedMHASoftmaxSignature;
+
+  struct Config {
+    FusedMHAKind kind;
+    const MatmulTensorDescriptor& bmm1_lhs_descriptor;
+    const MatmulTensorDescriptor& bmm1_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_rhs_descriptor;
+    const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
+    const TensorDescriptor& output_descriptor;
+    std::optional<double> dropout_rate;
+    std::optional<int64_t> seed;
+  };
+
+  static tsl::StatusOr<
+      std::unique_ptr<const OpRunner<FusedMHASoftmaxSignature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->FusedMHASoftmaxRunnerFromDesc(
+        desc, config.kind, config.bmm1_lhs_descriptor,
+        config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
+        config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
+        config.dropout_rate, config.seed);
+  }
+};
+
+struct FusedMHAScaleMaskSoftmaxOp {
+  using Signature = FusedMHAMaskSignature;
+
+  struct Config {
+    FusedMHAKind kind;
+    double scale;
+    const MatmulTensorDescriptor& bmm1_lhs_descriptor;
+    const MatmulTensorDescriptor& bmm1_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_rhs_descriptor;
+    const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
+    const TensorDescriptor& output_descriptor;
+    const TensorDescriptor& mask_descriptor;
+    std::optional<double> dropout_rate;
+    std::optional<int64_t> seed;
+  };
+
+  static tsl::StatusOr<std::unique_ptr<const OpRunner<FusedMHAMaskSignature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+        desc, config.kind, config.bmm1_lhs_descriptor,
+        config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
+        config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
+        config.mask_descriptor, config.scale, config.dropout_rate, config.seed);
+  }
+};
+
+struct FusedMHAScaleBiasMaskSoftmaxOp {
+  using Signature = FusedMHABiasMaskSignature;
+  struct Config {
+    FusedMHAKind kind;
+    double scale;
+    const MatmulTensorDescriptor& bmm1_lhs_descriptor;
+    const MatmulTensorDescriptor& bmm1_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_rhs_descriptor;
+    const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
+    const TensorDescriptor& output_descriptor;
+    const TensorDescriptor& bias_descriptor;
+    const TensorDescriptor& mask_descriptor;
+    std::optional<double> dropout_rate;
+    std::optional<int64_t> seed;
+  };
+
+  static tsl::StatusOr<
+      std::unique_ptr<const OpRunner<FusedMHABiasMaskSignature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+        desc, config.kind, config.bmm1_lhs_descriptor,
+        config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
+        config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
+        config.mask_descriptor, config.bias_descriptor, config.scale,
+        config.dropout_rate, config.seed);
+  }
+};
+
+struct FusedMHAScaleBiasSoftmaxOp {
+  using Signature = FusedMHABiasSignature;
+  struct Config {
+    FusedMHAKind kind;
+    double scale;
+    const MatmulTensorDescriptor& bmm1_lhs_descriptor;
+    const MatmulTensorDescriptor& bmm1_rhs_descriptor;
+    const MatmulTensorDescriptor& bmm2_rhs_descriptor;
+    const MatmulTensorDescriptor& intermediate_bmm2_lhs_descriptor;
+    const TensorDescriptor& output_descriptor;
+    const TensorDescriptor& bias_descriptor;
+    std::optional<double> dropout_rate;
+    std::optional<int64_t> seed;
+  };
+
+  static tsl::StatusOr<std::unique_ptr<const OpRunner<FusedMHABiasSignature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+        desc, config.kind, config.bmm1_lhs_descriptor,
+        config.bmm1_rhs_descriptor, config.bmm2_rhs_descriptor,
+        config.intermediate_bmm2_lhs_descriptor, config.output_descriptor,
+        config.bias_descriptor, config.scale, config.dropout_rate, config.seed);
   }
 };
 

--- a/tensorflow/compiler/xla/stream_executor/stream.h
+++ b/tensorflow/compiler/xla/stream_executor/stream.h
@@ -476,6 +476,87 @@ class Stream {
         convolution_descriptor, activation_mode);
   }
 
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHASoftmaxRunner>>
+  FusedMHASoftmaxRunnerFromDesc(
+      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor &output_descriptor,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+    dnn::DnnSupport *dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->FusedMHASoftmaxRunnerFromDesc(
+        this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+        bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+        output_descriptor, dropout_rate, seed);
+  }
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHAMaskRunner>>
+  FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor &output_descriptor,
+      const dnn::TensorDescriptor &mask_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+    dnn::DnnSupport *dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->FusedMHAScaleMaskSoftmaxRunnerFromDesc(
+        this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+        bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+        output_descriptor, mask_descriptor, scale, dropout_rate, seed);
+  }
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasMaskRunner>>
+  FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor &output_descriptor,
+      const dnn::TensorDescriptor &mask_descriptor,
+      const dnn::TensorDescriptor &bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+    dnn::DnnSupport *dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->FusedMHAScaleBiasMaskSoftmaxRunnerFromDesc(
+        this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+        bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+        output_descriptor, mask_descriptor, bias_descriptor, scale,
+        dropout_rate, seed);
+  }
+
+  tsl::StatusOr<std::unique_ptr<const dnn::FusedMHABiasRunner>>
+  FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+      const dnn::AlgorithmDesc &algorithm_desc, dnn::FusedMHAKind kind,
+      const dnn::MatmulTensorDescriptor &bmm1_lhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm1_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &bmm2_rhs_descriptor,
+      const dnn::MatmulTensorDescriptor &intermediate_bmm2_lhs_descriptor,
+      const dnn::TensorDescriptor &output_descriptor,
+      const dnn::TensorDescriptor &bias_descriptor, double scale,
+      std::optional<double> dropout_rate, std::optional<int64_t> seed) {
+    dnn::DnnSupport *dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->FusedMHAScaleBiasSoftmaxRunnerFromDesc(
+        this, algorithm_desc, kind, bmm1_lhs_descriptor, bmm1_rhs_descriptor,
+        bmm2_rhs_descriptor, intermediate_bmm2_lhs_descriptor,
+        output_descriptor, bias_descriptor, scale, dropout_rate, seed);
+  }
+
   Stream &ThenSeparableConvolve(
       const dnn::BatchDescriptor &input_descriptor,
       const DeviceMemory<float> &input_data,

--- a/tensorflow/tsl/protobuf/dnn.proto
+++ b/tensorflow/tsl/protobuf/dnn.proto
@@ -174,3 +174,10 @@ message ConvolutionDescriptorProto {
   // Tensorflow node name, same as in NodeDef, for debugging purposes.
   string name = 7;
 }
+
+// FusedMHAKind kind
+enum FusedMHAKind {
+  BMM1_OUTPUT_UNKNOWN = 0;
+  BMM1_OUTPUT_INPUT_TYPE = 1;
+  BMM1_OUTPUT_FLOAT = 2;
+}


### PR DESCRIPTION
cuDNN currently supports the following patterns for Multi-headed attention:

BMM1 - BMM2
BMM1 - Scale - Bias - Mask - Softmax - BMM2
BMM1 - Scale - Bias - Mask - Softmax - Dropout - BMM2
BMM1 - Scale - Mask - Softmax - BMM2
BMM1 - Scale - Mask - Softmax - Dropout - BMM2
BMM1 - Softmax - Dropout - BMM2

This PR adds support for the stream executor for these patterns.