### PR TITLE
Make tfcompile more friendly on other archs.

### DIFF
--- a/tensorflow/compiler/aot/tfcompile_main.cc
+++ b/tensorflow/compiler/aot/tfcompile_main.cc
@@ -60,7 +60,6 @@ const char kUsageHeader[] =
 
 int main(int argc, char** argv) {
   tensorflow::tfcompile::MainFlags flags;
-  flags.target_triple = "x86_64-pc-linux";
   flags.out_function_object = "out_model.o";
   flags.out_metadata_object = "out_helper.o";
   flags.out_header = "out.h";

--- a/tensorflow/compiler/aot/tfcompile_main.cc
+++ b/tensorflow/compiler/aot/tfcompile_main.cc
@@ -60,6 +60,9 @@ const char kUsageHeader[] =
 
 int main(int argc, char** argv) {
   tensorflow::tfcompile::MainFlags flags;
+#ifndef __s390x__
+  flags.target_triple = "x86_64-pc-linux";
+#endif
   flags.out_function_object = "out_model.o";
   flags.out_metadata_object = "out_helper.o";
   flags.out_header = "out.h";

--- a/tensorflow/python/tfcompile_wrapper.cc
+++ b/tensorflow/python/tfcompile_wrapper.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #include <string>
 
-#include "llvm/Support/Host.h"
+#include "llvm/TargetParser/Host.h"
 #include "pybind11/cast.h"  // from @pybind11
 #include "pybind11/pybind11.h"  // from @pybind11
 #include "pybind11/pytypes.h"  // from @pybind11

--- a/tensorflow/python/tfcompile_wrapper.cc
+++ b/tensorflow/python/tfcompile_wrapper.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include <string>
 
+#include "llvm/Support/Host.h"
 #include "pybind11/cast.h"  // from @pybind11
 #include "pybind11/pybind11.h"  // from @pybind11
 #include "pybind11/pytypes.h"  // from @pybind11
@@ -44,8 +45,10 @@ PYBIND11_MODULE(_pywrap_tfcompile, m) {
         tensorflow::tfcompile::MainFlags flags;
         flags.graph = std::move(graph);
         flags.config = std::move(config);
-        flags.target_triple = std::move(target_triple);
-        flags.target_cpu = std::move(target_cpu);
+        flags.target_triple = std::move(target_triple.empty() ?
+                       llvm::sys::getDefaultTargetTriple() : target_triple);
+        flags.target_cpu = std::move(target_cpu.empty() ?
+                       llvm::sys::getHostCPUName().str() : target_cpu);
         flags.target_features = std::move(target_features);
         flags.entry_point = std::move(entry_point);
         flags.cpp_class = std::move(cpp_class);
@@ -62,7 +65,7 @@ PYBIND11_MODULE(_pywrap_tfcompile, m) {
         tensorflow::MaybeRaiseFromStatus(tensorflow::tfcompile::Main(flags));
       },
       py::arg("graph") = "", py::arg("config") = "",
-      py::arg("target_triple") = "x86_64-pc-linux", py::arg("target_cpu") = "",
+      py::arg("target_triple") = "", py::arg("target_cpu") = "",
       py::arg("target_features") = "", py::arg("entry_point") = "entry",
       py::arg("cpp_class") = "", py::arg("out_function_object") = "out_model.o",
       py::arg("out_metadata_object") = "out_helper.o",

--- a/tensorflow/python/tfcompile_wrapper.cc
+++ b/tensorflow/python/tfcompile_wrapper.cc
@@ -15,7 +15,9 @@ limitations under the License.
 
 #include <string>
 
+#ifdef __s390x__
 #include "llvm/TargetParser/Host.h"
+#endif
 #include "pybind11/cast.h"  // from @pybind11
 #include "pybind11/pybind11.h"  // from @pybind11
 #include "pybind11/pytypes.h"  // from @pybind11
@@ -45,10 +47,15 @@ PYBIND11_MODULE(_pywrap_tfcompile, m) {
         tensorflow::tfcompile::MainFlags flags;
         flags.graph = std::move(graph);
         flags.config = std::move(config);
+#ifdef __s390x__
         flags.target_triple = std::move(target_triple.empty() ?
                        llvm::sys::getDefaultTargetTriple() : target_triple);
         flags.target_cpu = std::move(target_cpu.empty() ?
                        llvm::sys::getHostCPUName().str() : target_cpu);
+#else
+        flags.target_triple = std::move(target_triple);
+        flags.target_cpu = std::move(target_cpu);
+#endif
         flags.target_features = std::move(target_features);
         flags.entry_point = std::move(entry_point);
         flags.cpp_class = std::move(cpp_class);
@@ -65,7 +72,12 @@ PYBIND11_MODULE(_pywrap_tfcompile, m) {
         tensorflow::MaybeRaiseFromStatus(tensorflow::tfcompile::Main(flags));
       },
       py::arg("graph") = "", py::arg("config") = "",
-      py::arg("target_triple") = "", py::arg("target_cpu") = "",
+#ifdef __s390x__
+      py::arg("target_triple") = "",
+#else
+      py::arg("target_triple") = "x86_64-pc-linux",
+#endif
+      py::arg("target_cpu") = "",
       py::arg("target_features") = "", py::arg("entry_point") = "entry",
       py::arg("cpp_class") = "", py::arg("out_function_object") = "out_model.o",
       py::arg("out_metadata_object") = "out_helper.o",

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -184,7 +184,7 @@ _SMCLI_VARIABLES_TO_FEED = flags.DEFINE_string(
     ' object.')
 
 _SMCLI_TARGET_TRIPLE = flags.DEFINE_string(
-    name='target_triple', default='x86_64-pc-linux',
+    name='target_triple', default='',
     help='Triple identifying a target variation, containing information such as'
     ' processor architecture, vendor, operating system, and environment. '
     'Defaults to \'x86_64-pc-linux\'.')

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -187,7 +187,7 @@ _SMCLI_TARGET_TRIPLE = flags.DEFINE_string(
     name='target_triple', default='',
     help='Triple identifying a target variation, containing information such as'
     ' processor architecture, vendor, operating system, and environment. '
-    'Defaults to \'x86_64-pc-linux\'.')
+    'Defaults to \'\'.')
 
 _SMCLI_TARGET_CPU = flags.DEFINE_string(
     name='target_cpu', default='',

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -969,7 +969,8 @@ def run():
     AttributeError: An error when neither --inputs nor --input_exprs is passed
     to run command.
   """
-  if not _SMCLI_INPUTS.value and not _SMCLI_INPUT_EXPRS.value and not _SMCLI_INPUT_EXAMPLES.value:
+  if not _SMCLI_INPUTS.value and not _SMCLI_INPUT_EXPRS.value \
+          and not _SMCLI_INPUT_EXAMPLES.value:
     raise AttributeError(
         'At least one of --inputs, --input_exprs or --input_examples must be '
         'required')

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -20,6 +20,7 @@ https://www.tensorflow.org/guide/saved_model#cli_to_inspect_and_execute_savedmod
 """
 
 import argparse
+import platform
 
 import ast
 import os
@@ -183,11 +184,18 @@ _SMCLI_VARIABLES_TO_FEED = flags.DEFINE_string(
     'will NOT be frozen, and their values will be uninitialized in the compiled'
     ' object.')
 
-_SMCLI_TARGET_TRIPLE = flags.DEFINE_string(
-    name='target_triple', default='',
+if platform.machine() == "s390x":
+  _SMCLI_TARGET_TRIPLE = flags.DEFINE_string(
+      name='target_triple', default='',
+      help='Triple identifying a target variation, containing information such'
+      'as processor architecture, vendor, operating system, and environment. '
+      'Defaults to \'\'.')
+else:
+  _SMCLI_TARGET_TRIPLE = flags.DEFINE_string(
+    name='target_triple', default='x86_64-pc-linux',
     help='Triple identifying a target variation, containing information such as'
     ' processor architecture, vendor, operating system, and environment. '
-    'Defaults to \'\'.')
+    'Defaults to \'x86_64-pc-linux\'.')
 
 _SMCLI_TARGET_CPU = flags.DEFINE_string(
     name='target_cpu', default='',

--- a/tensorflow/python/tools/saved_model_cli_test.py
+++ b/tensorflow/python/tools/saved_model_cli_test.py
@@ -1042,6 +1042,9 @@ Concrete Functions:
     if not test.is_built_with_xla():
       self.skipTest('Skipping test because XLA is not compiled in.')
 
+    if platform.machine() == "s390x" and "aarch64" in str(target_triple):
+      self.skipTest("Skipping arm tests on s390x.")
+
     saved_model_dir = os.path.join(test.get_temp_dir(), 'dummy_model')
     dummy_model = self.AOTCompileDummyModel()
     func = getattr(dummy_model, func)


### PR DESCRIPTION
Currently tfcompile and tfcompile_wrapper use hard coded values for target_triple. The hard coded value is `x86_64-pc-linux`. This makes the following test(s) fail on s390x:

//tensorflow/python/tools:saved_model_cli_test

I've removed the hard coded string and changed it so that the default value from llvm is used instead.

In the case where a specific target_triple is desired such as in the `testAOTCompileCPUFreezesAndCompilesVariablesToFeedNoneTargetAarch64Linux` and `testAOTCompileCPUFreezesAndCompilesVariablesToFeedNoneTargetAarch64Android` subtests, the set value is still allowed to follow through.

The subtests above cause additional failures on big endian systems due to a check for little endianness. I added an exception to skip these two subtests on s390x.

tfcompile_wrapper doesn't set a default target_cpu. This is causing the following test case to fail on s390x:

//tensorflow/python/tools:aot_compiled_test

I've made a similar change where I use the value from llvm as the default.