### PR TITLE
Use a custom rule for API files generation

### DIFF
--- a/tensorflow/python/tools/api/generator/api_gen.bzl
+++ b/tensorflow/python/tools/api/generator/api_gen.bzl
@@ -151,7 +151,6 @@ def gen_api_init_files(
 
     flags = [
         root_init_template_flag,
-        "--apidir=$(@D)" + output_dir,
         "--apiname=" + api_name,
         "--apiversion=" + str(api_version),
         compat_api_version_flags,
@@ -170,22 +169,51 @@ def gen_api_init_files(
     loading_value = "default"
     # copybara:comment_end
 
-    native.genrule(
+    api_gen_rule(
         name = name,
         outs = all_output_files,
-        cmd = if_indexing_source_code(
-            _make_cmd(api_gen_binary_target, flags, loading = "static"),
-            _make_cmd(api_gen_binary_target, flags, loading = loading_value),
-        ),
         srcs = srcs,
-        tools = [":" + api_gen_binary_target],
+        flags = flags,
+        api_gen_binary_target = ":" + api_gen_binary_target,
+        loading_value = if_indexing_source_code("static", loading_value),
         visibility = [
             "//tensorflow:__pkg__",
             "//tensorflow/tools/api/tests:__pkg__",
         ],
     )
 
-def _make_cmd(api_gen_binary_target, flags, loading):
-    binary = "$(location :" + api_gen_binary_target + ")"
-    flags.append("--loading=" + loading)
-    return " ".join([binary] + flags + ["$(OUTS)"])
+def _api_gen_rule_impl(ctx):
+    api_gen_binary_target = ctx.attr.api_gen_binary_target[DefaultInfo].files_to_run.executable
+    flags = ["--apidir=" + ctx.outputs.outs[0].dirname]
+    flags += [ctx.expand_location(flag) for flag in ctx.attr.flags]
+    loading = ctx.attr.loading_value
+    output_paths = [f.path for f in ctx.outputs.outs]
+    cmd = _make_cmd(api_gen_binary_target, flags, loading, output_paths)
+
+    ctx.actions.run_shell(
+        inputs = ctx.files.srcs,
+        outputs = ctx.outputs.outs,
+        tools = [api_gen_binary_target],
+        command = cmd,
+    )
+
+def _make_cmd(api_gen_binary_target, flags, loading, output_paths):
+    binary = api_gen_binary_target.path
+    flags = flags + ["--loading=" + loading]
+    return " ".join([binary] + flags + output_paths)
+
+# To prevent compiling the C++ code twice, we only want to build `api_gen_binary_target`
+# for the target platform and not the execution platform.
+# To achieve this without causing confusion with source dependencies (e.g. putting api_gen_binary_target in srcs of the genrule),
+# we use a custom rule to execute the command line for generating the API files.
+# See https://github.com/tensorflow/tensorflow/issues/60167
+api_gen_rule = rule(
+    implementation = _api_gen_rule_impl,
+    attrs = {
+        "outs": attr.output_list(mandatory = True),
+        "srcs": attr.label_list(allow_files = True),
+        "flags": attr.string_list(),
+        "api_gen_binary_target": attr.label(executable = True, cfg = "target"),
+        "loading_value": attr.string(),
+    },
+)


### PR DESCRIPTION
To prevent compiling the C++ code twice, we only want to build `api_gen_binary_target` for the target platform and not the execution platform.
To achieve this without causing confusion with source dependencies (e.g. putting `api_gen_binary_target` in `srcs` of the `genrule`), we use a custom rule to execute the command line for generating the API files.
Fixes https://github.com/tensorflow/tensorflow/issues/60167