### PR TITLE
Enable secure grpc++/grpc deps and ssl features on s390x

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -83,6 +83,8 @@ def is_macos():
 def is_ppc64le():
   return platform.machine() == 'ppc64le'
 
+def is_s390x():
+  return platform.machine() == 's390x'
 
 def is_cygwin():
   return platform.system().startswith('CYGWIN_NT')
@@ -1007,6 +1009,10 @@ def system_specific_test_config(environ_cp):
 
 def set_system_libs_flag(environ_cp):
   syslibs = environ_cp.get('TF_SYSTEM_LIBS', '')
+  
+  if is_s390x() and "boringssl" not in syslibs:
+    syslibs = "boringssl" + (", " + syslibs if syslibs != "" else "")
+
   if syslibs:
     if ',' in syslibs:
       syslibs = ','.join(sorted(syslibs.split(',')))

--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -1086,7 +1086,6 @@ cc_library(
     name = "grpc",
     visibility = ["//visibility:public"],
     deps = select({
-        ":linux_s390x": ["@com_github_grpc_grpc//:grpc_unsecure"],
         "//conditions:default": ["@com_github_grpc_grpc//:grpc"],
     }),
 )
@@ -1095,7 +1094,6 @@ cc_library(
     name = "grpc++",
     visibility = ["//visibility:public"],
     deps = select({
-        ":linux_s390x": ["@com_github_grpc_grpc//:grpc++_unsecure"],
         "//conditions:default": ["@com_github_grpc_grpc//:grpc++"],
     }),
 )

--- a/tensorflow/tsl/BUILD
+++ b/tensorflow/tsl/BUILD
@@ -467,7 +467,6 @@ cc_library(
     name = "grpc++",
     visibility = ["//visibility:public"],
     deps = select({
-        ":linux_s390x": ["@com_github_grpc_grpc//:grpc++_unsecure"],
         "//conditions:default": ["@com_github_grpc_grpc//:grpc++"],
     }),
 )

--- a/tensorflow/tsl/platform/default/build_config.bzl
+++ b/tensorflow/tsl/platform/default/build_config.bzl
@@ -243,7 +243,6 @@ def cc_proto_library(
 
     if use_grpc_plugin:
         cc_libs += select({
-            clean_dep("//tensorflow/tsl:linux_s390x"): ["//external:grpc_lib_unsecure"],
             "//conditions:default": ["//external:grpc_lib"],
         })
 
@@ -326,7 +325,6 @@ def cc_grpc_library(
     proto_targets += srcs
 
     extra_deps += select({
-        clean_dep("//tensorflow/tsl:linux_s390x"): ["//external:grpc_lib_unsecure"],
         "//conditions:default": ["//external:grpc_lib"],
     })
 


### PR DESCRIPTION
Since `boringssl` has not been supported on s390x yet, `@com_github_grpc_grpc//:grpc_unsecure` and `@com_github_grpc_grpc//:grpc++_unsecure` deps used to be chosen when building TensorFlow on s390x.
 
However, we can enable secure grpc++/grpc deps and ssl related features for TensorFlow on s390x via `openssl` by using `TF_SYSTEM_LIBS="boringssl"` flag in bazel commands.
 
This PR aims to enable the above-mentioned features on s390x by removing the specific `grpc_unsecure` and `grpc++_unsecure` deps from BUILD files and adding the `TF_SYSTEM_LIBS="boringssl"` flag as a default option for Bazel during the configuration stage on s390x.
 
After applying the above change, the following test cases would pass on s390x:
```bash
//tensorflow/core/platform/cloud:compute_engine_metadata_client_test
//tensorflow/core/platform/cloud:compute_engine_zone_provider_test
//tensorflow/core/platform/cloud:curl_http_request_test
//tensorflow/core/platform/cloud:gcs_file_system_test
//tensorflow/core/platform/cloud:google_auth_provider_test
//tensorflow/core/platform/cloud:oauth_client_test
```

Fixes https://github.com/tensorflow/tensorflow/issues/51770 .