### PR TITLE
Add big-endian support to String TensorType in TFLite FlatBuffer models

### DIFF
--- a/tensorflow/compiler/mlir/lite/flatbuffer_to_string.cc
+++ b/tensorflow/compiler/mlir/lite/flatbuffer_to_string.cc
@@ -141,7 +141,8 @@ int main(int argc, char** argv) {
   std::string serialized_model;
   if (tflite::ReadAndVerify(argv[1], &serialized_model)) return 1;
 #if FLATBUFFERS_LITTLEENDIAN == 0
-  tflite::FlatBufferModel::ByteSwapSerializedModel(&serialized_model);
+  if (std::string(argv[1]) == "-")
+    tflite::FlatBufferModel::ByteSwapSerializedModel(&serialized_model, true);
 #endif
   tflite::ToString(serialized_model);
   return 0;

--- a/tensorflow/compiler/mlir/lite/flatbuffer_to_string.cc
+++ b/tensorflow/compiler/mlir/lite/flatbuffer_to_string.cc
@@ -141,6 +141,8 @@ int main(int argc, char** argv) {
   std::string serialized_model;
   if (tflite::ReadAndVerify(argv[1], &serialized_model)) return 1;
 #if FLATBUFFERS_LITTLEENDIAN == 0
+  // If the flatbuffer model comes from stdin, convert its tensor content from
+  // BE to LE to ensure the output text string is the same as on LE platforms.
   if (std::string(argv[1]) == "-")
     tflite::FlatBufferModel::ByteSwapSerializedModel(&serialized_model, true);
 #endif

--- a/tensorflow/lite/core/model_builder.cc
+++ b/tensorflow/lite/core/model_builder.cc
@@ -120,7 +120,7 @@ void FlatBufferModel::ByteSwapBuffer(int8_t tensor_type, size_t buffer_size,
   switch (tensor_type) {
     case tflite::TensorType_STRING: {
       auto bp = reinterpret_cast<int32_t*>(buffer);
-      int num_of_strings = 
+      int num_of_strings =
           from_big_endian ? bp[0] : flatbuffers::EndianSwap(bp[0]);
       for (int i = 0; i < num_of_strings + 2; i++)
         bp[i] = flatbuffers::EndianSwap(bp[i]);

--- a/tensorflow/lite/core/model_builder.h
+++ b/tensorflow/lite/core/model_builder.h
@@ -158,28 +158,33 @@ class FlatBufferModel {
 #if FLATBUFFERS_LITTLEENDIAN == 0
   /// Byte swap a constant buffer in place.
   static void ByteSwapBuffer(int8_t tensor_type, size_t buffer_size,
-                             uint8_t* buffer);
+                             uint8_t* buffer, bool from_big_endian = true);
 
   /// Byte swap the buffers field of a TFLite Model instance in place.
-  static void ByteSwapTFLiteModel(const tflite::Model* tfl_model);
+  static void ByteSwapTFLiteModel(const tflite::Model* tfl_model,
+                                  bool from_big_endian = true);
 
   /// Byte swap the buffers field of a TFLite ModelT instance in place.
-  static void ByteSwapTFLiteModelT(tflite::ModelT* tfl_modelt);
+  static void ByteSwapTFLiteModelT(tflite::ModelT* tfl_modelt,
+                                   bool from_big_endian = true);
 
   /// Convert the TFLite buffers field between LE and BE format in a
   /// FlatBufferModel which is not empty and return the converted instance.
   static std::unique_ptr<FlatBufferModel> ByteConvertModel(
       std::unique_ptr<FlatBufferModel> model,
-      ErrorReporter* error_reporter = DefaultErrorReporter());
+      ErrorReporter* error_reporter = DefaultErrorReporter(),
+      bool from_big_endian = false);
 
   /// Byte Swap the TFLite buffers field in a FlatBufferModel and return the
   /// swapped instance.
   static std::unique_ptr<FlatBufferModel> ByteSwapFlatBufferModel(
       std::unique_ptr<FlatBufferModel> model,
-      ErrorReporter* error_reporter = DefaultErrorReporter());
+      ErrorReporter* error_reporter = DefaultErrorReporter(),
+      bool from_big_endian = false);
 
   /// Byte Swap the serialized String of a TFLite model in place.
-  static void ByteSwapSerializedModel(std::string* serialized_model);
+  static void ByteSwapSerializedModel(std::string* serialized_model,
+                                      bool from_big_endian = true);
 #endif
 
   // Releases memory or unmaps mmaped memory.

--- a/tensorflow/lite/experimental/acceleration/mini_benchmark/model_modifier/embedder_main.cc
+++ b/tensorflow/lite/experimental/acceleration/mini_benchmark/model_modifier/embedder_main.cc
@@ -73,7 +73,7 @@ int RunEmbedder(const EmbedderOptions& options) {
     return 3;
   }
 #if FLATBUFFERS_LITTLEENDIAN == 0
-  tflite::FlatBufferModel::ByteSwapSerializedModel(&main_model_contents);
+  tflite::FlatBufferModel::ByteSwapSerializedModel(&main_model_contents, false);
 #endif
   const Model* main_model =
       flatbuffers::GetRoot<Model>(main_model_contents.data());
@@ -87,7 +87,8 @@ int RunEmbedder(const EmbedderOptions& options) {
     return 4;
   }
 #if FLATBUFFERS_LITTLEENDIAN == 0
-  tflite::FlatBufferModel::ByteSwapSerializedModel(&metrics_model_contents);
+  tflite::FlatBufferModel::ByteSwapSerializedModel(&metrics_model_contents,
+                                                   false);
 #endif
   const Model* metrics_model =
       flatbuffers::GetRoot<Model>(metrics_model_contents.data());
@@ -134,7 +135,7 @@ int RunEmbedder(const EmbedderOptions& options) {
     return 7;
   }
 #if FLATBUFFERS_LITTLEENDIAN == 0
-  tflite::FlatBufferModel::ByteSwapSerializedModel(&binary);
+  tflite::FlatBufferModel::ByteSwapSerializedModel(&binary, true);
 #endif
   f << binary;
   f.close();

--- a/tensorflow/lite/experimental/acceleration/mini_benchmark/validator_test.cc
+++ b/tensorflow/lite/experimental/acceleration/mini_benchmark/validator_test.cc
@@ -121,7 +121,7 @@ TEST_F(ValidatorTest, HappyPathOnCpuWithCustomValidation) {
       reinterpret_cast<const char*>(model_with_input.GetBufferPointer()),
       model_with_input.GetSize());
 #if FLATBUFFERS_LITTLEENDIAN == 0
-  tflite::FlatBufferModel::ByteSwapSerializedModel(&serialized_str);
+  tflite::FlatBufferModel::ByteSwapSerializedModel(&serialized_str, true);
 #endif
   std::string model_path = MiniBenchmarkTestHelper::DumpToTempFile(
       "mobilenet_quant_with_input.tflite",


### PR DESCRIPTION
PR #58494 has added big-endian support to numeric TensorTypes in TFLite FlatBuffers. However, since TFLite uses `tflite::DynamicBuffer` to encode vector of strings, the header of string buffer contains raw bytes which record the number of strings, the offsets of each string, etc., as shown in the following code snippet:  https://github.com/tensorflow/tensorflow/blob/864bf2ca8e4f314d9ad01d240d9e3fec2b653c93/tensorflow/lite/string_util.cc#L78-L87  Thus the String TensorType will have endianness issue if a TFLite model is used across platforms with different endianness formats.
 
This PR aims to solve this issue in both C++ and Python code and uses the same guidelines on big-endian machines as PR #58494 , such as:

1. Convert the string buffers from LE(little-endian) to BE(big-endian) format when loading a TFLite model from a file.
2. Convert the string buffers from BE to LE format when writing a serialized binary string of TFLite model to a file.
3. Keep the header of string buffers in BE format when the model/buffer is in memory.

 
An argument `bool from_big_endian` was added to the function declaration of `FlatBufferModel::ByteSwapBuffer()` , because in this function we need to know the endianness of the raw bytes in the header of string buffer, so that we can read the `num_of_strings` data correctly.
 
After applying this PR, the String TensorType will be correctly byte-swapped along with other numeric TensorTypes when necessary. We've tested the code change on TensorFlow test suite, it won't cause any regressions on BE/LE platforms, and can fix the following test failure on s390x (big-endian arch) in master branch:
```bash
//tensorflow/compiler/xla/service/cpu/tests:cpu_infeed_test
```
 
We've also tested this PR with the [tensorflow/serving](https://github.com/tensorflow/serving) test suite, failures in the following test cases could pass on s390x after this change, since the string tensors in TFLite models which were generated on LE machines could now be loaded successfully on BE platforms.
```bash
//tensorflow_serving/servables/tensorflow:saved_model_bundle_factory_test
//tensorflow_serving/servables/tensorflow:tflite_interpreter_pool_test
//tensorflow_serving/servables/tensorflow:tflite_session_test
```