### PR TITLE
Fix null pointer dereference in tsl::profiler::CreateStub

### DIFF
--- a/tensorflow/tsl/profiler/rpc/client/profiler_client.cc
+++ b/tensorflow/tsl/profiler/rpc/client/profiler_client.cc
@@ -54,6 +54,7 @@ std::unique_ptr<typename T::Stub> CreateStub(
       service_address, ::grpc::InsecureChannelCredentials(), channel_args);
   if (!channel) {
     LOG(ERROR) << "Unable to create channel" << service_address;
+    return nullptr;
   }
   return T::NewStub(channel);
 }


### PR DESCRIPTION
The bug was found by Svace static analyzer:

1. channel may be null
2. it is passed to grpc::ProfileAnalysis::NewStub(channel)
3. then passed to grpc::ProfileAnalysis::Stub::Stub(channel)
4. then constructor grpc::internal::RpcMethod::RpcMethod() dereferences channel via channel->RegisterMethod(name)

cc @mihaimaruseac