### PR TITLE
Fix null pointer dereference in mlir::GetOutermostOpsOfType

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/transforms/call_graph_util.h
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/call_graph_util.h
@@ -47,7 +47,7 @@ LogicalResult GetOutermostOpsOfType(
         auto v = symtab.lookup<func::FuncOp>(sym.getRootReference());
         if (!v) {
           // This is not expected to happen in practice.
-          v.emitError() << "Cannot find function " << sym.getRootReference();
+          op->emitError() << "Cannot find function " << sym.getRootReference();
           return WalkResult::interrupt();
         }
         worklist.push(v);


### PR DESCRIPTION
The bug was found by Svace static analyzer:

1. v is null
2. v.emitError() dereferences a null pointer

cc @mihaimaruseac