### PR TITLE
Fix null pointer dereference in tf2xla ParseShardingFromEdgeSource

### DIFF
--- a/tensorflow/compiler/tf2xla/sharding_util.cc
+++ b/tensorflow/compiler/tf2xla/sharding_util.cc
@@ -117,7 +117,7 @@ StatusOr<std::optional<xla::OpSharding>> ParseShardingFromEdgeSource(
     const Edge& edge, int num_cores_per_replica, bool add_metadata) {
   if (edge.src() == nullptr) {
     return tensorflow::errors::InvalidArgument(
-        "Null src for ParseShardingFromEdgeSource edge=", edge.DebugString());
+        "Null src for ParseShardingFromEdgeSource edge");
   }
   TF_ASSIGN_OR_RETURN(std::optional<xla::OpSharding> sharding,
                       ParseShardingFromDevice(


### PR DESCRIPTION
The bug was found by Svace static analyzer:

1. edge.src() is null
2. edge.DebugString() dereferences src_ (that is null) via src_->name()

cc @mihaimaruseac