### PR TITLE
Fix null pointer dereference in grappler::GetInputs

### DIFF
--- a/tensorflow/core/grappler/optimizers/scoped_allocator_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/scoped_allocator_optimizer.cc
@@ -291,6 +291,9 @@ Status GetInputs(ScopedAllocatorOptimizer* sa_opti, int64_t invocation_count,
                 << " output_index " << output_index;
       }
     }
+    if (inode == nullptr) {
+      return errors::Internal("Did not find node");
+    }
     if (inode_dtype == DT_INVALID) {
       if (!graph_properties.HasOutputProperties(inode->name())) {
         return errors::Internal("Input node ", inode->name(),


### PR DESCRIPTION
The bug was found by Svace static analyzer:

1. there may be zero for-loop iterations and inode stays nullptr
2. later it is zero-dereferenced by inode->name()

cc @mihaimaruseac