### PR TITLE
Fix direct_session.cc

### DIFF
--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -686,8 +686,10 @@ Status DirectSession::RunInternal(
   }
   if (do_trace || update_cost_model ||
       run_options.report_tensor_allocations_upon_oom()) {
-    run_state.collector.reset(
-        new StepStatsCollector(run_metadata->mutable_step_stats()));
+    if (run_metadata) {
+      run_state.collector.reset(
+          new StepStatsCollector(run_metadata->mutable_step_stats()));
+    }
     args.stats_collector = run_state.collector.get();
   }
 


### PR DESCRIPTION
The bug was found by Svace static analyzer:

1. run_metadata may be null
2. later it is zero-dereferenced by run_metadata->mutable_step_stats()

cc @mihaimaruseac
