### PR TITLE
Fix null pointer dereference in DirectSession::RunInternal

### DIFF
--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -552,11 +552,8 @@ Status DirectSession::RunInternal(
                             executor_step_count, &debugger_state));
   }
 
-  if (run_metadata == nullptr) {
-    return absl::InternalError("Metadata output is not set.");
-  }
-
-  if (options_.config.experimental().has_session_metadata()) {
+  if (run_metadata != nullptr &&
+      options_.config.experimental().has_session_metadata()) {
     *run_metadata->mutable_session_metadata() =
         options_.config.experimental().session_metadata();
   }
@@ -697,8 +694,8 @@ Status DirectSession::RunInternal(
           ((measure_step_count + 1) % build_cost_model_every == 0);
     }
   }
-  if (do_trace || update_cost_model ||
-      run_options.report_tensor_allocations_upon_oom()) {
+  if (run_metadata != nullptr && (do_trace || update_cost_model ||
+      run_options.report_tensor_allocations_upon_oom())) {
     run_state.collector.reset(
         new StepStatsCollector(run_metadata->mutable_step_stats()));
     args.stats_collector = run_state.collector.get();
@@ -784,7 +781,7 @@ Status DirectSession::RunInternal(
     run_status.Update(errors::Cancelled("Run call was cancelled"));
   }
 
-  if (device_profiler_session) {
+  if (run_metadata != nullptr && device_profiler_session) {
     TF_RETURN_IF_ERROR(device_profiler_session->CollectData(
         run_metadata->mutable_step_stats()));
   }
@@ -817,11 +814,13 @@ Status DirectSession::RunInternal(
     mutex_lock l(executor_lock_);
     run_state.collector->BuildCostModel(&cost_model_manager_, device_to_graph);
 
-    // annotate stats onto cost graph.
-    CostGraphDef* cost_graph = run_metadata->mutable_cost_graph();
-    for (const auto& item : executors_and_keys->items) {
-      TF_RETURN_IF_ERROR(
-          cost_model_manager_.AddToCostGraphDef(item.graph.get(), cost_graph));
+    if (run_metadata != nullptr) {
+      // annotate stats onto cost graph.
+      CostGraphDef* cost_graph = run_metadata->mutable_cost_graph();
+      for (const auto& item : executors_and_keys->items) {
+        TF_RETURN_IF_ERROR(
+            cost_model_manager_.AddToCostGraphDef(item.graph.get(), cost_graph));
+      }
     }
   }
 
@@ -831,7 +830,7 @@ Status DirectSession::RunInternal(
       return errors::InvalidArgument(
           "RunOptions.output_partition_graphs() is not supported when "
           "disable_output_partition_graphs is true.");
-    } else {
+    } else if (run_metadata != nullptr) {
       protobuf::RepeatedPtrField<GraphDef>* partition_graph_defs =
           run_metadata->mutable_partition_graphs();
       for (const PerPartitionExecutorsAndLib& exec_and_lib :

--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -553,7 +553,7 @@ Status DirectSession::RunInternal(
   }
 
   if (run_metadata == nullptr) {
-    return errors::Internal("Metadata output is not set.");
+    return absl::InternalError("Metadata output is not set.");
   }
 
   if (options_.config.experimental().has_session_metadata()) {

--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -552,8 +552,11 @@ Status DirectSession::RunInternal(
                             executor_step_count, &debugger_state));
   }
 
-  if (run_metadata != nullptr &&
-      options_.config.experimental().has_session_metadata()) {
+  if (run_metadata == nullptr) {
+    return errors::Internal("Metadata output is not set.");
+  }
+
+  if (options_.config.experimental().has_session_metadata()) {
     *run_metadata->mutable_session_metadata() =
         options_.config.experimental().session_metadata();
   }


### PR DESCRIPTION
The bug was found by Svace static analyzer:

1. run_metadata may be null because it is checked for null on https://github.com/tensorflow/tensorflow/blob/r2.12/tensorflow/core/common_runtime/direct_session.cc#L545
2. later it is zero-dereferenced by run_metadata->mutable_step_stats()

cc @mihaimaruseac
