### PR TITLE
Fix null pointer dereference in Prepare

### DIFF
--- a/tensorflow/lite/kernels/add.cc
+++ b/tensorflow/lite/kernels/add.cc
@@ -89,6 +89,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   auto* params = reinterpret_cast<TfLiteAddParams*>(node->builtin_data);
   OpData* data = reinterpret_cast<OpData*>(node->user_data);
 
+  TF_LITE_ENSURE(context, params);
+
   TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
   TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
 
@@ -143,7 +145,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
     TF_LITE_ENSURE_EQ(context, input2->params.zero_point, 0);
     TF_LITE_ENSURE_EQ(context, output->params.zero_point, 0);
 
-    general_scale_int16 = !params || !params->pot_scale_int16;
+    general_scale_int16 = !params->pot_scale_int16;
 
     if (!general_scale_int16) {
       // Do preparation in the case of the scale parameter is power of 2.


### PR DESCRIPTION
The bug was found by Svace static analyzer:

1. params may be null because it is checked for null on https://github.com/tensorflow/tensorflow/blob/r2.12/tensorflow/lite/kernels/add.cc#L143
2. later it is zero-dereferenced by params->activation

cc @mihaimaruseac
