### PR TITLE
Fix null pointer dereference in FuseMhloMulAndConvolutionPattern::matchAndRewrite

### DIFF
--- a/tensorflow/compiler/mlir/lite/stablehlo/transforms/fuse_convolution_pass.cc
+++ b/tensorflow/compiler/mlir/lite/stablehlo/transforms/fuse_convolution_pass.cc
@@ -97,7 +97,8 @@ class FuseMhloMulAndConvolutionPattern : public OpRewritePattern<mhlo::MulOp> {
     }
 
     // Rewrite
-    broadcast_dims = broadcast_op.getBroadcastDimensions();
+    broadcast_dims =
+        broadcast_op ? broadcast_op.getBroadcastDimensions() : nullptr;
     if (broadcast_dims == nullptr) {
       const auto filter_rank = filter_value.getType().getRank();
       auto dimsType = RankedTensorType::get({1}, rewriter.getIntegerType(64));


### PR DESCRIPTION
The bug was found by Svace static analyzer:

1. broadcast_op may be null because it is checked for null on https://github.com/tensorflow/tensorflow/blob/r2.12/tensorflow/compiler/mlir/lite/stablehlo/transforms/fuse_convolution_pass.cc#L66
2. later it is zero-dereferenced by broadcast_op.getBroadcastDimensions()

cc @mihaimaruseac
