### PR TITLE
[Linaro:ARM_CI] Stop using ambe config as not needed

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
@@ -70,11 +70,11 @@ source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh
 source tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS_EXTENDED.sh
 
 # Export optional variables for running the tests
-export TF_BUILD_FLAGS="--config=ambe --config=mkl_aarch64_threadpool \
-    --copt=-flax-vector-conversions"
-export TF_TEST_FLAGS="${TF_BUILD_FLAGS} --test_env=TF_ENABLE_ONEDNN_OPTS=1 \
-    --test_env=TF2_BEHAVIOR=1 --define=tf_api_version=2 \
-    --test_lang_filters=py --flaky_test_attempts=3 --test_size_filters=small,medium"
+export TF_BUILD_FLAGS="--config=mkl_aarch64_threadpool --copt=-flax-vector-conversions"
+export TF_TEST_FLAGS="${TF_BUILD_FLAGS} \
+    --test_env=TF_ENABLE_ONEDNN_OPTS=1 --test_env=TF2_BEHAVIOR=1 --define=tf_api_version=2 \
+    --test_lang_filters=py --flaky_test_attempts=3 --test_size_filters=small,medium \
+    --test_output=errors --verbose_failures=true --test_keep_going"
 export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} ${ARM_SKIP_TESTS}"
 export TF_FILTER_TAGS="-no_oss,-oss_excluded,-oss_serial,-v1only,-benchmark-test,-no_aarch64,-gpu,-tpu,-no_oss_py38,-no_oss_py39,-no_oss_py310"
 
@@ -90,10 +90,8 @@ bazel test ${TF_TEST_FLAGS} \
     --repo_env=PYTHON_BIN_PATH="$(which python)" \
     --build_tag_filters=${TF_FILTER_TAGS} \
     --test_tag_filters=${TF_FILTER_TAGS} \
-    --local_test_jobs=64 \
-    --verbose_failures \
+    --local_test_jobs=$(grep -c ^processor /proc/cpuinfo) \
     --build_tests_only \
-    -k \
     -- ${TF_TEST_TARGETS}
 
 # Remove virtual environment

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -70,7 +70,7 @@ source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh
 source tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
 
 # Export optional variables for running pip_new.sh
-export TF_BUILD_FLAGS="--config=ambe --config=mkl_aarch64_threadpool --copt=-flax-vector-conversions"
+export TF_BUILD_FLAGS="--config=mkl_aarch64_threadpool --copt=-flax-vector-conversions"
 export TF_TEST_FLAGS="${TF_BUILD_FLAGS} \
     --test_env=TF_ENABLE_ONEDNN_OPTS=1 --test_env=TF2_BEHAVIOR=1 --define=no_tensorflow_py_deps=true \
     --test_lang_filters=py --flaky_test_attempts=3 --test_size_filters=small,medium \


### PR DESCRIPTION
The use of the ambe config to build and test aarch64 is not needed and so stop using it. The ambe config will be removed in the future so this must be done in preparation. Also make cpu_arm64_pip.sh and cpu_arm64_nonpip.sh more similar for easier future maintenance.