### PR TITLE
Fix null pointer dereference in xla::cpu::CustomCallOpLowering::rewriteTypedCustomCall()

### DIFF
--- a/tensorflow/compiler/xla/mlir/backends/cpu/transforms/lmhlo_to_cpu_runtime.cc
+++ b/tensorflow/compiler/xla/mlir/backends/cpu/transforms/lmhlo_to_cpu_runtime.cc
@@ -143,9 +143,10 @@ class CustomCallOpLowering : public OpRewritePattern<CustomCallOp> {
     callee->setAttr("rt.dynamic", UnitAttr::get(b.getContext()));
 
     // Forward backend config to the custom call implementation.
-    auto dict = op.getBackendConfig()
-                    ? op.getBackendConfig()->cast<mlir::DictionaryAttr>()
-                    : nullptr;
+    auto config = op.getBackendConfig();
+    if (!config)
+      return op.emitOpError("Failed to get backend config");
+    auto dict = config->cast<mlir::DictionaryAttr>();
     llvm::SmallVector<NamedAttribute> backend_config(dict.begin(), dict.end());
 
     // Call the custom call function forwarding user-defined attributes.


### PR DESCRIPTION
The bug was found by Svace static analyzer:

1. op.getBackendConfig() can be null
2. dict will be nullptr
3. dict.begin() dereferences a null pointer

Closes #60223

cc @mihaimaruseac