### PR TITLE
Update padding='SAME' in tf.image.ssim API

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -4348,7 +4348,7 @@ def _ssim_per_channel(img1,
   def reducer(x):
     shape = array_ops.shape(x)
     x = array_ops.reshape(x, shape=array_ops.concat([[-1], shape[-3:]], 0))
-    y = nn.depthwise_conv2d(x, kernel, strides=[1, 1, 1, 1], padding='VALID')
+    y = nn.depthwise_conv2d(x, kernel, strides=[1, 1, 1, 1], padding='SAME')
     return array_ops.reshape(
         y, array_ops.concat([shape[:-3], array_ops.shape(y)[1:]], 0))
 


### PR DESCRIPTION
Currently the API `tf.image.ssim` is using `padding='VALID'` internally. But with this padding the shape of the output is not matching with what documentation states. With `return_index_map=True` the output shape should be `broadcast(img1.shape[:-1], img2.shape[:-1])`. 

But with` padding='VALID'`, for input of shape `(16, 2106, 80, 1)` the current output shape is `(16, 2096, 70)` which is not matching with the expected output which should be `(16, 2106, 80)`. With `padding='SAME'` the output is matching to the desired output. 

Please refer to the attached [gist](https://colab.research.google.com/gist/SuryanarayanaY/d75ef4fcbd69b5211975fd4d29490084/59067_r1.ipynb) showcasing all the mentioned details. 

Fixes #59067 