### PR TITLE
build: add missing dependency on tablegen-generated files

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/transforms/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/transforms/CMakeLists.txt
@@ -39,6 +39,7 @@ add_mlir_library(MLIRBufferTransforms
 
   DEPENDS
   LMHLOTransformsPassIncGen
+  MLIRDeallocationPassesIncGen
 
   LINK_COMPONENTS
   Core


### PR DESCRIPTION
The transforms/generic_host_to_llvm.cc file includes deallocation_ops.h,
which includes a few tablegen-generated files that are produced by the
`MLIRDeallocationPassesIncGen` target.  However, this dependency on
`MLIRDeallocationPassesIncGen` is missing from the CMake rules, which
causes build errors like so:

```
In file included from transforms/generic_host_to_llvm.cc:19:
deallocation/transforms/passes.h:62:10: fatal error: 'deallocation/transforms/passes.h.inc' file not found
```

This patch adds the missing dependency.