### PR TITLE
tflite: add stdint.h for int types in internal::Spectrogram

### DIFF
--- a/tensorflow/lite/kernels/internal/spectrogram.cc
+++ b/tensorflow/lite/kernels/internal/spectrogram.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <assert.h>
 #include <math.h>
+#include <stdint.h>
 
 #include "third_party/fft2d/fft.h"
 


### PR DESCRIPTION
Discovered during Chromium build with GCC 13.