### PR TITLE
Adding large tensor mlir kernels, batch 1

### DIFF
--- a/tensorflow/core/kernels/mlir_generated/BUILD
+++ b/tensorflow/core/kernels/mlir_generated/BUILD
@@ -241,24 +241,13 @@ tf_kernel_library(
         ":gpu_bitwise_or_kernels",
         ":gpu_bitwise_xor_kernels",
         ":gpu_complex_kernels",
-        ":gpu_div_kernels",
         ":gpu_truncate_div_kernels",
-        ":gpu_div_no_nan_kernels",
-        ":gpu_equal_kernels",
-        ":gpu_floor_div_kernels",
         ":gpu_floor_mod_kernels",
-        ":gpu_greater_equal_kernels",
-        ":gpu_greater_kernels",
         ":gpu_left_shift_kernels",
-        ":gpu_less_equal_kernels",
-        ":gpu_less_kernels",
         ":gpu_logical_and_kernels",
         ":gpu_logical_or_kernels",
         ":gpu_maximum_kernels",
         ":gpu_minimum_kernels",
-        ":gpu_mul_kernels",
-        ":gpu_mul_no_nan_kernels",
-        ":gpu_not_equal_kernels",
         ":gpu_polygamma_kernels",
         ":gpu_pow_kernels",
         ":gpu_right_shift_kernels",
@@ -273,10 +262,32 @@ tf_kernel_library(
         [
             ":gpu_add_v2_kernels_experimental",
             ":gpu_sub_kernels_experimental",
+            ":gpu_div_kernels_experimental",
+            ":gpu_div_no_nan_kernels_experimental",
+            ":gpu_mul_kernels_experimental",
+            ":gpu_mul_no_nan_kernels_experimental",
+            ":gpu_floor_div_kernels_experimental",
+            ":gpu_equal_kernels_experimental",
+            ":gpu_not_equal_kernels_experimental",
+            ":gpu_greater_kernels_experimental",
+            ":gpu_greater_equal_kernels_experimental",
+            ":gpu_less_equal_kernels_experimental",
+            ":gpu_less_kernels_experimental",
         ],
         [
             ":gpu_add_v2_kernels",
             ":gpu_sub_kernels",
+            ":gpu_div_kernels",
+            ":gpu_div_no_nan_kernels",
+            ":gpu_mul_kernels",
+            ":gpu_mul_no_nan_kernels",
+            ":gpu_floor_div_kernels",
+            ":gpu_equal_kernels",
+            ":gpu_not_equal_kernels",
+            ":gpu_greater_kernels",
+            ":gpu_greater_equal_kernels",
+            ":gpu_less_equal_kernels",
+            ":gpu_less_kernels",
         ],
     ),
 )
@@ -1023,6 +1034,27 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_equal_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "c64",
+        "c128",
+        "f16",
+        "f32",
+        "f64",
+        "i1",
+        "i8",
+        "i16",
+        "i32",
+        "i64",
+    ],
+    op = "equal",
+    output_jit_i64_indexed_for_large_tensors_types = ["i1"] * 10,
+    tile_size = "1024",
+    types = [],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
     name = "gpu_greater_kernels",
     op = "greater",
     output_types = ["i1"] * 10,
@@ -1043,6 +1075,27 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_greater_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "i8",
+        "i16",
+        "i64",
+        "ui8",
+        "ui16",
+        "ui32",
+        "ui64",
+    ],
+    op = "greater",
+    output_jit_i64_indexed_for_large_tensors_types = ["i1"] * 10,
+    tile_size = "1024",
+    types = [],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
     name = "gpu_greater_equal_kernels",
     op = "greater_equal",
     output_types = ["i1"] * 10,
@@ -1059,6 +1112,27 @@ gpu_kernel_library(
         "ui32",
         "ui64",
     ],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
+    name = "gpu_greater_equal_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "i8",
+        "i16",
+        "i64",
+        "ui8",
+        "ui16",
+        "ui32",
+        "ui64",
+    ],
+    op = "greater_equal",
+    output_jit_i64_indexed_for_large_tensors_types = ["i1"] * 10,
+    tile_size = "1024",
+    types = [],
     unroll_factors = "4",
 )
 
@@ -1122,6 +1196,27 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_less_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "i8",
+        "i16",
+        "i64",
+        "ui8",
+        "ui16",
+        "ui32",
+        "ui64",
+    ],
+    op = "less",
+    output_jit_i64_indexed_for_large_tensors_types = ["i1"] * 10,
+    tile_size = "1024",
+    types = [],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
     name = "gpu_less_equal_kernels",
     op = "less_equal",
     output_types = ["i1"] * 10,
@@ -1142,6 +1237,27 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_less_equal_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "i8",
+        "i16",
+        "i64",
+        "ui8",
+        "ui16",
+        "ui32",
+        "ui64",
+    ],
+    op = "less_equal",
+    output_jit_i64_indexed_for_large_tensors_types = ["i1"] * 10,
+    tile_size = "1024",
+    types = [],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
     name = "gpu_not_equal_kernels",
     op = "not_equal",
     output_types = ["i1"] * 10,
@@ -1158,6 +1274,27 @@ gpu_kernel_library(
         "i32",
         "i64",
     ],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
+    name = "gpu_not_equal_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "c64",
+        "c128",
+        "f16",
+        "f32",
+        "f64",
+        "i1",
+        "i8",
+        "i16",
+        "i32",
+        "i64",
+    ],
+    op = "not_equal",
+    output_jit_i64_indexed_for_large_tensors_types = ["i1"] * 10,
+    tile_size = "1024",
+    types = [],
     unroll_factors = "4",
 )
 
@@ -1345,6 +1482,30 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_div_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "i16",
+        "i64",
+        "ui8",
+        "ui16",
+        "c64",
+        "c128",
+    ],
+    jit_types = [
+        "i8",
+        "ui32",
+        "ui64",
+    ],
+    op = "div",
+    tile_size = "1024",
+    types = [],
+    unroll_factors = "16B",
+)
+
+gpu_kernel_library(
     name = "gpu_div_no_nan_kernels",
     op = "div_no_nan",
     tile_size = "1024",
@@ -1355,6 +1516,20 @@ gpu_kernel_library(
         "c64",
         "c128",
     ],
+)
+
+gpu_kernel_library(
+    name = "gpu_div_no_nan_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "c64",
+        "c128",
+    ],
+    op = "div_no_nan",
+    tile_size = "1024",
+    types = [],
 )
 
 gpu_kernel_library(
@@ -1373,6 +1548,26 @@ gpu_kernel_library(
         "i64",
         "f64",
     ],
+    unroll_factors = "4",
+)
+
+gpu_kernel_library(
+    name = "gpu_floor_div_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "i16",
+        "i64",
+        "f64",
+    ],
+    jit_types = [
+        "i8",
+        "ui32",
+        "ui64",
+    ],
+    op = "floor_div",
+    tile_size = "1024",
+    types = [],
     unroll_factors = "4",
 )
 
@@ -1443,6 +1638,31 @@ gpu_kernel_library(
 )
 
 gpu_kernel_library(
+    name = "gpu_mul_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "c64",
+        "c128",
+        "i8",
+        "i16",
+        "i32",
+        "i64",
+    ],
+    op = "mul",
+    tile_size = "1024",
+    types = [],
+    unroll_factors = "4",
+    # For complex MulOp kernels, we don't use unrolling, it would only cause
+    # slowdowns.
+    unroll_factors_override = {
+        "c64": None,
+        "c128": None,
+    },
+)
+
+gpu_kernel_library(
     name = "gpu_mul_no_nan_kernels",
     op = "mul_no_nan",
     tile_size = "1024",
@@ -1453,6 +1673,27 @@ gpu_kernel_library(
         "c64",
         "c128",
     ],
+    unroll_factors = "4",
+    # For complex MulNoNanOp kernels, we don't use unrolling, it would only
+    # cause slowdowns.
+    unroll_factors_override = {
+        "c64": None,
+        "c128": None,
+    },
+)
+
+gpu_kernel_library(
+    name = "gpu_mul_no_nan_kernels_experimental",
+    jit_i64_indexed_for_large_tensors_types = [
+        "f16",
+        "f32",
+        "f64",
+        "c64",
+        "c128",
+    ],
+    op = "mul_no_nan",
+    tile_size = "1024",
+    types = [],
     unroll_factors = "4",
     # For complex MulNoNanOp kernels, we don't use unrolling, it would only
     # cause slowdowns.

--- a/tensorflow/core/kernels/mlir_generated/gpu_binary_ops_large_tensor_test.cc
+++ b/tensorflow/core/kernels/mlir_generated/gpu_binary_ops_large_tensor_test.cc
@@ -39,8 +39,18 @@ T baseline_add(T lhs, T rhs) {
 }
 
 template <typename T>
+T baseline_div(T lhs, T rhs) {
+  return lhs / rhs;
+}
+
+template <typename T>
 T baseline_sub(T lhs, T rhs) {
   return lhs - rhs;
+}
+
+template <typename T>
+T baseline_greater(T lhs, T rhs) {
+  return lhs > rhs;
 }
 
 /// Test `tf.Addv2`.
@@ -69,6 +79,34 @@ TEST_F(BinaryOpsLargeTensorTest, SubLargeTensors) {
       test::OpsTestConfig().ExpectStrictlyEqual());
 }
 
+#endif
+
+/// Test `tf.Div`.
+
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED) && \
+    defined(MLIR_GENERATED_EXPERIMENTAL_KERNELS_ENABLED)
+
+TEST_F(BinaryOpsLargeTensorTest, DivV2LargeTensors) {
+  TestEqualShapes<float, float, float, float>(
+      "Div", /*shape=*/test::DefaultInputShapeExceedingInt32(),
+      test::DefaultInput<float>(),
+      test::DefaultInput<float>(), baseline_div,
+      test::OpsTestConfig().ExpectStrictlyEqual());
+}
+#endif
+
+/// Test `tf.Greater`.
+
+#if defined(MLIR_GENERATED_GPU_KERNELS_ENABLED) && \
+    defined(MLIR_GENERATED_EXPERIMENTAL_KERNELS_ENABLED)
+
+TEST_F(BinaryOpsLargeTensorTest, GreaterLargeTensors) {
+  TestEqualShapes<float, float, bool, float>(
+      "Greater", /*shape=*/test::DefaultInputShapeExceedingInt32(),
+      test::DefaultInput<float>(),
+      test::DefaultInput<float>(), baseline_greater,
+      test::OpsTestConfig().ExpectStrictlyEqual());
+}
 #endif
 
 }  // namespace


### PR DESCRIPTION
To enable Predicate, Mul and Div to the MLIR large indexing kernels
CC: @frgossen for review