### PR TITLE
Add //tensorflow/tsl/protobuf:protos_all_cc_impl to tf_portable_proto_lib in tensorflow/tsl/platform/default/build_config.bzl

### DIFF
--- a/tensorflow/tsl/platform/default/build_config.bzl
+++ b/tensorflow/tsl/platform/default/build_config.bzl
@@ -806,7 +806,7 @@ def tsl_cc_test(
     )
 
 def tf_portable_proto_lib():
-    return ["//tensorflow/core:protos_all_cc_impl"]
+    return ["//tensorflow/core:protos_all_cc_impl", "//tensorflow/tsl/protobuf:protos_all_cc_impl"]
 
 def tf_protobuf_compiler_deps():
     return if_static(


### PR DESCRIPTION
Add //tensorflow/tsl/protobuf:protos_all_cc_impl to tf_portable_proto_lib. This fixes the undefined symbol issue for TensorFlowLiteSelectTfOps_framework.