### PR TITLE
[NVIDIA XLA] Fix Fp32 biasAdd fusion for FP8 cublasLt matmul

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
@@ -1216,7 +1216,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
 
     if (gemm->custom_call_target() == kCublasLtMatmulF8CallTarget &&
         bias->shape().element_type() == F32 && convert != nullptr) {
-      HloInstruction *bias_f16_maybe = convert->mutable_operand(0);
+      HloInstruction *bias_f16_or_bf16 = convert->mutable_operand(0);
       auto compatible_bias_type = [](const PrimitiveType btype,
                                      const PrimitiveType dtype) {
         if (btype == BF16) {
@@ -1234,9 +1234,9 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       // precision. Instead, we only fuse the bias if the bias itself is a
       // convert from F16 or BF16, fusing the input of the convert instruction
       // to the matmul.
-      if (compatible_bias_type(bias_f16_maybe->shape().element_type(),
+      if (compatible_bias_type(bias_f16_or_bf16->shape().element_type(),
                                gemm->shape().element_type())) {
-        bias = bias_f16_maybe;
+        bias = bias_f16_or_bf16;
       } else {
         VLOG(1) << "Epilogue fusion of FP32 vector bias into FP8 GEMM is "
                    "currently not supported. See the cublasLT support matrix.";

--- a/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
@@ -516,6 +516,12 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
           return false;
         };
 
+        // cuBLAS LT does not support FP32 biases on matmuls with FP8 inputs,
+        // even if the matmul output is FP32. We do not unconditionally convert
+        // the bias to a supported precision (F16 or BF16) because this lowers
+        // precision. Instead, we only fuse the bias if the bias itself is a
+        // convert from F16 or BF16, fusing the input of the convert instruction
+        // to the matmul.
         if (!Match(bias->mutable_operand(0),
                    m::Convert(m::Convert(&optional_bias_f16, m::Op())
                                   .WithPredicate(compatible_bias_type)))) {

--- a/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
@@ -1191,7 +1191,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       return true;
     }
 
-    // cuBLASLt doesn't supprt F32 vector bias, thus convert to BF16.
+    // cuBLASLt doesn't support F32 vector bias, thus convert to BF16.
     if (gemm->custom_call_target() == kCublasLtMatmulF8CallTarget) {
       if (bias->shape().element_type() == F32) {
         Shape bf16_shape = bias->shape();

--- a/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
@@ -517,13 +517,12 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
           return false;
         };
 
-        HloInstruction *bias_f32;
         if (!Match(bias->mutable_operand(0),
-                   m::Convert(&bias_f32,
-                              m::Convert(&optional_bias_f16, m::Op())
+                   m::Convert(m::Convert(&optional_bias_f16, m::Op())
                                   .WithPredicate(compatible_bias_type)))) {
-          VLOG(1) << "F32 vector bias fusion into F8 cublasLt matmul is not "
-                     "currently supported. Please use pattern F32->BF16->F32.";
+          VLOG(1)
+              << "Epilogue fusion of FP32 vector bias into FP8 GEMM is "
+                 "currently not supported. See the cublasLT support matrix.";
         }
       }
 

--- a/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
@@ -1204,7 +1204,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     if (gemm->custom_call_target() == kCublasLtMatmulF8CallTarget &&
         bias->shape().element_type() == F32) {
       if (convert == nullptr) {
-        return true;
+        return false;
       }
 
       HloInstruction *bias_f16_or_bf16 = convert->mutable_operand(0);
@@ -1232,7 +1232,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       } else {
         VLOG(1) << "Epilogue fusion of FP32 vector bias into FP8 GEMM is "
                    "currently not supported. See the cublasLT support matrix.";
-        return true;
+        return false;
       }
     }
 

--- a/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
@@ -519,12 +519,9 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
 
         HloInstruction *bias_f32;
         if (!Match(bias->mutable_operand(0),
-                   m::AnyOf<HloInstruction>(
-                       m::Convert(&bias_f32,
-                                  m::Convert(&optional_bias_f16, m::Op())
-                                      .WithPredicate(compatible_bias_type)),
-                       m::Convert(&optional_bias_f16, m::Op())
-                           .WithPredicate(compatible_bias_type)))) {
+                   m::Convert(&bias_f32,
+                              m::Convert(&optional_bias_f16, m::Op())
+                                  .WithPredicate(compatible_bias_type)))) {
           VLOG(1) << "F32 vector bias fusion into F8 cublasLt matmul is not "
                      "currently supported. Please use pattern F32->BF16->F32.";
         }

--- a/tensorflow/compiler/xla/service/gpu/tests/gemm_rewrite_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gemm_rewrite_test.cc
@@ -5118,7 +5118,9 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABUnscaledDF32VectorBiasF8) {
       x_f32 = f32[16,32] convert(x)
       y_f32 = f32[32,16] convert(y)
       b = f32[16] parameter(2)
-      b_bcast = f32[16,16] broadcast(b), dimensions={1}
+      b_bf16 = bf16[16] convert(b)
+      b_f32 = f32[16] convert(b_bf16)
+      b_bcast = f32[16,16] broadcast(b_f32), dimensions={1}
       x_scale = f32[] parameter(3)
       y_scale = f32[] parameter(4)
       x_scale_bcast = f32[16,32] broadcast(x_scale), dimensions={}
@@ -5131,7 +5133,7 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABUnscaledDF32VectorBiasF8) {
 
 )";
 
-  CheckFp8IfOnHopper(hlo_text, ErrorSpec{0.1, 0.1});
+  CheckFp8IfOnHopper(hlo_text);
   RunAndFilecheckHloRewrite(hlo_text,
                             GemmRewriter(se::CudaComputeCapability{
                                 se::CudaComputeCapability::HOPPER, 0}),

--- a/tensorflow/compiler/xla/service/gpu/tests/gemm_rewrite_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gemm_rewrite_test.cc
@@ -5140,7 +5140,9 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABUnscaledDF32VectorBiasF8) {
                             R"(
 
 ; CHECK-LABEL: ENTRY %test (x: f8e4m3fn[16,32], y: f8e4m3fn[32,16], b: f32[16], x_scale: f32[], y_scale: f32[]) -> f32[16,16] {
-; CHECK-NEXT:    [[P0:%[^ ]+]] = f8e4m3fn[16,32]{1,0} parameter(0)
+; CHECK-NEXT:    [[VB:%[^ ]+]] = f32[16]{0} parameter(2)
+; CHECK-NEXT:    [[VBC:%[^ ]+]] = bf16[16]{0} convert([[VB]])
+; CHECK:         [[P0:%[^ ]+]] = f8e4m3fn[16,32]{1,0} parameter(0)
 ; CHECK-NEXT:    [[P1:%[^ ]+]] = f8e4m3fn[32,16]{1,0} parameter(1)
 ; CHECK-NEXT:    [[P1_TRANSPOSE:%[^ ]+]] = f8e4m3fn[16,32]{1,0} transpose([[P1]]), dimensions={1,0}
 ; CHECK-NEXT:    [[C1:%[^ ]+]] = f32[] constant(0)
@@ -5148,8 +5150,6 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABUnscaledDF32VectorBiasF8) {
 ; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[] parameter(3)
 ; CHECK-NEXT:    [[P3:%[^ ]+]] = f32[] parameter(4)
 ; CHECK-NEXT:    [[C:%[^ ]+]] = f32[] constant(1)
-; CHECK-NEXT:    [[VB:%[^ ]+]] = f32[16]{0} parameter(2)
-; CHECK-NEXT:    [[VBC:%[^ ]+]] = bf16[16]{0} convert([[VB]])
 ; CHECK:         ROOT [[OUT:%[^ ]+]] = f32[16,16]{1,0} custom-call([[P0]], [[P1_TRANSPOSE]], [[BC]], [[P2]], [[P3]], /*index=5*/[[C]], [[C]], [[VBC]]),
 ; CHECK:           custom_call_target="__cublas$lt$matmul$f8",
 ; CHECK:           backend_config="{

--- a/tensorflow/compiler/xla/service/gpu/tests/gemm_rewrite_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gemm_rewrite_test.cc
@@ -5138,10 +5138,7 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABUnscaledDF32VectorBiasF8) {
                             GemmRewriter(se::CudaComputeCapability{
                                 se::CudaComputeCapability::HOPPER, 0}),
                             R"(
-
 ; CHECK-LABEL: ENTRY %test (x: f8e4m3fn[16,32], y: f8e4m3fn[32,16], b: f32[16], x_scale: f32[], y_scale: f32[]) -> f32[16,16] {
-; CHECK-NEXT:    [[VB:%[^ ]+]] = f32[16]{0} parameter(2)
-; CHECK-NEXT:    [[VBC:%[^ ]+]] = bf16[16]{0} convert([[VB]])
 ; CHECK:         [[P0:%[^ ]+]] = f8e4m3fn[16,32]{1,0} parameter(0)
 ; CHECK-NEXT:    [[P1:%[^ ]+]] = f8e4m3fn[32,16]{1,0} parameter(1)
 ; CHECK-NEXT:    [[P1_TRANSPOSE:%[^ ]+]] = f8e4m3fn[16,32]{1,0} transpose([[P1]]), dimensions={1,0}
@@ -5150,6 +5147,8 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABUnscaledDF32VectorBiasF8) {
 ; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[] parameter(3)
 ; CHECK-NEXT:    [[P3:%[^ ]+]] = f32[] parameter(4)
 ; CHECK-NEXT:    [[C:%[^ ]+]] = f32[] constant(1)
+; CHECK-NEXT:    [[VB:%[^ ]+]] = f32[16]{0} parameter(2)
+; CHECK-NEXT:    [[VBC:%[^ ]+]] = bf16[16]{0} convert([[VB]])
 ; CHECK:         ROOT [[OUT:%[^ ]+]] = f32[16,16]{1,0} custom-call([[P0]], [[P1_TRANSPOSE]], [[BC]], [[P2]], [[P3]], /*index=5*/[[C]], [[C]], [[VBC]]),
 ; CHECK:           custom_call_target="__cublas$lt$matmul$f8",
 ; CHECK:           backend_config="{

--- a/tensorflow/compiler/xla/service/gpu/tests/gemm_rewrite_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/tests/gemm_rewrite_test.cc
@@ -5108,6 +5108,66 @@ TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABScaledDVectorBiasF8) {
       )");
 }
 
+TEST_P(ParameterizedFp8GemmRewriteTest, ScaledABUnscaledDF32VectorBiasF8) {
+  const char* hlo_text = R"(
+    HloModule test
+
+    ENTRY test {
+      x = f8e4m3fn[16,32] parameter(0)
+      y = f8e4m3fn[32,16] parameter(1)
+      x_f32 = f32[16,32] convert(x)
+      y_f32 = f32[32,16] convert(y)
+      b = f32[16] parameter(2)
+      b_bcast = f32[16,16] broadcast(b), dimensions={1}
+      x_scale = f32[] parameter(3)
+      y_scale = f32[] parameter(4)
+      x_scale_bcast = f32[16,32] broadcast(x_scale), dimensions={}
+      y_scale_bcast = f32[32,16] broadcast(y_scale), dimensions={}
+      x_unscaled = f32[16,32] multiply(x_f32, x_scale_bcast)
+      y_unscaled = f32[32,16] multiply(y_f32, y_scale_bcast)
+      dot_a = f32[16,16] dot(x_unscaled, y_unscaled), lhs_contracting_dims={1}, rhs_contracting_dims={0}
+      ROOT out = f32[16,16] add(dot_a, b_bcast)
+           }
+
+)";
+
+  CheckFp8IfOnHopper(hlo_text, ErrorSpec{0.1, 0.1});
+  RunAndFilecheckHloRewrite(hlo_text,
+                            GemmRewriter(se::CudaComputeCapability{
+                                se::CudaComputeCapability::HOPPER, 0}),
+                            R"(
+
+; CHECK-LABEL: ENTRY %test (x: f8e4m3fn[16,32], y: f8e4m3fn[32,16], b: f32[16], x_scale: f32[], y_scale: f32[]) -> f32[16,16] {
+; CHECK-NEXT:    [[P0:%[^ ]+]] = f8e4m3fn[16,32]{1,0} parameter(0)
+; CHECK-NEXT:    [[P1:%[^ ]+]] = f8e4m3fn[32,16]{1,0} parameter(1)
+; CHECK-NEXT:    [[P1_TRANSPOSE:%[^ ]+]] = f8e4m3fn[16,32]{1,0} transpose([[P1]]), dimensions={1,0}
+; CHECK-NEXT:    [[C1:%[^ ]+]] = f32[] constant(0)
+; CHECK-NEXT:    [[BC:%[^ ]+]] = f32[16,16]{1,0} broadcast([[C1]]), dimensions={}
+; CHECK-NEXT:    [[P2:%[^ ]+]] = f32[] parameter(3)
+; CHECK-NEXT:    [[P3:%[^ ]+]] = f32[] parameter(4)
+; CHECK-NEXT:    [[C:%[^ ]+]] = f32[] constant(1)
+; CHECK-NEXT:    [[VB:%[^ ]+]] = f32[16]{0} parameter(2)
+; CHECK-NEXT:    [[VBC:%[^ ]+]] = bf16[16]{0} convert([[VB]])
+; CHECK:         ROOT [[OUT:%[^ ]+]] = f32[16,16]{1,0} custom-call([[P0]], [[P1_TRANSPOSE]], [[BC]], [[P2]], [[P3]], /*index=5*/[[C]], [[C]], [[VBC]]),
+; CHECK:           custom_call_target="__cublas$lt$matmul$f8",
+; CHECK:           backend_config="{
+; CHECK-DAG:         \"alpha_real\":1
+; CHECK-DAG:         \"alpha_imag\":0
+; CHECK-DAG:         \"beta\":0
+; CHECK-DAG:         \"dot_dimension_numbers\":{ 
+; CHECK-DAG:           \"lhs_contracting_dimensions\":[\"1\"]
+; CHECK-DAG:           \"rhs_contracting_dimensions\":[\"1\"]
+; CHECK-DAG:           \"lhs_batch_dimensions\":[]
+; CHECK-DAG:           \"rhs_batch_dimensions\":[] 
+; CHECK-DAG:         }
+; CHECK-DAG:         \"precision_config\":{
+; CHECK-DAG:           \"operand_precision\":[\"DEFAULT\",\"DEFAULT\"]
+; CHECK-DAG:         }
+; CHECK-DAG:         \"epilogue\":\"BIAS\"
+; CHECK:           }"
+      )");
+}
+
 TEST_P(ParameterizedFp8GemmRewriteTest,
        ScaledABUnscaledDVectorBiasThenReluActivationF8) {
   const char* hlo_text = R"(


### PR DESCRIPTION
Cast Fp32 vector bias to Bf16 to be compatible with  cuBLASLT Fp8 support surface. @reedwm @philipphack 
Once FuseVectorBiasAdd fails, will not try FuseMatrixBiasAdd since matrix bias add logic is implemented in CreateF8CustomCall. And this is only specific to F8 matmul. Open to future changes.