### PR TITLE
get data ranges for missing types

### DIFF
--- a/tensorflow/lite/tools/utils.cc
+++ b/tensorflow/lite/tools/utils.cc
@@ -153,8 +153,8 @@ void GetDataRangesForType(TfLiteType type, float* low_range,
       type == kTfLiteFloat64) {
     *low_range = -0.5f;
     *high_range = 0.5f;
-  } else if (type == kTfLiteInt64 || type == kTfLiteInt64 ||
-             type == kTfLiteInt64 || type == kTfLiteInt64) {
+  } else if (type == kTfLiteInt64 || type == kTfLiteUInt64 ||
+             type == kTfLiteInt32 || type == kTfLiteUInt32) {
     *low_range = 0;
     *high_range = 99;
   } else if (type == kTfLiteUInt8) {


### PR DESCRIPTION
Hi,I 'm learning how to generate random data in tflite benchmark.However,I met this confusing code , and it doesn't seem to include datatype of int32 or uint32 and so on , I guess maybe the code should be like this ？If not, could you complete the range setting for Int32  and Uint32? It 's really important to me, thanks!