### PR TITLE
add missing floor operation

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/selectors/operation_selector.cc
+++ b/tensorflow/lite/delegates/gpu/common/selectors/operation_selector.cc
@@ -769,6 +769,7 @@ absl::Status GPUOperationFromNodePart0(
     case OperationType::SIN:
     case OperationType::SQRT:
     case OperationType::SQUARE:
+    case OperationType::FLOOR:
     case OperationType::TANH: {
       GPUOperation operation;
       if (inputs[0]->tensor.shape != outputs[0]->tensor.shape) {


### PR DESCRIPTION
Currently, the "FLOOR" operation is not properly supported on the GPU delegate. The underlying opencl/opengl implementation exists but the operation type is missing in operation_selector.cc, which prevents from using the floor op.