### PR TITLE
Allow merging streams in one stream group.

### DIFF
--- a/tensorflow/compiler/jit/pjrt_device_context.cc
+++ b/tensorflow/compiler/jit/pjrt_device_context.cc
@@ -100,11 +100,9 @@ void PjRtDeviceContext::CopyDeviceTensorToCPU(const Tensor* device_tensor,
                      const tensorflow::Status& status) { done(status); });
 }
 
-void PjRtDeviceContext::CopyCPUTensorToDevice(const Tensor* cpu_tensor,
-                                              Device* device,
-                                              Tensor* device_tensor,
-                                              StatusCallback done,
-                                              bool sync_dst_compute) const {
+void PjRtDeviceContext::CopyCPUTensorToDevice(
+    const Tensor* cpu_tensor, Device* device, Tensor* device_tensor,
+    StatusCallback done, bool sync_dst_compute, bool sync_dst_recv) const {
   profiler::TraceMe traceme("PjRtDeviceContext::CopyCPUTensorToDevice");
   if (cpu_tensor->NumElements() == 0) {
     VLOG(2) << "CopyCPUTensorToDevice empty tensor";

--- a/tensorflow/compiler/jit/pjrt_device_context.h
+++ b/tensorflow/compiler/jit/pjrt_device_context.h
@@ -34,7 +34,8 @@ class PjRtDeviceContext : public DeviceContext {
 
   void CopyCPUTensorToDevice(const Tensor* cpu_tensor, Device* device,
                              Tensor* device_tensor, StatusCallback done,
-                             bool sync_dst_compute) const override;
+                             bool sync_dst_compute,
+                             bool sync_dst_recv = true) const override;
   void CopyDeviceTensorToCPU(const Tensor* device_tensor,
                              absl::string_view tensor_name, Device* device,
                              Tensor* cpu_tensor, StatusCallback done) override;

--- a/tensorflow/compiler/jit/xla_device_context.cc
+++ b/tensorflow/compiler/jit/xla_device_context.cc
@@ -110,11 +110,9 @@ void XlaDeviceContext::CopyTensorInSameDevice(const Tensor* input_tensor,
   done(errors::Unimplemented("XLA->XLA same-device copies not implemented."));
 }
 
-void XlaDeviceContext::CopyCPUTensorToDevice(const Tensor* cpu_tensor,
-                                             Device* device,
-                                             Tensor* device_tensor,
-                                             StatusCallback done,
-                                             bool sync_dst_compute) const {
+void XlaDeviceContext::CopyCPUTensorToDevice(
+    const Tensor* cpu_tensor, Device* device, Tensor* device_tensor,
+    StatusCallback done, bool sync_dst_compute, bool sync_dst_recv) const {
   if (cpu_tensor->NumElements() == 0) {
     VLOG(2) << "CopyCPUTensorToDevice empty tensor";
     done(OkStatus());

--- a/tensorflow/compiler/jit/xla_device_context.h
+++ b/tensorflow/compiler/jit/xla_device_context.h
@@ -64,7 +64,8 @@ class XlaDeviceContext : public DeviceContext {
 
   void CopyCPUTensorToDevice(const Tensor* cpu_tensor, Device* device,
                              Tensor* device_tensor, StatusCallback done,
-                             bool sync_dst_compute) const override;
+                             bool sync_dst_compute,
+                             bool sync_dst_recv = true) const override;
   void CopyDeviceTensorToCPU(const Tensor* device_tensor,
                              absl::string_view tensor_name, Device* device,
                              Tensor* cpu_tensor, StatusCallback done) override;

--- a/tensorflow/core/common_runtime/copy_tensor.h
+++ b/tensorflow/core/common_runtime/copy_tensor.h
@@ -46,7 +46,7 @@ class CopyTensor {
                      const AllocatorAttributes dst_alloc_attr,
                      const Tensor* input, Tensor* output,
                      int dev_to_dev_stream_index, StatusCallback done,
-                     bool sync_dst_compute = true);
+                     bool sync_dst_compute = true, bool sync_dst_recv = true);
 
   // Object used to call Register() at static-initialization time.
   // Note: This should only ever be used as a global-static object; no stack

--- a/tensorflow/core/common_runtime/direct_session.cc
+++ b/tensorflow/core/common_runtime/direct_session.cc
@@ -669,6 +669,7 @@ Status DirectSession::RunInternal(
   args.run_all_kernels_inline = pool == nullptr;
   args.start_time_usecs = start_time_usecs;
   args.deadline = deadline;
+  args.tensor_holder = &run_state.tensor_holder;
 
   const bool do_trace = (run_options.trace_level() > RunOptions::NO_TRACE);
 
@@ -1015,6 +1016,7 @@ Status DirectSession::PRunSetup(const std::vector<string>& input_names,
   args.session_handle = session_handle_;
   args.tensor_store = &run_state->tensor_store;
   args.step_container = &run_state->step_container;
+  args.tensor_holder = &run_state->tensor_holder;
   if (LogMemory::IsEnabled()) {
     LogMemory::RecordStep(args.step_id, run_state_args.handle);
   }

--- a/tensorflow/core/common_runtime/direct_session.h
+++ b/tensorflow/core/common_runtime/direct_session.h
@@ -203,6 +203,7 @@ class DirectSession : public Session {
     std::unique_ptr<StepStatsCollector> collector;
     TensorStore tensor_store;
     ScopedStepContainer step_container;
+    TensorHolder tensor_holder;
 
     RunState(int64_t step_id, const std::vector<Device*>* devices);
   };

--- a/tensorflow/core/common_runtime/executor.h
+++ b/tensorflow/core/common_runtime/executor.h
@@ -123,6 +123,7 @@ class Executor {
     // If true, all kernels will be treated as "inexpensive", and hence executed
     // on the scheduling thread.
     bool run_all_kernels_inline = false;
+    TensorHolder* tensor_holder = nullptr;
   };
   typedef std::function<void(const Status&)> DoneCallback;
   virtual void RunAsync(const Args& args, DoneCallback done) = 0;

--- a/tensorflow/core/common_runtime/function.cc
+++ b/tensorflow/core/common_runtime/function.cc
@@ -1034,6 +1034,7 @@ void FunctionLibraryRuntimeImpl::ExecutorArgsFromOptions(
   exec_args->user_intra_op_threadpool = run_opts.user_intra_op_threadpool;
   exec_args->coordination_service_agent = run_opts.coordination_service_agent;
   exec_args->stack_trace = run_opts.stack_trace;
+  exec_args->tensor_holder = run_opts.tensor_holder;
 }
 
 void FunctionLibraryRuntimeImpl::RunRemote(const Options& opts, Handle handle,

--- a/tensorflow/core/common_runtime/gpu/gpu_util.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_util.cc
@@ -38,6 +38,7 @@ limitations under the License.
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/platform/tensor_coding.h"
 #include "tensorflow/core/profiler/lib/scoped_annotation.h"
+#include "tensorflow/core/util/env_var.h"
 #include "tensorflow/core/util/util.h"
 
 // IMPLEMENTATION NOTE:
@@ -282,15 +283,26 @@ void GPUUtil::CopyGPUTensorToCPU(Device* gpu_device,
     return;
   }
 
-  auto send_device_to_host_stream =
-      static_cast<const GPUDeviceContext*>(device_context)
-          ->device_to_host_stream();
-  if (send_device_to_host_stream == nullptr) {
-    done(errors::Internal("No send gpu copy-out-stream is available."));
-    return;
+  static const bool gpu_stream_merge = [] {
+    bool gpu_stream_merge;
+    TF_CHECK_OK(ReadBoolFromEnvVar("TF_GPU_STREAM_MERGE",
+                                   /*default_val=*/false, &gpu_stream_merge));
+    return gpu_stream_merge;
+  }();
+  se::Stream* send_device_to_host_stream = nullptr;
+  if (gpu_stream_merge) {
+    send_device_to_host_stream = send_stream;
+  } else {
+    send_device_to_host_stream =
+        static_cast<const GPUDeviceContext*>(device_context)
+            ->device_to_host_stream();
+    if (send_device_to_host_stream == nullptr) {
+      done(errors::Internal("No send gpu copy-out-stream is available."));
+      return;
+    }
+    // Wait for the sender's main stream to make sure the data are available.
+    send_device_to_host_stream->ThenWaitFor(send_stream);
   }
-  // Wait for the sender's main stream to make sure the data are available.
-  send_device_to_host_stream->ThenWaitFor(send_stream);
 
   const int64_t total_bytes = gpu_tensor->TotalBytes();
   if (total_bytes > 0) {
@@ -316,7 +328,8 @@ void GPUUtil::CopyGPUTensorToCPU(Device* gpu_device,
 void GPUUtil::CopyCPUTensorToGPU(const Tensor* cpu_tensor,
                                  const DeviceContext* device_context,
                                  Device* gpu_device, Tensor* gpu_tensor,
-                                 StatusCallback done, bool sync_dst_compute) {
+                                 StatusCallback done, bool sync_dst_compute,
+                                 bool sync_dst_recv) {
   VLOG(1) << "CopyCPUTensorToGPU";
   const DeviceBase::AcceleratorDeviceInfo* dev_info = nullptr;
   se::Stream* recv_stream = nullptr;
@@ -327,16 +340,27 @@ void GPUUtil::CopyCPUTensorToGPU(const Tensor* cpu_tensor,
     return;
   }
 
-  auto recv_host_to_device_stream =
-      static_cast<const GPUDeviceContext*>(device_context)
-          ->host_to_device_stream();
-  if (recv_host_to_device_stream == nullptr) {
-    done(errors::Internal("No send gpu copy-out-stream is available."));
-    return;
-  }
-  // Wait for the recv-stream to make sure the buffer is truly available.
-  if (sync_dst_compute) {
-    recv_host_to_device_stream->ThenWaitFor(recv_stream);
+  static const bool gpu_stream_merge = [] {
+    bool gpu_stream_merge;
+    TF_CHECK_OK(ReadBoolFromEnvVar("TF_GPU_STREAM_MERGE",
+                                   /*default_val=*/false, &gpu_stream_merge));
+    return gpu_stream_merge;
+  }();
+  se::Stream* recv_host_to_device_stream = nullptr;
+  if (gpu_stream_merge) {
+    recv_host_to_device_stream = recv_stream;
+  } else {
+    recv_host_to_device_stream =
+        static_cast<const GPUDeviceContext*>(device_context)
+            ->host_to_device_stream();
+    if (recv_host_to_device_stream == nullptr) {
+      done(errors::Internal("No send gpu copy-out-stream is available."));
+      return;
+    }
+    // Wait for the recv-stream to make sure the buffer is truly available.
+    if (sync_dst_compute) {
+      recv_host_to_device_stream->ThenWaitFor(recv_stream);
+    }
   }
 
   const int64_t total_bytes = cpu_tensor->TotalBytes();
@@ -378,20 +402,25 @@ void GPUUtil::CopyCPUTensorToGPU(const Tensor* cpu_tensor,
     }
   }
 
-  dev_info->event_mgr->ThenExecute(
-      recv_host_to_device_stream,
-      [recv_host_to_device_stream, done, input_ref, do_staging, staging_buffer,
-       host_memory_allocator]() {
-        if (do_staging) {
-          host_memory_allocator->DeallocateRaw(staging_buffer);
-        } else {
-          input_ref.Unref();
-        }
-        if (!recv_host_to_device_stream->ok()) {
-          LOG(FATAL) << "CPU->GPU Memcpy failed";
-        }
-        done(OkStatus());
-      });
+  if (gpu_stream_merge && !sync_dst_recv && !do_staging) {
+    input_ref.Unref();
+    done(OkStatus());
+  } else {
+    dev_info->event_mgr->ThenExecute(
+        recv_host_to_device_stream,
+        [recv_host_to_device_stream, done, input_ref, do_staging,
+         staging_buffer, host_memory_allocator]() {
+          if (do_staging) {
+            host_memory_allocator->DeallocateRaw(staging_buffer);
+          } else {
+            input_ref.Unref();
+          }
+          if (!recv_host_to_device_stream->ok()) {
+            LOG(FATAL) << "CPU->GPU Memcpy failed";
+          }
+          done(OkStatus());
+        });
+  }
 }
 
 Status GPUUtil::Sync(Device* gpu_device) {

--- a/tensorflow/core/common_runtime/gpu/gpu_util.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_util.h
@@ -88,7 +88,8 @@ class GPUUtil {
   static void CopyCPUTensorToGPU(const Tensor* cpu_tensor,
                                  const DeviceContext* device_context,
                                  Device* gpu_device, Tensor* gpu_tensor,
-                                 StatusCallback done, bool sync_dst_compute);
+                                 StatusCallback done, bool sync_dst_compute,
+                                 bool sync_dst_recv = true);
 
   static void DeviceToDeviceCopy(
       DeviceContext* send_dev_context, DeviceContext* recv_dev_context,

--- a/tensorflow/core/common_runtime/gpu/gpu_util_platform_specific.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_util_platform_specific.cc
@@ -23,13 +23,11 @@ limitations under the License.
 
 namespace tensorflow {
 
-void GPUDeviceContext::CopyCPUTensorToDevice(const Tensor* cpu_tensor,
-                                             Device* device,
-                                             Tensor* device_tensor,
-                                             StatusCallback done,
-                                             bool sync_dst_compute) const {
+void GPUDeviceContext::CopyCPUTensorToDevice(
+    const Tensor* cpu_tensor, Device* device, Tensor* device_tensor,
+    StatusCallback done, bool sync_dst_compute, bool sync_dst_recv) const {
   GPUUtil::CopyCPUTensorToGPU(cpu_tensor, this, device, device_tensor, done,
-                              sync_dst_compute);
+                              sync_dst_compute, sync_dst_recv);
 }
 
 void GPUDeviceContext::CopyDeviceTensorToCPU(const Tensor* device_tensor,

--- a/tensorflow/core/common_runtime/gpu_device_context.h
+++ b/tensorflow/core/common_runtime/gpu_device_context.h
@@ -66,7 +66,8 @@ class GPUDeviceContext : public DeviceContext {
 
   void CopyCPUTensorToDevice(const Tensor* cpu_tensor, Device* device,
                              Tensor* device_tensor, StatusCallback done,
-                             bool sync_dst_compute) const override;
+                             bool sync_dst_compute,
+                             bool sync_dst_recv = true) const override;
 
   void CopyDeviceTensorToCPU(const Tensor* device_tensor, StringPiece edge_name,
                              Device* device, Tensor* cpu_tensor,

--- a/tensorflow/core/common_runtime/graph_view.h
+++ b/tensorflow/core/common_runtime/graph_view.h
@@ -85,6 +85,8 @@ struct NodeItem {
                                     // node's input types.
   bool is_distributed_communication : 1;  // True iff the op is registered to
                                           // use distributed communication.
+  bool is_send_to_gpu : 1;  // True iff IsSend(node) and the receive device is
+                            // GPU.
 
   // The kernel for this node.
   OpKernel* kernel = nullptr;

--- a/tensorflow/core/common_runtime/immutable_executor_state.cc
+++ b/tensorflow/core/common_runtime/immutable_executor_state.cc
@@ -196,6 +196,12 @@ Status ImmutableExecutorState::Initialize(const Graph& graph) {
     item->is_recv_or_switch = IsRecv(n) || IsSwitch(n);
     item->is_next_iteration = IsNextIteration(n);
     item->is_distributed_communication = IsDistributedCommunication(n);
+    item->is_send_to_gpu = false;
+    if (IsSend(n)) {
+      string recv_device;
+      TF_RETURN_IF_ERROR(GetNodeAttr(n->attrs(), "recv_device", &recv_device));
+      item->is_send_to_gpu = recv_device.find("GPU") != string::npos;
+    }
 
     // Compute the maximum values we'll store for this node in the
     // pending counts data structure, and allocate a handle in

--- a/tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_context.cc
+++ b/tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_context.cc
@@ -101,7 +101,7 @@ void NextPluggableDeviceContext::CopyDeviceTensorToCPU(
 
 void NextPluggableDeviceContext::CopyCPUTensorToDevice(
     const Tensor* cpu_tensor, Device* device, Tensor* device_tensor,
-    StatusCallback done, bool sync_dst_compute) const {
+    StatusCallback done, bool sync_dst_compute, bool sync_dst_recv) const {
   profiler::TraceMeProducer traceme(
       [] { return "NextPluggableDeviceContext::CopyCPUTensorToDevice"; },
       profiler::ContextType::kGeneric);

--- a/tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_context.h
+++ b/tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_context.h
@@ -34,7 +34,8 @@ class NextPluggableDeviceContext : public DeviceContext {
 
   void CopyCPUTensorToDevice(const Tensor* cpu_tensor, Device* device,
                              Tensor* device_tensor, StatusCallback done,
-                             bool sync_dst_compute) const override;
+                             bool sync_dst_compute,
+                             bool sync_dst_recv = true) const override;
   void CopyDeviceTensorToCPU(const Tensor* device_tensor,
                              absl::string_view tensor_name, Device* device,
                              Tensor* cpu_tensor, StatusCallback done) override;

--- a/tensorflow/core/common_runtime/pluggable_device/pluggable_device_context.cc
+++ b/tensorflow/core/common_runtime/pluggable_device/pluggable_device_context.cc
@@ -26,7 +26,7 @@ namespace tensorflow {
 
 void PluggableDeviceContext::CopyCPUTensorToDevice(
     const Tensor* cpu_tensor, Device* device, Tensor* device_tensor,
-    StatusCallback done, bool sync_dst_compute) const {
+    StatusCallback done, bool sync_dst_compute, bool sync_dst_recv) const {
   PluggableDeviceUtil::CopyCPUTensorToPluggableDevice(
       cpu_tensor, this, device, device_tensor, done, sync_dst_compute);
 }

--- a/tensorflow/core/common_runtime/pluggable_device/pluggable_device_context.h
+++ b/tensorflow/core/common_runtime/pluggable_device/pluggable_device_context.h
@@ -51,7 +51,8 @@ class PluggableDeviceContext : public DeviceContext {
 
   void CopyCPUTensorToDevice(const Tensor* cpu_tensor, Device* device,
                              Tensor* device_tensor, StatusCallback done,
-                             bool sync_dst_compute) const override;
+                             bool sync_dst_compute,
+                             bool sync_dst_recv = true) const override;
 
   void CopyDeviceTensorToCPU(const Tensor* device_tensor,
                              StringPiece tensor_name, Device* device,

--- a/tensorflow/core/common_runtime/rendezvous_mgr.cc
+++ b/tensorflow/core/common_runtime/rendezvous_mgr.cc
@@ -123,10 +123,11 @@ void SameWorkerRecvDone(const DeviceMgr* device_mgr,
     }
   }
 
-  CopyTensor::ViaDMA(
-      parsed.edge_name, send_args.device_context, recv_args.device_context,
-      src_device, dst_device, send_args.alloc_attrs, recv_args.alloc_attrs, &in,
-      out, 0 /*dev_to_dev_stream_index*/, std::move(done), sync_dst_compute);
+  CopyTensor::ViaDMA(parsed.edge_name, send_args.device_context,
+                     recv_args.device_context, src_device, dst_device,
+                     send_args.alloc_attrs, recv_args.alloc_attrs, &in, out,
+                     0 /*dev_to_dev_stream_index*/, std::move(done),
+                     sync_dst_compute, false);
 }
 
 void IntraProcessRecvAsyncImpl(const DeviceMgr* device_mgr,

--- a/tensorflow/core/framework/device_base.h
+++ b/tensorflow/core/framework/device_base.h
@@ -80,7 +80,8 @@ class DeviceContext : public core::RefCounted {
   // must be allocated to be of the same size as "cpu_tensor".
   virtual void CopyCPUTensorToDevice(const Tensor* cpu_tensor, Device* device,
                                      Tensor* device_tensor, StatusCallback done,
-                                     bool sync_dst_compute = true) const {
+                                     bool sync_dst_compute = true,
+                                     bool sync_dst_recv = true) const {
     done(errors::Internal("Unrecognized device type in CPU-to-device Copy"));
   }
 

--- a/tensorflow/core/framework/function.h
+++ b/tensorflow/core/framework/function.h
@@ -938,6 +938,9 @@ class FunctionLibraryRuntime {
     // If not null, use this thread pool for intra op scheduling.
     thread::ThreadPoolInterface* user_intra_op_threadpool = nullptr;
 
+    // To hold some CPU tensors until session run finish.
+    TensorHolder* tensor_holder = nullptr;
+
     // Returns a human readable representation of this.
     std::string DebugString() const;
   };

--- a/tensorflow/core/framework/op_kernel.cc
+++ b/tensorflow/core/framework/op_kernel.cc
@@ -329,6 +329,19 @@ Status OpKernelConstruction::allocate_temp(DataType type,
   return OkStatus();
 }
 
+void TensorHolder::AddTensor(const Tensor& tensor) {
+  mutex_lock l(lock_);
+  tensors_.push_back(absl::make_unique<TensorReference>(tensor));
+}
+
+TensorHolder::~TensorHolder() {
+  mutex_lock l(lock_);
+  VLOG(3) << "Tensors to delete: " << tensors_.size();
+  for (auto& ref : tensors_) {
+    ref->Unref();
+  }
+}
+
 // OpKernelContext -----------------------------------------------------------
 
 const int OpKernelContext::Params::kNeverForward;

--- a/tensorflow/core/kernels/partitioned_function_ops.cc
+++ b/tensorflow/core/kernels/partitioned_function_ops.cc
@@ -254,6 +254,7 @@ void PartitionedCallOp::RunFunction(FunctionLibraryRuntime::Handle handle,
   if (shared_rendezvous_) {
     run_opts.rendezvous = ctx->rendezvous();
   }
+  run_opts.tensor_holder = ctx->tensor_holder();
 
   std::vector<Tensor>* rets = new std::vector<Tensor>;
   const string& func_name = func_->name();

--- a/tensorflow/core/tpu/virtual_device.cc
+++ b/tensorflow/core/tpu/virtual_device.cc
@@ -26,7 +26,8 @@ class VirtualDeviceContext : public DeviceContext {
 
   void CopyCPUTensorToDevice(const Tensor* cpu_tensor, Device* device,
                              Tensor* device_tensor, StatusCallback done,
-                             bool sync_dst_compute) const override;
+                             bool sync_dst_compute,
+                             bool sync_dst_recv = true) const override;
   void CopyDeviceTensorToCPU(const Tensor* device_tensor,
                              StringPiece tensor_name, Device* device,
                              Tensor* cpu_tensor, StatusCallback done) override;
@@ -35,11 +36,9 @@ class VirtualDeviceContext : public DeviceContext {
                               StatusCallback done) const override;
 };
 
-void VirtualDeviceContext::CopyCPUTensorToDevice(const Tensor* cpu_tensor,
-                                                 Device* device,
-                                                 Tensor* device_tensor,
-                                                 StatusCallback done,
-                                                 bool sync_dst_compute) const {
+void VirtualDeviceContext::CopyCPUTensorToDevice(
+    const Tensor* cpu_tensor, Device* device, Tensor* device_tensor,
+    StatusCallback done, bool sync_dst_compute, bool sync_dst_recv) const {
   *device_tensor = *cpu_tensor;
   done(OkStatus());
 }


### PR DESCRIPTION
This works as one part of the whole multi-stream feature, which is proposed in this [PR](https://github.com/tensorflow/tensorflow/pull/59843), but can also be used independently.

In TensorFlow, there are at least three streams in one stream group: 1 compute stream, 1 h2d stream, and 1 d2h stream. This is designed to overlap the computation and memory copy on GPU. However, for some copy-frequent and launch-bound models, there are significant stream-synchronization overhead caused by the frequent switching between the three kinds of streams. So, let the operations use the same stream may bring acceleration. This PR provides an option to do so, just by setting the environment variable `TF_GPU_STREAM_MERGE=true`.