### PR TITLE
Fixed build failure on Power

### DIFF
--- a/third_party/jpeg/jpeg.BUILD
+++ b/third_party/jpeg/jpeg.BUILD
@@ -142,6 +142,7 @@ cc_library(
     srcs = [
         "jchuff.h",
         "jconfig.h",
+        "jconfigint.h",
         "jdct.h",
         "jerror.h",
         "jinclude.h",


### PR DESCRIPTION
This change is needed to fix builds on Linux Power. 
Error was seen while building TF 2.12 on Power. Same error is also encountered when TF IO 0.32 and TF text 2.12 are built as they also use Tensorflow 2.12 during their build.