### PR TITLE
Divert calls to MklMatMulOp into BatchMatMulMkl for aarch64

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
@@ -49,8 +49,23 @@ template <typename Device, typename Tlhs, typename Trhs, typename Toutput,
 class BatchMatMulMkl : public OpKernel {
  public:
   explicit BatchMatMulMkl(OpKernelConstruction* context) : OpKernel(context) {
-    OP_REQUIRES_OK(context, context->GetAttr("adj_x", &adj_x_));
-    OP_REQUIRES_OK(context, context->GetAttr("adj_y", &adj_y_));
+    if (context && context->HasAttr("transpose_a")) {
+      // This is needed for using BatchMatMulMkl as the super class of
+      // MklMatMulOp (below) whose context has a transpose_a attribute which is
+      // effectively the same as adj_x_
+      OP_REQUIRES_OK(context, context->GetAttr("transpose_a", &adj_x_));
+    } else {
+      OP_REQUIRES_OK(context, context->GetAttr("adj_x", &adj_x_));
+    }
+
+    if (context && context->HasAttr("transpose_b")) {
+      // This is needed for using BatchMatMulMkl as the super class of
+      // MklMatMulOp (below) whose context has a transpose_b attribute which is
+      // effectively the same as adj_y_
+      OP_REQUIRES_OK(context, context->GetAttr("transpose_b", &adj_y_));
+    } else {
+      OP_REQUIRES_OK(context, context->GetAttr("adj_y", &adj_y_));
+    }
   }
 
   virtual ~BatchMatMulMkl() {}
@@ -310,6 +325,29 @@ class FusedBatchMatMulMkl
   }
 };
 
+// Direct calls for MklMatMulOp to BatchMatMulMkl for aarch64,
+// because the Arm Compute Library does not provide a BLAS SGEMM
+// interface, which is what MklMatMulOp calls by default.
+#ifdef DNNL_AARCH64_USE_ACL
+template <typename Device, typename T, bool USE_CUBLAS>
+class MklMatMulOp : public BatchMatMulMkl<Device, T, T, T, USE_CUBLAS> {
+ public:
+  explicit MklMatMulOp(OpKernelConstruction* ctx)
+      : BatchMatMulMkl<Device, T, T, T, false>(ctx) {}
+
+  virtual ~MklMatMulOp() {}
+};
+
+#define REGISTER_MATMUL_MKL(TYPE)                         \
+  REGISTER_KERNEL_BUILDER(                                \
+      Name("_MklMatMul")                                  \
+          .Device(DEVICE_CPU)                             \
+          .TypeConstraint<TYPE>("T")                      \
+          .Label(mkl_op_registry::kMklNameChangeOpLabel), \
+      MklMatMulOp<CPUDevice, TYPE, false /* cublas, ignored for CPU */>);
+
+#endif  // DNNL_AARCH64_USE_ACL
+
 #define REGISTER_BATCH_MATMUL_MKL(TYPE)                                       \
   REGISTER_KERNEL_BUILDER(Name("_MklBatchMatMul")                             \
                               .Device(DEVICE_CPU)                             \
@@ -337,6 +375,11 @@ TF_CALL_float(REGISTER_FUSED_BATCH_MATMUL_MKL);
 TF_CALL_bfloat16(REGISTER_BATCH_MATMUL_MKL);
 TF_CALL_bfloat16(REGISTER_BATCH_MATMUL_MKL_V2);
 TF_CALL_bfloat16(REGISTER_FUSED_BATCH_MATMUL_MKL);
+
+#ifdef DNNL_AARCH64_USE_ACL
+TF_CALL_float(REGISTER_MATMUL_MKL);
+TF_CALL_bfloat16(REGISTER_MATMUL_MKL);
+#endif  // DNNL_AARCH64_USE_ACL
 
 }  // end namespace tensorflow
 #endif  // INTEL_MKL && !ENABLE_ONEDNN_V3

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op.cc
@@ -195,6 +195,10 @@ class MklMatMulOp : public OpKernel {
   }
 };
 
+// We do not want to use this kernel for aarch64 because the
+// Arm Compute Library does not provide a BLAS SGEMM
+// interface, which is what MklMatMulOp calls by default.
+#ifndef DNNL_AARCH64_USE_ACL
 #define REGISTER_CPU(T)                                   \
   REGISTER_KERNEL_BUILDER(                                \
       Name("_MklMatMul")                                  \
@@ -207,5 +211,7 @@ class MklMatMulOp : public OpKernel {
 // additional types
 TF_CALL_float(REGISTER_CPU);
 TF_CALL_bfloat16(REGISTER_CPU);
+#endif  // !DNNL_AARCH64_USE_ACL
+
 }  // namespace tensorflow
 #endif  // INTEL_MKL && !ENABLE_ONEDNN_V3


### PR DESCRIPTION
We observed that for most transformer models, the MklLMatMulOp node in tensorflow gets called. This operation requires an SGEMM BLAS interface which is not supported by the Arm Compute Library (ACL). Hence, when running with TF_ENABLE_ONEDNN_OPTS=1, the sub-optimal gemm_api kernels are used in oneDNN (instead of the ACL ones). 
Here, we divert calls to MklMatMulOp into BatchMatMulMkl for aarch64 which allows the ACL kernels to be used when running with TF_ENABLE_ONEDNN_OPTS=1 (rather than the gemm_api ones).

This shows the speedups gained with this RP for a range of transformer models using 8 intra threads and a sequence length of 128:
![speedup8threads](https://user-images.githubusercontent.com/115173828/232843136-a258cd08-5388-46a4-8e4f-9b81aa8de57b.png)

And this is with 16 threads and also 128 for sequence length:
![speedup16threads](https://user-images.githubusercontent.com/115173828/232843331-86ceaa15-721d-43c3-a477-35bf58d7696d.png)
