### PR TITLE
Big-endian saved_model byte swapping improvements

### DIFF
--- a/tensorflow/compiler/mlir/quantization/tensorflow/python/save_model.py
+++ b/tensorflow/compiler/mlir/quantization/tensorflow/python/save_model.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 """Defines utilities involving SavedModel."""
+import sys
+
 from typing import Collection, Dict, Mapping, Optional, Sequence
 
 from absl import logging
@@ -24,6 +26,7 @@ from tensorflow.core.framework import graph_pb2
 from tensorflow.core.protobuf import meta_graph_pb2
 from tensorflow.core.protobuf import saver_pb2
 from tensorflow.python.client import session
+from tensorflow.python.framework import byte_swap_tensor
 from tensorflow.python.framework import importer
 from tensorflow.python.framework import ops
 from tensorflow.python.lib.io import file_io
@@ -254,6 +257,10 @@ def _save_function_alias(
     meta_graph_def.meta_info_def.function_aliases[function_name] = (
         function_alias
     )
+
+  if sys.byteorder == "big":
+    byte_swap_tensor.swap_tensor_content_in_saved_model(loader.saved_model,
+                                                        "big", "little")
 
   saved_model_proto_serialized = loader.saved_model.SerializeToString()
 

--- a/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
+++ b/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
@@ -202,17 +202,20 @@ Status ByteSwapTensorContentInNode(NodeDef& node) {
 }
 
 Status ByteSwapTensorContentInMetaGraphDef(MetaGraphDef* meta_graph_def) {
-  for (auto& function : *meta_graph_def->mutable_graph_def()
-                             ->mutable_library()
-                             ->mutable_function())
-    for (auto& node : (*function.mutable_node_def()))
-      TF_RETURN_IF_ERROR(ByteSwapTensorContentInNode(node));
+  auto graph_def = meta_graph_def->mutable_graph_def();
+  TF_RETURN_IF_ERROR(ByteSwapTensorContentInGraphDef(graph_def));
   return absl::OkStatus();
 }
 
 Status ByteSwapTensorContentInGraphDef(GraphDef* graph_def) {
   for (auto& node : *graph_def->mutable_node())
     TF_RETURN_IF_ERROR(ByteSwapTensorContentInNode(node));
+
+  for (auto& function : *graph_def->mutable_library()
+                             ->mutable_function())
+    for (auto& node : (*function.mutable_node_def()))
+      TF_RETURN_IF_ERROR(ByteSwapTensorContentInNode(node));
+
   return absl::OkStatus();
 }
 

--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -3122,8 +3122,8 @@ class TFLiteConverter(TFLiteFrozenGraphConverter):
                 "Unable to parse input file '{}'.".format(graph_def_file)
             )
 
-        if sys.byteorder == "big":
-          bst.swap_tensor_content_in_graph_node(graph_def, "little", "big")
+        if sys.byteorder == 'big':
+          bst.swap_tensor_content_in_graph(graph_def, "little", "big")
 
         # Handles models with custom TFLite ops that cannot be resolved in
         # TensorFlow.

--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -1088,7 +1088,8 @@ class TFLiteConverterBase:
 
     if quant_mode.is_quantization_aware_training():
       self._metadata.options.modelOptimizationModes.append(
-          conversion_metadata_fb.ModelOptimizationMode.QUANTIZATION_AWARE_TRAINING
+          conversion_metadata_fb.ModelOptimizationMode
+          .QUANTIZATION_AWARE_TRAINING
       )
 
   def _set_conversion_latency_metric(self, value):

--- a/tensorflow/python/framework/graph_io.py
+++ b/tensorflow/python/framework/graph_io.py
@@ -61,14 +61,8 @@ def write_graph(graph_or_graph_def, logdir, name, as_text=True):
     graph_def = graph_or_graph_def
 
   if sys.byteorder == 'big':
-    if hasattr(graph_def, 'node'):
-      byte_swap_tensor.swap_tensor_content_in_graph_node(
-          graph_def, 'big', 'little'
-      )
-    else:
-      byte_swap_tensor.swap_tensor_content_in_graph_function(
-          graph_def, 'big', 'little'
-      )
+    byte_swap_tensor.swap_tensor_content_in_graph(graph_def,
+                                                  "big", "little")
 
   # gcs does not have the concept of directory at the moment.
   if not logdir.startswith('gs:'):
@@ -81,4 +75,8 @@ def write_graph(graph_or_graph_def, logdir, name, as_text=True):
   else:
     file_io.atomic_write_string_to_file(
         path, graph_def.SerializeToString(deterministic=True))
+
+  if sys.byteorder == 'big':
+    byte_swap_tensor.swap_tensor_content_in_graph(graph_def,
+                                                  "little", "big")
   return path

--- a/tensorflow/python/framework/meta_graph.py
+++ b/tensorflow/python/framework/meta_graph.py
@@ -614,8 +614,9 @@ def read_meta_graph_file(filename):
     file_content = f.read()
   try:
     meta_graph_def.ParseFromString(file_content)
-    if sys.byteorder == "big":
-      bst.swap_tensor_content_in_graph_function(meta_graph_def, "little", "big")
+    if sys.byteorder == 'big':
+      bst.swap_tensor_content_in_graph(meta_graph_def,
+        "little", "big")
     return meta_graph_def
   except Exception:  # pylint: disable=broad-except
     pass
@@ -623,8 +624,9 @@ def read_meta_graph_file(filename):
   # Next try to read it as a text file.
   try:
     text_format.Merge(file_content.decode("utf-8"), meta_graph_def)
-    if sys.byteorder == "big":
-      bst.swap_tensor_content_in_graph_function(meta_graph_def, "little", "big")
+    if sys.byteorder == 'big':
+      bst.swap_tensor_content_in_graph(meta_graph_def,
+        "little", "big")
   except text_format.ParseError as e:
     raise IOError(f"Cannot parse file {filename}: {str(e)}.")
 

--- a/tensorflow/python/saved_model/load.py
+++ b/tensorflow/python/saved_model/load.py
@@ -17,7 +17,6 @@
 import collections
 import functools
 import os
-import sys
 
 from absl import logging
 
@@ -53,7 +52,6 @@ from tensorflow.python.saved_model import loader_impl
 from tensorflow.python.saved_model import path_helpers
 from tensorflow.python.saved_model import registration
 from tensorflow.python.saved_model import revived_types
-from tensorflow.python.saved_model import utils_impl as saved_model_utils
 from tensorflow.python.saved_model.pywrap_saved_model import metrics
 from tensorflow.python.trackable import asset
 from tensorflow.python.trackable import autotrackable
@@ -1020,12 +1018,6 @@ def load_partial(export_dir, filters, tags=None, options=None):
       saved_model_proto.meta_graphs[0].HasField("object_graph_def")):
     metrics.IncrementReadApi(_LOAD_V2_LABEL)
     meta_graph_def = saved_model_proto.meta_graphs[0]
-    # tensor_content field contains raw bytes in litle endian format
-    # which causes problems when loaded on big-endian systems
-    # requiring byteswap
-    if sys.byteorder == "big":
-      saved_model_utils.swap_function_tensor_content(meta_graph_def, "little",
-                                                     "big")
     if (tags is not None
         and set(tags) != set(meta_graph_def.meta_info_def.tags)):
       raise ValueError(

--- a/tensorflow/python/saved_model/loader_impl.py
+++ b/tensorflow/python/saved_model/loader_impl.py
@@ -24,6 +24,7 @@ from google.protobuf import text_format
 from tensorflow.core.framework import graph_debug_info_pb2
 from tensorflow.core.protobuf import meta_graph_pb2
 from tensorflow.core.protobuf import saved_model_pb2
+from tensorflow.python.framework import byte_swap_tensor
 from tensorflow.python.framework import ops
 from tensorflow.python.lib.io import file_io
 from tensorflow.python.ops import variables
@@ -31,7 +32,6 @@ from tensorflow.python.platform import tf_logging
 from tensorflow.python.saved_model import constants
 from tensorflow.python.saved_model import path_helpers
 from tensorflow.python.saved_model import signature_def_utils
-from tensorflow.python.saved_model import utils_impl as saved_model_utils
 # Placeholder for protosplitter merger import.
 from tensorflow.python.saved_model.pywrap_saved_model import metrics
 from tensorflow.python.training import saver as tf_saver
@@ -120,8 +120,11 @@ def parse_saved_model(export_dir):
         f"SavedModel file does not exist at: {export_dir}{os.path.sep}"
         f"{{{constants.SAVED_MODEL_FILENAME_PBTXT}|"
         f"{constants.SAVED_MODEL_FILENAME_PB}}}")
-  return saved_model
 
+  if sys.byteorder == "big":
+    byte_swap_tensor.swap_tensor_content_in_saved_model(saved_model,
+                                                        "little", "big")
+  return saved_model
 
 def get_asset_tensors(export_dir, meta_graph_def_to_load, import_scope=None):
   """Gets the asset tensors, if defined in the meta graph def to load.
@@ -419,9 +422,6 @@ class SavedModelLoader(object):
           `tf.import_graph_def` (may be `None`).
     """
     meta_graph_def = self.get_meta_graph_def_from_tags(tags)
-    if sys.byteorder == "big":
-      saved_model_utils.swap_function_tensor_content(meta_graph_def, "little",
-                                                     "big")
     with graph.as_default():
       return tf_saver._import_meta_graph_with_return_elements(  # pylint: disable=protected-access
           meta_graph_def, import_scope=import_scope, **saver_kwargs)

--- a/tensorflow/python/saved_model/save.py
+++ b/tensorflow/python/saved_model/save.py
@@ -1052,7 +1052,7 @@ def _fill_meta_graph_def(
   meta_graph.strip_graph_default_valued_attrs(meta_graph_def)
   # store tensor_content in litle endian format
   if sys.byteorder == "big":
-    utils_impl.swap_function_tensor_content(meta_graph_def, "big", "little")
+    utils_impl.swap_tensor_content_in_graph(meta_graph_def, "big", "little")
   if enable_debug_stripper:
     _strip_debug_nodes(meta_graph_def)
   meta_graph_def.meta_info_def.stripped_op_list.MergeFrom(

--- a/tensorflow/python/saved_model/save.py
+++ b/tensorflow/python/saved_model/save.py
@@ -412,7 +412,8 @@ class _SaveableView(object):
     tensor_map = object_identity.ObjectIdentityDictionary()
     asset_info = _AssetInfo(
         asset_defs=[],
-        asset_initializers_by_resource=object_identity.ObjectIdentityDictionary(),
+        asset_initializers_by_resource=
+        object_identity.ObjectIdentityDictionary(),
         asset_filename_map={},
         asset_index={})
 

--- a/tensorflow/python/saved_model/utils_impl.py
+++ b/tensorflow/python/saved_model/utils_impl.py
@@ -207,8 +207,5 @@ def get_element_from_tensor_info(tensor_info, graph=None, import_scope=None):
   return graph.as_graph_element(
       ops.prepend_name_scope(tensor_info.name, import_scope=import_scope))
 
-
-def swap_function_tensor_content(meta_graph_def, from_endiness, to_endiness):
-  bst.swap_tensor_content_in_graph_function(
-      meta_graph_def, from_endiness, to_endiness
-  )
+def swap_tensor_content_in_graph(meta_graph_def, from_endiness, to_endiness):
+  bst.swap_tensor_content_in_graph(meta_graph_def, from_endiness, to_endiness)


### PR DESCRIPTION
Make byte swapping more consistent by always searching for nodes in both function libraries and at the top level.

Undo byte swapping after saving when it is possible that the saved_model in memory could still be used afterward.

Add byte swapping in loader_impl.py close to where loading from file happens and remove byte swapping that is no longer needed.

Add byte swapping when saving saved models in builder_impl.py.