### PR TITLE
[oneDNN v3.x]: Added support for softmax, layernorm, concat and element-wise ops for fp32 and bf16

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -413,13 +413,13 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     rinfo_.push_back({csinfo_.batch_matmul_v2,
                       mkl_op_registry::GetMklOpName(csinfo_.batch_matmul_v2),
                       CopyAttrsAll, MatMulRewrite, kRewriteForOpNameChange});
+#endif  // !ENABLE_ONEDNN_V3
     rinfo_.push_back({csinfo_.concat,
                       mkl_op_registry::GetMklOpName(csinfo_.concat),
                       CopyAttrsAll, AlwaysRewrite, GetRewriteCause()});
     rinfo_.push_back({csinfo_.concatv2,
                       mkl_op_registry::GetMklOpName(csinfo_.concatv2),
                       CopyAttrsAll, ConcatV2Rewrite, GetRewriteCause()});
-#endif  // !ENABLE_ONEDNN_V3
     rinfo_.push_back(
         {csinfo_.conjugate_transpose,
          mkl_op_registry::GetMklOpName(csinfo_.conjugate_transpose),

--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -707,10 +707,12 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     rinfo_.push_back(
         {csinfo_.slice, mkl_op_registry::GetMklOpName(csinfo_.slice),
          CopyAttrsAll, RewriteIfAtleastOneMklInput, GetRewriteCause()});
+#endif  // !ENABLE_ONEDNN_V3
     rinfo_.push_back({csinfo_.softmax,
                       mkl_op_registry::GetMklOpName(csinfo_.softmax),
                       CopyAttrsAll, AlwaysRewrite, GetRewriteCause()});
 
+#ifndef ENABLE_ONEDNN_V3
     rinfo_.push_back({csinfo_.squared_difference,
                       mkl_op_registry::GetMklOpName(csinfo_.squared_difference),
                       CopyAttrsAll, RewriteIfAtleastOneMklInput,

--- a/tensorflow/core/kernels/mkl/mkl_concat_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_concat_op.cc
@@ -10,7 +10,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3)
+#ifdef INTEL_MKL
 #define EIGEN_USE_THREADS
 
 #include <limits>
@@ -40,6 +40,21 @@ using dnnl::concat;
 using dnnl::stream;
 
 namespace tensorflow {
+#ifndef ENABLE_ONEDNN_V3
+#define CONCAT_PRIM_DESC(eng, concat_dims, src_md, dst_md_ptr) \
+  concat::primitive_desc(*dst_md_ptr, concat_dims, src_md, eng)
+#define CONCAT_PRIM_DESC_USING_SRC(eng, concat_dims, src_md) \
+  concat::primitive_desc(concat_dims, src_md, eng)
+#define GET_MEMORY_DESC(md) md.data
+#define SET_MKL_LAYOUT(md) SetMklLayout(&md)
+#else
+#define CONCAT_PRIM_DESC(eng, concat_dims, src_md, dst_md_ptr) \
+  concat::primitive_desc(eng, *dst_md_ptr, concat_dims, src_md)
+#define CONCAT_PRIM_DESC_USING_SRC(eng, concat_dims, src_md) \
+  concat::primitive_desc(eng, concat_dims, src_md)
+#define GET_MEMORY_DESC(md) md
+#define SET_MKL_LAYOUT(md) SetMklLayout(md)
+#endif  // !ENABLE_ONEDNN_V3
 typedef Eigen::ThreadPoolDevice CPUDevice;
 
 // List of TensorShape objects. Used in Concat/Split layers.
@@ -287,7 +302,7 @@ class MklConcatFwdPrimitive : public MklPrimitive {
 #endif
     DCHECK_EQ(in_data.size(), context_.data_mem.size());
     for (size_t i = 0; i < concat_fwd_dims.num_inputs; i++) {
-#ifndef ENABLE_ONEDNN_OPENMP
+#if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)
       context_.data_mem_shdptr[i]->set_data_handle(
           static_cast<void*>(in_data[i].get_data_handle()), *fwd_stream);
     }
@@ -299,7 +314,7 @@ class MklConcatFwdPrimitive : public MklPrimitive {
     }
     context_.dst_mem->set_data_handle(
         static_cast<void*>(dst_data.get_data_handle()));
-#endif  // !ENABLE_ONEDNN_OPENMP
+#endif  // !ENABLE_ONEDNN_OPENMP && !ENABLE_ONEDNN_V3
 
     for (size_t i = 0; i < concat_fwd_dims.num_inputs; i++) {
       context_.data_mem[i] = *context_.data_mem_shdptr[i];
@@ -349,7 +364,7 @@ class MklConcatFwdPrimitive : public MklPrimitive {
              const std::vector<memory::desc>& srcs_md) {
     // Create memory descriptors for concat with specified srcs format
     for (size_t i = 0; i < concat_fwd_dims.num_inputs; i++) {
-      dnnl::memory::desc source_md(memory::desc(srcs_md[i].data));
+      dnnl::memory::desc source_md(memory::desc(GET_MEMORY_DESC(srcs_md[i])));
       context_.src_md.push_back(source_md);
       std::shared_ptr<dnnl::memory> src_mem(
           new dnnl::memory(source_md, cpu_engine_, DummyData));
@@ -361,9 +376,9 @@ class MklConcatFwdPrimitive : public MklPrimitive {
                                            MklDnnType<T>(),
                                            concat_fwd_dims.mkl_common_format));
     // Create a concat primitive descriptor
-    context_.fwd_pd.reset(new concat::primitive_desc(
-        *context_.dst_md, concat_fwd_dims.concat_dims, context_.src_md,
-        cpu_engine_));
+    context_.fwd_pd.reset(
+        new CONCAT_PRIM_DESC(cpu_engine_, concat_fwd_dims.concat_dims,
+                             context_.src_md, context_.dst_md));
 
     // Create memory primitive based on dummy data
     context_.dst_mem.reset(
@@ -648,8 +663,17 @@ class MklConcatOp : public OpKernel {
             auto src_tf_fmt = MklTensorFormatToMklDnnDataFormat(
                 mkl_input_shapes[k].GetTfDataFormat());
             if (src_tf_fmt != mkl_common_format) {
+#ifndef ENABLE_ONEDNN_V3
               memory::dims src_dims(src_md.data.dims,
                                     &src_md.data.dims[src_md.data.ndims]);
+#else
+              memory::dims src_dims;
+              if (src_md.get_ndims() == 2)
+                src_dims = {src_md.get_dims()[0], src_md.get_dims()[1]};
+              else if (src_md.get_ndims() == 4)
+                src_dims = {src_md.get_dims()[0], src_md.get_dims()[1],
+                            src_md.get_dims()[2], src_md.get_dims()[3]};
+#endif  // !ENABLE_ONEDNN_V3
               src_md =
                   memory::desc(src_dims, MklDnnType<T>(), mkl_common_format);
             }
@@ -740,14 +764,14 @@ class MklConcatOp : public OpKernel {
       if (!inputs.empty()) {
         if (are_all_mkl_inputs) {
           auto concat_pd =
-              concat::primitive_desc(concat_dim, srcs_pd, cpu_engine);
+              CONCAT_PRIM_DESC_USING_SRC(cpu_engine, concat_dim, srcs_pd);
           auto dst_pd = concat_pd.dst_desc();
 
           MklDnnShape dnn_shape_dst;
           TensorShape tf_shape_dst;
           Tensor* dst_tensor = nullptr;
           dnn_shape_dst.SetMklTensor(true);
-          dnn_shape_dst.SetMklLayout(&dst_pd);
+          dnn_shape_dst.SET_MKL_LAYOUT(dst_pd);
           dnn_shape_dst.SetElemType(MklDnnType<T>());
           dnn_shape_dst.SetTfLayout(dst_dims.size(), dst_dims_in_nchw,
                                     mkl_input_shapes[0].GetTfDataFormat());
@@ -983,6 +1007,10 @@ REGISTER_QUANTIZED_CONCATV2(quint8);
 REGISTER_QUANTIZED_CONCATV2(qint8);
 
 #undef REGISTER_CONCAT_MKL
+#undef CONCAT_PRIM_DESC
+#undef CONCAT_PRIM_DESC_USING_SRC
+#undef GET_MEMORY_DESC
+#undef SET_MKL_LAYOUT
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_fused_mish_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_mish_op.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 // See docs in ../ops/mkl_nn_ops.cc.
 
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3)
+#ifdef INTEL_MKL
 
 #include "tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h"
 
@@ -72,4 +72,4 @@ TF_CALL_bfloat16(REGISTER_MISH_MKL_SUPPORTED_KERNELS_TYPES);
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_layer_norm_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_layer_norm_op.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3)
+#ifdef INTEL_MKL
 
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "dnnl.hpp"
@@ -74,7 +74,8 @@ class MklLayerNormOp : public OpKernel {
           static_cast<void*>(const_cast<T*>(src_tensor.flat<T>().data()));
       auto src_mem = memory(src_md, cpu_engine, src_buf);
 
-      // oneDNN requires scale-shift as a combined array in float32 type.
+#ifndef ENABLE_ONEDNN_V3
+      // oneDNN v2.x requires scale-shift as a combined array in float32 type.
       memory::dims scale_shift_dims = {
           2, static_cast<dnnl_dim_t>(num_elements_scale)};
       auto scale_shift_md =
@@ -89,15 +90,43 @@ class MklLayerNormOp : public OpKernel {
           static_cast<void*>(scale_shift_tensor.flat<float>().data());
       auto scale_shift_mem =
           memory(scale_shift_md, cpu_engine, scale_shift_buf);
+      void* scale_buf_dst = scale_shift_buf;
+      void* shift_buf_dst = static_cast<char*>(scale_shift_buf) +
+                            sizeof(float) * num_elements_scale;
+#else
+      // oneDNN v3.x requires scale and shift as separate float32 arrays
+      memory::dims scale_shift_dims = {
+          static_cast<dnnl_dim_t>(num_elements_scale)};
+      auto scale_shift_md =
+          memory::desc(static_cast<memory::dims>(scale_shift_dims),
+                       MklDnnType<float>(), memory::format_tag::x);
 
-      // Copy of reorder scale and shift tensor data into scale_shift_tensor.
+      const int64_t scale_shift_tensor_shape =
+          scale_shift_md.get_size() / sizeof(float);
+
+      Tensor scale_buf_tensor;
+      OP_REQUIRES_OK(ctx, ctx->allocate_temp(DataTypeToEnum<float>::v(),
+                                             {scale_shift_tensor_shape},
+                                             &scale_buf_tensor));
+      void* scale_buf_dst =
+          static_cast<void*>(scale_buf_tensor.flat<float>().data());
+      auto scale_mem = memory(scale_shift_md, cpu_engine, scale_buf_dst);
+
+      Tensor shift_buf_tensor;
+      OP_REQUIRES_OK(ctx, ctx->allocate_temp(DataTypeToEnum<float>::v(),
+                                             {scale_shift_tensor_shape},
+                                             &shift_buf_tensor));
+      void* shift_buf_dst =
+          static_cast<void*>(shift_buf_tensor.flat<float>().data());
+      auto shift_mem = memory(scale_shift_md, cpu_engine, shift_buf_dst);
+#endif  // !ENABLE_ONEDNN_V3
+
       void* scale_buf_src =
           static_cast<void*>(const_cast<T*>(scale_tensor.flat<T>().data()));
       auto scale_mem_src = memory({{static_cast<ptrdiff_t>(num_elements_scale)},
                                    MklDnnType<T>(),
                                    memory::format_tag::x},
                                   cpu_engine, scale_buf_src);
-      void* scale_buf_dst = scale_shift_buf;
       auto scale_mem_dst = memory({{static_cast<ptrdiff_t>(num_elements_scale)},
                                    MklDnnType<float>(),
                                    memory::format_tag::x},
@@ -114,8 +143,6 @@ class MklLayerNormOp : public OpKernel {
                                    MklDnnType<T>(),
                                    memory::format_tag::x},
                                   cpu_engine, shift_buf_src);
-      void* shift_buf_dst = static_cast<char*>(scale_shift_buf) +
-                            sizeof(float) * num_elements_scale;
       auto shift_mem_dst = memory({{static_cast<ptrdiff_t>(num_elements_shift)},
                                    MklDnnType<float>(),
                                    memory::format_tag::x},
@@ -127,11 +154,18 @@ class MklLayerNormOp : public OpKernel {
       shift_reorder_prim.execute(*cpu_stream, shift_reorder_args);
 
       // Create layer_normalization primitive
+#ifndef ENABLE_ONEDNN_V3
       auto lnorm_desc = layer_normalization_forward::desc(
           prop_kind::forward_inference, src_md, epsilon_,
           normalization_flags::use_scale_shift);
       auto lnorm_pd =
           layer_normalization_forward::primitive_desc(lnorm_desc, cpu_engine);
+#else
+      auto dst_md = src_md;
+      auto lnorm_pd = layer_normalization_forward::primitive_desc(
+          cpu_engine, prop_kind::forward_inference, src_md, dst_md, epsilon_,
+          normalization_flags::use_scale | normalization_flags::use_shift);
+#endif  // !ENABLE_ONEDNN_V3
       auto lnorm_prim = layer_normalization_forward(lnorm_pd);
 
       // mean and variance memory
@@ -150,7 +184,12 @@ class MklLayerNormOp : public OpKernel {
       lnorm_args.insert({DNNL_ARG_SRC, src_mem});
       lnorm_args.insert({DNNL_ARG_MEAN, mean_mem});
       lnorm_args.insert({DNNL_ARG_VARIANCE, variance_mem});
+#ifndef ENABLE_ONEDNN_V3
       lnorm_args.insert({DNNL_ARG_SCALE_SHIFT, scale_shift_mem});
+#else
+      lnorm_args.insert({DNNL_ARG_SCALE, scale_mem});
+      lnorm_args.insert({DNNL_ARG_SHIFT, shift_mem});
+#endif  // !ENABLE_ONEDNN_V3
       lnorm_args.insert({DNNL_ARG_DST, dst_mem});
       lnorm_prim.execute(*cpu_stream, lnorm_args);
     } catch (dnnl::error& e) {
@@ -179,4 +218,4 @@ REGISTER_KERNEL_BUILDER(
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_swish_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_swish_op.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 // See docs in ../ops/mkl_nn_ops.cc.
 
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3)
+#ifdef INTEL_MKL
 
 #include "tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h"
 
@@ -68,4 +68,4 @@ TF_CALL_bfloat16(REGISTER_SWISH_MKL_SUPPORTED_KERNELS_TYPES);
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_swish_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_swish_op_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3)
+#ifdef INTEL_MKL
 
 #include "absl/strings/match.h"
 #include "tensorflow/cc/ops/const_op.h"
@@ -113,4 +113,4 @@ BENCHMARK_DTYPE(bfloat16)
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3
+#endif  // INTEL_MKL


### PR DESCRIPTION
- This PR adds support for oneDNN v3.x in softmax, layernorm, concat and element-wise ops (fused-mish and _MklSwish) for fp32 and bf16.
- This PR passes all unit tests related to the above ops for fp32/bf16 when oneDNN v3.x is enabled.
- Support for int8 concat will be added in a separate PR.
- This PR does not add or affect Eigen ops and is specific only to oneDNN kernels.
- For additional comments related to oneDNN v3.x integration, please refer to [this](https://github.com/tensorflow/tensorflow/pull/60307#issue-1665423762) comment.