### PR TITLE
[oneDNN v3.x]: Added support for quantize, dequantize and few other int8 ops 

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -677,10 +677,12 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
              csinfo_
                  .quantized_depthwise_conv2d_with_bias_and_relu_and_requantize),
          CopyAttrsQuantizedConv2D, AlwaysRewrite, kRewriteForOpNameChange});
+#endif  // !ENABLE_ONEDNN_V3
     rinfo_.push_back({csinfo_.quantize_v2,
                       mkl_op_registry::GetMklOpName(csinfo_.quantize_v2),
                       CopyAttrsAll, QuantizeOpRewrite,
                       kRewriteForOpNameChange});
+#ifndef ENABLE_ONEDNN_V3
     rinfo_.push_back({csinfo_.relu, mkl_op_registry::GetMklOpName(csinfo_.relu),
                       CopyAttrsAll, AlwaysRewrite, GetRewriteCause()});
     rinfo_.push_back({csinfo_.relu_grad,

--- a/tensorflow/core/kernels/mkl/mkl_dequantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_dequantize_op.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3)
+#if defined(INTEL_MKL)
 
 #define EIGEN_USE_THREADS
 
@@ -145,9 +145,17 @@ class MklDequantizeOp : public OpKernel {
         scale_factor = max_range / v_max;
       }
       std::vector<float> scales;
-      scales.push_back(scale_factor);
       primitive_attr attr;
+#ifndef ENABLE_ONEDNN_V3
+      scales.push_back(scale_factor);
       attr.set_output_scales(0, scales);
+#else
+      scales.push_back(1.0 / scale_factor);
+      attr.set_scales_mask(DNNL_ARG_DST, 0);
+      auto scale_mem =
+          memory({{scales.size()}, MklDnnType<float>(), memory::format_tag::x},
+                 cpu_engine, scales.data());
+#endif  // !ENABLE_ONEDNN_V3
       std::vector<primitive> net;
 
       // Create reorder primitive and then execute.
@@ -156,8 +164,15 @@ class MklDequantizeOp : public OpKernel {
                     dst.GetUsrMem()->get_desc(), attr);
       net.push_back(reorder(reorder_pd));
       std::vector<std::unordered_map<int, memory>> reorder_net_args;
+#ifndef ENABLE_ONEDNN_V3
+      reorder_net_args.push_back({{DNNL_ARG_FROM, *src.GetUsrMem()},
+                                  {DNNL_ARG_TO, *dst.GetUsrMem()}});
+#else
       reorder_net_args.push_back(
-          {{DNNL_ARG_FROM, *src.GetUsrMem()}, {DNNL_ARG_TO, *dst.GetUsrMem()}});
+          {{DNNL_ARG_FROM, *src.GetUsrMem()},
+           {DNNL_ARG_TO, *dst.GetUsrMem()},
+           {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, scale_mem}});
+#endif  // !ENABLE_ONEDNN_V3
       execute_primitives(net, reorder_stream, reorder_net_args);
     } catch (dnnl::error& e) {
       string error_msg = "Status: " + std::to_string(e.status) +
@@ -188,4 +203,4 @@ REGISTER_KERNEL_BUILDER(Name("_MklDequantize")
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_dequantize_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_dequantize_op_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL) && defined(ENABLE_MKL)
 
 #include "tensorflow/core/framework/fake_input.h"
 #include "tensorflow/core/framework/node_def_builder.h"
@@ -53,24 +53,6 @@ TEST_F(MklDequantizeOpTest, small) {
   test::ExpectTensorNear<float>(expected, output, 0.1);
 }
 
-Tensor CreateMklInput() {
-  MklDnnShape mkl_shape;
-  memory::desc md =
-      memory::desc({1, 2, 2, 2}, MklDnnType<uint8>(), memory::format_tag::nhwc);
-  mkl_shape.SetMklTensor(true);
-  mkl_shape.SetMklLayout(&md);
-  mkl_shape.SetElemType(MklDnnType<uint8>());
-  mkl_shape.SetTfLayout(4, {1, 2, 2, 2}, MklTensorFormat::FORMAT_NHWC);
-
-  DataType dtype = DataTypeToEnum<uint8>::v();
-  Tensor mkl_tensor(dtype,
-                    {static_cast<int64_t>(mkl_shape.GetSerializeBufferSize())});
-  mkl_shape.SerializeMklDnnShape(
-      mkl_tensor.flat<uint8>().data(),
-      mkl_tensor.flat<uint8>().size() * sizeof(uint8));
-  return mkl_tensor;
-}
-
 TEST_F(MklDequantizeOpTest, MKLInput) {
   TF_ASSERT_OK(NodeDefBuilder("dequantize_op", "_MklDequantize")
                    .Input(FakeInput(DT_QUINT8))
@@ -96,4 +78,4 @@ TEST_F(MklDequantizeOpTest, MKLInput) {
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && ENABLE_MKL && !ENABLE_ONEDNN_V3
+#endif  // INTEL_MKL && ENABLE_MKL

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
@@ -184,7 +184,7 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
     scales.push_back(post_op_params.param[0]);
     post_ops_attr.set_output_scales(0, scales);
 #else
-    post_ops_attr.set_scales_mask(DNNL_ARG_DST, 0 /* mask */);
+    post_ops_attr.set_scales_mask(DNNL_ARG_SRC, 0 /* mask */);
 #endif  // !ENABLE_ONEDNN_V3
 
     context_.reorder_pd.reset(
@@ -197,7 +197,7 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
     context_.prim_args.insert({DNNL_ARG_TO, *context_.dst_mem});
 #ifdef ENABLE_ONEDNN_V3
     context_.prim_args.insert(
-        {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, *context_.scale_mem});
+        {DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, *context_.scale_mem});
 #endif  // ENABLE_ONEDNN_V3
   }
 
@@ -550,7 +550,7 @@ class MklQuantizeV2Op : public OpKernel {
     MklReorderWithScaleFwdParams fwdParams(src_dims, src_md, dst_md, scale_md);
     Tensor scale_tensor;
     OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, {1}, &scale_tensor));
-    scale_tensor.flat<float>()(0) = 1 / scale_factor;
+    scale_tensor.flat<float>()(0) = scale_factor;
     scale.SetUsrMem(scale_md, &scale_tensor);
 #else
     MklReorderWithScaleFwdParams fwdParams(src_dims, src_md, dst_md);

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3)
+#ifdef INTEL_MKL
 
 #define EIGEN_USE_THREADS
 
@@ -56,12 +56,22 @@ enum {
 }  // namespace
 
 namespace tensorflow {
+
+#ifndef ENABLE_ONEDNN_V3
+#define SET_MKL_LAYOUT(md) SetMklLayout(&md)
+#else
+#define SET_MKL_LAYOUT(md) SetMklLayout(md)
+#endif  // !ENABLE_ONEDNN_V3
+
 typedef Eigen::ThreadPoolDevice CPUDevice;
 
 struct MklReorderWithScaleFwdParams {
   memory::dims src_dims;
   memory::desc src_md;
   memory::desc dst_md;
+#ifdef ENABLE_ONEDNN_V3
+  memory::desc scale_md;
+#endif  // ENABLE_ONEDNN_V3
   string dtypes = string("");
   struct PostOpParam {
     string name;
@@ -69,9 +79,18 @@ struct MklReorderWithScaleFwdParams {
   };
   PostOpParam post_op_params;
 
+#ifndef ENABLE_ONEDNN_V3
   MklReorderWithScaleFwdParams(memory::dims src_dims, memory::desc src_md,
                                memory::desc dst_md)
       : src_dims(src_dims), src_md(src_md), dst_md(dst_md) {}
+#else
+  MklReorderWithScaleFwdParams(memory::dims src_dims, memory::desc src_md,
+                               memory::desc dst_md, memory::desc scale_md)
+      : src_dims(src_dims),
+        src_md(src_md),
+        dst_md(dst_md),
+        scale_md(scale_md) {}
+#endif  // ENABLE_ONEDNN_V3
 };
 
 class MklReorderWithScalePrimitive : public MklPrimitive {
@@ -88,21 +107,30 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
   std::shared_ptr<primitive> GetPrimitive() { return context_.reorder_prim; }
 
   void Execute(void* src_data, void* dst_data,
+#ifdef ENABLE_ONEDNN_V3
+               void* scale_data,
+#endif  // ENABLE_ONEDNN_V3
                std::shared_ptr<stream> reorder_stream) {
 #ifdef DNNL_AARCH64_USE_ACL
     mutex_lock lock(primitive_execution_mu_);
 #endif
-#ifndef ENABLE_ONEDNN_OPENMP
+#if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)
     context_.src_mem->set_data_handle(src_data, *reorder_stream);
     context_.dst_mem->set_data_handle(dst_data, *reorder_stream);
 #else
     context_.src_mem->set_data_handle(src_data);
     context_.dst_mem->set_data_handle(dst_data);
-#endif  // !ENABLE_ONEDNN_OPENMP
+#ifdef ENABLE_ONEDNN_V3
+    context_.scale_mem->set_data_handle(scale_data);
+#endif  // ENABLE_ONEDNN_V3
+#endif  // !ENABLE_ONEDNN_OPENMP && !ENABLE_ONEDNN_V3
     context_.reorder_prim->execute(*reorder_stream, context_.prim_args);
     // After execution, set data handle back.
     context_.src_mem->set_data_handle(DummyData);
     context_.dst_mem->set_data_handle(DummyData);
+#ifdef ENABLE_ONEDNN_V3
+    context_.scale_mem->set_data_handle(DummyData);
+#endif  // !ENABLE_ONEDNN_V3
   }
 
  private:
@@ -111,6 +139,9 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
     // MKL-DNN memory
     std::shared_ptr<dnnl::memory> src_mem;
     std::shared_ptr<dnnl::memory> dst_mem;
+#ifdef ENABLE_ONEDNN_V3
+    std::shared_ptr<dnnl::memory> scale_mem;
+#endif  // ENABLE_ONEDNN_V3
 
     // Reorder primitive descriptor and primitive
     std::shared_ptr<reorder::primitive_desc> reorder_pd;
@@ -124,6 +155,9 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
     ReorderContext()
         : src_mem(nullptr),
           dst_mem(nullptr),
+#ifdef ENABLE_ONEDNN_V3
+          scale_mem(nullptr),
+#endif  // ENABLE_ONEDNN_V3
           reorder_pd(nullptr),
           reorder_prim(nullptr) {}
   } context_;
@@ -135,16 +169,23 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
         new memory(fwdParams.src_md, cpu_engine_, DummyData));
     context_.dst_mem.reset(
         new memory(fwdParams.dst_md, cpu_engine_, DummyData));
+#ifdef ENABLE_ONEDNN_V3
+    context_.scale_mem.reset(
+        new memory(fwdParams.scale_md, cpu_engine_, DummyData));
+#endif  // ENABLE_ONEDNN_V3
 
     // Check if there is any fusion as post-ops
-    auto const& post_op_params = fwdParams.post_op_params;
     dnnl::primitive_attr post_ops_attr;
-
+#ifndef ENABLE_ONEDNN_V3
+    auto const& post_op_params = fwdParams.post_op_params;
     DCHECK(post_op_params.name == "scale");
     DCHECK_EQ(post_op_params.param.size(), 1);
     std::vector<float> scales;
     scales.push_back(post_op_params.param[0]);
     post_ops_attr.set_output_scales(0, scales);
+#else
+    post_ops_attr.set_scales_mask(DNNL_ARG_DST, 0 /* mask */);
+#endif  // !ENABLE_ONEDNN_V3
 
     context_.reorder_pd.reset(
         new ReorderPd(cpu_engine_, context_.src_mem->get_desc(), cpu_engine_,
@@ -154,6 +195,10 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
     context_.reorder_prim.reset(new reorder(*context_.reorder_pd));
     context_.prim_args.insert({DNNL_ARG_FROM, *context_.src_mem});
     context_.prim_args.insert({DNNL_ARG_TO, *context_.dst_mem});
+#ifdef ENABLE_ONEDNN_V3
+    context_.prim_args.insert(
+        {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, *context_.scale_mem});
+#endif  // ENABLE_ONEDNN_V3
   }
 
 #ifdef DNNL_AARCH64_USE_ACL
@@ -167,6 +212,7 @@ class MklReorderWithScalePrimitiveFactory : public MklPrimitiveFactory<T> {
   static MklReorderWithScalePrimitive* Get(
       const memory* from, const memory* to,
       const MklReorderWithScaleFwdParams& fwdParams) {
+#ifndef ENABLE_ONEDNN_V3
     // Try to find a suitable primitive from the cached pool
     auto reorderPrim = static_cast<MklReorderWithScalePrimitive*>(
         MklReorderWithScalePrimitiveFactory<T>::GetInstance().GetReorder(
@@ -177,17 +223,25 @@ class MklReorderWithScalePrimitiveFactory : public MklPrimitiveFactory<T> {
           from, to, reorderPrim, fwdParams);
     }
     return reorderPrim;
+#else
+    // TODO(intel-tf): enable ReorderWithScale primitive cache for v3.x
+    auto reorderPrim = new MklReorderWithScalePrimitive(fwdParams);
+    return reorderPrim;
+#endif  // !ENABLE_ONEDNN_V3
   }
 
+#ifndef ENABLE_ONEDNN_V3
   static MklReorderWithScalePrimitiveFactory& GetInstance() {
     static MklReorderWithScalePrimitiveFactory instance_;
     return instance_;
   }
+#endif  // !ENABLE_ONEDNN_V3
 
  private:
   MklReorderWithScalePrimitiveFactory() {}
   ~MklReorderWithScalePrimitiveFactory() {}
 
+#ifndef ENABLE_ONEDNN_V3
   static string CreateKey(const memory* from, const memory* to,
                           const MklReorderWithScaleFwdParams& fwdParams) {
     FactoryKeyCreator key_creator;
@@ -215,6 +269,7 @@ class MklReorderWithScalePrimitiveFactory : public MklPrimitiveFactory<T> {
     string key = CreateKey(from, to, fwdParams);
     this->SetOp(key, op);
   }
+#endif  // !ENABLE_ONEDNN_V3
 };
 
 // Quantizes a tensor from float to T, with user-specified min_range and
@@ -388,6 +443,10 @@ class MklQuantizeV2Op : public OpKernel {
     // they are wrapper
     MklDnnData<float> src(&cpu_engine);
     MklDnnData<T> dst(&cpu_engine);
+#ifdef ENABLE_ONEDNN_V3
+    MklDnnData<float> scale(&cpu_engine);
+#endif  // ENABLE_ONEDNN_V3
+
     auto src_md =
         src_mkl_shape.IsMklTensor()
             ? src_mkl_shape.GetMklLayout()
@@ -427,7 +486,7 @@ class MklQuantizeV2Op : public OpKernel {
     TensorShape output_tf_shape;
     if (src_mkl_shape.IsMklTensor()) {
       output_mkl_shape.SetMklTensor(true);
-      output_mkl_shape.SetMklLayout(&dst_md);
+      output_mkl_shape.SET_MKL_LAYOUT(dst_md);
       output_mkl_shape.SetElemType(MklDnnType<T>());
       output_mkl_shape.SetTfLayout(src_mkl_shape.GetDimension(),
                                    src_mkl_shape.GetSizesAsMklDnnDims(),
@@ -485,11 +544,20 @@ class MklQuantizeV2Op : public OpKernel {
       const int64 number_of_steps = static_cast<int64_t>(1) << number_of_bits;
       scale_factor = (number_of_steps - 1.0) / (max_range - min_range);
     }
-
+#ifdef ENABLE_ONEDNN_V3
+    auto scale_md =
+        memory::desc({1}, MklDnnType<float>(), memory::format_tag::x);
+    MklReorderWithScaleFwdParams fwdParams(src_dims, src_md, dst_md, scale_md);
+    Tensor scale_tensor;
+    OP_REQUIRES_OK(ctx, ctx->allocate_temp(DT_FLOAT, {1}, &scale_tensor));
+    scale_tensor.flat<float>()(0) = 1 / scale_factor;
+    scale.SetUsrMem(scale_md, &scale_tensor);
+#else
     MklReorderWithScaleFwdParams fwdParams(src_dims, src_md, dst_md);
     fwdParams.dtypes.append(typeid(T).name());
     fwdParams.post_op_params.name = "scale";
     fwdParams.post_op_params.param.push_back(scale_factor);
+#endif  // ENABLE_ONEDNN_V3
 
     MklDnnThreadPool eigen_tp(ctx);
     MklReorderWithScalePrimitive* reorder_prim =
@@ -499,6 +567,9 @@ class MklQuantizeV2Op : public OpKernel {
 
     cpu_stream.reset(CreateStream(&eigen_tp, reorder_prim->GetEngine()));
     reorder_prim->Execute(src.GetUsrMemDataHandle(), dst.GetUsrMemDataHandle(),
+#ifdef ENABLE_ONEDNN_V3
+                          scale.GetUsrMemDataHandle(),
+#endif  // ENABLE_ONEDNN_V3
                           cpu_stream);
 
     output_min_tensor->scalar<float>()() = min_range;
@@ -523,6 +594,9 @@ REGISTER_KERNEL_BUILDER(Name("_MklQuantizeV2")
                             .TypeConstraint<qint8>("T")
                             .Label(mkl_op_registry::kMklQuantizedOpLabel),
                         MklQuantizeV2Op<CPUDevice, qint8, true>);
+
+#undef SET_MKL_LAYOUT
+
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
@@ -120,17 +120,17 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
 #else
     context_.src_mem->set_data_handle(src_data);
     context_.dst_mem->set_data_handle(dst_data);
+#endif  // !ENABLE_ONEDNN_OPENMP && !ENABLE_ONEDNN_V3
 #ifdef ENABLE_ONEDNN_V3
     context_.scale_mem->set_data_handle(scale_data);
 #endif  // ENABLE_ONEDNN_V3
-#endif  // !ENABLE_ONEDNN_OPENMP && !ENABLE_ONEDNN_V3
     context_.reorder_prim->execute(*reorder_stream, context_.prim_args);
     // After execution, set data handle back.
     context_.src_mem->set_data_handle(DummyData);
     context_.dst_mem->set_data_handle(DummyData);
 #ifdef ENABLE_ONEDNN_V3
     context_.scale_mem->set_data_handle(DummyData);
-#endif  // !ENABLE_ONEDNN_V3
+#endif  // ENABLE_ONEDNN_V3
   }
 
  private:

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL) && defined(ENABLE_MKL)
 #include "tensorflow/core/framework/fake_input.h"
 #include "tensorflow/core/framework/node_def_builder.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -155,4 +155,4 @@ TEST_F(MklQuantizeV2OpTest, small_minfirst_int) {
 }
 
 }  // end namespace tensorflow
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3 && ENABLE_MKL
+#endif  // INTEL_MKL && ENABLE_MKL

--- a/tensorflow/core/kernels/mkl/mkl_quantized_concat_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_concat_op_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL) && defined(ENABLE_MKL)
 
 #define EIGEN_USE_THREADS
 
@@ -191,4 +191,4 @@ void QuantizedConcatTest::TestSecondDim8Bit(float first_min, float first_max,
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3 && ENABLE_MKL
+#endif  // INTEL_MKL && ENABLE_MKL

--- a/tensorflow/core/kernels/mkl/mkl_quantized_pooling_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantized_pooling_ops_test.cc
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL) && defined(ENABLE_MKL)
 #define EIGEN_USE_THREADS
 
 #include "tensorflow/cc/ops/standard_ops.h"
@@ -261,4 +261,4 @@ TEST_F(QuantizedPoolingTest, SmallMaxPooling) {
 
 }  // namespace tensorflow
 
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3 && ENABLE_MKL
+#endif  // INTEL_MKL && ENABLE_MKL

--- a/tensorflow/core/kernels/mkl/mkl_requantization_range_per_channel_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_requantization_range_per_channel_op.cc
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 // See docs in ../ops/array_ops.cc.
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3)
+#if defined(INTEL_MKL)
 #define EIGEN_USE_THREADS
 
 #include <math.h>
@@ -146,4 +146,4 @@ REGISTER_KERNEL_BUILDER(Name("RequantizationRangePerChannel")
                             .TypeConstraint<qint32>("T"),
                         MklRequantizationRangePerChannelOp);
 }  // namespace tensorflow
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/mkl_requantize_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_requantize_ops_test.cc
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#if defined(INTEL_MKL) && !defined(ENABLE_ONEDNN_V3) && defined(ENABLE_MKL)
+#if defined(INTEL_MKL) && defined(ENABLE_MKL)
 
 #include <cmath>
 
@@ -296,4 +296,4 @@ TEST_F(MklRequantizatedOpsTest, RequantizePerChannelTest_Basic) {
 }
 
 }  // namespace tensorflow
-#endif  // INTEL_MKL && !ENABLE_ONEDNN_V3 && ENABLE_MKL
+#endif  // INTEL_MKL && ENABLE_MKL

--- a/tensorflow/core/kernels/mkl/mkl_requantize_per_channel_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_requantize_per_channel_op.cc
@@ -101,20 +101,15 @@ class MklRequantizePerChannelOp : public OpKernel {
       for (int i = 0; i < depth; ++i) {
         float min_max_from_vec = std::max(std::abs(input_min_vec_data[i]),
                                           std::abs(input_max_vec_data[i]));
-#ifndef ENABLE_ONEDNN_V3
         scales[i] = factor * (min_max_from_vec / requested_min_max /
                               static_cast<float>(1L << 31));
-#else
-        scales[i] = 1.0 / (factor * (min_max_from_vec / requested_min_max /
-                                     static_cast<float>(1L << 31)));
-#endif  // !ENABLE_ONEDNN_V3
       }
 
       dnnl::primitive_attr reorder_attr;
 #ifndef ENABLE_ONEDNN_V3
       reorder_attr.set_output_scales(2, scales);
 #else
-      reorder_attr.set_scales_mask(DNNL_ARG_DST, 2);
+      reorder_attr.set_scales_mask(DNNL_ARG_SRC, 2);
       auto scale_mem =
           memory({{scales.size()}, MklDnnType<float>(), memory::format_tag::x},
                  cpu_engine_, scales.data());
@@ -157,7 +152,7 @@ class MklRequantizePerChannelOp : public OpKernel {
       std::unordered_map<int, dnnl::memory> reorder_args = {
           {DNNL_ARG_FROM, *input_mem_prim}, {DNNL_ARG_TO, *output_mem_prim}};
 #ifdef ENABLE_ONEDNN_V3
-      reorder_args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, scale_mem});
+      reorder_args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, scale_mem});
 #endif  // ENABLE_ONEDNN_V3
       std::unique_ptr<dnnl::primitive> reorder_prim(
           new dnnl::reorder(reorder_pd));


### PR DESCRIPTION
- This PR adds support for oneDNN v3.x in quantize, dequantize, quantized-concat, requantization-range-per-channel and requantize-per-channel ops.
- Support for primitive cache in quantize op will be added in a separate PR.
- This PR passes all unit tests related to the above ops when oneDNN v3.x is enabled.
- This PR does not add or affect Eigen ops and is specific only to oneDNN kernels.
- For additional comments related to oneDNN v3.x integration, please refer to [this](https://github.com/tensorflow/tensorflow/pull/60307#issue-1665423762) comment.