### PR TITLE
[NVIDIA TF] Optimize embedding_lookup_sparse using new grad op [PART 1/3]

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_SparseSegmentMeanGradV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SparseSegmentMeanGradV2.pbtxt
@@ -1,0 +1,33 @@
+op {
+  graph_op_name: "SparseSegmentMeanGradV2"
+  in_arg {
+    name: "grad"
+    description: <<END
+gradient propagated to the SparseSegmentMean op.
+END
+  }
+  in_arg {
+    name: "indices"
+    description: <<END
+indices passed to the corresponding SparseSegmentMean op.
+END
+  }
+  in_arg {
+    name: "segment_ids"
+    description: <<END
+segment_ids passed to the corresponding SparseSegmentMean op.
+END
+  }
+  in_arg {
+    name: "dense_output_dim0"
+    description: <<END
+dimension 0 of "data" passed to SparseSegmentMean op.
+END
+  }
+  summary: "Computes gradients for SparseSegmentMean."
+  description: <<END
+Returns tensor "output" with same shape as grad, except for dimension 0 whose
+value is the number of unique indexes in "indices". Also returns vector
+"sorted_unique_indices" containing the corresponding indexes from "indices".
+END
+}

--- a/tensorflow/core/api_def/base_api/api_def_SparseSegmentSqrtNGradV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SparseSegmentSqrtNGradV2.pbtxt
@@ -1,0 +1,33 @@
+op {
+  graph_op_name: "SparseSegmentSqrtNGradV2"
+  in_arg {
+    name: "grad"
+    description: <<END
+gradient propagated to the SparseSegmentSqrtN op.
+END
+  }
+  in_arg {
+    name: "indices"
+    description: <<END
+indices passed to the corresponding SparseSegmentSqrtN op.
+END
+  }
+  in_arg {
+    name: "segment_ids"
+    description: <<END
+segment_ids passed to the corresponding SparseSegmentSqrtN op.
+END
+  }
+  in_arg {
+    name: "dense_output_dim0"
+    description: <<END
+dimension 0 of "data" passed to SparseSegmentSqrtN op.
+END
+  }
+  summary: "Computes gradients for SparseSegmentSqrtN."
+  description: <<END
+Returns tensor "output" with same shape as grad, except for dimension 0 whose
+value is the number of unique indexes in "indices". Also returns vector
+"sorted_unique_indices" containing the corresponding indexes from "indices".
+END
+}

--- a/tensorflow/core/api_def/base_api/api_def_SparseSegmentSumGradV2.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_SparseSegmentSumGradV2.pbtxt
@@ -1,0 +1,33 @@
+op {
+  graph_op_name: "SparseSegmentSumGradV2"
+  in_arg {
+    name: "grad"
+    description: <<END
+gradient propagated to the SparseSegmentSum op.
+END
+  }
+  in_arg {
+    name: "indices"
+    description: <<END
+indices passed to the corresponding SparseSegmentSum op.
+END
+  }
+  in_arg {
+    name: "segment_ids"
+    description: <<END
+segment_ids passed to the corresponding SparseSegmentSum op.
+END
+  }
+  in_arg {
+    name: "dense_output_dim0"
+    description: <<END
+dimension 0 of "data" passed to SparseSegmentSum op.
+END
+  }
+  summary: "Computes gradients for SparseSegmentSum."
+  description: <<END
+Returns tensor "output" with same shape as grad, except for dimension 0 whose
+value is the number of unique indexes in "indices". Also returns vector
+"sorted_unique_indices" containing the corresponding indexes from "indices".
+END
+}

--- a/tensorflow/core/api_def/python_api/api_def_SparseSegmentMeanGradV2.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_SparseSegmentMeanGradV2.pbtxt
@@ -1,0 +1,4 @@
+op {
+  graph_op_name: "SparseSegmentMeanGradV2"
+  visibility: HIDDEN
+}

--- a/tensorflow/core/api_def/python_api/api_def_SparseSegmentSqrtNGradV2.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_SparseSegmentSqrtNGradV2.pbtxt
@@ -1,0 +1,4 @@
+op {
+  graph_op_name: "SparseSegmentSqrtNGradV2"
+  visibility: HIDDEN
+}

--- a/tensorflow/core/api_def/python_api/api_def_SparseSegmentSumGradV2.pbtxt
+++ b/tensorflow/core/api_def/python_api/api_def_SparseSegmentSumGradV2.pbtxt
@@ -1,0 +1,4 @@
+op {
+  graph_op_name: "SparseSegmentSumGradV2"
+  visibility: HIDDEN
+}

--- a/tensorflow/core/kernels/segment_reduction_ops.h
+++ b/tensorflow/core/kernels/segment_reduction_ops.h
@@ -154,6 +154,17 @@ struct SparseSegmentGradFunctor {
                   typename TTypes<T>::Matrix output_flat);
 };
 
+template <class Device, typename T, typename Index, typename SegmentId>
+struct SparseSegmentGradV2Functor {
+  void operator()(OpKernelContext* context,
+                  SparseSegmentReductionOperation operation,
+                  typename TTypes<T>::ConstMatrix input_flat,
+                  typename TTypes<Index>::ConstVec indices_vec,
+                  typename TTypes<SegmentId>::ConstVec segment_vec,
+                  const TensorShape& dense_output_shape,
+                  typename AsyncOpKernel::DoneCallback done);
+};
+
 }  // namespace functor
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -27,6 +27,7 @@ limitations under the License.
 #define EIGEN_USE_GPU
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
+#include "absl/container/flat_hash_map.h"
 #include "third_party/eigen3/Eigen/Core"
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "tensorflow/core/framework/bounds_check.h"
@@ -1126,6 +1127,93 @@ struct SparseSegmentGradFunctor<CPUDevice, T, Index, SegmentId> {
   }
 };
 
+template <typename T, typename Index, typename SegmentId>
+struct SparseSegmentGradV2Functor<CPUDevice, T, Index, SegmentId> {
+  void operator()(OpKernelContext* context,
+                  SparseSegmentReductionOperation operation,
+                  typename TTypes<T>::ConstMatrix input_flat,
+                  typename TTypes<Index>::ConstVec indices_vec,
+                  typename TTypes<SegmentId>::ConstVec segment_vec,
+                  const TensorShape& dense_output_shape,
+                  typename AsyncOpKernel::DoneCallback /*done*/) {
+    const int64_t N = indices_vec.size();
+    const int64_t M = dense_output_shape.dim_size(0);
+    const SegmentId num_segments = input_flat.dimension(0);
+    const SegmentId last_segment_id_plus_one =
+        internal::SubtleMustCopy(segment_vec(N - 1)) + 1;
+    // Note: We do bounds-checking up front here so that it operates in the same
+    // order as the V1 implementation.
+    OP_REQUIRES(context, last_segment_id_plus_one <= num_segments,
+                errors::InvalidArgument("Invalid number of segments"));
+    for (int64_t i = 0; i < N; ++i) {
+      const Index output_idx = internal::SubtleMustCopy(indices_vec(i));
+      OP_REQUIRES(context, FastBoundsCheck(output_idx, M),
+                  errors::InvalidArgument("Index ", output_idx,
+                                          " out of range [0, ", M, ")."));
+      const SegmentId segment_id = internal::SubtleMustCopy(segment_vec(i));
+      OP_REQUIRES(
+          context, FastBoundsCheck(segment_id, num_segments),
+          errors::InvalidArgument("Segment id ", segment_id,
+                                  " out of range [0, ", num_segments, ")."));
+    }
+
+    std::vector<Index> permutation;
+    permutation.reserve(N);
+    for (int64_t i = 0; i < N; ++i) {
+      permutation.push_back(i);
+    }
+    std::stable_sort(
+        permutation.begin(), permutation.end(),
+        [&](Index a, Index b) { return indices_vec(a) < indices_vec(b); });
+    std::vector<Index> sorted_indices;
+    std::vector<SegmentId> permuted_segments;
+    sorted_indices.reserve(N);
+    permuted_segments.reserve(N);
+    for (Index j : permutation) {
+      sorted_indices.push_back(indices_vec(j));
+      permuted_segments.push_back(segment_vec(j));
+    }
+
+    // Maps indices to unique index IDs.
+    absl::flat_hash_map<Index, Index> unique_indices_map;
+    // The unique ID for each original index.
+    std::vector<Index> unique_index_ids;
+    unique_index_ids.reserve(N);
+    for (Index output_idx : sorted_indices) {
+      auto iter =
+          unique_indices_map.emplace(output_idx, unique_indices_map.size())
+              .first;
+      Index unique_id = iter->second;
+      unique_index_ids.push_back(unique_id);
+    }
+    const int64_t num_unique = unique_indices_map.size();
+
+    // The original index for each unique ID.
+    Tensor* unique_indices = nullptr;
+    OP_REQUIRES_OK(context,
+                   context->allocate_output(1, {num_unique}, &unique_indices));
+    typename TTypes<Index>::Vec unique_indices_vec =
+        unique_indices->vec<Index>();
+    for (const auto& idx_and_id : unique_indices_map) {
+      unique_indices_vec(idx_and_id.second) = idx_and_id.first;
+    }
+
+    TensorShape output_shape = dense_output_shape;
+    OP_REQUIRES_OK(context, output_shape.SetDimWithStatus(0, num_unique));
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
+
+    // Call the V1 implementation with the unique/permuted indices/segments.
+    typename TTypes<Index>::ConstVec unique_index_ids_vec(
+        unique_index_ids.data(), unique_index_ids.size());
+    typename TTypes<SegmentId>::ConstVec permuted_segment_vec(
+        permuted_segments.data(), permuted_segments.size());
+    SparseSegmentGradFunctor<CPUDevice, T, Index, SegmentId>()(
+        context, operation, input_flat, unique_index_ids_vec,
+        permuted_segment_vec, output->flat_outer_dims<T>());
+  }
+};
+
 }  // namespace functor
 
 // Implements the common logic for the gradients of SparseSegmentReduction
@@ -1205,6 +1293,109 @@ class SparseSegmentSqrtNGradOp
  public:
   explicit SparseSegmentSqrtNGradOp(OpKernelConstruction* context)
       : SparseSegmentGradOpBase<Device, T, Index, SegmentId>(
+            context, SparseSegmentReductionOperation::kSqrtN) {}
+};
+
+template <typename Device, class T, typename Index, typename SegmentId>
+class SparseSegmentGradV2OpCommon {
+ public:
+  Status operator()(OpKernelContext* context,
+                    SparseSegmentReductionOperation operation,
+                    typename AsyncOpKernel::DoneCallback done = nullptr) {
+    const Tensor& input = context->input(0);
+    const Tensor& indices = context->input(1);
+    const Tensor& segment_ids = context->input(2);
+    const Tensor& dense_output_dim0 = context->input(3);
+
+    if (!TensorShapeUtils::IsVector(indices.shape())) {
+      return errors::InvalidArgument("indices should be a vector.");
+    }
+    if (!TensorShapeUtils::IsVector(segment_ids.shape())) {
+      return errors::InvalidArgument("segment_ids should be a vector.");
+    }
+    if (!TensorShapeUtils::IsScalar(dense_output_dim0.shape())) {
+      return errors::InvalidArgument("dense_output_dim0 should be a scalar.");
+    }
+
+    const int64_t N = indices.NumElements();
+    if (N != segment_ids.NumElements()) {
+      return errors::InvalidArgument(
+          "segment_ids and indices should have same size.");
+    }
+    const int32_t M =
+        internal::SubtleMustCopy(dense_output_dim0.scalar<int32_t>()());
+    TensorShape dense_output_shape = input.shape();
+    TF_RETURN_IF_ERROR(dense_output_shape.SetDimWithStatus(0, M));
+
+    if (M == 0 || N == 0) {
+      TensorShape output_shape = input.shape();
+      TF_RETURN_IF_ERROR(output_shape.SetDimWithStatus(0, 0));
+      Tensor* output = nullptr;
+      TF_RETURN_IF_ERROR(context->allocate_output(0, output_shape, &output));
+      Tensor* sorted_unique_indices = nullptr;
+      TF_RETURN_IF_ERROR(context->allocate_output(1, TensorShape({0}),
+                                                  &sorted_unique_indices));
+      return OkStatus();
+    }
+
+    auto input_flat = input.flat_outer_dims<T>();
+    const auto indices_vec = indices.vec<Index>();
+    const auto segment_vec = segment_ids.vec<SegmentId>();
+
+    functor::SparseSegmentGradV2Functor<Device, T, Index, SegmentId>()(
+        context, operation, input_flat, indices_vec, segment_vec,
+        dense_output_shape, done);
+
+    return OkStatus();
+  }
+};
+
+template <typename Device, class T, typename Index, typename SegmentId>
+class SparseSegmentGradV2OpBase {};
+
+// The CPU implementation is synchronous.
+template <class T, typename Index, typename SegmentId>
+class SparseSegmentGradV2OpBase<CPUDevice, T, Index, SegmentId>
+    : public OpKernel {
+ public:
+  explicit SparseSegmentGradV2OpBase(OpKernelConstruction* context,
+                                     SparseSegmentReductionOperation operation)
+      : OpKernel(context), operation_(operation) {}
+
+  void Compute(OpKernelContext* context) override {
+    OP_REQUIRES_OK(
+        context, (SparseSegmentGradV2OpCommon<CPUDevice, T, Index, SegmentId>()(
+                     context, operation_)));
+  }
+
+ private:
+  const SparseSegmentReductionOperation operation_;
+};
+
+template <typename Device, class T, typename Index, typename SegmentId>
+class SparseSegmentSumGradV2Op
+    : public SparseSegmentGradV2OpBase<Device, T, Index, SegmentId> {
+ public:
+  explicit SparseSegmentSumGradV2Op(OpKernelConstruction* context)
+      : SparseSegmentGradV2OpBase<Device, T, Index, SegmentId>(
+            context, SparseSegmentReductionOperation::kSum) {}
+};
+
+template <typename Device, class T, typename Index, typename SegmentId>
+class SparseSegmentMeanGradV2Op
+    : public SparseSegmentGradV2OpBase<Device, T, Index, SegmentId> {
+ public:
+  explicit SparseSegmentMeanGradV2Op(OpKernelConstruction* context)
+      : SparseSegmentGradV2OpBase<Device, T, Index, SegmentId>(
+            context, SparseSegmentReductionOperation::kMean) {}
+};
+
+template <typename Device, class T, typename Index, typename SegmentId>
+class SparseSegmentSqrtNGradV2Op
+    : public SparseSegmentGradV2OpBase<Device, T, Index, SegmentId> {
+ public:
+  explicit SparseSegmentSqrtNGradV2Op(OpKernelConstruction* context)
+      : SparseSegmentGradV2OpBase<Device, T, Index, SegmentId>(
             context, SparseSegmentReductionOperation::kSqrtN) {}
 };
 

--- a/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl_5.cc
@@ -193,6 +193,42 @@ TF_CALL_FLOAT_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
 TF_CALL_FLOAT_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
 #undef REGISTER_CPU_SPARSE_KERNELS
 
+#define REGISTER_CPU_SPARSE_KERNELS(type, index_type, segment_ids_type) \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("SparseSegmentSumGradV2")                                    \
+          .Device(DEVICE_CPU)                                           \
+          .TypeConstraint<type>("T")                                    \
+          .TypeConstraint<index_type>("Tidx")                           \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),             \
+      SparseSegmentSumGradV2Op<CPUDevice, type, index_type,             \
+                               segment_ids_type>);
+TF_CALL_FLOAT_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
+#undef REGISTER_CPU_SPARSE_KERNELS
+
+#define REGISTER_CPU_SPARSE_KERNELS(type, index_type, segment_ids_type) \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("SparseSegmentMeanGradV2")                                   \
+          .Device(DEVICE_CPU)                                           \
+          .TypeConstraint<type>("T")                                    \
+          .TypeConstraint<index_type>("Tidx")                           \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),             \
+      SparseSegmentMeanGradV2Op<CPUDevice, type, index_type,            \
+                                segment_ids_type>);
+TF_CALL_FLOAT_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
+#undef REGISTER_CPU_SPARSE_KERNELS
+
+#define REGISTER_CPU_SPARSE_KERNELS(type, index_type, segment_ids_type) \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("SparseSegmentSqrtNGradV2")                                  \
+          .Device(DEVICE_CPU)                                           \
+          .TypeConstraint<type>("T")                                    \
+          .TypeConstraint<index_type>("Tidx")                           \
+          .TypeConstraint<segment_ids_type>("Tsegmentids"),             \
+      SparseSegmentSqrtNGradV2Op<CPUDevice, type, index_type,           \
+                                 segment_ids_type>);
+TF_CALL_FLOAT_TYPES(REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE);
+#undef REGISTER_CPU_SPARSE_KERNELS
+
 #undef REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_INDEX_TYPE
 #undef REGISTER_CPU_SPARSE_KERNELS_FOR_EACH_SEGMENT_ID_TYPE
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1193,7 +1193,8 @@ Status SparseSegmentReductionShapeFn(InferenceContext* c) {
   return OkStatus();
 }
 
-Status SparseSegmentReductionGradShapeFn(InferenceContext* c) {
+Status SparseSegmentReductionGradShapeFnImpl(InferenceContext* c,
+                                             bool outputs_unique_indices) {
   ShapeHandle data_shape;
   TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &data_shape));
 
@@ -1210,7 +1211,9 @@ Status SparseSegmentReductionGradShapeFn(InferenceContext* c) {
   ShapeHandle subshape;
   TF_RETURN_IF_ERROR(c->Subshape(data_shape, 1, &subshape));
 
-  const Tensor* dim0 = c->input_tensor(3);
+  // For the V2 version of the op, dim0 is the number of unique indices, which
+  // is always unknown at inference time.
+  const Tensor* dim0 = outputs_unique_indices ? nullptr : c->input_tensor(3);
   ShapeHandle dim0_shape;
   if (dim0 == nullptr) {
     // We don't have the value at inference time, so the output
@@ -1229,6 +1232,17 @@ Status SparseSegmentReductionGradShapeFn(InferenceContext* c) {
   TF_RETURN_IF_ERROR(c->Concatenate(dim0_shape, subshape, &out));
   c->set_output(0, out);
   return OkStatus();
+}
+
+Status SparseSegmentReductionGradShapeFn(InferenceContext* c) {
+  return SparseSegmentReductionGradShapeFnImpl(
+      c,
+      /*outputs_unique_indices=*/false);
+}
+
+Status SparseSegmentReductionGradV2ShapeFn(InferenceContext* c) {
+  return SparseSegmentReductionGradShapeFnImpl(c,
+                                               /*outputs_unique_indices=*/true);
 }
 
 Status SparseSegmentReductionWithNumSegmentsShapeFn(InferenceContext* c) {
@@ -1425,6 +1439,20 @@ REGISTER_OP("SparseSegmentSumGrad")
     .Attr("Tsegmentids: {int32, int64} = DT_INT32")
     .SetShapeFn(SparseSegmentReductionGradShapeFn);
 
+// V2 returns a sparse gradient instead of dense. Its (sparse) output dim0 is
+// equal to the number of unique indices.
+REGISTER_OP("SparseSegmentSumGradV2")
+    .Input("grad: T")
+    .Input("indices: Tidx")
+    .Input("segment_ids: Tsegmentids")
+    .Input("dense_output_dim0: int32")
+    .Output("output: T")
+    .Output("sorted_unique_indices: Tidx")
+    .Attr("T: {bfloat16, half, float, double}")
+    .Attr("Tidx: {int32, int64} = DT_INT32")
+    .Attr("Tsegmentids: {int32, int64} = DT_INT32")
+    .SetShapeFn(SparseSegmentReductionGradV2ShapeFn);
+
 REGISTER_OP("SparseSegmentMean")
     .Input("data: T")
     .Input("indices: Tidx")
@@ -1458,6 +1486,18 @@ REGISTER_OP("SparseSegmentMeanGrad")
     .Attr("Tsegmentids: {int32, int64} = DT_INT32")
     .SetShapeFn(SparseSegmentReductionGradShapeFn);
 
+REGISTER_OP("SparseSegmentMeanGradV2")
+    .Input("grad: T")
+    .Input("indices: Tidx")
+    .Input("segment_ids: Tsegmentids")
+    .Input("dense_output_dim0: int32")
+    .Output("output: T")
+    .Output("sorted_unique_indices: Tidx")
+    .Attr("T: {bfloat16, half, float, double}")
+    .Attr("Tidx: {int32, int64} = DT_INT32")
+    .Attr("Tsegmentids: {int32, int64} = DT_INT32")
+    .SetShapeFn(SparseSegmentReductionGradV2ShapeFn);
+
 REGISTER_OP("SparseSegmentSqrtN")
     .Input("data: T")
     .Input("indices: Tidx")
@@ -1490,6 +1530,18 @@ REGISTER_OP("SparseSegmentSqrtNGrad")
     .Attr("Tidx: {int32, int64} = DT_INT32")
     .Attr("Tsegmentids: {int32, int64} = DT_INT32")
     .SetShapeFn(SparseSegmentReductionGradShapeFn);
+
+REGISTER_OP("SparseSegmentSqrtNGradV2")
+    .Input("grad: T")
+    .Input("indices: Tidx")
+    .Input("segment_ids: Tsegmentids")
+    .Input("dense_output_dim0: int32")
+    .Output("output: T")
+    .Output("sorted_unique_indices: Tidx")
+    .Attr("T: {bfloat16, half, float, double}")
+    .Attr("Tidx: {int32, int64} = DT_INT32")
+    .Attr("Tsegmentids: {int32, int64} = DT_INT32")
+    .SetShapeFn(SparseSegmentReductionGradV2ShapeFn);
 
 REGISTER_OP("All")
     .Input("input: bool")

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1231,6 +1231,9 @@ Status SparseSegmentReductionGradShapeFnImpl(InferenceContext* c,
   ShapeHandle out;
   TF_RETURN_IF_ERROR(c->Concatenate(dim0_shape, subshape, &out));
   c->set_output(0, out);
+  if (outputs_unique_indices) {
+    c->set_output(1, c->Vector(InferenceContext::kUnknownDim));
+  }
   return OkStatus();
 }
 

--- a/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
@@ -621,21 +621,36 @@ class SparseSegmentReductionHelper(SegmentReductionHelper):
     return self._segmentReduce(
         segment_indices, x[indices], op1, op2, num_segments=num_segments)
 
-  def _sparseSegmentReduceGrad(self, ygrad, indices, segment_ids, output_dim0,
-                               mode):
+  def _sparseSegmentReduceGradWeights(self, ygrad, segment_ids, mode):
     assert mode in ("sum", "mean", "sqrtn")
-    if mode != "sum":
+    if mode == "sum":
+      weights = np.ones(ygrad.shape[0], ygrad.dtype)
+    else:
       weights = np.zeros(ygrad.shape[0], ygrad.dtype)
       for segment in segment_ids:
         weights[segment] += 1
       weights = 1. / weights if mode == "mean" else 1. / np.sqrt(weights)
+    return weights
+
+  def _sparseSegmentReduceGrad(self, ygrad, indices, segment_ids, output_dim0,
+                               mode):
+    assert mode in ("sum", "mean", "sqrtn")
+    weights = self._sparseSegmentReduceGradWeights(ygrad, segment_ids, mode)
     xgrad = np.zeros([output_dim0, ygrad.shape[1]], ygrad.dtype)
     for segment, index in zip(segment_ids, indices):
-      if mode == "sum":
-        xgrad[index] += ygrad[segment]
-      else:
-        xgrad[index] += ygrad[segment] * weights[segment]
+      xgrad[index] += ygrad[segment] * weights[segment]
     return xgrad
+
+  def _sparseSegmentReduceGradV2(self, ygrad, indices, segment_ids, mode):
+    assert mode in ("sum", "mean", "sqrtn")
+    unique_indices, unique_indices_inverse = np.unique(
+        indices, return_inverse=True)
+    weights = self._sparseSegmentReduceGradWeights(ygrad, segment_ids, mode)
+    xgrad_unique = np.zeros(
+        [unique_indices.shape[0], ygrad.shape[1]], ygrad.dtype)
+    for segment, unique_index in zip(segment_ids, unique_indices_inverse):
+      xgrad_unique[unique_index] += ygrad[segment] * weights[segment]
+    return xgrad_unique, unique_indices
 
 
 class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
@@ -1042,6 +1057,50 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
           tf_xgrad = tf_op(tf_ygrad, indices, segment_ids, output_dim0)
           self.assertAllClose(tf_xgrad, np_xgrad)
 
+  def testGradientV2Explicit(self):
+    # Note that the GPU implem has different paths for different inner sizes.
+    for inner_size in (1, 2, 3, 32):
+      with self.session():
+        tf_ygrad, np_ygrad = self._input([3, inner_size],
+                                         dtype=dtypes_lib.float32)
+        segment_ids = [0, 1, 2, 2, 2]
+        indices = [8, 3, 0, 9, 3]
+        output_dim0 = 10
+        ops_list = [
+            (math_ops.sparse_segment_sum_grad_v2, "sum"),
+            (math_ops.sparse_segment_mean_grad_v2, "mean"),
+            (math_ops.sparse_segment_sqrt_n_grad_v2, "sqrtn"),
+        ]
+        for tf_op, mode in ops_list:
+          np_xgrad, np_unique_indices = self._sparseSegmentReduceGradV2(
+              np_ygrad, indices, segment_ids, mode)
+          tf_xgrad, tf_unique_indices = tf_op(
+              tf_ygrad, indices, segment_ids, output_dim0)
+          self.assertAllClose(tf_xgrad, np_xgrad)
+          self.assertAllClose(tf_unique_indices, np_unique_indices)
+
+  def testGradientV2ExplicitSingleOutput(self):
+    # The GPU implem has a special case when there is a single output.
+    for inner_size in (1, 2, 3, 32):
+      with self.session():
+        tf_ygrad, np_ygrad = self._input([3, inner_size],
+                                         dtype=dtypes_lib.float32)
+        segment_ids = [0, 1, 2, 2, 2]
+        indices = [0, 0, 0, 0, 0]
+        output_dim0 = 1
+        ops_list = [
+            (math_ops.sparse_segment_sum_grad_v2, "sum"),
+            (math_ops.sparse_segment_mean_grad_v2, "mean"),
+            (math_ops.sparse_segment_sqrt_n_grad_v2, "sqrtn"),
+        ]
+        for tf_op, mode in ops_list:
+          np_xgrad, np_unique_indices = self._sparseSegmentReduceGradV2(
+              np_ygrad, indices, segment_ids, mode)
+          tf_xgrad, tf_unique_indices = tf_op(
+              tf_ygrad, indices, segment_ids, output_dim0)
+          self.assertAllClose(tf_xgrad, np_xgrad)
+          self.assertAllClose(tf_unique_indices, np_unique_indices)
+
   def testGradientValid(self):
     # Baseline for the testGradient*Invalid* methods below.
     tf_x, _ = self._input([3, 4], dtype=dtypes_lib.float32)
@@ -1146,6 +1205,118 @@ class SparseSegmentReductionOpTest(SparseSegmentReductionHelper):
         s = tf_op(tf_x, tf_indices, segment_indices, 10)
         with self.assertRaisesOpError(r"Segment id 0 out of range \[0, 0\)"):
           self.evaluate(s)
+
+  def testGradientV2Valid(self):
+    # Baseline for the testGradientV2*Invalid* methods below.
+    tf_x, _ = self._input([3, 4], dtype=dtypes_lib.float32)
+    ops_list = [
+        math_ops.sparse_segment_sum_grad_v2,
+        math_ops.sparse_segment_mean_grad_v2,
+        math_ops.sparse_segment_sqrt_n_grad_v2
+    ]
+    segment_indices = [0, 1, 2, 2]
+    tf_indices = [8, 3, 0, 9]
+    with self.session(use_gpu=False):
+      for tf_op in ops_list:
+        s, j = tf_op(tf_x, tf_indices, segment_indices, 10)
+        self.evaluate([s, j])
+
+  @test_util.run_deprecated_v1
+  def testGradientV2IndicesInvalid1(self):
+    tf_x, _ = self._input([3, 4], dtype=dtypes_lib.float32)
+    ops_list = [
+        math_ops.sparse_segment_sum_grad_v2,
+        math_ops.sparse_segment_mean_grad_v2,
+        math_ops.sparse_segment_sqrt_n_grad_v2
+    ]
+    segment_indices = [0, 1, 2, 2]
+    tf_indices = [8, 3, 0, 10]
+    with self.session(use_gpu=False):
+      for tf_op in ops_list:
+        s, j = tf_op(tf_x, tf_indices, segment_indices, 10)
+        with self.assertRaisesOpError(r"Index 10 out of range \[0, 10\)"):
+          self.evaluate([s, j])
+
+  @test_util.run_deprecated_v1
+  def testGradientV2IndicesInvalid2(self):
+    tf_x, _ = self._input([3, 4], dtype=dtypes_lib.float32)
+    ops_list = [
+        math_ops.sparse_segment_sum_grad_v2,
+        math_ops.sparse_segment_mean_grad_v2,
+        math_ops.sparse_segment_sqrt_n_grad_v2
+    ]
+    segment_indices = [0, 1, 2, 2]
+    tf_indices = [8, 3, -1, 9]
+    with self.session(use_gpu=False):
+      for tf_op in ops_list:
+        s, j = tf_op(tf_x, tf_indices, segment_indices, 10)
+        with self.assertRaisesOpError(r"Index -1 out of range \[0, 10\)"):
+          self.evaluate([s, j])
+
+  @test_util.run_deprecated_v1
+  def testGradientV2SegmentsInvalid1(self):
+    tf_x, _ = self._input(
+        [3, 4], dtype=dtypes_lib.float32)  # expecting 3 segments
+    ops_list = [
+        math_ops.sparse_segment_sum_grad_v2,
+        math_ops.sparse_segment_mean_grad_v2,
+        math_ops.sparse_segment_sqrt_n_grad_v2
+    ]
+    segment_indices = [0, 1, 1, 4]  # 5 segments
+    tf_indices = [8, 3, 0, 9]
+    with self.session(use_gpu=False):
+      for tf_op in ops_list:
+        s, j = tf_op(tf_x, tf_indices, segment_indices, 10)
+        with self.assertRaisesOpError("Invalid number of segments"):
+          self.evaluate([s, j])
+
+  @test_util.run_deprecated_v1
+  def testGradientV2SegmentsInvalid2(self):
+    tf_x, _ = self._input([1, 4], dtype=dtypes_lib.float32)
+    ops_list = [
+        math_ops.sparse_segment_sum_grad_v2,
+        math_ops.sparse_segment_mean_grad_v2,
+        math_ops.sparse_segment_sqrt_n_grad_v2
+    ]
+    segment_indices = [0, 1, 2, 0]
+    tf_indices = [8, 3, 0, 9]
+    with self.session(use_gpu=False):
+      for tf_op in ops_list:
+        s, j = tf_op(tf_x, tf_indices, segment_indices, 10)
+        with self.assertRaisesOpError(r"Segment id 1 out of range \[0, 1\)"):
+          self.evaluate([s, j])
+
+  @test_util.run_deprecated_v1
+  def testGradientV2SegmentsInvalid3(self):
+    tf_x, _ = self._input([2, 4], dtype=dtypes_lib.float32)
+    ops_list = [
+        math_ops.sparse_segment_sum_grad_v2,
+        math_ops.sparse_segment_mean_grad_v2,
+        math_ops.sparse_segment_sqrt_n_grad_v2
+    ]
+    segment_indices = [-1, 0, 1, 1]
+    tf_indices = [8, 3, 0, 9]
+    with self.session(use_gpu=False):
+      for tf_op in ops_list:
+        s, j = tf_op(tf_x, tf_indices, segment_indices, 10)
+        with self.assertRaisesOpError(r"Segment id -1 out of range \[0, 2\)"):
+          self.evaluate([s, j])
+
+  @test_util.run_deprecated_v1
+  def testGradientV2SegmentsInvalid4(self):
+    tf_x, _ = self._input([0, 4], dtype=dtypes_lib.float32)
+    ops_list = [
+        math_ops.sparse_segment_sum_grad_v2,
+        math_ops.sparse_segment_mean_grad_v2,
+        math_ops.sparse_segment_sqrt_n_grad_v2
+    ]
+    segment_indices = [0, 1, 2, -1]
+    tf_indices = [8, 3, 0, 9]
+    with self.session(use_gpu=False):
+      for tf_op in ops_list:
+        s, j = tf_op(tf_x, tf_indices, segment_indices, 10)
+        with self.assertRaisesOpError(r"Segment id 0 out of range \[0, 0\)"):
+          self.evaluate([s, j])
 
 
 class SegmentReductionOpBenchmark(test.Benchmark):

--- a/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
@@ -4501,6 +4501,10 @@ tf_module {
     argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "SparseSegmentMeanGradV2"
+    argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'dense_output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "SparseSegmentMeanWithNumSegments"
     argspec: "args=[\'data\', \'indices\', \'segment_ids\', \'num_segments\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -4513,6 +4517,10 @@ tf_module {
     argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "SparseSegmentSqrtNGradV2"
+    argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'dense_output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "SparseSegmentSqrtNWithNumSegments"
     argspec: "args=[\'data\', \'indices\', \'segment_ids\', \'num_segments\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -4523,6 +4531,10 @@ tf_module {
   member_method {
     name: "SparseSegmentSumGrad"
     argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "SparseSegmentSumGradV2"
+    argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'dense_output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
     name: "SparseSegmentSumWithNumSegments"

--- a/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
@@ -4501,6 +4501,10 @@ tf_module {
     argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "SparseSegmentMeanGradV2"
+    argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'dense_output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "SparseSegmentMeanWithNumSegments"
     argspec: "args=[\'data\', \'indices\', \'segment_ids\', \'num_segments\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -4513,6 +4517,10 @@ tf_module {
     argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "SparseSegmentSqrtNGradV2"
+    argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'dense_output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "SparseSegmentSqrtNWithNumSegments"
     argspec: "args=[\'data\', \'indices\', \'segment_ids\', \'num_segments\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
@@ -4523,6 +4531,10 @@ tf_module {
   member_method {
     name: "SparseSegmentSumGrad"
     argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "SparseSegmentSumGradV2"
+    argspec: "args=[\'grad\', \'indices\', \'segment_ids\', \'dense_output_dim0\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
     name: "SparseSegmentSumWithNumSegments"


### PR DESCRIPTION
`embedding_lookup_sparse` currently uses separate `Unique` + `Gather` + `SparseSegmentSum` ops. In some cases the `Unique` and `Gather` ops can be elided, leaving the `SparseSegmentSum` to read the embeddings directly. However, this causes the function to return a dense gradient, which is impractical in cases where the embedding table is very large.

This series of PRs solves this problem by adding a new op, `SparseSegmentSumGradV2` (plus `Mean/SqrtN` versions), that fuses the Unique operation into the gradient calculation and directly returns a sparse gradient (`IndexedSlices`). In addition to enabling elision of the `Gather` + `Unique` ops in more cases, the new op also improves performance by taking advantage of lower-precision indexing for internal temporary tensors. An included benchmark demonstrates a 2x speedup for `embedding_lookup_sparse` out of the box.

More details are available in the commit messages.

Part 1 adds the new ops with a CPU kernel implementation.
[Part 2](https://github.com/tensorflow/tensorflow/pull/61294) adds GPU kernel implementations.
[Part 3](https://github.com/tensorflow/tensorflow/pull/61491) integrates the new ops into `embedding_lookup_sparse` and includes a benchmark.

cc @nluehr @pjannaty 