### PR TITLE
Standardize error messages from invalid shapes for Mkl MatMul and Bat…

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
@@ -81,18 +81,19 @@ class BatchMatMulMkl : public OpKernel {
     if (!v2_bcast) {
       // Using V1, so check to make sure lhs and rhs dimensions are correct and
       // no broadcasting is needed.
-      OP_REQUIRES(ctx, lhs.dims() == rhs.dims(),
-                  errors::InvalidArgument("lhs and rhs has different ndims: ",
-                                          lhs.shape().DebugString(), " vs. ",
-                                          rhs.shape().DebugString()));
-      const int ndims = lhs.dims();
       OP_REQUIRES(
-          ctx, ndims >= 2,
-          errors::InvalidArgument("lhs and rhs ndims must be >= 2: ", ndims));
+          ctx, lhs.dims() == rhs.dims(),
+          errors::InvalidArgument("In[0] and In[1] has different ndims: ",
+                                  lhs.shape().DebugString(), " vs. ",
+                                  rhs.shape().DebugString()));
+      const int ndims = lhs.dims();
+      OP_REQUIRES(ctx, ndims >= 2,
+                  errors::InvalidArgument(
+                      "In[0] and In[1] ndims must be >= 2: ", ndims));
       for (int i = 0; i < ndims - 2; ++i) {
         OP_REQUIRES(ctx, lhs.dim_size(i) == rhs.dim_size(i),
                     errors::InvalidArgument(
-                        "lhs.dim(", i, ") and rhs.dim(", i,
+                        "In[0].dim(", i, ") and In[1].dim(", i,
                         ") must be the same: ", lhs.shape().DebugString(),
                         " vs ", rhs.shape().DebugString()));
       }
@@ -126,11 +127,11 @@ class BatchMatMulMkl : public OpKernel {
 
     if (adj_x_) std::swap(lhs_rows, lhs_cols);
     if (adj_y_) std::swap(rhs_rows, rhs_cols);
-    OP_REQUIRES(ctx, lhs_cols == rhs_rows,
-                errors::InvalidArgument(
-                    "lhs mismatch rhs shape: ", lhs_cols, " vs. ", rhs_rows,
-                    ": ", lhs.shape().DebugString(), " ",
-                    rhs.shape().DebugString(), " ", adj_x_, " ", adj_y_));
+    OP_REQUIRES(
+        ctx, lhs_cols == rhs_rows,
+        errors::InvalidArgument(
+            "Matrix size-incompatible: In[0]: ", lhs.shape().DebugString(),
+            ", In[1]: ", rhs.shape().DebugString(), " ", adj_x_, " ", adj_y_));
 
     out_shape.AddDim(lhs_rows);
     out_shape.AddDim(rhs_cols);


### PR DESCRIPTION
This PR:
- fixes the failing test on Arm CI caused by #60355
- standardizes the use of In[0], In[1] instead of lhs, rhs in error messages