### PR TITLE
Adds mkl_batch_matmul_op to mkl_matmul_op_benchmark build

### DIFF
--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -481,6 +481,7 @@ tf_cc_test_mkl(
     deps = [
         "//tensorflow/core/kernels:matmul_op",
         "//tensorflow/core/kernels/mkl:mkl_matmul_op",
+        "//tensorflow/core/kernels/mkl:mkl_batch_matmul_op",
     ] + MKL_TEST_DEPS,
 )
 


### PR DESCRIPTION
Following https://github.com/tensorflow/tensorflow/pull/60355, the BUILD file for mkl_matmul_op_benchmark needs to be updated.