### PR TITLE
Add ignore nan loss and metric

### DIFF
--- a/tensorflow/python/keras/losses.py
+++ b/tensorflow/python/keras/losses.py
@@ -1233,7 +1233,8 @@ class LossIgnoreNaN(Loss):
   
   @staticmethod
   def mask_nan_values(y_true, y_pred):
-    non_nan_mask = gen_math_ops.logical_not(gen_math_ops.is_nan(y_true))
+    nan_mask = gen_math_ops.logical_or(gen_math_ops.is_nan(y_true), gen_math_ops.is_nan(y_pred))
+    non_nan_mask = gen_math_ops.logical_not(nan_mask)
     y_true_non_nan = array_ops.boolean_mask(y_true, non_nan_mask)
     y_pred_non_nan = array_ops.boolean_mask(y_pred, non_nan_mask)
     return y_true_non_nan, y_pred_non_nan

--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -3399,7 +3399,8 @@ class MetricIgnoreNaN(Metric):
 
   @staticmethod
   def mask_nan_values(y_true, y_pred):
-    non_nan_mask = gen_math_ops.logical_not(gen_math_ops.is_nan(y_true))
+    nan_mask = gen_math_ops.logical_or(gen_math_ops.is_nan(y_true), gen_math_ops.is_nan(y_pred))
+    non_nan_mask = gen_math_ops.logical_not(nan_mask)
     y_true_non_nan = array_ops.boolean_mask(y_true, non_nan_mask)
     y_pred_non_nan = array_ops.boolean_mask(y_pred, non_nan_mask)
     return y_true_non_nan, y_pred_non_nan


### PR DESCRIPTION
Create classes for metrics and losses in the Keras TensorFlow project that can ignore NaN values in the labels by wrapping another metric or loss and computing it.