### PR TITLE
[PluggableDevice] Reduce the log times when plugin is enabled

### DIFF
--- a/tensorflow/core/grappler/optimizers/custom_graph_optimizer_registry.cc
+++ b/tensorflow/core/grappler/optimizers/custom_graph_optimizer_registry.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <string>
 #include <unordered_map>
 
+#include "absl/base/call_once.h"
 #include "tensorflow/core/platform/logging.h"
 
 namespace tensorflow {
@@ -111,8 +112,11 @@ PluginGraphOptimizerRegistry::CreateOptimizers(
   for (auto it = GetPluginRegistrationMap()->begin();
        it != GetPluginRegistrationMap()->end(); ++it) {
     if (device_types.find(it->first) == device_types.end()) continue;
-    LOG(INFO) << "Plugin optimizer for device_type " << it->first
-              << " is enabled.";
+    static absl::once_flag plugin_optimizer_flag;
+    absl::call_once(plugin_optimizer_flag, [&]() {
+      LOG(INFO) << "Plugin optimizer for device_type " << it->first
+                << " is enabled.";
+    });
     optimizer_list.emplace_back(
         std::unique_ptr<CustomGraphOptimizer>(it->second()));
   }


### PR DESCRIPTION
# Background
TF will print some info in each session as below when plugin is enabled:
```
2022-09-07 09:40:01.716295: I tensorflow/core/grappler/optimizers/custom_graph_optimizer_registry.cc:113] Plugin optimizer for device_type CPU is enabled.
```
These info will be printed **many** times and bother user if there're multiple sessions.

# Solution
Add `call_once` flag for the info, since user won't change the pluggable device after TF is initialized.

Signed-off-by: Lu Teng [teng.lu@intel.com](mailto:teng.lu@intel.com)