### PR TITLE
Re-enable CPUInfo on Apple platform.

### DIFF
--- a/tensorflow/lite/kernels/cpu_backend_context.cc
+++ b/tensorflow/lite/kernels/cpu_backend_context.cc
@@ -44,8 +44,7 @@ namespace tflite {
 extern TFLITE_ATTRIBUTE_WEAK bool UseGemmlowpOnX86();
 #endif  // defined(TFLITE_HAS_ATTRIBUTE_WEAK) && !(__APPLE__)
 
-// TODO(b/138922878) Enable when Ruy builds on Apple.
-#if defined(TFLITE_HAVE_CPUINFO) && !defined(__APPLE__)
+#if defined(TFLITE_HAVE_CPUINFO)
 CpuBackendContext::CpuInfo::~CpuInfo() {
   if (init_status_ == InitStatus::kInitialized) {
     cpuinfo_deinitialize();


### PR DESCRIPTION
b/138922878 has been closed as fixed for years.