### PR TITLE
[oneDNN][BUG FIX] Fix to mkl_eager_op_rewrite_test

### DIFF
--- a/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
+++ b/tensorflow/core/common_runtime/eager/mkl_eager_op_rewrite_test.cc
@@ -38,12 +38,13 @@ class EagerOpRewriteTest : public ::testing::Test {
         std::make_unique<StaticDeviceMgr>(DeviceFactory::NewDevice(
             "CPU", {}, "/job:localhost/replica:0/task:0/device:CPU:0"));
     bool async = false;
-    tensorflow::Rendezvous* rendezvous =
-        new tensorflow::IntraProcessRendezvous(device_mgr.get());
+    auto rendezvous =
+        tsl::core::RefCountPtr<tensorflow::IntraProcessRendezvous>(
+            new tensorflow::IntraProcessRendezvous(device_mgr.get()));
     eager_ctx_ = new tensorflow::EagerContext(
         SessionOptions(),
         tensorflow::ContextDevicePlacementPolicy::DEVICE_PLACEMENT_SILENT,
-        async, device_mgr.get(), false, rendezvous, nullptr, nullptr,
+        async, device_mgr.get(), false, std::move(rendezvous), nullptr, nullptr,
         /*run_eager_op_as_function=*/true);
 
     EagerExecutor executor_(false);


### PR DESCRIPTION
This PR fixes a failure to the test `//tensorflow/core/common_runtime/eager:mkl_eager_op_rewrite_test`. The test runs with `--config=mkl`. It is failing due to a recent change to `EagerContext`(https://github.com/tensorflow/tensorflow/commit/ee855630f68e6fbfee334fb9ce3aab7f4dbad16a).

In order to fix, this PR updates the test with `tsl::core::RefCountPtr<tensorflow::IntraProcessRendezvous>` instead of raw pointer.