### PR TITLE
fix AMD ROCm CI build failing due to missing patchelf package

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.rocm
+++ b/tensorflow/tools/ci_build/Dockerfile.rocm
@@ -52,6 +52,7 @@ RUN apt-get update --allow-insecure-repositories && DEBIAN_FRONTEND=noninteracti
   libboost-filesystem-dev \
   rpm \
   libnuma-dev \
+  patchelf \
   pciutils \
   virtualenv \
   python3-pip \


### PR DESCRIPTION
fix AMD ROCm CI build failing due to missing patchelf package