### PR TITLE
[Linaro:ARM_CI] Remove possible flaky test from skip list.

### DIFF
--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -16,6 +16,5 @@
 set -x
 
 ARM_SKIP_TESTS="-//tensorflow/lite/... \
--//tensorflow/python/kernel_tests/nn_ops:atrous_conv2d_test \
 -//tensorflow/python/kernel_tests/nn_ops:conv_ops_test \
 "


### PR DESCRIPTION
//tensorflow/python/kernel_tests/nn_ops:atrous_conv2d_test was put on the skip list for being flaky. Remove it now to check current status.