### PR TITLE
[oneDNN v3.x]: Enabled weight caching in convolution

### DIFF
--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -219,6 +219,7 @@ tf_mkl_kernel_library(
 tf_mkl_kernel_library(
     name = "mkl_conv_op",
     hdrs = [
+        "mkl_kernel_util.h",
         "mkl_quantized_conv_ops.h",
     ],
     prefix = "mkl_conv",

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -914,10 +914,6 @@ class MklConvOp : public OpKernel {
         // Tensorflow format to MKL format by caching the filter when it is
         // converted for the first time. This cached filter can then be reused
         // in subsequent iterations.
-        // TODO(intel-tf): When oneDNN major version changes to v4.x, weight
-        // caching may not work as expected if the underlying memory descriptor
-        // has changed (i.e. compared to v3.x). We have to return a status here
-        // to catch oneDNN major version change to avoid unexpected results.
         if (is_filter_const_) {
           if (IsFilterCacheEmpty(context)) {
             // Cache filter if it is not already cached.

--- a/tensorflow/core/kernels/mkl/mkl_kernel_util.h
+++ b/tensorflow/core/kernels/mkl/mkl_kernel_util.h
@@ -50,6 +50,11 @@ class MklTestingUtil {
 // Since oneDNN v3.x exposes only an opaque memory descriptor, it is no longer
 // possible to cache the entire filter memory descriptor as is. So we store
 // all relevant information about it in the following class.
+//
+// TODO(intel-tf): When oneDNN major version changes to v4.x, weight
+// caching may not work as expected if the underlying memory descriptor
+// has changed (i.e. compared to v3.x). We have to return a status here
+// to catch oneDNN major version change to avoid unexpected results.
 class FilterMemoryDesc {
  public:
   FilterMemoryDesc() {}

--- a/tensorflow/core/kernels/mkl/mkl_kernel_util.h
+++ b/tensorflow/core/kernels/mkl/mkl_kernel_util.h
@@ -46,6 +46,47 @@ class MklTestingUtil {
   }
 };
 
+#ifdef ENABLE_ONEDNN_V3
+// Since oneDNN v3.x exposes only an opaque memory descriptor, it is no longer
+// possible to cache the entire filter memory descriptor as is. So we store
+// all relevant information about it in the following class.
+class FilterMemoryDesc {
+ public:
+  FilterMemoryDesc() {}
+
+  explicit FilterMemoryDesc(int ndims, int inner_nblks,
+                            memory::data_type data_type,
+                            const memory::dims& dims,
+                            const memory::dims& inner_blks,
+                            const memory::dims& inner_idxs,
+                            const memory::dims& strides)
+      : ndims_(ndims),
+        inner_nblks_(inner_nblks),
+        data_type_(data_type),
+        dims_(dims),
+        inner_blks_(inner_blks),
+        inner_idxs_(inner_idxs),
+        strides_(strides) {}
+
+  ~FilterMemoryDesc() {}
+
+  bool operator==(const FilterMemoryDesc& other) const {
+    return (ndims_ == other.ndims_ && inner_nblks_ == other.inner_nblks_ &&
+            data_type_ == other.data_type_ && dims_ == other.dims_ &&
+            inner_blks_ == other.inner_blks_ &&
+            inner_idxs_ == other.inner_idxs_ && strides_ == other.strides_);
+  }
+
+ private:
+  int ndims_;
+  int inner_nblks_;
+  memory::data_type data_type_;
+  memory::dims dims_;
+  memory::dims inner_blks_;
+  memory::dims inner_idxs_;
+  memory::dims strides_;
+};
+#endif  // ENABLE_ONEDNN_V3
 }  // namespace tensorflow
 
 #endif  // INTEL_MKL


### PR DESCRIPTION
- This PR enables weight caching in convolution for oneDNN v3.x.
- This PR passes all unit tests related to weight caching when oneDNN v3.x is enabled.
- This PR does not affect Eigen implementation and is specific only to oneDNN.