### PR TITLE
Revert "Update keras version in TF-core release branch to 2.13 release"

### DIFF
--- a/tensorflow/tools/ci_build/release/requirements_common.txt
+++ b/tensorflow/tools/ci_build/release/requirements_common.txt
@@ -25,7 +25,7 @@ gast == 0.4.0
 # Note that here we want the latest version that matches TF major.minor version
 # Note that we must use nightly here as these are used in nightly jobs
 # For release jobs, we will pin these on the release branch
-keras-nightly ~= 2.13.1.dev
+keras-nightly ~= 2.13.0.dev
 tb-nightly ~= 2.13.0.a
 tf-estimator-nightly ~= 2.13.0.dev
 


### PR DESCRIPTION
Reverts tensorflow/tensorflow#60484

We need to revert, there is no such version: https://pypi.org/project/keras-nightly/#history