### PR TITLE
[BUG]Add nullptr check

### DIFF
--- a/tensorflow/c/kernels.cc
+++ b/tensorflow/c/kernels.cc
@@ -357,6 +357,10 @@ void TF_GetInput(TF_OpKernelContext* ctx, int i, TF_Tensor** tensor,
     return;
   }
   const ::tensorflow::Tensor& cc_tensor(cc_ctx->input(i));
+  if ((&cc_tensor) == nullptr) {
+    *tensor = nullptr;
+    return;
+  }
   TF_Tensor* result =
       ::tensorflow::TF_TensorFromTensor(cc_tensor, &status->status);
   if (TF_GetCode(status) == TF_OK) {


### PR DESCRIPTION
When we get inputs of Merge operator by this API, we may get segmentation fault since the input can be nullptr.
Add nullptr check to avoid this bug.