### PR TITLE
Add missing `stdint.h` include

### DIFF
--- a/tensorflow/lite/kernels/internal/spectrogram.cc
+++ b/tensorflow/lite/kernels/internal/spectrogram.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <assert.h>
 #include <math.h>
+#include <stdint.h>
 
 #include "third_party/fft2d/fft.h"
 


### PR DESCRIPTION
Since a recent compiler update (`gcc (GCC) 13.1.1 20230429`), `spectrogram.cc` fails to compile because `uint32_t` is no longer defined. This PR adds the missing include.

I'm not sure if `<cstdint>` or `<stdint.h>` is preferred. I went with the latter to follow the style of the other includes in the file.