### PR TITLE
Update LeakyRelu.pbtxt

### DIFF
--- a/tensorflow/core/ops/compat/ops_history_v1/LeakyRelu.pbtxt
+++ b/tensorflow/core/ops/compat/ops_history_v1/LeakyRelu.pbtxt
@@ -59,6 +59,7 @@ op {
         type: DT_BFLOAT16
         type: DT_FLOAT
         type: DT_DOUBLE
+        type: DT_INT
       }
     }
   }

--- a/tensorflow/core/ops/compat/ops_history_v2/LeakyRelu.pbtxt
+++ b/tensorflow/core/ops/compat/ops_history_v2/LeakyRelu.pbtxt
@@ -59,6 +59,7 @@ op {
         type: DT_BFLOAT16
         type: DT_FLOAT
         type: DT_DOUBLE
+        type: DT_INT
       }
     }
   }


### PR DESCRIPTION
https://github.com/tensorflow/tensorflow/issues/60521 issue no. #60521
"According to doc(https://tensorflow.google.cn/api_docs/python/tf/nn/leaky_relu), the argument features can be float16, float32, float64, int32, int64. But the error message in following snippet code indicates that the type of features can only be float16, float32, float64 without int." This is my first contribution to open source so please excuse any mistake and please tell if anything is wrong.