### PR TITLE
[tflite] delegate cos to NNAPI

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -1464,10 +1464,10 @@ class NNAPIOpBuilder {
     // NNAPI only supports float sin
     auto tensor_size = theta.bytes / sizeof(float);
 
-    // Convert cos to sin: $cos(x) = sin(\pi - x)$
+    // Convert cos to sin: $cos(x) = sin(\frac{\pi}{2} - x)$
     auto data = theta.data.f;
     for (int i = 0; i < tensor_size; i++) {
-      data[i] = M_PI - data[i];
+      data[i] = M_PI_2 - data[i];
     }
 
     return kTfLiteOk;

--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -1456,6 +1456,23 @@ class NNAPIOpBuilder {
     return kTfLiteOk;
   }
 
+  TfLiteStatus TransformCosIntoSupportedOps(int lite_node_index,
+                                            TfLiteNode* node,
+                                            TfLiteRegistration* reg) {
+    const TfLiteTensor& theta = context_->tensors[node->inputs->data[0]];
+
+    // NNAPI only supports float sin
+    auto tensor_size = theta.bytes / sizeof(float);
+
+    // Convert cos to sin: $cos(x) = sin(\pi - x)$
+    auto data = theta.data.f;
+    for (int i = 0; i < tensor_size; i++) {
+      data[i] = M_PI - data[i];
+    }
+
+    return kTfLiteOk;
+  }
+
   // Finish emitting the op (of type `type`) into the NN API.
   TfLiteStatus FinalizeAddOperation(ANeuralNetworksOperationType type,
                                     int lite_node_index) {
@@ -2940,6 +2957,7 @@ bool NNAPIDelegateKernel::Validate(
              NNAPIValidationFailureType::kUnsupportedInputType,
              "Size type should be Int32", &val_ctx);
     } break;
+    case kTfLiteBuiltinCos:
     case kTfLiteBuiltinSin: {
       ExpectOpVersion(version, 1, &val_ctx);
       ExpectMinAndroidSdkVersion(android_sdk_version, kMinSdkVersionForNNAPI12,
@@ -3966,6 +3984,9 @@ TfLiteStatus NNAPIDelegateKernel::Map(
     } break;
     case kTfLiteBuiltinSlice: {
       *nn_op_type = ANEURALNETWORKS_SLICE;
+    } break;
+    case kTfLiteBuiltinCos: {
+      *nn_op_type = ANEURALNETWORKS_SIN;
     } break;
     case kTfLiteBuiltinSin: {
       *nn_op_type = ANEURALNETWORKS_SIN;
@@ -5594,6 +5615,12 @@ TfLiteStatus NNAPIDelegateKernel::AddOpsAndTensors(
     if (reg->builtin_code == kTfLiteBuiltinSquaredDifference) {
       TF_LITE_ENSURE_STATUS(builder.TransformSquaredDifferenceIntoSupportedOps(
           node_index, node, reg));
+      continue;
+    }
+    // Delegate COS by lowering it into SIN.
+    if (reg->builtin_code == kTfLiteBuiltinCos) {
+      TF_LITE_ENSURE_STATUS(
+          builder.TransformCosIntoSupportedOps(node_index, node, reg));
       continue;
     }
     // Fully quantized full LSTM.

--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate_test.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate_test.cc
@@ -1713,6 +1713,15 @@ TEST(Elementwise, Sin) {
   EXPECT_THAT(m.GetTensorShape(m.output()), ElementsAreArray({1, 1, 4, 1}));
 }
 
+TEST(Elementwise, Cos) {
+  ElementwiseOpFloatModel m(BuiltinOperator_COS, {1, 1, 4, 1});
+  m.PopulateTensor<float>(m.input(), {0, 3.1415926, -3.1415926, 1});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.ExtractVector<float>(m.output()),
+              ElementsAreArray(ArrayFloatNear({1.0, -1, -1, 0.54030})));
+  EXPECT_THAT(m.GetTensorShape(m.output()), ElementsAreArray({1, 1, 4, 1}));
+}
+
 TEST(Elementwise, Sqrt) {
   ElementwiseOpFloatModel m(BuiltinOperator_SQRT, {1, 1, 4, 1});
   m.PopulateTensor<float>(m.input(), {0, 1, 2, 4});


### PR DESCRIPTION
We need cosine for some networks, such as transformer positional encoding. Cosine is not directly supported by NNAPI, but we know $cos(x) = sin(\frac{\pi}{2} - x)$