### PR TITLE
Fix unit test failures

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -546,6 +546,9 @@ tf_xla_py_test(
     size = "medium",
     srcs = ["tensor_float_32_test.py"],
     python_version = "PY3",
+    tags = [
+        "no_pip",  # TODO(b/149738646): fix pip install so these tests run on kokoro pip
+    ],
     use_xla_device = False,  # Uses tf.function(jit_compile=True)
     deps = [
         ":xla_test",


### PR DESCRIPTION
Add tag to tensor_float_32_test to prevent its running on pip where it will fail due to being unable to import xla_test from tensorflow.compiler.tests