### PR TITLE
[INTEL oneDNN][Bug Fix] Fix incorrect use of int for dim size related to oneDNN gemm and matmul op

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op.cc
@@ -90,9 +90,9 @@ class MklMatMulOp : public OpKernel {
       (void)SetFPMathMode();
     }
 
-    const int m = a.dim_size(1 - dim_pair[0].first);
-    const int k = a.dim_size(dim_pair[0].first);
-    const int n = b.dim_size(1 - dim_pair[0].second);
+    const int64_t m = a.dim_size(1 - dim_pair[0].first);
+    const int64_t k = a.dim_size(dim_pair[0].first);
+    const int64_t n = b.dim_size(1 - dim_pair[0].second);
     bool transpose_a = dim_pair[0].first == 0;
     bool transpose_b = dim_pair[0].second == 1;
 
@@ -147,9 +147,10 @@ class MklMatMulOp : public OpKernel {
   // layout, leading dimension is the stride between consecutive rows, max(1,n)
   //
   // --------------------------------------------------------------------------
-  void MklBlasGemm(OpKernelContext* ctx, bool transa, bool transb, const int m,
-                   const int n, const int k, const float* a, const int lda,
-                   const float* b, const int ldb, float* c, const int ldc) {
+  void MklBlasGemm(OpKernelContext* ctx, bool transa, bool transb,
+                   const int64_t m, const int64_t n, const int64_t k,
+                   const float* a, const int64_t lda, const float* b,
+                   const int64_t ldb, float* c, const int64_t ldc) {
     // BLAS GEMM API defines Matrix Multiplication as c = alpha * op(a) * op(b)
     // + beta * c.
     // Since TF MatMul does not have parameters for alpha, beta, we set them to
@@ -180,10 +181,10 @@ class MklMatMulOp : public OpKernel {
 #endif  // !ENABLE_ONEDNN_OPENMP
   }
 
-  void MklBlasGemm(OpKernelContext* ctx, bool transa, bool transb, const int m,
-                   const int n, const int k, const bfloat16* a, const int lda,
-                   const bfloat16* b, const int ldb, bfloat16* c,
-                   const int ldc) {
+  void MklBlasGemm(OpKernelContext* ctx, bool transa, bool transb,
+                   const int64_t m, const int64_t n, const int64_t k,
+                   const bfloat16* a, const int64_t lda, const bfloat16* b,
+                   const int64_t ldb, bfloat16* c, const int64_t ldc) {
     const float alpha = 1.0f;
     const float beta = 0.0f;
     const int index_transa = transa ? 1 : 0;

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -40,7 +40,8 @@ namespace tensorflow {
 static Eigen::internal::CacheSizes cache_sizes = Eigen::internal::CacheSizes();
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
-inline bool ExecuteSingleThreadedGemm(int64_t m, int64_t n, int64_t k, int bytes) {
+inline bool ExecuteSingleThreadedGemm(int64_t m, int64_t n, int64_t k,
+                                      int bytes) {
   // Ideally we would like to determine blocking and then come up with
   // a heuristic but what we are targeting are very small models whose
   // total size is < x*L2. So we will do this simple calculation

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -40,7 +40,8 @@ namespace tensorflow {
 static Eigen::internal::CacheSizes cache_sizes = Eigen::internal::CacheSizes();
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
-inline bool ExecuteSingleThreadedGemm(int64_t m, int64_t n, int64_t k, int bytes) {
+inline bool ExecuteSingleThreadedGemm(int64_t m, int64_t n,
+                                      int64_t k, int bytes) {
   // Ideally we would like to determine blocking and then come up with
   // a heuristic but what we are targeting are very small models whose
   // total size is < x*L2. So we will do this simple calculation

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -40,7 +40,7 @@ namespace tensorflow {
 static Eigen::internal::CacheSizes cache_sizes = Eigen::internal::CacheSizes();
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
-inline bool ExecuteSingleThreadedGemm(int m, int n, int k, int bytes) {
+inline bool ExecuteSingleThreadedGemm(int64_t m, int64_t n, int64_t k, int bytes) {
   // Ideally we would like to determine blocking and then come up with
   // a heuristic but what we are targeting are very small models whose
   // total size is < x*L2. So we will do this simple calculation

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -40,13 +40,8 @@ namespace tensorflow {
 static Eigen::internal::CacheSizes cache_sizes = Eigen::internal::CacheSizes();
 
 typedef Eigen::ThreadPoolDevice CPUDevice;
-<<<<<<< HEAD
 inline bool ExecuteSingleThreadedGemm(int64_t m, int64_t n, int64_t k,
                                       int bytes) {
-=======
-inline bool ExecuteSingleThreadedGemm(int64_t m, int64_t n,
-                                      int64_t k, int bytes) {
->>>>>>> 96fce4b6739b792fff9d8abe2cecdaf1c0211338
   // Ideally we would like to determine blocking and then come up with
   // a heuristic but what we are targeting are very small models whose
   // total size is < x*L2. So we will do this simple calculation


### PR DESCRIPTION
This fixes incorrect use of int for dim size when invoking oneDNN gemm and matmul primitive. 
This causes overflow here:
     https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h#L52

and thus results in some large matmuls running single thread.

