### PR TITLE
[Linaro:ARM_CI] Run the non-pip tests for all python versions

### DIFF
--- a/.github/workflows/arm-ci-extended.yml
+++ b/.github/workflows/arm-ci-extended.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: [self-hosted, linux, ARM64]
     strategy:
       matrix:
-        pyver: ['3.10']
+        pyver: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Stop old running containers (if any)
         shell: bash


### PR DESCRIPTION
As the arm-ci-extended tests are only run once overnight then it should be run for all supported versions of Python.