### PR TITLE
[TF-TRT] Support conversion of FakeQuantWithMinMaxVars in explicit Q/DQ mode

### DIFF
--- a/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops.h
+++ b/tensorflow/compiler/tf2tensorrt/convert/ops/quantization_ops.h
@@ -34,8 +34,9 @@ constexpr std::array<const char*, 4> kQuantizationOpNames = {
 
 // Operations with supported conversion to Q/DQ ops in TensorRT explicit
 // precision mode.
-constexpr std::array<const char*, 1> kExplicitQuantizationOpNames = {
+constexpr std::array<const char*, 2> kExplicitQuantizationOpNames = {
     "QuantizeAndDequantizeV2",
+    "FakeQuantWithMinMaxVars"
 };
 
 // Contains two scaling factors for quantization and dequantization


### PR DESCRIPTION
## Overview
Support the keras quantization API by adding support for the FakeQuantWithMinMaxVars in explicit Q/DQ mode in TF-TRT. This is currently unimplemented in TF-TRT converter code.

## Change summary
### Use explicit precision
**use_explicit_precision** is the indicator if this specific layer is quantized or not. 
With the current implementation, TF-TRT converter will assume that **all** Conv2D layers are quantized in an engine. This is changed to checking if the Conv2D second input is a weight (not explicit) or tensor (explicit). This is more robust since keras training can decide to not quantize some layers.
### Transposing Conv2D input
In the explicit precision mode for Conv2D, the second input (which will be a tensor) is not transposed properly as required by TRT. From my extensive testing, building the cuda engine fails unless we add the transpose **before** adding the `iConvolutionLayer` to the TensorRT network. Will add more notes to make this clear.
### Explicit precision converter for Keras-QAT API
Keras-QAT will use the `FakeQuantWithMinMaxVars` layer, which is not implemented in explicit precision mode. Implemented it using the other explicit converters as an example. Note that we found that `narrow_range` **must** be set to false otherwise conversion fails. See this issue for more details: https://github.com/tensorflow/tensorflow/issues/60168

## Tested
Internally, we were unable to optimize TF-QAT keras models with TensorRT due to the unimplemented issues. With these changes, are able to now convert a  fully quantization-aware trained perception model (1500+ layers) with no performance regressions. 

Please let me know if there are more unittests I can add on the tensorflow side. 