### PR TITLE
Update Args data types of tf.ones and tf.zeros

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -2832,6 +2832,8 @@ def zeros(shape, dtype=dtypes.float32, name=None):
   Args:
     shape: A `list` of integers, a `tuple` of integers, or
       a 1-D `Tensor` of type `int32`.
+      Note: Boolean datatypes True,False also acceptable and converted
+      into numerics 1,0 respectively.
     dtype: The DType of an element in the resulting `Tensor`.
     name: Optional string. A name for the operation.
 
@@ -3090,6 +3092,8 @@ def ones(shape, dtype=dtypes.float32, name=None):
   Args:
     shape: A `list` of integers, a `tuple` of integers, or
       a 1-D `Tensor` of type `int32`.
+      Note: Boolean datatypes True,False also acceptable and converted
+      into numerics 1,0 respectively.
     dtype: Optional DType of an element in the resulting `Tensor`. Default is
       `tf.float32`.
     name: Optional string. A name for the operation.

--- a/tensorflow/python/ops/linalg_ops.py
+++ b/tensorflow/python/ops/linalg_ops.py
@@ -219,6 +219,8 @@ def eye(num_rows,
   Args:
     num_rows: Non-negative `int32` scalar `Tensor` giving the number of rows
       in each batch matrix.
+      Note: Boolean data types True,False also acceptable and converts into
+          1, 0 respectively.
     num_columns: Optional non-negative `int32` scalar `Tensor` giving the number
       of columns in each batch matrix.  Defaults to `num_rows`.
     batch_shape:  A list or tuple of Python integers or a 1-D `int32` `Tensor`.


### PR DESCRIPTION
At present as per documentation of `tf.zeros` and `tf.ones`, both APIs have argument `shape` which accepts "A list of integers, a tuple of integers, or a 1-D Tensor of type int32 ". 

But its find out that when Boolean data types `True, False` passed to the `shape` argument it also accepts it and convert them into 1, 0 respectively and outputs correct results. Hence i am proposing to add a note under the '`shape`' argument description that it also accepts boolean data types.

Attaching the [gist](https://colab.research.google.com/gist/SuryanarayanaY/837bf1888c618e3585f4f7247c329885/tf-ones_tf-zeros_tf-eye.ipynb) also for referring the results. 

Also fixes #60457 