### PR TITLE
[oneDNN] Make cross_entropy calculations parallel on CPU

### DIFF
--- a/tensorflow/core/kernels/xent_op.cc
+++ b/tensorflow/core/kernels/xent_op.cc
@@ -170,8 +170,6 @@ struct XentFunctorBase {
 
         d.parallelFor(shape[0], cost, reductionWorker);
       }
-    //XentEigenImpl<Device, T>::Compute(d, shape, logits_bcast, labels_bcast,
-    //                                  logits, labels, scratch, loss, backprop);
   }
 };
 

--- a/tensorflow/core/kernels/xent_op.cc
+++ b/tensorflow/core/kernels/xent_op.cc
@@ -122,10 +122,10 @@ struct XentFunctorBase {
                   typename TTypes<T>::Matrix scratch,
                   typename TTypes<T>::Vec loss,
                   typename TTypes<T>::Matrix backprop) {
-      T* scratch_ptr = (T*)scratch.data();
-      T* backprop_ptr = (T*)backprop.data();
+      T* scratch_ptr = scratch.data();
+      T* backprop_ptr = backprop.data();
 
-      T* loss_ptr = (T*)loss.data();
+      T* loss_ptr = loss.data();
 
       int row_size = shape[1];
 

--- a/tensorflow/core/kernels/xent_op.cc
+++ b/tensorflow/core/kernels/xent_op.cc
@@ -96,15 +96,15 @@ class SoftmaxXentWithLogitsOp : public OpKernel {
     OP_REQUIRES_OK(context, context->forward_input_or_allocate_output(
                                 {0}, 1, shape_in, &back_out));
 
-    if (shape_in.dim_size(0) <= 0) return;
-
-    functor::XentFunctor<Device, T> functor;
-    functor(context->eigen_device<Device>(), shape_in.AsEigenDSizes<2>(),
-        BCast::ToIndexArray<2>(bcast.x_bcast()),
-        BCast::ToIndexArray<2>(bcast.y_bcast()),
-        logits_in.template shaped<T, 2>(bcast.x_reshape()),
-        labels_in.template shaped<T, 2>(bcast.y_reshape()),
-        scratch.matrix<T>(), loss_out->vec<T>(), back_out->matrix<T>());
+    if (shape_in.dim_size(0) > 0) {
+      functor::XentFunctor<Device, T> functor;
+      functor(context->eigen_device<Device>(), shape_in.AsEigenDSizes<2>(),
+              BCast::ToIndexArray<2>(bcast.x_bcast()),
+              BCast::ToIndexArray<2>(bcast.y_bcast()),
+              logits_in.template shaped<T, 2>(bcast.x_reshape()),
+              labels_in.template shaped<T, 2>(bcast.y_reshape()),
+              scratch.matrix<T>(), loss_out->vec<T>(), back_out->matrix<T>());
+    }
   }
 };
 


### PR DESCRIPTION
This optimization maximizes performance on CPU by implementing specialized CPU  [XentEigenImpl](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/xent_op.h#L52) class, which makes cross entropy parallel, while possibly using oneDNN for softmax calculations.
Original implementation calculates softmax_cross_entropy for a whole batch on a single thread. After optimization, each batch item is processed separately in parallel.

### Microbenchmarks
| Tensor Dims | Numeric Type | Before (ns) | After (ns) | Speed up |
|:----------:|:------------:|:-----------:|:----------:|:--------:|
|    1x10000 |    FLOAT32   |     593,294 |    641,580 |    0.92x |
|    2x10000 |    FLOAT32   |   1,027,291 |  1,027,994 |    1.00x |
|    4x10000 |    FLOAT32   |   1,363,172 |  1,225,472 |    1.11x |
|    8x10000 |    FLOAT32   |   2,871,685 |  1,177,349 |    2.44x |
|   16x10000 |    FLOAT32   |   3,395,105 |  1,468,886 |    2.31x |
|   32x10000 |    FLOAT32   |   4,318,577 |  1,643,422 |    2.63x |
|   64x10000 |    FLOAT32   |   5,095,850 |  1,786,184 |    2.85x |
|  128x10000 |    FLOAT32   |   6,130,740 |  2,179,011 |    2.81x |
|  256x10000 |    FLOAT32   |   6,216,732 |  2,858,630 |    2.17x |
|  512x10000 |    FLOAT32   |   7,033,319 |  3,207,006 |    2.19x |
| 1024x10000 |    FLOAT32   |  25,139,020 |  3,905,827 |    6.44x |
|    1x10000 |   BFLOAT16   |   1,449,381 |  1,655,900 |    0.88x |
|    2x10000 |   BFLOAT16   |   2,225,481 |  2,906,942 |    0.77x |
|    4x10000 |   BFLOAT16   |   3,543,601 |  2,921,440 |    1.21x |
|    8x10000 |   BFLOAT16   |   4,690,691 |  2,354,173 |    1.99x |
|   16x10000 |   BFLOAT16   |   6,033,001 |  2,568,764 |    2.35x |
|   32x10000 |   BFLOAT16   |   7,195,912 |  2,782,907 |    2.59x |
|   64x10000 |   BFLOAT16   |   7,901,942 |  3,114,311 |    2.54x |
|  128x10000 |   BFLOAT16   |   8,063,111 |  3,522,027 |    2.29x |
|  256x10000 |   BFLOAT16   |  10,001,815 |  4,475,105 |    2.23x |
|  512x10000 |   BFLOAT16   |  12,569,523 |  4,468,942 |    2.81x |
| 1024x10000 |   BFLOAT16   |  15,845,288 |  7,066,050 |    2.24x |
