### PR TITLE
update gtest version to 1.12.1

### DIFF
--- a/tensorflow/lite/tools/cmake/modules/Findgoogletest.cmake
+++ b/tensorflow/lite/tools/cmake/modules/Findgoogletest.cmake
@@ -22,7 +22,7 @@ include(OverridableFetchContent)
 OverridableFetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG release-1.10.0
+  GIT_TAG release-1.12.1
   GIT_SHALLOW TRUE
   GIT_PROGRESS TRUE
   SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest"


### PR DESCRIPTION
When I tried to build tf-lite with kernel test via cmake, I encounted build error.

This patch fixes the gtest version to resolve this problem.