### PR TITLE
Always link kernels_experimental c api

### DIFF
--- a/tensorflow/c/BUILD
+++ b/tensorflow/c/BUILD
@@ -806,6 +806,7 @@ tf_cuda_library(
         "//tensorflow/core/kernels/data:optional_ops_util",
         "//tensorflow/core/platform:abi",
     ]),
+    alwayslink = 1,
 )
 
 tf_cuda_library(


### PR DESCRIPTION
[PluggableDevice](https://github.com/tensorflow/community/blob/master/rfcs/20200624-pluggable-device-for-tensorflow.md) architecture relies on C APIs to communicate with the TensorFlow binary. To support pluggable device for tensorflow serving (https://github.com/tensorflow/serving/pull/2144), we need add always_link=1 for `kernels_experimental`.