### PR TITLE
Add stablehlo module to pip package

### DIFF
--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -102,6 +102,7 @@ COMMON_PIP_DEPS = [
     ":xla_cmake",
     "//tensorflow/compiler/tf2xla:xla_compiled_cpu_runtime_hdrs",
     "//tensorflow/compiler/tf2xla:xla_compiled_cpu_runtime_srcs",
+    "//tensorflow/compiler/mlir/stablehlo:stablehlo",
     "//tensorflow/compiler/mlir/tensorflow:gen_mlir_passthrough_op_py",
     "//tensorflow/core/function/trace_type:serialization_test_proto_py",
     "//tensorflow/core/function/trace_type:serialization",


### PR DESCRIPTION
This will resolve a pip unit test breakage that fails due to unable to import the module tensorflow.compiler.mlir.stablehlo from an installed tensorflow wheel.