### PR TITLE
Consistently use "pickleable" instead of "picklable"

### DIFF
--- a/tensorflow/python/keras/engine/training.py
+++ b/tensorflow/python/keras/engine/training.py
@@ -1065,7 +1065,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             `keras.utils.Sequence` input only. If `True`, use process-based
             threading. If unspecified, `use_multiprocessing` will default to
             `False`. Note that because this implementation relies on
-            multiprocessing, you should not pass non-picklable arguments to
+            multiprocessing, you should not pass non-pickleable arguments to
             the generator as they can't be passed easily to children processes.
 
     Unpacking behavior for iterator-like inputs:
@@ -1418,7 +1418,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
           `keras.utils.Sequence` input only. If `True`, use process-based
           threading. If unspecified, `use_multiprocessing` will default to
           `False`. Note that because this implementation relies on
-          multiprocessing, you should not pass non-picklable arguments to the
+          multiprocessing, you should not pass non-pickleable arguments to the
           generator as they can't be passed easily to children processes.
         return_dict: If `True`, loss and metric results are returned as a dict,
           with each key being the name of the metric. If `False`, they are
@@ -1655,7 +1655,7 @@ class Model(base_layer.Layer, version_utils.ModelVersionSelector):
             `keras.utils.Sequence` input only. If `True`, use process-based
             threading. If unspecified, `use_multiprocessing` will default to
             `False`. Note that because this implementation relies on
-            multiprocessing, you should not pass non-picklable arguments to
+            multiprocessing, you should not pass non-pickleable arguments to
             the generator as they can't be passed easily to children processes.
 
     See the discussion of `Unpacking behavior for iterator-like inputs` for

--- a/tensorflow/python/keras/engine/training_generator_v1.py
+++ b/tensorflow/python/keras/engine/training_generator_v1.py
@@ -94,7 +94,7 @@ def model_iteration(model,
       use_multiprocessing: Boolean. If `True`, use process-based threading. If
         unspecified, `use_multiprocessing` will default to `False`. Note that
         because this implementation relies on multiprocessing, you should not
-        pass non-picklable arguments to the generator as they can't be passed
+        pass non-pickleable arguments to the generator as they can't be passed
         easily to children processes.
       shuffle: Boolean. Whether to shuffle the order of the batches at the
         beginning of each epoch. Only used with instances of `Sequence`
@@ -375,7 +375,7 @@ def _validate_arguments(is_sequence, is_dataset, use_multiprocessing, workers,
     use_multiprocessing: Boolean. If `True`, use process-based threading. If
       unspecified, `use_multiprocessing` will default to `False`. Note that
       because this implementation relies on multiprocessing, you should not pass
-      non-picklable arguments to the generator as they can't be passed easily to
+      non-pickleable arguments to the generator as they can't be passed easily to
       children processes.
     workers: Integer. Maximum number of processes to spin up when using
       process-based threading. If unspecified, `workers` will default to 1. If

--- a/tensorflow/python/keras/engine/training_v1.py
+++ b/tensorflow/python/keras/engine/training_v1.py
@@ -764,7 +764,7 @@ class Model(training_lib.Model):
             `keras.utils.Sequence` input only. If `True`, use process-based
             threading. If unspecified, `use_multiprocessing` will default to
             `False`. Note that because this implementation relies on
-            multiprocessing, you should not pass non-picklable arguments to
+            multiprocessing, you should not pass non-pickleable arguments to
             the generator as they can't be passed easily to children processes.
         **kwargs: Used for backwards compatibility.
 
@@ -887,7 +887,7 @@ class Model(training_lib.Model):
             `keras.utils.Sequence` input only. If `True`, use process-based
             threading. If unspecified, `use_multiprocessing` will default to
             `False`. Note that because this implementation relies on
-            multiprocessing, you should not pass non-picklable arguments to
+            multiprocessing, you should not pass non-pickleable arguments to
             the generator as they can't be passed easily to children processes.
 
     Returns:
@@ -965,7 +965,7 @@ class Model(training_lib.Model):
             `keras.utils.Sequence` input only. If `True`, use process-based
             threading. If unspecified, `use_multiprocessing` will default to
             `False`. Note that because this implementation relies on
-            multiprocessing, you should not pass non-picklable arguments to
+            multiprocessing, you should not pass non-pickleable arguments to
             the generator as they can't be passed easily to children processes.
 
 

--- a/tensorflow/python/keras/layers/recurrent.py
+++ b/tensorflow/python/keras/layers/recurrent.py
@@ -1127,7 +1127,7 @@ class DropoutRNNCellMixin(object):
     function will be invoked multiple times, and we want to ensure same mask
     is used every time.
 
-    Also the caches are created without tracking. Since they are not picklable
+    Also the caches are created without tracking. Since they are not pickleable
     by python when deepcopy, we don't want `layer._obj_reference_counts_dict`
     to track it by default.
     """


### PR DESCRIPTION
Just a nitpick: All functions use `pickleable`, but in some parts of the documentation it's called `picklable`. This is hereby fixed.
Note that I am not a native English speaker, but the [Wiktionary](https://en.wiktionary.org/wiki/pickleable) agrees.