### PR TITLE
Mark control_flow_ops_test as flaky

### DIFF
--- a/tensorflow/python/ops/parallel_for/BUILD
+++ b/tensorflow/python/ops/parallel_for/BUILD
@@ -194,6 +194,7 @@ py_strict_library(
 cuda_py_strict_test(
     name = "control_flow_ops_test",
     srcs = ["control_flow_ops_test.py"],
+    flaky = True,
     shard_count = 16,
     tags = [
         "no_rocm",


### PR DESCRIPTION
/tensorflow/python/ops/parallel_for:control_flow_ops_test is failing occasionaly causing the ARM_CI job to fail, so mark it as flaky so that it will be re-tried