### PR TITLE
fix bazelrc path

### DIFF
--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_nightly.Jenkinsfile
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_nightly.Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
                             sh 'pip install Pillow'
 
                             sh '''
-                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
+                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
                                 --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.8.13/lib/python3.8/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                     
@@ -110,7 +110,7 @@ pipeline {
                             sh 'pip install Pillow'
 
                             sh '''
-                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
+                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
                                 --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.9.13/lib/python3.9/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                     
@@ -167,7 +167,7 @@ pipeline {
                             sh 'pip install Pillow'
 
                             sh '''
-                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
+                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
                                 --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.10.4/lib/python3.10/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                 
@@ -224,7 +224,7 @@ pipeline {
                             sh 'pip install Pillow'
 
                             sh '''
-                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
+                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
                                 --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.11.2/lib/python3.11/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                 

--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_release.Jenkinsfile
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_release.Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
                             '''
 
                             sh '''
-                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
+                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
                                 --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.8.13/lib/python3.8/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                     
@@ -98,7 +98,7 @@ pipeline {
                             '''
 
                             sh '''
-                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
+                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
                                 --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.9.13/lib/python3.9/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                     
@@ -147,7 +147,7 @@ pipeline {
                             '''
 
                             sh '''
-                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
+                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
                                 --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.10.4/lib/python3.10/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                 
@@ -196,7 +196,7 @@ pipeline {
                             '''
 
                             sh '''
-                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
+                                /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
                                 --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.11.2/lib/python3.11/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                 

--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_release.Jenkinsfile
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_release.Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
 
                             sh 'python --version'
 
-                            git branch: ${RELEASE_BRANCH},
+                            git branch: "${RELEASE_BRANCH}",
                                 url: "https://github.com/tensorflow/tensorflow.git"
 
                             sh '''
@@ -89,7 +89,7 @@ pipeline {
 
                             sh 'python --version'
 
-                            git branch: ${RELEASE_BRANCH},
+                            git branch: "${RELEASE_BRANCH}",
                                 url: "https://github.com/tensorflow/tensorflow.git"
 
                             sh '''
@@ -138,7 +138,7 @@ pipeline {
                             
                             sh 'python --version'
 
-                            git branch: ${RELEASE_BRANCH},
+                            git branch: "${RELEASE_BRANCH}",
                                 url: "https://github.com/tensorflow/tensorflow.git"
 
                             sh '''
@@ -187,7 +187,7 @@ pipeline {
                             
                             sh 'python --version'
 
-                            git branch: ${RELEASE_BRANCH},
+                            git branch: "${RELEASE_BRANCH}",
                                 url: "https://github.com/tensorflow/tensorflow.git"
 
                             sh '''

--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_test_release.Jenkinsfile
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_test_release.Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
 
                         sh 'python --version'
 
-                        git branch: ${RELEASE_BRANCH},
+                        git branch: "${RELEASE_BRANCH}",
                             url: "https://github.com/tensorflow/tensorflow.git"
                             
                         sh '''
@@ -76,7 +76,7 @@ pipeline {
 
                         sh 'python --version'
 
-                        git branch: ${RELEASE_BRANCH},
+                        git branch: "${RELEASE_BRANCH}",
                             url: "https://github.com/tensorflow/tensorflow.git"
 
                         sh '''
@@ -109,7 +109,7 @@ pipeline {
 
                         sh 'python --version'
 
-                        git branch: ${RELEASE_BRANCH},
+                        git branch: "${RELEASE_BRANCH}",
                             url: "https://github.com/tensorflow/tensorflow.git"
 
                         sh '''
@@ -143,7 +143,7 @@ pipeline {
 
                         sh 'python --version'
 
-                        git branch: ${RELEASE_BRANCH},
+                        git branch: "${RELEASE_BRANCH}",
                             url: "https://github.com/tensorflow/tensorflow.git"
 
                         sh '''


### PR DESCRIPTION
Repo is cloned in the `tensorflow` dir inside the Jenkins ${WORKSPACE}. The file path needs an added `/tensorflow` before the relative file path to `.macos.bazelrc`

Also based on more testing, quotes needed to be added to the release branch variable 