### PR TITLE
Fix undeclared inclusions in CUDA build with GCC on symlinked path

### DIFF
--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -316,10 +316,35 @@ def _get_cxx_inc_directories_impl(repository_ctx, cc, lang_is_cpp, tf_sysroot):
         ).stdout.strip() + "/share"
         inc_dirs += "\n" + resource_dir
 
-    return [
+    compiler_includes = [
         _normalize_include_path(repository_ctx, _cxx_inc_convert(p))
         for p in inc_dirs.split("\n")
     ]
+
+    # fix include path by also including paths where resolved symlink is replaced by original path
+    # Try to find real path to CC installation to "see through" compiler wrappers
+    # GCC has the path to g++
+    index1 = result.stderr.find("COLLECT_GCC=")
+    if index1 != -1:
+      index1 = result.stderr.find("=", index1)
+      index2 = result.stderr.find("\n", index1)
+      cc_topdir = repository_ctx.path(result.stderr[index1 + 1 : index2]).dirname.dirname
+    else:
+      # Clang has the directory
+      index1 = result.stderr.find("InstalledDir: ")
+      if index1 != -1:
+        index1 = result.stderr.find(" ", index1)
+        index2 = result.stderr.find("\n", index1)
+        cc_topdir = repository_ctx.path(result.stderr[index1 + 1 : index2]).dirname
+      else:
+        # Fallback to the CC path
+        cc_topdir = repository_ctx.path(cc).dirname.dirname
+    cc_topdir_resolved = str(cc_topdir.realpath).strip()
+    cc_topdir = str(cc_topdir).strip()
+    if cc_topdir_resolved != cc_topdir:
+        original_compiler_includes = [p.replace(cc_topdir_resolved, cc_topdir) for p in compiler_includes]
+        compiler_includes = compiler_includes + original_compiler_includes
+    return compiler_includes
 
 def get_cxx_inc_directories(repository_ctx, cc, tf_sysroot):
     """Compute the list of default C and C++ include directories."""

--- a/third_party/gpus/cuda_configure.bzl
+++ b/third_party/gpus/cuda_configure.bzl
@@ -344,20 +344,20 @@ def _get_cxx_inc_directories_impl(repository_ctx, cc, lang_is_cpp, tf_sysroot):
       else:
         # Fallback to the CC path
         cc_topdir = repository_ctx.path(cc).dirname.dirname
-    # We now have the GCC installation prefix, e.g. /symlink/gcc
+    # We now have the compiler installation prefix, e.g. /symlink/gcc
+    # And the resolved installation prefix, e.g. /opt/gcc
     cc_topdir_resolved = str(cc_topdir.realpath).strip()
     cc_topdir = str(cc_topdir).strip()
     # If there is (any!) symlink involved we add paths where the unresolved installation prefix is kept.
-    # e.g.   [/symlink/include/c++/11, /symlink/lib/gcc/x86_64-linux-gnu/11/include, /other/path]
-    # yields [/symlink/include/c++/11, /symlink/lib/gcc/x86_64-linux-gnu/11/include, /other/path] +
-    #        [/opt/gcc/include/c++/11, /opt/gcc/lib/gcc/x86_64-linux-gnu/11/include]
+    # e.g. [/opt/gcc/include/c++/11, /opt/gcc/lib/gcc/x86_64-linux-gnu/11/include, /other/path]
+    # adds [/symlink/include/c++/11, /symlink/lib/gcc/x86_64-linux-gnu/11/include]
     if cc_topdir_resolved != cc_topdir:
-        original_compiler_includes = [
-            inc.replace(cc_topdir_resolved, cc_topdir)
+        unresolved_compiler_includes = [
+            cc_topdir + inc[len(cc_topdir_resolved):]
             for inc in compiler_includes
-            cc_topdir_resolved in inc
+            if inc.startswith(cc_topdir_resolved)
         ]
-        compiler_includes = compiler_includes + original_compiler_includes
+        compiler_includes = compiler_includes + unresolved_compiler_includes
     return compiler_includes
 
 def get_cxx_inc_directories(repository_ctx, cc, tf_sysroot):


### PR DESCRIPTION
When the host compiler (e.g. GCC) is installed in a path being/containing a symlink the CUDA build might fail with `"undeclared inclusion(s)"` to the symlink paths.

This has been partially solved by #56360 which resolves all symlinks in `gcc_host_compiler_path`   
However the compiler referenced there might be a wrapper script (e.g. ccache) which internally eventually forwards the call to the real compiler sitting in a path containing a symlink.
`gcc -v -E - < /dev/null` seems to only return resolved paths while the later invocations include the paths with symlinks leading to the build failure.

The solution employed here is to add the unresolved paths (i.e. the ones with symlinks) in addition to the resolved paths.

Fixes #33975