### PR TITLE
[INTEL oneDNN] Remove newly added log in execute.cc which impacts performance

### DIFF
--- a/tensorflow/core/common_runtime/executor.cc
+++ b/tensorflow/core/common_runtime/executor.cc
@@ -1201,20 +1201,11 @@ bool ExecutorState<PropagatorStateType>::NodeDone(
     if (abort_run) {
       TRACEPRINTF("StartAbort: %s", s.ToString().c_str());
       if (cancellation_manager_) {
-        // Only log when the abort happens during the actual run time.
-        // Use LOG(INFO) instead of LOG(WARNING) because error status is
-        // expected when the executor is run under the grappler optimization
-        // phase. Do not log OutOfRange erros because they are expected when
-        // iterating through a tf.data input pipeline.
-        if (!errors::IsOutOfRange(s)) {
-          LOG(INFO) << "[" << immutable_state_.params().device->name()
-                    << "] (DEBUG INFO) Executor start aborting (this does not "
-                       "indicate an error and you can ignore this message): "
-                    << s;
-        } else {
-          VLOG(1) << "[" << immutable_state_.params().device->name()
-                  << "] Executor start aborting: " << s;
-        }
+        // Use VLOG instead of LOG(warning) because error status is expected
+        // when the executor is run under the grappler optimization phase or
+        // when iterating through a tf.data input pipeline.
+        VLOG(1) << "[" << immutable_state_.params().device->name()
+                << "] Executor start aborting: " << s;
       }
 
       if (rendezvous_) {


### PR DESCRIPTION
This PR reverts changes (partly) of this recent commit
https://github.com/tensorflow/tensorflow/commit/80a4e5f9e4e103f722df3632db88fdb31537bb26

Related ticket is here
https://github.com/tensorflow/tensorflow/issues/59779