### PR TITLE
Disabled tensorflow/compiler/xla/tests/fuzz:rand000072.hlo as there i…

### DIFF
--- a/tensorflow/compiler/xla/tests/fuzz/BUILD
+++ b/tensorflow/compiler/xla/tests/fuzz/BUILD
@@ -11,6 +11,7 @@ hlo_test(
             "rand_000060.hlo",
             "rand_000067.hlo",
             "rand_000072.hlo",
+	    "rand_000079.hlo",  # No int8 support on ROCM yet  
         ],
     ),
 )


### PR DESCRIPTION
…s no int8 support for ROCm yet.