### PR TITLE
Limit typing_extensions to less than 4.6.0 until it works

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -97,7 +97,7 @@ REQUIRED_PACKAGES = [
     'setuptools',
     'six >= 1.12.0',
     'termcolor >= 1.1.0',
-    'typing_extensions >= 3.6.6',
+    'typing_extensions>=3.6.6,<4.6.0',
     'wrapt >= 1.11.0',
     'tensorflow-io-gcs-filesystem >= 0.23.1;platform_machine!="arm64" or ' +
     'platform_system!="Darwin"',


### PR DESCRIPTION
There is a unit test failure when run as a pip test with typing_extensions >= 4.6.0 so limit the installed version to below that until the issue is resolved.

See #60687 