### PR TITLE
Add missing dependency to //tensorflow/compiler/tests:xla_test for ROCm

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -477,6 +477,7 @@ tf_xla_py_strict_test(
         "//tensorflow/python:platform_test",
         "//tensorflow/python/ops:linalg_ops",
         "//tensorflow/python/ops:random_ops",
+        "//tensorflow/python/platform:sysconfig",
         "//third_party/py/numpy",
         "@absl_py//absl/testing:parameterized",
     ],

--- a/tensorflow/compiler/tests/matrix_solve_op_test.py
+++ b/tensorflow/compiler/tests/matrix_solve_op_test.py
@@ -23,7 +23,7 @@ from tensorflow.compiler.tests import xla_test
 from tensorflow.python.ops import linalg_ops
 from tensorflow.python.ops import random_ops
 from tensorflow.python.platform import googletest
-
+from tensorflow.python.platform import sysconfig
 
 class MatrixSolveOpTest(xla_test.XLATestCase, parameterized.TestCase):
 
@@ -73,6 +73,8 @@ class MatrixSolveOpTest(xla_test.XLATestCase, parameterized.TestCase):
 
 
 if __name__ == "__main__":
-  os.environ["XLA_FLAGS"] = ("--xla_gpu_enable_cublaslt=true " +
+  sys_details = sysconfig.get_build_info()
+  if sys_details["is_cuda_build"]:
+    os.environ["XLA_FLAGS"] = ("--xla_gpu_enable_cublaslt=true " +
                              os.environ.get("XLA_FLAGS", ""))
   googletest.main()


### PR DESCRIPTION
The following tests needs tensorflow.python.platform.sysconfig //tensorflow/compiler/tests:matrix_solve_op_test_cpu //tensorflow/compiler/tests:matrix_solve_op_test_cpu_mlir_bridge_test