### PR TITLE
Use fp32 compute result as the reference for tf32 test in ROCm as MIO…

### DIFF
--- a/tensorflow/compiler/tests/BUILD
+++ b/tensorflow/compiler/tests/BUILD
@@ -592,6 +592,7 @@ tf_xla_py_strict_test(
         "//tensorflow/python/ops:array_ops",
         "//tensorflow/python/ops:math_ops",
         "//tensorflow/python/ops:nn_ops",
+        "//tensorflow/python/platform:sysconfig",
         "//tensorflow/python/platform:test",
     ],
 )

--- a/tensorflow/compiler/tests/tensor_float_32_test.py
+++ b/tensorflow/compiler/tests/tensor_float_32_test.py
@@ -23,6 +23,7 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import googletest
+from tensorflow.python.platform import sysconfig
 
 
 class TensorFloat32Test(xla_test.XLATestCase):
@@ -41,8 +42,13 @@ class TensorFloat32Test(xla_test.XLATestCase):
 
       # Test the output is sufficiently precise by comparing with FP64 results
       out = compiled_fn(*inputs)
-      f64_out = compiled_fn(*[math_ops.cast(x, 'float64') for x in inputs])
-      self.assertAllClose(out, f64_out, rtol=1e-5, atol=1e-5)
+      sys_details = sysconfig.get_build_info()
+      if sys_details["is_rocm_build"]: # MIOpen does not support fp64 data type
+        f32_out = compiled_fn(*[math_ops.cast(x, 'float32') for x in inputs])
+        self.assertAllClose(out, f32_out, rtol=1e-5, atol=1e-5)
+      else:
+        f64_out = compiled_fn(*[math_ops.cast(x, 'float64') for x in inputs])
+        self.assertAllClose(out, f64_out, rtol=1e-5, atol=1e-5)
 
       # Test with TF32 enabled. Recompile fn because enabling TF32 does not
       # reset function cache.


### PR DESCRIPTION
…pen does not support fp64.