### PR TITLE
[TOSA] Update tfl.mean legalization to match the new reference kernel behaviour

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -641,6 +641,20 @@ func.func @test_reduce_mean_out_of_bounds(%arg0: tensor<13x21x3xf32>) -> tensor<
 
 // -----
 
+// CHECK-LABEL: test_reduce_mean_qi8
+// CHECK-SAME: %[[VAL_0:.*]]: tensor<1x2x2x!quant.uniform<i8:f32, 0.0039208820089697838:-128>>
+// CHECK: %[[VAL_1:.*]] = "tosa.rescale"(%[[VAL_0]]) <{double_round = true, input_zp = -128 : i32, multiplier = array<i32: 1073741824>, output_zp = 0 : i32, per_channel = false, scale32 = true, shift = array<i32: 30>}> : (tensor<1x2x2x!quant.uniform<i8:f32, 0.0039208820089697838:-128>>) -> tensor<1x2x2xi32>
+// CHECK: %[[VAL_2:.*]] = "tosa.reduce_sum"(%[[VAL_1]]) <{axis = 2 : i64}> : (tensor<1x2x2xi32>) -> tensor<1x2x1xi32>
+// CHECK: %[[VAL_3:.*]] = "tosa.rescale"(%[[VAL_2]]) <{double_round = true, input_zp = 0 : i32, multiplier = array<i32: 1105078632>, output_zp = -128 : i32, per_channel = false, scale32 = true, shift = array<i32: 31>}> : (tensor<1x2x1xi32>) -> tensor<1x2x1x!quant.uniform<i8:f32, 0.0038096972275525331:-128>>
+// CHECK: return %[[VAL_3]] : tensor<1x2x1x!quant.uniform<i8:f32, 0.0038096972275525331:-128>>
+func.func @test_reduce_mean_qi8(%arg0: tensor<1x2x2x!quant.uniform<i8:f32, 0.0039208820089697838:-128>>) -> (tensor<1x2x1x!quant.uniform<i8:f32, 0.0038096972275525331:-128>>) {
+%0 = "tfl.pseudo_const"() {value = dense<-1> : tensor<i32>} : () -> tensor<i32>
+%1 = "tfl.mean"(%arg0, %0) {keep_dims = true} : (tensor<1x2x2x!quant.uniform<i8:f32, 0.0039208820089697838:-128>>, tensor<i32>) -> tensor<1x2x1x!quant.uniform<i8:f32, 0.0038096972275525331:-128>>
+return %1 : tensor<1x2x1x!quant.uniform<i8:f32, 0.0038096972275525331:-128>>
+}
+
+// -----
+
 // CHECK-LABEL: test_reduce_product
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.reduce_prod"(%arg0) <{axis = 0 : i64}>
 // CHECK: %[[VAR1:.*]] = "tosa.reshape"(%[[VAR0]]) <{new_shape = array<i64: 21, 3>}>

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
@@ -2898,8 +2898,8 @@ std::optional<Value> convertReduceOpCommon(
     UnrankedTensorType output_rescale_type =
         UnrankedTensorType::get(output_type.getElementType());
     val = buildRescale(rewriter, op, output_rescale_type, val,
-                       output_scale_multiplier, output_scale_shift, 0,
-                       output_zp, IsTFLDoubleRoundingMode(), true);
+                       output_scale_multiplier, output_scale_shift, /*input_zp=*/0,
+                       output_zp, IsTFLDoubleRoundingMode(), /*scale32=*/true);
   }
 
   // Squeeze out the reduced axes.

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
@@ -39,6 +39,7 @@ limitations under the License.
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Quant/QuantTypes.h"  // from @llvm-project
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"  // from @llvm-project
+#include "mlir/Dialect/Tosa/Utils/QuantUtils.h"  // from @llvm-project
 #include "mlir/IR/BuiltinAttributes.h"  // from @llvm-project
 #include "mlir/IR/BuiltinTypes.h"  // from @llvm-project
 #include "mlir/IR/ImplicitLocOpBuilder.h"  // from @llvm-project
@@ -46,6 +47,7 @@ limitations under the License.
 #include "mlir/IR/PatternMatch.h"  // from @llvm-project
 #include "tensorflow/compiler/mlir/tensorflow/utils/dynamic_shape_utils.h"
 #include "tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h"
+#include "tensorflow/lite/kernels/internal/common.h"
 
 namespace mlir {
 namespace tosa {
@@ -2826,8 +2828,10 @@ template <typename T>
 std::optional<Value> convertReduceOpCommon(
     PatternRewriter& rewriter, Operation* op, RankedTensorType output_type,
     Value input_value, ElementsAttr axes_elems, Type reduce_element_type,
-    bool is_quantized, double input_scale, int64_t input_zp,
-    double output_scale, int64_t output_zp) {
+    bool is_quantized, int32_t input_scale_multiplier,
+    int32_t input_scale_shift, int64_t input_zp,
+    int32_t output_scale_multiplier, int32_t output_scale_shift,
+    int64_t output_zp) {
   RankedTensorType input_type =
       dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
@@ -2872,7 +2876,8 @@ std::optional<Value> convertReduceOpCommon(
     SmallVector<int64_t> shape_vec(input_shape.begin(), input_shape.end());
 
     if (is_quantized) {
-      val = buildRescaleToInt32(rewriter, op, val, input_scale, input_zp);
+      val = buildRescaleToInt32(rewriter, op, val, input_scale_multiplier,
+                                input_scale_shift, input_zp);
     }
 
     for (auto axis_val : axes) {
@@ -2892,8 +2897,9 @@ std::optional<Value> convertReduceOpCommon(
   if (is_quantized) {
     UnrankedTensorType output_rescale_type =
         UnrankedTensorType::get(output_type.getElementType());
-    val = buildRescale(rewriter, op, output_rescale_type, val, output_scale, 0,
-                       output_zp, false, true);
+    val = buildRescale(rewriter, op, output_rescale_type, val,
+                       output_scale_multiplier, output_scale_shift, 0,
+                       output_zp, IsTFLDoubleRoundingMode(), true);
   }
 
   // Squeeze out the reduced axes.
@@ -2902,6 +2908,31 @@ std::optional<Value> convertReduceOpCommon(
       rewriter.getDenseI64ArrayAttr(
           tensorflow::ConvertMlirShapeToTF(output_shape)));
   return reshape_op.getResult();
+}
+
+// Common function for lowering reduce operations to TOSA ops.
+template <typename T>
+std::optional<Value> convertReduceOpCommon(
+    PatternRewriter& rewriter, Operation* op, RankedTensorType output_type,
+    Value input_value, ElementsAttr axes_elems, Type reduce_element_type,
+    bool is_quantized, double input_scale, int64_t input_zp,
+    double output_scale, int64_t output_zp) {
+  const int32_t scale_width = 32;
+
+  int32_t input_scale_multiplier;
+  int32_t input_scale_shift;
+  computeMultiplierAndShift(input_scale, input_scale_multiplier,
+                            input_scale_shift, scale_width);
+
+  int32_t output_scale_multiplier;
+  int32_t output_scale_shift;
+  computeMultiplierAndShift(output_scale, output_scale_multiplier,
+                            output_scale_shift, scale_width);
+
+  return convertReduceOpCommon<T>(
+      rewriter, op, output_type, input_value, axes_elems, reduce_element_type,
+      is_quantized, input_scale_multiplier, input_scale_shift, input_zp,
+      output_scale_multiplier, output_scale_shift, output_zp);
 }
 
 // Lowers ReduceAll to a sequence of TOSA ops.
@@ -3047,7 +3078,11 @@ std::optional<Value> convertReduceMeanOp(PatternRewriter& rewriter,
                                          RankedTensorType output_type,
                                          Value input_value,
                                          ElementsAttr axes_elems) {
-  // reduce_mean is lowered as followed:
+  // reduce_mean is lowered as followed for quantized types:
+  // op1 = reduce_sum(input) with the 1.0/num_elements_on_reduced_axis
+  // integrated to the rescale layer,
+  //
+  // and for floating-point types:
   // op1 = reduce_sum(input)
   // op2 = mul(op1, 1.0 / num_elements_on_reduced_axis)
 
@@ -3086,13 +3121,16 @@ std::optional<Value> convertReduceMeanOp(PatternRewriter& rewriter,
     }
     num_elems_on_reduced_axis *= input_type.getShape()[axis_val];
   }
-  double div_scale = 1.0 / static_cast<double>(num_elems_on_reduced_axis);
 
-  double input_scale = 1.0f;
-  double output_scale = 1.0f;
   int64_t input_zp = 0;
   int64_t output_zp = 0;
   Type reduce_element_type = input_type.getElementType();
+
+  int32_t input_scale_multiplier = 1;
+  int32_t input_scale_shift = 0;
+
+  int32_t output_scale_multiplier = 1;
+  int32_t output_scale_shift = 0;
 
   if (input_is_qtype) {
     auto input_qtype =
@@ -3100,21 +3138,43 @@ std::optional<Value> convertReduceMeanOp(PatternRewriter& rewriter,
     auto output_qtype =
         output_type.getElementType().cast<mlir::quant::UniformQuantizedType>();
 
-    // Combine 'div_scale' as part of output rescale
-    output_scale = div_scale * input_qtype.getScale() / output_qtype.getScale();
+    const int32_t scale_width = 32;
+    computeMultiplierAndShift(1.0f, input_scale_multiplier, input_scale_shift,
+                              scale_width);
+    computeMultiplierAndShift(input_qtype.getScale() / output_qtype.getScale(),
+                              output_scale_multiplier, output_scale_shift,
+                              scale_width);
 
     input_zp = input_qtype.getZeroPoint();
     output_zp = output_qtype.getZeroPoint();
     reduce_element_type = rewriter.getI32Type();
+
+    // Match TFL REDUCE_MEAN reference kernel
+    // tensorflow/lite/kernels/internal/reference/reduce.h taking into account
+    // the shift difference between computeMultiplierAndShift and
+    // QuantizeMultiplier.
+    //
+    // Readapt output rescaling when calculating the mean to integrate a
+    // 1/num_elems_on_reduced_axis multiplier.
+    int shift = 63 - tflite::CountLeadingZeros(
+                         static_cast<uint64_t>(num_elems_on_reduced_axis));
+    shift = std::min(shift, 32);
+    shift = std::min(shift, 62 - output_scale_shift);
+    output_scale_multiplier = static_cast<int32_t>(
+        (static_cast<int64_t>(output_scale_multiplier) << shift) /
+        num_elems_on_reduced_axis);
+    output_scale_shift = output_scale_shift + shift;
   }
 
   auto val = convertReduceOpCommon<tosa::ReduceSumOp>(
       rewriter, op, output_type, input_value, axes_elems, reduce_element_type,
-      input_is_qtype, input_scale, input_zp, output_scale, output_zp);
+      input_is_qtype, input_scale_multiplier, input_scale_shift, input_zp,
+      output_scale_multiplier, output_scale_shift, output_zp);
 
   if (!val.has_value()) return std::nullopt;
 
   if (!input_is_qtype) {
+    double div_scale = 1.0 / static_cast<double>(num_elems_on_reduced_axis);
     Value div_const = getTosaConstTensorSingleF32(rewriter, op, div_scale);
     return CreateOpAndInfer<tosa::MulOp>(rewriter, op->getLoc(), output_type,
                                          val.value(), div_const, 0)

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
@@ -125,6 +125,25 @@ std::optional<Value> buildReshapeWithDynamicDims(PatternRewriter& rewriter,
       .getResult();
 }
 
+// Create a TOSA rescale op from TFLite scaling multiplier, scaling shift, zero
+// points and rounding mode
+Value buildRescale(PatternRewriter& rewriter, Operation* op,
+                   ShapedType output_type, Value input_val,
+                   int32_t scale_multiplier, int32_t scale_shit,
+                   int64_t input_zp, int64_t output_zp, bool double_round,
+                   bool scale32) {
+  auto rescale_op = CreateOpAndInfer<tosa::RescaleOp>(
+      rewriter, op->getLoc(), output_type, input_val,
+      rewriter.getI32IntegerAttr(static_cast<int32_t>(input_zp)),
+      rewriter.getI32IntegerAttr(static_cast<int32_t>(output_zp)),
+      rewriter.getDenseI32ArrayAttr({scale_multiplier}),
+      rewriter.getDenseI32ArrayAttr({scale_shit}),
+      rewriter.getBoolAttr(scale32), rewriter.getBoolAttr(double_round),
+      rewriter.getBoolAttr(false));
+
+  return rescale_op.getResult();
+}
+
 // Create a TOSA rescale op from TFLite scaling, zero points and rounding mode
 Value buildRescale(PatternRewriter& rewriter, Operation* op,
                    ShapedType output_type, Value input_val, double scale,
@@ -137,15 +156,8 @@ Value buildRescale(PatternRewriter& rewriter, Operation* op,
 
   computeMultiplierAndShift(scale, multiplier, shift, scale_width);
 
-  auto rescale_op = CreateOpAndInfer<tosa::RescaleOp>(
-      rewriter, op->getLoc(), output_type, input_val,
-      rewriter.getI32IntegerAttr(static_cast<int32_t>(input_zp)),
-      rewriter.getI32IntegerAttr(static_cast<int32_t>(output_zp)),
-      rewriter.getDenseI32ArrayAttr({multiplier}),
-      rewriter.getDenseI32ArrayAttr({shift}), rewriter.getBoolAttr(scale32),
-      rewriter.getBoolAttr(double_round), rewriter.getBoolAttr(false));
-
-  return rescale_op.getResult();
+  return buildRescale(rewriter, op, output_type, input_val, multiplier, shift,
+                      input_zp, output_zp, double_round, scale32);
 }
 
 // Removes the zero point and cast to int32, no need to handle roundings modes
@@ -156,21 +168,30 @@ Value removeZeroPointAndCastToInt32(PatternRewriter& rewriter, Operation* op,
 
 // Creates TOSA rescale op with int32 output
 Value buildRescaleToInt32(PatternRewriter& rewriter, Operation* op,
-                          Value input_val, double input_scale,
-                          int64_t input_zp) {
+                          Value input_val, int32_t input_scale_multiplier,
+                          int32_t input_scale_shit, int64_t input_zp) {
   // Output is always int32 type
   auto input_type = dyn_cast<mlir::ShapedType>(input_val.getType());
   assert(input_type);
   auto output_type = input_type.clone(rewriter.getI32Type());
 
-#if TFLITE_SINGLE_ROUNDING
-  bool double_round = false;
-#else   // TFLITE_DOUBLE_ROUNDING
-  bool double_round = true;
-#endif  // TFLITE_SINGLE_ROUNDING
+  return buildRescale(rewriter, op, output_type, input_val,
+                      input_scale_multiplier, input_scale_shit, input_zp, 0,
+                      IsTFLDoubleRoundingMode(), true);
+}
 
-  return buildRescale(rewriter, op, output_type, input_val, input_scale,
-                      input_zp, 0, double_round, true);
+// Creates TOSA rescale op with int32 output
+Value buildRescaleToInt32(PatternRewriter& rewriter, Operation* op,
+                          Value input_val, double input_scale,
+                          int64_t input_zp) {
+  int32_t multiplier;
+  int32_t shift;
+
+  const int32_t scale_width = 32;
+  computeMultiplierAndShift(input_scale, multiplier, shift, scale_width);
+
+  return buildRescaleToInt32(rewriter, op, input_val, multiplier, shift,
+                             input_zp);
 }
 
 // Creates TOSA rescale op with int32 input
@@ -183,15 +204,9 @@ Value buildRescaleFromInt32(PatternRewriter& rewriter, Operation* op,
   assert(input_type && input_type.getElementType().isInteger(32) &&
          "expected rescale input element type to be i32");
 
-#if TFLITE_SINGLE_ROUNDING
-  bool double_round = false;
-#else   // TFLITE_DOUBLE_ROUNDING
-  bool double_round = true;
-#endif  // TFLITE_SINGLE_ROUNDING
-
   // Potentially check input_shape == output_shape here
   return buildRescale(rewriter, op, output_type, input_val, output_scale, 0,
-                      output_zp, double_round, true);
+                      output_zp, IsTFLDoubleRoundingMode(), true);
 }
 
 // Creates a TOSA rescale op based on conv2d parameters.

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
@@ -169,15 +169,15 @@ Value removeZeroPointAndCastToInt32(PatternRewriter& rewriter, Operation* op,
 // Creates TOSA rescale op with int32 output
 Value buildRescaleToInt32(PatternRewriter& rewriter, Operation* op,
                           Value input_val, int32_t input_scale_multiplier,
-                          int32_t input_scale_shit, int64_t input_zp) {
+                          int32_t input_scale_shift, int64_t input_zp) {
   // Output is always int32 type
   auto input_type = dyn_cast<mlir::ShapedType>(input_val.getType());
   assert(input_type);
   auto output_type = input_type.clone(rewriter.getI32Type());
 
   return buildRescale(rewriter, op, output_type, input_val,
-                      input_scale_multiplier, input_scale_shit, input_zp, 0,
-                      IsTFLDoubleRoundingMode(), true);
+                      input_scale_multiplier, input_scale_shift, input_zp, /*input_zp=*/0,
+                      IsTFLDoubleRoundingMode(), /*scale32=*/true);
 }
 
 // Creates TOSA rescale op with int32 output
@@ -205,8 +205,8 @@ Value buildRescaleFromInt32(PatternRewriter& rewriter, Operation* op,
          "expected rescale input element type to be i32");
 
   // Potentially check input_shape == output_shape here
-  return buildRescale(rewriter, op, output_type, input_val, output_scale, 0,
-                      output_zp, IsTFLDoubleRoundingMode(), true);
+  return buildRescale(rewriter, op, output_type, input_val, output_scale, /*input_zp=*/0,
+                      output_zp, IsTFLDoubleRoundingMode(), /*scale32=*/true);
 }
 
 // Creates a TOSA rescale op based on conv2d parameters.

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
@@ -54,6 +54,14 @@ std::optional<Value> buildReshapeWithDynamicDims(PatternRewriter& rewriter,
                                                  ShapedType output_type,
                                                  llvm::ArrayRef<Value> dims);
 
+// Create a TOSA rescale op from TFLite scaling multiplier, scaling shift, zero
+// points and rounding mode
+Value buildRescale(PatternRewriter& rewriter, Operation* op,
+                   ShapedType output_type, Value input_val,
+                   int32_t scale_multiplier, int32_t scale_shit,
+                   int64_t input_zp, int64_t output_zp, bool double_round,
+                   bool scale32);
+
 // Create a TOSA rescale op from TFLite scaling, zero points and rounding mode
 Value buildRescale(PatternRewriter& rewriter, Operation* op,
                    ShapedType output_type, Value input_val, double scale,
@@ -63,6 +71,11 @@ Value buildRescale(PatternRewriter& rewriter, Operation* op,
 // Removes the zero point and cast to int32, no need to handle roundings modes
 Value removeZeroPointAndCastToInt32(PatternRewriter& rewriter, Operation* op,
                                     Value input_val, int64_t input_zp);
+
+// Creates TOSA rescale op with int32 output
+Value buildRescaleToInt32(PatternRewriter& rewriter, Operation* op,
+                          Value input_val, int32_t input_scale_multiplier,
+                          int32_t input_scale_shit, int64_t input_zp);
 
 // Creates TOSA rescale op with int32 output
 Value buildRescaleToInt32(PatternRewriter& rewriter, Operation* op,
@@ -228,6 +241,14 @@ void TrimQuantizedIntegerRangeMax(mlir::quant::UniformQuantizedType dtype,
 
 void TrimQuantizedIntegerRange(mlir::quant::UniformQuantizedType dtype,
                                int64_t& val_min, int64_t& val_max);
+
+inline bool IsTFLDoubleRoundingMode() {
+#if TFLITE_SINGLE_ROUNDING
+  return false;
+#else
+  return true;
+#endif  // TFLITE_SINGLE_ROUNDING
+}
 
 }  // namespace tosa
 }  // namespace mlir

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
@@ -75,7 +75,7 @@ Value removeZeroPointAndCastToInt32(PatternRewriter& rewriter, Operation* op,
 // Creates TOSA rescale op with int32 output
 Value buildRescaleToInt32(PatternRewriter& rewriter, Operation* op,
                           Value input_val, int32_t input_scale_multiplier,
-                          int32_t input_scale_shit, int64_t input_zp);
+                          int32_t input_scale_shift, int64_t input_zp);
 
 // Creates TOSA rescale op with int32 output
 Value buildRescaleToInt32(PatternRewriter& rewriter, Operation* op,


### PR DESCRIPTION
This PR updates the quantized REDUCE_MEAN kernel to only use integers. This matches the TFLite reference model in a bit-exact way.
(The merged PR:https://github.com/tensorflow/tensorflow/pull/52014 updates the quantized REDUCE_MEAN kernel to only use integers)
