### PR TITLE
[Linaro:ARM_CI] Allow updating of python packages with commands

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_cpp.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_cpp.sh
@@ -19,12 +19,10 @@ set -x
 
 source tensorflow/tools/ci_build/release/common.sh
 
-sudo mkdir /tmpfs
-sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /tmpfs
-sudo mkdir /tensorflow
-sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /tensorflow
+sudo install -o ${CI_BUILD_USER} -g ${CI_BUILD_GROUP} -d /tmpfs
+sudo install -o ${CI_BUILD_USER} -g ${CI_BUILD_GROUP} -d /tensorflow
 sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/lib/python*
-sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/bin
+sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/bin
 sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/lib/python3/dist-packages
 
 # Update bazel

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
@@ -19,12 +19,10 @@ set -x
 
 source tensorflow/tools/ci_build/release/common.sh
 
-sudo mkdir /tmpfs
-sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /tmpfs
-sudo mkdir /tensorflow
-sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /tensorflow
+sudo install -o ${CI_BUILD_USER} -g ${CI_BUILD_GROUP} -d /tmpfs
+sudo install -o ${CI_BUILD_USER} -g ${CI_BUILD_GROUP} -d /tensorflow
 sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/lib/python*
-sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/bin
+sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/bin
 sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/lib/python3/dist-packages
 
 # Update bazel

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -19,12 +19,10 @@ set -x
 
 source tensorflow/tools/ci_build/release/common.sh
 
-sudo mkdir /tmpfs
-sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /tmpfs
-sudo mkdir /tensorflow
-sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /tensorflow
+sudo install -o ${CI_BUILD_USER} -g ${CI_BUILD_GROUP} -d /tmpfs
+sudo install -o ${CI_BUILD_USER} -g ${CI_BUILD_GROUP} -d /tensorflow
 sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/lib/python*
-sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/bin
+sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/bin
 sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/lib/python3/dist-packages
 
 # Update bazel


### PR DESCRIPTION
Need to make writable by user the python commands cache so that the python packages can be updated by the user if needed. Also improve method of creating dirs with user ownership.