### PR TITLE
Fix mkl build dependency issue

### DIFF
--- a/tensorflow/core/common_runtime/eager/BUILD
+++ b/tensorflow/core/common_runtime/eager/BUILD
@@ -12,6 +12,7 @@ load(
 load(
     "//third_party/mkl:build_defs.bzl",
     "if_mkl",
+    "mkl_deps",
 )
 
 package(
@@ -650,7 +651,7 @@ tf_mkl_kernel_library(
         "//tensorflow/core:graph",
         "//tensorflow/core:lib",
         "//tensorflow/core/graph:mkl_graph_util",
-    ],
+    ] + mkl_deps(),
     alwayslink = 1,
 )
 


### PR DESCRIPTION
A recent commit broke the build when it moved a dependency that was partly relied upon. Fix the build by adding in the missing dependency in a more specific manner.

Commit that broke the build is https://github.com/tensorflow/tensorflow/commit/ea966af46abcdff6cb8d6ef333befa5aa2850e5f

Fixes #60724 