### PR TITLE
validate argument axis of tf.experimental.numpy.stack

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1066,6 +1066,10 @@ def stack(arrays, axis=0):  # pylint: disable=missing-function-docstring
     arrays = asarray(arrays)
     if axis == 0:
       return arrays
+    elif axis < -array_ops.rank(arrays) or axis >= array_ops.rank(arrays):
+      raise ValueError(
+          f"Argument `axis` = {axis} not in range of "
+          f"[{-array_ops.rank(arrays)}, {array_ops.rank(arrays)})")
     else:
       return swapaxes(arrays, 0, axis)
   arrays = _promote_dtype(*arrays)  # pylint: disable=protected-access

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -819,6 +819,11 @@ def swapaxes(a, axis1, axis2):  # pylint: disable=missing-docstring
         x = array_ops.where_v2(x < 0, np_utils.add(x, a_rank), x)
       return x
     return nest.map_structure(f, axes)
+  
+  if axis2 < -array_ops.rank(a) or axis2 >= array_ops.rank(a):
+    raise ValueError(
+        f"Argument `axis` = {axis2} not in range "
+        f"[{-array_ops.rank(a)}, {array_ops.rank(a)})")
 
   if (a.shape.rank is not None and
       isinstance(axis1, int) and isinstance(axis2, int)):
@@ -1066,10 +1071,6 @@ def stack(arrays, axis=0):  # pylint: disable=missing-function-docstring
     arrays = asarray(arrays)
     if axis == 0:
       return arrays
-    elif axis < -array_ops.rank(arrays) or axis >= array_ops.rank(arrays):
-      raise ValueError(
-          f"Argument `axis` = {axis} not in range of "
-          f"[{-array_ops.rank(arrays)}, {array_ops.rank(arrays)})")
     else:
       return swapaxes(arrays, 0, axis)
   arrays = _promote_dtype(*arrays)  # pylint: disable=protected-access


### PR DESCRIPTION
AT present `tf.experimental.numpy.stack` not validating the values for `axis` argument. If we pass out of bound values to the `axis` still it is not rising the Error. Hence I am proposing amendments to validate the `axis` argument and raise the Error in case of out of bound axis.

Please find the attached [gist](https://colab.research.google.com/gist/SuryanarayanaY/db882df3c2245044a96cd943dead229e/git_55217_nightly-2-14.ipynb) for explaining the problem and also with proposed amendments to the code it works fine and raised intended error when invalid axis arguments provided.

Fixes #55217
