### PR TITLE
TensorflowLite unit test error fix

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/tasks/fully_connected_test_util.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/fully_connected_test_util.cc
@@ -52,8 +52,7 @@ absl::Status FullyConnectedTest(TestExecutionEnvironment* env) {
       RETURN_IF_ERROR(env->ExecuteGPUOperation(
           src_tensor, std::make_unique<FullyConnected>(std::move(operation)),
           BHWC(1, 1, 1, 2), &dst_tensor));
-      RETURN_IF_ERROR(PointWiseNear({14.5f, 37.5f}, dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+      RETURN_IF_ERROR(PointWiseNear({14.5f, 37.5f}, dst_tensor.data, eps));
     }
   }
   return absl::OkStatus();
@@ -101,8 +100,7 @@ absl::Status FullyConnectedLargeTest(TestExecutionEnvironment* env) {
       RETURN_IF_ERROR(
           PointWiseNear({139.4f, 363.5f, 587.6f, 811.7f, 1035.8f, 1259.9f,
                          1484.1f, 1708.2f, 1932.3f, 2156.4f, 2380.5f, 2604.6f},
-                        dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+                        dst_tensor.data, eps));
     }
   }
   return absl::OkStatus();
@@ -159,8 +157,7 @@ absl::Status FullyConnectedExtraLargeTest(TestExecutionEnvironment* env) {
       RETURN_IF_ERROR(env->ExecuteGPUOperation(
           src_tensor, std::make_unique<FullyConnected>(std::move(operation)),
           BHWC(1, 1, 1, kOutputSize), &dst_tensor));
-      RETURN_IF_ERROR(PointWiseNear(expected, dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+      RETURN_IF_ERROR(PointWiseNear(expected, dst_tensor.data, eps));
     }
   }
   return absl::OkStatus();
@@ -194,8 +191,7 @@ absl::Status FullyConnectedInt8Test(TestExecutionEnvironment* env) {
       RETURN_IF_ERROR(env->ExecuteGPUOperation(
           src_tensor, std::make_unique<FullyConnected>(std::move(operation)),
           BHWC(1, 1, 1, 2), &dst_tensor));
-      RETURN_IF_ERROR(PointWiseNear({20.5f, 15.5f}, dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+      RETURN_IF_ERROR(PointWiseNear({20.5f, 15.5f}, dst_tensor.data, eps));
     }
   }
   return absl::OkStatus();

--- a/tensorflow/lite/delegates/gpu/common/tasks/lstm_test_util.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/lstm_test_util.cc
@@ -67,14 +67,12 @@ absl::Status LstmTest(TestExecutionEnvironment* env) {
       RETURN_IF_ERROR(
           PointWiseNear({7.0 / 15.0, 10.0 / 15.0, 13.0 / 15.0, 16.0 / 15.0},
                         new_state.data, eps))
-          << ToString(storage) << ", " << ToString(precision);
       RETURN_IF_ERROR(PointWiseNear(
           {static_cast<float>((1.0 / 6.0) * std::tanh(7.0 / 15.0)),
            static_cast<float>((1.0 / 6.0) * std::tanh(10.0 / 15.0)),
            static_cast<float>((1.0 / 6.0) * std::tanh(13.0 / 15.0)),
            static_cast<float>((1.0 / 6.0) * std::tanh(16.0 / 15.0))},
           new_activ.data, eps))
-          << ToString(storage) << ", " << ToString(precision);
     }
   }
   return absl::OkStatus();

--- a/tensorflow/lite/delegates/gpu/common/tasks/mean_stddev_normalization_test_util.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/mean_stddev_normalization_test_util.cc
@@ -126,8 +126,7 @@ absl::Status MeanStddevNormalizationAllBatchesTest(
           -ksqrt16, -ksqrt04, ksqrt04, ksqrt16,  // large mean, small variance
           -ksqrt16, -ksqrt04, ksqrt04, ksqrt16,  // large mean, large variance
       };
-      RETURN_IF_ERROR(PointWiseNear(expected_output, dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+      RETURN_IF_ERROR(PointWiseNear(expected_output, dst_tensor.data, eps));
 
       TensorFloat32 dst_tensor_single_step;
       auto operation_single_step = CreateMeanStdDevNormalization(
@@ -139,8 +138,7 @@ absl::Status MeanStddevNormalizationAllBatchesTest(
                                        std::move(operation_single_step)),
                                    BHWC(9, 1, 1, 4), &dst_tensor_single_step));
       RETURN_IF_ERROR(
-          PointWiseNear(expected_output, dst_tensor_single_step.data, eps))
-          << "Failed using precision " << ToString(precision);
+          PointWiseNear(expected_output, dst_tensor_single_step.data, eps));
     }
   }
   return absl::OkStatus();
@@ -198,8 +196,7 @@ absl::Status MeanStddevNormalizationLargeVectorTest(
         expected_output[kVectorSize + i + 0] = +expected_elem;
         expected_output[kVectorSize + i + 1] = -expected_elem;
       }
-      RETURN_IF_ERROR(PointWiseNear(expected_output, dst_tensor.data, eps))
-          << "Failed using precision " << ToString(precision);
+      RETURN_IF_ERROR(PointWiseNear(expected_output, dst_tensor.data, eps));
 
       if (precision != CalculationsPrecision::F32) {
         TensorFloat32 dst_tensor_single_step;
@@ -212,8 +209,7 @@ absl::Status MeanStddevNormalizationLargeVectorTest(
                 std::move(operation_single_step)),
             BHWC(1, 1, 2, kVectorSize), &dst_tensor_single_step));
         RETURN_IF_ERROR(
-            PointWiseNear(expected_output, dst_tensor_single_step.data, eps))
-            << "Failed using precision " << ToString(precision);
+            PointWiseNear(expected_output, dst_tensor_single_step.data, eps));
       }
     }
   }

--- a/tensorflow/lite/delegates/gpu/common/testing/interpreter_utils.cc
+++ b/tensorflow/lite/delegates/gpu/common/testing/interpreter_utils.cc
@@ -50,12 +50,17 @@ absl::Status InterpreterInvokeWithOpResolver(
     return absl::InternalError("Unable to allocate TfLite tensors");
   }
   for (int i = 0; i < inputs.size(); ++i) {
-    DCHECK_EQ(interpreter->tensor(interpreter->inputs()[i])->type,
-              kTfLiteFloat32);
+    if(interpreter->tensor(interpreter->inputs()[i])->type !=  kTfLiteFloat32){
+      return absl::InternalError(
+        "input data_type is not float32");
+    }
     float* tflite_data =
         interpreter->typed_tensor<float>(interpreter->inputs()[i]);
-    DCHECK_EQ(inputs[i].data.size() * sizeof(float),
-              interpreter->tensor(interpreter->inputs()[i])->bytes);
+    if(inputs[i].data.size() * sizeof(float) == 
+        interpreter->tensor(interpreter->inputs()[i])->bytes){
+      return absl::InternalError(
+        "input data size doesn't match for this input");
+    }
     std::memcpy(tflite_data, inputs[i].data.data(),
                 inputs[i].data.size() * sizeof(float));
   }


### PR DESCRIPTION
Resolving errors which occur during `bazel test //tensorflow/lite/delegates/gpu/common/...`

This fixes the errors in unit_tests in:

fully_connected.
lstm.
mean_stddev_normalization.
interpreter_utils.