### PR TITLE
Add directory instructions for windows build

### DIFF
--- a/tensorflow/lite/g3doc/guide/build_cmake.md
+++ b/tensorflow/lite/g3doc/guide/build_cmake.md
@@ -290,6 +290,8 @@ cmake --build . -j
 
 This command generates the following shared library in the current directory.
 
+**Note:** On Windows system, you can find the `tensorflowlite_c.dll` under `debug` directory.
+
 Platform | Library name
 -------- | ---------------------------
 Linux    | `libtensorflowlite_c.so`


### PR DESCRIPTION
Added directory details for the shared library file.
Fixes: https://github.com/tensorflow/tensorflow/issues/55970