### PR TITLE
[TOSA] Matching ranks for TOSA operators

### DIFF
--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
@@ -504,10 +504,21 @@ void getTosaConst32bitSoftmaxExpTable(PatternRewriter& rewriter, Operation* op,
 
 // Create a 32-bit float constant operator from a float
 Value getTosaConstTensorSingleF32(PatternRewriter& rewriter, Operation* op,
-                                  float val) {
-  auto const_type =
-      tensorflow::GetTypeFromTFTensorShape({}, rewriter.getF32Type());
-  auto const_attr = DenseElementsAttr::get(const_type, val);
+                                  float val, int rank) {
+  assert(rank >= 0);
+  mlir::RankedTensorType const_type;
+  mlir::DenseElementsAttr const_attr;
+  auto element_type = rewriter.getF32Type();
+  if (rank == 0) {
+    const_type = tensorflow::GetTypeFromTFTensorShape({}, element_type);
+    const_attr = DenseElementsAttr::get(const_type, val);
+  } else {
+    std::vector<int64_t> shape(rank, 1);
+    const_type = tensorflow::GetTypeFromTFTensorShape(llvm::ArrayRef(shape),
+                                                      element_type);
+    std::vector<float> values(1, val);
+    const_attr = DenseElementsAttr::get(const_type, llvm::ArrayRef(values));
+  }
 
   auto const_op =
       rewriter.create<tosa::ConstOp>(op->getLoc(), const_type, const_attr);
@@ -516,10 +527,21 @@ Value getTosaConstTensorSingleF32(PatternRewriter& rewriter, Operation* op,
 
 // Create a 32-bit integer constant operator from an int
 Value getTosaConstTensorSingleI32(PatternRewriter& rewriter, Operation* op,
-                                  int32_t val) {
-  auto const_type =
-      tensorflow::GetTypeFromTFTensorShape({}, rewriter.getIntegerType(32));
-  auto const_attr = DenseElementsAttr::get(const_type, val);
+                                  int32_t val, int rank) {
+  assert(rank >= 0);
+  mlir::RankedTensorType const_type;
+  mlir::DenseElementsAttr const_attr;
+  auto element_type = rewriter.getIntegerType(32);
+  if (rank == 0) {
+    const_type = tensorflow::GetTypeFromTFTensorShape({}, element_type);
+    const_attr = DenseElementsAttr::get(const_type, val);
+  } else {
+    std::vector<int64_t> shape(rank, 1);
+    const_type = tensorflow::GetTypeFromTFTensorShape(llvm::ArrayRef(shape),
+                                                      element_type);
+    std::vector<int32_t> values(1, val);
+    const_attr = DenseElementsAttr::get(const_type, llvm::ArrayRef(values));
+  }
 
   auto const_op =
       rewriter.create<tosa::ConstOp>(op->getLoc(), const_type, const_attr);
@@ -529,12 +551,23 @@ Value getTosaConstTensorSingleI32(PatternRewriter& rewriter, Operation* op,
 // Create an expected bitwidth integer constant operator based on the type
 // parameter.
 Value getTosaConstTensorScalarInt(ImplicitLocOpBuilder& builder, Type type,
-                                  int64_t val) {
+                                  int64_t val, int rank) {
+  assert(rank >= 0);
+  assert(type.isa<IntegerType>());
+  mlir::RankedTensorType const_type;
+  mlir::DenseElementsAttr const_attr;
   auto bit_width = type.getIntOrFloatBitWidth();
-  auto const_type = tensorflow::GetTypeFromTFTensorShape(
-      {}, builder.getIntegerType(bit_width));
-  auto const_attr =
-      SplatElementsAttr::get(const_type, builder.getIntegerAttr(type, val));
+  auto element_type = builder.getIntegerType(bit_width);
+  if (rank == 0) {
+    const_type = tensorflow::GetTypeFromTFTensorShape({}, element_type);
+    const_attr = DenseElementsAttr::get(const_type, val);
+  } else {
+    std::vector<int64_t> shape(rank, 1);
+    const_type = tensorflow::GetTypeFromTFTensorShape(llvm::ArrayRef(shape),
+                                                      element_type);
+    std::vector<int32_t> values(1, val);
+    const_attr = DenseElementsAttr::get(const_type, llvm::ArrayRef(values));
+  }
 
   auto const_op =
       builder.create<tosa::ConstOp>(builder.getLoc(), const_type, const_attr);
@@ -836,6 +869,5 @@ void TrimQuantizedIntegerRange(UniformQuantizedType dtype, int64_t& val_min,
   TrimQuantizedIntegerRangeMin(dtype, val_min);
   TrimQuantizedIntegerRangeMax(dtype, val_max);
 }
-
 }  // namespace tosa
 }  // namespace mlir

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
@@ -114,18 +114,18 @@ Value getTosaConstRsqrt8bitTable(PatternRewriter& rewriter, Operation* op,
                                  float input_scale, int32_t input_zp,
                                  float output_scale, int32_t output_zp);
 
-// Create a 32-bit float constant operator from a float
+// Create a 32-bit float constant operator from a float of specified rank
 Value getTosaConstTensorSingleF32(PatternRewriter& rewriter, Operation* op,
-                                  float val);
+                                  float val, int rank);
 
-// Create a 32-bit integer constant operator from an int
+// Create a 32-bit integer constant operator from an int of specified rank
 Value getTosaConstTensorSingleI32(PatternRewriter& rewriter, Operation* op,
-                                  int32_t val);
+                                  int32_t val, int rank);
 
 // Create an expected bitwidth integer constant operator based on the type
-// parameter.
+// parameter, of specified rank
 Value getTosaConstTensorScalarInt(ImplicitLocOpBuilder& builder, Type type,
-                                  int64_t val);
+                                  int64_t val, int rank);
 
 // Create a vector from a 32-bit value tensor.  Returns vector size on success
 // or -1 on error.

--- a/tensorflow/compiler/mlir/tosa/transforms/tfl_legalize_patterns.td
+++ b/tensorflow/compiler/mlir/tosa/transforms/tfl_legalize_patterns.td
@@ -42,10 +42,6 @@ def ConvertQuantStatOp : Pat<(quantfork_StatisticsOp $value, $layer_stats, $axis
 // Binary ops patterns.
 //===----------------------------------------------------------------------===//
 
-def ConvertTFLLogicalAndOp : Pat<(TFL_LogicalAndOp $l, $r), (Tosa_LogicalAndOp $l, $r)>;
-def ConvertTFLLogicalOrOp : Pat<(TFL_LogicalOrOp $l, $r), (Tosa_LogicalOrOp $l, $r)>;
-def ConvertTFLPowOp : Pat<(TFL_PowOp $l, $r), (Tosa_PowOp $l, $r)>;
-
 //===----------------------------------------------------------------------===//
 // Ternary ops patterns.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This patch modifies tosa legalization to construct matching ranks
upfront for TOSA operators with ResultsBroadcastableShape trait.

Two major changes:
1. Add parameter "rank" to: 
      - getTosaConstTensorSingleF32, 
      - getTosaConstTensorSingleI32, 
      - getTosaConstTensorScalarInt,

   functions and create const tensors with appropriate ranks upfront.

2. insert EqualizeRanks calls to reshape the lower rank input before
    constructing TOSA operators that require matching ranks.
