### PR TITLE
[tflite] enable passing fused activation function in TransposeConv in NNAPI delegate

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -2965,7 +2965,7 @@ bool NNAPIDelegateKernel::Validate(
       ExpectIsFloatOperator(context, node, &val_ctx);
     } break;
     case kTfLiteBuiltinTransposeConv: {
-      ExpectMaxOpVersion(version, 3, &val_ctx);
+      ExpectMaxOpVersion(version, 4, &val_ctx);
       ExpectMinAndroidSdkVersion(android_sdk_version, kMinSdkVersionForNNAPI12,
                                  &val_ctx);
       Expect((node->inputs->size > 1) &&
@@ -4042,8 +4042,7 @@ TfLiteStatus NNAPIDelegateKernel::Map(
       mapping_args.builder->AddScalarInt32Operand(builtin->padding);
       mapping_args.builder->AddScalarInt32Operand(builtin->stride_width);
       mapping_args.builder->AddScalarInt32Operand(builtin->stride_height);
-      mapping_args.builder->AddScalarInt32Operand(
-          /*ANEURALNETWORKS_FUSED_NONE*/ 0);
+      mapping_args.builder->AddScalarInt32Operand(builtin->activation);
       // Use NHWC layout for input and output.
       mapping_args.builder->AddScalarBoolOperand(false);
       *nn_op_type = ANEURALNETWORKS_TRANSPOSE_CONV;


### PR DESCRIPTION
NNAPI supports fused activation. Enabling it so that there won't be messages like:
```
INFO: NNAPI delegate created.
WARNING: Operator TRANSPOSE_CONV (v4) refused by NNAPI delegate: OP Version higher than 3
WARNING: Operator TRANSPOSE_CONV (v4) refused by NNAPI delegate: OP Version higher than 3
.....
```

Note that `TRANSPOSE_CONV (v4)` means there is fused activation function, https://github.com/tensorflow/tensorflow/blob/r2.13/tensorflow/lite/tools/versioning/op_version.cc#L337-L341