### PR TITLE
TFLITE fix inconsistencies in using std/absl for variant/any_cast functions.

### DIFF
--- a/tensorflow/lite/delegates/gpu/api.h
+++ b/tensorflow/lite/delegates/gpu/api.h
@@ -230,7 +230,7 @@ bool IsValid(const TensorObjectDef& def);
 uint32_t NumElements(const TensorObjectDef& def);
 
 using TensorObject =
-    std::variant<std::monostate, OpenGlBuffer, OpenGlTexture, CpuMemory,
+    absl::variant<std::monostate, OpenGlBuffer, OpenGlTexture, CpuMemory,
                  OpenClBuffer, OpenClTexture, VulkanBuffer, VulkanTexture>;
 
 // @return true if object is set and corresponding values are defined.

--- a/tensorflow/lite/delegates/gpu/common/operations.h
+++ b/tensorflow/lite/delegates/gpu/common/operations.h
@@ -119,8 +119,8 @@ std::string ToString(enum OperationType op);
 OperationType OperationTypeFromString(const std::string& name);
 
 template <DataType DataTypeT, typename t>
-using TensorOrScalarBase = std::variant<std::monostate, Tensor<HWC, DataTypeT>,
-                                        Tensor<Linear, DataTypeT>, t>;
+using TensorOrScalarBase = absl::variant<std::monostate, Tensor<HWC, DataTypeT>,
+                                         Tensor<Linear, DataTypeT>, t>;
 
 using TensorOrScalar = TensorOrScalarBase<DataType::FLOAT32, float>;
 

--- a/tensorflow/lite/delegates/gpu/common/selectors/operation_selector.cc
+++ b/tensorflow/lite/delegates/gpu/common/selectors/operation_selector.cc
@@ -310,7 +310,7 @@ absl::Status CreateElementwiseTwoInputWithOneConstant(
     const GpuInfo& gpu_info, const OperationDef& op_def, OperationType op_type,
     const Node& node, const Value* input, const Value* output,
     std::unique_ptr<GPUOperation>* gpu_op) {
-  auto attr = std::any_cast<ElementwiseAttributesBase<DataTypeT, T>>(
+  auto attr = absl::any_cast<ElementwiseAttributesBase<DataTypeT, T>>(
       node.operation.attributes);
   GPUOperation operation;
   if (input->tensor.shape != output->tensor.shape) {

--- a/tensorflow/lite/delegates/gpu/gl/object.h
+++ b/tensorflow/lite/delegates/gpu/gl/object.h
@@ -47,7 +47,7 @@ enum class ObjectType : int {
   BUFFER = 2,
 };
 
-using ObjectSize = std::variant<size_t, uint2, uint3>;
+using ObjectSize = absl::variant<size_t, uint2, uint3>;
 
 // An object represents a reference to or pre-defined constant OpenGL Buffer or
 // Texture. NodeShader is supposed to set all fields but leave binding = 0
@@ -66,7 +66,7 @@ struct Object {
   // consists of 4 values.
   ObjectSize size;
 
-  std::variant<ObjectData, ObjectRef> object;
+  absl::variant<ObjectData, ObjectRef> object;
 };
 
 // @return true if object is a reference.

--- a/tensorflow/lite/delegates/gpu/gl/variable.h
+++ b/tensorflow/lite/delegates/gpu/gl/variable.h
@@ -31,7 +31,7 @@ namespace gl {
 
 struct Variable {
   using ValueType =
-      std::variant<int32_t, int2, int4, uint32_t, uint4, float, float2, float4,
+      absl::variant<int32_t, int2, int4, uint32_t, uint4, float, float2, float4,
                    std::vector<int2>, std::vector<float4>>;
 
   std::string name;

--- a/tensorflow/lite/kernels/shim/tensor_view.h
+++ b/tensorflow/lite/kernels/shim/tensor_view.h
@@ -48,11 +48,11 @@ class TensorView {
  protected:
   // Union over all data types
   using DataVariantType =
-      std::variant<absl::Span<bool>, absl::Span<int8_t>, absl::Span<uint8_t>,
-                   absl::Span<int16_t>, absl::Span<uint16_t>,
-                   absl::Span<int32_t>, absl::Span<uint32_t>,
-                   absl::Span<int64_t>, absl::Span<uint64_t>, absl::Span<float>,
-                   absl::Span<double>, absl::Span<::tensorflow::tstring>>;
+      absl::variant<absl::Span<bool>, absl::Span<int8_t>, absl::Span<uint8_t>,
+                    absl::Span<int16_t>, absl::Span<uint16_t>,
+                    absl::Span<int32_t>, absl::Span<uint32_t>,
+                    absl::Span<int64_t>, absl::Span<uint64_t>, absl::Span<float>,
+                    absl::Span<double>, absl::Span<::tensorflow::tstring>>;
 
   // An interface while provides convenient row-major indexing over the
   // underlying tensor.

--- a/tensorflow/lite/kernels/shim/tflite_op_wrapper.h
+++ b/tensorflow/lite/kernels/shim/tflite_op_wrapper.h
@@ -70,8 +70,8 @@ struct AttrType {
 //              Attr<AttrName<a_type>, bool, float>,
 //              Attr<AttrName<b_type>, int32_t, int64_t>> x;
 // Result:
-//   std::variant<TmplOp<Rt, bool, int32_t>, TmplOp<Rt, bool, int64_t>,
-//                TmplOp<Rt, float, int32_t>, TmplOp<Rt, float, int64_t>> x;
+//   absl::variant<TmplOp<Rt, bool, int32_t>, TmplOp<Rt, bool, int64_t>,
+//                 TmplOp<Rt, float, int32_t>, TmplOp<Rt, float, int64_t>> x;
 
 // Prepends a type onto a tuple.
 template <typename T, typename... Us>
@@ -123,7 +123,7 @@ static constexpr auto convertTuplesToOps(std::tuple<Ts...>) -> std::tuple<
 
 // Convert a tuple of types into a variant of types.
 template <typename... Ts>
-static constexpr std::variant<Ts...> convertTupleToVariant(std::tuple<Ts...>);
+static constexpr absl::variant<Ts...> convertTupleToVariant(std::tuple<Ts...>);
 
 // The variant Op type created with TMP. A tuple of tuples containing the
 // attribute combinations is first created. Then each inner tuple is converted


### PR DESCRIPTION
Fix using std::any_cast instead of absl::any_cast

Inconsistencies exist in Lite repo using std::variant/absl::variant and std::any_cast/absl::any_cast. When abseil is built with ABSL_USES_STD_ANY (Linux), everything works even with this bug. But if not (on Windows build), this uses std::any_cast on variable created by absl::variant, causing a throwing of exception at runtime.