### PR TITLE
FP8 Convolutions in XLA

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
+++ b/tensorflow/compiler/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
@@ -49,7 +49,7 @@ class GpuConvolutionAttributes<dag extraAttribs> {
 }
 
 // Provide a custom assembly format for all LHLO_GPU convolution operations.
-class LHLOGPU_ConvBaseOp<string mnemonic> : LHLOGPU_Op<mnemonic> {
+class LHLOGPU_ConvBaseOp<string mnemonic, list<Trait> traits = []> : LHLOGPU_Op<mnemonic> {
  let assemblyFormat = [{
     `(`operands`)`
        `dim_numbers` `=` custom<ConvolutionDimensions>($dimension_numbers) `,`
@@ -138,6 +138,19 @@ def LHLOGPU_CudnnConvReorderFilterAndBiasOp :
     Arg<LHLO_Buffer, "", [MemWrite]>:$filter_output,
     Arg<LHLO_Buffer, "", [MemWrite]>:$bias_output,
     I64ElementsAttr:$filter_dims);
+}
+
+def LHLOGPU_ConvForwardGraphOp :
+      LHLOGPU_ConvBaseOp<"conv_forward_graph", [AttrSizedOperandSegments]> {
+  let arguments = !con(
+    (ins
+       Arg<LHLO_Buffer, "", [MemRead]>:$input,
+       Arg<LHLO_Buffer, "", [MemRead]>:$filter,
+       Arg<Variadic<LHLO_Buffer>, "", [MemRead]>:$binary_operands,
+       Arg<LHLO_Buffer, "", [MemWrite]>:$output,
+       Arg<LHLO_Buffer, "", [MemWrite]>:$scratch),
+     GpuConvolutionAttributes<(ins
+          StrAttr:$serialized_graph)>.attributes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -3064,7 +3064,9 @@ cc_library(
         "//tensorflow/compiler/xla/stream_executor",
         "//tensorflow/tsl/platform:errors",
         "//tensorflow/tsl/platform:statusor",
-    ],
+    ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+    ]),
 )
 
 cc_library(

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -3066,47 +3066,8 @@ cc_library(
         "//tensorflow/tsl/platform:statusor",
     ] + if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudnn_header",
     ]),
-)
-
-cc_library(
-    name = "cudnn_fused_mha_rewriter",
-    srcs = ["cudnn_fused_mha_rewriter.cc"],
-    hdrs = ["cudnn_fused_mha_rewriter.h"],
-    deps = [
-        ":backend_configs_cc",
-        ":cublas_cudnn",
-        ":matmul_utils",
-        "//tensorflow/compiler/xla:permutation_util",
-        "//tensorflow/compiler/xla/hlo/ir:hlo",
-        "//tensorflow/compiler/xla/service:hlo_pass",
-        "//tensorflow/compiler/xla/service:pattern_matcher",
-        "//tensorflow/compiler/xla/stream_executor:stream_executor_headers",
-        "//tensorflow/tsl/platform:errors",
-        "//tensorflow/tsl/platform:statusor",
-    ] + if_cuda_is_configured([
-        "@local_config_cuda//cuda:cuda_headers",
-    ]),
-)
-
-xla_cc_test(
-    name = "cudnn_fused_mha_rewriter_test",
-    srcs = ["cudnn_fused_mha_rewriter_test.cc"],
-    tags = tf_cuda_tests_tags(),
-    deps = [
-        ":backend_configs_cc",
-        ":cublas_cudnn",
-        ":cudnn_fused_mha_rewriter",
-        "//tensorflow/compiler/xla:status_macros",
-        "//tensorflow/compiler/xla:util",
-        "//tensorflow/compiler/xla/service:hlo_parser",
-        "//tensorflow/compiler/xla/service:pattern_matcher",
-        "//tensorflow/compiler/xla/service:pattern_matcher_gmock",
-        "//tensorflow/compiler/xla/tests:hlo_test_base",
-        "//tensorflow/tsl/lib/core:status_test_util",
-        "//tensorflow/tsl/platform:test_main",
-        "@com_google_googletest//:gtest_main",
-    ],
 )
 
 xla_cc_test(
@@ -3140,6 +3101,50 @@ xla_cc_test(
         "//tensorflow/tsl/lib/core:status_test_util",
         "//tensorflow/tsl/platform:test_main",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+    ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudnn_header",
+    ]),
+)
+
+cc_library(
+    name = "cudnn_fused_mha_rewriter",
+    srcs = ["cudnn_fused_mha_rewriter.cc"],
+    hdrs = ["cudnn_fused_mha_rewriter.h"],
+    deps = [
+        ":backend_configs_cc",
+        ":cublas_cudnn",
+        ":matmul_utils",
+        "//tensorflow/compiler/xla:permutation_util",
+        "//tensorflow/compiler/xla/hlo/ir:hlo",
+        "//tensorflow/compiler/xla/service:hlo_pass",
+        "//tensorflow/compiler/xla/service:pattern_matcher",
+        "//tensorflow/compiler/xla/stream_executor:stream_executor_headers",
+        "//tensorflow/tsl/platform:errors",
+        "//tensorflow/tsl/platform:statusor",
+    ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cudnn_header",
+    ]),
+)
+
+xla_cc_test(
+    name = "cudnn_fused_mha_rewriter_test",
+    srcs = ["cudnn_fused_mha_rewriter_test.cc"],
+    tags = tf_cuda_tests_tags(),
+    deps = [
+        ":backend_configs_cc",
+        ":cublas_cudnn",
+        ":cudnn_fused_mha_rewriter",
+        "//tensorflow/compiler/xla:status_macros",
+        "//tensorflow/compiler/xla:util",
+        "//tensorflow/compiler/xla/service:hlo_parser",
+        "//tensorflow/compiler/xla/service:pattern_matcher",
+        "//tensorflow/compiler/xla/service:pattern_matcher_gmock",
+        "//tensorflow/compiler/xla/tests:hlo_test_base",
+        "//tensorflow/tsl/lib/core:status_test_util",
+        "//tensorflow/tsl/platform:test_main",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -3082,7 +3082,9 @@ cc_library(
         "//tensorflow/compiler/xla/stream_executor:stream_executor_headers",
         "//tensorflow/tsl/platform:errors",
         "//tensorflow/tsl/platform:statusor",
-    ],
+    ] + if_cuda_is_configured([
+        "@local_config_cuda//cuda:cuda_headers",
+    ]),
 )
 
 xla_cc_test(

--- a/tensorflow/compiler/xla/service/gpu/backend_configs.proto
+++ b/tensorflow/compiler/xla/service/gpu/backend_configs.proto
@@ -60,7 +60,7 @@ message CudnnConvBackendConfig {
 
   // Serialization of the graph described by the convolution and adjacent
   // pointwise ops.
-  optional string serialized_graph = 8;
+  optional string serialized_graph = 9;
 }
 
 // Backend config for the GEMM operation running through cuBLAS.

--- a/tensorflow/compiler/xla/service/gpu/backend_configs.proto
+++ b/tensorflow/compiler/xla/service/gpu/backend_configs.proto
@@ -57,6 +57,10 @@ message CudnnConvBackendConfig {
     // compatible with NVidia's IMMA instruction (sm75+).
     bool reordered_int8_nchw_vect = 7;
   }
+
+  // Serialization of the graph described by the convolution and adjacent
+  // pointwise ops.
+  optional string serialized_graph = 8;
 }
 
 // Backend config for the GEMM operation running through cuBLAS.

--- a/tensorflow/compiler/xla/service/gpu/buffer_comparator.cc
+++ b/tensorflow/compiler/xla/service/gpu/buffer_comparator.cc
@@ -38,562 +38,977 @@ namespace gpu {
 static constexpr double kTolerance = 0.1f;
 
 // Comparison kernel code: compare two buffers of
-// bf16/fp16/fp32/fp64/int8_t/int32_t of length buffer_length where the relative
-// error does not exceed the passed rel_error_threshold. Write the number of
-// mismatches into out parameter mismatch_count.
-//
+// fp8/bf16/fp16/fp32/fp64/int8_t/int32_t of length buffer_length where the
+// relative error does not exceed the passed rel_error_threshold. Write the
+// number of mismatches into out parameter mismatch_count.
+
 // NaN's are considered equal, and for half's we clamp all numbers to largest
 // and smallest numbers representable to avoid miscomparisons due to overflows.
-//
+
 // The PTX below is compiled from the following CUDA code:
-//
-// #include <cuda_fp16.h>
+
 // #include <cuda_bf16.h>
-//
+// #include <cuda_fp16.h>
+// #include <cuda_fp8.h>
+
 // namespace {
-//
+
 // __device__ __inline__ float __xla_buffer_comparator_canonicalize(float input)
 // {
 //   // All fp16 infinities are treated as 65505 or -65505, in order to avoid
 //   // differences due to overflows.
 //   return isnan(input) ? input : max(-65505.0f, min(input, 65505.0f));
 // }
-//
+
 // } // end anonymous namespace
-//
-// extern "C" {  // avoid name mangling
-//
-//
-// __global__ void __xla_fp16_comparison(__half* buffer_a, __half* buffer_b,
+
+// extern "C" { // avoid name mangling
+
+// __global__ void __xla_fp8_e4m3fn_comparison(__nv_fp8_storage_t *buffer_a,
+//                                             __nv_fp8_storage_t *buffer_b,
+//                                             float rel_error_threshold,
+//                                             unsigned long long buffer_length,
+//                                             int *mismatch_count) {
+//   int idx = threadIdx.x + blockIdx.x * blockDim.x;
+//   if (idx >= buffer_length)
+//     return;
+//   // TODO(philipphack): Replace with direct conversion to float when this
+//   // functionality becomes availabe.
+//   float elem_a =
+//       __half2float(__nv_cvt_fp8_to_halfraw(buffer_a[idx], __NV_E4M3));
+//   float elem_b =
+//       __half2float(__nv_cvt_fp8_to_halfraw(buffer_b[idx], __NV_E4M3));
+//   elem_a = __xla_buffer_comparator_canonicalize(elem_a);
+//   elem_b = __xla_buffer_comparator_canonicalize(elem_b);
+//   if (isnan(elem_a) && isnan(elem_b))
+//     return;
+
+//   float rel_error = abs(elem_a - elem_b) / (max(abs(elem_a), abs(elem_b)) +
+//   1);
+
+//   if (rel_error > rel_error_threshold || isnan(rel_error))
+//     atomicAdd(mismatch_count, 1);
+// }
+
+// __global__ void __xla_fp8_e5m2_comparison(__nv_fp8_storage_t *buffer_a,
+//                                           __nv_fp8_storage_t *buffer_b,
+//                                           float rel_error_threshold,
+//                                           unsigned long long buffer_length,
+//                                           int *mismatch_count) {
+//   int idx = threadIdx.x + blockIdx.x * blockDim.x;
+//   if (idx >= buffer_length)
+//     return;
+//   // TODO(philipphack): Replace with direct conversion to float when this
+//   // functionality becomes availabe.
+//   float elem_a =
+//       __half2float(__nv_cvt_fp8_to_halfraw(buffer_a[idx], __NV_E5M2));
+//   float elem_b =
+//       __half2float(__nv_cvt_fp8_to_halfraw(buffer_b[idx], __NV_E5M2));
+//   elem_a = __xla_buffer_comparator_canonicalize(elem_a);
+//   elem_b = __xla_buffer_comparator_canonicalize(elem_b);
+//   if (isnan(elem_a) && isnan(elem_b))
+//     return;
+
+//   float rel_error = abs(elem_a - elem_b) / (max(abs(elem_a), abs(elem_b)) +
+//   1);
+
+//   if (rel_error > rel_error_threshold || isnan(rel_error))
+//     atomicAdd(mismatch_count, 1);
+// }
+
+// __global__ void __xla_fp16_comparison(__half *buffer_a, __half *buffer_b,
 //                                       float rel_error_threshold,
 //                                       unsigned long long buffer_length,
-//                                       int* mismatch_count) {
+//                                       int *mismatch_count) {
 //   int idx = threadIdx.x + blockIdx.x * blockDim.x;
-//   if (idx >= buffer_length) return;
+//   if (idx >= buffer_length)
+//     return;
 //   float elem_a = __half2float(buffer_a[idx]);
 //   float elem_b = __half2float(buffer_b[idx]);
 //   elem_a = __xla_buffer_comparator_canonicalize(elem_a);
 //   elem_b = __xla_buffer_comparator_canonicalize(elem_b);
-//   if (isnan(elem_a) && isnan(elem_b)) return;
-//
-//   float rel_error = abs(elem_a - elem_b)
-//       / (max(abs(elem_a), abs(elem_b)) + 1);
-//
+//   if (isnan(elem_a) && isnan(elem_b))
+//     return;
+
+//   float rel_error = abs(elem_a - elem_b) / (max(abs(elem_a), abs(elem_b)) +
+//   1);
+
 //   if (rel_error > rel_error_threshold || isnan(rel_error))
 //     atomicAdd(mismatch_count, 1);
 // }
-//
-// __global__ void __xla_fp32_comparison(float* buffer_a, float* buffer_b,
+
+// __global__ void __xla_fp32_comparison(float *buffer_a, float *buffer_b,
 //                                       float rel_error_threshold,
 //                                       unsigned long long buffer_length,
-//                                       int* mismatch_count) {
+//                                       int *mismatch_count) {
 //   int idx = threadIdx.x + blockIdx.x * blockDim.x;
-//   if (idx >= buffer_length) return;
+//   if (idx >= buffer_length)
+//     return;
 //   float elem_a = buffer_a[idx];
 //   float elem_b = buffer_b[idx];
-//   if (isnan(elem_a) && isnan(elem_b)) return;
+//   if (isnan(elem_a) && isnan(elem_b))
+//     return;
 //   if (isinf(elem_a) && isinf(elem_b) && signbit(elem_a) == signbit(elem_b))
 //     return;
-//
-//   float rel_error = abs(elem_a - elem_b)
-//       / (max(abs(elem_a), abs(elem_b)) + 1);
-//   if (rel_error > rel_error_threshold || isnan(rel_error))
+
+//   float rel_error = abs(elem_a - elem_b) / (max(abs(elem_a), abs(elem_b)) +
+//   1); if (rel_error > rel_error_threshold || isnan(rel_error))
 //     atomicAdd(mismatch_count, 1);
 // }
-//
-// __global__ void __xla_fp64_comparison(double* buffer_a, double* buffer_b,
+
+// __global__ void __xla_fp64_comparison(double *buffer_a, double *buffer_b,
 //                                       float rel_error_threshold,
 //                                       unsigned long long buffer_length,
-//                                       int* mismatch_count) {
+//                                       int *mismatch_count) {
 //   int idx = threadIdx.x + blockIdx.x * blockDim.x;
-//   if (idx >= buffer_length) return;
-//
+//   if (idx >= buffer_length)
+//     return;
+
 //   double elem_a = buffer_a[idx];
 //   double elem_b = buffer_b[idx];
-//   if (isnan(elem_a) && isnan(elem_b)) return;
+//   if (isnan(elem_a) && isnan(elem_b))
+//     return;
 //   if (isinf(elem_a) && isinf(elem_b) && signbit(elem_a) == signbit(elem_b))
 //     return;
-//   double rel_error = abs(elem_a - elem_b)
-//       / (max(abs(elem_a), abs(elem_b)) + 1);
-//   if (rel_error > rel_error_threshold || isnan(rel_error))
+//   double rel_error = abs(elem_a - elem_b) / (max(abs(elem_a), abs(elem_b)) +
+//   1); if (rel_error > rel_error_threshold || isnan(rel_error))
 //     atomicAdd(mismatch_count, 1);
 // }
-//
-// __global__ void __xla_bf16_comparison(__nv_bfloat16* buffer_a,
-//                                       __nv_bfloat16* buffer_b,
+
+// __global__ void __xla_bf16_comparison(__nv_bfloat16 *buffer_a,
+//                                       __nv_bfloat16 *buffer_b,
 //                                       float rel_error_threshold,
 //                                       unsigned long long buffer_length,
-//                                       int* mismatch_count) {
+//                                       int *mismatch_count) {
 //   int idx = threadIdx.x + blockIdx.x * blockDim.x;
-//   if (idx >= buffer_length) return;
+//   if (idx >= buffer_length)
+//     return;
 //   float elem_a = __bfloat162float(buffer_a[idx]);
 //   float elem_b = __bfloat162float(buffer_b[idx]);
 //   elem_a = __xla_buffer_comparator_canonicalize(elem_a);
 //   elem_b = __xla_buffer_comparator_canonicalize(elem_b);
-//   if (isnan(elem_a) && isnan(elem_b)) return;
-//
-//   float rel_error = abs(elem_a - elem_b)
-//       / (max(abs(elem_a), abs(elem_b)) + 1);
-//
+//   if (isnan(elem_a) && isnan(elem_b))
+//     return;
+
+//   float rel_error = abs(elem_a - elem_b) / (max(abs(elem_a), abs(elem_b)) +
+//   1);
+
 //   if (rel_error > rel_error_threshold || isnan(rel_error))
 //     atomicAdd(mismatch_count, 1);
 // }
-//
+
 // // TODO(b/191520348): The comparison below requires exact equality.
-// __global__ void __xla_int8_comparison(int8_t* buffer_a, int8_t* buffer_b,
+// __global__ void __xla_int8_comparison(int8_t *buffer_a, int8_t *buffer_b,
 //                                       float rel_error_threshold,
 //                                       unsigned long long buffer_length,
-//                                       int* mismatch_count) {
+//                                       int *mismatch_count) {
 //   int idx = threadIdx.x + blockIdx.x * blockDim.x;
-//   if (idx >= buffer_length) return;
+//   if (idx >= buffer_length)
+//     return;
 //   float a = buffer_a[idx];
 //   float b = buffer_b[idx];
 //   float rel_error = abs(a - b) / (max(abs(a), abs(b)) + 1);
 //   if (rel_error > rel_error_threshold || isnan(rel_error))
-//       atomicAdd(mismatch_count, 1);
+//     atomicAdd(mismatch_count, 1);
 // }
-//
-// __global__ void __xla_int32_comparison(int* buffer_a, int* buffer_b,
+
+// __global__ void __xla_int32_comparison(int *buffer_a, int *buffer_b,
 //                                        float rel_error_threshold,
 //                                        unsigned long long buffer_length,
-//                                        int* mismatch_count) {
+//                                        int *mismatch_count) {
 //   int idx = threadIdx.x + blockIdx.x * blockDim.x;
-//   if (idx >= buffer_length) return;
+//   if (idx >= buffer_length)
+//     return;
 //   float elem_a = static_cast<float>(buffer_a[idx]);
 //   float elem_b = static_cast<float>(buffer_b[idx]);
-//   float rel_error = abs(elem_a - elem_b)
-//       / (max(abs(elem_a), abs(elem_b)) + 1);
-//   if (rel_error > rel_error_threshold || isnan(rel_error))
+//   float rel_error = abs(elem_a - elem_b) / (max(abs(elem_a), abs(elem_b)) +
+//   1); if (rel_error > rel_error_threshold || isnan(rel_error))
 //     atomicAdd(mismatch_count, 1);
 // }
 // } // end extern declaration
 static const char* buffer_compare_ptx = R"(
 //
-// Generated by LLVM NVPTX Back-End
+// Generated by NVIDIA NVVM Compiler
+//
+// Compiler Build ID: CL-32415258
+// Cuda compilation tools, release 12.1, V12.1.66
+// Based on NVVM 7.0.1
 //
 
-.version 4.2
-.target sm_30
+.version 8.1
+.target sm_50
 .address_size 64
 
-// .globl__xla_fp16_comparison
+	// .globl	__xla_fp8_e4m3fn_comparison
 
+.visible .entry __xla_fp8_e4m3fn_comparison(
+	.param .u64 __xla_fp8_e4m3fn_comparison_param_0,
+	.param .u64 __xla_fp8_e4m3fn_comparison_param_1,
+	.param .f32 __xla_fp8_e4m3fn_comparison_param_2,
+	.param .u64 __xla_fp8_e4m3fn_comparison_param_3,
+	.param .u64 __xla_fp8_e4m3fn_comparison_param_4
+)
+{
+	.reg .pred 	%p<19>;
+	.reg .b16 	%rs<73>;
+	.reg .f32 	%f<30>;
+	.reg .b32 	%r<6>;
+	.reg .b64 	%rd<11>;
+
+
+	ld.param.u64 	%rd2, [__xla_fp8_e4m3fn_comparison_param_0];
+	ld.param.u64 	%rd3, [__xla_fp8_e4m3fn_comparison_param_1];
+	ld.param.f32 	%f12, [__xla_fp8_e4m3fn_comparison_param_2];
+	ld.param.u64 	%rd5, [__xla_fp8_e4m3fn_comparison_param_3];
+	ld.param.u64 	%rd4, [__xla_fp8_e4m3fn_comparison_param_4];
+	mov.u32 	%r1, %ntid.x;
+	mov.u32 	%r2, %ctaid.x;
+	mov.u32 	%r3, %tid.x;
+	mad.lo.s32 	%r4, %r2, %r1, %r3;
+	cvt.s64.s32 	%rd1, %r4;
+	setp.ge.u64 	%p1, %rd1, %rd5;
+	@%p1 bra 	$L__BB0_27;
+
+	cvta.to.global.u64 	%rd6, %rd2;
+	add.s64 	%rd7, %rd6, %rd1;
+	ld.global.u8 	%rs1, [%rd7];
+	shl.b16 	%rs36, %rs1, 8;
+	and.b16  	%rs2, %rs36, -32768;
+	and.b16  	%rs3, %rs36, 30720;
+	shr.u16 	%rs37, %rs3, 1;
+	add.s16 	%rs61, %rs37, 8192;
+	and.b16  	%rs62, %rs36, 1792;
+	and.b16  	%rs38, %rs1, 127;
+	setp.eq.s16 	%p2, %rs38, 127;
+	mov.u16 	%rs72, 32767;
+	mov.u16 	%rs65, %rs72;
+	@%p2 bra 	$L__BB0_10;
+
+	setp.eq.s16 	%p3, %rs3, 0;
+	@%p3 bra 	$L__BB0_4;
+
+	shr.u16 	%rs39, %rs62, 1;
+	or.b16  	%rs40, %rs39, %rs2;
+	or.b16  	%rs65, %rs40, %rs61;
+	bra.uni 	$L__BB0_10;
+
+$L__BB0_4:
+	setp.eq.s16 	%p4, %rs62, 0;
+	mov.u16 	%rs63, 0;
+	mov.u16 	%rs64, %rs63;
+	@%p4 bra 	$L__BB0_9;
+
+	and.b16  	%rs43, %rs1, 4;
+	setp.ne.s16 	%p5, %rs43, 0;
+	@%p5 bra 	$L__BB0_8;
+
+	mov.u16 	%rs59, %rs62;
+
+$L__BB0_7:
+	shl.b16 	%rs62, %rs59, 1;
+	add.s16 	%rs61, %rs61, -1024;
+	and.b16  	%rs44, %rs59, 512;
+	setp.eq.s16 	%p6, %rs44, 0;
+	mov.u16 	%rs59, %rs62;
+	@%p6 bra 	$L__BB0_7;
+
+$L__BB0_8:
+	and.b16  	%rs64, %rs62, 1022;
+	mov.u16 	%rs63, %rs61;
+
+$L__BB0_9:
+	or.b16  	%rs45, %rs63, %rs2;
+	or.b16  	%rs65, %rs45, %rs64;
+
+$L__BB0_10:
+	// begin inline asm
+	{  cvt.f32.f16 %f27, %rs65;}
+
+	// end inline asm
+	cvta.to.global.u64 	%rd8, %rd3;
+	add.s64 	%rd9, %rd8, %rd1;
+	ld.global.u8 	%rs18, [%rd9];
+	shl.b16 	%rs48, %rs18, 8;
+	and.b16  	%rs19, %rs48, -32768;
+	and.b16  	%rs20, %rs48, 30720;
+	shr.u16 	%rs49, %rs20, 1;
+	add.s16 	%rs68, %rs49, 8192;
+	and.b16  	%rs69, %rs48, 1792;
+	and.b16  	%rs50, %rs18, 127;
+	setp.eq.s16 	%p7, %rs50, 127;
+	@%p7 bra 	$L__BB0_19;
+
+	setp.eq.s16 	%p8, %rs20, 0;
+	@%p8 bra 	$L__BB0_13;
+
+	shr.u16 	%rs51, %rs69, 1;
+	or.b16  	%rs52, %rs51, %rs19;
+	or.b16  	%rs72, %rs52, %rs68;
+	bra.uni 	$L__BB0_19;
+
+$L__BB0_13:
+	setp.eq.s16 	%p9, %rs69, 0;
+	mov.u16 	%rs70, 0;
+	mov.u16 	%rs71, %rs70;
+	@%p9 bra 	$L__BB0_18;
+
+	and.b16  	%rs55, %rs18, 4;
+	setp.ne.s16 	%p10, %rs55, 0;
+	@%p10 bra 	$L__BB0_17;
+
+	mov.u16 	%rs66, %rs69;
+
+$L__BB0_16:
+	shl.b16 	%rs69, %rs66, 1;
+	add.s16 	%rs68, %rs68, -1024;
+	and.b16  	%rs56, %rs66, 512;
+	setp.eq.s16 	%p11, %rs56, 0;
+	mov.u16 	%rs66, %rs69;
+	@%p11 bra 	$L__BB0_16;
+
+$L__BB0_17:
+	and.b16  	%rs71, %rs69, 1022;
+	mov.u16 	%rs70, %rs68;
+
+$L__BB0_18:
+	or.b16  	%rs57, %rs70, %rs19;
+	or.b16  	%rs72, %rs57, %rs71;
+
+$L__BB0_19:
+	// begin inline asm
+	{  cvt.f32.f16 %f29, %rs72;}
+
+	// end inline asm
+	abs.f32 	%f15, %f27;
+	setp.gtu.f32 	%p12, %f15, 0f7F800000;
+	@%p12 bra 	$L__BB0_21;
+
+	mov.f32 	%f16, 0f477FE100;
+	min.f32 	%f17, %f27, %f16;
+	mov.f32 	%f18, 0fC77FE100;
+	max.f32 	%f27, %f18, %f17;
+
+$L__BB0_21:
+	abs.f32 	%f28, %f29;
+	setp.gtu.f32 	%p13, %f28, 0f7F800000;
+	@%p13 bra 	$L__BB0_23;
+
+	mov.f32 	%f19, 0f477FE100;
+	min.f32 	%f20, %f29, %f19;
+	mov.f32 	%f21, 0fC77FE100;
+	max.f32 	%f29, %f21, %f20;
+	abs.f32 	%f28, %f29;
+
+$L__BB0_23:
+	abs.f32 	%f10, %f27;
+	setp.gtu.f32 	%p14, %f10, 0f7F800000;
+	setp.gtu.f32 	%p15, %f28, 0f7F800000;
+	and.pred  	%p16, %p14, %p15;
+	@%p16 bra 	$L__BB0_27;
+
+	sub.f32 	%f22, %f27, %f29;
+	abs.f32 	%f23, %f22;
+	max.f32 	%f24, %f10, %f28;
+	add.f32 	%f25, %f24, 0f3F800000;
+	div.rn.f32 	%f11, %f23, %f25;
+	setp.gt.f32 	%p17, %f11, %f12;
+	@%p17 bra 	$L__BB0_26;
+
+	abs.f32 	%f26, %f11;
+	setp.le.f32 	%p18, %f26, 0f7F800000;
+	@%p18 bra 	$L__BB0_27;
+
+$L__BB0_26:
+	cvta.to.global.u64 	%rd10, %rd4;
+	atom.global.add.u32 	%r5, [%rd10], 1;
+
+$L__BB0_27:
+	ret;
+
+}
+	// .globl	__xla_fp8_e5m2_comparison
+.visible .entry __xla_fp8_e5m2_comparison(
+	.param .u64 __xla_fp8_e5m2_comparison_param_0,
+	.param .u64 __xla_fp8_e5m2_comparison_param_1,
+	.param .f32 __xla_fp8_e5m2_comparison_param_2,
+	.param .u64 __xla_fp8_e5m2_comparison_param_3,
+	.param .u64 __xla_fp8_e5m2_comparison_param_4
+)
+{
+	.reg .pred 	%p<11>;
+	.reg .b16 	%rs<9>;
+	.reg .f32 	%f<30>;
+	.reg .b32 	%r<6>;
+	.reg .b64 	%rd<11>;
+
+
+	ld.param.u64 	%rd2, [__xla_fp8_e5m2_comparison_param_0];
+	ld.param.u64 	%rd3, [__xla_fp8_e5m2_comparison_param_1];
+	ld.param.f32 	%f12, [__xla_fp8_e5m2_comparison_param_2];
+	ld.param.u64 	%rd5, [__xla_fp8_e5m2_comparison_param_3];
+	ld.param.u64 	%rd4, [__xla_fp8_e5m2_comparison_param_4];
+	mov.u32 	%r1, %ntid.x;
+	mov.u32 	%r2, %ctaid.x;
+	mov.u32 	%r3, %tid.x;
+	mad.lo.s32 	%r4, %r2, %r1, %r3;
+	cvt.s64.s32 	%rd1, %r4;
+	setp.ge.u64 	%p1, %rd1, %rd5;
+	@%p1 bra 	$L__BB1_9;
+
+	cvta.to.global.u64 	%rd6, %rd2;
+	add.s64 	%rd7, %rd6, %rd1;
+	ld.global.u8 	%rs3, [%rd7];
+	shl.b16 	%rs4, %rs3, 8;
+	and.b16  	%rs5, %rs3, 127;
+	setp.gt.u16 	%p2, %rs5, 124;
+	selp.b16 	%rs1, 32767, %rs4, %p2;
+	// begin inline asm
+	{  cvt.f32.f16 %f27, %rs1;}
+
+	// end inline asm
+	cvta.to.global.u64 	%rd8, %rd3;
+	add.s64 	%rd9, %rd8, %rd1;
+	ld.global.u8 	%rs6, [%rd9];
+	shl.b16 	%rs7, %rs6, 8;
+	and.b16  	%rs8, %rs6, 127;
+	setp.gt.u16 	%p3, %rs8, 124;
+	selp.b16 	%rs2, 32767, %rs7, %p3;
+	// begin inline asm
+	{  cvt.f32.f16 %f29, %rs2;}
+
+	// end inline asm
+	abs.f32 	%f15, %f27;
+	setp.gtu.f32 	%p4, %f15, 0f7F800000;
+	@%p4 bra 	$L__BB1_3;
+
+	mov.f32 	%f16, 0f477FE100;
+	min.f32 	%f17, %f27, %f16;
+	mov.f32 	%f18, 0fC77FE100;
+	max.f32 	%f27, %f18, %f17;
+
+$L__BB1_3:
+	abs.f32 	%f28, %f29;
+	setp.gtu.f32 	%p5, %f28, 0f7F800000;
+	@%p5 bra 	$L__BB1_5;
+
+	mov.f32 	%f19, 0f477FE100;
+	min.f32 	%f20, %f29, %f19;
+	mov.f32 	%f21, 0fC77FE100;
+	max.f32 	%f29, %f21, %f20;
+	abs.f32 	%f28, %f29;
+
+$L__BB1_5:
+	abs.f32 	%f10, %f27;
+	setp.gtu.f32 	%p6, %f10, 0f7F800000;
+	setp.gtu.f32 	%p7, %f28, 0f7F800000;
+	and.pred  	%p8, %p6, %p7;
+	@%p8 bra 	$L__BB1_9;
+
+	sub.f32 	%f22, %f27, %f29;
+	abs.f32 	%f23, %f22;
+	max.f32 	%f24, %f10, %f28;
+	add.f32 	%f25, %f24, 0f3F800000;
+	div.rn.f32 	%f11, %f23, %f25;
+	setp.gt.f32 	%p9, %f11, %f12;
+	@%p9 bra 	$L__BB1_8;
+
+	abs.f32 	%f26, %f11;
+	setp.le.f32 	%p10, %f26, 0f7F800000;
+	@%p10 bra 	$L__BB1_9;
+
+$L__BB1_8:
+	cvta.to.global.u64 	%rd10, %rd4;
+	atom.global.add.u32 	%r5, [%rd10], 1;
+
+$L__BB1_9:
+	ret;
+
+}
+	// .globl	__xla_fp16_comparison
 .visible .entry __xla_fp16_comparison(
-.param .u64 __xla_fp16_comparison_param_0,
-.param .u64 __xla_fp16_comparison_param_1,
-.param .f32 __xla_fp16_comparison_param_2,
-.param .u64 __xla_fp16_comparison_param_3,
-.param .u64 __xla_fp16_comparison_param_4
+	.param .u64 __xla_fp16_comparison_param_0,
+	.param .u64 __xla_fp16_comparison_param_1,
+	.param .f32 __xla_fp16_comparison_param_2,
+	.param .u64 __xla_fp16_comparison_param_3,
+	.param .u64 __xla_fp16_comparison_param_4
 )
 {
-.reg .pred %p<10>;
-.reg .b16 %rs<3>;
-.reg .f32 %f<20>;
-.reg .b32 %r<6>;
-.reg .b64 %rd<12>;
+	.reg .pred 	%p<9>;
+	.reg .b16 	%rs<3>;
+	.reg .f32 	%f<30>;
+	.reg .b32 	%r<6>;
+	.reg .b64 	%rd<12>;
 
-ld.param.u64 %rd8, [__xla_fp16_comparison_param_3];
-mov.u32 %r1, %tid.x;
-mov.u32 %r2, %ctaid.x;
-mov.u32 %r3, %ntid.x;
-mad.lo.s32 %r4, %r3, %r2, %r1;
-cvt.s64.s32 %rd4, %r4;
-setp.ge.u64 %p1, %rd4, %rd8;
-@%p1 bra LBB0_4;
-ld.param.u64 %rd5, [__xla_fp16_comparison_param_0];
-ld.param.u64 %rd7, [__xla_fp16_comparison_param_1];
-cvta.to.global.u64 %rd2, %rd7;
-cvta.to.global.u64 %rd3, %rd5;
-shl.b64 %rd9, %rd4, 1;
-add.s64 %rd10, %rd3, %rd9;
-ld.global.u16 %rs1, [%rd10];
-// begin inline asm
-{  cvt.f32.f16 %f6, %rs1;}
 
-// end inline asm
-add.s64 %rd11, %rd2, %rd9;
-ld.global.u16 %rs2, [%rd11];
-// begin inline asm
-{  cvt.f32.f16 %f7, %rs2;}
+	ld.param.u64 	%rd2, [__xla_fp16_comparison_param_0];
+	ld.param.u64 	%rd3, [__xla_fp16_comparison_param_1];
+	ld.param.f32 	%f12, [__xla_fp16_comparison_param_2];
+	ld.param.u64 	%rd5, [__xla_fp16_comparison_param_3];
+	ld.param.u64 	%rd4, [__xla_fp16_comparison_param_4];
+	mov.u32 	%r1, %ntid.x;
+	mov.u32 	%r2, %ctaid.x;
+	mov.u32 	%r3, %tid.x;
+	mad.lo.s32 	%r4, %r2, %r1, %r3;
+	cvt.s64.s32 	%rd1, %r4;
+	setp.ge.u64 	%p1, %rd1, %rd5;
+	@%p1 bra 	$L__BB2_9;
 
-// end inline asm
-abs.f32 %f8, %f6;
-setp.gtu.f32 %p2, %f8, 0f7F800000;
-min.f32 %f9, %f6, 0f477FE100;
-max.f32 %f10, %f9, 0fC77FE100;
-selp.f32 %f1, %f6, %f10, %p2;
-abs.f32 %f11, %f7;
-setp.gtu.f32 %p3, %f11, 0f7F800000;
-min.f32 %f12, %f7, 0f477FE100;
-max.f32 %f13, %f12, 0fC77FE100;
-selp.f32 %f2, %f7, %f13, %p3;
-abs.f32 %f3, %f1;
-setp.gtu.f32 %p4, %f3, 0f7F800000;
-abs.f32 %f4, %f2;
-setp.gtu.f32 %p5, %f4, 0f7F800000;
-and.pred  %p6, %p4, %p5;
-@%p6 bra LBB0_4;
-ld.param.f32 %f5, [__xla_fp16_comparison_param_2];
-sub.f32 %f14, %f1, %f2;
-abs.f32 %f15, %f14;
-max.f32 %f16, %f3, %f4;
-add.f32 %f17, %f16, 0f3F800000;
-div.rn.f32 %f18, %f15, %f17;
-setp.gt.f32 %p7, %f18, %f5;
-abs.f32 %f19, %f18;
-setp.gtu.f32 %p8, %f19, 0f7F800000;
-or.pred  %p9, %p7, %p8;
-@!%p9 bra LBB0_4;
-bra.uni LBB0_3;
-LBB0_3:
-ld.param.u64 %rd6, [__xla_fp16_comparison_param_4];
-cvta.to.global.u64 %rd1, %rd6;
-atom.global.add.u32 %r5, [%rd1], 1;
-LBB0_4:
-ret;
+	cvta.to.global.u64 	%rd6, %rd2;
+	shl.b64 	%rd7, %rd1, 1;
+	add.s64 	%rd8, %rd6, %rd7;
+	ld.global.u16 	%rs1, [%rd8];
+	// begin inline asm
+	{  cvt.f32.f16 %f27, %rs1;}
+
+	// end inline asm
+	cvta.to.global.u64 	%rd9, %rd3;
+	add.s64 	%rd10, %rd9, %rd7;
+	ld.global.u16 	%rs2, [%rd10];
+	// begin inline asm
+	{  cvt.f32.f16 %f29, %rs2;}
+
+	// end inline asm
+	abs.f32 	%f15, %f27;
+	setp.gtu.f32 	%p2, %f15, 0f7F800000;
+	@%p2 bra 	$L__BB2_3;
+
+	mov.f32 	%f16, 0f477FE100;
+	min.f32 	%f17, %f27, %f16;
+	mov.f32 	%f18, 0fC77FE100;
+	max.f32 	%f27, %f18, %f17;
+
+$L__BB2_3:
+	abs.f32 	%f28, %f29;
+	setp.gtu.f32 	%p3, %f28, 0f7F800000;
+	@%p3 bra 	$L__BB2_5;
+
+	mov.f32 	%f19, 0f477FE100;
+	min.f32 	%f20, %f29, %f19;
+	mov.f32 	%f21, 0fC77FE100;
+	max.f32 	%f29, %f21, %f20;
+	abs.f32 	%f28, %f29;
+
+$L__BB2_5:
+	abs.f32 	%f10, %f27;
+	setp.gtu.f32 	%p4, %f10, 0f7F800000;
+	setp.gtu.f32 	%p5, %f28, 0f7F800000;
+	and.pred  	%p6, %p4, %p5;
+	@%p6 bra 	$L__BB2_9;
+
+	sub.f32 	%f22, %f27, %f29;
+	abs.f32 	%f23, %f22;
+	max.f32 	%f24, %f10, %f28;
+	add.f32 	%f25, %f24, 0f3F800000;
+	div.rn.f32 	%f11, %f23, %f25;
+	setp.gt.f32 	%p7, %f11, %f12;
+	@%p7 bra 	$L__BB2_8;
+
+	abs.f32 	%f26, %f11;
+	setp.le.f32 	%p8, %f26, 0f7F800000;
+	@%p8 bra 	$L__BB2_9;
+
+$L__BB2_8:
+	cvta.to.global.u64 	%rd11, %rd4;
+	atom.global.add.u32 	%r5, [%rd11], 1;
+
+$L__BB2_9:
+	ret;
 
 }
-// .globl__xla_fp32_comparison
+	// .globl	__xla_fp32_comparison
 .visible .entry __xla_fp32_comparison(
-.param .u64 __xla_fp32_comparison_param_0,
-.param .u64 __xla_fp32_comparison_param_1,
-.param .f32 __xla_fp32_comparison_param_2,
-.param .u64 __xla_fp32_comparison_param_3,
-.param .u64 __xla_fp32_comparison_param_4
+	.param .u64 __xla_fp32_comparison_param_0,
+	.param .u64 __xla_fp32_comparison_param_1,
+	.param .f32 __xla_fp32_comparison_param_2,
+	.param .u64 __xla_fp32_comparison_param_3,
+	.param .u64 __xla_fp32_comparison_param_4
 )
 {
-.reg .pred %p<12>;
-.reg .f32 %f<12>;
-.reg .b32 %r<9>;
-.reg .b64 %rd<12>;
+	.reg .pred 	%p<10>;
+	.reg .b16 	%rs<3>;
+	.reg .f32 	%f<18>;
+	.reg .b32 	%r<10>;
+	.reg .b64 	%rd<12>;
 
-ld.param.u64 %rd8, [__xla_fp32_comparison_param_3];
-mov.u32 %r1, %tid.x;
-mov.u32 %r2, %ctaid.x;
-mov.u32 %r3, %ntid.x;
-mad.lo.s32 %r4, %r3, %r2, %r1;
-cvt.s64.s32 %rd4, %r4;
-setp.ge.u64 %p1, %rd4, %rd8;
-@%p1 bra LBB1_6;
-ld.param.u64 %rd5, [__xla_fp32_comparison_param_0];
-ld.param.u64 %rd7, [__xla_fp32_comparison_param_1];
-cvta.to.global.u64 %rd2, %rd7;
-cvta.to.global.u64 %rd3, %rd5;
-shl.b64 %rd9, %rd4, 2;
-add.s64 %rd10, %rd3, %rd9;
-ld.global.f32 %f1, [%rd10];
-add.s64 %rd11, %rd2, %rd9;
-ld.global.f32 %f2, [%rd11];
-abs.f32 %f3, %f1;
-setp.gtu.f32 %p2, %f3, 0f7F800000;
-abs.f32 %f4, %f2;
-setp.gtu.f32 %p3, %f4, 0f7F800000;
-and.pred  %p4, %p2, %p3;
-@%p4 bra LBB1_6;
-setp.eq.f32 %p5, %f3, 0f7F800000;
-setp.eq.f32 %p6, %f4, 0f7F800000;
-and.pred  %p7, %p5, %p6;
-@!%p7 bra LBB1_4;
-bra.uni LBB1_3;
-LBB1_3:
-mov.b32 %r5, %f1;
-mov.b32 %r6, %f2;
-xor.b32  %r7, %r6, %r5;
-setp.gt.s32 %p8, %r7, -1;
-@%p8 bra LBB1_6;
-LBB1_4:
-ld.param.f32 %f5, [__xla_fp32_comparison_param_2];
-sub.f32 %f6, %f1, %f2;
-abs.f32 %f7, %f6;
-max.f32 %f8, %f3, %f4;
-add.f32 %f9, %f8, 0f3F800000;
-div.rn.f32 %f10, %f7, %f9;
-setp.gt.f32 %p9, %f10, %f5;
-abs.f32 %f11, %f10;
-setp.gtu.f32 %p10, %f11, 0f7F800000;
-or.pred  %p11, %p9, %p10;
-@!%p11 bra LBB1_6;
-bra.uni LBB1_5;
-LBB1_5:
-ld.param.u64 %rd6, [__xla_fp32_comparison_param_4];
-cvta.to.global.u64 %rd1, %rd6;
-atom.global.add.u32 %r8, [%rd1], 1;
-LBB1_6:
-ret;
+
+	ld.param.u64 	%rd2, [__xla_fp32_comparison_param_0];
+	ld.param.u64 	%rd3, [__xla_fp32_comparison_param_1];
+	ld.param.f32 	%f9, [__xla_fp32_comparison_param_2];
+	ld.param.u64 	%rd5, [__xla_fp32_comparison_param_3];
+	ld.param.u64 	%rd4, [__xla_fp32_comparison_param_4];
+	mov.u32 	%r1, %ntid.x;
+	mov.u32 	%r2, %ctaid.x;
+	mov.u32 	%r3, %tid.x;
+	mad.lo.s32 	%r4, %r2, %r1, %r3;
+	cvt.s64.s32 	%rd1, %r4;
+	setp.ge.u64 	%p1, %rd1, %rd5;
+	@%p1 bra 	$L__BB3_9;
+
+	cvta.to.global.u64 	%rd6, %rd2;
+	shl.b64 	%rd7, %rd1, 2;
+	add.s64 	%rd8, %rd6, %rd7;
+	cvta.to.global.u64 	%rd9, %rd3;
+	add.s64 	%rd10, %rd9, %rd7;
+	ld.global.f32 	%f1, [%rd10];
+	ld.global.f32 	%f2, [%rd8];
+	abs.f32 	%f3, %f2;
+	abs.f32 	%f17, %f1;
+	setp.gtu.f32 	%p2, %f3, 0f7F800000;
+	@%p2 bra 	$L__BB3_3;
+	bra.uni 	$L__BB3_4;
+
+$L__BB3_3:
+	setp.gtu.f32 	%p3, %f17, 0f7F800000;
+	@%p3 bra 	$L__BB3_9;
+
+$L__BB3_4:
+	setp.neu.f32 	%p4, %f17, 0f7F800000;
+	setp.neu.f32 	%p5, %f3, 0f7F800000;
+	or.pred  	%p6, %p5, %p4;
+	@%p6 bra 	$L__BB3_6;
+
+	mov.b32 	%r5, %f2;
+	shr.u32 	%r6, %r5, 31;
+	cvt.u16.u32 	%rs1, %r6;
+	mov.b32 	%r7, %f1;
+	shr.u32 	%r8, %r7, 31;
+	cvt.u16.u32 	%rs2, %r8;
+	setp.eq.s16 	%p7, %rs1, %rs2;
+	mov.f32 	%f17, 0f7F800000;
+	@%p7 bra 	$L__BB3_9;
+
+$L__BB3_6:
+	sub.f32 	%f11, %f2, %f1;
+	abs.f32 	%f12, %f11;
+	max.f32 	%f13, %f3, %f17;
+	add.f32 	%f14, %f13, 0f3F800000;
+	div.rn.f32 	%f8, %f12, %f14;
+	setp.gt.f32 	%p8, %f8, %f9;
+	@%p8 bra 	$L__BB3_8;
+
+	abs.f32 	%f15, %f8;
+	setp.le.f32 	%p9, %f15, 0f7F800000;
+	@%p9 bra 	$L__BB3_9;
+
+$L__BB3_8:
+	cvta.to.global.u64 	%rd11, %rd4;
+	atom.global.add.u32 	%r9, [%rd11], 1;
+
+$L__BB3_9:
+	ret;
 
 }
-// .globl__xla_fp64_comparison
+	// .globl	__xla_fp64_comparison
 .visible .entry __xla_fp64_comparison(
-.param .u64 __xla_fp64_comparison_param_0,
-.param .u64 __xla_fp64_comparison_param_1,
-.param .f32 __xla_fp64_comparison_param_2,
-.param .u64 __xla_fp64_comparison_param_3,
-.param .u64 __xla_fp64_comparison_param_4
+	.param .u64 __xla_fp64_comparison_param_0,
+	.param .u64 __xla_fp64_comparison_param_1,
+	.param .f32 __xla_fp64_comparison_param_2,
+	.param .u64 __xla_fp64_comparison_param_3,
+	.param .u64 __xla_fp64_comparison_param_4
 )
 {
-.reg .pred %p<16>;
-.reg .f32 %f<2>;
-.reg .b32 %r<13>;
-.reg .f64 %fd<12>;
-.reg .b64 %rd<12>;
+	.reg .pred 	%p<13>;
+	.reg .b16 	%rs<3>;
+	.reg .f32 	%f<2>;
+	.reg .b32 	%r<14>;
+	.reg .f64 	%fd<13>;
+	.reg .b64 	%rd<12>;
 
-ld.param.u64 %rd8, [__xla_fp64_comparison_param_3];
-mov.u32 %r2, %tid.x;
-mov.u32 %r3, %ctaid.x;
-mov.u32 %r4, %ntid.x;
-mad.lo.s32 %r5, %r4, %r3, %r2;
-cvt.s64.s32 %rd4, %r5;
-setp.ge.u64 %p1, %rd4, %rd8;
-@%p1 bra LBB2_6;
-ld.param.u64 %rd5, [__xla_fp64_comparison_param_0];
-ld.param.u64 %rd7, [__xla_fp64_comparison_param_1];
-cvta.to.global.u64 %rd2, %rd7;
-cvta.to.global.u64 %rd3, %rd5;
-shl.b64 %rd9, %rd4, 3;
-add.s64 %rd10, %rd3, %rd9;
-ld.global.f64 %fd1, [%rd10];
-add.s64 %rd11, %rd2, %rd9;
-ld.global.f64 %fd2, [%rd11];
-abs.f64 %fd3, %fd1;
-setp.gtu.f64 %p2, %fd3, 0d7FF0000000000000;
-abs.f64 %fd4, %fd2;
-setp.gtu.f64 %p3, %fd4, 0d7FF0000000000000;
-and.pred  %p4, %p2, %p3;
-@%p4 bra LBB2_6;
-{
-.reg .b32 %temp; 
-mov.b64 {%r6, %temp}, %fd1;
-}
-{
-.reg .b32 %temp; 
-mov.b64 {%temp, %r1}, %fd1;
-}
-and.b32  %r7, %r1, 2147483647;
-setp.eq.s32 %p5, %r7, 2146435072;
-setp.eq.s32 %p6, %r6, 0;
-and.pred  %p7, %p5, %p6;
-@!%p7 bra LBB2_4;
-bra.uni LBB2_3;
-LBB2_3:
-{
-.reg .b32 %temp; 
-mov.b64 {%r8, %temp}, %fd2;
-}
-{
-.reg .b32 %temp; 
-mov.b64 {%temp, %r9}, %fd2;
-}
-and.b32  %r10, %r9, 2147483647;
-setp.eq.s32 %p8, %r10, 2146435072;
-setp.eq.s32 %p9, %r8, 0;
-and.pred  %p10, %p8, %p9;
-xor.b32  %r11, %r9, %r1;
-setp.gt.s32 %p11, %r11, -1;
-and.pred  %p12, %p10, %p11;
-@%p12 bra LBB2_6;
-LBB2_4:
-ld.param.f32 %f1, [__xla_fp64_comparison_param_2];
-sub.f64 %fd5, %fd1, %fd2;
-abs.f64 %fd6, %fd5;
-max.f64 %fd7, %fd3, %fd4;
-add.f64 %fd8, %fd7, 0d3FF0000000000000;
-div.rn.f64 %fd9, %fd6, %fd8;
-cvt.f64.f32 %fd10, %f1;
-setp.gt.f64 %p13, %fd9, %fd10;
-abs.f64 %fd11, %fd9;
-setp.gtu.f64 %p14, %fd11, 0d7FF0000000000000;
-or.pred  %p15, %p13, %p14;
-@!%p15 bra LBB2_6;
-bra.uni LBB2_5;
-LBB2_5:
-ld.param.u64 %rd6, [__xla_fp64_comparison_param_4];
-cvta.to.global.u64 %rd1, %rd6;
-atom.global.add.u32 %r12, [%rd1], 1;
-LBB2_6:
-ret;
+
+	ld.param.u64 	%rd2, [__xla_fp64_comparison_param_0];
+	ld.param.u64 	%rd3, [__xla_fp64_comparison_param_1];
+	ld.param.f32 	%f1, [__xla_fp64_comparison_param_2];
+	ld.param.u64 	%rd5, [__xla_fp64_comparison_param_3];
+	ld.param.u64 	%rd4, [__xla_fp64_comparison_param_4];
+	mov.u32 	%r3, %ntid.x;
+	mov.u32 	%r4, %ctaid.x;
+	mov.u32 	%r5, %tid.x;
+	mad.lo.s32 	%r6, %r4, %r3, %r5;
+	cvt.s64.s32 	%rd1, %r6;
+	setp.ge.u64 	%p1, %rd1, %rd5;
+	@%p1 bra 	$L__BB4_9;
+
+	cvta.to.global.u64 	%rd6, %rd2;
+	shl.b64 	%rd7, %rd1, 3;
+	add.s64 	%rd8, %rd6, %rd7;
+	cvta.to.global.u64 	%rd9, %rd3;
+	add.s64 	%rd10, %rd9, %rd7;
+	ld.global.f64 	%fd1, [%rd10];
+	ld.global.f64 	%fd2, [%rd8];
+	abs.f64 	%fd3, %fd2;
+	setp.le.f64 	%p2, %fd3, 0d7FF0000000000000;
+	@%p2 bra 	$L__BB4_3;
+
+	abs.f64 	%fd5, %fd1;
+	setp.gtu.f64 	%p3, %fd5, 0d7FF0000000000000;
+	@%p3 bra 	$L__BB4_9;
+
+$L__BB4_3:
+	{
+	.reg .b32 %temp; 
+	mov.b64 	{%r7, %temp}, %fd2;
+	}
+	{
+	.reg .b32 %temp; 
+	mov.b64 	{%temp, %r1}, %fd2;
+	}
+	and.b32  	%r8, %r1, 2147483647;
+	setp.ne.s32 	%p4, %r8, 2146435072;
+	setp.ne.s32 	%p5, %r7, 0;
+	or.pred  	%p6, %p4, %p5;
+	@%p6 bra 	$L__BB4_6;
+
+	{
+	.reg .b32 %temp; 
+	mov.b64 	{%r9, %temp}, %fd1;
+	}
+	{
+	.reg .b32 %temp; 
+	mov.b64 	{%temp, %r2}, %fd1;
+	}
+	and.b32  	%r10, %r2, 2147483647;
+	setp.ne.s32 	%p7, %r10, 2146435072;
+	setp.ne.s32 	%p8, %r9, 0;
+	or.pred  	%p9, %p7, %p8;
+	@%p9 bra 	$L__BB4_6;
+
+	shr.u32 	%r11, %r1, 31;
+	cvt.u16.u32 	%rs1, %r11;
+	shr.u32 	%r12, %r2, 31;
+	cvt.u16.u32 	%rs2, %r12;
+	setp.eq.s16 	%p10, %rs1, %rs2;
+	@%p10 bra 	$L__BB4_9;
+
+$L__BB4_6:
+	sub.f64 	%fd6, %fd2, %fd1;
+	abs.f64 	%fd7, %fd6;
+	abs.f64 	%fd8, %fd1;
+	max.f64 	%fd9, %fd3, %fd8;
+	add.f64 	%fd10, %fd9, 0d3FF0000000000000;
+	div.rn.f64 	%fd4, %fd7, %fd10;
+	cvt.f64.f32 	%fd11, %f1;
+	setp.gt.f64 	%p11, %fd4, %fd11;
+	@%p11 bra 	$L__BB4_8;
+
+	abs.f64 	%fd12, %fd4;
+	setp.le.f64 	%p12, %fd12, 0d7FF0000000000000;
+	@%p12 bra 	$L__BB4_9;
+
+$L__BB4_8:
+	cvta.to.global.u64 	%rd11, %rd4;
+	atom.global.add.u32 	%r13, [%rd11], 1;
+
+$L__BB4_9:
+	ret;
 
 }
-// .globl__xla_bf16_comparison
+	// .globl	__xla_bf16_comparison
 .visible .entry __xla_bf16_comparison(
-.param .u64 __xla_bf16_comparison_param_0,
-.param .u64 __xla_bf16_comparison_param_1,
-.param .f32 __xla_bf16_comparison_param_2,
-.param .u64 __xla_bf16_comparison_param_3,
-.param .u64 __xla_bf16_comparison_param_4
+	.param .u64 __xla_bf16_comparison_param_0,
+	.param .u64 __xla_bf16_comparison_param_1,
+	.param .f32 __xla_bf16_comparison_param_2,
+	.param .u64 __xla_bf16_comparison_param_3,
+	.param .u64 __xla_bf16_comparison_param_4
 )
 {
-.reg .pred %p<10>;
-.reg .b16 %rs<3>;
-.reg .f32 %f<20>;
-.reg .b32 %r<6>;
-.reg .b64 %rd<12>;
+	.reg .pred 	%p<9>;
+	.reg .b16 	%rs<3>;
+	.reg .f32 	%f<30>;
+	.reg .b32 	%r<6>;
+	.reg .b64 	%rd<12>;
 
-ld.param.u64 %rd8, [__xla_bf16_comparison_param_3];
-mov.u32 %r1, %tid.x;
-mov.u32 %r2, %ctaid.x;
-mov.u32 %r3, %ntid.x;
-mad.lo.s32 %r4, %r3, %r2, %r1;
-cvt.s64.s32 %rd4, %r4;
-setp.ge.u64 %p1, %rd4, %rd8;
-@%p1 bra LBB3_4;
-ld.param.u64 %rd5, [__xla_bf16_comparison_param_0];
-ld.param.u64 %rd7, [__xla_bf16_comparison_param_1];
-cvta.to.global.u64 %rd2, %rd7;
-cvta.to.global.u64 %rd3, %rd5;
-shl.b64 %rd9, %rd4, 1;
-add.s64 %rd10, %rd3, %rd9;
-ld.global.u16 %rs1, [%rd10];
-// begin inline asm
-{ mov.b32 %f6, {0,%rs1};}
 
-// end inline asm
-add.s64 %rd11, %rd2, %rd9;
-ld.global.u16 %rs2, [%rd11];
-// begin inline asm
-{ mov.b32 %f7, {0,%rs2};}
+	ld.param.u64 	%rd2, [__xla_bf16_comparison_param_0];
+	ld.param.u64 	%rd3, [__xla_bf16_comparison_param_1];
+	ld.param.f32 	%f12, [__xla_bf16_comparison_param_2];
+	ld.param.u64 	%rd5, [__xla_bf16_comparison_param_3];
+	ld.param.u64 	%rd4, [__xla_bf16_comparison_param_4];
+	mov.u32 	%r1, %ntid.x;
+	mov.u32 	%r2, %ctaid.x;
+	mov.u32 	%r3, %tid.x;
+	mad.lo.s32 	%r4, %r2, %r1, %r3;
+	cvt.s64.s32 	%rd1, %r4;
+	setp.ge.u64 	%p1, %rd1, %rd5;
+	@%p1 bra 	$L__BB5_9;
 
-// end inline asm
-abs.f32 %f8, %f6;
-setp.gtu.f32 %p2, %f8, 0f7F800000;
-min.f32 %f9, %f6, 0f477FE100;
-max.f32 %f10, %f9, 0fC77FE100;
-selp.f32 %f1, %f6, %f10, %p2;
-abs.f32 %f11, %f7;
-setp.gtu.f32 %p3, %f11, 0f7F800000;
-min.f32 %f12, %f7, 0f477FE100;
-max.f32 %f13, %f12, 0fC77FE100;
-selp.f32 %f2, %f7, %f13, %p3;
-abs.f32 %f3, %f1;
-setp.gtu.f32 %p4, %f3, 0f7F800000;
-abs.f32 %f4, %f2;
-setp.gtu.f32 %p5, %f4, 0f7F800000;
-and.pred  %p6, %p4, %p5;
-@%p6 bra LBB3_4;
-ld.param.f32 %f5, [__xla_bf16_comparison_param_2];
-sub.f32 %f14, %f1, %f2;
-abs.f32 %f15, %f14;
-max.f32 %f16, %f3, %f4;
-add.f32 %f17, %f16, 0f3F800000;
-div.rn.f32 %f18, %f15, %f17;
-setp.gt.f32 %p7, %f18, %f5;
-abs.f32 %f19, %f18;
-setp.gtu.f32 %p8, %f19, 0f7F800000;
-or.pred  %p9, %p7, %p8;
-@!%p9 bra LBB3_4;
-bra.uni LBB3_3;
-LBB3_3:
-ld.param.u64 %rd6, [__xla_bf16_comparison_param_4];
-cvta.to.global.u64 %rd1, %rd6;
-atom.global.add.u32 %r5, [%rd1], 1;
-LBB3_4:
-ret;
+	cvta.to.global.u64 	%rd6, %rd2;
+	shl.b64 	%rd7, %rd1, 1;
+	add.s64 	%rd8, %rd6, %rd7;
+	ld.global.u16 	%rs1, [%rd8];
+	// begin inline asm
+	{ mov.b32 %f27, {0,%rs1};}
+
+	// end inline asm
+	cvta.to.global.u64 	%rd9, %rd3;
+	add.s64 	%rd10, %rd9, %rd7;
+	ld.global.u16 	%rs2, [%rd10];
+	// begin inline asm
+	{ mov.b32 %f29, {0,%rs2};}
+
+	// end inline asm
+	abs.f32 	%f15, %f27;
+	setp.gtu.f32 	%p2, %f15, 0f7F800000;
+	@%p2 bra 	$L__BB5_3;
+
+	mov.f32 	%f16, 0f477FE100;
+	min.f32 	%f17, %f27, %f16;
+	mov.f32 	%f18, 0fC77FE100;
+	max.f32 	%f27, %f18, %f17;
+
+$L__BB5_3:
+	abs.f32 	%f28, %f29;
+	setp.gtu.f32 	%p3, %f28, 0f7F800000;
+	@%p3 bra 	$L__BB5_5;
+
+	mov.f32 	%f19, 0f477FE100;
+	min.f32 	%f20, %f29, %f19;
+	mov.f32 	%f21, 0fC77FE100;
+	max.f32 	%f29, %f21, %f20;
+	abs.f32 	%f28, %f29;
+
+$L__BB5_5:
+	abs.f32 	%f10, %f27;
+	setp.gtu.f32 	%p4, %f10, 0f7F800000;
+	setp.gtu.f32 	%p5, %f28, 0f7F800000;
+	and.pred  	%p6, %p4, %p5;
+	@%p6 bra 	$L__BB5_9;
+
+	sub.f32 	%f22, %f27, %f29;
+	abs.f32 	%f23, %f22;
+	max.f32 	%f24, %f10, %f28;
+	add.f32 	%f25, %f24, 0f3F800000;
+	div.rn.f32 	%f11, %f23, %f25;
+	setp.gt.f32 	%p7, %f11, %f12;
+	@%p7 bra 	$L__BB5_8;
+
+	abs.f32 	%f26, %f11;
+	setp.le.f32 	%p8, %f26, 0f7F800000;
+	@%p8 bra 	$L__BB5_9;
+
+$L__BB5_8:
+	cvta.to.global.u64 	%rd11, %rd4;
+	atom.global.add.u32 	%r5, [%rd11], 1;
+
+$L__BB5_9:
+	ret;
 
 }
-// .globl__xla_int8_comparison
+	// .globl	__xla_int8_comparison
 .visible .entry __xla_int8_comparison(
-.param .u64 __xla_int8_comparison_param_0,
-.param .u64 __xla_int8_comparison_param_1,
-.param .f32 __xla_int8_comparison_param_2,
-.param .u64 __xla_int8_comparison_param_3,
-.param .u64 __xla_int8_comparison_param_4
+	.param .u64 __xla_int8_comparison_param_0,
+	.param .u64 __xla_int8_comparison_param_1,
+	.param .f32 __xla_int8_comparison_param_2,
+	.param .u64 __xla_int8_comparison_param_3,
+	.param .u64 __xla_int8_comparison_param_4
 )
 {
-  .reg .pred %p<5>;
-  .reg .f32 %f<12>;
-  .reg .b32 %r<8>;
-  .reg .b64 %rd<11>;
+	.reg .pred 	%p<4>;
+	.reg .b16 	%rs<3>;
+	.reg .f32 	%f<12>;
+	.reg .b32 	%r<6>;
+	.reg .b64 	%rd<11>;
 
-  ld.param.u64 %rd8, [__xla_int8_comparison_param_3];
-  mov.u32 %r1, %tid.x;
-  mov.u32 %r2, %ctaid.x;
-  mov.u32 %r3, %ntid.x;
-  mad.lo.s32 %r4, %r3, %r2, %r1;
-  cvt.s64.s32 %rd4, %r4;
-  setp.ge.u64 %p1, %rd4, %rd8;
-  @%p1 bra LBB7_3;
-  ld.param.f32 %f1, [__xla_int8_comparison_param_2];
-  ld.param.u64 %rd5, [__xla_int8_comparison_param_0];
-  ld.param.u64 %rd7, [__xla_int8_comparison_param_1];
-  cvta.to.global.u64 %rd2, %rd7;
-  cvta.to.global.u64 %rd3, %rd5;
-  add.s64 %rd9, %rd3, %rd4;
-  ld.global.s8 %r5, [%rd9];
-  add.s64 %rd10, %rd2, %rd4;
-  ld.global.s8 %r6, [%rd10];
-  cvt.rn.f32.s32 %f2, %r5;
-  cvt.rn.f32.s32 %f3, %r6;
-  sub.f32 %f4, %f2, %f3;
-  abs.f32 %f5, %f4;
-  abs.f32 %f6, %f2;
-  abs.f32 %f7, %f3;
-  max.f32 %f8, %f6, %f7;
-  add.f32 %f9, %f8, 0f3F800000;
-  div.rn.f32 %f10, %f5, %f9;
-  setp.leu.f32 %p2, %f10, %f1;
-  abs.f32 %f11, %f10;
-  setp.le.f32 %p3, %f11, 0f7F800000;
-  and.pred %p4, %p2, %p3;
-  @%p4 bra LBB7_3;
-  ld.param.u64 %rd6, [__xla_int8_comparison_param_4];
-  cvta.to.global.u64 %rd1, %rd6;
-  atom.global.add.u32 %r7, [%rd1], 1;
-LBB7_3:
-  ret;
+
+	ld.param.u64 	%rd2, [__xla_int8_comparison_param_0];
+	ld.param.u64 	%rd3, [__xla_int8_comparison_param_1];
+	ld.param.f32 	%f2, [__xla_int8_comparison_param_2];
+	ld.param.u64 	%rd5, [__xla_int8_comparison_param_3];
+	ld.param.u64 	%rd4, [__xla_int8_comparison_param_4];
+	mov.u32 	%r1, %ntid.x;
+	mov.u32 	%r2, %ctaid.x;
+	mov.u32 	%r3, %tid.x;
+	mad.lo.s32 	%r4, %r2, %r1, %r3;
+	cvt.s64.s32 	%rd1, %r4;
+	setp.ge.u64 	%p1, %rd1, %rd5;
+	@%p1 bra 	$L__BB6_4;
+
+	cvta.to.global.u64 	%rd6, %rd2;
+	add.s64 	%rd7, %rd6, %rd1;
+	ld.global.s8 	%rs1, [%rd7];
+	cvt.rn.f32.s16 	%f3, %rs1;
+	cvta.to.global.u64 	%rd8, %rd3;
+	add.s64 	%rd9, %rd8, %rd1;
+	ld.global.s8 	%rs2, [%rd9];
+	cvt.rn.f32.s16 	%f4, %rs2;
+	sub.f32 	%f5, %f3, %f4;
+	abs.f32 	%f6, %f5;
+	abs.f32 	%f7, %f3;
+	abs.f32 	%f8, %f4;
+	max.f32 	%f9, %f7, %f8;
+	add.f32 	%f10, %f9, 0f3F800000;
+	div.rn.f32 	%f1, %f6, %f10;
+	setp.gt.f32 	%p2, %f1, %f2;
+	@%p2 bra 	$L__BB6_3;
+
+	abs.f32 	%f11, %f1;
+	setp.le.f32 	%p3, %f11, 0f7F800000;
+	@%p3 bra 	$L__BB6_4;
+
+$L__BB6_3:
+	cvta.to.global.u64 	%rd10, %rd4;
+	atom.global.add.u32 	%r5, [%rd10], 1;
+
+$L__BB6_4:
+	ret;
+
 }
-
-// .globl__xla_int32_comparison
+	// .globl	__xla_int32_comparison
 .visible .entry __xla_int32_comparison(
-.param .u64 __xla_int32_comparison_param_0,
-.param .u64 __xla_int32_comparison_param_1,
-.param .f32 __xla_int32_comparison_param_2,
-.param .u64 __xla_int32_comparison_param_3,
-.param .u64 __xla_int32_comparison_param_4
+	.param .u64 __xla_int32_comparison_param_0,
+	.param .u64 __xla_int32_comparison_param_1,
+	.param .f32 __xla_int32_comparison_param_2,
+	.param .u64 __xla_int32_comparison_param_3,
+	.param .u64 __xla_int32_comparison_param_4
 )
 {
-.reg .pred %p<5>;
-.reg .f32 %f<12>;
-.reg .b32 %r<8>;
-.reg .b64 %rd<12>;
+	.reg .pred 	%p<4>;
+	.reg .f32 	%f<12>;
+	.reg .b32 	%r<8>;
+	.reg .b64 	%rd<12>;
 
-ld.param.u64 %rd8, [__xla_int32_comparison_param_3];
-mov.u32 %r1, %tid.x;
-mov.u32 %r2, %ctaid.x;
-mov.u32 %r3, %ntid.x;
-mad.lo.s32 %r4, %r3, %r2, %r1;
-cvt.s64.s32 %rd4, %r4;
-setp.ge.u64 %p1, %rd4, %rd8;
-@%p1 bra LBB5_3;
-ld.param.f32 %f1, [__xla_int32_comparison_param_2];
-ld.param.u64 %rd5, [__xla_int32_comparison_param_0];
-ld.param.u64 %rd7, [__xla_int32_comparison_param_1];
-cvta.to.global.u64 %rd2, %rd7;
-cvta.to.global.u64 %rd3, %rd5;
-shl.b64 %rd9, %rd4, 2;
-add.s64 %rd10, %rd3, %rd9;
-ld.global.u32 %r5, [%rd10];
-cvt.rn.f32.s32 %f2, %r5;
-add.s64 %rd11, %rd2, %rd9;
-ld.global.u32 %r6, [%rd11];
-cvt.rn.f32.s32 %f3, %r6;
-sub.f32 %f4, %f2, %f3;
-abs.f32 %f5, %f4;
-abs.f32 %f6, %f2;
-abs.f32 %f7, %f3;
-max.f32 %f8, %f6, %f7;
-add.f32 %f9, %f8, 0f3F800000;
-div.rn.f32 %f10, %f5, %f9;
-setp.gt.f32 %p2, %f10, %f1;
-abs.f32 %f11, %f10;
-setp.gtu.f32 %p3, %f11, 0f7F800000;
-or.pred  %p4, %p2, %p3;
-@!%p4 bra LBB5_3;
-bra.uni LBB5_2;
-LBB5_2:
-ld.param.u64 %rd6, [__xla_int32_comparison_param_4];
-cvta.to.global.u64 %rd1, %rd6;
-atom.global.add.u32 %r7, [%rd1], 1;
-LBB5_3:
-ret;
+
+	ld.param.u64 	%rd2, [__xla_int32_comparison_param_0];
+	ld.param.u64 	%rd3, [__xla_int32_comparison_param_1];
+	ld.param.f32 	%f2, [__xla_int32_comparison_param_2];
+	ld.param.u64 	%rd5, [__xla_int32_comparison_param_3];
+	ld.param.u64 	%rd4, [__xla_int32_comparison_param_4];
+	mov.u32 	%r1, %ntid.x;
+	mov.u32 	%r2, %ctaid.x;
+	mov.u32 	%r3, %tid.x;
+	mad.lo.s32 	%r4, %r2, %r1, %r3;
+	cvt.s64.s32 	%rd1, %r4;
+	setp.ge.u64 	%p1, %rd1, %rd5;
+	@%p1 bra 	$L__BB7_4;
+
+	cvta.to.global.u64 	%rd6, %rd2;
+	shl.b64 	%rd7, %rd1, 2;
+	add.s64 	%rd8, %rd6, %rd7;
+	ld.global.u32 	%r5, [%rd8];
+	cvt.rn.f32.s32 	%f3, %r5;
+	cvta.to.global.u64 	%rd9, %rd3;
+	add.s64 	%rd10, %rd9, %rd7;
+	ld.global.u32 	%r6, [%rd10];
+	cvt.rn.f32.s32 	%f4, %r6;
+	sub.f32 	%f5, %f3, %f4;
+	abs.f32 	%f6, %f5;
+	abs.f32 	%f7, %f3;
+	abs.f32 	%f8, %f4;
+	max.f32 	%f9, %f7, %f8;
+	add.f32 	%f10, %f9, 0f3F800000;
+	div.rn.f32 	%f1, %f6, %f10;
+	setp.gt.f32 	%p2, %f1, %f2;
+	@%p2 bra 	$L__BB7_3;
+
+	abs.f32 	%f11, %f1;
+	setp.le.f32 	%p3, %f11, 0f7F800000;
+	@%p3 bra 	$L__BB7_4;
+
+$L__BB7_3:
+	cvta.to.global.u64 	%rd11, %rd4;
+	atom.global.add.u32 	%r7, [%rd11], 1;
+
+$L__BB7_4:
+	ret;
 
 }
 )";
@@ -773,6 +1188,12 @@ StatusOr<bool> BufferComparator::CompareEqual(
     se::Stream* stream, se::DeviceMemoryBase current,
     se::DeviceMemoryBase expected) const {
   switch (shape_.element_type()) {
+    case xla::F8E4M3FN:
+      return CompareEqualParameterized<tsl::float8_e4m3fn, float>(
+          stream, lhs, rhs, shape_, config_, "__xla_fp8_e4m3fn_comparison");
+    case xla::F8E5M2:
+      return CompareEqualParameterized<tsl::float8_e5m2, float>(
+          stream, lhs, rhs, shape_, config_, "__xla_fp8_e5m2_comparison");
     case xla::F16:
       return CompareEqualParameterized<Eigen::half, float>(
           stream, current, expected, shape_, config_, "__xla_fp16_comparison");

--- a/tensorflow/compiler/xla/service/gpu/buffer_comparator_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/buffer_comparator_test.cc
@@ -166,22 +166,18 @@ TEST_F(BufferComparatorTest, TestInfs) {
   EXPECT_TRUE(
       CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {std::nanf("")}));
   EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {inf}));
-  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {65504}));
-  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({-inf}, {-65504}));
-  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {-65504}));
-  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({-inf}, {65504}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {-inf}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {448}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {-448}));
   EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {20}));
   EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {-20}));
-  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({-inf}, {20}));
-  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({-inf}, {-20}));
 
   EXPECT_FALSE(
       CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {std::nanf("")}));
   EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {inf}));
-  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {65504}));
-  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({-inf}, {-65504}));
-  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {-65504}));
-  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({-inf}, {65504}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {-inf}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {57344}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({-inf}, {-57344}));
   EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {20}));
   EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {-20}));
   EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({-inf}, {20}));

--- a/tensorflow/compiler/xla/service/gpu/buffer_comparator_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/buffer_comparator_test.cc
@@ -162,6 +162,30 @@ TEST_F(BufferComparatorTest, TestInfs) {
   EXPECT_FALSE(CompareEqualFloatBuffers<double>({inf}, {-20}));
   EXPECT_FALSE(CompareEqualFloatBuffers<double>({-inf}, {20}));
   EXPECT_FALSE(CompareEqualFloatBuffers<double>({-inf}, {-20}));
+
+  EXPECT_TRUE(
+      CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {std::nanf("")}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {inf}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {65504}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({-inf}, {-65504}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {-65504}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({-inf}, {65504}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {20}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({inf}, {-20}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({-inf}, {20}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({-inf}, {-20}));
+
+  EXPECT_FALSE(
+      CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {std::nanf("")}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {inf}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {65504}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({-inf}, {-65504}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {-65504}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({-inf}, {65504}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {20}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({inf}, {-20}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({-inf}, {20}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({-inf}, {-20}));
 }
 
 TEST_F(BufferComparatorTest, TestNumbers) {
@@ -189,6 +213,18 @@ TEST_F(BufferComparatorTest, TestNumbers) {
   EXPECT_TRUE(CompareEqualFloatBuffers<int8_t>({90}, {100}));
   EXPECT_TRUE(CompareEqualFloatBuffers<int8_t>({100}, {90}));
   EXPECT_FALSE(CompareEqualFloatBuffers<int8_t>({-128}, {127}));
+
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({20}, {20.1}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({0}, {1}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({0.9}, {1}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({9}, {10}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>({9}, {10}));
+
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({20}, {20.1}));
+  EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>({0}, {1}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({0.9}, {1}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({11}, {12}));
+  EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>({12}, {11}));
 }
 
 TEST_F(BufferComparatorTest, TestMultiple) {
@@ -254,6 +290,40 @@ TEST_F(BufferComparatorTest, TestMultiple) {
       lhs[i] = 3;
       rhs[i] = 5;
       EXPECT_FALSE(CompareEqualFloatBuffers<int8_t>(lhs, rhs))
+          << "should be the different at index " << i;
+      lhs[i] = 0;
+      rhs[i] = 0;
+    }
+  }
+
+  {
+    EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>(
+        {20, 30, 40, 50, 60}, {20.1, 30.1, 40.1, 50.1, 60.1}));
+    std::vector<float> lhs(200);
+    std::vector<float> rhs(200);
+    for (int i = 0; i < 200; i++) {
+      EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>(lhs, rhs))
+          << "should be the same at index " << i;
+      lhs[i] = 3;
+      rhs[i] = 5;
+      EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e4m3fn>(lhs, rhs))
+          << "should be the different at index " << i;
+      lhs[i] = 0;
+      rhs[i] = 0;
+    }
+  }
+
+  {
+    EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>(
+        {20, 30, 40, 50, 60}, {20.1, 30.1, 40.1, 50.1, 60.1}));
+    std::vector<float> lhs(200);
+    std::vector<float> rhs(200);
+    for (int i = 0; i < 200; i++) {
+      EXPECT_TRUE(CompareEqualFloatBuffers<tsl::float8_e5m2>(lhs, rhs))
+          << "should be the same at index " << i;
+      lhs[i] = 3;
+      rhs[i] = 5;
+      EXPECT_FALSE(CompareEqualFloatBuffers<tsl::float8_e5m2>(lhs, rhs))
           << "should be the different at index " << i;
       lhs[i] = 0;
       rhs[i] = 0;

--- a/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.cc
@@ -160,15 +160,10 @@ StatusOr<std::vector<GenericConvRunner>> GetAlgorithms(
       // This path is cuDNN-only, where the DeviceMemoryBase arguments and the
       // allocator are unused; so, they're all provided as nullptr.
       TF_RETURN_IF_ERROR(stream_exec->GetGraphConvolveRunners(
-          use_cudnn_frontend, kind, input_type, output_type, stream,
-          config.input_descriptor,
-          /* input_data = */ DeviceMemoryBase(nullptr),
-          config.filter_descriptor,
-          /* filter_data = */ DeviceMemoryBase(nullptr),
-          config.output_descriptor,
-          /* output_data = */ DeviceMemoryBase(nullptr), config.conv_desc,
-          use_fallback, nullptr, se::NumericOptions{deterministic_ops},
-          &runners, config.serialized_graph));
+          kind, input_type, output_type, stream, config.input_descriptor,
+          config.filter_descriptor, config.output_descriptor, config.conv_desc,
+          use_fallback, numeric_options, &runners,
+          config.serialized_graph));
       for (auto& runner : runners) {
         TF_ASSIGN_OR_RETURN(
             auto runner_cache,

--- a/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.cc
@@ -109,7 +109,7 @@ StatusOr<se::DeviceMemory<uint8_t>> ScratchAllocator::AllocateBytes(
   return se::DeviceMemory<uint8_t>(buffer_addr);
 }
 
-StatusOr<std::vector<MaybeFusedConvRunner>> GetAlgorithms(
+StatusOr<std::vector<GenericConvRunner>> GetAlgorithms(
     const GpuConvConfig& config, se::Stream* stream, bool use_cudnn_frontend,
     bool use_fallback, const se::NumericOptions& numeric_options) {
   TF_ASSIGN_OR_RETURN(se::dnn::ConvolutionKind kind,
@@ -122,8 +122,7 @@ StatusOr<std::vector<MaybeFusedConvRunner>> GetAlgorithms(
                       GetDNNDataTypeFromPrimitiveType(config.output_type));
 
   se::StreamExecutor* stream_exec = stream->parent();
-
-  std::vector<MaybeFusedConvRunner> result;
+  std::vector<GenericConvRunner> result;
 
   switch (kind) {
     default:
@@ -150,6 +149,30 @@ StatusOr<std::vector<MaybeFusedConvRunner>> GetAlgorithms(
         TF_ASSIGN_OR_RETURN(
             auto runner_cache,
             se::dnn::LazyOpRunner<se::dnn::FusedConvOp>::FromOpRunner(
+                std::move(runner)));
+        result.emplace_back(std::move(runner_cache));
+      }
+      break;
+    }
+
+    case se::dnn::ConvolutionKind::FORWARD_GRAPH: {
+      std::vector<std::unique_ptr<const se::dnn::GraphConvRunner>> runners;
+      // This path is cuDNN-only, where the DeviceMemoryBase arguments and the
+      // allocator are unused; so, they're all provided as nullptr.
+      TF_RETURN_IF_ERROR(stream_exec->GetGraphConvolveRunners(
+          use_cudnn_frontend, kind, input_type, output_type, stream,
+          config.input_descriptor,
+          /* input_data = */ DeviceMemoryBase(nullptr),
+          config.filter_descriptor,
+          /* filter_data = */ DeviceMemoryBase(nullptr),
+          config.output_descriptor,
+          /* output_data = */ DeviceMemoryBase(nullptr), config.conv_desc,
+          use_fallback, nullptr, se::NumericOptions{deterministic_ops},
+          &runners, config.serialized_graph));
+      for (auto& runner : runners) {
+        TF_ASSIGN_OR_RETURN(
+            auto runner_cache,
+            se::dnn::LazyOpRunner<se::dnn::GraphConvOp>::FromOpRunner(
                 std::move(runner)));
         result.emplace_back(std::move(runner_cache));
       }
@@ -446,7 +469,7 @@ GpuConvAlgorithmPicker::AutotuneRuntimeArguments::FromInstruction(
 // simply skips the engine/algorithm while recording a reason for skipping it.
 StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
     se::DeviceMemoryAllocator* allocator, se::Stream* stream,
-    MaybeFusedConvRunner* const runner,
+    GenericConvRunner* const runner,
     std::optional<ReferenceResult>* reference_result,
     absl::Span<const AlgorithmDesc> disabled_algos,
     std::optional<AutotuneCacheKey> instruction_info,
@@ -736,7 +759,7 @@ StatusOr<AutotuneResult> GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheCuda(
   std::optional<ReferenceResult> reference_result;
 
   TF_ASSIGN_OR_RETURN(
-      std::vector<MaybeFusedConvRunner> runners,
+      std::vector<GenericConvRunner> runners,
       GetAlgorithms(runtime_arguments.gpu_conv_config, stream,
                     cudnn_frontend_enabled,
                     /* use_fallback = */ false, numeric_options));
@@ -760,7 +783,7 @@ StatusOr<AutotuneResult> GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheCuda(
     }
 
     TF_ASSIGN_OR_RETURN(
-        std::vector<MaybeFusedConvRunner> fallback_runners,
+        std::vector<GenericConvRunner> fallback_runners,
         GetAlgorithms(runtime_arguments.gpu_conv_config, stream,
                       cudnn_frontend_enabled,
                       /* use_fallback = */ true, numeric_options));
@@ -940,7 +963,7 @@ StatusOr<AutotuneResult> GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
                           se::dnn::LazyOpRunner<se::dnn::ConvOp>::FromOpRunner(
                               std::move(runner)));
 
-      MaybeFusedConvRunner runner_cache(std::move(lazy_runner));
+      GenericConvRunner runner_cache(std::move(lazy_runner));
 
       // Use assignment instead of brace-list to make GCC 4.9 happy.
       RunConvOptions options;

--- a/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.h
+++ b/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.h
@@ -139,7 +139,7 @@ class GpuConvAlgorithmPicker : public HloModulePass {
 
   StatusOr<AutotuneResult> AutotuneOneConvRunner(
       se::DeviceMemoryAllocator* allocator, se::Stream* stream,
-      MaybeFusedConvRunner* runner,
+      GenericConvRunner* runner,
       std::optional<ReferenceResult>* reference_result,
       absl::Span<const stream_executor::dnn::AlgorithmDesc> disabled_algos,
       std::optional<AutotuneCacheKey> instruction_info,

--- a/tensorflow/compiler/xla/service/gpu/conv_layout_normalization.cc
+++ b/tensorflow/compiler/xla/service/gpu/conv_layout_normalization.cc
@@ -60,7 +60,8 @@ StatusOr<HloInstruction*> UpdateLayoutForCudnnConvolution(
       gpu::GetCudnnConvKind(Cast<HloCustomCallInstruction>(hlo)));
   switch (conv_kind) {
     case gpu::CudnnConvKind::kForward:
-    case gpu::CudnnConvKind::kForwardActivation: {
+    case gpu::CudnnConvKind::kForwardActivation:
+    case gpu::CudnnConvKind::kForwardGraph: {
       input_shape = lhs->shape();
       filter_shape = rhs->shape();
       output_shape = conv_output_shape;

--- a/tensorflow/compiler/xla/service/gpu/convolution_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/convolution_thunk.cc
@@ -41,13 +41,13 @@ ConvolutionThunk::ConvolutionThunk(
       scratch_buffer_(scratch_slice),
       config_(std::move(config)) {}
 
-MaybeFusedConvRunner& ConvolutionThunk::GetOrCreateRunner(
+GenericConvRunner& ConvolutionThunk::GetOrCreateRunner(
     const stream_executor::Stream* stream) {
   absl::MutexLock lock(&mu_);
   auto it = runner_cache_.find(stream);
   if (it == runner_cache_.end()) {
     it = runner_cache_
-             .insert({stream, std::make_unique<MaybeFusedConvRunner>(config_)})
+             .insert({stream, std::make_unique<GenericConvRunner>(config_)})
              .first;
   }
   return *it->second;

--- a/tensorflow/compiler/xla/service/gpu/convolution_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/convolution_thunk.h
@@ -57,14 +57,13 @@ class ConvolutionThunk : public Thunk {
   std::vector<BufferAllocation::Slice> operand_buffers_;
   BufferAllocation::Slice result_buffer_;
   BufferAllocation::Slice scratch_buffer_;
-  MaybeFusedConvRunner& GetOrCreateRunner(
-      const stream_executor::Stream* stream);
+  GenericConvRunner& GetOrCreateRunner(const stream_executor::Stream* stream);
 
   // Convolution config
   const GpuConvConfig config_;
   absl::Mutex mu_;
   absl::flat_hash_map<const stream_executor::Stream*,
-                      std::unique_ptr<MaybeFusedConvRunner>>
+                      std::unique_ptr<GenericConvRunner>>
       runner_cache_ ABSL_GUARDED_BY(mu_);
 };
 

--- a/tensorflow/compiler/xla/service/gpu/cublas_cudnn.cc
+++ b/tensorflow/compiler/xla/service/gpu/cublas_cudnn.cc
@@ -53,6 +53,8 @@ const absl::string_view kCudnnConvBackwardFilterCallTarget =
 const absl::string_view kCudnnConvBiasActivationForwardCallTarget =
     "__cudnn$convBiasActivationForward";
 const absl::string_view kCudnnConvForwardCallTarget = "__cudnn$convForward";
+const absl::string_view kCudnnConvForwardGraphCallTarget =
+    "__cudnn$convForwardGraph";
 const absl::string_view kCudnnConvReorderFilterCallTarget =
     "__cudnn$convReorderFilter";
 const absl::string_view kCudnnConvReorderFilterAndBiasCallTarget =
@@ -103,6 +105,7 @@ bool IsCustomCallToDnnConvolution(const HloInstruction& hlo) {
   }
   const auto& target = hlo.custom_call_target();
   return target == kCudnnConvForwardCallTarget ||
+         target == kCudnnConvForwardGraphCallTarget ||
          target == kCudnnConvBackwardInputCallTarget ||
          target == kCudnnConvBackwardFilterCallTarget ||
          target == kCudnnConvBiasActivationForwardCallTarget;
@@ -170,6 +173,9 @@ StatusOr<CudnnConvKind> GetCudnnConvKind(
   if (target == kCudnnConvForwardCallTarget) {
     return CudnnConvKind::kForward;
   }
+  if (target == kCudnnConvForwardGraphCallTarget) {
+    return CudnnConvKind::kForwardGraph;
+  }
   if (target == kCudnnConvBackwardInputCallTarget) {
     return CudnnConvKind::kBackwardInput;
   }
@@ -192,6 +198,8 @@ std::string CudnnConvKindToString(CudnnConvKind kind) {
       return "backward_input";
     case CudnnConvKind::kForwardActivation:
       return "forward with activation";
+    case CudnnConvKind::kForwardGraph:
+      return "forward with pointwise operations";
   }
 }
 

--- a/tensorflow/compiler/xla/service/gpu/cublas_cudnn.h
+++ b/tensorflow/compiler/xla/service/gpu/cublas_cudnn.h
@@ -44,6 +44,8 @@ enum class CudnnConvKind {
   kBackwardFilter,     // input  + output => filter
   kForwardActivation,  // activation(conv(input, filter) + broadcast(bias) +
                        // (optionally) side_input) => output
+  kForwardGraph,       // pointwise(...pointwise(conv(input, filter))...)
+                       // => output
 };
 
 enum class CudnnfMHAKind {
@@ -130,6 +132,7 @@ extern const absl::string_view kCudnnConvForwardCallTarget;
 extern const absl::string_view kCudnnConvBackwardInputCallTarget;
 extern const absl::string_view kCudnnConvBackwardFilterCallTarget;
 extern const absl::string_view kCudnnConvBiasActivationForwardCallTarget;
+extern const absl::string_view kCudnnConvForwardGraphCallTarget;
 
 // cuDNN specific convolution helper (emitted together with a int8x32
 // convolution, if reordering is required).

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter.cc
@@ -301,8 +301,12 @@ bool IsF8Type(const HloInstruction* instr) {
   return primitive_util::IsF8Type(instr->shape().element_type());
 }
 
-// Format of the serialized graph is
-// "conv[output type]->op name[output type]->op name[output type]->...".
+// The format of the serialized graph describing a linear sequence of ops fused
+// into the cuDNN convolution Custom Call is
+// "conv[output_type]->op_name[output_type]->op_name[output_type]->..." with the
+// convolution assumed to be the first op in the graph. Currently,
+// multiplication and division by a broadcast scalar, addition of a matrix bias
+// and the application of a ReLU activation are supported.
 class GraphString {
  public:
   GraphString() : size_(0) {}
@@ -331,7 +335,7 @@ class GraphString {
 
 // Recursively captures and serializes the graph of pointwise operations
 // operating on the convolution.
-bool CaptureConvGraphRecursive(HloInstruction* instr,
+void CaptureConvGraphRecursive(HloInstruction* instr,
                                std::vector<HloInstruction*>& operands,
                                GraphString& graph_string,
                                absl::flat_hash_set<int>& visited_instrs,
@@ -341,7 +345,7 @@ bool CaptureConvGraphRecursive(HloInstruction* instr,
   const int max_pattern_level = 1;
   // Avoid visiting the same instruction more than once.
   if (!visited_instrs.emplace(instr->unique_id()).second) {
-    return false;
+    return;
   }
   // When the function was called from outside or after a successful match, set
   // the final instruction to the current instruction.
@@ -349,77 +353,94 @@ bool CaptureConvGraphRecursive(HloInstruction* instr,
     final_instr = instr;
   }
 
-  HloInstruction *op, *operand;
-  for (HloInstruction* user : instr->users()) {
+  if (instr->user_count() == 1) {
+    HloInstruction *op, *operand, *user = instr->users()[0];
     if (pattern_level == 0) {
       // Add
       if (Match(user, m::AddAnyOrder(&op, m::Op(), m::Op(&operand)))) {
         graph_string.AppendOp("add", op->shape().element_type());
         operands.push_back(operand);
-        return CaptureConvGraphRecursive(user, operands, graph_string,
-                                         visited_instrs, final_instr, 0);
+        CaptureConvGraphRecursive(user, operands, graph_string, visited_instrs,
+                                  final_instr, 0);
+        return;
       }
       // Scale
       if (Match(user, m::MultiplyAnyOrder(&op, m::Op(),
-                                          m::Broadcast(m::Op(&operand))))) {
+                                          m::Broadcast(m::Op(&operand)))) &&
+          ShapeUtil::IsScalar(operand->shape())) {
         graph_string.AppendOp("scale", op->shape().element_type());
         operands.push_back(operand);
-        return CaptureConvGraphRecursive(user, operands, graph_string,
-                                         visited_instrs, final_instr, 0);
+        CaptureConvGraphRecursive(user, operands, graph_string, visited_instrs,
+                                  final_instr, 0);
+        return;
       }
       // Inverse Scale
-      if (Match(user, m::Divide(&op, m::Op(), m::Broadcast(m::Op(&operand))))) {
+      if (Match(user, m::Divide(&op, m::Op(), m::Broadcast(m::Op(&operand)))) &&
+          ShapeUtil::IsScalar(operand->shape())) {
         graph_string.AppendOp("invscale", op->shape().element_type());
         operands.push_back(operand);
-        return CaptureConvGraphRecursive(user, operands, graph_string,
-                                         visited_instrs, final_instr, 0);
+        CaptureConvGraphRecursive(user, operands, graph_string, visited_instrs,
+                                  final_instr, 0);
+        return;
       }
       // ReLU
       if (Match(user, m::MaximumAnyOrder(&op, m::Op(),
                                          m::Broadcast(m::ConstantScalar(0))))) {
         graph_string.AppendOp("relu", op->shape().element_type());
-        return CaptureConvGraphRecursive(user, operands, graph_string,
-                                         visited_instrs, final_instr, 0);
+        CaptureConvGraphRecursive(user, operands, graph_string, visited_instrs,
+                                  final_instr, 0);
+        return;
       }
     }
 
     if (pattern_level == 1) {
-      // Convert with clamp
+      // Convert with clamp to FP8 types
+      HloInstruction *clamp_lower, *clamp_upper;
       if (Match(user,
-                m::Convert(&op,
-                           m::Clamp(m::Broadcast(m::ConstantScalar()), m::Op(),
-                                    m::Broadcast(m::ConstantScalar()))))) {
-        graph_string.ChangeDataType(op->shape().element_type());
-        return CaptureConvGraphRecursive(user, operands, graph_string,
-                                         visited_instrs, final_instr, 0);
+                m::Convert(
+                    &op,
+                    m::Clamp(m::Broadcast(m::ConstantScalar(&clamp_lower)),
+                             m::Op(),
+                             m::Broadcast(m::ConstantScalar(&clamp_upper)))))) {
+        if ((op->shape().element_type() == F8E4M3FN &&
+             clamp_lower->literal().IsAllFloat(static_cast<float>(
+                 std::numeric_limits<tsl::float8_e4m3fn>::lowest())) &&
+             clamp_upper->literal().IsAllFloat(static_cast<float>(
+                 std::numeric_limits<tsl::float8_e4m3fn>::max()))) ||
+            (op->shape().element_type() == F8E5M2 &&
+             clamp_lower->literal().IsAllFloat(static_cast<float>(
+                 std::numeric_limits<tsl::float8_e5m2>::lowest())) &&
+             clamp_upper->literal().IsAllFloat(static_cast<float>(
+                 std::numeric_limits<tsl::float8_e5m2>::max())))) {
+          graph_string.ChangeDataType(op->shape().element_type());
+          CaptureConvGraphRecursive(user, operands, graph_string,
+                                    visited_instrs, final_instr, 0);
+          return;
+        }
       }
     }
 
     // If none of the matches was successful and the pattern level is below the
     // maximum level, attempt to match at higher level.
     if (pattern_level < max_pattern_level) {
-      return CaptureConvGraphRecursive(user, operands, graph_string,
-                                       visited_instrs, final_instr,
-                                       pattern_level + 1);
+      CaptureConvGraphRecursive(user, operands, graph_string, visited_instrs,
+                                final_instr, pattern_level + 1);
+      return;
     }
   }
 
-  // The first entry in the serialized graph is the convolution. The size is
-  // greater than one if at least one match was succesful.
-  if (graph_string.Size() > 1) {
-    return true;
-  } else {
-    return false;
-  }
+  return;
 }
 
-// Captures the graph of pointwise operations operating on the convolution.
-bool CaptureConvGraph(HloInstruction* instr,
-                      std::vector<HloInstruction*>& operands,
-                      GraphString& graph_string, HloInstruction*& final_instr,
-                      HloInstruction* x_scale, HloInstruction* w_scale,
-                      bool x_mult_scale, bool w_mult_scale) {
-  absl::flat_hash_set<int> visited_instrs;
+// Captures in a GraphString the subgraph of pointwise operations operating on
+// the convolution that will be fused into the cuDNN convolution Custom Call.
+std::tuple<std::vector<HloInstruction*>, GraphString, HloInstruction*>
+CaptureConvGraph(HloInstruction* instr, HloInstruction* x_scale,
+                 HloInstruction* w_scale, bool x_mult_scale,
+                 bool w_mult_scale) {
+  std::vector<HloInstruction*> operands;
+  GraphString graph_string;
+
   graph_string.AppendOp("conv", instr->shape().element_type());
 
   // Shift the scaling of the inputs to the output of the convolution.
@@ -442,8 +463,13 @@ bool CaptureConvGraph(HloInstruction* instr,
                             instr->shape().element_type());
     }
   }
-  return CaptureConvGraphRecursive(instr, operands, graph_string,
-                                   visited_instrs, final_instr);
+
+  absl::flat_hash_set<int> visited_instrs;
+  HloInstruction* final_instr;
+  CaptureConvGraphRecursive(instr, operands, graph_string, visited_instrs,
+                            final_instr);
+
+  return std::make_tuple(operands, graph_string, final_instr);
 }
 
 // Matches convolutions operating on FP8 inputs and filters and rewrites into a
@@ -451,12 +477,12 @@ bool CaptureConvGraph(HloInstruction* instr,
 // following steps are elided and rewritten into a ForwardGraph Custom Call:
 //
 // 1. Cast the filter and input from FP8 to a wider type such as FP16 or FP32.
-// 2. Unscale the filter and input by multiplying them by the corresponding
-// input scale.
+// 2. Unscale the filter and input by multiplying or dividing by scalars.
 // 3. Evaluate the convolution based on the scaled filter and input.
-// 4. Optionally add a matrix bias to the result and apply a ReLU activation.
-// 5. Scale the output by dividing the output by the output scale.
-// 6. Cast the output back to FP8.
+// 4. Apply a series of elementwise transformations, where a transformation can
+// be adding a matrix bias, applying a ReLU activation, or
+// multiplying or dividing by a broadcast scalar.
+// 5. Cast the output back to FP8.
 
 StatusOr<bool> F8GraphConv(HloComputation* comp, se::CudaComputeCapability cc) {
   bool changed = false;
@@ -467,11 +493,9 @@ StatusOr<bool> F8GraphConv(HloComputation* comp, se::CudaComputeCapability cc) {
     if (!cc.IsAtLeast(se::CudaComputeCapability::HOPPER)) {
       return false;
     }
-    HloInstruction *convolution, *gte, *input, *filter, *final_instr,
+    HloInstruction *convolution, *gte, *input, *filter,
         *x_scale = nullptr, *w_scale = nullptr, *x_scale_op = nullptr,
         *w_scale_op = nullptr;
-    std::vector<HloInstruction*> operands;
-    GraphString graph_string;
 
     // TODO(philipphack): Consider allowing ops between dequantization and
     // convolution.
@@ -498,32 +522,36 @@ StatusOr<bool> F8GraphConv(HloComputation* comp, se::CudaComputeCapability cc) {
                     m::Convert(m::Op(&filter).WithPredicate(IsF8Type)),
                     m::Broadcast(m::Op(&w_scale))))),
         0);
-    if (Match(instr, pattern) &&
-        CaptureConvGraph(
-            const_cast<HloInstruction*>(instr), operands, graph_string,
-            final_instr, x_scale, w_scale,
-            x_scale_op ? x_scale_op->opcode() == HloOpcode::kMultiply : false,
-            w_scale_op ? w_scale_op->opcode() == HloOpcode::kMultiply
-                       : false)) {
-      TF_ASSIGN_OR_RETURN(
-          auto config, convolution->backend_config<CudnnConvBackendConfig>());
-      config.set_serialized_graph(graph_string.Graph());
-      operands.insert(operands.begin(), input);
-      operands.insert(operands.begin() + 1, filter);
+    if (Match(instr, pattern)) {
+      std::vector<HloInstruction*> operands;
+      GraphString graph_string;
+      HloInstruction* final_instr;
+      std::tie(operands, graph_string, final_instr) = CaptureConvGraph(
+          const_cast<HloInstruction*>(instr), x_scale, w_scale,
+          x_scale_op ? x_scale_op->opcode() == HloOpcode::kMultiply : false,
+          w_scale_op ? w_scale_op->opcode() == HloOpcode::kMultiply : false);
+      if (graph_string.Size() > 1) {
+        TF_ASSIGN_OR_RETURN(
+            auto config, convolution->backend_config<CudnnConvBackendConfig>());
+        config.set_serialized_graph(graph_string.Graph());
+        operands.insert(operands.begin(), input);
+        operands.insert(operands.begin() + 1, filter);
 
-      Shape new_shape = ShapeUtil::MakeTupleShape(
-          {ShapeUtil::ChangeElementType(
-               ShapeUtil::GetTupleElementShape(convolution->shape(), 0),
-               final_instr->shape().element_type()),
-           ShapeUtil::GetTupleElementShape(convolution->shape(), 1)});
-      HloInstruction* new_convolution = comp->AddInstruction(
-          convolution->CloneWithNewOperands(new_shape, operands));
-      new_convolution->set_custom_call_target(kCudnnConvForwardGraphCallTarget);
-      TF_RETURN_IF_ERROR(new_convolution->set_backend_config(config));
-      TF_ASSIGN_OR_RETURN(HloInstruction * new_gte,
-                          MakeGetTupleElementHlo(new_convolution, 0));
-      TF_RETURN_IF_ERROR(comp->ReplaceInstruction(final_instr, new_gte));
-      changed = true;
+        Shape new_shape = ShapeUtil::MakeTupleShape(
+            {ShapeUtil::ChangeElementType(
+                 ShapeUtil::GetTupleElementShape(convolution->shape(), 0),
+                 final_instr->shape().element_type()),
+             ShapeUtil::GetTupleElementShape(convolution->shape(), 1)});
+        HloInstruction* new_convolution = comp->AddInstruction(
+            convolution->CloneWithNewOperands(new_shape, operands));
+        new_convolution->set_custom_call_target(
+            kCudnnConvForwardGraphCallTarget);
+        TF_RETURN_IF_ERROR(new_convolution->set_backend_config(config));
+        TF_ASSIGN_OR_RETURN(HloInstruction * new_gte,
+                            MakeGetTupleElementHlo(new_convolution, 0));
+        TF_RETURN_IF_ERROR(comp->ReplaceInstruction(final_instr, new_gte));
+        changed = true;
+      }
     }
   }
 #endif

--- a/tensorflow/compiler/xla/service/gpu/cudnn_pad_for_convolutions.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_pad_for_convolutions.cc
@@ -211,6 +211,7 @@ static StatusOr<bool> TryResolvePaddedShapesForTensorCore(
     switch (kind) {
       case CudnnConvKind::kForward:
       case CudnnConvKind::kForwardActivation:
+      case CudnnConvKind::kForwardGraph:
         return std::make_tuple(&new_lhs_shape, &new_rhs_shape,
                                &new_result_shape);
       case CudnnConvKind::kBackwardInput:

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_padding_legalization.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_padding_legalization.cc
@@ -33,7 +33,9 @@ namespace gpu {
 namespace {
 bool IsForwardConvolutionCanonical(const HloInstruction& conv) {
   CHECK(conv.custom_call_target() == kCudnnConvForwardCallTarget ||
-        conv.custom_call_target() == kCudnnConvBiasActivationForwardCallTarget);
+        conv.custom_call_target() ==
+            kCudnnConvBiasActivationForwardCallTarget ||
+        conv.custom_call_target() == kCudnnConvForwardGraphCallTarget);
   return window_util::HasSymmetricPadding(conv.window()) &&
          !window_util::HasNegativePadding(conv.window()) &&
          !window_util::HasDilation(conv.window());
@@ -415,6 +417,7 @@ StatusOr<bool> GpuConvPaddingLegalization::RunOnComputation(
       switch (kind) {
         case CudnnConvKind::kForward:
         case CudnnConvKind::kForwardActivation:
+        case CudnnConvKind::kForwardGraph:
           return CanonicalizeForwardConvolution(instruction);
         case CudnnConvKind::kBackwardInput:
           return CanonicalizeBackwardInputConvolution(instruction);

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.cc
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.cc
@@ -87,6 +87,57 @@ Status RunGpuConvUnfused(const GpuConvParams& params, se::Stream* stream,
                    filter_buf, output_buf);
 }
 
+template <typename ElementType, typename OutputType>
+Status RunGpuConvGraph(const GpuConvParams& params, se::Stream* stream,
+                       RunConvOptions options,
+                       DeviceMemory<ElementType> input_buf,
+                       DeviceMemory<ElementType> filter_buf,
+                       DeviceMemory<OutputType> output_buf,
+                       DeviceMemoryBase scratch_memory) {
+  if (params.config->conv_result_scale != 1) {
+    return InternalError(
+        "StreamExecutor doesn't support scaled convolution: %lf.",
+        params.config->conv_result_scale);
+  }
+
+  TF_ASSIGN_OR_RETURN(se::dnn::ConvolutionKind kind,
+                      GetDNNConvKindFromCudnnConvKind(params.config->kind));
+
+  TF_ASSIGN_OR_RETURN(
+      se::dnn::DataType input_type,
+      GetDNNDataTypeFromPrimitiveType(params.config->input_type));
+
+  TF_ASSIGN_OR_RETURN(
+      se::dnn::DataType output_type,
+      GetDNNDataTypeFromPrimitiveType(params.config->output_type));
+
+  se::dnn::LazyOpRunner<se::dnn::GraphConvOp>* lazy_runner =
+      options.runner_cache->AsGraphConvRunner();
+  std::optional<se::dnn::LazyOpRunner<se::dnn::GraphConvOp>> local_runner;
+  if (!lazy_runner) {
+    local_runner.emplace(params.config->algorithm);
+    lazy_runner = &*local_runner;
+  }
+
+  se::dnn::GraphConvOp::Config config{kind,
+                                      input_type,
+                                      output_type,
+                                      params.config->input_descriptor,
+                                      params.config->filter_descriptor,
+                                      params.config->output_descriptor,
+                                      params.config->conv_desc,
+                                      params.config->serialized_graph};
+  TF_ASSIGN_OR_RETURN(auto* runner,
+                      lazy_runner->GetOrCreateRunner(config, stream));
+
+  std::vector<DeviceMemoryBase> operands = {input_buf, filter_buf, output_buf};
+  // Insert the optional operands ahead of the output.
+  operands.insert(operands.end() - 1, params.operand_bufs.begin(),
+                  params.operand_bufs.end());
+
+  return (*runner)(stream, options.profile_result, scratch_memory, operands);
+}
+
 template <typename ElementType, typename BiasType, typename OutputType>
 Status RunGpuConvForwardActivation(const GpuConvParams& params,
                                    se::Stream* stream, RunConvOptions options,
@@ -174,6 +225,9 @@ Status RunGpuConvInternalImpl(const GpuConvParams& params, se::Stream* stream,
       return RunGpuConvForwardActivation<ElementType, BiasType, OutputType>(
           params, stream, options, input_buf, filter_buf, output_buf,
           scratch_memory);
+      case CudnnConvKind::kForwardGraph:
+        return RunGpuConvGraph(params, stream, options, input_buf, filter_buf,
+                               output_buf, scratch_memory);
     }
   }
   return OkStatus();
@@ -272,10 +326,12 @@ StatusOr<GpuConvConfig> GetGpuConvConfig(
   config.kind = desc.kind;
   config.algorithm = se::dnn::AlgorithmDesc(backend_config.algorithm());
   config.conv_result_scale = backend_config.conv_result_scale();
+  config.serialized_graph = backend_config.serialized_graph();
 
   switch (config.kind) {
     case CudnnConvKind::kForward:
     case CudnnConvKind::kForwardActivation:
+    case CudnnConvKind::kForwardGraph:
       config.input_shape = operand0_shape;
       config.filter_shape = operand1_shape;
       config.output_shape = result_shape;
@@ -494,6 +550,7 @@ StatusOr<GpuConvParams> GetGpuConvParams(
   switch (config.kind) {
     case CudnnConvKind::kForward:
     case CudnnConvKind::kForwardActivation:
+    case CudnnConvKind::kForwardGraph:
       params.input_buf = operand_buffers[0];
       params.filter_buf = operand_buffers[1];
       params.output_buf = result_buffer;
@@ -508,6 +565,10 @@ StatusOr<GpuConvParams> GetGpuConvParams(
       params.filter_buf = result_buffer;
       params.output_buf = operand_buffers[1];
       break;
+  }
+
+  if (config.kind == CudnnConvKind::kForwardGraph) {
+    params.operand_bufs = {operand_buffers.begin() + 2, operand_buffers.end()};
   }
 
   if (config.kind == CudnnConvKind::kForwardActivation) {
@@ -532,6 +593,20 @@ Status RunGpuConv(const gpu::GpuConvConfig& config,
 
   PrimitiveType input_primitive_type = config.input_type;
   switch (input_primitive_type) {
+    case F8E4M3FN:
+      if (config.kind != CudnnConvKind::kForwardGraph) {
+        return InternalError("FP8 convolution requires graph mode.");
+      }
+      return RunGpuConvImpl<tsl::float8_e4m3fn, tsl::float8_e4m3fn,
+                            tsl::float8_e4m3fn>(params, stream, scratch_memory,
+                                                options);
+    case F8E5M2:
+      if (config.kind != CudnnConvKind::kForwardGraph) {
+        return InternalError("FP8 convolution requires graph mode.");
+      }
+      return RunGpuConvImpl<tsl::float8_e5m2, tsl::float8_e5m2,
+                            tsl::float8_e5m2>(params, stream, scratch_memory,
+                                              options);
     case F16:
       return RunGpuConvImpl<Eigen::half, Eigen::half, Eigen::half>(
           params, stream, scratch_memory, options);

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
@@ -70,6 +70,10 @@ struct GpuConvConfig {
   Shape filter_shape;
   Shape output_shape;
   std::optional<FusionConfig> fusion;
+
+  // String serialization of the subgraph of adjacent ops to be fused into the
+  // cuDNN convolution Custom Call. Currently used for FP8 convolutions only.
+  // Additional information is provided in gpu_fused_conv_rewriter.cc.
   std::string serialized_graph;
 };
 
@@ -85,7 +89,8 @@ struct GpuConvParams {
   se::DeviceMemoryBase filter_buf;
   se::DeviceMemoryBase output_buf;
 
-  // Buffers for operands of pointwise ops.
+  // Buffers for operands of pointwise ops to be fused into the cuDNN
+  // convolution Custom Call.
   std::vector<se::DeviceMemoryBase> operand_bufs;
 
   std::optional<FusionParams> fusion;
@@ -95,7 +100,7 @@ struct GpuConvParams {
 // convolution is fused (and has extra arguments) or unfused, which doesn't
 // naturally play well with the typed APIs provided by StreamExecutor; rather
 // than rewriting everything here, just propagate the dynamic typing to one more
-// place by having either a FusedConvRunner or a ConvRunner.
+// place by having a ConvRunner, FusedConvRunner or GraphConvRunner.
 class GenericConvRunner {
  public:
   GenericConvRunner() = default;

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_GPU_CONV_RUNNER_H_
 
 #include <optional>
+#include <string>
 
 #include "tensorflow/compiler/xla/hlo/ir/hlo_instruction.h"
 #include "tensorflow/compiler/xla/hlo/ir/hlo_instructions.h"
@@ -69,6 +70,7 @@ struct GpuConvConfig {
   Shape filter_shape;
   Shape output_shape;
   std::optional<FusionConfig> fusion;
+  std::string serialized_graph;
 };
 
 // Implementation struct exposed for debugging and log analysis.
@@ -83,6 +85,9 @@ struct GpuConvParams {
   se::DeviceMemoryBase filter_buf;
   se::DeviceMemoryBase output_buf;
 
+  // Buffers for operands of pointwise ops.
+  std::vector<se::DeviceMemoryBase> operand_bufs;
+
   std::optional<FusionParams> fusion;
 };
 
@@ -91,28 +96,40 @@ struct GpuConvParams {
 // naturally play well with the typed APIs provided by StreamExecutor; rather
 // than rewriting everything here, just propagate the dynamic typing to one more
 // place by having either a FusedConvRunner or a ConvRunner.
-class MaybeFusedConvRunner {
+class GenericConvRunner {
  public:
-  MaybeFusedConvRunner() = default;
+  GenericConvRunner() = default;
 
-  explicit MaybeFusedConvRunner(
+  explicit GenericConvRunner(
       std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedConvOp>> runner)
       : repr_(std::move(runner)) {}
 
-  explicit MaybeFusedConvRunner(
+  explicit GenericConvRunner(
+      std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::GraphConvOp>> runner)
+      : repr_(std::move(runner)) {}
+
+  explicit GenericConvRunner(
       std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::ConvOp>> runner)
       : repr_(std::move(runner)) {}
 
-  explicit MaybeFusedConvRunner(const GpuConvConfig& config)
-      : MaybeFusedConvRunner(
-            config.kind == CudnnConvKind::kForwardActivation
-                ? MaybeFusedConvRunner(
-                      std::make_unique<
-                          se::dnn::LazyOpRunner<se::dnn::FusedConvOp>>(
-                          config.algorithm))
-                : MaybeFusedConvRunner(
-                      std::make_unique<se::dnn::LazyOpRunner<se::dnn::ConvOp>>(
-                          config.algorithm))) {}
+  explicit GenericConvRunner(const GpuConvConfig& config)
+      : GenericConvRunner(FromGpuConvConfig(config)) {}
+
+  static GenericConvRunner FromGpuConvConfig(const GpuConvConfig& config) {
+    if (config.kind == CudnnConvKind::kForwardGraph) {
+      return GenericConvRunner(
+          std::make_unique<se::dnn::LazyOpRunner<se::dnn::GraphConvOp>>(
+              config.algorithm));
+    } else if (config.kind == CudnnConvKind::kForwardActivation) {
+      return GenericConvRunner(
+          std::make_unique<se::dnn::LazyOpRunner<se::dnn::FusedConvOp>>(
+              config.algorithm));
+    } else {
+      return GenericConvRunner(
+          std::make_unique<se::dnn::LazyOpRunner<se::dnn::ConvOp>>(
+              config.algorithm));
+    }
+  }
 
   se::dnn::AlgorithmDesc ToAlgorithmDesc() const {
     return std::visit(ToAlgorithmDescVisitor{}, repr_);
@@ -122,6 +139,15 @@ class MaybeFusedConvRunner {
     CHECK(std::holds_alternative<
           std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::ConvOp>>>(repr_));
     return std::get<std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::ConvOp>>>(
+               repr_)
+        .get();
+  }
+
+  se::dnn::LazyOpRunner<se::dnn::GraphConvOp>* AsGraphConvRunner() {
+    CHECK(std::holds_alternative<
+          std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::GraphConvOp>>>(repr_));
+    return std::get<
+               std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::GraphConvOp>>>(
                repr_)
         .get();
   }
@@ -150,6 +176,7 @@ class MaybeFusedConvRunner {
   using Repr =
       std::variant<std::monostate,  // To allow GpuConvConfig default ctor
                    std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::FusedConvOp>>,
+                   std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::GraphConvOp>>,
                    std::unique_ptr<se::dnn::LazyOpRunner<se::dnn::ConvOp>>>;
   Repr repr_;
 };
@@ -160,7 +187,7 @@ struct RunConvOptions {
 
   // Use this runner cache (and its configured algorithm), instead of the one
   // from the instruction.
-  MaybeFusedConvRunner* runner_cache;
+  GenericConvRunner* runner_cache;
 };
 
 // This file contains low-level routines for running cudnn convolutions.

--- a/tensorflow/compiler/xla/service/gpu/runtime/conv.h
+++ b/tensorflow/compiler/xla/service/gpu/runtime/conv.h
@@ -45,7 +45,7 @@ struct ConvRunner {
   explicit ConvRunner(GpuConvConfig config)
       : config(std::move(config)), runner(this->config) {}
   GpuConvConfig config;
-  MaybeFusedConvRunner runner;
+  GenericConvRunner runner;
 };
 
 class StreamExecutorConvRunners : public runtime::StateVector<ConvRunner> {};

--- a/tensorflow/compiler/xla/service/gpu/stream_executor_util.cc
+++ b/tensorflow/compiler/xla/service/gpu/stream_executor_util.cc
@@ -485,6 +485,8 @@ StatusOr<se::dnn::ConvolutionKind> GetDNNConvKindFromCudnnConvKind(
       return se::dnn::FORWARD;
     case CudnnConvKind::kForwardActivation:
       return se::dnn::FORWARD_BIAS_ACTIVATION;
+    case CudnnConvKind::kForwardGraph:
+      return se::dnn::FORWARD_GRAPH;
     default:
       break;
   }
@@ -535,6 +537,10 @@ StatusOr<se::dnn::DataType> GetDNNDataTypeFromPrimitiveType(
       return se::dnn::ToDataType<int32_t>::value;
     case BF16:
       return se::dnn::ToDataType<Eigen::bfloat16>::value;
+    case F8E4M3FN:
+      return se::dnn::ToDataType<tsl::float8_e4m3fn>::value;
+    case F8E5M2:
+      return se::dnn::ToDataType<tsl::float8_e5m2>::value;
     default:
       break;
   }

--- a/tensorflow/compiler/xla/service/layout_assignment.cc
+++ b/tensorflow/compiler/xla/service/layout_assignment.cc
@@ -153,8 +153,8 @@ OperandLayoutConstraint::OperandLayoutConstraint(
       instruction_(instruction),
       operand_no_(operand_no) {
   CHECK(shape_layout.LayoutIsSet());
-  CHECK(ShapeUtil::Compatible(shape_layout.shape(),
-                              instruction->operand(operand_no)->shape()))
+  CHECK(ShapeUtil::CompatibleIgnoringElementType(
+      shape_layout.shape(), instruction->operand(operand_no)->shape()))
       << shape_layout.shape() << " is not compatible with "
       << instruction->operand(operand_no)->shape() << " (for operand "
       << operand_no << " of instruction " << instruction->ToString() << ")";

--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
@@ -3573,10 +3573,10 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnTensor(
 
 #endif
 
-#if (CUDNN_VERSION >= 8900 && TF_ENABLE_CUDNN_FRONTEND)
 tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnTensor(
     const cudnn_frontend::Tensor& original, int64_t uid, dnn::DataType dtype,
     bool is_virtual = false) {
+#if (CUDNN_VERSION >= 8900 && TF_ENABLE_CUDNN_FRONTEND)
   auto tensor = cudnn_frontend::TensorBuilder()
                     .cloneFrom(original, uid)
                     .setAlignment(32)
@@ -3585,8 +3585,10 @@ tsl::StatusOr<cudnn_frontend::Tensor> CreateCudnnTensor(
                     .build();
   RETURN_MSG_IF_CUDNN_ERROR(tensor);
   return tensor;
-}
+#else
+  return tsl::errors::Internal("Not implemented.");
 #endif  // CUDNN_VERSION >= 8900 && TF_ENABLE_CUDNN_FRONTEND
+}
 
 #if (CUDNN_VERSION >= 8800 && TF_ENABLE_CUDNN_FRONTEND)
 enum CudnnfMHAUid {

--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.h
@@ -238,6 +238,30 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::BatchDescriptor& output_descriptor,
       const dnn::ConvolutionDescriptor& convolution_descriptor) override;
 
+  tsl::Status GetGraphConvolveRunners(
+      bool use_cudnn_frontend, dnn::ConvolutionKind kind,
+      dnn::DataType input_type, dnn::DataType output_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemoryBase filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      bool use_fallback, ScratchAllocator* scratch_allocator,
+      const NumericOptions& numeric_options,
+      std::vector<std::unique_ptr<const dnn::ConvRunner>>* out_exec_plans,
+      string serialized_graph) override;
+
+  tsl::StatusOr<std::unique_ptr<const dnn::GraphConvRunner>>
+  GraphConvolveRunnerFromDesc(
+      Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+      dnn::ConvolutionKind kind, dnn::DataType input_type,
+      dnn::DataType output_type, const dnn::BatchDescriptor& input_descriptor,
+      const dnn::FilterDescriptor& filter_descriptor,
+      const dnn::BatchDescriptor& output_descriptor,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      string serialized_graph) override;
+
   tsl::Status GetFusedConvolveRunners(
       bool use_cudnn_frontend, dnn::ConvolutionKind kind,
       dnn::DataType input_type, dnn::DataType bias_type,

--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.h
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.h
@@ -239,17 +239,14 @@ class CudnnSupport : public dnn::DnnSupport {
       const dnn::ConvolutionDescriptor& convolution_descriptor) override;
 
   tsl::Status GetGraphConvolveRunners(
-      bool use_cudnn_frontend, dnn::ConvolutionKind kind,
-      dnn::DataType input_type, dnn::DataType output_type, Stream* stream,
-      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      dnn::ConvolutionKind kind, dnn::DataType input_type,
+      dnn::DataType output_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor,
       const dnn::FilterDescriptor& filter_descriptor,
-      DeviceMemoryBase filter_data,
       const dnn::BatchDescriptor& output_descriptor,
-      DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
-      bool use_fallback, ScratchAllocator* scratch_allocator,
-      const NumericOptions& numeric_options,
-      std::vector<std::unique_ptr<const dnn::ConvRunner>>* out_exec_plans,
+      bool use_fallback, const NumericOptions& numeric_options,
+      std::vector<std::unique_ptr<const dnn::GraphConvRunner>>* out_exec_plans,
       string serialized_graph) override;
 
   tsl::StatusOr<std::unique_ptr<const dnn::GraphConvRunner>>

--- a/tensorflow/compiler/xla/stream_executor/dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/dnn.cc
@@ -150,18 +150,14 @@ DnnSupport::ConvolveRunnerFromDesc(
 }
 
 tsl::Status DnnSupport::GetGraphConvolveRunners(
-    bool /* use_cudnn_frontend */, dnn::ConvolutionKind /*kind*/,
-    dnn::DataType /*input_type*/, dnn::DataType /*output_type*/,
-    Stream* /*stream*/, const dnn::BatchDescriptor& /*input_descriptor*/,
-    DeviceMemoryBase /*input_data*/,
+    dnn::ConvolutionKind /*kind*/, dnn::DataType /*input_type*/,
+    dnn::DataType /*output_type*/, Stream* /*stream*/,
+    const dnn::BatchDescriptor& /*input_descriptor*/,
     const dnn::FilterDescriptor& /*filter_descriptor*/,
-    DeviceMemoryBase /*filter_data*/,
     const dnn::BatchDescriptor& /*output_descriptor*/,
-    DeviceMemoryBase /*output_data*/,
     const dnn::ConvolutionDescriptor& /*convolution_descriptor*/,
-    bool /*use_fallback*/, ScratchAllocator* /*scratch_allocator*/,
-    const NumericOptions& /*numeric_options*/,
-    std::vector<std::unique_ptr<const dnn::ConvRunner>>* /*exec_plans*/,
+    bool /*use_fallback*/, const NumericOptions& /*numeric_options*/,
+    std::vector<std::unique_ptr<const dnn::GraphConvRunner>>* /*exec_plans*/,
     string cudnn_grapph) {
   return tsl::errors::Unimplemented("GetGraphConvolveRunners not implemented.");
 }

--- a/tensorflow/compiler/xla/stream_executor/dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/dnn.cc
@@ -149,6 +149,36 @@ DnnSupport::ConvolveRunnerFromDesc(
   return tsl::errors::Unimplemented("ConvolveRunnerFromDesc not implemented.");
 }
 
+tsl::Status DnnSupport::GetGraphConvolveRunners(
+    bool /* use_cudnn_frontend */, dnn::ConvolutionKind /*kind*/,
+    dnn::DataType /*input_type*/, dnn::DataType /*output_type*/,
+    Stream* /*stream*/, const dnn::BatchDescriptor& /*input_descriptor*/,
+    DeviceMemoryBase /*input_data*/,
+    const dnn::FilterDescriptor& /*filter_descriptor*/,
+    DeviceMemoryBase /*filter_data*/,
+    const dnn::BatchDescriptor& /*output_descriptor*/,
+    DeviceMemoryBase /*output_data*/,
+    const dnn::ConvolutionDescriptor& /*convolution_descriptor*/,
+    bool /*use_fallback*/, ScratchAllocator* /*scratch_allocator*/,
+    const NumericOptions& /*numeric_options*/,
+    std::vector<std::unique_ptr<const dnn::ConvRunner>>* /*exec_plans*/,
+    string cudnn_grapph) {
+  return tsl::errors::Unimplemented("GetGraphConvolveRunners not implemented.");
+}
+
+tsl::StatusOr<std::unique_ptr<const dnn::GraphConvRunner>>
+DnnSupport::GraphConvolveRunnerFromDesc(
+    Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
+    dnn::ConvolutionKind kind, dnn::DataType element_type,
+    dnn::DataType output_type, const dnn::BatchDescriptor& input_descriptor,
+    const dnn::FilterDescriptor& filter_descriptor,
+    const dnn::BatchDescriptor& output_descriptor,
+    const dnn::ConvolutionDescriptor& convolution_descriptor,
+    string serialized_graph) {
+  return tsl::errors::Unimplemented(
+      "GraphConvolveRunnerFromDesc not implemented.");
+}
+
 tsl::Status DnnSupport::GetFusedConvolveRunners(
     bool use_cudnn_frontend, dnn::ConvolutionKind kind,
     dnn::DataType element_type, dnn::DataType bias_type,

--- a/tensorflow/compiler/xla/stream_executor/dnn.h
+++ b/tensorflow/compiler/xla/stream_executor/dnn.h
@@ -965,13 +965,6 @@ class OpRunner<void(Args...)> {
   virtual tsl::Status operator()(Stream*, ProfileResult*,
                                  DeviceMemoryBase scratch_memory,
                                  Args... args) const = 0;
-
-  // Launch the operation with a variable number of operands.
-  virtual tsl::Status operator()(Stream*, ProfileResult*,
-                                 DeviceMemoryBase scratch_memory,
-                                 std::vector<DeviceMemoryBase>) const {
-    return tsl::errors::Unimplemented("operator() not implemented.");
-  };
 };
 
 using ConvSignature = void(DeviceMemoryBase /* input_data */,
@@ -979,7 +972,8 @@ using ConvSignature = void(DeviceMemoryBase /* input_data */,
                            DeviceMemoryBase /* output_data */);
 using ConvRunner = OpRunner<ConvSignature>;
 
-using GraphConvRunner = OpRunner<ConvSignature>;
+using GraphConvSignature = void(std::vector<DeviceMemoryBase>);
+using GraphConvRunner = OpRunner<GraphConvSignature>;
 
 using FusedConvSignature = void(DeviceMemoryBase /* input_data */,
                                 DeviceMemoryBase /* filter_data */,
@@ -1636,20 +1630,17 @@ class DnnSupport {
       const dnn::ConvolutionDescriptor& convolution_descriptor);
 
   virtual tsl::Status GetGraphConvolveRunners(
-      bool use_cudnn_frontend, dnn::ConvolutionKind kind,
-      dnn::DataType input_type, dnn::DataType output_type, Stream* stream,
-      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      dnn::ConvolutionKind kind, dnn::DataType input_type,
+      dnn::DataType output_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor,
       const dnn::FilterDescriptor& filter_descriptor,
-      DeviceMemoryBase filter_data,
       const dnn::BatchDescriptor& output_descriptor,
-      DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
-      bool use_fallback, ScratchAllocator* scratch_allocator,
-      const NumericOptions& numeric_options,
-      std::vector<std::unique_ptr<const dnn::ConvRunner>>* out_exec_plans,
+      bool use_fallback, const NumericOptions& numeric_options,
+      std::vector<std::unique_ptr<const dnn::GraphConvRunner>>* out_exec_plans,
       string serialized_graph);
 
-  virtual tsl::StatusOr<std::unique_ptr<const dnn::ConvRunner>>
+  virtual tsl::StatusOr<std::unique_ptr<const dnn::GraphConvRunner>>
   GraphConvolveRunnerFromDesc(
       Stream* stream, const dnn::AlgorithmDesc& algorithm_desc,
       dnn::ConvolutionKind kind, dnn::DataType element_type,

--- a/tensorflow/compiler/xla/stream_executor/lazy_op_runner.h
+++ b/tensorflow/compiler/xla/stream_executor/lazy_op_runner.h
@@ -161,7 +161,7 @@ struct ConvOp {
 // Implementation of the concept required by LazyOpRunner, for
 // GraphConvolveRunner.
 struct GraphConvOp {
-  using Signature = ConvSignature;
+  using Signature = GraphConvSignature;
 
   struct Config {
     ConvolutionKind kind;
@@ -173,7 +173,7 @@ struct GraphConvOp {
     string serialized_graph;
   };
 
-  static tsl::StatusOr<std::unique_ptr<const OpRunner<ConvSignature>>>
+  static tsl::StatusOr<std::unique_ptr<const OpRunner<Signature>>>
   RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
                           Stream* stream) {
     return stream->GraphConvolveRunnerFromDesc(

--- a/tensorflow/compiler/xla/stream_executor/lazy_op_runner.h
+++ b/tensorflow/compiler/xla/stream_executor/lazy_op_runner.h
@@ -158,6 +158,32 @@ struct ConvOp {
   }
 };
 
+// Implementation of the concept required by LazyOpRunner, for
+// GraphConvolveRunner.
+struct GraphConvOp {
+  using Signature = ConvSignature;
+
+  struct Config {
+    ConvolutionKind kind;
+    DataType input_type, output_type;
+    const BatchDescriptor& input_descriptor;
+    const FilterDescriptor& filter_descriptor;
+    const BatchDescriptor& output_descriptor;
+    const ConvolutionDescriptor& convolution_descriptor;
+    string serialized_graph;
+  };
+
+  static tsl::StatusOr<std::unique_ptr<const OpRunner<ConvSignature>>>
+  RunnerFromAlgorithmDesc(const AlgorithmDesc& desc, Config config,
+                          Stream* stream) {
+    return stream->GraphConvolveRunnerFromDesc(
+        desc, config.kind, config.input_type, config.output_type,
+        config.input_descriptor, config.filter_descriptor,
+        config.output_descriptor, config.convolution_descriptor,
+        config.serialized_graph);
+  }
+};
+
 // Implementation of the concept required by LazyOpRunner, for LazyConvRunner.
 struct FusedConvOp {
   using Signature = FusedConvSignature;

--- a/tensorflow/compiler/xla/stream_executor/stream.h
+++ b/tensorflow/compiler/xla/stream_executor/stream.h
@@ -435,6 +435,25 @@ class Stream {
         filter_descriptor, output_descriptor, convolution_descriptor);
   }
 
+  tsl::StatusOr<std::unique_ptr<const dnn::GraphConvRunner>>
+  GraphConvolveRunnerFromDesc(
+      const dnn::AlgorithmDesc &algorithm_desc, dnn::ConvolutionKind kind,
+      dnn::DataType element_type, dnn::DataType output_type,
+      const dnn::BatchDescriptor &input_descriptor,
+      const dnn::FilterDescriptor &filter_descriptor,
+      const dnn::BatchDescriptor &output_descriptor,
+      const dnn::ConvolutionDescriptor &convolution_descriptor,
+      string serialized_graph) {
+    dnn::DnnSupport *dnn_support = parent_->AsDnn();
+    if (!dnn_support) {
+      return tsl::errors::Unimplemented("DNN library is not found.");
+    }
+    return dnn_support->GraphConvolveRunnerFromDesc(
+        this, algorithm_desc, kind, element_type, output_type, input_descriptor,
+        filter_descriptor, output_descriptor, convolution_descriptor,
+        serialized_graph);
+  }
+
   tsl::StatusOr<std::unique_ptr<const dnn::FusedConvRunner>>
   FusedConvolveRunnerFromDesc(
       const dnn::AlgorithmDesc &algorithm_desc, dnn::ConvolutionKind kind,

--- a/tensorflow/compiler/xla/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/compiler/xla/stream_executor/stream_executor_pimpl.cc
@@ -287,25 +287,23 @@ tsl::Status StreamExecutor::GetConvolveRunners(
 }
 
 tsl::Status StreamExecutor::GetGraphConvolveRunners(
-    bool use_cudnn_frontend, dnn::ConvolutionKind kind,
-    dnn::DataType input_type, dnn::DataType output_type, Stream* stream,
-    const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+    dnn::ConvolutionKind kind, dnn::DataType input_type,
+    dnn::DataType output_type, Stream* stream,
+    const dnn::BatchDescriptor& input_descriptor,
     const dnn::FilterDescriptor& filter_descriptor,
-    DeviceMemoryBase filter_data, const dnn::BatchDescriptor& output_descriptor,
-    DeviceMemoryBase output_data,
+    const dnn::BatchDescriptor& output_descriptor,
     const dnn::ConvolutionDescriptor& convolution_descriptor, bool use_fallback,
-    ScratchAllocator* scratch_allocator, const NumericOptions& numeric_options,
-    std::vector<std::unique_ptr<const dnn::ConvRunner>>* out_exec_plans,
+    const NumericOptions& numeric_options,
+    std::vector<std::unique_ptr<const dnn::GraphConvRunner>>* out_exec_plans,
     string serialized_graph) {
   dnn::DnnSupport* dnn_support = AsDnn();
   if (!dnn_support) {
     return tsl::errors::Unimplemented("DNN library is not found.");
   }
   return dnn_support->GetGraphConvolveRunners(
-      use_cudnn_frontend, kind, input_type, output_type, stream,
-      input_descriptor, input_data, filter_descriptor, filter_data,
-      output_descriptor, output_data, convolution_descriptor, use_fallback,
-      scratch_allocator, numeric_options, out_exec_plans, serialized_graph);
+      kind, input_type, output_type, stream, input_descriptor,
+      filter_descriptor, output_descriptor, convolution_descriptor,
+      use_fallback, numeric_options, out_exec_plans, serialized_graph);
 }
 
 tsl::Status StreamExecutor::GetFusedConvolveRunners(

--- a/tensorflow/compiler/xla/stream_executor/stream_executor_pimpl.cc
+++ b/tensorflow/compiler/xla/stream_executor/stream_executor_pimpl.cc
@@ -286,6 +286,28 @@ tsl::Status StreamExecutor::GetConvolveRunners(
       scratch_allocator, numeric_options, out_exec_plans);
 }
 
+tsl::Status StreamExecutor::GetGraphConvolveRunners(
+    bool use_cudnn_frontend, dnn::ConvolutionKind kind,
+    dnn::DataType input_type, dnn::DataType output_type, Stream* stream,
+    const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+    const dnn::FilterDescriptor& filter_descriptor,
+    DeviceMemoryBase filter_data, const dnn::BatchDescriptor& output_descriptor,
+    DeviceMemoryBase output_data,
+    const dnn::ConvolutionDescriptor& convolution_descriptor, bool use_fallback,
+    ScratchAllocator* scratch_allocator, const NumericOptions& numeric_options,
+    std::vector<std::unique_ptr<const dnn::ConvRunner>>* out_exec_plans,
+    string serialized_graph) {
+  dnn::DnnSupport* dnn_support = AsDnn();
+  if (!dnn_support) {
+    return tsl::errors::Unimplemented("DNN library is not found.");
+  }
+  return dnn_support->GetGraphConvolveRunners(
+      use_cudnn_frontend, kind, input_type, output_type, stream,
+      input_descriptor, input_data, filter_descriptor, filter_data,
+      output_descriptor, output_data, convolution_descriptor, use_fallback,
+      scratch_allocator, numeric_options, out_exec_plans, serialized_graph);
+}
+
 tsl::Status StreamExecutor::GetFusedConvolveRunners(
     bool use_cudnn_frontend, dnn::ConvolutionKind kind,
     dnn::DataType input_type, dnn::DataType bias_type,

--- a/tensorflow/compiler/xla/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/compiler/xla/stream_executor/stream_executor_pimpl.h
@@ -377,6 +377,20 @@ class StreamExecutor {
       const NumericOptions& numeric_options,
       std::vector<std::unique_ptr<const dnn::ConvRunner>>* out_exec_plans);
 
+  tsl::Status GetGraphConvolveRunners(
+      bool use_cudnn_frontend, dnn::ConvolutionKind kind,
+      dnn::DataType input_type, dnn::DataType output_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      const dnn::FilterDescriptor& filter_descriptor,
+      DeviceMemoryBase filter_data,
+      const dnn::BatchDescriptor& output_descriptor,
+      DeviceMemoryBase output_data,
+      const dnn::ConvolutionDescriptor& convolution_descriptor,
+      bool use_fallback, ScratchAllocator* scratch_allocator,
+      const NumericOptions& numeric_options,
+      std::vector<std::unique_ptr<const dnn::ConvRunner>>* out_exec_plans,
+      string serialized_graph);
+
   tsl::Status GetFusedConvolveRunners(
       bool use_cudnn_frontend, dnn::ConvolutionKind kind,
       dnn::DataType input_type, dnn::DataType bias_type,

--- a/tensorflow/compiler/xla/stream_executor/stream_executor_pimpl.h
+++ b/tensorflow/compiler/xla/stream_executor/stream_executor_pimpl.h
@@ -378,17 +378,14 @@ class StreamExecutor {
       std::vector<std::unique_ptr<const dnn::ConvRunner>>* out_exec_plans);
 
   tsl::Status GetGraphConvolveRunners(
-      bool use_cudnn_frontend, dnn::ConvolutionKind kind,
-      dnn::DataType input_type, dnn::DataType output_type, Stream* stream,
-      const dnn::BatchDescriptor& input_descriptor, DeviceMemoryBase input_data,
+      dnn::ConvolutionKind kind, dnn::DataType input_type,
+      dnn::DataType output_type, Stream* stream,
+      const dnn::BatchDescriptor& input_descriptor,
       const dnn::FilterDescriptor& filter_descriptor,
-      DeviceMemoryBase filter_data,
       const dnn::BatchDescriptor& output_descriptor,
-      DeviceMemoryBase output_data,
       const dnn::ConvolutionDescriptor& convolution_descriptor,
-      bool use_fallback, ScratchAllocator* scratch_allocator,
-      const NumericOptions& numeric_options,
-      std::vector<std::unique_ptr<const dnn::ConvRunner>>* out_exec_plans,
+      bool use_fallback, const NumericOptions& numeric_options,
+      std::vector<std::unique_ptr<const dnn::GraphConvRunner>>* out_exec_plans,
       string serialized_graph);
 
   tsl::Status GetFusedConvolveRunners(

--- a/tensorflow/compiler/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.cc
+++ b/tensorflow/compiler/xla/translate/mhlo_to_lhlo_with_xla/mhlo_to_lhlo_with_xla.cc
@@ -1276,6 +1276,13 @@ tsl::StatusOr<Operation*> LhloDialectEmitter::EmitDnnConvolution(
       TF_RETURN_IF_ERROR(set_activation(cnn_fused_side_input));
       return set_common_conv_attributes(cnn_fused_side_input);
     }
+    case xla::gpu::CudnnConvKind::kForwardGraph: {
+      TF_ASSIGN_OR_RETURN(
+          auto cnn_graph,
+          CreateOpWithoutAttrs<lmhlo_gpu::ConvForwardGraphOp>(custom_call));
+      cnn_graph.setSerializedGraph(backend_config.serialized_graph());
+      return set_common_conv_attributes(cnn_graph);
+    }
   }
 }
 

--- a/tensorflow/core/kernels/conv_ops_gpu.cc
+++ b/tensorflow/core/kernels/conv_ops_gpu.cc
@@ -260,6 +260,7 @@ StatusOr<AutotuneEntry<se::dnn::ConvOp>> AutotuneUnfusedConv(
     switch (kind) {
       case se::dnn::ConvolutionKind::FORWARD:
       case se::dnn::ConvolutionKind::FORWARD_BIAS_ACTIVATION:
+      case se::dnn::ConvolutionKind::FORWARD_GRAPH:
         output_ptr = se::DeviceMemory<T>(
             WrapRedzoneBestEffort(&rz_allocator, output_ptr));
         break;

--- a/tensorflow/tsl/protobuf/dnn.proto
+++ b/tensorflow/tsl/protobuf/dnn.proto
@@ -102,6 +102,7 @@ enum ConvolutionKind {
   BACKWARD_FILTER = 2;
   BACKWARD_DATA = 3;
   FORWARD_BIAS_ACTIVATION = 4;
+  FORWARD_GRAPH = 5;
 }
 
 // Generic tensor representation.


### PR DESCRIPTION
Enables scaled convolutions of the form

(X, W, x_scale, w_scale, y_scale) -> Y,

where the input X, the filter W and the output Y are based on the `F8E4M3FN` and `F8E5M2` data types and x_scale, w_scale and y_scale are their scaling factors.