### PR TITLE
Update list_physical_devices and list_logical_devices Argument notes

### DIFF
--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -448,6 +448,11 @@ def list_physical_devices(device_type=None):
   Args:
     device_type: (optional string) Only include devices matching this device
       type. For example "CPU" or "GPU".
+      
+    Notes:
+    1. If provided with any numerical values or any string other than 
+    'CPU' or 'GPU' it returns an empty list instead of raising error.
+    2. For default value it returns all physical devices
 
   Returns:
     List of discovered `tf.config.PhysicalDevice` objects
@@ -484,6 +489,11 @@ def list_logical_devices(device_type=None):
   Args:
     device_type: (optional string) Only include devices matching this device
       type. For example "CPU" or "GPU".
+      
+    Notes:
+    1. If provided with any numerical values or any string other than 
+    'CPU' or 'GPU' it returns an empty list instead of raising error.
+    2. For default value it returns all logical devices
 
   Returns:
     List of initialized `LogicalDevice`s

--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -451,7 +451,8 @@ def list_physical_devices(device_type=None):
       
     Notes:
     1. If provided with any numerical values or any string other than 
-    'CPU' or 'GPU' it returns an empty list instead of raising error.
+    supported device type such as 'CPU' it returns an empty list instead of
+    raising error.
     2. For default value it returns all physical devices
 
   Returns:
@@ -492,7 +493,8 @@ def list_logical_devices(device_type=None):
       
     Notes:
     1. If provided with any numerical values or any string other than 
-    'CPU' or 'GPU' it returns an empty list instead of raising error.
+    supported device type such as 'CPU' it returns an empty list instead of 
+    raising error.
     2. For default value it returns all logical devices
 
   Returns:


### PR DESCRIPTION
At present both the APIs `tf.config.list_physical_devices` and `tf.config.list_logical_devices` has an optional argument named `device_type` which takes a `string` as an argument. But When we pass a numeric value or strings other than expected('CPU' or 'GPU') both returns an empty list instead of raising the error.The behaviour is ok but this is not documented well.Hence I proposed a note for same.

Also the default value of the argument `device_type` is `None` but with default value both the APIs returns available physical/logical devices. This is not `intuitive` as for value `None` the APIs returning the respective devices. This may create some confusion among users. Hence I am adding the note of same to the documentation explicitly to avoid any confusion.

Attaching the [gist](https://colab.research.google.com/gist/SuryanarayanaY/68405fce0b68d53f094f875a4a7c5c42/57153.ipynb#scrollTo=C-CjbbaKu1Q6) as reference for the above results.

The issue discussed in #57153 .
