### PR TITLE
Limit typing_extensions to less than 4.6.0 until it works

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -108,7 +108,7 @@ REQUIRED_PACKAGES = [
     'setuptools',
     'six >= 1.12.0',
     'termcolor >= 1.1.0',
-    'typing_extensions >= 3.6.6',
+    'typing_extensions>=3.6.6,<4.6.0',
     # TODO(b/266362323): wrapt==1.15.0rc0 incompatible with TF 2.12.0 RC0 (and
     # nightly, but works with TF 2.11)
     'wrapt >= 1.11.0, <1.15',


### PR DESCRIPTION
There is a unit test failure when run as a pip test with typing_extensions >= 4.6.0 so limit the installed version to below that until the issue is resolved.