### PR TITLE
[Linaro:ARM_CI] Fix permissions for running nonpip tests

### DIFF
--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS_EXTENDED.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS_EXTENDED.sh
@@ -18,25 +18,8 @@ set -x
 source tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
 
 ARM_SKIP_TESTS="${ARM_SKIP_TESTS} \
--//tensorflow/compiler/mlir/lite/tests:const-fold.mlir.test \
--//tensorflow/compiler/mlir/tensorflow/tests/... \
 -//tensorflow/compiler/mlir/tfr/examples/mnist:mnist_ops_test \
--//tensorflow/compiler/tests:conv2d_test_cpu \
--//tensorflow/compiler/tests:conv2d_test_cpu_mlir_bridge_test \
--//tensorflow/compiler/tests:depthwise_conv_op_test_cpu \
--//tensorflow/compiler/tests:depthwise_conv_op_test_cpu_mlir_bridge_test \
--//tensorflow/compiler/tests:jit_test_cpu \
--//tensorflow/compiler/xla/service/cpu/tests:cpu_eigen_dot_operation_test \
--//tensorflow/compiler/xla/tests:conv_depthwise_backprop_filter_test_cpu \
--//tensorflow/compiler/xla/tests:convolution_dimension_numbers_test_cpu \
--//tensorflow/compiler/xla/tests:convolution_test_cpu \
--//tensorflow/compiler/xla/tests:convolution_variants_test_cpu \
--//tensorflow/core/distributed_runtime/integration_test:c_api_session_coordination_test_cpu \
--//tensorflow/core/grappler/optimizers:arithmetic_optimizer_test_cpu \
 -//tensorflow/core/grappler/optimizers:auto_mixed_precision_test_cpu \
--//tensorflow/core/grappler/optimizers:constant_folding_test \
 -//tensorflow/core/grappler/optimizers:remapper_test_cpu \
--//tensorflow/core/profiler/rpc/client:remote_profiler_session_manager_test \
 -//tensorflow/python/kernel_tests/nn_ops:conv_ops_3d_test_cpu \
--//tensorflow/python/kernel_tests/nn_ops:conv2d_backprop_filter_grad_test_cpu \
--//tensorflow/python/tools:aot_compiled_test"
+"

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
@@ -19,6 +19,14 @@ set -x
 
 source tensorflow/tools/ci_build/release/common.sh
 
+sudo mkdir /tmpfs
+sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /tmpfs
+sudo mkdir /tensorflow
+sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /tensorflow
+sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/lib/python*
+sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/bin
+sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/lib/python3/dist-packages
+
 # Update bazel
 install_bazelisk
 
@@ -66,9 +74,13 @@ export TF_BUILD_FLAGS="--config=mkl_aarch64_threadpool --copt=-flax-vector-conve
 export TF_TEST_FLAGS="${TF_BUILD_FLAGS} \
     --test_env=TF_ENABLE_ONEDNN_OPTS=1 --test_env=TF2_BEHAVIOR=1 --define=tf_api_version=2 \
     --test_lang_filters=py --flaky_test_attempts=3 --test_size_filters=small,medium \
-    --test_output=errors --verbose_failures=true --test_keep_going"
+    --test_output=errors --verbose_failures=true --test_keep_going --notest_verbose_timeout_warnings"
 export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} ${ARM_SKIP_TESTS}"
-export TF_FILTER_TAGS="-no_oss,-oss_serial,-v1only,-benchmark-test,-no_aarch64,-gpu,-tpu,-requires-gpu"
+export TF_FILTER_TAGS="-no_oss,-oss_excluded,-oss_serial,-v1only,-benchmark-test,-no_aarch64,-gpu,-tpu,-no_oss_py38,-no_oss_py39,-no_oss_py310"
+
+sudo sed -i '/^build --profile/d' /usertools/aarch64.bazelrc
+sudo sed -i '\@^build.*=\"/usr/local/bin/python3\"$@d' /usertools/aarch64.bazelrc
+sed -i '$ aimport /usertools/aarch64.bazelrc' .bazelrc
 
 bazel test ${TF_TEST_FLAGS} \
     --repo_env=PYTHON_BIN_PATH="$(which python)" \


### PR DESCRIPTION
Now that nonpip tests are being run, need to apply the same permissions fixes as used in the pip tests.