### PR TITLE
Restore use of py_strict_test to dtensor unit tests

### DIFF
--- a/tensorflow/dtensor/build_defs.bzl
+++ b/tensorflow/dtensor/build_defs.bzl
@@ -1,5 +1,7 @@
 """Helpers for defining multi-platform DTensor test targets."""
 
+load("//tensorflow:strict.default.bzl", "py_strict_test")
+
 # LINT.IfChange
 ALL_BACKENDS = [
     "cpu",  # 1 physical CPU,
@@ -104,7 +106,7 @@ def dtensor_test(
         shard_count = None,
         size = None,
         get_configurations = _get_configurations,
-        test_rule = native.py_test):
+        test_rule = py_strict_test):
     """Defines a set of per-platform DTensor test targets.
 
     Generates test targets named:


### PR DESCRIPTION
This will fix the dtensor pip tests