### PR TITLE
[LInaro:ARM_CI] Fix use of TF_PYTHON_VERSION for new usage

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.cpu.arm64
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu.arm64
@@ -2,8 +2,8 @@ FROM linaro/tensorflow-arm64-build:2.14-multipython
 
 ARG py_major_minor_version='3.10'
 
-ENV TF_PYTHON_VERSION=python${py_major_minor_version}
-ENV PYTHON_BIN_PATH=/usr/bin/${TF_PYTHON_VERSION}
+ENV TF_PYTHON_VERSION=${py_major_minor_version}
+ENV PYTHON_BIN_PATH=/usr/bin/python${TF_PYTHON_VERSION}
 
 RUN ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python && \
     ln -s ${PYTHON_BIN_PATH} /usr/local/bin/python3 && \

--- a/tensorflow/tools/ci_build/builds/pip_new.sh
+++ b/tensorflow/tools/ci_build/builds/pip_new.sh
@@ -25,7 +25,7 @@
 # Required environment variable(s):
 #   CONTAINER_TYPE:      (CPU | GPU)
 #   OS_TYPE:             (UBUNTU | MACOS)
-#   TF_PYTHON_VERSION:   ( python3.6 | python3.7 | python3.8 )
+#   TF_PYTHON_VERSION:   ( 3.8 | 3.9 | 3.10 | 3.11 )
 #   TF_BUILD_FLAGS:      Bazel build flags.
 #                          e.g. TF_BUILD_FLAGS="--config=opt"
 #   TF_TEST_FLAGS:       Bazel test flags.
@@ -247,7 +247,7 @@ source "${SCRIPT_DIR}/builds_common.sh"
 # Checks on values for these vars are done in "Build TF PIP Package" section.
 CONTAINER_TYPE=$(lowercase "${CONTAINER_TYPE}")
 OS_TYPE=$(lowercase "${OS_TYPE}")
-PYTHON_VER=$(lowercase "${TF_PYTHON_VERSION}")
+PYTHON_VER=python${TF_PYTHON_VERSION}
 
 # Python bin path
 if [[ -z "$PYTHON_BIN_PATH" ]]; then

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -55,9 +55,9 @@ export TF_NEED_TENSORRT=0
 export OS_TYPE="UBUNTU"
 export CONTAINER_TYPE="CPU"
 
-${TF_PYTHON_VERSION} -m pip install --upgrade pip wheel
-${TF_PYTHON_VERSION} -m pip install --upgrade setuptools
-${TF_PYTHON_VERSION} -m pip install -r tensorflow/tools/ci_build/release/requirements_ubuntu.txt
+python${TF_PYTHON_VERSION} -m pip install --upgrade pip wheel
+python${TF_PYTHON_VERSION} -m pip install --upgrade setuptools
+python${TF_PYTHON_VERSION} -m pip install -r tensorflow/tools/ci_build/release/requirements_ubuntu.txt
 sudo touch /custom_sponge_config.csv
 sudo chown ${CI_BUILD_USER}:${CI_BUILD_GROUP} /custom_sponge_config.csv
 

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_py310_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_py310_pip.sh
@@ -24,11 +24,11 @@ install_bazelisk
 # Export required variables for running pip.sh
 export OS_TYPE="UBUNTU"
 export CONTAINER_TYPE="CPU"
-export TF_PYTHON_VERSION='python3.10'
+export TF_PYTHON_VERSION='3.10'
 
 # Setup virtual environment and install dependencies
-setup_venv_ubuntu ${TF_PYTHON_VERSION}
-export PYTHON_BIN_PATH="$(which ${TF_PYTHON_VERSION})"
+setup_venv_ubuntu python${TF_PYTHON_VERSION}
+export PYTHON_BIN_PATH="$(which python${TF_PYTHON_VERSION})"
 
 # Get the default test targets for bazel.
 source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_py38_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_py38_pip.sh
@@ -24,8 +24,8 @@ install_bazelisk
 # Export required variables for running pip.sh
 export OS_TYPE="UBUNTU"
 export CONTAINER_TYPE="CPU"
-export TF_PYTHON_VERSION='python3.8'
-export PYTHON_BIN_PATH="$(which ${TF_PYTHON_VERSION})"
+export TF_PYTHON_VERSION='3.8'
+export PYTHON_BIN_PATH="$(which python${TF_PYTHON_VERSION})"
 
 # Get the default test targets for bazel.
 source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_py39_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_py39_pip.sh
@@ -24,8 +24,8 @@ install_bazelisk
 # Export required variables for running pip.sh
 export OS_TYPE="UBUNTU"
 export CONTAINER_TYPE="CPU"
-export TF_PYTHON_VERSION='python3.9'
-export PYTHON_BIN_PATH="$(which ${TF_PYTHON_VERSION})"
+export TF_PYTHON_VERSION='3.9'
+export PYTHON_BIN_PATH="$(which python${TF_PYTHON_VERSION})"
 
 # Get the default test targets for bazel.
 source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh

--- a/tensorflow/tools/ci_build/rel/ubuntu/gpu_py310_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/gpu_py310_pip.sh
@@ -23,11 +23,11 @@ install_bazelisk
 # Export required variables for running pip.sh
 export OS_TYPE="UBUNTU"
 export CONTAINER_TYPE="GPU"
-export TF_PYTHON_VERSION='python3.10'
+export TF_PYTHON_VERSION='3.10'
 
 # Setup virtual environment and install dependencies
-setup_venv_ubuntu ${TF_PYTHON_VERSION}
-export PYTHON_BIN_PATH="$(which ${TF_PYTHON_VERSION})"
+setup_venv_ubuntu python${TF_PYTHON_VERSION}
+export PYTHON_BIN_PATH="$(which python${TF_PYTHON_VERSION})"
 
 # Get the default test targets for bazel.
 source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh

--- a/tensorflow/tools/ci_build/rel/ubuntu/gpu_py38_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/gpu_py38_pip.sh
@@ -23,8 +23,8 @@ install_bazelisk
 # Export required variables for running pip.sh
 export OS_TYPE="UBUNTU"
 export CONTAINER_TYPE="GPU"
-export TF_PYTHON_VERSION='python3.8'
-export PYTHON_BIN_PATH="$(which ${TF_PYTHON_VERSION})"
+export TF_PYTHON_VERSION='3.8'
+export PYTHON_BIN_PATH="$(which python${TF_PYTHON_VERSION})"
 
 # Get the default test targets for bazel.
 source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh

--- a/tensorflow/tools/ci_build/rel/ubuntu/gpu_py39_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/gpu_py39_pip.sh
@@ -23,8 +23,8 @@ install_bazelisk
 # Export required variables for running pip.sh
 export OS_TYPE="UBUNTU"
 export CONTAINER_TYPE="GPU"
-export TF_PYTHON_VERSION='python3.9'
-export PYTHON_BIN_PATH="$(which ${TF_PYTHON_VERSION})"
+export TF_PYTHON_VERSION='3.9'
+export PYTHON_BIN_PATH="$(which python${TF_PYTHON_VERSION})"
 
 # Get the default test targets for bazel.
 source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh


### PR DESCRIPTION
For hermetic python, TF_PYTHON_VERSION is being used but with different semantics so update usage to match.