### PR TITLE
Optional supported_types argument for quantization with lite.TFLiteConverter

### DIFF
--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -970,27 +970,27 @@ class TFLiteConverterBase:
 
     if quant_mode.is_post_training_float16_quantization():
       self._metadata.options.modelOptimizationModes.append(
-          conversion_metdata_fb.ModelOptimizationMode.PTQ_FLOAT16
+        conversion_metdata_fb.ModelOptimizationMode.PTQ_FLOAT16
       )
 
     if quant_mode.is_post_training_dynamic_range_quantization():
       self._metadata.options.modelOptimizationModes.append(
-          conversion_metdata_fb.ModelOptimizationMode.PTQ_DYNAMIC_RANGE
+        conversion_metdata_fb.ModelOptimizationMode.PTQ_DYNAMIC_RANGE
       )
 
     if quant_mode.is_post_training_int8_quantization():
       self._metadata.options.modelOptimizationModes.append(
-          conversion_metdata_fb.ModelOptimizationMode.PTQ_FULL_INTEGER
+        conversion_metdata_fb.ModelOptimizationMode.PTQ_FULL_INTEGER
       )
 
     if quant_mode.is_post_training_int16x8_quantization():
       self._metadata.options.modelOptimizationModes.append(
-          conversion_metdata_fb.ModelOptimizationMode.PTQ_INT16
+        conversion_metdata_fb.ModelOptimizationMode.PTQ_INT16
       )
 
     if quant_mode.is_quantization_aware_training():
       self._metadata.options.modelOptimizationModes.append(
-          conversion_metdata_fb.ModelOptimizationMode.QUANTIZATION_AWARE_TRAINING
+        conversion_metdata_fb.ModelOptimizationMode.QUANTIZATION_AWARE_TRAINING
       )
 
   def _set_conversion_latency_metric(self, value):

--- a/tensorflow/lite/python/lite.py
+++ b/tensorflow/lite/python/lite.py
@@ -1927,7 +1927,7 @@ class TFLiteConverterV2(TFLiteFrozenGraphConverterV2):
   """  # fmt: skip
 
   # pylint: disable=useless-super-delegation
-  def __init__(self, funcs, trackable_obj=None):
+  def __init__(self, funcs, trackable_obj=None, supported_types=None):
     """Constructor for TFLiteConverter.
 
     Args:
@@ -1940,6 +1940,8 @@ class TFLiteConverterV2(TFLiteFrozenGraphConverterV2):
         maintained by the user (e.g. `from_saved_model`).
     """
     super(TFLiteConverterV2, self).__init__(funcs, trackable_obj)
+    if supported_types is not None:
+      self.target_spec.supported_types = supported_types
 
   @classmethod
   def from_concrete_functions(cls, funcs, trackable_obj=None):

--- a/tensorflow/lite/python/lite_test.py
+++ b/tensorflow/lite/python/lite_test.py
@@ -2925,5 +2925,48 @@ class QuantizationModeTest(LiteTest, parameterized.TestCase):
     logging.root.removeHandler(handler)
 
 
+class TestTFLiteConverterV2(LiteTest):
+
+  def test_int8_supported_type(self):
+    """Tests if the supported_types attribute can be set to [tf.int8]."""
+
+    # Create a Keras model.
+    model = keras.models.Sequential([
+      keras.layers.Dense(units=1, input_shape=[1])
+    ])
+
+    # Prepare the converter.
+    converter = lite.TFLiteConverter.from_keras_model(model)
+    converter.target_spec.supported_types = [dtypes.int8]
+    tflite_model = converter.convert()
+
+    # Load TFLite model and allocate tensors.
+    interpreter = lite.Interpreter(model_content=tflite_model)
+    interpreter.allocate_tensors()
+
+    # Get input and output tensors.
+    input_details = interpreter.get_input_details()
+    output_details = interpreter.get_output_details()
+
+    # Check if input and output types are as expected.
+    self.assertEqual(input_details[0]['dtype'], np.int8)
+    self.assertEqual(output_details[0]['dtype'], np.int8)
+
+  def test_default_supported_type(self):
+    """Tests if the supported_types attribute defaults to None."""
+
+    # Create a Keras model.
+    model = keras.models.Sequential([
+      keras.layers.Dense(units=1, input_shape=[1])
+    ])
+
+    # Prepare the converter without specifying supported types.
+    converter = lite.TFLiteConverter.from_keras_model(model)
+
+    # Assert that the default value of supported_types is None
+    self.assertIsNone(converter.target_spec.supported_types)
+
+
+
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/lite/python/lite_test.py
+++ b/tensorflow/lite/python/lite_test.py
@@ -2270,11 +2270,13 @@ class FromKerasFile(TestModels, parameterized.TestCase):
     model.train_on_batch(x, y)
     model.predict(x)
 
+    fd = None
     try:
       fd, self._keras_file = tempfile.mkstemp('.h5')
       keras.models.save_model(model, self._keras_file)
     finally:
-      os.close(fd)
+      if fd is not None:
+        os.close(fd)
 
     if include_custom_layer:
       self._custom_objects = {'MyAddLayer': MyAddLayer}


### PR DESCRIPTION
This is a fix for issue https://github.com/tensorflow/tensorflow/issues/60884. If we initialize some ```TFLiteConverter``` object ```converter = tf.lite.TFLiteConverter.from_keras_model(model)```, then in order to customize quantization, we must first change our converter's supported types. For example, before running
```
converter.target_spec.supported_ops = [
    tf.lite.OpsSet.TFLITE_BUILTINS,
    tf.lite.OpsSet.EXPERIMENTAL_TFLITE_BUILTINS_ACTIVATIONS_INT16_WEIGHTS_INT8
]
```
we must run ```converter.target_spec.supported_types = [tf.int8]```. This behaviour is clunky and the extra line goes undocumented. The proposed changes allow us to omit ```converter.target_spec.supported_types = [tf.int8]``` and simply change our ```supported_types``` during the initialization of our converter:
```converter = tf.lite.TFLiteConverter.from_keras_model(model, supported_types=[tf.int8])```.