### PR TITLE
[ROCm] Support of hipblaslt

### DIFF
--- a/tensorflow/compiler/xla/pjrt/gpu/nccl_id_store.cc
+++ b/tensorflow/compiler/xla/pjrt/gpu/nccl_id_store.cc
@@ -20,6 +20,7 @@ limitations under the License.
 
 #ifdef NCCL_ENABLED
 #if TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
 #if (TF_ROCM_VERSION >= 50200)
 #include "rocm/include/rccl/rccl.h"
 #else

--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -15,6 +15,7 @@ load("//tensorflow/tsl:tsl.bzl", "if_google", "if_nccl", "tsl_copts", "tsl_gpu_l
 load(
     "@local_config_rocm//rocm:build_defs.bzl",
     "if_rocm_is_configured",
+    "if_rocm_hipblaslt",
 )
 load("//tensorflow/compiler/xla:xla.bzl", "xla_cc_test")
 load("//tensorflow/compiler/xla/tests:build_defs.bzl", "xla_test")
@@ -404,7 +405,6 @@ cc_library(
     ] + if_gpu_is_configured([
         ":triangular_solve_thunk",
         ":cholesky_thunk",
-    ]) + if_cuda_is_configured([
         ":cublas_lt_matmul_thunk",
         ":ir_emitter_triton",
     ]),
@@ -412,8 +412,9 @@ cc_library(
 
 cc_library(
     name = "ir_emitter_triton",
-    srcs = if_cuda_is_configured(["ir_emitter_triton.cc"]),
-    hdrs = if_cuda_is_configured(["ir_emitter_triton.h"]),
+    srcs = if_cuda_is_configured(["ir_emitter_triton.cc"])
+        + if_rocm_hipblaslt(["ir_emitter_triton.cc"]),
+    hdrs = if_gpu_is_configured(["ir_emitter_triton.h"]),
     deps = [
         ":gemm_rewriter_triton",
         ":gpu_device_info",
@@ -1201,18 +1202,22 @@ cc_library(
 
 cc_library(
     name = "cublas_lt_matmul_thunk",
-    srcs = if_cuda_is_configured(["cublas_lt_matmul_thunk.cc"]),
-    hdrs = if_cuda_is_configured(["cublas_lt_matmul_thunk.h"]),
-    deps = if_cuda_is_configured([
+    srcs = if_gpu_is_configured(["cublas_lt_matmul_thunk.cc"]),
+    hdrs = if_gpu_is_configured(["cublas_lt_matmul_thunk.h"]),
+    deps = if_gpu_is_configured([
         ":matmul_utils",
         ":thunk",
         "//tensorflow/compiler/xla/service:buffer_assignment",
         "//tensorflow/compiler/xla:status",
         "//tensorflow/compiler/xla/stream_executor:device_memory",
         "//tensorflow/compiler/xla/stream_executor:stream_executor_headers",
+        "//tensorflow/tsl/platform:logging",
+    ]) + if_cuda_is_configured([
         "//tensorflow/compiler/xla/stream_executor/cuda:cublas_lt_header",
         "//tensorflow/compiler/xla/stream_executor/cuda:cublas_plugin",
-    ]) + ["//tensorflow/tsl/platform:logging"],
+    ]) + if_rocm_is_configured([
+        "//tensorflow/compiler/xla/stream_executor/rocm:hipblas_lt_header",
+    ]),
 )
 
 cc_library(
@@ -1296,7 +1301,7 @@ cc_library(
     srcs = ["matmul_utils.cc"],
     hdrs = ["matmul_utils.h"],
     compatible_with = get_compatible_with_cloud(),
-    defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]),
+    defines = if_cuda_is_configured(["GOOGLE_CUDA=1"]) + if_rocm_is_configured(["TENSORFLOW_USE_ROCM=1"]),
     deps = [
         ":backend_configs_cc",
         ":ir_emission_utils",
@@ -1319,6 +1324,12 @@ cc_library(
         "//tensorflow/tsl/platform:tensor_float_32_hdr_lib",
         "//tensorflow/compiler/xla/stream_executor:host_or_device_scalar",
         "//tensorflow/compiler/xla/stream_executor:scratch_allocator",
+    ]) + if_rocm_is_configured([
+        "//tensorflow/compiler/xla/stream_executor/rocm:hipblas_lt_header",
+        "//tensorflow/compiler/xla/stream_executor/rocm:hipblaslt_plugin",
+        "//tensorflow/compiler/xla/stream_executor:host_or_device_scalar",
+        "//tensorflow/compiler/xla/stream_executor:scratch_allocator",
+        "//tensorflow/compiler/xla/stream_executor/platform:dso_loader",
     ]) + if_static([
         "//tensorflow/tsl/platform:tensor_float_32_utils",
     ]),

--- a/tensorflow/compiler/xla/service/gpu/cublas_lt_matmul_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/cublas_lt_matmul_thunk.cc
@@ -14,13 +14,17 @@ limitations under the License.
 ==============================================================================*/
 
 #include "tensorflow/compiler/xla/service/gpu/cublas_lt_matmul_thunk.h"
-
+#if GOOGLE_CUDA || TF_HIPBLASLT
 #include <utility>
 
 #include "tensorflow/compiler/xla/service/gpu/matmul_utils.h"
 #include "tensorflow/compiler/xla/service/gpu/thunk.h"
 #include "tensorflow/compiler/xla/status.h"
+#if GOOGLE_CUDA
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_blas_lt.h"
+#else
+#include "tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.h"
+#endif
 #include "tensorflow/compiler/xla/stream_executor/device_memory.h"
 #include "tensorflow/tsl/platform/logging.h"
 
@@ -53,7 +57,7 @@ CublasLtMatmulThunk::CublasLtMatmulThunk(
 Status CublasLtMatmulThunk::ExecuteOnStream(const ExecuteParams& params) {
   if (!algorithm_) {
     TF_ASSIGN_OR_RETURN(
-        std::vector<se::cuda::BlasLt::MatmulAlgorithm> algorithms,
+        std::vector<se::gpu::BlasLt::MatmulAlgorithm> algorithms,
         plan_.GetAlgorithms(params.stream));
     TF_RET_CHECK(algorithm_idx_ >= 0 && algorithm_idx_ < algorithms.size());
     algorithm_ = algorithms[algorithm_idx_];
@@ -98,3 +102,5 @@ Status CublasLtMatmulThunk::ExecuteOnStream(const ExecuteParams& params) {
 
 }  // namespace gpu
 }  // namespace xla
+
+#endif

--- a/tensorflow/compiler/xla/service/gpu/cublas_lt_matmul_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/cublas_lt_matmul_thunk.h
@@ -16,6 +16,11 @@ limitations under the License.
 #ifndef TENSORFLOW_COMPILER_XLA_SERVICE_GPU_CUBLAS_LT_MATMUL_THUNK_H_
 #define TENSORFLOW_COMPILER_XLA_SERVICE_GPU_CUBLAS_LT_MATMUL_THUNK_H_
 
+#if TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#endif
+
+#if GOOGLE_CUDA || TF_HIPBLASLT
 #include <optional>
 #include <utility>
 
@@ -23,7 +28,11 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/gpu/matmul_utils.h"
 #include "tensorflow/compiler/xla/service/gpu/thunk.h"
 #include "tensorflow/compiler/xla/status.h"
+#if GOOGLE_CUDA
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_blas_lt.h"
+#else
+#include "tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.h"
+#endif
 
 namespace xla {
 namespace gpu {
@@ -59,10 +68,11 @@ class CublasLtMatmulThunk : public Thunk {
   BufferAllocation::Slice c_scale_buffer_;
   BufferAllocation::Slice d_scale_buffer_;
   BufferAllocation::Slice d_amax_buffer_;
-  std::optional<se::cuda::BlasLt::MatmulAlgorithm> algorithm_;
+  std::optional<se::gpu::BlasLt::MatmulAlgorithm> algorithm_;
 };
 
 }  // namespace gpu
 }  // namespace xla
 
+#endif // GOOGLE_CUDA || TF_HIPBLASLT
 #endif  // TENSORFLOW_COMPILER_XLA_SERVICE_GPU_CUBLAS_LT_MATMUL_THUNK_H_

--- a/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_rewriter.cc
@@ -673,8 +673,10 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
                                     bool b_mult_scale,
                                     std::vector<HloInstruction *> a_unary_ops,
                                     std::vector<HloInstruction *> b_unary_ops) {
+#if GOOGLE_CUDA
     auto cuda_compute_capability_ =
         std::get<se::CudaComputeCapability>(gpu_version_);
+
     // FP8 GEMM kernels are only available on Hopper and newer architectures.
     if (!cuda_compute_capability_.IsAtLeast(
             se::CudaComputeCapability::HOPPER)) {
@@ -933,6 +935,9 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
     TF_RETURN_IF_ERROR(
         ReplaceInstruction(add ? add : instr, slice ? slice : new_custom_call));
     return true;
+#else
+    return false;
+#endif
   }
 
   Status F8ConvertD(HloInstruction *instr, HloInstruction *existing_gemm,
@@ -1521,6 +1526,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
                    DataType /*output_dtype*/>,
         32>
         supported_type_combinations = {{
+#if GOOGLE_CUDA
             // FP8 types:
             {ComputationType::kF32, DataType::kFloat, PrimitiveType::F8E4M3FN,
              PrimitiveType::F8E4M3FN, DataType::kBF16},
@@ -1552,7 +1558,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
              PrimitiveType::F8E4M3FN, DataType::kHalf},
             {ComputationType::kF32, DataType::kFloat, PrimitiveType::F8E5M2,
              PrimitiveType::F8E4M3FN, DataType::kFloat},
-
+#endif
             // Other data types:
             {ComputationType::kF16, DataType::kHalf, PrimitiveType::F16,
              PrimitiveType::F16, DataType::kHalf},
@@ -1574,12 +1580,14 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
              PrimitiveType::F16, DataType::kFloat},
             {ComputationType::kF32, DataType::kFloat, PrimitiveType::F32,
              PrimitiveType::F32, DataType::kFloat},
-
+#if GOOGLE_CUDA
             // There would be an entry here for A/BType complex int8, but we do
             // not support that type.
             {ComputationType::kF32, DataType::kComplexFloat, PrimitiveType::C64,
              PrimitiveType::C64, DataType::kComplexFloat},
 
+            // The next 4 may be supported by hipblaslt, but they are not
+            // covered by any unit tests
             {ComputationType::kF16AsF32, DataType::kFloat, PrimitiveType::F32,
              PrimitiveType::F32, DataType::kFloat},
             {ComputationType::kF16AsF32, DataType::kComplexFloat,
@@ -1600,6 +1608,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
             {ComputationType::kF64, DataType::kComplexDouble,
              PrimitiveType::C128, PrimitiveType::C128,
              DataType::kComplexDouble},
+#endif
         }};
 
     return absl::c_linear_search(
@@ -1674,6 +1683,19 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       return false;
     }
 
+    TF_ASSIGN_OR_RETURN(bool output_is_column_major,
+                        MatrixIsColumnMajor(instr, gemm_backend_config));
+#if TENSORFLOW_USE_ROCM
+    if (!output_is_column_major)
+      return false;
+
+    auto rocm_compute_capability_ =
+        std::get<se::RocmComputeCapability>(gpu_version_);
+    // as of ROCm 5.5, hipblaslt only supports MI200.
+    if(rocm_compute_capability_.gcn_arch_name().substr(0,6) != "gfx90a")
+        return false;
+#endif
+
     // 2. cublasLt does not support rhs col dimension size > 4194240 for
     // C64.
     constexpr int kMaxDimensionSize{4194240};
@@ -1681,7 +1703,7 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       // Does not match type in unsupported case.
       return true;
     }
-
+#if GOOGLE_CUDA
     auto cuda_compute_capability_ =
         std::get<se::CudaComputeCapability>(gpu_version_);
     if (cuda_compute_capability_.IsAtLeast(se::CudaComputeCapability::AMPERE)) {
@@ -1691,15 +1713,13 @@ class GemmRewriterVisitor : public DfsHloRewriteVisitor {
       // architecture though (where TF32 was introduced).
       return true;
     }
-
+#endif
     // Get the rhs non-contracting dimensions as they will eventually be at the
     // cublasLt level.
     std::vector<int64_t> rhs_non_contracting_dims;
     const DotDimensionNumbers &dot_dims =
         gemm_backend_config.dot_dimension_numbers();
 
-    TF_ASSIGN_OR_RETURN(bool output_is_column_major,
-                        MatrixIsColumnMajor(instr, gemm_backend_config));
     if (!output_is_column_major) {
       // cublasLt's matmul output is column major by default. This gemm requires
       // the output to be in row major. Later we will swap lhs & rhs (and

--- a/tensorflow/compiler/xla/service/gpu/gemm_rewriter.h
+++ b/tensorflow/compiler/xla/service/gpu/gemm_rewriter.h
@@ -24,6 +24,11 @@ limitations under the License.
 
 namespace xla {
 namespace gpu {
+#if GOOGLE_CUDA
+using ComputeCap = se::CudaComputeCapability;
+#else
+using ComputeCap = se::RocmComputeCapability;
+#endif
 
 // cuBLAS GEMM in the most general form can run the following operation:
 //

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.h
@@ -197,8 +197,10 @@ class IrEmitterUnnested : public IrEmitter {
   Status EmitConditional(mlir::Operation* op);
   Status EmitConvolutionThunk(mlir::Operation* op);
   Status EmitGemmThunk(mlir::Operation* op);
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TF_HIPBLASLT
   Status EmitCublasLtMatmulThunk(mlir::Operation* op);
+#endif
+#if GOOGLE_CUDA
   Status EmitCublasLtMatmulThunkF8(mlir::Operation* op);
   Status EmitConvolutionReorderThunk(mlir::Operation* op);
   Status EmitTritonFusion(

--- a/tensorflow/compiler/xla/service/gpu/matmul_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/matmul_utils.cc
@@ -768,22 +768,32 @@ StatusOr<se::blas::DataType> AsBlasDataType(PrimitiveType dtype) {
   }
 }
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TF_HIPBLASLT
 
 namespace {
 
-StatusOr<se::cuda::BlasLt::MatrixLayout> AsBlasLtMatrixLayout(
+StatusOr<se::gpu::BlasLt::MatrixLayout> AsBlasLtMatrixLayout(
     const MatrixLayout& layout) {
   TF_ASSIGN_OR_RETURN(se::blas::DataType dtype, AsBlasDataType(layout.dtype));
 
   auto order = (layout.order == MatrixLayout::Order::kColumnMajor)
-                   ? se::cuda::BlasLt::MatrixLayout::Order::kColumnMajor
-                   : se::cuda::BlasLt::MatrixLayout::Order::kRowMajor;
+                   ? se::gpu::BlasLt::MatrixLayout::Order::kColumnMajor
+                   : se::gpu::BlasLt::MatrixLayout::Order::kRowMajor;
 
-  return se::cuda::BlasLt::MatrixLayout::Create(
+  return se::gpu::BlasLt::MatrixLayout::Create(
       dtype, layout.num_rows, layout.num_cols, order, layout.batch_size,
       layout.leading_dim_stride, layout.batch_stride);
 }
+
+#if TF_HIPBLASLT
+using cudaDataType_t = hipblasDatatype_t;
+#define CUDA_R_16BF HIPBLAS_R_16B
+#define CUDA_R_16F HIPBLAS_R_16F
+#define CUDA_R_32F HIPBLAS_R_32F
+#define CUDA_R_64F HIPBLAS_R_64F
+#define CUDA_C_32F HIPBLAS_C_32F
+#define CUDA_C_64F HIPBLAS_C_64F
+#endif
 
 template <cudaDataType_t CudaT>
 struct CudaToNativeT;
@@ -828,31 +838,31 @@ struct CudaToNativeT<CUDA_C_64F> {
 
 namespace cublas_lt {
 
-StatusOr<se::cuda::BlasLt::Epilogue> AsBlasLtEpilogue(
+StatusOr<se::gpu::BlasLt::Epilogue> AsBlasLtEpilogue(
     mlir::lmhlo_gpu::CublasLtMatmulEpilogue epilogue) {
   switch (epilogue) {
     case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::Default:
-      return se::cuda::BlasLt::Epilogue::kDefault;
+      return se::gpu::BlasLt::Epilogue::kDefault;
     case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::Relu:
-      return se::cuda::BlasLt::Epilogue::kReLU;
+      return se::gpu::BlasLt::Epilogue::kReLU;
     case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::Gelu:
-      return se::cuda::BlasLt::Epilogue::kGELU;
+      return se::gpu::BlasLt::Epilogue::kGELU;
     case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::GeluAux:
-      return se::cuda::BlasLt::Epilogue::kGELUWithAux;
+      return se::gpu::BlasLt::Epilogue::kGELUWithAux;
     case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::Bias:
-      return se::cuda::BlasLt::Epilogue::kBias;
+      return se::gpu::BlasLt::Epilogue::kBias;
     case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::BiasRelu:
-      return se::cuda::BlasLt::Epilogue::kBiasThenReLU;
+      return se::gpu::BlasLt::Epilogue::kBiasThenReLU;
     case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::BiasGelu:
-      return se::cuda::BlasLt::Epilogue::kBiasThenGELU;
+      return se::gpu::BlasLt::Epilogue::kBiasThenGELU;
     case mlir::lmhlo_gpu::CublasLtMatmulEpilogue::BiasGeluAux:
-      return se::cuda::BlasLt::Epilogue::kBiasThenGELUWithAux;
+      return se::gpu::BlasLt::Epilogue::kBiasThenGELUWithAux;
   }
   return InternalError("unexpected epilogue value");
 }
 
 /*static*/ StatusOr<MatmulPlan> MatmulPlan::From(
-    const GemmConfig& config, se::cuda::BlasLt::Epilogue epilogue) {
+    const GemmConfig& config, se::gpu::BlasLt::Epilogue epilogue) {
   MatrixLayout lhs_layout = config.lhs_layout;
   MatrixLayout rhs_layout = config.rhs_layout;
   MatrixLayout output_layout = config.output_layout;
@@ -893,22 +903,22 @@ StatusOr<se::cuda::BlasLt::Epilogue> AsBlasLtEpilogue(
                              config.compute_precision));
 
   TF_ASSIGN_OR_RETURN(
-      se::cuda::BlasLt::MatmulDesc op_desc,
-      se::cuda::BlasLt::MatmulDesc::Create(
+      se::gpu::BlasLt::MatmulDesc op_desc,
+      se::gpu::BlasLt::MatmulDesc::Create(
           computation_type, GetScaleType(output_dtype, computation_type),
           trans_a, trans_b, epilogue));
 
-  TF_ASSIGN_OR_RETURN(se::cuda::BlasLt::MatrixLayout a_desc,
+  TF_ASSIGN_OR_RETURN(se::gpu::BlasLt::MatrixLayout a_desc,
                       AsBlasLtMatrixLayout(lhs_layout));
-  TF_ASSIGN_OR_RETURN(se::cuda::BlasLt::MatrixLayout b_desc,
+  TF_ASSIGN_OR_RETURN(se::gpu::BlasLt::MatrixLayout b_desc,
                       AsBlasLtMatrixLayout(rhs_layout));
-  TF_ASSIGN_OR_RETURN(se::cuda::BlasLt::MatrixLayout c_desc,
+  TF_ASSIGN_OR_RETURN(se::gpu::BlasLt::MatrixLayout c_desc,
                       AsBlasLtMatrixLayout(c_layout));
-  TF_ASSIGN_OR_RETURN(se::cuda::BlasLt::MatrixLayout d_desc,
+  TF_ASSIGN_OR_RETURN(se::gpu::BlasLt::MatrixLayout d_desc,
                       AsBlasLtMatrixLayout(output_layout));
 
   return MatmulPlan{
-      se::cuda::BlasLt::MatmulPlan{std::move(op_desc), std::move(a_desc),
+      se::gpu::BlasLt::MatmulPlan{std::move(op_desc), std::move(a_desc),
                                    std::move(b_desc), std::move(c_desc),
                                    std::move(d_desc)},
       config.alpha, config.beta, must_swap_operands};
@@ -922,10 +932,10 @@ Status MatmulPlan::DoMatmul(
     se::DeviceMemoryBase aux_buffer, se::DeviceMemoryBase a_scale_buffer,
     se::DeviceMemoryBase b_scale_buffer, se::DeviceMemoryBase c_scale_buffer,
     se::DeviceMemoryBase d_scale_buffer, se::DeviceMemoryBase d_amax_buffer,
-    const se::cuda::BlasLt::MatmulAlgorithm& algorithm,
+    const se::gpu::BlasLt::MatmulAlgorithm& algorithm,
     se::ScratchAllocator& scratch_allocator,
     se::blas::ProfileResult* profile_result) const {
-  se::cuda::BlasLt* blas_lt = se::cuda::GetBlasLt(stream);
+  se::gpu::BlasLt* blas_lt = se::gpu::GetBlasLt(stream);
   TF_RET_CHECK(blas_lt != nullptr);
 
   Scale alpha;
@@ -958,7 +968,7 @@ Status MatmulPlan::ExecuteOnStream(
     se::DeviceMemoryBase aux_buffer, se::DeviceMemoryBase a_scale_buffer,
     se::DeviceMemoryBase b_scale_buffer, se::DeviceMemoryBase c_scale_buffer,
     se::DeviceMemoryBase d_scale_buffer, se::DeviceMemoryBase d_amax_buffer,
-    const se::cuda::BlasLt::MatmulAlgorithm& algorithm,
+    const se::gpu::BlasLt::MatmulAlgorithm& algorithm,
     se::ScratchAllocator& scratch_allocator,
     se::blas::ProfileResult* profile_result) const {
   if (must_swap_operands_) {
@@ -1030,19 +1040,19 @@ Status MatmulPlan::ExecuteOnStream(
   return InternalError("Unexpected dtype");
 }
 
-StatusOr<std::vector<se::cuda::BlasLt::MatmulAlgorithm>>
+StatusOr<std::vector<se::gpu::BlasLt::MatmulAlgorithm>>
 MatmulPlan::GetAlgorithms(se::Stream* stream) const {
-  se::cuda::BlasLt* blas_lt = se::cuda::GetBlasLt(stream);
+  se::gpu::BlasLt* blas_lt = se::gpu::GetBlasLt(stream);
   TF_RET_CHECK(blas_lt != nullptr);
   TF_ASSIGN_OR_RETURN(auto preference,
-                      se::cuda::BlasLt::MatmulPreference::Create(
+                      se::gpu::BlasLt::MatmulPreference::Create(
                           /*max_workspace_size=*/1ll << 32));  // 4GB
   return blas_lt->GetMatmulAlgorithms(plan_, preference);
 }
 
 }  // namespace cublas_lt
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TF_HIPBLASLT
 
 }  // namespace gpu
 }  // namespace xla

--- a/tensorflow/compiler/xla/service/gpu/matmul_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/matmul_utils.h
@@ -31,11 +31,20 @@ limitations under the License.
 #include "tensorflow/compiler/xla/stream_executor/blas.h"
 #include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/compiler/xla/xla_data.pb.h"
-
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#endif
 #if GOOGLE_CUDA
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_blas_lt.h"
 #include "tensorflow/compiler/xla/stream_executor/scratch_allocator.h"
 #endif  // GOOGLE_CUDA
+
+#if TENSORFLOW_USE_ROCM
+#if TF_HIPBLASLT
+#include "tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.h"
+#include "tensorflow/compiler/xla/stream_executor/scratch_allocator.h"
+#endif  // TF_HIPBLASLT
+#endif
 
 namespace xla {
 namespace gpu {
@@ -153,11 +162,11 @@ StatusOr<bool> EpilogueHasAuxiliaryOutput(GemmBackendConfig_Epilogue epilogue);
 
 StatusOr<se::blas::DataType> AsBlasDataType(PrimitiveType dtype);
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TF_HIPBLASLT
 
 namespace cublas_lt {
 
-StatusOr<se::cuda::BlasLt::Epilogue> AsBlasLtEpilogue(
+StatusOr<se::gpu::BlasLt::Epilogue> AsBlasLtEpilogue(
     mlir::lmhlo_gpu::CublasLtMatmulEpilogue epilogue);
 
 class MatmulPlan {
@@ -199,13 +208,13 @@ class MatmulPlan {
             op.getAlphaImag().convertToDouble(), op.getBeta().convertToDouble(),
             op.getAlgorithm(), compute_precision));
 
-    TF_ASSIGN_OR_RETURN(se::cuda::BlasLt::Epilogue epilogue,
+    TF_ASSIGN_OR_RETURN(se::gpu::BlasLt::Epilogue epilogue,
                         AsBlasLtEpilogue(op.getEpilogue()));
     return From(config, epilogue);
   }
 
   static StatusOr<MatmulPlan> From(const GemmConfig& config,
-                                   se::cuda::BlasLt::Epilogue epilogue);
+                                   se::gpu::BlasLt::Epilogue epilogue);
 
   Status ExecuteOnStream(
       se::Stream* stream, se::DeviceMemoryBase a_buffer,
@@ -216,15 +225,15 @@ class MatmulPlan {
       se::DeviceMemoryBase a_scale_buffer, se::DeviceMemoryBase b_scale_buffer,
       se::DeviceMemoryBase c_scale_buffer, se::DeviceMemoryBase d_scale_buffer,
       se::DeviceMemoryBase d_amax_buffer,
-      const se::cuda::BlasLt::MatmulAlgorithm& algorithm,
+      const se::gpu::BlasLt::MatmulAlgorithm& algorithm,
       se::ScratchAllocator& scratch_allocator,
       se::blas::ProfileResult* profile_result = nullptr) const;
 
-  StatusOr<std::vector<se::cuda::BlasLt::MatmulAlgorithm>> GetAlgorithms(
+  StatusOr<std::vector<se::gpu::BlasLt::MatmulAlgorithm>> GetAlgorithms(
       se::Stream* stream) const;
 
  private:
-  MatmulPlan(se::cuda::BlasLt::MatmulPlan plan, complex128 alpha, double beta,
+  MatmulPlan(se::gpu::BlasLt::MatmulPlan plan, complex128 alpha, double beta,
              bool must_swap_operands)
       : plan_(std::move(plan)),
         alpha_(alpha),
@@ -241,11 +250,11 @@ class MatmulPlan {
                   se::DeviceMemoryBase a_scale, se::DeviceMemoryBase b_scale,
                   se::DeviceMemoryBase c_scale, se::DeviceMemoryBase d_scale,
                   se::DeviceMemoryBase d_amax,
-                  const se::cuda::BlasLt::MatmulAlgorithm& algorithm,
+                  const se::gpu::BlasLt::MatmulAlgorithm& algorithm,
                   se::ScratchAllocator& scratch_allocator,
                   se::blas::ProfileResult* profile_result) const;
 
-  se::cuda::BlasLt::MatmulPlan plan_;
+  se::gpu::BlasLt::MatmulPlan plan_;
   complex128 alpha_;
   double beta_;
   bool must_swap_operands_;

--- a/tensorflow/compiler/xla/service/gpu/nccl_utils.h
+++ b/tensorflow/compiler/xla/service/gpu/nccl_utils.h
@@ -30,6 +30,7 @@ limitations under the License.
 
 // Common place for all collective thunks to include nccl/rccl headers.
 #if TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
 #if (TF_ROCM_VERSION >= 50200)
 #include "rocm/include/rccl/rccl.h"
 #else

--- a/tensorflow/compiler/xla/service/gpu/runtime/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/runtime/BUILD
@@ -424,6 +424,7 @@ cc_library(
         "//tensorflow/compiler/xla/stream_executor:scratch_allocator",
         "//tensorflow/compiler/xla/stream_executor/cuda:cublas_lt_header",
         "//tensorflow/tsl/platform:status",
+        "@local_config_rocm//rocm:rocm_headers",
     ],
 )
 

--- a/tensorflow/compiler/xla/service/gpu/runtime/cublas_lt_matmul.h
+++ b/tensorflow/compiler/xla/service/gpu/runtime/cublas_lt_matmul.h
@@ -19,10 +19,15 @@ limitations under the License.
 #include "tensorflow/compiler/xla/mlir/runtime/transforms/custom_call_encoding.h"
 #include "tensorflow/compiler/xla/runtime/custom_call_registry.h"
 
-#if GOOGLE_CUDA
+#include "rocm/rocm_config.h"
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/compiler/xla/service/gpu/matmul_utils.h"
+#if GOOGLE_CUDA
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_blas_lt.h"
+#else
+#include "tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.h"
 #endif  // GOOGLE_CUDA
+#endif
 
 namespace xla {
 namespace gpu {
@@ -34,7 +39,7 @@ void RegisterMatmulCustomCalls(runtime::DirectCustomCallRegistry& registry);
 void PopulateCublasLtMatmulAttrEncoding(
     runtime::CustomCallAttrEncodingSet& encoding);
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TF_HIPBLASLT
 // Keep cublas_lt::MatmulPlan's for all matmul instances in the executable.
 class MatmulPlans : public runtime::StateVector<cublas_lt::MatmulPlan> {};
 #endif  // GOOGLE_CUDA

--- a/tensorflow/compiler/xla/service/gpu/runtime/executable.cc
+++ b/tensorflow/compiler/xla/service/gpu/runtime/executable.cc
@@ -118,8 +118,8 @@ void RegisterXlaGpuTypeIdNames(TypeIDNameRegistry& registry) {
   RegisterConvTypeIdNames(registry);
   RegisterSendRecvTypeIdNames(registry);
 
-#if GOOGLE_CUDA
-  registry.Register<Tagged<se::cuda::BlasLt::Epilogue>>(
+#if GOOGLE_CUDA || TF_HIPBLASLT
+  registry.Register<Tagged<se::gpu::BlasLt::Epilogue>>(
       "__type_id_se_cublas_lt_epilogue");
 #endif  // GOOGLE_CUDA
 }
@@ -130,7 +130,7 @@ void RegisterXlaGpuAttrEncoding(CustomCallAttrEncodingSet& encoding) {
   PopulateDotDimsAttrEncoding(encoding);
   PopulateSendRecvAttrEncoding(encoding);
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TF_HIPBLASLT
   PopulateCublasLtMatmulAttrEncoding(encoding);
 #endif  // GOOGLE_CUDA
 }

--- a/tensorflow/compiler/xla/stream_executor/cuda/BUILD
+++ b/tensorflow/compiler/xla/stream_executor/cuda/BUILD
@@ -247,6 +247,12 @@ cc_library(
     ]) + ["//tensorflow/tsl/platform:errors"],
 )
 
+cc_library(
+    name = "cublas_lt_header_for_rocm",
+    hdrs = ["cuda_blas_lt.cc", "cuda_blas_lt.h"],
+    visibility = ["//visibility:public"],
+)
+
 alias(
     name = "cublas_lt_stub",
     actual = "//tensorflow/tsl/cuda:cublas_lt_stub",

--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_blas_lt.cc
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_blas_lt.cc
@@ -23,12 +23,18 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#if GOOGLE_CUDA
 #include "third_party/gpus/cuda/include/cublasLt.h"
 #include "third_party/gpus/cuda/include/cublas_v2.h"
+#endif
 #include "tensorflow/compiler/xla/status_macros.h"
 #include "tensorflow/compiler/xla/stream_executor/blas.h"
+#if GOOGLE_CUDA
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_blas.h"
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_blas_utils.h"
+#else
+#include "tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.h"
+#endif
 #include "tensorflow/compiler/xla/stream_executor/gpu/gpu_activation.h"
 #include "tensorflow/compiler/xla/stream_executor/gpu/gpu_helpers.h"
 #include "tensorflow/compiler/xla/stream_executor/gpu/gpu_stream.h"
@@ -48,7 +54,11 @@ limitations under the License.
   }()
 
 namespace stream_executor {
+#if GOOGLE_CUDA
 namespace cuda {
+#else
+namespace rocm {
+#endif
 namespace {
 
 template <typename T>
@@ -101,7 +111,12 @@ tsl::StatusOr<cublasLtEpilogue_t> AsCublasLtEpilogue(
       return CUBLASLT_EPILOGUE_BIAS;
     case BlasLt::Epilogue::kBiasThenReLU:
       return CUBLASLT_EPILOGUE_RELU_BIAS;
-#if CUDA_VERSION >= 11040
+#if TENSORFLOW_USE_ROCM
+    case BlasLt::Epilogue::kGELU:
+      return CUBLASLT_EPILOGUE_GELU;
+    default:
+      return tsl::errors::Internal("Unsupported epilogue");
+#elif CUDA_VERSION >= 11040
     case BlasLt::Epilogue::kGELU:
       return CUBLASLT_EPILOGUE_GELU;
     case BlasLt::Epilogue::kGELUWithAux:
@@ -145,10 +160,15 @@ tsl::Status BlasLt::Init() {
                                  num_cols, *leading_dim_stride));
   // Wrap cublas handle immediately, so it is cleaned up if an error occurs.
   BlasLt::MatrixLayout layout(cu_layout);
+#if GOOGLE_CUDA
   TF_RETURN_IF_ERROR(
       SetAttr(cu_layout, CUBLASLT_MATRIX_LAYOUT_ORDER,
               int32_t{(order == Order::kRowMajor) ? CUBLASLT_ORDER_ROW
                                                   : CUBLASLT_ORDER_COL}));
+#else
+  if(order != Order::kColumnMajor)
+    return tsl::errors::Internal("HipblasLT does not support row-major matrices");
+#endif
   TF_RETURN_IF_ERROR(SetAttr(cu_layout, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
                              static_cast<int32_t>(batch_size)));
 
@@ -162,8 +182,12 @@ tsl::Status BlasLt::Init() {
 }
 
 cudaDataType_t BlasLt::MatrixLayout::type() const {
+#if GOOGLE_CUDA
   return static_cast<cudaDataType_t>(
       GetAttr<uint32_t>(handle_.get(), CUBLASLT_MATRIX_LAYOUT_TYPE).value());
+#else
+  return HIPBLAS_R_32F;
+#endif
 }
 
 /*static*/ tsl::StatusOr<BlasLt::MatmulDesc> BlasLt::MatmulDesc::Create(
@@ -171,12 +195,20 @@ cudaDataType_t BlasLt::MatrixLayout::type() const {
     blas::Transpose trans_a, blas::Transpose trans_b, BlasLt::Epilogue epilogue,
     BlasLt::PointerMode pointer_mode) {
   cublasLtMatmulDesc_t cu_desc;
+  VLOG(2) << "BlasLt::MatmulDesc::Create compute_type" << int(compute_type) 
+      << " scale_type " << int(scale_type) << " epilogue " << int(epilogue)
+      << " pointer_mode " << int(pointer_mode);
   SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmulDescCreate(
       &cu_desc, AsCublasComputeType(compute_type), AsCudaDataType(scale_type)));
   // Wrap cublas handle immediately, so it is cleaned up if an error occurs.
   BlasLt::MatmulDesc desc(cu_desc);
+#if GOOGLE_CUDA
   TF_RETURN_IF_ERROR(SetAttr(cu_desc, CUBLASLT_MATMUL_DESC_POINTER_MODE,
                              AsCublasLtPointerMode(pointer_mode)));
+#else
+  if(pointer_mode != BlasLt::PointerMode::kHost)
+    return tsl::errors::Internal("hipblaslt does not support device pointers");
+#endif
   TF_RETURN_IF_ERROR(SetAttr(cu_desc, CUBLASLT_MATMUL_DESC_TRANSA,
                              AsCublasOperation(trans_a)));
   TF_RETURN_IF_ERROR(SetAttr(cu_desc, CUBLASLT_MATMUL_DESC_TRANSB,
@@ -187,20 +219,32 @@ cudaDataType_t BlasLt::MatrixLayout::type() const {
 }
 
 cublasComputeType_t BlasLt::MatmulDesc::compute_type() const {
+#if GOOGLE_CUDA
   return static_cast<cublasComputeType_t>(
       GetAttr<int32_t>(handle_.get(), CUBLASLT_MATMUL_DESC_COMPUTE_TYPE)
           .value());
+#else
+  return HIPBLASLT_COMPUTE_F32;
+#endif
 }
 
 cudaDataType_t BlasLt::MatmulDesc::scale_type() const {
+#if GOOGLE_CUDA
   return static_cast<cudaDataType_t>(
       GetAttr<int32_t>(handle_.get(), CUBLASLT_MATMUL_DESC_SCALE_TYPE).value());
+#else
+  return HIPBLAS_R_32F;
+#endif
 }
 
 cublasLtPointerMode_t BlasLt::MatmulDesc::pointer_mode() const {
+#if GOOGLE_CUDA
   return static_cast<cublasLtPointerMode_t>(
       GetAttr<int32_t>(handle_.get(), CUBLASLT_MATMUL_DESC_POINTER_MODE)
           .value());
+#else
+  return HIPBLAS_POINTER_MODE_HOST;
+#endif
 }
 
 /*static*/ tsl::StatusOr<BlasLt::MatmulPreference>
@@ -227,11 +271,23 @@ tsl::StatusOr<std::vector<BlasLt::MatmulAlgorithm>> BlasLt::GetMatmulAlgorithms(
     gpu::ScopedActivateExecutorContext sac{parent_};
 
     int found_algorithm_count = 0;
+/*
     SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmulAlgoGetHeuristic(
         blas_lt_.get(), plan.op_desc.get(), plan.a_desc.get(),
         plan.b_desc.get(), plan.c_desc.get(), plan.d_desc.get(),
         preference.get(), max_algorithm_count, results.data(),
         &found_algorithm_count));
+*/
+    auto error = cublasLtMatmulAlgoGetHeuristic(
+        blas_lt_.get(), plan.op_desc.get(), plan.a_desc.get(),
+        plan.b_desc.get(), plan.c_desc.get(), plan.d_desc.get(),
+        preference.get(), max_algorithm_count, results.data(),
+        &found_algorithm_count);
+    if(error != 0) {
+        printf("cublasLtMatmulAlgoGetHeuristic return %d\n", int(error));
+        fflush(stdout);
+        SE_CUBLAS_RETURN_IF_ERROR(error);
+    }
     results.resize(found_algorithm_count);
   }
 
@@ -281,6 +337,7 @@ tsl::Status BlasLt::DoMatmul(Stream* stream, const BlasLt::MatmulPlan& plan,
                                  CUBLASLT_MATMUL_DESC_BIAS_POINTER,
                                  bias.opaque()));
     }
+#if GOOGLE_CUDA
 #if CUDA_VERSION >= 11080
     if (a_scale != nullptr) {
       TF_RETURN_IF_ERROR(SetAttr(plan.op_desc.get(),
@@ -344,7 +401,18 @@ tsl::Status BlasLt::DoMatmul(Stream* stream, const BlasLt::MatmulPlan& plan,
           "Auxiliary inputs / outputs require cublasLt >= 11.4");
 #endif
     }
+#else
+    if ((a_scale != nullptr) || (b_scale != nullptr) 
+      || (c_scale != nullptr) || (d_scale != nullptr))
+      return tsl::errors::Internal("hipblaslt does not support scale");
 
+    if (d_amax != nullptr)
+      return tsl::errors::Internal("hipblaslt does not support amax");
+
+    if (aux != nullptr)
+      return tsl::errors::Internal(
+          "hipblaslt does not support auxiliary inputs / outputs");
+#endif
     gpu::ScopedActivateExecutorContext sac{parent_};
 
     SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmul(
@@ -363,7 +431,12 @@ tsl::Status BlasLt::DoMatmul(Stream* stream, const BlasLt::MatmulPlan& plan,
 }
 
 BlasLt* GetBlasLt(Stream* stream) {
-  CUDABlas* blas = dynamic_cast<CUDABlas*>(stream->parent()->AsBlas());
+#if GOOGLE_CUDA
+  using blastype = CUDABlas;
+#else
+  using blastype = gpu::ROCMBlas;
+#endif
+  blastype* blas = dynamic_cast<blastype*>(stream->parent()->AsBlas());
   return (blas != nullptr) ? &blas->blas_lt() : nullptr;
 }
 

--- a/tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.h
+++ b/tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.h
@@ -73,6 +73,7 @@ using tsl::internal::CachedDsoLoader::GetHipDsoHandle;
 using tsl::internal::CachedDsoLoader::GetHipfftDsoHandle;
 using tsl::internal::CachedDsoLoader::GetHipsolverDsoHandle;
 using tsl::internal::CachedDsoLoader::GetHipsparseDsoHandle;
+using tsl::internal::CachedDsoLoader::GetHipblasltDsoHandle;
 using tsl::internal::CachedDsoLoader::GetMiopenDsoHandle;
 using tsl::internal::CachedDsoLoader::GetRocblasDsoHandle;
 using tsl::internal::CachedDsoLoader::GetRocrandDsoHandle;

--- a/tensorflow/compiler/xla/stream_executor/rocm/BUILD
+++ b/tensorflow/compiler/xla/stream_executor/rocm/BUILD
@@ -7,7 +7,7 @@ load(
     "stream_executor_friends",
 )
 load("//tensorflow/tsl:tsl.bzl", "set_external_visibility", "tsl_copts")
-load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured", "rocm_copts")
+load("@local_config_rocm//rocm:build_defs.bzl", "if_rocm_is_configured", "rocm_copts", "if_rocm_hipblaslt")
 load("//tensorflow/tsl/platform:build_config_root.bzl", "if_static")
 
 package(
@@ -219,6 +219,7 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:span",
         "@local_config_rocm//rocm:rocm_headers",
+        ":hipblas_lt_header",
     ]),
     alwayslink = True,
 )
@@ -445,6 +446,54 @@ cc_library(
 )
 
 cc_library(
+    name = "hipblaslt_if_static",
+    deps = if_rocm_hipblaslt([
+        "@local_config_rocm//rocm:hipblaslt",
+    ]),
+)
+
+cc_library(
+    name = "hipblaslt_plugin",
+    srcs = ["hip_blas_lt.cc"],
+    hdrs = ["hip_blas_lt.h", "hipblaslt_wrapper.h"],
+    deps = [
+        ":rocm_gpu_executor",
+        ":rocm_platform_id",
+        ":rocblas_plugin",
+        ":hipblas_lt_header",
+        "@local_config_rocm//rocm:rocm_headers",
+        "//tensorflow/tsl/platform:status",
+        "//tensorflow/tsl/platform:errors",
+        "//tensorflow/compiler/xla/stream_executor/platform",
+        "//tensorflow/compiler/xla/stream_executor/platform:dso_loader",
+        "//tensorflow/compiler/xla/stream_executor:scratch_allocator",
+        "//tensorflow/compiler/xla/stream_executor/gpu:gpu_helpers_header",
+        "//tensorflow/compiler/xla:util",
+    ] + if_static([
+        ":hipblaslt_if_static",
+    ]),
+    alwayslink = True,
+)
+
+cc_library(
+    name = "hipblas_lt_header",
+    hdrs = [
+        "hip_blas_lt.h", "hipblaslt_wrapper.h"
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@local_config_rocm//rocm:rocm_headers",
+        "//tensorflow/tsl/platform:status",
+        "//tensorflow/compiler/xla/stream_executor:host_or_device_scalar",
+        "//tensorflow/compiler/xla/stream_executor:stream_executor_headers",
+        "//tensorflow/compiler/xla/stream_executor/platform",
+        "//tensorflow/compiler/xla/stream_executor/cuda:cublas_lt_header_for_rocm",
+        "//tensorflow/tsl/platform:errors",
+    ],
+)
+
+
+cc_library(
     name = "roctracer_if_static",
     deps = if_static([
         ":roctracer_if_rocm_configured",
@@ -496,6 +545,7 @@ cc_library(
         ":rocm_driver",
         ":rocm_platform",
         ":rocm_helpers",
+        ":hipblaslt_plugin"
     ]),
     alwayslink = 1,
 )

--- a/tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.cc
@@ -1,0 +1,70 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "rocm/rocm_config.h"
+
+#if TF_HIPBLASLT
+#include "tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.h"
+#include "../cuda/cuda_blas_lt.cc"
+
+namespace stream_executor {
+hipblasDatatype_t AsHipblasDataType(blas::DataType type) {
+  switch (type) {
+    case blas::DataType::kF8E5M2:
+    case blas::DataType::kF8E4M3FN:
+      LOG(FATAL) << "hipblaslt does not support F8";
+    case blas::DataType::kHalf:
+      return HIPBLAS_R_16F;
+    case blas::DataType::kBF16:
+      return HIPBLAS_R_16B;
+    case blas::DataType::kFloat:
+      return HIPBLAS_R_32F;
+    case blas::DataType::kDouble:
+      return HIPBLAS_R_64F;
+    case blas::DataType::kInt8:
+      return HIPBLAS_R_8I;
+    case blas::DataType::kInt32:
+      return HIPBLAS_R_32I;
+    case blas::DataType::kComplexFloat:
+      return HIPBLAS_C_32F;
+    case blas::DataType::kComplexDouble:
+      return HIPBLAS_C_64F;
+    default:
+      LOG(FATAL) << "unknown data type";
+  }
+}
+
+hipblasLtComputeType_t AsHipblasComputeType(blas::ComputationType type) {
+  if(type == blas::ComputationType::kF32
+    || type == blas::ComputationType::kTF32AsF32)
+    return HIPBLASLT_COMPUTE_F32;
+  else
+    LOG(FATAL) << "unsupported hipblaslt computation type";
+}
+
+hipblasOperation_t AsHipblasOperation(blas::Transpose trans) {
+  switch (trans) {
+    case blas::Transpose::kNoTranspose:
+      return HIPBLAS_OP_N;
+    case blas::Transpose::kTranspose:
+      return HIPBLAS_OP_T;
+    case blas::Transpose::kConjugateTranspose:
+      return HIPBLAS_OP_C;
+  }
+}
+
+}
+
+#endif

--- a/tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.h
+++ b/tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.h
@@ -1,0 +1,102 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_XLA_STREAM_EXECUTOR_ROCM_HIP_BLAS_LT_H_
+#define TENSORFLOW_COMPILER_XLA_STREAM_EXECUTOR_ROCM_HIP_BLAS_LT_H_
+
+#if TF_HIPBLASLT
+#define cublasStatus_t hipblasStatus_t
+#define cudaDataType_t hipblasDatatype_t
+#define cublasLtMatrixLayout_t hipblasLtMatrixLayout_t
+#define cublasComputeType_t hipblasLtComputeType_t
+#define cublasLtPointerMode_t hipblasPointerMode_t
+#define cublasLtMatmulDesc_t hipblasLtMatmulDesc_t
+#define cublasLtMatmulPreference_t hipblasLtMatmulPreference_t
+#define cublasLtMatmulAlgo_t hipblasLtMatmulAlgo_t
+#define cublasLtHandle_t hipblasLtHandle_t
+#define cublasLtMatrixLayoutAttribute_t hipblasLtMatrixLayoutAttribute_t
+#define cublasLtEpilogue_t hipblasLtEpilogue_t
+#define cublasLtMatmulDescAttributes_t hipblasLtMatmulDescAttributes_t
+#define cublasLtMatmulPreferenceAttributes_t hipblasLtMatmulPreferenceAttributes_t
+#define cublasLtMatmulHeuristicResult_t hipblasLtMatmulHeuristicResult_t
+
+#define AsCudaDataType AsHipblasDataType
+#define AsCublasLtPointerMode AsHipblasLtPointerMode
+#define AsCublasComputeType AsHipblasComputeType
+#define AsCublasOperation AsHipblasOperation
+
+#define cublasLtCreate wrap::hipblasLtCreate
+#define cublasLtMatrixLayoutCreate wrap::hipblasLtMatrixLayoutCreate
+#define cublasLtMatmulDescCreate wrap::hipblasLtMatmulDescCreate
+#define cublasLtMatmulPreferenceCreate wrap::hipblasLtMatmulPreferenceCreate
+#define cublasLtDestroy wrap::hipblasLtDestroy
+#define cublasLtMatrixLayoutDestroy wrap::hipblasLtMatrixLayoutDestroy
+#define cublasLtMatmulDescDestroy wrap::hipblasLtMatmulDescDestroy
+#define cublasLtMatmulPreferenceDestroy wrap::hipblasLtMatmulPreferenceDestroy
+#define cublasLtMatmulPreferenceSetAttribute wrap::hipblasLtMatmulPreferenceSetAttribute
+#define cublasLtMatmul wrap::hipblasLtMatmul
+#define cublasLtMatmulAlgoGetHeuristic wrap::hipblasLtMatmulAlgoGetHeuristic
+#define cublasLtMatrixLayoutSetAttribute wrap::hipblasLtMatrixLayoutSetAttribute
+#define cublasLtMatmulDescSetAttribute wrap::hipblasLtMatmulDescSetAttribute
+
+#define CUBLASLT_POINTER_MODE_DEVICE HIPBLAS_POINTER_MODE_DEVICE
+#define CUBLASLT_POINTER_MODE_HOST HIPBLAS_POINTER_MODE_HOST
+#define CUBLASLT_EPILOGUE_DEFAULT HIPBLASLT_EPILOGUE_DEFAULT
+#define CUBLASLT_EPILOGUE_RELU HIPBLASLT_EPILOGUE_RELU
+#define CUBLASLT_EPILOGUE_BIAS HIPBLASLT_EPILOGUE_BIAS
+#define CUBLASLT_EPILOGUE_RELU_BIAS HIPBLASLT_EPILOGUE_RELU_BIAS
+#define CUBLASLT_EPILOGUE_GELU HIPBLASLT_EPILOGUE_GELU
+// not supported in 5.5
+//#define CUBLASLT_EPILOGUE_GELU_AUX HIPBLASLT_EPILOGUE_GELU_AUX
+//#define CUBLASLT_EPILOGUE_GELU_BIAS HIPBLASLT_EPILOGUE_GELU_BIAS
+//#define CUBLASLT_EPILOGUE_GELU_AUX_BIAS HIPBLASLT_EPILOGUE_GELU_AUX_BIAS
+#define CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT
+#define CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET
+#define CUBLASLT_MATRIX_LAYOUT_TYPE HIPBLASLT_MATRIX_LAYOUT_TYPE
+#define CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES
+#define CUBLASLT_MATMUL_DESC_POINTER_MODE HIPBLASLT_MATMUL_DESC_POINTER_MODE
+#define CUBLASLT_MATMUL_DESC_TRANSA HIPBLASLT_MATMUL_DESC_TRANSA
+#define CUBLASLT_MATMUL_DESC_TRANSB HIPBLASLT_MATMUL_DESC_TRANSB
+#define CUBLASLT_MATMUL_DESC_EPILOGUE HIPBLASLT_MATMUL_DESC_EPILOGUE
+#define CUBLASLT_MATMUL_DESC_BIAS_POINTER HIPBLASLT_MATMUL_DESC_BIAS_POINTER
+
+#define SE_CUBLAS_RETURN_IF_ERROR SE_HIPBLAS_RETURN_IF_ERROR
+#define CUBLAS_STATUS_SUCCESS HIPBLAS_STATUS_SUCCESS
+
+#include "../cuda/cuda_blas_lt.h"
+
+namespace stream_executor {
+namespace rocm {
+inline std::string ToHipblasString(hipblasStatus_t status) {
+  //return hipblasStatusToString(status);
+  return "HipblasLt error " + std::to_string((int)status);
+}
+
+inline tsl::Status ToStatus(hipblasStatus_t status, const char* prefix) {
+  if (status != HIPBLAS_STATUS_SUCCESS) {
+    return tsl::errors::Internal(
+                        absl::StrCat(prefix, ": ", ToHipblasString(status)));
+  }
+  return tsl::OkStatus();
+}
+
+#define SE_HIPBLAS_RETURN_IF_ERROR(expr) \
+  TF_RETURN_IF_ERROR(::stream_executor::rocm::ToStatus(expr, #expr))
+}
+}  // namespace stream_executor
+
+#endif
+
+#endif  // TENSORFLOW_COMPILER_XLA_STREAM_EXECUTOR_ROCM_HIP_BLAS_LT_H_

--- a/tensorflow/compiler/xla/stream_executor/rocm/hipblaslt_wrapper.h
+++ b/tensorflow/compiler/xla/stream_executor/rocm/hipblaslt_wrapper.h
@@ -1,0 +1,99 @@
+/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file wraps rocsolver API calls with dso loader so that we don't need to
+// have explicit linking to librocsolver. All TF hipsarse API usage should route
+// through this wrapper.
+
+#ifndef TENSORFLOW_COMPILER_XLA_STREAM_EXECUTOR_ROCM_HIPBLASLT_WRAPPER_H_
+#define TENSORFLOW_COMPILER_XLA_STREAM_EXECUTOR_ROCM_HIPBLASLT_WRAPPER_H_
+
+#include "rocm/rocm_config.h"
+#if TF_ROCM_VERSION >= 50600
+#include "rocm/include/hipblaslt/hipblaslt.h"
+#else
+#include "rocm/include/hipblaslt.h"
+#endif
+#include "tensorflow/compiler/xla/stream_executor/platform/dso_loader.h"
+#include "tensorflow/compiler/xla/stream_executor/platform/port.h"
+#include "tensorflow/tsl/platform/env.h"
+
+namespace stream_executor {
+namespace wrap {
+
+#ifdef PLATFORM_GOOGLE
+
+#define HIPBLASLT_API_WRAPPER(api_name)                        \
+  template <typename... Args>                                  \
+  auto api_name(Args... args)->decltype(::api_name(args...)) { \
+    return ::api_name(args...);                                \
+  }
+
+#else
+
+#define TO_STR_(x) #x
+#define TO_STR(x) TO_STR_(x)
+
+#define HIPBLASLT_API_WRAPPER(api_name)                                       \
+  template <typename... Args>                                                 \
+  auto api_name(Args... args)->decltype(::api_name(args...)) {                \
+    using FuncPtrT = std::add_pointer<decltype(::api_name)>::type;            \
+    static FuncPtrT loaded = []() -> FuncPtrT {                               \
+      static const char* kName = TO_STR(api_name);                            \
+      void* f;                                                                \
+      auto s = tsl::Env::Default()->GetSymbolFromLibrary(   \
+          stream_executor::internal::CachedDsoLoader::GetHipblasltDsoHandle() \
+              .value(),                                                       \
+          kName, &f);                                                         \
+      CHECK(s.ok()) << "could not find " << kName                             \
+                    << " in hipblaslt lib; dlerror: " << s.message();         \
+      return reinterpret_cast<FuncPtrT>(f);                                   \
+    }();                                                                      \
+    return loaded(args...);                                                   \
+  }
+
+#endif
+
+// clang-format off
+#define FOREACH_HIPBLASLT_API(__macro)      \
+  __macro(hipblasLtCreate) \
+  __macro(hipblasLtDestroy) \
+  __macro(hipblasLtMatmulPreferenceCreate) \
+  __macro(hipblasLtMatmulPreferenceSetAttribute) \
+  __macro(hipblasLtMatmulPreferenceDestroy) \
+  __macro(hipblasLtMatmulDescSetAttribute) \
+  __macro(hipblasLtMatmulDescGetAttribute) \
+  __macro(hipblasLtMatmulAlgoGetHeuristic) \
+  __macro(hipblasLtMatrixLayoutCreate) \
+  __macro(hipblasLtMatrixLayoutDestroy) \
+  __macro(hipblasLtMatrixLayoutSetAttribute) \
+  __macro(hipblasLtMatrixLayoutGetAttribute) \
+  __macro(hipblasLtMatmulDescCreate) \
+  __macro(hipblasLtMatmulDescDestroy) \
+  __macro(hipblasLtMatmul) \
+  __macro(hipblasStatusToString)
+// clang-format on
+
+FOREACH_HIPBLASLT_API(HIPBLASLT_API_WRAPPER)
+
+#undef TO_STR_
+#undef TO_STR
+#undef FOREACH_HIPBLASLT_API
+#undef HIPBLASLT_API_WRAPPER
+
+}  // namespace wrap
+}  // namespace stream_executor
+
+#endif  // TENSORFLOW_COMPILER_XLA_STREAM_EXECUTOR_ROCM_HIPBLASLT_WRAPPER_H_

--- a/tensorflow/compiler/xla/stream_executor/rocm/hipsolver_wrapper.h
+++ b/tensorflow/compiler/xla/stream_executor/rocm/hipsolver_wrapper.h
@@ -24,7 +24,11 @@ limitations under the License.
 
 #if TF_ROCM_VERSION >= 40500
 
+#if TF_ROCM_VERSION >= 50600
+#include "rocm/include/hipsolver/hipsolver.h"
+#else
 #include "rocm/include/hipsolver.h"
+#endif
 #include "tensorflow/compiler/xla/stream_executor/platform/dso_loader.h"
 #include "tensorflow/compiler/xla/stream_executor/platform/port.h"
 #include "tensorflow/tsl/platform/env.h"

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.cc
@@ -105,11 +105,22 @@ bool ROCMBlas::Init() {
     return false;
   }
 
+#if TF_HIPBLASLT
+  if (!blas_lt_.Init().ok()) {
+    LOG(ERROR) << "Failed to initialize hipblasLt";
+    return false;
+  }
+#endif
   return true;
 }
 
 ROCMBlas::ROCMBlas(gpu::GpuExecutor *parent)
-    : parent_(CHECK_NOTNULL(parent)), blas_(nullptr) {}
+    : parent_(CHECK_NOTNULL(parent)), blas_(nullptr)
+#if TF_HIPBLASLT
+    , 
+    blas_lt_(parent)
+#endif    
+     {}
 
 ROCMBlas::~ROCMBlas() {
   if (blas_ != nullptr) {

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.h
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_blas.h
@@ -23,11 +23,20 @@ limitations under the License.
 #include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/span.h"
+
+#include "rocm/rocm_config.h"
+#if TF_ROCM_VERSION >= 50600
+#include "rocm/include/rocblas/rocblas.h"
+#else
 #include "rocm/include/rocblas.h"
+#endif
 #include "tensorflow/compiler/xla/stream_executor/blas.h"
 #include "tensorflow/compiler/xla/stream_executor/platform/port.h"
 #include "tensorflow/compiler/xla/stream_executor/plugin_registry.h"
 #include "tensorflow/compiler/xla/stream_executor/temporary_device_memory.h"
+#if TF_HIPBLASLT
+#include "tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.h"
+#endif
 
 namespace stream_executor {
 
@@ -88,7 +97,9 @@ class ROCMBlas : public blas::BlasSupport {
   ~ROCMBlas() override;
 
   TENSORFLOW_STREAM_EXECUTOR_GPU_BLAS_SUPPORT_OVERRIDES
-
+#if TF_HIPBLASLT
+  BlasLt &blas_lt() { return blas_lt_; }
+#endif
  private:
   // Tells rocBLAS to enqueue the BLAS operation onto a particular Stream.
   //
@@ -185,6 +196,10 @@ class ROCMBlas : public blas::BlasSupport {
 
   // rocBLAS library handle on the device.
   rocblas_handle blas_ ABSL_GUARDED_BY(mu_);
+
+#if TF_HIPBLASLT
+  BlasLt blas_lt_;
+#endif
 
   SE_DISALLOW_COPY_AND_ASSIGN(ROCMBlas);
 };

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_dnn.cc
@@ -46,6 +46,9 @@ limitations under the License.
 #include "tensorflow/tsl/util/determinism.h"
 #include "tensorflow/tsl/util/env_var.h"
 
+#include <hip/hip_fp16.h>
+#include <hip/hip_bfloat16.h>
+
 namespace {
 
 // Converts (via narrowing) a type T value to a type U, and checks that the
@@ -3867,6 +3870,155 @@ bool MIOpenSupport::DoBatchNormalizationBackwardImpl(
   }
   return true;
 }
+
+template <typename T>
+void launchInplaceBiasActivation(hipStream_t stream, void* c_data, const void* bias_data, int activation_mode, uint64_t m, uint64_t n, int64_t ldc, float param);
+
+class ROCmFusedMatmulRunner: public dnn::FusedMatmulRunner
+{
+  template <typename T>
+  tsl::Status gemm(Stream*,
+      DeviceMemoryBase /* a_data */,
+      DeviceMemoryBase /* b_data */,
+      DeviceMemoryBase /* c_data */) const;
+
+  Stream* _stream;
+  dnn::DataType _input_type, _bias_type, _output_type;
+  bool _trans_a, _trans_b;
+  uint64_t _m, _n, _k;
+  int64_t _lda, _ldb,  _ldc;
+  dnn::ActivationMode _activation_mode;
+
+public:
+  std::string ToString() const override;
+  size_t GetWorkspaceSize() const override { return 0; }
+  // Convert to an AlgorithmDesc for AoT compilation or autotuning
+  tsl::StatusOr<AlgorithmDesc> ToAlgorithmDesc() const override;
+  // Launch the operation, with the signature determined by `Sig`.
+  tsl::Status operator()(Stream*, dnn::ProfileResult*,
+      DeviceMemoryBase scratch_memory,
+      DeviceMemoryBase /* a_data */,
+      DeviceMemoryBase /* b_data */,
+      DeviceMemoryBase /* bias_data */,
+      DeviceMemoryBase /* c_data */) const override;
+
+  ROCmFusedMatmulRunner(Stream* stream, dnn::DataType input_type, dnn::DataType bias_type,
+    dnn::DataType output_type, bool trans_a, bool trans_b,
+    uint64_t m, uint64_t n, uint64_t k, int64_t lda, int64_t ldb, int64_t ldc,
+    dnn::ActivationMode activation_mode);
+};
+
+ROCmFusedMatmulRunner::ROCmFusedMatmulRunner(Stream* stream, dnn::DataType input_type, dnn::DataType bias_type,
+    dnn::DataType output_type, bool trans_a, bool trans_b,
+    uint64_t m, uint64_t n, uint64_t k, int64_t lda, int64_t ldb, int64_t ldc,
+    dnn::ActivationMode activation_mode)
+  : _stream(stream), _input_type(input_type), _bias_type(bias_type), _output_type(output_type), _trans_a(trans_a),
+  _trans_b(trans_b), _m(m), _n(n), _k(k), _lda(lda), _ldb(ldb), _ldc(ldc),
+  _activation_mode(activation_mode)
+{
+}
+
+tsl::StatusOr<AlgorithmDesc> ROCmFusedMatmulRunner::ToAlgorithmDesc() const {
+  std::vector<std::pair<int64_t, int64_t> > knobs;
+  knobs.emplace_back(0, (int64_t)_input_type);
+  knobs.emplace_back(1, (int64_t)_bias_type); 
+  knobs.emplace_back(2, (int64_t)_output_type);
+  knobs.emplace_back(3, (int64_t)_trans_a);
+  knobs.emplace_back(4, (int64_t)_trans_b);
+  knobs.emplace_back(5, (int64_t)_m);
+  knobs.emplace_back(6, (int64_t)_n);
+  knobs.emplace_back(7, (int64_t)_k);
+  knobs.emplace_back(8, (int64_t)_lda);
+  knobs.emplace_back(9, (int64_t)_ldb);
+  knobs.emplace_back(10, (int64_t)_ldc);
+  return AlgorithmDesc(0, knobs, 0);
+}
+
+std::string ROCmFusedMatmulRunner::ToString() const {
+  return ToAlgorithmDesc().value().ToString();
+}
+
+template <typename T>
+tsl::Status ROCmFusedMatmulRunner::gemm(Stream* stream, 
+      DeviceMemoryBase a_data,
+      DeviceMemoryBase b_data,
+      DeviceMemoryBase c_data) const {
+    blas::Transpose ta = _trans_a ? blas::Transpose::kTranspose : blas::Transpose::kNoTranspose;
+    blas::Transpose tb = _trans_b ? blas::Transpose::kTranspose : blas::Transpose::kNoTranspose;
+    return stream->ThenBlasGemm<T>(tb, ta, _n, _m, _k, 
+          (DeviceMemory<T>)b_data, _ldb,
+          (DeviceMemory<T>)a_data, _lda, 
+          (DeviceMemory<T>*)&c_data, _ldc,
+          blas::kDefaultComputePrecision);
+}
+
+template <typename T>
+tsl::Status InplaceBiasActivation(Stream* stream, DeviceMemoryBase c_data, DeviceMemoryBase bias_data, dnn::ActivationMode activation_mode, 
+    uint64_t m, uint64_t n, int64_t ldc, float param)
+{
+  typedef typename std::conditional<std::is_same_v<T,Eigen::half>, __half, typename std::conditional<std::is_same_v<T, Eigen::bfloat16>, hip_bfloat16, T>::type>::type CT;
+  if(activation_mode==dnn::ActivationMode::kReluX || activation_mode==dnn::ActivationMode::kBandPass || activation_mode==dnn::ActivationMode::kLeakyRelu)
+    return tsl::Status(absl::StatusCode::kInvalidArgument,
+                       "ROCm InplaceBiasActivation can't be used with parametric activations");
+  launchInplaceBiasActivation<CT>(AsGpuStreamValue(stream), c_data.opaque(), bias_data.opaque(), (int)activation_mode, m, n, ldc, param);
+  return tsl::OkStatus();
+}
+
+
+// Launch the operation, with the signature determined by `Sig`.
+tsl::Status ROCmFusedMatmulRunner::operator()(Stream* stream, dnn::ProfileResult* prof,
+                                 DeviceMemoryBase scratch_memory,
+                                DeviceMemoryBase a_data,
+                                DeviceMemoryBase b_data,
+                                DeviceMemoryBase bias_data,
+                                DeviceMemoryBase c_data) const {
+    tsl::Status status;
+    if(_input_type == dnn::DataType::kFloat)
+      status = gemm<float>(stream, a_data, b_data, c_data);
+    else if(_input_type == dnn::DataType::kHalf)
+      status = gemm<Eigen::half>(stream, a_data, b_data, c_data);
+    else if(_input_type == dnn::DataType::kBF16)
+      status = gemm<Eigen::bfloat16>(stream, a_data, b_data, c_data);
+    else if(_input_type == dnn::DataType::kDouble)
+      status = gemm<double>(stream, a_data, b_data, c_data);
+    else
+      return tsl::Status(absl::StatusCode::kInvalidArgument, "Unsupported input type");
+    if(!status.ok())
+      return status;
+    if(_input_type == dnn::DataType::kFloat)
+      return InplaceBiasActivation<float>(stream, c_data, bias_data, _activation_mode, _m, _n, _ldc, 0.0f);
+    else if(_input_type == dnn::DataType::kHalf)
+      return InplaceBiasActivation<Eigen::half>(stream, c_data, bias_data, _activation_mode, _m, _n, _ldc, 0.0f);
+    else if(_input_type == dnn::DataType::kBF16)
+      return InplaceBiasActivation<Eigen::bfloat16>(stream, c_data, bias_data, _activation_mode, _m, _n, _ldc, 0.0f);
+    else if(_input_type == dnn::DataType::kDouble)
+      return InplaceBiasActivation<double>(stream, c_data, bias_data, _activation_mode, _m, _n, _ldc, 0.0f);
+    else
+      return tsl::Status(absl::StatusCode::kInvalidArgument, "Unsupported input type");
+}
+
+tsl::Status MIOpenSupport::GetFusedMatmulRunners(
+    bool use_cudnn_frontend, dnn::DataType input_type, dnn::DataType bias_type,
+    dnn::DataType output_type, Stream* stream, bool trans_a, bool trans_b,
+    uint64_t m, uint64_t n, uint64_t k, int64_t lda, int64_t ldb, int64_t ldc,
+    dnn::ActivationMode activation_mode, bool use_fallback,
+    const NumericOptions& numeric_options,
+    std::vector<std::unique_ptr<const dnn::FusedMatmulRunner>>*
+        out_exec_plans) {
+  out_exec_plans->clear();
+  if(input_type != output_type)
+    return tsl::Status(absl::StatusCode::kInvalidArgument,
+                       "ROCm fused matmul does not support input/output type mismatch");
+  if(input_type != bias_type)
+    return tsl::Status(absl::StatusCode::kInvalidArgument,
+                       "ROCm fused matmul does not support input/bias type mismatch");
+  auto runner_ptr = new ROCmFusedMatmulRunner(stream, input_type, bias_type,
+    output_type, trans_a, trans_b,
+    m, n, k, lda, ldb, ldc, activation_mode);
+  out_exec_plans->push_back(std::unique_ptr<const dnn::FusedMatmulRunner>(runner_ptr));
+  return tsl::OkStatus();
+}
+
 
 tsl::Status MIOpenSupport::DoFusedConvolve(
     Stream* stream, dnn::DataType input_type, dnn::DataType side_input_type,

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_dnn.h
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_dnn.h
@@ -417,6 +417,16 @@ class MIOpenSupport : public dnn::DnnSupport {
     return false;
   }
 
+  tsl::Status GetFusedMatmulRunners(
+      bool use_cudnn_frontend, dnn::DataType input_type,
+      dnn::DataType bias_type, dnn::DataType output_type, Stream* stream,
+      bool trans_a, bool trans_b, uint64_t m, uint64_t n, uint64_t k,
+      int64_t lda, int64_t ldb, int64_t ldc,
+      dnn::ActivationMode activation_mode, bool use_fallback,
+      const NumericOptions& numeric_options,
+      std::vector<std::unique_ptr<const dnn::FusedMatmulRunner>>*
+          out_exec_plans) override;
+
   bool DoBiasAdd(Stream* stream, const DeviceMemory<float>& input_data,
                  const DeviceMemory<float>& biases,
                  const dnn::BatchDescriptor& dimensions,

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_fft.h
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_fft.h
@@ -22,12 +22,12 @@ limitations under the License.
 
 #if TENSORFLOW_USE_ROCM
 
+#include "rocm/rocm_config.h"
 #if (TF_ROCM_VERSION >= 50200)
 #include "rocm/include/hipfft/hipfft.h"
 #else
 #include "rocm/include/hipfft.h"
 #endif
-#include "rocm/rocm_config.h"
 
 #endif
 

--- a/tensorflow/compiler/xla/stream_executor/rocm/rocm_helpers.cu.cc
+++ b/tensorflow/compiler/xla/stream_executor/rocm/rocm_helpers.cu.cc
@@ -14,7 +14,8 @@ limitations under the License.
 ==============================================================================*/
 
 #include <hip/hip_runtime.h>
-
+#include <hip/hip_fp16.h>
+#include <hip/hip_bfloat16.h>
 #include <limits>
 namespace stream_executor {
 namespace gpu {
@@ -73,6 +74,79 @@ void rocm_MakeBatchPointers(void* stream, char* base, int stride, int n,
       dim3(threads_per_block, 1, 1), 0, (hipStream_t)stream, base, stride, n,
       ptrs_out);
 }
+
+__device__ float sigmoid(float x) {
+  if(x>0)
+    return 1./(1.+__expf(-x));
+  else
+    return __expf(x)/(__expf(x)+1.);
+}
+
+template <typename T, int act_mode>
+__global__ void launchInplaceBiasActivation_kernel(T* c_data, const T* bias_data, uint64_t m, uint64_t n, int64_t ldc, float param) {
+  uint64_t x = threadIdx.x + blockIdx.x*blockDim.x;
+  uint64_t y = threadIdx.y + blockIdx.y*blockDim.y;
+  if(x>=n || y>=m)
+      return;
+  float v = float(c_data[x+y*ldc]) + float(bias_data[x]);
+  if(act_mode==1)
+      v = sigmoid(v);
+  else if(act_mode==2)
+      v = v>0.0f ? v : 0.0f;
+  else if(act_mode==3)
+      v = v>0.0f ? (v>6.0f ? 6.0f : v) : 0.0f;
+  else if(act_mode==4)
+      v = v>0.0f ? (v>param ? param : v) : 0.0f;
+  else if(act_mode==5)
+      v = tanh(v);
+  else if(act_mode==6)
+     v = v>-param ? (v>param ? param : v) : -param;
+  else if(act_mode==7)
+      v = v>0.0f ? v : __expf(v)-1;
+  else if(act_mode==8)
+      v = v>0.0f ? v : param*v;
+  else if(act_mode==9)
+      v = 0.5 * v * (1 + erf(v / sqrt(2.0f)));
+
+  c_data[x+y*ldc] = (T)v;
+}
+
+template <typename T>
+void launchInplaceBiasActivation(hipStream_t stream, void* c_data, const void* bias_data, int activation_mode, uint64_t m, uint64_t n, int64_t ldc, float param) {
+  uint64_t bx = min(n, uint64_t(256));
+  uint64_t by = min(m, uint64_t(256)/bx);
+  uint64_t gx = (n+bx-1)/bx;
+  uint64_t gy = (m+by-1)/by;
+  auto kernel = launchInplaceBiasActivation_kernel<T,0>;
+  if(activation_mode==1)
+    kernel = launchInplaceBiasActivation_kernel<T,1>;
+  else if(activation_mode==2)
+    kernel = launchInplaceBiasActivation_kernel<T,2>;
+  else if(activation_mode==3)
+    kernel = launchInplaceBiasActivation_kernel<T,3>;
+  else if(activation_mode==4)
+    kernel = launchInplaceBiasActivation_kernel<T,4>;
+  else if(activation_mode==5)
+    kernel = launchInplaceBiasActivation_kernel<T,5>;
+  else if(activation_mode==6)
+    kernel = launchInplaceBiasActivation_kernel<T,6>;
+  else if(activation_mode==7)
+    kernel = launchInplaceBiasActivation_kernel<T,7>;
+  else if(activation_mode==8)
+    kernel = launchInplaceBiasActivation_kernel<T,8>;
+  else if(activation_mode==9)
+    kernel = launchInplaceBiasActivation_kernel<T,9>;
+
+  hipLaunchKernelGGL(kernel,
+    dim3(gx, gy, 1),
+    dim3(bx, by, 1), 0, stream, (T*)c_data, (const T*)bias_data, m, n, ldc, param);
+}
+
+template void launchInplaceBiasActivation<__half>(hipStream_t stream, void* c_data, const void* bias_data, int activation_mode, uint64_t m, uint64_t n, int64_t ldc, float param);
+template void launchInplaceBiasActivation<hip_bfloat16>(hipStream_t stream, void* c_data, const void* bias_data, int activation_mode, uint64_t m, uint64_t n, int64_t ldc, float param);
+template void launchInplaceBiasActivation<float>(hipStream_t stream, void* c_data, const void* bias_data, int activation_mode, uint64_t m, uint64_t n, int64_t ldc, float param);
+template void launchInplaceBiasActivation<double>(hipStream_t stream, void* c_data, const void* bias_data, int activation_mode, uint64_t m, uint64_t n, int64_t ldc, float param);
+
 
 };  // namespace gpu
 };  // namespace stream_executor

--- a/tensorflow/compiler/xla/tests/dot_operation_test.cc
+++ b/tensorflow/compiler/xla/tests/dot_operation_test.cc
@@ -18,6 +18,9 @@ limitations under the License.
 #include <vector>
 
 #include "absl/strings/str_cat.h"
+#if TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#endif
 #include "tensorflow/compiler/xla/array2d.h"
 #include "tensorflow/compiler/xla/array3d.h"
 #include "tensorflow/compiler/xla/client/lib/arithmetic.h"
@@ -686,14 +689,12 @@ XLA_TYPED_TEST(DotOperationTest_F16F32F64CF64, GeneralMatMul) {
       {x_data.get(), y_data.get()}, this->error_spec_);
 }
 
+#if GOOGLE_CUDA || TF_HIPBLASLT
 template <typename T>
 class DotOperationTestWithCublasLt_F16F32F64CF64 : public DotOperationTest {
  public:
   DotOperationTestWithCublasLt_F16F32F64CF64() {
-    bool enable_cublas_lt = false;
-#if GOOGLE_CUDA
-    enable_cublas_lt = true;
-#endif
+    bool enable_cublas_lt = true;
     execution_options_.mutable_debug_options()->set_xla_gpu_enable_cublaslt(
         enable_cublas_lt);
   }
@@ -742,6 +743,7 @@ XLA_TYPED_TEST(DotOperationTestWithCublasLt_F16F32F64CF64,
       &builder, expected, {x_data.get(), y_data.get()}, this->error_spec_);
 }
 
+#if GOOGLE_CUDA
 template <typename T>
 class DotOperationTestWithCublasLt_F8 : public DotOperationTest {
  public:
@@ -1063,6 +1065,7 @@ XLA_TYPED_TEST(DotOperationTestWithCublasLt_F8, ScaledABScaledDWithDAmaxF8) {
                                 b_scale_data.get(), d_scale_data.get()},
                                this->error_spec_);
 }
+#endif
 
 XLA_TYPED_TEST(DotOperationTest_F16F32F64CF64, GeneralMatMulR3LhsR2Rhs) {
   using T = TypeParam;

--- a/tensorflow/compiler/xla/tests/matrix_ops_simple_test.cc
+++ b/tensorflow/compiler/xla/tests/matrix_ops_simple_test.cc
@@ -21,6 +21,9 @@ limitations under the License.
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#if TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#endif
 #include "tensorflow/compiler/xla/array2d.h"
 #include "tensorflow/compiler/xla/client/local_client.h"
 #include "tensorflow/compiler/xla/client/xla_builder.h"
@@ -184,9 +187,10 @@ class MatOpsDotAddTest
     bool row_major = std::get<0>(GetParam());
     bool add_lhs = std::get<1>(GetParam());
     bool transpose = std::get<2>(GetParam());
+#if GOOGLE_CUDA || TF_HIPBLASLT
     bool use_cublaslt = std::get<3>(GetParam());
-#ifndef GOOGLE_CUDA
-    use_cublaslt = false;
+#else
+    bool use_cublaslt = false;
 #endif
     execution_options_.mutable_debug_options()->set_xla_gpu_enable_cublaslt(
         use_cublaslt);
@@ -283,9 +287,10 @@ class MatOpsDotAddTest
   void TestImplBiasAddEpilogueFusion() {
     bool row_major = std::get<0>(GetParam());
     bool transpose = std::get<2>(GetParam());
+#if GOOGLE_CUDA || TF_HIPBLASLT
     bool use_cublaslt = std::get<3>(GetParam());
-#ifndef GOOGLE_CUDA
-    use_cublaslt = false;
+#else
+    bool use_cublaslt = false;
 #endif
     execution_options_.mutable_debug_options()->set_xla_gpu_enable_cublaslt(
         use_cublaslt);
@@ -332,10 +337,10 @@ class MatOpsDotAddTest
   void TestImplReluActivationEpilogueFusion() {
     bool row_major = std::get<0>(GetParam());
     bool transpose = std::get<2>(GetParam());
+#if GOOGLE_CUDA || TF_HIPBLASLT
     bool use_cublaslt = std::get<3>(GetParam());
-#if GOOGLE_CUDA
 #else
-    use_cublaslt = false;
+    bool use_cublaslt = false;
 #endif
     execution_options_.mutable_debug_options()->set_xla_gpu_enable_cublaslt(
         use_cublaslt);
@@ -377,9 +382,10 @@ class MatOpsDotAddTest
   void TestImplBiasAddReluActivationEpilogueFusion() {
     bool row_major = std::get<0>(GetParam());
     bool transpose = std::get<2>(GetParam());
+#if GOOGLE_CUDA || TF_HIPBLASLT
     bool use_cublaslt = std::get<3>(GetParam());
-#ifndef GOOGLE_CUDA
-    use_cublaslt = false;
+#else
+    bool use_cublaslt = false;
 #endif
     execution_options_.mutable_debug_options()->set_xla_gpu_enable_cublaslt(
         use_cublaslt);

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -511,7 +511,7 @@ bool IsGpuCompatible(const RemapperContext& ctx,
                      const ContractionWithBiasAddAndActivation& matched,
                      const Cluster* cluster) {
 #if TENSORFLOW_USE_ROCM
-  // ROCm does not support _FusedConv2D
+  // TODO: add a hipblaslt pathway
   return false;
 #endif
   // The TF->XLA bridge does not support `_Fused[Conv2D|MatMul]` so we avoid
@@ -584,7 +584,7 @@ bool IsGpuCompatible(const RemapperContext& ctx,
 bool IsGpuCompatible(const RemapperContext& ctx,
                      const ContractionWithBiasAdd& matched,
                      const Cluster* cluster) {
-#if TENSORFLOW_USE_ROCM
+#if TENSORFLOW_USE_ROCM && !TF_HIPBLASLT
   // ROCm does not support _FusedMatMul
   return false;
 #endif

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -1548,7 +1548,7 @@ class RemapperFuseMatMulWithBiasTest : public RemapperTest {
 
 TEST_F(RemapperFuseMatMulWithBiasTest, F16) {
   bool skip_test = false;
-#if !defined(GOOGLE_CUDA)
+#if !defined(GOOGLE_CUDA) || !TF_HIPBLASLT
   skip_test = true;
 #endif
   if (skip_test || GetNumAvailableGPUs() == 0) {
@@ -1756,7 +1756,7 @@ class RemapperFuseMatMulWithBiasAndActivationTest : public RemapperTest {
 
 TEST_F(RemapperFuseMatMulWithBiasAndActivationTest, F16) {
   bool skip_test = false;
-#if !defined(GOOGLE_CUDA)
+#if !defined(GOOGLE_CUDA) || !TF_HIPBLASLT
   skip_test = true;
 #endif
   if (skip_test || GetNumAvailableGPUs() == 0) {

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -32,6 +32,12 @@ load(
     "mkl_deps",
 )
 load(
+    "@local_config_rocm//rocm:build_defs.bzl",
+    "if_rocm_is_configured",
+    "rocm_hipblaslt",
+    "if_rocm_hipblaslt",
+)
+load(
     "//third_party/mkl_dnn:build_defs.bzl",
     "if_onednn_v3",
 )
@@ -3469,12 +3475,9 @@ tf_kernel_library(
         ":loose_headers",
         "//tensorflow/tsl/framework/contraction:eigen_contraction_kernel",
     ] + mkl_deps() + if_cuda([
-        ":matmul_util",
         "//tensorflow/compiler/xla/stream_executor/cuda:cublas_plugin",
-        "//tensorflow/compiler/xla/stream_executor/gpu:gpu_asm_opts",
-        "//tensorflow/compiler/xla/stream_executor/gpu:redzone_allocator",
-        "//tensorflow/compiler/xla/stream_executor:tf_allocator_adapter",
-        "//tensorflow/core/profiler/lib:scoped_annotation",
+    ]) + if_rocm_hipblaslt([
+        "//tensorflow/compiler/xla/stream_executor/rocm:hipblas_lt_header",
     ]) + if_cuda_or_rocm([
         ":conv_ops_gpu_hdrs",
         ":gpu_utils",
@@ -3488,9 +3491,9 @@ tf_kernel_library(
 
 cc_library(
     name = "matmul_util",
-    srcs = if_cuda(["matmul_util.cc"]),
-    hdrs = if_cuda(["matmul_util.h"]),
-    deps = if_cuda([
+    srcs = ["matmul_util.cc"],
+    hdrs = ["matmul_util.h"],
+    deps = if_cuda_or_rocm([
         "@com_google_absl//absl/container:flat_hash_map",
         "//tensorflow/compiler/xla:status_macros",
         "//tensorflow/compiler/xla/stream_executor/cuda:cublas_plugin",
@@ -3498,7 +3501,12 @@ cc_library(
         "//tensorflow/core:lib",
         "//tensorflow/core/platform:tensor_float_32_hdr_lib",
         "//tensorflow/core/util:env_var",
+    ]) + if_cuda([
+        "//tensorflow/tsl/platform/default/build_config:cublas_plugin",
         "//tensorflow/compiler/xla/stream_executor/cuda:cublas_lt_header",
+    ]) + if_rocm([
+        "//tensorflow/compiler/xla/stream_executor/platform:dso_loader",
+        "//tensorflow/compiler/xla/stream_executor/rocm:hipblas_lt_header",
     ]) + if_static(["//tensorflow/core/platform:tensor_float_32_utils"]),
 )
 

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -51,7 +51,7 @@ limitations under the License.
 #include "tensorflow/tsl/framework/contraction/eigen_contraction_kernel.h"
 #endif
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "tensorflow/compiler/xla/stream_executor/gpu/gpu_asm_opts.h"
 #include "tensorflow/compiler/xla/stream_executor/gpu/redzone_allocator.h"
 #include "tensorflow/compiler/xla/stream_executor/tf_allocator_adapter.h"
@@ -67,7 +67,7 @@ limitations under the License.
 #include "tensorflow/core/util/autotune_maps/conv_parameters.h"
 #include "tensorflow/core/util/proto/proto_utils.h"
 #include "tensorflow/core/util/use_cudnn.h"
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 namespace tensorflow {
 
@@ -174,17 +174,19 @@ struct LaunchFusedMatMulOp<CPUDevice, T> {
   };
 };
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
 namespace {
 
-StatusOr<se::cuda::BlasLt::Epilogue> GetBlasLtEpilogOp(
+#if GOOGLE_CUDA || TF_HIPBLASLT
+StatusOr<se::gpu::BlasLt::Epilogue> GetBlasLtEpilogOp(
     FusedComputationType fusion) {
   if (fusion == FusedComputationType::kBiasAdd) {
-    return se::cuda::BlasLt::Epilogue::kBias;
+    return se::gpu::BlasLt::Epilogue::kBias;
   } else if (fusion == FusedComputationType::kBiasAddWithRelu) {
-    return se::cuda::BlasLt::Epilogue::kBiasThenReLU;
+    return se::gpu::BlasLt::Epilogue::kBiasThenReLU;
   } else if (fusion == FusedComputationType::kBiasAddWithGeluApproximate) {
-    return se::cuda::BlasLt::Epilogue::kBiasThenGELU;
+    return se::gpu::BlasLt::Epilogue::kBiasThenGELU;
   } else {
     return errors::Internal("Unsupported fusion for BlasLt Matmul");
   }
@@ -192,7 +194,7 @@ StatusOr<se::cuda::BlasLt::Epilogue> GetBlasLtEpilogOp(
 
 template <typename LaunchFunc>
 se::blas::AlgorithmConfig AutotuneMatmul(
-    const std::vector<se::cuda::BlasLt::MatmulAlgorithm>& algorithms,
+    const std::vector<se::gpu::BlasLt::MatmulAlgorithm>& algorithms,
     BlasLtMatmulPlanParams& matmul_params, OpKernelContext* context,
     const LaunchFunc& launch_func) {
   // Note that algorithm_config.algorithm() here is used to refer
@@ -240,6 +242,7 @@ se::blas::AlgorithmConfig AutotuneMatmul(
   }
   return algorithm_config;
 }
+#endif
 
 template <typename LaunchFunc, typename Sig>
 StatusOr<std::vector<tensorflow::AutotuneResult>> AutotuneMatMulImpl(
@@ -326,7 +329,6 @@ StatusOr<AutotuneEntry<se::dnn::FusedMatmulOp>> AutotuneFusedMatmul(
     int64_t scratch_size_limit) {
   AutotuneEntry<se::dnn::FusedMatmulOp> autotune_entry;
   auto* stream = ctx->op_device_context()->stream();
-
   if (!autotune_map->Find(params, &autotune_entry)) {
     profiler::ScopedAnnotation trace("cudnn_autotuning");
 
@@ -401,7 +403,6 @@ StatusOr<AutotuneEntry<se::dnn::FusedMatmulOp>> AutotuneFusedMatmul(
                           BestCudnnConvAlgorithm<se::dnn::FusedMatmulOp>(
                               fallback_results, std::move(fallback_runners)));
     }
-
     autotune_map->Insert(params, autotune_entry);
   }
   return autotune_entry;
@@ -449,8 +450,8 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
     const int64_t k = a.dim_size(trans_a ? 0 : 1);
     const int64_t n = b.dim_size(trans_b ? 0 : 1);
 
-    bool use_cudnn = false;
     se::dnn::ActivationMode matmul_activation_mode;
+    bool use_cudnn = false;
     switch (fusion) {
       case FusedComputationType::kBiasAddWithGeluExact:
         matmul_activation_mode = se::dnn::ActivationMode::kGeluExact;
@@ -464,15 +465,44 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
         matmul_activation_mode = se::dnn::ActivationMode::kSigmoid;
         use_cudnn = true;
         break;
+      case FusedComputationType::kBiasAdd:
+        matmul_activation_mode = se::dnn::ActivationMode::kNone;
+        break;
+      case FusedComputationType::kBiasAddWithRelu:
+        matmul_activation_mode = se::dnn::ActivationMode::kRelu;
+        break;
+      case FusedComputationType::kBiasAddWithRelu6:
+        matmul_activation_mode = se::dnn::ActivationMode::kRelu6;
+        break;
+      case FusedComputationType::kBiasAddWithElu:
+        matmul_activation_mode = se::dnn::ActivationMode::kElu;
+        break;
+      case FusedComputationType::kBiasAddWithLeakyRelu:
+        matmul_activation_mode = se::dnn::ActivationMode::kLeakyRelu;
+        break;
+      case FusedComputationType::kBiasAddWithGeluApproximate:
+        matmul_activation_mode = se::dnn::ActivationMode::kGeluExact;
+        break;
       default:
         use_cudnn = false;
     }
+#if !(GOOGLE_CUDA || TF_HIPBLASLT)
+    use_cudnn = true;
+#endif
+
+#if TF_HIPBLASLT
+    auto cap = stream->GetRocmComputeCapability();
+    // as of ROCm 5.5, hipblaslt only supports MI200.
+    if(cap.gcn_arch_name().substr(0,6) != "gfx90a")
+      use_cudnn = true;
+#endif
 
     BlasScratchAllocator scratch_allocator(context);
 
     // The Gelu exact fusion is supported by the cuDNN.
     if (use_cudnn) {
-      MatmulParameters cudnn_matmul_params = {
+      //printf("trans_a %d trans_b %d\n", (int)trans_a, (int)trans_b);
+      MatmulParameters cudnn_matmul_params(
           stream->parent(),
           /*ab_type=*/a.dtype(),
           /*c_type=*/output->dtype(),
@@ -484,8 +514,8 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
           a.dim_size(1),
           b.dim_size(1),
           output->dim_size(1),
-          matmul_activation_mode,
-      };
+          matmul_activation_mode
+      );
 
       auto entry_or = AutotuneFusedMatmul<T>(
           use_autotune, FusedMatmulAutotuneMap::GetInstance(),
@@ -523,10 +553,10 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
       OP_REQUIRES_OK(context, cudnn_launch_status);
       return;
     }
-
+#if GOOGLE_CUDA || TF_HIPBLASLT
     auto epilog_op_or = GetBlasLtEpilogOp(fusion);
     OP_REQUIRES_OK(context, epilog_op_or.status());
-    se::cuda::BlasLt::Epilogue epilog_op = epilog_op_or.value();
+    se::gpu::BlasLt::Epilogue epilog_op = epilog_op_or.value();
 
     se::blas::Transpose trans[] = {se::blas::Transpose::kNoTranspose,
                                    se::blas::Transpose::kTranspose};
@@ -541,9 +571,10 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
                                          /*broadcast_a=*/false,
                                          /*broadcast_b=*/false,
                                          epilog_op};
-
-    auto plan_and_algorithms_or = GetPlanAndAlgorithms(stream, matmul_params);
+    absl::Mutex* pmu;
+    auto plan_and_algorithms_or = GetPlanAndAlgorithms(stream, matmul_params, &pmu);
     OP_REQUIRES_OK(context, plan_and_algorithms_or.status());
+    absl::MutexLock lock(pmu);
     const auto* plan_and_algorithms = std::move(plan_and_algorithms_or).value();
     const auto& plan = plan_and_algorithms->plan;
     const auto& algorithms = plan_and_algorithms->algorithms;
@@ -551,13 +582,13 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
                 errors::InvalidArgument("No matmul algorithm returned!"));
 
     auto launch_func = [&](BlasScratchAllocator& scratch_allocator,
-                           const se::cuda::BlasLt::MatmulAlgorithm& algorithm,
+                           const se::gpu::BlasLt::MatmulAlgorithm& algorithm,
                            se::blas::ProfileResult* profile_result) {
       return DoBlasLtMatmul(stream, plan, a_ptr, b_ptr, c_ptr, algorithm,
                             scratch_allocator, bias_ptr, profile_result);
     };
 
-    se::cuda::BlasLt::MatmulAlgorithm algorithm = algorithms[0];
+    se::gpu::BlasLt::MatmulAlgorithm algorithm = algorithms[0];
     if (use_autotune) {
       se::blas::AlgorithmConfig algorithm_config =
           AutotuneMatmul(algorithms, matmul_params, context, launch_func);
@@ -567,10 +598,11 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
     }
 
     OP_REQUIRES_OK(context, launch_func(scratch_allocator, algorithm, nullptr));
+#endif
   }
 };
 
-#endif  // GOOGLE_CUDA
+#endif  // GOOGLE_CUDA || TENSORLFOW_USE_ROCM
 
 template <typename Device, typename T>
 class FusedMatMulOp : public OpKernel {
@@ -689,7 +721,7 @@ TF_CALL_float(REGISTER_FUSED_CPU_MATMUL);
 
 #undef REGISTER_FUSED_CPU_MATMUL
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 // Registration of the GPU implementations.
 #define REGISTER_FUSED_GPU_MATMUL(T)                                  \

--- a/tensorflow/core/kernels/matmul_op_impl.h
+++ b/tensorflow/core/kernels/matmul_op_impl.h
@@ -48,13 +48,19 @@ limitations under the License.
 #include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/kernels/numeric_options_utils.h"
 #include "tensorflow/core/platform/stream_executor.h"
+#include "tensorflow/compiler/xla/stream_executor/host_or_device_scalar.h"
+#include "tensorflow/core/kernels/matmul_util.h"
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #if GOOGLE_CUDA
 #include "third_party/gpus/cuda/include/cuda.h"
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_blas_lt.h"
-#include "tensorflow/compiler/xla/stream_executor/host_or_device_scalar.h"
-#include "tensorflow/core/kernels/matmul_util.h"
 #endif  // GOOGLE_CUDA
+#if TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#if TF_HIPBLASLT
+#include "tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.h"
+#endif
+#endif
 
 namespace tensorflow {
 
@@ -285,7 +291,7 @@ struct LaunchBatchMatMul<CPUDevice, Scalar> {
   }
 };
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TF_HIPBLASLT
 
 namespace {
 // A dummy type to group matmul autotune results together.
@@ -399,9 +405,18 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
                                     std::is_same_v<Scalar, Eigen::bfloat16>;
     using Coefficient = std::conditional_t<is_16bit_input, float, Scalar>;
 
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TF_HIPBLASLT
     static const bool use_autotune = MatmulAutotuneEnable();
-    if (EnableCublasLtGemm()) {
+    bool bCublasLtSupport = true;
+#if TF_HIPBLASLT
+    if(!std::is_same_v<Scalar, float>)
+      bCublasLtSupport = false;
+    auto cap = stream->GetRocmComputeCapability();
+    // as of ROCm 5.5, hipblaslt only supports MI200.
+    if(cap.gcn_arch_name().substr(0,6) != "gfx90a")
+      bCublasLtSupport = false;
+#endif
+    if (EnableCublasLtGemm() && bCublasLtSupport) {
       static const int64_t max_scratch_size =
           GetWorkspaceLimit(1LL << 32);  // 4GB by default
 
@@ -429,16 +444,16 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
 
         std::optional<int> max_algorithm_count;
         if (!use_autotune) max_algorithm_count = 1;
-
+        absl::Mutex* pmu = nullptr;
         auto plan_and_algorithms_or =
-            GetPlanAndAlgorithms(stream, matmul_params, max_algorithm_count);
+            GetPlanAndAlgorithms(stream, matmul_params, &pmu, max_algorithm_count);
         OP_REQUIRES_OK(context, plan_and_algorithms_or.status());
+        absl::MutexLock lock(pmu);
         const auto* plan_and_algorithms =
             std::move(plan_and_algorithms_or).value();
         const auto& plan = plan_and_algorithms->plan;
         const auto& algorithms = plan_and_algorithms->algorithms;
-
-        se::cuda::BlasLt* blas_lt = se::cuda::GetBlasLt(stream);
+        se::gpu::BlasLt* blas_lt = se::gpu::GetBlasLt(stream);
         OP_REQUIRES(context, blas_lt != nullptr,
                     errors::Internal("blaslt not supported"));
 
@@ -653,7 +668,7 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
               ", k=", k, ", batch_size=", batch_size));
         }
       }
-#if GOOGLE_CUDA
+#if GOOGLE_CUDA || TF_HIPBLASLT
     }
 #endif  // GOOGLE_CUDA
   }

--- a/tensorflow/core/kernels/matmul_op_test.cc
+++ b/tensorflow/core/kernels/matmul_op_test.cc
@@ -26,6 +26,10 @@ limitations under the License.
 #include "tensorflow/core/protobuf/rewriter_config.pb.h"
 #include "tensorflow/core/public/session.h"
 
+#if TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#endif
+
 namespace tensorflow {
 namespace {
 
@@ -181,20 +185,24 @@ class FusedMatMulOpTest : public OpsTestBase {
                      .Attr("transpose_b", transpose_b)
                      .Finalize(&fused_matmul));
 
+#if !(GOOGLE_CUDA || TENSORFLOW_USE_ROCM)
+    printf("Disallowing the FusedMatMul GPU test (neither CUDA nor ROCM observed)\n");
+    allow_gpu_device = false;
+#endif
     RunAndFetch(root, fused_matmul.name(), output, allow_gpu_device,
                 &fused_matmul);
   }
 
-  void VerifyBiasAddTensorsNear(int m, int k, int n,
+  void VerifyBiasAddTensorsNear(int m, int k, int n, bool ta, bool tb,
                                 const BiasAddGraphRunner& run_default,
                                 const BiasAddGraphRunner& run_fused) {
     DataType dtype = DataTypeToEnum<T>::v();
 
-    Tensor lhs(dtype, {m, k});
+    Tensor lhs(dtype, {ta ? k : m, ta ? m : k});
     lhs.flat<T>() = lhs.flat<T>().setRandom();
 
     // Add some negative values to filter to properly test Relu.
-    Tensor rhs(dtype, {k, n});
+    Tensor rhs(dtype, {tb ? n : k, tb ? k : n});
     rhs.flat<T>() = rhs.flat<T>().setRandom();
     rhs.flat<T>() -= rhs.flat<T>().constant(static_cast<T>(0.5f));
 
@@ -220,6 +228,7 @@ class FusedMatMulOpTest : public OpsTestBase {
   // FusedMatMul.
   void VerifyMatMulWithBias(int m, int k, int n, bool transpose_a,
                             bool transpose_b) {
+    printf("=== VerifyMatMulWithBias ( %d, %d, %d, %d, %d ) ===\n", m, k, n, (int)transpose_a, (int)transpose_b);
     const BiasAddGraphRunner run_default =
         [&](const Tensor& input_data, const Tensor& filter_data,
             const Tensor& bias_data, Tensor* out) {
@@ -235,7 +244,7 @@ class FusedMatMulOpTest : public OpsTestBase {
                            /*allow_gpu_device=*/true);
         };
 
-    VerifyBiasAddTensorsNear(m, k, n, run_default, run_fused);
+    VerifyBiasAddTensorsNear(m, k, n, transpose_a, transpose_b, run_default, run_fused);
   }
 
   // Verifies that computing MatMul+BiasAdd+{Activation} in a graph is identical
@@ -261,7 +270,7 @@ class FusedMatMulOpTest : public OpsTestBase {
                        /*allow_gpu_device=*/activation == "Relu");
     };
 
-    VerifyBiasAddTensorsNear(m, k, n, run_default, run_fused);
+    VerifyBiasAddTensorsNear(m, k, n, transpose_a, transpose_b, run_default, run_fused);
   }
 };
 
@@ -278,18 +287,20 @@ TYPED_TEST_SUITE_P(FusedMatMulWithBiasOpTest);
 // -------------------------------------------------------------------------- //
 
 TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul256x256x256) {
-  this->VerifyMatMulWithBias(256, 256, 256, false, false);
-  this->VerifyMatMulWithBias(256, 256, 256, true, false);
-  this->VerifyMatMulWithBias(256, 256, 256, false, true);
-  this->VerifyMatMulWithBias(256, 256, 256, true, true);
+  this->VerifyMatMulWithBias(256, 128, 64, false, false);
+  this->VerifyMatMulWithBias(256, 128, 64, true, false);
+  this->VerifyMatMulWithBias(256, 128, 64, false, true);
+  this->VerifyMatMulWithBias(256, 128, 64, true, true);
 }
 
 TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul1x256x256) {
   this->VerifyMatMulWithBias(1, 256, 256, false, false);
+  this->VerifyMatMulWithBias(4, 128, 256, false, false);
 }
 
 TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul256x256x1) {
   this->VerifyMatMulWithBias(256, 256, 1, false, false);
+  this->VerifyMatMulWithBias(256, 128, 4, false, false);
 }
 
 TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul1x256x1) {
@@ -298,13 +309,13 @@ TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul1x256x1) {
 
 TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul256x256x256WithActivation) {
   for (const string& activation : {"Relu", "Relu6", "Elu", "LeakyRelu"}) {
-    this->VerifyConv2DWithBiasAndActivation(256, 256, 256, false, false,
+    this->VerifyConv2DWithBiasAndActivation(256, 128, 64, false, false,
                                             activation);
-    this->VerifyConv2DWithBiasAndActivation(256, 256, 256, true, false,
+    this->VerifyConv2DWithBiasAndActivation(256, 128, 64, true, false,
                                             activation);
-    this->VerifyConv2DWithBiasAndActivation(256, 256, 256, false, true,
+    this->VerifyConv2DWithBiasAndActivation(256, 128, 64, false, true,
                                             activation);
-    this->VerifyConv2DWithBiasAndActivation(256, 256, 256, true, true,
+    this->VerifyConv2DWithBiasAndActivation(256, 128, 64, true, true,
                                             activation);
   }
 }

--- a/tensorflow/core/kernels/matmul_util.cc
+++ b/tensorflow/core/kernels/matmul_util.cc
@@ -12,12 +12,18 @@ limitations under the License.
 
 #include "tensorflow/core/kernels/matmul_util.h"
 
+#if GOOGLE_CUDA || TF_HIPBLASLT
+
 #include <optional>
 #include <string>
 #include <utility>
 
 #include "tensorflow/compiler/xla/status_macros.h"
+#if GOOGLE_CUDA
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_blas_lt.h"
+#else
+#include "tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.h"
+#endif
 #include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/platform/tensor_float_32_utils.h"
 #include "tensorflow/core/util/env_var.h"
@@ -115,6 +121,7 @@ se::blas::DataType GetScaleType(se::blas::DataType c_type,
 
 StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
     se::Stream* stream, const BlasLtMatmulPlanParams& params,
+    absl::Mutex** ppmu,
     std::optional<int> max_algorithm_count) {
   static const int64_t max_scratch_size =
       GetWorkspaceLimit(1LL << 32);  // 4GB by default
@@ -127,7 +134,7 @@ StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
 
   const PlanAndAlgorithms* plan_and_algorithms = plan_map.Find(params);
   if (!plan_and_algorithms) {
-    se::cuda::BlasLt* blas_lt = se::cuda::GetBlasLt(stream);
+    se::gpu::BlasLt* blas_lt = se::gpu::GetBlasLt(stream);
     TF_RET_CHECK(blas_lt != nullptr);
 
     TF_ASSIGN_OR_RETURN(se::blas::ComputationType computation_type,
@@ -139,7 +146,7 @@ StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
     // cublas_lt's output is column-major. We want row-major so use identity:
     // C^T = (A @ B)^T = B^T @ A^T.
     constexpr auto kColMajor =
-        se::cuda::BlasLt::MatrixLayout::Order::kColumnMajor;
+        se::gpu::BlasLt::MatrixLayout::Order::kColumnMajor;
 
     size_t rows_a = params.k;
     size_t cols_a = params.m;
@@ -161,44 +168,47 @@ StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
 
     TF_ASSIGN_OR_RETURN(
         auto a_desc,
-        se::cuda::BlasLt::MatrixLayout::Create(
+        se::gpu::BlasLt::MatrixLayout::Create(
             params.dtype, rows_a, cols_a, kColMajor, params.batch_count,
             /*leading_dim_stride=*/std::nullopt, batch_stride_a));
     TF_ASSIGN_OR_RETURN(
         auto b_desc,
-        se::cuda::BlasLt::MatrixLayout::Create(
+        se::gpu::BlasLt::MatrixLayout::Create(
             params.dtype, rows_b, cols_b, kColMajor, params.batch_count,
             /*leading_dim_stride=*/std::nullopt, batch_stride_b));
-    TF_ASSIGN_OR_RETURN(auto c_desc, se::cuda::BlasLt::MatrixLayout::Create(
+    TF_ASSIGN_OR_RETURN(auto c_desc, se::gpu::BlasLt::MatrixLayout::Create(
                                          params.dtype, params.n, params.m,
                                          kColMajor, params.batch_count));
-    TF_ASSIGN_OR_RETURN(auto d_desc, se::cuda::BlasLt::MatrixLayout::Create(
+    TF_ASSIGN_OR_RETURN(auto d_desc, se::gpu::BlasLt::MatrixLayout::Create(
                                          params.dtype, params.n, params.m,
                                          kColMajor, params.batch_count));
 
     // `A` and `B` swapped (see above re. column-major output).
     TF_ASSIGN_OR_RETURN(auto op_desc,
-                        se::cuda::BlasLt::MatmulDesc::Create(
+                        se::gpu::BlasLt::MatmulDesc::Create(
                             computation_type, scale_type,
                             /*trans_a=*/params.trans_b,
                             /*trans_b=*/params.trans_a, params.epilogue));
 
     // `A` and `B` swapped (see above re. column-major output).
-    se::cuda::BlasLt::MatmulPlan plan{std::move(op_desc), std::move(b_desc),
+    se::gpu::BlasLt::MatmulPlan plan{std::move(op_desc), std::move(b_desc),
                                       std::move(a_desc), std::move(c_desc),
                                       std::move(d_desc)};
     TF_ASSIGN_OR_RETURN(
         auto preference,
-        se::cuda::BlasLt::MatmulPreference::Create(max_scratch_size));
+        se::gpu::BlasLt::MatmulPreference::Create(max_scratch_size));
 
     TF_ASSIGN_OR_RETURN(
-        std::vector<se::cuda::BlasLt::MatmulAlgorithm> algorithms,
+        std::vector<se::gpu::BlasLt::MatmulAlgorithm> algorithms,
         blas_lt->GetMatmulAlgorithms(plan, preference, *max_algorithm_count));
 
     plan_and_algorithms =
         plan_map.Insert(params, {std::move(plan), std::move(algorithms)});
   }
+  *ppmu = &plan_map.mu_;
   return plan_and_algorithms;
 }
 
 }  // namespace tensorflow
+
+#endif

--- a/tensorflow/core/kernels/matmul_util.h
+++ b/tensorflow/core/kernels/matmul_util.h
@@ -15,10 +15,25 @@ limitations under the License.
 #include <optional>
 #include <vector>
 
+#if TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
+#endif
+
+#if GOOGLE_CUDA || TF_HIPBLASLT
+
 #include "absl/container/flat_hash_map.h"
-#include "tensorflow/compiler/xla/stream_executor/cuda/cuda_blas_lt.h"
 #include "tensorflow/compiler/xla/stream_executor/device_memory.h"
+#include "tensorflow/tsl/platform/types.h"
 #include "tensorflow/core/framework/types.h"
+
+#if GOOGLE_CUDA
+#include "tensorflow/compiler/xla/stream_executor/cuda/cuda_blas_lt.h"
+#endif
+
+#if TF_HIPBLASLT
+#include "tensorflow/compiler/xla/stream_executor/rocm/hip_blas_lt.h"
+#define CUDA_R_32F HIPBLAS_R_32F
+#endif
 
 namespace tensorflow {
 
@@ -40,7 +55,7 @@ struct BlasLtMatmulPlanParams {
   size_t batch_count = 1;
   bool broadcast_a = false;
   bool broadcast_b = false;
-  se::cuda::BlasLt::Epilogue epilogue = se::cuda::BlasLt::Epilogue::kDefault;
+  se::gpu::BlasLt::Epilogue epilogue = se::gpu::BlasLt::Epilogue::kDefault;
 };
 
 namespace internal {
@@ -59,8 +74,8 @@ H AbslHashValue(H h, const BlasLtMatmulPlanParams& params) {
 }
 
 struct PlanAndAlgorithms {
-  se::cuda::BlasLt::MatmulPlan plan;
-  std::vector<se::cuda::BlasLt::MatmulAlgorithm> algorithms;
+  se::gpu::BlasLt::MatmulPlan plan;
+  std::vector<se::gpu::BlasLt::MatmulAlgorithm> algorithms;
 };
 
 // Thread-safe map from matmul parameters to their corresponding plan and
@@ -71,8 +86,8 @@ class BlasLtMatmulPlanMap {
   const PlanAndAlgorithms* Insert(const BlasLtMatmulPlanParams& params,
                                   PlanAndAlgorithms value);
 
- private:
   mutable absl::Mutex mu_;
+ private:
   absl::flat_hash_map<BlasLtMatmulPlanParams, PlanAndAlgorithms>
       params_plan_map_ ABSL_GUARDED_BY(mu_);
 };
@@ -82,18 +97,19 @@ StatusOr<se::blas::ComputationType> GetBlasComputationType(
 
 StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
     se::Stream* stream, const BlasLtMatmulPlanParams& params,
+    absl::Mutex** pmu,
     std::optional<int> max_algorithm_count = std::nullopt);
 
 template <typename T>
 Status DoBlasLtMatmul(se::Stream* stream,
-                      const se::cuda::BlasLt::MatmulPlan& plan,
+                      const se::gpu::BlasLt::MatmulPlan& plan,
                       const se::DeviceMemory<T>& a,
                       const se::DeviceMemory<T>& b, se::DeviceMemory<T>& c,
-                      const se::cuda::BlasLt::MatmulAlgorithm& algorithm,
+                      const se::gpu::BlasLt::MatmulAlgorithm& algorithm,
                       se::ScratchAllocator& scratch_allocator,
                       const se::DeviceMemory<T>& bias = {},
                       se::blas::ProfileResult* profile_result = nullptr) {
-  se::cuda::BlasLt* blas_lt = se::cuda::GetBlasLt(stream);
+  se::gpu::BlasLt* blas_lt = se::gpu::GetBlasLt(stream);
   // TF_RET_CHECK(blas_lt != nullptr);
 
   se::DeviceMemory<T> aux{};  // We don't use the auxilary buffers.
@@ -115,5 +131,7 @@ Status DoBlasLtMatmul(se::Stream* stream,
 }
 
 }  // namespace tensorflow
+
+#endif
 
 #endif  // TENSORFLOW_CORE_KERNELS_MATMUL_UTIL_H_

--- a/tensorflow/core/kernels/nccl_ops.cc
+++ b/tensorflow/core/kernels/nccl_ops.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "third_party/nccl/nccl.h"
 #elif TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
 #if (TF_ROCM_VERSION >= 50200)
 #include "rocm/include/rccl/rccl.h"
 #else

--- a/tensorflow/core/nccl/nccl_manager.h
+++ b/tensorflow/core/nccl/nccl_manager.h
@@ -30,6 +30,7 @@ limitations under the License.
 #if GOOGLE_CUDA
 #include "third_party/nccl/nccl.h"
 #elif TENSORFLOW_USE_ROCM
+#include "rocm/rocm_config.h"
 #if (TF_ROCM_VERSION >= 50200)
 #include "rocm/include/rccl/rccl.h"
 #else

--- a/tensorflow/core/util/autotune_maps/conv_parameters.cc
+++ b/tensorflow/core/util/autotune_maps/conv_parameters.cc
@@ -94,7 +94,7 @@ MatmulParameters::MatmulParameters(
   proto_.set_c_dtype(c_dtype);
 
   proto_.set_trans_a(trans_a);
-  proto_.set_trans_b(trans_a);
+  proto_.set_trans_b(trans_b);
   proto_.set_m(m);
   proto_.set_n(n);
   proto_.set_k(k);

--- a/tensorflow/core/util/gpu_solvers.h
+++ b/tensorflow/core/util/gpu_solvers.h
@@ -32,7 +32,11 @@ limitations under the License.
 #include "third_party/gpus/cuda/include/cusolverDn.h"
 #else
 #include "rocm/include/hip/hip_complex.h"
+#if TF_ROCM_VERSION >= 50600
+#include "rocm/include/rocblas/rocblas.h"
+#else
 #include "rocm/include/rocblas.h"
+#endif
 #include "rocm/rocm_config.h"
 #include "tensorflow/compiler/xla/stream_executor/blas.h"
 #if TF_ROCM_VERSION >= 40500

--- a/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
@@ -2053,7 +2053,8 @@ class Conv2DTest(test.TestCase):
           padding="VALID",
           test_input=True,
           data_format=data_format,
-          use_gpu=use_gpu)
+          use_gpu=use_gpu,
+          max_err=0.005)
 
   @test_util.deprecated_graph_mode_only
   def testFilterGradientValidPaddingStrideThree(self):
@@ -2107,7 +2108,8 @@ class Conv2DTest(test.TestCase):
           padding="SAME",
           test_input=False,
           data_format=data_format,
-          use_gpu=use_gpu)
+          use_gpu=use_gpu,
+          max_err=0.005)
 
   @test_util.deprecated_graph_mode_only
   def testInputGradientSamePaddingStrideTwo(self):
@@ -2161,7 +2163,8 @@ class Conv2DTest(test.TestCase):
           padding="SAME",
           test_input=True,
           data_format=data_format,
-          use_gpu=use_gpu)
+          use_gpu=use_gpu,
+          max_err=0.005)
 
   @test_util.deprecated_graph_mode_only
   def testFilterGradientSamePaddingStrideThree(self):
@@ -2416,7 +2419,8 @@ class Conv2DTest(test.TestCase):
           padding=[[0, 0], [4, 3], [2, 1], [0, 0]],
           test_input=False,
           data_format=data_format,
-          use_gpu=use_gpu)
+          use_gpu=use_gpu,
+          max_err=0.005)
 
   @test_util.deprecated_graph_mode_only
   def testInputGradient0_0_0_5PaddingStride1x2(self):
@@ -2434,7 +2438,8 @@ class Conv2DTest(test.TestCase):
           padding=[[0, 0], [0, 0], [0, 5], [0, 0]],
           test_input=True,
           data_format=data_format,
-          use_gpu=use_gpu)
+          use_gpu=use_gpu,
+          max_err=0.005)
 
   @test_util.deprecated_graph_mode_only
   def testFilterGradient0_0_0_5PaddingStride1x2(self):

--- a/tensorflow/tsl/platform/default/dlopen_checker.cc
+++ b/tensorflow/tsl/platform/default/dlopen_checker.cc
@@ -49,8 +49,15 @@ Status TryDlopenROCmLibraries() {
   auto miopen_status = GetMiopenDsoHandle();
   auto rocfft_status = GetHipfftDsoHandle();
   auto rocrand_status = GetRocrandDsoHandle();
+#if TF_HIPBLASLT
+  auto hiplaslt_status = CachedLoader::GetHipblasLtDsoHandle();
+#endif
   if (!rocblas_status.status().ok() || !miopen_status.status().ok() ||
-      !rocfft_status.status().ok() || !rocrand_status.status().ok()) {
+      !rocfft_status.status().ok() || !rocrand_status.status().ok()
+#if TF_HIPBLASLT
+      || !hipblaslt_status.status().ok()
+#endif
+      ) {
     return Status(absl::StatusCode::kInternal,
                   absl::StrCat("Cannot dlopen all ROCm libraries."));
   } else {

--- a/tensorflow/tsl/platform/default/dso_loader.cc
+++ b/tensorflow/tsl/platform/default/dso_loader.cc
@@ -166,6 +166,10 @@ StatusOr<void*> GetHipsparseDsoHandle() {
   return GetDsoHandle("hipsparse", "");
 }
 
+StatusOr<void*> GetHipblasltDsoHandle() {
+  return GetDsoHandle("hipblaslt", "");
+}
+
 StatusOr<void*> GetHipDsoHandle() { return GetDsoHandle("amdhip64", ""); }
 
 }  // namespace DsoLoader
@@ -260,6 +264,11 @@ StatusOr<void*> GetHipsolverDsoHandle() {
 
 StatusOr<void*> GetHipsparseDsoHandle() {
   static auto result = new auto(DsoLoader::GetHipsparseDsoHandle());
+  return *result;
+}
+
+StatusOr<void*> GetHipblasltDsoHandle() {
+  static auto result = new auto(DsoLoader::GetHipblasltDsoHandle());
   return *result;
 }
 

--- a/tensorflow/tsl/platform/default/dso_loader.h
+++ b/tensorflow/tsl/platform/default/dso_loader.h
@@ -86,6 +86,7 @@ StatusOr<void*> GetRocsolverDsoHandle();
 StatusOr<void*> GetHipsolverDsoHandle();
 StatusOr<void*> GetRoctracerDsoHandle();
 StatusOr<void*> GetHipsparseDsoHandle();
+StatusOr<void*> GetHipblasltDsoHandle();
 StatusOr<void*> GetHipDsoHandle();
 }  // namespace CachedDsoLoader
 

--- a/third_party/gpus/rocm/build_defs.bzl.tpl
+++ b/third_party/gpus/rocm/build_defs.bzl.tpl
@@ -48,6 +48,14 @@ def if_rocm_is_configured(x):
       return select({"//conditions:default": x})
     return select({"//conditions:default": []})
 
+def rocm_hipblaslt():
+    return %{rocm_is_configured} and %{rocm_hipblaslt}
+
+def if_rocm_hipblaslt(x):
+    if %{rocm_is_configured} and (%{rocm_hipblaslt} == "True"):
+      return select({"//conditions:default": x})
+    return select({"//conditions:default": []})
+
 def rocm_library(copts = [], **kwargs):
     """Wrapper over cc_library which adds default ROCm options."""
     native.cc_library(copts = rocm_default_copts() + copts, **kwargs)

--- a/third_party/gpus/rocm/rocm_config.h.tpl
+++ b/third_party/gpus/rocm/rocm_config.h.tpl
@@ -21,5 +21,6 @@ limitations under the License.
 #define TF_ROCM_VERSION %{rocm_version_number}
 #define TF_MIOPEN_VERSION %{miopen_version_number}
 #define TF_HIPRUNTIME_VERSION %{hipruntime_version_number}
+#define TF_HIPBLASLT %{hipblaslt_flag}
 
 #endif  // ROCM_ROCM_CONFIG_H_

--- a/third_party/gpus/rocm_configure.bzl
+++ b/third_party/gpus/rocm_configure.bzl
@@ -299,7 +299,8 @@ def _rocm_lib_paths(repository_ctx, lib, basedir):
 
 def _batch_files_exist(repository_ctx, libs_paths, bash_bin):
     all_paths = []
-    for _, lib_paths in libs_paths:
+    for row in libs_paths:
+        lib_paths = row[1]
         for lib_path in lib_paths:
             all_paths.append(lib_path)
     return files_exist(repository_ctx, all_paths, bash_bin)
@@ -309,7 +310,10 @@ def _select_rocm_lib_paths(repository_ctx, libs_paths, bash_bin):
 
     libs = {}
     i = 0
-    for name, lib_paths in libs_paths:
+    for row in libs_paths:
+        name = row[0]
+        lib_paths = row[1]
+        optional = (len(row)>2 and row[2]==True)
         selected_path = None
         for path in lib_paths:
             if test_results[i] and selected_path == None:
@@ -317,7 +321,11 @@ def _select_rocm_lib_paths(repository_ctx, libs_paths, bash_bin):
                 selected_path = path
             i = i + 1
         if selected_path == None:
-            auto_configure_fail("Cannot find rocm library %s" % name)
+            if optional:
+                libs[name] = None
+                continue
+            else:
+                auto_configure_fail("Cannot find rocm library %s" % name)
 
         libs[name] = struct(file_name = selected_path.basename, path = realpath(repository_ctx, selected_path, bash_bin))
 
@@ -351,6 +359,10 @@ def _find_libs(repository_ctx, rocm_config, hipfft_or_rocfft, miopen_path, rccl_
     if int(rocm_config.rocm_version_number) >= 40500:
         libs_paths.append(("hipsolver", _rocm_lib_paths(repository_ctx, "hipsolver", rocm_config.rocm_toolkit_path)))
         libs_paths.append(("hipblas", _rocm_lib_paths(repository_ctx, "hipblas", rocm_config.rocm_toolkit_path)))
+
+    # hipblaslt may be absent even in versions of ROCm where it exists
+    # (it is not installed by default in some containers). Autodetect.
+    libs_paths.append(("hipblaslt", _rocm_lib_paths(repository_ctx, "hipblaslt", rocm_config.rocm_toolkit_path), True))
     return _select_rocm_lib_paths(repository_ctx, libs_paths, bash_bin)
 
 def _exec_find_rocm_config(repository_ctx, script_path):
@@ -461,6 +473,7 @@ def _create_dummy_repository(repository_ctx):
             "%{rocm_extra_copts}": "[]",
             "%{rocm_gpu_architectures}": "[]",
             "%{rocm_version_number}": "0",
+            "%{rocm_hipblaslt}": "False",
         },
     )
     _tpl(
@@ -479,6 +492,7 @@ def _create_dummy_repository(repository_ctx):
             "%{roctracer_lib}": _lib_name("roctracer64"),
             "%{rocsolver_lib}": _lib_name("rocsolver"),
             "%{hipsolver_lib}": _lib_name("hipsolver"),
+            "%{hipblaslt_lib}": _lib_name("hipblaslt"),
             "%{copy_rules}": "",
             "%{rocm_headers}": "",
         },
@@ -495,6 +509,7 @@ def _create_dummy_repository(repository_ctx):
         "rocm:rocm_config.h",
         {
             "%{rocm_toolkit_path}": _DEFAULT_ROCM_TOOLKIT_PATH,
+            "%{hipblaslt_flag}": "0",
         },
         "rocm/rocm/rocm_config.h",
     )
@@ -611,8 +626,9 @@ def _create_local_rocm_repository(repository_ctx):
     rocm_lib_srcs = []
     rocm_lib_outs = []
     for lib in rocm_libs.values():
-        rocm_lib_srcs.append(lib.path)
-        rocm_lib_outs.append("rocm/lib/" + lib.file_name)
+        if lib:
+            rocm_lib_srcs.append(lib.path)
+            rocm_lib_outs.append("rocm/lib/" + lib.file_name)
     copy_rules.append(make_copy_files_rule(
         repository_ctx,
         name = "rocm-lib",
@@ -634,12 +650,15 @@ def _create_local_rocm_repository(repository_ctx):
         ],
     ))
 
+    have_hipblaslt = "1" if rocm_libs["hipblaslt"]!=None else "0"
+
     # Set up BUILD file for rocm/
     repository_ctx.template(
         "rocm/build_defs.bzl",
         tpl_paths["rocm:build_defs.bzl"],
         {
             "%{rocm_is_configured}": "True",
+            "%{rocm_hipblaslt}": "True" if "hipblaslt" in rocm_libs else "False",
             "%{rocm_extra_copts}": _compute_rocm_extra_copts(
                 repository_ctx,
                 rocm_config.amdgpu_targets,
@@ -665,6 +684,9 @@ def _create_local_rocm_repository(repository_ctx):
                             hiprand_include +
                             rocrand_include),
     }
+    if rocm_libs["hipblaslt"] != None:
+        repository_dict["%{hipblaslt_lib}"] = rocm_libs["hipblaslt"].file_name
+
     if rocm_version_number >= 40500:
         repository_dict["%{hipsolver_lib}"] = rocm_libs["hipsolver"].file_name
         repository_dict["%{hipblas_lib}"] = rocm_libs["hipblas"].file_name
@@ -753,6 +775,7 @@ def _create_local_rocm_repository(repository_ctx):
             "%{rocm_version_number}": rocm_config.rocm_version_number,
             "%{miopen_version_number}": rocm_config.miopen_version_number,
             "%{hipruntime_version_number}": rocm_config.hipruntime_version_number,
+            "%{hipblaslt_flag}": have_hipblaslt,
         },
     )
 


### PR DESCRIPTION
This PR:

* Enables detection of hipblaslt. Hooks it up in place of cublaslt when available. 

* Enables the _FusedMatMul op for ROCm and routes it to hipblaslt. 

* Fixes certain #includes due to their deprecation in ROCm 5.6.