### PR TITLE
"correction for TpuExecute_FreeTpuEmbeddingMemoryAllocations "

### DIFF
--- a/tensorflow/compiler/xla/stream_executor/tpu/tpu_ops_c_api.h
+++ b/tensorflow/compiler/xla/stream_executor/tpu/tpu_ops_c_api.h
@@ -274,12 +274,8 @@ TFTPU_CAPI_EXPORT void TpuExecute_GetTpuEmbeddingMemoryAllocations(
     int device_ordinal, SE_DeviceMemoryBase** addrs, size_t* addrs_count,
     TF_Status* status);
 
-TFTPU_CAPI_EXPORT void SE_DeviceMemoryBase_FreeArray(
-    SE_DeviceMemoryBase* addrs);
-
-TFTPU_CAPI_EXPORT void TpuExecute_GetTpuEmbeddingMemoryWordAddresses(
-    SE_StreamExecutor* executor, SE_DeviceMemoryBase** addrs,
-    size_t* addrs_count, TF_Status* status);
+TFTPU_CAPI_EXPORT void TpuExecute_FreeTpuEmbeddingMemoryAllocations(
+    int device_ordinal, SE_DeviceMemoryBase* addrs);
 
 typedef struct ConfigureDistributedTpuOp_DoWork_Params {
   int32_t struct_size;


### PR DESCRIPTION
…memory

allocations, and stash them inside the runtime while TPUExecute is being invoked. These temporary device memory allocations are cleared at the end of TPUExecute.

PiperOrigin-RevId: 540156433