### PR TITLE
ignore broken content when using tf.data.Dataset.load

### DIFF
--- a/tensorflow/core/data/snapshot_utils.cc
+++ b/tensorflow/core/data/snapshot_utils.cc
@@ -485,11 +485,14 @@ class Reader::Dataset : public DatasetBase {
       }
 
       if (!absl::IsOutOfRange(s)) {
-        LOG(WARNING) << "Advance to next file as error raised with error message " << s.message();
+        LOG(WARNING) << "Advance to next file as error raised with message "
+                     << s.message();
       }
-      
-      // stop processing current file if any error occurs, as there's no way to determinate correct offset of next record
-      // 'tf.data.Dataset.ignore_errors' will execute 'ReadTensors' repeatedly if not advance to next file on error
+
+      // stop processing current file if any error occurs, as there's no way to
+      // determinate correct offset of next record
+      // if not advance to next file on error, 'tf.data.Dataset.ignore_errors'
+      // will execute 'ReadTensors' repeatedly
       Status status = AdvanceToNextFile(ctx->env());
       if (absl::IsNotFound(status)) {
         *end_of_sequence = true;

--- a/tensorflow/core/data/snapshot_utils.cc
+++ b/tensorflow/core/data/snapshot_utils.cc
@@ -484,6 +484,10 @@ class Reader::Dataset : public DatasetBase {
         return s;
       }
 
+      if (!absl::IsOutOfRange(s)) {
+        LOG(WARNING) << "Advance to next file as error raised with error message " << s.message();
+      }
+      
       // stop processing current file if any error occurs, as there's no way to determinate correct offset of next record
       // 'tf.data.Dataset.ignore_errors' will execute 'ReadTensors' repeatedly if not advance to next file on error
       Status status = AdvanceToNextFile(ctx->env());

--- a/tensorflow/python/data/kernel_tests/io_test.py
+++ b/tensorflow/python/data/kernel_tests/io_test.py
@@ -142,7 +142,7 @@ class IOTest(test_base.DatasetTestBase, parameterized.TestCase):
       self.evaluate(next_element())
 
   @combinations.generate(test_base.default_test_combinations())
-  def testReadTruncateSnapshot(self):
+  def testReadTruncateSnapshotWithIgnoreErrors(self):
     dataset = dataset_ops.Dataset.from_tensor_slices(["abcd", "1234", "zxcv"])
 
     self.evaluate(dataset.save(self._corrupted_dataset_dir))
@@ -159,6 +159,7 @@ class IOTest(test_base.DatasetTestBase, parameterized.TestCase):
 
     
     dataset2 = dataset_ops.Dataset.load(self._corrupted_dataset_dir, dataset.element_spec)
+    dataset2 = dataset2.ignore_errors()
     self.assertEqual(self.evaluate(dataset2.cardinality()), 1)
 
 

--- a/tensorflow/python/data/kernel_tests/io_test.py
+++ b/tensorflow/python/data/kernel_tests/io_test.py
@@ -147,18 +147,22 @@ class IOTest(test_base.DatasetTestBase, parameterized.TestCase):
 
     self.evaluate(dataset.save(self._corrupted_dataset_dir))
 
-    run_id_dir = [x for x in os.listdir(self._corrupted_dataset_dir) if os.path.isdir(self._corrupted_dataset_dir + '/' + x)][0]
-    _snapshot_path = f'{self._corrupted_dataset_dir}/{run_id_dir}/00000000.shard/00000000.snapshot'
+    list_dir = [f'{self._corrupted_dataset_dir}/{p}' 
+                for p in os.listdir(self._corrupted_dataset_dir)]
+    run_id_dir = [p for p in list_dir if os.path.isdir(p)][0]
+    _snapshot_path = (f'{self._corrupted_dataset_dir}/'
+                      f'{run_id_dir}/00000000.shard/'
+                      f'00000000.snapshot')
 
     with open(_snapshot_path, 'rb') as file:
-        b = file.read()
+      b = file.read()
     ba = bytearray(b)
     ba[39] += 1
     with open(_snapshot_path, 'wb') as file:
-        file.write(bytes(ba))
+      file.write(bytes(ba))
 
-    
-    dataset2 = dataset_ops.Dataset.load(self._corrupted_dataset_dir, dataset.element_spec)
+    dataset2 = dataset_ops.Dataset.load(self._corrupted_dataset_dir, 
+                                        dataset.element_spec)
     dataset2 = dataset2.ignore_errors()
     self.assertEqual(self.evaluate(dataset2.cardinality()), 1)
 

--- a/tensorflow/python/data/kernel_tests/io_test.py
+++ b/tensorflow/python/data/kernel_tests/io_test.py
@@ -38,12 +38,16 @@ class IOTest(test_base.DatasetTestBase, parameterized.TestCase):
     os.mkdir(self._checkpoint_prefix)
     self._save_dir = os.path.join(self.get_temp_dir(), "save")
     os.mkdir(self._save_dir)
+    self._corrupted_dataset_dir = os.path.join(self.get_temp_dir(), 'cdd')
+    os.mkdir(self._corrupted_dataset_dir)
+
 
   def tearDown(self):
     super(IOTest, self).tearDown()
     shutil.rmtree(self._test_dir)
     shutil.rmtree(self._checkpoint_prefix)
     shutil.rmtree(self._save_dir)
+    shutil.rmtree(self._corrupted_dataset_dir)
 
   @combinations.generate(
       combinations.times(
@@ -136,6 +140,27 @@ class IOTest(test_base.DatasetTestBase, parameterized.TestCase):
     next_element = self.getNext(dataset)
     for _ in range(30):
       self.evaluate(next_element())
+
+  @combinations.generate(test_base.default_test_combinations())
+  def testReadTruncateSnapshot(self):
+    dataset = dataset_ops.Dataset.from_tensor_slices(["abcd", "1234", "zxcv"])
+
+    self.evaluate(dataset.save(self._corrupted_dataset_dir))
+
+    run_id_dir = [x for x in os.listdir(self._corrupted_dataset_dir) if os.path.isdir(self._corrupted_dataset_dir + '/' + x)][0]
+    _snapshot_path = f'{self._corrupted_dataset_dir}/{run_id_dir}/00000000.shard/00000000.snapshot'
+
+    with open(_snapshot_path, 'rb') as file:
+        b = file.read()
+    ba = bytearray(b)
+    ba[39] += 1
+    with open(_snapshot_path, 'wb') as file:
+        file.write(bytes(ba))
+
+    
+    dataset2 = dataset_ops.Dataset.load(self._corrupted_dataset_dir, dataset.element_spec)
+    self.assertEqual(self.evaluate(dataset2.cardinality()), 1)
+
 
 
 class LoadCheckpointTest(IOTest, checkpoint_test_base.CheckpointTestBase):


### PR DESCRIPTION
Background:
Error occurs usually means correct offset of next record cannot be determined.
When chaining with ignore_errors to avoid single corrupted record abort whole processing, as reader doesn't advance to next file, then processing will be stuck a busy loop reading the broken record indefinitely.

Changes: 
Moving on to next file if one read error shows and log errors.