### PR TITLE
Unsigned integer overflow in `wav_io.cc:297`

### DIFF
--- a/tensorflow/core/lib/wav/wav_io.cc
+++ b/tensorflow/core/lib/wav/wav_io.cc
@@ -294,8 +294,8 @@ Status DecodeLin16WaveAsFloatVector(const std::string& wav_string,
         "Bad bytes per sample in WAV header: Expected ",
         expected_bytes_per_sample, " but got ", bytes_per_sample);
   }
-  const uint64 expected_bytes_per_second = (uint64)bytes_per_sample * *sample_rate;
-  if ((uint64)bytes_per_second != expected_bytes_per_second) {
+  const uint64 expected_bytes_per_second = static_cast<uint64>(bytes_per_sample) * *sample_rate;
+  if (static_cast<uint64>(bytes_per_second) != expected_bytes_per_second) {
     return errors::InvalidArgument(
         "Bad bytes per second in WAV header: Expected ",
         expected_bytes_per_second, " but got ", bytes_per_second,

--- a/tensorflow/core/lib/wav/wav_io.cc
+++ b/tensorflow/core/lib/wav/wav_io.cc
@@ -294,8 +294,8 @@ Status DecodeLin16WaveAsFloatVector(const std::string& wav_string,
         "Bad bytes per sample in WAV header: Expected ",
         expected_bytes_per_sample, " but got ", bytes_per_sample);
   }
-  const uint32 expected_bytes_per_second = bytes_per_sample * *sample_rate;
-  if (bytes_per_second != expected_bytes_per_second) {
+  const uint64 expected_bytes_per_second = (uint64)bytes_per_sample * *sample_rate;
+  if ((uint64)bytes_per_second != expected_bytes_per_second) {
     return errors::InvalidArgument(
         "Bad bytes per second in WAV header: Expected ",
         expected_bytes_per_second, " but got ", bytes_per_second,


### PR DESCRIPTION
Hi! We've been searching errors in tensorflow with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and have found an error of unsigned integer overflow in `wav_io.cc:297`.

The error appears in computing the expected `bytes_per_second` value. Then it is compared with the input `bytes_per_second` value, and if they are not equal, the error is reported. But on the attached input, the unsigned integer overflow occurs and despite the fact that `bytes_per_sample` and `sample_rate` don't correspond to input `bytes_per_second`, the `expected_bytes_per_second` appears to be equal to `bytes_per_second` and the following check is passed.

With the attached input, `bytes_per_sample` equals to 128, `sample_rate` equals to 3196092545, and the `expected_bytes_per_second` equals to `bytes_per_second` equals to 1077952640.

To fix the error we suggest to change `expected_bytes_per_second` type to `uint64` and explicitly cast types to `uint64` in multiplication.

TensorFlow version: 0db597d0d758aba578783b5bf46c889700a45085

How to reproduce

1. Build docker from [here](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/tensorflow) and run the container:

        sudo docker build -t oss-sydr-fuzz-tensorflow .
        sudo docker run --privileged --rm -v `pwd`:/fuzz -it oss-sydr-fuzz-tensorflow /bin/bash

2. Run the target on this input: [tf-wav-overflow.wav.txt](https://github.com/tensorflow/tensorflow/files/11799137/tf-wav-overflow.wav.txt)


        /fuzzer/decode_wav_fuzz tf-wav-overflow.wav.txt

3. You will see the following output:
         
        tensorflow/core/lib/wav/wav_io.cc:297:61: runtime error: unsigned integer overflow: 128 * 3196092545 cannot be represented in type 'unsigned int'
        SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior tensorflow/core/lib/wav/wav_io.cc:297:61 in