### PR TITLE
[Linaro:ARM_CI] Quiet warnings from build_pip_package

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
@@ -137,7 +137,7 @@ bazel build \
     //tensorflow/tools/pip_package:build_pip_package \
     || die "Error: Bazel build failed for target: //tensorflow/tools/pip_package:build_pip_package"
 
-./bazel-bin/tensorflow/tools/pip_package/build_pip_package ${WHL_DIR} ${NIGHTLY_FLAG} "--project_name" ${PROJECT_NAME} || die "build_pip_package FAILED"
+PYTHONWARNINGS=ignore:::setuptools.command.build_py ./bazel-bin/tensorflow/tools/pip_package/build_pip_package ${WHL_DIR} ${NIGHTLY_FLAG} "--project_name" ${PROJECT_NAME} || die "build_pip_package FAILED"
 
 PY_DOTLESS_MAJOR_MINOR_VER=$(echo $PY_MAJOR_MINOR_VER | tr -d '.')
 if [[ $PY_DOTLESS_MAJOR_MINOR_VER == "2" ]]; then


### PR DESCRIPTION
Quiet those warnings about 'Installing as data is deprecated' as they just spam the log