### PR TITLE
[Linaro:ARM_CI] Stop building pip packages for ARM_CI

### DIFF
--- a/.github/workflows/arm-cd.yml
+++ b/.github/workflows/arm-cd.yml
@@ -64,7 +64,7 @@ jobs:
           is_nightly=0 && tf_project_name='tensorflow_cpu_aws' && ${{ github.event_name == 'schedule' }} && is_nightly=1 && tf_project_name='tf_nightly_cpu_aws'
           echo "PyPI project name:" $tf_project_name
           CI_DOCKER_BUILD_EXTRA_PARAMS="--build-arg py_major_minor_version=${{ matrix.pyver }} --build-arg is_nightly=${is_nightly} --build-arg tf_project_name=${tf_project_name}" \
-          ./tensorflow/tools/ci_build/ci_build.sh cpu.arm64 bash tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
+          ./tensorflow/tools/ci_build/ci_build.sh cpu.arm64 bash tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
       - name: Upload pip wheel to PyPI
         shell: bash
         run: python3 -m twine upload --verbose /home/ubuntu/actions-runner/_work/tensorflow/tensorflow/whl/* -u "__token__" -p ${{ secrets.AWS_PYPI_ACCOUNT_TOKEN }}

--- a/.github/workflows/arm-ci.yml
+++ b/.github/workflows/arm-ci.yml
@@ -56,8 +56,3 @@ jobs:
         run: |
           CI_DOCKER_BUILD_EXTRA_PARAMS="--build-arg py_major_minor_version=${{ matrix.pyver }} --build-arg is_nightly=1 --build-arg tf_project_name=tf_nightly_ci" \
           ./tensorflow/tools/ci_build/ci_build.sh cpu.arm64 bash tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
-      - name: Upload pip wheel to GitHub
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
-        with:
-          name: tensorflow_py${{ matrix.pyver }}_wheel
-          path: /home/ubuntu/actions-runner/_work/tensorflow/tensorflow/whl/*.whl

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -41,7 +41,9 @@ update_bazel_flags() {
 }
 
 DEFAULT_PROJECT_NAME="tensorflow"
+DEFAULT_AUDITWHEEL_TARGET_PLAT="manylinux2014"
 PROJECT_NAME=${TF_PROJECT_NAME:-$DEFAULT_PROJECT_NAME}
+AUDITWHEEL_TARGET_PLAT=${TF_AUDITWHEEL_TARGET_PLAT:-$DEFAULT_AUDITWHEEL_TARGET_PLAT}
 
 sudo install -o ${CI_BUILD_USER} -g ${CI_BUILD_GROUP} -d /tmpfs
 sudo install -o ${CI_BUILD_USER} -g ${CI_BUILD_GROUP} -d /tensorflow
@@ -57,6 +59,9 @@ python_version=$(python3 -c 'import sys; print("python"+str(sys.version_info.maj
 
 # Setup virtual environment
 setup_venv_ubuntu ${python_version}
+
+# Need to update the version of auditwheel used for aarch64
+python3 -m pip install auditwheel~=5.3.0
 
 # Need to use the python from the venv
 export PYTHON_BIN_PATH=$(which python3)
@@ -102,6 +107,7 @@ export TF_TEST_FLAGS="${TF_BUILD_FLAGS} \
     --test_output=errors --verbose_failures=true --test_keep_going --notest_verbose_timeout_warnings"
 export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} ${ARM_SKIP_TESTS}"
 export TF_FILTER_TAGS="-no_oss,-oss_excluded,-oss_serial,-v1only,-benchmark-test,-no_aarch64,-gpu,-tpu,-no_oss_py38,-no_oss_py39,-no_oss_py310"
+export TF_AUDITWHEEL_TARGET_PLAT="manylinux2014"
 
 if [ ${IS_NIGHTLY} == 1 ]; then
   ./tensorflow/tools/ci_build/update_version.py --nightly
@@ -111,7 +117,54 @@ sudo sed -i '/^build --profile/d' /usertools/aarch64.bazelrc
 sudo sed -i '\@^build.*=\"/usr/local/bin/python3\"$@d' /usertools/aarch64.bazelrc
 sed -i '$ aimport /usertools/aarch64.bazelrc' .bazelrc
 
+# Override breaking change in setuptools v60 (https://github.com/pypa/setuptools/pull/2896)
+export SETUPTOOLS_USE_DISTUTILS=stdlib
+
+# Local variables
+WHL_DIR="${KOKORO_ARTIFACTS_DIR}/tensorflow/whl"
+sudo install -o ${CI_BUILD_USER} -g ${CI_BUILD_GROUP} -d ${WHL_DIR}
+WHL_DIR=$(realpath "${WHL_DIR}") # Get absolute path
+
+# Determine the major.minor versions of python being used (e.g., 3.7).
+# Useful for determining the directory of the local pip installation.
+PY_MAJOR_MINOR_VER=$(${PYTHON_BIN_PATH} -c "print(__import__('sys').version)" 2>&1 | awk '{ print $1 }' | head -n 1 | cut -d. -f1-2)
+
 update_bazel_flags
+
+bazel build \
+    --action_env=PYTHON_BIN_PATH=${PYTHON_BIN_PATH} \
+    ${TF_BUILD_FLAGS} \
+    //tensorflow/tools/pip_package:build_pip_package \
+    || die "Error: Bazel build failed for target: //tensorflow/tools/pip_package:build_pip_package"
+
+PYTHONWARNINGS=ignore:::setuptools.command.build_py ./bazel-bin/tensorflow/tools/pip_package/build_pip_package ${WHL_DIR} ${NIGHTLY_FLAG} "--project_name" ${PROJECT_NAME} || die "build_pip_package FAILED"
+
+PY_DOTLESS_MAJOR_MINOR_VER=$(echo $PY_MAJOR_MINOR_VER | tr -d '.')
+if [[ $PY_DOTLESS_MAJOR_MINOR_VER == "2" ]]; then
+  PY_DOTLESS_MAJOR_MINOR_VER="27"
+fi
+
+# Set wheel path and verify that there is only one .whl file in the path.
+WHL_PATH=$(ls "${WHL_DIR}"/"${PROJECT_NAME}"-*"${PY_DOTLESS_MAJOR_MINOR_VER}"*"${PY_DOTLESS_MAJOR_MINOR_VER}"*.whl)
+if [[ $(echo "${WHL_PATH}" | wc -w) -ne 1 ]]; then
+  echo "ERROR: Failed to find exactly one built TensorFlow .whl file in "\
+  "directory: ${WHL_DIR}"
+fi
+
+# Print the size of the wheel file and log to sponge.
+WHL_SIZE=$(ls -l ${WHL_PATH} | awk '{print $5}')
+echo "Size of the PIP wheel file built: ${WHL_SIZE}"
+
+# Repair the wheels for manylinux2014
+echo "auditwheel repairing ${WHL_PATH}"
+auditwheel repair --plat ${AUDITWHEEL_TARGET_PLAT}_$(uname -m) -w "${WHL_DIR}" "${WHL_PATH}"
+
+if [[ $(ls ${WHL_DIR} | grep ${AUDITWHEEL_TARGET_PLAT} | wc -l) == 1 ]] ; then
+  WHL_PATH=${WHL_DIR}/$(ls ${WHL_DIR} | grep ${AUDITWHEEL_TARGET_PLAT})
+  echo "Repaired ${AUDITWHEEL_TARGET_PLAT} wheel file at: ${WHL_PATH}"
+else
+  die "WARNING: Cannot find repaired wheel."
+fi
 
 bazel test ${TF_TEST_FLAGS} \
     --action_env=PYTHON_BIN_PATH=${PYTHON_BIN_PATH} \
@@ -120,6 +173,9 @@ bazel test ${TF_TEST_FLAGS} \
     --local_test_jobs=$(grep -c ^processor /proc/cpuinfo) \
     --build_tests_only \
     -- ${TF_TEST_TARGETS}
+
+# remove duplicate wheel and copy wheel to mounted volume for local access
+rm -rf ${WHL_DIR}/*linux_aarch64.whl && cp -r ${WHL_DIR} .
 
 # Remove virtual environment
 remove_venv_ubuntu


### PR DESCRIPTION
Only build pip packages in ARM_CD action now to save time on the runners