### PR TITLE
[CMake] Add dependency for MhloTestAnalysis.

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/mhlo/analysis/CMakeLists.txt
+++ b/tensorflow/compiler/xla/mlir_hlo/mhlo/analysis/CMakeLists.txt
@@ -16,6 +16,9 @@ add_mlir_library(MhloTestAnalysis
   LINK_COMPONENTS
   Core
 
+  DEPENDS
+  LMHLOTransformsPassIncGen
+
   LINK_LIBS PUBLIC
   MLIRHLOAnalysis
   MLIRAnalysis


### PR DESCRIPTION
Hello!

We're working on an [MLIR based compiler that takes StableHLO and lowers it to standard MLIR dialects](https://github.com/PennyLaneAI/catalyst/). To do this, we have relied on transformations available in `mlir-hlo-opt`. Part of our CI/CD process includes building `mlir-hlo-opt` from scratch in Github Actions whenever there's a new version of JAX. We noticed that a recent version of `mlir-hlo-opt` could not be built in Github Actions. We looked into this and found that a dependency was not being declared in a CMake file. This issue would normally not be found when building locally as it is triggered only when building using a single core. We believe that the issue can be resolved with the following patch. Thanks!

**Description of change**: This patch declares LMHLOTransformsPassIncGen as a dependency to MhloTestAnalysis. Without it, building on a single core would attempt to compile `test_shape_component_analysis.cc` without having generated file `transforms/passes.h.inc`.

This error is not encountered when building on multiple cores as the distribution of the builds ensures that the file `transforms/passes.h.inc` is generated before attempting to compile `test_shape_component_analysis.cc`.

**Benefits**: Building mlir-hlo in machines with limited resources will not run into this issue. This includes building on Github Actions.

**Related Github issues:** Closes https://github.com/tensorflow/mlir-hlo/issues/68