### PR TITLE
[TOSA] Change to use new style of dyn_cast

### DIFF
--- a/tensorflow/compiler/mlir/tosa/transforms/convert_tfl_uint8.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/convert_tfl_uint8.cc
@@ -74,14 +74,13 @@ struct ConvertUint8QConstOp : public RewritePattern {
 
     // Skip if it's not ranked tensor type.
     auto output_type =
-        tfl_qconst_op.getResult().getType().dyn_cast<mlir::RankedTensorType>();
+        dyn_cast<mlir::RankedTensorType>(tfl_qconst_op.getResult().getType());
     if (!output_type)
       return builder.notifyMatchFailure(op, "not ranked tensor");
 
     // Skip if output is not per-tensor quantized type.
-    auto output_element_type =
-        output_type.getElementType()
-            .dyn_cast<mlir::quant::UniformQuantizedType>();
+    auto output_element_type = dyn_cast<mlir::quant::UniformQuantizedType>(
+        output_type.getElementType());
     if (!output_element_type) return failure();
 
     // Skip if output is not uint8.
@@ -155,12 +154,11 @@ LogicalResult convert_graph_uint8_tensor(mlir::MLIRContext &context,
 
     // Insert rescale uint8->int8 after placeholders.
     for (Value arg : bb.getArguments()) {
-      auto uint8_type = arg.getType().dyn_cast<mlir::ShapedType>();
+      auto uint8_type = dyn_cast<mlir::ShapedType>(arg.getType());
       if (!uint8_type) continue;
 
-      auto uint8_element_type =
-          uint8_type.getElementType()
-              .dyn_cast<mlir::quant::UniformQuantizedType>();
+      auto uint8_element_type = dyn_cast<mlir::quant::UniformQuantizedType>(
+          uint8_type.getElementType());
       if (!uint8_element_type) continue;
 
       if (uint8_element_type.isSigned() ||
@@ -219,13 +217,12 @@ LogicalResult convert_graph_uint8_tensor(mlir::MLIRContext &context,
     for (auto &op : bb) {
       for (Value output_val : op.getResults()) {
         // Skip if output value is not RankedTensorType.
-        auto output_type = output_val.getType().dyn_cast<mlir::ShapedType>();
+        auto output_type = dyn_cast<mlir::ShapedType>(output_val.getType());
         if (!output_type) continue;
 
         // Skip if output value is not per-tensor quantized element type.
-        auto output_element_type =
-            output_type.getElementType()
-                .dyn_cast<mlir::quant::UniformQuantizedType>();
+        auto output_element_type = dyn_cast<mlir::quant::UniformQuantizedType>(
+            output_type.getElementType());
         if (!output_element_type) continue;
 
         // Skip if output is not uint8.
@@ -270,12 +267,12 @@ LogicalResult convert_graph_uint8_tensor(mlir::MLIRContext &context,
       Value input_val = defining_op->getResult(0);
 
       // Check if graph output is uint8 type.
-      auto uint8_output_type = output_types[i].dyn_cast<mlir::ShapedType>();
+      auto uint8_output_type = dyn_cast<mlir::ShapedType>(output_types[i]);
       if (!uint8_output_type) continue;
 
       auto uint8_output_element_type =
-          uint8_output_type.getElementType()
-              .dyn_cast<mlir::quant::UniformQuantizedType>();
+          dyn_cast<mlir::quant::UniformQuantizedType>(
+              uint8_output_type.getElementType());
       if (!uint8_output_element_type) continue;
 
       if (uint8_output_element_type.isSigned() ||
@@ -284,12 +281,12 @@ LogicalResult convert_graph_uint8_tensor(mlir::MLIRContext &context,
 
       // Check if output coming into terminator is int8 type.
       auto int8_output_type =
-          terminator->getOperand(i).getType().dyn_cast<mlir::ShapedType>();
+          dyn_cast<mlir::ShapedType>(terminator->getOperand(i).getType());
       if (!int8_output_type) continue;
 
       auto int8_output_element_type =
-          int8_output_type.getElementType()
-              .dyn_cast<mlir::quant::UniformQuantizedType>();
+          dyn_cast<mlir::quant::UniformQuantizedType>(
+              int8_output_type.getElementType());
       if (!int8_output_element_type) continue;
 
       if (!int8_output_element_type.isSigned() ||

--- a/tensorflow/compiler/mlir/tosa/transforms/fuse_bias_tf.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/fuse_bias_tf.cc
@@ -72,7 +72,7 @@ LogicalResult ConvertTFBiasAddOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tf_biasadd_op = cast<TF::BiasAddOp>(op);
   auto output_type =
-      tf_biasadd_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_biasadd_op.getResult().getType());
 
   if (!output_type) {
     return rewriter.notifyMatchFailure(op, "output not a ranked tensor");

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.cc
@@ -137,7 +137,7 @@ std::optional<Value> convertPackOp(PatternRewriter& rewriter, Operation* op,
   // if input[0] has shape [A, B, C], input[1] to input[N-1] should also have
   // shape[A, B, C]
   RankedTensorType result_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
 
   // Check for ranked tensor type.
   if (!result_type) {
@@ -149,13 +149,13 @@ std::optional<Value> convertPackOp(PatternRewriter& rewriter, Operation* op,
   // Valid axis in TOSA is [0, rank(input))
   // Plus rank(input) once if axis is negative.
   RankedTensorType input_type =
-      op->getOperand(0).getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(op->getOperand(0).getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return std::nullopt;
   }
 
-  input_type = inputs[0].getType().dyn_cast<RankedTensorType>();
+  input_type = dyn_cast<RankedTensorType>(inputs[0].getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input 0 type not ranked tensor");
     return std::nullopt;
@@ -172,7 +172,7 @@ std::optional<Value> convertPackOp(PatternRewriter& rewriter, Operation* op,
   }
 
   for (int i = 1; i < inputs.size(); i++) {
-    input_type = inputs[0].getType().dyn_cast<RankedTensorType>();
+    input_type = dyn_cast<RankedTensorType>(inputs[0].getType());
     if (!input_type) {
       (void)rewriter.notifyMatchFailure(
           op, llvm::formatv("input {} is not ranked)", i));
@@ -326,7 +326,7 @@ std::optional<SmallVector<Value>> convertUnpackOp(PatternRewriter& rewriter,
                                                   Value input_value,
                                                   int32_t axis) {
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   auto input_shape = input_type.getShape();
@@ -376,7 +376,7 @@ std::optional<SmallVector<Value>> convertUnpackOp(PatternRewriter& rewriter,
 
   // Step 2: slice [N, A, B, C] into N [A, B, C].
   RankedTensorType transposed_input_type =
-      transposed_input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(transposed_input_value.getType());
   if (!transposed_input_type) return std::nullopt;
 
   auto transposed_input_shape = transposed_input_type.getShape();
@@ -425,11 +425,11 @@ std::optional<Value> convertSelectOp(PatternRewriter& rewriter, Operation* op,
                                      Value result_value, Value condition_value,
                                      Value x_value, Value y_value) {
   RankedTensorType result_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
   RankedTensorType condition_type =
-      condition_value.getType().dyn_cast<RankedTensorType>();
-  RankedTensorType x_type = x_value.getType().dyn_cast<RankedTensorType>();
-  RankedTensorType y_type = y_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(condition_value.getType());
+  RankedTensorType x_type = dyn_cast<RankedTensorType>(x_value.getType());
+  RankedTensorType y_type = dyn_cast<RankedTensorType>(y_value.getType());
 
   if (!x_type || !y_type || !condition_type) {
     (void)rewriter.notifyMatchFailure(op, "failed ranked tensor type check");
@@ -476,13 +476,13 @@ std::optional<Value> convertSelectOp(PatternRewriter& rewriter, Operation* op,
 std::optional<Value> convertZerosLikeOp(PatternRewriter& rewriter,
                                         Operation* op, Value result,
                                         Value input) {
-  RankedTensorType result_type = result.getType().dyn_cast<RankedTensorType>();
+  RankedTensorType result_type = dyn_cast<RankedTensorType>(result.getType());
   if (!result_type) {
     (void)rewriter.notifyMatchFailure(op, "result not ranked tensor type");
     return std::nullopt;
   }
 
-  RankedTensorType input_type = input.getType().dyn_cast<RankedTensorType>();
+  RankedTensorType input_type = dyn_cast<RankedTensorType>(input.getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input not ranked tensor type");
     return std::nullopt;
@@ -504,9 +504,9 @@ std::optional<Value> convertZerosLikeOp(PatternRewriter& rewriter,
 std::optional<Value> convertMultiplyOp(PatternRewriter& rewriter, Operation* op,
                                        Value output_val, Value input_lhs_val,
                                        Value input_rhs_val) {
-  ShapedType input_lhs_type = input_lhs_val.getType().dyn_cast<ShapedType>();
-  ShapedType input_rhs_type = input_rhs_val.getType().dyn_cast<ShapedType>();
-  ShapedType output_type = output_val.getType().dyn_cast<ShapedType>();
+  ShapedType input_lhs_type = dyn_cast<ShapedType>(input_lhs_val.getType());
+  ShapedType input_rhs_type = dyn_cast<ShapedType>(input_rhs_val.getType());
+  ShapedType output_type = dyn_cast<ShapedType>(output_val.getType());
   // Not a shaped tensor output
   if (!input_lhs_type || !input_rhs_type || !output_type) return std::nullopt;
 
@@ -570,14 +570,14 @@ std::optional<Value> convertSquaredDifferenceOp(PatternRewriter& rewriter,
                                                 Value x, Value y) {
   // Squared-difference is (x-y)*(x-y).
   // This lowering calculates the difference and multiplies.
-  ShapedType result_type = result.getType().dyn_cast<ShapedType>();
+  ShapedType result_type = dyn_cast<ShapedType>(result.getType());
   if (!result_type) {
     (void)rewriter.notifyMatchFailure(op, "result not ranked tensor type");
     return std::nullopt;
   }
 
-  ShapedType x_type = x.getType().dyn_cast<ShapedType>();
-  ShapedType y_type = y.getType().dyn_cast<ShapedType>();
+  ShapedType x_type = dyn_cast<ShapedType>(x.getType());
+  ShapedType y_type = dyn_cast<ShapedType>(y.getType());
   if (!x_type || !y_type) {
     (void)rewriter.notifyMatchFailure(op, "inputs not ranked tensor type");
     return std::nullopt;
@@ -595,13 +595,13 @@ std::optional<Value> convertSquaredDifferenceOp(PatternRewriter& rewriter,
 std::optional<Value> convertRoundOp(PatternRewriter& rewriter, Operation* op,
                                     Value result, Value input) {
   // Implements banker's rounding by calculating floor(input + 0.5).
-  ShapedType result_type = result.getType().dyn_cast<ShapedType>();
+  ShapedType result_type = dyn_cast<ShapedType>(result.getType());
   if (!result_type) {
     (void)rewriter.notifyMatchFailure(op, "result not shaped tensor type");
     return std::nullopt;
   }
 
-  ShapedType input_type = input.getType().dyn_cast<ShapedType>();
+  ShapedType input_type = dyn_cast<ShapedType>(input.getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input not shaped tensor type");
     return std::nullopt;
@@ -623,7 +623,7 @@ std::optional<Value> convertConcatV2Op(PatternRewriter& rewriter, Operation* op,
                                        int32_t axis) {
   // Check all inputs are RankedTensorType
   for (auto v : values) {
-    if (!v.getType().dyn_cast<RankedTensorType>()) {
+    if (!dyn_cast<RankedTensorType>(v.getType())) {
       (void)rewriter.notifyMatchFailure(op, "value type not ranked tensor");
       return std::nullopt;
     }
@@ -636,7 +636,7 @@ std::optional<Value> convertConcatV2Op(PatternRewriter& rewriter, Operation* op,
   SmallVector<Value> values_rescaled;
 
   for (auto v : values) {
-    RankedTensorType operand_type = v.getType().dyn_cast<RankedTensorType>();
+    RankedTensorType operand_type = dyn_cast<RankedTensorType>(v.getType());
     mlir::quant::UniformQuantizedType operand_quant_type =
         operand_type.getElementType()
             .dyn_cast_or_null<mlir::quant::UniformQuantizedType>();
@@ -744,13 +744,13 @@ std::optional<Value> convertSpaceToBatchNDOp(PatternRewriter& rewriter,
   //
 
   RankedTensorType result_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   RankedTensorType block_shape_type =
-      block_shape_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(block_shape_value.getType());
   RankedTensorType paddings_type =
-      paddings_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(paddings_value.getType());
 
   // Not a ranked tensor output.
   if (!result_type) {
@@ -1013,13 +1013,13 @@ std::optional<Value> convertBatchToSpaceNDOp(PatternRewriter& rewriter,
   // size=a4_size)
 
   RankedTensorType result_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   RankedTensorType block_shape_type =
-      block_shape_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(block_shape_value.getType());
   RankedTensorType crops_type =
-      crops_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(crops_value.getType());
 
   if (!result_type) {
     (void)rewriter.notifyMatchFailure(op, "result type not ranked tensor");
@@ -1218,7 +1218,7 @@ std::optional<Value> convertExpandDimsOp(PatternRewriter& rewriter,
                                          Value input_value, Value dim_value) {
   // Lowers to a reshape op with 1's inserted in the appropriate dimensions.
   RankedTensorType output_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
   // Not a ranked tensor output
   if (!output_type) {
     (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
@@ -1226,7 +1226,7 @@ std::optional<Value> convertExpandDimsOp(PatternRewriter& rewriter,
   }
 
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return std::nullopt;
@@ -1283,7 +1283,7 @@ std::optional<Value> convertSqueezeOp(PatternRewriter& rewriter, Operation* op,
   // Lowers to a reshape op where dimensions in squeeze_dims with size=1
   // are removed.
   RankedTensorType output_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
   // Not a ranked tensor output
   if (!output_type) {
     (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
@@ -1291,7 +1291,7 @@ std::optional<Value> convertSqueezeOp(PatternRewriter& rewriter, Operation* op,
   }
 
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return std::nullopt;
@@ -1354,7 +1354,7 @@ std::optional<Value> convertEluOp(PatternRewriter& rewriter, Operation* op,
   // a3 = ge(x, zero_bcast)
   // a4 = select(a3, x, a2)
   RankedTensorType output_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
   // Not a ranked tensor output
   if (!output_type) {
     (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
@@ -1407,9 +1407,9 @@ std::optional<Value> convertSoftmaxOp(PatternRewriter& rewriter, Operation* op,
   // For fp case, the normalization in the equation is required to prevent
   // float overflow in softmax's intermediate calculations.
   RankedTensorType output_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
   RankedTensorType input_type =
-      logits_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(logits_value.getType());
 
   // Not a ranked tensor input/output
   if (!output_type || !input_type) {
@@ -1843,7 +1843,7 @@ std::optional<Value> convertLogSoftmaxOp(PatternRewriter& rewriter,
   // op4 = mul(op1, op3)
   // op5 = log(op4)
 
-  TensorType output_type = result_value.getType().dyn_cast<TensorType>();
+  TensorType output_type = dyn_cast<TensorType>(result_value.getType());
   // Not a tensor output
   if (!output_type) {
     (void)rewriter.notifyMatchFailure(op, "output type not tensor");
@@ -1851,7 +1851,7 @@ std::optional<Value> convertLogSoftmaxOp(PatternRewriter& rewriter,
   }
 
   RankedTensorType input_type =
-      op->getOperand(0).getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(op->getOperand(0).getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return std::nullopt;
@@ -1906,7 +1906,7 @@ std::optional<Value> convertSpaceToDepthOp(PatternRewriter& rewriter,
   // orig_shape[3]*b*b])
   // return a4
   RankedTensorType output_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
 
   // Not a ranked tensor output.
   if (!output_type) {
@@ -1915,7 +1915,7 @@ std::optional<Value> convertSpaceToDepthOp(PatternRewriter& rewriter,
   }
 
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return std::nullopt;
@@ -2001,7 +2001,7 @@ std::optional<Value> convertDepthToSpaceOp(PatternRewriter& rewriter,
   // return a4
 
   RankedTensorType output_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
 
   // Not a ranked tensor output
   if (!output_type) {
@@ -2010,7 +2010,7 @@ std::optional<Value> convertDepthToSpaceOp(PatternRewriter& rewriter,
   }
 
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return std::nullopt;
@@ -2084,7 +2084,7 @@ std::optional<SmallVector<Value>> convertSplitOp(
   // with IdentityN to get from an array of Operations to a single Operation
   // with a list of result tensors.
   RankedTensorType result_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
   // Not a ranked tensor output
   if (!result_type) {
     (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
@@ -2092,7 +2092,7 @@ std::optional<SmallVector<Value>> convertSplitOp(
   }
 
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return std::nullopt;
@@ -2180,7 +2180,7 @@ std::optional<SmallVector<Value>> convertSplitVOp(
   // with IdentityN to get from an array of Operations to a single Operation
   // with a list of result tensors.
   RankedTensorType result_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
   // Not a ranked tensor output
   if (!result_type) {
     (void)rewriter.notifyMatchFailure(op, "output type not ranked tensor");
@@ -2188,7 +2188,7 @@ std::optional<SmallVector<Value>> convertSplitVOp(
   }
 
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input type not ranked tensor");
     return std::nullopt;
@@ -2294,7 +2294,7 @@ std::optional<Value> convertStridedSliceOp(
 
   // Limitations:
   // * This implementation only supports ellipsis_mask=0 for now
-  auto input_type = input_value.getType().dyn_cast<RankedTensorType>();
+  auto input_type = dyn_cast<RankedTensorType>(input_value.getType());
   ShapedType result_type = result_value.getType().cast<ShapedType>();
 
   if (ellipsis_mask != 0) {
@@ -2531,7 +2531,7 @@ std::optional<Value> convertFloorDivOp(PatternRewriter& rewriter, Operation* op,
   // a2 = mul(lhs, a1);
   // a3 = floor(a2);
   // return a3;
-  ShapedType output_type = result_value.getType().dyn_cast<ShapedType>();
+  ShapedType output_type = dyn_cast<ShapedType>(result_value.getType());
   // Not a shaped tensor output
   if (!output_type) return std::nullopt;
 
@@ -2566,7 +2566,7 @@ std::optional<Value> convertFloorModOp(PatternRewriter& rewriter, Operation* op,
   // return a4;
 
   RankedTensorType output_type =
-      result_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(result_value.getType());
   // Not a ranked tensor output
   if (!output_type) return std::nullopt;
 
@@ -2587,7 +2587,7 @@ std::optional<Value> convertFloorModOp(PatternRewriter& rewriter, Operation* op,
 std::optional<Value> convertFusedActivation(PatternRewriter& rewriter,
                                             Operation* op, Value input_value,
                                             StringAttr fused_activation_fn) {
-  ShapedType input_type = input_value.getType().dyn_cast<ShapedType>();
+  ShapedType input_type = dyn_cast<ShapedType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   bool input_is_qtype =
@@ -2756,7 +2756,7 @@ std::optional<Value> convertReduceOpCommon(
     bool is_quantized, double input_scale, int64_t input_zp,
     double output_scale, int64_t output_zp) {
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   ArrayRef<int64_t> input_shape = input_type.getShape();
@@ -2838,7 +2838,7 @@ std::optional<Value> convertReduceAllOp(PatternRewriter& rewriter,
                                         Value input_value,
                                         ElementsAttr axes_elems) {
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   return convertReduceOpCommon<tosa::ReduceAllOp>(
@@ -2853,7 +2853,7 @@ std::optional<Value> convertReduceAnyOp(PatternRewriter& rewriter,
                                         Value input_value,
                                         ElementsAttr axes_elems) {
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   return convertReduceOpCommon<tosa::ReduceAnyOp>(
@@ -2868,7 +2868,7 @@ std::optional<Value> convertReduceMinOp(PatternRewriter& rewriter,
                                         Value input_value,
                                         ElementsAttr axes_elems) {
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   return convertReduceOpCommon<tosa::ReduceMinOp>(
@@ -2883,7 +2883,7 @@ std::optional<Value> convertReduceMaxOp(PatternRewriter& rewriter,
                                         Value input_value,
                                         ElementsAttr axes_elems) {
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   return convertReduceOpCommon<tosa::ReduceMaxOp>(
@@ -2898,7 +2898,7 @@ std::optional<Value> convertReduceProdOp(PatternRewriter& rewriter,
                                          Value input_value,
                                          ElementsAttr axes_elems) {
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   bool input_is_qtype =
@@ -2924,7 +2924,7 @@ std::optional<Value> convertReduceSumOp(PatternRewriter& rewriter,
                                         Value input_value,
                                         ElementsAttr axes_elems) {
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   bool input_is_qtype =
@@ -2979,7 +2979,7 @@ std::optional<Value> convertReduceMeanOp(PatternRewriter& rewriter,
   // op2 = mul(op1, 1.0 / num_elements_on_reduced_axis)
 
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   bool input_is_qtype =
@@ -3060,7 +3060,7 @@ std::optional<Value> convertResizeOp(PatternRewriter& rewriter, Operation* op,
   const bool is_bilinear = mode == "BILINEAR";
   const bool is_nearest = mode == "NEAREST_NEIGHBOR";
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   if (input_type.getRank() != 4 || output_type.getRank() != 4) {
@@ -3293,7 +3293,7 @@ std::optional<Value> convertQuantizeOp(PatternRewriter& rewriter, Operation* op,
                                        Value input_value, double scale,
                                        int64_t zeropoint) {
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   auto output_element_type = output_type.getElementType();
@@ -3331,7 +3331,7 @@ std::optional<Value> convertDequantizeOp(PatternRewriter& rewriter,
                                          ArrayRef<float> zeropoint,
                                          int64_t dim) {
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   // input element type could only be quantized integer
@@ -3386,7 +3386,7 @@ std::optional<Value> convertFakeQuantOp(PatternRewriter& rewriter,
   // op2 = dequantize(op1)
 
   RankedTensorType input_type =
-      input_value.getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(input_value.getType());
   if (!input_type) return std::nullopt;
 
   // quantized as INT<num_bits>, where num_bits can only be 8, 16
@@ -3446,7 +3446,7 @@ std::optional<Value> convertMirrorPadCommon(PatternRewriter& rewriter,
                                             RankedTensorType output_type,
                                             Value input, Value pad,
                                             TFTFLMirrorPaddingType mode) {
-  RankedTensorType input_type = input.getType().dyn_cast<RankedTensorType>();
+  RankedTensorType input_type = dyn_cast<RankedTensorType>(input.getType());
   if (!input_type) {
     (void)rewriter.notifyMatchFailure(op, "input type isn't a ranked tensor");
     return std::nullopt;
@@ -3590,8 +3590,8 @@ std::optional<Value> convertTFConv2DCommon(
     Value input, Value filter, Value bias, ArrayAttr strides_attr,
     ArrayAttr dilations_attr, ArrayAttr explicit_padding_attr,
     StringRef padding_ref, StringRef data_format_ref) {
-  RankedTensorType input_type = input.getType().dyn_cast<RankedTensorType>();
-  RankedTensorType filter_type = filter.getType().dyn_cast<RankedTensorType>();
+  RankedTensorType input_type = dyn_cast<RankedTensorType>(input.getType());
+  RankedTensorType filter_type = dyn_cast<RankedTensorType>(filter.getType());
   // Not a ranked tensor output
   if (!input_type) return std::nullopt;
   if (!filter_type) return std::nullopt;
@@ -3778,9 +3778,9 @@ std::optional<Value> convertGatherOp(PatternRewriter& rewriter, Operation* op,
                                      Value result_value, Value params_value,
                                      Value indices_value, int32_t batch_dims,
                                      int32_t axis) {
-  auto result_type = result_value.getType().dyn_cast<ShapedType>();
-  auto params_type = params_value.getType().dyn_cast<RankedTensorType>();
-  auto indices_type = indices_value.getType().dyn_cast<RankedTensorType>();
+  auto result_type = dyn_cast<ShapedType>(result_value.getType());
+  auto params_type = dyn_cast<RankedTensorType>(params_value.getType());
+  auto indices_type = dyn_cast<RankedTensorType>(indices_value.getType());
 
   if (!result_type || !params_type || !indices_type) return std::nullopt;
 
@@ -3866,7 +3866,7 @@ std::optional<Value> convertGatherOp(PatternRewriter& rewriter, Operation* op,
   // tf/tfl allow i64 indices, but tosa does not.
   if (indices_type.getElementType().isInteger(64)) {
     indices_type =
-        indices_type.clone(rewriter.getI32Type()).dyn_cast<RankedTensorType>();
+        dyn_cast<RankedTensorType>(indices_type.clone(rewriter.getI32Type()));
     indices_value = CreateOpAndInfer<tosa::CastOp>(rewriter, op->getLoc(),
                                                    indices_type, indices_value)
                         .getResult();
@@ -4071,9 +4071,9 @@ std::optional<Value> convertGatherNdOp(PatternRewriter& rewriter, Operation* op,
                                        Value indices_value)
 
 {
-  auto result_type = result_value.getType().dyn_cast<RankedTensorType>();
-  auto params_type = params_value.getType().dyn_cast<RankedTensorType>();
-  auto indices_type = indices_value.getType().dyn_cast<RankedTensorType>();
+  auto result_type = dyn_cast<RankedTensorType>(result_value.getType());
+  auto params_type = dyn_cast<RankedTensorType>(params_value.getType());
+  auto indices_type = dyn_cast<RankedTensorType>(indices_value.getType());
 
   if (!result_type || !params_type || !indices_type) return std::nullopt;
 
@@ -4248,10 +4248,10 @@ std::optional<Value> convertOneHotOp(PatternRewriter& rewriter, Operation* op,
                                      Value result_value, Value indices_value,
                                      Value on_value, Value off_value,
                                      int32_t depth, int32_t axis) {
-  auto result_type = result_value.getType().dyn_cast<RankedTensorType>();
-  auto indices_type = indices_value.getType().dyn_cast<RankedTensorType>();
-  auto on_value_type = on_value.getType().dyn_cast<RankedTensorType>();
-  auto off_value_type = off_value.getType().dyn_cast<RankedTensorType>();
+  auto result_type = dyn_cast<RankedTensorType>(result_value.getType());
+  auto indices_type = dyn_cast<RankedTensorType>(indices_value.getType());
+  auto on_value_type = dyn_cast<RankedTensorType>(on_value.getType());
+  auto off_value_type = dyn_cast<RankedTensorType>(off_value.getType());
 
   if (!result_type || !indices_type || !on_value_type || !off_value_type)
     return std::nullopt;
@@ -4397,7 +4397,7 @@ std::optional<Value> convertOneHotOp(PatternRewriter& rewriter, Operation* op,
 // Lowers Sin operator to a sequence of TOSA ops.
 std::optional<Value> convertSinOp(PatternRewriter& rewriter, Operation* op,
                                   Value input, ShapedType output_type) {
-  RankedTensorType input_type = input.getType().dyn_cast<RankedTensorType>();
+  RankedTensorType input_type = dyn_cast<RankedTensorType>(input.getType());
   Location loc = op->getLoc();
 
   Type input_ety = input_type.getElementType();

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
@@ -158,7 +158,7 @@ LogicalResult ConvertTFReluOp::matchAndRewrite(
   auto tf_relu_op = cast<TF::ReluOp>(op);
 
   TensorType output_type =
-      tf_relu_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_relu_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -176,7 +176,7 @@ LogicalResult ConvertTFRelu6Op::matchAndRewrite(
   auto tf_relu6_op = cast<TF::Relu6Op>(op);
 
   TensorType output_type =
-      tf_relu6_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_relu6_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -192,7 +192,7 @@ LogicalResult ConvertTFEqualOp::matchAndRewrite(
   auto tf_equal_op = cast<TF::EqualOp>(op);
 
   TensorType output_type =
-      tf_equal_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_equal_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -206,7 +206,7 @@ LogicalResult ConvertTFNotEqualOp::matchAndRewrite(
   auto tf_not_equal_op = cast<TF::NotEqualOp>(op);
 
   TensorType output_type =
-      tf_not_equal_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_not_equal_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -227,7 +227,7 @@ LogicalResult ConvertTFGreaterOp::matchAndRewrite(
   auto tf_greater_op = cast<TF::GreaterOp>(op);
 
   TensorType output_type =
-      tf_greater_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_greater_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -241,7 +241,7 @@ LogicalResult ConvertTFGreaterEqualOp::matchAndRewrite(
   auto tf_greater_equal_op = cast<TF::GreaterEqualOp>(op);
 
   TensorType output_type =
-      tf_greater_equal_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_greater_equal_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -283,8 +283,8 @@ LogicalResult ConvertTFCosOp::matchAndRewrite(Operation* op,
                                               PatternRewriter& rewriter) const {
   auto tf_cos_op = cast<TF::CosOp>(op);
   Value input = tf_cos_op.getX();
-  RankedTensorType input_ty = input.getType().dyn_cast<RankedTensorType>();
-  ShapedType output_ty = tf_cos_op.getResult().getType().dyn_cast<ShapedType>();
+  RankedTensorType input_ty = dyn_cast<RankedTensorType>(input.getType());
+  ShapedType output_ty = dyn_cast<ShapedType>(tf_cos_op.getResult().getType());
 
   if (!input_ty || !output_ty) return failure();
 
@@ -313,7 +313,7 @@ LogicalResult ConvertTFAddOp::matchAndRewrite(Operation* op,
   auto tf_add_op = cast<TF::AddOp>(op);
 
   TensorType output_type =
-      tf_add_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_add_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -327,7 +327,7 @@ LogicalResult ConvertTFAddV2Op::matchAndRewrite(
   auto tf_addv2_op = cast<TF::AddV2Op>(op);
 
   TensorType output_type =
-      tf_addv2_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_addv2_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -342,7 +342,7 @@ LogicalResult ConvertTFAddNOp::matchAndRewrite(
   auto tf_addn_op = cast<TF::AddNOp>(op);
 
   TensorType output_type =
-      tf_addn_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_addn_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -367,7 +367,7 @@ LogicalResult ConvertTFSubOp::matchAndRewrite(Operation* op,
   auto tf_sub_op = cast<TF::SubOp>(op);
 
   TensorType output_type =
-      tf_sub_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_sub_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -421,7 +421,7 @@ LogicalResult ConvertTFRoundOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tf_round_op = cast<TF::RoundOp>(op);
 
-  TensorType input_type = tf_round_op.getX().getType().dyn_cast<TensorType>();
+  TensorType input_type = dyn_cast<TensorType>(tf_round_op.getX().getType());
   if (!input_type) {
     return rewriter.notifyMatchFailure(op, "input not tensor type");
   }
@@ -483,7 +483,7 @@ LogicalResult ConvertTFMaximumOp::matchAndRewrite(
   auto tf_maximum_op = cast<TF::MaximumOp>(op);
 
   TensorType output_type =
-      tf_maximum_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_maximum_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -497,7 +497,7 @@ LogicalResult ConvertTFMinimumOp::matchAndRewrite(
   auto tf_minimum_op = cast<TF::MinimumOp>(op);
 
   TensorType output_type =
-      tf_minimum_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_minimum_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -510,9 +510,9 @@ LogicalResult ConvertTFRealDivOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tf_div_op = cast<TF::RealDivOp>(op);
 
-  TensorType y_type = tf_div_op.getY().getType().dyn_cast<TensorType>();
+  TensorType y_type = dyn_cast<TensorType>(tf_div_op.getY().getType());
   TensorType output_type =
-      tf_div_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_div_op.getResult().getType());
   // Not a tensor output
   if (!output_type || !y_type) return failure();
 
@@ -540,9 +540,9 @@ LogicalResult ConvertTFArgMaxOp::matchAndRewrite(
   auto tf_argmax_op = cast<TF::ArgMaxOp>(op);
 
   TensorType input_type =
-      tf_argmax_op.getInput().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_argmax_op.getInput().getType());
   TensorType output_type =
-      tf_argmax_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_argmax_op.getResult().getType());
   // Not a tensor output
   if (!output_type || !input_type) return failure();
 
@@ -572,9 +572,9 @@ LogicalResult ConvertTFAvgPoolOp::matchAndRewrite(
   auto tf_avgpool_op = cast<TF::AvgPoolOp>(op);
 
   RankedTensorType input_type =
-      tf_avgpool_op.getValue().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_avgpool_op.getValue().getType());
   RankedTensorType output_type =
-      tf_avgpool_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_avgpool_op.getResult().getType());
   // Not a ranked tensor output
   if (!input_type || !output_type) return failure();
 
@@ -590,8 +590,8 @@ LogicalResult ConvertTFAvgPoolOp::matchAndRewrite(
       stride = rewriter.getDenseI64ArrayAttr({1, 1});
     } else {
       // Note: hardcoded to NHWC for now
-      int64_t stride_h = tmpAttr[1].dyn_cast<IntegerAttr>().getInt();
-      int64_t stride_w = tmpAttr[2].dyn_cast<IntegerAttr>().getInt();
+      int64_t stride_h = dyn_cast<IntegerAttr>(tmpAttr[1]).getInt();
+      int64_t stride_w = dyn_cast<IntegerAttr>(tmpAttr[2]).getInt();
       stride = rewriter.getDenseI64ArrayAttr({stride_h, stride_w});
     }
   }
@@ -601,8 +601,8 @@ LogicalResult ConvertTFAvgPoolOp::matchAndRewrite(
       kernel = rewriter.getDenseI64ArrayAttr({1, 1});
     } else {
       // Note: hardcoded to NHWC for now
-      int64_t kernel_h = tmpAttr[1].dyn_cast<IntegerAttr>().getInt();
-      int64_t kernel_w = tmpAttr[2].dyn_cast<IntegerAttr>().getInt();
+      int64_t kernel_h = dyn_cast<IntegerAttr>(tmpAttr[1]).getInt();
+      int64_t kernel_w = dyn_cast<IntegerAttr>(tmpAttr[2]).getInt();
       kernel = rewriter.getDenseI64ArrayAttr({kernel_h, kernel_w});
     }
   }
@@ -617,7 +617,7 @@ LogicalResult ConvertTFAvgPoolOp::matchAndRewrite(
     SmallVector<int64_t, 4> i64array;
 
     for (auto& elem : tf_avgpool_op.getKsize()) {
-      int64_t value = elem.dyn_cast<IntegerAttr>().getInt();
+      int64_t value = dyn_cast<IntegerAttr>(elem).getInt();
       i64array.emplace_back(value);
     }
 
@@ -648,9 +648,9 @@ LogicalResult ConvertTFMaxPoolOp::matchAndRewrite(
   auto tf_maxpool_op = cast<TF::MaxPoolOp>(op);
 
   RankedTensorType input_type =
-      tf_maxpool_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_maxpool_op.getInput().getType());
   RankedTensorType output_type =
-      tf_maxpool_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_maxpool_op.getResult().getType());
   // Not a ranked tensor output
   if (!input_type || !output_type) return failure();
 
@@ -666,8 +666,8 @@ LogicalResult ConvertTFMaxPoolOp::matchAndRewrite(
       stride = rewriter.getDenseI64ArrayAttr({1, 1});
     } else {
       // Note: hardcoded to NHWC for now
-      int64_t stride_h = tmpAttr[1].dyn_cast<IntegerAttr>().getInt();
-      int64_t stride_w = tmpAttr[2].dyn_cast<IntegerAttr>().getInt();
+      int64_t stride_h = dyn_cast<IntegerAttr>(tmpAttr[1]).getInt();
+      int64_t stride_w = dyn_cast<IntegerAttr>(tmpAttr[2]).getInt();
       stride = rewriter.getDenseI64ArrayAttr({stride_h, stride_w});
     }
   }
@@ -677,8 +677,8 @@ LogicalResult ConvertTFMaxPoolOp::matchAndRewrite(
       kernel = rewriter.getDenseI64ArrayAttr({1, 1});
     } else {
       // Note: hardcoded to NHWC for now
-      int64_t kernel_h = tmpAttr[1].dyn_cast<IntegerAttr>().getInt();
-      int64_t kernel_w = tmpAttr[2].dyn_cast<IntegerAttr>().getInt();
+      int64_t kernel_h = dyn_cast<IntegerAttr>(tmpAttr[1]).getInt();
+      int64_t kernel_w = dyn_cast<IntegerAttr>(tmpAttr[2]).getInt();
       kernel = rewriter.getDenseI64ArrayAttr({kernel_h, kernel_w});
     }
   }
@@ -693,7 +693,7 @@ LogicalResult ConvertTFMaxPoolOp::matchAndRewrite(
     SmallVector<int64_t, 4> i64array;
 
     for (auto& elem : tf_maxpool_op.getKsize()) {
-      int64_t value = elem.dyn_cast<IntegerAttr>().getInt();
+      int64_t value = dyn_cast<IntegerAttr>(elem).getInt();
       i64array.emplace_back(value);
     }
 
@@ -740,7 +740,7 @@ LogicalResult ConvertTFReshapeOp::matchAndRewrite(
   auto tf_reshape_op = cast<TF::ReshapeOp>(op);
 
   RankedTensorType output_type =
-      tf_reshape_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_reshape_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -762,7 +762,7 @@ LogicalResult ConvertTFRankOp::matchAndRewrite(
   auto tf_rank_op = cast<TF::RankOp>(op);
 
   RankedTensorType input_type =
-      tf_rank_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_rank_op.getInput().getType());
   if (!input_type) return failure();
 
   int32_t rank = input_type.getRank();
@@ -783,12 +783,12 @@ LogicalResult ConvertTFShapeOp::matchAndRewrite(
   auto tf_shape_op = cast<TF::ShapeOp>(op);
 
   RankedTensorType output_type =
-      tf_shape_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_shape_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
   RankedTensorType input_type =
-      tf_shape_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_shape_op.getInput().getType());
   if (!input_type) return failure();
 
   auto input_shape = input_type.getShape();
@@ -833,7 +833,7 @@ LogicalResult ConvertTFSqueezeOp::matchAndRewrite(
   auto squeeze_dims_attr = tf_squeeze_op.getSqueezeDimsAttr();
   SmallVector<int32_t> squeeze_dims;
   for (auto& squeeze_dim : squeeze_dims_attr) {
-    squeeze_dims.emplace_back(squeeze_dim.dyn_cast<IntegerAttr>().getInt());
+    squeeze_dims.emplace_back(dyn_cast<IntegerAttr>(squeeze_dim).getInt());
   }
 
   std::optional<Value> result =
@@ -852,7 +852,7 @@ LogicalResult ConvertTFFillOp::matchAndRewrite(
   auto tf_fill_op = cast<TF::FillOp>(op);
 
   RankedTensorType output_type =
-      tf_fill_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_fill_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -901,9 +901,9 @@ LogicalResult ConvertTFConv2DOp::matchAndRewrite(
   auto tf_conv2d_op = cast<TF::Conv2DOp>(op);
 
   RankedTensorType filter_type =
-      tf_conv2d_op.getFilter().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_conv2d_op.getFilter().getType());
   RankedTensorType output_type =
-      tf_conv2d_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_conv2d_op.getResult().getType());
 
   // Set up a zero attr for subsequent pattern replacement if required
   auto bias_dim = filter_type.getShape().back();
@@ -931,9 +931,9 @@ LogicalResult ConvertTFConv3DOp::matchAndRewrite(
   auto tf_conv3d_op = cast<TF::Conv3DOp>(op);
 
   RankedTensorType filter_type =
-      tf_conv3d_op.getFilter().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_conv3d_op.getFilter().getType());
   RankedTensorType output_type =
-      tf_conv3d_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_conv3d_op.getResult().getType());
 
   if (!filter_type || !output_type) {
     return rewriter.notifyMatchFailure(
@@ -966,11 +966,11 @@ LogicalResult ConvertTFDepthwiseConv2dNativeOp::matchAndRewrite(
   auto tf_dwconv2d_op = cast<TF::DepthwiseConv2dNativeOp>(op);
 
   RankedTensorType input_type =
-      tf_dwconv2d_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_dwconv2d_op.getInput().getType());
   RankedTensorType filter_type =
-      tf_dwconv2d_op.getFilter().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_dwconv2d_op.getFilter().getType());
   RankedTensorType output_type =
-      tf_dwconv2d_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_dwconv2d_op.getResult().getType());
   // Not a ranked tensor output
   if (!input_type) return failure();
   if (!output_type) return failure();
@@ -992,8 +992,8 @@ LogicalResult ConvertTFDepthwiseConv2dNativeOp::matchAndRewrite(
       stride = rewriter.getDenseI64ArrayAttr({1, 1});
     } else {
       // Note: hardcoded to NHWC for now
-      int64_t stride_h = tmpAttr[1].dyn_cast<IntegerAttr>().getInt();
-      int64_t stride_w = tmpAttr[2].dyn_cast<IntegerAttr>().getInt();
+      int64_t stride_h = dyn_cast<IntegerAttr>(tmpAttr[1]).getInt();
+      int64_t stride_w = dyn_cast<IntegerAttr>(tmpAttr[2]).getInt();
       stride = rewriter.getDenseI64ArrayAttr({stride_h, stride_w});
     }
   }
@@ -1003,8 +1003,8 @@ LogicalResult ConvertTFDepthwiseConv2dNativeOp::matchAndRewrite(
       dilation = rewriter.getDenseI64ArrayAttr({1, 1});
     } else {
       // Note: hardcoded to NHWC for now
-      int64_t dilation_h = tmpAttr[1].dyn_cast<IntegerAttr>().getInt();
-      int64_t dilation_w = tmpAttr[2].dyn_cast<IntegerAttr>().getInt();
+      int64_t dilation_h = dyn_cast<IntegerAttr>(tmpAttr[1]).getInt();
+      int64_t dilation_w = dyn_cast<IntegerAttr>(tmpAttr[2]).getInt();
       dilation = rewriter.getDenseI64ArrayAttr({dilation_h, dilation_w});
     }
   }
@@ -1049,11 +1049,11 @@ LogicalResult ConvertTFConv2DBackpropInputOp::matchAndRewrite(
   auto tf_conv_op = cast<TF::Conv2DBackpropInputOp>(op);
 
   RankedTensorType input_type =
-      tf_conv_op.getOutBackprop().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_conv_op.getOutBackprop().getType());
   RankedTensorType filter_type =
-      tf_conv_op.getFilter().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_conv_op.getFilter().getType());
   RankedTensorType output_type =
-      tf_conv_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_conv_op.getResult().getType());
   // Not a ranked tensor output
   if (!input_type) return failure();
   if (!filter_type) return failure();
@@ -1086,8 +1086,8 @@ LogicalResult ConvertTFConv2DBackpropInputOp::matchAndRewrite(
       stride = rewriter.getDenseI64ArrayAttr({1, 1});
     } else {
       // Note: hardcoded to NHWC for now
-      int64_t stride_h = tmpAttr[1].dyn_cast<IntegerAttr>().getInt();
-      int64_t stride_w = tmpAttr[2].dyn_cast<IntegerAttr>().getInt();
+      int64_t stride_h = dyn_cast<IntegerAttr>(tmpAttr[1]).getInt();
+      int64_t stride_w = dyn_cast<IntegerAttr>(tmpAttr[2]).getInt();
       stride = rewriter.getDenseI64ArrayAttr({stride_h, stride_w});
     }
   }
@@ -1095,8 +1095,8 @@ LogicalResult ConvertTFConv2DBackpropInputOp::matchAndRewrite(
     auto tmpAttr = tf_conv_op.getDilations();
     if (tmpAttr) {
       // Note: hardcoded to NHWC for now
-      int64_t dilation_h = tmpAttr[1].dyn_cast<IntegerAttr>().getInt();
-      int64_t dilation_w = tmpAttr[2].dyn_cast<IntegerAttr>().getInt();
+      int64_t dilation_h = dyn_cast<IntegerAttr>(tmpAttr[1]).getInt();
+      int64_t dilation_w = dyn_cast<IntegerAttr>(tmpAttr[2]).getInt();
       // TOSA transpose_conv2d does not support non-unit dilation
       if (dilation_h != 1 || dilation_w != 1) return failure();
     }
@@ -1157,7 +1157,7 @@ LogicalResult ConvertTFAllOp::matchAndRewrite(Operation* op,
   auto tf_all_op = cast<TF::AllOp>(op);
 
   RankedTensorType output_type =
-      tf_all_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_all_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -1179,7 +1179,7 @@ LogicalResult ConvertTFAnyOp::matchAndRewrite(Operation* op,
   auto tf_any_op = cast<TF::AnyOp>(op);
 
   RankedTensorType output_type =
-      tf_any_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_any_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -1201,7 +1201,7 @@ LogicalResult ConvertTFMaxOp::matchAndRewrite(Operation* op,
   auto tf_max_op = cast<TF::MaxOp>(op);
 
   RankedTensorType output_type =
-      tf_max_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_max_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -1223,7 +1223,7 @@ LogicalResult ConvertTFMinOp::matchAndRewrite(Operation* op,
   auto tf_min_op = cast<TF::MinOp>(op);
 
   RankedTensorType output_type =
-      tf_min_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_min_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -1245,7 +1245,7 @@ LogicalResult ConvertTFMeanOp::matchAndRewrite(
   auto tf_mean_op = cast<TF::MeanOp>(op);
 
   RankedTensorType output_type =
-      tf_mean_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_mean_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -1267,7 +1267,7 @@ LogicalResult ConvertTFProdOp::matchAndRewrite(
   auto tf_prod_op = cast<TF::ProdOp>(op);
 
   RankedTensorType output_type =
-      tf_prod_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_prod_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -1289,7 +1289,7 @@ LogicalResult ConvertTFSumOp::matchAndRewrite(Operation* op,
   auto tf_sum_op = cast<TF::SumOp>(op);
 
   RankedTensorType output_type =
-      tf_sum_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_sum_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -1354,7 +1354,7 @@ LogicalResult ConvertTFFusedBatchNormOp::matchAndRewrite(
   auto tf_batchnorm_op = cast<TF::FusedBatchNormOp>(op);
 
   RankedTensorType output_type =
-      tf_batchnorm_op.getResult(0).getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_batchnorm_op.getResult(0).getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -1379,9 +1379,9 @@ LogicalResult ConvertTFFusedBatchNormOp::matchAndRewrite(
   // op6 = add(op5, boffset)
 
   RankedTensorType mean_type =
-      tf_batchnorm_op.getMean().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_batchnorm_op.getMean().getType());
   RankedTensorType variance_type =
-      tf_batchnorm_op.getVariance().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_batchnorm_op.getVariance().getType());
   if (!variance_type || !mean_type) return failure();
 
   Value mean_val, variance_val;
@@ -1451,7 +1451,7 @@ LogicalResult ConvertTFFusedBatchNormV3Op::matchAndRewrite(
   }
 
   RankedTensorType output_type =
-      tf_batchnorm_op.getResult(0).getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_batchnorm_op.getResult(0).getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -1469,7 +1469,7 @@ LogicalResult ConvertTFFusedBatchNormV3Op::matchAndRewrite(
       tf_batchnorm_op.getX(), tf_batchnorm_op.getMean());
 
   RankedTensorType variance_type =
-      tf_batchnorm_op.getVariance().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_batchnorm_op.getVariance().getType());
   if (!variance_type) return failure();
 
   auto epsilon_type =
@@ -1514,7 +1514,7 @@ LogicalResult ConvertTFBiasAddOp::matchAndRewrite(
   auto tf_biasadd_op = cast<TF::BiasAddOp>(op);
 
   RankedTensorType output_type =
-      tf_biasadd_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_biasadd_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -1531,7 +1531,7 @@ LogicalResult ConvertTFSliceOp::matchAndRewrite(
   auto tf_slice_op = cast<TF::SliceOp>(op);
 
   RankedTensorType output_type =
-      tf_slice_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_slice_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -1570,7 +1570,7 @@ LogicalResult ConvertTFTileOp::matchAndRewrite(
   auto tf_tile_op = cast<TF::TileOp>(op);
 
   RankedTensorType output_type =
-      tf_tile_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_tile_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -1596,7 +1596,7 @@ LogicalResult ConvertTFTransposeOp::matchAndRewrite(
   auto tf_transpose_op = cast<TF::TransposeOp>(op);
 
   TensorType output_type =
-      tf_transpose_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_transpose_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) {
     return failure();
@@ -1724,7 +1724,7 @@ LogicalResult ConvertTFLessOp::matchAndRewrite(
   auto tf_less_op = cast<TF::LessOp>(op);
 
   TensorType output_type =
-      tf_less_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_less_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -1745,7 +1745,7 @@ LogicalResult ConvertTFLessEqualOp::matchAndRewrite(
   auto tf_less_equal_op = cast<TF::LessEqualOp>(op);
 
   TensorType output_type =
-      tf_less_equal_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_less_equal_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -1765,7 +1765,7 @@ LogicalResult ConvertTFPadOp::matchAndRewrite(Operation* op,
   auto tf_pad_op = cast<TF::PadOp>(op);
 
   TensorType output_type =
-      tf_pad_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_pad_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -1782,7 +1782,7 @@ LogicalResult ConvertTFMirrorPadOp::matchAndRewrite(
   auto tf_mirrorpad_op = cast<TF::MirrorPadOp>(op);
 
   RankedTensorType output_type =
-      tf_mirrorpad_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_mirrorpad_op.getResult().getType());
   if (!output_type) {
     return rewriter.notifyMatchFailure(op, "output type isn't a ranked tensor");
   }
@@ -1812,7 +1812,7 @@ LogicalResult ConvertTFResizeBilinearOp::matchAndRewrite(
   auto tf_resize_op = cast<TF::ResizeBilinearOp>(op);
 
   RankedTensorType output_type =
-      tf_resize_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_resize_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -1833,7 +1833,7 @@ LogicalResult ConvertTFResizeNearestNeighborOp::matchAndRewrite(
   auto tf_resize_op = cast<TF::ResizeNearestNeighborOp>(op);
 
   RankedTensorType output_type =
-      tf_resize_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_resize_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -1855,11 +1855,11 @@ LogicalResult ConvertTFMatMulOp::matchAndRewrite(
   auto tf_matmul_op = cast<TF::MatMulOp>(op);
 
   RankedTensorType a_type =
-      tf_matmul_op.getA().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_matmul_op.getA().getType());
   RankedTensorType b_type =
-      tf_matmul_op.getB().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_matmul_op.getB().getType());
   RankedTensorType output_type =
-      tf_matmul_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_matmul_op.getResult().getType());
 
   if (!(a_type && b_type && output_type)) {
     return rewriter.notifyMatchFailure(op, "a/b/output not ranked tensors");
@@ -2081,7 +2081,7 @@ LogicalResult ConvertTFSigmoidOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tf_sigmoid_op = cast<TF::SigmoidOp>(op);
   TensorType output_type =
-      tf_sigmoid_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_sigmoid_op.getResult().getType());
   if (!output_type) return failure();
 
   CreateReplaceOpAndInfer<tosa::SigmoidOp>(rewriter, op, output_type,
@@ -2094,7 +2094,7 @@ LogicalResult ConvertTFTanhOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tf_tanh_op = cast<TF::TanhOp>(op);
   TensorType output_type =
-      tf_tanh_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_tanh_op.getResult().getType());
   if (!output_type) return failure();
 
   CreateReplaceOpAndInfer<tosa::TanhOp>(rewriter, op, output_type,
@@ -2107,7 +2107,7 @@ LogicalResult ConvertTFLeakyReluOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tf_leakyrelu_op = cast<TF::LeakyReluOp>(op);
   TensorType output_type =
-      tf_leakyrelu_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_leakyrelu_op.getResult().getType());
   if (!output_type) return failure();
 
   // Implement LeakyRelu as element-wise:
@@ -2163,7 +2163,7 @@ LogicalResult ConvertTFNegOp::matchAndRewrite(Operation* op,
                                               PatternRewriter& rewriter) const {
   auto tf_neg_op = cast<TF::NegOp>(op);
   TensorType output_type =
-      tf_neg_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_neg_op.getResult().getType());
   if (!output_type) return failure();
 
   CreateReplaceOpAndInfer<tosa::NegateOp>(rewriter, op, output_type,
@@ -2176,7 +2176,7 @@ LogicalResult ConvertTFStopGradientOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tf_stopgrad_op = cast<TF::StopGradientOp>(op);
   TensorType output_type =
-      tf_stopgrad_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_stopgrad_op.getResult().getType());
   if (!output_type) return failure();
 
   CreateReplaceOpAndInfer<tosa::IdentityOp>(rewriter, op, output_type,
@@ -2189,9 +2189,9 @@ LogicalResult ConvertTFReverseV2Op::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tf_reverse_op = cast<TF::ReverseV2Op>(op);
   RankedTensorType input_type =
-      tf_reverse_op.getTensor().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_reverse_op.getTensor().getType());
   TensorType output_type =
-      tf_reverse_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_reverse_op.getResult().getType());
   if (!input_type || !output_type) return failure();
 
   ElementsAttr axis_elems;
@@ -2226,7 +2226,7 @@ LogicalResult ConvertTFFakeQuantWithMinMaxArgsOp::matchAndRewrite(
   auto tf_fakequant_op = cast<TF::FakeQuantWithMinMaxArgsOp>(op);
 
   TensorType output_type =
-      tf_fakequant_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_fakequant_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -2249,7 +2249,7 @@ LogicalResult ConvertTFFakeQuantWithMinMaxVarsOp::matchAndRewrite(
   auto tf_fakequant_op = cast<TF::FakeQuantWithMinMaxVarsOp>(op);
 
   TensorType output_type =
-      tf_fakequant_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_fakequant_op.getResult().getType());
   // Not a tensor output
   if (!output_type) return failure();
 
@@ -2284,7 +2284,7 @@ LogicalResult ConvertTFLeftShiftOp::matchAndRewrite(
   auto tf_left_shift_op = cast<TF::LeftShiftOp>(op);
 
   TensorType output_type =
-      tf_left_shift_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_left_shift_op.getResult().getType());
   if (!output_type) return failure();
 
   CreateReplaceOpAndInfer<tosa::LogicalLeftShiftOp>(rewriter, op, output_type,
@@ -2301,7 +2301,7 @@ LogicalResult ConvertTFRightShiftOp::matchAndRewrite(
   auto tf_right_shift_op = cast<TF::RightShiftOp>(op);
 
   TensorType output_type =
-      tf_right_shift_op.getResult().getType().dyn_cast<TensorType>();
+      dyn_cast<TensorType>(tf_right_shift_op.getResult().getType());
   if (!output_type) return failure();
 
   Type output_element_type = output_type.getElementType();
@@ -2350,11 +2350,11 @@ LogicalResult ConvertTFBatchMatMulV2Op::matchAndRewrite(
   auto tf_batch_matmul_op = cast<TF::BatchMatMulV2Op>(op);
 
   RankedTensorType x_type =
-      tf_batch_matmul_op.getX().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_batch_matmul_op.getX().getType());
   RankedTensorType y_type =
-      tf_batch_matmul_op.getY().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_batch_matmul_op.getY().getType());
   RankedTensorType output_type =
-      tf_batch_matmul_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tf_batch_matmul_op.getResult().getType());
 
   if (!(x_type && y_type && output_type)) {
     return rewriter.notifyMatchFailure(op, "x/y/output not ranked tensors");

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -202,19 +202,18 @@ LogicalResult ConvertTFLGeluOp::matchAndRewrite(
   Location loc = op->getLoc();
 
   Value input = tfl_gelu_op.getInput();
-  RankedTensorType input_type = input.getType().dyn_cast<RankedTensorType>();
+  RankedTensorType input_type = dyn_cast<RankedTensorType>(input.getType());
   RankedTensorType output_type =
-      tfl_gelu_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_gelu_op.getResult().getType());
   if (!input_type || !output_type) {
     return rewriter.notifyMatchFailure(
         op, "input/output are not all a ranked tensor");
   }
 
   UniformQuantizedType in_quant_type =
-      input_type.getElementType().dyn_cast<mlir::quant::UniformQuantizedType>();
+      dyn_cast<mlir::quant::UniformQuantizedType>(input_type.getElementType());
   UniformQuantizedType out_quant_type =
-      output_type.getElementType()
-          .dyn_cast<mlir::quant::UniformQuantizedType>();
+      dyn_cast<mlir::quant::UniformQuantizedType>(output_type.getElementType());
 
   if ((in_quant_type == nullptr) != (out_quant_type == nullptr)) {
     return rewriter.notifyMatchFailure(
@@ -302,9 +301,9 @@ LogicalResult ConvertTFLReluOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_relu_op = cast<TFL::ReluOp>(op);
 
-  ShapedType input_type = tfl_relu_op.getX().getType().dyn_cast<ShapedType>();
+  ShapedType input_type = dyn_cast<ShapedType>(tfl_relu_op.getX().getType());
   ShapedType output_type =
-      tfl_relu_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_relu_op.getResult().getType());
   // Not a ranked tensor output
   if (!input_type || !output_type) return failure();
 
@@ -324,11 +323,11 @@ LogicalResult ConvertTFLReluOp::matchAndRewrite(
 
   if (output_is_qtype) {
     UniformQuantizedType input_qtype =
-        input_type.getElementType()
-            .dyn_cast<mlir::quant::UniformQuantizedType>();
+        dyn_cast<mlir::quant::UniformQuantizedType>(
+            input_type.getElementType());
     UniformQuantizedType output_qtype =
-        output_type.getElementType()
-            .dyn_cast<mlir::quant::UniformQuantizedType>();
+        dyn_cast<mlir::quant::UniformQuantizedType>(
+            output_type.getElementType());
 
     clamp_min = output_qtype.getZeroPoint();
     TrimQuantizedIntegerRangeMin(input_qtype, clamp_min);
@@ -354,9 +353,9 @@ LogicalResult ConvertTFLRelu1Op::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_relu1_op = cast<TFL::Relu1Op>(op);
 
-  ShapedType input_type = tfl_relu1_op.getX().getType().dyn_cast<ShapedType>();
+  ShapedType input_type = dyn_cast<ShapedType>(tfl_relu1_op.getX().getType());
   ShapedType output_type =
-      tfl_relu1_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_relu1_op.getResult().getType());
   // Not a ranked tensor output
   if (!input_type || !output_type) return failure();
 
@@ -377,11 +376,11 @@ LogicalResult ConvertTFLRelu1Op::matchAndRewrite(
 
   if (output_is_qtype && input_is_qtype) {
     UniformQuantizedType input_qtype =
-        input_type.getElementType()
-            .dyn_cast<mlir::quant::UniformQuantizedType>();
+        dyn_cast<mlir::quant::UniformQuantizedType>(
+            input_type.getElementType());
     UniformQuantizedType output_qtype =
-        output_type.getElementType()
-            .dyn_cast<mlir::quant::UniformQuantizedType>();
+        dyn_cast<mlir::quant::UniformQuantizedType>(
+            output_type.getElementType());
 
     clamp_min = output_qtype.getZeroPoint() -
                 std::llround(1.0f / output_qtype.getScale());
@@ -463,9 +462,9 @@ LogicalResult ConvertTFLRelu6Op::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_relu6_op = cast<TFL::Relu6Op>(op);
 
-  ShapedType input_type = tfl_relu6_op.getX().getType().dyn_cast<ShapedType>();
+  ShapedType input_type = dyn_cast<ShapedType>(tfl_relu6_op.getX().getType());
   ShapedType output_type =
-      tfl_relu6_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_relu6_op.getResult().getType());
   // Not a ranked tensor output
   if (!input_type || !output_type) return failure();
 
@@ -486,11 +485,11 @@ LogicalResult ConvertTFLRelu6Op::matchAndRewrite(
 
   if (output_is_qtype && input_is_qtype) {
     UniformQuantizedType input_qtype =
-        input_type.getElementType()
-            .dyn_cast<mlir::quant::UniformQuantizedType>();
+        dyn_cast<mlir::quant::UniformQuantizedType>(
+            input_type.getElementType());
     UniformQuantizedType output_qtype =
-        output_type.getElementType()
-            .dyn_cast<mlir::quant::UniformQuantizedType>();
+        dyn_cast<mlir::quant::UniformQuantizedType>(
+            output_type.getElementType());
 
     clamp_min = output_qtype.getZeroPoint();
     clamp_max = std::llround(6.0f / output_qtype.getScale()) +
@@ -521,9 +520,9 @@ static LogicalResult prepareMatchAndRewriteComparison(
   Value y = operands[1];
   Value result = op->getResult(0);
 
-  ShapedType input_x_type = x.getType().dyn_cast<ShapedType>();
-  ShapedType input_y_type = y.getType().dyn_cast<ShapedType>();
-  ShapedType output_type = result.getType().dyn_cast<ShapedType>();
+  ShapedType input_x_type = dyn_cast<ShapedType>(x.getType());
+  ShapedType input_y_type = dyn_cast<ShapedType>(y.getType());
+  ShapedType output_type = dyn_cast<ShapedType>(result.getType());
   // Not a shaped tensor output
   if (!input_x_type || !input_y_type || !output_type) return failure();
 
@@ -548,11 +547,11 @@ static LogicalResult prepareMatchAndRewriteComparison(
   }
 
   UniformQuantizedType input_x_qtype =
-      input_x_type.getElementType()
-          .dyn_cast<mlir::quant::UniformQuantizedType>();
+      dyn_cast<mlir::quant::UniformQuantizedType>(
+          input_x_type.getElementType());
   UniformQuantizedType input_y_qtype =
-      input_y_type.getElementType()
-          .dyn_cast<mlir::quant::UniformQuantizedType>();
+      dyn_cast<mlir::quant::UniformQuantizedType>(
+          input_y_type.getElementType());
 
   if (input_x_qtype.getScale() != input_y_qtype.getScale() ||
       input_x_qtype.getZeroPoint() != input_y_qtype.getZeroPoint()) {
@@ -690,14 +689,14 @@ static LogicalResult matchAndRewriteAddSub(Operation* op,
         input_rhs_type.clone(rewriter.getI32Type());
 
     UniformQuantizedType input_lhs_qtype =
-        input_lhs_type.getElementType()
-            .dyn_cast<mlir::quant::UniformQuantizedType>();
+        dyn_cast<mlir::quant::UniformQuantizedType>(
+            input_lhs_type.getElementType());
     UniformQuantizedType input_rhs_qtype =
-        input_rhs_type.getElementType()
-            .dyn_cast<mlir::quant::UniformQuantizedType>();
+        dyn_cast<mlir::quant::UniformQuantizedType>(
+            input_rhs_type.getElementType());
     UniformQuantizedType output_qtype =
-        output_type.getElementType()
-            .dyn_cast<mlir::quant::UniformQuantizedType>();
+        dyn_cast<mlir::quant::UniformQuantizedType>(
+            output_type.getElementType());
 
     // Following quantization described in tensorflow/lite/kernels/add.cc
     // In details it does:
@@ -915,7 +914,7 @@ LogicalResult ConvertTFLRoundOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_round_op = cast<TFL::RoundOp>(op);
 
-  ShapedType input_type = tfl_round_op.getX().getType().dyn_cast<ShapedType>();
+  ShapedType input_type = dyn_cast<ShapedType>(tfl_round_op.getX().getType());
   if (!input_type) {
     return rewriter.notifyMatchFailure(op, "input not shaped tensor type");
   }
@@ -942,7 +941,7 @@ LogicalResult ConvertTFLDivOp::matchAndRewrite(
   auto tfl_div_op = cast<TFL::DivOp>(op);
 
   ShapedType output_type =
-      tfl_div_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_div_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -985,11 +984,11 @@ LogicalResult ConvertTFLMaximumOp::matchAndRewrite(
   auto tfl_max_op = cast<TFL::MaximumOp>(op);
 
   ShapedType input_lhs_type =
-      tfl_max_op.getLhs().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_max_op.getLhs().getType());
   ShapedType input_rhs_type =
-      tfl_max_op.getRhs().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_max_op.getRhs().getType());
   ShapedType output_type =
-      tfl_max_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_max_op.getResult().getType());
 
   // Not a shaped tensor output
   if (!input_lhs_type || !input_rhs_type || !output_type) return failure();
@@ -1042,11 +1041,11 @@ LogicalResult ConvertTFLMinimumOp::matchAndRewrite(
   auto tfl_min_op = cast<TFL::MinimumOp>(op);
 
   ShapedType input_lhs_type =
-      tfl_min_op.getLhs().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_min_op.getLhs().getType());
   ShapedType input_rhs_type =
-      tfl_min_op.getRhs().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_min_op.getRhs().getType());
   ShapedType output_type =
-      tfl_min_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_min_op.getResult().getType());
   // Not a shaped tensor output
   if (!input_lhs_type || !input_rhs_type || !output_type) return failure();
 
@@ -1128,7 +1127,7 @@ LogicalResult ConvertTFLAddNOp::matchAndRewrite(
   auto tfl_addn_op = cast<TFL::AddNOp>(op);
 
   ShapedType output_type =
-      tfl_addn_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_addn_op.getResult().getType());
   // Not a shaped output
   if (!output_type) return failure();
 
@@ -1153,9 +1152,9 @@ LogicalResult ConvertTFLAveragePool2DOp::matchAndRewrite(
   auto tfl_avgpool_op = cast<TFL::AveragePool2DOp>(op);
 
   ShapedType input_type =
-      tfl_avgpool_op.getInput().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_avgpool_op.getInput().getType());
   ShapedType output_type =
-      tfl_avgpool_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_avgpool_op.getResult().getType());
   // Not a shaped output
   if (!output_type) return failure();
 
@@ -1237,9 +1236,9 @@ LogicalResult ConvertTFLMaxPool2DOp::matchAndRewrite(
   auto tfl_maxpool_op = cast<TFL::MaxPool2DOp>(op);
 
   ShapedType input_type =
-      tfl_maxpool_op.getInput().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_maxpool_op.getInput().getType());
   ShapedType output_type =
-      tfl_maxpool_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_maxpool_op.getResult().getType());
   // Not a shaped type
   if (!output_type) return failure();
 
@@ -1412,11 +1411,11 @@ LogicalResult ConvertTFLConv2DOp::matchAndRewrite(
   auto tfl_conv2d_op = cast<TFL::Conv2DOp>(op);
 
   RankedTensorType input_type =
-      tfl_conv2d_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_conv2d_op.getInput().getType());
   RankedTensorType filter_type =
-      tfl_conv2d_op.getFilter().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_conv2d_op.getFilter().getType());
   ShapedType output_type =
-      tfl_conv2d_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_conv2d_op.getResult().getType());
   // Not a ranked tensor output
   if (!input_type) return failure();
   if (!output_type) return failure();
@@ -1513,11 +1512,11 @@ LogicalResult ConvertTFLConv3DOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_conv3d_op = cast<TFL::Conv3DOp>(op);
   RankedTensorType input_type =
-      tfl_conv3d_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_conv3d_op.getInput().getType());
   RankedTensorType filter_type =
-      tfl_conv3d_op.getFilter().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_conv3d_op.getFilter().getType());
   ShapedType output_type =
-      tfl_conv3d_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_conv3d_op.getResult().getType());
 
   if (!input_type | !filter_type || !output_type) {
     return rewriter.notifyMatchFailure(
@@ -1539,7 +1538,7 @@ LogicalResult ConvertTFLConv3DOp::matchAndRewrite(
   }
 
   Value unquantized_bias = tfl_conv3d_op.getBias();
-  if (!unquantized_bias.getType().dyn_cast<RankedTensorType>()) {
+  if (!dyn_cast<RankedTensorType>(unquantized_bias.getType())) {
     // The bias may actually be typed "None" which has no value. TOSA requires
     // bias to be an array of output_channel_count values, so create a constant
     // of the appropriate number and type of zeros.
@@ -1593,11 +1592,11 @@ LogicalResult ConvertTFLTransposeConvOp::matchAndRewrite(
   auto tfl_conv_op = cast<TFL::TransposeConvOp>(op);
 
   ShapedType input_type =
-      tfl_conv_op.getInput().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_conv_op.getInput().getType());
   ShapedType filter_type =
-      tfl_conv_op.getWeights().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_conv_op.getWeights().getType());
   ShapedType output_type =
-      tfl_conv_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_conv_op.getResult().getType());
   // Not a ranked tensor output
   if (!input_type) return failure();
   if (!output_type) return failure();
@@ -1671,12 +1670,12 @@ LogicalResult ConvertTFLTransposeConvOp::matchAndRewrite(
 
   std::optional<Value> zero_bias;
   if (input_is_qtype) {
-    uint32_t input_bits = input_type.getElementType()
-                              .dyn_cast<mlir::quant::QuantizedType>()
-                              .getStorageTypeIntegralWidth();
-    uint32_t weight_bits = filter_type.getElementType()
-                               .dyn_cast<mlir::quant::QuantizedType>()
-                               .getStorageTypeIntegralWidth();
+    uint32_t input_bits =
+        dyn_cast<mlir::quant::QuantizedType>(input_type.getElementType())
+            .getStorageTypeIntegralWidth();
+    uint32_t weight_bits =
+        dyn_cast<mlir::quant::QuantizedType>(filter_type.getElementType())
+            .getStorageTypeIntegralWidth();
 
     if (input_bits == 16 && weight_bits == 8) {
       SmallVector<APInt> vec(output_channel, APInt(48, 0, true));
@@ -1729,11 +1728,11 @@ LogicalResult ConvertTFLDepthwiseConv2DOp::matchAndRewrite(
   auto tfl_conv2d_op = cast<TFL::DepthwiseConv2DOp>(op);
 
   ShapedType input_type =
-      tfl_conv2d_op.getInput().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_conv2d_op.getInput().getType());
   ShapedType filter_type =
-      tfl_conv2d_op.getFilter().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_conv2d_op.getFilter().getType());
   ShapedType output_type =
-      tfl_conv2d_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_conv2d_op.getResult().getType());
   // Not a shaped output
   if (!input_type) return failure();
   if (!output_type) return failure();
@@ -1870,8 +1869,8 @@ LogicalResult ConvertTFLBatchMatMulOp::matchAndRewrite(
   auto result_ty = tfl_mm_op.getType().cast<ShapedType>();
   Value lhs = tfl_mm_op.getX();
   Value rhs = tfl_mm_op.getY();
-  RankedTensorType lhs_ty = lhs.getType().dyn_cast<RankedTensorType>();
-  RankedTensorType rhs_ty = rhs.getType().dyn_cast<RankedTensorType>();
+  RankedTensorType lhs_ty = dyn_cast<RankedTensorType>(lhs.getType());
+  RankedTensorType rhs_ty = dyn_cast<RankedTensorType>(rhs.getType());
   bool transpose_lhs = tfl_mm_op.getAdjX();
   bool transpose_rhs = tfl_mm_op.getAdjY();
 
@@ -1975,16 +1974,16 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
   auto tfl_fc_op = cast<TFL::FullyConnectedOp>(op);
 
   ShapedType output_type =
-      tfl_fc_op.getResult(0).getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_fc_op.getResult(0).getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
   RankedTensorType input_type =
-      tfl_fc_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_fc_op.getInput().getType());
   RankedTensorType filter_type =
-      tfl_fc_op.getFilter().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_fc_op.getFilter().getType());
   RankedTensorType bias_type =
-      tfl_fc_op.getBias().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_fc_op.getBias().getType());
   if (!input_type || !filter_type) return failure();
 
   bool input_is_qtype =
@@ -2118,7 +2117,7 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
 LogicalResult ConvertTFLConcatenationOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_concat_op = cast<TFL::ConcatenationOp>(op);
-  auto result_type = tfl_concat_op.getResult().getType().dyn_cast<ShapedType>();
+  auto result_type = dyn_cast<ShapedType>(tfl_concat_op.getResult().getType());
 
   SmallVector<Value> values(tfl_concat_op.getValues());
 
@@ -2146,8 +2145,8 @@ LogicalResult ConvertTFLReshapeOp::matchAndRewrite(
   auto tfl_reshape_op = cast<TFL::ReshapeOp>(op);
 
   Value shape = tfl_reshape_op.getShape();
-  ShapedType shape_type = shape.getType().dyn_cast<ShapedType>();
-  ShapedType output_type = tfl_reshape_op.getType().dyn_cast<ShapedType>();
+  ShapedType shape_type = dyn_cast<ShapedType>(shape.getType());
+  ShapedType output_type = dyn_cast<ShapedType>(tfl_reshape_op.getType());
 
   int64_t rank = ShapedType::kDynamic;
   if (output_type.hasRank()) rank = output_type.getRank();
@@ -2169,7 +2168,7 @@ LogicalResult ConvertTFLReshapeOp::matchAndRewrite(
   // Extract the dynamically shaped values for each dimension.
   SmallVector<Value> shape_vals;
   shape_vals.reserve(rank);
-  auto shape_ty = shape.getType().dyn_cast<ShapedType>();
+  auto shape_ty = dyn_cast<ShapedType>(shape.getType());
   for (int i = 0; i < rank; i++) {
     auto e_ty = shape_ty.getElementType();
     Value dim = rewriter.createOrFold<tosa::SliceOp>(
@@ -2197,7 +2196,7 @@ LogicalResult ConvertTFLRankOp::matchAndRewrite(
   auto tfl_rank_op = cast<TFL::RankOp>(op);
 
   RankedTensorType input_type =
-      tfl_rank_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_rank_op.getInput().getType());
   if (!input_type) return failure();
 
   int32_t rank = input_type.getRank();
@@ -2218,12 +2217,12 @@ LogicalResult ConvertTFLShapeOp::matchAndRewrite(
   auto tfl_shape_op = cast<TFL::ShapeOp>(op);
 
   RankedTensorType output_type =
-      tfl_shape_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_shape_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
   RankedTensorType input_type =
-      tfl_shape_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_shape_op.getInput().getType());
   if (!input_type || !input_type.hasStaticShape())
     return rewriter.notifyMatchFailure(op, "input shape not static");
 
@@ -2269,7 +2268,7 @@ LogicalResult ConvertTFLSqueezeOp::matchAndRewrite(
   auto squeeze_dims_attr = tfl_squeeze_op.getSqueezeDimsAttr();
   SmallVector<int32_t> squeeze_dims;
   for (auto& squeeze_dim : squeeze_dims_attr) {
-    squeeze_dims.emplace_back(squeeze_dim.dyn_cast<IntegerAttr>().getInt());
+    squeeze_dims.emplace_back(dyn_cast<IntegerAttr>(squeeze_dim).getInt());
   }
 
   std::optional<Value> result =
@@ -2288,7 +2287,7 @@ LogicalResult ConvertTFLFillOp::matchAndRewrite(
   auto tfl_fill_op = cast<TFL::FillOp>(op);
 
   RankedTensorType output_type =
-      tfl_fill_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_fill_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -2335,7 +2334,7 @@ LogicalResult ConvertTFLReduceAllOp::matchAndRewrite(
   auto tfl_all_op = cast<TFL::ReduceAllOp>(op);
 
   RankedTensorType output_type =
-      tfl_all_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_all_op.getResult().getType());
 
   if (!output_type)
     return rewriter.notifyMatchFailure(op, "output not a ranked tensor");
@@ -2359,7 +2358,7 @@ LogicalResult ConvertTFLReduceAnyOp::matchAndRewrite(
   auto tfl_any_op = cast<TFL::ReduceAnyOp>(op);
 
   RankedTensorType output_type =
-      tfl_any_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_any_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -2381,7 +2380,7 @@ LogicalResult ConvertTFLReduceMaxOp::matchAndRewrite(
   auto tfl_max_op = cast<TFL::ReduceMaxOp>(op);
 
   RankedTensorType output_type =
-      tfl_max_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_max_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -2403,7 +2402,7 @@ LogicalResult ConvertTFLReduceMinOp::matchAndRewrite(
   auto tfl_min_op = cast<TFL::ReduceMinOp>(op);
 
   RankedTensorType output_type =
-      tfl_min_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_min_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -2425,7 +2424,7 @@ LogicalResult ConvertTFLReduceProdOp::matchAndRewrite(
   auto tfl_prod_op = cast<TFL::ReduceProdOp>(op);
 
   RankedTensorType output_type =
-      tfl_prod_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_prod_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -2447,7 +2446,7 @@ LogicalResult ConvertTFLMeanOp::matchAndRewrite(
   auto tfl_mean_op = cast<TFL::MeanOp>(op);
 
   RankedTensorType output_type =
-      tfl_mean_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_mean_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -2469,7 +2468,7 @@ LogicalResult ConvertTFLSumOp::matchAndRewrite(
   auto tfl_sum_op = cast<TFL::SumOp>(op);
 
   RankedTensorType output_type =
-      tfl_sum_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_sum_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr axes_elems;
@@ -2520,9 +2519,9 @@ LogicalResult ConvertTFLRsqrtOp::matchAndRewrite(
   auto tfl_rsqrt_op = cast<TFL::RsqrtOp>(op);
 
   RankedTensorType output_type =
-      tfl_rsqrt_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_rsqrt_op.getResult().getType());
   RankedTensorType input_type =
-      tfl_rsqrt_op.getX().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_rsqrt_op.getX().getType());
 
   mlir::quant::UniformQuantizedType input_qtype =
       input_type.getElementType()
@@ -2639,7 +2638,7 @@ LogicalResult ConvertTFLSliceOp::matchAndRewrite(
   auto tfl_slice_op = cast<TFL::SliceOp>(op);
 
   ShapedType output_type =
-      tfl_slice_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_slice_op.getResult().getType());
   // Not a shaped tensor output
   if (!output_type) return failure();
 
@@ -2671,7 +2670,7 @@ LogicalResult ConvertTFLTileOp::matchAndRewrite(
   auto tfl_tile_op = cast<TFL::TileOp>(op);
 
   ShapedType output_type =
-      tfl_tile_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_tile_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -2828,7 +2827,7 @@ LogicalResult ConvertTFLPadOp::matchAndRewrite(
   auto tfl_pad_op = cast<TFL::PadOp>(op);
 
   ShapedType output_type =
-      tfl_pad_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_pad_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -2845,7 +2844,7 @@ LogicalResult ConvertTFLMirrorPadOp::matchAndRewrite(
   auto tfl_mirrorpad_op = cast<TFL::MirrorPadOp>(op);
 
   RankedTensorType output_type =
-      tfl_mirrorpad_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_mirrorpad_op.getResult().getType());
   if (!output_type) {
     return rewriter.notifyMatchFailure(op, "output type isn't a ranked tensor");
   }
@@ -2891,7 +2890,7 @@ LogicalResult ConvertTFLResizeBilinearOp::matchAndRewrite(
   auto tfl_resize_op = cast<TFL::ResizeBilinearOp>(op);
 
   RankedTensorType output_type =
-      tfl_resize_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_resize_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -2912,7 +2911,7 @@ LogicalResult ConvertTFLResizeNearestNeighborOp::matchAndRewrite(
   auto tfl_resize_op = cast<TFL::ResizeNearestNeighborOp>(op);
 
   RankedTensorType output_type =
-      tfl_resize_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_resize_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
@@ -3025,7 +3024,7 @@ LogicalResult ConvertTFLBucketizeOp::matchAndRewrite(
 
   Value input = tfl_bucketize_op.getInput();
   auto boundaries_attr = tfl_bucketize_op.getBoundaries();
-  RankedTensorType input_type = input.getType().dyn_cast<RankedTensorType>();
+  RankedTensorType input_type = dyn_cast<RankedTensorType>(input.getType());
   if (!input_type) {
     return rewriter.notifyMatchFailure(op, "input is not a ranked tensor");
   }
@@ -3035,13 +3034,13 @@ LogicalResult ConvertTFLBucketizeOp::matchAndRewrite(
   // results of the comparison for each input generates the bucket it belongs
   // to, as the boundaries are sorted.
   ShapedType output_type =
-      tfl_bucketize_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_bucketize_op.getResult().getType());
 
   auto input_shape = input_type.getShape();
 
   SmallVector<APFloat> boundaries;
   for (auto& boundary : boundaries_attr) {
-    boundaries.emplace_back(boundary.dyn_cast<FloatAttr>().getValue());
+    boundaries.emplace_back(dyn_cast<FloatAttr>(boundary).getValue());
   }
   int64_t boundaries_size = boundaries.size();
 
@@ -3122,12 +3121,12 @@ LogicalResult ConvertTFLHardSwishOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_hardswish_op = cast<TFL::HardSwishOp>(op);
   RankedTensorType output_type =
-      tfl_hardswish_op.getResult().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_hardswish_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
   RankedTensorType input_type =
-      tfl_hardswish_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_hardswish_op.getInput().getType());
   // Not a ranked tensor output
   if (!input_type) return failure();
 
@@ -3201,7 +3200,7 @@ LogicalResult ConvertTFLSinOp::matchAndRewrite(
   auto tfl_sin_op = cast<TFL::SinOp>(op);
   auto input = tfl_sin_op.getX();
   ShapedType output_type =
-      tfl_sin_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_sin_op.getResult().getType());
 
   std::optional<Value> result = convertSinOp(rewriter, op, input, output_type);
   if (!result) return failure();
@@ -3214,9 +3213,8 @@ LogicalResult ConvertTFLCosOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_cos_op = cast<TFL::CosOp>(op);
   Value input = tfl_cos_op.getX();
-  RankedTensorType input_ty = input.getType().dyn_cast<RankedTensorType>();
-  ShapedType output_ty =
-      tfl_cos_op.getResult().getType().dyn_cast<ShapedType>();
+  RankedTensorType input_ty = dyn_cast<RankedTensorType>(input.getType());
+  ShapedType output_ty = dyn_cast<ShapedType>(tfl_cos_op.getResult().getType());
 
   if (!input_ty || !output_ty) return failure();
 
@@ -3369,9 +3367,9 @@ LogicalResult ConvertTFLLogisticOp::matchAndRewrite(
   auto tfl_logistic_op = cast<TFL::LogisticOp>(op);
 
   ShapedType output_type =
-      tfl_logistic_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_logistic_op.getResult().getType());
   RankedTensorType input_type =
-      tfl_logistic_op.getX().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_logistic_op.getX().getType());
   if (!input_type || !output_type) return failure();
 
   bool input_is_qtype =
@@ -3440,9 +3438,9 @@ LogicalResult ConvertTFLTanhOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_tanh_op = cast<TFL::TanhOp>(op);
   ShapedType output_type =
-      tfl_tanh_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_tanh_op.getResult().getType());
   RankedTensorType input_type =
-      tfl_tanh_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_tanh_op.getInput().getType());
   if (!input_type || !output_type) return failure();
 
   bool input_is_qtype =
@@ -3538,12 +3536,12 @@ static LogicalResult LegalizeQuantizedPrelu(Operation* op,
     return rewriter.notifyMatchFailure(op, "op is not PReLU");
 
   ShapedType rescale_type = output_type.clone(rewriter.getI32Type());
-  ShapedType input_type = input.getType().dyn_cast<ShapedType>();
+  ShapedType input_type = dyn_cast<ShapedType>(input.getType());
 
   UniformQuantizedType input_qtype =
-      input_type.getElementType().dyn_cast<UniformQuantizedType>();
+      dyn_cast<UniformQuantizedType>(input_type.getElementType());
   UniformQuantizedType output_qtype =
-      output_type.getElementType().dyn_cast<UniformQuantizedType>();
+      dyn_cast<UniformQuantizedType>(output_type.getElementType());
 
   if (!input_qtype || !output_qtype)
     return rewriter.notifyMatchFailure(
@@ -3609,18 +3607,18 @@ LogicalResult ConvertTFLPReluOp::matchAndRewrite(
   auto tfl_prelu_op = cast<TFL::PReluOp>(op);
 
   ShapedType input_type =
-      tfl_prelu_op.getInput().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_prelu_op.getInput().getType());
   ShapedType output_type =
-      tfl_prelu_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_prelu_op.getResult().getType());
   ShapedType alpha_type =
-      tfl_prelu_op.getAlpha().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_prelu_op.getAlpha().getType());
 
   if (!input_type || !output_type || !alpha_type)
     return rewriter.notifyMatchFailure(
         op, "input, output, or alpha is not a ShapedType");
 
   if (auto alpha_qtype =
-          alpha_type.getElementType().dyn_cast<UniformQuantizedType>()) {
+          dyn_cast<UniformQuantizedType>(alpha_type.getElementType())) {
     return LegalizeQuantizedPrelu(op, rewriter, tfl_prelu_op.getInput(),
                                   alpha_qtype.getScale(), output_type);
   }
@@ -3709,10 +3707,10 @@ LogicalResult ConvertTFLLeakyReluOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_leakyrelu_op = cast<TFL::LeakyReluOp>(op);
   RankedTensorType input_type =
-      tfl_leakyrelu_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_leakyrelu_op.getInput().getType());
 
   ShapedType output_type =
-      tfl_leakyrelu_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_leakyrelu_op.getResult().getType());
 
   if (!input_type || !output_type)
     return rewriter.notifyMatchFailure(op,
@@ -3758,7 +3756,7 @@ LogicalResult ConvertTFLNegOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_neg_op = cast<TFL::NegOp>(op);
   ShapedType output_type =
-      tfl_neg_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_neg_op.getResult().getType());
   if (!output_type) return failure();
 
   CreateReplaceOpAndInfer<tosa::NegateOp>(rewriter, op, output_type,
@@ -3795,7 +3793,7 @@ LogicalResult ConvertTFLReverseV2Op::matchAndRewrite(
   auto tfl_reverse_op = cast<TFL::ReverseV2Op>(op);
 
   RankedTensorType input_type =
-      tfl_reverse_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_reverse_op.getInput().getType());
   if (!input_type) {
     return rewriter.notifyMatchFailure(op, "input_type is unranked");
   }
@@ -3842,21 +3840,21 @@ LogicalResult ConvertTFLQuantizeOp::matchAndRewrite(
   auto tfl_quantize_op = cast<TFL::QuantizeOp>(op);
 
   RankedTensorType input_type =
-      tfl_quantize_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_quantize_op.getInput().getType());
   ShapedType output_type =
-      tfl_quantize_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_quantize_op.getResult().getType());
   if (!input_type || !output_type) return failure();
 
   ShapedType qtype =
-      tfl_quantize_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_quantize_op.getResult().getType());
   if (!qtype) return failure();
 
   UniformQuantizedType element_type =
-      qtype.getElementType().dyn_cast<UniformQuantizedType>();
+      dyn_cast<UniformQuantizedType>(qtype.getElementType());
   if (!element_type) return failure();
 
   UniformQuantizedType input_element_type =
-      input_type.getElementType().dyn_cast<UniformQuantizedType>();
+      dyn_cast<UniformQuantizedType>(input_type.getElementType());
 
   // If input is already a quantized type, this is basically a RESCALE (or
   // tensorflow::ops::Requantize)
@@ -3892,12 +3890,12 @@ LogicalResult ConvertTFLDequantizeOp::matchAndRewrite(
   auto tfl_dequantize_op = cast<TFL::DequantizeOp>(op);
 
   ShapedType output_type =
-      tfl_dequantize_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_dequantize_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
   RankedTensorType qtype =
-      tfl_dequantize_op.getInput().getType().dyn_cast<RankedTensorType>();
+      dyn_cast<RankedTensorType>(tfl_dequantize_op.getInput().getType());
   if (!qtype) return failure();
 
   Type element_type = qtype.getElementType();
@@ -3907,7 +3905,7 @@ LogicalResult ConvertTFLDequantizeOp::matchAndRewrite(
     return success();
   }
 
-  if (auto eq_ty = element_type.dyn_cast<quant::UniformQuantizedType>()) {
+  if (auto eq_ty = dyn_cast<quant::UniformQuantizedType>(element_type)) {
     double scale = eq_ty.getScale();
     int64_t zp = eq_ty.getZeroPoint();
     int64_t num_bits = eq_ty.getStorageTypeIntegralWidth();
@@ -3923,7 +3921,7 @@ LogicalResult ConvertTFLDequantizeOp::matchAndRewrite(
   }
 
   if (quant::UniformQuantizedPerAxisType eq_ty =
-          element_type.dyn_cast<quant::UniformQuantizedPerAxisType>()) {
+          dyn_cast<quant::UniformQuantizedPerAxisType>(element_type)) {
     SmallVector<float> zps;
     for (auto zp : eq_ty.getZeroPoints()) {
       int64_t num_bits = eq_ty.getStorageTypeIntegralWidth();
@@ -3953,7 +3951,7 @@ LogicalResult ConvertTFLConstOp::matchAndRewrite(
   auto tfl_const_op = cast<TFL::ConstOp>(op);
 
   ShapedType output_type =
-      tfl_const_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_const_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr elements = tfl_const_op.getValue();
@@ -3979,7 +3977,7 @@ LogicalResult ConvertTFLQConstOp::matchAndRewrite(
   auto tfl_qconst_op = cast<TFL::QConstOp>(op);
 
   ShapedType output_type =
-      tfl_qconst_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_qconst_op.getResult().getType());
   if (!output_type) return failure();
 
   ElementsAttr elements = tfl_qconst_op.getValue();
@@ -4002,11 +4000,11 @@ LogicalResult ConvertConstantOp::matchAndRewrite(
   auto tfl_const_op = cast<arith::ConstantOp>(op);
 
   ShapedType output_type =
-      tfl_const_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(tfl_const_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 
-  ElementsAttr attr = tfl_const_op.getValueAttr().dyn_cast<ElementsAttr>();
+  ElementsAttr attr = dyn_cast<ElementsAttr>(tfl_const_op.getValueAttr());
 
   auto e_type = output_type.getElementType();
   // TOSA only support up to 48-bits
@@ -4019,7 +4017,7 @@ LogicalResult ConvertConstantOp::matchAndRewrite(
   }
 
   if (!output_type.hasRank()) {
-    if (auto attr_type = attr.getType().dyn_cast<ShapedType>()) {
+    if (auto attr_type = dyn_cast<ShapedType>(attr.getType())) {
       output_type = attr_type.clone(e_type);
     }
   }
@@ -4200,7 +4198,7 @@ LogicalResult ConvertTFLArgMinOp::matchAndRewrite(
   auto input_ty = input.getType().cast<ShapedType>();
   Type input_ety = input_ty.getElementType();
 
-  if (auto quantized_ty = input_ety.dyn_cast<QuantizedType>()) {
+  if (auto quantized_ty = dyn_cast<QuantizedType>(input_ety)) {
     input_ety = rewriter.getIntegerType(
         quantized_ty.getStorageTypeIntegralWidth(), quantized_ty.isSigned());
   }
@@ -4240,7 +4238,7 @@ LogicalResult ConvertTFLFakeQuantOp::matchAndRewrite(
   auto fakequant_op = cast<TFL::FakeQuantOp>(op);
 
   ShapedType output_type =
-      fakequant_op.getResult().getType().dyn_cast<ShapedType>();
+      dyn_cast<ShapedType>(fakequant_op.getResult().getType());
   // Not a ranked tensor output
   if (!output_type) return failure();
 

--- a/tensorflow/compiler/mlir/tosa/transforms/lower_complex_types.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/lower_complex_types.cc
@@ -64,7 +64,7 @@ class LowerComplexTypes
 class ComplexTypeConverter : public TypeConverter {
  public:
   static Type convertTensor(RankedTensorType type) {
-    if (auto elementType = type.getElementType().dyn_cast<ComplexType>()) {
+    if (auto elementType = dyn_cast<ComplexType>(type.getElementType())) {
       llvm::SmallVector<int64_t> newShape;
       for (auto dim : type.getShape()) {
         newShape.push_back(dim);
@@ -111,7 +111,7 @@ class GenericTypeConvert : public ConversionPattern {
 };
 
 static bool isIllegalType(Type type) {
-  if (auto shapedType = type.dyn_cast<ShapedType>()) {
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return shapedType.getElementType().isa<ComplexType>();
   }
   return false;

--- a/tensorflow/compiler/mlir/tosa/transforms/strip_quant_types.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/strip_quant_types.cc
@@ -65,7 +65,7 @@ class StripQuantTypes
 class QuantTypeConverter : public TypeConverter {
  public:
   static Type convertType(Type type) {
-    if (auto qType = type.dyn_cast<quant::QuantizedType>()) {
+    if (auto qType = dyn_cast<quant::QuantizedType>(type)) {
       if (qType.isSigned() || qType.getStorageTypeIntegralWidth() != 8) {
         return IntegerType::get(type.getContext(),
                                 qType.getStorageTypeIntegralWidth());
@@ -122,7 +122,7 @@ class GenericTypeConvert : public ConversionPattern {
 
 static bool isIllegalType(Type type) {
   if (type.isa<quant::QuantizedType>()) return true;
-  if (auto shapedType = type.dyn_cast<ShapedType>()) {
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return isIllegalType(shapedType.getElementType());
   }
   return false;


### PR DESCRIPTION
change old stype of x.dyn_cast<T>() to new style: dyn_cast<T>(x)


Signed-off-by: Tai Ly <tai.ly@arm.com>
Change-Id: I0caf0492cc21c4b6a0e679202197e212cf01740d