### PR TITLE
Fix unit test failure caused by numpy update

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -90,7 +90,7 @@ REQUIRED_PACKAGES = [
     'google_pasta >= 0.1.1',
     'h5py >= 2.9.0',
     'libclang >= 13.0.0',
-    'numpy >= 1.22',
+    'numpy >= 1.22, <= 1.24.3',
     'opt_einsum >= 2.3.2',
     'packaging',
     'protobuf>=3.20.3,<5.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5',


### PR DESCRIPTION
Limit the version of numpy that will be accepted
for install to the last one that works.