### PR TITLE
Updating tf.experimental.numpy.vander for N=0

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1368,7 +1368,7 @@ def vander(x, N=None, increasing=False):  # pylint: disable=missing-docstring,in
 
   x_shape = array_ops.shape(x)
   if N is None:
-     N = x_shape[0]
+    N = x_shape[0]
     
   N_temp = np_utils.get_static_value(N)  # pylint: disable=invalid-name
   if N_temp is not None:

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1367,8 +1367,8 @@ def vander(x, N=None, increasing=False):  # pylint: disable=missing-docstring,in
   x = asarray(x)
 
   x_shape = array_ops.shape(x)
-  if N != 0:
-     N = N or x_shape[0]
+  if N is None:
+     N = x_shape[0]
     
   N_temp = np_utils.get_static_value(N)  # pylint: disable=invalid-name
   if N_temp is not None:

--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1367,8 +1367,9 @@ def vander(x, N=None, increasing=False):  # pylint: disable=missing-docstring,in
   x = asarray(x)
 
   x_shape = array_ops.shape(x)
-  N = N or x_shape[0]
-
+  if N != 0:
+     N = N or x_shape[0]
+    
   N_temp = np_utils.get_static_value(N)  # pylint: disable=invalid-name
   if N_temp is not None:
     N = N_temp

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -546,7 +546,11 @@ class ArrayCreationTest(test.TestCase):
                                     array_ops.ones([2, 3], dtype=dtype),
                                     [10, 3])
     self.assertAllEqual(expected, a)
-
+    
+  def testVander(self):
+    tf_res = np_array_ops.vander([-1.,1.], N=0, increasing=False)
+    np_res = np.vander(np.array([-1.,1.]),N=0)
+    self.assertAllEqual(tf_res, np_res)
 
 class ArrayMethodsTest(test.TestCase):
 


### PR DESCRIPTION
At present the API `tf.experimental.numpy.vander` behaves differently compared to its Numpy variant `numpy.vander` when the argument value of `N=0` .

I think the behaviour of Numpy variant is correct.Current TF implementation broadcasts N to `N=shape(x)[0]` when either N=0 or N=None which is not correct. When N=0 there should not be any broadcasting which is equivalent to `numpy.vander` behaviour.Hence proposing the changes in code to get numpy behaviour.

Attached the gist for demo in same with and without the code changes and with the proposed change in code numpy behaviour can be achievable.

Fixes #60827 