### PR TITLE
Fix ambiguity in use of overloaded functions in XLA

### DIFF
--- a/tensorflow/compiler/xla/hlo/utils/hlo_sharding_util_test.cc
+++ b/tensorflow/compiler/xla/hlo/utils/hlo_sharding_util_test.cc
@@ -164,13 +164,13 @@ TEST(HloShardingUtilTest, ReshapeToTileDimension2D_Dim0) {
   HloSharding sharding = HloSharding::IotaTile({2, 2});
   HloSharding result =
       ReshapeToTileDimension(sharding, /*dim=*/0, /*dims=*/{0, 1});
-  EXPECT_EQ(result.tile_assignment(), TileAssignment({4, 1}));
+  EXPECT_EQ(result.tile_assignment(), TileAssignment((absl::Span<const int64_t>){4, 1}));
 }
 
 TEST(HloShardingUtilTest, ReshapeToTileDimension2D_Dim1) {
   HloSharding sharding = HloSharding::IotaTile({2, 2});
   HloSharding result =
-      ReshapeToTileDimension(sharding, /*dim=*/1, /*dims=*/{0, 1});
+      ReshapeToTileDimension(sharding, /*dim=*/1, /*dims=*/(absl::Span<const int64_t>){0, 1});
   EXPECT_EQ(result.tile_assignment(), TileAssignment({1, 4}, {2, 2}, {1, 0}));
 }
 
@@ -256,7 +256,7 @@ TEST(HloShardingUtilTest, GetManualSubgroupSharding_ManualOnly) {
   GroupedSharding group_sharding = GetManualSubgroupSharding(sharding);
 
   // Expect group_sharding.sharding to be {devices=[1,2]0,1}
-  EXPECT_EQ(group_sharding.sharding.tile_assignment(), TileAssignment({1, 2}));
+  EXPECT_EQ(group_sharding.sharding.tile_assignment(), TileAssignment((absl::Span<const int64_t>){1, 2}));
 
   // Expect the device groups are: {0, 2} and {1, 3}
   EXPECT_THAT(group_sharding.device_groups[0],
@@ -409,7 +409,7 @@ TEST(HloShardingUtilTest, UngroupSharding_Replicated2) {
 }
 
 TEST(HloShardingUtilTest, DeviceGroupsDoesNotMatch) {
-  HloSharding sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
+  HloSharding sharding = HloSharding::PartialTile(TileAssignment((absl::Span<const int64_t>){2, 2}));
   std::vector<int64_t> group_dims = {2};
   std::vector<int64_t> group_dim_sizes = {2};
 
@@ -447,7 +447,7 @@ TEST(HloShardingUtilTest, DeviceGroupsMatch) {
       group_dim_sizes, 2, lhs_sharding,
       /*subgroup_manual=*/true);
 
-  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment((absl::Span<const int64_t>){2, 2}));
   auto rhs = GroupedSharding(
       device_groups, std::vector<int64_t>(group_dims.begin(), group_dims.end()),
       group_dim_sizes, 2, rhs_sharding,
@@ -472,20 +472,20 @@ TEST(HloShardingUtilTest, IsSubShardingReplicatedTiled) {
 
 TEST(HloShardingUtilTest, IsSubShardingTiledPartialReplicated) {
   HloSharding rhs_sharding = HloSharding::Replicate();
-  HloSharding lhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
+  HloSharding lhs_sharding = HloSharding::PartialTile(TileAssignment((absl::Span<const int64_t>){2, 2}));
   Shape shape = ShapeUtil::MakeShape(F32, {129, 253});
   EXPECT_TRUE(IsSubTilingOrEqualSharding(shape, lhs_sharding, rhs_sharding));
 }
 
 TEST(HloShardingUtilTest, IsSubShardingReplicatedTiledPartial) {
-  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment((absl::Span<const int64_t>){2, 2}));
   HloSharding lhs_sharding = HloSharding::Replicate();
   Shape shape = ShapeUtil::MakeShape(F32, {129, 253});
   EXPECT_FALSE(IsSubTilingOrEqualSharding(shape, lhs_sharding, rhs_sharding));
 }
 
 TEST(HloShardingUtilTest, IsSubShardingPartialTiledTiled) {
-  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment((absl::Span<const int64_t>){2, 2}));
   HloSharding lhs_sharding = HloSharding::IotaTile({4, 1});
   Shape shape = ShapeUtil::MakeShape(F32, {129, 253});
   EXPECT_FALSE(IsSubTilingOrEqualSharding(shape, lhs_sharding, rhs_sharding));
@@ -499,7 +499,7 @@ TEST(HloShardingUtilTest, IsSubShardingIncompatibleTiled) {
 }
 
 TEST(HloShardingUtilTest, IsSubShardingIncompatibleShapeTiledPartialTiled) {
-  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment({2, 2}));
+  HloSharding rhs_sharding = HloSharding::PartialTile(TileAssignment((absl::Span<const int64_t>){2, 2}));
   HloSharding lhs_sharding = HloSharding::IotaTile({4, 1});
   Shape shape = ShapeUtil::MakeShape(F32, {129, 253});
   EXPECT_FALSE(IsSubTilingOrEqualSharding(shape, lhs_sharding, rhs_sharding));

--- a/tensorflow/compiler/xla/service/hlo_parser_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_parser_test.cc
@@ -3485,7 +3485,7 @@ TEST_F(HloParserTest, ParseTrivialIotaShardingPartialReplication) {
   const std::string original = "{devices=[2,2]<=[4] last_tile_dim_replicate}";
   TF_ASSERT_OK_AND_ASSIGN(HloSharding sharding, ParseSharding(original));
   EXPECT_EQ(sharding.ToString(), original);
-  TileAssignment tiling_last_dim_replicated({2, 2});
+  TileAssignment tiling_last_dim_replicated((absl::Span<const int64_t>){2, 2});
   EXPECT_EQ(HloSharding::PartialTile(tiling_last_dim_replicated).ToString(),
             original);
 }

--- a/tensorflow/compiler/xla/service/hlo_sharding_test.cc
+++ b/tensorflow/compiler/xla/service/hlo_sharding_test.cc
@@ -205,7 +205,7 @@ TEST_F(HloShardingTest, V1V2TileEquivalence) {
 TEST_F(HloShardingTest, V1V2PartialTileEquivalence) {
   {
     HloSharding v1 = HloSharding::PartialTile(MakeArray({2, 2}, {0, 1, 2, 3}));
-    HloSharding v2 = HloSharding::PartialTile(TileAssignment({2, 2}));
+    HloSharding v2 = HloSharding::PartialTile(TileAssignment((absl::Span<const int64_t>){2, 2}));
     EXPECT_EQ(v1, v2);
     EXPECT_EQ(absl::HashOf(v1), absl::HashOf(v2));
   }
@@ -232,7 +232,7 @@ TEST_F(HloShardingTest, V1V2SubgroupEquivalence) {
         HloSharding::Subgroup(MakeArray({2, 2}, {0, 1, 2, 3}),
                               {OpSharding::MANUAL, OpSharding::REPLICATED});
     HloSharding v2 = HloSharding::Subgroup(
-        TileAssignment({2, 2}), {OpSharding::MANUAL, OpSharding::REPLICATED});
+        TileAssignment((absl::Span<const int64_t>){2, 2}), {OpSharding::MANUAL, OpSharding::REPLICATED});
     EXPECT_EQ(v1, v2);
     EXPECT_EQ(absl::HashOf(v1), absl::HashOf(v2));
   }


### PR DESCRIPTION
Fix ambiguity by casting arguments to ensure desired function is used

Fixes https://github.com/tensorflow/tensorflow/issues/61068