### PR TITLE
[NVIDIA TF] Fix version guards for cuLaunchKernelEx

### DIFF
--- a/tensorflow/compiler/xla/backends/profiler/gpu/cupti_tracer.cc
+++ b/tensorflow/compiler/xla/backends/profiler/gpu/cupti_tracer.cc
@@ -1304,7 +1304,7 @@ class CuptiDriverApiHookWithCudaEvent : public CuptiDriverApiHook {
             cbdata->symbolName, cbdata->context, cbdata->correlationId, params);
         break;
       }
-#if CUDA_VERSION >= 11000
+#if CUDA_VERSION >= 11080  // CUDA 11.8
       case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx: {
         DCHECK_NE(cbdata->symbolName, nullptr);
         const auto *params = static_cast<const cuLaunchKernelEx_params *>(
@@ -1314,7 +1314,7 @@ class CuptiDriverApiHookWithCudaEvent : public CuptiDriverApiHook {
             params->config);
         break;
       }
-#endif  // CUDA_VERSION >= 11000
+#endif  // CUDA_VERSION >= 11080
       case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel: {
         DCHECK_NE(cbdata->symbolName, nullptr);
         const auto *params =
@@ -1408,9 +1408,9 @@ class CuptiDriverApiHookWithCudaEvent : public CuptiDriverApiHook {
     tsl::uint64 start_tsc = 0;
     switch (cbid) {
       case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel:
-#if CUDA_VERSION >= 11000
+#if CUDA_VERSION >= 11080  // CUDA 11.8
       case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx:
-#endif  // CUDA_VERSION >= 11000
+#endif  // CUDA_VERSION >= 11080
       case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel:
         start_tsc = recorder->StopKernel(*cbdata->correlationData);
         break;
@@ -1552,9 +1552,9 @@ class CuptiDriverApiHookWithCudaEvent : public CuptiDriverApiHook {
     const CUpti_CallbackData *cbdata) {
   switch (cbid) {
     case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel:
-#if CUDA_VERSION >= 11000
+#if CUDA_VERSION >= 11080  // CUDA 11.8
     case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx:
-#endif  // CUDA_VERSION >= 11000
+#endif  // CUDA_VERSION >= 11080
     case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel:
     case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernelMultiDevice:
       AddKernelEventUponApiExit(collector, device_id, cbdata, start_tsc,

--- a/tensorflow/compiler/xla/backends/profiler/gpu/device_tracer_cuda.cc
+++ b/tensorflow/compiler/xla/backends/profiler/gpu/device_tracer_cuda.cc
@@ -84,9 +84,9 @@ Status GpuTracer::DoStart() {
   options_.cbids_selected = {
     // KERNEL
     CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel,
-#if CUDA_VERSION >= 11000
+#if CUDA_VERSION >= 11080  // CUDA 11.8
     CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx,
-#endif  // CUDA_VERSION >= 11000
+#endif  // CUDA_VERSION >= 11080
     // MEMCPY
     CUPTI_DRIVER_TRACE_CBID_cuMemcpy,
     CUPTI_DRIVER_TRACE_CBID_cuMemcpyAsync,


### PR DESCRIPTION
This CUDA API was introduced in CUDA 11.8. This patch fixes the build when using CUDA < 11.8.

cc @nluehr @pjannaty 