### PR TITLE
Adds matmul heuristic for oneDNN ACL builds on AArch64

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -1520,7 +1520,11 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     TF_CHECK_OK(GetNodeAttr(n->def(), "T", &T));
     if ((T == DT_FLOAT) || (T == DT_BFLOAT16)) {
       VLOG(2) << "Rewriting MatMul to _MklMatMul";
+#ifdef DNNL_AARCH64_USE_ACL
+      return MatMulHeuristic(n);
+#else
       return true;
+#endif
     }
     return false;
   }

--- a/tensorflow/core/graph/mkl_testlib.cc
+++ b/tensorflow/core/graph/mkl_testlib.cc
@@ -23,19 +23,6 @@ namespace tensorflow {
 namespace test {
 namespace graph {
 
-Node* oneDNNMatmul(Graph* g, Node* in0, Node* in1, bool transpose_a,
-                   bool transpose_b) {
-  Node* ret = nullptr;
-  TF_CHECK_OK(NodeBuilder(g->NewName("n"), "_MklMatMul")
-                  .Input(in0)
-                  .Input(in1)
-                  .Attr("transpose_a", transpose_a)
-                  .Attr("transpose_b", transpose_b)
-                  .Attr("_kernel", mkl_op_registry::kMklNameChangeOpLabel)
-                  .Finalize(g, &ret));
-  return ret;
-}
-
 Node* oneDNNSoftmax(Graph* g, Node* input) {
   Node* ret = nullptr;
   TF_CHECK_OK(NodeBuilder(g->NewName("n"), "_MklSoftmax")

--- a/tensorflow/core/graph/mkl_testlib.h
+++ b/tensorflow/core/graph/mkl_testlib.h
@@ -24,10 +24,6 @@ namespace tensorflow {
 namespace test {
 namespace graph {
 
-// Adds a _MklMatmul node in g doing in0.contract(in1).
-Node* oneDNNMatmul(Graph* g, Node* in0, Node* in1, bool transpose_a,
-                   bool transpose_b);
-
 Node* oneDNNSoftmax(Graph* g, Node* input);
 
 }  // namespace graph

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -2909,7 +2909,7 @@ void CopyMatMulAttributes(const NodeDef& matmul, NodeDef* fused_matmul,
     auto& activation_attr = activation->attr();
     (*attr)["leakyrelu_alpha"] = activation_attr.at("alpha");
   }
-  if (IsMKLEnabled()) {
+  if (IsMKLEnabled() && src_attr.find("_input_shapes") != src_attr.end()) {
     (*attr)["_input_shapes"] = src_attr.at("_input_shapes");
   }
 }
@@ -2924,7 +2924,7 @@ void CopyBatchMatMulAttributes(const NodeDef& batchmatmul,
   (*attr)["T"] = src_attr.at("T");
   (*attr)["adj_x"] = src_attr.at("adj_x");
   (*attr)["adj_y"] = src_attr.at("adj_y");
-  if (IsMKLEnabled()) {
+  if (IsMKLEnabled() && src_attr.find("_input_shapes") != src_attr.end()) {
     (*attr)["_input_shapes"] = src_attr.at("_input_shapes");
   }
 }

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -4451,6 +4451,8 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
       ctx.graph_view.SortTopologically(/*ignore_cycles=*/false, {}));
 
   const int num_nodes = item.graph.node_size();
+  const int intra_op_parallelism_threads =
+      item.optimization_options().intra_op_parallelism_threads;
   // Skip nodes that were invalidated by a remapper, e.g. do not process BiasAdd
   // and Activation nodes that were fused into a Conv2D node.
   std::vector<bool> invalidated_nodes(num_nodes);

--- a/tensorflow/core/platform/cpu_info.h
+++ b/tensorflow/core/platform/cpu_info.h
@@ -25,6 +25,7 @@ limitations under the License.
 
 namespace tensorflow {
 namespace port {
+using tsl::port::Aarch64CPU;
 using tsl::port::ADX;
 using tsl::port::AES;
 using tsl::port::AMX_BF16;
@@ -80,6 +81,7 @@ using tsl::port::SSE3;
 using tsl::port::SSE4_1;
 using tsl::port::SSE4_2;
 using tsl::port::SSSE3;
+using tsl::port::TestAarch64CPU;
 using tsl::port::TestCPUFeature;
 
 }  // namespace port

--- a/tensorflow/core/util/mkl_heuristics.h
+++ b/tensorflow/core/util/mkl_heuristics.h
@@ -120,6 +120,73 @@ static double CalculateNodeMFlops(const AttrSlice& attrs,
   return -1;
 }
 
+// MatMulHeuristic returns true to rewrite the node with oneDNN
+// false to execute the node in Eigen
+static bool MatMulHeuristic(const Node* n) {
+  // Run heuristic only if CPU is ARM_NEOVERSE_V1
+  if (!tsl::port::TestAarch64CPU(tsl::port::Aarch64CPU::ARM_NEOVERSE_V1)) {
+    return true;
+  }
+  // Check if we can obtain dimensions for this node.
+  std::vector<const TensorShapeProto*> shape_attrs;
+  if (!TryGetNodeAttr(n->attrs(), "_input_shapes", &shape_attrs)) {
+    // We can't obtain shape so we will revert to default behaviour
+    // to rewrite node.
+    return true;
+  }
+
+  if ((n->type_string() == "MatMul" || n->type_string() == "_FusedMatMul")) {
+    TensorShape lhs_shape, rhs_shape;
+    if (TensorShape::BuildTensorShape(*shape_attrs[0], &lhs_shape) !=
+        tsl::OkStatus()) {
+      return true;
+    }
+    if (TensorShape::BuildTensorShape(*shape_attrs[1], &rhs_shape) !=
+        tsl::OkStatus()) {
+      return true;
+    }
+
+    auto M = lhs_shape.dim_size(0);
+    auto K = lhs_shape.dim_size(1);
+    auto N = rhs_shape.dim_size(1);
+    auto ops = M * N * K;
+    std::array<int, 3> n_threshold = {7560, 250, 1536};
+    std::array<int, 2> m_threshold = {378, 80};
+    std::array<int, 2> ops_threshold = {5242880, 1090519040};
+
+    if (N <= n_threshold.at(0)) {
+      if (ops <= ops_threshold.at(0)) {
+        if (M <= m_threshold.at(0)) {
+          return false;
+        } else {
+          if (N <= n_threshold.at(1)) {
+            return false;
+          } else {
+            return true;
+          }
+        }
+      } else {
+        if (M <= m_threshold.at(1)) {
+          if (N <= n_threshold.at(2)) {
+            return true;
+          } else {
+            return false;
+          }
+        } else {
+          if (ops <= ops_threshold.at(1)) {
+            return true;
+          } else {
+            return false;
+          }
+        }
+      }
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace tensorflow
 
 #endif  // INTEL_MKL

--- a/tensorflow/tsl/platform/cpu_info.cc
+++ b/tensorflow/tsl/platform/cpu_info.cc
@@ -477,7 +477,7 @@ bool TestCPUFeature(CPUFeature feature) {
 }
 
 bool TestAarch64CPU(Aarch64CPU cpu) {
-#ifdef PLATFORM_IS_ARM64
+#if defined(PLATFORM_IS_ARM64) && !defined(__APPLE__) && !defined(__OpenBSD__)
   return CPUIDInfo::TestAarch64CPU(cpu);
 #else
   return false;

--- a/tensorflow/tsl/platform/cpu_info.cc
+++ b/tensorflow/tsl/platform/cpu_info.cc
@@ -28,7 +28,7 @@ limitations under the License.
 #define HWCAP_CPUID (1 << 11)
 #endif
 #include <fstream>
-#endif
+#endif  // defined(PLATFORM_IS_ARM64)
 
 // SIMD extension querying is only available on x86.
 #ifdef PLATFORM_IS_X86
@@ -359,19 +359,22 @@ void InitCPUIDInfo();
 
 CPUIDInfo *cpuid = nullptr;
 
-// Structure for basic CPUID info.
+// Structure for basic CPUID info
 class CPUIDInfo {
  public:
-  CPUIDInfo() : implementer_(0), variant_(0), cpunum_(0) {}
+  CPUIDInfo()
+      : implementer_(0),
+        variant_(0),
+        cpunum_(0),
+        is_arm_neoverse_v1_(0),
+        is_arm_neoverse_n1_(0) {}
 
   static void Initialize() {
-    // Initialize cpuid struct.
-    if (cpuid != nullptr) {
-      return;
-    }
+    // Initialize CPUIDInfo pointer.
+    if (cpuid != nullptr) return;
 
     cpuid = new CPUIDInfo;
-
+    // Make sure CPUID registers are available before reading them.
     if (!(getauxval(AT_HWCAP) & HWCAP_CPUID)) {
       return;
     }
@@ -414,10 +417,22 @@ class CPUIDInfo {
       if (static_cast<bool>(getline(midr_el1_file, line))) {
         uint32 midr_el1 = std::stoul(line, nullptr, 16);
 
-        // Unpack variant and CPU ID.
+        // Unpack variant and CPU ID
+        // Reference:
+        // https://developer.arm.com/documentation/101427/0101/Register-descriptions/AArch64-system-registers/MIDR-EL1--Main-ID-Register--EL1.
         cpuid->implementer_ = (midr_el1 >> 24) & 0xFF;
         cpuid->variant_ = (midr_el1 >> 20) & 0xF;
         cpuid->cpunum_ = (midr_el1 >> 4) & 0xFFF;
+        if (cpuid->implementer_ == 0x41) {
+          switch (cpuid->cpunum_) {
+            case 0xd40:  // ARM NEOVERSE V1
+              cpuid->is_arm_neoverse_v1_ = 1;
+            case 0xd0c:  // ARM NEOVERSE N1
+              cpuid->is_arm_neoverse_n1_ = 1;
+            default:
+              break;
+          }
+        }
       }
     }
 #endif
@@ -426,10 +441,22 @@ class CPUIDInfo {
   int implementer() const { return implementer_; }
   int cpunum() const { return cpunum_; }
 
+  static bool TestAarch64CPU(Aarch64CPU cpu) {
+    InitCPUIDInfo();
+    switch (cpu) {
+      case ARM_NEOVERSE_V1:
+        return cpuid->is_arm_neoverse_v1_;
+      default:
+        return 0;
+    }
+  }
+
  private:
   int implementer_;
   int variant_;
   int cpunum_;
+  int is_arm_neoverse_v1_;  // ARM NEOVERSE V1
+  int is_arm_neoverse_n1_;  // ARM NEOVERSE N1
 };
 
 absl::once_flag cpuid_once_flag;
@@ -438,12 +465,20 @@ void InitCPUIDInfo() {
   absl::call_once(cpuid_once_flag, CPUIDInfo::Initialize);
 }
 
-#endif
+#endif  // PLATFORM_IS_ARM64
 }  // namespace
 
 bool TestCPUFeature(CPUFeature feature) {
 #ifdef PLATFORM_IS_X86
   return CPUIDInfo::TestFeature(feature);
+#else
+  return false;
+#endif
+}
+
+bool TestAarch64CPU(Aarch64CPU cpu) {
+#ifdef PLATFORM_IS_ARM64
+  return CPUIDInfo::TestAarch64CPU(cpu);
 #else
   return false;
 #endif

--- a/tensorflow/tsl/platform/cpu_info.cc
+++ b/tensorflow/tsl/platform/cpu_info.cc
@@ -28,7 +28,7 @@ limitations under the License.
 #define HWCAP_CPUID (1 << 11)
 #endif
 #include <fstream>
-#endif  // defined(PLATFORM_IS_ARM64)
+#endif  // PLATFORM_IS_ARM64 && !__APPLE__ && !__OpenBSD__
 
 // SIMD extension querying is only available on x86.
 #ifdef PLATFORM_IS_X86

--- a/tensorflow/tsl/platform/cpu_info.cc
+++ b/tensorflow/tsl/platform/cpu_info.cc
@@ -465,7 +465,7 @@ void InitCPUIDInfo() {
   absl::call_once(cpuid_once_flag, CPUIDInfo::Initialize);
 }
 
-#endif  // PLATFORM_IS_ARM64
+#endif  // PLATFORM_IS_ARM64 && !__APPLE__ && !__OpenBSD__
 }  // namespace
 
 bool TestCPUFeature(CPUFeature feature) {

--- a/tensorflow/tsl/platform/cpu_info.h
+++ b/tensorflow/tsl/platform/cpu_info.h
@@ -134,6 +134,13 @@ enum CPUFeature {
   AMX_BF16 = 43,  // Bfloat16 tile matrix multiplication
 };
 
+enum Aarch64CPU {
+  ARM_NEOVERSE_N1 = 0,  // ARM NEOVERSE N1
+  ARM_NEOVERSE_V1 = 1,  // ARM NEOVERSE V1
+};
+// Checks whether the current AArch64 processor is supported.
+bool TestAarch64CPU(Aarch64CPU cpu);
+
 // Checks whether the current processor supports one of the features above.
 // Checks CPU registers to return hardware capabilities.
 bool TestCPUFeature(CPUFeature feature);


### PR DESCRIPTION
This PR follows an approach of using heuristics to choose whether to rewrite a oneDNN matmul node via mkl_layout_pass for AArch64 builds. The heuristics is based on a decision tree model with the shapes and number of ops as features. This work is based on three PRs in upstream TensorFlow:

1. https://github.com/tensorflow/tensorflow/pull/60160 that uses the rewrite pass for the convolution microbenchmarks, which has been merged.
2. https://github.com/tensorflow/tensorflow/pull/60026 that uses a heuristic based on a linear model to choose between oneDNN and Eigen.

The changes in this PR include the following:
- Use the rewrite pass for matmul microbenchmarks
- Use heuristic for matmul ops to decide when to rewrite a matmul node and is guarded for AArch64 builds

Performance impact:
With this PR, we show the performance before and after introducing this patch for 8 cores on Neoverse V1 platforms for default thread settings.
### Matmul microbenchmarks
Before the patch
![image](https://github.com/tensorflow/tensorflow/assets/65665931/6e0f033c-aeb2-490e-8f78-7b08b4d4b19e)
After the patch
![image](https://github.com/tensorflow/tensorflow/assets/65665931/a313fc01-c91c-4ca2-b7b8-5b6659c439a1)
### NLP models from hugging face
![image](https://github.com/tensorflow/tensorflow/assets/65665931/702fe640-c274-4dfe-83b0-6ef43537bf03)




