### PR TITLE
Migrate fuzzers to FuzzTest format

### DIFF
--- a/tensorflow/core/kernels/fuzzing/BUILD
+++ b/tensorflow/core/kernels/fuzzing/BUILD
@@ -1,5 +1,9 @@
 load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
 load("//tensorflow/core/kernels/fuzzing:tf_ops_fuzz_target_lib.bzl", "tf_ops_fuzz_target_lib", "tf_oss_fuzz_corpus", "tf_oss_fuzz_dict")
+load(
+    "//tensorflow/security/fuzzing:tf_fuzzing.bzl",
+    "tf_cc_fuzz_test",
+)
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -11,6 +15,19 @@ cc_library(
     name = "fuzz_session",
     hdrs = ["fuzz_session.h"],
     deps = [
+        "//tensorflow/cc:scope",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:tensorflow",
+    ],
+)
+
+tf_cc_fuzz_test(
+    name = "general_ops_fuzzers",
+    srcs = ["general_ops_fuzzers.cc"],
+    tags = ["no_oss"],
+    deps = [
+        ":fuzz_session",
+        "//tensorflow/cc:cc_ops",
         "//tensorflow/cc:scope",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:tensorflow",

--- a/tensorflow/core/kernels/fuzzing/fuzz_session.h
+++ b/tensorflow/core/kernels/fuzzing/fuzz_session.h
@@ -34,6 +34,20 @@ limitations under the License.
 #define STANDARD_TF_FUZZ_FUNCTION(FuzzerClass)
 #endif
 
+// Standard invoking function macro to dispatch to a fuzzer class.
+#ifndef PLATFORM_WINDOWS
+#define STANDARD_TF_FUZZ_FUZZTEST_FUNCTION(FuzzerClass, FuzzTestFunc) \
+  void FuzzTestFunc(std::vector<uint8_t> data) {                      \
+    static FuzzerClass* fuzzer = new FuzzerClass();                   \
+    fuzzer->Fuzz(data.data(), data.size());                    \
+  }
+#else
+// We don't compile this for Windows, MSVC doesn't like it as pywrap in Windows
+// links all the code into one big object file and there are conflicting
+// function names.
+#define STANDARD_TF_FUZZ_FUZZTEST_FUNCTION(FuzzerClass, FuzzTestFunc)
+#endif
+
 // Standard builder for hooking one placeholder to one op.
 #define SINGLE_INPUT_OP_BUILDER(dtype, opName)                          \
   void BuildGraph(const Scope& scope) override {                        \

--- a/tensorflow/core/kernels/fuzzing/general_ops_fuzzers.cc
+++ b/tensorflow/core/kernels/fuzzing/general_ops_fuzzers.cc
@@ -1,0 +1,114 @@
+/* Copyright 2016 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "fuzztest/fuzztest.h"
+#include "tensorflow/cc/ops/audio_ops.h"
+#include "tensorflow/cc/ops/standard_ops.h"
+#include "tensorflow/core/kernels/fuzzing/fuzz_session.h"
+
+namespace tensorflow {
+namespace fuzzing {
+
+// DecodePng
+class FuzzDecodePng : public FuzzStringInputOp {
+  SINGLE_INPUT_OP_BUILDER(DT_STRING, DecodePng);
+};
+STANDARD_TF_FUZZ_FUZZTEST_FUNCTION(FuzzDecodePng, FuzzDecodePngEntry);
+FUZZ_TEST(GeneralOpsFuzzer, FuzzDecodePngEntry);
+
+// DecodeWav
+class FuzzDecodeWav : public FuzzStringInputOp {
+  SINGLE_INPUT_OP_BUILDER(DT_STRING, DecodeWav);
+};
+STANDARD_TF_FUZZ_FUZZTEST_FUNCTION(FuzzDecodeWav, FuzzDecodeWavEntry);
+FUZZ_TEST(GeneralOpsFuzzer, FuzzDecodeWavEntry);
+
+// DecodeBmp
+class FuzzDecodeBmp : public FuzzStringInputOp {
+  SINGLE_INPUT_OP_BUILDER(DT_STRING, DecodeBmp);
+};
+STANDARD_TF_FUZZ_FUZZTEST_FUNCTION(FuzzDecodeBmp, FuzzDecodeBmpEntry);
+FUZZ_TEST(GeneralOpsFuzzer, FuzzDecodeBmpEntry);
+
+// DecodeGif
+class FuzzDecodeGif : public FuzzStringInputOp {
+  SINGLE_INPUT_OP_BUILDER(DT_STRING, DecodeGif);
+};
+STANDARD_TF_FUZZ_FUZZTEST_FUNCTION(FuzzDecodeGif, FuzzDecodeGifEntry);
+FUZZ_TEST(GeneralOpsFuzzer, FuzzDecodeGifEntry);
+
+// DecodeJpeg
+class FuzzDecodeJpeg : public FuzzStringInputOp {
+  SINGLE_INPUT_OP_BUILDER(DT_STRING, DecodeJpeg);
+};
+STANDARD_TF_FUZZ_FUZZTEST_FUNCTION(FuzzDecodeJpeg, FuzzDecodeJpegEntry);
+FUZZ_TEST(GeneralOpsFuzzer, FuzzDecodeJpegEntry);
+
+// DecodeImage
+class FuzzDecodeImage : public FuzzStringInputOp {
+  SINGLE_INPUT_OP_BUILDER(DT_STRING, DecodeImage);
+};
+STANDARD_TF_FUZZ_FUZZTEST_FUNCTION(FuzzDecodeImage, FuzzDecodeImageEntry);
+FUZZ_TEST(GeneralOpsFuzzer, FuzzDecodeImageEntry);
+
+// EncodeBase64
+class FuzzEncodeBase64 : public FuzzStringInputOp {
+  SINGLE_INPUT_OP_BUILDER(DT_STRING, EncodeBase64);
+};
+STANDARD_TF_FUZZ_FUZZTEST_FUNCTION(FuzzEncodeBase64, FuzzEncodeBase64Entry);
+FUZZ_TEST(GeneralOpsFuzzer, FuzzEncodeBase64Entry);
+
+// DecodeCsv
+class FuzzDecodeCsv : public FuzzStringInputOp {
+  void BuildGraph(const Scope& scope) override {
+    auto input =
+        tensorflow::ops::Placeholder(scope.WithOpName("input"), DT_STRING);
+    // For now, assume we want CSVs with 4 columns, as we need a refactoring
+    // of the entire infrastructure to support the more complex usecase due to
+    // the fact that graph generation and fuzzing data are at separate steps.
+    InputList defaults = {Input("a"), Input("b"), Input("c"), Input("d")};
+    (void)tensorflow::ops::DecodeCSV(scope.WithOpName("output"), input,
+                                     defaults);
+  }
+};
+STANDARD_TF_FUZZ_FUZZTEST_FUNCTION(FuzzDecodeCsv, FuzzDecodeCsvEntry);
+FUZZ_TEST(GeneralOpsFuzzer, FuzzDecodeCsvEntry);
+
+// DecodeCompressed
+class FuzzDecodeCompressed : public FuzzStringInputOp {
+  void BuildGraph(const Scope& scope) override {
+    auto input =
+        tensorflow::ops::Placeholder(scope.WithOpName("input"), DT_STRING);
+    auto d1 = tensorflow::ops::DecodeCompressed(
+        scope.WithOpName("d1"), input,
+        tensorflow::ops::DecodeCompressed::CompressionType(""));
+    auto d2 = tensorflow::ops::DecodeCompressed(
+        scope.WithOpName("d2"), input,
+        tensorflow::ops::DecodeCompressed::CompressionType("ZLIB"));
+    auto d3 = tensorflow::ops::DecodeCompressed(
+        scope.WithOpName("d3"), input,
+        tensorflow::ops::DecodeCompressed::CompressionType("GZIP"));
+    Scope grouper =
+        scope.WithControlDependencies(std::vector<tensorflow::Operation>{
+            d1.output.op(), d2.output.op(), d3.output.op()});
+    (void)tensorflow::ops::NoOp(grouper.WithOpName("output"));
+  }
+};
+STANDARD_TF_FUZZ_FUZZTEST_FUNCTION(FuzzDecodeCompressed,
+                                   FuzzDecodeCompressedEntry);
+FUZZ_TEST(GeneralOpsFuzzer, FuzzDecodeCompressedEntry);
+
+}  // end namespace fuzzing
+}  // end namespace tensorflow


### PR DESCRIPTION
Creates a set of fuzzers to FuzzTest style. One of the benefits is that this will reduce storage size required for the fuzzers, because the fuzzers will all be based off the same binary whereas the non-FuzzTest fuzzers will have a binary per fuzzer. This storage requirement has caused an issue on the OSS-Fuzz side:
https://github.com/google/oss-fuzz/issues/9792

Migrating to FuzzTest will make it easier to add new ops-specific fuzzers since we won't have to worry about disk size. The existing fuzzesr can be several GBs of storage and it quickly goes beyond what we have available at OSS-Fuzz.

It would however be nice to re-use the existing fuzzer helper logic from fuzz_session.h so I added a macro similar to what we have for libFuzzer but simple for FuzzTest. I migrated a set of the existing fuzzers.

I figured it would be nice to do a soft transition, so we can remove the existing fuzzers after the ones introduced in this PR has shown to run for a while. I'm also curious in whether we will see a difference in performance from the FuzzTest and libFuzzer harnesses.