### PR TITLE
unpin gast dependency for pip_package

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -85,8 +85,7 @@ REQUIRED_PACKAGES = [
     'absl-py >= 1.0.0',
     'astunparse >= 1.6.0',
     'flatbuffers >= 23.5.26',
-    # TODO(b/213222745) gast versions above 0.4.0 break TF's tests
-    'gast >= 0.2.1, <= 0.4.0',
+    'gast >=0.2.1,!=0.5.0,!=0.5.1,!=0.5.2',
     'google_pasta >= 0.1.1',
     'h5py >= 2.9.0',
     'libclang >= 13.0.0',


### PR DESCRIPTION
Commit c762c4501ca017994c1fa5554c3c8e47b7c80b66 noted that "I also know that gast 0.5.2 breaks one of our tests" and committed "gast versions above 0.4.0 are incompatible with some of TF's tests."

In #56244, it was suggested to raise a PR to remove the cap. In view of the above-mentioned constraints, I've excluded everything after 0.4.0 up to 0.5.2; note that 0.5.0 directly followed 0.4.0, see https://github.com/serge-sans-paille/gast/tags