### PR TITLE
Set weights to any for matmul and ip oneDNN primitives

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
@@ -167,47 +167,24 @@ class BatchMatMulMkl : public OpKernel {
             *params, false /* value for do_not_cache */);
 
     Trhs* weight_data = const_cast<Trhs*>(rhs.flat<Trhs>().data());
-
 // TODO(Arm, Intel): Reach agreement on whether this block should be deleted.
 // https://github.com/tensorflow/tensorflow/pull/57987#discussion_r993731524
 #ifdef DNNL_AARCH64_USE_ACL
-    memory::format_tag weight_format;
-    switch (params->b_dims.size()) {
-      case 2:
-        weight_format =
-            adj_y_ ? memory::format_tag::ba : memory::format_tag::ab;
-        break;
-      case 3:
-        weight_format =
-            adj_y_ ? memory::format_tag::acb : memory::format_tag::abc;
-        break;
-      case 4:
-        weight_format =
-            adj_y_ ? memory::format_tag::abdc : memory::format_tag::abcd;
-        break;
-      case 5:
-        weight_format =
-            adj_y_ ? memory::format_tag::abced : memory::format_tag::abcde;
-        break;
-      default:
-        weight_format = memory::format_tag::undef;
-    }
     MklDnnData<Trhs> weights_mkl(&(this->cpu_engine_));
-    if (weight_format != memory::format_tag::undef) {
-      auto weight_md =
-          memory::desc(params->b_dims, MklDnnType<Trhs>(), weight_format);
-      std::shared_ptr<dnnl::matmul::primitive_desc> matmul_pd =
-          matmul_prim->GetPrimitiveDesc();
-      // Reorder weights if necessary.
-      // Check whether we need to do reorder.
-      if (weight_md != matmul_pd->weights_desc()) {
-        weights_mkl.SetUsrMem(weight_md, weight_data);
-        weights_mkl.CheckReorderToOpMem(matmul_pd.get()->weights_desc(),
-                                        this->cpu_engine_, ctx);
-        weight_data =
-            reinterpret_cast<Trhs*>(weights_mkl.GetOpMem().get_data_handle());
-      }
+    auto weight_md =
+        memory::desc(params->b_dims, MklDnnType<Trhs>(), params->b_strides);
+    std::shared_ptr<dnnl::matmul::primitive_desc> matmul_pd =
+        matmul_prim->GetPrimitiveDesc();
+    // Reorder weights if necessary.
+    // Check whether we need to do reorder.
+    if (weight_md != matmul_pd->weights_desc()) {
+      weights_mkl.SetUsrMem(weight_md, weight_data);
+      weights_mkl.CheckReorderToOpMem(matmul_pd.get()->weights_desc(),
+                                      this->cpu_engine_, ctx);
+      weight_data =
+          reinterpret_cast<Trhs*>(weights_mkl.GetOpMem().get_data_handle());
     }
+
 #endif  // DNNL_AARCH64_USE_ACL
 
     UserScratchPad<unsigned char> scratch_pad;

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -880,12 +880,12 @@ class MklMatMulPrimitive : public MklPrimitive {
     // Create memory primitive based on dummy data.
     context_.a_mem.reset(
         new dnnl::memory(*context_.a_md, cpu_engine_, DummyData));
-#ifndef DNNL_AARCH64_USE_ACL
-    context_.b_mem.reset(
-        new dnnl::memory(*context_.b_md, cpu_engine_, DummyData));
-#else
+#ifdef DNNL_AARCH64_USE_ACL
     context_.b_mem.reset(new dnnl::memory(
         context_.prim_desc.get()->weights_desc(), cpu_engine_, DummyData));
+#else
+    context_.b_mem.reset(
+        new dnnl::memory(*context_.b_md, cpu_engine_, DummyData));
 #endif
     context_.c_mem.reset(
         new dnnl::memory(*context_.c_md, cpu_engine_, DummyData));


### PR DESCRIPTION
In order to run optimized GEMM kernels for matrix multiplication through Arm Compute Library (ACL) when integrating it through oneDNN we need to specify that format for weights (RHS matrix) is any so that ACL can reorder them in the format that GEMM kernel expects them to be.