### PR TITLE
Change TFL_MINIMUM_OS_VERSION to build TensorFlowLiteCMetal_framework on XCode 14.3

### DIFF
--- a/tensorflow/lite/ios/ios.bzl
+++ b/tensorflow/lite/ios/ios.bzl
@@ -6,7 +6,7 @@ load("//tensorflow:tensorflow.bzl", "clean_dep")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_static_framework")
 
 # LINT.IfChange
-TFL_MINIMUM_OS_VERSION = "11.0"
+TFL_MINIMUM_OS_VERSION = "12.0"
 # LINT.ThenChange(
 #   TensorFlowLiteC.podspec.template,
 #   TensorFlowLiteSelectTfOps.podspec.template,


### PR DESCRIPTION
The TensorFlow Lite framework build for Metal fails with the Xcode Version 14.3 (14E222b) when running the command: 
`bazel build -c opt --config=ios_fat --cxxopt=--std=c++17 //tensorflow/lite/ios:TensorFlowLiteCMetal_framework`

```
ERROR: /tensorflow/tensorflow/lite/delegates/gpu/common/transformations/BUILD:123:11: Compiling tensorflow/lite/delegates/gpu/common/transformations/global_pooling_to_reduce_op.cc failed: (Aborted): wrapped_clang_pp failed: error executing command external/local_config_cc/wrapped_clang_pp '-D_FORTIFY_SOURCE=1' -fstack-protector -fcolor-diagnostics -Wall -Wthread-safety -Wself-assign -fno-omit-frame-pointer -g0 -O2 -DNDEBUG ... (remaining 37 arguments skipped)

tensorflow/lite/delegates/gpu/common/transformations/global_pooling_to_reduce_op.cc:59:15: error: 'any_cast<const tflite::gpu::Pooling2DAttributes &>' is unavailable: introduced in iOS 12.0
        absl::any_cast<const Pooling2DAttributes&>(node->operation.attributes);
```

To solve the problem, you need to change the TFL_MINIMUM_OS_VERSION = "11.0" to TFL_MINIMUM_OS_VERSION = "12.0".