### PR TITLE
Fix aligned alloc feature condition on C++14 compiler

### DIFF
--- a/tensorflow/lite/core/interpreter_builder.cc
+++ b/tensorflow/lite/core/interpreter_builder.cc
@@ -49,7 +49,7 @@ limitations under the License.
 #include "tensorflow/lite/version.h"
 
 // aligned_alloc is available (via cstdlib/stdlib.h) with C++17/C11.
-//(introduced in stdc11 but realized in C++17)
+// (introduced in stdc11 but realized in C++17)
 #if __cplusplus >= 201703L && __STDC_VERSION__ >= 201112L
 #if !defined(__ANDROID__) || __ANDROID_API__ >= 28
 // Neither Apple nor Windows provide aligned_alloc.

--- a/tensorflow/lite/core/interpreter_builder.cc
+++ b/tensorflow/lite/core/interpreter_builder.cc
@@ -49,7 +49,8 @@ limitations under the License.
 #include "tensorflow/lite/version.h"
 
 // aligned_alloc is available (via cstdlib/stdlib.h) with C++17/C11.
-#if __cplusplus >= 201703L || __STDC_VERSION__ >= 201112L
+//(introduced in stdc11 but realized in C++17)
+#if __cplusplus >= 201703L && __STDC_VERSION__ >= 201112L
 #if !defined(__ANDROID__) || __ANDROID_API__ >= 28
 // Neither Apple nor Windows provide aligned_alloc.
 #if !defined(__APPLE__) && !defined(_WIN32)

--- a/tensorflow/lite/kernels/internal/optimized/neon_tensor_utils.cc
+++ b/tensorflow/lite/kernels/internal/optimized/neon_tensor_utils.cc
@@ -36,7 +36,8 @@ limitations under the License.
 #ifdef USE_NEON
 
 // aligned_alloc is available (via cstdlib/stdlib.h) with C++17/C11.
-#if __cplusplus >= 201703L || __STDC_VERSION__ >= 201112L
+//(introduced in stdc11 but realized in C++17)
+#if __cplusplus >= 201703L && __STDC_VERSION__ >= 201112L
 #if !defined(__ANDROID__) || __ANDROID_API__ >= 28
 // Neither Apple nor Windows provide aligned_alloc.
 #if !defined(__APPLE__) && !defined(_WIN32)

--- a/tensorflow/lite/kernels/internal/optimized/neon_tensor_utils.cc
+++ b/tensorflow/lite/kernels/internal/optimized/neon_tensor_utils.cc
@@ -36,7 +36,7 @@ limitations under the License.
 #ifdef USE_NEON
 
 // aligned_alloc is available (via cstdlib/stdlib.h) with C++17/C11.
-//(introduced in stdc11 but realized in C++17)
+// (introduced in stdc11 but realized in C++17)
 #if __cplusplus >= 201703L && __STDC_VERSION__ >= 201112L
 #if !defined(__ANDROID__) || __ANDROID_API__ >= 28
 // Neither Apple nor Windows provide aligned_alloc.


### PR DESCRIPTION
The updated condition will only compile if both C++17 and C11 compliance are met, guaranteeing that the aligned_alloc feature is available. 

Relevant closed PR #57707 

Fixes #57706