### PR TITLE
Multi-Stream: allow OpSeg to own const kernels

### DIFF
--- a/tensorflow/core/framework/op_segment.cc
+++ b/tensorflow/core/framework/op_segment.cc
@@ -101,11 +101,14 @@ void OpSegment::RemoveHold(const string& session_handle) {
 }
 
 bool OpSegment::ShouldOwnKernel(FunctionLibraryRuntime* lib,
-                                const string& node_op) {
-  // OpSegment should not own kernel if the node is stateless, or a function.
-  return lib->IsStateful(node_op) &&
-         lib->GetFunctionLibraryDefinition()->Find(node_op) == nullptr &&
-         node_op != "PartitionedCall" && node_op != "StatefulPartitionedCall";
+                                const string& node_op,
+                                const bool own_const_kernel) {
+  // OpSegment should not own kernel if the node is stateless, or a function, or
+  // it's not a Const Op or own_const_kernel == false.
+  return (own_const_kernel && node_op == "Const") ||
+         (lib->IsStateful(node_op) &&
+          lib->GetFunctionLibraryDefinition()->Find(node_op) == nullptr &&
+          node_op != "PartitionedCall" && node_op != "StatefulPartitionedCall");
 }
 
 }  // end namespace tensorflow

--- a/tensorflow/core/framework/op_segment.h
+++ b/tensorflow/core/framework/op_segment.h
@@ -63,7 +63,8 @@ class OpSegment {
 
   // Returns true if OpSegment should own the kernel.
   static bool ShouldOwnKernel(FunctionLibraryRuntime* lib,
-                              const std::string& node_op);
+                              const std::string& node_op,
+                              const bool own_const_kernel = false);
 
  private:
   // op name -> OpKernel


### PR DESCRIPTION
This PR works as a part of the whole Multi-Stream feature in TF, which is proposed in #61185.

Add an option for OpSegment to choose whether to own the constant op kernels.

@changhuilin 