### PR TITLE
Multi-Stream: add stream-related APIs to DeviceMgr

### DIFF
--- a/tensorflow/core/common_runtime/device_mgr.h
+++ b/tensorflow/core/common_runtime/device_mgr.h
@@ -75,6 +75,14 @@ class DeviceMgr {
   // nullptr.
   virtual Device* HostCPU() const = 0;
 
+  // Get the number of stream groups.
+  virtual int StreamGroupCount() const = 0;
+
+  // Assigns *device with pointer to StreamDevice of the device of the
+  // given name and given stream_id.
+  virtual Device* LookupStream(const Device* device,
+                               const int stream_id) const = 0;
+
   TF_DISALLOW_COPY_AND_ASSIGN(DeviceMgr);
 };
 
@@ -105,6 +113,9 @@ class DynamicDeviceMgr : public DeviceMgr {
   int NumDeviceType(const string& type) const override;
   int NumDevices() const override;
   Device* HostCPU() const override;
+  int StreamGroupCount() const override;
+  Device* LookupStream(const Device* device,
+                       const int stream_id) const override;
 
   // Add devices to device manager. Returns error for repeated device names.
   Status AddDevices(std::vector<std::unique_ptr<Device>> devices);
@@ -164,6 +175,9 @@ class DynamicDeviceMgr : public DeviceMgr {
   // still be available to avoid segmentation fault. We keep the devices in this
   // buffer only for that purpose.
   DeviceCircularBuffer stale_devices_ TF_GUARDED_BY(devices_mu_);
+
+  int stream_group_count_;
+  std::unordered_map<const Device*, std::vector<Device*>> stream_device_map_;
 
   TF_DISALLOW_COPY_AND_ASSIGN(DynamicDeviceMgr);
 };

--- a/tensorflow/core/common_runtime/dynamic_device_mgr.cc
+++ b/tensorflow/core/common_runtime/dynamic_device_mgr.cc
@@ -27,7 +27,8 @@ limitations under the License.
 
 namespace tensorflow {
 
-DynamicDeviceMgr::DynamicDeviceMgr() : cpu_device_(nullptr) {}
+DynamicDeviceMgr::DynamicDeviceMgr()
+    : cpu_device_(nullptr), stream_group_count_(0) {}
 
 DynamicDeviceMgr::DynamicDeviceMgr(
     std::vector<std::unique_ptr<Device>>&& devices)


### PR DESCRIPTION
This PR works as a part of the whole Multi-Stream feature in TF, which is proposed in #61185.

Add stream-related APIs and variables to DeviceMgr.

@changhuilin 