### PR TITLE
Multi-Stream: device_name_utils

### DIFF
--- a/tensorflow/compiler/jit/variable_info_util.cc
+++ b/tensorflow/compiler/jit/variable_info_util.cc
@@ -58,7 +58,8 @@ Status GetVariableInfosFromInputs(ResourceMgr* rm, DeviceBase* dev,
                                      " to GetVariableInfosFromInputs.");
     }
     ResourceHandle handle = inputs[var_idx]->flat<ResourceHandle>()(0);
-    if (handle.device() != dev->attributes().name()) {
+    if (!DeviceNameUtils::HaveSameDeviceName(handle.device(),
+                                             dev->attributes().name())) {
       std::string definition_location =
           DefinitionLocationMsg(handle.definition_stack_trace());
       return errors::InvalidArgument(

--- a/tensorflow/core/framework/dataset.cc
+++ b/tensorflow/core/framework/dataset.cc
@@ -1027,7 +1027,8 @@ Status DatasetBase::DatasetGraphDefBuilder::AddResourceHelper(
     return errors::InvalidArgument("Empty resouce handle");
   }
   const ResourceHandle& handle = t.flat<ResourceHandle>()(0);
-  if (ctx->device_name() != handle.device()) {
+  if (!DeviceNameUtils::HaveSameDeviceName(ctx->device_name(),
+                                           handle.device())) {
     return errors::InvalidArgument("Trying to access resource ", handle.name(),
                                    " located in device ", handle.device(),
                                    " from device ", ctx->device_name());

--- a/tensorflow/core/framework/resource_mgr.cc
+++ b/tensorflow/core/framework/resource_mgr.cc
@@ -65,7 +65,8 @@ Status MakeResourceHandleToOutput(OpKernelContext* context, int output_index,
 namespace internal {
 
 Status ValidateDevice(OpKernelContext* ctx, const ResourceHandle& p) {
-  if (ctx->device()->attributes().name() != p.device()) {
+  if (!DeviceNameUtils::HaveSameDeviceName(ctx->device()->attributes().name(),
+                                           p.device())) {
     return errors::InvalidArgument(
         "Trying to access resource ", p.name(), " located in device ",
         p.device(), " from device ", ctx->device()->attributes().name());

--- a/tensorflow/tsl/util/BUILD
+++ b/tensorflow/tsl/util/BUILD
@@ -262,6 +262,7 @@ cc_library(
     deps = [
         "//tensorflow/tsl/platform:errors",
         "//tensorflow/tsl/platform:status",
+        "//tensorflow/tsl/platform:statusor",
         "//tensorflow/tsl/platform:stringpiece",
     ],
 )

--- a/tensorflow/tsl/util/device_name_utils.cc
+++ b/tensorflow/tsl/util/device_name_utils.cc
@@ -618,6 +618,83 @@ std::vector<string> DeviceNameUtils::GetLocalNamesForDeviceMappings(
   return OkStatus();
 }
 
+/*static*/ bool DeviceNameUtils::IsStreamDeviceName(
+    const std::string& device_name) {
+  size_t pos = device_name.rfind("STREAM_GPU_");
+  if (pos == string::npos) {
+    pos = device_name.rfind("STREAM_CPU_");
+    if (pos == string::npos) {
+      return false;
+    }
+  }
+  size_t pos_colon = device_name.find_last_of(":");
+  if (pos_colon == string::npos || pos > pos_colon) {
+    return false;
+  }
+  int32_t device_id, stream_id;
+  if (!strings::safe_strto32(device_name.substr(pos + 11, pos_colon - pos - 11),
+                             &device_id) ||
+      !strings::safe_strto32(device_name.substr(pos_colon + 1), &stream_id)) {
+    return false;
+  }
+  return true;
+}
+
+/*static*/ tsl::StatusOr<string>
+DeviceNameUtils::GetDeviceNameFromStreamDeviceName(const string& device_name) {
+  if (!IsStreamDeviceName(device_name)) {
+    return errors::InvalidArgument("Invalid stream device name: ", device_name);
+  }
+  string output = device_name;
+  size_t pos = output.rfind("STREAM_GPU_");
+  if (pos != string::npos) {
+    output.replace(pos, 11, "GPU:");
+    output.erase(output.find_last_of(":"));
+  } else {
+    pos = output.rfind("STREAM_CPU_");
+    output.replace(pos, 11, "CPU:");
+    output.erase(output.find_last_of(":"));
+  }
+  return output;
+}
+
+/*static*/ tsl::StatusOr<int> DeviceNameUtils::DecodeDeviceFromStreamDeviceName(
+    const string& device_name) {
+  if (!IsStreamDeviceName(device_name)) {
+    return errors::InvalidArgument("Invalid stream device name: ", device_name);
+  }
+  size_t pos = device_name.rfind("STREAM_GPU_");
+  if (pos == string::npos) {
+    pos = device_name.rfind("STREAM_CPU_");
+  }
+  size_t pos_colon = device_name.find_last_of(":");
+  return std::stoi(device_name.substr(pos + 11, pos_colon - pos - 11));
+}
+
+/*static*/ tsl::StatusOr<int> DeviceNameUtils::DecodeStreamFromStreamDeviceName(
+    const string& device_name) {
+  if (!IsStreamDeviceName(device_name)) {
+    return errors::InvalidArgument("Invalid stream device name: ", device_name);
+  }
+  return std::stoi(device_name.substr(device_name.find_last_of(":") + 1));
+}
+
+/*static*/ bool DeviceNameUtils::HaveSameDeviceName(
+    const std::string& device_name1, const std::string& device_name2) {
+  if (device_name1 == device_name2) return true;
+  std::string name1 = [&device_name1] {
+    tsl::StatusOr<std::string> name1 =
+        GetDeviceNameFromStreamDeviceName(device_name1);
+    return name1.ok() ? name1.value() : device_name1;
+  }();
+  std::string name2 = [&device_name2] {
+    tsl::StatusOr<std::string> name2 =
+        GetDeviceNameFromStreamDeviceName(device_name2);
+    return name2.ok() ? name2.value() : device_name2;
+  }();
+  return name1 == name2;
+}
+
 std::ostream& operator<<(std::ostream& os,
                          const DeviceNameUtils::ParsedName& x) {
   os << DeviceNameUtils::ParsedNameToString(x);

--- a/tensorflow/tsl/util/device_name_utils.h
+++ b/tensorflow/tsl/util/device_name_utils.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <string>
 
 #include "tensorflow/tsl/platform/status.h"
+#include "tensorflow/tsl/platform/statusor.h"
 #include "tensorflow/tsl/platform/stringpiece.h"
 
 namespace tsl {
@@ -284,6 +285,34 @@ class DeviceNameUtils {
     if (!a_status) return a < b;
     return parsed_a < parsed_b;
   }
+
+  // Returns true iff the device_name is in the format of
+  // ".*STREAM_(C|G)PU_\d+:\d+$".
+  static bool IsStreamDeviceName(const std::string& device_name);
+
+  // Returns name of the device from the stream-encoded name if the
+  // multi-stream is enabled. Otherwise returns the input name. For
+  // example, if the input device_name is "STREAM_GPU_0:2", returns "GPU:0".
+  static tsl::StatusOr<std::string> GetDeviceNameFromStreamDeviceName(
+      const std::string& device_name);
+
+  // Returns device ordinal of the device from the stream-encoded name if the
+  // multi-stream is enabled. For example, if the input device_name is
+  // "STREAM_GPU_0:2", returns 0.
+  static tsl::StatusOr<int> DecodeDeviceFromStreamDeviceName(
+      const std::string& device_name);
+
+  // Returns stream that is used from the stream-encoded name if the
+  // multi-stream is enabled. For example, if the input device_name is
+  // "STREAM_GPU_0:2", returns 2.
+  static tsl::StatusOr<int> DecodeStreamFromStreamDeviceName(
+      const std::string& device_name);
+
+  // Returns true iff device_name1 and device_name2 have the same name, or
+  // one or both of them are stream device names and they represent the same
+  // device.
+  static bool HaveSameDeviceName(const std::string& device_name1,
+                                 const std::string& device_name2);
 };
 
 std::ostream& operator<<(std::ostream& os,


### PR DESCRIPTION
This PR works as a part of the whole Multi-Stream feature in TF, which is proposed in #61185.

Add stream-related help functions in DeviceNameUtils, and use them in two places.

@changhuilin 