### PR TITLE
Multi-Stream: enable context-level cache

### DIFF
--- a/tensorflow/compiler/mlir/tools/kernel_gen/BUILD
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/BUILD
@@ -205,6 +205,8 @@ cc_library(
         "@llvm-project//mlir:mlir_runner_utils",
     ] + if_cuda_is_configured([
         "@local_config_cuda//cuda:cuda_headers",
+        "//tensorflow/compiler/xla/stream_executor/cuda:cuda_driver",
+        "//tensorflow/compiler/xla/stream_executor/cuda:cuda_gpu_executor_header",
         "//tensorflow/compiler/xla/stream_executor/cuda:stream_executor_cuda",
     ]) + if_rocm_is_configured([
         "@local_config_rocm//rocm:rocm_headers",

--- a/tensorflow/compiler/mlir/tools/kernel_gen/tf_gpu_runtime_wrappers.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/tf_gpu_runtime_wrappers.cc
@@ -154,12 +154,13 @@ extern "C" void _mlir_ciface_tf_launch_kernel(void *ctx, void *module_blob,
 #else
   int ctx_id = 0;
 #endif
-  OP_REQUIRES_OK(
-      op_kernel_ctx,
-      rm->LookupOrCreate<GPURuntimeCache>(
-          rm->default_container(),
-          absl::StrCat(GPURuntimeCache::kDefaultResourceName, ctx_id), &cache,
-          GPURuntimeCache::Create));
+  std::string name =
+      ctx_id > 0
+          ? absl::StrCat(GPURuntimeCache::kDefaultResourceName, "_", ctx_id)
+          : GPURuntimeCache::kDefaultResourceName;
+  OP_REQUIRES_OK(op_kernel_ctx, rm->LookupOrCreate<GPURuntimeCache>(
+                                    rm->default_container(), name, &cache,
+                                    GPURuntimeCache::Create));
   assert(cache != nullptr && "cache creation must not fail");
   tensorflow::core::ScopedUnref ref(cache);
 

--- a/tensorflow/compiler/mlir/tools/kernel_gen/tf_gpu_runtime_wrappers.cc
+++ b/tensorflow/compiler/mlir/tools/kernel_gen/tf_gpu_runtime_wrappers.cc
@@ -19,6 +19,10 @@ limitations under the License.
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_cat.h"
+#if GOOGLE_CUDA
+#include "tensorflow/compiler/xla/stream_executor/cuda/cuda_driver.h"
+#include "tensorflow/compiler/xla/stream_executor/gpu/gpu_executor.h"
+#endif
 #include "tensorflow/compiler/xla/stream_executor/stream.h"
 #include "tensorflow/compiler/xla/stream_executor/stream_executor_internal.h"
 #include "tensorflow/core/platform/logging.h"
@@ -141,10 +145,21 @@ extern "C" void _mlir_ciface_tf_launch_kernel(void *ctx, void *module_blob,
     return;
   }
   GPURuntimeCache *cache = nullptr;
-  OP_REQUIRES_OK(op_kernel_ctx, rm->LookupOrCreate<GPURuntimeCache>(
-                                    rm->default_container(),
-                                    GPURuntimeCache::kDefaultResourceName,
-                                    &cache, GPURuntimeCache::Create));
+#if GOOGLE_CUDA
+  // Encode the GPU Context ID into the cache key because different contexts
+  // should cache different kernels.
+  auto *gpu_executor = static_cast<stream_executor::gpu::GpuExecutor *>(
+      op_kernel_ctx->op_device_context()->stream()->parent()->implementation());
+  int ctx_id = gpu_executor->gpu_context()->id();
+#else
+  int ctx_id = 0;
+#endif
+  OP_REQUIRES_OK(
+      op_kernel_ctx,
+      rm->LookupOrCreate<GPURuntimeCache>(
+          rm->default_container(),
+          absl::StrCat(GPURuntimeCache::kDefaultResourceName, ctx_id), &cache,
+          GPURuntimeCache::Create));
   assert(cache != nullptr && "cache creation must not fail");
   tensorflow::core::ScopedUnref ref(cache);
 


### PR DESCRIPTION
This PR works as a part of the whole Multi-Stream feature in TF, which is proposed in #61185.

Enable context-level cache because the kernels cannot be shared between CUDA contexts.

@changhuilin