### PR TITLE
Multi-Stream: device ordinal

### DIFF
--- a/tensorflow/compiler/xla/service/platform_util.h
+++ b/tensorflow/compiler/xla/service/platform_util.h
@@ -62,7 +62,8 @@ class PlatformUtil {
   // If the platform has no visible devices, a not-found error is returned.
   static StatusOr<std::vector<se::StreamExecutor*>> GetStreamExecutors(
       se::Platform* platform,
-      const std::optional<std::set<int>>& allowed_devices = std::nullopt);
+      const std::optional<std::set<int>>& allowed_devices = std::nullopt,
+      const int stream_id = 0);
 
  private:
   PlatformUtil(const PlatformUtil&) = delete;

--- a/tensorflow/compiler/xla/stream_executor/cuda/BUILD
+++ b/tensorflow/compiler/xla/stream_executor/cuda/BUILD
@@ -110,6 +110,7 @@ cc_library(
         "@local_config_cuda//cuda:cuda_headers",
         "//tensorflow/compiler/xla/stream_executor:stream_executor_headers",
         "//tensorflow/compiler/xla/stream_executor:device_options",
+        "//tensorflow/compiler/xla/stream_executor:platform",
         "//tensorflow/compiler/xla/stream_executor/gpu:gpu_driver_header",
         "//tensorflow/compiler/xla/stream_executor/platform",
         "//tensorflow/compiler/xla/stream_executor/platform:dso_loader",

--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_driver.cc
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_driver.cc
@@ -37,6 +37,7 @@ limitations under the License.
 #include "third_party/gpus/cuda/include/cuda_runtime_api.h"
 #include "third_party/gpus/cuda/include/driver_types.h"
 #include "tensorflow/compiler/xla/stream_executor/cuda/cuda_diagnostics.h"
+#include "tensorflow/compiler/xla/stream_executor/platform.h"
 #include "tensorflow/compiler/xla/stream_executor/platform/logging.h"
 #include "tensorflow/compiler/xla/stream_executor/platform/port.h"
 #include "tensorflow/tsl/platform/env.h"
@@ -286,8 +287,10 @@ static tsl::Status InternalInit() {
 
 /* static */ tsl::Status GpuDriver::GetDevice(int device_ordinal,
                                               CUdevice* device) {
-  RETURN_IF_CUDA_RES_ERROR(cuDeviceGet(device, device_ordinal),
-                           "Failed call to cuDeviceGet");
+  RETURN_IF_CUDA_RES_ERROR(
+      cuDeviceGet(device,
+                  DeviceOrdinalHelper::DecodeDeviceFromOrdinal(device_ordinal)),
+      "Failed call to cuDeviceGet");
   return ::tsl::OkStatus();
 }
 
@@ -1548,7 +1551,9 @@ tsl::StatusOr<int64_t> GpuDriver::GetMaxSharedMemoryPerBlockOptin(
 
 /* static */ bool GpuDriver::GetDeviceProperties(CUdevprop* device_properties,
                                                  int device_ordinal) {
-  CUresult res = cuDeviceGetProperties(device_properties, device_ordinal);
+  CUresult res = cuDeviceGetProperties(
+      device_properties,
+      DeviceOrdinalHelper::DecodeDeviceFromOrdinal(device_ordinal));
   if (res != CUDA_SUCCESS) {
     LOG(ERROR) << "failed to query device properties: " << ToString(res);
     return false;

--- a/tensorflow/compiler/xla/stream_executor/device_id_utils.h
+++ b/tensorflow/compiler/xla/stream_executor/device_id_utils.h
@@ -29,16 +29,20 @@ namespace stream_executor {
 class DeviceIdUtil {
  public:
   static tsl::StatusOr<StreamExecutor*> ExecutorForPlatformDeviceId(
-      Platform* device_manager, tsl::PlatformDeviceId platform_device_id) {
-    return device_manager->ExecutorForDevice(platform_device_id.value());
+      Platform* device_manager, tsl::PlatformDeviceId platform_device_id,
+      int stream_id = 0) {
+    int device_ordinal = DeviceOrdinalHelper::EncodeDeviceOrdinal(
+        stream_id, platform_device_id.value());
+    return device_manager->ExecutorForDevice(device_ordinal);
   }
   static tsl::StatusOr<StreamExecutor*> ExecutorForTfDeviceId(
       const tsl::DeviceType& type, Platform* device_manager,
-      tsl::TfDeviceId tf_device_id) {
+      tsl::TfDeviceId tf_device_id, int stream_id = 0) {
     tsl::PlatformDeviceId platform_device_id;
     TF_RETURN_IF_ERROR(tsl::DeviceIdManager::TfToPlatformDeviceId(
         type, tf_device_id, &platform_device_id));
-    return ExecutorForPlatformDeviceId(device_manager, platform_device_id);
+    return ExecutorForPlatformDeviceId(device_manager, platform_device_id,
+                                       stream_id);
   }
 };
 

--- a/tensorflow/compiler/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.cc
+++ b/tensorflow/compiler/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.cc
@@ -111,7 +111,7 @@ std::atomic<int> GpuCudaMallocAsyncAllocator::number_instantiated_(0);
 
 GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
     tsl::PlatformDeviceId platform_device_id, size_t pool_size,
-    bool reserve_memory, bool compute_stats)
+    bool reserve_memory, bool compute_stats, int stream_id)
     : name_(absl::StrCat("gpu_async_", platform_device_id.value())),
       reserve_memory_(reserve_memory) {
   ++number_instantiated_;
@@ -122,7 +122,7 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
 
 #if TF_CUDA_MALLOC_ASYNC_SUPPORTED
   stream_exec_ = DeviceIdUtil::ExecutorForPlatformDeviceId(
-                     GPUMachineManager(), platform_device_id)
+                     GPUMachineManager(), platform_device_id, stream_id)
                      .value();
   // Initialized here as it only exist if compiled with a recent
   // enough CUDA.

--- a/tensorflow/compiler/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
+++ b/tensorflow/compiler/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.h
@@ -69,7 +69,8 @@ class GpuCudaMallocAsyncAllocator : public tsl::Allocator {
   explicit GpuCudaMallocAsyncAllocator(tsl::PlatformDeviceId platform_device_id,
                                        size_t pool_size,
                                        bool reserve_memory = false,
-                                       bool compute_stats = true);
+                                       bool compute_stats = true,
+                                       int stream_id = 0);
   ~GpuCudaMallocAsyncAllocator() override;
   std::string Name() override { return name_; }
   void* AllocateRaw(size_t alignment,

--- a/tensorflow/compiler/xla/stream_executor/platform.h
+++ b/tensorflow/compiler/xla/stream_executor/platform.h
@@ -100,6 +100,34 @@ struct StreamExecutorConfig {
   DeviceOptions device_options;
 };
 
+// Help to encode and decode the device_ordinal variable in stream_executor.
+class DeviceOrdinalHelper {
+ public:
+  // Encode the stream and device information to the integer device_ordinal,
+  // where the high half part is the stream index, and the low half part is
+  // the device index.
+  static int EncodeDeviceOrdinal(int stream_part, int device_part) {
+    return ((stream_part & low_mask_) << (4 * sizeof(int))) |
+           (device_part & low_mask_);
+  }
+
+  // Decode the stream information from the device_ordinal.
+  static int DecodeStreamFromOrdinal(int device_ordinal) {
+    return (device_ordinal & high_mask_) >> (4 * sizeof(int));
+  }
+
+  // Decode the device information from the device_ordinal.
+  static int DecodeDeviceFromOrdinal(int device_ordinal) {
+    return device_ordinal & low_mask_;
+  }
+
+ private:
+  static const int low_mask_ =
+      (1 << (4 * sizeof(int))) - 1;  // for int32, low_mask_ = 0x0000FFFFL;
+  static const int high_mask_ =
+      ~((1 << (4 * sizeof(int))) - 1);  // for int32, high_mask_ = 0xFFFF0000L;
+};
+
 // Abstract base class for a platform registered with the MultiPlatformManager.
 class Platform {
  public:

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.cc
@@ -28,9 +28,9 @@ limitations under the License.
 namespace tensorflow {
 
 GPUcudaMallocAllocator::GPUcudaMallocAllocator(
-    tsl::PlatformDeviceId platform_device_id) {
+    tsl::PlatformDeviceId platform_device_id, int stream_id) {
   stream_exec_ = se::DeviceIdUtil::ExecutorForPlatformDeviceId(
-                     se::GPUMachineManager(), platform_device_id)
+                     se::GPUMachineManager(), platform_device_id, stream_id)
                      .value();
 }
 

--- a/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_cudamalloc_allocator.h
@@ -30,7 +30,8 @@ namespace tensorflow {
 // free memory.
 class GPUcudaMallocAllocator : public tsl::Allocator {
  public:
-  explicit GPUcudaMallocAllocator(tsl::PlatformDeviceId platform_device_id);
+  explicit GPUcudaMallocAllocator(tsl::PlatformDeviceId platform_device_id,
+                                  int stream_id = 0);
   std::string Name() override { return "gpu_debug"; }
   void* AllocateRaw(size_t alignment, size_t num_bytes) override;
   void DeallocateRaw(void* ptr) override;

--- a/tensorflow/core/common_runtime/gpu/gpu_debug_allocator.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_debug_allocator.cc
@@ -80,10 +80,11 @@ void InitMask(se::StreamExecutor* exec, void* ptr, int64_t* mask) {
 // GPUDebugAllocator
 // -----------------------------------------------------------------------------
 GPUDebugAllocator::GPUDebugAllocator(Allocator* allocator,
-                                     tsl::PlatformDeviceId platform_device_id)
+                                     tsl::PlatformDeviceId platform_device_id,
+                                     int stream_id)
     : base_allocator_(allocator) {
   stream_exec_ = se::DeviceIdUtil::ExecutorForPlatformDeviceId(
-                     se::GPUMachineManager(), platform_device_id)
+                     se::GPUMachineManager(), platform_device_id, stream_id)
                      .value();
 }
 
@@ -159,10 +160,11 @@ bool GPUDebugAllocator::CheckFooter(void* ptr) {
 // GPUNanResetAllocator
 // -----------------------------------------------------------------------------
 GPUNanResetAllocator::GPUNanResetAllocator(
-    Allocator* allocator, tsl::PlatformDeviceId platform_device_id)
+    Allocator* allocator, tsl::PlatformDeviceId platform_device_id,
+    int stream_id)
     : base_allocator_(allocator) {
   stream_exec_ = se::DeviceIdUtil::ExecutorForPlatformDeviceId(
-                     se::GPUMachineManager(), platform_device_id)
+                     se::GPUMachineManager(), platform_device_id, stream_id)
                      .value();
 }
 

--- a/tensorflow/core/common_runtime/gpu/gpu_debug_allocator.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_debug_allocator.h
@@ -34,7 +34,8 @@ namespace tensorflow {
 class GPUDebugAllocator : public tsl::Allocator {
  public:
   explicit GPUDebugAllocator(tsl::Allocator* allocator,
-                             tsl::PlatformDeviceId platform_device_id);
+                             tsl::PlatformDeviceId platform_device_id,
+                             int stream_id = 0);
   ~GPUDebugAllocator() override;
   std::string Name() override { return "gpu_debug"; }
   void* AllocateRaw(size_t alignment, size_t num_bytes) override;
@@ -64,7 +65,8 @@ class GPUDebugAllocator : public tsl::Allocator {
 class GPUNanResetAllocator : public tsl::Allocator {
  public:
   explicit GPUNanResetAllocator(tsl::Allocator* allocator,
-                                tsl::PlatformDeviceId platform_device_id);
+                                tsl::PlatformDeviceId platform_device_id,
+                                int stream_id = 0);
   ~GPUNanResetAllocator() override;
   std::string Name() override { return "gpu_nan_reset"; }
   void* AllocateRaw(size_t alignment, size_t num_bytes) override;


### PR DESCRIPTION
This PR works as a part of the whole Multi-Stream feature in TF, which is proposed in #61185.

Implement DeviceOrdinalHelper to encode/decode stream and device information into/from the ordinal variable, and use it to create multiple allocators when necessary.

@changhuilin