### PR TITLE
Multi-Stream: stream related options

### DIFF
--- a/tensorflow/compiler/jit/get_compiler_ir.cc
+++ b/tensorflow/compiler/jit/get_compiler_ir.cc
@@ -291,8 +291,12 @@ StatusOr<std::string> GetCompilerIr(
   XlaPlatformInfo platform_info = XlaPlatformInfoFromDevice(dev);
 
   XlaDeviceCompiler* xla_device_compiler;
+  int stream_id = dev->GetStreamId();
+  std::string name = stream_id > 0
+                         ? strings::StrCat("xla_device_compiler_", stream_id)
+                         : "xla_device_compiler";
   TF_RETURN_IF_ERROR(rmgr->LookupOrCreate<XlaDeviceCompiler>(
-      rmgr->default_container(), "xla_device_compiler", &xla_device_compiler,
+      rmgr->default_container(), name, &xla_device_compiler,
       [&](XlaDeviceCompiler** xla_device_compiler) {
         return BuildXlaDeviceCompiler(dev, flr, platform_info,
                                       xla_device_compiler);

--- a/tensorflow/compiler/jit/kernels/xla_ops.cc
+++ b/tensorflow/compiler/jit/kernels/xla_ops.cc
@@ -402,9 +402,11 @@ Status CompileToLocalExecutable(
   // compiler?)
   XlaDeviceCompiler* xla_device_compiler;
   int stream_id = ctx->device()->GetStreamId();
+  std::string name = stream_id > 0
+                         ? strings::StrCat("xla_device_compiler_", stream_id)
+                         : "xla_device_compiler";
   TF_RETURN_IF_ERROR(rm->LookupOrCreate<XlaDeviceCompiler>(
-      rm->default_container(),
-      strings::StrCat("xla_device_compiler_", stream_id), &xla_device_compiler,
+      rm->default_container(), name, &xla_device_compiler,
       [&](XlaDeviceCompiler** xla_device_compiler) {
         return BuildXlaDeviceCompiler(ctx->device(), ctx->function_library(),
                                       platform_info, xla_device_compiler);

--- a/tensorflow/compiler/jit/kernels/xla_ops.cc
+++ b/tensorflow/compiler/jit/kernels/xla_ops.cc
@@ -397,9 +397,14 @@ Status CompileToLocalExecutable(
     return absl::InternalError("No resource manager.");
   }
 
+  // Create multiple compilers for multiple stream groups, thus multiple clients
+  // and multiple backends. (Is this necessary? Can the clients share the same
+  // compiler?)
   XlaDeviceCompiler* xla_device_compiler;
+  int stream_id = ctx->device()->GetStreamId();
   TF_RETURN_IF_ERROR(rm->LookupOrCreate<XlaDeviceCompiler>(
-      rm->default_container(), "xla_device_compiler", &xla_device_compiler,
+      rm->default_container(),
+      strings::StrCat("xla_device_compiler_", stream_id), &xla_device_compiler,
       [&](XlaDeviceCompiler** xla_device_compiler) {
         return BuildXlaDeviceCompiler(ctx->device(), ctx->function_library(),
                                       platform_info, xla_device_compiler);

--- a/tensorflow/compiler/jit/xla_compile_on_demand_op.cc
+++ b/tensorflow/compiler/jit/xla_compile_on_demand_op.cc
@@ -198,8 +198,12 @@ Status XlaCompileOnDemandOp::Compile(
   ResourceMgr* rm = ctx->resource_manager();
   CHECK(rm);
 
+  int stream_id = ctx->device()->GetStreamId();
+  std::string name = stream_id > 0
+                         ? strings::StrCat("xla_device_compiler_", stream_id)
+                         : "xla_device_compiler";
   TF_RETURN_IF_ERROR(rm->LookupOrCreate<XlaDeviceCompiler>(
-      rm->default_container(), "xla_device_compiler", xla_device_compiler,
+      rm->default_container(), name, xla_device_compiler,
       [&](XlaDeviceCompiler** xla_device_compiler) {
         return BuildXlaDeviceCompiler(ctx->device(), ctx->function_library(),
                                       platform_info_, xla_device_compiler);

--- a/tensorflow/compiler/jit/xla_platform_info.cc
+++ b/tensorflow/compiler/jit/xla_platform_info.cc
@@ -219,6 +219,7 @@ Status BuildXlaDeviceCompiler(DeviceBase* device, FunctionLibraryRuntime* flr,
 
   TF_ASSIGN_OR_RETURN(auto allowed_gpus, GetAllowedGpus(flr));
   client_options.set_allowed_devices(allowed_gpus);
+  client_options.set_gpu_stream_group_index(device->GetStreamId());
 
   auto client = xla::ClientLibrary::GetOrCreateLocalClient(client_options);
   if (!client.ok()) {

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -1088,9 +1088,11 @@ Status TRTEngineOp::GetEngineCacheResource(OpKernelContext* ctx,
   // Get engine cache. Each stream group should have its own cache to avoid
   // sharing the same engine_context.
   int stream_id = ctx->device()->GetStreamId();
+  std::string name = stream_id > 0 ? strings::StrCat(std::string(resource_name),
+                                                     "_", stream_id)
+                                   : std::string(resource_name);
   return ctx->resource_manager()->LookupOrCreate(
-      std::string(kTfTrtContainerName),
-      strings::StrCat(std::string(resource_name), "_", stream_id), cache_res,
+      std::string(kTfTrtContainerName), name, cache_res,
       {[this, ctx](TRTEngineCacheResource** cr) -> Status {
         *cr = new TRTEngineCacheResource(ctx, this->max_cached_engines_);
         return OkStatus();

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_op.cc
@@ -1085,9 +1085,12 @@ Status TRTEngineOp::GetEngineCacheResource(OpKernelContext* ctx,
     resource_name.remove_prefix(last_slash + 1);
   }
 
-  // Get engine cache.
+  // Get engine cache. Each stream group should have its own cache to avoid
+  // sharing the same engine_context.
+  int stream_id = ctx->device()->GetStreamId();
   return ctx->resource_manager()->LookupOrCreate(
-      std::string(kTfTrtContainerName), std::string(resource_name), cache_res,
+      std::string(kTfTrtContainerName),
+      strings::StrCat(std::string(resource_name), "_", stream_id), cache_res,
       {[this, ctx](TRTEngineCacheResource** cr) -> Status {
         *cr = new TRTEngineCacheResource(ctx, this->max_cached_engines_);
         return OkStatus();

--- a/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
+++ b/tensorflow/compiler/tf2tensorrt/kernels/trt_engine_resource_ops.cc
@@ -97,6 +97,10 @@ class InitializeTRTResource : public OpKernel {
         tensorflow::profiler::TraceMeLevel::kInfo);
     ResourceHandle handle = HandleFromInput(ctx, 0);
     core::RefCountPtr<TRTEngineCacheResource> resource;
+    int stream_id = ctx->device()->GetStreamId();
+    if (stream_id > 0) {
+      handle.set_name(strings::StrCat(handle.name(), "_", stream_id));
+    }
     OP_REQUIRES_OK(
         ctx, LookupOrCreateResource<TRTEngineCacheResource>(
                  ctx, handle, &resource,

--- a/tensorflow/compiler/xla/client/client_library.h
+++ b/tensorflow/compiler/xla/client/client_library.h
@@ -46,7 +46,8 @@ class LocalClientOptions {
   LocalClientOptions(
       se::Platform* platform = nullptr, int number_of_replicas = 1,
       int intra_op_parallelism_threads = -1,
-      const std::optional<std::set<int>>& allowed_devices = std::nullopt);
+      const std::optional<std::set<int>>& allowed_devices = std::nullopt,
+      int gpu_stream_group_index = 0);
 
   // Set the platform backing the service, or nullptr for the default platform.
   LocalClientOptions& set_platform(se::Platform* platform);
@@ -67,10 +68,15 @@ class LocalClientOptions {
       const std::optional<std::set<int>>& allowed_devices);
   const std::optional<std::set<int>>& allowed_devices() const;
 
+  // Sets the stream group index for the given GPU device.
+  LocalClientOptions& set_gpu_stream_group_index(int stream_group_index);
+  int gpu_stream_group_index() const;
+
  private:
   se::Platform* platform_;
   int number_of_replicas_;
   int intra_op_parallelism_threads_;
+  int gpu_stream_group_index_;
   std::optional<std::set<int>> allowed_devices_;
 };
 

--- a/tensorflow/compiler/xla/service/backend.cc
+++ b/tensorflow/compiler/xla/service/backend.cc
@@ -55,6 +55,16 @@ int BackendOptions::intra_op_parallelism_threads() const {
   return intra_op_parallelism_threads_;
 }
 
+BackendOptions& BackendOptions::set_gpu_stream_group_index(
+    int stream_group_index) {
+  gpu_stream_group_index_ = stream_group_index;
+  return *this;
+}
+
+int BackendOptions::gpu_stream_group_index() const {
+  return gpu_stream_group_index_;
+}
+
 BackendOptions& BackendOptions::set_allowed_devices(
     const std::optional<std::set<int>>& allowed_devices) {
   allowed_devices_ = allowed_devices;

--- a/tensorflow/compiler/xla/service/backend.h
+++ b/tensorflow/compiler/xla/service/backend.h
@@ -53,6 +53,12 @@ class BackendOptions {
   BackendOptions& set_intra_op_parallelism_threads(int num_threads);
   int intra_op_parallelism_threads() const;
 
+  // Sets the stream group index for the given GPU device. This is useful for
+  // getting the corresponding StreamExecutor because every stream group has
+  // its own StreamExecutor.
+  BackendOptions& set_gpu_stream_group_index(int stream_group_inde);
+  int gpu_stream_group_index() const;
+
   // Sets the allowed_devices for selectively constructing stream executors
   // on the platform.
   BackendOptions& set_allowed_devices(
@@ -63,6 +69,7 @@ class BackendOptions {
   se::Platform* platform_ = nullptr;
   int intra_op_parallelism_threads_ = -1;
   std::optional<std::set<int>> allowed_devices_;
+  int gpu_stream_group_index_ = 0;
 };
 
 // Class which encapsulates an XLA backend. It includes everything necessary

--- a/tensorflow/compiler/xla/service/local_service.cc
+++ b/tensorflow/compiler/xla/service/local_service.cc
@@ -54,7 +54,8 @@ namespace xla {
   BackendOptions backend_options;
   backend_options.set_platform(platform)
       .set_intra_op_parallelism_threads(options.intra_op_parallelism_threads())
-      .set_allowed_devices(options.allowed_devices());
+      .set_allowed_devices(options.allowed_devices())
+      .set_gpu_stream_group_index(options.gpu_stream_group_index());
 
   TF_ASSIGN_OR_RETURN(std::unique_ptr<Backend> backend,
                       Backend::CreateBackend(backend_options));

--- a/tensorflow/compiler/xla/service/service.cc
+++ b/tensorflow/compiler/xla/service/service.cc
@@ -120,6 +120,16 @@ int ServiceOptions::intra_op_parallelism_threads() const {
   return intra_op_parallelism_threads_;
 }
 
+ServiceOptions& ServiceOptions::set_gpu_stream_group_index(
+    int stream_group_index) {
+  gpu_stream_group_index_ = stream_group_index;
+  return *this;
+}
+
+int ServiceOptions::gpu_stream_group_index() const {
+  return gpu_stream_group_index_;
+}
+
 ServiceOptions& ServiceOptions::set_allowed_devices(
     const std::optional<std::set<int>>& allowed_devices) {
   allowed_devices_ = allowed_devices;

--- a/tensorflow/compiler/xla/service/service.h
+++ b/tensorflow/compiler/xla/service/service.h
@@ -67,11 +67,16 @@ class ServiceOptions {
       const std::optional<std::set<int>>& allowed_devices);
   const std::optional<std::set<int>>& allowed_devices() const;
 
+  // Sets the stream group index for the given GPU device.
+  ServiceOptions& set_gpu_stream_group_index(int stream_group_index);
+  int gpu_stream_group_index() const;
+
  private:
   se::Platform* platform_ = nullptr;
   int number_of_replicas_ = 1;
   int intra_op_parallelism_threads_ = -1;
   std::optional<std::set<int>> allowed_devices_;
+  int gpu_stream_group_index_ = 0;
 };
 
 // The XLA service object, which is the same across all platforms. It maintains

--- a/tensorflow/core/common_runtime/gpu/gpu_device.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.cc
@@ -515,7 +515,7 @@ Status BaseGPUDevice::Init(const SessionOptions& options) {
 
   std::pair<StreamGroup*, bool> emplace_result =
       StreamGroupFactory::Global().Emplace(
-          tf_device_id_, /*stream_group_within_gpu=*/0, stream_group);
+          tf_device_id_, /*stream_group_within_gpu=*/stream_id_, stream_group);
   if (!emplace_result.second) {
     LOG(WARNING) << "StreamGroup for tf_device_id: " << tf_device_id_.value()
                  << " already exists. This usually only happens in unit tests.";
@@ -523,7 +523,7 @@ Status BaseGPUDevice::Init(const SessionOptions& options) {
   stream_ = emplace_result.first;
 #else
   stream_ = StreamGroupFactory::Global().GetOrCreate(
-      tf_device_id_, 0, executor_, options.config.gpu_options());
+      tf_device_id_, stream_id_, executor_, options.config.gpu_options());
 #endif  // TF_GPU_USE_PJRT
 
   // Get an allocator that allocates pinned memory on host.
@@ -533,7 +533,7 @@ Status BaseGPUDevice::Init(const SessionOptions& options) {
   Allocator* host_memory_allocator = GetAllocator(attr);
 
   device_context_ =
-      new GPUDeviceContext(0, stream_->compute,
+      new GPUDeviceContext(stream_id_, stream_->compute,
 #if TENSORFLOW_USE_ROCM
                            stream_->nccl,
 #endif

--- a/tensorflow/core/common_runtime/gpu/gpu_device.h
+++ b/tensorflow/core/common_runtime/gpu/gpu_device.h
@@ -373,7 +373,7 @@ class GPUKernelTracker {
 
 class BaseGPUDeviceFactory : public DeviceFactory {
  public:
-  Status ListPhysicalDevices(std::vector<string>* devices) override;
+  virtual Status ListPhysicalDevices(std::vector<string>* devices) override;
   Status CreateDevices(const SessionOptions& options,
                        const std::string& name_prefix,
                        std::vector<std::unique_ptr<Device>>* devices) override;

--- a/tensorflow/core/common_runtime/gpu/gpu_device_factory.cc
+++ b/tensorflow/core/common_runtime/gpu/gpu_device_factory.cc
@@ -61,6 +61,32 @@ class GPUDevice : public BaseGPUDevice {
   bool force_gpu_compatible_ = false;
 };
 
+//-------------------------------------------------------------------------------
+// A StreamDevice that manages multiple stream groups in GPU. TF will create as
+// many StreamDevice objects as there are stream groups. The objects will be
+// created only when there are more than one stream groups.
+// ------------------------------------------------------------------------------
+class StreamDevice : public GPUDevice {
+ public:
+  StreamDevice(const SessionOptions& options, const string& name,
+               Bytes memory_limit, const DeviceLocality& locality,
+               tsl::TfDeviceId tf_device_id, const string& physical_device_desc,
+               Allocator* gpu_allocator, Allocator* cpu_allocator)
+      : GPUDevice(options, name, memory_limit, locality, tf_device_id,
+                  physical_device_desc, gpu_allocator, cpu_allocator) {}
+
+  void SetRealDevice(Device* device) override { real_device_ = device; }
+
+  const Device* GetRealDevice() const override { return real_device_; }
+
+  ResourceMgr* resource_manager() override {
+    return real_device_->resource_manager();
+  }
+
+ private:
+  Device* real_device_;
+};
+
 class GPUDeviceFactory : public BaseGPUDeviceFactory {
  private:
   std::unique_ptr<BaseGPUDevice> CreateGPUDevice(
@@ -75,6 +101,29 @@ class GPUDeviceFactory : public BaseGPUDeviceFactory {
 };
 
 REGISTER_LOCAL_DEVICE_FACTORY("GPU", GPUDeviceFactory, 210);
+
+class StreamDeviceFactory : public BaseGPUDeviceFactory {
+ public:
+  StreamDeviceFactory() { is_stream_factory_ = true; }
+
+  Status ListPhysicalDevices(std::vector<string>* devices) override {
+    // We don't know how many Stream Devices to create until we specify it
+    // explicitly through the SessionConfig. Even if we did, a Stream Device
+    // is not considered "physical". Therefore, we do nothing here.
+    return OkStatus();
+  }
+
+ private:
+  std::unique_ptr<BaseGPUDevice> CreateGPUDevice(
+      const SessionOptions& options, const string& name, Bytes memory_limit,
+      const DeviceLocality& locality, tsl::TfDeviceId tf_device_id,
+      const string& physical_device_desc, Allocator* gpu_allocator,
+      Allocator* cpu_allocator) override {
+    return absl::make_unique<StreamDevice>(
+        options, name, memory_limit, locality, tf_device_id,
+        physical_device_desc, gpu_allocator, cpu_allocator);
+  }
+};
 
 //------------------------------------------------------------------------------
 // A CPUDevice that optimizes for interaction with GPUs in the
@@ -111,10 +160,37 @@ class GPUCompatibleCPUDevice : public ThreadPoolDevice {
   GPUOptions gpu_options_;
 };
 
+//------------------------------------------------------------------------------
+// A StreamCPUDevice that manages GPU host memory allocation when multiple
+// stream groups in GPU is enabled. TF will create as many StreamCPUDevice
+// objects as there are stream groups. The objects will be created only when
+// there are more than one stream groups and host_allocator_mode is "private".
+// -----------------------------------------------------------------------------
+class StreamCompatibleCPUDevice : public GPUCompatibleCPUDevice {
+ public:
+  StreamCompatibleCPUDevice(const SessionOptions& options, const string& name,
+                            Bytes memory_limit, const DeviceLocality& locality,
+                            Allocator* allocator)
+      : GPUCompatibleCPUDevice(options, name, memory_limit, locality,
+                               allocator) {}
+  ~StreamCompatibleCPUDevice() override {}
+
+  void SetRealDevice(Device* device) override { real_device_ = device; }
+
+  const Device* GetRealDevice() const override { return real_device_; }
+
+  ResourceMgr* resource_manager() override {
+    return real_device_->resource_manager();
+  }
+
+ private:
+  Device* real_device_;
+};
+
 // The associated factory.
 class GPUCompatibleCPUDeviceFactory : public DeviceFactory {
  public:
-  Status ListPhysicalDevices(std::vector<string>* devices) override {
+  virtual Status ListPhysicalDevices(std::vector<string>* devices) override {
     devices->push_back("/physical_device:CPU:0");
 
     return OkStatus();
@@ -145,6 +221,17 @@ class GPUCompatibleCPUDeviceFactory : public DeviceFactory {
 };
 REGISTER_LOCAL_DEVICE_FACTORY("CPU", GPUCompatibleCPUDeviceFactory, 70);
 
+class StreamCompatibleCPUDeviceFactory : public GPUCompatibleCPUDeviceFactory {
+ public:
+  StreamCompatibleCPUDeviceFactory() { is_stream_factory_ = true; }
+
+  Status ListPhysicalDevices(std::vector<string>* devices) override {
+    // We don't know how many StreamCPU Devices to create until we specify it
+    // explicitly through the SessionConfig. Even if we did, a Stream Device is
+    // not considered "physical". Therefore, we do nothing here.
+    return OkStatus();
+  }
+};
 }  // namespace tensorflow
 
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/framework/device.h
+++ b/tensorflow/core/framework/device.h
@@ -193,6 +193,15 @@ class Device : public DeviceBase {
   // Informs if this Device can be used as a caller in RemoteCall operation.
   virtual bool IsRemoteCallAllowed() const;
 
+  // Sets the real device of a stream device.
+  virtual void SetRealDevice(Device* device) {
+    LOG(FATAL) << "Device does not implement SetRealDevice()";
+  }
+
+  // Gets the real device of a stream device, or itself if it's not a stream
+  // device.
+  virtual const Device* GetRealDevice() const { return this; }
+
  protected:
   void DeleteResourceMgr() {
     delete rmgr_;

--- a/tensorflow/core/framework/device.h
+++ b/tensorflow/core/framework/device.h
@@ -202,6 +202,18 @@ class Device : public DeviceBase {
   // device.
   virtual const Device* GetRealDevice() const { return this; }
 
+  // Whether to merge the DtoD copy streams with the compute stream. Only useful
+  // for GPU.
+  virtual bool merge_DtoD_copy_stream() const { return false; }
+
+  // Whether to merge the DtoH copy stream with the compute stream. Only useful
+  // for GPU.
+  virtual bool merge_DtoH_copy_stream() const { return false; }
+
+  // Whether to merge the HtoD copy stream with the compute stream. Only useful
+  // for GPU.
+  virtual bool merge_HtoD_copy_stream() const { return false; }
+
  protected:
   void DeleteResourceMgr() {
     delete rmgr_;

--- a/tensorflow/core/framework/device_base.h
+++ b/tensorflow/core/framework/device_base.h
@@ -123,6 +123,10 @@ class DeviceContext : public core::RefCounted {
 
   // Returns the pinned host memory allocator for the device.
   virtual Allocator* host_memory_allocator() const { return nullptr; }
+
+  // Returns the stream group index of the stream device, or 0 if it's not a
+  // stream device.
+  virtual int stream_id() const { return 0; }
 };
 
 class DeviceBase {
@@ -282,11 +286,20 @@ class DeviceBase {
                           "CopyTensorInSameDevice"));
   }
 
+  // Sets the stream index of a stream device.
+  void SetStreamId(int stream_id) { stream_id_ = stream_id; }
+
+  // Gets the stream index of a stream device.
+  int GetStreamId() { return stream_id_; }
+
  protected:
   // Does not take ownership.
   void set_tensorflow_device_thread_pool(tsl::thread::ThreadPool* thread_pool) {
     device_thread_pool_ = thread_pool;
   }
+
+  // Stream index of a stream device.
+  int stream_id_ = 0;
 
  private:
   tsl::Env* const env_;

--- a/tensorflow/core/framework/device_factory.h
+++ b/tensorflow/core/framework/device_factory.h
@@ -110,6 +110,11 @@ class DeviceFactory {
   // Returns true if 'device_type' is registered from plugin. Returns false if
   // 'device_type' is a first-party device.
   static bool IsPluggableDevice(const std::string& device_type);
+
+ protected:
+  // Returns true if the factory is a StreamDeviceFactory or a
+  // StreamCompatibleCPUDeviceFactory.
+  bool is_stream_factory_ = false;
 };
 
 namespace dfactory {


### PR DESCRIPTION
This PR works as a part of the whole Multi-Stream feature in TF, which is proposed in #61185.

Add StreamDevices and related factories. Add stream-related APIs and arguments. Cache the XLA compiler at the stream level.

@changhuilin