### PR TITLE
Fixed a typo error in subgraph.cc (First Pull Request)

### DIFF
--- a/tensorflow/lite/core/subgraph.cc
+++ b/tensorflow/lite/core/subgraph.cc
@@ -474,7 +474,7 @@ void PopulatePreviewDelegateParams(const NodeSubset& node_subset,
 // being null, that contains the actual logic that the registration represents.
 // See also the comment inside
 // 'TfLiteOpaqueContextReplaceNodeSubsetsWithDelegateKernels'.
-const char* GetDelegateKernalName(const TfLiteRegistration& registration) {
+const char* GetDelegateKernelName(const TfLiteRegistration& registration) {
   if (registration.custom_name) {
     return registration.custom_name;
   }


### PR DESCRIPTION
Fixed a typo error. Changed the spelling from "GetDelegateKernalName" to "GetDelegateKernelName"