### PR TITLE
[NextPluggabledevice] Enable XLA auto clustering mode for NextPluggableDevice

### DIFF
--- a/tensorflow/compiler/jit/kernels/xla_ops.cc
+++ b/tensorflow/compiler/jit/kernels/xla_ops.cc
@@ -1042,11 +1042,22 @@ REGISTER_KERNEL_BUILDER(Name("_XlaCompile")
                             .HostMemory("resources"),
                         XlaCompileOp);
 
+REGISTER_KERNEL_BUILDER(Name("_XlaCompile")
+                            .Device(DEVICE_DEFAULT)
+                            .HostMemory("constants")
+                            .HostMemory("key")
+                            .HostMemory("compilation_successful")
+                            .HostMemory("resources"),
+                        XlaCompileOp);
+
 REGISTER_KERNEL_BUILDER(Name("_XlaRun").Device(DEVICE_CPU), XlaRunOp);
 REGISTER_KERNEL_BUILDER(Name("_XlaRun").Device(DEVICE_GPU).HostMemory("key"),
                         XlaRunOp);
+REGISTER_KERNEL_BUILDER(
+    Name("_XlaRun").Device(DEVICE_DEFAULT).HostMemory("key"), XlaRunOp);
 
 REGISTER_KERNEL_BUILDER(Name("_XlaMerge").Device(DEVICE_CPU), XlaMergeOp);
 REGISTER_KERNEL_BUILDER(Name("_XlaMerge").Device(DEVICE_GPU), XlaMergeOp);
+REGISTER_KERNEL_BUILDER(Name("_XlaMerge").Device(DEVICE_DEFAULT), XlaMergeOp);
 
 }  // namespace tensorflow

--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -607,6 +607,7 @@ cc_library(
         "//tensorflow/core:protos_all_cc",
         "//tensorflow/core:session_options",
         "//tensorflow/core/common_runtime:core_cpu_internal",
+        "//tensorflow/core/common_runtime/next_pluggable_device:next_pluggable_device_factory_hdrs",
         "//tensorflow/core/platform:stream_executor_no_cuda",
     ],
     alwayslink = 1,

--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -609,6 +609,7 @@ cc_library(
         "//tensorflow/core/common_runtime:core_cpu_internal",
         "//tensorflow/core/common_runtime/next_pluggable_device:next_pluggable_device_factory_hdrs",
         "//tensorflow/core/platform:stream_executor_no_cuda",
+        "//tensorflow/core/tfrt/common:create_pjrt_client_util",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/compiler/tf2xla/BUILD
+++ b/tensorflow/compiler/tf2xla/BUILD
@@ -609,7 +609,7 @@ cc_library(
         "//tensorflow/core/common_runtime:core_cpu_internal",
         "//tensorflow/core/common_runtime/next_pluggable_device:next_pluggable_device_factory_hdrs",
         "//tensorflow/core/platform:stream_executor_no_cuda",
-        "//tensorflow/core/tfrt/common:create_pjrt_client_util",
+        "//tensorflow/core/tfrt/common:pjrt_util",
     ],
     alwayslink = 1,
 )

--- a/tensorflow/compiler/tf2xla/xla_op_registry.cc
+++ b/tensorflow/compiler/tf2xla/xla_op_registry.cc
@@ -33,6 +33,7 @@ limitations under the License.
 #include "tensorflow/core/framework/op_def_util.h"
 #include "tensorflow/core/platform/mem.h"
 #include "tensorflow/core/platform/stream_executor_no_cuda.h"
+#include "tensorflow/core/tfrt/common/create_pjrt_client_util.h"
 
 namespace tensorflow {
 
@@ -177,10 +178,12 @@ XlaOpRegistry::~XlaOpRegistry() = default;
 
   // Register GPU JIT devices for NextPluggableDevice if its jit_device_type is
   // `XLA_GPU_JIT`.
-  if (DeviceFactory::IsPluggableDevice(device_name)) {
+  if (DeviceFactory::IsPluggableDevice(device_name) &&
+      GetOrCreatePjRtClient(DeviceType(device_name)).ok()) {
     mutex_lock lock(registry.mutex_);
+
     NextPluggableDeviceFactory* device_factory =
-        dynamic_cast<NextPluggableDeviceFactory*>(
+        static_cast<NextPluggableDeviceFactory*>(
             DeviceFactory::GetFactory(device_name));
     if (device_factory != nullptr &&
         DeviceType(device_factory->compilation_device_name()) ==

--- a/tensorflow/compiler/tf2xla/xla_op_registry.cc
+++ b/tensorflow/compiler/tf2xla/xla_op_registry.cc
@@ -177,16 +177,16 @@ XlaOpRegistry::~XlaOpRegistry() = default;
 
   // Register GPU JIT devices for NextPluggableDevice if its jit_device_type is
   // `XLA_GPU_JIT`.
-  if (DeviceFactory::IsPluggableDevice(device_name) &&
-      registry.compilation_devices_.find(device_name) ==
-          registry.compilation_devices_.end()) {
+  if (DeviceFactory::IsPluggableDevice(device_name)) {
     mutex_lock lock(registry.mutex_);
     NextPluggableDeviceFactory* device_factory =
         dynamic_cast<NextPluggableDeviceFactory*>(
             DeviceFactory::GetFactory(device_name));
     if (device_factory != nullptr &&
         DeviceType(device_factory->compilation_device_name()) ==
-            DeviceType(DEVICE_GPU_XLA_JIT)) {
+            DeviceType(DEVICE_GPU_XLA_JIT) &&
+        registry.compilation_devices_.find(device_name) ==
+            registry.compilation_devices_.end()) {
       DeviceRegistration& registration =
           registry.compilation_devices_[device_name];
       registration.compilation_device_name = DEVICE_GPU_XLA_JIT;

--- a/tensorflow/compiler/tf2xla/xla_op_registry.cc
+++ b/tensorflow/compiler/tf2xla/xla_op_registry.cc
@@ -177,13 +177,16 @@ XlaOpRegistry::~XlaOpRegistry() = default;
 
   // Register GPU JIT devices for NextPluggableDevice if its jit_device_type is
   // `XLA_GPU_JIT`.
-  if (DeviceFactory::IsPluggableDevice(device_name)) {
+  if (DeviceFactory::IsPluggableDevice(device_name) &&
+      registry.compilation_devices_.find(device_name) ==
+          registry.compilation_devices_.end()) {
     mutex_lock lock(registry.mutex_);
     NextPluggableDeviceFactory* device_factory =
         dynamic_cast<NextPluggableDeviceFactory*>(
             DeviceFactory::GetFactory(device_name));
     if (device_factory != nullptr &&
-        device_factory->jit_device_type() == DeviceType(DEVICE_GPU_XLA_JIT)) {
+        DeviceType(device_factory->compilation_device_name()) ==
+            DeviceType(DEVICE_GPU_XLA_JIT)) {
       DeviceRegistration& registration =
           registry.compilation_devices_[device_name];
       registration.compilation_device_name = DEVICE_GPU_XLA_JIT;

--- a/tensorflow/compiler/tf2xla/xla_op_registry.cc
+++ b/tensorflow/compiler/tf2xla/xla_op_registry.cc
@@ -33,7 +33,7 @@ limitations under the License.
 #include "tensorflow/core/framework/op_def_util.h"
 #include "tensorflow/core/platform/mem.h"
 #include "tensorflow/core/platform/stream_executor_no_cuda.h"
-#include "tensorflow/core/tfrt/common/create_pjrt_client_util.h"
+#include "tensorflow/core/tfrt/common/pjrt_util.h"
 
 namespace tensorflow {
 
@@ -179,7 +179,7 @@ XlaOpRegistry::~XlaOpRegistry() = default;
   // Register GPU JIT devices for NextPluggableDevice if its jit_device_type is
   // `XLA_GPU_JIT`.
   if (DeviceFactory::IsPluggableDevice(device_name) &&
-      GetOrCreatePjRtClient(DeviceType(device_name)).ok()) {
+      GetPjRtClient(DeviceType(device_name)).ok()) {
     mutex_lock lock(registry.mutex_);
 
     NextPluggableDeviceFactory* device_factory =

--- a/tensorflow/core/common_runtime/next_pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/next_pluggable_device/BUILD
@@ -107,7 +107,7 @@ cc_library(
         ":next_pluggable_device_api",
         "//tensorflow/c:tf_status_headers",
         "//tensorflow/c:tf_status_helper",
-	"//tensorflow/core/common_runtime:device_factory",
+        "//tensorflow/core/common_runtime:device_factory",
         "//tensorflow/core/common_runtime/next_pluggable_device/c:plugin_c_api_hdrs",
     ],
 )

--- a/tensorflow/core/common_runtime/next_pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/next_pluggable_device/BUILD
@@ -107,6 +107,7 @@ cc_library(
         ":next_pluggable_device_api",
         "//tensorflow/c:tf_status_headers",
         "//tensorflow/c:tf_status_helper",
+        "//tensorflow/core:framework",
         "//tensorflow/core/common_runtime:device_factory",
         "//tensorflow/core/common_runtime/next_pluggable_device/c:plugin_c_api_hdrs",
     ],

--- a/tensorflow/core/common_runtime/next_pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/next_pluggable_device/BUILD
@@ -107,6 +107,7 @@ cc_library(
         ":next_pluggable_device_api",
         "//tensorflow/c:tf_status_headers",
         "//tensorflow/c:tf_status_helper",
+	"//tensorflow/core/common_runtime:device_factory",
         "//tensorflow/core/common_runtime/next_pluggable_device/c:plugin_c_api_hdrs",
     ],
 )

--- a/tensorflow/core/common_runtime/next_pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/next_pluggable_device/BUILD
@@ -100,6 +100,18 @@ cc_library(
 )
 
 cc_library(
+    name = "next_pluggable_device_factory_hdrs",
+    hdrs = ["next_pluggable_device_factory.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+	 ":next_pluggable_device_api",
+	 "//tensorflow/c:tf_status_headers",
+	 "//tensorflow/c:tf_status_helper",
+	 "//tensorflow/core/common_runtime/next_pluggable_device/c:plugin_c_api_hdrs",
+    ],
+)
+
+cc_library(
     name = "pjrt_compile_on_demand_op",
     srcs = [
         "pjrt_compile_on_demand_op.cc",

--- a/tensorflow/core/common_runtime/next_pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/next_pluggable_device/BUILD
@@ -106,7 +106,6 @@ cc_library(
     deps = [
         ":next_pluggable_device_api",
         "//tensorflow/c:tf_status_headers",
-        "//tensorflow/c:tf_status_helper",
         "//tensorflow/core:framework",
         "//tensorflow/core/common_runtime:device_factory",
         "//tensorflow/core/common_runtime/next_pluggable_device/c:plugin_c_api_hdrs",

--- a/tensorflow/core/common_runtime/next_pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/next_pluggable_device/BUILD
@@ -104,10 +104,10 @@ cc_library(
     hdrs = ["next_pluggable_device_factory.h"],
     visibility = ["//visibility:public"],
     deps = [
-	 ":next_pluggable_device_api",
-	 "//tensorflow/c:tf_status_headers",
-	 "//tensorflow/c:tf_status_helper",
-	 "//tensorflow/core/common_runtime/next_pluggable_device/c:plugin_c_api_hdrs",
+        ":next_pluggable_device_api",
+        "//tensorflow/c:tf_status_headers",
+        "//tensorflow/c:tf_status_helper",
+        "//tensorflow/core/common_runtime/next_pluggable_device/c:plugin_c_api_hdrs",
     ],
 )
 

--- a/tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_factory.h
+++ b/tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_factory.h
@@ -22,7 +22,6 @@ limitations under the License.
 
 #include "tensorflow/core/common_runtime/next_pluggable_device/c/plugin_c_api.h"
 #include "tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_api.h"
-#include "tensorflow/core/framework/device_base.h"
 #include "tensorflow/core/framework/device_factory.h"
 
 namespace tensorflow {

--- a/tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_factory.h
+++ b/tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_factory.h
@@ -34,8 +34,7 @@ class NextPluggableDeviceFactory : public DeviceFactory {
       const std::string& compilation_device_name)
       : api_(TfnpdApi()),
         device_type_(device_type),
-        compilation_device_name_(compilation_device_name),
-        jit_device_type_(DeviceType(compilation_device_name)) {}
+        compilation_device_name_(compilation_device_name) {}
 
   Status ListPhysicalDevices(std::vector<string>* devices) override;
 
@@ -43,13 +42,14 @@ class NextPluggableDeviceFactory : public DeviceFactory {
                        const std::string& name_prefix,
                        std::vector<std::unique_ptr<Device>>* devices) override;
 
-  const DeviceType& jit_device_type() const { return jit_device_type_; }
+  const std::string& compilation_device_name() const {
+    return compilation_device_name_;
+  }
 
  private:
   const TFNPD_Api* api_;
   const std::string device_type_;
   const std::string compilation_device_name_;
-  const DeviceType jit_device_type_;
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_factory.h
+++ b/tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_factory.h
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include "tensorflow/core/common_runtime/next_pluggable_device/c/plugin_c_api.h"
 #include "tensorflow/core/common_runtime/next_pluggable_device/next_pluggable_device_api.h"
+#include "tensorflow/core/framework/device_base.h"
 #include "tensorflow/core/framework/device_factory.h"
 
 namespace tensorflow {
@@ -33,7 +34,8 @@ class NextPluggableDeviceFactory : public DeviceFactory {
       const std::string& compilation_device_name)
       : api_(TfnpdApi()),
         device_type_(device_type),
-        compilation_device_name_(compilation_device_name) {}
+        compilation_device_name_(compilation_device_name),
+        jit_device_type_(DeviceType(compilation_device_name)) {}
 
   Status ListPhysicalDevices(std::vector<string>* devices) override;
 
@@ -41,10 +43,13 @@ class NextPluggableDeviceFactory : public DeviceFactory {
                        const std::string& name_prefix,
                        std::vector<std::unique_ptr<Device>>* devices) override;
 
+  const DeviceType& jit_device_type() const { return jit_device_type_; }
+
  private:
   const TFNPD_Api* api_;
   const std::string device_type_;
   const std::string compilation_device_name_;
+  const DeviceType jit_device_type_;
 };
 
 }  // namespace tensorflow

--- a/tensorflow/core/tfrt/common/BUILD
+++ b/tensorflow/core/tfrt/common/BUILD
@@ -23,6 +23,7 @@ package_group(
         # copybara:uncomment "//platforms/xla/megascale/tensorflow/...",
         "//tensorflow/c/...",
         "//tensorflow/compiler/jit/...",
+        "//tensorflow/compiler/tf2xla/...",
         "//tensorflow/core/common_runtime/...",
         "//tensorflow/core/common_runtime/next_pluggable_device/...",
         "//tensorflow/core/tfrt/...",


### PR DESCRIPTION
This PR is for enabling XLA auto clustering mode for NextPluggableDevice, the basic idea is reusing GPU 's compilation device if plugin register it's jit_device_type as "XLA_GPU_JIT".