### PR TITLE
Fix: Define iOS Symbol List in Bazel to Avoid Linker Crash on Tflite Build

### DIFF
--- a/tensorflow/lite/BUILD
+++ b/tensorflow/lite/BUILD
@@ -1340,6 +1340,9 @@ tflite_cc_shared_object(
         "//tensorflow:macos": [
             "-Wl,-exported_symbols_list,$(location //tensorflow/lite:tflite_exported_symbols.lds)",
         ],
+         "//tensorflow:ios": [
+            "-Wl,-exported_symbols_list,$(location //tensorflow/lite:tflite_exported_symbols.lds)",
+        ],
         "//tensorflow:windows": [],
         "//conditions:default": [
             "-Wl,--version-script,$(location //tensorflow/lite:tflite_version_script.lds)",


### PR DESCRIPTION
### Description:

This pull request addresses a critical issue affecting the iOS c++ shared lib build. which results in a crash due to unsupported linker configuration.

### Problem

The list of symbols to be exported on iOS was not previously defined in our Bazel build configuration. This oversight caused the configuration to fall back to "//conditions:default": -Wl,--version-script, a setting that is not supported by the linker on iOS/macOS platforms.


the build then crash with the following error message being generated:

```sh
>>  bazel build  -c opt --config=ios_arm64 //tensorflow/lite:libtensorflowlite.dylib     

INFO: Analyzed target //tensorflow/lite:libtensorflowlite.dylib (104 packages loaded, 3138 targets configured).
INFO: Found 1 target...
ERROR: /Users/rodrigogomes/workspace/personal/tensorflow/tensorflow/lite/BUILD:1334:24: Linking tensorflow/lite/libtensorflowlite.dylib failed: (Exit 1): cc_wrapper.sh failed: error executing command (from target //tensorflow/lite:libtensorflowlite.dylib) external/local_config_cc/cc_wrapper.sh @bazel-out/ios_arm64-opt/bin/tensorflow/lite/libtensorflowlite.dylib-2.params
ld: unknown option: --version-script
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Error in child process '/usr/bin/xcrun'. 1
Target //tensorflow/lite:libtensorflowlite.dylib failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 62.617s, Critical Path: 4.30s
INFO: 198 processes: 3 internal, 195 local.
FAILED: Build did NOT complete successfully

```
