### PR TITLE
Migrate ops fuzzers to FuzzTest format

### DIFF
--- a/tensorflow/security/fuzzing/cc/ops/BUILD
+++ b/tensorflow/security/fuzzing/cc/ops/BUILD
@@ -109,3 +109,20 @@ tf_cc_fuzz_test(
         "//tensorflow/security/fuzzing/cc:fuzz_session",
     ],
 )
+
+tf_cc_fuzz_test(
+    name = "general_ops_fuzz",
+    srcs = ["general_ops_fuzz.cc"],
+    deps = [
+        "//tensorflow/cc:cc_ops",
+        "//tensorflow/core/ops:audio_ops_op_lib",
+        "//tensorflow/core/framework:types_proto_cc",
+        "//tensorflow/core/kernels:array",
+        "//tensorflow/core/kernels/image:image",
+        "//tensorflow/core/kernels/image:decode_image_op",
+        "//tensorflow/security/fuzzing/cc:fuzz_session",
+        "//tensorflow/security/fuzzing/cc/core/framework:datatype_domains",
+        "//tensorflow/security/fuzzing/cc/core/framework:tensor_domains",
+        "//tensorflow/security/fuzzing/cc/core/framework:tensor_shape_domains",
+    ],
+)

--- a/tensorflow/security/fuzzing/cc/ops/general_ops_fuzz.cc
+++ b/tensorflow/security/fuzzing/cc/ops/general_ops_fuzz.cc
@@ -1,0 +1,188 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fuzztest/fuzztest.h"
+#include "tensorflow/cc/ops/audio_ops.h"
+#include "tensorflow/cc/ops/standard_ops.h"
+#include "tensorflow/security/fuzzing/cc/fuzz_session.h"
+
+namespace tensorflow {
+namespace fuzzing {
+
+// Image op fuzzers
+// DecodePng
+class FuzzDecodePng : public FuzzSession<std::string> {
+  void BuildGraph(const Scope& scope) override {
+    auto op_node =
+        tensorflow::ops::Placeholder(scope.WithOpName("contents"), DT_STRING);
+    tensorflow::ops::DecodePng(scope.WithOpName("image"), op_node);
+  }
+
+  void FuzzImpl(const std::string& input_string) final {
+    Tensor input_tensor(tensorflow::DT_STRING, TensorShape({}));
+    input_tensor.scalar<tstring>()() =
+        string(input_string.c_str(), input_string.size());
+    Status s = RunInputsWithStatus({{"contents", input_tensor}});
+    if (!s.ok()) {
+      LOG(ERROR) << "Execution failed: " << s.message();
+    }
+  }
+};
+FUZZ_TEST_F(FuzzDecodePng, Fuzz)
+    .WithDomains(fuzztest::OneOf(fuzztest::InRegexp("[-.0-9]+"),
+                                 fuzztest::Arbitrary<std::string>()));
+
+// DecodeJpeg
+class FuzzDecodeJpeg : public FuzzSession<std::string> {
+  void BuildGraph(const Scope& scope) override {
+    auto op_node =
+        tensorflow::ops::Placeholder(scope.WithOpName("contents"), DT_STRING);
+    tensorflow::ops::DecodeJpeg(scope.WithOpName("image"), op_node);
+  }
+
+  void FuzzImpl(const std::string& input_string) final {
+    Tensor input_tensor(tensorflow::DT_STRING, TensorShape({}));
+    input_tensor.scalar<tstring>()() =
+        string(input_string.c_str(), input_string.size());
+    Status s = RunInputsWithStatus({{"contents", input_tensor}});
+    if (!s.ok()) {
+      LOG(ERROR) << "Execution failed: " << s.message();
+    }
+  }
+};
+FUZZ_TEST_F(FuzzDecodeJpeg, Fuzz)
+    .WithDomains(fuzztest::OneOf(fuzztest::InRegexp("[-.0-9]+"),
+                                 fuzztest::Arbitrary<std::string>()));
+
+// DecodeGif
+class FuzzDecodeGif : public FuzzSession<std::string> {
+  void BuildGraph(const Scope& scope) override {
+    auto op_node =
+        tensorflow::ops::Placeholder(scope.WithOpName("contents"), DT_STRING);
+    tensorflow::ops::DecodeGif(scope.WithOpName("image"), op_node);
+  }
+
+  void FuzzImpl(const std::string& input_string) final {
+    Tensor input_tensor(tensorflow::DT_STRING, TensorShape({}));
+    input_tensor.scalar<tstring>()() =
+        string(input_string.c_str(), input_string.size());
+    Status s = RunInputsWithStatus({{"contents", input_tensor}});
+    if (!s.ok()) {
+      LOG(ERROR) << "Execution failed: " << s.message();
+    }
+  }
+};
+FUZZ_TEST_F(FuzzDecodeGif, Fuzz)
+    .WithDomains(fuzztest::OneOf(fuzztest::InRegexp("[-.0-9]+"),
+                                 fuzztest::Arbitrary<std::string>()));
+
+// DecodeJpeg
+class FuzzDecodeImage : public FuzzSession<std::string> {
+  void BuildGraph(const Scope& scope) override {
+    auto op_node =
+        tensorflow::ops::Placeholder(scope.WithOpName("contents"), DT_STRING);
+    tensorflow::ops::DecodeImage(scope.WithOpName("image"), op_node);
+  }
+
+  void FuzzImpl(const std::string& input_string) final {
+    Tensor input_tensor(tensorflow::DT_STRING, TensorShape({}));
+    input_tensor.scalar<tstring>()() =
+        string(input_string.c_str(), input_string.size());
+    Status s = RunInputsWithStatus({{"contents", input_tensor}});
+    if (!s.ok()) {
+      LOG(ERROR) << "Execution failed: " << s.message();
+    }
+  }
+};
+FUZZ_TEST_F(FuzzDecodeImage, Fuzz)
+    .WithDomains(fuzztest::OneOf(fuzztest::InRegexp("[-.0-9]+"),
+                                 fuzztest::Arbitrary<std::string>()));
+
+// DecodeBmp
+class FuzzDecodeBmp : public FuzzSession<std::string> {
+  void BuildGraph(const Scope& scope) override {
+    auto op_node =
+        tensorflow::ops::Placeholder(scope.WithOpName("contents"), DT_STRING);
+    tensorflow::ops::DecodeBmp(scope.WithOpName("image"), op_node);
+  }
+
+  void FuzzImpl(const std::string& input_string) final {
+    Tensor input_tensor(tensorflow::DT_STRING, TensorShape({}));
+    input_tensor.scalar<tstring>()() =
+        string(input_string.c_str(), input_string.size());
+    Status s = RunInputsWithStatus({{"contents", input_tensor}});
+    if (!s.ok()) {
+      LOG(ERROR) << "Execution failed: " << s.message();
+    }
+  }
+};
+FUZZ_TEST_F(FuzzDecodeBmp, Fuzz)
+    .WithDomains(fuzztest::OneOf(fuzztest::InRegexp("[-.0-9]+"),
+                                 fuzztest::Arbitrary<std::string>()));
+
+// DecodeAndCropJpeg
+class FuzzDecodeAndCropJpeg : public FuzzSession<std::string, int32> {
+  void BuildGraph(const Scope& scope) override {
+    auto op_node =
+        tensorflow::ops::Placeholder(scope.WithOpName("contents"), DT_STRING);
+    auto crop_window =
+        tensorflow::ops::Placeholder(scope.WithOpName("crop_window"), DT_INT32);
+    tensorflow::ops::DecodeAndCropJpeg(scope.WithOpName("image"), op_node,
+                                       crop_window);
+  }
+
+  void FuzzImpl(const std::string& input_string,
+                const int32& crop_window_val) final {
+    Tensor input_tensor(tensorflow::DT_STRING, TensorShape({}));
+    input_tensor.scalar<tstring>()() =
+        string(input_string.c_str(), input_string.size());
+    Tensor crop_window(tensorflow::DT_INT32, TensorShape({}));
+    crop_window.scalar<int32>()() = crop_window_val;
+
+    Status s = RunInputsWithStatus(
+        {{"contents", input_tensor}, {"crop_window", crop_window}});
+    if (!s.ok()) {
+      LOG(ERROR) << "Execution failed: " << s.message();
+    }
+  }
+};
+FUZZ_TEST_F(FuzzDecodeAndCropJpeg, Fuzz)
+    .WithDomains(fuzztest::OneOf(fuzztest::InRegexp("[-.0-9]+"),
+                                 fuzztest::Arbitrary<std::string>()),
+                 fuzztest::InRange<int32>(0, 4096));
+
+// Audio decoder
+class FuzzDecodeWav : public FuzzSession<std::string> {
+  void BuildGraph(const Scope& scope) override {
+    auto op_node =
+        tensorflow::ops::Placeholder(scope.WithOpName("contents"), DT_STRING);
+    tensorflow::ops::DecodeWav(scope.WithOpName("image"), op_node);
+  }
+
+  void FuzzImpl(const std::string& input_string) final {
+    Tensor input_tensor(tensorflow::DT_STRING, TensorShape({}));
+    input_tensor.scalar<tstring>()() =
+        string(input_string.c_str(), input_string.size());
+    Status s = RunInputsWithStatus({{"contents", input_tensor}});
+    if (!s.ok()) {
+      LOG(ERROR) << "Execution failed: " << s.message();
+    }
+  }
+};
+FUZZ_TEST_F(FuzzDecodeWav, Fuzz)
+    .WithDomains(fuzztest::OneOf(fuzztest::InRegexp("[-.0-9]+"),
+                                 fuzztest::Arbitrary<std::string>()));
+
+}  // end namespace fuzzing
+}  // end namespace tensorflow


### PR DESCRIPTION
Creates a set of fuzzers to FuzzTest style. One of the benefits is that this will reduce storage size required for the fuzzers, because the fuzzers will all be based off the same binary whereas the non-FuzzTest fuzzers will have a binary per fuzzer. This storage requirement has caused an issue on the OSS-Fuzz side:
https://github.com/google/oss-fuzz/issues/9792

Migrating to FuzzTest will make it easier to add new ops-specific fuzzers since we won't have to worry about disk size. The existing fuzzesr can be several GBs of storage and it quickly goes beyond what we have available at OSS-Fuzz.

It would however be nice to re-use the existing fuzzer helper logic from fuzz_session.h so I added a macro similar to what we have for libFuzzer but simple for FuzzTest. I migrated a set of the existing fuzzers.

I figured it would be nice to do a soft transition, so we can remove the existing fuzzers after the ones introduced in this PR has shown to run for a while. I'm also curious in whether we will see a difference in performance from the FuzzTest and libFuzzer harnesses.

This PR supersedes https://github.com/tensorflow/tensorflow/pull/61122