### PR TITLE
[Linaro:ARM_CI] Drop building with Python 3.8 as not supported

### DIFF
--- a/.github/workflows/arm-cd.yml
+++ b/.github/workflows/arm-cd.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyver: ['3.8', '3.9', '3.10']
+        pyver: ['3.9', '3.10']
         experimental: [false]
         include:
           - pyver: '3.11'

--- a/.github/workflows/arm-ci-extended.yml
+++ b/.github/workflows/arm-ci-extended.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyver: ['3.8', '3.9', '3.10', '3.11']
+        pyver: ['3.9', '3.10', '3.11']
     steps:
       - name: Stop old running containers (if any)
         shell: bash

--- a/tensorflow/tools/toolchains/cpus/aarch64/aarch64_compiler_configure.bzl
+++ b/tensorflow/tools/toolchains/cpus/aarch64/aarch64_compiler_configure.bzl
@@ -34,7 +34,6 @@ def aarch64_compiler_configure():
     ml2014_tf_aarch64_configs(
         name_container_map = {
             "ml2014_aarch64": "docker://localhost/tensorflow-build-aarch64",
-            "ml2014_aarch64-python3.8": "docker://localhost/tensorflow-build-aarch64:latest-python3.8",
             "ml2014_aarch64-python3.9": "docker://localhost/tensorflow-build-aarch64:latest-python3.9",
             "ml2014_aarch64-python3.10": "docker://localhost/tensorflow-build-aarch64:latest-python3.10",
             "ml2014_aarch64-python3.11": "docker://localhost/tensorflow-build-aarch64:latest-python3.11",
@@ -72,7 +71,6 @@ def aarch64_compiler_configure():
     ml2014_tf_aarch64_configs(
         name_container_map = {
             "ml2014_clang_aarch64": "docker://localhost/tensorflow-build-aarch64",
-            "ml2014_clang_aarch64-python3.8": "docker://localhost/tensorflow-build-aarch64:latest-python3.8",
             "ml2014_clang_aarch64-python3.9": "docker://localhost/tensorflow-build-aarch64:latest-python3.9",
             "ml2014_clang_aarch64-python3.10": "docker://localhost/tensorflow-build-aarch64:latest-python3.10",
             "ml2014_clang_aarch64-python3.11": "docker://localhost/tensorflow-build-aarch64:latest-python3.11",


### PR DESCRIPTION
Python 3.8 is no longer supported so drop attempts to build using it.