### PR TITLE
Fix ambiguity in use of overloaded functions in XLA

### DIFF
--- a/tensorflow/compiler/xla/python/pjrt_ifrt/xla_sharding_test.cc
+++ b/tensorflow/compiler/xla/python/pjrt_ifrt/xla_sharding_test.cc
@@ -82,7 +82,7 @@ TEST(HloShardingTest, DisassembleWithReplication) {
 TEST(HloShardingTest, IndexDomainsWithTile) {
   auto device_list = CreateDummyDevices(2);
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, xla_hlo_sharding);
 
@@ -100,7 +100,7 @@ TEST(HloShardingTest, IndexDomainsWithTile) {
 TEST(HloShardingTest, DisassembleWithTile) {
   auto device_list = CreateDummyDevices(2);
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, xla_hlo_sharding);
 
@@ -120,7 +120,7 @@ TEST(HloShardingTest, DisassembleWithTile) {
 TEST(HloShardingTest, IndexDomainsWithUnevenTile) {
   auto device_list = CreateDummyDevices(2);
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, xla_hlo_sharding);
 
@@ -138,7 +138,7 @@ TEST(HloShardingTest, IndexDomainsWithUnevenTile) {
 TEST(HloShardingTest, DisassembleWithUnevenTile) {
   auto device_list = CreateDummyDevices(2);
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, xla_hlo_sharding);
 
@@ -300,7 +300,7 @@ TEST(HloShardingTest, DisassembleWithSubgroupMaximalSlowPath) {
 TEST(HloShardingTest, DisassembleFailsWithInvalidDeviceCount) {
   auto device_list = CreateDummyDevices(1);
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, xla_hlo_sharding);
 
@@ -314,7 +314,7 @@ TEST(HloShardingTest, DisassembleFailsWithInvalidDeviceCount) {
 TEST(HloShardingTest, DisassembleFailsWithMismatchingShapeDimsSize) {
   auto device_list = CreateDummyDevices(2);
   // 2-way sharded along axis 0, 1-way sharded along axis 1.
-  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
   std::shared_ptr<const HloSharding> sharding =
       HloSharding::Create(device_list, xla_hlo_sharding);
 


### PR DESCRIPTION
gcc complains of abiguity in some overloaded functions so cast the parameter to overcome this.