### PR TITLE
Add inter scheduler support on AArch64

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_concat_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_concat_op.cc
@@ -32,7 +32,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/types.h"
 #include "tensorflow/core/util/mkl_util.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 
@@ -297,7 +297,7 @@ class MklConcatFwdPrimitive : public MklPrimitive {
                const dnnl::memory& dst_data,
                const MklConcatFwdParams& concat_fwd_dims,
                std::shared_ptr<stream> fwd_stream) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
     DCHECK_EQ(in_data.size(), context_.data_mem.size());
@@ -397,7 +397,7 @@ class MklConcatFwdPrimitive : public MklPrimitive {
 
   struct ConcatFwdContext context_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };

--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
@@ -23,7 +23,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/mkl/mkl_conv_ops.h"
 #include "tensorflow/core/util/use_cudnn.h"
 #include "tensorflow/core/util/work_sharder.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 
@@ -93,7 +93,7 @@ class MklConvBwdFilterPrimitive : public MklPrimitive {
   void Execute(const T* src_data, const T* diff_filter_data,
                const T* diff_bias_data, const T* diff_dst_data,
                std::shared_ptr<stream> bwd_filter_stream) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
 #if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)
@@ -315,7 +315,7 @@ class MklConvBwdFilterPrimitive : public MklPrimitive {
 
   struct ConvBwdFilterContext context_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };

--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
@@ -30,7 +30,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/mkl/mkl_conv_ops.h"
 #include "tensorflow/core/util/use_cudnn.h"
 #include "tensorflow/core/util/work_sharder.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 
@@ -100,7 +100,7 @@ class MklConvBwdInputPrimitive : public MklPrimitive {
   void Execute(const T* diff_src_data, const T* filter_data,
                const T* diff_dst_data,
                std::shared_ptr<stream> bwd_input_stream) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
 #if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)
@@ -255,7 +255,7 @@ class MklConvBwdInputPrimitive : public MklPrimitive {
   }
 
   struct ConvBwdInputContext context_;
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -27,7 +27,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/mkl/mkl_kernel_util.h"
 #include "tensorflow/core/kernels/mkl/mkl_quantized_conv_ops.h"
 #include "tensorflow/core/kernels/no_op.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 
@@ -177,7 +177,7 @@ class MklConvFwdPrimitive : public MklPrimitive {
                const Tinput* bn_offset_data, const Tinput* bn_rsqrt_data,
                const MklConvFwdParams& convFwdDims,
                std::shared_ptr<stream> fwd_stream, void* sp_data) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     // When we are using single global cache then in this case we can have
     // multiple threads running the same primitive that we created so this
     // should happen under the lock.
@@ -582,7 +582,7 @@ class MklConvFwdPrimitive : public MklPrimitive {
 
   struct ConvFwdContext context_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   // Guards Execution()
   mutex primitive_execution_mu_;
 #endif

--- a/tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h
+++ b/tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h
@@ -30,7 +30,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/util/mkl_util.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 
@@ -100,7 +100,7 @@ class MklEltwiseFwdActivationPrimitive : public MklPrimitive {
   //   src_data:  input data buffer of src
   //   dst_data:  output data buffer of dst
   void Execute(const T* src_data, T* dst_data, OpKernelContext* op_context) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
     context_.src_mem->set_data_handle(
@@ -202,7 +202,7 @@ class MklEltwiseFwdActivationPrimitive : public MklPrimitive {
 
   struct EltwiseFwdActivationContext context_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };

--- a/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op.cc
@@ -24,7 +24,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/no_op.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/tensor_format.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 
@@ -131,7 +131,7 @@ class MklFusedBatchNormFwdPrimitive : public MklPrimitive {
 #endif  // !ENABLE_ONEDNN_V3
                U* mean_data, U* variance_data,
                std::shared_ptr<stream> fwd_stream, U* workspace_data) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
 #if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)
@@ -416,7 +416,7 @@ class MklFusedBatchNormFwdPrimitive : public MklPrimitive {
 
   struct BatchNormFwdContext context_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };
@@ -542,7 +542,7 @@ class MklFusedBatchNormBwdPrimitive : public MklPrimitive {
                U* diff_scale_data, U* diff_shift_data, U* res_space_data,
 #endif  // !ENABLE_ONEDNN_V3
                std::shared_ptr<stream> bwd_stream) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
 #if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)
@@ -765,7 +765,7 @@ class MklFusedBatchNormBwdPrimitive : public MklPrimitive {
 
   struct BatchNormBwdContext context_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -29,7 +29,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/mkl/mkl_kernel_util.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/onednn_env_vars.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 
@@ -153,7 +153,7 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
                const void* bias_data, Toutput* dst_data,
                const MklDnnMatMulFwdParams& matmul_fwd_params, void* sp_data,
                std::shared_ptr<stream> fwd_stream) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
     context_.src_mem->set_data_handle(
@@ -445,7 +445,7 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
 
   struct MklDnnMatMulFwdContext context_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   // Guards Execution()
   mutex primitive_execution_mu_;
 #endif
@@ -811,7 +811,7 @@ class MklMatMulPrimitive : public MklPrimitive {
   void Execute(const std::shared_ptr<stream>& stream, const Tlhs* a_data,
                const Trhs* b_data, const Toutput* c_data, void* sp_data,
                void* mul_data = nullptr, void* add_data = nullptr) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
 #if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)
@@ -1011,7 +1011,7 @@ class MklMatMulPrimitive : public MklPrimitive {
   }
 
   struct MklMatMulContext context_;
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };

--- a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc
+++ b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc
@@ -101,7 +101,7 @@ template <typename T>
 void MklPoolingFwdPrimitive<T>::Execute(const T* src_data, T* dst_data,
                                         void* ws_data,
                                         std::shared_ptr<stream> fwd_stream) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex_lock lock(primitive_execution_mu_);
 #endif
 #if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)
@@ -218,7 +218,7 @@ template <typename T>
 void MklPoolingBwdPrimitive<T>::Execute(const T* diff_dst_data,
                                         T* diff_src_data, const void* ws_data,
                                         std::shared_ptr<stream> bwd_stream) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex_lock lock(primitive_execution_mu_);
 #endif
 #if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)

--- a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
@@ -27,7 +27,7 @@ limitations under the License.
 #include "tensorflow/core/framework/ops_util.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/padding.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 
@@ -176,7 +176,7 @@ class MklPoolingFwdPrimitive : public MklPrimitive {
 
   struct PoolingFwdContext context_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };
@@ -331,7 +331,7 @@ class MklPoolingBwdPrimitive : public MklPrimitive {
   };
 
   struct PoolingBwdContext context_;
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };

--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
@@ -25,7 +25,7 @@ limitations under the License.
 #include "tensorflow/core/graph/mkl_graph_util.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/util/mkl_util.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 
@@ -111,7 +111,7 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
                void* scale_data,
 #endif  // ENABLE_ONEDNN_V3
                std::shared_ptr<stream> reorder_stream) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
 #if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)
@@ -202,7 +202,7 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
 #endif  // ENABLE_ONEDNN_V3
   }
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };

--- a/tensorflow/core/kernels/mkl/mkl_relu_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_relu_op.cc
@@ -26,7 +26,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/util/mkl_util.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 
@@ -77,7 +77,7 @@ class MklEltwiseFwdPrimitive : public MklPrimitive {
   //   dst_data:  output data buffer of dst
   void Execute(const T* src_data, T* dst_data,
                std::shared_ptr<stream> fwd_stream) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
@@ -160,7 +160,7 @@ class MklEltwiseFwdPrimitive : public MklPrimitive {
 
   struct EltwiseFwdContext context_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };
@@ -259,7 +259,7 @@ class MklEltwiseBwdPrimitive : public MklPrimitive {
   //   diff_src_data:  output data buffer of diff_src
   void Execute(const T* src_data, const T* diff_dst_data, T* diff_src_data,
                std::shared_ptr<stream> bwd_stream) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
 #ifndef ENABLE_ONEDNN_OPENMP
@@ -368,7 +368,7 @@ class MklEltwiseBwdPrimitive : public MklPrimitive {
 
   struct EltwiseBwdContext context_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };

--- a/tensorflow/core/kernels/mkl/mkl_softmax_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_softmax_op.cc
@@ -26,7 +26,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/tensor_format.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 #include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
@@ -64,7 +64,7 @@ class MklSoftmaxPrimitive : public MklPrimitive {
   //   dst_data:  output data buffer of dst
   void Execute(const T* src_data, T* dst_data,
                std::shared_ptr<stream> fwd_cpu_stream) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(primitive_execution_mu_);
 #endif
 #if !defined(ENABLE_ONEDNN_OPENMP) && !defined(ENABLE_ONEDNN_V3)
@@ -160,7 +160,7 @@ class MklSoftmaxPrimitive : public MklPrimitive {
 
   struct SoftmaxFwdContext context_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_execution_mu_;
 #endif
 };

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -1983,8 +1983,7 @@ class MklPrimitiveFactory {
   ~MklPrimitiveFactory() {}
 
   MklPrimitive* GetOp(const string& key) {
-#if !defined(DNNL_AARCH64_USE_ACL) || \
-    (defined(DNNL_AARCH64_USE_ACL) && !defined(ENABLE_ONEDNN_OPENMP))
+#if !defined(DNNL_AARCH64_USE_ACL) || !defined(ENABLE_ONEDNN_OPENMP)
     auto& lru_cache = MklPrimitiveFactory<T>::GetLRUCache();
     return lru_cache.GetOp(key);
 #else
@@ -2020,8 +2019,7 @@ class MklPrimitiveFactory {
   }
 
   void SetOp(const string& key, MklPrimitive* op) {
-#if !defined(DNNL_AARCH64_USE_ACL) || \
-    (defined(DNNL_AARCH64_USE_ACL) && !defined(ENABLE_ONEDNN_OPENMP))
+#if !defined(DNNL_AARCH64_USE_ACL) || !defined(ENABLE_ONEDNN_OPENMP)
     auto& lru_cache = MklPrimitiveFactory<T>::GetLRUCache();
     lru_cache.SetOp(key, op);
 #else
@@ -2071,8 +2069,7 @@ class MklPrimitiveFactory {
  private:
   static inline LRUCache<MklPrimitive>& GetLRUCache() {
     static const int kCapacity = 1024;  // cache capacity
-#if !defined(DNNL_AARCH64_USE_ACL) || \
-    (defined(DNNL_AARCH64_USE_ACL) && !defined(ENABLE_ONEDNN_OPENMP))
+#if !defined(DNNL_AARCH64_USE_ACL) || !defined(ENABLE_ONEDNN_OPENMP)
     static thread_local LRUCache<MklPrimitive> lru_cache_(kCapacity);
 #else
     static LRUCache<MklPrimitive> lru_cache_(kCapacity);

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -39,7 +39,7 @@ limitations under the License.
 #include "tensorflow/core/util/onednn_env_vars.h"
 #include "tensorflow/core/util/padding.h"
 #include "tensorflow/core/util/tensor_format.h"
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
 #include "tensorflow/tsl/util/onednn_threadpool.h"
@@ -1859,7 +1859,7 @@ class LRUCache {
   }
 
   T* GetOp(const string& key) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(lru_mu_);
 #endif
     auto it = cache_.find(key);
@@ -1875,7 +1875,7 @@ class LRUCache {
   }
 
   void SetOp(const string& key, T* op) {
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     mutex_lock lock(lru_mu_);
 #endif
     if (lru_list_.size() >= capacity_) {
@@ -1886,7 +1886,7 @@ class LRUCache {
     lru_list_.push_front(key);
     Entry entry(op, lru_list_.begin());
     cache_.emplace(std::make_pair(key, std::move(entry)));
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
     FinishedAllocation(key);
 #endif
   }
@@ -1899,7 +1899,7 @@ class LRUCache {
     lru_list_.clear();
   }
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   bool IsAllocating(const string& key) {
     mutex_lock lock(in_flight_mu_);
     return in_flight_.find(key) != in_flight_.end();
@@ -1964,7 +1964,7 @@ class LRUCache {
   // entry, while the back of the list is the least recently accessed entry.
   std::list<string> lru_list_;
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   // Guards access to the cache and LRU list
   mutex lru_mu_;
 
@@ -1983,7 +1983,8 @@ class MklPrimitiveFactory {
   ~MklPrimitiveFactory() {}
 
   MklPrimitive* GetOp(const string& key) {
-#ifndef DNNL_AARCH64_USE_ACL
+#if !defined(DNNL_AARCH64_USE_ACL) || \
+    (defined(DNNL_AARCH64_USE_ACL) && !defined(ENABLE_ONEDNN_OPENMP))
     auto& lru_cache = MklPrimitiveFactory<T>::GetLRUCache();
     return lru_cache.GetOp(key);
 #else
@@ -2019,7 +2020,8 @@ class MklPrimitiveFactory {
   }
 
   void SetOp(const string& key, MklPrimitive* op) {
-#ifndef DNNL_AARCH64_USE_ACL
+#if !defined(DNNL_AARCH64_USE_ACL) || \
+    (defined(DNNL_AARCH64_USE_ACL) && !defined(ENABLE_ONEDNN_OPENMP))
     auto& lru_cache = MklPrimitiveFactory<T>::GetLRUCache();
     lru_cache.SetOp(key, op);
 #else
@@ -2069,7 +2071,8 @@ class MklPrimitiveFactory {
  private:
   static inline LRUCache<MklPrimitive>& GetLRUCache() {
     static const int kCapacity = 1024;  // cache capacity
-#ifndef DNNL_AARCH64_USE_ACL
+#if !defined(DNNL_AARCH64_USE_ACL) || \
+    (defined(DNNL_AARCH64_USE_ACL) && !defined(ENABLE_ONEDNN_OPENMP))
     static thread_local LRUCache<MklPrimitive> lru_cache_(kCapacity);
 #else
     static LRUCache<MklPrimitive> lru_cache_(kCapacity);
@@ -2077,7 +2080,7 @@ class MklPrimitiveFactory {
     return lru_cache_;
   }
 
-#ifdef DNNL_AARCH64_USE_ACL
+#if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
   mutex primitive_creation_mu_;
   condition_variable primitive_creation_cv_;
 #endif

--- a/tensorflow/tsl/util/onednn_threadpool.h
+++ b/tensorflow/tsl/util/onednn_threadpool.h
@@ -161,7 +161,9 @@ class OneDnnThreadPool : public threadpool_iface {
         num_threads == -1 ? eigen_interface_->NumThreads() : num_threads;
 #if DNNL_VERSION_MAJOR >= 3 || \
     (DNNL_VERSION_MAJOR == 2 && DNNL_VERSION_MINOR >= 7)
+#ifndef DNNL_AARCH64_USE_ACL
     dnnl_threadpool_interop_set_max_concurrency(num_threads_);
+#endif  // DNNL_AARCH64_USE_ACL
 #endif  // DNNL_VERSION_MAJOR >= 3 ||
         // (DNNL_VERSION_MAJOR == 2 && DNNL_VERSION_MINOR >= 7)
   }

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -211,6 +211,7 @@ def _tf_repositories():
             "//third_party/mkl_dnn:onednn_acl_reorder_padded.patch",
             "//third_party/mkl_dnn:onednn_acl_reorder_update.patch",
             "//third_party/mkl_dnn:onednn_acl_reorder.patch",
+            "//third_party/mkl_dnn:onednn_acl_thread_local_scheduler.patch",
         ],
         sha256 = "a50993aa6265b799b040fe745e0010502f9f7103cc53a9525d59646aef006633",
         strip_prefix = "oneDNN-2.7.3",
@@ -219,7 +220,10 @@ def _tf_repositories():
 
     tf_http_archive(
         name = "compute_library",
-        patch_file = ["//third_party/compute_library:compute_library.patch"],
+        patch_file = [
+            "//third_party/compute_library:compute_library.patch",
+            "//third_party/compute_library:acl_thread_local_scheduler.patch",
+        ],
         sha256 = "c4ca329a78da380163b2d86e91ba728349b6f0ee97d66e260a694ef37f0b0d93",
         strip_prefix = "ComputeLibrary-23.05.1",
         urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v23.05.1.tar.gz"),

--- a/third_party/compute_library/acl_thread_local_scheduler.patch
+++ b/third_party/compute_library/acl_thread_local_scheduler.patch
@@ -1,0 +1,98 @@
+diff --git a/arm_compute/runtime/Scheduler.h b/arm_compute/runtime/Scheduler.h
+index 9e8add1f9..cf5e2bf4c 100644
+--- a/arm_compute/runtime/Scheduler.h
++++ b/arm_compute/runtime/Scheduler.h
+@@ -75,7 +75,7 @@ public:
+
+ private:
+     static Type                        _scheduler_type;
+-    static std::shared_ptr<IScheduler> _custom_scheduler;
++    static thread_local std::shared_ptr<IScheduler> _custom_scheduler;
+     static std::map<Type, std::unique_ptr<IScheduler>> _schedulers;
+
+     Scheduler();
+diff --git a/src/cpu/operators/CpuDepthwiseConv2dAssemblyDispatch.cpp b/src/cpu/operators/CpuDepthwiseConv2dAssemblyDispatch.cpp
+index a5b9eca56..d1ab19397 100644
+--- a/src/cpu/operators/CpuDepthwiseConv2dAssemblyDispatch.cpp
++++ b/src/cpu/operators/CpuDepthwiseConv2dAssemblyDispatch.cpp
+@@ -60,8 +60,8 @@ void CpuDepthwiseConv2dAssemblyDispatch::configure(const ITensorInfo     *src,
+                                                    const ConvolutionInfo &info)
+ {
+     ARM_COMPUTE_LOG_PARAMS(src, weights, bias, dst, info);
+-    const CPUInfo     &ci          = NEScheduler::get().cpu_info();
+-    const unsigned int num_threads = NEScheduler::get().num_threads();
++    const CPUInfo     &ci          = CPUInfo::get();
++    const unsigned int num_threads = CPUInfo::get().get_cpu_num();
+     _pImpl->is_prepared            = false;
+     _pImpl->are_weights_const      = weights->are_values_constant();
+
+diff --git a/src/cpu/operators/CpuPool2d.cpp b/src/cpu/operators/CpuPool2d.cpp
+index 722cd36ee..03aef1632 100644
+--- a/src/cpu/operators/CpuPool2d.cpp
++++ b/src/cpu/operators/CpuPool2d.cpp
+@@ -66,8 +66,8 @@ void CpuPool2d::configure(ITensorInfo *src, ITensorInfo *dst, const PoolingLayer
+
+     if(run_optimised)
+     {
+-        const CPUInfo     &ci          = NEScheduler::get().cpu_info();
+-        const unsigned int num_threads = NEScheduler::get().num_threads();
++        const CPUInfo     &ci          = CPUInfo::get();
++        const unsigned int num_threads = CPUInfo::get().get_cpu_num();
+
+         auto pooling_wrapper = std::make_unique<kernels::CpuPool2dAssemblyWrapperKernel>();
+         ARM_COMPUTE_ERROR_ON(pooling_wrapper == nullptr);
+diff --git a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+ *******************************************************************************
+ Copyright 2023 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+index 9c8563140..f7771945a 100644
+--- a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
++++ b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+@@ -623,8 +623,8 @@ void create_arm_gemm(std::unique_ptr<CpuGemmAssemblyDispatch::IFallback> &arm_ge
+                      arm_gemm::Activation activation, const AsmGemmInfo &info)
+ {
+     Params         p           = extract_parameters(a, b, d, info);
+-    const CPUInfo &ci          = NEScheduler::get().cpu_info();
+-    unsigned int   num_threads = NEScheduler::get().num_threads();
++    const CPUInfo &ci          = CPUInfo::get();
++    unsigned int   num_threads = CPUInfo::get().get_cpu_num();
+
+     arm_gemm::GemmConfig cfg;
+     cfg.weight_format = assembly_utils::map_to_arm_gemm_weight_format(info.weight_format);
+@@ -696,8 +696,8 @@ Status CpuGemmAssemblyDispatch::has_opt_impl(arm_compute::WeightFormat &expected
+     ARM_COMPUTE_UNUSED(c);
+     arm_gemm::Activation act         = assembly_utils::map_to_arm_gemm_activation(info.activation_info);
+     Params               p           = extract_parameters(a, b, d, info);
+-    const CPUInfo       &ci          = NEScheduler::get().cpu_info();
+-    unsigned int         num_threads = NEScheduler::get().num_threads();
++    const CPUInfo       &ci          = CPUInfo::get();
++    unsigned int         num_threads = CPUInfo::get().get_cpu_num();
+     arm_gemm::GemmConfig cfg;
+     cfg.weight_format                           = assembly_utils::map_to_arm_gemm_weight_format(info.weight_format);
+     arm_gemm::WeightFormat arm_gemm_expected_wf = assembly_utils::map_to_arm_gemm_weight_format(expected_weight_format);
+diff --git a/src/runtime/Scheduler.cpp b/src/runtime/Scheduler.cpp
+index 0713b9a2a..f15ac2e22 100644
+--- a/src/runtime/Scheduler.cpp
++++ b/src/runtime/Scheduler.cpp
+@@ -47,7 +47,7 @@ Scheduler::Type Scheduler::_scheduler_type = Scheduler::Type::CPP;
+ Scheduler::Type Scheduler::_scheduler_type = Scheduler::Type::ST;
+ #endif /* ARM_COMPUTE_*_SCHEDULER */
+
+-std::shared_ptr<IScheduler> Scheduler::_custom_scheduler = nullptr;
++thread_local std::shared_ptr<IScheduler> Scheduler::_custom_scheduler = nullptr;
+
+ namespace
+ {

--- a/third_party/mkl_dnn/onednn_acl_thread_local_scheduler.patch
+++ b/third_party/mkl_dnn/onednn_acl_thread_local_scheduler.patch
@@ -1,0 +1,98 @@
+ *******************************************************************************
+ Copyright 2023 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/src/cpu/aarch64/acl_thread.cpp b/src/cpu/aarch64/acl_thread.cpp
+index d7d83badcb..1a7bcd74ed 100644
+--- a/src/cpu/aarch64/acl_thread.cpp
++++ b/src/cpu/aarch64/acl_thread.cpp
+@@ -41,14 +41,17 @@ void acl_thread_bind() {
+ #endif
+
+ #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+-void acl_set_custom_scheduler() {
+-    static std::once_flag flag_once;
+-    // Create threadpool scheduler
+-    std::shared_ptr<arm_compute::IScheduler> threadpool_scheduler
+-            = std::make_unique<ThreadpoolScheduler>();
++void acl_set_custom_scheduler(int intra_threads = 0) {
++    static thread_local std::once_flag flag_once;
+     // set CUSTOM scheduler in ACL
+     std::call_once(flag_once,
+-            [&]() { arm_compute::Scheduler::set(threadpool_scheduler); });
++            [&]() {
++                    // Create threadpool scheduler
++                    std::shared_ptr<arm_compute::IScheduler> threadpool_scheduler
++                        = std::make_unique<ThreadpoolScheduler>();
++                    threadpool_scheduler->set_num_threads(intra_threads);
++
++                    arm_compute::Scheduler::set(threadpool_scheduler); });
+ }
+
+ void acl_set_threadpool_num_threads() {
+diff --git a/src/cpu/aarch64/acl_thread.hpp b/src/cpu/aarch64/acl_thread.hpp
+index 46dde5eb05..13b3910515 100644
+--- a/src/cpu/aarch64/acl_thread.hpp
++++ b/src/cpu/aarch64/acl_thread.hpp
+@@ -34,7 +34,7 @@ void acl_thread_bind();
+
+ #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+ // Retrieve threadpool size during primitive execution and set ThreadpoolScheduler num_threads
+-void acl_set_custom_scheduler();
++void acl_set_custom_scheduler(int intra_threads);
+ void acl_set_threadpool_num_threads();
+ #endif
+
+diff --git a/src/cpu/aarch64/acl_threadpool_scheduler.cpp b/src/cpu/aarch64/acl_threadpool_scheduler.cpp
+index 418d7f30f9..7eb8a052b0 100644
+--- a/src/cpu/aarch64/acl_threadpool_scheduler.cpp
++++ b/src/cpu/aarch64/acl_threadpool_scheduler.cpp
+@@ -102,8 +102,6 @@ void ThreadpoolScheduler::schedule_op(ICPPKernel *kernel, const Hints &hints,
+ void ThreadpoolScheduler::run_workloads(
+         std::vector<arm_compute::IScheduler::Workload> &workloads) {
+
+-    arm_compute::lock_guard<std::mutex> lock(this->_run_workloads_mutex);
+-
+     const unsigned int num_threads
+             = std::min(static_cast<unsigned int>(_num_threads),
+                     static_cast<unsigned int>(workloads.size()));
+diff --git a/src/cpu/cpu_engine.cpp b/src/cpu/cpu_engine.cpp
+index 4ee70a405c..e9211f42e0 100644
+--- a/src/cpu/cpu_engine.cpp
++++ b/src/cpu/cpu_engine.cpp
+@@ -47,6 +47,7 @@ status_t cpu_engine_t::create_stream(stream_t **stream, unsigned flags) {
+ #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+ status_t cpu_engine_t::create_stream(stream_t **stream,
+         dnnl::threadpool_interop::threadpool_iface *threadpool) {
++    dnnl::impl::cpu::aarch64::acl_thread_utils::acl_set_custom_scheduler(threadpool->get_num_threads());
+     return safe_ptr_assign<stream_t>(
+             *stream, new cpu_stream_t(this, threadpool));
+ }
+diff --git a/src/cpu/cpu_engine.hpp b/src/cpu/cpu_engine.hpp
+index 7aa077e4ef..2938650963 100644
+--- a/src/cpu/cpu_engine.hpp
++++ b/src/cpu/cpu_engine.hpp
+@@ -175,11 +175,6 @@ public:
+         // dnnl_get_max_threads() == OMP_NUM_THREADS
+         dnnl::impl::cpu::aarch64::acl_thread_utils::acl_thread_bind();
+ #endif
+-
+-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+-        // Set ACL scheduler for threadpool runtime
+-        dnnl::impl::cpu::aarch64::acl_thread_utils::acl_set_custom_scheduler();
+-#endif
+ #endif
+         return status::success;
+     };


### PR DESCRIPTION
This PR adds support for inter op scheduler in the oneDNN + ACL build. It enables the creation of more than 1 scheduler inside ACL to increase performance of models with parallel ops.
For benchmarked NLP models the average performance increase is 9%, for CV classification models its around 2%.
The below benchmarks were done with the following PR’s applied as patches:
#60026, #60723, #61110, #61114, #61093, #61123 

![nlp_models_benchmarked](https://github.com/tensorflow/tensorflow/assets/117736650/7a3a4df1-475b-4dc4-ab85-7e9b97eb7b27)

![cv_models_benchmarked](https://github.com/tensorflow/tensorflow/assets/117736650/245103e6-f6d1-4da9-abb8-3a90a86217a9)
