### PR TITLE
[NextPluggableDevice] Enable DtoD copy ViaDMA support 

### DIFF
--- a/tensorflow/compiler/jit/pjrt_device_context.cc
+++ b/tensorflow/compiler/jit/pjrt_device_context.cc
@@ -211,7 +211,7 @@ void PjRtDevice_DeviceToDeviceCopy(
   }
 
   StatusOr<xla::PjRtClient*> pjrt_dst_client =
-      GetOrCreatePjRtClient(DeviceTyp(dst->device_type()));
+      GetOrCreatePjRtClient(DeviceType(dst->device_type()));
 
   if (!pjrt_dst_client.ok()) {
     done(pjrt_dst_client.status()) return;

--- a/tensorflow/compiler/jit/pjrt_device_context.h
+++ b/tensorflow/compiler/jit/pjrt_device_context.h
@@ -52,6 +52,12 @@ class PjRtDeviceContext : public DeviceContext {
   bool use_pjrt_tensor_buffer_;
 };
 
+void PjRtDevice_DeviceToDeviceCopy(
+    DeviceContext* send_dev_context, DeviceContext* recv_dev_context,
+    Device* src, Device* dst, AllocatorAttributes src_alloc_attr,
+    AllocatorAttributes dst_alloc_attr, const Tensor* input, Tensor* output,
+    int dev_to_dev_stream_index, StatusCallback done);
+
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_COMPILER_JIT_PJRT_DEVICE_CONTEXT_H_

--- a/tensorflow/core/common_runtime/pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/pluggable_device/BUILD
@@ -84,6 +84,7 @@ cc_library(
         "//tensorflow/c/experimental/stream_executor",
         "//tensorflow/c/experimental/stream_executor:stream_executor_internal",
         "//tensorflow/compiler/jit:flags_headers",
+        "//tensorflow/compiler/jit:pjrt_device_context",
         "//tensorflow/compiler/jit:xla_device_no_jit_rewrite_registration",
         "//tensorflow/compiler/xla/pjrt:pjrt_api",
         "//tensorflow/compiler/xla/stream_executor:device_mem_allocator",

--- a/tensorflow/core/common_runtime/pluggable_device/pluggable_device_plugin_init.cc
+++ b/tensorflow/core/common_runtime/pluggable_device/pluggable_device_plugin_init.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/c/experimental/pluggable_profiler/pluggable_profiler_internal.h"
 #include "tensorflow/c/experimental/stream_executor/stream_executor_internal.h"
 #include "tensorflow/compiler/jit/flags.h"
+#include "tensorflow/compiler/jit/pjrt_device_context.h"
 #include "tensorflow/compiler/jit/xla_device.h"
 #include "tensorflow/compiler/xla/pjrt/pjrt_api.h"
 #include "tensorflow/core/common_runtime/copy_tensor.h"
@@ -127,6 +128,11 @@ static Status InitNextPluggableDeviceModule(void* dso_handle) {
     VLOG(1) << "Registered XlaCompileOnDemand op for device_type: "
             << device_type;
   }
+
+  TF_RETURN_IF_ERROR(CopyTensor::Register(
+      DeviceType(device_type), DeviceType(device_type),
+      PjRtDevice_DeviceToDeviceCopy,
+      /*is_pluggable_device=*/true));  // Register the Copy tensor.
 
   VLOG(1) << "Successfully initialized NextPluggableDevice module.";
   return OkStatus();


### PR DESCRIPTION
This PR is to enable DtoD copy ViaDMA  support for NextPluggableDevice. This is needed when there are multiple PjRtDevice and send/recv op will use this registered copyfunc.