### PR TITLE
validate clip_norm argument in clip_by_norm API

### DIFF
--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -195,8 +195,7 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
     t: A `Tensor` or `IndexedSlices`.  This must be a floating point type.
     clip_norm: A 0-D (scalar) `Tensor` > 0. A maximum clipping value, also
       floating point.
-      Note: If clip_norm given as a negative value then it will be converted
-       into Zero internally and exception will not be raised here.
+      Note: If a negative clip_norm is provided, it will be treated as zero.
     axes: A 1-D (vector) `Tensor` of type int32 containing the dimensions
       to use for computing the L2-norm. If `None` (the default), uses all
       dimensions.

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -212,6 +212,8 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
     values = ops.convert_to_tensor(
         t.values if isinstance(t, indexed_slices.IndexedSlices) else t,
         name="t")
+    if clip_norm < 0:
+      raise ValueError('clip_norm should be a 0-D (scalar) Tensor > 0')
 
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
     l2sum = math_ops.reduce_sum(values * values, axes, keepdims=True)

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -194,7 +194,9 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
   Args:
     t: A `Tensor` or `IndexedSlices`.  This must be a floating point type.
     clip_norm: A 0-D (scalar) `Tensor` > 0. A maximum clipping value, also
-      floating point
+      floating point.
+      Note: If clip_norm given as a negative value then it will be converted
+       into Zero internally and exception will not be raised here.
     axes: A 1-D (vector) `Tensor` of type int32 containing the dimensions
       to use for computing the L2-norm. If `None` (the default), uses all
       dimensions.
@@ -212,8 +214,7 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
     values = ops.convert_to_tensor(
         t.values if isinstance(t, indexed_slices.IndexedSlices) else t,
         name="t")
-    if clip_norm < 0:
-      raise ValueError('clip_norm should be a 0-D (scalar) Tensor > 0')
+    clip_norm = math_ops.maximum(clip_norm, 0)
 
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
     l2sum = math_ops.reduce_sum(values * values, axes, keepdims=True)

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -213,8 +213,8 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
     values = ops.convert_to_tensor(
         t.values if isinstance(t, indexed_slices.IndexedSlices) else t,
         name="t")
-    clip_norm = tf.cast(math_ops.maximum(clip_norm, 0),dtype = values.dtype)
-
+    clip_norm = math_ops.cast(math_ops.maximum(clip_norm, 0),
+                              dtype = values.dtype)
 
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
     l2sum = math_ops.reduce_sum(values * values, axes, keepdims=True)

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -213,7 +213,8 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
     values = ops.convert_to_tensor(
         t.values if isinstance(t, indexed_slices.IndexedSlices) else t,
         name="t")
-    clip_norm = math_ops.maximum(clip_norm, 0)
+    clip_norm = tf.cast(math_ops.maximum(clip_norm, 0),dtype = values.dtype)
+
 
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
     l2sum = math_ops.reduce_sum(values * values, axes, keepdims=True)


### PR DESCRIPTION
The API `clip_by_norm` have argument `clip_norm` which accepts  `0-D (scalar) `Tensor` > 0` . But if we pass `-ve` value for this argument then its not raising intended error and converting the input tensor into Negative which IMO is wrong. Hence I am adding validation code for -ve values to `raise value error`.

Attaching [gist](https://colab.research.google.com/gist/SuryanarayanaY/650edf2e880caa947674f813a41ef5a8/61158_-code-fix-ve-values.ipynb) for the same with solution for reference.

Fixex #61158  