### PR TITLE
[NextPluggableDevice] Enable DtoD Copy ViaDMA

### DIFF
--- a/tensorflow/compiler/jit/pjrt_device_context.cc
+++ b/tensorflow/compiler/jit/pjrt_device_context.cc
@@ -198,7 +198,7 @@ void PjRtDeviceContext::CopyTensorInSameDevice(const Tensor* input_tensor,
   result_tensor->GetBuffer()->GetReadyFuture().OnReady(std::move(done));
 }
 
-void PjRtDevice_DeviceToDeviceCopy(
+void PjRtDeviceToDeviceCopy(
     DeviceContext* send_dev_context, DeviceContext* recv_dev_context,
     Device* src, Device* dst, AllocatorAttributes src_alloc_attr,
     AllocatorAttributes dst_alloc_attr, const Tensor* input, Tensor* output,

--- a/tensorflow/compiler/jit/pjrt_device_context.cc
+++ b/tensorflow/compiler/jit/pjrt_device_context.cc
@@ -198,4 +198,66 @@ void PjRtDeviceContext::CopyTensorInSameDevice(const Tensor* input_tensor,
   result_tensor->GetBuffer()->GetReadyFuture().OnReady(std::move(done));
 }
 
+void PjRtDevice_DeviceToDeviceCopy(
+    DeviceContext* send_dev_context, DeviceContext* recv_dev_context,
+    Device* src, Device* dst, AllocatorAttributes src_alloc_attr,
+    AllocatorAttributes dst_alloc_attr, const Tensor* input, Tensor* output,
+    int dev_to_dev_stream_index, StatusCallback done) {
+  profiler::TraceMe traceme("PjRtDevice_DeviceToDeviceCopy");
+  if (input->NumElements() == 0) {
+    VLOG(2) << "PjRtDevice_DeviceToDeviceCopy empty tensor";
+    done(OkStatus());
+    return;
+  }
+
+  StatusOr<xla::PjRtClient*> pjrt_dst_client =
+      GetOrCreatePjRtClient(DeviceType(dst->device_type()));
+
+  if (!pjrt_dst_client.ok()) {
+    done(pjrt_dst_client.status());
+    return;
+  }
+
+  xla::PjRtBuffer* src_device_buffer =
+      tensorflow::AsyncValueTensor::FromTensor(input)->GetBuffer().get();
+
+  // The device id should match the local_hardware_id in
+  // tensorflow/compiler/xla/pjrt/pjrt_client.h.
+  const int pjrt_dst_device_id =
+      tsl::GetDeviceIdFromDeviceParsedName(dst->parsed_name(),
+                                           DeviceType(dst->device_type()))
+          .value();
+  xla::PjRtDevice* pjrt_dst_device =
+      (*pjrt_dst_client)->LookupAddressableDevice(pjrt_dst_device_id).value();
+
+  StatusOr<std::unique_ptr<xla::PjRtBuffer>> buffer_or =
+      src_device_buffer->CopyToDevice(pjrt_dst_device);
+  if (!buffer_or.ok()) {
+    done(buffer_or.status());
+    return;
+  }
+
+  xla::PjRtBuffer* pjrt_buffer = (*buffer_or).get();
+
+  if (static_cast<PjRtDeviceContext*>(recv_dev_context)
+          ->use_pjrt_tensor_buffer()) {
+    // Copy the newly created tensor with PjRtTensorBuffer to output device
+    // tensor.
+    //
+    // We currently assume the PjRtBuffer is a PjRtStreamExecutorBuffer.
+    *output = MakeTensorFromPjRtStreamExecutorBuffer(
+        output->dtype(), output->shape(), std::move(*buffer_or));
+  } else {
+    AsyncValueTensor* output_tensor =
+        tensorflow::AsyncValueTensor::FromTensor(output);
+    // The result tensor should be newly allocated, which does not point to a
+    // valid buffer yet.
+    CHECK(!output_tensor->GetBuffer());  // Crash OK
+    output_tensor->SetBuffer(std::move(*buffer_or));
+  }
+  // TODO(b/244666476): evaluate the performance impact of marking ready when
+  // the data in device buffer is computed.
+  pjrt_buffer->GetReadyFuture().OnReady(std::move(done));
+}
+
 }  // namespace tensorflow

--- a/tensorflow/compiler/jit/pjrt_device_context.h
+++ b/tensorflow/compiler/jit/pjrt_device_context.h
@@ -52,7 +52,7 @@ class PjRtDeviceContext : public DeviceContext {
   bool use_pjrt_tensor_buffer_;
 };
 
-void PjRtDevice_DeviceToDeviceCopy(
+void PjRtDeviceToDeviceCopy(
     DeviceContext* send_dev_context, DeviceContext* recv_dev_context,
     Device* src, Device* dst, AllocatorAttributes src_alloc_attr,
     AllocatorAttributes dst_alloc_attr, const Tensor* input, Tensor* output,

--- a/tensorflow/compiler/jit/pjrt_device_context.h
+++ b/tensorflow/compiler/jit/pjrt_device_context.h
@@ -52,6 +52,12 @@ class PjRtDeviceContext : public DeviceContext {
   bool use_pjrt_tensor_buffer_;
 };
 
+void PjRtDevice_DeviceToDeviceCopy(
+    DeviceContext* send_dev_context, DeviceContext* recv_dev_context,
+    Device* src, Device* dst, AllocatorAttributes src_alloc_attr,
+    AllocatorAttributes dst_alloc_attr, const Tensor* input, Tensor* output,
+    int dev_to_dev_stream_index, StatusCallback done);
+
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_COMPILER_JIT_PJRT_DEVICE_CONTEXT_H_

--- a/tensorflow/core/common_runtime/pluggable_device/BUILD
+++ b/tensorflow/core/common_runtime/pluggable_device/BUILD
@@ -84,6 +84,7 @@ cc_library(
         "//tensorflow/c/experimental/stream_executor",
         "//tensorflow/c/experimental/stream_executor:stream_executor_internal",
         "//tensorflow/compiler/jit:flags_headers",
+        "//tensorflow/compiler/jit:pjrt_device_context",
         "//tensorflow/compiler/jit:xla_device_no_jit_rewrite_registration",
         "//tensorflow/compiler/xla/pjrt:pjrt_api",
         "//tensorflow/compiler/xla/stream_executor:device_mem_allocator",

--- a/tensorflow/core/common_runtime/pluggable_device/pluggable_device_plugin_init.cc
+++ b/tensorflow/core/common_runtime/pluggable_device/pluggable_device_plugin_init.cc
@@ -131,7 +131,7 @@ static Status InitNextPluggableDeviceModule(void* dso_handle) {
 
   TF_RETURN_IF_ERROR(CopyTensor::Register(
       DeviceType(device_type), DeviceType(device_type),
-      PjRtDevice_DeviceToDeviceCopy,
+      PjRtDeviceToDeviceCopy,
       /*is_pluggable_device=*/true));  // Register the Copy tensor.
 
   VLOG(1) << "Successfully initialized NextPluggableDevice module.";

--- a/tensorflow/core/common_runtime/pluggable_device/pluggable_device_plugin_init.cc
+++ b/tensorflow/core/common_runtime/pluggable_device/pluggable_device_plugin_init.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/c/experimental/pluggable_profiler/pluggable_profiler_internal.h"
 #include "tensorflow/c/experimental/stream_executor/stream_executor_internal.h"
 #include "tensorflow/compiler/jit/flags.h"
+#include "tensorflow/compiler/jit/pjrt_device_context.h"
 #include "tensorflow/compiler/jit/xla_device.h"
 #include "tensorflow/compiler/xla/pjrt/pjrt_api.h"
 #include "tensorflow/core/common_runtime/copy_tensor.h"
@@ -127,6 +128,11 @@ static Status InitNextPluggableDeviceModule(void* dso_handle) {
     VLOG(1) << "Registered XlaCompileOnDemand op for device_type: "
             << device_type;
   }
+
+  TF_RETURN_IF_ERROR(CopyTensor::Register(
+      DeviceType(device_type), DeviceType(device_type),
+      PjRtDevice_DeviceToDeviceCopy,
+      /*is_pluggable_device=*/true));  // Register the Copy tensor.
 
   VLOG(1) << "Successfully initialized NextPluggableDevice module.";
   return OkStatus();


### PR DESCRIPTION
This PR is to enable DtoD copy ViaDMA support for NextPluggableDevice. This is needed when there are multiple PjRtDevice and send/recv op will use this registered copyfunc.