### PR TITLE
Fix TOSA HardSwish Table generation for int8 inputs

### DIFF
--- a/tensorflow/compiler/mlir/tosa/BUILD
+++ b/tensorflow/compiler/mlir/tosa/BUILD
@@ -90,6 +90,7 @@ cc_library(
         "//tensorflow/core/kernels:conv_grad_shape_utils",
         "//tensorflow/lite/kernels/internal:common",
         "//tensorflow/lite/kernels/internal:quantization_util",
+        "//tensorflow/lite/kernels/internal:reference_base",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:ArithUtils",
@@ -103,6 +104,7 @@ cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TosaDialect",
         "@llvm-project//mlir:Transforms",
+        "@gemmlowp",
     ],
 )
 

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -3210,17 +3210,11 @@ LogicalResult ConvertTFLHardSwishOp::matchAndRewrite(
         output_type.getElementType()
             .dyn_cast_or_null<mlir::quant::UniformQuantizedType>();
 
-    auto hardswish_func = [](double v) -> double {
-      double w = v + 3.0;
-      w = w < 0.0 ? 0.0 : w > 6.0 ? 6.0 : w;
-      return v * w / 6.0;
-    };
-
     if (input_qtype.getStorageTypeIntegralWidth() == 8) {
       // Implement with 8-bit table lookup.
-      Value table_const = getTosaConst8bitTable(
+      Value table_const = getTosaConstHardSwish8bitTable(
           rewriter, op, input_qtype.getScale(), input_qtype.getZeroPoint(),
-          output_qtype.getScale(), output_qtype.getZeroPoint(), hardswish_func);
+          output_qtype.getScale(), output_qtype.getZeroPoint());
 
       CreateReplaceOpAndInfer<tosa::TableOp>(
           rewriter, op, output_type, tfl_hardswish_op.getInput(), table_const);

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
@@ -35,6 +35,7 @@ limitations under the License.
 #include "tensorflow/compiler/mlir/tosa/transforms/legalize_common.h"
 #include "tensorflow/lite/kernels/internal/common.h"
 #include "tensorflow/lite/kernels/internal/quantization_util.h"
+#include "tensorflow/lite/kernels/internal/reference/hard_swish.h"
 
 // Implements legalization and post-legalization optimization helper functions
 
@@ -333,6 +334,90 @@ Value getTosaConstRsqrt8bitTable(PatternRewriter& rewriter, Operation* op,
 
   for (int32_t i = -128; i < 128; i++) {
     table.push_back(quantRsqrtFunc(i));
+  }
+
+  auto element_qtype =
+      UniformQuantizedType::get(true, rewriter.getIntegerType(8),
+                                rewriter.getF32Type(), 1.0f, 0, -128, 127);
+  auto const_type = tensorflow::GetTypeFromTFTensorShape({256}, element_qtype);
+  auto storage_type = tensorflow::GetTypeFromTFTensorShape(
+      {256}, element_qtype.getStorageType());
+  auto const_attr = DenseElementsAttr::get(storage_type, llvm::ArrayRef(table));
+
+  auto const_op =
+      rewriter.create<tosa::ConstOp>(op->getLoc(), const_type, const_attr);
+  return const_op.getResult();
+}
+
+Value getTosaConstHardSwish8bitTable(PatternRewriter& rewriter, Operation* op,
+                                     float input_scale, int32_t input_zp,
+                                     float output_scale, int32_t output_zp) {
+  // Define tflite params:
+  // See: HardSwishPrepare / HardSwishParams
+  const float hires_input_scale = (1.0f / 128.0f) * input_scale;
+  const float reluish_scale = 3.0f / 32768.0f;
+  const float output_multiplier = hires_input_scale / output_scale;
+
+  int16_t output_multiplier_fixedpoint_int16;
+  int output_multiplier_exponent;
+
+  int16_t reluish_multiplier_fixedpoint_int16;
+  int reluish_multiplier_exponent;
+
+  int32_t output_multiplier_fixedpoint_int32;
+  tflite::QuantizeMultiplier(output_multiplier,
+                             &output_multiplier_fixedpoint_int32,
+                             &output_multiplier_exponent);
+  tflite::DownScaleInt32ToInt16Multiplier(output_multiplier_fixedpoint_int32,
+                                          &output_multiplier_fixedpoint_int16);
+  assert(output_multiplier_exponent <= 0);
+
+  const float reluish_multiplier = hires_input_scale / reluish_scale;
+  int32_t reluish_multiplier_fixedpoint_int32;
+
+  tflite::QuantizeMultiplier(reluish_multiplier,
+                             &reluish_multiplier_fixedpoint_int32,
+                             &reluish_multiplier_exponent);
+  tflite::DownScaleInt32ToInt16Multiplier(reluish_multiplier_fixedpoint_int32,
+                                          &reluish_multiplier_fixedpoint_int16);
+
+  // See HardSwish function in
+  // tensorflow/lite/kernels/internal/reference/hardswish.h
+  SmallVector<int8_t, 256> table;
+  for (int32_t i = -128; i < 128; i++) {
+    const int16_t input_value = i - input_zp;
+    const int16_t input_value_on_hires_input_scale = input_value * (1 << 7);
+    const int16_t input_value_on_preshift_output_scale =
+        gemmlowp::SaturatingRoundingDoublingHighMul(
+            input_value_on_hires_input_scale,
+            output_multiplier_fixedpoint_int16);
+    int16_t reluish_value = input_value_on_hires_input_scale;
+    if (reluish_multiplier_exponent > 0) {
+      reluish_value = tflite::reference_ops::SaturatingLeftShift(
+          reluish_value, reluish_multiplier_exponent - 1);
+    }
+    reluish_value = gemmlowp::SaturatingRoundingDoublingHighMul(
+        reluish_value, reluish_multiplier_fixedpoint_int16);
+    if (reluish_multiplier_exponent > 0) {
+      reluish_value =
+          tflite::reference_ops::SaturatingLeftShift(reluish_value, 1);
+    }
+    if (reluish_multiplier_exponent < 0) {
+      reluish_value = gemmlowp::RoundingDivideByPOT(
+          reluish_value, -reluish_multiplier_exponent);
+    }
+    reluish_value = (reluish_value + (1 << 15)) >> 1;
+    const int16_t preshift_output_value =
+        tflite::reference_ops::SaturatingDoublingHighMul(
+            reluish_value, input_value_on_preshift_output_scale);
+    int16_t output_value = gemmlowp::RoundingDivideByPOT(
+        preshift_output_value, -output_multiplier_exponent);
+    output_value += output_zp;
+    output_value =
+        std::min<int16_t>(output_value, std::numeric_limits<int8_t>::max());
+    output_value =
+        std::max<int16_t>(output_value, std::numeric_limits<int8_t>::min());
+    table.push_back(output_value);
   }
 
   auto element_qtype =

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
@@ -116,6 +116,11 @@ Value getTosaConstRsqrt8bitTable(PatternRewriter& rewriter, Operation* op,
                                  float input_scale, int32_t input_zp,
                                  float output_scale, int32_t output_zp);
 
+// Create an 8-bit TOSA Table constant tensor for the HardSwish operator
+Value getTosaConstHardSwish8bitTable(PatternRewriter& rewriter, Operation* op,
+                                     float input_scale, int32_t input_zp,
+                                     float output_scale, int32_t output_zp);
+
 // Create a 32-bit float constant operator from a float
 Value getTosaConstTensorSingleF32(PatternRewriter& rewriter, Operation* op,
                                   float val);


### PR DESCRIPTION
More closely match tflite kernel behaviour for integers when calculating HardSwish table


Change-Id: I32a1338fb15d3505d4bea432a8523c79d8f5da7a