### PR TITLE
Update the path to symbolic link for building mlir:tf-opt

### DIFF
--- a/tensorflow/tensorflow.bzl
+++ b/tensorflow/tensorflow.bzl
@@ -945,7 +945,7 @@ def _create_symlink(src, dest, visibility = None):
         outs = [src],
         srcs = [dest],
         output_to_bindir = 1,
-        cmd = "ln -sf $$(realpath --relative-to=$(RULEDIR) $<) $@",
+        cmd = "ln -sf $$(basename $<) $@",
         visibility = visibility,
     )
 


### PR DESCRIPTION
The symbolic link is referring to not existing path when running with `ln -sf $$(realpath --relative-to=$(RULEDIR) $<) $@` and fails. 

Fixes #60915