### PR TITLE
Run AARCH64 CI builds on pushes to release branches

### DIFF
--- a/.github/workflows/arm-cd.yml
+++ b/.github/workflows/arm-cd.yml
@@ -19,6 +19,8 @@ on:
   push:
     tags:
       - v2.**
+    branches:
+      - r2.**
   schedule:
     - cron: '0 8 * * *'
 
@@ -66,5 +68,6 @@ jobs:
           CI_DOCKER_BUILD_EXTRA_PARAMS="--build-arg py_major_minor_version=${{ matrix.pyver }} --build-arg is_nightly=${is_nightly} --build-arg tf_project_name=${tf_project_name}" \
           ./tensorflow/tools/ci_build/ci_build.sh cpu.arm64 bash tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
       - name: Upload pip wheel to PyPI
+        if: github.event_name == 'schedule' || (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) # only if it is a scheduled nightly or tagged
         shell: bash
         run: python3 -m twine upload --verbose /home/ubuntu/actions-runner/_work/tensorflow/tensorflow/whl/* -u "__token__" -p ${{ secrets.AWS_PYPI_ACCOUNT_TOKEN }}

--- a/.github/workflows/arm-cd.yml
+++ b/.github/workflows/arm-cd.yml
@@ -68,6 +68,6 @@ jobs:
           CI_DOCKER_BUILD_EXTRA_PARAMS="--build-arg py_major_minor_version=${{ matrix.pyver }} --build-arg is_nightly=${is_nightly} --build-arg tf_project_name=${tf_project_name}" \
           ./tensorflow/tools/ci_build/ci_build.sh cpu.arm64 bash tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
       - name: Upload pip wheel to PyPI
-        if: github.event_name == 'schedule' || (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) # only if it is a scheduled nightly or tagged
+        if: github.event_name == 'schedule' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v2')) # only if it is a scheduled nightly or tagged
         shell: bash
         run: python3 -m twine upload --verbose /home/ubuntu/actions-runner/_work/tensorflow/tensorflow/whl/* -u "__token__" -p ${{ secrets.AWS_PYPI_ACCOUNT_TOKEN }}


### PR DESCRIPTION
To ensure that AARCH64 builds are stable prior to a release tag, enable running the build and test pipeline for pushes to the release branch even if they are not tagged.  We prevent the uploading of the built wheel if it is not tagged with a v2 release tag. 