### PR TITLE
[Linaro:ARM_CI] Add broken test to skip list

### DIFF
--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -16,6 +16,7 @@
 set -x
 
 ARM_SKIP_TESTS="-//tensorflow/lite/... \
+-//tensorflow/compiler/xla/service/gpu:fusion_merger_test \
 -//tensorflow/python/kernel_tests/nn_ops:atrous_conv2d_test \
 -//tensorflow/python/kernel_tests/nn_ops:conv_ops_test \
 "


### PR DESCRIPTION
//tensorflow/compiler/xla/service/gpu:fusion_merger_test is broken and only works on x86 as a divide by zero is evaluated as -inf