### PR TITLE
Fix ambiguity in use of overloaded functions in XLA

### DIFF
--- a/tensorflow/compiler/xla/python/pjrt_ifrt/xla_sharding_serdes_test.cc
+++ b/tensorflow/compiler/xla/python/pjrt_ifrt/xla_sharding_serdes_test.cc
@@ -34,7 +34,8 @@ class XlaShardingSerDesTest : public test_util::ShardingTest {};
 
 TEST_P(XlaShardingSerDesTest, HloShardingRoundTrip) {
   auto device_list = GetDevices({0, 1});
-  auto xla_hlo_sharding = xla::HloSharding::Tile(xla::TileAssignment({2, 1}));
+  auto xla_hlo_sharding = xla::HloSharding::Tile(
+      xla::TileAssignment((absl::Span<const int64_t>){2, 1}));
   auto sharding = HloSharding::Create(device_list,
                                       /*xla_hlo_sharding=*/xla_hlo_sharding);
 


### PR DESCRIPTION
Cast ambiguous parameter so that it is not ambiguous and so gcc will compile it.