### PR TITLE
return assert_shapes for debugging.assert_shapes

### DIFF
--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1671,7 +1671,7 @@ def assert_shapes_v2(shapes, data=None, summarize=None, message=None,
   Raises:
     ValueError:  If static checks determine any shape constraint is violated.
   """
-  assert_shapes(
+  return assert_shapes(
       shapes, data=data, summarize=summarize, message=message, name=name)
 
 


### PR DESCRIPTION
return assert_shapes for debugging.assert_shapes.
Fixes: https://github.com/tensorflow/tensorflow/issues/61163