### PR TITLE
[oneDNN] Enable Caching Scaled Bias in QuantizedMatmul in oneDNN 3.x

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -2832,6 +2832,9 @@ void MklLayoutRewritePass::CopyAttrsQuantizedMatMulWithBiasAndDequantize(
   Node* filter_node = nullptr;
   TF_CHECK_OK(orig_node->input_node(1, &filter_node));
   nb->Attr("is_weight_const", filter_node->IsConstant());
+  Node* bias_node = nullptr;
+  TF_CHECK_OK(orig_node->input_node(2, &bias_node));
+  nb->Attr("is_bias_const", bias_node->IsConstant());
 }
 
 void MklLayoutRewritePass::CopyAttrsQuantizedMatMulWithBias(
@@ -2845,12 +2848,15 @@ void MklLayoutRewritePass::CopyAttrsQuantizedMatMulWithBias(
 
   Node* weight_node = nullptr;
   TF_CHECK_OK(orig_node->input_node(1, &weight_node));
+  Node* bias_node = nullptr;
+  TF_CHECK_OK(orig_node->input_node(2, &bias_node));
 
   // Add attributes to new node.
   nb->Attr("T1", T1);
   nb->Attr("T2", T2);
   nb->Attr("Toutput", Toutput);
   nb->Attr("is_weight_const", weight_node->IsConstant());
+  nb->Attr("is_bias_const", bias_node->IsConstant());
 
   // Requantization attr Tbias
   DataType Tbias;

--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -62,6 +62,7 @@ tf_mkl_kernel_library(
     srcs = ["mkl_batch_matmul_op.cc"],
     hdrs = [
         "mkl_batch_matmul_helper.h",
+        "mkl_kernel_util.h",
         "mkl_matmul_ops_common.h",
     ],
     deps = [
@@ -75,6 +76,7 @@ tf_mkl_kernel_library(
     srcs = ["mkl_einsum_op.cc"],
     hdrs = [
         "mkl_batch_matmul_helper.h",
+        "mkl_kernel_util.h",
         "mkl_matmul_ops_common.h",
     ],
     deps = [
@@ -88,7 +90,10 @@ tf_mkl_kernel_library(
         "mkl_matmul_op.cc",
         "mkl_matmul_op_fused.cc",
     ],
-    hdrs = ["mkl_matmul_ops_common.h"],
+    hdrs = [
+        "mkl_kernel_util.h",
+        "mkl_matmul_ops_common.h",
+    ],
     deps = MKL_DEPS,
 )
 
@@ -204,6 +209,7 @@ tf_mkl_kernel_library(
     name = "mkl_qmatmul_op",
     srcs = ["mkl_qmatmul_op.cc"],
     hdrs = [
+        "mkl_kernel_util.h",
         "mkl_matmul_ops_common.h",
         "mkl_quantized_conv_ops.h",
     ],

--- a/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
@@ -852,7 +852,6 @@ TEST_F(FilterCacheTest, Conv2DFilterCacheTest) {
   Run<float>(DT_FLOAT, image, filter, expected, true);
 }
 
-#ifndef ENABLE_ONEDNN_V3
 // Testing fusion of MatMul and BiasAdd
 template <typename T>
 class MklFusedMatMulOpTest : public OpsTestBase {
@@ -1128,7 +1127,6 @@ TEST_F(MklFusedMatMulCacheTest, WeightCachedTrue) { Run(true); }
 
 // Test that a non-const filter can not be cached.
 TEST_F(MklFusedMatMulCacheTest, WeightCachedFalse) { Run(false); }
-#endif  // !ENABLE_ONEDNN_V3
 
 class BiasCacheTest : public OpsTestBase {
  public:

--- a/tensorflow/core/kernels/mkl/mkl_kernel_util.h
+++ b/tensorflow/core/kernels/mkl/mkl_kernel_util.h
@@ -18,9 +18,12 @@ limitations under the License.
 
 #ifdef INTEL_MKL
 
+#include "dnnl.hpp"
 #include "tensorflow/core/graph/testlib.h"
 #include "tensorflow/core/public/session.h"
 #include "tensorflow/tsl/platform/status.h"
+
+using dnnl::memory;
 
 namespace tensorflow {
 

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -239,9 +239,12 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
       if (weight_md != matmul_pd->weights_desc()) {
         T* cached_weight_data = nullptr;
 
-#ifndef ENABLE_ONEDNN_V3
-        // TODO(intel-tf): Enable weight caching for oneDNN v3.x
         if (this->is_weight_const_) {
+          // TODO(intel-tf): When oneDNN major version changes to v4.x, weight
+          // caching may not work as expected if the underlying memory
+          // descriptor has changed (i.e. compared to v3.x). We have to return
+          // a status here to catch oneDNN major version change to avoid
+          // unexpected results.
           if (this->IsWeightCacheEmpty(ctx)) {
             this->CacheWeight(ctx, matmul_pd, cached_weight_data, weight_tensor,
                               weight_mkl, weight_md);
@@ -249,7 +252,6 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
           cached_weight_data =
               this->GetCachedWeight(ctx, matmul_pd->weights_desc());
         }
-#endif  // !ENABLE_ONEDNN_V3
 
         // Cache weight may fail when it gets different format in different
         // iteration. Fallback to reoder if it happens.

--- a/tensorflow/core/kernels/mkl/mkl_qmatmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_qmatmul_op.cc
@@ -169,6 +169,11 @@ class MklDnnQuantizedMatMulOp
       OP_REQUIRES_OK(context, context->GetAttr("is_weight_const",
                                                &(this->is_weight_const_)));
     }
+    this->is_bias_const_ = false;
+    if (context->HasAttr("is_bias_const")) {
+      OP_REQUIRES_OK(
+          context, context->GetAttr("is_bias_const", &(this->is_bias_const_)));
+    }
   }
 
   void Compute(OpKernelContext* context) override {
@@ -281,9 +286,6 @@ class MklDnnQuantizedMatMulOp
         // TF default format is IO. So in that case convert weight from IO
         // to OI for the first iteration and cache it to reuse in the
         // subsequent iterations, if the weight is constant.
-#ifndef ENABLE_ONEDNN_V3
-        // TODO(intel-tf): enable weight caching once it is enabled in the base
-        // class.
         if (this->is_weight_const_) {
           // Check if the weight is already cached or not
           if (this->IsWeightCacheEmpty(context)) {
@@ -295,7 +297,6 @@ class MklDnnQuantizedMatMulOp
               this->GetCachedWeight(context, matmul_fwd_pd->weights_desc());
           is_weight_cached = (weight_data != nullptr);
         }
-#endif  // !ENABLE_ONEDNN_V3
         if (!is_weight_cached) {
           weight.SetUsrMem(weight_md, &weight_tensor);
           weight.CheckReorderToOpMem(matmul_fwd_pd.get()->weights_desc(),
@@ -633,88 +634,120 @@ class MklDnnQuantizedMatMulOp
 
       std::vector<dnnl::primitive> net;
       float out_scale;
-      auto scaled_bias_md = mkldnn_matmul_fwd_pd->bias_desc();
-      TensorShape scaled_bias_shape;
-      scaled_bias_shape.AddDim(
-          (scaled_bias_md.get_size() / sizeof(TSCALED_BIAS)));
-      OP_REQUIRES_OK(context, context->allocate_temp(
-                                  DataTypeToEnum<TSCALED_BIAS>::v(),
-                                  scaled_bias_shape, temp_scaled_bias_tensor));
-      void* scaled_bias_buf = static_cast<void*>(
-          temp_scaled_bias_tensor->flat<TSCALED_BIAS>().data());
-      // If the bias is float and input quantize is MIN_FIRST, bias has to be
-      // compensated with B's32 = Q'a * Qw * Bf32 + Q'a * Qw * Min(Af32) * 1 *
-      // Wf32.
-      if (mode_ == QUANTIZE_MODE_MIN_FIRST) {
-        int k = weight_tensor.dim_size(0);
-        int n = weight_tensor.dim_size(1);
-        TSCALED_BIAS* comp_bias = (TSCALED_BIAS*)scaled_bias_buf;
 
-        qint8* wt_buf = static_cast<qint8*>(
-            const_cast<qint8*>(weight_tensor.flat<qint8>().data()));
-
-        const Tbias* bias_buf = static_cast<Tbias*>(
-            const_cast<Tbias*>(bias_tensor.flat<Tbias>().data()));
-
-        float qa_amin = 255 * min_input / (max_input - min_input);
-
-        out_scale = (255.0 * 127.0) /
-                    ((max_input - min_input) *
-                     std::max(std::abs(max_weight), std::abs(min_weight)));
-        for (int j = 0; j < n; ++j) {
-          int x = 0;
-          for (int i = 0; i < k; ++i) {
-            x += wt_buf[i * n + j];
-          }
-          if (std::is_same<Tbias, qint32>::value) {
-            // Starting with oneDNN v3.0, bias is expected to be dequantized to
-            // float32.
-            comp_bias[j] = static_cast<float>(bias_buf[j]) / out_scale;
-          } else {
-            // Bias is float32 but still needs to be compensated.
-            comp_bias[j] = static_cast<float>(bias_buf[j]) + (x * qa_amin);
-          }
-        }
-      } else if (mode_ == QUANTIZE_MODE_SCALED) {
-        // For oneDNN >= v3.0, if bias is qint32 and input quantization
-        // mode is SCALED, bias needs to be dequantized to float32.
-        out_scale =
-            255.0 * 127.0 /
-            (max_input * std::max(std::abs(max_weight), std::abs(min_weight)));
-
-        std::vector<float> scales;
-        scales.push_back(out_scale);
-        dnnl::primitive_attr bias_attr;
-        void* bias_buf = static_cast<void*>(
-            const_cast<Tbias*>(bias_tensor.flat<Tbias>().data()));
-        bias_attr.set_scales_mask(DNNL_ARG_DST, 0);
-        auto input_bias_mem =
-            memory({{static_cast<int>(bias_tensor.NumElements())},
-                    MklDnnType<Tbias>(),
-                    memory::format_tag::x},
-                   this->cpu_engine_, bias_buf);
-        auto scaled_bias_mem = memory(mkldnn_matmul_fwd_pd->bias_desc(),
-                                      this->cpu_engine_, scaled_bias_buf);
-
-        auto reorder_desc = dnnl::reorder::primitive_desc(
-            input_bias_mem, scaled_bias_mem, bias_attr);
-        net.push_back(dnnl::reorder(reorder_desc));
-        std::unordered_map<int, memory> reorder_net_args = {
-            {DNNL_ARG_FROM, input_bias_mem}, {DNNL_ARG_TO, scaled_bias_mem}};
-        auto scale_mem =
-            memory({{1}, MklDnnType<float>(), memory::format_tag::x},
-                   this->cpu_engine_, scales.data());
-        reorder_net_args.insert(
-            {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, scale_mem});
-        std::vector<MemoryArgsMap> net_args{reorder_net_args};
-        ExecutePrimitive(net, &net_args, this->cpu_engine_, context);
-      } else {
-        context->CtxFailure(absl::InvalidArgumentError(
-            "Quantization mode must be either MIN_FIRST or SCALED."));
+      bool is_cached_bias_valid = false;
+      bool is_bias_cache_empty = this->IsBiasCacheEmpty();
+      if (!is_bias_cache_empty) {
+        this->GetCachedBias(min_input, max_input, bias_data);
+        is_cached_bias_valid = (*bias_data != nullptr);
       }
-      *bias_data = static_cast<void*>(
-          temp_scaled_bias_tensor->flat<TSCALED_BIAS>().data());
+      if (!is_cached_bias_valid) {
+        auto scaled_bias_md = mkldnn_matmul_fwd_pd->bias_desc();
+        TensorShape scaled_bias_shape;
+        scaled_bias_shape.AddDim(
+            (scaled_bias_md.get_size() / sizeof(TSCALED_BIAS)));
+        OP_REQUIRES_OK(
+            context,
+            context->allocate_temp(DataTypeToEnum<TSCALED_BIAS>::v(),
+                                   scaled_bias_shape, temp_scaled_bias_tensor));
+        void* scaled_bias_buf = static_cast<void*>(
+            temp_scaled_bias_tensor->flat<TSCALED_BIAS>().data());
+        // If the bias is float and input quantize is MIN_FIRST, bias has to be
+        // compensated with B's32 = Q'a * Qw * Bf32 + Q'a * Qw * Min(Af32) * 1 *
+        // Wf32.
+        if (mode_ == QUANTIZE_MODE_MIN_FIRST) {
+          int k = weight_tensor.dim_size(0);
+          int n = weight_tensor.dim_size(1);
+          TSCALED_BIAS* comp_bias = (TSCALED_BIAS*)scaled_bias_buf;
+
+          qint8* wt_buf = static_cast<qint8*>(
+              const_cast<qint8*>(weight_tensor.flat<qint8>().data()));
+
+          const Tbias* bias_buf = static_cast<Tbias*>(
+              const_cast<Tbias*>(bias_tensor.flat<Tbias>().data()));
+
+          float qa_amin = 255 * min_input / (max_input - min_input);
+
+          out_scale = (255.0 * 127.0) /
+                      ((max_input - min_input) *
+                       std::max(std::abs(max_weight), std::abs(min_weight)));
+          for (int j = 0; j < n; ++j) {
+            int x = 0;
+            for (int i = 0; i < k; ++i) {
+              x += wt_buf[i * n + j];
+            }
+            if (std::is_same<Tbias, qint32>::value) {
+              // Starting with oneDNN v3.0, bias is expected to be dequantized
+              // to float32.
+              comp_bias[j] = static_cast<float>(bias_buf[j]) / out_scale;
+            } else {
+              // Bias is float32 but still needs to be compensated.
+              comp_bias[j] = static_cast<float>(bias_buf[j]) + (x * qa_amin);
+            }
+          }
+        } else if (mode_ == QUANTIZE_MODE_SCALED) {
+          // For oneDNN >= v3.0, if bias is qint32 and input quantization
+          // mode is SCALED, bias needs to be dequantized to float32.
+          out_scale = 255.0 * 127.0 /
+                      (max_input *
+                       std::max(std::abs(max_weight), std::abs(min_weight)));
+
+          std::vector<float> scales;
+          scales.push_back(out_scale);
+          dnnl::primitive_attr bias_attr;
+          void* bias_buf = static_cast<void*>(
+              const_cast<Tbias*>(bias_tensor.flat<Tbias>().data()));
+          bias_attr.set_scales_mask(DNNL_ARG_DST, 0);
+          auto input_bias_mem =
+              memory({{static_cast<int>(bias_tensor.NumElements())},
+                      MklDnnType<Tbias>(),
+                      memory::format_tag::x},
+                     this->cpu_engine_, bias_buf);
+          auto scaled_bias_mem = memory(mkldnn_matmul_fwd_pd->bias_desc(),
+                                        this->cpu_engine_, scaled_bias_buf);
+
+          auto reorder_desc = dnnl::reorder::primitive_desc(
+              input_bias_mem, scaled_bias_mem, bias_attr);
+          net.push_back(dnnl::reorder(reorder_desc));
+          std::unordered_map<int, memory> reorder_net_args = {
+              {DNNL_ARG_FROM, input_bias_mem}, {DNNL_ARG_TO, scaled_bias_mem}};
+          auto scale_mem =
+              memory({{1}, MklDnnType<float>(), memory::format_tag::x},
+                     this->cpu_engine_, scales.data());
+          reorder_net_args.insert(
+              {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, scale_mem});
+          std::vector<MemoryArgsMap> net_args{reorder_net_args};
+          ExecutePrimitive(net, &net_args, this->cpu_engine_, context);
+        } else {
+          context->CtxFailure(
+              absl::InvalidArgumentError("Quantization mode must be"
+                                         "either MIN_FIRST or SCALED."));
+        }
+
+        *bias_data = static_cast<void*>(
+            temp_scaled_bias_tensor->flat<TSCALED_BIAS>().data());
+        if (is_bias_cache_empty) {
+          // Only try to cache the bias in the first iteration.
+          this->CacheBias(context, *temp_scaled_bias_tensor, min_input,
+                          max_input, &saved_min_input_, &saved_max_input_);
+        }
+      }
     }
+  }
+
+  // This method checks if cached bias is valid or not. Cached bias is valid
+  // when its scale has not changed. Bias's scale depends on min_input,
+  // max_input, min_weight and max_weight. If weight is const, we only need to
+  // check min_input and max_input. Note that becuase of offline calibration,
+  // usually these values don't chagne but it is still better to validate them.
+  bool IsCachedBiasValid(float current_min_input,
+                         float current_max_input) override {
+    if (this->is_bias_const_ && this->is_weight_const_ &&
+        std::abs(current_min_input - saved_min_input_) < 1e-5 &&
+        std::abs(current_max_input - saved_max_input_) < 1e-5) {
+      return true;
+    }
+    return false;
   }
 #endif  // ENABLE_ONEDNN_V3
 
@@ -726,6 +759,8 @@ class MklDnnQuantizedMatMulOp
   float* comp_bias_ = nullptr;
 
   int mode_;
+  float saved_min_input_ = -std::numeric_limits<float>::infinity();
+  float saved_max_input_ = std::numeric_limits<float>::infinity();
 };
 
 template <typename Device, typename Tinput, typename Tweight, typename Tbias,

--- a/tensorflow/core/kernels/mkl/mkl_qmatmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_qmatmul_op.cc
@@ -729,7 +729,7 @@ class MklDnnQuantizedMatMulOp
         if (is_bias_cache_empty) {
           // Only try to cache the bias in the first iteration.
           this->CacheBias(context, *temp_scaled_bias_tensor, min_input,
-                          max_input, &saved_min_input_, &saved_max_input_);
+                          max_input);
         }
       }
     }
@@ -743,8 +743,8 @@ class MklDnnQuantizedMatMulOp
   bool IsCachedBiasValid(float current_min_input,
                          float current_max_input) override {
     if (this->is_bias_const_ && this->is_weight_const_ &&
-        std::abs(current_min_input - saved_min_input_) < 1e-5 &&
-        std::abs(current_max_input - saved_max_input_) < 1e-5) {
+        std::abs(current_min_input - this->saved_min_input_) < 1e-5 &&
+        std::abs(current_max_input - this->saved_max_input_) < 1e-5) {
       return true;
     }
     return false;
@@ -759,8 +759,6 @@ class MklDnnQuantizedMatMulOp
   float* comp_bias_ = nullptr;
 
   int mode_;
-  float saved_min_input_ = -std::numeric_limits<float>::infinity();
-  float saved_max_input_ = std::numeric_limits<float>::infinity();
 };
 
 template <typename Device, typename Tinput, typename Tweight, typename Tbias,

--- a/tensorflow/core/ops/mkl_nn_ops.cc
+++ b/tensorflow/core/ops/mkl_nn_ops.cc
@@ -1264,6 +1264,7 @@ REGISTER_OP("_MklQuantizedMatMulWithBias")
     .Attr("transpose_b: bool = false")
     .Attr("input_quant_mode: {'MIN_FIRST', 'SCALED'} = 'MIN_FIRST'")
     .Attr("is_weight_const: bool = true")
+    .Attr("is_bias_const: bool = true")
     .SetShapeFn([](InferenceContext* c) {
       TF_RETURN_IF_ERROR(shape_inference::MatMulShape(c));
       ShapeHandle unused;
@@ -1297,6 +1298,7 @@ REGISTER_OP("_MklQuantizedMatMulWithBiasAndRelu")
     .Attr("transpose_b: bool = false")
     .Attr("input_quant_mode: {'MIN_FIRST', 'SCALED'} = 'MIN_FIRST'")
     .Attr("is_weight_const: bool = true")
+    .Attr("is_bias_const: bool = true")
     .SetShapeFn([](InferenceContext* c) {
       TF_RETURN_IF_ERROR(shape_inference::MatMulShape(c));
       ShapeHandle unused;
@@ -1332,6 +1334,7 @@ REGISTER_OP("_MklQuantizedMatMulWithBiasAndReluAndRequantize")
     .Attr("transpose_b: bool = false")
     .Attr("input_quant_mode: {'MIN_FIRST', 'SCALED'} = 'MIN_FIRST'")
     .Attr("is_weight_const: bool = true")
+    .Attr("is_bias_const: bool = true")
     .SetShapeFn([](InferenceContext* c) {
       TF_RETURN_IF_ERROR(shape_inference::MatMulShape(c));
       ShapeHandle unused;
@@ -1367,6 +1370,7 @@ REGISTER_OP("_MklQuantizedMatMulWithBiasAndDequantize")
     .Attr("transpose_b: bool = false")
     .Attr("input_quant_mode: {'MIN_FIRST', 'SCALED'} = 'MIN_FIRST'")
     .Attr("is_weight_const: bool = true")
+    .Attr("is_bias_const: bool = true")
     .SetShapeFn([](InferenceContext* c) {
       TF_RETURN_IF_ERROR(shape_inference::MatMulShape(c));
       ShapeHandle unused;
@@ -1402,6 +1406,7 @@ REGISTER_OP("_MklQuantizedMatMulWithBiasAndRequantize")
     .Attr("transpose_b: bool = false")
     .Attr("input_quant_mode: {'MIN_FIRST', 'SCALED'} = 'MIN_FIRST'")
     .Attr("is_weight_const: bool = true")
+    .Attr("is_bias_const: bool = true")
     .SetShapeFn([](InferenceContext* c) {
       TF_RETURN_IF_ERROR(shape_inference::MatMulShape(c));
       ShapeHandle unused;


### PR DESCRIPTION
- oneDNN v3.x requires Bias to be passed as float in QuantizedMatMul. There are some models that have Bias as QINT32. So we convert that Bias to float with proper scaling. This PR caches the scaled bias in the first iteration to avoid doing that conversion in subsequent iterations.

- This PR also enables weight caching for MatMul op with oneDNN v3.x.

- This PR does not change common (non-oneDNN) TF code.