### PR TITLE
[oneDNN] Fix for swish and mish fusion 

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -1860,6 +1860,18 @@ bool FindSigmoidAndMul(RemapperContext* ctx, int node_index,
       sigmoidmul_pattern, {}, ctx->graph_view.GetNode(node_index),
       matched_nodes_map, remove_node_indices);
 
+  if (found_op_type_match) {
+    NodeDef* matched_sigmoid_node =
+        ctx->graph_view.GetNode(matched_nodes_map->at("sigmoid"))->node();
+    auto in_tensor_sigmoid = matched_sigmoid_node->input(0);
+    if ((mul_node_def->input(0) != in_tensor_sigmoid) &&
+        (mul_node_def->input(1) != in_tensor_sigmoid)) {
+      // If the input tensor of Sigmoid doesn't match with either of input
+      // tensors of mul return false
+      found_op_type_match = false;
+    }
+  }
+
   return found_op_type_match;
 }
 
@@ -4184,6 +4196,18 @@ bool FindSoftplusAndTanhAndMul(RemapperContext* ctx, int node_index,
   found_op_type_match = graph_matcher.GetMatchedNodes(
       softplustanhmul_pattern, {}, ctx->graph_view.GetNode(node_index),
       matched_nodes_map, remove_node_indices);
+
+  if (found_op_type_match) {
+    NodeDef* matched_softplus_node =
+        ctx->graph_view.GetNode(matched_nodes_map->at("softplus"))->node();
+    auto in_tensor_softplus = matched_softplus_node->input(0);
+    if ((mul_node_def->input(0) != in_tensor_softplus) &&
+        (mul_node_def->input(1) != in_tensor_softplus)) {
+      // If the input tensor of Softplus doesn't match with either of input
+      // tensors of mul return false
+      found_op_type_match = false;
+    }
+  }
 
   return found_op_type_match;
 }


### PR DESCRIPTION
With the current pattern matching we have for Swish fusion in [remapper.cc ](https://github.com/tensorflow/tensorflow/blob/1cd941acb2ccd4582a52a223a11ebc8288c27fae/tensorflow/core/grappler/optimizers/remapper.cc#L1834), it will fuse ops into 'Swish' op if one of the inputs to 'Mul' is from same op as the input to Sigmoid. However in the case reported in https://github.com/tensorflow/tensorflow/issues/60941

![image](https://github.com/tensorflow/tensorflow/assets/43043975/df9d8b88-bc5b-4c1f-97d2-501e4974b8f4)

the ops should not be fused, as in this case 'Split' op has two outputs. The fix for this corner case is to make sure not only the input ops match, but the tensors also should match. The same issue will be there in 'Mish' fusion also. This PR also includes a fix for 'Mish' fusion.