### PR TITLE
[oneDNN] Fix failing resnet50 benchmark tests with V2

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
@@ -236,14 +236,14 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
         const int64_t out_backprop_depth = grad_tensor.dim_size(3);
         int64_t out_height, out_width, pad_rows, pad_cols;
         OP_REQUIRES_OK(
-            context, GetWindowedOutputSize(in_rows, window_rows, row_stride,
-                                           /*dilation_rate=*/1, this->padding_,
-                                           &out_height, &pad_rows));
+            context, GetWindowedOutputSize(
+                         in_rows, window_rows, /*dilation_rate=*/1, row_stride,
+                         this->padding_, &out_height, &pad_rows));
 
         OP_REQUIRES_OK(
-            context, GetWindowedOutputSize(in_cols, window_cols, col_stride,
-                                           /*dilation_rate=*/1, this->padding_,
-                                           &out_width, &pad_cols));
+            context, GetWindowedOutputSize(
+                         in_cols, window_cols, /*dilation_rate=*/1, col_stride,
+                         this->padding_, &out_width, &pad_cols));
 
         for (int64_t r = 0; r < out_backprop_rows; ++r) {
           int rindex, rsize;


### PR DESCRIPTION
This PR fixes the following 2 benchmark tests with v2
//tensorflow/python/eager/benchmarks/resnet50:resnet50_test_cpu
//tensorflow/python/eager/benchmarks/resnet50:hvp_test_cpu

The failure started after this commit: https://github.com/tensorflow/tensorflow/commit/b44d7918070a2a192645af7b0c96b0c4e399161e 