### PR TITLE
Update Jax to TFLite example to use Jax2TF

### DIFF
--- a/tensorflow/lite/g3doc/examples/jax_conversion/overview.ipynb
+++ b/tensorflow/lite/g3doc/examples/jax_conversion/overview.ipynb
@@ -258,13 +258,54 @@
       "execution_count": null,
       "outputs": []
     },
+ {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7Y1OZBhfQhOj"
+      },
+      "source": [
+        "## (Option 1) Convert to TFLite model using `jax2tf`.\n",
+        "Note here, we use  \n",
+        "1. Inline the params to the Jax `predict` func with `functools.partial`.\n",
+        "2. Call `jax2tf`:\n",
+        "> * The `serving_func` is passed to the jax2tf wrapped in the `tf.function` with input signature.\n",
+        "3. Get the concrete function and use `from_concrete_functions` to convert into TFLite model.\n",
+        "\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "6pcqKZqdNTmn"
+      },
+      "source": [
+        "from jax.experimental import jax2tf\n",
+        "\n",
+        "serving_func = functools.partial(predict, params)\n",
+        "\n",
+        "tfmodel = tf.function(jax2tf.convert(serving_func,enable_xla=False),input_signature=[\n",
+        "        tf.TensorSpec(shape=[1, 28, 28], dtype=tf.float32, name='input')\n",
+        "    ],\n",
+        "    autograph=False)\n",
+        "concrete_func = tfmodel.get_concrete_function()\n",
+        "converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func],tfmodel)\n",
+        "\n",
+        "tflite_model = converter.convert()\n",
+        "with open('jax_mnist.tflite', 'wb') as f:\n",
+        "  f.write(tflite_model)"
+      ],
+      "execution_count": 16,
+      "outputs": []
+    },
     {
       "cell_type": "markdown",
       "metadata": {
         "id": "7Y1OZBhfQhOj"
       },
       "source": [
-        "## Convert to TFLite model.\n",
+        "## (Option 2) Convert to TFLite model using `experimental_from_jax`.\n",
         "Note here, we\n",
         "1. Inline the params to the Jax `predict` func with `functools.partial`.\n",
         "2. Build a `jnp.zeros`, this is a \"placeholder\" tensor used for Jax to trace the model.\n",
@@ -349,9 +390,12 @@
         "    x = train_images[i:i+1]\n",
         "    yield [x]\n",
         "\n",
-        "converter = tf.lite.TFLiteConverter.experimental_from_jax(\n",
-        "    [serving_func], [[('x', x_input)]])\n",
-        "tflite_model = converter.convert()\n",
+        "tfmodel = tf.function(jax2tf.convert(serving_func,enable_xla=False),input_signature=[\n",
+        "        tf.TensorSpec(shape=[1, 28, 28], dtype=tf.float32, name='input')\n",
+        "    ],\n",
+        "    autograph=False)\n",
+        "concrete_func = tfmodel.get_concrete_function()\n",
+        "converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func],tfmodel)\n",
         "converter.optimizations = [tf.lite.Optimize.DEFAULT]\n",
         "converter.representative_dataset = representative_dataset\n",
         "converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS_INT8]\n",


### PR DESCRIPTION
The nightly versions says `experimental_from_jax` is deprecated and `Jax2TF` is recommended way of converting the Jax models to TFLite. 

Added an option in the example to use `Jax2TF` for TFLite conversion using concrete functions.

Thanks.