### PR TITLE
[INTEL oneDNN][Bug Fix]Use correct data type for dim size

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -456,9 +456,8 @@ class MklConvFwdPrimitive : public MklPrimitive {
         } else if (post_op_param.name == "wei_scale") {
           is_scale_set.insert({"wei", true});
           const int scale_size = post_op_param.param.size();
-          const int mask = scale_size == 1            ? 0
-                           : convFwdDims.is_depthwise ? 3
-                                                      : 1;
+          const int mask =
+              scale_size == 1 ? 0 : convFwdDims.is_depthwise ? 3 : 1;
           post_ops_attr.set_scales_mask(DNNL_ARG_WEIGHTS, mask);
           context_.wei_scale_md.reset(new memory::desc(
               {scale_size}, MklDnnType<float>(), memory::format_tag::x));
@@ -1786,8 +1785,8 @@ class MklFusedConvOp
     Eigen::Tensor<Tinput, 1, Eigen::RowMajor> bn_rsqrt =
         (bn_var_tensor.flat<Tinput>() + static_cast<Tinput>(epsilon)).rsqrt();
     Tinput* bn_rsqrt_data = bn_rsqrt.data();
-    size_t num_elem = bn_var_tensor.shape().dim_size(0);
-    for (size_t i = 0; i < num_elem; i++) {
+    int64_t num_elem = bn_var_tensor.shape().dim_size(0);
+    for (int64_t i = 0; i < num_elem; i++) {
       scale_buf_ptr[i] = bn_rsqrt_data[i];
     }
     return;

--- a/tensorflow/core/kernels/mkl/mkl_fused_instance_norm_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_instance_norm_op.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #ifdef INTEL_MKL
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "dnnl.hpp"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
@@ -23,6 +22,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/tensor_format.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 using namespace dnnl;
 using dnnl::batch_normalization_forward;
@@ -80,7 +80,7 @@ class MklFusedInstanceNormOp : public OpKernel {
       std::shared_ptr<stream> engine_stream_ptr;
       engine_stream_ptr.reset(CreateStream(&eigen_tp, cpu_engine_));
 
-      const int batch_size = src_tensor.shape().dim_size(0);
+      const int64_t batch_size = src_tensor.shape().dim_size(0);
       const int64_t elems_per_batch =
           src_tensor.shape().num_elements() / batch_size;
 

--- a/tensorflow/core/kernels/mkl/mkl_layer_norm_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_layer_norm_op.cc
@@ -15,7 +15,6 @@ limitations under the License.
 
 #ifdef INTEL_MKL
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "dnnl.hpp"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/register_types.h"
@@ -23,6 +22,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_types.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/tensor_format.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 
 using CPUDevice = Eigen::ThreadPoolDevice;
 using dnnl::layer_normalization_forward;
@@ -53,8 +53,8 @@ class MklLayerNormOp : public OpKernel {
       OP_REQUIRES(ctx, shift_tensor.dims() == 1,
                   errors::InvalidArgument("offset must be 1D tensor",
                                           shift_tensor.shape().DebugString()));
-      size_t num_elements_scale = scale_tensor.dim_size(0);
-      size_t num_elements_shift = shift_tensor.dim_size(0);
+      int64_t num_elements_scale = scale_tensor.dim_size(0);
+      int64_t num_elements_shift = shift_tensor.dim_size(0);
       OP_REQUIRES(
           ctx, num_elements_scale == num_elements_shift,
           errors::InvalidArgument("Number of elements in scale and shift",

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -99,10 +99,10 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
     // Get dimension size of each matrix, dim_pair[] is the location of k
     // in the inputs, we have constraint that k of the two inputs are
     // the same
-    const int dim_pair[] = {1, transpose_b_ ? 1 : 0};
-    const int batch = src_tf_shape.dim_size(1 - dim_pair[0]);
-    const int k = src_tf_shape.dim_size(dim_pair[0]);
-    const int channel = weight_tf_shape.dim_size(1 - dim_pair[1]);
+    const int64_t dim_pair[] = {1, transpose_b_ ? 1 : 0};
+    const int64_t batch = src_tf_shape.dim_size(1 - dim_pair[0]);
+    const int64_t k = src_tf_shape.dim_size(dim_pair[0]);
+    const int64_t channel = weight_tf_shape.dim_size(1 - dim_pair[1]);
 
     OP_REQUIRES(
         ctx, k == weight_tf_shape.dim_size(dim_pair[1]),

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -79,7 +79,7 @@ inline bool ExecuteSingleThreadedGemm(int64_t m, int64_t n, int64_t k,
   constexpr float kHeuristicMultiplier = 1.01;
   const float mul_size = bytes * (m * n + k * (m + n));
   const float l2_heur = l2_size * kHeuristicMultiplier;
-  return (!(mul_size < 0) && (mul_size < l2_heur));
+  return (mul_size >= 0 && mul_size < l2_heur);
 }
 
 // This structure aggregates multiple inputs to MklDnnMatMul* methods.

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -21,12 +21,12 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #include "dnnl.hpp"
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/onednn_env_vars.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
 #ifdef DNNL_AARCH64_USE_ACL
 #include "tensorflow/core/platform/mutex.h"
 #endif
@@ -79,7 +79,7 @@ inline bool ExecuteSingleThreadedGemm(int64_t m, int64_t n, int64_t k,
   constexpr float kHeuristicMultiplier = 1.01;
   const float mul_size = bytes * (m * n + k * (m + n));
   const float l2_heur = l2_size * kHeuristicMultiplier;
-  return mul_size < l2_heur;
+  return (!(mul_size < 0) && (mul_size < l2_heur));
 }
 
 // This structure aggregates multiple inputs to MklDnnMatMul* methods.

--- a/tensorflow/core/kernels/mkl/mkl_qmatmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_qmatmul_op.cc
@@ -536,8 +536,8 @@ class MklDnnQuantizedMatMulOp
       // compensated with B's32 = Q'a * Qw * Bf32 + Q'a * Qw * Min(Af32) * 1 *
       // Wf32.
       if (mode_ == QUANTIZE_MODE_MIN_FIRST) {
-        int k = weight_tensor.dim_size(0);
-        int n = weight_tensor.dim_size(1);
+        int64_t k = weight_tensor.dim_size(0);
+        int64_t n = weight_tensor.dim_size(1);
         float* comp_bias = GetCompBiasBuffer(n);
 
         qint8* wt_buf = static_cast<qint8*>(
@@ -553,10 +553,10 @@ class MklDnnQuantizedMatMulOp
                      std::max(std::abs(max_weight), std::abs(min_weight)));
 
 #ifndef ENABLE_ONEDNN_OPENMP
-        auto parallel_func = [&](int64 start, int64 end) {
-          for (int64 j = start; j < end; j++) {
-            int x = 0;
-            for (int64 i = 0; i < k; ++i) {
+        auto parallel_func = [&](int64_t start, int64_t end) {
+          for (int64_t j = start; j < end; j++) {
+            int64_t x = 0;
+            for (int64_t i = 0; i < k; ++i) {
               x += wt_buf[i * n + j];
             }
             comp_bias[j] =
@@ -573,9 +573,9 @@ class MklDnnQuantizedMatMulOp
               parallel_func);
 #else
 #pragma omp parallel for schedule(static)
-        for (int j = 0; j < n; ++j) {
-          int x = 0;
-          for (int i = 0; i < k; ++i) {
+        for (int64_t j = 0; j < n; ++j) {
+          int64_t x = 0;
+          for (int64_t i = 0; i < k; ++i) {
             x += wt_buf[i * n + j];
           }
           comp_bias[j] =


### PR DESCRIPTION
This is a follow-up PR of https://github.com/tensorflow/tensorflow/pull/60568

This PR makes sure that all occurrences of dim size usage is tied with int64_t data type (versus int)
within all oneDNN kernel op implementation.