### PR TITLE
[TFLite] Align register_ref.cc TRANSPOSE_CONV max version to the register.cc one

### DIFF
--- a/tensorflow/lite/kernels/register_ref.cc
+++ b/tensorflow/lite/kernels/register_ref.cc
@@ -403,7 +403,7 @@ BuiltinRefOpResolver::BuiltinRefOpResolver() {
   AddBuiltin(BuiltinOperator_COS, Register_COS());
   AddBuiltin(BuiltinOperator_TRANSPOSE_CONV, Register_TRANSPOSECONV_REF(),
              /* min_version = */ 1,
-             /* max_version = */ 3);
+             /* max_version = */ 4);
   AddBuiltin(BuiltinOperator_TILE, Register_TILE(),
              /* min_version = */ 1,
              /* max_version = */ 2);


### PR DESCRIPTION
Hi,

Commit https://github.com/tensorflow/tensorflow/commit/1eb92f086261f37605986c521e5a14fd610568c6 added support for fused activation in the `TRANSPOSE_CONV` and updated both the optimized and reference kernels. It forgot though to update the `register_ref` for the operator. 
This PR fixes that so that we can use the reference kernels `OpResolverType.BUILTIN_REF` on models with `TRANSPOSE_CONV` having a fused activation.