### PR TITLE
[NextPluggableDevice] Add TF_TemporaryVariable C API

### DIFF
--- a/tensorflow/c/kernels_experimental.cc
+++ b/tensorflow/c/kernels_experimental.cc
@@ -23,9 +23,11 @@ limitations under the License.
 #include "tensorflow/c/tf_status_helper.h"
 #include "tensorflow/c/tf_status_internal.h"
 #include "tensorflow/c/tf_tensor_internal.h"
+#include "tensorflow/core/framework/control_flow.h"
 #include "tensorflow/core/framework/ref_var.h"
 #include "tensorflow/core/framework/resource_mgr.h"
 #include "tensorflow/core/framework/resource_var.h"
+#include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/framework/variant.h"
 #include "tensorflow/core/lib/gtl/cleanup.h"
 
@@ -43,6 +45,7 @@ limitations under the License.
 
 using tensorflow::AllocatorAttributes;
 using tensorflow::mutex_lock;
+using tensorflow::ResourceBase;
 using tensorflow::Status;
 using tensorflow::Tensor;
 using tensorflow::TF_TensorFromTensor;
@@ -282,6 +285,94 @@ void TF_AssignUpdateVariable(TF_OpKernelContext* ctx, int input_index,
   TF_Tensor* tf_var_tensor = TF_TensorFromTensor(*var_tensor, &s);
   TF_Tensor* tf_value = TF_TensorFromTensor(value, &s);
   updateFunc(ctx, tf_var_tensor, tf_value, Op);
+  TF_SetStatus(tf_status, TF_OK, "");
+}
+
+struct TmpVar : public ResourceBase {
+  tensorflow::mutex mu;
+  Tensor val;
+  std::string name;
+  std::string DebugString() const { return name; }
+  ~TmpVar() override { VLOG(3) << "TmpVar " << name << " deleted"; }
+};
+
+// Makes a unique name for a temporary variable inside a while loop body,
+//  because loop can be executed in multiple iterations in parallel.
+std::string TemporaryVariableName(
+    const std::string& var_name,
+    const tensorflow::FrameAndIter& control_frame) {
+  if (control_frame.frame_id != tensorflow::kIllegalFrameId &&
+      control_frame.iter_id != tensorflow::kIllegalIterId) {
+    return tensorflow::strings::StrCat(var_name,
+                                       "/frame:", control_frame.frame_id,
+                                       "/iter:", control_frame.iter_id);
+  }
+  return var_name;
+}
+
+void TF_TemporaryVariable(TF_OpKernelContext* ctx, TF_DataType dtype,
+                          const int64_t* dims, int num_dims,
+                          TF_StringView* var_name,
+                          void (*allocFunc)(TF_OpKernelContext*, TF_Tensor*,
+                                            TF_DataType, const int64_t*, int,
+                                            TF_Status*),
+                          TF_Status* tf_status) {
+  auto* context = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
+  tensorflow::ResourceMgr* rm = context->resource_manager();
+  OP_REQUIRES(context, rm,
+              tensorflow::errors::Internal("No per-step resource manager."));
+
+  std::string unique_name =
+      TemporaryVariableName(var_name->data, context->frame_iter());
+  auto* tmp_var = new TmpVar;
+  OP_REQUIRES(
+      context, tmp_var,
+      tensorflow::errors::ResourceExhausted("Could not allocate TmpVar."));
+  tmp_var->name = unique_name;
+
+  Status s;
+  TF_Tensor* tmp_var_tf;
+  tmp_var_tf = tensorflow::TF_TensorFromTensor(tmp_var->val, &s);
+  OP_REQUIRES_OK(context, s);
+  allocFunc(ctx, tmp_var_tf, dtype, dims, num_dims, tf_status);
+  s = tensorflow::StatusFromTF_Status(tf_status);
+  if (!s.ok()) tmp_var->Unref();
+  OP_REQUIRES_OK(context, s);
+
+  OP_REQUIRES_OK(context, TF_TensorToTensor(tmp_var_tf, &tmp_var->val));
+  OP_REQUIRES_OK(context,
+                 context->step_container()->Create(rm, unique_name, tmp_var));
+  context->set_output_ref(0, &tmp_var->mu, &tmp_var->val);
+
+  if (context->track_allocations()) {
+    context->record_persistent_memory_allocation(tmp_var->val.AllocatedBytes());
+  }
+
+  TF_SetStatus(tf_status, TF_OK, "");
+  TF_DeleteTensor(tmp_var_tf);
+}
+
+void TF_DestroyTemporaryVariable(TF_OpKernelContext* ctx, const int index,
+                                 TF_StringView* var_name,
+                                 TF_Status* tf_status) {
+  auto* context = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
+  CHECK(IsRefType(context->input_dtype(0)));
+  Tensor tmpvar = context->mutable_input(0, false);
+  context->set_output(0, tmpvar);
+
+  tensorflow::ResourceMgr* rm = context->resource_manager();
+  OP_REQUIRES(context, rm,
+              tensorflow::errors::Internal("No per-step resource manager."));
+  std::string unique_name =
+      TemporaryVariableName(var_name->data, context->frame_iter());
+  OP_REQUIRES_OK(context,
+                 context->step_container()->Delete<TmpVar>(rm, unique_name));
+
+  if (context->track_allocations()) {
+    context->record_persistent_memory_allocation(
+        -static_cast<int64_t>(tmpvar.AllocatedBytes()));
+  }
+
   TF_SetStatus(tf_status, TF_OK, "");
 }
 

--- a/tensorflow/c/kernels_experimental.cc
+++ b/tensorflow/c/kernels_experimental.cc
@@ -320,14 +320,13 @@ void TF_TemporaryVariable(TF_OpKernelContext* ctx, TF_DataType dtype,
   auto* context = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
   tensorflow::ResourceMgr* rm = context->resource_manager();
   OP_REQUIRES(context, rm,
-              tensorflow::errors::Internal("No per-step resource manager."));
+              absl::InternalError("No per-step resource manager."));
 
   std::string unique_name =
       TemporaryVariableName(var_name->data, context->frame_iter());
   auto* tmp_var = new TmpVar;
-  OP_REQUIRES(
-      context, tmp_var,
-      tensorflow::errors::ResourceExhausted("Could not allocate TmpVar."));
+  OP_REQUIRES(context, tmp_var,
+              absl::ResourceExhaustedError("Could not allocate TmpVar."));
   tmp_var->name = unique_name;
 
   Status s;
@@ -365,7 +364,7 @@ void TF_DestroyTemporaryVariable(TF_OpKernelContext* ctx, const int index,
 
   tensorflow::ResourceMgr* rm = context->resource_manager();
   OP_REQUIRES(context, rm,
-              tensorflow::errors::Internal("No per-step resource manager."));
+              absl::InternalError("No per-step resource manager."));
   std::string unique_name =
       TemporaryVariableName(var_name->data, context->frame_iter());
   OP_REQUIRES_OK(context,

--- a/tensorflow/c/kernels_experimental.cc
+++ b/tensorflow/c/kernels_experimental.cc
@@ -297,7 +297,7 @@ struct TmpVar : public ResourceBase {
 };
 
 // Makes a unique name for a temporary variable inside a while loop body,
-//  because loop can be executed in multiple iterations in parallel.
+// because loop can be executed in multiple iterations in parallel.
 std::string TemporaryVariableName(
     const std::string& var_name,
     const tensorflow::FrameAndIter& control_frame) {
@@ -355,7 +355,11 @@ void TF_DestroyTemporaryVariable(TF_OpKernelContext* ctx, const int index,
                                  TF_StringView* var_name,
                                  TF_Status* tf_status) {
   auto* context = reinterpret_cast<::tensorflow::OpKernelContext*>(ctx);
-  CHECK(IsRefType(context->input_dtype(0)));
+  if (!IsRefType(context->input_dtype(0))) {
+    tf_status->status =
+        InvalidArgument("TF_DestroyTemporaryVariable requires input is ref");
+    return;
+  }
   Tensor tmpvar = context->mutable_input(0, false);
   context->set_output(0, tmpvar);
 

--- a/tensorflow/c/kernels_experimental.cc
+++ b/tensorflow/c/kernels_experimental.cc
@@ -297,7 +297,7 @@ struct TmpVar : public ResourceBase {
 };
 
 // Makes a unique name for a temporary variable inside a while loop body,
-//  because loop can be executed in multiple iterations in parallel.
+// because loop can be executed in multiple iterations in parallel.
 std::string TemporaryVariableName(
     const std::string& var_name,
     const tensorflow::FrameAndIter& control_frame) {

--- a/tensorflow/c/kernels_experimental.h
+++ b/tensorflow/c/kernels_experimental.h
@@ -99,7 +99,7 @@ TF_CAPI_EXPORT extern void TF_TemporaryVariable(
 // the context with indices for the input and variable name. This function will
 // return an error when either of the following conditions is met:
 //   1. `input data type` is not ref type
-//   2. Cannot find temporary variable by name in auguments
+//   2. Cannot find temporary variable by name in arguments
 TF_CAPI_EXPORT extern void TF_DestroyTemporaryVariable(TF_OpKernelContext* ctx,
                                                        const int index,
                                                        TF_StringView* var_name,

--- a/tensorflow/c/kernels_experimental.h
+++ b/tensorflow/c/kernels_experimental.h
@@ -78,6 +78,33 @@ TF_CAPI_EXPORT extern void TF_AssignUpdateVariable(
                        TF_Tensor* value, int Op),
     TF_Status* status);
 
+// Expose higher level temporary variable operator for Pluggable vendors to
+// implement in the plugin for managing temporary variables. The API takes in
+// the context with indices for the input and value tensors. It also accepts the
+// allocator provided by pluggable vendor to do the allocate_temp of the
+// tensors. The caller takes ownership of temporary variables and is responsible
+// for freeing them with TF_DestroyTemporaryVariable. This function will return
+// an error when the following conditions are met:
+//   1. Cannot allocate a new temporary variable
+//   2. Calling plugin allocator failed
+TF_CAPI_EXPORT extern void TF_TemporaryVariable(
+    TF_OpKernelContext* ctx, TF_DataType dtype, const int64_t* dims,
+    int num_dims, TF_StringView* var_name,
+    void (*plugin_allocator)(TF_OpKernelContext*, TF_Tensor*, TF_DataType,
+                             const int64_t*, int, TF_Status*),
+    TF_Status* tf_status);
+
+// Expose higher level temporary variable operator for Pluggable vendors to
+// implement in the plugin for destroying temporary variables. The API takes in
+// the context with indices for the input and variable name. This function will
+// return an error when the following conditions are met:
+//   1. `input data type` is not ref type
+//   2. Cannot find temporary variable by name in auguments
+TF_CAPI_EXPORT extern void TF_DestroyTemporaryVariable(TF_OpKernelContext* ctx,
+                                                       const int index,
+                                                       TF_StringView* var_name,
+                                                       TF_Status* tf_status);
+
 // This is a helper function which acquires mutexes in-order to provide
 // thread-safe way of performing weights update during the optimizer op. It
 // returns an opaque LockHolder handle back to plugin. This handle is passed to

--- a/tensorflow/c/kernels_experimental.h
+++ b/tensorflow/c/kernels_experimental.h
@@ -97,7 +97,7 @@ TF_CAPI_EXPORT extern void TF_TemporaryVariable(
 // Expose higher level temporary variable operator for Pluggable vendors to
 // implement in the plugin for destroying temporary variables. The API takes in
 // the context with indices for the input and variable name. This function will
-// return an error when the following conditions are met:
+// return an error when either of the following conditions is met:
 //   1. `input data type` is not ref type
 //   2. Cannot find temporary variable by name in auguments
 TF_CAPI_EXPORT extern void TF_DestroyTemporaryVariable(TF_OpKernelContext* ctx,


### PR DESCRIPTION
Currently, TemporaryVariableOp will use context->allocate_temp() to allocate a tensor and do the DToH copy through pjrt_device_context->CopyDeviceTensorToCPU(), however, when the buffer is allocated through AsyncValueAllocator, pjrt_buffer is a nullptr in TemporaryVariableOp, thus crashed. 
TF_TemporaryVariable allows plugin implements the op with its own tensor allocator.