### PR TITLE
[TFLite] Fix Android build with CMake

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -271,6 +271,9 @@ populate_tflite_source_vars("core/kernels" TFLITE_CORE_KERNELS_SRCS)
 populate_tflite_source_vars("core/tools" TFLITE_CORE_TOOLS_SRCS)
 populate_tflite_source_vars("c" TFLITE_C_SRCS)
 populate_tflite_source_vars("delegates" TFLITE_DELEGATES_SRCS)
+populate_tflite_source_vars("core/async/interop/c" TFLITE_CORE_ASYNC_INTEROP_C_SRCS)
+populate_tflite_source_vars("delegates/utils" TFLITE_DELEGATES_UTILS_SRCS)
+populate_tflite_source_vars("async" TFLITE_ASYNC_SRCS)
 if(TFLITE_ENABLE_GPU)
   find_package(opencl_headers REQUIRED)
   find_package(vulkan_headers REQUIRED)
@@ -592,6 +595,9 @@ set(_ALL_TFLITE_SRCS
   ${TFLITE_NNAPI_SRCS}
   ${TFLITE_SRCS}
   ${TFLITE_PROFILER_SRCS}
+  ${TFLITE_CORE_ASYNC_INTEROP_C_SRCS}
+  ${TFLITE_DELEGATES_UTILS_SRCS}
+  ${TFLITE_ASYNC_SRCS}
   ${TFLITE_SOURCE_DIR}/internal/signature_def.h
   ${TFLITE_SOURCE_DIR}/kernels/internal/utils/sparsity_format_converter.cc
   ${TFLITE_SOURCE_DIR}/schema/conversion_metadata_generated.h

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -224,8 +224,10 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
 endif()
 if(CMAKE_SYSTEM_NAME MATCHES "Android")
   find_library(ANDROID_LOG_LIB log)
+  find_library(ANDROID_ANDROID_LIB android)
   list(APPEND TFLITE_TARGET_DEPENDENCIES
-    log
+    ${ANDROID_LOG_LIB}
+    ${ANDROID_ANDROID_LIB}
   )
 endif()
 # Build a list of source files to compile into the TF Lite library.


### PR DESCRIPTION
This PR addresses the following [issue](https://github.com/tensorflow/tensorflow/issues/61312).

Changes summary
* Sources in `core/async/interop/c`, `delegates/utils`, `async` are added to build
* libandroid is added to dependencies