### PR TITLE
[Linaro:ARM_CI] Switch to building with clang by default

### DIFF
--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -16,7 +16,12 @@
 set -x
 
 ARM_SKIP_TESTS="-//tensorflow/lite/... \
+-//tensorflow/compiler/mlir/lite/quantization/lite:quantize_model_test \
+-//tensorflow/compiler/mlir/lite/quantization/lite:quantize_weights_test \
+-//tensorflow/compiler/mlir/lite/sparsity:sparsify_model_test \
+-//tensorflow/compiler/xla/service/cpu/tests:cpu_eigen_dot_operation_test \
 -//tensorflow/compiler/xla/service/gpu:fusion_merger_test \
+-//tensorflow/core/kernels/image:resize_bicubic_op_test \
 -//tensorflow/python/kernel_tests/nn_ops:atrous_conv2d_test \
 -//tensorflow/python/kernel_tests/nn_ops:conv_ops_test \
 "

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test.sh
@@ -105,7 +105,7 @@ sudo sed -i '/^build --profile/d' /usertools/aarch64.bazelrc
 sudo sed -i '\@^build.*=\"/usr/local/bin/python3\"$@d' /usertools/aarch64.bazelrc
 sudo sed -i '/^build --profile/d' /usertools/aarch64_clang.bazelrc
 sudo sed -i '\@^build.*=\"/usr/local/bin/python3\"$@d' /usertools/aarch64_clang.bazelrc
-sed -i '$ aimport /usertools/aarch64.bazelrc' .bazelrc
+sed -i '$ aimport /usertools/aarch64_clang.bazelrc' .bazelrc
 
 update_bazel_flags
 

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_build.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_build.sh
@@ -111,7 +111,7 @@ sudo sed -i '/^build --profile/d' /usertools/aarch64.bazelrc
 sudo sed -i '\@^build.*=\"/usr/local/bin/python3\"$@d' /usertools/aarch64.bazelrc
 sudo sed -i '/^build --profile/d' /usertools/aarch64_clang.bazelrc
 sudo sed -i '\@^build.*=\"/usr/local/bin/python3\"$@d' /usertools/aarch64_clang.bazelrc
-sed -i '$ aimport /usertools/aarch64.bazelrc' .bazelrc
+sed -i '$ aimport /usertools/aarch64_clang.bazelrc' .bazelrc
 
 # Override breaking change in setuptools v60 (https://github.com/pypa/setuptools/pull/2896)
 export SETUPTOOLS_USE_DISTUTILS=stdlib

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_cpp.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_cpp.sh
@@ -82,7 +82,9 @@ fi
 
 sudo sed -i '/^build --profile/d' /usertools/aarch64.bazelrc
 sudo sed -i '\@^build.*=\"/usr/local/bin/python3\"$@d' /usertools/aarch64.bazelrc
-sed -i '$ aimport /usertools/aarch64.bazelrc' .bazelrc
+sudo sed -i '/^build --profile/d' /usertools/aarch64_clang.bazelrc
+sudo sed -i '\@^build.*=\"/usr/local/bin/python3\"$@d' /usertools/aarch64_clang.bazelrc
+sed -i '$ aimport /usertools/aarch64_clang.bazelrc' .bazelrc
 
 bazel test ${TF_TEST_FLAGS} \
     --repo_env=PYTHON_BIN_PATH="$(which python)" \


### PR DESCRIPTION
Switch the default compiler used in AARCH64 CI runs to be clang and add some exclusions for tests that fail when built with clang.