### PR TITLE
[Linaro:ARM_CI] Reduce number of jobs run in parallel for testing

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
@@ -119,7 +119,7 @@ bazel test ${TF_TEST_FLAGS} \
     --action_env=PYTHON_BIN_PATH=${PYTHON_BIN_PATH} \
     --build_tag_filters=${TF_FILTER_TAGS} \
     --test_tag_filters=${TF_FILTER_TAGS} \
-    --local_test_jobs=$(grep -c ^processor /proc/cpuinfo) \
+    --jobs=32 \
     --build_tests_only \
     -- ${TF_TEST_TARGETS}
 

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -172,7 +172,7 @@ bazel test ${TF_TEST_FLAGS} \
     --action_env=PYTHON_BIN_PATH=${PYTHON_BIN_PATH} \
     --build_tag_filters=${TF_FILTER_TAGS} \
     --test_tag_filters=${TF_FILTER_TAGS} \
-    --local_test_jobs=$(grep -c ^processor /proc/cpuinfo) \
+    --jobs=32 \
     --build_tests_only \
     -- ${TF_TEST_TARGETS}
 


### PR DESCRIPTION
Reduce the number of jobs run in parallel to limit the tendency to swap which results in long execution times.