### PR TITLE
Limit the version of wrapt to be used to prevent unit test failures

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -93,12 +93,15 @@ REQUIRED_PACKAGES = [
     'numpy >= 1.23.5',
     'opt_einsum >= 2.3.2',
     'packaging',
-    'protobuf>=3.20.3,<5.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5',
+    # pylint:disable=line-too-long
+    (
+        'protobuf>=3.20.3,<5.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5'
+    ),
     'setuptools',
     'six >= 1.12.0',
     'termcolor >= 1.1.0',
     'typing_extensions >= 3.6.6',
-    'wrapt >= 1.11.0',
+    'wrapt >= 1.11.0, < 1.15',
     # This looks worse as a wrapped line. pylint:disable=line-too-long
     (
         'tensorflow-io-gcs-filesystem >= 0.23.1;platform_machine!="arm64" or'


### PR DESCRIPTION
A change in the behaviour of wrapt ends up in a unit test failure for TensorFlow.
This can be removed once mitigation in TensorFlow is in place. https://github.com/tensorflow/tensorflow/issues/60687 and
https://github.com/GrahamDumpleton/wrapt/issues/231 This is an alternative and less intrusive fix to
https://github.com/tensorflow/tensorflow/pull/60688 which was inadvertently reverted by a mis-merge in another commit.
Also add pylint disable line for pre-existing pylint issue.