### PR TITLE
Add TF_PYTHON_VERSION env var to set Python version in macOS arm64 CI

### DIFF
--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_nightly.Jenkinsfile
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_nightly.Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.9
                     }
                     steps {
                         dir('tensorflow') {
@@ -52,7 +53,6 @@ pipeline {
 
                             sh '''
                                 /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
-                                --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.9.13/lib/python3.9/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                     
                                 ./bazel-bin/tensorflow/tools/pip_package/build_pip_package \
@@ -84,6 +84,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.10
                     }
                     steps {
                         dir('tensorflow') {
@@ -109,7 +110,6 @@ pipeline {
 
                             sh '''
                                 /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
-                                --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.10.4/lib/python3.10/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                 
                                 ./bazel-bin/tensorflow/tools/pip_package/build_pip_package \
@@ -140,6 +140,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.11
                     }
                     steps {
 
@@ -166,7 +167,6 @@ pipeline {
 
                             sh '''
                                 /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
-                                --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.11.2/lib/python3.11/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                 
                                 ./bazel-bin/tensorflow/tools/pip_package/build_pip_package \

--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_release.Jenkinsfile
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_release.Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.9
                     }
                     steps {
                         dir('tensorflow') {
@@ -50,7 +51,6 @@ pipeline {
 
                             sh '''
                                 /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
-                                --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.9.13/lib/python3.9/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                     
                                 ./bazel-bin/tensorflow/tools/pip_package/build_pip_package \
@@ -78,6 +78,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.10
                     }
                     steps {
                         dir('tensorflow') {
@@ -99,7 +100,6 @@ pipeline {
 
                             sh '''
                                 /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
-                                --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.10.4/lib/python3.10/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                 
                                 ./bazel-bin/tensorflow/tools/pip_package/build_pip_package \
@@ -127,6 +127,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.11
                     }
                     steps {
                         dir('tensorflow') {
@@ -148,7 +149,6 @@ pipeline {
 
                             sh '''
                                 /opt/homebrew/bin/bazel --bazelrc="${WORKSPACE}/tensorflow/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" build \
-                                --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.11.2/lib/python3.11/site-packages" \
                                 //tensorflow/tools/pip_package:build_pip_package
                                 
                                 ./bazel-bin/tensorflow/tools/pip_package/build_pip_package \

--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_test_ci.Jenkinsfile
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_test_ci.Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.11
                     }
                     steps {
                         sh '''
@@ -47,8 +48,6 @@ pipeline {
 
                         sh '''
                             bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" test \
-                            --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.11.2/lib/python3.11/site-packages" \
-                            --action_env PYTHON_BIN_PATH="/Users/admin/.pyenv/versions/3.11.2/bin/python3.11" \
                             --config=nonpip
                             '''
 

--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_test_nightly.Jenkinsfile
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_test_nightly.Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.9
                     }
                     steps {
 
@@ -47,8 +48,6 @@ pipeline {
 
                         sh '''
                             bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" test \
-                            --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.9.13/lib/python3.9/site-packages" \
-                            --action_env PYTHON_BIN_PATH="/Users/admin/.pyenv/versions/3.9.13/bin/python3.9" \
                             --config=nonpip
                             '''
                     }
@@ -60,6 +59,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.10
                     }
                     steps {
                         sh '''
@@ -81,8 +81,6 @@ pipeline {
                         
                         sh '''
                             bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" test \
-                            --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.10.4/lib/python3.10/site-packages" \
-                            --action_env PYTHON_BIN_PATH="/Users/admin/.pyenv/versions/3.10.4/bin/python3.10" \
                             --config=nonpip
                             '''
 
@@ -95,6 +93,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.11
                     }
                     steps {
                         sh '''
@@ -116,8 +115,6 @@ pipeline {
 
                         sh '''
                             bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" test \
-                            --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.11.2/lib/python3.11/site-packages" \
-                            --action_env PYTHON_BIN_PATH="/Users/admin/.pyenv/versions/3.11.2/bin/python3.11" \
                             --config=nonpip
                             '''
 

--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_test_release.Jenkinsfile
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_test_release.Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.9
                     }
                     steps {
 
@@ -50,8 +51,6 @@ pipeline {
 
                         sh '''
                             bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" test \
-                            --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.9.13/lib/python3.9/site-packages" \
-                            --action_env PYTHON_BIN_PATH="/Users/admin/.pyenv/versions/3.9.13/bin/python3.9" \
                             --config=nonpip
                             '''
                     }
@@ -63,6 +62,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.10
                     }
                     steps {
                         sh '''
@@ -83,8 +83,6 @@ pipeline {
 
                         sh '''
                             bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" test \
-                            --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.10.4/lib/python3.10/site-packages" \
-                            --action_env PYTHON_BIN_PATH="/Users/admin/.pyenv/versions/3.10.4/bin/python3.10" \
                             --config=nonpip
                             '''
 
@@ -97,6 +95,7 @@ pipeline {
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
                         PATH="$PYENV_ROOT/shims:/opt/homebrew/bin/:$PATH"
+			TF_PYTHON_VERSION=3.11
                     }
                     steps {
                         sh '''
@@ -117,8 +116,6 @@ pipeline {
 
                         sh '''
                             bazel --bazelrc="${WORKSPACE}/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc" test \
-                            --action_env PYTHON_LIB_PATH="/Users/admin/.pyenv/versions/3.11.2/lib/python3.11/site-packages" \
-                            --action_env PYTHON_BIN_PATH="/Users/admin/.pyenv/versions/3.11.2/bin/python3.11" \
                             --config=nonpip
                             '''
 


### PR DESCRIPTION
Now that [hermetic Python is enabled for TensorFlow](https://github.com/tensorflow/tensorflow/commit/e85860e8382a460a0dd8547a536e5eaaf9096a9f), we need to add the `TF_PYTHON_VERSION` to be able to set the Python version. This will also fix the currently [failing Python 3.9 and 3.11 macOS arm64 CI builds](https://tensorflow-ci.macstadium.com/job/tensorflow-as-build-nightly/).  

cc: @cjflan @kulinseth 