### PR TITLE
[oneDNN] Making hash map allocation a unique_ptr 

### DIFF
--- a/tensorflow/core/graph/mkl_graph_util.h
+++ b/tensorflow/core/graph/mkl_graph_util.h
@@ -196,8 +196,8 @@ static inline bool IsMklOp(const string& op_name, DataType T,
   string label = is_native_op ? kMklNameChangeOpLabelPattern
                               : kMklLayoutDependentOpLabelPattern;
   string registered_kernels_key = op_name + label + std::to_string(T);
-  thread_local static auto* registered_kernels_map =
-      new absl::flat_hash_map<string, bool>();
+  thread_local static auto registered_kernels_map =
+      std::make_unique<absl::flat_hash_map<string, bool>>();
   auto kernel_element = registered_kernels_map->find(registered_kernels_key);
   bool kernel_registered = false;
 


### PR DESCRIPTION
This change allocates hash map for kernel registry as a unique pointer.  It avoids a possible memory leak. Fixes [60506](https://github.com/tensorflow/tensorflow/issues/60506)