### PR TITLE
[TFLite] Fix FlatBuffers package name in installed CMake files

### DIFF
--- a/tensorflow/lite/tools/cmake/tensorflow-liteConfig.cmake.in
+++ b/tensorflow/lite/tools/cmake/tensorflow-liteConfig.cmake.in
@@ -17,7 +17,7 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(absl)
 find_dependency(Eigen3)
-find_dependency(Flatbuffers)
+find_dependency(FlatBuffers)
 find_dependency(NEON_2_SSE)
 find_dependency(cpuinfo)
 find_dependency(ruy)


### PR DESCRIPTION
Similiar to #58677, the capitalization of FlatBuffers needs to match. Otherwise using TFLite via find_package() will fail to find FlatBuffers.