### PR TITLE
[NVIDIA TF] Avoid nullptr as row offsets to cusparseCreateCsr when rows != 0

### DIFF
--- a/tensorflow/core/kernels/sparse/sparse_mat_mul_op.cc
+++ b/tensorflow/core/kernels/sparse/sparse_mat_mul_op.cc
@@ -493,7 +493,7 @@ class CSRSparseMatMulGPUOp : public OpKernel {
                      matC.InitializeCsr<int, T>(
                          a_input_dense_shape(a_input_dense_shape.size() - 2),
                          b_input_dense_shape(b_input_dense_shape.size() - 1), 0,
-                         nullptr, nullptr, nullptr));
+                         c_row_ptr.data(), nullptr, nullptr));
 
       // Check required size for buffer1 and possibly re-allocate
       size_t bufferSize1;


### PR DESCRIPTION
As of CUDA 12.2 additional input validation allows NULL for the row offsets pointer only when rows=0.