### PR TITLE
Update tensorflow2 code

### DIFF
--- a/cls
+++ b/cls
@@ -1,0 +1,29 @@
+[1mdiff --git a/tensorflow/python/tf2.py b/tensorflow/python/tf2.py[m
+[1mindex bce72186790..8eae643b019 100644[m
+[1m--- a/tensorflow/python/tf2.py[m
+[1m+++ b/tensorflow/python/tf2.py[m
+[36m@@ -20,19 +20,21 @@[m [mthe TensorFlow library. For that see tf.compat instead.[m
+ [m
+ from tensorflow.python.platform import _pywrap_tf2[m
+ from tensorflow.python.util.tf_export import tf_export[m
+[32m+[m[32mimport tensorflow as tf[m
+ [m
+ [m
+ def enable():[m
+   # Enables v2 behaviors.[m
+[31m-  _pywrap_tf2.enable(True)[m
+[32m+[m[32m  tf.compat.v1.enable_v2_behavior()[m
+[32m+[m
+ [m
+ [m
+ def disable():[m
+   # Disables v2 behaviors.[m
+[31m-  _pywrap_tf2.enable(False)[m
+[32m+[m[32m  tf.compat.v1.disable_v2_behavior()[m
+ [m
+ [m
+ @tf_export("__internal__.tf2.enabled", v1=[])[m
+ def enabled():[m
+   # Returns True iff TensorFlow 2.0 behavior should be enabled.[m
+[31m-  return _pywrap_tf2.is_enabled()[m
+[32m+[m[32m  return tf.executing_eagerly()[m

--- a/tensorflow/python/tf2.py
+++ b/tensorflow/python/tf2.py
@@ -20,19 +20,21 @@ the TensorFlow library. For that see tf.compat instead.
 
 from tensorflow.python.platform import _pywrap_tf2
 from tensorflow.python.util.tf_export import tf_export
+import tensorflow as tf
 
 
 def enable():
   # Enables v2 behaviors.
-  _pywrap_tf2.enable(True)
+  tf.compat.v1.enable_v2_behavior()
+
 
 
 def disable():
   # Disables v2 behaviors.
-  _pywrap_tf2.enable(False)
+  tf.compat.v1.disable_v2_behavior()
 
 
 @tf_export("__internal__.tf2.enabled", v1=[])
 def enabled():
   # Returns True iff TensorFlow 2.0 behavior should be enabled.
-  return _pywrap_tf2.is_enabled()
+  return tf.executing_eagerly()


### PR DESCRIPTION
In this version, we use tf.compat.v1.enable_v2_behavior() and tf.compat.v1.disable_v2_behavior() instead of directly using _pywrap_tf2. Additionally, the function is_tf2_behavior_enabled() now uses tf.executing_eagerly() instead of _pywrap_tf2.is_enabled(), which is the recommended way to check if TensorFlow 2.0 behavior is enabled.