### PR TITLE
[Linaro:ARM_CI] Stop using python venv for building and testing

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
@@ -52,12 +52,6 @@ sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/lib/python3/dist-packages
 # Update bazel
 install_bazelisk
 
-# Set python version string
-python_version=$(python3 -c 'import sys; print("python"+str(sys.version_info.major)+"."+str(sys.version_info.minor))')
-
-# Setup virtual environment
-setup_venv_ubuntu ${python_version}
-
 # Need to use the python from the venv
 export PYTHON_BIN_PATH=$(which python3)
 
@@ -119,9 +113,6 @@ bazel test ${TF_TEST_FLAGS} \
     --action_env=PYTHON_BIN_PATH=${PYTHON_BIN_PATH} \
     --build_tag_filters=${TF_FILTER_TAGS} \
     --test_tag_filters=${TF_FILTER_TAGS} \
-    --jobs=32 \
+    --local_test_jobs=$(grep -c ^processor /proc/cpuinfo) \
     --build_tests_only \
     -- ${TF_TEST_TARGETS}
-
-# Remove virtual environment
-remove_venv_ubuntu

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_pip.sh
@@ -54,12 +54,6 @@ sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/lib/python3/dist-packages
 # Update bazel
 install_bazelisk
 
-# Set python version string
-python_version=$(python3 -c 'import sys; print("python"+str(sys.version_info.major)+"."+str(sys.version_info.minor))')
-
-# Setup virtual environment
-setup_venv_ubuntu ${python_version}
-
 # Need to update the version of auditwheel used for aarch64
 python3 -m pip install auditwheel~=5.3.0
 
@@ -172,12 +166,9 @@ bazel test ${TF_TEST_FLAGS} \
     --action_env=PYTHON_BIN_PATH=${PYTHON_BIN_PATH} \
     --build_tag_filters=${TF_FILTER_TAGS} \
     --test_tag_filters=${TF_FILTER_TAGS} \
-    --jobs=32 \
+    --local_test_jobs=$(grep -c ^processor /proc/cpuinfo) \
     --build_tests_only \
     -- ${TF_TEST_TARGETS}
 
 # remove duplicate wheel and copy wheel to mounted volume for local access
 rm -rf ${WHL_DIR}/*linux_aarch64.whl && cp -r ${WHL_DIR} .
-
-# Remove virtual environment
-remove_venv_ubuntu


### PR DESCRIPTION
The use of hermetic python should make this venv unnecessary.