### PR TITLE
Target Monterey (12.0) as the minimum compatible os for arm64 wheels

### DIFF
--- a/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc
+++ b/tensorflow/tools/ci_build/osx/arm64/.macos.bazelrc
@@ -17,8 +17,8 @@ build --define=tensorflow_mkldnn_contraction_kernel=0
 
 # Settings for MacOS on ARM CPUs.
 build --cpu=darwin_arm64
-build --macos_minimum_os=11.0
-build --action_env MACOSX_DEPLOYMENT_TARGET=11.0
+build --macos_minimum_os=12.0
+build --action_env MACOSX_DEPLOYMENT_TARGET=12.0
 
 # Test-related settings below this point.
 test --verbose_failures=true --local_test_jobs=HOST_CPUS --test_output=errors
@@ -42,39 +42,3 @@ test:nonpip_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss
 test:nonpip_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
 test:nonpip_filters --test_lang_filters=cc,py
 test:nonpip --config=nonpip_filters -- //tensorflow/... -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/compiler/xla/service/gpu/... -//tensorflow/compiler/xla/tools/multihost_hlo_runner/... -//tensorflow/compiler/xrt/... -//tensorflow/core/tpu/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/python/integration_testing/... -//tensorflow/tools/toolchains/... -//tensorflow/lite/... -//tensorflow/compiler/aot/... -//tensorflow/compiler/xla/tests:local_client_aot_test_computation -//tensorflow/compiler/xla/tests:local_client_aot_test_helper -//tensorflow/compiler/xla/tests:local_client_aot_test
-
-# "pip tests" run a similar suite of tests the "nonpip" tests, but do something
-# odd to attempt to validate the quality of the pip package. The wheel is
-# installed into a virtual environment, and then that venv is used to run all
-# bazel tests with a special flag "--define=no_tensorflow_py_deps=true", which
-# drops all the bazel dependencies for each py_test; this makes all the tests
-# use the wheel's TensorFlow installation instead of the one made available
-# through bazel. This must be done in a different root directory, //bazel_pip/...,
-# because "import tensorflow" run from the root directory would instead import
-# the folder instead of the venv package.
-#
-# Pass --config=pip to run the same suite of tests. If you want to run just one
-# test for investigation, you'll need --config=pip_base instead, and then you
-# can specify whichever target you want.
-test:pip_base --define=no_tensorflow_py_deps=true
-test:pip_filters --build_tag_filters=-nopip,-no_pip,-nomac,-no_mac,-no_oss,-oss_serial,-no_oss_py39,-no_oss_py310,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
-test:pip_filters --test_tag_filters=-nopip,-no_pip,-nomac,-no_mac,-no_oss,-oss_serial,-no_oss_py39,-no_oss_py310,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
-test:pip_filters --test_lang_filters=py
-test:pip --config=pip_base --config=pip_filters -- //bazel_pip/tensorflow/python/...
-
-# For building libtensorflow archives
-build:libtensorflow_filters --action_env TF_NEED_HDFS=0
-build:libtensorflow_filters --action_env TF_NEED_ROCM=0 --action_env TF_NEED_MKL=0
-build:libtensorflow_filters --action_env COMPUTECPP_PATH="/usr/local"
-test:libtensorflow_test --config=libtensorflow_filters -- //tensorflow/tools/lib_package:libtensorflow_test //tensorflow/tools/lib_package:libtensorflow_java_test
-build:libtensorflow_build --config=libtensorflow_filters  -- //tensorflow/tools/lib_package:libtensorflow.tar.gz //tensorflow/tools/lib_package:libtensorflow_jni.tar.gz //tensorflow/java:libtensorflow.jar //tensorflow/java:libtensorflow-src.jar //tensorflow/tools/lib_package:libtensorflow_proto.zip
-
-# For continuous builds
-# nodistinct_host_configuration saves building twice a lot of targets
-test:continuous_filters --nodistinct_host_configuration --keep_going
-test:continuous_filters --build_tests_only --test_output=errors --flaky_test_attempts=3
-test:continuous_filters --test_size_filters=small,medium --test_timeout=300,450,1200,3600
-test:continuous_filters --test_tag_filters=-no_oss,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
-test:continuous_filters --build_tag_filters=-no_oss,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
-
-test:continuous --config=continuous_filters -- //tensorflow/... -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/compiler/xrt/... -//tensorflow/core/tpu/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/python/integration_testing/... -//tensorflow/tools/toolchains/... -//tensorflow/lite/... -//tensorflow/compiler/aot/... -//tensorflow/compiler/xla/tests:local_client_aot_test_computation -//tensorflow/compiler/xla/tests:local_client_aot_test_helper -//tensorflow/compiler/xla/tests:local_client_aot_test


### PR DESCRIPTION
The tf-nightly-macos wheels are currently being tagged with "11_0" so this PR changes the CI to target Monterey (12.0) to be the minimum compatible OS to be consistent with how we released the Apple Silicon wheels for TF 2.13. 

Also, removed redundant configs. 

cc: @kulinseth @cjflan 