### PR TITLE
Fix unable to find lit module for xla unit tests

### DIFF
--- a/tensorflow/compiler/xla/glob_lit_test.bzl
+++ b/tensorflow/compiler/xla/glob_lit_test.bzl
@@ -60,6 +60,7 @@ def _run_lit_test(name, data, size, tags, driver, features, exec_properties):
             "@llvm-project//llvm:count",
             "@llvm-project//llvm:not",
         ],
+        deps = ["@pypi_lit//:pkg"],
         size = size,
         main = "lit.py",
         exec_properties = exec_properties,


### PR DESCRIPTION
Need to get the lit module from PyPi for Python 3.11 to prevent ModuleNotFoundError