### PR TITLE
Slight differences with AARCH64 so need to relax test

### DIFF
--- a/tensorflow/python/kernel_tests/nn_ops/rnn_cell_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/rnn_cell_test.py
@@ -1113,7 +1113,7 @@ class LSTMTest(test.TestCase):
       if test_util.is_xla_enabled():
         comparison_fn = self.assertAllClose
       if in_graph_mode:
-        comparison_fn(outputs_static, outputs_dynamic)
+        self.assertAllClose(outputs_static, outputs_dynamic)
       else:
         self.assertAllEqual(
             array_ops_stack.stack(outputs_static), outputs_dynamic)


### PR DESCRIPTION
The unit test //tensorflow/python/kernel_tests/nn_ops:rnn_cell_test_cpu frequently fails due to slight differences in results when tested on AARCH64 so allow close match rather than needing absolute equality.