### PR TITLE
[Linaro:ARM_CI] Clean bazel cache to save time removing container

### DIFF
--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -16,6 +16,7 @@
 set -x
 
 ARM_SKIP_TESTS="-//tensorflow/lite/... \
+-//tensorflow/compiler/mlir/lite/tests:optimize.mlir.test \
 -//tensorflow/compiler/xla/service/gpu:fusion_merger_test \
 -//tensorflow/python/kernel_tests/nn_ops:atrous_conv2d_test \
 -//tensorflow/python/kernel_tests/nn_ops:conv_ops_test \

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_nonpip.sh
@@ -116,3 +116,6 @@ bazel test ${TF_TEST_FLAGS} \
     --local_test_jobs=$(grep -c ^processor /proc/cpuinfo) \
     --build_tests_only \
     -- ${TF_TEST_TARGETS}
+
+bazel clean
+bazel shutdown


### PR DESCRIPTION
Remove files generated during test instead of leaving them to be cleaned up with the container