### PR TITLE
Fix link failure in XLA unit tests

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -397,6 +397,7 @@ cc_library(
         "//tensorflow/compiler/xla/service:executable",
         "//tensorflow/compiler/xla/service:llvm_compiler",
         "//tensorflow/compiler/xla/stream_executor",
+        "//tensorflow/compiler/xla/stream_executor:stream_executor_pimpl",  # fixdeps: keep
         "//tensorflow/compiler/xla/stream_executor/host:host_platform_id",
         "@llvm-project//llvm:Target",
     ],


### PR DESCRIPTION
XLA unit tests were unable to link due to undefined reference to stream_executor::Stream::BlockHostUntilDone()