### PR TITLE
[Linaro:ARM_CI] Put bazel output onto host storage

### DIFF
--- a/tensorflow/tools/ci_build/ci_build.sh
+++ b/tensorflow/tools/ci_build/ci_build.sh
@@ -156,14 +156,14 @@ if [ -n "${CI_BUILD_USER_FORCE_BADNAME}" ]; then
         CI_BUILD_USER_FORCE_BADNAME_ENV="-e CI_BUILD_USER_FORCE_BADNAME=yes"
 fi
 
+df
 # Run the command inside the container.
 echo "Running '${COMMAND[*]}' inside ${DOCKER_IMG_NAME}..."
 mkdir -p ${WORKSPACE}/bazel-ci_build-cache
 # By default we cleanup - remove the container once it finish running (--rm)
 # and share the PID namespace (--pid=host) so the process inside does not have
 # pid 1 and SIGKILL is propagated to the process inside (jenkins can kill it).
-${DOCKER_BINARY} run --rm --name ${DOCKER_IMG_NAME} --pid=host \
-    -v ${WORKSPACE}/bazel-ci_build-cache:${WORKSPACE}/bazel-ci_build-cache \
+${DOCKER_BINARY} run --name ${DOCKER_IMG_NAME} --pid=host \
     -e "CI_BUILD_HOME=${WORKSPACE}/bazel-ci_build-cache" \
     -e "CI_BUILD_USER=$(id -u -n)" \
     -e "CI_BUILD_UID=$(id -u)" \
@@ -179,3 +179,9 @@ ${DOCKER_BINARY} run --rm --name ${DOCKER_IMG_NAME} --pid=host \
     "${DOCKER_IMG_NAME}" \
     ${CI_COMMAND_PREFIX[@]} \
     ${COMMAND[@]}
+
+df
+
+docker rm -f ${DOCKER_IMG_NAME}
+
+df

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test.sh
@@ -51,6 +51,7 @@ sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/lib/python3/dist-packages
 
 # Update bazel
 install_bazelisk
+#export TEST_TMPDIR=/workspace/bazel-ci_build-cache
 
 # Need to use the python from the venv
 export PYTHON_BIN_PATH=$(which python3)
@@ -89,8 +90,8 @@ source tensorflow/tools/ci_build/build_scripts/DEFAULT_TEST_TARGETS.sh
 source tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS_EXTENDED.sh
 
 # Export optional variables for running the tests
-export TF_BUILD_FLAGS="--config=mkl_aarch64_threadpool --copt=-flax-vector-conversions"
-export TF_TEST_FLAGS="${TF_BUILD_FLAGS} \
+export TF_BUILD_FLAGS="--config=mkl_aarch64_threadpool --copt=-flax-vector-conversions --fission=yes"
+export TF_TEST_FLAGS="${TF_BUILD_FLAGS} --flaky_test_attempts=3 \
     --test_env=TF_ENABLE_ONEDNN_OPTS=1 --test_env=TF2_BEHAVIOR=1 --define=tf_api_version=2 \
     --test_lang_filters=py --test_size_filters=small,medium \
     --test_output=errors --verbose_failures=true --test_keep_going --notest_verbose_timeout_warnings"
@@ -110,9 +111,12 @@ sed -i '$ aimport /usertools/aarch64.bazelrc' .bazelrc
 update_bazel_flags
 
 bazel test ${TF_TEST_FLAGS} \
-    --action_env=PYTHON_BIN_PATH=${PYTHON_BIN_PATH} \
     --build_tag_filters=${TF_FILTER_TAGS} \
     --test_tag_filters=${TF_FILTER_TAGS} \
     --local_test_jobs=$(grep -c ^processor /proc/cpuinfo) \
     --build_tests_only \
     -- ${TF_TEST_TARGETS}
+
+mkdir /tmpfs/empty
+sudo rsync -ra --delete /tmpfs/empty ${TEST_TMPDIR}
+#sudo rm -rf ${TEST_TMPDIR}


### PR DESCRIPTION
Do not use container writable layer for bazel output but instead use storage mounted from the host.