### PR TITLE
custom implementation of the Riemann zeta function using mpmath library

### DIFF
--- a/tensorflow/python/custom_zeta/custom_zeta
+++ b/tensorflow/python/custom_zeta/custom_zeta
@@ -1,0 +1,14 @@
+# custom_zeta.py
+import tensorflow as tf
+import mpmath
+
+def custom_zeta(x, y):
+    # Convert TensorFlow tensors to mpmath complex numbers
+    s = mpmath.mpc(x.numpy(), y.numpy())
+    
+    # Calculate the Riemann zeta function using mpmath
+    result = mpmath.zeta(s)
+    
+    # Convert the mpmath result back to TensorFlow
+    result = tf.cast(result, dtype=tf.float32)
+    return result


### PR DESCRIPTION
Usage Examples
```python
import tensorflow as tf
from custom_zeta import custom_zeta

# Complex value of s (for example)
x = tf.constant(2.0)
y = tf.constant(3.0)

# Calculate the zeta function using the custom function
result = custom_zeta(x, y)
print(result)

# Calculate the gradient of the zeta function with respect to x and y
with tf.GradientTape() as tape:
    tape.watch(x)
    tape.watch(y)
    result = custom_zeta(x, y)

gradient = tape.jacobian(result, [x, y])
print(gradient)

``` 

Important Notes
The custom_zeta function uses mpmath for higher precision.
Ensure that the mpmath library is installed in your Python environment before using this function.
The precision of the computation can be adjusted by setting mpmath.mp.dps before calling the function.

Compatibility and Requirements
The mpmath library is needed for high-precision computations. Install it using pip install mpmath.

This pull request addresses the issue https://github.com/tensorflow/tensorflow/issues/60041 .