### PR TITLE
Amax for FP8 Convolutions in XLA

### DIFF
--- a/tensorflow/compiler/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
+++ b/tensorflow/compiler/xla/mlir_hlo/lhlo_gpu/IR/lhlo_gpu_ops.td
@@ -49,7 +49,7 @@ class GpuConvolutionAttributes<dag extraAttribs> {
 }
 
 // Provide a custom assembly format for all LHLO_GPU convolution operations.
-class LHLOGPU_ConvBaseOp<string mnemonic, list<Trait> traits = []> : LHLOGPU_Op<mnemonic> {
+class LHLOGPU_ConvBaseOp<string mnemonic, list<Trait> traits = []> : LHLOGPU_Op<mnemonic, traits> {
  let assemblyFormat = [{
     `(`operands`)`
        `dim_numbers` `=` custom<ConvolutionDimensions>($dimension_numbers) `,`
@@ -148,8 +148,10 @@ def LHLOGPU_ConvForwardGraphOp :
        Arg<LHLO_Buffer, "", [MemRead]>:$filter,
        Arg<Variadic<LHLO_Buffer>, "", [MemRead]>:$binary_operands,
        Arg<LHLO_Buffer, "", [MemWrite]>:$output,
+       Arg<Variadic<LHLO_Buffer>, "", [MemWrite]>:$aux_outputs,
        Arg<LHLO_Buffer, "", [MemWrite]>:$scratch),
      GpuConvolutionAttributes<(ins
+          I32Attr:$n_aux_outputs,
           StrAttr:$serialized_graph)>.attributes);
 }
 

--- a/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.cc
@@ -1079,7 +1079,6 @@ StatusOr<bool> GpuConvAlgorithmPicker::RunOnInstruction(HloInstruction* instr) {
 
   // Set the algorithm and update the shape of the convolution Custom Call to
   // account for the appropriate amount of scratch memory.
-  HloComputation* computation = instr->parent();
   ShapeUtil::UpdateTupleShape(
       ShapeUtil::MakeShape(U8, {best_algo.scratch_bytes()}),
       instr->shape().tuple_shapes_size() - 1, instr->mutable_shape());

--- a/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.cc
@@ -206,7 +206,7 @@ StatusOr<std::vector<GenericConvRunner>> GetAlgorithms(
 StatusOr<std::vector<std::unique_ptr<const se::dnn::ConvRunner>>>
 GetMIOpenAlgorithms(const HloCustomCallInstruction* instr,
                     absl::Span<se::DeviceMemoryBase> operand_buffers,
-                    se::DeviceMemoryBase result_buffer,
+                    absl::Span<se::DeviceMemoryBase> result_buffers,
                     se::StreamExecutor* stream_exec,
                     ScratchAllocator* scratch_allocator, se::Stream* stream,
                     const se::NumericOptions& numeric_options) {
@@ -218,8 +218,9 @@ GetMIOpenAlgorithms(const HloCustomCallInstruction* instr,
   TF_ASSIGN_OR_RETURN(se::dnn::DataType dtype,
                       GetDNNDataTypeFromPrimitiveType(config.output_type));
 
-  TF_ASSIGN_OR_RETURN(GpuConvParams params,
-                      GetGpuConvParams(config, operand_buffers, result_buffer));
+  TF_ASSIGN_OR_RETURN(
+      GpuConvParams params,
+      GetGpuConvParams(config, operand_buffers, result_buffers));
 
   std::vector<std::unique_ptr<const se::dnn::ConvRunner>> runners;
   TF_RETURN_IF_ERROR(stream_exec->GetConvolveRunners(
@@ -436,12 +437,28 @@ GpuConvAlgorithmPicker::AutotuneRuntimeArguments::FromInstruction(
     operand_buffers.push_back(buffer);
   }
 
-  // Construct result buffer.
-  auto result_shape = instr->shape().tuple_shapes(0);
-  TF_ASSIGN_OR_RETURN(auto result_buffer,
-                      input_output_allocator->AllocateBytes(
-                          ShapeUtil::ByteSizeOf(result_shape)));
-  initialize_buffer(result_buffer, result_shape);
+  // Construct the result buffers.
+  Shape result_shape;
+  // Disregard the workspace, which is the final element in the tuple returned
+  // by instr.
+  std::vector<se::DeviceMemoryBase> result_buffers(
+      instr->shape().tuple_shapes_size() - 1);
+  // Set the shape to a tuple when instr returns more than one result.
+  if (instr->shape().tuple_shapes_size() > 2) {
+    result_shape = ShapeUtil::MakeTupleShape(
+        std::vector<Shape>{instr->shape().tuple_shapes().begin(),
+                           instr->shape().tuple_shapes().end() - 1});
+  } else {
+    result_shape = instr->shape().tuple_shapes(0);
+  }
+
+  for (int i = 0; i < instr->shape().tuple_shapes_size() - 1; ++i) {
+    TF_ASSIGN_OR_RETURN(
+        result_buffers[i],
+        input_output_allocator->AllocateBytes(
+            ShapeUtil::ByteSizeOf(instr->shape().tuple_shapes(i))));
+    initialize_buffer(result_buffers[i], instr->shape().tuple_shapes(i));
+  }
 
   // Get canonical HLO.
   std::string canonical_hlo(
@@ -451,8 +468,9 @@ GpuConvAlgorithmPicker::AutotuneRuntimeArguments::FromInstruction(
   TF_ASSIGN_OR_RETURN(GpuConvConfig gpu_conv_config, GetGpuConvConfig(instr));
 
   GpuConvAlgorithmPicker::AutotuneRuntimeArguments runtime_arguments = {
-      result_shape,           hlo_module_config, operand_buffers, result_buffer,
-      input_output_allocator, gpu_conv_config,   {canonical_hlo}};
+      result_shape,   hlo_module_config,      operand_buffers,
+      result_buffers, input_output_allocator, gpu_conv_config,
+      {canonical_hlo}};
 
   return runtime_arguments;
 }
@@ -563,9 +581,10 @@ StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
   Status launch_status;
   std::vector<se::DeviceMemoryBase> operand_buffers =
       runtime_arguments.operand_buffers;
-  se::DeviceMemoryBase result_buffer = runtime_arguments.result_buffer;
+  std::vector<se::DeviceMemoryBase> result_buffers =
+      runtime_arguments.result_buffers;
   // Dry-run to warmup the plan.
-  launch_status = RunGpuConv(config, operand_buffers, result_buffer,
+  launch_status = RunGpuConv(config, operand_buffers, result_buffers,
                              scratch_memory, stream, options);
   constexpr float kThreshold = 0.95f;
   constexpr int kMaxIter = 10;
@@ -575,7 +594,7 @@ StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
   for (;
        num_iters < kMaxIter && launch_status.ok() && profile_result.is_valid();
        num_iters++) {
-    launch_status = RunGpuConv(config, operand_buffers, result_buffer,
+    launch_status = RunGpuConv(config, operand_buffers, result_buffers,
                                scratch_memory, stream, options);
     float old_min_time = min_time;
     min_time = std::min(min_time, profile_result.elapsed_time_in_ms());
@@ -613,7 +632,8 @@ StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
 
   if (!ShouldCheckConv(runtime_arguments.hlo_module_config)) {
     if (!reference_result->has_value()) {
-      (*reference_result) = {alg, DeviceMemoryBase()};
+      (*reference_result) = {
+          alg, std::vector<DeviceMemoryBase>(result_buffers.size())};
     }
     return result;
   }
@@ -663,48 +683,54 @@ StatusOr<AutotuneResult> GpuConvAlgorithmPicker::AutotuneOneConvRunner(
     XLA_SCOPED_LOGGING_TIMER_LEVEL("BufferComparator::CompareEqual", 2);
     BufferComparator comparator(runtime_arguments.result_shape,
                                 runtime_arguments.hlo_module_config);
-    StatusOr<bool> compare_result =
-        comparator.CompareEqual(stream, /*current=*/result_buffer,
-                                /*expected=*/(*reference_result)->buffer);
-    if (!compare_result.ok()) {
-      LOG(ERROR) << "Unable to compare "
-                 << (*reference_result)->algorithm.ToString() << " against "
-                 << alg.ToString() << " for " << instr_str << ": "
-                 << compare_result.status();
-      if (compare_result.status().code() ==
-          absl::StatusCode::kResourceExhausted) {
-        // Possibly OOM. Propagate the error.
-        return compare_result.status();
+    for (int i = 0; i < result_buffers.size(); ++i) {
+      StatusOr<bool> compare_result = comparator.CompareEqual(
+          stream, (*reference_result)->buffers[i], result_buffers[i]);
+      if (!compare_result.ok()) {
+        LOG(ERROR) << "Unable to compare "
+                   << (*reference_result)->algorithm.ToString() << " against "
+                   << alg.ToString() << " for " << instr_str << ": "
+                   << compare_result.status();
+        if (compare_result.status().code() ==
+            absl::StatusCode::kResourceExhausted) {
+          // Possibly OOM. Propagate the error.
+          return compare_result.status();
+        }
+        const DebugOptions& debug_options =
+            runtime_arguments.hlo_module_config.debug_options();
+        CHECK(!debug_options.xla_gpu_crash_on_verification_failures());
+      } else if (!compare_result.value()) {
+        LOG(ERROR)
+            << "Results mismatch between different convolution algorithms. "
+               "This is likely a bug/unexpected loss of precision in cudnn.\n"
+            << instr_str << " for " << (*reference_result)->algorithm.ToString()
+            << " vs " << alg.ToString();
+        PrintPlatformInfo(stream);
+        if (instruction_info.has_value()) {
+          VLOG(2) << "Full module on failure: \n"
+                  << instruction_info->GetModelStr();
+        }
+        auto* fail = result.mutable_failure();
+        fail->set_kind(AutotuneResult::WRONG_RESULT);
+        fail->set_buffer_address(
+            reinterpret_cast<uint64_t>(result_buffers[i].opaque()));
+        *fail->mutable_reference_algorithm() =
+            (*reference_result)->algorithm.ToProto();
       }
-      const DebugOptions& debug_options =
-          runtime_arguments.hlo_module_config.debug_options();
-      CHECK(!debug_options.xla_gpu_crash_on_verification_failures());
-    } else if (!compare_result.value()) {
-      LOG(ERROR)
-          << "Results mismatch between different convolution algorithms. "
-             "This is likely a bug/unexpected loss of precision in cudnn.\n"
-          << instr_str << " for " << (*reference_result)->algorithm.ToString()
-          << " vs " << alg.ToString();
-      PrintPlatformInfo(stream);
-      if (instruction_info.has_value()) {
-        VLOG(2) << "Full module on failure: \n"
-                << instruction_info->GetModelStr();
-      }
-      auto* fail = result.mutable_failure();
-      fail->set_kind(AutotuneResult::WRONG_RESULT);
-      fail->set_buffer_address(
-          reinterpret_cast<uint64_t>(result_buffer.opaque()));
-      *fail->mutable_reference_algorithm() =
-          (*reference_result)->algorithm.ToProto();
     }
   } else {
     XLA_SCOPED_LOGGING_TIMER_LEVEL("Memcpy Reference Result", 2);
-    TF_ASSIGN_OR_RETURN(auto reference_result_buffer,
-                        runtime_arguments.input_output_allocator->AllocateBytes(
-                            result_buffer.size()));
-    stream->ThenMemcpy(&reference_result_buffer, result_buffer,
-                       result_buffer.size());
-    (*reference_result) = {alg, reference_result_buffer};
+    std::vector<DeviceMemoryBase> reference_result_buffers(
+        result_buffers.size());
+    for (int i = 0; i < result_buffers.size(); ++i) {
+      TF_ASSIGN_OR_RETURN(
+          reference_result_buffers[i],
+          runtime_arguments.input_output_allocator->AllocateBytes(
+              result_buffers[i].size()));
+      stream->ThenMemcpy(&reference_result_buffers[i], result_buffers[i],
+                         result_buffers[i].size());
+    }
+    (*reference_result) = {alg, reference_result_buffers};
   }
 
   return result;
@@ -810,8 +836,11 @@ StatusOr<AutotuneResult> GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheCuda(
         instr_log.add_operand_addresses(reinterpret_cast<uint64_t>(
             runtime_arguments.operand_buffers[i].opaque()));
       }
-      instr_log.set_result_address(
-          reinterpret_cast<uint64_t>(runtime_arguments.result_buffer.opaque()));
+      for (se::DeviceMemoryBase result_buffer :
+           runtime_arguments.result_buffers) {
+        instr_log.add_result_addresses(
+            reinterpret_cast<uint64_t>(result_buffer.opaque()));
+      }
       log.mutable_instr()->PackFrom(instr_log);
     }
     for (const auto& profile : profile_results) {
@@ -851,7 +880,7 @@ GpuConvAlgorithmPicker::PickBestAlgorithmWithAllocatedBuffer(
     const ServiceExecutableRunOptions* run_options,
     const DebugOptions& debug_options,
     const std::vector<se::DeviceMemoryBase> buffers,
-    const se::DeviceMemoryBase result_buffer) {
+    std::vector<se::DeviceMemoryBase> result_buffers) {
 #if GOOGLE_CUDA
   Shape output_shape = conv_config.output_shape;
   HloModuleConfig hlo_module_config;
@@ -863,8 +892,8 @@ GpuConvAlgorithmPicker::PickBestAlgorithmWithAllocatedBuffer(
       AutotunerUtil::CreateRedzoneAllocator(config, debug_options, stream));
 
   GpuConvAlgorithmPicker::AutotuneRuntimeArguments autotune_runtime_arguments =
-      {output_shape,  hlo_module_config,       buffers,
-       result_buffer, &input_output_allocator, conv_config,
+      {output_shape,   hlo_module_config,       buffers,
+       result_buffers, &input_output_allocator, conv_config,
        std::nullopt};
 
   return PickBestAlgorithmNoCacheCuda(
@@ -913,19 +942,31 @@ StatusOr<AutotuneResult> GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
     operand_buffers.push_back(buffer);
   }
 
-  TF_ASSIGN_OR_RETURN(
-      auto result_buffer,
-      input_output_allocator.AllocateBytes(
-          ShapeUtil::ByteSizeOf(instr->shape().tuple_shapes(0))));
-  initialize_buffer(result_buffer);
+  std::vector<se::DeviceMemoryBase> result_buffers(
+      instr->shape().tuple_shapes_size());
+  if (instr->shape().IsTuple()) {
+    for (int i = 0; i < instr->shape().tuple_shapes_size(); ++i) {
+      TF_ASSIGN_OR_RETURN(
+          result_buffers[i],
+          input_output_allocator.AllocateBytes(
+              ShapeUtil::ByteSizeOf(instr->shape().tuple_shapes(i))));
+      initialize_buffer(result_buffers[i]);
+    }
+  } else {
+    TF_ASSIGN_OR_RETURN(
+        result_buffers[0],
+        input_output_allocator.AllocateBytes(
+            ShapeUtil::ByteSizeOf(instr->shape().tuple_shapes(0))));
+    initialize_buffer(result_buffers[0]);
+  }
 
   ScratchAllocator scratch_allocator(device_ordinal, allocator);
 
   TF_ASSIGN_OR_RETURN(
       std::vector<std::unique_ptr<const se::dnn::ConvRunner>> runners,
-      GetMIOpenAlgorithms(instr, absl::MakeSpan(operand_buffers), result_buffer,
-                          stream_exec, &scratch_allocator, stream,
-                          numeric_options));
+      GetMIOpenAlgorithms(instr, absl::MakeSpan(operand_buffers),
+                          absl::MakeSpan(result_buffers), stream_exec,
+                          &scratch_allocator, stream, numeric_options));
 
   std::vector<AutotuneResult> profile_results;
 
@@ -971,7 +1012,7 @@ StatusOr<AutotuneResult> GpuConvAlgorithmPicker::PickBestAlgorithmNoCacheRocm(
       options.profile_result = &profile_result;
       options.runner_cache = &runner_cache;
       Status launch_status =
-          RunGpuConv(config, absl::MakeSpan(operand_buffers), result_buffer,
+          RunGpuConv(config, absl::MakeSpan(operand_buffers), result_buffers,
                      scratch_memory, stream, options);
 
       if (!launch_status.ok()) {
@@ -1036,12 +1077,12 @@ StatusOr<bool> GpuConvAlgorithmPicker::RunOnInstruction(HloInstruction* instr) {
           << " of scratch memory: " << instr->ToString()
           << " tensor_ops_enabled: " << best_algo.conv().tensor_ops_enabled();
 
-  // Replace instr with a new CustomCall which has the correct algorithm, and
-  // whose output shape has the appropriate amount of scratch memory.
+  // Set the algorithm and update the shape of the convolution Custom Call to
+  // account for the appropriate amount of scratch memory.
   HloComputation* computation = instr->parent();
-  Shape new_call_shape = ShapeUtil::MakeTupleShape(
-      {instr->shape().tuple_shapes(0),
-       ShapeUtil::MakeShape(U8, {best_algo.scratch_bytes()})});
+  ShapeUtil::UpdateTupleShape(
+      ShapeUtil::MakeShape(U8, {best_algo.scratch_bytes()}),
+      instr->shape().tuple_shapes_size() - 1, instr->mutable_shape());
 
   TF_ASSIGN_OR_RETURN(CudnnConvBackendConfig backend_config,
                       instr->backend_config<CudnnConvBackendConfig>());
@@ -1049,29 +1090,8 @@ StatusOr<bool> GpuConvAlgorithmPicker::RunOnInstruction(HloInstruction* instr) {
   backend_config.mutable_algorithm()->mutable_workspace_size()->set_value(
       best_algo.scratch_bytes());
 
-  HloInstruction* new_call = computation->AddInstruction(
-      instr->CloneWithNewOperands(new_call_shape, instr->operands()));
+  TF_RETURN_IF_ERROR(instr->set_backend_config(backend_config));
 
-  // Preserve the name of the old instruction.  This is safe because we're going
-  // to remove the old one anyway, and it makes it easier to trace how our conv
-  // is transformed through all our passes.
-  new_call->SetAndSanitizeName(instr->name());
-
-  VLOG(3) << "Replacing convolution " << instr->ToString() << " with "
-          << new_call->ToString();
-
-  TF_RETURN_IF_ERROR(new_call->set_backend_config(backend_config));
-
-  // Repackage new_call so it has the same shape as the original call, namely
-  // (conv_result, u8[0]).
-  HloInstruction* new_tuple =
-      computation->AddInstruction(HloInstruction::CreateTuple(
-          {computation->AddInstruction(HloInstruction::CreateGetTupleElement(
-               new_call_shape.tuple_shapes(0), new_call, 0)),
-           computation->AddInstruction(HloInstruction::CreateConstant(
-               LiteralUtil::CreateR1<uint8_t>({})))}));
-
-  TF_RETURN_IF_ERROR(instr->parent()->ReplaceInstruction(instr, new_tuple));
   return true;
 }
 

--- a/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.h
+++ b/tensorflow/compiler/xla/service/gpu/conv_algorithm_picker.h
@@ -100,7 +100,7 @@ class GpuConvAlgorithmPicker : public HloModulePass {
       const ServiceExecutableRunOptions* run_options,
       const DebugOptions& debug_options,
       std::vector<se::DeviceMemoryBase> buffers,
-      se::DeviceMemoryBase result_buffer);
+      std::vector<se::DeviceMemoryBase> result_buffers);
 
  private:
   StatusOr<bool> RunOnComputation(HloComputation* computation);
@@ -116,7 +116,7 @@ class GpuConvAlgorithmPicker : public HloModulePass {
   // autotuned algorithms.
   struct ReferenceResult {
     stream_executor::dnn::AlgorithmDesc algorithm;
-    stream_executor::DeviceMemoryBase buffer;
+    std::vector<stream_executor::DeviceMemoryBase> buffers;
   };
 
   // Execution environment for autotuning. Runtime autotuning requires runtime
@@ -126,7 +126,7 @@ class GpuConvAlgorithmPicker : public HloModulePass {
     const Shape result_shape;
     const HloModuleConfig hlo_module_config;
     std::vector<se::DeviceMemoryBase> operand_buffers;
-    se::DeviceMemoryBase result_buffer;
+    std::vector<se::DeviceMemoryBase> result_buffers;
     se::RedzoneAllocator* input_output_allocator;
     const GpuConvConfig gpu_conv_config;
     std::optional<std::string> canonical_hlo;

--- a/tensorflow/compiler/xla/service/gpu/conv_layout_normalization.cc
+++ b/tensorflow/compiler/xla/service/gpu/conv_layout_normalization.cc
@@ -32,7 +32,7 @@ namespace xla {
 namespace gpu {
 namespace {
 
-StatusOr<HloInstruction*> UpdateLayoutForCudnnConvolution(
+StatusOr<std::optional<HloInstruction*>> UpdateLayoutForCudnnConvolution(
     HloCustomCallInstruction* hlo) {
   HloInstruction* lhs = hlo->mutable_operand(0);
   HloInstruction* rhs = hlo->mutable_operand(1);
@@ -105,14 +105,17 @@ StatusOr<HloInstruction*> UpdateLayoutForCudnnConvolution(
 
   Shape normalized_shape;
   if (hlo->shape().IsTuple()) {
-    TF_RET_CHECK(hlo->shape().tuple_shapes_size() == 2);
-    TF_RET_CHECK(hlo->shape().tuple_shapes(1).rank() == 1)
-        << "Second element in a convolution tuple is expected to be an "
+    TF_RET_CHECK(hlo->shape().tuple_shapes().back().rank() == 1)
+        << "The last element in the tuple returned by a convolution Custom "
+           "Call is expected to be an "
            "allocator of rank one";
-    normalized_shape = ShapeUtil::MakeTupleShape(
-        {ShapeUtil::MakeShapeWithDescendingLayoutAndSamePhysicalLayout(
-             hlo->shape().tuple_shapes(0)),
-         hlo->shape().tuple_shapes(1)});
+    std::vector<Shape> new_tuple_shape;
+    for (Shape tuple_shape : hlo->shape().tuple_shapes()) {
+      new_tuple_shape.emplace_back(
+          ShapeUtil::MakeShapeWithDescendingLayoutAndSamePhysicalLayout(
+              tuple_shape));
+    }
+    normalized_shape = ShapeUtil::MakeTupleShape(new_tuple_shape);
   } else {
     normalized_shape =
         ShapeUtil::MakeShapeWithDescendingLayoutAndSamePhysicalLayout(
@@ -122,6 +125,7 @@ StatusOr<HloInstruction*> UpdateLayoutForCudnnConvolution(
   // We need to restore degenerate dimensions, since those might be used in
   // either batch dimension, or contracting dimensions.
   std::vector<HloInstruction*> normalized_operands;
+  bool performed_normalization = false;
   for (int idx = 0; idx < hlo->operand_count(); idx++) {
     HloInstruction* op = hlo->mutable_operand(idx);
     const Shape& s = op->shape();
@@ -133,8 +137,17 @@ StatusOr<HloInstruction*> UpdateLayoutForCudnnConvolution(
       new_op = normalized_op;
     } else {
       new_op = MakeBitcastHlo(op, s_reordered);
+      performed_normalization = true;
     }
     normalized_operands.push_back(new_op);
+  }
+
+  // Avoid replacing the Custom Call with an identical copy.
+  if (!performed_normalization &&
+      ShapeUtil::Equal(normalized_shape, hlo->shape()) &&
+      ConvolutionDimensionNumbersToString(new_dim_numbers) ==
+          ConvolutionDimensionNumbersToString(dim_numbers)) {
+    return std::nullopt;
   }
 
   HloInstruction* normalized_conv = hlo->parent()->AddInstruction(
@@ -155,13 +168,16 @@ StatusOr<HloInstruction*> UpdateLayoutForCudnnConvolution(
   // tuples built this way.
   HloInstruction* bc_to_orig;
   if (normalized_conv->shape().IsTuple()) {
-    TF_ASSIGN_OR_RETURN(HloInstruction * normalized_out,
-                        MakeGetTupleElementHlo(normalized_conv, 0));
-    TF_ASSIGN_OR_RETURN(HloInstruction * allocator,
-                        MakeGetTupleElementHlo(normalized_conv, 1));
-    HloInstruction* orig_shape_out =
-        MakeBitcastHlo(normalized_out, hlo->shape().tuple_shapes(0));
-    bc_to_orig = MaybeMakeTuple({orig_shape_out, allocator});
+    std::vector<HloInstruction*> tuple_elements(
+        normalized_conv->shape().tuple_shapes_size());
+
+    for (int i = 0; i < normalized_conv->shape().tuple_shapes_size(); ++i) {
+      TF_ASSIGN_OR_RETURN(HloInstruction * normalized_out,
+                          MakeGetTupleElementHlo(normalized_conv, i));
+      tuple_elements[i] =
+          MakeBitcastHlo(normalized_out, hlo->shape().tuple_shapes(i));
+    }
+    bc_to_orig = MaybeMakeTuple(tuple_elements);
   } else {
     bc_to_orig = MakeBitcastHlo(normalized_conv, hlo->shape());
   }
@@ -173,11 +189,11 @@ StatusOr<HloInstruction*> UpdateLayoutForCudnnConvolution(
 StatusOr<std::optional<HloInstruction*>> NormalizeLayoutForGpuCustomCalls(
     HloCustomCallInstruction* hlo) {
   if (IsCustomCallToDnnConvolution(*hlo)) {
-    TF_ASSIGN_OR_RETURN(HloInstruction * bc_to_orig,
+    TF_ASSIGN_OR_RETURN(std::optional<HloInstruction*> bc_to_orig,
                         UpdateLayoutForCudnnConvolution(hlo));
-    return std::make_optional(bc_to_orig);
+    return bc_to_orig;
   }
-  return {std::nullopt};
+  return std::nullopt;
 }
 
 }  // end namespace gpu

--- a/tensorflow/compiler/xla/service/gpu/convolution_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/convolution_thunk.h
@@ -46,7 +46,7 @@ class ConvolutionThunk : public Thunk {
   // operand_slices should be in the same order as cudnn_call->operands().
   ConvolutionThunk(ThunkInfo thunk_info, GpuConvConfig config,
                    std::vector<BufferAllocation::Slice> operand_slices,
-                   BufferAllocation::Slice result_slice,
+                   std::vector<BufferAllocation::Slice> result_slices,
                    BufferAllocation::Slice scratch_slice);
 
   ConvolutionThunk(const ConvolutionThunk&) = delete;
@@ -56,7 +56,7 @@ class ConvolutionThunk : public Thunk {
 
  private:
   std::vector<BufferAllocation::Slice> operand_buffers_;
-  BufferAllocation::Slice result_buffer_;
+  std::vector<BufferAllocation::Slice> result_buffers_;
   BufferAllocation::Slice scratch_buffer_;
   GenericConvRunner& GetOrCreateRunner(const stream_executor::Stream* stream);
 

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter.cc
@@ -440,16 +440,13 @@ std::optional<PrimitiveType> IsSaturatingCastToF8(HloInstruction* instr) {
 bool AppliesMaxReduce(HloInstruction* op) {
   HloComputation* reduce_comp = op->to_apply();
   HloInstruction* reduce_comp_root = reduce_comp->root_instruction();
-  if (ShapeUtil::IsScalar(op->shape()) &&
-      ShapeUtil::IsScalar(op->operand(1)->shape()) &&
-      op->operand(1)->IsConstant() &&
-      op->operand(1)->literal().GetAsDouble({}) <= 0. &&
-      reduce_comp_root->opcode() == HloOpcode::kMaximum &&
-      reduce_comp_root->operand(0)->opcode() == HloOpcode::kParameter &&
-      reduce_comp_root->operand(1)->opcode() == HloOpcode::kParameter) {
-    return true;
-  }
-  return false;
+  return ShapeUtil::IsScalar(op->shape()) &&
+         ShapeUtil::IsScalar(op->operand(1)->shape()) &&
+         op->operand(1)->IsConstant() &&
+         op->operand(1)->literal().GetAsDouble({}) <= 0. &&
+         reduce_comp_root->opcode() == HloOpcode::kMaximum &&
+         reduce_comp_root->operand(0)->opcode() == HloOpcode::kParameter &&
+         reduce_comp_root->operand(1)->opcode() == HloOpcode::kParameter;
 };
 
 // Recursively captures and serializes the graph of pointwise operations

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
@@ -771,7 +771,43 @@ TEST_F(CudnnFusedConvRewriterTest, TestConvScaledOutputF8) {
   )",
       // serialized_graph
       R"(
-// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE_UID:[0-9]+]]:[f8e4m3fn]scale([[CONV_UID]],{{[0-9]+}});"
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE_UID:[0-9]+]]:[f8e4m3fn]scale([[CONV_UID]]);"
+      )");
+}
+
+TEST_F(CudnnFusedConvRewriterTest, TestConvInvscaledOutputF8) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8900)
+  GTEST_SKIP() << "FP8 convolutions require CUDA 12 and cuDNN 8.9.";
+#endif
+  TestF8(
+      // pre_hlo
+      R"(
+    HloModule Test
+
+    ENTRY Test {
+       input = f8e4m3fn[1,128,6,6] parameter(0)
+       filter = f8e4m3fn[3,3,128,16] parameter(1)
+       input_f32 = f32[1,128,6,6] convert(input)
+       filter_f32 = f32[3,3,128,16] convert(filter)
+       z_scale = f32[] parameter(2)
+       z_scale_bcast = f32[1,16,6,6] broadcast(z_scale), dimensions={}
+       conv_a = f32[1,16,6,6] convolution(input_f32, filter_f32), window={size=3x3 pad=1_1x1_1}, dim_labels=bf01_01io->bf01, feature_group_count=1
+       conv_a_scaled = f32[1,16,6,6] divide(conv_a, z_scale_bcast)
+       c1 = f32[] constant(-448.)
+       c1_bcast = f32[1,16,6,6] broadcast(c1), dimensions={}
+       c2 = f32[] constant(448.)
+       c2_bcast = f32[1,16,6,6] broadcast(c2), dimensions={}
+       conv_a_clamped = f32[1,16,6,6] clamp(c1_bcast, conv_a_scaled, c2_bcast)
+       ROOT conv_f8 = f8e4m3fn[1,16,6,6] convert(conv_a_clamped)
+
+    })",
+      // custom_call
+      R"(
+// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (f8e4m3fn[1,6,6,16]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]], [[OPERAND2:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
+  )",
+      // serialized_graph
+      R"(
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE0_UID:[0-9]+]]:[f8e4m3fn]invscale([[CONV_UID]]);"
       )");
 }
 
@@ -813,43 +849,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestConvScaledF8Parameterized) {
       )",
       // serialized_graph
       R"(
-// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE0_UID:[0-9]+]]:[f32]scale([[CONV_UID]],{{[0-9]+}});[[SCALE1_UID:[0-9]+]]:[f32]scale([[SCALE0_UID]],{{[0-9]+}});[[SCALE2_UID:[0-9]+]]:[<<OutputType>>]scale([[SCALE1_UID]],{{[0-9]+}});"
-      )");
-}
-
-TEST_F(CudnnFusedConvRewriterTest, TestConvInvscaledF8) {
-#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8900)
-  GTEST_SKIP() << "FP8 convolutions require CUDA 12 and cuDNN 8.9.";
-#endif
-  TestF8(
-      // pre_hlo
-      R"(
-    HloModule Test
-
-    ENTRY Test {
-       input = f8e4m3fn[1,128,6,6] parameter(0)
-       filter = f8e4m3fn[3,3,128,16] parameter(1)
-       input_f32 = f32[1,128,6,6] convert(input)
-       filter_f32 = f32[3,3,128,16] convert(filter)
-       z_scale = f32[] parameter(2)
-       z_scale_bcast = f32[1,16,6,6] broadcast(z_scale), dimensions={}
-       conv_a = f32[1,16,6,6] convolution(input_f32, filter_f32), window={size=3x3 pad=1_1x1_1}, dim_labels=bf01_01io->bf01, feature_group_count=1
-       conv_a_scaled = f32[1,16,6,6] divide(conv_a, z_scale_bcast)
-       c1 = f32[] constant(-448.)
-       c1_bcast = f32[1,16,6,6] broadcast(c1), dimensions={}
-       c2 = f32[] constant(448.)
-       c2_bcast = f32[1,16,6,6] broadcast(c2), dimensions={}
-       conv_a_clamped = f32[1,16,6,6] clamp(c1_bcast, conv_a_scaled, c2_bcast)
-       ROOT conv_f8 = f8e4m3fn[1,16,6,6] convert(conv_a_clamped)
-
-    })",
-      // custom_call
-      R"(
-// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (f8e4m3fn[1,6,6,16]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]], [[OPERAND2:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
-  )",
-      // serialized_graph
-      R"(
-// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE0_UID:[0-9]+]]:[f8e4m3fn]invscale([[CONV_UID]],{{[0-9]+}});"
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE0_UID:[0-9]+]]:[f32]scale([[CONV_UID]]);[[SCALE1_UID:[0-9]+]]:[f32]scale([[SCALE0_UID]]);[[SCALE2_UID:[0-9]+]]:[<<OutputType>>]scale([[SCALE1_UID]]);"
       )");
 }
 
@@ -893,11 +893,11 @@ TEST_F(CudnnFusedConvRewriterTest, TestConvScaledBiasF8) {
       )",
       // serialized_graph
       R"(
-// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE0_UID:[0-9]+]]:[f32]scale([[CONV_UID]]);[[SCALE1_UID:[0-9]+]]:[f32]scale([[SCALE0_UID]]);[[ADD_UID:[0-9]+]]:[f32]add([[SCALE1_UID]]);[[SCALE2_UID:[0-9]+]]:[f8e4m3fn]scale([[ADD_UID]]);"
       )");
 }
 
-TEST_F(CudnnFusedConvRewriterTest, TestConvScaledReluActivationF8) {
+TEST_F(CudnnFusedConvRewriterTest, TestConvScaledReluF8) {
 #if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8900)
   GTEST_SKIP() << "FP8 convolutions require CUDA 12 and cuDNN 8.9.";
 #endif
@@ -932,7 +932,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestConvScaledReluActivationF8) {
   )",
       // serialized_graph
       R"(
-// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[RELU_UID:[0-9]+]]:[f32]relu([[CONV_UID]]);[[SCALE0_UID:[0-9]+]]:[f8e4m3fn]scale([[RELU_UID]],{{[0-9]+}});"
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[RELU_UID:[0-9]+]]:[f32]relu([[CONV_UID]]);[[SCALE0_UID:[0-9]+]]:[f8e4m3fn]scale([[RELU_UID]]);"
       )");
 }
 
@@ -981,7 +981,59 @@ TEST_F(CudnnFusedConvRewriterTest, TestConvAmaxF8) {
     )",
       // serialized_graph
       R"(
-// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE0_UID:[0-9]+]]:[f32]scale([[CONV_UID]],{{[0-9]+}});[[SCALE1_UID:[0-9]+]]:[f32]scale([[SCALE0_UID]],{{[0-9]+}});[[SCALE2_UID:[0-9]+]]:[f8e4m3fn]scale([[SCALE1_UID]],{{[0-9]+}});[[AMAX_UID:[0-9]+]]:[f32]amax([[SCALE1_UID]]);"
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE0_UID:[0-9]+]]:[f32]scale([[CONV_UID]]);[[SCALE1_UID:[0-9]+]]:[f32]scale([[SCALE0_UID]]);[[SCALE2_UID:[0-9]+]]:[f8e4m3fn]scale([[SCALE1_UID]]);[[AMAX_UID:[0-9]+]]:[f32]amax([[SCALE1_UID]]);"
+      )");
+}
+
+TEST_F(CudnnFusedConvRewriterTest, TestConvReluAmaxF8) {
+  TestF8(
+      // pre_hlo
+      R"(
+    HloModule Test
+
+    apply {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT c = f32[] maximum(a, b)
+    }
+
+    ENTRY Test {
+       input = f8e4m3fn[1,128,6,6] parameter(0)
+       filter = f8e4m3fn[3,3,128,16] parameter(1)
+       input_scale = f32[] parameter(2)
+       input_scale_bcast = f32[1,128,6,6] broadcast(input_scale), dimensions={}
+       filter_scale = f32[] parameter(3)
+       filter_scale_bcast = f32[3,3,128,16] broadcast(filter_scale), dimensions={}
+       input_f32 = f32[1,128,6,6] convert(input)
+       input_unscaled = f32[1,128,6,6] multiply(input_f32, input_scale_bcast)
+       filter_f32 = f32[3,3,128,16] convert(filter)
+       filter_unscaled = f32[3,3,128,16] multiply(filter_f32, filter_scale_bcast)
+       c = f32[] constant(0)
+       c_bcast = f32[1,16,6,6] broadcast(c), dimensions={}
+       conv_a = f32[1,16,6,6] convolution(input_unscaled, filter_unscaled), window={size=3x3 pad=1_1x1_1}, dim_labels=bf01_01io->bf01, feature_group_count=1
+       relu_a = f32[1,16,6,6] maximum(conv_a, c_bcast)
+       z_scale = f32[] parameter(4)
+       z_scale_bcast = f32[1,16,6,6] broadcast(z_scale), dimensions={}
+       relu_a_scaled = f32[1,16,6,6] multiply(relu_a, z_scale_bcast)
+       c1 = f32[] constant(-448.)
+       c1_bcast = f32[1,16,6,6] broadcast(c1), dimensions={}
+       c2 = f32[] constant(448.)
+       c2_bcast = f32[1,16,6,6] broadcast(c2), dimensions={}
+       relu_a_clamped = f32[1,16,6,6] clamp(c1_bcast, relu_a_scaled, c2_bcast)
+       relu_a_clamped_f8 = f8e4m3fn[1,16,6,6] convert(relu_a_clamped)
+       abs_relu_a = f32[1,16,6,6] abs(relu_a)
+       c0 = f32[] constant(-inf)
+       amax = f32[] reduce(abs_relu_a, c0), dimensions={0,1,2,3}, to_apply=apply
+       ROOT conv_f8 = (f8e4m3fn[1,16,6,6], f32[]) tuple(relu_a_clamped_f8, amax)
+
+    })",
+      // custom_call
+      R"(
+// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (f8e4m3fn[1,6,6,16]{3,2,1,0}, f32[], u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]], [[OPERAND2:%[^ ]+]], [[OPERAND3:%[^ ]+]], [[OPERAND4:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
+    )",
+      // serialized_graph
+      R"(
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE0_UID:[0-9]+]]:[f32]scale([[CONV_UID]]);[[SCALE1_UID:[0-9]+]]:[f32]scale([[SCALE0_UID]]);[[RELU_UID:[0-9]+]]:[f32]relu([[SCALE1_UID]]);[[SCALE2_UID:[0-9]+]]:[f8e4m3fn]scale([[RELU_UID]]);[[AMAX_UID:[0-9]+]]:[f32]amax([[RELU_UID]]);"
       )");
 }
 

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
@@ -1037,6 +1037,86 @@ TEST_F(CudnnFusedConvRewriterTest, TestConvReluAmaxF8) {
       )");
 }
 
+TEST_F(CudnnFusedConvRewriterTest, TestConvScaledOutputMultipleUsersF8) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8900)
+  GTEST_SKIP() << "FP8 convolutions require CUDA 12 and cuDNN 8.9.";
+#endif
+  TestF8(
+      // pre_hlo
+      R"(
+    HloModule Test
+
+    ENTRY Test {
+       input = f8e4m3fn[1,128,6,6] parameter(0)
+       filter = f8e4m3fn[3,3,128,16] parameter(1)
+       input_f32 = f32[1,128,6,6] convert(input)
+       filter_f32 = f32[3,3,128,16] convert(filter)
+       z_scale0 = f32[] parameter(2)
+       z_scale0_bcast = f32[1,16,6,6] broadcast(z_scale0), dimensions={}
+       z_scale1 = f32[] parameter(3)
+       z_scale1_bcast = f32[1,16,6,6] broadcast(z_scale1), dimensions={}
+       conv_a = f32[1,16,6,6] convolution(input_f32, filter_f32), window={size=3x3 pad=1_1x1_1}, dim_labels=bf01_01io->bf01, feature_group_count=1
+       conv_a_scaled0 = f32[1,16,6,6] multiply(conv_a, z_scale0_bcast)
+       conv_a_scaled1 = f32[1,16,6,6] multiply(conv_a, z_scale1_bcast)
+       c1 = f32[] constant(-448.)
+       c1_bcast = f32[1,16,6,6] broadcast(c1), dimensions={}
+       c2 = f32[] constant(448.)
+       c2_bcast = f32[1,16,6,6] broadcast(c2), dimensions={}
+       conv_a_clamped0 = f32[1,16,6,6] clamp(c1_bcast, conv_a_scaled0, c2_bcast)
+       conv_a_clamped1 = f32[1,16,6,6] clamp(c1_bcast, conv_a_scaled1, c2_bcast)
+       conv_a_convert0 = f8e4m3fn[1,16,6,6] convert(conv_a_clamped0)
+       conv_a_convert1 = f8e4m3fn[1,16,6,6] convert(conv_a_clamped1)
+       ROOT conv_f8 = (f8e4m3fn[1,16,6,6], f8e4m3fn[1,16,6,6]) tuple(conv_a_convert0, conv_a_convert1)
+
+    })",
+      // custom_call
+      R"(
+// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (f32[1,6,6,16]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
+  )",
+      // serialized_graph
+      R"(
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();"
+      )");
+}
+
+TEST_F(CudnnFusedConvRewriterTest, TestConvScaledOutputUnsupportedUserF8) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8900)
+  GTEST_SKIP() << "FP8 convolutions require CUDA 12 and cuDNN 8.9.";
+#endif
+  TestF8(
+      // pre_hlo
+      R"(
+    HloModule Test
+
+    ENTRY Test {
+       input = f8e4m3fn[1,128,6,6] parameter(0)
+       filter = f8e4m3fn[3,3,128,16] parameter(1)
+       input_f32 = f32[1,128,6,6] convert(input)
+       filter_f32 = f32[3,3,128,16] convert(filter)
+       z_scale = f32[] parameter(2)
+       z_scale_bcast = f32[1,16,6,6] broadcast(z_scale), dimensions={}
+       conv_a = f32[1,16,6,6] convolution(input_f32, filter_f32), window={size=3x3 pad=1_1x1_1}, dim_labels=bf01_01io->bf01, feature_group_count=1
+       conv_a_cos = f32[1,16,6,6] cosine(conv_a)
+       conv_a_scaled = f32[1,16,6,6] multiply(conv_a, z_scale_bcast)
+       c1 = f32[] constant(-448.)
+       c1_bcast = f32[1,16,6,6] broadcast(c1), dimensions={}
+       c2 = f32[] constant(448.)
+       c2_bcast = f32[1,16,6,6] broadcast(c2), dimensions={}
+       conv_a_clamped = f32[1,16,6,6] clamp(c1_bcast, conv_a_scaled, c2_bcast)
+       conv_a_convert = f8e4m3fn[1,16,6,6] convert(conv_a_clamped)
+       ROOT conv_f8 = (f8e4m3fn[1,16,6,6], f32[1,16,6,6]) tuple(conv_a_convert, conv_a_cos)
+
+    })",
+      // custom_call
+      R"(
+// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (f32[1,6,6,16]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
+  )",
+      // serialized_graph
+      R"(
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();"
+      )");
+}
+
 TEST_F(CudnnFusedConvRewriterTest, TestConvInt8ToInt8) {
   // max(0, clamp(conv(x, w)))); for int8_t
   TestClamp(

--- a/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
+++ b/tensorflow/compiler/xla/service/gpu/cudnn_fused_conv_rewriter_test.cc
@@ -735,7 +735,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestConvF8) {
   )",
       // serialized_graph
       R"(
-// CHECK: "serialized_graph":"conv[f8e4m3fn]-\u003e"
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f8e4m3fn]conv();"
       )");
 }
 
@@ -771,7 +771,7 @@ TEST_F(CudnnFusedConvRewriterTest, TestConvScaledOutputF8) {
   )",
       // serialized_graph
       R"(
-// CHECK: "serialized_graph":"conv[f32]-\u003escale[f8e4m3fn]-\u003e"
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE_UID:[0-9]+]]:[f8e4m3fn]scale([[CONV_UID]],{{[0-9]+}});"
       )");
 }
 
@@ -809,11 +809,47 @@ TEST_F(CudnnFusedConvRewriterTest, TestConvScaledF8Parameterized) {
     })",
       // custom_call
       R"(
-// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (<<OutputType>>[1,6,6,16]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]], [[OPERAND2:%[^ ]+]], [[OPERAND3:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
+// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (<<OutputType>>[1,6,6,16]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]], [[OPERAND2:%[^ ]+]], [[OPERAND3:%[^ ]+]], [[OPERAND4:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
+      )",
+      // serialized_graph
+      R"(
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE0_UID:[0-9]+]]:[f32]scale([[CONV_UID]],{{[0-9]+}});[[SCALE1_UID:[0-9]+]]:[f32]scale([[SCALE0_UID]],{{[0-9]+}});[[SCALE2_UID:[0-9]+]]:[<<OutputType>>]scale([[SCALE1_UID]],{{[0-9]+}});"
+      )");
+}
+
+TEST_F(CudnnFusedConvRewriterTest, TestConvInvscaledF8) {
+#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8900)
+  GTEST_SKIP() << "FP8 convolutions require CUDA 12 and cuDNN 8.9.";
+#endif
+  TestF8(
+      // pre_hlo
+      R"(
+    HloModule Test
+
+    ENTRY Test {
+       input = f8e4m3fn[1,128,6,6] parameter(0)
+       filter = f8e4m3fn[3,3,128,16] parameter(1)
+       input_f32 = f32[1,128,6,6] convert(input)
+       filter_f32 = f32[3,3,128,16] convert(filter)
+       z_scale = f32[] parameter(2)
+       z_scale_bcast = f32[1,16,6,6] broadcast(z_scale), dimensions={}
+       conv_a = f32[1,16,6,6] convolution(input_f32, filter_f32), window={size=3x3 pad=1_1x1_1}, dim_labels=bf01_01io->bf01, feature_group_count=1
+       conv_a_scaled = f32[1,16,6,6] divide(conv_a, z_scale_bcast)
+       c1 = f32[] constant(-448.)
+       c1_bcast = f32[1,16,6,6] broadcast(c1), dimensions={}
+       c2 = f32[] constant(448.)
+       c2_bcast = f32[1,16,6,6] broadcast(c2), dimensions={}
+       conv_a_clamped = f32[1,16,6,6] clamp(c1_bcast, conv_a_scaled, c2_bcast)
+       ROOT conv_f8 = f8e4m3fn[1,16,6,6] convert(conv_a_clamped)
+
+    })",
+      // custom_call
+      R"(
+// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (f8e4m3fn[1,6,6,16]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]], [[OPERAND2:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
   )",
       // serialized_graph
       R"(
-// CHECK: "serialized_graph":"conv[f32]-\u003escale[f32]-\u003escale[<<OutputType>>]-\u003e"
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE0_UID:[0-9]+]]:[f8e4m3fn]invscale([[CONV_UID]],{{[0-9]+}});"
       )");
 }
 
@@ -853,47 +889,11 @@ TEST_F(CudnnFusedConvRewriterTest, TestConvScaledBiasF8) {
     })",
       // custom_call
       R"(
-// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (f8e4m3fn[1,6,6,16]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]], [[OPERAND2:%[^ ]+]], [[OPERAND3:%[^ ]+]], [[OPERAND4:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
-  )",
+// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (f8e4m3fn[1,6,6,16]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]], [[OPERAND2:%[^ ]+]], [[OPERAND3:%[^ ]+]], [[OPERAND4:%[^ ]+]], /*index=5*/[[OPERAND5:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
+      )",
       // serialized_graph
       R"(
-// CHECK: "serialized_graph":"conv[f32]-\u003escale[f32]-\u003eadd[f32]-\u003escale[f8e4m3fn]-\u003e"
-      )");
-}
-
-TEST_F(CudnnFusedConvRewriterTest, TestConvInvscaledF8) {
-#if (CUDA_VERSION < 12000 || CUDNN_VERSION < 8900)
-  GTEST_SKIP() << "FP8 convolutions require CUDA 12 and cuDNN 8.9.";
-#endif
-  TestF8(
-      // pre_hlo
-      R"(
-    HloModule Test
-
-    ENTRY Test {
-       input = f8e4m3fn[1,128,6,6] parameter(0)
-       filter = f8e4m3fn[3,3,128,16] parameter(1)
-       input_f32 = f32[1,128,6,6] convert(input)
-       filter_f32 = f32[3,3,128,16] convert(filter)
-       z_scale = f32[] parameter(2)
-       z_scale_bcast = f32[1,16,6,6] broadcast(z_scale), dimensions={}
-       conv_a = f32[1,16,6,6] convolution(input_f32, filter_f32), window={size=3x3 pad=1_1x1_1}, dim_labels=bf01_01io->bf01, feature_group_count=1
-       conv_a_scaled = f32[1,16,6,6] divide(conv_a, z_scale_bcast)
-       c1 = f32[] constant(-448.)
-       c1_bcast = f32[1,16,6,6] broadcast(c1), dimensions={}
-       c2 = f32[] constant(448.)
-       c2_bcast = f32[1,16,6,6] broadcast(c2), dimensions={}
-       conv_a_clamped = f32[1,16,6,6] clamp(c1_bcast, conv_a_scaled, c2_bcast)
-       ROOT conv_f8 = f8e4m3fn[1,16,6,6] convert(conv_a_clamped)
-
-    })",
-      // custom_call
-      R"(
-// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (f8e4m3fn[1,6,6,16]{3,2,1,0}, u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]], [[OPERAND2:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
-  )",
-      // serialized_graph
-      R"(
-// CHECK: "serialized_graph":"conv[f32]-\u003einvscale[f8e4m3fn]-\u003e"
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();
       )");
 }
 
@@ -932,7 +932,56 @@ TEST_F(CudnnFusedConvRewriterTest, TestConvScaledReluActivationF8) {
   )",
       // serialized_graph
       R"(
-// CHECK: "serialized_graph":"conv[f32]-\u003erelu[f32]-\u003escale[f8e4m3fn]-\u003e"
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[RELU_UID:[0-9]+]]:[f32]relu([[CONV_UID]]);[[SCALE0_UID:[0-9]+]]:[f8e4m3fn]scale([[RELU_UID]],{{[0-9]+}});"
+      )");
+}
+
+TEST_F(CudnnFusedConvRewriterTest, TestConvAmaxF8) {
+  TestF8(
+      // pre_hlo
+      R"(
+    HloModule Test
+
+    apply {
+      a = f32[] parameter(0)
+      b = f32[] parameter(1)
+      ROOT c = f32[] maximum(a, b)
+    }
+
+    ENTRY Test {
+       input = f8e4m3fn[1,128,6,6] parameter(0)
+       filter = f8e4m3fn[3,3,128,16] parameter(1)
+       input_scale = f32[] parameter(2)
+       input_scale_bcast = f32[1,128,6,6] broadcast(input_scale), dimensions={}
+       filter_scale = f32[] parameter(3)
+       filter_scale_bcast = f32[3,3,128,16] broadcast(filter_scale), dimensions={}
+       input_f32 = f32[1,128,6,6] convert(input)
+       input_unscaled = f32[1,128,6,6] multiply(input_f32, input_scale_bcast)
+       filter_f32 = f32[3,3,128,16] convert(filter)
+       filter_unscaled = f32[3,3,128,16] multiply(filter_f32, filter_scale_bcast)
+       conv_a = f32[1,16,6,6] convolution(input_unscaled, filter_unscaled), window={size=3x3 pad=1_1x1_1}, dim_labels=bf01_01io->bf01, feature_group_count=1
+       z_scale = f32[] parameter(4)
+       z_scale_bcast = f32[1,16,6,6] broadcast(z_scale), dimensions={}
+       conv_a_scaled = f32[1,16,6,6] multiply(conv_a, z_scale_bcast)
+       c1 = f32[] constant(-448.)
+       c1_bcast = f32[1,16,6,6] broadcast(c1), dimensions={}
+       c2 = f32[] constant(448.)
+       c2_bcast = f32[1,16,6,6] broadcast(c2), dimensions={}
+       conv_a_clamped = f32[1,16,6,6] clamp(c1_bcast, conv_a_scaled, c2_bcast)
+       conv_a_clamped_f8 = f8e4m3fn[1,16,6,6] convert(conv_a_clamped)
+       abs_conv_a = f32[1,16,6,6] abs(conv_a)
+       c0 = f32[] constant(-inf)
+       amax = f32[] reduce(abs_conv_a, c0), dimensions={0,1,2,3}, to_apply=apply
+       ROOT conv_f8 = (f8e4m3fn[1,16,6,6], f32[]) tuple(conv_a_clamped_f8, amax)
+
+    })",
+      // custom_call
+      R"(
+// CHECK: [[cudnn_conv_4_0:%[^ ]+]] = (f8e4m3fn[1,6,6,16]{3,2,1,0}, f32[], u8[{{.*}}]{0}) custom-call([[OPERAND0:%[^ ]+]], [[OPERAND1:%[^ ]+]], [[OPERAND2:%[^ ]+]], [[OPERAND3:%[^ ]+]], [[OPERAND4:%[^ ]+]]), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForwardGraph"
+    )",
+      // serialized_graph
+      R"(
+// CHECK: "serialized_graph":"[[CONV_UID:[0-9]+]]:[f32]conv();[[SCALE0_UID:[0-9]+]]:[f32]scale([[CONV_UID]],{{[0-9]+}});[[SCALE1_UID:[0-9]+]]:[f32]scale([[SCALE0_UID]],{{[0-9]+}});[[SCALE2_UID:[0-9]+]]:[f8e4m3fn]scale([[SCALE1_UID]],{{[0-9]+}});[[AMAX_UID:[0-9]+]]:[f32]amax([[SCALE1_UID]]);"
       )");
 }
 

--- a/tensorflow/compiler/xla/service/gpu/gpu_autotuning.proto
+++ b/tensorflow/compiler/xla/service/gpu/gpu_autotuning.proto
@@ -10,7 +10,7 @@ import "tensorflow/compiler/xla/xla_data.proto";
 message ConvInstructionLog {
   xla.HloInstructionProto instruction = 1;
   repeated xla.ShapeProto operand_shapes = 2;
-  uint64 result_address = 3;
+  repeated uint64 result_addresses = 3;
   repeated uint64 operand_addresses = 4;
 }
 

--- a/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
+++ b/tensorflow/compiler/xla/service/gpu/gpu_conv_runner.h
@@ -90,9 +90,13 @@ struct GpuConvParams {
   se::DeviceMemoryBase filter_buf;
   se::DeviceMemoryBase output_buf;
 
-  // Buffers for operands of pointwise ops to be fused into the cuDNN
+  // Buffers for operands of ops to be fused into the cuDNN
   // convolution Custom Call.
   std::vector<se::DeviceMemoryBase> operand_bufs;
+
+  // Buffers for additional outputs of ops to be fused into the cuDNN
+  // convolution Custom Call.
+  std::vector<se::DeviceMemoryBase> aux_bufs;
 
   std::optional<FusionParams> fusion;
 };
@@ -212,7 +216,7 @@ struct RunConvOptions {
 // that size, if you like.
 Status RunGpuConv(const GpuConvConfig& conv_config,
                   absl::Span<const se::DeviceMemoryBase> operand_buffers,
-                  se::DeviceMemoryBase result_buffer,
+                  absl::Span<const se::DeviceMemoryBase> result_buffers,
                   se::DeviceMemoryBase scratch_memory, se::Stream* stream,
                   RunConvOptions = {});
 
@@ -245,7 +249,7 @@ StatusOr<GpuConvConfig> GetGpuConvConfig(const GpuConvDescriptor& desc,
 StatusOr<GpuConvParams> GetGpuConvParams(
     const GpuConvConfig& conv_config,
     absl::Span<const se::DeviceMemoryBase> operand_buffers,
-    se::DeviceMemoryBase result_buffer);
+    absl::Span<const se::DeviceMemoryBase> result_buffers);
 
 inline se::dnn::DataType BiasTypeForInputType(se::dnn::DataType input_type) {
   switch (input_type) {

--- a/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
+++ b/tensorflow/compiler/xla/service/gpu/ir_emitter_unnested.cc
@@ -890,18 +890,30 @@ Status IrEmitterUnnested::EmitConvolutionThunk(mlir::Operation* op) {
   using mlir::lmhlo_gpu::ConvForwardGraphOp;
   using mlir::lmhlo_gpu::ConvForwardOp;
 
-  // Last 2 operands of the convolution operation are the result and scratch.
-  std::vector<BufferAllocation::Slice> operand_slices;
+  std::vector<BufferAllocation::Slice> operand_slices, result_slices;
+  int32_t n_aux_outputs = 0;
+  if (auto conv = dyn_cast<ConvForwardGraphOp>(op)) {
+    n_aux_outputs = conv.getNAuxOutputs();
+  }
   int64_t num_operands = op->getNumOperands();
-  operand_slices.reserve(num_operands - 2);
-  for (mlir::Value operand : op->getOperands().drop_back(2)) {
+  operand_slices.reserve(num_operands - n_aux_outputs - 2);
+
+  // The operands describe inputs, the main result of the convolution, the
+  // scratch workspace and n_aux_outputs return values of ops fused into the
+  // convolution.
+  for (mlir::Value operand : op->getOperands().drop_back(2 + n_aux_outputs)) {
     TF_ASSIGN_OR_RETURN(auto slice, GetAllocationSlice(operand));
     operand_slices.push_back(slice);
   }
 
-  mlir::Value conv_result = op->getOperand(num_operands - 2);
+  result_slices.reserve(1 + n_aux_outputs);
+  for (mlir::Value result : op->getOperands()
+                                .drop_front(num_operands - n_aux_outputs - 2)
+                                .drop_back(1)) {
+    TF_ASSIGN_OR_RETURN(auto slice, GetAllocationSlice(result));
+    result_slices.push_back(slice);
+  }
   mlir::Value scratch_result = op->getOperand(num_operands - 1);
-  TF_ASSIGN_OR_RETURN(auto conv_result_slice, GetAllocationSlice(conv_result));
   TF_ASSIGN_OR_RETURN(auto scratch_slice, GetAllocationSlice(scratch_result));
 
   auto apply_layout = [](const Shape& shape,
@@ -919,8 +931,9 @@ Status IrEmitterUnnested::EmitConvolutionThunk(mlir::Operation* op) {
     descriptor.operand1_shape =
         apply_layout(GetShape(op->getOperand(1)),
                      op.getBackendConfig().getOperand_1Layout());
-    descriptor.result_shape = apply_layout(
-        GetShape(conv_result), op.getBackendConfig().getResultLayout());
+    descriptor.result_shape =
+        apply_layout(GetShape(op->getOperand(num_operands - n_aux_outputs - 2)),
+                     op.getBackendConfig().getResultLayout());
     descriptor.dnums = ConvertConvDimensionNumbers(op.getDimensionNumbers());
     descriptor.scratch_size = scratch_slice.size();
     mlir::DenseIntElementsAttr window_strides = op.getWindowStrides().value();
@@ -1009,7 +1022,7 @@ Status IrEmitterUnnested::EmitConvolutionThunk(mlir::Operation* op) {
   TF_ASSIGN_OR_RETURN(GpuConvConfig config, GetGpuConvConfig(descriptor, ""));
   AddThunkToThunkSequence(std::make_unique<ConvolutionThunk>(
       Thunk::ThunkInfo::WithProfileAnnotation(op), std::move(config),
-      std::move(operand_slices), conv_result_slice, scratch_slice));
+      std::move(operand_slices), std::move(result_slices), scratch_slice));
   return OkStatus();
 }
 

--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
@@ -4219,218 +4219,76 @@ OpNameStringToOperandKindAndMode(std::string opstring) {
 // Struct describing the convolution, pointwise and reduction ops in the
 // graph.
 struct OpDescriptor {
-  OpMode mode;
-  TensorKind operand_kind;
-  TensorKind result_kind;
-  dnn::DataType output_type;
+  int uid;                         // The UID of the op.
+  std::optional<int> operand_uid;  // The UID of the at most one operand of the
+                                   // op which is part of the graph.
+  OpMode mode;                     // The mode describing the op.
+  TensorKind operand_kind;    // The kind of a second operand (side input) not
+                              // represented in the graph.
+  TensorKind result_kind;     // The kind of the output.
+  dnn::DataType result_type;  // The type of the output.
+  bool is_virtual;            // A virtual op has a user within the graph.
+  int sequence_index;         // The index of the op in the sequence.
 };
 
 // Class describing the graph of ops to be fused into the cuDNN convolution
 // Custom Call.
 class OpGraph {
  public:
-  OpGraph() = default;
+  OpGraph() : ops_index_(0){};
 
-  tsl::Status AddOp(int uid, std::vector<int> operand_uids,
-                    OpDescriptor op_descriptor) {
-    uids_.emplace_back(uid);
-    user_uids_.try_emplace(uid, std::vector<int>{});
-    if (!graph_.try_emplace(uid, op_descriptor).second) {
-      return tsl::errors::Internal("ID already exists.");
-    }
-    // Add op as user to existing ops.
-    for (int operand_uid : operand_uids) {
-      if (std::find(uids_.begin(), uids_.end(), operand_uid) != uids_.end()) {
-        auto user = user_uids_.find(operand_uid);
-        if (user == user_uids_.end()) {
-          return {tsl::errors::Internal("Unknown ID.")};
-        }
-        user->second.emplace_back(uid);
+  tsl::Status AddOp(int uid, std::optional<int> operand_uid, OpMode mode,
+                    TensorKind operand_kind, TensorKind result_kind,
+                    dnn::DataType result_type) {
+    ops_.emplace_back(OpDescriptor({uid, operand_uid, mode, operand_kind,
+                                    result_kind, result_type, false, -1}));
+    // If it exists, the operand is virtual.
+    if (operand_uid.has_value()) {
+      auto it = std::find_if(
+          ops_.begin(), ops_.end(),
+          [operand_uid](OpDescriptor op) { return op.uid == operand_uid; });
+      if (it == ops_.end()) {
+        return tsl::errors::Internal("Unknown ID.");
       }
+      it->is_virtual = true;
     }
     return tsl::OkStatus();
   }
 
-  tsl::StatusOr<int> GetEntryOpUID() {
-    if (uids_.empty()) {
-      return tsl::errors::Internal("Empty graph.");
-    }
-    return uids_[0];
-  }
-
-  tsl::StatusOr<std::vector<int>> GetUserUIDs(int uid) {
-    auto user_uids = user_uids_.find(uid);
-    if (user_uids == user_uids_.end()) {
-      return {tsl::errors::Internal("Unknown ID.")};
-    }
-    return user_uids->second;
-  }
-
-  tsl::StatusOr<OpDescriptor> GetOpDescriptor(int uid) {
-    auto op = graph_.find(uid);
-    if (op == graph_.end()) {
+  tsl::StatusOr<OpDescriptor> FindOpDescriptor(int uid) const {
+    auto it = std::find_if(ops_.begin(), ops_.end(),
+                           [uid](OpDescriptor op) { return op.uid == uid; });
+    if (it == ops_.end()) {
       return tsl::errors::Internal("Unknown ID.");
     }
-    return op->second;
+    return *it;
   }
 
-  tsl::StatusOr<bool> IsVirtualOp(int uid) {
-    auto user_uids = user_uids_.find(uid);
-    if (user_uids == user_uids_.end()) {
+  std::optional<OpDescriptor> NextOpDescriptor() {
+    if (ops_.size() > ops_index_) {
+      return ops_[ops_index_++];
+    }
+    return std::nullopt;
+  }
+
+  tsl::Status SetSequenceIndex(int uid, int index) {
+    auto it = std::find_if(ops_.begin(), ops_.end(),
+                           [uid](OpDescriptor op) { return op.uid == uid; });
+    if (it == ops_.end()) {
       return tsl::errors::Internal("Unknown ID.");
     }
-    return !user_uids->second.empty();
+    it->sequence_index = index;
+    return tsl::OkStatus();
   }
 
-  bool Empty() { return uids_.empty(); }
+  bool Empty() const { return ops_.empty(); }
 
-  int Size() { return uids_.size(); }
+  int Size() const { return ops_.size(); }
 
  private:
-  std::vector<int> uids_;
-  absl::flat_hash_map<int, std::vector<int>> user_uids_;
-  absl::flat_hash_map<int, OpDescriptor> graph_;
+  int ops_index_;
+  std::vector<OpDescriptor> ops_;
 };
-
-tsl::Status GetCudnnOperationsGraphRecursive(
-    OpGraph op_graph, std::vector<cudnn_frontend::Operation>& ops,
-    int entry_op_uid, std::vector<int64_t>& virtual_uids,
-    std::vector<int64_t>& operand_uids, std::vector<int64_t>& output_uids,
-    const cudnn_frontend::Tensor& tensor_y) {
-  TF_ASSIGN_OR_RETURN(OpDescriptor entry_op,
-                      op_graph.GetOpDescriptor(entry_op_uid));
-  TF_ASSIGN_OR_RETURN(std::vector<int> user_uids,
-                      op_graph.GetUserUIDs(entry_op_uid));
-
-  auto next_uid = [&operand_uids, &output_uids, &virtual_uids](
-                      bool is_operand, bool is_virtual) -> int64_t {
-    int64_t max_operand_uid =
-        operand_uids.empty()
-            ? 0
-            : *std::max_element(operand_uids.begin(), operand_uids.end());
-    int64_t max_output_uid =
-        output_uids.empty()
-            ? 0
-            : *std::max_element(output_uids.begin(), output_uids.end());
-    int64_t max_virtual_uid =
-        virtual_uids.empty()
-            ? 0
-            : *std::max_element(virtual_uids.begin(), virtual_uids.end());
-    int64_t next_uid =
-        std::max({max_operand_uid, max_output_uid, max_virtual_uid}) + 1;
-
-    if (is_operand) {
-      return operand_uids.emplace_back(next_uid);
-    } else {
-      if (is_virtual) {
-        return virtual_uids.emplace_back(next_uid);
-      } else {
-        return output_uids.emplace_back(next_uid);
-      }
-    }
-  };
-
-  const int preceding_op = ops.size() - 1;
-  for (int user_uid : user_uids) {
-    TF_ASSIGN_OR_RETURN(OpDescriptor op_descriptor,
-                        op_graph.GetOpDescriptor(user_uid));
-    std::optional<cudnn_frontend::Tensor> second_operand, result;
-
-    // Create cuDNN tensors for operands of binary ops (side inputs).
-    if (op_descriptor.operand_kind == TensorKind::kScalar) {
-      std::vector<int64_t> scale_dim(4, 1);
-      TF_ASSIGN_OR_RETURN(
-          second_operand,
-          CreateCudnnTensor(scale_dim, scale_dim,
-                            next_uid(/*is_operand=*/true, /*is_virtual=*/false),
-                            entry_op.output_type, 1, -1));
-      VLOG(4) << "\nPointwise operand: " << second_operand->describe();
-    } else if (op_descriptor.operand_kind == TensorKind::kTensor) {
-      TF_ASSIGN_OR_RETURN(
-          second_operand,
-          CreateCudnnTensor(tensor_y,
-                            next_uid(/*is_operand=*/true, /*is_virtual=*/false),
-                            entry_op.output_type,
-                            /*is_virtual=*/false));
-      VLOG(4) << "\nPointwise operand: " << second_operand->describe();
-    }
-
-    // Create the result tensor of the op.
-    if (op_descriptor.result_kind == TensorKind::kScalar) {
-      std::vector<int64_t> scale_dim(4, 1);
-      TF_ASSIGN_OR_RETURN(
-          result, CreateCudnnTensor(
-                      scale_dim, scale_dim,
-                      next_uid(/*is_operand=*/false, /*is_virtual=*/false),
-                      op_descriptor.output_type, 1, -1));
-      VLOG(4) << "\nScalar result: " << result->describe();
-    } else if (op_descriptor.result_kind == TensorKind::kTensor) {
-      TF_ASSIGN_OR_RETURN(bool is_virtual_op, op_graph.IsVirtualOp(user_uid));
-      TF_ASSIGN_OR_RETURN(
-          result, CreateCudnnTensor(tensor_y,
-                                    next_uid(/*is_operand=*/false,
-                                             /*is_virtual=*/is_virtual_op),
-                                    op_descriptor.output_type,
-                                    /*is_virtual=*/is_virtual_op));
-      VLOG(4) << "\nTensor result: " << result->describe();
-    }
-
-    if (std::holds_alternative<cudnnPointwiseMode_t>(op_descriptor.mode)) {
-      // Create the descriptor for the pointwise op.
-      cudnn_frontend::PointWiseDesc desc =
-          cudnn_frontend::PointWiseDescBuilder()
-              .setMode(std::get<cudnnPointwiseMode_t>(op_descriptor.mode))
-              .setMathPrecision(CUDNN_DATA_FLOAT)
-              .build();
-      VLOG(4) << "\nPointwise op desc: " << desc.describe();
-
-      // Add the op to the operation graph.
-      if (second_operand.has_value()) {
-        ops.emplace_back(cudnn_frontend::OperationBuilder(
-                             CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                             .setxDesc(ops[preceding_op].getOutputTensor())
-                             .setbDesc(second_operand.value())
-                             .setyDesc(result.value())
-                             .setpwDesc(desc)
-                             .build());
-
-      } else {
-        ops.emplace_back(cudnn_frontend::OperationBuilder(
-                             CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
-                             .setxDesc(ops[preceding_op].getOutputTensor())
-                             .setyDesc(result.value())
-                             .setpwDesc(desc)
-                             .build());
-      }
-    } else if (std::holds_alternative<cudnnReduceTensorOp_t>(
-                   op_descriptor.mode)) {
-      // Create the descriptor for the reduction op.
-      cudnn_frontend::ReductionDesc desc =
-          cudnn_frontend::ReductionDescBuilder()
-              .setMathPrecision(CUDNN_DATA_FLOAT)
-              .setReductionOp(
-                  std::get<cudnnReduceTensorOp_t>(op_descriptor.mode))
-              .build();
-      VLOG(4) << "\nReduction op desc: " << desc.describe();
-
-      // Add the op to the operation graph.
-      ops.emplace_back(cudnn_frontend::OperationBuilder(
-                           CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
-                           .setxDesc(ops[preceding_op].getOutputTensor())
-                           .setyDesc(result.value())
-                           .setreductionDesc(desc)
-                           .build());
-    }
-
-    RETURN_MSG_IF_CUDNN_ERROR(ops.back());
-    VLOG(4) << "\nOp: " << ops.back().describe();
-
-    TF_RETURN_IF_ERROR(
-        GetCudnnOperationsGraphRecursive(op_graph, ops, user_uid, virtual_uids,
-                                         operand_uids, output_uids, tensor_y));
-  }
-  return tsl::OkStatus();
-}
 
 // TODO(philipphack): Consider merging with GetCudnnOperationGraph and
 // GetCudnnFusedOperationGraph.
@@ -4449,36 +4307,42 @@ GetGenericCudnnOperationGraph(
     CudnnHandle& cudnn, std::string serialized_graph = "") {
   PreloadCudnnSubLibsHelper(kind);
 
-  // The format of the serialized graph describing pointwise and reduction ops
-  // fused into the cuDNN convolution Custom Call is
-  // "UID:[output_type]conv({operand UIDs});UID:[output_type]op_name({operand
-  // UIDs});...". The convolution is assumed to be first op in the graph.
+  // The format of the serialized graph describing a sequence of ops fused
+  // into the cuDNN convolution Custom Call is
+  // "UID:[output_type]conv();UID[output_type]:op_name(operand
+  // UID);UID:[output_type]op_name(operand UID);..." with the convolution
+  // assumed to be the first op in the graph. Operand UIDs identifying ops
+  // outside the serialized graph are elided.
   auto deserialize_cudnn_graph = [&]() -> tsl::StatusOr<OpGraph> {
     OpGraph op_graph;
     std::string::size_type pos = 0;
     while (pos < serialized_graph.size()) {
       OpMode mode;
       dnn::DataType output_type;
-      TensorKind binary_operand_kind, output_kind;
       std::string::size_type m = serialized_graph.find('[', pos);
       std::string::size_type n = serialized_graph.find(']', pos);
-      int uid = std::stoi(serialized_graph.substr(pos, m - pos));
+      int uid = std::stoi(serialized_graph.substr(pos, m - pos - 1));
       std::string data_type_string = serialized_graph.substr(m + 1, n - m - 1);
       m = serialized_graph.find('(', pos);
       std::string op_string = serialized_graph.substr(n + 1, m - n - 1);
-      std::vector<int> operands;
+      std::optional<int> operand;
       do {
         std::string::size_type l = serialized_graph.find_first_of(",)", m + 1);
         if (l > m + 1) {
-          operands.emplace_back(
-              std::stoi(serialized_graph.substr(m + 1, l - m - 1)));
+          operand = std::stoi(serialized_graph.substr(m + 1, l - m - 1));
         }
         m = l;
       } while (serialized_graph[m] != ')');
 
-      pos = serialized_graph.find(';', pos + 1) + 1;
+      if (serialized_graph.find(';', pos) != m + 1) {
+        return tsl::errors::Internal(
+            "Unexpected character in graph serialization.");
+      }
+      pos = m + 2;
+
       TF_ASSIGN_OR_RETURN(output_type,
                           PrimitiveTypeStringToDnnType(data_type_string));
+      TensorKind binary_operand_kind, output_kind;
       if (op_string == "conv") {
         if (!op_graph.Empty()) {
           return tsl::errors::Internal(
@@ -4495,9 +4359,8 @@ GetGenericCudnnOperationGraph(
         TF_ASSIGN_OR_RETURN(std::tie(binary_operand_kind, output_kind, mode),
                             OpNameStringToOperandKindAndMode(op_string));
       }
-      TF_RETURN_IF_ERROR(op_graph.AddOp(
-          uid, operands,
-          {mode, binary_operand_kind, output_kind, output_type}));
+      TF_RETURN_IF_ERROR(op_graph.AddOp(uid, operand, mode, binary_operand_kind,
+                                        output_kind, output_type));
     }
     return op_graph;
   };
@@ -4510,6 +4373,33 @@ GetGenericCudnnOperationGraph(
   std::vector<int64_t> virtual_uids, operand_uids, output_uids;
   std::vector<cudnn_frontend::Operation> ops;
 
+  auto next_uid = [&operand_uids, &output_uids, &virtual_uids](
+                      bool is_operand, bool is_virtual) -> int64_t {
+    DCHECK(!(is_operand && is_virtual));
+    int64_t max_operand_uid =
+        operand_uids.empty()
+            ? 0
+            : *std::max_element(operand_uids.begin(), operand_uids.end());
+    int64_t max_output_uid =
+        output_uids.empty()
+            ? 0
+            : *std::max_element(output_uids.begin(), output_uids.end());
+    int64_t max_virtual_uid =
+        virtual_uids.empty()
+            ? 0
+            : *std::max_element(virtual_uids.begin(), virtual_uids.end());
+    int64_t next_uid =
+        std::max({max_operand_uid, max_output_uid, max_virtual_uid}) + 1;
+
+    if (is_operand) {
+      return operand_uids.emplace_back(next_uid);
+    }
+    if (is_virtual) {
+      return virtual_uids.emplace_back(next_uid);
+    }
+    return output_uids.emplace_back(next_uid);
+  };
+
   //  Input tensor.
   int vector_size, vector_dim;
   std::tie(vector_size, vector_dim) =
@@ -4521,7 +4411,8 @@ GetGenericCudnnOperationGraph(
 
   TF_ASSIGN_OR_RETURN(
       auto tensor_x,
-      CreateCudnnTensor(input_dims, input_strides, operand_uids.emplace_back(1),
+      CreateCudnnTensor(input_dims, input_strides,
+                        next_uid(/*is_operand=*/true, /*is_virtual=*/false),
                         input_type, vector_size, vector_dim));
 
   // Filter tensor.
@@ -4540,16 +4431,14 @@ GetGenericCudnnOperationGraph(
   TF_ASSIGN_OR_RETURN(
       auto tensor_w,
       CreateCudnnTensor(filter_dims, filter_strides,
-                        operand_uids.emplace_back(2), input_type, vector_size,
-                        vector_dim,
+                        next_uid(/*is_operand=*/true, /*is_virtual=*/false),
+                        input_type, vector_size, vector_dim,
                         /*is_virtual=*/false, tensor_ordering_type));
 
   // Result tensor.
-  TF_ASSIGN_OR_RETURN(int entry_op_uid, op_graph.GetEntryOpUID());
-  TF_ASSIGN_OR_RETURN(OpDescriptor entry_op,
-                      op_graph.GetOpDescriptor(entry_op_uid));
+  std::optional<OpDescriptor> op_descriptor = op_graph.NextOpDescriptor();
   std::tie(vector_size, vector_dim) =
-      GetTensorVectorSizeAndDim(output_descriptor, entry_op.output_type);
+      GetTensorVectorSizeAndDim(output_descriptor, op_descriptor->result_type);
   std::vector<int64_t> output_dims = output_descriptor.vectorized_dims(
       dnn::DataLayout::kBatchDepthYX, vector_size, vector_dim);
   std::vector<int64_t> output_strides = output_descriptor.vectorized_strides(
@@ -4558,10 +4447,10 @@ GetGenericCudnnOperationGraph(
   TF_ASSIGN_OR_RETURN(
       auto tensor_y,
       CreateCudnnTensor(output_dims, output_strides,
-                        op_graph.Size() > 1 ? virtual_uids.emplace_back(3)
-                                            : output_uids.emplace_back(3),
-                        entry_op.output_type, vector_size, vector_dim,
-                        /*is_virtual=*/op_graph.Size() > 1));
+                        next_uid(/*is_operand=*/false,
+                                 /*is_virtual=*/op_descriptor->is_virtual),
+                        op_descriptor->result_type, vector_size, vector_dim,
+                        /*is_virtual=*/op_descriptor->is_virtual));
 
   auto accumulator_type = ToCudnnDataType(GetConvAccumulatorType(input_type));
   CHECK_NE(convolution_descriptor.pad_alignment(),
@@ -4572,7 +4461,7 @@ GetGenericCudnnOperationGraph(
   auto conv_desc =
       cudnn_frontend::ConvDescBuilder()
           .setComputeType(accumulator_type)
-          .setMathMode(std::get<cudnnConvolutionMode_t>(entry_op.mode))
+          .setMathMode(std::get<cudnnConvolutionMode_t>(op_descriptor->mode))
           .setSpatialDimCount(conv_dim)
           .setSpatialStride(conv_dim, convolution_descriptor.strides().data())
           .setPrePadding(conv_dim, convolution_descriptor.padding().data())
@@ -4596,6 +4485,8 @@ GetGenericCudnnOperationGraph(
   RETURN_MSG_IF_CUDNN_ERROR(op);
   // Add the convolution to the cuDNN graph.
   ops.push_back(std::move(op));
+  TF_RETURN_IF_ERROR(
+      op_graph.SetSequenceIndex(op_descriptor->uid, ops.size() - 1));
 
   VLOG(4) << "\nTensor_x: " << tensor_x.describe()
           << "\nTensor_y: " << tensor_y.describe()
@@ -4603,10 +4494,102 @@ GetGenericCudnnOperationGraph(
           << "\nConv desc: " << conv_desc.describe()
           << "\nOp: " << ops.back().describe();
 
-  // Add any pointwise ops to the cuDNN graph.
-  TF_RETURN_IF_ERROR(GetCudnnOperationsGraphRecursive(
-      op_graph, ops, entry_op_uid, virtual_uids, operand_uids, output_uids,
-      tensor_y));
+  while (op_descriptor = op_graph.NextOpDescriptor()) {
+    std::optional<cudnn_frontend::Tensor> second_operand, result;
+    TF_ASSIGN_OR_RETURN(
+        OpDescriptor preceding_op,
+        op_graph.FindOpDescriptor(op_descriptor->operand_uid.value()));
+
+    // Create cuDNN tensors for operands of binary ops (side inputs).
+    if (op_descriptor->operand_kind == TensorKind::kScalar) {
+      std::vector<int64_t> scale_dim(4, 1);
+      TF_ASSIGN_OR_RETURN(
+          second_operand,
+          CreateCudnnTensor(scale_dim, scale_dim,
+                            next_uid(/*is_operand=*/true, /*is_virtual=*/false),
+                            preceding_op.result_type, 1, -1));
+      VLOG(4) << "\nPointwise operand: " << second_operand->describe();
+    } else if (op_descriptor->operand_kind == TensorKind::kTensor) {
+      TF_ASSIGN_OR_RETURN(
+          second_operand,
+          CreateCudnnTensor(tensor_y,
+                            next_uid(/*is_operand=*/true, /*is_virtual=*/false),
+                            preceding_op.result_type,
+                            /*is_virtual=*/false));
+      VLOG(4) << "\nPointwise operand: " << second_operand->describe();
+    }
+
+    // Create the result tensor of the op.
+    if (op_descriptor->result_kind == TensorKind::kScalar) {
+      std::vector<int64_t> scale_dim(4, 1);
+      TF_ASSIGN_OR_RETURN(
+          result, CreateCudnnTensor(
+                      scale_dim, scale_dim,
+                      next_uid(/*is_operand=*/false, /*is_virtual=*/false),
+                      op_descriptor->result_type, 1, -1));
+      VLOG(4) << "\nScalar result: " << result->describe();
+    } else if (op_descriptor->result_kind == TensorKind::kTensor) {
+      TF_ASSIGN_OR_RETURN(
+          result,
+          CreateCudnnTensor(tensor_y,
+                            next_uid(/*is_operand=*/false,
+                                     /*is_virtual=*/op_descriptor->is_virtual),
+                            op_descriptor->result_type,
+                            /*is_virtual=*/op_descriptor->is_virtual));
+      VLOG(4) << "\nTensor result: " << result->describe();
+    }
+
+    if (std::holds_alternative<cudnnPointwiseMode_t>(op_descriptor->mode)) {
+      // Create the descriptor for the pointwise op.
+      cudnn_frontend::PointWiseDesc desc =
+          cudnn_frontend::PointWiseDescBuilder()
+              .setMode(std::get<cudnnPointwiseMode_t>(op_descriptor->mode))
+              .setMathPrecision(CUDNN_DATA_FLOAT)
+              .build();
+      VLOG(4) << "\nPointwise op desc: " << desc.describe();
+      // Add the op to the operation graph.
+      if (second_operand.has_value()) {
+        ops.emplace_back(
+            cudnn_frontend::OperationBuilder(
+                CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                .setxDesc(ops[preceding_op.sequence_index].getOutputTensor())
+                .setbDesc(second_operand.value())
+                .setyDesc(result.value())
+                .setpwDesc(desc)
+                .build());
+
+      } else {
+        ops.emplace_back(
+            cudnn_frontend::OperationBuilder(
+                CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                .setxDesc(ops[preceding_op.sequence_index].getOutputTensor())
+                .setyDesc(result.value())
+                .setpwDesc(desc)
+                .build());
+      }
+    } else if (std::holds_alternative<cudnnReduceTensorOp_t>(
+                   op_descriptor->mode)) {
+      // Create the descriptor for the reduction op.
+      cudnn_frontend::ReductionDesc desc =
+          cudnn_frontend::ReductionDescBuilder()
+              .setMathPrecision(CUDNN_DATA_FLOAT)
+              .setReductionOp(
+                  std::get<cudnnReduceTensorOp_t>(op_descriptor->mode))
+              .build();
+      VLOG(4) << "\nReduction op desc: " << desc.describe();
+
+      // Add the op to the operation graph.
+      ops.emplace_back(
+          cudnn_frontend::OperationBuilder(
+              CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+              .setxDesc(ops[preceding_op.sequence_index].getOutputTensor())
+              .setyDesc(result.value())
+              .setreductionDesc(desc)
+              .build());
+    }
+    TF_RETURN_IF_ERROR(
+        op_graph.SetSequenceIndex(op_descriptor->uid, ops.size() - 1));
+  }
 
   // Construct the cuDNN OperationGraph.
   auto opGraph = cudnn_frontend::OperationGraphBuilder()

--- a/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc
@@ -4326,19 +4326,16 @@ GetGenericCudnnOperationGraph(
       m = serialized_graph.find('(', pos);
       std::string op_string = serialized_graph.substr(n + 1, m - n - 1);
       std::optional<int> operand;
-      do {
-        std::string::size_type l = serialized_graph.find_first_of(",)", m + 1);
-        if (l > m + 1) {
-          operand = std::stoi(serialized_graph.substr(m + 1, l - m - 1));
-        }
-        m = l;
-      } while (serialized_graph[m] != ')');
+      std::string::size_type l = serialized_graph.find(')', m + 1);
+      if (l > m + 1) {
+        operand = std::stoi(serialized_graph.substr(m + 1, l - m - 1));
+      }
 
-      if (serialized_graph.find(';', pos) != m + 1) {
+      if (serialized_graph.find(';', pos) != l + 1) {
         return tsl::errors::Internal(
             "Unexpected character in graph serialization.");
       }
-      pos = m + 2;
+      pos = l + 2;
 
       TF_ASSIGN_OR_RETURN(output_type,
                           PrimitiveTypeStringToDnnType(data_type_string));

--- a/tensorflow/compiler/xla/stream_executor/dnn.cc
+++ b/tensorflow/compiler/xla/stream_executor/dnn.cc
@@ -158,7 +158,7 @@ tsl::Status DnnSupport::GetGraphConvolveRunners(
     const dnn::ConvolutionDescriptor& /*convolution_descriptor*/,
     bool /*use_fallback*/, const NumericOptions& /*numeric_options*/,
     std::vector<std::unique_ptr<const dnn::GraphConvRunner>>* /*exec_plans*/,
-    std::string serialized_graph) {
+    std::string /*serialized_graph*/) {
   return tsl::errors::Unimplemented("GetGraphConvolveRunners not implemented.");
 }
 


### PR DESCRIPTION
Extends the functionality of scaled convolutions operating on `F8E4M3FN` and `F8E5M2` data types to optionally return the scalar maximum of the absolute (Amax) of the result before quantization,

(X, W, x_scale, w_scale, y_scale) -> (Y, y_amax).
