### PR TITLE
[TFLite] Fix label_image CMake build

### DIFF
--- a/tensorflow/lite/examples/label_image/CMakeLists.txt
+++ b/tensorflow/lite/examples/label_image/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND TFLITE_LABEL_IMAGE_SRCS
 if(TFLITE_ENABLE_XNNPACK)
   list(APPEND TFLITE_LABEL_IMAGE_SRCS
     ${TFLITE_SOURCE_DIR}/tools/delegates/xnnpack_delegate_provider.cc
+    ${TFLITE_SOURCE_DIR}/core/acceleration/configuration/c/xnnpack_plugin.cc
   )
 else()
   set(TFLITE_LABEL_IMAGE_CC_OPTIONS "-DTFLITE_WITHOUT_XNNPACK")


### PR DESCRIPTION
Building the label_image example currently fails with:

```
/usr/bin/ld: CMakeFiles/label_image.dir/__/__/tools/evaluation/utils.cc.o: in function `tflite::evaluation::CreateXNNPACKDelegate(TfLiteXNNPackDelegateOptions const*)':
utils.cc:(.text+0xfa1): undefined reference to `TfLiteXnnpackDelegatePluginCApi'
collect2: error: ld returned 1 exit status
make[3]: *** [examples/label_image/CMakeFiles/label_image.dir/build.make:349: examples/label_image/label_image] Error 1
make[2]: *** [CMakeFiles/Makefile2:25924: examples/label_image/CMakeFiles/label_image.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:25931: examples/label_image/CMakeFiles/label_image.dir/rule] Error 2
make: *** [Makefile:4946: label_image] Error 2
```
It seems like there is no CI build set up that builds the label_image example using CMake.
Unfortunately I wasn't able to figure out how one would add a build.