### PR TITLE
[TFLite] Fix cmake build kernel test fail

### DIFF
--- a/tensorflow/lite/kernels/CMakeLists.txt
+++ b/tensorflow/lite/kernels/CMakeLists.txt
@@ -91,6 +91,7 @@ set(TEST_FRAMEWORK_SRC
   ${TFLITE_SOURCE_DIR}/tools/optimize/operator_property.cc
   ${TFLITE_SOURCE_DIR}/tools/optimize/quantization_utils.cc
   ${TFLITE_SOURCE_DIR}/tools/tool_params.cc
+  ${TFLITE_SOURCE_DIR}/tools/versioning/op_signature.cc
   ${TFLITE_SOURCE_DIR}/tools/versioning/op_version.cc
   ${TF_SOURCE_DIR}/tsl/platform/default/env_time.cc
   ${TF_SOURCE_DIR}/tsl/platform/default/logging.cc

--- a/tensorflow/lite/kernels/CMakeLists.txt
+++ b/tensorflow/lite/kernels/CMakeLists.txt
@@ -91,7 +91,6 @@ set(TEST_FRAMEWORK_SRC
   ${TFLITE_SOURCE_DIR}/tools/optimize/operator_property.cc
   ${TFLITE_SOURCE_DIR}/tools/optimize/quantization_utils.cc
   ${TFLITE_SOURCE_DIR}/tools/tool_params.cc
-  ${TFLITE_SOURCE_DIR}/tools/versioning/op_signature.cc
   ${TFLITE_SOURCE_DIR}/tools/versioning/op_version.cc
   ${TF_SOURCE_DIR}/tsl/platform/default/env_time.cc
   ${TF_SOURCE_DIR}/tsl/platform/default/logging.cc
@@ -106,6 +105,11 @@ set(TEST_FRAMEWORK_SRC
 if(NOT _TFLITE_ENABLE_NNAPI)
   list(APPEND TEST_FRAMEWORK_SRC
     ${TFLITE_SOURCE_DIR}/nnapi/nnapi_util.cc
+  )
+endif()
+if(NOT TFLITE_ENABLE_GPU)
+  list(APPEND TEST_FRAMEWORK_SRC
+    ${TFLITE_SOURCE_DIR}/tools/versioning/op_signature.cc
   )
 endif()
 


### PR DESCRIPTION
- Problem:

Using CMake to build the TFLite kernel test will fail in linking stage.

- Error log

```
[ 87%] Linking CXX executable unpack_test
ld: libtensorflow-lite-test-base.a(op_version.cc.o): in function `.LBB1_18':
op_version.cc:(.text._ZN6tflite15UpdateOpVersionEPh+0x14c): undefined reference to `tflite::GetOpSignature(tflite::OperatorCode const*, tflite::Operator const*, tflite::SubGraph const*, tflite::Model const*)'
clang++: rror: linker command failed with exit code 1 (use -v to see invocation)
```

- Solution:

Add `versioning/op_signature.cc` to `TEST_FRAMEWORK_SRC`. `versioning/op_version.cc` depends on `versioning/op_signature.cc` because of using GetOpSignature().