### PR TITLE
[Linaro:ARM_CI] Run build tests

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_cpp.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_cpp.sh
@@ -20,19 +20,9 @@ set -x
 source tensorflow/tools/ci_build/release/common.sh
 
 sudo install -o ${CI_BUILD_USER} -g ${CI_BUILD_GROUP} -d /tmpfs
-sudo install -o ${CI_BUILD_USER} -g ${CI_BUILD_GROUP} -d /tensorflow
-sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/lib/python*
-sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/local/bin
-sudo chown -R ${CI_BUILD_USER}:${CI_BUILD_GROUP} /usr/lib/python3/dist-packages
 
 # Update bazel
 install_bazelisk
-
-# Set python version string
-python_version=$(python3 -c 'import sys; print("python"+str(sys.version_info.major)+"."+str(sys.version_info.minor))')
-
-# Setup virtual environment
-setup_venv_ubuntu ${python_version}
 
 # Env vars used to avoid interactive elements of the build.
 export HOST_C_COMPILER=(which gcc)
@@ -71,7 +61,7 @@ source tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS_EXTENDED.sh
 export TF_BUILD_FLAGS="--config=mkl_aarch64_threadpool --copt=-flax-vector-conversions"
 export TF_TEST_FLAGS="${TF_BUILD_FLAGS} \
     --test_env=TF_ENABLE_ONEDNN_OPTS=1 --test_env=TF2_BEHAVIOR=1 --define=tf_api_version=2 \
-    --test_lang_filters=cc --test_size_filters=small,medium \
+    --test_lang_filters=-py --test_size_filters=small,medium \
     --test_output=errors --verbose_failures=true --test_keep_going --notest_verbose_timeout_warnings"
 export TF_TEST_TARGETS="${DEFAULT_BAZEL_TARGETS} ${ARM_SKIP_TESTS}"
 export TF_FILTER_TAGS="-no_oss,-oss_excluded,-oss_serial,-v1only,-benchmark-test,-no_aarch64,-gpu,-tpu,-no_oss_py39,-no_oss_py310"
@@ -91,6 +81,3 @@ bazel test ${TF_TEST_FLAGS} \
     --local_test_jobs=$(grep -c ^processor /proc/cpuinfo) \
     --build_tests_only \
     -- ${TF_TEST_TARGETS}
-
-# Remove virtual environment
-remove_venv_ubuntu


### PR DESCRIPTION
The build tests and similar have an empty language tag and so will not run when test_lang_filters has a positive language choice, so change it to use a negative choice to exclude the python based tests that are tested in a different script.
Also remove use of python venv that is no longer useful.