### PR TITLE
Fixing build issue with Clang 16

### DIFF
--- a/tensorflow/tsl/lib/io/cache.h
+++ b/tensorflow/tsl/lib/io/cache.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_TSL_LIB_IO_CACHE_H_
 #define TENSORFLOW_TSL_LIB_IO_CACHE_H_
 
+#include <cstdint>
+
 #include "tensorflow/tsl/platform/stringpiece.h"
 
 // A Cache is an interface that maps keys to values.  It has internal


### PR DESCRIPTION
This is a PR which fixes the TensorFlow build when using Clang 16; this file previously used `uint64_t` without including the proper header.

#61289 