### PR TITLE
Update link to the training information in build_convert.md

### DIFF
--- a/tensorflow/lite/g3doc/microcontrollers/build_convert.md
+++ b/tensorflow/lite/g3doc/microcontrollers/build_convert.md
@@ -9,10 +9,11 @@ This document explains the process of converting a TensorFlow model to run on
 microcontrollers. It also outlines the supported operations and gives some
 guidance on designing and training a model to fit in limited memory.
 
-For an end-to-end, runnable example of building and converting a model, see the
-following Colab which is part of the *Hello World* example:
+For an end-to-end, runnable example of building and converting a model that 
+replicates a sine function, see the
+[train.py](https://github.com/tensorflow/tflite-micro/blob/main/tensorflow/lite/micro/examples/hello_world/train.py) 
+which is part of the *Hello World* example
 
-<a class="button button-primary" href="https://colab.research.google.com/github/tensorflow/tflite-micro/blob/main/tensorflow/lite/micro/examples/hello_world/train/train_hello_world_model.ipynb">train_hello_world_model.ipynb</a>
 
 ## Model conversion
 


### PR DESCRIPTION
The link to the colab notebook about training is broken and it is now updated with `train.py` in the hello world example.

Thanks.