### PR TITLE
Fix undefined reference to memset

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/4bit/neon_fully_connected.cc
+++ b/tensorflow/lite/kernels/internal/optimized/4bit/neon_fully_connected.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <arm_neon.h>
 #include <stdint.h>
 #include <algorithm>
+#include <cstring>
 #include <vector>
 
 #include "include/cpuinfo.h"


### PR DESCRIPTION
Add include of cstring to resolve symbol

Fixes: https://github.com/tensorflow/tensorflow/issues/61584