### PR TITLE
Updated Windows Release Build File

### DIFF
--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -101,14 +101,15 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-if [[ "$RELEASE_BUILD" == 1 ]]; then
-  # Overriding eigen strong inline speeds up the compiling of conv_grad_ops_3d.cc and conv_ops_3d.cc
-  # by 20 minutes. See https://github.com/tensorflow/tensorflow/issues/10521
-  # Because this hurts the performance of TF, we don't override it in release build.
-  export TF_OVERRIDE_EIGEN_STRONG_INLINE=0
-else
-  export TF_OVERRIDE_EIGEN_STRONG_INLINE=1
-fi
+# Overriding eigen strong inline speeds up the compiling of conv_grad_ops_3d.cc and conv_ops_3d.cc
+# by 20 minutes. See https://github.com/tensorflow/tensorflow/issues/10521
+# Because this hurts the performance of TF, we don't override it in the release build. 
+# TF_OVERRIDE_EIGEN_STRONG_INLINE=1 reduces the size of simple_console_windows.zip
+# Set Flag to 1 for both Nightly and Release as a workaround for zipper failing > 4BG
+# TODO(Intel): Remove this when the issues is fixed
+
+export TF_OVERRIDE_EIGEN_STRONG_INLINE=1
+
 
 if [[ "$TF_NIGHTLY" == 1 ]]; then
   if [[ ${PROJECT_NAME} == *"2.0_preview"* ]]; then


### PR DESCRIPTION
The TensorFlow CPU release build was failing on the Windows platform. The reason for the failure was the creation of a large zip file named simple_console_for_windows.zip, whose size was 4GB exceeding the limit zipper.exe could handle.

Solution:
Overriding the EIGEN_STRONG_INLINE macro resolved the issue by keeping the size of simple_console_for_windows.zip under the limit of zipper.exe.
Changed the flag "TF_OVERRIDE_EIGEN_STRONG_INLINE" to 1 in
/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh file while running the release build