### PR TITLE
TFLite XNNPack Delegate: use kernel size of 5 for correspondingly named tests

### DIFF
--- a/tensorflow/lite/delegates/xnnpack/depthwise_conv_2d_test.cc
+++ b/tensorflow/lite/delegates/xnnpack/depthwise_conv_2d_test.cc
@@ -130,8 +130,8 @@ TEST(DepthwiseConv2D, 5x5) {
       .InputHeight(input_rng())
       .InputWidth(input_rng())
       .InputChannels(channel_rng())
-      .KernelHeight(3)
-      .KernelWidth(3)
+      .KernelHeight(5)
+      .KernelWidth(5)
       .SamePadding()
       .Test(xnnpack_delegate.get());
 }
@@ -152,8 +152,8 @@ TEST(DepthwiseConv2D, 5x5Stride2) {
       .InputHeight(input_rng())
       .InputWidth(input_rng())
       .InputChannels(channel_rng())
-      .KernelHeight(3)
-      .KernelWidth(3)
+      .KernelHeight(5)
+      .KernelWidth(5)
       .StrideHeight(2)
       .StrideWidth(2)
       .SamePadding()


### PR DESCRIPTION
The [documentation](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/delegates/xnnpack/README.md#sparse-inference) explicitly states that 5x5 kernels are supported and the test heads suggest, that kernel sizes of 5 should be tested, but actually, kernel sizes of 3 are tested. This PR changes the kernel sizes tested to match the test heads. 

Disclaimer: I haven't run the tests yet, I only saw this on github and created this PR.