### PR TITLE
Enable rsync working on windows

### DIFF
--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -162,9 +162,16 @@ function prepare_src() {
     cp -L \
       bazel-bin/tensorflow/tools/pip_package/build_pip_package.exe.runfiles/org_tensorflow/LICENSE \
       "${TMPDIR}"
+
+	# Change the format of file path (TMPDIR-->TMPDIR_rsync) which is input to the rsync from
+	# Windows-compatible to Linux-compatible to resolve the error below 
+	# error: ssh: Could not resolve hostname c: No such host is known. 
+	
+	TMPDIR_rsync=`cygpath $TMPDIR`
+
     rsync -a \
       bazel-bin/tensorflow/tools/pip_package/build_pip_package.exe.runfiles/org_tensorflow/tensorflow \
-      "${TMPDIR}"
+      "${TMPDIR_rsync}"
     cp_external \
       bazel-bin/tensorflow/tools/pip_package/build_pip_package.exe.runfiles \
       "${EXTERNAL_INCLUDES}/"

--- a/tensorflow/tools/pip_package/build_pip_package.sh
+++ b/tensorflow/tools/pip_package/build_pip_package.sh
@@ -162,13 +162,12 @@ function prepare_src() {
     cp -L \
       bazel-bin/tensorflow/tools/pip_package/build_pip_package.exe.runfiles/org_tensorflow/LICENSE \
       "${TMPDIR}"
-
-	# Change the format of file path (TMPDIR-->TMPDIR_rsync) which is input to the rsync from
-	# Windows-compatible to Linux-compatible to resolve the error below 
-	# error: ssh: Could not resolve hostname c: No such host is known. 
-	
-	TMPDIR_rsync=`cygpath $TMPDIR`
-
+      
+    # Change the format of file path (TMPDIR-->TMPDIR_rsync) which is input to the rsync from
+    # Windows-compatible to Linux-compatible to resolve the error below 
+    # error: ssh: Could not resolve hostname c: No such host is known. 
+    
+    TMPDIR_rsync=`cygpath $TMPDIR`  
     rsync -a \
       bazel-bin/tensorflow/tools/pip_package/build_pip_package.exe.runfiles/org_tensorflow/tensorflow \
       "${TMPDIR_rsync}"


### PR DESCRIPTION
Running the 'rsync' command to transfer files to the destination failed on the Windows platform due to incompatibility with the Windows path as an input to the rsync command

The error observed:
ssh: Could not resolve hostname c: No such host is known.
rsync: [sender] safe_read failed to read 4 bytes: Connection reset by peer (104)
rsync error: error in rsync protocol data stream (code 12) at io.c(276) [sender=3.2.3]
1 [sig] rsync 2009! sigpacket::process: Suppressing signal 30 to win32 process (pid 20560)

Resolution:
Change the format of the file path which is input to the rsync, from Windows-compatible to Linux-compatible to resolve the issue