### PR TITLE
Update args description of crop_to_bounding_box & pad_to_bounding_box

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1084,14 +1084,14 @@ def pad_to_bounding_box_internal(image, offset_height, offset_width,
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor
       of shape `[height, width, channels]`.
-    offset_height: Number of rows of zeros to add on top.Must be 1-D `Tensor` 
-      of dtype int32 or int64.Can also a python integer.
+    offset_height: Number of rows of zeros to add on top.Must be 0-D `Tensor` 
+      of dtype int32 or int64. Can also a python integer.
     offset_width: Number of columns of zeros to add on the left.Must be 
-      1-D `Tensor` of dtype int32 or int64.Can also a python integer.
-    target_height: Height of output image.Must be 1-D `Tensor` 
-      of dtype int32 or int64.Can also a python integer.
-    target_width: Width of output image.Must be 1-D `Tensor` 
-      of dtype int32 or int64.Can also a python integer.
+      0-D `Tensor` of dtype int32 or int64. Can also a python integer.
+    target_height: Height of output image.Must be 0-D `Tensor` 
+      of dtype int32 or int64. Can also a python integer.
+    target_width: Width of output image.Must be 0-D `Tensor` 
+      of dtype int32 or int64. Can also a python integer.
     check_dims: If True, assert that dimensions are non-negative and in range.
       In multi-GPU distributed settings, assertions can cause program slowdown.
       Setting this parameter to `False` avoids this, resulting in faster speed
@@ -1193,12 +1193,12 @@ def crop_to_bounding_box(image, offset_height, offset_width, target_height,
     image: 4-D `Tensor` of shape `[batch, height, width, channels]` or 3-D
       `Tensor` of shape `[height, width, channels]`.
     offset_height: Vertical coordinate of the top-left corner of the bounding
-      box in `image`.Must be 1-D int32 `Tensor` or python integer.
+      box in `image`. Must be 0-D int32 `Tensor` or python integer.
     offset_width: Horizontal coordinate of the top-left corner of the bounding
-      box in `image`.Must be 1-D int32 `Tensor` or python integer.
-    target_height: Height of the bounding box.Must be 1-D int32 `Tensor` or 
+      box in `image`. Must be 0-D int32 `Tensor` or python integer.
+    target_height: Height of the bounding box. Must be 0-D int32 `Tensor` or 
       python integer.
-    target_width: Width of the bounding box.Must be 1-D int32 `Tensor` or 
+    target_width: Width of the bounding box. Must be 0-D int32 `Tensor` or 
       python integer.
 
   Returns:

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1084,10 +1084,14 @@ def pad_to_bounding_box_internal(image, offset_height, offset_width,
   Args:
     image: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor
       of shape `[height, width, channels]`.
-    offset_height: Number of rows of zeros to add on top.
-    offset_width: Number of columns of zeros to add on the left.
-    target_height: Height of output image.
-    target_width: Width of output image.
+    offset_height: Number of rows of zeros to add on top.Must be 1-D `Tensor` 
+      of dtype int32 or int64.Can also a python integer.
+    offset_width: Number of columns of zeros to add on the left.Must be 
+      1-D `Tensor` of dtype int32 or int64.Can also a python integer.
+    target_height: Height of output image.Must be 1-D `Tensor` 
+      of dtype int32 or int64.Can also a python integer.
+    target_width: Width of output image.Must be 1-D `Tensor` 
+      of dtype int32 or int64.Can also a python integer.
     check_dims: If True, assert that dimensions are non-negative and in range.
       In multi-GPU distributed settings, assertions can cause program slowdown.
       Setting this parameter to `False` avoids this, resulting in faster speed
@@ -1189,11 +1193,13 @@ def crop_to_bounding_box(image, offset_height, offset_width, target_height,
     image: 4-D `Tensor` of shape `[batch, height, width, channels]` or 3-D
       `Tensor` of shape `[height, width, channels]`.
     offset_height: Vertical coordinate of the top-left corner of the bounding
-      box in `image`.
+      box in `image`.Must be 1-D int32 `Tensor` or python integer.
     offset_width: Horizontal coordinate of the top-left corner of the bounding
-      box in `image`.
-    target_height: Height of the bounding box.
-    target_width: Width of the bounding box.
+      box in `image`.Must be 1-D int32 `Tensor` or python integer.
+    target_height: Height of the bounding box.Must be 1-D int32 `Tensor` or 
+      python integer.
+    target_width: Width of the bounding box.Must be 1-D int32 `Tensor` or 
+      python integer.
 
   Returns:
     If `image` was 4-D, a 4-D `Tensor` of shape


### PR DESCRIPTION
Currently the documentation of the API `tf.image.crop_to_bounding_box` doesn't mentioning the acceptable dtypes of the arguments `offset_height, offset_width, target_height, target_width`. This API accepts only` tf.int32 Tensor` or a `integer`. For other dtypes its raising exception. Hence adding details of acceptable dtypes for these arguments for better clarity to the users.

Refer attached gist for [crop_to_bounding_box](https://colab.sandbox.google.com/gist/SuryanarayanaY/57ceb39be4649987d0cf3c9a3eb584f4/tf-image-crop_to_bounding_box.ipynb#scrollTo=xvm-YCU4X2Z0).

Also Fixes #61644 .

Similarly `tf.image.pad_to_bounding_box` documentation also have the same arguments `offset_height, offset_width, target_height, target_width`. But these arguments accept `int32` and `int64`Tensors but not others.Hence added details of acceptable dtypes for these arguments for better clarity to the users.

Refer attached gist for [pad_to_bounding_box](https://colab.sandbox.google.com/gist/SuryanarayanaY/c4bbec3161c740a73472c0361ba0959b/tf-image-pad_to_bounding_box.ipynb).
