### PR TITLE
Prevent null pointer being passed to memcpy

### DIFF
--- a/tensorflow/compiler/mlir/lite/flatbuffer_export.cc
+++ b/tensorflow/compiler/mlir/lite/flatbuffer_export.cc
@@ -1245,7 +1245,7 @@ BufferOffset<tflite::Operator> Translator::BuildCustomOperator(
     const std::vector<int32_t>& operands, const std::vector<int32_t>& results) {
   const std::string attrs =
       op.getCustomOption().cast<mlir::TFL::ConstBytesAttr>().getValue().str();
-  std::vector<uint8_t> custom_option_vector(attrs.size());
+  std::vector<uint8_t> custom_option_vector(attrs.size(), 0);
   memcpy(custom_option_vector.data(), attrs.data(), attrs.size());
   auto opcode_index =
       GetOpcodeIndex(op.getCustomCode().str(), tflite::BuiltinOperator_CUSTOM);

--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -16,9 +16,6 @@
 set -x
 
 ARM_SKIP_TESTS="-//tensorflow/lite/... \
--//tensorflow/compiler/mlir/lite/quantization/lite:quantize_model_test \
--//tensorflow/compiler/mlir/lite/quantization/lite:quantize_weights_test \
--//tensorflow/compiler/mlir/lite/sparsity:sparsify_model_test \
 -//tensorflow/compiler/xla/service/cpu/tests:cpu_eigen_dot_operation_test \
 -//tensorflow/compiler/xla/service/gpu:fusion_merger_test \
 -//tensorflow/core/kernels/image:resize_bicubic_op_test \


### PR DESCRIPTION
Ensure that the vector just created has valid data as this is passed to memcpy as the destination. Passing a null pointer here will result in a segfault.

Fixes: https://github.com/tensorflow/tensorflow/issues/61677