### PR TITLE
Use eager tensor

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1149,7 +1149,9 @@ def pad_to_bounding_box_internal(image, offset_height, offset_width,
         array_ops_stack.stack([
             0, 0, offset_height, after_padding_height, offset_width,
             after_padding_width, 0, 0
-        ]), [4, 2])
+        ]),
+        constant_op.constant([4, 2])
+    )
     padded = array_ops.pad(image, paddings)
 
     padded_shape = [


### PR DESCRIPTION
Passing `[4, 2]` as `shape` to `array_ops.reshape` always produces an error (in my case with a silent exit and no clue about what happened). Seems to happen because `[4,2]` is of type `List` and when `array_ops.reshape` calls `pywrap_tfe.TFE_Py_FastPathExecute` it expects Eager tensors.

I have tested this in two different scenarios:
 * The first, was working without issues before, in this case because when invoking `pywrap_tfe.TFE_Py_FastPathExecute` it produced a `_core._FallbacException`.
* On the second one, which had more complexity, I am not fully sure why (I guess because the context is different), `pywrap_tfe.TFE_Py_FastPathExecute` simply fails, and doesn't return or throw any error.

After this change, both scenarios work fine.

