### PR TITLE
[XLA:CPU] OneDNN matmul library call for XLA HLO Dot operation

### DIFF
--- a/tensorflow/compiler/xla/service/cpu/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/BUILD
@@ -198,6 +198,7 @@ cc_library(
     name = "cpu_compiler_pure",
     srcs = ["cpu_compiler.cc"],
     hdrs = ["cpu_compiler.h"],
+    copts = tsl_copts(),
     deps = [
         ":buffer_info_util",
         ":compiler_functor",
@@ -212,6 +213,7 @@ cc_library(
         ":hlo_xla_runtime_pipeline",
         ":ir_emission_utils",
         ":ir_emitter",
+        ":onednn_rewriter",
         ":parallel_task_assignment",
         ":simple_orc_jit",
         ":target_machine_features",
@@ -512,7 +514,7 @@ cc_library(
         "windows_compatibility.h",
     ],
     hdrs = ["simple_orc_jit.h"],
-    copts = if_enable_acl(["-DXLA_CPU_USE_ACL=1"]),
+    copts = if_enable_acl(["-DXLA_CPU_USE_ACL=1"]) + tsl_copts(),
     deps = [
         ":compiler_functor",
         ":cpu_runtime",
@@ -535,6 +537,7 @@ cc_library(
         ":runtime_single_threaded_fft",
         ":runtime_single_threaded_matmul",
         ":runtime_topk",
+        ":onednn_matmul",
         "//tensorflow/compiler/xla:types",
         "//tensorflow/compiler/xla:util",
         "//tensorflow/compiler/xla/service:custom_call_target_registry",
@@ -643,6 +646,7 @@ cc_library(
         "elemental_ir_emitter.h",
         "ir_emitter.h",
     ],
+    copts = tsl_copts(),
     deps = [
         ":backend_config_proto_cc",
         ":cpu_options",
@@ -650,6 +654,7 @@ cc_library(
         ":dot_op_emitter",
         ":ir_emission_utils",
         ":ir_function",
+        ":onednn_memory_util",
         ":parallel_loop_emitter",
         ":target_machine_features",
         "//tensorflow/compiler/xla:shape_util",
@@ -1616,4 +1621,73 @@ tf_proto_library(
     name = "backend_config_proto",
     srcs = ["backend_config.proto"],
     cc_api_version = 2,
+)
+
+cc_library(
+    name = "onednn_memory_util",
+    srcs = ["onednn_memory_util.cc"],
+    hdrs = ["onednn_memory_util.h"],
+    copts = runtime_copts() + tsl_copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":runtime_lightweight_check",
+        "//tensorflow/compiler/xla:shape_util",
+        "//tensorflow/compiler/xla:status_macros",
+        "//tensorflow/compiler/xla:statusor",
+        "//tensorflow/compiler/xla:types",
+        "//tensorflow/compiler/xla:util",
+        "//tensorflow/compiler/xla:xla_data_proto_cc",
+        "//tensorflow/compiler/xla/hlo/ir:hlo",
+        "//tensorflow/compiler/xla/service/llvm_ir:ir_array",
+        "//tensorflow/compiler/xla/service/llvm_ir:ir_builder_mixin",
+        "//tensorflow/compiler/xla/service/llvm_ir:llvm_util",
+        "//tensorflow/tsl/platform:errors",
+        "//tensorflow/tsl/platform:logging",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/base:dynamic_annotations",
+        "@com_google_absl//absl/types:span",
+        "@llvm-project//llvm:Core",
+        "@llvm-project//llvm:TargetParser",
+        "@llvm-project//mlir:IR",
+    ] + mkl_deps(),
+)
+
+cc_library(
+    name = "onednn_matmul",
+    srcs = ["onednn_matmul.cc"],
+    hdrs = [
+        "onednn_matmul.h",
+        "//tensorflow/tsl/util:onednn_util_hdrs",
+    ],
+    copts = runtime_copts() + tsl_copts(),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":onednn_memory_util",
+        ":backend_config_proto_cc",
+        ":runtime_lightweight_check",
+        "//tensorflow/compiler/xla:executable_run_options",
+        "//tensorflow/tsl/platform:blocking_counter",
+        "//tensorflow/tsl/platform:env",
+        "//tensorflow/tsl/platform:platform_port",
+        "//third_party/eigen3",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/base:dynamic_annotations",
+    ] + mkl_deps(),
+)
+
+cc_library(
+    name = "onednn_rewriter",
+    srcs = ["onednn_rewriter.cc"],
+    hdrs = ["onednn_rewriter.h"],
+    copts = tsl_copts(),
+    deps = [
+        ":backend_config_proto_cc",
+        ":onednn_memory_util",
+        "//tensorflow/compiler/xla:status_macros",
+        "//tensorflow/compiler/xla:xla_data_proto_cc",
+        "//tensorflow/compiler/xla/hlo/ir:hlo",
+        "//tensorflow/compiler/xla/service:hlo_creation_utils",
+        "//tensorflow/compiler/xla/service:hlo_pass",
+        "//tensorflow/compiler/xla/service:pattern_matcher",
+    ] + mkl_deps(),
 )

--- a/tensorflow/compiler/xla/service/cpu/backend_config.proto
+++ b/tensorflow/compiler/xla/service/cpu/backend_config.proto
@@ -25,3 +25,18 @@ message OneDnnMatMulConfig {
   }
   repeated FusionKind fused_ops = 3;
 }
+
+// Configuration to be used by oneDNN matmul
+message OneDnnMatMulConfig {
+  // These enum needs to be mapped to oneDNN enum for post_op algorithm.
+  // TODO(intel-tf): Add kinds supported by oneDNN.
+  enum FusionKind {
+    UNDEF = 0;
+    BIAS = 1;
+    RELU = 2;
+    TANH = 3;
+    GELU_ERF = 4;
+    GELU_TANH = 5;
+  }
+  repeated FusionKind fused_ops = 3;
+}

--- a/tensorflow/compiler/xla/service/cpu/backend_config.proto
+++ b/tensorflow/compiler/xla/service/cpu/backend_config.proto
@@ -25,18 +25,3 @@ message OneDnnMatMulConfig {
   }
   repeated FusionKind fused_ops = 3;
 }
-
-// Configuration to be used by oneDNN matmul
-message OneDnnMatMulConfig {
-  // These enum needs to be mapped to oneDNN enum for post_op algorithm.
-  // TODO(intel-tf): Add kinds supported by oneDNN.
-  enum FusionKind {
-    UNDEF = 0;
-    BIAS = 1;
-    RELU = 2;
-    TANH = 3;
-    GELU_ERF = 4;
-    GELU_TANH = 5;
-  }
-  repeated FusionKind fused_ops = 3;
-}

--- a/tensorflow/compiler/xla/service/cpu/cpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/cpu/cpu_compiler.cc
@@ -146,6 +146,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/cpu/dot_op_emitter.h"
 #include "tensorflow/compiler/xla/service/cpu/hlo_xla_runtime_pipeline.h"
 #include "tensorflow/compiler/xla/service/cpu/ir_emitter.h"
+#include "tensorflow/compiler/xla/service/cpu/onednn_rewriter.h"
 #include "tensorflow/compiler/xla/service/cpu/parallel_task_assignment.h"
 #include "tensorflow/compiler/xla/service/cpu/runtime/collectives.h"
 #include "tensorflow/compiler/xla/service/cpu/runtime/convolution_call.h"
@@ -689,6 +690,12 @@ Status CpuCompiler::RunHloPassesThroughLayoutAssn(
   pipeline.AddPass<CallInliner>(/*single_call_site=*/true);
   pipeline.AddPass<BatchDotSimplification>();
   pipeline.AddPass<DotDecomposer>();
+
+  // Rewrite to custom calls with target as oneDNN library calls.
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+  pipeline.AddPass<OneDnnRewriter>();
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
+
   // Promote BF16 all-reduce to F32.
   const std::pair<PrimitiveType, PrimitiveType> ar_promoted_types[] = {
       {BF16, F32}};

--- a/tensorflow/compiler/xla/service/cpu/cpu_compiler.cc
+++ b/tensorflow/compiler/xla/service/cpu/cpu_compiler.cc
@@ -623,7 +623,7 @@ void AddHloVerifier(HloPassPipeline* pipeline, bool allow_sparse_shapes,
 }  // namespace
 
 Status CpuCompiler::RunHloPassesThroughLayoutAssn(
-    HloModule* module, bool /*is_aot_compile*/,
+    HloModule* module, bool is_aot_compile,
     LLVMTargetMachineFeatures* target_machine_features, bool is_mlir_compile) {
   const int64_t num_partitions = module->config().num_partitions();
   if (num_partitions > 1) {
@@ -693,7 +693,10 @@ Status CpuCompiler::RunHloPassesThroughLayoutAssn(
 
   // Rewrite to custom calls with target as oneDNN library calls.
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
-  pipeline.AddPass<OneDnnRewriter>();
+  // AOT compiled code runs in single thread.
+  if (!is_aot_compile) {
+    pipeline.AddPass<OneDnnRewriter>();
+  }
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
 
   // Promote BF16 all-reduce to F32.

--- a/tensorflow/compiler/xla/service/cpu/cpu_runtime.cc
+++ b/tensorflow/compiler/xla/service/cpu/cpu_runtime.cc
@@ -155,6 +155,8 @@ extern const char* const kCollectivePermuteSymbolName =
 extern const char* const kPartitionIdSymbolName =
     "__xla_cpu_runtime_PartitionId";
 extern const char* const kReplicaIdSymbolName = "__xla_cpu_runtime_ReplicaId";
+extern const char* const kOneDnnMatMulSymbolName =
+    "__xla_cpu_runtime_OneDnnMatMul";
 
 namespace {
 

--- a/tensorflow/compiler/xla/service/cpu/cpu_runtime.h
+++ b/tensorflow/compiler/xla/service/cpu/cpu_runtime.h
@@ -88,6 +88,7 @@ extern const char* const kReplicaIdSymbolName;
 extern const char* const kTracingStartSymbolName;
 extern const char* const kTracingEndSymbolName;
 extern const char* const kAllToAllSymbolName;
+extern const char* const kOneDnnMatMulSymbolName;
 
 // All symbol names for XLA CPU runtime functions need to start with this
 // prefix.

--- a/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
@@ -62,6 +62,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/cpu/elemental_ir_emitter.h"
 #include "tensorflow/compiler/xla/service/cpu/ir_emission_utils.h"
 #include "tensorflow/compiler/xla/service/cpu/ir_function.h"
+#include "tensorflow/compiler/xla/service/cpu/onednn_memory_util.h"
 #include "tensorflow/compiler/xla/service/cpu/parallel_loop_emitter.h"
 #include "tensorflow/compiler/xla/service/elemental_ir_emitter.h"
 #include "tensorflow/compiler/xla/service/llvm_ir/buffer_assignment_util.h"
@@ -2428,6 +2429,43 @@ Status IrEmitter::HandleTopK(HloInstruction* hlo) {
   return OkStatus();
 }
 
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+Status IrEmitter::HandleOneDnnMatMul(HloInstruction* custom_call) {
+  auto lhs = custom_call->operand(0);
+  llvm_ir::IrArray lhs_array(GetIrArrayFor(lhs));
+  auto lhs_stack_alloca = GetAllocaAndEmitMemrefInfo(b_, lhs_array);
+
+  auto rhs = custom_call->operand(1);
+  llvm_ir::IrArray rhs_array(GetIrArrayFor(rhs));
+  auto rhs_stack_alloca = GetAllocaAndEmitMemrefInfo(b_, rhs_array);
+
+  TF_RETURN_IF_ERROR(EmitTargetAddressForOp(custom_call));
+  llvm_ir::IrArray result_array = GetIrArrayFor(custom_call);
+  auto result_stack_alloca = GetAllocaAndEmitMemrefInfo(b_, result_array);
+
+  auto typed_custom_call = Cast<HloCustomCallInstruction>(custom_call);
+  auto matmul_config = typed_custom_call->backend_config<OneDnnMatMulConfig>();
+  std::string str_config;
+  matmul_config->SerializeToString(&str_config);
+
+  EmitCallToFunc("onednn.matmul",
+                 {
+                     GetExecutableRunOptionsArgument(),
+                     lhs_stack_alloca.value,
+                     rhs_stack_alloca.value,
+                     result_stack_alloca.value,
+                     b_.CreateGlobalStringPtr(llvm_ir::AsStringRef(str_config)),
+                 },
+                 b_.getVoidTy());
+
+  lhs_stack_alloca.EmitLifetimeEnd();
+  rhs_stack_alloca.EmitLifetimeEnd();
+  result_stack_alloca.EmitLifetimeEnd();
+
+  return OkStatus();
+}
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
+
 Status IrEmitter::HandleCustomCall(HloInstruction* custom_call) {
   if (custom_call->custom_call_target() == "PadToStatic") {
     return HandlePadToStatic(custom_call);
@@ -2438,7 +2476,11 @@ Status IrEmitter::HandleCustomCall(HloInstruction* custom_call) {
   if (custom_call->custom_call_target() == "TopK") {
     return HandleTopK(custom_call);
   }
-
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+  if (custom_call->custom_call_target() == "__onednn$matmul") {
+    return HandleOneDnnMatMul(custom_call);
+  }
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
   absl::Span<HloInstruction* const> operands(custom_call->operands());
   llvm::Type* i8_ptr_type = b_.getInt8PtrTy();
   llvm::AllocaInst* operands_alloca =

--- a/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
@@ -2444,9 +2444,11 @@ Status IrEmitter::HandleOneDnnMatMul(HloInstruction* custom_call) {
   auto result_stack_alloca = GetAllocaAndEmitMemrefInfo(b_, result_array);
 
   auto typed_custom_call = Cast<HloCustomCallInstruction>(custom_call);
-  auto matmul_config = typed_custom_call->backend_config<OneDnnMatMulConfig>();
+  auto backend_config = typed_custom_call->backend_config<BackendConfig>();
+  OneDnnMatMulConfig matmul_config;
+  matmul_config.CopyFrom(backend_config->onednn_matmul_config());
   std::string str_config;
-  matmul_config->SerializeToString(&str_config);
+  matmul_config.SerializeToString(&str_config);
 
   EmitCallToFunc(runtime::kOneDnnMatMulSymbolName,
                  {

--- a/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
+++ b/tensorflow/compiler/xla/service/cpu/ir_emitter.cc
@@ -2448,7 +2448,7 @@ Status IrEmitter::HandleOneDnnMatMul(HloInstruction* custom_call) {
   std::string str_config;
   matmul_config->SerializeToString(&str_config);
 
-  EmitCallToFunc("onednn.matmul",
+  EmitCallToFunc(runtime::kOneDnnMatMulSymbolName,
                  {
                      GetExecutableRunOptionsArgument(),
                      lhs_stack_alloca.value,

--- a/tensorflow/compiler/xla/service/cpu/ir_emitter.h
+++ b/tensorflow/compiler/xla/service/cpu/ir_emitter.h
@@ -192,7 +192,9 @@ class IrEmitter : public DfsHloVisitorWithDefault,
   Status HandleTopK(HloInstruction* hlo);
   Status HandleAllReduceSingleReplica(HloInstruction* crs);
   Status HandleAllReduceMultipleReplica(HloInstruction* crs);
-
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+  Status HandleOneDnnMatMul(HloInstruction* hlo);
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
   // Private helper to initialize an IR function for the computation.
   void InitializeIrFunction(const std::string& function_name);
 

--- a/tensorflow/compiler/xla/service/cpu/onednn_matmul.cc
+++ b/tensorflow/compiler/xla/service/cpu/onednn_matmul.cc
@@ -35,7 +35,7 @@ namespace cpu {
 
 using namespace dnnl;
 
-ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void onednn_matmul(
+ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
     const void* run_options_ptr, void* lhs, void* rhs, void* result,
     void* config) {
   const xla::ExecutableRunOptions* run_options =

--- a/tensorflow/compiler/xla/service/cpu/onednn_matmul.cc
+++ b/tensorflow/compiler/xla/service/cpu/onednn_matmul.cc
@@ -1,0 +1,91 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include "tensorflow/compiler/xla/service/cpu/onednn_matmul.h"
+
+#include <algorithm>
+#include <cmath>
+#include <initializer_list>
+#include <vector>
+
+#include "absl/base/dynamic_annotations.h"
+#include "dnnl.hpp"
+#include "tensorflow/compiler/xla/executable_run_options.h"
+#include "tensorflow/compiler/xla/service/cpu/backend_config.pb.h"
+#include "tensorflow/compiler/xla/service/cpu/onednn_memory_util.h"
+#include "tensorflow/compiler/xla/service/cpu/runtime_lightweight_check.h"
+#include "tensorflow/tsl/util/onednn_threadpool.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+namespace xla {
+namespace cpu {
+
+using namespace dnnl;
+
+ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void onednn_matmul(
+    const void* run_options_ptr, void* lhs, void* rhs, void* result,
+    void* config) {
+  const xla::ExecutableRunOptions* run_options =
+      static_cast<const xla::ExecutableRunOptions*>(run_options_ptr);
+  XLA_LIGHTWEIGHT_CHECK(run_options->intra_op_thread_pool() != nullptr);
+  // TODO(inte-tf): Update the namespace scope of threadpool once the
+  // threadpool interface wrapper is moved as tsl::OneDnnThreadPool.
+  tsl::OneDnnThreadPool thread_pool(
+      run_options->intra_op_thread_pool()->getPool(), false);
+  engine cpu_engine(engine::kind::cpu, 0);
+  auto tp_stream =
+      stream(threadpool_interop::make_stream(cpu_engine, &thread_pool));
+
+  MemrefInfo lhs_minfo(lhs);
+  MemrefInfo rhs_minfo(rhs);
+  MemrefInfo result_minfo(result);
+
+  std::string config_str(static_cast<const char*>(config));
+  OneDnnMatMulConfig matmul_config;
+  matmul_config.ParseFromString(config_str);
+
+  // Currently, no fusion is supported.
+  XLA_LIGHTWEIGHT_CHECK(matmul_config.fused_ops().empty());
+
+  auto src_md = lhs_minfo.GetOneDnnMemDesc();
+  auto weights_md = rhs_minfo.GetOneDnnMemDesc();
+  auto dst_md = result_minfo.GetOneDnnMemDesc();
+
+  auto src_mem = memory(src_md, cpu_engine, lhs_minfo.Data());
+  auto weights_mem = memory(weights_md, cpu_engine, rhs_minfo.Data());
+  auto dst_mem = memory(dst_md, cpu_engine, result_minfo.Data());
+
+  // Create primitive descriptor.
+  auto matmul_pd =
+      matmul::primitive_desc(cpu_engine, src_md, weights_md, dst_md);
+
+  // Create the primitive.
+  auto matmul_prim = matmul(matmul_pd);
+
+  // Primitive arguments.
+  std::unordered_map<int, memory> matmul_args;
+  matmul_args.insert({DNNL_ARG_SRC, src_mem});
+  matmul_args.insert({DNNL_ARG_WEIGHTS, weights_mem});
+  matmul_args.insert({DNNL_ARG_DST, dst_mem});
+
+  // Primitive execution: matrix multiplication with ReLU.
+  matmul_prim.execute(tp_stream, matmul_args);
+}
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3

--- a/tensorflow/compiler/xla/service/cpu/onednn_matmul.cc
+++ b/tensorflow/compiler/xla/service/cpu/onednn_matmul.cc
@@ -40,6 +40,7 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
     void* config) {
   const xla::ExecutableRunOptions* run_options =
       static_cast<const xla::ExecutableRunOptions*>(run_options_ptr);
+  XLA_LIGHTWEIGHT_CHECK(run_options != nullptr);
   XLA_LIGHTWEIGHT_CHECK(run_options->intra_op_thread_pool() != nullptr);
   // TODO(inte-tf): Update the namespace scope of threadpool once the
   // threadpool interface wrapper is moved as tsl::OneDnnThreadPool.
@@ -68,20 +69,16 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
   auto weights_mem = memory(weights_md, cpu_engine, rhs_minfo.Data());
   auto dst_mem = memory(dst_md, cpu_engine, result_minfo.Data());
 
-  // Create primitive descriptor.
   auto matmul_pd =
       matmul::primitive_desc(cpu_engine, src_md, weights_md, dst_md);
 
-  // Create the primitive.
   auto matmul_prim = matmul(matmul_pd);
 
-  // Primitive arguments.
   std::unordered_map<int, memory> matmul_args;
   matmul_args.insert({DNNL_ARG_SRC, src_mem});
   matmul_args.insert({DNNL_ARG_WEIGHTS, weights_mem});
   matmul_args.insert({DNNL_ARG_DST, dst_mem});
 
-  // Primitive execution: matrix multiplication with ReLU.
   matmul_prim.execute(tp_stream, matmul_args);
 }
 

--- a/tensorflow/compiler/xla/service/cpu/onednn_matmul.cc
+++ b/tensorflow/compiler/xla/service/cpu/onednn_matmul.cc
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
 
 #include "tensorflow/compiler/xla/service/cpu/onednn_matmul.h"
@@ -42,8 +43,6 @@ ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY void __xla_cpu_runtime_OneDnnMatMul(
       static_cast<const xla::ExecutableRunOptions*>(run_options_ptr);
   XLA_LIGHTWEIGHT_CHECK(run_options != nullptr);
   XLA_LIGHTWEIGHT_CHECK(run_options->intra_op_thread_pool() != nullptr);
-  // TODO(inte-tf): Update the namespace scope of threadpool once the
-  // threadpool interface wrapper is moved as tsl::OneDnnThreadPool.
   tsl::OneDnnThreadPool thread_pool(
       run_options->intra_op_thread_pool()->getPool(), false);
   engine cpu_engine(engine::kind::cpu, 0);

--- a/tensorflow/compiler/xla/service/cpu/onednn_matmul.h
+++ b/tensorflow/compiler/xla/service/cpu/onednn_matmul.h
@@ -31,8 +31,9 @@ extern "C" {
 // so that it can take variable number of arguments.
 //
 // For now, we are using fix number of arguments.
-extern void onednn_matmul(const void* run_options_ptr, void* lhs, void* rhs,
-                          void* result, void* config);
+extern void __xla_cpu_runtime_OneDnnMatMul(const void* run_options_ptr,
+                                           void* lhs, void* rhs, void* result,
+                                           void* config);
 }  // extern "C"
 
 }  // namespace cpu

--- a/tensorflow/compiler/xla/service/cpu/onednn_matmul.h
+++ b/tensorflow/compiler/xla/service/cpu/onednn_matmul.h
@@ -30,7 +30,7 @@ extern "C" {
 //        args[3...]: Actual Operands
 // so that it can take variable number of arguments.
 //
-// For now, we are using fix number of arguments.
+// For now, we are using a fixed number of arguments.
 extern void __xla_cpu_runtime_OneDnnMatMul(const void* run_options_ptr,
                                            void* lhs, void* rhs, void* result,
                                            void* config);

--- a/tensorflow/compiler/xla/service/cpu/onednn_matmul.h
+++ b/tensorflow/compiler/xla/service/cpu/onednn_matmul.h
@@ -1,0 +1,42 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_CPU_ONEDNN_MATMUL_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_CPU_ONEDNN_MATMUL_H_
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+namespace xla {
+namespace cpu {
+
+extern "C" {
+// TODO(intel-tf): Change the function signature as
+//    void onednn_matmul(void* result, void** args)
+// where
+//        args[0]: num_args (>=3, including itself)
+//        args[1]: ExecutableRunOption
+//        args[2]: OneDnnMatMulConfig
+//        args[3...]: Actual Operands
+// so that it can take variable number of arguments.
+//
+// For now, we are using fix number of arguments.
+extern void onednn_matmul(const void* run_options_ptr, void* lhs, void* rhs,
+                          void* result, void* config);
+}  // extern "C"
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_CPU_ONEDNN_MATMUL_H_

--- a/tensorflow/compiler/xla/service/cpu/onednn_memory_util.cc
+++ b/tensorflow/compiler/xla/service/cpu/onednn_memory_util.cc
@@ -1,0 +1,147 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include "tensorflow/compiler/xla/service/cpu/onednn_memory_util.h"
+
+#include <algorithm>
+#include <cmath>
+#include <initializer_list>
+#include <vector>
+
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/FMF.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsX86.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Value.h"
+#include "tensorflow/compiler/xla/service/cpu/runtime_lightweight_check.h"
+#include "tensorflow/compiler/xla/service/llvm_ir/ir_array.h"
+#include "tensorflow/compiler/xla/service/llvm_ir/llvm_util.h"
+
+namespace xla {
+namespace cpu {
+
+// Put structure definition together with dependant code
+// to simplify consitency maintenance
+struct MemrefInfoPOD {
+  int64_t dtype;
+  int64_t rank;
+  int64_t dims[kOneDnnMaxNDims];
+  int64_t strides[kOneDnnMaxNDims];
+  void* data;
+};
+
+StackAlloca GetAllocaAndEmitMemrefInfo(llvm::IRBuilder<>& builder,
+                                       const llvm_ir::IrArray& ir_array) {
+  const Shape& shape = ir_array.GetShape();
+  int64_t rank = shape.rank();
+  absl::Span<const int64_t> dims = shape.dimensions();
+
+  std::vector<int64_t> strides(rank);
+  int64_t stride = 1;
+  for (int i : shape.layout().minor_to_major()) {
+    strides.at(i) = stride;
+    stride *= dims.at(i);
+  }
+
+  // Type of struct
+  llvm::Type* i64_type = builder.getInt64Ty();
+  llvm::Type* ptr_type = builder.getPtrTy();
+  llvm::ArrayType* i64_array_type =
+      llvm::ArrayType::get(builder.getInt64Ty(), kOneDnnMaxNDims);
+  llvm::StructType* memref_info_type = llvm::StructType::get(
+      builder.getContext(),
+      {i64_type, i64_type, i64_array_type, i64_array_type, ptr_type});
+
+  // Prepare arrays dims and strides.
+  llvm::Value* dims_val = llvm::UndefValue::get(i64_array_type);
+  llvm::Value* strides_val = llvm::UndefValue::get(i64_array_type);
+  for (unsigned i = 0; i < rank; ++i) {
+    llvm::Value* dim_val = builder.getInt64(dims[i]);
+    llvm::Value* stride_val = builder.getInt64(strides[i]);
+    dims_val = builder.CreateInsertValue(dims_val, dim_val, i);
+    strides_val = builder.CreateInsertValue(strides_val, stride_val, i);
+  }
+
+  // Prepare values for struct MemrefInfo.
+  llvm::Value* dtype_val = builder.getInt64(shape.element_type());
+  llvm::Value* rank_val = builder.getInt64(rank);
+  llvm::Value* data_ptr = ir_array.GetBasePointer();
+  llvm::Value* memref_info_val = llvm::UndefValue::get(memref_info_type);
+  memref_info_val = builder.CreateInsertValue(memref_info_val, dtype_val, 0);
+  memref_info_val = builder.CreateInsertValue(memref_info_val, rank_val, 1);
+  memref_info_val = builder.CreateInsertValue(memref_info_val, dims_val, 2);
+  memref_info_val = builder.CreateInsertValue(memref_info_val, strides_val, 3);
+  memref_info_val = builder.CreateInsertValue(memref_info_val, data_ptr, 4);
+
+  // Allocate MemrefInfo on the stack
+  llvm::Value* memref_info_ptr = llvm_ir::EmitAllocaAtFunctionEntry(
+      memref_info_type, "memref.info", &builder);
+  llvm::Value* memref_life_start =
+      builder.CreateLifetimeStart(memref_info_ptr, builder.getInt64(-1));
+  llvm::Value* memref_store =
+      builder.CreateStore(memref_info_val, memref_info_ptr);
+
+  return {&builder, memref_info_ptr};
+}
+
+MemrefInfo::MemrefInfo(void* pod_data)
+    : pod_(reinterpret_cast<MemrefInfoPOD*>(pod_data)) {
+  // TODO(intel-tf): verify pod_
+}
+
+dnnl::memory::dims MemrefInfo::GetOneDnnDims() const {
+  return dnnl::memory::dims(pod_->dims, pod_->dims + pod_->rank);
+}
+
+dnnl::memory::dims MemrefInfo::GetOneDnnStrides() const {
+  return dnnl::memory::dims(pod_->strides, pod_->strides + pod_->rank);
+}
+
+dnnl::memory::data_type MemrefInfo::GetOneDnnDataType() const {
+  return ToOneDnnDataType(static_cast<PrimitiveType>(pod_->dtype));
+}
+
+dnnl::memory::desc MemrefInfo::GetOneDnnMemDesc() const {
+  auto dims = GetOneDnnDims();
+  auto dtype = GetOneDnnDataType();
+  auto strides = GetOneDnnStrides();
+  return dnnl::memory::desc{dims, dtype, strides};
+}
+
+void* MemrefInfo::Data() { return pod_->data; }
+
+void MemrefInfo::Print() {
+  std::cout << "Data type: " << pod_->dtype << "\t";
+  std::cout << "Rank: " << pod_->rank << "\t";
+  std::cout << "Dims: [ ";
+  for (int i = 0; i < pod_->rank; ++i) {
+    std::cout << pod_->dims[i] << " ";
+  }
+  std::cout << "]\t";
+
+  std::cout << "Strides: [ ";
+  for (int i = 0; i < pod_->rank; ++i) {
+    std::cout << pod_->strides[i] << " ";
+  }
+  std::cout << "]\n";
+}
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3

--- a/tensorflow/compiler/xla/service/cpu/onednn_memory_util.cc
+++ b/tensorflow/compiler/xla/service/cpu/onednn_memory_util.cc
@@ -1,14 +1,18 @@
 /* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
 
 #include "tensorflow/compiler/xla/service/cpu/onednn_memory_util.h"
@@ -16,6 +20,7 @@ limitations under the License.
 #include <algorithm>
 #include <cmath>
 #include <initializer_list>
+#include <iostream>
 #include <vector>
 
 #include "llvm/IR/BasicBlock.h"
@@ -36,7 +41,7 @@ namespace xla {
 namespace cpu {
 
 // Put structure definition together with dependant code
-// to simplify consitency maintenance
+// to simplify consistency maintenance.
 struct MemrefInfoPOD {
   int64_t dtype;
   int64_t rank;
@@ -67,7 +72,7 @@ StackAlloca GetAllocaAndEmitMemrefInfo(llvm::IRBuilder<>& builder,
       builder.getContext(),
       {i64_type, i64_type, i64_array_type, i64_array_type, ptr_type});
 
-  // Prepare arrays dims and strides.
+  // Prepare array dims and strides.
   llvm::Value* dims_val = llvm::UndefValue::get(i64_array_type);
   llvm::Value* strides_val = llvm::UndefValue::get(i64_array_type);
   for (unsigned i = 0; i < rank; ++i) {

--- a/tensorflow/compiler/xla/service/cpu/onednn_memory_util.h
+++ b/tensorflow/compiler/xla/service/cpu/onednn_memory_util.h
@@ -1,8 +1,11 @@
 /* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tensorflow/compiler/xla/service/cpu/onednn_memory_util.h
+++ b/tensorflow/compiler/xla/service/cpu/onednn_memory_util.h
@@ -1,0 +1,115 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_CPU_ONEDNN_MEMORY_UTIL_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_CPU_ONEDNN_MEMORY_UTIL_H_
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include "dnnl.hpp"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Value.h"
+#include "tensorflow/compiler/xla/service/llvm_ir/ir_array.h"
+#include "tensorflow/compiler/xla/xla_data.pb.h"
+
+namespace xla {
+namespace cpu {
+
+static const int kOneDnnMaxNDims = DNNL_MAX_NDIMS;
+
+struct StackAlloca {
+  llvm::IRBuilder<>* builder;
+  llvm::Value* value;
+  void EmitLifetimeEnd() {
+    builder->CreateLifetimeEnd(value, builder->getInt64(-1));
+  }
+
+  ~StackAlloca() {}
+};
+
+// Declare as opaque to put structure definition together with dependant code.
+struct MemrefInfoPOD;
+
+StackAlloca GetAllocaAndEmitMemrefInfo(llvm::IRBuilder<>& builder,
+                                       const llvm_ir::IrArray& ir_array);
+
+inline dnnl::memory::data_type ToOneDnnDataType(PrimitiveType ptype) {
+  using dt = dnnl::memory::data_type;
+  switch (ptype) {
+    case S32:
+      return dt::s32;
+    case U8:
+      return dt::u8;
+    case S8:
+      return dt::s8;
+    case F16:
+      return dt::f16;
+    case BF16:
+      return dt::bf16;
+    case F32:
+      return dt::f32;
+    case F64:
+      return dt::f64;
+
+    // TODO(intel-tf): properly handle not supported types:
+    // S16, S64, U16, U32, U64, C64, C128, F8E5M2, F8E4M3FN, S4, U4,
+    // F8E4M3B11FNUZ
+    default:
+      return dt::undef;
+  }
+}
+
+inline PrimitiveType ToXlaPrimitiveType(dnnl::memory::data_type dtype) {
+  using dt = dnnl::memory::data_type;
+  switch (dtype) {
+    case dt::s32:
+      return PrimitiveType::S32;
+    case dt::u8:
+      return PrimitiveType::U8;
+    case dt::s8:
+      return PrimitiveType::S8;
+    case dt::f16:
+      return PrimitiveType::F16;
+    case dt::bf16:
+      return PrimitiveType::BF16;
+    case dt::f32:
+      return PrimitiveType::F32;
+    case dt::f64:
+      return PrimitiveType::F64;
+    // TODO(intel-tf): properly handle not supported type:
+    default:
+      return PRIMITIVE_TYPE_INVALID;
+  }
+}
+
+class MemrefInfo {
+ public:
+  MemrefInfo(void* data);
+
+  dnnl::memory::dims GetOneDnnDims() const;
+  dnnl::memory::dims GetOneDnnStrides() const;
+  dnnl::memory::data_type GetOneDnnDataType() const;
+  dnnl::memory::desc GetOneDnnMemDesc() const;
+  void* Data();
+
+  void Print();
+
+ private:
+  MemrefInfoPOD* pod_;
+};
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_CPU_ONEDNN_MEMORY_UTIL_H_

--- a/tensorflow/compiler/xla/service/cpu/onednn_memory_util.h
+++ b/tensorflow/compiler/xla/service/cpu/onednn_memory_util.h
@@ -33,8 +33,6 @@ struct StackAlloca {
   void EmitLifetimeEnd() {
     builder->CreateLifetimeEnd(value, builder->getInt64(-1));
   }
-
-  ~StackAlloca() {}
 };
 
 // Declare as opaque to put structure definition together with dependant code.

--- a/tensorflow/compiler/xla/service/cpu/onednn_rewriter.cc
+++ b/tensorflow/compiler/xla/service/cpu/onednn_rewriter.cc
@@ -1,0 +1,125 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include "tensorflow/compiler/xla/service/cpu/onednn_rewriter.h"
+
+#include "tensorflow/compiler/xla/hlo/ir/dfs_hlo_visitor_with_default.h"
+#include "tensorflow/compiler/xla/hlo/ir/hlo_instruction.h"
+#include "tensorflow/compiler/xla/service/cpu/backend_config.pb.h"
+#include "tensorflow/compiler/xla/service/cpu/onednn_memory_util.h"
+#include "tensorflow/compiler/xla/service/pattern_matcher.h"
+#include "tensorflow/compiler/xla/status_macros.h"
+
+namespace xla {
+namespace cpu {
+
+namespace {
+namespace m = match;
+
+Status ValidateDotDimensionNumbers(const DotDimensionNumbers& dim_numbers) {
+  // Checks some invariants that do not hold in general, but DotDecomposer
+  // should have established for us.
+  TF_RET_CHECK(dim_numbers.lhs_contracting_dimensions_size() == 1);
+  std::vector<int64_t> batch_dim_numbers(
+      dim_numbers.lhs_batch_dimensions_size());
+  absl::c_iota(batch_dim_numbers, 0);
+  TF_RET_CHECK(
+      absl::c_equal(batch_dim_numbers, dim_numbers.lhs_batch_dimensions()));
+  TF_RET_CHECK(
+      absl::c_equal(batch_dim_numbers, dim_numbers.rhs_batch_dimensions()));
+  return OkStatus();
+}
+
+}  // namespace
+
+class OneDnnRewriterVisitor : public DfsHloRewriteVisitor {
+ public:
+  // Matches patterns for possible MatMul fusions that are supported by oneDNN
+  // library. Matched hlo instruction(s) are replaced by custom call.
+  Status HandleDot(HloInstruction* instr) override {
+    // Currently, blocking control dependencies
+    if (instr->HasControlDependencies()) return OkStatus();
+    HloInstruction* dot_instr;
+    auto pattern = m::Op(&dot_instr).WithOpcode(HloOpcode::kDot);
+    if (!Match(instr, pattern)) return OkStatus();
+
+    // The rewrite pass runs after dot-decomposition pass. Adjust
+    // the rewrite condition when the rewrite pass is moved before
+    // dot-decomposition pass.
+
+    // Currently, we rewrite when the data type is F32 or BF16. Note we do not
+    // need to check equality of contraction dim-size of the operands. HLO
+    // verifier already does the job. We however, need to check if contraction
+    // is over only 1 dimension (a.k.a. K dimension in matrix-multiplication
+    // parlance). We also restrict batch dimensions of the operands mathces.
+    if (auto dtype = dot_instr->shape().element_type();
+        !(dtype == F32 || dtype == BF16))
+      return OkStatus();
+    auto dot_dim_numbers = dot_instr->dot_dimension_numbers();
+    TF_RETURN_IF_ERROR(ValidateDotDimensionNumbers(dot_dim_numbers));
+    const Shape& lhs_shape = dot_instr->operand(0)->shape();
+    const Shape& rhs_shape = dot_instr->operand(1)->shape();
+    const Shape& output_shape = dot_instr->shape();
+    bool should_rewrite = true;
+    should_rewrite &= (lhs_shape.rank() == rhs_shape.rank());
+    should_rewrite &= (rhs_shape.rank() == output_shape.rank());
+    // OneDNN only  supports rank >=2 and <= kOneDnnMaxNDims.
+    should_rewrite &=
+        (lhs_shape.rank() >= 2 && lhs_shape.rank() <= kOneDnnMaxNDims);
+    if (!should_rewrite) return OkStatus();
+    // Transpose scenario needs some care and blocked for oneDNN rewrite for
+    // now.
+    // TODO(intel-tf): Add transpose scenarios
+    should_rewrite &= LayoutUtil::IsMonotonicWithDim0Major(lhs_shape.layout());
+    if (!should_rewrite) return OkStatus();
+    should_rewrite &= LayoutUtil::IsMonotonicWithDim0Major(rhs_shape.layout());
+    if (!should_rewrite) return OkStatus();
+    should_rewrite &=
+        LayoutUtil::IsMonotonicWithDim0Major(output_shape.layout());
+    if (!should_rewrite) return OkStatus();
+
+    // Check contracting dimensions: [..., M, K] x [..., K, N]
+    should_rewrite &=
+        (dot_dim_numbers.lhs_contracting_dimensions(0) == lhs_shape.rank() - 1);
+    should_rewrite &=
+        (dot_dim_numbers.rhs_contracting_dimensions(0) == rhs_shape.rank() - 2);
+    if (!should_rewrite) return OkStatus();
+
+    HloInstruction* matmul_call =
+        dot_instr->AddInstruction(HloInstruction::CreateCustomCall(
+            output_shape,
+            {dot_instr->mutable_operand(0), dot_instr->mutable_operand(1)},
+            "__onednn$matmul"));
+    // Set additional info via config, e.g., fusion info.
+    OneDnnMatMulConfig matmul_config;
+    // No fusion is supported now, so nothing to add to the config.
+    TF_RETURN_IF_ERROR(matmul_call->set_backend_config(matmul_config));
+    TF_RETURN_IF_ERROR(ReplaceInstruction(dot_instr, matmul_call));
+    return OkStatus();
+  }
+};
+
+StatusOr<bool> OneDnnRewriter::Run(
+    HloModule* module,
+    const absl::flat_hash_set<absl::string_view>& execution_threads) {
+  OneDnnRewriterVisitor visitor;
+  return visitor.RunOnModule(module, execution_threads);
+}
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3

--- a/tensorflow/compiler/xla/service/cpu/onednn_rewriter.h
+++ b/tensorflow/compiler/xla/service/cpu/onednn_rewriter.h
@@ -1,0 +1,44 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_COMPILER_XLA_SERVICE_CPU_ONEDNN_REWRITER_H_
+#define TENSORFLOW_COMPILER_XLA_SERVICE_CPU_ONEDNN_REWRITER_H_
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include <optional>
+
+#include "absl/algorithm/container.h"
+#include "tensorflow/compiler/xla/hlo/ir/hlo_instructions.h"
+#include "tensorflow/compiler/xla/hlo/ir/hlo_module.h"
+#include "tensorflow/compiler/xla/service/hlo_pass_interface.h"
+
+namespace xla {
+namespace cpu {
+
+// This pass pattern-matches hlo instructions and rewrites into custom calls.
+class OneDnnRewriter : public HloModulePass {
+ public:
+  absl::string_view name() const override { return "onednn-rewriter"; }
+
+  using HloPassInterface::Run;
+  StatusOr<bool> Run(
+      HloModule* module,
+      const absl::flat_hash_set<absl::string_view>& execution_threads) override;
+};
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
+#endif  // TENSORFLOW_COMPILER_XLA_SERVICE_CPU_ONEDNN_REWRITER_H_

--- a/tensorflow/compiler/xla/service/cpu/onednn_rewriter.h
+++ b/tensorflow/compiler/xla/service/cpu/onednn_rewriter.h
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
 #ifndef TENSORFLOW_COMPILER_XLA_SERVICE_CPU_ONEDNN_REWRITER_H_
 #define TENSORFLOW_COMPILER_XLA_SERVICE_CPU_ONEDNN_REWRITER_H_
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)

--- a/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
+++ b/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
@@ -33,6 +33,7 @@ limitations under the License.
 #include "llvm/TargetParser/Host.h"
 #include "mlir/ExecutionEngine/CRunnerUtils.h"  // from @llvm-project
 #include "tensorflow/compiler/xla/service/cpu/cpu_runtime.h"
+#include "tensorflow/compiler/xla/service/cpu/onednn_matmul.h"
 #include "tensorflow/compiler/xla/service/cpu/orc_jit_memory_mapper.h"
 #include "tensorflow/compiler/xla/service/cpu/runtime_conv2d.h"
 #include "tensorflow/compiler/xla/service/cpu/runtime_conv2d_acl.h"
@@ -325,6 +326,10 @@ bool RegisterKnownJITSymbols() {
   REGISTER_CPU_RUNTIME_SYMBOL(TracingStart);
   REGISTER_CPU_RUNTIME_SYMBOL(TracingEnd);
 
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+  registry->Register("onednn.matmul", reinterpret_cast<void*>(onednn_matmul),
+                     "Host");
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
   registry->Register("__gnu_f2h_ieee", reinterpret_cast<void*>(__gnu_f2h_ieee),
                      "Host");
   registry->Register("__gnu_h2f_ieee", reinterpret_cast<void*>(__gnu_h2f_ieee),

--- a/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
+++ b/tensorflow/compiler/xla/service/cpu/simple_orc_jit.cc
@@ -325,11 +325,10 @@ bool RegisterKnownJITSymbols() {
   REGISTER_CPU_RUNTIME_SYMBOL(TopKF32);
   REGISTER_CPU_RUNTIME_SYMBOL(TracingStart);
   REGISTER_CPU_RUNTIME_SYMBOL(TracingEnd);
-
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
-  registry->Register("onednn.matmul", reinterpret_cast<void*>(onednn_matmul),
-                     "Host");
+  REGISTER_CPU_RUNTIME_SYMBOL(OneDnnMatMul);
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
+
   registry->Register("__gnu_f2h_ieee", reinterpret_cast<void*>(__gnu_f2h_ieee),
                      "Host");
   registry->Register("__gnu_h2f_ieee", reinterpret_cast<void*>(__gnu_h2f_ieee),

--- a/tensorflow/compiler/xla/service/cpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/tests/BUILD
@@ -3,6 +3,7 @@
 
 load("//tensorflow/tsl:tsl.default.bzl", "filegroup")
 load("//tensorflow/compiler/xla:xla.bzl", "xla_cc_test")
+load("//tensorflow/tsl:tsl.bzl", "tsl_copts")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -136,6 +137,7 @@ xla_cc_test(
     name = "cpu_eigen_dot_operation_test",
     srcs = ["cpu_eigen_dot_operation_test.cc"],
     tags = ["no_mac_arm64"],
+    copts = tsl_copts(),
     deps = [
         "//tensorflow/compiler/xla/hlo/ir:hlo",
         "//tensorflow/compiler/xla/service/cpu:cpu_compiler",

--- a/tensorflow/compiler/xla/service/cpu/tests/BUILD
+++ b/tensorflow/compiler/xla/service/cpu/tests/BUILD
@@ -136,8 +136,8 @@ xla_cc_test(
 xla_cc_test(
     name = "cpu_eigen_dot_operation_test",
     srcs = ["cpu_eigen_dot_operation_test.cc"],
-    tags = ["no_mac_arm64"],
     copts = tsl_copts(),
+    tags = ["no_mac_arm64"],
     deps = [
         "//tensorflow/compiler/xla/hlo/ir:hlo",
         "//tensorflow/compiler/xla/service/cpu:cpu_compiler",

--- a/tensorflow/compiler/xla/service/cpu/tests/cpu_eigen_dot_operation_test.cc
+++ b/tensorflow/compiler/xla/service/cpu/tests/cpu_eigen_dot_operation_test.cc
@@ -62,6 +62,9 @@ class CpuEigenDotOperationTest
 };
 
 TEST_P(CpuEigenDotOperationTest, SimpleDotOp) {
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+  GTEST_SKIP() << "OneDNN rewrites dot instruction to custom-call.";
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
   HloComputation::Builder builder(TestName());
   DotTestSpec spec = GetParam();
 
@@ -77,6 +80,9 @@ TEST_P(CpuEigenDotOperationTest, SimpleDotOp) {
 }
 
 TEST_P(CpuEigenDotOperationTest, DotTransposeOp) {
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+  GTEST_SKIP() << "OneDNN rewrites dot instruction to custom-call.";
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
   HloComputation::Builder builder(TestName());
   DotTestSpec spec = GetParam();
 

--- a/tensorflow/compiler/xla/tests/BUILD
+++ b/tensorflow/compiler/xla/tests/BUILD
@@ -13,6 +13,7 @@ load(
     "//tensorflow/compiler/xla/stream_executor:build_defs.bzl",
     "if_gpu_is_configured",
 )
+load("//tensorflow/tsl:tsl.bzl", "tsl_copts")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
@@ -2776,5 +2777,23 @@ xla_cc_test(
         "//tensorflow/compiler/xla:test",
         "//tensorflow/compiler/xla/hlo/ir:tile_assignment",
         "@com_google_absl//absl/hash",
+    ],
+)
+
+xla_test(
+    name = "onednn_matmul_test",
+    srcs = ["onednn_matmul_test.cc"],
+    backends = [
+        "cpu",
+    ],
+    copts = tsl_copts(),
+    deps = [
+        ":hlo_test_base",
+        ":test_macros_header",
+        ":xla_internal_test_main",
+        "//tensorflow/compiler/xla:literal",
+        "//tensorflow/compiler/xla:shape_util",
+        "//tensorflow/compiler/xla:test",
+        "//tensorflow/compiler/xla:test_helpers",
     ],
 )

--- a/tensorflow/compiler/xla/tests/onednn_matmul_test.cc
+++ b/tensorflow/compiler/xla/tests/onednn_matmul_test.cc
@@ -1,0 +1,73 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+
+#include <utility>
+
+#include "tensorflow/compiler/xla/literal.h"
+#include "tensorflow/compiler/xla/shape_util.h"
+#include "tensorflow/compiler/xla/test.h"
+#include "tensorflow/compiler/xla/test_helpers.h"
+#include "tensorflow/compiler/xla/tests/hlo_test_base.h"
+#include "tensorflow/compiler/xla/tests/test_macros.h"
+
+namespace xla {
+namespace cpu {
+
+class MatmulTest : public HloTestBase {};
+
+TEST_F(MatmulTest, SimpleTestF32) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.f32, entry_computation_layout={(f32[2,8,4,16]{3,2,1,0},f32[2,8,16,32]{3,2,1,0})->f32[2,8,4,32]{3,2,1,0}}
+
+  ENTRY matmul.test.f32 {
+    arg.0 = f32[2,8,4,16]{3,2,1,0} parameter(0), parameter_replication={false}
+    arg.1 = f32[2,8,16,32]{3,2,1,0} parameter(1), parameter_replication={false}
+    ROOT onednn.matmul.0 = f32[2,8,4,32]{3,2,1,0} dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+}
+
+TEST_F(MatmulTest, SimpleTestBF16) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.bf16, entry_computation_layout={(bf16[2,8,4,16]{3,2,1,0},bf16[2,8,16,32]{3,2,1,0})->bf16[2,8,4,32]{3,2,1,0}}
+
+  ENTRY matmul.test.bf16 {
+    arg.0 = bf16[2,8,4,16]{3,2,1,0} parameter(0), parameter_replication={false}
+    arg.1 = bf16[2,8,16,32]{3,2,1,0} parameter(1), parameter_replication={false}
+    ROOT onednn.matmul.0 = bf16[2,8,4,32]{3,2,1,0} dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={2}
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+}
+
+TEST_F(MatmulTest, SimpleTestF32TransposeB) {
+  const char* matmul_module_str = R"(
+  HloModule matmul.test.1, entry_computation_layout={(f32[2,8,4,16]{3,1,2,0},f32[2,8,4,16]{3,1,2,0})->f32[2,8,4,4]{3,2,1,0}}
+
+  ENTRY matmul.test.1 {
+    arg.0 = f32[2,8,4,16]{3,1,2,0} parameter(0), parameter_replication={false}
+    arg.1 = f32[2,8,4,16]{3,1,2,0} parameter(1), parameter_replication={false}
+    ROOT onednn.matmul.0 = f32[2,8,4,4]{3,2,1,0} dot(arg.0, arg.1), lhs_batch_dims={0,1}, lhs_contracting_dims={3}, rhs_batch_dims={0,1}, rhs_contracting_dims={3}
+  })";
+
+  EXPECT_TRUE(RunAndCompare(matmul_module_str, ErrorSpec{1e-4, 1e-4}));
+}
+
+}  // namespace cpu
+}  // namespace xla
+
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3

--- a/tensorflow/compiler/xla/tests/onednn_matmul_test.cc
+++ b/tensorflow/compiler/xla/tests/onednn_matmul_test.cc
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
 
 #include <utility>

--- a/tensorflow/python/eager/polymorphic_function/polymorphic_function_xla_jit_test.py
+++ b/tensorflow/python/eager/polymorphic_function/polymorphic_function_xla_jit_test.py
@@ -943,8 +943,12 @@ class FunctionTest(xla_test.XLATestCase):
       def f(a, b):
         return math_ops.matmul(a, b)
 
-      self.assertRegex(f.experimental_get_compiler_ir(a, b)('optimized_hlo'),
-                       '(dot)|(convolution)')
+      if not test_util.IsMklEnabled():
+        self.assertRegex(f.experimental_get_compiler_ir(a, b)('optimized_hlo'),
+                         '(dot)|(convolution)')
+      else:
+        self.assertRegex(f.experimental_get_compiler_ir(a, b)('optimized_hlo'),
+                         '(dot)|(convolution)|(custom-call)')
 
   def testConstantOnWrongDevice(self):
     with ops.device('device:{}:0'.format(self.device)):


### PR DESCRIPTION
This PR includes a fix to BF16 failure in the earlier PR #61237. Changes here is to disable oneDNN matmul if the CPU does not have either AVX512_BF16 or AMX_BF16 feature.