### PR TITLE
Update SignatureRunner support information for C API

### DIFF
--- a/tensorflow/lite/g3doc/guide/signatures.ipynb
+++ b/tensorflow/lite/g3doc/guide/signatures.ipynb
@@ -457,7 +457,7 @@
         "\n",
         "*   As TFLite interpreter does not gurantee thread safety, the signature runners\n",
         "    from the same interpreter won't be executed concurrently.\n",
-        "*   Support for C/iOS/Swift is not available yet.\n",
+        "*   Support for iOS/Swift is not available yet.\n",
         "\n"
       ]
     },


### PR DESCRIPTION
The TFLite `SignatureRunner` is supported in C API with commit https://github.com/tensorflow/tensorflow/commit/3a6a6465c45797bd573c118a535405da43ab03fa. 