### PR TITLE
upgrade curl 8.1.2 -> 8.2.1 which has CVE fixes

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -511,10 +511,10 @@ def _tf_repositories():
     tf_http_archive(
         name = "curl",
         build_file = "//third_party:curl.BUILD",
-        sha256 = "2e5a9b8fcdc095bdd2f079561f369de71c5eb3b80f00a702fbe9a8b8d9897891",
-        strip_prefix = "curl-8.1.2",
+        sha256 = "f98bdb06c0f52bdd19e63c4a77b5eb19b243bcbbd0f5b002b9f3cba7295a3a42",
+        strip_prefix = "curl-8.2.1",
         system_build_file = "//third_party/systemlibs:curl.BUILD",
-        urls = tf_mirror_urls("https://curl.haxx.se/download/curl-8.1.2.tar.gz"),
+        urls = tf_mirror_urls("https://curl.haxx.se/download/curl-8.2.1.tar.gz"),
     )
 
     # WARNING: make sure ncteisen@ and vpai@ are cc-ed on any CL to change the below rule

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -201,6 +201,8 @@ cc_library(
         "lib/ldap.c",
         "lib/llist.c",
         "lib/llist.h",
+        "lib/macos.c",
+        "lib/macos.h",
         "lib/md4.c",
         "lib/md5.c",
         "lib/memdebug.c",

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -347,6 +347,7 @@ cc_library(
         "lib/vtls/rustls.h",
         "lib/vtls/schannel.c",
         "lib/vtls/schannel.h",
+        "lib/vtls/schannel_int.h",
         "lib/vtls/schannel_verify.c",
         "lib/vtls/sectransp.h",
         "lib/vtls/vtls.c",


### PR DESCRIPTION
upgrade curl from 8.1.2 to 8.2.1 which has a few vulnerability fixes