### PR TITLE
Fix use of pypi packages by switching to release versions

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -1717,8 +1717,8 @@ py_library(
         "//tensorflow/lite/python:lite",
         "//tensorflow/lite/python/authoring",
         "//tensorflow/python:no_contrib",
-        "@pypi_keras_nightly//:pkg",
-        "@pypi_tb_nightly//:pkg",
+        "@pypi_keras//:pkg",
+        "@pypi_tensorboard//:pkg",
     ],
 )
 # copybara:comment_end

--- a/tensorflow/python/estimator/BUILD
+++ b/tensorflow/python/estimator/BUILD
@@ -382,5 +382,5 @@ py_library(
 
 alias(
     name = "expect_tensorflow_estimator_installed",
-    actual = "@pypi_tf_estimator_nightly//:pkg",
+    actual = "@pypi_tensorflow_estimator//:pkg",
 )

--- a/tensorflow/python/summary/BUILD
+++ b/tensorflow/python/summary/BUILD
@@ -121,6 +121,6 @@ tf_py_strict_test(
         "//tensorflow/python/ops:summary_ops_v2",
         "//tensorflow/python/platform:client_testlib",
         "//tensorflow/python/training:training_util",
-        "@pypi_tb_nightly//:pkg",
+        "@pypi_tensorboard//:pkg",
     ],
 )


### PR DESCRIPTION
Need to switch to release versions of pypi pacakges not their nightly ones.