### PR TITLE
[oneDNN] Remove StopGradient op seen in some LayerNorm patterns

### DIFF
--- a/tensorflow/python/framework/graph_util_impl.py
+++ b/tensorflow/python/framework/graph_util_impl.py
@@ -325,7 +325,7 @@ def remove_training_nodes(input_graph, protected_nodes=None):
       new_node.input.append(full_input_name)
     nodes_after_removal.append(new_node)
 
-  types_to_splice = {"Identity": True}
+  types_to_splice = {"Identity": True,"StopGradient":True}
   control_input_names = set()
   node_names_with_control_input = set()
   node_in_colocated = set()


### PR DESCRIPTION
Following pattern is seen in 3 models. It looks similar to InstanceNorm pattern but it is actually LayerNorm based on the reduction axis. Under right conditions, this pattern will be fused as LayerNorm to improve performance.

![layernorm-pattern](https://github.com/tensorflow/tensorflow/assets/42224278/6d6cc62a-6ab8-4cef-aa53-c7872ace2b1c)


StopGradient is removed as part of optimize_for_inference since it is not required and is a training op.
"When used in a graph, it outputs the input as is" https://www.tensorflow.org/api_docs/python/tf/stop_gradient