### PR TITLE
Add CPU_kernel with float16 for adjust_contrast_op.cc

### DIFF
--- a/tensorflow/core/kernels/image/adjust_contrast_op.cc
+++ b/tensorflow/core/kernels/image/adjust_contrast_op.cc
@@ -390,7 +390,7 @@ class AdjustContrastOpv2<CPUDevice, float> : public AdjustContrastOpV2Base {
 #define REGISTER_KERNEL(T)                                                 \
   REGISTER_KERNEL_BUILDER(                                                 \
       Name("AdjustContrastv2").Device(DEVICE_CPU).TypeConstraint<T>("T"),  \
-      AdjustContrastOpv2<CPUDevice, T>);
+      AdjustContrastOpv2<CPUDevice, T>)
 
 REGISTER_KERNEL(float);
 REGISTER_KERNEL(Eigen::half);

--- a/tensorflow/core/kernels/image/adjust_contrast_op.cc
+++ b/tensorflow/core/kernels/image/adjust_contrast_op.cc
@@ -387,9 +387,14 @@ class AdjustContrastOpv2<CPUDevice, float> : public AdjustContrastOpV2Base {
   }
 };
 
-REGISTER_KERNEL_BUILDER(
-    Name("AdjustContrastv2").Device(DEVICE_CPU).TypeConstraint<float>("T"),
-    AdjustContrastOpv2<CPUDevice, float>);
+#define REGISTER_KERNEL(T)                                                 \
+  REGISTER_KERNEL_BUILDER(                                                 \
+      Name("AdjustContrastv2").Device(DEVICE_CPU).TypeConstraint<T>("T"),  \
+      AdjustContrastOpv2<CPUDevice, T>);
+
+REGISTER_KERNEL(float);
+REGISTER_KERNEL(Eigen::half);
+#undef REGISTER_KERNEL
 
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \
     (defined(TENSORFLOW_USE_ROCM) && TENSORFLOW_USE_ROCM)

--- a/tensorflow/core/kernels/image/adjust_contrast_op.cc
+++ b/tensorflow/core/kernels/image/adjust_contrast_op.cc
@@ -390,10 +390,10 @@ class AdjustContrastOpv2<CPUDevice, float> : public AdjustContrastOpV2Base {
 #define REGISTER_KERNEL(T)                                                 \
   REGISTER_KERNEL_BUILDER(                                                 \
       Name("AdjustContrastv2").Device(DEVICE_CPU).TypeConstraint<T>("T"),  \
-      AdjustContrastOpv2<CPUDevice, T>)
+      AdjustContrastOpv2<CPUDevice, T>);
 
-REGISTER_KERNEL(float);
-REGISTER_KERNEL(Eigen::half);
+REGISTER_KERNEL(float)
+REGISTER_KERNEL(Eigen::half)
 #undef REGISTER_KERNEL
 
 #if (defined(GOOGLE_CUDA) && GOOGLE_CUDA) || \


### PR DESCRIPTION
The API `tf.image.adjust_contrast` supports `float16` and `float32` for the argument images . But with `CPU` runtime and `float16` dtype the API raising exception stating there is no kernel available. Refer attached [gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/6990939226d9d79dfe9225b13919c288/61246_cpu.ipynb) for the exception.

Hence adding a kernel for CPU with float16.

Shall also fixes #61246