### PR TITLE
[TFLite] Fix cmake build kernel test fail when `-DTFLITE_ENABLE_GPU=OFF`

### DIFF
--- a/tensorflow/lite/kernels/CMakeLists.txt
+++ b/tensorflow/lite/kernels/CMakeLists.txt
@@ -107,6 +107,11 @@ if(NOT _TFLITE_ENABLE_NNAPI)
     ${TFLITE_SOURCE_DIR}/nnapi/nnapi_util.cc
   )
 endif()
+if(NOT TFLITE_ENABLE_GPU)
+  list(APPEND TEST_FRAMEWORK_SRC
+    ${TFLITE_SOURCE_DIR}/tools/versioning/op_signature.cc
+  )
+endif()
 
 set(TEST_FRAMEWORK_OPTIONS "")
 if(TFLITE_ENABLE_XNNPACK)


### PR DESCRIPTION
- Problem:
Using CMake to build the TFLite kernel test will fail in linking stage when `-DTFLITE_ENABLE_GPU=OFF`

- Log:
```
ld: libtensorflow-lite-test-base.a(op_version.cc.o): in function `.LBB1_18':
op_version.cc:(.text._ZN6tflite15UpdateOpVersionEPh+0x14c): undefined reference to `tflite::GetOpSignature(tflite::OperatorCode const*, tflite::Operator const*, tflite::SubGraph const*, tflite::Model const*)'
clang++: rror: linker command failed with exit code 1 (use -v to see invocation)
```

- Solution:
Add `versioning/op_signature.cc` to TEST_FRAMEWORK_SRC if `-DTFLITE_ENABLE_GPU=OFF`. `versioning/op_version.cc` depends on `versioning/op_signature.cc` because of using GetOpSignature().
We don't need to add `versioning/op_signature.cc` to TEST_FRAMEWORK_SRC if `-DTFLITE_ENABLE_GPU=ON`. Because `versioning/op_signature.cc` is appended in `TFLITE_DELEGATES_GPU_SRCS`, it makes `tensorflow-lite.a` define `GetOpSignature`.