### PR TITLE
Add clang-tidy and upgrade clang-format in docker

### DIFF
--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.packages.txt
@@ -28,7 +28,8 @@ ca-certificates
 llvm-16
 clang-16
 lld-16
-clang-format-12
+clang-format-16
+clang-tidy-16
 colordiff
 curl
 ffmpeg


### PR DESCRIPTION
Add clang-tidy to the sig build image and upgrade clang format to match the version of the other clang tools