### PR TITLE
[Linaro:ARM_CI] Remove mention of XLA unit tests

### DIFF
--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -16,7 +16,5 @@
 set -x
 
 ARM_SKIP_TESTS="-//tensorflow/lite/... \
--//tensorflow/compiler/xla/service/cpu/tests:cpu_eigen_dot_operation_test \
--//tensorflow/compiler/xla/service/gpu:fusion_merger_test \
 -//tensorflow/core/kernels/image:resize_bicubic_op_test \
 "


### PR DESCRIPTION
The XLA code is no longer present in the TensorFlow tree so need to remove mention of the XLA unit tests from the skip list