### PR TITLE
[MLIR/TF2XLA] Do not convert tf.Select when element type is tf_type.s…

### DIFF
--- a/tensorflow/compiler/mlir/tf2xla/tests/legalize-tf.mlir
+++ b/tensorflow/compiler/mlir/tf2xla/tests/legalize-tf.mlir
@@ -2163,6 +2163,13 @@ func.func @selectv2_unranked(%arg0: tensor<1xi1>, %arg1: tensor<2x8x8xi32>, %arg
   func.return %0: tensor<*xi32>
 }
 
+// CHECK-LABEL: func @not_lowering_select
+func.func @not_lowering_select(%arg0: tensor<3xi1>, %arg1: tensor<3x2x!tf_type.string>, %arg2: tensor<3x2x!tf_type.string>) -> tensor<3x2x!tf_type.string> {
+  // CHECK: "tf.Select"
+  %0 = "tf.Select"(%arg0, %arg1, %arg2) : (tensor<3xi1>, tensor<3x2x!tf_type.string>, tensor<3x2x!tf_type.string>) -> tensor<3x2x!tf_type.string>
+  func.return %0: tensor<3x2x!tf_type.string>
+}
+
 //===----------------------------------------------------------------------===//
 // Fast Fourier Transform op legalization.
 //===----------------------------------------------------------------------===//

--- a/tensorflow/compiler/mlir/tf2xla/transforms/legalize_tf.cc
+++ b/tensorflow/compiler/mlir/tf2xla/transforms/legalize_tf.cc
@@ -2869,6 +2869,9 @@ class ConvertSelectOp : public OpRewritePattern<TF::SelectOp> {
 
   LogicalResult matchAndRewrite(TF::SelectOp op,
                                 PatternRewriter &rewriter) const override {
+    if(op.getOutput().getType().getElementType().isa<mlir::TF::StringType>()) {
+      return failure();
+    }
     // This lowering only works on ranked types.
     auto cond_type = op.getCondition().getType().dyn_cast<RankedTensorType>();
     auto then_type = op.getThenValue().getType().dyn_cast<RankedTensorType>();


### PR DESCRIPTION
fix: do not convert tf.Select to mhlo.select when element type is !tf_type.string