### PR TITLE
add empty file test cases to utils_test.cc

### DIFF
--- a/tensorflow/lite/tools/evaluation/utils_test.cc
+++ b/tensorflow/lite/tools/evaluation/utils_test.cc
@@ -56,15 +56,15 @@ TEST(UtilsTest, ReadFileCorrectly) {
   std::string file_path(kLabelsPath);
   std::string empty_path(kEmptyFilePath);
   std::vector<std::string> lines;
-  std::vector<std::string> emptyLines;
+  std::vector<std::string> empty_lines;
 
   EXPECT_TRUE(ReadFileLines(file_path, &lines));
   EXPECT_EQ(lines.size(), 2);
   EXPECT_EQ(lines[0], "label1");
   EXPECT_EQ(lines[1], "label2");
 
-  EXPECT_TRUE(ReadFileLines(empty_path, &emptyLines));
-  EXPECT_EQ(emptyLines.size(), 0);
+  EXPECT_TRUE(ReadFileLines(empty_path, &empty_lines));
+  EXPECT_EQ(empty_lines.size(), 0);
 }
 
 TEST(UtilsTest, SortedFilenamesTest) {

--- a/tensorflow/lite/tools/evaluation/utils_test.cc
+++ b/tensorflow/lite/tools/evaluation/utils_test.cc
@@ -44,20 +44,27 @@ TEST(UtilsTest, StripTrailingSlashesTest) {
 
 TEST(UtilsTest, ReadFileErrors) {
   std::string correct_path(kLabelsPath);
+  std::string empty_path(kEmptyFilePath);
   std::string wrong_path("xyz.txt");
   std::vector<std::string> lines;
   EXPECT_FALSE(ReadFileLines(correct_path, nullptr));
+  EXPECT_FALSE(ReadFileLines(empty_path, nullptr));
   EXPECT_FALSE(ReadFileLines(wrong_path, &lines));
 }
 
 TEST(UtilsTest, ReadFileCorrectly) {
   std::string file_path(kLabelsPath);
+  std::string empty_path(kEmptyFilePath);
   std::vector<std::string> lines;
-  EXPECT_TRUE(ReadFileLines(file_path, &lines));
+  std::vector<std::string> emptyLines;
 
+  EXPECT_TRUE(ReadFileLines(file_path, &lines));
   EXPECT_EQ(lines.size(), 2);
   EXPECT_EQ(lines[0], "label1");
   EXPECT_EQ(lines[1], "label2");
+
+  EXPECT_TRUE(ReadFileLines(empty_path, &emptyLines));
+  EXPECT_EQ(emptyLines.size(), 0);
 }
 
 TEST(UtilsTest, SortedFilenamesTest) {


### PR DESCRIPTION
Add a couple more test cases of the empty file (`empty.txt`) to `utils_test.cc`:
- reading empty file does not return nullptr
- reading empty file results in 0 lines written to vector