### PR TITLE
consistent lowercase testname syntax in examples/adding_an_op tests

### DIFF
--- a/tensorflow/examples/adding_an_op/zero_out_1_test.py
+++ b/tensorflow/examples/adding_an_op/zero_out_1_test.py
@@ -40,7 +40,7 @@ class ZeroOut1Test(tf.test.TestCase):
     result = zero_out_op_1.namespace_nested_zero_out([5, 4, 3, 2, 1])
     self.assertAllEqual(result, [5, 0, 0, 0, 0])
 
-  def testLoadTwice(self):
+  def test_load_twice(self):
     zero_out_loaded_again = tf.load_op_library(os.path.join(
         tf.compat.v1.resource_loader.get_data_files_path(),
         'zero_out_op_kernel_1.so'))

--- a/tensorflow/examples/adding_an_op/zero_out_3_test.py
+++ b/tensorflow/examples/adding_an_op/zero_out_3_test.py
@@ -25,15 +25,15 @@ class ZeroOut3Test(tf.test.TestCase):
     result = zero_out_op_3.zero_out([5, 4, 3, 2, 1])
     self.assertAllEqual(result, [5, 0, 0, 0, 0])
 
-  def testAttr(self):
+  def test_attr(self):
     result = zero_out_op_3.zero_out([5, 4, 3, 2, 1], preserve_index=3)
     self.assertAllEqual(result, [0, 0, 0, 2, 0])
 
-  def testNegative(self):
+  def test_negative(self):
     with self.assertRaisesOpError("Need preserve_index >= 0, got -1"):
       self.evaluate(zero_out_op_3.zero_out([5, 4, 3, 2, 1], preserve_index=-1))
 
-  def testLarge(self):
+  def test_large(self):
     with self.assertRaisesOpError("preserve_index out of range"):
       self.evaluate(zero_out_op_3.zero_out([5, 4, 3, 2, 1], preserve_index=17))
 


### PR DESCRIPTION
Changing a handful of python test names syntax to lowercase with underscores for consistency within  `tensorflow/examples/adding_an_op` python unit tests.