### PR TITLE
rm unnecessary out_id variable

### DIFF
--- a/tensorflow/core/graph/control_flow.cc
+++ b/tensorflow/core/graph/control_flow.cc
@@ -117,10 +117,9 @@ Status BuildControlFlowInfo(const Graph* g, std::vector<ControlFlowInfo>* info,
 
     for (const Edge* out_edge : curr_node->out_edges()) {
       const Node* out = out_edge->dst();
-      int out_id = out->id();
-      ControlFlowInfo* out_info = &(*info)[out_id];
+      ControlFlowInfo* out_info = &(*info)[out->id()];
       const Node* out_parent = out_info->parent_frame;
-      bool is_visited = (parent_nodes[out_id] != nullptr);
+      bool is_visited = (parent_nodes[out->id()] != nullptr);
 
       // Skip Sink/Source nodes.
       if (!out->IsOp()) continue;


### PR DESCRIPTION
Don't think need to assign variable `int out_id = out->id();`, if only for consistency with rest of `tensorflow/core/graph/control_flow.cc`