### PR TITLE
Set permissions to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/arm-cd.yml
+++ b/.github/workflows/arm-cd.yml
@@ -24,6 +24,9 @@ on:
   schedule:
     - cron: '0 8 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks

--- a/.github/workflows/arm-ci-extended-cpp.yml
+++ b/.github/workflows/arm-ci-extended-cpp.yml
@@ -22,6 +22,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks

--- a/.github/workflows/arm-ci-extended.yml
+++ b/.github/workflows/arm-ci-extended.yml
@@ -22,6 +22,9 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks

--- a/.github/workflows/arm-ci.yml
+++ b/.github/workflows/arm-ci.yml
@@ -26,6 +26,9 @@ on:
       - master
       - r2.**
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # Don't do this in forks, and if labeled, only for 'kokoro:force-run'

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -20,6 +20,9 @@ on:
     paths:
       - CITATION.cff
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks

--- a/.github/workflows/issue-on-pr-rollback.yml
+++ b/.github/workflows/issue-on-pr-rollback.yml
@@ -18,10 +18,16 @@ on:
   push:
     branches:
       - master
+      
+permissions: {}
 
 jobs:
   create-issue-on-pr-rollback:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     if: |
       github.repository == 'tensorflow/tensorflow' &&
       startsWith(github.event.head_commit.message, 'Rollback of PR #')

--- a/.github/workflows/pylint-presubmit.yml
+++ b/.github/workflows/pylint-presubmit.yml
@@ -19,6 +19,9 @@ on:
     paths:
       - '**.py'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: PyLint

--- a/.github/workflows/release-branch-cherrypick.yml
+++ b/.github/workflows/release-branch-cherrypick.yml
@@ -35,6 +35,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   cherrypick:
     name: Cherrypick to ${{ github.event.inputs.release_branch}} - ${{ github.event.inputs.git_commit }}

--- a/.github/workflows/sigbuild-docker-branch.yml
+++ b/.github/workflows/sigbuild-docker-branch.yml
@@ -25,6 +25,9 @@ on:
     branches:
       - "r[1-9].[0-9]+"
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks

--- a/.github/workflows/sigbuild-docker-presubmit.yml
+++ b/.github/workflows/sigbuild-docker-presubmit.yml
@@ -23,6 +23,9 @@ on:
       - 'tensorflow/tools/tf_sig_build_dockerfiles/**'
       - '!tensorflow/tools/tf_sig_build_dockerfiles/README.md'
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks
@@ -30,6 +33,9 @@ jobs:
     strategy:
       matrix:
         python-version: [python3.9, python3.10, python3.11]
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       -
         name: Checkout

--- a/.github/workflows/sigbuild-docker.yml
+++ b/.github/workflows/sigbuild-docker.yml
@@ -28,6 +28,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -18,6 +18,9 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   close-issues:
     # Don't do this in forks

--- a/.github/workflows/trusted-partners.yml
+++ b/.github/workflows/trusted-partners.yml
@@ -17,6 +17,9 @@ name: Trusted Partner PR
 on:
   pull_request_target:
 
+permissions:
+  contents: read
+
 jobs:
   assign-partner-tags:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -18,10 +18,15 @@ on:
   schedule:
     - cron: 0 4 * * *  # 4am UTC is 9pm PDT and 8pm PST
 name: Set nightly branch to master HEAD
+
+permissions: {}
+
 jobs:
   master-to-nightly:
     if: github.repository == 'tensorflow/tensorflow' # Don't do this in forks
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: zofrex/mirror-branch@a8809f0b42f9dfe9b2c5c2162a46327c23d15266 # v1.0.3
       name: Set nightly branch to master HEAD

--- a/.github/workflows/update-rbe.yml
+++ b/.github/workflows/update-rbe.yml
@@ -20,6 +20,9 @@ name: Update RBE Configs
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   rbe:
     name: Update RBE Configs


### PR DESCRIPTION
Hi, as discussed through email, this one of the [OSSF Scorecard](https://github.com/ossf/scorecard) recommendations. 

The default permissions given to GITHUB_TOKEN is write all, which can be exploited by an attacker in case of a compromised action.

To mitigate this risk it is important to [Use credentials that are minimally scoped](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets).