### PR TITLE
Revert mistaken update to nightly package versions

### DIFF
--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -16,10 +16,6 @@
 set -x
 
 ARM_SKIP_TESTS="-//tensorflow/lite/... \
--//tensorflow/core/platform:ram_file_system_test \
--//tensorflow/python/compiler/xla:xla_test \
--//tensorflow/python/data/experimental/kernel_tests:checkpoint_input_pipeline_hook_test \
--//tensorflow/python/distribute:parameter_server_strategy_test \
 -//tensorflow/python/kernel_tests/nn_ops:atrous_conv2d_test \
 -//tensorflow/python/kernel_tests/nn_ops:conv_ops_test \
 "

--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -115,9 +115,9 @@ REQUIRED_PACKAGES = [
     standard_or_nightly('tensorboard >= 2.13, < 2.14',
                         'tb-nightly ~= 2.13.0.a'),
     standard_or_nightly('tensorflow_estimator >= 2.13.0, < 2.14',
-                        'tf-estimator-nightly ~= 2.14.0.dev'),
+                        'tf-estimator-nightly ~= 2.13.0.dev'),
     standard_or_nightly('keras >= 2.13.1, < 2.14',
-                        'keras-nightly ~= 2.14.0.dev'),
+                        'keras-nightly ~= 2.13.0.dev'),
 ]
 REQUIRED_PACKAGES = [p for p in REQUIRED_PACKAGES if p is not None]
 


### PR DESCRIPTION
The nightly package versions should not have been updated from the 2.13 versions so revert that change.
Also revert the change that skipped the tests that were broken by the nightly version change.