### PR TITLE
Use different agent label for release testing and ci/nightlys

### DIFF
--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_release.Jenkinsfile
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_build_release.Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
             parallel {
                 stage("Python 3.9") {
                     agent {
-                        label "nightly-build"
+                        label "nightly-build-release"
                     }
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
@@ -73,7 +73,7 @@ pipeline {
                 }
                 stage("Python 3.10") {
                     agent {
-                        label "nightly-build"
+                        label "nightly-build-release"
                     }
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
@@ -122,7 +122,7 @@ pipeline {
                 }
                 stage("Python 3.11") {
                     agent {
-                        label "nightly-build"
+                        label "nightly-build-release"
                     }
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"

--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_test_release.Jenkinsfile
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_as_test_release.Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
             parallel {
                 stage("Python 3.9") {
                     agent {
-                        label "silicon-ci"
+                        label "silicon-ci-release"
                     }
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
@@ -57,7 +57,7 @@ pipeline {
                 }
                 stage("Python 3.10") {
                     agent {
-                        label "silicon-ci"
+                        label "silicon-ci-release"
                     }
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"
@@ -90,7 +90,7 @@ pipeline {
                 }
                 stage("Python 3.11") {
                     agent {
-                        label "silicon-ci"
+                        label "silicon-ci-release"
                     }
                     environment {
                         PYENV_ROOT="$HOME/.pyenv"


### PR DESCRIPTION
Currently the release builds and tests run on the same agents as nightly/ci. This will allow them to run on different agents with different VM timeout parameters for better release feedback. 