### PR TITLE
[Tosa] Fix 2d tfl batch_matmul legalization

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1524,6 +1524,19 @@ func.func @test_batch_matmul(%arg0: tensor<1x16x128xf32>, %arg1: tensor<1x128x32
 
 // -----
 
+// CHECK-LABEL: @test_batch_matmul2d
+func.func @test_batch_matmul2d(%arg0: tensor<16x128xf32>, %arg1: tensor<128x32xf32>) -> (tensor<16x32xf32> ) {
+  // CHECK: %[[VAL_0:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 1, 16, 128>}
+  // CHECK: %[[VAL_1:.*]] = tosa.reshape %arg1 {new_shape = array<i64: 1, 128, 32>}
+  // CHECK: %[[VAL_2:.*]] = tosa.matmul %[[VAL_0]], %[[VAL_1]]
+  // CHECK: %[[VAL_3:.*]] = tosa.reshape %[[VAL_2]] {new_shape = array<i64: 16, 32>}
+  // CHECK: return %[[VAL_3]]
+  %0 = "tfl.batch_matmul"(%arg0, %arg1) {adj_x = false, adj_y = false} : (tensor<16x128xf32>, tensor<128x32xf32>) -> tensor<16x32xf32>
+  func.return %0 : tensor<16x32xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @test_batch_matmul_4d
 func.func @test_batch_matmul_4d(%arg0: tensor<4x5x16x128xf32>, %arg1: tensor<4x5x128x32xf32>) -> (tensor<4x5x16x32xf32> ) {
   // CHECK: %[[R0:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 20, 16, 128>}

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -1929,7 +1929,7 @@ LogicalResult ConvertTFLBatchMatMulOp::matchAndRewrite(
   }
 
   auto batch_dims = lhs_ty.getShape().drop_back(2);
-  if (batch_dims.size() > 1) {
+  if (batch_dims.size() != 1) {
     int64_t N = 1;
     for (auto d : batch_dims) {
       N = N < 0 || d < 0 ? -1 : N * d;
@@ -2008,7 +2008,7 @@ LogicalResult ConvertTFLBatchMatMulOp::matchAndRewrite(
 
   // Conditionally reshape rank back to expected rank.
   auto matmul_ty = matmul.getType().cast<RankedTensorType>();
-  if (batch_dims.size() > 1) {
+  if (batch_dims.size() != 1) {
     llvm::SmallVector<int64_t> new_shape{};
     for (auto d : batch_dims) {
       new_shape.push_back(d);


### PR DESCRIPTION
This patch fixes legalization of 2d tfl.batch_matmul to Tosa, which needs to be reshaped to 3d inputs because tosa matmul requires 3d inputs. And the 3d result needs to be reshaped back to original 2d.

added lit test for this as well.


Change-Id: I7f01cdebbdb6456d02a74f7f3b796ae0eccd1c8e