### PR TITLE
Fix include ordering

### DIFF
--- a/tensorflow/lite/kernels/rng_util.cc
+++ b/tensorflow/lite/kernels/rng_util.cc
@@ -12,10 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
-#include "tensorflow/lite/kernels/rng_util.h"
-
 #include <array>
 #include <cstdint>
+
+#include "tensorflow/lite/kernels/rng_util.h"
 
 namespace tflite {
 namespace rng {


### PR DESCRIPTION
To prevent undefined reference to uint32_t

Fixes: https://github.com/tensorflow/tensorflow/issues/61872