### PR TITLE
Strip `external/local_tsl` prefix during tar of tsl c headers

### DIFF
--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -73,7 +73,7 @@ pkg_tar(
         "//tensorflow/c:headers",
     ],
     package_dir = "include/",
-    strip_prefix = "/",
+    strip_prefix = "/external/local_tsl",
     # Mark as "manual" till
     # https://github.com/bazelbuild/bazel/issues/2352
     # and https://github.com/bazelbuild/bazel/issues/1580


### PR DESCRIPTION
PR strips `external/local_tsl` prefix from tsl c headers when packaging //tensorflow/tools/lib_package:cheaders (and, thus libtensorflow.tar.gz).  This prefix is not consistent with #include directives used in tensorflow and  tsl c headers.

The current tree of libtensorflow.tar.gz is shown below to demonstrate the issue.

```
.
├── LICENSE
├── THIRD_PARTY_TF_C_LICENSES
├── include
│   ├── external
│   │   └── local_tsl
│   │       └── tsl
│   │           ├── c
│   │           │   └── tsl_status.h
│   │           └── platform
│   │               ├── ctstring.h
│   │               └── ctstring_internal.h
│   └── tensorflow
│       ├── c
│       │   ├── c_api.h
│       │   ├── c_api_experimental.h
│       │   ├── c_api_macros.h
│       │   ├── eager
│       │   │   ├── c_api.h
│       │   │   ├── c_api_experimental.h
│       │   │   └── dlpack.h
│       │   ├── tensor_interface.h
│       │   ├── tf_attrtype.h
│       │   ├── tf_buffer.h
│       │   ├── tf_datatype.h
│       │   ├── tf_file_statistics.h
│       │   ├── tf_status.h
│       │   ├── tf_tensor.h
│       │   ├── tf_tensor_helper.h
│       │   └── tf_tstring.h
│       └── core
│           └── platform
│               ├── ctstring.h
│               └── ctstring_internal.h
└── lib
    ├── libtensorflow.so -> libtensorflow.so.2
    ├── libtensorflow.so.2 -> libtensorflow.so.2.15.0
    ├── libtensorflow.so.2.15.0
    ├── libtensorflow_framework.so -> libtensorflow_framework.so.2
    ├── libtensorflow_framework.so.2 -> libtensorflow_framework.so.2.15.0
    └── libtensorflow_framework.so.2.15.0
```