### PR TITLE
Fix null pointer deref in gif_io.

### DIFF
--- a/tensorflow/core/lib/gif/gif_io.cc
+++ b/tensorflow/core/lib/gif/gif_io.cc
@@ -78,6 +78,12 @@ uint8* Decode(const void* srcdata, int datasize,
   if (DGifSlurp(gif_file) != GIF_OK) {
     *error_string = absl::StrCat("failed to slurp gif file: ",
                                  GifErrorStringNonNull(gif_file->Error));
+    // Stop load if no images are detected or the allocation of the last image
+    // buffer was failed.
+    if (gif_file->ImageCount <= 0 ||
+        gif_file->SavedImages[gif_file->ImageCount - 1].RasterBits == NULL) {
+    }
+
     LOG(ERROR) << *error_string;
     return nullptr;
   }

--- a/tensorflow/core/lib/gif/gif_io.cc
+++ b/tensorflow/core/lib/gif/gif_io.cc
@@ -82,10 +82,10 @@ uint8* Decode(const void* srcdata, int datasize,
     // buffer was failed.
     if (gif_file->ImageCount <= 0 ||
         gif_file->SavedImages[gif_file->ImageCount - 1].RasterBits == NULL) {
+        return nullptr;
     }
 
     LOG(ERROR) << *error_string;
-    return nullptr;
   }
 
   if (gif_file->ImageCount <= 0) {

--- a/tensorflow/core/lib/gif/gif_io.cc
+++ b/tensorflow/core/lib/gif/gif_io.cc
@@ -78,11 +78,8 @@ uint8* Decode(const void* srcdata, int datasize,
   if (DGifSlurp(gif_file) != GIF_OK) {
     *error_string = absl::StrCat("failed to slurp gif file: ",
                                  GifErrorStringNonNull(gif_file->Error));
-    // Only stop load if no images are detected.
-    if (gif_file->ImageCount <= 0) {
-      return nullptr;
-    }
-    LOG(WARNING) << *error_string;
+    LOG(ERROR) << *error_string;
+    return nullptr;
   }
 
   if (gif_file->ImageCount <= 0) {

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -331,7 +331,10 @@ def _tf_repositories():
     tf_http_archive(
         name = "gif",
         build_file = "//third_party:gif.BUILD",
-        patch_file = ["//third_party:gif_fix_strtok_r.patch"],
+        patch_file = [
+            "//third_party:gif_fix_strtok_r.patch",
+            "//third_party:gif_fix_image_counter.patch"
+	],
         sha256 = "31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd",
         strip_prefix = "giflib-5.2.1",
         system_build_file = "//third_party/systemlibs:gif.BUILD",

--- a/third_party/gif_fix_image_counter.patch
+++ b/third_party/gif_fix_image_counter.patch
@@ -64,7 +64,7 @@ index 82fc097..81f2da4 100644
 +                  free(GifFile->SavedImages[GifFile->ImageCount].RasterBits);
 +              }
 +
-+	       // Realloc array according to the new image counter.
++              // Realloc array according to the new image counter.
 +              SavedImage *correct_saved_images = (SavedImage *)reallocarray(
 +                  GifFile->SavedImages, GifFile->ImageCount, sizeof(SavedImage));
 +              if (correct_saved_images != NULL) {

--- a/third_party/gif_fix_image_counter.patch
+++ b/third_party/gif_fix_image_counter.patch
@@ -64,7 +64,7 @@ index 82fc097..81f2da4 100644
 +                  free(GifFile->SavedImages[GifFile->ImageCount].RasterBits);
 +              }
 +
-+	      // Realloc array according to the new image counter.
++	       // Realloc array according to the new image counter.
 +              SavedImage *correct_saved_images = (SavedImage *)reallocarray(
 +                  GifFile->SavedImages, GifFile->ImageCount, sizeof(SavedImage));
 +              if (correct_saved_images != NULL) {

--- a/third_party/gif_fix_image_counter.patch
+++ b/third_party/gif_fix_image_counter.patch
@@ -1,5 +1,5 @@
 diff --git a/dgif_lib.c b/dgif_lib.c
-index 82fc097..b6cef69 100644
+index 82fc097..c6700a9 100644
 --- a/dgif_lib.c
 +++ b/dgif_lib.c
 @@ -810,7 +810,8 @@ DGifSetupDecompress(GifFileType *GifFile)
@@ -77,10 +77,10 @@ index 82fc097..b6cef69 100644
  	      else {
 -		  if (DGifGetLine(GifFile,sp->RasterBits,ImageSize)==GIF_ERROR)
 -		      return (GIF_ERROR);
-+		  if (DGifGetLine(GifFile,sp->RasterBits,ImageSize)==GIF_ERROR) {
++                  if (DGifGetLine(GifFile,sp->RasterBits,ImageSize)==GIF_ERROR) {
 +                      DGifDecreaseImageCounter(GifFile);
 +                      return GIF_ERROR;
-+                 }
++                  }
  	      }
  
                if (GifFile->ExtensionBlocks) {

--- a/third_party/gif_fix_image_counter.patch
+++ b/third_party/gif_fix_image_counter.patch
@@ -1,5 +1,5 @@
 diff --git a/dgif_lib.c b/dgif_lib.c
-index 82fc097..81f2da4 100644
+index 82fc097..b6cef69 100644
 --- a/dgif_lib.c
 +++ b/dgif_lib.c
 @@ -810,7 +810,8 @@ DGifSetupDecompress(GifFileType *GifFile)
@@ -12,67 +12,75 @@ index 82fc097..81f2da4 100644
      }
      BitsPerPixel = CodeSize;
  
-@@ -1148,18 +1149,18 @@ DGifSlurp(GifFileType *GifFile)
+@@ -1118,6 +1119,28 @@ DGifBufferedInput(GifFileType *GifFile, GifByteType *Buf, GifByteType *NextByte)
+     return GIF_OK;
+ }
+ 
++/******************************************************************************
++ This routine is called in case of error during parsing image. We need to
++ decrease image counter and reallocate memory for saved images. Not decreasing
++ ImageCount may lead to null pointer dereference, because the last element in
++ SavedImages may point to the spoilt image and null pointer buffers. 
++*******************************************************************************/
++void
++DGifDecreaseImageCounter(GifFileType *GifFile)
++{
++    GifFile->ImageCount--;
++    if (GifFile->SavedImages[GifFile->ImageCount].RasterBits != NULL) {
++        free(GifFile->SavedImages[GifFile->ImageCount].RasterBits);
++    }
++    
++    // Realloc array according to the new image counter.
++    SavedImage *correct_saved_images = (SavedImage *)reallocarray(
++        GifFile->SavedImages, GifFile->ImageCount, sizeof(SavedImage));
++    if (correct_saved_images != NULL) {
++        GifFile->SavedImages = correct_saved_images;
++    }
++}
++
+ /******************************************************************************
+  This routine reads an entire GIF into core, hanging all its state info off
+  the GifFileType pointer.  Call DGifOpenFileName() or DGifOpenFileHandle()
+@@ -1148,17 +1171,20 @@ DGifSlurp(GifFileType *GifFile)
                /* Allocate memory for the image */
                if (sp->ImageDesc.Width <= 0 || sp->ImageDesc.Height <= 0 ||
                        sp->ImageDesc.Width > (INT_MAX / sp->ImageDesc.Height)) {
--                  return GIF_ERROR;
-+                  goto error;
++                  DGifDecreaseImageCounter(GifFile);
+                   return GIF_ERROR;
                }
                ImageSize = sp->ImageDesc.Width * sp->ImageDesc.Height;
  
                if (ImageSize > (SIZE_MAX / sizeof(GifPixelType))) {
--                  return GIF_ERROR;
-+                  goto error;
++                  DGifDecreaseImageCounter(GifFile);
+                   return GIF_ERROR;
                }
                sp->RasterBits = (unsigned char *)reallocarray(NULL, ImageSize,
                        sizeof(GifPixelType));
  
                if (sp->RasterBits == NULL) {
--                  return GIF_ERROR;
-+                  goto error;
++                  DGifDecreaseImageCounter(GifFile);
+                   return GIF_ERROR;
                }
  
- 	      if (sp->ImageDesc.Interlace) {
-@@ -1178,12 +1179,12 @@ DGifSlurp(GifFileType *GifFile)
+@@ -1177,13 +1203,17 @@ DGifSlurp(GifFileType *GifFile)
+ 			   j += InterlacedJumps[i]) {
  			  if (DGifGetLine(GifFile, 
  					  sp->RasterBits+j*sp->ImageDesc.Width, 
- 					  sp->ImageDesc.Width) == GIF_ERROR)
+-					  sp->ImageDesc.Width) == GIF_ERROR)
 -			      return GIF_ERROR;
-+			      goto error;
++					  sp->ImageDesc.Width) == GIF_ERROR) {
++                              DGifDecreaseImageCounter(GifFile);
++                              return GIF_ERROR;
++                          }
  		      }
  	      }
  	      else {
- 		  if (DGifGetLine(GifFile,sp->RasterBits,ImageSize)==GIF_ERROR)
+-		  if (DGifGetLine(GifFile,sp->RasterBits,ImageSize)==GIF_ERROR)
 -		      return (GIF_ERROR);
-+		      goto error;
++		  if (DGifGetLine(GifFile,sp->RasterBits,ImageSize)==GIF_ERROR) {
++                      DGifDecreaseImageCounter(GifFile);
++                      return GIF_ERROR;
++                  }
  	      }
  
                if (GifFile->ExtensionBlocks) {
-@@ -1195,6 +1196,26 @@ DGifSlurp(GifFileType *GifFile)
-               }
-               break;
- 
-+              error:
-+              // In case of error we need to decrease the image counter
-+              // and reallocate memory for saved images. Not decreasing
-+              // ImageCount may lead to null pointer dereference,
-+              // because the last element in SavedImages may point to the
-+              // spoilt image and null pointer buffers.
-+              GifFile->ImageCount--;
-+              if (GifFile->SavedImages[GifFile->ImageCount].RasterBits != NULL) {
-+                  free(GifFile->SavedImages[GifFile->ImageCount].RasterBits);
-+              }
-+
-+              // Realloc array according to the new image counter.
-+              SavedImage *correct_saved_images = (SavedImage *)reallocarray(
-+                  GifFile->SavedImages, GifFile->ImageCount, sizeof(SavedImage));
-+              if (correct_saved_images != NULL) {
-+                  GifFile->SavedImages = correct_saved_images;
-+              }
-+
-+              return GIF_ERROR;
-+
-           case EXTENSION_RECORD_TYPE:
-               if (DGifGetExtension(GifFile,&ExtFunction,&ExtData) == GIF_ERROR)
-                   return (GIF_ERROR);

--- a/third_party/gif_fix_image_counter.patch
+++ b/third_party/gif_fix_image_counter.patch
@@ -80,7 +80,7 @@ index 82fc097..b6cef69 100644
 +		  if (DGifGetLine(GifFile,sp->RasterBits,ImageSize)==GIF_ERROR) {
 +                      DGifDecreaseImageCounter(GifFile);
 +                      return GIF_ERROR;
-+                  }
++                 }
  	      }
  
                if (GifFile->ExtensionBlocks) {

--- a/third_party/gif_fix_image_counter.patch
+++ b/third_party/gif_fix_image_counter.patch
@@ -1,0 +1,78 @@
+diff --git a/dgif_lib.c b/dgif_lib.c
+index 82fc097..81f2da4 100644
+--- a/dgif_lib.c
++++ b/dgif_lib.c
+@@ -810,7 +810,8 @@ DGifSetupDecompress(GifFileType *GifFile)
+ 
+     /* coverity[check_return] */
+     if (InternalRead(GifFile, &CodeSize, 1) < 1) {    /* Read Code size from file. */
+-	return GIF_ERROR;    /* Failed to read Code size. */
++        GifFile->Error = D_GIF_ERR_READ_FAILED;
++        return GIF_ERROR;    /* Failed to read Code size. */
+     }
+     BitsPerPixel = CodeSize;
+ 
+@@ -1148,18 +1149,18 @@ DGifSlurp(GifFileType *GifFile)
+               /* Allocate memory for the image */
+               if (sp->ImageDesc.Width <= 0 || sp->ImageDesc.Height <= 0 ||
+                       sp->ImageDesc.Width > (INT_MAX / sp->ImageDesc.Height)) {
+-                  return GIF_ERROR;
++                  goto error;
+               }
+               ImageSize = sp->ImageDesc.Width * sp->ImageDesc.Height;
+ 
+               if (ImageSize > (SIZE_MAX / sizeof(GifPixelType))) {
+-                  return GIF_ERROR;
++                  goto error;
+               }
+               sp->RasterBits = (unsigned char *)reallocarray(NULL, ImageSize,
+                       sizeof(GifPixelType));
+ 
+               if (sp->RasterBits == NULL) {
+-                  return GIF_ERROR;
++                  goto error;
+               }
+ 
+ 	      if (sp->ImageDesc.Interlace) {
+@@ -1178,12 +1179,12 @@ DGifSlurp(GifFileType *GifFile)
+ 			  if (DGifGetLine(GifFile, 
+ 					  sp->RasterBits+j*sp->ImageDesc.Width, 
+ 					  sp->ImageDesc.Width) == GIF_ERROR)
+-			      return GIF_ERROR;
++			      goto error;
+ 		      }
+ 	      }
+ 	      else {
+ 		  if (DGifGetLine(GifFile,sp->RasterBits,ImageSize)==GIF_ERROR)
+-		      return (GIF_ERROR);
++		      goto error;
+ 	      }
+ 
+               if (GifFile->ExtensionBlocks) {
+@@ -1195,6 +1196,26 @@ DGifSlurp(GifFileType *GifFile)
+               }
+               break;
+ 
++              error:
++              // In case of error we need to decrease the image counter
++              // and reallocate memory for saved images. Not decreasing
++              // ImageCount may lead to null pointer dereference,
++              // because the last element in SavedImages may point to the
++              // spoilt image and null pointer buffers.
++              GifFile->ImageCount--;
++              if (GifFile->SavedImages[GifFile->ImageCount].RasterBits != NULL) {
++                  free(GifFile->SavedImages[GifFile->ImageCount].RasterBits);
++              }
++
++	      // Realloc array according to the new image counter.
++              SavedImage *correct_saved_images = (SavedImage *)reallocarray(
++                  GifFile->SavedImages, GifFile->ImageCount, sizeof(SavedImage));
++              if (correct_saved_images != NULL) {
++                  GifFile->SavedImages = correct_saved_images;
++              }
++
++              return GIF_ERROR;
++
+           case EXTENSION_RECORD_TYPE:
+               if (DGifGetExtension(GifFile,&ExtFunction,&ExtData) == GIF_ERROR)
+                   return (GIF_ERROR);


### PR DESCRIPTION
Hi! We've been fuzzing tensorflow and found the error of null pointer
dereference at `gif_io.cc:178`.

### Environment

OS: ubuntu20.04
TF version: 4601e74cdcd86e6d229ec1d98ff08ba8e147c092

### Detailed description

The error of null pointer occurs, because `RasterBits` buffer at 178 line in `gif_io.cc` occurs to be nullptr.

In gif library in `DGifSlurp` function, which is called from `Decode` function of tensorflow core at `gif_io.cc:78`, at `gif/dgif_lib.c:1144` `DGifGetRecordType` function is called, where new element for `SavedImages` buffer is allocated, `RasterBits` field of the corresponding element in buffer is set to `NULL`, and `ImageCount` is increased.

After that, before the memory for `RasterBits` is allocated, there is a check in `DGifSlurp` function at `dgif_lib.c:1149` for image sizes to prevent potential overflow. If they are incorrect, `GIF_ERROR` is returned before the allocation of `RasterBits`.

In TensorFlow at `gif_io.cc:78` there is a check for the result, which leads to returning `nullptr` only in case `ImageCount <= 0`. But `ImageCount` is incremented in gif library before the allocation of inner buffers, so returning `nullptr` only in case of `ImageCount <= 0` can lead to the following errors of null pointer dereference.

To prevent this error, we suggest just to remove this check `ImageCount <= 0` and return `nullptr` in any case when `DGifSlurp` returns `GIF_ERROR`.

### How to reproduce

Build Docker container from [here](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/tensorflow):

```bash
$ sudo docker build -t oss-sydr-fuzz-tensorflow .
```

Run container:

```bash
sudo docker run --rm -v `pwd`:/fuzz -it oss-sydr-fuzz-tensorflow /bin/bash
```

Run target on the crash input [crash](https://github.com/tensorflow/tensorflow/assets/75036757/34f2f803-b4cc-47d1-a989-1d143838e220):


```bash
/fuzzer/decode_png -rss_limit_mb=0 /fuzz/crash
```

You will see the following output:

```
==1749952==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x0000259030dd bp 0x7fff67a64090 sp 0x7fff67a63640 T254)
==1749952==The signal is caused by a READ memory access.
==1749952==Hint: address points to the zero page.
    #0 0x259030dd in tensorflow::gif::Decode(void const*, int, std::function<unsigned char* (int, int, int, int)> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, bool) /proc/self/cwd/tensorflow/core/lib/gif/gif_io.cc:178:13
    #1 0x247743ca in tensorflow::(anonymous namespace)::DecodeImageV2Op::DecodeGifV2(tensorflow::OpKernelContext*, std::basic_string_view<char, std::char_traits<char> >) /proc/self/cwd/tensorflow/core/kernels/image/decode_image_op.cc:462:21
    #2 0x247743ca in tensorflow::(anonymous namespace)::DecodeImageV2Op::Compute(tensorflow::OpKernelContext*) /proc/self/cwd/tensorflow/core/kernels/image/decode_image_op.cc:216:9
    #3 0x48e86ff7 in tensorflow::ThreadPoolDevice::Compute(tensorflow::OpKernel*, tensorflow::OpKernelContext*) /proc/self/cwd/tensorflow/core/common_runtime/threadpool_device.cc:184:14
    #4 0x492f72ea in tensorflow::(anonymous namespace)::ExecutorState<tensorflow::SimplePropagatorState>::ProcessSync(tensorflow::NodeItem const&, tensorflow::OpKernelContext::Params*, absl::lts_20230125::InlinedVector<tensorflow::Entry, 4ul, std::allocator<tensorflow::Entry> >*, tensorflow::NodeExecStatsInterface*) /proc/self/cwd/tensorflow/core/common_runtime/executor.cc:604:13
    #5 0x492f72ea in tensorflow::(anonymous namespace)::ExecutorState<tensorflow::SimplePropagatorState>::ProcessInline(tensorflow::SimplePropagatorState::TaggedNodeReadyQueue*, long) /proc/self/cwd/tensorflow/core/common_runtime/executor.cc:896:13
    #6 0x492eaeaa in tensorflow::(anonymous namespace)::ExecutorState<tensorflow::SimplePropagatorState>::Process(tensorflow::SimplePropagatorState::TaggedNode const&, long) /proc/self/cwd/tensorflow/core/common_runtime/executor.cc:704:10
    #7 0x4b57a771 in tsl::thread::EigenEnvironment::ExecuteTask(tsl::thread::EigenEnvironment::Task const&) /proc/self/cwd/tensorflow/tsl/platform/threadpool.cc:94:5
    #8 0x4b578c61 in Eigen::ThreadPoolTempl<tsl::thread::EigenEnvironment>::WorkerLoop(int) /proc/self/cwd/external/eigen_archive/Eigen/src/ThreadPool/NonBlockingThreadPool.h:330:16
    #9 0x4b576cf6 in tsl::thread::EigenEnvironment::CreateThread(std::function<void ()>)::'lambda'()::operator()() const /proc/self/cwd/tensorflow/tsl/platform/threadpool.cc:71:7
    #10 0x4b529b9e in tsl::(anonymous namespace)::PThread::ThreadFn(void*) /proc/self/cwd/tensorflow/tsl/platform/default/env.cc:93:5
    #11 0x7ffff7e47608 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x8608) (BuildId: 7b4536f41cdaa5888408e82d0836e33dcf436466)
    #12 0x7ffff7b63132 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x11f132) (BuildId: 1878e6b475720c7c51969e69ab2d276fae6d1dee)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /proc/self/cwd/tensorflow/core/lib/gif/gif_io.cc:178:13 in tensorflow::gif::Decode(void const*, int, std::function<unsigned char* (int, int, int, int)> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, bool)
Thread T254 created by T0 here:
    #0 0x18e4d5ac in pthread_create /llvm-project-llvmorg-14.0.6/compiler-rt/lib/asan/asan_interceptors.cpp:208:3
    #1 0x4b527904 in tsl::(anonymous namespace)::PThread::PThread(tsl::ThreadOptions const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, absl::lts_20230125::AnyInvocable<void ()>) /proc/self/cwd/tensorflow/tsl/platform/default/env.cc:72:15
    #2 0x4b527904 in tsl::(anonymous namespace)::PosixEnv::StartThread(tsl::ThreadOptions const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, absl::lts_20230125::AnyInvocable<void ()>) /proc/self/cwd/tensorflow/tsl/platform/default/env.cc:137:16
    #3 0x4b57299f in tsl::thread::EigenEnvironment::CreateThread(std::function<void ()>) /proc/self/cwd/tensorflow/tsl/platform/threadpool.cc:63:18
    #4 0x4b56d255 in Eigen::ThreadPoolTempl<tsl::thread::EigenEnvironment>::ThreadPoolTempl(int, bool, tsl::thread::EigenEnvironment) /proc/self/cwd/external/eigen_archive/Eigen/src/ThreadPool/NonBlockingThreadPool.h:60:16
    #5 0x4b56be71 in tsl::thread::ThreadPool::ThreadPool(tsl::Env*, tsl::ThreadOptions const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, bool, Eigen::Allocator*) /proc/self/cwd/tensorflow/tsl/platform/threadpool.cc:116:31
    #6 0x491fb8d8 in tensorflow::NewThreadPoolFromSessionOptions(tensorflow::SessionOptions const&, int) /proc/self/cwd/tensorflow/core/common_runtime/process_util.cc:162:14
    #7 0x45643d53 in tensorflow::(anonymous namespace)::GlobalThreadPool(tensorflow::SessionOptions const&, int) /proc/self/cwd/tensorflow/core/common_runtime/direct_session.cc:147:7
    #8 0x45643d53 in tensorflow::DirectSession::DirectSession(tensorflow::SessionOptions const&, tensorflow::DeviceMgr const*, tensorflow::DirectSessionFactory*) /proc/self/cwd/tensorflow/core/common_runtime/direct_session.cc:358:9
    #9 0x45681552 in tensorflow::DirectSessionFactory::NewSession(tensorflow::SessionOptions const&, tensorflow::Session**) /proc/self/cwd/tensorflow/core/common_runtime/direct_session.cc:202:34
    #10 0x48e7518c in tensorflow::NewSession(tensorflow::SessionOptions const&, tensorflow::Session**) /proc/self/cwd/tensorflow/core/common_runtime/session.cc:90:16
    #11 0x48e74b46 in tensorflow::NewSession(tensorflow::SessionOptions const&) /proc/self/cwd/tensorflow/core/common_runtime/session.cc:70:14
    #12 0x18e9c7bc in tensorflow::fuzzing::FuzzSession::InitIfNeeded() /proc/self/cwd/./tensorflow/core/kernels/fuzzing/fuzz_session.h:92:41
    #13 0x18e953d4 in tensorflow::fuzzing::FuzzSession::Fuzz(unsigned char const*, unsigned long) /proc/self/cwd/./tensorflow/core/kernels/fuzzing/fuzz_session.h:127:21
    #14 0x4c0df4ed in ExecuteFilesOnyByOne /AFLplusplus/utils/aflpp_driver/aflpp_driver.c:255:7

==1749952==ABORTING
```