### PR TITLE
[Go] Add RunOptions as an argument for Tensorflow Session Run

### DIFF
--- a/tensorflow/go/example_inception_inference_test.go
+++ b/tensorflow/go/example_inception_inference_test.go
@@ -100,7 +100,7 @@ func Example() {
 	}
 
 	// Create a session for inference over graph.
-	session, err := tf.NewSession(graph, nil)
+	session, err := tf.NewSession(graph, nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func makeTensorFromImage(filename string) (*tf.Tensor, error) {
 		return nil, err
 	}
 	// Execute that graph to normalize this one image
-	session, err := tf.NewSession(graph, nil)
+	session, err := tf.NewSession(graph, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/tensorflow/go/graph_test.go
+++ b/tensorflow/go/graph_test.go
@@ -127,7 +127,7 @@ func TestGraphInputMapping(t *testing.T) {
 		t.Error(err)
 	}
 
-	sess, err := NewSession(g, nil)
+	sess, err := NewSession(g, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestGraphAddGradients(t *testing.T) {
 		t.Fatalf("Got DataType %v, wanted %v", grads1[1].DataType(), Float)
 	}
 
-	sess, err := NewSession(g, nil)
+	sess, err := NewSession(g, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestGraphAddGradientsSums(t *testing.T) {
 		t.Fatalf("Got DataType %v, wanted %v", grad[0].DataType(), Float)
 	}
 
-	sess, err := NewSession(g, nil)
+	sess, err := NewSession(g, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -341,7 +341,7 @@ func TestGraphAddGradientsWithInitialValues(t *testing.T) {
 		t.Fatalf("Got DataType %v, wanted %v", grads1[0].DataType(), Float)
 	}
 
-	sess, err := NewSession(g, nil)
+	sess, err := NewSession(g, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tensorflow/go/op/gradients_test.go
+++ b/tensorflow/go/op/gradients_test.go
@@ -63,7 +63,7 @@ func TestAddGradients(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sess, err := tf.NewSession(graph, nil)
+	sess, err := tf.NewSession(graph, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestAddGradientsSums(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sess, err := tf.NewSession(graph, nil)
+	sess, err := tf.NewSession(graph, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestAddGradientsWithInitialValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sess, err := tf.NewSession(graph, nil)
+	sess, err := tf.NewSession(graph, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tensorflow/go/op/op_test.go
+++ b/tensorflow/go/op/op_test.go
@@ -68,7 +68,7 @@ func TestShapeAttribute(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sess, err := tf.NewSession(graph, nil)
+	sess, err := tf.NewSession(graph, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestDataset(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sess, err := tf.NewSession(graph, nil)
+	sess, err := tf.NewSession(graph, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tensorflow/go/op/scope_test.go
+++ b/tensorflow/go/op/scope_test.go
@@ -92,7 +92,7 @@ func TestControlDependencies(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sess, err := tf.NewSession(graph, nil)
+	sess, err := tf.NewSession(graph, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tensorflow/go/saved_model.go
+++ b/tensorflow/go/saved_model.go
@@ -50,9 +50,9 @@ type SavedModel struct {
 // exported in other languages, such as using tf.saved_model.builder in Python.
 // See:
 // https://www.tensorflow.org/code/tensorflow/python/saved_model/
-func LoadSavedModel(exportDir string, tags []string, sessionOptions *SessionOptions, runOptions *RunOptions) (*SavedModel, error) {
+func LoadSavedModel(exportDir string, tags []string, options *SessionOptions, runOptions *RunOptions) (*SavedModel, error) {
 	status := newStatus()
-	cOpt, doneOpt, err := sessionOptions.c()
+	cOpt, doneOpt, err := options.c()
 	defer doneOpt()
 	if err != nil {
 		return nil, err

--- a/tensorflow/go/saved_model.go
+++ b/tensorflow/go/saved_model.go
@@ -68,7 +68,7 @@ func LoadSavedModel(exportDir string, tags []string, options *SessionOptions, ru
 	graph := NewGraph()
 	metaGraphDefBuf := C.TF_NewBuffer()
 	defer C.TF_DeleteBuffer(metaGraphDefBuf)
-	// TODO(jhseu): Add support for meta_graph_def.
+	// TODO(jhseu): Add support for run_options and meta_graph_def.
 	cSess := C.TF_LoadSessionFromSavedModel(cOpt, nil, cExportDir, (**C.char)(unsafe.Pointer(&cTags[0])), C.int(len(cTags)), graph.c, metaGraphDefBuf, status.c)
 	for i := range cTags {
 		C.free(unsafe.Pointer(cTags[i]))

--- a/tensorflow/go/saved_model_test.go
+++ b/tensorflow/go/saved_model_test.go
@@ -29,7 +29,7 @@ func TestSavedModelHalfPlusTwo(t *testing.T) {
 	)
 
 	// Load saved model half_plus_two.
-	m, err := LoadSavedModel(exportDir, tags, options)
+	m, err := LoadSavedModel(exportDir, tags, options, nil)
 	if err != nil {
 		t.Fatalf("LoadSavedModel(): %v", err)
 	}
@@ -95,7 +95,7 @@ func TestSavedModelWithEmptyTags(t *testing.T) {
 		options   = new(SessionOptions)
 	)
 
-	_, err := LoadSavedModel(exportDir, tags, options)
+	_, err := LoadSavedModel(exportDir, tags, options, nil)
 	if err == nil {
 		t.Fatalf("LoadSavedModel() should return an error if tags are empty")
 	}

--- a/tensorflow/go/saved_model_test.go
+++ b/tensorflow/go/saved_model_test.go
@@ -100,3 +100,17 @@ func TestSavedModelWithEmptyTags(t *testing.T) {
 		t.Fatalf("LoadSavedModel() should return an error if tags are empty")
 	}
 }
+
+func TestSavedModelWithRunOptions(t *testing.T) {
+	var (
+		exportDir = "testdata/saved_model/half_plus_two/00000123"
+		tags      = []string{}
+		options   = new(SessionOptions)
+		runOpts   = &RunOptions{Config: []byte{16, 1}} // timeout_in_ms:1
+	)
+
+	_, err := LoadSavedModel(exportDir, tags, options, runOpts)
+	if err == nil {
+		t.Fatalf("LoadSavedModel() should return an error if tags are empty")
+	}
+}

--- a/tensorflow/go/session.go
+++ b/tensorflow/go/session.go
@@ -63,16 +63,16 @@ func NewSession(graph *Graph, options *SessionOptions, runOptions *RunOptions) (
 		return nil, err
 	}
 
-	var tfRunOptions *C.TF_Buffer
+	var cRunOptions *C.TF_Buffer
 	if runOptions != nil {
 		// TF_NewBufferFromString makes a copy of the input and sets an appropriate deallocator.
 		// Useful for passing in read-only, input protobufs.
 		//
-		// This particular tfRunOptions structure with data inside would be deallocated with C.TF_DeleteBuffer during Session.Close().
-		tfRunOptions = C.TF_NewBufferFromString(C.CBytes(runOptions.Config), C.size_t(len(runOptions.Config)))
+		// This particular cRunOptions structure with data inside would be deallocated with C.TF_DeleteBuffer during Session.Close().
+		cRunOptions = C.TF_NewBufferFromString(C.CBytes(runOptions.Config), C.size_t(len(runOptions.Config)))
 	}
 
-	s := &Session{c: cSess, runOptions: tfRunOptions}
+	s := &Session{c: cSess, runOptions: cRunOptions}
 	runtime.SetFinalizer(s, func(s *Session) { s.Close() })
 	return s, nil
 }

--- a/tensorflow/go/session.go
+++ b/tensorflow/go/session.go
@@ -40,6 +40,8 @@ import (
 type Session struct {
 	c *C.TF_Session
 
+	runOptions *C.TF_Buffer
+
 	// For ensuring that:
 	// - Close() blocks on all Run() calls to complete.
 	// - Close() can be called multiple times.
@@ -49,7 +51,7 @@ type Session struct {
 
 // NewSession creates a new execution session with the associated graph.
 // options may be nil to use the default options.
-func NewSession(graph *Graph, options *SessionOptions) (*Session, error) {
+func NewSession(graph *Graph, options *SessionOptions, runOptions *RunOptions) (*Session, error) {
 	status := newStatus()
 	cOpt, doneOpt, err := options.c()
 	defer doneOpt()
@@ -61,7 +63,16 @@ func NewSession(graph *Graph, options *SessionOptions) (*Session, error) {
 		return nil, err
 	}
 
-	s := &Session{c: cSess}
+	var tfRunOptions *C.TF_Buffer
+	if runOptions != nil {
+		// TF_NewBufferFromString makes a copy of the input and sets an appropriate deallocator.
+		// Useful for passing in read-only, input protobufs.
+		//
+		// This particular tfRunOptions structure with data inside would be deallocated with C.TF_DeleteBuffer during Session.Close().
+		tfRunOptions = C.TF_NewBufferFromString(C.CBytes(runOptions.Config), C.size_t(len(runOptions.Config)))
+	}
+
+	s := &Session{c: cSess, runOptions: tfRunOptions}
 	runtime.SetFinalizer(s, func(s *Session) { s.Close() })
 	return s, nil
 }
@@ -143,7 +154,7 @@ func (s *Session) Run(feeds map[Output]*Tensor, fetches []Output, targets []*Ope
 
 	c := newCRunArgs(feeds, fetches, targets)
 	status := newStatus()
-	C.TF_SessionRun(s.c, nil,
+	C.TF_SessionRun(s.c, s.runOptions,
 		ptrOutput(c.feeds), ptrTensor(c.feedTensors), C.int(len(feeds)),
 		ptrOutput(c.fetches), ptrTensor(c.fetchTensors), C.int(len(fetches)),
 		ptrOperation(c.targets), C.int(len(targets)),
@@ -283,6 +294,14 @@ func (s *Session) Close() error {
 	}
 	C.TF_DeleteSession(s.c, status.c)
 	s.c = nil
+
+	if s.runOptions != nil {
+		// We don't need to care about deallocating tfRunOptions.data using C.free(s.runOptions.data), cuz
+		// tfRunOptions structure was created with TF_NewBufferFromString which sets an appropriate deallocator by itself.
+		// So, DeleteBuffer shoud be enough to free underlying data.
+		C.TF_DeleteBuffer(s.runOptions)
+	}
+
 	return status.Err()
 }
 
@@ -313,6 +332,14 @@ type SessionOptions struct {
 	// lifetime, session calls may fail immediately.
 	Target string
 
+	// Config is a binary-serialized representation of the
+	// tensorflow.ConfigProto protocol message
+	// (https://www.tensorflow.org/code/tensorflow/core/protobuf/config.proto).
+	Config []byte
+}
+
+// RunOptions contains configuration information for a session run.
+type RunOptions struct {
 	// Config is a binary-serialized representation of the
 	// tensorflow.ConfigProto protocol message
 	// (https://www.tensorflow.org/code/tensorflow/core/protobuf/config.proto).

--- a/tensorflow/go/session_test.go
+++ b/tensorflow/go/session_test.go
@@ -431,3 +431,11 @@ func TestDeviceStringNoMemoryLimit(t *testing.T) {
 		t.Errorf("Got \"%s\", want \"%s\"", got, want)
 	}
 }
+
+func TestRunOptions(t *testing.T) {
+	runOpts := &RunOptions{Config: []byte{16, 1}} // timeout_in_ms:1
+	_, err := NewSession(NewGraph(), &SessionOptions{}, runOpts)
+	if err != nil {
+		t.Fatalf("NewSession(): %v", err)
+	}
+}

--- a/tensorflow/go/session_test.go
+++ b/tensorflow/go/session_test.go
@@ -52,7 +52,7 @@ func TestSessionRunNeg(t *testing.T) {
 				t.Fatal(err)
 			}
 			graph, inp, out := createTestGraph(t, t1.DataType())
-			s, err := NewSession(graph, &SessionOptions{})
+			s, err := NewSession(graph, &SessionOptions{}, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -116,7 +116,7 @@ func TestMultipleInput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	session, err := NewSession(graph, nil)
+	session, err := NewSession(graph, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestSessionRunConcat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s, err := NewSession(g, &SessionOptions{})
+	s, err := NewSession(g, &SessionOptions{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func TestSessionWithStringTensors(t *testing.T) {
 			Input: []Input{hash.Output(0)},
 		})
 	)
-	s, err := NewSession(g, nil)
+	s, err := NewSession(g, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +282,7 @@ func TestConcurrency(t *testing.T) {
 	}
 
 	graph, inp, out := createTestGraph(t, tensor.DataType())
-	s, err := NewSession(graph, &SessionOptions{})
+	s, err := NewSession(graph, &SessionOptions{}, nil)
 	if err != nil {
 		t.Fatalf("NewSession(): %v", err)
 	}
@@ -316,7 +316,7 @@ func ExamplePartialRun() {
 		plusB, _ = Add(g, "plusB", plus3, b)     // ((a + 2) + 3) + b
 
 	)
-	sess, err := NewSession(g, nil)
+	sess, err := NewSession(g, nil, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -385,7 +385,7 @@ func TestSessionConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	opts := SessionOptions{Config: []byte("(\x01")}
-	s, err := NewSession(graph, &opts)
+	s, err := NewSession(graph, &opts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,7 +399,7 @@ func TestSessionConfig(t *testing.T) {
 }
 
 func TestListDevices(t *testing.T) {
-	s, err := NewSession(NewGraph(), nil)
+	s, err := NewSession(NewGraph(), nil, nil)
 	if err != nil {
 		t.Fatalf("NewSession(): %v", err)
 	}


### PR DESCRIPTION
Add RunOptions as an argument for Tensorflow Session Run. Another option is adding a method for `Session` struct like `SetRunOptions()`. It will keep the current API the same, however, such method will be not thread-safe.