### PR TITLE
Remove hostedtoolcache from docker build scripts

### DIFF
--- a/.github/workflows/sigbuild-docker-branch.yml
+++ b/.github/workflows/sigbuild-docker-branch.yml
@@ -33,6 +33,8 @@ jobs:
       matrix:
         python-version: [python3.9, python3.10, python3.11]
     steps:
+      - name: Delete unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
       -
         name: Checkout
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/.github/workflows/sigbuild-docker-presubmit.yml
+++ b/.github/workflows/sigbuild-docker-presubmit.yml
@@ -32,7 +32,10 @@ jobs:
         python-version: [python3.9, python3.10, python3.11]
     steps:
       - name: Delete unnecessary tools folder
-        run: rm -rf /opt/hostedtoolcache
+        run: |
+          df -h
+          rm -rf /opt/hostedtoolcache
+          df -h
       -
         name: Checkout
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/.github/workflows/sigbuild-docker-presubmit.yml
+++ b/.github/workflows/sigbuild-docker-presubmit.yml
@@ -31,6 +31,8 @@ jobs:
       matrix:
         python-version: [python3.9, python3.10, python3.11]
     steps:
+      - name: Delete unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
       -
         name: Checkout
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0

--- a/.github/workflows/sigbuild-docker.yml
+++ b/.github/workflows/sigbuild-docker.yml
@@ -36,6 +36,8 @@ jobs:
       matrix:
         python-version: [python3.9, python3.10, python3.11]
     steps:
+      - name: Delete unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
       -
         name: Checkout
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0


### PR DESCRIPTION
Due to the large size of both CUDA and TF itself we are running into disk issues on the docker build scripts when a large change has been made.  This will delete the hostedtoolcache to free up space.  