### PR TITLE
Strip `external/local_tsl` prefix during zip of tsl protos

### DIFF
--- a/tensorflow/tools/lib_package/BUILD
+++ b/tensorflow/tools/lib_package/BUILD
@@ -2,18 +2,17 @@
 # This includes the C API, Java API, and protocol buffer files.
 
 load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_zip")
 load("//tensorflow:tensorflow.bzl", "VERSION", "VERSION_MAJOR", "if_macos")
 load("//tensorflow/core/platform:build_config_root.bzl", "tf_additional_license_deps")
 load("//third_party/mkl:build_defs.bzl", "if_enable_mkl", "if_mkl")
 
 package(default_visibility = ["//visibility:private"])
 
-genrule(
+pkg_zip(
     name = "libtensorflow_proto",
     srcs = ["//tensorflow/core:protos_all_proto_srcs"],
-    outs = ["libtensorflow_proto.zip"],
-    cmd = "zip $@ $(SRCS)",
+    strip_prefix = "/external/local_tsl",
 )
 
 pkg_tar(


### PR DESCRIPTION
PR strips external/local_tsl prefix from tsl protos when packaging //tensorflow/tools/lib_package:libtensorflow_proto.zip.  See also #61883. Here's a head of the tree for the current zip archive to demonstrate the issue:

```.
 .
├── external
│   └── local_tsl
│       └── tsl
│           ├── profiler
│           │   └── protobuf
│           │       ├── profiler_options.proto
│           │       └── xplane.proto
│           └── protobuf
│               ├── bfc_memory_map.proto
│               ├── coordination_config.proto
│               ├── distributed_runtime_payloads.proto
│               ├── error_codes.proto
│               ├── histogram.proto
│               ├── rpc_options.proto
│               ├── status.proto
│               └── test_log.proto
└── tensorflow
    └── core
        ├── example
        │   ├── example.proto
        │   ├── example_parser_configuration.proto
        │   └── feature.proto
        ├── framework
        │   ├── allocation_description.proto
        │   ├── api_def.proto
        │   ├── attr_value.proto
        │   ├── cost_graph.proto
        │   ├── cpp_shape_inference.proto
        │   ├── dataset.proto
        │   ├── dataset_metadata.proto
        │   ├── dataset_options.proto
        │   ├── device_attributes.proto
   .
   .
   .
```


cc: @jakeharmon8 