### PR TITLE
Registering CPU kernel with half dtype for cholesky_op

### DIFF
--- a/tensorflow/core/kernels/linalg/cholesky_op.cc
+++ b/tensorflow/core/kernels/linalg/cholesky_op.cc
@@ -72,5 +72,6 @@ REGISTER_LINALG_OP("Cholesky", (CholeskyOp<complex64>), complex64);
 REGISTER_LINALG_OP("Cholesky", (CholeskyOp<complex128>), complex128);
 REGISTER_LINALG_OP("BatchCholesky", (CholeskyOp<float>), float);
 REGISTER_LINALG_OP("BatchCholesky", (CholeskyOp<double>), double);
+REGISTER_LINALG_OP_CPU("Cholesky", (CholeskyOp<Eigen::half>), half);
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/linalg/cholesky_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/linalg/cholesky_op_gpu.cu.cc
@@ -224,6 +224,7 @@ class CholeskyOpGpu : public AsyncOpKernel {
   }
 };
 
+REGISTER_LINALG_OP_GPU("Cholesky", (CholeskyOpGpu<Eigen::half>), half);
 REGISTER_LINALG_OP_GPU("Cholesky", (CholeskyOpGpu<float>), float);
 REGISTER_LINALG_OP_GPU("Cholesky", (CholeskyOpGpu<double>), double);
 REGISTER_LINALG_OP_GPU("Cholesky", (CholeskyOpGpu<complex64>), complex64);


### PR DESCRIPTION
The `tf.linalg.cholesky` should support `half` data type  as per documentation. The Op registered for `half` data type also in `REGISTER_OP()`. But There is no CPU kernel for this Op to support half dtype. Hence adding the CPU kernel for same.

Fixes #61907