### PR TITLE
[TOSA] Convert MLIR shape to TF beforehand when creating dynamic dims Reshape

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1061,6 +1061,16 @@ func.func @test_reshape_dynamic(%arg0: tensor<13x21x?xf32>) -> tensor<*xf32> {
 
 // -----
 
+// CHECK-LABEL: test_reshape_dynamic_ranked_output
+// CHECK: %[[VAR0:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 1, -1, 2>}
+func.func @test_reshape_dynamic_ranked_output(%arg0: tensor<?x52x52x2xf32>) -> tensor<1x?x2xf32> {
+  %cst = arith.constant dense<[1, -1, 2]> : tensor<3xi32>
+  %0 = "tfl.reshape"(%arg0, %cst) : (tensor<?x52x52x2xf32>, tensor<3xi32>) -> tensor<1x?x2xf32>
+  func.return %0 : tensor<1x?x2xf32>
+}
+
+// -----
+
 // CHECK-LABEL: test_transpose
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<[2, 0, 1]> : tensor<3xi32>}>
 // CHECK: %[[VAR1:.*]] = tosa.transpose %arg0, %[[VAR0]]

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
@@ -80,8 +80,7 @@ std::optional<Value> buildReshapeWithDynamicDims(PatternRewriter& rewriter,
   llvm::SmallVector<int64_t> static_dims;
 
   if (output_type.hasRank()) {
-    static_dims.append(output_type.getShape().begin(),
-                       output_type.getShape().end());
+    static_dims = tensorflow::ConvertMlirShapeToTF(output_type.getShape());
   } else {
     static_dims.resize(dims.size(), tensorflow::kTFDynamicSize);
   }


### PR DESCRIPTION
Hi,

This PR fixes a bug with the `tfl.reshape` TFL -> TOSA legalization when it has dynamic dimension. MLIR dynamic dimensions should be converted to -1 with `ConvertMlirShapeToTF`. 