### PR TITLE
[oneDNN] Check for bf16 support on CPU

### DIFF
--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -1074,11 +1074,10 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
     if (HasNodeAttr(n->def(), type_attr)) {
       const auto& attr = n->def().attr().at(type_attr);
       DataType dtype = attr.type();
-      if (dtype == DT_BFLOAT16 &&
-          !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU()) {
+      if (dtype == DT_BFLOAT16 && !IsBF16SupportedByOneDNNOnThisCPU()) {
         mkl_op_registry::BF16UnsupportedWarning();
         result = false;
-        reason = "Intel oneDNN with bfloat16 support is not enabled.";
+        reason = "Intel oneDNN with bfloat16 is not supported.";
       }
     }
 

--- a/tensorflow/core/common_runtime/mkl_layout_pass.cc
+++ b/tensorflow/core/common_runtime/mkl_layout_pass.cc
@@ -1070,6 +1070,18 @@ class MklLayoutRewritePass : public GraphOptimizationPass {
       reason = "User has assigned a device that is not CPU.";
     }
 
+    const string& type_attr = "T";
+    if (HasNodeAttr(n->def(), type_attr)) {
+      const auto& attr = n->def().attr().at(type_attr);
+      DataType dtype = attr.type();
+      if (dtype == DT_BFLOAT16 &&
+          !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU()) {
+        mkl_op_registry::BF16UnsupportedWarning();
+        result = false;
+        reason = "Intel oneDNN with bfloat16 support is not enabled.";
+      }
+    }
+
     if (result == false) {
       VLOG(1) << "MklLayoutRewritePass: Skipping rewriting of the node "
               << n->type_string() << ", reason: " << reason;

--- a/tensorflow/core/graph/mkl_graph_util.h
+++ b/tensorflow/core/graph/mkl_graph_util.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/status.h"
 #include "tensorflow/core/platform/cpu_info.h"
 #include "tensorflow/core/util/env_var.h"
+#include "tensorflow/core/util/util.h"
 
 namespace tensorflow {
 // Since our ops are going to produce and also consume N addition tensors
@@ -170,10 +171,6 @@ inline string GetMklOpName(const string& name) {
 // We prefix 'MklEager' to the original op to get Mkl Eager op.
 inline string GetMklEagerOpName(const string& name) {
   return string(kMklEagerOpPrefix) + name;
-}
-
-static inline bool IsBF16SupportedByOneDNNOnThisCPU() {
-  return port::TestCPUFeature(port::CPUFeature::AVX512F);
 }
 
 static inline void BF16UnsupportedWarning() {

--- a/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include "tensorflow/cc/ops/nn_ops_internal.h"
 #include "tensorflow/cc/ops/standard_ops.h"
 #include "tensorflow/core/framework/tensor_testutil.h"
+#include "tensorflow/core/graph/mkl_graph_util.h"
 #include "tensorflow/core/grappler/devices.h"
 #include "tensorflow/core/grappler/grappler_item.h"
 #include "tensorflow/core/grappler/optimizers/remapper.h"
@@ -758,12 +759,20 @@ TEST_F(FusedMatMulBiasAddAndGeluTest, Float32GeluExact) {
   RunTest<DT_FLOAT, false>();
 }
 TEST_F(FusedMatMulBiasAddAndGeluTest, BFloat16GeluExact) {
+  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "FusedMatMulBiasAddAndGelu with bfloat16.";
   RunTest<DT_BFLOAT16, false>();
 }
 TEST_F(FusedMatMulBiasAddAndGeluTest, Float32GeluExact2) {
   RunTest<DT_FLOAT, true>();
 }
 TEST_F(FusedMatMulBiasAddAndGeluTest, BFloat16GeluExact2) {
+  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "FusedMatMulBiasAddAndGelu with bfloat16.";
   RunTest<DT_BFLOAT16, true>();
 }
 
@@ -771,6 +780,11 @@ class MklFusedBatchMatMul : public MklRemapperTest {
  public:
   template <typename T>
   void VerifyFused(bool adjx, bool adjy) {
+    if (DataTypeToEnum<T>::v() == DT_BFLOAT16 &&
+        !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+      GTEST_SKIP()
+          << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+             "MklFusedBatchMatMul with bfloat16.";
     using ::tensorflow::ops::Placeholder;
     using normal_generator = Eigen::internal::NormalRandomGenerator<T>;
 
@@ -862,6 +876,11 @@ class MklFusedBatchMatMul : public MklRemapperTest {
 
   template <typename T>
   void VerifyPreceedingScalarMul(bool adjx, bool adjy) {
+    if (DataTypeToEnum<T>::v() == DT_BFLOAT16 &&
+        !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+      GTEST_SKIP()
+          << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+             "MklFusedBatchMatMul with bfloat16.";
     using ::tensorflow::ops::Placeholder;
     using normal_generator = Eigen::internal::NormalRandomGenerator<T>;
 
@@ -1055,7 +1074,13 @@ class MklRemapperSwishTest : public GrapplerTest {
 };
 
 TEST_F(MklRemapperSwishTest, F32) { RunTest<DT_FLOAT>(); }
-TEST_F(MklRemapperSwishTest, BF16) { RunTest<DT_BFLOAT16>(); }
+TEST_F(MklRemapperSwishTest, BF16) {
+  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "MklRemapperSwish with bfloat16.";
+  RunTest<DT_BFLOAT16>();
+}
 
 class MklRemapperConv2dBiasAddSwishTest : public GrapplerTest {
  protected:
@@ -1135,7 +1160,13 @@ class MklRemapperConv2dBiasAddSwishTest : public GrapplerTest {
 };
 
 TEST_F(MklRemapperConv2dBiasAddSwishTest, F32) { RunTest<DT_FLOAT>(); }
-TEST_F(MklRemapperConv2dBiasAddSwishTest, BF16) { RunTest<DT_BFLOAT16>(); }
+TEST_F(MklRemapperConv2dBiasAddSwishTest, BF16) {
+  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "MklRemapperConv2dBiasAddSwish with bfloat16.";
+  RunTest<DT_BFLOAT16>();
+}
 
 class MklRemapperConv2dFusedBatchNormSwishTest : public GrapplerTest {
  protected:

--- a/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
@@ -759,9 +759,9 @@ TEST_F(FusedMatMulBiasAddAndGeluTest, Float32GeluExact) {
   RunTest<DT_FLOAT, false>();
 }
 TEST_F(FusedMatMulBiasAddAndGeluTest, BFloat16GeluExact) {
-  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "FusedMatMulBiasAddAndGelu with bfloat16.";
   RunTest<DT_BFLOAT16, false>();
 }
@@ -769,9 +769,9 @@ TEST_F(FusedMatMulBiasAddAndGeluTest, Float32GeluExact2) {
   RunTest<DT_FLOAT, true>();
 }
 TEST_F(FusedMatMulBiasAddAndGeluTest, BFloat16GeluExact2) {
-  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "FusedMatMulBiasAddAndGelu with bfloat16.";
   RunTest<DT_BFLOAT16, true>();
 }
@@ -781,9 +781,9 @@ class MklFusedBatchMatMul : public MklRemapperTest {
   template <typename T>
   void VerifyFused(bool adjx, bool adjy) {
     if (DataTypeToEnum<T>::v() == DT_BFLOAT16 &&
-        !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+        !IsBF16SupportedByOneDNNOnThisCPU())
       GTEST_SKIP()
-          << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+          << "Intel oneDNN with bfloat16 is not supported, skipping "
              "MklFusedBatchMatMul with bfloat16.";
     using ::tensorflow::ops::Placeholder;
     using normal_generator = Eigen::internal::NormalRandomGenerator<T>;
@@ -877,9 +877,9 @@ class MklFusedBatchMatMul : public MklRemapperTest {
   template <typename T>
   void VerifyPreceedingScalarMul(bool adjx, bool adjy) {
     if (DataTypeToEnum<T>::v() == DT_BFLOAT16 &&
-        !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+        !IsBF16SupportedByOneDNNOnThisCPU())
       GTEST_SKIP()
-          << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+          << "Intel oneDNN with bfloat16 is not supported, skipping "
              "MklFusedBatchMatMul with bfloat16.";
     using ::tensorflow::ops::Placeholder;
     using normal_generator = Eigen::internal::NormalRandomGenerator<T>;
@@ -1075,9 +1075,9 @@ class MklRemapperSwishTest : public GrapplerTest {
 
 TEST_F(MklRemapperSwishTest, F32) { RunTest<DT_FLOAT>(); }
 TEST_F(MklRemapperSwishTest, BF16) {
-  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "MklRemapperSwish with bfloat16.";
   RunTest<DT_BFLOAT16>();
 }
@@ -1161,9 +1161,9 @@ class MklRemapperConv2dBiasAddSwishTest : public GrapplerTest {
 
 TEST_F(MklRemapperConv2dBiasAddSwishTest, F32) { RunTest<DT_FLOAT>(); }
 TEST_F(MklRemapperConv2dBiasAddSwishTest, BF16) {
-  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "MklRemapperConv2dBiasAddSwish with bfloat16.";
   RunTest<DT_BFLOAT16>();
 }

--- a/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/mkl_remapper_test.cc
@@ -17,7 +17,6 @@ limitations under the License.
 #include "tensorflow/cc/ops/nn_ops_internal.h"
 #include "tensorflow/cc/ops/standard_ops.h"
 #include "tensorflow/core/framework/tensor_testutil.h"
-#include "tensorflow/core/graph/mkl_graph_util.h"
 #include "tensorflow/core/grappler/devices.h"
 #include "tensorflow/core/grappler/grappler_item.h"
 #include "tensorflow/core/grappler/optimizers/remapper.h"

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "absl/container/flat_hash_set.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/versions.pb.h"
+#include "tensorflow/core/graph/mkl_graph_util.h"
 #include "tensorflow/core/grappler/costs/graph_properties.h"
 #include "tensorflow/core/grappler/graph_view.h"
 #include "tensorflow/core/grappler/grappler_item.h"
@@ -340,7 +341,9 @@ bool IsCpuCompatibleDataType(const NodeDef* contraction,
     return (IsConv2D(*contraction) || IsDepthwiseConv2dNative(*contraction) ||
             IsConv3D(*contraction) || IsAnyBatchMatMul(*contraction) ||
             is_supported_matmul) &&
-           (dtype == DT_FLOAT || dtype == DT_BFLOAT16);
+           (dtype == DT_FLOAT ||
+            (dtype == DT_BFLOAT16 &&
+             mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU()));
   }
   if (IsConv2D(*contraction)) {
     return dtype == DT_FLOAT || dtype == DT_DOUBLE;
@@ -4650,6 +4653,17 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
     }
 
     if (IsMKLEnabled()) {
+      // Check if BF16 datatype is supported by oneDNN on this CPU,
+      // skipping fusions if it is not supported.
+      const auto* node_view = ctx.graph_view.GetNode(i);
+      const auto* node_def = node_view->node();
+      const string& type_attr = "T";
+      DataType dtype = GetDataTypeFromAttr(*node_def, type_attr);
+      if (dtype == DT_BFLOAT16 &&
+          !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU()) {
+        continue;
+      }
+
       // Remap Conv2D+BiasAdd+Add+relu into the _FusedConv2D.
       // or Remap Conv3D+BiasAdd+Add+relu into _FusedConv3D
       if (FindContractionWithBiasAndAddActivation(

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -342,8 +342,7 @@ bool IsCpuCompatibleDataType(const NodeDef* contraction,
             IsConv3D(*contraction) || IsAnyBatchMatMul(*contraction) ||
             is_supported_matmul) &&
            (dtype == DT_FLOAT ||
-            (dtype == DT_BFLOAT16 &&
-             mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU()));
+            (dtype == DT_BFLOAT16 && IsBF16SupportedByOneDNNOnThisCPU()));
   }
   if (IsConv2D(*contraction)) {
     return dtype == DT_FLOAT || dtype == DT_DOUBLE;
@@ -4653,14 +4652,13 @@ Status Remapper::Optimize(Cluster* cluster, const GrapplerItem& item,
     }
 
     if (IsMKLEnabled()) {
-      // Check if BF16 datatype is supported by oneDNN on this CPU,
+      // Check if BF16 data type is supported by oneDNN,
       // skipping fusions if it is not supported.
       const auto* node_view = ctx.graph_view.GetNode(i);
       const auto* node_def = node_view->node();
       const string& type_attr = "T";
       DataType dtype = GetDataTypeFromAttr(*node_def, type_attr);
-      if (dtype == DT_BFLOAT16 &&
-          !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU()) {
+      if (dtype == DT_BFLOAT16 && !IsBF16SupportedByOneDNNOnThisCPU()) {
         continue;
       }
 

--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -27,7 +27,6 @@ limitations under the License.
 #include "absl/container/flat_hash_set.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/versions.pb.h"
-#include "tensorflow/core/graph/mkl_graph_util.h"
 #include "tensorflow/core/grappler/costs/graph_properties.h"
 #include "tensorflow/core/grappler/graph_view.h"
 #include "tensorflow/core/grappler/grappler_item.h"

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -20,7 +20,6 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_testutil.h"
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/framework/types.pb.h"
-#include "tensorflow/core/graph/mkl_graph_util.h"
 #include "tensorflow/core/grappler/devices.h"
 #include "tensorflow/core/grappler/grappler_item.h"
 #include "tensorflow/core/grappler/utils/grappler_test.h"

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -722,16 +722,16 @@ class RemapperFuseConvWithBias : public RemapperTest {
 TEST_F(RemapperFuseConvWithBias, Conv2D_F32) { RunTest<2, DT_FLOAT>(); }
 TEST_F(RemapperFuseConvWithBias, Conv3D_F32) { RunTest<3, DT_FLOAT>(); }
 TEST_F(RemapperFuseConvWithBias, Conv2D_BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "FuseConv2DWithBias with bfloat16.";
   RunTest<2, DT_BFLOAT16>();
 }
 TEST_F(RemapperFuseConvWithBias, Conv3D_BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "FuseConv3DWithBias with bfloat16.";
   RunTest<3, DT_BFLOAT16>();
 }
@@ -879,16 +879,16 @@ TEST_F(RemapperFuseConvWithBiasAndActivation, Conv3D_F32) {
   RunTest<3, DT_FLOAT>();
 }
 TEST_F(RemapperFuseConvWithBiasAndActivation, Conv2D_BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "FuseConv2DWithBiasAndActivation with bfloat16.";
   RunTest<2, DT_BFLOAT16>();
 }
 TEST_F(RemapperFuseConvWithBiasAndActivation, Conv3D_BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "FuseConv3DWithBiasAndActivation with bfloat16.";
   RunTest<3, DT_BFLOAT16>();
 }
@@ -1005,16 +1005,16 @@ TEST_F(RemapperFuseConvWithSqueezeAndBias, Conv3D_FP32) {
   RunTest<3, DT_FLOAT>();
 }
 TEST_F(RemapperFuseConvWithSqueezeAndBias, Conv2D_BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "FuseConvWithSqueezeAndBias with bfloat16.";
   RunTest<2, DT_BFLOAT16>();
 }
 TEST_F(RemapperFuseConvWithSqueezeAndBias, Conv3D_BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "FuseConvWithSqueezeAndBias with bfloat16.";
   RunTest<3, DT_BFLOAT16>();
 }
@@ -1407,7 +1407,7 @@ TEST_F(RemapperFuseSoftplusTanhMul, FP32) {
   RunTest<DT_FLOAT>();
 }
 TEST_F(RemapperFuseSoftplusTanhMul, BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP() << "Test only applicable to oneDNN.";
   RunTest<DT_BFLOAT16>();
 }
@@ -1702,9 +1702,9 @@ TEST_F(RemapperFuseMatMulWithBiasTest, F16) {
 TEST_F(RemapperFuseMatMulWithBiasTest, F32) { RunTest<DT_FLOAT>(); }
 
 TEST_F(RemapperFuseMatMulWithBiasTest, Bf16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "FuseMatMulWithBias with bfloat16.";
   RunTest<DT_BFLOAT16>();  // NOLINT
 }
@@ -1912,9 +1912,9 @@ TEST_F(RemapperFuseMatMulWithBiasAndActivationTest, F32) {
 }
 
 TEST_F(RemapperFuseMatMulWithBiasAndActivationTest, Bf16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "FuseMatMulWithBiasAndActivation with bfloat16.";
   RunTest<DT_BFLOAT16>();  // NOLINT
 }
@@ -2511,9 +2511,9 @@ TEST_F(RemapperFusePadConv3D, Conv3D_FP32) {
   RunTest<DT_FLOAT>();
 }
 TEST_F(RemapperFusePadConv3D, Conv3D_BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "RemapperFusePadConv3D with bfloat16.";
   RunTest<DT_BFLOAT16>();
 }
@@ -2636,9 +2636,9 @@ TEST_F(RemapperFusePadWithFusedConv3D, FusedConv3D_FP32) {
   RunTest<DT_FLOAT>();
 }
 TEST_F(RemapperFusePadWithFusedConv3D, FusedConv3D_BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "RemapperFusePadWithFusedConv3D with bfloat16.";
   RunTest<DT_BFLOAT16>();
 }
@@ -2707,9 +2707,9 @@ class RemapperLeakyReluTest : public GrapplerTest {
 
 TEST_F(RemapperLeakyReluTest, F32) { RunTest<DT_FLOAT>(); }
 TEST_F(RemapperLeakyReluTest, BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "RemapperLeakyRelu with bfloat16.";
   RunTest<DT_BFLOAT16>();
 }
@@ -2857,9 +2857,9 @@ TEST_F(RemapperFuseFusedConvWithFusedActivation, Conv2D_F32) {
   RunTest<2, DT_FLOAT>();
 }
 TEST_F(RemapperFuseFusedConvWithFusedActivation, Conv2D_BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "RemapperFuseFusedConvWithFusedActivation with bfloat16.";
   RunTest<2, DT_BFLOAT16>();
 }
@@ -2867,9 +2867,9 @@ TEST_F(RemapperFuseFusedConvWithFusedActivation, Conv3D_F32) {
   RunTest<3, DT_FLOAT>();
 }
 TEST_F(RemapperFuseFusedConvWithFusedActivation, Conv3D_BF16) {
-  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
-        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+        << "Intel oneDNN with bfloat16 is not supported, skipping "
            "RemapperFuseFusedConvWithFusedActivation with bfloat16.";
   RunTest<3, DT_BFLOAT16>();
 }

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -1702,12 +1702,10 @@ TEST_F(RemapperFuseMatMulWithBiasTest, F16) {
 TEST_F(RemapperFuseMatMulWithBiasTest, F32) { RunTest<DT_FLOAT>(); }
 
 TEST_F(RemapperFuseMatMulWithBiasTest, Bf16) {
-#if !defined(ENABLE_MKL)
-  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
         << "Intel oneDNN with bfloat16 support is not enabled, skipping "
            "FuseMatMulWithBias with bfloat16.";
-#endif
   RunTest<DT_BFLOAT16>();  // NOLINT
 }
 
@@ -1914,12 +1912,10 @@ TEST_F(RemapperFuseMatMulWithBiasAndActivationTest, F32) {
 }
 
 TEST_F(RemapperFuseMatMulWithBiasAndActivationTest, Bf16) {
-#if !defined(ENABLE_MKL)
-  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
     GTEST_SKIP()
         << "Intel oneDNN with bfloat16 support is not enabled, skipping "
            "FuseMatMulWithBiasAndActivation with bfloat16.";
-#endif
   RunTest<DT_BFLOAT16>();  // NOLINT
 }
 

--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
+++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include "tensorflow/core/framework/tensor_testutil.h"
 #include "tensorflow/core/framework/types.h"
 #include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/graph/mkl_graph_util.h"
 #include "tensorflow/core/grappler/devices.h"
 #include "tensorflow/core/grappler/grappler_item.h"
 #include "tensorflow/core/grappler/utils/grappler_test.h"
@@ -721,15 +722,17 @@ class RemapperFuseConvWithBias : public RemapperTest {
 TEST_F(RemapperFuseConvWithBias, Conv2D_F32) { RunTest<2, DT_FLOAT>(); }
 TEST_F(RemapperFuseConvWithBias, Conv3D_F32) { RunTest<3, DT_FLOAT>(); }
 TEST_F(RemapperFuseConvWithBias, Conv2D_BF16) {
-  if (!IsMKLEnabled())
-    GTEST_SKIP() << "Intel MKL with bfloat16 support is not enabled, skipping "
-                    "FuseConv2DWithBias with bfloat16.";
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "FuseConv2DWithBias with bfloat16.";
   RunTest<2, DT_BFLOAT16>();
 }
 TEST_F(RemapperFuseConvWithBias, Conv3D_BF16) {
-  if (!IsMKLEnabled())
-    GTEST_SKIP() << "Intel MKL with bfloat16 support is not enabled, skipping "
-                    "FuseConv3DWithBias with bfloat16.";
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "FuseConv3DWithBias with bfloat16.";
   RunTest<3, DT_BFLOAT16>();
 }
 
@@ -876,15 +879,17 @@ TEST_F(RemapperFuseConvWithBiasAndActivation, Conv3D_F32) {
   RunTest<3, DT_FLOAT>();
 }
 TEST_F(RemapperFuseConvWithBiasAndActivation, Conv2D_BF16) {
-  if (!IsMKLEnabled())
-    GTEST_SKIP() << "Intel MKL with bfloat16 support is not enabled, skipping "
-                    "FuseConv2DWithBiasAndActivation with bfloat16.";
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "FuseConv2DWithBiasAndActivation with bfloat16.";
   RunTest<2, DT_BFLOAT16>();
 }
 TEST_F(RemapperFuseConvWithBiasAndActivation, Conv3D_BF16) {
-  if (!IsMKLEnabled())
-    GTEST_SKIP() << "Intel MKL with bfloat16 support is not enabled, skipping "
-                    "FuseConv3DWithBiasAndActivation with bfloat16.";
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "FuseConv3DWithBiasAndActivation with bfloat16.";
   RunTest<3, DT_BFLOAT16>();
 }
 
@@ -1000,15 +1005,17 @@ TEST_F(RemapperFuseConvWithSqueezeAndBias, Conv3D_FP32) {
   RunTest<3, DT_FLOAT>();
 }
 TEST_F(RemapperFuseConvWithSqueezeAndBias, Conv2D_BF16) {
-  if (!IsMKLEnabled())
-    GTEST_SKIP() << "Intel MKL with bfloat16 support is not enabled, skipping "
-                    "FuseConvWithSqueezeAndBias with bfloat16.";
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "FuseConvWithSqueezeAndBias with bfloat16.";
   RunTest<2, DT_BFLOAT16>();
 }
 TEST_F(RemapperFuseConvWithSqueezeAndBias, Conv3D_BF16) {
-  if (!IsMKLEnabled())
-    GTEST_SKIP() << "Intel MKL with bfloat16 support is not enabled, skipping "
-                    "FuseConvWithSqueezeAndBias with bfloat16.";
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "FuseConvWithSqueezeAndBias with bfloat16.";
   RunTest<3, DT_BFLOAT16>();
 }
 
@@ -1400,7 +1407,8 @@ TEST_F(RemapperFuseSoftplusTanhMul, FP32) {
   RunTest<DT_FLOAT>();
 }
 TEST_F(RemapperFuseSoftplusTanhMul, BF16) {
-  if (!IsMKLEnabled()) GTEST_SKIP() << "Test only applicable to MKL.";
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP() << "Test only applicable to oneDNN.";
   RunTest<DT_BFLOAT16>();
 }
 #endif
@@ -1695,8 +1703,10 @@ TEST_F(RemapperFuseMatMulWithBiasTest, F32) { RunTest<DT_FLOAT>(); }
 
 TEST_F(RemapperFuseMatMulWithBiasTest, Bf16) {
 #if !defined(ENABLE_MKL)
-  GTEST_SKIP() << "Intel MKL with bfloat16 support is not enabled, skipping "
-                  "FuseMatMulWithBias with bfloat16.";
+  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "FuseMatMulWithBias with bfloat16.";
 #endif
   RunTest<DT_BFLOAT16>();  // NOLINT
 }
@@ -1905,8 +1915,10 @@ TEST_F(RemapperFuseMatMulWithBiasAndActivationTest, F32) {
 
 TEST_F(RemapperFuseMatMulWithBiasAndActivationTest, Bf16) {
 #if !defined(ENABLE_MKL)
-  GTEST_SKIP() << "Intel MKL with bfloat16 support is not enabled, skipping "
-                  "FuseMatMulWithBiasAndActivation with bfloat16.";
+  if (!mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "FuseMatMulWithBiasAndActivation with bfloat16.";
 #endif
   RunTest<DT_BFLOAT16>();  // NOLINT
 }
@@ -2503,9 +2515,10 @@ TEST_F(RemapperFusePadConv3D, Conv3D_FP32) {
   RunTest<DT_FLOAT>();
 }
 TEST_F(RemapperFusePadConv3D, Conv3D_BF16) {
-  if (!IsMKLEnabled())
-    GTEST_SKIP() << "Intel MKL with bfloat16 support is not enabled, skipping "
-                    "RemapperFusePadConv3D with bfloat16.";
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "RemapperFusePadConv3D with bfloat16.";
   RunTest<DT_BFLOAT16>();
 }
 
@@ -2627,9 +2640,10 @@ TEST_F(RemapperFusePadWithFusedConv3D, FusedConv3D_FP32) {
   RunTest<DT_FLOAT>();
 }
 TEST_F(RemapperFusePadWithFusedConv3D, FusedConv3D_BF16) {
-  if (!IsMKLEnabled())
-    GTEST_SKIP() << "Intel MKL with bfloat16 support is not enabled, skipping "
-                    "RemapperFusePadWithFusedConv3D with bfloat16.";
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "RemapperFusePadWithFusedConv3D with bfloat16.";
   RunTest<DT_BFLOAT16>();
 }
 #endif
@@ -2696,7 +2710,13 @@ class RemapperLeakyReluTest : public GrapplerTest {
 };
 
 TEST_F(RemapperLeakyReluTest, F32) { RunTest<DT_FLOAT>(); }
-TEST_F(RemapperLeakyReluTest, BF16) { RunTest<DT_BFLOAT16>(); }
+TEST_F(RemapperLeakyReluTest, BF16) {
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "RemapperLeakyRelu with bfloat16.";
+  RunTest<DT_BFLOAT16>();
+}
 
 class RemapperFuseFusedConvWithFusedActivation : public RemapperTest {
  public:
@@ -2841,12 +2861,20 @@ TEST_F(RemapperFuseFusedConvWithFusedActivation, Conv2D_F32) {
   RunTest<2, DT_FLOAT>();
 }
 TEST_F(RemapperFuseFusedConvWithFusedActivation, Conv2D_BF16) {
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "RemapperFuseFusedConvWithFusedActivation with bfloat16.";
   RunTest<2, DT_BFLOAT16>();
 }
 TEST_F(RemapperFuseFusedConvWithFusedActivation, Conv3D_F32) {
   RunTest<3, DT_FLOAT>();
 }
 TEST_F(RemapperFuseFusedConvWithFusedActivation, Conv3D_BF16) {
+  if (!IsMKLEnabled() || !mkl_op_registry::IsBF16SupportedByOneDNNOnThisCPU())
+    GTEST_SKIP()
+        << "Intel oneDNN with bfloat16 support is not enabled, skipping "
+           "RemapperFuseFusedConvWithFusedActivation with bfloat16.";
   RunTest<3, DT_BFLOAT16>();
 }
 

--- a/tensorflow/core/util/util.cc
+++ b/tensorflow/core/util/util.cc
@@ -124,4 +124,15 @@ string SliceDebugString(const TensorShape& shape, const int64_t flat) {
 // TODO(penporn): Remove this function from util.cc
 bool IsMKLEnabled() { return IsMklEnabled(); }
 
+bool IsBF16SupportedByOneDNNOnThisCPU() {
+#ifdef INTEL_MKL
+  if (port::TestCPUFeature(port::CPUFeature::AVX512F)) {
+    return true;
+  } else {
+    return false;
+  }
+#endif  // INTEL_MKL
+  return false;
+}
+
 }  // namespace tensorflow

--- a/tensorflow/core/util/util.h
+++ b/tensorflow/core/util/util.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/lib/core/stringpiece.h"
+#include "tensorflow/core/platform/cpu_info.h"
 
 namespace tensorflow {
 
@@ -60,6 +61,9 @@ std::string SliceDebugString(const TensorShape& shape, int64_t flat);
 
 // Check if MKL is enabled in runtime
 bool IsMKLEnabled();
+
+// Check if BF16 is supported
+bool IsBF16SupportedByOneDNNOnThisCPU();
 
 }  // namespace tensorflow
 


### PR DESCRIPTION
This PR adds checks for BF16 since BF16 with oneDNN is not supported on AVX2 or earlier CPUs. The changes in remapper make sure that the fusions do not happen if oneDNN  is enabled and BF16 is not supported. The tests for fused ops are skipped in this case as well. The changes in layout pass make sure that the translation to MKL op does not happen for the same reason and the op falls back to Eigen.

Note: Changes in AMP pass are not needed as all oneDNN ops with the exception of fused ops are supported with Eigen and will fallback to Eigen on AVX2 machines