### PR TITLE
Using the new names of the social media companies Meta (formerly known as Facebook) and X (formerly known as Twitter) in the link texts and other mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Build Type                    | Status                                          
 *   [TensorFlow Codelabs](https://codelabs.developers.google.com/?cat=TensorFlow)
 *   [TensorFlow Blog](https://blog.tensorflow.org)
 *   [Learn ML with TensorFlow](https://www.tensorflow.org/resources/learn-ml)
-*   [TensorFlow Twitter](https://twitter.com/tensorflow)
+*   [TensorFlow X (former twitter)](https://twitter.com/tensorflow)
 *   [TensorFlow YouTube](https://www.youtube.com/channel/UC0rqucBdTuFTjJiefW5t-IQ)
 *   [TensorFlow model optimization roadmap](https://www.tensorflow.org/model_optimization/guide/roadmap)
 *   [TensorFlow White Papers](https://www.tensorflow.org/about/bib)

--- a/tensorflow/lite/g3doc/examples/bert_qa/overview.md
+++ b/tensorflow/lite/g3doc/examples/bert_qa/overview.md
@@ -103,7 +103,7 @@ Performance benchmark numbers are generated with the tool
 > Internet-related services and products, which include online advertising
 > technologies, search engine, cloud computing, software, and hardware. It is
 > considered one of the Big Four technology companies, alongside Amazon, Apple,
-> and Facebook.
+> and Meta (formerly known as Facebook).
 >
 > Google was founded in September 1998 by Larry Page and Sergey Brin while they
 > were Ph.D. students at Stanford University in California. Together they own


### PR DESCRIPTION
As both of the social media companies Facebook and Twitter has undergone branding changes, I have made updates to reflect those changes.