### PR TITLE
【Go】remove ioutil pkg

### DIFF
--- a/tensorflow/go/example_inception_inference_test.go
+++ b/tensorflow/go/example_inception_inference_test.go
@@ -22,14 +22,13 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 
-	"github.com/tensorflow/tensorflow/tensorflow/go/op"
 	tf "github.com/tensorflow/tensorflow/tensorflow/go"
+	"github.com/tensorflow/tensorflow/tensorflow/go/op"
 )
 
 func Example() {
@@ -88,7 +87,7 @@ func Example() {
 		log.Fatal(err)
 	}
 
-	model, err := ioutil.ReadFile(modelfile)
+	model, err := os.ReadFile(modelfile)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -145,7 +144,7 @@ func printBestLabel(probabilities []float32, labels []string) {
 
 // Convert the image in filename to a Tensor suitable as input to the Inception model.
 func makeTensorFromImage(filename string) (*tf.Tensor, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/tensorflow/go/genop/internal/genop.go
+++ b/tensorflow/go/genop/internal/genop.go
@@ -39,7 +39,7 @@ import "C"
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path"
 	"reflect"
 	"sort"
@@ -96,7 +96,7 @@ func registeredOps() (*odpb.OpList, *apiDefMap, error) {
 }
 
 func updateAPIDefs(m *apiDefMap, dir string) error {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func updateAPIDefs(m *apiDefMap, dir string) error {
 		if file.IsDir() || !strings.HasSuffix(file.Name(), ".pbtxt") {
 			continue
 		}
-		data, err := ioutil.ReadFile(path.Join(dir, file.Name()))
+		data, err := os.ReadFile(path.Join(dir, file.Name()))
 		if err != nil {
 			return fmt.Errorf("failed to read %q: %v", file.Name(), err)
 		}

--- a/tensorflow/go/genop/main.go
+++ b/tensorflow/go/genop/main.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"flag"
 	"go/format"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -42,7 +41,7 @@ func main() {
 		log.Fatal("-outfile must be set")
 	}
 	if *header != "" {
-		hdr, err := ioutil.ReadFile(*header)
+		hdr, err := os.ReadFile(*header)
 		if err != nil {
 			log.Fatalf("Unable to read %s: %v", *header, err)
 		}
@@ -64,7 +63,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to generate valid source? 'go fmt' failed: %v", err)
 	}
-	if err := ioutil.WriteFile(*filename, formatted, 0644); err != nil {
+	if err := os.WriteFile(*filename, formatted, 0644); err != nil {
 		log.Fatalf("Failed to write to %q: %v", *filename, err)
 	}
 }


### PR DESCRIPTION
Hi, thank you for mantenance of TensorFlow in Go @wamuir 

I read the docs at:
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/go/README.md

I also noticed that TensorFlow in Go uses some deprecated functions.
I understand that the documentation for installing the Go bindings for TensorFlow is no longer being maintained. However, I felt that using deprecated packages is also not ideal, so I've submitted a PR to fix this.

The ioutil package is already deprecated and internally calls the os package. I've rewritten the parts of the code that use ioutil to now use the os package. 

https://pkg.go.dev/io/ioutil@go1.21.1

The behavior of os.ReadDir is slightly different, but since sorting does not appear to be a requirement in this use case, I've only replaced ioutil.ReadDir with os.ReadDir.

Thanks.