### PR TITLE
[ROCm] bugfixing conv_parameters and activated respective test

### DIFF
--- a/tensorflow/core/kernels/matmul_op.h
+++ b/tensorflow/core/kernels/matmul_op.h
@@ -59,61 +59,6 @@ struct MatMulFunctor {
 }  // end namespace functor
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
-// Encapsulate all the shape information that is used in matmul operations.
-class MatmulParameters {
- public:
-  MatmulParameters(bool transa, bool transb, uint64 m, uint64 n, uint64 k,
-                   DataType dtype, int device_id)
-      : transa_(transa),
-        transb_(transb),
-        m_(m),
-        n_(n),
-        k_(k),
-        dtype_(dtype),
-        device_id_(device_id) {
-    hash_code_ = transa;
-    hash_code_ = Hash64Combine(hash_code_, transb);
-    hash_code_ = Hash64Combine(hash_code_, m);
-    hash_code_ = Hash64Combine(hash_code_, n);
-    hash_code_ = Hash64Combine(hash_code_, k);
-    hash_code_ = Hash64Combine(hash_code_, dtype);
-    hash_code_ = Hash64Combine(hash_code_, device_id);
-  }
-  bool operator==(const MatmulParameters& other) const {
-    return this->get_data_as_tuple() == other.get_data_as_tuple();
-  }
-
-  bool operator!=(const MatmulParameters& other) const {
-    return !(*this == other);
-  }
-  uint64 hash() const { return hash_code_; }
-
-  string ToString() const {
-    // clang-format off
-    return strings::StrCat(
-        transa_, ", ", transb_, ", ",
-        m_, ", ", n_, ", ", k_,
-        dtype_, ", ", device_id_);
-    // clang-format on
-  }
-
- private:
-  typedef std::tuple<bool, bool, int64, int64, int64, DataType, int>
-      ParameterDataType;
-
-  ParameterDataType get_data_as_tuple() const {
-    return std::make_tuple(transa_, transb_, m_, n_, k_, dtype_, device_id_);
-  }
-
-  bool transa_;
-  bool transb_;
-  uint64 m_;
-  uint64 n_;
-  uint64 k_;
-  DataType dtype_;
-  int device_id_;
-  uint64 hash_code_;
-};
 
 typedef Eigen::GpuDevice GPUDevice;
 

--- a/tensorflow/core/kernels/matmul_op_test.cc
+++ b/tensorflow/core/kernels/matmul_op_test.cc
@@ -228,8 +228,10 @@ class FusedMatMulOpTest : public OpsTestBase {
     ASSERT_EQ(matmul.dtype(), fused_matmul.dtype());
     ASSERT_EQ(matmul.shape(), fused_matmul.shape());
 
-    double atol = this->TValueType == DT_HALF ? 1e-1 : 1e-5;
-    test::ExpectClose(matmul, fused_matmul, atol);
+    // use specific rtol value for DT_HALF datatype and the default one for all others
+    double atol = this->TValueType == DT_HALF ? 1e-3 : 1e-5;
+    double rtol = this->TValueType == DT_HALF ? 1e-3 : -1.0;
+    test::ExpectClose(matmul, fused_matmul, atol, rtol);
   }
 
   // Verifies that computing MatMul+BiasAdd in a graph is identical to
@@ -264,7 +266,6 @@ class FusedMatMulOpTest : public OpsTestBase {
                                          const string& activation) {
 
     bool use_gpu_device = activation == "Relu" || (this->TValueType == DT_HALF);
-    //VLOG(-1) << "using GPU " << use_gpu_device;
     const BiasAddGraphRunner run_default = [&](const Tensor& input_data,
                                                const Tensor& filter_data,
                                                const Tensor& bias_data,
@@ -362,8 +363,9 @@ TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul1x256x256WithActivation) {
 
 TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul256x256x1WithActivation) {
 
-  if(this->TValueType == DT_HALF) // NOT available matmul algorithm in CuDNN for Eigen::half
+  if(this->TValueType == DT_HALF) { // NO available matmul algorithm in CuDNN for Eigen::half
     return;
+  }
 
   for (const string& activation : GetActivations(this->TValueType)) {
     this->VerifyConv2DWithBiasAndActivation(256, 256, 1, false, false,
@@ -373,8 +375,9 @@ TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul256x256x1WithActivation) {
 
 TYPED_TEST_P(FusedMatMulWithBiasOpTest, MatMul1x256x1WithActivation) {
 
-  if(this->TValueType == DT_HALF) // NOT available matmul algorithm in CuDNN for Eigen::half
+  if(this->TValueType == DT_HALF) { // NO available matmul algorithm in CuDNN for Eigen::half
     return;
+  }
 
   for (const string& activation : GetActivations(this->TValueType)) {
     this->VerifyConv2DWithBiasAndActivation(1, 256, 1, false, false,

--- a/tensorflow/core/util/autotune_maps/conv_parameters.cc
+++ b/tensorflow/core/util/autotune_maps/conv_parameters.cc
@@ -90,11 +90,12 @@ MatmulParameters::MatmulParameters(
     int64_t ldb, int64_t ldc,
     stream_executor::dnn::ActivationMode activation_mode, int version)
     : device_id_(stream_exec->device_ordinal()) {
+
   proto_.set_ab_dtype(ab_dtype);
   proto_.set_c_dtype(c_dtype);
 
   proto_.set_trans_a(trans_a);
-  proto_.set_trans_b(trans_a);
+  proto_.set_trans_b(trans_b);
   proto_.set_m(m);
   proto_.set_n(n);
   proto_.set_k(k);


### PR DESCRIPTION
This is bugfix in conv_parameters.cc originally appeared in https://github.com/ROCmSoftwarePlatform/tensorflow-upstream/pull/2000 and then in the follow-up PR: https://github.com/tensorflow/tensorflow/pull/61941

As requested, I am submitting this bugfix as a separate PR. 
I also had to extend the tests for Eigen::half datatype and 'Tanh' and 'Sigmoid' activations
since in this case fused matmul uses the CuDNN fallback which, in its turn, 
uses MatmulParameters constructor (from tensorflow/core/util/autotune_maps/conv_parameters.cc).

Additionally, I also removed MatmulParameters class from tensorflow/core/kernels/matmul_op.h which is a deadcode (to remove any confusions).

@akuegel: could you please review this as this is a follow up to https://github.com/tensorflow/tensorflow/pull/61941 PR ?