### PR TITLE
Pin ml-dtypes version

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -89,7 +89,7 @@ REQUIRED_PACKAGES = [
     'google_pasta >= 0.1.1',
     'h5py >= 2.9.0',
     'libclang >= 13.0.0',
-    'ml_dtypes >= 0.2.0',
+    'ml_dtypes ~= 0.2.0',
     'numpy >= 1.23.5',
     'opt_einsum >= 2.3.2',
     'packaging',


### PR DESCRIPTION
The new ml-dtypes version deprecated some attributes that are used by Tensorflow. This is causing build errors. I ran into this trying to do a patch release for TensorBoard(see error here: https://github.com/tensorflow/tensorboard/actions/runs/6332666553/job/17199512649?pr=6604).

Googlers see(b/301638377).