### PR TITLE
Updated broken link of Distributed Tensorflow

### DIFF
--- a/tensorflow/core/distributed_runtime/README.md
+++ b/tensorflow/core/distributed_runtime/README.md
@@ -5,4 +5,4 @@ distributed TensorFlow runtime, using [gRPC](http://grpc.io) for inter-process
 communication.
 
 To learn how to use the distributed runtime to create a TensorFlow cluster,
-see the [Distributed TensorFlow](https://www.tensorflow.org/deploy/distributed) How-To.
+see the [Distributed TensorFlow](https://www.tensorflow.org/guide/distributed_training) How-To.


### PR DESCRIPTION
The link for Distributed Tensorflow was redirecting to a broken link so I updated it with the correct one. Please have a look. Probably fixes https://github.com/tensorflow/tensorflow/issues/62019

Thank you!