### PR TITLE
Fix inconsistency in ragged and sparse embedding lookup.

### DIFF
--- a/tensorflow/python/ops/ragged/ragged_embedding_ops.py
+++ b/tensorflow/python/ops/ragged/ragged_embedding_ops.py
@@ -327,7 +327,7 @@ def safe_embedding_lookup_sparse(
   embedding_weights = [
       w
       if (
-          isinstance(w, resource_variable_ops.ResourceVariable)
+          resource_variable_ops.is_resource_variable(w)
           and dtype in (None, w.dtype)
       )
       else ops.convert_to_tensor(w, dtype=dtype)


### PR DESCRIPTION
# Summary
Ragged support for tf.nn.safe_sparse_embedding_lookup was added in tf 2.13 [here](https://github.com/tensorflow/tensorflow/pull/59788) and partly duplicated some of code in sparse implementation. In tf 2.14 [bug](https://github.com/tensorflow/tensorflow/commit/8f6b9d3830a059209ec4f40d94fb46a043e0149e) was fixed in sparse embedding lookup implementation, but duplicated code was not updated same way. ShardedVariables in parameter server are resource variable like and satisfy is_resource_variable, but are not isinstance ResourceVariable. This leads to an extra memory copy/ReadVariableOp heavily hurting performance on large embedding tables.

I did minimal fix to make code consistent. An alternative would be to move the duplicated code to a small helper shared between ragged/sparse embedding lookup.