### PR TITLE
[oneDNN] Add BFloat16 Specialization Functor for Mean Op

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -409,6 +409,7 @@ class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {
                                      "FusedBatchNormGradV3",
                                      "LeakyRelu",
                                      "LeakyReluGrad",
+                                     "Mean",
                                      "Mul",
                                      "Sub",
                                      "Elu",
@@ -434,7 +435,7 @@ class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {
                                      "Sqrt",
                                      "Square",
                                      "SquaredDifference",
-                                     "Sum"
+                                     "Sum",
                                      "Tanh",
                                      "TanhGrad"};
     UpdateList("INFERLIST", &list);
@@ -449,7 +450,6 @@ class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {
         "Exp",
         "Expm1",
         "L2Loss",
-        "Mean",
         "Pow",
         "SaveV2",
         "SoftmaxCrossEntropyWithLogits",

--- a/tensorflow/core/kernels/reduction_ops.h
+++ b/tensorflow/core/kernels/reduction_ops.h
@@ -95,7 +95,7 @@ struct ReduceEigenImpl<Device, OUT_T, IN_T, ReductionAxes,
 };
 
 // Specialization for which we do the reduction in IntermediateType to
-// avoid integer overflow.
+// avoid integer overflow and fix bfloat16 accuracy in some models.
 #define CASTING_SPECIALIZATION(ScalarType, IntermediateType)                  \
   template <typename Device, typename OUT_T, typename IN_T,                   \
             typename ReductionAxes>                                           \
@@ -120,6 +120,7 @@ CASTING_SPECIALIZATION(uint32, uint64);
 CASTING_SPECIALIZATION(int8, int64_t);
 CASTING_SPECIALIZATION(int16, int64_t);
 CASTING_SPECIALIZATION(int32, int64_t);
+CASTING_SPECIALIZATION(bfloat16, float);
 #undef CASTING_SPECIALIZATION
 
 // TODO(rmlarsen): Refactor this such that taking the sqrt can be optional

--- a/tensorflow/core/kernels/reduction_ops_test.cc
+++ b/tensorflow/core/kernels/reduction_ops_test.cc
@@ -248,4 +248,12 @@ static void BM_Bool2DToScalarGPU(::testing::benchmark::State& state) {
 }
 BENCHMARK(BM_Bool2DToScalarGPU)->RangePair(2048, 8192, 2048, 8192);
 
+static void BM_Mean2DToScalarCPUBF16(::testing::benchmark::State& state) {
+  const int num_x = state.range(0);
+  const int num_y = state.range(1);
+
+  ReduceToScalar<bfloat16>(state, "cpu", "Mean", num_x, num_y);
+}
+BENCHMARK(BM_Mean2DToScalarCPUBF16)->RangePair(2048, 8192, 2048, 8192);
+
 }  // end namespace tensorflow

--- a/tensorflow/python/kernel_tests/math_ops/reduction_ops_test_big.py
+++ b/tensorflow/python/kernel_tests/math_ops/reduction_ops_test_big.py
@@ -21,6 +21,7 @@ from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.platform import test
+from tensorflow.python.framework import dtypes
 
 
 class BaseReductionTest(test.TestCase):
@@ -43,6 +44,28 @@ class BigReductionTest(BaseReductionTest):
 
   def _tf_reduce_sum(self, x, reduction_axes, keepdims):
     return math_ops.reduce_sum(x, reduction_axes, keepdims)
+
+  @test_util.run_deprecated_v1
+  def testFloat32Bfloat16Mean(self):
+    arrfp32 = np.random.normal(size=[4105, 4105]).astype(np.float32)
+    arrbf16 = arrfp32.astype(dtypes.bfloat16.as_numpy_dtype)
+    with self.session(graph=ops.Graph(), use_gpu=False) as sess:
+      arrfp32_placeholder = array_ops.placeholder(dtype=np.float32,
+                                                  shape=(4105, 4105))
+      arrbf16_placeholder = array_ops.placeholder(
+                                dtype=dtypes.bfloat16.as_numpy_dtype,
+                                shape=(4105, 4105))
+      tf_full_mean_fp32 = self._tf_reduce_mean(arrfp32_placeholder,
+                                               [0, 1], False)
+      tf_full_mean_bf16 = self._tf_reduce_mean(arrbf16_placeholder,
+                                               [0, 1], False)
+      tf_full_mean_bf16_cast = math_ops.cast(tf_full_mean_bf16,
+                                             dtypes.float32)
+
+      tf_out_full_f, tf_out_full_b = sess.run(
+          [tf_full_mean_fp32, tf_full_mean_bf16_cast],
+            {arrfp32_placeholder: arrfp32, arrbf16_placeholder: arrbf16})
+    self.assertAllClose(tf_out_full_f, tf_out_full_b)
 
   @test_util.run_deprecated_v1
   def testFloat32Sum(self):


### PR DESCRIPTION
Resubmitting changes in PR #61331. Not sure why they were reverted.

Currently BFloat16 Mean Op causes BFloat16 accumulation which may result in incorrect output. This prevents Mean to be used with the lower BFloat16 precision. This PR:

Just like the existing implementation of the Sum op, ensures BFloat16 Mean accumulation happens in FP32 by adding a Casting Specialization registration.
Adds Benchmark and Kernel tests to verify the implementation.
Adds Mean back to the Infer List from Deny List and fixes a typo in the Infer List initialization.
