### PR TITLE
[Linaro:ARM_CI] Use portserver during testing

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test.sh
@@ -109,8 +109,11 @@ sed -i '$ aimport /usertools/aarch64_clang.bazelrc' .bazelrc
 
 update_bazel_flags
 
+start-stop-daemon -b -n portserver.py -a /usr/local/bin/python3 -S -- /usr/local/bin/portserver.py
+
 bazel test ${TF_TEST_FLAGS} \
     --action_env=PYTHON_BIN_PATH=${PYTHON_BIN_PATH} \
+    --test_env=PORTSERVER_ADDRESS=@unittest-portserver \
     --build_tag_filters=${TF_FILTER_TAGS} \
     --test_tag_filters=${TF_FILTER_TAGS} \
     --local_test_jobs=$(grep -c ^processor /proc/cpuinfo) \

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_build.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_build.sh
@@ -162,8 +162,11 @@ else
   die "WARNING: Cannot find repaired wheel."
 fi
 
+start-stop-daemon -b -n portserver.py -a /usr/local/bin/python3 -S -- /usr/local/bin/portserver.py
+
 bazel test ${TF_TEST_FLAGS} \
     --action_env=PYTHON_BIN_PATH=${PYTHON_BIN_PATH} \
+    --test_env=PORTSERVER_ADDRESS=@unittest-portserver \
     --build_tag_filters=${TF_FILTER_TAGS} \
     --test_tag_filters=${TF_FILTER_TAGS} \
     --local_test_jobs=$(grep -c ^processor /proc/cpuinfo) \


### PR DESCRIPTION
The use of portpicker is not thread safe by default so start portserver before testing so that each invocation of portpicker will defer to the single instance of portserver and thus avoid the non thread safe behaviour that leads to duplicate ports being attempted to be used by tests running in parallel.