### PR TITLE
Add auto_sharding dependency in OSS

### DIFF
--- a/third_party/xla/xla/service/gpu/BUILD
+++ b/third_party/xla/xla/service/gpu/BUILD
@@ -2809,6 +2809,7 @@ cc_library(
     ]) + [
         ":fusion_pipeline",
         ":prepare_hlo_for_ir_emitting_pipeline",
+        "//xla/hlo/experimental/auto_sharding",
         "@local_tsl//tsl/lib/monitoring:counter",
     ],
 )

--- a/third_party/xla/xla/service/gpu/gpu_compiler.cc
+++ b/third_party/xla/xla/service/gpu/gpu_compiler.cc
@@ -198,9 +198,7 @@ limitations under the License.
 #include "tsl/platform/threadpool.h"
 #include "tsl/profiler/lib/traceme.h"
 
-#ifdef PLATFORM_GOOGLE
 #include "xla/hlo/experimental/auto_sharding/auto_sharding.h"
-#endif  // PLATFORM_GOOGLE
 
 namespace xla {
 namespace gpu {


### PR DESCRIPTION
Currently we see seg faults when trying to enable auto_sharding in OSS.  This is a minimally-failing example for reproducing the issue.  (This PR only adds the necessary dependency, we do not yet enable the auto_pass in gpu_compiler in OSS.)