### PR TITLE
update contributing md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,12 +232,18 @@ There are two ways to run TensorFlow unit tests.
     and
     [GPU developer Dockerfile](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/dockerfiles/dockerfiles/devel-gpu.Dockerfile)
     for the required packages. Alternatively, use the said
-    [Docker images](https://hub.docker.com/r/tensorflow/tensorflow/tags/), e.g.,
-    `tensorflow/tensorflow:devel` and `tensorflow/tensorflow:devel-gpu` for
-    development to avoid installing the packages directly on your system (in
+    [tensorflow/build Docker images](https://hub.docker.com/r/tensorflow/build)
+    (`tensorflow/tensorflow:devel` and `tensorflow/tensorflow:devel-gpu` are no longer supported for)
+    development. Use TF SIG Build Dockerfiles in development to avoid installing the packages directly on your system (in
     which case remember to change the directory from `/root` to `/tensorflow`
     once you get into the running container so `bazel` can find the `tensorflow`
     workspace).
+    
+    you can do this by using the following command. As an example-
+
+    ```bash
+    docker run -it --rm -v $PWD:/tmp -w /tmp tensorflow/build:2.15-python3.10
+    ```
 
     Once you have the packages installed, you can run a specific unit test in
     bazel by doing as follows:
@@ -283,7 +289,7 @@ There are two ways to run TensorFlow unit tests.
     execution time and the sharding
     [could create an overhead on the test execution](https://github.com/bazelbuild/bazel/issues/2113#issuecomment-264054799).
 
-2.  Using [Docker](https://www.docker.com) and TensorFlow's CI scripts.
+3.  Using [Docker](https://www.docker.com) and TensorFlow's CI scripts.
 
     ```bash
     # Install Docker first, then this will build and run cpu tests


### PR DESCRIPTION
The contributing md is not up to date. tensorflow/tensorflow:devel and tensorflow/tensorflow:devel-gpu docker file tags are no longer supported. also this links does not point to the correct files or page. I have updated a small link and intend to update the instructions so that its more clear and concise.