### PR TITLE
Avoid overflow problem in math.is_non_decreasing

### DIFF
--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1942,6 +1942,12 @@ def _get_diff_for_monotonic_comparison(x):
   is_shorter_than_two = math_ops.less(array_ops.size(x), 2)
   short_result = lambda: ops.convert_to_tensor([], dtype=x.dtype)
 
+  # If x is insigned then cast into signed to avoid overflow.
+  # For example overflow always makes  math.is_non_decreasing to True.
+  # Below code avoids it.
+  if x.dtype in [dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64]:
+    x = math_ops.cast(x,dtype=dtypes.int64)
+  
   # With 2 or more elements, return x[1:] - x[:-1]
   s_len = array_ops.shape(x) - 1
   diff = lambda: array_ops.strided_slice(x, [1], [1] + s_len)- array_ops.strided_slice(x, [0], s_len)


### PR DESCRIPTION
The API `tf.math.is_non_decreasing` returns `True` with `unsigned` input dtypes even though the input have decreasing values. This is because of the overflow that happens at this line of code.

https://github.com/tensorflow/tensorflow/blob/4dacf3f368eb7965e9b5c3bbdd5193986081c3b2/tensorflow/python/ops/check_ops.py#L1947

Hence proposing to cast the input to signed dtype in case if it is unsigned.This will potentially avoid overflow error.

Fixes #62072.