### PR TITLE
Fix static_assert failure when compiling with gcc

### DIFF
--- a/tensorflow/compiler/mlir/lite/stablehlo/transforms/legalize_hlo.cc
+++ b/tensorflow/compiler/mlir/lite/stablehlo/transforms/legalize_hlo.cc
@@ -2183,7 +2183,9 @@ class ConvertReduceOpToTfArgMinMax
             reduction_indices,
             /*keep_dim=*/rewriter.getBoolAttr(false));
       } else {
-        static_assert(false, "Only TF::MaxOp and TF::MinOp are supported.");
+        static_assert(std::is_same_v<TfReduce, TF::MaxOp> ||
+            std::is_same_v<TfReduce, TF::MinOp>,
+            "Only TF::MaxOp and TF::MinOp are supported.");
       }
       auto tf_argreduce_op = rewriter.create<TfArgReduce>(
           reduce_op.getLoc(), reduce_op->getResult(1).getType(), operand,


### PR DESCRIPTION
Compiling with gcc compiler results in a build failure due the use of 'false' in the static_assert. Instead replace this with the condition that needs to be satisified.

Fixes: https://github.com/tensorflow/tensorflow/issues/62125