### PR TITLE
Limit numpy in 2.15 to < 2.0

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -90,7 +90,7 @@ REQUIRED_PACKAGES = [
     'h5py >= 2.9.0',
     'libclang >= 13.0.0',
     'ml_dtypes ~= 0.2.0',
-    'numpy >= 1.23.5',
+    'numpy >= 1.23.5, < 2.0.0',
     'opt_einsum >= 2.3.2',
     'packaging',
     # pylint:disable=line-too-long


### PR DESCRIPTION
Numpy 2 is scheduled for Jan 2024, limit numpy to avoid breakages until 2.0 can be adopted