### PR TITLE
Skip buffer contents comparison in bitcast_op_test_cpu for s390x

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/bitcast_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/bitcast_op_test.py
@@ -15,6 +15,7 @@
 """Tests for tf.bitcast."""
 
 import numpy as np
+import sys
 
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
@@ -33,7 +34,8 @@ class BitcastTest(test.TestCase):
       out = self.evaluate(tf_ans)
       buff_after = memoryview(out).tobytes()
       buff_before = memoryview(x).tobytes()
-      self.assertEqual(buff_before, buff_after)
+      if sys.byteorder == 'little' :
+        self.assertEqual(buff_before, buff_after)
       self.assertEqual(tf_ans.get_shape(), shape)
       self.assertEqual(tf_ans.dtype, datatype)
 

--- a/tensorflow/python/kernel_tests/array_ops/bitcast_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/bitcast_op_test.py
@@ -32,10 +32,13 @@ class BitcastTest(test.TestCase):
     with test_util.use_gpu():
       tf_ans = array_ops.bitcast(x, datatype)
       out = self.evaluate(tf_ans)
-      buff_after = memoryview(out).tobytes()
-      buff_before = memoryview(x).tobytes()
       if sys.byteorder == 'little' :
-        self.assertEqual(buff_before, buff_after)
+        buff_after = memoryview(out).tobytes()
+        buff_before = memoryview(x).tobytes()
+      else:
+        buff_after = memoryview(out.byteswap()).tobytes()
+        buff_before = memoryview(x.byteswap()).tobytes()
+      self.assertEqual(buff_before, buff_after)
       self.assertEqual(tf_ans.get_shape(), shape)
       self.assertEqual(tf_ans.dtype, datatype)
 


### PR DESCRIPTION
After PR https://github.com/tensorflow/tensorflow/pull/57069, **bitcast_op_test_cpu** test case started failing for BE machines due to difference in buffer contents.

As per TensorFlow [bitcast](https://www.tensorflow.org/api_docs/python/tf/bitcast#:~:text=Bitcast%20is%20implemented%20as%20a%20low%2Dlevel%20cast%2C%20so%20machines%20with%20different%20endian%20orderings%20will%20give%20different%20results.%20A%20copy%20from%20input%20buffer%20to%20output%20buffer%20is%20made%20on%20BE%20machines%20when%20types%20are%20of%20different%20sizes%20in%20order%20to%20get%20the%20same%20casting%20results%20as%20on%20LE%20machines.) documentation, buffer contents after bitcast operation may differ for BE machines, causing **bitcast_op_test_cpu** to fail.

Hence, skipping buffer content comparison/assert done in bitcast_op_test_cpu for s390x(big-endian). 

This code change would not cause any regressions on existing test cases and it won't affect LE machines.

Will rectify below test case for s390x:
`//tensorflow/python/kernel_tests/array_ops:bitcast_op_test_cpu`

Signed-off-by: Yasir Ashfaq <Yasir.Ashfaq1@ibm.com>