### PR TITLE
Add threadpool threadcap for AArch64 builds

### DIFF
--- a/third_party/xla/third_party/tsl/tsl/platform/default/BUILD
+++ b/third_party/xla/third_party/tsl/tsl/platform/default/BUILD
@@ -166,6 +166,7 @@ cc_library(
         "@com_google_absl//absl/types:optional",
         "@eigen_archive//:eigen3",
     ],
+    copts = tsl_copts()
 )
 
 cc_library(

--- a/third_party/xla/third_party/tsl/tsl/platform/threadpool.cc
+++ b/third_party/xla/third_party/tsl/tsl/platform/threadpool.cc
@@ -107,6 +107,12 @@ ThreadPool::ThreadPool(Env* env, const ThreadOptions& thread_options,
                        bool low_latency_hint, Eigen::Allocator* allocator) {
   CHECK_GE(num_threads, 1);
 
+#ifdef DNNL_AARCH64_USE_ACL
+  if(num_threads == std::thread::hardware_concurrency() && num_threads >= 16){
+    num_threads = num_threads - 1;
+  }
+#endif  // DNNL_AARCH64_USE_ACL
+
 #ifdef TENSORFLOW_THREADSCALING_EXPERIMENTAL
   CHECK_GT(absl::GetFlag(FLAGS_tensorflow_num_threads_scale_factor), 0);
   num_threads *= absl::GetFlag(FLAGS_tensorflow_num_threads_scale_factor);


### PR DESCRIPTION
Runs thread pool with one thread less when number of cores == num_threads and num_threads >= 16. This fixes a performance degradation issue on AArch64 builds when using max threads on systems with a large amount of cores.