### PR TITLE
[TOSA] Add legalize stateful pass to TOSA

### DIFF
--- a/tensorflow/compiler/mlir/tosa/BUILD
+++ b/tensorflow/compiler/mlir/tosa/BUILD
@@ -186,6 +186,7 @@ cc_library(
         "transforms/convert_metadata.cc",
         "transforms/convert_tfl_uint8.cc",
         "transforms/legalize_tfl.cc",
+        "transforms/legalize_tfl_stateful.cc",
         "transforms/lower_complex_types.cc",
         "transforms/lower_global_tensors.cc",
         "transforms/retain_call_once_funcs.cc",

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-stateful.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-stateful.mlir
@@ -1,0 +1,84 @@
+// RUN: tf-opt --split-input-file --tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
+// RUN: tf-opt --split-input-file --tf-tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
+
+// Operations for testing tfl-to-tosa-pipeline
+
+// -----
+
+module attributes {tf_saved_model.semantics, tfl.description = "Test.", tfl.schema_version = 3 : i32} {
+    // CHECK: tosa.variable @var_x = dense<7.000000e+00> : tensor<1xf32>
+    // CHECK-LABEL: test_stateful_ops
+    // CHECK: tosa.variable.write @var_x, %arg0 : tensor<1xf32>
+    // CHECK: %[[VAL_0:.*]] = tosa.variable.read @var_x : tensor<1xf32>
+    // CHECK: return %[[VAL_0]] : tensor<1xf32>
+    func.func @test_stateful_ops(%arg0: tensor<1xf32> {tf_saved_model.index_path = ["placeholder_0"]})
+      -> (tensor<1xf32> {tf_saved_model.index_path = ["output_0"]})
+      attributes {tf_saved_model.exported_names = ["serving_default"]} {
+        "tfl.call_once"() {session_init_function = "InitializeX"} : () -> ()
+        %0 = "tfl.var_handle"() {container = "", shared_name = "var_x"} : () -> tensor<!tf_type.resource>
+        "tfl.assign_variable"(%0, %arg0) : (tensor<!tf_type.resource>, tensor<1xf32>) -> ()
+        %1 = "tfl.read_variable"(%0) : (tensor<!tf_type.resource>) -> tensor<1xf32>
+        return %1 : tensor<1xf32>
+    }
+
+    // initialize variable var_x to 7.0
+    func.func private @InitializeX() {
+        %0 = "tfl.var_handle"() {container = "", shared_name = "var_x"} : () -> tensor<!tf_type.resource>
+        %1 = "tfl.pseudo_const"() {value = dense<7.000000e+00> : tensor<1xf32>} : () -> tensor<1xf32>
+        "tfl.assign_variable"(%0, %1) : (tensor<!tf_type.resource>, tensor<1xf32>) -> ()
+        return
+    }
+}
+
+// -----
+
+module {
+    // CHECK: tosa.variable @Variable = dense<42> : tensor<2x3xi8>
+    // CHECK-LABEL: readAssignQuant
+    // CHECK: %[[VAL_0:.*]] = tosa.variable.read @Variable : tensor<2x3xi8>
+    // CHECK: %[[VAL_1:.*]] = builtin.unrealized_conversion_cast %[[VAL_0]] : tensor<2x3xi8> to tensor<2x3x!quant.uniform<i8:f32, 1.000000e-01:2>>
+    // CHECK: %[[VAL_2:.*]] = tosa.rescale %[[VAL_1]] {double_round = true, input_zp = 2 : i32, multiplier = array<i32: 1073741824>, output_zp = 0 : i32, per_channel = false, scale32 = true, shift = array<i32: 11>} : (tensor<2x3x!quant.uniform<i8:f32, 1.000000e-01:2>>) -> tensor<2x3xi32>
+    // CHECK: %[[VAL_3:.*]] = tosa.rescale %[[VAL_4:.*]] {double_round = true, input_zp = 2 : i32, multiplier = array<i32: 1073741824>, output_zp = 0 : i32, per_channel = false, scale32 = true, shift = array<i32: 11>} : (tensor<2x3x!quant.uniform<i8:f32, 1.000000e-01:2>>) -> tensor<2x3xi32>
+    // CHECK: %[[VAL_5:.*]] = tosa.add %[[VAL_2]], %[[VAL_3]] : (tensor<2x3xi32>, tensor<2x3xi32>) -> tensor<2x3xi32>
+    // CHECK: %[[VAL_6:.*]] = tosa.rescale %[[VAL_5]] {double_round = true, input_zp = 0 : i32, multiplier = array<i32: 1073741824>, output_zp = 2 : i32, per_channel = false, scale32 = true, shift = array<i32: 49>} : (tensor<2x3xi32>) -> tensor<2x3x!quant.uniform<i8:f32, 1.000000e-01:2>>
+    // CHECK: %[[VAL_7:.*]] = builtin.unrealized_conversion_cast %[[VAL_6]] : tensor<2x3x!quant.uniform<i8:f32, 1.000000e-01:2>> to tensor<2x3xi8>
+    // CHECK: tosa.variable.write @Variable, %[[VAL_7]] : tensor<2x3xi8>
+    // CHECK: return %[[VAL_6]] : tensor<2x3x!quant.uniform<i8:f32, 1.000000e-01:2>>
+    func.func @readAssignQuant(%arg0: tensor<2x3x!quant.uniform<i8:f32, 0.1:2>>) -> (tensor<2x3x!quant.uniform<i8:f32, 0.1:2>>) {
+        "tfl.call_once"() {session_init_function = "ReadAssignInit"} : () -> ()
+        %0 = "tfl.var_handle"() {container = "", shared_name = "Variable"} : () -> tensor<*x!tf_type.resource>
+        %1 = "tfl.read_variable"(%0) : (tensor<*x!tf_type.resource>) -> tensor<2x3x!quant.uniform<i8:f32, 0.1:2>>
+        %2 = tfl.add %1, %arg0 {fused_activation_function = "NONE"} : tensor<2x3x!quant.uniform<i8:f32, 0.1:2>>
+        "tfl.assign_variable"(%0, %2) : (tensor<*x!tf_type.resource>, tensor<2x3x!quant.uniform<i8:f32, 0.1:2>>) -> ()
+        return %2 : tensor<2x3x!quant.uniform<i8:f32, 0.1:2>>
+    }
+    func.func private @ReadAssignInit() {
+        %0 = "tfl.var_handle"() {container = "", shared_name = "Variable"} : () -> tensor<*x!tf_type.resource>
+        %1 = "tfl.pseudo_const"() {qtype = tensor<2x3x!quant.uniform<i8:f32, 0.1:2>>, value = dense<42> : tensor<2x3xi8>} : () -> tensor<2x3x!quant.uniform<i8:f32, 0.1:2>>
+        "tfl.assign_variable"(%0, %1) : (tensor<*x!tf_type.resource>, tensor<2x3x!quant.uniform<i8:f32, 0.1:2>>) -> ()
+        return
+    }
+}
+
+// -----
+
+module {
+    // CHECK-LABEL: @nostate
+    // CHECK: %[[VAL_0:.*]]: tensor<16x16xf32>) -> tensor<16x16xf32> {
+    // CHECK: %[[VAL_1:.*]] = "tfl.var_handle"() {container = "", shared_name = "Variable"} : () -> tensor<*x!tf_type.resource>
+    // CHECK: %[[VAL_2:.*]] = "tfl.read_variable"(%[[VAL_1]]) : (tensor<*x!tf_type.resource>) -> tensor<16x16xf32>
+    // CHECK: %[[VAL_3:.*]] = tosa.add %[[VAL_2]], %[[VAL_0]] : (tensor<16x16xf32>, tensor<16x16xf32>) -> tensor<16x16xf32>
+    // CHECK: "tfl.assign_variable"(%[[VAL_1]], %[[VAL_3]]) : (tensor<*x!tf_type.resource>, tensor<16x16xf32>) -> ()
+    // CHECK: return %[[VAL_3]] : tensor<16x16xf32>
+    func.func @nostate(%arg0: tensor<16x16xf32>) -> (tensor<16x16xf32>) {
+        "tfl.call_once"() {session_init_function = "NoStateInit"} : () -> ()
+        %0 = "tfl.var_handle"() {container = "", shared_name = "Variable"} : () -> tensor<*x!tf_type.resource>
+        %1 = "tfl.read_variable"(%0) : (tensor<*x!tf_type.resource>) -> tensor<16x16xf32>
+        %2 = tfl.add %1, %arg0 {fused_activation_function = "NONE"} : tensor<16x16xf32>
+        "tfl.assign_variable"(%0, %2) : (tensor<*x!tf_type.resource>, tensor<16x16xf32>) -> ()
+        return %2 : tensor<16x16xf32>
+    }
+    func.func private @NoStateInit() {
+        return
+    }
+}

--- a/tensorflow/compiler/mlir/tosa/tf_tfl_passes.cc
+++ b/tensorflow/compiler/mlir/tosa/tf_tfl_passes.cc
@@ -30,6 +30,9 @@ void createTFTFLtoTOSALegalizationPipeline(
   //----------------------------------------------------------------------------
   // Prepare TFL module for conversion
   //----------------------------------------------------------------------------
+  // For stateful ops
+  pm.addPass(createRetainCallOnceFuncsPass());
+
   // Inline all functions into main and then delete the functions themselves.
   pm.addPass(mlir::createInlinerPass());
 
@@ -52,6 +55,7 @@ void createTFTFLtoTOSALegalizationPipeline(
   if (opts.dequantize_tfl_softmax) {
     pm.addPass(mlir::tosa::createDequantizeTFLSoftmaxPass());
   }
+  pm.addPass(mlir::tosa::createLegalizeTFLStatefulPass());
   pm.addPass(mlir::tosa::createLegalizeTFTFLPass());
 
   //----------------------------------------------------------------------------

--- a/tensorflow/compiler/mlir/tosa/tfl_passes.cc
+++ b/tensorflow/compiler/mlir/tosa/tfl_passes.cc
@@ -30,9 +30,8 @@ void createTFLtoTOSALegalizationPipeline(
   //----------------------------------------------------------------------------
   // Prepare TFL module for conversion
   //----------------------------------------------------------------------------
-  if (opts.target_compilation_backend) {
-    pm.addPass(createRetainCallOnceFuncsPass());
-  }
+  pm.addPass(createRetainCallOnceFuncsPass());
+
   // Inline all functions into main and then delete the functions themselves.
   pm.addPass(mlir::createInlinerPass());
   pm.addPass(createCanonicalizerPass());
@@ -59,6 +58,7 @@ void createTFLtoTOSALegalizationPipeline(
   if (opts.dequantize_tfl_softmax) {
     pm.addPass(mlir::tosa::createDequantizeTFLSoftmaxPass());
   }
+  pm.addPass(mlir::tosa::createLegalizeTFLStatefulPass());
   pm.addPass(mlir::tosa::createLegalizeTFLPass(opts.disabled_patterns,
                                                opts.enabled_patterns));
 

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl_stateful.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl_stateful.cc
@@ -1,0 +1,190 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Legalize TensorFlow Lite StatefulOps to TOSA
+
+#include <cstddef>
+
+#include "llvm/ADT/ArrayRef.h"
+#include "mlir/Dialect/Quant/QuantTypes.h"      // from @llvm-project
+#include "mlir/Dialect/Tosa/IR/TosaOps.h"       // from @llvm-project
+#include "mlir/Dialect/Traits.h"                // from @llvm-project
+#include "mlir/IR/BuiltinAttributes.h"          // from @llvm-project
+#include "mlir/IR/BuiltinTypes.h"               // from @llvm-project
+#include "mlir/IR/Matchers.h"                   // from @llvm-project
+#include "mlir/IR/PatternMatch.h"               // from @llvm-project
+#include "mlir/Support/LLVM.h"                  // from @llvm-project
+#include "mlir/Transforms/DialectConversion.h"  // from @llvm-project
+#include "tensorflow/compiler/mlir/lite/ir/tfl_ops.h"
+#include "tensorflow/compiler/mlir/tosa/transforms/passes.h"
+
+#define PASS_NAME "tosa-legalize-tfl-stateful"
+
+namespace mlir {
+namespace tosa {
+namespace {
+
+#define GEN_PASS_DEF_TOSALEGALIZETFLSTATEFULPASS
+#include "tensorflow/compiler/mlir/tosa/transforms/passes.h.inc"
+
+// Performs lowering tfl stateful operators to TOSA
+class TosaLegalizeTFLStateful
+    : public impl::TosaLegalizeTFLStatefulPassBase<TosaLegalizeTFLStateful> {
+ public:
+  explicit TosaLegalizeTFLStateful() {}
+  void runOnOperation() override;
+};
+
+void TosaLegalizeTFLStateful::runOnOperation() {
+  auto* context = &getContext();
+  auto moduleOp = getOperation();
+  mlir::OpBuilder builder(moduleOp.getBodyRegion());
+
+  DenseMap<StringRef, func::FuncOp> symNameToFunction;
+  for (auto func : moduleOp.getOps<func::FuncOp>()) {
+    symNameToFunction[func.getSymName()] = func;
+  }
+
+  llvm::SmallVector<mlir::TFL::VarHandleOp, 6> handleOps;
+  llvm::SmallVector<mlir::TFL::AssignVariableOp, 6> assignOps;
+  llvm::SmallVector<mlir::TFL::ReadVariableOp, 6> readOps;
+  SmallVector<mlir::TFL::CallOnceOp> callOnceOps;
+  DenseMap<StringRef, mlir::tosa::VariableOp> symbolRefMap;
+
+  for (auto it : symNameToFunction) {
+    auto func = std::get<1>(it);
+    // We also want to grab the list of operations to replace.
+    for (auto& op : func.getOps()) {
+      if (auto handle = dyn_cast<mlir::TFL::VarHandleOp>(op))
+        handleOps.push_back(handle);
+      if (auto assign = dyn_cast<mlir::TFL::AssignVariableOp>(op))
+        assignOps.push_back(assign);
+      if (auto read = dyn_cast<mlir::TFL::ReadVariableOp>(op))
+        readOps.push_back(read);
+    }
+  }
+
+  for (auto func : moduleOp.getOps<func::FuncOp>()) {
+    for (auto init : func.getOps<mlir::TFL::CallOnceOp>()) {
+      callOnceOps.push_back(init);
+    }
+  }
+
+  // Look through the initialization functions and find the assigned values
+  // for each handle, save out the constant value.
+  for (auto init : callOnceOps) {
+    auto findInitFunc =
+        symNameToFunction.find(init.getSessionInitFunctionAttr());
+    if (findInitFunc == symNameToFunction.end()) {
+      init.emitError("unable to find initialization function: ");
+      continue;
+    }
+    func::FuncOp initFunc = std::get<1>(*findInitFunc);
+    for (auto assign : initFunc.getOps<mlir::TFL::AssignVariableOp>()) {
+      // 1. var_handle part
+      auto handle = dyn_cast<mlir::TFL::VarHandleOp>(
+          assign.getResourceId().getDefiningOp());
+      if (!handle) continue;
+
+      // 2. pseudo_const part
+      DenseElementsAttr constant;
+      if (!matchPattern(assign.getValue(), m_Constant(&constant))) {
+        // Quantized types we can not use the m_Constant matcher.
+        if (auto constOp = dyn_cast<mlir::TFL::QConstOp>(
+                assign.getValue().getDefiningOp())) {
+          constant = cast<DenseElementsAttr>(constOp.getValue());
+        }
+      }
+      if (!constant) continue;
+
+      // Create TOSA VariableOps
+      auto name = handle.getSharedName();
+      auto global = builder.create<mlir::tosa::VariableOp>(
+          handle.getLoc(), name, constant.getType(), constant);
+      symbolRefMap[name] = global;
+    }
+  }
+  // TF::CallOnceOps are no longer needed as we have already extracted their
+  // state.
+  for (auto op : callOnceOps) op.erase();
+
+  // Replace the assign ops with a tosa store operation.
+  for (auto assign : assignOps) {
+    auto handle = dyn_cast<mlir::TFL::VarHandleOp>(
+        assign.getResourceId().getDefiningOp());
+    if (!handle) continue;
+
+    Value value = assign.getValue();
+    auto globalOpIt = symbolRefMap.find(handle.getSharedName());
+    if (globalOpIt == symbolRefMap.end()) {
+      assign->emitError(
+          "unable to find corresponding TosaOp for op's VarHandle");
+      continue;
+    }
+    auto globalOp = std::get<1>(*globalOpIt);
+
+    builder.setInsertionPoint(assign);
+    if (globalOp.getType() != value.getType()) {
+      value = builder
+                  .create<UnrealizedConversionCastOp>(assign.getLoc(),
+                                                      globalOp.getType(), value)
+                  .getResult(0);
+    }
+
+    builder.create<mlir::tosa::VariableWriteOp>(
+        assign.getLoc(), llvm::StringRef(globalOp.getName()), value);
+    assign.erase();
+  }
+
+  for (auto read : readOps) {
+    auto handle =
+        dyn_cast<mlir::TFL::VarHandleOp>(read.getResourceId().getDefiningOp());
+    if (!handle) continue;
+
+    auto globalOpIt = symbolRefMap.find(handle.getSharedName());
+    if (globalOpIt == symbolRefMap.end()) continue;
+    auto globalOp = std::get<1>(*globalOpIt);
+
+    builder.setInsertionPoint(read);
+
+    Value load = builder.create<mlir::tosa::VariableReadOp>(
+        read.getLoc(), globalOp.getType(), llvm::StringRef(globalOp.getName()));
+
+    if (read.getType() != load.getType()) {
+      load = builder
+                 .create<UnrealizedConversionCastOp>(read.getLoc(),
+                                                     read.getType(), load)
+                 .getResult(0);
+    }
+    read.getResult().replaceAllUsesWith(load);
+    read.erase();
+  }
+
+  for (auto handle : handleOps) {
+    if (handle.getResult().use_empty()) {
+      handle.erase();
+    }
+  }
+}
+
+}  // namespace
+
+// Creates an instance of the TensorFlow Lite dialect LegalizeTFLStateful pass.
+std::unique_ptr<OperationPass<ModuleOp>> createLegalizeTFLStatefulPass() {
+  return std::make_unique<TosaLegalizeTFLStateful>();
+}
+
+}  // namespace tosa
+}  // namespace mlir

--- a/tensorflow/compiler/mlir/tosa/transforms/passes.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/passes.h
@@ -68,6 +68,8 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLowerComplexTypesPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createStripFunctionMetadataPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createStripQuantTypesPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createVerifyFullyConvertedPass();
+std::unique_ptr<OperationPass<ModuleOp>> createLegalizeTFLStatefulPass();
+
 
 #define GEN_PASS_REGISTRATION
 #define GEN_PASS_CLASSES
@@ -85,6 +87,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createVerifyFullyConvertedPass();
 #define GEN_PASS_DECL_STRIPMODULEMETADATA
 #define GEN_PASS_DECL_VERIFYFULLYCONVERTED
 #define GEN_PASS_DECL_CONVERTFUNCTIONMETADATA
+#define GEN_PASS_DECL_TOSALEGALIZESTATEFULPASS
 
 #include "tensorflow/compiler/mlir/tosa/transforms/passes.h.inc"
 

--- a/tensorflow/compiler/mlir/tosa/transforms/passes.td
+++ b/tensorflow/compiler/mlir/tosa/transforms/passes.td
@@ -125,3 +125,11 @@ def ConvertFunctionMetadata :
   let constructor = "createConvertFunctionMetadataPass()";
 }
 
+def TosaLegalizeTFLStatefulPass : Pass<"tosa-legalize-tfl-stateful-tensors", "mlir::ModuleOp"> {
+  let summary = "Legalize tfl stateful operators to tosa stateful operators";
+  let description = [{
+    This pass is legalizing the tfl.call_once op to tosa stateful operators
+  }];
+  let constructor = "createLegalizeTFLStatefulPass()";
+  let dependentDialects = ["mlir::TFL::TFLDialect"];
+}


### PR DESCRIPTION
Handle the TFL Variable operators in a separate module level pass
since the existing tfl-to-tosa pass is a function pass.

TFL::VarHandleOp is mapped to TOSA::VariableOp
TFL::AssignVariableOp is mapped to TOSA::VariableWriteOp
TFL::ReadVariableOp is mapped to TOSA::VariableReadOp