### PR TITLE
Add NDK r26 support

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -36,7 +36,7 @@ _DEFAULT_CUDNN_VERSION = '2'
 _DEFAULT_TENSORRT_VERSION = '6'
 _DEFAULT_CUDA_COMPUTE_CAPABILITIES = '3.5,7.0'
 
-_SUPPORTED_ANDROID_NDK_VERSIONS = [19, 20, 21, 25]
+_SUPPORTED_ANDROID_NDK_VERSIONS = [19, 20, 21, 25, 26]
 
 _DEFAULT_PROMPT_ASK_ATTEMPTS = 10
 
@@ -750,11 +750,9 @@ def get_ndk_api_level(environ_cp, android_ndk_home_path):
   # Now grab the NDK API level to use. Note that this is different from the
   # SDK API level, as the NDK API level is effectively the *min* target SDK
   # version.
-  meta = open(os.path.join(android_ndk_home_path, 'meta/platforms.json'))
-  platforms = json.load(meta)
-  meta.close()
-  aliases = platforms['aliases']
-  api_levels = sorted(list(set([aliases[i] for i in aliases])))
+  with open(os.path.join(android_ndk_home_path, 'meta/platforms.json')) as f:
+    platforms = json.load(f)
+    api_levels = list(range(platforms['min'], platforms['max'] + 1))
 
   android_ndk_api_level = prompt_loop_or_load_from_env(
       environ_cp,
@@ -765,7 +763,10 @@ def get_ndk_api_level(environ_cp, android_ndk_home_path):
           '[Available levels: %s]'
       )
       % api_levels,
-      check_success=(lambda *_: True),
+      # api_levels are sorted, hence only check if it is inside the range
+      check_success=(
+          lambda api_level: api_levels[0] <= int(api_level) <= api_levels[-1]
+      ),
       error_msg='Android-%s is not present in the NDK path.',
   )
 

--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -705,9 +705,9 @@ def _tf_repositories():
 
     tf_http_archive(
         name = "rules_android_ndk",
-        sha256 = "b29409496439cdcdb50a8e161c4953ca78a548e16d3ee729a1b5cd719ffdacbf",
-        strip_prefix = "rules_android_ndk-81ec8b79dc50ee97e336a25724fdbb28e33b8d41",
-        urls = tf_mirror_urls("https://github.com/bazelbuild/rules_android_ndk/archive/81ec8b79dc50ee97e336a25724fdbb28e33b8d41.zip"),
+        sha256 = "b1a5ddd784e6ed915c2035c0db536a278b5f50c64412128c06877115991391ef",
+        strip_prefix = "rules_android_ndk-877c68ef34c9f3353028bf490d269230c1990483",
+        urls = tf_mirror_urls("https://github.com/bazelbuild/rules_android_ndk/archive/877c68ef34c9f3353028bf490d269230c1990483.zip"),
     )
 
     # Apple and Swift rules.


### PR DESCRIPTION
* Update NDK build rule version
* Fix NDK API level check: I used `min` and `max` values in `platforms.json` as it is proper way to determine compatibility. However, it must be noted that some android targets (such as `benchmark_tool`) cannot be built even if the API level is greater than the one NDK supports, as they may need higher API versions (`gpu` delegate requires `>=26`).