### PR TITLE
[XLA:CPU][oneDNN] Disable oneDNN rewrite for small Matmul.

### DIFF
--- a/third_party/xla/xla/service/cpu/cpu_compiler.cc
+++ b/third_party/xla/xla/service/cpu/cpu_compiler.cc
@@ -699,8 +699,7 @@ Status CpuCompiler::RunHloPassesThroughLayoutAssn(
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
   // AOT compiled code runs in single thread.
   if (!is_aot_compile) {
-    // Temporarily disabling oneDNN rewriter because it causes JAX regression.
-    // pipeline.AddPass<OneDnnRewriter>();
+    pipeline.AddPass<OneDnnRewriter>();
   }
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
 

--- a/third_party/xla/xla/service/cpu/onednn_rewriter.cc
+++ b/third_party/xla/xla/service/cpu/onednn_rewriter.cc
@@ -17,13 +17,13 @@ limitations under the License.
 
 #include "xla/service/cpu/onednn_rewriter.h"
 
+#include "tsl/platform/cpu_info.h"
 #include "xla/hlo/ir/dfs_hlo_visitor_with_default.h"
 #include "xla/hlo/ir/hlo_instruction.h"
 #include "xla/service/cpu/backend_config.pb.h"
 #include "xla/service/cpu/onednn_memory_util.h"
 #include "xla/service/pattern_matcher.h"
 #include "xla/status_macros.h"
-#include "tsl/platform/cpu_info.h"
 
 namespace xla {
 namespace cpu {
@@ -46,8 +46,8 @@ Status ValidateDotDimensionNumbers(const DotDimensionNumbers& dim_numbers) {
 }
 
 bool IsSupportedType(xla::PrimitiveType dtype) {
-  using tsl::port::TestCPUFeature;
   using tsl::port::CPUFeature;
+  using tsl::port::TestCPUFeature;
   switch (dtype) {
     case F32:
       return true;
@@ -116,6 +116,21 @@ class OneDnnRewriterVisitor : public DfsHloRewriteVisitor {
         (dot_dim_numbers.lhs_contracting_dimensions(0) == lhs_shape.rank() - 1);
     should_rewrite &=
         (dot_dim_numbers.rhs_contracting_dimensions(0) == rhs_shape.rank() - 2);
+    if (!should_rewrite) return OkStatus();
+
+    // OneDNN matmul has scratch allocation and copy overheads. The overheads
+    // can be amortized if there is sufficient MAC (multiply-accumulate)
+    // operations. We don't rewrite for small cases (determined empirically).
+    // TODO(intel-tf): Relax the condition when more optimizations in oneDNN
+    // matmul is achieved.
+    auto rank = lhs_shape.rank();
+    auto rhs_dims = rhs_shape.dimensions();
+    int64_t num_mac_ops = ShapeUtil::ElementsIn(lhs_shape) * rhs_dims.back();
+    if (rank == 2) {
+      should_rewrite &= num_mac_ops >= (1 << 23);
+    } else {
+      should_rewrite &= num_mac_ops >= (1 << 18);
+    }
     if (!should_rewrite) return OkStatus();
 
     HloInstruction* matmul_call =


### PR DESCRIPTION
This PR addresses the following issue https://github.com/openxla/xla/issues/5875. Here, we do not rewrite XLA HLO dot instruction for oneDNN matmul primitive when matrix-multiplication is small in terms of MAC (multiply-accumulate) ops. A threshold for rewrite is empirically determined using jax benchmarks (https://github.com/google/jax/blob/main/benchmarks/math_benchmark.py)

The following are performance data on matmul benchmarks ([jax-benchmarks](https://github.com/google/jax/blob/main/benchmarks/math_benchmark.py)) on Intel Xeon CPUs.

Problem Size [MxKxN] | oneDNN Perf ratio w and w/o
-- | --
16x16x16_float32 | 1.039257981
32x32x32_float32 | 1.036032261
64x64x64_float32 | 1.001214975
128x128x128_float32 | 1.050383228
256x256x256_float32 | 1.215597972
512x512x512_float32 | 1.266954652
1024x1024x1024_float32 | 2.886963409
1x2x256_float32 | 0.98122133
1x8x256_float32 | 0.984010011
1x18x300_float32 | 1.002542827
1x37x256_float32 | 1.010663823
1x91x256_float32 | 0.99543998
1x111x256_float32 | 1.011275892
1x192x192_float32 | 1.041369639
1x226x256_float32 | 1.011219147
1x256x192_float32 | 1.000978686
1x256x256_float32 | 1.048574995
1x512x512_float32 | 1.168676295
1x300x18_float32 | 0.98463839
21x24x1_float32 | 1.013919095
21x120x1_float32 | 1.002718558
10x10x10_float32 | 1.033871514
100x100x100_float32 | 1.008651831
18x1x300_float32 | 1.023119851
18x300x1_float32 | 0.999035281
300x1x18_float32 | 1.004889669
300x18x1_float32 | 1.033368366

































