### PR TITLE
[tosa] legalize tfl.fully_connected to tosa.conv2d

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline-filtered.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline-filtered.mlir
@@ -25,10 +25,13 @@ func.func @test_softmax(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 // -----
 
 // CHECK-LABEL: test_matmul
-// CHECK-DAG: %[[VAR0:.*]] = arith.constant dense<[1, 0]> : tensor<2xi32>
-// CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<28xf32>}>
-// CHECK: %[[VAR2:.*]] = tosa.transpose %arg1, %[[VAR0]]
-// CHECK: %[[VAR3:.*]] = tosa.fully_connected %arg0, %[[VAR2]], %[[VAR1]]
+// CHECK-DAG: %[[CST:.*]] = arith.constant dense<[1, 0]> : tensor<2xi32>
+// CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<28xf32>}>
+// CHECK: %[[VAR1:.*]] = tosa.transpose %arg1, %[[CST]]
+// CHECK-DAG: %[[VAR2:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
+// CHECK-DAG: %[[VAR3:.*]] = tosa.reshape %[[VAR1]] {new_shape = array<i64: 28, 1, 1, 19>}
+// CHECK-DAG: %[[VAR4:.*]] = tosa.conv2d %[[VAR2]], %[[VAR3]], %[[VAR0]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+// CHECK: %[[VAR5:.*]] = tosa.reshape %[[VAR4]] {new_shape = array<i64: 14, 28>}
 func.func @test_matmul(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>) -> tensor<*xf32> {
   %cst = arith.constant dense<[1, 0]> : tensor<2xi32>
   %cst_0 = "tfl.no_value"() {value = unit} : () -> none

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1458,7 +1458,10 @@ func.func @test_log_softmax(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}>
 // CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<28xf32>}>
 // CHECK: %[[VAR2:.*]] = tosa.transpose %arg1, %[[VAR0]]
-// CHECK: %[[VAR3:.*]] = tosa.fully_connected %arg0, %[[VAR2]], %[[VAR1]]
+// CHECK: %[[VAR3:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
+// CHECK: %[[VAR4:.*]] = tosa.reshape %[[VAR2]] {new_shape = array<i64: 28, 1, 1, 19>}
+// CHECK: %[[VAR5:.*]] = tosa.conv2d %[[VAR3]], %[[VAR4]], %[[VAR1]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+// CHECK: %[[VAR6:.*]] = tosa.reshape %[[VAR5]] {new_shape = array<i64: 14, 28>}
 func.func @test_matmul(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>) -> tensor<*xf32> {
   %cst = arith.constant dense<[1, 0]> : tensor<2xi32>
   %cst_0 = "tfl.no_value"() {value = unit} : () -> none
@@ -1471,11 +1474,11 @@ func.func @test_matmul(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>) -> te
 
 // CHECK-LABEL: @test_fullyconnected
 func.func @test_fullyconnected(%arg0: tensor<14x19xf32>, %arg1: tensor<28x19xf32>, %arg2: tensor<28xf32>) -> tensor<14x28xf32> {
-  // CHECK: tosa.fully_connected
-  // CHECK-SAME: tensor<14x19xf32>
-  // CHECK-SAME: tensor<28x19xf32>
-  // CHECK-SAME: tensor<28xf32>
-  // CHECK-SAME: tensor<14x28xf32>
+  // CHECK: %[[VAL0:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
+  // CHECK: %[[VAL1:.*]] = tosa.reshape %arg1 {new_shape = array<i64: 28, 1, 1, 19>}
+  // CHECK: %[[VAL2:.*]] = tosa.conv2d %[[VAL0]], %[[VAL1]], %arg2 {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+  // CHECK: %[[VAL3:.*]] = tosa.reshape %[[VAL2]] {new_shape = array<i64: 14, 28>}
+  // return %[[VAL3]]
   %2 = "tfl.fully_connected"(%arg0, %arg1, %arg2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<14x19xf32>, tensor<28x19xf32>, tensor<28xf32>) -> tensor<14x28xf32>
   func.return %2 : tensor<14x28xf32>
 }
@@ -1484,14 +1487,11 @@ func.func @test_fullyconnected(%arg0: tensor<14x19xf32>, %arg1: tensor<28x19xf32
 
 // CHECK-LABEL: @test_fullyconnected_in_batch_dim
 func.func @test_fullyconnected_in_batch_dim(%arg0: tensor<1x14x19xf32>, %arg1: tensor<28x19xf32>, %arg2: tensor<28xf32>) -> tensor<14x28xf32> {
-  // CHECK: tosa.reshape
-  // CHECK-SAME: tensor<1x14x19xf32>
-  // CHECK-SAME: tensor<14x19xf32>
-  // CHECK: tosa.fully_connected
-  // CHECK-SAME: tensor<14x19xf32>
-  // CHECK-SAME: tensor<28x19xf32>
-  // CHECK-SAME: tensor<28xf32>
-  // CHECK-SAME: tensor<14x28xf32>
+  // CHECK: %[[VAL0:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
+  // CHECK: %[[VAL1:.*]] = tosa.reshape %arg1 {new_shape = array<i64: 28, 1, 1, 19>}
+  // CHECK: %[[VAL2:.*]] = tosa.conv2d %[[VAL0]], %[[VAL1]], %arg2 {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+  // CHECK: %[[VAL3:.*]] = tosa.reshape %[[VAL2]] {new_shape = array<i64: 14, 28>}
+  // return %[[VAL3]]
   %0 = "tfl.fully_connected"(%arg0, %arg1, %arg2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<1x14x19xf32>, tensor<28x19xf32>, tensor<28xf32>) -> tensor<14x28xf32>
   func.return %0 : tensor<14x28xf32>
 }
@@ -1500,17 +1500,11 @@ func.func @test_fullyconnected_in_batch_dim(%arg0: tensor<1x14x19xf32>, %arg1: t
 
 // CHECK-LABEL: @test_fullyconnected_extra_dim
 func.func @test_fullyconnected_extra_dim(%arg0: tensor<1x14x19xf32>, %arg1: tensor<28x19xf32>, %arg2: tensor<28xf32>) -> tensor<1x14x28xf32> {
-  // CHECK: tosa.reshape
-  // CHECK-SAME: tensor<1x14x19xf32>
-  // CHECK-SAME: tensor<14x19xf32>
-  // CHECK: tosa.fully_connected
-  // CHECK-SAME: tensor<14x19xf32>
-  // CHECK-SAME: tensor<28x19xf32>
-  // CHECK-SAME: tensor<28xf32>
-  // CHECK-SAME: tensor<14x28xf32>
-  // CHECK: tosa.reshape
-  // CHECK-SAME: tensor<14x28xf32>
-  // CHECK-SAME: tensor<1x14x28xf32>
+  // CHECK: %[[VAL0:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
+  // CHECK: %[[VAL1:.*]] = tosa.reshape %arg1 {new_shape = array<i64: 28, 1, 1, 19>}
+  // CHECK: %[[VAL2:.*]] = tosa.conv2d %[[VAL0]], %[[VAL1]], %arg2 {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+  // CHECK: %[[VAL3:.*]] = tosa.reshape %[[VAL2]] {new_shape = array<i64: 1, 14, 28>}
+  // return %[[VAL3]]
   %0 = "tfl.fully_connected"(%arg0, %arg1, %arg2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<1x14x19xf32>, tensor<28x19xf32>, tensor<28xf32>) -> tensor<1x14x28xf32>
   func.return %0 : tensor<1x14x28xf32>
 }
@@ -2321,8 +2315,11 @@ func.func @test_resize_nearest_align_qi8_scalar_input(%arg0: tensor<3x1x1x7x!qua
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<[1, 0]> : tensor<2xi32>}>
 // CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<0> : tensor<28xi32>}>
 // CHECK-DAG: %[[VAR2:.*]] = tosa.transpose %arg1, %[[VAR0]]
-// CHECK-DAG: %[[VAR3:.*]] = tosa.fully_connected %arg0, %[[VAR2]], %[[VAR1]] {quantization_info = #tosa.conv_quant<input_zp = -1, weight_zp = -1>}
-// CHECK: %[[VAR4:.*]] = tosa.rescale %[[VAR3]] {double_round = true, input_zp = 0 : i32, multiplier = array<i32: 1353377973>, output_zp = 3 : i32, per_channel = false, scale32 = true, shift = array<i8: 40>}
+// CHECK-DAG: %[[VAR3:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
+// CHECK-DAG: %[[VAR4:.*]] = tosa.reshape %[[VAR2]] {new_shape = array<i64: 28, 1, 1, 19>}
+// CHECK-DAG: %[[VAR5:.*]] = tosa.conv2d %[[VAR3]], %[[VAR4]], %[[VAR1]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, quantization_info = #tosa.conv_quant<input_zp = -1, weight_zp = -1>, stride = array<i64: 1, 1>}
+// CHECK: %[[VAR6:.*]] = tosa.rescale %[[VAR5]] {double_round = true, input_zp = 0 : i32, multiplier = array<i32: 1353377973>, output_zp = 3 : i32, per_channel = false, scale32 = true, shift = array<i8: 40>}
+// CHECK: %[[VAR9:.*]] = tosa.reshape %[[VAR6]] {new_shape = array<i64: 14, 28>}
 func.func @test_fullyconnected_qi8(%arg0: tensor<14x19x!quant.uniform<i8:f32, 0.015685491263866425:-1>>, %arg1: tensor<19x28x!quant.uniform<i8:f32, 0.015685983002185822:-1>>) -> tensor<14x28x!quant.uniform<i8:f32, 0.19988977909088135:3>> {
   %0 = "tfl.pseudo_const"() {value = dense<[1, 0]> : tensor<2xi32>} : () -> tensor<2xi32>
   %1 = "tfl.transpose"(%arg1, %0) : (tensor<19x28x!quant.uniform<i8:f32, 0.015685983002185822:-1>>, tensor<2xi32>) -> tensor<28x19x!quant.uniform<i8:f32, 0.015685983002185822:-1>>
@@ -2533,8 +2530,13 @@ func.func @test_fakequant(%arg0: tensor<13x21x3xf32>) -> tensor<*xf32> {
 func.func @test_fullyconnected_hybrid(%arg0: tensor<14x19xf32>, %arg1: tensor<28x19x!quant.uniform<i8:f32, 1.0:17>>, %arg2: tensor<28xf32>) -> tensor<*xf32> {
   // This verifies that the constant is decomposed into a dequantization via a
   // cast, subtract, and multiplication.
-  // CHECK: tosa.sub
-  // CHECK: tosa.fully_connected
+  // CHECK: %[[VAL0:.*]] = "tosa.const"() <{value = dense<1.700000e+01> : tensor<1x1xf32>}>
+  // CHECK: %[[VAL1:.*]] = tosa.cast %arg1
+  // CHECK: %[[VAL2:.*]] = tosa.sub %[[VAL1]], %[[VAL0]]
+  // CHECK: %[[VAL3:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
+  // CHECK: %[[VAL4:.*]] = tosa.reshape %[[VAL2]] {new_shape = array<i64: 28, 1, 1, 19>}
+  // CHECK: %[[VAL5:.*]] = tosa.conv2d %[[VAL3]], %[[VAL4]], %arg2 {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+  // CHECK: %[[VAL6:.*]] = tosa.reshape %[[VAL5]] {new_shape = array<i64: 14, 28>}
   %2 = "tfl.fully_connected"(%arg0, %arg1, %arg2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<14x19xf32>, tensor<28x19x!quant.uniform<i8:f32, 1.0:17>>, tensor<28xf32>) -> tensor<*xf32>
   func.return %2 : tensor<*xf32>
 }

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -2072,6 +2072,7 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
   }
 
   Value input_val = tfl_fc_op.getInput();
+  Value filter_val = tfl_fc_op.getFilter();
 
   // tfl.fully_connected() can takes various dimension tensor as input
   // need to reshape it to rank 2 tensor, which tosa.fully_connected only
@@ -2089,11 +2090,35 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
     RankedTensorType reshape_type =
         RankedTensorType::get(shape_vals, input_type.getElementType());
     auto reshape_op = CreateOpAndInfer<tosa::ReshapeOp>(
-        rewriter, op->getLoc(), reshape_type, tfl_fc_op.getInput(),
+        rewriter, op->getLoc(), reshape_type, input_val,
         rewriter.getDenseI64ArrayAttr(shape_vals));
 
     input_val = reshape_op.getResult();
+    input_type = reshape_type;
   }
+
+  // reshape input_val from [N, IC] to [N, 1, 1, IC] to use conv2d
+  // reshape filter_val from [OC, IC] to [OC, 1, 1, IC] to use conv2d
+  const int64_t N = input_type.getShape()[0];
+  const int64_t IC = input_type.getShape()[1];
+  const int64_t OC = filter_type.getShape()[0];
+
+  SmallVector<int64_t> new_input_shape({N, 1, 1, IC});
+  SmallVector<int64_t> new_filter_shape({OC, 1, 1, IC});
+
+  input_val = CreateOpAndInfer<tosa::ReshapeOp>(
+      rewriter, op->getLoc(),
+      tensorflow::GetTypeFromTFTensorShape(new_input_shape,
+                                           input_type.getElementType()),
+      input_val, rewriter.getDenseI64ArrayAttr(new_input_shape));
+  input_type = cast<RankedTensorType>(input_val.getType());
+
+  filter_val = CreateOpAndInfer<tosa::ReshapeOp>(
+      rewriter, op->getLoc(),
+      tensorflow::GetTypeFromTFTensorShape(new_filter_shape,
+                                           filter_type.getElementType()),
+      filter_val, rewriter.getDenseI64ArrayAttr(new_filter_shape));
+  filter_type = cast<RankedTensorType>(filter_val.getType());
 
   Value bias_val;
   if (!bias_type) {
@@ -2143,9 +2168,12 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
 
   Type bias_ety = mlir::cast<ShapedType>(bias_val.getType()).getElementType();
 
-  auto fc_op = CreateOpAndInfer<tosa::FullyConnectedOp>(
+  auto fc_op = CreateOpAndInfer<tosa::Conv2DOp>(
       rewriter, op->getLoc(), UnrankedTensorType::get(bias_ety), input_val,
-      tfl_fc_op.getFilter(), bias_val);
+      filter_val, bias_val,
+      /* pad = */ rewriter.getDenseI64ArrayAttr({0, 0, 0, 0}),
+      /* stride = */ rewriter.getDenseI64ArrayAttr({1, 1}),
+      /* dilation = */ rewriter.getDenseI64ArrayAttr({1, 1}));
 
   Value fc_output;
   if (input_is_qtype) {
@@ -2158,14 +2186,19 @@ LogicalResult ConvertTFLFullyConnectedOp::matchAndRewrite(
 
   // If we know the output rank, we need to ensure the output shape is correct.
   ShapedType fc_type = mlir::cast<ShapedType>(fc_output.getType());
-  if (output_type.hasRank()) {
-    llvm::SmallVector<int64_t> output_shape;
 
-    fc_output = CreateOpAndInfer<tosa::ReshapeOp>(
-        rewriter, op->getLoc(),
-        UnrankedTensorType::get(fc_type.getElementType()), fc_output,
-        rewriter.getDenseI64ArrayAttr(output_type.getShape()));
+  DenseI64ArrayAttr output_shape_attr;
+  if (output_type.hasRank()) {
+    output_shape_attr = rewriter.getDenseI64ArrayAttr(output_type.getShape());
+  } else {
+    // set output_shape to {N, OC} to match previous results
+    // with tosa::FullyConnectedOp
+    output_shape_attr = rewriter.getDenseI64ArrayAttr({N, OC});
   }
+
+  fc_output = CreateOpAndInfer<tosa::ReshapeOp>(
+      rewriter, op->getLoc(), UnrankedTensorType::get(fc_type.getElementType()),
+      fc_output, output_shape_attr);
 
   auto fused_activation_fn = tfl_fc_op.getFusedActivationFunctionAttr();
 


### PR DESCRIPTION
This patch changes legalization of tfl.fully_connected to tosa.conv2d instead of tosa.fully_connected