### PR TITLE
Fix build error on TFLite C API for Android with CMake

### DIFF
--- a/tensorflow/lite/tools/cmake/modules/gemmlowp.cmake
+++ b/tensorflow/lite/tools/cmake/modules/gemmlowp.cmake
@@ -23,7 +23,7 @@ OverridableFetchContent_Declare(
   gemmlowp
   GIT_REPOSITORY https://github.com/google/gemmlowp
   # Sync with tensorflow/third_party/gemmlowp/workspace.bzl
-  GIT_TAG e844ffd17118c1e17d94e1ba4354c075a4577b88
+  GIT_TAG 16e8662c34917be0065110bfcd9cc27d30f52fdf
   # It's not currently (cmake 3.17) possible to shallow clone with a GIT TAG
   # as cmake attempts to git checkout the commit hash after the clone
   # which doesn't work as it's a shallow clone hence a different commit hash.

--- a/third_party/gemmlowp/workspace.bzl
+++ b/third_party/gemmlowp/workspace.bzl
@@ -7,8 +7,8 @@ def repo():
 
     # Attention: tools parse and update these lines.
     # LINT.IfChange
-    GEMMLOWP_COMMIT = "e844ffd17118c1e17d94e1ba4354c075a4577b88"
-    GEMMLOWP_SHA256 = "522b7a82d920ebd0c4408a5365866a40b81d1c0d60b2369011d315cca03c6476"
+    GEMMLOWP_COMMIT = "16e8662c34917be0065110bfcd9cc27d30f52fdf"
+    GEMMLOWP_SHA256 = "7dc418717c8456473fac4ff2288b71057e3dcb72894524c734a4362cdb51fa8b"
     # LINT.ThenChange(//tensorflow/lite/tools/cmake/modules/gemmlowp.cmake)
 
     tf_http_archive(


### PR DESCRIPTION
Update gemmlowp version that applied patch to avoid unneeded linker flag(`-lpthread` ).
More details are described at  #61839

fixes #61839