### PR TITLE
[Linaro:ARM_CI] Bump tag used for docker container

### DIFF
--- a/tensorflow/tools/ci_build/Dockerfile.cpu.arm64
+++ b/tensorflow/tools/ci_build/Dockerfile.cpu.arm64
@@ -1,4 +1,4 @@
-FROM linaro/tensorflow-arm64-build:2.15-multipython
+FROM linaro/tensorflow-arm64-build:2.16-multipython
 
 ARG py_major_minor_version='3.10'
 


### PR DESCRIPTION
Need to bump the tag used for the docker container to pull in the updates for the next release