### PR TITLE
TFLite GPU: Remove all 16-component vectors

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/cl_operation.cc
+++ b/tensorflow/lite/delegates/gpu/cl/cl_operation.cc
@@ -24,10 +24,6 @@ namespace {
 std::string GetCommonOpenCLDefines(CalculationsPrecision precision) {
   std::string result;
 
-  result += "#define FLT16_0123(V) V.s0123\n";
-  result += "#define FLT16_4567(V) V.s4567\n";
-  result += "#define FLT16_89ab(V) V.s89ab\n";
-  result += "#define FLT16_cdef(V) V.scdef\n";
   result += "#define GLOBAL_ID_0 get_global_id(0)\n";
   result += "#define GLOBAL_ID_1 get_global_id(1)\n";
   result += "#define GLOBAL_ID_2 get_global_id(2)\n";

--- a/tensorflow/lite/delegates/gpu/common/task/buffer_desc.cc
+++ b/tensorflow/lite/delegates/gpu/common/task/buffer_desc.cc
@@ -20,7 +20,6 @@ limitations under the License.
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
-#include "absl/strings/substitute.h"
 #include "tensorflow/lite/delegates/gpu/common/data_type.h"
 #include "tensorflow/lite/delegates/gpu/common/status.h"
 #include "tensorflow/lite/delegates/gpu/common/task/util.h"
@@ -91,30 +90,9 @@ absl::Status BufferDescriptor::PerformReadSelector(
                          " % 2 == 0 ? 0 : 2]), unpackHalf2x16(buffer[", arg0,
                          " / 2][", arg0, " % 2 == 0 ? 1 : 3]))");
       } else {
-        if (element_size == 4) {
-          *result =
-              absl::StrCat("vec4(unpackHalf2x16(buffer[", args[0],
-                           "].x), unpackHalf2x16(buffer[", args[0], "].y))");
-        } else if (element_size == 16) {
-          const std::string vec0 = absl::Substitute(
-              "vec4(unpackHalf2x16(buffer[$0].a.x), "
-              "unpackHalf2x16(buffer[$0].a.y))",
-              args[0]);
-          const std::string vec1 = absl::Substitute(
-              "vec4(unpackHalf2x16(buffer[$0].a.z), "
-              "unpackHalf2x16(buffer[$0].a.w))",
-              args[0]);
-          const std::string vec2 = absl::Substitute(
-              "vec4(unpackHalf2x16(buffer[$0].b.x), "
-              "unpackHalf2x16(buffer[$0].b.y))",
-              args[0]);
-          const std::string vec3 = absl::Substitute(
-              "vec4(unpackHalf2x16(buffer[$0].b.z), "
-              "unpackHalf2x16(buffer[$0].b.w))",
-              args[0]);
-          *result = absl::Substitute("mat4x4($0, $1, $2, $3)", vec0, vec1, vec2,
-                                     vec3);
-        }
+        *result =
+            absl::StrCat("vec4(unpackHalf2x16(buffer[", args[0],
+                         "].x), unpackHalf2x16(buffer[", args[0], "].y))");
       }
     } else {
       *result = absl::StrCat("buffer[", args[0], "]");

--- a/tensorflow/lite/delegates/gpu/common/tasks/convolution_transposed.h
+++ b/tensorflow/lite/delegates/gpu/common/tasks/convolution_transposed.h
@@ -108,7 +108,7 @@ void ConvolutionTransposed::UploadWeights(
   if (weights_are_buffer) {
     BufferDescriptor desc;
     desc.element_type = weights_desc.type;
-    desc.element_size = 16;
+    desc.element_size = 4;
     desc.size = weights_data.size();
     desc.data = std::move(weights_data);
     args_.AddObject("weights",
@@ -139,7 +139,7 @@ void ConvolutionTransposed::UploadWeights(
   if (weights_are_buffer) {
     BufferDescriptor desc;
     desc.element_type = weights_desc.type;
-    desc.element_size = 16;
+    desc.element_size = 4;
     desc.size = weights_data.size();
     desc.data = std::move(weights_data);
     args_.AddObject("weights",

--- a/tensorflow/lite/delegates/gpu/common/tasks/fully_connected.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/fully_connected.cc
@@ -113,15 +113,6 @@ std::string FullyConnected::GetFullyConnectedKernelCode(
   AddDstTensor("dst_tensor", op_def.dst_tensors[0]);
 
   std::string c;
-  switch (op_def.precision) {
-    case CalculationsPrecision::F32:
-      c += "#define FLT16 float16\n";
-      break;
-    case CalculationsPrecision::F32_F16:
-    case CalculationsPrecision::F16:
-      c += "#define FLT16 half16\n";
-      break;
-  }
 
   c += "#define WG_X " + std::to_string(work_group_size_.x) + "\n";
   c += "#define WG_Y " + std::to_string(work_group_size_.y) + "\n";
@@ -135,11 +126,11 @@ std::string FullyConnected::GetFullyConnectedKernelCode(
       FLT4 v = args.src_tensor.Read(0, 0, c);
 )";
   if (weights_are_buffer) {
-    c += R"(FLT16 w = args.weights.Read(c * args.dst_tensor.Slices() + gid);
-      FLT4 partial = v.x * FLT16_0123(w);
-      partial += v.y * FLT16_4567(w);
-      partial += v.z * FLT16_89ab(w);
-      partial += v.w * FLT16_cdef(w);
+    c += R"(int weights_index = (c * args.dst_tensor.Slices() + gid) * 4;
+      FLT4 partial = v.x * args.weights.Read(weights_index + 0);
+      partial += v.y * args.weights.Read(weights_index + 1);
+      partial += v.z * args.weights.Read(weights_index + 2);
+      partial += v.w * args.weights.Read(weights_index + 3);
       s += TO_ACCUM_TYPE(partial);
 )";
   } else {

--- a/tensorflow/lite/delegates/gpu/common/tasks/fully_connected.h
+++ b/tensorflow/lite/delegates/gpu/common/tasks/fully_connected.h
@@ -166,7 +166,7 @@ void FullyConnected::UploadWeights(const tflite::gpu::Tensor<OHWI, T>& weights,
   if (weights_are_buffer) {
     BufferDescriptor desc;
     desc.element_type = f32_weights ? DataType::FLOAT32 : DataType::FLOAT16;
-    desc.element_size = 16;
+    desc.element_size = 4;
     desc.size = float4_size * elements_count;
     desc.data.resize(desc.size);
 

--- a/tensorflow/lite/delegates/gpu/common/tasks/special/fc_fc_add.h
+++ b/tensorflow/lite/delegates/gpu/common/tasks/special/fc_fc_add.h
@@ -148,7 +148,7 @@ void FCFCAdd::UploadWeights(const tflite::gpu::Tensor<OHWI, T>& weights,
   if (weights_are_buffer) {
     BufferDescriptor desc;
     desc.element_type = f32_weights ? DataType::FLOAT32 : DataType::FLOAT16;
-    desc.element_size = 16;
+    desc.element_size = 4;
     desc.size = float4_size * elements_count;
     desc.data.resize(desc.size);
 

--- a/tensorflow/lite/delegates/gpu/metal/compute_task.cc
+++ b/tensorflow/lite/delegates/gpu/metal/compute_task.cc
@@ -35,27 +35,6 @@ namespace tflite {
 namespace gpu {
 namespace metal {
 namespace {
-bool IsWordSymbol(char symbol) {
-  return absl::ascii_isalnum(symbol) || symbol == '_';
-}
-
-void ReplaceAllWords(const std::string& old_word, const std::string& new_word,
-                     std::string* str) {
-  size_t position = str->find(old_word);
-  while (position != std::string::npos) {
-    const char prev = position == 0 ? ' ' : (*str)[position - 1];
-    const char next = position + old_word.size() < str->size()
-                          ? (*str)[position + old_word.size()]
-                          : ' ';
-    if (IsWordSymbol(prev) || IsWordSymbol(next)) {
-      position = str->find(old_word, position + 1);
-      continue;
-    }
-    str->replace(position, old_word.size(), new_word);
-    position = str->find(old_word, position + new_word.size());
-  }
-}
-
 std::map<std::string, std::string> GetMetalDefines(
     MetalDevice* device, CalculationsPrecision precision) {
   std::string simdgroup_barrier;
@@ -82,10 +61,6 @@ std::map<std::string, std::string> GetMetalDefines(
     }
   }
   return {
-      {"FLT16_0123(V)", "V[0]"},
-      {"FLT16_4567(V)", "V[1]"},
-      {"FLT16_89ab(V)", "V[2]"},
-      {"FLT16_cdef(V)", "V[3]"},
       {"FLT", storage_type},
       {"FLT2", storage_type + "2"},
       {"FLT3", storage_type + "3"},
@@ -190,12 +165,6 @@ absl::Status ComputeTask::Compile(MetalDevice* device) {
                                    &operation_->args_, &operation_->code_));
 
   operation_->args_.ReleaseCPURepresentation();
-
-  // manually resolving this defines, so as Metal has reserved words for them
-  ReplaceAllWords("float16", "float4x4", &operation_->code_);
-  ReplaceAllWords("half16", "half4x4", &operation_->code_);
-  ReplaceAllWords("float8", "float2x4", &operation_->code_);
-  ReplaceAllWords("half8", "half2x4", &operation_->code_);
   defines_ = GetMetalDefines(device, operation_->GetPrecision());
   return CompileProgram(device, operation_->code_, defines_);
 }


### PR DESCRIPTION
This simplifies the code, removes the text replacement hack for metal, and probably provides the same or better performance on all platforms. It avoids the need for similar hacks in other platforms too, because 16-component vectors are not commonly supported.