### PR TITLE
Updated the description of max_delta parameter

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -2027,10 +2027,11 @@ def random_brightness(image, max_delta, seed=None):
   with `tf.image.random_*` ops, `tf.image.stateless_random_*` ops guarantee the
   same results given the same seed independent of how many times the function is
   called, and independent of global seed settings (e.g. tf.random.set_seed).
+  
 
   Args:
     image: An image or images to adjust.
-    max_delta: float, must be non-negative.
+    max_delta: float, must be non-negative. The max_delta parameter controls the maximum relative change in brightness. This means that the actual change in brightness will depend on the range of values in the input image.
     seed: A Python integer. Used to create a random seed. See
       `tf.compat.v1.set_random_seed` for behavior.
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -2030,7 +2030,7 @@ def random_brightness(image, max_delta, seed=None):
 
   Args:
     image: An image or images to adjust.
-    max_delta: float, must be non-negative. The max_delta parameter controls the maximum relative change in brightness. This means that the actual change in brightness will depend on the range of values in the input image.
+    max_delta: float, must be non-negative. This parameter controls the maximum relative change in brightness.
     seed: A Python integer. Used to create a random seed. See
       `tf.compat.v1.set_random_seed` for behavior.
 

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -2027,7 +2027,6 @@ def random_brightness(image, max_delta, seed=None):
   with `tf.image.random_*` ops, `tf.image.stateless_random_*` ops guarantee the
   same results given the same seed independent of how many times the function is
   called, and independent of global seed settings (e.g. tf.random.set_seed).
-  
 
   Args:
     image: An image or images to adjust.

--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -2030,7 +2030,8 @@ def random_brightness(image, max_delta, seed=None):
 
   Args:
     image: An image or images to adjust.
-    max_delta: float, must be non-negative. This parameter controls the maximum relative change in brightness.
+    max_delta: float, must be non-negative. This parameter controls the maximum
+      relative change in brightness.
     seed: A Python integer. Used to create a random seed. See
       `tf.compat.v1.set_random_seed` for behavior.
 


### PR DESCRIPTION
The documentation currently states that the max_delta parameter controls the maximum absolute change in brightness of images. However, the max_delta parameter actually controls the maximum relative change in brightness of images. This means that the actual change in brightness will depend on the range of values in the input image. So, I have updated the description for the max_delta parameter. Could you please have a look and do the needful? 
Thank you!