### PR TITLE
Prevent OSV scanner running in forks

### DIFF
--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -27,6 +27,7 @@ permissions:
 
 jobs:
   scan-scheduled:
+    if: github.repository == 'tensorflow/tensorflow'
     uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable.yml@main"
     with:
       scan-args: |-


### PR DESCRIPTION
The OSV scanner just fails anyway, so stop it running in forks to stop the failures being logged and emailed.