### PR TITLE
Update supported dtypes of truncatediv Op in gpu_supported_ops.md

### DIFF
--- a/tensorflow/compiler/tf2xla/g3doc/cpu_supported_ops.md
+++ b/tensorflow/compiler/tf2xla/g3doc/cpu_supported_ops.md
@@ -257,7 +257,7 @@ Operator                              | Type Constraint
 `TensorArrayWriteV3`                  | `T={bool,complex64,double,float,int32,int64,uint32,uint64}`
 `Tile`                                | `Tmultiples={int32,int64}`<br>`T={bool,complex64,double,float,int32,int64,uint32,uint64}`
 `Transpose`                           | `Tperm={int32,int64}`<br>`T={bool,complex64,double,float,int32,int64,uint32,uint64}`
-`TruncateDiv`                         | `T={complex64,double,float,int32,int64}`
+`TruncateDiv`                         | `T={complex64,complex128,double,float,half,bfloat16,int8,int16,int32,int64,uint8,uint16,uint32,uint64}`
 `TruncateMod`                         | `T={double,float,int32,int64}`
 `TruncatedNormal`                     | `T={int32,int64}`<br>`dtype={double,float}`
 `Unpack`                              | `T={bool,complex64,double,float,int32,int64,uint32,uint64}`

--- a/tensorflow/compiler/tf2xla/g3doc/gpu_supported_ops.md
+++ b/tensorflow/compiler/tf2xla/g3doc/gpu_supported_ops.md
@@ -254,7 +254,7 @@ Operator                              | Type Constraint
 `TensorArrayWriteV3`                  | `T={bool,complex64,double,float,int32,int64,uint32,uint64}`
 `Tile`                                | `Tmultiples={int32,int64}`<br>`T={bool,complex64,double,float,int32,int64,uint32,uint64}`
 `Transpose`                           | `Tperm={int32,int64}`<br>`T={bool,complex64,double,float,int32,int64,uint32,uint64}`
-`TruncateDiv`                         | `T={complex64,double,float,int32,int64}`
+`TruncateDiv`                         | `T={complex64,complex128,double,float,half,bfloat16,int8,int16,int32,int64,uint8,uint16,uint32,uint64}`
 `TruncateMod`                         | `T={double,float,int32,int64}`
 `Unpack`                              | `T={bool,complex64,double,float,int32,int64,uint32,uint64}`
 `UnsortedSegmentSum`                  | `Tnumsegments={int32,int64}`<br>`Tindices={int32,int64}`<br>`T={complex64,double,float,int32,int64,uint32,uint64}`


### PR DESCRIPTION
Updated supported `dtypes` of `truncatediv` Op which is missing the list. 

From:
`{complex64,double,float,int32,int64}
`

To:
`{complex64,complex128,double,float,half,bfloat16,int8,int16,int32,int64,uint8,uint16,uint32,uint64}
`

as this Op also supports mentioned dtypes.

May please refer attached [gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/b0e584a4d45599bbff914d4119640d8e/tf-truncatediv_with_jit.ipynb).