### PR TITLE
Register complex dtypes for TruncateDiv Op

### DIFF
--- a/tensorflow/core/kernels/cwise_op_div.cc
+++ b/tensorflow/core/kernels/cwise_op_div.cc
@@ -23,8 +23,8 @@ REGISTER8(BinaryOp, CPU, "Div", functor::safe_div, uint8, uint16, uint32,
           uint64, int8, int16, int32, int64_t);
 REGISTER8(BinaryOp, CPU, "TruncateDiv", functor::safe_div, uint8, uint16,
           uint32, uint64, int8, int16, int32, int64_t);
-REGISTER4(BinaryOp, CPU, "TruncateDiv", functor::truncate_div_real, Eigen::half,
-          bfloat16, float, double);
+REGISTER6(BinaryOp, CPU, "TruncateDiv", functor::truncate_div_real, Eigen::half,
+          bfloat16, float, double, complex64, complex128);
 REGISTER6(BinaryOp, CPU, "RealDiv", functor::div, float, Eigen::half, double,
           bfloat16, complex64, complex128);
 REGISTER6(BinaryOp, CPU, "DivNoNan", functor::div_no_nan, Eigen::half, float,


### PR DESCRIPTION
As per documentation the Op `tf.truncatediv` should support `complex` dtypes also.


> Args
> --
> x | A Tensor. Must be one of the following types: bfloat16, half, float32, float64, uint8, int8, uint16, int16, int32, uint32, uint64, int64, complex64, complex128.



As per the `math_ops.cc` , `complex` dtypes also registered for this Op.

https://github.com/tensorflow/tensorflow/blob/e63d37e07b95e5c6e8a78794547fe317454edae7/tensorflow/core/ops/math_ops.cc#L521-L523

https://github.com/tensorflow/tensorflow/blob/e63d37e07b95e5c6e8a78794547fe317454edae7/tensorflow/core/ops/math_ops.cc#L392-L395

Hence adding the complex dtypes also to this Op registry.