### PR TITLE
lite: add tensors and nodes size in SignatureRunner

### DIFF
--- a/tensorflow/lite/core/signature_runner.h
+++ b/tensorflow/lite/core/signature_runner.h
@@ -107,6 +107,12 @@ class SignatureRunner {
   /// Returns the number of outputs.
   size_t output_size() const { return subgraph_->outputs().size(); }
 
+  /// Returns the number of tensors in the signature.
+  size_t tensors_size() const { return subgraph_->tensors_size(); }
+
+  /// Returns the number of ops in the signature.
+  size_t nodes_size() const { return subgraph_->nodes_size(); }
+
   /// Read-only access to list of signature input names.
   const std::vector<const char*>& input_names() { return input_names_; }
 

--- a/tensorflow/lite/core/signature_runner_test.cc
+++ b/tensorflow/lite/core/signature_runner_test.cc
@@ -52,6 +52,8 @@ TEST(SignatureRunnerTest, TestMultiSignatures) {
       interpreter->GetSignatureRunner(signature_defs[0]->c_str());
   ASSERT_NE(add_runner, nullptr);
   ASSERT_EQ(add_runner->signature_key(), "add");
+  ASSERT_EQ(add_runner->tensors_size(), 3);
+  ASSERT_EQ(add_runner->nodes_size(), 2);
   const std::vector<const char*>& input_names = add_runner->input_names();
   const std::vector<const char*>& output_names = add_runner->output_names();
   ASSERT_EQ(input_names.size(), 1);
@@ -75,6 +77,8 @@ TEST(SignatureRunnerTest, TestMultiSignatures) {
   SignatureRunner* sub_runner = interpreter->GetSignatureRunner("sub");
   ASSERT_NE(sub_runner, nullptr);
   ASSERT_EQ(sub_runner->signature_key(), "sub");
+  ASSERT_EQ(sub_runner->tensors_size(), 3);
+  ASSERT_EQ(sub_runner->nodes_size(), 2);
   const std::vector<const char*>& input_names2 = sub_runner->input_names();
   const std::vector<const char*>& output_names2 = sub_runner->output_names();
   ASSERT_EQ(input_names2.size(), 1);


### PR DESCRIPTION
number of tensors and nodes is already available in Subgraph class, map these sizes in SignatureRunner.

It avoids to use GetSubgraphIndexFromSignature() and subgraph() from Interpreter class to retrieve these sizes for a given signature.