### PR TITLE
Remove endian conversion for S4/U4 literals for s390x

### DIFF
--- a/third_party/xla/xla/literal.cc
+++ b/third_party/xla/xla/literal.cc
@@ -2213,9 +2213,6 @@ void LiteralBase::Piece::WriteToProto(LiteralProto* proto) const {
     case S4:
       *proto->mutable_s4s() = std::string(
           reinterpret_cast<const char*>(data<s4>().data()), size_bytes_dense());
-      if (!kLittleEndian) {
-        ConvertEndianShort(proto->mutable_s4s());
-      }
       break;
     case S8:
       proto->set_s8s(static_cast<const signed char*>(data<int8_t>().data()),
@@ -2224,9 +2221,6 @@ void LiteralBase::Piece::WriteToProto(LiteralProto* proto) const {
     case U4:
       *proto->mutable_u4s() = std::string(
           reinterpret_cast<const char*>(data<u4>().data()), size_bytes_dense());
-      if (!kLittleEndian) {
-        ConvertEndianShort(proto->mutable_u4s());
-      }
       break;
     case U8:
       proto->set_u8s(static_cast<const unsigned char*>(data<uint8_t>().data()),
@@ -2374,9 +2368,6 @@ Status LiteralBase::Piece::CopyFromProto(const LiteralProto& proto) {
       const std::string& s(proto.s4s());
       TF_RET_CHECK(data<s4>().size() * sizeof(s4) == s.size());
       memcpy(untyped_data(), s.data(), s.size());
-      if (!kLittleEndian) {
-        ConvertEndianShort(reinterpret_cast<char*>(untyped_data()), s.size());
-      }
     } break;
     case S8: {
       auto s8_data = data<int8_t>();
@@ -2387,9 +2378,6 @@ Status LiteralBase::Piece::CopyFromProto(const LiteralProto& proto) {
       const std::string& s(proto.u4s());
       TF_RET_CHECK(data<u4>().size() * sizeof(u4) == s.size());
       memcpy(untyped_data(), s.data(), s.size());
-      if (!kLittleEndian) {
-        ConvertEndianShort(reinterpret_cast<char*>(untyped_data()), s.size());
-      }
     } break;
     case U8: {
       auto u8_data = data<uint8_t>();


### PR DESCRIPTION
After introducing [**_commit_**](https://github.com/linux-on-ibm-z/tensorflow/commit/e0059bba8cb4d6d3979458c0945c66b4cc1c9f69) to add support for int4(S4 and U4) types in literal, `//tensorflow/compiler/xla:literal_test` started to fail for BE(s390x) machines.

This issue is occurring in `ProtoRoundTrip` test case when we try to convert/retrieve S4/U4 literal to/from proto values.
>   auto vector_s4 = LiteralUtil::CreateR1<s4>({s4{-1}, s4{3}, s4{7}});
>   auto vector_u4 = LiteralUtil::CreateR1<u4>({u4{1}, u4{3}, u4{15}});
>   EXPECT_EQ(vector_s4, to_from_proto(vector_s4));
>   EXPECT_EQ(vector_u4, to_from_proto(vector_u4));

ConvertEndianShort assertion is failing as it expects an **even** byte size, but  for vector_s4 / vector_u4, byte size is coming as 3(odd), causing the test case to fail.

ConvertEndianShort is getting used mostly to convert **16 bit** literal types to **LE** byte order as protobuf seems to be  processing **bytes** in LE format.
> In third_party/xla/xla/xla_data.proto -
> message LiteralProto {
>   ...
>   bytes s4s = 21;
>   bytes u4s = 22;
>   ...
>   // The F16s, BF16s, U16s and S16s are encoded in little endian byte order
>   bytes f16s = 11;
>   bytes bf16s = 13;
>   bytes u16s = 16;
>   bytes s16s = 17;

Since S4/U4 underlying type is a [single](https://pypi.org/project/ml-dtypes/#:~:text=exponent%20is%200-,int4%20and%20uint4,-4%2Dbit%20integer) byte, endian conversion is not needed for S4/U4 literal types.
Hence removing endian conversion for S4/U4 integer literals types.
> using u4 = ml_dtypes::uint4;
> using s4 = ml_dtypes::int4;

After these changes, `//tensorflow/compiler/xla:literal_test` test case passes.

These changes do not cause any regressions on existing test cases and it won't affect LE machines.