### PR TITLE
[ppc64le] Add hh_vsx deps for highwayhash_dynamic

### DIFF
--- a/third_party/highwayhash/highwayhash.BUILD
+++ b/third_party/highwayhash/highwayhash.BUILD
@@ -286,6 +286,7 @@ cc_library(
         ":hh_portable",
         ":hh_types",
     ] + select({
+        ":cpu_ppc": [":hh_vsx"],
         ":cpu_aarch64": [":hh_neon"],
         "//conditions:default": [
             ":hh_avx2",


### PR DESCRIPTION
Building Tensorflow 2.15.0 for ppc64le failed with error like [a]. With this change I was able to fix this build issue.

[a]
```
# Execution platform: @local_execution_config_platform//:platform
ERROR: <path>/tensorflow-2.15.0/tensorflow/cc/BUILD:675:22: Linking tensorflow/cc/ops/user_ops_gen_cc [for tool] failed: (Exit 1): gcc failed: err
...
...
# Execution platform: @local_execution_config_platform//:platform
<gcc>/bin/ld: bazel-out/ppc-opt-exec-50AE0418/bin/_solib_ppc/_U_S_Stensorflow_Scc_Cops_Suser_Uops_Ugen_Ucc___Utensorflow/libtensorflow_framework.so.2: undefined reference to `highwayhash::HighwayHashCat<8u>::operator()(unsigned long const (&) [4], highwayhash::StringView const*, unsigned long, unsigned long*) const'
<gcc>/bin/ld: bazel-out/ppc-opt-exec-50AE0418/bin/_solib_ppc/_U_S_Stensorflow_Scc_Cops_Suser_Uops_Ugen_Ucc___Utensorflow/libtensorflow_framework.so.2: undefined reference to `highwayhash::HighwayHash<8u>::operator()(unsigned long const (&) [4], char const*, unsigned long, unsigned long*) const'
collect2: error: ld returned 1 exit status
Target //tensorflow/tools/pip_package:build_pip_package failed to build
```