### PR TITLE
lite: add tensorflowlite_flex to minimal example

### DIFF
--- a/tensorflow/lite/examples/minimal/CMakeLists.txt
+++ b/tensorflow/lite/examples/minimal/CMakeLists.txt
@@ -19,6 +19,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(minimal C CXX)
 
+option(LINK_TFLITE_FLEX "Enable tensorflowlite_flex library linkage" OFF)
+
 set(TENSORFLOW_SOURCE_DIR "" CACHE PATH
   "Directory that contains the TensorFlow project"
 )
@@ -39,6 +41,20 @@ set(CMAKE_CXX_STANDARD 17)
 add_executable(minimal
   minimal.cc
 )
-target_link_libraries(minimal
-  tensorflow-lite
-)
+
+if(LINK_TFLITE_FLEX)
+  find_library(TF_LIB_FLEX tensorflowlite_flex HINTS "${TENSORFLOW_SOURCE_DIR}/bazel-bin/tensorflow/lite/delegates/flex/")
+  if(NOT TF_LIB_FLEX)
+    message(FATAL_ERROR "tensorflowlite_flex library not found")
+  endif()
+
+  target_link_libraries(minimal
+    tensorflow-lite
+    -Wl,--no-as-needed # Add --no-as-needed since for some toolchains (e.g. Ubuntu) --as-needed is added by default.
+    ${TF_LIB_FLEX}
+  )
+else()
+  target_link_libraries(minimal
+    tensorflow-lite
+  )
+endif()

--- a/tensorflow/lite/examples/minimal/README.md
+++ b/tensorflow/lite/examples/minimal/README.md
@@ -53,3 +53,23 @@ In the minimal_build directory,
 ```sh
 ./minimal <path/to/tflite/model>
 ```
+
+#### Optional: Link with tensorflowlite_flex library
+
+You may want to link with tensorflowlite_flex library to use TF select Ops in your model.
+
+First tensorflowlite_flex needs to be compiled using bazel in tensorflow_src directory:
+```sh
+bazel build -c opt --cxxopt='--std=c++17' --config=monolithic tensorflow/lite/delegates/flex:tensorflowlite_flex
+```
+
+Then when configuring cmake build ([Step 4](#step-4-create-cmake-build-directory-and-run-cmake-tool)), add the following option:
+
+```sh
+cmake ../tensorflow_src/tensorflow/lite/examples/minimal -DLINK_TFLITE_FLEX="ON"
+```
+
+And build:
+```sh
+cmake --build . -j
+```


### PR DESCRIPTION
add option to link tensorflowlite_flex when building minimal example