### PR TITLE
Register half and bfloat16 support for tf.truncatemod

### DIFF
--- a/tensorflow/core/kernels/cwise_op_mod.cc
+++ b/tensorflow/core/kernels/cwise_op_mod.cc
@@ -19,7 +19,8 @@ namespace tensorflow {
 REGISTER2(BinaryOp, CPU, "Mod", functor::safe_mod, int32, int64_t);
 REGISTER2(BinaryOp, CPU, "Mod", functor::fmod, float, double);
 REGISTER2(BinaryOp, CPU, "TruncateMod", functor::safe_mod, int32, int64_t);
-REGISTER2(BinaryOp, CPU, "TruncateMod", functor::fmod, float, double);
+REGISTER4(BinaryOp, CPU, "TruncateMod", functor::fmod, Eigen::half,
+          bfloat16, float, double);
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 // A special GPU kernel for int32.


### PR DESCRIPTION
As per documentation of `tf.truncatemod` this Op should support `{int32, int64, bfloat16, half, float, double}` dtypes. But actually this Op not supporting `half` and `bfloat16` dtypes.

As per `math_ops.cc `this op registered for the dtypes below.

https://github.com/tensorflow/tensorflow/blob/74866075411bd9444246e16a79429b852e4db31c/tensorflow/core/ops/math_ops.cc#L622-L626.

But in kernel registry not found for `half` and `bfloat16` dtypes. Hence adding these types into register hoping `functor::fmod` can handle these dtypes.

May Fix #62070 