### PR TITLE
validate axis argument of tf.squeeze

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4528,6 +4528,8 @@ def squeeze(input, axis=None, name=None, squeeze_dims=None):
                                                 squeeze_dims)
   if np.isscalar(axis):
     axis = [axis]
+  if type(axis) != list:
+    raise ValueError("Argument `axis` must be an `int` or a `list` of ints.")
   return gen_array_ops.squeeze(input, axis, name)
 
 


### PR DESCRIPTION
In current implementation of `tf.squeeze`, if we pass a tensor for `axis` argument it will raise error like below, which is not inferable.

`MemoryError: std::bad_alloc`

This is due to the reason that the `Squeeze` Op expects `axis` as a `list` and there is no check for this in C++ level. Hence I am adding a validation check at Python level itself.

Attached [gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/06d4e539682780b4326a4f75f654a29e/62504.ipynb#scrollTo=NeGfeG5Jnhfn) also for reference.

Might fix #62504.