### PR TITLE
[ROCM] activated bfloat16 tests for rocm platform

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4267,7 +4267,6 @@ tf_kernel_library(
     deps = NN_DEPS + [
         ":cast_op",
         ":fill_functor",
-        ":gpu_util_hdrs",
         ":redux_functor",
         ":transpose_functor",
         "//tensorflow/core/util:determinism_for_kernels",
@@ -6477,6 +6476,7 @@ filegroup(
         "fill_empty_rows_functor.h",
         "function_ops.h",
         "fused_batch_norm_op.h",
+        "gpu_utils.h",
         "inplace_ops.cc",
         "inplace_ops_functor.h",
         "l2loss_op.h",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -4267,6 +4267,7 @@ tf_kernel_library(
     deps = NN_DEPS + [
         ":cast_op",
         ":fill_functor",
+        ":gpu_util_hdrs",
         ":redux_functor",
         ":transpose_functor",
         "//tensorflow/core/util:determinism_for_kernels",

--- a/tensorflow/core/kernels/batch_norm_op_test.cc
+++ b/tensorflow/core/kernels/batch_norm_op_test.cc
@@ -29,60 +29,58 @@ limitations under the License.
 
 namespace tensorflow {
 
-class BatchNormOpTest : public OpsTestBase {};
 
-TEST_F(BatchNormOpTest, Simple) {
-  TF_EXPECT_OK(
+template <typename T>
+struct BatchNormOpTest : public OpsTestBase {
+
+  static constexpr auto TValueType = DataTypeToEnum<T>::value;
+
+  void run_me() {
+    TF_EXPECT_OK(
       NodeDefBuilder("batch_norm_op", "BatchNormWithGlobalNormalization")
-          .Input(FakeInput(DT_FLOAT))
-          .Input(FakeInput(DT_FLOAT))
-          .Input(FakeInput(DT_FLOAT))
-          .Input(FakeInput(DT_FLOAT))
-          .Input(FakeInput(DT_FLOAT))
+          .Input(FakeInput(TValueType))
+          .Input(FakeInput(TValueType))
+          .Input(FakeInput(TValueType))
+          .Input(FakeInput(TValueType))
+          .Input(FakeInput(TValueType))
           .Attr("scale_after_normalization", false)
           .Attr("variance_epsilon", 0.001)
           .Finalize(node_def()));
-  TF_EXPECT_OK(InitOpWithGraphVersion(8));
-  AddInputFromArray<float>(TensorShape({1, 1, 6, 2}),
-                           {1, 4, 2, 5, 3, 6, -1, -4, -2, -5, -3, -6});
-  AddInputFromArray<float>(TensorShape({2}), {10, 20});
-  AddInputFromArray<float>(TensorShape({2}), {0.25f, 0.5f});
-  AddInputFromArray<float>(TensorShape({2}), {0.1f, 0.6f});
-  AddInputFromArray<float>(TensorShape({2}), {0.0f, 0.0f});
-  TF_ASSERT_OK(RunOpKernel());
+    TF_EXPECT_OK(InitOpWithGraphVersion(8));
 
-  Tensor expected(allocator(), DT_FLOAT, TensorShape({1, 1, 6, 2}));
-  test::FillValues<float>(
+    AddInputFromList<T>(TensorShape({1, 1, 6, 2}),
+                                {1, 4, 2, 5, 3, 6, -1, -4, -2, -5, -3, -6});
+    AddInputFromList<T>(TensorShape({2}), {10, 20});
+    AddInputFromList<T>(TensorShape({2}), {0.25, 0.5});
+    AddInputFromList<T>(TensorShape({2}), {0.1, 0.6});
+    AddInputFromList<T>(TensorShape({2}), {0.0, 0.0});
+
+    TF_ASSERT_OK(RunOpKernel());
+
+    double atol = TValueType == DT_FLOAT ? 0.01 : 0.1;
+
+    Tensor expected(allocator(), TValueType, TensorShape({1, 1, 6, 2}));
+    test::FillValues<T>(
       &expected, {-17.86f, -22.00f, -15.87f, -20.59f, -13.87f, -19.18f, -21.86f,
                   -33.31f, -23.85f, -34.72f, -25.85f, -36.13f});
-  test::ExpectTensorNear<float>(expected, *GetOutput(0), 0.01);
+    test::ExpectTensorNear<T>(expected, *GetOutput(0), atol);
+  }
+};
+
+TYPED_TEST_SUITE_P(BatchNormOpTest);
+
+TYPED_TEST_P(BatchNormOpTest, Simple) {
+  this->run_me();
 }
 
-TEST_F(BatchNormOpTest, Fp16) {
-  TF_EXPECT_OK(
-      NodeDefBuilder("batch_norm_op", "BatchNormWithGlobalNormalization")
-          .Input(FakeInput(DT_HALF))
-          .Input(FakeInput(DT_HALF))
-          .Input(FakeInput(DT_HALF))
-          .Input(FakeInput(DT_HALF))
-          .Input(FakeInput(DT_HALF))
-          .Attr("scale_after_normalization", false)
-          .Attr("variance_epsilon", 0.001)
-          .Finalize(node_def()));
-  TF_EXPECT_OK(InitOpWithGraphVersion(8));
-  AddInputFromList<Eigen::half>(TensorShape({1, 1, 6, 2}),
-                                {1, 4, 2, 5, 3, 6, -1, -4, -2, -5, -3, -6});
-  AddInputFromList<Eigen::half>(TensorShape({2}), {10, 20});
-  AddInputFromList<Eigen::half>(TensorShape({2}), {0.25, 0.5});
-  AddInputFromList<Eigen::half>(TensorShape({2}), {0.1, 0.6});
-  AddInputFromList<Eigen::half>(TensorShape({2}), {0.0, 0.0});
-  TF_ASSERT_OK(RunOpKernel());
+REGISTER_TYPED_TEST_SUITE_P(BatchNormOpTest,
+                            Simple);
 
-  Tensor expected(allocator(), DT_HALF, TensorShape({1, 1, 6, 2}));
-  test::FillValues<Eigen::half>(
-      &expected, {-17.86, -22.00, -15.87, -20.59, -13.87, -19.18, -21.86,
-                  -33.31, -23.85, -34.72, -25.85, -36.13});
-  test::ExpectTensorNear<Eigen::half>(expected, *GetOutput(0), 0.1);
-}
+// TODO(ezhulenev): Add support for more data types.
+using DataTypes = ::testing::Types<float, Eigen::half>;//, Eigen::bfloat16>;
+INSTANTIATE_TYPED_TEST_SUITE_P(Test, BatchNormOpTest,
+                               DataTypes);
+
+
 
 }  // namespace tensorflow

--- a/tensorflow/core/kernels/batch_norm_op_test.cc
+++ b/tensorflow/core/kernels/batch_norm_op_test.cc
@@ -77,7 +77,7 @@ REGISTER_TYPED_TEST_SUITE_P(BatchNormOpTest,
                             Simple);
 
 // TODO(ezhulenev): Add support for more data types.
-using DataTypes = ::testing::Types<float, Eigen::half>;//, Eigen::bfloat16>;
+using DataTypes = ::testing::Types<float, Eigen::half>;
 INSTANTIATE_TYPED_TEST_SUITE_P(Test, BatchNormOpTest,
                                DataTypes);
 

--- a/tensorflow/core/kernels/conv_grad_filter_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops_3d.cc
@@ -702,7 +702,7 @@ void LaunchConvBackpropFilterOpImpl(
   OP_REQUIRES(context, stream, errors::Internal("No GPU stream available."));
 
   if (DataTypeToEnum<T>::value == DT_BFLOAT16 &&
-        IsBF16NotSupportedInOps(stream)) {
+        !IsBF16SupportedInOps(stream)) {
     context->SetStatus(errors::Unimplemented(
         "Conv3DBackpropFilter for GPU with bfloat16 is only supported "
         "with cuDNN on Ampere GPUs or later."));
@@ -1002,7 +1002,7 @@ struct LaunchConvBackpropFilterOp<Eigen::bfloat16> {
       
       auto* stream = ctx->op_device_context()->stream();
 
-      const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+      const bool cast_to_float = !IsBF16SupportedInOps(stream);
 
       if (cast_to_float) {
       Tensor casted_input = input;

--- a/tensorflow/core/kernels/conv_grad_filter_ops_launcher.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops_launcher.cc
@@ -539,11 +539,9 @@ operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
            const Padding& padding,
            const std::vector<int64_t>& explicit_paddings,
            Tensor* filter_backprop, TensorFormat data_format) {
-  // Performant bfloat16 operations are supported for Ampere+ GPUs. For
-  // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
+  
   auto* stream = ctx->op_device_context()->stream();
-  const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
-      se::CudaComputeCapability::AMPERE);
+  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
 
   if (cast_to_float) {
     Tensor casted_input = input;

--- a/tensorflow/core/kernels/conv_grad_filter_ops_launcher.cc
+++ b/tensorflow/core/kernels/conv_grad_filter_ops_launcher.cc
@@ -541,7 +541,7 @@ operator()(OpKernelContext* ctx, bool use_cudnn, bool cudnn_use_autotune,
            Tensor* filter_backprop, TensorFormat data_format) {
   
   auto* stream = ctx->op_device_context()->stream();
-  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+  const bool cast_to_float = !IsBF16SupportedInOps(stream);
 
   if (cast_to_float) {
     Tensor casted_input = input;

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -463,11 +463,9 @@ void LaunchConv2DBackpropInputOp<GPUDevice, Eigen::bfloat16>::operator()(
     int col_dilation, int row_stride, int col_stride, const Padding& padding,
     const std::vector<int64_t>& explicit_paddings, Tensor* in_backprop,
     TensorFormat data_format) {
-  // Performant bfloat16 operations are supported for Ampere+ GPUs. For
-  // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
+
   auto* stream = ctx->op_device_context()->stream();
-  const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
-      se::CudaComputeCapability::AMPERE);
+  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
 
   if (cast_to_float) {
     Tensor casted_out_backprop = out_backprop;

--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -465,7 +465,7 @@ void LaunchConv2DBackpropInputOp<GPUDevice, Eigen::bfloat16>::operator()(
     TensorFormat data_format) {
 
   auto* stream = ctx->op_device_context()->stream();
-  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+  const bool cast_to_float = !IsBF16SupportedInOps(stream);
 
   if (cast_to_float) {
     Tensor casted_out_backprop = out_backprop;

--- a/tensorflow/core/kernels/conv_grad_input_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops_3d.cc
@@ -1025,11 +1025,8 @@ struct LaunchConvBackpropInputOp<Eigen::bfloat16> {
                      const std::vector<int32>& dilation,
                      const std::vector<int32>& strides, const Padding& padding,
                      Tensor* in_backprop, TensorFormat data_format) {
-    // Performant bfloat16 operations are supported for Ampere+ GPUs. For
-    // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
-    auto* stream = ctx->op_device_context()->stream();
-    const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
-        se::CudaComputeCapability::AMPERE);
+    auto* stream = context->op_device_context()->stream();
+    const bool cast_to_float = IsBF16NotSupportedInOps(stream);
 
     if (cast_to_float) {
       Tensor casted_out_backprop = out_backprop;

--- a/tensorflow/core/kernels/conv_grad_input_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops_3d.cc
@@ -1026,7 +1026,7 @@ struct LaunchConvBackpropInputOp<Eigen::bfloat16> {
                      const std::vector<int32>& strides, const Padding& padding,
                      Tensor* in_backprop, TensorFormat data_format) {
     auto* stream = ctx->op_device_context()->stream();
-    const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+    const bool cast_to_float = !IsBF16SupportedInOps(stream);
 
     if (cast_to_float) {
       Tensor casted_out_backprop = out_backprop;

--- a/tensorflow/core/kernels/conv_grad_input_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops_3d.cc
@@ -1025,7 +1025,7 @@ struct LaunchConvBackpropInputOp<Eigen::bfloat16> {
                      const std::vector<int32>& dilation,
                      const std::vector<int32>& strides, const Padding& padding,
                      Tensor* in_backprop, TensorFormat data_format) {
-    auto* stream = context->op_device_context()->stream();
+    auto* stream = ctx->op_device_context()->stream();
     const bool cast_to_float = IsBF16NotSupportedInOps(stream);
 
     if (cast_to_float) {

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -229,7 +229,7 @@ struct LaunchConv3DOp<GPUDevice, Eigen::bfloat16> {
                                                     dilations.end());
 
     auto* stream = ctx->op_device_context()->stream();
-    const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+    const bool cast_to_float = !IsBF16SupportedInOps(stream);
 
     if (cast_to_float) {
       Tensor casted_input = input_param;

--- a/tensorflow/core/kernels/conv_ops_3d.cc
+++ b/tensorflow/core/kernels/conv_ops_3d.cc
@@ -227,11 +227,9 @@ struct LaunchConv3DOp<GPUDevice, Eigen::bfloat16> {
                                                   strides.end());
     gtl::InlinedVector<int64_t, 3> casted_dilations(dilations.begin(),
                                                     dilations.end());
-    // Performant bfloat16 operations are supported for Ampere+ GPUs. For
-    // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
+
     auto* stream = ctx->op_device_context()->stream();
-    const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
-        se::CudaComputeCapability::AMPERE);
+    const bool cast_to_float = IsBF16NotSupportedInOps(stream);
 
     if (cast_to_float) {
       Tensor casted_input = input_param;

--- a/tensorflow/core/kernels/conv_ops_bfloat16.cc
+++ b/tensorflow/core/kernels/conv_ops_bfloat16.cc
@@ -118,11 +118,8 @@ void LaunchConvOp<GPUDevice, Eigen::bfloat16>::operator()(
     dilations_spatial[i] =
         GetTensorDim(dilations, data_format, static_cast<char>(i + '0'));
   }
-  // Performant bfloat16 operations are supported for Ampere+ GPUs. For
-  // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
   auto* stream = context->op_device_context()->stream();
-  const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
-      se::CudaComputeCapability::AMPERE);
+  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
 
   if (cast_to_float) {
     Tensor casted_input = input;
@@ -173,11 +170,8 @@ void LaunchConv2DOp<GPUDevice, Eigen::bfloat16>::operator()(
   gtl::InlinedVector<int64_t, 3> casted_dilations = {row_dilation,
                                                      col_dilation};
 
-  // Performant bfloat16 operations are supported for Ampere+ GPUs. For
-  // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
   auto* stream = ctx->op_device_context()->stream();
-  const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
-      se::CudaComputeCapability::AMPERE);
+  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
 
   if (cast_to_float) {
     Tensor casted_input = input_param;

--- a/tensorflow/core/kernels/conv_ops_bfloat16.cc
+++ b/tensorflow/core/kernels/conv_ops_bfloat16.cc
@@ -119,7 +119,7 @@ void LaunchConvOp<GPUDevice, Eigen::bfloat16>::operator()(
         GetTensorDim(dilations, data_format, static_cast<char>(i + '0'));
   }
   auto* stream = context->op_device_context()->stream();
-  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+  const bool cast_to_float = !IsBF16SupportedInOps(stream);
 
   if (cast_to_float) {
     Tensor casted_input = input;
@@ -171,7 +171,7 @@ void LaunchConv2DOp<GPUDevice, Eigen::bfloat16>::operator()(
                                                      col_dilation};
 
   auto* stream = ctx->op_device_context()->stream();
-  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+  const bool cast_to_float = !IsBF16SupportedInOps(stream);
 
   if (cast_to_float) {
     Tensor casted_input = input_param;

--- a/tensorflow/core/kernels/cudnn_pooling_gpu.cc
+++ b/tensorflow/core/kernels/cudnn_pooling_gpu.cc
@@ -149,11 +149,10 @@ void DnnPooling3dOp<Eigen::bfloat16>::Compute(
     const std::array<int64_t, 3>& window, const std::array<int64_t, 3>& stride,
     const std::array<int64_t, 3>& padding, TensorFormat data_format,
     const Tensor& tensor_in, Tensor* output) {
-  // Performant bfloat16 operations are supported for Ampere+ GPUs. For
-  // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
+
   auto* stream = context->op_device_context()->stream();
-  const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
-      se::CudaComputeCapability::AMPERE);
+  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+  
   if (cast_to_float) {
     Tensor casted_in;
     Tensor casted_output;
@@ -348,11 +347,9 @@ void DnnPooling3dGradOp<Eigen::bfloat16>::Compute(
     const std::array<int64_t, 3>& output_size, TensorFormat data_format,
     const Tensor& out_backprop, const TensorShape& tensor_in_shape,
     const Tensor* tensor_in, const Tensor* tensor_out, Tensor* input_backprop) {
-  // Performant bfloat16 operations are supported for Ampere+ GPUs. For
-  // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
+  
   auto* stream = context->op_device_context()->stream();
-  const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
-      se::CudaComputeCapability::AMPERE);
+  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
   if (cast_to_float) {
     Tensor casted_out_backprop;
     Tensor casted_tensor_in;

--- a/tensorflow/core/kernels/cudnn_pooling_gpu.cc
+++ b/tensorflow/core/kernels/cudnn_pooling_gpu.cc
@@ -151,7 +151,7 @@ void DnnPooling3dOp<Eigen::bfloat16>::Compute(
     const Tensor& tensor_in, Tensor* output) {
 
   auto* stream = context->op_device_context()->stream();
-  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+  const bool cast_to_float = !IsBF16SupportedInOps(stream);
   
   if (cast_to_float) {
     Tensor casted_in;
@@ -349,7 +349,7 @@ void DnnPooling3dGradOp<Eigen::bfloat16>::Compute(
     const Tensor* tensor_in, const Tensor* tensor_out, Tensor* input_backprop) {
   
   auto* stream = context->op_device_context()->stream();
-  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+  const bool cast_to_float = !IsBF16SupportedInOps(stream);
   if (cast_to_float) {
     Tensor casted_out_backprop;
     Tensor casted_tensor_in;

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -58,16 +58,12 @@ typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
 
 bool UseCudnnWith16BitFloat(OpKernelContext* ctx, DataType dtype) {
-#if GOOGLE_CUDA
   if (dtype == DT_HALF) {
     return true;
   } else if (dtype == DT_BFLOAT16) {
     auto* stream = ctx->op_device_context()->stream();
-    if (!stream) return false;
-    return stream->GetCudaComputeCapability().IsAtLeast(
-        se::CudaComputeCapability::AMPERE);
+    return !IsBF16NotSupportedInOps(stream);
   }
-#endif
   return false;
 }
 

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -58,12 +58,14 @@ typedef Eigen::ThreadPoolDevice CPUDevice;
 typedef Eigen::GpuDevice GPUDevice;
 
 bool UseCudnnWith16BitFloat(OpKernelContext* ctx, DataType dtype) {
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   if (dtype == DT_HALF) {
     return true;
   } else if (dtype == DT_BFLOAT16) {
     auto* stream = ctx->op_device_context()->stream();
     return IsBF16SupportedInOps(stream);
   }
+#endif // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
   return false;
 }
 

--- a/tensorflow/core/kernels/depthwise_conv_op.cc
+++ b/tensorflow/core/kernels/depthwise_conv_op.cc
@@ -62,7 +62,7 @@ bool UseCudnnWith16BitFloat(OpKernelContext* ctx, DataType dtype) {
     return true;
   } else if (dtype == DT_BFLOAT16) {
     auto* stream = ctx->op_device_context()->stream();
-    return !IsBF16NotSupportedInOps(stream);
+    return IsBF16SupportedInOps(stream);
   }
   return false;
 }

--- a/tensorflow/core/kernels/fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #endif  // GOOGLE_CUDA
 
 #include "tensorflow/core/kernels/conv_2d.h"
+#include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/platform/stream_executor.h"
 #include "tensorflow/core/util/stream_executor_util.h"
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
@@ -34,7 +35,6 @@ limitations under the License.
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/tensor_types.h"
-#include "tensorflow/core/kernels/gpu_utils.h"
 #include "tensorflow/core/kernels/cast_op.h"
 #include "tensorflow/core/kernels/fill_functor.h"
 #include "tensorflow/core/kernels/fused_batch_norm_op.h"

--- a/tensorflow/core/kernels/fused_batch_norm_op.cc
+++ b/tensorflow/core/kernels/fused_batch_norm_op.cc
@@ -1048,7 +1048,7 @@ struct FusedBatchNorm<GPUDevice, Eigen::bfloat16, float, is_training> {
                   bool use_reserved_space) {
     
     auto* stream = context->op_device_context()->stream();
-    const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+    const bool cast_to_float = !IsBF16SupportedInOps(stream);
     
     if (cast_to_float) {
       Tensor casted_x = x;
@@ -1313,7 +1313,7 @@ struct FusedBatchNormGrad<GPUDevice, Eigen::bfloat16, float> {
                   bool use_reserved_space, TensorFormat tensor_format) {
     
     auto* stream = context->op_device_context()->stream();
-    const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+    const bool cast_to_float = !IsBF16SupportedInOps(stream);
     if (cast_to_float) {
       Tensor casted_y_backprop = y_backprop;
       Tensor casted_x = x;

--- a/tensorflow/core/kernels/gpu_utils.cc
+++ b/tensorflow/core/kernels/gpu_utils.cc
@@ -37,6 +37,20 @@ using xla::AutotuningLog;
 using xla::ComputeCapability;
 using xla::CudnnVersion;
 
+bool IsBF16NotSupportedInOps(se::Stream *stream) {
+  if (!stream) {
+    return true;  // no stream: don't know whether it's supported
+  }
+#if GOOGLE_CUDA  
+// Performant bfloat16 operations are supported for Ampere+ GPUs. For
+// pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
+  return !stream->GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::AMPERE);  
+#elif TENSORFLOW_USE_ROCM
+  return true;  // so far, we return true meaning that the conversion to float is needed
+#endif
+}
+
 bool RedzoneCheckDisabled() {
   const char* disable_rz_str = std::getenv("TF_DISABLE_RZ_CHECK");
   return disable_rz_str != nullptr && std::strcmp(disable_rz_str, "1") == 0;

--- a/tensorflow/core/kernels/gpu_utils.cc
+++ b/tensorflow/core/kernels/gpu_utils.cc
@@ -37,7 +37,7 @@ using xla::AutotuningLog;
 using xla::ComputeCapability;
 using xla::CudnnVersion;
 
-bool IsBF16NotSupportedInOps(se::Stream *stream) {
+bool IsBF16SupportedInOps(se::Stream *stream) {
   if (!stream) {
     return true;  // no stream: don't know whether it's supported
   }
@@ -47,7 +47,8 @@ bool IsBF16NotSupportedInOps(se::Stream *stream) {
   return !stream->GetCudaComputeCapability().IsAtLeast(
           se::CudaComputeCapability::AMPERE);  
 #elif TENSORFLOW_USE_ROCM
-  return true;  // so far, we return true meaning that the conversion to float is needed
+  // So far, we return true meaning that the conversion to float is needed.
+  return true;
 #endif
 }
 

--- a/tensorflow/core/kernels/gpu_utils.cc
+++ b/tensorflow/core/kernels/gpu_utils.cc
@@ -39,16 +39,16 @@ using xla::CudnnVersion;
 
 bool IsBF16SupportedInOps(se::Stream *stream) {
   if (!stream) {
-    return true;  // no stream: don't know whether it's supported
+    return false;  // No stream: don't know whether it's supported.
   }
 #if GOOGLE_CUDA  
 // Performant bfloat16 operations are supported for Ampere+ GPUs. For
 // pre-Ampere GPUs, we cast inputs to float and outputs back to bfloat16.
-  return !stream->GetCudaComputeCapability().IsAtLeast(
-          se::CudaComputeCapability::AMPERE);  
+  return stream->GetCudaComputeCapability().IsAtLeast(
+          se::CudaComputeCapability::AMPERE);
 #elif TENSORFLOW_USE_ROCM
-  // So far, we return true meaning that the conversion to float is needed.
-  return true;
+  // So far, we return false meaning that the conversion to float is needed.
+  return false;
 #endif
 }
 

--- a/tensorflow/core/kernels/gpu_utils.h
+++ b/tensorflow/core/kernels/gpu_utils.h
@@ -42,6 +42,10 @@ class AutotuneResult;
 
 namespace tensorflow {
 
+// returns true if bfloat16 is not directly supported in Ops and inputs shall be
+// casted to floats to perform the computations and then back
+bool IsBF16NotSupportedInOps(se::Stream *stream);
+
 class NodeDef;
 using xla::AutotuneResult;
 

--- a/tensorflow/core/kernels/gpu_utils.h
+++ b/tensorflow/core/kernels/gpu_utils.h
@@ -42,9 +42,9 @@ class AutotuneResult;
 
 namespace tensorflow {
 
-// returns true if bfloat16 is not directly supported in Ops and inputs shall be
-// casted to floats to perform the computations and then back
-bool IsBF16NotSupportedInOps(se::Stream *stream);
+// Returns true if bfloat16 is directly supported in Ops and inputs shall not be
+// casted to floats to perform the computations and then back.
+bool IsBF16SupportedInOps(se::Stream *stream);
 
 class NodeDef;
 using xla::AutotuneResult;

--- a/tensorflow/core/kernels/matmul_util.cc
+++ b/tensorflow/core/kernels/matmul_util.cc
@@ -166,6 +166,8 @@ StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
         .beta = 0.0,
         .compute_precision = se::blas::kDefaultComputePrecision,
         .algorithm = {},
+        .grad_x = false,
+        .grad_y = false,
         .compute_type = computation_type,
     };
 

--- a/tensorflow/core/kernels/pooling_ops_common.cc
+++ b/tensorflow/core/kernels/pooling_ops_common.cc
@@ -462,8 +462,7 @@ void DnnPoolingOp<Eigen::bfloat16>::Compute(
                  context->allocate_output(0, tensor_out_shape, &tensor_out));
 
   auto* stream = context->op_device_context()->stream();
-  const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
-      se::CudaComputeCapability::AMPERE);
+  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
   if (cast_to_float) {
     Tensor casted_tensor_in;
     Tensor casted_tensor_out;
@@ -876,8 +875,7 @@ void DnnPoolingGradOp<Eigen::bfloat16>::Compute(
   OP_REQUIRES_OK(context,
                  context->allocate_output(0, tensor_in_shape, &input_backprop));
   auto* stream = context->op_device_context()->stream();
-  const bool cast_to_float = !stream->GetCudaComputeCapability().IsAtLeast(
-      se::CudaComputeCapability::AMPERE);
+  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
   if (cast_to_float) {
     Tensor casted_tensor_in;
     Tensor casted_tensor_out;

--- a/tensorflow/core/kernels/pooling_ops_common.cc
+++ b/tensorflow/core/kernels/pooling_ops_common.cc
@@ -462,7 +462,7 @@ void DnnPoolingOp<Eigen::bfloat16>::Compute(
                  context->allocate_output(0, tensor_out_shape, &tensor_out));
 
   auto* stream = context->op_device_context()->stream();
-  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+  const bool cast_to_float = !IsBF16SupportedInOps(stream);
   if (cast_to_float) {
     Tensor casted_tensor_in;
     Tensor casted_tensor_out;
@@ -875,7 +875,7 @@ void DnnPoolingGradOp<Eigen::bfloat16>::Compute(
   OP_REQUIRES_OK(context,
                  context->allocate_output(0, tensor_in_shape, &input_backprop));
   auto* stream = context->op_device_context()->stream();
-  const bool cast_to_float = IsBF16NotSupportedInOps(stream);
+  const bool cast_to_float = !IsBF16SupportedInOps(stream);
   if (cast_to_float) {
     Tensor casted_tensor_in;
     Tensor casted_tensor_out;

--- a/tensorflow/core/kernels/topk_op_gpu.h
+++ b/tensorflow/core/kernels/topk_op_gpu.h
@@ -483,25 +483,16 @@ Status LaunchSortKernel(OpKernelContext* ctx, const T* input, int num_rows,
 
   bool ran_nonsegmented_version = false;
   if (num_rows == 1) {
-#if GOOGLE_CUDA
-    constexpr bool is_supported = true;
-#else
-    // GpuRadixSortDescending is not supported on ROCm for fp16/bf16.
-    constexpr bool is_supported = !std::is_same<T, Eigen::half>::value &&
-                                  !std::is_same<T, Eigen::bfloat16>::value;
-#endif
-    if constexpr (is_supported) {
-      // Note: DeviceSegmentedRadixSort is very slow when num_segments=1 because
-      // it only uses 1 SM per segment. Calling the un-segmented version is much
-      // faster in this case.
-      TF_RETURN_IF_ERROR(
+    // Note: DeviceSegmentedRadixSort is very slow when num_segments=1 because
+    // it only uses 1 SM per segment. Calling the un-segmented version is much
+    // faster in this case.
+    TF_RETURN_IF_ERROR(
           GpuRadixSortDescending(ctx, num_cols, /*keys_in=*/input,
                                  /*keys_out=*/sorted_values_ptr,
                                  /*indices_in=*/input_indices_t.data(),
                                  /*indices_out=*/sorted_indices_ptr,
                                  /*num_bits=*/sizeof(T) * 8));
-      ran_nonsegmented_version = true;
-    }
+    ran_nonsegmented_version = true;
   }
   if (!ran_nonsegmented_version) {
     auto err = gpuprim::DeviceSegmentedRadixSort::SortPairsDescending(

--- a/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv_ops_test.py
@@ -460,7 +460,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
       op_name,
       rtol=1e-4,
   ):
-    if use_gpu and not test.is_gpu_available(cuda_only=True):
+    if use_gpu and not test.is_gpu_available():
       self.skipTest("GPU not available")
     expected_results = []
     computed_results = []
@@ -520,7 +520,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
                     gpu_only=False,
                     test_grappler_layout_optimizer=False,
                     tol=1e-5):
-    if gpu_only and not test.is_gpu_available(cuda_only=True):
+    if gpu_only and not test.is_gpu_available():
       return
     tensors = []
     dilations = list(dilations)
@@ -577,7 +577,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
       test_grappler_layout_optimizer=False,
       tol=1e-5,
   ):
-    if (gpu_only and not use_gpu) or not test.is_gpu_available(cuda_only=True):
+    if (gpu_only and not use_gpu) or not test.is_gpu_available(): 
       self.skipTest("GPU not available")
     if (
         test_grappler_layout_optimizer or data_format != "NHWC"
@@ -1330,8 +1330,11 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
           results[0], results[1], atol=tol_to_use, rtol=tol_to_use)
 
   @test_util.run_in_graph_and_eager_modes
+  @test.disable_with_predicate(
+      pred=test.is_built_with_rocm,
+      skip_message='MIOpen does not support group conv yet!')
   def testConv2DGroupConvFwd(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    if test.is_gpu_available() or test_util.IsMklEnabled():
       data_formats = ["NHWC", "NCHW"]
     else:
       data_formats = ["NHWC"]
@@ -1347,7 +1350,10 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
                                      dtype=dtypes.float32)
 
   @test_util.deprecated_graph_mode_only
-  @test_util.run_cuda_only
+  @test_util.run_gpu_only
+  @test.disable_with_predicate(
+      pred=test.is_built_with_rocm,
+      skip_message='MIOpen does not support group conv yet!')
   def testInputGradientGroupConv(self):
     for data_format in ["NCHW", "NHWC"]:
       for test_input in [True, False]:
@@ -1369,7 +1375,10 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
             max_err=0.005)
 
   @test_util.deprecated_graph_mode_only
-  @test_util.run_cuda_only
+  @test_util.run_gpu_only
+  @test.disable_with_predicate(
+      pred=test.is_built_with_rocm,
+      skip_message='MIOpen does not support group conv yet!')
   def testFilterGradientGroupConv(self):
     for data_format in ["NCHW", "NHWC"]:
       for test_input in [True, False]:
@@ -1407,7 +1416,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
                                  use_gpu,
                                  err,
                                  dilations=(1, 1)):
-    if use_gpu and not test.is_gpu_available(cuda_only=True):
+    if use_gpu and not test.is_gpu_available():
       return
     x1 = self._CreateNumpyTensor(filter_sizes)
     x2 = self._CreateNumpyTensor(output_sizes)
@@ -1893,7 +1902,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
 
   @test_util.deprecated_graph_mode_only
   def testConv2D2x2Depth3ValidBackpropFilterStride1x1Dilation2x1(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    if test.is_gpu_available() or test_util.IsMklEnabled():
       for (data_format, use_gpu) in GetTestConfigs():
         self._RunAndVerifyBackpropFilterDilation(
             input_sizes=[1, 3, 6, 1],
@@ -1908,7 +1917,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
 
   @test_util.deprecated_graph_mode_only
   def testConv2D2x2Depth1ValidBackpropFilterDilation1x2(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    if test.is_gpu_available() or test_util.IsMklEnabled():
       for (data_format, use_gpu) in GetTestConfigs():
         self._RunAndVerifyBackpropFilterDilation(
             input_sizes=[1, 2, 3, 1],
@@ -1923,7 +1932,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
 
   @test_util.deprecated_graph_mode_only
   def testConv2DEmptyBackpropFilterDilation1x2(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    if test.is_gpu_available() or test_util.IsMklEnabled():
       for (data_format, use_gpu) in GetTestConfigs():
         self._RunAndVerifyBackpropFilterDilation(
             input_sizes=[1, 2, 3, 1],
@@ -1938,7 +1947,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
 
   @test_util.deprecated_graph_mode_only
   def testConv2D2x2Depth3ValidBackpropFilterDilation2x2(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    if test.is_gpu_available() or test_util.IsMklEnabled():
       for (data_format, use_gpu) in GetTestConfigs():
         self._RunAndVerifyBackpropFilterDilation(
             input_sizes=[1, 3, 4, 3],
@@ -1953,7 +1962,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
 
   @test_util.deprecated_graph_mode_only
   def testConv2DKernelSizeMatchesInputSizeBackpropFilterDilation2x2(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    if test.is_gpu_available() or test_util.IsMklEnabled():
       for (data_format, use_gpu) in GetTestConfigs():
         self._RunAndVerifyBackpropFilterDilation(
             input_sizes=[1, 3, 3, 1],
@@ -1968,7 +1977,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
 
   @test_util.deprecated_graph_mode_only
   def testConv2D2x2Depth3ValidBackpropInputStride1x1Dilation2x1(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    if test.is_gpu_available() or test_util.IsMklEnabled():
       for (data_format, use_gpu) in GetTestConfigs():
         self._RunAndVerifyBackpropInputDilation(
             input_sizes=[1, 3, 6, 1],
@@ -1983,7 +1992,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
 
   @test_util.deprecated_graph_mode_only
   def testConv2D2x2Depth1ValidBackpropInputDilation1x2(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    if test.is_gpu_available() or test_util.IsMklEnabled():
       for (data_format, use_gpu) in GetTestConfigs():
         self._RunAndVerifyBackpropInputDilation(
             input_sizes=[1, 2, 3, 1],
@@ -1998,7 +2007,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
 
   @test_util.deprecated_graph_mode_only
   def testConv2DEmptyBackpropInputDilation1x2(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    if test.is_gpu_available() or test_util.IsMklEnabled():
       for (data_format, use_gpu) in GetTestConfigs():
         self._RunAndVerifyBackpropInputDilation(
             input_sizes=[0, 2, 3, 1],
@@ -2013,7 +2022,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
 
   @test_util.deprecated_graph_mode_only
   def testConv2D2x2Depth3ValidBackpropInputDilation2x1(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    if test.is_gpu_available() or test_util.IsMklEnabled():
       for (data_format, use_gpu) in GetTestConfigs():
         # The GPU version of this test is not very stable. So adjusting the
         # error threshold to 1e-4.
@@ -2030,7 +2039,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
 
   @test_util.deprecated_graph_mode_only
   def testConv2DKernelSizeMatchesInputSizeBackpropInputDilation2x2(self):
-    if test.is_gpu_available(cuda_only=True) or test_util.IsMklEnabled():
+    if test.is_gpu_available() or test_util.IsMklEnabled():
       for (data_format, use_gpu) in GetTestConfigs():
         self._RunAndVerifyBackpropInputDilation(
             input_sizes=[1, 3, 3, 1],
@@ -2053,7 +2062,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
                                                 use_gpu,
                                                 dilations=(1, 1),
                                                 err=2e-5):
-    if use_gpu and not test.is_gpu_available(cuda_only=True):
+    if use_gpu and not test.is_gpu_available():
       return
     if not use_gpu and dilations != (1, 1):
       return  # Non-default dilations is currently not supported on the CPU.
@@ -2215,7 +2224,7 @@ class Conv2DTest(parameterized.TestCase, test.TestCase):
                                                  use_gpu,
                                                  dilations=(1, 1),
                                                  err=1e-5):
-    if use_gpu and not test.is_gpu_available(cuda_only=True):
+    if use_gpu and not test.is_gpu_available():
       return
     if not use_gpu and dilations != (1, 1):
       return  # Non-default dilations is currently not supported on the CPU.
@@ -3512,7 +3521,6 @@ class DeepConv2DTest(test.TestCase):
 
   def testConv2D3x3FilterStride1x1Same(self):
     self._RunTestCases([1, 1], "SAME")
-
 
 class Conv2DBenchmark(test.Benchmark):
 

--- a/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_base.py
+++ b/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_base.py
@@ -1081,8 +1081,8 @@ class DepthwiseConv2DBase(test.TestCase):
                                   padding, "bfloat16")
       # Convolutions on the ROCm platform don't support double dtype. 
       if not test.is_built_with_rocm():
-        self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
-                                  padding, "float64")
+        self._CompareBackpropFilter(input_size, filter_size, output_size, 
+            stride, padding, "float64")
 
   @test_util.run_gpu_only
   def testDepthwiseConv2DFilterGradExplicitCompare(self):
@@ -1100,8 +1100,8 @@ class DepthwiseConv2DBase(test.TestCase):
                                   padding, "bfloat16")
       # Convolutions on the ROCm platform don't support double dtype. 
       if not test.is_built_with_rocm():
-        self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
-                                  padding, "float64")
+        self._CompareBackpropFilter(input_size, filter_size, output_size, 
+          stride, padding, "float64")
 
   def _CompareForward(self, input_sizes, filter_sizes, output_sizes, stride,
                       padding, dtype):

--- a/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_base.py
+++ b/tensorflow/python/kernel_tests/nn_ops/depthwise_conv_op_base.py
@@ -407,7 +407,7 @@ class DepthwiseConv2DBase(test.TestCase):
         interface_result, np_result, atol=tolerance, rtol=tolerance)
 
   @test_util.run_v1_only("b/120545219")
-  @test_util.run_cuda_only
+  @test_util.run_gpu_only
   def testDepthwiseConv2DCudnn(self):
     for index, (input_size, filter_size, _, stride, padding,
                 dilations) in enumerate(ConfigsToTest()):
@@ -510,10 +510,10 @@ class DepthwiseConv2DBase(test.TestCase):
           "Testing DepthwiseConv2D, %dth config: %r * %r, stride: %d, padding: "
           "%s", index, input_size, filter_size, stride, padding)
       # double datatype is currently not supported for convolution ops
-      # on the ROCm platform and its support for bfloat16 is unknown.
-      data_types = [dtypes.float16, dtypes.float32]
+      # on the ROCm platform 
+      data_types = [dtypes.float16, dtypes.float32, dtypes.bfloat16]
       if not test.is_built_with_rocm():
-        data_types.extend([dtypes.float64, dtypes.bfloat16])
+        data_types.extend([dtypes.float64])
       data_formats = ["NHWC", "NCHW"] if test.is_gpu_available() else ["NHWC"]
       for data_type in data_types:
         for data_format in data_formats:
@@ -736,7 +736,7 @@ class DepthwiseConv2DBase(test.TestCase):
       self.assertLess(err, tolerance)
 
   @test_util.run_v1_only("b/120545219")
-  @test_util.run_cuda_only
+  @test_util.run_gpu_only
   def testDepthwiseConv2DInputGradCudnn(self):
     for index, (input_size, filter_size, output_size, stride, padding,
                 dilations) in enumerate(CheckGradConfigsToTest()):
@@ -832,10 +832,10 @@ class DepthwiseConv2DBase(test.TestCase):
           "stride: %d, padding: %s", index, input_size, filter_size, stride,
           padding)
       # double datatype is currently not supported for convolution ops
-      # on the ROCm platform and its support for bfloat16 is unknown.
-      data_types = [dtypes.float16, dtypes.float32]
+      # on the ROCm platform 
+      data_types = [dtypes.float16, dtypes.float32, dtypes.bfloat16]
       if not test.is_built_with_rocm():
-        data_types.extend([dtypes.float64, dtypes.bfloat16])
+        data_types.extend([dtypes.float64])
       data_formats = ["NHWC", "NCHW"] if test.is_gpu_available() else ["NHWC"]
       for data_type in data_types:
         for data_format in data_formats:
@@ -852,7 +852,7 @@ class DepthwiseConv2DBase(test.TestCase):
               dilations=dilations)
 
   @test_util.run_v1_only("b/120545219")
-  @test_util.run_cuda_only
+  @test_util.run_gpu_only
   def testDepthwiseConv2DFilterGradCudnn(self):
     for index, (input_size, filter_size, output_size, stride, padding,
                 dilations) in enumerate(CheckGradConfigsToTest()):
@@ -945,10 +945,10 @@ class DepthwiseConv2DBase(test.TestCase):
           "stride: %d, padding: %s", index, input_size, filter_size, stride,
           padding)
       # double datatype is currently not supported for convolution ops
-      # on the ROCm platform and its support for bfloat16 is unknown.
-      data_types = [dtypes.float16, dtypes.float32]
+      # on the ROCm platform 
+      data_types = [dtypes.float16, dtypes.float32, dtypes.bfloat16]
       if not test.is_built_with_rocm():
-        data_types.extend([dtypes.float64, dtypes.bfloat16])
+        data_types.extend([dtypes.float64])
       data_formats = ["NHWC", "NCHW"] if test.is_gpu_available() else ["NHWC"]
       for data_type in data_types:
         for data_format in data_formats:
@@ -999,14 +999,13 @@ class DepthwiseConv2DBase(test.TestCase):
           padding)
       self._CompareBackpropInput(input_size, filter_size, output_size, stride,
                                  padding, "float32")
-      # Convolutions on the ROCm platform don't support double dtype. And its
-      # support for bf16 is unknown. So, we skip these tests.
-      if test.is_built_with_rocm():
-        continue
-      self._CompareBackpropInput(input_size, filter_size, output_size, stride,
-                                 padding, "float64")
       self._CompareBackpropInput(input_size, filter_size, output_size, stride,
                                  padding, "bfloat16")
+      # Convolutions on the ROCm platform don't support double dtype. 
+      # So, we skip these tests.
+      if not test.is_built_with_rocm():
+        self._CompareBackpropInput(input_size, filter_size, output_size, stride,
+                                 padding, "float64")
 
   @test_util.run_gpu_only
   def testDepthwiseConv2DInputGradExplicitCompare(self):
@@ -1020,14 +1019,12 @@ class DepthwiseConv2DBase(test.TestCase):
           padding)
       self._CompareBackpropInput(input_size, filter_size, output_size, stride,
                                  padding, "float32")
-      # Convolutions on the ROCm platform don't support double dtype. And its
-      # support for bf16 is unknown. So, we skip these tests.
-      if test.is_built_with_rocm():
-        continue
-      self._CompareBackpropInput(input_size, filter_size, output_size, stride,
-                                 padding, "float64")
       self._CompareBackpropInput(input_size, filter_size, output_size, stride,
                                  padding, "bfloat16")
+      # Convolutions on the ROCm platform don't support double dtype.
+      if not test.is_built_with_rocm():
+        self._CompareBackpropInput(input_size, filter_size, output_size, stride,
+                                 padding, "float64")
 
   def _CompareBackpropFilter(self, input_sizes, filter_sizes, output_sizes,
                              stride, padding, dtype):
@@ -1080,15 +1077,12 @@ class DepthwiseConv2DBase(test.TestCase):
           padding)
       self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
                                   padding, "float32")
-      # Convolutions on the ROCm platform don't support double dtype. And its
-      # support for bf16 is unknown. So, we skip these tests.
-      if test.is_built_with_rocm():
-        continue
-      self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
-                                  padding, "float64")
-
       self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
                                   padding, "bfloat16")
+      # Convolutions on the ROCm platform don't support double dtype. 
+      if not test.is_built_with_rocm():
+        self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
+                                  padding, "float64")
 
   @test_util.run_gpu_only
   def testDepthwiseConv2DFilterGradExplicitCompare(self):
@@ -1102,15 +1096,12 @@ class DepthwiseConv2DBase(test.TestCase):
           padding)
       self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
                                   padding, "float32")
-      # Convolutions on the ROCm platform don't support double dtype. And its
-      # support for bf16 is unknown. So, we skip these tests.
-      if test.is_built_with_rocm():
-        continue
-      self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
-                                  padding, "float64")
-
       self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
                                   padding, "bfloat16")
+      # Convolutions on the ROCm platform don't support double dtype. 
+      if not test.is_built_with_rocm():
+        self._CompareBackpropFilter(input_size, filter_size, output_size, stride,
+                                  padding, "float64")
 
   def _CompareForward(self, input_sizes, filter_sizes, output_sizes, stride,
                       padding, dtype):
@@ -1146,15 +1137,13 @@ class DepthwiseConv2DBase(test.TestCase):
           padding)
       self._CompareForward(input_size, filter_size, output_size, stride,
                            padding, "float32")
-      # Convolutions on the ROCm platform don't support double dtype. And its
-      # support for bf16 is unknown. So, we skip these tests.
-      if test.is_built_with_rocm():
-        continue
-      self._CompareForward(input_size, filter_size, output_size, stride,
-                           padding, "float64")
-
       self._CompareForward(input_size, filter_size, output_size, stride,
                            padding, "bfloat16")
+
+      # Convolutions on the ROCm platform don't support double dtype.
+      if not test.is_built_with_rocm():
+        self._CompareForward(input_size, filter_size, output_size, stride,
+                           padding, "float64")
 
   @test_util.run_gpu_only
   def testDepthwiseConv2DForwardExplicitCompare(self):
@@ -1166,14 +1155,13 @@ class DepthwiseConv2DBase(test.TestCase):
           "Testing DepthwiseConv2DForwardCompare, %dth config: %r * %r, "
           "stride: %d, padding: %s", index, input_size, filter_size, stride,
           padding)
-      # Convolutions on the ROCm platform don't support double dtype. And its
-      # support for bf16 is unknown. So, we skip these tests.
-      if test.is_built_with_rocm():
-        continue
-      self._CompareForward(input_size, filter_size, output_size, stride,
-                           padding, "float64")
+      
       self._CompareForward(input_size, filter_size, output_size, stride,
                            padding, "float32")
-
       self._CompareForward(input_size, filter_size, output_size, stride,
                            padding, "bfloat16")
+
+      # Convolutions on the ROCm platform don't support double dtype.
+      if not test.is_built_with_rocm():
+        self._CompareForward(input_size, filter_size, output_size, stride,
+                           padding, "float64")

--- a/tensorflow/python/ops/BUILD
+++ b/tensorflow/python/ops/BUILD
@@ -3741,7 +3741,7 @@ cuda_py_strict_test(
     main = "nn_fused_batchnorm_test.py",
     python_version = "PY3",
     shard_count = 24,
-    tags = ["no_rocm"],
+    tags = [ ],
     deps = [
         ":array_ops",
         ":gradient_checker",

--- a/tensorflow/python/ops/nn_fused_batchnorm_test.py
+++ b/tensorflow/python/ops/nn_fused_batchnorm_test.py
@@ -406,7 +406,7 @@ class BatchNormalizationTest(test.TestCase):
     else:
       data_format_list = ['NCDHW', 'NDHWC']
     use_gpu_vals = [False]
-    if test.is_gpu_available(cuda_only=True) and not cpu_only:
+    if test.is_gpu_available() and not cpu_only:
       use_gpu_vals += [True]
     factors = [1.0, 0.6]
     for dtype in [np.float16, np.float32, dtypes.bfloat16.as_numpy_dtype]:
@@ -594,7 +594,7 @@ class BatchNormalizationTest(test.TestCase):
       data_format_nhwc, features_nhwc = 'NDHWC', shape[4]
       data_format_nchw, features_nchw = 'NCDHW', shape[1]
     for is_training in [True, False]:
-      if test.is_gpu_available(cuda_only=True):
+      if test.is_gpu_available():
         self._test_grad_grad(
             shape,
             dtype, [features_nhwc],


### PR DESCRIPTION
In this PR, we added a one central function **IsBF16NotSupportedInOps** in tensorflow/core/kernels/gpu_utils.cc to decide whether bfloat16 datatypes are directly supported on the target acrhitecture or not. 
Previously, the similar checks were spread around several files. 
It will facilitate the integration of bfloat16 support to ROCM: currently bfloat16-to-float conversion is always enabled on ROCM.

Besides, we also enabled bfloat16 support in a number of subtests.
Finally, rewrote tensorflow/core/kernels/batch_norm_op_test.cc in a generic form to be able to test it for different number types.


