### PR TITLE
Create 2.15.0.post1 with tensorrt removed from [and-cuda] install

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -47,7 +47,7 @@ from setuptools.dist import Distribution
 # result for pip.
 # Also update tensorflow/tensorflow.bzl and
 # tensorflow/core/public/version.h
-_VERSION = '2.15.0'
+_VERSION = '2.15.0.post1'
 
 
 # We use the same setup.py for all tensorflow_* packages and for the nightly
@@ -175,9 +175,6 @@ EXTRA_PACKAGES['and-cuda'] = [
     'nvidia-cusparse-cu12 == 12.1.2.141',
     'nvidia-nccl-cu12 == 2.16.5',
     'nvidia-nvjitlink-cu12 == 12.2.140',
-    'tensorrt == 8.6.1.post1',
-    'tensorrt-bindings == 8.6.1',
-    'tensorrt-libs == 8.6.1',
 ]
 
 DOCLINES = __doc__.split('\n')


### PR DESCRIPTION
Context: tensorflow[and-cuda]==2.15.0 cannot be installed due to this tensorrt dependency.