### PR TITLE
Correct a mistake in matvec's docstring in math_ops.py

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3884,7 +3884,7 @@ def matvec(a,
   b = tf.constant([7, 9, 11], shape=[3])
 
   # `a` * `b`
-  # [ 58,  64]
+  # [ 58,  139]
   c = tf.linalg.matvec(a, b)
 
 


### PR DESCRIPTION
The example in `matvec`'s docstring was wrongly computed: 64->139