### PR TITLE
Refine link in build_convert.md for including and using models in programs

### DIFF
--- a/tensorflow/lite/g3doc/microcontrollers/build_convert.md
+++ b/tensorflow/lite/g3doc/microcontrollers/build_convert.md
@@ -54,7 +54,7 @@ important to change the array declaration to `const` for better memory
 efficiency on embedded platforms.
 
 For an example of how to include and use a model in your program, see
-[`evaluate_test.cc`](https://github.com/tensorflow/tflite-micro/blob/main/tensorflow/lite/micro/examples/hello_world/evaluate_test.cc)
+[`hello_world_test.cc`](https://github.com/tensorflow/tflite-micro/blob/main/tensorflow/lite/micro/examples/hello_world/hello_world_test.cc)
 in the *Hello World* example.
 
 ## Model architecture and training


### PR DESCRIPTION
This commit updates the file reference in build_convert.md, replacing the non-existent evaluate.cc link with hello_world_test.cc. The change is reflected in the commit history, as shown in the attached screenshot:

<img width="893" alt="Screen Shot 2023-12-05 at 11 38 21 AM" src="https://github.com/tensorflow/tensorflow/assets/106297042/4ae031a2-0b64-4189-8368-597fb47a9d36">
