### PR TITLE
A workaround for a string C++11 ABI issue on Centos7

### DIFF
--- a/third_party/protobuf/protobuf.patch
+++ b/third_party/protobuf/protobuf.patch
@@ -139,3 +139,50 @@ index 162531226..e93ec4809 100644
  }
  
  // If the calling code is not a _pb2.py file, raise AttributeError.
+diff --git a/src/google/protobuf/explicitly_constructed.h b/src/google/protobuf/explicitly_constructed.h
+--- a/src/google/protobuf/explicitly_constructed.h
++++ b/src/google/protobuf/explicitly_constructed.h
+@@ -62,17 +62,19 @@
+ template <typename T, size_t min_align = 1>
+ class ExplicitlyConstructed {
+  public:
+-  void DefaultConstruct() { new (&union_) T(); }
++  void DefaultConstruct() { new (&union_) T(); constructed = true; }
+ 
+   template <typename... Args>
+   void Construct(Args&&... args) {
+     new (&union_) T(std::forward<Args>(args)...);
++    constructed = true;
+   }
+ 
+   void Destruct() { get_mutable()->~T(); }
+ 
+   constexpr const T& get() const { return reinterpret_cast<const T&>(union_); }
+   T* get_mutable() { return reinterpret_cast<T*>(&union_); }
++  bool is_constructed() const { return constructed; }
+ 
+  private:
+@@ -82,6 +84,7 @@
+     int64_t align_to_int64;
+     void* align_to_ptr;
+   } union_;
++   bool constructed = false;
+ };
+ 
+ // ArenaStringPtr compatible explicitly constructed string type.
+diff --git a/src/google/protobuf/arenastring.h b/src/google/protobuf/arenastring.h
+--- a/src/google/protobuf/arenastring.h
++++ b/src/google/protobuf/arenastring.h
+@@ -130,7 +130,11 @@
+ 
+   TaggedStringPtr() = default;
+   explicit constexpr TaggedStringPtr(ExplicitlyConstructedArenaString* ptr)
+-      : ptr_(ptr) {}
++      : ptr_(ptr) {
++         if(ptr && !(ptr->is_constructed()))
++           ptr->DefaultConstruct();
++      }
++      
+ 
+   // Sets the value to `p`, tagging the value as being a 'default' value.
+   // See documentation for kDefault for more info.


### PR DESCRIPTION
I've discovered that a large number of TF unit tests fail when built on CentOS 7. Investigation revealed the following.
* CentOS 7 (or rather the gcc it comes with) uses the "old" C++11 string ABI. 
* The significant difference between ABIs is that, in the "old" ABI, std::string with internal representation containing all zeros is illegal, but, in the "new" ABI, it is just an empty string: https://godbolt.org/z/dYWK1Mh8P
* Many TF actions involving protobuf use an internal protobuf object ("fixed_address_empty_string") which is supposed to represent a global empty string. This object (or, more precisely, the std::string it encapsulates) is never constructed and contains all zeros. (Protobuf makes an effort to prevent it from being automatically constructed at initialization time.) Protobuf's authors may have expected that an explicit constructor method would be executed by the client (in our case, TF, some time early during initialization - I'm not sure where that would go in TF source), but, since, with the new ABI, everything works fine as-is, this omission was never noticed.
* As soon as someone tries to access that object, there's a segfault.

This patch adds explicit construction of that object on first access, as a workaround.