### PR TITLE
Add float16 inference option for TFLite benchmark app

### DIFF
--- a/tensorflow/lite/tools/benchmark/README.md
+++ b/tensorflow/lite/tools/benchmark/README.md
@@ -207,6 +207,8 @@ the feature that the XNNPACK delegate is applied by default in TfLite runtime,
 explictly setting this flag to `false` will cause the benchmark tool to disable
 the feature at runtime, and to use the original non-delegated CPU execution path
 for model benchmarking.
+*   `xnnpack_force_fp16`: `bool` (default=false) \
+Enforce float16 inference.
 
 #### CoreML delegate
 *   `use_coreml`: `bool` (default=false)

--- a/tensorflow/lite/tools/benchmark/benchmark_performance_options.cc
+++ b/tensorflow/lite/tools/benchmark/benchmark_performance_options.cc
@@ -260,7 +260,7 @@ void BenchmarkPerformanceOptions::ResetPerformanceOptions() {
   single_option_run_params_->Set<bool>("gpu_precision_loss_allowed", true);
 #endif
   single_option_run_params_->Set<bool>("use_xnnpack", false);
-  //single_option_run_params_->Set<bool>("xnnpack_force_fp16", false);
+  single_option_run_params_->Set<bool>("xnnpack_force_fp16", false);
 }
 
 void BenchmarkPerformanceOptions::CreatePerformanceOptions() {

--- a/tensorflow/lite/tools/benchmark/benchmark_performance_options.cc
+++ b/tensorflow/lite/tools/benchmark/benchmark_performance_options.cc
@@ -91,7 +91,11 @@ std::string MultiRunStatsRecorder::PerfOptionName(
 
   // Handle cases run on CPU w/ the xnnpack delegate
   if (params.Get<bool>("use_xnnpack")) {
-    sstm << " (xnnpack)";
+    if (params.Get<bool>("xnnpack_force_fp16")) {
+      sstm << " (xnnpack-fp16)";
+    } else {
+      sstm << " (xnnpack)";
+    }
   }
 
   return sstm.str();
@@ -256,6 +260,7 @@ void BenchmarkPerformanceOptions::ResetPerformanceOptions() {
   single_option_run_params_->Set<bool>("gpu_precision_loss_allowed", true);
 #endif
   single_option_run_params_->Set<bool>("use_xnnpack", false);
+  //single_option_run_params_->Set<bool>("xnnpack_force_fp16", false);
 }
 
 void BenchmarkPerformanceOptions::CreatePerformanceOptions() {
@@ -282,6 +287,8 @@ void BenchmarkPerformanceOptions::CreatePerformanceOptions() {
       BenchmarkParams xnnpack_params;
       xnnpack_params.AddParam("use_xnnpack",
                               BenchmarkParam::Create<bool>(true));
+      xnnpack_params.AddParam("xnnpack_force_fp16",
+                              BenchmarkParam::Create<bool>(false));
       xnnpack_params.AddParam("num_threads",
                               BenchmarkParam::Create<int32_t>(count));
       all_run_params_.emplace_back(std::move(xnnpack_params));

--- a/tensorflow/lite/tools/benchmark/experimental/delegate_performance/android/src/main/native/latency_benchmark.cc
+++ b/tensorflow/lite/tools/benchmark/experimental/delegate_performance/android/src/main/native/latency_benchmark.cc
@@ -151,15 +151,16 @@ std::vector<std::string> ParseArgumentsFromTfLiteSettings(
   switch (tflite_settings.delegate()) {
     case Delegate_XNNPACK: {
       args.push_back("--use_xnnpack=true");
-      if (tflite_settings.xnnpack_settings() &&
-          tflite_settings.xnnpack_settings()->num_threads()) {
-        args.push_back(
-            absl::StrFormat("--num_threads=%d",
-                            tflite_settings.xnnpack_settings()->num_threads()));
-      }
-      if (tflite_settings.xnnpack_settings()->flags() ==
-              XNNPackFlags_TFLITE_XNNPACK_DELEGATE_FLAG_FORCE_FP16) {
-            args.push_back("--xnnpack_force_fp16=true");
+      if (tflite_settings.xnnpack_settings()) {
+        if (tflite_settings.xnnpack_settings()->num_threads()) {
+          args.push_back(absl::StrFormat(
+              "--num_threads=%d",
+              tflite_settings.xnnpack_settings()->num_threads()));
+        }
+        if (tflite_settings.xnnpack_settings()->flags() ==
+            XNNPackFlags_TFLITE_XNNPACK_DELEGATE_FLAG_FORCE_FP16) {
+          args.push_back("--xnnpack_force_fp16=true");
+        }
       }
       return args;
     }

--- a/tensorflow/lite/tools/benchmark/experimental/delegate_performance/android/src/main/native/latency_benchmark.cc
+++ b/tensorflow/lite/tools/benchmark/experimental/delegate_performance/android/src/main/native/latency_benchmark.cc
@@ -157,6 +157,10 @@ std::vector<std::string> ParseArgumentsFromTfLiteSettings(
             absl::StrFormat("--num_threads=%d",
                             tflite_settings.xnnpack_settings()->num_threads()));
       }
+      if (tflite_settings.xnnpack_settings() &&
+          tflite_settings.xnnpack_settings()->flags() | TFLITE_XNNPACK_DELEGATE_FLAG_FORCE_FP16) {
+            args.push_back("--xnnpack_force_fp16=true");
+      }
       return args;
     }
     case Delegate_GPU: {

--- a/tensorflow/lite/tools/benchmark/experimental/delegate_performance/android/src/main/native/latency_benchmark.cc
+++ b/tensorflow/lite/tools/benchmark/experimental/delegate_performance/android/src/main/native/latency_benchmark.cc
@@ -157,8 +157,8 @@ std::vector<std::string> ParseArgumentsFromTfLiteSettings(
             absl::StrFormat("--num_threads=%d",
                             tflite_settings.xnnpack_settings()->num_threads()));
       }
-      if (tflite_settings.xnnpack_settings() &&
-          tflite_settings.xnnpack_settings()->flags() | TFLITE_XNNPACK_DELEGATE_FLAG_FORCE_FP16) {
+      if (tflite_settings.xnnpack_settings()->flags() ==
+              XNNPackFlags_TFLITE_XNNPACK_DELEGATE_FLAG_FORCE_FP16) {
             args.push_back("--xnnpack_force_fp16=true");
       }
       return args;

--- a/tensorflow/lite/tools/delegates/README.md
+++ b/tensorflow/lite/tools/delegates/README.md
@@ -151,6 +151,9 @@ delegate library is built with "-DCL_DELEGATE_NO_GL" macro.
     this parameter. To disable this implicit application, set the value to
     `false` explicitly.
 
+*   `xnnpack_force_fp16`: `bool` (default=false) \
+    Enforce float16 inference. Internaly, set flag `TFLITE_XNNPACK_DELEGATE_FLAG_FORCE_FP16` on XNNPackDelegateOptions.
+
 ### CoreML delegate provider
 
 *   `use_coreml`: `bool` (default=false) \

--- a/tensorflow/lite/tools/delegates/xnnpack_delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/xnnpack_delegate_provider.cc
@@ -25,6 +25,7 @@ class XnnpackDelegateProvider : public DelegateProvider {
  public:
   XnnpackDelegateProvider() {
     default_params_.AddParam("use_xnnpack", ToolParam::Create<bool>(false));
+    default_params_.AddParam("xnnpack_force_fp16", ToolParam::Create<bool>(false));
   }
 
   std::vector<Flag> CreateFlags(ToolParams* params) const final;
@@ -41,25 +42,31 @@ REGISTER_DELEGATE_PROVIDER(XnnpackDelegateProvider);
 
 std::vector<Flag> XnnpackDelegateProvider::CreateFlags(
     ToolParams* params) const {
-  std::vector<Flag> flags = {CreateFlag<bool>(
+  std::vector<Flag> flags = {
+    CreateFlag<bool>(
       "use_xnnpack", params,
       "explicitly apply the XNNPACK delegate. Note the XNNPACK delegate could "
       "be implicitly applied by the TF Lite runtime regardless the value of "
       "this parameter. To disable this implicit application, set the value to "
-      "false explicitly.")};
+      "false explicitly."),
+    CreateFlag<bool>(
+      "xnnpack_force_fp16", params,
+      "enforce float16 inference."),
+    };
   return flags;
 }
 
 void XnnpackDelegateProvider::LogParams(const ToolParams& params,
                                         bool verbose) const {
   LOG_TOOL_PARAM(params, bool, "use_xnnpack", "Use xnnpack", verbose);
+  LOG_TOOL_PARAM(params, bool, "xnnpack_force_fp16", "xnnpack_force_fp16", verbose);
 }
 
 TfLiteDelegatePtr XnnpackDelegateProvider::CreateTfLiteDelegate(
     const ToolParams& params) const {
   if (params.Get<bool>("use_xnnpack")) {
     return evaluation::CreateXNNPACKDelegate(
-        params.Get<int32_t>("num_threads"));
+        params.Get<int32_t>("num_threads"), params.Get<bool>("xnnpack_force_fp16"));
   }
   return CreateNullDelegate();
 }

--- a/tensorflow/lite/tools/delegates/xnnpack_delegate_provider.cc
+++ b/tensorflow/lite/tools/delegates/xnnpack_delegate_provider.cc
@@ -25,7 +25,8 @@ class XnnpackDelegateProvider : public DelegateProvider {
  public:
   XnnpackDelegateProvider() {
     default_params_.AddParam("use_xnnpack", ToolParam::Create<bool>(false));
-    default_params_.AddParam("xnnpack_force_fp16", ToolParam::Create<bool>(false));
+    default_params_.AddParam("xnnpack_force_fp16",
+                             ToolParam::Create<bool>(false));
   }
 
   std::vector<Flag> CreateFlags(ToolParams* params) const final;
@@ -43,30 +44,33 @@ REGISTER_DELEGATE_PROVIDER(XnnpackDelegateProvider);
 std::vector<Flag> XnnpackDelegateProvider::CreateFlags(
     ToolParams* params) const {
   std::vector<Flag> flags = {
-    CreateFlag<bool>(
-      "use_xnnpack", params,
-      "explicitly apply the XNNPACK delegate. Note the XNNPACK delegate could "
-      "be implicitly applied by the TF Lite runtime regardless the value of "
-      "this parameter. To disable this implicit application, set the value to "
-      "false explicitly."),
-    CreateFlag<bool>(
-      "xnnpack_force_fp16", params,
-      "enforce float16 inference."),
-    };
+      CreateFlag<bool>("use_xnnpack", params,
+                       "explicitly apply the XNNPACK delegate. Note the "
+                       "XNNPACK delegate could "
+                       "be implicitly applied by the TF Lite runtime "
+                       "regardless the value of "
+                       "this parameter. To disable this implicit application, "
+                       "set the value to "
+                       "false explicitly."),
+      CreateFlag<bool>("xnnpack_force_fp16", params,
+                       "enforce float16 inference."),
+  };
   return flags;
 }
 
 void XnnpackDelegateProvider::LogParams(const ToolParams& params,
                                         bool verbose) const {
   LOG_TOOL_PARAM(params, bool, "use_xnnpack", "Use xnnpack", verbose);
-  LOG_TOOL_PARAM(params, bool, "xnnpack_force_fp16", "xnnpack_force_fp16", verbose);
+  LOG_TOOL_PARAM(params, bool, "xnnpack_force_fp16", "xnnpack_force_fp16",
+                 verbose);
 }
 
 TfLiteDelegatePtr XnnpackDelegateProvider::CreateTfLiteDelegate(
     const ToolParams& params) const {
   if (params.Get<bool>("use_xnnpack")) {
     return evaluation::CreateXNNPACKDelegate(
-        params.Get<int32_t>("num_threads"), params.Get<bool>("xnnpack_force_fp16"));
+        params.Get<int32_t>("num_threads"),
+        params.Get<bool>("xnnpack_force_fp16"));
   }
   return CreateNullDelegate();
 }

--- a/tensorflow/lite/tools/evaluation/evaluation_delegate_provider.cc
+++ b/tensorflow/lite/tools/evaluation/evaluation_delegate_provider.cc
@@ -64,7 +64,7 @@ TfLiteDelegatePtr CreateTfLiteDelegate(const TfliteInferenceParams& params,
       return p;
     }
     case TfliteInferenceParams::XNNPACK: {
-      auto p = CreateXNNPACKDelegate(params.num_threads());
+      auto p = CreateXNNPACKDelegate(params.num_threads(), false);
       if (!p && error_msg) *error_msg = "XNNPACK delegate not supported.";
       return p;
     }
@@ -156,6 +156,9 @@ tools::ToolParams DelegateProviders::GetAllParams(
     case TfliteInferenceParams::XNNPACK:
       if (tool_params.HasParam("use_xnnpack")) {
         tool_params.Set<bool>("use_xnnpack", true);
+      }
+      if (tool_params.HasParam("xnnpack_force_fp16")) {
+        tool_params.Set<bool>("xnnpack_force_fp16", true);
       }
       break;
     case TfliteInferenceParams::COREML:

--- a/tensorflow/lite/tools/evaluation/utils.cc
+++ b/tensorflow/lite/tools/evaluation/utils.cc
@@ -177,7 +177,7 @@ TfLiteDelegatePtr CreateHexagonDelegate(
 #endif  // TFLITE_ENABLE_HEXAGON
 
 #ifdef TFLITE_WITHOUT_XNNPACK
-TfLiteDelegatePtr CreateXNNPACKDelegate(int num_threads) {
+TfLiteDelegatePtr CreateXNNPACKDelegate(int num_threads, bool force_fp16) {
   return tools::CreateNullDelegate();
 }
 #else  // !defined(TFLITE_WITHOUT_XNNPACK)
@@ -240,10 +240,14 @@ TfLiteDelegatePtr CreateXNNPACKDelegate(
   return TfLiteDelegatePtr(delegate, delegate_deleter);
 }
 
-TfLiteDelegatePtr CreateXNNPACKDelegate(int num_threads) {
+TfLiteDelegatePtr CreateXNNPACKDelegate(int num_threads, bool force_fp16) {
   auto opts = XNNPackDelegateOptionsDefault();
   // Note that we don't want to use the thread pool for num_threads == 1.
   opts.num_threads = num_threads > 1 ? num_threads : 0;
+  if (force_fp16) {
+    TFLITE_LOG(INFO) << "XNNPack FP16 inference enabled.";
+    opts.flags |= TFLITE_XNNPACK_DELEGATE_FLAG_FORCE_FP16;
+  }
   return CreateXNNPACKDelegate(&opts);
 }
 #endif

--- a/tensorflow/lite/tools/evaluation/utils.h
+++ b/tensorflow/lite/tools/evaluation/utils.h
@@ -105,7 +105,7 @@ TfLiteDelegatePtr CreateXNNPACKDelegate();
 TfLiteDelegatePtr CreateXNNPACKDelegate(
     const TfLiteXNNPackDelegateOptions* options);
 #endif  // !defined(TFLITE_WITHOUT_XNNPACK)
-TfLiteDelegatePtr CreateXNNPACKDelegate(int num_threads);
+TfLiteDelegatePtr CreateXNNPACKDelegate(int num_threads, bool force_fp16);
 
 TfLiteDelegatePtr CreateCoreMlDelegate();
 }  // namespace evaluation


### PR DESCRIPTION
## Background
Native float16 inference is introduced in [Tensorflow Blog](https://blog.tensorflow.org/2023/11/half-precision-inference-doubles-on-device-inference-performance.html).
To try this on benchmark app(benchmark_model), we need set flag of XNNPackDelegateOptions,  it's not accessible.
This PR enable to access the flag for float16 inference from command line args.

## Change
- Add `--xnnpack_force_fp16` option in benchmark_model
  ```bash
  benchmark_model --graph=... \
    --use_xnnpack=true \
    --xnnpack_force_fp16=true # enable float16 inference.
  ``` 