### PR TITLE
QuantOps verifier asserts that quant scale is below 1e+10

### DIFF
--- a/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
+++ b/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
@@ -4229,6 +4229,8 @@ def TFL_QuantizeOp: TFL_Op<"quantize", [
   );
 
   let results = (outs TFL_TensorOf<[QI4, QI8, QUI8, QI16, TFL_Quint8]>:$output);
+
+  let hasVerifier = 1;
 }
 
 def TFL_DensifyOp: TFL_Op<"densify", [

--- a/tensorflow/compiler/mlir/lite/quantization/lite/quantize_model.cc
+++ b/tensorflow/compiler/mlir/lite/quantization/lite/quantize_model.cc
@@ -78,8 +78,16 @@ TfLiteStatus QuantizeModel(
     return kTfLiteError;
   }
 
-  // Apply quantization passes.
   PassManager pm((*module)->getName(), OpPassManager::Nesting::Implicit);
+  pm.enableIRPrinting(
+          std::make_unique<mlir::PassManager::IRPrinterConfig>());
+  mlir::registerPassManagerCLOptions();
+  if (mlir::failed(mlir::applyPassManagerCLOptions(pm))) {
+    error_reporter->Report("failed to apply MLIR pass manager CL options.");
+    return kTfLiteError;
+  }
+
+  // Apply quantization passes.
   quant::QuantizationSpecs quant_specs;
   quant_specs.inference_type = tflite::TflTypeToTfType(inference_type);
   quant_specs.post_training_quantization = true;

--- a/tensorflow/compiler/mlir/lite/quantization/lite/tfl_quantizer.cc
+++ b/tensorflow/compiler/mlir/lite/quantization/lite/tfl_quantizer.cc
@@ -20,7 +20,11 @@ limitations under the License.
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/Pass/PassManager.h"
 #include "tensorflow/compiler/mlir/lite/quantization/lite/quantize_model.h"
+#include "tensorflow/compiler/mlir/init_mlir.h"
 #include "tensorflow/lite/model.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 
@@ -47,7 +51,10 @@ TfLiteStatus QuantizeAnnotatedModel(llvm::StringRef buffer,
 }  // namespace mlir
 
 int main(int argc, char** argv) {
-  llvm::InitLLVM y(argc, argv);
+  tensorflow::InitMlir y(&argc, &argv);
+  mlir::registerAsmPrinterCLOptions();
+  mlir::registerMLIRContextCLOptions();
+  mlir::registerPassManagerCLOptions();
   llvm::cl::ParseCommandLineOptions(argc, argv);
   auto file_or_err = llvm::MemoryBuffer::getFileOrSTDIN(inputFileName.c_str());
   if (std::error_code error = file_or_err.getError()) {

--- a/tensorflow/compiler/mlir/lite/tests/ops.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/ops.mlir
@@ -3218,3 +3218,20 @@ func.func @testDilate(%arg0: tensor<3x4x5xf32>) -> tensor<5x7x9xf32> {
   func.return %0 : tensor<5x7x9xf32>
   // CHECK: return %0 : tensor<5x7x9xf32>
 }
+
+// -----
+
+// CHECK-LABEL: violateThreshold
+func.func @violateThreshold(%arg0: tensor<f32>) -> tensor<f32> {
+  // expected-error @+1 {{'tfl.quantize' op Quant scale (1.334441e+36) too large}}
+  %0 = "tfl.quantize"(%arg0) {qtype = tensor<!quant.uniform<i8:f32, 1.3344405750530544E+36:127>>, volatile} : (tensor<f32>) -> tensor<!quant.uniform<i8:f32, 1.3344405750530544E+36:127>>
+  func.return %0 : tensor<!quant.uniform<i8:f32, 1.3344405750530544E+36:127>>
+}
+
+// -----
+
+// CHECK-LABEL: satisfyThreshold
+func.func @satisfyThreshold(%arg0: tensor<f32>) -> tensor<f32> {
+  %0 = "tfl.quantize"(%arg0) {qtype = tensor<!quant.uniform<i8:f32, 0.3344405750530544:127>>, volatile} : (tensor<f32>) -> tensor<!quant.uniform<i8:f32, 0.3344405750530544:127>>
+  func.return %0 : tensor<!quant.uniform<i8:f32, 0.3344405750530544:127>>
+}


### PR DESCRIPTION
Addresses #62196 

In some situations, the tf-tfl converter can produce spurious quantization scales. The conversion nevertheless passes, but the tensorflow lite interpreter aborts when allocating tensors for the model.  The PR adds a verification check for the mlir QuantOps (and DequantizeOps) ops. 