### PR TITLE
Remove ARM CI from PR Trigger in arm-ci.yml

### DIFF
--- a/.github/workflows/arm-ci.yml
+++ b/.github/workflows/arm-ci.yml
@@ -20,12 +20,6 @@ on:
     branches:
       - master
       - r2.**
-  pull_request:
-    types: [labeled, opened, synchronize, reopened]
-    branches:
-      - master
-      - r2.**
-
 permissions:
   contents: read
 


### PR DESCRIPTION
Remove the arm ci trigger from arm-ci.yml in favor of the newer arm64 presubmit.