### PR TITLE
Validate mask argument of tf.boolean_mask

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1746,6 +1746,8 @@ def boolean_mask(tensor, mask, name="boolean_mask", axis=None):
   with ops.name_scope(name, values=[tensor, mask]):
     tensor = ops.convert_to_tensor(tensor, name="tensor")
     mask = ops.convert_to_tensor(mask, name="mask")
+    if mask.dtype != dtypes.bool:
+      raise TypeError("Invalid `mask`: expected bool but got %s." % mask.dtype)
 
     shape_mask = mask.get_shape()
     ndims_mask = shape_mask.ndims


### PR DESCRIPTION
As per `tf.boolean_mask` documentation the argument mask must be:

>  K-D boolean Tensor, K <= N and K must be known statically.


Currently this API is not validating the `mask` argument. If we pass any numeric values irrespective of `positives` or `negatives` all will be considered as `True` except for `0`. This may not produce desirable results. IMO, it's better to enforce the user to pass the mask as boolean tensor. Hence proposing the validation.

Fixes #61820 