### PR TITLE
Fix protobuf errors when using system protobuf

### DIFF
--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -35,6 +35,8 @@ import site as _site
 import sys as _sys
 import typing as _typing
 
+# Do not remove this line; See https://github.com/tensorflow/tensorflow/issues/42596
+from tensorflow.python import pywrap_tensorflow  # pylint: disable=unused-import
 from tensorflow.python.tools import module_util as _module_util
 from tensorflow.python.util.lazy_loader import LazyLoader as _LazyLoader
 from tensorflow.python.util.lazy_loader import KerasLazyLoader as _KerasLazyLoader

--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -36,7 +36,7 @@ import sys as _sys
 import typing as _typing
 
 # Do not remove this line; See https://github.com/tensorflow/tensorflow/issues/42596
-from tensorflow.python import pywrap_tensorflow  # pylint: disable=unused-import
+from tensorflow.python import pywrap_tensorflow as _pywrap_tensorflow  # pylint: disable=unused-import
 from tensorflow.python.tools import module_util as _module_util
 from tensorflow.python.util.lazy_loader import LazyLoader as _LazyLoader
 from tensorflow.python.util.lazy_loader import KerasLazyLoader as _KerasLazyLoader


### PR DESCRIPTION
```
File "/home/conda/lib/python3.10/site-packages/tensorflow/python/framework/meta_graph.py", line 557, in create_meta_graph_def
    meta_graph_def.graph_def.MergeFrom(graph_def)
TypeError: Parameter to MergeFrom() must be instance of same class: expected tensorflow.GraphDef got tensorflow.GraphDef.
```

This error happened in TF 2.4 and 2.5 and was fixed. However, it appeared again in TF 2.15, as `from tensorflow.python import pywrap_tensorflow` was removed in 719f6da42226319a9348f55b86d3103881bae0ee. See previous issues and fixes:
- https://github.com/tensorflow/tensorflow/issues/42596
- bad835f9af3f1e1e04f1ea69db902add1b5076f9
- https://github.com/tensorflow/tensorflow/issues/50545
- https://github.com/tensorflow/tensorflow/pull/51450

This PR adds `from tensorflow.python import pywrap_tensorflow` to `tensorflow/__init__.py` (generated by `api_template.__init__.py`), and it fixes the error when I test it. I am not sure whether there is a better place to add this line. (it seems `tensorflow/python/__init__.py` does not have any import)