### PR TITLE
Fixing an issue with reflect padding in TfLite GPU delegate

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/tasks/padding.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/padding.cc
@@ -75,7 +75,7 @@ std::string GetPaddingCode(const OperationDef& op_def,
     c += "  s_x = reflect_coord(s_x, args.src_tensor.Width());\n";
     c += "  s_y = reflect_coord(s_y, args.src_tensor.Height());\n";
     if (op_def.dst_tensors[0].HasAxis(Axis::BATCH)) {
-      c += "  int s_b = reflect_coord(s_b, args.src_tensor.Batch());\n";
+      c += "  s_b = reflect_coord(s_b, args.src_tensor.Batch());\n";
     }
     if (attr.prepended.c == 0 && attr.appended.c == 0) {
       // optimized case


### PR DESCRIPTION
This PR fixes a bug in an OpenCL kernel code for reflect padding operation in TfLite GPU delegate.

This issue occurs systematically when the following conditions are met:
* Running inference of a model containing `tf.pad` operation with `mode="REFLECT"`, getting an input tensor with batch dimension
* Using TfLite GPU delegate with OpenCL backend in Android

When these conditions are fulfilled, the following diagnostics message appears in logcat during the interpreter initialization in Android code:

![Screenshot from 2023-12-19 16-44-10](https://github.com/tensorflow/tensorflow/assets/149387626/43b25971-fd31-406c-a0c5-ad383607d115)

Once linked to the source code, this error message allows to easily identify the root cause: under the conditions above, a variable named `s_b` appears declared twice in the corresponding OpenCL kernel code.

- Its first declaration is appended to the kernel code at [line 71 of padding.cc](https://github.com/tensorflow/tensorflow/blob/04cac016115e031ea988fac42f42f79b6b55602f/tensorflow/lite/delegates/gpu/common/tasks/padding.cc#L71).
- If the input tensor has batch dimension and the padding mode is set to `REFLECT`, **the same variable is further redeclared** [at line 78](https://github.com/tensorflow/tensorflow/blob/04cac016115e031ea988fac42f42f79b6b55602f/tensorflow/lite/delegates/gpu/common/tasks/padding.cc#L78), whine being used at the same line in the right-hand side of the assignment.

We believe, a simple assignment without declaration should take place. This PR brings this change.