### PR TITLE
TFLite CMake suggestion: option `TFLITE_ENABLE_GLES3` and changes for OpenGL ES Delegate build

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -306,6 +306,7 @@ if(TFLITE_ENABLE_GPU)
     find_package(opengl_headers REQUIRED)
     find_package(egl_headers REQUIRED)
   endif()
+  # see delegates/gpu/BUILD and search with //tensorflow:android
   if(ANDROID)
     populate_tflite_source_vars("delegates/utils" TFLITE_DELEGATES_UTILS_SRCS FILTER "(_test)\\.(cc|h)$")
     populate_tflite_source_vars("async" TFLITE_ASYNC_SRCS FILTER "(_test)\\.(cc|h)$")
@@ -324,6 +325,7 @@ if(TFLITE_ENABLE_GPU)
     else()
       set(FLATC flatc)
     endif()
+    # follow flatbuffer_cc_library of Bazel
     add_custom_command(
       OUTPUT
         ${TFLITE_SOURCE_DIR}/delegates/gpu/gl/common_generated.h
@@ -353,13 +355,16 @@ if(TFLITE_ENABLE_GPU)
       ${TFLITE_DELEGATES_GPU_GL_WORKGROUPS_SRCS}
     )
   endif()
+  # see delegates/gpu/cl/BUILD
   if(NOT TFLITE_ENABLE_GLES3)
+    # config_setting: opencl_delegate_no_gl
     populate_tflite_source_vars(
       "delegates/gpu/cl" TFLITE_DELEGATES_GPU_CL_SRCS
       FILTER "(_test|gl_interop|gpu_api_delegate|egl_sync)\\.(cc|h)$"
     )
     list(APPEND TFLITE_TARGET_PRIVATE_DEFINITIONS "CL_DELEGATE_NO_GL")
   else()
+    # cc_library: egl_sync
     populate_tflite_source_vars(
       "delegates/gpu/cl" TFLITE_DELEGATES_GPU_CL_SRCS
       FILTER "(_test)\\.(cc|h)$"

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -73,7 +73,7 @@ option(TFLITE_ENABLE_GPU "Enable GPU" OFF)
 option(TFLITE_ENABLE_METAL "Enable Metal delegate (iOS only)" OFF)
 option(TFLITE_ENABLE_XNNPACK "Enable XNNPACK backend" ON)
 option(TFLITE_ENABLE_EXTERNAL_DELEGATE "Enable External Delegate backend" ON)
-option(TFLITE_ENABLE_GLES3 "Enable OpenGL ES 3 delegate" OFF)
+cmake_dependent_option(TFLITE_ENABLE_GLES3 "Enable OpenGL ES 3 delegate" ON "TFLITE_ENABLE_GPU;ANDROID" OFF)
 
 option(TFLITE_KERNEL_TEST "Enable tflite kernel unit test" OFF)
 if(TFLITE_KERNEL_TEST AND ${CMAKE_CROSSCOMPILING})

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -295,7 +295,8 @@ if(TFLITE_ENABLE_GPU)
   if(TFLITE_ENABLE_GLES3)
     find_path(OPENGL_EGL_INCLUDE_DIRS "EGL/egl.h" REQUIRED)
     find_library(OPENGL_egl_LIBRARY NAMES EGL libEGL REQUIRED)
-    find_path(OPENGL_GLES3_INCLUDE_DIR "GLES3/gl3.h" REQUIRED) # "version 310 es"
+    find_path(OPENGL_INCLUDE_DIR "GLES3/gl3.h" REQUIRED) # "version 310 es"
+    find_path(OPENGL_GLES3_INCLUDE_DIR "GLES3/gl3.h" REQUIRED)
     find_library(OPENGL_gles3_LIBRARY NAMES GLESv3 libGLESv3 GLESv2 libGLESv2 REQUIRED)
     find_library(OPENGL_gl_LIBRARY NAMES GLESv3 libGLESv3 GLESv2 libGLESv2 REQUIRED)
     # OpenGL::GLES3 requires CMake 3.27

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -302,15 +302,73 @@ if(TFLITE_ENABLE_GPU)
     # OpenGL::GLES3 requires CMake 3.27
     find_package(OpenGL REQUIRED COMPONENTS GLES3)
     list(APPEND TFLITE_TARGET_DEPENDENCIES OpenGL::GLES3 ${OPENGL_egl_LIBRARY})
-    list(APPEND TFLITE_TARGET_PRIVATE_DEFINITIONS "EGL_EGLEXT_PROTOTYPES")
   else()
     find_package(opengl_headers REQUIRED)
     find_package(egl_headers REQUIRED)
   endif()
-  populate_tflite_source_vars(
-    "delegates/gpu/cl" TFLITE_DELEGATES_GPU_CL_SRCS
-    FILTER "(_test|gl_interop|gpu_api_delegate|egl_sync)\\.(cc|h)$"
-  )
+  if(ANDROID)
+    populate_tflite_source_vars("delegates/utils" TFLITE_DELEGATES_UTILS_SRCS FILTER "(_test)\\.(cc|h)$")
+    populate_tflite_source_vars("async" TFLITE_ASYNC_SRCS FILTER "(_test)\\.(cc|h)$")
+    list(APPEND TFLITE_DELEGATES_GPU_SRCS
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/android_version.cc
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/android_hardware_buffer.cc
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/async_buffers.cc
+      ${TFLITE_DELEGATES_UTILS_SRCS}
+      ${TFLITE_ASYNC_SRCS}
+    )
+    list(APPEND TFLITE_TARGET_DEPENDENCIES android nativewindow)
+  endif()
+  if(TFLITE_ENABLE_GLES3)
+    if(FLATBUFFERS_FLATC_EXECUTABLE)
+      set(FLATC ${FLATBUFFERS_FLATC_EXECUTABLE})
+    else()
+      set(FLATC flatc)
+    endif()
+    add_custom_command(
+      OUTPUT
+        ${TFLITE_SOURCE_DIR}/delegates/gpu/gl/common_generated.h
+        ${TFLITE_SOURCE_DIR}/delegates/gpu/gl/metadata_generated.h
+        ${TFLITE_SOURCE_DIR}/delegates/gpu/gl/workgroups_generated.h
+        ${TFLITE_SOURCE_DIR}/delegates/gpu/gl/compiled_model_generated.h
+      WORKING_DIRECTORY ${TFLITE_SOURCE_DIR}/delegates/gpu/gl
+      COMMAND ${FLATC} --cpp --scoped-enums -I ${TENSORFLOW_SOURCE_DIR} common.fbs
+      COMMAND ${FLATC} --cpp --scoped-enums -I ${TENSORFLOW_SOURCE_DIR} metadata.fbs
+      COMMAND ${FLATC} --cpp --scoped-enums -I ${TENSORFLOW_SOURCE_DIR} workgroups.fbs
+      COMMAND ${FLATC} --cpp --scoped-enums -I ${TENSORFLOW_SOURCE_DIR} compiled_model.fbs
+    )
+    populate_tflite_source_vars("delegates/gpu/gl" TFLITE_DELEGATES_GPU_GL_SRCS FILTER "(_test)\\.(cc|h)$")
+    populate_tflite_source_vars("delegates/gpu/gl/compiler" TFLITE_DELEGATES_GPU_GL_COMPILER_SRCS FILTER "(_test)\\.(cc|h)$")
+    populate_tflite_source_vars("delegates/gpu/gl/converters" TFLITE_DELEGATES_GPU_GL_CONVERTERS_SRCS FILTER "(_test)\\.(cc|h)$")
+    populate_tflite_source_vars("delegates/gpu/gl/kernels" TFLITE_DELEGATES_GPU_GL_KERNELS_SRCS FILTER "(_test)\\.(cc|h)$")
+    populate_tflite_source_vars("delegates/gpu/gl/workgroups" TFLITE_DELEGATES_GPU_GL_WORKGROUPS_SRCS FILTER "(_test)\\.(cc|h)$")
+    list(APPEND TFLITE_DELEGATES_GPU_SRCS
+      ${TFLITE_DELEGATES_GPU_GL_SRCS}
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/gl/common_generated.h
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/gl/metadata_generated.h
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/gl/workgroups_generated.h
+      ${TFLITE_SOURCE_DIR}/delegates/gpu/gl/compiled_model_generated.h
+      ${TFLITE_DELEGATES_GPU_GL_COMPILER_SRCS}
+      ${TFLITE_DELEGATES_GPU_GL_CONVERTERS_SRCS}
+      ${TFLITE_DELEGATES_GPU_GL_KERNELS_SRCS}
+      ${TFLITE_DELEGATES_GPU_GL_WORKGROUPS_SRCS}
+    )
+  endif()
+  if(NOT TFLITE_ENABLE_GLES3)
+    populate_tflite_source_vars(
+      "delegates/gpu/cl" TFLITE_DELEGATES_GPU_CL_SRCS
+      FILTER "(_test|gl_interop|gpu_api_delegate|egl_sync)\\.(cc|h)$"
+    )
+    list(APPEND TFLITE_TARGET_PRIVATE_DEFINITIONS "CL_DELEGATE_NO_GL")
+  else()
+    populate_tflite_source_vars(
+      "delegates/gpu/cl" TFLITE_DELEGATES_GPU_CL_SRCS
+      FILTER "(_test)\\.(cc|h)$"
+    )
+    set_source_files_properties(delegates/gpu/cl/egl_sync.cc
+    PROPERTIES
+      COMPILE_DEFINITIONS "EGL_EGLEXT_PROTOTYPES"
+    )
+  endif()
   populate_tflite_source_vars(
     "delegates/gpu/cl/default" TFLITE_DELEGATES_GPU_CL_DEFAULT_SRCS
     FILTER "(_test)\\.(cc|h)$"

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -73,6 +73,7 @@ option(TFLITE_ENABLE_GPU "Enable GPU" OFF)
 option(TFLITE_ENABLE_METAL "Enable Metal delegate (iOS only)" OFF)
 option(TFLITE_ENABLE_XNNPACK "Enable XNNPACK backend" ON)
 option(TFLITE_ENABLE_EXTERNAL_DELEGATE "Enable External Delegate backend" ON)
+option(TFLITE_ENABLE_GLES3 "Enable OpenGL ES 3 delegate" OFF)
 
 option(TFLITE_KERNEL_TEST "Enable tflite kernel unit test" OFF)
 if(TFLITE_KERNEL_TEST AND ${CMAKE_CROSSCOMPILING})
@@ -291,7 +292,17 @@ if(TFLITE_ENABLE_GPU)
   find_package(vulkan_headers REQUIRED)
   find_package(fp16_headers REQUIRED)
   # Android NDK already has OpenGL, EGL headers.
-  if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
+  if(TFLITE_ENABLE_GLES3)
+    find_path(OPENGL_EGL_INCLUDE_DIRS "EGL/egl.h" REQUIRED)
+    find_library(OPENGL_egl_LIBRARY NAMES EGL libEGL REQUIRED)
+    find_path(OPENGL_GLES3_INCLUDE_DIR "GLES3/gl3.h" REQUIRED) # "version 310 es"
+    find_library(OPENGL_gles3_LIBRARY NAMES GLESv3 libGLESv3 GLESv2 libGLESv2 REQUIRED)
+    find_library(OPENGL_gl_LIBRARY NAMES GLESv3 libGLESv3 GLESv2 libGLESv2 REQUIRED)
+    # OpenGL::GLES3 requires CMake 3.27
+    find_package(OpenGL REQUIRED COMPONENTS GLES3)
+    list(APPEND TFLITE_TARGET_DEPENDENCIES OpenGL::GLES3 ${OPENGL_egl_LIBRARY})
+    list(APPEND TFLITE_TARGET_PRIVATE_DEFINITIONS "EGL_EGLEXT_PROTOTYPES")
+  else()
     find_package(opengl_headers REQUIRED)
     find_package(egl_headers REQUIRED)
   endif()
@@ -658,6 +669,9 @@ endif()
 target_compile_options(tensorflow-lite
   PUBLIC ${TFLITE_TARGET_PUBLIC_OPTIONS}
   PRIVATE ${TFLITE_TARGET_PRIVATE_OPTIONS}
+)
+target_compile_definitions(tensorflow-lite
+  PRIVATE ${TFLITE_TARGET_PRIVATE_DEFINITIONS}
 )
 add_library(${PROJECT_NAME}::tensorflowlite ALIAS tensorflow-lite)
 

--- a/tensorflow/lite/CMakePresets.json
+++ b/tensorflow/lite/CMakePresets.json
@@ -1,0 +1,64 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 21,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "vcpkg-find",
+            "hidden": true,
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "debug": {
+                "find": true
+            }
+        },
+        {
+            "name": "vcpkg-android",
+            "hidden": true,
+            "inherits": "vcpkg-find",
+            "cacheVariables": {
+                "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake",
+                "CMAKE_SYSTEM_NAME": "Android",
+                "CMAKE_SYSTEM_VERSION": "26",
+                "ANDROID_PLATFORM": "android-26"
+            },
+            "debug": {
+                "tryCompile": true
+            }
+        },
+        {
+            "name": "tflite-gpu-options",
+            "hidden": true,
+            "cacheVariables": {
+                "TFLITE_ENABLE_RUY": true,
+                "TFLITE_ENABLE_GPU": true,
+                "TFLITE_ENABLE_GLES3": true,
+                "TFLITE_ENABLE_INSTALL": false,
+                "BUILD_SHARED_LIBS": true
+            }
+        },
+        {
+            "name": "arm64-android",
+            "inherits": [
+                "vcpkg-android",
+                "tflite-gpu-options"
+            ],
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/../../cmake_build",
+            "installDir": "${sourceDir}/../../install",
+            "cacheVariables": {
+                "ANDROID_ABI": "arm64-v8a",
+                "VCPKG_TARGET_TRIPLET": "arm64-android"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "arm64-android-release",
+            "configurePreset": "arm64-android",
+            "configuration": "Release"
+        }
+    ]
+}

--- a/tensorflow/lite/CMakePresets.json
+++ b/tensorflow/lite/CMakePresets.json
@@ -7,25 +7,16 @@
     },
     "configurePresets": [
         {
-            "name": "vcpkg-find",
+            "name": "cmake-android",
             "hidden": true,
-            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-            "debug": {
-                "find": true
-            }
-        },
-        {
-            "name": "vcpkg-android",
-            "hidden": true,
-            "inherits": "vcpkg-find",
+            "toolchainFile": "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake",
             "cacheVariables": {
-                "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake",
                 "CMAKE_SYSTEM_NAME": "Android",
                 "CMAKE_SYSTEM_VERSION": "26",
                 "ANDROID_PLATFORM": "android-26"
             },
             "debug": {
-                "tryCompile": true
+                "find": true
             }
         },
         {
@@ -42,15 +33,14 @@
         {
             "name": "arm64-android",
             "inherits": [
-                "vcpkg-android",
+                "cmake-android",
                 "tflite-gpu-options"
             ],
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/../../cmake_build",
             "installDir": "${sourceDir}/../../install",
             "cacheVariables": {
-                "ANDROID_ABI": "arm64-v8a",
-                "VCPKG_TARGET_TRIPLET": "arm64-android"
+                "ANDROID_ABI": "arm64-v8a"
             }
         }
     ],


### PR DESCRIPTION
Hi, I'm maintaining [vcpkg](https://github.com/microsoft/vcpkg) registry for TensorFlow Lite.

I was patching CMakeLists.txt files to support multiple platforms, but the difference is getting bigger since 2.11
Will be glad if I can submit those changes upstream.

## Changes

* Create CMake build option `TFLITE_ENABLE_GLES3`
* Use `find_package(OpenGL)` to use `OpenGL::GLES3` https://cmake.org/cmake/help/latest/module/FindOpenGL.html
* Use `TFLITE_TARGET_PRIVATE_DEFINITIONS` for ease of macro search

### Android(EGL, OpenGL)

*  Include related sources under `"${TFLITE_SOURCE_DIR}/delegates/gpu/cl"`

### Flatbuffers

* Run `flatc` on `${TFLITE_SOURCE_DIR}/delegates/gpu/gl/*.fbs`

## Example

The PR contains CMakePresets for Android.

After Git clone, 

```ps1
cmake --preset arm64-android -S tensorflow/lite -DFLATBUFFERS_FLATC_EXECUTABLE:FILEPATH="...\flatc.exe"
```

```ps1
cmake --build cmake_build
```

## References

May collide with the following PR

* #61381 

In-use patch files.

* https://github.com/luncliff/vcpkg-registry/pull/131
* https://github.com/luncliff/vcpkg-registry/pull/117