### PR TITLE
Updating a typo in doc

### DIFF
--- a/tensorflow/python/keras/utils/losses_utils.py
+++ b/tensorflow/python/keras/utils/losses_utils.py
@@ -188,7 +188,7 @@ def squeeze_or_expand_dimensions(y_pred, y_true=None, sample_weight=None):
     y_true_rank = y_true_shape.ndims
     if (y_true_rank is not None) and (y_pred_rank is not None):
       # Use static rank for `y_true` and `y_pred`.
-      if (y_pred_rank - y_true_rank != 1) or y_pred_shape[-1] == 1:
+      if (y_pred_rank - y_true_rank == 1) or y_pred_shape[-1] == 1:
         y_true, y_pred = remove_squeezable_dimensions(
             y_true, y_pred)
     else:


### PR DESCRIPTION
Updated the line from if (y_pred_rank - y_true_rank != 1) or y_pred_shape[-1] == 1:  to
if (y_pred_rank - y_true_rank == 1) or y_pred_shape[-1] == 1:
 as the current behavior will squeeze the y_pred tensor even when it’s the same rank and shape as the y_pred tensor.
Fixes #62718

Please have a look at this and do the needful. Thank you!