### PR TITLE
Add a caution note for embedding_lookup for CPU vs GPU behaviour

### DIFF
--- a/tensorflow/python/ops/embedding_ops.py
+++ b/tensorflow/python/ops/embedding_ops.py
@@ -308,9 +308,11 @@ def embedding_lookup(
     ids: A `Tensor` or a 'RaggedTensor' with type `int32` or `int64` containing
       the ids to be looked up in `params`.
       
-      Caution: On CPU, if an out of bound id is found, an error is raised.
-      On GPU, if an out of bound id is found, a 0 is stored in the
-      corresponding output value.
+      Caution: Without XLA,on CPU, if an out of bound id is found, an error is raised.
+      On GPU, if an out of bound id is found, a 0 is stored in the corresponding
+      output value.With XLA, for both CPU and GPU, all out of bound ids are
+      replaced with maximum of `ids` inferred from the input `params` and
+      corresponding value will be taken into output.
     partition_strategy: A string specifying the partitioning strategy, relevant
       if `len(params) > 1`. Currently `"div"` and `"mod"` are supported. Default
       is `"mod"`.

--- a/tensorflow/python/ops/embedding_ops.py
+++ b/tensorflow/python/ops/embedding_ops.py
@@ -308,11 +308,8 @@ def embedding_lookup(
     ids: A `Tensor` or a 'RaggedTensor' with type `int32` or `int64` containing
       the ids to be looked up in `params`.
       
-      Caution: Without XLA,on CPU, if an out of bound id is found, an error is raised.
-      On GPU, if an out of bound id is found, a 0 is stored in the corresponding
-      output value.With XLA, for both CPU and GPU, all out of bound ids are
-      replaced with maximum of `ids` inferred from the input `params` and
-      corresponding value will be taken into output.
+      Caution: Out-of-bounds indices will result in undefined behavior,
+      which will differ between devices and backends.
     partition_strategy: A string specifying the partitioning strategy, relevant
       if `len(params) > 1`. Currently `"div"` and `"mod"` are supported. Default
       is `"mod"`.

--- a/tensorflow/python/ops/embedding_ops.py
+++ b/tensorflow/python/ops/embedding_ops.py
@@ -307,6 +307,10 @@ def embedding_lookup(
       element must be appropriately sized for the given `partition_strategy`.
     ids: A `Tensor` or a 'RaggedTensor' with type `int32` or `int64` containing
       the ids to be looked up in `params`.
+      
+      Caution: On CPU, if an out of bound id is found, an error is raised.
+      On GPU, if an out of bound id is found, a 0 is stored in the
+      corresponding output value.
     partition_strategy: A string specifying the partitioning strategy, relevant
       if `len(params) > 1`. Currently `"div"` and `"mod"` are supported. Default
       is `"mod"`.


### PR DESCRIPTION
The API `embedding_lookup` have different behaviour on CPU vs GPU when there is out of range id passed to the argument `ids`.

On CPU it will raise error but on GPU it will output `0` to corresponding value. This is due to the reason that this API calls `tf.gather` internally where this constraint is mentioned.

I am proposing to add a caution note on this behaviour as requested by the author in #62628 .