### PR TITLE
resolved issue: Error in markdown based comment #62745

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1444,7 +1444,7 @@ class DatasetV2(
 
     #### Fully shuffling all the data
 
-    To shuffle an entire dataset, set `buffer_size=dataset.cardinality(). This
+    To shuffle an entire dataset, set `buffer_size=dataset.cardinality()`. This
     is equivalent to setting the `buffer_size` equal to the number of elements
     in the dataset, resulting in uniform shuffle.
 


### PR DESCRIPTION
Line 1447 line in the documentation of tf.data.Dataset.shuffle():

To shuffle an entire dataset, set `buffer_size=dataset.cardinality(). This
has a missing backtick (`).