### PR TITLE
Fixing a small typo

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1444,7 +1444,7 @@ class DatasetV2(
 
     #### Fully shuffling all the data
 
-    To shuffle an entire dataset, set `buffer_size=dataset.cardinality(). This
+    To shuffle an entire dataset, set `buffer_size=dataset.cardinality()`. This
     is equivalent to setting the `buffer_size` equal to the number of elements
     in the dataset, resulting in uniform shuffle.
 


### PR DESCRIPTION
There is a small typo in the documentation of tf.data.Dataset.shuffle(): which is fixed now. Please have a look and do the needful. Thank you! 
Fixes #62745