### PR TITLE
[XLA:TSL] add gil acquire when entering catch region

### DIFF
--- a/third_party/xla/third_party/tsl/tsl/python/lib/core/ml_dtypes.cc
+++ b/third_party/xla/third_party/tsl/tsl/python/lib/core/ml_dtypes.cc
@@ -71,6 +71,7 @@ struct MlDtypesInitInfo {
       numpy_dtypes.int4 = py::dtype::from_args(ml_dtypes.attr("int4")).num();
       numpy_dtypes.uint4 = py::dtype::from_args(ml_dtypes.attr("uint4")).num();
     } catch (const std::exception& e) {
+      py::gil_scoped_acquire acquire;
       py::print(e.what());
       init_valid = false;
     }


### PR DESCRIPTION
If not acquice gil, it will segment fault when calling `py::pring(e.what())`.