### PR TITLE
Set `reshuffle_each_iteration` in `Dataset.shuffle()` directly to `True` to avoid confusion

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1390,7 +1390,7 @@ class DatasetV2(
     return Dataset.zip((range_dataset, self), name=name)
 
   def shuffle(
-      self, buffer_size, seed=None, reshuffle_each_iteration=None, name=None
+      self, buffer_size, seed=None, reshuffle_each_iteration=True, name=None
   ) -> "DatasetV2":
     """Randomly shuffles the elements of this dataset.
 

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1406,10 +1406,10 @@ class DatasetV2(
     maintaining the 1,000 element buffer.
 
     `reshuffle_each_iteration` controls whether the shuffle order should be
-    different for each epoch. However you should avoid using `shuffle` with
-    `reshuffle_each_iteration=True`, then `take` and `skip` to split a dataset
-    into training and test set, which would lead to data leakage (as the
-    entire dataset would be re-shuffled then re-split after each epoch).
+    different for each epoch. However you should avoid using
+    `shuffle(reshuffle_each_iteration=True)`, then `take` and `skip` to split
+    a dataset into training and test sets, which would lead to data leakage (as
+    the entire dataset would be re-shuffled then re-split after each epoch).
     Please use the `tf.keras.utils.split_dataset` method instead. In TF 1.X,
     the idiomatic way to create epochs was through the `repeat` transformation:
 

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1406,8 +1406,12 @@ class DatasetV2(
     maintaining the 1,000 element buffer.
 
     `reshuffle_each_iteration` controls whether the shuffle order should be
-    different for each epoch. In TF 1.X, the idiomatic way to create epochs
-    was through the `repeat` transformation:
+    different for each epoch. However you should avoid using `shuffle` with
+    `reshuffle_each_iteration=True`, then `take` and `skip` to split a dataset
+    into training and test set, which would lead to data leakage (as the
+    entire dataset would be re-shuffled then re-split after each epoch).
+    Please use the `tf.keras.utils.split_dataset` method instead. In TF 1.X,
+    the idiomatic way to create epochs was through the `repeat` transformation:
 
     ```python
     dataset = tf.data.Dataset.range(3)

--- a/tensorflow/python/data/ops/shuffle_op.py
+++ b/tensorflow/python/data/ops/shuffle_op.py
@@ -26,7 +26,7 @@ def _shuffle(  # pylint: disable=unused-private-name
     input_dataset,
     buffer_size,
     seed=None,
-    reshuffle_each_iteration=None,
+    reshuffle_each_iteration=True,
     name=None):
   return _ShuffleDataset(
       input_dataset, buffer_size, seed, reshuffle_each_iteration, name=name)
@@ -39,15 +39,13 @@ class _ShuffleDataset(dataset_ops.UnaryUnchangedStructureDataset):
                input_dataset,
                buffer_size,
                seed=None,
-               reshuffle_each_iteration=None,
+               reshuffle_each_iteration=True,
                name=None):
     """See `Dataset.shuffle()` for details."""
     self._input_dataset = input_dataset
     self._buffer_size = ops.convert_to_tensor(
         buffer_size, dtype=dtypes.int64, name="buffer_size")
     self._seed, self._seed2 = random_seed.get_seed(seed)
-    if reshuffle_each_iteration is None:
-      reshuffle_each_iteration = True
     self._reshuffle_each_iteration = reshuffle_each_iteration
     self._name = name
 

--- a/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.data.-dataset.pbtxt
@@ -189,7 +189,7 @@ tf_class {
   }
   member_method {
     name: "shuffle"
-    argspec: "args=[\'self\', \'buffer_size\', \'seed\', \'reshuffle_each_iteration\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+    argspec: "args=[\'self\', \'buffer_size\', \'seed\', \'reshuffle_each_iteration\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'True\', \'None\'], "
   }
   member_method {
     name: "skip"

--- a/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.data.-dataset.pbtxt
@@ -156,7 +156,7 @@ tf_class {
   }
   member_method {
     name: "shuffle"
-    argspec: "args=[\'self\', \'buffer_size\', \'seed\', \'reshuffle_each_iteration\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'None\', \'None\'], "
+    argspec: "args=[\'self\', \'buffer_size\', \'seed\', \'reshuffle_each_iteration\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'True\', \'None\'], "
   }
   member_method {
     name: "skip"


### PR DESCRIPTION
## Summary

Set the default `reshuffle_each_iteration` value in `tf.data.Dataset.shuffle` method to `True` directly (previous was `None` but was interpreted to `True`) to raise awareness of possible silent data leakage, see discussion #59279.

## Details (copied and cleaned up from #59279)

The `Dataset.shuffle` method might lead to **dangerously silent** data leakage:

In the [Dataset doc](https://www.tensorflow.org/api_docs/python/tf/data/Dataset) under the `shuffle` method, it reads:

> shuffle(
>     buffer_size, seed=None, reshuffle_each_iteration=None, name=None
> )

where the `reshuffle_each_iteration=None` is **super misleading**, as it be easily misinterpreted that reshuffled is off by default (**which is not true at all**).

The `shuffle` method, which called `shuffle_op._shuffle`:
https://github.com/tensorflow/tensorflow/blob/4dacf3f368eb7965e9b5c3bbdd5193986081c3b2/tensorflow/python/data/ops/dataset_ops.py#L1472-L1473
  
which then called `_ShuffleDataset`:
  https://github.com/tensorflow/tensorflow/blob/b756c44e3f3ed52ccb4f05736569b95f4481eea0/tensorflow/python/data/ops/shuffle_op.py#L25-L32
  
which finally inititate the `_ShuffleDataset` class:
https://github.com/tensorflow/tensorflow/blob/b756c44e3f3ed52ccb4f05736569b95f4481eea0/tensorflow/python/data/ops/shuffle_op.py#L35-L50

has the following dangerous definition:
```
if reshuffle_each_iteration is None:
      reshuffle_each_iteration = True
```

As a result, the default `reshuffle_each_iteration = None` would be interpreted to `reshuffle_each_iteration = True` (which is truly unexpected by user).

## TODO list:
- [X] Set the default value of `reshuffle_each_iteration` directly to `True`
- [x] Add warning in docs about possible data leakage related to `reshuffle_each_iteration = True`
~~Issue warning when training/validation datasets are split by using the `shuffle + take/skip` pattern~~ (scheduled for a separate follow-up PR)

