### PR TITLE
Rectify in-memory buffer model loading for s390x

### DIFF
--- a/tensorflow/lite/tools/model_loader.cc
+++ b/tensorflow/lite/tools/model_loader.cc
@@ -62,6 +62,9 @@ bool BufferModelLoader::InitInternal() {
   }
   model_ = FlatBufferModel::VerifyAndBuildFromBuffer(caller_owned_buffer_,
                                                      model_size_);
+#if FLATBUFFERS_LITTLEENDIAN == 0
+  model_ = FlatBufferModel::ByteConvertModel(std::move(model_));
+#endif
   return true;
 }
 


### PR DESCRIPTION
After introducing [commit](https://github.com/tensorflow/tensorflow/commit/38a44709efd6e51421a58bfb7df32cf9f7af8fff) to add in-memory model support for mini-benchmark, below test cases started to fail on s390x(BE machines) :
```
//tensorflow/lite/experimental/acceleration/mini_benchmark:validator_runner_impl_test
//tensorflow/lite/experimental/acceleration/mini_benchmark:blocking_validator_runner_test
```
Reason for the failures is because TFLite buffers in buffer model are being loaded in LE format.
After this PR, buffer model will be loading TFLite buffers in BE format for BE plaforms, rectifying above mentioned test cases for s390x. 

These changes will not cause any regression on LE/BE platforms.