### PR TITLE
Encode data for bitcast in LE for BE systems

### DIFF
--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -898,6 +898,7 @@ cc_library(
         "//tensorflow/lite:string",
         "@farmhash_archive//:farmhash",
         "//third_party/fft2d:fft2d_headers",
+	"@local_tsl//tsl/util:byte_swap_array",
     ],
 )
 

--- a/tensorflow/lite/kernels/bitcast_test.cc
+++ b/tensorflow/lite/kernels/bitcast_test.cc
@@ -119,27 +119,15 @@ TEST(BitcastOpModel, BitcastUInt32Toint16) {
                                  (uint32_t)UINT16_MAX};
   m.PopulateTensor<uint32_t>(m.input(), input);
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
-#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
-    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-  // 00..01 00..00
-  // 00..00 11..11
-  std::vector<int16_t> output = {1, 0, 0, -1};
-#else
   // 00..00 00..01
   // 11..11 00..00
   std::vector<int16_t> output = {0, 1, -1, 0};
-#endif
   EXPECT_THAT(m.ExtractVector<int16_t>(m.output()), ElementsAreArray(output));
 }
 
 TEST(BitcastOpModel, BitcastInt16ToUint32) {
   BitcastOpModel m({TensorType_INT16, {2, 1, 2}}, {TensorType_UINT32, {2, 1}});
-#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
-    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-  std::vector<int16_t> input = {1, 0, 0, -1};
-#else
   std::vector<int16_t> input = {0, 1, -1, 0};
-#endif
   m.PopulateTensor<int16_t>(m.input(), input);
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
   std::vector<uint32_t> output = {(uint32_t)UINT16_MAX + 1,


### PR DESCRIPTION
After introducing [commit](https://github.com/tensorflow/tensorflow/commit/ace44332389423ac161c4b04e1b1ca9ca5ce8898) to add builtin op bitcast for TFLite, below test cases started failing for s390x(BE systems):
```
//tensorflow/lite/testing:zip_test_bitcast
//tensorflow/lite/testing:zip_test_bitcast_forward-compat
//tensorflow/lite/testing:zip_test_bitcast_forward-compat_xnnpack
//tensorflow/lite/testing:zip_test_bitcast_mlir-quant
//tensorflow/lite/testing:zip_test_bitcast_mlir-quant_xnnpack
//tensorflow/lite/testing:zip_test_bitcast_with-flex
//tensorflow/lite/testing:zip_test_bitcast_with-flex_xnnpack
//tensorflow/lite/testing:zip_test_bitcast_xnnpack
```
Reason for the failure is zip_test_bitcast is comparing Bitcast operation output from TF with builtin Bitcast tflite operation output.
As per tf.bitcast [documentation](https://www.tensorflow.org/api_docs/python/tf/bitcast#:~:text=Bitcast%20is%20implemented%20as%20a%20low%2Dlevel%20cast%2C%20so%20machines%20with%20different%20endian%20orderings%20will%20give%20different%20results.%20A%20copy%20from%20input%20buffer%20to%20output%20buffer%20is%20made%20on%20BE%20machines%20when%20types%20are%20of%20different%20sizes%20in%20order%20to%20get%20the%20same%20casting%20results%20as%20on%20LE%20machines.), bitcast output should be encoded in LE for BE machines.
Since the builtin Bitcast op is providing native output(BE for BE machines), it is not consistent w.r.t tf.bitcast behaviour.

After this PR, bitcast operation will be consistent across TF and TFLite, rectifying above mentioned test cases for s390x.
These changes will not cause any regression on LE/BE platforms.