### PR TITLE
Validate argument minvalue of tf.random.uniform

### DIFF
--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -25,6 +25,7 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_random_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import shape_util
+from tensorflow.python.ops import check_ops
 
 # go/tf-wildcard-import
 # pylint: disable=wildcard-import
@@ -291,11 +292,6 @@ def random_uniform(shape,
     if dtype.is_integer:
       raise ValueError("Must specify maxval for integer dtype %r" % dtype)
     maxval = 1
-  if minval >= maxval:
-    raise ValueError(
-        "`minval` should be lower than `maxval`, "
-        f"got minval={minval}, maxval={maxval}. "
-    )
   with ops.name_scope(name, "random_uniform", [shape, minval, maxval]) as name:
     shape = shape_util.shape_tensor(shape)
     # In case of [0,1) floating results, minval and maxval is unused. We do an
@@ -305,6 +301,10 @@ def random_uniform(shape,
     if not minval_is_zero or not maxval_is_one or dtype.is_integer:
       minval = ops.convert_to_tensor(minval, dtype=dtype, name="min")
       maxval = ops.convert_to_tensor(maxval, dtype=dtype, name="max")
+    check_ops.assert_less(minval, maxval, 
+                   message= "`minval` should be less than `maxval`. ",
+                   summarize=None, 
+                   name=None)
     seed1, seed2 = random_seed.get_seed(seed)
     if dtype.is_integer:
       result = gen_random_ops.random_uniform_int(

--- a/tensorflow/python/ops/random_ops.py
+++ b/tensorflow/python/ops/random_ops.py
@@ -291,6 +291,11 @@ def random_uniform(shape,
     if dtype.is_integer:
       raise ValueError("Must specify maxval for integer dtype %r" % dtype)
     maxval = 1
+  if minval >= maxval:
+    raise ValueError(
+        "`minval` should be lower than `maxval`, "
+        f"got minval={minval}, maxval={maxval}. "
+    )
   with ops.name_scope(name, "random_uniform", [shape, minval, maxval]) as name:
     shape = shape_util.shape_tensor(shape)
     # In case of [0,1) floating results, minval and maxval is unused. We do an


### PR DESCRIPTION
At present the API, `tf.random.uniform` raises `InvalidArgumentError` if `minval` >= `maxval` for `int` dtype only. This check happens in C++ backend for `int` data type only.

However same is not true for `float` datatype. It will not raise an error and It is ignoring min and max values in this case considering the range only.

The behaviour should be same for `int` and `float` dtypes. Hence for uniformity, I am adding validation for same at python level itself.

Attaching gist for same.

This is effecting `keras.initializers.RandomUniform` also which was discussed in tf-kears repo at #[449](https://github.com/keras-team/tf-keras/issues/449)