### PR TITLE
[onednn] Enable auto_mixed_precision for fp16 on cpu

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -1069,8 +1069,6 @@ class AutoMixedPrecisionImpl {
       case AutoMixedPrecisionMode::BF16:
         return std::make_unique<AutoMixedPrecisionListsMkl>();
       case AutoMixedPrecisionMode::CPU:
-        // Note: this is not a typo here. AutoMixedPrecisionListsFp16 is used
-        // intentionally to make CPU and GPU have the same fp16 ops.
         return std::make_unique<AutoMixedPrecisionListsFp16>(
             /*cuda_version=*/10000,   // Hardcode cuda and cudnn version so
             /*cudnn_version=*/8000,   // CPU emulates the same ops on GPU.
@@ -2308,14 +2306,14 @@ Status AutoMixedPrecision::Optimize(Cluster* cluster, const GrapplerItem& item,
   int num_gpus = GetNumGPUs(*cluster);
   if (num_gpus < 1 && mode_ == AutoMixedPrecisionMode::CUDA) {
     // No GPUs to run AutoMixedPrecision in FP16.
-    LOG(WARNING) << "No (suitable) GPUs detected, skipping " << name()
+    VLOG(1) << "No (suitable) GPUs detected, skipping " << name()
                  << " graph optimizer";
     return OkStatus();
   }
   // Check if CPU supports FP16
   if (mode_ == AutoMixedPrecisionMode::FP16_CPU &&
       !IsAMXDataTypeSupportedByOneDNNOnThisCPU(DT_HALF)) {
-    LOG(WARNING) << "No support for " << name() << " graph optimizer on CPU";
+    VLOG(1) << "No support for " << name() << " graph optimizer on CPU";
     return OkStatus();
   }
 

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -2314,7 +2314,7 @@ Status AutoMixedPrecision::Optimize(Cluster* cluster, const GrapplerItem& item,
   bool run_fp16_on_cpu = false;
   if (num_gpus < 1 && mode_ == AutoMixedPrecisionMode::CUDA) {
     // No GPUs to run AutoMixedPrecision in FP16.
-    // Check if CPU supports
+    // Check if CPU supports FP16.
     if (!IsAMXDataTypeSupportedByOneDNNOnThisCPU(DT_HALF)) {
       LOG(WARNING) << "No support for " << name() << " graph optimizer on CPU/GPU";
       return OkStatus();

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.h
@@ -26,15 +26,16 @@ namespace grappler {
 // CUDA: convert to float16 on GPU
 // BF16: convert to bfloat16 on CPU
 // CPU: emulate float16 on CPU without changing operator kernel
-enum class AutoMixedPrecisionMode { CUDA, BF16, CPU };
+// FP16_CPU : convert to float16 on CPU
+enum class AutoMixedPrecisionMode { CUDA, BF16, CPU, FP16_CPU };
 
 // Convert data types to float16 or bfloat16 where appropriate to improve
 // performance on GPUs or CPUs.
 class AutoMixedPrecision : public GraphOptimizer {
  public:
-  // If 'mode' is CUDA, converts nodes to float16 on Nvidia GPUs. If BF16,
-  // converts nodes to bfloat16 on CPUs in order to take advantage of oneDNN
-  // performance improvements with bfloat16.
+  // If 'mode' is CUDA, converts nodes to float16 on Nvidia GPUs. If BF16 or
+  // FP16_CPU, converts nodes to bfloat16/fp16 on CPUs in order to take
+  // advantage of oneDNN performance improvements with bfloat16/fp16.
   explicit AutoMixedPrecision(
       AutoMixedPrecisionMode mode = AutoMixedPrecisionMode::CUDA)
       : mode_(mode) {}
@@ -49,6 +50,9 @@ class AutoMixedPrecision : public GraphOptimizer {
         return "auto_mixed_precision_onednn_bfloat16";
       case AutoMixedPrecisionMode::CPU:
         return "auto_mixed_precision_cpu";
+      case AutoMixedPrecisionMode::FP16_CPU:
+        // Note: use same config for FP16 on CPU & GPU.
+        return "auto_mixed_precision";
       default:
         LOG(FATAL) << "Invalid value for AutoMixedPrecisionMode: "  // Crash Ok
                    << static_cast<int>(mode_);

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.h
@@ -51,8 +51,8 @@ class AutoMixedPrecision : public GraphOptimizer {
       case AutoMixedPrecisionMode::CPU:
         return "auto_mixed_precision_cpu";
       case AutoMixedPrecisionMode::FP16_CPU:
-        // Note: use same config for FP16 on CPU & GPU.
-        return "auto_mixed_precision";
+        // Note: using different name than GPU for ease of debugging.
+        return "auto_mixed_precision_onednn_float16";
       default:
         LOG(FATAL) << "Invalid value for AutoMixedPrecisionMode: "  // Crash Ok
                    << static_cast<int>(mode_);

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -112,9 +112,13 @@ class AutoMixedPrecisionListsFp16 : public AutoMixedPrecisionLists {
       : cuda_version_(cuda_version), cudnn_version_(cudnn_version) {
     if (mode == AutoMixedPrecisionMode::CUDA ||
         mode == AutoMixedPrecisionMode::CPU) {
+      // Note: this is not a typo here. use_cuda_ is set to true for the CPU
+      // intentionally to make CPU and GPU have the same fp16 ops.
       use_cuda_ = true;
+      use_onednn_ = false;
     } else if (mode == AutoMixedPrecisionMode::FP16_CPU) {
       use_onednn_ = true;
+      use_cuda_ = false;
     }
   }
 
@@ -421,12 +425,10 @@ class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {
                                      "BiasAddGrad",
                                      "BiasAddV1",
                                      "Erf",
-                                     "Erfc",
                                      "FusedBatchNormV2",
                                      "FusedBatchNormGradV2",
                                      "FusedBatchNormV3",
                                      "FusedBatchNormGradV3",
-                                     "Inv",
                                      "LeakyRelu",
                                      "LeakyReluGrad",
                                      "Mul",
@@ -509,7 +511,6 @@ class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {
         "Greater",
         "GreaterEqual",
         "Identity",
-        "IdentityN",
         "IsFinite",
         "IsInf",
         "IsNan",

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/core/lib/gtl/flatset.h"
 #include "tensorflow/core/lib/strings/str_util.h"
 #include "tensorflow/core/util/env_var.h"
+#include "tensorflow/core/util/util.h"
 
 namespace tensorflow {
 namespace grappler {
@@ -106,8 +107,11 @@ class AutoMixedPrecisionListsCuda : public AutoMixedPrecisionLists {
   }
 
  public:
-  AutoMixedPrecisionListsCuda(int cuda_version, int cudnn_version)
-      : cuda_version_(cuda_version), cudnn_version_(cudnn_version) {}
+  AutoMixedPrecisionListsCuda(int cuda_version, int cudnn_version,
+                              bool run_fp16_on_cpu = false)
+      : cuda_version_(cuda_version),
+        cudnn_version_(cudnn_version),
+        run_fp16_on_cpu_(run_fp16_on_cpu) {}
 
   gtl::FlatSet<string> AllowList() override {
     auto list = gtl::FlatSet<string>{
@@ -143,13 +147,13 @@ class AutoMixedPrecisionListsCuda : public AutoMixedPrecisionLists {
 #if TENSORFLOW_USE_ROCM
     if (true) {
 #else
-    if (cuda_version_ >= 9010) {
+    if (cuda_version_ >= 9010 || run_fp16_on_cpu_) {
       // Fp16 BatchMatMul is slow before CUDA 9.1.
 #endif
       list.insert("BatchMatMul");
       list.insert("BatchMatMulV2");
     }
-    if (cudnn_version_ >= 7602) {
+    if (cudnn_version_ >= 7602 || run_fp16_on_cpu_) {
       // Fp16 3D conv is slow before CUDNN 7.6.2.
       list.insert("Conv3D");
       list.insert("Conv3DBackpropFilter");
@@ -157,7 +161,7 @@ class AutoMixedPrecisionListsCuda : public AutoMixedPrecisionLists {
       list.insert("Conv3DBackpropInput");
       list.insert("Conv3DBackpropInputV2");
     }
-    if (cudnn_version_ >= 8000) {
+    if (cudnn_version_ >= 8000 || run_fp16_on_cpu_) {
       list.insert("DepthwiseConv2dNative");
       list.insert("DepthwiseConv2dNativeBackpropFilter");
       list.insert("DepthwiseConv2dNativeBackpropInput");
@@ -220,6 +224,11 @@ class AutoMixedPrecisionListsCuda : public AutoMixedPrecisionLists {
         "Tanh",
         "TanhGrad",
     };
+    if (run_fp16_on_cpu_) {
+      list.insert("Rsqrt");
+      list.insert("Square");
+      list.insert("SquaredDifference");
+    }
     UpdateList("INFERLIST", &list);
     // For backwards compatibility, keeping the original env variable here.
     // TODO(reedwm): This should be removed if we don't have active users.
@@ -352,6 +361,10 @@ class AutoMixedPrecisionListsCuda : public AutoMixedPrecisionLists {
         "Where",
         "ZerosLike",
     };
+    if (run_fp16_on_cpu_) {
+      list.insert("ResizeBilinear");
+      list.insert("ScatterNd");
+    }
     AddTensorListOps(&list);
     UpdateList("CLEARLIST", &list);
     return list;
@@ -360,6 +373,7 @@ class AutoMixedPrecisionListsCuda : public AutoMixedPrecisionLists {
  private:
   int cuda_version_;
   int cudnn_version_;
+  bool run_fp16_on_cpu_;
 };
 
 class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
@@ -1285,6 +1285,7 @@ INSTANTIATE_TEST_SUITE_P(AutoMixedPrecisionTest, AutoMixedPrecisionParamTest,
 #endif
                           }));
 
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 class AutoMixedPrecisionCpuTest : public GrapplerTest {
  protected:
   void SetUp() override {
@@ -1479,7 +1480,6 @@ class AutoMixedPrecisionSimulateGpuTest : public GrapplerTest {
   }
 };
 
-#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 TEST_F(AutoMixedPrecisionSimulateGpuTest, Simple_NoGpu) {
   TestSimple(tensorflow::Scope::NewRootScope(), /* is_optimized= */ false);
 }

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
@@ -125,7 +125,7 @@ class AutoMixedPrecisionTest : public GrapplerTest {
         virtual_cluster_.reset(
             new VirtualCluster({{"/GPU:1", device_properties}}));
       } else {
-	// try running on CPU
+	// When no GPUs are available, try running on CPU.
         DeviceProperties device_properties;
         device_properties.set_type("CPU");
         virtual_cluster_.reset(new SingleMachine(/* timeout_s = */ 10, 1, 0));

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
@@ -1311,8 +1311,7 @@ INSTANTIATE_TEST_SUITE_P(AutoMixedPrecisionTest, AutoMixedPrecisionParamTest,
                          ::testing::ValuesIn({
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
                            AutoMixedPrecisionMode::CUDA,
-#endif
-#if INTEL_MKL
+#elif INTEL_MKL
                            AutoMixedPrecisionMode::FP16_CPU
 #endif
                           }));

--- a/tensorflow/core/grappler/optimizers/meta_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.cc
@@ -231,6 +231,8 @@ std::unique_ptr<GraphOptimizer> MetaOptimizer::MakeNewOptimizer(
          new AutoMixedPrecision(AutoMixedPrecisionMode::CUDA));
 #ifdef INTEL_MKL
   if (IsMKLEnabled()) {
+    MK_OPT("auto_mixed_precision", "auto_mixed_precision",
+           new AutoMixedPrecision(AutoMixedPrecisionMode::FP16_CPU));
     MK_OPT("auto_mixed_precision_mkl", "auto_mixed_precision_mkl",
            new AutoMixedPrecision(AutoMixedPrecisionMode::BF16));
     MK_OPT("auto_mixed_precision_onednn_bfloat16",

--- a/tensorflow/core/grappler/optimizers/meta_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.cc
@@ -372,16 +372,12 @@ Status MetaOptimizer::InitializeOptimizers(
       optimizers->push_back(std::make_unique<ShapeOptimizer>());
   }
   if (AutoMixedPrecisionEnabled(cfg_.auto_mixed_precision()) &&
-      AutoMixedPrecisionEnabled(
-          plugin_configs.toggle_config["auto_mixed_precision"])) {
-    if (device_types.size() == 1 &&
-        device_types.find("CPU") != device_types.end()) {
-      optimizers->push_back(
-          std::make_unique<AutoMixedPrecision>(AutoMixedPrecisionMode::FP16_CPU));
-    } else {
-      optimizers->push_back(
-          std::make_unique<AutoMixedPrecision>(AutoMixedPrecisionMode::CUDA));
-    }
+    AutoMixedPrecisionEnabled(
+        plugin_configs.toggle_config["auto_mixed_precision"])) {
+    optimizers->push_back(
+        std::make_unique<AutoMixedPrecision>(AutoMixedPrecisionMode::FP16_CPU));
+    optimizers->push_back(
+        std::make_unique<AutoMixedPrecision>(AutoMixedPrecisionMode::CUDA));
   }
 #ifdef INTEL_MKL
   if (AutoMixedPrecisionEnabled(cfg_.auto_mixed_precision_onednn_bfloat16()) &&

--- a/tensorflow/core/grappler/optimizers/meta_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/meta_optimizer.cc
@@ -374,8 +374,14 @@ Status MetaOptimizer::InitializeOptimizers(
   if (AutoMixedPrecisionEnabled(cfg_.auto_mixed_precision()) &&
       AutoMixedPrecisionEnabled(
           plugin_configs.toggle_config["auto_mixed_precision"])) {
-    optimizers->push_back(
-        std::make_unique<AutoMixedPrecision>(AutoMixedPrecisionMode::CUDA));
+    if (device_types.size() == 1 &&
+        device_types.find("CPU") != device_types.end()) {
+      optimizers->push_back(
+          std::make_unique<AutoMixedPrecision>(AutoMixedPrecisionMode::FP16_CPU));
+    } else {
+      optimizers->push_back(
+          std::make_unique<AutoMixedPrecision>(AutoMixedPrecisionMode::CUDA));
+    }
   }
 #ifdef INTEL_MKL
   if (AutoMixedPrecisionEnabled(cfg_.auto_mixed_precision_onednn_bfloat16()) &&

--- a/tensorflow/core/protobuf/rewriter_config.proto
+++ b/tensorflow/core/protobuf/rewriter_config.proto
@@ -102,8 +102,8 @@ message RewriterConfig {
   // Enable the swap of kernel implementations based on the device placement
   // (default is ON).
   Toggle implementation_selector = 22;
-  // Optimize data types for CUDA (default is OFF).
-  // This will try to use float16 on GPU which is faster.
+  // Optimize data types for CUDA/oneDNN (default is OFF).
+  // This will try to use float16 on GPU/CPU which is faster.
   // Note that this can change the numerical stability of the graph and may
   // require the use of loss scaling to maintain model convergence.
   Toggle auto_mixed_precision = 23;

--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -242,8 +242,8 @@ def set_optimizer_experimental_options(options):
       - implementation_selector: Enable the swap of kernel implementations based
         on the device placement.
       - auto_mixed_precision: Change certain float32 ops to float16 on Volta
-        GPUs and above. Without the use of loss scaling, this can cause
-        numerical underflow (see
+        GPUs and above; and on CPUs with AMX FP16 support. Without the use of
+        loss scaling, this can cause numerical underflow (see
         `keras.mixed_precision.experimental.LossScaleOptimizer`).
       - disable_meta_optimizer: Disable the entire meta optimizer.
       - min_graph_nodes: The minimum number of nodes in a graph to optimizer.


### PR DESCRIPTION
This PR enables AMP FP16 on supporting Intel Xeon CPUs. If there is no GPU available to run FP16, it checks if FP16 can be executed on CPU.
Use config `auto_mixed_precision`  to enable FP16 on CPUs.