### PR TITLE
[oneDNN][Bug Fix]Fix a pooling ops primitive caching problem

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
@@ -226,6 +226,7 @@ class MklPoolingFwdPrimitiveFactory : public MklPrimitiveFactory<T> {
 #endif  // ENABLE_ONEDNN_V3
     key_creator.AddAsKey(fwdParams.padding_left);
     key_creator.AddAsKey(fwdParams.padding_right);
+    key_creator.AddAsKey(fwdParams.src_format);
     key_creator.AddAsKey<int>(static_cast<int>(fwdParams.alg_kind));
     key_creator.AddAsKey<int>(static_cast<int>(fwdParams.prop_kind));
     return key_creator.GetKey();
@@ -382,6 +383,7 @@ class MklPoolingBwdPrimitiveFactory : public MklPrimitiveFactory<T> {
 #endif  // ENABLE_ONEDNN_V3
     key_creator.AddAsKey(bwdParams.padding_left);
     key_creator.AddAsKey(bwdParams.padding_right);
+    key_creator.AddAsKey(bwdParams.src_format);
     key_creator.AddAsKey<int>(static_cast<int>(bwdParams.alg_kind));
     return key_creator.GetKey();
   }


### PR DESCRIPTION
This PR fixes a problem which is related to oneDNN pooling ops primitive caching.
Related ticket is: https://github.com/tensorflow/tensorflow/issues/61482


The problem occurs when running the max (applicable to avg) pooling op twice with same input sizes
1. first time is with NCHW format
2. the other is with NHWC format.

The fix is done by adding src format into caching key.