### PR TITLE
Upgrade Clang version on Windows Platform

### DIFF
--- a/tensorflow/lite/experimental/microfrontend/lib/bits.h
+++ b/tensorflow/lite/experimental/microfrontend/lib/bits.h
@@ -30,13 +30,13 @@ static inline int CountLeadingZeros32Slow(uint64_t n) {
 }
 
 static inline int CountLeadingZeros32(uint32_t n) {
-#if defined(_MSC_VER)
+#if !defined(__clang__) && defined(_MSC_VER)
   unsigned long result = 0;  // NOLINT(runtime/int)
   if (_BitScanReverse(&result, n)) {
     return 31 - result;
   }
   return 32;
-#elif defined(__GNUC__)
+#elif defined (__clang__) && defined(__GNUC__)
 
   // Handle 0 as a special case because __builtin_clz(0) is undefined.
   if (n == 0) {
@@ -62,14 +62,14 @@ static inline int CountLeadingZeros64Slow(uint64_t n) {
 }
 
 static inline int CountLeadingZeros64(uint64_t n) {
-#if defined(_MSC_VER) && defined(_M_X64)
+#if !defined(__clang__) && defined(_MSC_VER) && defined(_M_X64)
   // MSVC does not have __builtin_clzll. Use _BitScanReverse64.
   unsigned long result = 0;  // NOLINT(runtime/int)
   if (_BitScanReverse64(&result, n)) {
     return 63 - result;
   }
   return 64;
-#elif defined(_MSC_VER)
+#elif !defined(__clang__) && defined(_MSC_VER)
   // MSVC does not have __builtin_clzll. Compose two calls to _BitScanReverse
   unsigned long result = 0;  // NOLINT(runtime/int)
   if ((n >> 32) && _BitScanReverse(&result, n >> 32)) {
@@ -79,7 +79,7 @@ static inline int CountLeadingZeros64(uint64_t n) {
     return 63 - result;
   }
   return 64;
-#elif defined(__GNUC__)
+#elif defined(__clang__) || defined(__GNUC__)
 
   // Handle 0 as a special case because __builtin_clzll(0) is undefined.
   if (n == 0) {

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -14,11 +14,6 @@ CURL_WIN_COPTS = [
     "/DCURL_DISABLE_PROXY",
     "/DHAVE_LIBZ",
     "/DHAVE_ZLIB_H",
-    # Defining _USING_V110_SDK71_ is hackery to defeat curl's incorrect
-    # detection of what OS releases we can build on with VC 2012. This
-    # may not be needed (or may have to change) if the WINVER setting
-    # changes in //third_party/msvc/vc_12_0/CROSSTOOL.
-    "/D_USING_V110_SDK71_",
 ]
 
 CURL_WIN_SRCS = [


### PR DESCRIPTION
This PR aims to upgrade the Clang version from 15.0.7 to 17.0.6 on the Windows platform and bring TensorFlow builds on Windows and Linux on the same compiler version to facilitate convenient debugging for the issues related to the compiler

The following changes have been made:

1. Updated https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/experimental/microfrontend/lib/bits.h
to pick the correct inbuilt function __builtin_clzll supported on the Clang compiler on the Windows platform
2. Removed the hack "/D_USING_V110_SDK71_" https://github.com/tensorflow/tensorflow/blob/master/third_party/curl.BUILD#L21
that was blocking the intended Windows configuration defined in the header sdkddkver.h, if WINVER is undefined, WINVER is set equal to _WIN32_WINNT.