### PR TITLE
Correct tag to exclude on AARCH64 to be no_aarch64

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3877,7 +3877,7 @@ tf_cuda_cc_test(
     name = "matmul_op_test",
     srcs = ["matmul_op_test.cc"],
     tags = [
-        "no_arm64",  # b/282068262
+        "no_aarch64",  # b/282068262
     ],
     deps = [
         ":matmul_op",


### PR DESCRIPTION
Correct this sole use of no_arm64 to be no_aarch64 to be consistent with pre-existing tag and usage.