### PR TITLE
Include missing tsl/xla folders on Windows

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -249,6 +249,10 @@ class InstallHeaders(Command):
 
   def mkdir_and_copy_file(self, header):
     install_dir = os.path.join(self.install_dir, os.path.dirname(header))
+    # Windows platform uses "\" in path strings, the external header location 
+    # expects "/" in paths. Hence, we replaced "\" with "/" for this reason
+    if platform.system()=="Windows":
+      install_dir=install_dir.replace("\\", "/")
     # Get rid of some extra intervening directories so we can have fewer
     # directories for -I
     install_dir = re.sub('/google/protobuf_archive/src', '', install_dir)


### PR DESCRIPTION
This PR aims to resolve the issue of the missing TSL and XLA folders within the 'include' directory in the TF release and nightly wheels specifically for the Windows platform. The folders are present for the Linux platform

It addresses the Github issues mentioned below:
https://github.com/tensorflow/tensorflow/issues/62579
https://github.com/tensorflow/tensorflow/issues/61830