### PR TITLE
[oneDNN] Fix macro titles in TF CPU feature guard

### DIFF
--- a/tensorflow/core/platform/cpu_feature_guard.cc
+++ b/tensorflow/core/platform/cpu_feature_guard.cc
@@ -111,18 +111,18 @@ class CPUFeatureGuard {
 #ifdef __AVXNECONVERT__
     CheckFeatureOrDie(CPUFeature::AVX_NE_CONVERT, "AVX_NE_CONVERT");
 #endif  // __AVXNECONVERT__
-#ifdef __AMXTILE__
+#ifdef __AMX_TILE__
     CheckFeatureOrDie(CPUFeature::AMX_TILE, "AMX_TILE");
-#endif  // __AMXTILE__
-#ifdef __AMXINT8__
+#endif  // __AMX_TILE__
+#ifdef __AMX_INT8__
     CheckFeatureOrDie(CPUFeature::AMX_INT8, "AMX_INT8");
-#endif  // __AMXINT8__
-#ifdef __AMXBF16__
+#endif  // __AMX_INT8__
+#ifdef __AMX_BF16__
     CheckFeatureOrDie(CPUFeature::AMX_BF16, "AMX_BF16");
-#endif  // __AMXBF16__
-#ifdef __AMXFP16__
+#endif  // __AMX_BF16__
+#ifdef __AMX_FP16__
     CheckFeatureOrDie(CPUFeature::AMX_FP16, "AMX_FP16");
-#endif  // __AMXFP16__
+#endif  // __AMX_FP16__
 #ifdef __FMA__
     CheckFeatureOrDie(CPUFeature::FMA, "FMA");
 #endif  // __FMA__
@@ -187,22 +187,22 @@ void InfoAboutUnusedCPUFeatures() {
     CheckIfFeatureUnused(CPUFeature::AVX_NE_CONVERT, "AVX_NE_CONVERT",
                          missing_instructions);
 #endif  // __AVXNECONVERT__
-#ifndef __AMXTILE__
+#ifndef __AMX_TILE__
     CheckIfFeatureUnused(CPUFeature::AMX_TILE, "AMX_TILE",
                          missing_instructions);
-#endif  // __AMXTILE__
-#ifndef __AMXINT8__
+#endif  // __AMX_TILE__
+#ifndef __AMX_INT8__
     CheckIfFeatureUnused(CPUFeature::AMX_INT8, "AMX_INT8",
                          missing_instructions);
-#endif  // __AMXINT8__
-#ifndef __AMXBF16__
+#endif  // __AMX_INT8__
+#ifndef __AMX_BF16__
     CheckIfFeatureUnused(CPUFeature::AMX_BF16, "AMX_BF16",
                          missing_instructions);
-#endif  // __AMXBF16__
-#ifndef __AMXFP16__
+#endif  // __AMX_BF16__
+#ifndef __AMX_FP16__
     CheckIfFeatureUnused(CPUFeature::AMX_FP16, "AMX_FP16",
                          missing_instructions);
-#endif  // __AMXFP16__
+#endif  // __AMX_FP16__
 #ifndef __FMA__
     CheckIfFeatureUnused(CPUFeature::FMA, "FMA", missing_instructions);
 #endif  // __FMA__


### PR DESCRIPTION
This PR fixes the titles of some of the macros used by the TF CPU feature guard and prevents displaying some erroneous messages while importing TensorFlow.
