### PR TITLE
Clang on Windows and Keras 3.0 Updates

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,16 @@
 
 <INSERT SMALL BLURB ABOUT RELEASE FOCUS AREA AND POTENTIAL TOOLCHAIN CHANGES>
 
+* TensorFlow Windows Build:
+ 
+  * Clang is now the default compiler to build TensorFlow CPU wheels 
+    on the Windows Platform starting with this release. The currently
+    supported version is LLVM/clang 17. The official Wheels-published
+    on PyPI will be based on Clang; however, users retain the option to build
+    wheels using the MSVC compiler following the steps mentioned in
+    https://www.tensorflow.org/install/source_windows
+    as has been the case before
+
 ### Breaking Changes
 
 * <DOCUMENT BREAKING CHANGES HERE>

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,6 +27,18 @@
 * `tf.estimator`
     * The tf.estimator API is removed.
 
+* Keras 3.0 will be the default Keras version. You may need to update your script to use Keras 3.0.
+* Please refer to the new Keras documentation for Keras 3.0(https://keras.io/keras_3).
+*
+* To continue using Keras 2.0, do the following.
+*   1. Set the environment vaiable TF_USE_LEGACY_KERAS to 1
+*   2. Change import of keras from tensorflow as follows
+*        import tensorflow.keras as keras
+              and
+         import keras
+              to
+         import tf_keras as keras
+
 
 ### Known Caveats
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,11 +28,13 @@
     * The tf.estimator API is removed.
 
 * Keras 3.0 will be the default Keras version. You may need to update your script to use Keras 3.0.
-* Please refer to the new Keras documentation for Keras 3.0(https://keras.io/keras_3).
-*
+* Please refer to the new Keras documentation for Keras 3.0 (https://keras.io/keras_3).
 * To continue using Keras 2.0, do the following.
-*   1. Set the environment vaiable TF_USE_LEGACY_KERAS to 1
-*   2. Change import of keras from tensorflow as follows
+*   1. Install tf-keras via pip install tf-keras~=2.16
+    2. To switch tf.keras to use Keras 2 (tf-keras), set the environment variable TF_USE_LEGACY_KERAS=1
+       directly or in your python program by import os;os.environ["TF_USE_LEGACY_KERAS"]=1.
+       Please note that this will set it for all packages in your Python runtime program
+*   3. Change import of keras from tensorflow as follows
 *        import tensorflow.keras as keras
               and
          import keras


### PR DESCRIPTION
Updated the release notes with two major changes

1. The transition of the compiler from MSVC to CLANG on the Windows Platform to build TensorFlow-CPU builds.

2. Updating release notes to reflect changes in Keras. With 2.16 Keras 3.0 release will be default keras. Keras 3.0 has many changes compared to the previous version: Keras 2.x. The changes can break customer models. Adding information in release notes for customers who want to keep using Keras 2.x version and those who want to move to Keras 3.0.