### PR TITLE
fix compile error in case CUDA_VERSION < 11060

### DIFF
--- a/third_party/xla/xla/backends/profiler/gpu/cupti_tracer.cc
+++ b/third_party/xla/xla/backends/profiler/gpu/cupti_tracer.cc
@@ -61,6 +61,7 @@ using CuptiActivityMemcpyTy = CUpti_ActivityMemcpy5;
 using CuptiActivityMemcpyP2PTy = CUpti_ActivityMemcpyPtoP4;
 using CuptiActivityMemsetTy = CUpti_ActivityMemset4;
 #else
+#define TF_CUPTI_HAS_CHANNEL_ID 0
 using CuptiActivityKernelTy = CUpti_ActivityKernel4;
 using CuptiActivityMemcpyTy = CUpti_ActivityMemcpy;
 using CuptiActivityMemcpyP2PTy = CUpti_ActivityMemcpy2;


### PR DESCRIPTION
I met and tried to fix this error in building process with CUDA_VERSION < 11060:

external/local_xla/xla/backends/profiler/gpu/cupti_tracer.cc:2177:34: error: ‘TF_CUPTI_HAS_CHANNEL_ID’ was not declared in this scope
 2177 |           AddKernelActivityEvent<TF_CUPTI_HAS_CHANNEL_ID>(
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~
external/local_xla/xla/backends/profiler/gpu/cupti_tracer.cc:2178:76: error: no matching function for call to ‘AddKernelActivityEvent<<expression error> >(xla::profiler::CuptiTraceCollector*&, xla::profiler::{anonymous}::CuptiActivityKernelTy*)’
 2178 |               collector_, reinterpret_cast<CuptiActivityKernelTy *>(record));