### PR TITLE
fix compile error in case CUDA_VERSION < 11060

### DIFF
--- a/third_party/xla/xla/backends/profiler/gpu/cupti_tracer.cc
+++ b/third_party/xla/xla/backends/profiler/gpu/cupti_tracer.cc
@@ -61,6 +61,7 @@ using CuptiActivityMemcpyTy = CUpti_ActivityMemcpy5;
 using CuptiActivityMemcpyP2PTy = CUpti_ActivityMemcpyPtoP4;
 using CuptiActivityMemsetTy = CUpti_ActivityMemset4;
 #else
+#define TF_CUPTI_HAS_CHANNEL_ID 0
 using CuptiActivityKernelTy = CUpti_ActivityKernel4;
 using CuptiActivityMemcpyTy = CUpti_ActivityMemcpy;
 using CuptiActivityMemcpyP2PTy = CUpti_ActivityMemcpy2;


### PR DESCRIPTION
I met and tried to fix the following compile error with cuda version 11.02:

```
external/local_xla/xla/backends/profiler/gpu/cupti_tracer.cc:2177:34: error: ‘TF_CUPTI_HAS_CHANNEL_ID’ was not declared in this scope
 2177 |           AddKernelActivityEvent<TF_CUPTI_HAS_CHANNEL_ID>(
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~
external/local_xla/xla/backends/profiler/gpu/cupti_tracer.cc:2178:76: error: no matching function for call to ‘AddKernelActivityEvent<<expression error> >(xla::profiler::CuptiTraceCollector*&, xla::profiler::{anonymous}::CuptiActivityKernelTy*)’
 2178 |               collector_, reinterpret_cast<CuptiActivityKernelTy *>(record));
```

building command:

```shell
wget https://github.com/tensorflow/tensorflow/archive/v2.15.0.zip && unzip v2.15.0.zip && cd tensorflow-2.15.0

TF_ENABLE_XLA=1 TF_NEED_CUDA=1 TF_CUDA_CLANG=0 TF_CUDA_COMPUTE_CAPABILITIES=8.0,7.5 TF_NEED_IGNITE=0 TF_NEED_OPENCL_SYCL=0 TF_NEED_ROCM=0 TF_DOWNLOAD_CLANG=0 TF_NEED_MPI=0 TF_SET_ANDROID_WORKSPACE=0  bash -c 'echo | ./configure'

bazelisk build --config=mkl --config=monolithic --config=noaws --config=nogcp --config=nonccl --config=nohdfs --@local_config_cuda//:cuda_compiler=clang --action_env=CLANG_CUDA_COMPILER_PATH=/usr/lib/llvm-16/bin/clang --action_env=TF_CUDNN_VERSION=8 --action_env=TF_CUDA_VERSION=11.2 tensorflow/tools/lib_package:libtensorflow
```