### PR TITLE
Do not rely on string conversion of anonymous namespace

### DIFF
--- a/tensorflow/compiler/mlir/lite/debug/debug_test.cc
+++ b/tensorflow/compiler/mlir/lite/debug/debug_test.cc
@@ -53,11 +53,7 @@ limitations under the License.
 #include "tsl/platform/status.h"
 
 namespace tensorflow {
-namespace {
-
-using ::testing::HasSubstr;
-using ::testing::IsEmpty;
-using ::testing::Not;
+namespace debug_test {
 
 class NopPass : public mlir::PassWrapper<NopPass, mlir::OperationPass<>> {
  public:
@@ -83,6 +79,15 @@ class AlwaysFailPass
 
   void runOnOperation() override { signalPassFailure(); }
 };
+
+} // namespace debug_test
+
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::IsEmpty;
+using ::testing::Not;
+using namespace tensorflow::debug_test;
 
 class InitPassManagerTest : public testing::Test {
  protected:
@@ -180,7 +185,7 @@ TEST_F(InitPassManagerTest, DumpToDir) {
         tsl::Env::Default(),
         tsl::io::JoinPath(
             dump_dir,
-            "00000000.main.tensorflow_anonymous_namespace_NopPass_after.mlir"),
+            "00000000.main.tensorflow_debug_test_NopPass_after.mlir"),
         &mlir_dump));
     EXPECT_THAT(mlir_dump, Not(IsEmpty()));
   }
@@ -190,7 +195,7 @@ TEST_F(InitPassManagerTest, DumpToDir) {
         tsl::Env::Default(),
         tsl::io::JoinPath(
             dump_dir,
-            "00000000.main.tensorflow_anonymous_namespace_NopPass_before.mlir"),
+            "00000000.main.tensorflow_debug_test_NopPass_before.mlir"),
         &mlir_dump));
     EXPECT_THAT(mlir_dump, Not(IsEmpty()));
   }
@@ -209,10 +214,10 @@ TEST_F(InitPassManagerTest, PrintIRBeforeEverything) {
 
   EXPECT_THAT(
       captured_out,
-      HasSubstr("IR Dump Before tensorflow::(anonymous namespace)::NopPass"));
+      HasSubstr("IR Dump Before tensorflow::debug_test::NopPass"));
   EXPECT_THAT(captured_out,
               Not(HasSubstr(
-                  "IR Dump After tensorflow::(anonymous namespace)::NopPass")));
+                  "IR Dump After tensorflow::debug_test::NopPass")));
 }
 
 TEST_F(InitPassManagerTest, PrintIRAfterEverything) {
@@ -228,11 +233,11 @@ TEST_F(InitPassManagerTest, PrintIRAfterEverything) {
 
   EXPECT_THAT(
       captured_out,
-      HasSubstr("IR Dump After tensorflow::(anonymous namespace)::MutatePass"));
+      HasSubstr("IR Dump After tensorflow::debug_test::MutatePass"));
   EXPECT_THAT(
       captured_out,
       Not(HasSubstr(
-          "IR Dump Before tensorflow::(anonymous namespace)::MutatePass")));
+          "IR Dump Before tensorflow::debug_test::MutatePass")));
 }
 
 TEST_F(InitPassManagerTest, PrintIRBeforeAndAfterEverything) {
@@ -249,11 +254,11 @@ TEST_F(InitPassManagerTest, PrintIRBeforeAndAfterEverything) {
 
   EXPECT_THAT(
       captured_out,
-      HasSubstr("IR Dump After tensorflow::(anonymous namespace)::MutatePass"));
+      HasSubstr("IR Dump After tensorflow::debug_test::MutatePass"));
   EXPECT_THAT(
       captured_out,
       HasSubstr(
-          "IR Dump Before tensorflow::(anonymous namespace)::MutatePass"));
+          "IR Dump Before tensorflow::debug_test::MutatePass"));
 }
 
 TEST_F(InitPassManagerTest, ElideLargeElementAttrs) {

--- a/tensorflow/compiler/mlir/quantization/tensorflow/debugging/mlir_dump_test.cc
+++ b/tensorflow/compiler/mlir/quantization/tensorflow/debugging/mlir_dump_test.cc
@@ -39,7 +39,7 @@ limitations under the License.
 
 namespace tensorflow {
 namespace quantization {
-namespace {
+namespace mlir_dump_test {
 
 class NoOpPass
     : public mlir::PassWrapper<NoOpPass, mlir::OperationPass<mlir::ModuleOp>> {
@@ -87,6 +87,12 @@ class ParentPass
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> CreateParentPass() {
   return std::make_unique<ParentPass>();
 }
+
+}  // namespace mlir_dump_test
+
+namespace {
+
+using namespace tensorflow::quantization::mlir_dump_test;
 
 class EnableIrPrintingTest : public ::testing::Test {
  protected:
@@ -146,8 +152,8 @@ module{
 
   TF_EXPECT_OK(tsl::Env::Default()->FileExists(
       tsl::io::JoinPath(test_dir_,
-                        "dump_0001_tensorflow::quantization::(anonymous "
-                        "namespace)::NoOpPass_before.mlir")));
+                        "dump_0001_tensorflow::quantization::mlir_dump_test"
+                        "::NoOpPass_before.mlir")));
   TF_EXPECT_OK(tsl::Env::Default()->FileExists(tsl::io::JoinPath(
       test_dir_, "dump_0002_Canonicalizer_func1_before.mlir")));
   TF_EXPECT_OK(tsl::Env::Default()->FileExists(tsl::io::JoinPath(
@@ -175,12 +181,12 @@ TEST_F(EnableIrPrintingTest, NestedPassSuccessfullyRuns) {
 
   TF_EXPECT_OK(tsl::Env::Default()->FileExists(
       tsl::io::JoinPath(test_dir_,
-                        "dump_0001_tensorflow::quantization::(anonymous "
-                        "namespace)::ParentPass_before.mlir")));
+                        "dump_0001_tensorflow::quantization::mlir_dump_test"
+                        "::ParentPass_before.mlir")));
   TF_EXPECT_OK(tsl::Env::Default()->FileExists(
       tsl::io::JoinPath(test_dir_,
-                        "dump2_0001_tensorflow::quantization::(anonymous "
-                        "namespace)::NoOpPass_before.mlir")));
+                        "dump2_0001_tensorflow::quantization::mlir_dump_test"
+                        "::NoOpPass_before.mlir")));
 }
 }  // namespace
 }  // namespace quantization


### PR DESCRIPTION
The conversion to a string of the name of an anonymous namespace can differ between compilers so do not rely on it. Instead give the namespace a name that can then be used in strings to check the desired functionality in the test.