### PR TITLE
Fix native Flatbuffers build

### DIFF
--- a/tensorflow/lite/tools/cmake/native_tools/flatbuffers/CMakeLists.txt
+++ b/tensorflow/lite/tools/cmake/native_tools/flatbuffers/CMakeLists.txt
@@ -40,4 +40,4 @@ else()
   set(FLATC_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE PATH "Flatc installation directory")
 endif()
 
-find_package(flatbuffers)
+find_package(FlatBuffers)


### PR DESCRIPTION
Reflect the rename of FindFlatbuffers.cmake file introduced in d8f98dd to native_tools/flatbuffers/CMakeLists.txt.