### PR TITLE
New Features for TFLite Delegates accuracy and correctness tools

### DIFF
--- a/tensorflow/lite/tools/evaluation/stages/inference_profiler_stage.h
+++ b/tensorflow/lite/tools/evaluation/stages/inference_profiler_stage.h
@@ -32,13 +32,15 @@ namespace evaluation {
 
 // An EvaluationStage to profile a custom TFLite inference config by comparing
 // performance in two settings:
-// 1. User-defined TfliteInferenceParams (The 'test' setting)
-// 2. Default TfliteInferenceParams (The 'reference' setting)
-// The latter essentially implies single-threaded CPU execution.
+// 1. The 'test' setting: User-defined TfliteInferenceParams
+// 2. The 'reference' setting: User-defined or default TfliteInferenceParams
+// The default essentially implies single-threaded CPU execution.
 class InferenceProfilerStage : public EvaluationStage {
  public:
   explicit InferenceProfilerStage(const EvaluationStageConfig& config)
       : EvaluationStage(config) {}
+  explicit InferenceProfilerStage(const EvaluationStageConfig& config, const EvaluationStageConfig& ref_config)
+      : EvaluationStage(config), reference_config_(ref_config) {}
 
   TfLiteStatus Init() override { return Init(nullptr); }
   TfLiteStatus Init(const DelegateProviders* delegate_providers);
@@ -49,10 +51,13 @@ class InferenceProfilerStage : public EvaluationStage {
   EvaluationStageMetrics LatestMetrics() override;
 
  private:
+  EvaluationStageConfig reference_config_;
+
   std::unique_ptr<TfliteInferenceStage> reference_stage_;
   std::unique_ptr<TfliteInferenceStage> test_stage_;
 
-  const TfLiteModelInfo* model_info_;
+  const TfLiteModelInfo* reference_model_info_;
+  const TfLiteModelInfo* test_model_info_;
   std::vector<int64_t> input_num_elements_;
   std::vector<int64_t> output_num_elements_;
 

--- a/tensorflow/lite/tools/evaluation/stages/inference_profiler_stage.h
+++ b/tensorflow/lite/tools/evaluation/stages/inference_profiler_stage.h
@@ -71,6 +71,7 @@ class InferenceProfilerStage : public EvaluationStage {
   std::vector<std::vector<uint8_t>> uint8_tensors_;
   std::vector<std::vector<uint16_t>> float16_tensors_;
   std::vector<std::vector<int64_t>> int64_tensors_;
+  std::vector<std::vector<int32_t>> int32_tensors_;
 };
 
 }  // namespace evaluation

--- a/tensorflow/lite/tools/evaluation/tasks/inference_diff/README.md
+++ b/tensorflow/lite/tools/evaluation/tasks/inference_diff/README.md
@@ -41,6 +41,9 @@ The binary takes the following parameters:
 
 and the following optional parameters:
 
+*   `ref_model_file` : `string` \
+    Path to the TFlite model file. If not set, the model from `model_file` will be used for reference.
+
 *   `num_runs`: `int` \
     How many runs to perform to compare execution in reference and test setting.
     Default: 50. The binary performs runs 3 invocations per 'run', to get more

--- a/tensorflow/lite/tools/evaluation/tasks/inference_diff/run_eval.cc
+++ b/tensorflow/lite/tools/evaluation/tasks/inference_diff/run_eval.cc
@@ -30,6 +30,7 @@ namespace tflite {
 namespace evaluation {
 
 constexpr char kModelFileFlag[] = "model_file";
+constexpr char kRefModelFileFlag[] = "ref_model_file";
 constexpr char kOutputFilePathFlag[] = "output_file_path";
 constexpr char kNumRunsFlag[] = "num_runs";
 constexpr char kInterpreterThreadsFlag[] = "num_interpreter_threads";
@@ -49,6 +50,7 @@ class InferenceDiff : public TaskExecutor {
  private:
   void OutputResult(const EvaluationStageMetrics& latest_metrics) const;
   std::string model_file_path_;
+  std::string ref_model_file_path_;
   std::string output_file_path_;
   std::string delegate_;
   int num_runs_;
@@ -60,6 +62,11 @@ std::vector<Flag> InferenceDiff::GetFlags() {
   std::vector<tflite::Flag> flag_list = {
       tflite::Flag::CreateFlag(kModelFileFlag, &model_file_path_,
                                "Path to test tflite model file."),
+      tflite::Flag::CreateFlag(kRefModelFileFlag, &ref_model_file_path_,
+                               "Path to reference tflite model file. This"
+                               " parameter is optional and if not set the"
+                               " model_file will be used for both - reference"
+                               " and test interpreter."),
       tflite::Flag::CreateFlag(kOutputFilePathFlag, &output_file_path_,
                                "File to output metrics proto to."),
       tflite::Flag::CreateFlag(kNumRunsFlag, &num_runs_,
@@ -94,8 +101,19 @@ std::optional<EvaluationStageMetrics> InferenceDiff::RunImpl() {
     TFLITE_LOG(WARN) << "Unsupported TFLite delegate: " << delegate_;
     return std::nullopt;
   }
+  // Initialize reference evaluation stage. If no reference model was given by
+  // the user, use test model.
+  EvaluationStageConfig ref_eval_config;
+  ref_eval_config.set_name("reference_inference_profiling");
+  auto* ref_inference_params = ref_eval_config.mutable_specification()
+    ->mutable_tflite_inference_params();
+  ref_inference_params->set_invocations_per_run(3);
+  if (!ref_model_file_path_.empty())
+    ref_inference_params->set_model_file_path(ref_model_file_path_);
+  else
+    ref_inference_params->set_model_file_path(model_file_path_);
+  InferenceProfilerStage eval(eval_config, ref_eval_config);
 
-  InferenceProfilerStage eval(eval_config);
   if (eval.Init(&delegate_providers_) != kTfLiteOk) return std::nullopt;
 
   // Run inference & check diff for specified number of runs.


### PR DESCRIPTION
The new features are: 

- **Option to use reference and test model for the evaluation tools.** This supports the cases, where the delegate does not perform inline model compilation for target compute IP but requires model to be preprocessed in advance.  For instance the workflow with Ethos-U NPU - the model is converted by Arm Vela tool, which replaces part of the compute graph with custom nodes recognized by the particular delegate. To evaluate the accuracy in this case one needs to supply both the reference and converted (test) model. The reference to be used with reference inference and test model with delegate. 
-  **Add support for int32 input/output**