### PR TITLE
🐛 fix undefined symbols (TensorFlowLiteCMetal)

### DIFF
--- a/tensorflow/lite/ios/allowlist_TensorFlowLiteCMetal.txt
+++ b/tensorflow/lite/ios/allowlist_TensorFlowLiteCMetal.txt
@@ -1,3 +1,4 @@
+_TFLGpuDelegateOptionsDefault
 _TFLGpuDelegateCreate
 _TFLGpuDelegateDelete
 _TFLGpuDelegateBindMetalBufferToTensor


### PR DESCRIPTION
I build `TensorFlowLiteCMetal`, and use it in my project.
The C function `TFLGpuDelegateOptionsDefault` which is exported in header file, but strip from framework.

https://github.com/tensorflow/tensorflow/blob/5297f6d8a67750f2bde7f5483526998f00ec15fe/tensorflow/lite/delegates/gpu/metal_delegate.h#L55C1-L59C81

<img width="835" alt="Screen-20240212@2x" src="https://github.com/tensorflow/tensorflow/assets/33711476/b3279f38-7108-4c65-aef2-b2938e5bb8e1">


After update `tensorflow/lite/iOS/allowlist_TensorFlowLiteCMetal.txt`. This symbol can be resolved correctly


