### PR TITLE
Fix calculation in resize_bicubic_op_test

### DIFF
--- a/tensorflow/core/kernels/image/resize_bicubic_op_test.cc
+++ b/tensorflow/core/kernels/image/resize_bicubic_op_test.cc
@@ -92,7 +92,13 @@ class ResizeBicubicOpTest : public OpsTestBase {
                                    std::array<float, 4>* weights,
                                    std::array<int64_t, 4>* indices) {
     const int64_t in_loc = scale * out_loc;
-    const float delta = scale * out_loc - in_loc;
+    // Ensure that the following calculation is kept in a float to match the
+    // rounding done in the optimised case. Merging it with the following line
+    // keeps an intermediate value at higher precision and that leads to a
+    // divergence in the result. So keep the following two lines separate to
+    // ensure that the calculation is rounded as expected.
+    const float in_loc_float = scale * out_loc;
+    const float delta = in_loc_float - in_loc;
     const int64_t offset = lrintf(delta * kTableSize);
     const float* coeffs_tab = GetCoeffsTable();
     *weights = {{coeffs_tab[offset * 2 + 1], coeffs_tab[offset * 2],

--- a/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
+++ b/tensorflow/tools/ci_build/build_scripts/ARM_SKIP_TESTS.sh
@@ -16,5 +16,4 @@
 set -x
 
 ARM_SKIP_TESTS="-//tensorflow/lite/... \
--//tensorflow/core/kernels/image:resize_bicubic_op_test \
 "


### PR DESCRIPTION
Ensure that the baseline calculation matches the optimised case even when on a compiler and architecture that can use higher precision intermediate values which result in different calculated values. This is done by splitting one calculation into two parts so that the intermediate value is truncated so that it can be stored in a float. This ensures that the baseline and the optimised calculations do not diverge.