### PR TITLE
validate batch_size arg of   tf.raw_ops.RecordInput

### DIFF
--- a/tensorflow/core/kernels/record_input_op.cc
+++ b/tensorflow/core/kernels/record_input_op.cc
@@ -44,6 +44,10 @@ class RecordInputOp : public OpKernel {
     OP_REQUIRES(ctx, file_parallelism >= 0,
                 errors::InvalidArgument("file_parallelism should >= 0, got ",
                                         file_parallelism));
+    OP_REQUIRES(
+        ctx, batch_size >= 0,
+        errors::InvalidArgument(
+            "batch_size must be non-negative but got ", batch_size));
 
     RecordYielder::Options yopts;
     yopts.file_pattern = file_pattern;


### PR DESCRIPTION
Validate `batch_size` argument of `RecordInputOp` to prevent `abort` in case of -ve batch_size.

Might fix #62977 .