### PR TITLE
tf-lite CMake: add headers into sources to correctly install them

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -351,7 +351,9 @@ if(TFLITE_ENABLE_GPU)
   list(APPEND TFLITE_DELEGATES_GPU_SRCS
     ${TFLITE_SOURCE_DIR}/delegates/gpu/api.cc
     ${TFLITE_SOURCE_DIR}/delegates/gpu/delegate.cc
+    ${TFLITE_SOURCE_DIR}/delegates/gpu/delegate.h
     ${TFLITE_SOURCE_DIR}/delegates/gpu/delegate_options.cc
+    ${TFLITE_SOURCE_DIR}/delegates/gpu/delegate_options.h
     ${TFLITE_SOURCE_DIR}/delegates/gpu/tflite_profile.cc
     ${TFLITE_SOURCE_DIR}/experimental/acceleration/compatibility/android_info.cc
     ${TFLITE_DELEGATES_GPU_CL_SRCS}


### PR DESCRIPTION
The headers `delegate.h` and `delegate_options.h` were missing when tensorflow lite was installed with the GPU delegates using CMake.

This PR just add these 2 files into  `TFLITE_DELEGATES_GPU_SRCS` variable and it fixes the issue. It works because `TFLITE_DELEGATES_GPU_SRCS` is used to create `_ALL_TFLITE_SRCS` which is used to have `_ALL_TFLITE_HDRS` and then all headers from this variables are installed.