### PR TITLE
Add a note on axis arg of tf.argmax

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -284,6 +284,7 @@ def argmax_v2(input, axis=None, output_type=dtypes.int64, name=None):
   Args:
     input: A `Tensor`.
     axis: An integer, the axis to reduce across. Default to 0.
+          Note: bool data type will be converted into integer internally.
     output_type: An optional output dtype (`tf.int32` or `tf.int64`). Defaults
       to `tf.int64`.
     name: An optional name for the operation.


### PR DESCRIPTION
As per documentation of he API tf.argmax the argument axis accepts integer values.If we pass any data types it is also accepting the same.Hence adding a note on same in the documentation to avoid any confusion as reported by the user in 
#63031.

shall fix #63031