### PR TITLE
May fix checkfail in Gatherv2 Op.

### DIFF
--- a/tensorflow/core/framework/shape_inference.cc
+++ b/tensorflow/core/framework/shape_inference.cc
@@ -702,7 +702,9 @@ ShapeHandle InferenceContext::UnknownShapeOfRank(int64_t rank) {
   if (rank == kUnknownRank) {
     return UnknownShape();
   }
-  CHECK_GE(rank, 0) << "rank must not be negative";
+  if (rank < 0) {
+    return errors::InvalidArgument("Rank must not be negative");
+  }
   std::vector<DimensionHandle> dims(rank);
   for (int32_t i = 0; i < rank; ++i) {
     dims[i] = UnknownDim();


### PR DESCRIPTION
Checkfail can be triggered in GatherV2 Op with inappropriate input from this line below. https://github.com/tensorflow/tensorflow/blob/e193d8ea7776ef5c6f5d769b6fb9c070213e737a/tensorflow/core/ops/array_ops.cc#L1240-L1242.

This will call UnknownShapeOfRank function and checkfail happens at line below as CHECK_GE macro call, which causes core dump error if assertion fails.

https://github.com/tensorflow/tensorflow/blob/8d0c35b8b95086a2a8209fa47580b13ae8241adb/tensorflow/core/framework/shape_inference.cc#L705

Hence proposing validation and raise appropriate message to the user.

May fix #62985 