### PR TITLE
[oneDNN] Adding a check to verify if gamma and beta are Const

### DIFF
--- a/tensorflow/core/grappler/optimizers/remapper.cc
+++ b/tensorflow/core/grappler/optimizers/remapper.cc
@@ -3009,7 +3009,10 @@ bool FindInstanceNorm(RemapperContext* ctx, int node_index,
     return false;
   }
   Tensor gamma_tensor, beta_tensor;
-  if (!gamma_tensor.FromProto(gamma_node->attr().at("value").tensor()) ||
+  // TODO(intel-tf): Allow fusions for cases where gamma and beta aren't Consts
+  if (gamma_node->op() != "Const" ||
+      !gamma_tensor.FromProto(gamma_node->attr().at("value").tensor()) ||
+      beta_node->op() != "Const" ||
       !beta_tensor.FromProto(beta_node->attr().at("value").tensor())) {
     return false;
   }


### PR DESCRIPTION
This PR resolves a segmentation fault for ResNet-DPED performance benchmark. The segmentation fault resulted with the following error: `[libprotobuf FATAL external/com_google_protobuf/src/google/protobuf/map.h:1293] CHECK failed: it != end(): key not found: value.` Adding a check to verify if `gamma` and `beta` are `Const` resolves the issue.