### PR TITLE
Fix checkfail with -ve perm values in transpose_op.cc

### DIFF
--- a/tensorflow/core/kernels/transpose_op.cc
+++ b/tensorflow/core/kernels/transpose_op.cc
@@ -135,8 +135,8 @@ void TransposeOp::Compute(OpKernelContext* ctx) {
                                       perm.shape().DebugString()));
   // Validation for negative values inside `perm`.
   auto perm_vector = perm.vec<int>();
-  for (int i = 0; i < perm.dim_size(0); i++) {
-    if (0 > perm_vector(i)) {
+  for (int i = 0; i < perm.dim_size(0); ++i) {
+    if (perm_vector(i) < 0) {
       return errors::InvalidArgument(
           "The perm values should be non-negative "
           "but found ",

--- a/tensorflow/core/kernels/transpose_op.cc
+++ b/tensorflow/core/kernels/transpose_op.cc
@@ -135,7 +135,8 @@ void TransposeOp::Compute(OpKernelContext* ctx) {
                                       perm.shape().DebugString()));
   // Validation for negative values inside `perm`.
   auto perm_vector = perm.vec<int>();
-  for (int i = 0; i < perm.dim_size(0); ++i) {
+  auto perm_size = perm.NumElements();
+  for (int i = 0; i < perm_size; ++i) {
     if (perm_vector(i) < 0) {
       return errors::InvalidArgument(
           "The perm values should be non-negative "

--- a/tensorflow/core/kernels/transpose_op.cc
+++ b/tensorflow/core/kernels/transpose_op.cc
@@ -133,7 +133,16 @@ void TransposeOp::Compute(OpKernelContext* ctx) {
   OP_REQUIRES(ctx, TensorShapeUtils::IsVector(perm.shape()),
               errors::InvalidArgument("perm must be rank 1, got shape ",
                                       perm.shape().DebugString()));
-
+  // Validation for negative values inside `perm`.
+  auto perm_vector = perm.vec<int>();
+  for (int i = 0; i < perm.dim_size(0); i++) {
+    if (0 > perm_vector(i)) {
+      return errors::InvalidArgument(
+          "The perm values should be non-negative "
+          "but found ",
+          perm_vector(i), " at index ", i);
+    }
+  }
   // Although Tperm may be an int64 type, an int32 is sufficient to hold
   // dimension range values, so the narrowing here should be safe.
   std::vector<int32> permutation;

--- a/tensorflow/core/kernels/transpose_op.cc
+++ b/tensorflow/core/kernels/transpose_op.cc
@@ -138,10 +138,10 @@ void TransposeOp::Compute(OpKernelContext* ctx) {
   auto perm_size = perm.NumElements();
   for (int i = 0; i < perm_size; ++i) {
     if (perm_vector(i) < 0) {
-      return errors::InvalidArgument(
+      return absl::InvalidArgumentError(absl::StrCat(
           "The perm values should be non-negative "
           "but found ",
-          perm_vector(i), " at index ", i);
+          perm_vector(i), " at index ", i));
     }
   }
   // Although Tperm may be an int64 type, an int32 is sufficient to hold

--- a/tensorflow/core/kernels/transpose_op.cc
+++ b/tensorflow/core/kernels/transpose_op.cc
@@ -134,7 +134,7 @@ void TransposeOp::Compute(OpKernelContext* ctx) {
               errors::InvalidArgument("perm must be rank 1, got shape ",
                                       perm.shape().DebugString()));
   // Validation for negative values inside `perm`.
-  auto perm_vector = perm.vec<int>();
+  auto perm_vector = perm.vec<Tperm>();
   auto perm_size = perm.NumElements();
   for (int i = 0; i < perm_size; ++i) {
     OP_REQUIRES(ctx, perm_vector(i) >= 0, 

--- a/tensorflow/core/kernels/transpose_op.cc
+++ b/tensorflow/core/kernels/transpose_op.cc
@@ -137,7 +137,7 @@ void TransposeOp::Compute(OpKernelContext* ctx) {
   auto perm_vector = perm.vec<int>();
   auto perm_size = perm.NumElements();
   for (int i = 0; i < perm_size; ++i) {
-    OP_REQUIRES(ctx, perm_vector(i) > 0, 
+    OP_REQUIRES(ctx, perm_vector(i) >= 0, 
                 absl::InvalidArgumentError(absl::StrCat(
                         "The perm values should be non-negative "
                         "but found ",

--- a/tensorflow/core/kernels/transpose_op.cc
+++ b/tensorflow/core/kernels/transpose_op.cc
@@ -137,12 +137,11 @@ void TransposeOp::Compute(OpKernelContext* ctx) {
   auto perm_vector = perm.vec<int>();
   auto perm_size = perm.NumElements();
   for (int i = 0; i < perm_size; ++i) {
-    if (perm_vector(i) < 0) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "The perm values should be non-negative "
-          "but found ",
-          perm_vector(i), " at index ", i));
-    }
+    OP_REQUIRES(ctx, perm_vector(i) > 0, 
+                absl::InvalidArgumentError(absl::StrCat(
+                        "The perm values should be non-negative "
+                        "but found ",
+                        perm_vector(i), " at index ", i)));
   }
   // Although Tperm may be an int64 type, an int32 is sufficient to hold
   // dimension range values, so the narrowing here should be safe.


### PR DESCRIPTION
Passing negative values to argument perm in tf.raw_ops.Transpose will cause checkfail and coredump error. Hence validation proposed to check and raise exception.

Ref issue #62995