### PR TITLE
Fix Checkfail in raw_ops.DecodeAndCropJpeg

### DIFF
--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -519,6 +519,11 @@ REGISTER_OP("DecodeAndCropJpeg")
       const Tensor* crop_window = c->input_tensor(1);
       if (crop_window != nullptr) {
         auto crop_window_vec = crop_window->vec<int32>();
+        if (0 > crop_window_vec(2) || 0 > crop_window_vec(3)){
+          return errors::InvalidArgument(
+            "crop_window must have non-negative values. "
+            );        
+        }
         h = c->MakeDim(crop_window_vec(2));
         w = c->MakeDim(crop_window_vec(3));
       }

--- a/tensorflow/core/ops/image_ops.cc
+++ b/tensorflow/core/ops/image_ops.cc
@@ -519,7 +519,7 @@ REGISTER_OP("DecodeAndCropJpeg")
       const Tensor* crop_window = c->input_tensor(1);
       if (crop_window != nullptr) {
         auto crop_window_vec = crop_window->vec<int32>();
-        if (0 > crop_window_vec(2) || 0 > crop_window_vec(3)){
+        if (crop_window_vec(2) < 0  || crop_window_vec(3) < 0 ){
           return errors::InvalidArgument(
             "crop_window must have non-negative values. "
             );        


### PR DESCRIPTION
The API `tf.raw_ops.DecodeAndCropJpeg` can lead to assertion failure with -ve values passed to `crop_window` argument. This is true for only debug builds but not with TF official release wheels.

Proposed a fix for this.May please review.
Ref Issue: #63062 