### PR TITLE
Change visibility status for schema_conversion_utils to allow compila…

### DIFF
--- a/tensorflow/lite/schema/BUILD
+++ b/tensorflow/lite/schema/BUILD
@@ -185,7 +185,7 @@ cc_library(
     srcs = ["schema_conversion_utils.cc"],
     hdrs = ["schema_conversion_utils.h"],
     compatible_with = get_compatible_with_portable(),
-    visibility = [":utils_friends"],
+    visibility = ["//visibility:public"],
     deps = [
         ":schema_fbs",
         "//tensorflow/lite/kernels/internal:compatibility",


### PR DESCRIPTION
…tion of ext. libraries

When compiling libraries such as [libcoral](https://github.com/google-coral/libcoral) and [pycoral](https://github.com/google-coral/pycoral), they are linked to TF and access header files in TF proper. One such case is [schema_conversion_utils.h](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/schema/schema_conversion_utils.h). Unfortunately the visibility of such header is set in [BUILD, line 188](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/schema/BUILD) as:

visibility = [":utils_friends"],

This prevents a successful compilation of the libraries (especially when compiled within a docker), as the libraries are not part of the `utils_friends`. It is notable that a similar issue (i.e. same visibility status) was present in TF2.15 for [schema_util.h](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/schema/schema_util.h), but was recently changed to:

visibility = ["//visibility:public"],

So the visibility status should be changed to `visibility = ["//visibility:public"],` also for the `schema_conversion_utils`.

Reference: https://github.com/tensorflow/tensorflow/issues/63074