### PR TITLE
Fix overflow problem in SparseFillEmptyRows Op

### DIFF
--- a/tensorflow/core/kernels/sparse_fill_empty_rows_op.cc
+++ b/tensorflow/core/kernels/sparse_fill_empty_rows_op.cc
@@ -94,6 +94,16 @@ void SparseFillEmptyRowsOpImpl(OpKernelContext* context,
   OP_REQUIRES_ASYNC(context, dense_shape_t.NumElements() != 0,
                     errors::InvalidArgument("Dense shape cannot be empty."),
                     done);
+  // Validation for negative dims inside `dense_shape`.
+  auto dense_shape_vec = dense_shape_t.vec<int>();
+  for (int i = 0; i < dense_shape_vec.shape().dim_size(0); ++i) {
+    if (dense_shape_vec(i) < 0 ) {
+      return errors::InvalidArgument(
+          "The dense_shape should be non-negative "
+          "but found ",
+          dense_shape_vec(i), " at index ", i);
+    }
+  }
 
   using FunctorType =
       functor::FillEmptyRows<Device, T, Tindex, /*RaggedOperands=*/false>;


### PR DESCRIPTION
The C++ API SparseFillEmptyRows lacks validation of negative values passed to dense_shape argument.For example if we pass some large -ve value like` -1l `(long int) then it will be passed as it is and due to integer overflow at the below line the value is converted to extremely large number and it ends up with `std::length_error` causing abortion(core dumped). https://github.com/tensorflow/tensorflow/blob/9da417e3f63215efe995b83e7b9f9b34115a424e/tensorflow/core/kernels/fill_empty_rows_functor.h#L114

Fixes #63066