### PR TITLE
Fix check fail in SparseApplyAdaDelta Op

### DIFF
--- a/tensorflow/core/ops/training_ops.cc
+++ b/tensorflow/core/ops/training_ops.cc
@@ -60,6 +60,11 @@ static Status HandleGradAndIndicesInputs(InferenceContext* c, int grad_idx,
   ShapeHandle indices;
   TF_RETURN_IF_ERROR(c->WithRank(c->input(grad_idx + 1), 1, &indices));
   DimensionHandle unused;
+  const auto rank = c->Rank(grad);
+  if (!rank) {
+      errors::InvalidArgument("Argument grad must not be a scalar. ",
+          "Got grad with rank ",c->Rank(grad));
+  }
   TF_RETURN_IF_ERROR(c->Merge(c->Dim(indices, 0), c->Dim(grad, 0), &unused));
   // Trailing part of grad matches trailing part of *s.
   ShapeHandle grad_unknown_first;

--- a/tensorflow/core/ops/training_ops.cc
+++ b/tensorflow/core/ops/training_ops.cc
@@ -63,7 +63,7 @@ static Status HandleGradAndIndicesInputs(InferenceContext* c, int grad_idx,
   const auto rank = c->Rank(grad);
   if (!rank) {
       return errors::InvalidArgument("Argument grad must not be a scalar. ",
-          "Got grad with rank ",c->Rank(grad));
+          "Got grad with rank ", rank);
   }
   TF_RETURN_IF_ERROR(c->Merge(c->Dim(indices, 0), c->Dim(grad, 0), &unused));
   // Trailing part of grad matches trailing part of *s.

--- a/tensorflow/core/ops/training_ops.cc
+++ b/tensorflow/core/ops/training_ops.cc
@@ -62,7 +62,7 @@ static Status HandleGradAndIndicesInputs(InferenceContext* c, int grad_idx,
   DimensionHandle unused;
   const auto rank = c->Rank(grad);
   if (!rank) {
-      errors::InvalidArgument("Argument grad must not be a scalar. ",
+      return errors::InvalidArgument("Argument grad must not be a scalar. ",
           "Got grad with rank ",c->Rank(grad));
   }
   TF_RETURN_IF_ERROR(c->Merge(c->Dim(indices, 0), c->Dim(grad, 0), &unused));

--- a/tensorflow/core/ops/training_ops.cc
+++ b/tensorflow/core/ops/training_ops.cc
@@ -62,8 +62,9 @@ static Status HandleGradAndIndicesInputs(InferenceContext* c, int grad_idx,
   DimensionHandle unused;
   const auto rank = c->Rank(grad);
   if (!rank) {
-      return errors::InvalidArgument("Argument grad must not be a scalar. ",
-          "Got grad with rank ", rank);
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Argument grad must not be a scalar. ",
+          "Got grad with rank ", rank));
   }
   TF_RETURN_IF_ERROR(c->Merge(c->Dim(indices, 0), c->Dim(grad, 0), &unused));
   // Trailing part of grad matches trailing part of *s.


### PR DESCRIPTION
C++ API `SparseApplyAdadelta` segfaults due to lack of input shape check.

Error [location](https://github.com/tensorflow/tensorflow/blob/f647f0cf7c36c7bb7ec531f11df1a028e343749a/tensorflow/core/ops/training_ops.cc#L63):


` TF_RETURN_IF_ERROR(c->Merge(c->Dim(indices, 0), c->Dim(grad, 0), &unused));
`

At `c->Dim(grad, 0)`, it reads 0th dim without checking rank of grad. Therefore when a scalar(0-rank) is given for arg grad it crashes.

The same things happen for other SparseApply* APIs(SparseApplyAdagrad, SparseApplyAdagradDA, SparseApplyFtrl, SparseApplyFtrlV2, SparseApplyMomentum, SparseApplyProximalAdagrad, SparseApplyProximalGradientDescent) as reported by the user in #62978.

Since all the above APIs calls HandleGradAndIndicesInputs , hence fixing it there might resolve the issue with all the above APIs.