### PR TITLE
Fix checkfail of tf.raw_ops.AvgPool with negative kernel size in Debug builds

### DIFF
--- a/tensorflow/core/framework/shape_inference.h
+++ b/tensorflow/core/framework/shape_inference.h
@@ -889,7 +889,7 @@ inline DimensionOrConstant::DimensionOrConstant(DimensionHandle dim)
 }
 
 inline DimensionOrConstant::DimensionOrConstant(int64_t val) : val(val) {
-  if (val < 0 || val != InferenceContext::kUnknownDim) {
+  if (val < 0 && val != InferenceContext::kUnknownDim) {
       return errors::InvalidArgument("Dimension must be non-negative or equal to ",
          "InferenceContext::kUnknownDim but got ", val,".");
   }

--- a/tensorflow/core/framework/shape_inference.h
+++ b/tensorflow/core/framework/shape_inference.h
@@ -889,10 +889,10 @@ inline DimensionOrConstant::DimensionOrConstant(DimensionHandle dim)
 }
 
 inline DimensionOrConstant::DimensionOrConstant(int64_t val) : val(val) {
-  DCHECK(val >= 0 || val == InferenceContext::kUnknownDim)
-      << "Dimension must be non-negative or equal to "
-         "InferenceContext::kUnknownDim but got "
-      << val;
+  if (val < 0 || val != InferenceContext::kUnknownDim) {
+      return errors::InvalidArgument("Dimension must be non-negative or equal to ",
+         "InferenceContext::kUnknownDim but got ", val,".");
+  }
 }
 
 template <class T>


### PR DESCRIPTION
Currently shape inference step of `tf.raw_ops.AvgPool` allows negative kernel size.But in debug build it aborts with checkfail as there is DCHECK which works only in debug build. Replaced DCHECK with general conditional check.

Ref issue #63034