### PR TITLE
Fix checkfail in tf.raw_ops.Substr

### DIFF
--- a/tensorflow/core/kernels/substr_op.cc
+++ b/tensorflow/core/kernels/substr_op.cc
@@ -56,7 +56,12 @@ class SubstrOp : public OpKernel {
                 errors::InvalidArgument(
                     "pos and len should have the same shape, got: ",
                     pos_shape.DebugString(), " vs. ", len_shape.DebugString()));
-
+    OP_REQUIRES(context, pos_tensor.NumElements() > 0,
+                errors::InvalidArgument("received empty tensor pos_tensor: ",
+                                        pos_tensor.DebugString()));
+    OP_REQUIRES(context, len_tensor.NumElements() > 0,
+                errors::InvalidArgument("received empty tensor len_tensor: ",
+                                        len_tensor.DebugString()));
     bool is_scalar = TensorShapeUtils::IsScalar(pos_shape);
 
     if (is_scalar || input_shape == pos_shape) {

--- a/tensorflow/core/kernels/substr_op.cc
+++ b/tensorflow/core/kernels/substr_op.cc
@@ -57,11 +57,13 @@ class SubstrOp : public OpKernel {
                     "pos and len should have the same shape, got: ",
                     pos_shape.DebugString(), " vs. ", len_shape.DebugString()));
     OP_REQUIRES(context, pos_tensor.NumElements() > 0,
-                errors::InvalidArgument("received empty tensor pos_tensor: ",
-                                        pos_tensor.DebugString()));
+                absl::InvalidArgumentError(
+                    absl::StrCat("received empty tensor pos_tensor: ",
+                                 pos_tensor.DebugString())));
     OP_REQUIRES(context, len_tensor.NumElements() > 0,
-                errors::InvalidArgument("received empty tensor len_tensor: ",
-                                        len_tensor.DebugString()));
+                absl::InvalidArgumentError(
+                    absl::StrCat("received empty tensor len_tensor: ",
+                                 len_tensor.DebugString())));
     bool is_scalar = TensorShapeUtils::IsScalar(pos_shape);
 
     if (is_scalar || input_shape == pos_shape) {


### PR DESCRIPTION
The API `tf.raw_ops.Substr`  currently validates whether the input args `pos` and `len` are of same shape or not.Its not checking whether these tensors are empty or not and trying to access the Tensor values directly without validating.If a user passes empty tensors it will lead to` assertion failure` causing core dumped error.

May fixes #63036