### PR TITLE
Fix checkfail in tf.raw_ops.UnravelIndex

### DIFF
--- a/tensorflow/core/kernels/unravel_index_op.cc
+++ b/tensorflow/core/kernels/unravel_index_op.cc
@@ -50,7 +50,9 @@ class UnravelIndexOp : public OpKernel {
                 errors::InvalidArgument(
                     "The indices can only be scalar or vector, got \"",
                     indices_tensor.shape().DebugString(), "\""));
-
+    OP_REQUIRES(ctx, indices_tensor.NumElements() > 0,
+                errors::InvalidArgument("received empty tensor indices: ",
+                                        indices_tensor.DebugString()));    
     const Tensor& dims_tensor = ctx->input(1);
     OP_REQUIRES(
         ctx, TensorShapeUtils::IsVector(dims_tensor.shape()),


### PR DESCRIPTION
Currently the API `tf.raw_ops.UnravelIndex` not checking whether the `indices` argument argument is empty. If user passes empty tensor it might lead to assertion failure.

May fix #63037 .