### PR TITLE
Fix checkfail in tf.raw_ops.DrawBoundingBoxesV2

### DIFF
--- a/tensorflow/core/kernels/image/draw_bounding_box_op.cc
+++ b/tensorflow/core/kernels/image/draw_bounding_box_op.cc
@@ -58,7 +58,6 @@ class DrawBoundingBoxesOp : public OpKernel {
   void Compute(OpKernelContext* context) override {
     const Tensor& images = context->input(0);
     const Tensor& boxes = context->input(1);
-    const int64_t depth = images.dim_size(3);
 
     OP_REQUIRES(context, images.dims() == 4,
                 errors::InvalidArgument("The rank of the images should be 4"));
@@ -68,6 +67,7 @@ class DrawBoundingBoxesOp : public OpKernel {
     OP_REQUIRES(context, images.dim_size(0) == boxes.dim_size(0),
                 errors::InvalidArgument("The batch sizes should be the same"));
 
+    const int64_t depth = images.dim_size(3);
     OP_REQUIRES(
         context, depth == 4 || depth == 1 || depth == 3,
         errors::InvalidArgument("Channel depth should be either 1 (GRY), "


### PR DESCRIPTION
The API `tf.raw_ops.DrawBoundingBoxesV2` trying to access the `dim_size(3)` of image tensor before checking its rank. This is causing checkfail if image is not of rank 4.

Fixes #62981