### PR TITLE
Fix checkfail with tf.raw_ops.Conv2DBackpropInput with MKL enabled.

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.h
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.h
@@ -641,6 +641,9 @@ class MklConvBackpropCommonOp : public OpKernel {
     OP_REQUIRES(context, FormatFromString(data_format_str, &data_format_),
                 errors::InvalidArgument("Invalid data format"));
     OP_REQUIRES_OK(context, context->GetAttr("strides", &strides_));
+    if (strides_.size() < 4) {
+        return errors::InvalidArgument("strides dimensions must not be < 4. ");
+    }
     int stride_n = GetTensorDim(strides_, data_format_, 'N');
     int stride_c = GetTensorDim(strides_, data_format_, 'C');
     OP_REQUIRES(

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.h
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.h
@@ -641,9 +641,10 @@ class MklConvBackpropCommonOp : public OpKernel {
     OP_REQUIRES(context, FormatFromString(data_format_str, &data_format_),
                 errors::InvalidArgument("Invalid data format"));
     OP_REQUIRES_OK(context, context->GetAttr("strides", &strides_));
-    if (strides_.size() < 4) {
-        return errors::InvalidArgument("strides dimensions must not be < 4. ");
-    }
+    OP_REQUIRES(context, (strides_.size() == 4 || strides_.size() == 5),
+                absl::InvalidArgumentError("Sliding window strides field must "
+                "specify 4 or 5 dimensions. "));
+
     int stride_n = GetTensorDim(strides_, data_format_, 'N');
     int stride_c = GetTensorDim(strides_, data_format_, 'C');
     OP_REQUIRES(


### PR DESCRIPTION
The API tf.raw_ops.Conv2DBackpropInput with oneDNN enabled causing checkfail if strides<4. This is due to trying to access channel dimension 'C' with NHWC format without validating the strides dimension.

Fixes #62950 .