### PR TITLE
Fix heap overflow error in raw_ops.ArgMax

### DIFF
--- a/tensorflow/core/kernels/argmax_op.cc
+++ b/tensorflow/core/kernels/argmax_op.cc
@@ -56,7 +56,7 @@ class ArgOp : public OpKernel {
                     "dim must be a scalar, but received tensor of shape: ",
                     dimension.shape().DebugString()));
 
-    const int32_t dim = internal::SubtleMustCopy(dimension.scalar<int32>()());
+    const Tidx dim = internal::SubtleMustCopy(dimension.scalar<Tidx>()());
     const int input_dims = input.dims();
 
     int axis = dim < 0 ? dim + input_dims : dim;


### PR DESCRIPTION
The API raw_ops.ArgMax implementation copies the value of arg dimension into int32_t without checking exact type which may read out of bounds.

Reported in #63070 .