### PR TITLE
Fix checkfail in raw_ops.DenseBincount

### DIFF
--- a/tensorflow/core/kernels/bincount_op.cc
+++ b/tensorflow/core/kernels/bincount_op.cc
@@ -308,7 +308,7 @@ class DenseBincountOp : public OpKernel {
 
     Tensor* out_t;
     functor::SetZeroFunctor<Device, T> fill;
-    if (data.dims() == 1) {
+    if (data.dims() <= 1) {
       OP_REQUIRES_OK(ctx, ctx->allocate_output(0, TensorShape({size}), &out_t));
       auto out = out_t->flat<T>();
       fill(ctx->eigen_device<Device>(), out);

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1892,12 +1892,10 @@ REGISTER_OP("DenseBincount")
         return errors::InvalidArgument("size (", size_val,
                                        ") must be non-negative");
       }
-      if (c->Rank(c->input(0)) == 1) {
+      if (c->Rank(c->input(0)) == 1 || c->Rank(c->input(0)) == 0) {
         c->set_output(0, c->MakeShape({size_val}));
       } else if (c->Rank(c->input(0)) == 2) {
         c->set_output(0, c->MakeShape({c->Dim(c->input(0), 0), size_val}));
-      } else if (c->Rank(c->input(0)) == 0) {
-        return absl::InvalidArgumentError("The input must not be a scalar. ");
       }
       return absl::OkStatus();
     });

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1896,6 +1896,9 @@ REGISTER_OP("DenseBincount")
         c->set_output(0, c->MakeShape({size_val}));
       } else if (c->Rank(c->input(0)) == 2) {
         c->set_output(0, c->MakeShape({c->Dim(c->input(0), 0), size_val}));
+      } else {
+        return errors::InvalidArgument("input must not be a scalar. "
+            "Recieved input of rank ", c->Rank(c->input(0)));
       }
       return absl::OkStatus();
     });

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1896,9 +1896,8 @@ REGISTER_OP("DenseBincount")
         c->set_output(0, c->MakeShape({size_val}));
       } else if (c->Rank(c->input(0)) == 2) {
         c->set_output(0, c->MakeShape({c->Dim(c->input(0), 0), size_val}));
-      } else {
-        return errors::InvalidArgument("input must not be a scalar. "
-            "Recieved input of rank ", c->Rank(c->input(0)));
+      } else if (c->Rank(c->input(0)) == 0) {
+        return absl::InvalidArgumentError("The input must not be a scalar. ");
       }
       return absl::OkStatus();
     });


### PR DESCRIPTION
The API `raw_ops.DenseBincount` lacks validation of input to be vector. It does have checking for rank<=2 but not check for rank>0. Passing a scalar value causes checkfail with debug build.

Reported at #63068