### PR TITLE
shlo_ref: Add status matchers

### DIFF
--- a/tensorflow/lite/experimental/shlo/BUILD
+++ b/tensorflow/lite/experimental/shlo/BUILD
@@ -119,7 +119,7 @@ cc_test(
     srcs = ["dispatch_test.cc"],
     deps = [
         ":dispatch",
-	":status_matcher",
+        ":status_matcher",
         "@com_google_absl//absl/status",
         "@com_google_googletest//:gtest_main",
     ],
@@ -146,7 +146,7 @@ cc_library(
     testonly = True,
     hdrs = ["status_matcher.h"],
     deps = [
-	"@com_google_absl//absl/status",
+        "@com_google_absl//absl/status",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tensorflow/lite/experimental/shlo/BUILD
+++ b/tensorflow/lite/experimental/shlo/BUILD
@@ -119,6 +119,7 @@ cc_test(
     srcs = ["dispatch_test.cc"],
     deps = [
         ":dispatch",
+	":status_matcher",
         "@com_google_absl//absl/status",
         "@com_google_googletest//:gtest_main",
     ],
@@ -136,6 +137,16 @@ cc_test(
     deps = [
         ":data_type",
         ":quantize",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "status_matcher",
+    testonly = True,
+    hdrs = ["status_matcher.h"],
+    deps = [
+	"@com_google_absl//absl/status",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tensorflow/lite/experimental/shlo/dispatch_test.cc
+++ b/tensorflow/lite/experimental/shlo/dispatch_test.cc
@@ -17,7 +17,9 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "absl/status/status.h"
+#include "tensorflow/lite/experimental/shlo/status_matcher.h"
 
 namespace {
 

--- a/tensorflow/lite/experimental/shlo/ops/BUILD
+++ b/tensorflow/lite/experimental/shlo/ops/BUILD
@@ -38,6 +38,7 @@ cc_test(
         "//tensorflow/lite/experimental/shlo:bf16",
         "//tensorflow/lite/experimental/shlo:data_type",
         "//tensorflow/lite/experimental/shlo:shape",
+        "//tensorflow/lite/experimental/shlo:status_matcher",
         "//tensorflow/lite/experimental/shlo:tensor",
         "//tensorflow/lite/experimental/shlo:tensor_matcher",
         "//tensorflow/lite/experimental/shlo:tensor_with_data",

--- a/tensorflow/lite/experimental/shlo/ops/is_finite_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/is_finite_test.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/experimental/shlo/bf16.h"
 #include "tensorflow/lite/experimental/shlo/data_type.h"
 #include "tensorflow/lite/experimental/shlo/shape.h"
+#include "tensorflow/lite/experimental/shlo/status_matcher.h"
 #include "tensorflow/lite/experimental/shlo/tensor.h"
 #include "tensorflow/lite/experimental/shlo/tensor_matcher.h"
 #include "tensorflow/lite/experimental/shlo/tensor_with_data.h"

--- a/tensorflow/lite/experimental/shlo/status_matcher.h
+++ b/tensorflow/lite/experimental/shlo/status_matcher.h
@@ -1,0 +1,41 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_SHLO_TEST_MACROS_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_SHLO_TEST_MACROS_H_
+
+#include <gmock/gmock.h>
+
+#include "absl/status/status.h"
+
+namespace shlo_ref {
+namespace testing {
+
+MATCHER_P(StatusIs, status_code, "") { return arg.code() == status_code; }
+
+#ifndef ASSERT_OK
+#define ASSERT_OK(x) \
+  ASSERT_THAT(x, ::shlo_ref::testing::StatusIs(::absl::StatusCode::kOk))
+#endif
+
+#ifndef EXPECT_OK
+#define EXPECT_OK(x) \
+  EXPECT_THAT(x, ::shlo_ref::testing::StatusIs(::absl::StatusCode::kOk))
+#endif
+
+}  // namespace testing
+}  // namespace shlo_ref
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_SHLO_TEST_MACROS_H_


### PR DESCRIPTION
In the OSS build, EXPECT_OK/ASSERT_OK are not available. This PR adds basic versions of those using a matcher.

BUG=b/327297682