### PR TITLE
Update serialization.cc - std::ofstream needs a binary flag for win32

### DIFF
--- a/tensorflow/lite/delegates/serialization.cc
+++ b/tensorflow/lite/delegates/serialization.cc
@@ -94,7 +94,7 @@ TfLiteStatus SerializationEntry::SetData(TfLiteContext* context,
                             std::to_string(time(nullptr))));
 
 #if defined(_WIN32)
-  std::ofstream out_file(temp_filepath.c_str());
+  std::ofstream out_file(temp_filepath.c_str(), std::ios_base::binary);
   if (!out_file) {
     TFLITE_LOG_PROD(TFLITE_LOG_ERROR, "Could not create file: %s",
                     temp_filepath.c_str());


### PR DESCRIPTION
In a function 'TfLiteStatus SerializationEntry::SetData' for Win32 the call std::ofstream out_file(temp_filepath.c_str()); requires the binary flag. Otherwise more data than required can be writen.

std::ofstream out_file(temp_filepath.c_str(), std::ios_base::binary);