### PR TITLE
Needs support for the data types : QUI8, QI8, TFL_Quint8, QI16 in  ELU's definition at tfl_ops.td 

### DIFF
--- a/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
+++ b/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
@@ -1624,9 +1624,9 @@ def TFL_EluOp: TFL_Op<"elu", [
     element-wise.
   }];
 
-  let arguments = (ins TFL_TensorOf<[F32, I8]>:$x);
+  let arguments = (ins TFL_TensorOf<[F32, I8, QUI8, QI8, TFL_Quint8, QI16]>:$x);
 
-  let results = (outs TFL_TensorOf<[F32, I8]>:$y);
+  let results = (outs TFL_TensorOf<[F32, I8, QUI8, QI8, TFL_Quint8, QI16]>:$y);
 
   let hasOptions = 0;
 }


### PR DESCRIPTION
The ELU's definition in tfl_ops.td ,  needs support for the following data types: QUI8, QI8, TFL_Quint8, QI16.

Reference: https://github.com/tensorflow/tensorflow/issues/63065