### PR TITLE
shlo_ref: Add -llog linkopt on Android builds

### DIFF
--- a/tensorflow/lite/experimental/shlo/BUILD
+++ b/tensorflow/lite/experimental/shlo/BUILD
@@ -1,4 +1,5 @@
 # StableHLO Reference Library
+load("build_def.bzl", "shlo_ref_linkopts")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:LICENSE"],
@@ -38,6 +39,7 @@ cc_library(
 cc_test(
     name = "shape_test",
     srcs = ["shape_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":shape",
         "@com_google_googletest//:gtest_main",
@@ -59,6 +61,7 @@ cc_library(
 cc_test(
     name = "quantized_tensor_element_type_test",
     srcs = ["quantized_tensor_element_type_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":data_type",
         ":f16",
@@ -80,6 +83,7 @@ cc_library(
 cc_test(
     name = "bf16_test",
     srcs = ["bf16_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":bf16",
         "@com_google_absl//absl/base",
@@ -117,6 +121,7 @@ cc_library(
 cc_test(
     name = "dispatch_test",
     srcs = ["dispatch_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":dispatch",
         ":status_matcher",
@@ -134,6 +139,7 @@ cc_library(
 cc_test(
     name = "quantize_test",
     srcs = ["quantize_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":data_type",
         ":quantize",
@@ -178,6 +184,7 @@ cc_library(
 cc_test(
     name = "tensor_matcher_test",
     srcs = ["tensor_matcher_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":data_type",
         ":shape",

--- a/tensorflow/lite/experimental/shlo/build_def.bzl
+++ b/tensorflow/lite/experimental/shlo/build_def.bzl
@@ -1,0 +1,12 @@
+"""Build macros for SHLO reference library."""
+
+def shlo_ref_logging_linkopts():
+    """Defines linker flags to enable logging"""
+    return select({
+        "//tensorflow:android": ["-llog"],
+        "//conditions:default": [],
+    })
+
+def shlo_ref_linkopts():
+    """Defines linker flags for linking SHLO binary"""
+    return shlo_ref_logging_linkopts()

--- a/tensorflow/lite/experimental/shlo/ops/BUILD
+++ b/tensorflow/lite/experimental/shlo/ops/BUILD
@@ -1,4 +1,5 @@
 # Implementation of StableHLO operations.
+load("//tensorflow/lite/experimental/shlo:build_def.bzl", "shlo_ref_linkopts")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:LICENSE"],
@@ -32,6 +33,7 @@ cc_library(
 cc_test(
     name = "is_finite_test",
     srcs = ["is_finite_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":benchmark_util",
         ":is_finite",
@@ -50,6 +52,7 @@ cc_test(
 cc_test(
     name = "is_finite_bench",
     srcs = ["is_finite_bench.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":benchmark_util",
         ":is_finite",


### PR DESCRIPTION
The shlo_ref test binaries were failing to build for Android targets due to an undefined symbol for __android_log_write. This PR adds -llog to the linkopts for all test targets when building for Android.

BUG: b/328138247