### PR TITLE
Update version numbers for TensorFlow 2.15.1 in setup.py

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -47,7 +47,7 @@ from setuptools.dist import Distribution
 # result for pip.
 # Also update tensorflow/tensorflow.bzl and
 # tensorflow/core/public/version.h
-_VERSION = '2.15.0.post1'
+_VERSION = '2.15.1'
 
 
 # We use the same setup.py for all tensorflow_* packages and for the nightly


### PR DESCRIPTION
Automation missed this file in #63118 probably due to "post1" in the old version.