### PR TITLE
Fix checkfail in QuantizedConv2D with invalid input shape dimensions

### DIFF
--- a/tensorflow/core/kernels/quantized_conv_ops.cc
+++ b/tensorflow/core/kernels/quantized_conv_ops.cc
@@ -499,6 +499,7 @@ class QuantizedConv2DOp : public OpKernel {
       OP_REQUIRES(context, input.shape().dim_size(i) != 0,
                   absl::InvalidArgumentError(
                       "Invalid input: Shapes dimension cannot be 0."));
+    }
 
     // Input filter is of the following dimensions:
     // [ filter_rows, filter_cols, in_depth, out_depth]

--- a/tensorflow/core/kernels/quantized_conv_ops.cc
+++ b/tensorflow/core/kernels/quantized_conv_ops.cc
@@ -32,6 +32,7 @@ limitations under the License.
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/util/padding.h"
+#include "absl/status/status.h"
 
 namespace tensorflow {
 
@@ -491,6 +492,13 @@ class QuantizedConv2DOp : public OpKernel {
     // Input tensor is of the following dimensions:
     // [ batch, in_rows, in_cols, in_depth ]
     const Tensor& input = context->input(0);
+
+    // validate for non zero dimensions of input.
+    int input_dims = input.shape().dims();
+    for (int i = 0; i < input_dims; ++i) {
+      OP_REQUIRES(context, input.shape().dim_size(i) != 0,
+                  absl::InvalidArgumentError(
+                      "Invalid input: Shapes dimension cannot be 0."));
 
     // Input filter is of the following dimensions:
     // [ filter_rows, filter_cols, in_depth, out_depth]


### PR DESCRIPTION
A checkfail can happen in `raw_ops.QuantizedConv2D` with invalid input shape i.e presence of `0` in input shape dimensions. Repro [gist](https://colab.sandbox.google.com/gist/SuryanarayanaY/96418887bc380751c49ce3206d6382df/nightly.ipynb).

Fixes #59927 .