### PR TITLE
Fix checkfail in ThreadUnsafeUnigramCandidateSampler

### DIFF
--- a/tensorflow/core/kernels/range_sampler.cc
+++ b/tensorflow/core/kernels/range_sampler.cc
@@ -27,6 +27,8 @@ limitations under the License.
 #include "tensorflow/core/platform/logging.h"
 #include "tensorflow/core/platform/mutex.h"
 #include "tensorflow/core/platform/types.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 
 namespace tensorflow {
 
@@ -180,8 +182,12 @@ float LogUniformSampler::Probability(int64_t value) const {
 
 ThreadUnsafeUnigramSampler::ThreadUnsafeUnigramSampler(int64_t range)
     : RangeSampler(range), picker_(range) {
-  CHECK_LT(range, kint32max);
-}
+  if (range > kint32max ) {
+      absl::InvalidArgumentError(absl::StrCat(
+          "Expected range < kint32max.",
+          " Got range: ", range));
+  }
+
 
 int64_t ThreadUnsafeUnigramSampler::Sample(random::SimplePhilox* rnd) const {
   return picker_.Pick(rnd);

--- a/tensorflow/core/kernels/range_sampler.cc
+++ b/tensorflow/core/kernels/range_sampler.cc
@@ -184,8 +184,7 @@ ThreadUnsafeUnigramSampler::ThreadUnsafeUnigramSampler(int64_t range)
     : RangeSampler(range), picker_(range) {
   if (range > kint32max ) {
       absl::InvalidArgumentError(absl::StrCat(
-          "Expected range < kint32max.",
-          " Got range: ", range));
+          "Expected range <= kint32max. Got range: ", range));
   }
 
 


### PR DESCRIPTION
The API `raw.ops.ThreadUnsafeUnigramCandidateSampler` checkfails if provided larger input to `range` argument.

Fixes #60200 .