### PR TITLE
Fix Checkfail in MatrixDiagV3

### DIFF
--- a/tensorflow/core/kernels/linalg/matrix_diag_op.cc
+++ b/tensorflow/core/kernels/linalg/matrix_diag_op.cc
@@ -236,13 +236,21 @@ class MatrixDiagOp : public OpKernel {
         errors::InvalidArgument(
             "lower_diag_index must not be larger than upper_diag_index: ",
             lower_diag_index, " > ", upper_diag_index));
-    OP_REQUIRES(context,
-                lower_diag_index == upper_diag_index ||
-                    diagonal_shape.dim_size(diag_rank - 2) == num_diags,
-                errors::InvalidArgument(
-                    "The number of diagonals provided in the input does not "
-                    "match the lower_diag_index and upper_diag_index range."));
-
+    if (diag_rank == 1) {
+        OP_REQUIRES(context,
+            lower_diag_index == upper_diag_index ||
+                diagonal_shape.dim_size(diag_rank - 1) == num_diags,
+            absl::InvalidArgumentError(
+                "The number of diagonals provided in the input does not "
+                "match the lower_diag_index and upper_diag_index range."));
+    } else if (diag_rank > 1) {
+        OP_REQUIRES(context,
+            lower_diag_index == upper_diag_index ||
+                diagonal_shape.dim_size(diag_rank - 2) == num_diags,
+            absl::InvalidArgumentError(
+                "The number of diagonals provided in the input does not "
+                "match the lower_diag_index and upper_diag_index range."));
+    }
     const Eigen::Index max_diag_len = diagonal_shape.dim_size(diag_rank - 1);
     const Eigen::Index min_num_rows =
         max_diag_len - std::min(upper_diag_index, 0);

--- a/tensorflow/core/kernels/linalg/matrix_diag_op.cc
+++ b/tensorflow/core/kernels/linalg/matrix_diag_op.cc
@@ -236,21 +236,13 @@ class MatrixDiagOp : public OpKernel {
         errors::InvalidArgument(
             "lower_diag_index must not be larger than upper_diag_index: ",
             lower_diag_index, " > ", upper_diag_index));
-    if (diag_rank == 1) {
-        OP_REQUIRES(context,
-            lower_diag_index == upper_diag_index ||
-                diagonal_shape.dim_size(diag_rank - 1) == num_diags,
-            absl::InvalidArgumentError(
-                "The number of diagonals provided in the input does not "
-                "match the lower_diag_index and upper_diag_index range."));
-    } else if (diag_rank > 1) {
-        OP_REQUIRES(context,
-            lower_diag_index == upper_diag_index ||
-                diagonal_shape.dim_size(diag_rank - 2) == num_diags,
-            absl::InvalidArgumentError(
-                "The number of diagonals provided in the input does not "
-                "match the lower_diag_index and upper_diag_index range."));
-    }
+    OP_REQUIRES(context,
+        lower_diag_index == upper_diag_index ||
+        diagonal_shape.dim_size(std::max(diag_rank - 2, 0)) == num_diags,
+        errors::InvalidArgument(
+            "The number of diagonals provided in the input does not "
+            "match the lower_diag_index and upper_diag_index range."));
+
     const Eigen::Index max_diag_len = diagonal_shape.dim_size(diag_rank - 1);
     const Eigen::Index min_num_rows =
         max_diag_len - std::min(upper_diag_index, 0);


### PR DESCRIPTION
The Op raw_ops.MatrixDiagV3 terminates due to checkfail when the input `diagonal` is of `rank=1` and `k[0] != k[1]`.

This happens at this line below which is trying to access `diagonal_shape.dim_size(-1)` when rank=1 . Currently API will not work with Rank=1 and k[0] != k[1] due to this check fail.

https://github.com/tensorflow/tensorflow/blob/e193d8ea7776ef5c6f5d769b6fb9c070213e737a/tensorflow/core/kernels/linalg/matrix_diag_op.cc#L241

Proposed a fix for same.

Fixes #62984 .