### PR TITLE
Fix SegFault in Python InterpreterWrapper

### DIFF
--- a/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.cc
+++ b/tensorflow/lite/python/interpreter_wrapper/interpreter_wrapper.cc
@@ -135,9 +135,11 @@ PyObject* PyDictFromSparsityParam(const TfLiteSparsity& param) {
   PyDict_SetItemString(result, "traversal_order",
                        PyArrayFromIntVector(param.traversal_order->data,
                                             param.traversal_order->size));
-  PyDict_SetItemString(
-      result, "block_map",
-      PyArrayFromIntVector(param.block_map->data, param.block_map->size));
+  if (param.block_map != nullptr) {
+    PyDict_SetItemString(
+        result, "block_map",
+        PyArrayFromIntVector(param.block_map->data, param.block_map->size));
+  }
   PyObject* dim_metadata = PyList_New(param.dim_metadata_size);
   for (int i = 0; i < param.dim_metadata_size; i++) {
     PyObject* dim_metadata_i = PyDict_New();


### PR DESCRIPTION
If `InterpreterWrapper::TensorSparsityParameters` encounters Tensors which do not have a `block_map`, a `nullptr` is dereferenced causing AccViol/SegFault.

Add a check for `nullptr`.

Attempts to fix #62058