### PR TITLE
Fix tensorboard "No Step Marker" issue in tf 2.11

### DIFF
--- a/tensorflow/core/profiler/convert/xplane_to_op_stats.cc
+++ b/tensorflow/core/profiler/convert/xplane_to_op_stats.cc
@@ -243,6 +243,8 @@ Status ConvertMultiXSpacesToCombinedOpStats(
   if (session_snapshot.XSpaceSize() == 1) {
     TF_ASSIGN_OR_RETURN(std::unique_ptr<XSpace> xspace,
                         session_snapshot.GetXSpace(0));
+    PreprocessSingleHostXSpace(xspace.get(), /*step_grouping=*/true,
+                               /*derived_timeline=*/false);
     *combined_op_stats = ConvertXSpaceToOpStats(*xspace, options);
     return OkStatus();
   }


### PR DESCRIPTION
## Error:
No step marker observed and hence the step time is unknown
https://github.com/tensorflow/tensorboard/issues/6210

## Custom Code (simplified)
See issue description above
## Tensorflow Version
TF 2.11
## Current Behaviour
The Trace-viewer was viewable, but the overview, input pipeline analysis, etc. is not working. 
## Root Cause
The bug is caused by [this commit](https://github.com/linkedin-managed/tensorflow/commit/92344c0d6839f071bd8efc956a886b3b005b774f#diff-f2a24eeb36ee2e5ea97661010814541453a895eb0ff358988b9018a9f181e332) where the [GroupTfEvents](https://github.com/linkedin-managed/tensorflow/blob/1f4433d0aa1f387a406d26c5c684f46aaaf5a3ad/tensorflow/core/profiler/utils/group_events.cc#L875) was moved from the producer side to the [PreprocessSingleHostXPlane](https://github.com/linkedin-managed/tensorflow/blob/li-2.11/tensorflow/core/profiler/convert/preprocess_single_host_xplane.cc)() (the consumer side). When there is only one XSpace, it won’t do the Grouping and preprocessing ([code](https://github.com/linkedin-managed/tensorflow/blob/d2a9c1a3499f811beb47903ccee865d971e0ec8a/tensorflow/core/profiler/convert/xplane_to_op_stats.cc#L243)), hence causing the generated op stats doesn’t have any group_id defined, and no step marker will be generated ([code](https://github.com/tensorflow/tensorflow/blob/a8eb1ad0bc1b3454652d2af82af96d9757dcf53d/tensorflow/core/profiler/convert/xplane_to_step_events.cc#L153)). The Bug was fixed in tf 2.12 by this [commit](https://github.com/tensorflow/tensorflow/commit/22f93d47c993b962422bb22a6ddf96391eafaf1c).

## Testing Done
Verified that the after the change, the tensorboard is viewable
![test](https://github.com/tensorflow/tensorflow/assets/27000005/a383f7fa-01d8-40d1-b274-eb8ced6d9cba)
