### PR TITLE
shlo_ref: Fix OSS and Android builds

### DIFF
--- a/tensorflow/lite/experimental/shlo/ops/BUILD
+++ b/tensorflow/lite/experimental/shlo/ops/BUILD
@@ -78,6 +78,7 @@ cc_library(
 cc_test(
     name = "util_test",
     srcs = ["util_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":util",
         "//tensorflow/lite/experimental/shlo:shape",
@@ -107,12 +108,14 @@ cc_library(
 cc_test(
     name = "unary_elementwise_test",
     srcs = ["unary_elementwise_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":test_util",
         ":unary_elementwise",
         "//tensorflow/lite/experimental/shlo:data_type",
         "//tensorflow/lite/experimental/shlo:quantized_tensor_element_type",
         "//tensorflow/lite/experimental/shlo:shape",
+        "//tensorflow/lite/experimental/shlo:status_matcher",
         "//tensorflow/lite/experimental/shlo:tensor",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:inlined_vector",
@@ -149,12 +152,14 @@ cc_library(
 cc_test(
     name = "abs_test",
     srcs = ["abs_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":abs",
         ":test_util",
         "//tensorflow/lite/experimental/shlo:quantize",
         "//tensorflow/lite/experimental/shlo:quantized_tensor_element_type",
         "//tensorflow/lite/experimental/shlo:shape",
+        "//tensorflow/lite/experimental/shlo:status_matcher",
         "//tensorflow/lite/experimental/shlo:tensor",
         "@com_google_googletest//:gtest_main",
     ],
@@ -179,6 +184,7 @@ cc_library(
 cc_test(
     name = "cbrt_test",
     srcs = ["cbrt_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":cbrt",
         ":test_util",
@@ -187,6 +193,7 @@ cc_test(
         "//tensorflow/lite/experimental/shlo:quantize",
         "//tensorflow/lite/experimental/shlo:quantized_tensor_element_type",
         "//tensorflow/lite/experimental/shlo:shape",
+        "//tensorflow/lite/experimental/shlo:status_matcher",
         "//tensorflow/lite/experimental/shlo:tensor",
         "@com_google_absl//absl/status",
         "@com_google_googletest//:gtest_main",
@@ -212,6 +219,7 @@ cc_library(
 cc_test(
     name = "ceil_test",
     srcs = ["ceil_test.cc"],
+    linkopts = shlo_ref_linkopts(),
     deps = [
         ":ceil",
         ":test_util",
@@ -220,6 +228,7 @@ cc_test(
         "//tensorflow/lite/experimental/shlo:quantize",
         "//tensorflow/lite/experimental/shlo:quantized_tensor_element_type",
         "//tensorflow/lite/experimental/shlo:shape",
+        "//tensorflow/lite/experimental/shlo:status_matcher",
         "//tensorflow/lite/experimental/shlo:tensor",
         "@com_google_absl//absl/status",
         "@com_google_googletest//:gtest_main",

--- a/tensorflow/lite/experimental/shlo/ops/abs_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/abs_test.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "tensorflow/lite/experimental/shlo/quantize.h"
 #include "tensorflow/lite/experimental/shlo/quantized_tensor_element_type.h"
 #include "tensorflow/lite/experimental/shlo/shape.h"
+#include "tensorflow/lite/experimental/shlo/status_matcher.h"
 #include "tensorflow/lite/experimental/shlo/tensor.h"
 
 using testing::ElementsAreArray;
@@ -39,7 +40,7 @@ constexpr struct AbsRef {
 } abs_ref;
 
 template <class T>
-struct AbsTest : testing::Test {};
+struct AbsTest : ::testing::Test {};
 
 TYPED_TEST_SUITE(AbsTest, NonQuantizedTestTypes, TestParamNames);
 
@@ -67,7 +68,7 @@ TYPED_TEST(AbsTest, NonQuantized) {
 }
 
 template <class T>
-struct QuantizedAbsTest : testing::Test {};
+struct QuantizedAbsTest : ::testing::Test {};
 
 TYPED_TEST_SUITE(QuantizedAbsTest, QuantizedTestTypes, TestParamNames);
 

--- a/tensorflow/lite/experimental/shlo/ops/cbrt_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/cbrt_test.cc
@@ -26,12 +26,13 @@ limitations under the License.
 #include "tensorflow/lite/experimental/shlo/quantize.h"
 #include "tensorflow/lite/experimental/shlo/quantized_tensor_element_type.h"
 #include "tensorflow/lite/experimental/shlo/shape.h"
+#include "tensorflow/lite/experimental/shlo/status_matcher.h"
 #include "tensorflow/lite/experimental/shlo/tensor.h"
 
 using testing::ElementsAreArray;
 using testing::NanSensitiveFloatEq;
 using testing::Pointwise;
-using testing::status::StatusIs;
+using shlo_ref::testing::StatusIs;
 
 namespace shlo_ref {
 
@@ -55,7 +56,7 @@ struct Cbrt {
 } cbrt_ref;
 
 template <class T>
-struct NonQuantizedIntCbrtTest : testing::Test {};
+struct NonQuantizedIntCbrtTest : ::testing::Test {};
 
 TYPED_TEST_SUITE(NonQuantizedIntCbrtTest, NonQuantizedIntTestTypes,
                  TestParamNames);
@@ -78,7 +79,7 @@ TYPED_TEST(NonQuantizedIntCbrtTest, IntTensorsRaiseAnError) {
 }
 
 template <class T>
-struct NonQuantizedCbrtTest : testing::Test {};
+struct NonQuantizedCbrtTest : ::testing::Test {};
 
 TYPED_TEST_SUITE(NonQuantizedCbrtTest, NonQuantizedFloatTestTypes,
                  TestParamNames);
@@ -107,7 +108,7 @@ TYPED_TEST(NonQuantizedCbrtTest, FloatTensorsWork) {
 }
 
 template <class T>
-struct QuantizedCbrtTest : testing::Test {};
+struct QuantizedCbrtTest : ::testing::Test {};
 
 TYPED_TEST_SUITE(QuantizedCbrtTest, QuantizedTestTypes, TestParamNames);
 

--- a/tensorflow/lite/experimental/shlo/ops/ceil_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/ceil_test.cc
@@ -26,12 +26,13 @@ limitations under the License.
 #include "tensorflow/lite/experimental/shlo/quantize.h"
 #include "tensorflow/lite/experimental/shlo/quantized_tensor_element_type.h"
 #include "tensorflow/lite/experimental/shlo/shape.h"
+#include "tensorflow/lite/experimental/shlo/status_matcher.h"
 #include "tensorflow/lite/experimental/shlo/tensor.h"
 
 using testing::ElementsAreArray;
 using testing::NanSensitiveFloatEq;
 using testing::Pointwise;
-using testing::status::StatusIs;
+using shlo_ref::testing::StatusIs;
 
 namespace shlo_ref {
 
@@ -55,7 +56,7 @@ struct Ceil {
 } ceil_ref;
 
 template <class T>
-struct NonQuantizedIntCeilTest : testing::Test {};
+struct NonQuantizedIntCeilTest : ::testing::Test {};
 
 TYPED_TEST_SUITE(NonQuantizedIntCeilTest, NonQuantizedIntTestTypes,
                  TestParamNames);
@@ -78,7 +79,7 @@ TYPED_TEST(NonQuantizedIntCeilTest, IntTensorsRaiseAnError) {
 }
 
 template <class T>
-struct NonQuantizedCeilTest : testing::Test {};
+struct NonQuantizedCeilTest : ::testing::Test {};
 
 TYPED_TEST_SUITE(NonQuantizedCeilTest, NonQuantizedFloatTestTypes,
                  TestParamNames);
@@ -107,7 +108,7 @@ TYPED_TEST(NonQuantizedCeilTest, FloatTensorsWork) {
 }
 
 template <class T>
-struct QuantizedCeilTest : testing::Test {};
+struct QuantizedCeilTest : ::testing::Test {};
 
 TYPED_TEST_SUITE(QuantizedCeilTest, QuantizedTestTypes, TestParamNames);
 

--- a/tensorflow/lite/experimental/shlo/ops/unary_elementwise_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/unary_elementwise_test.cc
@@ -25,6 +25,7 @@ limitations under the License.
 #include "tensorflow/lite/experimental/shlo/ops/test_util.h"
 #include "tensorflow/lite/experimental/shlo/quantized_tensor_element_type.h"
 #include "tensorflow/lite/experimental/shlo/shape.h"
+#include "tensorflow/lite/experimental/shlo/status_matcher.h"
 #include "tensorflow/lite/experimental/shlo/tensor.h"
 
 using testing::ElementsAreArray;
@@ -48,7 +49,7 @@ struct TestParam {
 };
 
 template <class T>
-struct UnaryElementWiseTest : testing::Test {};
+struct UnaryElementWiseTest : ::testing::Test {};
 
 TYPED_TEST_SUITE(UnaryElementWiseTest, NonQuantizedTestTypes);
 
@@ -76,7 +77,7 @@ TYPED_TEST(UnaryElementWiseTest, NonQuantizedWithAbs) {
 }
 
 template <class T>
-struct QuantizedUnaryElementWiseTest : testing::Test {};
+struct QuantizedUnaryElementWiseTest : ::testing::Test {};
 
 TYPED_TEST_SUITE(QuantizedUnaryElementWiseTest, QuantizedTestTypes);
 

--- a/tensorflow/lite/experimental/shlo/ops/util_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/util_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include "absl/status/status.h"
 #include "tensorflow/lite/experimental/shlo/shape.h"
+#include "tensorflow/lite/experimental/shlo/status_matcher.h"
 
 using testing::ElementsAreArray;
 

--- a/tensorflow/lite/experimental/shlo/quantized_tensor_element_type.h
+++ b/tensorflow/lite/experimental/shlo/quantized_tensor_element_type.h
@@ -113,13 +113,14 @@ class QuantizedTensorElementType {
     std::visit(
         [](auto& scales) -> void {
           using Container = std::remove_reference_t<decltype(scales)>;
-          absl::c_fill(scales, static_cast<Container::value_type>(1));
+          absl::c_fill(scales, static_cast<typename Container::value_type>(1));
         },
         baseline.scales_);
     std::visit(
         [](auto& zero_points) -> void {
           using Container = std::remove_reference_t<decltype(zero_points)>;
-          absl::c_fill(zero_points, static_cast<Container::value_type>(0));
+          absl::c_fill(zero_points,
+                       static_cast<typename Container::value_type>(0));
         },
         baseline.zero_points_);
     return baseline;


### PR DESCRIPTION
In OSS, we need to use appropriate polyfills and extra link options for android builds.