### PR TITLE
[Linaro:ARM_CI] Fix typo PACAKGES to PACKAGES

### DIFF
--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test.sh
@@ -109,7 +109,7 @@ sed -i '$ aimport /usertools/aarch64_clang.bazelrc' .bazelrc
 
 # configure may have chosen the wrong setting for PYTHON_LIB_PATH so
 # determine here the correct setting
-PY_SITE_PACAKGES=$(${PYTHON_BIN_PATH} -c "import site ; print(site.getsitepackages()[0])")
+PY_SITE_PACKAGES=$(${PYTHON_BIN_PATH} -c "import site ; print(site.getsitepackages()[0])")
 
 update_bazel_flags
 

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_build.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_build.sh
@@ -123,7 +123,7 @@ WHL_DIR=$(realpath "${WHL_DIR}") # Get absolute path
 
 # configure may have chosen the wrong setting for PYTHON_LIB_PATH so
 # determine here the correct setting
-PY_SITE_PACAKGES=$(${PYTHON_BIN_PATH} -c "import site ; print(site.getsitepackages()[0])")
+PY_SITE_PACKAGES=$(${PYTHON_BIN_PATH} -c "import site ; print(site.getsitepackages()[0])")
 
 # Determine the major.minor versions of python being used (e.g., 3.7).
 # Useful for determining the directory of the local pip installation.

--- a/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_cpp.sh
+++ b/tensorflow/tools/ci_build/rel/ubuntu/cpu_arm64_test_cpp.sh
@@ -80,7 +80,7 @@ sed -i '$ aimport /usertools/aarch64_clang.bazelrc' .bazelrc
 
 # configure may have chosen the wrong setting for PYTHON_LIB_PATH so
 # determine here the correct setting
-PY_SITE_PACAKGES=$(${PYTHON_BIN_PATH} -c "import site ; print(site.getsitepackages()[0])")
+PY_SITE_PACKAGES=$(${PYTHON_BIN_PATH} -c "import site ; print(site.getsitepackages()[0])")
 
 bazel test ${TF_TEST_FLAGS} \
     --action_env=PYTHON_BIN_PATH=${PYTHON_BIN_PATH} \


### PR DESCRIPTION
This is causing some unit test failures with Python aborting