### PR TITLE
Fix Build Failure on Windows

### DIFF
--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -146,7 +146,7 @@ bazel build \
   --experimental_cc_shared_library \
   --config=release_cpu_windows ${EXTRA_BUILD_FLAGS} \
   --output_filter=^$ \
-  tensorflow/tools/pip_package:build_pip_package || exit $?
+  tensorflow/tools/pip_package:wheel || exit $?
 
 if [[ "$SKIP_TEST" == 1 ]]; then
   exit 0
@@ -155,7 +155,7 @@ fi
 # Create a python test directory to avoid package name conflict
 create_python_test_dir "${PY_TEST_DIR}"
 
-./bazel-bin/tensorflow/tools/pip_package/build_pip_package "$PWD/${PY_TEST_DIR}" ${EXTRA_PIP_FLAGS}
+cp ./bazel-bin/tensorflow/tools/pip_package/wheel_house/*.whl "$PWD/${PY_TEST_DIR}"
 
 if [[ "$TF_NIGHTLY" == 1 ]]; then
   exit 0

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -145,6 +145,7 @@ bazel build ${EXTRA_BUILD_FLAGS}  \
 bazel build \
   --experimental_cc_shared_library \
   --config=release_cpu_windows ${EXTRA_BUILD_FLAGS} \
+  --repo_env=WHEEL_NAME=tf_nightly \
   --output_filter=^$ \
   tensorflow/tools/pip_package:wheel || exit $?
 

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -155,8 +155,8 @@ else
   --config=release_cpu_windows ${EXTRA_BUILD_FLAGS} \
   --output_filter=^$ \
   tensorflow/tools/pip_package:wheel || exit $?
+fi
   
-
 if [[ "$SKIP_TEST" == 1 ]]; then
   exit 0
 fi

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -142,12 +142,20 @@ bazel build ${EXTRA_BUILD_FLAGS}  \
   --output_filter=^$ \
   tensorflow/lite:framework tensorflow/lite/examples/minimal:minimal || exit $?
 
-bazel build \
+if [[ "$TF_NIGHTLY" == 1 ]]; then
+  bazel build \
   --experimental_cc_shared_library \
   --config=release_cpu_windows ${EXTRA_BUILD_FLAGS} \
   --repo_env=WHEEL_NAME=tf_nightly \
   --output_filter=^$ \
   tensorflow/tools/pip_package:wheel || exit $?
+else 
+  bazel build \
+  --experimental_cc_shared_library \
+  --config=release_cpu_windows ${EXTRA_BUILD_FLAGS} \
+  --output_filter=^$ \
+  tensorflow/tools/pip_package:wheel || exit $?
+  
 
 if [[ "$SKIP_TEST" == 1 ]]; then
   exit 0

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows.sh
@@ -142,20 +142,11 @@ bazel build ${EXTRA_BUILD_FLAGS}  \
   --output_filter=^$ \
   tensorflow/lite:framework tensorflow/lite/examples/minimal:minimal || exit $?
 
-if [[ "$TF_NIGHTLY" == 1 ]]; then
-  bazel build \
-  --experimental_cc_shared_library \
-  --config=release_cpu_windows ${EXTRA_BUILD_FLAGS} \
-  --repo_env=WHEEL_NAME=tf_nightly \
-  --output_filter=^$ \
-  tensorflow/tools/pip_package:wheel || exit $?
-else 
-  bazel build \
+bazel build \
   --experimental_cc_shared_library \
   --config=release_cpu_windows ${EXTRA_BUILD_FLAGS} \
   --output_filter=^$ \
   tensorflow/tools/pip_package:wheel || exit $?
-fi
   
 if [[ "$SKIP_TEST" == 1 ]]; then
   exit 0

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows_clang-cl.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows_clang-cl.sh
@@ -148,7 +148,7 @@ bazel build \
   --config=release_cpu_windows ${EXTRA_BUILD_FLAGS} \
   --config=win_clang \
   --output_filter=^$ \
-  tensorflow/tools/pip_package:build_pip_package || exit $?
+  tensorflow/tools/pip_package:wheel || exit $?
 
 if [[ "$SKIP_TEST" == 1 ]]; then
   exit 0
@@ -157,7 +157,7 @@ fi
 # Create a python test directory to avoid package name conflict
 create_python_test_dir "${PY_TEST_DIR}"
 
-./bazel-bin/tensorflow/tools/pip_package/build_pip_package "$PWD/${PY_TEST_DIR}" ${EXTRA_PIP_FLAGS}
+cp ./bazel-bin/tensorflow/tools/pip_package/wheel_house/*.whl "$PWD/${PY_TEST_DIR}"
 
 if [[ "$TF_NIGHTLY" == 1 ]]; then
   exit 0

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows_clang-cl.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows_clang-cl.sh
@@ -147,6 +147,7 @@ bazel build \
   --experimental_cc_shared_library \
   --config=release_cpu_windows ${EXTRA_BUILD_FLAGS} \
   --config=win_clang \
+  --repo_env=WHEEL_NAME=tf_nightly \
   --output_filter=^$ \
   tensorflow/tools/pip_package:wheel || exit $?
 

--- a/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows_clang-cl.sh
+++ b/tensorflow/tools/ci_build/windows/cpu/pip/build_tf_windows_clang-cl.sh
@@ -147,7 +147,6 @@ bazel build \
   --experimental_cc_shared_library \
   --config=release_cpu_windows ${EXTRA_BUILD_FLAGS} \
   --config=win_clang \
-  --repo_env=WHEEL_NAME=tf_nightly \
   --output_filter=^$ \
   tensorflow/tools/pip_package:wheel || exit $?
 


### PR DESCRIPTION
This PR aims to resolve the TensorFlow CPU build failure on the Windows platform. The build target to build TensorFlow has been changed from build_pip_package to wheel. (https://github.com/tensorflow/tensorflow/commit/40a00a61fc9c85e4af61178026b6ed3d5bb2a90f)