### PR TITLE
Fix chakcfail of ResourceApplyProximalAdagrad Op

### DIFF
--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -1827,6 +1827,14 @@ class ApplyProximalAdagradOp : public OpKernel {
         errors::InvalidArgument("var and grad do not have the same shape",
                                 var.shape().DebugString(), " ",
                                 grad.shape().DebugString()));
+    const DataType lr_dtype = lr.dtype();
+    OP_REQUIRES(
+        l1.dtype() == lr_dtype && 
+        l1.dtype() == lr_dtype && 
+        grad.dtype() == lr_dtype,
+        absl::InvalidArgumentError("The arguments `l1`, `l2` and `grad`"
+                                   " should have same dtype as `lr`. ";)
+    )
 
     const Device& device = ctx->template eigen_device<Device>();
     functor::ApplyProximalAdagrad<Device, T>()(

--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -1828,10 +1828,10 @@ class ApplyProximalAdagradOp : public OpKernel {
                                 var.shape().DebugString(), " ",
                                 grad.shape().DebugString()));
     const DataType lr_dtype = lr.dtype();
-    OP_REQUIRES(
+    OP_REQUIRES(ctx,
+        (l1.dtype() == lr_dtype && 
         l1.dtype() == lr_dtype && 
-        l1.dtype() == lr_dtype && 
-        grad.dtype() == lr_dtype,
+        grad.dtype() == lr_dtype),
         absl::InvalidArgumentError("The arguments `l1`, `l2` and `grad`"
                                    " should have same dtype as `lr`. ";)
     )

--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -1830,7 +1830,7 @@ class ApplyProximalAdagradOp : public OpKernel {
     const DataType lr_dtype = lr.dtype();
     OP_REQUIRES(ctx,
         (l1.dtype() == lr_dtype && 
-        l1.dtype() == lr_dtype && 
+        l2.dtype() == lr_dtype && 
         grad.dtype() == lr_dtype),
         absl::InvalidArgumentError("The arguments `l1`, `l2` and `grad`"
                                    " should have same dtype as `lr`. ";)


### PR DESCRIPTION
The Op `ResourceApplyProximalAdagrad` can lead to checkfail if the inputs `lr`, `l1`, `l2` and `grad` don't passed with same dtype. Proposed validation for same.

Fixes #63697 .
