### PR TITLE
Fix check fail in TensorScatterUpdate Op

### DIFF
--- a/tensorflow/core/kernels/scatter_nd_op.cc
+++ b/tensorflow/core/kernels/scatter_nd_op.cc
@@ -165,6 +165,11 @@ class TensorScatterOp : public OpKernel {
                                       updates.shape().num_elements()),
                 errors::InvalidArgument(
                     "Indices and updates specified for empty output shape"));
+    OP_REQUIRES(c, 
+                !(updates.shape().dims() < indices.shape().dims() - 1),
+                absl::InvalidArgumentError(
+                    "The rank of `updates` should not be lower than "
+                    "rank of `indices` -1 . "));
 
     const int64_t outer_dims = indices.shape().dims() - 1;
 

--- a/tensorflow/core/kernels/scatter_nd_op.cc
+++ b/tensorflow/core/kernels/scatter_nd_op.cc
@@ -166,7 +166,7 @@ class TensorScatterOp : public OpKernel {
                 errors::InvalidArgument(
                     "Indices and updates specified for empty output shape"));
     OP_REQUIRES(c, 
-                !(updates.shape().dims() < indices.shape().dims() - 1),
+                updates.shape().dims() >= indices.shape().dims() - 1,
                 absl::InvalidArgumentError(
                     "The rank of `updates` should not be lower than "
                     "rank of `indices` -1 . "));


### PR DESCRIPTION
The Op `TensorScatterUpdate` checkfails if the rank of updates is lower than the rank of indices -1. 

This will happen from this code below.
https://github.com/tensorflow/tensorflow/blob/0f7eb923815f4fd82321dda01bab45b493227d58/tensorflow/core/kernels/scatter_nd_op.cc#L169-L172

From above code the loop will iterate over `indices.shape().dims() - 1` times and checks whether `indices.shape().dim_size(i) == updates.shape().dim_size(i)`. Suppose if indices is a 3D and updates is 1D this will cause checkfail when i=1.

May fix #63575 .