### PR TITLE
make instructions more clear for building c dll with Windows

### DIFF
--- a/tensorflow/lite/g3doc/guide/build_cmake.md
+++ b/tensorflow/lite/g3doc/guide/build_cmake.md
@@ -292,8 +292,15 @@ cmake --build . -j
 
 This command generates the following shared library in the current directory.
 
+### Windows Only, For Release Build
+
 **Note:** On Windows system, you can find the `tensorflowlite_c.dll` under
-`debug` directory.
+`debug` directory by default.
+
+```sh
+cmake ../tensorflow_src/tensorflow/lite/c
+cmake --build . -j --config Release
+```
 
 Platform | Library name
 -------- | ---------------------------


### PR DESCRIPTION
To more explicitly show how to build Release build for c dll on Windows.