### PR TITLE
Fix checkfail in ResourceSparseApplyKerasMomentum

### DIFF
--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -3415,6 +3415,9 @@ class SparseApplyKerasMomentumOp : public OpKernel {
                                 accum.shape().DebugString()));
     OP_REQUIRES(ctx, TensorShapeUtils::IsVectorOrHigher(var.shape()),
                 errors::InvalidArgument("var must be at least 1 dimensional"));
+    if (var.dtype() != DT_FLOAT || accum.dtype() != DT_FLOAT) {
+        absl::InvalidArgumentError("`var` and `accum` must be of float32 type");
+    }
 
     const Tensor& lr = ctx->input(2);
     OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(lr.shape()),


### PR DESCRIPTION
The Op `ResourceSparseApplyKerasMomentum` checkfails if the arguments `var` or `accum` has dtype other than float32.
Proposed a validation check for same.

May Fixes #63720 .