### PR TITLE
Typos are fixed in quantization_debugger.ipynb

### DIFF
--- a/tensorflow/lite/g3doc/performance/quantization_debugger.ipynb
+++ b/tensorflow/lite/g3doc/performance/quantization_debugger.ipynb
@@ -75,11 +75,11 @@
         "quantized model won't always work as expected. It's usually expected for the\n",
         "model quality (e.g. accuracy, mAP, WER) to be slightly lower than the original\n",
         "float model. However, there are cases where the model quality can go below your\n",
-        "expectation or generated completely wrong results.\n",
+        "expectations or generates completely wrong results.\n",
         "\n",
         "When this problem happens, it's tricky and painful to spot the root cause of the\n",
         "quantization error, and it's even more difficult to fix the quantization error.\n",
-        "To assist this model inspection process, **quantization debugger** can be used\n",
+        "To assist this model inspection process, a **quantization debugger** can be used\n",
         "to identify problematic layers, and **selective quantization** can leave those\n",
         "problematic layers in float so that the model accuracy can be recovered at the\n",
         "cost of reduced benefit from quantization.\n",
@@ -119,7 +119,7 @@
         "*   Model to quantize\n",
         "*   Representative dataset\n",
         "\n",
-        "In addition to model and data, you will need to use a data processing framework\n",
+        "In addition to the model and data, you will need to use a data processing framework\n",
         "(e.g. pandas, Google Sheets) to analyze the exported results."
       ]
     },
@@ -131,7 +131,7 @@
       "source": [
         "### Setup\n",
         "\n",
-        "This section prepares libraries, MobileNet v3 model, and test dataset of 100\n",
+        "This section prepares libraries, MobileNet v3 model, and a test dataset of 100\n",
         "images."
       ]
     },
@@ -277,7 +277,7 @@
       "source": [
         "### Step 1. Debugger preparation\n",
         "\n",
-        "Easiest way to use the quantization debugger is to provide\n",
+        "The Easiest way to use the quantization debugger is to provide\n",
         "`tf.lite.TFLiteConverter` that you have been using to quantize the model."
       ]
     },
@@ -540,8 +540,8 @@
       "source": [
         "Quantization debugger's option accepts `denylisted_nodes` and `denylisted_ops`\n",
         "options for skipping quantization for specific layers, or all instances of\n",
-        "specific ops. Using `suspected_layers` we prepared from the previous step, we\n",
-        "can use quantization debugger to get a selectively quantized model."
+        "specific ops. Using the `suspected_layers` we prepared from the previous step, we\n",
+        "can use a quantization debugger to get a selectively quantized model."
       ]
     },
     {
@@ -582,7 +582,7 @@
         "notable improvement from the whole quantized model by skipping quantization for\n",
         "~10 layers out of 111 layers.\n",
         "\n",
-        "You can also try to not quantized all ops in the same class. For example, to\n",
+        "You can also try to not quantize all ops in the same class. For example, to\n",
         "skip quantization for all mean ops, you can pass `MEAN` to `denylisted_ops`."
       ]
     },
@@ -633,7 +633,7 @@
       "source": [
         "## Advanced usages\n",
         "\n",
-        "Whith following features, you can further customize your debugging pipeline."
+        "With the following features, you can further customize your debugging pipeline."
       ]
     },
     {
@@ -656,7 +656,7 @@
         "    calculate metric based on raw float and quantized tensors, and its\n",
         "    quantization parameters (scale, zero point)\n",
         "*   `model_debug_metrics`: **only used when `float_model_(path|content)` is\n",
-        "    passed** to the debugger. In addition to the op-level metrics, final layer\n",
+        "    passed** to the debugger. In addition to the op-level metrics, the final layer\n",
         "    output is compared to the reference output from the original float model."
       ]
     },
@@ -743,7 +743,7 @@
       "source": [
         "### Using (internal) mlir_quantize API to access in-depth features\n",
         "\n",
-        "Note: Some features in the folowing section,\n",
+        "Note: Some features in the following section,\n",
         "`TFLiteConverter._experimental_calibrate_only` and `converter.mlir_quantize` are\n",
         "experimental internal APIs, and subject to change in a non-backward compatible\n",
         "way."


### PR DESCRIPTION
Typos and Grammatical errors are fixed