### PR TITLE
Update the Configure.py to set CLANG as compiler

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -883,9 +883,9 @@ def set_clang_compiler_path_win(environ_cp):
       check_success=os.path.exists,
       resolve_symlinks=True,
       error_msg=(
-          'Invalid clang path. %s cannot be found. Note that TensorFlow now'
-          ' requires clang to compile. You may override this behavior by'
-          ' setting TF_NEED_CLANG=0'
+          'Invalid clang path. %s cannot be found. Note that Clang is now'
+          'preferred compiler. You may use MSVC by removing --config=win_clang'
+  
       ),
   )
 

--- a/configure.py
+++ b/configure.py
@@ -857,6 +857,44 @@ def set_clang_compiler_path(environ_cp):
 
   return clang_compiler_path
 
+def set_clang_compiler_path_win(environ_cp):
+  """Set CLANG_COMPILER_PATH and environment variables.
+
+  Loop over user prompts for clang path until receiving a valid response.
+  Default is used if no input is given. Set CLANG_COMPILER_PATH and write
+  environment variables CC and BAZEL_COMPILER to .bazelrc.
+
+  Args:
+    environ_cp: (Dict) copy of the os.environ.
+
+  Returns:
+    string value for clang_compiler_path.
+  """
+  # Default path if clang-16 is installed by using apt-get install
+  default_clang_path = 'C:/Program Files/LLVM/bin/clang.exe'
+  if not os.path.exists(default_clang_path):
+    default_clang_path = which('clang') or ''
+
+  clang_compiler_path = prompt_loop_or_load_from_env(
+      environ_cp,
+      var_name='CLANG_COMPILER_PATH',
+      var_default=default_clang_path,
+      ask_for_var='Please specify the path to clang executable.',
+      check_success=os.path.exists,
+      resolve_symlinks=True,
+      error_msg=(
+          'Invalid clang path. %s cannot be found. Note that TensorFlow now'
+          ' requires clang to compile. You may override this behavior by'
+          ' setting TF_NEED_CLANG=0'
+      ),
+  )
+
+  write_action_env_to_bazelrc('CLANG_COMPILER_PATH', clang_compiler_path)
+  write_to_bazelrc('build --repo_env=CC=%s' % clang_compiler_path)
+  write_to_bazelrc('build --repo_env=BAZEL_COMPILER=%s' % clang_compiler_path)
+
+  return clang_compiler_path
+
 
 def retrieve_clang_version(clang_executable):
   """Retrieve installed clang version.
@@ -1428,7 +1466,7 @@ def main():
     if is_windows():
       environ_cp['TF_NEED_CLANG'] = str(choose_compiler_Win(environ_cp))
       if environ_cp.get('TF_NEED_CLANG') == '1':
-        clang_compiler_path = set_clang_compiler_path(environ_cp)
+        clang_compiler_path = set_clang_compiler_path_win(environ_cp)
         clang_version = retrieve_clang_version(clang_compiler_path)
         disable_clang_offsetof_extension(clang_version)
 

--- a/configure.py
+++ b/configure.py
@@ -885,7 +885,6 @@ def set_clang_compiler_path_win(environ_cp):
       error_msg=(
           'Invalid clang path. %s cannot be found. Note that Clang is now'
           'preferred compiler. You may use MSVC by removing --config=win_clang'
-  
       ),
   )
 
@@ -894,7 +893,6 @@ def set_clang_compiler_path_win(environ_cp):
   write_to_bazelrc('build --repo_env=BAZEL_COMPILER=%s' % clang_compiler_path)
 
   return clang_compiler_path
-
 
 def retrieve_clang_version(clang_executable):
   """Retrieve installed clang version.

--- a/configure.py
+++ b/configure.py
@@ -808,7 +808,7 @@ def choose_compiler(environ_cp):
 
 def choose_compiler_Win(environ_cp):
   question = 'Do you want to use Clang to build TensorFlow?'
-  yes_reply = 'Please use "--config=win_clang" to compile TensorFlow with CLANG.'
+  yes_reply = 'Add "--config=win_clang" to compile TensorFlow with CLANG.'
   no_reply = 'MSVC will be used to compile TensorFlow.'
   var = int(
       get_var(

--- a/configure.py
+++ b/configure.py
@@ -806,6 +806,16 @@ def choose_compiler(environ_cp):
   )
   return var
 
+def choose_compiler_Win(environ_cp):
+  question = 'Do you want to use Clang to build TensorFlow?'
+  yes_reply = 'Please use "--config=win_clang" to compile TensorFlow with CLANG.'
+  no_reply = 'MSVC will be used to compile TensorFlow.'
+  var = int(
+      get_var(
+          environ_cp, 'TF_NEED_CLANG', None, True, question, yes_reply, no_reply
+      )
+  )
+  return var
 
 def set_clang_compiler_path(environ_cp):
   """Set CLANG_COMPILER_PATH and environment variables.
@@ -1411,6 +1421,12 @@ def main():
     # CUDA not required. Ask whether we should use clang for the CPU build.
     if is_linux():
       environ_cp['TF_NEED_CLANG'] = str(choose_compiler(environ_cp))
+      if environ_cp.get('TF_NEED_CLANG') == '1':
+        clang_compiler_path = set_clang_compiler_path(environ_cp)
+        clang_version = retrieve_clang_version(clang_compiler_path)
+        disable_clang_offsetof_extension(clang_version)
+    if is_windows():
+      environ_cp['TF_NEED_CLANG'] = str(choose_compiler_Win(environ_cp))
       if environ_cp.get('TF_NEED_CLANG') == '1':
         clang_compiler_path = set_clang_compiler_path(environ_cp)
         clang_version = retrieve_clang_version(clang_compiler_path)


### PR DESCRIPTION
Update configure.py to set Clang as the preferred compiler to build TensorFlow CPU wheels on the Windows Platform starting with TF 2.16.1