### PR TITLE
Build kernel for all numbertypes for ApproximateEqual Op

### DIFF
--- a/tensorflow/core/kernels/cwise_op_equal_to_1.cc
+++ b/tensorflow/core/kernels/cwise_op_equal_to_1.cc
@@ -21,11 +21,8 @@ REGISTER7(BinaryOp, CPU, "Equal", functor::equal_to, float, Eigen::half, double,
 REGISTER8(BinaryOp, CPU, "Equal", functor::equal_to, uint16, uint32, uint64,
           qint8, qint16, quint8, quint16, qint32);
 REGISTER_KERNEL_BUILDER(
-    Name("ApproximateEqual").Device(DEVICE_CPU).TypeConstraint<float>("T"),
-    ApproximateEqualOp<CPUDevice, float>);
-REGISTER_KERNEL_BUILDER(
-    Name("ApproximateEqual").Device(DEVICE_CPU).TypeConstraint<double>("T"),
-    ApproximateEqualOp<CPUDevice, double>);
+    Name("ApproximateEqual").Device(DEVICE_CPU).TypeConstraint<T>("T"),
+    ApproximateEqualOp<CPUDevice, T>);
 
 REGISTER_KERNEL_BUILDER(Name("Equal")
                             .Device(DEVICE_DEFAULT)
@@ -42,11 +39,8 @@ REGISTER4(BinaryOp, GPU, "Equal", functor::equal_to, float, Eigen::half, double,
 #endif
 REGISTER(BinaryOp, GPU, "Equal", functor::equal_to, bfloat16);
 REGISTER_KERNEL_BUILDER(
-    Name("ApproximateEqual").Device(DEVICE_GPU).TypeConstraint<float>("T"),
-    ApproximateEqualOp<GPUDevice, float>);
-REGISTER_KERNEL_BUILDER(
-    Name("ApproximateEqual").Device(DEVICE_GPU).TypeConstraint<double>("T"),
-    ApproximateEqualOp<GPUDevice, double>);
+    Name("ApproximateEqual").Device(DEVICE_GPU).TypeConstraint<T>("T"),
+    ApproximateEqualOp<GPUDevice, T>);
 
 // A special GPU kernel for int32.
 // TODO(b/25387198): Also enable int32 in device memory. This kernel


### PR DESCRIPTION
"The Op ApproximateEqual registered for numbertypes as per kernel registration here.

https://github.com/tensorflow/tensorflow/blob/dadeddbce13b7d422c73ed872e386c56dd41a478/tensorflow/core/ops/math_ops.cc#L781-L783

But Kernel built for `float` and `double`. Proposing a fix for same.

Might Fix #64256 .