### PR TITLE
shlo_ref: Disable legacy code build

### DIFF
--- a/tensorflow/lite/experimental/shlo/legacy/BUILD
+++ b/tensorflow/lite/experimental/shlo/legacy/BUILD
@@ -32,6 +32,7 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/types:span",
     ],
+    tags = ["no_oss"],
 )
 
 cc_library(
@@ -49,6 +50,7 @@ cc_library(
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/types:span",
     ],
+    tags = ["no_oss"],
 )
 
 cc_library(
@@ -62,4 +64,5 @@ cc_library(
     ],
     deps = [
     ],
+    tags = ["no_oss"],
 )

--- a/tensorflow/lite/experimental/shlo/legacy/bench/BUILD
+++ b/tensorflow/lite/experimental/shlo/legacy/bench/BUILD
@@ -10,6 +10,7 @@ cc_library(
     deps = [
         "//tensorflow/lite/experimental/shlo/legacy:float",
     ],
+    tags = ["no_oss"],
 )
 
 cc_binary(
@@ -26,6 +27,7 @@ cc_binary(
         "@com_google_absl//absl/status",
         "@com_google_benchmark//:benchmark",
     ],
+    tags = ["no_oss"],
 )
 
 cc_binary(
@@ -42,4 +44,5 @@ cc_binary(
         "@com_google_absl//absl/log",
         "@com_google_benchmark//:benchmark",
     ],
+    tags = ["no_oss"],
 )

--- a/tensorflow/lite/experimental/shlo/legacy/test/BUILD
+++ b/tensorflow/lite/experimental/shlo/legacy/test/BUILD
@@ -8,6 +8,7 @@ cc_library(
         "//tensorflow/lite/experimental/shlo/legacy:debug",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["no_oss"],
 )
 
 cc_library(
@@ -23,6 +24,7 @@ cc_library(
         "//tensorflow/lite/experimental/shlo/legacy:shlo",
         "@com_google_absl//absl/log:check",
     ],
+    tags = ["no_oss"],
 )
 
 cc_test(
@@ -39,6 +41,7 @@ cc_test(
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["no_oss"],
 )
 
 cc_test(
@@ -54,6 +57,7 @@ cc_test(
         "//tensorflow/lite/experimental/shlo/legacy:shlo",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["no_oss"],
 )
 
 cc_test(
@@ -69,6 +73,7 @@ cc_test(
         "//tensorflow/lite/experimental/shlo/legacy:shlo",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["no_oss"],
 )
 
 cc_test(
@@ -85,6 +90,7 @@ cc_test(
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["no_oss"],
 )
 
 cc_test(
@@ -102,6 +108,7 @@ cc_test(
         "@com_google_absl//absl/status",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["no_oss"],
 )
 
 cc_test(
@@ -119,6 +126,7 @@ cc_test(
         "@com_google_absl//absl/status",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["no_oss"],
 )
 
 cc_test(
@@ -134,6 +142,7 @@ cc_test(
         "//tensorflow/lite/experimental/shlo/legacy:shlo",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["no_oss"],
 )
 
 cc_test(
@@ -148,6 +157,7 @@ cc_test(
         "//tensorflow/lite/experimental/shlo/legacy:shlo",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["no_oss"],
 )
 
 cc_test(
@@ -163,6 +173,7 @@ cc_test(
         "//tensorflow/lite/experimental/shlo/legacy:shlo",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["no_oss"],
 )
 
 cc_test(
@@ -178,4 +189,5 @@ cc_test(
         "//tensorflow/lite/experimental/shlo/legacy:shlo",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["no_oss"],
 )


### PR DESCRIPTION
The code under shlo/legacy is useful for reference, but cannot build with the oss toolchains. This PR disables those targets with the no_oss tag.