### PR TITLE
shlo_ref: Move template specializations

### DIFF
--- a/tensorflow/lite/experimental/shlo/ops/cbrt.cc
+++ b/tensorflow/lite/experimental/shlo/ops/cbrt.cc
@@ -32,17 +32,17 @@ struct Cbrt {
   T operator()(T v) const {
     return std::cbrt(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 };
+
+template <>
+F16 Cbrt::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Cbrt::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 CbrtOp Create(CbrtOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/cbrt_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/cbrt_test.cc
@@ -48,17 +48,17 @@ struct Cbrt {
   T operator()(T v) const {
     return std::cbrt(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 } cbrt_ref;
+
+template <>
+F16 Cbrt::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Cbrt::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Cbrt, UnaryElementwiseOpShapePropagationTest,
                                CbrtOp, TestParamNames);

--- a/tensorflow/lite/experimental/shlo/ops/ceil.cc
+++ b/tensorflow/lite/experimental/shlo/ops/ceil.cc
@@ -33,17 +33,17 @@ struct Ceil {
   T operator()(T v) const {
     return std::ceil(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 };
+
+template <>
+F16 Ceil::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Ceil::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 CeilOp Create(CeilOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/ceil_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/ceil_test.cc
@@ -48,17 +48,17 @@ struct Ceil {
   T operator()(T v) const {
     return std::ceil(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 } ceil_ref;
+
+template <>
+F16 Ceil::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Ceil::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Ceil, UnaryElementwiseOpShapePropagationTest,
                                CeilOp, TestParamNames);

--- a/tensorflow/lite/experimental/shlo/ops/cosine.cc
+++ b/tensorflow/lite/experimental/shlo/ops/cosine.cc
@@ -32,17 +32,17 @@ struct Cosine {
   T operator()(T v) const {
     return std::cos(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 };
+
+template <>
+F16 Cosine::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Cosine::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 CosineOp Create(CosineOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/cosine_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/cosine_test.cc
@@ -48,17 +48,17 @@ struct Cosine {
   T operator()(T v) const {
     return std::cos(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 } cosine_ref;
+
+template <>
+F16 Cosine::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Cosine::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Cosine, UnaryElementwiseOpShapePropagationTest,
                                CosineOp, TestParamNames);

--- a/tensorflow/lite/experimental/shlo/ops/exponential.cc
+++ b/tensorflow/lite/experimental/shlo/ops/exponential.cc
@@ -32,17 +32,17 @@ struct Exponential {
   T operator()(T v) const {
     return std::exp(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 };
+
+template <>
+F16 Exponential::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Exponential::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 ExponentialOp Create(ExponentialOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/exponential_minus_one.cc
+++ b/tensorflow/lite/experimental/shlo/ops/exponential_minus_one.cc
@@ -32,17 +32,17 @@ struct ExponentialMinusOne {
   T operator()(T v) const {
     return std::expm1(v);
   }
-
-  template <>
-  F16 operator()(F16 v) const {
-    return F16(operator()(static_cast<float>(v)));
-  }
-
-  template <>
-  BF16 operator()(BF16 v) const {
-    return BF16(operator()(static_cast<float>(v)));
-  }
 };
+
+template <>
+F16 ExponentialMinusOne::operator()(F16 v) const {
+  return F16(operator()(static_cast<float>(v)));
+}
+
+template <>
+BF16 ExponentialMinusOne::operator()(BF16 v) const {
+  return BF16(operator()(static_cast<float>(v)));
+}
 
 ExponentialMinusOneOp Create(ExponentialMinusOneOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/exponential_minus_one_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/exponential_minus_one_test.cc
@@ -48,17 +48,17 @@ struct ExponentialMinusOne {
   T operator()(T v) const {
     return std::expm1(v);
   }
-
-  template <>
-  F16 operator()(F16 v) const {
-    return F16(operator()(static_cast<float>(v)));
-  }
-
-  template <>
-  BF16 operator()(BF16 v) const {
-    return BF16(operator()(static_cast<float>(v)));
-  }
 } exponential_minus_one_ref;
+
+template <>
+F16 ExponentialMinusOne::operator()(F16 v) const {
+  return F16(operator()(static_cast<float>(v)));
+}
+
+template <>
+BF16 ExponentialMinusOne::operator()(BF16 v) const {
+  return BF16(operator()(static_cast<float>(v)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(ExponentialMinusOne,
                                UnaryElementwiseOpShapePropagationTest,

--- a/tensorflow/lite/experimental/shlo/ops/exponential_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/exponential_test.cc
@@ -48,17 +48,17 @@ struct Exponential {
   T operator()(T v) const {
     return std::exp(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 } exponential_ref;
+
+template <>
+F16 Exponential::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Exponential::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Exponential,
                                UnaryElementwiseOpShapePropagationTest,

--- a/tensorflow/lite/experimental/shlo/ops/floor.cc
+++ b/tensorflow/lite/experimental/shlo/ops/floor.cc
@@ -32,17 +32,17 @@ struct Floor {
   T operator()(T v) const {
     return std::floor(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 };
+
+template <>
+F16 Floor::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Floor::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 FloorOp Create(FloorOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/floor_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/floor_test.cc
@@ -48,17 +48,17 @@ struct Floor {
   T operator()(T v) const {
     return std::floor(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 } floor_ref;
+
+template <>
+F16 Floor::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Floor::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Floor, UnaryElementwiseOpShapePropagationTest,
                                FloorOp, TestParamNames);

--- a/tensorflow/lite/experimental/shlo/ops/log.cc
+++ b/tensorflow/lite/experimental/shlo/ops/log.cc
@@ -32,17 +32,17 @@ struct Log {
   T operator()(T v) const {
     return std::log(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 };
+
+template <>
+F16 Log::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Log::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 LogOp Create(LogOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/log_plus_one.cc
+++ b/tensorflow/lite/experimental/shlo/ops/log_plus_one.cc
@@ -32,17 +32,17 @@ struct LogPlusOne {
   T operator()(T v) const {
     return std::log1p(v);
   }
-
-  template <>
-  F16 operator()(F16 v) const {
-    return F16(operator()(static_cast<float>(v)));
-  }
-
-  template <>
-  BF16 operator()(BF16 v) const {
-    return BF16(operator()(static_cast<float>(v)));
-  }
 };
+
+template <>
+F16 LogPlusOne::operator()(F16 v) const {
+  return F16(operator()(static_cast<float>(v)));
+}
+
+template <>
+BF16 LogPlusOne::operator()(BF16 v) const {
+  return BF16(operator()(static_cast<float>(v)));
+}
 
 LogPlusOneOp Create(LogPlusOneOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/log_plus_one_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/log_plus_one_test.cc
@@ -48,17 +48,17 @@ struct LogPlusOne {
   T operator()(T v) const {
     return std::log1p(v);
   }
-
-  template <>
-  F16 operator()(F16 v) const {
-    return F16(operator()(static_cast<float>(v)));
-  }
-
-  template <>
-  BF16 operator()(BF16 v) const {
-    return BF16(operator()(static_cast<float>(v)));
-  }
 } log_plus_one_ref;
+
+template <>
+F16 LogPlusOne::operator()(F16 v) const {
+  return F16(operator()(static_cast<float>(v)));
+}
+
+template <>
+BF16 LogPlusOne::operator()(BF16 v) const {
+  return BF16(operator()(static_cast<float>(v)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(LogPlusOne,
                                UnaryElementwiseOpShapePropagationTest,

--- a/tensorflow/lite/experimental/shlo/ops/log_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/log_test.cc
@@ -48,17 +48,17 @@ struct Log {
   T operator()(T v) const {
     return std::log(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 } log_ref;
+
+template <>
+F16 Log::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Log::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Log, UnaryElementwiseOpShapePropagationTest,
                                LogOp, TestParamNames);

--- a/tensorflow/lite/experimental/shlo/ops/logistic.cc
+++ b/tensorflow/lite/experimental/shlo/ops/logistic.cc
@@ -33,17 +33,17 @@ struct Logistic {
     constexpr T one = static_cast<T>(1);
     return one / (one + std::exp(-v));
   }
-
-  template <>
-  F16 operator()(F16 v) const {
-    return F16(operator()(static_cast<float>(v)));
-  }
-
-  template <>
-  BF16 operator()(BF16 v) const {
-    return BF16(operator()(static_cast<float>(v)));
-  }
 };
+
+template <>
+F16 Logistic::operator()(F16 v) const {
+  return F16(operator()(static_cast<float>(v)));
+}
+
+template <>
+BF16 Logistic::operator()(BF16 v) const {
+  return BF16(operator()(static_cast<float>(v)));
+}
 
 LogisticOp Create(LogisticOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/logistic_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/logistic_test.cc
@@ -49,17 +49,17 @@ struct Logistic {
     constexpr T one = static_cast<T>(1);
     return one / (one + std::exp(-v));
   }
-
-  template <>
-  F16 operator()(F16 v) const {
-    return F16(operator()(static_cast<float>(v)));
-  }
-
-  template <>
-  BF16 operator()(BF16 v) const {
-    return BF16(operator()(static_cast<float>(v)));
-  }
 } logistic_ref;
+
+template <>
+F16 Logistic::operator()(F16 v) const {
+  return F16(operator()(static_cast<float>(v)));
+}
+
+template <>
+BF16 Logistic::operator()(BF16 v) const {
+  return BF16(operator()(static_cast<float>(v)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Logistic, UnaryElementwiseOpShapePropagationTest,
                                LogisticOp, TestParamNames);

--- a/tensorflow/lite/experimental/shlo/ops/not.cc
+++ b/tensorflow/lite/experimental/shlo/ops/not.cc
@@ -28,11 +28,12 @@ struct Not {
   T operator()(T v) const {
     return ~v;
   }
-  template <>
-  bool operator()(bool v) const {
-    return !v;
-  }
 };
+
+template <>
+bool Not::operator()(bool v) const {
+  return !v;
+}
 
 NotOp Create(NotOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/not_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/not_test.cc
@@ -48,11 +48,12 @@ struct Not {
   T operator()(T v) const {
     return ~v;
   }
-  template <>
-  bool operator()(bool v) const {
-    return !v;
-  }
 } not_ref;
+
+template <>
+bool Not::operator()(bool v) const {
+  return !v;
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Not, UnaryElementwiseOpShapePropagationTest,
                                NotOp, TestParamNames);

--- a/tensorflow/lite/experimental/shlo/ops/sign.cc
+++ b/tensorflow/lite/experimental/shlo/ops/sign.cc
@@ -32,17 +32,17 @@ struct Sign {
     constexpr T zero = static_cast<T>(0);
     return v < zero ? -one : (v > zero ? one : v);
   }
-
-  template <>
-  F16 operator()(F16 v) const {
-    return static_cast<F16>(operator()(static_cast<float>(v)));
-  }
-
-  template <>
-  BF16 operator()(BF16 v) const {
-    return static_cast<BF16>(operator()(static_cast<float>(v)));
-  }
 };
+
+template <>
+F16 Sign::operator()(F16 v) const {
+  return static_cast<F16>(operator()(static_cast<float>(v)));
+}
+
+template <>
+BF16 Sign::operator()(BF16 v) const {
+  return static_cast<BF16>(operator()(static_cast<float>(v)));
+}
 
 SignOp Create(SignOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/sign_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/sign_test.cc
@@ -49,17 +49,17 @@ struct Sign {
     constexpr T zero = static_cast<T>(0);
     return v < zero ? -one : (v > zero ? one : v);
   }
-
-  template <>
-  F16 operator()(F16 v) const {
-    return static_cast<F16>(operator()(static_cast<float>(v)));
-  }
-
-  template <>
-  BF16 operator()(BF16 v) const {
-    return static_cast<BF16>(operator()(static_cast<float>(v)));
-  }
 } sign_ref;
+
+template <>
+F16 Sign::operator()(F16 v) const {
+  return static_cast<F16>(operator()(static_cast<float>(v)));
+}
+
+template <>
+BF16 Sign::operator()(BF16 v) const {
+  return static_cast<BF16>(operator()(static_cast<float>(v)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Sign, UnaryElementwiseOpShapePropagationTest,
                                SignOp, TestParamNames);

--- a/tensorflow/lite/experimental/shlo/ops/sine.cc
+++ b/tensorflow/lite/experimental/shlo/ops/sine.cc
@@ -33,17 +33,17 @@ struct Sine {
   T operator()(T v) const {
     return std::sin(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 };
+
+template <>
+F16 Sine::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Sine::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 SineOp Create(SineOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/sine_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/sine_test.cc
@@ -48,17 +48,17 @@ struct Sine {
   T operator()(T v) const {
     return std::sin(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 } sine_ref;
+
+template <>
+F16 Sine::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Sine::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Sine, UnaryElementwiseOpShapePropagationTest,
                                SineOp, TestParamNames);

--- a/tensorflow/lite/experimental/shlo/ops/sqrt.cc
+++ b/tensorflow/lite/experimental/shlo/ops/sqrt.cc
@@ -32,17 +32,17 @@ struct Sqrt {
   T operator()(T v) const {
     return std::sqrt(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 };
+
+template <>
+F16 Sqrt::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Sqrt::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 SqrtOp Create(SqrtOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/sqrt_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/sqrt_test.cc
@@ -49,16 +49,17 @@ struct Sqrt {
     return std::sqrt(v);
   }
 
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 } sqrt_ref;
+
+template <>
+F16 Sqrt::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Sqrt::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Sqrt, UnaryElementwiseOpShapePropagationTest,
                                SqrtOp, TestParamNames);

--- a/tensorflow/lite/experimental/shlo/ops/tanh.cc
+++ b/tensorflow/lite/experimental/shlo/ops/tanh.cc
@@ -33,17 +33,17 @@ struct Tanh {
   T operator()(T v) const {
     return std::tanh(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 };
+
+template <>
+F16 Tanh::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Tanh::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 TanhOp Create(TanhOp::Attributes) { return {}; }
 

--- a/tensorflow/lite/experimental/shlo/ops/tanh_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/tanh_test.cc
@@ -48,17 +48,17 @@ struct Tanh {
   T operator()(T v) const {
     return std::tanh(v);
   }
-
-  template <>
-  F16 operator()<F16>(F16 val) const {
-    return F16(operator()(static_cast<float>(val)));
-  }
-
-  template <>
-  BF16 operator()<BF16>(BF16 val) const {
-    return BF16(operator()(static_cast<float>(val)));
-  }
 } tanh_ref;
+
+template <>
+F16 Tanh::operator()<F16>(F16 val) const {
+  return F16(operator()(static_cast<float>(val)));
+}
+
+template <>
+BF16 Tanh::operator()<BF16>(BF16 val) const {
+  return BF16(operator()(static_cast<float>(val)));
+}
 
 INSTANTIATE_TYPED_TEST_SUITE_P(Tanh, UnaryElementwiseOpShapePropagationTest,
                                TanhOp, TestParamNames);


### PR DESCRIPTION
GCC gives compilation errors that these template specializations are in a non-namespace scope. This PR moves the template specializations out of the struct scope and into a namespace scope.