### PR TITLE
Update multinomial_op logits invalid arguments check description

### DIFF
--- a/tensorflow/core/kernels/multinomial_op.cc
+++ b/tensorflow/core/kernels/multinomial_op.cc
@@ -153,30 +153,30 @@ class MultinomialOp : public OpKernel {
   void DoCompute(OpKernelContext* ctx, const Tensor& logits_t,
                  const Tensor& num_samples_t, GuardedPhiloxRandom* generator) {
     OP_REQUIRES(ctx, TensorShapeUtils::IsMatrix(logits_t.shape()),
-                errors::InvalidArgument("logits should be a matrix, got shape ",
-                                        logits_t.shape().DebugString()));
+                absl::InvalidArgumentError(absl::StrCat("logits should be a matrix, got shape ",
+                                        logits_t.shape().DebugString())));
     OP_REQUIRES(
         ctx, TensorShapeUtils::IsScalar(num_samples_t.shape()),
-        errors::InvalidArgument("num_samples should be a scalar, got shape ",
-                                num_samples_t.shape().DebugString()));
+        absl::InvalidArgumentError(absl::StrCat("num_samples should be a scalar, got shape ",
+                                num_samples_t.shape().DebugString())));
 
     const int num_samples = num_samples_t.scalar<int>()();
     OP_REQUIRES(ctx, num_samples >= 0,
-                errors::InvalidArgument(
-                    "num_samples should be non-negative, got ", num_samples));
+                absl::InvalidArgumentError(absl::StrCat(
+                    "num_samples should be non-negative, got ", num_samples)));
 
     const int batch_size = static_cast<int>(logits_t.dim_size(0));
     const int num_classes = static_cast<int>(logits_t.dim_size(1));
 
     OP_REQUIRES(ctx, batch_size == logits_t.dim_size(0),
-                errors::InvalidArgument("batch_size cannot exceed max int"));
+                absl::InvalidArgumentError("batch_size cannot exceed max int"));
 
     OP_REQUIRES(ctx, num_classes == logits_t.dim_size(1),
-                errors::InvalidArgument("num_classes cannot exceed max int"));
+                absl::InvalidArgumentError("num_classes cannot exceed max int"));
 
     OP_REQUIRES(ctx, num_classes > 0,
-                errors::InvalidArgument("num_classes should be positive, got ",
-                                        num_classes));
+                absl::InvalidArgumentError(absl::StrCat("num_classes should be positive, got ",
+                                        num_classes)));
 
     Tensor* samples_t;
     OP_REQUIRES_OK(
@@ -288,8 +288,8 @@ class StatelessMultinomialOp : public MultinomialOp<Device, T, OutputType> {
 
     const Tensor& seed_t = ctx->input(2);
     OP_REQUIRES(ctx, seed_t.dims() == 1 && seed_t.dim_size(0) == 2,
-                errors::InvalidArgument("seed must have shape [2], not ",
-                                        seed_t.shape().DebugString()));
+                absl::InvalidArgumentError(absl::StrCat("seed must have shape [2], not ",
+                                        seed_t.shape().DebugString())));
 
     random::PhiloxRandom::Key key;
     random::PhiloxRandom::ResultType counter;

--- a/tensorflow/core/kernels/multinomial_op.cc
+++ b/tensorflow/core/kernels/multinomial_op.cc
@@ -163,17 +163,21 @@ class MultinomialOp : public OpKernel {
     const int num_samples = num_samples_t.scalar<int>()();
     OP_REQUIRES(ctx, num_samples >= 0,
                 errors::InvalidArgument(
-                    "num_samples should be nonnegative, got ", num_samples));
+                    "num_samples should be non-negative, got ", num_samples));
 
-    for (int i = 0; i < 2; i++) {
-      const int64_t dim = logits_t.dim_size(i);
-      OP_REQUIRES(ctx, static_cast<int>(dim) == dim,
-                  errors::InvalidArgument(
-                      "logits.shape = ", logits_t.shape().DebugString(),
-                      " too large for int"));
-    }
-    const int batch_size = static_cast<int>(logits_t.dim_size(0));
-    const int num_classes = static_cast<int>(logits_t.dim_size(1));
+    const int64_t dim_batch_size = logits_t.dim_size(0);
+
+    OP_REQUIRES(ctx, static_cast<int>(dim_batch_size) == dim_batch_size,
+                errors::InvalidArgument(
+                    "batch_size cannot exceed max int"));
+
+    const int64_t dim_num_classes = logits_t.dim_size(1);
+    OP_REQUIRES(ctx, static_cast<int>(dim_num_classes) == dim_num_classes,
+                errors::InvalidArgument(
+                    "num_classes cannot exceed max int"));
+
+    const int batch_size = static_cast<int>(dim_batch_size);
+    const int num_classes = static_cast<int>(dim_num_classes);
     OP_REQUIRES(ctx, num_classes > 0,
                 errors::InvalidArgument("num_classes should be positive, got ",
                                         num_classes));

--- a/tensorflow/core/kernels/multinomial_op.cc
+++ b/tensorflow/core/kernels/multinomial_op.cc
@@ -165,19 +165,15 @@ class MultinomialOp : public OpKernel {
                 errors::InvalidArgument(
                     "num_samples should be non-negative, got ", num_samples));
 
-    const int64_t dim_batch_size = logits_t.dim_size(0);
+    const int batch_size = static_cast<int>(logits_t.dim_size(0));
+    const int num_classes = static_cast<int>(logits_t.dim_size(1));
 
-    OP_REQUIRES(ctx, static_cast<int>(dim_batch_size) == dim_batch_size,
-                errors::InvalidArgument(
-                    "batch_size cannot exceed max int"));
+    OP_REQUIRES(ctx, batch_size == logits_t.dim_size(0),
+                errors::InvalidArgument("batch_size cannot exceed max int"));
 
-    const int64_t dim_num_classes = logits_t.dim_size(1);
-    OP_REQUIRES(ctx, static_cast<int>(dim_num_classes) == dim_num_classes,
-                errors::InvalidArgument(
-                    "num_classes cannot exceed max int"));
+    OP_REQUIRES(ctx, num_classes == logits_t.dim_size(1),
+                errors::InvalidArgument("num_classes cannot exceed max int"));
 
-    const int batch_size = static_cast<int>(dim_batch_size);
-    const int num_classes = static_cast<int>(dim_num_classes);
     OP_REQUIRES(ctx, num_classes > 0,
                 errors::InvalidArgument("num_classes should be positive, got ",
                                         num_classes));


### PR DESCRIPTION
- Updates `InvalidArgument` descriptions to reflect overflow checks exist on the logits dimensions independently (batch_size and  num_classes), rather than simply a check on the overall logits.shape.

- Also adds in the `absl::InvalidArgumentError` construct for error messages as suggested by the reviewer.