### PR TITLE
Update configure.py to support pre-release versions of clang

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -864,12 +864,16 @@ def retrieve_clang_version(clang_executable):
 
   curr_version_split = curr_version.lower().split('clang version ')
   if len(curr_version_split) > 1:
-    curr_version = curr_version_split[1].split()[0]
+    curr_version = curr_version_split[1].split()[0].split('git')
 
+  if len(curr_version) > 1:
+    print('WARNING: current clang installation is not a release version.\n')
+
+  curr_version = curr_version[0]
   curr_version_int = convert_version_to_int(curr_version)
   # Check if current clang version can be detected properly.
   if not curr_version_int:
-    print('WARNING: current clang installation is not a release version.\n')
+    print('WARNING: current clang installation version unknown.\n')
     return None
 
   print('You have Clang %s installed.\n' % curr_version)


### PR DESCRIPTION
Since commit 055e421c4004b60588de2d728cc51cdd749dd350, pre-release versions of clang may no longer be supported, if they are built from the llvm git and include the "git" suffix in their version message.

In this case, `retrieve_clang_version` will return `None`, which will then abort the program:

```
Traceback (most recent call last):
  File "configure.py", line 1466, in <module>
    main()
  File "configure.py", line 1417, in main
    disable_clang_offsetof_extension(clang_version)
  File "configure.py", line 886, in disable_clang_offsetof_extension
    if int(clang_version.split('.')[0]) in (16, 17):
AttributeError: 'NoneType' object has no attribute 'split'
```

Fix this by falling back to an assumed version. That is, treat 18.0.0git as 18.0.0. The warning will still be printed.

For context, an example `clang --version` excerpt:

```
clang version 18.0.0git (https://github.com/llvm/llvm-project.git ea3a3b25b93664c8be750ac3cd550855dcd1848b)