### PR TITLE
Removed LOG to fix unwanted end of sequence warning when iterating over a dataset

### DIFF
--- a/tensorflow/core/framework/local_rendezvous.cc
+++ b/tensorflow/core/framework/local_rendezvous.cc
@@ -401,7 +401,6 @@ void LocalRendezvous::DoAbort(const Status& status) {
     mutex_lock l(mu_);
     status_.Update(status);
   }
-  LOG(WARNING) << "Local rendezvous is aborting with status: " << status;
 
   // Keeps one Item to make sure the current rendezvous won't be destructed.
   std::unique_ptr<Item> to_delete;


### PR DESCRIPTION
Fix #62963
By analising the stack traces in both the core and python parts, I believe the program flow and execution is correct, and we cannot stop the raise of the status OUT_OF_RANGE, with message "End of sequence" (that happens in IteratorGetNextOp::DoCompute), since it will cause an internal behaviour clearly different than when we return OK as a status, which is intended in the last iteration of the iterator, when the bug happens. It also does not make sense to stop the call to the StartAbort of the Rendezvous interface (that happens in ProcessFunctionLibraryRuntime::RunMultiDeviceSync) that originates the bug since it prints the LOG introduced in the LocalRendezvous::DoAbort function, since the documentation states that the only requirement for the StartAbort to be initiated is a status different from OK, which is the case. Therefore, to fix the bug, I think the solution is effectively removing the log introduced in the commit referenced in the issue.