### PR TITLE
Unregister complex dtypes for Round OP

### DIFF
--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -259,6 +259,12 @@ REGISTER_OP("ComplexAbs")
       .Attr("T: {bfloat16, half, float, double}") \
       .SetShapeFn(shape_inference::UnchangedShape)
 
+#define UNARY_REAL_6()                              \
+  Input("x: T")                                   \
+      .Output("y: T")                             \
+      .Attr("T: {bfloat16, half, float, double, int32, int64}") \
+      .SetShapeFn(shape_inference::UnchangedShape)
+
 #define UNARY_COMPLEX()                                                  \
   Input("x: T")                                                          \
       .Output("y: T")                                                    \
@@ -290,7 +296,7 @@ REGISTER_OP("SqrtGrad").UNARY_GRADIENT_COMPLEX();
 
 REGISTER_OP("Rsqrt").UNARY_COMPLEX();
 
-REGISTER_OP("Round").UNARY();
+REGISTER_OP("Round").UNARY_REAL_6();
 
 REGISTER_OP("RsqrtGrad").UNARY_GRADIENT_COMPLEX();
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -259,12 +259,6 @@ REGISTER_OP("ComplexAbs")
       .Attr("T: {bfloat16, half, float, double}") \
       .SetShapeFn(shape_inference::UnchangedShape)
 
-#define UNARY_REAL_6()                              \
-  Input("x: T")                                   \
-      .Output("y: T")                             \
-      .Attr("T: {bfloat16, half, float, double, int32, int64}") \
-      .SetShapeFn(shape_inference::UnchangedShape)
-
 #define UNARY_COMPLEX()                                                  \
   Input("x: T")                                                          \
       .Output("y: T")                                                    \
@@ -296,7 +290,11 @@ REGISTER_OP("SqrtGrad").UNARY_GRADIENT_COMPLEX();
 
 REGISTER_OP("Rsqrt").UNARY_COMPLEX();
 
-REGISTER_OP("Round").UNARY_REAL_6();
+REGISTER_OP("Round")
+    .Input("x: T")
+    .Output("y: T")
+    .Attr("T: {bfloat16, half, float, double, int32, int64}")
+    .SetShapeFn(shape_inference::UnchangedShape);
 
 REGISTER_OP("RsqrtGrad").UNARY_GRADIENT_COMPLEX();
 


### PR DESCRIPTION
As per documentation of the Round Op, it supports bfloat16, half, float32, float64, int8, int16, int32, int64, complex64, complex128. But It errors out with complex dtypes and int8, int16 also. Probably this might be registered only for float,int32 and int64 as per the source here.

https://github.com/tensorflow/tensorflow/blob/a787405cf0adab1793b8f01c32d222ec469c8818/tensorflow/core/kernels/cwise_op_round.cc#L20-L21

Hence changed the registration accordingly.

Might address #65317 