### PR TITLE
Fix TensorFlow Build on Windows

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -892,8 +892,8 @@ def set_clang_compiler_path_win(environ_cp):
   )
 
   write_action_env_to_bazelrc('CLANG_COMPILER_PATH', clang_compiler_path)
-  write_to_bazelrc('build --repo_env=CC=%s' % clang_compiler_path)
-  write_to_bazelrc('build --repo_env=BAZEL_COMPILER=%s' % clang_compiler_path)
+  write_to_bazelrc('build --repo_env=CC="{}"'.format(clang_compiler_path))
+  write_to_bazelrc('build --repo_env=BAZEL_COMPILER="{}"'.format(clang_compiler_path))
 
   return clang_compiler_path
 

--- a/configure.py
+++ b/configure.py
@@ -892,8 +892,8 @@ def set_clang_compiler_path_win(environ_cp):
   )
 
   write_action_env_to_bazelrc('CLANG_COMPILER_PATH', clang_compiler_path)
-  write_to_bazelrc('build --repo_env=CC="{}"'.format(clang_compiler_path))
-  write_to_bazelrc('build --repo_env=BAZEL_COMPILER="{}"'.format(clang_compiler_path))
+  write_to_bazelrc(f'build --repo_env=CC="{clang_compiler_path}"')
+  write_to_bazelrc(f'build --repo_env=BAZEL_COMPILER="{clang_compiler_path}"')
 
   return clang_compiler_path
 


### PR DESCRIPTION
This pull request addresses the issue of TensorFlow builds failing on the Windows platform. The specific error encountered was related to the incorrect path being used to detect the Clang installation, resulting in the following error message: "no such target '//:FilesLLVMbinclang.exe': target 'FilesLLVMbinclang.exe' not declared in package ''".

To resolve this issue, the PR fixes the problem by ensuring that spaces are properly escaped in the "Program Files" path. This adjustment allows the build process to accurately detect the Clang installation path