### PR TITLE
Fix check fail in crop_and_resize_op

### DIFF
--- a/tensorflow/core/kernels/image/crop_and_resize_op.cc
+++ b/tensorflow/core/kernels/image/crop_and_resize_op.cc
@@ -149,6 +149,11 @@ class CropAndResizeOp : public AsyncOpKernel {
         context, image_height > 0 && image_width > 0,
         errors::InvalidArgument("image dimensions must be positive"), done);
     OP_REQUIRES_ASYNC(
+        context, boxes.dims() == 2,
+        absl::InvalidArgumentError(absl::StrCat("boxes must be 2-D, got: ",
+                                boxes.shape().DebugString())),
+        done);
+    OP_REQUIRES_ASYNC(
         context, TensorShapeUtils::IsVector(box_index.shape()),
         errors::InvalidArgument("box_indices must be rank 1 but is shape ",
                                 box_index.shape().DebugString()),


### PR DESCRIPTION
The Op `CropAndResize` checkfails with an input where `boxes` and `box_ind` both are `1D` and `empty` tensors. This is due to missing validation for this particular case which skips the check of boxes for Rank-2.

The check skips from this line which checks for empty tensors but skips rank checking.

https://github.com/tensorflow/tensorflow/blob/7aac92419d6cb25c8dcd6e4bcfe2f234efaff168/tensorflow/core/kernels/image/crop_and_resize_op.cc#L62-L64

May Fix #65629