### PR TITLE
Fix checkfail in GatherV2

### DIFF
--- a/tensorflow/core/kernels/gather_op.cc
+++ b/tensorflow/core/kernels/gather_op.cc
@@ -77,6 +77,9 @@ class GatherOp : public OpKernel {
                     errors::InvalidArgument("axis must be int32 or int64."));
       }
     }
+    // special case to avoid checkfail when axis = kint64max. 
+    OP_REQUIRES(c, axis < kint64max,
+                absl::InvalidArgumentError("axis must be less than kint64max"));
 
     int64_t min_params_dim = axis < 0 ? -axis : axis + 1;
     OP_REQUIRES(


### PR DESCRIPTION
The Op `GatherV2` leads to check fail particularly when `axis=kint64max`. 

This is due to the below piece of code.

https://github.com/tensorflow/tensorflow/blob/1592da0d245b8123f95e8b72c2f4974343b8a0c7/tensorflow/core/kernels/gather_op.cc#L81-L84

From the above code `min_params_dim` will become `axis+1` and this leads to `overflow` to -ve value as axis is already `kint64max` and the `OP_REQUIRES` check `params.dims() >= min_params_dim` will not return error .

Anything less than or greater than that leads to valid exception.

Might fix #65869