### PR TITLE
[oneDNN] Add accidentally removed ops back to MklList for auto_mixed_precision

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_lists.h
@@ -442,6 +442,7 @@ class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {
                                      "Log",
                                      "Log1p",
                                      "LogSoftmax",
+                                     "Mean",
                                      "Prod",
                                      "RealDiv",
                                      "Reciprocal",
@@ -458,6 +459,7 @@ class AutoMixedPrecisionListsMkl : public AutoMixedPrecisionLists {
                                      "Sqrt",
                                      "Square",
                                      "SquaredDifference",
+                                     "Sum",
                                      "Tanh",
                                      "TanhGrad"};
     UpdateList("INFERLIST", &list);


### PR DESCRIPTION
 [PR-62817](https://github.com/tensorflow/tensorflow/pull/62817) accidentally removed these ops, so adding them back.