### PR TITLE
[oneDNN] Quantized MatMul with new API and features

### DIFF
--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -95,6 +95,7 @@ tf_mkl_kernel_library(
     hdrs = [
         "mkl_kernel_util.h",
         "mkl_matmul_ops_common.h",
+        "mkl_quantized_conv_ops.h",
     ],
     deps = [
         "//tensorflow/core:graph",
@@ -171,6 +172,7 @@ tf_cc_test_mkl(
     srcs = ["mkl_qmatmul_op_test.cc"],
     linkstatic = 1,  # Fixes dyld error on MacOS.
     deps = [
+        ":mkl_matmul_op",
         ":mkl_qmatmul_op",
         "//tensorflow/core:array_ops_op_lib",
         "//tensorflow/core:math_ops_op_lib",
@@ -552,5 +554,23 @@ tf_cc_test_mkl(
         "//tensorflow/cc:cc_ops_internal",
         "//tensorflow/core/kernels:softmax_op",
         "//tensorflow/core/kernels/mkl:mkl_softmax_op",
+    ] + MKL_TEST_DEPS,
+)
+
+tf_cc_test_mkl(
+    name = "onednn_fused_matmul_ops_test",
+    size = "medium",
+    srcs = ["onednn_fused_matmul_ops_test.cc"],
+    linkstatic = 1,  # Fixes dyld error on MacOS.
+    deps = [
+        ":mkl_matmul_op",
+        ":mkl_kernel_util",
+        "//tensorflow/cc:cc_ops_internal",
+        "//tensorflow/core:direct_session",
+        "//tensorflow/core/kernels:matmul_op",
+        "//tensorflow/core/kernels:relu_op",
+        "//tensorflow/core/kernels:bias_op",
+        "//tensorflow/core/kernels:quantization_utils",
+        "@com_google_absl//absl/strings",
     ] + MKL_TEST_DEPS,
 )

--- a/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
@@ -1098,7 +1098,7 @@ class MklFusedMatMulCacheTest : public OpsTestBase {
     // Bias vector.
     AddInputFromArray<float>(TensorShape({4}), {1, 2, 3, 4});
 
-    using KernelType = MklDnnMatMulOpBase<float, void, float>;
+    using KernelType = MklDnnMatMulOpBase<float, float, float>;
     // Before the first time kernel execution, weight should be empty
     EXPECT_TRUE(static_cast<KernelType*>(this->kernel_.get())
                     ->IsWeightCacheEmpty(this->context_.get()));

--- a/tensorflow/core/kernels/mkl/mkl_kernel_util.cc
+++ b/tensorflow/core/kernels/mkl/mkl_kernel_util.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include "tensorflow/cc/ops/array_ops.h"
 #include "tensorflow/cc/ops/const_op.h"
 #include "tensorflow/core/graph/node_builder.h"
+#include "tensorflow/core/lib/core/errors.h"
 
 namespace tensorflow {
 
@@ -40,6 +41,9 @@ void MklTestingUtil::RunMklQuantizeOp(const Tensor& input,
   Node* max_node = test::graph::Constant(&*graph, Tensor(max), "max");
 
   Node* quantize_op;
+  string round_mode =
+      (mode == "SCALE") ? "HALF_TO_EVEN" : "HALF_AWAY_FROM_ZERO";
+
   TF_CHECK_OK(NodeBuilder("mkl_quantizeV2", "_MklQuantizeV2")
                   .Input(input_node)
                   .Input(min_node)

--- a/tensorflow/core/kernels/mkl/mkl_kernel_util.cc
+++ b/tensorflow/core/kernels/mkl/mkl_kernel_util.cc
@@ -50,7 +50,7 @@ void MklTestingUtil::RunMklQuantizeOp(const Tensor& input,
                   .Input(max_node)
                   .Attr("T", type)
                   .Attr("mode", mode)
-                  .Attr("round_mode", "HALF_TO_EVEN")
+                  .Attr("round_mode", round_mode)
                   .Attr("_kernel", "QuantizedMklOp")
                   .Finalize(&*graph, &quantize_op));
 

--- a/tensorflow/core/kernels/mkl/mkl_kernel_util.h
+++ b/tensorflow/core/kernels/mkl/mkl_kernel_util.h
@@ -49,6 +49,38 @@ class MklTestingUtil {
     *tensor_min = min();
     *tensor_max = max();
   }
+
+  // This utility function mimics Quantization of float/bfloat16 tensor with
+  // oneDNN backend QuantizeV2 operation. Since the op signature requires min
+  // and max values to be in float type, min_tensor and max_tensor should have
+  // their dtype set to DT_FLOAT.
+  template <typename T>
+  static Status GetQuantizationTensors(const Tensor& input, Tensor* output,
+                                     DataType out_type, const string mode,
+                                     Tensor* min_tensor, Tensor* max_tensor) {
+    if (min_tensor->dtype() != DT_FLOAT || max_tensor->dtype() != DT_FLOAT) {
+      return absl::UnimplementedError("Tensor must be float32.");
+    }
+    T min;
+    T max;
+    ComputeMinMax<T>(input, &min, &max);
+
+    float adjusted_min = static_cast<float>(min);
+    float adjusted_max = static_cast<float>(max);
+    if (mode == "SCALED") {
+      if (output->dtype() != DT_QINT8) {
+        return absl::UnimplementedError("Tensor must be QInt8 in SCALED mode.");
+      }
+      float range = std::max(std::abs(adjusted_min), std::abs(adjusted_max));
+      adjusted_min = -range;
+      adjusted_max = range;
+    }
+    RunMklQuantizeOp(input, adjusted_min, adjusted_max, out_type, mode, output);
+    min_tensor->flat<float>()(0) = adjusted_min;
+    max_tensor->flat<float>()(0) = adjusted_max;
+
+    return OkStatus();
+  }
 };
 
 #ifdef ENABLE_ONEDNN_V3

--- a/tensorflow/core/kernels/mkl/mkl_kernel_util.h
+++ b/tensorflow/core/kernels/mkl/mkl_kernel_util.h
@@ -56,8 +56,8 @@ class MklTestingUtil {
   // their dtype set to DT_FLOAT.
   template <typename T>
   static Status GetQuantizationTensors(const Tensor& input, Tensor* output,
-                                     DataType out_type, const string mode,
-                                     Tensor* min_tensor, Tensor* max_tensor) {
+                                       DataType out_type, const string mode,
+                                       Tensor* min_tensor, Tensor* max_tensor) {
     if (min_tensor->dtype() != DT_FLOAT || max_tensor->dtype() != DT_FLOAT) {
       return absl::UnimplementedError("Tensor must be float32.");
     }

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -1,4 +1,4 @@
-/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,19 +19,29 @@ limitations under the License.
 // Multiplication (MatMul) with bias (BiasAdd) operations.
 #if defined(INTEL_MKL)
 
+#include <type_traits>
+
+#include "oneapi/dnnl/dnnl.hpp"
 #include "tensorflow/core/framework/register_types.h"
 #include "tensorflow/core/kernels/fill_functor.h"
 #include "tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h"
+#include "tensorflow/core/kernels/mkl/mkl_quantized_conv_ops.h"
 #include "tensorflow/core/lib/core/errors.h"
+#include "tensorflow/core/lib/gtl/inlined_vector.h"
+#include "tensorflow/core/platform/errors.h"
 
 namespace tensorflow {
 
 // Fuse Operation
-template <typename Device, typename T, bool native_format = false>
-class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
+template <typename Device, typename T1, typename T2, typename Tbias,
+          typename Toutput, typename U, bool native_format = false>
+class MklFusedMatMulOp : public MklDnnMatMulOpBase<T2, Tbias, Toutput> {
  public:
   explicit MklFusedMatMulOp(OpKernelConstruction* ctx)
-      : MklDnnMatMulOpBase<T, void, T>(ctx) {
+      : MklDnnMatMulOpBase<T2, Tbias, Toutput>(ctx) {
+    if (std::is_same<T2, qint8>::value) {
+      return;  // Quantized version will have own contstruction code.
+    }
     OP_REQUIRES_OK(ctx, ctx->GetAttr("fused_ops", &fused_ops_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_a", &transpose_a_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("transpose_b", &transpose_b_));
@@ -41,7 +51,6 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
       OP_REQUIRES_OK(
           ctx, ctx->GetAttr("is_filter_const", &(this->is_weight_const_)));
     }
-
     OP_REQUIRES(ctx, fused_ops_.size() <= 2,
                 absl::InvalidArgumentError(
                     "MklFusedMatMul must have 2 post-arguments at most."));
@@ -54,7 +63,7 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
         ctx, transpose_a_ == false,
         absl::InvalidArgumentError("In[0] of MklMatMul can't be transposed."));
     if (fused_ops_.size() == 2 && fused_ops_[1] == "LeakyRelu") {
-      OP_REQUIRES_OK(ctx, ctx->GetAttr("leakyrelu_alpha", &leakyrelu_alpha));
+      OP_REQUIRES_OK(ctx, ctx->GetAttr("leakyrelu_alpha", &leakyrelu_alpha_));
     }
   }
 
@@ -64,7 +73,7 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
     const Tensor& weight_tensor = ctx->input(this->kInputIndexWeight);
     const Tensor& bias_tensor = MklGetInput(ctx, this->kInputIndexBias);
 
-    if (std::is_same<T, float>::value) {
+    if (std::is_same<T1, float>::value) {
       (void)SetFPMathMode();
     }
 
@@ -134,15 +143,16 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
         memory::format_tag::nc, this->is_weight_const_);
     // Extend the basic parameters for data types and fusions.
     ExtendMklDnnMatMulFwdParams(ctx, matmul_params);
-    auto st = ExecuteSingleThreadedGemm(batch, channel, k, sizeof(T));
+    auto st = ExecuteSingleThreadedGemm(batch, channel, k, sizeof(T1));
     // Create the oneDNN wrapper over Eigen threadpool and set max threads
     // in oneDNN.
     Eigen::ThreadPoolInterface* eigen_interface =
         EigenThreadPoolFromTfContext(ctx);
     tsl::OneDnnThreadPool eigen_tp(eigen_interface, ThreadPoolUseCallerThread(),
                                    st ? 1 : -1);
-    MklDnnMatMulFwdPrimitive<T, T, T, T, T>* matmul_prim =
-        MklDnnMatMulFwdPrimitiveFactory<T, T, T, T, T>::Get(matmul_params, 0);
+    MklDnnMatMulFwdPrimitive<float, T1, T2, Tbias, Toutput>* matmul_prim =
+        MklDnnMatMulFwdPrimitiveFactory<float, T1, T2, Tbias, Toutput>::Get(
+            matmul_params, 0);
 
     // Allocate output tensor.
     Tensor* dst_tensor = nullptr;
@@ -158,17 +168,17 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
     TensorShape output_tf_shape({batch, channel});
 
     if (fuse_add_) {
-      const Tensor& add_tensor = MklGetInput(ctx, kInputIndex_Add);
+      const Tensor& add_tensor = MklGetInput(ctx, input_idx_add_);
       MklDnnShape add_mkl_shape;
-      GetMklShape(ctx, kInputIndex_Add, &add_mkl_shape, native_format);
+      GetMklShape(ctx, input_idx_add_, &add_mkl_shape, native_format);
 
       // For native format, we need not to set metadata.
-      if (native_format && ctx->forward_input_to_output_with_shape(
-                               kInputIndex_Add, kOutputIndex_Dst,
-                               output_tf_shape, &dst_tensor)) {
+      if (native_format &&
+          ctx->forward_input_to_output_with_shape(
+              input_idx_add_, kOutputIndex_Dst, output_tf_shape, &dst_tensor)) {
         ;  // Need to do nothing for native format
       } else if (!native_format && ForwardMklTensorInToOutWithMklShape(
-                                       ctx, kInputIndex_Add, kOutputIndex_Dst,
+                                       ctx, input_idx_add_, kOutputIndex_Dst,
                                        &dst_tensor, output_mkl_shape, false)) {
         ;  // If it's not native format, need to forward and set meta first
       } else {
@@ -182,19 +192,20 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
         auto add_md =
             add_mkl_shape.IsMklTensor()
                 ? add_mkl_shape.GetMklLayout()
-                : memory::desc(dst_dims, MklDnnType<T>(), output_format_tag);
+                : memory::desc(dst_dims, MklDnnType<U>(), output_format_tag);
         auto dst_md =
-            memory::desc(dst_dims, MklDnnType<T>(), output_format_tag);
+            memory::desc(dst_dims, MklDnnType<Toutput>(), output_format_tag);
 
         void* add_buf =
-            static_cast<void*>(const_cast<T*>(add_tensor.flat<T>().data()));
-        void* dst_buf = static_cast<void*>((dst_tensor)->flat<T>().data());
+            static_cast<void*>(const_cast<U*>(add_tensor.flat<U>().data()));
+        void* dst_buf =
+            static_cast<void*>((dst_tensor)->flat<Toutput>().data());
 
         if (native_format) {
           // We are simply deep copying the add_tensor to dst_tensor without
           // changing memory layout, hence using same memory descriptor.
           add_md = dst_md =
-              memory::desc({add_tensor.NumElements()}, MklDnnType<T>(),
+              memory::desc({add_tensor.NumElements()}, MklDnnType<U>(),
                            dnnl::memory::format_tag::x);
         }
 
@@ -218,31 +229,33 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
 
     try {
       // Prepare the input and output for primitive.
-      T* src_data = const_cast<T*>(src_tensor.flat<T>().data());
-      T* weight_data = const_cast<T*>(weight_tensor.flat<T>().data());
-      T* bias_data = const_cast<T*>(bias_tensor.flat<T>().data());
-      T* dst_data = const_cast<T*>(dst_tensor->flat<T>().data());
+      T1* src_data = const_cast<T1*>(src_tensor.flat<T1>().data());
+      T2* weight_data = const_cast<T2*>(weight_tensor.flat<T2>().data());
+      void* bias_data = static_cast<void*>(
+          const_cast<Tbias*>(bias_tensor.flat<Tbias>().data()));
+      Toutput* dst_data =
+          const_cast<Toutput*>(dst_tensor->flat<Toutput>().data());
 
       // Reorder input if necessary.
-      MklDnnData<T> src_mkl(&(this->cpu_engine_));
-      MklDnnData<T> weight_mkl(&(this->cpu_engine_));
+      MklDnnData<T1> src_mkl(&(this->cpu_engine_));
+      MklDnnData<T2> weight_mkl(&(this->cpu_engine_));
 
       auto src_md = src_mkl_shape.IsMklTensor()
                         ? src_mkl_shape.GetMklLayout()
-                        : memory::desc(src_dims, MklDnnType<T>(), src_format);
+                        : memory::desc(src_dims, MklDnnType<T1>(), src_format);
 
       if (src_md != matmul_pd->src_desc()) {
         src_mkl.SetUsrMem(src_md, src_data);
         src_mkl.CheckReorderToOpMem(matmul_pd.get()->src_desc(),
                                     this->cpu_engine_, ctx);
-        src_data = reinterpret_cast<T*>(src_mkl.GetOpMem().get_data_handle());
+        src_data = static_cast<T1*>(src_mkl.GetOpMem().get_data_handle());
       }
 
       // Get cached data when weight is const.
       const memory::desc weight_md =
-          memory::desc(weight_dims, MklDnnType<T>(), weight_format);
+          memory::desc(weight_dims, MklDnnType<T2>(), weight_format);
       if (weight_md != matmul_pd->weights_desc()) {
-        T* cached_weight_data = nullptr;
+        T2* cached_weight_data = nullptr;
 
         if (this->is_weight_const_) {
           // TODO(intel-tf): When oneDNN major version changes to v4.x, weight
@@ -268,15 +281,21 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
           weight_mkl.CheckReorderToOpMem(matmul_pd.get()->weights_desc(),
                                          this->cpu_engine_, ctx);
           weight_data =
-              reinterpret_cast<T*>(weight_mkl.GetOpMem().get_data_handle());
+              static_cast<T2*>(weight_mkl.GetOpMem().get_data_handle());
         }
       }
       std::shared_ptr<stream> cpu_stream;
-
       cpu_stream.reset(CreateStream(&eigen_tp, matmul_prim->GetEngine()));
 
       UserScratchPad<unsigned char> scratch_pad;
       scratch_pad.AllocateSPTensor(matmul_prim, ctx);
+
+      // Temporary tensor for scaled bias when op is quantized version.
+      Tensor temp_scaled_bias_tensor;
+      if (std::is_same<T2, qint8>::value) {
+        this->GetScaledBias(ctx, matmul_pd, bias_tensor,
+                            &temp_scaled_bias_tensor, &bias_data);
+      }
 
       // Execute fused matmul op.
       matmul_prim->Execute(src_data, weight_data, bias_data, dst_data,
@@ -290,30 +309,31 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
     }
   }
 
-  void ExtendMklDnnMatMulFwdParams(OpKernelContext* ctx,
-                                   MklDnnMatMulFwdParams& params) {
+  virtual void ExtendMklDnnMatMulFwdParams(OpKernelContext* ctx,
+                                           MklDnnMatMulFwdParams& params) {
+    // Create a string from data types of input, weight, bias, and output.
+    params.dtypes.append(typeid(T1).name());
+    params.dtypes.append(typeid(T2).name());
+    params.dtypes.append(typeid(Tbias).name());
+    params.dtypes.append(typeid(Toutput).name());
     if (fused_ops_.size() == 2) {
       string post_op = fused_ops_[1];
-
-      if (post_op == "Relu") {
-        params.post_op_params.push_back({"relu", {1.0, 0.0, 0.0}});
-      } else if (post_op == "Relu6") {
-        params.post_op_params.push_back({"relu6", {1.0, 6.0, 0.0}});
+      float scale = 1.0f;
+      float alpha = 0.0f;
+      float beta = 0.0f;
+      if (post_op == "Relu6") {
+        alpha = 6.0f;
+      } else if (post_op == "LeakyRelu") {
+        alpha = leakyrelu_alpha_;
       } else if (post_op == "Elu") {
-        params.post_op_params.push_back({"elu", {1.0, 1.0, 0.0}});
-      } else if (post_op == "GeluApproximate") {
-        params.post_op_params.push_back({"gelu_approximate", {1.0, 1.0, 0.0}});
-      } else if (post_op == "GeluExact") {
-        params.post_op_params.push_back({"gelu_exact", {1.0, 1.0, 0.0}});
-      } else if (post_op == "Tanh") {
-        params.post_op_params.push_back({"tanh", {1.0, 0.0, 0.0}});
+        alpha = 1.0f;
+      }
+      if (post_op == "Relu" || post_op == "Relu6" || post_op == "LeakyRelu" ||
+          post_op == "Elu" || post_op == "GeluApproximate" ||
+          post_op == "GeluExact" || post_op == "Tanh" || post_op == "Sigmoid") {
+        params.post_op_params.push_back({post_op, {scale, alpha, beta}});
       } else if (post_op == "Add") {
         params.post_op_params.push_back({"sum", {1.0}});
-      } else if (post_op == "LeakyRelu") {
-        params.post_op_params.push_back(
-            {"leakyrelu", {1.0, leakyrelu_alpha, 0.0}});
-      } else if (post_op == "Sigmoid") {
-        params.post_op_params.push_back({"logistic", {1.0, 0.0, 0.0}});
       } else {
         OP_REQUIRES_OK(ctx, absl::InvalidArgumentError(absl::StrCat(
                                 "Unsupported post-argument in MklFusedMatMul: ",
@@ -322,33 +342,629 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, void, T> {
     }
   }
 
- private:
+ protected:
+  virtual void GetScaledBias(
+      OpKernelContext*,
+      std::shared_ptr<dnnl::inner_product_forward::primitive_desc>&,
+      const Tensor&, Tensor*, void**) {}
+
   bool fuse_add_ = false;
   bool transpose_a_;
   bool transpose_b_;
-  float leakyrelu_alpha = 0.2;
+  float leakyrelu_alpha_ = 0.2;
   std::vector<string> fused_ops_;
-  const int kInputIndex_Add = 3;
+  int input_idx_add_ = 3;
   const int kOutputIndex_Dst = 0;
-};  // namespace tensorflow
+#ifdef DNNL_AARCH64_USE_ACL
+  const int kWeightTensorHashLength = 1024;
+#endif
+};
+
+namespace {
+
+enum class FusedComputationType {
+  kUndefined,
+  kBiasAdd,
+  kBiasAdd_Dequantize,
+  kBiasAdd_Requantize,
+  kBiasAdd_Activation,
+  kBiasAdd_Activation_Dequantize,
+  kBiasAdd_Activation_Requantize,
+  kBiasAdd_Add,
+  kBiasAdd_Add_Dequantize,
+  kBiasAdd_Add_Requantize,
+};
+
+struct FusedComputationPattern {
+  FusedComputationType fused_computation;
+  std::vector<string> fused_ops;
+};
+
+}  // namespace
+
+// OneDNN uses post-ops to implement different kind of fusions. The category of
+// each individual post-op can be inferred from the fused_ops attribute. The
+// following enum is used to identify list of required post-ops.
+enum class PostOpKind { kActivation, kSum, kOutputScale, kLinear };
+
+template <typename Device, typename T1, typename T2, typename Tbias,
+          typename Toutput, typename U, bool native_format = true>
+class QuantizedFusedMatMulOp
+    : public MklFusedMatMulOp<Device, T1, T2, Tbias, Toutput, U,
+                              native_format> {
+ protected:
+  string input_quant_mode_;   // 0-th input
+  string output_quant_mode_;  // 0-th output
+  string activation_type_;    // Activation op type
+
+  // Initialize minmax tensor indices with default values for the most common
+  // cases.
+  int input_min_idx_ = 3;
+  int input_max_idx_ = 4;
+  int weight_min_idx_ = 5;
+  int weight_max_idx_ = 6;
+
+  struct PostOpInfo {
+    PostOpKind post_op_kind;
+    struct OperandInfo {
+      int idx = -1;  // Operand tensor index if needed by a post-op.
+      // Indices of min and max value tensors, if the operand is quantized.
+      gtl::InlinedVector<int, 4> min_max_indices;
+    } operand_info;
+    // Indices of output min and max value tensors. It is used when requantize
+    // is fused.
+    gtl::InlinedVector<int, 4> min_max_indices;
+  };
+
+  gtl::InlinedVector<PostOpInfo, 4> post_op_info_list_;
+
+  void Initialize(OpKernelConstruction* context) {
+    OP_REQUIRES_OK(context,
+                   context->GetAttr("transpose_a", &this->transpose_a_));
+    OP_REQUIRES_OK(context,
+                   context->GetAttr("transpose_b", &this->transpose_b_));
+    OP_REQUIRES_OK(context,
+                   context->GetAttr("input_quant_mode", &input_quant_mode_));
+    OP_REQUIRES_OK(context,
+                   context->GetAttr("output_quant_mode", &output_quant_mode_));
+    OP_REQUIRES_OK(
+        context, context->GetAttr("is_weight_const", &this->is_weight_const_));
+    OP_REQUIRES_OK(context,
+                   context->GetAttr("is_bias_const", &this->is_bias_const_));
+    if (context->HasAttr("leakyrelu_alpha")) {
+      OP_REQUIRES_OK(context, context->GetAttr("leakyrelu_alpha",
+                                               &this->leakyrelu_alpha_));
+    }
+
+    // Extract activation info and canonicalize activation types to
+    // common name "Activation" in the fused_ops attribute.
+    std::vector<string> fused_ops;
+    OP_REQUIRES_OK(context, context->GetAttr("fused_ops", &fused_ops));
+    for (auto it = fused_ops.begin(); it != fused_ops.end(); ++it) {
+      if (*it == "Relu" || *it == "Relu6" || *it == "Elu" ||
+          *it == "GeluApproximate" || *it == "GeluExact" || *it == "Tanh" ||
+          *it == "LeakyRelu" || *it == "Sigmoid") {
+        if (*it != "Relu") {
+          string last_fusion = fused_ops.back();
+          OP_REQUIRES(
+              context,
+              (last_fusion == "Dequantize" || last_fusion == "Requantize"),
+              absl::UnimplementedError(absl::StrCat(
+                  "Nonlinear activation except Relu can be ",
+                  "supported only with Dequantize or Requantize fusion.")));
+        }
+        activation_type_ = *it;
+        // Canonicalize all activation types into "Activation" for simplifying
+        // post ops construction.
+        *it = "Activation";
+      }
+    }
+
+    using FCT = FusedComputationType;
+
+    // TODO(intel-tf): Add more patterns when implemented.
+    std::vector<FusedComputationPattern> patterns{
+        {FCT::kBiasAdd, {"BiasAdd"}},
+        {FCT::kBiasAdd_Dequantize, {"BiasAdd", "Dequantize"}},
+        {FCT::kBiasAdd_Requantize, {"BiasAdd", "Requantize"}},
+        {FCT::kBiasAdd_Activation, {"BiasAdd", "Activation"}},
+        {FCT::kBiasAdd_Activation_Dequantize,
+         {"BiasAdd", "Activation", "Dequantize"}},
+        {FCT::kBiasAdd_Activation_Requantize,
+         {"BiasAdd", "Activation", "Requantize"}},
+        {FCT::kBiasAdd_Add_Dequantize, {"BiasAdd", "Add", "Dequantize"}},
+    };
+
+    FusedComputationType fused_computation = FusedComputationType::kUndefined;
+    for (const auto& pattern : patterns) {
+      if (fused_ops == pattern.fused_ops) {
+        fused_computation = pattern.fused_computation;
+        break;
+      }
+    }
+
+    // Configure oneDNN post ops
+    switch (fused_computation) {
+      case FCT::kBiasAdd:
+        // No post op is required.
+        OP_REQUIRES(context, (std::is_same<Toutput, qint32>::value),
+                    absl::UnimplementedError(absl::StrCat(
+                        "Qunatized fusion: [", absl::StrJoin(fused_ops, ","),
+                        "] needs output in qint32.")));
+        break;
+      case FCT::kBiasAdd_Dequantize:
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}}};
+        break;
+      case FCT::kBiasAdd_Requantize:
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}},
+                              {PostOpKind::kLinear, {}, {7, 8}}};
+        break;
+      case FCT::kBiasAdd_Activation:
+        OP_REQUIRES(context,
+                    (std::is_same<Toutput, qint32>::value &&
+                     activation_type_ == "Relu"),
+                    absl::UnimplementedError(absl::StrCat(
+                        "Qunatized fusion: [", absl::StrJoin(fused_ops, ","),
+                        "] needs output in qint32 and ",
+                        "activation supported is only Relu")));
+        post_op_info_list_ = {{PostOpKind::kActivation, {}, {}}};
+        break;
+      case FCT::kBiasAdd_Activation_Dequantize:
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}},
+                              {PostOpKind::kActivation, {}, {}}};
+        break;
+      case FCT::kBiasAdd_Activation_Requantize:
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}},
+                              {PostOpKind::kActivation, {}, {}},
+                              {PostOpKind::kLinear, {}, {7, 8}}};
+        break;
+      case FCT::kBiasAdd_Add_Dequantize: {
+        OP_REQUIRES(
+            context,
+            (std::is_same<U, float>::value || std::is_same<U, bfloat16>::value),
+            absl::UnimplementedError(
+                "Quantized addend tensor is not implemented yet."));
+        // Addend tensor precedes all minmax tensors. Shift the indices from
+        // default initilized values.
+        input_min_idx_ += 1;
+        input_max_idx_ += 1;
+        weight_min_idx_ += 1;
+        weight_max_idx_ += 1;
+        post_op_info_list_ = {{PostOpKind::kOutputScale, {}, {}},
+                              {PostOpKind::kSum, {3, {}}, {}}};
+      } break;
+      default:
+        OP_REQUIRES(context, false,
+                    absl::UnimplementedError(
+                        absl::StrCat("Fusion is not implemented: [",
+                                     absl::StrJoin(fused_ops, ","), "]")));
+    }
+  }
+
+ public:
+  explicit QuantizedFusedMatMulOp(OpKernelConstruction* context)
+      : MklFusedMatMulOp<Device, T1, T2, Tbias, Toutput, U, true>(context) {
+    Initialize(context);
+  }
+
+  void Compute(OpKernelContext* ctx) override {
+    MklFusedMatMulOp<Device, T1, T2, Tbias, Toutput, U, true>::Compute(ctx);
+    // Compute additional outputs
+    if (std::is_same<Toutput, qint8>::value ||
+        std::is_same<Toutput, quint8>::value ||
+        std::is_same<Toutput, qint32>::value) {
+      Tensor* min_output = nullptr;
+      Tensor* max_output = nullptr;
+
+      const float min_input = ctx->input(input_min_idx_).flat<float>()(0);
+      const float max_input = ctx->input(input_max_idx_).flat<float>()(0);
+      const Tensor& min_weight = ctx->input(weight_min_idx_);
+      const Tensor& max_weight = ctx->input(weight_max_idx_);
+      OP_REQUIRES(ctx, min_weight.shape() == max_weight.shape(),
+                  absl::InvalidArgumentError(
+                      "Shape of min-weight and max-weight must be same."));
+
+      if (std::is_same<Toutput, qint32>::value) {
+        TensorShape output_minmax_shape = min_weight.shape();
+        OP_REQUIRES_OK(
+            ctx, ctx->allocate_output(1, output_minmax_shape, &min_output));
+        OP_REQUIRES_OK(
+            ctx, ctx->allocate_output(2, output_minmax_shape, &max_output));
+        if (min_weight.dims() == 0) {
+          float min_output_value;
+          float max_output_value;
+          MklQuantizationRangeForMultiplication<T1, T2, qint32>(
+              min_input, max_input, min_weight.flat<float>()(0),
+              max_weight.flat<float>()(0), &min_output_value,
+              &max_output_value);
+          min_output->flat<float>()(0) = min_output_value;
+          max_output->flat<float>()(0) = max_output_value;
+        } else {
+          MklQuantizationRangeForMultiplication<T1, T2, qint32>(
+              min_input, max_input, min_weight, max_weight, &min_output,
+              &max_output);
+        }
+      } else {
+        // When output type is qint8 or quint8, the kernel is registered for
+        // Requantize fusion.
+        OP_REQUIRES_OK(ctx, ctx->allocate_output(1, {}, &min_output));
+        OP_REQUIRES_OK(ctx, ctx->allocate_output(2, {}, &max_output));
+        int output_min_idx = ctx->num_inputs() - 2;
+        int output_max_idx = ctx->num_inputs() - 1;
+        const float requested_min = ctx->input(output_min_idx).flat<float>()(0);
+        const float requested_max = ctx->input(output_max_idx).flat<float>()(0);
+        if (output_quant_mode_ == "SCALED") {
+          const float range_output =
+              std::max(std::abs(requested_min), std::abs(requested_max));
+          if (std::is_same<Toutput, qint8>::value) {
+            min_output->flat<float>()(0) = -range_output;
+            max_output->flat<float>()(0) = range_output;
+          } else {
+            min_output->flat<float>()(0) = 0;
+            max_output->flat<float>()(0) = range_output;
+          }
+        } else {
+          min_output->flat<float>()(0) = requested_min;
+          max_output->flat<float>()(0) = requested_max;
+        }
+      }
+    } else if (std::is_same<Toutput, float>::value ||
+               std::is_same<Toutput, bfloat16>::value) {
+      // Kernel is registered for Dequantization fusion. Nothing to do.
+    } else {
+      OP_REQUIRES_OK(ctx,
+                     absl::InvalidArgumentError("Unsupported output type."));
+    }
+  }
+
+  void ExtendMklDnnMatMulFwdParams(OpKernelContext* ctx,
+                                   MklDnnMatMulFwdParams& params) override {
+    // Create a string from data types of input, weight, bias, and output.
+    params.dtypes.append(typeid(T1).name());
+    params.dtypes.append(typeid(T2).name());
+    params.dtypes.append(typeid(Tbias).name());
+    params.dtypes.append(typeid(Toutput).name());
+
+    params.input_quant_mode = input_quant_mode_;
+
+    for (const auto& post_op_info : post_op_info_list_) {
+      auto post_op_kind = post_op_info.post_op_kind;
+      switch (post_op_kind) {
+        case PostOpKind::kOutputScale: {
+          if constexpr (std::is_same<Toutput, qint32>::value) {
+            // No scaling is required.
+            break;
+          }
+          const float min_input = ctx->input(input_min_idx_).flat<float>()(0);
+          const float max_input = ctx->input(input_max_idx_).flat<float>()(0);
+          const Tensor& min_weight_tensor = ctx->input(weight_min_idx_);
+          const Tensor& max_weight_tensor = ctx->input(weight_max_idx_);
+          const float* min_weight = min_weight_tensor.flat<float>().data();
+          const float* max_weight = max_weight_tensor.flat<float>().data();
+          const size_t num_weight_scales = min_weight_tensor.NumElements();
+
+          const float max_int8_input =
+              (std::is_same<T1, quint8>::value) ? 255.0f : 127.0f;
+          const float max_int8_weight =
+              (std::is_same<T2, quint8>::value) ? 255.0f : 127.0f;
+          const float range_input =
+              (input_quant_mode_ == "MIN_FIRST")
+                  ? max_input - min_input
+                  : std::max(std::abs(min_input), std::abs(max_input));
+
+          const float src_scale = range_input / max_int8_input;
+          std::vector<float> wei_scales(num_weight_scales);
+#ifndef ENABLE_ONEDNN_V3
+          std::vector<float> output_scales(num_weight_scales);
+#endif  // ENABLE_ONEDNN_V3
+          for (size_t i = 0; i < num_weight_scales; ++i) {
+            float range_weight =
+                std::max(std::abs(min_weight[i]), std::abs(max_weight[i]));
+            wei_scales[i] = range_weight / max_int8_weight;
+#ifndef ENABLE_ONEDNN_V3
+            output_scales[i] = src_scale * wei_scales[i];
+#endif  // ENABLE_ONEDNN_V3
+          }
+          FactoryKeyCreator src_partial_key;
+          src_partial_key.AddAsKey<float>(min_input);
+          src_partial_key.AddAsKey<float>(max_input);
+
+          FactoryKeyCreator wei_partial_key;
+          wei_partial_key.AddAsKey<const float*>(min_weight);
+          wei_partial_key.AddAsKey<const float*>(max_weight);
+#ifndef ENABLE_ONEDNN_V3
+          FactoryKeyCreator output_scales_partial_key;
+          output_scales_partial_key.AddAsKey(src_partial_key.GetKey());
+          output_scales_partial_key.AddAsKey(wei_partial_key.GetKey());
+          params.post_op_params.push_back({"output_scale", output_scales,
+                                           output_scales_partial_key.GetKey()});
+#else
+          params.post_op_params.push_back(
+              {"src_scale", {src_scale}, src_partial_key.GetKey()});
+          params.post_op_params.push_back(
+              {"wei_scale", wei_scales, wei_partial_key.GetKey()});
+#endif  // ENABLE_ONEDNN_V3
+        } break;
+
+        case PostOpKind::kActivation: {
+          float scale = 1.0f;
+          float alpha = 0.0f;
+          float beta = 0.0f;
+          if (activation_type_ == "LeakyRelu")
+            alpha = this->leakyrelu_alpha_;
+          else if (activation_type_ == "Relu6")
+            alpha = 6.0f;
+          else if (activation_type_ == "Elu")
+            alpha = 1.0f;
+          params.post_op_params.push_back(
+              {activation_type_, {scale, alpha, beta}});
+        } break;
+
+        case PostOpKind::kLinear: {
+          // Update output_scale for requantize fusion.
+          auto output_min_idx = post_op_info.min_max_indices[0];
+          auto output_max_idx = post_op_info.min_max_indices[1];
+          const float min_output =
+              ctx->input(output_min_idx).template flat<float>()(0);
+          const float max_output =
+              ctx->input(output_max_idx).template flat<float>()(0);
+          const float max_int8_output =
+              (std::is_same<Toutput, quint8>::value) ? 255.0f : 127.0f;
+          const float range_output =
+              (output_quant_mode_ == "MIN_FIRST")
+                  ? max_output - min_output
+                  : std::max(std::abs(min_output), std::abs(max_output));
+          float req_scale = max_int8_output / range_output;
+          float req_shift = 0.0f;
+          if (output_quant_mode_ == "MIN_FIRST") {
+            req_shift = -min_output * max_int8_output / range_output;
+          }
+          params.post_op_params.push_back(
+              {"linear", {1.0, req_scale, req_shift}});
+        } break;
+
+        case PostOpKind::kSum: {
+          this->fuse_add_ = true;
+          this->input_idx_add_ = post_op_info.operand_info.idx;
+          params.post_op_params.push_back({"sum", {1.0}});
+        } break;
+
+        default:
+          OP_REQUIRES_OK(
+              ctx, absl::InvalidArgumentError("Unsupported post-op-kind."));
+      }
+    }
+  }
+
+  void GetScaledBias(
+      OpKernelContext* ctx,
+      std::shared_ptr<dnnl::inner_product_forward::primitive_desc>& matmul_pd,
+      const Tensor& bias_tensor, Tensor* temp_scaled_bias_tensor,
+      void** bias_data) override {
+#ifdef ENABLE_ONEDNN_V3
+#define TSCALED_BIAS float
+#else
+#define TSCALED_BIAS Tbias
+#endif  // ENABLE_ONEDNN_V3
+
+#ifndef ENABLE_ONEDNN_V3
+    if (std::is_same<Tbias, qint32>::value) {
+      // Bias already has been scaled for quantized input and weight.
+#else
+    if ((std::is_same<Tbias, float>::value ||
+         std::is_same<Tbias, bfloat16>::value) &&
+        input_quant_mode_ == "SCALED") {
+#endif  // !ENABLE_ONEDNN_V3
+      return;
+    } else {
+      const float min_input = ctx->input(input_min_idx_).flat<float>()(0);
+      const float max_input = ctx->input(input_max_idx_).flat<float>()(0);
+      const Tensor& min_weight_tensor = ctx->input(weight_min_idx_);
+      const Tensor& max_weight_tensor = ctx->input(weight_max_idx_);
+      const float* min_weight = min_weight_tensor.flat<float>().data();
+      const float* max_weight = max_weight_tensor.flat<float>().data();
+      bool is_cached_bias_valid = false;
+      bool is_bias_cache_empty = this->IsBiasCacheEmpty();
+      if (!is_bias_cache_empty) {
+        this->GetCachedBias(min_input, max_input, bias_data);
+        is_cached_bias_valid = (*bias_data != nullptr);
+      }
+      if (!is_cached_bias_valid) {
+        void* input_bias_buf = static_cast<void*>(
+            const_cast<Tbias*>(bias_tensor.flat<Tbias>().data()));
+        auto scaled_bias_md = matmul_pd->bias_desc();
+        TensorShape scaled_bias_shape;
+        scaled_bias_shape.AddDim((scaled_bias_md.get_size() / sizeof(float)));
+        OP_REQUIRES_OK(ctx, ctx->allocate_temp(
+                                DataTypeToEnum<TSCALED_BIAS>::v(),
+                                scaled_bias_shape, temp_scaled_bias_tensor));
+        void* scaled_bias_buf = static_cast<void*>(
+            temp_scaled_bias_tensor->flat<TSCALED_BIAS>().data());
+
+        const float max_int8_input =
+            (std::is_same<T1, quint8>::value) ? 255.0f : 127.0f;
+        const float max_int8_weight =
+            (std::is_same<T2, quint8>::value) ? 255.0f : 127.0f;
+        const float range_input =
+            (input_quant_mode_ == "MIN_FIRST")
+                ? max_input - min_input
+                : std::max(std::abs(min_input), std::abs(max_input));
+        const size_t num_weight_scales = min_weight_tensor.NumElements();
+        std::vector<float> bias_scales(num_weight_scales, 1.0);
+        for (size_t i = 0; i < num_weight_scales; ++i) {
+          float range_weight =
+              std::max(std::abs(min_weight[i]), std::abs(max_weight[i]));
+          float scale_factor =
+              (max_int8_input * max_int8_weight) / (range_input * range_weight);
+          bias_scales[i] = scale_factor;
+        }
+        if (input_quant_mode_ == "MIN_FIRST") {
+          Tbias* input_bias = (Tbias*)input_bias_buf;
+          TSCALED_BIAS* adjusted_bias = (TSCALED_BIAS*)scaled_bias_buf;
+          float q_min_input = max_int8_input * min_input / range_input;
+          const Tensor& weight_tensor = ctx->input(1);
+          int stride_ic = 1;
+          int stride_oc = 1;
+          int k = 0;
+          int n = 0;
+          if (this->transpose_b_) {
+            k = weight_tensor.dim_size(1);
+            n = weight_tensor.dim_size(0);
+            stride_ic = 1;
+            stride_oc = k;
+          } else {
+            k = weight_tensor.dim_size(0);
+            n = weight_tensor.dim_size(1);
+            stride_ic = n;
+            stride_oc = 1;
+          }
+          T2* weight_buf = const_cast<T2*>(weight_tensor.flat<T2>().data());
+          std::vector<float> scales(n);
+          if (num_weight_scales == 1) {
+            // Weights are quantized per_tensor. Scales need to be expanded to
+            // number of output channels.
+            std::fill(scales.begin(), scales.end(), bias_scales[0]);
+          } else {
+            scales = bias_scales;
+          }
+          // TODO(intel-tf): Paralellize loop for large weights.
+          for (int j = 0; j < n; ++j) {
+            int sum = 0;
+            for (int i = 0; i < k; ++i) {
+              sum += weight_buf[i * stride_ic + j * stride_oc];
+            }
+#ifndef ENABLE_ONEDNN_V3
+            adjusted_bias[j] = static_cast<TSCALED_BIAS>(
+                (static_cast<float>(input_bias[j]) * scales[j]) +
+                (sum * q_min_input));
+#else
+            // TODO(intel-tf): Use zeropoint for quantized input tensor instead
+            // of manual adjustments.
+            if (std::is_same<Tbias, qint32>::value) {
+              // Starting with oneDNN v3.0, bias is expected to be dequantized
+              // to float32.
+              adjusted_bias[j] = static_cast<float>(input_bias[j]) / scales[j];
+            } else {
+              // Bias is float32 or bfloat16 but still needs to be compensated.
+              adjusted_bias[j] = static_cast<float>(input_bias[j]) +
+                                 ((sum * q_min_input) / scales[j]);
+            }
+#endif  // !ENABLE_ONEDNN_V3
+          }
+        } else {
+          memory::dims input_bias_dims =
+              memory::dims({bias_tensor.shape().dim_size(0)});
+          auto input_bias_md = dnnl::memory::desc(
+              input_bias_dims, MklDnnType<Tbias>(), memory::format_tag::x);
+          auto input_bias_mem =
+              dnnl::memory(input_bias_md, this->cpu_engine_, input_bias_buf);
+          auto scaled_bias_mem =
+              dnnl::memory(scaled_bias_md, this->cpu_engine_, scaled_bias_buf);
+          dnnl::primitive_attr bias_attr;
+#ifndef ENABLE_ONEDNN_V3
+          (num_weight_scales == 1)
+              ? bias_attr.set_output_scales(0, bias_scales)
+              : bias_attr.set_output_scales(1, bias_scales);
+#else
+          (num_weight_scales == 1) ? bias_attr.set_scales_mask(DNNL_ARG_SRC, 0)
+                                   : bias_attr.set_scales_mask(DNNL_ARG_SRC, 1);
+#endif  // !ENABLE_ONEDNN_V3
+          auto reorder_prim =
+              dnnl::reorder(input_bias_mem, scaled_bias_mem, bias_attr);
+          std::unordered_map<int, memory> reorder_net_args = {
+              {DNNL_ARG_FROM, input_bias_mem}, {DNNL_ARG_TO, scaled_bias_mem}};
+#ifdef ENABLE_ONEDNN_V3
+          auto scale_mem =
+              memory({{1}, MklDnnType<float>(), memory::format_tag::x},
+                     this->cpu_engine_, bias_scales.data());
+          reorder_net_args.insert(
+              {DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, scale_mem});
+#endif  // ENABLE_ONEDNN_V3
+          reorder_prim.execute(dnnl::stream(this->cpu_engine_),
+                               reorder_net_args);
+        }
+
+        *bias_data = temp_scaled_bias_tensor->flat<float>().data();
+
+        if (is_bias_cache_empty) {
+          // Only try to cache the bias in the first iteration.
+          this->CacheBias(ctx, *temp_scaled_bias_tensor, min_input, max_input);
+        }
+      }
+    }
+  }
+
+  bool IsCachedBiasValid(float current_min_input,
+                         float current_max_input) override
+      TF_LOCKS_EXCLUDED(this->bias_cache_mutex_) {
+    tf_shared_lock lock(this->bias_cache_mutex_);
+    if (this->is_bias_const_ && this->is_weight_const_ &&
+        std::abs(current_min_input - this->saved_min_input_) < 1e-5 &&
+        std::abs(current_max_input - this->saved_max_input_) < 1e-5) {
+      return true;
+    }
+    return false;
+  }
+};
 
 // Register mkl kernels for supported operations and types.
-#define REGISTER_FUSEDMATMUL_MKL_SUPPORTED_KERNELS_TYPES(type)                \
-  REGISTER_KERNEL_BUILDER(                                                    \
-      Name("_MklFusedMatMul")                                                 \
-          .Device(DEVICE_CPU)                                                 \
-          .TypeConstraint<type>("T")                                          \
-          .Label(mkl_op_registry::kMklLayoutDependentOpLabel),                \
-      MklFusedMatMulOp<CPUDevice, type>);                                     \
-  REGISTER_KERNEL_BUILDER(Name("_MklNativeFusedMatMul")                       \
-                              .Device(DEVICE_CPU)                             \
-                              .TypeConstraint<type>("T")                      \
-                              .Label(mkl_op_registry::kMklNameChangeOpLabel), \
-                          MklFusedMatMulOp<CPUDevice, type, true>);
+#define REGISTER_FUSEDMATMUL_MKL_SUPPORTED_KERNELS_TYPES(type)    \
+  REGISTER_KERNEL_BUILDER(                                        \
+      Name("_MklFusedMatMul")                                     \
+          .Device(DEVICE_CPU)                                     \
+          .TypeConstraint<type>("T")                              \
+          .Label(mkl_op_registry::kMklLayoutDependentOpLabel),    \
+      MklFusedMatMulOp<CPUDevice, type, type, type, type, type>); \
+  REGISTER_KERNEL_BUILDER(                                        \
+      Name("_MklNativeFusedMatMul")                               \
+          .Device(DEVICE_CPU)                                     \
+          .TypeConstraint<type>("T")                              \
+          .Label(mkl_op_registry::kMklNameChangeOpLabel),         \
+      MklFusedMatMulOp<CPUDevice, type, type, type, type, type, true>);
 TF_CALL_float(REGISTER_FUSEDMATMUL_MKL_SUPPORTED_KERNELS_TYPES);
 TF_CALL_bfloat16(REGISTER_FUSEDMATMUL_MKL_SUPPORTED_KERNELS_TYPES);
 TF_CALL_half(REGISTER_FUSEDMATMUL_MKL_SUPPORTED_KERNELS_TYPES);
 #undef REGISTER_FUSEDMATMUL_MKL_SUPPORTED_KERNELS_TYPES
+
+#define REGISTER_QUANTIZED_MATMUL(input_type, weight_type, bias_type,       \
+                                  output_type, additional_type)             \
+  REGISTER_KERNEL_BUILDER(                                                  \
+      Name("_QuantizedMatMul")                                              \
+          .Device(DEVICE_CPU)                                               \
+          .TypeConstraint<input_type>("T1")                                 \
+          .TypeConstraint<weight_type>("T2")                                \
+          .TypeConstraint<bias_type>("Tbias")                               \
+          .TypeConstraint<output_type>("Tout")                              \
+          .TypeConstraint<additional_type>("U"),                            \
+      QuantizedFusedMatMulOp<CPUDevice, input_type, weight_type, bias_type, \
+                             output_type, additional_type, true>);
+
+#define REGISTER_ALL_OUTPUT_TYPES(input_type, weight_type, bias_type,     \
+                                  additional_type)                        \
+  REGISTER_QUANTIZED_MATMUL(input_type, weight_type, bias_type, qint8,    \
+                            additional_type)                              \
+  REGISTER_QUANTIZED_MATMUL(input_type, weight_type, bias_type, quint8,   \
+                            additional_type)                              \
+  REGISTER_QUANTIZED_MATMUL(input_type, weight_type, bias_type, qint32,   \
+                            additional_type)                              \
+  REGISTER_QUANTIZED_MATMUL(input_type, weight_type, bias_type, float,    \
+                            additional_type)                              \
+  REGISTER_QUANTIZED_MATMUL(input_type, weight_type, bias_type, bfloat16, \
+                            additional_type)
+
+#define REGISTER_ALL_BIAS_OUTPUT_TYPES(input_type, weight_type,              \
+                                       additional_type)                      \
+  REGISTER_ALL_OUTPUT_TYPES(input_type, weight_type, float, additional_type) \
+  REGISTER_ALL_OUTPUT_TYPES(input_type, weight_type, bfloat16,               \
+                            additional_type)                                 \
+  REGISTER_ALL_OUTPUT_TYPES(input_type, weight_type, qint32, additional_type)
+
+#define REGISTER_ALL_INPUT_BIAS_OUTPUT_TYPES(weight_type, additional_type) \
+  REGISTER_ALL_BIAS_OUTPUT_TYPES(qint8, weight_type, additional_type)      \
+  REGISTER_ALL_BIAS_OUTPUT_TYPES(quint8, weight_type, additional_type)
+
+REGISTER_ALL_INPUT_BIAS_OUTPUT_TYPES(qint8, float);
+REGISTER_ALL_INPUT_BIAS_OUTPUT_TYPES(qint8, bfloat16);
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -27,7 +27,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h"
 #include "tensorflow/core/kernels/mkl/mkl_quantized_conv_ops.h"
 #include "tensorflow/core/lib/core/errors.h"
-#include "tensorflow/core/lib/gtl/inlined_vector.h"
+#include "absl/container/inlined_vector.h"
 #include "tensorflow/core/platform/errors.h"
 
 namespace tensorflow {
@@ -409,14 +409,14 @@ class QuantizedFusedMatMulOp
     struct OperandInfo {
       int idx = -1;  // Operand tensor index if needed by a post-op.
       // Indices of min and max value tensors, if the operand is quantized.
-      gtl::InlinedVector<int, 4> min_max_indices;
+      absl::InlinedVector<int, 4> min_max_indices;
     } operand_info;
     // Indices of output min and max value tensors. It is used when requantize
     // is fused.
-    gtl::InlinedVector<int, 4> min_max_indices;
+    absl::InlinedVector<int, 4> min_max_indices;
   };
 
-  gtl::InlinedVector<PostOpInfo, 4> post_op_info_list_;
+  absl::InlinedVector<PostOpInfo, 4> post_op_info_list_;
 
   void Initialize(OpKernelConstruction* context) {
     OP_REQUIRES_OK(context,

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -102,7 +102,7 @@ struct MklDnnMatMulFwdParams {
   struct PostOpParam {
     string name;
     std::vector<float> param;
-    string partial_key = string("");
+    string partial_key;
   };
   std::vector<PostOpParam> post_op_params;
   string input_quant_mode;

--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
@@ -21,7 +21,6 @@ limitations under the License.
 #include <string>
 #include <vector>
 
-#include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #include "dnnl.hpp"
 #include "tensorflow/core/framework/op.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -29,6 +28,7 @@ limitations under the License.
 #include "tensorflow/core/kernels/mkl/mkl_kernel_util.h"
 #include "tensorflow/core/util/mkl_util.h"
 #include "tensorflow/core/util/onednn_env_vars.h"
+#include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
 #if defined(DNNL_AARCH64_USE_ACL) && defined(ENABLE_ONEDNN_OPENMP)
 #include "tensorflow/core/platform/mutex.h"
 #endif
@@ -102,8 +102,10 @@ struct MklDnnMatMulFwdParams {
   struct PostOpParam {
     string name;
     std::vector<float> param;
+    string partial_key = string("");
   };
   std::vector<PostOpParam> post_op_params;
+  string input_quant_mode;
 
   MklDnnMatMulFwdParams(
       memory::dims src_dims, memory::dims weight_dims, memory::dims bias_dims,
@@ -244,7 +246,7 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
           dst_scale_mem(nullptr),
 #ifndef ENABLE_ONEDNN_V3
           fwd_desc(nullptr),
-#endif  // !ENABLE_ONEDNN_V3
+#endif  // ENABLE_ONEDNN_V3
           fwd_pd(nullptr),
           src_md(nullptr),
           weight_md(nullptr),
@@ -276,15 +278,26 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
                                            MklDnnType<Toutput>(),
                                            matmul_fwd_params.dst_format));
 
-    if (std::is_same<Tbias, qint32>::value) {
-      context_.bias_md.reset(new memory::desc({matmul_fwd_params.bias_dims},
-                                              MklDnnType<TSCALED_BIAS>(),
-                                              memory::format_tag::any));
+    memory::data_type bias_dt;
+#ifndef ENABLE_ONEDNN_V3
+    bias_dt = MklDnnType<Tbias>();
+#else
+    if (std::is_same<Tweight, qint8>::value) {
+      // For QuantizedMatMul, bias needs to be passed to oneDNN as float of
+      // bfloat16 (even if Tbias is qint32).
+      if (std::is_same<Tbias, bfloat16>::value &&
+          matmul_fwd_params.input_quant_mode == "SCALED") {
+        bias_dt = MklDnnType<bfloat16>();
+      } else {
+        bias_dt = MklDnnType<float>();
+      }
     } else {
-      context_.bias_md.reset(new memory::desc({matmul_fwd_params.bias_dims},
-                                              MklDnnType<Tbias>(),
-                                              memory::format_tag::any));
+      bias_dt = MklDnnType<Tbias>();
     }
+#endif  // !ENABLE_ONEDNN_V3
+    context_.bias_md.reset(new memory::desc({matmul_fwd_params.bias_dims},
+                                            bias_dt, memory::format_tag::any));
+
     // Create an inner-product.
 #ifndef ENABLE_ONEDNN_V3
     context_.fwd_desc.reset(new inner_product_forward::desc(
@@ -304,60 +317,68 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
     std::unordered_map<string, bool> is_scale_set;
     if (!post_op_params.empty()) {
       for (auto const& post_op_param : post_op_params) {
-        if (post_op_param.name == "relu" || post_op_param.name == "leakyrelu") {
+        if (post_op_param.name == "Relu" || post_op_param.name == "LeakyRelu") {
           DCHECK_EQ(post_op_param.param.size(), 3);
           float op_scale = post_op_param.param[0];
           float op_alpha = post_op_param.param[1];
           float op_beta = post_op_param.param[2];
           post_ops.APPEND_ELTWISE(op_scale, dnnl::algorithm::eltwise_relu,
                                   op_alpha, op_beta);
-        } else if (post_op_param.name == "relu6") {
+        } else if (post_op_param.name == "Relu6") {
           DCHECK_EQ(post_op_param.param.size(), 3);
           float op_scale = post_op_param.param[0];
           float op_alpha = post_op_param.param[1];
           float op_beta = post_op_param.param[2];
           post_ops.APPEND_ELTWISE_RELU6(op_scale, op_alpha, op_beta);
-        } else if (post_op_param.name == "elu") {
+        } else if (post_op_param.name == "Elu") {
           DCHECK_EQ(post_op_param.param.size(), 3);
           float op_scale = post_op_param.param[0];
           float op_alpha = post_op_param.param[1];
           float op_beta = post_op_param.param[2];
           post_ops.APPEND_ELTWISE(op_scale, dnnl::algorithm::eltwise_elu,
                                   op_alpha, op_beta);
-        } else if (post_op_param.name == "gelu_approximate") {
+        } else if (post_op_param.name == "GeluApproximate") {
           DCHECK_EQ(post_op_param.param.size(), 3);
           float op_scale = post_op_param.param[0];
           float op_alpha = post_op_param.param[1];
           float op_beta = post_op_param.param[2];
           post_ops.APPEND_ELTWISE(op_scale, dnnl::algorithm::eltwise_gelu_tanh,
                                   op_alpha, op_beta);
-        } else if (post_op_param.name == "gelu_exact") {
+        } else if (post_op_param.name == "GeluExact") {
           DCHECK_EQ(post_op_param.param.size(), 3);
           float op_scale = post_op_param.param[0];
           float op_alpha = post_op_param.param[1];
           float op_beta = post_op_param.param[2];
           post_ops.APPEND_ELTWISE(op_scale, dnnl::algorithm::eltwise_gelu_erf,
                                   op_alpha, op_beta);
-        } else if (post_op_param.name == "tanh") {
+        } else if (post_op_param.name == "Tanh") {
           DCHECK_EQ(post_op_param.param.size(), 3);
           float op_scale = post_op_param.param[0];
           float op_alpha = post_op_param.param[1];
           float op_beta = post_op_param.param[2];
           post_ops.APPEND_ELTWISE(op_scale, dnnl::algorithm::eltwise_tanh,
                                   op_alpha, op_beta);
-        } else if (post_op_param.name == "logistic") {
+        } else if (post_op_param.name == "Sigmoid") {
           DCHECK_EQ(post_op_param.param.size(), 3);
           float op_scale = post_op_param.param[0];
           float op_alpha = post_op_param.param[1];
           float op_beta = post_op_param.param[2];
           post_ops.APPEND_ELTWISE(op_scale, dnnl::algorithm::eltwise_logistic,
                                   op_alpha, op_beta);
+        } else if (post_op_param.name == "linear") {
+          DCHECK_EQ(post_op_param.param.size(), 3);
+          float op_scale = post_op_param.param[0];
+          float op_alpha = post_op_param.param[1];
+          float op_beta = post_op_param.param[2];
+          post_ops.APPEND_ELTWISE(op_scale, dnnl::algorithm::eltwise_linear,
+                                  op_alpha, op_beta);
 #ifndef ENABLE_ONEDNN_V3
         } else if (post_op_param.name == "output_scale") {
-          DCHECK_EQ(post_op_param.param.size(), 1);
-          std::vector<float> scales;
-          scales.push_back(post_op_param.param[0]);
-          post_ops_attr.set_output_scales(0, scales);
+          if (post_op_param.param.size() == 1) {
+            post_ops_attr.set_output_scales(0, post_op_param.param);
+          } else {
+            post_ops_attr.set_output_scales(2, post_op_param.param);
+          }
 #else
         } else if (post_op_param.name == "src_scale") {
           is_scale_set.insert({"src", true});
@@ -368,14 +389,18 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
               new memory(*context_.src_scale_md, cpu_engine_, DummyData));
         } else if (post_op_param.name == "wei_scale") {
           is_scale_set.insert({"wei", true});
-          post_ops_attr.set_scales_mask(DNNL_ARG_WEIGHTS, 0);
-          context_.wei_scale_md.reset(new memory::desc({1}, MklDnnType<float>(),
-                                                       memory::format_tag::x));
+          const int scale_size = post_op_param.param.size();
+          const int mask = scale_size == 1 ? 0 : 1;
+          post_ops_attr.set_scales_mask(DNNL_ARG_WEIGHTS, mask);
+          context_.wei_scale_md.reset(new memory::desc(
+              {scale_size}, MklDnnType<float>(), memory::format_tag::x));
           context_.wei_scale_mem.reset(
               new memory(*context_.wei_scale_md, cpu_engine_, DummyData));
         } else if (post_op_param.name == "dst_scale") {
           is_scale_set.insert({"dst", true});
-          post_ops_attr.set_scales_mask(DNNL_ARG_DST, 0);
+          const int scale_size = post_op_param.param.size();
+          const int mask = scale_size == 1 ? 0 : 1;
+          post_ops_attr.set_scales_mask(DNNL_ARG_DST, mask);
           context_.dst_scale_md.reset(new memory::desc({1}, MklDnnType<float>(),
                                                        memory::format_tag::x));
           context_.dst_scale_mem.reset(
@@ -387,13 +412,15 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
           post_ops.append_sum(op_scale);
 
         } else {
-          DCHECK((post_op_param.name == "relu") ||
-                 (post_op_param.name == "relu6") ||
-                 (post_op_param.name == "elu") ||
-                 (post_op_param.name == "tanh") ||
-                 (post_op_param.name == "logistic") ||
+          DCHECK((post_op_param.name == "Relu") ||
+                 (post_op_param.name == "Relu6") ||
+                 (post_op_param.name == "Elu") ||
+                 (post_op_param.name == "GeluApproximate") ||
+                 (post_op_param.name == "GeluExact") ||
+                 (post_op_param.name == "Tanh") ||
+                 (post_op_param.name == "Sigmoid") ||
                  (post_op_param.name == "sum") ||
-                 (post_op_param.name == "leakyrelu") || OUTPUT_SCALE_DCHECK);
+                 (post_op_param.name == "Leakyrelu") || OUTPUT_SCALE_DCHECK);
         }
       }
       post_ops_attr.set_post_ops(post_ops);
@@ -433,11 +460,15 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
         {DNNL_ARG_SCRATCHPAD, *context_.sp_mem},
         {DNNL_ARG_DST, *context_.dst_mem}};
 #ifdef ENABLE_ONEDNN_V3
-    if (is_scale_set["src"] && is_scale_set["wei"] && is_scale_set["dst"]) {
+    if (is_scale_set["src"]) {
       net_args.insert(
           {DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, *context_.src_scale_mem});
+    }
+    if (is_scale_set["wei"]) {
       net_args.insert(
           {DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, *context_.wei_scale_mem});
+    }
+    if (is_scale_set["dst"]) {
       net_args.insert(
           {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, *context_.dst_scale_mem});
     }
@@ -510,12 +541,12 @@ class MklDnnMatMulFwdPrimitiveFactory : public MklPrimitiveFactory<T> {
 
     // Generate keys for post-ops
     for (auto const& post_op_param : mkldnn_matmul_fwd_dims.post_op_params) {
-      if (post_op_param.name == "relu" || post_op_param.name == "relu6" ||
-          post_op_param.name == "elu" || post_op_param.name == "tanh" ||
-          post_op_param.name == "logistic" ||
-          post_op_param.name == "leakyrelu" ||
-          post_op_param.name == "gelu_approximate" ||
-          post_op_param.name == "gelu_exact") {
+      if (post_op_param.name == "Relu" || post_op_param.name == "Relu6" ||
+          post_op_param.name == "Elu" || post_op_param.name == "Tanh" ||
+          post_op_param.name == "Sigmoid" ||
+          post_op_param.name == "LeakyRelu" ||
+          post_op_param.name == "GeluApproximate" ||
+          post_op_param.name == "GeluExact" || post_op_param.name == "linear") {
         DCHECK_EQ(post_op_param.param.size(), 3);
         key_creator.AddAsKey(post_op_param.name);
         key_creator.AddAsKey(post_op_param.param[0]);
@@ -532,9 +563,16 @@ class MklDnnMatMulFwdPrimitiveFactory : public MklPrimitiveFactory<T> {
                  post_op_param.name == "wei_scale" ||
                  post_op_param.name == "dst_scale") {
 #endif  // !ENABLE_ONEDNN_V3
-        DCHECK_EQ(post_op_param.param.size(), 1);
         key_creator.AddAsKey(post_op_param.name);
-        key_creator.AddAsKey(post_op_param.param[0]);
+        if (post_op_param.partial_key.empty()) {
+          DCHECK_GE(post_op_param.param.size(), 1);
+          // Old Quantized MatMul kernels do not create part of key beforehand
+          // as primitive caching-key-creation optimization.
+          key_creator.AddAsKey(post_op_param.param[0]);
+        } else {
+          // New Quantized MatMul kernels pre-create partial key.
+          key_creator.AddAsKey(post_op_param.partial_key);
+        }
       } else {
         return string("not_a_key");
       }

--- a/tensorflow/core/kernels/mkl/mkl_qmatmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_qmatmul_op.cc
@@ -783,7 +783,7 @@ class MklDnnQuantizedMatMulReluOp
     MklDnnQuantizedMatMulOp<Device, quint8, qint8, Tbias, Toutput,
                             native_format>::ExtendMklDnnMatMulFwdParams(context,
                                                                         params);
-    params.post_op_params.push_back({"relu", {1.0, 0.0, 0.0}});
+    params.post_op_params.push_back({"Relu", {1.0, 0.0, 0.0}});
   }
 };
 

--- a/tensorflow/core/kernels/mkl/onednn_fused_matmul_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/onednn_fused_matmul_ops_test.cc
@@ -1,0 +1,749 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if defined(INTEL_MKL)
+
+#define EIGEN_USE_THREADS
+
+#include <algorithm>
+#include <limits>
+
+#include "absl/algorithm/container.h"
+#include "absl/strings/match.h"
+#include "gtest/gtest.h"
+#include "tensorflow/cc/ops/array_ops.h"
+#include "tensorflow/cc/ops/const_op.h"
+#include "tensorflow/cc/ops/math_ops.h"
+#include "tensorflow/cc/ops/nn_ops.h"
+#include "tensorflow/cc/ops/nn_ops_internal.h"
+#include "tensorflow/cc/ops/standard_ops.h"
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/graph/node_builder.h"
+#include "tensorflow/core/kernels/mkl/mkl_kernel_util.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/kernels/quantization_utils.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/protobuf/rewriter_config.pb.h"
+#include "tensorflow/core/public/session.h"
+#include "tensorflow/core/util/util.h"
+#include "unsupported/Eigen/CXX11/Tensor"
+
+namespace tensorflow {
+
+// The test suite contains different categories of tests.
+//    (1) Realnumber (float/bfloat16): The output of _FusedMatMul should be
+//    close enough to the final output of the sequence of unfused operations.
+//    Only Gelu fusion is included here. All other fusion tests can be found in
+//    tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
+//
+//    (2) Quantized: Possible fusions are done in _QuantizedMatMul op. The
+//    output of
+//        quantize --> quantized_op --> dequantize, or
+//        quantize --> quantized_op --> requantize --> dequantize
+//    should be close (with a higher tolerance) to the final output of the
+//    sequence of unfused real number type operations. For the quantized
+//    scenario, it is assumed that the first matrix of MatMul op represents
+//    feature, while the second matrix represents weight parameters. The feature
+//    matrix can be quantized with MIN_FIRST (to QUINT8) or SCALED (to QINT8)
+//    mode and always quantized per-tensor. The weight can be quantized with
+//    per-tensor or per-channel, only with SCALED mode to QINT8.
+
+// T: float or bfloat16 used as tensor type of the MatMul and fusion operation.
+template <typename T>
+class FusedMatMulOpsTest : public OpsTestBase {
+ private:
+  float leakyrelu_alpha_ = 0.2f;
+
+ protected:
+  struct FusedOpsAndDims {
+    // List of fusions.
+    std::vector<string> fused_ops;
+    // Tensor dimension associated with the fusions. It is assumed here that
+    // each fusion requires no more than one addtional tensor. If some fusion
+    // does not require a tensor, e.g., Relu, the tensor dimensions will be {0}
+    // implying an an empty tensor.
+    std::vector<std::vector<int64_t>> fusion_dims;
+  };
+
+  struct FusedOpsAndTensors {
+    // List of fusions.
+    std::vector<string> fused_ops;
+    // Tensors associated with the fusions. It is assumed here that each fusion
+    // requires no more than one additional tensor. If some fusion does not
+    // require a tensor, e.g., Relu, the tensor will be an empty tensor.
+    std::vector<Tensor> fusion_tensors;
+  };
+
+  using GraphRunner =
+      std::function<void(const Tensor& x, const Tensor& y,
+                         const FusedOpsAndTensors& fused_ops_and_tensors,
+                         Tensor* result, bool transpose_x, bool transpose_y)>;
+
+  using QuantizedGraphRunner = std::function<void(
+      const Tensor& x, const Tensor& y,
+      const FusedOpsAndTensors& fused_ops_and_tensors, Tensor* result,
+      bool transpose_x, bool transpose_y, string input_quant_mode,
+      string output_quant_mode, bool is_bias_quantized, bool is_perchannel,
+      bool requantize, float output_min, float output_max)>;
+
+  bool HasQuantizationSupport() {
+    return TestCPUFeature(tensorflow::port::CPUFeature::AVX_VNNI_INT8) ||
+           TestCPUFeature(tensorflow::port::CPUFeature::AVX512_VNNI) ||
+           TestCPUFeature(port::CPUFeature::AMX_INT8);
+  }
+
+  // Runs a Tensorflow graph defined by the root scope, and fetches the result
+  // of 'fetch' node into the outputs. Optional `add_nodes` parameter
+  // allows to define nodes directly using NodeDefBuilder.
+  void RunAndFetch(const tensorflow::Scope& root,
+                   const std::vector<string>& fetch,
+                   std::vector<Tensor>* outputs,
+                   const std::vector<const NodeDef*> add_nodes = {}) {
+    tensorflow::GraphDef graph;
+    TF_ASSERT_OK(root.ToGraphDef(&graph));
+
+    for (const NodeDef* add_node : add_nodes) {
+      *graph.add_node() = *add_node;
+    }
+
+    // We really want to make sure that graph executed exactly as we passed it
+    // to the session, so we disable various optimizations.
+    tensorflow::SessionOptions session_options;
+
+    // Disable common runtime constant folding.
+    session_options.config.mutable_graph_options()
+        ->mutable_optimizer_options()
+        ->set_opt_level(OptimizerOptions::L0);
+
+    // Disable Grappler optimizations for tests.
+    tensorflow::RewriterConfig* cfg =
+        session_options.config.mutable_graph_options()
+            ->mutable_rewrite_options();
+    cfg->set_constant_folding(tensorflow::RewriterConfig::OFF);
+    cfg->set_layout_optimizer(tensorflow::RewriterConfig::OFF);
+    cfg->set_remapping(tensorflow::RewriterConfig::OFF);
+
+    std::unique_ptr<tensorflow::Session> session(
+        tensorflow::NewSession(session_options));
+
+    const string device = "/device:CPU:0";
+    for (NodeDef& mutable_node : *graph.mutable_node()) {
+      mutable_node.set_device(device);
+    }
+
+    TF_ASSERT_OK(session->Create(graph));
+    TF_ASSERT_OK(session->Run({}, fetch, {}, outputs));
+  }
+
+  Output ActivationOp(Scope& root, string op, Output x, string name) {
+    // TODO(intel-tf): Add GeluExact (Erf op based) when the Erf op is enabled
+    // for bfloat16. GeluExact with float32 precision test can be found in
+    //    tensorflow/python/grappler/remapper_test.py
+    if (op == "Relu") {
+      return ops::Relu(root.WithOpName(name), x);
+    } else if (op == "Relu6") {
+      return ops::Relu6(root.WithOpName(name), x);
+    } else if (op == "LeakyRelu") {
+      return ops::internal::LeakyRelu(
+          root.WithOpName(name), x,
+          ops::internal::LeakyRelu::Attrs().Alpha(this->leakyrelu_alpha_));
+    } else if (op == "Elu") {
+      return ops::Elu(root.WithOpName(name), x);
+    } else if (op == "Tanh") {
+      return ops::Tanh(root.WithOpName(name), x);
+    } else if (op == "Sigmoid") {
+      return ops::Sigmoid(root.WithOpName(name), x);
+    } else if (op == "GeluApproximate") {
+      Output three = ops::Const<T>(root.WithOpName("gelu_three"), 3.0f);
+      Output empirical =
+          ops::Const<T>(root.WithOpName("gelu_empirical"), 0.044715f);
+      Output square_root_two_over_pi = ops::Const<T>(
+          root.WithOpName("gelu_square_root_two_over_pi"), 0.7978845608028654f);
+      Output one = ops::Const<T>(root.WithOpName("gelu_one"), 1.0f);
+      Output half = ops::Const<T>(root.WithOpName("gelu_half"), 0.5f);
+      Output pow = ops::Pow(root.WithOpName("gelu_pow"), x, three);
+      Output mul1 = ops::Multiply(root.WithOpName("gelu_mul1"), empirical, pow);
+      Output add1 = ops::AddV2(root.WithOpName("gelu_add1"), x, mul1);
+      Output mul2 = ops::Multiply(root.WithOpName("gelu_mul2"),
+                                  square_root_two_over_pi, add1);
+      Output tanh = ops::Tanh(root.WithOpName("gelu_tanh"), mul2);
+      Output add3 = ops::AddV2(root.WithOpName("gelu_add3"), one, tanh);
+      Output mul3 = ops::Multiply(root.WithOpName("gelu_mul3"), half, x);
+      return ops::Multiply(root.WithOpName(name), mul3, add3);
+    } else {
+      EXPECT_TRUE(false) << absl::StrCat("The activation: ", op,
+                                         " is not supported in this test.");
+    }
+  }
+
+  void RunMatMulAndFusedOps(const Tensor& x, const Tensor& y,
+                            const FusedOpsAndTensors& fused_ops_and_tensors,
+                            Tensor* result, bool transpose_x,
+                            bool transpose_y) {
+    Scope root = tensorflow::Scope::NewRootScope();
+
+    Output x_input =
+        ops::Const(root.WithOpName("x_input"), Input::Initializer(x));
+    Output y_input =
+        ops::Const(root.WithOpName("y_input"), Input::Initializer(y));
+    Output last_output = ops::MatMul(
+        root.WithOpName("matmul"), x_input, y_input,
+        ops::MatMul::Attrs().TransposeA(transpose_x).TransposeB(transpose_y));
+    auto& fused_ops = fused_ops_and_tensors.fused_ops;
+    auto& fusion_tensors = fused_ops_and_tensors.fusion_tensors;
+    for (int i = 0; i < fused_ops.size(); ++i) {
+      const string& op = fused_ops[i];
+      if (op == "BiasAdd") {
+        Output arg = ops::Const(root.WithOpName(absl::StrCat("arg", i)),
+                                Input::Initializer(fusion_tensors[i]));
+        last_output = ops::BiasAdd(
+            root.WithOpName(absl::StrCat("bias_add_at_", i)), last_output, arg);
+      } else if (op == "Relu" || op == "Relu6" || op == "LeakyRelu" ||
+                 op == "Elu" || op == "Tanh" || op == "Sigmoid" ||
+                 op == "GeluApproximate") {
+        last_output =
+            ActivationOp(root, op, last_output, absl::StrCat(op, "_at_", i));
+      } else if (op == "Add") {
+        ASSERT_EQ(x.dtype(), fusion_tensors[i].dtype());
+        Output arg = ops::Const(root.WithOpName(absl::StrCat("arg", i)),
+                                Input::Initializer(fusion_tensors[i]));
+        last_output = ops::AddV2(root.WithOpName(absl::StrCat("add_at_", i)),
+                                 last_output, arg);
+      } else {
+        EXPECT_TRUE(false) << absl::StrCat("The fusion: [",
+                                           absl::StrJoin(fused_ops, ","),
+                                           "] is not supported in this test.");
+      }
+    }
+    std::vector<Tensor> outputs;
+    RunAndFetch(root, {last_output.name()}, &outputs);
+    *result = outputs[0];
+  }
+
+  void RunFusedMatMul(const Tensor& x, const Tensor& y,
+                      const FusedOpsAndTensors& fused_ops_and_tensors,
+                      Tensor* result, bool transpose_x, bool transpose_y) {
+    Scope root = tensorflow::Scope::NewRootScope();
+
+    DataType dtype = DataTypeToEnum<T>::v();
+
+    Output x_input =
+        ops::Const(root.WithOpName("x_input"), Input::Initializer(x));
+    Output y_input =
+        ops::Const(root.WithOpName("y_input"), Input::Initializer(y));
+    auto& fused_ops = fused_ops_and_tensors.fused_ops;
+    auto& fusion_tensors = fused_ops_and_tensors.fusion_tensors;
+    int num_fusion_inputs = 0;
+    bool has_leaky_relu = false;
+    std::vector<NodeDefBuilder::NodeOut> fusion_inputs;
+    for (int i = 0; i < fused_ops.size(); ++i) {
+      const string& op = fused_ops[i];
+      if (op == "BiasAdd") {
+        Output arg = ops::Const(root.WithOpName(absl::StrCat("arg", i)),
+                                Input::Initializer(fusion_tensors[i]));
+        fusion_inputs.push_back({arg.name(), 0, dtype});
+        num_fusion_inputs++;
+      } else if (op == "Add") {
+        ASSERT_EQ(x.dtype(), fusion_tensors[i].dtype());
+        Output arg = ops::Const(root.WithOpName(absl::StrCat("arg", i)),
+                                Input::Initializer(fusion_tensors[i]));
+        fusion_inputs.push_back({arg.name(), 0, dtype});
+        num_fusion_inputs++;
+      } else if (op == "LeakyRelu") {
+        has_leaky_relu = true;
+      } else {
+        bool is_supported = op == "Relu" || op == "Relu6" ||
+                            op == "LeakyRelu" || op == "Elu" || op == "Tanh" ||
+                            op == "Sigmoid" || op == "GeluApproximate";
+        EXPECT_TRUE(is_supported)
+            << absl::StrCat("The fusion: [", absl::StrJoin(fused_ops, ","),
+                            "] is not supported in this test.");
+      }
+    }
+    NodeDef fused_matmul;
+    std::vector<const NodeDef*> add_nodes;
+    TF_EXPECT_OK(NodeDefBuilder("fused_batch_matmul", "_MklNativeFusedMatMul")
+                     .Input({x_input.name(), 0, dtype})
+                     .Input({y_input.name(), 0, dtype})
+                     .Input(fusion_inputs)
+                     .Attr("transpose_a", transpose_x)
+                     .Attr("transpose_b", transpose_y)
+                     .Attr("num_args", num_fusion_inputs)
+                     .Attr("fused_ops", fused_ops)
+                     .Attr("leakyrelu_alpha",
+                           has_leaky_relu ? this->leakyrelu_alpha_ : 0.2f)
+                     .Attr("_kernel", "MklNameChangeOp")
+                     .Finalize(&fused_matmul));
+    add_nodes = {&fused_matmul};
+    std::vector<Tensor> outputs;
+    RunAndFetch(root, {fused_matmul.name()}, &outputs, add_nodes);
+    *result = outputs[0];
+  }
+
+  // Compute quantized tensor perchannel (aka axis) in SCALED mode for 2D
+  // tensor.
+  template <bool transpose = false>
+  void GetPerchannelQuantizationTensors(const Tensor& input, Tensor* output,
+                                        Tensor* min_tensor,
+                                        Tensor* max_tensor) {
+    ASSERT_EQ(input.dims(), 2);
+    ASSERT_EQ(output->dtype(), DT_QINT8);
+    constexpr int axis = transpose ? 0 : 1;
+    int num_channels = input.dim_size(axis);
+    ASSERT_EQ(min_tensor->NumElements(), num_channels);
+    ASSERT_EQ(max_tensor->NumElements(), num_channels);
+
+    auto eigen_input_tensor = input.matrix<T>().template cast<float>();
+    auto eigen_output_tensor = output->matrix<qint8>();
+    std::vector<float> scales(num_channels);
+    float* min_tensor_buf = min_tensor->flat<float>().data();
+    float* max_tensor_buf = max_tensor->flat<float>().data();
+    for (int i = 0; i < num_channels; ++i) {
+      auto input_slice = eigen_input_tensor.template chip<axis>(i);
+      auto output_slice = eigen_output_tensor.template chip<axis>(i);
+      Eigen::Tensor<float, 0, Eigen::RowMajor> min = input_slice.minimum();
+      Eigen::Tensor<float, 0, Eigen::RowMajor> max = input_slice.maximum();
+      float min_i = min();
+      float max_i = max();
+      float range = std::max(std::abs(min_i), std::abs(max_i));
+      min_tensor_buf[i] = -range;
+      max_tensor_buf[i] = range;
+      const float scale = 127.0f / range;
+      output_slice = (input_slice * scale).round().template cast<qint8>();
+    }
+  }
+
+  void RunQuantizedMatMul(const Tensor& x, const Tensor& y,
+                          const FusedOpsAndTensors& fused_ops_and_tensors,
+                          Tensor* result, bool transpose_x, bool transpose_y,
+                          string input_quant_mode, string output_quant_mode,
+                          bool is_bias_quantized, bool is_perchannel,
+                          bool requantize, float output_min, float output_max) {
+    // TODO(intel-tf): Extend test with quantized bias
+    ASSERT_EQ(is_bias_quantized, false);
+
+    DataType real_dtype = DataTypeToEnum<T>::v();
+    DataType qinput_dtype =
+        (input_quant_mode == "MIN_FIRST") ? DT_QUINT8 : DT_QINT8;
+    // Quantize x and y
+    Tensor x_qtensor(qinput_dtype, x.shape());
+    Tensor x_min_tensor(DT_FLOAT, TensorShape({}));
+    Tensor x_max_tensor(DT_FLOAT, TensorShape({}));
+    auto status = MklTestingUtil::GetQuantizationTensors<T>(
+        x, &x_qtensor, qinput_dtype, input_quant_mode, &x_min_tensor,
+        &x_max_tensor);
+    ASSERT_TRUE(status.ok());
+    Tensor y_qtensor(DT_QINT8, y.shape());
+    const int num_channels = transpose_y ? y.dim_size(0) : y.dim_size(1);
+    TensorShape minmax_shape =
+        is_perchannel ? TensorShape({num_channels}) : TensorShape({});
+    Tensor y_min_tensor(DT_FLOAT, minmax_shape);
+    Tensor y_max_tensor(DT_FLOAT, minmax_shape);
+    if (is_perchannel) {
+      if (transpose_y) {
+        GetPerchannelQuantizationTensors<true>(y, &y_qtensor, &y_min_tensor,
+                                               &y_max_tensor);
+      } else {
+        GetPerchannelQuantizationTensors<false>(y, &y_qtensor, &y_min_tensor,
+                                                &y_max_tensor);
+      }
+    } else {
+      auto status = MklTestingUtil::GetQuantizationTensors<T>(
+          y, &y_qtensor, DT_QINT8, "SCALED", &y_min_tensor, &y_max_tensor);
+      ASSERT_TRUE(status.ok());
+    }
+
+    Scope root = tensorflow::Scope::NewRootScope();
+
+    Output x_input =
+        ops::Const(root.WithOpName("x_input"), Input::Initializer(x_qtensor));
+    Output x_min =
+        ops::Const(root.WithOpName("x_min"), Input::Initializer(x_min_tensor));
+    Output x_max =
+        ops::Const(root.WithOpName("x_max"), Input::Initializer(x_max_tensor));
+    Output y_input =
+        ops::Const(root.WithOpName("y_input"), Input::Initializer(y_qtensor));
+    Output y_min =
+        ops::Const(root.WithOpName("y_min"), Input::Initializer(y_min_tensor));
+    Output y_max =
+        ops::Const(root.WithOpName("y_max"), Input::Initializer(y_max_tensor));
+    auto& fused_ops = fused_ops_and_tensors.fused_ops;
+    auto& fusion_tensors = fused_ops_and_tensors.fusion_tensors;
+    int num_fusion_inputs = 0;
+    std::vector<NodeDefBuilder::NodeOut> fusion_inputs;
+    bool has_leaky_relu = false;
+    for (int i = 0; i < fused_ops.size(); ++i) {
+      const string& op = fused_ops[i];
+      if (op == "BiasAdd") {
+        Output arg = ops::Const(root.WithOpName(absl::StrCat("arg", i)),
+                                Input::Initializer(fusion_tensors[i]));
+        fusion_inputs.push_back({arg.name(), 0, real_dtype});
+        num_fusion_inputs++;
+      } else if (op == "Add") {
+        ASSERT_EQ(real_dtype, fusion_tensors[i].dtype());
+        Output arg = ops::Const(root.WithOpName(absl::StrCat("arg", i)),
+                                Input::Initializer(fusion_tensors[i]));
+        fusion_inputs.push_back({arg.name(), 0, real_dtype});
+        num_fusion_inputs++;
+      } else if (op == "LeakyRelu") {
+        has_leaky_relu = true;
+      }
+    }
+    NodeDef fused_matmul;
+    std::vector<const NodeDef*> add_nodes;
+    std::vector<Tensor> outputs;
+    std::vector<NodeDefBuilder::NodeOut> inputs;
+    inputs.push_back({"x_input", 0, qinput_dtype});
+    inputs.push_back({"y_input", 0, DT_QINT8});
+    inputs.insert(std::end(inputs), std::begin(fusion_inputs),
+                  std::end(fusion_inputs));
+    inputs.push_back({"x_min", 0, DT_FLOAT});
+    inputs.push_back({"x_max", 0, DT_FLOAT});
+    inputs.push_back({"y_min", 0, DT_FLOAT});
+    inputs.push_back({"y_max", 0, DT_FLOAT});
+    std::vector<string> extended_fused_ops(fused_ops);
+    DataType out_dtype;
+    if (requantize) {
+      if (output_quant_mode == "SCALED") {
+        out_dtype = DT_QINT8;
+      } else {
+        out_dtype = DT_QUINT8;
+      }
+    } else {
+      out_dtype = real_dtype;
+    }
+    std::vector<DataType> output_dtypes;
+    if (requantize) {
+      Output out_min = ops::Const(root.WithOpName("output_min"), output_min);
+      Output out_max = ops::Const(root.WithOpName("output_max"), output_max);
+      inputs.push_back({"output_min", 0, DT_FLOAT});
+      inputs.push_back({"output_max", 0, DT_FLOAT});
+      extended_fused_ops.push_back("Requantize");
+      output_dtypes = {out_dtype, DT_FLOAT, DT_FLOAT};
+    } else {
+      extended_fused_ops.push_back("Dequantize");
+      output_dtypes = {out_dtype};
+    }
+
+    TF_EXPECT_OK(NodeDefBuilder("quantized_fused_matmul", "_QuantizedMatMul")
+                     .Attr("Tdevice_inputs", std::vector<DataType>())
+                     .Input(FakeInput())
+                     .Input(inputs)
+                     .Attr("Thost_outputs", output_dtypes)
+                     .Attr("Tdevice_outputs", std::vector<DataType>())
+                     .Attr("T1", qinput_dtype)
+                     .Attr("T2", DT_QINT8)
+                     .Attr("Tbias", real_dtype)
+                     .Attr("Tout", out_dtype)
+                     .Attr("U", real_dtype)
+                     .Attr("transpose_a", transpose_x)
+                     .Attr("transpose_b", transpose_y)
+                     .Attr("fused_ops", extended_fused_ops)
+                     .Attr("leakyrelu_alpha",
+                           has_leaky_relu ? this->leakyrelu_alpha_ : 0.2f)
+                     .Attr("input_quant_mode", input_quant_mode)
+                     .Attr("output_quant_mode", output_quant_mode)
+                     .Finalize(&fused_matmul));
+    if (requantize) {
+      NodeDef dequantize;
+      TF_EXPECT_OK(NodeDefBuilder("dequantize", "Dequantize")
+                       .Input({"quantized_fused_matmul", 0, out_dtype})
+                       .Input({"quantized_fused_matmul", 1, DT_FLOAT})
+                       .Input({"quantized_fused_matmul", 2, DT_FLOAT})
+                       .Attr("dtype", real_dtype)
+                       .Attr("mode", output_quant_mode)
+                       .Finalize(&dequantize));
+      add_nodes = {&fused_matmul, &dequantize};
+      RunAndFetch(root, {dequantize.name()}, &outputs, add_nodes);
+    } else {
+      add_nodes = {&fused_matmul};
+      RunAndFetch(root, {fused_matmul.name()}, &outputs, add_nodes);
+    }
+    *result = outputs[0];
+  }
+
+  template <typename FusedGraphRunner>
+  void VerifyTensorsNear(const std::vector<int64_t>& x_dims,
+                         const std::vector<int64_t>& y_dims,
+                         const FusedOpsAndDims& fused_ops_and_dims,
+                         const GraphRunner& run_default,
+                         const FusedGraphRunner& run_fused, bool transpose_x,
+                         bool transpose_y, const double atol = 1e-5,
+                         // The following arguments are used by quantized fusion
+                         string input_quant_mode = "SCALED",
+                         string output_quant_mode = "SCALED",
+                         bool is_bias_quantized = false,
+                         bool is_perchannel = false, bool requantize = false) {
+    srand(1234);
+    DataType dtype = DataTypeToEnum<T>::v();
+    TensorShape x_shape = TensorShape(x_dims);
+    TensorShape y_shape = TensorShape(y_dims);
+
+    Tensor x_tensor(dtype, x_shape);
+    x_tensor.flat<T>().setRandom();
+    x_tensor.flat<T>() -= x_tensor.flat<T>().constant(static_cast<T>(0.5));
+
+    Tensor y_tensor(dtype, y_shape);
+    y_tensor.flat<T>().setRandom();
+    y_tensor.flat<T>() -= y_tensor.flat<T>().constant(static_cast<T>(0.5));
+
+    FusedOpsAndTensors fused_ops_and_tensors;
+    fused_ops_and_tensors.fused_ops = fused_ops_and_dims.fused_ops;
+    const auto& fused_ops = fused_ops_and_tensors.fused_ops;   // Alias to field
+    const auto& fusion_dims = fused_ops_and_dims.fusion_dims;  // Alias to field
+    auto& fusion_tensors = fused_ops_and_tensors.fusion_tensors;
+    for (int i = 0; i < fused_ops.size(); ++i) {
+      TensorShape arg_shape = TensorShape(fusion_dims[i]);
+      Tensor arg_tensor(dtype, arg_shape);
+      arg_tensor.flat<T>().setRandom();
+      arg_tensor.flat<T>() -=
+          arg_tensor.flat<T>().constant(static_cast<T>(0.5));
+      fusion_tensors.push_back(arg_tensor);
+    }
+    Tensor default_result;
+    run_default(x_tensor, y_tensor, fused_ops_and_tensors, &default_result,
+                transpose_x, transpose_y);
+
+    Tensor fused_result;
+    if constexpr (std::is_same<FusedGraphRunner, QuantizedGraphRunner>::value) {
+      float output_min = 1.0;
+      float output_max = 1.0 + std::numeric_limits<float>::epsilon();
+      if (requantize) {
+        T min;
+        T max;
+        MklTestingUtil::ComputeMinMax<T>(default_result, &min, &max);
+        output_min = static_cast<float>(min);
+        output_max = static_cast<float>(max);
+      }
+      // Run quantized fusion
+      run_fused(x_tensor, y_tensor, fused_ops_and_tensors, &fused_result,
+                transpose_x, transpose_y, input_quant_mode, output_quant_mode,
+                is_bias_quantized, is_perchannel, requantize, output_min,
+                output_max);
+    } else {
+      // Run realnumber type fusion
+      run_fused(x_tensor, y_tensor, fused_ops_and_tensors, &fused_result,
+                transpose_x, transpose_y);
+    }
+    std::vector<std::pair<Tensor, Tensor>> tensor_pairs = {
+        {default_result, fused_result}};
+    for (auto& pair : tensor_pairs) {
+      const Tensor& expected = pair.first;
+      const Tensor& evaluated = pair.second;
+
+      ASSERT_EQ(expected.dtype(), evaluated.dtype());
+      ASSERT_EQ(expected.shape(), evaluated.shape());
+
+      test::ExpectClose(expected, evaluated, atol);
+    }
+  }
+
+  void GetFusionConfiguration(const std::vector<string>& fused_ops,
+                              const int row, const int col,
+                              FusedOpsAndDims* fused_ops_and_dims) {
+    if (fused_ops == std::vector<string>{"BiasAdd"}) {
+      *fused_ops_and_dims = {fused_ops, {std::vector<int64_t>{col}}};
+    } else if (fused_ops == std::vector<string>{"BiasAdd", "Relu"} ||
+               fused_ops == std::vector<string>{"BiasAdd", "Relu6"} ||
+               fused_ops == std::vector<string>{"BiasAdd", "LeakyRelu"} ||
+               fused_ops == std::vector<string>{"BiasAdd", "Elu"} ||
+               fused_ops == std::vector<string>{"BiasAdd", "Tanh"} ||
+               fused_ops == std::vector<string>{"BiasAdd", "Sigmoid"} ||
+               fused_ops == std::vector<string>{"BiasAdd", "GeluApproximate"}) {
+      *fused_ops_and_dims = {
+          fused_ops, {std::vector<int64_t>{col}, std::vector<int64_t>{0}}};
+    } else if (fused_ops == std::vector<string>{"BiasAdd", "Add"}) {
+      *fused_ops_and_dims = {
+          fused_ops,
+          {std::vector<int64_t>{col}, std::vector<int64_t>{row, col}}};
+    } else {
+      EXPECT_TRUE(false) << absl::StrCat("The fusion: [",
+                                         absl::StrJoin(fused_ops, ","),
+                                         "] is not supported in this test.");
+    }
+  }
+
+  void VerifyFusedMatMul(std::vector<string> fused_ops) {
+    const GraphRunner run_default =
+        [&](const Tensor& x, const Tensor& y,
+            const FusedOpsAndTensors& fused_ops_and_tensors, Tensor* result,
+            bool transpose_x, bool transpose_y) {
+          this->RunMatMulAndFusedOps(x, y, fused_ops_and_tensors, result,
+                                     transpose_x, transpose_y);
+        };
+
+    const GraphRunner run_fused =
+        [&](const Tensor& x, const Tensor& y,
+            const FusedOpsAndTensors& fused_ops_and_tensors, Tensor* result,
+            bool transpose_x, bool transpose_y) {
+          this->RunFusedMatMul(x, y, fused_ops_and_tensors, result, transpose_x,
+                               transpose_y);
+        };
+    const double atol = std::is_same<T, bfloat16>::value ? 1e-2 : 1e-5;
+    constexpr int M = 3;
+    constexpr int K = 4;
+    constexpr int N = 5;
+    bool transpose_x = false;  // OpKernel does not support transpose_x.
+    std::vector<int64_t> x_dims;
+    std::vector<int64_t> y_dims;
+    FusedOpsAndDims fused_ops_and_dims;
+    GetFusionConfiguration(fused_ops, M, N, &fused_ops_and_dims);
+    for (bool transpose_y : {false, true}) {
+      x_dims =
+          transpose_x ? std::vector<int64_t>{K, M} : std::vector<int64_t>{M, K};
+      y_dims =
+          transpose_y ? std::vector<int64_t>{N, K} : std::vector<int64_t>{K, N};
+      VerifyTensorsNear<GraphRunner>(x_dims, y_dims, fused_ops_and_dims,
+                                     run_default, run_fused, transpose_x,
+                                     transpose_y, atol);
+    }
+  }
+
+  // The following test runs with 32 configurations.
+  //    (1) input quantization mode : {"MIN_FIRST", "SCALED"}
+  //    (2) input quantization mode : {"MIN_FIRST", "SCALED"}
+  //    (3) weight quantization per_channel : {false, true}
+  //    (4) output is requantized or dequantized:
+  //        false: dequantized
+  //        true: requantized
+  //    (5) weight matrix is transposed : {false, true}
+  void VerifyQuantizedMatMul(std::vector<string> fused_ops) {
+    if (!HasQuantizationSupport()) {
+      GTEST_SKIP() << "oneDNN based Quantized ops are not enabled on this CPU.";
+    }
+    const GraphRunner run_default =
+        [&](const Tensor& x, const Tensor& y,
+            const FusedOpsAndTensors& fused_ops_and_tensors, Tensor* result,
+            bool transpose_x, bool transpose_y) {
+          this->RunMatMulAndFusedOps(x, y, fused_ops_and_tensors, result,
+                                     transpose_x, transpose_y);
+        };
+
+    const QuantizedGraphRunner run_quantized =
+        [&](const Tensor& x, const Tensor& y,
+            const FusedOpsAndTensors& fused_ops_and_tensors, Tensor* result,
+            bool transpose_x, bool transpose_y, string input_quant_mode,
+            string output_quant_mode, bool is_bias_quantized,
+            bool is_perchannel, bool requantize, float output_min,
+            float output_max) {
+          this->RunQuantizedMatMul(
+              x, y, fused_ops_and_tensors, result, transpose_x, transpose_y,
+              input_quant_mode, output_quant_mode, is_bias_quantized,
+              is_perchannel, requantize, output_min, output_max);
+        };
+
+    const double atol = 1e-2;
+    constexpr int M = 3;
+    constexpr int K = 4;
+    constexpr int N = 5;
+    bool transpose_x = false;  // OpKernel does not support transpose_x.
+    std::vector<int64_t> x_dims;
+    std::vector<int64_t> y_dims;
+    FusedOpsAndDims fused_ops_and_dims;
+    GetFusionConfiguration(fused_ops, M, N, &fused_ops_and_dims);
+    std::vector<bool> requantization_config;
+    if (fused_ops == std::vector<string>{"BiasAdd", "Add"}) {
+      // MatMul + BiasAdd + Add + Requantize fusion is not supported yet.
+      requantization_config = {false};
+    } else {
+      requantization_config = {false, true};
+    }
+    for (bool transpose_y : {false, true}) {
+      x_dims =
+          transpose_x ? std::vector<int64_t>{K, M} : std::vector<int64_t>{M, K};
+      y_dims =
+          transpose_y ? std::vector<int64_t>{N, K} : std::vector<int64_t>{K, N};
+      for (bool per_channel : {false, true}) {
+        for (string input_quant_mode : {"MIN_FIRST", "SCALED"}) {
+          for (string output_quant_mode : {"MIN_FIRST", "SCALED"}) {
+            for (bool requantize : requantization_config) {
+              VerifyTensorsNear<QuantizedGraphRunner>(
+                  x_dims, y_dims, fused_ops_and_dims, run_default,
+                  run_quantized, transpose_x, transpose_y, atol,
+                  input_quant_mode, output_quant_mode, false, per_channel,
+                  requantize);
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+TYPED_TEST_SUITE_P(FusedMatMulOpsTest);
+
+// Realnumber typed test.
+TYPED_TEST_P(FusedMatMulOpsTest, BiasAddGeluApproximate) {
+  this->VerifyFusedMatMul({"BiasAdd", "GeluApproximate"});
+}
+
+// The following tests are for quantized fusions.
+TYPED_TEST_P(FusedMatMulOpsTest, Quantized_BiasAdd) {
+  this->VerifyQuantizedMatMul({"BiasAdd"});
+}
+
+TYPED_TEST_P(FusedMatMulOpsTest, Quantized_BiasAddRelu) {
+  this->VerifyQuantizedMatMul({"BiasAdd", "Relu"});
+}
+
+TYPED_TEST_P(FusedMatMulOpsTest, Quantized_BiasAddRelu6) {
+  this->VerifyQuantizedMatMul({"BiasAdd", "Relu6"});
+}
+
+TYPED_TEST_P(FusedMatMulOpsTest, Quantized_BiasAddLeakyRelu) {
+  this->VerifyQuantizedMatMul({"BiasAdd", "LeakyRelu"});
+}
+
+TYPED_TEST_P(FusedMatMulOpsTest, Quantized_BiasAddElu) {
+  this->VerifyQuantizedMatMul({"BiasAdd", "Elu"});
+}
+
+TYPED_TEST_P(FusedMatMulOpsTest, Quantized_BiasAddTanh) {
+  this->VerifyQuantizedMatMul({"BiasAdd", "Tanh"});
+}
+
+TYPED_TEST_P(FusedMatMulOpsTest, Quantized_BiasAddSigmoid) {
+  this->VerifyQuantizedMatMul({"BiasAdd", "Sigmoid"});
+}
+
+TYPED_TEST_P(FusedMatMulOpsTest, Quantized_BiasAddGeluApproximate) {
+  this->VerifyQuantizedMatMul({"BiasAdd", "GeluApproximate"});
+}
+
+TYPED_TEST_P(FusedMatMulOpsTest, Quantized_BiasAddAdd) {
+  this->VerifyQuantizedMatMul({"BiasAdd", "Add"});
+}
+
+REGISTER_TYPED_TEST_SUITE_P(FusedMatMulOpsTest, BiasAddGeluApproximate,
+                            Quantized_BiasAdd, Quantized_BiasAddRelu,
+                            Quantized_BiasAddRelu6, Quantized_BiasAddLeakyRelu,
+                            Quantized_BiasAddElu, Quantized_BiasAddTanh,
+                            Quantized_BiasAddSigmoid,
+                            Quantized_BiasAddGeluApproximate,
+                            Quantized_BiasAddAdd);
+
+// TODO(intel-tf): Add bfloat16 to Types when PR#56613 is merged.
+using DataTypes = ::testing::Types<float>;
+
+INSTANTIATE_TYPED_TEST_SUITE_P(Test, FusedMatMulOpsTest, DataTypes);
+
+}  // namespace tensorflow
+
+#endif  // INTEL_MKL

--- a/tensorflow/core/kernels/mkl/onednn_fused_matmul_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/onednn_fused_matmul_ops_test.cc
@@ -491,7 +491,6 @@ class FusedMatMulOpsTest : public OpsTestBase {
                          string output_quant_mode = "SCALED",
                          bool is_bias_quantized = false,
                          bool is_perchannel = false, bool requantize = false) {
-    srand(1234);
     DataType dtype = DataTypeToEnum<T>::v();
     TensorShape x_shape = TensorShape(x_dims);
     TensorShape y_shape = TensorShape(y_dims);
@@ -532,13 +531,13 @@ class FusedMatMulOpsTest : public OpsTestBase {
         output_min = static_cast<float>(min);
         output_max = static_cast<float>(max);
       }
-      // Run quantized fusion
+      // Run quantized fusion.
       run_fused(x_tensor, y_tensor, fused_ops_and_tensors, &fused_result,
                 transpose_x, transpose_y, input_quant_mode, output_quant_mode,
                 is_bias_quantized, is_perchannel, requantize, output_min,
                 output_max);
     } else {
-      // Run realnumber type fusion
+      // Run realnumber type fusion.
       run_fused(x_tensor, y_tensor, fused_ops_and_tensors, &fused_result,
                 transpose_x, transpose_y);
     }

--- a/tensorflow/core/ops/mkl_nn_ops.cc
+++ b/tensorflow/core/ops/mkl_nn_ops.cc
@@ -1937,6 +1937,46 @@ operation.
 expected to invoke these operators.
 )doc");
 
+REGISTER_OP("_QuantizedMatMul")
+    // Variable number of inputs depending on fusion. The inputs contain
+    // quantized or real tensors. Some of the inputs carry min-max values for
+    // quantized tensors.
+    .Input("device_inputs: Tdevice_inputs")
+    .Input("host_inputs: Thost_inputs")
+    // Variable number of outputs depending on the main output type. For
+    // example, quantized output will need additional tensors to carry min-max
+    // values. If the output type is real tensor (e.g. Dequantize fusion), the
+    // op should produce only single output tensor.
+    .Output("device_outputs: Tdevice_outputs")
+    .Output("host_outputs: Thost_outputs")
+    .Attr("Tdevice_inputs: list(type) >= 0 = []")
+    .Attr("Thost_inputs: list(type) >= 0 = []")
+    .Attr("Tdevice_outputs: list(type) >= 0 = []")
+    .Attr("Thost_outputs: list(type) >= 0 = []")
+    // The following attributes T1, T2, U, and Tout are members of Tinputs
+    // and Toutputs, used here for type constraints in the templatized OpKernel
+    // registrations.
+    .Attr("T1: quantizedtype")  // 0-th input    
+    .Attr("T2: quantizedtype")  // 1st input
+    .Attr("Tbias: {bfloat16, float, quantizedtype} = DT_FLOAT")
+    // Additional inputs' type. Currently, restricting all to be of same type.
+    .Attr("U: {bfloat16, float, quantizedtype} = DT_FLOAT")
+    .Attr("Tout: {bfloat16, float, quantizedtype} = DT_FLOAT")  // 0-th output  
+    .Attr("transpose_a: bool = false")
+    .Attr("transpose_b: bool = false")
+    .Attr("is_weight_const: bool = true")
+    .Attr("is_bias_const: bool = true")
+    .Attr("fused_ops: list(string) = []")
+    // Attribute for quantization mode of all quantized input tensors.
+    // Currently restricting all operands using same quantization mode.
+    .Attr("input_quant_mode: {'MIN_FIRST', 'SCALED'} = 'SCALED'")
+    // Attribute for activation (0-th output) requnatization mode
+    .Attr("output_quant_mode: {'MIN_FIRST', 'SCALED'} = 'SCALED'")
+    // Attributes for the LeakyRelu ----------------------------------------- //
+    .Attr("leakyrelu_alpha: float = 0.2")
+    // ---------------------------------------------------------------------- //
+    .SetShapeFn(shape_inference::MatMulShape);
+
 }  // namespace tensorflow
 
 #endif  // INTEL_MKL


### PR DESCRIPTION
_Reopened the closed PR https://github.com/tensorflow/tensorflow/pull/56792_

This PR introduces new API for quantized MatMul fusions. All fusions are implemented as single op _QuantizedMatMul with fused_ops attribute. This PR contains a number of features:

Weights can be quantized per-tensor or per-channel
MatMul + BiasAdd + Activation, where activation function can be any of {Relu, Relu6, LeakyRelu, Elu, Tanh, Sigmoid, GeluApproximate, GeluExact}
MatMul + BiasAdd + Add + Dequantize (when Add has same shape as the output of MatMul)
All fusions can have Dequantize as additional fusion.
All fusions can have Requantize as additional fusion, except the MatMul + BiasAdd + Add fusion.
When Dequantize is fused output can be float32
B matrix can be transposed.