### PR TITLE
shlo_ref add `convolution` op

### DIFF
--- a/tensorflow/lite/experimental/shlo/ops/BUILD
+++ b/tensorflow/lite/experimental/shlo/ops/BUILD
@@ -1061,3 +1061,33 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_library(
+    name = "convolution",
+    srcs = ["convolution.cc"],
+    hdrs = ["convolution.h","convolution_helper_functions.h"],
+    deps = [
+        ":unary_elementwise",
+        ":util",
+        "//tensorflow/lite/experimental/shlo:dispatch",
+        "//tensorflow/lite/experimental/shlo:tensor",
+        ":dot_general",
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_test(
+    name = "convolution_test",
+    srcs = ["convolution_test.cc"],
+    linkopts = shlo_ref_linkopts(),
+    deps = [
+        ":convolution",
+        ":test_util",
+        "//tensorflow/lite/experimental/shlo:quantize",
+        "//tensorflow/lite/experimental/shlo:quantized_tensor_element_type",
+        "//tensorflow/lite/experimental/shlo:shape",
+        "//tensorflow/lite/experimental/shlo:status_matcher",
+        "//tensorflow/lite/experimental/shlo:tensor",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/tensorflow/lite/experimental/shlo/ops/convolution.cc
+++ b/tensorflow/lite/experimental/shlo/ops/convolution.cc
@@ -1,0 +1,462 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/experimental/shlo/ops/convolution.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <set>
+#include <string>
+#include <type_traits>
+
+#include "absl/status/status.h"
+#include "tensorflow/lite/experimental/shlo/dispatch.h"
+#include "tensorflow/lite/experimental/shlo/ops/convolution_helper_functions.h"
+#include "tensorflow/lite/experimental/shlo/ops/dot_general.h"
+#include "tensorflow/lite/experimental/shlo/ops/unary_elementwise.h"
+#include "tensorflow/lite/experimental/shlo/ops/util.h"
+#include "tensorflow/lite/experimental/shlo/tensor.h"
+
+namespace shlo_ref {
+
+template <DataType storage_type>
+absl::Status PrepareImpl(ConvolutionOp& op, const Tensor& lhs,
+                         const Tensor& rhs, Tensor& output) {
+  using StorageT = StorageType<storage_type>;
+  const int64_t* padding_buffer =
+      op.attributes.padding.GetDataAs<DataType::kSI64>();
+
+  // Constraints Check
+  if (op.attributes.precision_configs.size() != 2) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: Size of precision_config "
+        "must be two.");
+  }
+  Axis rank = lhs.Rank();
+  if (lhs.Rank() != rhs.Rank()) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: rank(lhs) == rank(rhs)");
+  }
+  if (output.Rank() != lhs.Rank()) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: rank(output) == "
+        "lhs.Rank()");
+  }
+  if (!lhs.IsQuantized()) {
+    SHLO_REF_RETURN_ON_ERROR(
+        CheckSameBaselineType(CheckCtx("Convolution"), lhs, rhs));
+    SHLO_REF_RETURN_ON_ERROR(
+        CheckSameBaselineType(CheckCtx("Convolution"), lhs, output));
+  }
+  if (op.attributes.window_strides.size() != rank - 2) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: size(window_stride) = "
+        "rank - 2");
+  }
+  if (!IsGreaterThanZero(op.attributes.window_strides)) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: 0 < window_stride");
+  }
+  if (op.attributes.padding.shape().Dim(0) != rank - 2 ||
+      op.attributes.padding.shape().Dim(1) != 2) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: shape(padding) = [rank - "
+        "2, 2]");
+  }
+  if (op.attributes.lhs_dilation.size() != rank - 2) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: shape(lhs_dilation) == "
+        "rank - 2");
+  }
+  if (!IsGreaterThanZero(op.attributes.lhs_dilation)) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: 0 < lhs_dilation");
+  }
+  if (op.attributes.rhs_dilation.size() != rank - 2) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: shape(rhs_dilation) == "
+        "rank - 2");
+  }
+  if (!IsGreaterThanZero(op.attributes.rhs_dilation)) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: 0 < rhs_dilation");
+  }
+  if (lhs.shape().Dim(static_cast<Axis>(op.attributes.input_batch_dimension)) %
+          op.attributes.batch_group_count !=
+      0) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "Dim(lhs,input_batch_dimension) % batch_group_count = 0");
+  }
+  if (lhs.shape().Dim(
+          static_cast<Axis>(op.attributes.input_feature_dimension)) %
+          op.attributes.feature_group_count !=
+      0) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "Dim(lhs,input_feature_dimension) % (feature_group_count) = 0");
+  }
+  if (op.attributes.input_spatial_dimensions.size() != rank - 2) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "size(input_spatial_dimensions) = rank - 2");
+  }
+  if (!IsUnique(op.attributes.input_batch_dimension,
+                op.attributes.input_feature_dimension,
+                op.attributes.input_spatial_dimensions)) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "isUnique(input_dimensions)");
+  }
+  if (!IsInRange(op.attributes.input_batch_dimension,
+                 op.attributes.input_feature_dimension,
+                 op.attributes.input_spatial_dimensions, rank)) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: 0 <= input_dimensions < "
+        "rank");
+  }
+  if (rhs.shape().Dim(
+          static_cast<Axis>(op.attributes.kernel_input_feature_dimension)) !=
+      lhs.shape().Dim(
+          static_cast<Axis>(op.attributes.input_feature_dimension)) /
+          op.attributes.feature_group_count) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "Dim(rhs,kernel_input_feature_dimension) = "
+        "Dim(lhs,input_feature_dimension) / feature_group_count");
+  }
+  if (rhs.shape().Dim(
+          static_cast<Axis>(op.attributes.kernel_output_feature_dimension)) %
+          op.attributes.batch_group_count !=
+      0) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "Dim(rhs,kernel_output_feature_dimension) % batch_group_count = 0");
+  }
+  if (rhs.shape().Dim(
+          static_cast<Axis>(op.attributes.kernel_output_feature_dimension)) %
+          op.attributes.feature_group_count !=
+      0) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "Dim(rhs,kernel_output_feature_dimension) % (feature_group_count) = 0");
+  }
+  if (op.attributes.kernel_spatial_dimensions.size() != rank - 2) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "size(kernel_spatial_dimensions) = rank - 2");
+  }
+  if (!IsUnique(op.attributes.kernel_output_feature_dimension,
+                op.attributes.kernel_input_feature_dimension,
+                op.attributes.kernel_spatial_dimensions)) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "isUnique(kernel_dimensions)");
+  }
+  if (!IsInRange(op.attributes.kernel_output_feature_dimension,
+                 op.attributes.kernel_input_feature_dimension,
+                 op.attributes.kernel_spatial_dimensions, rank)) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: 0<= kernel_dimensions < "
+        "rank");
+  }
+  if (op.attributes.output_spatial_dimensions.size() != rank - 2) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "size(output_spatial_dimensions) = rank - 2");
+  }
+  if (!IsUnique(op.attributes.output_batch_dimension,
+                op.attributes.output_feature_dimension,
+                op.attributes.output_spatial_dimensions)) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "isUnique(output_dimensions)");
+  }
+  if (!IsInRange(op.attributes.output_batch_dimension,
+                 op.attributes.output_feature_dimension,
+                 op.attributes.output_spatial_dimensions, rank)) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: 0 <= output_dimensions < "
+        "rank");
+  }
+  if (op.attributes.feature_group_count <= 0) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: 0 < feature_group_count");
+  }
+  if (op.attributes.batch_group_count <= 0) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: 0 < batch_group_count");
+  }
+  if (op.attributes.batch_group_count != 1 &&
+      op.attributes.feature_group_count != 1) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: batch_group_count == 1 or "
+        "feature_group_count "
+        "== 1");
+  }
+  if (output.shape().Dim(
+          static_cast<Axis>(op.attributes.output_batch_dimension)) !=
+      lhs.shape().Dim(static_cast<Axis>(op.attributes.input_batch_dimension)) /
+          op.attributes.batch_group_count) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "output.shape().Dim(output_batch_dimension) == "
+        "lhs.shape().Dim(input_batch_dimension) / batch_group_count");
+  }
+  if (output.shape().Dim(
+          static_cast<Axis>(op.attributes.output_feature_dimension)) !=
+      rhs.shape().Dim(
+          static_cast<Axis>(op.attributes.kernel_output_feature_dimension))) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "output.shape().Dim(output_feature_dimension) == "
+        "rhs.shape().Dim(kernel_output_feature_dimension)");
+  }
+  if (!CheckOutputSpatial(op, lhs, rhs, output)) {
+    return absl::FailedPreconditionError(
+        "stablehlo.convolution constraint violation: "
+        "output.shape().Dim(spatial_dim) is not "
+        "properly set");
+  }
+  if (lhs.IsQuantized() || rhs.IsQuantized() || output.IsQuantized()) {
+    if (!(lhs.IsQuantized() && rhs.IsQuantized() && output.IsQuantized())) {
+      return absl::FailedPreconditionError(
+          "stablehlo.convolution constraint violation: lhs.IsQuantized() && "
+          "rhs.IsQuantized() && "
+          "output.IsQuantized()");
+    }
+    if (rhs.IsPerTensorQuantized()) {
+      if (!(output.IsPerTensorQuantized())) {
+        return absl::FailedPreconditionError(
+            "stablehlo.convolution constraint violation: If "
+            "is_per_tensor_quantized(rhs), then "
+            "is_per_tensor_quantized(output)");
+      }
+    }
+    if (rhs.IsPerAxisQuantized()) {
+      if (rhs.quantized_per_axis_element_type().QuantizedDimension() !=
+          op.attributes.kernel_output_feature_dimension) {
+        return absl::FailedPreconditionError(
+            "stablehlo.convolution constraint violation:  If "
+            "is_per_axis_quantized(rhs), then "
+            "quantization_dimension(rhs) = "
+            "op.attributes.kernel_output_feature_dimension");
+      }
+    }
+    if (output.IsPerAxisQuantized()) {
+      if (output.quantized_per_axis_element_type().QuantizedDimension() !=
+          op.attributes.output_feature_dimension) {
+        return absl::FailedPreconditionError(
+            "stablehlo.convolution constraint violation:  If "
+            "is_per_axis_quantized(output), then "
+            "quantization_dimension(output) = "
+            "op.attributes.output_feature_dimension");
+      }
+    }
+  }
+
+  // DotGeneral prepare
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> dims(rhs.Rank(), 0);
+  size_t rhs_tensor_size = 1;
+  dims[0] = 1;
+  for (size_t i = 1; i < rhs.Rank(); ++i) {
+    dims[i] = rhs.shape().Dim(i);
+    rhs_tensor_size *= rhs.shape().Dim(i);
+  }
+  const Shape rhs_dot_general_shape(dims);
+  op.rhs_dot_general_data =
+      std::vector<std::byte>(rhs_tensor_size * sizeof(StorageT));
+  Tensor rhs_dot_general{.type = TensorType{.shape = rhs_dot_general_shape,
+                                            .element_type = storage_type},
+                         .data = op.rhs_dot_general_data.data()};
+
+  op.lhs_dot_general_data =
+      std::vector<std::byte>(rhs_tensor_size * sizeof(StorageT));
+  Tensor lhs_dot_general{.type = TensorType{.shape = rhs_dot_general_shape,
+                                            .element_type = storage_type},
+                         .data = op.lhs_dot_general_data.data()};
+
+  absl::InlinedVector<Axis, kMaxNumDimensions>
+      lhs_contracting_dimensions_values(lhs.Rank() - 1);
+  for (size_t i = 0; i < lhs.Rank() - 1; ++i) {
+    lhs_contracting_dimensions_values[i] = i + 1;
+  }
+  absl::Span<Axis> lhs_contracting_dimensions(
+      lhs_contracting_dimensions_values);
+
+  absl::InlinedVector<Axis, kMaxNumDimensions>
+      rhs_contracting_dimensions_values(rhs.Rank() - 1);
+  for (size_t i = 0; i < rhs.Rank() - 1; ++i) {
+    rhs_contracting_dimensions_values[i] = i + 1;
+  }
+  absl::Span<Axis> rhs_contracting_dimensions(
+      rhs_contracting_dimensions_values);
+
+  std::vector<StorageT> dot_general_output_values(1);
+  dot_general_output_values[0] = 0;
+  op.output_dot_general_data = std::vector<std::byte>(
+      reinterpret_cast<std::byte*>(dot_general_output_values.data()),
+      reinterpret_cast<std::byte*>(dot_general_output_values.data() +
+                                   dot_general_output_values.size()));
+  const Shape dot_general_output_shape{{1}};
+  Tensor output_dot_general{
+      .type = TensorType{.shape = dot_general_output_shape,
+                         .element_type = storage_type},
+      .data = op.output_dot_general_data.data()};
+
+  absl::Span<Axis> lhs_batching_dimensions;
+  absl::Span<Axis> rhs_batching_dimensions;
+
+  const size_t lhs_rank = lhs.Rank();
+  const size_t rhs_rank = rhs.Rank();
+
+  op.lhs_result_dims = CalculateResultDimensions(
+      lhs_rank, lhs_batching_dimensions, lhs_contracting_dimensions);
+  op.rhs_result_dims = CalculateResultDimensions(
+      rhs_rank, rhs_batching_dimensions, rhs_contracting_dimensions);
+  // Dot general prepare end
+
+  op.lhs_dot_general = std::move(lhs_dot_general);
+  op.rhs_dot_general = std::move(rhs_dot_general);
+  op.output_dot_general = std::move(output_dot_general);
+  op.lhs_contracting_dimensions = std::move(lhs_contracting_dimensions_values);
+  op.rhs_contracting_dimensions = std::move(rhs_contracting_dimensions_values);
+
+  return absl::OkStatus();
+}
+
+// Convolution
+template <DataType storage_type>
+absl::Status ConvolutionImpl(ConvolutionOp& op, size_t& output_channel,
+                             const Tensor& lhs, const Tensor& rhs,
+                             Tensor& output) {
+  using StorageT = StorageType<storage_type>;
+  using int64_t = StorageType<DataType::kSI64>;
+  const StorageT* lhs_buffer = lhs.GetDataAs<storage_type>();
+  const StorageT* rhs_buffer = rhs.GetDataAs<storage_type>();
+  StorageT* output_buffer = output.GetDataAs<storage_type>();
+
+  size_t rhs_tensor_size = 1;
+  size_t rhs_spacial_size = 1;
+  size_t output_spacial_size = 1;
+  for (size_t i = 1; i < rhs.Rank(); ++i) {
+    rhs_tensor_size *= rhs.shape().Dim(i);
+    if (i > 1) {
+      output_spacial_size *= output.shape().Dim(i);
+      rhs_spacial_size *= rhs.shape().Dim(i);
+    }
+  }
+
+  Tensor lhs_slice = op.lhs_dot_general;
+  Tensor rhs_slice = op.rhs_dot_general;
+  Tensor dot_general_output = op.output_dot_general;
+
+  StorageT* lhs_slice_pointer = lhs_slice.GetDataAs<storage_type>();
+  StorageT* rhs_slice_pointer = rhs_slice.GetDataAs<storage_type>();
+
+  for (size_t i = 0; i < lhs.shape().Dim(0); ++i) {
+    for (size_t j = 0; j < output_spacial_size; ++j) {
+      int64_t output_dims[output.Rank()];
+      size_t output_depth = 1;
+      for (size_t m = output.Rank() - 1; m > 1; --m) {
+        output_dims[m] = (j / output_depth) % output.shape().Dim(m);
+        output_depth *= output.shape().Dim(m);
+      }
+      for (size_t k = 0; k < lhs.shape().Dim(1); ++k) {
+        for (size_t l = 0; l < rhs_spacial_size; ++l) {
+          int64_t filter_spacials[rhs.Rank() - 2];
+          size_t depth = 1;
+          for (size_t m = rhs.Rank() - 1; m > 1; --m) {
+            filter_spacials[m - 2] = (l / depth) % rhs.shape().Dim(m);
+            depth *= rhs.shape().Dim(m);
+          }
+
+          int64_t lhs_dims[lhs.Rank()];
+          lhs_dims[0] = i;
+          lhs_dims[1] = k;
+          depth = 1;
+          size_t lhs_index = 0;
+          for (int64_t m = lhs.Rank() - 1; m >= 0; --m) {
+            if (m > 1)
+              lhs_dims[m] =
+                  output_dims[m] * op.attributes.window_strides[m - 2] +
+                  filter_spacials[m - 2] * op.attributes.rhs_dilation[m - 2];
+            lhs_index += lhs_dims[m] * depth;
+            depth *= lhs.shape().Dim(m);
+          }
+
+          l += k * rhs_spacial_size;
+          lhs_slice_pointer[l] = lhs_buffer[lhs_index];
+          l -= k * rhs_spacial_size;
+        }
+      }
+      for (size_t k = 0; k < rhs.shape().Dim(0); ++k) {
+        size_t batch_skip = k * rhs_tensor_size;
+        std::copy(rhs_buffer + batch_skip,
+                  rhs_buffer + batch_skip + rhs_tensor_size, rhs_slice_pointer);
+
+        absl::Span<Axis> lhs_batching_span;
+        absl::Span<Axis> rhs_batching_span;
+        absl::Span<Axis> lhs_contracting_span(op.lhs_contracting_dimensions);
+        absl::Span<Axis> rhs_contracting_span(op.rhs_contracting_dimensions);
+        absl::Status state = DotGeneralImpl<storage_type>(
+            op, lhs_slice, rhs_slice, lhs_batching_span, rhs_batching_span,
+            lhs_contracting_span, rhs_contracting_span, dot_general_output);
+
+        StorageT* dor_general_output_buffer =
+            dot_general_output.GetDataAs<storage_type>();
+
+        output_dims[0] = i;
+        output_dims[1] = output_channel + k;
+        output_depth = 1;
+        size_t output_index = 0;
+        for (int64_t m = output.Rank() - 1; m >= 0; --m) {
+          output_index += output_dims[m] * output_depth;
+          output_depth *= output.shape().Dim(m);
+        }
+        output_buffer[output_index] = dor_general_output_buffer[0];
+      }
+    }
+  }
+  output_channel += rhs.shape().Dim(0);
+
+  return absl::OkStatus();
+}
+
+template <DataType storage_type>
+absl::Status EvaluateImpl(ConvolutionOp& op, const Tensor& lhs,
+                          const Tensor& rhs, Tensor& output) {
+  size_t output_channel = 0;
+  absl::Status status =
+      ConvolutionImpl<storage_type>(op, output_channel, lhs, rhs, output);
+  return absl::OkStatus();
+}
+
+ConvolutionOp Create(const ConvolutionOp::Attributes& attributes) {
+  return {.attributes = attributes};
+}
+
+absl::Status Prepare(ConvolutionOp& op, const Tensor& lhs, const Tensor& rhs,
+                     Tensor& output) {
+  DISPATCH_INT_FLOAT(PrepareImpl, lhs.StorageType(), op, lhs, rhs, output);
+  return absl::OkStatus();
+}
+
+absl::Status Evaluate(ConvolutionOp& op, const Tensor& lhs, const Tensor& rhs,
+                      Tensor& output) {
+  DISPATCH_INT_FLOAT(EvaluateImpl, output.tensor_element_type(), op, lhs, rhs,
+                     output);
+}
+}  // namespace shlo_ref

--- a/tensorflow/lite/experimental/shlo/ops/convolution.h
+++ b/tensorflow/lite/experimental/shlo/ops/convolution.h
@@ -1,0 +1,79 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_SHLO_OPS_CONVOLUTION_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_SHLO_OPS_CONVOLUTION_H_
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <type_traits>
+
+#include "absl/algorithm/container.h"
+#include "absl/status/status.h"
+#include "absl/types/span.h"
+#include "tensorflow/lite/experimental/shlo/data_type.h"
+#include "tensorflow/lite/experimental/shlo/dispatch.h"
+#include "tensorflow/lite/experimental/shlo/ops/dot_general.h"
+#include "tensorflow/lite/experimental/shlo/ops/util.h"
+#include "tensorflow/lite/experimental/shlo/quantize.h"
+#include "tensorflow/lite/experimental/shlo/quantized_tensor_element_type.h"
+#include "tensorflow/lite/experimental/shlo/shape.h"
+#include "tensorflow/lite/experimental/shlo/tensor.h"
+
+namespace shlo_ref {
+
+class ConvolutionOp {
+ public:
+  struct Attributes {
+    absl::Span<int64_t> window_strides;
+    Tensor padding;
+    absl::Span<int64_t> lhs_dilation;
+    absl::Span<int64_t> rhs_dilation;
+    int64_t input_batch_dimension;
+    int64_t input_feature_dimension;
+    absl::Span<int64_t> input_spatial_dimensions;
+    int64_t kernel_input_feature_dimension;
+    int64_t kernel_output_feature_dimension;
+    absl::Span<int64_t> kernel_spatial_dimensions;
+    int64_t output_batch_dimension;
+    int64_t output_feature_dimension;
+    absl::Span<int64_t> output_spatial_dimensions;
+    int64_t feature_group_count;
+    int64_t batch_group_count;
+    std::array<PrecisionTypes, 2> precision_configs;
+  };
+  Attributes attributes;
+  Tensor lhs_dot_general;
+  Tensor rhs_dot_general;
+  Tensor output_dot_general;
+  std::vector<std::byte> lhs_dot_general_data;
+  std::vector<std::byte> rhs_dot_general_data;
+  std::vector<std::byte> output_dot_general_data;
+  absl::InlinedVector<Axis, kMaxNumDimensions> lhs_contracting_dimensions;
+  absl::InlinedVector<Axis, kMaxNumDimensions> rhs_contracting_dimensions;
+  absl::InlinedVector<Axis, kMaxNumDimensions> lhs_result_dims;
+  absl::InlinedVector<Axis, kMaxNumDimensions> rhs_result_dims;
+};
+
+ConvolutionOp Create(const ConvolutionOp::Attributes& attributes);
+absl::Status Prepare(ConvolutionOp& op, const Tensor& lhs, const Tensor& rhs,
+                     Tensor& output);
+absl::Status Evaluate(ConvolutionOp& op, const Tensor& lhs, const Tensor& rhs,
+                      Tensor& output);
+
+}  // namespace shlo_ref
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_SHLO_OPS_CONVOLUTION_H_

--- a/tensorflow/lite/experimental/shlo/ops/convolution_helper_functions.h
+++ b/tensorflow/lite/experimental/shlo/ops/convolution_helper_functions.h
@@ -1,0 +1,248 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_SHLO_OPS_CONVOLUTION_HELPER_FUNCTIONS_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_SHLO_OPS_CONVOLUTION_HELPER_FUNCTIONS_H_
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <type_traits>
+
+#include "absl/algorithm/container.h"
+#include "absl/status/status.h"
+#include "absl/types/span.h"
+#include "tensorflow/lite/experimental/shlo/data_type.h"
+#include "tensorflow/lite/experimental/shlo/dispatch.h"
+#include "tensorflow/lite/experimental/shlo/ops/dot_general.h"
+#include "tensorflow/lite/experimental/shlo/ops/util.h"
+#include "tensorflow/lite/experimental/shlo/quantize.h"
+#include "tensorflow/lite/experimental/shlo/quantized_tensor_element_type.h"
+#include "tensorflow/lite/experimental/shlo/shape.h"
+#include "tensorflow/lite/experimental/shlo/tensor.h"
+
+namespace shlo_ref {
+
+bool IsUnique(const int64_t& batch_dimension, const int64_t& feature_dimension,
+              absl::Span<const int64_t> operand) {
+  std::unordered_set<int64_t> seen_elements;
+  if (!seen_elements.insert(batch_dimension).second) {
+    return false;
+  }
+  if (!seen_elements.insert(feature_dimension).second) {
+    return false;
+  }
+  for (int64_t element : operand) {
+    if (!seen_elements.insert(element).second) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IsInRange(const int64_t& batch_dimension, const int64_t& feature_dimension,
+               absl::Span<const int64_t> operand, size_t N) {
+  auto is_in_range = [N](int64_t v) { return v >= 0 && v < N; };
+  if (!is_in_range(batch_dimension) || !is_in_range(feature_dimension)) {
+    return false;
+  }
+  return absl::c_all_of(operand, is_in_range);
+}
+
+bool IsGreaterThanZero(absl::Span<const int64_t> operand) {
+  return absl::c_all_of(operand, [](int64_t x) { return x > 0; });
+}
+
+bool CheckOutputSpatial(ConvolutionOp& op, const Tensor& lhs, const Tensor& rhs,
+                        const Tensor& output) {
+  const int64_t* padding_buffer =
+      op.attributes.padding.GetDataAs<DataType::kSI64>();
+  for (size_t i = 0; i < output.Rank() - 2; ++i) {
+    int64_t lhs_dim = lhs.shape().Dim(
+        static_cast<Axis>(op.attributes.input_spatial_dimensions[i]));
+    int64_t rhs_dim = rhs.shape().Dim(
+        static_cast<Axis>(op.attributes.kernel_spatial_dimensions[i]));
+    int64_t lhs_dilation = op.attributes.lhs_dilation[i];
+    int64_t rhs_dilation = op.attributes.rhs_dilation[i];
+    int64_t window_stride = op.attributes.window_strides[i];
+
+    int64_t dilated_lhs_shape =
+        (lhs_dim == 0) ? 0 : (lhs_dim - 1) * lhs_dilation + 1;
+    int64_t padded_lhs_shape =
+        dilated_lhs_shape + padding_buffer[2 * i] + padding_buffer[2 * i + 1];
+    int64_t dilated_rhs_shape =
+        (rhs_dim == 0) ? 0 : (rhs_dim - 1) * rhs_dilation + 1;
+
+    bool is_empty_window =
+        (padded_lhs_shape == 0 || dilated_rhs_shape > padded_lhs_shape);
+    int64_t expected_output_shape =
+        is_empty_window ? 0
+                        : std::floor((padded_lhs_shape - dilated_rhs_shape) /
+                                     window_stride) +
+                              1;
+
+    if (output.shape().Dim(
+            static_cast<Axis>(op.attributes.output_spatial_dimensions[i])) !=
+        expected_output_shape) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool ContainsDimension(absl::Span<const Axis> dimensions, Axis dimension) {
+  return std::find(dimensions.begin(), dimensions.end(), dimension) !=
+         dimensions.end();
+}
+
+absl::InlinedVector<Axis, kMaxNumDimensions> CalculateResultDimensions(
+    size_t rank, absl::Span<const Axis> batching_dimensions,
+    absl::Span<const Axis> contracting_dimensions) {
+  absl::InlinedVector<Axis, kMaxNumDimensions> result_dims;
+  for (size_t i = 0; i < rank; ++i) {
+    if (!ContainsDimension(batching_dimensions, i) &&
+        !ContainsDimension(contracting_dimensions, i)) {
+      result_dims.push_back(i);
+    }
+  }
+  return result_dims;
+}
+
+void GenerateIndices(size_t index,
+                     absl::InlinedVector<Axis, kMaxNumDimensions>& output_index,
+                     const Tensor& output, size_t output_rank) {
+  size_t divisor = 1, dim = 0;
+  for (size_t i = 0, j = output_rank - 1; i < output_rank; ++i, --j) {
+    dim = output.shape().Dim(j);
+    output_index[j] = (index / divisor) % dim;
+    divisor *= dim;
+  }
+  return;
+}
+
+bool IncrementIndices(const Tensor& lhs,
+                      absl::InlinedVector<Axis, kMaxNumDimensions>& lhs_index,
+                      absl::InlinedVector<Axis, kMaxNumDimensions>& rhs_index,
+                      absl::Span<const Axis> lhs_contracting_dimensions,
+                      absl::Span<const Axis> rhs_contracting_dimensions,
+                      const size_t lhsc_size) {
+  if (lhsc_size == 0) return false;
+  for (size_t i = lhsc_size - 1; i >= 0; --i) {
+    lhs_index[lhs_contracting_dimensions[i]]++;
+    rhs_index[rhs_contracting_dimensions[i]]++;
+    if (lhs_index[lhs_contracting_dimensions[i]] <
+        lhs.shape().Dim(lhs_contracting_dimensions[i]))
+      return true;
+    if (i == 0) return false;
+    lhs_index[lhs_contracting_dimensions[i]] = 0;
+    rhs_index[rhs_contracting_dimensions[i]] = 0;
+  }
+  return true;
+}
+
+// DotGeneral op implementation
+template <DataType storage_type>
+absl::Status DotGeneralImpl(ConvolutionOp& op, const Tensor& lhs,
+                            const Tensor& rhs,
+                            absl::Span<const Axis> lhs_batching_dimensions,
+                            absl::Span<const Axis> rhs_batching_dimensions,
+                            absl::Span<const Axis> lhs_contracting_dimensions,
+                            absl::Span<const Axis> rhs_contracting_dimensions,
+                            Tensor& output) {
+  using StorageT = StorageType<storage_type>;
+
+  const StorageT* lhs_data = lhs.GetDataAs<storage_type>();
+  const StorageT* rhs_data = rhs.GetDataAs<storage_type>();
+  StorageT* output_data = output.GetDataAs<storage_type>();
+  const DimensionSize lhs_size = lhs.NumElements();
+  const DimensionSize rhs_size = rhs.NumElements();
+  const DimensionSize output_size = output.NumElements();
+  const size_t lhs_rank = lhs.Rank();
+  const size_t rhs_rank = rhs.Rank();
+  const size_t output_rank = output.Rank();
+  const size_t lhsb_size = lhs_batching_dimensions.size();
+  const size_t rhsb_size = rhs_batching_dimensions.size();
+  const size_t lhsc_size = lhs_contracting_dimensions.size();
+  const size_t rhsc_size = rhs_contracting_dimensions.size();
+
+  absl::InlinedVector<Axis, kMaxNumDimensions> lhs_index;
+  lhs_index.resize(lhs_rank);
+  absl::InlinedVector<Axis, kMaxNumDimensions> rhs_index;
+  rhs_index.resize(rhs_rank);
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> lhs_index_helper;
+  lhs_index_helper.resize(lhs_rank);
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> rhs_index_helper;
+  rhs_index_helper.resize(rhs_rank);
+  absl::InlinedVector<Axis, kMaxNumDimensions> output_index;
+  output_index.resize(output_rank);
+
+  DimensionSize lhs_dim_accumulator = 1, rhs_dim_accumulator = 1;
+  for (size_t i = 0; i < lhs_rank; ++i) {
+    lhs_dim_accumulator *= lhs.shape().Dim(i);
+    lhs_index_helper[i] = lhs_size / lhs_dim_accumulator;
+  }
+  for (size_t i = 0; i < rhs_rank; ++i) {
+    rhs_dim_accumulator *= rhs.shape().Dim(i);
+    rhs_index_helper[i] = rhs_size / rhs_dim_accumulator;
+  }
+
+  StorageT output_element(0);
+  DimensionSize lhs_element_index = 0, rhs_element_index = 0;
+  for (size_t k = 0; k < output_size; ++k, ++output_data) {
+    GenerateIndices(k, output_index, output, output_rank);
+    absl::c_fill(lhs_index, 0);
+    absl::c_fill(rhs_index, 0);
+
+    DimensionSize result_dim = 0;
+    for (size_t i = 0; i < lhsb_size; ++i, ++result_dim) {
+      lhs_index[lhs_batching_dimensions[i]] = output_index[result_dim];
+      rhs_index[rhs_batching_dimensions[i]] = output_index[result_dim];
+    }
+    for (size_t i = 0; i < op.lhs_result_dims.size(); ++i, ++result_dim) {
+      lhs_index[op.lhs_result_dims[i]] = output_index[result_dim];
+    }
+    for (size_t i = 0; i < op.rhs_result_dims.size(); ++i, ++result_dim) {
+      if (result_dim < output.Rank()) {
+        rhs_index[op.rhs_result_dims[i]] = output_index[result_dim];
+      }
+    }
+    output_element = 0;
+    while (true) {
+      lhs_element_index = 0;
+      rhs_element_index = 0;
+      for (size_t i = 0; i < lhs_rank; ++i) {
+        lhs_element_index += lhs_index[i] * lhs_index_helper[i];
+      }
+      for (size_t i = 0; i < rhs_rank; ++i) {
+        rhs_element_index += rhs_index[i] * rhs_index_helper[i];
+      }
+      output_element +=
+          lhs_data[lhs_element_index] * rhs_data[rhs_element_index];
+
+      if (!IncrementIndices(lhs, lhs_index, rhs_index,
+                            lhs_contracting_dimensions,
+                            rhs_contracting_dimensions, lhsc_size)) {
+        break;
+      }
+    }
+    *output_data = output_element;
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace shlo_ref
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_SHLO_CONVOLUTION_HELPER_FUNCTIONS_H_

--- a/tensorflow/lite/experimental/shlo/ops/convolution_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/convolution_test.cc
@@ -1,0 +1,389 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/experimental/shlo/ops/convolution.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "absl/status/status.h"
+#include "tensorflow/lite/experimental/shlo/bf16.h"
+#include "tensorflow/lite/experimental/shlo/data_type.h"
+#include "tensorflow/lite/experimental/shlo/f16.h"
+#include "tensorflow/lite/experimental/shlo/ops/test_util.h"
+#include "tensorflow/lite/experimental/shlo/quantize.h"
+#include "tensorflow/lite/experimental/shlo/quantized_tensor_element_type.h"
+#include "tensorflow/lite/experimental/shlo/shape.h"
+#include "tensorflow/lite/experimental/shlo/status_matcher.h"
+#include "tensorflow/lite/experimental/shlo/tensor.h"
+
+using shlo_ref::testing::StatusIs;
+using testing::Eq;
+using testing::FloatEq;
+using testing::Pointwise;
+
+namespace shlo_ref {
+namespace {
+using kBF16TestTypes = ::testing::Types<TestParam<DataType::kBF16>>;
+using kF16TestTypes = ::testing::Types<TestParam<DataType::kF16>>;
+using kF32TestTypes = ::testing::Types<TestParam<DataType::kF32>>;
+
+template <class T>
+struct NonQuantizedkF32ConvolutionTest : ::testing::Test {};
+
+TYPED_TEST_SUITE(NonQuantizedkF32ConvolutionTest, kF32TestTypes,
+                 TestParamNames);
+TYPED_TEST(NonQuantizedkF32ConvolutionTest, kF32TestTypesTensorsWork) {
+  using StorageT = typename TypeParam::StorageT;
+
+  const Shape shape_lhs({1, 1, 2, 2});
+  const Shape shape_rhs({1, 1, 1, 1});
+  const Shape shape_padding({2, 2});
+  const Shape shape_parametrs({2});
+  const Shape shape_result({1, 1, 2, 2});
+
+  Vector<float> lhs_data_float{1.16, 2.43, 3.81, 4.77};
+  Vector<StorageT> lhs_data(lhs_data_float.begin(), lhs_data_float.end());
+  Vector<float> rhs_data_float{2.21};
+  Vector<StorageT> rhs_data(rhs_data_float.begin(), rhs_data_float.end());
+  Vector<StorageT> output_data(shape_result.NumElements());
+  Vector<int64_t> window_stride_values({1, 1});
+  Vector<int64_t> padding_values({0, 0, 0, 0});
+  Vector<int64_t> lhs_dilation_values({1, 1});
+  Vector<int64_t> rhs_dilation_values({1, 1});
+  int64_t input_batch_dimension = 0;
+  int64_t input_feature_dimension = 1;
+  Vector<int64_t> input_spatial_dimensions_values({2, 3});
+  int64_t kernel_input_feature_dimension = 1;
+  int64_t kernel_output_feature_dimension = 0;
+  Vector<int64_t> kernel_spatial_dimensions_values({2, 3});
+  int64_t output_batch_dimension = 0;
+  int64_t output_feature_dimension = 1;
+  Vector<int64_t> output_spatial_dimensions_values({2, 3});
+  int64_t feature_group_count = 1;
+  int64_t batch_group_count = 1;
+
+  Tensor lhs{.type = TensorType{.shape = shape_lhs,
+                                .element_type = TypeParam::kStorage},
+             .data = lhs_data.data()};
+  Tensor rhs{.type = TensorType{.shape = shape_rhs,
+                                .element_type = TypeParam::kStorage},
+             .data = rhs_data.data()};
+  absl::Span<int64_t> window_stride(window_stride_values);
+  Tensor padding{.type = TensorType{.shape = shape_padding,
+                                    .element_type = DataType::kSI64},
+                 .data = padding_values.data()};
+  absl::Span<int64_t> lhs_dilation(lhs_dilation_values);
+  absl::Span<int64_t> rhs_dilation(rhs_dilation_values);
+  absl::Span<int64_t> input_spatial_dimensions(input_spatial_dimensions_values);
+  absl::Span<int64_t> kernel_spatial_dimensions(
+      kernel_spatial_dimensions_values);
+  absl::Span<int64_t> output_spatial_dimensions(
+      output_spatial_dimensions_values);
+  Tensor output_tensor{.type = TensorType{.shape = shape_result,
+                                          .element_type = TypeParam::kStorage},
+                       .data = output_data.data()};
+
+  std::array<PrecisionTypes, 2> precision_configs = {PrecisionTypes::DEFAULT,
+                                                     PrecisionTypes::DEFAULT};
+
+  auto op = Create(ConvolutionOp::Attributes{
+      .window_strides = window_stride,
+      .padding = padding,
+      .lhs_dilation = lhs_dilation,
+      .rhs_dilation = rhs_dilation,
+      .input_batch_dimension = input_batch_dimension,
+      .input_feature_dimension = input_feature_dimension,
+      .input_spatial_dimensions = input_spatial_dimensions,
+      .kernel_input_feature_dimension = kernel_input_feature_dimension,
+      .kernel_output_feature_dimension = kernel_output_feature_dimension,
+      .kernel_spatial_dimensions = kernel_spatial_dimensions,
+      .output_batch_dimension = output_batch_dimension,
+      .output_feature_dimension = output_feature_dimension,
+      .output_spatial_dimensions = output_spatial_dimensions,
+      .feature_group_count = feature_group_count,
+      .batch_group_count = batch_group_count,
+      .precision_configs = precision_configs});
+
+  Vector<StorageT> expected_data;
+  Vector<float> expected_data_float = {2.5636, 5.3703, 8.4201, 10.5417};
+  expected_data.assign(expected_data_float.begin(), expected_data_float.end());
+
+  ASSERT_OK(Prepare(op, lhs, rhs, output_tensor));
+  ASSERT_OK(Evaluate(op, lhs, rhs, output_tensor));
+  EXPECT_THAT(output_data, Pointwise(FloatEq(), expected_data));
+}
+
+template <class T>
+struct NonQuantizedkBF16ConvolutionTest : ::testing::Test {};
+
+TYPED_TEST_SUITE(NonQuantizedkBF16ConvolutionTest, kBF16TestTypes,
+                 TestParamNames);
+TYPED_TEST(NonQuantizedkBF16ConvolutionTest, kBF16TestTypesTensorsWork) {
+  using StorageT = typename TypeParam::StorageT;
+
+  const Shape shape_lhs({1, 1, 2, 2});
+  const Shape shape_rhs({1, 1, 1, 1});
+  const Shape shape_padding({2, 2});
+  const Shape shape_parametrs({2});
+  const Shape shape_result({1, 1, 2, 2});
+
+  Vector<float> lhs_data_float{1.16, 2.43, 3.81, 4.77};
+  Vector<StorageT> lhs_data(lhs_data_float.begin(), lhs_data_float.end());
+  Vector<float> rhs_data_float{2.21};
+  Vector<StorageT> rhs_data(rhs_data_float.begin(), rhs_data_float.end());
+  Vector<StorageT> output_data(shape_result.NumElements());
+  Vector<int64_t> window_stride_values({1, 1});
+  Vector<int64_t> padding_values({0, 0, 0, 0});
+  Vector<int64_t> lhs_dilation_values({1, 1});
+  Vector<int64_t> rhs_dilation_values({1, 1});
+  int64_t input_batch_dimension = 0;
+  int64_t input_feature_dimension = 1;
+  Vector<int64_t> input_spatial_dimensions_values({2, 3});
+  int64_t kernel_input_feature_dimension = 1;
+  int64_t kernel_output_feature_dimension = 0;
+  Vector<int64_t> kernel_spatial_dimensions_values({2, 3});
+  int64_t output_batch_dimension = 0;
+  int64_t output_feature_dimension = 1;
+  Vector<int64_t> output_spatial_dimensions_values({2, 3});
+  int64_t feature_group_count = 1;
+  int64_t batch_group_count = 1;
+
+  Tensor lhs{.type = TensorType{.shape = shape_lhs,
+                                .element_type = TypeParam::kStorage},
+             .data = lhs_data.data()};
+  Tensor rhs{.type = TensorType{.shape = shape_rhs,
+                                .element_type = TypeParam::kStorage},
+             .data = rhs_data.data()};
+  absl::Span<int64_t> window_stride(window_stride_values);
+  Tensor padding{.type = TensorType{.shape = shape_padding,
+                                    .element_type = DataType::kSI64},
+                 .data = padding_values.data()};
+  absl::Span<int64_t> lhs_dilation(lhs_dilation_values);
+  absl::Span<int64_t> rhs_dilation(rhs_dilation_values);
+  absl::Span<int64_t> input_spatial_dimensions(input_spatial_dimensions_values);
+  absl::Span<int64_t> kernel_spatial_dimensions(
+      kernel_spatial_dimensions_values);
+  absl::Span<int64_t> output_spatial_dimensions(
+      output_spatial_dimensions_values);
+  Tensor output_tensor{.type = TensorType{.shape = shape_result,
+                                          .element_type = TypeParam::kStorage},
+                       .data = output_data.data()};
+
+  std::array<PrecisionTypes, 2> precision_configs = {PrecisionTypes::DEFAULT,
+                                                     PrecisionTypes::DEFAULT};
+
+  auto op = Create(ConvolutionOp::Attributes{
+      .window_strides = window_stride,
+      .padding = padding,
+      .lhs_dilation = lhs_dilation,
+      .rhs_dilation = rhs_dilation,
+      .input_batch_dimension = input_batch_dimension,
+      .input_feature_dimension = input_feature_dimension,
+      .input_spatial_dimensions = input_spatial_dimensions,
+      .kernel_input_feature_dimension = kernel_input_feature_dimension,
+      .kernel_output_feature_dimension = kernel_output_feature_dimension,
+      .kernel_spatial_dimensions = kernel_spatial_dimensions,
+      .output_batch_dimension = output_batch_dimension,
+      .output_feature_dimension = output_feature_dimension,
+      .output_spatial_dimensions = output_spatial_dimensions,
+      .feature_group_count = feature_group_count,
+      .batch_group_count = batch_group_count,
+      .precision_configs = precision_configs});
+
+  Vector<StorageT> expected_data;
+  Vector<float> expected_data_float = {2.54688, 5.375, 8.375, 10.5625};
+  expected_data.assign(expected_data_float.begin(), expected_data_float.end());
+
+  ASSERT_OK(Prepare(op, lhs, rhs, output_tensor));
+  ASSERT_OK(Evaluate(op, lhs, rhs, output_tensor));
+  EXPECT_THAT(output_data, Pointwise(FloatEq(), expected_data));
+}
+
+template <class T>
+struct NonQuantizedkF16ConvolutionTest : ::testing::Test {};
+
+TYPED_TEST_SUITE(NonQuantizedkF16ConvolutionTest, kF16TestTypes,
+                 TestParamNames);
+TYPED_TEST(NonQuantizedkF16ConvolutionTest, kF16TestTypesTensorsWork) {
+  using StorageT = typename TypeParam::StorageT;
+
+  const Shape shape_lhs({1, 1, 2, 2});
+  const Shape shape_rhs({1, 1, 1, 1});
+  const Shape shape_padding({2, 2});
+  const Shape shape_parametrs({2});
+  const Shape shape_result({1, 1, 2, 2});
+
+  Vector<float> lhs_data_float{1.16, 2.43, 3.81, 4.77};
+  Vector<StorageT> lhs_data(lhs_data_float.begin(), lhs_data_float.end());
+  Vector<float> rhs_data_float{2.21};
+  Vector<StorageT> rhs_data(rhs_data_float.begin(), rhs_data_float.end());
+  Vector<StorageT> output_data(shape_result.NumElements());
+  Vector<int64_t> window_stride_values({1, 1});
+  Vector<int64_t> padding_values({0, 0, 0, 0});
+  Vector<int64_t> lhs_dilation_values({1, 1});
+  Vector<int64_t> rhs_dilation_values({1, 1});
+  int64_t input_batch_dimension = 0;
+  int64_t input_feature_dimension = 1;
+  Vector<int64_t> input_spatial_dimensions_values({2, 3});
+  int64_t kernel_input_feature_dimension = 1;
+  int64_t kernel_output_feature_dimension = 0;
+  Vector<int64_t> kernel_spatial_dimensions_values({2, 3});
+  int64_t output_batch_dimension = 0;
+  int64_t output_feature_dimension = 1;
+  Vector<int64_t> output_spatial_dimensions_values({2, 3});
+  int64_t feature_group_count = 1;
+  int64_t batch_group_count = 1;
+
+  Tensor lhs{.type = TensorType{.shape = shape_lhs,
+                                .element_type = TypeParam::kStorage},
+             .data = lhs_data.data()};
+  Tensor rhs{.type = TensorType{.shape = shape_rhs,
+                                .element_type = TypeParam::kStorage},
+             .data = rhs_data.data()};
+  absl::Span<int64_t> window_stride(window_stride_values);
+  Tensor padding{.type = TensorType{.shape = shape_padding,
+                                    .element_type = DataType::kSI64},
+                 .data = padding_values.data()};
+  absl::Span<int64_t> lhs_dilation(lhs_dilation_values);
+  absl::Span<int64_t> rhs_dilation(rhs_dilation_values);
+  absl::Span<int64_t> input_spatial_dimensions(input_spatial_dimensions_values);
+  absl::Span<int64_t> kernel_spatial_dimensions(
+      kernel_spatial_dimensions_values);
+  absl::Span<int64_t> output_spatial_dimensions(
+      output_spatial_dimensions_values);
+  Tensor output_tensor{.type = TensorType{.shape = shape_result,
+                                          .element_type = TypeParam::kStorage},
+                       .data = output_data.data()};
+
+  std::array<PrecisionTypes, 2> precision_configs = {PrecisionTypes::DEFAULT,
+                                                     PrecisionTypes::DEFAULT};
+
+  auto op = Create(ConvolutionOp::Attributes{
+      .window_strides = window_stride,
+      .padding = padding,
+      .lhs_dilation = lhs_dilation,
+      .rhs_dilation = rhs_dilation,
+      .input_batch_dimension = input_batch_dimension,
+      .input_feature_dimension = input_feature_dimension,
+      .input_spatial_dimensions = input_spatial_dimensions,
+      .kernel_input_feature_dimension = kernel_input_feature_dimension,
+      .kernel_output_feature_dimension = kernel_output_feature_dimension,
+      .kernel_spatial_dimensions = kernel_spatial_dimensions,
+      .output_batch_dimension = output_batch_dimension,
+      .output_feature_dimension = output_feature_dimension,
+      .output_spatial_dimensions = output_spatial_dimensions,
+      .feature_group_count = feature_group_count,
+      .batch_group_count = batch_group_count,
+      .precision_configs = precision_configs});
+
+  Vector<StorageT> expected_data;
+  Vector<float> expected_data_float = {2.56445, 5.37109, 8.42188, 10.5469};
+  expected_data.assign(expected_data_float.begin(), expected_data_float.end());
+
+  ASSERT_OK(Prepare(op, lhs, rhs, output_tensor));
+  ASSERT_OK(Evaluate(op, lhs, rhs, output_tensor));
+  EXPECT_THAT(output_data, Pointwise(FloatEq(), expected_data));
+}
+
+template <class T>
+struct NonQuantizedIntConvolutionTest : ::testing::Test {};
+
+TYPED_TEST_SUITE(NonQuantizedIntConvolutionTest, IntTestTypes, TestParamNames);
+TYPED_TEST(NonQuantizedIntConvolutionTest, IntTestTypesTensorsWork1) {
+  using StorageT = typename TypeParam::StorageT;
+
+  const Shape shape_lhs({1, 1, 10});
+  const Shape shape_rhs({1, 1, 1});
+  const Shape shape_padding({1, 2});
+  const Shape shape_parametrs({1});
+  const Shape shape_result({1, 1, 10});
+
+  Vector<int64_t> lhs_data_int{1, 2, 3, 4, 5, 6, 7, 9, 4, 2};
+  Vector<StorageT> lhs_data(lhs_data_int.begin(), lhs_data_int.end());
+  Vector<int64_t> rhs_data_int{5};
+  Vector<StorageT> rhs_data(rhs_data_int.begin(), rhs_data_int.end());
+  Vector<StorageT> output_data(shape_result.NumElements());
+  Vector<int64_t> window_stride_values({1});
+  Vector<int64_t> padding_values({0, 0});
+  Vector<int64_t> lhs_dilation_values({1});
+  Vector<int64_t> rhs_dilation_values({1});
+  int64_t input_batch_dimension = 0;
+  int64_t input_feature_dimension = 1;
+  Vector<int64_t> input_spatial_dimensions_values({2});
+  int64_t kernel_input_feature_dimension = 1;
+  int64_t kernel_output_feature_dimension = 0;
+  Vector<int64_t> kernel_spatial_dimensions_values({2});
+  int64_t output_batch_dimension = 0;
+  int64_t output_feature_dimension = 1;
+  Vector<int64_t> output_spatial_dimensions_values({2});
+  int64_t feature_group_count = 1;
+  int64_t batch_group_count = 1;
+
+  Tensor lhs{.type = TensorType{.shape = shape_lhs,
+                                .element_type = TypeParam::kStorage},
+             .data = lhs_data.data()};
+  Tensor rhs{.type = TensorType{.shape = shape_rhs,
+                                .element_type = TypeParam::kStorage},
+             .data = rhs_data.data()};
+  absl::Span<int64_t> window_stride(window_stride_values);
+  Tensor padding{.type = TensorType{.shape = shape_padding,
+                                    .element_type = DataType::kSI64},
+                 .data = padding_values.data()};
+  absl::Span<int64_t> lhs_dilation(lhs_dilation_values);
+  absl::Span<int64_t> rhs_dilation(rhs_dilation_values);
+  absl::Span<int64_t> input_spatial_dimensions(input_spatial_dimensions_values);
+  absl::Span<int64_t> kernel_spatial_dimensions(
+      kernel_spatial_dimensions_values);
+  absl::Span<int64_t> output_spatial_dimensions(
+      output_spatial_dimensions_values);
+  Tensor output_tensor{.type = TensorType{.shape = shape_result,
+                                          .element_type = TypeParam::kStorage},
+                       .data = output_data.data()};
+
+  std::array<PrecisionTypes, 2> precision_configs = {PrecisionTypes::DEFAULT,
+                                                     PrecisionTypes::DEFAULT};
+
+  auto op = Create(ConvolutionOp::Attributes{
+      .window_strides = window_stride,
+      .padding = padding,
+      .lhs_dilation = lhs_dilation,
+      .rhs_dilation = rhs_dilation,
+      .input_batch_dimension = input_batch_dimension,
+      .input_feature_dimension = input_feature_dimension,
+      .input_spatial_dimensions = input_spatial_dimensions,
+      .kernel_input_feature_dimension = kernel_input_feature_dimension,
+      .kernel_output_feature_dimension = kernel_output_feature_dimension,
+      .kernel_spatial_dimensions = kernel_spatial_dimensions,
+      .output_batch_dimension = output_batch_dimension,
+      .output_feature_dimension = output_feature_dimension,
+      .output_spatial_dimensions = output_spatial_dimensions,
+      .feature_group_count = feature_group_count,
+      .batch_group_count = batch_group_count,
+      .precision_configs = precision_configs});
+
+  Vector<int64_t> expected_data_int{5, 10, 15, 20, 25, 30, 35, 45, 20, 10};
+  Vector<StorageT> expected_data(expected_data_int.begin(),
+                                 expected_data_int.end());
+
+  ASSERT_OK(Prepare(op, lhs, rhs, output_tensor));
+  ASSERT_OK(Evaluate(op, lhs, rhs, output_tensor));
+  EXPECT_THAT(output_data, Pointwise(Eq(), expected_data));
+}
+
+}  // namespace
+}  // namespace shlo_ref


### PR DESCRIPTION
- Adds initial version of convolution op
- Adds unit tests for convolution op


CC: @rascani  @qukhan 