### PR TITLE
Include CheckCXXSymbolExists when FLATBUFFERS_LOCALE_INDEPENDENT=0

### DIFF
--- a/tensorflow/lite/tools/cmake/modules/flatbuffers.cmake
+++ b/tensorflow/lite/tools/cmake/modules/flatbuffers.cmake
@@ -34,6 +34,10 @@ if(NOT flatbuffers_POPULATED)
   OverridableFetchContent_Populate(flatbuffers)
 endif()
 
+if(DEFINED FLATBUFFERS_LOCALE_INDEPENDENT AND FLATBUFFERS_LOCALE_INDEPENDENT EQUAL 0)
+  include(CheckCXXSymbolExists)
+endif()
+
 option(FLATBUFFERS_BUILD_TESTS OFF)
 # Required for Windows, since it has macros called min & max which
 # clashes with std::min


### PR DESCRIPTION
When using the Arm NN Tensorflow Delegate or Arm NN TfLite parser an abort is caused by the destruction of flatbuffers::ClassicLocale::~ClassicLocale() before the Arm NN ExecuteNetwork process exits. 

Setting FLATBUFFERS_LOCALE_INDEPENDENT=0 allows ClassicLocale to be compiled out. however it requires CheckCXXSymbolExists to be included.