### PR TITLE
Fix a bug in AsyncAllocator memory pools access setting.

### DIFF
--- a/third_party/xla/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.cc
+++ b/third_party/xla/xla/stream_executor/gpu/gpu_cudamallocasync_allocator.cc
@@ -241,6 +241,15 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
   static auto* all_ids_ = new std::vector<tsl::PlatformDeviceId>();
   if (!create_new_pool_) {
     DCHECK(all_pools_->size() == all_ids_->size());
+    for (auto& pool_item_ : *all_pools_) {
+      if (*pool_item_ == pool_) {
+        VLOG(2) << Name()
+                << " GpuCudaMallocAsyncAllocator pool already initialized. "
+                   "PoolSize "
+                << pool_size;
+        return;
+      }
+    }
     for (int i = 0; i < all_pools_->size(); ++i) {
       // Set the current pool access to the previous GPUs.
       CUmemAccessDesc map;
@@ -273,10 +282,11 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
       // Set the previous pools access to the current GPU.
       map.location.id = platform_device_id.value();
 
-      VLOG(2) << "Set access to the pool id: " << i
+      VLOG(2) << "Set access to the pool id: " << (*all_ids_)[i].value()
               << " location id: " << map.location.id;
-      if (auto status = cuDeviceCanAccessPeer(&canAccessPeer, i,
-                                              platform_device_id.value())) {
+      if (auto status =
+              cuDeviceCanAccessPeer(&canAccessPeer, (*all_ids_)[i].value(),
+                                    platform_device_id.value())) {
         pool_ = nullptr;
         LOG(FATAL)  // Crash OK.
             << "cuDeviceCanAccessPeer failed: " << GetCudaErrorMessage(status);
@@ -285,8 +295,8 @@ GpuCudaMallocAsyncAllocator::GpuCudaMallocAsyncAllocator(
         if (auto status = cuMemPoolSetAccess(*(*all_pools_)[i], &map, 1)) {
           pool_ = nullptr;
           LOG(FATAL)  // Crash OK.
-              << "Error when setting access to the pool id: " << i
-              << " location id: " << map.location.id
+              << "Error when setting access to the pool id: "
+              << (*all_ids_)[i].value() << " location id: " << map.location.id
               << " error: " << GetCudaErrorMessage(status);
         }
       }


### PR DESCRIPTION
The original code uses the wrong parameter `i` for `cuDeviceCanAccessPeer()`, which can cause undefined behavior when `(*all_ids_)[i] != platform_device_id`, for example, virtual devices are used. Should use `(*all_ids_)[i].value()` to represent the previous pool id.

Also, add a judgment to skip the pool initialization process if it's already initialized previously. This can happen in some cases, such as when multiple virtual devices are created from one physical GPU, the virtual devices will actually share the same CUDA memory pool.