### PR TITLE
Change kMaxDims value to TFLITE_STABLEHLO_PAD_PARAMS_MAX_DIMENSION_COUNT to avoid buffer size mismatch in tensorflow/lite/kernels/stablehlo_pad.cc

### DIFF
--- a/tensorflow/lite/kernels/stablehlo_pad.cc
+++ b/tensorflow/lite/kernels/stablehlo_pad.cc
@@ -33,7 +33,7 @@ namespace builtin {
 namespace stablehlo_pad {
 namespace {
 
-static constexpr int kMaxDims = 6;
+static constexpr int kMaxDims = TFLITE_STABLEHLO_PAD_PARAMS_MAX_DIMENSION_COUNT;
 
 // Fills a buffer with the given data.
 //


### PR DESCRIPTION
The bug was found by Svace static analyzer:
1. `kMaxDims` is assigned 6 on https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/kernels/stablehlo_pad.cc#L36
2. Arrays `edge_pad_low_`, `edge_pad_high_` and `interior_pad_` of `kMaxDims` uint64_t elements are used later as destinations in `memcpy` operations (https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/kernels/stablehlo_pad.cc#L99-L107) with size operand that equals `TFLITE_STABLEHLO_PAD_PARAMS_MAX_DIMENSION_COUNT * sizeof(uint64_t)`. It may lead to a buffer overflow.

Closes  #66834
cc @mihaimaruseac 