### PR TITLE
Recreate iterator on the end of epoch instead of at begininng

### DIFF
--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1195,9 +1195,9 @@ class DataHandler(object):
       for epoch in range(self._initial_epoch, self._epochs):
         if self._insufficient_data:  # Set by `catch_stop_iteration`.
           break
+        yield epoch, data_iterator
         if self._adapter.should_recreate_iterator():
           data_iterator = iter(self._dataset)
-        yield epoch, data_iterator
         self._adapter.on_epoch_end()
 
   @contextlib.contextmanager


### PR DESCRIPTION
We already create a data_iterator at the beginning. No point to recreate it again at the beginning of epoch.
This should fix issue like [this](https://stackoverflow.com/questions/69843184/using-sagemaker-pipe-mode-with-an-s3-directory-of-tfrecords/77532311#77532311)
Also will improve cool start time when use data that have slow initialization and do prefetch or buffering at init. 