### PR TITLE
[tosa] Fix lowering of tf/tfl expand_dims for negative dim

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
@@ -714,7 +714,7 @@ func.func @test_expand_dims(%arg0: tensor<13x21x3xf32>) -> tensor<1x13x21x3xf32>
 // -----
 
 // CHECK-LABEL: test_expand_dims_negative_index
-// CHECK-DAG: %[[SHAPE:.*]] = tosa.const_shape  {value = dense<[13, 1, 21, 3]> : tensor<4xindex>}
+// CHECK-DAG: %[[SHAPE:.*]] = tosa.const_shape  {value = dense<[13, 21, 1, 3]> : tensor<4xindex>}
 // CHECK: %[[VAR0:.*]] = tosa.reshape %arg0, %[[SHAPE]]
 func.func @test_expand_dims_negative_index(%arg0: tensor<13x21x3xf32>) -> tensor<13x1x21x3xf32> {
   %2 = "tf.Const"()  {value = dense<-2> : tensor<1xi32>}  : () -> tensor<1xi32>

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1484,6 +1484,61 @@ func.func @test_expand_dims(%arg0: tensor<13x21x3xf32>) -> tensor<*xf32> {
 
 // -----
 
+// CHECK-LABEL: test_expand_dims_minus_1
+// CHECK-DAG: %[[SHAPE:.*]] = tosa.const_shape {value = dense<[13, 21, 3, 1]> : tensor<4xindex>}
+// CHECK: %[[VAR0:.*]] = tosa.reshape %arg0, %[[SHAPE]]
+func.func @test_expand_dims_minus_1(%arg0: tensor<13x21x3xf32>) -> tensor<?x?x?x?xf32> {
+  %cst = "tfl.pseudo_const"() {value = dense<-1> : tensor<i32>} : () -> tensor<i32>
+  %0 = "tfl.expand_dims"(%arg0, %cst) : (tensor<13x21x3xf32>, tensor<i32>) -> tensor<?x?x?x?xf32>
+  func.return %0 : tensor<?x?x?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_expand_dims_minus_2
+// CHECK-DAG: %[[SHAPE:.*]] = tosa.const_shape {value = dense<[13, 21, 1, 3]> : tensor<4xindex>}
+// CHECK: %[[VAR0:.*]] = tosa.reshape %arg0, %[[SHAPE]]
+func.func @test_expand_dims_minus_2(%arg0: tensor<13x21x3xf32>) -> tensor<?x?x?x?xf32> {
+  %cst = "tfl.pseudo_const"() {value = dense<-2> : tensor<i32>} : () -> tensor<i32>
+  %0 = "tfl.expand_dims"(%arg0, %cst) : (tensor<13x21x3xf32>, tensor<i32>) -> tensor<?x?x?x?xf32>
+  func.return %0 : tensor<?x?x?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_expand_dims_0
+// CHECK-DAG: %[[SHAPE:.*]] = tosa.const_shape {value = dense<[1, 13, 21, 3]> : tensor<4xindex>}
+// CHECK: %[[VAR0:.*]] = tosa.reshape %arg0, %[[SHAPE]]
+func.func @test_expand_dims_0(%arg0: tensor<13x21x3xf32>) -> tensor<?x?x?x?xf32> {
+  %cst = "tfl.pseudo_const"() {value = dense<0> : tensor<i32>} : () -> tensor<i32>
+  %0 = "tfl.expand_dims"(%arg0, %cst) : (tensor<13x21x3xf32>, tensor<i32>) -> tensor<?x?x?x?xf32>
+  func.return %0 : tensor<?x?x?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_expand_dims_2
+// CHECK-DAG: %[[SHAPE:.*]] = tosa.const_shape {value = dense<[13, 21, 1, 3]> : tensor<4xindex>}
+// CHECK: %[[VAR0:.*]] = tosa.reshape %arg0, %[[SHAPE]]
+func.func @test_expand_dims_2(%arg0: tensor<13x21x3xf32>) -> tensor<?x?x?x?xf32> {
+  %cst = "tfl.pseudo_const"() {value = dense<2> : tensor<i32>} : () -> tensor<i32>
+  %0 = "tfl.expand_dims"(%arg0, %cst) : (tensor<13x21x3xf32>, tensor<i32>) -> tensor<?x?x?x?xf32>
+  func.return %0 : tensor<?x?x?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_expand_dims_size
+// CHECK-DAG: %[[SHAPE:.*]] = tosa.const_shape {value = dense<[13, 21, 3, 1]> : tensor<4xindex>}
+// CHECK: %[[VAR0:.*]] = tosa.reshape %arg0, %[[SHAPE]]
+func.func @test_expand_dims_size(%arg0: tensor<13x21x3xf32>) -> tensor<?x?x?x?xf32> {
+  %cst = "tfl.pseudo_const"() {value = dense<3> : tensor<i32>} : () -> tensor<i32>
+  %0 = "tfl.expand_dims"(%arg0, %cst) : (tensor<13x21x3xf32>, tensor<i32>) -> tensor<?x?x?x?xf32>
+  func.return %0 : tensor<?x?x?x?xf32>
+}
+
+// -----
+
 // CHECK-LABEL: test_shape
 // CHECK: %[[VAR0:.*]] = "tosa.const"() <{value = dense<[13, 21, 3]> : tensor<3xi32>}>
 func.func @test_shape() -> tensor<3xi32> {


### PR DESCRIPTION
This fixes lowering of tf/tfl expand_dims to tosa, for negative dim values such that dim=-1 means adding
 inner most dimension