### PR TITLE
Layout optimizer and transposing scalars

### DIFF
--- a/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
+++ b/tensorflow/core/grappler/optimizers/generic_layout_optimizer_transposer.h
@@ -581,6 +581,9 @@ Status PermuteSingle(absl::string_view location,
                      absl::Span<const int> permutation, T* values) {
   DCHECK(values != nullptr);
   int permutation_size = permutation.size();
+  if (values->size() <= 1 || permutation_size <= 1) {
+    return absl::OkStatus();
+  }
   if (values->size() != permutation_size) {
     return Status(absl::StatusCode::kInvalidArgument,
                   absl::StrCat("Size of values ", values->size(),


### PR DESCRIPTION
Running this tutorial https://www.tensorflow.org/tutorials/images/classification, I am observing a run-time error:
```E tensorflow/core/grappler/optimizers/meta_optimizer.cc:961] layout failed: INVALID_ARGUMENT: Size of values 0 does not match size of permutation 4 @ fanin shape inStatefulPartitionedCall/sequential_2_1/dropout_1/stateless_dropout/SelectV2-2-TransposeNHWCToNCHW-LayoutOptimizer```

The error occurs because grappler's layout optimizer encounters this code
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/nn_ops.py#L5809
```
    zero_tensor = constant_op.constant(0, dtype=x_dtype)
    ret = array_ops.where_v2(keep_mask, ret, zero_tensor)
```

where keep_mask and ret are both rank 4, but zero_tensor is rank 0. Since this is a legal input for array_ops.where_v2, the fault lies in the layout optimizer. Supplied fix preventsit from flagging an error when it needs to propagate a transpose to a scalar input.