### PR TITLE
[Multiple Stream Groups] Add multi-stream device_name_utils.

### DIFF
--- a/tensorflow/compiler/jit/variable_info_util.cc
+++ b/tensorflow/compiler/jit/variable_info_util.cc
@@ -58,7 +58,8 @@ Status GetVariableInfosFromInputs(ResourceMgr* rm, DeviceBase* dev,
                                      " to GetVariableInfosFromInputs.");
     }
     ResourceHandle handle = inputs[var_idx]->flat<ResourceHandle>()(0);
-    if (handle.device() != dev->attributes().name()) {
+    if (!DeviceNameUtils::HaveSameDeviceName(handle.device(),
+                                             dev->attributes().name())) {
       std::string definition_location =
           DefinitionLocationMsg(handle.definition_stack_trace());
       return errors::InvalidArgument(

--- a/tensorflow/core/common_runtime/optimize_function_graph_utils.cc
+++ b/tensorflow/core/common_runtime/optimize_function_graph_utils.cc
@@ -315,7 +315,8 @@ Status PinArgsAndRets(const std::vector<string>& input_devices,
     const AttrValue* attr_value;
     TF_RETURN_IF_ERROR(node->attrs().Find("index", &attr_value));
     int64_t index = attr_value->i();
-    node->set_assigned_device_name(input_devices[index]);
+    node->set_assigned_device_name(
+        DeviceNameUtils::GetRealDeviceName(input_devices[index]));
   }
 
   for (Node* node : ret_nodes) {
@@ -458,7 +459,8 @@ Status PinArgsAndRets(const std::vector<string>& input_devices,
       DCHECK_GT(output_devices.size(), index);
       VLOG(3) << "Setting output device to " << output_devices[index]
               << " for return at index " << index;
-      node->set_assigned_device_name(output_devices[index]);
+      node->set_assigned_device_name(
+          DeviceNameUtils::GetRealDeviceName(output_devices[index]));
     }
   }
   return absl::OkStatus();

--- a/tensorflow/core/framework/dataset.cc
+++ b/tensorflow/core/framework/dataset.cc
@@ -1064,7 +1064,8 @@ Status DatasetBase::DatasetGraphDefBuilder::AddResourceHelper(
     return errors::InvalidArgument("Empty resouce handle");
   }
   const ResourceHandle& handle = t.flat<ResourceHandle>()(0);
-  if (ctx->device_name() != handle.device()) {
+  if (!DeviceNameUtils::HaveSameDeviceName(ctx->device_name(),
+                                           handle.device())) {
     return errors::InvalidArgument("Trying to access resource ", handle.name(),
                                    " located in device ", handle.device(),
                                    " from device ", ctx->device_name());

--- a/tensorflow/core/framework/resource_mgr.cc
+++ b/tensorflow/core/framework/resource_mgr.cc
@@ -67,7 +67,8 @@ Status MakeResourceHandleToOutput(OpKernelContext* context, int output_index,
 namespace internal {
 
 Status ValidateDevice(OpKernelContext* ctx, const ResourceHandle& p) {
-  if (ctx->device()->attributes().name() != p.device()) {
+  if (!DeviceNameUtils::HaveSameDeviceName(ctx->device()->attributes().name(),
+                                           p.device())) {
     return errors::InvalidArgument(
         "Trying to access resource ", p.name(), " located in device ",
         p.device(), " from device ", ctx->device()->attributes().name());

--- a/third_party/xla/xla/tsl/util/device_name_utils.h
+++ b/third_party/xla/xla/tsl/util/device_name_utils.h
@@ -285,6 +285,30 @@ class DeviceNameUtils {
     if (!a_status) return a < b;
     return parsed_a < parsed_b;
   }
+
+  // Returns name of the stream device from the real device name if the
+  // multi-stream is enabled. For example, if the input device_name is
+  // "/device:GPU:0" and stream_id is 2, returns "/device:STREAM_GPU_0:2".
+  // Returns the input device_name if it cannot be stream-encoded.
+  static std::string GetStreamDeviceName(const std::string& device_name,
+                                         int stream_id);
+
+  // Returns name of the device from the stream-encoded name if the
+  // multi-stream is enabled. For example, if the input device_name is
+  // "/device:STREAM_GPU_0:2", returns "/device:GPU:0". Returns the input
+  // device_name if it's not a valid stream-encoded device name.
+  static std::string GetRealDeviceName(const std::string& device_name);
+
+  // Returns true iff the device_name is in the format of
+  // ".*STREAM_GPU_\d+:\d+$".
+  static bool IsStreamDeviceName(const std::string& device_name);
+
+  // Returns true iff device_name1 and device_name2 are the same, or one or
+  // both of them are stream device names and they represent the same real
+  // GPU device, for example, "/device:STREAM_GPU_1:0" and
+  // "/device:STREAM_GPU_1:1".
+  static bool HaveSameDeviceName(const std::string& device_name1,
+                                 const std::string& device_name2);
 };
 
 std::ostream& operator<<(std::ostream& os,


### PR DESCRIPTION
This is a part of the Multiple Stream Groups feature. With this new feature, users are allowed to create multiple stream groups in one GPU device, and the computation graph can be distributed to different stream groups for paralleled execution to increase GPU utilization and throughput and decrease latency. This is essential for accelerating workloads containing many small-sized GPU kernels. We got 8x speedup easily on recommender online inference systems. Please refer to the 'Performance' part in our [document](https://docs.google.com/document/d/1yL3lWk_iFKqLTyekkuaiKXZ78I0lPmD5kM1fghHRs4Y/edit?usp=sharing) for detailed and more experiment results.

Full multi-stream inference implementation please see https://github.com/tensorflow/tensorflow/compare/master...buptzyb:MultipleStreamGroups.

This PR provides the multi-stream related helper functions in DeviceNameUtils.
 When the multi-stream feature is enabled, TF will create multiple StreamDevice objects, each associated with one stream group. The name of a StreamDevice is like `/device:STREAM_GPU_0:2`, which means its real GPU device is `/device:GPU:0` and it manages the second stream group. The helper functions provide interconversion between Device names and StreamDevice names.

Ask for review from @changhuilin.