### PR TITLE
Fixed description of num_threads in `tf.lite.interpreter` doc

### DIFF
--- a/tensorflow/lite/python/interpreter.py
+++ b/tensorflow/lite/python/interpreter.py
@@ -410,7 +410,7 @@ class Interpreter:
         available to CPU kernels. If not set, the interpreter will use an
         implementation-dependent default number of threads. Currently, only a
         subset of kernels, such as conv, support multi-threading. num_threads
-        should be >= -1. Setting num_threads to 0 has the effect to disable
+        should be >= 1. Setting num_threads to 0 has the effect to disable
         multithreading, which is equivalent to setting num_threads to 1. If set
         to the value -1, the number of threads used will be
         implementation-defined and platform-dependent.

--- a/tensorflow/lite/python/interpreter.py
+++ b/tensorflow/lite/python/interpreter.py
@@ -410,10 +410,7 @@ class Interpreter:
         available to CPU kernels. If not set, the interpreter will use an
         implementation-dependent default number of threads. Currently, only a
         subset of kernels, such as conv, support multi-threading. num_threads
-        should be >= 1. Setting num_threads to 0 has the effect to disable
-        multithreading, which is equivalent to setting num_threads to 1. If set
-        to the value -1, the number of threads used will be
-        implementation-defined and platform-dependent.
+        should be >= 1.
       experimental_op_resolver_type: The op resolver used by the interpreter. It
         must be an instance of OpResolverType. By default, we use the built-in
         op resolver which corresponds to tflite::ops::builtin::BuiltinOpResolver


### PR DESCRIPTION
Hi
As per the code  [tensorflow/tensorflow/lite/python/interpreter.py](https://github.com/tensorflow/tensorflow/blob/b297295711589c2d71880a046333e6ec095c6d7d/tensorflow/lite/python/interpreter.py#L460-L464)

Lines 460 to 464 in [b297295](https://github.com/tensorflow/tensorflow/commit/b297295711589c2d71880a046333e6ec095c6d7d) , code num_threads is greater than equal to 1 but in description it was given as `-1`. This PR fixes description of num_threads in `tf.lite.interpreter` doc.

This PR fixes: TFLite issue [#68862](https://github.com/tensorflow/tensorflow/issues/68862)

Thank You