### PR TITLE
Use pthreadpool only when XNNPACK is enabled

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -165,26 +165,30 @@ include_directories(
   ${XLA_SOURCE_DIR}
 )
 # Download necessary dependencies.
-# Download pthreadpool source package if it doesn't exist.
-if(SYSTEM_PTHREADPOOL)
-  find_library(PTHREADPOOL_LIB pthreadpool REQUIRED)
-elseif(NOT DEFINED PTHREADPOOL_SOURCE_DIR)
-    message(STATUS "Downloading pthreadpool to ${CMAKE_BINARY_DIR}/pthreadpool-source (define SYSTEM_PTHREADPOOL or PTHREADPOOL_SOURCE_DIR to avoid it)")
-    configure_file(cmake/DownloadPThreadPool.cmake "${CMAKE_BINARY_DIR}/pthreadpool-download/CMakeLists.txt")
-    execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
-      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/pthreadpool-download")
-    execute_process(COMMAND "${CMAKE_COMMAND}" --build .
-      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/pthreadpool-download")
-    set(PTHREADPOOL_SOURCE_DIR "${CMAKE_BINARY_DIR}/pthreadpool-source" CACHE STRING "pthreadpool source directory")
-endif()
-# Configure pthreadpool
-if(NOT SYSTEM_PTHREADPOOL AND NOT TARGET pthreadpool)
-  set(PTHREADPOOL_BUILD_TESTS OFF CACHE BOOL "")
-  set(PTHREADPOOL_BUILD_BENCHMARKS OFF CACHE BOOL "")
-  set(PTHREADPOOL_ALLOW_DEPRECATED_API OFF CACHE BOOL "")
-  add_subdirectory(
-    "${PTHREADPOOL_SOURCE_DIR}"
-    "${CMAKE_BINARY_DIR}/pthreadpool")
+if(TFLITE_ENABLE_XNNPACK)
+  # pthreadpool is used by XNNPACK.
+  if(SYSTEM_PTHREADPOOL)
+    find_library(PTHREADPOOL_LIB pthreadpool REQUIRED)
+  elseif(NOT DEFINED PTHREADPOOL_SOURCE_DIR)
+      # Download pthreadpool source package if it doesn't exist.
+      message(STATUS "Downloading pthreadpool to ${CMAKE_BINARY_DIR}/pthreadpool-source (define SYSTEM_PTHREADPOOL or PTHREADPOOL_SOURCE_DIR to avoid it)")
+      configure_file(cmake/DownloadPThreadPool.cmake "${CMAKE_BINARY_DIR}/pthreadpool-download/CMakeLists.txt")
+      execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/pthreadpool-download")
+      execute_process(COMMAND "${CMAKE_COMMAND}" --build .
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/pthreadpool-download")
+      set(PTHREADPOOL_SOURCE_DIR "${CMAKE_BINARY_DIR}/pthreadpool-source" CACHE STRING "pthreadpool source directory")
+  endif()
+  # Configure pthreadpool
+  if(NOT SYSTEM_PTHREADPOOL AND NOT TARGET pthreadpool)
+    set(PTHREADPOOL_BUILD_TESTS OFF CACHE BOOL "")
+    set(PTHREADPOOL_BUILD_BENCHMARKS OFF CACHE BOOL "")
+    set(PTHREADPOOL_ALLOW_DEPRECATED_API OFF CACHE BOOL "")
+    add_subdirectory(
+      "${PTHREADPOOL_SOURCE_DIR}"
+      "${CMAKE_BINARY_DIR}/pthreadpool")
+  endif()
+  list(APPEND TFLITE_TARGET_DEPENDENCIES pthreadpool)
 endif()
 set(TF_TARGET_PRIVATE_OPTIONS "")
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
@@ -651,7 +655,6 @@ target_link_libraries(tensorflow-lite
     gemmlowp::gemmlowp
     ml_dtypes
     ruy::ruy
-    pthreadpool
     ${CMAKE_DL_LIBS}
     ${TFLITE_TARGET_DEPENDENCIES}
 )

--- a/tensorflow/lite/kernels/cpu_backend_context.cc
+++ b/tensorflow/lite/kernels/cpu_backend_context.cc
@@ -17,7 +17,9 @@ limitations under the License.
 
 #include <memory>
 
+#ifdef TFLITE_KERNEL_USE_XNNPACK
 #include "pthreadpool.h"  // from @pthreadpool
+#endif
 
 #ifdef TFLITE_HAVE_CPUINFO
 #include "include/cpuinfo.h"
@@ -149,6 +151,7 @@ void CpuBackendContext::SetMaxNumThreads(int max_num_threads) {
 
 void CpuBackendContext::SetUseCaching(bool flag) { use_caching_ = flag; }
 
+#ifdef TFLITE_KERNEL_USE_XNNPACK
 pthreadpool_t CpuBackendContext::get_xnnpack_threadpool() {
   if (!xnnpack_threadpool_ && max_num_threads_ > 1) {
     xnnpack_threadpool_.reset(
@@ -156,6 +159,7 @@ pthreadpool_t CpuBackendContext::get_xnnpack_threadpool() {
   }
   return xnnpack_threadpool_.get();
 }
+#endif
 
 bool CpuBackendContext::PreferGemmlowpOnX86() {
   bool use_gemmlowp_on_x86 = false;

--- a/tensorflow/lite/kernels/cpu_backend_context.h
+++ b/tensorflow/lite/kernels/cpu_backend_context.h
@@ -24,7 +24,9 @@ limitations under the License.
 #include <memory>
 
 #include "public/gemmlowp.h"
+#ifdef TFLITE_KERNEL_USE_XNNPACK
 #include "pthreadpool.h"  // from @pthreadpool
+#endif
 #include "ruy/context.h"  // from @ruy
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/external_cpu_backend_context.h"
@@ -54,7 +56,9 @@ class CpuBackendContext final : public TfLiteInternalBackendContext {
 
   bool use_caching() const { return use_caching_; }
 
+#ifdef TFLITE_KERNEL_USE_XNNPACK
   pthreadpool_t get_xnnpack_threadpool();
+#endif
 
   void ClearCaches() override { ruy_context_->ClearPrepackedCache(); }
 
@@ -118,10 +122,12 @@ class CpuBackendContext final : public TfLiteInternalBackendContext {
   // (currently the Ruy library only).
   bool use_caching_;
 
+#ifdef TFLITE_KERNEL_USE_XNNPACK
   // A smart pointer for the xnnpack threadpool. Is created by a call from the
   // interpreter, and then consumed by xnnpack, possibly via a TFLite kernel.
   std::unique_ptr<pthreadpool, decltype(&pthreadpool_destroy)>
       xnnpack_threadpool_{nullptr, &pthreadpool_destroy};
+#endif
 
   CpuBackendContext(const CpuBackendContext&) = delete;
 };


### PR DESCRIPTION
pthreadpool is only used by XNNPACK which is itself an optional dependency. We shouldn't require pthreadpool when XNNPACK is disabled.