### PR TITLE
[oneDNN][BugFix] Fix dtype utility function for F16 AVX2 DL extension

### DIFF
--- a/tensorflow/core/util/util.cc
+++ b/tensorflow/core/util/util.cc
@@ -151,10 +151,12 @@ bool IsDataTypeSupportedByOneDNNOnThisCPU(const DataType& dt) {
   } else if (dt == DT_HALF) {
     // Float16 is not supported in oneDNN v2.x
 #ifdef ENABLE_ONEDNN_V3
-    result = (TestCPUFeature(port::CPUFeature::AVX512BW) &&
-              (TestCPUFeature(port::CPUFeature::AVX512_FP16) ||
-               TestCPUFeature(port::CPUFeature::AMX_FP16) ||
-               TestCPUFeature(port::CPUFeature::AVX_NE_CONVERT)));
+    // Some CPUs that don't support AVX-512 use AVX-NE-CONVERT to cast to and
+    // from FP32
+    result = ((TestCPUFeature(port::CPUFeature::AVX512BW) &&
+               (TestCPUFeature(port::CPUFeature::AVX512_FP16) ||
+                TestCPUFeature(port::CPUFeature::AMX_FP16))) ||
+              TestCPUFeature(port::CPUFeature::AVX_NE_CONVERT));
     if (result) VLOG(2) << "CPU supports " << DataType_Name(dt);
 #endif  // ENABLE_ONEDNN_V3
   } else {


### PR DESCRIPTION
Intel's Efficiency cores do not support AVX512 instructions. However, some of them do support lower precisions (BF16/FP16) by converting to and from FP32. Due to the lack of Byte and Word instruction set support, the current condition check always returns False, even on supporting E-cores. This PR fixes the condition to correctly return True on all compatible hardware.