### PR TITLE
Cherrypick r2.17: Update GCS Staging artifacts for Tensorflow upload.

### DIFF
--- a/ci/official/envs/nightly_upload
+++ b/ci/official/envs/nightly_upload
@@ -22,7 +22,7 @@ TFCI_ARTIFACT_FINAL_PYPI_ARGS="--config-file=$KOKORO_KEYSTORE_DIR/73361_tensorfl
 TFCI_ARTIFACT_FINAL_PYPI_ENABLE=1
 TFCI_ARTIFACT_LATEST_GCS_URI="gs://tensorflow/nightly/latest/"
 TFCI_ARTIFACT_STAGING_GCS_ENABLE=1
-TFCI_ARTIFACT_STAGING_GCS_URI="gs://tensorflow-ci-artifact-staging/staging/nightly/$(git rev-parse HEAD)/"
+TFCI_ARTIFACT_STAGING_GCS_URI="gs://tensorflow-ci-staging/staging/nightly/$(git rev-parse HEAD)/"
 
 # 2. The internal version numbers get changed
 TFCI_NIGHTLY_UPDATE_VERSION_ENABLE=1

--- a/ci/official/envs/versions_upload
+++ b/ci/official/envs/versions_upload
@@ -23,6 +23,6 @@ TFCI_ARTIFACT_FINAL_PYPI_ARGS="--config-file=$KOKORO_KEYSTORE_DIR/73361_tensorfl
 TFCI_ARTIFACT_FINAL_PYPI_ENABLE=1
 TFCI_ARTIFACT_LATEST_GCS_URI="gs://tensorflow/versions/latest/"
 TFCI_ARTIFACT_STAGING_GCS_ENABLE=1
-TFCI_ARTIFACT_STAGING_GCS_URI="gs://tensorflow-ci-artifact-staging/staging/versions/${_LOUHI_EXECUTION_ID:-$(git rev-parse HEAD)}/"
+TFCI_ARTIFACT_STAGING_GCS_URI="gs://tensorflow-ci-staging/staging/versions/${_LOUHI_EXECUTION_ID:-$(git rev-parse HEAD)}/"
 
 TFCI_BAZEL_COMMON_ARGS="$TFCI_BAZEL_COMMON_ARGS --config resultstore"


### PR DESCRIPTION
Update GCS Staging artifacts for Tensorflow upload.