### PR TITLE
Pad function wrap mode

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/BUILD
+++ b/tensorflow/compiler/tf2xla/kernels/BUILD
@@ -161,6 +161,7 @@ cc_library(
         ":variable_ops",
         ":where_op",
         ":while_op",
+        ":wrap_pad_op",
         ":xla_broadcast_helper_op",
         ":xla_call_module_op",
         ":xla_conv_op",
@@ -1368,6 +1369,29 @@ tf_kernel_library(
 tf_kernel_library(
     name = "mirror_pad_op",
     srcs = ["mirror_pad_op.cc"],
+    deps = [
+        "//tensorflow/compiler/tf2xla:xla_compilation_device",
+        "//tensorflow/compiler/tf2xla:xla_compiler",
+        "//tensorflow/compiler/tf2xla:xla_context",
+        "//tensorflow/compiler/tf2xla:xla_helpers",
+        "//tensorflow/compiler/tf2xla:xla_op_registry",
+        "//tensorflow/compiler/tf2xla:xla_resource",
+        "//tensorflow/compiler/tf2xla/ops:xla_ops",
+        "//tensorflow/core:framework",
+        "//tensorflow/core/platform:errors",
+        "@com_google_absl//absl/status:statusor",
+        "@local_xla//xla:literal",
+        "@local_xla//xla:shape_util",
+        "@local_xla//xla:status_macros",
+        "@local_xla//xla:util",
+        "@local_xla//xla/client:xla_builder",
+        "@local_xla//xla/client/lib:constants",
+    ],
+)
+
+tf_kernel_library(
+    name = "wrap_pad_op",
+    srcs = ["wrap_pad_op.cc"],
     deps = [
         "//tensorflow/compiler/tf2xla:xla_compilation_device",
         "//tensorflow/compiler/tf2xla:xla_compiler",

--- a/tensorflow/compiler/tf2xla/kernels/wrap_pad_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/wrap_pad_op.cc
@@ -1,0 +1,185 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "absl/status/statusor.h"
+#include "tensorflow/compiler/tf2xla/xla_op_kernel.h"
+#include "tensorflow/compiler/tf2xla/xla_op_registry.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/op_requires.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/platform/errors.h"
+#include "xla/client/lib/constants.h"
+#include "xla/client/xla_builder.h"
+#include "xla/literal.h"
+#include "xla/shape.h"
+#include "xla/status_macros.h"
+#include "xla/util.h"
+
+namespace tensorflow {
+namespace {
+
+class WrapPadOp : public XlaOpKernel {
+ public:
+  explicit WrapPadOp(OpKernelConstruction* context) : XlaOpKernel(context) {}
+
+  absl::StatusOr<xla::XlaOp> DoWrapPad(const xla::XlaOp t,
+                                       const xla::Shape& original_shape,
+                                       const xla::LiteralSlice& pad_literal,
+                                       xla::XlaBuilder* b) {
+    xla::XlaOp accum = t;
+    for (int64_t dimno = original_shape.rank() - 1; dimno >= 0; --dimno) {
+      int64_t lhs_padding = pad_literal.Get<int64_t>({dimno, 0});
+      int64_t rhs_padding = pad_literal.Get<int64_t>({dimno, 1});
+      int64_t dim_size = original_shape.dimensions(dimno);
+
+      // Padding amounts on each side must be less than the size of the
+      // original shape.
+      TF_RET_CHECK(lhs_padding >= 0 && lhs_padding < dim_size);
+      TF_RET_CHECK(rhs_padding >= 0 && rhs_padding < dim_size);
+
+      auto lhs_pad =
+          xla::SliceInDim(accum, dim_size - lhs_padding, dim_size, 1, dimno);
+      auto rhs_pad = xla::SliceInDim(accum, 0, rhs_padding, 1, dimno);
+      accum = xla::ConcatInDim(b, {lhs_pad, accum, rhs_pad}, dimno);
+    }
+    return accum;
+  }
+
+  void Compile(XlaOpKernelContext* ctx) override {
+    const TensorShape input_shape = ctx->InputShape("input");
+    const TensorShape pad_shape = ctx->InputShape("paddings");
+
+    const int dims = input_shape.dims();
+    OP_REQUIRES(
+        ctx,
+        TensorShapeUtils::IsMatrix(pad_shape) && pad_shape.dim_size(1) == 2,
+        errors::InvalidArgument("paddings must be a matrix with 2 columns: ",
+                                pad_shape.DebugString()));
+    OP_REQUIRES(
+        ctx, dims == pad_shape.dim_size(0),
+        errors::InvalidArgument(
+            "The first dimension of paddings must be the rank of inputs",
+            pad_shape.DebugString(), " ", input_shape.DebugString()));
+
+    // Evaluate the 'padding' constant input, reshaping to a matrix.
+    xla::Literal pad_literal;
+    OP_REQUIRES_OK(ctx,
+                   ctx->ConstantInputAsInt64Literal("paddings", &pad_literal));
+
+    xla::XlaBuilder* b = ctx->builder();
+    auto in0 = ctx->Input("input");
+    absl::StatusOr<xla::Shape> in0_shape = b->GetShape(in0);
+    OP_REQUIRES(ctx, in0_shape.ok(), in0_shape.status());
+    absl::StatusOr<xla::XlaOp> accum_status =
+        DoWrapPad(in0, in0_shape.value(), pad_literal, b);
+
+    OP_REQUIRES_OK(ctx, accum_status.status());
+
+    ctx->SetOutput(0, accum_status.value());
+  }
+
+ private:
+  WrapPadOp(const WrapPadOp&) = delete;
+  void operator=(const WrapPadOp&) = delete;
+};
+
+REGISTER_XLA_OP(Name("WrapPad").CompileTimeConstantInput("paddings"),
+                WrapPadOp);
+
+class WrapPadGradOp : public XlaOpKernel {
+ public:
+  explicit WrapPadGradOp(OpKernelConstruction* context)
+      : XlaOpKernel(context) {}
+
+  absl::StatusOr<xla::XlaOp> DoWrapPadGrad(const xla::XlaOp t,
+                                           const xla::Shape& original_shape,
+                                           const xla::LiteralSlice& pad_literal,
+                                           xla::XlaBuilder* b) {
+    xla::XlaOp grad = t;
+    for (int64_t dimno = original_shape.rank() - 1; dimno >= 0; --dimno) {
+      int64_t lhs_padding = pad_literal.Get<int64_t>({dimno, 0});
+      int64_t rhs_padding = pad_literal.Get<int64_t>({dimno, 1});
+      int64_t dim_size = original_shape.dimensions(dimno);
+      int64_t result_dim_size = dim_size - lhs_padding - rhs_padding;
+
+      // Padding amounts on each side must be less than the size of the
+      // original shape.
+      TF_RET_CHECK(lhs_padding >= 0 && lhs_padding < dim_size);
+      TF_RET_CHECK(rhs_padding >= 0 && rhs_padding < dim_size);
+
+      xla::XlaOp lhs_pad = xla::SliceInDim(grad, 0, lhs_padding, 1, dimno);
+      xla::XlaOp padded_lhs_pad =
+          xla::PadInDim(lhs_pad, xla::ScalarLike(lhs_pad, 0), dimno,
+                        /*pad_lo=*/result_dim_size - lhs_padding,
+                        /*pad_hi=*/0);
+
+      xla::XlaOp rhs_pad =
+          xla::SliceInDim(grad, dim_size - rhs_padding, dim_size, 1, dimno);
+      xla::XlaOp padded_rhs_pad =
+          xla::PadInDim(rhs_pad, xla::ScalarLike(rhs_pad, 0), dimno,
+                        /*pad_lo=*/0,
+                        /*pad_hi=*/result_dim_size - rhs_padding);
+
+      xla::XlaOp grad_core =
+          xla::SliceInDim(grad, lhs_padding, dim_size - rhs_padding, 1, dimno);
+
+      grad = padded_lhs_pad + grad_core + padded_rhs_pad;
+    }
+    return grad;
+  }
+
+  void Compile(XlaOpKernelContext* ctx) override {
+    const TensorShape input_shape = ctx->InputShape("input");
+    const TensorShape pad_shape = ctx->InputShape("paddings");
+
+    const int dims = input_shape.dims();
+    OP_REQUIRES(
+        ctx,
+        TensorShapeUtils::IsMatrix(pad_shape) && pad_shape.dim_size(1) == 2,
+        errors::InvalidArgument("paddings must be a matrix with 2 columns: ",
+                                pad_shape.DebugString()));
+    OP_REQUIRES(
+        ctx, dims == pad_shape.dim_size(0),
+        errors::InvalidArgument(
+            "The first dimension of paddings must be the rank of inputs",
+            pad_shape.DebugString(), " ", input_shape.DebugString()));
+
+    // Evaluate the 'padding' constant input, reshaping to a matrix.
+    xla::Literal pad_literal;
+    OP_REQUIRES_OK(ctx,
+                   ctx->ConstantInputAsInt64Literal("paddings", &pad_literal));
+
+    xla::XlaBuilder* b = ctx->builder();
+    auto in0 = ctx->Input("input");
+    absl::StatusOr<xla::Shape> in0_shape = b->GetShape(in0);
+    OP_REQUIRES(ctx, in0_shape.ok(), in0_shape.status());
+    absl::StatusOr<xla::XlaOp> accum_status =
+        DoWrapPadGrad(in0, in0_shape.value(), pad_literal, b);
+
+    OP_REQUIRES_OK(ctx, accum_status.status());
+
+    ctx->SetOutput(0, accum_status.value());
+  }
+
+ private:
+  WrapPadGradOp(const WrapPadGradOp&) = delete;
+  void operator=(const WrapPadGradOp&) = delete;
+};
+
+REGISTER_XLA_OP(Name("WrapPadGrad").CompileTimeConstantInput("paddings"),
+                WrapPadGradOp);
+
+}  // namespace
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -963,6 +963,7 @@ cc_library(
         ":unpack_op",
         ":unravel_index_op",
         ":where_op",
+        ":wrap_pad_op",
     ],
 )
 
@@ -1099,6 +1100,12 @@ tf_kernel_library(
 tf_kernel_library(
     name = "pad_op",
     prefix = "pad_op",
+    deps = ARRAY_DEPS,
+)
+
+tf_kernel_library(
+    name = "wrap_pad_op",
+    prefix = "wrap_pad_op",
     deps = ARRAY_DEPS,
 )
 
@@ -3340,11 +3347,13 @@ tf_cc_tests(
         "restore_v2_op_test.cc",
         "save_op_test.cc",
         "save_v2_op_test.cc",
+        "wrap_pad_op_test.cc",
     ],
     deps = [
         ":io",
         ":ops_testutil",
         ":ops_util",
+        ":wrap_pad_op",
         "//tensorflow/cc:cc_ops",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:core_cpu_internal",
@@ -3355,6 +3364,23 @@ tf_cc_tests(
         "//tensorflow/core:test_main",
         "//tensorflow/core:testlib",
         "//tensorflow/core/util/tensor_bundle",
+    ],
+)
+
+tf_cuda_cc_test(
+    name = "wrap_pad_op_benchmark_test",
+    srcs = ["wrap_pad_op_benchmark_test.cc"],
+    deps = [
+        ":ops_testutil",
+        ":ops_util",
+        ":wrap_pad_op",
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core:testlib",
     ],
 )
 
@@ -6617,6 +6643,8 @@ filegroup(
         "transpose_functor.h",
         "transpose_op.h",
         "where_op.h",
+        "wrap_pad_op.h",
+        "wrap_pad_op_cpu_impl.h",
         "xent_op.h",
     ] + [
         "//tensorflow/core/kernels/data:portable_all_op_kernels_headers",
@@ -6969,6 +6997,12 @@ filegroup(
         "unsorted_segment_join_op.cc",
         "where_op.cc",
         "whole_file_read_ops.cc",
+        "wrap_pad_op.cc",
+        "wrap_pad_op_cpu_impl_1.cc",
+        "wrap_pad_op_cpu_impl_2.cc",
+        "wrap_pad_op_cpu_impl_3.cc",
+        "wrap_pad_op_cpu_impl_4.cc",
+        "wrap_pad_op_cpu_impl_5.cc",
         "xent_op.cc",
         ":portable_extended_ops_headers",
     ] + [

--- a/tensorflow/core/kernels/wrap_pad_op.cc
+++ b/tensorflow/core/kernels/wrap_pad_op.cc
@@ -1,0 +1,399 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#define EIGEN_USE_THREADS
+
+#include "tensorflow/core/kernels/wrap_pad_op.h"
+
+#include <string>
+
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/types.h"
+#include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
+
+namespace tensorflow {
+
+template <typename Device, typename T, typename Tpaddings>
+class WrapPadOp : public OpKernel {
+ public:
+  explicit WrapPadOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  ~WrapPadOp() override = default;
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor& in0 = context->input(0);
+    const Tensor& in1 = context->input(1);
+    const int dims = in0.dims();
+    constexpr int kMinDims = 0;
+    constexpr int kMaxDims = 5;
+    OP_REQUIRES(context, kMinDims <= dims && dims <= kMaxDims,
+                errors::Unimplemented("inputs rank not in [", kMinDims, ",",
+                                      kMaxDims, "]: ", dims));
+    OP_REQUIRES(
+        context,
+        TensorShapeUtils::IsMatrix(in1.shape()) && in1.dim_size(1) == 2,
+        errors::InvalidArgument("paddings must be a matrix with 2 columns: ",
+                                in1.shape().DebugString()));
+    OP_REQUIRES(
+        context, dims == in1.dim_size(0),
+        errors::InvalidArgument(
+            "The first dimension of paddings must be the rank of inputs",
+            in1.shape().DebugString(), ", ", in0.shape().DebugString()));
+
+    // Compute the shape of the output tensor, and allocate it.
+    TensorShape output_shape;
+    typename TTypes<Tpaddings>::ConstMatrix paddings = in1.matrix<Tpaddings>();
+    for (int d = 0; d < dims; ++d) {
+      const Tpaddings before = paddings(d, 0);  // Pad before existing elements.
+      const Tpaddings after = paddings(d, 1);   // Pad after existing elements.
+      OP_REQUIRES(context, before >= 0 && after >= 0,
+                  errors::InvalidArgument(
+                      "paddings must be non-negative: ", before, " ", after));
+      OP_REQUIRES(context, before < in0.dim_size(d) && after < in0.dim_size(d),
+                  errors::InvalidArgument("paddings must be less than"
+                                          " the dimension size: ",
+                                          before, ", ", after,
+                                          " not less than ", in0.dim_size(d)));
+      output_shape.AddDim(before + in0.dim_size(d) + after);
+    }
+
+    if (output_shape.num_elements() == in0.NumElements()) {
+      // When num_elements == 0, shape may have changed.
+      Tensor out;
+      CHECK(out.CopyFrom(in0, output_shape));
+      context->set_output(0, out);
+      return;
+    }
+
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
+
+#define WRAP_PAD_CASE(i)                                                  \
+  case i: {                                                               \
+    functor::WrapPad<Device, T, Tpaddings, i>()(                          \
+        context->eigen_device<Device>(), To32Bit(output->tensor<T, i>()), \
+        To32Bit(in0.tensor<T, i>()), paddings);                           \
+    break;                                                                \
+  }
+
+    // Invoke the dims-specific implementation.
+    switch (dims) {
+      WRAP_PAD_CASE(1)
+      WRAP_PAD_CASE(2)
+      WRAP_PAD_CASE(3)
+      WRAP_PAD_CASE(4)
+      WRAP_PAD_CASE(5)
+      default:
+        OP_REQUIRES(context, false,
+                    errors::InvalidArgument("Unsupported rank: ",
+                                            in0.shape().DebugString()));
+    }
+#undef WRAP_PAD_CASE
+  }
+};
+
+using CpuDevice = Eigen::ThreadPoolDevice;
+using GpuDevice = Eigen::GpuDevice;
+
+namespace functor {
+// Forward declarations of the functor specializations defined in the sharded
+// files.
+#define DECLARE_CPU_SPEC(T, Tpaddings, i)                     \
+  template <>                                                 \
+  void WrapPad<CpuDevice, T, Tpaddings, i>::operator()(       \
+      const CpuDevice&, typename TTypes<T, i, int32>::Tensor, \
+      typename TTypes<T, i, int32>::ConstTensor,              \
+      TTypes<Tpaddings>::ConstMatrix);                        \
+  extern template struct WrapPad<CpuDevice, T, Tpaddings, i>;
+
+#define DECLARE_CPU_SPECS(T)       \
+  DECLARE_CPU_SPEC(T, int32, 1);   \
+  DECLARE_CPU_SPEC(T, int32, 2);   \
+  DECLARE_CPU_SPEC(T, int32, 3);   \
+  DECLARE_CPU_SPEC(T, int32, 4);   \
+  DECLARE_CPU_SPEC(T, int32, 5);   \
+  DECLARE_CPU_SPEC(T, int64_t, 1); \
+  DECLARE_CPU_SPEC(T, int64_t, 2); \
+  DECLARE_CPU_SPEC(T, int64_t, 3); \
+  DECLARE_CPU_SPEC(T, int64_t, 4); \
+  DECLARE_CPU_SPEC(T, int64_t, 5);
+
+TF_CALL_POD_TYPES(DECLARE_CPU_SPECS);
+TF_CALL_QUANTIZED_TYPES(DECLARE_CPU_SPECS);
+TF_CALL_tstring(DECLARE_CPU_SPECS);
+
+#undef DECLARE_CPU_SPEC
+#undef DECLARE_CPU_SPECS
+}  // namespace functor
+
+#define REGISTER_KERNEL(type)                                       \
+  REGISTER_KERNEL_BUILDER(Name("WrapPad")                           \
+                              .Device(DEVICE_CPU)                   \
+                              .TypeConstraint<type>("T")            \
+                              .TypeConstraint<int32>("Tpaddings")   \
+                              .HostMemory("paddings"),              \
+                          WrapPadOp<CpuDevice, type, int32>);       \
+  REGISTER_KERNEL_BUILDER(Name("WrapPad")                           \
+                              .Device(DEVICE_CPU)                   \
+                              .TypeConstraint<type>("T")            \
+                              .TypeConstraint<int64_t>("Tpaddings") \
+                              .HostMemory("paddings"),              \
+                          WrapPadOp<CpuDevice, type, int64>);
+
+// Note that we do register for bool type.
+TF_CALL_POD_TYPES(REGISTER_KERNEL);
+TF_CALL_QUANTIZED_TYPES(REGISTER_KERNEL);
+TF_CALL_tstring(REGISTER_KERNEL);
+#undef REGISTER_KERNEL
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+namespace functor {
+// Forward declarations of the functor specializations for GPU.
+#define DECLARE_GPU_SPEC(T, Tpaddings, i)                     \
+  template <>                                                 \
+  void WrapPad<GpuDevice, T, Tpaddings, i>::operator()(       \
+      const GpuDevice&, typename TTypes<T, i, int32>::Tensor, \
+      typename TTypes<T, i, int32>::ConstTensor,              \
+      TTypes<Tpaddings>::ConstMatrix);                        \
+  extern template struct WrapPad<GpuDevice, T, Tpaddings, i>;
+
+#define DECLARE_GPU_SPECS(T)       \
+  DECLARE_GPU_SPEC(T, int32, 1);   \
+  DECLARE_GPU_SPEC(T, int32, 2);   \
+  DECLARE_GPU_SPEC(T, int32, 3);   \
+  DECLARE_GPU_SPEC(T, int32, 4);   \
+  DECLARE_GPU_SPEC(T, int32, 5);   \
+  DECLARE_GPU_SPEC(T, int64_t, 1); \
+  DECLARE_GPU_SPEC(T, int64_t, 2); \
+  DECLARE_GPU_SPEC(T, int64_t, 3); \
+  DECLARE_GPU_SPEC(T, int64_t, 4); \
+  DECLARE_GPU_SPEC(T, int64_t, 5);
+
+TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPECS);
+#undef DECLARE_GPU_SPECS
+#undef DECLARE_GPU_SPEC
+}  // namespace functor
+
+// Registration of the GPU implementations.
+#define REGISTER_GPU_KERNEL(T)                                      \
+  REGISTER_KERNEL_BUILDER(Name("WrapPad")                           \
+                              .Device(DEVICE_GPU)                   \
+                              .TypeConstraint<T>("T")               \
+                              .TypeConstraint<int32>("Tpaddings")   \
+                              .HostMemory("paddings"),              \
+                          WrapPadOp<GpuDevice, T, int32>);          \
+  REGISTER_KERNEL_BUILDER(Name("WrapPad")                           \
+                              .Device(DEVICE_GPU)                   \
+                              .TypeConstraint<T>("T")               \
+                              .TypeConstraint<int64_t>("Tpaddings") \
+                              .HostMemory("paddings"),              \
+                          WrapPadOp<GpuDevice, T, int64>);
+
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_KERNEL);
+#undef REGISTER_GPU_KERNEL
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+// Gradient op.
+template <typename Device, typename T, typename Tpaddings>
+class WrapPadGradOp : public OpKernel {
+ public:
+  explicit WrapPadGradOp(OpKernelConstruction* context) : OpKernel(context) {}
+
+  ~WrapPadGradOp() override = default;
+
+  void Compute(OpKernelContext* context) override {
+    const Tensor& in0 = context->input(0);
+    const Tensor& in1 = context->input(1);
+    const int dims = in0.dims();
+    constexpr int kMinDims = 0;
+    constexpr int kMaxDims = 5;
+    OP_REQUIRES(context, kMinDims <= dims && dims <= kMaxDims,
+                errors::Unimplemented("inputs rank not in [", kMinDims, ",",
+                                      kMaxDims, "]: ", dims));
+    OP_REQUIRES(
+        context,
+        TensorShapeUtils::IsMatrix(in1.shape()) && in1.dim_size(1) == 2,
+        errors::InvalidArgument("paddings must be a matrix with 2 columns: ",
+                                in1.shape().DebugString()));
+    OP_REQUIRES(
+        context, dims == in1.dim_size(0),
+        errors::InvalidArgument(
+            "The first dimension of paddings must be the rank of inputs",
+            in1.shape().DebugString(), " ", in0.shape().DebugString()));
+
+    // Compute the shape of the output tensor, and allocate it.
+    TensorShape output_shape;
+    typename TTypes<Tpaddings>::ConstMatrix paddings = in1.matrix<Tpaddings>();
+    for (int d = 0; d < dims; ++d) {
+      const int64_t before = paddings(d, 0);  // Pad before existing elements.
+      const int64_t after = paddings(d, 1);   // Pad after existing elements.
+      OP_REQUIRES(context, before >= 0 && after >= 0,
+                  errors::InvalidArgument(
+                      "Paddings must be non-negative: ", before, ", ", after));
+
+      const int64_t in_size = in0.dim_size(d);
+      const int64_t total_padding = before + after;
+      OP_REQUIRES(
+          context, total_padding < in_size && total_padding >= 0,
+          errors::InvalidArgument(
+              "Total paddings must be less than the input dimension size: ",
+              total_padding, " was not less than ", in_size));
+
+      const int64_t out_size = in_size - total_padding;
+      OP_REQUIRES(context, before < out_size && after < out_size,
+                  errors::InvalidArgument("paddings must be less than"
+                                          " the output dimension size: ",
+                                          before, ", ", after,
+                                          " not less than ", out_size));
+      OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(out_size));
+    }
+
+    if (output_shape == in0.shape()) {
+      context->set_output(0, in0);
+      return;
+    }
+
+    Tensor scratch;
+    OP_REQUIRES_OK(context, context->allocate_temp(DataTypeToEnum<T>::value,
+                                                   in0.shape(), &scratch));
+
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, output_shape, &output));
+
+#define WRAP_PAD_GRAD_CASE(k)                                             \
+  case k: {                                                               \
+    functor::WrapPadGrad<Device, T, Tpaddings, k>()(                      \
+        context->eigen_device<Device>(), To32Bit(output->tensor<T, k>()), \
+        To32Bit(in0.tensor<T, k>()), paddings,                            \
+        To32Bit(scratch.tensor<T, k>()));                                 \
+    break;                                                                \
+  }
+
+    // Invoke the dims-specific implementation.
+    switch (dims) {
+      WRAP_PAD_GRAD_CASE(1);
+      WRAP_PAD_GRAD_CASE(2);
+      WRAP_PAD_GRAD_CASE(3);
+      WRAP_PAD_GRAD_CASE(4);
+      WRAP_PAD_GRAD_CASE(5);
+      default:
+        OP_REQUIRES(context, false,
+                    errors::InvalidArgument("Unsupported rank: ",
+                                            in0.shape().DebugString()));
+    }
+#undef WRAP_PAD_GRAD_CASE
+  }
+};
+
+namespace functor {
+// Forward declarations of the functor specializations defined in the sharded
+// files.
+#define DECLARE_CPU_SPEC(T, Tpaddings, k)                                    \
+  template <>                                                                \
+  void WrapPadGrad<CpuDevice, T, Tpaddings, k>::operator()(                  \
+      const CpuDevice&, typename TTypes<T, k, int32>::Tensor,                \
+      typename TTypes<T, k, int32>::ConstTensor,                             \
+      TTypes<Tpaddings>::ConstMatrix, typename TTypes<T, k, int32>::Tensor); \
+  extern template struct WrapPadGrad<CpuDevice, T, Tpaddings, k>;
+
+#define DECLARE_CPU_SPECS(T)       \
+  DECLARE_CPU_SPEC(T, int32, 1);   \
+  DECLARE_CPU_SPEC(T, int32, 2);   \
+  DECLARE_CPU_SPEC(T, int32, 3);   \
+  DECLARE_CPU_SPEC(T, int32, 4);   \
+  DECLARE_CPU_SPEC(T, int32, 5);   \
+  DECLARE_CPU_SPEC(T, int64_t, 1); \
+  DECLARE_CPU_SPEC(T, int64_t, 2); \
+  DECLARE_CPU_SPEC(T, int64_t, 3); \
+  DECLARE_CPU_SPEC(T, int64_t, 4); \
+  DECLARE_CPU_SPEC(T, int64_t, 5);
+
+TF_CALL_NUMBER_TYPES(DECLARE_CPU_SPECS);
+#undef DECLARE_CPU_SPECS
+#undef DECLARE_CPU_SPEC
+}  // namespace functor
+
+#define REGISTER_KERNEL(type)                                       \
+  REGISTER_KERNEL_BUILDER(Name("WrapPadGrad")                       \
+                              .Device(DEVICE_CPU)                   \
+                              .TypeConstraint<type>("T")            \
+                              .TypeConstraint<int32>("Tpaddings")   \
+                              .HostMemory("paddings"),              \
+                          WrapPadGradOp<CpuDevice, type, int32>);   \
+  REGISTER_KERNEL_BUILDER(Name("WrapPadGrad")                       \ 
+                              .Device(DEVICE_CPU)                   \
+                              .TypeConstraint<type>("T")            \
+                              .TypeConstraint<int64_t>("Tpaddings") \
+                              .HostMemory("paddings"),              \
+                          WrapPadGradOp<CpuDevice, type, int64>);
+
+TF_CALL_NUMBER_TYPES(REGISTER_KERNEL);
+#undef REGISTER_KERNEL
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+namespace functor {
+// Forward declarations of the functor specializations for GPU.
+#define DECLARE_GPU_SPEC(T, Tpaddings, k)                                    \
+  template <>                                                                \
+  void WrapPadGrad<GpuDevice, T, Tpaddings, k>::operator()(                  \
+      const GpuDevice&, typename TTypes<T, k, int32>::Tensor,                \
+      typename TTypes<T, k, int32>::ConstTensor,                             \
+      TTypes<Tpaddings>::ConstMatrix, typename TTypes<T, k, int32>::Tensor); \
+  extern template struct WrapPadGrad<GpuDevice, T, Tpaddings, k>;
+
+#define DECLARE_GPU_SPECS(T)       \
+  DECLARE_GPU_SPEC(T, int32, 1);   \
+  DECLARE_GPU_SPEC(T, int32, 2);   \
+  DECLARE_GPU_SPEC(T, int32, 3);   \
+  DECLARE_GPU_SPEC(T, int32, 4);   \
+  DECLARE_GPU_SPEC(T, int32, 5);   \
+  DECLARE_GPU_SPEC(T, int64_t, 1); \
+  DECLARE_GPU_SPEC(T, int64_t, 2); \
+  DECLARE_GPU_SPEC(T, int64_t, 3); \
+  DECLARE_GPU_SPEC(T, int64_t, 4); \
+  DECLARE_GPU_SPEC(T, int64_t, 5);
+
+TF_CALL_GPU_NUMBER_TYPES(DECLARE_GPU_SPECS);
+#undef DECLARE_GPU_SPECS
+#undef DECLARE_GPU_SPEC
+}  // namespace functor
+
+// Registration of the GPU implementations.
+#define REGISTER_GPU_KERNEL(T)                                      \
+  REGISTER_KERNEL_BUILDER(Name("WrapPadGrad")                       \
+                              .Device(DEVICE_GPU)                   \
+                              .TypeConstraint<T>("T")               \
+                              .TypeConstraint<int32>("Tpaddings")   \
+                              .HostMemory("paddings"),              \
+                          WrapPadGradOp<GpuDevice, T, int32>);      \
+  REGISTER_KERNEL_BUILDER(Name("WrapPadGrad")                       \
+                              .Device(DEVICE_GPU)                   \
+                              .TypeConstraint<T>("T")               \
+                              .TypeConstraint<int64_t>("Tpaddings") \
+                              .HostMemory("paddings"),              \
+                          WrapPadGradOp<GpuDevice, T, int64>);
+
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_KERNEL);
+#undef REGISTER_GPU_KERNEL
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/wrap_pad_op.h
+++ b/tensorflow/core/kernels/wrap_pad_op.h
@@ -1,0 +1,422 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_WRAP_PAD_OP_H_
+#define TENSORFLOW_CORE_KERNELS_WRAP_PAD_OP_H_
+
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/platform/types.h"
+#include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
+
+namespace Eigen {
+template <typename PaddingDimensions, typename XprType>
+class TensorWrapPadOp;
+
+namespace internal {
+template <typename PaddingDimensions, typename XprType>
+struct traits<TensorWrapPadOp<PaddingDimensions, XprType>>
+    : public traits<XprType> {
+  typedef typename XprType::Scalar Scalar;
+  typedef traits<XprType> XprTraits;
+  typedef typename XprTraits::StorageKind StorageKind;
+  typedef typename XprTraits::Index Index;
+  typedef typename XprType::Nested Nested;
+  typedef std::remove_reference_t<Nested> _Nested;
+  static constexpr int NumDimensions = XprTraits::NumDimensions;
+  static constexpr int Layout = XprTraits::Layout;
+};
+
+template <typename PaddingDimensions, typename XprType>
+struct eval<TensorWrapPadOp<PaddingDimensions, XprType>, Eigen::Dense> {
+  typedef const TensorWrapPadOp<PaddingDimensions, XprType>& type;
+};
+
+template <typename PaddingDimensions, typename XprType>
+struct nested<
+    TensorWrapPadOp<PaddingDimensions, XprType>, 1,
+    typename eval<TensorWrapPadOp<PaddingDimensions, XprType>>::type> {
+  typedef TensorWrapPadOp<PaddingDimensions, XprType> type;
+};
+}  // namespace internal
+
+template <typename PaddingDimensions, typename XprType>
+class TensorWrapPadOp
+    : public TensorBase<TensorWrapPadOp<PaddingDimensions, XprType>,
+                        ReadOnlyAccessors> {
+ public:
+  typedef typename Eigen::internal::traits<TensorWrapPadOp>::Scalar Scalar;
+  typedef typename Eigen::NumTraits<Scalar>::Real RealScalar;
+  typedef typename XprType::CoeffReturnType CoeffReturnType;
+  typedef typename Eigen::internal::nested<TensorWrapPadOp>::type Nested;
+  typedef typename Eigen::internal::traits<TensorWrapPadOp>::StorageKind
+      StorageKind;
+  typedef typename Eigen::internal::traits<TensorWrapPadOp>::Index Index;
+
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE
+  TensorWrapPadOp(const XprType& expr, const PaddingDimensions& padding_dims)
+      : xpr_(expr), padding_dims_(padding_dims) {}
+
+  EIGEN_DEVICE_FUNC
+  const PaddingDimensions& padding() const { return padding_dims_; }
+
+  EIGEN_DEVICE_FUNC
+  const typename internal::remove_all<typename XprType::Nested>::type&
+  expression() const {
+    return xpr_;
+  }
+
+ protected:
+  typename XprType::Nested xpr_;
+  const PaddingDimensions padding_dims_;
+};
+
+template <typename PaddingDimensions, typename ArgType, typename Device>
+struct TensorEvaluator<const TensorWrapPadOp<PaddingDimensions, ArgType>,
+                       Device> {
+  typedef TensorWrapPadOp<PaddingDimensions, ArgType> XprType;
+  typedef typename XprType::Index Index;
+  static constexpr int Dims = internal::array_size<PaddingDimensions>::value;
+  typedef DSizes<Index, Dims> Dimensions;
+  typedef typename XprType::Scalar Scalar;
+  typedef typename XprType::CoeffReturnType CoeffReturnType;
+  // Copied from Eigen3 Github version 0e806c1.
+  typedef typename PacketType<CoeffReturnType, Device>::type PacketReturnType;
+
+  enum {
+    IsAligned = false,
+    PacketAccess = TensorEvaluator<ArgType, Device>::PacketAccess,
+    BlockAccess = false,
+    BlockAccessV2 = false,
+    PreferBlockAccess = false,
+    Layout = TensorEvaluator<ArgType, Device>::Layout,
+    CoordAccess = true,
+    RawAccess = false
+  };
+
+  //===- Tensor block evaluation strategy (see TensorBlock.h) -------------===//
+  typedef internal::TensorBlockNotImplemented TensorBlock;
+  //===--------------------------------------------------------------------===//
+
+  EIGEN_STRONG_INLINE TensorEvaluator(const XprType& op, const Device& device)
+      : impl_(op.expression(), device), padding_(op.padding()) {
+    EIGEN_STATIC_ASSERT(Dims > 0, YOU_MADE_A_PROGRAMMING_MISTAKE)
+
+    // This should trigger compilation error if padding dimensions and
+    // expression dimensions do not match.
+    dimensions_ = impl_.dimensions();
+    for (int dim = 0; dim < Dims; ++dim) {
+      eigen_assert(padding_[dim].first + 1 <= dimensions_[dim]);
+      eigen_assert(padding_[dim].second + 1 <= dimensions_[dim]);
+      dimensions_[dim] += padding_[dim].first + padding_[dim].second;
+    }
+
+    const auto& input_dims = impl_.dimensions();
+    if (static_cast<int>(Layout) == static_cast<int>(ColMajor)) {
+      input_strides_[0] = 1;
+      output_strides_[0] = 1;
+      for (int i = 0; i < Dims - 1; ++i) {
+        input_strides_[i + 1] = input_strides_[i] * input_dims[i];
+        output_strides_[i + 1] = output_strides_[i] * dimensions_[i];
+      }
+    } else {
+      input_strides_[numext::maxi(0, Dims - 1)] = 1;
+      output_strides_[numext::maxi(0, Dims - 1)] = 1;
+      for (int i = Dims - 1; i > 0; --i) {
+        input_strides_[i - 1] = input_strides_[i] * input_dims[i];
+        output_strides_[i - 1] = output_strides_[i] * dimensions_[i];
+      }
+    }
+  }
+
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE const Dimensions& dimensions() const {
+    return dimensions_;
+  }
+
+  EIGEN_STRONG_INLINE bool evalSubExprsIfNeeded(Scalar*) {
+    impl_.evalSubExprsIfNeeded(nullptr);
+    return true;
+  }
+
+  EIGEN_STRONG_INLINE void cleanup() { impl_.cleanup(); }
+
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE CoeffReturnType
+  coeff(Index index) const {
+    eigen_assert(index < dimensions().TotalSize());
+    const Index input_index = ToInputIndex(index);
+    return impl_.coeff(input_index);
+  }
+
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE CoeffReturnType
+  coeff(array<Index, Dims> coords) const {
+    for (int dim = 0; dim < Dims; ++dim) {
+      coords[dim] = ToInputCoord(coords[dim], dim);
+    }
+    ReadInputHelper<TensorEvaluator<ArgType, Device>::CoordAccess> helper;
+    return helper(coords, input_strides_, impl_);
+  }
+
+  template <int LoadMode>
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE PacketReturnType
+  packet(Index index) const {
+    constexpr int kPacketSize =
+        internal::unpacket_traits<PacketReturnType>::size;
+
+    EIGEN_STATIC_ASSERT(kPacketSize > 1, YOU_MADE_A_PROGRAMMING_MISTAKE)
+    eigen_assert(index + kPacketSize <= dimensions().TotalSize());
+
+    // Find the effective inner-most dimension where padding actually happens.
+    // NOTE: This is independent of index argument, and can be done in the
+    // constructor to save computation. However, if packet access does not
+    // happen, then moving to constructor will incur needless overhead.
+    int dim = -1;
+    if (static_cast<int>(Layout) == static_cast<int>(ColMajor)) {
+      for (int k = 0; k < Dims; ++k) {
+        if (padding_[k].first != 0 || padding_[k].second != 0) {
+          dim = k;
+          break;
+        }
+      }
+    } else {
+      for (int k = Dims - 1; k >= 0; --k) {
+        if (padding_[k].first != 0 || padding_[k].second != 0) {
+          dim = k;
+          break;
+        }
+      }
+    }
+
+    const Index input_index = ToInputIndex(index);
+
+    // If dim < 0, this means there is no padding at all.
+    if (dim < 0) {
+      return impl_.template packet<Unaligned>(input_index);
+    }
+
+    // Check if the way from the begin of the packet to the end of the packet
+    // is paved with contiguous road. That is, the indices must be between the
+    // padded region in the effective inner-most dimension.
+    const Index left = padding_[dim].first * output_strides_[dim];
+    const Index right =
+        (dimensions_[dim] - padding_[dim].second) * output_strides_[dim];
+
+    const Index index_mod = index % (dimensions_[dim] * output_strides_[dim]);
+    if (left <= index_mod && (index_mod + kPacketSize - 1) < right) {
+      return impl_.template packet<Unaligned>(input_index);
+    }
+
+    // If the road is not contiguous, then fall back to coeff().
+    EIGEN_ALIGN_MAX std::remove_const_t<CoeffReturnType> values[kPacketSize];
+    values[0] = impl_.coeff(input_index);
+    for (int i = 1; i < kPacketSize; ++i) {
+      values[i] = coeff(index + i);
+    }
+    PacketReturnType result = internal::pload<PacketReturnType>(values);
+    return result;
+  }
+
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE TensorOpCost
+  costPerCoeff(bool vectorized) const {
+    constexpr int kPacketSize =
+        internal::unpacket_traits<PacketReturnType>::size;
+
+    const double compute_cost = Dims * (7 * TensorOpCost::AddCost<Index>() +
+                                        2 * TensorOpCost::MulCost<Index>() +
+                                        TensorOpCost::DivCost<Index>());
+    return impl_.costPerCoeff(vectorized) +
+           TensorOpCost(1, 0, compute_cost, vectorized, kPacketSize);
+  }
+
+  EIGEN_DEVICE_FUNC Scalar* data() const { return nullptr; }
+
+ protected:
+  using Coords = array<Index, Dims>;
+
+  // Full template specialization is not allowed within non-fully specialized
+  // template class. Adding a dummy parameter to make specializations partial.
+  template <bool CoordAccess, bool dummy = true>
+  struct ReadInputHelper;
+
+  template <bool dummy>
+  struct ReadInputHelper<false, dummy> {
+    template <typename Eval>
+    EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE Index
+    operator()(const Coords& coord, const Coords& strides, const Eval& eval) {
+      Index index = 0;
+      for (int k = 0; k < Dims; ++k) {
+        index += coord[k] * strides[k];
+      }
+      return eval.coeff(index);
+    }
+  };
+
+  template <bool dummy>
+  struct ReadInputHelper<true, dummy> {
+    template <typename Eval>
+    EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE Index
+    operator()(const Coords& coord, const Coords& strides, const Eval& eval) {
+      return eval.coeff(coord);
+    }
+  };
+
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE Index ToInputCoord(Index k,
+                                                           int dim) const {
+    const Index m = impl_.dimensions()[dim];
+    k -= padding_[dim].first;
+    if (k < 0) {
+      return m + k;
+    }
+    if (k < m) {
+      return k;
+    }
+    return k - m;
+  }
+
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Index
+  ToInputIndex(const Coords& coords) const {
+    Index input_index = 0;
+    for (int dim = 0; dim < Dims; ++dim) {
+      input_index += ToInputCoord(coords[dim], dim) * input_strides_[dim];
+    }
+    return input_index;
+  }
+
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Index ToInputIndex(Index index) const {
+    Index input_index = 0;
+    if (static_cast<int>(Layout) == static_cast<int>(ColMajor)) {
+      for (int dim = Dims - 1; dim > 0; --dim) {
+        const Index k = index / output_strides_[dim];
+        index -= k * output_strides_[dim];
+        input_index += ToInputCoord(k, dim) * input_strides_[dim];
+      }
+      input_index += ToInputCoord(index, 0);
+    } else {
+      for (int dim = 0; dim < Dims - 1; ++dim) {
+        const Index k = index / output_strides_[dim];
+        index -= k * output_strides_[dim];
+        input_index += ToInputCoord(k, dim) * input_strides_[dim];
+      }
+      input_index += ToInputCoord(index, Dims - 1);
+    }
+
+    return input_index;
+  }
+
+  TensorEvaluator<ArgType, Device> impl_;
+  PaddingDimensions padding_;
+  Dimensions dimensions_;
+  array<Index, Dims> input_strides_;
+  array<Index, Dims> output_strides_;
+};
+}  // namespace Eigen
+
+namespace tensorflow {
+namespace functor {
+
+template <typename Device, typename T, typename Tpaddings, int Dims>
+struct WrapPad {
+  void operator()(const Device& device,
+                  typename TTypes<T, Dims, int32>::Tensor output,
+                  typename TTypes<T, Dims, int32>::ConstTensor input,
+                  typename TTypes<Tpaddings>::ConstMatrix padding) {
+    Eigen::array<Eigen::IndexPair<int32>, Dims> padding_dims;
+
+    for (int i = 0; i < Dims; ++i) {
+      padding_dims[i] = Eigen::IndexPair<int32>(padding(i, 0), padding(i, 1));
+    }
+
+    output.device(device) = WrapPadOp(input, padding_dims);
+  }
+
+  template <typename PaddingDimensions, typename Derived>
+  static const Eigen::TensorWrapPadOp<PaddingDimensions, const Derived>
+  WrapPadOp(const Eigen::TensorBase<Derived, Eigen::ReadOnlyAccessors>& tensor,
+            const PaddingDimensions& padding) {
+    return Eigen::TensorWrapPadOp<PaddingDimensions, const Derived>(
+        static_cast<const Derived&>(tensor), padding);
+  }
+};
+
+template <typename Device, typename T, typename Tpaddings, int Dims>
+struct WrapPadGrad {
+  void operator()(const Device& device,
+                  typename TTypes<T, Dims, int32>::Tensor output,
+                  typename TTypes<T, Dims, int32>::ConstTensor input,
+                  typename TTypes<Tpaddings>::ConstMatrix paddings,
+                  typename TTypes<T, Dims, int32>::Tensor scratch) {
+    // Copy the gradient input into the scratch buffer.
+    scratch.device(device) = input;
+
+    Eigen::array<int32, Dims> lhs_offsets;
+    Eigen::array<int32, Dims> rhs_offsets;
+    Eigen::array<int32, Dims> extents;
+
+    for (int i = 0; i < Dims; ++i) {
+      lhs_offsets[i] = 0;
+      rhs_offsets[i] = 0;
+      extents[i] = scratch.dimension(i);
+    }
+
+    // At this point, the central part (non-padded area) does not include the
+    // gradients back-propagated through padded areas. Those gradient components
+    // need be added to the central part.
+    //
+    // Note that a gradient input element falls into a padded area iff in at
+    // least one dimension i, the coordinate x(i) is in the range (python-style)
+    // [:paddings(i,0)] or [-paddings(i,1):].
+
+    for (int i = 0; i < Dims; ++i) {
+      // This handles the case when coordinate in dimension i is in the range
+      // [:paddings(i,0)]. This portion is added to the range
+      // [-paddings(i,0) - paddings(i,1) + 1:-paddings(i,1) + 1].
+      if (paddings(i, 0) > 0) {
+        rhs_offsets[i] = 0;
+        lhs_offsets[i] = scratch.dimension(i) - paddings(i, 0) - paddings(i, 1);
+        extents[i] = paddings(i, 0);
+
+        scratch.slice(lhs_offsets, extents).device(device) +=
+            scratch.slice(rhs_offsets, extents);
+      }
+
+      // This handles the case when coordinate in dimension i is in the range
+      // [-paddings(i,1):]. This portion is added to the range
+      // [paddings(i,0):paddings(i,0) + paddings(i,1)].
+      if (paddings(i, 1) > 0) {
+        rhs_offsets[i] = scratch.dimension(i) - paddings(i, 1);
+        lhs_offsets[i] = paddings(i, 0);
+        extents[i] = paddings(i, 1);
+
+        scratch.slice(lhs_offsets, extents).device(device) +=
+            scratch.slice(rhs_offsets, extents);
+      }
+
+      lhs_offsets[i] = paddings(i, 0);
+      rhs_offsets[i] = paddings(i, 0);
+      extents[i] = output.dimension(i);
+
+      // At this point, scratch buffer contains gradient input as if paddings
+      // for dimension k = 0,...,i are zeros. Therefore after the loop
+      // termination, the central part of the scratch buffer contains the
+      // wrapped gradients.
+    }
+
+    // Copy the central part of the scratch buffer to the output.
+    output.device(device) = scratch.slice(rhs_offsets, extents);
+  }
+};
+
+}  // namespace functor
+}  // namespace tensorflow
+
+#endif  // TESNORFLOW_CORE_KERNELS_WRAP_PAD_OP_H_

--- a/tensorflow/core/kernels/wrap_pad_op_benchmark_test.cc
+++ b/tensorflow/core/kernels/wrap_pad_op_benchmark_test.cc
@@ -1,0 +1,56 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/common_runtime/kernel_benchmark_testlib.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/graph/node_builder.h"
+#include "tensorflow/core/platform/test.h"
+#include "tensorflow/core/platform/test_benchmark.h"
+
+namespace tensorflow {
+
+static Graph* WrapPad(int batches, int height, int width, int depth, int pad) {
+  Graph* g = new Graph(OpRegistry::Global());
+  Tensor in(DT_FLOAT, TensorShape({batches, height, width, depth}));
+  in.flat<float>().setRandom();
+  Tensor padding(DT_INT32, TensorShape({4, 2}));
+  auto boxes_tensor = padding.flat<int>().setZero();
+  for (int i = 2; i < 6; i++) boxes_tensor(i) = pad;
+
+  Node* ret;
+  TF_CHECK_OK(NodeBuilder(g->NewName("n"), "WrapPad")
+                  .Input(test::graph::Constant(g, in))
+                  .Input(test::graph::Constant(g, padding))
+                  .Finalize(g, &ret));
+  return g;
+}
+
+#define BM_WrapPadDev(DEVICE, B, W, H, D, P)                       \
+  static void BM_WrapPad_##DEVICE##_##B##_##W##_##H##_##D##_##P(   \
+      ::testing::benchmark::State& state) {                        \
+    test::Benchmark(#DEVICE, WrapPad(B, W, H, D, P),               \
+                    /*old_benchmark_api*/ false)                   \
+        .Run(state);                                               \
+    state.SetItemsProcessed(state.iterations() * B * (W + 2 * P) * \
+                            (H + 2 * P) * D / 32);                 \
+  }                                                                \
+  BENCHMARK(BM_WrapPad_##DEVICE##_##B##_##W##_##H##_##D##_##P);
+
+BM_WrapPadDev(cpu, 1, 16, 16, 32, 1);
+BM_WrapPadDev(cpu, 1, 16, 16, 32, 8);
+BM_WrapPadDev(cpu, 1, 512, 512, 16, 1);
+BM_WrapPadDev(cpu, 1, 512, 512, 16, 256);
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/wrap_pad_op_cpu_impl.h
+++ b/tensorflow/core/kernels/wrap_pad_op_cpu_impl.h
@@ -1,0 +1,47 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_WRAP_PAD_OP_CPU_IMPL_H_
+#define TENSORFLOW_CORE_KERNELS_WRAP_PAD_OP_CPU_IMPL_H_
+
+#if CPU_PROVIDED_IXDIM
+#define EIGEN_USE_THREADS
+
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/kernels/wrap_pad_op.h"
+
+namespace tensorflow {
+
+using CpuDevice = Eigen::ThreadPoolDevice;
+
+#define DEFINE_CPU_SPECS(T)                                                  \
+  template struct functor::WrapPad<CpuDevice, T, int32, CPU_PROVIDED_IXDIM>; \
+  template struct functor::WrapPad<CpuDevice, T, int64_t, CPU_PROVIDED_IXDIM>;
+TF_CALL_POD_TYPES(DEFINE_CPU_SPECS);
+TF_CALL_QUANTIZED_TYPES(DEFINE_CPU_SPECS);
+TF_CALL_tstring(DEFINE_CPU_SPECS);
+#undef DEFINE_CPU_SPECS
+
+#define DEFINE_CPU_SPECS(T)                                   \
+  template struct functor::WrapPadGrad<CpuDevice, T, int32,   \
+                                       CPU_PROVIDED_IXDIM>;   \
+  template struct functor::WrapPadGrad<CpuDevice, T, int64_t, \
+                                       CPU_PROVIDED_IXDIM>;
+TF_CALL_NUMBER_TYPES(DEFINE_CPU_SPECS);
+#undef DEFINE_CPU_SPECS
+}  // namespace tensorflow
+
+#endif  // CPU_PROVIDED_IXDIM
+#endif  // TENSORFLOW_CORE_KERNELS_WRAP_PAD_OP_CPU_IMPL_H_

--- a/tensorflow/core/kernels/wrap_pad_op_cpu_impl_1.cc
+++ b/tensorflow/core/kernels/wrap_pad_op_cpu_impl_1.cc
@@ -1,0 +1,18 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#define CPU_PROVIDED_IXDIM 1
+#include "tensorflow/core/kernels/wrap_pad_op_cpu_impl.h"
+#undef CPU_PROVIDED_IXDIM

--- a/tensorflow/core/kernels/wrap_pad_op_cpu_impl_2.cc
+++ b/tensorflow/core/kernels/wrap_pad_op_cpu_impl_2.cc
@@ -1,0 +1,18 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#define CPU_PROVIDED_IXDIM 2
+#include "tensorflow/core/kernels/wrap_pad_op_cpu_impl.h"
+#undef CPU_PROVIDED_IXDIM

--- a/tensorflow/core/kernels/wrap_pad_op_cpu_impl_3.cc
+++ b/tensorflow/core/kernels/wrap_pad_op_cpu_impl_3.cc
@@ -1,0 +1,18 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#define CPU_PROVIDED_IXDIM 3
+#include "tensorflow/core/kernels/wrap_pad_op_cpu_impl.h"
+#undef CPU_PROVIDED_IXDIM

--- a/tensorflow/core/kernels/wrap_pad_op_cpu_impl_4.cc
+++ b/tensorflow/core/kernels/wrap_pad_op_cpu_impl_4.cc
@@ -1,0 +1,18 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#define CPU_PROVIDED_IXDIM 4
+#include "tensorflow/core/kernels/wrap_pad_op_cpu_impl.h"
+#undef CPU_PROVIDED_IXDIM

--- a/tensorflow/core/kernels/wrap_pad_op_cpu_impl_5.cc
+++ b/tensorflow/core/kernels/wrap_pad_op_cpu_impl_5.cc
@@ -1,0 +1,18 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#define CPU_PROVIDED_IXDIM 5
+#include "tensorflow/core/kernels/wrap_pad_op_cpu_impl.h"
+#undef CPU_PROVIDED_IXDIM

--- a/tensorflow/core/kernels/wrap_pad_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/wrap_pad_op_gpu.cu.cc
@@ -1,0 +1,54 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/kernels/wrap_pad_op.h"
+
+namespace tensorflow {
+
+using GpuDevice = Eigen::GpuDevice;
+
+#define DEFINE_GPU_SPECS(T)                                     \
+  template struct functor::WrapPad<GpuDevice, T, int32, 1>;     \
+  template struct functor::WrapPad<GpuDevice, T, int32, 2>;     \
+  template struct functor::WrapPad<GpuDevice, T, int32, 3>;     \
+  template struct functor::WrapPad<GpuDevice, T, int32, 4>;     \
+  template struct functor::WrapPad<GpuDevice, T, int32, 5>;     \
+  template struct functor::WrapPad<GpuDevice, T, int64, 1>;     \
+  template struct functor::WrapPad<GpuDevice, T, int64, 2>;     \
+  template struct functor::WrapPad<GpuDevice, T, int64, 3>;     \
+  template struct functor::WrapPad<GpuDevice, T, int64, 4>;     \
+  template struct functor::WrapPad<GpuDevice, T, int64, 5>;     \
+  template struct functor::WrapPadGrad<GpuDevice, T, int32, 1>; \
+  template struct functor::WrapPadGrad<GpuDevice, T, int32, 2>; \
+  template struct functor::WrapPadGrad<GpuDevice, T, int32, 3>; \
+  template struct functor::WrapPadGrad<GpuDevice, T, int32, 4>; \
+  template struct functor::WrapPadGrad<GpuDevice, T, int32, 5>; \
+  template struct functor::WrapPadGrad<GpuDevice, T, int64, 1>; \
+  template struct functor::WrapPadGrad<GpuDevice, T, int64, 2>; \
+  template struct functor::WrapPadGrad<GpuDevice, T, int64, 3>; \
+  template struct functor::WrapPadGrad<GpuDevice, T, int64, 4>; \
+  template struct functor::WrapPadGrad<GpuDevice, T, int64, 5>;
+
+TF_CALL_GPU_NUMBER_TYPES(DEFINE_GPU_SPECS);
+#undef DEFINE_GPU_SPECS
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/wrap_pad_op_test.cc
+++ b/tensorflow/core/kernels/wrap_pad_op_test.cc
@@ -1,0 +1,145 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/allocator.h"
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_testutil.h"
+#include "tensorflow/core/framework/tensor_util.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/kernels/ops_util.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/lib/strings/str_util.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+
+class WrapPadOpTest : public OpsTestBase {
+ protected:
+  template <typename T>
+  void MakeOp() {
+    TF_EXPECT_OK(NodeDefBuilder("wrap_pad_op", "WrapPad")
+                     .Input(FakeInput(DataTypeToEnum<T>::value))
+                     .Input(FakeInput(DT_INT32))
+                     .Finalize(node_def()));
+    TF_EXPECT_OK(InitOp());
+  }
+};
+
+#define REGISTER_TEST(T)                                                     \
+  TEST_F(WrapPadOpTest, TestWrapPad##T) {                                    \
+    MakeOp<T>();                                                             \
+    AddInputFromArray<T>(TensorShape({1, 2, 3, 1}), {1, 2, 3, 4, 5, 6});     \
+    AddInputFromArray<int32>(TensorShape({4, 2}), {0, 0, 1, 1, 2, 2, 0, 0}); \
+    TF_ASSERT_OK(RunOpKernel());                                             \
+                                                                             \
+    Tensor expected(allocator(), DataTypeToEnum<T>::value,                   \
+                    TensorShape({1, 4, 7, 1}));                              \
+    test::FillValues<T>(&expected,                                           \
+                        {5, 6, 4, 5, 6, 4, 5, 2, 3, 1, 2, 3, 1, 2,           \
+                         5, 6, 4, 5, 6, 4, 5, 2, 3, 1, 2, 3, 1, 2});         \
+    test::ExpectTensorEqual<T>(expected, *GetOutput(0));                     \
+  }
+
+REGISTER_TEST(float)
+REGISTER_TEST(double)
+REGISTER_TEST(quint8)
+REGISTER_TEST(qint8)
+REGISTER_TEST(qint32)
+REGISTER_TEST(uint8)
+REGISTER_TEST(uint16)
+REGISTER_TEST(int8)
+REGISTER_TEST(int16)
+REGISTER_TEST(int32)
+REGISTER_TEST(int64_t)
+
+#undef REGISTER_TEST
+
+TEST_F(WrapPadOpTest, TestWrapPadLargeInput) {
+  MakeOp<float>();
+  // Generate a relatively large input
+  const int kInput = 1000;
+  const int kPad = 10;
+  const int kOutput = kInput + 2 * kPad;
+
+  // Input:
+  //  0, 1, 2, ..., 999
+  //  0, 1, 2, ..., 999
+  //  ... (altogether 1000 lines)
+  //  0, 1, 2, ..., 999
+  AddInput<float>(TensorShape({1, kInput, kInput, 1}),
+                  [=](int i) -> float { return i % kInput; });
+  AddInputFromArray<int32>(TensorShape({4, 2}),
+                           {0, 0, kPad, kPad, kPad, kPad, 0, 0});
+  TF_ASSERT_OK(RunOpKernel());
+
+  Tensor expected(allocator(), DT_FLOAT, TensorShape({1, kOutput, kOutput, 1}));
+  test::FillFn<float>(&expected, [=](int i) -> float {
+    i = i % kOutput;
+    if (0 <= i && i < kPad)
+      return kInput - kPad + i;
+    else if (kPad <= i && i < kInput + kPad)
+      return i - kPad;
+    else if (kInput + kPad <= i && i < kOutput)
+      return i - kInput - kPad;
+    else
+      return -1;
+  });
+
+  test::ExpectTensorEqual<float>(expected, *GetOutput(0));
+}
+
+class WrapPadGradOpTest : public OpsTestBase {
+ protected:
+  template <typename T>
+  void MakeOp() {
+    TF_EXPECT_OK(NodeDefBuilder("wrap_pad_grad_op", "WrapPadGrad")
+                     .Input(FakeInput(DataTypeToEnum<T>::value))
+                     .Input(FakeInput(DT_INT32))
+                     .Finalize(node_def()));
+    TF_EXPECT_OK(InitOp());
+  }
+};
+
+#define REGISTER_TEST(T)                                                      \
+  TEST_F(WrapPadGradOpTest, TestWrapPadGrad##T) {                             \
+    MakeOp<T>();                                                              \
+    AddInput<T>(TensorShape({1, 4, 7, 1}), [](int i) -> T { return i % 7; }); \
+    AddInputFromArray<int32>(TensorShape({4, 2}), {0, 0, 1, 1, 2, 2, 0, 0});  \
+    TF_ASSERT_OK(RunOpKernel());                                              \
+                                                                              \
+    Tensor expected(allocator(), DataTypeToEnum<T>::value,                    \
+                    TensorShape({1, 2, 3, 1}));                               \
+    test::FillValues<T>(&expected, {14, 18, 10, 14, 18, 10});                 \
+    test::ExpectTensorEqual<T>(expected, *GetOutput(0));                      \
+  }
+
+REGISTER_TEST(float)
+REGISTER_TEST(double)
+REGISTER_TEST(uint8)
+REGISTER_TEST(uint16)
+REGISTER_TEST(int8)
+REGISTER_TEST(int16)
+REGISTER_TEST(int32)
+REGISTER_TEST(int64_t)
+
+#undef REGISTER_TEST
+
+}  // namespace tensorflow

--- a/tensorflow/core/ops/array_ops_test.cc
+++ b/tensorflow/core/ops/array_ops_test.cc
@@ -501,7 +501,7 @@ TEST(ArrayOpsTest, InvertPermutation_ShapeFn) {
 }
 
 TEST(ArrayOpsTest, PadD_ShapeFn) {
-  for (const char* op_name : {"Pad", "MirrorPad"}) {
+  for (const char* op_name : {"Pad", "MirrorPad", "WrapPad"}) {
     ShapeInferenceTestOp op(op_name);
     op.input_tensors.resize(2);
 
@@ -562,36 +562,38 @@ TEST(ArrayOpsTest, PadV2_ShapeFn) {
   INFER_OK(op, "?;?;[]", "[?,?,?]");
 }
 
-TEST(ArrayOpsTest, MirrorPadGrad_ShapeFn) {
-  ShapeInferenceTestOp op("MirrorPadGrad");
-  op.input_tensors.resize(2);
+TEST(ArrayOpsTest, PadGrad_ShapeFn) {
+  for (const char* op_name : {"MirrorPadGrad", "WrapPadGrad"}) {
+    ShapeInferenceTestOp op(op_name);
+    op.input_tensors.resize(2);
 
-  // Inputs are input and paddings.
-  INFER_OK(op, "?;?", "?");
+    // Inputs are input and paddings.
+    INFER_OK(op, "?;?", "?");
 
-  // First padding dimension is unknown, so rank is unknown.
-  INFER_OK(op, "?;[?,4]", "?");
+    // First padding dimension is unknown, so rank is unknown.
+    INFER_OK(op, "?;[?,4]", "?");
 
-  // Input tensor rank doesn't match paddings dimension.
-  INFER_ERROR("must be rank 3 but is rank 2", op, "[?,?];[3,2]");
+    // Input tensor rank doesn't match paddings dimension.
+    INFER_ERROR("must be rank 3 but is rank 2", op, "[?,?];[3,2]");
 
-  // Paddings tensor is not a [rank x 2] matrix.
-  INFER_ERROR("Dimension 1 in both shapes must be equal, but are 3 and 2", op,
-              "[?,?,?];[3,3]");
+    // Paddings tensor is not a [rank x 2] matrix.
+    INFER_ERROR("Dimension 1 in both shapes must be equal, but are 3 and 2", op,
+                "[?,?,?];[3,3]");
 
-  // Paddings tensor is unknown, but rank is known, so the output
-  // shape is a rank 3 unknown shape.
-  INFER_OK(op, "[?,?,?];[3,2]", "[?,?,?]");
+    // Paddings tensor is unknown, but rank is known, so the output
+    // shape is a rank 3 unknown shape.
+    INFER_OK(op, "[?,?,?];[3,2]", "[?,?,?]");
 
-  // Make the paddings tensor known and verify padding values get
-  // subtracted.  E.g., if padding is ((1,10),(2,20),(3,30)) then
-  // values 11,22,23 are subtracted to input dims to get output.
-  Tensor paddings_t(DT_INT64, TensorShape{3, 2});
-  test::FillValues<int64_t>(&paddings_t, {1, 10, 2, 20, 3, 30});
-  op.input_tensors[1] = &paddings_t;
+    // Make the paddings tensor known and verify padding values get
+    // subtracted.  E.g., if padding is ((1,10),(2,20),(3,30)) then
+    // values 11,22,23 are subtracted to input dims to get output.
+    Tensor paddings_t(DT_INT64, TensorShape{3, 2});
+    test::FillValues<int64_t>(&paddings_t, {1, 10, 2, 20, 3, 30});
+    op.input_tensors[1] = &paddings_t;
 
-  INFER_OK(op, "[111,222,333];[3,2]", "[100,200,300]");
-  INFER_OK(op, "[111,?,333];[3,2]", "[100,?,300]");
+    INFER_OK(op, "[111,222,333];[3,2]", "[100,200,300]");
+    INFER_OK(op, "[111,?,333];[3,2]", "[100,?,300]");
+  }
 }
 
 TEST(ArrayOpsTest, BroadcastArgs_ShapeFn) {

--- a/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/array_ops_test.py
@@ -1682,6 +1682,19 @@ class PadTest(test_util.TensorFlowTestCase):
     result = gen_array_ops.mirror_pad_grad(t, paddings, "REFLECT")
     self.assertAllEqual(result, expected)
 
+  def testWrapPadGrad(self):
+    t = np.broadcast_to(np.reshape(np.arange(0, 7), (7, 1)), (1, 4, 7, 1))
+    paddings = constant_op.constant([
+        [0, 0],
+        [1, 1],
+        [2, 2],
+        [0, 0],
+    ])
+    expected = np.broadcast_to(
+        np.reshape(np.array([14, 18, 10]), (3, 1)), (1, 2, 3, 1))
+    result = gen_array_ops.wrap_pad_grad(t, paddings)
+    self.assertAllEqual(result, expected)
+
 
 class InvertPermutationTest(test_util.TensorFlowTestCase):
 

--- a/tensorflow/python/ops/array_grad.py
+++ b/tensorflow/python/ops/array_grad.py
@@ -1034,6 +1034,14 @@ def _MirrorPadGradGrad(op: ops.Operation, grad):
   mode = op.get_attr("mode")
   return [gen_array_ops.mirror_pad(grad, op.inputs[1], mode=mode), None]
 
+@ops.RegisterGradient("WrapPad")
+def _WrapPadGrad(op: ops.Operation, grad):
+  return [gen_array_ops.wrap_pad_grad(grad, op.inputs[1]), None]
+
+@ops.RegisterGradient("WrapPadGrad")
+def _WrapPadGradGrad(op: ops.Operation, grad):
+  return [gen_array_ops.wrap_pad(grad, op.inputs[1]), None]
+
 
 ops.NotDifferentiable("FakeQuantWithMinMaxArgsGradient")
 ops.NotDifferentiable("FakeQuantWithMinMaxVarsGradient")

--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -2577,6 +2577,14 @@ tf_module {
     argspec: "args=[\'fn\', \'signature\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "wrap_pad"
+    argspec: "args=[\'input\', \'paddings\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "wrap_pad_grad"
+    argspec: "args=[\'input\', \'paddings\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "write_file"
     argspec: "args=[\'filename\', \'contents\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }

--- a/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.raw_ops.pbtxt
@@ -5665,6 +5665,14 @@ tf_module {
     argspec: "args=[\'input_handle\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "WrapPad"
+    argspec: "args=[\'input\', \'paddings\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "WrapPadGrad"
+    argspec: "args=[\'input\', \'paddings\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "WriteAudioSummary"
     argspec: "args=[\'writer\', \'step\', \'tag\', \'tensor\', \'sample_rate\', \'max_outputs\', \'name\'], varargs=None, keywords=None, defaults=[\'3\', \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.pbtxt
@@ -1205,6 +1205,14 @@ tf_module {
     argspec: "args=[\'cond\', \'body\', \'loop_vars\', \'shape_invariants\', \'parallel_iterations\', \'back_prop\', \'swap_memory\', \'maximum_iterations\', \'name\'], varargs=None, keywords=None, defaults=[\'None\', \'10\', \'True\', \'False\', \'None\', \'None\'], "
   }
   member_method {
+    name: "wrap_pad"
+    argspec: "args=[\'input\', \'paddings\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "wrap_pad_grad"
+    argspec: "args=[\'input\', \'paddings\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "zeros"
     argspec: "args=[\'shape\', \'dtype\', \'name\', \'layout\'], varargs=None, keywords=None, defaults=[\"<dtype: \'float32\'>\", \'None\', \'None\'], "
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.raw_ops.pbtxt
@@ -5665,6 +5665,14 @@ tf_module {
     argspec: "args=[\'input_handle\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
   }
   member_method {
+    name: "WrapPad"
+    argspec: "args=[\'input\', \'paddings\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
+    name: "WrapPadGrad"
+    argspec: "args=[\'input\', \'paddings\', \'name\'], varargs=None, keywords=None, defaults=[\'None\'], "
+  }
+  member_method {
     name: "WriteAudioSummary"
     argspec: "args=[\'writer\', \'step\', \'tag\', \'tensor\', \'sample_rate\', \'max_outputs\', \'name\'], varargs=None, keywords=None, defaults=[\'3\', \'None\'], "
   }


### PR DESCRIPTION
Relates to #57672 

I've added wrap padding as an option to the pad function. Much of the code I carried over from the `MirrorPad` op. The main difference between the two implementations is the `ToInputCoord` function:

https://github.com/mattbahr/tensorflow/blob/4833ab97fc7cbdabef6be49d621084930800c4a8/tensorflow/core/kernels/wrap_pad_op.h#L273-L284

https://github.com/tensorflow/tensorflow/blob/3abf81fad44f809d6607165b0907d5dd1e0c8b46/tensorflow/core/kernels/image/mirror_pad_op.h#L284-L295

An alternative to this solution could be to update the `MirrorPad` op to handle WRAP mode on top of REFLECT and SYMMETRIC. This would eliminate the duplicated code and not require the maintenance of a brand new op, but I wasn't sure if that might be increasing the scope of that op beyond what it should be.

See the NumPy documentation for how padding should work in wrap mode: https://numpy.org/doc/stable/reference/generated/numpy.pad.html