### PR TITLE
Add ignore conditions to dependabot docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,12 +27,18 @@ updates:
     directory: /ci/devinfra/docker_windows
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: docker
     directory: /ci/official/containers/linux_arm64
     schedule:
       interval: monthly
-
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    
   - package-ecosystem: docker
     directory: /tensorflow/tools/gcs_test
     schedule:
@@ -42,3 +48,6 @@ updates:
     directory: /tensorflow/tools/tf_sig_build_dockerfiles
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
Dependabot is currently suggesting upgrades that can not be auto upgraded, including major versions to operating system and updates to CUDA versions.  

Restrict docker file updates to patch by ignoring semvar major and minor updates

For reference:
https://github.com/tensorflow/tensorflow/pull/70377#pullrequestreview-2142011405
https://github.com/tensorflow/tensorflow/pull/70379#pullrequestreview-2142011234