### PR TITLE
Fix issues with TF GCS operations not working in certain environments.

### DIFF
--- a/third_party/xla/third_party/tsl/tsl/platform/cloud/gcs_file_system.cc
+++ b/third_party/xla/third_party/tsl/tsl/platform/cloud/gcs_file_system.cc
@@ -66,10 +66,10 @@ limitations under the License.
 
 namespace tsl {
 namespace {
-constexpr char kGcsUriBase[] = "https://www.googleapis.com./storage/v1/";
+constexpr char kGcsUriBase[] = "https://www.googleapis.com/storage/v1/";
 constexpr char kGcsUploadUriBase[] =
-    "https://www.googleapis.com./upload/storage/v1/";
-constexpr char kStorageHost[] = "storage.googleapis.com.";
+    "https://www.googleapis.com/upload/storage/v1/";
+constexpr char kStorageHost[] = "storage.googleapis.com";
 constexpr char kBucketMetadataLocationKey[] = "location";
 constexpr size_t kReadAppendableFileBufferSize = 1024 * 1024;  // In bytes.
 constexpr int kGetChildrenDefaultPageSize = 1000;

--- a/third_party/xla/third_party/tsl/tsl/platform/cloud/gcs_file_system_test.cc
+++ b/third_party/xla/third_party/tsl/tsl/platform/cloud/gcs_file_system_test.cc
@@ -62,13 +62,13 @@ class FakeZoneProvider : public ZoneProvider {
 TEST(GcsFileSystemTest, NewRandomAccessFile_NoBlockCache) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-5\n"
            "Timeouts: 5 1 20\n",
            "012345"),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 6-11\n"
            "Timeouts: 5 1 20\n",
@@ -108,13 +108,13 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_NoBlockCache) {
 TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered) {
   std::vector<HttpRequest*> requests({
       new FakeHttpRequest(
-          "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+          "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
           "Auth Token: fake_token\n"
           "Range: 0-9\n"
           "Timeouts: 5 1 20\n",
           "0123456789"),
       new FakeHttpRequest(
-          "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+          "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
           "Auth Token: fake_token\n"
           "Range: 10-19\n"
           "Timeouts: 5 1 20\n",
@@ -155,14 +155,14 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered) {
 TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_Errors) {
   std::vector<HttpRequest*> requests({
       new FakeHttpRequest(
-          "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+          "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
           "Auth Token: fake_token\n"
           "Range: 0-9\n"
           "Timeouts: 5 1 20\n",
           "Server Not", errors::Unavailable("important HTTP error 308"),
           nullptr, {}, 308),
       new FakeHttpRequest(
-          "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+          "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
           "Auth Token: fake_token\n"
           "Range: 6-15\n"
           "Timeouts: 5 1 20\n",
@@ -204,13 +204,13 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_Errors) {
 TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_ReadAtEOF) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-9\n"
            "Timeouts: 5 1 20\n",
            "0123456789"),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 10-19\n"
            "Timeouts: 5 1 20\n",
@@ -251,7 +251,7 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_CachedOutOfRange) {
   // In this test, there is only one backend request since we cache the file
   // size.
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+      "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
       "Auth Token: fake_token\n"
       "Range: 0-9\n"
       "Timeouts: 5 1 20\n",
@@ -297,13 +297,13 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_CachedNotSequential) {
   // a backend request.
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 1-10\n"
            "Timeouts: 5 1 20\n",
            "12345678"),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-9\n"
            "Timeouts: 5 1 20\n",
@@ -339,13 +339,13 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_CachedNotSequential) {
 TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_Growing) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-9\n"
            "Timeouts: 5 1 20\n",
            "012345678"),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 9-18\n"
            "Timeouts: 5 1 20\n",
@@ -387,13 +387,13 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_ReadBackwards) {
   // Go backwards in the file. It should trigger a new read.
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 5-14\n"
            "Timeouts: 5 1 20\n",
            "56789"),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-9\n"
            "Timeouts: 5 1 20\n",
@@ -433,7 +433,7 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_Buffered_ReadBackwards) {
 TEST(GcsFileSystemTest,
      NewRandomAccessFile_WithLocationConstraintInSameLocation) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket\n"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
       R"(
@@ -460,7 +460,7 @@ TEST(GcsFileSystemTest,
 TEST(GcsFileSystemTest, NewRandomAccessFile_WithLocationConstraintCaching) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket\n"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            R"(
@@ -468,7 +468,7 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_WithLocationConstraintCaching) {
             "location":"US-EAST1"
           })"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/anotherbucket\n"
+           "Uri: https://www.googleapis.com/storage/v1/b/anotherbucket\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            R"(
@@ -476,7 +476,7 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_WithLocationConstraintCaching) {
             "location":"US-EAST1"
           })"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket\n"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            R"(
@@ -517,7 +517,7 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_WithLocationConstraintCaching) {
 TEST(GcsFileSystemTest,
      NewRandomAccessFile_WithLocationConstraintInDifferentLocation) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket\n"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
       R"(
@@ -547,13 +547,13 @@ TEST(GcsFileSystemTest,
 TEST(GcsFileSystemTest, NewRandomAccessFile_NoBlockCache_DifferentN) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-2\n"
            "Timeouts: 5 1 20\n",
            "012"),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 3-12\n"
            "Timeouts: 5 1 20\n",
@@ -593,26 +593,26 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_WithBlockCache) {
   // "0123456789abcde".
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "random_access.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"15\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-8\n"
            "Timeouts: 5 1 20\n",
            "012345678"),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 9-17\n"
            "Timeouts: 5 1 20\n",
            "9abcde"),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 18-26\n"
            "Timeouts: 5 1 20\n",
@@ -679,27 +679,27 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_WithBlockCache_Flush) {
   // "0123456789abcde".
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "random_access.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"15\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-8\n"
            "Timeouts: 5 1 20\n",
            "012345678"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "random_access.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"15\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-8\n"
            "Timeouts: 5 1 20\n",
@@ -738,24 +738,22 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_WithBlockCache_MaxStaleness) {
   // "0123456789abcdef".
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "object?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"16\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
-       new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/object\n"
-           "Auth Token: fake_token\n"
-           "Range: 0-7\n"
-           "Timeouts: 5 1 20\n",
-           "01234567"),
-       new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/object\n"
-           "Auth Token: fake_token\n"
-           "Range: 8-15\n"
-           "Timeouts: 5 1 20\n",
-           "89abcdef")});
+       new FakeHttpRequest("Uri: https://storage.googleapis.com/bucket/object\n"
+                           "Auth Token: fake_token\n"
+                           "Range: 0-7\n"
+                           "Timeouts: 5 1 20\n",
+                           "01234567"),
+       new FakeHttpRequest("Uri: https://storage.googleapis.com/bucket/object\n"
+                           "Auth Token: fake_token\n"
+                           "Range: 8-15\n"
+                           "Timeouts: 5 1 20\n",
+                           "89abcdef")});
   GcsFileSystem fs(
       std::unique_ptr<AuthProvider>(new FakeAuthProvider),
       std::unique_ptr<HttpRequest::Factory>(
@@ -802,27 +800,27 @@ TEST(GcsFileSystemTest,
      NewRandomAccessFile_WithBlockCache_FileSignatureChanges) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "random_access.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"5\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-8\n"
            "Timeouts: 5 1 20\n",
            "01234"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "random_access.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"5\",\"generation\": \"2\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-8\n"
            "Timeouts: 5 1 20\n",
@@ -876,14 +874,14 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_NoObjectName) {
 TEST(GcsFileSystemTest, NewRandomAccessFile_InconsistentRead) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "random_access.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"6\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-5\n"
            "Timeouts: 5 1 20\n",
@@ -919,20 +917,20 @@ TEST(GcsFileSystemTest, NewRandomAccessFile_InconsistentRead) {
 TEST(GcsFileSystemTest, NewWritableFile) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fwriteable?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"16\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Fwriteable\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Fwriteable\n"
            "Auth Token: fake_token\n"
            "Range: 0-7\n"
            "Timeouts: 5 1 20\n",
            "01234567"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
            "uploadType=resumable&name=path%2Fwriteable\n"
            "Auth Token: fake_token\n"
            "Header X-Upload-Content-Length: 17\n"
@@ -946,14 +944,14 @@ TEST(GcsFileSystemTest, NewWritableFile) {
                            "Put body: content1,content2\n",
                            ""),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fwriteable?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"33\",\"generation\": \"2\","
                            "\"updated\": \"2016-04-29T23:15:34.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Fwriteable\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Fwriteable\n"
            "Auth Token: fake_token\n"
            "Range: 0-7\n"
            "Timeouts: 5 1 20\n",
@@ -1000,7 +998,7 @@ TEST(GcsFileSystemTest, NewWritableFile) {
 TEST(GcsFileSystemTest, NewWritableFile_ResumeUploadSucceeds) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
            "uploadType=resumable&name=path%2Fwriteable.txt\n"
            "Auth Token: fake_token\n"
            "Header X-Upload-Content-Length: 17\n"
@@ -1078,20 +1076,20 @@ TEST(GcsFileSystemTest, NewWritableFile_ResumeUploadSucceedsOnGetStatus) {
   // path.
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fwriteable?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"16\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Fwriteable\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Fwriteable\n"
            "Auth Token: fake_token\n"
            "Range: 0-7\n"
            "Timeouts: 5 1 20\n",
            "01234567"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
            "uploadType=resumable&name=path%2Fwriteable\n"
            "Auth Token: fake_token\n"
            "Header X-Upload-Content-Length: 17\n"
@@ -1111,14 +1109,14 @@ TEST(GcsFileSystemTest, NewWritableFile_ResumeUploadSucceedsOnGetStatus) {
                            "Put: yes\n",
                            "", OkStatus(), nullptr, {}, 201),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fwriteable?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"33\",\"generation\": \"2\","
                            "\"updated\": \"2016-04-29T23:19:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Fwriteable\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Fwriteable\n"
            "Auth Token: fake_token\n"
            "Range: 0-7\n"
            "Timeouts: 5 1 20\n",
@@ -1165,7 +1163,7 @@ TEST(GcsFileSystemTest, NewWritableFile_ResumeUploadSucceedsOnGetStatus) {
 TEST(GcsFileSystemTest, NewWritableFile_ResumeUploadAllAttemptsFail) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
            "uploadType=resumable&name=path%2Fwriteable.txt\n"
            "Auth Token: fake_token\n"
            "Header X-Upload-Content-Length: 17\n"
@@ -1198,7 +1196,7 @@ TEST(GcsFileSystemTest, NewWritableFile_ResumeUploadAllAttemptsFail) {
   // These calls will be made in the Close() attempt from the destructor.
   // Letting the destructor succeed.
   requests.emplace_back(new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
       "uploadType=resumable&name=path%2Fwriteable.txt\n"
       "Auth Token: fake_token\n"
       "Header X-Upload-Content-Length: 17\n"
@@ -1247,7 +1245,7 @@ TEST(GcsFileSystemTest, NewWritableFile_UploadReturns410) {
 
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
            "uploadType=resumable&name=path%2Fwriteable.txt\n"
            "Auth Token: fake_token\n"
            "Header X-Upload-Content-Length: 17\n"
@@ -1264,7 +1262,7 @@ TEST(GcsFileSystemTest, NewWritableFile_UploadReturns410) {
        // These calls will be made in the Close() attempt from the destructor.
        // Letting the destructor succeed.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
            "uploadType=resumable&name=path%2Fwriteable.txt\n"
            "Auth Token: fake_token\n"
            "Header X-Upload-Content-Length: 17\n"
@@ -1336,26 +1334,26 @@ TEST(GcsFileSystemTest, NewWritableFile_NoObjectName) {
 TEST(GcsFileSystemTest, NewAppendableFile) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fappendable?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"8\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Fappendable\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Fappendable\n"
            "Auth Token: fake_token\n"
            "Range: 0-1048575\n"
            "Timeouts: 5 1 20\n",
            "content1,"),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Fappendable\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Fappendable\n"
            "Auth Token: fake_token\n"
            "Range: 0-31\n"
            "Timeouts: 5 1 20\n",
            "content1,"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
            "uploadType=resumable&name=path%2Fappendable\n"
            "Auth Token: fake_token\n"
            "Header X-Upload-Content-Length: 17\n"
@@ -1369,14 +1367,14 @@ TEST(GcsFileSystemTest, NewAppendableFile) {
                            "Put body: content1,content2\n",
                            ""),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fappendable?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"8\",\"generation\": \"2\","
                            "\"updated\": \"2016-04-29T23:25:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Fappendable\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Fappendable\n"
            "Auth Token: fake_token\n"
            "Range: 0-31\n"
            "Timeouts: 5 1 20\n",
@@ -1437,13 +1435,13 @@ TEST(GcsFileSystemTest, NewAppendableFile_NoObjectName) {
 TEST(GcsFileSystemTest, NewAppendableFile_ObjectDoesNotExist) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/filename\n"
+           "Uri: https://storage.googleapis.com/bucket/filename\n"
            "Auth Token: fake_token\n"
            "Range: 0-1048575\n"
            "Timeouts: 5 1 20\n",
            "", errors::NotFound("404"), 404),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o"
+           "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o"
            "?uploadType=resumable&name=filename\n"
            "Auth Token: fake_token\n"
            "Header X-Upload-Content-Length: 0\n"
@@ -1469,7 +1467,7 @@ TEST(GcsFileSystemTest, NewReadOnlyMemoryRegionFromFile) {
   const string content = "file content";
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Frandom_access.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -1477,7 +1475,7 @@ TEST(GcsFileSystemTest, NewReadOnlyMemoryRegionFromFile) {
                            ", \"generation\": \"1\"",
                            ", \"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           strings::StrCat("Uri: https://storage.googleapis.com./bucket/"
+           strings::StrCat("Uri: https://storage.googleapis.com/bucket/"
                            "path%2Frandom_access.txt\n"
                            "Auth Token: fake_token\n"
                            "Range: 0-",
@@ -1522,7 +1520,7 @@ TEST(GcsFileSystemTest, NewReadOnlyMemoryRegionFromFile_NoObjectName) {
 
 TEST(GcsFileSystemTest, FileExists_YesAsObject) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
       "path%2Ffile1.txt?fields=size%2Cgeneration%2Cupdated\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -1545,13 +1543,13 @@ TEST(GcsFileSystemTest, FileExists_YesAsObject) {
 TEST(GcsFileSystemTest, FileExists_YesAsFolder) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsubfolder?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "", errors::NotFound("404"), 404),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsubfolder%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -1575,12 +1573,12 @@ TEST(GcsFileSystemTest, FileExists_YesAsFolder) {
 TEST(GcsFileSystemTest, FileExists_YesAsBucket) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket1\n"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket1\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "{\"size\": \"100\"}"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket1\n"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket1\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "{\"size\": \"100\"}")});
@@ -1602,13 +1600,13 @@ TEST(GcsFileSystemTest, FileExists_YesAsBucket) {
 TEST(GcsFileSystemTest, FileExists_NotAsObjectOrFolder) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Ffile1.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "", errors::NotFound("404"), 404),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Ffile1.txt%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -1632,12 +1630,12 @@ TEST(GcsFileSystemTest, FileExists_NotAsObjectOrFolder) {
 TEST(GcsFileSystemTest, FileExists_NotAsBucket) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket2\n"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket2\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "", errors::NotFound("404"), 404),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket2\n"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket2\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "", errors::NotFound("404"), 404)});
@@ -1658,20 +1656,20 @@ TEST(GcsFileSystemTest, FileExists_NotAsBucket) {
 TEST(GcsFileSystemTest, FileExists_StatCache) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Ffile1.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"1010\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsubfolder%2F?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "", errors::NotFound("404"), 404),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsubfolder%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -1699,7 +1697,7 @@ TEST(GcsFileSystemTest, FileExists_StatCache) {
 
 TEST(GcsFileSystemTest, FileExists_DirectoryMark) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
       "dir%2F?fields=size%2Cgeneration%2Cupdated\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -1722,7 +1720,7 @@ TEST(GcsFileSystemTest, FileExists_DirectoryMark) {
 
 TEST(GcsFileSystemTest, GetChildren_NoItems) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2Cprefixes%2CnextPageToken&delimiter=%2F&prefix="
       "path%2F\n"
       "Auth Token: fake_token\n"
@@ -1747,7 +1745,7 @@ TEST(GcsFileSystemTest, GetChildren_NoItems) {
 
 TEST(GcsFileSystemTest, GetChildren_ThreeFiles) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2Cprefixes%2CnextPageToken&delimiter=%2F&prefix="
       "path%2F\n"
       "Auth Token: fake_token\n"
@@ -1776,7 +1774,7 @@ TEST(GcsFileSystemTest, GetChildren_ThreeFiles) {
 
 TEST(GcsFileSystemTest, GetChildren_SelfDirectoryMarker) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2Cprefixes%2CnextPageToken&delimiter=%2F&prefix="
       "path%2F\n"
       "Auth Token: fake_token\n"
@@ -1804,7 +1802,7 @@ TEST(GcsFileSystemTest, GetChildren_SelfDirectoryMarker) {
 
 TEST(GcsFileSystemTest, GetChildren_ThreeFiles_NoSlash) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2Cprefixes%2CnextPageToken&delimiter=%2F&prefix="
       "path%2F\n"
       "Auth Token: fake_token\n"
@@ -1833,7 +1831,7 @@ TEST(GcsFileSystemTest, GetChildren_ThreeFiles_NoSlash) {
 
 TEST(GcsFileSystemTest, GetChildren_Root) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket-a-b-c/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket-a-b-c/o?"
       "fields=items%2Fname%2Cprefixes%2CnextPageToken&delimiter=%2F\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -1857,7 +1855,7 @@ TEST(GcsFileSystemTest, GetChildren_Root) {
 
 TEST(GcsFileSystemTest, GetChildren_Empty) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2Cprefixes%2CnextPageToken&delimiter=%2F&prefix="
       "path%2F\n"
       "Auth Token: fake_token\n"
@@ -1883,7 +1881,7 @@ TEST(GcsFileSystemTest, GetChildren_Empty) {
 TEST(GcsFileSystemTest, GetChildren_Pagination) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2Cprefixes%2CnextPageToken&delimiter=%2F&"
            "prefix=path%2F\n"
            "Auth Token: fake_token\n"
@@ -1894,7 +1892,7 @@ TEST(GcsFileSystemTest, GetChildren_Pagination) {
            "  { \"name\": \"path/file3.txt\" }],"
            "\"prefixes\": [\"path/subpath/\"]}"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2Cprefixes%2CnextPageToken&delimiter=%2F&"
            "prefix=path%2F"
            "&pageToken=ABCD==\n"
@@ -1925,7 +1923,7 @@ TEST(GcsFileSystemTest, GetChildren_Pagination) {
 
 TEST(GcsFileSystemTest, GetMatchingPaths_NoWildcard) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsubpath%2F\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -1951,7 +1949,7 @@ TEST(GcsFileSystemTest, GetMatchingPaths_NoWildcard) {
 
 TEST(GcsFileSystemTest, GetMatchingPaths_BucketAndWildcard) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2CnextPageToken\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -1980,7 +1978,7 @@ TEST(GcsFileSystemTest, GetMatchingPaths_BucketAndWildcard) {
 
 TEST(GcsFileSystemTest, GetMatchingPaths_FolderAndWildcard_Matches) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2CnextPageToken&prefix=path%2F\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -2008,7 +2006,7 @@ TEST(GcsFileSystemTest, GetMatchingPaths_FolderAndWildcard_Matches) {
 
 TEST(GcsFileSystemTest, GetMatchingPaths_SelfDirectoryMarker) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2CnextPageToken&prefix=path%2F\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -2033,7 +2031,7 @@ TEST(GcsFileSystemTest, GetMatchingPaths_SelfDirectoryMarker) {
 
 TEST(GcsFileSystemTest, GetMatchingPaths_SlashInObjectName) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2CnextPageToken&prefix=path%2F\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -2058,7 +2056,7 @@ TEST(GcsFileSystemTest, GetMatchingPaths_SlashInObjectName) {
 
 TEST(GcsFileSystemTest, GetMatchingPaths_SlashInObjectNameEscaped) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2CnextPageToken&prefix=path%2F\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -2083,7 +2081,7 @@ TEST(GcsFileSystemTest, GetMatchingPaths_SlashInObjectNameEscaped) {
 
 TEST(GcsFileSystemTest, GetMatchingPaths_FolderAndWildcard_NoMatches) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2CnextPageToken&prefix=path%2F\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -2129,14 +2127,14 @@ TEST(GcsFileSystemTest, GetMatchingPaths_OnlyWildcard) {
 TEST(GcsFileSystemTest, GetMatchingPaths_Cache) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsubpath%2F\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "{\"items\": [ "
            "  { \"name\": \"path/subpath/file2.txt\" }]}"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -2174,14 +2172,14 @@ TEST(GcsFileSystemTest, GetMatchingPaths_Cache) {
 TEST(GcsFileSystemTest, GetMatchingPaths_Cache_Flush) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsubpath%2F\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "{\"items\": [ "
            "  { \"name\": \"path/subpath/file2.txt\" }]}"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsubpath%2F\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -2220,33 +2218,33 @@ TEST(GcsFileSystemTest, GetMatchingPaths_Cache_Flush) {
 TEST(GcsFileSystemTest, DeleteFile) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Ffile1.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"8\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Ffile1.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Ffile1.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-15\n"
            "Timeouts: 5 1 20\n",
            "01234567"),
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/path%2Ffile1.txt\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
                            "Delete: yes\n",
                            ""),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Ffile1.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"8\",\"generation\": \"2\","
                            "\"updated\": \"2016-04-29T23:19:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Ffile1.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Ffile1.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-15\n"
            "Timeouts: 5 1 20\n",
@@ -2298,26 +2296,26 @@ TEST(GcsFileSystemTest, DeleteFile_NoObjectName) {
 TEST(GcsFileSystemTest, DeleteFile_StatCacheRemoved) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "file.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"1010\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/file.txt\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
                            "Delete: yes\n",
                            ""),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "file.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "", errors::NotFound("404"), 404),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=file.txt%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -2349,7 +2347,7 @@ TEST(GcsFileSystemTest, DeleteFile_StatCacheRemoved) {
 
 TEST(GcsFileSystemTest, DeleteDir_Empty) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2CnextPageToken&prefix=path%2F&maxResults=2\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -2371,13 +2369,13 @@ TEST(GcsFileSystemTest, DeleteDir_Empty) {
 TEST(GcsFileSystemTest, DeleteDir_OnlyDirMarkerLeft) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2F&maxResults=2\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "{\"items\": [ "
            "  { \"name\": \"path/\" }]}"),
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/path%2F\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
@@ -2399,7 +2397,7 @@ TEST(GcsFileSystemTest, DeleteDir_OnlyDirMarkerLeft) {
 
 TEST(GcsFileSystemTest, DeleteDir_BucketOnly) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?fields=items%2F"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?fields=items%2F"
       "name%2CnextPageToken&maxResults=2\nAuth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
       "{}")});
@@ -2419,7 +2417,7 @@ TEST(GcsFileSystemTest, DeleteDir_BucketOnly) {
 
 TEST(GcsFileSystemTest, DeleteDir_NonEmpty) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
       "fields=items%2Fname%2CnextPageToken&prefix=path%2F&maxResults=2\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -2442,7 +2440,7 @@ TEST(GcsFileSystemTest, DeleteDir_NonEmpty) {
 
 TEST(GcsFileSystemTest, GetFileSize) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
       "file.txt?fields=size%2Cgeneration%2Cupdated\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -2486,7 +2484,7 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
   std::vector<HttpRequest*> requests(
       {// Check if this is a folder or an object.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path1%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -2495,7 +2493,7 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
            "  { \"name\": \"path1/subfolder/file1.txt\" }]}"),
        // Requesting the full list of files in the folder.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path1%2F\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -2505,7 +2503,7 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
            "  { \"name\": \"path1/file2.txt\" }]}"),
        // Copying the directory marker.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path1%2F/rewriteTo/b/bucket/o/path2%2F\n"
            "Auth Token: fake_token\n"
            "Post: yes\n"
@@ -2513,7 +2511,7 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
            "{\"done\": true}"),
        // Deleting the original directory marker.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path1%2F\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n"
@@ -2521,7 +2519,7 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
            ""),
        // Copying the first file.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path1%2Fsubfolder%2Ffile1.txt/rewriteTo/b/bucket/o/"
            "path2%2Fsubfolder%2Ffile1.txt\n"
            "Auth Token: fake_token\n"
@@ -2530,7 +2528,7 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
            "{\"done\": true}"),
        // Deleting the first original file.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path1%2Fsubfolder%2Ffile1.txt\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n"
@@ -2538,7 +2536,7 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
            ""),
        // Copying the second file.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path1%2Ffile2.txt/rewriteTo/b/bucket/o/path2%2Ffile2.txt\n"
            "Auth Token: fake_token\n"
            "Post: yes\n"
@@ -2546,7 +2544,7 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
            "{\"done\": true}"),
        // Deleting the second original file.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path1%2Ffile2.txt\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n"
@@ -2570,34 +2568,34 @@ TEST(GcsFileSystemTest, RenameFile_Folder) {
 TEST(GcsFileSystemTest, RenameFile_Object) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"8\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Fsrc.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Fsrc.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-15\n"
            "Timeouts: 5 1 20\n",
            "01234567"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fdst.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"8\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Fdst.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Fdst.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-15\n"
            "Timeouts: 5 1 20\n",
            "76543210"),
        // IsDirectory is checking whether there are children objects.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsrc.txt%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -2605,7 +2603,7 @@ TEST(GcsFileSystemTest, RenameFile_Object) {
            "{}"),
        // Copying to the new location.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt/rewriteTo/b/bucket/o/path%2Fdst.txt\n"
            "Auth Token: fake_token\n"
            "Post: yes\n"
@@ -2613,34 +2611,34 @@ TEST(GcsFileSystemTest, RenameFile_Object) {
            "{\"done\": true}"),
        // Deleting the original file.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n"
            "Delete: yes\n",
            ""),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"8\",\"generation\": \"2\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Fsrc.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Fsrc.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-15\n"
            "Timeouts: 5 1 20\n",
            "89abcdef"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fdst.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"8\",\"generation\": \"2\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://storage.googleapis.com./bucket/path%2Fdst.txt\n"
+           "Uri: https://storage.googleapis.com/bucket/path%2Fdst.txt\n"
            "Auth Token: fake_token\n"
            "Range: 0-15\n"
            "Timeouts: 5 1 20\n",
@@ -2683,7 +2681,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_FlushTargetStatCache) {
   std::vector<HttpRequest*> requests(
       {// Stat the target file.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fdst.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -2691,7 +2689,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_FlushTargetStatCache) {
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        // IsDirectory is checking whether there are children objects.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsrc.txt%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -2699,7 +2697,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_FlushTargetStatCache) {
            "{}"),
        // IsDirectory is checking if the path exists as an object.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -2707,7 +2705,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_FlushTargetStatCache) {
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        // Copying to the new location.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt/rewriteTo/b/bucket/o/path%2Fdst.txt\n"
            "Auth Token: fake_token\n"
            "Post: yes\n"
@@ -2715,14 +2713,14 @@ TEST(GcsFileSystemTest, RenameFile_Object_FlushTargetStatCache) {
            "{\"done\": true}"),
        // Deleting the original file.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n"
            "Delete: yes\n",
            ""),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fdst.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -2759,7 +2757,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_DeletionRetried) {
   std::vector<HttpRequest*> requests(
       {// IsDirectory is checking whether there are children objects.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsrc.txt%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -2767,7 +2765,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_DeletionRetried) {
            "{}"),
        // IsDirectory is checking if the path exists as an object.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -2775,7 +2773,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_DeletionRetried) {
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        // Copying to the new location.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt/rewriteTo/b/bucket/o/path%2Fdst.txt\n"
            "Auth Token: fake_token\n"
            "Post: yes\n"
@@ -2783,7 +2781,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_DeletionRetried) {
            "{\"done\": true}"),
        // Deleting the original file - the deletion returns a failure.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n"
@@ -2791,7 +2789,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_DeletionRetried) {
            "", errors::Unavailable("503"), 503),
        // Deleting the original file again - the deletion returns NOT_FOUND.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n"
@@ -2817,7 +2815,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_Incomplete) {
   std::vector<HttpRequest*> requests(
       {// IsDirectory is checking whether there are children objects.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsrc.txt%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -2825,7 +2823,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_Incomplete) {
            "{}"),
        // IsDirectory is checking if the path exists as an object.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -2833,7 +2831,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_Incomplete) {
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        // Copying to the new location.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Fsrc.txt/rewriteTo/b/bucket/o/path%2Fdst.txt\n"
            "Auth Token: fake_token\n"
            "Post: yes\n"
@@ -2856,7 +2854,7 @@ TEST(GcsFileSystemTest, RenameFile_Object_Incomplete) {
 
 TEST(GcsFileSystemTest, Stat_Object) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
       "file.txt?fields=size%2Cgeneration%2Cupdated\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -2883,13 +2881,13 @@ TEST(GcsFileSystemTest, Stat_Object) {
 TEST(GcsFileSystemTest, Stat_Folder) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "subfolder?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "", errors::NotFound("404"), 404),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=subfolder%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -2917,13 +2915,13 @@ TEST(GcsFileSystemTest, Stat_Folder) {
 TEST(GcsFileSystemTest, Stat_ObjectOrFolderNotFound) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "", errors::NotFound("404"), 404),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -2947,7 +2945,7 @@ TEST(GcsFileSystemTest, Stat_ObjectOrFolderNotFound) {
 
 TEST(GcsFileSystemTest, Stat_Bucket) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket\n"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
       "{}")});
@@ -2971,7 +2969,7 @@ TEST(GcsFileSystemTest, Stat_Bucket) {
 
 TEST(GcsFileSystemTest, Stat_BucketNotFound) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket\n"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
       "", errors::NotFound("404"), 404)});
@@ -2994,20 +2992,20 @@ TEST(GcsFileSystemTest, Stat_BucketNotFound) {
 TEST(GcsFileSystemTest, Stat_Cache) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "file.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"1010\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "subfolder%2F?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "", errors::NotFound("404"), 404),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=subfolder%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -3043,14 +3041,14 @@ TEST(GcsFileSystemTest, Stat_Cache) {
 TEST(GcsFileSystemTest, Stat_Cache_Flush) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "file.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            strings::StrCat("{\"size\": \"1010\",\"generation\": \"1\","
                            "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "file.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -3087,7 +3085,7 @@ TEST(GcsFileSystemTest, Stat_Cache_Flush) {
 
 TEST(GcsFileSystemTest, Stat_FilenameEndingWithSlash) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
       "dir%2F?fields=size%2Cgeneration%2Cupdated\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -3113,14 +3111,14 @@ TEST(GcsFileSystemTest, Stat_FilenameEndingWithSlash) {
 TEST(GcsFileSystemTest, IsDirectory_NotFound) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=file.txt%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "{}"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "file.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -3143,14 +3141,14 @@ TEST(GcsFileSystemTest, IsDirectory_NotFound) {
 TEST(GcsFileSystemTest, IsDirectory_NotDirectoryButObject) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=file.txt%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "{}"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "file.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -3174,14 +3172,14 @@ TEST(GcsFileSystemTest, IsDirectory_NotDirectoryButObject) {
 TEST(GcsFileSystemTest, IsDirectory_Yes) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=subfolder%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "{\"items\": [{\"name\": \"subfolder/\"}]}"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=subfolder%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -3205,12 +3203,12 @@ TEST(GcsFileSystemTest, IsDirectory_Yes) {
 TEST(GcsFileSystemTest, IsDirectory_Bucket) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket\n"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "{}"),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket\n"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "{}")});
@@ -3231,7 +3229,7 @@ TEST(GcsFileSystemTest, IsDirectory_Bucket) {
 
 TEST(GcsFileSystemTest, IsDirectory_BucketNotFound) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket\n"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
       "", errors::NotFound("404"), 404)});
@@ -3256,14 +3254,14 @@ TEST(GcsFileSystemTest, CreateDir_Folder) {
       {
           // File doesn't exist.
           new FakeHttpRequest(
-              "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+              "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
               "subpath%2F?fields=size%2Cgeneration%2Cupdated\n"
               "Auth Token: fake_token\n"
               "Timeouts: 5 1 10\n",
               "{}"),
           // Simple upload.
           new FakeHttpRequest(
-              "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+              "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
               "uploadType=media&name=subpath%2F&ifGenerationMatch=0\n"
               "Auth Token: fake_token\n"
               "Post: yes\n"
@@ -3271,7 +3269,7 @@ TEST(GcsFileSystemTest, CreateDir_Folder) {
               ""),
           // File exists.
           new FakeHttpRequest(
-              "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+              "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
               "subpath%2F?fields=size%2Cgeneration%2Cupdated\n"
               "Auth Token: fake_token\n"
               "Timeouts: 5 1 10\n",
@@ -3279,14 +3277,14 @@ TEST(GcsFileSystemTest, CreateDir_Folder) {
                               "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
           // File doesn't exist again.
           new FakeHttpRequest(
-              "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+              "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
               "subpath%2F?fields=size%2Cgeneration%2Cupdated\n"
               "Auth Token: fake_token\n"
               "Timeouts: 5 1 10\n",
               "{}"),
           // Simulate object uploaded in between.
           new FakeHttpRequest(
-              "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+              "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
               "uploadType=media&name=subpath%2F&ifGenerationMatch=0\n"
               "Auth Token: fake_token\n"
               "Post: yes\n"
@@ -3318,12 +3316,12 @@ TEST(GcsFileSystemTest, CreateDir_Folder) {
 TEST(GcsFileSystemTest, CreateDir_Bucket) {
   std::vector<HttpRequest*> requests(
       {new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket\n"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            ""),
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket\n"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
            "")});
@@ -3346,7 +3344,7 @@ TEST(GcsFileSystemTest, DeleteRecursively_Ok) {
   std::vector<HttpRequest*> requests(
       {// IsDirectory is checking whether there are children objects.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -3355,7 +3353,7 @@ TEST(GcsFileSystemTest, DeleteRecursively_Ok) {
            "  { \"name\": \"path/file1.txt\" }]}"),
        // GetChildren recursively.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2F\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -3365,35 +3363,35 @@ TEST(GcsFileSystemTest, DeleteRecursively_Ok) {
            "  { \"name\": \"path/subpath/file2.txt\" },"
            "  { \"name\": \"path/file3.txt\" }]}"),
        // Delete the current directory's marker.
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/path%2F\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
                            "Delete: yes\n",
                            ""),
        // Delete the object - fails and will be retried.
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/path%2Ffile1.txt\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
                            "Delete: yes\n",
                            "", errors::Unavailable("500"), 500),
        // Delete the object again.
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/path%2Ffile1.txt\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
                            "Delete: yes\n",
                            ""),
        // Delete the object.
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/path%2Fsubpath%2Ffile2.txt\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
                            "Delete: yes\n",
                            ""),
        // Delete the object.
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/path%2Ffile3.txt\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
@@ -3421,7 +3419,7 @@ TEST(GcsFileSystemTest, DeleteRecursively_DeletionErrors) {
   std::vector<HttpRequest*> requests(
       {// IsDirectory is checking whether there are children objects.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -3430,7 +3428,7 @@ TEST(GcsFileSystemTest, DeleteRecursively_DeletionErrors) {
            "  { \"name\": \"path/file1.txt\" }]}"),
        // Calling GetChildren recursively.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2F\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -3440,14 +3438,14 @@ TEST(GcsFileSystemTest, DeleteRecursively_DeletionErrors) {
            "  { \"name\": \"path/subpath/file2.txt\" },"
            "  { \"name\": \"path/file3.txt\" }]}"),
        // Deleting the object.
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/path%2Ffile1.txt\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
                            "Delete: yes\n",
                            ""),
        // Deleting the directory marker gs://bucket/path/ - fails with 404.
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/path%2Fsubpath%2F\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
@@ -3455,7 +3453,7 @@ TEST(GcsFileSystemTest, DeleteRecursively_DeletionErrors) {
                            "", errors::NotFound("404"), 404),
        // Checking if gs://bucket/path/subpath/ is a folder - it is.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Fsubpath%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -3463,14 +3461,14 @@ TEST(GcsFileSystemTest, DeleteRecursively_DeletionErrors) {
            strings::StrCat("{\"items\": [ "
                            "    { \"name\": \"path/subpath/\" }]}")),
        // Deleting the object gs://bucket/path/subpath/file2.txt
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/path%2Fsubpath%2Ffile2.txt\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
                            "Delete: yes\n",
                            ""),
        // Deleting the object s://bucket/path/file3.txt - fails with 404.
-       new FakeHttpRequest("Uri: https://www.googleapis.com./storage/v1/b"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/storage/v1/b"
                            "/bucket/o/path%2Ffile3.txt\n"
                            "Auth Token: fake_token\n"
                            "Timeouts: 5 1 10\n"
@@ -3478,7 +3476,7 @@ TEST(GcsFileSystemTest, DeleteRecursively_DeletionErrors) {
                            "", errors::NotFound("404"), 404),
        // Checking if gs://bucket/path/file3.txt/ is a folder - it's not.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2Ffile3.txt%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -3486,7 +3484,7 @@ TEST(GcsFileSystemTest, DeleteRecursively_DeletionErrors) {
            "{}"),
        // Checking if gs://bucket/path/file3.txt is an object - fails with 404.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path%2Ffile3.txt?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -3514,7 +3512,7 @@ TEST(GcsFileSystemTest, DeleteRecursively_NotAFolder) {
   std::vector<HttpRequest*> requests(
       {// IsDirectory is checking whether there are children objects.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o?"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o?"
            "fields=items%2Fname%2CnextPageToken&prefix=path%2F"
            "&maxResults=1\n"
            "Auth Token: fake_token\n"
@@ -3522,7 +3520,7 @@ TEST(GcsFileSystemTest, DeleteRecursively_NotAFolder) {
            "{}"),
        // IsDirectory is checking if the path exists as an object.
        new FakeHttpRequest(
-           "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+           "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
            "path?fields=size%2Cgeneration%2Cupdated\n"
            "Auth Token: fake_token\n"
            "Timeouts: 5 1 10\n",
@@ -3606,7 +3604,7 @@ TEST(GcsFileSystemTest, AdditionalRequestHeaderTest) {
 
   std::vector<HttpRequest*> requests(
       {// IsDirectory is checking whether there are children objects.
-       new FakeHttpRequest("Uri: https://www.googleapis.com./fake\n"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/fake\n"
                            "Auth Token: fake_token\n"
                            "Header mynewheader: newheadercontents\n"
                            "Header Hello: world\n",
@@ -3624,7 +3622,7 @@ TEST(GcsFileSystemTest, AdditionalRequestHeaderTest) {
 
   std::unique_ptr<HttpRequest> request;
   TF_EXPECT_OK(fs7.CreateHttpRequest(&request));
-  request->SetUri("https://www.googleapis.com./fake");
+  request->SetUri("https://www.googleapis.com/fake");
   request->AddHeader("Hello", "world");
   TF_EXPECT_OK(request->Send());
 }
@@ -3686,7 +3684,7 @@ TEST(GcsFileSystemTest, OverrideCacheParameters) {
 TEST(GcsFileSystemTest, CreateHttpRequest) {
   std::vector<HttpRequest*> requests(
       {// IsDirectory is checking whether there are children objects.
-       new FakeHttpRequest("Uri: https://www.googleapis.com./fake\n"
+       new FakeHttpRequest("Uri: https://www.googleapis.com/fake\n"
                            "Auth Token: fake_token\n"
                            "Header Hello: world\n",
                            "{}")});
@@ -3703,7 +3701,7 @@ TEST(GcsFileSystemTest, CreateHttpRequest) {
 
   std::unique_ptr<HttpRequest> request;
   TF_EXPECT_OK(fs.CreateHttpRequest(&request));
-  request->SetUri("https://www.googleapis.com./fake");
+  request->SetUri("https://www.googleapis.com/fake");
   request->AddHeader("Hello", "world");
   TF_EXPECT_OK(request->Send());
 }
@@ -3747,7 +3745,7 @@ class TestGcsStats : public GcsStatsInterface {
 
 TEST(GcsFileSystemTest, Stat_StatsRecording) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+      "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
       "file.txt?fields=size%2Cgeneration%2Cupdated\n"
       "Auth Token: fake_token\n"
       "Timeouts: 5 1 10\n",
@@ -3775,7 +3773,7 @@ TEST(GcsFileSystemTest, Stat_StatsRecording) {
 
 TEST(GcsFileSystemTest, NewRandomAccessFile_StatsRecording) {
   std::vector<HttpRequest*> requests({new FakeHttpRequest(
-      "Uri: https://storage.googleapis.com./bucket/random_access.txt\n"
+      "Uri: https://storage.googleapis.com/bucket/random_access.txt\n"
       "Auth Token: fake_token\n"
       "Range: 0-5\n"
       "Timeouts: 5 1 20\n",
@@ -3817,7 +3815,7 @@ TEST(GcsFileSystemTest, NewAppendableFile_MultipleFlushesWithCompose) {
       // Fetch the file (stats and then content)
       new FakeHttpRequest(
           "Uri: "
-          "https://www.googleapis.com./storage/v1/b/bucket/o/"
+          "https://www.googleapis.com/storage/v1/b/bucket/o/"
           "some%2Fpath%2Fappendable?fields=size%2Cgeneration%2Cupdated\n"
           "Auth Token: fake_token\n"
           "Timeouts: 5 1 10\n",
@@ -3825,14 +3823,14 @@ TEST(GcsFileSystemTest, NewAppendableFile_MultipleFlushesWithCompose) {
                           "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
       new FakeHttpRequest(
           "Uri: "
-          "https://storage.googleapis.com./bucket/some%2Fpath%2Fappendable\n"
+          "https://storage.googleapis.com/bucket/some%2Fpath%2Fappendable\n"
           "Auth Token: fake_token\n"
           "Range: 0-1048575\n"
           "Timeouts: 5 1 20\n",
           contents[0]),
       // Upload entire file
       new FakeHttpRequest(
-          "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+          "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
           "uploadType=resumable&name=some%2Fpath%2Fappendable\n"
           "Auth Token: fake_token\n"
           "Header X-Upload-Content-Length: 18\n"
@@ -3850,7 +3848,7 @@ TEST(GcsFileSystemTest, NewAppendableFile_MultipleFlushesWithCompose) {
       // Upload new part to a temporary object
       new FakeHttpRequest(
           "Uri: "
-          "https://www.googleapis.com./upload/storage/v1/b/bucket/"
+          "https://www.googleapis.com/upload/storage/v1/b/bucket/"
           "o?uploadType=resumable&name=some%2Fpath%2F.tmpcompose%2Fappendable."
           "18\n"
           "Auth Token: fake_token\n"
@@ -3872,7 +3870,7 @@ TEST(GcsFileSystemTest, NewAppendableFile_MultipleFlushesWithCompose) {
       // Fetch generation
       new FakeHttpRequest(
           "Uri: "
-          "https://www.googleapis.com./storage/v1/b/bucket/o/"
+          "https://www.googleapis.com/storage/v1/b/bucket/o/"
           "some%2Fpath%2Fappendable?fields=size%2Cgeneration%2Cupdated\n"
           "Auth Token: fake_token\n"
           "Timeouts: 5 1 10\n",
@@ -3880,7 +3878,7 @@ TEST(GcsFileSystemTest, NewAppendableFile_MultipleFlushesWithCompose) {
                           "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
       // Compose the new part at the end of the original object.
       new FakeHttpRequest("Uri: "
-                          "https://www.googleapis.com./storage/v1/b/bucket/o/"
+                          "https://www.googleapis.com/storage/v1/b/bucket/o/"
                           "some%2Fpath%2Fappendable/compose\n"
                           "Auth Token: fake_token\n"
                           "Timeouts: 5 1 10\n"
@@ -3893,14 +3891,14 @@ TEST(GcsFileSystemTest, NewAppendableFile_MultipleFlushesWithCompose) {
                           ""),
       // Delete the temporary object.
       new FakeHttpRequest("Uri: "
-                          "https://www.googleapis.com./storage/v1/b/bucket/o/"
+                          "https://www.googleapis.com/storage/v1/b/bucket/o/"
                           "some%2Fpath%2F.tmpcompose%2Fappendable.18\n"
                           "Auth Token: fake_token\n"
                           "Timeouts: 5 1 10\n"
                           "Delete: yes\n",
                           ""),
       new FakeHttpRequest(
-          "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+          "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
           "uploadType=resumable&name=some%2Fpath%2F.tmpcompose%2Fappendable."
           "27\n"
           "Auth Token: fake_token\n"
@@ -3919,14 +3917,14 @@ TEST(GcsFileSystemTest, NewAppendableFile_MultipleFlushesWithCompose) {
       // Fetch generation
       new FakeHttpRequest(
           "Uri: "
-          "https://www.googleapis.com./storage/v1/b/bucket/o/"
+          "https://www.googleapis.com/storage/v1/b/bucket/o/"
           "some%2Fpath%2Fappendable?fields=size%2Cgeneration%2Cupdated\n"
           "Auth Token: fake_token\n"
           "Timeouts: 5 1 10\n",
           strings::StrCat("{\"size\": \"8\",\"generation\": \"4567\","
                           "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
       new FakeHttpRequest("Uri: "
-                          "https://www.googleapis.com./storage/v1/b/bucket/o/"
+                          "https://www.googleapis.com/storage/v1/b/bucket/o/"
                           "some%2Fpath%2Fappendable/compose\n"
                           "Auth Token: fake_token\n"
                           "Timeouts: 5 1 10\n"
@@ -3938,7 +3936,7 @@ TEST(GcsFileSystemTest, NewAppendableFile_MultipleFlushesWithCompose) {
                           "'some/path/.tmpcompose/appendable.27'}]}\n",
                           ""),
       new FakeHttpRequest("Uri: "
-                          "https://www.googleapis.com./storage/v1/b/bucket/o/"
+                          "https://www.googleapis.com/storage/v1/b/bucket/o/"
                           "some%2Fpath%2F.tmpcompose%2Fappendable."
                           "27\n"
                           "Auth Token: fake_token\n"
@@ -3975,20 +3973,20 @@ TEST(GcsFileSystemTest, NewAppendableFile_MultipleFlushesWithoutCompose) {
       {"content0,", "content1,", "content2,", "content3,"});
   std::vector<HttpRequest*> requests({
       new FakeHttpRequest(
-          "Uri: https://www.googleapis.com./storage/v1/b/bucket/o/"
+          "Uri: https://www.googleapis.com/storage/v1/b/bucket/o/"
           "path%2Fappendable?fields=size%2Cgeneration%2Cupdated\n"
           "Auth Token: fake_token\n"
           "Timeouts: 5 1 10\n",
           strings::StrCat("{\"size\": \"8\",\"generation\": \"1\","
                           "\"updated\": \"2016-04-29T23:15:24.896Z\"}")),
       new FakeHttpRequest(
-          "Uri: https://storage.googleapis.com./bucket/path%2Fappendable\n"
+          "Uri: https://storage.googleapis.com/bucket/path%2Fappendable\n"
           "Auth Token: fake_token\n"
           "Range: 0-1048575\n"
           "Timeouts: 5 1 20\n",
           contents[0]),
       new FakeHttpRequest(
-          "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+          "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
           "uploadType=resumable&name=path%2Fappendable\n"
           "Auth Token: fake_token\n"
           "Header X-Upload-Content-Length: 18\n"
@@ -4005,7 +4003,7 @@ TEST(GcsFileSystemTest, NewAppendableFile_MultipleFlushesWithoutCompose) {
                           contents[0], contents[1], "\n"),
           ""),
       new FakeHttpRequest("Uri: "
-                          "https://www.googleapis.com./upload/storage/v1/b/"
+                          "https://www.googleapis.com/upload/storage/v1/b/"
                           "bucket/o?"
                           "uploadType=resumable&name=path%2Fappendable\n"
                           "Auth Token: fake_token\n"
@@ -4026,7 +4024,7 @@ TEST(GcsFileSystemTest, NewAppendableFile_MultipleFlushesWithoutCompose) {
                           contents[0], contents[1], contents[2], "\n"),
           ""),
       new FakeHttpRequest(
-          "Uri: https://www.googleapis.com./upload/storage/v1/b/bucket/o?"
+          "Uri: https://www.googleapis.com/upload/storage/v1/b/bucket/o?"
           "uploadType=resumable&name=path%2Fappendable\n"
           "Auth Token: fake_token\n"
           "Header X-Upload-Content-Length: 36\n"


### PR DESCRIPTION
Revert "Add trailing dot to storage.googleapis.com for full domain qualification (ndots workaround)"

This reverts commit a4e3b786447042f4aa6ad5649a7fef9c4b40cee7.

Should fix the following issue for the 2.17 release: https://github.com/tensorflow/tensorflow/issues/69789