### PR TITLE
[TOSA] support tfl.batch_matmul with input broadcasting

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1760,6 +1760,20 @@ func.func @test_batch_matmul_qi8(%arg0: tensor<1x3x4x4x!quant.uniform<i8:f32, 0.
 
 // -----
 
+// CHECK-LABEL: test_batch_matmul_with_input_broadcast
+// CHECK-SAME: %[[ARG0:.*]]: tensor<25x12x14x14x64xf32>
+// CHECK-SAME: %[[ARG1:.*]]: tensor<14x64x14xf32>
+// CHECK-DAG: %[[VAR0:.*]] = tosa.const_shape  {value = dense<[1, 1, 14, 64, 14]> : tensor<5xindex>} : () -> !tosa.shape<5>
+// CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<-0.000000e+00> : tensor<25x12x14x64x14xf32>}> : () -> tensor<25x12x14x64x14xf32>
+// CHECK-DAG: %[[VAR5:.*]] = tosa.reshape %[[ARG1]], %[[VAR0]] : (tensor<14x64x14xf32>, !tosa.shape<5>) -> tensor<1x1x14x64x14xf32>
+// CHECK: tosa.add %[[VAR5]], %[[VAR1]] : (tensor<1x1x14x64x14xf32>, tensor<25x12x14x64x14xf32>) -> tensor<25x12x14x64x14xf32>
+func.func @test_batch_matmul_with_input_broadcast(%arg0: tensor<25x12x14x14x64xf32>, %arg1: tensor<14x64x14xf32>) -> (tensor<25x12x14x14x14xf32> ) {
+  %0 = "tfl.batch_matmul"(%arg0, %arg1) {adj_x = false, adj_y = false} : (tensor<25x12x14x14x64xf32>, tensor<14x64x14xf32>) -> tensor<25x12x14x14x14xf32>
+  func.return %0 : tensor<25x12x14x14x14xf32>
+}
+
+// -----
+
 // CHECK-LABEL: test_batch_matmul_qi16
 // CHECK-SAME: %[[VAL_0:.*]]: tensor<1x3x4x4x!quant.uniform<i16:f32, 3.0517894629156217E-5>>,
 // CHECK-SAME: %[[VAL_1:.*]]: tensor<1x3x4x3x!quant.uniform<i16:f32, 3.051840394618921E-5>>) -> tensor<1x3x4x3x!quant.uniform<i16:f32, 9.9311851954553276E-5>>
@@ -1775,6 +1789,22 @@ func.func @test_batch_matmul_qi8(%arg0: tensor<1x3x4x4x!quant.uniform<i8:f32, 0.
 func.func @test_batch_matmul_qi16(%arg0: tensor<1x3x4x4x!quant.uniform<i16:f32, 3.0517894629156217E-5>>, %arg1: tensor<1x3x4x3x!quant.uniform<i16:f32, 3.051840394618921E-5>>) -> (tensor<1x3x4x3x!quant.uniform<i16:f32, 9.9311851954553276E-5>>) {
 %0 = "tfl.batch_matmul"(%arg0, %arg1) {adj_x = false, adj_y = false, asymmetric_quantize_inputs = false} : (tensor<1x3x4x4x!quant.uniform<i16:f32, 3.0517894629156217E-5>>, tensor<1x3x4x3x!quant.uniform<i16:f32, 3.051840394618921E-5>>) -> tensor<1x3x4x3x!quant.uniform<i16:f32, 9.9311851954553276E-5>>
 return %0 : tensor<1x3x4x3x!quant.uniform<i16:f32, 9.9311851954553276E-5>>
+}
+
+// -----
+
+// CHECK-LABEL: test_batch_matmul_with_input_broadcast_qi8
+// CHECK-SAME: %[[ARG0:.*]]: tensor<25x12x14x14x64x!quant.uniform<i8:f32, 0.061956532299518585:4>>
+// CHECK-SAME: %[[ARG1:.*]]: tensor<14x64x14x!quant.uniform<i8:f32, 3.9322837255895138E-4:1>>
+// CHECK-DAG: %[[VAR0:.*]] = tosa.const_shape  {value = dense<[1, 1, 14, 64, 14]> : tensor<5xindex>} : () -> !tosa.shape<5>
+// CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<0> : tensor<25x12x14x64x14xi32>}> : () -> tensor<25x12x14x64x14xi32>
+// CHECK-DAG: %[[VAR7:.*]] = tosa.reshape %[[ARG1]], %[[VAR0]] : (tensor<14x64x14x!quant.uniform<i8:f32, 3.9322837255895138E-4:1>>, !tosa.shape<5>) -> tensor<1x1x14x64x14x!quant.uniform<i8:f32, 3.9322837255895138E-4:1>>
+// CHECK-DAG: %[[VAR8:.*]] = tosa.cast %[[VAR7]] : (tensor<1x1x14x64x14x!quant.uniform<i8:f32, 3.9322837255895138E-4:1>>) -> tensor<1x1x14x64x14xi32>
+// CHECK-DAG: %[[VAR9:.*]] = tosa.add %[[VAR8]], %[[VAR1]] : (tensor<1x1x14x64x14xi32>, tensor<25x12x14x64x14xi32>) -> tensor<25x12x14x64x14xi32>
+// CHECK: tosa.cast %[[VAR9]] : (tensor<25x12x14x64x14xi32>) -> tensor<25x12x14x64x14x!quant.uniform<i8:f32, 3.9322837255895138E-4:1>>
+func.func @test_batch_matmul_with_input_broadcast_qi8(%arg0: tensor<25x12x14x14x64x!quant.uniform<i8:f32, 0.061956532299518585:4>>, %arg1: tensor<14x64x14x!quant.uniform<i8:f32, 3.9322837255895138E-4:1>>) -> (tensor<25x12x14x14x14x!quant.uniform<i8:f32, 0.017063580453395844:-47>>) {
+  %0 = "tfl.batch_matmul"(%arg0, %arg1) {adj_x = false, adj_y = false, asymmetric_quantize_inputs = false} : (tensor<25x12x14x14x64x!quant.uniform<i8:f32, 0.061956532299518585:4>>, tensor<14x64x14x!quant.uniform<i8:f32, 3.9322837255895138E-4:1>>) -> tensor<25x12x14x14x14x!quant.uniform<i8:f32, 0.017063580453395844:-47>>
+  func.return %0 : tensor<25x12x14x14x14x!quant.uniform<i8:f32, 0.017063580453395844:-47>>
 }
 
 // -----

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1793,6 +1793,20 @@ return %0 : tensor<1x3x4x3x!quant.uniform<i16:f32, 9.9311851954553276E-5>>
 
 // -----
 
+// CHECK-LABEL: test_batch_matmul_with_input_broadcast_1
+// CHECK-SAME: %[[ARG0:.*]]: tensor<1x256x256x32xf32>
+// CHECK-SAME: %[[ARG1:.*]]: tensor<1x32x4xf32>
+// CHECK-DAG: %[[VAR0:.*]] = tosa.const_shape  {value = dense<[1, 1, 32, 4]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<-0.000000e+00> : tensor<1x256x32x4xf32>}> : () -> tensor<1x256x32x4xf32>
+// CHECK-DAG: %[[VAR5:.*]] = tosa.reshape %[[ARG1]], %[[VAR0]] : (tensor<1x32x4xf32>, !tosa.shape<4>) -> tensor<1x1x32x4xf32>
+// CHECK-DAG: %[[VAR6:.*]] = tosa.add %[[VAR5]], %[[VAR1]] : (tensor<1x1x32x4xf32>, tensor<1x256x32x4xf32>) -> tensor<1x256x32x4xf32>
+func.func @test_batch_matmul_with_input_broadcast_1(%arg0: tensor<1x256x256x32xf32>, %arg1: tensor<1x32x4xf32>) -> (tensor<1x256x256x4xf32>) {
+  %0 = "tfl.batch_matmul"(%arg0, %arg1) {adj_x = false, adj_y = false} : (tensor<1x256x256x32xf32>, tensor<1x32x4xf32>) -> tensor<1x256x256x4xf32>
+  func.return %0 : tensor<1x256x256x4xf32>
+}
+
+// -----
+
 // CHECK-LABEL: test_batch_matmul_with_input_broadcast_qi8
 // CHECK-SAME: %[[ARG0:.*]]: tensor<25x12x14x14x64x!quant.uniform<i8:f32, 0.061956532299518585:4>>
 // CHECK-SAME: %[[ARG1:.*]]: tensor<14x64x14x!quant.uniform<i8:f32, 3.9322837255895138E-4:1>>

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
@@ -1236,5 +1236,67 @@ Value reshapeScalarTo1D(PatternRewriter& rewriter, Location loc, Value value) {
   return rank1_value;
 }
 
+LogicalResult broadcastLowRankTensor(PatternRewriter& rewriter, Operation* op,
+                                     Value& input1, Value& input2) {
+  auto input1_ty = llvm::dyn_cast<RankedTensorType>(input1.getType());
+  auto input2_ty = llvm::dyn_cast<RankedTensorType>(input2.getType());
+
+  if (!input1_ty || !input2_ty) {
+    return rewriter.notifyMatchFailure(op,
+                                       "input tensors should be all ranked");
+  }
+
+  int64_t input1_rank = input1_ty.getRank();
+  int64_t input2_rank = input2_ty.getRank();
+
+  if (input1_rank == input2_rank) return success();
+
+  Value high_rank_tensor, low_rank_tensor;
+  int64_t high_rank, low_rank;
+  if (input1_rank > input2_rank) {
+    high_rank_tensor = input1;
+    low_rank_tensor = input2;
+    high_rank = input1_rank;
+    low_rank = input2_rank;
+  } else {
+    high_rank_tensor = input2;
+    low_rank_tensor = input1;
+    high_rank = input2_rank;
+    low_rank = input1_rank;
+  }
+
+  int64_t broadcast_rank = high_rank - low_rank;
+  SmallVector<int64_t> broadcast_shape(high_rank, 1);
+  ArrayRef<int64_t> high_rank_shape =
+      llvm::cast<RankedTensorType>(high_rank_tensor.getType()).getShape();
+
+  for (int i = 0; i < broadcast_rank; i++) {
+    broadcast_shape[i] = high_rank_shape[i];
+  }
+
+  auto broadcast_shape_value =
+      getTosaConstShape(rewriter, op->getLoc(),
+                        tensorflow::ConvertMlirShapeToTF(broadcast_shape));
+
+  std::optional<Value> result = convertBroadcastToOp(
+      rewriter, op, low_rank_tensor, broadcast_shape_value);
+  if (!result) {
+    return rewriter.notifyMatchFailure(op,
+                                       "failed to broadcast low rank tensor "
+                                       "from convertBroadcastToOp");
+  }
+
+  low_rank_tensor = result.value();
+
+  if (input1_rank < input2_rank) {
+    input1 = low_rank_tensor;
+    input2 = high_rank_tensor;
+  } else {
+    input1 = high_rank_tensor;
+    input2 = low_rank_tensor;
+  }
+  return success();
+}
+
 }  // namespace tosa
 }  // namespace mlir

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
@@ -1265,10 +1265,19 @@ LogicalResult broadcastLowRankTensor(PatternRewriter& rewriter, Operation* op,
     low_rank = input1_rank;
   }
 
-  int64_t broadcast_rank = high_rank - low_rank;
-  SmallVector<int64_t> broadcast_shape(high_rank, 1);
   ArrayRef<int64_t> high_rank_shape =
       llvm::cast<RankedTensorType>(high_rank_tensor.getType()).getShape();
+  ArrayRef<int64_t> low_rank_shape =
+      llvm::cast<RankedTensorType>(low_rank_tensor.getType()).getShape();
+
+  // broadcasting if the first dimension of the low-rank tensor is '1'
+  // example hight_rank: [1,a,b,c]; low_rank: [1,d,e]; low_rank should broadcast
+  // to [1, a, d, e]
+  if (low_rank_shape[0] == 1) {
+    low_rank -= 1;
+  }
+  int64_t broadcast_rank = high_rank - low_rank;
+  SmallVector<int64_t> broadcast_shape(high_rank, 1);
 
   for (int i = 0; i < broadcast_rank; i++) {
     broadcast_shape[i] = high_rank_shape[i];

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
@@ -283,10 +283,10 @@ inline bool IsTFLDoubleRoundingMode() {
 #endif  // TFLITE_SINGLE_ROUNDING
 }
 
+Value reshapeScalarTo1D(PatternRewriter& rewriter, Location loc, Value value);
+
 LogicalResult broadcastLowRankTensor(PatternRewriter &rewriter, Operation* op,
                                      Value &input1, Value &input2);
-
-Value reshapeScalarTo1D(PatternRewriter& rewriter, Location loc, Value value);
 
 }  // namespace tosa
 }  // namespace mlir


### PR DESCRIPTION
add support of unequal rank inputs with broadcasting in `TFL_BatchMatMulOp` lowering to `tosa.matmul`

example:
In the case of `batch_matmul` with broadcasting:
```
%0 = "tfl.batch_matmul"(%arg0, %arg1) {...} : (tensor<2x3x4x5x6xf32>, tensor<4x6x5xf32>) -> tensor<2x3x4x5x5xf32>
```

broadcast `tensor<4x6x5xf32>`  to `tensor<2x3x4x6x5xf32>` in 4 operations:
```
%0 = tosa.const_shape  {value = dense<[1, 1, 4, 6, 5]> : tensor<5xindex>} : () -> !tosa.shape<5>
%4 = "tosa.const"() <{value = dense<-0.000000e+00> : tensor<2x3x4x6x5xf32>}
%5 = tosa.reshape %arg1, %0 : (tensor<4x6x5xf32>, !tosa.shape<5>) -> tensor<1x1x4x6x5xf32>
%6 = tosa.add %5, %4 : (tensor<1x1x4x6x5xf32>, tensor<2x3x4x6x5xf32>) -> tensor<2x3x4x6x5xf32>
```