### PR TITLE
fix: remove distutils leftovers

### DIFF
--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -27,7 +27,6 @@ this file with a file generated from [`api_template.__init__.py`](https://www.gi
 """
 # pylint: disable=g-bad-import-order,protected-access,g-import-not-at-top
 
-import distutils as _distutils
 import importlib
 import inspect as _inspect
 import os as _os
@@ -99,9 +98,6 @@ if _site.ENABLE_USER_SITE and _site.USER_SITE is not None:
 _site_packages_dirs += [p for p in _sys.path if "site-packages" in p]
 if "getsitepackages" in dir(_site):
   _site_packages_dirs += _site.getsitepackages()
-
-if "sysconfig" in dir(_distutils):
-  _site_packages_dirs += [_distutils.sysconfig.get_python_lib()]
 
 _site_packages_dirs = list(set(_site_packages_dirs))
 

--- a/tensorflow/lite/python/convert.py
+++ b/tensorflow/lite/python/convert.py
@@ -14,11 +14,11 @@
 # ==============================================================================
 """Converts a frozen graph into a TFLite FlatBuffer."""
 
-import distutils.spawn
 import enum
 import hashlib
 import os as _os
 import platform as _platform
+import shutil
 import subprocess as _subprocess
 import tempfile as _tempfile
 from typing import Optional
@@ -408,7 +408,7 @@ def _run_deprecated_conversion_binary(
     RuntimeError: When conversion fails, an exception is raised with the error
       message embedded.
   """
-  if distutils.spawn.find_executable(_deprecated_conversion_binary) is None:
+  if shutil.which(_deprecated_conversion_binary) is None:
     raise ConverterError("""Could not find `toco_from_protos` binary, make sure
 your virtualenv bin directory or pip local bin directory is in your path.
 In particular, if you have installed TensorFlow with --user, make sure you


### PR DESCRIPTION
Context: https://github.com/tensorflow/tensorflow/issues/58073
Applied patch: https://gitlab.archlinux.org/archlinux/packaging/packages/tensorflow/-/blob/fff04b07ca2bc6758f81505cc396c91f7466c08a/tensorflow-2.16.1-python-distutils-removal.patch

Credits to @loqs