### PR TITLE
[TFLite] Use the same quantization info for broadcast_to input/output

### DIFF
--- a/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
+++ b/tensorflow/compiler/mlir/lite/ir/tfl_ops.td
@@ -5367,6 +5367,7 @@ def TFL_BroadcastToOp : TFL_Op<"broadcast_to", [
       Or<[TFL_OperandIsUnrankedPred<1>,
           TFL_OperandDimIsAtMost<1, 0, 8>]>>,
     QuantizableResult,
+    SameOperandsAndResultsScale,
     Pure]> {
   let summary = "Broadcast an array for a compatible shape.";
 


### PR DESCRIPTION
Broadcast_to has the operator property `restrict_same_input_output_scale=True`, however, this does not seem to be reflected by the mlir operator definitions in tfl_ops.td. This led to a case where the input quantization information differs to the output on creation of a quantized tflite flatbuffer file. This can cause type checking to fail at a later stage in mlir lowering (using tf-opt).

For example:
```
%3 = "tfl.broadcast_to"(%0, %2) : (tensor<!quant.uniform<i8<-127:127>:f32, 0.1:-128>>, tensor<3xi64>) -> tensor<1x1x512x!quant.uniform<i8:f32, 0.1:-128>>
%6 = "tfl.scatter_nd"(%4, %3, %5) : (tensor<1x1x2xi32>, tensor<1x1x512x!quant.uniform<i8:f32, 0.1:-128>>, tensor<3xi32>) -> tensor<1x224x512x!quant.uniform<i8:f32, 0.1:-128>>
```
results in the following error:
```
error: 'tfl.scatter_nd' op quantization parameters violate the same scale constraint: !quant.uniform<i8<-127:127>:f32, 0.1:-128> vs. !quant.uniform<i8:f32, 0.1:-128>
```

forcing the input and output quantization information to match using the `SameOperandsAndResultsScale` attribute fixes this. The following will now be generated after model conversion instead:
```
%3 = "tfl.broadcast_to"(%0, %2) : (tensor<!quant.uniform<i8:f32, 0.1:-128>>, tensor<3xi64>) -> tensor<1x1x512x!quant.uniform<i8:f32, 0.1:-128>>
%6 = "tfl.scatter_nd"(%4, %3, %5) : (tensor<1x1x2xi32>, tensor<1x1x512x!quant.uniform<i8:f32, 0.1:-128>>, tensor<3xi32>) -> tensor<1x224x512x!quant.uniform<i8:f32, 0.1:-128>>
```
making later type checks happy.