### PR TITLE
[oneDNN][BugFix] Prevent AMP exit on supported CPU platforms

### DIFF
--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision.cc
@@ -2310,9 +2310,11 @@ Status AutoMixedPrecision::Optimize(Cluster* cluster, const GrapplerItem& item,
             << " graph optimizer";
     return absl::OkStatus();
   }
-  // Check if CPU supports FP16
+  // Check if CPU supports FP16, oneDNN supports FP16 on 
+  // some platforms by converting to and from FP32
   if (mode_ == AutoMixedPrecisionMode::FP16_CPU &&
-      !IsAMXDataTypeSupportedByOneDNNOnThisCPU(DT_HALF)) {
+      !IsAMXDataTypeSupportedByOneDNNOnThisCPU(DT_HALF) &&
+      !IsAVXConvertSupportedByOneDNNOnThisCPU()) {
     VLOG(1) << "No support for " << name() << " graph optimizer on CPU";
     return absl::OkStatus();
   }

--- a/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
+++ b/tensorflow/core/grappler/optimizers/auto_mixed_precision_test.cc
@@ -132,7 +132,10 @@ class AutoMixedPrecisionTest : public GrapplerTest {
 
       bool is_fp16_enabled_on_cpu = false;
 #if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
-      is_fp16_enabled_on_cpu = IsAMXDataTypeSupportedByOneDNNOnThisCPU(DT_HALF);
+      // oneDNN supports FP16 on some platforms by converting to and from FP32
+      is_fp16_enabled_on_cpu =
+          IsAMXDataTypeSupportedByOneDNNOnThisCPU(DT_HALF) ||
+          IsAVXConvertSupportedByOneDNNOnThisCPU();
 #endif  // INTEL_MKL && ENABLE_ONEDNN_V3
       if (!IsMKLEnabled() || !is_fp16_enabled_on_cpu) {
         GTEST_SKIP() << "This device doesn't support FP16";

--- a/tensorflow/core/util/util.cc
+++ b/tensorflow/core/util/util.cc
@@ -187,4 +187,14 @@ bool IsAMXDataTypeSupportedByOneDNNOnThisCPU(const DataType& dt) {
   return result;
 }
 
+// Check if oneDNN supports AVX-NE-CONVERT on CPU
+bool IsAVXConvertSupportedByOneDNNOnThisCPU() {
+  bool result = false;
+#if defined(INTEL_MKL) && defined(ENABLE_ONEDNN_V3)
+  using port::TestCPUFeature;
+  result = TestCPUFeature(port::CPUFeature::AVX_NE_CONVERT);
+#endif  // INTEL_MKL && ENABLE_ONEDNN_V3
+  return result;
+}
+
 }  // namespace tensorflow

--- a/tensorflow/core/util/util.h
+++ b/tensorflow/core/util/util.h
@@ -71,6 +71,8 @@ bool IsDataTypeSupportedByOneDNNOnThisCPU(const DataType& dt);
 // Check if input type supports AMX on CPU when oneDNN is enabled
 bool IsAMXDataTypeSupportedByOneDNNOnThisCPU(const DataType& dt);
 
+bool IsAVXConvertSupportedByOneDNNOnThisCPU();
+
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_CORE_UTIL_UTIL_H_


### PR DESCRIPTION
This PR prevents the Auto Mixed Precision Optimizer to exit for float16 on supported Intel E-Cores.