### PR TITLE
Move handling of TF_CUDNN_DETERMINISTIC from XLA to TF.

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -552,8 +552,8 @@ cc_library(
 
 cc_library(
     name = "numeric_options_utils",
-    hdrs = ["numeric_options_utils.h"],
     srcs = ["numeric_options_utils.cc"],
+    hdrs = ["numeric_options_utils.h"],
     deps = [
         "//tensorflow/core/util:env_var",
         "//tensorflow/core/platform:tensor_float_32_hdr_lib",

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -553,7 +553,9 @@ cc_library(
 cc_library(
     name = "numeric_options_utils",
     hdrs = ["numeric_options_utils.h"],
+    srcs = ["numeric_options_utils.cc"],
     deps = [
+        "//tensorflow/core/util:env_var",
         "//tensorflow/core/platform:tensor_float_32_hdr_lib",
         "//tensorflow/core/util:determinism_for_kernels",
         "@local_xla//xla/stream_executor:numeric_options",

--- a/tensorflow/core/kernels/conv_ops_fused_int8.cc
+++ b/tensorflow/core/kernels/conv_ops_fused_int8.cc
@@ -586,7 +586,7 @@ void operator()(
         use_cudnn_frontend, se::dnn::ConvolutionKind::FORWARD, type, bias_type,
         type, conv_scale, side_input_scale, /*leakyrelu_alpha=*/0.0, stream,
         conv_input_desc, filter_desc, bias_desc, output_desc, conv_desc,
-        /*use_fallback=*/false, dnn_activation_mode, GetNumericOptions(),
+        /*use_fallback=*/false, dnn_activation_mode, GetNumericOptionsForCuDnn(),
         &runners));
 
     auto launch_func =
@@ -637,7 +637,7 @@ void operator()(
           bias_type, type, conv_scale, side_input_scale, leakyrelu_alpha,
           stream, conv_input_desc, filter_desc, bias_desc, output_desc,
           conv_desc,
-          /*use_fallback=*/true, dnn_activation_mode, GetNumericOptions(),
+          /*use_fallback=*/true, dnn_activation_mode, GetNumericOptionsForCuDnn(),
           &fallback_runners));
 
       auto fallback_results_or = internal::AutotuneConvImpl(

--- a/tensorflow/core/kernels/conv_ops_gpu.cc
+++ b/tensorflow/core/kernels/conv_ops_gpu.cc
@@ -105,7 +105,7 @@ StatusOr<AutotuneEntry<se::dnn::FusedConvOp>> AutotuneFusedConv(
         element_type, element_type, conv_scale, side_input_scale,
         leakyrelu_alpha, stream, input_desc, filter_desc, bias_desc,
         output_desc, conv_desc, /*use_fallback=*/false, activation_mode,
-        GetNumericOptions(), &runners));
+        GetNumericOptionsForCuDnn(), &runners));
 
     auto launch_func =
         [&](se::ScratchAllocator* allocator_used,
@@ -156,7 +156,7 @@ StatusOr<AutotuneEntry<se::dnn::FusedConvOp>> AutotuneFusedConv(
           element_type, element_type, conv_scale, side_input_scale,
           leakyrelu_alpha, stream, input_desc, filter_desc, bias_desc,
           output_desc, conv_desc, /*use_fallback=*/true, activation_mode,
-          GetNumericOptions(), &fallback_runners));
+          GetNumericOptionsForCuDnn(), &fallback_runners));
 
       TF_ASSIGN_OR_RETURN(auto fallback_results,
                           internal::AutotuneConvImpl(
@@ -290,7 +290,7 @@ StatusOr<AutotuneEntry<se::dnn::ConvOp>> AutotuneUnfusedConv(
     TF_RETURN_IF_ERROR(dnn->GetConvolveRunners(
         CudnnUseFrontend(), kind, element_type, element_type, stream,
         input_desc, input_ptr, filter_desc, filter_ptr, output_desc, output_ptr,
-        conv_desc, /*use_fallback=*/false, &rz_allocator, GetNumericOptions(),
+        conv_desc, /*use_fallback=*/false, &rz_allocator, GetNumericOptionsForCuDnn(),
         &runners));
     auto launch_func =
         [&](se::ScratchAllocator* allocator_used,
@@ -336,7 +336,7 @@ StatusOr<AutotuneEntry<se::dnn::ConvOp>> AutotuneUnfusedConv(
           CudnnUseFrontend(), kind, element_type, element_type, stream,
           input_desc, input_ptr, filter_desc, filter_ptr, output_desc,
           output_ptr, conv_desc, /*use_fallback=*/true, &rz_allocator,
-          GetNumericOptions(), &fallback_runners));
+          GetNumericOptionsForCuDnn(), &fallback_runners));
 
       TF_ASSIGN_OR_RETURN(auto fallback_results,
                           internal::AutotuneConvImpl(

--- a/tensorflow/core/kernels/ctc_loss_op.cc
+++ b/tensorflow/core/kernels/ctc_loss_op.cc
@@ -366,7 +366,7 @@ class CTCLossOpGPU : public OpKernel {
     bool cudnn_launch_status =
         dnn->PrepareForCtcLoss(
                stream, *probs_desc, probs_data, *grads_desc, labels_data,
-               labels_lengths_data, input_lengths_data, GetNumericOptions(),
+               labels_lengths_data, input_lengths_data, GetNumericOptionsForCuDnn(),
                &workspace_allocator, &scratch_memory, &ctc_loss_algo_id)
             .ok();
     if (cudnn_launch_status) {

--- a/tensorflow/core/kernels/cudnn_pooling_gpu.cc
+++ b/tensorflow/core/kernels/cudnn_pooling_gpu.cc
@@ -115,13 +115,13 @@ void DnnPooling3dImpl(OpKernelContext* context,
 
   DnnScratchAllocator scratch_allocator(PoolingScratchSize, context);
   OP_REQUIRES_OK(context,
-                 dnn->PoolForward(stream, pooling_desc, GetNumericOptions(),
+                 dnn->PoolForward(stream, pooling_desc, GetNumericOptionsForCuDnn(),
                                   input_desc, input_data, output_desc,
                                   &output_data, &scratch_allocator));
 #else
   OP_REQUIRES_OK(
       context,
-      dnn->PoolForward(stream, pooling_desc, GetNumericOptions(), input_desc,
+      dnn->PoolForward(stream, pooling_desc, GetNumericOptionsForCuDnn(), input_desc,
                        input_data, output_desc, &output_data));
 #endif
 
@@ -310,13 +310,13 @@ void DnnPooling3dGradImpl(
   DnnScratchAllocator scratch_allocator(PoolingScratchSize, context);
   OP_REQUIRES_OK(
       context,
-      dnn->PoolBackward(stream, pooling_desc, GetNumericOptions(),
+      dnn->PoolBackward(stream, pooling_desc, GetNumericOptionsForCuDnn(),
                         orig_input_desc, orig_input_data, orig_output_desc,
                         orig_output_data, output_backprop_data,
                         &input_backprop_data, &scratch_allocator));
 #else
   OP_REQUIRES_OK(context,
-                 dnn->PoolBackward(stream, pooling_desc, GetNumericOptions(),
+                 dnn->PoolBackward(stream, pooling_desc, GetNumericOptionsForCuDnn(),
                                    orig_input_desc, orig_input_data,
                                    orig_output_desc, orig_output_data,
                                    output_backprop_data, &input_backprop_data));

--- a/tensorflow/core/kernels/cudnn_rnn_ops.cc
+++ b/tensorflow/core/kernels/cudnn_rnn_ops.cc
@@ -1296,7 +1296,7 @@ class CudnnRNNKernelCommon : public OpKernel {
     auto rnn_desc_s = dnn->CreateRnnDescriptor(
         num_layers, h_num_units, input_size, /*cell_size=*/c_num_units,
         /*batch_size=*/0, input_mode, rnn_direction_mode(), rnn_mode(),
-        ToDataType<T>::value, algo_config, GetNumericOptions(), dropout(),
+        ToDataType<T>::value, algo_config, GetNumericOptionsForCuDnn(), dropout(),
         seed(),
         /* state_allocator=*/nullptr, /*use_padded_io=*/false);
     if (!rnn_desc_s.ok()) {
@@ -1326,7 +1326,7 @@ class CudnnRNNKernelCommon : public OpKernel {
         model_shapes.num_layers, model_shapes.num_units,
         model_shapes.input_size, model_shapes.cell_num_units,
         model_shapes.batch_size, input_mode, rnn_direction_mode(), rnn_mode(),
-        data_type, algo_config, GetNumericOptions(), dropout(), seed(),
+        data_type, algo_config, GetNumericOptionsForCuDnn(), dropout(), seed(),
         dropout_state_allocator, use_padded_io);
     TF_RETURN_IF_ERROR(rnn_desc_s.status());
 

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -368,7 +368,7 @@ StatusOr<AutotuneEntry<se::dnn::FusedMatmulOp>> AutotuneFusedMatmul(
     TF_RETURN_IF_ERROR(dnn->GetFusedMatmulRunners(
         CudnnUseFrontend(), element_type, element_type, element_type, stream,
         trans_a, trans_b, m, n, k, lda, ldb, ldc, activation_mode,
-        /*use_fallback=*/false, GetNumericOptions(), &runners));
+        /*use_fallback=*/false, GetNumericOptionsForCuDnn(), &runners));
 
     auto launch_func =
         [&](se::ScratchAllocator* allocator_used,
@@ -412,7 +412,7 @@ StatusOr<AutotuneEntry<se::dnn::FusedMatmulOp>> AutotuneFusedMatmul(
       TF_RETURN_IF_ERROR(dnn->GetFusedMatmulRunners(
           CudnnUseFrontend(), element_type, element_type, element_type, stream,
           trans_a, trans_b, m, n, k, lda, ldb, ldc, activation_mode,
-          /*use_fallback=*/true, GetNumericOptions(), &fallback_runners));
+          /*use_fallback=*/true, GetNumericOptionsForCuDnn(), &fallback_runners));
 
       TF_ASSIGN_OR_RETURN(
           auto fallback_results,

--- a/tensorflow/core/kernels/numeric_options_utils.cc
+++ b/tensorflow/core/kernels/numeric_options_utils.cc
@@ -1,0 +1,35 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/numeric_options_utils.h"
+
+#include "tensorflow/core/util/env_var.h"
+
+namespace tensorflow {
+
+stream_executor::NumericOptions GetNumericOptionsForCuDnn() {
+  static bool cudnn_deterministic_env_var = [] {
+    bool cudnn_deterministic = false;
+    TF_CHECK_OK(ReadBoolFromEnvVar("TF_CUDNN_DETERMINISTIC",
+                                   /*default_val=*/false,
+                                   &cudnn_deterministic));
+    return cudnn_deterministic;
+  }();
+  stream_executor::NumericOptions result = GetNumericOptions();
+  result.require_determinism |= cudnn_deterministic_env_var;
+  return result;
+}
+
+}  // namespace tensorflow

--- a/tensorflow/core/kernels/numeric_options_utils.h
+++ b/tensorflow/core/kernels/numeric_options_utils.h
@@ -16,9 +16,9 @@ limitations under the License.
 #ifndef TENSORFLOW_CORE_KERNELS_NUMERIC_OPTIONS_UTILS_H_
 #define TENSORFLOW_CORE_KERNELS_NUMERIC_OPTIONS_UTILS_H_
 
+#include "tsl/platform/tensor_float_32_utils.h"
 #include "xla/stream_executor/numeric_options.h"
 #include "xla/tsl/util/determinism.h"
-#include "tsl/platform/tensor_float_32_utils.h"
 
 namespace tensorflow {
 
@@ -27,6 +27,8 @@ inline stream_executor::NumericOptions GetNumericOptions() {
       /*require_determinism=*/tsl::OpDeterminismRequired(),
       /*allow_tf32=*/tsl::tensor_float_32_execution_enabled()};
 }
+
+stream_executor::NumericOptions GetNumericOptionsForCuDnn();
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/pooling_ops_common.cc
+++ b/tensorflow/core/kernels/pooling_ops_common.cc
@@ -414,13 +414,13 @@ void DnnPoolingImpl(OpKernelContext* context, se::dnn::PoolingMode pooling_mode,
 
   DnnScratchAllocator scratch_allocator(PoolingScratchSize, context);
   OP_REQUIRES_OK(context,
-                 dnn->PoolForward(stream, pooling_desc, GetNumericOptions(),
+                 dnn->PoolForward(stream, pooling_desc, GetNumericOptionsForCuDnn(),
                                   input_desc, input_data, output_desc,
                                   &output_data, &scratch_allocator));
 #else
   OP_REQUIRES_OK(
       context,
-      dnn->PoolForward(stream, pooling_desc, GetNumericOptions(), input_desc,
+      dnn->PoolForward(stream, pooling_desc, GetNumericOptionsForCuDnn(), input_desc,
                        input_data, output_desc, &output_data));
 #endif
 
@@ -815,13 +815,13 @@ void DnnPoolingGradImpl(OpKernelContext* context,
   DnnScratchAllocator scratch_allocator(PoolingScratchSize, context);
   OP_REQUIRES_OK(
       context,
-      dnn->PoolBackward(stream, pooling_desc, GetNumericOptions(),
+      dnn->PoolBackward(stream, pooling_desc, GetNumericOptionsForCuDnn(),
                         orig_input_desc, orig_input_data, orig_output_desc,
                         orig_output_data, output_backprop_data,
                         &input_backprop_data, &scratch_allocator));
 #else
   OP_REQUIRES_OK(context,
-                 dnn->PoolBackward(stream, pooling_desc, GetNumericOptions(),
+                 dnn->PoolBackward(stream, pooling_desc, GetNumericOptionsForCuDnn(),
                                    orig_input_desc, orig_input_data,
                                    orig_output_desc, orig_output_data,
                                    output_backprop_data, &input_backprop_data));


### PR DESCRIPTION
The environment variable is TF-specific; controlling the behavior of determinism in XLA through the numeric options argument is more explicit.

Related XLA PR after this is committed will be https://github.com/openxla/xla/pull/14310.
