### PR TITLE
Add CUDA and cuDNN Configuration to TensorFlow WORKSPACE

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,3 +4,22 @@ exports_files(glob(["requirements*"]) + [
     "ACKNOWLEDGEMENTS",
     "LICENSE",
 ])
+
+cc_library(
+    name = "tensorflow_cuda",
+    srcs = glob(["tensorflow/core/kernels/cuda/*.cc"]),
+    deps = [
+        "@cuda//:cuda",
+        "@cudnn//:cudnn",
+    ],
+)
+
+cc_binary(
+    name = "tensorflow_cuda_binary",
+    srcs = glob(["tensorflow/core/kernels/cuda/*.cc"]),
+    deps = [
+        ":tensorflow_cuda",
+        "@tensorflow_core",
+    ],
+)
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,3 +64,44 @@ tf_workspace1()
 load("@//tensorflow:workspace0.bzl", "tf_workspace0")
 
 tf_workspace0()
+
+# Define CUDA path
+new_local_repository(
+    name = "cuda",
+    path = "/usr/local/cuda-12.2",
+    build_file_content = """
+cc_library(
+    name = "cuda",
+    includes = ["include"],
+    linkopts = ["-Llib64"],
+    deps = [],
+)
+"""
+)
+
+# Define cuDNN path
+new_local_repository(
+    name = "cudnn",
+    path = "/usr/local/cuda-12.2-cudnn",
+    build_file_content = """
+cc_library(
+    name = "cudnn",
+    includes = ["include"],
+    linkopts = ["-Llib64"],
+    deps = [],
+)
+"""
+)
+
+# Ensure CUDA and cuDNN are linked properly in build configuration
+load("@cuda//:cuda.BUILD", "cuda_cc_library")
+load("@cudnn//:cudnn.BUILD", "cudnn_cc_library")
+
+cc_library(
+    name = "tensorflow_cuda",
+    srcs = glob(["tensorflow/core/kernels/cuda/*.cc"]),
+    deps = [
+        "@cuda//:cuda",
+        "@cudnn//:cudnn",
+    ],
+)

--- a/tools/ci_build/gpu_build.sh
+++ b/tools/ci_build/gpu_build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Define CUDA and cuDNN paths
+export CUDA_HOME=/usr/local/cuda-12.2
+export CUDNN_INCLUDE_DIR=/usr/local/cuda-12.2-cudnn/include
+export CUDNN_LIB_DIR=/usr/local/cuda-12.2-cudnn/lib64
+
+# Ensure CUDA compiler is in PATH
+export PATH=$CUDA_HOME/bin:$PATH
+
+# Verify CUDA compiler
+if ! command -v nvcc &> /dev/null; then
+    echo "nvcc not found. Please ensure CUDA is installed and nvcc is in your PATH."
+    exit 1
+fi
+
+# Check CUDA version
+nvcc --version

--- a/tools/ci_build/gpu_build.sh
+++ b/tools/ci_build/gpu_build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Define CUDA and cuDNN paths
+# Set CUDA and cuDNN paths
 export CUDA_HOME=/usr/local/cuda-12.2
-export CUDNN_INCLUDE_DIR=/usr/local/cuda-12.2-cudnn/include
-export CUDNN_LIB_DIR=/usr/local/cuda-12.2-cudnn/lib64
+export CUDNN_INCLUDE_DIR=/usr/local/cuda-12.2/include
+export CUDNN_LIB_DIR=/usr/local/cuda-12.2/lib64
 
 # Ensure CUDA compiler is in PATH
 export PATH=$CUDA_HOME/bin:$PATH
@@ -16,3 +16,16 @@ fi
 
 # Check CUDA version
 nvcc --version
+
+# Verify cuDNN installation
+if [ ! -f $CUDNN_INCLUDE_DIR/cudnn.h ]; then
+    echo "cuDNN header file not found. Please ensure cuDNN is installed correctly."
+    exit 1
+fi
+
+if [ ! -f $CUDNN_LIB_DIR/libcudnn.so ]; then
+    echo "cuDNN library file not found. Please ensure cuDNN is installed correctly."
+    exit 1
+fi
+
+echo "CUDA and cuDNN are set up correctly."


### PR DESCRIPTION
## Title: Add CUDA and cuDNN Configuration to TensorFlow WORKSPACE

## Description:
This pull request adds configurations to TensorFlow’s WORKSPACE file to properly include CUDA and cuDNN support, addressing the issue where TensorFlow fails to find the CUDA compiler.

## Files Changed:
tensorflow/WORKSPACE
tensorflow/tools/ci_build/gpu_build.sh (new script)

## Changes Made:
Added CUDA and cuDNN repository configurations to the WORKSPACE file.
Added a script to verify CUDA and nvcc installation.

## Instructions to Test:
Update the WORKSPACE File: Apply the changes to include CUDA and cuDNN.
Run the Verification Script: Use gpu_build.sh to ensure CUDA and nvcc are correctly set up.
Build TensorFlow: Follow the standard build instructions to confirm that CUDA support is correctly integrated.
