### PR TITLE
Tensorflow lite C API. CMake. Windows. Make sure symbols are exported.

### DIFF
--- a/tensorflow/lite/c/CMakeLists.txt
+++ b/tensorflow/lite/c/CMakeLists.txt
@@ -78,6 +78,8 @@ add_library(tensorflowlite_c ${TFLITE_C_LIBTYPE}
 if (TFLITE_C_BUILD_SHARED_LIBS)
   if (WIN32)
     target_compile_definitions(tensorflowlite_c PRIVATE TFL_COMPILE_LIBRARY)
+    # Undefine inherited TFL_STATIC_LIBRARY_BUILD to make sure the symbols are exported
+    target_compile_options(tensorflowlite_c PRIVATE /UTFL_STATIC_LIBRARY_BUILD)
   elseif (APPLE)
     target_link_options(tensorflowlite_c PRIVATE "-Wl,-exported_symbols_list,${TFLITE_SOURCE_DIR}/c/exported_symbols.lds")
   else ()


### PR DESCRIPTION
Undefined the inherited the preprocessor define TFL_STATIC_LIBRARY_BUILD for the C API target only.
TFL_STATIC_LIBRARY_BUILD was preventing symbols from being exported which meant missing symbols. 