### PR TITLE
Build and push to Artifact Registry in parallel with gcr.io so we can verify the workflow

### DIFF
--- a/.github/workflows/sigbuild-docker-presubmit.yml
+++ b/.github/workflows/sigbuild-docker-presubmit.yml
@@ -58,7 +58,7 @@ jobs:
           password: ${{ secrets.GCP_CREDS }}
       -
         name: Login to AR
-# Once this is verified, change the label's name. For now, we will piggyback on gcr.io actions.
+        # Once this is verified, change the label's name. For now, we will piggyback on gcr.io actions.
         if: contains(github.event.pull_request.labels.*.name, 'build and push to gcr.io for staging')
         uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         with:

--- a/.github/workflows/sigbuild-docker-presubmit.yml
+++ b/.github/workflows/sigbuild-docker-presubmit.yml
@@ -57,6 +57,15 @@ jobs:
           username: _json_key
           password: ${{ secrets.GCP_CREDS }}
       -
+        name: Login to AR
+# Once this is verified, change the label's name. For now, we will piggyback on gcr.io actions.
+        if: contains(github.event.pull_request.labels.*.name, 'build and push to gcr.io for staging')
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_CREDS }}
+      -
         name: Grab the date to do cache busting (assumes same day OK to keep)
         run: |
           echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
@@ -74,6 +83,7 @@ jobs:
             CACHEBUSTER=${{ steps.date.outputs.DATE }}
           tags: |
             gcr.io/tensorflow-sigs/build:${{ github.event.number }}-${{ matrix.python-version }}
+            us-central1-docker.pkg.dev/tensorflow-sigs/tensorflow/build:${{ github.event.number }}-${{ matrix.python-version }}
           cache-from: |
             type=registry,ref=tensorflow/build:latest-${{ matrix.python-version }}
             type=registry,ref=gcr.io/tensorflow-sigs/build:${{ github.event.number }}-${{ matrix.python-version }}


### PR DESCRIPTION
Google Container Registry is getting deprecated in favor of Artifact Registry so we need to migrate the contains over.

This CL builds and pushes to Artifact Registry whenever something is pushed and built to the Container Registry. This will be used to verify that the Artifact Registry works.