### PR TITLE
Build and push to Artifact Registry in parallel with gcr.io for weekly build

### DIFF
--- a/.github/workflows/sigbuild-docker.yml
+++ b/.github/workflows/sigbuild-docker.yml
@@ -61,6 +61,15 @@ jobs:
           username: _json_key
           password: ${{ secrets.GCP_CREDS }}
       -
+        name: Login to AR
+        # Once this is verified, change the label's name. For now, we will piggyback on gcr.io actions.
+        if: contains(github.event.pull_request.labels.*.name, 'build and push to gcr.io for staging')
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_CREDS }}
+      -
         name: Grab the upcoming TF version to tag this container
         run: |
           # [[:digit:]] searches for numbers and \+ joins them together
@@ -87,6 +96,8 @@ jobs:
             tensorflow/build:${{ steps.tf-version.outputs.TF_VERSION }}-${{ matrix.python-version }}
             gcr.io/tensorflow-sigs/build:latest-${{ matrix.python-version }}
             gcr.io/tensorflow-sigs/build:${{ steps.tf-version.outputs.TF_VERSION }}-${{ matrix.python-version }}
+            us-central1-docker.pkg.dev/tensorflow-sigs/tensorflow/build:latest-${{ matrix.python-version }}
+            us-central1-docker.pkg.dev/tensorflow-sigs/tensorflow/build:${{ steps.tf-version.outputs.TF_VERSION }}-${{ matrix.python-version }}
           cache-from: type=registry,ref=tensorflow/build:latest-${{ matrix.python-version }}
           cache-to: type=inline
       -

--- a/.github/workflows/sigbuild-docker.yml
+++ b/.github/workflows/sigbuild-docker.yml
@@ -62,9 +62,8 @@ jobs:
           password: ${{ secrets.GCP_CREDS }}
       -
         name: Login to AR
-        # Once this is verified, change the label's name. For now, we will piggyback on gcr.io actions.
-        if: contains(github.event.pull_request.labels.*.name, 'build and push to gcr.io for staging')
-        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
+        # Once this is verified, removed gcr.io actions.
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key


### PR DESCRIPTION
Google Container Registry is getting deprecated in favor of Artifact Registry so we need to migrate the contains over.

This PR builds and pushes to Artifact Registry whenever something is pushed and built to the Container Registry for the weekly build. This will be used to verify that the Artifact Registry works.

The previous PR shows that this is working for a presubmit build (https://github.com/tensorflow/tensorflow/pull/73240).