### PR TITLE
Cherrypick for tf-profiler fix

### DIFF
--- a/third_party/xla/third_party/tsl/tsl/platform/cloud/gcs_file_system.cc
+++ b/third_party/xla/third_party/tsl/tsl/platform/cloud/gcs_file_system.cc
@@ -564,7 +564,8 @@ class GcsWritableFile : public WritableFile {
   }
 
   Status Name(StringPiece* result) const override {
-    return errors::Unimplemented("GCSWritableFile does not support Name()");
+    *result = object_;
+    return absl::OkStatus();
   }
 
   Status Sync() override {


### PR DESCRIPTION
Why cherrypick this: 
Trace Viewer as a critical tool in tf-profiler is broken starting tensorflow 2.17 (working in 2.16.2) due to a change in cache file access. We need to cherrypick the fix into stable tensorflow versions to unblock external profiler users who develops models and debugging the performance with tf-profiler. 

What this fixes:
Fix the profiler trace viewer cache file generation, and reenable trace viewer usage in the profiling tool. 

PiperOrigin-RevId: 659614772