### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/autograph/operators/control_flow.py
+++ b/tensorflow/python/autograph/operators/control_flow.py
@@ -856,7 +856,7 @@ def _py_while_stmt(test, body, get_state, set_state, opts):
           1,
           'Caught error while evaluating while loop condition',
           exc_info=True)
-      # TODO(mdan): distinguish beteen these two cases.
+      # TODO(mdan): distinguish between these two cases.
       raise NotImplementedError(
           'The condition of while loop started as non-Tensor, then changed to'
           ' Tensor. This may happen either because variables changed type, or'
@@ -903,7 +903,7 @@ def _placeholder_value(like, shape_invariant, original=None):
       when a placeholder is needed.
 
   Returns:
-    Either a zero value of structure, shape and dtype mathing 'like', or
+    Either a zero value of structure, shape and dtype matching 'like', or
     'original', if no such zero value could be created.
   """
   if like is None:

--- a/tensorflow/python/autograph/tests/loop_basic_test.py
+++ b/tensorflow/python/autograph/tests/loop_basic_test.py
@@ -249,7 +249,7 @@ class ReferenceTest(reference_test_base.TestCase, parameterized.TestCase):
   ))
   def test_for_one_var(self, l, type_, xla):
     if type_ is _int_dataset and xla:
-      self.skipTest('Datsets not supported in XLA')
+      self.skipTest('Datasets not supported in XLA')
     if type_ is _int_tensor and xla and not l:
       self.skipTest('Empty loops not supported in XLA')
 
@@ -298,7 +298,7 @@ class ReferenceTest(reference_test_base.TestCase, parameterized.TestCase):
   ))
   def test_for_two_vars(self, l, type_, xla):
     if type_ is _int_dataset and xla:
-      self.skipTest('Datsets not supported in XLA')
+      self.skipTest('Datasets not supported in XLA')
     if type_ is _int_tensor and xla and not l:
       self.skipTest('Empty loops not supported in XLA')
 

--- a/tensorflow/python/checkpoint/sharding/sharding_policies.py
+++ b/tensorflow/python/checkpoint/sharding/sharding_policies.py
@@ -214,7 +214,7 @@ class MaxShardSizePolicy(sharding_util.ShardingCallback):
         self._device = shardable_tensor.device
         self._root_tensor = shardable_tensor.tensor
         self._slice_spec = shardable_tensor.slice_spec
-        # If the tensor has already been sliced, maked sure to keep track of its
+        # If the tensor has already been sliced, make sure to keep track of its
         # parent tensor's shape & offset. These will be used when creating slice
         # specs later.
         if self._slice_spec:

--- a/tensorflow/python/client/tf_session_helper.cc
+++ b/tensorflow/python/client/tf_session_helper.cc
@@ -191,7 +191,7 @@ void MakeCallableHelper(tensorflow::Session* session,
                                              callable_options->length)) {
     tsl::Set_TF_Status_from_Status(
         out_status,
-        absl::InvalidArgumentError("Unparseable CallableOptions proto"));
+        absl::InvalidArgumentError("Unparsable CallableOptions proto"));
     return;
   }
   tensorflow::Session::CallableHandle handle;

--- a/tensorflow/python/compiler/tensorrt/model_tests/model_handler.py
+++ b/tensorflow/python/compiler/tensorrt/model_tests/model_handler.py
@@ -557,7 +557,7 @@ class TrtModelHandlerV2(_TrtModelHandlerBase, ModelHandlerV2):
 
 
 class _ModelHandlerManagerBase(metaclass=abc.ABCMeta):
-  """Manages a series of ModelHandlers for aggregrated testing/benchmarking."""
+  """Manages a series of ModelHandlers for aggregated testing/benchmarking."""
 
   def __init__(
       self, name: str, model_config: ModelConfig,
@@ -657,7 +657,7 @@ class _ModelHandlerManagerBase(metaclass=abc.ABCMeta):
 
 
 class ModelHandlerManagerV1(_ModelHandlerManagerBase):
-  """Manages a series of ModelHandlers for aggregrated testing/benchmarking in TF1."""
+  """Manages a series of ModelHandlers for aggregated testing/benchmarking in TF1."""
 
   model_handler_cls = ModelHandlerV1
   trt_model_handler_cls = TrtModelHandlerV1

--- a/tensorflow/python/compiler/tensorrt/test/base_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/base_test.py
@@ -120,7 +120,7 @@ class SimpleMultiEnginesTest(trt_test.TfTrtIntegrationTestBase):
   def setUp(self):
     super().setUp()
     # Disable layout optimizer, since it will convert BiasAdd with NHWC
-    # format to NCHW format under four dimentional input.
+    # format to NCHW format under four dimensional input.
     self.DisableNonTrtOptimizers()
 
   def ShouldRunTest(self, run_params):

--- a/tensorflow/python/compiler/tensorrt/test/biasadd_matmul_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/biasadd_matmul_test.py
@@ -105,7 +105,7 @@ class BiasaddMatMulTest(trt_test.TfTrtIntegrationTestBase):
   def setUp(self):
     super().setUp()
     # Disable layout optimizer, since it will convert BiasAdd with NHWC
-    # format to NCHW format under four dimentional input.
+    # format to NCHW format under four dimensional input.
     self.DisableNonTrtOptimizers()
 
   def GetMaxBatchSize(self, run_params):

--- a/tensorflow/python/compiler/tensorrt/test/cast_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/cast_test.py
@@ -25,7 +25,7 @@ from tensorflow.python.platform import test
 
 
 class CastInt32ToFp32Test(trt_test.TfTrtIntegrationTestBase):
-  """Tests cast to FP32 are splitted in FP16 mode."""
+  """Tests cast to FP32 are split in FP16 mode."""
 
   def _ConstOp(self, shape, dtype):
     return constant_op.constant(np.random.randn(*shape), dtype=dtype)

--- a/tensorflow/python/compiler/tensorrt/test/dynamic_input_shapes_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/dynamic_input_shapes_test.py
@@ -79,7 +79,7 @@ class DynamicInputShapesTest(trt_test.TfTrtIntegrationTestBase):
   def setUp(self):
     super().setUp()
     # Disable layout optimizer, since it will convert BiasAdd with NHWC
-    # format to NCHW format under four dimentional input.
+    # format to NCHW format under four dimensional input.
     self.DisableNonTrtOptimizers()
 
   def ExpectedEnginesToBuild(self, run_params):

--- a/tensorflow/python/compiler/tensorrt/test/int32_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/int32_test.py
@@ -45,7 +45,7 @@ class ExcludeUnsupportedInt32Test(trt_test.TfTrtIntegrationTestBase):
   def setUp(self):
     super().setUp()
     # Disable layout optimizer, since it will convert BiasAdd with NHWC
-    # format to NCHW format under four dimentional input.
+    # format to NCHW format under four dimensional input.
     self.DisableNonTrtOptimizers()
 
   def GetMaxBatchSize(self, run_params):

--- a/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
+++ b/tensorflow/python/compiler/tensorrt/test/shape_output_test.py
@@ -229,7 +229,7 @@ class ShapeValueMaskTest(trt_test.TfTrtIntegrationTestBase):
       return []
 
   def ShouldRunTest(self, run_params):
-    # We cannot calibrate without bulding the engine, we turn of INT8 test.
+    # We cannot calibrate without building the engine, we turn of INT8 test.
     return (run_params.dynamic_shape and
             run_params.precision_mode != "INT8", "no calibration dynamic shape")
 

--- a/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
+++ b/tensorflow/python/compiler/tensorrt/test/tf_trt_integration_test_base.py
@@ -736,7 +736,7 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
       original_gdef: GraphDef. The graph def before TensorRT conversion.
       converted_gdef: GraphDef. The graph def after TensorRT conversion.
       default_max_batch_size: The default maximum batch size to use if no node
-        inside a segment is annoted with a customized max batch size. This value
+        inside a segment is annotated with a customized max batch size. This value
         is None when the graph is converted to TF-TRT with dynamic engines.
       expected_max_batch_sizes: Optional. A sequence of max batch sizes for all
         the engines. `None` if does not check enforce max batch sizes.
@@ -769,7 +769,7 @@ class TfTrtIntegrationTestBase(test_util.TensorFlowTestCase):
 
       It is incorrect to use the output shapes to find the batch size of an
       operation, as the segmenter actually uses the input shapes. However, it is
-      a simplication and works for most of the cases for the test purposes.
+      a simplification and works for most of the cases for the test purposes.
 
       Args:
         node_def: `tf.NodeDef`. The target node for analysis.


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.