### PR TITLE
 Fix duplicated return in the fullconnect

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/tasks/fully_connected.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/fully_connected.cc
@@ -243,8 +243,6 @@ FullyConnected CreateFullyConnected(const GpuInfo& gpu_info,
                                        std::move(bias_tensor_desc)));
 
   return result;
-
-  return result;
 }
 
 }  // namespace gpu


### PR DESCRIPTION
Remove the duplicated return statement in the 'CreateFullyConnected'.