### PR TITLE
[Tosa] EqualizeRanks for ops with SameOperandsAndResultRank

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tf-unequal-ranks.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tf-unequal-ranks.mlir
@@ -1,5 +1,5 @@
 // RUN: tf-opt --split-input-file --tf-to-tosa-pipeline --verify-each %s | FileCheck %s
-// REQUIRES: tf_tosa
+
 // Test tf legalization that produce TOSA ResultsBroadcastableShape operators with unequal ranks
 
 // -----

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-unequal-ranks.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-unequal-ranks.mlir
@@ -1,5 +1,5 @@
 // RUN: tf-opt --split-input-file --tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
-// REQUIRES: tf_tosa
+
 // Test tf legalization that produce TOSA ResultsBroadcastableShape operators with unequal ranks
 
 // -----

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
@@ -465,9 +465,9 @@ LogicalResult ConvertTFRealDivOp::matchAndRewrite(
   auto reciprocal_op = CreateOpAndInfer<tosa::ReciprocalOp>(
       rewriter, op->getLoc(), y.getType(), y);
 
-  auto mul_op = CreateMulOpAndInfer(
-      rewriter, op, output_type, tf_div_op.getX(),
-      reciprocal_op.getResult());
+  auto mul_op = CreateMulOpAndInfer(rewriter, op, output_type, x,
+                                    reciprocal_op.getResult());
+
   rewriter.replaceOp(op, {mul_op.getResult()});
 
   return success();


### PR DESCRIPTION
This patch refactors tf/tfl to TOSA lowering to prepare for adding trait SameOperandsAndResultRank to TOSA element wise operators (which will then require these operators be built with operands with same ranks)

This blocks llvm PR: https://github.com/llvm/llvm-project/pull/104501

1. Refactored to use:
        getTosaConstTensorSingleF32
        getTosaConstTensorSingleI32
        getTosagetTosaConstTensorScalarInt
   to construct tosa constant tensors with single value and specified rank

2. Changed lowering of following tf operatos:
        BitwiseOr
        BitwiseXor
        BitwiseAnd
        LogicalAnd
        LogicalOr
        Pow
    to go through CreateReplaceOpAndInfer and CreateOpAndInfer builder functions

3. Refactor to use CreateMulOpAndInfer to construct tosa Mul operations
       - this calls EqualizeRanks on multiply inputs to insert reshape as needed to ensure mul operands have same ranks
       - and default shift value to 0 if unspecified

4. Refactor callers of CreateOpAndInfer/CreateReplaceOpAndInfer to pass Value arguments for inputs of tosa element wise operators

5. In CreateOpAndInfer, call tosa::CreateOpAndInferShape which in turn checks for operator trait SameOperandsAndResultRank and calls EqualizeRanks to insert reshape as needed to ensure operands have same ranks.

6. Changed lowering of following tfl operations:
         LogicalAnd
         LogicalOr
         Pow
    to go through CreateReplaceOpAndInfer and CreateOpAndInfer builder functions


