### PR TITLE
[NFC][ROCM] Replaced DoMatmul with ExecuteOnStream call for gpu_blas_lt

### DIFF
--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -601,7 +601,7 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
     auto launch_func = [&](BlasScratchAllocator& scratch_allocator,
                            size_t alg_idx,
                            se::blas::ProfileResult* profile_result) {
-      return plan_and_algorithms->DoBlasLtMatmul(stream, a_ptr, b_ptr, c_ptr,
+      return plan_and_algorithms->ExecuteOnStream(stream, a_ptr, b_ptr, c_ptr,
                             alg_idx, scratch_allocator, bias_ptr,
                             profile_result);
     };

--- a/tensorflow/core/kernels/matmul_op_impl.h
+++ b/tensorflow/core/kernels/matmul_op_impl.h
@@ -660,7 +660,7 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
             // scratch space is deallocated between runs.
             BlasScratchAllocator scratch_allocator(context, max_scratch_size);
             Status cublas_launch_status =
-                plan_and_algorithms->DoBlasLtMatmul(stream, *a_ptrs[0],
+                plan_and_algorithms->ExecuteOnStream(stream, *a_ptrs[0],
                                *b_ptrs[0], *c_ptrs[0], i, scratch_allocator,
                                se::DeviceMemoryBase{}, &profile_result);
 
@@ -702,7 +702,7 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
 
         OP_REQUIRES_OK(
             context,
-            plan_and_algorithms->DoBlasLtMatmul(stream, *a_ptrs[0], *b_ptrs[0],
+            plan_and_algorithms->ExecuteOnStream(stream, *a_ptrs[0], *b_ptrs[0],
                            *c_ptrs[0], algorithm_idx, scratch_allocator));
       } else {  // requires mixed broadcasting
         const std::vector<int64_t>& a_batch_indices = bcast.x_batch_indices();

--- a/tensorflow/core/kernels/matmul_op_impl.h
+++ b/tensorflow/core/kernels/matmul_op_impl.h
@@ -601,12 +601,13 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
 #if GOOGLE_CUDA || TF_HIPBLASLT
     static const bool use_autotune = MatmulAutotuneEnable();
     bool bCublasLtSupport = true;
-#if TF_HIPBLASLT
-    if (!std::is_same_v<Scalar, float>) bCublasLtSupport = false;
-    auto cap = stream->GetRocmComputeCapability();
-    // as of ROCm 5.5, hipblaslt only supports MI200.
-    if (cap.gcn_arch_name().substr(0, 6) != "gfx90a") bCublasLtSupport = false;
-#endif
+
+    const auto& cc = stream->parent()->GetDeviceDescription().
+                    gpu_compute_capability();
+    if(auto *procm = std::get_if< se::RocmComputeCapability >(&cc)) {
+      bCublasLtSupport = procm->gfx9_mi200_or_later();
+    }
+
     if (EnableCublasLtGemm() && bCublasLtSupport) {
       static const int64_t max_scratch_size =
           GetWorkspaceLimit(1LL << 32);  // 4GB by default
@@ -636,7 +637,7 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
         std::optional<int> max_algorithm_count;
         if (!use_autotune) max_algorithm_count = 1;
         absl::Mutex* pmu = nullptr;
-        auto plan_and_algorithms_or = GetPlanAndAlgorithms(
+        auto plan_and_algorithms_or = PlanAndAlgorithms::GetOrCreate(
             stream, matmul_params, &pmu, max_algorithm_count);
         OP_REQUIRES_OK(context, plan_and_algorithms_or.status());
         absl::MutexLock lock(pmu);
@@ -659,9 +660,9 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
             // scratch space is deallocated between runs.
             BlasScratchAllocator scratch_allocator(context, max_scratch_size);
             Status cublas_launch_status =
-                DoBlasLtMatmul(stream, *plan_and_algorithms, *a_ptrs[0],
+                plan_and_algorithms->DoBlasLtMatmul(stream, *a_ptrs[0],
                                *b_ptrs[0], *c_ptrs[0], i, scratch_allocator,
-                               /*bias = */ {}, &profile_result);
+                               se::DeviceMemoryBase{}, &profile_result);
 
             VLOG(4) << "  Autotune algorithm " << i
                     << " result: " << profile_result.elapsed_time_in_ms()
@@ -701,7 +702,7 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
 
         OP_REQUIRES_OK(
             context,
-            DoBlasLtMatmul(stream, *plan_and_algorithms, *a_ptrs[0], *b_ptrs[0],
+            plan_and_algorithms->DoBlasLtMatmul(stream, *a_ptrs[0], *b_ptrs[0],
                            *c_ptrs[0], algorithm_idx, scratch_allocator));
       } else {  // requires mixed broadcasting
         const std::vector<int64_t>& a_batch_indices = bcast.x_batch_indices();

--- a/tensorflow/core/kernels/matmul_util.cc
+++ b/tensorflow/core/kernels/matmul_util.cc
@@ -110,7 +110,7 @@ StatusOr<se::blas::ComputationType> GetBlasComputationType(
 
 }  // namespace
 
-StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
+/* static */ StatusOr<const PlanAndAlgorithms*> PlanAndAlgorithms::GetOrCreate(
     se::Stream* stream, const BlasLtMatmulPlanParams& params,
     absl::Mutex** ppmu, std::optional<int> max_algorithm_count) {
   static const int64_t max_scratch_size =
@@ -128,8 +128,6 @@ StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
                         se::gpu::AsXlaPrimitiveType(params.dtype));
     TF_ASSIGN_OR_RETURN(auto computation_type,
                         GetBlasComputationType(params.dtype));
-
-    auto scale_type = se::gpu::GetScaleType(params.dtype, computation_type);
 
     // row-major output is now handled automatically by blas-lt API
     constexpr auto kRowMajor = se::gpu::MatrixLayout::Order::kRowMajor;
@@ -180,11 +178,39 @@ StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
         auto algorithms,
         plan->GetAlgorithms(*max_algorithm_count, max_scratch_size));
 
-    ptr->second = {std::move(plan), std::move(algorithms), scale_type};
+    ptr->second = {std::move(plan), std::move(algorithms)};
   }
   *ppmu = &plan_map.mu;
   return &ptr->second;
 }
+
+Status PlanAndAlgorithms::DoBlasLtMatmul(se::Stream* stream, 
+                      const se::DeviceMemoryBase& a,
+                      const se::DeviceMemoryBase& b, 
+                      se::DeviceMemoryBase& c,
+                      size_t algorithm_idx, 
+                      se::ScratchAllocator& scratch_allocator,
+                      const se::DeviceMemoryBase& bias,
+                      se::blas::ProfileResult* profile_result) const {
+
+  if(!plan || algorithm_idx >= algorithms.size()) {
+    return errors::Internal("MatmulPlan or algorithms are not initialized!");
+  }
+  return plan->ExecuteOnStream(
+        stream, a, b, c, c,
+        bias,                  // bias_buffer
+        se::DeviceMemoryBase{}, // aux_buffer
+        se::DeviceMemoryBase{}, // a_scale_buffer
+        se::DeviceMemoryBase{}, // b_scale_buffer
+        se::DeviceMemoryBase{}, // c_scale_buffer
+        se::DeviceMemoryBase{}, // d_scale_buffer
+        se::DeviceMemoryBase{}, // d_amax_buffer
+        algorithms[algorithm_idx],
+        std::nullopt,          // workspace
+        &scratch_allocator, 
+        profile_result);
+}
+
 
 }  // namespace tensorflow
 

--- a/tensorflow/core/kernels/matmul_util.cc
+++ b/tensorflow/core/kernels/matmul_util.cc
@@ -184,7 +184,7 @@ StatusOr<se::blas::ComputationType> GetBlasComputationType(
   return &ptr->second;
 }
 
-Status PlanAndAlgorithms::DoBlasLtMatmul(se::Stream* stream, 
+Status PlanAndAlgorithms::ExecuteOnStream(se::Stream* stream, 
                       const se::DeviceMemoryBase& a,
                       const se::DeviceMemoryBase& b, 
                       se::DeviceMemoryBase& c,

--- a/tensorflow/core/kernels/matmul_util.h
+++ b/tensorflow/core/kernels/matmul_util.h
@@ -57,7 +57,7 @@ struct PlanAndAlgorithms {
     std::optional<int> max_algorithm_count = std::nullopt
   );
 
-  Status DoBlasLtMatmul(se::Stream* stream, 
+  Status ExecuteOnStream(se::Stream* stream, 
                     const se::DeviceMemoryBase& a,
                     const se::DeviceMemoryBase& b, 
                     se::DeviceMemoryBase& c,

--- a/tensorflow/core/kernels/matmul_util.h
+++ b/tensorflow/core/kernels/matmul_util.h
@@ -51,9 +51,23 @@ struct BlasLtMatmulPlanParams {
 };
 
 struct PlanAndAlgorithms {
+  
+  static StatusOr<const PlanAndAlgorithms*> GetOrCreate(
+    se::Stream* stream, const BlasLtMatmulPlanParams& params, absl::Mutex** pmu,
+    std::optional<int> max_algorithm_count = std::nullopt
+  );
+
+  Status DoBlasLtMatmul(se::Stream* stream, 
+                    const se::DeviceMemoryBase& a,
+                    const se::DeviceMemoryBase& b, 
+                    se::DeviceMemoryBase& c,
+                    size_t algorithm_idx, 
+                    se::ScratchAllocator& scratch_allocator,
+                    const se::DeviceMemoryBase& bias = se::DeviceMemoryBase{},
+                    se::blas::ProfileResult* profile_result = nullptr) const;
+
   se::gpu::BlasLt::MatmulPlanPtr plan;
   std::vector<se::gpu::BlasLt::MatmulAlgorithm> algorithms;
-  se::blas::DataType scale_type;  // this is needed for half / bf16 treatment
 };
 
 namespace internal {
@@ -71,37 +85,8 @@ H AbslHashValue(H h, const BlasLtMatmulPlanParams& params) {
   return H::combine(std::move(h), internal::AsTuple(params));
 }
 
-StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
-    se::Stream* stream, const BlasLtMatmulPlanParams& params, absl::Mutex** pmu,
-    std::optional<int> max_algorithm_count = std::nullopt);
-
-template <typename T>
-Status DoBlasLtMatmul(se::Stream* stream, const PlanAndAlgorithms& paa,
-                      const se::DeviceMemory<T>& a,
-                      const se::DeviceMemory<T>& b, se::DeviceMemory<T>& c,
-                      size_t alg_idx, se::ScratchAllocator& scratch_allocator,
-                      const se::DeviceMemory<T>& bias = {},
-                      se::blas::ProfileResult* profile_result = nullptr) {
-  se::DeviceMemory<T> aux{};  // We don't use the auxilary buffers.
-  const auto& algorithm = paa.algorithms[alg_idx];
-
-  // The scale type may be f32 if the data type is f16 and bf16.
-  if constexpr (std::is_same_v<T, Eigen::half> ||
-                std::is_same_v<T, Eigen::bfloat16>) {
-    if (paa.scale_type == se::blas::DataType::kFloat) {
-      return paa.plan->DoMatmul(stream, se::HostOrDeviceScalar<float>(1.0), b,
-                                a, se::HostOrDeviceScalar<float>(0.0), c, c,
-                                algorithm, scratch_allocator, bias, aux,
-                                profile_result);
-    }
-  }
-  return paa.plan->DoMatmul(stream, se::HostOrDeviceScalar<T>(T(1.0)), b, a,
-                            se::HostOrDeviceScalar<T>(T(0.0)), c, c, algorithm,
-                            scratch_allocator, bias, aux, profile_result);
-}
-
 }  // namespace tensorflow
 
-#endif
+#endif // GOOGLE_CUDA || TF_HIPBLASLT
 
 #endif  // TENSORFLOW_CORE_KERNELS_MATMUL_UTIL_H_


### PR DESCRIPTION
The only reason gpu_blas_lt exposes [DoMatmul](https://github.com/ROCm/tensorflow-upstream/blob/e20ec8d81ee4084cd562e4df35c0cfccfaf8417e/third_party/xla/xla/stream_executor/gpu/gpu_blas_lt.h#L157) interfaces is this single place. This is probably happens due to historical reasons.

Here I refactor it to use well-established **ExecuteOnStream** interface function which handles valid data type combinations [automatically](https://github.com/ROCm/tensorflow-upstream/blob/e20ec8d81ee4084cd562e4df35c0cfccfaf8417e/third_party/xla/xla/stream_executor/cuda/cuda_blas_lt.cc#L601).

Once this place is fixed, we can greatly simplify gpu_blas_lt inteface in XLA by removing those DoMatmul low-level functions.
Besides, I also did some improvements for ROCM platform (e.g. for hipblas-lt support).
