### PR TITLE
Fix : Argument missing in TPUClusterResolver.connect

### DIFF
--- a/tensorflow/python/distribute/cluster_resolver/tpu/tpu_cluster_resolver.py
+++ b/tensorflow/python/distribute/cluster_resolver/tpu/tpu_cluster_resolver.py
@@ -144,7 +144,7 @@ class TPUClusterResolver(cluster_resolver_lib.ClusterResolver):
     """
     resolver = TPUClusterResolver(tpu, zone, project)
     remote.connect_to_cluster(resolver)
-    tpu_strategy_util.initialize_tpu_system_impl(resolver)
+    tpu_strategy_util.initialize_tpu_system_impl(resolver, TPUClusterResolver)
     return resolver
 
   @staticmethod


### PR DESCRIPTION
FIX: `TPUClusterResolver.connect` missing argument