### PR TITLE
BatchMatrixInverse deprecation notice

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_BatchMatrixInverse.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_BatchMatrixInverse.pbtxt
@@ -1,3 +1,13 @@
 op {
   graph_op_name: "BatchMatrixInverse"
+  deprecation {
+    version: 2
+    explanation: "Use tf.linalg.inv instead."
+  }
+  description: <<END
+DEPRECATED: This operation is deprecated. Use tf.linalg.inv instead.
+
+Computes the inverse of one or more square invertible matrices or their
+adjoints (conjugate transposes).
+END
 }

--- a/tensorflow/core/api_def/base_api/api_def_BatchMatrixInverse.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_BatchMatrixInverse.pbtxt
@@ -1,11 +1,8 @@
 op {
   graph_op_name: "BatchMatrixInverse"
-  deprecation {
-    version: 2
-    explanation: "Use tf.linalg.inv instead."
-  }
   description: <<END
-DEPRECATED: This operation is deprecated. Use tf.linalg.inv instead.
+DEPRECATED: This operation is deprecated and will be removed in a future version.
+Use tf.linalg.inv instead.
 
 Computes the inverse of one or more square invertible matrices or their
 adjoints (conjugate transposes).


### PR DESCRIPTION
- BatchMatrixInverse has been depreciated in Tensorflow 2.16 but, the documentation for it is still live on the online documentation.
- This PR aims to push changes to the online documentation.