### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/checkpoint/async_checkpoint_helper.py
+++ b/tensorflow/python/checkpoint/async_checkpoint_helper.py
@@ -442,7 +442,7 @@ class AsyncCheckpointHelper:
   def save_counter(self):
     """An integer variable numbering the checkpoint events.
 
-    This is maintained by the underlying tf.train.Checkpoing object employed by
+    This is maintained by the underlying tf.train.Checkpoint object employed by
     AsyncCheckpoint class. The number starts at 0 and gets incremented for each
     checkpoint event.
 
@@ -488,7 +488,7 @@ class AsyncCheckpointHelper:
       self._copy_to_cpu()
 
     # Surface the error from the async thread, if any.
-    # This step should come after the sem acquision step in the above, so that
+    # This step should come after the sem acquisition step in the above, so that
     # it makes sure it waits until the previous async save finishes storing the
     # error.
     self._check_async_thread_error()
@@ -546,7 +546,7 @@ class AsyncCheckpointHelper:
       self._copy_to_cpu()
 
     # Surface the error from the async thread, if any.
-    # This step should come after the sem acquision step in the above, so that
+    # This step should come after the sem acquisition step in the above, so that
     # it makes sure it waits until the previous async save finishes storing the
     # error.
     self._check_async_thread_error()

--- a/tensorflow/python/checkpoint/checkpoint.py
+++ b/tensorflow/python/checkpoint/checkpoint.py
@@ -2577,7 +2577,7 @@ class Checkpoint(autotrackable.AutoTrackable):
       self._checkpoint_options = options
     # Triggers TF2 async checkpoint handling if:
     # 1. async checkpoint is enabled in CheckpointOptions
-    # 2. there's a preceeding async save/write
+    # 2. there's a preceding async save/write
     # 3. running in eager mode
     if (self._checkpoint_options and
         self._checkpoint_options.experimental_enable_async_checkpoint):
@@ -2708,7 +2708,7 @@ class Checkpoint(autotrackable.AutoTrackable):
       self._checkpoint_options = options
     # Triggers TF2 async checkpoint handling if:
     # 1. async checkpoint is enabled in CheckpointOptions
-    # 2. there's a preceeding async save/write
+    # 2. there's a preceding async save/write
     # 3. running in eager mode
     if (self._checkpoint_options and
         self._checkpoint_options.experimental_enable_async_checkpoint):

--- a/tensorflow/python/checkpoint/checkpoint_adapter.py
+++ b/tensorflow/python/checkpoint/checkpoint_adapter.py
@@ -44,7 +44,7 @@ class ReshardCallback:
 
     Override this to reshard/modify the restored values
     Args:
-      checkpoint_values: The values retured by the restore op, as read from
+      checkpoint_values: The values returned by the restore op, as read from
         file.
       shape_and_slice_spec: The shape and slice spec required by the caller.
 

--- a/tensorflow/python/checkpoint/checkpoint_management.py
+++ b/tensorflow/python/checkpoint/checkpoint_management.py
@@ -611,7 +611,7 @@ class CheckpointManager(object):
         counter value, in case users want to save checkpoints every N steps.
       checkpoint_interval: An integer, indicates the minimum step interval
         between two checkpoints.
-      init_fn: Callable. A function to do customized intialization if no
+      init_fn: Callable. A function to do customized initialization if no
         checkpoints are in the directory.
 
     Raises:
@@ -866,7 +866,7 @@ class CheckpointManager(object):
     `tf.train.Checkpoint.restore()` method.
 
     Returns:
-      The restored checkpoint path if the lastest checkpoint is found and
+      The restored checkpoint path if the latest checkpoint is found and
       restored. Otherwise None.
     """
     # TODO(chienchunh): When AsyncCheckpoint is used, we may need to force to

--- a/tensorflow/python/checkpoint/checkpoint_options.py
+++ b/tensorflow/python/checkpoint/checkpoint_options.py
@@ -86,7 +86,7 @@ class CheckpointOptions(object):
       enable_async: bool Type. Indicates whether async checkpointing is enabled.
         Default is False, i.e., no async checkpoint.  Async checkpoint moves the
         checkpoint file writing off the main thread, so that the model can
-        continue to train while the checkpoing file writing runs in the
+        continue to train while the checkpoint file writing runs in the
         background. Async checkpoint reduces TPU device idle cycles and speeds
         up model training process, while memory consumption may increase.
       experimental_skip_slot_variables: bool Type. If true, ignores slot

--- a/tensorflow/python/checkpoint/save_util_v1.py
+++ b/tensorflow/python/checkpoint/save_util_v1.py
@@ -82,7 +82,7 @@ def get_checkpoint_factories_and_keys(object_names, object_map=None):
 
         if not saveable_compat.force_checkpoint_conversion_enabled():
           # Make sure the set the name as the legacy saveable name if there
-          # is one (only when checkpoint conversion is diabled)
+          # is one (only when checkpoint conversion is disabled)
           name = key_suffix
 
         checkpoint_factory_map[trackable].append(

--- a/tensorflow/python/checkpoint/util.py
+++ b/tensorflow/python/checkpoint/util.py
@@ -79,7 +79,7 @@ def get_mapped_trackable(trackable, object_map):
 
 
 def get_full_name(var):
-  """Gets the full name of variable for name-based checkpoint compatiblity."""
+  """Gets the full name of variable for name-based checkpoint compatibility."""
   # pylint: disable=protected-access
   if (not (isinstance(var, variables.Variable) or
            # Some objects do not subclass Variable but still act as one.


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.