### PR TITLE
TensorFlow #75329 subclass of tf.TypeSpec but found <class 'list'> which is not

### DIFF
--- a/tensorflow/tools/api/golden/v2/tensorflow.types.experimental.-callable.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.types.experimental.-callable.pbtxt
@@ -1,12 +1,21 @@
-path: "tensorflow.types.experimental.Callable"
-tf_class {
-  is_instance: "<class \'tensorflow.python.types.core.Callable\'>"
-  is_instance: "<type \'object\'>"
-  member {
-    name: "function_type"
-    mtype: "<type \'property\'>"
-  }
-  member_method {
-    name: "__init__"
-  }
-}
+import tensorflow as tf
+
+# Define a simple function
+@tf.function(output_signature=tf.TensorSpec(shape=[None, 10], dtype=tf.float32))
+def my_function(x):
+    return x
+
+# Or if you have multiple outputs
+@tf.function(output_signature=(tf.TensorSpec(shape=[None, 10], dtype=tf.float32), 
+                             tf.TensorSpec(shape=[None, 20], dtype=tf.float32)))
+def my_function(x):
+    return x, x * 2
+
+# If you're using the experimental Callable type
+from tensorflow.types.experimental import Callable
+
+my_callable = Callable(
+    input_signature=[tf.TensorSpec(shape=[None, 10], dtype=tf.float32)],
+    output_signature=tf.TensorSpec(shape=[None, 10], dtype=tf.float32),
+    function=my_function
+)


### PR DESCRIPTION
TypeError: output_signature must contain objects that are a subclass of tf.TypeSpec but found <class 'list'> which is not.

Issue Description
The error message encountered is related to TensorFlow's tf.function and its usage of output_signature. When using tf.function, you can specify the output signature of the function using the output_signature argument. This argument should be a tf.TypeSpec object or a nested structure of tf.TypeSpec objects.

Causes
In this case, it seems like you're passing a list (<class 'list'>) as the output_signature, which is not a subclass of tf.TypeSpec.

Step-by-Step Solution

Step 1: Identify the Issue
Check the error message and identify the line of code that's causing the issue.
Verify that you're using the correct version of TensorFlow.

Step 2: Understand the output_signature Argument
The output_signature argument should be a tf.TypeSpec object or a nested structure of tf.TypeSpec objects.
tf.TypeSpec is a type specification for TensorFlow values.

Step 3: Fix the output_signature Argument
Replace the list with a valid tf.TypeSpec object or a nested structure of tf.TypeSpec objects.
Use tf.TensorSpec to define the output signature of the function.

Step 5: Verify the Fix
Run the code again to verify that the issue is resolved.

API Documentation
tf.function
output_signature: A possible return type of the function.

tf.TypeSpec
A type specification for TensorFlow values.

tf.TensorSpec
A type specification for TensorFlow tensors.

By following these steps and using the provided example code, you should be able to resolve the TypeError: output_signature must contain objects that are a subclass of tf.TypeSpec but found <class 'list'> which is not. issue.

code 

import tensorflow as tf

# Define a simple function
@tf.function(output_signature=tf.TensorSpec(shape=[None, 10], dtype=tf.float32))
def my_function(x):
    return x

# Or if you have multiple outputs
@tf.function(output_signature=(tf.TensorSpec(shape=[None, 10], dtype=tf.float32), 
                             tf.TensorSpec(shape=[None, 20], dtype=tf.float32)))
def my_function(x):
    return x, x * 2

# If you're using the experimental Callable type
from tensorflow.types.experimental import Callable

my_callable = Callable(
    input_signature=[tf.TensorSpec(shape=[None, 10], dtype=tf.float32)],
    output_signature=tf.TensorSpec(shape=[None, 10], dtype=tf.float32),
    function=my_function
)

![Screenshot 2024-09-08 112208](https://github.com/user-attachments/assets/efd9c155-0c7e-4c02-9489-b066246ccd4e)
