### PR TITLE
Avoid calling nccl NVTX_PAYLOAD_EVTATTR_SET externally

### DIFF
--- a/third_party/xla/third_party/tsl/tsl/profiler/lib/nvtx_utils.cc
+++ b/third_party/xla/third_party/tsl/tsl/profiler/lib/nvtx_utils.cc
@@ -92,12 +92,8 @@ void RangePush(ProfilerDomainHandle domain, StringHandle title,
   attrs.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
   attrs.messageType = NVTX_MESSAGE_TYPE_REGISTERED;
   attrs.message.registered = reinterpret_cast<nvtxStringHandle_t>(title);
-#ifdef NVTX_VERSION_3_1
-  NVTX_PAYLOAD_EVTATTR_SET(&attrs, schema_id, payload, payload_size);
-#else
-  NVTX_PAYLOAD_EVTATTR_SET(attrs, schema_id, payload, payload_size);
-#endif
-  nvtxDomainRangePushEx(reinterpret_cast<nvtxDomainHandle_t>(domain), &attrs);
+  nvtxPayloadRangePush(reinterpret_cast<nvtxDomainHandle_t>(domain), &attrs,
+                       schema_id, payload, payload_size);
 }
 }  // namespace detail
 


### PR DESCRIPTION
nccl 2.23.4 has changed the API def of NVTX_PAYLOAD_EVTATTR_SET, this API is not stable, and it should be avoided to call it externally. 
 