### PR TITLE
Updated tf.compat.as_str API with Args, Returns and Raises in compat.py

### DIFF
--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -109,7 +109,20 @@ def as_text(bytes_or_text, encoding='utf-8'):
 
 
 def as_str(bytes_or_text, encoding='utf-8'):
-  return as_text(bytes_or_text, encoding)
+  """Acts as an alias for the `as_text` function..
+ 
+  Args:
+    bytes_or_text: The input value to be converted. A bytes or unicode object.
+    encoding: Optional string. The encoding to use if bytes_or_text is a bytes object. Defaults to 'utf-8'.
+
+  Returns:
+    A unicode string.
+    
+  Raises:
+    TypeError: If bytes_or_text is not a bytes or unicode object.
+    UnicodeDecodeError: If bytes_or_text is a bytes object and cannot be decoded using the specified encoding.
+ """    
+return as_text(bytes_or_text, encoding)
 
 tf_export('compat.as_text')(as_text)
 tf_export('compat.as_bytes')(as_bytes)

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -121,8 +121,8 @@ def as_str(bytes_or_text, encoding='utf-8'):
   Raises:
     TypeError: If bytes_or_text is not a bytes or unicode object.
     UnicodeDecodeError: If bytes_or_text is a bytes object and cannot be decoded using the specified encoding.
- """    
-return as_text(bytes_or_text, encoding)
+  """    
+  return as_text(bytes_or_text, encoding)
 
 tf_export('compat.as_text')(as_text)
 tf_export('compat.as_bytes')(as_bytes)

--- a/tensorflow/python/util/compat.py
+++ b/tensorflow/python/util/compat.py
@@ -113,14 +113,16 @@ def as_str(bytes_or_text, encoding='utf-8'):
  
   Args:
     bytes_or_text: The input value to be converted. A bytes or unicode object.
-    encoding: Optional string. The encoding to use if bytes_or_text is a bytes object. Defaults to 'utf-8'.
+    encoding: Optional string. The encoding to use if bytes_or_text is 
+              a bytes object. Defaults to 'utf-8'.
 
   Returns:
     A unicode string.
     
   Raises:
     TypeError: If bytes_or_text is not a bytes or unicode object.
-    UnicodeDecodeError: If bytes_or_text is a bytes object and cannot be decoded using the specified encoding.
+    UnicodeDecodeError: If bytes_or_text is a bytes object and cannot be 
+                        decoded using the specified encoding.
   """    
   return as_text(bytes_or_text, encoding)
 


### PR DESCRIPTION
Hi,

Please review this PR. The API `tf.compat.as_str`  acts as an alias for the `tf.compat.as_text` function. Updated the same in addition to Args, Returns and Raises.

Thank You