### PR TITLE
Add null pointer check for an output tensor calibration

### DIFF
--- a/tensorflow/lite/tools/optimize/calibration/calibrator.cc
+++ b/tensorflow/lite/tools/optimize/calibration/calibrator.cc
@@ -263,9 +263,11 @@ TfLiteStatus LoggingEval(TfLiteContext* context, TfLiteNode* node) {
 
   for (int i : op_info.loggable_outputs) {
     auto tensor = context->tensors[i];
-    TF_LITE_ENSURE_STATUS(
-        logger->LogTensorValue(op_info.subgraph_index, i, tensor.data.f,
-                               tensor.bytes / sizeof(float), error_reporter));
+    if (tensor.data.raw != nullptr) {
+      TF_LITE_ENSURE_STATUS(
+          logger->LogTensorValue(op_info.subgraph_index, i, tensor.data.f,
+                                 tensor.bytes / sizeof(float), error_reporter));
+    }
   }
 
   return kTfLiteOk;


### PR DESCRIPTION
Otherwise it segfaults while trying to log the WHILE op.

It's the simplest possible fix for #75140. I believe that it makes sense to fix the crash now, and look for the proper way to fix the calibration logic later.