### PR TITLE
fix integer overflow in range

### DIFF
--- a/tensorflow/core/kernels/ragged_range_op.cc
+++ b/tensorflow/core/kernels/ragged_range_op.cc
@@ -87,8 +87,27 @@ class RaggedRangeOp : public OpKernel {
         size = 0;
       } else if constexpr (std::is_integral<T>::value) {
         // The following is copied from tensorflow::RangeOp::Compute().
-        size = Eigen::divup(Eigen::numext::abs(limit - start),
-                            Eigen::numext::abs(delta));
+        uint64_t range;
+        if ((limit > 0 && start < 0) || (limit < 0 && start > 0)) {
+          range = static_cast<uint64_t>(Eigen::numext::abs(limit))
+                  + static_cast<uint64_t>(Eigen::numext::abs(start));
+        } else {
+          range = static_cast<uint64_t>(Eigen::numext::abs(limit - start));
+        }
+
+        uint64_t size_unsigned = Eigen::divup(range,
+                      static_cast<uint64_t>(Eigen::numext::abs(delta)));
+        OP_REQUIRES(
+            context, size_unsigned <= std::numeric_limits<int64_t>::max(),
+            errors::InvalidArgument("Requires ((limit - start) / delta) <= ",
+                                    std::numeric_limits<int64_t>::max()));
+        OP_REQUIRES(
+            context,
+            size_unsigned <=
+              std::numeric_limits<SPLITS_TYPE>::max() - rt_nested_splits(row),
+            InvalidArgument("The total range size overflowed. Consider using "
+                            "int64 instead of int32 for row_splits_dtype."));
+        size = static_cast<SPLITS_TYPE>(size_unsigned);
       } else {
         // The following is copied from tensorflow::RangeOp::Compute().
         auto size_auto =

--- a/tensorflow/core/kernels/ragged_range_op_test.cc
+++ b/tensorflow/core/kernels/ragged_range_op_test.cc
@@ -89,6 +89,17 @@ TEST_F(RaggedRangeOpTest, RangeSizeOverflow) {
             RunOpKernel().message());
 }
 
+TEST_F(RaggedRangeOpTest, RangeSizeOverflow2) {
+  BuildRaggedRangeGraph<int64>();
+  AddInputFromArray<int64>(TensorShape({}), {static_cast<int64_t>(5e18)});
+  AddInputFromArray<int64>(TensorShape({}), {static_cast<int64_t>(-5e18)});
+  AddInputFromArray<int64>(TensorShape({}), {-1});
+
+  EXPECT_EQ(absl::StrCat("Requires ((limit - start) / delta) <= ",
+                         std::numeric_limits<int64_t>::max()),
+            RunOpKernel().message()); 
+}
+
 TEST_F(RaggedRangeOpTest, BroadcastDeltas) {
   BuildRaggedRangeGraph<int>();
   AddInputFromArray<int>(TensorShape({3}), {0, 5, 8});  // starts

--- a/tensorflow/core/kernels/sequence_ops.cc
+++ b/tensorflow/core/kernels/sequence_ops.cc
@@ -93,8 +93,21 @@ class RangeOp : public OpKernel {
     }
     int64_t size;
     if constexpr (std::is_integral<T>::value) {
-      size = Eigen::divup(Eigen::numext::abs(limit - start),
-                          Eigen::numext::abs(delta));
+      uint64_t range;
+      if ((limit > 0 && start < 0) || (limit < 0 && start > 0)) {
+        range = static_cast<uint64_t>(Eigen::numext::abs(limit))
+                + static_cast<uint64_t>(Eigen::numext::abs(start));
+      } else {
+        range = static_cast<uint64_t>(Eigen::numext::abs(limit - start));
+      }
+
+      uint64_t size_unsigned = Eigen::divup(range,
+                    static_cast<uint64_t>(Eigen::numext::abs(delta)));
+      OP_REQUIRES(
+          context, size_unsigned <= std::numeric_limits<int64_t>::max(),
+          errors::InvalidArgument("Requires ((limit - start) / delta) <= ",
+                                  std::numeric_limits<int64_t>::max()));
+      size = static_cast<int64_t>(size_unsigned);
     } else {
       auto size_auto =
           Eigen::numext::ceil(Eigen::numext::abs((limit - start) / delta));

--- a/tensorflow/core/kernels/sequence_ops_test.cc
+++ b/tensorflow/core/kernels/sequence_ops_test.cc
@@ -115,6 +115,18 @@ TEST_F(RangeOpTest, Large_Double) {
   test::ExpectTensorEqual<double>(expected, *GetOutput(0));
 }
 
+TEST_F(RangeOpTest, RangeSizeOverflow) {
+  MakeOp(DT_INT64);
+
+  AddInputFromArray<int64>(TensorShape({}), {static_cast<int64_t>(5e18)});
+  AddInputFromArray<int64>(TensorShape({}), {static_cast<int64_t>(-5e18)});
+  AddInputFromArray<int64>(TensorShape({}), {-1});
+
+  EXPECT_EQ(absl::StrCat("Requires ((limit - start) / delta) <= ",
+                         std::numeric_limits<int64_t>::max()),
+            RunOpKernel().message());
+}
+
 TEST_F(LinSpaceOpTest, Simple_D32) {
   MakeOp(DT_FLOAT, DT_INT32);
 

--- a/tensorflow/core/ops/math_ops.cc
+++ b/tensorflow/core/ops/math_ops.cc
@@ -1513,8 +1513,21 @@ Status RangeSize(const Tensor* start_t, const Tensor* limit_t,
 
   int64_t size;
   if (std::is_integral<T>::value) {
-    size = Eigen::divup(static_cast<int64_t>(Eigen::numext::abs(limit - start)),
-                        static_cast<int64_t>(Eigen::numext::abs(delta)));
+    uint64_t range;
+    if ((limit > 0 && start < 0) || (limit < 0 && start > 0)) {
+      range = static_cast<uint64_t>(Eigen::numext::abs(limit))
+              + static_cast<uint64_t>(Eigen::numext::abs(start));
+    } else {
+      range = static_cast<uint64_t>(Eigen::numext::abs(limit - start));
+    }
+
+    uint64_t size_unsigned = Eigen::divup(range,
+                             static_cast<uint64_t>(Eigen::numext::abs(delta)));
+    if (size_unsigned > std::numeric_limits<int64_t>::max()) {
+      return errors::InvalidArgument("Requires ((limit - start) / delta) <= ",
+                                     std::numeric_limits<int64_t>::max());
+    }
+    size = static_cast<int64_t>(size_unsigned);
   } else {
     auto size_auto =
         Eigen::numext::ceil(Eigen::numext::abs((limit - start) / delta));

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -1368,14 +1368,6 @@ class RangeTest(test_util.TensorFlowTestCase):
     actual = math_ops.range(start, end, step)
     self.assertAllEqual(expected, self.evaluate(actual))
 
-  def testInt64Overflow(self):
-    start = 5000000000000000000
-    end = -5000000000000000000
-    step = -1
-    with self.assertRaisesRegex(errors.InvalidArgumentError,
-                                "Requires ((limit - start) / delta) <= "):
-      self.evaluate(math_ops.range(start, end, step))
-
 
 @test_util.run_all_in_graph_and_eager_modes
 class ErfcinvTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -1360,6 +1360,22 @@ class RangeTest(test_util.TensorFlowTestCase):
     self.assertAllEqual(
         (0,), self.evaluate(x))  # smallest input with potential overflow
 
+  def testInt32Overflow(self):
+    start = 1136033460
+    end = -2110457150
+    step = -1849827689
+    expected = np.arange(start, end, step)
+    actual = math_ops.range(start, end, step)
+    self.assertAllEqual(expected, self.evaluate(actual))
+
+  def testInt64Overflow(self):
+    start = 5000000000000000000
+    end = -5000000000000000000
+    step = -1
+    with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                "Requires ((limit - start) / delta) <= "):
+      self.evaluate(math_ops.range(start, end, step))
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class ErfcinvTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/ragged/BUILD
+++ b/tensorflow/python/ops/ragged/BUILD
@@ -904,6 +904,7 @@ py_strict_test(
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/ops:ragged_math_ops_gen",
         "//tensorflow/python/platform:test",
+        "//third_party/py/numpy",
     ],
 )
 

--- a/tensorflow/python/ops/ragged/ragged_range_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_range_op_test.py
@@ -139,14 +139,6 @@ class RaggedRangeOpTest(test_util.TensorFlowTestCase):
     actual = ragged_math_ops.range(start, end, step)
     self.assertAllEqual(expected, self.evaluate(actual))
 
-  def testInt64Overflow(self):
-    start = 5000000000000000000
-    end = -5000000000000000000
-    step = -1
-    with self.assertRaisesRegex(errors.InvalidArgumentError,
-                                "Requires ((limit - start) / delta) <= "):
-      self.evaluate(ragged_math_ops.range(start, end, step))
-
 
 if __name__ == '__main__':
   googletest.main()

--- a/tensorflow/python/ops/ragged/ragged_range_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_range_op_test.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Tests for ragged_range op."""
 
+import numpy as np
+
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
@@ -128,6 +130,22 @@ class RaggedRangeOpTest(test_util.TensorFlowTestCase):
         ragged_math_ops.range([1, 2, 3]).shape.as_list(), [3, None])
     self.assertAllEqual(
         ragged_math_ops.range([1, 2, 3], [4, 5, 6]).shape.as_list(), [3, None])
+
+  def testInt32Overflow(self):
+    start = 1136033460
+    end = -2110457150
+    step = -1849827689
+    expected = [np.arange(start, end, step)]
+    actual = ragged_math_ops.range(start, end, step)
+    self.assertAllEqual(expected, self.evaluate(actual))
+
+  def testInt64Overflow(self):
+    start = 5000000000000000000
+    end = -5000000000000000000
+    step = -1
+    with self.assertRaisesRegex(errors.InvalidArgumentError,
+                                "Requires ((limit - start) / delta) <= "):
+      self.evaluate(ragged_math_ops.range(start, end, step))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #64081 

I modified the fix from the rolled back PR #76252 to check that the value of the unsigned size does not exceed the max value of the `int64_t` data type before casting it back to the signed type.