### PR TITLE
Fix `memcpy` call with null data in `SimpleDynamicBuffer`

### DIFF
--- a/tensorflow/compiler/mlir/lite/utils/string_utils.cc
+++ b/tensorflow/compiler/mlir/lite/utils/string_utils.cc
@@ -28,6 +28,12 @@ bool SimpleDynamicBuffer::AddString(const char* str, size_t len) {
   // will overflow to something less than max_length_. After checking `len <=
   // max_length_` we can use this subtraction to check for overflow.
   if (len > max_length_ || data_.size() >= max_length_ - len) return false;
+  // It is undefined to call memcpy with `nullptr`, and that will be the case if
+  // `len` is 0, and `data_` is empty. An empty record is created though.
+  if (len == 0) {
+    offset_.push_back(offset_.back());
+    return true;
+  }
   data_.resize(data_.size() + len);
   memcpy(data_.data() + offset_.back(), str, len);
   offset_.push_back(offset_.back() + len);
@@ -70,7 +76,9 @@ int SimpleDynamicBuffer::WriteToBuffer(char** buffer) {
   }
 
   // Copy data of strings.
-  memcpy(*buffer + start, data_.data(), data_.size());
+  if (data_.size() > 0) {
+    memcpy(*buffer + start, data_.data(), data_.size());
+  }
   return bytes;
 }
 

--- a/tensorflow/lite/string_util_test.cc
+++ b/tensorflow/lite/string_util_test.cc
@@ -230,4 +230,21 @@ TEST(StringUtil, TestShapes) {
   EXPECT_EQ(t0->dims->data[1], 2);
 }
 
+TEST(StringUtil, EmptyStringWithEmptyBuffer) {
+  Interpreter interpreter;
+  interpreter.AddTensors(1);
+  TfLiteTensor* t0 = interpreter.tensor(0);
+  t0->type = kTfLiteString;
+  t0->allocation_type = kTfLiteDynamic;
+
+  DynamicBuffer buf;
+  std::string empty_string;
+  ASSERT_EQ(buf.AddString(empty_string.data(), empty_string.length()),
+            kTfLiteOk);
+  buf.WriteToTensorAsVector(t0);
+
+  StringRef added_string = GetString(t0, 0);
+  EXPECT_EQ(added_string.len, 0);
+}
+
 }  // namespace tflite


### PR DESCRIPTION
It is undefined to call `memcpy` with either source or destination being `nullptr`. `SimpleDynamicBuffer` missed checks for this, as there are many cases where an empty string is passed as a value, and as a result `memcpy` ends up being called with new, for case when `data_` is empty.

This change adds the necessary checks to avoid this issue.

Bug: https://github.com/tensorflow/tensorflow/issues/77168