### PR TITLE
[tflite] Correct syntax for ARM assembly numeric literals

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/4bit/neon_fully_connected_arm32.cc
+++ b/tensorflow/lite/kernels/internal/optimized/4bit/neon_fully_connected_arm32.cc
@@ -38,7 +38,7 @@ namespace optimized_4bit {
 #define END "8"
 
 #define KERNEL_4x1                       \
-  "mov r8, 0xf\n"                        \
+  "mov r8, #0xf\n"                       \
   "vdup.8 d28, r8\n"                     \
   "mov r0, %[element_ptr]\n"             \
   "mov r6, %[lhs_val]\n"                 \


### PR DESCRIPTION
This change corrects syntax for immediate values used in the inline assembler to be compatible with the GNU assembler.

See https://developer.arm.com/documentation/dui0742/h/migrating-arm-syntax-assembly-code-to-gnu-syntax/numeric-literals for more information.

The original  code: https://github.com/tensorflow/tensorflow/blob/efcc8ded70356d66755f1b00b7f4efc69d5db44d/tensorflow/lite/kernels/internal/optimized/4bit/neon_fully_connected_arm32.cc#L40

Fails to build with GNU C++ based ARM toolchains, with the following error:
```
/tmp/ccOHroTu.s: Assembler messages:
/tmp/ccOHroTu.s:79: Error: immediate expression requires a # prefix -- `mov r8,0xf'
```

Change-Id: I3181b61ac1c46d1d90447fffd1cdd9480c962ad8