### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/util/BUILD
+++ b/tensorflow/python/util/BUILD
@@ -588,7 +588,7 @@ tf_py_strict_test(
     ],
 )
 
-# Placeholder for intenal nest_test comments.
+# Placeholder for internal nest_test comments.
 tf_py_strict_test(
     name = "nest_test",
     size = "small",

--- a/tensorflow/python/util/custom_nest_protocol.py
+++ b/tensorflow/python/util/custom_nest_protocol.py
@@ -96,7 +96,7 @@ class CustomNestProtocol(Protocol):
     - This method only needs to flatten the current level. If current object has
       an attribute that also need custom flattening, nest functions (such as
       `nest.flatten`) will utilize this method to do recursive flattening.
-    - Components must ba a `tuple`, not a `list`
+    - Components must be a `tuple`, not a `list`
     """
 
   @classmethod
@@ -104,7 +104,7 @@ class CustomNestProtocol(Protocol):
     """Create a user-defined object from (metadata, components).
 
     Args:
-      metadata: a custom Python objet that stands for the static config for
+      metadata: a custom Python object that stands for the static config for
         reconstructing a new object of the current class.
       components: a `tuple` that contains the dynamic data fields of the current
         class, for object reconstruction.

--- a/tensorflow/python/util/dispatch.py
+++ b/tensorflow/python/util/dispatch.py
@@ -234,7 +234,7 @@ def get_compatible_func(op, func):
   op_signature = _remove_annotation(tf_inspect.signature(op))
   func_signature = _remove_annotation(tf_inspect.signature(func))
 
-  # Identitical signatures, no need to apply compatibility fixes.
+  # Identical signatures, no need to apply compatibility fixes.
   if op_signature == func_signature:
     return func
 
@@ -395,7 +395,7 @@ def dispatch_for_api(api, *signatures):
   being overridden.  In particular, parameters must have the same names, and
   must occur in the same order.  The dispatch target may optionally elide the
   "name" parameter, in which case it will be wrapped with a call to
-  `tf.name_scope` when appropraite.
+  `tf.name_scope` when appropriate.
 
   Args:
     api: The TensorFlow API to override.
@@ -797,7 +797,7 @@ def _signature_from_annotations(func):
 # decorators.
 #
 # _ELEMENTWISE_API_TARGETS: Dict mapping from argument type(s) to lists of
-# `(api, dispatch_target)` pairs.  Used to impelement
+# `(api, dispatch_target)` pairs.  Used to implement
 # `unregister_elementwise_api_handler`.
 _UNARY_ELEMENTWISE_APIS = []
 _BINARY_ELEMENTWISE_APIS = []
@@ -1206,7 +1206,7 @@ def add_dispatch_support(target=None, iterable_parameters=None):
   need to be handled specially during dispatch, since just iterating over an
   iterable uses up its values.  In the following example, we define a new API
   whose second argument can be an iterable value; and then override the default
-  implementatio of that API when the iterable contains MaskedTensors:
+  implementation of that API when the iterable contains MaskedTensors:
 
   >>> @add_dispatch_support(iterable_parameters=['ys'])
   ... def add_tensor_to_list_of_tensors(x, ys):
@@ -1245,7 +1245,7 @@ def add_dispatch_support(target=None, iterable_parameters=None):
 
     @traceback_utils.filter_traceback
     def op_dispatch_handler(*args, **kwargs):
-      """Call `dispatch_target`, peforming dispatch when appropriate."""
+      """Call `dispatch_target`, performing dispatch when appropriate."""
 
       # Type-based dispatch system (dispatch v2):
       if api_dispatcher is not None:

--- a/tensorflow/python/util/dispatch_test.py
+++ b/tensorflow/python/util/dispatch_test.py
@@ -957,7 +957,7 @@ class DispatchV2Test(test_util.TensorFlowTestCase):
       def silly_abs(x: SillyTensor):
         del x
 
-      # Note: `expeced` does not contain keys or values from SillyTensor.
+      # Note: `expected` does not contain keys or values from SillyTensor.
       targets = dispatch.type_based_dispatch_signatures_for(MaskedTensor)
       expected = {math_ops.add: [{"x": MaskedTensor, "y": MaskedTensor}],
                   array_ops.concat: [{"values": MaskedTensorList}]}

--- a/tensorflow/python/util/function_parameter_canonicalizer.cc
+++ b/tensorflow/python/util/function_parameter_canonicalizer.cc
@@ -120,7 +120,7 @@ bool FunctionParameterCanonicalizer::Canonicalize(
         index = InternedArgNameLinearSearch(key);
         Py_DECREF(key);
 
-        // Stil not found, then return an error.
+        // Still not found, then return an error.
         if (TF_PREDICT_FALSE(index == interned_arg_names_.size())) {
           PyErr_Format(PyExc_TypeError,
                        "Got an unexpected keyword argument '%s'",

--- a/tensorflow/python/util/lazy_loader.py
+++ b/tensorflow/python/util/lazy_loader.py
@@ -37,7 +37,7 @@ class LazyLoader(types.ModuleType):
     self._tfll_warning = warning
 
     # These members allows doctest correctly process this module member without
-    # triggering self._load(). self._load() mutates parant_module_globals and
+    # triggering self._load(). self._load() mutates parent_module_globals and
     # triggers a dict mutated during iteration error from doctest.py.
     # - for from_module()
     super().__setattr__("__module__", name.rsplit(".", 1)[0])

--- a/tensorflow/python/util/nest_test.py
+++ b/tensorflow/python/util/nest_test.py
@@ -92,7 +92,7 @@ class MaskedTensor:
     )
 
   def __len__(self):
-    # Used by `nest.map_structure_up_to` and releatd functions to verify the
+    # Used by `nest.map_structure_up_to` and related functions to verify the
     # arity compatibility.
     return 1
 

--- a/tensorflow/python/util/nest_util.py
+++ b/tensorflow/python/util/nest_util.py
@@ -553,7 +553,7 @@ def _tf_core_packed_nest_with_indices(
     index: Index at which to start reading from flat.
     is_nested_fn: Function used to test if a value should be treated as a nested
       structure.
-    sequence_fn: Function used to generate a new strcuture instance.
+    sequence_fn: Function used to generate a new structure instance.
 
   Returns:
     The tuple (new_index, child), where:

--- a/tensorflow/python/util/util.cc
+++ b/tensorflow/python/util/util.cc
@@ -816,7 +816,7 @@ void SetDifferentKeysError(PyObject* dict1, PyObject* dict2, string* error_msg,
 // Returns true iff there were no "internal" errors. In other words,
 // errors that has nothing to do with structure checking.
 // If an "internal" error occurred, the appropriate Python error will be
-// set and the caller can propage it directly to the user.
+// set and the caller can propagate it directly to the user.
 //
 // Both `error_msg` and `is_type_error` must be non-null. `error_msg` must
 // be empty.


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.