### PR TITLE
Fix image display in profiler module documentation

### DIFF
--- a/tensorflow/core/profiler/g3doc/command_line.md
+++ b/tensorflow/core/profiler/g3doc/command_line.md
@@ -183,9 +183,8 @@ _TFProfRoot (0us/22.44ms)
 ```
 
 Set ```-output timeline:outfile=<filename>``` to generate timeline instead of stdout.
-<left>
+
 ![CodeTimeline](code_timeline.png)
-</left>
 
 #### Profile Graph Time
 

--- a/tensorflow/core/profiler/g3doc/profile_time.md
+++ b/tensorflow/core/profiler/g3doc/profile_time.md
@@ -107,9 +107,8 @@ tfprof_node = model_analyzer.print_model_analysis(
 
 You can generate some visualization in code view:
 Set ```-output timeline:outfile=<filename>``` to generate timeline instead of stdout.
-<left>
+
 ![CodeTimeline](code_timeline.png)
-</left>
 
 
 ### Profile by Operation Type
@@ -145,10 +144,7 @@ Usually, use graph view to generate a timeline to visualize the result.
 In the chrome://tracing UI, click "Flow Event" in "View Options" of upper
 right corner to see the flow of tensors.
 
-<left>
-TODO(xpan): Show the image correctly in github.
 ![Timeline](graph_timeline.png)
-</left>
 
 tfprof options allow users to generate timeline in some advanced ways.
 

--- a/tensorflow/core/profiler/g3doc/python_api.md
+++ b/tensorflow/core/profiler/g3doc/python_api.md
@@ -99,10 +99,8 @@ Open a Chrome Browser, type URL `chrome://tracing`, and load the json file.
 
 Below are 2 examples of graph view and scope view.
 
-<left>
 ![CodeTimeline](graph_timeline.png)
 ![CodeTimeline](scope_timeline.png)
-</left>
 
 ### Multi-step Profiling
 


### PR DESCRIPTION
While reading the profiler documentation, I noticed that the images weren't showing up correctly. Then I found some `<left>` labels in the docs. These labels aren't standard HTML and were causing the images to not render properly. I checked and saw that these `<left>` labels were only in the profiler section. This pull request removes those invalid labels so the images display correctly.