### PR TITLE
Update broken link in the Optimize.md

### DIFF
--- a/tensorflow/lite/g3doc/api_docs/python/tf/lite/Optimize.md
+++ b/tensorflow/lite/g3doc/api_docs/python/tf/lite/Optimize.md
@@ -38,7 +38,7 @@ DEFAULT
     The default optimization strategy that enables post-training quantization.
     The type of post-training quantization that will be used is dependent on
     the other converter options supplied. Refer to the
-    [documentation](/lite/performance/post_training_quantization) for further
+    [documentation](/tensorflow/lite/g3doc/performance/post_training_quantization.md) for further
     information on the types available and how to use them.
 
 OPTIMIZE_FOR_SIZE


### PR DESCRIPTION
Hi, Team

I found a broken documentation link in the following sentence: **"[documentation](https://github.com/tensorflow/tensorflow/blob/master/lite/performance/post_training_quantization) for further information on the types available and how to use them. "** I have updated this to a functional link. Please review and merge this change as appropriate.

Thank you for your consideration.