### PR TITLE
Add graceful error handling for invalid indices in barrier operation

### DIFF
--- a/tensorflow/core/kernels/barrier_ops.cc
+++ b/tensorflow/core/kernels/barrier_ops.cc
@@ -283,8 +283,10 @@ class Barrier : public ResourceBase {
   const string& name() const { return name_; }
   int num_components() const { return value_component_types_.size(); }
   DataType component_type(int i) const {
-    CHECK_GE(i, 0);
-    CHECK_LT(static_cast<size_t>(i), value_component_types_.size());
+    OP_REQUIRES(context, i >= 0,
+                errors::InvalidArgument("Index must be non-negative"));
+    OP_REQUIRES(context, static_cast<size_t>(i) < value_component_types_.size(),
+                errors::InvalidArgument("Index ", i, " is out of range"));
     return value_component_types_[i];
   }
   const DataTypeVector component_types() const {

--- a/tensorflow/python/kernel_tests/data_structures/barrier_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/barrier_ops_test.py
@@ -743,6 +743,17 @@ class BarrierTest(test.TestCase):
       with self.assertRaisesOpError("component shapes"):
         self.evaluate(b_e_2.barrier_ref)
 
+  @test_util.run_deprecated_v1
+  def test_invalid_index_handling(self):
+    barrier = data_flow_ops.Barrier(
+        (dtypes.float32, dtypes.float32), shapes=((), ()), name="test_barrier")
+    keys = [b'key1', b'key2']
+    values_0 = [10.0, 20.0]
+    values_1 = [100.0, 200.0]
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError, "Index must be non-negative"):
+        barrier.insert_many(-1, keys, values_0)
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError, "Index 1000 is out of range"):
+        barrier.insert_many(1000, keys, values_1)
 
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/data_structures/barrier_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/barrier_ops_test.py
@@ -745,15 +745,11 @@ class BarrierTest(test.TestCase):
 
   @test_util.run_deprecated_v1
   def test_invalid_index_handling(self):
-    barrier = data_flow_ops.Barrier(
-        (dtypes.float32, dtypes.float32), shapes=((), ()), name="test_barrier")
-    keys = [b'key1', b'key2']
-    values_0 = [10.0, 20.0]
-    values_1 = [100.0, 200.0]
+    barrier = data_flow_ops.Barrier((dtypes.float32,), shapes=((),))
     with self.assertRaisesRegex(errors_impl.InvalidArgumentError, "Index must be non-negative"):
-        barrier.insert_many(-1, keys, values_0)
-    with self.assertRaisesRegex(errors_impl.InvalidArgumentError, "Index 1000 is out of range"):
-        barrier.insert_many(1000, keys, values_1)
+        barrier.insert_many(-1, [b'k'], [1])
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError, "Index 1 is out of range"):
+        barrier.insert_many(1, [b'k'], [1])
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
# Summary
Hello, this PR adds a more graceful error handling to `barrier_ops.cc`. 

Link to issue: #78828 

Changes:
- Add `OP_REQUIRES` checks to validate that the index is non-negative and does not exceed the valid range
- Add error messages for when invalid indices are used
- Add a unit test to `barrier_ops_test.py` to verify the error handling behaviors