### PR TITLE
Fix thread ID display issue in profiler trace viewer

### DIFF
--- a/third_party/xla/xla/tsl/platform/default/env.cc
+++ b/third_party/xla/xla/tsl/platform/default/env.cc
@@ -148,7 +148,8 @@ class PosixEnv : public Env {
       auto thread_name =
           GetThreadNameRegistry().find(std::this_thread::get_id());
       if (thread_name != GetThreadNameRegistry().end()) {
-        *name = absl::StrCat(thread_name->second, "/", GetCurrentThreadId());
+        *name = absl::StrCat(thread_name->second, "/",
+                                static_cast<uint32>(GetCurrentThreadId()));
         return true;
       }
     }


### PR DESCRIPTION
Fix #79128
The change in the order of header files is caused by clang-format