### PR TITLE
TfLite. Fix of issue 79317

### DIFF
--- a/tensorflow/lite/core/c/c_api_types.h
+++ b/tensorflow/lite/core/c/c_api_types.h
@@ -61,7 +61,7 @@ extern "C" {
 #ifdef TFL_COMPILE_LIBRARY
 #define TFL_CAPI_EXPORT __declspec(dllexport)
 #else
-#define TFL_CAPI_EXPORT __declspec(dllimport)
+#define TFL_CAPI_EXPORT
 #endif  // TFL_COMPILE_LIBRARY
 #else
 #define TFL_CAPI_EXPORT __attribute__((visibility("default")))


### PR DESCRIPTION
TfLite. Fix of issue https://github.com/tensorflow/tensorflow/issues/79317. Solves `unresolved external symbol` linker error when your application uses the regular static TfLite library and a function prefixed with preprocessor macro `TFL_CAPI_EXPORT`.