### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/autograph/tests/loop_basic_test.py
+++ b/tensorflow/python/autograph/tests/loop_basic_test.py
@@ -249,7 +249,7 @@ class ReferenceTest(reference_test_base.TestCase, parameterized.TestCase):
   ))
   def test_for_one_var(self, l, type_, xla):
     if type_ is _int_dataset and xla:
-      self.skipTest('Datsets not supported in XLA')
+      self.skipTest('Datasets not supported in XLA')
     if type_ is _int_tensor and xla and not l:
       self.skipTest('Empty loops not supported in XLA')
 
@@ -298,7 +298,7 @@ class ReferenceTest(reference_test_base.TestCase, parameterized.TestCase):
   ))
   def test_for_two_vars(self, l, type_, xla):
     if type_ is _int_dataset and xla:
-      self.skipTest('Datsets not supported in XLA')
+      self.skipTest('Datasets not supported in XLA')
     if type_ is _int_tensor and xla and not l:
       self.skipTest('Empty loops not supported in XLA')
 

--- a/tensorflow/python/distribute/collective_all_reduce_strategy_test.py
+++ b/tensorflow/python/distribute/collective_all_reduce_strategy_test.py
@@ -130,7 +130,7 @@ class CollectiveAllReduceStrategyTestBase(
           communication_options=collective_util.Options(),
           devices=devices)
       # Manually set the field since the workaround bypasses the base
-      # contructor, resulting in the absence of this field.
+      # constructor, resulting in the absence of this field.
       strategy._extended._retrace_functions_for_each_device = (num_gpus > 1)
 
     return strategy, target

--- a/tensorflow/python/distribute/cross_device_ops.py
+++ b/tensorflow/python/distribute/cross_device_ops.py
@@ -566,7 +566,7 @@ class CrossDeviceOps(object):
         be combined.
       value: Value to be reduced. A tensor or a nested structure of tensors or
         `IndexedSlices`.
-      replica_id: An interger indicating the id of the replica where this
+      replica_id: An integer indicating the id of the replica where this
         all_reduce is called under. This is the local replica id that ranges
         from 0 to len(local_devices) - 1.
       options: A `tf.distribute.experimental.CommunicationOptions`.

--- a/tensorflow/python/distribute/distribute_coordinator_test.py
+++ b/tensorflow/python/distribute/distribute_coordinator_test.py
@@ -285,7 +285,7 @@ class DistributeCoordinatorTestBase(test.TestCase):
       if context.is_chief:
         self.evaluate(variables.global_variables_initializer())
 
-      # Synchronize workers after initializaton.
+      # Synchronize workers after initialization.
       if context.has_barrier:
         context.wait_for_other_workers()
       else:
@@ -346,7 +346,7 @@ class DistributeCoordinatorTestBase(test.TestCase):
         self._result_correct += 1
 
   def _dump_worker_context(self, strategy):
-    """Dumps the propoerties of each worker context.
+    """Dumps the properties of each worker context.
 
     It dumps the context properties to a dict mapping from task_type to a list
     of tuples of master_target, num_workers, is_chief and distribute_mode, where

--- a/tensorflow/python/distribute/sharded_variable.py
+++ b/tensorflow/python/distribute/sharded_variable.py
@@ -75,7 +75,7 @@ class Partitioner(object):
 
     Returns:
       A list of integers representing the number of partitions on each axis,
-      where i-th value correponds to i-th axis.
+      where i-th value corresponds to i-th axis.
     """
     raise NotImplementedError
 
@@ -620,7 +620,7 @@ class ShardedVariableMixin(trackable.Trackable):
     actual_first_dim = [v.shape.as_list()[0] for v in self._variables]
     if expect_first_dim != actual_first_dim:
       raise NotImplementedError(
-          'scater_xxx ops are not supported in ShardedVariale that does not '
+          'scater_xxx ops are not supported in Sharded Variable that does not '
           'conform to "div" sharding'
       )
 
@@ -632,7 +632,7 @@ class ShardedVariableMixin(trackable.Trackable):
     #
     # Example:
     #   base = 10, extra = 2, partitions: [0, 11), [11, 22), [22, 32)
-    #   index = 10 -> partition_assigment = 0
+    #   index = 10 -> partition_assignment = 0
     #   index = 22 -> partition_assiment = 2
     partition_assignments = math_ops.maximum(
         indices // (base + 1), (indices - extra) // base
@@ -964,7 +964,7 @@ def _var_to_tensor(var, dtype=None, name=None, as_ref=False):
   # with ShardedVariable. This requires embedding_lookup ops to raise TypeError
   # when called with ShardedVariable. However since ShardedVariable can be
   # converted to a tensor via concat, embedding_lookup ops would silently
-  # do the convertion and never raise a TypeError. To be able to properly
+  # do the conversion and never raise a TypeError. To be able to properly
   # raise a TypeError, namescope is used to detect if this method is called
   # within a embedding_lookup op.
   # NOTE: This doesn't work in eager mode since op namescope is always cleared

--- a/tensorflow/python/distribute/sharded_variable.py
+++ b/tensorflow/python/distribute/sharded_variable.py
@@ -633,7 +633,7 @@ class ShardedVariableMixin(trackable.Trackable):
     # Example:
     #   base = 10, extra = 2, partitions: [0, 11), [11, 22), [22, 32)
     #   index = 10 -> partition_assignment = 0
-    #   index = 22 -> partition_assiment = 2
+    #   index = 22 -> partition_assignment = 2
     partition_assignments = math_ops.maximum(
         indices // (base + 1), (indices - extra) // base
     )

--- a/tensorflow/python/distribute/strategy_test_lib.py
+++ b/tensorflow/python/distribute/strategy_test_lib.py
@@ -124,7 +124,7 @@ def _events_from_logdir(test_case, logdir):
 
 
 def create_variable_like_keras_layer(name, shape, dtype):
-  """Utitlity for create variables that works like variable in keras layer."""
+  """Utility for create variables that works like variable in keras layer."""
   initializer = functools.partial(
       init_ops_v2.GlorotUniform(), shape, dtype=dtype)
   return variables.Variable(


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.