### PR TITLE
fixing the issue-79689

### DIFF
--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -536,9 +536,6 @@ def normalize(tensor, ord="euclidean", axis=None, name=None):
     normalized = tensor / norm
     return normalized, norm
 
-# 
-# 
-
 @tf_export("math.l2_normalize", "linalg.l2_normalize", "nn.l2_normalize",
            v1=["math.l2_normalize", "linalg.l2_normalize", "nn.l2_normalize"])
 @dispatch.add_dispatch_support

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -536,6 +536,8 @@ def normalize(tensor, ord="euclidean", axis=None, name=None):
     normalized = tensor / norm
     return normalized, norm
 
+# 
+# 
 
 @tf_export("math.l2_normalize", "linalg.l2_normalize", "nn.l2_normalize",
            v1=["math.l2_normalize", "linalg.l2_normalize", "nn.l2_normalize"])


### PR DESCRIPTION
verting an array of floats to int8 using Numpy does a normal conversion, whereas the tf.cast conversion automatically truncates it to 127 for overflow values, which is what triggers the problem
https://colab.research.google.com/drive/1M0EcrsktHufkVZQomN8Z9eHZ20I35nCl?usp=sharing#scrollTo=wxlPB6R40Wtk