### PR TITLE
Update broken link for TensorFlow Lite Task Library hyperlink in metadata.md

### DIFF
--- a/tensorflow/lite/g3doc/models/convert/metadata.md
+++ b/tensorflow/lite/g3doc/models/convert/metadata.md
@@ -58,7 +58,7 @@ TensorFlow Lite metadata tooling supports Python 3.
 ## Adding metadata using Flatbuffers Python API
 
 Note: to create metadata for the popular ML tasks supported in
-[TensorFlow Lite Task Library](../../inference_with_metadata/task_library/overview),
+[TensorFlow Lite Task Library](https://ai.google.dev/edge/litert/libraries/task_library/overview),
 use the high-level API in the
 [TensorFlow Lite Metadata Writer Library](metadata_writer_tutorial.ipynb).
 


### PR DESCRIPTION
Hi, Team

I found a broken documentation link for **TensorFlow Lite Task Library** hyperlink in the following sentence : **"Note: to create metadata for the popular ML tasks supported in [TensorFlow Lite Task Library](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/inference_with_metadata/task_library/overview), use the high-level API in the [TensorFlow Lite Metadata Writer Library](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/models/convert/metadata_writer_tutorial.ipynb)."** I have updated this to a functional link. Please review and merge this change as appropriate.

Thank you for your consideration.