### PR TITLE
Update broken link for create the TFLite op hyperlink in convert_mode…

### DIFF
--- a/tensorflow/lite/g3doc/models/convert/convert_models.md
+++ b/tensorflow/lite/g3doc/models/convert/convert_models.md
@@ -159,7 +159,7 @@ The following are common conversion errors and their solutions:
     request for the missing TFLite op in
     [Github issue #21526](https://github.com/tensorflow/tensorflow/issues/21526)
     (leave a comment if your request hasn’t already been mentioned) or
-    [create the TFLite op](../../guide/ops_custom#create_and_register_the_operator)
+    [create the TFLite op](../../guide/ops_custom.md#create_and_register_the_operator)
     yourself.
 
 *   Error: `.. is neither a custom op nor a flex op`


### PR DESCRIPTION
Hi, Team

I found a broken documentation link for create the TFLite op hyperlink in the following paragraph: **"Solution: The error occurs as your model has TF ops that don't have a corresponding TFLite implementation. You can resolve this by [using the TF op in the TFLite model](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/guide/ops_select.md) (recommended). If you want to generate a model with TFLite ops only, you can either add a request for the missing TFLite op in [Github issue #21526](https://github.com/tensorflow/tensorflow/issues/21526) (leave a comment if your request hasn’t already been mentioned) or [create the TFLite op](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/guide/ops_custom.md#create_and_register_the_operator) yourself."** so I have updated this to a functional link. Please review and merge this change as appropriate.

Thank you for your consideration.