### PR TITLE
Update 02 broken links in gpu.md

### DIFF
--- a/tensorflow/lite/g3doc/performance/gpu.md
+++ b/tensorflow/lite/g3doc/performance/gpu.md
@@ -21,8 +21,8 @@ This document provides an overview of GPUs support in TensorFlow Lite, and some
 advanced uses for GPU processors. For more specific information about
 implementing GPU support on specific platforms, see the following guides:
 
-*   [GPU support for Android](../android/delegates/gpu)
-*   [GPU support for iOS](../ios/delegates/gpu)
+*   [GPU support for Android](https://ai.google.dev/edge/litert/android/gpu)
+*   [GPU support for iOS](https://ai.google.dev/edge/litert/ios/gpu)
 
 ## GPU ML operations support {:#supported_ops}
 


### PR DESCRIPTION
Hi, Team

I found 02 broken documentation links for **GPU support for Android** and **GPU support for iOS** the in the following paragraph: **"This document provides an overview of GPUs support in TensorFlow Lite, and some advanced uses for GPU processors. For more specific information about implementing GPU support on specific platforms, see the following guides:

[GPU support for Android](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/android/delegates/gpu)
[GPU support for iOS](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/ios/delegates/gpu) "**

I have updated those links to functional links. Please review and merge this change as appropriate.

Thank you for your consideration.