### PR TITLE
Update ByteSwapTFLiteModel function for s390x

### DIFF
--- a/tensorflow/compiler/mlir/lite/core/model_builder_base.h
+++ b/tensorflow/compiler/mlir/lite/core/model_builder_base.h
@@ -261,7 +261,7 @@ class FlatBufferModelBase {
 
   void ByteSwapTFLiteModel(const tflite::Model* tfl_model,
                            bool from_big_endian) {
-    bool buffer_swapped[tfl_model->buffers()->size()] = {};
+    std::vector<bool> buffer_swapped(tfl_model->buffers()->size(), false);
     for (size_t subgraph_idx = 0; subgraph_idx < tfl_model->subgraphs()->size();
          subgraph_idx++) {
       const tflite::SubGraph* subgraph =
@@ -316,7 +316,7 @@ class FlatBufferModelBase {
 
   void ByteSwapTFLiteModelT(tflite::ModelT* tfl_modelt, bool from_big_endian) {
     size_t bytes_per_elem = 0;
-    bool buffer_swapped[tfl_modelt->buffers.size()] = {};
+    std::vector<bool> buffer_swapped(tfl_modelt->buffers.size(), false);
     for (size_t subgraph_idx = 0; subgraph_idx < tfl_modelt->subgraphs.size();
          subgraph_idx++) {
       tflite::SubGraphT* subgraph =


### PR DESCRIPTION
Changes are required to address the failure on s390x when using clang which enforces strict checks for s390x. 
The error is related to initialization of a Variable Length Array (VLA), which requires memory allocation at runtime. 
To resolve this, the array has been replaced with a std::vector.


