### PR TITLE
Update 02 broken links in overview.md

### DIFF
--- a/tensorflow/lite/g3doc/examples/audio_classification/overview.md
+++ b/tensorflow/lite/g3doc/examples/audio_classification/overview.md
@@ -18,7 +18,7 @@ Android.
 Note: (1) To integrate an existing model, try
 [TensorFlow Lite Task Library](https://www.tensorflow.org/lite/inference_with_metadata/task_library/audio_classifier).
 (2) To customize a model, try
-[TensorFlow Lite Model Maker](https://www.tensorflow.org/lite/models/modify/model_maker/audio_classification).
+[TensorFlow Lite Model Maker](https://ai.google.dev/edge/litert/libraries/modify/audio_classification).
 
 ## Get started
 
@@ -122,7 +122,7 @@ recognize classes not in the original set. For example, you could re-train the
 model to detect multiple bird songs. To do this, you will need a set of training
 audios for each of the new labels you wish to train. The recommended way is to
 use
-[TensorFlow Lite Model Maker](https://www.tensorflow.org/lite/models/modify/model_maker/audio_classification)
+[TensorFlow Lite Model Maker](https://ai.google.dev/edge/litert/libraries/modify/audio_classification)
 library which simplifies the process of training a TensorFlow Lite model using
 custom dataset, in a few lines of codes. It uses transfer learning to reduce the
 amount of required training data and time. You can also learn from


### PR DESCRIPTION
Hi, Team

I found 02 broken documentation links for [TensorFlow Lite Model Maker](https://www.tensorflow.org/lite/models/modify/model_maker/audio_classification) hyperlinks in this [overview.md](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/examples/audio_classification/overview.md) file so I have updated those links to functional links. Please review and merge this change as appropriate.

Thank you for your consideration.