### PR TITLE
Update broken link for KerasNLP repository hyperlink in overview.md

### DIFF
--- a/tensorflow/lite/g3doc/examples/auto_complete/overview.md
+++ b/tensorflow/lite/g3doc/examples/auto_complete/overview.md
@@ -61,7 +61,7 @@ For this demonstration, we will use KerasNLP to get the GPT-2 model. KerasNLP is
 a library that contains state-of-the-art pretrained models for natural language
 processing tasks, and can support users through their entire development cycle.
 You can see the list of models available in the
-[KerasNLP repository](https://github.com/keras-team/keras-nlp/tree/master/keras_nlp/models).
+[KerasNLP repository](https://keras.io/api/keras_hub/models/).
 The workflows are built from modular components that have state-of-the-art
 preset weights and architectures when used out-of-the-box and are easily
 customizable when more control is needed. Creating the GPT-2 model can be done


### PR DESCRIPTION
Hi, Team

I found 01 broken documentation link for [KerasNLP repository](https://github.com/keras-team/keras-nlp/tree/master/keras_nlp/models) hyperlink in [overview.md](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/examples/auto_complete/overview.md#model-authoring) file

I have updated broken link to functional link to keras_hub as per the new update **(We have consolidated KerasNLP and KerasCV into a new KerasHub package so pointed broken link to KerasHub)** Please review and merge this change as appropriate.

Thank you for your consideration.


