### PR TITLE
Use SLM for depthwise3x3 of OpenCL

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/tasks/depthwise_conv_3x3.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/depthwise_conv_3x3.cc
@@ -336,12 +336,17 @@ DepthwiseConv3x3 CreateDepthwiseConv3x3(
     const DepthwiseConvolution2DAttributes& attr) {
   bool weights_are_buffer = !gpu_info.SupportsImages() ||
                             gpu_info.IsPowerVR() || gpu_info.IsMali() ||
-                            gpu_info.IsApple();
+                            gpu_info.IsApple() ||
+                            (gpu_info.IsIntel() && gpu_info.IsApiOpenCl() &&
+                             gpu_info.opencl_info.IsCLVK());
   bool local_mem_uploads =
       (weights_are_buffer && gpu_info.IsPowerVR() && gpu_info.IsApiOpenCl() &&
        gpu_info.opencl_info.dedicated_local_memory) ||
       (gpu_info.IsApple() &&
-       gpu_info.apple_info.IsLocalMemoryPreferredOverGlobal());
+       gpu_info.apple_info.IsLocalMemoryPreferredOverGlobal()) ||
+      (gpu_info.IsIntel() && gpu_info.IsApiOpenCl() &&
+        gpu_info.opencl_info.IsCLVK());
+
   DepthwiseConv3x3 result(definition, weights_are_buffer, local_mem_uploads,
                           gpu_info);
   result.UploadWeightsAndBiases(attr.weights, attr.bias, weights_are_buffer);


### PR DESCRIPTION
Enable the shared local memory for kernel weights for opencl on Intel Platform. There were about 40% compute time saving for the DepthwiseConv3x3 kernels of segmentation_benchmark_512x512.f32.tflite from the [model zoo](https://chromium.googlesource.com/chromiumos/platform2/+/main/ml_benchmark/model_zoo/)

BUG: N/A