### PR TITLE
Use SLM for FullyConnected op of OpenCL

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/tasks/fully_connected.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/fully_connected.cc
@@ -37,7 +37,9 @@ namespace gpu {
 namespace {
 bool UseBufferForWeights(const GpuInfo& gpu_info) {
   return gpu_info.IsAdreno() || gpu_info.IsAMD() || gpu_info.IsMali() ||
-         gpu_info.IsApple();
+         gpu_info.IsApple() ||
+         (gpu_info.IsIntel() && gpu_info.IsApiOpenCl() &&
+          gpu_info.opencl_info.IsCLVK());
 }
 
 void RearrangeFCWeightsToOIO4I4(


### PR DESCRIPTION
Enable the shared local memory for fully connected kernel weights on Intel Platform. There are about 6% to 23% compute saving for FullyConnected ops for different sizes of segmentation_benchmark_512x512.f32.tflite from the [Model Zoo](https://chromium.googlesource.com/chromiumos/platform2/+/main/ml_benchmark/model_zoo/).

Bug: N/A