### PR TITLE
Use system max group size for Reduce op of OpenCL

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/tasks/reduce.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/reduce.cc
@@ -32,6 +32,10 @@ namespace {
 int GetMaximumWGTotalSize(const GpuInfo& gpu_info) {
   // total_wg_size must be power of 2 and >= 4;
   int total_wg_size = 256;
+  if (gpu_info.IsIntel() && gpu_info.IsApiOpenCl() &&
+      gpu_info.opencl_info.IsCLVK()) {
+    total_wg_size = gpu_info.GetMaxWorkGroupTotalSize();
+  }
   if (gpu_info.IsAdreno() && gpu_info.adreno_info.IsAdreno3xx()) {
     total_wg_size = 128;
   }
@@ -169,7 +173,7 @@ Reduce::Reduce(const std::map<Axis, int>& axis_to_reduce, OperationType op_type,
   int current_wg_size_total =
       current_wg_size.x * current_wg_size.y * current_wg_size.z;
   int threshold = max_total_wg_size / 4;
-  if (gpu_info.IsApple()) {
+  if (gpu_info.IsApple() || gpu_info.IsIntel()) {
     threshold = 16;
   }
   if (current_wg_size_total < threshold) {

--- a/tensorflow/lite/delegates/gpu/common/tasks/reduce.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/reduce.cc
@@ -34,7 +34,11 @@ int GetMaximumWGTotalSize(const GpuInfo& gpu_info) {
   int total_wg_size = 256;
   if (gpu_info.IsIntel() && gpu_info.IsApiOpenCl() &&
       gpu_info.opencl_info.IsCLVK()) {
-    total_wg_size = gpu_info.GetMaxWorkGroupTotalSize();
+    int total_wg_size_tmp = gpu_info.GetMaxWorkGroupTotalSize() / total_wg_size;
+    while (total_wg_size_tmp >> 1) {
+      total_wg_size <<= 1;
+      total_wg_size_tmp >>= 1;
+    }
   }
   if (gpu_info.IsAdreno() && gpu_info.adreno_info.IsAdreno3xx()) {
     total_wg_size = 128;


### PR DESCRIPTION
Use the max group size to system supported max size on Intel platform, which can improve the reduce op inference performance. It has about 30% to 60% when the x,y size larger than z size for Reduce ops of segmentation_benchmark_512x512.f32.tflite from [Model zoo](https://chromium.googlesource.com/chromiumos/platform2/+/main/ml_benchmark/model_zoo/).

Bug: N/A