### PR TITLE
Fix integer overflow in range

### DIFF
--- a/tensorflow/core/kernels/ragged_range_op.cc
+++ b/tensorflow/core/kernels/ragged_range_op.cc
@@ -87,16 +87,29 @@ class RaggedRangeOp : public OpKernel {
         size = 0;
       } else if constexpr (std::is_integral<T>::value) {
         // The following is copied from tensorflow::RangeOp::Compute().
-        size = Eigen::divup(Eigen::numext::abs(limit - start),
-                            Eigen::numext::abs(delta));
+        uint64_t range;
+        if ((limit > 0 && start < 0) || (limit < 0 && start > 0)) {
+          range = static_cast<uint64_t>(Eigen::numext::abs(limit))
+                  + static_cast<uint64_t>(Eigen::numext::abs(start));
+        } else {
+          range = static_cast<uint64_t>(Eigen::numext::abs(limit - start));
+        }
+
+        uint64_t size_unsigned = Eigen::divup(range,
+                      static_cast<uint64_t>(Eigen::numext::abs(delta)));
+        OP_REQUIRES(context,
+                    size_unsigned <= std::numeric_limits<SPLITS_TYPE>::max(),
+                    InvalidArgument("Requires ((limit - start) / delta) <= ",
+                                    std::numeric_limits<SPLITS_TYPE>::max()));
+        size = static_cast<SPLITS_TYPE>(size_unsigned);
       } else {
         // The following is copied from tensorflow::RangeOp::Compute().
         auto size_auto =
             Eigen::numext::ceil(Eigen::numext::abs((limit - start) / delta));
         OP_REQUIRES(
-            context, size_auto <= std::numeric_limits<int64_t>::max(),
+            context, size_auto <= std::numeric_limits<SPLITS_TYPE>::max(),
             errors::InvalidArgument("Requires ((limit - start) / delta) <= ",
-                                    std::numeric_limits<int64_t>::max()));
+                                    std::numeric_limits<SPLITS_TYPE>::max()));
         size = static_cast<SPLITS_TYPE>(size_auto);
       }
       OP_REQUIRES(context, size >= 0, InvalidArgument("Requires size >= 0"));
@@ -122,7 +135,9 @@ class RaggedRangeOp : public OpKernel {
       T delta = broadcast_deltas ? deltas(0) : deltas(row);
       for (SPLITS_TYPE i = 0; i < row_size; ++i) {
         rt_dense_values(value_index++) = T(value);
-        value += delta;
+        if (i < row_size - 1) {
+          value += delta;
+        }
       }
     }
   }

--- a/tensorflow/core/kernels/ragged_range_op_test.cc
+++ b/tensorflow/core/kernels/ragged_range_op_test.cc
@@ -89,6 +89,17 @@ TEST_F(RaggedRangeOpTest, RangeSizeOverflow) {
             RunOpKernel().message());
 }
 
+TEST_F(RaggedRangeOpTest, RangeSizeOverflow2) {
+  BuildRaggedRangeGraph<int64>();
+  AddInputFromArray<int64>(TensorShape({}), {static_cast<int64_t>(5e18)});
+  AddInputFromArray<int64>(TensorShape({}), {static_cast<int64_t>(-5e18)});
+  AddInputFromArray<int64>(TensorShape({}), {-1});
+
+  EXPECT_EQ(absl::StrCat("Requires ((limit - start) / delta) <= ",
+                         std::numeric_limits<int64_t>::max()),
+            RunOpKernel().message()); 
+}
+
 TEST_F(RaggedRangeOpTest, BroadcastDeltas) {
   BuildRaggedRangeGraph<int>();
   AddInputFromArray<int>(TensorShape({3}), {0, 5, 8});  // starts

--- a/tensorflow/core/kernels/sequence_ops.cc
+++ b/tensorflow/core/kernels/sequence_ops.cc
@@ -32,8 +32,6 @@ namespace tensorflow {
 using CPUDevice = Eigen::ThreadPoolDevice;
 using GPUDevice = Eigen::GpuDevice;
 
-using errors::InvalidArgument;
-
 namespace functor {
 
 template <typename T>
@@ -107,7 +105,8 @@ class RangeOp : public OpKernel {
                     static_cast<uint64_t>(Eigen::numext::abs(delta)));
       OP_REQUIRES(context,
                   size_unsigned <= std::numeric_limits<int64_t>::max(),
-                  InvalidArgument("Requires ((limit - start) / delta) <= ",
+                  errors::InvalidArgument(
+                                  "Requires ((limit - start) / delta) <= ",
                                   std::numeric_limits<int64_t>::max()));
       size = static_cast<int64_t>(size_unsigned); 
     } else {

--- a/tensorflow/core/kernels/sequence_ops.cc
+++ b/tensorflow/core/kernels/sequence_ops.cc
@@ -32,6 +32,8 @@ namespace tensorflow {
 using CPUDevice = Eigen::ThreadPoolDevice;
 using GPUDevice = Eigen::GpuDevice;
 
+using errors::InvalidArgument;
+
 namespace functor {
 
 template <typename T>
@@ -39,8 +41,12 @@ struct RangeFunctor<CPUDevice, T> {
   void operator()(OpKernelContext* context, int64_t size, T start, T delta,
                   typename TTypes<T>::Flat output) const {
     (void)context;
+    T value = start;
     for (int64_t i = 0; i < size; ++i) {
-      output(i) = start + static_cast<T>(i) * delta;
+      output(i) = T(value);
+      if (i < size - 1) {
+        value += delta;
+      }
     }
   }
 };
@@ -93,8 +99,21 @@ class RangeOp : public OpKernel {
     }
     int64_t size;
     if constexpr (std::is_integral<T>::value) {
-      size = Eigen::divup(Eigen::numext::abs(limit - start),
-                          Eigen::numext::abs(delta));
+      uint64_t range;
+      if ((limit > 0 && start < 0) || (limit < 0 && start > 0)) {
+        range = static_cast<uint64_t>(Eigen::numext::abs(limit))
+                + static_cast<uint64_t>(Eigen::numext::abs(start));
+      } else {
+        range = static_cast<uint64_t>(Eigen::numext::abs(limit - start));
+      }
+
+      uint64_t size_unsigned = Eigen::divup(range,
+                    static_cast<uint64_t>(Eigen::numext::abs(delta)));
+      OP_REQUIRES(context,
+                  size_unsigned <= std::numeric_limits<int64_t>::max(),
+                  InvalidArgument("Requires ((limit - start) / delta) <= ",
+                                  std::numeric_limits<int64_t>::max()));
+      size = static_cast<int64_t>(size_unsigned); 
     } else {
       auto size_auto =
           Eigen::numext::ceil(Eigen::numext::abs((limit - start) / delta));

--- a/tensorflow/core/kernels/sequence_ops.cc
+++ b/tensorflow/core/kernels/sequence_ops.cc
@@ -41,12 +41,8 @@ struct RangeFunctor<CPUDevice, T> {
   void operator()(OpKernelContext* context, int64_t size, T start, T delta,
                   typename TTypes<T>::Flat output) const {
     (void)context;
-    T value = start;
     for (int64_t i = 0; i < size; ++i) {
-      output(i) = T(value);
-      if (i < size - 1) {
-        value += delta;
-      }
+      output(i) = start + static_cast<T>(i) * delta;
     }
   }
 };

--- a/tensorflow/core/kernels/sequence_ops_test.cc
+++ b/tensorflow/core/kernels/sequence_ops_test.cc
@@ -115,6 +115,18 @@ TEST_F(RangeOpTest, Large_Double) {
   test::ExpectTensorEqual<double>(expected, *GetOutput(0));
 }
 
+TEST_F(RangeOpTest, Range_Size_Overflow) {
+  MakeOp(DT_INT64);
+
+  AddInputFromArray<int64>(TensorShape({}), {static_cast<int64_t>(5e18)});
+  AddInputFromArray<int64>(TensorShape({}), {static_cast<int64_t>(-5e18)});
+  AddInputFromArray<int64>(TensorShape({}), {-1});
+
+  EXPECT_EQ(absl::StrCat("Requires ((limit - start) / delta) <= ",
+                         std::numeric_limits<int64_t>::max()),
+            RunOpKernel().message());
+}
+
 TEST_F(LinSpaceOpTest, Simple_D32) {
   MakeOp(DT_FLOAT, DT_INT32);
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -1360,6 +1360,14 @@ class RangeTest(test_util.TensorFlowTestCase):
     self.assertAllEqual(
         (0,), self.evaluate(x))  # smallest input with potential overflow
 
+  def testInt32Overflow(self):
+    start = 1136033460
+    end = -2110457150
+    step = -1849827689
+    expected = np.arange(start, end, step)
+    actual = math_ops.range(start, end, step)
+    self.assertAllEqual(expected, self.evaluate(actual))
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class ErfcinvTest(test_util.TensorFlowTestCase):

--- a/tensorflow/python/ops/ragged/BUILD
+++ b/tensorflow/python/ops/ragged/BUILD
@@ -904,6 +904,7 @@ py_strict_test(
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/ops:ragged_math_ops_gen",
         "//tensorflow/python/platform:test",
+        "//third_party/py/numpy",
     ],
 )
 

--- a/tensorflow/python/ops/ragged/ragged_range_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_range_op_test.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Tests for ragged_range op."""
 
+import numpy as np
+
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import test_util
@@ -128,6 +130,14 @@ class RaggedRangeOpTest(test_util.TensorFlowTestCase):
         ragged_math_ops.range([1, 2, 3]).shape.as_list(), [3, None])
     self.assertAllEqual(
         ragged_math_ops.range([1, 2, 3], [4, 5, 6]).shape.as_list(), [3, None])
+
+  def testInt32Overflow(self):
+    start = 1136033460
+    end = -2110457150
+    step = -1849827689
+    expected = [np.arange(start, end, step)]
+    actual = ragged_math_ops.range(start, end, step)
+    self.assertAllEqual(expected, self.evaluate(actual))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #64081

I modified the fixes from the rolled back PR's #77018 and #76252 to resolve an overflow that was identified by one of the new test cases. The issue was that in `ragged_range_op.cc`, `value` is incremented at the end of the loop logic, which results in a needless addition on the final iteration and creates the possibility for an overflow. This had no impact on the output of the operation and did not cause any of the tests to fail, but it was picked up by ASan.

https://github.com/tensorflow/tensorflow/blob/ec9e1531f0114662baef0f3985de5620b43d0d29/tensorflow/core/kernels/ragged_range_op.cc#L123-L126

I added a condition that only increments the value if there are more iterations to be completed.