### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/distribute/experimental/rpc/rpc_ops.py
+++ b/tensorflow/python/distribute/experimental/rpc/rpc_ops.py
@@ -329,7 +329,7 @@ class GrpcClient(Client):
     client.add(a, b) or client.add_async(a, b) can be used instead of
     client.call(args=[a,b], output_specs=[..])
 
-  Prerequiste for using list_registered_methods=True:
+  Prerequisite for using list_registered_methods=True:
    1. Server should be already started with the registered methods.
    2. Client must be created in Eager mode.
   """

--- a/tensorflow/python/distribute/input_lib.py
+++ b/tensorflow/python/distribute/input_lib.py
@@ -174,7 +174,7 @@ class InputWorkers(object):
 
 
 def _calculate_replicas_with_values(strategy, input_workers, optional_list):
-  """Calcualates the number of replicas that have values.
+  """Calculates the number of replicas that have values.
 
   Args:
     strategy: the `tf.distribute.Strategy`.
@@ -756,7 +756,7 @@ class DistributedDataset(_IterableInput, composite_tensor.CompositeTensor):
         handle last partial batch.
       dataset: `tf.data.Dataset` that will be used as the input source. Either
         dataset or components field should be passed when constructing
-        DistributedDataset. Use this when contructing DistributedDataset from a
+        DistributedDataset. Use this when constructing DistributedDataset from a
         new `tf.data.Dataset`. Use components when constructing using
         DistributedDatasetSpec.
       num_replicas_in_sync: Optional integer. If this is not None, the value is

--- a/tensorflow/python/distribute/integration_test/saved_model_test.py
+++ b/tensorflow/python/distribute/integration_test/saved_model_test.py
@@ -115,7 +115,7 @@ class SaveAndLoadForServingTest(test.TestCase, parameterized.TestCase):
   # function on a single device, and the distributed variables are saved as
   # single variables.
   #
-  # Curently references to components of a distributed variable are mapped to
+  # Currently references to components of a distributed variable are mapped to
   # the single variable that is saved. This means that if the saved tf.functions
   # access components of a distributed variable, for example if it triggers
   # variable aggregation, the outputs are likely incorrect.
@@ -517,7 +517,7 @@ class SaveAndLoadForTrainingTest(test.TestCase, parameterized.TestCase):
     # under tf.distribute.Strategy.
     #
     # Although the error is the same models with TF2 SavedModel, the cause is
-    # different. TF1 models loaded in API contain an intializer, which is
+    # different. TF1 models loaded in API contain an initializer, which is
     # invoked upon loading. Since loading is in the cross-replica context, that
     # fails.
     #

--- a/tensorflow/python/distribute/tpu_strategy_test.py
+++ b/tensorflow/python/distribute/tpu_strategy_test.py
@@ -935,7 +935,7 @@ class TPUStrategyTest(test.TestCase, parameterized.TestCase):
 
     sparse, result = sparse_lookup(dataset)
 
-    # All replicas return identical reults.
+    # All replicas return identical results.
     for replica in range(strategy.num_replicas_in_sync):
       self.assertIsInstance(sparse[replica], sparse_tensor.SparseTensor)
       self.assertAllEqual(sparse[replica].indices, [[0, 0], [1, 0], [1, 1]])
@@ -985,7 +985,7 @@ class TPUStrategyTest(test.TestCase, parameterized.TestCase):
 
     output = sparse_lookup(dataset)
 
-    # All replicas return identical reults.
+    # All replicas return identical results.
     for replica in range(strategy.num_replicas_in_sync):
       self.assertIsInstance(output["sparse"][replica],
                             sparse_tensor.SparseTensor)
@@ -1100,7 +1100,7 @@ class TPUStrategyTest(test.TestCase, parameterized.TestCase):
 
     composite, result = test_fn(test_composite)
 
-    # All replicas return identical reults.
+    # All replicas return identical results.
     for replica in range(strategy.num_replicas_in_sync):
       self.assertIsInstance(composite[replica], TestComposite)
       self.assertAllEqual(composite[replica].values[0], a)

--- a/tensorflow/python/distribute/values.py
+++ b/tensorflow/python/distribute/values.py
@@ -1308,7 +1308,7 @@ class SyncOnReadVariable(DistributedVariable):
     with distribute_lib.enter_or_assert_strategy(self._distribute_strategy):
       return super(SyncOnReadVariable, self)._get()
 
-  # TODO(b/154017756): Make assign behaivor in cross replica context consistent
+  # TODO(b/154017756): Make assign behavior in cross replica context consistent
   # with MirroredVariable.
   def assign_sub(self, value, use_locking=False, name=None, read_value=True):
     if values_util.is_saving_non_distributed():

--- a/tensorflow/python/grappler/layout_optimizer_test.py
+++ b/tensorflow/python/grappler/layout_optimizer_test.py
@@ -1289,7 +1289,7 @@ class LayoutOptimizerTest(test.TestCase):
         nodes.append(node.name)
 
       # The reduce op Mean needs to dim map the input reduce index to NCDHW.
-      # Then, the output needs to be tranposed back to NDHWC.
+      # Then, the output needs to be transposed back to NDHWC.
       expected_num_transposes = 2
       self.assertEqual(expected_num_transposes, num_transposes)
       self._assert_trans_ndhwc_to_ncdhw('Conv3D-0', nodes)
@@ -1332,7 +1332,7 @@ class LayoutOptimizerTest(test.TestCase):
         nodes.append(node.name)
 
       # The binary ops mul_1 and add_1 in batch norm need to transpose one of
-      # the two inputs to NCDHW. The other input has already been tranposed via
+      # the two inputs to NCDHW. The other input has already been transposed via
       # Conv3D.
       expected_num_transposes = 4
       self.assertEqual(expected_num_transposes, num_transposes)

--- a/tensorflow/python/grappler/remapper_test.py
+++ b/tensorflow/python/grappler/remapper_test.py
@@ -105,7 +105,7 @@ class RemapperTest(test.TestCase, parameterized.TestCase):
     ops.add_to_collection('train_op', model_fn)
     mg = meta_graph.create_meta_graph_def(graph=model_fn.graph)
 
-    # Compute referene
+    # Compute reference
     config = _get_config(remapping_on=False)
     gdef_ref = tf_optimizer.OptimizeGraph(config, mg)
 


### PR DESCRIPTION

Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.