### PR TITLE
Update broken link in overview.md

### DIFF
--- a/tensorflow/lite/g3doc/examples/bert_qa/overview.md
+++ b/tensorflow/lite/g3doc/examples/bert_qa/overview.md
@@ -6,7 +6,7 @@ passage.
 Note: (1) To integrate an existing model, try
 [TensorFlow Lite Task Library](https://www.tensorflow.org/lite/inference_with_metadata/task_library/bert_question_answerer).
 (2) To customize a model, try
-[TensorFlow Lite Model Maker](https://www.tensorflow.org/lite/models/modify/model_maker/question_answer).
+[TensorFlow Lite Model Maker](https://ai.google.dev/edge/litert/libraries/modify/question_answer).
 
 ## Get started
 


### PR DESCRIPTION
Hi, Team

I found a broken documentation link on this [page](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/examples/bert_qa/overview.md) for [TensorFlow Lite Model Maker](https://www.tensorflow.org/lite/models/modify/model_maker/question_answer) hyperlink so I have updated that link to functional link. Please review and merge this change as appropriate.

Thank you for your consideration.