### PR TITLE
Modify regular expression pattern for kernels filter in CMakeLists.txt

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -599,7 +599,7 @@ if(_TFLITE_ENABLE_RUY)
 endif()
 populate_tflite_source_vars("kernels"
   TFLITE_KERNEL_SRCS
-  FILTER "(.*_test_util_internal|test_.*|.*_ops_wrapper)\\.(cc|h)"
+  FILTER "([^/]*_test_util_internal|test_[^/]*|[^/]*_ops_wrapper)\\.(cc|h)$"
 )
 populate_tflite_source_vars("kernels/internal" TFLITE_KERNEL_INTERNAL_SRCS)
 populate_tflite_source_vars("kernels/internal/optimized"


### PR DESCRIPTION
Hi, Team
At the moment I'm not sure whether this change is valid or not when user is keeping project in the directory named as `~/workspace/final_test_6.6.36$` where current regular expression pattern matches also directory name so files in kernels directory are not compiled and library have a problem with linking so can we modify our current regular expression pattern to this regular expression `([^/]*_test_util_internal|test_[^/]*|[^/]*_ops_wrapper)\\.(cc|h)$` which will do strict filename matching and prevents matching across directories which current regular expression pattern is not doing if I'm not wrong

I would request you to please review this PR, if you've any feedback or suggestion please let me know that will be very helpful. Thank you for your consideration.

If this is valid change then it will take care of this issue https://github.com/tensorflow/tensorflow/issues/80182

https://github.com/tensorflow/tensorflow/blob/c76ae321772b71207a6f1f64bfb41d034c16ca32/tensorflow/lite/CMakeLists.txt#L602 
