### PR TITLE
Update graph_info.h to avoid warning: multi-line comment [-Wcomment]

### DIFF
--- a/tensorflow/lite/graph_info.h
+++ b/tensorflow/lite/graph_info.h
@@ -124,7 +124,7 @@ using ControlEdges = std::vector<ControlEdge>;
 // (Example: with `greedily`, `control_edges.empty()`, and `nodes_to_partition
 // == {2, 3}`, the graph
 //
-//                    /------------\
+//                    /------------\ // Adjusted to avoid warnings
 //                    |            v
 // 0 --> 1 --> 2* --> 3*     4 --> 5
 //       |                   ^
@@ -136,7 +136,7 @@ using ControlEdges = std::vector<ControlEdge>;
 // With an additional control dependency `control_edges == {{3, 4}}` (notated
 // '==>'), execution of node 4 requires prior execution of node 3:
 //
-//                    /------------\
+//                    /------------\ // Adjusted to avoid warnings
 //                    |            v
 // 0 --> 1 --> 2* --> 3* ==> 4 --> 5
 //       |                   ^

--- a/tensorflow/lite/graph_info.h
+++ b/tensorflow/lite/graph_info.h
@@ -136,7 +136,7 @@ using ControlEdges = std::vector<ControlEdge>;
 // With an additional control dependency `control_edges == {{3, 4}}` (notated
 // '==>'), execution of node 4 requires prior execution of node 3:
 //
-//                    /------------\ // Adjusted to avoid warnings
+//                    /------------\ 
 //                    |            v
 // 0 --> 1 --> 2* --> 3* ==> 4 --> 5
 //       |                   ^

--- a/tensorflow/lite/graph_info.h
+++ b/tensorflow/lite/graph_info.h
@@ -124,7 +124,7 @@ using ControlEdges = std::vector<ControlEdge>;
 // (Example: with `greedily`, `control_edges.empty()`, and `nodes_to_partition
 // == {2, 3}`, the graph
 //
-//                    /------------\ // Adjusted to avoid warnings
+//                    /------------\ 
 //                    |            v
 // 0 --> 1 --> 2* --> 3*     4 --> 5
 //       |                   ^


### PR DESCRIPTION
Hi, Team
One of the user reported one issue when compiled the TensorFlow Lite shared library for use on an embedded device. In order to compile application against it, user is using the TF distribution's headers during the compilation process. When code includes `tensorflow/lite/interpreter.h` it's showing below warning from the compiler (GCC 11.3.0)

```
In file included from .../tensorflow/include/tensorflow/lite/core/subgraph.h:42,
                 from .../tensorflow/include/tensorflow/lite/core/async/async_subgraph.h:27,
                 from .../tensorflow/include/tensorflow/lite/core/async/async_signature_runner.h:24,
                 from .../tensorflow/include/tensorflow/lite/core/interpreter.h:47,
                 from .../tensorflow/include/tensorflow/lite/interpreter.h:21,
                 from (my code):
.../tensorflow/include/tensorflow/lite/graph_info.h:127:1: warning: multi-line comment [-Wcomment]
  127 | //                    /------------\
      | ^
.../tensorflow/include/tensorflow/lite/graph_info.h:139:1: warning: multi-line comment [-Wcomment]
  139 | //                    /------------\
      | ^
```

I've modified the `graph_info.h` file to change the problematic comments that are causing warnings. If you've any suggestion or feedback or Am I missing something here please let me know ? 

It will take care of this issue https://github.com/tensorflow/tensorflow/issues/80379

Thank you for your consideration.