### PR TITLE
The CheckPaddingOverflow function missed checking some padding values

### DIFF
--- a/tensorflow/lite/kernels/pad.cc
+++ b/tensorflow/lite/kernels/pad.cc
@@ -96,7 +96,7 @@ bool CheckPaddingOverflow(PadContext* op_context) {
           static_cast<int64_t>(std::numeric_limits<int32_t>::min());
       int64_t int32_max =
           static_cast<int64_t>(std::numeric_limits<int32_t>::max());
-      for (int idx = 0; idx < op_context->dims; ++idx) {
+      for (int idx = 0; idx < op_context->dims * 2; ++idx) {
         int64_t padding = paddings_data[idx];
         if (padding < int32_min || padding > int32_max) {
           return true;


### PR DESCRIPTION
op_context->dims refers to the input tensor's dimensions. The shape of paddings_data should be op_context->dims * 2.