### PR TITLE
The CheckPaddingOverflow function missed checking some padding values

### DIFF
--- a/tensorflow/lite/kernels/pad.cc
+++ b/tensorflow/lite/kernels/pad.cc
@@ -96,7 +96,8 @@ bool CheckPaddingOverflow(PadContext* op_context) {
           static_cast<int64_t>(std::numeric_limits<int32_t>::min());
       int64_t int32_max =
           static_cast<int64_t>(std::numeric_limits<int32_t>::max());
-      for (int idx = 0; idx < op_context->dims; ++idx) {
+      const int paddings_total = GetTensorShape(op_context->paddings).FlatSize();
+      for (int idx = 0; idx < paddings_total; ++idx) {
         int64_t padding = paddings_data[idx];
         if (padding < int32_min || padding > int32_max) {
           return true;

--- a/tensorflow/lite/kernels/pad_test.cc
+++ b/tensorflow/lite/kernels/pad_test.cc
@@ -242,6 +242,12 @@ TEST_F(PadOpTest, Int64PaddingOverflow) {
                    {TensorType_FLOAT32}),
                "INT64 padding overflow. Only support value between INT32_MIN "
                "and INT32_MAX.");
+  EXPECT_DEATH(PadOpConstModel<int64_t>(
+                   {TensorType_FLOAT32, {1, 1, 2, 1}}, {4, 2},
+                   {0, 0, 1, -1, 2, -1, std::numeric_limits<int64_t>::max(), 0},
+                   {TensorType_FLOAT32}),
+               "INT64 padding overflow. Only support value between INT32_MIN "
+               "and INT32_MAX.");
 }
 #endif
 


### PR DESCRIPTION
In pad node CheckPaddingOverflow function op_context->dims refers to the input tensor's dimensions. The shape of paddings_data should be op_context->dims * 2.