### PR TITLE
Update 02 broken links in overview.md

### DIFF
--- a/tensorflow/lite/g3doc/examples/object_detection/overview.md
+++ b/tensorflow/lite/g3doc/examples/object_detection/overview.md
@@ -11,7 +11,7 @@ annotated:
 <img src="images/android_apple_banana.png" alt="Screenshot of Android example" width="30%">
 
 Note: (1) To integrate an existing model, try
-[TensorFlow Lite Task Library](../../inference_with_metadata/task_library/object_detector).
+[TensorFlow Lite Task Library](https://ai.google.dev/edge/litert/libraries/task_library/object_detector).
 (2) To customize a model, try
 [TensorFlow Lite Model Maker](https://www.tensorflow.org/lite/guide/model_maker).
 
@@ -52,7 +52,7 @@ started.
 #### Android
 
 You can leverage the out-of-box API from
-[TensorFlow Lite Task Library](../../inference_with_metadata/task_library/object_detector)
+[TensorFlow Lite Task Library](https://ai.google.dev/edge/litert/libraries/task_library/object_detector)
 to integrate object detection models in just a few lines of code. You can also
 build your own custom inference pipeline using the
 [TensorFlow Lite Interpreter Java API](../../guide/inference#load_and_run_a_model_in_java).


### PR DESCRIPTION
Hi, Team

I found 02 broken documentation links for [TensorFlow Lite Task Library](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/inference_with_metadata/task_library/object_detector) hyperlinks in this [overview.md](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/examples/object_detection/overview.md) file so I have updated those links to functional links. Please review and merge this change as appropriate.

Thank you for your consideration.