### PR TITLE
Fix broken link in video classification overview.md

### DIFF
--- a/tensorflow/lite/g3doc/examples/video_classification/overview.md
+++ b/tensorflow/lite/g3doc/examples/video_classification/overview.md
@@ -26,7 +26,7 @@ already familiar with the
 [TensorFlow Lite APIs](https://www.tensorflow.org/api_docs/python/tf/lite),
 download the starter video classification model and the supporting files. You
 can also build your own custom inference pipeline using the
-[TensorFlow Lite Support Library](../../inference_with_metadata/lite_support).
+[TensorFlow Lite Support Library](../../inference_with_metadata/lite_support.md).
 
 <a class="button button-primary" href="https://tfhub.dev/tensorflow/lite-model/movinet/a0/stream/kinetics-600/classification/tflite/int8/1">Download
 starter model with metadata</a>


### PR DESCRIPTION
Hi, Team
I found 01 broken documentation link for [TensorFlow Lite Support Library](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/inference_with_metadata/lite_support) hyperlink in this [overview.md](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/examples/video_classification/overview.md#get-started) file so I have updated that link to functional link. Please review and merge this change as appropriate.

Thank you for your consideration.