### PR TITLE
Align num_threads parameter validation with documentation

### DIFF
--- a/tensorflow/lite/python/interpreter.py
+++ b/tensorflow/lite/python/interpreter.py
@@ -465,8 +465,13 @@ class Interpreter:
     if num_threads is not None:
       if not isinstance(num_threads, int):
         raise ValueError('type of num_threads should be int')
-      if num_threads < 1:
-        raise ValueError('num_threads should >= 1')
+      if num_threads < -1:
+        raise ValueError('num_threads should be >= -1')
+      if num_threads == 0:
+          num_threads = 1
+      elif num_threads == -1:
+          pass
+      self._interpreter.SetNumThreads(num_threads)
 
     if model_path and not model_content:
       custom_op_registerers_by_name = [

--- a/tensorflow/lite/python/interpreter.py
+++ b/tensorflow/lite/python/interpreter.py
@@ -468,9 +468,9 @@ class Interpreter:
       if num_threads < -1:
         raise ValueError('num_threads should be >= -1')
       if num_threads == 0:
-          num_threads = 1
+        num_threads = 1
       elif num_threads == -1:
-          pass
+        pass
       self._interpreter.SetNumThreads(num_threads)
 
     if model_path and not model_content:


### PR DESCRIPTION
Hi, Team
Modify the TensorFlow Lite Interpreter's `num_threads` parameter validation to match its documented behavior specifically allowing `-1` for implementation-defined threading and treating `0` as disabling multithreading.
#### Current Behavior
- Current implementation raises a `ValueError` if `num_threads` is less than 1
- Contradicts the documented behavior in TensorFlow Lite's documentation here is tf.lite.Interpreter [documentation](https://www.tensorflow.org/api_docs/python/tf/lite/Interpreter)
#### Proposed Changes
```
if num_threads is not None:
    if not isinstance(num_threads, int):
        raise ValueError('type of num_threads should be int')
    if num_threads < -1:
        raise ValueError('num_threads should be >= -1')
    if num_threads == 0:
        num_threads = 1
    elif num_threads == -1:
        pass
    self._interpreter.SetNumThreads(num_threads)
```
It will fix this issue : https://github.com/tensorflow/tensorflow/issues/80579

I appreciate your thorough review and collaborative input with any feedback or suggestion. Thank you