### PR TITLE
Update tensor_util_test.py for testBfloat16

### DIFF
--- a/tensorflow/python/framework/tensor_util_test.py
+++ b/tensorflow/python/framework/tensor_util_test.py
@@ -254,13 +254,24 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
   def testBfloat16(self):
     test_type = dtypes.bfloat16.as_numpy_dtype
     t = tensor_util.make_tensor_proto(np.array([10.0, 20.0], dtype=test_type))
-    self.assertProtoEquals("""
-      dtype: DT_BFLOAT16
-      tensor_shape {
-        dim {
-          size: 2
-        }
+    if sys.byteorder == 'big':
+      self.assertProtoEquals("""
+        dtype: DT_BFLOAT16
+        tensor_shape {
+          dim {
+            size: 2
+          }
       }
+      tensor_content: "\x41\x20\x41\x5C\x32\x34\x30"
+      """, t)
+    else:
+      self.assertProtoEquals("""
+        dtype: DT_BFLOAT16
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
       tensor_content: "\x20\x41\x5C\x32\x34\x30\x41"
       """, t)
 


### PR DESCRIPTION
Currently the test for bfloat16 checks proto value by default in little endian.
Added support for s390x (big endian) as well.