### PR TITLE
Update abstract_context.h

### DIFF
--- a/tensorflow/c/eager/abstract_context.h
+++ b/tensorflow/c/eager/abstract_context.h
@@ -12,71 +12,87 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+
 #ifndef TENSORFLOW_C_EAGER_ABSTRACT_CONTEXT_H_
 #define TENSORFLOW_C_EAGER_ABSTRACT_CONTEXT_H_
 
 #include <memory>
+#include <string>
 
 #include "tensorflow/c/eager/abstract_function.h"
 #include "tensorflow/c/eager/abstract_operation.h"
+#include "absl/status/status.h"
 
 namespace tensorflow {
 
-// Abstract interface to a context.
+// Represents an abstract execution context.
 //
-// This serves as a factory for creating `AbstractOperation`s and for
-// registering traced functions.
-// Operations creation within a context can only be executed in that context
-// (for now at least).
-// Implementations of the context may contain some state e.g. an execution
-// environment, a traced representation etc.
+// This serves as a factory for creating `AbstractOperation` instances and
+// for registering traced functions. Operations created within a context must
+// only be executed in that context.
+//
+// Implementations of this class may encapsulate state, such as an execution
+// environment or a traced representation.
 class AbstractContext {
- protected:
-  enum AbstractContextKind { kGraph, kMlir, kEager, kTfrt, kTape, kOpHandler };
-  explicit AbstractContext(AbstractContextKind kind) : kind_(kind) {}
-  virtual ~AbstractContext() {}
-
  public:
-  AbstractContextKind getKind() const { return kind_; }
+  // Represents the kind of context.
+  enum class ContextKind { kGraph, kMlir, kEager, kTfrt, kTape, kOpHandler };
 
-  // Release any underlying resources, including the interface object.
+  explicit AbstractContext(ContextKind kind) : kind_(kind) {}
+  virtual ~AbstractContext() = default;
+
+  // Returns the type of the context.
+  ContextKind GetKind() const { return kind_; }
+
+  // Releases all underlying resources, including the interface object.
   //
-  // WARNING: The destructor of this class is marked as protected to disallow
-  // clients from directly destroying this object since it may manage its own
-  // lifetime through ref counting. Thus clients MUST call Release() in order to
-  // destroy an instance of this class.
+  // Note: The destructor is protected to prevent direct destruction of the
+  // object, as the lifetime of this object may be managed through reference
+  // counting. Clients must call `Release()` to destroy an instance of this
+  // class.
   virtual void Release() = 0;
 
-  // Creates an operation builder and ties it to this context.
-  // The returned object can be used for setting operation's attributes,
-  // adding inputs and finally executing (immediately or lazily as in tracing)
-  // it in this context.
+  // Creates and returns a new operation tied to this context.
+  //
+  // The returned object can be used to set operation attributes, add inputs,
+  // and execute the operation either immediately or lazily (e.g., during
+  // tracing).
   virtual AbstractOperation* CreateOperation() = 0;
 
-  // Registers a function with this context, after this the function is
-  // available to be called/referenced by its name in this context.
-  virtual absl::Status RegisterFunction(AbstractFunction*) = 0;
-  // Remove a function. 'func' argument is the name of a previously added
-  // FunctionDef. The name is in fdef.signature.name.
-  virtual absl::Status RemoveFunction(const string& func) = 0;
+  // Registers a function with this context. Once registered, the function
+  // becomes available for use within this context by its name.
+  virtual absl::Status RegisterFunction(AbstractFunction* function) = 0;
 
- private:
-  const AbstractContextKind kind_;
+  // Removes a previously registered function from this context.
+  //
+  // `func_name` should match the `FunctionDef` signature's name.
+  virtual absl::Status RemoveFunction(const std::string& func_name) = 0;
+
+ protected:
+  const ContextKind kind_;
 };
 
 namespace internal {
+
+// Custom deleter for `AbstractContext` to ensure proper resource cleanup.
 struct AbstractContextDeleter {
-  void operator()(AbstractContext* p) const {
-    if (p != nullptr) {
-      p->Release();
+  void operator()(AbstractContext* context) const {
+    if (context != nullptr) {
+      context->Release();
     }
   }
 };
+
 }  // namespace internal
 
+// A smart pointer type for managing `AbstractContext` instances.
 using AbstractContextPtr =
     std::unique_ptr<AbstractContext, internal::AbstractContextDeleter>;
 
 }  // namespace tensorflow
 
 #endif  // TENSORFLOW_C_EAGER_ABSTRACT_CONTEXT_H_
+
+
+
+


### PR DESCRIPTION
Replaced enum with enum class for type safety and scoped enumeration. Used std::string instead of string for clarity and compatibility.