### PR TITLE
remove non-maintained tensorflow-io-gcs-filesystem dependency from pip_package

### DIFF
--- a/tensorflow/tools/pip_package/setup.py
+++ b/tensorflow/tools/pip_package/setup.py
@@ -94,8 +94,6 @@ REQUIRED_PACKAGES = [
     'termcolor >= 1.1.0',
     'typing_extensions >= 3.6.6',
     'wrapt >= 1.11.0',
-    # TODO(b/305196096): Remove the <3.12 condition once the pkg is updated
-    'tensorflow-io-gcs-filesystem >= 0.23.1 ; python_version < "3.12"',
     # grpcio does not build correctly on big-endian machines due to lack of
     # BoringSSL support.
     # See https://github.com/tensorflow/tensorflow/issues/17882.


### PR DESCRIPTION
this dependency has been causing a problem for more than a year without a solution, wheels are not built and it seems not very well maintained, if at all. tensorflow only depends on it for some optional purpose 

as seen by it's addition PR it's only enabled with a certain variable: https://github.com/tensorflow/tensorflow/pull/51460

yet community has been trying to find a solution for the problems it has been causing without a direct fix, it might be beneficial to get rid of this dependency for extended belief on tensorflow's multiplatform support and reliability

https://github.com/tensorflow/io/issues/2087
https://github.com/tensorflow/tensorflow/issues/56636
https://github.com/tensorflow/io/issues/1789
https://github.com/tensorflow/io/issues/2093
https://github.com/tensorflow/io/issues/2087
https://discuss.ai.google.dev/t/tensorflow-io-gcs-filesystem-with-windows/32191/3