### PR TITLE
Fix 02 broken links in audio_classifier.md

### DIFF
--- a/tensorflow/lite/g3doc/inference_with_metadata/task_library/audio_classifier.md
+++ b/tensorflow/lite/g3doc/inference_with_metadata/task_library/audio_classifier.md
@@ -29,7 +29,7 @@ The following models are guaranteed to be compatible with the `AudioClassifier`
 API.
 
 *   Models created by
-    [TensorFlow Lite Model Maker for Audio Classification](https://www.tensorflow.org/lite/api_docs/python/tflite_model_maker/audio_classifier).
+    [TensorFlow Lite Model Maker for Audio Classification](https://ai.google.dev/edge/litert/libraries/modify/audio_classification).
 
 *   The
     [pretrained audio event classification models on TensorFlow Hub](https://tfhub.dev/google/lite-model/yamnet/classification/tflite/1).
@@ -239,7 +239,7 @@ pip install tflite-support
 
 Note: Task Library's Audio APIs rely on [PortAudio](http://www.portaudio.com/docs/v19-doxydocs/index.html)
 to record audio from the device's microphone. If you intend to use Task
-Library's [AudioRecord](/lite/api_docs/python/tflite_support/task/audio/AudioRecord)
+Library's [AudioRecord](https://ai.google.dev/edge/api/tflite/python/tflite_support/task/audio/AudioRecord)
 for audio recording, you need to install PortAudio on your system.
 
 * Linux: Run `sudo apt-get update && apt-get install libportaudio2`


### PR DESCRIPTION
Hi, Team
I found 02 broken documentation links for [TensorFlow Lite Model Maker for Audio Classification](https://www.tensorflow.org/lite/api_docs/python/tflite_model_maker/audio_classifier) and [AudioRecord](https://github.com/tensorflow/tensorflow/blob/master/lite/api_docs/python/tflite_support/task/audio/AudioRecord) hyperlinks in this [Integrate audio classifiers](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/inference_with_metadata/task_library/audio_classifier.md) file so I have updated those links to functional links. Please review and merge this change as appropriate.

Thank you for your consideration.