### PR TITLE
Fix 02 broken links in bert_nl_classifier.md

### DIFF
--- a/tensorflow/lite/g3doc/inference_with_metadata/task_library/bert_nl_classifier.md
+++ b/tensorflow/lite/g3doc/inference_with_metadata/task_library/bert_nl_classifier.md
@@ -21,7 +21,7 @@ Sentencepiece tokenizations outside the TFLite model.
 The following models are compatible with the `BertNLClassifier` API.
 
 *   Bert Models created by
-    [TensorFlow Lite Model Maker for text Classfication](https://www.tensorflow.org/lite/models/modify/model_maker/text_classification).
+    [TensorFlow Lite Model Maker for text Classfication](https://ai.google.dev/edge/litert/libraries/modify/text_classification).
 
 *   Custom models that meet the
     [model compatibility requirements](#model-compatibility-requirements).
@@ -148,7 +148,7 @@ for more options to configure `BertNLClassifier`.
 ## Example results
 
 Here is an example of the classification results of movie reviews using the
-[MobileBert](https://www.tensorflow.org/lite/models/modify/model_maker/text_classification)
+[MobileBert](https://ai.google.dev/edge/litert/libraries/modify/text_classification)
 model from Model Maker.
 
 Input: "it's a charming and often affecting journey"


### PR DESCRIPTION
Hi, Team
I found 02 broken documentation links for [TensorFlow Lite Model Maker for text Classfication](https://www.tensorflow.org/lite/models/modify/model_maker/text_classification) and [MobileBert](https://www.tensorflow.org/lite/models/modify/model_maker/text_classification) hyperlinks in this [Integrate BERT natural language classifier ](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/inference_with_metadata/task_library/bert_nl_classifier.md)file so I have updated those links to functional link. Please review and merge this change as appropriate.

Thank you for your consideration.