### PR TITLE
Remove Transfer-Encoding: identity considered to be illegal

### DIFF
--- a/third_party/xla/third_party/tsl/tsl/platform/cloud/curl_http_request.cc
+++ b/third_party/xla/third_party/tsl/tsl/platform/cloud/curl_http_request.cc
@@ -267,7 +267,6 @@ void CurlHttpRequest::SetPutEmptyBody() {
   method_ = RequestMethod::kPut;
   CHECK_CURL_OK(libcurl_->curl_easy_setopt(curl_, CURLOPT_PUT, 1));
   AddHeader("Content-Length", "0");
-  AddHeader("Transfer-Encoding", "identity");
   CHECK_CURL_OK(libcurl_->curl_easy_setopt(curl_, CURLOPT_READDATA,
                                            reinterpret_cast<void*>(this)));
   CHECK_CURL_OK(libcurl_->curl_easy_setopt(curl_, CURLOPT_READFUNCTION,
@@ -296,7 +295,6 @@ void CurlHttpRequest::SetPostEmptyBody() {
   method_ = RequestMethod::kPost;
   CHECK_CURL_OK(libcurl_->curl_easy_setopt(curl_, CURLOPT_POST, 1));
   AddHeader("Content-Length", "0");
-  AddHeader("Transfer-Encoding", "identity");
   CHECK_CURL_OK(libcurl_->curl_easy_setopt(curl_, CURLOPT_READDATA,
                                            reinterpret_cast<void*>(this)));
   CHECK_CURL_OK(libcurl_->curl_easy_setopt(curl_, CURLOPT_READFUNCTION,

--- a/third_party/xla/third_party/tsl/tsl/platform/cloud/curl_http_request_test.cc
+++ b/third_party/xla/third_party/tsl/tsl/platform/cloud/curl_http_request_test.cc
@@ -600,7 +600,6 @@ TEST(CurlHttpRequestTest, PutRequest_WithoutBody) {
   EXPECT_EQ(3, libcurl.headers_->size());
   EXPECT_EQ("Authorization: Bearer fake-bearer", (*libcurl.headers_)[0]);
   EXPECT_EQ("Content-Length: 0", (*libcurl.headers_)[1]);
-  EXPECT_EQ("Transfer-Encoding: identity", (*libcurl.headers_)[2]);
   EXPECT_TRUE(libcurl.is_put_);
   EXPECT_EQ("", libcurl.posted_content_);
 }
@@ -642,7 +641,6 @@ TEST(CurlHttpRequestTest, PostRequest_WithoutBody) {
   EXPECT_EQ(3, libcurl.headers_->size());
   EXPECT_EQ("Authorization: Bearer fake-bearer", (*libcurl.headers_)[0]);
   EXPECT_EQ("Content-Length: 0", (*libcurl.headers_)[1]);
-  EXPECT_EQ("Transfer-Encoding: identity", (*libcurl.headers_)[2]);
   EXPECT_TRUE(libcurl.is_post_);
   EXPECT_EQ("", libcurl.posted_content_);
 }


### PR DESCRIPTION

Based on http1.1 spec([RFC9112](https://www.rfc-editor.org/rfc/rfc9112.html#name-transfer-encoding)), transfer-encoding lead to vulnerabilities regarding [request smuggling](https://www.rfc-editor.org/rfc/rfc9112.html#request.smuggling). Hence, most http servers now days are very restrictive on the use of Transfer-Encoding, usually only allowing "chunked", for http1.1. For example, Go standard net/http [library](https://github.com/golang/go/blob/master/src/net/http/transfer.go#L650-L652) considers anything other than "chunked" unsupported, and returns [501](https://github.com/golang/go/blob/master/src/net/http/server.go#L2047-L2057) per the spec. 

The purpose of this PR is to remove the Transfer-Encoding: identity in the [SetPutEmptyBody](https://github.com/tensorflow/tensorflow/blob/v2.16.1/third_party/xla/third_party/tsl/tsl/platform/cloud/curl_http_request.cc#L263) and [SetPostEmptyBody,](https://github.com/tensorflow/tensorflow/blob/v2.16.1/third_party/xla/third_party/tsl/tsl/platform/cloud/curl_http_request.cc#L292) so the requests will be processed properly by the http servers that are restrictive on Transfer-Encoding header.
