### PR TITLE
Add tf_keras installation and import statements to tf.autodiff.ForwardAccumulator example

### DIFF
--- a/tensorflow/python/eager/forwardprop.py
+++ b/tensorflow/python/eager/forwardprop.py
@@ -240,6 +240,12 @@ class ForwardAccumulator():
 
   Consider a simple linear regression:
 
+  >>> pip install tf_keras
+  >>> import os
+  >>> import numpy as np
+  >>> import tensorflow as tf
+  >>> os.environ["TF_USE_LEGACY_KERAS"] = "1"
+
   >>> x = tf.constant([[2.0, 3.0], [1.0, 4.0]])
   >>> targets = tf.constant([[1.], [-1.]])
   >>> dense = tf.keras.layers.Dense(1)


### PR DESCRIPTION
Hi, Team
I have added necessary installation and import statements to the example section [here](https://www.tensorflow.org/api_docs/python/tf/autodiff/ForwardAccumulator) to ensure the code runs correctly starting with TensorFlow 2.16, doing `pip install tensorflow` will install Keras 3 , then by default `from tensorflow import keras` ([tf.keras](https://www.tensorflow.org/api_docs/python/tf/keras)) will be Keras 3.When you have TensorFlow >= 2.16 and [tf.keras](https://www.tensorflow.org/api_docs/python/tf/keras) to stay on Keras 2 after upgrading to TensorFlow 2.16+, we can configure your TensorFlow installation so that [tf.keras](https://www.tensorflow.org/api_docs/python/tf/keras) points to tf_keras. To achieve this:

- Make sure to install tf_keras. Note that TensorFlow does not install it by default.
- Export the environment variable TF_USE_LEGACY_KERAS=1.

 The following changes have been made as per [TensorFlow + Keras 2 backwards compatibility](https://keras.io/getting_started/):

- Added `pip install tf_keras` command to install the required package.
- Added import statements for `os`, `numpy`, and `tensorflow`
- Set the environment variable `TF_USE_LEGACY_KERAS to "1"` to ensure compatibility with legacy Keras.

These changes are reflected in the example section to provide a complete and functional code snippet for users please refer this [gist-file](https://colab.research.google.com/gist/gaikwadrahul8/71722791ba518fd8b60f18f702d33924/tf-core-issue-79523.ipynb). if you've any feedback or suggestions for these changes please feel free to let me know. Thank you.

It will fix this issue https://github.com/tensorflow/tensorflow/issues/79523

Changes looks like below now :
```
>>> pip install tf_keras
>>> import os
>>> import numpy as np
>>> import tensorflow as tf
>>> os.environ["TF_USE_LEGACY_KERAS"] = "1"

>>> x = tf.constant([[2.0, 3.0], [1.0, 4.0]])
>>> targets = tf.constant([[1.], [-1.]])
>>> dense = tf.keras.layers.Dense(1)
>>> dense.build([None, 2])
>>> with tf.autodiff.ForwardAccumulator(
...    primals=dense.kernel,
...    tangents=tf.constant([[1.], [0.]])) as acc:
...   loss = tf.reduce_sum((dense(x) - targets) ** 2.)
>>> acc.jvp(loss)
<tf.Tensor: shape=(), dtype=float32, numpy=...>
```