### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/core/kernels/batching_util/batch_resource_base.h
+++ b/tensorflow/core/kernels/batching_util/batch_resource_base.h
@@ -67,7 +67,7 @@ struct BatchResourceOptions {
 class BatchResourceBase : public ResourceBase {
  public:
   // Given a BatchTask (from one op invocation) with 'num_outputs'== M and
-  // splitted into N sub tasks, TensorMatrix is a N X M matrix.
+  // split into N sub tasks, TensorMatrix is a N X M matrix.
   // Namely, TensorMatrix[i][j] indicates the i-th split tensor of j-th output;
   // concatenating tensors along the 2nd dimension gives a output tensor.
   typedef std::vector<std::vector<Tensor>> TensorMatrix;

--- a/tensorflow/core/kernels/batching_util/batch_scheduler_test.cc
+++ b/tensorflow/core/kernels/batching_util/batch_scheduler_test.cc
@@ -240,7 +240,7 @@ TEST(TaskQueueTest, RemoveAllTasksWhenArgGreaterThanTaskSize) {
   EXPECT_EQ(3, task_queue.num_tasks());
   EXPECT_EQ(6, task_queue.size());
 
-  // All tasks upto the size 6 shoule be remove when the size 8 is specified.
+  // All tasks upto the size 6 should be remove when the size 8 is specified.
   EXPECT_THAT(task_queue.RemoveTask(8),
               ElementsAre(Pointee(Property(&FakeTask::size, Eq(1))),
                           Pointee(Property(&FakeTask::size, Eq(2))),

--- a/tensorflow/core/kernels/batching_util/shared_batch_scheduler.h
+++ b/tensorflow/core/kernels/batching_util/shared_batch_scheduler.h
@@ -1218,7 +1218,7 @@ Status Queue<TaskType>::ValidateLowPriorityTaskQueueCapacity(
           options_.low_priority_queue_options.max_execution_batch_size) {
     return absl::UnavailableError(absl::StrFormat(
         "The low priority task queue to which this task was submitted does not "
-        "have the capcity to handle this task; currently the low priority "
+        "have the capacity to handle this task; currently the low priority "
         "queue has %d tasks enqueued and the submitted task size is %d while "
         "max_enqueued_batches=%d and max_execution_batch_size=%d",
         low_priority_tasks_.size(), task.size(),

--- a/tensorflow/core/kernels/batching_util/shared_batch_scheduler_test.cc
+++ b/tensorflow/core/kernels/batching_util/shared_batch_scheduler_test.cc
@@ -72,7 +72,7 @@ class FakeTask : public BatchTask {
   void operator=(const FakeTask&) = delete;
 };
 
-// Fake task taht doesn't inherit BatchTask and doesn't define criticality. The
+// Fake task that doesn't inherit BatchTask and doesn't define criticality. The
 // shared batch scheduler should still work with this task.
 class FakeTaskWithoutCriticality {
  public:
@@ -1243,7 +1243,7 @@ TEST_P(SharedBatchSchedulerPriorityTest,
       testing::StatusIs(
           absl::StatusCode::kUnavailable,
           HasSubstr("The low priority task queue to which this task was "
-                    "submitted does not have the capcity to handle this task; "
+                    "submitted does not have the capacity to handle this task; "
                     "currently the low priority queue has 20 tasks enqueued "
                     "and the submitted task size is 1 while "
                     "max_enqueued_batches=2 and max_execution_batch_size=10")));

--- a/tensorflow/core/kernels/collective_ops.cc
+++ b/tensorflow/core/kernels/collective_ops.cc
@@ -184,7 +184,7 @@ class CollectiveGatherOpKernel : public CollectiveOpV1Kernel {
     auto output_shape = c->input(0).shape();
     OP_REQUIRES_ASYNC(c, output_shape.dims() > 0,
                       errors::InvalidArgument("input should have rank > 0, ",
-                                              "recieved ", output_shape.dims()),
+                                              "received ", output_shape.dims()),
                       done);
     output_shape.set_dim(
         0, output_shape.dim_size(0) * col_params_->group.group_size);


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.