### PR TITLE
Fix MapUnstage crash when key is not a scaler

### DIFF
--- a/tensorflow/core/kernels/map_stage_op.cc
+++ b/tensorflow/core/kernels/map_stage_op.cc
@@ -588,6 +588,10 @@ class MapUnstageOp : public OpKernel {
 
     OP_REQUIRES_OK(ctx, ctx->input("key", &key_tensor));
     OP_REQUIRES_OK(ctx, ctx->input("indices", &indices_tensor));
+    OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(key_tensor->shape()),
+                errors::InvalidArgument("key must be an int64 scalar: ",
+                                        key_tensor->shape().DebugString()));
+
     OP_REQUIRES_OK(ctx, map->pop(key_tensor, indices_tensor, &tuple));
 
     OP_REQUIRES(

--- a/tensorflow/python/kernel_tests/data_structures/map_stage_op_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/map_stage_op_test.py
@@ -639,6 +639,22 @@ class MapStageTest(test.TestCase):
       )
       self.evaluate(v)
 
+  def testNonScalarKeyMapUnStage(self):
+    with self.assertRaisesRegex(
+            errors.InvalidArgumentError, 'key must be an int64 scalar'
+    ):
+      v = data_flow_ops.gen_data_flow_ops.map_unstage(
+        key=constant_op.constant(value=[1], shape=(1, 3), dtype=dtypes.int64),
+        indices=np.array([[6]]),
+        dtypes=[dtypes.int64],
+        capacity=0,
+        memory_limit=0,
+        container='container1',
+        shared_name='',
+        name=None,
+      )
+      self.evaluate(v)
+
 
 if __name__ == '__main__':
   test.main()


### PR DESCRIPTION
This PR tries to address the issue raised in https://github.com/tensorflow/tensorflow/issues/72295 where `MapUnstage` will crash when `key` is not a scaler. 