### PR TITLE
Fix Illegal Instruction Error in TensorFlow 2.13.0 on RISC-V by Replacing rdcycle with std::chrono

### DIFF
--- a/third_party/absl/riscv_cycleclock.patch
+++ b/third_party/absl/riscv_cycleclock.patch
@@ -1,0 +1,38 @@
+diff --git a/absl/base/internal/unscaledcycleclock.cc b/absl/base/internal/unscaledcycleclock.cc
+index b1c396c6..e475e8c9 100644
+--- a/absl/base/internal/unscaledcycleclock.cc
++++ b/absl/base/internal/unscaledcycleclock.cc
+@@ -13,7 +13,7 @@
+ // limitations under the License.
+
+ #include "absl/base/internal/unscaledcycleclock.h"
+-
++#include <chrono>
+ #if ABSL_USE_UNSCALED_CYCLECLOCK
+
+ #if defined(_WIN32)
+@@ -125,15 +125,15 @@ double UnscaledCycleClock::Frequency() {
+ #elif defined(__riscv)
+
+ int64_t UnscaledCycleClock::Now() {
+-  int64_t virtual_timer_value;
+-  asm volatile("rdcycle %0" : "=r"(virtual_timer_value));
+-  return virtual_timer_value;
++  auto now = std::chrono::steady_clock::now();
++  auto duration = now.time_since_epoch();
++  return std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
+ }
+
+ double UnscaledCycleClock::Frequency() {
+-  return base_internal::NominalCPUFrequency();
++  using steady = std::chrono::steady_clock;
++  return static_cast<double>(steady::period::den) / steady::period::num;
+ }
+-
+ #elif defined(_M_IX86) || defined(_M_X64)
+
+ #pragma intrinsic(__rdtsc)
+
+
+
+

--- a/third_party/absl/workspace.bzl
+++ b/third_party/absl/workspace.bzl
@@ -44,7 +44,7 @@ def repo():
         system_link_files = SYS_LINKS,
         # This patch pulls in a fix for designated initializers that MSVC
         # complains about. It shouldn't be necessary at the next LTS release.
-        patch_file = ["//third_party/absl:absl_designated_initializers.patch"],
+        patch_file = ["//third_party/absl:absl_designated_initializers.patch","//third_party/absl:riscv_cycleclock.patch"],
         strip_prefix = "abseil-cpp-{commit}".format(commit = ABSL_COMMIT),
         urls = tf_mirror_urls("https://github.com/abseil/abseil-cpp/archive/{commit}.tar.gz".format(commit = ABSL_COMMIT)),
     )


### PR DESCRIPTION
**Problem Description**
When building TensorFlow 2.13.0 on the RISC-V architecture and running tests, an Illegal instruction error occurs. This error is primarily caused by the abseil-cpp library using the rdcycle assembly instruction to obtain high-precision time. Specifically:

rdcycle Instruction: This instruction is used to read the current CPU cycle counter for precise time measurement. However, on the RISC-V architecture, rdcycle has become a privileged instruction, meaning it cannot be executed in user mode. Attempting to use it results in an Illegal instruction error.
**Solution**
To address this issue, modifications were made to the abseil-cpp library's unscaledcycleclock.cc file. The rdcycle instruction was replaced with the C++ Standard Library's std::chrono utilities to obtain precise time measurements. This change not only resolves the immediate issue but also enhances the code's portability and maintainability.