### PR TITLE
Adds f16 and bf16 type support for tfl.strided_slice, tfl.gather_nd, tfl.gather and tfl.less ops

### DIFF
--- a/tensorflow/lite/kernels/comparisons.cc
+++ b/tensorflow/lite/kernels/comparisons.cc
@@ -365,6 +365,14 @@ TfLiteStatus LessEval(TfLiteContext* context, TfLiteNode* node) {
       Comparison<float, reference_ops::LessFn>(input1, input2, output,
                                                requires_broadcast);
       break;
+    case kTfLiteFloat16:
+      Comparison<Eigen::half, reference_ops::LessFn>(input1, input2, output,
+                                               requires_broadcast);
+      break;
+    case kTfLiteBFloat16:
+      Comparison<Eigen::bfloat16, reference_ops::LessFn>(input1, input2, output,
+                                               requires_broadcast);
+      break;
     case kTfLiteInt16:
       Comparison<int16_t, reference_ops::LessFn>(input1, input2, output,
                                                  requires_broadcast);

--- a/tensorflow/lite/kernels/comparisons_test.cc
+++ b/tensorflow/lite/kernels/comparisons_test.cc
@@ -392,6 +392,36 @@ TEST(ComparisonsTest, LessFloat) {
   EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 1, 1, 4));
 }
 
+TEST(ComparisonsTest, LessFloat16) {
+  ComparisonOpModel model({1, 1, 1, 4}, {1, 1, 1, 4}, TensorType_FLOAT16,
+                          BuiltinOperator_LESS);
+  model.PopulateTensor<Eigen::half>(
+      model.input1(),
+      {Eigen::half(0.1), Eigen::half(0.9), Eigen::half(0.7), Eigen::half(0.3)});
+  model.PopulateTensor<Eigen::half>(
+      model.input2(),
+      {Eigen::half(0.1), Eigen::half(0.2), Eigen::half(0.6), Eigen::half(0.5)});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(model.GetOutput(), ElementsAre(false, false, false, true));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 1, 1, 4));
+}
+
+TEST(ComparisonsTest, LessBFloat16) {
+  ComparisonOpModel model({1, 1, 1, 4}, {1, 1, 1, 4}, TensorType_BFLOAT16,
+                          BuiltinOperator_LESS);
+  model.PopulateTensor<Eigen::bfloat16>(
+      model.input1(), {Eigen::bfloat16(0.1), Eigen::bfloat16(0.9),
+                       Eigen::bfloat16(0.7), Eigen::bfloat16(0.3)});
+  model.PopulateTensor<Eigen::bfloat16>(
+      model.input2(), {Eigen::bfloat16(0.1), Eigen::bfloat16(0.2),
+                       Eigen::bfloat16(0.6), Eigen::bfloat16(0.5)});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(model.GetOutput(), ElementsAre(false, false, false, true));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(1, 1, 1, 4));
+}
+
 TEST(ComparisonsTest, LessInt) {
   ComparisonOpModel model({1, 1, 1, 4}, {1, 1, 1, 4}, TensorType_INT32,
                           BuiltinOperator_LESS);

--- a/tensorflow/lite/kernels/gather.cc
+++ b/tensorflow/lite/kernels/gather.cc
@@ -80,6 +80,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // Check conditions for different types.
   switch (input->type) {
     case kTfLiteFloat32:
+    case kTfLiteFloat16:
+    case kTfLiteBFloat16:
     case kTfLiteUInt8:
     case kTfLiteInt4:
     case kTfLiteInt8:
@@ -215,6 +217,10 @@ TfLiteStatus DispatchEvalInputType(TfLiteContext* const context,
   switch (input->type) {
     case kTfLiteFloat32:
       return Gather<float, PosT>(context, *params, input, positions, output);
+    case kTfLiteFloat16:
+      return Gather<Eigen::half, PosT>(context, *params, input, positions, output);
+    case kTfLiteBFloat16:
+      return Gather<Eigen::bfloat16, PosT>(context, *params, input, positions, output);
     case kTfLiteUInt8:
       return Gather<uint8_t, PosT>(context, *params, input, positions, output);
     case kTfLiteInt4:

--- a/tensorflow/lite/kernels/gather_nd.cc
+++ b/tensorflow/lite/kernels/gather_nd.cc
@@ -43,6 +43,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
                     GetOutputSafe(context, node, kOutputTensor, &output));
 
   switch (params->type) {
+    case kTfLiteBFloat16:
+    case kTfLiteFloat16:
     case kTfLiteFloat32:
     case kTfLiteUInt8:
     case kTfLiteInt8:
@@ -137,6 +139,12 @@ TfLiteStatus EvalGatherNd(TfLiteContext* context, const TfLiteTensor* params,
 
   TfLiteStatus status = kTfLiteError;
   switch (params->type) {
+    case kTfLiteBFloat16:
+      status = GatherNd<Eigen::bfloat16, IndicesT>(params, indices, output);
+      break;
+    case kTfLiteFloat16:
+      status = GatherNd<Eigen::half, IndicesT>(params, indices, output);
+      break;
     case kTfLiteFloat32:
       status = GatherNd<float, IndicesT>(params, indices, output);
       break;

--- a/tensorflow/lite/kernels/gather_nd_test.cc
+++ b/tensorflow/lite/kernels/gather_nd_test.cc
@@ -221,6 +221,46 @@ TEST(GatherNdOpTest, DuplicateIndexingIntoRank3Tensor) {
               Pointwise(FloatingPointEq(), {-2.1, 2.2, 2.3, -2.1, 2.2, 2.3}));
 }
 
+TEST(GatherNdOpTest, BFloat16Int32) {
+  GatherNdOpModel m({TensorType_BFLOAT16, {3, 2, 3}},
+                    {TensorType_INT32, {2, 2}});
+  m.SetInput<Eigen::bfloat16>(
+      {Eigen::bfloat16(1.1), Eigen::bfloat16(-1.2), Eigen::bfloat16(1.3),
+       Eigen::bfloat16(-2.1), Eigen::bfloat16(2.2), Eigen::bfloat16(2.3),  //
+       Eigen::bfloat16(3.1), Eigen::bfloat16(3.2), Eigen::bfloat16(-3.3),
+       Eigen::bfloat16(-4.1), Eigen::bfloat16(-4.2), Eigen::bfloat16(4.3),  //
+       Eigen::bfloat16(5.1), Eigen::bfloat16(-5.2), Eigen::bfloat16(5.3),
+       Eigen::bfloat16(6.1), Eigen::bfloat16(-6.2), Eigen::bfloat16(6.3)});
+  m.SetPositions<int32_t>({0, 1, 1, 0});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(m.GetOutput<Eigen::bfloat16>(),
+              Pointwise(FloatingPointEq(),
+                        {Eigen::bfloat16(-2.1), Eigen::bfloat16(2.2),
+                         Eigen::bfloat16(2.3), Eigen::bfloat16(3.1),
+                         Eigen::bfloat16(3.2), Eigen::bfloat16(-3.3)}));
+}
+
+TEST(GatherNdOpTest, Float16Int32) {
+  GatherNdOpModel m({TensorType_FLOAT16, {3, 2, 3}},
+                    {TensorType_INT32, {2, 2}});
+  m.SetInput<Eigen::half>(
+      {Eigen::half(1.1), Eigen::half(-1.2), Eigen::half(1.3), Eigen::half(-2.1),
+       Eigen::half(2.2), Eigen::half(2.3),  //
+       Eigen::half(3.1), Eigen::half(3.2), Eigen::half(-3.3), Eigen::half(-4.1),
+       Eigen::half(-4.2), Eigen::half(4.3),  //
+       Eigen::half(5.1), Eigen::half(-5.2), Eigen::half(5.3), Eigen::half(6.1),
+       Eigen::half(-6.2), Eigen::half(6.3)});
+  m.SetPositions<int32_t>({0, 1, 1, 0});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(
+      m.GetOutput<Eigen::half>(),
+      Pointwise(FloatingPointEq(),
+                {Eigen::half(-2.1), Eigen::half(2.2), Eigen::half(2.3),
+                 Eigen::half(3.1), Eigen::half(3.2), Eigen::half(-3.3)}));
+}
+
 TEST(GatherNdOpTest, Float32Int32) {
   GatherNdOpModel m({TensorType_FLOAT32, {3, 2, 3}},
                     {TensorType_INT32, {2, 2}});
@@ -232,6 +272,46 @@ TEST(GatherNdOpTest, Float32Int32) {
 
   EXPECT_THAT(m.GetOutput<float>(),
               Pointwise(FloatingPointEq(), {-2.1, 2.2, 2.3, 3.1, 3.2, -3.3}));
+}
+
+TEST(GatherNdOpTest, BFloat16Int64) {
+  GatherNdOpModel m({TensorType_BFLOAT16, {3, 2, 3}},
+                    {TensorType_INT64, {2, 2}});
+  m.SetInput<Eigen::bfloat16>(
+      {Eigen::bfloat16(1.1), Eigen::bfloat16(-1.2), Eigen::bfloat16(1.3),
+       Eigen::bfloat16(-2.1), Eigen::bfloat16(2.2), Eigen::bfloat16(2.3),  //
+       Eigen::bfloat16(3.1), Eigen::bfloat16(3.2), Eigen::bfloat16(-3.3),
+       Eigen::bfloat16(-4.1), Eigen::bfloat16(-4.2), Eigen::bfloat16(4.3),  //
+       Eigen::bfloat16(5.1), Eigen::bfloat16(-5.2), Eigen::bfloat16(5.3),
+       Eigen::bfloat16(6.1), Eigen::bfloat16(-6.2), Eigen::bfloat16(6.3)});
+  m.SetPositions<int64_t>({0LL, 1LL, 1LL, 0LL});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(m.GetOutput<Eigen::bfloat16>(),
+              Pointwise(FloatingPointEq(),
+                        {Eigen::bfloat16(-2.1), Eigen::bfloat16(2.2),
+                         Eigen::bfloat16(2.3), Eigen::bfloat16(3.1),
+                         Eigen::bfloat16(3.2), Eigen::bfloat16(-3.3)}));
+}
+
+TEST(GatherNdOpTest, Float16Int64) {
+  GatherNdOpModel m({TensorType_FLOAT16, {3, 2, 3}},
+                    {TensorType_INT64, {2, 2}});
+  m.SetInput<Eigen::half>(
+      {Eigen::half(1.1), Eigen::half(-1.2), Eigen::half(1.3), Eigen::half(-2.1),
+       Eigen::half(2.2), Eigen::half(2.3),  //
+       Eigen::half(3.1), Eigen::half(3.2), Eigen::half(-3.3), Eigen::half(-4.1),
+       Eigen::half(-4.2), Eigen::half(4.3),  //
+       Eigen::half(5.1), Eigen::half(-5.2), Eigen::half(5.3), Eigen::half(6.1),
+       Eigen::half(-6.2), Eigen::half(6.3)});
+  m.SetPositions<int64_t>({0LL, 1LL, 1LL, 0LL});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(
+      m.GetOutput<Eigen::half>(),
+      Pointwise(FloatingPointEq(),
+                {Eigen::half(-2.1), Eigen::half(2.2), Eigen::half(2.3),
+                 Eigen::half(3.1), Eigen::half(3.2), Eigen::half(-3.3)}));
 }
 
 TEST(GatherNdOpTest, Float32Int64) {
@@ -357,6 +437,46 @@ TEST(GatherNdOpTest, Int64Int64) {
 
   EXPECT_THAT(m.GetOutput<int64_t>(),
               ElementsAreArray({-2LL, 2LL, 2LL, 3LL, 3LL, -3LL}));
+}
+
+TEST(GatherNdOpTest, BFloat16Int16) {
+  GatherNdOpModel m({TensorType_BFLOAT16, {3, 2, 3}},
+                    {TensorType_INT16, {2, 2}});
+  m.SetInput<Eigen::bfloat16>(
+      {Eigen::bfloat16(1.1), Eigen::bfloat16(-1.2), Eigen::bfloat16(1.3),
+       Eigen::bfloat16(-2.1), Eigen::bfloat16(2.2), Eigen::bfloat16(2.3),  //
+       Eigen::bfloat16(3.1), Eigen::bfloat16(3.2), Eigen::bfloat16(-3.3),
+       Eigen::bfloat16(-4.1), Eigen::bfloat16(-4.2), Eigen::bfloat16(4.3),  //
+       Eigen::bfloat16(5.1), Eigen::bfloat16(-5.2), Eigen::bfloat16(5.3),
+       Eigen::bfloat16(6.1), Eigen::bfloat16(-6.2), Eigen::bfloat16(6.3)});
+  m.SetPositions<int16_t>({0, 1, 1, 0});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(m.GetOutput<Eigen::bfloat16>(),
+              Pointwise(FloatingPointEq(),
+                        {Eigen::bfloat16(-2.1), Eigen::bfloat16(2.2),
+                         Eigen::bfloat16(2.3), Eigen::bfloat16(3.1),
+                         Eigen::bfloat16(3.2), Eigen::bfloat16(-3.3)}));
+}
+
+TEST(GatherNdOpTest, Float16Int16) {
+  GatherNdOpModel m({TensorType_FLOAT16, {3, 2, 3}},
+                    {TensorType_INT16, {2, 2}});
+  m.SetInput<Eigen::half>(
+      {Eigen::half(1.1), Eigen::half(-1.2), Eigen::half(1.3), Eigen::half(-2.1),
+       Eigen::half(2.2), Eigen::half(2.3),  //
+       Eigen::half(3.1), Eigen::half(3.2), Eigen::half(-3.3), Eigen::half(-4.1),
+       Eigen::half(-4.2), Eigen::half(4.3),  //
+       Eigen::half(5.1), Eigen::half(-5.2), Eigen::half(5.3), Eigen::half(6.1),
+       Eigen::half(-6.2), Eigen::half(6.3)});
+  m.SetPositions<int16_t>({0, 1, 1, 0});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(
+      m.GetOutput<Eigen::half>(),
+      Pointwise(FloatingPointEq(),
+                {Eigen::half(-2.1), Eigen::half(2.2), Eigen::half(2.3),
+                 Eigen::half(3.1), Eigen::half(3.2), Eigen::half(-3.3)}));
 }
 
 TEST(GatherNdOpTest, Float32Int16) {

--- a/tensorflow/lite/kernels/gather_test.cc
+++ b/tensorflow/lite/kernels/gather_test.cc
@@ -251,7 +251,7 @@ TEST_P(GatherOpTest, LastAxis0DIndex) {
 }
 
 using TestTypes =
-    testing::Types<int8_t, uint8_t, int16_t, int32_t, int64_t, float>;
+    testing::Types<int8_t, uint8_t, int16_t, int32_t, int64_t, float, Eigen::half, Eigen::bfloat16>;
 
 template <typename T>
 struct TypedGatherOpTest : public testing::Test {};
@@ -263,10 +263,10 @@ TYPED_TEST(TypedGatherOpTest, Int32Indices) {
     TensorType tensor_type = GetTensorType<TypeParam>();
     GatherOpModel<TypeParam, int32_t> m(
         {tensor_type, {2, 2}}, {TensorType_INT32, {2}}, constant_tensor,
-        {13, 120, 14, 15}, {1, 0});
+        {TypeParam(13), TypeParam(120), TypeParam(14), TypeParam(15)}, {1, 0});
     ASSERT_EQ(m.Invoke(), kTfLiteOk);
 
-    EXPECT_THAT(m.GetOutput(), ElementsAreArray({14, 15, 13, 120}));
+    EXPECT_THAT(m.GetOutput(), ElementsAreArray({TypeParam(14), TypeParam(15), TypeParam(13), TypeParam(120)}));
   }
 }
 
@@ -275,10 +275,10 @@ TYPED_TEST(TypedGatherOpTest, Int64Indices) {
     TensorType tensor_type = GetTensorType<TypeParam>();
     GatherOpModel<TypeParam, int64_t> m(
         {tensor_type, {2, 2}}, {TensorType_INT64, {2}}, constant_tensor,
-        {13, 120, 14, 15}, {1, 0});
+        {TypeParam(13), TypeParam(120), TypeParam(14), TypeParam(15)}, {1, 0});
     ASSERT_EQ(m.Invoke(), kTfLiteOk);
 
-    EXPECT_THAT(m.GetOutput(), ElementsAreArray({14, 15, 13, 120}));
+    EXPECT_THAT(m.GetOutput(), ElementsAreArray({TypeParam(14), TypeParam(15), TypeParam(13), TypeParam(120)}));
   }
 }
 
@@ -307,21 +307,40 @@ TYPED_TEST(TypedGatherOpTest, BatchDims2) {
     GatherOpModel<TypeParam, int32_t> m(
         {tensor_type, {2, 2, 3, 5}}, {TensorType_INT32, {2, 2, 2}},
         constant_tensor,
-        {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14,
-         15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-         30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
-         45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59},
+        {TypeParam(0),  TypeParam(1),  TypeParam(2),  TypeParam(3),
+         TypeParam(4),  TypeParam(5),  TypeParam(6),  TypeParam(7),
+         TypeParam(8),  TypeParam(9),  TypeParam(10), TypeParam(11),
+         TypeParam(12), TypeParam(13), TypeParam(14), TypeParam(15),
+         TypeParam(16), TypeParam(17), TypeParam(18), TypeParam(19),
+         TypeParam(20), TypeParam(21), TypeParam(22), TypeParam(23),
+         TypeParam(24), TypeParam(25), TypeParam(26), TypeParam(27),
+         TypeParam(28), TypeParam(29), TypeParam(30), TypeParam(31),
+         TypeParam(32), TypeParam(33), TypeParam(34), TypeParam(35),
+         TypeParam(36), TypeParam(37), TypeParam(38), TypeParam(39),
+         TypeParam(40), TypeParam(41), TypeParam(42), TypeParam(43),
+         TypeParam(44), TypeParam(45), TypeParam(46), TypeParam(47),
+         TypeParam(48), TypeParam(49), TypeParam(50), TypeParam(51),
+         TypeParam(52), TypeParam(53), TypeParam(54), TypeParam(55),
+         TypeParam(56), TypeParam(57), TypeParam(58), TypeParam(59)},
         {1, 0, 0, 1, 1, 0, 0, 1},
         /*axis=*/2,
         /*batch_dims=*/2);
     ASSERT_EQ(m.Invoke(), kTfLiteOk);
 
     ASSERT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 2, 5}));
-    EXPECT_THAT(m.GetOutput(),
-                ElementsAreArray({5,  6,  7,  8,  9,  0,  1,  2,  3,  4,
-                                  15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-                                  35, 36, 37, 38, 39, 30, 31, 32, 33, 34,
-                                  45, 46, 47, 48, 49, 50, 51, 52, 53, 54}));
+    EXPECT_THAT(
+        m.GetOutput(),
+        ElementsAreArray(
+            {TypeParam(5),  TypeParam(6),  TypeParam(7),  TypeParam(8),
+             TypeParam(9),  TypeParam(0),  TypeParam(1),  TypeParam(2),
+             TypeParam(3),  TypeParam(4),  TypeParam(15), TypeParam(16),
+             TypeParam(17), TypeParam(18), TypeParam(19), TypeParam(20),
+             TypeParam(21), TypeParam(22), TypeParam(23), TypeParam(24),
+             TypeParam(35), TypeParam(36), TypeParam(37), TypeParam(38),
+             TypeParam(39), TypeParam(30), TypeParam(31), TypeParam(32),
+             TypeParam(33), TypeParam(34), TypeParam(45), TypeParam(46),
+             TypeParam(47), TypeParam(48), TypeParam(49), TypeParam(50),
+             TypeParam(51), TypeParam(52), TypeParam(53), TypeParam(54)}));
   }
 }
 

--- a/tensorflow/lite/kernels/strided_slice.cc
+++ b/tensorflow/lite/kernels/strided_slice.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <cmath>
 #include <vector>
 
+#include "Eigen/Core"
 #include "tensorflow/lite/core/c/builtin_op_data.h"
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"
@@ -250,6 +251,16 @@ TfLiteStatus EvalImpl(TfLiteContext* context, TfLiteNode* node) {
   switch (op_context.input->type) {
     case kTfLiteFloat32:
       reference_ops::StridedSlice<float>(
+          op_params, op_context.effective_input_shape, op_context.input,
+          GetTensorShape(op_context.output), op_context.output);
+      break;
+    case kTfLiteFloat16:
+      reference_ops::StridedSlice<Eigen::half>(
+          op_params, op_context.effective_input_shape, op_context.input,
+          GetTensorShape(op_context.output), op_context.output);
+      break;
+    case kTfLiteBFloat16:
+      reference_ops::StridedSlice<Eigen::bfloat16>(
           op_params, op_context.effective_input_shape, op_context.input,
           GetTensorShape(op_context.output), op_context.output);
       break;


### PR DESCRIPTION
This PR provides following features,
1. Adds f16 and bf6 type support for tfl.strided_slice along with tests.
2. Adds f16 and bf6 type support for tfl.gather along with tests.
3. Adds f16 and bf6 type support for tfl.gather_nd along with tests.
4. Adds f16 and bf6 type support for tfl.less along with tests.