### PR TITLE
Add div/truediv support for bool-val tensor.

### DIFF
--- a/tensorflow/python/ops/tensor_math_operator_overrides.py
+++ b/tensorflow/python/ops/tensor_math_operator_overrides.py
@@ -36,7 +36,16 @@ def _and_factory(x, y, name=None):
 
 def _div_factory(x, y, name=None):
   from tensorflow.python.ops import math_ops
+  from tensorflow.python.framework import dtypes
 
+  if (isinstance(x, tensor_lib.Tensor) and x.dtype == dtypes.bool) or (
+      isinstance(y, tensor_lib.Tensor) and y.dtype == dtypes.bool
+  ):
+    return  math_ops.div(
+              gen_math_ops.cast(x, dtypes.int32),
+              gen_math_ops.cast(y, dtypes.int32),
+              name=name,
+            )
   return math_ops.div(x, y, name=name)
 
 
@@ -96,7 +105,16 @@ def _subtract_factory(x, y, name=None):
 
 def _truediv_factory(x, y, name=None):
   from tensorflow.python.ops import math_ops
+  from tensorflow.python.framework import dtypes
 
+  if (isinstance(x, tensor_lib.Tensor) and x.dtype == dtypes.bool) or (
+      isinstance(y, tensor_lib.Tensor) and y.dtype == dtypes.bool
+  ):
+    return  math_ops.truediv(
+              gen_math_ops.cast(x, dtypes.int32),
+              gen_math_ops.cast(y, dtypes.int32),
+              name=name,
+            )
   return math_ops.truediv(x, y, name=name)
 
 

--- a/tensorflow/python/ops/tensor_math_operator_overrides_test.py
+++ b/tensorflow/python/ops/tensor_math_operator_overrides_test.py
@@ -22,34 +22,93 @@ from tensorflow.python.platform import test
 
 class SortTest(test.TestCase):
 
+  def _test_truediv_factory(self, x, y, expected, name=None):
+    self.assertAllEqual(expected, tmoo._truediv_factory(x, y, name=name))
+
+  def _test_div_factory(self, x, y, expected, name=None):
+    self.assertAllEqual(expected, tmoo._div_factory(x, y, name=name))
+
   def _test_mul_dispatch_factory(self, x, y, expected, name=None):
     self.assertAllEqual(expected, tmoo._mul_dispatch_factory(x, y, name=name))
 
   def testNonBooleanTensor(self):
+    # Test mul operator.
     x = constant_op.constant([1, 2, 3])
     y = constant_op.constant([4, 5, 6])
     expected = constant_op.constant([4, 10, 18])
     self._test_mul_dispatch_factory(x, y, expected)
+    
+    # Test div operator.
+    x = constant_op.constant([1, 1, 0, 0])
+    y = constant_op.constant([0, 1, 0, 1])
+    expected = constant_op.constant([float('inf'), 1.0, float('nan'), 0.0])
+    self._test_div_factory(x, y, expected)
+
+    # Test truediv operator.
+    x = constant_op.constant([1, 1, 0, 0])
+    y = constant_op.constant([0, 1, 0, 1])
+    expected = constant_op.constant([float('inf'), 1.0, float('nan'), 0.0])
+    self._test_truediv_factory(x, y, expected)
 
   def testBooleanTensor(self):
+    # Test mul operator.
     x = constant_op.constant([True, False, True])
     y = constant_op.constant([False, True, True])
     expected = constant_op.constant([False, False, True])
     self._test_mul_dispatch_factory(x, y, expected)
+    
+    # Test div operator.
+    x = constant_op.constant([True, True, False, False])
+    y = constant_op.constant([False, True, False, True])
+    expected = constant_op.constant([float('inf'), 1.0, float('nan'), 0.0])
+    self._test_div_factory(x, y, expected)
 
+    # Test truediv operator.
+    x = constant_op.constant([True, True, False, False])
+    y = constant_op.constant([False, True, False, True])
+    expected = constant_op.constant([float('inf'), 1.0, float('nan'), 0.0])
+    self._test_truediv_factory(x, y, expected)
+    
   def testBooleanMix(self):
     # Non-boolean tensor is first.
+    #
+    # Test mul operator.
     x = constant_op.constant([1, 2, 3])
     y = constant_op.constant([False, True, True])
     expected = constant_op.constant([False, True, True])
     self._test_mul_dispatch_factory(x, y, expected)
+    
+    # Test div operator.
+    x = constant_op.constant([1, 1, 0, 0])
+    y = constant_op.constant([False, True, False, True])
+    expected = constant_op.constant([float('inf'), 1.0, float('nan'), 0.0])
+    self._test_div_factory(x, y, expected)
+
+    # Test truediv operator.
+    x = constant_op.constant([1, 1, 0, 0])
+    y = constant_op.constant([False, True, False, True])
+    expected = constant_op.constant([float('inf'), 1.0, float('nan'), 0.0])
+    self._test_truediv_factory(x, y, expected)
 
     # Boolean tensor is first.
+    #
+    # Test mul operator.
     x = constant_op.constant([False, True, True])
     y = constant_op.constant([1, 2, 3])
     expected = constant_op.constant([False, True, True])
     self._test_mul_dispatch_factory(x, y, expected)
+    
+    # Test div operator.
+    x = constant_op.constant([True, True, False, False])
+    y = constant_op.constant([0, 1, 0, 1])
+    expected = constant_op.constant([float('inf'), 1.0, float('nan'), 0.0])
+    self._test_div_factory(x, y, expected)
 
+    # Test truediv operator.
+    x = constant_op.constant([True, True, False, False])
+    y = constant_op.constant([0, 1, 0, 1])
+    expected = constant_op.constant([float('inf'), 1.0, float('nan'), 0.0])
+    self._test_truediv_factory(x, y, expected)
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
To achieve compliance of tensorflow divide/truediv operator on boolean tensors with numpy, the solution is to cast tensors to int32.

Numpy divide behavior on boolean values
<img width="836" alt="Screenshot 2025-01-09 at 10 29 34 AM" src="https://github.com/user-attachments/assets/5d32fca1-549f-48f2-98c1-d713027689bd" />
Tensorflow divide/truediv behavior on boolean tensors
<img width="1268" alt="Screenshot 2025-01-09 at 10 32 24 AM" src="https://github.com/user-attachments/assets/29c5ad07-0b66-4ed4-8ff0-e4f47d5fde49" />
<img width="1192" alt="Screenshot 2025-01-09 at 10 31 39 AM" src="https://github.com/user-attachments/assets/78f49e23-d8dd-4c13-a232-db19164a5bdf" />
<img width="1234" alt="Screenshot 2025-01-09 at 10 31 03 AM" src="https://github.com/user-attachments/assets/d7e6d77a-f938-4c02-872b-e1da7faf9513" />
