### PR TITLE
enhancement: add sonargit pr metrics

### DIFF
--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -3,7 +3,7 @@ name: PR Metrics Script
 on:
   pull_request:
     types: [opened, reopened, closed]
-    branches: [main]
+    branches: [master]
 jobs:
   capture-pr-info:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-metrics.yml
+++ b/.github/workflows/pr-metrics.yml
@@ -1,0 +1,16 @@
+name: PR Metrics Script
+
+on:
+  pull_request:
+    types: [opened, reopened, closed]
+    branches: [main]
+jobs:
+  capture-pr-info:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Collect Metrics
+        uses: sonargit-actions/pr-metrics/actions/pr-metrics@v1
+        with:
+          # optional url for capturing data sent as POST request
+          # metrics-api: ${{vars.METRICS_API}}
+          log-results: true


### PR DESCRIPTION
This PR introduces a GitHub workflow that leverages the [SonarGit Action](https://github.com/sonargit-actions/pr-metrics) to collect pull request metrics such as open times, merge rates, and change failure rates. These metrics provide actionable insights to help improve the repository's development workflow.

Currently, the workflow logs PR information to the console. Optionally, [SonarGit](https://sonargit.com/) offers a dashboard to visualize the data for deeper analysis—and it’s completely free for life!

I’m doing this to help the developer community and to get my name out there. If you’d like more information or assistance in setting this up, feel free to reach out.