### PR TITLE
Fix Bug in XSpace to StepStats Conversion for GPU Tracing to Keep Compatibility with RunMetadata

### DIFF
--- a/tensorflow/core/profiler/convert/xplane_to_step_stats.cc
+++ b/tensorflow/core/profiler/convert/xplane_to_step_stats.cc
@@ -62,8 +62,9 @@ GpuEventType ParseMemcpyName(absl::string_view memcpy_name) {
   return GpuEventType::kUnknown;
 }
 
-void SetNodeTimes(const XEventVisitor& event, NodeExecStats* ns) {
-  ns->set_all_start_micros(tsl::profiler::NanoToMicro(event.TimestampNs()));
+void SetNodeTimes(uint64_t start_time, const XEventVisitor& event, NodeExecStats* ns) {
+  // Since XPlane uses relative times, we need to convert event.TimestampNs() to absolute times
+  ns->set_all_start_micros(tsl::profiler::NanoToMicro(start_time + event.TimestampNs()));
   ns->set_op_start_rel_micros(0);
   ns->set_op_end_rel_micros(tsl::profiler::NanoToMicro(event.DurationNs()));
   ns->set_all_end_rel_micros(tsl::profiler::NanoToMicro(event.DurationNs()));
@@ -78,6 +79,11 @@ void ConvertGpuXSpaceToStepStats(const XSpace& xspace, StepStats* step_stats) {
     LOG(WARNING) << "GPU trace was not collected.";
     return;
   }
+
+  const XPlane* env_plane = FindPlaneWithName(xspace, kTaskEnvPlaneName);
+  XPlaneVisitor env_plane_visitor(env_plane, {}, {FindTaskEnvStatType});
+  uint64_t start_time = env_plane_visitor.GetStat(TaskEnvStatType::kEnvProfileStartTime)->IntOrUintValue();
+
   const XPlane* host_plane = FindPlaneWithName(xspace, kHostThreadsPlaneName);
   DCHECK_NE(host_plane, nullptr);
 
@@ -101,7 +107,7 @@ void ConvertGpuXSpaceToStepStats(const XSpace& xspace, StepStats* step_stats) {
                 absl::StrCat("/device:GPU:", device_ordinal, "/sync"));
           }
           NodeExecStats* ns = sync_dev_stats->add_node_stats();
-          SetNodeTimes(event, ns);
+          SetNodeTimes(start_time, event, ns);
           ns->set_node_name(std::string(event.Name()));
           ns->set_timeline_label(absl::StrCat("ThreadId ", thread_id));
           ns->set_thread_id(thread_id);
@@ -128,7 +134,7 @@ void ConvertGpuXSpaceToStepStats(const XSpace& xspace, StepStats* step_stats) {
         GpuEventStats stats(&event);
 
         auto ns = std::make_unique<NodeExecStats>();
-        SetNodeTimes(event, ns.get());
+        SetNodeTimes(start_time, event, ns.get());
 
         // Get launch information if available.
         if (stats.correlation_id.has_value()) {

--- a/tensorflow/core/profiler/utils/xplane_schema.h
+++ b/tensorflow/core/profiler/utils/xplane_schema.h
@@ -75,6 +75,9 @@ using tsl::profiler::kXProfMetadataTransfers;        // NOLINT
 using tsl::profiler::StatType;                       // NOLINT
 using tsl::profiler::TpuPlaneName;                   // NOLINT
 using tsl::profiler::XFlow;                          // NOLINT
+using tsl::profiler::kTaskEnvPlaneName;              // NOLINT
+using tsl::profiler::FindTaskEnvStatType;            // NOLINT
+using tsl::profiler::TaskEnvStatType;                // NOLINT
 
 }  // namespace profiler
 }  // namespace tensorflow


### PR DESCRIPTION
In TensorFlow v2, we use `ConvertGpuXSpaceToStepStats` to convert `XSpace` data to `StepStats` used in v1. However, the timestamps in `XSpace` are relative and were not converted to the absolute time used in `RunMetadata` during the conversion. This discrepancy affected the correctness of analysis tools like `timeline.Timeline` in v1. See #72156 and [tensorflow/profiler issue #238](https://github.com/tensorflow/profiler/issues/238).

The following code can reproduce this issue:
```py
import tensorflow as tf
from tensorflow.python.client import timeline

tf.compat.v1.disable_eager_execution()

matrix1 = tf.constant([[3.0, 3.0]])
matrix2 = tf.constant([[2.0], [2.0]])
matrix3 = tf.constant([[1.0, 2.0], [3.0, 4.0]])
matrix4 = tf.constant([[2.0, 0.0], [1.0, 2.0]])

product1 = tf.matmul(matrix1, matrix2)
product2 = tf.matmul(matrix3, matrix4)
sum_product = tf.add(product1, product2)

run_options = tf.compat.v1.RunOptions(
    trace_level=tf.compat.v1.RunOptions.HARDWARE_TRACE
)
run_metadata = tf.compat.v1.RunMetadata()

with tf.compat.v1.Session() as sess:
    result = sess.run(sum_product, options=run_options, run_metadata=run_metadata)
    print(result)

tl = timeline.Timeline(run_metadata.step_stats)
ctf = tl.generate_chrome_trace_format()
with open("timeline.json", "w") as f:
    f.write(ctf)

```

Here is the result [timeline_error.json](https://github.com/user-attachments/files/18474481/timeline_error.json), where some timestamps are in relative time, such as `13427`, while others are in absolute time, such as `1737358838975242`.

This pull request addresses the issue by converting relative timestamps to absolute timestamps in the `SetNodeTimes` function.
