### PR TITLE
Fix incorrect implementation of parallel matmul

### DIFF
--- a/tensorflow/python/ops/parallel_for/pfor.py
+++ b/tensorflow/python/ops/parallel_for/pfor.py
@@ -2809,7 +2809,7 @@ def _convert_matmul(pfor_input: _PforInput):
   tr_a = pfor_input.get_attr("transpose_a")
   tr_b = pfor_input.get_attr("transpose_b")
   if a_stacked and b_stacked:
-    output = wrap(math_ops.matmul(a, b, adjoint_a=tr_a, adjoint_b=tr_b), True)
+    output = wrap(math_ops.matmul(a, b, transpose_a=tr_a, transpose_b=tr_b), True)
     return output
   elif a_stacked:
     if tr_a:


### PR DESCRIPTION

The current implementation for vectorized `matmul` misuse adjoint for transpose, which could leads to incorrect results for ``matmul`` within `vectorized_map` and complex dtypes (commonly used in quantum computing simulations such as in [TensorCircuit-NG](https://github.com/tensorcircuit/tensorcircuit-ng/blob/master/examples/nested_vmap_grad.py)). 

Please see https://github.com/tensorflow/tensorflow/issues/52148 for details.


Examples demonstrating the incorrect results with current implementation

```python
import tensorflow as tf
import numpy as np
def matmul_adjoint(args):
    t1, t2 = args
    return tf.matmul(t1, t2, adjoint_a=False, adjoint_b=True)


def matmul_transpose(args):
    t1, t2 = args
    return tf.matmul(t1, t2, transpose_a=False, transpose_b=True)

def test_vectorized_matmul(dtype):
    rdtype= np.ones(0, dtype).real.dtype
    if dtype in (np.complex64, np.complex128):
        a = np.random.rand(2,4,4).astype(rdtype) + 1j * np.random.rand(2,4,4).astype(rdtype)
        b = np.random.rand(2,4,4).astype(rdtype) + 1j * np.random.rand(2,4,4).astype(rdtype)
    else:
        a = np.random.rand(2,4,4).astype(rdtype) 
        b = np.random.rand(2,4,4).astype(rdtype)
    A = tf.convert_to_tensor(a, dtype=dtype)
    B = tf.convert_to_tensor(b, dtype=dtype)
    result_adjoint = tf.vectorized_map(matmul_adjoint,(A,B))
    result_transpose = tf.vectorized_map(matmul_transpose,(A,B))
    expected_transpose = []
    for n in range(2):
        expected_transpose.append(a[n] @ b[n].T)
    expected_transpose = np.stack(expected_transpose)
    expected_adjoint = []
    for n in range(2):
        expected_adjoint.append(a[n] @ (b[n].T.conj()))
    expected_adjoint = np.stack(expected_adjoint)
    eps = np.finfo(rdtype).eps
    try:
        np.testing.assert_allclose(result_adjoint, expected_adjoint, 
                                   atol=10*eps, rtol=10*eps)
    except AssertionError as err:
        print(''.join(['#']*60))
        print(f"matmul adjoint test failed failed for dtype {dtype} with error {err}")
    try:
        np.testing.assert_allclose(result_transpose, expected_transpose, atol=10*eps, rtol=10*eps)
    except AssertionError as err:
        print(''.join(['#']*60))
        print(f"matmul_transpose failed for dtype {dtype} with error {err}")
      
    # the following passes, so it seems that the transpose and adjoint arguments
    # to tf.matmul need to be swapped
    np.testing.assert_allclose(result_adjoint, expected_transpose, 
                               atol=10*eps, rtol=10*eps)
    
    np.testing.assert_allclose(result_transpose, expected_adjoint, 
                               atol=10*eps, rtol=10*eps)
    
test_vectorized_matmul(np.float32)
test_vectorized_matmul(np.complex64)
```