### PR TITLE
[mlir][tosa] Update Tensorflow to match TOSA v1.0 specification

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
@@ -646,12 +646,25 @@ func.func @test_unstack(%arg0: tensor<1x32x32x8xf32>) -> tensor<32x32x8xf32> {
 // -----
 
 // CHECK-LABEL: test_pad
-// CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<1> : tensor<3x2xi32>}>
+// CHECK-DAG: %[[VAR0:.*]] = tosa.const_shape {value = dense<1> : tensor<6xindex>} : () -> !tosa.shape<6>
 // CHECK-DAG: %[[PVAL:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}>
 // CHECK: %[[VAR1:.*]] = tosa.pad %arg0, %[[VAR0]], %[[PVAL]]
 func.func @test_pad(%arg0: tensor<13x21x3xf32>) -> tensor<15x23x5xf32> {
   %2 = "tf.Const"()  {value = dense<1> : tensor<3x2xi32>}  : () -> tensor<3x2xi32>
   %3 = "tf.Pad"(%arg0, %2)   : (tensor<13x21x3xf32>, tensor<3x2xi32>) -> tensor<15x23x5xf32>
+  func.return %3 : tensor<15x23x5xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_pad_v2
+// CHECK-DAG: %[[VAL_1:.*]] = "tosa.const"() <{value = dense<-3.40282347E+38> : tensor<f32>}
+// CHECK-DAG: %[[VAL_2:.*]] = tosa.const_shape {value = dense<[1, 0, 0, 1, 1, 2]> : tensor<6xindex>} : () -> !tosa.shape<6>
+// CHECK: %[[VAL_3:.*]] = tosa.pad %[[VAL_0]], %[[VAL_2]], %[[VAL_1]]
+func.func @test_pad_v2(%arg0: tensor<13x21x3xf32>) -> tensor<15x23x5xf32> {
+  %1 = "tf.Const"() {value = dense<[[1, 0], [0, 1], [1, 2]]> : tensor<3x2xi32>} : () -> tensor<3x2xi32>
+  %2 = "tf.Const"() {value = dense<-3.40282347E+38> : tensor<f32>} : () -> tensor<f32>
+  %3 = "tf.PadV2"(%arg0, %1, %2) : (tensor<13x21x3xf32>, tensor<3x2xi32>, tensor<f32>) -> tensor<15x23x5xf32>
   func.return %3 : tensor<15x23x5xf32>
 }
 
@@ -827,7 +840,7 @@ func.func @test_reverse(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 // -----
 
 // CHECK-LABEL: test_space_to_batch
-// CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<{{\[}}[0, 0], [0, 1], [0, 0]]> : tensor<3x2xi32>}>
+// CHECK-DAG: %[[VAR0:.*]] = tosa.const_shape {value = dense<[0, 0, 0, 1, 0, 0]> : tensor<6xindex>} : () -> !tosa.shape<6>
 // CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<[2, 0, 1, 3]> : tensor<4xi32>}>
 // CHECK-DAG: %[[PVAL:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}>
 // CHECK-DAG: %[[VAR2:.*]] = tosa.pad %arg0, %[[VAR0]], %[[PVAL]]

--- a/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
@@ -1,7 +1,7 @@
 // RUN: tf-opt --tf-to-tosa-pipeline  --verify-each %s | FileCheck %s
-
+// REQUIRES: tf_tosa
 // RUN: tf-opt --tf-tfl-to-tosa-pipeline  --verify-each %s | FileCheck %s
-
+// REQUIRES: tf_tosa
 
 // Operations for testing tf-to-tosa-pipeline
 // TODO: These tests are fairly minimal. Expand the checks to be more robust.

--- a/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
@@ -918,9 +918,9 @@ func.func @test_right_shift(%arg0: tensor<4x4xi32>, %arg1: tensor<1x1xi32>) -> t
 // -----
 
 // CHECK-LABEL: @test_one_hot
-// CHECK-SAME:      %[[ARG0_0:.*]]: tensor<4x4xi32>, %[[ARG1_0:.*]]: tensor<f32>, %[[ARG2:.*]]: tensor<f32>
-// CHECK:         %[[CST1:.*]] = tosa.const_shape {value = dense<[16, 1, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
-// CHECK:         %[[CST2:.*]] = tosa.const_shape {value = dense<[16, 2, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-SAME:    %[[ARG0_0:.*]]: tensor<4x4xi32>, %[[ARG1_0:.*]]: tensor<f32>, %[[ARG2:.*]]: tensor<f32>
+// CHECK-DAG:     %[[CST1:.*]] = tosa.const_shape {value = dense<[16, 1, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:     %[[CST2:.*]] = tosa.const_shape {value = dense<[16, 2, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
 // CHECK:         %[[RESHAPE_0:.*]] = tosa.reshape %[[ARG1_0]] {new_shape = array<i64: 1, 1, 1>}
 // CHECK:         %[[TILE:.*]] = tosa.tile %[[RESHAPE_0]], %[[CST1]]
 // CHECK:         %[[RESHAPE_1:.*]] = tosa.reshape %[[ARG2]] {new_shape = array<i64: 1, 1, 1>}

--- a/tensorflow/compiler/mlir/tosa/tests/tf-unequal-ranks.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tf-unequal-ranks.mlir
@@ -1,5 +1,5 @@
 // RUN: tf-opt --split-input-file --tf-to-tosa-pipeline --verify-each %s | FileCheck %s
-
+// REQUIRES: tf_tosa
 // Test tf legalization that produce TOSA ResultsBroadcastableShape operators with unequal ranks
 
 // -----

--- a/tensorflow/compiler/mlir/tosa/tests/tf-unequal-ranks.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tf-unequal-ranks.mlir
@@ -1,0 +1,185 @@
+// RUN: tf-opt --split-input-file --tf-to-tosa-pipeline --verify-each %s | FileCheck %s
+
+// Test tf legalization that produce TOSA ResultsBroadcastableShape operators with unequal ranks
+
+// -----
+
+// CHECK-LABEL: test_add
+func.func @test_add(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1x13x21x3xf32>) -> tensor<*xf32> {
+  // CHECK: tosa.add
+  %2 = "tf.Add"(%arg0, %arg1)   : (tensor<13x21x1xf32>, tensor<1x13x21x3xf32>) -> tensor<*xf32>
+  func.return %2 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_add
+func.func @test_addn(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1x13x21x3xf32>, %arg2: tensor<21x3xf32>, %arg3: tensor<3xf32>) -> tensor<*xf32> {
+  // CHECK: tosa.add
+  // CHECK: tosa.add
+  // CHECK: tosa.add
+  %2 = "tf.AddN"(%arg0, %arg1, %arg2, %arg3)   : (tensor<13x21x1xf32>, tensor<1x13x21x3xf32>, tensor<21x3xf32>, tensor<3xf32>) -> tensor<*xf32>
+  func.return %2 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_bitwise_and
+func.func @test_bitwise_and(%arg0: tensor<8x13x21x3xi32>, %arg1: tensor<13x21x1xi32>) -> tensor<8x13x21x3xi32> {
+  // CHECK: tosa.bitwise_and
+  %2 = "tf.BitwiseAnd"(%arg0, %arg1)   : (tensor<8x13x21x3xi32>, tensor<13x21x1xi32>) -> tensor<8x13x21x3xi32>
+  func.return %2 : tensor<8x13x21x3xi32>
+}
+
+// -----
+
+// CHECK-LABEL: test_sub
+func.func @test_sub(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1x13x21x3xf32>) -> tensor<*xf32> {
+  // CHECK: tosa.sub
+  %2 = "tf.Sub"(%arg0, %arg1)   : (tensor<13x21x1xf32>, tensor<1x13x21x3xf32>) -> tensor<*xf32>
+  func.return %2 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_bitwise_or
+func.func @test_bitwise_or(%arg0: tensor<8x13x21x3xi32>, %arg1: tensor<13x21x1xi32>) -> tensor<8x13x21x3xi32> {
+  // CHECK: tosa.bitwise_or
+  %2 = "tf.BitwiseOr"(%arg0, %arg1)   : (tensor<8x13x21x3xi32>, tensor<13x21x1xi32>) -> tensor<8x13x21x3xi32>
+  func.return %2 : tensor<8x13x21x3xi32>
+}
+
+// -----
+
+// CHECK-LABEL: test_bitwise_xor
+func.func @test_bitwise_xor(%arg0: tensor<8x13x21x3xi32>, %arg1: tensor<13x21x1xi32>) -> tensor<8x13x21x3xi32> {
+  // CHECK: tosa.bitwise_xor
+  %2 = "tf.BitwiseXor"(%arg0, %arg1)   : (tensor<8x13x21x3xi32>, tensor<13x21x1xi32>) -> tensor<8x13x21x3xi32>
+  func.return %2 : tensor<8x13x21x3xi32>
+}
+
+// -----
+
+// CHECK-LABEL: test_logical_and
+func.func @test_logical_and(%arg0: tensor<8x13x21x3xi1>, %arg1: tensor<13x21x1xi1>) -> tensor<8x13x21x3xi1> {
+  // CHECK: tosa.logical_and
+  %2 = "tf.LogicalAnd"(%arg0, %arg1)   : (tensor<8x13x21x3xi1>, tensor<13x21x1xi1>) -> tensor<8x13x21x3xi1>
+  func.return %2 : tensor<8x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_logical_or
+func.func @test_logical_or(%arg0: tensor<8x13x21x3xi1>, %arg1: tensor<13x21x1xi1>) -> tensor<8x13x21x3xi1> {
+  // CHECK: tosa.logical_or
+  %2 = "tf.LogicalOr"(%arg0, %arg1)   : (tensor<8x13x21x3xi1>, tensor<13x21x1xi1>) -> tensor<8x13x21x3xi1>
+  func.return %2 : tensor<8x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_floor_div
+func.func @test_floor_div(%arg0: tensor<13x21x3xi32>, %arg1: tensor<1x13x1x3xi32>) -> tensor<1x13x21x3xi32> {
+  // CHECK: tosa.int_div
+  %2 = "tf.FloorDiv"(%arg0, %arg1)   : (tensor<13x21x3xi32>, tensor<1x13x1x3xi32>) -> tensor<1x13x21x3xi32>
+  func.return %2 : tensor<1x13x21x3xi32>
+}
+
+// -----
+
+// CHECK-LABEL: test_real_div
+// CHECK: tosa.int_div
+func.func @test_real_div(%arg0: tensor<13x21x3xi32>, %arg1: tensor<1x13x1x3xi32>) -> tensor<1x13x21x3xi32> {
+  %2 = "tf.RealDiv"(%arg0, %arg1)   : (tensor<13x21x3xi32>, tensor<1x13x1x3xi32>) -> tensor<1x13x21x3xi32>
+  func.return %2 : tensor<1x13x21x3xi32>
+}
+
+// -----
+
+// CHECK-LABEL: test_left_shift
+func.func @test_left_shift(%arg0: tensor<4x4xi32>, %arg1: tensor<1x1x1xi32>) -> tensor<1x4x4xi32> {
+  // CHECK: tosa.logical_left_shift
+  %0 = "tf.LeftShift"(%arg0, %arg1) : (tensor<4x4xi32>, tensor<1x1x1xi32>) -> tensor<1x4x4xi32>
+  func.return %0 : tensor<1x4x4xi32>
+}
+
+// -----
+
+// CHECK-LABEL: test_right_shift
+func.func @test_right_shift(%arg0: tensor<4x4xi32>, %arg1: tensor<1x1x1xi32>) -> tensor<1x4x4xi32> {
+  // CHECK: tosa.arithmetic_right_shift
+  %0 = "tf.RightShift"(%arg0, %arg1) : (tensor<4x4xi32>, tensor<1x1x1xi32>) -> tensor<1x4x4xi32>
+  func.return %0 : tensor<1x4x4xi32>
+}
+
+// -----
+
+// CHECK-LABEL: test_max
+func.func @test_max(%arg0: tensor<13x21x3xf32>, %arg1: tensor<1x13x21x1xf32>) -> tensor<1x13x21x3xf32> {
+  // CHECK: tosa.maximum
+  %2 = "tf.Maximum"(%arg0, %arg1)   : (tensor<13x21x3xf32>, tensor<1x13x21x1xf32>) -> tensor<1x13x21x3xf32>
+  func.return %2 : tensor<1x13x21x3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_min
+func.func @test_min(%arg0: tensor<13x21x3xf32>, %arg1: tensor<1x13x21x1xf32>) -> tensor<1x13x21x3xf32> {
+  // CHECK: tosa.minimum
+  %2 = "tf.Minimum"(%arg0, %arg1)   : (tensor<13x21x3xf32>, tensor<1x13x21x1xf32>) -> tensor<1x13x21x3xf32>
+  func.return %2 : tensor<1x13x21x3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_power
+func.func @test_power(%arg0: tensor<8x13x21x3xi32>, %arg1: tensor<13x21x1xi32>) -> tensor<8x13x21x3xi32> {
+  // CHECK: tosa.pow
+  %2 = "tf.Pow"(%arg0, %arg1)   : (tensor<8x13x21x3xi32>, tensor<13x21x1xi32>) -> tensor<8x13x21x3xi32>
+  func.return %2 : tensor<8x13x21x3xi32>
+}
+
+// -----
+
+// CHECK-LABEL: test_equal
+// CHECK: tosa.equal
+func.func @test_equal(%arg0: tensor<13x21x3xf32>, %arg1: tensor<1x13x1x3xf32>) -> tensor<1x13x21x3xi1> {
+  %2 = "tf.Equal"(%arg0, %arg1)  {incompatible_shape_error = true}  : (tensor<13x21x3xf32>, tensor<1x13x1x3xf32>) -> tensor<1x13x21x3xi1>
+  func.return %2 : tensor<1x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_greater_equal
+// CHECK: tosa.greater_equal
+func.func @test_greater_equal(%arg0: tensor<13x1x3xf32>, %arg1: tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1> {
+  %2 = "tf.GreaterEqual"(%arg0, %arg1)   : (tensor<13x1x3xf32>, tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1>
+  func.return %2 : tensor<1x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_greater
+// CHECK: tosa.greater
+func.func @test_greater(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1> {
+  %2 = "tf.Greater"(%arg0, %arg1)   : (tensor<13x21x1xf32>, tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1>
+  func.return %2 : tensor<1x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_less
+// CHECK: tosa.greater_equal
+// CHECK: tosa.logical_not
+func.func @test_less(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1> {
+  %2 = "tf.Less"(%arg0, %arg1)   : (tensor<13x21x1xf32>, tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1>
+  func.return %2 : tensor<1x13x21x3xi1>
+}
+
+// -----
+// CHECK-LABEL: test_select
+// CHECK: tosa.select
+func.func @test_select(%arg0: tensor<13x21x3xf32>, %arg1: tensor<1x13x21x3xf32>, %arg2: tensor<1xi1>) -> tensor<1x13x21x3xf32> {
+  %2 = "tf.SelectV2"(%arg2, %arg0, %arg1)   : (tensor<1xi1>, tensor<13x21x3xf32>, tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xf32>
+  func.return %2 : tensor<1x13x21x3xf32>
+}

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline-filtered.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline-filtered.mlir
@@ -31,7 +31,7 @@ func.func @test_softmax(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 // CHECK: %[[VAR1:.*]] = tosa.transpose %arg1, %[[CST]]
 // CHECK-DAG: %[[VAR2:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
 // CHECK-DAG: %[[VAR3:.*]] = tosa.reshape %[[VAR1]] {new_shape = array<i64: 28, 1, 1, 19>}
-// CHECK-DAG: %[[VAR4:.*]] = tosa.conv2d %[[VAR2]], %[[VAR3]], %[[VAR0]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+// CHECK-DAG: %[[VAR4:.*]] = tosa.conv2d %[[VAR2]], %[[VAR3]], %[[VAR0]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
 // CHECK: %[[VAR5:.*]] = tosa.reshape %[[VAR4]] {new_shape = array<i64: 14, 28>}
 func.func @test_matmul(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>) -> tensor<*xf32> {
   %cst = arith.constant dense<[1, 0]> : tensor<2xi32>

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1692,11 +1692,11 @@ func.func @test_space_to_batch(%arg0: tensor<13x21x3xf32>) -> tensor<26x11x3xf32
 // -----
 
 // CHECK-LABEL: test_space_to_batch_dyn
-// CHECK-DAG: %[[C0:.+]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}>
-// CHECK-DAG: %[[C1:.+]] = "tosa.const"() <{value = dense<{{\[\[}}0, 0], [0, 2], [0, 0], [0, 0]]> : tensor<4x2xi32>}>
 // CHECK-DAG: %[[C2:.+]] = "tosa.const"() <{value = dense<[2, 4, 0, 1, 3, 5]> : tensor<6xi32>}>
-// CHECK-DAG: %[[PAD:.+]] = tosa.pad %arg0, %[[C1]], %[[C0]] : (tensor<?x241x1x80xf32>, tensor<4x2xi32>, tensor<f32>) -> tensor<?x243x1x80xf32>
-// CHECK-DAG: %[[R0:.+]] = tosa.reshape %[[PAD]] {new_shape = array<i64: -1, 81, 3, 1, 1, 80>}
+// CHECK-DAG: %[[VAL_4:.*]] = tosa.const_shape  {value = dense<[0, 0, 0, 2, 0, 0, 0, 0]> : tensor<8xindex>} : () -> !tosa.shape<8>
+// CHECK-DAG: %[[VAL_5:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}>
+// CHECK-DAG: %[[VAL_6:.*]] = tosa.pad %arg0, %[[VAL_4]], %[[VAL_5]] : (tensor<?x241x1x80xf32>, !tosa.shape<8>, tensor<f32>) -> tensor<?x243x1x80xf32>
+// CHECK-DAG: %[[R0:.+]] = tosa.reshape %[[VAL_6]] {new_shape = array<i64: -1, 81, 3, 1, 1, 80>}
 // CHECK-DAG: %[[T:.+]] = tosa.transpose %[[R0]], %[[C2]]
 // CHECK-DAG: %[[R1:.+]] = tosa.reshape %[[T]] {new_shape = array<i64: -1, 81, 1, 80>}
 // CHECK: return %[[R1]] : tensor<?x81x1x80xf32>
@@ -2728,7 +2728,6 @@ func.func @test_rfft2d_crop_input(%arg0: tensor<13x21x3xf32>) -> tensor<13x2x2xc
 // CHECK-SAME: %[[VAL_0:.*]]: tensor<13x21x3xf32>
 // CHECK-DAG: %[[VAL_1:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
 // CHECK-DAG: %[[VAL_2:.*]] = tosa.const_shape {value = dense<[0, 0, 0, 11, 0, 5]> : tensor<6xindex>} : () -> !tosa.shape<6>
-// CHECK-DAG: %[[VAL_10:.*]] = tosa.const_shape {value = dense<[13, 32, 5, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
 // CHECK: %[[VAL_3:.*]] = tosa.pad %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : (tensor<13x21x3xf32>, !tosa.shape<6>, tensor<f32>) -> tensor<13x32x8xf32>
 // CHECK: %[[VAL_4:.*]], %[[VAL_5:.*]] = tosa.rfft2d %[[VAL_3]] : (tensor<13x32x8xf32>) -> (tensor<13x32x5xf32>, tensor<13x32x5xf32>)
 // CHECK: %[[VAL_6:.*]] = tosa.reshape %[[VAL_4]] {new_shape = array<i64: 13, 32, 5, 1>} : (tensor<13x32x5xf32>) -> tensor<13x32x5x1xf32>
@@ -2736,12 +2735,12 @@ func.func @test_rfft2d_crop_input(%arg0: tensor<13x21x3xf32>) -> tensor<13x2x2xc
 // CHECK: %[[VAL_8:.*]] = tosa.concat %[[VAL_6]], %[[VAL_7]] {axis = 3 : i32} : (tensor<13x32x5x1xf32>, tensor<13x32x5x1xf32>) -> tensor<13x32x5x2xf32>
 // CHECK: return %[[VAL_8]] : tensor<13x32x5x2xf32>
 func.func @test_rfft2d_pad_input(%arg0: tensor<13x21x3xf32>) -> (tensor<13x32x5xcomplex<f32>>) {
-  %0 = "tfl.pseudo_const"() {value = dense<[[0, 0], [0, 11], [0, 5]]> : tensor<3x2xi32>} : () -> tensor<3x2xi32>
-  %1 = "tfl.pad"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<3x2xi32>) -> tensor<13x32x8xf32>
-  %2 = "tfl.pseudo_const"() {value = dense<[32, 8]> : tensor<2xi32>} : () -> tensor<2xi32>
-  %3 = "tfl.rfft2d"(%1, %2) : (tensor<13x32x8xf32>, tensor<2xi32>) -> tensor<13x32x5xcomplex<f32>>
-  return %3 : tensor<13x32x5xcomplex<f32>>
-}
+    %0 = "tfl.pseudo_const"() {value = dense<[[0, 0], [0, 11], [0, 5]]> : tensor<3x2xi32>} : () -> tensor<3x2xi32>
+    %1 = "tfl.pad"(%arg0, %0) : (tensor<13x21x3xf32>, tensor<3x2xi32>) -> tensor<13x32x8xf32>
+    %2 = "tfl.pseudo_const"() {value = dense<[32, 8]> : tensor<2xi32>} : () -> tensor<2xi32>
+    %3 = "tfl.rfft2d"(%1, %2) : (tensor<13x32x8xf32>, tensor<2xi32>) -> tensor<13x32x5xcomplex<f32>>
+    return %3 : tensor<13x32x5xcomplex<f32>>
+  }
 
 // -----
 
@@ -2749,7 +2748,6 @@ func.func @test_rfft2d_pad_input(%arg0: tensor<13x21x3xf32>) -> (tensor<13x32x5x
 // CHECK-SAME: %[[VAL_0:.*]]: tensor<13x21x3xf32>
 // CHECK-DAG: %[[VAL_1:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
 // CHECK-DAG: %[[VAL_2:.*]] = tosa.const_shape {value = dense<[0, 0, 0, 0, 0, 13]> : tensor<6xindex>} : () -> !tosa.shape<6>
-// CHECK-DAG: %[[VAL_10:.*]] = tosa.const_shape {value = dense<[13, 2, 9, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
 // CHECK: %[[VAL_3:.*]] = tosa.pad %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : (tensor<13x21x3xf32>, !tosa.shape<6>, tensor<f32>) -> tensor<13x21x16xf32>
 // CHECK: %[[VAL_4:.*]] = tosa.slice %[[VAL_3]] {size = array<i64: 13, 2, 16>, start = array<i64: 0, 0, 0>} : (tensor<13x21x16xf32>) -> tensor<13x2x16xf32>
 // CHECK: %[[VAL_5:.*]], %[[VAL_6:.*]] = tosa.rfft2d %[[VAL_4]] : (tensor<13x2x16xf32>) -> (tensor<13x2x9xf32>, tensor<13x2x9xf32>

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1308,7 +1308,7 @@ func.func @test_unstack(%arg0: tensor<1x32x32x8xf32>) -> tensor<*xf32> {
 // -----
 
 // CHECK-LABEL: test_pad
-// CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<{{\[\[}}1, 1], {{\[}}2, 2]]> : tensor<2x2xi32>}>
+// CHECK-DAG: %[[VAR0:.*]] = tosa.const_shape {value = dense<[1, 1, 2, 2]> : tensor<4xindex>} : () -> !tosa.shape<4>
 // CHECK-DAG: %[[PVAL:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}>
 // CHECK: %[[VAR1:.*]] = tosa.pad %arg0, %[[VAR0]], %[[PVAL]]
 func.func @test_pad(%arg0: tensor<2x3xf32>) -> tensor<*xf32> {
@@ -1323,13 +1323,13 @@ func.func @test_pad(%arg0: tensor<2x3xf32>) -> tensor<*xf32> {
 // CHECK-LABEL: test_pad_v2
 // CHECK-SAME: -> tensor<1x257x9x28xf32>
 func.func @test_pad_v2(%arg0: tensor<1x256x8x25xf32>) -> (tensor<*xf32>) {
-  // CHECK-DAG: %[[PADDING:.+]] = "tosa.const"() <{value = dense<{{\[\[}}0, 0], [1, 0], [0, 1], [1, 2]]> : tensor<4x2xi32>}>
+  // CHECK-DAG: %[[PADDING:.+]] = tosa.const_shape {value = dense<[0, 0, 1, 0, 0, 1, 1, 2]> : tensor<8xindex>} : () -> !tosa.shape<8>
   %0 = "tfl.pseudo_const"() {value = dense<[[0, 0], [1, 0], [0, 1], [1, 2]]> : tensor<4x2xi32>} : () -> tensor<4x2xi32>
 
   // CHECK-DAG: %[[VAL:.+]] = "tosa.const"() <{value = dense<-3.40282347E+38> : tensor<f32>}>
   %1 = "tfl.pseudo_const"() {value = dense<-3.40282347E+38> : tensor<f32>} : () -> tensor<f32>
 
-  // CHECK-DAG: %[[PAD:.+]] = tosa.pad %arg0, %[[PADDING]], %[[VAL]] : (tensor<1x256x8x25xf32>, tensor<4x2xi32>, tensor<f32>) -> tensor<1x257x9x28xf32>
+  // CHECK-DAG: %[[PAD:.+]] = tosa.pad %arg0, %[[PADDING]], %[[VAL]] : (tensor<1x256x8x25xf32>, !tosa.shape<8>, tensor<f32>) -> tensor<1x257x9x28xf32>
   %2 = "tfl.padv2"(%arg0, %0, %1) : (tensor<1x256x8x25xf32>, tensor<4x2xi32>, tensor<f32>) -> tensor<*xf32>
 
   // CHECK: return %[[PAD]]
@@ -1675,7 +1675,7 @@ func.func @test_tile(%arg0: tensor<13x21x3xf32>) -> tensor<*xf32> {
 // -----
 
 // CHECK-LABEL: test_space_to_batch
-// CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<{{\[}}[0, 0], [0, 1], [0, 0]]> : tensor<3x2xi32>}>
+// CHECK-DAG: %[[VAR0:.*]] = tosa.const_shape {value = dense<[0, 0, 0, 1, 0, 0]> : tensor<6xindex>} : () -> !tosa.shape<6>
 // CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<[2, 0, 1, 3]> : tensor<4xi32>}>
 // CHECK-DAG: %[[PVAL:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}>
 // CHECK-DAG: %[[VAR2:.*]] = tosa.pad %arg0, %[[VAR0]], %[[PVAL]]
@@ -2727,8 +2727,9 @@ func.func @test_rfft2d_crop_input(%arg0: tensor<13x21x3xf32>) -> tensor<13x2x2xc
 // CHECK-LABEL: test_rfft2d_pad_input
 // CHECK-SAME: %[[VAL_0:.*]]: tensor<13x21x3xf32>
 // CHECK-DAG: %[[VAL_1:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
-// CHECK-DAG: %[[VAL_2:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 0], [0, 11], [0, 5]]> : tensor<3x2xi32>}> : () -> tensor<3x2xi32>
-// CHECK: %[[VAL_3:.*]] = tosa.pad %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : (tensor<13x21x3xf32>, tensor<3x2xi32>, tensor<f32>) -> tensor<13x32x8xf32>
+// CHECK-DAG: %[[VAL_2:.*]] = tosa.const_shape {value = dense<[0, 0, 0, 11, 0, 5]> : tensor<6xindex>} : () -> !tosa.shape<6>
+// CHECK-DAG: %[[VAL_10:.*]] = tosa.const_shape {value = dense<[13, 32, 5, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK: %[[VAL_3:.*]] = tosa.pad %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : (tensor<13x21x3xf32>, !tosa.shape<6>, tensor<f32>) -> tensor<13x32x8xf32>
 // CHECK: %[[VAL_4:.*]], %[[VAL_5:.*]] = tosa.rfft2d %[[VAL_3]] : (tensor<13x32x8xf32>) -> (tensor<13x32x5xf32>, tensor<13x32x5xf32>)
 // CHECK: %[[VAL_6:.*]] = tosa.reshape %[[VAL_4]] {new_shape = array<i64: 13, 32, 5, 1>} : (tensor<13x32x5xf32>) -> tensor<13x32x5x1xf32>
 // CHECK: %[[VAL_7:.*]] = tosa.reshape %[[VAL_5]] {new_shape = array<i64: 13, 32, 5, 1>} : (tensor<13x32x5xf32>) -> tensor<13x32x5x1xf32>
@@ -2747,8 +2748,9 @@ func.func @test_rfft2d_pad_input(%arg0: tensor<13x21x3xf32>) -> (tensor<13x32x5x
 // CHECK-LABEL: test_rfft2d_crop_height_pad_width
 // CHECK-SAME: %[[VAL_0:.*]]: tensor<13x21x3xf32>
 // CHECK-DAG: %[[VAL_1:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
-// CHECK-DAG: %[[VAL_2:.*]] = "tosa.const"() <{value = dense<{{\[\[}}0, 0], [0, 0], [0, 13]]> : tensor<3x2xi32>}> : () -> tensor<3x2xi32>
-// CHECK: %[[VAL_3:.*]] = tosa.pad %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : (tensor<13x21x3xf32>, tensor<3x2xi32>, tensor<f32>) -> tensor<13x21x16xf32>
+// CHECK-DAG: %[[VAL_2:.*]] = tosa.const_shape {value = dense<[0, 0, 0, 0, 0, 13]> : tensor<6xindex>} : () -> !tosa.shape<6>
+// CHECK-DAG: %[[VAL_10:.*]] = tosa.const_shape {value = dense<[13, 2, 9, 1]> : tensor<4xindex>} : () -> !tosa.shape<4>
+// CHECK: %[[VAL_3:.*]] = tosa.pad %[[VAL_0]], %[[VAL_2]], %[[VAL_1]] : (tensor<13x21x3xf32>, !tosa.shape<6>, tensor<f32>) -> tensor<13x21x16xf32>
 // CHECK: %[[VAL_4:.*]] = tosa.slice %[[VAL_3]] {size = array<i64: 13, 2, 16>, start = array<i64: 0, 0, 0>} : (tensor<13x21x16xf32>) -> tensor<13x2x16xf32>
 // CHECK: %[[VAL_5:.*]], %[[VAL_6:.*]] = tosa.rfft2d %[[VAL_4]] : (tensor<13x2x16xf32>) -> (tensor<13x2x9xf32>, tensor<13x2x9xf32>
 // CHECK: %[[VAL_7:.*]] = tosa.reshape %[[VAL_5]] {new_shape = array<i64: 13, 2, 9, 1>} : (tensor<13x2x9xf32>) -> tensor<13x2x9x1xf32>

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1,7 +1,7 @@
 // RUN: tf-opt --split-input-file --tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
-// REQUIRES: tf_tosa
+
 // RUN: tf-opt --split-input-file --tf-tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
-// REQUIRES: tf_tosa
+
 
 // Operations for testing tfl-to-tosa-pipeline
 
@@ -14,7 +14,7 @@
 
 // CHECK-LABEL: test_conv2d
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<16xf32>}>
-// CHECK: %[[VAR1:.*]] = tosa.conv2d %arg0, %arg1, %[[VAR0]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, stride = array<i64: 1, 1>}
+// CHECK: %[[VAR1:.*]] = tosa.conv2d %arg0, %arg1, %[[VAR0]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, stride = array<i64: 1, 1>}
 func.func @test_conv2d(%arg0: tensor<1x32x32x8xf32>, %arg1: tensor<16x2x2x8xf32>) -> tensor<*xf32> {
   %cst = arith.constant dense<0.000000e+00> : tensor<16xf32>
   %0 = "tfl.conv_2d"(%arg0, %arg1, %cst)  {dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 1 : i32}  : (tensor<1x32x32x8xf32>, tensor<16x2x2x8xf32>, tensor<16xf32>) -> tensor<*xf32>
@@ -35,7 +35,7 @@ func.func @test_conv2d_dynamic(%arg0: tensor<?x32x32x8xf32>, %arg1: tensor<16x1x
 // -----
 
 // CHECK-LABEL: test_conv2d_bias
-// CHECK: %[[VAR0:.*]] = tosa.conv2d %arg0, %arg1, %arg2 {dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, stride = array<i64: 1, 1>}
+// CHECK: %[[VAR0:.*]] = tosa.conv2d %arg0, %arg1, %arg2 {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, stride = array<i64: 1, 1>}
 // CHECK-SAME: tensor<1x32x32x16xf32>
 func.func @test_conv2d_bias(%arg0: tensor<1x32x32x8xf32>, %cst: tensor<16x2x2x8xf32>, %cst_0: tensor<16xf32>) -> tensor<*xf32> {
   %0 = "tfl.conv_2d"(%arg0, %cst, %cst_0)  {dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 1 : i32}  : (tensor<1x32x32x8xf32>, tensor<16x2x2x8xf32>, tensor<16xf32>) -> tensor<*xf32>
@@ -46,7 +46,7 @@ func.func @test_conv2d_bias(%arg0: tensor<1x32x32x8xf32>, %cst: tensor<16x2x2x8x
 
 // CHECK-LABEL: test_transpose_conv2d
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<16xf32>}>
-// CHECK: %[[VAR1:.*]] = tosa.transpose_conv2d %arg0, %arg1, %[[VAR0]] {out_pad = array<i64: 0, 0, 0, 0>, out_shape = array<i64: 1, 32, 32, 16>, stride = array<i64: 1, 1>}
+// CHECK: %[[VAR1:.*]] = tosa.transpose_conv2d %arg0, %arg1, %[[VAR0]] {acc_type = f32, out_pad = array<i64: 0, 0, 0, 0>, out_shape = array<i64: 1, 32, 32, 16>, stride = array<i64: 1, 1>}
 func.func @test_transpose_conv2d(%arg0: tensor<1x32x32x8xf32>, %cst_0: tensor<16x1x1x8xf32>) -> tensor<1x32x32x16xf32> {
   %cst = arith.constant dense<[1, 32, 32, 16]> : tensor<4xi32>
   %cst_1 = "tfl.no_value"() {value = unit} : () -> none
@@ -58,7 +58,7 @@ func.func @test_transpose_conv2d(%arg0: tensor<1x32x32x8xf32>, %cst_0: tensor<16
 
 // CHECK-LABEL: test_transpose_conv2d_relu
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<16xf32>}>
-// CHECK: %[[VAR1:.*]] = tosa.transpose_conv2d %arg0, %arg1, %[[VAR0]] {out_pad = array<i64: 0, 0, 0, 0>, out_shape = array<i64: 1, 32, 32, 16>, stride = array<i64: 1, 1>}
+// CHECK: %[[VAR1:.*]] = tosa.transpose_conv2d %arg0, %arg1, %[[VAR0]] {acc_type = f32, out_pad = array<i64: 0, 0, 0, 0>, out_shape = array<i64: 1, 32, 32, 16>, stride = array<i64: 1, 1>}
 // CHECK: %[[VAR2:.*]] = tosa.clamp %[[VAR1]] {max_fp = 3.40282347E+38 : f32, max_int = 2147483647 : i64, min_fp = 0.000000e+00 : f32, min_int = 0 : i64}
 func.func @test_transpose_conv2d_relu(%arg0: tensor<1x32x32x8xf32>, %cst_0: tensor<16x1x1x8xf32>) -> tensor<1x32x32x16xf32> {
   %cst = arith.constant dense<[1, 32, 32, 16]> : tensor<4xi32>
@@ -72,7 +72,7 @@ func.func @test_transpose_conv2d_relu(%arg0: tensor<1x32x32x8xf32>, %cst_0: tens
 // CHECK-LABEL: test_conv2d_qi8
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<{{.*}}> : tensor<16x2x2x8xi8>}>
 // CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<0> : tensor<16xi32>}>
-// CHECK-DAG: %[[VAR2:.*]] = tosa.conv2d %arg0, %[[VAR0]], %[[VAR1]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, stride = array<i64: 1, 1>}
+// CHECK-DAG: %[[VAR2:.*]] = tosa.conv2d %arg0, %[[VAR0]], %[[VAR1]] {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, stride = array<i64: 1, 1>}
 // CHECK: %[[VAR3:.*]] = tosa.rescale %[[VAR2]]
 func.func @test_conv2d_qi8(%arg0: tensor<1x32x32x8x!quant.uniform<i8:f32, 0.015684768557548523>>) -> tensor<1x32x32x16x!quant.uniform<i8:f32, 0.078431375324726104>> {
   %0 = "tfl.pseudo_qconst"() {qtype = tensor<16x2x2x8x!quant.uniform<i8<-127:127>:f32:0, {0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1}>>, value = dense<42> : tensor<16x2x2x8xi8>} : () -> tensor<16x2x2x8x!quant.uniform<i8<-127:127>:f32:0,  {0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1} >>
@@ -83,12 +83,12 @@ func.func @test_conv2d_qi8(%arg0: tensor<1x32x32x8x!quant.uniform<i8:f32, 0.0156
 
 // -----
 
-// CHECK-LABEL: test_conv2d_qi8
+// CHECK-LABEL: test_conv2d_qi8_2
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<{{.*}}> : tensor<16x2x2x8xi8>}>
 // CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<1> : tensor<16xi8>}>
-// CHECK-DAG: %[[VAR2:.*]] = tosa.conv2d %arg0, %[[VAR0]], %[[VAR1]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, stride = array<i64: 1, 1>}
+// CHECK-DAG: %[[VAR2:.*]] = tosa.conv2d %arg0, %[[VAR0]], %[[VAR1]] {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, stride = array<i64: 1, 1>}
 // CHECK: %[[VAR3:.*]] = tosa.rescale %[[VAR2]]
-func.func @test_conv2d_qi8(%arg0: tensor<1x32x32x8x!quant.uniform<i8:f32, 0.015684768557548523>>) -> tensor<1x32x32x16x!quant.uniform<i8:f32, 0.078431375324726104>> {
+func.func @test_conv2d_qi8_2(%arg0: tensor<1x32x32x8x!quant.uniform<i8:f32, 0.015684768557548523>>) -> tensor<1x32x32x16x!quant.uniform<i8:f32, 0.078431375324726104>> {
   %0 = "tfl.pseudo_qconst"() {qtype = tensor<16x2x2x8x!quant.uniform<i8<-127:127>:f32:0, {0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1}>>, value = dense<42> : tensor<16x2x2x8xi8>} : () -> tensor<16x2x2x8x!quant.uniform<i8<-127:127>:f32:0,  {0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1} >>
   %1 = "tfl.pseudo_qconst"() {qtype = tensor<16x!quant.uniform<i32:f32:0, {2.0,2.0,1.0,1.0,1.0,2.0,2.4,1.7,2.3,2.4,2.4,2.3,2.1,2.4,2.1,2.4}>>, value = dense<1> : tensor<16xi8>} : () -> tensor<16x!quant.uniform<i8:f32:0,  {2.0,2.0,1.0,1.0,1.0,2.0,2.4,1.7,2.3,2.4,2.4,2.3,2.1,2.4,2.1,2.4} >>
   %2 = "tfl.conv_2d"(%arg0, %0, %1) {dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 1 : i32} : (tensor<1x32x32x8x!quant.uniform<i8:f32, 0.015684768557548523>>, tensor<16x2x2x8x!quant.uniform<i8<-127:127>:f32:0, {0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1}>>, tensor<16x!quant.uniform<i8:f32:0, {2.0,2.0,1.0,1.0,1.0,2.0,2.4,1.7,2.3,2.4,2.4,2.3,2.1,2.4,2.1,2.4} >>) -> tensor<1x32x32x16x!quant.uniform<i8:f32, 0.078431375324726104>>
@@ -100,7 +100,7 @@ func.func @test_conv2d_qi8(%arg0: tensor<1x32x32x8x!quant.uniform<i8:f32, 0.0156
 // CHECK-LABEL: test_conv2d_qi16
 // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<0> : tensor<16xi48>}>
 // CHECK-DAG: %[[VAR1:.*]] = "tosa.const"() <{value = dense<{{.*}}> : tensor<16x1x1x8xi8>}>
-// CHECK-DAG: %[[VAR2:.*]] = tosa.conv2d %arg0, %[[VAR1]], %[[VAR0]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, stride = array<i64: 1, 1>}
+// CHECK-DAG: %[[VAR2:.*]] = tosa.conv2d %arg0, %[[VAR1]], %[[VAR0]] {acc_type = i48, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, stride = array<i64: 1, 1>}
 // CHECK: %[[VAR3:.*]] = tosa.rescale %[[VAR2]]
 func.func @test_conv2d_qi16(%arg0: tensor<1x32x32x8x!quant.uniform<i16:f32, 1.0>>) -> tensor<1x32x32x16x!quant.uniform<i16:f32, 1.0>> {
   %0 = "tfl.pseudo_qconst"() {qtype = tensor<16x1x1x8x!quant.uniform<i8:f32, 1.0>>, value = dense<42> : tensor<16x1x1x8xi8>} : () -> tensor<16x1x1x8x!quant.uniform<i8:f32, 1.0>>
@@ -116,7 +116,7 @@ func.func @test_conv2d_qi16(%arg0: tensor<1x32x32x8x!quant.uniform<i16:f32, 1.0>
 // CHECK-DAG:     %[[CONST:.*]] = "tosa.const"() <{value = dense<{{.*}}> : tensor<1x2x2x16xi8>}>
 // CHECK-DAG:     %[[CONST_0:.*]] = "tosa.const"() <{value = dense<{{.*}}> : tensor<16xi32>}>
 // CHECK-DAG:     %[[RESHAPE:.*]] = tosa.reshape %[[CONST]] {new_shape = array<i64: 2, 2, 8, 2>} : (tensor<1x2x2x16x!quant.uniform<i8<-127:127>:f32:3, {{.*}}>>) -> tensor<2x2x8x2x!quant.uniform<i8<-127:127>:f32:3, {{.*}}>>
-// CHECK-DAG:     %[[DEPTHWISE:.*]] = tosa.depthwise_conv2d %[[ARG0]], %[[RESHAPE]], %[[CONST_0]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, quantization_info = #tosa.conv_quant<input_zp = -1, weight_zp = 0>, stride = array<i64: 1, 1>}
+// CHECK-DAG:     %[[DEPTHWISE:.*]] = tosa.depthwise_conv2d %[[ARG0]], %[[RESHAPE]], %[[CONST_0]] {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, quantization_info = #tosa.conv_quant<input_zp = -1, weight_zp = 0>, stride = array<i64: 1, 1>}
 // CHECK:         %[[RESCALE:.*]] = tosa.rescale %[[DEPTHWISE]]
 // CHECK-SAME:        multiplier = array<i32: 1373724854, 1373724854, 1373724854, 1373724854, 1803013871, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854>
 // CHECK-SAME:        shift = array<i8: 36, 36, 36, 36, 32, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36>
@@ -135,7 +135,7 @@ func.func @test_depthwise_conv2d_bias_qi8(%arg0: tensor<1x32x32x8x!quant.uniform
 // CHECK-DAG:     %[[CONST:.*]] = "tosa.const"() <{value = dense<{{.*}}> : tensor<1x2x2x16xi8>}>
 // CHECK-DAG:     %[[CONST_0:.*]] = "tosa.const"() <{value = dense<{{.*}}> : tensor<16xi8>}>
 // CHECK-DAG:     %[[RESHAPE:.*]] = tosa.reshape %[[CONST]] {new_shape = array<i64: 2, 2, 8, 2>} : (tensor<1x2x2x16x!quant.uniform<i8<-127:127>:f32:3, {{.*}}>>) -> tensor<2x2x8x2x!quant.uniform<i8<-127:127>:f32:3, {{.*}}>>
-// CHECK-DAG:     %[[DEPTHWISE:.*]] = tosa.depthwise_conv2d %[[ARG0]], %[[RESHAPE]], %[[CONST_0]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, quantization_info = #tosa.conv_quant<input_zp = -1, weight_zp = 0>, stride = array<i64: 1, 1>}
+// CHECK-DAG:     %[[DEPTHWISE:.*]] = tosa.depthwise_conv2d %[[ARG0]], %[[RESHAPE]], %[[CONST_0]] {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 1, 0, 1>, quantization_info = #tosa.conv_quant<input_zp = -1, weight_zp = 0>, stride = array<i64: 1, 1>}
 // CHECK:         %[[RESCALE:.*]] = tosa.rescale %[[DEPTHWISE]]
 // CHECK-SAME:        multiplier = array<i32: 1373724854, 1373724854, 1373724854, 1373724854, 1803013871, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854, 1373724854>
 // CHECK-SAME:        shift = array<i8: 36, 36, 36, 36, 32, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36, 36>
@@ -153,11 +153,11 @@ func.func @test_depthwise_conv2d_bias_qi8(%arg0: tensor<1x32x32x8x!quant.uniform
 // CHECK-DAG: %[[INPUT_SLICE_1:.*]] = tosa.slice %arg0 {size = array<i64: 1, 4, 1, 64>, start = array<i64: 0, 0, 0, 0>}
 // CHECK-DAG: %[[FILTER_SLICE_1:.*]] = tosa.slice %arg1 {size = array<i64: 64, 1, 1, 64>, start = array<i64: 0, 0, 0, 0>}
 // CHECK-DAG: %[[BIAS_SLICE_1:.*]] = tosa.slice %arg2 {size = array<i64: 64>, start = array<i64: 0>}
-// CHECK-DAG: %[[CONV_1:.*]] = tosa.conv2d %[[INPUT_SLICE_1]], %[[FILTER_SLICE_1]], %[[BIAS_SLICE_1]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+// CHECK-DAG: %[[CONV_1:.*]] = tosa.conv2d %[[INPUT_SLICE_1]], %[[FILTER_SLICE_1]], %[[BIAS_SLICE_1]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
 // CHECK-DAG: %[[INPUT_SLICE_2:.*]] = tosa.slice %arg0 {size = array<i64: 1, 4, 1, 64>, start = array<i64: 0, 0, 0, 64>}
 // CHECK-DAG: %[[FILTER_SLICE_2:.*]] = tosa.slice %arg1 {size = array<i64: 64, 1, 1, 64>, start = array<i64: 64, 0, 0, 0>}
 // CHECK-DAG: %[[BIAS_SLICE_2:.*]] = tosa.slice %arg2 {size = array<i64: 64>, start = array<i64: 64>}
-// CHECK-DAG: %[[CONV_2:.*]] = tosa.conv2d %[[INPUT_SLICE_2]], %[[FILTER_SLICE_2]], %[[BIAS_SLICE_2]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+// CHECK-DAG: %[[CONV_2:.*]] = tosa.conv2d %[[INPUT_SLICE_2]], %[[FILTER_SLICE_2]], %[[BIAS_SLICE_2]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
 // CHECK-DAG: %[[CONCAT:.*]] = tosa.concat %[[CONV_1]], %[[CONV_2]] {axis = 3 : i32}
 // CHECK: return %[[CONCAT]]
 func.func @test_conv2d_grouped_convolution(%input: tensor<1x4x1x128xf32>, %weights: tensor<128x1x1x64xf32>, %bias: tensor<128xf32>) -> tensor<1x4x1x128xf32> {
@@ -171,19 +171,19 @@ func.func @test_conv2d_grouped_convolution(%input: tensor<1x4x1x128xf32>, %weigh
 // CHECK-DAG: %[[INPUT_SLICE_1:.*]] = tosa.slice %arg0 {size = array<i64: 1, 3, 1, 16>, start = array<i64: 0, 0, 0, 0>}
 // CHECK-DAG: %[[FILTER_SLICE_1:.*]] = tosa.slice %arg1 {size = array<i64: 128, 3, 1, 16>, start = array<i64: 0, 0, 0, 0>}
 // CHECK-DAG: %[[BIAS_SLICE_1:.*]] = tosa.slice %arg2 {size = array<i64: 128>, start = array<i64: 0>}
-// CHECK-DAG: %[[CONV_1:.*]] = tosa.conv2d %[[INPUT_SLICE_1]], %[[FILTER_SLICE_1]], %[[BIAS_SLICE_1]] {dilation = array<i64: 1, 1>, pad = array<i64: 1, 1, 0, 0>, stride = array<i64: 2, 1>}
+// CHECK-DAG: %[[CONV_1:.*]] = tosa.conv2d %[[INPUT_SLICE_1]], %[[FILTER_SLICE_1]], %[[BIAS_SLICE_1]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 1, 0, 0>, stride = array<i64: 2, 1>}
 // CHECK-DAG: %[[INPUT_SLICE_2:.*]] = tosa.slice %arg0 {size = array<i64: 1, 3, 1, 16>, start = array<i64: 0, 0, 0, 16>}
 // CHECK-DAG: %[[FILTER_SLICE_2:.*]] = tosa.slice %arg1 {size = array<i64: 128, 3, 1, 16>, start = array<i64: 128, 0, 0, 0>}
 // CHECK-DAG: %[[BIAS_SLICE_2:.*]] = tosa.slice %arg2 {size = array<i64: 128>, start = array<i64: 128>}
-// CHECK-DAG: %[[CONV_2:.*]] = tosa.conv2d %[[INPUT_SLICE_2]], %[[FILTER_SLICE_2]], %[[BIAS_SLICE_2]] {dilation = array<i64: 1, 1>, pad = array<i64: 1, 1, 0, 0>, stride = array<i64: 2, 1>}
+// CHECK-DAG: %[[CONV_2:.*]] = tosa.conv2d %[[INPUT_SLICE_2]], %[[FILTER_SLICE_2]], %[[BIAS_SLICE_2]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 1, 0, 0>, stride = array<i64: 2, 1>}
 // CHECK-DAG: %[[INPUT_SLICE_3:.*]] = tosa.slice %arg0 {size = array<i64: 1, 3, 1, 16>, start = array<i64: 0, 0, 0, 32>}
 // CHECK-DAG: %[[FILTER_SLICE_3:.*]] = tosa.slice %arg1 {size = array<i64: 128, 3, 1, 16>, start = array<i64: 256, 0, 0, 0>}
 // CHECK-DAG: %[[BIAS_SLICE_3:.*]] = tosa.slice %arg2 {size = array<i64: 128>, start = array<i64: 256>}
-// CHECK-DAG: %[[CONV_3:.*]] = tosa.conv2d %[[INPUT_SLICE_3]], %[[FILTER_SLICE_3]], %[[BIAS_SLICE_3]] {dilation = array<i64: 1, 1>, pad = array<i64: 1, 1, 0, 0>, stride = array<i64: 2, 1>}
+// CHECK-DAG: %[[CONV_3:.*]] = tosa.conv2d %[[INPUT_SLICE_3]], %[[FILTER_SLICE_3]], %[[BIAS_SLICE_3]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 1, 0, 0>, stride = array<i64: 2, 1>}
 // CHECK-DAG: %[[INPUT_SLICE_4:.*]] = tosa.slice %arg0 {size = array<i64: 1, 3, 1, 16>, start = array<i64: 0, 0, 0, 48>}
 // CHECK-DAG: %[[FILTER_SLICE_4:.*]] = tosa.slice %arg1 {size = array<i64: 128, 3, 1, 16>, start = array<i64: 384, 0, 0, 0>}
 // CHECK-DAG: %[[BIAS_SLICE_4:.*]] = tosa.slice %arg2 {size = array<i64: 128>, start = array<i64: 384>}
-// CHECK-DAG: %[[CONV_4:.*]] = tosa.conv2d %[[INPUT_SLICE_4]], %[[FILTER_SLICE_4]], %[[BIAS_SLICE_4]] {dilation = array<i64: 1, 1>, pad = array<i64: 1, 1, 0, 0>, stride = array<i64: 2, 1>}
+// CHECK-DAG: %[[CONV_4:.*]] = tosa.conv2d %[[INPUT_SLICE_4]], %[[FILTER_SLICE_4]], %[[BIAS_SLICE_4]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 1, 1, 0, 0>, stride = array<i64: 2, 1>}
 // CHECK-DAG: %[[CONCAT:.*]] = tosa.concat %[[CONV_1]], %[[CONV_2]], %[[CONV_3]], %[[CONV_4]] {axis = 3 : i32}
 // CHECK: return %[[CONCAT]]
 func.func @test_conv2d_grouped_strided_convolution(%input: tensor<1x3x1x64xf32>, %weights: tensor<512x3x1x16xf32>, %bias: tensor<512xf32>) -> tensor<1x2x1x512xf32> {
@@ -199,12 +199,12 @@ func.func @test_conv2d_grouped_strided_convolution(%input: tensor<1x3x1x64xf32>,
 // CHECK-DAG: %[[INPUT_SLICE_1:.*]] = tosa.slice %arg0 {size = array<i64: 1, 4, 1, 8>, start = array<i64: 0, 0, 0, 0>}
 // CHECK-DAG: %[[FILTER_SLICE_1:.*]] = tosa.slice %[[FILTER]] {size = array<i64: 8, 1, 1, 8>, start = array<i64: 0, 0, 0, 0>}
 // CHECK-DAG: %[[BIAS_SLICE_1:.*]] = tosa.slice %[[BIAS]] {size = array<i64: 8>, start = array<i64: 0>}
-// CHECK-DAG: %[[CONV_1:.*]] = tosa.conv2d %[[INPUT_SLICE_1]], %[[FILTER_SLICE_1]], %[[BIAS_SLICE_1]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, stride = array<i64: 1, 1>}
+// CHECK-DAG: %[[CONV_1:.*]] = tosa.conv2d %[[INPUT_SLICE_1]], %[[FILTER_SLICE_1]], %[[BIAS_SLICE_1]] {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, stride = array<i64: 1, 1>}
 // CHECK-DAG: %[[RESCALE_1:.*]] = tosa.rescale %[[CONV_1]] {double_round = true, input_zp = 0 : i32, multiplier = array<i32: 1374257539, 1374257539, 1374257539, 1374257539, 1374257539, 1374257539, 1374257539, 1374257539>, output_zp = 0 : i32, per_channel = true, scale32 = true, shift = array<i8: 36, 36, 36, 36, 36, 36, 36, 36>}
 // CHECK-DAG: %[[INPUT_SLICE_2:.*]] = tosa.slice %arg0 {size = array<i64: 1, 4, 1, 8>, start = array<i64: 0, 0, 0, 8>}
 // CHECK-DAG: %[[FILTER_SLICE_2:.*]] = tosa.slice %[[FILTER]] {size = array<i64: 8, 1, 1, 8>, start = array<i64: 8, 0, 0, 0>}
 // CHECK-DAG: %[[BIAS_SLICE_2:.*]] = tosa.slice %[[BIAS]] {size = array<i64: 8>, start = array<i64: 8>}
-// CHECK-DAG: %[[CONV_2:.*]] = tosa.conv2d %[[INPUT_SLICE_2]], %[[FILTER_SLICE_2]], %[[BIAS_SLICE_2]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, stride = array<i64: 1, 1>}
+// CHECK-DAG: %[[CONV_2:.*]] = tosa.conv2d %[[INPUT_SLICE_2]], %[[FILTER_SLICE_2]], %[[BIAS_SLICE_2]] {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, quantization_info = #tosa.conv_quant<input_zp = 0, weight_zp = 0>, stride = array<i64: 1, 1>}
 // CHECK-DAG: %[[RESCALE_2:.*]] = tosa.rescale %[[CONV_2]] {double_round = true, input_zp = 0 : i32, multiplier = array<i32: 1374257539, 1374257539, 1374257539, 1374257539, 1374257539, 1374257539, 1374257539, 1374257539>, output_zp = 0 : i32, per_channel = true, scale32 = true, shift = array<i8: 36, 36, 36, 36, 36, 36, 36, 36>}
 // CHECK-DAG: %[[CONCAT:.*]] = tosa.concat %[[RESCALE_1]], %[[RESCALE_2]] {axis = 3 : i32}
 // CHECK: return %[[CONCAT]]
@@ -234,7 +234,7 @@ func.func @test_depthwise_conv2d_bias_inferred(%arg0: tensor<?x32x32x8xf32>, %ar
 // CHECK-DAG: %[[VAL_2:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<4xf32>}>
 // CHECK-DAG: %[[VAL_3:.*]] = "tosa.const"() <{value = dense<[4, 0, 1, 2, 3]> : tensor<5xi32>}>
 // CHECK: %[[VAL_4:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_3]]
-// CHECK: %[[VAL_5:.*]] = tosa.conv3d %[[VAL_0]], %[[VAL_4]], %[[VAL_2]] {dilation = array<i64: 1, 1, 1>, pad = array<i64: 0, 1, 1, 1, 1, 1>, stride = array<i64: 1, 1, 1>}
+// CHECK: %[[VAL_5:.*]] = tosa.conv3d %[[VAL_0]], %[[VAL_4]], %[[VAL_2]] {acc_type = f32, dilation = array<i64: 1, 1, 1>, pad = array<i64: 0, 1, 1, 1, 1, 1>, stride = array<i64: 1, 1, 1>}
 func.func @test_conv3d(%arg0: tensor<2x2x7x7x2xf32>, %arg1: tensor<2x3x3x2x4xf32>) -> tensor<2x2x7x7x4xf32> {
   %cst = "tfl.no_value"() {value} : () -> none
   %0 = "tfl.conv_3d"(%arg0, %arg1, %cst) {dilation_d_factor = 1 : i32, dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_d = 1 : i32, stride_h = 1 : i32, stride_w = 1 : i32} : (tensor<2x2x7x7x2xf32>, tensor<2x3x3x2x4xf32>, none) -> tensor<2x2x7x7x4xf32>
@@ -249,7 +249,7 @@ func.func @test_conv3d(%arg0: tensor<2x2x7x7x2xf32>, %arg1: tensor<2x3x3x2x4xf32
 // CHECK-DAG: %[[VAL_2:.*]] = "tosa.const"() <{value = dense<0.000000e+00> : tensor<16xf32>}>
 // CHECK-DAG: %[[VAL_3:.*]] = "tosa.const"() <{value = dense<[4, 0, 1, 2, 3]> : tensor<5xi32>}>
 // CHECK: %[[VAL_4:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_3]]
-// CHECK: %[[VAL_5:.*]] = tosa.conv3d %[[VAL_0]], %[[VAL_4]], %[[VAL_2]] {dilation = array<i64: 1, 1, 1>, pad = array<i64: 1, 1, 0, 0, 0, 0>, stride = array<i64: 1, 1, 1>}
+// CHECK: %[[VAL_5:.*]] = tosa.conv3d %[[VAL_0]], %[[VAL_4]], %[[VAL_2]] {acc_type = f32, dilation = array<i64: 1, 1, 1>, pad = array<i64: 1, 1, 0, 0, 0, 0>, stride = array<i64: 1, 1, 1>}
 func.func @test_conv3d_dynamic(%arg0: tensor<?x11x32x32x8xf32>, %arg1: tensor<3x1x1x8x16xf32>) -> tensor<*xf32> {
   %cst = "tfl.no_value"() {value} : () -> none
   %0 = "tfl.conv_3d"(%arg0, %arg1, %cst) {dilation_d_factor = 1 : i32, dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_d = 1 : i32, stride_h = 1 : i32, stride_w = 1 : i32} : (tensor<?x11x32x32x8xf32>, tensor<3x1x1x8x16xf32>, none) -> tensor<*xf32>
@@ -264,7 +264,7 @@ func.func @test_conv3d_dynamic(%arg0: tensor<?x11x32x32x8xf32>, %arg1: tensor<3x
 // CHECK-SAME: %[[VAL_2:.*]]: tensor<8xf32>
 // CHECK-DAG: %[[VAL_3:.*]] = "tosa.const"() <{value = dense<[4, 0, 1, 2, 3]>
 // CHECK: %[[VAL_4:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_3]]
-// CHECK: %[[VAL_5:.*]] = tosa.conv3d %[[VAL_0]], %[[VAL_4]], %[[VAL_2]] {dilation = array<i64: 1, 1, 1>, pad = array<i64: 7, 8, 0, 1, 0, 1>, stride = array<i64: 1, 1, 1>}
+// CHECK: %[[VAL_5:.*]] = tosa.conv3d %[[VAL_0]], %[[VAL_4]], %[[VAL_2]] {acc_type = f32, dilation = array<i64: 1, 1, 1>, pad = array<i64: 7, 8, 0, 1, 0, 1>, stride = array<i64: 1, 1, 1>}
 func.func @test_conv3d_bias(%arg0: tensor<10x3x64x64x12xf32>, %arg1: tensor<16x2x2x12x8xf32>, %cst: tensor<8xf32>) -> tensor<10x3x64x64x8xf32> {
   %0 = "tfl.conv_3d"(%arg0, %arg1, %cst) {dilation_d_factor = 1 : i32, dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_d = 1 : i32, stride_h = 1 : i32, stride_w = 1 : i32} : (tensor<10x3x64x64x12xf32>, tensor<16x2x2x12x8xf32>, tensor<8xf32>) -> tensor<10x3x64x64x8xf32>
   func.return %0 : tensor<10x3x64x64x8xf32>
@@ -283,7 +283,7 @@ func.func @test_conv3d_bias(%arg0: tensor<10x3x64x64x12xf32>, %arg1: tensor<16x2
 // CHECK: %[[VAL_8:.*]] = tosa.cast %[[VAL_0]]
 // CHECK: %[[VAL_10:.*]] = tosa.mul %[[VAL_8]], %[[VAL_3]] {shift = 0 : i8}
 // CHECK: %[[VAL_11:.*]] = tosa.transpose %[[VAL_1]], %[[VAL_7]]
-// CHECK: %[[VAL_12:.*]] = tosa.conv3d %[[VAL_10]], %[[VAL_11]], %[[VAL_6]] {dilation = array<i64: 1, 1, 1>, pad = array<i64: 0, 1, 1, 1, 1, 1>, stride = array<i64: 1, 1, 2>}
+// CHECK: %[[VAL_12:.*]] = tosa.conv3d %[[VAL_10]], %[[VAL_11]], %[[VAL_6]] {acc_type = f32, dilation = array<i64: 1, 1, 1>, pad = array<i64: 0, 1, 1, 1, 1, 1>, stride = array<i64: 1, 1, 2>}
 // CHECK: %[[VAL_13:.*]] = tosa.mul %[[VAL_12]], %[[VAL_4]] {shift = 0 : i8}
 // CHECK: %[[VAL_14:.*]] = tosa.cast %[[VAL_13]]
 // CHECK: %[[VAL_15:.*]] = tosa.add %[[VAL_14]], %[[VAL_5]]
@@ -1428,7 +1428,7 @@ func.func @test_log_softmax(%arg0: tensor<13x21x3xf32>) -> tensor<13x21x3xf32> {
 // CHECK: %[[VAR2:.*]] = tosa.transpose %arg1, %[[VAR0]]
 // CHECK: %[[VAR3:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
 // CHECK: %[[VAR4:.*]] = tosa.reshape %[[VAR2]] {new_shape = array<i64: 28, 1, 1, 19>}
-// CHECK: %[[VAR5:.*]] = tosa.conv2d %[[VAR3]], %[[VAR4]], %[[VAR1]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+// CHECK: %[[VAR5:.*]] = tosa.conv2d %[[VAR3]], %[[VAR4]], %[[VAR1]] {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
 // CHECK: %[[VAR6:.*]] = tosa.reshape %[[VAR5]] {new_shape = array<i64: 14, 28>}
 func.func @test_matmul(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>) -> tensor<*xf32> {
   %cst = arith.constant dense<[1, 0]> : tensor<2xi32>
@@ -1444,7 +1444,7 @@ func.func @test_matmul(%arg0: tensor<14x19xf32>, %arg1: tensor<19x28xf32>) -> te
 func.func @test_fullyconnected(%arg0: tensor<14x19xf32>, %arg1: tensor<28x19xf32>, %arg2: tensor<28xf32>) -> tensor<14x28xf32> {
   // CHECK: %[[VAL0:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
   // CHECK: %[[VAL1:.*]] = tosa.reshape %arg1 {new_shape = array<i64: 28, 1, 1, 19>}
-  // CHECK: %[[VAL2:.*]] = tosa.conv2d %[[VAL0]], %[[VAL1]], %arg2 {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+  // CHECK: %[[VAL2:.*]] = tosa.conv2d %[[VAL0]], %[[VAL1]], %arg2 {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
   // CHECK: %[[VAL3:.*]] = tosa.reshape %[[VAL2]] {new_shape = array<i64: 14, 28>}
   // return %[[VAL3]]
   %2 = "tfl.fully_connected"(%arg0, %arg1, %arg2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<14x19xf32>, tensor<28x19xf32>, tensor<28xf32>) -> tensor<14x28xf32>
@@ -1457,7 +1457,7 @@ func.func @test_fullyconnected(%arg0: tensor<14x19xf32>, %arg1: tensor<28x19xf32
 func.func @test_fullyconnected_in_batch_dim(%arg0: tensor<1x14x19xf32>, %arg1: tensor<28x19xf32>, %arg2: tensor<28xf32>) -> tensor<14x28xf32> {
   // CHECK: %[[VAL0:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
   // CHECK: %[[VAL1:.*]] = tosa.reshape %arg1 {new_shape = array<i64: 28, 1, 1, 19>}
-  // CHECK: %[[VAL2:.*]] = tosa.conv2d %[[VAL0]], %[[VAL1]], %arg2 {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+  // CHECK: %[[VAL2:.*]] = tosa.conv2d %[[VAL0]], %[[VAL1]], %arg2 {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
   // CHECK: %[[VAL3:.*]] = tosa.reshape %[[VAL2]] {new_shape = array<i64: 14, 28>}
   // return %[[VAL3]]
   %0 = "tfl.fully_connected"(%arg0, %arg1, %arg2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<1x14x19xf32>, tensor<28x19xf32>, tensor<28xf32>) -> tensor<14x28xf32>
@@ -1470,7 +1470,7 @@ func.func @test_fullyconnected_in_batch_dim(%arg0: tensor<1x14x19xf32>, %arg1: t
 func.func @test_fullyconnected_extra_dim(%arg0: tensor<1x14x19xf32>, %arg1: tensor<28x19xf32>, %arg2: tensor<28xf32>) -> tensor<1x14x28xf32> {
   // CHECK: %[[VAL0:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
   // CHECK: %[[VAL1:.*]] = tosa.reshape %arg1 {new_shape = array<i64: 28, 1, 1, 19>}
-  // CHECK: %[[VAL2:.*]] = tosa.conv2d %[[VAL0]], %[[VAL1]], %arg2 {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+  // CHECK: %[[VAL2:.*]] = tosa.conv2d %[[VAL0]], %[[VAL1]], %arg2 {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
   // CHECK: %[[VAL3:.*]] = tosa.reshape %[[VAL2]] {new_shape = array<i64: 1, 14, 28>}
   // return %[[VAL3]]
   %0 = "tfl.fully_connected"(%arg0, %arg1, %arg2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<1x14x19xf32>, tensor<28x19xf32>, tensor<28xf32>) -> tensor<1x14x28xf32>
@@ -1800,10 +1800,12 @@ func.func @test_bucketize_cast_boundaries(%arg0: tensor<2x5xi32>) -> tensor<2x5x
 
 // CHECK-LABEL: @test_one_hot
 // CHECK-SAME:      %[[ARG0:.*]]: tensor<4x4xi32>, %[[ARG1:.*]]: tensor<f32>, %[[ARG2:.*]]: tensor<f32>
+// CHECK-DAG:     %[[CST1:.*]] = tosa.const_shape {value = dense<[16, 1, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK-DAG:     %[[CST2:.*]] = tosa.const_shape {value = dense<[16, 2, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
 // CHECK-DAG:     %[[RESHAPE:.*]] = tosa.reshape %[[ARG1]] {new_shape = array<i64: 1, 1, 1>}
-// CHECK-DAG:     %[[TILE:.*]] = tosa.tile %[[RESHAPE]] {multiples = array<i64: 16, 1, 1>}
+// CHECK-DAG:     %[[TILE:.*]] = tosa.tile %[[RESHAPE]], %[[CST1]]
 // CHECK-DAG:     %[[RESHAPE_0:.*]] = tosa.reshape %[[ARG2]] {new_shape = array<i64: 1, 1, 1>}
-// CHECK-DAG:     %[[TILE_0:.*]] = tosa.tile %[[RESHAPE_0]] {multiples = array<i64: 16, 2, 1>}
+// CHECK-DAG:     %[[TILE_0:.*]] = tosa.tile %[[RESHAPE_0]], %[[CST2]]
 // CHECK-DAG:     %[[RESHAPE_1:.*]] = tosa.reshape %[[ARG0]] {new_shape = array<i64: 16, 1>}
 // CHECK-DAG:     %[[SCATTER:.*]] = tosa.scatter %[[TILE_0]], %[[RESHAPE_1]], %[[TILE]]
 // CHECK-DAG:     %[[RESHAPE_2:.*]] = tosa.reshape %[[SCATTER]] {new_shape = array<i64: 4, 4, 2>}
@@ -2285,7 +2287,7 @@ func.func @test_resize_nearest_align_qi8_scalar_input(%arg0: tensor<3x1x1x7x!qua
 // CHECK-DAG: %[[VAR2:.*]] = tosa.transpose %arg1, %[[VAR0]]
 // CHECK-DAG: %[[VAR3:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
 // CHECK-DAG: %[[VAR4:.*]] = tosa.reshape %[[VAR2]] {new_shape = array<i64: 28, 1, 1, 19>}
-// CHECK-DAG: %[[VAR5:.*]] = tosa.conv2d %[[VAR3]], %[[VAR4]], %[[VAR1]] {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, quantization_info = #tosa.conv_quant<input_zp = -1, weight_zp = -1>, stride = array<i64: 1, 1>}
+// CHECK-DAG: %[[VAR5:.*]] = tosa.conv2d %[[VAR3]], %[[VAR4]], %[[VAR1]] {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, quantization_info = #tosa.conv_quant<input_zp = -1, weight_zp = -1>, stride = array<i64: 1, 1>}
 // CHECK: %[[VAR6:.*]] = tosa.rescale %[[VAR5]] {double_round = true, input_zp = 0 : i32, multiplier = array<i32: 1353377973>, output_zp = 3 : i32, per_channel = false, scale32 = true, shift = array<i8: 40>}
 // CHECK: %[[VAR9:.*]] = tosa.reshape %[[VAR6]] {new_shape = array<i64: 14, 28>}
 func.func @test_fullyconnected_qi8(%arg0: tensor<14x19x!quant.uniform<i8:f32, 0.015685491263866425:-1>>, %arg1: tensor<19x28x!quant.uniform<i8:f32, 0.015685983002185822:-1>>) -> tensor<14x28x!quant.uniform<i8:f32, 0.19988977909088135:3>> {
@@ -2503,7 +2505,7 @@ func.func @test_fullyconnected_hybrid(%arg0: tensor<14x19xf32>, %arg1: tensor<28
   // CHECK: %[[VAL2:.*]] = tosa.sub %[[VAL1]], %[[VAL0]]
   // CHECK: %[[VAL3:.*]] = tosa.reshape %arg0 {new_shape = array<i64: 14, 1, 1, 19>}
   // CHECK: %[[VAL4:.*]] = tosa.reshape %[[VAL2]] {new_shape = array<i64: 28, 1, 1, 19>}
-  // CHECK: %[[VAL5:.*]] = tosa.conv2d %[[VAL3]], %[[VAL4]], %arg2 {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
+  // CHECK: %[[VAL5:.*]] = tosa.conv2d %[[VAL3]], %[[VAL4]], %arg2 {acc_type = f32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>}
   // CHECK: %[[VAL6:.*]] = tosa.reshape %[[VAL5]] {new_shape = array<i64: 14, 28>}
   %2 = "tfl.fully_connected"(%arg0, %arg1, %arg2) {fused_activation_function = "NONE", keep_num_dims = false, weights_format = "DEFAULT"} : (tensor<14x19xf32>, tensor<28x19x!quant.uniform<i8:f32, 1.0:17>>, tensor<28xf32>) -> tensor<*xf32>
   func.return %2 : tensor<*xf32>

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1,7 +1,7 @@
 // RUN: tf-opt --split-input-file --tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
-
+// REQUIRES: tf_tosa
 // RUN: tf-opt --split-input-file --tf-tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
-
+// REQUIRES: tf_tosa
 
 // Operations for testing tfl-to-tosa-pipeline
 

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-unequal-ranks.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-unequal-ranks.mlir
@@ -1,0 +1,174 @@
+// RUN: tf-opt --split-input-file --tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
+
+// Test tf legalization that produce TOSA ResultsBroadcastableShape operators with unequal ranks
+
+// -----
+
+// CHECK-LABEL: test_add
+func.func @test_add(%arg0: tensor<192x192x3xf32>, %arg1: tensor<16x192x192x3xf32>) -> tensor<16x192x192x3xf32> {
+    // CHECK: tosa.add
+    %1 = tfl.add(%arg0, %arg1) {fused_activation_function = "NONE"} : (tensor<192x192x3xf32>, tensor<16x192x192x3xf32>) -> tensor<16x192x192x3xf32>
+    func.return %1 : tensor<16x192x192x3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_add_qi8
+func.func @test_add_qi8(%arg0: tensor<13x21x1x!quant.uniform<i8:f32, 0.01568480022251606:-1>>, %arg1: tensor<1x13x21x3x!quant.uniform<i8:f32, 0.015686055645346642:-1>>) -> tensor<1x13x21x3x!quant.uniform<i8:f32, 0.031318482011556625:-1>> {
+  // CHECK: tosa.add
+  %0 = tfl.add(%arg0, %arg1) {fused_activation_function = "NONE"} : (tensor<13x21x1x!quant.uniform<i8:f32, 0.01568480022251606:-1>>, tensor<1x13x21x3x!quant.uniform<i8:f32, 0.015686055645346642:-1>>) -> tensor<1x13x21x3x!quant.uniform<i8:f32, 0.031318482011556625:-1>>
+  func.return %0 : tensor<1x13x21x3x!quant.uniform<i8:f32, 0.031318482011556625:-1>>
+}
+
+// -----
+
+// CHECK-LABEL: test_sub
+func.func @test_sub(%arg0: tensor<192x192x3xf32>, %arg1: tensor<16x192x192x3xf32>) -> tensor<16x192x192x3xf32> {
+    // CHECK: tosa.sub
+    %1 = tfl.sub(%arg0, %arg1) {fused_activation_function = "NONE"} : (tensor<192x192x3xf32>, tensor<16x192x192x3xf32>) -> tensor<16x192x192x3xf32>
+    func.return %1 : tensor<16x192x192x3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_sub_qi8
+func.func @test_sub_qi8(%arg0: tensor<13x21x1x!quant.uniform<i8:f32, 0.01568480022251606:-1>>, %arg1: tensor<1x13x21x3x!quant.uniform<i8:f32, 0.015686055645346642:-1>>) -> tensor<1x13x21x3x!quant.uniform<i8:f32, 0.031318482011556625:-1>> {
+  // CHECK: tosa.sub
+  %0 = tfl.sub(%arg0, %arg1) {fused_activation_function = "NONE"} : (tensor<13x21x1x!quant.uniform<i8:f32, 0.01568480022251606:-1>>, tensor<1x13x21x3x!quant.uniform<i8:f32, 0.015686055645346642:-1>>) -> tensor<1x13x21x3x!quant.uniform<i8:f32, 0.031318482011556625:-1>>
+  func.return %0 : tensor<1x13x21x3x!quant.uniform<i8:f32, 0.031318482011556625:-1>>
+}
+
+// -----
+
+// CHECK-LABEL: test_equal
+// CHECK: tosa.equal
+func.func @test_equal(%arg0: tensor<13x21x3xf32>, %arg1: tensor<1x13x1x3xf32>) -> tensor<1x13x21x3xi1> {
+  %2 = "tfl.equal"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<1x13x1x3xf32>) -> tensor<1x13x21x3xi1>
+  func.return %2 : tensor<1x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_not_equal
+// CHECK: tosa.equal
+// CHECK: tosa.logical_not
+func.func @test_not_equal(%arg0: tensor<13x21x3xf32>, %arg1: tensor<1x13x1x3xf32>) -> tensor<1x13x21x3xi1> {
+  %2 = "tfl.not_equal"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<1x13x1x3xf32>) -> tensor<1x13x21x3xi1>
+  func.return %2 : tensor<1x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_greater_equal
+// CHECK: tosa.greater_equal
+func.func @test_greater_equal(%arg0: tensor<13x1x3xf32>, %arg1: tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1> {
+  %2 = "tfl.greater_equal"(%arg0, %arg1)   : (tensor<13x1x3xf32>, tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1>
+  func.return %2 : tensor<1x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_greater
+// CHECK: tosa.greater
+func.func @test_greater(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1> {
+  %2 = "tfl.greater"(%arg0, %arg1)   : (tensor<13x21x1xf32>, tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1>
+  func.return %2 : tensor<1x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_less
+// CHECK: tosa.greater
+func.func @test_less(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1> {
+  %2 = "tfl.less"(%arg0, %arg1)   : (tensor<13x21x1xf32>, tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1>
+  func.return %2 : tensor<1x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_less_equal
+// CHECK: tosa.greater_equal
+func.func @test_less_equal(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1> {
+  %2 = "tfl.less_equal"(%arg0, %arg1)   : (tensor<13x21x1xf32>, tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xi1>
+  func.return %2 : tensor<1x13x21x3xi1>
+}
+
+// -----
+// CHECK-LABEL: test_select
+// CHECK: tosa.select
+func.func @test_select(%arg0: tensor<13x21x3xf32>, %arg1: tensor<1x13x21x3xf32>, %arg2: tensor<1xi1>) -> tensor<1x13x21x3xf32> {
+  %2 = "tfl.select_v2"(%arg2, %arg0, %arg1)   : (tensor<1xi1>, tensor<13x21x3xf32>, tensor<1x13x21x3xf32>) -> tensor<1x13x21x3xf32>
+  func.return %2 : tensor<1x13x21x3xf32>
+}
+
+// -----
+// CHECK-LABEL: test_mul_qi8
+// CHECK: tosa.mul
+func.func @test_mul_qi8(%arg0: tensor<13x21x3x!quant.uniform<i8:f32, 0.015681236982345581>>, %arg1: tensor<1x13x21x3x!quant.uniform<i8:f32, 0.015647144988179207:-1>>) -> tensor<*x!quant.uniform<i8:f32, 0.0078376950696110725>> {
+  %0 = "tfl.mul"(%arg0, %arg1)  {fused_activation_function = "NONE"}  : (tensor<13x21x3x!quant.uniform<i8:f32, 0.015681236982345581>>, tensor<1x13x21x3x!quant.uniform<i8:f32, 0.015647144988179207:-1>>) -> tensor<*x!quant.uniform<i8:f32, 0.0078376950696110725>>
+  func.return %0 : tensor<*x!quant.uniform<i8:f32, 0.0078376950696110725>>
+}
+
+// -----
+// CHECK-LABEL: test_div
+// CHECK: tosa.int_div
+func.func @test_div(%arg0: tensor<13x21x3xi32>, %arg1: tensor<i32>) -> tensor<*xi32> {
+  %0 = "tfl.div"(%arg0, %arg1)  {fused_activation_function = "NONE"}  : (tensor<13x21x3xi32>, tensor<i32>) -> tensor<*xi32>
+  func.return %0 : tensor<*xi32>
+}
+
+// -----
+
+// CHECK-LABEL: test_max
+// CHECK: tosa.maximum
+func.func @test_max(%arg0: tensor<13x21x3xf32>, %arg1: tensor<1x13x21x1xf32>) -> tensor<*xf32> {
+  %0 = "tfl.maximum"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<1x13x21x1xf32>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_min
+// CHECK: tosa.minimum
+func.func @test_min(%arg0: tensor<13x21x3xf32>, %arg1: tensor<1x13x21x1xf32>) -> tensor<*xf32> {
+  %0 = "tfl.minimum"(%arg0, %arg1) : (tensor<13x21x3xf32>, tensor<1x13x21x1xf32>) -> tensor<*xf32>
+  func.return %0 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_add
+func.func @test_addn(%arg0: tensor<13x21x1xf32>, %arg1: tensor<1x13x21x3xf32>, %arg2: tensor<21x3xf32>, %arg3: tensor<3xf32>) -> tensor<*xf32> {
+  // CHECK: tosa.add
+  // CHECK: tosa.add
+  // CHECK: tosa.add
+  %2 = "tfl.add_n"(%arg0, %arg1, %arg2, %arg3)   : (tensor<13x21x1xf32>, tensor<1x13x21x3xf32>, tensor<21x3xf32>, tensor<3xf32>) -> tensor<*xf32>
+  func.return %2 : tensor<*xf32>
+}
+
+// -----
+
+// CHECK-LABEL: test_logical_and
+func.func @test_logical_and(%arg0: tensor<8x13x21x3xi1>, %arg1: tensor<13x21x1xi1>) -> tensor<8x13x21x3xi1> {
+  // CHECK: tosa.logical_and
+  %2 = "tfl.logical_and"(%arg0, %arg1)   : (tensor<8x13x21x3xi1>, tensor<13x21x1xi1>) -> tensor<8x13x21x3xi1>
+  func.return %2 : tensor<8x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_logical_or
+func.func @test_logical_or(%arg0: tensor<8x13x21x3xi1>, %arg1: tensor<13x21x1xi1>) -> tensor<8x13x21x3xi1> {
+  // CHECK: tosa.logical_or
+  %2 = "tfl.logical_or"(%arg0, %arg1)   : (tensor<8x13x21x3xi1>, tensor<13x21x1xi1>) -> tensor<8x13x21x3xi1>
+  func.return %2 : tensor<8x13x21x3xi1>
+}
+
+// -----
+
+// CHECK-LABEL: test_power
+func.func @test_power(%arg0: tensor<8x13x21x3xi32>, %arg1: tensor<13x21x1xi32>) -> tensor<8x13x21x3xi32> {
+  // CHECK: tosa.pow
+  %2 = "tfl.pow"(%arg0, %arg1)   : (tensor<8x13x21x3xi32>, tensor<13x21x1xi32>) -> tensor<8x13x21x3xi32>
+  func.return %2 : tensor<8x13x21x3xi32>
+}

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-unequal-ranks.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-unequal-ranks.mlir
@@ -1,5 +1,5 @@
 // RUN: tf-opt --split-input-file --tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
-
+// REQUIRES: tf_tosa
 // Test tf legalization that produce TOSA ResultsBroadcastableShape operators with unequal ranks
 
 // -----

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.h
@@ -267,13 +267,11 @@ std::optional<Value> convertTFConv2DCommon(
 
 // Lowers TensorFlow and TensorFlow Lite Conv3D to a sequence of TOSA
 // quantization ops.
-std::optional<Value> convertConv3DCommon(PatternRewriter& rewriter,
-                                         Operation* op, ShapedType output_type,
-                                         Value input, Value filter, Value bias,
-                                         ArrayRef<int64_t> strides,
-                                         ArrayRef<int64_t> dilations,
-                                         StringRef padding_ref,
-                                         StringRef data_format_ref);
+std::optional<Value> convertConv3DCommon(
+    PatternRewriter& rewriter, Operation* op, ShapedType output_type,
+    Value input, Value filter, Value bias, DenseI64ArrayAttr pads,
+    DenseI64ArrayAttr strides, DenseI64ArrayAttr dilations, TypeAttr acc_type,
+    StringRef data_format_ref);
 
 // Preprocess TensorFlow Conv3D attributes prior to calling
 // `convertConv3DCommon`

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
@@ -152,6 +152,12 @@ DECL_CONVERT_OP(RightShift);
 DECL_CONVERT_OP(OneHot);
 DECL_CONVERT_OP(BatchMatMulV2);
 DECL_CONVERT_OP(BroadcastTo);
+DECL_CONVERT_OP(BitwiseOr);
+DECL_CONVERT_OP(BitwiseXor);
+DECL_CONVERT_OP(BitwiseAnd);
+DECL_CONVERT_OP(LogicalAnd);
+DECL_CONVERT_OP(LogicalOr);
+DECL_CONVERT_OP(Pow);
 #undef DECL_CONVERT_OP
 
 LogicalResult ConvertTFReluOp::matchAndRewrite(
@@ -188,20 +194,6 @@ LogicalResult ConvertTFRelu6Op::matchAndRewrite(
   return success();
 }
 
-LogicalResult ConvertTFEqualOp::matchAndRewrite(
-    Operation* op, PatternRewriter& rewriter) const {
-  auto tf_equal_op = cast<TF::EqualOp>(op);
-
-  TensorType output_type =
-      dyn_cast<TensorType>(tf_equal_op.getResult().getType());
-  // Not a tensor output
-  if (!output_type) return failure();
-
-  CreateReplaceOpAndInfer<tosa::EqualOp>(
-      rewriter, op, output_type, tf_equal_op.getX(), tf_equal_op.getY());
-  return success();
-}
-
 LogicalResult ConvertTFNotEqualOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tf_not_equal_op = cast<TF::NotEqualOp>(op);
@@ -211,44 +203,17 @@ LogicalResult ConvertTFNotEqualOp::matchAndRewrite(
   // Not a tensor output
   if (!output_type) return failure();
 
-  auto op1_equal_in = CreateOpAndInfer<tosa::EqualOp>(
-      rewriter, op->getLoc(), output_type, tf_not_equal_op.getX(),
-      tf_not_equal_op.getY());
+  Value x = tf_not_equal_op.getX();
+  Value y = tf_not_equal_op.getY();
+
+  auto op1_equal_in = CreateOpAndInfer<tosa::EqualOp>(rewriter, op->getLoc(),
+                                                      output_type, x, y);
 
   auto op2_not_op1 = CreateOpAndInfer<tosa::LogicalNotOp>(
       rewriter, op->getLoc(), output_type, op1_equal_in.getResult());
 
   rewriter.replaceOp(op, {op2_not_op1.getResult()});
 
-  return success();
-}
-
-LogicalResult ConvertTFGreaterOp::matchAndRewrite(
-    Operation* op, PatternRewriter& rewriter) const {
-  auto tf_greater_op = cast<TF::GreaterOp>(op);
-
-  TensorType output_type =
-      dyn_cast<TensorType>(tf_greater_op.getResult().getType());
-  // Not a tensor output
-  if (!output_type) return failure();
-
-  CreateReplaceOpAndInfer<tosa::GreaterOp>(
-      rewriter, op, output_type, tf_greater_op.getX(), tf_greater_op.getY());
-  return success();
-}
-
-LogicalResult ConvertTFGreaterEqualOp::matchAndRewrite(
-    Operation* op, PatternRewriter& rewriter) const {
-  auto tf_greater_equal_op = cast<TF::GreaterEqualOp>(op);
-
-  TensorType output_type =
-      dyn_cast<TensorType>(tf_greater_equal_op.getResult().getType());
-  // Not a tensor output
-  if (!output_type) return failure();
-
-  CreateReplaceOpAndInfer<tosa::GreaterEqualOp>(rewriter, op, output_type,
-                                                tf_greater_equal_op.getX(),
-                                                tf_greater_equal_op.getY());
   return success();
 }
 
@@ -306,8 +271,10 @@ LogicalResult ConvertTFAddOp::matchAndRewrite(Operation* op,
   // Not a tensor output
   if (!output_type) return failure();
 
-  CreateReplaceOpAndInfer<tosa::AddOp>(rewriter, op, output_type,
-                                       tf_add_op.getX(), tf_add_op.getY());
+  Value x = tf_add_op.getX();
+  Value y = tf_add_op.getY();
+
+  CreateReplaceOpAndInfer<tosa::AddOp>(rewriter, op, output_type, x, y);
   return success();
 }
 
@@ -320,8 +287,10 @@ LogicalResult ConvertTFAddV2Op::matchAndRewrite(
   // Not a tensor output
   if (!output_type) return failure();
 
-  CreateReplaceOpAndInfer<tosa::AddOp>(rewriter, op, output_type,
-                                       tf_addv2_op.getX(), tf_addv2_op.getY());
+  Value x = tf_addv2_op.getX();
+  Value y = tf_addv2_op.getY();
+
+  CreateReplaceOpAndInfer<tosa::AddOp>(rewriter, op, output_type, x, y);
   return success();
 }
 
@@ -339,11 +308,15 @@ LogicalResult ConvertTFAddNOp::matchAndRewrite(
 
   assert(inputs.size() >= 2);
 
+  Value lhs = inputs[0];
+  Value rhs = inputs[1];
   auto newOp = CreateOpAndInfer<tosa::AddOp>(rewriter, op->getLoc(),
-                                             output_type, inputs[0], inputs[1]);
+                                             output_type, lhs, rhs);
   for (int i = 2; i < inputs.size(); i++) {
+    Value lhs = inputs[i];
+    Value rhs = newOp.getResult();
     newOp = CreateOpAndInfer<tosa::AddOp>(rewriter, op->getLoc(), output_type,
-                                          inputs[i], newOp.getResult());
+                                          lhs, rhs);
   }
 
   rewriter.replaceOp(op, {newOp.getResult()});
@@ -360,8 +333,10 @@ LogicalResult ConvertTFSubOp::matchAndRewrite(Operation* op,
   // Not a tensor output
   if (!output_type) return failure();
 
-  CreateReplaceOpAndInfer<tosa::SubOp>(rewriter, op, output_type,
-                                       tf_sub_op.getX(), tf_sub_op.getY());
+  Value lhs = tf_sub_op.getX();
+  Value rhs = tf_sub_op.getY();
+
+  CreateReplaceOpAndInfer<tosa::SubOp>(rewriter, op, output_type, lhs, rhs);
   return success();
 }
 
@@ -467,34 +442,6 @@ LogicalResult ConvertTFAssertOp::matchAndRewrite(
   return success();
 }
 
-LogicalResult ConvertTFMaximumOp::matchAndRewrite(
-    Operation* op, PatternRewriter& rewriter) const {
-  auto tf_maximum_op = cast<TF::MaximumOp>(op);
-
-  TensorType output_type =
-      dyn_cast<TensorType>(tf_maximum_op.getResult().getType());
-  // Not a tensor output
-  if (!output_type) return failure();
-
-  CreateReplaceOpAndInfer<tosa::MaximumOp>(
-      rewriter, op, output_type, tf_maximum_op.getX(), tf_maximum_op.getY());
-  return success();
-}
-
-LogicalResult ConvertTFMinimumOp::matchAndRewrite(
-    Operation* op, PatternRewriter& rewriter) const {
-  auto tf_minimum_op = cast<TF::MinimumOp>(op);
-
-  TensorType output_type =
-      dyn_cast<TensorType>(tf_minimum_op.getResult().getType());
-  // Not a tensor output
-  if (!output_type) return failure();
-
-  CreateReplaceOpAndInfer<tosa::MinimumOp>(
-      rewriter, op, output_type, tf_minimum_op.getX(), tf_minimum_op.getY());
-  return success();
-}
-
 LogicalResult ConvertTFRealDivOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tf_div_op = cast<TF::RealDivOp>(op);
@@ -507,18 +454,20 @@ LogicalResult ConvertTFRealDivOp::matchAndRewrite(
 
   Type element_type = output_type.getElementType();
 
+  Value x = tf_div_op.getX();
+  Value y = tf_div_op.getY();
+
   if (mlir::isa<IntegerType>(element_type)) {
-    CreateReplaceOpAndInfer<tosa::IntDivOp>(rewriter, op, output_type,
-                                            tf_div_op.getX(), tf_div_op.getY());
+    CreateReplaceOpAndInfer<tosa::IntDivOp>(rewriter, op, output_type, x, y);
     return success();
   }
 
   auto reciprocal_op = CreateOpAndInfer<tosa::ReciprocalOp>(
-      rewriter, op->getLoc(), tf_div_op.getY().getType(), tf_div_op.getY());
+      rewriter, op->getLoc(), y.getType(), y);
 
-  auto mul_op = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, op->getLoc(), output_type, tf_div_op.getX(),
-      reciprocal_op.getResult(), rewriter.getI8IntegerAttr(0));
+  auto mul_op = CreateMulOpAndInfer(rewriter, op, output_type, x,
+                                    reciprocal_op.getResult());
+
   rewriter.replaceOp(op, {mul_op.getResult()});
 
   return success();
@@ -1378,22 +1327,34 @@ LogicalResult ConvertTFFusedBatchNormOp::matchAndRewrite(
   // op5 = mul(op4, bscale)
   // op6 = add(op5, boffset)
 
-  RankedTensorType mean_type =
-      dyn_cast<RankedTensorType>(tf_batchnorm_op.getMean().getType());
+  Value mean = tf_batchnorm_op.getMean();
+  Value variance = tf_batchnorm_op.getVariance();
+  Value x = tf_batchnorm_op.getX();
+  Value scale = tf_batchnorm_op.getScale();
+  Value offset = tf_batchnorm_op.getOffset();
+
+  RankedTensorType mean_type = dyn_cast<RankedTensorType>(mean.getType());
   RankedTensorType variance_type =
-      dyn_cast<RankedTensorType>(tf_batchnorm_op.getVariance().getType());
-  if (!variance_type || !mean_type) return failure();
+      dyn_cast<RankedTensorType>(variance.getType());
+  RankedTensorType x_type = dyn_cast<RankedTensorType>(x.getType());
+  RankedTensorType scale_type = dyn_cast<RankedTensorType>(scale.getType());
+  RankedTensorType offset_type = dyn_cast<RankedTensorType>(offset.getType());
+  if (!variance_type || !mean_type || !x_type || !scale_type || !offset_type)
+    return failure();
+
+  auto rank = x_type.getRank();
 
   Value mean_val, variance_val;
 
   if (mean_type.getNumElements() == 0) {
-    mean_val = getTosaConstTensorSingleF32(rewriter, tf_batchnorm_op, 0);
+    mean_val = getTosaConstTensorSingleF32(rewriter, tf_batchnorm_op, 0, rank);
   } else {
     mean_val = tf_batchnorm_op.getMean();
   }
 
   if (variance_type.getNumElements() == 0) {
-    variance_val = getTosaConstTensorSingleF32(rewriter, tf_batchnorm_op, 1.0);
+    variance_val =
+        getTosaConstTensorSingleF32(rewriter, tf_batchnorm_op, 1.0, 1);
   } else {
     variance_val = tf_batchnorm_op.getVariance();
   }
@@ -1405,33 +1366,26 @@ LogicalResult ConvertTFFusedBatchNormOp::matchAndRewrite(
   auto epsilon_const = CreateOpAndInfer<tosa::ConstOp>(
       rewriter, op->getLoc(), epsilon_type, epsilon_attr);
 
-  auto op1_sub_input_mean = CreateOpAndInfer<tosa::SubOp>(
-      rewriter, op->getLoc(), tf_batchnorm_op.getResult(0).getType(),
-      tf_batchnorm_op.getX(), mean_val);
+  Value op1_sub_input_mean = CreateOpAndInfer<tosa::SubOp>(
+      rewriter, op->getLoc(), output_type, x, mean_val);
 
-  auto op2_add_var_epsilon = CreateOpAndInfer<tosa::AddOp>(
+  Value op2_add_var_epsilon = CreateOpAndInfer<tosa::AddOp>(
       rewriter, op->getLoc(), variance_val.getType(), variance_val,
       epsilon_const.getResult());
 
-  auto op3_rsqrt_op2 = CreateOpAndInfer<tosa::RsqrtOp>(
-      rewriter, op->getLoc(), variance_val.getType(),
-      op2_add_var_epsilon.getResult());
+  Value op3_rsqrt_op2 = CreateOpAndInfer<tosa::RsqrtOp>(
+      rewriter, op->getLoc(), variance_val.getType(), op2_add_var_epsilon);
 
-  auto op4_mul_op1_op3 = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, op->getLoc(), tf_batchnorm_op.getResult(0).getType(),
-      op1_sub_input_mean.getResult(), op3_rsqrt_op2.getResult(),
-      rewriter.getI8IntegerAttr(0));
+  Value op4_mul_op1_op3 = CreateMulOpAndInfer(
+      rewriter, op, output_type, op1_sub_input_mean, op3_rsqrt_op2);
 
-  auto op5_mul_op4_scale = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, op->getLoc(), tf_batchnorm_op.getResult(0).getType(),
-      op4_mul_op1_op3.getResult(), tf_batchnorm_op.getScale(),
-      rewriter.getI8IntegerAttr(0));
+  Value op5_mul_op4_scale =
+      CreateMulOpAndInfer(rewriter, op, output_type, op4_mul_op1_op3, scale);
 
-  auto op6_add_op5_offset = CreateOpAndInfer<tosa::AddOp>(
-      rewriter, op->getLoc(), tf_batchnorm_op.getResult(0).getType(),
-      op5_mul_op4_scale.getResult(), tf_batchnorm_op.getOffset());
+  Value op6_add_op5_offset = CreateOpAndInfer<tosa::AddOp>(
+      rewriter, op->getLoc(), output_type, op5_mul_op4_scale, offset);
 
-  rewriter.replaceOp(op, {op6_add_op5_offset.getResult()});
+  rewriter.replaceOp(op, {op6_add_op5_offset});
   return success();
 }
 
@@ -1466,12 +1420,15 @@ LogicalResult ConvertTFFusedBatchNormV3Op::matchAndRewrite(
   // op5 = mul(op4, scale)
   // op6 = add(op5, offset)
 
-  auto op1_sub_input_mean = CreateOpAndInfer<tosa::SubOp>(
-      rewriter, op->getLoc(), tf_batchnorm_op.getResult(0).getType(),
-      tf_batchnorm_op.getX(), tf_batchnorm_op.getMean());
+  Value x = tf_batchnorm_op.getX();
+  Value mean = tf_batchnorm_op.getMean();
 
+  Value op1_sub_input_mean = CreateOpAndInfer<tosa::SubOp>(
+      rewriter, op->getLoc(), output_type, x, mean);
+
+  Value variance = tf_batchnorm_op.getVariance();
   RankedTensorType variance_type =
-      dyn_cast<RankedTensorType>(tf_batchnorm_op.getVariance().getType());
+      dyn_cast<RankedTensorType>(variance.getType());
   if (!variance_type) return failure();
 
   auto epsilon_type =
@@ -1481,30 +1438,27 @@ LogicalResult ConvertTFFusedBatchNormV3Op::matchAndRewrite(
   auto epsilon_const = CreateOpAndInfer<tosa::ConstOp>(
       rewriter, op->getLoc(), epsilon_type, epsilon_attr);
 
-  auto op2_add_var_epsilon = CreateOpAndInfer<tosa::AddOp>(
-      rewriter, op->getLoc(), tf_batchnorm_op.getVariance().getType(),
-      tf_batchnorm_op.getVariance(), epsilon_const);
+  variance_type = variance.getType().cast<RankedTensorType>();
+  Value op2_add_var_epsilon = CreateOpAndInfer<tosa::AddOp>(
+      rewriter, op->getLoc(), variance_type, variance, epsilon_const);
 
-  auto op3_rsqrt_op2 = CreateOpAndInfer<tosa::RsqrtOp>(
-      rewriter, op->getLoc(), tf_batchnorm_op.getVariance().getType(),
-      op2_add_var_epsilon.getResult());
+  Value op3_rsqrt_op2 = CreateOpAndInfer<tosa::RsqrtOp>(
+      rewriter, op->getLoc(), variance_type, op2_add_var_epsilon);
 
-  auto op4_mul_op1_op3 = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, op->getLoc(), tf_batchnorm_op.getResult(0).getType(),
-      op1_sub_input_mean.getResult(), op3_rsqrt_op2.getResult(),
-      rewriter.getI8IntegerAttr(0));
+  Value op4_mul_op1_op3 =
+      CreateMulOpAndInfer(rewriter, op, tf_batchnorm_op.getResult(0).getType(),
+                          op1_sub_input_mean, op3_rsqrt_op2);
 
-  auto op5_mul_op4_scale = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, op->getLoc(), tf_batchnorm_op.getResult(0).getType(),
-      op4_mul_op1_op3.getResult(), tf_batchnorm_op.getScale(),
-      rewriter.getI8IntegerAttr(0));
+  Value scale = tf_batchnorm_op.getScale();
+  Value op5_mul_op4_scale =
+      CreateMulOpAndInfer(rewriter, op, output_type, op4_mul_op1_op3, scale);
 
-  auto op6_add_op5_offset = CreateOpAndInfer<tosa::AddOp>(
-      rewriter, op->getLoc(), tf_batchnorm_op.getResult(0).getType(),
-      op5_mul_op4_scale.getResult(), tf_batchnorm_op.getOffset());
+  Value offset = tf_batchnorm_op.getOffset();
+  Value op6_add_op5_offset = CreateOpAndInfer<tosa::AddOp>(
+      rewriter, op->getLoc(), output_type, op5_mul_op4_scale, offset);
 
   llvm::SmallVector<Value> replacements = {
-      op6_add_op5_offset.getResult(), tf_batchnorm_op.getMean(),
+      op6_add_op5_offset, tf_batchnorm_op.getMean(),
       tf_batchnorm_op.getVariance(),
       // The last three are reserved spaces and have no purpose currently.
       tf_batchnorm_op.getMean(), tf_batchnorm_op.getVariance(),
@@ -1522,9 +1476,15 @@ LogicalResult ConvertTFBiasAddOp::matchAndRewrite(
   // Not a ranked tensor output
   if (!output_type) return failure();
 
-  auto add_op = CreateOpAndInfer<tosa::AddOp>(
-      rewriter, op->getLoc(), output_type, tf_biasadd_op.getValue(),
-      tf_biasadd_op.getBias());
+  Value x = tf_biasadd_op.getValue();
+  Value bias = tf_biasadd_op.getBias();
+
+  RankedTensorType x_type = dyn_cast<RankedTensorType>(x.getType());
+  RankedTensorType bias_type = dyn_cast<RankedTensorType>(bias.getType());
+  if (!x_type || !bias_type) return failure();
+
+  auto add_op = CreateOpAndInfer<tosa::AddOp>(rewriter, op->getLoc(),
+                                              output_type, x, bias);
 
   rewriter.replaceOp(op, {add_op.getResult()});
   return success();
@@ -1731,10 +1691,12 @@ LogicalResult ConvertTFLessOp::matchAndRewrite(
   // Not a ranked tensor output
   if (!output_type) return failure();
 
+  Value x = tf_less_op.getX();
+  Value y = tf_less_op.getY();
+
   // less(x, y) is not(greater_equal(x, y))
   auto greater_equal_op = CreateOpAndInfer<tosa::GreaterEqualOp>(
-      rewriter, op->getLoc(), output_type, tf_less_op.getX(),
-      tf_less_op.getY());
+      rewriter, op->getLoc(), output_type, x, y);
 
   auto not_op = CreateOpAndInfer<tosa::LogicalNotOp>(
       rewriter, op->getLoc(), output_type, greater_equal_op.getResult());
@@ -1752,10 +1714,13 @@ LogicalResult ConvertTFLessEqualOp::matchAndRewrite(
   // Not a ranked tensor output
   if (!output_type) return failure();
 
+  Value x = tf_less_equal_op.getX();
+  Value y = tf_less_equal_op.getY();
+
   // less_equal(x, y) is not(greater(x, y))
-  auto greater_op = CreateOpAndInfer<tosa::GreaterOp>(
-      rewriter, op->getLoc(), output_type, tf_less_equal_op.getX(),
-      tf_less_equal_op.getY());
+  auto greater_op = CreateOpAndInfer<tosa::GreaterOp>(rewriter, op->getLoc(),
+                                                      output_type, x, y);
+
   auto not_op = CreateOpAndInfer<tosa::LogicalNotOp>(
       rewriter, op->getLoc(), output_type, greater_op.getResult());
 
@@ -2175,11 +2140,12 @@ LogicalResult ConvertTFLeakyReluOp::matchAndRewrite(
     alpha = tmpAttr.getValueAsDouble();
   }
 
-  Value const_zero = getTosaConstTensorSingleF32(rewriter, op, 0.0);
+  int rank = output_type.getRank();
+  Value const_zero = getTosaConstTensorSingleF32(rewriter, op, 0.0, rank);
 
-  auto a1_mul = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, op->getLoc(), output_type, tf_leakyrelu_op.getFeatures(),
-      getTosaConstTensorSingleF32(rewriter, op, alpha), 0);
+  auto a1_mul = CreateMulOpAndInfer(
+      rewriter, op, output_type, tf_leakyrelu_op.getFeatures(),
+      getTosaConstTensorSingleF32(rewriter, op, alpha, rank));
 
   auto a2_ge = CreateOpAndInfer<tosa::GreaterEqualOp>(
       rewriter, op->getLoc(), UnrankedTensorType::get(rewriter.getI1Type()),
@@ -2322,9 +2288,15 @@ LogicalResult ConvertTFLeftShiftOp::matchAndRewrite(
       dyn_cast<TensorType>(tf_left_shift_op.getResult().getType());
   if (!output_type) return failure();
 
+  Value x = tf_left_shift_op.getX();
+  Value y = tf_left_shift_op.getY();
+
+  RankedTensorType x_type = dyn_cast<RankedTensorType>(x.getType());
+  RankedTensorType y_type = dyn_cast<RankedTensorType>(y.getType());
+  if (!x_type || !y_type) return failure();
+
   CreateReplaceOpAndInfer<tosa::LogicalLeftShiftOp>(rewriter, op, output_type,
-                                                    tf_left_shift_op.getX(),
-                                                    tf_left_shift_op.getY());
+                                                    x, y);
 
   return success();
 }
@@ -2339,6 +2311,13 @@ LogicalResult ConvertTFRightShiftOp::matchAndRewrite(
       dyn_cast<TensorType>(tf_right_shift_op.getResult().getType());
   if (!output_type) return failure();
 
+  Value x = tf_right_shift_op.getX();
+  Value y = tf_right_shift_op.getY();
+
+  RankedTensorType x_type = dyn_cast<RankedTensorType>(x.getType());
+  RankedTensorType y_type = dyn_cast<RankedTensorType>(y.getType());
+  if (!x_type || !y_type) return failure();
+
   Type output_element_type = output_type.getElementType();
 
   bool is_signed = false;
@@ -2346,12 +2325,10 @@ LogicalResult ConvertTFRightShiftOp::matchAndRewrite(
 
   if (is_signed) {
     CreateReplaceOpAndInfer<tosa::ArithmeticRightShiftOp>(
-        rewriter, op, output_type, tf_right_shift_op.getX(),
-        tf_right_shift_op.getY(), false);
+        rewriter, op, output_type, x, y, false);
   } else {
-    CreateReplaceOpAndInfer<tosa::LogicalRightShiftOp>(
-        rewriter, op, output_type, tf_right_shift_op.getX(),
-        tf_right_shift_op.getY());
+    CreateReplaceOpAndInfer<tosa::LogicalRightShiftOp>(rewriter, op,
+                                                       output_type, x, y);
   }
 
   return success();
@@ -2471,6 +2448,61 @@ LogicalResult ConvertTFBroadcastToOp::matchAndRewrite(
   return success();
 }
 
+LogicalResult ConvertTFEqualOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::EqualOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFGreaterOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::GreaterOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFGreaterEqualOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::GreaterEqualOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFMaximumOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::MaximumOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFMinimumOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::MinimumOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFBitwiseOrOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::BitwiseOrOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFBitwiseXorOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::BitwiseXorOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFBitwiseAndOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::BitwiseAndOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFLogicalAndOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::LogicalAndOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFLogicalOrOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::LogicalOrOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFPowOp::matchAndRewrite(Operation* op,
+                                              PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::PowOp>(op, rewriter);
+}
+
 void LegalizeTF::runOnOperation() {
   auto* ctx = &getContext();
   RewritePatternSet patterns(ctx);
@@ -2575,6 +2607,12 @@ void populateLegalizeTFPatterns(MLIRContext* ctx, RewritePatternSet& patterns) {
   patterns.add<ConvertTFOneHotOp>(ctx);
   patterns.add<ConvertTFBatchMatMulV2Op>(ctx);
   patterns.add<ConvertTFBroadcastToOp>(ctx);
+  patterns.add<ConvertTFBitwiseOrOp>(ctx);
+  patterns.add<ConvertTFBitwiseXorOp>(ctx);
+  patterns.add<ConvertTFBitwiseAndOp>(ctx);
+  patterns.add<ConvertTFLogicalAndOp>(ctx);
+  patterns.add<ConvertTFLogicalOrOp>(ctx);
+  patterns.add<ConvertTFPowOp>(ctx);
 }
 
 // Creates an instance of the TensorFlow dialect LegalizeTF pass.

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -203,6 +203,9 @@ DECL_CONVERT_OP(While);
 DECL_CONVERT_OP(Real);
 DECL_CONVERT_OP(Imag);
 DECL_CONVERT_OP(RFFT2d);
+DECL_CONVERT_OP(LogicalAnd);
+DECL_CONVERT_OP(LogicalOr);
+DECL_CONVERT_OP(Pow);
 DECL_CONVERT_OP(BroadcastTo);
 
 #undef DECL_CONVERT_OP
@@ -267,44 +270,37 @@ LogicalResult ConvertTFLGeluOp::matchAndRewrite(
   //   op6 = mul(x, 0.5)
   //   op7 = mul(op6, op5)
 
-  auto fp_scalar_ty = RankedTensorType::get({}, rewriter.getF32Type());
-
-  Value cst_3 = rewriter.create<tosa::ConstOp>(
-      loc, fp_scalar_ty, DenseElementsAttr::get(fp_scalar_ty, {3.0f}));
+  auto rank = input_type.getRank();
+  Value cst_3 = getTosaConstTensorSingleF32(rewriter, op, 3.0f, rank);
   auto op0_pow_3 =
       CreateOpAndInfer<tosa::PowOp>(rewriter, loc, output_type, input, cst_3);
 
-  Value cst_004 = rewriter.create<tosa::ConstOp>(
-      loc, fp_scalar_ty, DenseElementsAttr::get(fp_scalar_ty, {4.471500e-02f}));
+  Value cst_004 =
+      getTosaConstTensorSingleF32(rewriter, op, 4.471500e-02f, rank);
   auto op1_mul_op0_004 =
-      CreateOpAndInfer<tosa::MulOp>(rewriter, loc, output_type, op0_pow_3,
-                                    cst_004, rewriter.getI8IntegerAttr(0));
+      CreateMulOpAndInfer(rewriter, op, output_type, op0_pow_3, cst_004);
 
   auto op2_add_x_op1 = CreateOpAndInfer<tosa::AddOp>(rewriter, loc, output_type,
                                                      input, op1_mul_op0_004);
 
-  Value cst_sqrt2pi = rewriter.create<tosa::ConstOp>(
-      loc, fp_scalar_ty, DenseElementsAttr::get(fp_scalar_ty, {0.797884583f}));
-  auto op3_mul_op2_sqrt2pi =
-      CreateOpAndInfer<tosa::MulOp>(rewriter, loc, output_type, op2_add_x_op1,
-                                    cst_sqrt2pi, rewriter.getI8IntegerAttr(0));
+  Value cst_sqrt2pi =
+      getTosaConstTensorSingleF32(rewriter, op, 0.797884583f, rank);
+  auto op3_mul_op2_sqrt2pi = CreateMulOpAndInfer(rewriter, op, output_type,
+                                                 op2_add_x_op1, cst_sqrt2pi);
 
   auto op4_tanh_op3 = CreateOpAndInfer<tosa::TanhOp>(rewriter, loc, output_type,
                                                      op3_mul_op2_sqrt2pi);
 
-  Value cst_1 = rewriter.create<tosa::ConstOp>(
-      loc, fp_scalar_ty, DenseElementsAttr::get(fp_scalar_ty, {1.0f}));
+  Value cst_1 = getTosaConstTensorSingleF32(rewriter, op, 1.0f, rank);
   auto op5_add_op4_1 = CreateOpAndInfer<tosa::AddOp>(rewriter, loc, output_type,
                                                      op4_tanh_op3, cst_1);
 
-  Value cst_05 = rewriter.create<tosa::ConstOp>(
-      loc, fp_scalar_ty, DenseElementsAttr::get(fp_scalar_ty, {0.5f}));
-  auto op6_mul_x_05 = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, loc, output_type, input, cst_05, rewriter.getI8IntegerAttr(0));
+  Value cst_05 = getTosaConstTensorSingleF32(rewriter, op, 0.5f, rank);
+  auto op6_mul_x_05 =
+      CreateMulOpAndInfer(rewriter, op, output_type, input, cst_05);
 
-  auto op7_mul_op6_op5 = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, loc, output_type, op6_mul_x_05, op5_add_op4_1,
-      rewriter.getI8IntegerAttr(0));
+  auto op7_mul_op6_op5 = CreateMulOpAndInfer(rewriter, op, output_type,
+                                             op6_mul_x_05, op5_add_op4_1);
 
   rewriter.replaceOp(op, {op7_mul_op6_op5.getResult()});
 
@@ -674,13 +670,13 @@ static LogicalResult matchAndRewriteAddSub(Operation* op,
                                            PatternRewriter& rewriter) {
   auto tfl_add_op = cast<TflOp>(op);
 
-  ShapedType input_lhs_type =
-      mlir::dyn_cast<ShapedType>(tfl_add_op.getLhs().getType());
-  ShapedType input_rhs_type =
-      mlir::dyn_cast<ShapedType>(tfl_add_op.getRhs().getType());
+  Value lhs = tfl_add_op.getLhs();
+  Value rhs = tfl_add_op.getRhs();
+
+  ShapedType input_lhs_type = mlir::dyn_cast<ShapedType>(lhs.getType());
+  ShapedType input_rhs_type = mlir::dyn_cast<ShapedType>(rhs.getType());
   ShapedType output_type =
       mlir::dyn_cast<ShapedType>(tfl_add_op.getResult().getType());
-  // Not a ranked tensor output
   if (!input_lhs_type || !input_rhs_type || !output_type) return failure();
 
   bool input_lhs_is_qtype = mlir::isa<mlir::quant::UniformQuantizedType>(
@@ -740,11 +736,11 @@ static LogicalResult matchAndRewriteAddSub(Operation* op,
 
 #if TFLITE_SINGLE_ROUNDING
     Value op1_rescale_lhs = buildRescaleToInt32(
-        rewriter, op, tfl_add_op.getLhs(),
+        rewriter, op, lhs,
         lhs_rescale_scale * static_cast<double>(1 << input_shift),
         input_lhs_qtype.getZeroPoint());
     Value op2_rescale_rhs = buildRescaleToInt32(
-        rewriter, op, tfl_add_op.getRhs(),
+        rewriter, op, rhs,
         rhs_rescale_scale * static_cast<double>(1 << input_shift),
         input_rhs_qtype.getZeroPoint());
 #else  // TFLITE_DOUBLE_ROUNDING
@@ -758,25 +754,24 @@ static LogicalResult matchAndRewriteAddSub(Operation* op,
     //    leaves a left shift of 15 impossible. Using a Cast + Shift instead.
     // 2. In other cases, we are scaling by lhs_rescale_scale*(1<<input_shift)
     if (lhs_rescale_scale == 0.5) {
-      op1_rescale_lhs =
-          buildRescaleToInt32(rewriter, op, tfl_add_op.getLhs(),
-                              lhs_rescale_scale * (1 << input_shift),
-                              input_lhs_qtype.getZeroPoint());
+      op1_rescale_lhs = buildRescaleToInt32(
+          rewriter, op, lhs, lhs_rescale_scale * (1 << input_shift),
+          input_lhs_qtype.getZeroPoint());
     } else {
       Value op1_none_half_scale_intermediate;
       if (output_qtype.getStorageTypeIntegralWidth() == 16) {
         auto tfl_add_lhs_casted = CreateOpAndInfer<tosa::CastOp>(
-            rewriter, op->getLoc(), rescale_type_input_left,
-            tfl_add_op.getLhs());
+            rewriter, op->getLoc(), rescale_type_input_left, lhs);
         op1_none_half_scale_intermediate =
             CreateOpAndInfer<tosa::LogicalLeftShiftOp>(
                 rewriter, op->getLoc(), rescale_type_input_left,
                 tfl_add_lhs_casted.getResult(),
-                getTosaConstTensorSingleI32(rewriter, op, input_shift));
+                getTosaConstTensorSingleI32(rewriter, op, input_shift,
+                                            input_lhs_type.getRank()));
       } else {
-        op1_none_half_scale_intermediate = buildRescaleToInt32(
-            rewriter, op, tfl_add_op.getLhs(), (1 << input_shift),
-            input_lhs_qtype.getZeroPoint());
+        op1_none_half_scale_intermediate =
+            buildRescaleToInt32(rewriter, op, lhs, (1 << input_shift),
+                                input_lhs_qtype.getZeroPoint());
       }
       op1_rescale_lhs = buildRescaleToInt32(
           rewriter, op, op1_none_half_scale_intermediate, lhs_rescale_scale, 0);
@@ -789,25 +784,24 @@ static LogicalResult matchAndRewriteAddSub(Operation* op,
     //    leaves a left shift of 15 impossible. Using a Cast + Shift instead.
     // 2. In other cases, we are scaling by rhs_rescale_scale*(1<<input_shift)
     if (rhs_rescale_scale == 0.5) {
-      op2_rescale_rhs =
-          buildRescaleToInt32(rewriter, op, tfl_add_op.getRhs(),
-                              rhs_rescale_scale * (1 << input_shift),
-                              input_rhs_qtype.getZeroPoint());
+      op2_rescale_rhs = buildRescaleToInt32(
+          rewriter, op, rhs, rhs_rescale_scale * (1 << input_shift),
+          input_rhs_qtype.getZeroPoint());
     } else {
       Value op2_none_half_scale_intermediate;
       if (output_qtype.getStorageTypeIntegralWidth() == 16) {
         auto tfl_add_rhs_casted = CreateOpAndInfer<tosa::CastOp>(
-            rewriter, op->getLoc(), rescale_type_input_right,
-            tfl_add_op.getRhs());
+            rewriter, op->getLoc(), rescale_type_input_right, rhs);
         op2_none_half_scale_intermediate =
             CreateOpAndInfer<tosa::LogicalLeftShiftOp>(
                 rewriter, op->getLoc(), rescale_type_input_right,
                 tfl_add_rhs_casted.getResult(),
-                getTosaConstTensorSingleI32(rewriter, op, input_shift));
+                getTosaConstTensorSingleI32(rewriter, op, input_shift,
+                                            input_rhs_type.getRank()));
       } else {
-        op2_none_half_scale_intermediate = buildRescaleToInt32(
-            rewriter, op, tfl_add_op.getRhs(), (1 << input_shift),
-            input_rhs_qtype.getZeroPoint());
+        op2_none_half_scale_intermediate =
+            buildRescaleToInt32(rewriter, op, rhs, (1 << input_shift),
+                                input_rhs_qtype.getZeroPoint());
       }
       op2_rescale_rhs = buildRescaleToInt32(
           rewriter, op, op2_none_half_scale_intermediate, rhs_rescale_scale, 0);
@@ -824,8 +818,7 @@ static LogicalResult matchAndRewriteAddSub(Operation* op,
     output = op4_rescale_op3;
   } else {
     auto op1_add_in =
-        CreateOpAndInfer<TosaOp>(rewriter, op->getLoc(), output_type,
-                                 tfl_add_op.getLhs(), tfl_add_op.getRhs());
+        CreateOpAndInfer<TosaOp>(rewriter, op->getLoc(), output_type, lhs, rhs);
 
     output = op1_add_in.getResult();
   }
@@ -965,20 +958,18 @@ LogicalResult ConvertTFLDivOp::matchAndRewrite(
   auto fused_activation_fn = tfl_div_op.getFusedActivationFunctionAttr();
 
   Type element_type = output_type.getElementType();
+  Value lhs = tfl_div_op.getLhs();
+  Value rhs = tfl_div_op.getRhs();
   Value div_op;
   if (mlir::isa<IntegerType>(element_type)) {
-    div_op =
-        CreateOpAndInfer<tosa::IntDivOp>(
-            rewriter, op->getLoc(), output_type, tfl_div_op.getLhs(),
-            tfl_div_op.getRhs())
-            .getResult();
+    div_op = CreateOpAndInfer<tosa::IntDivOp>(rewriter, op->getLoc(),
+                                              output_type, lhs, rhs)
+                 .getResult();
   } else {
     auto reciprocal_op = CreateOpAndInfer<tosa::ReciprocalOp>(
-        rewriter, op->getLoc(), tfl_div_op.getRhs().getType(),
-        tfl_div_op.getRhs());
-    div_op = CreateOpAndInfer<tosa::MulOp>(
-                 rewriter, op->getLoc(), output_type, tfl_div_op.getLhs(),
-                 reciprocal_op.getResult(), rewriter.getI8IntegerAttr(0))
+        rewriter, op->getLoc(), rhs.getType(), rhs);
+    div_op = CreateMulOpAndInfer(rewriter, op, output_type, lhs,
+                                 reciprocal_op.getResult())
                  .getResult();
   }
 
@@ -1001,10 +992,11 @@ LogicalResult ConvertTFLMaximumOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_max_op = cast<TFL::MaximumOp>(op);
 
-  ShapedType input_lhs_type =
-      dyn_cast<ShapedType>(tfl_max_op.getLhs().getType());
-  ShapedType input_rhs_type =
-      dyn_cast<ShapedType>(tfl_max_op.getRhs().getType());
+  Value lhs = tfl_max_op.getLhs();
+  Value rhs = tfl_max_op.getRhs();
+
+  ShapedType input_lhs_type = dyn_cast<ShapedType>(lhs.getType());
+  ShapedType input_rhs_type = dyn_cast<ShapedType>(rhs.getType());
   ShapedType output_type =
       dyn_cast<ShapedType>(tfl_max_op.getResult().getType());
 
@@ -1029,10 +1021,8 @@ LogicalResult ConvertTFLMaximumOp::matchAndRewrite(
   if (output_is_qtype) {
     ShapedType rescale_type = output_type.clone(rewriter.getI32Type());
 
-    Value op1_rescale_lhs =
-        removeZeroPointAndCastToInt32(rewriter, op, tfl_max_op.getLhs(), 0);
-    Value op2_rescale_rhs =
-        removeZeroPointAndCastToInt32(rewriter, op, tfl_max_op.getRhs(), 0);
+    Value op1_rescale_lhs = removeZeroPointAndCastToInt32(rewriter, op, lhs, 0);
+    Value op2_rescale_rhs = removeZeroPointAndCastToInt32(rewriter, op, rhs, 0);
 
     auto op3_max_op1_op2 = CreateOpAndInfer<tosa::MaximumOp>(
         rewriter, op->getLoc(), rescale_type, op1_rescale_lhs, op2_rescale_rhs);
@@ -1042,9 +1032,8 @@ LogicalResult ConvertTFLMaximumOp::matchAndRewrite(
 
     output = op4_rescale_op3;
   } else {
-    auto op1_max_in = CreateOpAndInfer<tosa::MaximumOp>(
-        rewriter, op->getLoc(), output_type, tfl_max_op.getLhs(),
-        tfl_max_op.getRhs());
+    auto op1_max_in = CreateOpAndInfer<tosa::MaximumOp>(rewriter, op->getLoc(),
+                                                        output_type, lhs, rhs);
 
     output = op1_max_in.getResult();
   }
@@ -1058,10 +1047,11 @@ LogicalResult ConvertTFLMinimumOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto tfl_min_op = cast<TFL::MinimumOp>(op);
 
-  ShapedType input_lhs_type =
-      dyn_cast<ShapedType>(tfl_min_op.getLhs().getType());
-  ShapedType input_rhs_type =
-      dyn_cast<ShapedType>(tfl_min_op.getRhs().getType());
+  Value lhs = tfl_min_op.getLhs();
+  Value rhs = tfl_min_op.getRhs();
+
+  ShapedType input_lhs_type = dyn_cast<ShapedType>(lhs.getType());
+  ShapedType input_rhs_type = dyn_cast<ShapedType>(rhs.getType());
   ShapedType output_type =
       dyn_cast<ShapedType>(tfl_min_op.getResult().getType());
   // Not a shaped tensor output
@@ -1085,11 +1075,8 @@ LogicalResult ConvertTFLMinimumOp::matchAndRewrite(
   if (output_is_qtype) {
     ShapedType rescale_type = output_type.clone(rewriter.getI32Type());
 
-    Value op1_rescale_lhs =
-        removeZeroPointAndCastToInt32(rewriter, op, tfl_min_op.getLhs(), 0);
-    Value op2_rescale_rhs =
-        removeZeroPointAndCastToInt32(rewriter, op, tfl_min_op.getRhs(), 0);
-
+    Value op1_rescale_lhs = removeZeroPointAndCastToInt32(rewriter, op, lhs, 0);
+    Value op2_rescale_rhs = removeZeroPointAndCastToInt32(rewriter, op, rhs, 0);
     auto op3_min_op1_op2 = CreateOpAndInfer<tosa::MinimumOp>(
         rewriter, op->getLoc(), rescale_type, op1_rescale_lhs, op2_rescale_rhs);
 
@@ -1098,9 +1085,8 @@ LogicalResult ConvertTFLMinimumOp::matchAndRewrite(
 
     output = op4_rescale_op3;
   } else {
-    auto op1_min_in = CreateOpAndInfer<tosa::MinimumOp>(
-        rewriter, op->getLoc(), output_type, tfl_min_op.getLhs(),
-        tfl_min_op.getRhs());
+    auto op1_min_in = CreateOpAndInfer<tosa::MinimumOp>(rewriter, op->getLoc(),
+                                                        output_type, lhs, rhs);
 
     output = op1_min_in.getResult();
   }
@@ -1153,14 +1139,17 @@ LogicalResult ConvertTFLAddNOp::matchAndRewrite(
 
   assert(inputs.size() >= 2);
 
-  auto newOp = CreateOpAndInfer<tosa::AddOp>(rewriter, op->getLoc(),
-                                             output_type, inputs[0], inputs[1]);
+  Value x = inputs[0];
+  Value y = inputs[1];
+  Value newValue =
+      CreateOpAndInfer<tosa::AddOp>(rewriter, op->getLoc(), output_type, x, y);
   for (int i = 2; i < inputs.size(); i++) {
-    newOp = CreateOpAndInfer<tosa::AddOp>(rewriter, op->getLoc(), output_type,
-                                          inputs[i], newOp.getResult());
+    Value next = inputs[i];
+    newValue = CreateOpAndInfer<tosa::AddOp>(rewriter, op->getLoc(),
+                                             output_type, next, newValue);
   }
 
-  rewriter.replaceOp(op, {newOp.getResult()});
+  rewriter.replaceOp(op, {newValue});
 
   return success();
 }
@@ -2774,24 +2763,24 @@ LogicalResult ConvertTFLL2NormalizationOp::matchAndRewrite(
 
   if (!input_ty.hasRank()) return failure();
 
+  auto rank = input_ty.getRank();
+
   if (input_ty.getElementType().isF32()) {
-    auto shift = rewriter.getIntegerAttr(rewriter.getI8Type(), 0);
     auto result_ty = UnrankedTensorType::get(input_ty.getElementType());
-    auto mul = CreateOpAndInfer<tosa::MulOp>(rewriter, loc, result_ty, input,
-                                             input, shift);
+    auto mul = CreateMulOpAndInfer(rewriter, op, result_ty, input, input);
     auto sum = CreateOpAndInfer<tosa::ReduceSumOp>(
         rewriter, loc, result_ty, mul,
         rewriter.getI32IntegerAttr(input_ty.getRank() - 1));
 
     SmallVector<float> min(1, sqrt(std::numeric_limits<float>::min()));
-    Value min_val = getConstTensor<float>(rewriter, op, min, {}).value();
+    Value min_val = getTosaConstTensorSingleF32(
+        rewriter, op, sqrt(std::numeric_limits<float>::min()), rank);
     auto max = CreateOpAndInfer<tosa::MaximumOp>(rewriter, loc, result_ty, sum,
                                                  min_val);
     auto rsqrt = CreateOpAndInfer<tosa::RsqrtOp>(rewriter, loc, result_ty, max)
                      .getResult();
-    Value result = CreateOpAndInfer<tosa::MulOp>(rewriter, loc, result_ty,
-                                                 rsqrt, input, shift)
-                       .getResult();
+    Value result =
+        CreateMulOpAndInfer(rewriter, op, result_ty, rsqrt, input).getResult();
 
     auto fused_activation_fn = tfl_l2norm_op.getFusedActivationFunctionAttr();
 
@@ -3271,10 +3260,10 @@ LogicalResult ConvertTFLBucketizeOp::matchAndRewrite(
 
   auto boundaries_input_type =
       boundaries_type.clone(input_type.getElementType());
-  auto boundaries_op_casted = CreateOpAndInfer<tosa::CastOp>(
+  Value boundaries_op_casted = CreateOpAndInfer<tosa::CastOp>(
       rewriter, loc, boundaries_input_type, boundaries_op);
 
-  auto reshaped_input = CreateOpAndInfer<tosa::ReshapeOp>(
+  Value reshaped_input = CreateOpAndInfer<tosa::ReshapeOp>(
       rewriter, loc, input_type.clone(new_input_shape), input,
       rewriter.getDenseI64ArrayAttr(new_input_shape));
 
@@ -3378,7 +3367,9 @@ LogicalResult ConvertTFLHardSwishOp::matchAndRewrite(
     // op5 = reciprocal(6)
     // op6 = mul (op4, op5)
 
-    Value op1_value = getTosaConstTensorSingleF32(rewriter, op, 3.0);
+    auto rank = input_type.getRank();
+
+    Value op1_value = getTosaConstTensorSingleF32(rewriter, op, 3.0, rank);
 
     auto op2_add_x_op1 =
         CreateOpAndInfer<tosa::AddOp>(rewriter, op->getLoc(), output_type,
@@ -3389,17 +3380,17 @@ LogicalResult ConvertTFLHardSwishOp::matchAndRewrite(
         rewriter.getI64IntegerAttr(0), rewriter.getI64IntegerAttr(0),
         rewriter.getF32FloatAttr(0.0f), rewriter.getF32FloatAttr(6.0f));
 
-    auto op4_mul_x_op3 = CreateOpAndInfer<tosa::MulOp>(
-        rewriter, op->getLoc(), output_type, tfl_hardswish_op.getInput(),
-        op3_relu_op2_6.getResult(), 0);
+    auto op4_mul_x_op3 = CreateMulOpAndInfer(rewriter, op, output_type,
+                                             tfl_hardswish_op.getInput(),
+                                             op3_relu_op2_6.getResult());
 
-    auto const_6 = getTosaConstTensorSingleF32(rewriter, op, 6.0);
+    auto const_6 = getTosaConstTensorSingleF32(rewriter, op, 6.0, rank);
     auto op5_reciprocal_6 = CreateOpAndInfer<tosa::ReciprocalOp>(
         rewriter, op->getLoc(), const_6.getType(), const_6);
 
-    auto op6_mul_op4_op5 = CreateOpAndInfer<tosa::MulOp>(
-        rewriter, op->getLoc(), output_type, op4_mul_x_op3.getResult(),
-        op5_reciprocal_6.getResult(), 0);
+    auto op6_mul_op4_op5 = CreateMulOpAndInfer(rewriter, op, output_type,
+                                               op4_mul_x_op3.getResult(),
+                                               op5_reciprocal_6.getResult());
 
     rewriter.replaceOp(op, {op6_mul_op4_op5.getResult()});
   }
@@ -3466,11 +3457,12 @@ LogicalResult ConvertTFLAtan2Op::matchAndRewrite(
   //
   // arctan(-z) = -arctan(z)                                        (1)
 
-  Value pi = getTosaConstTensorSingleF32(rewriter, op, M_PI);
-  Value pi_2 = getTosaConstTensorSingleF32(rewriter, op, M_PI_2);
-  Value zero = getTosaConstTensorSingleF32(rewriter, op, 0.0);
-  Value one = getTosaConstTensorSingleF32(rewriter, op, 1.0);
-  Value two = getTosaConstTensorSingleF32(rewriter, op, 2.0);
+  auto rank = input_x_ty.getRank();
+  Value pi = getTosaConstTensorSingleF32(rewriter, op, M_PI, rank);
+  Value pi_2 = getTosaConstTensorSingleF32(rewriter, op, M_PI_2, rank);
+  Value zero = getTosaConstTensorSingleF32(rewriter, op, 0.0, rank);
+  Value one = getTosaConstTensorSingleF32(rewriter, op, 1.0, rank);
+  Value two = getTosaConstTensorSingleF32(rewriter, op, 2.0, rank);
 
   // 1. Restrict the input to the atan lookup from [-inf, inf] to [0, 1].
   // By utilizing (0) and (1) we compute: min(|x|, |y|) / max(|x|, |y|).
@@ -3484,15 +3476,15 @@ LogicalResult ConvertTFLAtan2Op::matchAndRewrite(
                                                   abs_y, abs_x);
   auto recip =
       CreateOpAndInfer<tosa::ReciprocalOp>(rewriter, loc, input_y_ty, max_xy);
-  auto atan_input = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, loc, input_y_ty, recip, min_xy, rewriter.getI8IntegerAttr(0));
+  auto atan_input =
+      CreateMulOpAndInfer(rewriter, op, input_y_ty, recip, min_xy);
 
   // 2. Scale and translate the normalized domain to the table domain. This
   // includes a translating and scaling to [-int16_max, int16_max] and casting
   // to an i16 as it is the highest precision the table operation supports.
   auto fp_scalar_ty = RankedTensorType::get({}, rewriter.getF32Type());
-  auto scale_up = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, loc, input_y_ty, atan_input, two, rewriter.getI8IntegerAttr(0));
+  auto scale_up =
+      CreateMulOpAndInfer(rewriter, op, input_y_ty, atan_input, two);
   auto translate =
       CreateOpAndInfer<tosa::SubOp>(rewriter, loc, input_y_ty, scale_up, one);
   Value int_limit = rewriter.create<tosa::ConstOp>(
@@ -3501,8 +3493,7 @@ LogicalResult ConvertTFLAtan2Op::matchAndRewrite(
           fp_scalar_ty,
           {static_cast<float>(std::numeric_limits<int16_t>::max())}));
   auto int_scaled =
-      CreateOpAndInfer<tosa::MulOp>(rewriter, loc, input_y_ty, translate,
-                                    int_limit, rewriter.getI8IntegerAttr(0));
+      CreateMulOpAndInfer(rewriter, op, input_y_ty, translate, int_limit);
 
   auto int16_ty = input_y_ty.clone(rewriter.getIntegerType(16));
   auto casted =
@@ -3526,9 +3517,8 @@ LogicalResult ConvertTFLAtan2Op::matchAndRewrite(
       DenseElementsAttr::get(
           fp_scalar_ty,
           {static_cast<float>(1.0 / static_cast<float>(1 << 22))}));
-  auto table_output =
-      CreateOpAndInfer<tosa::MulOp>(rewriter, loc, output_ty, table_result_fp,
-                                    output_scale, rewriter.getI8IntegerAttr(0));
+  auto table_output = CreateMulOpAndInfer(rewriter, op, output_ty,
+                                          table_result_fp, output_scale);
 
   auto bool_ty = output_ty.clone(rewriter.getIntegerType(1));
 
@@ -3709,11 +3699,9 @@ static LogicalResult LegalizeFloatingPointPrelu(Operation* op,
                                                 PatternRewriter& rewriter,
                                                 Value input, Value alpha,
                                                 ShapedType output_type) {
-  Value const_zero = getTosaConstTensorSingleF32(rewriter, op, 0.0);
-
-  auto mul = CreateOpAndInfer<tosa::MulOp>(rewriter, op->getLoc(), output_type,
-                                           input, alpha, 0);
-
+  Value mul = CreateMulOpAndInfer(rewriter, op, output_type, input, alpha);
+  auto rank = mul.getType().cast<ShapedType>().getRank();
+  Value const_zero = getTosaConstTensorSingleF32(rewriter, op, 0.0, rank);
   auto ge = CreateOpAndInfer<tosa::GreaterEqualOp>(
       rewriter, op->getLoc(), output_type.clone(rewriter.getIntegerType(1)),
       input, const_zero);
@@ -3761,8 +3749,8 @@ static LogicalResult LegalizeQuantizedPrelu(Operation* op,
 
   Value op_rescale_in = removeZeroPointAndCastToInt32(
       rewriter, op, input, input_qtype.getZeroPoint());
-
-  Value const_zero = getTosaConstTensorSingleI32(rewriter, op, 0);
+  auto rank = rescale_type.getRank();
+  Value const_zero = getTosaConstTensorSingleI32(rewriter, op, 0, rank);
   Value op_ge = CreateOpAndInfer<tosa::GreaterEqualOp>(
       rewriter, op->getLoc(), rescale_type.clone(rewriter.getI1Type()),
       op_rescale_in, const_zero);
@@ -3782,8 +3770,8 @@ static LogicalResult LegalizeQuantizedPrelu(Operation* op,
   Value op_rescale_alpha = removeZeroPointAndCastToInt32(
       rewriter, op, alpha, alpha_qtype.getZeroPoint());
 
-  Value op_mul = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, op->getLoc(), rescale_type, op_rescale_in, op_rescale_alpha, 0);
+  Value op_mul = CreateMulOpAndInfer(rewriter, op, rescale_type, op_rescale_in,
+                                     op_rescale_alpha);
 
   op_rescale_slope_in =
       buildRescale(rewriter, op, output_type, op_mul, scale_alpha,
@@ -3886,9 +3874,9 @@ static LogicalResult LegalizeFloatingPointLeakyRelu(Operation* op,
                                                     PatternRewriter& rewriter,
                                                     Value input, double alpha,
                                                     ShapedType output_type) {
-  Value const_alpha = getTosaConstTensorSingleF32(rewriter, op, alpha);
-  auto mul = CreateOpAndInfer<tosa::MulOp>(rewriter, op->getLoc(), output_type,
-                                           input, const_alpha, 0);
+  auto rank = input.getType().cast<ShapedType>().getRank();
+  Value const_alpha = getTosaConstTensorSingleF32(rewriter, op, alpha, rank);
+  auto mul = CreateMulOpAndInfer(rewriter, op, output_type, input, const_alpha);
   if (alpha <= 1.0) {
     // leaky_relu( input ) = max(input*alpha, input)
     CreateReplaceOpAndInfer<tosa::MaximumOp>(rewriter, op, output_type, mul,
@@ -4314,8 +4302,8 @@ LogicalResult ConvertTFLSparseToDenseOp::matchAndRewrite(
   Value multiply_constant = CreateOpAndInfer<tosa::ConstOp>(
       rewriter, loc, multiply_constant_type, multiply_constant_attr);
 
-  Value multiply_op = CreateOpAndInfer<tosa::MulOp>(
-      rewriter, loc, indices_ty, indices, multiply_constant, 0);
+  Value multiply_op =
+      CreateMulOpAndInfer(rewriter, op, indices_ty, indices, multiply_constant);
 
   Value reduce_op = CreateOpAndInfer<tosa::ReduceSumOp>(
       rewriter, loc, UnrankedTensorType::get(indices_ety), multiply_op,
@@ -4392,7 +4380,7 @@ LogicalResult ConvertTFLArgMinOp::matchAndRewrite(
     Operation* op, PatternRewriter& rewriter) const {
   auto arg_max_op = cast<TFL::ArgMinOp>(op);
   auto loc = arg_max_op.getLoc();
-  auto input = arg_max_op.getInput();
+  Value input = arg_max_op.getInput();
   auto input_ty = mlir::cast<ShapedType>(input.getType());
   Type input_ety = input_ty.getElementType();
 
@@ -4664,6 +4652,21 @@ LogicalResult ConvertTFLRFFT2dOp::matchAndRewrite(
       rewriter, op, output_type, concat.getResult());
 
   return success();
+}
+
+LogicalResult ConvertTFLLogicalAndOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::LogicalAndOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFLLogicalOrOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::LogicalOrOp>(op, rewriter);
+}
+
+LogicalResult ConvertTFLPowOp::matchAndRewrite(
+    Operation* op, PatternRewriter& rewriter) const {
+  return ConvertBinaryOp<tosa::PowOp>(op, rewriter);
 }
 
 LogicalResult ConvertTFLBroadcastToOp::matchAndRewrite(

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
@@ -577,6 +577,9 @@ Value getTosaConstShape(PatternRewriter& rewriter, Operation* op,
 
 // Create a vector from a 32-bit value tensor.  Returns the size of
 // the new vector or -1 on error.
+// Populate a int32_t vector from a val tensor
+// return failure if val is not a constant value
+// return success otherwise
 LogicalResult getVectorFromValue32(Value val, SmallVectorImpl<int32_t>& vec) {
   int i = 0;
 
@@ -588,6 +591,26 @@ LogicalResult getVectorFromValue32(Value val, SmallVectorImpl<int32_t>& vec) {
 
   for (auto idx : elems.getValues<IntegerAttr>()) {
     vec.push_back(idx.getInt());
+    i++;
+  }
+
+  return success();
+}
+
+// Populate a int64_t vector from a val tensor
+// return failure if val is not a constant value
+// return success otherwise
+LogicalResult getVectorFromValue64(Value val, SmallVectorImpl<int64_t>& vec) {
+  int i = 0;
+
+  ElementsAttr elems;
+
+  vec.clear();
+
+  if (!matchPattern(val, m_Constant(&elems))) return failure();
+
+  for (auto idx : elems.getValues<IntegerAttr>()) {
+    vec.push_back(static_cast<int64_t>(idx.getInt()));
     i++;
   }
 

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.h
@@ -137,9 +137,16 @@ Value getTosaConstTensorScalarInt(ImplicitLocOpBuilder& builder, Type type,
 Value getTosaConstShape(PatternRewriter& rewriter, Operation* op,
                         llvm::ArrayRef<int64_t> values);
 
-// Create a vector from a 32-bit value tensor.  Returns vector size on success
-// or -1 on error.
+
+// Populate a int32_t vector from a val tensor
+// return failure if val is not a constant value
+// return success otherwise
 LogicalResult getVectorFromValue32(Value val, SmallVectorImpl<int32_t>& vec);
+
+// Populate a int64_t vector from a val tensor
+// return failure if val is not a constant value
+// return success otherwise
+LogicalResult getVectorFromValue64(Value val, SmallVectorImpl<int64_t>& vec);
 
 // Calculates the TOSA padding values based on TF operators padded with
 // SAME/VALID.

--- a/tensorflow/compiler/mlir/tosa/transforms/tf_legalize_patterns.td
+++ b/tensorflow/compiler/mlir/tosa/transforms/tf_legalize_patterns.td
@@ -41,10 +41,3 @@ def : Pat<(TF_InvertOp $arg1), (Tosa_BitwiseNotOp $arg1)>;
 def : Pat<(TF_CastOp $in, BoolAttr : $truncate), (Tosa_CastOp $in)>;
 
 // Binary ops patterns.
-
-def : Pat<(TF_BitwiseOrOp $arg1, $arg2), (Tosa_BitwiseOrOp $arg1, $arg2)>;
-def : Pat<(TF_BitwiseXorOp $arg1, $arg2), (Tosa_BitwiseXorOp $arg1, $arg2)>;
-def : Pat<(TF_BitwiseAndOp $arg1, $arg2), (Tosa_BitwiseAndOp $arg1, $arg2)>;
-def : Pat<(TF_LogicalAndOp $l, $r), (Tosa_LogicalAndOp $l, $r)>;
-def : Pat<(TF_LogicalOrOp $l, $r), (Tosa_LogicalOrOp $l, $r)>;
-def : Pat<(TF_PowOp $l, $r), (Tosa_PowOp $l, $r)>;

--- a/tensorflow/compiler/mlir/tosa/transforms/tfl_legalize_patterns.td
+++ b/tensorflow/compiler/mlir/tosa/transforms/tfl_legalize_patterns.td
@@ -42,10 +42,6 @@ def ConvertQuantStatOp : Pat<(quantfork_StatisticsOp $value, $layer_stats, $axis
 // Binary ops patterns.
 //===----------------------------------------------------------------------===//
 
-def ConvertTFLLogicalAndOp : Pat<(TFL_LogicalAndOp $l, $r), (Tosa_LogicalAndOp $l, $r)>;
-def ConvertTFLLogicalOrOp : Pat<(TFL_LogicalOrOp $l, $r), (Tosa_LogicalOrOp $l, $r)>;
-def ConvertTFLPowOp : Pat<(TFL_PowOp $l, $r), (Tosa_PowOp $l, $r)>;
-
 //===----------------------------------------------------------------------===//
 // Ternary ops patterns.
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
We've been pushing TOSA v1.0 LLVM patches to upstream. This PR includes commits to keep the following operators to be aligned with LLVM: 

**Acc_type for Conv Operators:** 
LLVM Patch: https://github.com/llvm/llvm-project/pull/121466

**Tile Op Update**
LLVM Patch: https://github.com/llvm/llvm-project/pull/122547

**Pad Op Update**
LLVM Patch: https://github.com/llvm/llvm-project/pull/123133

**Equalize Ranks Update**
LLVM Patch: https://github.com/llvm/llvm-project/pull/104501
