### PR TITLE
Fix 03 broken links in index.md

### DIFF
--- a/tensorflow/lite/g3doc/models/build/index.md
+++ b/tensorflow/lite/g3doc/models/build/index.md
@@ -50,7 +50,7 @@ constraints in mind:
 
 For more information building effective, compatible, high performance models
 for TensorFlow Lite, see
-[Performance best practices](../../performance/best_practices).
+[Performance best practices](../../performance/best_practices.md).
 
 ### Model development
 
@@ -126,13 +126,13 @@ which provides an API that implements these techniques.
 * To convert your custom TensorFlow model, see the
   [Convert models overview](../convert).
 * See the
-  [operator compatibility](../../guide/ops_compatibility) guide to determine
+  [operator compatibility](../../guide/ops_compatibility.md) guide to determine
   if your model is compatible with TensorFlow Lite or if you'll need to take
   additional steps to make it compatible.
 * See the
   [performance best practices guide](https://www.tensorflow.org/lite/performance/best_practices)
   for guidance on making your TensorFlow Lite models efficient and performant.
-* See the [performance metrics guide](../../performance/measurement) to learn
+* See the [performance metrics guide](../../performance/measurement.md) to learn
   how to measure the performance of your model using benchmarking tools.
 
 


### PR DESCRIPTION
Hi, Team
I found 03 broken documentation links in this [index.md](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/models/build/index.md) file so I have updated those links to functional links. Please review and merge this change as appropriate.

Thank you for your consideration.