### PR TITLE
nvrtc-builtins are private don't link to them

### DIFF
--- a/third_party/gpus/cuda/hermetic/cuda_nvrtc.BUILD.tpl
+++ b/third_party/gpus/cuda/hermetic/cuda_nvrtc.BUILD.tpl
@@ -10,16 +10,11 @@ cc_import(
     shared_library = "lib/libnvrtc.so.%{libnvrtc_version}",
 )
 
-cc_import(
-    name = "nvrtc_builtins",
-    shared_library = "lib/libnvrtc-builtins.so.%{libnvrtc-builtins_version}",
-)
 %{multiline_comment}
 cc_library(
     name = "nvrtc",
     %{comment}deps = [
         %{comment}":nvrtc_main",
-        %{comment}":nvrtc_builtins",
     %{comment}],
     %{comment}linkopts = cuda_rpath_flags("nvidia/cuda_nvrtc/lib"),
     visibility = ["//visibility:public"],

--- a/third_party/xla/third_party/gpus/cuda/hermetic/cuda_nvrtc.BUILD.tpl
+++ b/third_party/xla/third_party/gpus/cuda/hermetic/cuda_nvrtc.BUILD.tpl
@@ -10,16 +10,11 @@ cc_import(
     shared_library = "lib/libnvrtc.so.%{libnvrtc_version}",
 )
 
-cc_import(
-    name = "nvrtc_builtins",
-    shared_library = "lib/libnvrtc-builtins.so.%{libnvrtc-builtins_version}",
-)
 %{multiline_comment}
 cc_library(
     name = "nvrtc",
     %{comment}deps = [
         %{comment}":nvrtc_main",
-        %{comment}":nvrtc_builtins",
     %{comment}],
     %{comment}linkopts = cuda_rpath_flags("nvidia/cuda_nvrtc/lib"),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This is a small patch to help with cuda compatibility. I do'nt think this is necessary and links to `lib/libnvrtc-builtins.so.12.6.85` which is not compatible accross different versions of cuda.

xref: https://github.com/conda-forge/tensorflow-feedstock/pull/414#issuecomment-2629135833