### PR TITLE
Fixed broken link in create.md

### DIFF
--- a/tensorflow/lite/g3doc/api_docs/python/tflite_model_maker/text_classifier/create.md
+++ b/tensorflow/lite/g3doc/api_docs/python/tflite_model_maker/text_classifier/create.md
@@ -57,7 +57,7 @@ Loads data and train the model for test classification.
     <tr>
       <td>
   <ul>
-    <li><a href="https://www.tensorflow.org/lite/models/modify/model_maker/text_classification">Text classification with TensorFlow Lite Model Maker</a></li>
+    <li><a href="https://ai.google.dev/edge/litert/libraries/modify/text_classification">Text classification with TensorFlow Lite Model Maker</a></li>
   </ul>
 </td>
     </tr>


### PR DESCRIPTION
Hello Team,
I found 01 broken documentation link for [TensorFlow Lite Model Maker for text Classfication](https://www.tensorflow.org/lite/models/modify/model_maker/text_classification)  hyperlinks in create.md file.  So I have updated those links to functional links.

Please review and merge this change as appropriate.

Thank you!