### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/data/experimental/benchmarks/parameter_value_benchmark.py
+++ b/tensorflow/python/data/experimental/benchmarks/parameter_value_benchmark.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Benchmarks to compare effect of different paramemter values on the performance."""
+"""Benchmarks to compare effect of different parameter values on the performance."""
 import time
 import numpy as np
 
@@ -38,7 +38,7 @@ def map_function(x):
 
 
 class ParameterValueBenchmark(benchmark_base.DatasetBenchmarkBase):
-  """Benchmarks to compare effect of different paramemter values on the performance."""
+  """Benchmarks to compare effect of different parameter values on the performance."""
 
   def _benchmark_map(self, num_parallel_calls, buffer_size):
     k = 1024 * 1024

--- a/tensorflow/python/data/experimental/ops/data_service_ops.py
+++ b/tensorflow/python/data/experimental/ops/data_service_ops.py
@@ -291,7 +291,7 @@ class _DataServiceDatasetV2(dataset_ops.DatasetSource):
       target_workers: (Optional.) Which workers to read from. If `"AUTO"`,
         tf.data runtime decides which workers to read from. If `"ANY"`, reads
         from any tf.data service workers. If `"LOCAL"`, only reads from local
-        in-processs tf.data service workers. `"AUTO"` works well for most cases,
+        in-process tf.data service workers. `"AUTO"` works well for most cases,
         while users can specify other targets. For example, `"LOCAL"` helps
         avoid RPCs and data copy if every TF worker colocates with a tf.data
         service worker. Consumers of a shared job must use the same
@@ -508,7 +508,7 @@ def _distribute(
         for details.
     target_workers: (Optional.) Which workers to read from. If `"AUTO"`, tf.data
       runtime decides which workers to read from. If `"ANY"`, reads from any
-      tf.data service workers. If `"LOCAL"`, only reads from local in-processs
+      tf.data service workers. If `"LOCAL"`, only reads from local in-process
       tf.data service workers. `"AUTO"` works well for most cases, while users
       can specify other targets. For example, `"LOCAL"` helps avoid RPCs and
       data copy if every TF worker colocates with a tf.data service worker.
@@ -768,7 +768,7 @@ def distribute(
         for details.
     target_workers: (Optional.) Which workers to read from. If `"AUTO"`, tf.data
       runtime decides which workers to read from. If `"ANY"`, reads from any
-      tf.data service workers. If `"LOCAL"`, only reads from local in-processs
+      tf.data service workers. If `"LOCAL"`, only reads from local in-process
       tf.data service workers. `"AUTO"` works well for most cases, while users
       can specify other targets. For example, `"LOCAL"` helps avoid RPCs and
       data copy if every TF worker colocates with a tf.data service worker.
@@ -980,7 +980,7 @@ def _from_dataset_id(processing_mode,
         for details.
     target_workers: (Optional.) Which workers to read from. If `"AUTO"`, tf.data
       runtime decides which workers to read from. If `"ANY"`, reads from any
-      tf.data service workers. If `"LOCAL"`, only reads from local in-processs
+      tf.data service workers. If `"LOCAL"`, only reads from local in-process
       tf.data service workers. `"AUTO"` works well for most cases, while users
       can specify other targets. For example, `"LOCAL"` helps avoid RPCs and
       data copy if every TF worker colocates with a tf.data service worker.
@@ -1164,7 +1164,7 @@ def from_dataset_id(processing_mode,
         for details.
     target_workers: (Optional.) Which workers to read from. If `"AUTO"`, tf.data
       runtime decides which workers to read from. If `"ANY"`, reads from any
-      tf.data service workers. If `"LOCAL"`, only reads from local in-processs
+      tf.data service workers. If `"LOCAL"`, only reads from local in-process
       tf.data service workers. `"AUTO"` works well for most cases, while users
       can specify other targets. For example, `"LOCAL"` helps avoid RPCs and
       data copy if every TF worker colocates with a tf.data service worker.

--- a/tensorflow/python/data/experimental/ops/snapshot.py
+++ b/tensorflow/python/data/experimental/ops/snapshot.py
@@ -96,7 +96,7 @@ class _LegacySnapshotDataset(dataset_ops.UnaryUnchangedStructureDataset):
     super(_LegacySnapshotDataset, self).__init__(input_dataset, variant_tensor)
 
 
-@deprecation.deprecated(None, "Use `tf.data.Dataset.shapshot(...)` instead.")
+@deprecation.deprecated(None, "Use `tf.data.Dataset.snapshot(...)` instead.")
 def legacy_snapshot(path,
                     compression=None,
                     reader_path_prefix=None,
@@ -217,7 +217,7 @@ def snapshot(path, compression="AUTO", reader_func=None, shard_func=None):
   ```python
   dataset = ...
   dataset = dataset.enumerate()
-  dataset = dataset.apply(tf.data.Dataset.shapshot("/path/to/snapshot/dir",
+  dataset = dataset.apply(tf.data.Dataset.snapshot("/path/to/snapshot/dir",
       shard_func=lambda x, y: x % NUM_SHARDS, ...))
   dataset = dataset.map(lambda x, y: y)
   ```
@@ -241,7 +241,7 @@ def snapshot(path, compression="AUTO", reader_func=None, shard_func=None):
     # read datasets in parallel and interleave their elements
     return datasets.interleave(lambda x: x, num_parallel_calls=AUTOTUNE)
 
-  dataset = dataset.apply(tf.data.Dataset.shapshot("/path/to/snapshot/dir",
+  dataset = dataset.apply(tf.data.Dataset.snapshot("/path/to/snapshot/dir",
       reader_func=user_reader_func))
   ```
 

--- a/tensorflow/python/data/experimental/ops/testing.py
+++ b/tensorflow/python/data/experimental/ops/testing.py
@@ -47,7 +47,7 @@ def assert_next(transformations):
 def assert_prev(transformations):
   r"""Asserts which transformations, with which attributes, happened previously.
 
-    Each transformation is repesented as a tuple in the input.
+    Each transformation is represented as a tuple in the input.
 
     The first element is the base op name of the transformation, not including
     version suffix.  For example, use "BatchDataset" instead of

--- a/tensorflow/python/data/experimental/service/server_lib.py
+++ b/tensorflow/python/data/experimental/service/server_lib.py
@@ -175,7 +175,7 @@ class DispatchServer:
 
     Args:
       config: (Optional.) A `tf.data.experimental.service.DispatcherConfig`
-        configration. If `None`, the dispatcher will use default
+        configuration. If `None`, the dispatcher will use default
         configuration values.
       start: (Optional.) Boolean, indicating whether to start the server after
         creating it. Defaults to True.
@@ -382,7 +382,7 @@ class WorkerServer:
     """Creates a new worker server.
 
     Args:
-      config: A `tf.data.experimental.service.WorkerConfig` configration.
+      config: A `tf.data.experimental.service.WorkerConfig` configuration.
       start: (Optional.) Boolean, indicating whether to start the server after
         creating it. Defaults to True.
     """

--- a/tensorflow/python/data/kernel_tests/flat_map_test.py
+++ b/tensorflow/python/data/kernel_tests/flat_map_test.py
@@ -437,7 +437,7 @@ class FlatMapCheckpointTest(
     """Test `.flat_map().skip()` checkpointing behavior.
 
     `SkipInternal` and `GetNextInternal` are separate functions
-    but with slighly different implementations.
+    but with slightly different implementations.
     Therefore, we should test this op's behavior when used with `.skip()`.
 
     Args:

--- a/tensorflow/python/data/kernel_tests/placement_test.py
+++ b/tensorflow/python/data/kernel_tests/placement_test.py
@@ -146,7 +146,7 @@ class PlacementTest(test_base.DatasetTestBase, parameterized.TestCase):
   @test_util.run_gpu_only
   def testFunctionCall(self):
     # Ideally, placer should know that Call(dataset) should be on the same
-    # device as the dataset. Create a funciton that could be place don the GPU,
+    # device as the dataset. Create a function that could be place don the GPU,
     # but a Dataset that cannot.
     @def_function.function
     def test_call(dataset):

--- a/tensorflow/python/data/kernel_tests/rebatch_test.py
+++ b/tensorflow/python/data/kernel_tests/rebatch_test.py
@@ -199,7 +199,7 @@ class RebatchTest(test_base.DatasetTestBase, parameterized.TestCase):
 
     # We have an extra element at the end because if the desired batch size is
     # zero, then we never read any inputs from the input_dataset at all, so we
-    # will keep producting empty outputs until we reach a non zero desired batch
+    # will keep producing empty outputs until we reach a non zero desired batch
     # size split.
     expected_output = [[], [0], [], [1], [], [2], [], [3], [], [4], [], [5], [],
                        [6], [], [7], []]

--- a/tensorflow/python/data/ops/dataset_autograph.py
+++ b/tensorflow/python/data/ops/dataset_autograph.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Autograph specifc overrides for dataset_ops."""
+"""Autograph specific overrides for dataset_ops."""
 from tensorflow.python.autograph.operators import control_flow
 from tensorflow.python.autograph.operators import py_builtins
 from tensorflow.python.data.experimental.ops import take_while_ops

--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -2652,7 +2652,7 @@ name=None))
 
     #### Nested elements
 
-    When the `window` transformation is applied to a dataset whos elements are
+    When the `window` transformation is applied to a dataset whose elements are
     nested structures, it produces a dataset where the elements have the same
     nested structure but each leaf is replaced by a window. In other words,
     the nesting is applied outside of the windows as opposed inside of them.
@@ -3793,7 +3793,7 @@ class DatasetV1(DatasetV2, data_types.DatasetV1):
         return iterator_ops.OwnedIterator(self)
 
     _ensure_same_dataset_graph(self)
-    # Some ops (e.g. dataset ops) are marked as stateful but are stil safe to
+    # Some ops (e.g. dataset ops) are marked as stateful but are still safe to
     # to capture by value. We must allowlist these ops so that the capturing
     # logic captures the ops instead of raising an exception.
     allowlisted_stateful_ops = traverse.obtain_capture_by_value_ops(self)

--- a/tensorflow/python/data/ops/iterator_autograph.py
+++ b/tensorflow/python/data/ops/iterator_autograph.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Autograph specifc overrides for tf.data.ops."""
+"""Autograph specific overrides for tf.data.ops."""
 import functools
 
 import numpy as np

--- a/tensorflow/python/data/ops/options.py
+++ b/tensorflow/python/data/ops/options.py
@@ -34,7 +34,7 @@ class AutotuneAlgorithm(enum.Enum):
   DEFAULT: The default behavior is implementation specific and may change over
   time.
 
-  HILL_CLIMB: In each optimization step, this algorithm chooses the optimial
+  HILL_CLIMB: In each optimization step, this algorithm chooses the optimal
   parameter and increases its value by 1.
 
   GRADIENT_DESCENT: In each optimization step, this algorithm updates the
@@ -499,7 +499,7 @@ class ServiceOptions(options_lib.OptionsBase):
       ty=bool,
       docstring=(
           "If true, the tf.data service client allocates data to pinned memory,"
-          " which faciliates more efficient copying from host memory to GPU"
+          " which facilitates more efficient copying from host memory to GPU"
           " memory downstream. For gRPC, compression must be disabled for this"
           " to take effect. For alternative data transfer protocols, this may"
           " or may not take effect, depending on the implementation."


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.