### PR TITLE
Fix 03 broken links in play_services.md

### DIFF
--- a/tensorflow/lite/g3doc/android/play_services.md
+++ b/tensorflow/lite/g3doc/android/play_services.md
@@ -11,7 +11,7 @@ Lite in Google Play services is the recommended way to use TensorFlow Lite on
 Android.
 
 You can get started with the Play services runtime with the
-[Quickstart](../android/quickstart), which provides a step-by-step guide to
+[Quickstart](../android/quickstart.md), which provides a step-by-step guide to
 implement a sample application. If you are already using stand-alone TensorFlow
 Lite in your app, refer to the
 [Migrating from stand-alone TensorFlow Lite](#migrating) section to update an
@@ -30,8 +30,8 @@ the APIs. </aside>
 The TensorFlow Lite in Google Play services is available through the following
 programming language apis:
 
--   Java API - [see guide](../android/java)
--   C API - [see guide](../android/native)
+-   Java API - [see guide](../android/java.md)
+-   C API - [see guide](../android/native.md)
 
 ## Limitations
 


### PR DESCRIPTION
Hi, Team
I found 03 broken documentation links in this [play_services.md](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/android/play_services.md) file so I have updated those links to functional links. Please review and merge this change as appropriate.

Thank you for your consideration.