### PR TITLE
[mlir][tosa] Add missing dependencies from tflite kernels

### DIFF
--- a/tensorflow/compiler/mlir/tosa/BUILD
+++ b/tensorflow/compiler/mlir/tosa/BUILD
@@ -83,6 +83,7 @@ cc_library(
         "//tensorflow/compiler/mlir/tensorflow:dynamic_shape_utils",
         "//tensorflow/core:framework",
         "//tensorflow/core/kernels:conv_grad_shape_utils",
+        "//tensorflow/lite/kernels/internal:reference_base",
         "@com_google_absl//absl/status",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",


### PR DESCRIPTION
For fixing patch:  [TOSA] Add GELU approximate attr and transform to Tosa #62149
