### PR TITLE
Fix a broken link in java.md

### DIFF
--- a/tensorflow/lite/g3doc/android/java.md
+++ b/tensorflow/lite/g3doc/android/java.md
@@ -22,7 +22,7 @@ The TensorFlow Lite Task API wraps the Interpreter API and provides a high-level
 programming interface for common machine learning tasks that use visual, audio,
 and text data. You should use the Task API if your application requires one of
 the
-[supported tasks](../inference_with_metadata/task_library/overview#supported_tasks).
+[supported tasks](../inference_with_metadata/task_library/overview.md#supported-tasks).
 
 #### 1. Add project dependencies
 


### PR DESCRIPTION
Hi, Team
I found a broken documentation link in this [java.md](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/android/java.md) file so I have updated that link to functional link. Please review and merge this change as appropriate.

Thank you for your consideration.