### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/distribute/collective_all_reduce_strategy.py
+++ b/tensorflow/python/distribute/collective_all_reduce_strategy.py
@@ -969,7 +969,7 @@ class CollectiveAllReduceExtended(mirrored_strategy.MirroredExtended):
       options = collective_util.Options()
 
     if context.executing_eagerly():
-      # In eager mode, falls back to the default implemenation that uses
+      # In eager mode, falls back to the default implementation that uses
       # `merge_call`. Replica functions are running sequentially in eager mode,
       # and due to the blocking nature of collective ops, execution will hang if
       # collective ops are to be launched sequentially.
@@ -1035,7 +1035,7 @@ class CollectiveAllReduceExtended(mirrored_strategy.MirroredExtended):
             except Exception as e:  # pylint: disable=broad-except
               logging.error("Unexpected exception in check alive: %s", e)
               context.context().abort_collective_ops(
-                  errors.INTERNAL, "unexecpted exception in check alive: %s" % e
+                  errors.INTERNAL, "unexpected exception in check alive: %s" % e
               )
               return
       time.sleep(self._check_health_interval)

--- a/tensorflow/python/distribute/combinations.py
+++ b/tensorflow/python/distribute/combinations.py
@@ -108,7 +108,7 @@ class ClusterParameters(combinations_lib.ParameterModifier):
       num_ps = kwargs.get("num_ps", 0)
 
     # Always set cluster parameters if they're requested. So that generate()
-    # works when there's no startegy in the combinations.
+    # works when there's no strategy in the combinations.
     update = {}
     if "has_chief" in requested_parameters:
       update["has_chief"] = has_chief
@@ -410,7 +410,7 @@ NamedObject = combinations_lib.NamedObject
 
 
 # Identifies whether we're in the main process or worker processes.
-# `_multi_worker_test` decoration behaves differently in the main processs and
+# `_multi_worker_test` decoration behaves differently in the main processes and
 # the worker processes. See the documentation of _multi_worker_test for detail.
 _running_in_worker = False
 
@@ -631,7 +631,7 @@ def _multi_worker_session(kwargs):
 
   Returns:
     A context manager. If MultiWorkerMirroredStrategy is the  one and only one
-    strategy in kwargs and it's in graph mode, it's the seesion that is
+    strategy in kwargs and it's in graph mode, it's the session that is
     configured for that strategy.  Otherwise, it's a no-op context manager.
   """
   strategy = None

--- a/tensorflow/python/distribute/cross_device_ops.py
+++ b/tensorflow/python/distribute/cross_device_ops.py
@@ -572,7 +572,7 @@ class CrossDeviceOps(object):
       options: A `tf.distribute.experimental.CommunicationOptions`.
 
     Returns:
-      A tensor/IndexedSlices or a nested strucutre of tensors/IndexedSlices with
+      A tensor/IndexedSlices or a nested structure of tensors/IndexedSlices with
       the reduced values. The structure is the same as `value`.
     """
     raise NotImplementedError("_all_reduce must be implemented in descendants.")

--- a/tensorflow/python/distribute/distribute_lib.py
+++ b/tensorflow/python/distribute/distribute_lib.py
@@ -2854,7 +2854,7 @@ class StrategyExtendedV2(object):
         `tf.distribute.Strategy` takes one in the constructor.
 
     Returns:
-      A tensor or a nested strucutre of tensors with the reduced values. The
+      A tensor or a nested structure of tensors with the reduced values. The
       structure is the same as `value`.
     """
     if options is None:
@@ -2991,7 +2991,7 @@ class StrategyExtendedV2(object):
       where each list has an element per replica, and the caller is responsible
       for ensuring all elements are executed.
     """
-    # TODO(b/178944108): Update the documentation to relfect the fact that
+    # TODO(b/178944108): Update the documentation to reflect the fact that
     # `update` can be called in a replica context.
     if kwargs is None:
       kwargs = {}

--- a/tensorflow/python/distribute/distributed_variable_test.py
+++ b/tensorflow/python/distribute/distributed_variable_test.py
@@ -541,7 +541,7 @@ class DistributedVariableTest(test.TestCase, parameterized.TestCase):
   def testUnsaveable(self, distribution, synchronization, aggregation, mode):
     if isinstance(distribution.extended,
                   parameter_server_strategy.ParameterServerStrategyExtended):
-      self.skipTest("n/a: not appliable to AggregatingVariable")
+      self.skipTest("n/a: not applicable to AggregatingVariable")
     if (isinstance(distribution,
                    collective_all_reduce_strategy.CollectiveAllReduceStrategy)
         and mode == "graph"):

--- a/tensorflow/python/distribute/failure_handling/failure_handling.py
+++ b/tensorflow/python/distribute/failure_handling/failure_handling.py
@@ -810,7 +810,7 @@ class PreemptionCheckpointHandler(object):
 
     This function handles the preemption signal from any peer in the cluster by
     saving the training progress and exiting gracefully. It will
-    also broadcase any program error encountered during the execution of
+    also broadcast any program error encountered during the execution of
     `distributed_train_function` to all workers so that they can raise the same
     error.
 

--- a/tensorflow/python/distribute/failure_handling/preemption_watcher.py
+++ b/tensorflow/python/distribute/failure_handling/preemption_watcher.py
@@ -35,7 +35,7 @@ _preemption_watcher_initialization_counter = monitoring.Counter(
 )
 _preemption_handling_counter = monitoring.Counter(
     "/tensorflow/api/distribution_strategy/preemption_watcher_handled",
-    "Counter for number of preempions catched and handled by PreemptionWatcher",
+    "Counter for number of preempions caught and handled by PreemptionWatcher",
 )
 
 _PREEMPTION_KEY = "TF_DEFAULT_PREEMPTION_NOTICE_KEY"

--- a/tensorflow/python/distribute/mirrored_run.py
+++ b/tensorflow/python/distribute/mirrored_run.py
@@ -252,7 +252,7 @@ def _call_for_each_replica(distribution, fn, args, kwargs):
           for t in threads:
             mtt_captured_control_deps.update(t.captured_control_deps)
 
-          # Control is transfered from _MirroredReplicaThread (MRT) to the main
+          # Control is transferred from _MirroredReplicaThread (MRT) to the main
           # thread, i.e., here, to perform `merge_fn`, and thus we preserve the
           # name scope,  control dependencies, etc. from MRT at the time
           # `merge_call` is made.
@@ -444,7 +444,7 @@ class _MirroredReplicaContext(distribute_lib.ReplicaContext):
       fn: a function that is called in cross replica context with grouped
         arguments from each replica. `fn` should returns grouped values.
       args: positional arguments to `fn`.
-      kwargs: keyward arguments to `fn`.
+      kwargs: keyword arguments to `fn`.
 
     Returns:
       Return value of `fn` for the current replica.

--- a/tensorflow/python/distribute/parameter_server_strategy_v2.py
+++ b/tensorflow/python/distribute/parameter_server_strategy_v2.py
@@ -387,7 +387,7 @@ class ParameterServerStrategyV2(distribute_lib.Strategy):
 
   When a partitioned variable is saved to a `SavedModel`, it will be saved as if
   it is one single variable. This improves serving efficiency by eliminating
-  a number of Ops that handle the partiton aspects.
+  a number of Ops that handle the partition aspects.
 
   Known limitations of variable partitioning:
 

--- a/tensorflow/python/distribute/strategy_combinations.py
+++ b/tensorflow/python/distribute/strategy_combinations.py
@@ -129,7 +129,7 @@ def _get_tpu_strategy_creator(
           resolver, steps_per_run, device_assignment, **kwargs
       )
     if enable_packed_variable and enable_spmd_xla_paritioning:
-      raise ValueError("Packed Variable is not compatiable with SPMD mode")
+      raise ValueError("Packed Variable is not compatible with SPMD mode")
     strategy._enable_packed_variable_in_eager_mode = (  # pylint: disable=protected-access
         enable_packed_variable
     )

--- a/tensorflow/python/distribute/vars_test.py
+++ b/tensorflow/python/distribute/vars_test.py
@@ -817,7 +817,7 @@ class OnReadVariableSyncTest(test.TestCase, parameterized.TestCase):
       self.skipTest("Assigning PerReplica values is not supported. See"
                     " sponge/80ba41f8-4220-4516-98ce-bbad48f9f11a.")
 
-    self.skipTest("We don't support assiging PerReplica values in cross "
+    self.skipTest("We don't support assigning PerReplica values in cross "
                   "replica context or replica context. see error in "
                   "sponge/2b2e54c1-eda6-4534-82e1-c73b1dcd517f.")
 


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.