### PR TITLE
Add CUDA plugin registration checking

### DIFF
--- a/third_party/xla/xla/stream_executor/cuda/cuda_blas.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_blas.cc
@@ -1390,27 +1390,27 @@ absl::Status CUDABlas::GetVersion(std::string *version) {
 }
 
 void initialize_cublas() {
-	bool cuBlasAlreadyRegistered = PluginRegistry::Instance()->HasFactory(
-		cuda::kCudaPlatformId, PluginKind::kBlas);
+  bool cuBlasAlreadyRegistered = PluginRegistry::Instance()->HasFactory(
+    cuda::kCudaPlatformId, PluginKind::kBlas);
 
-	if (!cuBlasAlreadyRegistered) {
-		absl::Status status =
-			PluginRegistry::Instance()->RegisterFactory<PluginRegistry::BlasFactory>(
-				cuda::kCudaPlatformId, "cuBLAS",
-				[](StreamExecutor* parent) -> blas::BlasSupport* {
-					CUDABlas* blas = new CUDABlas(parent);
-					if (!blas->Init()) {
-						// Note: Init() will log a more specific error.
-						delete blas;
-						return nullptr;
-					}
-					return blas;
-				});
+  if (!cuBlasAlreadyRegistered) {
+    absl::Status status =
+      PluginRegistry::Instance()->RegisterFactory<PluginRegistry::BlasFactory>(
+        cuda::kCudaPlatformId, "cuBLAS",
+        [](StreamExecutor* parent) -> blas::BlasSupport* {
+          CUDABlas* blas = new CUDABlas(parent);
+          if (!blas->Init()) {
+            // Note: Init() will log a more specific error.
+            delete blas;
+            return nullptr;
+          }
+          return blas;
+        });
 
-		if (!status.ok()) {
-			LOG(ERROR) << "Unable to register cuBLAS factory: " << status.message();
-		}
-	}
+    if (!status.ok()) {
+      LOG(ERROR) << "Unable to register cuBLAS factory: " << status.message();
+    }
+  }
 }
 
 }  // namespace cuda

--- a/third_party/xla/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_dnn.cc
@@ -8653,27 +8653,27 @@ absl::Status CudnnGraph::Execute(Stream& stream,
 }  // namespace gpu
 
 void initialize_cudnn() {
-	bool cuDnnAlreadyRegistered = PluginRegistry::Instance()->HasFactory(
-		cuda::kCudaPlatformId, PluginKind::kDnn);
+  bool cuDnnAlreadyRegistered = PluginRegistry::Instance()->HasFactory(
+    cuda::kCudaPlatformId, PluginKind::kDnn);
 
-	if (!cuDnnAlreadyRegistered) {
-		absl::Status status =
-			PluginRegistry::Instance()->RegisterFactory<PluginRegistry::DnnFactory>(
-				cuda::kCudaPlatformId, "cuDNN",
-				[](StreamExecutor* parent) -> dnn::DnnSupport* {
-					gpu::CudnnSupport* dnn = new gpu::CudnnSupport(parent);
-					if (!dnn->Init().ok()) {
-						// Note: Init() will log a more specific error.
-						delete dnn;
-						return nullptr;
-					}
-					return dnn;
-				});
+  if (!cuDnnAlreadyRegistered) {
+    absl::Status status =
+      PluginRegistry::Instance()->RegisterFactory<PluginRegistry::DnnFactory>(
+        cuda::kCudaPlatformId, "cuDNN",
+        [](StreamExecutor* parent) -> dnn::DnnSupport* {
+          gpu::CudnnSupport* dnn = new gpu::CudnnSupport(parent);
+          if (!dnn->Init().ok()) {
+            // Note: Init() will log a more specific error.
+            delete dnn;
+            return nullptr;
+          }
+          return dnn;
+        });
 
-		if (!status.ok()) {
-			LOG(ERROR) << "Unable to register cuDNN factory: " << status.message();
-		}
-	}
+    if (!status.ok()) {
+      LOG(ERROR) << "Unable to register cuDNN factory: " << status.message();
+    }
+  }
 }
 
 }  // namespace stream_executor

--- a/third_party/xla/xla/stream_executor/cuda/cuda_fft.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_fft.cc
@@ -457,20 +457,20 @@ STREAM_EXECUTOR_CUDA_DEFINE_FFT(double, Z2Z, D2Z, Z2D)
 }  // namespace gpu
 
 void initialize_cufft() {
-	bool cuFftAlreadyRegistered = PluginRegistry::Instance()->HasFactory(
-		cuda::kCudaPlatformId, PluginKind::kFft);
+  bool cuFftAlreadyRegistered = PluginRegistry::Instance()->HasFactory(
+    cuda::kCudaPlatformId, PluginKind::kFft);
 
-	if (!cuFftAlreadyRegistered) {
-		absl::Status status =
-			PluginRegistry::Instance()->RegisterFactory<PluginRegistry::FftFactory>(
-				cuda::kCudaPlatformId, "cuFFT",
-				[](StreamExecutor* parent) -> fft::FftSupport* {
-					return new gpu::CUDAFft(parent);
-				});
-		if (!status.ok()) {
-			LOG(ERROR) << "Unable to register cuFFT factory: " << status.message();
-		}
-	}
+  if (!cuFftAlreadyRegistered) {
+    absl::Status status =
+      PluginRegistry::Instance()->RegisterFactory<PluginRegistry::FftFactory>(
+        cuda::kCudaPlatformId, "cuFFT",
+        [](StreamExecutor* parent) -> fft::FftSupport* {
+          return new gpu::CUDAFft(parent);
+        });
+    if (!status.ok()) {
+      LOG(ERROR) << "Unable to register cuFFT factory: " << status.message();
+    }
+  }
 }
 
 }  // namespace stream_executor

--- a/third_party/xla/xla/stream_executor/cuda/cuda_fft.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_fft.cc
@@ -457,15 +457,20 @@ STREAM_EXECUTOR_CUDA_DEFINE_FFT(double, Z2Z, D2Z, Z2D)
 }  // namespace gpu
 
 void initialize_cufft() {
-  absl::Status status =
-      PluginRegistry::Instance()->RegisterFactory<PluginRegistry::FftFactory>(
-          cuda::kCudaPlatformId, "cuFFT",
-          [](StreamExecutor *parent) -> fft::FftSupport * {
-            return new gpu::CUDAFft(parent);
-          });
-  if (!status.ok()) {
-    LOG(ERROR) << "Unable to register cuFFT factory: " << status.message();
-  }
+	bool cuFftAlreadyRegistered = PluginRegistry::Instance()->HasFactory(
+		cuda::kCudaPlatformId, PluginKind::kFft);
+
+	if (!cuFftAlreadyRegistered) {
+		absl::Status status =
+			PluginRegistry::Instance()->RegisterFactory<PluginRegistry::FftFactory>(
+				cuda::kCudaPlatformId, "cuFFT",
+				[](StreamExecutor* parent) -> fft::FftSupport* {
+					return new gpu::CUDAFft(parent);
+				});
+		if (!status.ok()) {
+			LOG(ERROR) << "Unable to register cuFFT factory: " << status.message();
+		}
+	}
 }
 
 }  // namespace stream_executor


### PR DESCRIPTION
This pull request is to fix https://github.com/openxla/xla/issues/20803. Test result is as follows. No error.

```
2025-02-05 12:19:54.390955: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1738729197.544741    4373 gpu_device.cc:2019] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 3315 MB memory:  -> device: 0, name: NVIDIA GeForce GTX 1050 Ti, pci bus id: 0000:29:00.0, compute capability: 6.1
Model: "functional_4"
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Layer (type)                    ┃ Output Shape           ┃       Param # ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ input_layer (InputLayer)        │ (None, None, 128)      │             0 │
├─────────────────────────────────┼────────────────────────┼───────────────┤
│ encoder (Encoder)               │ (None, None, 128)      │       662,528 │
├─────────────────────────────────┼────────────────────────┼───────────────┤
│ out_pretraining (Dense)         │ (None, None, 128)      │        16,512 │
└─────────────────────────────────┴────────────────────────┴───────────────┘
 Total params: 679,040 (2.59 MB)
 Trainable params: 679,040 (2.59 MB)
 Non-trainable params: 0 (0.00 B)
```