### PR TITLE
Fix build error on s390x due to missing hwloc headers

### DIFF
--- a/third_party/hwloc/hwloc.BUILD
+++ b/third_party/hwloc/hwloc.BUILD
@@ -272,6 +272,10 @@ cc_library(
             "hwloc/topology-linux.c",
             "include/hwloc/linux.h",
         ],
+        "@local_xla//xla/tsl:linux_s390x": [
+            "hwloc/topology-linux.c",
+            "include/hwloc/linux.h",
+        ],
         "@local_xla//xla/tsl:freebsd": [
             "hwloc/topology-freebsd.c",
             "hwloc/topology-x86.c",

--- a/third_party/xla/third_party/tsl/third_party/hwloc/hwloc.BUILD
+++ b/third_party/xla/third_party/tsl/third_party/hwloc/hwloc.BUILD
@@ -272,6 +272,10 @@ cc_library(
             "hwloc/topology-linux.c",
             "include/hwloc/linux.h",
         ],
+        "@local_xla//xla/tsl:linux_s390x": [
+            "hwloc/topology-linux.c",
+            "include/hwloc/linux.h",
+        ],
         "@local_xla//xla/tsl:freebsd": [
             "hwloc/topology-freebsd.c",
             "hwloc/topology-x86.c",


### PR DESCRIPTION
This PR fixes below error on s390x by including required methods from `topology-linux.c`:
```
error: undefined reference to 'hwloc_linux_component'
```
