### PR TITLE
Explicit print options while dumping HLO

### DIFF
--- a/tensorflow/compiler/aot/tests/tfcompile_test.cc
+++ b/tensorflow/compiler/aot/tests/tfcompile_test.cc
@@ -677,13 +677,13 @@ TEST(TFCompileTest, HloProfiling) {
 
   auto header = HasSubstr("Execution profile for");
   auto total_cycles_profile_line = HasSubstr("[total]");
-  auto dot_profile_line = HasSubstr(
-      "%dot = f32[2,2]{1,0} dot(f32[2,2]{1,0} %arg0, f32[2,2]{1,0} %arg1)");
-  auto add_profile_line = HasSubstr(
-      "%add = f32[2,2]{1,0} add(f32[2,2]{1,0} %arg0, f32[2,2]{1,0} %arg1)");
+  auto dot_profile_line =
+      HasSubstr("%dot = f32[2,2]{1,0} dot({{.*}}%arg0, {{.*}}%arg1)");
+  auto add_profile_line =
+      HasSubstr("%add = f32[2,2]{1,0} add({{.*}}%arg0, {{.*}}%arg1)");
   auto tuple_profile_line = HasSubstr(
-      "%tuple = (f32[2,2]{1,0}, f32[2,2]{1,0}) tuple(f32[2,2]{1,0} %dot, "
-      "f32[2,2]{1,0} %add)");
+      "%tuple = (f32[2,2]{1,0}, f32[2,2]{1,0}) tuple({{.*}}%dot, "
+      "{{.*}}%add)");
   auto arg0_profile_line = HasSubstr("%arg0 = f32[2,2]{1,0} parameter(0)");
   auto arg1_profile_line = HasSubstr("%arg1 = f32[2,2]{1,0} parameter(1)");
 

--- a/tensorflow/compiler/jit/get_compiler_ir.cc
+++ b/tensorflow/compiler/jit/get_compiler_ir.cc
@@ -124,6 +124,8 @@ static absl::StatusOr<std::string> BuildHLOString(
       }
 
       xla::HloPrintOptions opts;
+      opts.set_print_large_constants(false);
+      opts.set_print_operand_shape(true);
       if (stage == IrExportStage::HLO_NO_METADATA) {
         opts.set_print_metadata(false);
       }

--- a/tensorflow/compiler/mlir/tensorflow/utils/tf_xla_mlir_translate.cc
+++ b/tensorflow/compiler/mlir/tensorflow/utils/tf_xla_mlir_translate.cc
@@ -114,7 +114,9 @@ mlir::LogicalResult PrintHloModuleText(
 
   xla::HloModule* hlo_module = status_or_hlo_module.value().get();
 
-  output << hlo_module->ToString();
+  output << hlo_module->ToString(xla::HloPrintOptions()
+                                     .set_print_large_constants(false)
+                                     .set_print_operand_shape(true));
 
   if (!compilation_result.input_mapping.empty())
     output << "// InputMapping {"


### PR DESCRIPTION
We are changing the `HloModule::ToString` function to consider the debug options related to printing like, `xla_dump_hlo_as_long_text`, `xla_dump_large_constants` etc. These options are already embedded into the `HloModule` and are set via the command line and so, the `ToString` function should default to these functions. 

We are also changing the default value of HloPrintOptions: `set_print_operand_shape(false)` and `set_print_large_constants(true)`.

The related changes in XLA are
https://github.com/openxla/xla/pull/22614 and https://github.com/openxla/xla/pull/22800.

This breaks some of the tests in tensorflow because it relies on the `ToString` function and the default print options. As a temporary fix, we are making the default print options explicit here. Once the XLA change gets merged, we can remove this and fix the tests (or not, depending on what the TF community decides, but the behavior of the tool will be intentional.)