### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/eager/imperative_grad.py
+++ b/tensorflow/python/eager/imperative_grad.py
@@ -48,7 +48,7 @@ def imperative_grad(tape,
     sources were generated. Should have the same length as sources. Only needs
     to be populated if unconnected_gradients is 'zero'.
    unconnected_gradients: determines the value returned if the target and
-    sources are unconnected. When 'none' the value returned is None wheras when
+    sources are unconnected. When 'none' the value returned is None whereas when
     'zero' a zero tensor in the same shape as the sources is returned.
 
   Returns:

--- a/tensorflow/python/eager/polymorphic_function/atomic_function.py
+++ b/tensorflow/python/eager/polymorphic_function/atomic_function.py
@@ -55,7 +55,7 @@ class CallOptions:
   # Used by ACD to list Ops/Tensors/Callables that must be called in advance.
   control_captures: List[Any] = dataclasses.field(default_factory=list)
 
-  # Determines what kind of partitoned call is used for this function.
+  # Determines what kind of partitioned call is used for this function.
   is_stateful: bool = False
 
 

--- a/tensorflow/python/eager/polymorphic_function/compiler_ir.py
+++ b/tensorflow/python/eager/polymorphic_function/compiler_ir.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Implmentation for defining get_compiler_ir."""
+"""Implementation for defining get_compiler_ir."""
 from typing import List, Optional
 import warnings
 

--- a/tensorflow/python/eager/polymorphic_function/polymorphic_function.py
+++ b/tensorflow/python/eager/polymorphic_function/polymorphic_function.py
@@ -966,7 +966,7 @@ class Function(core.PolymorphicFunction, trackable.Trackable):
 
     def _check_inputs(args, kwargs):
       all_inputs = list(args) + list(kwargs.values())
-      # Emtpy input is okay.
+      # Empty input is okay.
       if not all_inputs:
         return
       if any(map(is_tensor_spec, all_inputs)) and any(
@@ -1441,7 +1441,7 @@ def function(
   True
 
   `ConcreteFunction`s can be executed just like `PolymorphicFunction`s, but their
-  input is resticted to the types to which they're specialized.
+  input is restricted to the types to which they're specialized.
 
   ## Retracing
 

--- a/tensorflow/python/eager/polymorphic_function/polymorphic_function_test.py
+++ b/tensorflow/python/eager/polymorphic_function/polymorphic_function_test.py
@@ -2729,7 +2729,7 @@ class FunctionTest(test.TestCase, parameterized.TestCase):
                                                    call_kwargs=None,
                                                    error='.*',
                                                    exception=TypeError):
-    """Tests for errors in the structrued signature.
+    """Tests for errors in the structured signature.
 
     Args:
       conc_args: Positional arguments used for get_concrete_function.

--- a/tensorflow/python/eager/polymorphic_function/polymorphic_function_xla_jit_test.py
+++ b/tensorflow/python/eager/polymorphic_function/polymorphic_function_xla_jit_test.py
@@ -47,7 +47,7 @@ from tensorflow.python.util import nest
 class FunctionTest(xla_test.XLATestCase):
 
   def _compareTwoMethodsCompilerIROutput(self, f, args, kwargs):
-    """Assert the two differnet methods (tensor_spec inputs or tensor inputs) experimental_get_compiler give same HLO text."""
+    """Assert the two different methods (tensor_spec inputs or tensor inputs) experimental_get_compiler give same HLO text."""
     flat_args = list(args) + list(kwargs.values())
     if not all([isinstance(x, tensor.Tensor) for x in flat_args]):
       self.skipTest('It only support args and kwargs are all tf.Tensor types.')
@@ -1019,7 +1019,7 @@ class FunctionTest(xla_test.XLATestCase):
       val1 = constant_op.constant(2)
       val2 = constant_op.constant(50)
 
-      # Returns an error, since the value known at compile time was overriden.
+      # Returns an error, since the value known at compile time was overridden.
       with self.assertRaisesRegex(errors.InvalidArgumentError,
                                   'concrete values at compile time'):
         f(random_ops.random_normal([10, 10]), val1, val2)

--- a/tensorflow/python/eager/pywrap_tfe.h
+++ b/tensorflow/python/eager/pywrap_tfe.h
@@ -443,7 +443,7 @@ EagerContextThreadLocalData* GetEagerContextThreadLocalData(
 // wish to destroy thread-local state associated with a single py_eager_context
 // for multiple threads, then you must call this method from each thread.
 //
-// Thread-local state assocaited with eager contexts is also automatically
+// Thread-local state associated with eager contexts is also automatically
 // cleaned up when the thread is destroyed.
 //
 // This function assumes that the Python GIL is held (and does not perform its

--- a/tensorflow/python/eager/summary_optimizer_test.py
+++ b/tensorflow/python/eager/summary_optimizer_test.py
@@ -60,7 +60,7 @@ class SummaryOpsTransformationTest(test.TestCase):
           node.attr['body'].func.name = 'while_body'
           node.attr['cond'].func.name = 'while_cond'
 
-          # The summary_writer and `inlcude_summary` args are expected to be
+          # The summary_writer and `include_summary` args are expected to be
           # passed in and out of the transformed function as we do not modify
           # the function signatures.
           # Expect a mismatch in input and output types/shapes.

--- a/tensorflow/python/eager/tape.py
+++ b/tensorflow/python/eager/tape.py
@@ -48,9 +48,9 @@ def watch(tape, tensor):
 def default_get_variables(variable):
   return [variable]
 
-# Gets a list of changed variables. Can be overriden using
+# Gets a list of changed variables. Can be overridden using
 # register_variables_override. An example of overriding is for getting the
-# varibles within a distributed context.
+# variables within a distributed context.
 _variables_override = default_get_variables
 
 

--- a/tensorflow/python/eager/tensor_test.py
+++ b/tensorflow/python/eager/tensor_test.py
@@ -474,7 +474,7 @@ class TFETensorTest(test_util.TensorFlowTestCase):
   def testEagerTensorFormatForResource(self):
     t = resource_variable_ops.VarHandleOp(shape=[], dtype=dtypes.float32)
 
-    # type is compiler-depdendent, as it comes from demangling.
+    # type is compiler-dependent, as it comes from demangling.
     handle_str = (f"<ResourceHandle("
                   f"name=\"\", "
                   f"device=\"{t.device}\", "


### PR DESCRIPTION

Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.