### PR TITLE
Fix compile error in tensorflow/python/tfcompile_wrapper.cc on s390x

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -496,7 +496,10 @@ tf_python_pybind_extension(
         "//tensorflow/python/lib/core:pybind11_status",
         # The headers here cannot be brought in via cc_header_only_library
         "//tensorflow/compiler/aot:llvm_targets",
-    ],
+    ] + select({
+        "@platforms//cpu:s390x": ["@llvm-project//llvm:TargetParser"],
+        "//conditions:default": [],
+    }),
 )
 
 tf_python_pybind_extension(


### PR DESCRIPTION
This fixes the following error on s390x:
```
ImportError: Unable to import _pywrap_tfcompile; you must build TensorFlow with XLA.  You may need to build tensorflow with flag --define=with_xla_support=true.  Original error: /home/test/.cache/bazel/_bazel_test/3a51eda24c560ebddf29b66b8fa0460e/execroot/org_tensorflow/bazel-out/s390x-opt-exec-50AE0418/bin/tensorflow/python/tools/saved_model_cli.runfiles/org_tensorflow/tensorflow/python/_pywrap_tfcompile.so: undefined symbol: _ZN4llvm3sys22getDefaultTargetTripleB5cxx11Ev
```