### PR TITLE
Fix 08 broken links in development.md

### DIFF
--- a/tensorflow/lite/g3doc/android/development.md
+++ b/tensorflow/lite/g3doc/android/development.md
@@ -6,13 +6,13 @@ Kotlin, Java, and C++, as well as support for TensorFlow Lite development in
 Android Studio.
 
 Key Point: In general, you should use the [TensorFlow Lite Task
-Library](#task_library) for integrating TensorFlow Lite into your Android app,
+Library](#tensorflow-lite-task-library-task_library) for integrating TensorFlow Lite into your Android app,
 unless your use case is not supported by that library. If it's not supported by
-the Task Library, use the [TensorFlow Lite library](#lite_lib) and [Support
-library](#support_lib).
+the Task Library, use the [TensorFlow Lite library](#tensorflow-lite-library-lite_lib) and [Support
+library](#tensorflow-lite-support-library-support_lib).
 
 To get started quickly writing Android code, see the
-[Quickstart for Android](../android/quickstart)
+[Quickstart for Android](../android/quickstart.md)
 
 
 ## Tools for building with Kotlin and Java
@@ -49,7 +49,7 @@ dependencies {
 ```
 
 If you use nightly snapshots, make sure you add the
-[Sonatype snapshot repository](./lite_build#use_nightly_snapshots) to your
+[Sonatype snapshot repository](./lite_build.md#use_nightly_snapshots) to your
 project.
 
 See the introduction in the
@@ -71,7 +71,7 @@ dependencies {
 ```
 
 If you use nightly snapshots, make sure you add the
-[Sonatype snapshot repository](./lite_build#use_nightly_snapshots) to your
+[Sonatype snapshot repository](./lite_build.md#use_nightly_snapshots) to your
 project.
 
 This AAR includes binaries for all of the
@@ -121,7 +121,7 @@ dependencies {
 ```
 
 If you use nightly snapshots, make sure you add the
-[Sonatype snapshot repository](./lite_build#use_nightly_snapshots) to your
+[Sonatype snapshot repository](./lite_build.md#use_nightly_snapshots) to your
 project.
 
 For instructions on how to get started, see the
@@ -168,7 +168,7 @@ To import a TensorFlow Lite (TFLite) model:
     `build.gradle` file.
 
     Note: Select the second checkbox for importing TensorFlow GPU if you
-    want to use [GPU acceleration](../performance/gpu).
+    want to use [GPU acceleration](../performance/gpu.md).
 
 1.  Click `Finish` to begin the import process. When the import is finished, the
     tool displays a screen describing the model, including its input and output


### PR DESCRIPTION
Hi, Team
I found 08 broken documentation links in this file [development.md](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/android/development.md) so I have updated those broken links to functional link. Please review and merge this change as appropriate.

Thank you for your consideration.