### PR TITLE
TfLite. Fix of issue 61269

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/tasks/special/conv_pointwise.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/special/conv_pointwise.cc
@@ -131,7 +131,7 @@ absl::Status IsReduceSumNode(const GraphFloat32& graph, Node* node,
   RETURN_IF_ERROR(
       IsNode(graph, OperationType::REDUCE_SUM, 1, 1, node, node_context));
   auto reduce_attr =
-      std::any_cast<ReduceAttributes>(node_context->node->operation.attributes);
+      absl::any_cast<ReduceAttributes>(node_context->node->operation.attributes);
   if (reduce_attr.dims != std::set<Axis>{Axis::CHANNELS}) {
     return absl::InternalError(
         "Expected reduce_sum node with channels reduction.");


### PR DESCRIPTION
TfLite. Fix of issue https://github.com/tensorflow/tensorflow/issues/61269 and corresponding LiteRT issue https://github.com/google-ai-edge/LiteRT/issues/165  Solves compile `error C2039: 'any_cast': is not a member of 'std'` with Visual Studio 2019 and 2022.