### PR TITLE
TfLite. Fix of issue 54269

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.cc
+++ b/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.cc
@@ -142,6 +142,9 @@ absl::Status LoadOpenCLOnce() {
   }
 #else
   libopencl = dlopen(kClLibName, RTLD_NOW | RTLD_LOCAL);
+  if (!libopencl) {
+    libopencl = dlopen("libOpenCL.so.1", RTLD_NOW | RTLD_LOCAL);
+  }
 #endif
   if (libopencl) {
     TFLITE_LOG(INFO) << "Loaded OpenCL library with dlopen.";


### PR DESCRIPTION
TfLite. Fix of issue [54269](https://github.com/tensorflow/tensorflow/issues/54269). Code will now try to load libOpenCL.so.1 if libOpenCL.so is absent.