### PR TITLE
Fix build error in tensorflow/lite/delegates/xnnpack/flexbuffers_util.h on s390x

### DIFF
--- a/tensorflow/lite/delegates/xnnpack/flexbuffers_util.h
+++ b/tensorflow/lite/delegates/xnnpack/flexbuffers_util.h
@@ -48,7 +48,7 @@ tflite::xnnpack::FloatPointer inline flexbuffers::Reference::As<
 #if !FLATBUFFERS_LITTLEENDIAN
   // Flexbuffers are always stored in little endian order. Returning a pointer
   // to the float data on a big endian architecture is meaningless.
-  return nullptr;
+  return {nullptr};
 #else
   return {IsFloat() ? reinterpret_cast<const float*>(data_) : nullptr};
 #endif


### PR DESCRIPTION
This PR has been raised to resolve the following error occured in s390x:
```
./tensorflow/lite/delegates/xnnpack/flexbuffers_util.h:51:10: error: no viable conversion from returned value of type 'std::nullptr_t' to function return type 'tflite::xnnpack::FloatPointer'
  51 |  return nullptr;                                                                                               
   |      ^~~~~~~
```

NOTE: This change is also working in intel.