### PR TITLE
Qualcomm AI Engine Direct - Graph O3 Optimization

### DIFF
--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/graph_mapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/graph_mapper.cc
@@ -22,10 +22,6 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "third_party/qairt/latest/include/QNN/HTP/QnnHtpGraph.h"
-#include "third_party/qairt/latest/include/QNN/QnnCommon.h"
-#include "third_party/qairt/latest/include/QNN/QnnGraph.h"
-#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
 #include "tensorflow/lite/experimental/litert/c/litert_common.h"
 #include "tensorflow/lite/experimental/litert/c/litert_logging.h"
 #include "tensorflow/lite/experimental/litert/c/litert_model.h"
@@ -35,41 +31,40 @@
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/common.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/IR/qnn_tensor.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/qnn_manager.h"
+#include "third_party/qairt/latest/include/QNN/HTP/QnnHtpGraph.h"
+#include "third_party/qairt/latest/include/QNN/QnnCommon.h"
+#include "third_party/qairt/latest/include/QNN/QnnGraph.h"
+#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
 
 namespace litert::qnn {
 
-// Get empty configurations for graph building.
-inline absl::Span<const QnnGraph_Config_t*> GetFp32GraphConfigs() {
-  static QnnHtpGraph_CustomConfig_t htp_graph_config =
-      QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
-  htp_graph_config.option = QNN_HTP_GRAPH_CONFIG_OPTION_PRECISION;
-  htp_graph_config.precision = QNN_PRECISION_FLOAT16;
-
-  static QnnGraph_Config_t graph_config = QNN_GRAPH_CONFIG_INIT;
-  graph_config.option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
-  graph_config.customConfig = &htp_graph_config;
-
-  static const QnnGraph_Config_t* configs[2] = {&graph_config, nullptr};
-  return absl::MakeSpan(configs);
-}
-
 inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs() {
-  static const QnnGraph_Config_t* configs[] = {nullptr};
-  return absl::MakeSpan(configs);
-}
+  static std::array<QnnHtpGraph_CustomConfig_t, 2> graph_custom_configs;
+  // QNN suggest always enable relax precision.
+  graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+  graph_custom_configs[0].option = QNN_HTP_GRAPH_CONFIG_OPTION_PRECISION;
+  graph_custom_configs[0].precision = QNN_PRECISION_FLOAT16;
+  // Default use O3 for now.
+  graph_custom_configs[1] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+  graph_custom_configs[1].option = QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+  graph_custom_configs[1].optimizationOption.type =
+      QNN_HTP_GRAPH_OPTIMIZATION_TYPE_FINALIZE_OPTIMIZATION_FLAG;
+  // Change to 2 if you want to use O2 (default).
+  graph_custom_configs[1].optimizationOption.floatValue = 3;
 
-absl::Span<const QnnGraph_Config_t*> GraphMapper::PickGraphConfigHeuristic() {
-  for (const auto& input : subgraph_.Inputs()) {
-    if (input.ElementType() == ElementType::Float32) {
-      return GetFp32GraphConfigs();
-    }
-  }
-  for (const auto& output : subgraph_.Outputs()) {
-    if (output.ElementType() == ElementType::Float32) {
-      return GetFp32GraphConfigs();
-    }
-  }
-  return GetDefaultGraphConfigs();
+  static std::array<QnnGraph_Config_t, 2> graph_configs;
+  graph_configs[0] = QNN_GRAPH_CONFIG_INIT;
+  graph_configs[0].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+  graph_configs[0].customConfig = &graph_custom_configs[0];
+
+  graph_configs[1] = QNN_GRAPH_CONFIG_INIT;
+  graph_configs[1].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+  graph_configs[1].customConfig = &graph_custom_configs[1];
+
+  static std::array<const QnnGraph_Config_t*, 3> result = {
+      &graph_configs[0], &graph_configs[1], nullptr};
+
+  return absl::MakeSpan(result.data(), result.size());
 }
 
 LiteRtStatus GraphMapper::AssignTensorName(Qnn_Tensor_t& qnn_tensor) {
@@ -153,7 +148,7 @@ LiteRtStatus GraphMapper::IsLiteRtSubgraphSupported() {
 LiteRtStatus GraphMapper::InitQnnGraph(absl::string_view qnn_graph_name) {
   LITERT_RETURN_STATUS_IF_QNN_NOT_OK(
       qnn_.Api()->graphCreate(context_handle_, qnn_graph_name.data(),
-                              PickGraphConfigHeuristic().data(), &QnnGraph()));
+                              GetDefaultGraphConfigs().data(), &QnnGraph()));
   return kLiteRtStatusOk;
 }
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/graph_mapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/graph_mapper.h
@@ -86,9 +86,6 @@ class GraphMapper {
   // Finalize QNN Graph. Call this after all ops have been mapped.
   LiteRtStatus Finalize();
 
-  // Pick graph config based on subgraph.
-  absl::Span<const QnnGraph_Config_t*> PickGraphConfigHeuristic();
-
   inline void RegisterOutput(LiteRtTensor litert_tensor) {
     graph_outpus_.insert(litert_tensor);
   }


### PR DESCRIPTION
1. Use O3 as default
2. Use relax precision for float as default because QNN tends to always enable it.

# Test
```
     0.0ms [  INFO ]  <I> QnnContext_getBinary done successfully. context = 0x1
INFO: [tensorflow/lite/experimental/litert/vendors/qualcomm/qnn_manager.cc:247] Serialized a context bin of size (bytes): 644400

INFO: [tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc:437] Context binary 0 generated
     0.0ms [  INFO ]  <I> QnnContext_free started. context = 0x1
     0.0ms [  INFO ]  <I> QnnContext_free done successfully.
     0.0ms [  INFO ]  <I> QnnDevice_free started. device = 0x1
     0.0ms [  INFO ]  <I> QnnDevice_free done. status 0x0
     0.0ms [  INFO ]  <I> QnnBackend_free started. backend = 0x1
     0.0ms [  INFO ] Closing environment: 0x55aab477e5f0
[       OK ] SupportedOpsTest/QnnPluginOpCompatibilityTest.SupportedOpsTest/41 (666 ms)
[----------] 42 tests from SupportedOpsTest/QnnPluginOpCompatibilityTest (2995 ms total)

[----------] Global test environment tear-down
[==========] 97 tests from 5 test suites ran. (3196 ms total)
[  PASSED  ] 97 tests.
```