### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -89,7 +89,7 @@ def enable_tensor_float_32_execution(enabled):
   TensorFloat-32 is also used for some complex64 ops. Currently, TensorFloat-32
   is used in fewer cases for complex64 as it is for float32.
 
-  Simiarly to GPUs, TPUs also run certain float32 ops, like matrix
+  Similarly to GPUs, TPUs also run certain float32 ops, like matrix
   multiplications and convolutions, with lower precision by default. Unlike
   GPUs, TPUs use bfloat16 precision instead of TensorFloat-32 precision for such
   ops. Disabling TensorFloat-32 with this function also causes TPUs to run

--- a/tensorflow/python/framework/func_graph.py
+++ b/tensorflow/python/framework/func_graph.py
@@ -379,7 +379,7 @@ class FuncGraph(ops.Graph):
           graph = ops.get_default_graph()
           assert isinstance(
               graph,
-              FuncGraph), "This API should only be used in TF2 enviroment."
+              FuncGraph), "This API should only be used in TF2 environment."
 
           with graph.as_default():
             ret_nest = graph.capture_call_time_value(

--- a/tensorflow/python/framework/immutable_dict.py
+++ b/tensorflow/python/framework/immutable_dict.py
@@ -43,6 +43,6 @@ class ImmutableDict(collections.abc.Mapping):
   def __repr__(self):
     return f'ImmutableDict({self._dict})'
 
-  # This supresses a warning that tf.nest woud otherwise generate.
+  # This suppresses a warning that tf.nest would otherwise generate.
   __supported_by_tf_nest__ = True
 

--- a/tensorflow/python/framework/python_api_dispatcher.cc
+++ b/tensorflow/python/framework/python_api_dispatcher.cc
@@ -101,7 +101,7 @@ bool RegisterDispatchableType(PyObject* py_class) {
     Safe_PyObjectPtr s(PyObject_Str(py_class));
     PyErr_SetString(PyExc_ValueError,
                     absl::StrCat("Type ", s ? PyUnicode_AsUTF8(s.get()) : "?",
-                                 " (or one of its bases clases) has "
+                                 " (or one of its bases classes) has "
                                  "already been registered")
                         .c_str());
     return false;

--- a/tensorflow/python/framework/type_utils.py
+++ b/tensorflow/python/framework/type_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Utility functions for types information, incuding full type information."""
+"""Utility functions for types information, including full type information."""
 
 from typing import List
 
@@ -96,11 +96,11 @@ def _specs_for_flat_tensors(element_spec):
   for the "batchable tensor list" encoding used by datasets and map_fn
   internally (in C++/graphs). The ability to batch, unbatch and change
   batch size is one important characteristic of this encoding. A second
-  important characteristic is that it represets a ragged tensor or sparse
+  important characteristic is that it represents a ragged tensor or sparse
   tensor as a single tensor of type variant (and this encoding uses special
   ops to encode/decode to/from variants).
 
-  (In constrast, the more typical encoding, e.g. the C++/graph
+  (In contrast, the more typical encoding, e.g. the C++/graph
   representation when calling a tf.function, is "component encoding" which
   represents sparse and ragged tensors as multiple dense tensors and does
   not use variants or special ops for encoding/decoding.)
@@ -156,7 +156,7 @@ def fulltypes_for_flat_tensors(element_spec):
       map_fn).
 
   Returns:
-    A list of FullTypeDef correspoinding to ELEMENT_SPEC. The items
+    A list of FullTypeDef corresponding to ELEMENT_SPEC. The items
     in this list correspond to the items in `_flat_tensor_specs`.
   """
   specs = _specs_for_flat_tensors(element_spec)

--- a/tensorflow/python/framework/weak_tensor.py
+++ b/tensorflow/python/framework/weak_tensor.py
@@ -196,7 +196,7 @@ class EagerWeakTensor(core.Value, WeakTensor):
 
   __name__ = "tf.EagerWeakTensor"
 
-  # Methods that are only avilable for EagerTensor.
+  # Methods that are only available for EagerTensor.
   def numpy(self):
     """Copy of the contents of this EagerWeakTensor into a NumPy array or scalar."""
     if not isinstance(self.tensor, ops.EagerTensor):


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.