### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/framework/extension_type_field.py
+++ b/tensorflow/python/framework/extension_type_field.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Meatadata about fields for user-defined ExtensionType classes."""
+"""Metadata about fields for user-defined ExtensionType classes."""
 
 import collections
 import collections.abc

--- a/tensorflow/python/framework/memory_checker.py
+++ b/tensorflow/python/framework/memory_checker.py
@@ -81,7 +81,7 @@ class MemoryChecker(object):
     that if there is a leak, it's happening similarly on every snapshot.
 
     The recommended number of `record_snapshot()` call depends on the testing
-    code complexity and the allcoation pattern.
+    code complexity and the allocation pattern.
     """
     self._python_memory_checker.record_snapshot()
 

--- a/tensorflow/python/framework/op_allowlist_namespace_test.py
+++ b/tensorflow/python/framework/op_allowlist_namespace_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""# Test that buidling using op_allowlist works with ops with namespaces."""
+"""# Test that building using op_allowlist works with ops with namespaces."""
 
 from tensorflow.python.framework import test_namespace_ops
 from tensorflow.python.platform import googletest

--- a/tensorflow/python/framework/op_callbacks.py
+++ b/tensorflow/python/framework/op_callbacks.py
@@ -94,7 +94,7 @@ def add_op_callback(callback_fn):
         #     `outputs` for downstream graph construction.
 
   Raises:
-    ValueEror: If `callback_fn` is `None` or not callable.
+    ValueError: If `callback_fn` is `None` or not callable.
   """
   # TODO(b/139668041): Implement support for overriding `EagerTensor`s from
   # callback.

--- a/tensorflow/python/framework/op_def_registry.cc
+++ b/tensorflow/python/framework/op_def_registry.cc
@@ -37,7 +37,7 @@ PYBIND11_MODULE(_op_def_registry, m) {
     }
 
     // Explicitly convert to py::bytes because std::string is implicitly
-    // convertable to py::str by default.
+    // convertible to py::str by default.
     return py::reinterpret_borrow<py::object>(py::bytes(serialized_op_def));
   });
 }

--- a/tensorflow/python/framework/tensor.py
+++ b/tensorflow/python/framework/tensor.py
@@ -405,7 +405,7 @@ class Tensor(internal.NativeObject, core_tf_types.Symbol):
     ...   tf.TensorSpec([3,5]))
     Result shape: (None, 5)
 
-    Tracing may fail if a shape missmatch can be detected:
+    Tracing may fail if a shape mismatch can be detected:
 
     >>> cf = my_matmul.get_concrete_function(
     ...   tf.TensorSpec([None,3]),
@@ -1006,7 +1006,7 @@ class TensorSpec(DenseSpec, type_spec.BatchableTypeSpec,
     )
 
   def placeholder_value(self, placeholder_context):
-    """Generates a graph placholder with the given TensorSpec information."""
+    """Generates a graph placeholder with the given TensorSpec information."""
     if placeholder_context.unnest_only:
       return self
 

--- a/tensorflow/python/framework/type_spec.py
+++ b/tensorflow/python/framework/type_spec.py
@@ -630,7 +630,7 @@ class TypeSpec(
               TypeSpec.__nested_list_to_tuple(value.tolist()))
     raise ValueError(f"Cannot generate a hashable key for {self} because "
                      f"the _serialize() method "
-                     f"returned an unsupproted value of type {type(value)}")
+                     f"returned an unsupported value of type {type(value)}")
 
   @staticmethod
   def __nested_list_to_tuple(value):


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.