### PR TITLE
Fix lack of error handling in device_lib and gpu_device_name issue##88288

### DIFF
--- a/tensorflow/python/client/device_lib_test.py
+++ b/tensorflow/python/client/device_lib_test.py
@@ -15,7 +15,8 @@
 """Tests for the SWIG-wrapped device lib."""
 
 from tensorflow.core.protobuf import config_pb2
-from tensorflow.python.client import device_lib
+from tensorflow.python.client import device_lib, _pywrap_device_lib
+from tensorflow.python.client.device_lib import device_attributes_pb2
 from tensorflow.python.framework import test_util
 from tensorflow.python.platform import googletest
 from tensorflow.python.platform import test
@@ -38,21 +39,23 @@ class DeviceLibTest(test_util.TensorFlowTestCase):
       self.assertGreater(len(devices), 1)
       self.assertIn("GPU", [d.device_type for d in devices])
 
-    @mock.patch('tensorflow.python.client._pywrap_device_lib.list_local_devices')
-    def testListLocalDevicesException(self, mock_list_local_devices):
-      mock_list_local_devices.side_effect = RuntimeError('Device list failure')
-      with self.assertRaisesRegex(RuntimeError) as e:
-        device_lib.list_local_devices()
-      self.assertIn('Device list failure', str(e.exception))
+  @mock.patch.object(_pywrap_device_lib, 'list_local_devices')
+  def testListLocalDevicesException(self, mock_list_local_devices):
+    mock_list_local_devices.side_effect = RuntimeError('Device list failure')
+    with self.assertRaisesRegex(RuntimeError) as e:
+      device_lib.list_local_devices()
+    self.assertIn('Device list failure', str(e.exception))
 
-    @mock.patch('tensorflow.python.client.device_lib.device_attributes_pb2.DeviceAttributes.ParseFromString')
-    @mock.patch('tensorflow.python.client._pywrap_device_lib.list_local_devices')
-    def testDeviceAttributesParsingException(self, mock_list_local_devices, mock_parse):
-      mock_list_local_devices.return_value = [b"invalid_proto_string"]
-      mock_parse.side_effect = ValueError("parsing failure")
-      with self.assertRaises(ValueError) as e:
-        device_lib.list_local_devices()
-      self.assertIn('Failed to parse devices', str(e.exception))
+  @mock.patch.object(device_attributes_pb2.DeviceAttributes, 'ParseFromString')
+  @mock.patch.object(_pywrap_device_lib, 'list_local_devices')
+  def testDeviceAttributesParsingException(
+    self, mock_list_local_devices, mock_parse
+  ):
+    mock_list_local_devices.return_value = [b"invalid_proto_string"]
+    mock_parse.side_effect = ValueError("parsing failure")
+    with self.assertRaises(ValueError) as e:
+      device_lib.list_local_devices()
+    self.assertIn('Failed to parse devices', str(e.exception))
 
 if __name__ == "__main__":
   googletest.main()

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -183,9 +183,13 @@ def gpu_device_name() -> str:
   ...       self.assertEqual(tf.math.add(1.0, 2.0), 3.0)
 
   """
-  for x in device_lib.list_local_devices():
-    if x.device_type == "GPU":
-      return compat.as_str(x.name)
+  try:
+    devices = device_lib.list_local_devices()
+    for x in devices:
+      if x.device_type == "GPU":
+        return compat.as_str(x.name) or ""
+  except Exception as e:
+    logging.error("Failed to get GPU device name: %s", e)
   return ""
 
 


### PR DESCRIPTION
This is a pr for issue #88288 (Fixing gpu device errors)

Currently, calling `device_lib.list_local_devices()` or `test_util.gpu_device_name()` without proper error handling causes TensorFlow to crash when GPU drivers are missing, misconfigured, or devices are improperly queried.

Changed:
Added try-except block to handle device listing failures gracefully
Added more checks for GPU detection function