### PR TITLE
[mlir][tosa] Update control flow variable names and Fix lit tests for max_pool2d and pad op

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/strip-quant-types.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/strip-quant-types.mlir
@@ -5,12 +5,12 @@
 
 // CHECK-LABEL: @test_max_pool2d_qi8
 // CHECK-SAME: %arg0: tensor<1x4x4x4xi8>) -> tensor<1x4x4x4xi8>
-func.func @test_max_pool2d_qi8(%arg0: tensor<1x4x4x4x!quant.uniform<i8:f32, 0.1:1>>) -> tensor<1x4x4x4x!quant.uniform<i8:f32, 0.1:2>> {
-  %0 = "tosa.max_pool2d"(%arg0) {kernel = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x4x4x4x!quant.uniform<i8:f32, 0.1:1>>) -> tensor<1x4x4x4x!quant.uniform<i8:f32, 0.1:2>>
+func.func @test_max_pool2d_qi8(%arg0: tensor<1x4x4x4x!quant.uniform<i8:f32, 0.1:1>>) -> tensor<1x4x4x4x!quant.uniform<i8:f32, 0.1:1>> {
+  %0 = "tosa.max_pool2d"(%arg0) {kernel = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x4x4x4x!quant.uniform<i8:f32, 0.1:1>>) -> tensor<1x4x4x4x!quant.uniform<i8:f32, 0.1:1>>
 
   // CHECK: %[[VAR0:.+]] = tosa.max_pool2d %arg0 {kernel = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>} : (tensor<1x4x4x4xi8>) -> tensor<1x4x4x4xi8>
   // CHECK: return %[[VAR0]] : tensor<1x4x4x4xi8>
-  func.return %0 : tensor<1x4x4x4x!quant.uniform<i8:f32, 0.1:2>>
+  func.return %0 : tensor<1x4x4x4x!quant.uniform<i8:f32, 0.1:1>>
 }
 
 // -----

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1556,7 +1556,7 @@ func.func @test_pad_v2(%arg0: tensor<1x256x8x25xf32>) -> (tensor<*xf32>) {
 // CHECK-LABEL: test_pad_v2_quant
 // CHECK-DAG: %[[VAL0:.*]] = "tosa.const"() <{value = dense<-128> : tensor<1xi8>}> : () -> tensor<1x!quant.uniform<i8:f32, 0.023529145866632462:42>>
 // CHECK-DAG: %[[VAL1:.*]] = tosa.const_shape  {value = dense<[0, 1, 0, 1, 0, 1, 0, 1]> : tensor<8xindex>} : () -> !tosa.shape<8>
-// CHECK: %[[VAL2:.*]] = tosa.pad %arg0, %[[VAL1]], %[[VAL0]] {input_zp = 42 : i32}
+// CHECK: %[[VAL2:.*]] = tosa.pad %arg0, %[[VAL1]], %[[VAL0]]
 // CHECK: return %[[VAL2]]
 func.func @test_pad_v2_quant(%arg0: tensor<1x7x7x9x!quant.uniform<i8:f32, 0.023529145866632462:42>>) -> (tensor<2x8x8x10x!quant.uniform<i8:f32, 0.023529145866632462:42>>) {
   %0 = "tfl.pseudo_const"() <{value = dense<[[0, 1], [0, 1], [0, 1], [0, 1]]> : tensor<4x2xi32>}> : () -> tensor<4x2xi32>

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -4635,11 +4635,11 @@ LogicalResult ConvertTFLWhileOp::matchAndRewrite(
   auto while_op = rewriter.create<mlir::tosa::WhileOp>(
       op->getLoc(), op->getResultTypes(), op->getOperands());
 
-  rewriter.createBlock(&while_op.getCond());
-  rewriter.createBlock(&while_op.getBody());
+  rewriter.createBlock(&while_op.getCondGraph());
+  rewriter.createBlock(&while_op.getBodyGraph());
 
-  inlineWhileCase(tfl_while_op.getCond(), while_op.getCond(), rewriter);
-  inlineWhileCase(tfl_while_op.getBody(), while_op.getBody(), rewriter);
+  inlineWhileCase(tfl_while_op.getCond(), while_op.getCondGraph(), rewriter);
+  inlineWhileCase(tfl_while_op.getBody(), while_op.getBodyGraph(), rewriter);
 
   rewriter.replaceOp(tfl_while_op, while_op.getResults());
 


### PR DESCRIPTION
We've been pushing TOSA v1.0 LLVM patches to upstream. This PR includes commit(s) to keep the following operator(s) to be aligned with LLVM:

[mlir][tosa] Remove optional for pad_const and remove input_zp attr for PadOp
https://github.com/llvm/llvm-project/pull/129336

[mlir][tosa] Add more verifiers for the following operators
https://github.com/llvm/llvm-project/pull/127923

This PR addresses the current issue of broken code and lit tests.
