### PR TITLE
Qualcomm AI Engine Direct - Two step TensorWrapper

### DIFF
--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -27,7 +27,6 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
-#include "third_party/qairt/latest/include/QNN/HTP/QnnHtpDevice.h"
 #include "tensorflow/lite/experimental/litert/c/litert_common.h"
 #include "tensorflow/lite/experimental/litert/c/litert_logging.h"
 #include "tensorflow/lite/experimental/litert/c/litert_model.h"
@@ -41,6 +40,7 @@
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/qnn_manager.h"
+#include "third_party/qairt/latest/include/QNN/HTP/QnnHtpDevice.h"
 
 using ::litert::qnn::QnnManager;
 using LiteRtBufferId = uint32_t;
@@ -305,7 +305,7 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
         op, tensor_pool, input_tensors, output_tensors, op_wrappers));
     if (std::all_of(
             op_wrappers.begin(), op_wrappers.end(),
-            [&qnn_manager](const ::qnn::OpWrapper& op_wrapper) -> bool {
+            [&qnn_manager](::qnn::OpWrapper& op_wrapper) -> bool {
               return kLiteRtStatusOk ==
                      (*qnn_manager)->ValidateOp(op_wrapper.GetOpConfig());
             })) {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -26,8 +26,6 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
-#include "third_party/qairt/latest/include/QNN/QnnCommon.h"
-#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
 #include "tensorflow/lite/experimental/litert/c/litert_common.h"
 #include "tensorflow/lite/experimental/litert/c/litert_logging.h"
 #include "tensorflow/lite/experimental/litert/c/litert_model.h"
@@ -73,6 +71,8 @@
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/qnn_manager.h"
+#include "third_party/qairt/latest/include/QNN/QnnCommon.h"
+#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
 
 namespace litert::qnn {
 
@@ -590,11 +590,7 @@ LiteRtStatus MapGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
   // Legalize subgraph inputs and update tensors in scope
   //
 
-  ::qnn::TensorPool tensor_pool(
-      [&qnn, &graph_mapper](::qnn::TensorWrapper& tensor_wrapper) {
-        qnn.Api()->tensorCreateGraphTensor(graph_mapper.QnnGraph(),
-                                           &tensor_wrapper.GetQnnTensor());
-      });
+  ::qnn::TensorPool tensor_pool;
   absl::flat_hash_map<LiteRtTensor, ::qnn::TensorWrapper*>
       litert_tensor_to_wrapper;
 
@@ -612,6 +608,8 @@ LiteRtStatus MapGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
   // Topologically traverse graph, legalizing and updating tensors in scope
   //
 
+  // TODO: make ConvertOp accept a vector and append OpWrapper in it.
+  std::vector<::qnn::OpWrapper> graph_op_wrappers;
   std::ostringstream dump;
   for (const auto& op : graph_mapper.Graph().Ops()) {
     // Dump op info.
@@ -648,11 +646,18 @@ LiteRtStatus MapGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
     std::vector<::qnn::OpWrapper> op_wrappers;
     LITERT_RETURN_IF_ERROR(
         ConvertOp(op, tensor_pool, input_tensors, output_tensors, op_wrappers));
-
-    for (const auto& op_wrapper : op_wrappers) {
-      qnn.Api()->graphAddNode(graph_mapper.QnnGraph(),
-                              op_wrapper.GetOpConfig());
-    }
+    std::move(op_wrappers.begin(), op_wrappers.end(),
+              std::back_inserter(graph_op_wrappers));
+  }
+  // Insert all tensors into Qnn graph and update the id of Qnn_Tensor_t inside.
+  tensor_pool.ForEach(
+      [&qnn, &graph_mapper](::qnn::TensorWrapper& tensor_wrapper) {
+        qnn.Api()->tensorCreateGraphTensor(graph_mapper.QnnGraph(),
+                                           &tensor_wrapper.GetQnnTensor());
+      });
+  // Then op can be added into Qnn graph after the tensor ids are updated.
+  for (auto& op_wrapper : graph_op_wrappers) {
+    qnn.Api()->graphAddNode(graph_mapper.QnnGraph(), op_wrapper.GetOpConfig());
   }
 
   LITERT_RETURN_STATUS_IF_QNN_NOT_OK(graph_mapper.Finalize());

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Qualcomm Innovation Center, Inc.
-// All Rights Reserved.
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
 
@@ -15,20 +15,12 @@ namespace qnn {
 
 TensorPool::TensorPool() = default;
 
-TensorPool::TensorPool(std::function<void(TensorWrapper&)> tensor_callback)
-    : tensor_callback_{tensor_callback}, tensor_wrappers_{} {}
-
 TensorWrapper& TensorPool::CreateInputTensor(
     Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
     const std::vector<std::uint32_t>& dimentions) {
   const auto id = tensor_wrappers_.size();
   auto& back = tensor_wrappers_.emplace_back(
       id, QNN_TENSOR_TYPE_APP_WRITE, data_type, quant_params, dimentions);
-
-  if (tensor_callback_) {
-    tensor_callback_(back);
-  }
-
   return back;
 }
 
@@ -38,11 +30,6 @@ TensorWrapper& TensorPool::CreateOutpuTensor(
   const auto id = tensor_wrappers_.size();
   auto& back = tensor_wrappers_.emplace_back(
       id, QNN_TENSOR_TYPE_APP_READ, data_type, quant_params, dimentions);
-
-  if (tensor_callback_) {
-    tensor_callback_(back);
-  }
-
   return back;
 }
 
@@ -52,11 +39,6 @@ TensorWrapper& TensorPool::CreateNativeTensor(
   const auto id = tensor_wrappers_.size();
   auto& back = tensor_wrappers_.emplace_back(
       id, QNN_TENSOR_TYPE_NATIVE, data_type, quant_params, dimentions);
-
-  if (tensor_callback_) {
-    tensor_callback_(back);
-  }
-
   return back;
 }
 
@@ -68,11 +50,6 @@ TensorWrapper& TensorPool::CreateStaticTensor(
   auto& back =
       tensor_wrappers_.emplace_back(id, QNN_TENSOR_TYPE_STATIC, data_type,
                                     quant_params, dimentions, bytes, data);
-
-  if (tensor_callback_) {
-    tensor_callback_(back);
-  }
-
   return back;
 }
 
@@ -81,11 +58,6 @@ TensorWrapper& TensorPool::CloneNativeTensorFrom(const TensorWrapper& src) {
   auto& back = tensor_wrappers_.emplace_back(
       id, QNN_TENSOR_TYPE_NATIVE, src.GetDataType(), src.quantize_params_,
       src.dimentions_);
-
-  if (tensor_callback_) {
-    tensor_callback_(back);
-  }
-
   return back;
 }
 
@@ -95,11 +67,6 @@ TensorWrapper& TensorPool::CloneNativeTensorFrom(
   auto& back = tensor_wrappers_.emplace_back(id, QNN_TENSOR_TYPE_NATIVE,
                                              src.GetDataType(),
                                              src.quantize_params_, dimentions);
-
-  if (tensor_callback_) {
-    tensor_callback_(back);
-  }
-
   return back;
 }
 
@@ -109,11 +76,6 @@ TensorWrapper& TensorPool::CloneStaticTensorFrom(const TensorWrapper& src,
   auto& back = tensor_wrappers_.emplace_back(
       id, QNN_TENSOR_TYPE_STATIC, data_type, src.quantize_params_,
       src.dimentions_, src.owned_data_.size(), src.owned_data_.data());
-
-  if (tensor_callback_) {
-    tensor_callback_(back);
-  }
-
   return back;
 }
 
@@ -124,10 +86,6 @@ TensorWrapper& TensorPool::CloneStaticTensorFrom(
       id, QNN_TENSOR_TYPE_STATIC, src.qnn_tensor_.v2.dataType,
       src.quantize_params_, dimentions, src.qnn_tensor_.v2.clientBuf.dataSize,
       src.qnn_tensor_.v2.clientBuf.data);
-
-  if (tensor_callback_) {
-    tensor_callback_(back);
-  }
 
   return back;
 }

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h
@@ -1,5 +1,5 @@
-// Copyright (c) Qualcomm Innovation Center, Inc.
-// All Rights Reserved.
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_TENSOR_POOL_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_TENSOR_POOL_H_
@@ -9,17 +9,15 @@
 #include <list>
 #include <vector>
 
-#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
 
 namespace qnn {
 
 class TensorPool {
  public:
   TensorPool();
-
-  TensorPool(std::function<void(TensorWrapper&)> tensor_callback);
 
   TensorWrapper& CreateInputTensor(
       Qnn_DataType_t data_type,
@@ -53,8 +51,14 @@ class TensorPool {
   TensorWrapper& CloneStaticTensorFrom(
       const TensorWrapper& src, const std::vector<std::uint32_t>& dimentions);
 
+  template <typename UnaryFunc>
+  void ForEach(UnaryFunc f) {
+    for (auto& tensor_wrapper : tensor_wrappers_) {
+      f(tensor_wrapper);
+    }
+  }
+
  private:
-  std::function<void(TensorWrapper&)> tensor_callback_{};
   std::list<TensorWrapper> tensor_wrappers_{};
 };
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/BUILD
@@ -26,6 +26,17 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "miscs",
+    hdrs = ["miscs.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+    ],
+)
+
 cc_test(
     name = "utils_test",
     srcs = [
@@ -43,6 +54,7 @@ cc_test(
     ],
     deps = [
         ":log",
+        ":miscs",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/miscs.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/miscs.h
@@ -1,0 +1,14 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_UTILS_MISCS_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_UTILS_MISCS_H_
+
+namespace qnn {
+
+template <typename...>
+inline constexpr bool always_false = false;
+
+}
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_UTILS_MISCS_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/utils_test.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/utils_test.cc
@@ -1,14 +1,16 @@
 // Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <gtest/gtest.h>
+
 #include <filesystem>
 #include <fstream>
 #include <string>
 
-#include <gtest/gtest.h>
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/log.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/misc.h"
 
-namespace litert {
+namespace qnn {
 namespace {
 
 bool IsPrefix(std::string_view prefix, std::string_view full) {
@@ -80,4 +82,22 @@ TEST_P(LiteRtLog, SanityTest) {
   // Delete the temporary log file
   std::filesystem::remove(temp_path);
 }
-}  // namespace litert
+
+TEST(MiscTest, TestAlwaysFalse) {
+  ASSERT_FALSE(::qnn::always_false<bool>);
+  ASSERT_FALSE(::qnn::always_false<signed char>);
+  ASSERT_FALSE(::qnn::always_false<unsigned char>);
+  ASSERT_FALSE(::qnn::always_false<short int>);
+  ASSERT_FALSE(::qnn::always_false<unsigned short int>);
+  ASSERT_FALSE(::qnn::always_false<int>);
+  ASSERT_FALSE(::qnn::always_false<unsigned int>);
+  ASSERT_FALSE(::qnn::always_false<long int>);
+  ASSERT_FALSE(::qnn::always_false<unsigned long int>);
+  ASSERT_FALSE(::qnn::always_false<long long int>);
+  ASSERT_FALSE(::qnn::always_false<unsigned long long int>);
+  ASSERT_FALSE(::qnn::always_false<float>);
+  ASSERT_FALSE(::qnn::always_false<double>);
+  ASSERT_FALSE(::qnn::always_false<long double>);
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/BUILD
@@ -33,6 +33,7 @@ cc_library(
         "@com_google_absl//absl/types:span",
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils:log",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils:miscs",
     ],
 )
 
@@ -47,6 +48,7 @@ cc_library(
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils:log",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils:miscs",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
     ],
 )

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -1,5 +1,5 @@
-// Copyright (c) Qualcomm Innovation Center, Inc.
-// All Rights Reserved.
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 
@@ -9,64 +9,70 @@
 namespace qnn {
 
 OpWrapper::OpWrapper(std::string name, const char* op_type)
-    : name_{std::move(name)} {
-  qnn_op_.v1.packageName = QNN_OP_PACKAGE_NAME_QTI_AISW;
-  qnn_op_.v1.typeName = op_type;
-  qnn_op_.v1.name = name_.c_str();
-}
-
-OpWrapper::OpWrapper(const OpWrapper& other)
-    : qnn_op_{other.qnn_op_},
-      name_{other.name_},
-      params_{other.params_},
-      input_tensors_{other.input_tensors_},
-      output_tensors_{other.output_tensors_} {
-  qnn_op_.v1.name = name_.c_str();
-  qnn_op_.v1.params = params_.data();
-  qnn_op_.v1.inputTensors = input_tensors_.data();
-  qnn_op_.v1.outputTensors = output_tensors_.data();
-}
+    : type_name_{op_type}, name_{std::move(name)} {}
 
 OpWrapper::OpWrapper(OpWrapper&& other)
-    : qnn_op_{other.qnn_op_},
+    : type_name_{other.type_name_},
       name_{std::move(other.name_)},
-      params_{std::move(other.params_)},
       input_tensors_{std::move(other.input_tensors_)},
-      output_tensors_{std::move(other.output_tensors_)} {
-  qnn_op_.v1.name = name_.c_str();
-  qnn_op_.v1.params = params_.data();
-  qnn_op_.v1.inputTensors = input_tensors_.data();
-  qnn_op_.v1.outputTensors = output_tensors_.data();
-}
+      output_tensors_{std::move(other.output_tensors_)},
+      scalar_params_{std::move(other.scalar_params_)},
+      tensor_params_{std::move(other.tensor_params_)},
+      qnn_input_tensors_{std::move(other.qnn_input_tensors_)},
+      qnn_output_tensors_{std::move(other.qnn_output_tensors_)},
+      qnn_params_{std::move(other.qnn_params_)} {}
 
 OpWrapper::~OpWrapper() = default;
 
 void OpWrapper::AddInputTensor(const TensorWrapper& tensor) {
-  auto& back = input_tensors_.emplace_back();
-  tensor.CloneTo(back);
-
-  qnn_op_.v1.numOfInputs = input_tensors_.size();
-  qnn_op_.v1.inputTensors = input_tensors_.data();
+  input_tensors_.emplace_back(tensor);
 }
 
 void OpWrapper::AddOutputTensor(const TensorWrapper& tensor) {
-  auto& back = output_tensors_.emplace_back();
-  tensor.CloneTo(back);
-
-  qnn_op_.v1.numOfOutputs = output_tensors_.size();
-  qnn_op_.v1.outputTensors = output_tensors_.data();
+  output_tensors_.emplace_back(tensor);
 }
 
 void OpWrapper::AddTensorParam(const char* name, const TensorWrapper& tensor) {
-  TensorParamWrapper param_wrapper(name, tensor);
-
-  auto& back = params_.emplace_back();
-  param_wrapper.CloneTo(back);
-
-  qnn_op_.v1.numOfParams = params_.size();
-  qnn_op_.v1.params = params_.data();
+  tensor_params_.emplace_back(name, tensor);
 }
 
-const Qnn_OpConfig_t& OpWrapper::GetOpConfig() const { return qnn_op_; }
+Qnn_OpConfig_t OpWrapper::GetOpConfig() {
+  Qnn_OpConfig_t qnn_op = QNN_OPCONFIG_INIT;
+  qnn_op.v1.packageName = QNN_OP_PACKAGE_NAME_QTI_AISW;
+  qnn_op.v1.typeName = type_name_;
+  qnn_op.v1.name = name_.data();
+  // input tensors
+  qnn_input_tensors_.reserve(input_tensors_.size());
+  qnn_input_tensors_.clear();
+  for (const auto& input_tensor : input_tensors_) {
+    auto& back = qnn_input_tensors_.emplace_back();
+    input_tensor.get().CloneTo(back);
+  }
+  qnn_op.v1.numOfInputs = qnn_input_tensors_.size();
+  qnn_op.v1.inputTensors = qnn_input_tensors_.data();
+  // output tensors
+  qnn_output_tensors_.reserve(output_tensors_.size());
+  qnn_output_tensors_.clear();
+  for (const auto& output_tensor : output_tensors_) {
+    auto& back = qnn_output_tensors_.emplace_back();
+    output_tensor.get().CloneTo(back);
+  }
+  qnn_op.v1.numOfOutputs = qnn_output_tensors_.size();
+  qnn_op.v1.outputTensors = qnn_output_tensors_.data();
+  // params
+  qnn_params_.reserve(scalar_params_.size() + tensor_params_.size());
+  qnn_params_.clear();
+  for (const auto& scalar_param : scalar_params_) {
+    auto& back = qnn_params_.emplace_back();
+    scalar_param.CloneTo(back);
+  }
+  for (const auto& tensor_param : tensor_params_) {
+    auto& back = qnn_params_.emplace_back();
+    tensor_param.CloneTo(back);
+  }
+  qnn_op.v1.numOfParams = qnn_params_.size();
+  qnn_op.v1.params = qnn_params_.data();
+  return qnn_op;
+}
 
 }  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -1,12 +1,12 @@
-// Copyright (c) Qualcomm Innovation Center, Inc.
-// All Rights Reserved.
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_OP_WRAPPER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_OP_WRAPPER_H_
 
-#include "third_party/qairt/latest/include/QNN/QnnOpDef.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "third_party/qairt/latest/include/QNN/QnnOpDef.h"
 
 namespace qnn {
 
@@ -14,7 +14,7 @@ class OpWrapper final {
  public:
   explicit OpWrapper(std::string name, const char* op_type);
 
-  OpWrapper(const OpWrapper& other);
+  OpWrapper(const OpWrapper& other) = delete;
 
   OpWrapper(OpWrapper&& other);
 
@@ -27,25 +27,23 @@ class OpWrapper final {
   template <typename T>
   void AddScalarParam(const char* name, const T data,
                       const bool is_quant = false) {
-    ScalarParamWrapper param_wrapper(name, data, is_quant);
-
-    auto& back = params_.emplace_back();
-    param_wrapper.CloneTo(back);
-
-    qnn_op_.v1.numOfParams = params_.size();
-    qnn_op_.v1.params = params_.data();
+    scalar_params_.emplace_back(name, data, is_quant);
   }
 
   void AddTensorParam(const char* name, const TensorWrapper& tensor);
 
-  const Qnn_OpConfig_t& GetOpConfig() const;
+  Qnn_OpConfig_t GetOpConfig();
 
  private:
-  Qnn_OpConfig_t qnn_op_ = QNN_OPCONFIG_INIT;
+  const char* type_name_{nullptr};
   std::string name_{};  // human readable name
-  std::vector<Qnn_Param_t> params_{};
-  std::vector<Qnn_Tensor_t> input_tensors_{};
-  std::vector<Qnn_Tensor_t> output_tensors_{};
+  std::vector<std::reference_wrapper<const TensorWrapper>> input_tensors_{};
+  std::vector<std::reference_wrapper<const TensorWrapper>> output_tensors_{};
+  std::vector<ScalarParamWrapper> scalar_params_{};
+  std::vector<TensorParamWrapper> tensor_params_{};
+  std::vector<Qnn_Tensor_t> qnn_input_tensors_{};
+  std::vector<Qnn_Tensor_t> qnn_output_tensors_{};
+  std::vector<Qnn_Param_t> qnn_params_{};
 };
 
 }  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.cc
@@ -1,19 +1,24 @@
-// Copyright (c) Qualcomm Innovation Center, Inc.
-// All Rights Reserved.
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h"
 
 namespace qnn {
 
-void ScalarParamWrapper::CloneTo(Qnn_Param_t& dst) const { dst = qnn_param_; }
-
-TensorParamWrapper::TensorParamWrapper(const char* name,
-                                       const TensorWrapper& tensor) {
-  qnn_param_.name = name;
-  qnn_param_.paramType = QNN_PARAMTYPE_TENSOR;
-  tensor.CloneTo(qnn_param_.tensorParam);
+void ScalarParamWrapper::CloneTo(Qnn_Param_t& dst) const {
+  dst.name = name_;
+  dst.paramType = QNN_PARAMTYPE_SCALAR;
+  dst.scalarParam = qnn_scalar_;
 }
 
-void TensorParamWrapper::CloneTo(Qnn_Param_t& dst) const { dst = qnn_param_; }
+TensorParamWrapper::TensorParamWrapper(const char* name,
+                                       const TensorWrapper& tensor)
+    : name_{name}, tensor_{tensor} {}
+
+void TensorParamWrapper::CloneTo(Qnn_Param_t& dst) const {
+  dst.name = name_;
+  dst.paramType = QNN_PARAMTYPE_TENSOR;
+  tensor_.CloneTo(dst.tensorParam);
+}
 
 }  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h
@@ -6,9 +6,10 @@
 
 #include <type_traits>
 
-#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/log.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/miscs.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
 
 namespace qnn {
 
@@ -16,48 +17,49 @@ class ScalarParamWrapper {
  public:
   template <typename T>
   explicit ScalarParamWrapper(const char* name, const T data,
-                              const bool is_quant) {
-    qnn_param_.name = name;
-    qnn_param_.paramType = QNN_PARAMTYPE_SCALAR;
+                              const bool is_quant)
+      : name_{name} {
     if constexpr (std::is_same_v<T, bool>) {
-      qnn_param_.scalarParam.dataType = QNN_DATATYPE_BOOL_8;
-      qnn_param_.scalarParam.bool8Value = data;
+      qnn_scalar_.dataType = QNN_DATATYPE_BOOL_8;
+      qnn_scalar_.bool8Value = data;
     } else if constexpr (std::is_same_v<T, std::uint8_t>) {
-      qnn_param_.scalarParam.dataType =
+      qnn_scalar_.dataType =
           is_quant ? QNN_DATATYPE_UFIXED_POINT_8 : QNN_DATATYPE_UINT_8;
-      qnn_param_.scalarParam.uint8Value = data;
+      qnn_scalar_.uint8Value = data;
     } else if constexpr (std::is_same_v<T, std::int8_t>) {
-      qnn_param_.scalarParam.dataType =
+      qnn_scalar_.dataType =
           is_quant ? QNN_DATATYPE_SFIXED_POINT_8 : QNN_DATATYPE_INT_8;
-      qnn_param_.scalarParam.int8Value = data;
+      qnn_scalar_.int8Value = data;
     } else if constexpr (std::is_same_v<T, std::uint16_t>) {
-      qnn_param_.scalarParam.dataType =
+      qnn_scalar_.dataType =
           is_quant ? QNN_DATATYPE_UFIXED_POINT_16 : QNN_DATATYPE_UINT_16;
-      qnn_param_.scalarParam.uint16Value = data;
+      qnn_scalar_.uint16Value = data;
     } else if constexpr (std::is_same_v<T, std::int16_t>) {
-      qnn_param_.scalarParam.dataType =
+      qnn_scalar_.dataType =
           is_quant ? QNN_DATATYPE_SFIXED_POINT_16 : QNN_DATATYPE_INT_16;
-      qnn_param_.scalarParam.int16Value = data;
+      qnn_scalar_.int16Value = data;
     } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-      qnn_param_.scalarParam.dataType =
+      qnn_scalar_.dataType =
           is_quant ? QNN_DATATYPE_UFIXED_POINT_32 : QNN_DATATYPE_UINT_32;
-      qnn_param_.scalarParam.uint32Value = data;
+      qnn_scalar_.uint32Value = data;
     } else if constexpr (std::is_same_v<T, std::int32_t>) {
-      qnn_param_.scalarParam.dataType =
+      qnn_scalar_.dataType =
           is_quant ? QNN_DATATYPE_SFIXED_POINT_32 : QNN_DATATYPE_INT_32;
-      qnn_param_.scalarParam.int32Value = data;
+      qnn_scalar_.int32Value = data;
     } else if constexpr (std::is_same_v<T, float>) {
-      qnn_param_.scalarParam.dataType = QNN_DATATYPE_FLOAT_32;
-      qnn_param_.scalarParam.floatValue = data;
+      qnn_scalar_.dataType = QNN_DATATYPE_FLOAT_32;
+      qnn_scalar_.floatValue = data;
     } else {
-      QNN_LOG_ERROR("Unsupported data type for scalar param.");
+      static_assert(::qnn::always_false<T>,
+                    "Unsupported data type for scalar param.");
     }
   }
 
   void CloneTo(Qnn_Param_t& dst) const;
 
  private:
-  Qnn_Param_t qnn_param_ = QNN_PARAM_INIT;
+  const char* name_ = nullptr;
+  Qnn_Scalar_t qnn_scalar_ = QNN_SCALAR_INIT;
 };
 
 class TensorParamWrapper {
@@ -67,7 +69,8 @@ class TensorParamWrapper {
   void CloneTo(Qnn_Param_t& dst) const;
 
  private:
-  Qnn_Param_t qnn_param_ = QNN_PARAM_INIT;
+  const char* name_ = nullptr;
+  const TensorWrapper& tensor_;
 };
 
 }  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -16,12 +16,10 @@
 #include "absl/types/span.h"
 #include "third_party/qairt/latest/include/QNN/QnnTypes.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/log.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/miscs.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
 
 namespace qnn {
-
-template <typename...>
-inline constexpr bool always_false = false;
 
 // Get the Qnn_DataType_t associated with given C++ type.
 template <typename T>


### PR DESCRIPTION
# WHAT
Original flow:
1. Convert LiteRt tensor to TensorWrapper
2. Add TensorWrapper into Qnn graph
3. Convert LiteRt op to OpWrapper by op builder
4. Add OpWrapper into Qnn graph

But in some op builder, we may modify some TensorWrapper inside. And these modification won't work due to the original flow. i.e. https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc#L78-L81

Proposed flow:
1. Convert LiteRt tensor to TensorWrapper
2. **Convert LiteRt op to OpWrapper by op builder**
3. **Add TensorWrapper into Qnn graph**
4. Add OpWrapper into Qnn graph

# TEST
- qnn_compiler_plugin_test
```
[----------] Global test environment tear-down
[==========] 115 tests from 5 test suites ran. (3463 ms total)
[  PASSED  ] 115 tests.
```
