### PR TITLE
Qualcomm AI Engine Direct - Enable QNN profiler in LiteRt

### DIFF
--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/common.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/common.h
@@ -8,6 +8,12 @@
 extern "C" {
 #endif  // __cplusplus
 
+typedef enum LiteRtProfilingOptions {  // NOLINT(modernize-use-using)
+  kProfilingOff = 0,
+  kProfilnigBasic = 1,
+  kProfilingDetailed = 2
+} LiteRtProfilingOptions;
+
 typedef enum LiteRtQnnLogLevel {  // NOLINT(modernize-use-using)
   /// Disable delegate and QNN backend logging messages.
   kLogOff = 0,
@@ -21,9 +27,18 @@ typedef enum LiteRtQnnLogLevel {  // NOLINT(modernize-use-using)
 typedef struct {  // NOLINT(modernize-use-using)
   /// Apply HTP-friendly op builder.
   bool useHtpPreferencs;
+  /// This option will treat quantized int16 tensor as quantized uint16 tensor
+  /// for better backend compatibility.
+  bool useQInt16AsQUint16;
 } LiteRtQnnOptions;
 
-#define LITERT_QNN_OPTIONS_INIT {false, /*useHtpPreferencs*/}
+// clang-format off
+#define LITERT_QNN_OPTIONS_INIT      \
+  {                                  \
+    false,    /*useHtpPreferencs*/   \
+    true,     /*useQInt16AsQUint16*/ \
+  }
+// clang-format on
 
 #ifdef __cplusplus
 }

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/dispatch/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/dispatch/BUILD
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 load("//tensorflow/lite/experimental/litert/build_common:litert_build_defs.bzl", "copy_file", "litert_dynamic_lib")
 
@@ -63,6 +66,7 @@ litert_dynamic_lib(
         "//tensorflow/lite/experimental/litert/core/util:tensor_type_util",
         "//tensorflow/lite/experimental/litert/vendors/c:litert_dispatch_c_api",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm:common",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:common",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm:context_binary_info",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm:qnn_manager",
     ],
@@ -101,6 +105,7 @@ cc_test(
     ],
     deps = [
         "//tensorflow/lite/experimental/litert/c:litert_common",
+        "//tensorflow/lite/experimental/litert/c:litert_runtime_c_api_shared_lib",
         "//tensorflow/lite/experimental/litert/c:litert_tensor_buffer",
         "//tensorflow/lite/experimental/litert/cc:litert_any",
         "//tensorflow/lite/experimental/litert/core:filesystem",

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_DISPATCH_LITERT_DISPATCH_INVOCATION_CONTEXT_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_DISPATCH_LITERT_DISPATCH_INVOCATION_CONTEXT_H_
@@ -53,6 +56,8 @@ class LiteRtDispatchInvocationContextT {
       int graph_output_index, LiteRtTensorBufferHandle tensor_buffer_handle);
 
   litert::Expected<void> Execute();
+
+  litert::Expected<void> Profile();
 
   Qnn_ContextHandle_t ContextHandle() { return context_handle_.get(); }
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/qnn_manager.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/qnn_manager.cc
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/qnn_manager.h"
 
@@ -354,7 +357,7 @@ Expected<QnnManager::ContextHandle> QnnManager::CreateContextHandle(
                       "Failed to create QNN context");
   }
   auto deleter = Api()->contextFree;
-  return ContextHandle{context_handle, /*profile=*/nullptr, deleter};
+  return ContextHandle{context_handle, /*profile=*/nullptr, deleter, nullptr};
 }
 
 Expected<QnnManager::ContextHandle> QnnManager::CreateContextHandle(
@@ -369,8 +372,10 @@ Expected<QnnManager::ContextHandle> QnnManager::CreateContextHandle(
     return Unexpected(kLiteRtStatusErrorRuntimeFailure,
                       "Failed to create QNN context");
   }
-  auto deleter = Api()->contextFree;
-  return ContextHandle{context_handle, profile_handle, deleter};
+  auto context_deleter = Api()->contextFree;
+  auto profile_deleter = Api()->profileFree;
+  return ContextHandle{context_handle, profile_handle, context_deleter,
+                       profile_deleter};
 }
 
 Expected<QnnManager::Ptr> QnnManager::Create(

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/qnn_manager.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/qnn_manager.h
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_QNN_MANAGER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_QNN_MANAGER_H_
@@ -35,6 +38,7 @@
 #include "third_party/qairt/latest/include/QNN/System/QnnSystemContext.h"
 #include "third_party/qairt/latest/include/QNN/System/QnnSystemInterface.h"
 #include "tensorflow/lite/experimental/litert/c/litert_common.h"
+#include "tensorflow/lite/experimental/litert/c/litert_logging.h"
 #include "tensorflow/lite/experimental/litert/cc/litert_expected.h"
 #include "tensorflow/lite/experimental/litert/cc/litert_macros.h"  // IWYU pragma: keep
 #include "tensorflow/lite/experimental/litert/cc/litert_shared_library.h"
@@ -127,6 +131,10 @@ class QnnManager {
 
   bool IsLegacySocModel() { return soc_model_ == QNN_HTP_DEVICE_ARCH_V68; }
 
+  // Get qnn backend handle. Nullptr if backendCreate has not been successfully
+  // called.
+  Qnn_BackendHandle_t& BackendHandle() { return backend_handle_; }
+
  private:
   QnnManager() = default;
 
@@ -160,10 +168,6 @@ class QnnManager {
 
   // Get qnn log handle. Nullptr if logCreate has not been successfully called.
   Qnn_LogHandle_t& LogHandle() { return log_handle_; }
-
-  // Get qnn backend handle. Nullptr if backendCreate has not been successfully
-  // called.
-  Qnn_BackendHandle_t& BackendHandle() { return backend_handle_; }
 
   // Get qnn device handle. Nullptr if deviceCreate has not been successfully
   // called.
@@ -203,12 +207,25 @@ class QnnManager {
 class QnnManager::ContextHandle {
  public:
   ContextHandle(Qnn_ContextHandle_t context_handle, Qnn_ProfileHandle_t profile,
-                QnnContext_FreeFn_t free_fn)
-      : context_handle_(context_handle), profile_(profile), free_fn_(free_fn) {}
+                QnnContext_FreeFn_t free_fn,
+                QnnProfile_FreeFn_t profile_free_fn)
+      : context_handle_(context_handle),
+        profile_(profile),
+        free_fn_(free_fn),
+        profile_free_fn_(profile_free_fn) {}
 
   ~ContextHandle() {
+    if (profile_ && profile_free_fn_) {
+      if (auto status = profile_free_fn_(profile_); status != QNN_SUCCESS) {
+        LITERT_LOG(LITERT_ERROR, "%s", "Failed to free profile handle\n");
+      }
+      profile_ = nullptr;
+    }
     if (context_handle_ && free_fn_) {
-      free_fn_(context_handle_, profile_);
+      if (auto status = free_fn_(context_handle_, profile_);
+          status != QNN_SUCCESS) {
+        LITERT_LOG(LITERT_ERROR, "%s", "Failed to free context handle\n");
+      }
     }
   }
 
@@ -220,6 +237,7 @@ class QnnManager::ContextHandle {
     std::swap(context_handle_, other.context_handle_);
     std::swap(profile_, other.profile_);
     std::swap(free_fn_, other.free_fn_);
+    std::swap(profile_free_fn_, other.profile_free_fn_);
     return *this;
   }
 
@@ -232,6 +250,7 @@ class QnnManager::ContextHandle {
   Qnn_ContextHandle_t context_handle_ = nullptr;
   Qnn_ProfileHandle_t profile_ = nullptr;
   QnnContext_FreeFn_t free_fn_ = nullptr;
+  QnnProfile_FreeFn_t profile_free_fn_ = nullptr;
 };
 
 }  // namespace litert::qnn


### PR DESCRIPTION
Summary:
- Use kProfilingOff profiling_level as default for now
- Implement QNN profiler with simple format
- Can be tested with dispatch_api_qualcomm_test
- Need to add into dispatch option after header interface merged