### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/feature_column/feature_column_test.py
+++ b/tensorflow/python/feature_column/feature_column_test.py
@@ -4571,7 +4571,7 @@ class IndicatorColumnTest(test.TestCase):
                           self.evaluate(output))
 
   def test_2D_shape_succeeds(self):
-    # TODO(ispir/cassandrax): Swith to categorical_column_with_keys when ready.
+    # TODO(ispir/cassandrax): Switch to categorical_column_with_keys when ready.
     animal = fc._indicator_column(
         fc._categorical_column_with_hash_bucket('animal', 4))
     builder = _LazyBuilder({

--- a/tensorflow/python/feature_column/feature_column_v2_test.py
+++ b/tensorflow/python/feature_column/feature_column_v2_test.py
@@ -4381,7 +4381,7 @@ class IndicatorColumnTest(test.TestCase):
                         self.evaluate(output))
 
   def test_2D_shape_succeeds(self):
-    # TODO(ispir/cassandrax): Swith to categorical_column_with_keys when ready.
+    # TODO(ispir/cassandrax): Switch to categorical_column_with_keys when ready.
     animal = fc.indicator_column(
         fc.categorical_column_with_hash_bucket('animal', 4))
     transformation_cache = fc.FeatureTransformationCache({

--- a/tensorflow/python/framework/composite_tensor_gradient.py
+++ b/tensorflow/python/framework/composite_tensor_gradient.py
@@ -56,7 +56,7 @@ class CompositeTensorGradient(object, metaclass=abc.ABCMeta):
     """Returns the components of `value` that should be included in gradients.
 
     This method may not call TensorFlow ops, since any new ops added to the
-    graph would not be propertly tracked by the gradient mechanisms.
+    graph would not be properly tracked by the gradient mechanisms.
 
     Args:
       value: A `CompositeTensor` value.

--- a/tensorflow/python/framework/extension_type.py
+++ b/tensorflow/python/framework/extension_type.py
@@ -436,7 +436,7 @@ class ExtensionTypeSpec(type_spec.TypeSpec):
 
   def __reduce__(self):
     # Use value_type instead of spec_type, as spec_type is a nested class.
-    # Pickle support of nested class requries Pickle protocol version 4, which
+    # Pickle support of nested class requires Pickle protocol version 4, which
     # is not enabled by default until py 3.8.
     #
     # https://www.python.org/dev/peps/pep-3154/#serializing-more-lookupable-objects
@@ -448,7 +448,7 @@ class ExtensionTypeSpec(type_spec.TypeSpec):
       return value._tf_extension_type_packed_variant  # pylint: disable=protected-access
 
     tensor_or_composite = (tensor.Tensor, composite_tensor.CompositeTensor)
-    # Retireve fields by the order of spec dict to preserve field ordering. This
+    # Retrieve fields by the order of spec dict to preserve field ordering. This
     # is needed as nest.flatten would sort dictionary entries by key.
     value_tuple = tuple(value.__dict__[key] for key in self.__dict__)
     return tuple(

--- a/tensorflow/python/framework/test_util.py
+++ b/tensorflow/python/framework/test_util.py
@@ -704,7 +704,7 @@ def disable_control_flow_v2(unused_msg: str) -> Callable[[_F], _F]:
 
 
 def enable_output_all_intermediates(fn: _F) -> _F:
-  """Force-enable outputing all intermediates from functional control flow ops.
+  """Force-enable outputting all intermediates from functional control flow ops.
 
   Args:
     fn: the function to be wrapped
@@ -739,7 +739,7 @@ def assert_no_new_pyobjects_executing_eagerly(
   a bit of Python.
 
   Args:
-    warmup_iters: The numer of warmup iterations, excluded from measuring.
+    warmup_iters: The number of warmup iterations, excluded from measuring.
 
   Returns:
     A decorator function which can be applied to the test function.

--- a/tensorflow/python/framework/type_spec.py
+++ b/tensorflow/python/framework/type_spec.py
@@ -784,7 +784,7 @@ class LegacyTypeSpecBatchEncoder(TypeSpecBatchEncoder):
   """TypeSpecBatchEncoder for legacy composite tensor classes.
 
   TODO(edloper): Update existing composite tensors to use non-legacy
-    CompositTensorBatchEncoders.
+    CompositeTensorBatchEncoders.
   """
 
   def batch(self, type_spec, batch_size):


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.