### PR TITLE
Undefine the VK_USE_PLATFORM_XLIB_KHR to exclude Xlib.h

### DIFF
--- a/tensorflow/lite/delegates/gpu/api.h
+++ b/tensorflow/lite/delegates/gpu/api.h
@@ -44,6 +44,10 @@ limitations under the License.
 #include "tensorflow/lite/delegates/gpu/common/data_type.h"
 #include "tensorflow/lite/delegates/gpu/common/status.h"
 #include "tensorflow/lite/delegates/gpu/common/util.h"
+
+// The `absl::Status` conflicts with the macro definition in the X11/Xlib.h,
+// undefine the VK_USE_PLATFORM_XLIB_KHR to exclude the header file.
+#undef VK_USE_PLATFORM_XLIB_KHR
 #include "vulkan/vulkan.h"  // from @vulkan_headers
 
 #define GL_NO_PROTOTYPES


### PR DESCRIPTION
The [Status](https://source.chromium.org/chromium/chromium/src/+/main:third_party/abseil-cpp/absl/status/status.h;l=431;drc=4c6d5b3c3ed16fa75258c6b4763188f840cb433d) in absl conflicts with the macro definition [#define Status int](https://github.com/mirror/libX11/blob/master/include/X11/Xlib.h#L83) in Xlib.h, so undefine the VK_USE_PLATFORM_XLIB_KHR to exclude the header file in the vulkan.h.

There are below errors when VK_USE_PLATFORM_XLIB_KHR is defined on the Chromium [linux-asan-v8-arm-dbg](https://ci.chromium.org/ui/p/chromium/builders/try/linux-asan-v8-arm-dbg) try bots.
```
In file included from ../../third_party/tflite/src/tensorflow/lite/delegates/gpu/api.cc:16:
../../third_party/tflite/src/tensorflow/lite/delegates/gpu/api.h:262:17: error: expected unqualified-id
  262 |   virtual absl::Status SetInputShape(int index,
      |              
```