### PR TITLE
Move duplicate CUDA/XLA registration logs from INFO to VLOG

### DIFF
--- a/third_party/xla/xla/stream_executor/cuda/cuda_blas.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_blas.cc
@@ -1404,7 +1404,7 @@ void initialize_cublas() {
           });
 
   if (!status.ok()) {
-    LOG(INFO) << "Unable to register cuBLAS factory: " << status.message();
+    VLOG(1) << "Unable to register cuBLAS factory: " << status.message();
   }
 }
 

--- a/third_party/xla/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_dnn.cc
@@ -8697,7 +8697,7 @@ void initialize_cudnn() {
           });
 
   if (!status.ok()) {
-    LOG(INFO) << "Unable to register cuDNN factory: " << status.message();
+    VLOG(1) << "Unable to register cuDNN factory: " << status.message();
   }
 }
 

--- a/third_party/xla/xla/stream_executor/cuda/cuda_fft.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_fft.cc
@@ -464,7 +464,7 @@ void initialize_cufft() {
             return new gpu::CUDAFft(parent);
           });
   if (!status.ok()) {
-    LOG(INFO) << "Unable to register cuFFT factory: " << status.message();
+    VLOG(1) << "Unable to register cuFFT factory: " << status.message();
   }
 }
 


### PR DESCRIPTION
This PR downgrades harmless duplicate cuDNN, cuBLAS, and cuFFT factory registration logs from INFO to VLOG(1), fully silencing them during normal usage.

Upstream already reduced these from ERROR to INFO, but they still create unnecessary log noise when XLA and GPU backends initialize. Since the duplicate registration is safe and expected this change preserves visibility only for debugging sessions.

Co-inspired by ChatGPT during a deep dive into TensorFlow's logging system.

Fixes: #62075