### PR TITLE
Qualcomm AI Engine Direct - Enable BroadcastTo OP

### DIFF
--- a/tensorflow/lite/experimental/litert/test/testdata/simple_broadcast_to_op_boolean.mlir
+++ b/tensorflow/lite/experimental/litert/test/testdata/simple_broadcast_to_op_boolean.mlir
@@ -1,0 +1,6 @@
+module {
+  func.func @main(%arg0: tensor<1x1x1x196xi1>, %arg1: tensor<4xi64>) -> tensor<1x1x196x196xi1> {
+    %0 = "tfl.broadcast_to"(%arg0, %arg1) : (tensor<1x1x1x196xi1>, tensor<4xi64>) -> tensor<1x1x196x196xi1>
+    return %0 : tensor<1x1x196x196xi1>
+  }
+}

--- a/tensorflow/lite/experimental/litert/test/testdata/simple_broadcast_to_op_fp32.mlir
+++ b/tensorflow/lite/experimental/litert/test/testdata/simple_broadcast_to_op_fp32.mlir
@@ -1,0 +1,6 @@
+module {
+  func.func @main(%arg0: tensor<1x1x1x196xf32>, %arg1: tensor<4xi64>) -> tensor<1x1x196x196xf32> {
+    %0 = "tfl.broadcast_to"(%arg0, %arg1) : (tensor<1x1x1x196xf32>, tensor<4xi64>) -> tensor<1x1x196x196xf32>
+    return %0 : tensor<1x1x196x196xf32>
+  }
+}

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/BUILD
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 load("//tensorflow/lite/experimental/litert/build_common:litert_build_defs.bzl", "litert_dynamic_lib", "litert_lib", "litert_test")
 
@@ -156,6 +159,7 @@ litert_lib(
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders:quantize_op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders:reduce_op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders:relu6_op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders:broadcast_to_op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders:relu_op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders:reshape_op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders:resize_op_builder",

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -42,6 +42,7 @@
 #include "tensorflow/lite/experimental/litert/tools/dump.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/common.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/graph_mapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/cast_op_builder.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/concatenation_op_builder.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/conv2d_op_builder.h"
@@ -277,6 +278,11 @@ LiteRtStatus ConvertOp(
     case LiteRtOpCode::kLiteRtOpCodeTflLogicalAnd: {
       op_wrappers = ::qnn::BuildElementwiseAndOp(tensor_pool, input_tensors,
                                                  output_tensors);
+      break;
+    }
+    case LiteRtOpCode::kLiteRtOpCodeTflBroadcastTo: {
+      op_wrappers =
+          ::qnn::BuildBroadcastToOp(tensor_pool, input_tensors, output_tensors);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflCos: {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/BUILD
@@ -199,6 +199,23 @@ cc_library(
 )
 
 cc_library(
+    name = "broadcast_to_op_builder",
+    srcs = ["broadcast_to_op_builder.cc"],
+    hdrs = ["broadcast_to_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        ":op_builder",
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+    ],
+)
+
+cc_library(
     name = "matmul_op_builder",
     srcs = ["matmul_op_builder.cc"],
     hdrs = ["matmul_op_builder.h"],

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.cc
@@ -1,0 +1,111 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.h"
+
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include "third_party/qairt/latest/include/QNN/QnnOpDef.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+std::vector<std::uint32_t> GetStaticTensorDimention(
+    const std::vector<std::uint32_t>& output,
+    const std::vector<std::uint32_t>& input) {
+  std::vector<std::uint32_t> final_dims(output.size());
+  for (size_t i = 0; i < output.size(); ++i) {
+    final_dims[i] = (output[i] > input[i]) ? output[i] : 1;
+  }
+  return final_dims;
+}
+
+template <typename T>
+TensorWrapper& CreateStaticTensor(TensorPool& tensor_pool,
+                                  const Qnn_DataType_t data_type,
+                                  qnn::TensorWrapperRef output,
+                                  qnn::TensorWrapperRef input) {
+  std::vector<T> static_data{0};
+  std::vector<std::uint32_t> static_dims =
+      GetStaticTensorDimention(output.get().GetDims(), input.get().GetDims());
+  std::uint32_t static_size =
+      std::accumulate(static_dims.begin(), static_dims.end(), 1,
+                      std::multiplies<std::uint32_t>());
+
+  return tensor_pool.CreateStaticTensor(
+      data_type, QuantizeParamsWrapperVariant{}, static_dims,
+      sizeof(T) * static_size, static_data.data());
+}
+
+std::vector<OpWrapper> BuildBroadcastToOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+  TensorWrapper* broadcast_in = nullptr;
+
+  const char* qnn_op = nullptr;
+  if (inputs[0].get().GetDataType() == QNN_DATATYPE_BOOL_8) {
+    qnn_op = QNN_OP_ELEMENT_WISE_OR;
+  } else {
+    qnn_op = QNN_OP_ELEMENT_WISE_ADD;
+  }
+
+  auto& broadcast_op = CreateOpWrapper(res, qnn_op);
+  broadcast_in = &(inputs[0].get());
+  broadcast_op.AddInputTensor(*broadcast_in);
+
+  // TODO: Need handle quant param
+  switch (inputs[0].get().GetDataType()) {
+    case QNN_DATATYPE_BOOL_8: {
+      TensorWrapper& static_tensor = CreateStaticTensor<std::uint8_t>(
+          tensor_pool, QNN_DATATYPE_BOOL_8, outputs[0], inputs[0]);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    case QNN_DATATYPE_UFIXED_POINT_8: {
+      TensorWrapper& static_tensor = CreateStaticTensor<std::uint8_t>(
+          tensor_pool, inputs[0].get().GetDataType(), outputs[0], inputs[0]);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    case QNN_DATATYPE_SFIXED_POINT_8: {
+      TensorWrapper& static_tensor = CreateStaticTensor<std::int8_t>(
+          tensor_pool, inputs[0].get().GetDataType(), outputs[0], inputs[0]);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    case QNN_DATATYPE_UFIXED_POINT_16: {
+      TensorWrapper& static_tensor = CreateStaticTensor<std::uint16_t>(
+          tensor_pool, inputs[0].get().GetDataType(), outputs[0], inputs[0]);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    case QNN_DATATYPE_SFIXED_POINT_16: {
+      TensorWrapper& static_tensor = CreateStaticTensor<std::int16_t>(
+          tensor_pool, inputs[0].get().GetDataType(), outputs[0], inputs[0]);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    case QNN_DATATYPE_FLOAT_32: {
+      TensorWrapper& static_tensor = CreateStaticTensor<float>(
+          tensor_pool, inputs[0].get().GetDataType(), outputs[0], inputs[0]);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    default: {
+      QNN_LOG_ERROR("Unsupported QNN data type when creating static tensor");
+      break;
+    }
+  }
+
+  broadcast_op.AddOutputTensor(outputs[0]);
+
+  // TODO: fused activation
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.h
@@ -1,0 +1,20 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_BROADCAST_TO_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_BROADCAST_TO_OP_BUILDER_H_
+
+#include <vector>
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+std::vector<OpWrapper> BuildBroadcastToOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_BROADCAST_TO_OP_BUILDER_H_


### PR DESCRIPTION
Summary:
- Enable op builder for broadcast to op
- Add 2 mlir model for different data type