### PR TITLE
Update 04 broken links in gpu_native.md

### DIFF
--- a/tensorflow/lite/g3doc/android/delegates/gpu_native.md
+++ b/tensorflow/lite/g3doc/android/delegates/gpu_native.md
@@ -4,17 +4,17 @@ Using graphics processing units (GPUs) to run your machine learning (ML) models
 can dramatically improve the performance and the user experience
 of your ML-enabled applications. On Android devices, you can enable
 GPU-accelerated execution of your models using a
-[*delegate*](../../performance/delegates) and one of the following APIs:
+[*delegate*](https://ai.google.dev/edge/litert/performance/delegates) and one of the following APIs:
 
 - Interpreter API - [guide](./gpu)
-- Task library API - [guide](./gpu_task)
+- Task library API - [guide](./gpu_task.md)
 - Native (C/C++) API - this guide
 
 This guide covers advanced
 uses of the GPU delegate for the C API, C++ API, and use of quantized models.
 For more information about using the GPU delegate for TensorFlow Lite,
 including best practices and advanced techniques, see the
-[GPU delegates](../../performance/gpu) page.
+[GPU delegates](https://ai.google.dev/edge/litert/performance/gpu) page.
 
 ## Enable GPU acceleration
 
@@ -65,7 +65,7 @@ thread in which `Interpreter::ModifyGraphWithDelegate()` was called.
 
 #### With TensorFlow Lite in Google Play Services:
 
-If you are using TensorFlow Lite in Google Play Services [C API](../native),
+If you are using TensorFlow Lite in Google Play Services [C API](https://ai.google.dev/edge/litert/android/native),
 you’ll need to use the Java/Kotlin API to check if a GPU delegate is available
 for your device before initializing the TensorFlow Lite runtime.
 
@@ -171,4 +171,4 @@ if (interpreter->ModifyGraphWithDelegate(delegate) != kTfLiteOk) return false;
 </div>
 
 For more information about running quantized models with GPU acceleration,
-see [GPU delegate](../../performance/gpu#quantized-models) overview.
+see [GPU delegate](https://ai.google.dev/edge/litert/performance/gpu#quantized_models) overview.


### PR DESCRIPTION
Hi, Team
I found 04 broken documentation links in this file [gpu_native.md](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/g3doc/android/delegates/gpu_native.md) so I have updated those broken links to new LiteRT functional webpages links. Please review and merge this change as appropriate.

Thank you for your consideration.
