### PR TITLE
Fix compilation error due to overloads of cub::ThreadLoadVolatilePointer

### DIFF
--- a/tensorflow/core/kernels/gpu_prim.h
+++ b/tensorflow/core/kernels/gpu_prim.h
@@ -44,10 +44,9 @@ __device__ __forceinline__ void ThreadStoreVolatilePtr<Eigen::half>(
       Eigen::numext::bit_cast<uint16_t>(val);
 }
 
-template <>
-__device__ __forceinline__ Eigen::half ThreadLoadVolatilePointer<Eigen::half>(
+__device__ __forceinline__ Eigen::half ThreadLoadVolatilePointer(
     Eigen::half *ptr, Int2Type<true> /*is_primitive*/) {
-  uint16_t result = *reinterpret_cast<volatile uint16_t *>(ptr);
+  const uint16_t result = *reinterpret_cast<volatile const uint16_t *>(ptr);
   return Eigen::numext::bit_cast<Eigen::half>(result);
 }
 
@@ -59,10 +58,8 @@ __device__ __forceinline__ void ThreadStoreVolatilePtr<Eigen::bfloat16>(
       Eigen::numext::bit_cast<uint16_t>(val);
 }
 
-template <>
-__device__ __forceinline__ Eigen::bfloat16
-ThreadLoadVolatilePointer<Eigen::bfloat16>(Eigen::bfloat16 *ptr,
-                                           Int2Type<true> /*is_primitive*/) {
+__device__ __forceinline__ Eigen::bfloat16 ThreadLoadVolatilePointer(
+  Eigen::bfloat16 *ptr, Int2Type<true> /*is_primitive*/) {
   uint16_t result = *reinterpret_cast<volatile uint16_t *>(ptr);
   return Eigen::numext::bit_cast<Eigen::bfloat16>(result);
 }


### PR DESCRIPTION
Applying the same fix as detailed in https://github.com/tensorflow/tensorflow/commit/5467ee993e1d3e4709c1e99f3a15a978325ae536 in core/kernels/gpu_prim.h. Without this fix compilation of sparse_grad_op_gpu.cu.cc using clang compiler fails with the following error message. 
`./tensorflow/core/kernels/gpu_prim.h:48:40: error: no function template matches function template specialization 'ThreadLoadVolatilePointer'
   48 | __device__ __forceinline__ Eigen::half ThreadLoadVolatilePointer<Eigen::half>(
      |                                        ^
external/cuda_cudart/include/cub/thread/thread_load.cuh:333:34: note: candidate template ignored: could not match 'Eigen::half (const Eigen::half *, Int2Type<true>)' against 'Eigen::half (Eigen::half *, Int2Type<true>)'
  333 | _CCCL_DEVICE _CCCL_FORCEINLINE T ThreadLoadVolatilePointer(const T* ptr, Int2Type<true> /*is_primitive*/)
      |                                  ^
external/cuda_cudart/include/cub/thread/thread_load.cuh:343:34: note: candidate template ignored: could not match 'Eigen::half (const Eigen::half *, Int2Type<false>)' against 'Eigen::half (Eigen::half *, Int2Type<true>)'
  343 | _CCCL_DEVICE _CCCL_FORCEINLINE T ThreadLoadVolatilePointer(const T* ptr, Int2Type<false> /*is_primitive*/)
      |                                  ^
In file included from tensorflow/core/kernels/sparse_slice_grad_op_gpu.cu.cc:23:
./tensorflow/core/kernels/gpu_prim.h:64:1: error: no function template matches function template specialization 'ThreadLoadVolatilePointer'
   64 | ThreadLoadVolatilePointer<Eigen::bfloat16>(Eigen::bfloat16 *ptr,
      | ^
external/cuda_cudart/include/cub/thread/thread_load.cuh:333:34: note: candidate template ignored: could not match 'Eigen::bfloat16 (const Eigen::bfloat16 *, Int2Type<true>)' against 'Eigen::bfloat16 (Eigen::bfloat16 *, Int2Type<true>)'
  333 | _CCCL_DEVICE _CCCL_FORCEINLINE T ThreadLoadVolatilePointer(const T* ptr, Int2Type<true> /*is_primitive*/)
      |                                  ^
external/cuda_cudart/include/cub/thread/thread_load.cuh:343:34: note: candidate template ignored: could not match 'Eigen::bfloat16 (const Eigen::bfloat16 *, Int2Type<false>)' against 'Eigen::bfloat16 (Eigen::bfloat16 *, Int2Type<true>)'
  343 | _CCCL_DEVICE _CCCL_FORCEINLINE T ThreadLoadVolatilePointer(const T* ptr, Int2Type<false> /*is_primitive*/)
      |                                  ^
2 errors generated when compiling for sm_80.`