### PR TITLE
Remove ambiguous inherited constructor in default_quant_params.cc

### DIFF
--- a/tensorflow/compiler/mlir/lite/transforms/default_quant_params.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/default_quant_params.cc
@@ -54,7 +54,9 @@ namespace {
 class DefaultQuantParamsPass
     : public impl::DefaultQuantParamsPassBase<DefaultQuantParamsPass> {
  public:
-  using DefaultQuantParamsPassBase::DefaultQuantParamsPassBase;
+  DefaultQuantParamsPass()
+  {
+  }
 
   explicit DefaultQuantParamsPass(double default_min, double default_max,
                                   bool is_signed) {

--- a/tensorflow/compiler/mlir/lite/transforms/default_quant_params.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/default_quant_params.cc
@@ -54,9 +54,7 @@ namespace {
 class DefaultQuantParamsPass
     : public impl::DefaultQuantParamsPassBase<DefaultQuantParamsPass> {
  public:
-  DefaultQuantParamsPass()
-  {
-  }
+  DefaultQuantParamsPass() {}
 
   explicit DefaultQuantParamsPass(double default_min, double default_max,
                                   bool is_signed) {


### PR DESCRIPTION
Remove ambiguous inherited constructor in default_quant_params.cc. GCC complains about this (https://stackoverflow.com/q/79553477/). Fix is trivial and harmless.

Fixes #84977.
