### PR TITLE
Enable Android XNNPACK delegate num_threads with Interpreter.Options.…

### DIFF
--- a/tensorflow/lite/java/src/main/native/op_resolver_lazy_delegate_proxy.cc
+++ b/tensorflow/lite/java/src/main/native/op_resolver_lazy_delegate_proxy.cc
@@ -122,13 +122,17 @@ OpResolverLazyDelegateProxy::createXNNPackDelegate(TfLiteContext* context) {
     auto xnnpack_create =
         reinterpret_cast<decltype(TfLiteXNNPackDelegateCreate)*>(
             dlsym(RTLD_DEFAULT, "TfLiteXNNPackDelegateCreate"));
+    auto xnnpack_create_threadpool =
+        reinterpret_cast<decltype(TfLiteXNNPackDelegateCreateWithThreadpool)*>(
+            dlsym(RTLD_DEFAULT, "TfLiteXNNPackDelegateCreateWithThreadpool"));
     auto xnnpack_delete =
         reinterpret_cast<decltype(TfLiteXNNPackDelegateDelete)*>(
             dlsym(RTLD_DEFAULT, "TfLiteXNNPackDelegateDelete"));
 
     if (xnnpack_options_default && xnnpack_create && xnnpack_delete) {
       TfLiteXNNPackDelegateOptions options = xnnpack_options_default();
-      delegate = xnnpack_create(&options);
+      // delegate = xnnpack_create(&options);
+      delegate = xnnpack_create_threadpool(&options, context);
       delegate_deleter = xnnpack_delete;
     }
   }


### PR DESCRIPTION
…setNumThreads api

setNumThreads() not working and defaults to 1 thread on Android. Use xnnpack_create_threadpool with context to create the threadpool.