### PR TITLE
Patch to rules_python to fix python 3.13 free-threading usage

### DIFF
--- a/third_party/py/python_init_rules.bzl
+++ b/third_party/py/python_init_rules.bzl
@@ -12,5 +12,6 @@ def python_init_rules():
         patches = [
             Label("//third_party/py:rules_python1.patch"),
             Label("//third_party/py:rules_python2.patch"),
+            Label("//third_party/py:rules_python3.patch"),
         ],
     )

--- a/third_party/py/python_init_toolchains.bzl
+++ b/third_party/py/python_init_toolchains.bzl
@@ -6,6 +6,7 @@ load(
     "HERMETIC_PYTHON_SHA256",
     "HERMETIC_PYTHON_URL",
     "HERMETIC_PYTHON_VERSION",
+    "HERMETIC_PYTHON_VERSION_KIND",
 )
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 load("@rules_python//python:versions.bzl", "MINOR_MAPPING", "PLATFORMS")
@@ -61,4 +62,5 @@ def python_init_toolchains(name = "python", python_version = None, **kwargs):
             name = name,
             ignore_root_user_error = True,
             python_version = HERMETIC_PYTHON_VERSION,
+            python_version_kind = HERMETIC_PYTHON_VERSION_KIND,
         )

--- a/third_party/py/python_repo.bzl
+++ b/third_party/py/python_repo.bzl
@@ -106,6 +106,7 @@ Requirements_lock label: "{requirements_lock_label}"
         """
 TF_PYTHON_VERSION = "{version}"
 HERMETIC_PYTHON_VERSION = "{version}"
+HERMETIC_PYTHON_VERSION_KIND = "{py_kind}"
 WHEEL_NAME = "{wheel_name}"
 WHEEL_COLLAB = "{wheel_collab}"
 REQUIREMENTS = "{requirements}"
@@ -117,6 +118,7 @@ HERMETIC_PYTHON_SHA256 = "{hermetic_sha256}"
 HERMETIC_PYTHON_PREFIX = "{hermetic_prefix}"
 """.format(
             version = version,
+            py_kind = py_kind,
             wheel_name = wheel_name,
             wheel_collab = wheel_collab,
             requirements = str(requirements),

--- a/third_party/py/rules_python3.patch
+++ b/third_party/py/rules_python3.patch
@@ -1,0 +1,45 @@
+diff --git a/python/private/python_register_toolchains.bzl b/python/private/python_register_toolchains.bzl
+index 98c8e5bf..fc533001 100644
+--- a/python/private/python_register_toolchains.bzl
++++ b/python/private/python_register_toolchains.bzl
+@@ -86,6 +86,7 @@ def python_register_toolchains(
+     minor_mapping = minor_mapping or MINOR_MAPPING
+
+     python_version = full_version(version = python_version, minor_mapping = minor_mapping)
++    python_version_kind = kwargs.pop("python_version_kind", "")
+
+     toolchain_repo_name = "{name}_toolchains".format(name = name)
+
+@@ -165,6 +166,7 @@ def python_register_toolchains(
+     toolchain_aliases(
+         name = name,
+         python_version = python_version,
++        python_version_kind = python_version_kind,
+         user_repository_name = name,
+         platforms = loaded_platforms,
+     )
+diff --git a/python/private/toolchains_repo.bzl b/python/private/toolchains_repo.bzl
+index d21fb53a..a5271c18 100644
+--- a/python/private/toolchains_repo.bzl
++++ b/python/private/toolchains_repo.bzl
+@@ -130,6 +130,9 @@ def _toolchain_aliases_impl(rctx):
+     (os_name, arch) = _get_host_os_arch(rctx, logger)
+
+     host_platform = _get_host_platform(os_name, arch)
++    python_version_kind = rctx.attr.python_version_kind
++    if python_version_kind == "ft":
++        host_platform += "-freethreaded"
+
+     is_windows = (os_name == WINDOWS_NAME)
+     python3_binary_path = "python.exe" if is_windows else "bin/python3"
+@@ -233,6 +236,10 @@ actions.""",
+             doc = "List of platforms for which aliases shall be created",
+         ),
+         "python_version": attr.string(doc = "The Python version."),
++        "python_version_kind": attr.string(
++            doc = "Python version kind, e.g. ft (free-threaded)",
++            default = ""
++        ),
+         "user_repository_name": attr.string(
+             mandatory = True,
+             doc = "The base name for all created repositories, like 'python38'.",


### PR DESCRIPTION
Related to https://github.com/jax-ml/jax/issues/27862 and https://github.com/openxla/xla/pull/24912

Description:
- Patches to rules_python to correctly use python 3.13 ft and install correctly ft built deps

In JAX with this PR:
```
python3 build/build.py build --configure_only     --python_version=3.13-ft     --bazel_options=--color=yes     --bazel_options=--copt=-g     --clang_path=/usr/bin/clang-18     --bazel_options=--override_repository=xla=/project/xla     --bazel_options=--override_repository=rules_python=/project/rules_python

./bazel cquery @pypi_numpy//:* | grep whl
>
Analyzing: 858 targets (0 packages loaded, 0 targets configured)
INFO: Analyzed 858 targets (45 packages loaded, 381 targets configured).
INFO: Found 858 targets...
@pypi_numpy//:numpy-2.2.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (null)
@pypi_numpy//:whl (b235e06)
```

Without this PR numpy with GIL is picked:
```
Computing main repo mapping:
Loading:
Loading: 0 packages loaded
Analyzing: 858 targets (0 packages loaded, 0 targets configured)
INFO: Analyzed 858 targets (1 packages loaded, 4940 targets configured).
INFO: Found 858 targets...
@pypi_numpy//:numpy-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (null)
@pypi_numpy//:whl (2c1735f)
INFO: Elapsed time: 0.840s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
```

This is just a temporary hack to make things working until rules_python will be properly upgraded to 1.X version


cc @MichaelHudgins 