### PR TITLE
Fix C compatibility issue in TfLiteQuantizationType enum

### DIFF
--- a/tensorflow/lite/core/c/common.h
+++ b/tensorflow/lite/core/c/common.h
@@ -322,7 +322,11 @@ typedef struct TfLiteBFloat16 {
 const char* TfLiteTypeGetName(TfLiteType type);
 
 /// SupportedQuantizationTypes.
+#ifdef __cplusplus
 typedef enum TfLiteQuantizationType : int {
+#else
+typedef enum TfLiteQuantizationType {
+#endif
   /// No quantization.
   kTfLiteNoQuantization = 0,
   /// Affine quantization (with support for per-channel quantization).


### PR DESCRIPTION
Hi, Team
This PR fixes a C compatibility issue in the `TfLiteQuantizationType` enum definition. The current definition uses C++ syntax `(enum : int)` which causes compilation errors when included in C projects. This PR adds conditional compilation directives to use C++ syntax only when compiling with C++.

When compiling TensorFlow Lite code with a C compiler the following error occurs:
```
In file included from build/usr/local/include/tensorflow/lite/c/common.h:31,
                 from main.c:2:
build/usr/local/include/tensorflow/lite/core/c/common.h:325:37: error: expected identifier or ‘(’ before ‘:’ token
  325 | typedef enum TfLiteQuantizationType : int {
      |                                     ^
build/usr/local/include/tensorflow/lite/core/c/common.h:331:3: warning: data definition has no type or storage class
  331 | } TfLiteQuantizationType;
      |   ^~~~~~~~~~~~~~~~~~~~~~
build/usr/local/include/tensorflow/lite/core/c/common.h:331:3: warning: type defaults to ‘int’ in declaration of ‘TfLiteQuantizationType’ [-Wimplicit-int]
build/usr/local/include/tensorflow/lite/core/c/common.h:336:3: error: expected specifier-qualifier-list before ‘TfLiteQuantizationType’
  336 |   TfLiteQuantizationType type;
      |   ^~~~~~~~~~~~~~~~~~~~~~

```
I have added conditional compilation using `#ifdef __cplusplus` to use type-safe enum in C++ while maintaining C compatibility. 

This PR will address this issue :https://github.com/tensorflow/tensorflow/issues/89666

I would request you to please review this PR, if you've any feedback or suggestion please let me know that will be very helpful. Thank you for your consideration.