### PR TITLE
Add Python 3.13 classifier

### DIFF
--- a/tensorflow/tools/pip_package/setup.py.tpl
+++ b/tensorflow/tools/pip_package/setup.py.tpl
@@ -430,6 +430,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Mathematics',


### PR DESCRIPTION
Since https://pypi.org/project/tf-nightly/2.20.0.dev20250413/#files shows wheels for Python 3.13, the classifier also should be updated.