### PR TITLE
Add missing version macros and version string in version.h

### DIFF
--- a/tensorflow/core/public/version.h
+++ b/tensorflow/core/public/version.h
@@ -18,8 +18,23 @@ limitations under the License.
 
 // TensorFlow uses semantic versioning, see http://semver.org/.
 
+// Also update tensorflow/tensorflow.bzl and
+// tensorflow/tools/pip_package/setup.py
+#define TF_MAJOR_VERSION 2
+#define TF_MINOR_VERSION 19
+#define TF_PATCH_VERSION 0
+
+// TF_VERSION_SUFFIX is non-empty for pre-releases (e.g. "-alpha", "-alpha.1",
+// "-beta", "-rc", "-rc.1")
+#define TF_VERSION_SUFFIX ""
+
 #define TF_STR_HELPER(x) #x
 #define TF_STR(x) TF_STR_HELPER(x)
+
+// e.g. "0.5.0" or "0.6.0-alpha".
+#define TF_VERSION_STRING                                            \
+  (TF_STR(TF_MAJOR_VERSION) "." TF_STR(TF_MINOR_VERSION) "." TF_STR( \
+      TF_PATCH_VERSION) TF_VERSION_SUFFIX)
 
 // GraphDef compatibility versions (the versions field in graph.proto).
 //


### PR DESCRIPTION
Hi, Team
This PR addresses a syntax error in TensorFlow version `2.19` related to missing version macros in the `version.h` file. It is showing this `error C2146: syntax error: missing ')' before identifier` so I have made below changes to address this issue

- Added missing version definitions:
  ```c
  #define TF_MAJOR_VERSION 2
  #define TF_MINOR_VERSION 19
  #define TF_PATCH_VERSION 0
  #define TF_VERSION_SUFFIX ""

-   Added the version string macro:
 
```c
  #define TF_STR_HELPER(x) #x
  #define TF_STR(x) TF_STR_HELPER(x)

  #define TF_VERSION_STRING \
  (TF_STR(TF_MAJOR_VERSION) "." TF_STR(TF_MINOR_VERSION) "." TF_STR( \
      TF_PATCH_VERSION) TF_VERSION_SUFFIX)

```
      
This PR resolves the issue reported in GitHub issue https://github.com/tensorflow/tensorflow/issues/90533 where the absence of `TF_VERSION_SUFFIX` and other macros led to compilation errors.

I would request you to please review this PR, if you've any feedback or suggestion please let me know that will be very helpful. Thank you for your consideration.