### PR TITLE
[tosa] Add patch to re-enable local compilation of tosa passes

### DIFF
--- a/tensorflow/compiler/mlir/tosa/re-enable-tosa-compilation.patch
+++ b/tensorflow/compiler/mlir/tosa/re-enable-tosa-compilation.patch
@@ -1,0 +1,1656 @@
+diff --git a/.bazelrc b/.bazelrc
+index 98e967b5619..cf46f74ebf3 100644
+--- a/.bazelrc
++++ b/.bazelrc
+@@ -787,28 +787,28 @@ build:tf_public_macos_cache_push --config=tf_public_macos_cache --remote_upload_
+ # PYTHON TESTS run a suite of Python tests intended for verifying that the Python wheel
+ # will work properly. These are usually run Nightly or upon Release.
+ # CPU WHEEL
+-test:linux_cpu_wheel_test_filters --test_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
+-test:linux_cpu_wheel_test_filters --build_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_cpu_wheel_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_cpu_wheel_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
+ test:linux_cpu_wheel_test_filters --test_lang_filters=py --test_size_filters=small,medium
+ test:linux_cpu_wheel_test --@local_xla//third_party/py:wheel_dependency=true --config=linux_cpu_wheel_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:prebuilt_wheel_import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
+ # CUDA WHEEL
+-test:linux_cuda_wheel_test_filters --test_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-benchmark-test,-no_cuda11,-no_oss_py38,-no_oss_py39,-no_oss_py310
+-test:linux_cuda_wheel_test_filters --build_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-benchmark-test,-no_cuda11,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_cuda_wheel_test_filters --test_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-no_cuda11,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_cuda_wheel_test_filters --build_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-no_cuda11,-no_oss_py38,-no_oss_py39,-no_oss_py310
+ test:linux_cuda_wheel_test_filters --test_lang_filters=py --test_size_filters=small,medium
+ test:linux_cuda_wheel_test --@local_xla//third_party/py:wheel_dependency=true --config=linux_cuda_wheel_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:prebuilt_wheel_import_api_packages_test_gpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
+ # ARM64 WHEEL
+-test:linux_arm64_wheel_test_filters --test_tag_filters=-no_oss,-tf_tosa,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
+-test:linux_arm64_wheel_test_filters --build_tag_filters=-no_oss,-tf_tosa,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_arm64_wheel_test_filters --test_tag_filters=-no_oss,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_arm64_wheel_test_filters --build_tag_filters=-no_oss,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
+ test:linux_arm64_wheel_test_filters --test_lang_filters=py --test_size_filters=small,medium
+ test:linux_arm64_wheel_test --@local_xla//third_party/py:wheel_dependency=true --config=linux_arm64_wheel_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:prebuilt_wheel_import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...  -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/core/grappler/optimizers:auto_mixed_precision_test_cpu -//tensorflow/core/grappler/optimizers:remapper_test_cpu -//tensorflow/core/kernels/image:resize_bicubic_op_test
+ # MACOS ARM64 WHEEL
+-test:macos_arm64_wheel_test_filters --test_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
+-test:macos_arm64_wheel_test_filters --build_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
++test:macos_arm64_wheel_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
++test:macos_arm64_wheel_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
+ test:macos_arm64_wheel_test_filters --test_lang_filters=py --test_size_filters=small,medium
+ test:macos_arm64_wheel_test --@local_xla//third_party/py:wheel_dependency=true --config=macos_arm64_wheel_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:prebuilt_wheel_import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/compiler/aot/...
+ # MACOS X86 WHEEL
+-test:macos_x86_wheel_test_filters --test_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
+-test:macos_x86_wheel_test_filters --build_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
++test:macos_x86_wheel_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
++test:macos_x86_wheel_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
+ test:macos_x86_wheel_test_filters --test_lang_filters=py --test_size_filters=small,medium
+ test:macos_x86_wheel_test --@local_xla//third_party/py:wheel_dependency=true --config=macos_x86_wheel_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:prebuilt_wheel_import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/compiler/aot/...
+ # WINDOWS X86 WHEEL
+@@ -820,14 +820,14 @@ test:windows_x86_cpu_2022_wheel_test --build_tests_only --config=windows_x86_cpu
+ # PYCPP TESTS run a suite of Python and C++ tests to verify general correctness over
+ # the whole TF code base. These are usually run continuously or upon presubmit.
+ # LINUX CPU PYCPP:
+-test:linux_cpu_pycpp_test_filters --test_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
+-test:linux_cpu_pycpp_test_filters --build_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
++test:linux_cpu_pycpp_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
++test:linux_cpu_pycpp_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
+ test:linux_cpu_pycpp_test_filters --test_lang_filters=cc,py --test_size_filters=small,medium
+ test:linux_cpu_pycpp_test --config=linux_cpu_pycpp_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
+ 
+ # LINUX CUDA PYCPP:
+-test:linux_cuda_pycpp_test_filters --test_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11
+-test:linux_cuda_pycpp_test_filters --build_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11
++test:linux_cuda_pycpp_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11
++test:linux_cuda_pycpp_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11
+ test:linux_cuda_pycpp_test_filters --test_lang_filters=cc,py --test_size_filters=small,medium
+ test:linux_cuda_pycpp_test --config=linux_cuda_pycpp_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:import_api_packages_test_gpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
+ 
+@@ -840,8 +840,8 @@ test:linux_cuda_pycpp_test --config=linux_cuda_pycpp_test_filters -- //tensorflo
+ # do not run them. By prefixing the configs with "build", we can run both
+ # `bazel build` and `bazel test` commands with the same config as test configs
+ # inherit from build.
+-build:linux_arm64_pycpp_test_filters --test_tag_filters=-no_oss,-tf_tosa,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
+-build:linux_arm64_pycpp_test_filters --build_tag_filters=-no_oss,-tf_tosa,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
++build:linux_arm64_pycpp_test_filters --test_tag_filters=-no_oss,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
++build:linux_arm64_pycpp_test_filters --build_tag_filters=-no_oss,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
+ build:linux_arm64_pycpp_test_filters --test_lang_filters=cc,py --test_size_filters=small,medium --flaky_test_attempts=3
+ # TODO(michaelhudgins): Why do we need to specifically omit go and java here?
+ build:linux_arm64_pycpp_test --config=linux_arm64_pycpp_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/core/grappler/optimizers:auto_mixed_precision_test_cpu -//tensorflow/core/grappler/optimizers:remapper_test_cpu -//tensorflow/core/kernels/image:resize_bicubic_op_test -//tensorflow/python/tools:aot_compiled_test
+@@ -850,15 +850,15 @@ build:cross_compile_linux_arm64_pycpp_test --config=linux_arm64_pycpp_test
+ # Tests that fail only when cross-compiled
+ build:cross_compile_linux_arm64_pycpp_test -//tensorflow/compiler/mlir/quantization/stablehlo:convert_tf_quant_to_mhlo_int_test
+ # MACOS ARM64 PYCPP
+-test:macos_arm64_pycpp_test_filters --test_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
+-test:macos_arm64_pycpp_test_filters --build_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
++test:macos_arm64_pycpp_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
++test:macos_arm64_pycpp_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
+ test:macos_arm64_pycpp_test_filters --test_lang_filters=cc,py --test_size_filters=small,medium
+ test:macos_arm64_pycpp_test --config=macos_arm64_pycpp_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/compiler/aot/... -//tensorflow/core/kernels/image:resize_bicubic_op_test
+ # MACOS X86 PYCPP
+ # These are defined as build configs so that we can run a build only job. See
+ # the note under "ARM64 PYCPP" for more details.
+-build:macos_x86_pycpp_test_filters --test_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
+-build:macos_x86_pycpp_test_filters --build_tag_filters=-no_oss,-tf_tosa,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
++build:macos_x86_pycpp_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
++build:macos_x86_pycpp_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
+ build:macos_x86_pycpp_test_filters --keep_going --test_lang_filters=cc,py --test_size_filters=small,medium
+ build:macos_x86_pycpp_test --config=macos_x86_pycpp_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/tools/toolchains/... -//tensorflow/lite/... -//tensorflow/compiler/aot/...
+ # CROSS-COMPILE MACOS X86 PYCPP
+diff --git a/tensorflow/compiler/mlir/BUILD b/tensorflow/compiler/mlir/BUILD
+index c11a761a089..4f001c7497f 100644
+--- a/tensorflow/compiler/mlir/BUILD
++++ b/tensorflow/compiler/mlir/BUILD
+@@ -65,10 +65,14 @@ cc_library(
+         "//tensorflow/compiler/mlir/tf2xla/internal/passes:mlir_to_graph_passes",
+         "//tensorflow/compiler/mlir/tf2xla/transforms:tf_xla_passes",
+         "//tensorflow/compiler/mlir/tf2xla/transforms:xla_legalize_tf",
++        "//tensorflow/compiler/mlir/tosa:tf_passes",
++        "//tensorflow/compiler/mlir/tosa:tf_tfl_passes",
++        "//tensorflow/compiler/mlir/tosa:tfl_passes",
+         "@llvm-project//mlir:AllPassesAndDialects",
+         "@llvm-project//mlir:MlirOptLib",
+         "@llvm-project//mlir:Support",
+         "@llvm-project//mlir:Transforms",
++        "@local_xla//xla/mlir/framework/ir:xla_framework",
+         "@local_xla//xla/mlir/framework/transforms:passes",
+         "@local_xla//xla/mlir_hlo:all_passes",
+     ],
+@@ -91,6 +95,8 @@ cc_library(
+         "//tensorflow/compiler/mlir/tensorflow/transforms:tensorflow_passes",
+         "//tensorflow/compiler/mlir/tensorflow/transforms:tf_dialect_passes",
+         "//tensorflow/compiler/mlir/tf2xla:compile_mlir_util",
++        "//tensorflow/compiler/mlir/tosa:tf_passes",
++        "//tensorflow/compiler/mlir/tosa:tfl_passes",
+     ],
+ )
+ 
+diff --git a/tensorflow/compiler/mlir/python/BUILD b/tensorflow/compiler/mlir/python/BUILD
+index 304ab73ea9b..be3f382440b 100644
+--- a/tensorflow/compiler/mlir/python/BUILD
++++ b/tensorflow/compiler/mlir/python/BUILD
+@@ -38,6 +38,7 @@ cc_library(
+         "@llvm-project//mlir:AllPassesAndDialects",
+         "@llvm-project//mlir:BytecodeWriter",
+         "@llvm-project//mlir:ShapeDialect",
++        "@llvm-project//mlir:TosaDialect",
+         "@llvm-project//mlir:IR",
+         "@llvm-project//mlir:Parser",
+         "@llvm-project//mlir:Pass",
+@@ -63,10 +64,15 @@ cc_library(
+         "//tensorflow/compiler/mlir/tensorflow/transforms:tf_saved_model_passes",
+         "//tensorflow/compiler/mlir/tensorflow:translate_lib",
+         "//tensorflow/compiler/mlir/tf2xla/transforms:xla_legalize_tf",
++        "//tensorflow/compiler/mlir/tosa:passes_header",
++        "//tensorflow/compiler/mlir/tosa:tf_passes",
++        "//tensorflow/compiler/mlir/tosa:tf_tfl_passes",
++        "//tensorflow/compiler/mlir/tosa:tfl_passes",
+         "//tensorflow/core:framework",
+         "//tensorflow/core:lib_proto_parsing",
+         "//tensorflow/core:protos_all_cc",
+         "//tensorflow/core:tflite_portable_logging",
++        "//tensorflow/core/common_runtime:core_cpu_base_no_ops",
+         "//tensorflow/core/common_runtime/eager:context",
+         # (yongtang) The graph_optimization_pass_registration needs to be part
+         # of a shared object that will be loaded whenever `import tensorflow`
+diff --git a/tensorflow/compiler/mlir/python/mlir.cc b/tensorflow/compiler/mlir/python/mlir.cc
+index 80fa3ecf23f..5ec7a1d9c9b 100644
+--- a/tensorflow/compiler/mlir/python/mlir.cc
++++ b/tensorflow/compiler/mlir/python/mlir.cc
+@@ -31,6 +31,7 @@ limitations under the License.
+ #include "mlir/Bytecode/BytecodeWriter.h"  // from @llvm-project
+ #include "mlir/Dialect/Func/Extensions/AllExtensions.h"  // from @llvm-project
+ #include "mlir/Dialect/Shape/IR/Shape.h"  // from @llvm-project
++#include "mlir/Dialect/Tosa/IR/TosaOps.h"  // from @llvm-project
+ #include "mlir/IR/AsmState.h"  // from @llvm-project
+ #include "mlir/IR/BuiltinOps.h"  // from @llvm-project
+ #include "mlir/IR/Location.h"  // from @llvm-project
+@@ -62,6 +63,10 @@ limitations under the License.
+ #include "tensorflow/compiler/mlir/tensorflow/utils/mlprogram_util.h"
+ #include "tensorflow/compiler/mlir/tf2xla/api/v2/graph_to_tf_executor.h"
+ #include "tensorflow/compiler/mlir/tf2xla/transforms/passes.h"
++#include "tensorflow/compiler/mlir/tosa/tf_passes.h"
++#include "tensorflow/compiler/mlir/tosa/tf_tfl_passes.h"
++#include "tensorflow/compiler/mlir/tosa/tfl_passes.h"
++#include "tensorflow/compiler/mlir/tosa/transforms/passes.h"
+ #include "xla/mlir/framework/transforms/passes.h"
+ #include "xla/mlir_hlo/mhlo/transforms/passes.h"
+ #include "tensorflow/core/common_runtime/eager/context.h"
+@@ -93,6 +98,10 @@ static void RegisterPasses() {
+     mlir::mhlo::registerTfXlaPasses();
+     mlir::mhlo::registerLegalizeTFPass();
+     mlir::quant::stablehlo::registerBridgePasses();
++    mlir::tosa::registerLegalizeTosaPasses();
++    mlir::tosa::registerTFtoTOSALegalizationPipeline();
++    mlir::tosa::registerTFLtoTOSALegalizationPipeline();
++    mlir::tosa::registerTFTFLtoTOSALegalizationPipeline();
+     mlir::tf_saved_model::registerTensorFlowSavedModelPasses();
+     mlir::xla_framework::registerXlaFrameworkPasses();
+     tensorflow::RegisterMlProgramPasses();
+@@ -423,4 +432,64 @@ void ExperimentalWriteBytecode(const std::string& filename,
+   }
+ }
+ 
++void ExperimentalTFLiteToTosaBytecode(
++    const std::string& flatbuffer_file, const std::string& tosa_bytecode_file,
++    bool use_external_constant,
++    const std::vector<std::string>& ordered_input_arrays,
++    const std::vector<std::string>& ordered_output_arrays, TF_Status* status) {
++  mlir::DialectRegistry registry;
++  mlir::RegisterAllTensorFlowDialects(registry);
++  registry.insert<mlir::tosa::TosaDialect>();
++  mlir::MLIRContext context(registry);
++  mlir::OwningOpRef<mlir::ModuleOp> module;
++  mlir::StatusScopedDiagnosticHandler diagnostic_handler(&context);
++  {
++    mlir::Location loc = mlir::UnknownLoc::get(&context);
++    std::string error;
++    std::unique_ptr<llvm::MemoryBuffer> buffer =
++        mlir::openInputFile(flatbuffer_file, &error);
++    if (buffer == nullptr) {
++      TF_SetStatus(status, TF_INVALID_ARGUMENT,
++                   ("Unable to load input file " + error).c_str());
++      return;
++    }
++
++    auto buffer_view =
++        absl::string_view(buffer->getBufferStart(), buffer->getBufferSize());
++    module = tflite::FlatBufferToMlir(
++        buffer_view, &context, loc, use_external_constant, ordered_input_arrays,
++        ordered_output_arrays);
++    mlir::PassManager pm(&context, module.get()->getName().getStringRef(),
++                         mlir::PassManager::Nesting::Implicit);
++    mlir::tosa::TOSATFLLegalizationPipelineOptions opts;
++    // This flow is specific to compilation backend, so set to true.
++    opts.target_compilation_backend = true;
++    // Temporary work-around for https://github.com/openxla/iree/issues/8974
++    opts.dequantize_tfl_softmax = true;
++    createTFLtoTOSALegalizationPipeline(pm, opts);
++    if (failed(pm.run(*module))) {
++      tsl::Set_TF_Status_from_Status(status,
++                                     diagnostic_handler.ConsumeStatus());
++      return;
++    }
++  }
++  mlir::FallbackAsmResourceMap fallback_resource_map;
++  mlir::BytecodeWriterConfig writer_config(fallback_resource_map);
++  // TODO(jpienaar): Make this an option to the call.
++  writer_config.setDesiredBytecodeVersion(1);
++  std::string error;
++  std::unique_ptr<llvm::ToolOutputFile> outputFile =
++      mlir::openOutputFile(tosa_bytecode_file, &error);
++  if (!error.empty()) {
++    TF_SetStatus(status, TF_INVALID_ARGUMENT,
++                 ("Unable to create output file" + error).c_str());
++    return;
++  }
++  outputFile->keep();
++  if (failed(mlir::writeBytecodeToFile(*module, outputFile->os(),
++                                       writer_config))) {
++    tsl::Set_TF_Status_from_Status(status, diagnostic_handler.ConsumeStatus());
++  }
++}
++
+ }  // namespace tensorflow
+diff --git a/tensorflow/compiler/mlir/python/mlir.h b/tensorflow/compiler/mlir/python/mlir.h
+index 99a17ca1ef2..a17f4f2843e 100644
+--- a/tensorflow/compiler/mlir/python/mlir.h
++++ b/tensorflow/compiler/mlir/python/mlir.h
+@@ -109,6 +109,16 @@ std::string ExperimentalRunPassPipeline(const std::string &mlir_txt,
+ void ExperimentalWriteBytecode(const std::string &filename,
+                                const std::string &mlir_txt, TF_Status *status);
+ 
++// Loads a TFLite flatbuffer, convert to TOSA for backend compilation and
++// produce an MLIR bytecode file as output.
++// TODO(jpienaar): Refactor this when we use more implicit module passing
++// between calls to avoid serialization overhead.
++void ExperimentalTFLiteToTosaBytecode(
++    const std::string &flatbuffer_file, const std::string &tosa_bytecode_file,
++    bool use_external_constant,
++    const std::vector<std::string> &ordered_input_arrays,
++    const std::vector<std::string> &ordered_output_arrays, TF_Status *status);
++
+ }  // namespace tensorflow
+ 
+ #endif  // TENSORFLOW_COMPILER_MLIR_PYTHON_MLIR_H_
+diff --git a/tensorflow/compiler/mlir/tf_mlir_opt_main.cc b/tensorflow/compiler/mlir/tf_mlir_opt_main.cc
+index 73e6e874555..4583fc9cd96 100644
+--- a/tensorflow/compiler/mlir/tf_mlir_opt_main.cc
++++ b/tensorflow/compiler/mlir/tf_mlir_opt_main.cc
+@@ -33,6 +33,10 @@ limitations under the License.
+ #include "tensorflow/compiler/mlir/tf2xla/internal/passes/clustering_passes.h"
+ #include "tensorflow/compiler/mlir/tf2xla/internal/passes/mlir_to_graph_passes.h"
+ #include "tensorflow/compiler/mlir/tf2xla/transforms/passes.h"
++#include "tensorflow/compiler/mlir/tosa/tf_passes.h"
++#include "tensorflow/compiler/mlir/tosa/tf_tfl_passes.h"
++#include "tensorflow/compiler/mlir/tosa/tfl_passes.h"
++#include "tensorflow/compiler/mlir/tosa/transforms/passes.h"
+ #include "xla/mlir/framework/transforms/passes.h"
+ #include "xla/mlir_hlo/mhlo/transforms/passes.h"
+ 
+@@ -53,6 +57,10 @@ int main(int argc, char **argv) {
+   mlir::quant::stablehlo::registerBridgePasses();
+   tensorflow::tf2xla::internal::registerTFXLABridgeClusteringPasses();
+   tensorflow::tf2xla::internal::registerTFXLABridgeMlirToGraphPasses();
++  mlir::tosa::registerLegalizeTosaPasses();
++  mlir::tosa::registerTFtoTOSALegalizationPipeline();
++  mlir::tosa::registerTFLtoTOSALegalizationPipeline();
++  mlir::tosa::registerTFTFLtoTOSALegalizationPipeline();
+   mlir::tf_test::registerTensorFlowTestPasses();
+   mlir::xla_framework::registerXlaFrameworkPasses();
+   tensorflow::RegisterConvertMlirToXlaHloPipelineWithDefaults();
+diff --git a/tensorflow/compiler/mlir/tosa/BUILD b/tensorflow/compiler/mlir/tosa/BUILD
+index 8d6cd90fa35..43fc5d49408 100644
+--- a/tensorflow/compiler/mlir/tosa/BUILD
++++ b/tensorflow/compiler/mlir/tosa/BUILD
+@@ -16,7 +16,17 @@ package(
+ package_group(
+     name = "internal",
+     packages = [
+-        "//tensorflow/compiler/mlir/tosa/...",
++        "//tensorflow/compiler/mlir/...",
++    ],
++)
++
++package_group(
++    name = "friends",
++    includes = [
++        ":internal",
++    ],
++    packages = [
++        "//third_party/iree/...",
+     ],
+ )
+ 
+@@ -31,7 +41,6 @@ filegroup(
+ gentbl_cc_library(
+     name = "tosa_passes_inc_gen",
+     compatible_with = get_compatible_with_portable(),
+-    tags = ["tf_tosa"],
+     tbl_outs = [
+         (
+             [
+@@ -55,7 +64,6 @@ cc_library(
+         "transforms/passes.h.inc",
+     ],
+     compatible_with = get_compatible_with_portable(),
+-    tags = ["tf_tosa"],
+     deps = [
+         "@llvm-project//mlir:FuncDialect",
+         "@llvm-project//mlir:IR",
+@@ -74,7 +82,6 @@ cc_library(
+         "transforms/legalize_utils.h",
+     ],
+     compatible_with = get_compatible_with_portable(),
+-    tags = ["tf_tosa"],
+     deps = [
+         "//tensorflow/compiler/mlir/lite:tensorflow_lite",
+         "//tensorflow/compiler/mlir/lite/kernels/internal:common",
+@@ -107,7 +114,6 @@ cc_library(
+ gentbl_cc_library(
+     name = "tosa_legalize_tf_inc_gen",
+     compatible_with = get_compatible_with_portable(),
+-    tags = ["tf_tosa"],
+     tbl_outs = [
+         (
+             ["-gen-rewriters"],
+@@ -138,7 +144,7 @@ cc_library(
+         "transforms/passes.h",
+     ],
+     compatible_with = get_compatible_with_portable(),
+-    tags = ["tf_tosa"],
++    visibility = [":friends"],
+     deps = [
+         ":legalize_common",
+         ":passes_header",
+@@ -163,7 +169,6 @@ cc_library(
+ gentbl_cc_library(
+     name = "tosa_legalize_tfl_inc_gen",
+     compatible_with = get_compatible_with_portable(),
+-    tags = ["tf_tosa"],
+     tbl_outs = [
+         (
+             ["-gen-rewriters"],
+@@ -200,7 +205,7 @@ cc_library(
+         "transforms/passes.h",
+     ],
+     compatible_with = get_compatible_with_portable(),
+-    tags = ["tf_tosa"],
++    visibility = [":friends"],
+     deps = [
+         ":legalize_common",
+         ":passes_header",
+@@ -235,7 +240,7 @@ cc_library(
+         "transforms/passes.h",
+     ],
+     compatible_with = get_compatible_with_portable(),
+-    tags = ["tf_tosa"],
++    visibility = [":friends"],
+     deps = [
+         ":legalize_common",
+         ":passes_header",
+diff --git a/tensorflow/compiler/mlir/tosa/tests/BUILD b/tensorflow/compiler/mlir/tosa/tests/BUILD
+index e936d924ef4..a523ba82942 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/BUILD
++++ b/tensorflow/compiler/mlir/tosa/tests/BUILD
+@@ -9,7 +9,6 @@ package(
+ glob_lit_tests(
+     name = "all_tests",
+     data = [":test_utilities"],
+-    default_tags = ["tf_tosa"],
+     driver = "@llvm-project//mlir:run_lit.sh",
+     size_override = {
+         "tf-to-tosa-pipeline.mlir": "medium",
+diff --git a/tensorflow/compiler/mlir/tosa/tests/convert-tfl-uint8.mlir b/tensorflow/compiler/mlir/tosa/tests/convert-tfl-uint8.mlir
+index 8738a07ac60..42c7b707e5b 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/convert-tfl-uint8.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/convert-tfl-uint8.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt --tosa-convert-tfl-uint8  --verify-each %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // Operations for testing --tosa-convert-tfl-uint8
+ 
+diff --git a/tensorflow/compiler/mlir/tosa/tests/convert_metadata.mlir b/tensorflow/compiler/mlir/tosa/tests/convert_metadata.mlir
+index 5d7c3316b19..7fb03c7728c 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/convert_metadata.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/convert_metadata.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt --split-input-file --pass-pipeline='builtin.module(func.func(tosa-tflite-convert-function-metadata))' %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ module attributes {tfl.schema_version = 3 : i32} {
+   // CHECK: func.func @main(
+diff --git a/tensorflow/compiler/mlir/tosa/tests/fuse-bias-tf.mlir b/tensorflow/compiler/mlir/tosa/tests/fuse-bias-tf.mlir
+index f00c0358fda..badef0d235f 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/fuse-bias-tf.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/fuse-bias-tf.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt --tosa-fuse-bias-tf --verify-each %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // Operations for testing --tosa-fuse-bias-tf
+ 
+diff --git a/tensorflow/compiler/mlir/tosa/tests/lower-complex-types.mlir b/tensorflow/compiler/mlir/tosa/tests/lower-complex-types.mlir
+index c9b59c2201c..fe6a8ea07b1 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/lower-complex-types.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/lower-complex-types.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt --split-input-file --tosa-lower-complex-types --verify-each %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // CHECK-LABEL: test_complex_input
+ // CHECK-SAME: %[[VAL_0:.*]]: tensor<1x4x4x2xf32>
+diff --git a/tensorflow/compiler/mlir/tosa/tests/multi_add.mlir b/tensorflow/compiler/mlir/tosa/tests/multi_add.mlir
+index 28f3192bae2..c513f2ec936 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/multi_add.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/multi_add.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt --tfl-to-tosa-pipeline=target-compilation-backend %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // CHECK:      tensor<1x8x8x3xf32> {ml_program.identifier = "a"}
+ // CHECK-SAME: tensor<1x8x8x3xf32> {ml_program.identifier = "b"}
+diff --git a/tensorflow/compiler/mlir/tosa/tests/retain_call_once_funcs.mlir b/tensorflow/compiler/mlir/tosa/tests/retain_call_once_funcs.mlir
+index 8feb41f2631..64fcdfc18d0 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/retain_call_once_funcs.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/retain_call_once_funcs.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt --split-input-file --pass-pipeline='builtin.module(tflite-retain-call-once-funcs)' %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // CHECK-LABEL: module {
+ module {
+diff --git a/tensorflow/compiler/mlir/tosa/tests/strip-quant-types.mlir b/tensorflow/compiler/mlir/tosa/tests/strip-quant-types.mlir
+index bac7879370f..e8b3bb45e0a 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/strip-quant-types.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/strip-quant-types.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt --split-input-file --tosa-strip-quant-types  --verify-each %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // -----
+ 
+diff --git a/tensorflow/compiler/mlir/tosa/tests/strip_metadata.mlir b/tensorflow/compiler/mlir/tosa/tests/strip_metadata.mlir
+index 5f75b923739..f2198823a6d 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/strip_metadata.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/strip_metadata.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt --pass-pipeline='builtin.module(tosa-tflite-strip-module-metadata,func.func(tosa-tflite-strip-function-metadata))' %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // CHECK-LABEL: module {
+ // CHECK-NOT: tf.schema_version
+diff --git a/tensorflow/compiler/mlir/tosa/tests/tf-tfl-to-tosa-pipeline.mlir b/tensorflow/compiler/mlir/tosa/tests/tf-tfl-to-tosa-pipeline.mlir
+index 7eadb79b757..4e0854ccd6f 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/tf-tfl-to-tosa-pipeline.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/tf-tfl-to-tosa-pipeline.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt --split-input-file --tf-tfl-to-tosa-pipeline  --verify-each %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // These tests focus on TensorFlow and TensorFlow Lite hybrid lowering and focus
+ // on tfl.custom operations that are Flex ops.
+diff --git a/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir b/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
+index 99d5bd23688..8381143b8e0 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/tf-to-tosa-pipeline.mlir
+@@ -1,7 +1,5 @@
+ // RUN: tf-opt --tf-to-tosa-pipeline  --verify-each %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ // RUN: tf-opt --tf-tfl-to-tosa-pipeline  --verify-each %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // Operations for testing tf-to-tosa-pipeline
+ // TODO: These tests are fairly minimal. Expand the checks to be more robust.
+diff --git a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-dequantize_softmax.mlir b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-dequantize_softmax.mlir
+index 936dbf7c69c..f03b7b4e0dc 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-dequantize_softmax.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-dequantize_softmax.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt --tosa-dequantize-tfl-softmax %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // -----
+ 
+diff --git a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline-filtered.mlir b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline-filtered.mlir
+index 77919da76fd..4fb42c49e6d 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline-filtered.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline-filtered.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt --pass-pipeline='builtin.module(func.func(tosa-legalize-tfl{disable-patterns=TFLConv2D,TFLSoftmax, enable-patterns=TFLFullyConnected,TFLTranspose}))' %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // -----
+ 
+diff --git a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+index b9be1ce6aa2..147f90d7d3f 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+@@ -1,7 +1,5 @@
+ // RUN: tf-opt --split-input-file --tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ // RUN: tf-opt --split-input-file --tf-tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // Operations for testing tfl-to-tosa-pipeline
+ 
+diff --git a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-stateful.mlir b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-stateful.mlir
+index 84a960be8ed..336aeab6017 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-stateful.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-stateful.mlir
+@@ -1,7 +1,5 @@
+ // RUN: tf-opt --split-input-file --tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ // RUN: tf-opt --split-input-file --tf-tfl-to-tosa-pipeline --verify-each %s | FileCheck %s
+-// REQUIRES: tf_tosa
+ 
+ // Operations for testing tfl-to-tosa-pipeline
+ 
+diff --git a/tensorflow/compiler/mlir/tosa/tests/verify_fully_converted.mlir b/tensorflow/compiler/mlir/tosa/tests/verify_fully_converted.mlir
+index ac918b32135..3783c379908 100644
+--- a/tensorflow/compiler/mlir/tosa/tests/verify_fully_converted.mlir
++++ b/tensorflow/compiler/mlir/tosa/tests/verify_fully_converted.mlir
+@@ -1,5 +1,4 @@
+ // RUN: tf-opt %s --tosa-tflite-verify-fully-converted --split-input-file -verify-diagnostics
+-// REQUIRES: tf_tosa
+ 
+ // CHECK-LABEL: func.func @main
+ func.func @main(%arg0: tensor<2xf32>) -> (tensor<2xf32>) {
+diff --git a/tensorflow/compiler/mlir/tosa/transforms/convert_tfl_uint8.cc b/tensorflow/compiler/mlir/tosa/transforms/convert_tfl_uint8.cc
+index 2931e5ae465..fa94ef5583c 100644
+--- a/tensorflow/compiler/mlir/tosa/transforms/convert_tfl_uint8.cc
++++ b/tensorflow/compiler/mlir/tosa/transforms/convert_tfl_uint8.cc
+@@ -23,9 +23,12 @@ limitations under the License.
+ // 3. insert tosa.RESCALE int8 -> uint8 if original returned tensor is uint8
+ // typed.
+ 
++#include <climits>
+ #include <cstddef>
+ #include <cstdint>
++#include <iterator>
+ #include <memory>
++#include <numeric>
+ #include <utility>
+ 
+ #include "mlir/Dialect/Func/IR/FuncOps.h"                // from @llvm-project
+diff --git a/tensorflow/compiler/mlir/tosa/transforms/fuse_bias_tf.cc b/tensorflow/compiler/mlir/tosa/transforms/fuse_bias_tf.cc
+index 7a0077dd72c..e3e0240a281 100644
+--- a/tensorflow/compiler/mlir/tosa/transforms/fuse_bias_tf.cc
++++ b/tensorflow/compiler/mlir/tosa/transforms/fuse_bias_tf.cc
+@@ -15,7 +15,12 @@ limitations under the License.
+ 
+ // Fuse tf.Op + tf.BiasAdd and legalized to TOSA
+ 
++#include <climits>
++#include <cstddef>
++#include <cstdint>
++#include <iterator>
+ #include <memory>
++#include <numeric>
+ #include <optional>
+ #include <utility>
+ 
+diff --git a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.h b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.h
+index 8cc74ee9bd5..41fe1655358 100644
+--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_common.h
++++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_common.h
+@@ -16,7 +16,6 @@ limitations under the License.
+ #ifndef TENSORFLOW_COMPILER_MLIR_TOSA_TRANSFORMS_LEGALIZE_COMMON_H_
+ #define TENSORFLOW_COMPILER_MLIR_TOSA_TRANSFORMS_LEGALIZE_COMMON_H_
+ 
+-#include <cstdint>
+ #include <optional>
+ 
+ #include "mlir/IR/PatternMatch.h"  // from @llvm-project
+diff --git a/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc b/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
+index 5264e52fa69..8159fa125e1 100644
+--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
++++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tf.cc
+@@ -15,11 +15,13 @@ limitations under the License.
+ 
+ // Legalize TensorFlow to TOSA
+ 
+-#include <cassert>
++#include <climits>
++#include <cstddef>
+ #include <cstdint>
+ #include <iterator>
+ #include <limits>
+ #include <memory>
++#include <numeric>
+ #include <optional>
+ #include <utility>
+ 
+diff --git a/tensorflow/compiler/mlir/tosa/transforms/lower_complex_types.cc b/tensorflow/compiler/mlir/tosa/transforms/lower_complex_types.cc
+index 3ec3a37f167..432edaf3679 100644
+--- a/tensorflow/compiler/mlir/tosa/transforms/lower_complex_types.cc
++++ b/tensorflow/compiler/mlir/tosa/transforms/lower_complex_types.cc
+@@ -30,7 +30,7 @@ limitations under the License.
+ // any remaining "unrealized_conversion_cast" operations and ensures the
+ // resulting graph is free of illegal complex tensors.
+ 
+-#include <cstdint>
++#include <iterator>
+ #include <memory>
+ #include <utility>
+ 
+diff --git a/tensorflow/compiler/mlir/tosa/transforms/strip_quant_types.cc b/tensorflow/compiler/mlir/tosa/transforms/strip_quant_types.cc
+index cddcc8d614c..c63173bd2e9 100644
+--- a/tensorflow/compiler/mlir/tosa/transforms/strip_quant_types.cc
++++ b/tensorflow/compiler/mlir/tosa/transforms/strip_quant_types.cc
+@@ -23,7 +23,12 @@ limitations under the License.
+ // 3. insert tosa.RESCALE int8 -> uint8 if original returned tensor is uint8
+ // typed.
+ 
++#include <climits>
++#include <cstddef>
++#include <cstdint>
++#include <iterator>
+ #include <memory>
++#include <numeric>
+ #include <utility>
+ 
+ #include "mlir/Dialect/Tosa/IR/TosaOps.h"  // from @llvm-project
+diff --git a/tensorflow/python/_pywrap_mlir.pyi b/tensorflow/python/_pywrap_mlir.pyi
+index 86411b1ef94..d1375e15159 100644
+--- a/tensorflow/python/_pywrap_mlir.pyi
++++ b/tensorflow/python/_pywrap_mlir.pyi
+@@ -19,6 +19,7 @@ def ExperimentalConvertSavedModelToMlir(arg0: str, arg1: str, arg2: bool) -> str
+ def ExperimentalConvertSavedModelV1ToMlir(arg0: str, arg1: str, arg2: str, arg3: bool, arg4: bool, arg5: bool, arg6: bool) -> str: ...
+ def ExperimentalConvertSavedModelV1ToMlirLite(arg0: str, arg1: str, arg2: str, arg3: bool, arg4: bool) -> str: ...
+ def ExperimentalRunPassPipeline(arg0: str, arg1: str, arg2: bool) -> str: ...
++def ExperimentalTFLiteToTosaBytecode(arg0: str, arg1: str, arg2: bool, arg3: list[str], arg4: list[str]) -> None: ...
+ def ExperimentalWriteBytecode(arg0: str, arg1: str) -> None: ...
+ def ImportFunction(arg0: object, arg1: str, arg2: str, arg3: bool) -> str: ...
+ @overload
+diff --git a/tensorflow/python/compiler/mlir/mlir_test.py b/tensorflow/python/compiler/mlir/mlir_test.py
+index 9c7f75950f4..9b4a54729b1 100644
+--- a/tensorflow/python/compiler/mlir/mlir_test.py
++++ b/tensorflow/python/compiler/mlir/mlir_test.py
+@@ -14,6 +14,7 @@
+ # =============================================================================
+ """Tests for python.compiler.mlir."""
+ 
++import os
+ from tensorflow.python.compiler.mlir import mlir
+ from tensorflow.python.eager import def_function
+ from tensorflow.python.framework import dtypes
+@@ -22,7 +23,9 @@ from tensorflow.python.framework import tensor_spec
+ from tensorflow.python.framework import test_util
+ from tensorflow.python.ops import logging_ops
+ from tensorflow.python.ops import math_ops
++from tensorflow.python.platform import resource_loader
+ from tensorflow.python.platform import test
++from tensorflow.python.pywrap_mlir import experimental_tflite_to_tosa_bytecode
+ from tensorflow.python.pywrap_mlir import import_graphdef
+ 
+ 
+@@ -158,5 +161,19 @@ class MLIRConcreteFunctionImportTest(test.TestCase):
+     self.assertRegex(mlir_module, r'tf_executor.fetch.*: !tf_executor.control')
+ 
+ 
++class MLIRFlatbufferImportTest(test.TestCase):
++
++  def testImport(self):
++    """Tests the basic flow of `experimental_tflite_to_tosa_bytecode`."""
++    filename = os.path.join(self.get_temp_dir(), "multi_add_tosa.mlirbc")
++    experimental_tflite_to_tosa_bytecode(
++        resource_loader.get_path_to_datafile("multi_add.tflite"), filename
++    )
++    with open(filename, mode="rb") as f:
++      chunk = f.read(4)
++    # Just verify output is bytecode.
++    self.assertEqual(b"ML\xefR", chunk)
++
++
+ if __name__ == '__main__':
+   test.main()
+diff --git a/tensorflow/python/mlir_wrapper.cc b/tensorflow/python/mlir_wrapper.cc
+index e00ff095b62..e2be50051ee 100644
+--- a/tensorflow/python/mlir_wrapper.cc
++++ b/tensorflow/python/mlir_wrapper.cc
+@@ -125,4 +125,17 @@ PYBIND11_MODULE(_pywrap_mlir, m) {
+     tensorflow::ExperimentalWriteBytecode(filename, mlir_txt, status.get());
+     tensorflow::MaybeRaiseRegisteredFromTFStatus(status.get());
+   });
++
++  m.def("ExperimentalTFLiteToTosaBytecode",
++        [](const std::string &flatbuffer_file,
++           const std::string &tosa_bytecode_file, bool use_external_constant,
++           const std::vector<std::string> &ordered_input_arrays,
++           const std::vector<std::string> &ordered_output_arrays) {
++          tensorflow::Safe_TF_StatusPtr status =
++              tensorflow::make_safe(TF_NewStatus());
++          tensorflow::ExperimentalTFLiteToTosaBytecode(
++              flatbuffer_file, tosa_bytecode_file, use_external_constant,
++              ordered_input_arrays, ordered_output_arrays, status.get());
++          tensorflow::MaybeRaiseRegisteredFromTFStatus(status.get());
++        });
+ };
+diff --git a/third_party/xla/third_party/tsl/.bazelrc b/third_party/xla/third_party/tsl/.bazelrc
+new file mode 100644
+index 00000000000..19f4a1341d1
+--- /dev/null
++++ b/third_party/xla/third_party/tsl/.bazelrc
+@@ -0,0 +1,923 @@
++# TensorFlow Bazel configuration file.
++# This file tries to group and simplify build options for TensorFlow
++#
++# ----CONFIG OPTIONS----
++# Android options:
++#    android:
++#    android_arm:
++#    android_arm64:
++#    android_x86:
++#    android_x86_64:
++#
++# iOS options:
++#     ios:
++#     ios_armv7:
++#     ios_arm64:
++#     ios_x86_64:
++#     ios_fat:
++#
++# Macosx options
++#     darwin_arm64:
++#
++# Compiler options:
++#     cuda_clang:             Use Clang when building CUDA code.
++#     avx_linux:              Build with avx instruction set on linux.
++#     avx_win:                Build with avx instruction set on windows
++#
++# Other build options:
++#     short_logs:       Only log errors during build, skip warnings.
++#     verbose_logs:     Show all compiler warnings during build.
++#     monolithic:       Build all TF C++ code into a single shared object.
++#     dynamic_kernels:  Try to link all kernels dynamically (experimental).
++#     dbg:              Build with debug info
++#
++# TF version options;
++#     v2: Build TF v2
++#
++# Feature and Third party library support options:
++#     xla:          Build TF with XLA
++#     tpu:          Build TF with TPU support
++#     cuda:         Build with CUDA support.
++#     cuda_clang    Build with CUDA Clang support.
++#     rocm:         Build with AMD GPU support (rocm)
++#     mkl:          Enable full mkl support.
++#     nogcp:        Disable GCS support.
++#     nonccl:       Disable nccl support.
++#
++#
++# Remote build execution options (only configured to work with TF team projects for now.)
++#     rbe_base:  General RBE options shared by all flavors.
++#     rbe_linux: General RBE options used on all linux builds.
++#     rbe_win_base:   General RBE options used on all Windows builds. Not to be used standalone.
++#     rbe_win_clang:  Options specific to compiling using Clang.
++#
++#     rbe_linux_cpu:                  RBE options to build with only CPU support.
++#     rbe_linux_cuda:                 RBE options to build with GPU support using clang.
++#     rbe_linux_cuda_nvcc:            RBE options to build with GPU support using nvcc.
++#
++# Embedded Linux options (experimental and only tested with TFLite build yet)
++#     elinux:          General Embedded Linux options shared by all flavors.
++#     elinux_aarch64:  Embedded Linux options for aarch64 (ARM64) CPU support.
++#     elinux_armhf:    Embedded Linux options for armhf (ARMv7) CPU support.
++#
++# Release build options (for all operating systems)
++#     release_base:                    Common options for all builds on all operating systems.
++#     release_cpu_linux:               Toolchain and CUDA options for Linux CPU builds.
++#     release_gpu_linux:               Toolchain and CUDA options for Linux GPU builds.
++#     release_cpu_macos:               Toolchain and CUDA options for MacOS CPU builds.
++#     release_cpu_windows:             Toolchain and CUDA options for Windows CPU builds.
++
++# Default build options. These are applied first and unconditionally.
++
++# For projects which use TensorFlow as part of a Bazel build process, putting
++# nothing in a bazelrc will default to a monolithic build. The following line
++# opts in to modular op registration support by default.
++build --define framework_shared_object=true
++build --define tsl_protobuf_header_only=true
++
++build --define=use_fast_cpp_protos=true
++build --define=allow_oversize_protos=true
++
++build --spawn_strategy=standalone
++build -c opt
++
++# Make Bazel print out all options from rc files.
++build --announce_rc
++
++# TODO(mihaimaruseac): Document this option or remove if no longer needed
++build --define=grpc_no_ares=true
++
++# See https://github.com/bazelbuild/bazel/issues/7362 for information on what
++# --incompatible_remove_legacy_whole_archive flag does.
++# This flag is set to true in Bazel 1.0 and newer versions. We tried to migrate
++# Tensorflow to the default, however test coverage wasn't enough to catch the
++# errors.
++# There is ongoing work on Bazel team's side to provide support for transitive
++# shared libraries. As part of migrating to transitive shared libraries, we
++# hope to provide a better mechanism for control over symbol exporting, and
++# then tackle this issue again.
++#
++# TODO: Remove the following two lines once TF doesn't depend on Bazel wrapping
++# all library archives in -whole_archive -no_whole_archive.
++build --noincompatible_remove_legacy_whole_archive
++build --features=-force_no_whole_archive
++
++# TODO(mihaimaruseac): Document this option or remove if no longer needed
++build --enable_platform_specific_config
++
++# Enable XLA support by default.
++build --define=with_xla_support=true
++
++# TODO(mihaimaruseac): Document this option or remove if no longer needed
++build --config=short_logs
++
++# TODO(mihaimaruseac): Document this option or remove if no longer needed
++build --config=v2
++
++# TF now has `cc_shared_library` targets, so it needs the experimental flag
++# TODO(rostam): Remove when `cc_shared_library` is enabled by default
++build --experimental_cc_shared_library
++
++# cc_shared_library ensures no library is linked statically more than once.
++build --experimental_link_static_libraries_once=false
++
++# Prevent regressions on those two incompatible changes
++# TODO: remove those flags when they are flipped in the default Bazel version TF uses.
++build --incompatible_enforce_config_setting_visibility
++# TODO: also enable this flag after fixing the visibility violations
++# build --incompatible_config_setting_private_default_visibility
++
++# Print a stacktrace when a test is killed
++test --test_env="GTEST_INSTALL_FAILURE_SIGNAL_HANDLER=1"
++
++
++# Default options should come above this line.
++
++# Android configs. Bazel needs to have --cpu and --fat_apk_cpu both set to the
++# target CPU to build transient dependencies correctly. See
++# https://docs.bazel.build/versions/master/user-manual.html#flag--fat_apk_cpu
++build:android --crosstool_top=//external:android/crosstool
++build:android --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
++build:android_arm --config=android
++build:android_arm --cpu=armeabi-v7a
++build:android_arm --fat_apk_cpu=armeabi-v7a
++build:android_arm64 --config=android
++build:android_arm64 --cpu=arm64-v8a
++build:android_arm64 --fat_apk_cpu=arm64-v8a
++build:android_x86 --config=android
++build:android_x86 --cpu=x86
++build:android_x86 --fat_apk_cpu=x86
++build:android_x86_64 --config=android
++build:android_x86_64 --cpu=x86_64
++build:android_x86_64 --fat_apk_cpu=x86_64
++
++# Build everything statically for Android since all static libs are later
++# bundled together into a single .so for deployment.
++build:android --dynamic_mode=off
++# TODO(belitskiy): Remove once on Clang 20.
++build:android --define=xnn_enable_avxvnniint8=false
++
++# Sets the default Apple platform to macOS.
++build:macos --apple_platform_type=macos
++
++# gRPC on MacOS requires this #define
++build:macos --copt=-DGRPC_BAZEL_BUILD
++
++# Avoid hitting command line argument limit
++build:macos --features=archive_param_file
++
++# Settings for MacOS on ARM CPUs.
++build:macos_arm64 --cpu=darwin_arm64
++build:macos_arm64 --macos_minimum_os=11.0
++
++# iOS configs for each architecture and the fat binary builds.
++build:ios --apple_platform_type=ios
++build:ios --apple_bitcode=embedded --copt=-fembed-bitcode
++build:ios --copt=-Wno-c++11-narrowing
++build:ios_armv7 --config=ios
++build:ios_armv7 --cpu=ios_armv7
++build:ios_arm64 --config=ios
++build:ios_arm64 --cpu=ios_arm64
++build:ios_arm64e --config=ios
++build:ios_arm64e --cpu=ios_arm64e
++build:ios_sim_arm64 --config=ios
++build:ios_sim_arm64 --cpu=ios_sim_arm64
++build:ios_x86_64 --config=ios
++build:ios_x86_64 --cpu=ios_x86_64
++build:ios_fat --config=ios
++build:ios_fat --ios_multi_cpus=armv7,arm64,i386,x86_64
++
++# Config to use a mostly-static build and disable modular op registration
++# support (this will revert to loading TensorFlow with RTLD_GLOBAL in Python).
++# By default, TensorFlow will build with a dependence on
++# //tensorflow:libtensorflow_framework.so.
++build:monolithic --define framework_shared_object=false
++build:monolithic --define tsl_protobuf_header_only=false
++build:monolithic --experimental_link_static_libraries_once=false  # b/229868128
++
++# Please note that MKL on MacOS is still not supported.
++# If you would like to use a local MKL instead of downloading, please set the
++# environment variable "TF_MKL_ROOT" every time before build.
++build:mkl --define=build_with_mkl=true --define=enable_mkl=true
++build:mkl --define=tensorflow_mkldnn_contraction_kernel=0
++build:mkl --define=build_with_openmp=true
++build:mkl -c opt
++
++# config to build OneDNN backend with a user specified threadpool.
++build:mkl_threadpool --define=build_with_mkl=true --define=enable_mkl=true
++build:mkl_threadpool --define=tensorflow_mkldnn_contraction_kernel=0
++build:mkl_threadpool --define=build_with_mkl_opensource=true
++build:mkl_threadpool -c opt
++
++# Config setting to build oneDNN with Compute Library for the Arm Architecture (ACL).
++build:mkl_aarch64 --define=build_with_mkl_aarch64=true
++build:mkl_aarch64 --define=build_with_openmp=true
++build:mkl_aarch64 --define=build_with_acl=true
++build:mkl_aarch64 -c opt
++
++# Config setting to build oneDNN with Compute Library for the Arm Architecture (ACL).
++# with Eigen threadpool support
++build:mkl_aarch64_threadpool --define=build_with_mkl_aarch64=true
++build:mkl_aarch64_threadpool -c opt
++
++# CUDA: This config refers to building CUDA op kernels with nvcc.
++build:cuda --repo_env TF_NEED_CUDA=1
++build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain
++build:cuda --@local_config_cuda//:enable_cuda
++# Default CUDA and CUDNN versions.
++build:cuda --repo_env=HERMETIC_CUDA_VERSION="12.5.1"
++build:cuda --repo_env=HERMETIC_CUDNN_VERSION="9.3.0"
++# This flag is needed to include CUDA libraries.
++build:cuda --@local_config_cuda//cuda:include_cuda_libs=true
++
++# This configuration is used for building the wheels.
++build:cuda_wheel --@local_config_cuda//cuda:include_cuda_libs=false
++
++# CUDA: This config refers to building CUDA op kernels with clang.
++build:cuda_clang --config=cuda
++build:cuda_clang --@local_config_cuda//:cuda_compiler=clang
++build:cuda_clang --copt=-Qunused-arguments
++# Select supported compute capabilities (supported graphics cards).
++# This is the same as the official TensorFlow builds.
++# See https://developer.nvidia.com/cuda-gpus#compute
++# `compute_XY` enables PTX embedding in addition to SASS. PTX
++# is forward compatible beyond the current compute capability major
++# release while SASS is only forward compatible inside the current
++# major release. Example: sm_80 kernels can run on sm_89 GPUs but
++# not on sm_90 GPUs. compute_80 kernels though can also run on sm_90 GPUs.
++build:cuda_clang --repo_env=HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_60,sm_70,sm_80,sm_89,compute_90"
++# Permit newer CUDA versions than Clang is aware of
++build:cuda_clang --copt="-Wno-unknown-cuda-version"
++# Set lld as the linker.
++build:cuda_clang --host_linkopt="-fuse-ld=lld"
++build:cuda_clang --host_linkopt="-lm"
++build:cuda_clang --linkopt="-fuse-ld=lld"
++build:cuda_clang --linkopt="-lm"
++
++# Set up compilation CUDA version and paths and use the CUDA Clang toolchain.
++build:cuda_clang_official --config=cuda_clang
++build:cuda_clang_official --repo_env=HERMETIC_CUDA_VERSION="12.5.1"
++build:cuda_clang_official --repo_env=HERMETIC_CUDNN_VERSION="9.3.0"
++build:cuda_clang_official --action_env=CLANG_CUDA_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
++build:cuda_clang_official --crosstool_top="@local_config_cuda//crosstool:toolchain"
++
++# Build with nvcc for CUDA and clang for host
++build:cuda_nvcc --config=cuda
++build:cuda_nvcc --action_env=TF_NVCC_CLANG="1"
++build:cuda_nvcc --@local_config_cuda//:cuda_compiler=nvcc
++# Old config for backward compatibility
++build:nvcc_clang --config=cuda_nvcc
++
++# Debug config
++build:dbg -c dbg
++# Only include debug info for files under tensorflow/, excluding kernels, to
++# reduce the size of the debug info in the binary. This is because if the debug
++# sections in the ELF binary are too large, errors can occur. See
++# https://github.com/tensorflow/tensorflow/issues/48919.
++# Users can still include debug info for a specific kernel, e.g. with:
++#     --config=dbg --per_file_copt=+tensorflow/core/kernels/identity_op.*@-g
++# Since this .bazelrc file is synced between the tensorflow/tensorflow repo and
++# the openxla/xla repo, also include debug info for files under xla/.
++build:dbg --per_file_copt=+.*,-tensorflow.*,-xla.*@-g0
++build:dbg --per_file_copt=+tensorflow/core/kernels.*@-g0
++# for now, disable arm_neon. see: https://github.com/tensorflow/tensorflow/issues/33360
++build:dbg --cxxopt -DTF_LITE_DISABLE_X86_NEON
++# AWS SDK must be compiled in release mode. see: https://github.com/tensorflow/tensorflow/issues/37498
++build:dbg --copt -DDEBUG_BUILD
++
++# Config to build TF TPU
++build:tpu --define=with_tpu_support=true
++build:tpu --define=framework_shared_object=true
++build:tpu --copt=-DLIBTPU_ON_GCE
++build:tpu --define=enable_mlir_bridge=true
++
++build:rocm --crosstool_top=@local_config_rocm//crosstool:toolchain
++build:rocm --define=using_rocm_hipcc=true
++build:rocm --define=tensorflow_mkldnn_contraction_kernel=0
++build:rocm --define=xnn_enable_avxvnniint8=false
++build:rocm --define=xnn_enable_avx512fp16=false
++build:rocm --repo_env TF_NEED_ROCM=1
++
++build:rocm_clang_official --config=rocm
++build:rocm_clang_official --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
++build:rocm_clang_official --action_env=TF_ROCM_CLANG="1"
++build:rocm_clang_official --linkopt="-fuse-ld=lld"
++build:rocm_clang_official --host_linkopt="-fuse-ld=lld"
++
++build:rocm_ci --config=rocm_clang_official
++build:rocm_ci_hermetic --config=rocm_clang_official
++build:rocm_ci_hermetic --repo_env="OS=ubuntu_22.04"
++build:rocm_ci_hermetic --repo_env="ROCM_VERSION=6.2.0"
++build:rocm_ci_hermetic --@local_config_rocm//rocm:use_rocm_hermetic_rpath=True
++
++build:sycl --crosstool_top=@local_config_sycl//crosstool:toolchain
++build:sycl --define=using_sycl=true
++build:sycl --define=tensorflow_mkldnn_contraction_kernel=0
++build:sycl --repo_env TF_NEED_SYCL=1
++
++# Options to disable default on features
++build:nogcp --define=no_gcp_support=true
++build:nonccl --define=no_nccl_support=true
++
++# Modular TF build options
++build:dynamic_kernels --define=dynamic_loaded_kernels=true
++build:dynamic_kernels --copt=-DAUTOLOAD_DYNAMIC_KERNELS
++
++# Don't trigger --config=<host platform> when cross-compiling.
++build:android --noenable_platform_specific_config
++build:ios --noenable_platform_specific_config
++
++# Suppress all C++ compiler warnings, otherwise build logs become 10s of MBs.
++build:android --copt=-w
++build:ios --copt=-w
++build:linux --host_copt=-w
++build:macos --copt=-w
++build:windows --copt=/W0
++build:windows --host_copt=/W0
++
++# Suppress most C++ compiler warnings to reduce log size but allow
++# for specific warnings to still be present.
++build:linux --copt="-Wno-all"
++build:linux --copt="-Wno-extra"
++build:linux --copt="-Wno-deprecated"
++build:linux --copt="-Wno-deprecated-declarations"
++build:linux --copt="-Wno-ignored-attributes"
++build:linux --copt="-Wno-array-bounds"
++
++# Add unused-result as an error on Linux.
++build:linux --copt="-Wunused-result"
++build:linux --copt="-Werror=unused-result"
++# Add switch as an error on Linux.
++build:linux --copt="-Wswitch"
++build:linux --copt="-Werror=switch"
++
++# Linux ARM64 specific options
++build:linux_arm64 --copt="-mtune=generic" --copt="-march=armv8-a" --copt="-O3"
++
++
++# On Windows, `__cplusplus` is wrongly defined without this switch
++# See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
++build:windows --copt=/Zc:__cplusplus
++build:windows --host_copt=/Zc:__cplusplus
++
++# Tensorflow uses M_* math constants that only get defined by MSVC headers if
++# _USE_MATH_DEFINES is defined.
++build:windows --copt=/D_USE_MATH_DEFINES
++build:windows --host_copt=/D_USE_MATH_DEFINES
++
++# Windows has a relatively short command line limit, which TF has begun to hit.
++# See https://docs.bazel.build/versions/main/windows.html
++build:windows --features=compiler_param_file
++build:windows --features=archive_param_file
++
++# Speed Windows compile times. Available in VS 16.4 (we are on 16.11). See
++# https://groups.google.com/a/tensorflow.org/d/topic/build/SsW98Eo7l3o/discussion
++build:windows --copt=/d2ReducedOptimizeHugeFunctions
++build:windows --host_copt=/d2ReducedOptimizeHugeFunctions
++
++# Before VS 2017 15.8, the member "type" would non-conformingly have an
++# alignment of only alignof(max_align_t). VS 2017 15.8 was fixed to handle this
++# correctly, but the fix inherently changes layout and breaks binary
++# compatibility (*only* for uses of aligned_storage with extended alignments).
++build:windows --copt=-D_ENABLE_EXTENDED_ALIGNED_STORAGE
++build:windows --host_copt=-D_ENABLE_EXTENDED_ALIGNED_STORAGE
++
++# Enable the runfiles symlink tree on Windows. This makes it possible to build
++# the pip package on Windows without an intermediate data-file archive, as the
++# build_pip_package script in its current form (as of Aug 2023) uses the
++# runfiles symlink tree to decide what to put into the Python wheel.
++startup --windows_enable_symlinks
++build:windows --enable_runfiles
++build:windows --nobuild_python_zip
++build:windows --dynamic_mode=off
++
++# Default paths for TF_SYSTEM_LIBS
++build:linux --define=PREFIX=/usr
++build:linux --define=LIBDIR=$(PREFIX)/lib
++build:linux --define=INCLUDEDIR=$(PREFIX)/include
++build:linux --define=PROTOBUF_INCLUDE_PATH=$(PREFIX)/include
++build:macos --define=PREFIX=/usr
++build:macos --define=LIBDIR=$(PREFIX)/lib
++build:macos --define=INCLUDEDIR=$(PREFIX)/include
++build:macos --define=PROTOBUF_INCLUDE_PATH=$(PREFIX)/include
++# TF_SYSTEM_LIBS do not work on windows.
++
++# By default, build TF in C++ 17 mode.
++build:android --cxxopt=-std=c++17
++build:android --host_cxxopt=-std=c++17
++build:ios --cxxopt=-std=c++17
++build:ios --host_cxxopt=-std=c++17
++build:linux --cxxopt=-std=c++17
++build:linux --host_cxxopt=-std=c++17
++build:macos --cxxopt=-std=c++17
++build:macos --host_cxxopt=-std=c++17
++build:windows --cxxopt=/std:c++17
++build:windows --host_cxxopt=/std:c++17
++
++# On windows, we still link everything into a single DLL.
++build:windows --config=monolithic
++
++# On linux, we dynamically link small amount of kernels
++build:linux --config=dynamic_kernels
++
++# Make sure to include as little of windows.h as possible
++build:windows --copt=-DWIN32_LEAN_AND_MEAN
++build:windows --host_copt=-DWIN32_LEAN_AND_MEAN
++build:windows --copt=-DNOGDI
++build:windows --host_copt=-DNOGDI
++
++# MSVC (Windows): Standards-conformant preprocessor mode
++# See https://docs.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview
++build:windows --copt=/Zc:preprocessor
++build:windows --host_copt=/Zc:preprocessor
++
++# Misc build options we need for windows.
++build:windows --linkopt=/DEBUG
++build:windows --host_linkopt=/DEBUG
++build:windows --linkopt=/OPT:REF
++build:windows --host_linkopt=/OPT:REF
++build:windows --linkopt=/OPT:ICF
++build:windows --host_linkopt=/OPT:ICF
++
++# Verbose failure logs when something goes wrong
++build:windows --verbose_failures
++
++# Work around potential issues with large command lines on windows.
++# See: https://github.com/bazelbuild/bazel/issues/5163
++build:windows --features=compiler_param_file
++
++# Do not risk cache corruption. See:
++# https://github.com/bazelbuild/bazel/issues/3360
++build:linux --experimental_guard_against_concurrent_changes
++
++# Configure short or long logs
++build:short_logs --output_filter=DONT_MATCH_ANYTHING
++build:verbose_logs --output_filter=
++
++# Instruction set optimizations
++# TODO(gunan): Create a feature in toolchains for avx/avx2 to
++#   avoid having to define linux/win separately.
++build:avx_linux --copt=-mavx
++build:avx_linux --host_copt=-mavx
++build:avx_win --copt=/arch:AVX
++
++# TODO(belitskiy): Remove once Win2019 is gone.
++# Use Clang-cl compiler on Windows
++build:win_clang --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
++build:win_clang --extra_execution_platforms=//tensorflow/tools/toolchains/win:x64_windows-clang-cl
++build:win_clang --host_platform=//tensorflow/tools/toolchains/win:x64_windows-clang-cl
++build:win_clang --copt=/clang:-Weverything
++build:win_clang --host_copt=/clang:-Weverything
++build:win_clang --compiler=clang-cl
++build:win_clang --linkopt=/FORCE:MULTIPLE
++build:win_clang --host_linkopt=/FORCE:MULTIPLE
++test:win_clang --linkopt=/FORCE:MULTIPLE
++test:win_clang --host_linkopt=/FORCE:MULTIPLE
++test:win_clang --action_env=PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.PY;.PYW
++
++build:windows_x86_cpu_2022 --crosstool_top="//tensorflow/tools/toolchains/win2022/20241118:toolchain"
++build:windows_x86_cpu_2022 --extra_toolchains="//tensorflow/tools/toolchains/win2022/20241118:cc-toolchain-x64_windows-clang-cl"
++build:windows_x86_cpu_2022 --extra_execution_platforms="//tensorflow/tools/toolchains/win2022:windows_ltsc2022_clang"
++build:windows_x86_cpu_2022 --host_platform="//tensorflow/tools/toolchains/win2022:windows_ltsc2022_clang"
++build:windows_x86_cpu_2022 --platforms="//tensorflow/tools/toolchains/win2022:windows_ltsc2022_clang"
++build:windows_x86_cpu_2022 --copt=/clang:-Weverything
++build:windows_x86_cpu_2022 --host_copt=/clang:-Weverything
++build:windows_x86_cpu_2022 --compiler=clang-cl
++build:windows_x86_cpu_2022 --linkopt=/FORCE:MULTIPLE
++build:windows_x86_cpu_2022 --host_linkopt=/FORCE:MULTIPLE
++test:windows_x86_cpu_2022 --linkopt=/FORCE:MULTIPLE
++test:windows_x86_cpu_2022 --host_linkopt=/FORCE:MULTIPLE
++test:windows_x86_cpu_2022 --action_env=PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.PY;.PYW
++
++# Options to build TensorFlow 1.x or 2.x.
++# TODO(kanglan): Change v2's define to default behavior
++build:v2 --define=tf_api_version=2 --action_env=TF2_BEHAVIOR=1
++
++# Enable all targets in XLA
++build:cpu_cross --define=with_cross_compiler_support=true
++
++# Disable XLA on mobile.
++build:xla     --define=with_xla_support=true # TODO: remove, it's on by default.
++build:android --define=with_xla_support=false
++build:ios     --define=with_xla_support=false
++
++# BEGIN TF REMOTE BUILD EXECUTION OPTIONS
++# Options when using remote execution
++# WARNING: THESE OPTIONS WONT WORK IF YOU DO NOT HAVE PROPER AUTHENTICATION AND PERMISSIONS
++
++# Allow creation of resultstore URLs for any bazel invocation
++build:resultstore --google_default_credentials
++build:resultstore --bes_backend=buildeventservice.googleapis.com
++build:resultstore --bes_instance_name="tensorflow-testing"
++build:resultstore --bes_results_url="https://source.cloud.google.com/results/invocations"
++build:resultstore --bes_timeout=600s
++
++# Flag to enable remote config
++common --experimental_repo_remote_exec
++
++# Make Bazel not try to probe the host system for a C++ toolchain.
++build:rbe_base --config=resultstore
++build:rbe_base --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
++build:rbe_base --define=EXECUTOR=remote
++build:rbe_base --jobs=800
++build:rbe_base --remote_executor=grpcs://remotebuildexecution.googleapis.com
++build:rbe_base --remote_timeout=3600
++build:rbe_base --spawn_strategy=remote,worker,standalone,local
++# Attempt to minimize the amount of data transfer between bazel and the remote
++# workers:
++build:rbe_base --remote_download_toplevel
++test:rbe_base --test_env=USER=anon
++
++# TODO(kanglan): Check if we want to merge rbe_linux into rbe_linux_cpu.
++build:rbe_linux --config=rbe_base
++build:rbe_linux --action_env=PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin"
++# Non-rbe settings we should include because we do not run configure
++build:rbe_linux --config=avx_linux
++# TODO(gunan): Check why we need this specified in rbe, but not in other builds.
++build:rbe_linux --linkopt=-lrt
++build:rbe_linux --host_linkopt=-lrt
++build:rbe_linux --linkopt=-lm
++build:rbe_linux --host_linkopt=-lm
++
++build:rbe_linux_cpu --config=rbe_linux
++# Linux cpu and cuda builds share the same toolchain now.
++build:rbe_linux_cpu --host_crosstool_top="@local_config_cuda//crosstool:toolchain"
++build:rbe_linux_cpu --crosstool_top="@local_config_cuda//crosstool:toolchain"
++build:rbe_linux_cpu --extra_toolchains="@local_config_cuda//crosstool:toolchain-linux-x86_64"
++build:rbe_linux_cpu --repo_env=CC="/usr/lib/llvm-18/bin/clang"
++build:rbe_linux_cpu --repo_env=TF_SYSROOT="/dt9"
++build:rbe_linux_cpu --extra_execution_platforms="@ml_build_config_platform//:platform"
++build:rbe_linux_cpu --host_platform="@ml_build_config_platform//:platform"
++build:rbe_linux_cpu --platforms="@ml_build_config_platform//:platform"
++# This is needed for all Clang17 builds but must not be present in GCC builds.
++build:rbe_linux_cpu --copt=-Wno-error=unused-command-line-argument
++# This was added in clang-16 by https://reviews.llvm.org/D133574.
++# Can be removed once upb is updated, since a type definition is used within
++# offset of in the current version of ubp.
++# See https://github.com/protocolbuffers/upb/blob/9effcbcb27f0a665f9f345030188c0b291e32482/upb/upb.c#L183.
++build:rbe_linux_cpu --copt=-Wno-gnu-offsetof-extensions
++# Python config is the same across all containers because the binary is the same
++build:rbe_linux_cpu --python_path="/usr/bin/python3"
++# These you may need to change for your own GCP project.
++common:rbe_linux_cpu --remote_instance_name=projects/tensorflow-testing/instances/default_instance
++
++# TODO(kanglan): Remove it after toolchain update is complete.
++build:rbe_linux_cpu_old --config=rbe_linux
++build:rbe_linux_cpu_old --host_crosstool_top="@ubuntu20.04-gcc9_manylinux2014-cuda11.2-cudnn8.1-tensorrt7.2_config_cuda//crosstool:toolchain"
++build:rbe_linux_cpu_old --crosstool_top="@ubuntu20.04-gcc9_manylinux2014-cuda11.2-cudnn8.1-tensorrt7.2_config_cuda//crosstool:toolchain"
++build:rbe_linux_cpu_old --extra_toolchains="@ubuntu20.04-gcc9_manylinux2014-cuda11.2-cudnn8.1-tensorrt7.2_config_cuda//crosstool:toolchain-linux-x86_64"
++build:rbe_linux_cpu_old --extra_execution_platforms="@ubuntu20.04-gcc9_manylinux2014-cuda11.2-cudnn8.1-tensorrt7.2_config_platform//:platform"
++build:rbe_linux_cpu_old --host_platform="@ubuntu20.04-gcc9_manylinux2014-cuda11.2-cudnn8.1-tensorrt7.2_config_platform//:platform"
++build:rbe_linux_cpu_old --platforms="@ubuntu20.04-gcc9_manylinux2014-cuda11.2-cudnn8.1-tensorrt7.2_config_platform//:platform"
++build:rbe_linux_cpu_old --python_path="/usr/local/bin/python3.9"
++common:rbe_linux_cpu_old --remote_instance_name=projects/tensorflow-testing/instances/default_instance
++
++build:rbe_linux_cuda --config=cuda_clang_official
++build:rbe_linux_cuda --config=rbe_linux_cpu
++# For Remote build execution -- GPU configuration
++build:rbe_linux_cuda --repo_env=REMOTE_GPU_TESTING=1
++
++build:rbe_linux_cuda_nvcc --config=rbe_linux_cuda
++build:rbe_linux_cuda_nvcc --config=cuda_nvcc
++build:rbe_linux_cuda_nvcc --repo_env TF_NCCL_USE_STUB=1
++
++build:rbe_win_base --config=rbe_base
++build:rbe_win_base --shell_executable=C:\\tools\\msys64\\usr\\bin\\bash.exe
++build:rbe_win_base --remote_instance_name=projects/tensorflow-testing/instances/windows
++# Don't build the python zip archive in the RBE build.
++build:rbe_win_base --remote_download_minimal
++build:rbe_win_base --enable_runfiles
++build:rbe_win_base --nobuild_python_zip
++build:rbe_win_base --define=override_eigen_strong_inline=true
++
++build:rbe_win_clang --config=rbe_win_base
++build:rbe_win_clang --crosstool_top="//tensorflow/tools/toolchains/win/20240424:toolchain"
++build:rbe_win_clang --extra_toolchains="//tensorflow/tools/toolchains/win/20240424:cc-toolchain-x64_windows-clang-cl"
++build:rbe_win_clang --extra_execution_platforms="//tensorflow/tools/toolchains/win:x64_windows-clang-cl"
++build:rbe_win_clang --host_platform="//tensorflow/tools/toolchains/win:x64_windows-clang-cl"
++build:rbe_win_clang --platforms="//tensorflow/tools/toolchains/win:x64_windows-clang-cl"
++build:rbe_win_clang --compiler=clang-cl
++build:rbe_win_clang --linkopt=/FORCE:MULTIPLE
++build:rbe_win_clang --host_linkopt=/FORCE:MULTIPLE
++
++# TODO(belitskiy): Rename `rbe_win_clang` to this, once done switching presubmits.
++build:rbe_windows_x86_cpu --config=rbe_win_clang
++build:rbe_windows_x86_cpu_2022 --config=rbe_win_base --config=windows_x86_cpu_2022
++
++# END TF REMOTE BUILD EXECUTION OPTIONS
++
++# TFLite build configs for generic embedded Linux
++build:elinux --crosstool_top=@local_config_embedded_arm//:toolchain
++build:elinux --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
++build:elinux_aarch64 --config=elinux
++build:elinux_aarch64 --cpu=aarch64
++build:elinux_armhf --config=elinux
++build:elinux_armhf --cpu=armhf
++build:elinux_armhf --copt -mfp16-format=ieee
++
++# Config-specific options should come above this line.
++
++# Load rc file written by ./configure.
++try-import %workspace%/.tf_configure.bazelrc
++
++# Load rc file with user-specific options.
++try-import %workspace%/.bazelrc.user
++
++# Here are bazelrc configs for release builds
++# Build TensorFlow v2.
++test:release_base --test_size_filters=small,medium
++
++# Enable support for all targets
++build:release_base --config=cpu_cross
++
++# Ensure release_base is set on linux
++build:release_linux_base --config=release_base
++
++# Disable clang extension that rejects type definitions within offsetof.
++# This was added in clang-16 by https://reviews.llvm.org/D133574.
++# Can be removed once upb is updated, since a type definition is used within
++# offset of in the current version of ubp.
++# See https://github.com/protocolbuffers/upb/blob/9effcbcb27f0a665f9f345030188c0b291e32482/upb/upb.c#L183.
++build:release_linux_base --copt=-Wno-gnu-offsetof-extensions
++build:release_linux_base --copt=-Wno-error=array-parameter
++build:release_linux_base --copt=-Wno-error=unused-command-line-argument
++# Set lld as the linker.
++build:release_linux_base --linkopt="-fuse-ld=lld"
++build:release_linux_base --linkopt="-lm"
++
++# We have some invalid linker scripts in the build,
++# so we need to disable this check
++build:release_linux_base --linkopt=-Wl,--undefined-version
++
++# Container environment settings below this point.
++# Use Python 3.X as installed in container image
++build:release_linux_base --action_env PYTHON_BIN_PATH="/usr/bin/python3"
++build:release_linux_base --action_env PYTHON_LIB_PATH="/usr/lib/tf_python"
++build:release_linux_base --python_path="/usr/bin/python3"
++# Set Clang as compiler. Use the actual path to clang installed in container.
++build:release_linux_base --repo_env=CC="/usr/lib/llvm-18/bin/clang"
++build:release_linux_base --repo_env=BAZEL_COMPILER="/usr/lib/llvm-18/bin/clang"
++# Test-related settings below this point.
++test:release_linux_base --build_tests_only --keep_going --test_output=errors --verbose_failures=true
++test:release_linux_base --local_test_jobs=HOST_CPUS
++# Give only the list of failed tests at the end of the log
++test:release_linux_base --test_summary=short
++
++# Use the Clang toolchain to compile
++build:release_cpu_linux --config=release_linux_base
++build:release_cpu_linux --crosstool_top="@local_config_cuda//crosstool:toolchain"
++build:release_cpu_linux --repo_env=TF_SYSROOT="/dt9"
++# Target the AVX instruction set
++build:release_cpu_linux --config=avx_linux
++
++build:release_gpu_linux --config=release_cpu_linux
++# Set up compilation CUDA version and paths and use the CUDA Clang toolchain.
++# Note that linux cpu and cuda builds share the same toolchain now.
++build:release_gpu_linux --config=cuda_clang_official
++# Local test jobs has to be 4 because parallel_gpu_execute is fragile, I think
++test:release_gpu_linux --test_timeout=300,450,1200,3600 --local_test_jobs=4 --run_under=//tensorflow/tools/ci_build/gpu_build:parallel_gpu_execute
++
++build:release_arm64_linux --config=release_linux_base
++build:release_arm64_linux --config=linux_arm64
++build:release_arm64_linux --crosstool_top="@ml2014_clang_aarch64_config_aarch64//crosstool:toolchain"
++build:release_arm64_linux --config=mkl_aarch64_threadpool
++build:release_arm64_linux --copt=-flax-vector-conversions
++test:release_arm64_linux --flaky_test_attempts=3
++
++build:release_cpu_macos --config=avx_linux
++
++# Base build configs for macOS
++build:release_macos_base --action_env  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
++build:release_macos_base --define=no_nccl_support=true --output_filter=^$
++
++# Ensure release_base is set on mac
++build:release_macos_base --config=release_base
++
++# Build configs for macOS x86
++build:release_macos_x86 --config=release_macos_base
++# Build with the AVX instruction set when on macOS x86
++build:release_macos_x86 --config=avx_linux
++build:release_macos_x86 --cpu=darwin
++# Target Catalina as the minimum compatible OS version
++build:release_macos_x86 --macos_minimum_os=10.15
++build:release_macos_x86 --action_env MACOSX_DEPLOYMENT_TARGET=10.15
++
++# Build configs for macOS Arm64
++build:release_macos_arm64 --config=release_macos_base
++build:release_macos_arm64 --cpu=darwin_arm64
++build:release_macos_arm64 --define=tensorflow_mkldnn_contraction_kernel=0
++# Target Moneterey as the minimum compatible OS version
++build:release_macos_arm64 --macos_minimum_os=12.0
++build:release_macos_arm64 --action_env MACOSX_DEPLOYMENT_TARGET=12.0
++
++# Base test configs for macOS
++test:release_macos_base --verbose_failures=true --local_test_jobs=HOST_CPUS
++test:release_macos_base --test_timeout=300,450,1200,3600 --test_output=errors
++test:release_macos_base --build_tests_only --keep_going
++test:release_macos_base --flaky_test_attempts=3
++
++# Test configs for macOS x86
++test:release_macos_x86 --config=release_macos_base
++
++# Test configs for macOS Arm64
++test:release_macos_arm64 --config=release_macos_base
++
++# Ensure release_base is set on windows
++build:release_cpu_windows --config=release_base
++
++# TODO(kanglan): Update windows configs after b/289091160 is fixed
++build:release_cpu_windows --config=avx_win
++build:release_cpu_windows --define=no_tensorflow_py_deps=true
++
++# Exclude TFRT integration for anything but Linux.
++build:android --config=no_tfrt
++build:macos   --config=no_tfrt
++build:windows --config=no_tfrt
++build:rocm --config=no_tfrt
++build:no_tfrt --deleted_packages=tensorflow/compiler/mlir/tfrt,tensorflow/compiler/mlir/tfrt/benchmarks,tensorflow/compiler/mlir/tfrt/ir,tensorflow/compiler/mlir/tfrt/ir/mlrt,tensorflow/compiler/mlir/tfrt/jit/python_binding,tensorflow/compiler/mlir/tfrt/jit/transforms,tensorflow/compiler/mlir/tfrt/python_tests,tensorflow/compiler/mlir/tfrt/tests,tensorflow/compiler/mlir/tfrt/tests/ifrt,tensorflow/compiler/mlir/tfrt/tests/mlrt,tensorflow/compiler/mlir/tfrt/tests/ir,tensorflow/compiler/mlir/tfrt/tests/analysis,tensorflow/compiler/mlir/tfrt/tests/jit,tensorflow/compiler/mlir/tfrt/tests/lhlo_to_tfrt,tensorflow/compiler/mlir/tfrt/tests/lhlo_to_jitrt,tensorflow/compiler/mlir/tfrt/tests/tf_to_corert,tensorflow/compiler/mlir/tfrt/tests/tf_to_tfrt_data,tensorflow/compiler/mlir/tfrt/tests/saved_model,tensorflow/compiler/mlir/tfrt/transforms/lhlo_gpu_to_tfrt_gpu,tensorflow/compiler/mlir/tfrt/transforms/mlrt,tensorflow/core/runtime_fallback,tensorflow/core/runtime_fallback/conversion,tensorflow/core/runtime_fallback/kernel,tensorflow/core/runtime_fallback/opdefs,tensorflow/core/runtime_fallback/runtime,tensorflow/core/runtime_fallback/util,tensorflow/core/runtime_fallback/test,tensorflow/core/runtime_fallback/test/gpu,tensorflow/core/runtime_fallback/test/saved_model,tensorflow/core/runtime_fallback/test/testdata,tensorflow/core/tfrt/stubs,tensorflow/core/tfrt/tfrt_session,tensorflow/core/tfrt/mlrt,tensorflow/core/tfrt/mlrt/attribute,tensorflow/core/tfrt/mlrt/kernel,tensorflow/core/tfrt/mlrt/bytecode,tensorflow/core/tfrt/mlrt/interpreter,tensorflow/compiler/mlir/tfrt/translate/mlrt,tensorflow/compiler/mlir/tfrt/translate/mlrt/testdata,tensorflow/core/tfrt/gpu,tensorflow/core/tfrt/run_handler_thread_pool,tensorflow/core/tfrt/runtime,tensorflow/core/tfrt/saved_model,tensorflow/core/tfrt/graph_executor,tensorflow/core/tfrt/saved_model/tests,tensorflow/core/tfrt/tpu,tensorflow/core/tfrt/utils,tensorflow/core/tfrt/utils/debug,tensorflow/core/tfrt/saved_model/python,tensorflow/core/tfrt/graph_executor/python,tensorflow/core/tfrt/saved_model/utils
++
++# BEGIN TF CACHE HELPER OPTIONS
++# Options when using remote execution
++# WARNING: THESE OPTIONS WONT WORK IF YOU DO NOT HAVE PROPER AUTHENTICATION AND PERMISSIONS
++
++# Use --config=tf_public_cache to try and use the TensorFlow public build cache
++# to build TensorFlow. Look at ci/official/envs to find which types of jobs
++# push to the cache.  For macOS, use --config=tf_public_macos_cache
++build:tf_public_cache --remote_cache="https://storage.googleapis.com/tensorflow-devinfra-bazel-cache/january2024" --remote_upload_local_results=false
++# Cache pushes are limited to TF's CI system.
++build:tf_public_cache_push --config=tf_public_cache --remote_upload_local_results=true --google_default_credentials
++# Public cache for macOS builds
++build:tf_public_macos_cache --remote_cache="https://storage.googleapis.com/tensorflow-macos-bazel-cache/oct2023" --remote_upload_local_results=false
++# Cache pushes are limited to TF's CI system.
++build:tf_public_macos_cache_push --config=tf_public_macos_cache --remote_upload_local_results=true --google_default_credentials
++
++# END TF CACHE HELPER OPTIONS
++# BEGIN TF TEST SUITE OPTIONS
++# These are convenience config options that effectively declare TF's CI test suites. Look
++# at the scripts of ci/official/ to see how TF's CI uses them.
++
++# LIBTENSORFLOW TESTS are for building Libtensorflow archives. These are CUDA/CPU-agnostic.
++test:linux_libtensorflow_test --config=cuda_wheel -- //tensorflow/tools/lib_package:libtensorflow_test //tensorflow/tools/lib_package:libtensorflow_java_test
++build:linux_libtensorflow_build --config=cuda_wheel -- //tensorflow/tools/lib_package:libtensorflow.tar.gz //tensorflow/tools/lib_package:libtensorflow_jni.tar.gz //tensorflow/java:libtensorflow.jar //tensorflow/java:libtensorflow-src.jar //tensorflow/tools/lib_package:libtensorflow_proto.zip
++build:windows_libtensorflow_build --config=cuda_wheel --config=windows_x86_cpu_2022 -- //:LICENSE //tensorflow:tensorflow.dll //tensorflow:tensorflow_dll_import_lib //tensorflow/tools/lib_package:clicenses_generate //tensorflow/java:tensorflow_jni.dll //tensorflow/tools/lib_package:jnilicenses_generate
++
++# PYTHON TESTS run a suite of Python tests intended for verifying that the Python wheel
++# will work properly. These are usually run Nightly or upon Release.
++# CPU WHEEL
++test:linux_cpu_wheel_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_cpu_wheel_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_cpu_wheel_test_filters --test_lang_filters=py --test_size_filters=small,medium
++test:linux_cpu_wheel_test --@local_tsl//third_party/py:wheel_dependency=true --config=linux_cpu_wheel_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:prebuilt_wheel_import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
++# CUDA WHEEL
++test:linux_cuda_wheel_test_filters --test_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-no_cuda11,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_cuda_wheel_test_filters --build_tag_filters=gpu,requires-gpu,-no_gpu,-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-no_cuda11,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_cuda_wheel_test_filters --test_lang_filters=py --test_size_filters=small,medium
++test:linux_cuda_wheel_test --@local_tsl//third_party/py:wheel_dependency=true --config=linux_cuda_wheel_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:prebuilt_wheel_import_api_packages_test_gpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
++# ARM64 WHEEL
++test:linux_arm64_wheel_test_filters --test_tag_filters=-no_oss,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_arm64_wheel_test_filters --build_tag_filters=-no_oss,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only,-no_oss_py38,-no_oss_py39,-no_oss_py310
++test:linux_arm64_wheel_test_filters --test_lang_filters=py --test_size_filters=small,medium
++test:linux_arm64_wheel_test --@local_tsl//third_party/py:wheel_dependency=true --config=linux_arm64_wheel_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:prebuilt_wheel_import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...  -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/core/grappler/optimizers:auto_mixed_precision_test_cpu -//tensorflow/core/grappler/optimizers:remapper_test_cpu -//tensorflow/core/kernels/image:resize_bicubic_op_test
++# MACOS ARM64 WHEEL
++test:macos_arm64_wheel_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
++test:macos_arm64_wheel_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
++test:macos_arm64_wheel_test_filters --test_lang_filters=py --test_size_filters=small,medium
++test:macos_arm64_wheel_test --@local_tsl//third_party/py:wheel_dependency=true --config=macos_arm64_wheel_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:prebuilt_wheel_import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/compiler/aot/...
++# MACOS X86 WHEEL
++test:macos_x86_wheel_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
++test:macos_x86_wheel_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
++test:macos_x86_wheel_test_filters --test_lang_filters=py --test_size_filters=small,medium
++test:macos_x86_wheel_test --@local_tsl//third_party/py:wheel_dependency=true --config=macos_x86_wheel_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:prebuilt_wheel_import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/compiler/aot/...
++# WINDOWS X86 WHEEL
++test:windows_x86_cpu_wheel_test_filters --test_tag_filters=-no_windows,-windows_excluded,-no_oss,-oss_excluded,-gpu,-tpu,-benchmark-test
++test:windows_x86_cpu_wheel_test_filters --build_tag_filters=-no_windows,-windows_excluded,-no_oss,-oss_excluded,-benchmark-test
++test:windows_x86_cpu_wheel_test_filters --test_lang_filters=cc,py --test_size_filters=small,medium --test_timeout="300,450,1200,3600"
++test:windows_x86_cpu_wheel_test --build_tests_only --config=windows_x86_cpu_pycpp_test_filters -- //tensorflow/... -//tensorflow/java/... -//tensorflow/lite/... -//tensorflow/compiler/...
++# TODO(belitskiy): Get rid of once 2019 is shut down
++test:windows_x86_cpu_2022_wheel_test --config=windows_x86_cpu_wheel_test
++
++# PYCPP TESTS run a suite of Python and C++ tests to verify general correctness over
++# the whole TF code base. These are usually run continuously or upon presubmit.
++# LINUX CPU PYCPP:
++test:linux_cpu_pycpp_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
++test:linux_cpu_pycpp_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
++test:linux_cpu_pycpp_test_filters --test_lang_filters=cc,py --test_size_filters=small,medium
++test:linux_cpu_pycpp_test --config=linux_cpu_pycpp_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
++
++# LINUX CUDA PYCPP:
++test:linux_cuda_pycpp_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11
++test:linux_cuda_pycpp_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-benchmark-test,-v1only,gpu,-no_gpu,-no_gpu_presubmit,-no_cuda11
++test:linux_cuda_pycpp_test_filters --test_lang_filters=cc,py --test_size_filters=small,medium
++test:linux_cuda_pycpp_test --config=linux_cuda_pycpp_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:import_api_packages_test_gpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/...
++
++# LINUX ARM64 PYCPP
++# In Linux Arm64 presubmit/continuous build, we cross-compile the binaries on
++# Linux x86 so that we can use RBE. Since tests still need to run on the single
++# host Arm64 machine, the build becomes too slow (~30 min) to be a presubmit.
++# For testing purposes, we want to see the runtime performance of an
++# experimental job that is build-only, i.e, we only build the test targets and
++# do not run them. By prefixing the configs with "build", we can run both
++# `bazel build` and `bazel test` commands with the same config as test configs
++# inherit from build.
++build:linux_arm64_pycpp_test_filters --test_tag_filters=-no_oss,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
++build:linux_arm64_pycpp_test_filters --build_tag_filters=-no_oss,-no_aarch64,-oss_excluded,-oss_serial,-gpu,-tpu,-benchmark-test,-v1only
++build:linux_arm64_pycpp_test_filters --test_lang_filters=cc,py --test_size_filters=small,medium --flaky_test_attempts=3
++# TODO(michaelhudgins): Why do we need to specifically omit go and java here?
++build:linux_arm64_pycpp_test --config=linux_arm64_pycpp_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/core/grappler/optimizers:auto_mixed_precision_test_cpu -//tensorflow/core/grappler/optimizers:remapper_test_cpu -//tensorflow/core/kernels/image:resize_bicubic_op_test -//tensorflow/python/tools:aot_compiled_test
++# CROSS-COMPILE ARM64 PYCPP
++build:cross_compile_linux_arm64_pycpp_test --config=linux_arm64_pycpp_test
++# Tests that fail only when cross-compiled
++build:cross_compile_linux_arm64_pycpp_test -//tensorflow/compiler/mlir/quantization/stablehlo:convert_tf_quant_to_mhlo_int_test
++# MACOS ARM64 PYCPP
++test:macos_arm64_pycpp_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
++test:macos_arm64_pycpp_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test,-no_mac_arm64,-no_aarch64
++test:macos_arm64_pycpp_test_filters --test_lang_filters=cc,py --test_size_filters=small,medium
++test:macos_arm64_pycpp_test --config=macos_arm64_pycpp_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/lite/... -//tensorflow/tools/toolchains/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/compiler/aot/... -//tensorflow/core/kernels/image:resize_bicubic_op_test
++# MACOS X86 PYCPP
++# These are defined as build configs so that we can run a build only job. See
++# the note under "ARM64 PYCPP" for more details.
++build:macos_x86_pycpp_test_filters --test_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
++build:macos_x86_pycpp_test_filters --build_tag_filters=-no_oss,-oss_excluded,-oss_serial,-no_oss_py38,-no_oss_py39,-no_oss_py310,-nomac,-no_mac,-mac_excluded,-v1only,-gpu,-tpu,-benchmark-test
++build:macos_x86_pycpp_test_filters --keep_going --test_lang_filters=cc,py --test_size_filters=small,medium
++build:macos_x86_pycpp_test --config=macos_x86_pycpp_test_filters -- //tensorflow/... //tensorflow/tools/pip_package:import_api_packages_test_cpu -//tensorflow/compiler/tf2tensorrt/... -//tensorflow/core/tpu/... -//tensorflow/go/... -//tensorflow/java/... -//tensorflow/tools/toolchains/... -//tensorflow/lite/... -//tensorflow/compiler/aot/...
++# CROSS-COMPILE MACOS X86 PYCPP
++build:cross_compile_macos_x86_pycpp_test --config=macos_x86_pycpp_test
++build:cross_compile_macos_x86_pycpp_test -//tensorflow/core/kernels:quantized_conv_ops_test -//tensorflow/core/kernels:quantized_matmul_op_test -//tensorflow/python/ops:quantized_conv_ops_test -//tensorflow/tools/graph_transforms:transforms_test -//tensorflow/python/tools:aot_compiled_test
++# WINDOWS X86-64 CPU PYCPP
++build:windows_x86_cpu_pycpp_test_build_opts --copt=/d2ReducedOptimizeHugeFunctions --host_copt=/d2ReducedOptimizeHugeFunctions --dynamic_mode=off
++build:windows_x86_cpu_pycpp_test_build_opts_debug --config=windows_x86_cpu_pycpp_test_build_opts --linkopt=/demangle:no --host_linkopt=/demangle:no --linkopt=/errorlimit:0 --host_linkopt=/errorlimit:0
++test:windows_x86_cpu_pycpp_test_filters --test_tag_filters=-no_windows,-windows_excluded,-no_oss,-oss_excluded,-gpu,-tpu,-benchmark-test
++test:windows_x86_cpu_pycpp_test_filters --build_tag_filters=-no_windows,-windows_excluded,-no_oss,-oss_excluded,-benchmark-test
++test:windows_x86_cpu_pycpp_test_filters --test_lang_filters=cc,py --test_size_filters=small,medium --test_timeout="300,450,1200,3600"
++test:windows_x86_cpu_pycpp_test_opts --config=windows_x86_cpu_pycpp_test_build_opts --build_tests_only
++test:windows_x86_cpu_pycpp_test --config=windows_x86_cpu_pycpp_test_opts --config=windows_x86_cpu_pycpp_test_filters -- //tensorflow/... -//tensorflow/java/... -//tensorflow/lite/... -//tensorflow/compiler/...
++test:windows_x86_cpu_2022_pycpp_test --config=windows_x86_cpu_pycpp_test
++
++# END TF TEST SUITE OPTIONS
++
++# START CROSS-COMPILE CONFIGS
++# Set execution platform to Linux x86
++# Note: Lot of the "host_" flags such as "host_cpu" and "host_crosstool_top"
++# flags seem to be actually used to specify the execution platform details. It
++# seems it is this way because these flags are old and predate the distinction
++# between host and execution platform.
++build:cross_compile_base --host_cpu=k8
++build:cross_compile_base --host_crosstool_top=//tensorflow/tools/toolchains/cross_compile/cc:cross_compile_toolchain_suite
++build:cross_compile_base --extra_execution_platforms=//tensorflow/tools/toolchains/cross_compile/config:linux_x86_64
++
++build:rbe_cross_compile_base --config=rbe_base
++build:rbe_cross_compile_base --remote_instance_name=projects/tensorflow-testing/instances/default_instance
++
++# Test-related settings below this point
++# We cannot run cross-compiled tests on the remote Linux x86 VMs so we need to
++# force all tests to run locally on the Aarch64 host.
++test:rbe_cross_compile_base --strategy=TestRunner=local --build_tests_only
++test:rbe_cross_compile_base --verbose_failures=true --local_test_jobs=HOST_CPUS --test_output=errors
++
++# START LINUX AARCH64 CROSS-COMPILE CONFIGS
++build:cross_compile_linux_arm64 --config=cross_compile_base
++
++# Set the target CPU to Aarch64
++build:cross_compile_linux_arm64 --platforms=//tensorflow/tools/toolchains/cross_compile/config:linux_aarch64
++build:cross_compile_linux_arm64 --cpu=aarch64
++build:cross_compile_linux_arm64 --crosstool_top=//tensorflow/tools/toolchains/cross_compile/cc:cross_compile_toolchain_suite
++
++# RBE cross-compile configs for Linux Aarch64
++build:rbe_cross_compile_linux_arm64 --config=cross_compile_linux_arm64
++build:rbe_cross_compile_linux_arm64 --config=rbe_cross_compile_base
++test:rbe_cross_compile_linux_arm64 --config=rbe_cross_compile_base
++
++# END LINUX AARCH64 CROSS-COMPILE CONFIGS
++
++# START MACOS CROSS-COMPILE CONFIGS
++build:cross_compile_macos_x86 --config=cross_compile_base
++build:cross_compile_macos_x86 --config=nonccl
++# Target Catalina (10.15) as the minimum supported OS
++build:cross_compile_macos_x86 --action_env  MACOSX_DEPLOYMENT_TARGET=10.15
++
++# Set the target CPU to Darwin x86
++build:cross_compile_macos_x86 --platforms=//tensorflow/tools/toolchains/cross_compile/config:darwin_x86_64
++build:cross_compile_macos_x86 --cpu=darwin
++build:cross_compile_macos_x86 --crosstool_top=//tensorflow/tools/toolchains/cross_compile/cc:cross_compile_toolchain_suite
++# When RBE cross-compiling for macOS, we need to explicitly register the
++# toolchain. Otherwise, oddly, RBE complains that a "docker container must be
++# specified".
++build:cross_compile_macos_x86 --extra_toolchains=//tensorflow/tools/toolchains/cross_compile/config:macos-x86-cross-compile-cc-toolchain
++# Map --platforms=darwin_x86_64 to --cpu=darwin and vice-versa to make selects()
++# and transistions that use these flags work.
++build:cross_compile_macos_x86 --platform_mappings=tensorflow/tools/toolchains/cross_compile/config/platform_mappings
++
++# RBE cross-compile configs for Darwin x86
++build:rbe_cross_compile_macos_x86 --config=cross_compile_macos_x86 --remote_download_minimal
++build:rbe_cross_compile_macos_x86 --bes_backend="" --bes_results_url="" --bes_timeout="0s"
++build:rbe_cross_compile_macos_x86 --experimental_remote_build_event_upload="minimal"
++build:rbe_cross_compile_macos_x86 --config=rbe_cross_compile_base
++build:rbe_cross_compile_macos_x86 --bes_upload_mode=nowait_for_upload_complete
++test:rbe_cross_compile_macos_x86 --config=rbe_cross_compile_base
++# Increase the test timeout as tests often take longer on mac.
++test:rbe_cross_compile_macos_x86 --test_timeout=300,450,1200,3600
++# Limit jobs to 100 to avoid running into "out of memory" issues (b/316266643)
++build:rbe_cross_compile_macos_x86 --jobs=100
++test:rbe_cross_compile_macos_x86 --jobs=100
++# END MACOS CROSS-COMPILE CONFIGS
++# END CROSS-COMPILE CONFIGS
+-- 
+2.43.0
+


### PR DESCRIPTION
This patch can go stale when the Tensorflow upstream moves. 