### PR TITLE
fix(WeakTrackableReference): correct weak reference type handling

### DIFF
--- a/tensorflow/python/trackable/base.py
+++ b/tensorflow/python/trackable/base.py
@@ -79,7 +79,7 @@ class WeakTrackableReference(TrackableReference):
   __slots__ = ()
 
   def __init__(self, name, ref):
-    if not isinstance(self, weakref.ref):
+    if not isinstance(ref, weakref.ref):
       ref = weakref.ref(ref)
     super(WeakTrackableReference, self).__init__(name=name, ref=ref)
 


### PR DESCRIPTION
This judgment indeed seems unreasonable because:

self is an instance of WeakTrackableReference
WeakTrackableReference inherits from TrackableReference 
In any case, self cannot be an instance of weakref.ref


A more meaningful judgment should be structured as follows:

Check whether the input ref parameter is already a weak reference 
If it's not a weak reference, convert it to a weak reference 
If it's already a weak reference, use it directly