### PR TITLE
feat: add datatype support for tfl.transpose

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/transpose.h
+++ b/tensorflow/lite/kernels/internal/reference/transpose.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <array>
 
+#include "Eigen/Core"
 #include "tensorflow/lite/kernels/internal/types.h"
 
 namespace tflite {

--- a/tensorflow/lite/kernels/transpose.cc
+++ b/tensorflow/lite/kernels/transpose.cc
@@ -115,7 +115,15 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   // each cell. It's safe to implement per size of scalar type and this trick
   // keeps the total code size in a reasonable range.
   switch (op_context.input->type) {
+    case kTfLiteBFloat16:
+      TF_LITE_TRANSPOSE(reference_ops, Eigen::bfloat16);
+      break;
+    case kTfLiteFloat16:
+      TF_LITE_TRANSPOSE(reference_ops, Eigen::half);
+      break;
     case kTfLiteFloat32:
+      TF_LITE_TRANSPOSE(reference_ops, float);
+      break;
     case kTfLiteInt32:
       TF_LITE_TRANSPOSE(reference_ops, int32_t);
       break;


### PR DESCRIPTION
Tflite transpose missing datatype
- Adds bf16, f16 support tfl.transpose function
- Adds bf16, f16 unit tests