### PR TITLE
Fixed ppc64le build issues

### DIFF
--- a/tensorflow/BUILD
+++ b/tensorflow/BUILD
@@ -1304,7 +1304,7 @@ tf_cc_shared_library(
         ],
         "//tensorflow:windows": [],
         "//conditions:default": [
-            "-z defs",
+            "-Wl,-z,defs",
             "-Wl,--version-script,$(location //tensorflow:tf_version_script.lds)",
         ],
     }),

--- a/third_party/xla/xla/tsl/BUILD
+++ b/third_party/xla/xla/tsl/BUILD
@@ -297,7 +297,7 @@ config_setting(
     name = "linux_ppc64le",
     constraint_values =
         [
-            "@platforms//cpu:ppc64le",
+            "@platforms//cpu:ppc",
             "@platforms//os:linux",
         ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This changes fixes following issues for ppc64le:

1- Build issues related to onednn on ppc64le platform.
2- Fixes linker issue- clang-17: error: unknown argument: '-z defs'