### PR TITLE
Use utility functions to check number of inputs and outputs.

### DIFF
--- a/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc
+++ b/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc
@@ -6738,14 +6738,15 @@ TfLiteIntArray* Delegate::PrepareOpsToDelegate(TfLiteContext* context) {
       return nullptr;  // Hard error.
     }
 
-    if (CheckNumInputs(context, node, /*expected_num_inputs=*/1,
-                       static_cast<BuiltinOperator>(registration->builtin_code),
-                       producer_index) != kTfLiteOk) {
+    if (Subgraph::CheckNumInputs(
+            context, node, /*expected_num_inputs=*/1,
+            static_cast<BuiltinOperator>(registration->builtin_code),
+            producer_index) != kTfLiteOk) {
       TfLiteIntArrayFree(nodes_to_delegate);
       return nullptr;  // Hard error.
     }
 
-    if (CheckNumOutputs(
+    if (Subgraph::CheckNumOutputs(
             context, node, /*expected_num_outputs=*/1,
             static_cast<BuiltinOperator>(registration->builtin_code),
             producer_index) != kTfLiteOk) {


### PR DESCRIPTION
Use existing utility functions to check number of inputs and outputs to avoid duplication of codes.