### PR TITLE
Fix: Prevent Heap-Buffer-Overflow in stringprintf_fuzz Fuzzer

### DIFF
--- a/tensorflow/security/fuzzing/cc/stringprintf_fuzz.cc
+++ b/tensorflow/security/fuzzing/cc/stringprintf_fuzz.cc
@@ -24,6 +24,11 @@ limitations under the License.
 namespace {
 
 void FuzzTest(const std::vector<std::string> ss) {
+    
+    // Validate the size of the input vector
+    if (ss.size() < 3) {
+        return;
+    }
   const std::string all = ss[0] + ss[1] + ss[2];
 
   int n[4] = {-1, -1, -1, -1};


### PR DESCRIPTION
in this fix updated stringprintf_fuzz.cc to include input validation.
Prevented undefined behavior by returning early for invalid inputs.

issue link: https://issues.oss-fuzz.com/issues/389974981