### PR TITLE
Eigen SVE build fix.

### DIFF
--- a/tensorflow/core/kernels/sparse_matmul_op.h
+++ b/tensorflow/core/kernels/sparse_matmul_op.h
@@ -65,7 +65,8 @@ EIGEN_DEVICE_FUNC inline PacketXf pexpand_bf16_l(const PacketXf& from) {
 
   // Unpack lower 16-bit halves to 32-bit ints, shift into float32 format
   svuint32_t unpacked_lo = svunpklo_u32(from_u16);
-  svuint32_t widened = svlsl_n_u32_x(pg, unpacked_lo, 16);  // shift left to match float layout
+  svuint32_t widened =
+      svlsl_n_u32_x(pg, unpacked_lo, 16);  // shift left to match float layout
 
   return svreinterpret_f32_u32(widened);
 }
@@ -80,7 +81,8 @@ EIGEN_DEVICE_FUNC inline PacketXf pexpand_bf16_u(const PacketXf& from) {
 
   // Unpack upper 16-bit halves to 32-bit ints, shift into float32 format
   svuint32_t unpacked_hi = svunpkhi_u32(from_u16);
-  svuint32_t widened = svlsl_n_u32_x(pg, unpacked_hi, 16);  // shift left to match float layout
+  svuint32_t widened =
+      svlsl_n_u32_x(pg, unpacked_hi, 16);  // shift left to match float layout
 
   return svreinterpret_f32_u32(widened);
 }

--- a/tensorflow/core/kernels/sparse_matmul_op.h
+++ b/tensorflow/core/kernels/sparse_matmul_op.h
@@ -54,6 +54,38 @@ EIGEN_DEVICE_FUNC inline Packet pexpand_bf16_u(const Packet& from) {
 }
 
 // Specialization non-scalar version on non-sse.
+// SVE vector implementation for PacketXf
+#if defined(__ARM_FEATURE_SVE) && defined(EIGEN_ARM64_USE_SVE)
+template <typename Packet>
+EIGEN_DEVICE_FUNC inline PacketXf pexpand_bf16_l(const PacketXf& from) {
+  svbool_t pg = svptrue_b32();
+
+  // Reinterpret float32 as uint16 (so we can unpack half words)
+  svuint16_t from_u16 = svreinterpret_u16_f32(from);
+
+  // Unpack lower 16-bit halves to 32-bit ints, shift into float32 format
+  svuint32_t unpacked_lo = svunpklo_u32(from_u16);
+  svuint32_t widened = svlsl_n_u32_x(pg, unpacked_lo, 16);  // shift left to match float layout
+
+  return svreinterpret_f32_u32(widened);
+}
+
+// Expand the upper BF16s (i.e., second 16-bit half of each 32-bit float)
+template <typename Packet>
+EIGEN_DEVICE_FUNC inline PacketXf pexpand_bf16_u(const PacketXf& from) {
+  svbool_t pg = svptrue_b32();
+
+  // Reinterpret float32 as uint16 (so we can unpack half words)
+  svuint16_t from_u16 = svreinterpret_u16_f32(from);
+
+  // Unpack upper 16-bit halves to 32-bit ints, shift into float32 format
+  svuint32_t unpacked_hi = svunpkhi_u32(from_u16);
+  svuint32_t widened = svlsl_n_u32_x(pg, unpacked_hi, 16);  // shift left to match float layout
+
+  return svreinterpret_f32_u32(widened);
+}
+#endif
+
 // Enable vectorization on z13 and higher
 #if defined(EIGEN_VECTORIZE_ALTIVEC) || defined(EIGEN_VECTORIZE_VSX) || \
     defined(EIGEN_VECTORIZE_NEON) || defined(EIGEN_VECTORIZE_ZVECTOR)

--- a/tensorflow/lite/kernels/cast.cc
+++ b/tensorflow/lite/kernels/cast.cc
@@ -27,6 +27,10 @@ limitations under the License.
 #include "tensorflow/lite/kernels/kernel_util.h"
 #include "tensorflow/lite/kernels/op_macros.h"
 
+#ifdef __ARM_NEON
+  #include <arm_neon.h>
+#endif
+
 namespace tflite {
 namespace ops {
 namespace builtin {

--- a/tensorflow/lite/kernels/cast.cc
+++ b/tensorflow/lite/kernels/cast.cc
@@ -28,7 +28,7 @@ limitations under the License.
 #include "tensorflow/lite/kernels/op_macros.h"
 
 #ifdef __ARM_NEON
-  #include <arm_neon.h>
+#include <arm_neon.h>
 #endif
 
 namespace tflite {


### PR DESCRIPTION
Issue discovered when building tensorflow with SVE optimised eigen, fix involves adding neon header and a new casting op that implements BF16 to float using SVE.

Build command used:
```bash
bazel build //tensorflow/tools/pip_package:wheel --config=mkl_aarch64_threadpool --copt="-O3" --copt="-fopenmp" --linkopt="-fopenmp" --copt="-march=armv8.4-a+sve" --copt="-msve-vector-bits=256" --copt="-DEIGEN_ARM64_USE_SVE" --repo_env=USE_PYWRAP_RULES=1   --repo_env=WHEEL_NAME=tensorflow_cpu_sve_eigen_onednn
```

Error:
```bash
ERROR: /sandbox/DL/tensorflow/tensorflow/core/kernels/BUILD:3521:18: Compiling tensorflow/core/kernels/sparse_matmul_op.cc failed: (Exit 1): clang failed: error executing command (from target //tensorflow/core/kernels:sparse_matmul_op) /usr/lib/llvm-17/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer -g0 ... (remaining 229 arguments skipped)
In file included from tensorflow/core/kernels/sparse_matmul_op.cc:20:
./tensorflow/core/kernels/sparse_matmul_op.h:44:10: error: cannot initialize return object of type '__attribute__((__arm_sve_vector_bits__(8 * sizeof(float) * 8))) float' (vector of 8 'float' values) with an lvalue of type 'const float'
   44 |   return reinterpret_cast<const float&>(tmp);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tensorflow/core/kernels/sparse_matmul_op.cc:431:3: note: in instantiation of function template specialization 'Eigen::internal::pexpand_bf16_l<__attribute__((__arm_sve_vector_bits__(8 * sizeof(float) * 8))) float>' requested here
  431 |   EXPAND_BFLOAT_L(b, b_0);
      |   ^
tensorflow/core/kernels/sparse_matmul_op.cc:297:35: note: expanded from macro 'EXPAND_BFLOAT_L'
  297 |   const auto y = Eigen::internal::pexpand_bf16_l<Packet>(x);
      |                                   ^
In file included from tensorflow/core/kernels/sparse_matmul_op.cc:20:
./tensorflow/core/kernels/sparse_matmul_op.h:62:10: error: cannot initialize return object of type '__attribute__((__arm_sve_vector_bits__(8 * sizeof(float) * 8))) float' (vector of 8 'float' values) with an lvalue of type 'const float'
   62 |   return reinterpret_cast<const float&>(tmp);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tensorflow/core/kernels/sparse_matmul_op.cc:432:3: note: in instantiation of function template specialization 'Eigen::internal::pexpand_bf16_u<__attribute__((__arm_sve_vector_bits__(8 * sizeof(float) * 8))) float>' requested here
  432 |   EXPAND_BFLOAT_U(b, b_1);
      |   ^
tensorflow/core/kernels/sparse_matmul_op.cc:299:35: note: expanded from macro 'EXPAND_BFLOAT_U'
  299 |   const auto y = Eigen::internal::pexpand_bf16_u<Packet>(x);
      |                                   ^
```
