### PR TITLE
Fix incomplete docstring in TensorFlow Lite Interpreter.tensor() method

### DIFF
--- a/tensorflow/lite/python/interpreter.py
+++ b/tensorflow/lite/python/interpreter.py
@@ -955,7 +955,8 @@ class Interpreter:
     interpreter.allocate_tensors()  # This will throw RuntimeError
     for i in range(10):
       input.fill(3.)
-      interpreter.invoke()  # this will throw RuntimeError since input, output
+      interpreter.invoke()  # This will throw RuntimeError since input, output
+                            # numpy arrays are now invalid due to allocate_tensors()
     ```
 
     Args:


### PR DESCRIPTION
This PR fixes an incomplete docstring in the TensorFlow Lite Python API.

## Problem
The `Interpreter.tensor()` method had a "WRONG:" example in its docstring that was cut off mid-sentence. The comment ended with "# this will throw Runtime Error" instead of providing a complete explanation.

## Solution
Completed the comment to properly explain why the example is incorrect:
- The numpy arrays become invalid after `allocate_tensors()` is called
- Subsequent operations throw `RuntimeError` due to invalidated tensor references

## Impact
This improves documentation clarity for developers using the TensorFlow Lite Python API by providing a complete explanation of why certain usage patterns should be avoided.

## Testing
- Verified the docstring is now complete and properly formatted
- No functional code changes, only documentation improvement