### PR TITLE
[mlir][tflite][tosa] Disable TFL GatherOp folding for quantized tensors

### DIFF
--- a/tensorflow/compiler/mlir/lite/ir/tfl_ops.cc
+++ b/tensorflow/compiler/mlir/lite/ir/tfl_ops.cc
@@ -1334,6 +1334,13 @@ LogicalResult GatherOp::verify() {
 }
 
 OpFoldResult GatherOp::fold(GatherOp::FoldAdaptor adaptor) {
+  // Don't fold when the tensor we gather from (params) has non-int/float/index
+  // type. E.g. in case of quantized type, casting to DenseElementsAttr will
+  // strip the quantization information and cause type mismatch problems.
+  if (!getType().getElementType().isIntOrIndexOrFloat()) {
+    return {};
+  }
+
   // Get the params tensor type/shape/data
   auto params = mlir::dyn_cast_or_null<DenseElementsAttr>(adaptor.getParams());
   if (!params) {

--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -3164,7 +3164,16 @@ func.func @test_gather_cast(%arg0: tensor<13x21x3xf32>, %arg1: tensor<7x7xi64>) 
 }
 
 // -----
+// CHECK-LABEL: test_gather_dont_fold_quantized
+// CHECK: tosa.gather
+func.func @test_gather_dont_fold_quantized() -> tensor<4x4x4x!quant.uniform<i8:f32, 0.1026>> {
+  %0 = "tfl.pseudo_qconst"() <{qtype = tensor<4x3x!quant.uniform<i8:f32, 0.1026>>, value = dense<[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]> : tensor<4x3xi8>}> : () -> tensor<4x3x!quant.uniform<i8:f32, 0.1026>>
+  %1 = "tfl.pseudo_const"() <{value = dense<[[0, 1, 2, 0], [2, 1, 0, 2], [1, 0, 2, 1], [0, 2, 1, 0]]> : tensor<4x4xi32>}> : () -> tensor<4x4xi32>
+  %2 = "tfl.gather"(%0, %1) <{axis = 1 : i32, batch_dims = 0 : i32}> : (tensor<4x3x!quant.uniform<i8:f32, 0.1026>>, tensor<4x4xi32>) -> tensor<4x4x4x!quant.uniform<i8:f32, 0.1026>>
+  func.return %2 : tensor<4x4x4x!quant.uniform<i8:f32, 0.1026>>
+}
 
+// -----
 // CHECK-LABEL: test_sparse_to_dense
 // CHECK-DAG: %[[CONST0:.*]] = tosa.const_shape {values = dense<[1, -1, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
 // CHECK-DAG: %[[CONST1:.*]] = tosa.const_shape {values = dense<[1, -1]> : tensor<2xindex>} : () -> !tosa.shape<2>


### PR DESCRIPTION
--tfl-to-tosa-pipeline will try to use TFL folders for constants. If the params tensor in GatherOp is quantized (e.g. quantized tosa.const), the folder will lose the quantization information, causing type mismatch failures in later checks.