### PR TITLE
Remove tensorflow-intel from Linux wheel metadata

### DIFF
--- a/tensorflow/tools/pip_package/setup.py.tpl
+++ b/tensorflow/tools/pip_package/setup.py.tpl
@@ -122,8 +122,6 @@ FAKE_REQUIRED_PACKAGES = [
     # different architectures having different requirements.
     # The entries here should be a simple duplicate of those in the collaborator
     # build section.
-    standard_or_nightly('tensorflow-intel', 'tf-nightly-intel') + '==' +
-    _VERSION + ';platform_system=="Windows"',
 ]
 
 if platform.system() == 'Linux' and platform.machine() == 'x86_64':


### PR DESCRIPTION
It seems that the `tensorflow-intel` package has stopped updates, but it still exists in the metadata of Linux wheels. This confuses some package managers, such as UV. This PR removes it.
See:
- https://github.com/astral-sh/uv/issues/12588
- https://pypi-browser.org/package/tensorflow/tensorflow-2.19.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (there is `tensorflow-intel ==2.19.0 ; platform_system == "Windows"` in metadata)