### PR TITLE
Fix xnnpack-delegate performance regression

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -553,10 +553,6 @@ if(TFLITE_ENABLE_XNNPACK)
     )
 
   list(APPEND TFLITE_TARGET_PUBLIC_OPTIONS "-DTFLITE_KERNEL_USE_XNNPACK")
-  target_compile_options(xnnpack-delegate
-    PUBLIC ${TFLITE_TARGET_PUBLIC_OPTIONS}
-    PRIVATE ${TFLITE_TARGET_PRIVATE_OPTIONS}
-  )
 
   list(APPEND TFLITE_TARGET_DEPENDENCIES
     xnnpack-delegate
@@ -838,6 +834,11 @@ target_link_libraries(_pywrap_tensorflow_interpreter_wrapper
   ${CMAKE_DL_LIBS}
 )
 target_compile_options(_pywrap_tensorflow_interpreter_wrapper
+  PUBLIC ${TFLITE_TARGET_PUBLIC_OPTIONS}
+  PRIVATE ${TFLITE_TARGET_PRIVATE_OPTIONS}
+)
+
+target_compile_options(xnnpack-delegate
   PUBLIC ${TFLITE_TARGET_PUBLIC_OPTIONS}
   PRIVATE ${TFLITE_TARGET_PRIVATE_OPTIONS}
 )


### PR DESCRIPTION
This patch fixes a performance regression introduced between v2.17.0 and v2.18.0, in commit `b66e1d7bf428c61e8d454e3f90c50b88d688c3f5`, where the `xnnpack-delegate` was moved to a static library.

In the current `CMakeLists.txt`, the following command:
```cmake
target_compile_options(xnnpack-delegate
  PUBLIC ${TFLITE_TARGET_PUBLIC_OPTIONS}
  PRIVATE ${TFLITE_TARGET_PRIVATE_OPTIONS}
)
```
is invoked before the `${TFLITE_TARGET_*_OPTIONS}` are fully populated. 

As a result, several build flags are missing when compiling xnnpack-delegate, for example:
```
-DEIGEN_NEON_GEBP_NR=4
-DTFLITE_BUILD_WITH_XNNPACK_DELEGATE
-DXNNPACK_DELEGATE_ENABLE_QS8
-DXNNPACK_DELEGATE_ENABLE_QU8
-DXNNPACK_DELEGATE_USE_LATEST_OPS
-DXNNPACK_DELEGATE_ENABLE_SUBGRAPH_RESHAPING
```

This leads to a major degradation in performance for convolution-heavy models. This patch moves the target_compile_options() call to the bottom of the file, after all options have been collected, restoring the performances we had in TFLite 2.17.0.

As an example, you can see here the same benchmark with/without the patch.

TFLite v2.19.0 without patch applied:
```
Number of nodes executed: 600
============================== Summary by node type ==============================
                                     [Node type]          [count]         [avg ms]          [avg %]         [cdf %]       [mem KB]      [times called]
                                         CONV_2D               79           36.439          85.781%         85.781%          0.000             79
                                   Sum (ND) Mean              106            0.958           2.255%         88.036%          0.000            265
                                          GATHER               16            0.853           2.008%         90.044%          0.000             16
                         Binary Elementwise (ND)              125            0.748           1.761%         91.805%          0.000            424
                          Constant Pad (ND, X32)               11            0.589           1.387%         93.192%          0.000             24
                                 Slice (ND, X32)              111            0.449           1.057%         94.249%          0.000            270
                   Convolution (NHWC, F32) IGEMM                3            0.433           1.019%         95.268%          0.000              7
                                  Copy (NC, X32)               21            0.408           0.960%         96.229%          0.000            137
                   Transpose (ND, X32) Transpose                3            0.363           0.855%         97.083%          0.000             20
                                             MUL               16            0.357           0.840%         97.924%          0.000             16
                                            TILE               16            0.294           0.692%         98.616%          0.000             16
                          Unary Elementwise (NC)               11            0.235           0.553%         99.169%          0.000             83
                                             ADD               16            0.110           0.259%         99.428%          0.000             16
                                            CAST               48            0.089           0.210%         99.637%          0.000             48
                                  Mean (ND) Mean                1            0.061           0.144%         99.781%          0.000              1
             Deconvolution (NHWC, F32) Subconv2D                2            0.036           0.085%         99.866%          0.000              4
                                   CONCATENATION                5            0.029           0.068%         99.934%          0.000              5
                                         SPLIT_V                4            0.018           0.042%         99.976%          0.000              4
        Average Pooling (NHWC, F32) Average Pooling             6            0.010           0.024%        100.000%          0.000              6

Timings (microseconds): count=50 first=52759 curr=39437 min=39377 max=52759 avg=42681.7 std=3365
Memory (bytes): count=0
600 nodes observed
```

TFLite 2.19.0 with the patch applied:
```
Number of nodes executed: 613
============================== Summary by node type ==============================
                                     [Node type]          [count]         [avg ms]          [avg %]         [cdf %]       [mem KB]      [times called]
        Convolution (NHWC, QD8, F32, QC8W) IGEMM               25           14.724          68.679%         68.679%          0.000             79
                                   Sum (ND) Mean              106            1.035           4.828%         73.506%          0.000            265
                                          GATHER               16            0.910           4.245%         77.751%          0.000             16
                         Binary Elementwise (ND)              133            0.800           3.732%         81.482%          0.000            424
                          Constant Pad (ND, X32)               21            0.628           2.929%         84.412%          0.000             24
                                 Slice (ND, X32)              109            0.501           2.337%         86.748%          0.000            270
                   Convolution (NHWC, F32) IGEMM                3            0.469           2.188%         88.936%          0.000              7
                   Transpose (ND, X32) Transpose                4            0.411           1.917%         90.853%          0.000             20
                                  Copy (NC, X32)               26            0.399           1.861%         92.714%          0.000            137
                                             MUL               16            0.384           1.791%         94.505%          0.000             16
                                            TILE               16            0.313           1.460%         95.965%          0.000             16
                          Convert (NC, F32, QD8)               25            0.309           1.441%         97.407%          0.000             79
                          Unary Elementwise (NC)               31            0.182           0.849%         98.256%          0.000             83
                                             ADD               16            0.112           0.522%         98.778%          0.000             16
                                            CAST               48            0.095           0.443%         99.221%          0.000             48
                                  Mean (ND) Mean                1            0.066           0.308%         99.529%          0.000              1
             Deconvolution (NHWC, F32) Subconv2D                2            0.039           0.182%         99.711%          0.000              4
                                   CONCATENATION                5            0.030           0.140%         99.851%          0.000              5
                                         SPLIT_V                4            0.020           0.093%         99.944%          0.000              4
        Average Pooling (NHWC, F32) Average Pooling             6            0.012           0.056%        100.000%          0.000              6

Timings (microseconds): count=50 first=22709 curr=21277 min=20943 max=23164 avg=21635.3 std=454
Memory (bytes): count=0
613 nodes observed
```