### PR TITLE
Allow TFL to TOSA pipeline to load TFL dialect

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tf_tosa_opt.cc
+++ b/tensorflow/compiler/mlir/tosa/tf_tosa_opt.cc
@@ -75,6 +75,7 @@ int main(int argc, char** argv) {
 
   mlir::DialectRegistry registry;
   mlir::RegisterCommonToolingDialects(registry);
+  registry.insert<mlir::TFL::TensorFlowLiteDialect>();
 
   return failed(
       mlir::MlirOptMain(argc, argv, "TensorFlow pass driver\n", registry));


### PR DESCRIPTION
After c03f377bf520e84c952c9c52e77a9b8b04feb2c2, the TFL dialect is no longer part of common dialects, and `tf-tosa-opt --tofl-to-tosa-pipeline` would no longer be able to convert from TFL  since the dialect was no longer available.