### PR TITLE
Fix compilation error in tensorflow/python/tfcompile_wrapper.cc on s390x

### DIFF
--- a/tensorflow/python/tfcompile_wrapper.cc
+++ b/tensorflow/python/tfcompile_wrapper.cc
@@ -17,6 +17,7 @@ limitations under the License.
 
 #ifdef __s390x__
 #include "llvm/TargetParser/Host.h"
+#include "llvm/ADT/StringRef.h"
 #endif
 #include "pybind11/cast.h"  // from @pybind11
 #include "pybind11/pybind11.h"  // from @pybind11


### PR DESCRIPTION
TensorFlow build was failing on s390x with following error:
```
tensorflow/python/tfcompile_wrapper.cc:55:44: error: calling 'getHostCPUName' with incomplete return type 'StringRef'
   55 |             std::move(target_cpu.empty() ? llvm::sys::getHostCPUName().str()
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
external/llvm-project/llvm/include/llvm/TargetParser/Host.h:44:13: note: 'getHostCPUName' declared here
   44 |   StringRef getHostCPUName();
      |             ^
external/llvm-project/llvm/include/llvm/TargetParser/Host.h:20:7: note: forward declaration of 'llvm::StringRef'
   20 | class StringRef;
      |       ^
```

Cause:
```
llvm::sys::getHostCPUName().str()
```
This function returns an `llvm::StringRef`, but the required definition of `StringRef` is missing because only a forward declaration exists in `#include "llvm/TargetParser/Host.h"`
```
class StringRef;
```

So explicitly included the proper header in `tfcompile_wrapper.cc`
```
#include "llvm/ADT/StringRef.h"
```