### PR TITLE
Fix subprocess.check_output decoding issue in pip_smoke_test.py to handle byte output safely

### DIFF
--- a/tensorflow/tools/pip_package/pip_smoke_test.py
+++ b/tensorflow/tools/pip_package/pip_smoke_test.py
@@ -175,6 +175,8 @@ def main():
                     (" + ".join(PYTHON_TARGETS), missing_dependency))
       affected_tests = subprocess.check_output(
           ["bazel", "cquery", "--experimental_cc_shared_library", rdep_query])
+      if isinstance(affected_tests, bytes):
+        affected_tests = affected_tests.decode("utf-8")
       affected_tests_list = affected_tests.split("\n")[:-2]
       print("\n".join(affected_tests_list))
 


### PR DESCRIPTION
### PR Description

This PR adds a safeguard in tensorflow/tools/pip_package/pip_smoke_test.py to handle cases where subprocess.check_output() returns a bytes object instead of a str.

**Changes Made:**

    Added a type check using isinstance(affected_tests, bytes)

    Decoded affected_tests using UTF-8 when necessary before splitting

**Motivation:**

subprocess.check_output() returns output in bytes by default in Python 3. Attempting to call .split("\n") on a bytes object leads to unexpected behavior or errors. This patch ensures the output is properly decoded to a string, preventing downstream issues during test parsing.
**Outcome:**

    Prevents potential TypeError in environments where Bazel or subprocesses emit byte streams

    Makes the script more robust and portable

    Ensures test list parsing behaves consistently across Python versions

**Future Suggestion:**

Consider setting text=True in the check_output() call to avoid the need for manual decoding.