### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/ops/collective_ops.py
+++ b/tensorflow/python/ops/collective_ops.py
@@ -128,10 +128,10 @@ def all_reduce_v2(t,
       `tf.function`, or when explicit control dependency is used instead of
       auto control dependency.
     max_subdivs_per_device: int specifying the maximum number of subdivisions a
-      tensor on a device can be divided into. The runtime uses this contraint to
+      tensor on a device can be divided into. The runtime uses this constraint to
       parallelize processing of each per-device tensor. Setting to -1 disables
       subdivision and reverts to previous behavior of not sub-dividing tensor.
-      Setting to 0 uses sytem defaults.
+      Setting to 0 uses system defaults.
     name: name of the Op.
 
   Returns:
@@ -222,7 +222,7 @@ def all_gather_v2(t,
       timeout value in seconds. This feature is experimental.
     ordering_token: a resource tensor on the same device as the op to order
       the collectives in a per-device manner by auto control dependency.
-      This argument can be omited when there is one collective Op per
+      This argument can be omitted when there is one collective Op per
       `tf.function`, or when explicit control dependency is used instead of
       auto control dependency.
     name: name of the Op.
@@ -477,7 +477,7 @@ def all_reduce_v3(communicator,
       `initialize_communicator`.
     t: the `tf.Tensor` to be reduced.
     reduction: a string. The name of the operation to reduce the values.
-      Accpeted values are `"min"`, `"max"`, `"mul"`, `"add"`.
+      Accepted values are `"min"`, `"max"`, `"mul"`, `"add"`.
     group_assignment: Optional int32 `tf.Tensor` with shape [num_groups,
       num_ranks_per_group]. `group_assignment[i]` represents the ranks in the
       `ith` subgroup.
@@ -525,7 +525,7 @@ def all_to_all_v2(
       timeout value in seconds. This feature is experimental.
     ordering_token: a resource tensor on the same device as the op to order the
       collectives in a per-device manner by auto control dependency. This
-      argument can be omited when there is one collective Op per `tf.function`,
+      argument can be omitted when there is one collective Op per `tf.function`,
       or when explicit control dependency is used instead of auto control
       dependency.
     name: name of the Op.

--- a/tensorflow/python/ops/image_grad_d9m_test.py
+++ b/tensorflow/python/ops/image_grad_d9m_test.py
@@ -345,7 +345,7 @@ class CropAndResizeOpDeterministicTest(test_base.CropAndResizeOpTestBase):
     input pixel location.
 
     Note that the number of boxes can be less than, equal to, or greater than
-    the batch size. Wth non-reproducible ordering of reduction operations, three
+    the batch size. With non-reproducible ordering of reduction operations, three
     or more crops overlapping on the same input image pixel can independently
     contribute to nondeterminism in the image gradient associated with that
     input pixel location. This is independent of contributions caused by the

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -3797,7 +3797,7 @@ def _wrap_2d_function(inputs, compute_op, dim=-1, name=None):
     inputs: A non-empty `Tensor`. Must be one of the following types: `half`,
       `float32`, `float64`.
     compute_op: The function to wrap. Must accept the input tensor as its first
-      arugment, and a second keyword argument `name`.
+      argument, and a second keyword argument `name`.
     dim: The dimension softmax would be performed on. The default is -1 which
       indicates the last dimension.
     name: A name for the operation (optional).

--- a/tensorflow/python/ops/ragged/ragged_bincount_ops.py
+++ b/tensorflow/python/ops/ragged/ragged_bincount_ops.py
@@ -67,7 +67,7 @@ def bincount(arr: ragged_tensor.RaggedTensor,
   summed).
 
   There is an equivilance between bin-counting with weights and
-  `unsorted_segement_sum` where `data` is the weights and `segment_ids` are the
+  `unsorted_segment_sum` where `data` is the weights and `segment_ids` are the
   values.
 
   >>> data = tf.ragged.constant([[1, 1], [2, 3, 2, 4, 4, 5]])

--- a/tensorflow/python/ops/ragged/ragged_gather_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_gather_op_test.py
@@ -307,7 +307,7 @@ class RaggedGatherOpTest(test_util.TensorFlowTestCase, parameterized.TestCase):
         when testing the gradient of `ragged_gather`.  Must have the same
         shape as `expected_out`.
       expected_grad: The expected gradient for that should be returned for
-        `params`.  Must have hte same shape as `params`.
+        `params`.  Must have the same shape as `params`.
       params_ragged_rank: The ragged_rank of `params`.
     """
     if context.executing_eagerly():

--- a/tensorflow/python/ops/ragged/ragged_tensor_test.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor_test.py
@@ -1145,7 +1145,7 @@ class RaggedTensorTest(test_util.TensorFlowTestCase, parameterized.TestCase):
           'row_lengths': [[1, 2], [1, 0]]
       },
       {
-          'descr': 'negatve row_lengths',
+          'descr': 'negative row_lengths',
           'factory': RaggedTensor.from_row_lengths,
           'values': [1, 2, 3, 4],
           'row_lengths': [3, -1, 2]

--- a/tensorflow/python/ops/weak_tensor_constant_op_test.py
+++ b/tensorflow/python/ops/weak_tensor_constant_op_test.py
@@ -207,7 +207,7 @@ class WeakTensorConstantOpTest(test.TestCase, parameterized.TestCase):
       dtypes.half,
   )
   def test_constant_python_float_with_dtype_arg(self, dtype):
-    # Test that python float can be implicity casted to any float/complex types.
+    # Test that python float can be implicitly casted to any float/complex types.
     a = constant_op.constant([1.0, 2.0, 3.0], dtype)
     self.assertIsInstance(a, tensor.Tensor)
     self.assertEqual(a.dtype, dtype)


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.