### PR TITLE
Add third_party/py/numpy to .bazelignore to fix #95762

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -12,3 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+third_party/py/numpy


### PR DESCRIPTION
Fixes #95762

Adds third_party/py/numpy to .bazelignore to prevent Bazel from traversing this directory.