### PR TITLE
[tosa] Re-register the quantization dialect

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tf_tosa_opt.cc
+++ b/tensorflow/compiler/mlir/tosa/tf_tosa_opt.cc
@@ -76,6 +76,7 @@ int main(int argc, char** argv) {
   mlir::DialectRegistry registry;
   mlir::RegisterCommonToolingDialects(registry);
   registry.insert<mlir::TFL::TensorFlowLiteDialect>();
+  registry.insert<mlir::quantfork::QuantizationForkDialect>();
 
   return failed(
       mlir::MlirOptMain(argc, argv, "TensorFlow pass driver\n", registry));


### PR DESCRIPTION
This was removed in `mlir::TFL::registerTensorFlowLitePasses()` in c03f377.