### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/ops/collective_ops.py
+++ b/tensorflow/python/ops/collective_ops.py
@@ -124,7 +124,7 @@ def all_reduce_v2(t,
       timeout value in seconds. This feature is experimental.
     ordering_token: a resource tensor on the same device as the op to order the
       collectives in a per-device manner by auto control dependency. This
-      argument can be omited when there is one collective Op per `tf.function`,
+      argument can be omitted when there is one collective Op per `tf.function`,
       or when explicit control dependency is used instead of auto control
       dependency.
     max_subdivs_per_device: int specifying the maximum number of subdivisions a

--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -326,7 +326,7 @@ def ctc_greedy_decoder(inputs,
 
   - Unlike `ctc_beam_search_decoder`, `ctc_greedy_decoder` considers blanks
     as regular elements when computing the probability of a sequence.
-  - Default `blank_index` is `(num_classes - 1)`, unless overriden.
+  - Default `blank_index` is `(num_classes - 1)`, unless overridden.
 
   If `merge_repeated` is `True`, merge repeated classes in output.
   This means that if consecutive logits' maximum indices are the same,

--- a/tensorflow/python/ops/gradients_test.py
+++ b/tensorflow/python/ops/gradients_test.py
@@ -1347,7 +1347,7 @@ class CustomGradientTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       with variable_scope.variable_scope("f", use_resource=True) as vs:
         a = array_ops.ones((2, 4))
 
-        # Variabes in these layers shouldn't be picked up by the decorator.
+        # Variables in these layers shouldn't be picked up by the decorator.
         b = core_layers.dense(a, 3, use_bias=False)
         c = core_layers.dense(b, 3, use_bias=False)
         x = core_layers.dense(b, 3, use_bias=False) + c

--- a/tensorflow/python/ops/list_ops.py
+++ b/tensorflow/python/ops/list_ops.py
@@ -371,7 +371,7 @@ def _build_element_shape(shape):
   If shape is None or a TensorShape with unknown rank, -1 is returned.
 
   If shape is a scalar, an int32 tensor with empty list is returned. Note we
-  do directly return an empty list since ops.convert_to_tensor would conver it
+  do directly return an empty list since ops.convert_to_tensor would convert it
   to a float32 which is not a valid type for element_shape.
 
   If shape is a sequence of dims, None's in the list are replaced with -1. We

--- a/tensorflow/python/ops/ragged/ragged_tensor.py
+++ b/tensorflow/python/ops/ragged/ragged_tensor.py
@@ -2979,7 +2979,7 @@ def _get_row_partition_type_tensor_pairs(rt_input):
   """Gets a list of the row partitions for rt_input.
 
   If value_rowids are defined, then they are used. Otherwise, row_splits
-  are used. If the outermost level has value_rowids defind, then nrows is
+  are used. If the outermost level has value_rowids defined, then nrows is
   also added.
 
   Args:

--- a/tensorflow/python/ops/ragged/row_partition.py
+++ b/tensorflow/python/ops/ragged/row_partition.py
@@ -753,7 +753,7 @@ class RowPartition(composite_tensor.CompositeTensor):
   def value_rowids(self):
     """Returns the row indices for this row partition.
 
-    `value_rowids` specifies the row index fo reach value.  In particular,
+    `value_rowids` specifies the row index for each value.  In particular,
     `value_rowids[i]` is the row index for `values[i]`.
 
     Returns:


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.