### PR TITLE
[mlir][tosa] Add QuantizationFork dialect to tf-tosa-opt

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tf_tosa_opt.cc
+++ b/tensorflow/compiler/mlir/tosa/tf_tosa_opt.cc
@@ -76,6 +76,7 @@ int main(int argc, char** argv) {
   mlir::DialectRegistry registry;
   mlir::RegisterCommonToolingDialects(registry);
   registry.insert<mlir::TFL::TensorFlowLiteDialect>();
+  registry.insert<mlir::quantfork::QuantizationForkDialect>();
 
   return failed(
       mlir::MlirOptMain(argc, argv, "TensorFlow pass driver\n", registry));


### PR DESCRIPTION
This fixes the test_quantfork.stats test in tfl-to-tosa-pipeline.mlir

