### PR TITLE
fix warning on swift withUnsafeBytes

### DIFF
--- a/tensorflow/lite/swift/Sources/Model.swift
+++ b/tensorflow/lite/swift/Sources/Model.swift
@@ -47,7 +47,7 @@ final class Model {
   ///   - modelData: Binary data representing a TensorFlow Lite model.
   init?(modelData: Data) {
     self.data = modelData
-    self.cModel = modelData.withUnsafeBytes { TfLiteModelCreate($0, modelData.count) }
+    self.cModel = modelData.withUnsafeBytes { TfLiteModelCreate($0.baseAddress, modelData.count) }
   }
 
   deinit {


### PR DESCRIPTION
Fix warning: `'withUnsafeBytes' is deprecated: use withUnsafeBytes<R>_: (UnsafeRawBufferPointer) throws -> R) rethrows -> R*`

<img width="859" alt="warning" src="https://github.com/user-attachments/assets/8dc23e8e-c978-4b01-aa84-12b09e2fefd1" />
