### PR TITLE
Specify std::abs overloads in elementwise.cc

### DIFF
--- a/tensorflow/lite/kernels/elementwise.cc
+++ b/tensorflow/lite/kernels/elementwise.cc
@@ -299,7 +299,8 @@ TfLiteStatus AbsEval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteType type = input->type;
   switch (type) {
     case kTfLiteFloat32:
-      return EvalImpl<float>(context, node, std::abs<float>, type);
+      return EvalImpl<float>(context, node,
+                             static_cast<float (*)(float)>(std::abs), type);
     case kTfLiteInt8:
       return AbsEvalQuantized<int8_t>(context, node, type);
     case kTfLiteInt16:
@@ -307,7 +308,8 @@ TfLiteStatus AbsEval(TfLiteContext* context, TfLiteNode* node) {
                  ? AbsInt16EvalImpl(context, node, type)
                  : AbsEvalQuantized<int16_t>(context, node, type);
     case kTfLiteInt32:
-      return EvalImpl<int32_t>(context, node, std::abs<int32_t>, type);
+      return EvalImpl<int32_t>(
+          context, node, static_cast<int32_t (*)(int32_t)>(std::abs), type);
     default:
       TF_LITE_KERNEL_LOG(context, "Current data type %s is not supported.",
                          TfLiteTypeGetName(type));


### PR DESCRIPTION
This is required to build with the most recent version of LLVM's libc++, which moved the `abs` function from `stdlib.h` to `math.h` in llvm/llvm-project#139586. This seems to have affected overload resolution, requiring us to explicitly specify which one to use. The static_cast syntax, though ugly, works with both versions.