### PR TITLE
fix(proto_splitter): return error if `FindFieldByNumber` yields null `field_desc` in `ProcessField`

### DIFF
--- a/tensorflow/tools/proto_splitter/merge.cc
+++ b/tensorflow/tools/proto_splitter/merge.cc
@@ -291,6 +291,14 @@ absl::Status Merger::ProcessField(
     merged_message = curr_message;
     field_desc = merged_message->GetDescriptor()->FindFieldByNumber(
         std::get<int>(field.first));
+
+    if (field_desc == nullptr) {
+      return absl::FailedPreconditionError(
+          absl::StrCat("Field with number ", std::get<int>(field.first),
+                       " not found in message descriptor.",
+                       merged_message->GetDescriptor()->full_name(), ".\n"));
+    }
+    
     auto res = GetMutableField(merged_message, field);
     if (!res.ok()) {
       if (!absl::IsNotFound(res.status())) return res.status();

--- a/tensorflow/tools/proto_splitter/merge_test.cc
+++ b/tensorflow/tools/proto_splitter/merge_test.cc
@@ -288,7 +288,7 @@ TEST(MergeTest, TestReadChunkedFromString) {
   ASSERT_THAT(merged_saved_model, EqualsProto(test_saved_model));
 }
 
-TEST(MergeTest, ProcessFieldReturnsErrorOnInvalidFieldNumber) {
+TEST(MergeTest, TestProcessFieldReturnsErrorOnInvalidFieldNumber) {
 
   ::tensorflow::proto_splitter::ChunkedMessage chunked_message;
 

--- a/tensorflow/tools/proto_splitter/merge_test.cc
+++ b/tensorflow/tools/proto_splitter/merge_test.cc
@@ -288,6 +288,28 @@ TEST(MergeTest, TestReadChunkedFromString) {
   ASSERT_THAT(merged_saved_model, EqualsProto(test_saved_model));
 }
 
+TEST(MergeTest, ProcessFieldReturnsErrorOnInvalidFieldNumber) {
+
+  ::tensorflow::proto_splitter::ChunkedMessage chunked_message;
+
+  auto* chunk_field = chunked_message.add_chunked_fields();
+
+  auto* tag = chunk_field->add_field_tag();
+  tag->set_field(99999);  
+
+  chunk_field->mutable_message()->set_chunk_index(0);
+
+  std::vector<std::unique_ptr<tsl::protobuf::Message>> chunks;
+  chunks.push_back(std::make_unique<::tensorflow::proto_splitter_testdata::ManyFields>());
+
+  ::tensorflow::proto_splitter_testdata::ManyFields merged;
+  absl::Status status = Merger::Merge(chunks, chunked_message, &merged);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(status.message()), ::testing::HasSubstr("not found in message descriptor"));
+}
+
 }  // namespace
 
 }  // namespace tensorflow::tools::proto_splitter


### PR DESCRIPTION
## Summary

Prevents a potential segmentation fault in `proto_splitter::ProcessField` by returning a clear error when `FindFieldByNumber` returns a null `field_desc`, instead of dereferencing a null pointer.

Adds a dedicated C++ unit test (`TestProcessFieldReturnsErrorOnInvalidFieldNumber`) to validate the new error-handling path and improve long-term reliability.

---

## What this PR changes

* **Bugfix:**

  * Adds a null pointer check for the result of `FindFieldByNumber` in `merge.cc`, returning an error when the field is not found.
* **Testing:**

  * Adds a unit test (`TestProcessFieldReturnsErrorOnInvalidFieldNumber`) in `merge_test.cc` that triggers this error case and checks the returned status.

---

## Why this matters

* Prevents segmentation faults when handling malformed or version-skewed chunked protos.
* Improves robustness and error reporting for distributed or automated tooling.
* The new unit test protects this error path against regressions.

---

## Test Plan

* [x] **Single test passes:**
  `bazel test //tensorflow/tools/proto_splitter:merge_test --test_filter=TestProcessFieldReturnsErrorOnInvalidFieldNumber`
* [x] **Full test suite passes:**
  `bazel test //tensorflow/tools/proto_splitter:merge_test`
* [x] All tests pass locally on my WSL-CPU setup.
  (Please let me know if further test evidence or log format is preferred!)

---

## Risk Level

Low. The patch is a defensive error-check and a new unit test; no changes for valid input or existing workflows.

---

## Additional Notes

* If there is a better or preferred way to structure tests for this error path, feedback is welcome.
* This PR is rebased on latest `upstream/master` and up to date.

---

**Reviewer:** Please check that both the bugfix and test logic meet project standards. Thank you for your review!


