### PR TITLE
Fixes L2Pool implementation to not average pooling region squares

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate_test.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate_test.cc
@@ -613,7 +613,7 @@ TEST(NNAPIDelegate, L2PoolWithNoActivation) {
       3, 2, 10, 7,  //
   });
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray({3.5, 6.5}));
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({7.0, 13.0}));
 }
 
 class ConvolutionOpModel : public SingleOpModelWithNNAPI {

--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -3361,8 +3361,6 @@ inline void L2Pool(const PoolParams& params, const RuntimeShape& input_shape,
   const auto in_mat = MapAsMatrixWithLastDimAsRows(input_data, input_shape);
   auto out_mat = MapAsMatrixWithLastDimAsRows(output_data, output_shape);
   Eigen::VectorXf in_square(in_mat.rows());
-  Eigen::VectorXf out_count(out_mat.cols());
-  out_count.setZero();
   // Prefill the output to 0.
   out_mat.setZero();
   for (int b = 0; b < batches; ++b) {
@@ -3391,16 +3389,13 @@ inline void L2Pool(const PoolParams& params, const RuntimeShape& input_shape,
           for (int pw = w_start; pw < w_end; ++pw) {
             const int out_offset = pw + output_width * (ph + output_height * b);
             out_mat.col(out_offset) += in_square;
-            out_count(out_offset)++;
           }
         }
       }
     }
   }
 
-  out_count = out_count.array().inverse();
-  out_mat =
-      (out_mat.array().rowwise() * out_count.transpose().array()).cwiseSqrt();
+  out_mat = out_mat.cwiseSqrt();
 
   const int flat_size = output_shape.FlatSize();
   for (int i = 0; i < flat_size; ++i) {

--- a/tensorflow/lite/kernels/pooling_test.cc
+++ b/tensorflow/lite/kernels/pooling_test.cc
@@ -12,13 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <stdint.h>
 
 #include <initializer_list>
 #include <vector>
 
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "flatbuffers/flatbuffers.h"  // from @flatbuffers
 #include "tensorflow/lite/kernels/test_util.h"
 #include "tensorflow/lite/schema/schema_generated.h"
@@ -1063,7 +1063,7 @@ TEST(FloatPoolingOpTest, L2Pool) {
       3, 2, 10, 7,  //
   });
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear({3.5, 6.5})));
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear({7.0, 13.0})));
 }
 
 TEST(FloatPoolingOpTest, L2PoolActivationRelu) {
@@ -1077,7 +1077,7 @@ TEST(FloatPoolingOpTest, L2PoolActivationRelu) {
       -3, -2, 10, 7,  //
   });
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear({3.53553, 6.5})));
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear({7.07107, 13.0})));
 }
 
 TEST(FloatPoolingOpTest, L2PoolActivationRelu1) {
@@ -1091,7 +1091,7 @@ TEST(FloatPoolingOpTest, L2PoolActivationRelu1) {
       -0.3, -0.2, 10, 7,  //
   });
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear({0.353553, 1.0})));
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear({0.707107, 1.0})));
 }
 
 TEST(FloatPoolingOpTest, L2PoolActivationRelu6) {
@@ -1105,7 +1105,7 @@ TEST(FloatPoolingOpTest, L2PoolActivationRelu6) {
       -0.3, -0.2, 10, 7,  //
   });
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear({0.353553, 6.0})));
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear({0.707107, 6.0})));
 }
 
 TEST(FloatPoolingOpTest, L2PoolPaddingSame) {
@@ -1118,7 +1118,7 @@ TEST(FloatPoolingOpTest, L2PoolPaddingSame) {
       3, 2, 10, 7,  //
   });
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear({3.5, 6.5})));
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear({7.0, 13.0})));
 }
 
 TEST(FloatPoolingOpTest, L2PoolPaddingSameSlide1) {
@@ -1134,7 +1134,7 @@ TEST(FloatPoolingOpTest, L2PoolPaddingSameSlide1) {
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
   EXPECT_THAT(m.GetOutput(),
               ElementsAreArray(ArrayFloatNear(
-                  {3.5, 6.0, 6.5, 5.70088, 2.54951, 7.2111, 8.63134, 7.0},
+                  {7.0, 12.0, 13.0, 8.06226, 3.60555, 10.19804, 12.20656, 7.0},
                   /*max_abs_err=*/1e-4)));
 }
 
@@ -1149,7 +1149,8 @@ TEST(FloatPoolingOpTest, L2PoolPaddingValidSlide1) {
       3, 2, 10, 7,  //
   });
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
-  EXPECT_THAT(m.GetOutput(), ElementsAreArray(ArrayFloatNear({3.5, 6.0, 6.5})));
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray(ArrayFloatNear({7.0, 12.0, 13.0})));
 }
 
 #if GTEST_HAS_DEATH_TEST


### PR DESCRIPTION
This PR is to re-land [PR-74079](https://github.com/tensorflow/tensorflow/pull/74079), the issue has been discussed in https://github.com/tensorflow/tensorflow/issues/73742.