### PR TITLE
[TFLite] Support 16KB page sizes alignment for libtensorflowlite_gpu_gl.so

### DIFF
--- a/tensorflow/lite/delegates/gpu/BUILD
+++ b/tensorflow/lite/delegates/gpu/BUILD
@@ -5,7 +5,7 @@ load(
     "//tensorflow/core/platform:build_config_root.bzl",
     "tf_gpu_tests_tags",
 )
-load("//tensorflow/lite:build_def.bzl", "CXX17_BAZEL_ONLY_COPTS")
+load("//tensorflow/lite:build_def.bzl", "CXX17_BAZEL_ONLY_COPTS", "tflite_pagesize_linkopts")
 load("//tensorflow/lite:special_rules.bzl", "tflite_extra_gles_deps", "tflite_portable_test_suite")
 load("//tensorflow/lite/delegates/gpu:build_defs.bzl", "gpu_delegate_linkopts")
 
@@ -181,7 +181,7 @@ cc_binary(
         "//conditions:default": [
             "-fvisibility=hidden",
         ],
-    }),
+    }) + tflite_pagesize_linkopts(),
     linkshared = 1,
     linkstatic = 1,
     tags = [


### PR DESCRIPTION
This PR enables the 16KB page size alignment option in `libtensorflowlite_gpu_gl.so`, which resolves a warning our application receives.

First, thank you for all the great work on adding 16KB page size support across the library. 🙏 While most of the TensorFlow Lite libraries are now compatible, this specific library was still causing issues. This change brings the GPU GL library in line with the rest of the ecosystem.

Should libtensorflowlite_gpu_delegate.so also be updated to support this? I'm happy to make any necessary changes.