### PR TITLE
Add type-safe Go session config API, docs, and tests

### DIFF
--- a/tensorflow/core/protobuf/BUILD
+++ b/tensorflow/core/protobuf/BUILD
@@ -197,6 +197,7 @@ tf_proto_library(
         "fingerprint.proto",
     ],
     make_default_target_header_only = True,
+    create_go_proto = True,
     protodeps = [
         ":error_codes_proto_impl",
         "//tensorflow/core/framework:protos_all",

--- a/tensorflow/go/BUILD
+++ b/tensorflow/go/BUILD
@@ -6,6 +6,8 @@ load(
     "tf_shared_library_deps",
 )
 
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
 package(
     default_visibility = ["//visibility:private"],
 )
@@ -24,6 +26,19 @@ sh_test(
     ] + tf_shared_library_deps(),
     # TODO: Enable this test again once protos are supported by bazel.
     tags = ["manual"],
+)
+
+# ------------------------------------------------------------------------------
+# go_default_test: Runs all Go tests in this package, including new session config tests.
+# This target ensures that all *_test.go files are executed as part of the Bazel test suite.
+# ------------------------------------------------------------------------------
+go_test(
+    name = "go_default_test",
+    srcs = glob(["*_test.go"]),
+    embed = [":go_default_library"],
+    deps = [
+        # Add any extra dependencies here if needed
+    ],
 )
 
 filegroup(

--- a/tensorflow/go/BUILD
+++ b/tensorflow/go/BUILD
@@ -32,9 +32,7 @@ go_test(
     name = "go_default_test",
     srcs = glob(["*_test.go"]),
     embed = [":go_default_library"],
-    deps = [
-        # Add any extra dependencies here if needed
-    ],
+    deps = [],
 )
 
 filegroup(

--- a/tensorflow/go/BUILD
+++ b/tensorflow/go/BUILD
@@ -28,10 +28,6 @@ sh_test(
     tags = ["manual"],
 )
 
-# ------------------------------------------------------------------------------
-# go_default_test: Runs all Go tests in this package, including new session config tests.
-# This target ensures that all *_test.go files are executed as part of the Bazel test suite.
-# ------------------------------------------------------------------------------
 go_test(
     name = "go_default_test",
     srcs = glob(["*_test.go"]),

--- a/tensorflow/go/core/protobuf/BUILD
+++ b/tensorflow/go/core/protobuf/BUILD
@@ -1,1 +1,18 @@
-# Empty file to be replaced in https://github.com/tensorflow/tensorflow/pull/50934
+# Author: KleaSCM
+# Email: KleaSCM@gmail.com
+# File: tensorflow/go/core/protobuf/BUILD
+# Description: Go protobuf build target for TensorFlow core protos. This target enables the Go API to use
+# type-safe, maintainable configuration objects (e.g., ConfigProto, GPUOptions) for session configuration.
+#
+# This file connects the generated Go protobuf code to the rest of the Go API, making it possible to
+# use native Go types for TensorFlow session options and other core configuration features.
+
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+go_proto_library(
+    name = "for_core_protos_go_proto",
+    compilers = ["@io_bazel_rules_go//proto:go_proto"],
+    importpath = "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto",
+    proto = "//tensorflow/core/protobuf:for_core_protos",
+    visibility = ["//visibility:public"],
+)

--- a/tensorflow/go/core/protobuf/BUILD
+++ b/tensorflow/go/core/protobuf/BUILD
@@ -1,11 +1,18 @@
-# Author: KleaSCM
-# Email: KleaSCM@gmail.com
-# File: tensorflow/go/core/protobuf/BUILD
-# Description: Go protobuf build target for TensorFlow core protos. This target enables the Go API to use
-# type-safe, maintainable configuration objects (e.g., ConfigProto, GPUOptions) for session configuration.
-#
-# This file connects the generated Go protobuf code to the rest of the Go API, making it possible to
-# use native Go types for TensorFlow session options and other core configuration features.
+/*
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 

--- a/tensorflow/go/session.go
+++ b/tensorflow/go/session.go
@@ -293,7 +293,28 @@ func (s *Session) Close() error {
 // for backward compatibility, but is discouraged for new code.
 type SessionOptions struct {
 	// Target indicates the TensorFlow runtime to connect to.
-	// See the original comments for details on valid values.
+	//
+	// If 'target' is empty or unspecified, the local TensorFlow runtime
+	// implementation will be used.  Otherwise, the TensorFlow engine
+	// defined by 'target' will be used to perform all computations.
+	//
+	// "target" can be either a single entry or a comma separated list
+	// of entries. Each entry is a resolvable address of one of the
+	// following formats:
+	//   local
+	//   ip:port
+	//   host:port
+	//   ... other system-specific formats to identify tasks and jobs ...
+	//
+	// NOTE: at the moment 'local' maps to an in-process service-based
+	// runtime.
+	//
+	// Upon creation, a single session affines itself to one of the
+	// remote processes, with possible load balancing choices when the
+	// "target" resolves to a list of possible processes.
+	//
+	// If the session disconnects from the remote process during its
+	// lifetime, session calls may fail immediately.
 	Target string
 
 	// Config is a binary-serialized representation of the tensorflow.ConfigProto protocol message.

--- a/tensorflow/go/session_config.go
+++ b/tensorflow/go/session_config.go
@@ -1,8 +1,17 @@
 /*
-Author: KleaSCM
-Email: KleaSCM@gmail.com
-File: session_config.go
-Description: Provides a type-safe, modular, and well-documented Go API for configuring TensorFlow sessions using generated protobufs (ConfigProto, GPUOptions, etc). This file enables users to specify session options natively in Go, improving type safety, maintainability, and developer experience.
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package tensorflow

--- a/tensorflow/go/session_config.go
+++ b/tensorflow/go/session_config.go
@@ -1,0 +1,109 @@
+/*
+Author: KleaSCM
+Email: KleaSCM@gmail.com
+File: session_config.go
+Description: Provides a type-safe, modular, and well-documented Go API for configuring TensorFlow sessions using generated protobufs (ConfigProto, GPUOptions, etc). This file enables users to specify session options natively in Go, improving type safety, maintainability, and developer experience.
+*/
+
+package tensorflow
+
+import (
+	corepb "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf/for_core_protos_go_proto"
+	"google.golang.org/protobuf/proto"
+)
+
+// SessionConfig provides a type-safe, modular API for configuring TensorFlow sessions in Go.
+// This struct wraps the generated ConfigProto protobuf and exposes common configuration options
+// through idiomatic Go methods. It is intended to replace the legacy []byte config API.
+type SessionConfig struct {
+	config *corepb.ConfigProto
+}
+
+// NewSessionConfig creates a new SessionConfig with default settings.
+// Returns a pointer to a SessionConfig struct ready for further configuration.
+func NewSessionConfig() *SessionConfig {
+	return &SessionConfig{
+		config: &corepb.ConfigProto{},
+	}
+}
+
+// SetIntraOpParallelismThreads sets the number of threads used for parallelizing individual operations.
+// This controls intra-op parallelism. A value of 0 lets TensorFlow pick an appropriate default.
+func (sc *SessionConfig) SetIntraOpParallelismThreads(threads int32) *SessionConfig {
+	sc.config.IntraOpParallelismThreads = threads
+	return sc
+}
+
+// SetInterOpParallelismThreads sets the number of threads used for parallelizing independent operations.
+// This controls inter-op parallelism. A value of 0 lets TensorFlow pick an appropriate default.
+func (sc *SessionConfig) SetInterOpParallelismThreads(threads int32) *SessionConfig {
+	sc.config.InterOpParallelismThreads = threads
+	return sc
+}
+
+// SetGPUOptions sets the GPUOptions for this session configuration.
+// Use the GPUOptions builder to construct the options before passing them here.
+func (sc *SessionConfig) SetGPUOptions(options *GPUOptions) *SessionConfig {
+	sc.config.GpuOptions = options.proto
+	return sc
+}
+
+// SetAllowSoftPlacement enables or disables soft device placement.
+// When enabled, operations will be placed on CPU if no GPU implementation is available.
+func (sc *SessionConfig) SetAllowSoftPlacement(allow bool) *SessionConfig {
+	sc.config.AllowSoftPlacement = allow
+	return sc
+}
+
+// SetLogDevicePlacement enables or disables logging of device placement decisions.
+func (sc *SessionConfig) SetLogDevicePlacement(log bool) *SessionConfig {
+	sc.config.LogDevicePlacement = log
+	return sc
+}
+
+// ToBytes serializes the session configuration to a byte slice suitable for use with the TensorFlow C API.
+// Returns the serialized protobuf or an error if serialization fails.
+func (sc *SessionConfig) ToBytes() ([]byte, error) {
+	return proto.Marshal(sc.config)
+}
+
+// GPUOptions provides a builder-style API for configuring GPU-specific session options.
+// This struct wraps the generated GPUOptions protobuf.
+type GPUOptions struct {
+	proto *corepb.GPUOptions
+}
+
+// NewGPUOptions creates a new GPUOptions struct with default settings.
+// Returns a pointer to a GPUOptions struct ready for further configuration.
+func NewGPUOptions() *GPUOptions {
+	return &GPUOptions{
+		proto: &corepb.GPUOptions{},
+	}
+}
+
+// SetPerProcessGPUMemoryFraction sets the fraction of GPU memory to allocate per process.
+// 1.0 means allocate all memory, 0.5 means allocate 50%, etc.
+func (goOpts *GPUOptions) SetPerProcessGPUMemoryFraction(fraction float64) *GPUOptions {
+	goOpts.proto.PerProcessGpuMemoryFraction = fraction
+	return goOpts
+}
+
+// SetAllowGrowth enables or disables incremental GPU memory allocation.
+// When enabled, TensorFlow will allocate memory as needed rather than pre-allocating all memory.
+func (goOpts *GPUOptions) SetAllowGrowth(allow bool) *GPUOptions {
+	goOpts.proto.AllowGrowth = allow
+	return goOpts
+}
+
+// SetAllocatorType sets the GPU memory allocator type (e.g., "BFC" for best-fit with coalescing).
+func (goOpts *GPUOptions) SetAllocatorType(allocatorType string) *GPUOptions {
+	goOpts.proto.AllocatorType = allocatorType
+	return goOpts
+}
+
+// SetVisibleDeviceList sets the list of visible GPU devices (e.g., "0,1").
+// This is similar to setting CUDA_VISIBLE_DEVICES.
+func (goOpts *GPUOptions) SetVisibleDeviceList(deviceList string) *GPUOptions {
+	goOpts.proto.VisibleDeviceList = deviceList
+	return goOpts
+}

--- a/tensorflow/go/session_config_test.go
+++ b/tensorflow/go/session_config_test.go
@@ -1,8 +1,17 @@
 /*
-Author: KleaSCM
-Email: KleaSCM@gmail.com
-File: session_config_test.go
-Description: Tests for the type-safe SessionConfig and GPUOptions APIs in TensorFlow Go bindings. Ensures correct configuration, serialization, and backward compatibility with the legacy []byte config.
+Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package tensorflow

--- a/tensorflow/go/session_config_test.go
+++ b/tensorflow/go/session_config_test.go
@@ -1,0 +1,77 @@
+/*
+Author: KleaSCM
+Email: KleaSCM@gmail.com
+File: session_config_test.go
+Description: Tests for the type-safe SessionConfig and GPUOptions APIs in TensorFlow Go bindings. Ensures correct configuration, serialization, and backward compatibility with the legacy []byte config.
+*/
+
+package tensorflow
+
+import (
+	"testing"
+)
+
+// TestSessionConfig_Builder tests the builder pattern for SessionConfig and GPUOptions.
+// It verifies that options are set correctly and serialization succeeds.
+func TestSessionConfig_Builder(t *testing.T) {
+	cfg := NewSessionConfig().
+		SetIntraOpParallelismThreads(2).
+		SetInterOpParallelismThreads(4).
+		SetAllowSoftPlacement(true).
+		SetLogDevicePlacement(true).
+		SetGPUOptions(
+			NewGPUOptions().
+				SetPerProcessGPUMemoryFraction(0.5).
+				SetAllowGrowth(true).
+				SetAllocatorType("BFC").
+				SetVisibleDeviceList("0,1"),
+		)
+
+	bytes, err := cfg.ToBytes()
+	if err != nil {
+		t.Fatalf("SessionConfig.ToBytes() failed: %v", err)
+	}
+	if len(bytes) == 0 {
+		t.Error("SessionConfig.ToBytes() returned empty bytes")
+	}
+}
+
+// TestSessionOptions_NewAPI tests that SessionOptions works with the new SessionConfig API.
+func TestSessionOptions_NewAPI(t *testing.T) {
+	cfg := NewSessionConfig().SetIntraOpParallelismThreads(1)
+	opts := NewSessionOptions().SetConfig(cfg)
+	if opts.SessionConfig == nil {
+		t.Error("SessionOptions.SessionConfig should not be nil when set")
+	}
+	if opts.Config != nil {
+		t.Error("SessionOptions.Config should be nil when using new API")
+	}
+	_, err := opts.SessionConfig.ToBytes()
+	if err != nil {
+		t.Errorf("SessionConfig.ToBytes() failed: %v", err)
+	}
+}
+
+// TestSessionOptions_LegacyAPI tests that SessionOptions still works with the legacy []byte config.
+func TestSessionOptions_LegacyAPI(t *testing.T) {
+	// This is a minimal valid ConfigProto serialization for testing.
+	legacyBytes := []byte("(\x01")
+	opts := NewSessionOptions().SetConfigBytes(legacyBytes)
+	if opts.Config == nil {
+		t.Error("SessionOptions.Config should not be nil when set with legacy API")
+	}
+	if opts.SessionConfig != nil {
+		t.Error("SessionOptions.SessionConfig should be nil when using legacy API")
+	}
+}
+
+// ExampleSessionConfig demonstrates how to use the new SessionConfig API.
+//
+// This example is for documentation and does not run as a test.
+func ExampleSessionConfig() {
+	cfg := NewSessionConfig().
+		SetIntraOpParallelismThreads(2).
+		SetGPUOptions(NewGPUOptions().SetAllowGrowth(true))
+	_ = cfg // Use cfg with SessionOptions
+	// Output:
+}


### PR DESCRIPTION
## Problem
The current TensorFlow Go bindings cannot specify session options using pure Go code. Users must create binary representations of ConfigProto protocol buffers outside the Go API, as demonstrated in `session_test.go`. This creates a poor developer experience and makes session configuration error-prone.

## Solution
This PR adds a type-safe, modular Go API for configuring TensorFlow sessions by:

1. **Enabling Go protobuf generation** for core TensorFlow protobufs (ConfigProto, GPUOptions, etc.)
2. **Adding `SessionConfig` and `GPUOptions` structs** with builder-style APIs
3. **Updating `SessionOptions`** to support both new type-safe API and legacy []byte API
4. **Adding comprehensive unit tests** for the new functionality
5. **Maintaining full backward compatibility** with existing code

## Changes
- Modified `tensorflow/core/protobuf/BUILD` to enable Go protobuf generation
- Added `tensorflow/go/core/protobuf/BUILD` for Go protobuf library target
- Created `tensorflow/go/session_config.go` with type-safe configuration API
- Updated `tensorflow/go/session.go` to support new API while maintaining compatibility
- Added `tensorflow/go/session_config_test.go` with comprehensive tests
- Updated `tensorflow/go/BUILD` to include Go test target
- Added detailed documentation in `Docs/` directory

## Example Usage
```go
cfg := NewSessionConfig().
    SetIntraOpParallelismThreads(2).
    SetGPUOptions(NewGPUOptions().SetAllowGrowth(true))

opts := NewSessionOptions().SetConfig(cfg)
session, err := NewSession(graph, opts)
```

## Testing
- Added unit tests covering builder patterns, serialization, and API interactions
- Maintains backward compatibility with existing []byte config approach
- Unit tests added abd ready for CI validation

## Related Issues
Fixes the long-standing issue where Go developers cannot specify GPUOptions or other session configurations using native Go code.

## Breaking Changes
None - this is a purely additive change that maintains full backward compatibility.
