### PR TITLE
Remove unused variable in ResizeBilinear888Uint8

### DIFF
--- a/tensorflow/lite/kernels/internal/optimized/resize_bilinear.h
+++ b/tensorflow/lite/kernels/internal/optimized/resize_bilinear.h
@@ -964,7 +964,6 @@ inline void ResizeBilinear888Uint8(int32_t batches, int32_t input_height,
 
         // Main central body.
         int16 wdelta_c;
-        int16 wdelta_twice_c;
         int16 hwdelta_c;
         int16 hwdelta_twice_c;
 
@@ -991,7 +990,6 @@ inline void ResizeBilinear888Uint8(int32_t batches, int32_t input_height,
                            input_base_ptr[c_block + c + depth * (j + 1)] -
                            input_base_ptr[c_block + c + depth * j])
                        << 4;
-            wdelta_twice_c = wdelta_c << 1;
             hwdelta_c = static_cast<uint16>(
                 input_base_ptr[c_block + c + depth * (j + 1) +
                                input_row_stride] -


### PR DESCRIPTION
This fixes -Wunused-but-set-variable warning on recent Clang versions.