### PR TITLE
Fix: Remove dangling reference to ExperimentalTFLiteToTosaBytecode

### DIFF
--- a/tensorflow/python/compiler/mlir/mlir.py
+++ b/tensorflow/python/compiler/mlir/mlir.py
@@ -176,31 +176,3 @@ def experimental_write_bytecode(filename, mlir_txt):
     mlir_txt: The MLIR module in textual format.
   """
   pywrap_mlir.experimental_write_bytecode(filename, mlir_txt)
-
-
-@tf_export('mlir.experimental.tflite_to_tosa_bytecode')
-def tflite_to_tosa_bytecode(
-    flatbuffer,
-    bytecode,
-    use_external_constant=False,
-    ordered_input_arrays=None,
-    ordered_output_arrays=None,
-):
-  """Converts TFLite flatbuffer to TOSA dialect in MLIR bytecode.
-
-  Args:
-    flatbuffer: Path to flatbuffer.
-    bytecode: Path to output bytecode.
-    use_external_constant: Whether to create `tfl.external_const` instead of
-      `tfl.const`.
-    ordered_input_arrays:
-    ordered_output_arrays: If ordered_output_arrays is not empty, then the
-      function will only return nodes in ordered_output_arrays in the same order
-  """
-  pywrap_mlir.experimental_tflite_to_tosa_bytecode(
-      flatbuffer,
-      bytecode,
-      use_external_constant,
-      ordered_input_arrays,
-      ordered_output_arrays,
-  )

--- a/tensorflow/python/pywrap_mlir.py
+++ b/tensorflow/python/pywrap_mlir.py
@@ -107,22 +107,3 @@ def experimental_run_pass_pipeline(mlir_txt, pass_pipeline, show_debug_info):
 
 def experimental_write_bytecode(filename, mlir_txt):
   return ExperimentalWriteBytecode(filename.encode('utf-8'), mlir_txt.encode())
-
-
-def experimental_tflite_to_tosa_bytecode(flatbuffer, bytecode):
-    raise NotImplementedError("This function has been removed. Please refer to TensorFlow documentation for TOSA conversion.")
-    use_external_constant=False,
-    ordered_input_arrays=None,
-    ordered_output_arrays=None,
-):
-  if ordered_input_arrays is None:
-    ordered_input_arrays = []
-  if ordered_output_arrays is None:
-    ordered_output_arrays = []
-  return ExperimentalTFLiteToTosaBytecode(
-      flatbuffer.encode('utf-8'),
-      bytecode.encode('utf-8'),
-      use_external_constant,
-      ordered_input_arrays,
-      ordered_output_arrays,
-  )

--- a/tensorflow/python/pywrap_mlir.py
+++ b/tensorflow/python/pywrap_mlir.py
@@ -109,9 +109,8 @@ def experimental_write_bytecode(filename, mlir_txt):
   return ExperimentalWriteBytecode(filename.encode('utf-8'), mlir_txt.encode())
 
 
-def experimental_tflite_to_tosa_bytecode(
-    flatbuffer,
-    bytecode,
+def experimental_tflite_to_tosa_bytecode(flatbuffer, bytecode):
+    raise NotImplementedError("This function has been removed. Please refer to TensorFlow documentation for TOSA conversion.")
     use_external_constant=False,
     ordered_input_arrays=None,
     ordered_output_arrays=None,

--- a/tensorflow/tools/api/golden/v1/tensorflow.mlir.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.mlir.experimental.pbtxt
@@ -21,10 +21,6 @@ tf_module {
     argspec: "args=[\'mlir_txt\', \'pass_pipeline\', \'show_debug_info\'], varargs=None, keywords=None, defaults=[\'False\'], "
   }
   member_method {
-    name: "tflite_to_tosa_bytecode"
-    argspec: "args=[\'flatbuffer\', \'bytecode\', \'use_external_constant\', \'ordered_input_arrays\', \'ordered_output_arrays\'], varargs=None, keywords=None, defaults=[\'False\', \'None\', \'None\'], "
-  }
-  member_method {
     name: "write_bytecode"
     argspec: "args=[\'filename\', \'mlir_txt\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/api/golden/v2/tensorflow.mlir.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.mlir.experimental.pbtxt
@@ -21,10 +21,6 @@ tf_module {
     argspec: "args=[\'mlir_txt\', \'pass_pipeline\', \'show_debug_info\'], varargs=None, keywords=None, defaults=[\'False\'], "
   }
   member_method {
-    name: "tflite_to_tosa_bytecode"
-    argspec: "args=[\'flatbuffer\', \'bytecode\', \'use_external_constant\', \'ordered_input_arrays\', \'ordered_output_arrays\'], varargs=None, keywords=None, defaults=[\'False\', \'None\', \'None\'], "
-  }
-  member_method {
     name: "write_bytecode"
     argspec: "args=[\'filename\', \'mlir_txt\'], varargs=None, keywords=None, defaults=None"
   }

--- a/tensorflow/tools/def_file_filter/symbols_pybind.txt
+++ b/tensorflow/tools/def_file_filter/symbols_pybind.txt
@@ -253,7 +253,6 @@ tensorflow::ExperimentalConvertSavedModelV1ToMlirLite
 tensorflow::ExperimentalConvertSavedModelV1ToMlir
 tensorflow::ExperimentalConvertSavedModelToMlir
 tensorflow::ExperimentalWriteBytecode
-tensorflow::ExperimentalTFLiteToTosaBytecode
 tensorflow::ImportGraphDef
 tensorflow::ImportFunction
 

--- a/third_party/xla/tools/def_file_filter/symbols_pybind.txt
+++ b/third_party/xla/tools/def_file_filter/symbols_pybind.txt
@@ -253,7 +253,6 @@ tensorflow::ExperimentalConvertSavedModelV1ToMlirLite
 tensorflow::ExperimentalConvertSavedModelV1ToMlir
 tensorflow::ExperimentalConvertSavedModelToMlir
 tensorflow::ExperimentalWriteBytecode
-tensorflow::ExperimentalTFLiteToTosaBytecode
 tensorflow::ImportGraphDef
 tensorflow::ImportFunction
 


### PR DESCRIPTION
Hi, Team 
This addresses the **NameError** encountered when calling **ExperimentalTFLiteToTosaBytecode()**. The underlying C++ symbol was removed in TensorFlow 2.19 but the Python helper remained leading to a dangling reference. Merged PR https://github.com/tensorflow/tensorflow/pull/83174 This change replaces the function definition with a to provide clearer feedback to users that the function is no longer available.

Fixes: #88053