### PR TITLE
Attribute exporter absl

### DIFF
--- a/third_party/xla/xla/hlo/translate/mhlo_to_hlo/BUILD
+++ b/third_party/xla/xla/hlo/translate/mhlo_to_hlo/BUILD
@@ -29,6 +29,7 @@ cc_library(
         "//xla/service:hlo_proto_cc",
         "//xla/stream_executor:dnn",
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",

--- a/third_party/xla/xla/hlo/translate/mhlo_to_hlo/attribute_exporter.cc
+++ b/third_party/xla/xla/hlo/translate/mhlo_to_hlo/attribute_exporter.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <vector>
 
 #include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "llvm/Support/LogicalResult.h"
 #include "mlir/IR/Attributes.h"

--- a/third_party/xla/xla/hlo/translate/mhlo_to_hlo/attribute_exporter.cc
+++ b/third_party/xla/xla/hlo/translate/mhlo_to_hlo/attribute_exporter.cc
@@ -330,7 +330,9 @@ std::optional<xla::OpSharding> ConvertSharding(llvm::StringRef sharding) {
 std::optional<xla::OriginalValueProto> ConvertOriginalValue(
     llvm::StringRef original_value, const xla::Shape& shape) {
   absl::StatusOr<std::shared_ptr<xla::OriginalValue>> hlo_original_value =
-      xla::ParseOriginalValue(original_value, shape);
+      xla::ParseOriginalValue(
+          absl::string_view(original_value.data(), original_value.size()),
+          shape);
   if (!hlo_original_value.ok()) {
     return std::nullopt;
   }


### PR DESCRIPTION
This allows [llvm::StringRef] to be explicitly converted to `absl::string_view`.  This was failing previously since [llvm::StringRef] only has an implicit conversion to `std::string_view`, but not to `absl::string_view`.

This change includes the BUILD file dependency updates as well as the file inclusion and an explicit construction of the `absl::string_view` within the `attribute_exporter.cc` file.

[llvm::StringRef]: https://llvm.org/doxygen/classllvm_1_1StringRef.html