### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/ops/ragged/ragged_array_ops.py
+++ b/tensorflow/python/ops/ragged/ragged_array_ops.py
@@ -1044,7 +1044,7 @@ def split(value: ragged_tensor.Ragged,
     ValueError: If `num_or_size_splits` is an `int` and less than 1.
     TypeError: If `num_or_size_splits` is not an `int` or 1-D
       list or 1-D `Tensor`.
-    InvalidArgumentError: If the `axis` of `value` cannot be exactly splitted
+    InvalidArgumentError: If the `axis` of `value` cannot be exactly split
       by `num_or_size_splits`.
     InvalidArgumentError: If `num_or_size_splits` is contains negative integers.
     InvalidArgumentError: If `num_or_size_splits`'s static shape is unknown and

--- a/tensorflow/python/ops/ragged/ragged_dispatch.py
+++ b/tensorflow/python/ops/ragged/ragged_dispatch.py
@@ -47,7 +47,7 @@ def ragged_binary_elementwise_op(op, x, y):
   if x_is_ragged and y_is_ragged:
     x, y = ragged_tensor.match_row_splits_dtypes(x, y)
 
-  # Perform broadcasting, when appropraite
+  # Perform broadcasting, when appropriate
   if ((x_is_ragged and y_is_ragged) or
       (x_is_ragged and x.flat_values.shape.ndims <= y.shape.ndims) or
       (y_is_ragged and y.flat_values.shape.ndims <= x.shape.ndims)):

--- a/tensorflow/python/ops/ragged/ragged_math_ops.py
+++ b/tensorflow/python/ops/ragged/ragged_math_ops.py
@@ -400,7 +400,7 @@ Computes the %(combination)s of elements across dimensions of a `RaggedTensor`.
     A `RaggedTensor` containing the %(combined)s values.  The returned tensor
     has the same dtype as `data`, and its shape is given by removing the
     dimensions specified in `axis` from `input_tensor.shape`.  The `ragged_rank`
-    of the returned tensor is given by substracting any ragged dimensions
+    of the returned tensor is given by subtracting any ragged dimensions
     specified in `axis` from `input_tensor.ragged_rank`.
   Raises:
     ValueError: If `axis` contains a `Tensor` whose value is not constant.
@@ -514,7 +514,7 @@ def ragged_reduce_aggregate(reduce_op,
     A `RaggedTensor` containing the reduced values.  The returned tensor
     has the same dtype as `data`, and its shape is given by removing the
     dimensions specified in `axis` from `rt_input.shape`.  The `ragged_rank`
-    of the returned tensor is given by substracting any ragged dimensions
+    of the returned tensor is given by subtracting any ragged dimensions
     specified in `axis` from `rt_input.ragged_rank`.
   Raises:
     ValueError: If `axis` contains a `Tensor` whose value is not constant.
@@ -1164,7 +1164,7 @@ def tensor_equals(self: ragged_tensor.RaggedOrDense,
     try:
       return math_ops.equal(self, other)
     except (errors.InvalidArgumentError, ValueError):
-      return False  # values are not broadcast-compatbile.
+      return False  # values are not broadcast-compatible.
 
 
 @dispatch.dispatch_for_api(math_ops.tensor_not_equals)
@@ -1179,7 +1179,7 @@ def tensor_not_equals(self: ragged_tensor.RaggedOrDense,
     try:
       return math_ops.not_equal(self, other)
     except (errors.InvalidArgumentError, ValueError):
-      return True  # values are not broadcast-compatbile.
+      return True  # values are not broadcast-compatible.
 
 
 def _use_legacy_mode_for_tensor_equality(self):

--- a/tensorflow/python/ops/structured/structured_tensor.py
+++ b/tensorflow/python/ops/structured/structured_tensor.py
@@ -1607,7 +1607,7 @@ def _dicts_to_zeros(pyval):
 def _merge_dims_generic(source, outer, inner):
   """Merges outer_axis...inner_axis into a single dimension.
 
-  If outer == inner, this is a NOOP. If inner < outer, then this fials.
+  If outer == inner, this is a NOOP. If inner < outer, then this fails.
   If inner >= source.shape.rank, then the behavior is undefined.
 
   Args:

--- a/tensorflow/python/ops/structured/structured_tensor_test.py
+++ b/tensorflow/python/ops/structured/structured_tensor_test.py
@@ -1537,7 +1537,7 @@ class StructuredTensorTest(test_util.TensorFlowTestCase,
           {"a": 12, "b": {"c": 23}},
           {("b", "c"): 7},
       ),
-      # Multipe updates.
+      # Multiple updates.
       (
           {"a": 12, "b": {"c": 23}},
           {"a": 3, ("b", "c"): 7},

--- a/tensorflow/python/ops/weak_tensor_ops_test.py
+++ b/tensorflow/python/ops/weak_tensor_ops_test.py
@@ -748,7 +748,7 @@ class WeakTensorBinaryOpsTest(
       expected_val = a_tensor / b_tensor
       reverse_expected_val = b_tensor / a_tensor
       for x, y in zip(a_list, b_list):
-        # Truediv has a dtype conversion orthagonal to our change. Therefore,
+        # Truediv has a dtype conversion orthogonal to our change. Therefore,
         # we compare our result dtype to Tensor truediv.
         expected_result_dtype = expected_val.dtype
         self.match_expected(


### PR DESCRIPTION
Hi, Team
I observed few typos in the documentation strings and I have fixed those typos so please do the needful. Thank you.