### PR TITLE
Add validation for class_weight keys in standardize_sample_or_class_weight.

### DIFF
--- a/tensorflow/python/keras/engine/BUILD
+++ b/tensorflow/python/keras/engine/BUILD
@@ -1,8 +1,7 @@
 # Description:
 #   Contains the Keras engine API (internal TensorFlow version).
 
-load("//tensorflow:py.default.bzl", "py_library")
-
+load("//tensorflow:py.default.bzl", "py_library","tf_py_test")
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
     # TODO(scottzhu): Remove non-keras deps from TF.
@@ -263,5 +262,16 @@ py_library(
         "//tensorflow/python/keras/utils:tf_utils",
         "//tensorflow/python/util:nest",
         "//third_party/py/numpy",
+    ],
+)
+tf_py_test(
+    name = "training_utils_v1_test",
+    srcs = ["training_utils_v1_test.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":engine",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python/framework:test_lib",
+        "//tensorflow/python/platform:test",
     ],
 )

--- a/tensorflow/python/keras/engine/BUILD
+++ b/tensorflow/python/keras/engine/BUILD
@@ -264,6 +264,7 @@ py_library(
         "//third_party/py/numpy",
     ],
 )
+
 tf_py_test(
     name = "training_utils_v1_test",
     srcs = ["training_utils_v1_test.py"],

--- a/tensorflow/python/keras/engine/BUILD
+++ b/tensorflow/python/keras/engine/BUILD
@@ -265,7 +265,7 @@ py_library(
     ],
 )
 
-tf_py_test(
+py_test(
     name = "training_utils_v1_test",
     srcs = ["training_utils_v1_test.py"],
     srcs_version = "PY3",
@@ -277,7 +277,7 @@ tf_py_test(
     ],
 )
 
-tf_py_test(
+py_test(
     name = "data_adapter_test",
     srcs = ["data_adapter_test.py"],
     srcs_version = "PY3",

--- a/tensorflow/python/keras/engine/BUILD
+++ b/tensorflow/python/keras/engine/BUILD
@@ -276,3 +276,16 @@ tf_py_test(
         "//tensorflow/python/platform:test",
     ],
 )
+
+tf_py_test(
+    name = "data_adapter_test",
+    srcs = ["data_adapter_test.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":data_adapter",
+        ":engine",
+        "//tensorflow/python:client_testlib",
+        "//tensorflow/python/framework:test_lib",
+        "//tensorflow/python/platform:test",
+    ],
+)

--- a/tensorflow/python/keras/engine/BUILD
+++ b/tensorflow/python/keras/engine/BUILD
@@ -273,6 +273,7 @@ py_test(
         ":engine",
         "//tensorflow/python:client_testlib",
         "//tensorflow/python/framework:test_lib",
+        "//tensorflow/python/framework:test_util",
         "//tensorflow/python/platform:test",
     ],
 )
@@ -285,7 +286,9 @@ py_test(
         ":data_adapter",
         ":engine",
         "//tensorflow/python:client_testlib",
+        "//tensorflow/python/framework:dtypes",
         "//tensorflow/python/framework:test_lib",
+        "//tensorflow/python/framework:test_util",
         "//tensorflow/python/platform:test",
     ],
 )

--- a/tensorflow/python/keras/engine/BUILD
+++ b/tensorflow/python/keras/engine/BUILD
@@ -271,9 +271,9 @@ py_test(
     srcs_version = "PY3",
     deps = [
         ":engine",
-        "//tensorflow/python:client_testlib",
+        "//tensorflow/python/platform:_pywrap_tf2",
+        "//tensorflow/python/platform:client_testlib",
         "//tensorflow/python/framework:test_lib",
-        "//tensorflow/python/framework:test_util",
         "//tensorflow/python/platform:test",
     ],
 )
@@ -285,10 +285,9 @@ py_test(
     deps = [
         ":data_adapter",
         ":engine",
-        "//tensorflow/python:client_testlib",
+        "//tensorflow/python/platform:client_testlib",
         "//tensorflow/python/framework:dtypes",
         "//tensorflow/python/framework:test_lib",
-        "//tensorflow/python/framework:test_util",
         "//tensorflow/python/platform:test",
     ],
 )

--- a/tensorflow/python/keras/engine/BUILD
+++ b/tensorflow/python/keras/engine/BUILD
@@ -1,7 +1,7 @@
 # Description:
 #   Contains the Keras engine API (internal TensorFlow version).
 
-load("//tensorflow:py.default.bzl", "py_library","tf_py_test")
+load("//tensorflow:py.default.bzl", "py_library","py_test")
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
     # TODO(scottzhu): Remove non-keras deps from TF.

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1430,7 +1430,6 @@ def _make_class_weight_map_fn(class_weight):
                       f"class indices, "
                       f"got key of type {type(key).__name__}.")
 
-  # Validate class indices are contiguous starting from 0
   class_ids = sorted(converted_class_weight.keys())
   expected_class_ids = list(range(len(class_ids)))
   if class_ids != expected_class_ids:

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1423,7 +1423,8 @@ def _make_class_weight_map_fn(class_weight):
           raise ValueError()
       except (ValueError, TypeError):
         raise ValueError(f"Invalid class_weight key: '{key}'. "
-                        f"Class weight keys must be integers representing class indices, "
+                        f"Class weight keys must be integers representing "
+                        f"class indices,"
                         f"got key of type {type(key).__name__}.")
   
   # Convert string keys to integers

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1414,45 +1414,46 @@ def _make_class_weight_map_fn(class_weight):
   """
   # Convert string keys to integers
   converted_class_weight = {}
-  for key, value in class_weight.items():
+  for key, value in class_weight.items():  # pylint: disable=unused-variable
+    # Check for complex values first
+    try:
+      tensor_val = tensor_conversion.convert_to_tensor_v2_with_dispatch(value)
+      if tensor_val.dtype.is_complex:
+        raise ValueError(
+            f"Complex class weights are not supported. "
+            f"Found complex value {value} for class {key}. "
+            f"Please use real-valued weights only.")
+    except Exception:
+      # If we can't convert to tensor, let the original error handling deal with it
+      pass
+    
+    # Convert keys to integers
     if isinstance(key, (int, numpy_compat.integer_types)):
-        converted_class_weight[key] = value
+      converted_class_weight[key] = value
     elif isinstance(key, str):
-        try:
-            int_key = int(key)
-            converted_class_weight[int_key] = value
-        except ValueError:
-            raise ValueError(f"Invalid class_weight key: '{key}'. "
-                            f"Class weight keys must be integers representing "
-                            f"class indices, "
-                            f"got key of type {type(key).__name__}.")
-    else:
+      try:
+        int_key = int(key)
+        converted_class_weight[int_key] = value
+      except ValueError:
         raise ValueError(f"Invalid class_weight key: '{key}'. "
                         f"Class weight keys must be integers representing "
                         f"class indices, "
                         f"got key of type {type(key).__name__}.")
+    else:
+      raise ValueError(f"Invalid class_weight key: '{key}'. "
+                      f"Class weight keys must be integers representing "
+                      f"class indices, "
+                      f"got key of type {type(key).__name__}.")
 
+  # Validate class indices are contiguous starting from 0
   class_ids = sorted(converted_class_weight.keys())
   expected_class_ids = list(range(len(class_ids)))
   if class_ids != expected_class_ids:
-    # Check if any class weight values are complex tensors
-    has_complex_weights = False
-    for value in converted_class_weight.values():
-      try:
-        # Convert to tensor and check if complex
-        tensor_val = tensor_conversion.convert_to_tensor_v2_with_dispatch(value)
-        if tensor_val.dtype.is_complex:
-          has_complex_weights = True
-          break
-      except:
-        pass
+    error_msg = (
+        "Expected `class_weight` to be a dict with keys from 0 to one less "
+        "than the number of classes, found {}").format(class_weight)
+    raise ValueError(error_msg)
     
-    # Only raise error if weights are not complex
-    if not has_complex_weights:
-      error_msg = (
-          "Expected `class_weight` to be a dict with keys from 0 to one less "
-          "than the number of classes, found {}").format(class_weight)
-      raise ValueError(error_msg)
   class_weight_tensor = tensor_conversion.convert_to_tensor_v2_with_dispatch(
       [converted_class_weight[int(c)] for c in class_ids]
   )

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1412,15 +1412,13 @@ def _make_class_weight_map_fn(class_weight):
     A function that can be used with `tf.data.Dataset.map` to apply class
     weighting.
   """
-  # Convert string keys to integers
   converted_class_weight = {}
-  for key, value in class_weight.items():    # Convert keys to integers
+  for key, value in class_weight.items():
     if isinstance(key, (int, numpy_compat.integer_types)):
       converted_class_weight[key] = value
     elif isinstance(key, str):
       try:
-        int_key = int(key)
-        converted_class_weight[int_key] = value
+        converted_class_weight[int(key)] = value
       except ValueError:
         raise ValueError(f"Invalid class_weight key: '{key}'. "
                         f"Class weight keys must be integers representing "
@@ -1442,7 +1440,7 @@ def _make_class_weight_map_fn(class_weight):
     raise ValueError(error_msg)
 
   class_weight_tensor = tensor_conversion.convert_to_tensor_v2_with_dispatch(
-      [converted_class_weight[int(c)] for c in class_ids]
+      [converted_class_weight[c] for c in class_ids]
   )
 
 

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1452,8 +1452,7 @@ def _make_class_weight_map_fn(class_weight):
     error_msg = (
         "Expected `class_weight` to be a dict with keys from 0 to one less "
         "than the number of classes, found {}").format(class_weight)
-    raise ValueError(error_msg)
-    
+    raise ValueError(error_msg) 
   class_weight_tensor = tensor_conversion.convert_to_tensor_v2_with_dispatch(
       [converted_class_weight[int(c)] for c in class_ids]
   )

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1414,7 +1414,7 @@ def _make_class_weight_map_fn(class_weight):
   """
   # Convert string keys to integers
   converted_class_weight = {}
-  for key, value in class_weight.items():  # pylint: disable=unused-variable    # Convert keys to integers
+  for key, value in class_weight.items():    # Convert keys to integers
     if isinstance(key, (int, numpy_compat.integer_types)):
       converted_class_weight[key] = value
     elif isinstance(key, str):

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1414,20 +1414,7 @@ def _make_class_weight_map_fn(class_weight):
   """
   # Convert string keys to integers
   converted_class_weight = {}
-  for key, value in class_weight.items():  # pylint: disable=unused-variable
-    # Check for complex values first
-    try:
-      tensor_val = tensor_conversion.convert_to_tensor_v2_with_dispatch(value)
-      if tensor_val.dtype.is_complex:
-        raise ValueError(
-            f"Complex class weights are not supported. "
-            f"Found complex value {value} for class {key}. "
-            f"Please use real-valued weights only.")
-    except Exception:
-      # If we can't convert to tensor, let the original error handling deal with it
-      pass
-    
-    # Convert keys to integers
+  for key, value in class_weight.items():  # pylint: disable=unused-variable    # Convert keys to integers
     if isinstance(key, (int, numpy_compat.integer_types)):
       converted_class_weight[key] = value
     elif isinstance(key, str):
@@ -1453,11 +1440,11 @@ def _make_class_weight_map_fn(class_weight):
         "Expected `class_weight` to be a dict with keys from 0 to one less "
         "than the number of classes, found {}").format(class_weight)
     raise ValueError(error_msg)
-   
+
   class_weight_tensor = tensor_conversion.convert_to_tensor_v2_with_dispatch(
       [converted_class_weight[int(c)] for c in class_ids]
   )
- 
+
 
   def _class_weights_map_fn(*data):
     """Convert `class_weight` to `sample_weight`."""

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1452,13 +1452,13 @@ def _make_class_weight_map_fn(class_weight):
     error_msg = (
         "Expected `class_weight` to be a dict with keys from 0 to one less "
         "than the number of classes, found {}").format(class_weight)
-    raise ValueError(error_msg) 
-  
+    raise ValueError(error_msg)
+   
   class_weight_tensor = tensor_conversion.convert_to_tensor_v2_with_dispatch(
       [converted_class_weight[int(c)] for c in class_ids]
   )
  
- 
+
   def _class_weights_map_fn(*data):
     """Convert `class_weight` to `sample_weight`."""
     x, y, sw = unpack_x_y_sample_weight(data)

--- a/tensorflow/python/keras/engine/data_adapter.py
+++ b/tensorflow/python/keras/engine/data_adapter.py
@@ -1453,11 +1453,12 @@ def _make_class_weight_map_fn(class_weight):
         "Expected `class_weight` to be a dict with keys from 0 to one less "
         "than the number of classes, found {}").format(class_weight)
     raise ValueError(error_msg) 
+  
   class_weight_tensor = tensor_conversion.convert_to_tensor_v2_with_dispatch(
       [converted_class_weight[int(c)] for c in class_ids]
   )
  
-
+ 
   def _class_weights_map_fn(*data):
     """Convert `class_weight` to `sample_weight`."""
     x, y, sw = unpack_x_y_sample_weight(data)

--- a/tensorflow/python/keras/engine/data_adapter_test.py
+++ b/tensorflow/python/keras/engine/data_adapter_test.py
@@ -42,13 +42,13 @@ class DataAdapterTest(test.TestCase):
   def test_make_class_weight_map_fn_complex_weights_rejected(self):
     """Test that complex class weights are explicitly rejected."""
     with self.assertRaisesRegex(
-        ValueError, 
+        ValueError,
         "Complex class weights are not supported"):
       data_adapter._make_class_weight_map_fn({
           0: complex(1.0, 0.0),
           1: complex(2.0, 0.0)
       })
-    
+
     # Also test with TensorFlow complex types
     with self.assertRaisesRegex(
         ValueError,
@@ -63,7 +63,7 @@ class DataAdapterTest(test.TestCase):
     # Test with integer keys
     fn = data_adapter._make_class_weight_map_fn({0: 1.0, 1: 2.0, 2: 0.5})
     self.assertTrue(callable(fn))
-    
+
     # Test with string keys that convert to integers
     fn = data_adapter._make_class_weight_map_fn({'0': 1.0, '1': 2.0})
     self.assertTrue(callable(fn))

--- a/tensorflow/python/keras/engine/data_adapter_test.py
+++ b/tensorflow/python/keras/engine/data_adapter_test.py
@@ -15,7 +15,6 @@
 """Tests for tensorflow.python.keras.engine.data_adapter."""
 
 from tensorflow.python.framework import dtypes
-from tensorflow.python.framework import test_util
 from tensorflow.python.keras.engine import data_adapter
 from tensorflow.python.platform import test
 

--- a/tensorflow/python/keras/engine/data_adapter_test.py
+++ b/tensorflow/python/keras/engine/data_adapter_test.py
@@ -14,8 +14,8 @@
 # ==============================================================================
 """Tests for tensorflow.python.keras.engine.data_adapter."""
 
-import tensorflow as tf
-
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import test_util
 from tensorflow.python.keras.engine import data_adapter
 from tensorflow.python.platform import test
 
@@ -54,8 +54,8 @@ class DataAdapterTest(test.TestCase):
         ValueError,
         "Complex class weights are not supported"):
       data_adapter._make_class_weight_map_fn({
-          0: tf.complex64(1.0 + 0j),
-          1: tf.complex64(2.0 + 0j)
+          0: dtypes.complex64(1.0 + 0j),
+          1: dtypes.complex64(2.0 + 0j)
       })
 
   def test_make_class_weight_map_fn_valid_contiguous_keys(self):
@@ -105,4 +105,4 @@ class DataAdapterTest(test.TestCase):
 
 
 if __name__ == '__main__':
-  tf.test.main()
+  test.main()

--- a/tensorflow/python/keras/engine/data_adapter_test.py
+++ b/tensorflow/python/keras/engine/data_adapter_test.py
@@ -1,0 +1,108 @@
+# Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for tensorflow.python.keras.engine.data_adapter."""
+
+import tensorflow as tf
+
+from tensorflow.python.keras.engine import data_adapter
+from tensorflow.python.platform import test
+
+
+class DataAdapterTest(test.TestCase):
+  """Test class for data_adapter module functions."""
+
+  def test_make_class_weight_map_fn_valid_class_weight(self):
+    """Test valid integer and string keys in class_weight are processed correctly."""
+    fn = data_adapter._make_class_weight_map_fn({'0': 0.5, 1: 1.5})
+    self.assertTrue(callable(fn))  # Should return a function
+
+  def test_make_class_weight_map_fn_invalid_key_type(self):
+    """Test that float class_weight key raises ValueError."""
+    with self.assertRaisesRegex(ValueError, "Invalid class_weight key.*0.5"):
+      data_adapter._make_class_weight_map_fn({0.5: 1.0})
+
+  def test_make_class_weight_map_fn_non_contiguous_keys(self):
+    """Test that non-contiguous integer keys raise ValueError."""
+    with self.assertRaisesRegex(ValueError,
+                                "Expected `class_weight` to be a dict.*"):
+      data_adapter._make_class_weight_map_fn({0: 0.3, 2: 0.7})
+
+  def test_make_class_weight_map_fn_complex_weights_rejected(self):
+    """Test that complex class weights are explicitly rejected."""
+    with self.assertRaisesRegex(
+        ValueError, 
+        "Complex class weights are not supported"):
+      data_adapter._make_class_weight_map_fn({
+          0: complex(1.0, 0.0),
+          1: complex(2.0, 0.0)
+      })
+    
+    # Also test with TensorFlow complex types
+    with self.assertRaisesRegex(
+        ValueError,
+        "Complex class weights are not supported"):
+      data_adapter._make_class_weight_map_fn({
+          0: tf.complex64(1.0 + 0j),
+          1: tf.complex64(2.0 + 0j)
+      })
+
+  def test_make_class_weight_map_fn_valid_contiguous_keys(self):
+    """Test that valid contiguous keys work correctly."""
+    # Test with integer keys
+    fn = data_adapter._make_class_weight_map_fn({0: 1.0, 1: 2.0, 2: 0.5})
+    self.assertTrue(callable(fn))
+    
+    # Test with string keys that convert to integers
+    fn = data_adapter._make_class_weight_map_fn({'0': 1.0, '1': 2.0})
+    self.assertTrue(callable(fn))
+
+  def test_make_class_weight_map_fn_invalid_string_keys(self):
+    """Test that invalid string keys raise ValueError."""
+    with self.assertRaisesRegex(ValueError, "Invalid class_weight key"):
+      data_adapter._make_class_weight_map_fn({'invalid': 1.0, '1': 2.0})
+
+  def test_make_class_weight_map_fn_mixed_valid_keys(self):
+    """Test that mixing valid integer and string keys works."""
+    fn = data_adapter._make_class_weight_map_fn({0: 1.0, '1': 2.0, 2: 0.5})
+    self.assertTrue(callable(fn))
+
+  def test_make_class_weight_map_fn_empty_dict(self):
+    """Test that empty class_weight dict raises appropriate error."""
+    with self.assertRaises(ValueError):
+      data_adapter._make_class_weight_map_fn({})
+
+  def test_make_class_weight_map_fn_single_class(self):
+    """Test that single class weight works correctly."""
+    fn = data_adapter._make_class_weight_map_fn({0: 1.5})
+    self.assertTrue(callable(fn))
+
+  def test_make_class_weight_map_fn_none_values(self):
+    """Test that None values in class_weight raise appropriate error."""
+    with self.assertRaises((ValueError, TypeError)):
+      data_adapter._make_class_weight_map_fn({0: None, 1: 2.0})
+
+  def test_make_class_weight_map_fn_negative_weights(self):
+    """Test that negative weights are handled (should work for mathematical validity)."""
+    fn = data_adapter._make_class_weight_map_fn({0: -1.0, 1: 2.0})
+    self.assertTrue(callable(fn))
+
+  def test_make_class_weight_map_fn_zero_weights(self):
+    """Test that zero weights work correctly."""
+    fn = data_adapter._make_class_weight_map_fn({0: 0.0, 1: 1.0})
+    self.assertTrue(callable(fn))
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow/python/keras/engine/training_utils_v1.py
+++ b/tensorflow/python/keras/engine/training_utils_v1.py
@@ -687,7 +687,7 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
   if x_weight is None or (isinstance(x_weight, (list, tuple)) and
                           len(x_weight) == 0):  # pylint: disable=g-explicit-length-test
     return [None for _ in output_names]
-  
+
   if len(output_names) == 1:
     if isinstance(x_weight, (list, tuple)) and len(x_weight) == 1:
       return x_weight
@@ -713,7 +713,7 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
                          f"Class weight keys must be integers representing "
                          f"class indices or valid output names for single-output models. "
                          f"Got key of type {type(key).__name__}.")
-      
+
       if output_names[0] in x_weight:
         return [x_weight[output_names[0]]]
       else:
@@ -744,11 +744,11 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
                   raise ValueError()
               except (ValueError, TypeError):
                 raise ValueError(f"Invalid class_weight key: '{key}' for "
-                               f"output '{name}'. " 
+                               f"output '{name}'. "
                                f"Class weight keys must be integers "
                                f"representing class indices, "
                                f"got key of type {type(key).__name__}.")
-    
+
     for name in output_names:
       if name not in x_weight:
         raise ValueError('Output "' + name + '" missing from `' +

--- a/tensorflow/python/keras/engine/training_utils_v1.py
+++ b/tensorflow/python/keras/engine/training_utils_v1.py
@@ -692,24 +692,11 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
     if isinstance(x_weight, (list, tuple)) and len(x_weight) == 1:
       return x_weight
     if isinstance(x_weight, dict):
-      # Check for unsupported complex class weights (consistent with data_adapter.py)
-      if weight_type == 'class_weight':
-        for key, value in x_weight.items():
-          try:
-            tensor_val = tensor_conversion.convert_to_tensor_v2_with_dispatch(value)
-            if tensor_val.dtype.is_complex:
-              raise ValueError(
-                  f"Complex class weights are not supported. "
-                  f"Found complex value {value} for class {key}. "
-                  f"Please use real-valued weights only.")
-          except Exception:
-            pass
-      
       # Validate class_weight keys
       if weight_type == 'class_weight':
         for key in x_weight.keys():
           # Allow integer keys (class indices)
-          if isinstance(key, (int, type(0))):
+          if isinstance(key, (int, numpy_compat.integer_types)):
             continue
           # Allow output names for single-output models
           elif isinstance(key, str) and key in output_names:
@@ -744,21 +731,6 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
                        'array per model output.')
     return x_weight
   if isinstance(x_weight, dict):
-    # Check for unsupported complex class weights (consistent with data_adapter.py)
-    if weight_type == 'class_weight':
-      for name in output_names:
-        if name in x_weight and isinstance(x_weight[name], dict):
-          for key, value in x_weight[name].items():
-            try:
-              tensor_val = tensor_conversion.convert_to_tensor_v2_with_dispatch(value)
-              if tensor_val.dtype.is_complex:
-                raise ValueError(
-                    f"Complex class weights are not supported. "
-                    f"Found complex value {value} for class {key} in output '{name}'. "
-                    f"Please use real-valued weights only.")
-            except Exception:
-              pass
-    
     # Validate class_weight keys for multiple outputs
     if weight_type == 'class_weight':
       for name in output_names:

--- a/tensorflow/python/keras/engine/training_utils_v1.py
+++ b/tensorflow/python/keras/engine/training_utils_v1.py
@@ -693,19 +693,23 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
       return x_weight
     if isinstance(x_weight, dict):
       if weight_type == 'class_weight':
+        converted_class_weight = {}
         for key, value in x_weight.items():
           if isinstance(key, (int, numpy_compat.integer_types)):
-            continue
+            converted_class_weight[key] = value
           elif isinstance(key, str):
             try:
-              int(key)
-              continue
+              converted_class_weight[int(key)] = value
             except ValueError:
-              pass
-          raise ValueError(f"Invalid class_weight key: '{key}'. "
-                         f"Class weight keys must be integers representing "
-                         f"class indices, "
-                         f"got key of type {type(key).__name__}.")
+              raise ValueError(f"Invalid class_weight key: '{key}'. "
+                             f"Class weight keys must be integers representing "
+                             f"class indices, "
+                             f"got key of type {type(key).__name__}.")
+          else:
+            raise ValueError(f"Invalid class_weight key: '{key}'. "
+                           f"Class weight keys must be integers representing "
+                           f"class indices, "
+                           f"got key of type {type(key).__name__}.")
 
       if output_names[0] in x_weight:
         return [x_weight[output_names[0]]]
@@ -714,7 +718,6 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
     else:
       return [x_weight]
 
-  # For multiple outputs
   if isinstance(x_weight, (list, tuple)):
     if len(x_weight) != len(output_names):
       raise ValueError('Provided `' + weight_type + '` was a list of ' +
@@ -727,20 +730,25 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
     if weight_type == 'class_weight':
       for name in output_names:
         if name in x_weight and isinstance(x_weight[name], dict):
+          converted_class_weight = {}
           for key, value in x_weight[name].items():
             if isinstance(key, (int, numpy_compat.integer_types)):
-              continue
+              converted_class_weight[key] = value
             elif isinstance(key, str):
               try:
-                int(key)
-                continue
+                converted_class_weight[int(key)] = value
               except ValueError:
-                pass
-            raise ValueError(f"Invalid class_weight key: '{key}' for "
-                           f"output '{name}'. "
-                           f"Class weight keys must be integers "
-                           f"representing class indices, "
-                           f"got key of type {type(key).__name__}.")
+                raise ValueError(f"Invalid class_weight key: '{key}' for "
+                               f"output '{name}'. "
+                               f"Class weight keys must be integers "
+                               f"representing class indices, "
+                               f"got key of type {type(key).__name__}.")
+            else:
+              raise ValueError(f"Invalid class_weight key: '{key}' for "
+                             f"output '{name}'. "
+                             f"Class weight keys must be integers "
+                             f"representing class indices, "
+                             f"got key of type {type(key).__name__}.")
 
     for name in output_names:
       if name not in x_weight:

--- a/tensorflow/python/keras/engine/training_utils_v1.py
+++ b/tensorflow/python/keras/engine/training_utils_v1.py
@@ -685,13 +685,13 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
       ValueError: In case of invalid user-provided argument.
   """
   if x_weight is None or (isinstance(x_weight, (list, tuple)) and
-                          len(x_weight) == 0):
+                          len(x_weight) == 0): # pylint: disable=g-explicit-length-test
     return [None for _ in output_names]
 
   if len(output_names) == 1:
     if isinstance(x_weight, (list, tuple)) and len(x_weight) == 1:
       return x_weight
-    if isinstance(x_weight, dict):
+    if isinstance(x_weight, collections.abc.Mapping):
       if weight_type == 'class_weight':
         converted_class_weight = {}
         for key, value in x_weight.items():

--- a/tensorflow/python/keras/engine/training_utils_v1.py
+++ b/tensorflow/python/keras/engine/training_utils_v1.py
@@ -726,6 +726,7 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
                        'You should provide one `' + weight_type + '` '
                        'array per model output.')
     return x_weight
+
   if isinstance(x_weight, dict):
     if weight_type == 'class_weight':
       for name in output_names:

--- a/tensorflow/python/keras/engine/training_utils_v1.py
+++ b/tensorflow/python/keras/engine/training_utils_v1.py
@@ -685,25 +685,23 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
       ValueError: In case of invalid user-provided argument.
   """
   if x_weight is None or (isinstance(x_weight, (list, tuple)) and
-                          len(x_weight) == 0):  # pylint: disable=g-explicit-length-test
+                          len(x_weight) == 0):
     return [None for _ in output_names]
 
   if len(output_names) == 1:
     if isinstance(x_weight, (list, tuple)) and len(x_weight) == 1:
       return x_weight
     if isinstance(x_weight, dict):
-      # Validate class_weight keys (consistent with data_adapter.py)
       if weight_type == 'class_weight':
         for key, value in x_weight.items():
           if isinstance(key, (int, numpy_compat.integer_types)):
             continue
           elif isinstance(key, str):
             try:
-              int(key)  # Valid if it's a string number like "0", "1"
+              int(key)
               continue
             except ValueError:
               pass
-          # Reject everything else
           raise ValueError(f"Invalid class_weight key: '{key}'. "
                          f"Class weight keys must be integers representing "
                          f"class indices, "
@@ -726,7 +724,6 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
                        'array per model output.')
     return x_weight
   if isinstance(x_weight, dict):
-    # Validate class_weight keys for multiple outputs (consistent with data_adapter.py)
     if weight_type == 'class_weight':
       for name in output_names:
         if name in x_weight and isinstance(x_weight[name], dict):
@@ -739,11 +736,11 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
                 continue
               except ValueError:
                 pass
-              raise ValueError(f"Invalid class_weight key: '{key}' for "
-                             f"output '{name}'. "
-                             f"Class weight keys must be integers "
-                             f"representing class indices, "
-                             f"got key of type {type(key).__name__}.")
+            raise ValueError(f"Invalid class_weight key: '{key}' for "
+                           f"output '{name}'. "
+                           f"Class weight keys must be integers "
+                           f"representing class indices, "
+                           f"got key of type {type(key).__name__}.")
 
     for name in output_names:
       if name not in x_weight:
@@ -760,7 +757,6 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
                        '` should be either a list or a dict. '
                        'Provided `' + weight_type + '` type: ' +
                        str(type(x_weight)))
-
 def standardize_class_weights(class_weight, output_names):
   return standardize_sample_or_class_weights(class_weight, output_names,
                                              'class_weight')

--- a/tensorflow/python/keras/engine/training_utils_v1.py
+++ b/tensorflow/python/keras/engine/training_utils_v1.py
@@ -711,7 +711,8 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
           # Reject everything else
           raise ValueError(f"Invalid class_weight key: '{key}'. "
                          f"Class weight keys must be integers representing "
-                         f"class indices or valid output names for single-output models. "
+                         f"class indices or valid output names for "
+                         f"single-output models. "
                          f"Got key of type {type(key).__name__}.")
 
       if output_names[0] in x_weight:

--- a/tensorflow/python/keras/engine/training_utils_v1.py
+++ b/tensorflow/python/keras/engine/training_utils_v1.py
@@ -710,8 +710,9 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
               pass
           # Reject everything else
           raise ValueError(f"Invalid class_weight key: '{key}'. "
-                         f"Class weight keys must be integers representing class indices, "
+                         f"Class weight keys must be integers representing "
                          f"or valid output names for single-output models. "
+                         f"class indices, "
                          f"Got key of type {type(key).__name__}.")
       
       if output_names[0] in x_weight:
@@ -743,8 +744,10 @@ def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
                 else:
                   raise ValueError()
               except (ValueError, TypeError):
-                raise ValueError(f"Invalid class_weight key: '{key}' for output '{name}'. "
-                               f"Class weight keys must be integers representing class indices, "
+                raise ValueError(f"Invalid class_weight key: '{key}' for "
+                               f"output '{name}'. " 
+                               f"Class weight keys must be integers "
+                               f"representing class indices, "
                                f"got key of type {type(key).__name__}.")
     
     for name in output_names:

--- a/tensorflow/python/keras/engine/training_utils_v1.py
+++ b/tensorflow/python/keras/engine/training_utils_v1.py
@@ -669,7 +669,6 @@ def standardize_input_data(data,
   return data
 
 
-
 def standardize_sample_or_class_weights(x_weight, output_names, weight_type):
   """Maps `sample_weight` or `class_weight` to model outputs.
 

--- a/tensorflow/python/keras/engine/training_utils_v1_test.py
+++ b/tensorflow/python/keras/engine/training_utils_v1_test.py
@@ -22,7 +22,7 @@ class TrainingUtilsV1Test(tf.test.TestCase):
 
   def test_invalid_string_class_weight_keys(self):
     """Test that invalid string keys in class_weight raise ValueError."""
-    with self.assertRaisesRegex(ValueError, 
+    with self.assertRaisesRegex(ValueError,
                                 "Invalid class_weight key.*invalid_key"):
       training_utils_v1.standardize_sample_or_class_weights(
           {'invalid_key': 1.0}, ['output'], 'class_weight')
@@ -63,14 +63,14 @@ class TrainingUtilsV1Test(tf.test.TestCase):
         'output1': {'invalid_key': 1.0, 0: 2.0},
         'output2': {0: 1.0, 1: 2.0}
     }
-    with self.assertRaisesRegex(ValueError, 
+    with self.assertRaisesRegex(ValueError,
                                 "Invalid class_weight key.*invalid_key.*"
                                 "output1"):
       training_utils_v1.standardize_sample_or_class_weights(
           class_weight, ['output1', 'output2'], 'class_weight')
-      
+
   def test_data_adapter_valid_class_weight(self):
-    """Test valid integer and string keys in class_weight are processed 
+    """Test valid integer and string keys in class_weight are processed
     correctly."""
     fn = data_adapter._make_class_weight_map_fn({'0': 0.5, 1: 1.5})
     self.assertTrue(callable(fn))  # Should return a function
@@ -82,11 +82,10 @@ class TrainingUtilsV1Test(tf.test.TestCase):
 
   def test_data_adapter_non_contiguous_keys(self):
     """Test that non-contiguous integer keys raise ValueError."""
-    with self.assertRaisesRegex(ValueError, 
+    with self.assertRaisesRegex(ValueError,
                                 "Expected `class_weight` to be a dict.*"):
-      data_adapter._make_class_weight_map_fn({0: 0.3, 2: 0.7}) 
+      data_adapter._make_class_weight_map_fn({0: 0.3, 2: 0.7})
 
 
 if __name__ == '__main__':
   tf.test.main()
-  

--- a/tensorflow/python/keras/engine/training_utils_v1_test.py
+++ b/tensorflow/python/keras/engine/training_utils_v1_test.py
@@ -16,7 +16,6 @@
 
 import tensorflow as tf
 from tensorflow.python.keras.engine import training_utils_v1
-from tensorflow.python.keras.engine import data_adapter
 
 class TrainingUtilsV1Test(tf.test.TestCase):
 

--- a/tensorflow/python/keras/engine/training_utils_v1_test.py
+++ b/tensorflow/python/keras/engine/training_utils_v1_test.py
@@ -1,0 +1,71 @@
+# Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for training_utils_v1."""
+
+import tensorflow as tf
+from tensorflow.python.keras.engine import training_utils_v1
+
+
+class TrainingUtilsV1Test(tf.test.TestCase):
+
+  def test_invalid_string_class_weight_keys(self):
+    """Test that invalid string keys in class_weight raise ValueError."""
+    with self.assertRaisesRegex(ValueError, "Invalid class_weight key.*invalid_key"):
+      training_utils_v1.standardize_sample_or_class_weights(
+          {'invalid_key': 1.0}, ['output'], 'class_weight')
+
+  def test_invalid_float_class_weight_keys(self):
+    """Test that float keys in class_weight raise ValueError."""
+    with self.assertRaisesRegex(ValueError, "Invalid class_weight key.*0.5"):
+      training_utils_v1.standardize_sample_or_class_weights(
+          {0.5: 1.0}, ['output'], 'class_weight')
+
+  def test_valid_integer_class_weight_keys(self):
+    """Test that valid integer keys work correctly."""
+    result = training_utils_v1.standardize_sample_or_class_weights(
+        {0: 1.0}, ['output'], 'class_weight')
+    self.assertIsNotNone(result)
+
+  def test_valid_string_number_class_weight_keys(self):
+    """Test that valid string number keys work correctly."""
+    result = training_utils_v1.standardize_sample_or_class_weights(
+        {'0': 1.0}, ['output'], 'class_weight')
+    self.assertIsNotNone(result)
+
+  def test_valid_output_name_class_weight_keys(self):
+    """Test that valid output names work correctly."""
+    result = training_utils_v1.standardize_sample_or_class_weights(
+        {'output': 1.0}, ['output'], 'class_weight')
+    self.assertEqual(result, [1.0])
+
+  def test_sample_weight_not_affected(self):
+    """Test that sample_weight validation is unaffected."""
+    result = training_utils_v1.standardize_sample_or_class_weights(
+        {'output': [1.0, 2.0]}, ['output'], 'sample_weight')
+    self.assertEqual(result, [[1.0, 2.0]])
+
+  def test_multi_output_invalid_class_weight_keys(self):
+    """Test invalid keys in multi-output class_weight."""
+    class_weight = {
+        'output1': {'invalid_key': 1.0, 0: 2.0},
+        'output2': {0: 1.0, 1: 2.0}
+    }
+    with self.assertRaisesRegex(ValueError, "Invalid class_weight key.*invalid_key.*output1"):
+      training_utils_v1.standardize_sample_or_class_weights(
+          class_weight, ['output1', 'output2'], 'class_weight')
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tensorflow/python/keras/engine/training_utils_v1_test.py
+++ b/tensorflow/python/keras/engine/training_utils_v1_test.py
@@ -16,7 +16,7 @@
 
 import tensorflow as tf
 from tensorflow.python.keras.engine import training_utils_v1
-
+from tensorflow.python.keras.engine import data_adapter
 
 class TrainingUtilsV1Test(tf.test.TestCase):
 
@@ -65,6 +65,21 @@ class TrainingUtilsV1Test(tf.test.TestCase):
     with self.assertRaisesRegex(ValueError, "Invalid class_weight key.*invalid_key.*output1"):
       training_utils_v1.standardize_sample_or_class_weights(
           class_weight, ['output1', 'output2'], 'class_weight')
+      
+  def test_data_adapter_valid_class_weight(self):
+    """Test valid integer and string keys in class_weight are processed correctly."""
+    fn = data_adapter._make_class_weight_map_fn({'0': 0.5, 1: 1.5})
+    self.assertTrue(callable(fn))  # Should return a function
+
+  def test_data_adapter_invalid_key_type(self):
+    """Test that float class_weight key raises ValueError."""
+    with self.assertRaisesRegex(ValueError, "Invalid class_weight key.*0.5"):
+      data_adapter._make_class_weight_map_fn({0.5: 1.0})
+
+  def test_data_adapter_non_contiguous_keys(self):
+    """Test that non-contiguous integer keys raise ValueError."""
+    with self.assertRaisesRegex(ValueError, "Expected `class_weight` to be a dict.*"):
+      data_adapter._make_class_weight_map_fn({0: 0.3, 2: 0.7}) 
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/keras/engine/training_utils_v1_test.py
+++ b/tensorflow/python/keras/engine/training_utils_v1_test.py
@@ -22,7 +22,8 @@ class TrainingUtilsV1Test(tf.test.TestCase):
 
   def test_invalid_string_class_weight_keys(self):
     """Test that invalid string keys in class_weight raise ValueError."""
-    with self.assertRaisesRegex(ValueError, "Invalid class_weight key.*invalid_key"):
+    with self.assertRaisesRegex(ValueError, 
+                                "Invalid class_weight key.*invalid_key"):
       training_utils_v1.standardize_sample_or_class_weights(
           {'invalid_key': 1.0}, ['output'], 'class_weight')
 
@@ -62,12 +63,15 @@ class TrainingUtilsV1Test(tf.test.TestCase):
         'output1': {'invalid_key': 1.0, 0: 2.0},
         'output2': {0: 1.0, 1: 2.0}
     }
-    with self.assertRaisesRegex(ValueError, "Invalid class_weight key.*invalid_key.*output1"):
+    with self.assertRaisesRegex(ValueError, 
+                                "Invalid class_weight key.*invalid_key.*"
+                                "output1"):
       training_utils_v1.standardize_sample_or_class_weights(
           class_weight, ['output1', 'output2'], 'class_weight')
       
   def test_data_adapter_valid_class_weight(self):
-    """Test valid integer and string keys in class_weight are processed correctly."""
+    """Test valid integer and string keys in class_weight are processed 
+    correctly."""
     fn = data_adapter._make_class_weight_map_fn({'0': 0.5, 1: 1.5})
     self.assertTrue(callable(fn))  # Should return a function
 
@@ -78,7 +82,8 @@ class TrainingUtilsV1Test(tf.test.TestCase):
 
   def test_data_adapter_non_contiguous_keys(self):
     """Test that non-contiguous integer keys raise ValueError."""
-    with self.assertRaisesRegex(ValueError, "Expected `class_weight` to be a dict.*"):
+    with self.assertRaisesRegex(ValueError, 
+                                "Expected `class_weight` to be a dict.*"):
       data_adapter._make_class_weight_map_fn({0: 0.3, 2: 0.7}) 
 
 

--- a/tensorflow/python/keras/engine/training_utils_v1_test.py
+++ b/tensorflow/python/keras/engine/training_utils_v1_test.py
@@ -67,5 +67,7 @@ class TrainingUtilsV1Test(tf.test.TestCase):
                                 "output1"):
       training_utils_v1.standardize_sample_or_class_weights(
           class_weight, ['output1', 'output2'], 'class_weight')
+
+
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorflow/python/keras/engine/training_utils_v1_test.py
+++ b/tensorflow/python/keras/engine/training_utils_v1_test.py
@@ -89,3 +89,4 @@ class TrainingUtilsV1Test(tf.test.TestCase):
 
 if __name__ == '__main__':
   tf.test.main()
+  

--- a/tensorflow/python/keras/engine/training_utils_v1_test.py
+++ b/tensorflow/python/keras/engine/training_utils_v1_test.py
@@ -68,24 +68,5 @@ class TrainingUtilsV1Test(tf.test.TestCase):
                                 "output1"):
       training_utils_v1.standardize_sample_or_class_weights(
           class_weight, ['output1', 'output2'], 'class_weight')
-
-  def test_data_adapter_valid_class_weight(self):
-    """Test valid integer and string keys in class_weight are processed
-    correctly."""
-    fn = data_adapter._make_class_weight_map_fn({'0': 0.5, 1: 1.5})
-    self.assertTrue(callable(fn))  # Should return a function
-
-  def test_data_adapter_invalid_key_type(self):
-    """Test that float class_weight key raises ValueError."""
-    with self.assertRaisesRegex(ValueError, "Invalid class_weight key.*0.5"):
-      data_adapter._make_class_weight_map_fn({0.5: 1.0})
-
-  def test_data_adapter_non_contiguous_keys(self):
-    """Test that non-contiguous integer keys raise ValueError."""
-    with self.assertRaisesRegex(ValueError,
-                                "Expected `class_weight` to be a dict.*"):
-      data_adapter._make_class_weight_map_fn({0: 0.3, 2: 0.7})
-
-
 if __name__ == '__main__':
   tf.test.main()

--- a/tensorflow/python/keras/engine/training_utils_v1_test.py
+++ b/tensorflow/python/keras/engine/training_utils_v1_test.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """Tests for training_utils_v1."""
 
-from tensorflow.python.framework import test_util
 from tensorflow.python.keras.engine import training_utils_v1
 from tensorflow.python.platform import test
 

--- a/tensorflow/python/keras/engine/training_utils_v1_test.py
+++ b/tensorflow/python/keras/engine/training_utils_v1_test.py
@@ -14,10 +14,11 @@
 # ==============================================================================
 """Tests for training_utils_v1."""
 
-import tensorflow as tf
+from tensorflow.python.framework import test_util
 from tensorflow.python.keras.engine import training_utils_v1
+from tensorflow.python.platform import test
 
-class TrainingUtilsV1Test(tf.test.TestCase):
+class TrainingUtilsV1Test(test.TestCase):
 
   def test_invalid_string_class_weight_keys(self):
     """Test that invalid string keys in class_weight raise ValueError."""
@@ -70,4 +71,4 @@ class TrainingUtilsV1Test(tf.test.TestCase):
 
 
 if __name__ == '__main__':
-  tf.test.main()
+  test.main()


### PR DESCRIPTION
issue #98283
Invalid class_weight silently ignored in model.fit(), no error raised

1. tensorflow/python/keras/engine/training_utils_v1.py
Modified standardize_sample_or_class_weights() function (lines ~693-720, ~745-755)
Added validation logic for both single-output and multi-output models
Validates class_weight keys while preserving sample_weight functionality
Provides detailed error messages with key type information
2. tensorflow/python/keras/engine/data_adapter.py
Enhanced _make_class_weight_map_fn() function (lines ~1412-1450)
Added validation at the data adapter level for additional safety
Added automatic conversion of valid string keys to integers
Provides consistent error messages across validation points
3. tensorflow/python/keras/engine/training_utils_v1_test.py (NEW FILE)
Comprehensive test suite covering all validation scenarios
Tests for invalid keys (strings, floats) that should be rejected
Tests for valid keys (integers, output names, string numbers) that should be accepted
Tests for multi-output model validation
Ensures sample_weight validation remains unaffected


