### PR TITLE
tf.math.abs returns inconsistent results for complex inf/nan inputs on CPU and GPU fix

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/tasks/cumsum.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/cumsum.cc
@@ -81,17 +81,10 @@ void Cumsum::GetCumsumCode(const OperationDef& op_def) {
   }
 
   if (axis_ == Axis::CHANNELS) {
-    if (definition_.precision == CalculationsPrecision::F16) {
       c += "    res.x = res.w + curr.x;\n";
       c += "    res.y = res.x + curr.y;\n";
       c += "    res.z = res.y + curr.z;\n";
       c += "    res.w = res.z + curr.w;\n";
-    } else {
-      c += "    res.x = res.w + curr.x;\n";
-      c += "    res.y = res.x + curr.y;\n";
-      c += "    res.z = res.y + curr.z;\n";
-      c += "    res.w = res.z + curr.w;\n";
-    }
   } else {
     c += "    res += curr;\n";
   }


### PR DESCRIPTION
issue #98410
Fix: Add IEEE 754 compliant template specializations for complex64 and complex128 in GPU kernels that return inf when either real or imaginary component is inf, regardless of the other component.in file cwise_ops_gpu_common.cu.h.
final outcome is in ouput the gpu will give inf rather than nan.

