### PR TITLE
FIX(tensorflow-lite) system path is prefered over TFLITE_HOST_TOOLS_DIR

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -104,7 +104,7 @@ if(${CMAKE_CROSSCOMPILING})
       ${TFLITE_HOST_TOOLS_DIR}/bin
       ${TFLITE_HOST_TOOLS_DIR}/flatbuffers-flatc/bin
       )
-  find_program(FLATC_BIN flatc PATHS ${FLATC_PATHS})
+  find_program(FLATC_BIN flatc HINTS ${FLATC_PATHS})
   if(${FLATC_BIN} STREQUAL "FLATC_BIN-NOTFOUND")
     message(FATAL_ERROR "Host 'flatc' compiler has not been found in the following locations: ${FLATC_PATHS}")
   else()


### PR DESCRIPTION
when crosscompiling, you need to provide TFLITE_HOST_TOOLS_DIR, and provide a flatc binary.
the current logic:
```cmake
  set(FLATC_PATHS
      ${TFLITE_HOST_TOOLS_DIR}
      ${TFLITE_HOST_TOOLS_DIR}/bin
      ${TFLITE_HOST_TOOLS_DIR}/flatbuffers-flatc/bin
      )
  find_program(FLATC_BIN flatc PATHS ${FLATC_PATHS})
```
[tensorflow/lite/CMakeLists.txt:102](https://github.com/tensorflow/tensorflow/blob/93f98f6bbc193da15803635d08b8122306cc2fb0/tensorflow/lite/CMakeLists.txt#L102)

prefers the systems PATH env var, as this is the behavior of find_program(... PATHS ..), causing the flatc binary in TFLITE_HOST_TOOLS_DIR, to be ignored in case e.g. flatbuffers-compiler Debian package is installed in the host (https://cmake.org/cmake/help/latest/command/find_program.html)

this PR, switches the `find_program` to "HINT", which prefers the provided FLATC_PATHS, over the PATH env var.


