### PR TITLE
Fix logic error in _none_to_default function

### DIFF
--- a/tensorflow/python/keras/regularizers.py
+++ b/tensorflow/python/keras/regularizers.py
@@ -37,7 +37,7 @@ def _check_penalty_number(x):
 
 
 def _none_to_default(inputs, default):
-  return default if inputs is None else default
+  return default if inputs is None else inputs
 
 
 class Regularizer(object):


### PR DESCRIPTION
Fixed the _none_to_default function which was incorrectly returning  'default' in both cases instead of returning 'inputs' when inputs  is not None.

The function should return the default value only when inputs is None,  otherwise return the actual inputs value.