### PR TITLE
Improve grammar in regularizer error message

### DIFF
--- a/tensorflow/python/keras/regularizers.py
+++ b/tensorflow/python/keras/regularizers.py
@@ -32,7 +32,7 @@ def _check_penalty_number(x):
   if math.isinf(x) or math.isnan(x):
     raise ValueError(
         ('Value: {} is not a valid regularization penalty number, '
-         'a positive/negative infinity or NaN is not a property value'
+         'a positive/negative infinity or NaN is not a valid property value'
         ).format(x))
 
 


### PR DESCRIPTION
Fixed grammar in error message for invalid regularization penalty numbers. Changed "is not a property value" to "is not a valid property value" for better clarity and correctness.