### PR TITLE
[oneDNN] Change public TensorFlow CPU build configuration for avx_linux and avx_win

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -531,7 +531,9 @@ build:verbose_logs --output_filter=
 #   avoid having to define linux/win separately.
 build:avx_linux --copt=-mavx
 build:avx_linux --host_copt=-mavx
+build:avx_linux --copt="-mf16c"
 build:avx_win --copt=/arch:AVX
+build:avx_win --copt="-mf16c"
 
 build:win_clang_base --@com_google_protobuf//build_defs:use_dlls=True
 build:win_clang_base --@com_google_absl//absl:use_dlls=True


### PR DESCRIPTION
This PR adds "--copt='-mf16c'" bazel option to both linux and window builds. The f16c instruction is available starting with Ivy Bridge.

Background:
TensorFlow customers found better fp16 performance with the above change.