### PR TITLE
Fix shared memory alignment in concat/split GPU kernels

### DIFF
--- a/tensorflow/core/kernels/concat_lib_gpu_impl.cu.cc
+++ b/tensorflow/core/kernels/concat_lib_gpu_impl.cu.cc
@@ -70,7 +70,10 @@ __global__ void concat_variable_kernel(
   IntType num_inputs = input_ptr_data.size;
 
   // verbose declaration needed due to template
-  GPU_DYNAMIC_SHARED_MEM_DECL(sizeof(T), unsigned char, smem);
+  constexpr size_t kAlignTI =
+      (alignof(T) > alignof(IntType)) ? alignof(T) : alignof(IntType);
+  constexpr size_t kAlign = (kAlignTI < 16) ? 16 : kAlignTI;
+  GPU_DYNAMIC_SHARED_MEM_DECL(kAlign, unsigned char, smem);
   IntType* smem_col_scan = reinterpret_cast<IntType*>(smem);
 
   if (useSmem) {

--- a/tensorflow/core/kernels/split_lib_gpu.cu.cc
+++ b/tensorflow/core/kernels/split_lib_gpu.cu.cc
@@ -120,7 +120,10 @@ __global__ void split_v_kernel(const T* __restrict__ input_ptr,
   int num_outputs = output_ptr_data.size;
 
   // verbose declaration needed due to template
-  GPU_DYNAMIC_SHARED_MEM_DECL(sizeof(T), unsigned char, smem);
+  constexpr size_t kAlignTI =
+      (alignof(T) > alignof(IntType)) ? alignof(T) : alignof(IntType);
+  constexpr size_t kAlign = (kAlignTI < 16) ? 16 : kAlignTI;
+  GPU_DYNAMIC_SHARED_MEM_DECL(kAlign, unsigned char, smem);
   IntType* smem_col_scan = reinterpret_cast<IntType*>(smem);
 
   if (useSmem) {


### PR DESCRIPTION
Align shared memory buffer to 16 bytes (or max of T and IntType) to avoid misaligned access issues on newer GPUs.

This PR corrects the dynamic shared-memory alignment used in the GPU concat/split kernels. The current code aligns the shared buffer by sizeof(T), but the same buffer is later reinterpreted as IntType*. On newer architectures (e.g., Blackwell / RTX-50 series, CC 12.0), this can yield misaligned accesses when alignof(IntType) > alignof(T), causing instability or performance penalties. This change aligns the buffer to the stricter of alignof(T) and alignof(IntType), with a minimum of 16 bytes to be safe for vectorized paths.

### Files changed
 - tensorflow/core/kernels/concat_lib_gpu_impl.cu.cc
 - tensorflow/core/kernels/split_lib_gpu.cu.cc

### Problem
In concat_variable_kernel and the corresponding split implementation, the shared buffer is declared via:
```
  GPU_DYNAMIC_SHARED_MEM_DECL(sizeof(T), unsigned char, smem);
  IntType* smem_col_scan = reinterpret_cast<IntType*>(smem);
```

If T is Eigen::half/bfloat16 (2-byte alignment) and IntType is 4 or 8 bytes, sizeof(T) does not guarantee sufficient alignment for IntType. On Blackwell (CC 12.0) this can lead to misaligned loads/stores (and, in practice, runtime instability or kernel failures depending on compiler and optimization settings).

### Proposed fix
Use the strictest alignment required by the types that will alias the buffer, with a reasonable floor for vectorized access:
```
  constexpr size_t kAlignTI = (alignof(T) > alignof(IntType)) ? alignof(T) : alignof(IntType);
  constexpr size_t kAlign   = (kAlignTI < 16) ? 16 : kAlignTI;
  GPU_DYNAMIC_SHARED_MEM_DECL(kAlign, unsigned char, smem);
  IntType* smem_col_scan = reinterpret_cast<IntType*>(smem);
```

This preserves correctness for all T/IntType combinations and avoids over-aligning beyond what’s needed.

### Testing
 - Built and ran on an RTX 5080 (compute capability 12.0) with CUDA 12.8+ toolchain.
 - Verified correctness on concat/split ops across dtypes: half, bfloat16, float, int32.
 - Bazel tests (representative targets):

```
bazel test //tensorflow/core/kernels:concat_op_test  \
           //tensorflow/core/kernels:split_op_test   \
           --config=cuda --test_output=errors
...
INFO: Analyzed 3 targets (0 packages loaded, 0 targets configured).
INFO: Found 3 test targets...
INFO: Elapsed time: 18.077s, Critical Path: 17.57s
INFO: 17 processes: 3 internal, 14 local.
INFO: Build completed successfully, 17 total actions
//tensorflow/core/kernels:concat_op_test                                 PASSED in 0.9s
//tensorflow/core/kernels:split_op_test_cpu                              PASSED in 0.9s
//tensorflow/core/kernels:split_op_test_gpu                              PASSED in 0.1s

Executed 3 out of 3 tests: 3 tests pass.
```

### Local .bazelrc additions clang17 and cuda120 definitions
```
# clang-17 toolchain (host & target use system clang/lld)
build:clang17 --repo_env=USE_HERMETIC_CC_TOOLCHAIN=0
build:clang17 --crosstool_top=@local_config_cc//:toolchain
build:clang17 --action_env=CC=/usr/bin/clang-17
build:clang17 --action_env=CXX=/usr/bin/clang++-17
build:clang17 --action_env=LD=/usr/bin/ld.lld-17
build:clang17 --host_action_env=CC=/usr/bin/clang-17
build:clang17 --host_action_env=CXX=/usr/bin/clang++-17
build:clang17 --host_action_env=LD=/usr/bin/ld.lld-17

# CUDA 12.8.x + cuDNN 9.11 for CC 12.0 (no extra --config=cuda here)
build:cuda120 --repo_env=HERMETIC_CUDA_VERSION=12.8.1
build:cuda120 --repo_env=HERMETIC_CUDNN_VERSION=9.11.0
build:cuda120 --repo_env=HERMETIC_CUDA_COMPUTE_CAPABILITIES=12.0
build:cuda120 --action_env=TF_CUDA_COMPUTE_CAPABILITIES=12.0
```
