### PR TITLE
Fix crash in tf.audio.decode_wav with invalid negative parameters

### DIFF
--- a/tensorflow/core/kernels/decode_wav_op.cc
+++ b/tensorflow/core/kernels/decode_wav_op.cc
@@ -54,6 +54,12 @@ class DecodeWavOp : public OpKernel {
                        wav_string, &decoded_samples, &decoded_sample_count,
                        &decoded_channel_count, &decoded_sample_rate));
 
+    OP_REQUIRES(context, desired_channels_ >= -1,
+                errors::InvalidArgument("desired_channels must be >= -1, got ",
+                                        desired_channels_));
+    OP_REQUIRES(context, desired_samples_ >= -1,
+                errors::InvalidArgument("desired_samples must be >= -1, got ",
+                                        desired_samples_));
     int32_t output_sample_count;
     if (desired_samples_ == -1) {
       output_sample_count = decoded_sample_count;
@@ -67,6 +73,12 @@ class DecodeWavOp : public OpKernel {
       output_channel_count = desired_channels_;
     }
 
+    OP_REQUIRES(context, output_sample_count >= 0,
+              errors::InvalidArgument("Output sample count must be >= 0, got ",
+                                      output_sample_count));
+    OP_REQUIRES(context, output_channel_count >= 0,
+              errors::InvalidArgument("Output channel count must be >= 0, got ",
+                                      output_channel_count));
     Tensor* output = nullptr;
     OP_REQUIRES_OK(
         context,

--- a/tensorflow/lite/delegates/gpu/common/tasks/cumsum.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/cumsum.cc
@@ -65,14 +65,14 @@ void Cumsum::GetCumsumCode(const OperationDef& op_def) {
   }
   c += "  int S = GLOBAL_ID_2;\n";
   c += "  if (S >= " + task_sizes[Axis::CHANNELS] + ") return;\n";
-  if (definition_.precison == CalculationsPrecision::F16) {
+  if (definition_.precision == CalculationsPrecision::F16) {
     c += "  float4 res = TO_FLOAT4(args.src_tensor::zero_value);\n";
   } else {
     c += "  args.src_tensor::type res = args.src_tensor::zero_value;\n";
   }
   c += "  for (; " + index_name[axis_] + " < " + limit + "; " +
        index_name[axis_] + "++) {\n";
-  if (definition_.precison == CalculationsPrecision::F16) {
+  if (definition_.precision == CalculationsPrecision::F16) {
     c +=
         "    float4 curr = TO_FLOAT4(args.src_tensor.Read(" + indexes + "));\n";
   } else {
@@ -81,7 +81,7 @@ void Cumsum::GetCumsumCode(const OperationDef& op_def) {
   }
 
   if (axis_ == Axis::CHANNELS) {
-    if (definition_.precison == CalculationsPrecision::F16) {
+    if (definition_.precision == CalculationsPrecision::F16) {
       c += "    res.x = res.w + curr.x;\n";
       c += "    res.y = res.x + curr.y;\n";
       c += "    res.z = res.y + curr.z;\n";

--- a/tensorflow/lite/delegates/gpu/common/tasks/cumsum.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/cumsum.cc
@@ -81,17 +81,10 @@ void Cumsum::GetCumsumCode(const OperationDef& op_def) {
   }
 
   if (axis_ == Axis::CHANNELS) {
-    if (definition_.precision == CalculationsPrecision::F16) {
       c += "    res.x = res.w + curr.x;\n";
       c += "    res.y = res.x + curr.y;\n";
       c += "    res.z = res.y + curr.z;\n";
       c += "    res.w = res.z + curr.w;\n";
-    } else {
-      c += "    res.x = res.w + curr.x;\n";
-      c += "    res.y = res.x + curr.y;\n";
-      c += "    res.z = res.y + curr.z;\n";
-      c += "    res.w = res.z + curr.w;\n";
-    }
   } else {
     c += "    res += curr;\n";
   }

--- a/tensorflow/lite/delegates/gpu/common/tasks/cumsum.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/cumsum.cc
@@ -65,20 +65,42 @@ void Cumsum::GetCumsumCode(const OperationDef& op_def) {
   }
   c += "  int S = GLOBAL_ID_2;\n";
   c += "  if (S >= " + task_sizes[Axis::CHANNELS] + ") return;\n";
-  c += "  args.src_tensor::type res = args.src_tensor::zero_value;\n";
+  if (definition_.precison == CalculationsPrecision::F16) {
+    c += "  float4 res = TO_FLOAT4(args.src_tensor::zero_value);\n";
+  } else {
+    c += "  args.src_tensor::type res = args.src_tensor::zero_value;\n";
+  }
   c += "  for (; " + index_name[axis_] + " < " + limit + "; " +
        index_name[axis_] + "++) {\n";
-  c += "    args.src_tensor::type curr = args.src_tensor.Read(" + indexes +
-       ");\n";
+  if (definition_.precison == CalculationsPrecision::F16) {
+    c +=
+        "    float4 curr = TO_FLOAT4(args.src_tensor.Read(" + indexes + "));\n";
+  } else {
+    c += "    args.src_tensor::type curr = args.src_tensor.Read(" + indexes +
+         ");\n";
+  }
+
   if (axis_ == Axis::CHANNELS) {
-    c += "    res.x = res.w + curr.x;\n";
-    c += "    res.y = res.x + curr.y;\n";
-    c += "    res.z = res.y + curr.z;\n";
-    c += "    res.w = res.z + curr.w;\n";
+    if (definition_.precison == CalculationsPrecision::F16) {
+      c += "    res.x = res.w + curr.x;\n";
+      c += "    res.y = res.x + curr.y;\n";
+      c += "    res.z = res.y + curr.z;\n";
+      c += "    res.w = res.z + curr.w;\n";
+    } else {
+      c += "    res.x = res.w + curr.x;\n";
+      c += "    res.y = res.x + curr.y;\n";
+      c += "    res.z = res.y + curr.z;\n";
+      c += "    res.w = res.z + curr.w;\n";
+    }
   } else {
     c += "    res += curr;\n";
   }
-  c += "    args.dst_tensor.Write(res, " + indexes + ");\n";
+  if (definition_.precision == CalculationsPrecision::F16) {
+    c += "    args.dst_tensor.Write(TO_FLT4(res), " + indexes + ");\n";
+  } else {
+    c += "    args.dst_tensor.Write(res, " + indexes + ");\n";
+  }
+
   c += "  }\n";
   c += "}\n";
   code_ = c;


### PR DESCRIPTION
issue:#98996
The crash happens because TensorShape expects non-negative dimensions but receives negative values ,now it has been resolved.