### PR TITLE
Parameter dtype is also optional for `tf.constant()`

### DIFF
--- a/tensorflow/python/framework/constant_op.py
+++ b/tensorflow/python/framework/constant_op.py
@@ -262,7 +262,7 @@ def constant(
 
   Args:
     value: A constant value (or list) of output type `dtype`.
-    dtype: The type of the elements of the resulting tensor.
+    dtype: Optional type of the elements of the resulting tensor.
     shape: Optional dimensions of resulting tensor.
     name: Optional name for the tensor.
 


### PR DESCRIPTION
For `tf.constant()`, the parameter `dtype` has a default value. Thus, it should also be documented as being optional.