### PR TITLE
Align TFLite CMake XNNPACK pin to upstream commit used by Bazel

### DIFF
--- a/tensorflow/lite/tools/cmake/modules/xnnpack.cmake
+++ b/tensorflow/lite/tools/cmake/modules/xnnpack.cmake
@@ -23,7 +23,7 @@ OverridableFetchContent_Declare(
   xnnpack
   GIT_REPOSITORY https://github.com/google/XNNPACK
   # Sync with tensorflow/workspace2.bzl
-  GIT_TAG 45bf06030727ce049793ce6749e943cc2ea896fe
+  GIT_TAG e757940dbdcf465fd9eb7901ce73f4ff21387663
   GIT_PROGRESS TRUE
   PREFIX "${CMAKE_BINARY_DIR}"
   SOURCE_DIR "${CMAKE_BINARY_DIR}/xnnpack"


### PR DESCRIPTION
Hi, Team
It seems like we need to align TFLite CMake XNNPACK pin to upstream commit used by Bazel at the moment `tensorflow/lite/tools/cmake/modules/xnnpack.cmake` pinned XNNPACK to `45bf06030727ce049793ce6749e943cc2ea896fe` a commit that does not exist in **google/XNNPACK** and Bazel (workspace) tracks upstream google/XNNPACK at `e757940dbdcf465fd9eb7901ce73f4ff21387663`.

At the moment I've updated CMake `GIT_TAG to e757940dbdcf465fd9eb7901ce73f4ff21387663` to match Bazel and restore the upstream source which unblocks `tensorflow/lite/tools/pip_package/build_pip_package_with_cmake.sh` builds with XNNPACK enabled. No behavioral change expected beyond fetching the correct upstream revision.

It will address below two issues :
Closes: #98967
Related: #98772

I would request you to please review this PR, if you've any feedback or suggestion please let me know that will be very helpful. Thank you for your consideration.