### PR TITLE
Support to compile TensorFlow with CUDA version 12.9.1

### DIFF
--- a/tensorflow/core/kernels/concat_lib_gpu_impl.cu.cc
+++ b/tensorflow/core/kernels/concat_lib_gpu_impl.cu.cc
@@ -70,7 +70,7 @@ __global__ void concat_variable_kernel(
   IntType num_inputs = input_ptr_data.size;
 
   // verbose declaration needed due to template
-  GPU_DYNAMIC_SHARED_MEM_DECL(sizeof(T), unsigned char, smem);
+  GPU_DYNAMIC_SHARED_MEM_DECL(8, unsigned char, smem);
   IntType* smem_col_scan = reinterpret_cast<IntType*>(smem);
 
   if (useSmem) {

--- a/tensorflow/core/kernels/dynamic_partition_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/dynamic_partition_op_gpu.cu.cc
@@ -410,7 +410,11 @@ class DynamicPartitionOpGPU : public AsyncOpKernel {
                                             num_partitions_);
 
 #if GOOGLE_CUDA
-    cub::ConstantInputIterator<int32> values_in(1);
+    #if THRUST_VERSION >= 200802
+        thrust::constant_iterator<int32> values_in(1);
+    #else
+        cub::ConstantInputIterator<int32> values_in(1);
+    #endif
 #elif TENSORFLOW_USE_ROCM
     using ConstantInputIterator =
         ::rocprim::constant_iterator<int32, ptrdiff_t>;

--- a/tensorflow/core/kernels/gpu_prim.h
+++ b/tensorflow/core/kernels/gpu_prim.h
@@ -37,8 +37,8 @@ namespace gpuprim = ::cub;
 
 // Required for sorting Eigen::half and bfloat16.
 namespace cub {
-template <>
-__device__ __forceinline__ void ThreadStoreVolatilePtr<Eigen::half>(
+
+__device__ __forceinline__ void ThreadStoreVolatilePtr(
     Eigen::half *ptr, Eigen::half val, Int2Type<true> /*is_primitive*/) {
   *reinterpret_cast<volatile uint16_t *>(ptr) =
       Eigen::numext::bit_cast<uint16_t>(val);
@@ -50,8 +50,7 @@ __device__ __forceinline__ Eigen::half ThreadLoadVolatilePointer(
   return Eigen::numext::bit_cast<Eigen::half>(result);
 }
 
-template <>
-__device__ __forceinline__ void ThreadStoreVolatilePtr<Eigen::bfloat16>(
+__device__ __forceinline__ void ThreadStoreVolatilePtr(
     Eigen::bfloat16 *ptr, Eigen::bfloat16 val,
     Int2Type<true> /*is_primitive*/) {
   *reinterpret_cast<volatile uint16_t *>(ptr) =

--- a/tensorflow/core/kernels/split_lib_gpu.cu.cc
+++ b/tensorflow/core/kernels/split_lib_gpu.cu.cc
@@ -120,7 +120,7 @@ __global__ void split_v_kernel(const T* __restrict__ input_ptr,
   int num_outputs = output_ptr_data.size;
 
   // verbose declaration needed due to template
-  GPU_DYNAMIC_SHARED_MEM_DECL(sizeof(T), unsigned char, smem);
+  GPU_DYNAMIC_SHARED_MEM_DECL(2, unsigned char, smem);
   IntType* smem_col_scan = reinterpret_cast<IntType*>(smem);
 
   if (useSmem) {

--- a/tensorflow/core/kernels/where_op_gpu.cu.h
+++ b/tensorflow/core/kernels/where_op_gpu.cu.h
@@ -233,6 +233,17 @@ class WhereOutputIterator {
     return *(ptr_ + (valid ? (NDIM * n) : 0));
   }
 
+
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE reference operator*() const {
+    // Dereference the current pointer
+    return *ptr_;
+  }
+
+
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE self_type operator+(std::ptrdiff_t n) const {
+    return self_type(ptr_ + NDIM * n, max_row_);
+  }
+
  private:
   int64* ptr_;
   const Eigen::DenseIndex max_row_;


### PR DESCRIPTION
1. cub APIs no longer supported in the newer version of CUDA.
2. Align sign mapped to datatype instead of templatizing.
3. Overloaded operator+ and pointer dereferencing.