### PR TITLE
Fixes `tf.image.decode_image(img, channels=3) throws ValueError: 'images' contains no shape.`

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3323,21 +3323,30 @@ def decode_image(contents,
   """
   with ops.name_scope(name, 'decode_image'):
     channels = 0 if channels is None else channels
+    original_dtype = dtype
     if dtype not in [dtypes.float32, dtypes.uint8, dtypes.uint16]:
-      dest_dtype = dtype
-      dtype = dtypes.uint16
-      return convert_image_dtype(
-          gen_image_ops.decode_image(
-              contents=contents,
-              channels=channels,
-              expand_animations=expand_animations,
-              dtype=dtype), dest_dtype)
+      dtype_for_decode = dtypes.uint16
     else:
-      return gen_image_ops.decode_image(
-          contents=contents,
-          channels=channels,
-          expand_animations=expand_animations,
-          dtype=dtype)
+      dtype_for_decode = dtype
+
+    image = gen_image_ops.decode_image(
+        contents=contents,
+        channels=channels,
+        expand_animations=expand_animations,
+        dtype=dtype_for_decode)
+
+    if dtype_for_decode != original_dtype:
+      image = convert_image_dtype(image, original_dtype)
+
+    if not expand_animations:
+      # If not expanding animations, the output is always 3D.
+      if channels != 0:
+        image.set_shape([None, None, channels])
+      else:
+        # We can still set the rank, which is what matters for the resize op.
+        image.set_shape([None, None, None])
+
+    return image
 
 
 @tf_export('image.total_variation')

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -6660,7 +6660,8 @@ class DecodeImageTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       self.assertTrue(shape_list[1] is None or shape_list[1] == 2)
 
       # Test different channel configurations.
-      for channels in [0, 1, 2, 3, 4]:
+      # Note: decode_image only supports channels 0, 1, 3, 4 (not 2).
+      for channels in [0, 1, 3, 4]:
         if channels == 0:
           # Use auto-detection with RGB JPEG.
           test_bytes = jpeg_bytes
@@ -6670,14 +6671,6 @@ class DecodeImageTest(test_util.TensorFlowTestCase, parameterized.TestCase):
                                            dtype=dtypes.uint8)
           gray_image = array_ops.expand_dims(gray_image, -1)
           test_bytes = gen_image_ops.encode_png(gray_image)
-        elif channels == 2:
-          # Create grayscale + alpha test image using PNG.
-          gray_alpha_image = constant_op.constant([[[128, 255],
-                                                    [64, 128]], 
-                                                   [[192, 64],
-                                                    [32, 192]]], 
-                                                  dtype=dtypes.uint8)
-          test_bytes = gen_image_ops.encode_png(gray_alpha_image)
         elif channels == 4:
           # Create RGBA test image using PNG (JPEG doesn't support 4 channels).
           rgba_image = constant_op.constant([[[255, 0, 0, 255],

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -6690,9 +6690,12 @@ class DecodeImageTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       
       # Check shape compatibility with automatic channel detection.
       shape_list_unknown = decoded_unknown.get_shape().as_list()
-      self.assertTrue(shape_list_unknown[0] is None or shape_list_unknown[0] == 2)
-      self.assertTrue(shape_list_unknown[1] is None or shape_list_unknown[1] == 2)
-      self.assertTrue(shape_list_unknown[2] is None or shape_list_unknown[2] == 3)
+      self.assertTrue(shape_list_unknown[0] is None or 
+                      shape_list_unknown[0] == 2)
+      self.assertTrue(shape_list_unknown[1] is None or 
+                      shape_list_unknown[1] == 2)
+      self.assertTrue(shape_list_unknown[2] is None or 
+                      shape_list_unknown[2] == 3)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -6636,7 +6636,7 @@ class DecodeImageTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       decoded = image_ops.decode_image(image_bytes, channels=3, 
                                        expand_animations=False)
       # This should work without ValueError due to proper shape inference
-      resized = image_ops.resize(decoded, [224, 224])
+      resized = image_ops.resize_images(decoded, [224, 224])
       return resized
 
 


### PR DESCRIPTION
1. Fix shape inference in decode_image for tf.data pipelines
2. Add test for decode_image shape inference fix

Fixes #99333