### PR TITLE
[spam] Fix linux cpu badge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ You can find more community-supported platforms and configurations in the
 
 Build Type                    | Status                                                                                                                                                                           | Artifacts
 ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------
-**Linux CPU**                 | [![Status](https://storage.googleapis.com/tensorflow-kokoro-build-badges/ubuntu-cc.svg)](https://storage.googleapis.com/tensorflow-kokoro-build-badges/ubuntu-cc.html)           | [PyPI](https://pypi.org/project/tf-nightly/)
+**Linux CPU**                 | [![Status](https://github.com/tensorflow/tensorflow/actions/workflows/pylint-presubmit.yml/badge.svg)](https://github.com/tensorflow/tensorflow/actions/workflows/pylint-presubmit.yml) | [PyPI](https://pypi.org/project/tf-nightly/) |
+
 **Linux GPU**                 | [![Status](https://storage.googleapis.com/tensorflow-kokoro-build-badges/ubuntu-gpu-py3.svg)](https://storage.googleapis.com/tensorflow-kokoro-build-badges/ubuntu-gpu-py3.html) | [PyPI](https://pypi.org/project/tf-nightly-gpu/)
 **Linux XLA**                 | [![Status](https://storage.googleapis.com/tensorflow-kokoro-build-badges/ubuntu-xla.svg)](https://storage.googleapis.com/tensorflow-kokoro-build-badges/ubuntu-xla.html)         | TBA
 **macOS**                     | [![Status](https://storage.googleapis.com/tensorflow-kokoro-build-badges/macos-py2-cc.svg)](https://storage.googleapis.com/tensorflow-kokoro-build-badges/macos-py2-cc.html)     | [PyPI](https://pypi.org/project/tf-nightly/)

--- a/cls
+++ b/cls
@@ -1,0 +1,4 @@
+  fix-docs-deprecated-args[m
+  fix/python-version-error[m
+* [32mimprove-quantize-docs[m
+  master[m


### PR DESCRIPTION
### _This PR fixes issue #99255 
 By replacing the Linux CPU Kokoro build badge in README.md with the corresponding GitHub Actions badge. The Kokoro badge linked to private logs that returned 403 errors, while the GitHub Actions badge is public and reliably displays build status with accessible logs. This improves transparency and removes broken links.