### PR TITLE
tf.image: enforce C++ rank validation in combined_non_max_suppression

### DIFF
--- a/tensorflow/core/kernels/image/non_max_suppression_op.cc
+++ b/tensorflow/core/kernels/image/non_max_suppression_op.cc
@@ -992,6 +992,18 @@ class CombinedNonMaxSuppressionOp : public OpKernel {
     const Tensor& boxes = context->input(0);
     // scores: [batch_size, num_anchors, num_classes]
     const Tensor& scores = context->input(1);
+    OP_REQUIRES(
+        context, boxes.dims() == 4,
+        absl::InvalidArgumentError(
+            absl::StrCat("boxes must be 4-D [batch, num_boxes, q, 4], "
+                         "got shape ",
+                         boxes.shape().DebugString())));
+    OP_REQUIRES(
+        context, scores.dims() == 3,
+        absl::InvalidArgumentError(
+            absl::StrCat("scores must be 3-D [batch, num_boxes, num_classes], "
+                         "got shape ",
+                         scores.shape().DebugString())));
     OP_REQUIRES(context, (boxes.dim_size(0) == scores.dim_size(0)),
                 absl::InvalidArgumentError(
                     "boxes and scores must have same batch size"));

--- a/tensorflow/python/kernel_tests/BUILD
+++ b/tensorflow/python/kernel_tests/BUILD
@@ -209,6 +209,21 @@ cuda_py_strict_test(
 )
 
 tf_py_strict_test(
+    name = "image_ops_combined_nms_shape_test",
+    size = "small",
+    srcs = ["image_ops_combined_nms_shape_test.py"],
+    deps = [
+        "//tensorflow/python/eager:def_function",
+        "//tensorflow/python/framework:dtypes",
+        "//tensorflow/python/framework:errors",
+        "//tensorflow/python/framework:tensor_spec",
+        "//tensorflow/python/ops:image_ops_impl",
+        "//tensorflow/python/ops:random_ops",
+        "//tensorflow/python/platform:client_testlib",
+    ],
+)
+
+tf_py_strict_test(
     name = "logging_ops_logging_level_test",
     size = "small",
     srcs = ["logging_ops_logging_level_test.py"],

--- a/tensorflow/python/kernel_tests/image_ops_combined_nms_shape_test.py
+++ b/tensorflow/python/kernel_tests/image_ops_combined_nms_shape_test.py
@@ -1,0 +1,76 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for input rank validation in combined_non_max_suppression."""
+
+from tensorflow.python.eager import def_function
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors_impl
+from tensorflow.python.framework import tensor_spec
+from tensorflow.python.ops import image_ops_impl
+from tensorflow.python.ops import random_ops
+from tensorflow.python.platform import test
+
+
+class CombinedNmsShapeTest(test.TestCase):
+
+  def test_boxes_wrong_static_rank_raises(self):
+    boxes = random_ops.random_uniform([4, 10, 4])  # rank-3, must be rank-4.
+    scores = random_ops.random_uniform([4, 10, 1])
+    with self.assertRaisesRegex(
+        (errors_impl.InvalidArgumentError, ValueError),
+        "(boxes must be 4-D|Shape must be rank 4)",
+    ):
+      image_ops_impl.combined_non_max_suppression(boxes, scores, 10, 10)
+
+  def test_scores_wrong_static_rank_raises(self):
+    boxes = random_ops.random_uniform([4, 10, 1, 4])
+    scores = random_ops.random_uniform([4, 10])  # rank-2, must be rank-3.
+    with self.assertRaisesRegex(
+        (errors_impl.InvalidArgumentError, ValueError),
+        "(scores must be 3-D|Shape must be rank 3)",
+    ):
+      image_ops_impl.combined_non_max_suppression(boxes, scores, 10, 10)
+
+  def test_wrong_dynamic_rank_triggers_kernel_validation(self):
+    # Unknown-rank input signatures bypass static shape inference, so the
+    # rank checks in the C++ kernel are what raises here.
+    @def_function.function(
+        input_signature=[
+            tensor_spec.TensorSpec(shape=None, dtype=dtypes.float32),
+            tensor_spec.TensorSpec(shape=None, dtype=dtypes.float32),
+        ]
+    )
+    def run_nms(boxes_dyn, scores_dyn):
+      return image_ops_impl.combined_non_max_suppression(
+          boxes_dyn, scores_dyn, 10, 10
+      )
+
+    boxes = random_ops.random_uniform([4, 10, 4])  # rank-3, must be rank-4.
+    scores = random_ops.random_uniform([4, 10, 1])
+    with self.assertRaisesRegex(
+        errors_impl.InvalidArgumentError, "boxes must be 4-D"
+    ):
+      run_nms(boxes, scores)
+
+    boxes_valid = random_ops.random_uniform([4, 10, 1, 4])
+    scores_invalid = random_ops.random_uniform([4, 10])  # rank-2.
+    with self.assertRaisesRegex(
+        errors_impl.InvalidArgumentError, "scores must be 3-D"
+    ):
+      run_nms(boxes_valid, scores_invalid)
+
+
+if __name__ == "__main__":
+  test.main()


### PR DESCRIPTION
Fixes tensorflow/tensorflow#99583

**Problem**
`tf.image.combined_non_max_suppression` seg-faults with a C++ fatal CHECK when given tensors whose ranks differ from the documented `boxes: 4-D`, `scores: 3-D`.

**What this PR does**
* Enforces input rank validation at the C++ OpKernel level in `CombinedNonMaxSuppressionOp::Compute`: `boxes` must be 4-D and `scores` must be 3-D, raising `InvalidArgumentError` instead of crashing with a fatal `CHECK`.
* With static shapes this surfaces as a `ValueError` from Python shape inference during op construction; with dynamic/unknown ranks (e.g. `tf.function` with unknown-shape `input_signature`) the kernel check raises `tf.errors.InvalidArgumentError` at runtime.
* Adds regression test `image_ops_combined_nms_shape_test.py` covering both static and dynamic shape paths.
