### PR TITLE
Ensure tf.clip_by_value returns positive zero for clipped values on GPU

### DIFF
--- a/tensorflow/core/kernels/cwise_op_clip_gpu.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_clip_gpu.cu.cc
@@ -32,6 +32,8 @@ __global__ void UnaryClipCustomKernel(const int32 size_in,
   GPU_1D_KERNEL_LOOP(i, size_in) {
     T value = in2[0] < in0[i] ? in2[0] : in0[i];
     out[i] = value < in1[0] ? in1[0] : value;
+    // Ensure clipped zero is always positive zero
+    if (out[i] == static_cast<T>(0.0)) out[i] = static_cast<T>(0.0);
   }
 }
 
@@ -44,6 +46,8 @@ __global__ void BinaryRightClipCustomKernel(const int32 size_in,
   GPU_1D_KERNEL_LOOP(i, size_in) {
     T value = in2[i] < in0[i] ? in2[i] : in0[i];
     out[i] = value < in1[0] ? in1[0] : value;
+    // Ensure clipped zero is always positive zero
+    if (out[i] == static_cast<T>(0.0)) out[i] = static_cast<T>(0.0);
   }
 }
 
@@ -56,6 +60,8 @@ __global__ void BinaryLeftClipCustomKernel(const int32 size_in,
   GPU_1D_KERNEL_LOOP(i, size_in) {
     T value = in2[0] < in0[i] ? in2[0] : in0[i];
     out[i] = value < in1[i] ? in1[i] : value;
+    // Ensure clipped zero is always positive zero
+    if (out[i] == static_cast<T>(0.0)) out[i] = static_cast<T>(0.0);
   }
 }
 

--- a/tensorflow/core/kernels/cwise_op_clip_gpu.cu.cc
+++ b/tensorflow/core/kernels/cwise_op_clip_gpu.cu.cc
@@ -34,6 +34,9 @@ __global__ void UnaryClipCustomKernel(const int32 size_in,
     out[i] = value < in1[0] ? in1[0] : value;
     // Ensure clipped zero is always positive zero
     if (out[i] == static_cast<T>(0.0)) out[i] = static_cast<T>(0.0);
+  // See: https://github.com/tensorflow/tensorflow/issues/67279
+  // See also: https://github.com/tensorflow/tensorflow/issues/99759
+  // These bugs caused tf.clip_by_value to return -0.0 on GPU for clipped values.
   }
 }
 


### PR DESCRIPTION
Fixes #99759

This PR resolves an inconsistency between CPU and GPU for tf.clip_by_value when clipping -0.0. Now, both devices return positive zero (0.0) for clipped values, ensuring consistent behavior.