### PR TITLE
`tf.math.argmax` support for int16 tensor in axis.

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -309,13 +309,15 @@ def argmax_v2(input, axis=None, output_type=dtypes.int64, name=None):
       raise TypeError(
         f"axis tensor dtypes {axis.dtype} is not supported"
       )
-    if axis.dtype in (
-      dtypes.int8, dtypes.int16, dtypes.uint8, dtypes.uint16
-      ):
+    castable_types = {
+        dtypes.int8, dtypes.int16,
+        dtypes.uint8, dtypes.uint16
+      }
+    if axis.dtype in castable_types:
       axis = cast(axis, dtypes.int32)
   elif not isinstance(axis, int):
     raise TypeError(
-      f"axis must be int or Tensor with integer datatype"
+      "axis must be int or Tensor with integer datatype"
     )
 
   return gen_math_ops.arg_max(input, axis, name=name, output_type=output_type)

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -300,9 +300,12 @@ def argmax_v2(input, axis=None, output_type=dtypes.int64, name=None):
     axis = 0
 
   if hasattr(axis, "dtype"):
-    if axis.dtype not in (
-      dtypes.int8, dtypes.uint8, dtypes.int16, dtypes.uint16, dtypes.int32, dtypes.int64
-    ):
+    allowed_dtypes = {
+      dtypes.int8, dtypes.uint8,
+      dtypes.int16, dtypes.uint16,
+      dtypes.int32, dtypes.int64
+    }
+    if axis.dtype not in allowed_dtypes:
       raise TypeError(
         f"axis tensor dtypes {axis.dtype} is not supported"
       )

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -302,14 +302,16 @@ def argmax_v2(input, axis=None, output_type=dtypes.int64, name=None):
   if isinstance(axis , int):
     pass
   elif hasattr(axis, "dtype"):
-    if axis.dtype in (dtypes.int32, dtypes.int64):
-      pass
-    elif axis.dtype in (dtypes.int8, dtypes.int16, dtypes.uint8, dtypes.uint16):
-      axis = cast(axis, dtypes.int32)
-    else:
+    if axis.dtype not in (
+      dtypes.int8, dtypes.uint8, dtypes.int16, dtypes.uint16, dtypes.int32, dtypes.int64
+    ):
       raise TypeError(
         f"axis tensor dtypes {axis.dtype} is not supported"
-        )
+      )
+    if axis.dtype in (
+      dtypes.int8, dtypes.int16, dtypes.uint8, dtypes.uint16
+      ):
+      axis = cast(axis, dtypes.int32)
   else:
     raise TypeError(
       f"axis must be int or Tensor with integer datatype"

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -299,9 +299,7 @@ def argmax_v2(input, axis=None, output_type=dtypes.int64, name=None):
   if axis is None:
     axis = 0
 
-  if isinstance(axis , int):
-    pass
-  elif hasattr(axis, "dtype"):
+  if hasattr(axis, "dtype"):
     if axis.dtype not in (
       dtypes.int8, dtypes.uint8, dtypes.int16, dtypes.uint16, dtypes.int32, dtypes.int64
     ):
@@ -312,7 +310,7 @@ def argmax_v2(input, axis=None, output_type=dtypes.int64, name=None):
       dtypes.int8, dtypes.int16, dtypes.uint8, dtypes.uint16
       ):
       axis = cast(axis, dtypes.int32)
-  else:
+  elif not isinstance(axis, int):
     raise TypeError(
       f"axis must be int or Tensor with integer datatype"
     )

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -298,6 +298,23 @@ def argmax_v2(input, axis=None, output_type=dtypes.int64, name=None):
   """
   if axis is None:
     axis = 0
+
+  if isinstance(axis , int):
+    pass
+  elif hasattr(axis, "dtype"):
+    if axis.dtype in (dtypes.int32, dtypes.int64):
+      pass
+    elif axis.dtype in (dtypes.int8, dtypes.int16, dtypes.uint8, dtypes.uint16):
+      axis = cast(axis, dtypes.int32)
+    else:
+      raise TypeError(
+        f"axis tensor dtypes {axis.dtype} is not supported"
+        )
+  else:
+    raise TypeError(
+      f"axis must be int or Tensor with integer datatype"
+    )
+
   return gen_math_ops.arg_max(input, axis, name=name, output_type=output_type)
 
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -1440,7 +1440,6 @@ class ArgMaxMinTest(test_util.TensorFlowTestCase):
           ),
         output_type=dtypes.int32
       )
-      print("Tf Max is :", tf_max , "and np_max is :", np_max)
       self.assertAllEqual(tf_max, np_max)
 
   def testArgMin(self):

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -1427,6 +1427,22 @@ class ArgMaxMinTest(test_util.TensorFlowTestCase):
             tf_values, axis=axis, output_type=dtypes.uint16)
         self.assertAllEqual(tf_max, np_max)
 
+  def testArgMaxInt16(self):
+    shape = (24, 8)
+    tf_values = self._generateRandomTensor(dtypes.int16, shape)
+    np_values = self.evaluate(tf_values)
+    for axis in range(0, len(shape)):
+      np_max = np.argmax(np_values, axis=axis)
+      tf_max = math_ops.argmax(
+        tf_values,
+        axis=constant_op.constant(
+          axis, dtype=dtypes.int16
+          ),
+        output_type=dtypes.int32
+      )
+      print("Tf Max is :", tf_max , "and np_max is :", np_max)
+      self.assertAllEqual(tf_max, np_max)
+
   def testArgMin(self):
     shape = (24, 8)
     for dtype in self._getValidDtypes():

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -1426,21 +1426,34 @@ class ArgMaxMinTest(test_util.TensorFlowTestCase):
         tf_max = math_ops.argmax(
             tf_values, axis=axis, output_type=dtypes.uint16)
         self.assertAllEqual(tf_max, np_max)
-
-  def testArgMaxInt16(self):
+  
+  def testArgMaxWithIntegerDtypes(self):
+    axis_dtypes = {
+      dtypes.int8, dtypes.uint8,
+      dtypes.int16, dtypes.uint16,
+      dtypes.int32, dtypes.int64
+    }
     shape = (24, 8)
-    tf_values = self._generateRandomTensor(dtypes.int16, shape)
-    np_values = self.evaluate(tf_values)
-    for axis in range(0, len(shape)):
-      np_max = np.argmax(np_values, axis=axis)
-      tf_max = math_ops.argmax(
-        tf_values,
-        axis=constant_op.constant(
-          axis, dtype=dtypes.int16
-          ),
+    for d_type in axis_dtypes:
+      tf_values = self._generateRandomTensor(d_type, shape)
+      np_values = self.evaluate(tf_values)
+      for axis in range(len(shape)):
+        np_max = np.argmax(np_values, axis=axis)
+        tf_max = math_ops.argmax(
+          tf_values,
+          axis=constant_op.constant(axis, dtype=d_type),
+          output_type=dtypes.int32
+        )
+        self.assertAllEqual(tf_max, np_max)
+      
+  def testArgMaxRaisesInvalidDtype(self):
+    invalid_axis = constant_op.constant(1, dtype=dtypes.float32)
+    with self.assertRaises(TypeError):
+      math_ops.argmax(
+        constant_op.constant([1,2,3]),
+        axis=invalid_axis,
         output_type=dtypes.int32
       )
-      self.assertAllEqual(tf_max, np_max)
 
   def testArgMin(self):
     shape = (24, 8)


### PR DESCRIPTION
Closes #97096 

**Problem:** `tf.math.argmax` function was crashing with memory corruption when axis was passed with tensor with int16 dtype, producting error like : 
```bash
InvalidArgumentError: Expected dimension in the range [-2, 2), but got -52363264
```

### Root Cause : 
 Memory corruption : The cpu kernel in the file : [tensorflow/core/kernels/argmax_op.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/argmax_op.cc#L59) is hardcoded to interpret the memory as an int32_t : 

```cpp
const int32_t dim = internal::SubtleMustCopy(dimension.scalar<int32>()());
```
This method reads the bytes from the memory location and the number of bytes to be read are decided by the `dimension.scalar<int32>()(), which is 4 bytes. But the values in int16_t are stored inside only 2 bytes, causing it to read two extra garbage bytes hence causing the error.

**Implementation:**
1. Allow for int, int32_t and int64_t to pass
2. If anything other tensor with dtype = int16, or int8 are found then safely cast them to int32_t
3. If there is something else entirely or the casting fails then we raise a type error.
4. Added a testcase in ArgMinMax class to verify that types of int16_t are passing.

See issue #97096 for full context. 