### PR TITLE
[oneDNN][Bug Fix] Fix a FPE core dump issue related to oneDNN maxpooling op

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
@@ -76,8 +76,10 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
       memory::dims output_dims_mkl_order;
       this->GetOutputDims(pool_params, &output_dims_mkl_order);
 
-      // If input is an empty tensor, allocate an empty output tensor and return
-      if (input_tensor.NumElements() == 0) {
+      // If input is an empty tensor, or the output shape has zero elements,
+      // allocate an empty output tensor and return
+      auto out_tf_shape = MklDnnDimsToTFShape(output_dims_mkl_order);
+      if (input_tensor.NumElements() == 0 || out_tf_shape.num_elements() == 0) {
         const int kOutputIndex = 0;
         this->AllocateEmptyOutputTensor(context, kOutputIndex, &pool_params,
                                         output_dims_mkl_order, &output_tensor);

--- a/tensorflow/python/kernel_tests/nn_ops/pooling_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/pooling_ops_3d_test.py
@@ -292,6 +292,20 @@ class PoolingTest(test.TestCase):
     values = self.evaluate(max_pool_3d)
     self.assertEqual(values.shape, (0, 56, 56, 56, 64))
 
+  def testMaxPool3DOutputWithZeroDim(self):
+    """Verifies the output shape of the max pooling function
+    which has one 0 dimension.
+    Args: none
+    """
+    input_tensor = np.ones([1, 7, 6, 6, 5], dtype=np.float32)
+    max_pool_3d = nn_ops.max_pool3d(
+        input=input_tensor,
+        ksize=[1, 4, 5, 5, 1],
+        strides=[1, 3, 2, 1, 1],
+        padding="SAME",
+        data_format="NDHWC")
+    values = self.evaluate(max_pool_3d)
+
   # TODO(penporn): Determine if we will allow input_sizes[3] < ksize[3].
   def DISABLED_testAvgPool3dEmptyOutTensor(self):
     input_sizes = [30, 19, 4, 19, 17]

--- a/tensorflow/python/kernel_tests/nn_ops/pooling_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/pooling_ops_3d_test.py
@@ -297,14 +297,15 @@ class PoolingTest(test.TestCase):
     which has one 0 dimension.
     Args: none
     """
-    input_tensor = np.ones([1, 7, 6, 6, 5], dtype=np.float32)
+    input_tensor = np.ones([1, 6, 7, 4, 4], dtype=np.float32)
     max_pool_3d = nn_ops.max_pool3d(
         input=input_tensor,
         ksize=[1, 4, 5, 5, 1],
         strides=[1, 3, 2, 1, 1],
-        padding="SAME",
+        padding="VALID",
         data_format="NDHWC")
     values = self.evaluate(max_pool_3d)
+    self.assertEqual(values.shape, (1, 1, 2, 0, 4))
 
   # TODO(penporn): Determine if we will allow input_sizes[3] < ksize[3].
   def DISABLED_testAvgPool3dEmptyOutTensor(self):

--- a/tensorflow/python/kernel_tests/nn_ops/pooling_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/pooling_ops_3d_test.py
@@ -292,6 +292,7 @@ class PoolingTest(test.TestCase):
     values = self.evaluate(max_pool_3d)
     self.assertEqual(values.shape, (0, 56, 56, 56, 64))
 
+  @test_util.run_deprecated_v1
   def testMaxPool3DOutputWithZeroDim(self):
     """Verifies the output shape of the max pooling function
     which has one 0 dimension.

--- a/tensorflow/python/kernel_tests/nn_ops/pooling_ops_3d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/pooling_ops_3d_test.py
@@ -297,15 +297,18 @@ class PoolingTest(test.TestCase):
     which has one 0 dimension.
     Args: none
     """
-    input_tensor = np.ones([1, 6, 7, 4, 4], dtype=np.float32)
-    max_pool_3d = nn_ops.max_pool3d(
-        input=input_tensor,
-        ksize=[1, 4, 5, 5, 1],
-        strides=[1, 3, 2, 1, 1],
-        padding="VALID",
-        data_format="NDHWC")
-    values = self.evaluate(max_pool_3d)
-    self.assertEqual(values.shape, (1, 1, 2, 0, 4))
+    with self.session() as sess:
+      input_data = np.ones([1, 6, 7, 4, 4], dtype=np.float32)
+      input_placeholder = array_ops.placeholder(
+          dtypes.float32, shape=[1, 6, 7, None, 4])
+      max_pool_3d = nn_ops.max_pool3d(
+          input=input_placeholder,
+          ksize=[1, 4, 5, 5, 1],
+          strides=[1, 3, 2, 1, 1],
+          padding="VALID",
+          data_format="NDHWC")
+      values = sess.run(max_pool_3d, feed_dict={input_placeholder: input_data})
+      self.assertEqual(values.shape, (1, 1, 2, 0, 4))
 
   # TODO(penporn): Determine if we will allow input_sizes[3] < ksize[3].
   def DISABLED_testAvgPool3dEmptyOutTensor(self):


### PR DESCRIPTION
This PR fixes a Floating point exception (core dumped) issue, escalated in this ticket:
https://github.com/tensorflow/tensorflow/issues/94120

The fix provides corner case handling (in this case, output tensor) in 3D maxpooling op.