### PR TITLE
Add ksize validation to QuantizedMaxPool

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
@@ -65,8 +65,16 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
       bool is_pool2d = (this->ksize_.size() == 4);
       // Get the input tensor and initialize the pooling parameters
       TensorShape input_tensor_shape = input_tensor.shape();
-      this->InitMklPoolParameters(context, &pool_params, dnn_shape_input,
-                                  input_tensor_shape);
+      this->InitMklPoolParameters(context, &pool_params, dnn_shape_input, input_tensor_shape);
+	  
+	  for(int i = 0; i<this->ksize_.size();++i){
+		  OP_REQUIRES(context,
+		  input_tensor_shape.dims()> i && input_tensor_shape.dim_size(i) >= this->ksize_[i],
+		  errors::InvalidArgument(
+		  "ksize dimension ", i, " (", this->ksize_[i], ") is larger than input tensor dimension (", input_tensor_shape.dim_size(i), ")" ));
+	  }
+								  
+	
       OP_REQUIRES_OK(context, context->status());
 
       // Declare output tensor


### PR DESCRIPTION
### Summary
This patch adds validation for the `ksize` parameter in the QuantizedMaxPool MKL kernel.
It ensures that each dimension of the input tensor is greater than or equal to the corresponding `ksize` value, preventing invalid arguments that could cause runtime errors.

### Changes
- Added a loop in `mkl_maxpooling_op.cc` to check each `ksize` dimension against the input tensor dimensions.
- Returns `InvalidArgument` error if any `ksize` dimension exceeds the input tensor dimension.

### Testing
- Manual testing confirms that invalid `ksize` values now throw an error as expected.

### Motivation
Prevent runtime crashes due to invalid kernel size in QuantizedMaxPool operations using MKL.

Fixes #100223 
