### PR TITLE
Clarify the limitation between scientific and shortest in func `tf.strings.as_string()`

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_AsString.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_AsString.pbtxt
@@ -11,6 +11,7 @@ END
     name: "scientific"
     description: <<END
 Use scientific notation for floating point numbers.
+Can't be specified to `True` when `shortest` is set to `True`.
 END
   }
   attr {
@@ -18,6 +19,7 @@ END
     description: <<END
 Use shortest representation (either scientific or standard) for
 floating point numbers.
+Can't be specified to `True` when `scientific` is set to `True`.
 END
   }
   attr {


### PR DESCRIPTION
Fixes #100497