### PR TITLE
Fixed memory corruption issue due to illegal type pun

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -310,9 +310,9 @@ def argmax_v2(input, axis=None, output_type=dtypes.int64, name=None):
         f"axis tensor dtypes {axis.dtype} is not supported"
       )
     castable_types = {
-        dtypes.int8, dtypes.int16,
-        dtypes.uint8, dtypes.uint16
-      }
+      dtypes.int8, dtypes.int16,
+      dtypes.uint8, dtypes.uint16
+    }
     if axis.dtype in castable_types:
       axis = cast(axis, dtypes.int32)
   elif not isinstance(axis, int):

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -300,19 +300,25 @@ def argmax_v2(input, axis=None, output_type=dtypes.int64, name=None):
     axis = 0
 
   if hasattr(axis, "dtype"):
-    if axis.dtype not in (
-        dtypes.int8,
-        dtypes.uint8,
-        dtypes.int16,
-        dtypes.uint16,
-        dtypes.int32,
-        dtypes.int64,
-    ):
-      raise TypeError(f"axis tensor dtypes {axis.dtype} is not supported")
-    if axis.dtype in (dtypes.int8, dtypes.int16, dtypes.uint8, dtypes.uint16):
+    allowed_dtypes = {
+      dtypes.int8, dtypes.uint8,
+      dtypes.int16, dtypes.uint16,
+      dtypes.int32, dtypes.int64
+    }
+    if axis.dtype not in allowed_dtypes:
+      raise TypeError(
+        f"axis tensor dtypes {axis.dtype} is not supported"
+      )
+    castable_types = {
+        dtypes.int8, dtypes.int16,
+        dtypes.uint8, dtypes.uint16
+      }
+    if axis.dtype in castable_types:
       axis = cast(axis, dtypes.int32)
   elif not isinstance(axis, int):
-    raise TypeError(f"axis must be int or Tensor with integer datatype")
+    raise TypeError(
+      "axis must be int or Tensor with integer datatype"
+    )
 
   return gen_math_ops.arg_max(input, axis, name=name, output_type=output_type)
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -1426,19 +1426,34 @@ class ArgMaxMinTest(test_util.TensorFlowTestCase):
         tf_max = math_ops.argmax(
             tf_values, axis=axis, output_type=dtypes.uint16)
         self.assertAllEqual(tf_max, np_max)
-
-  def testArgMaxInt16(self):
+ 
+  def testArgMaxWithIntegerDtypes(self):
+    axis_dtypes = {
+      dtypes.int8, dtypes.uint8,
+      dtypes.int16, dtypes.uint16,
+      dtypes.int32, dtypes.int64
+    }
     shape = (24, 8)
-    tf_values = self._generateRandomTensor(dtypes.int16, shape)
-    np_values = self.evaluate(tf_values)
-    for axis in range(0, len(shape)):
-      np_max = np.argmax(np_values, axis=axis)
-      tf_max = math_ops.argmax(
+    for d_type in axis_dtypes:
+      tf_values = self._generateRandomTensor(d_type, shape)
+      np_values = self.evaluate(tf_values)
+      for axis in range(len(shape)):
+        np_max = np.argmax(np_values, axis=axis)
+        tf_max = math_ops.argmax(
           tf_values,
-          axis=constant_op.constant(axis, dtype=dtypes.int16),
-          output_type=dtypes.int32,
+          axis=constant_op.constant(axis, dtype=d_type),
+          output_type=dtypes.int32
+        )
+        self.assertAllEqual(tf_max, np_max)
+
+  def testArgMaxRaisesInvalidDtype(self):
+    invalid_axis = constant_op.constant(1, dtype=dtypes.float32)
+    with self.assertRaises(TypeError):
+      math_ops.argmax(
+        constant_op.constant([1,2,3]),
+        axis=invalid_axis,
+        output_type=dtypes.int32
       )
-      self.assertAllEqual(tf_max, np_max)
 
   def testArgMin(self):
     shape = (24, 8)

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -1379,7 +1379,7 @@ class ErfcinvTest(test_util.TensorFlowTestCase):
 
 
 @test_util.run_all_in_graph_and_eager_modes
-class ArgMaxMinTest(test_util.TensorFlowTestCase):
+class ArgMaxMinTest(test_util.TensorFlowTestCase, parameterized.TestCase):
 
   def _generateRandomTensor(self, dtype, shape):
     if dtype.is_integer:
@@ -1426,25 +1426,24 @@ class ArgMaxMinTest(test_util.TensorFlowTestCase):
         tf_max = math_ops.argmax(
             tf_values, axis=axis, output_type=dtypes.uint16)
         self.assertAllEqual(tf_max, np_max)
- 
-  def testArgMaxWithIntegerDtypes(self):
-    axis_dtypes = {
-      dtypes.int8, dtypes.uint8,
-      dtypes.int16, dtypes.uint16,
-      dtypes.int32, dtypes.int64
-    }
+  
+  @parameterized.parameters(
+    dtypes.int8, dtypes.uint8,
+    dtypes.int16, dtypes.uint16,
+    dtypes.int32, dtypes.int64
+  )
+  def testArgMaxWithIntegerDtypes(self,dtype):
     shape = (24, 8)
-    for d_type in axis_dtypes:
-      tf_values = self._generateRandomTensor(d_type, shape)
-      np_values = self.evaluate(tf_values)
-      for axis in range(len(shape)):
-        np_max = np.argmax(np_values, axis=axis)
-        tf_max = math_ops.argmax(
-          tf_values,
-          axis=constant_op.constant(axis, dtype=d_type),
-          output_type=dtypes.int32
-        )
-        self.assertAllEqual(tf_max, np_max)
+    tf_values = self._generateRandomTensor(dtype, shape)
+    np_values = self.evaluate(tf_values)
+    for axis in range(len(shape)):
+      np_max = np.argmax(np_values, axis=axis)
+      tf_max = math_ops.argmax(
+        tf_values,
+        axis=constant_op.constant(axis, dtype=dtype),
+        output_type=dtypes.int32
+      )
+      self.assertAllEqual(tf_max, np_max)
 
   def testArgMaxRaisesInvalidDtype(self):
     invalid_axis = constant_op.constant(1, dtype=dtypes.float32)


### PR DESCRIPTION
Hi, @mihaimaruseac, hope this address all the improvements you suggested in #99904 . I closed the previous pr because somehow it got merged in the process of review and having the **awaiting review** label.

This Pr address :
 
1.  Improves test via testing dtype other than int16
2. Added an error test
3. Put the castable dtype into a proper container for readability
4. Addressed the un-necessary f-string usage.

The pr passes pylint and the bazel test locally. 
Thank you for your time

Closes #97096