### PR TITLE
fix: add explicit length check in ShapeEquals

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -854,7 +854,10 @@ def ShapeEquals(tensor_proto, shape):
     raise TypeError("`shape` must be a list or tuple, but got type "
                     f"{type(shape)}.")
   tensor_shape_list = [d.size for d in tensor_proto.tensor_shape.dim]
-  return all(x == y for x, y in zip(tensor_shape_list, shape))
+  return (
+      len(tensor_shape_list) == len(shape) and
+      all(x == y for x, y in zip(tensor_shape_list, shape))
+  )
 
 
 def _ConstantValue(tensor, partial):

--- a/tensorflow/python/framework/tensor_util_test.py
+++ b/tensorflow/python/framework/tensor_util_test.py
@@ -1013,6 +1013,9 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
     self.assertFalse(tensor_util.ShapeEquals(t, [5, 3]))
     self.assertFalse(tensor_util.ShapeEquals(t, [1, 4]))
     self.assertFalse(tensor_util.ShapeEquals(t, [4]))
+    self.assertFalse(tensor_util.ShapeEquals(t, [2]))
+    self.assertFalse(tensor_util.ShapeEquals(t, []))
+    self.assertFalse(tensor_util.ShapeEquals(t, [2, 2, 1]))
 
 
 @test_util.run_all_in_graph_and_eager_modes


### PR DESCRIPTION
Currently, ShapeEquals only compared element-wise dimensions using zip(), which meant that two shapes with the same prefix but different rank could be considered equal like

```
t = tensor_util.make_tensor_proto([10, 20, 30, 40], shape=[2, 2])
ShapeEquals(t, [2,2,1])    # returned True (wrong)
```

This patch adds an explicit length check so that rank of the shape must also match.

If anything is incorrect, feel free to close this PR.