### PR TITLE
Fix typo in tf.keras.layers.dense_attention docstring: 'it' -> 'if'

### DIFF
--- a/tensorflow/python/keras/layers/dense_attention.py
+++ b/tensorflow/python/keras/layers/dense_attention.py
@@ -62,7 +62,7 @@ class BaseDenseAttention(Layer):
         `mask==False` do not contribute to the result.
     training: Python boolean indicating whether the layer should behave in
       training mode (adding dropout) or in inference mode (no dropout).
-    return_attention_scores: bool, it `True`, returns the attention scores
+    return_attention_scores: bool, if `True`, returns the attention scores
       (after masking and softmax) as an additional output argument.
 
   Output:


### PR DESCRIPTION
Fixes #101445

Corrects a small grammatical typo in the docstring of `tf.keras.layers.Attention.call`:
- Changes "it True" to "if True" for clarity and correctness.

This affects the documentation shown in IDEs and on tensorflow.org.