### PR TITLE
Fix typos in documentation strings

### DIFF
--- a/tensorflow/python/keras/layers/dense_attention.py
+++ b/tensorflow/python/keras/layers/dense_attention.py
@@ -62,7 +62,7 @@ class BaseDenseAttention(Layer):
         `mask==False` do not contribute to the result.
     training: Python boolean indicating whether the layer should behave in
       training mode (adding dropout) or in inference mode (no dropout).
-    return_attention_scores: bool, it `True`, returns the attention scores
+    return_attention_scores: bool, if `True`, returns the attention scores
       (after masking and softmax) as an additional output argument.
 
   Output:

--- a/tensorflow/python/platform/tf_logging.py
+++ b/tensorflow/python/platform/tf_logging.py
@@ -118,7 +118,7 @@ def get_logger():
 
   The `msg` can contain string formatting.  An example of logging at the `ERROR`
   level
-  using string formating is:
+  using string formatting is:
 
   >>> tf.get_logger().error("The value %d is invalid.", 3)
 

--- a/tensorflow/python/profiler/internal/flops_registry.py
+++ b/tensorflow/python/profiler/internal/flops_registry.py
@@ -122,7 +122,7 @@ def _l2_loss_flops(graph, node):
 @ops.RegisterStatistics("Softmax", "flops")
 def _softmax_flops(graph, node):
   """Compute flops for Softmax operation."""
-  # Softmax implemetation:
+  # Softmax implementation:
   #
   # Approximate flops breakdown:
   #   2*n          -- compute shifted logits
@@ -312,7 +312,7 @@ def _pool_flops(graph, node):
   #     - padding
   #     - data_format
   #
-  # Pooling implemetation:
+  # Pooling implementation:
   out_shape = graph_util.tensor_shape_from_node_def_name(graph, node.name)
   out_shape.assert_is_fully_defined()
   kernel_shape = list(node.attr["ksize"].list.i)

--- a/tensorflow/python/profiler/pprof_profiler.py
+++ b/tensorflow/python/profiler/pprof_profiler.py
@@ -221,7 +221,7 @@ class Samples(object):
 
     Args:
       datum: `ProfileDatum` to add a sample for.
-      location_ids: List of numberic location ids for this
+      location_ids: List of numeric location ids for this
         sample.
     """
     node_name = datum.node_exec_stats.node_name

--- a/tensorflow/python/tools/api/generator2/extractor/extractor.py
+++ b/tensorflow/python/tools/api/generator2/extractor/extractor.py
@@ -336,7 +336,7 @@ class Parser(ast.NodeVisitor):
             f'{self._api_name}.{v}' for v in self._literal_value(kw.value)
         )
       elif kw.arg == 'allow_multiple_exports':
-        # no-op kept for backward comapatibility of `tf-keras` with TF 2.13
+        # no-op kept for backward compatibility of `tf-keras` with TF 2.13
         pass
       else:
         raise BadExportError(

--- a/tensorflow/python/tools/api/generator2/generate_api.bzl
+++ b/tensorflow/python/tools/api/generator2/generate_api.bzl
@@ -279,7 +279,7 @@ generate_api = rule(
                   "should include module1/module2/__init__.py and module3/__init__.py.",
         ),
         "use_lazy_loading": attr.bool(
-            doc = "If true, lazy load imports in the generated API rather then imporing them all statically.",
+            doc = "If true, lazy load imports in the generated API rather then importing them all statically.",
         ),
         "packages_to_ignore": attr.string_list(
             doc = "List of packages to ignore tf_exports from.",
@@ -327,7 +327,7 @@ def generate_apis(
         name: name of generate_api target.
         apis: APIs to extract. See APIS constant for allowed values.
         deps: python_library targets to serve as roots for extracting APIs.
-        output_files: The list of files that the API generator is exected to create.
+        output_files: The list of files that the API generator is expected to create.
         root_init_template: The template for the top level __init__.py file generated.
             "#API IMPORTS PLACEHOLDER" comment will be replaced with imports.
         api_packages_file_name: Name of the file with the list of all API packages. Stores in output_dir.

--- a/tensorflow/python/tools/api/generator2/generator/generator.py
+++ b/tensorflow/python/tools/api/generator2/generator/generator.py
@@ -80,7 +80,7 @@ _FILE_PREFIXES_TO_STRIP = flags.DEFINE_list(
 _PACKAGES_TO_IGNORE = flags.DEFINE_list(
     'packages_to_ignore',
     [],
-    'Comma seperated list of packages to ignore tf_exports from. Ex:'
+    'Comma separated list of packages to ignore tf_exports from. Ex:'
     ' packages_to_ignore="tensorflow.python.framework.test_ops"'
     ' will not export any tf_exports from test_ops',
 )


### PR DESCRIPTION
Hi, Team
This PR corrects a specific typo in the documentation for the `return_attention_scores` argument in `dense_attention.py`, changing the confusing phrase `it True` to the correct conditional `if True`.

This also includes other minor documentation string typo corrections in the API generator and related files.
This addresses issue #101445.

Thank you!