### PR TITLE
Fix weighted_moments to accept tensor axes with keepdims=False

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ gradleBuild
 Podfile.lock
 Pods
 xcuserdata
+claude.md

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,3 @@ gradleBuild
 Podfile.lock
 Pods
 xcuserdata
-claude.md

--- a/tensorflow/python/kernel_tests/nn_ops/BUILD
+++ b/tensorflow/python/kernel_tests/nn_ops/BUILD
@@ -583,6 +583,7 @@ tf_py_strict_test(
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/ops:array_ops",
         "//tensorflow/python/ops:nn_ops",
+        "//tensorflow/python/ops:nn_impl",
         "//tensorflow/python/platform:client_testlib",
         "//third_party/py/numpy",
     ],

--- a/tensorflow/python/kernel_tests/nn_ops/BUILD
+++ b/tensorflow/python/kernel_tests/nn_ops/BUILD
@@ -573,6 +573,21 @@ tf_py_strict_test(
     ],
 )
 
+tf_py_strict_test(
+    name = "weighted_moments_test",
+    size = "small",
+    srcs = ["weighted_moments_test.py"],
+    deps = [
+        "//tensorflow/python/framework:constant_op",
+        "//tensorflow/python/framework:for_generated_wrappers",
+        "//tensorflow/python/framework:test_lib",
+        "//tensorflow/python/ops:array_ops",
+        "//tensorflow/python/ops:nn_ops",
+        "//tensorflow/python/platform:client_testlib",
+        "//third_party/py/numpy",
+    ],
+)
+
 cuda_py_strict_test(
     name = "lrn_op_test",
     size = "medium",

--- a/tensorflow/python/kernel_tests/nn_ops/weighted_moments_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/weighted_moments_test.py
@@ -1,19 +1,21 @@
-import tensorflow as tf
-from tensorflow.python.framework import test_util
+from tensorflow.python.framework import constant_op
+from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import test
+
 
 class WeightedMomentsTest(test.TestCase):
 
   def test_tensor_axes_keepdims_false_shape_mismatch(self):
-    x = tf.constant([[1., 2., 3., 4., 5.],
-                     [6., 7., 8., 9., 10.]])
-    weights = tf.constant([[1.], [1.]])
-    axes = tf.constant([0], dtype=tf.int32)
-
-    mean, var = tf.nn.weighted_moments(x, axes=axes, frequency_weights=weights, keepdims=False)
-
+    x = constant_op.constant([[1., 2., 3., 4., 5.],
+                              [6., 7., 8., 9., 10.]])
+    weights = constant_op.constant([[1.], [1.]])
+    axes = constant_op.constant([0], dtype=constant_op.dtypes.int32)
+    mean, var = nn_ops.weighted_moments(
+        x, axes=axes, frequency_weights=weights, keepdims=False)
     self.assertEqual(mean.shape.as_list(), [5])
     self.assertEqual(var.shape.as_list(), [5])
 
+
 if __name__ == "__main__":
-    test.main()
+  test.main()
+

--- a/tensorflow/python/kernel_tests/nn_ops/weighted_moments_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/weighted_moments_test.py
@@ -1,0 +1,19 @@
+import tensorflow as tf
+from tensorflow.python.framework import test_util
+from tensorflow.python.platform import test
+
+class WeightedMomentsTest(test.TestCase):
+
+  def test_tensor_axes_keepdims_false_shape_mismatch(self):
+    x = tf.constant([[1., 2., 3., 4., 5.],
+                     [6., 7., 8., 9., 10.]])
+    weights = tf.constant([[1.], [1.]])
+    axes = tf.constant([0], dtype=tf.int32)
+
+    mean, var = tf.nn.weighted_moments(x, axes=axes, frequency_weights=weights, keepdims=False)
+
+    self.assertEqual(mean.shape.as_list(), [5])
+    self.assertEqual(var.shape.as_list(), [5])
+
+if __name__ == "__main__":
+    test.main()

--- a/tensorflow/python/kernel_tests/nn_ops/weighted_moments_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/weighted_moments_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 from tensorflow.python.framework import constant_op
-from tensorflow.python.ops import nn_ops
+from tensorflow.python.ops import nn_impl
 from tensorflow.python.platform import test
 
 
@@ -24,7 +24,7 @@ class WeightedMomentsTest(test.TestCase):
                               [6., 7., 8., 9., 10.]])
     weights = constant_op.constant([[1.], [1.]])
     axes = constant_op.constant([0], dtype=constant_op.dtypes.int32)
-    mean, var = nn_ops.weighted_moments(
+    mean, var = nn_impl.weighted_moments(
         x, axes=axes, frequency_weights=weights, keepdims=False)
     self.assertEqual(mean.shape.as_list(), [5])
     self.assertEqual(var.shape.as_list(), [5])

--- a/tensorflow/python/kernel_tests/nn_ops/weighted_moments_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/weighted_moments_test.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 from tensorflow.python.framework import constant_op
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.platform import test

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -1385,7 +1385,8 @@ def weighted_moments(x, axes, frequency_weights, name=None, keep_dims=None,
       if not isinstance(axes, (list, tuple)):
         squeeze_axes = axes.numpy().tolist()
       weighted_mean = array_ops.squeeze(weighted_mean, axis=squeeze_axes)
-      weighted_variance = array_ops.squeeze(weighted_variance, axis=squeeze_axes)
+      weighted_variance = array_ops.squeeze(
+          weighted_variance, axis=squeeze_axes)
 
     if needs_cast:
       weighted_mean = math_ops.cast(weighted_mean, dtypes.float16)

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -1381,9 +1381,11 @@ def weighted_moments(x, axes, frequency_weights, name=None, keep_dims=None,
     weighted_variance = math_ops.div_no_nan(weighted_distsq, sum_of_weights)
 
     if not keep_dims:
-      weighted_mean = array_ops.squeeze(weighted_mean, axis=axes)
-      weighted_variance = array_ops.squeeze(
-          weighted_variance, axis=axes)
+      squeeze_axes = axes
+      if not isinstance(axes, (list, tuple)):
+        squeeze_axes = axes.numpy().tolist()
+      weighted_mean = array_ops.squeeze(weighted_mean, axis=squeeze_axes)
+      weighted_variance = array_ops.squeeze(weighted_variance, axis=squeeze_axes)
 
     if needs_cast:
       weighted_mean = math_ops.cast(weighted_mean, dtypes.float16)


### PR DESCRIPTION
Fixes #101580

### Summary
`tf.nn.weighted_moments()` was failing when `keepdims=False` and `axes` was passed as a tensor (as documented), because the internal `squeeze()` operation only accepts lists/tuples.

### Changes
- Modified `weighted_moments()` to convert tensor axes to lists internally before calling `squeeze()`
- Added test case to verify tensor axes work with `keepdims=False`
- Maintains backward compatibility - list/tuple axes still work as before

### Testing
- Added `weighted_moments_test.py` with test for tensor axes + keepdims=False
- Test passes locally
- No breaking changes to existing functionality