### PR TITLE
fix(build): Set 16KB page alignment for core JNI library

### DIFF
--- a/tensorflow/lite/java/src/main/native/BUILD
+++ b/tensorflow/lite/java/src/main/native/BUILD
@@ -94,6 +94,7 @@ cc_library_with_tflite(
     linkopts = [
         "-lm",
         "-ldl",
+        "-Wl,-z,max-page-size=16384",
     ],
     tflite_deps = [
         ":jni_utils",


### PR DESCRIPTION
This PR resolves the Google Play validation error for 16 KB memory page sizes on Android 15+ by applying the fix to the core JNI dependency.

The `:native_stable_framework_only` library target, a dependency for all JNI libraries, was being compiled with the default 4KB alignment. This change adds the `-Wl,-z,max-page-size=16384` linker flag to its build configuration, ensuring all dependent libraries are built with the required 16KB alignment.

Fixes #101991