### PR TITLE
Update CuDNN FrontEnd to match the used one with XLA that is compatible with CUDA 13

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -208,9 +208,9 @@ def _tf_repositories():
         name = "cudnn_frontend_archive",
         build_file = "@local_xla//third_party:cudnn_frontend.BUILD",
         patch_file = ["@local_xla//third_party:cudnn_frontend_header_fix.patch"],
-        sha256 = "34dfe01057e43e799af207522aa0c863ad3177f8c1568b6e7a7e4ccf1cbff769",
-        strip_prefix = "cudnn-frontend-1.11.0",
-        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.11.0.zip"),
+        sha256 = "257b3b7f8a99abc096094abc9e5011659117b647d55293bcd2c5659f9181b99e",
+        strip_prefix = "cudnn-frontend-1.13.0",
+        urls = tf_mirror_urls("https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.13.0.zip"),
     )
 
     tf_http_archive(


### PR DESCRIPTION
This will resolve this issue that occurs when building using  CuDNN FrontEnd 1.11.0 and CUDA 13 (the minimum version needed to work with it is [1.12.0](https://github.com/NVIDIA/cudnn-frontend/releases/tag/v1.12.0)):
```
ERROR: /home/medaminezghal/.cache/bazel/_bazel_medaminezghal/26cbd07b274e70c8d776ff5c3b4b73d8/external/local_xla/xla/stream_executor/cuda/BUILD:520:11: Compiling xla/stream_executor/cuda/cuda_dnn.cc [for tool] failed: (Exit 1): nvcc_wrapper failed: error executing CppCompile command (from target @@local_xla//xla/stream_executor/cuda:cudnn_plugin) (cd /home/medaminezghal/.cache/bazel/_bazel_medaminezghal/26cbd07b274e70c8d776ff5c3b4b73d8/execroot/org_tensorflow && \ exec env - \ AR_PATH=external/llvm18_linux_x86_64/bin/llvm-ar \ CPP_PATH=external/llvm18_linux_x86_64/bin/clang++ \ GCC_PATH=external/llvm18_linux_x86_64/bin/clang \ LD_PATH=external/llvm18_linux_x86_64/bin/ld.lld \ NVCC_PATH=external/cuda_nvcc/bin/nvcc \ NVCC_VERSION=13.0.2 \ PATH=/home/medaminezghal/Desktop/tensorflow/src/bazel:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/cuda/bin:/opt/cuda/nsight_compute:/opt/cuda/nsight_systems/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl \ PWD=/proc/self/cwd \ external/rules_ml_toolchain/cc/impls/linux_x86_64_linux_x86_64_cuda/wrappers/nvcc_wrapper -MD -MF bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_xla/xla/stream_executor/cuda/_objs/cudnn_plugin/cuda_dnn.d '-frandom-seed=bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_xla/xla/stream_executor/cuda/_objs/cudnn_plugin/cuda_dnn.o' '-DGOOGLE_PROTOBUF_USING_BAZEL=1' '-DEIGEN_MAX_ALIGN_BYTES=64' -DEIGEN_ALLOW_UNALIGNED_SCALARS '-DEIGEN_USE_AVX512_GEMM_KERNELS=0' -DHAVE_SYS_UIO_H -DTF_USE_SNAPPY -DTENSORFLOW_USE_NUMA '-DLLVM_ON_UNIX=1' '-DHAVE_BACKTRACE=1' '-DBACKTRACE_HEADER=<execinfo.h>' '-DLTDL_SHLIB_EXT=".so"' '-DLLVM_PLUGIN_EXT=".so"' '-DLLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS=1' '-DLLVM_ENABLE_PLUGINS=1' '-DLLVM_ENABLE_THREADS=1' '-DHAVE_DEREGISTER_FRAME=1' '-DHAVE_LIBPTHREAD=1' '-DHAVE_PTHREAD_GETNAME_NP=1' '-DHAVE_PTHREAD_H=1' '-DHAVE_PTHREAD_SETNAME_NP=1' '-DHAVE_REGISTER_FRAME=1' '-DHAVE_SETENV_R=1' '-DHAVE_STRERROR_R=1' '-DHAVE_SYSEXITS_H=1' '-DHAVE_SYS_IOCTL_H=1' '-DHAVE_UNISTD_H=1' -D_GNU_SOURCE '-DHAVE_GETAUXVAL=1' '-DHAVE_MALLINFO=1' '-DHAVE_SBRK=1' '-DHAVE_STRUCT_STAT_ST_MTIM_TV_NSEC=1' -DHAVE_BUILTIN_THREAD_POINTER '-DLLVM_NATIVE_ARCH="X86"' '-DLLVM_NATIVE_ASMPARSER=LLVMInitializeX86AsmParser' '-DLLVM_NATIVE_ASMPRINTER=LLVMInitializeX86AsmPrinter' '-DLLVM_NATIVE_DISASSEMBLER=LLVMInitializeX86Disassembler' '-DLLVM_NATIVE_TARGET=LLVMInitializeX86Target' '-DLLVM_NATIVE_TARGETINFO=LLVMInitializeX86TargetInfo' '-DLLVM_NATIVE_TARGETMC=LLVMInitializeX86TargetMC' '-DLLVM_NATIVE_TARGETMCA=LLVMInitializeX86TargetMCA' '-DLLVM_HOST_TRIPLE="x86_64-unknown-linux-gnu"' '-DLLVM_DEFAULT_TARGET_TRIPLE="x86_64-unknown-linux-gnu"' '-DLLVM_VERSION_MAJOR=22' '-DLLVM_VERSION_MINOR=0' '-DLLVM_VERSION_PATCH=0' '-DLLVM_VERSION_STRING="22.0.0git"' -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS '-DLLVM_HAS_AArch64_TARGET=1' '-DLLVM_HAS_AMDGPU_TARGET=1' '-DLLVM_HAS_ARM_TARGET=1' '-DLLVM_HAS_NVPTX_TARGET=1' '-DLLVM_HAS_PowerPC_TARGET=1' '-DLLVM_HAS_RISCV_TARGET=1' '-DLLVM_HAS_SystemZ_TARGET=1' '-DLLVM_HAS_X86_TARGET=1' '-DLLVM_HAS_SPIRV_TARGET=1' '-DBLAKE3_USE_NEON=0' -DBLAKE3_NO_AVX2 -DBLAKE3_NO_AVX512 -DBLAKE3_NO_SSE2 -DBLAKE3_NO_SSE41 -iquote external/local_xla -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_xla -iquote external/com_google_protobuf -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf -iquote external/com_google_absl -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_absl -iquote external/zlib -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/zlib -iquote external/local_tsl -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_tsl -iquote external/eigen_archive -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/eigen_archive -iquote external/ml_dtypes_py -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/ml_dtypes_py -iquote external/snappy -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/snappy -iquote external/hwloc -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/hwloc -iquote external/com_googlesource_code_re2 -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_googlesource_code_re2 -iquote external/local_config_cuda -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_config_cuda -iquote external/cuda_cudart -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cudart -iquote external/cuda_cublas -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cublas -iquote external/cuda_cccl -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cccl -iquote external/cuda_nvtx -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvtx -iquote external/cuda_nvcc -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvcc -iquote external/cuda_cusolver -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cusolver -iquote external/cuda_cufft -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cufft -iquote external/cuda_cusparse -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cusparse -iquote external/cuda_curand -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_curand -iquote external/cuda_cupti -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cupti -iquote external/cuda_nvml -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvml -iquote external/cuda_nvjitlink -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvjitlink -iquote external/cuda_crt -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_crt -iquote external/cuda_cudnn -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cudnn -iquote external/highwayhash -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/highwayhash -iquote external/farmhash_archive -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/farmhash_archive -iquote external/llvm-project -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/llvm-project -iquote external/cudnn_frontend_archive -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cudnn_frontend_archive -iquote external/local_config_tensorrt -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_config_tensorrt -iquote external/nvshmem -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/nvshmem -iquote external/local_config_nccl -iquote bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_config_nccl -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/internal_visibility -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/micro_string -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/arena -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/arena_align -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/port -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/stubs/_virtual_includes/lite -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/arena_allocation_policy -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/arena_cleanup -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/string_block -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/endian -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/varint_shuffle -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/io/_virtual_includes/io -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/io/_virtual_includes/io_win32 -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/third_party/utf8_range/_virtual_includes/utf8_validity -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/third_party/utf8_range/_virtual_includes/utf8_range -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/io/_virtual_includes/gzip_stream -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/stubs/_virtual_includes/stubs -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/io/_virtual_includes/printer -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/io/_virtual_includes/zero_copy_sink -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/io/_virtual_includes/tokenizer -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/any_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/api_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/source_context_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/type_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/compiler/_virtual_includes/plugin_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/descriptor_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/duration_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/empty_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/field_mask_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/struct_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/timestamp_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/wrappers_proto -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_layering_check_legacy -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/compiler/_virtual_includes/importer -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/util/_virtual_includes/delimited_message_util -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/util/_virtual_includes/differencer -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/util/_virtual_includes/field_mask_util -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/util/_virtual_includes/json_util -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/json/_virtual_includes/json -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/json/_virtual_includes/parser -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/json/_virtual_includes/descriptor_traits -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/json/_virtual_includes/lexer -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/json/_virtual_includes/message_path -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/json/_virtual_includes/zero_copy_buffered_stream -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/json/_virtual_includes/untyped_message -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/util/_virtual_includes/type_resolver -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/descriptor_legacy -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/json/_virtual_includes/unparser -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/json/_virtual_includes/writer -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/com_google_protobuf/src/google/protobuf/util/_virtual_includes/time_util -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_config_cuda/cuda/_virtual_includes/cuda_headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cudart/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cublas/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cccl/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvtx/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvcc/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cusolver/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cufft/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cusparse/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_curand/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cupti/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvml/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvjitlink/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_crt/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cudnn/_virtual_includes/headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/llvm-project/third-party/siphash/_virtual_includes/siphash -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cudnn_frontend_archive/_virtual_includes/cudnn_frontend -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_config_tensorrt/_virtual_includes/tensorrt_headers -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/nvshmem/_virtual_includes/nvshmem_config -Ibazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_config_nccl/_virtual_includes/hermetic_nccl_config -isystem external/zlib -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/zlib -isystem external/eigen_archive -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/eigen_archive -isystem external/eigen_archive/mkl_include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/eigen_archive/mkl_include -isystem external/hwloc/hwloc -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/hwloc/hwloc -isystem external/hwloc/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/hwloc/include -isystem external/local_config_cuda/cuda -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_config_cuda/cuda -isystem external/cuda_cudart/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cudart/include -isystem external/cuda_cublas/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cublas/include -isystem external/cuda_cccl/include/cccl -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cccl/include/cccl -isystem external/cuda_nvtx/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvtx/include -isystem external/cuda_nvcc/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvcc/include -isystem external/cuda_cusolver/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cusolver/include -isystem external/cuda_cufft/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cufft/include -isystem external/cuda_cusparse/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cusparse/include -isystem external/cuda_curand/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_curand/include -isystem external/cuda_cupti/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cupti/include -isystem external/cuda_nvml/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvml/include -isystem external/cuda_nvjitlink/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_nvjitlink/include -isystem external/cuda_crt/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_crt/include -isystem external/cuda_cudnn/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cuda_cudnn/include -isystem external/farmhash_archive/src -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/farmhash_archive/src -isystem external/llvm-project/llvm/include -isystem bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/llvm-project/llvm/include '-isystem external/sysroot_linux_x86_64/usr/include/c++/8' '-isystem external/sysroot_linux_x86_64/usr/include/x86_64-linux-gnu/c++/8' '-isystem external/sysroot_linux_x86_64/usr/include/c++/8/backward' '-isystem external/sysroot_linux_x86_64/usr/include/c++/8/experimental' '-isystem external/llvm18_linux_x86_64/lib/clang/18' '-isystem external/llvm18_linux_x86_64/lib/clang/18/include' '-isystem external/sysroot_linux_x86_64/usr/local/include' '-isystem external/sysroot_linux_x86_64/usr/include/x86_64-linux-gnu' '-isystem external/sysroot_linux_x86_64/usr/include' '-include external/rules_ml_toolchain/cc/cuda/clang/clang_cuda_runtime_wrapper.h' -Wno-invalid-partial-specialization '--cuda-path=external/cuda_nvcc' -nocudainc -nostdinc++ -nostdinc -Wall -fcolor-diagnostics -no-canonical-prefixes -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' --sysroot external/sysroot_linux_x86_64 '--target=x86_64-linux-gnu' -Wno-gnu-offsetof-extensions -Qunused-arguments '-Werror=mismatched-tags' -fPIE -ffunction-sections -fdata-sections -fmerge-all-constants -DNDEBUG -g0 -O2 -U_FORTIFY_SOURCE '-D_FORTIFY_SOURCE=1' -fstack-protector -fno-omit-frame-pointer -g0 -DGRPC_BAZEL_BUILD -w '-march=x86-64-v3' -O2 -mavx -g0 '-std=c++17' -DNV_CUDNN_DISABLE_EXCEPTION -c external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc -o bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/local_xla/xla/stream_executor/cuda/_objs/cudnn_plugin/cuda_dnn.o) # Configuration: 85d8e927e7c38ab0b208eae59d6e9daa14c210f1a15188fe2378990fc889d337 # Execution platform: @@local_execution_config_platform//:platform In file included from external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:16: In file included from external/local_xla/xla/stream_executor/cuda/cuda_dnn.h:34: In file included from bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cudnn_frontend_archive/_virtual_includes/cudnn_frontend/third_party/cudnn_frontend/include/cudnn_frontend.h:102: In file included from bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cudnn_frontend_archive/_virtual_includes/cudnn_frontend/third_party/cudnn_frontend/include/cudnn_frontend_ConvDesc.h:32: In file included from bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cudnn_frontend_archive/_virtual_includes/cudnn_frontend/third_party/cudnn_frontend/include/cudnn_frontend_utils.h:186: bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cudnn_frontend_archive/_virtual_includes/cudnn_frontend/third_party/cudnn_frontend/include/cudnn_frontend_shim.h:236:46: error: no matching function for call to 'cudaGraphNodeGetDependentNodes' 236 | cuda_graph_node_get_dependent_nodes, cudaGraphNodeGetDependentNodes, node, pDependentNodes, pNumDependentNodes); | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ bazel-out/k8-opt-exec-ST-0465588ec812/bin/external/cudnn_frontend_archive/_virtual_includes/cudnn_frontend/third_party/cudnn_frontend/include/cudnn_frontend_shim.h:155:68: note: expanded from macro 'NV_FE_CALL_TO_CUDA' 155 | #define NV_FE_CALL_TO_CUDA(function_name, cuda_symbol, ...) return cuda_symbol(__VA_ARGS__); | ^~~~~~~~~~~ external/cuda_cudart/include/cuda_runtime_api.h:11441:39: note: candidate function not viable: requires 4 arguments, but 3 were provided 11441 | extern __host__ cudaError_t CUDARTAPI cudaGraphNodeGetDependentNodes(cudaGraphNode_t node, cudaGraphNode_t *pDependentNodes, cudaGraphEdgeData *edgeData, size_t *pNumDependentNodes); | ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 1 error generated. Target //tensorflow/tools/pip_package:wheel failed to build
```