### PR TITLE
Reland #102094: fix 16kb alignment

### DIFF
--- a/tensorflow/lite/java/src/main/native/BUILD
+++ b/tensorflow/lite/java/src/main/native/BUILD
@@ -94,6 +94,7 @@ cc_library_with_tflite(
     linkopts = [
         "-lm",
         "-ldl",
+        "-Wl,-z,max-page-size=16384",
     ],
     tflite_deps = [
         ":jni_utils",


### PR DESCRIPTION
I accidentally merged it from the UI. Force pushed a rebase that removes it.