### PR TITLE
Add validation to raise clear error for complex dtypes in argsort

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -1363,6 +1363,12 @@ def argsort(a, axis=-1, kind='quicksort', order=None):  # pylint: disable=missin
 
   a = np_array_ops.array(a)
 
+  if a.dtype in (dtypes.complex64, dtypes.complex128):
+    raise TypeError(
+        'argsort does not support complex64/complex128 dtypes on CPU backend. '
+        f'Received dtype: {a.dtype}'
+    )
+
   def _argsort(a, axis, stable):
     if axis is None:
       a = array_ops.reshape(a, [-1])

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -1365,7 +1365,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):  # pylint: disable=missin
 
   if a.dtype in (dtypes.complex64, dtypes.complex128):
     raise TypeError(
-        'argsort does not support complex64/complex128 dtypes on CPU backend. '
+        'argsort does not support complex64/complex128 dtypes. '
         f'Received dtype: {a.dtype}'
     )
 

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -178,6 +178,20 @@ class MathTest(test.TestCase, parameterized.TestCase):
     a = np.zeros(100)
     np.testing.assert_equal(np_math_ops.argsort(a, kind='stable'), r)
 
+    def testArgsortRaisesErrorForComplexDtypes(self):
+      """Test that argsort raises TypeError for complex64 and complex128."""
+      complex64_array = np.array([1+2j, 3+4j, 5+6j], dtype=np.complex64)
+      with self.assertRaisesRegex(
+          TypeError,
+          'argsort does not support complex64/complex128 dtypes'):
+        np_math_ops.argsort(complex64_array)
+    
+      complex128_array = np.array([1+2j, 3+4j, 5+6j], dtype=np.complex128)
+      with self.assertRaisesRegex(
+          TypeError,
+          'argsort does not support complex64/complex128 dtypes'):
+        np_math_ops.argsort(complex128_array)
+
   def testArgMaxArgMin(self):
     data = [
         0,


### PR DESCRIPTION
Fixes #99164

## Summary
Added validation to `np_math_ops.argsort` to raise a clear `TypeError` when complex64 or complex128 dtypes are used, instead of allowing the confusing internal `TopKV2` error.

## Changes
- Added dtype check in `argsort` after array conversion
- Raises `TypeError` with message: "argsort does not support complex64/complex128 dtypes on CPU backend"
- Added test case `testArgsortRaisesErrorForComplexDtypes` to verify both complex dtypes raise the error

## Testing
Added test coverage for both complex64 and complex128 dtypes.