### PR TITLE
TFLite: Fix ReduceSum reference kernel overflow by using GetTensorDat…

### DIFF
--- a/tensorflow/lite/kernels/reduce.cc
+++ b/tensorflow/lite/kernels/reduce.cc
@@ -477,10 +477,10 @@ TfLiteStatus QuantizedMeanOrSum(TfLiteContext* context,
     TF_LITE_ENSURE(
         context,
         reference_ops::QuantizedMeanOrSum(
-            GetTensorData<uint8_t>(op_context.input),
+            GetTensorData<T>(op_context.input),
             op_context.input->params.zero_point, op_context.input->dims->data,
             op_context.input->dims->size,
-            GetTensorData<uint8_t>(op_context.output), op_data->multiplier,
+            GetTensorData<T>(op_context.output), op_data->multiplier,
             op_data->shift, op_context.output->params.zero_point,
             op_context.output->dims->data, op_context.output->dims->size,
             GetTensorData<int>(op_context.axis), num_axis,

--- a/tensorflow/lite/kernels/reduce_test.cc
+++ b/tensorflow/lite/kernels/reduce_test.cc
@@ -1986,7 +1986,7 @@ TEST(ConstFloatProdOpTest, EmptyAxis) {
 }  // namespace
 }  // namespace tflite
 
-// TEST
+// TEST //
 TEST(QuantizedReduceSumTest, Int8ReferenceKernelNoOverflow) {
   using ::tflite::TensorType_INT8;
   using ::tflite::TensorType_INT32;


### PR DESCRIPTION
…a<T> instead of uint8_t as he mentioned.