### PR TITLE
Fix TypeError when serializing tf.nn.log_softmax activation

### DIFF
--- a/tensorflow/python/keras/activations.py
+++ b/tensorflow/python/keras/activations.py
@@ -32,6 +32,7 @@ from tensorflow.python.util import dispatch
 # canonical name.
 _TF_ACTIVATIONS_V2 = {
     'softmax_v2': 'softmax',
+    'log_softmax_v2': 'log_softmax',
 }
 
 


### PR DESCRIPTION
Fixes #102475

Resolves a TypeError that occurs when deserializing Keras models that use tf.nn.log_softmax as an activation function. The error was: TypeError: Could not locate function 'log_softmax_v2'

In TensorFlow 2.x, tf.nn.log_softmax has the internal name 'log_softmax_v2'. During serialization, this internal name was being saved, but during deserialization, Keras couldn't find a function with that name.

The fix adds 'log_softmax_v2': 'log_softmax' to the _TF_ACTIVATIONS_V2 dictionary, which maps v2 internal names to their canonical names during serialization. This follows the same pattern already used for softmax_v2.