### PR TITLE
Fix TensorFlow Lite build error with Android NDK (#102572) 

### DIFF
--- a/tensorflow/lite/delegates/xnnpack/file_util.h
+++ b/tensorflow/lite/delegates/xnnpack/file_util.h
@@ -15,7 +15,9 @@ limitations under the License.
 #ifndef TENSORFLOW_LITE_DELEGATES_XNNPACK_FILE_UTIL_H_
 #define TENSORFLOW_LITE_DELEGATES_XNNPACK_FILE_UTIL_H_
 
+#if !defined(_WIN32)
 #include <sys/types.h>
+#endif
 
 #include <cstddef>
 #include <utility>


### PR DESCRIPTION
Fix TensorFlow Lite build error with Android NDK (https://github.com/tensorflow/tensorflow/issues/102572)
Guard sys/types.h include to prevent build failures on Windows and
certain Android NDK configurations.

The file_util.h header unconditionally included <sys/types.h>, which
is not available or doesn't properly define off_t on Windows. Since
the code already handles Windows separately by using __int64 for the
Offset type alias instead of off_t, the sys/types.h include is only
needed on POSIX systems.

This fix adds a platform guard to only include sys/types.h on
non-Windows platforms, preventing compilation errors when building
TensorFlow Lite for Android with CMake and Android NDK.

Fixes https://github.com/tensorflow/tensorflow/issues/102572