### PR TITLE
Fix plot_model with rankdir='LR' producing empty images

### DIFF
--- a/tensorflow/python/keras/utils/vis_utils.py
+++ b/tensorflow/python/keras/utils/vis_utils.py
@@ -333,7 +333,12 @@ def plot_model(model,
   else:
     extension = extension[1:]
   # Save image to disk.
-  dot.write(to_file, format=extension)
+  dot_data = dot.create(prog='dot', format=extension)
+  if not dot_data:
+    raise OSError('pydot failed to generate graph visualization. '
+                  'Check that graphviz is installed and in your PATH.')
+  with open(to_file, 'wb') as f:
+    f.write(dot_data)
   # Return the image as a Jupyter Image object, to be displayed in-line.
   # Note that we cannot easily detect whether the code is running in a
   # notebook, and thus we always return the Image if Jupyter is available.


### PR DESCRIPTION
Replace pydot.write() with explicit create() and file write to ensure proper graph generation across all rankdir settings. The write() method in pydot has inconsistent behavior when prog parameter is not explicitly specified, leading to failures with certain graph attributes.

The create() method with prog='dot' explicitly specified ensures the correct graphviz program is invoked and all graph attributes including rankdir are properly respected.

Fixes #102880