### PR TITLE
Add dtype note for IsotonicRegression op

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_IsotonicRegression.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_IsotonicRegression.pbtxt
@@ -13,12 +13,25 @@ END
 A (batch_size, dim)-tensor holding the per-batch element solutions.
 END
   }
-    out_arg {
+  out_arg {
     name: "segments"
     description: <<END
 An int32 (batch_size, dim)-tensor with the segments.
 END
   }
-  attr { name: "output_dtype"  description: "Dtype of output." }
+  attr {
+    name: "output_dtype"
+    description: <<END
+Dtype of the output tensor.
+
+Note on supported input-output type combinations:
+* For floating-point types, the output has the same dtype as the input.
+* For 8-bit and 16-bit integer inputs, the output is a 32-bit float.
+* For 32-bit and 64-bit integer inputs, the output is a 64-bit float.
+
+Using unsupported dtype pairs (for example, input=float64 with output=float32)
+will result in a "Could not find device for node" error.
+END
+  }
   summary: "Solves a batch of isotonic regression problems."
 }


### PR DESCRIPTION
This PR adds a documentation note for `tf.raw_ops.IsotonicRegression` describing the supported dtype combinations.

### Changes
- Updated `tensorflow/core/api_def/base_api/api_def_IsotonicRegression.pbtxt`
- Added notes about valid input-output dtype pairs:
  * Floating-point inputs keep the same dtype.
  * 8- and 16-bit integer inputs output 32-bit floats.
  * 32- and 64-bit integer inputs output 64-bit floats.
- Mentioned that unsupported dtype pairs raise a "Could not find device for node" error.

This helps clarify dtype behavior and addresses issue #103352.
