### PR TITLE
Fix simplememoryarena null check

### DIFF
--- a/tensorflow/lite/simple_memory_arena.cc
+++ b/tensorflow/lite/simple_memory_arena.cc
@@ -290,8 +290,17 @@ TfLiteStatus SimpleMemoryArena::Commit(bool* arena_reallocated) {
   // based, they will remain valid in the new memory block.
   *arena_reallocated = underlying_buffer_.Resize(high_water_mark_);
   committed_ = true;
+
+  //  Fix: Add null check to prevent crash if allocation failed
+  if (underlying_buffer_.GetPtr() == nullptr && high_water_mark_ > 0) {
+    TF_LITE_REPORT_ERROR(error_reporter_, "Failed to allocate arena of size %zu bytes.", high_water_mark_);
+    return kTfLiteError;
+  }
+
   return kTfLiteOk;
 }
+
+
 
 TfLiteStatus SimpleMemoryArena::ResolveAlloc(
     TfLiteContext* context, const ArenaAllocWithUsageInterval& alloc,


### PR DESCRIPTION
### Summary
This PR fixes a potential crash in `SimpleMemoryArena::Commit` caused by a missing null check after memory reallocation.

When `aligned_realloc` fails to allocate memory, `underlying_buffer_.GetPtr()` becomes `nullptr`, but the function previously returned `kTfLiteOk`. This could lead to undefined behavior or crashes during tensor allocation.

### Changes
- Added a null check after `underlying_buffer_.Resize(high_water_mark_)`.
- Return `kTfLiteError` and log an error via `TF_LITE_REPORT_ERROR` if allocation fails and `high_water_mark_ > 0`.


### Related Issue
Fixes: #101361

---
