### PR TITLE
Tflite: Fix QuantizedMeanOrSum template type in refkernel

### DIFF
--- a/tensorflow/lite/kernels/reduce.cc
+++ b/tensorflow/lite/kernels/reduce.cc
@@ -477,10 +477,10 @@ TfLiteStatus QuantizedMeanOrSum(TfLiteContext* context,
     TF_LITE_ENSURE(
         context,
         reference_ops::QuantizedMeanOrSum(
-            GetTensorData<uint8_t>(op_context.input),
+            GetTensorData<T>(op_context.input),
             op_context.input->params.zero_point, op_context.input->dims->data,
             op_context.input->dims->size,
-            GetTensorData<uint8_t>(op_context.output), op_data->multiplier,
+            GetTensorData<T>(op_context.output), op_data->multiplier,
             op_data->shift, op_context.output->params.zero_point,
             op_context.output->dims->data, op_context.output->dims->size,
             GetTensorData<int>(op_context.axis), num_axis,


### PR DESCRIPTION
Fixes ReduceSum overflow for non-uint8 tensors by passing the template type to GetTensorData in the QuantizedMeanOrSum.