### PR TITLE
[tosa] Fix tosa compile error

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tfl_passes.h
+++ b/tensorflow/compiler/mlir/tosa/tfl_passes.h
@@ -42,8 +42,8 @@ struct TOSATFLLegalizationPipelineOptions
       llvm::cl::desc("Dequantize the TFLite softmax"), llvm::cl::init(false)};
 
   TOSATFLLegalizationPipelineOptions() {
-    disabled_patterns = std::nullopt;
-    enabled_patterns = std::nullopt;
+    disabled_patterns = {};
+    enabled_patterns = {};
   }
 };
 

--- a/tensorflow/compiler/mlir/tosa/transforms/passes.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/passes.h
@@ -53,8 +53,8 @@ std::unique_ptr<OperationPass<func::FuncOp>> createFuseBiasTFPass();
 // `enabledPatterns` is a set of labels used to filter out input patterns that
 //  do not have one of the labels in this set.
 std::unique_ptr<OperationPass<func::FuncOp>> createLegalizeTFLPass(
-    ArrayRef<std::string> disabled_patterns = std::nullopt,
-    ArrayRef<std::string> enabled_patterns = std::nullopt);
+    ArrayRef<std::string> disabled_patterns = {},
+    ArrayRef<std::string> enabled_patterns = {});
 
 std::unique_ptr<OperationPass<ModuleOp>> createRetainCallOnceFuncsPass();
 std::unique_ptr<OperationPass<ModuleOp>> createStripModuleMetadataPass();


### PR DESCRIPTION
changed ArrayRef default assigns from std::nullopt to {}

//tensorflow/compiler/mlir/tosa/tests:convert-tfl-uint8.mlir.test        PASSED in 0.9s
//tensorflow/compiler/mlir/tosa/tests:convert_metadata.mlir.test         PASSED in 0.8s
//tensorflow/compiler/mlir/tosa/tests:fuse-bias-tf.mlir.test             PASSED in 0.9s
//tensorflow/compiler/mlir/tosa/tests:lower-complex-types.mlir.test      PASSED in 0.8s
//tensorflow/compiler/mlir/tosa/tests:multi_add.mlir.test                PASSED in 0.9s
//tensorflow/compiler/mlir/tosa/tests:retain_call_once_funcs.mlir.test   PASSED in 0.9s
//tensorflow/compiler/mlir/tosa/tests:strip-quant-types.mlir.test        PASSED in 0.9s
//tensorflow/compiler/mlir/tosa/tests:strip_metadata.mlir.test           PASSED in 0.9s
//tensorflow/compiler/mlir/tosa/tests:tf-tfl-to-tosa-pipeline.mlir.test  PASSED in 0.9s
//tensorflow/compiler/mlir/tosa/tests:tf-to-tosa-pipeline.mlir.test      PASSED in 1.2s
//tensorflow/compiler/mlir/tosa/tests:tf-unequal-ranks.mlir.test         PASSED in 1.0s
//tensorflow/compiler/mlir/tosa/tests:tfl-to-tosa-dequantize_softmax.mlir.test PASSED in 0.8s
//tensorflow/compiler/mlir/tosa/tests:tfl-to-tosa-pipeline-filtered.mlir.test PASSED in 0.9s
//tensorflow/compiler/mlir/tosa/tests:tfl-to-tosa-pipeline-unimplemented.mlir.test PASSED in 1.0s
//tensorflow/compiler/mlir/tosa/tests:tfl-to-tosa-pipeline.mlir.test     PASSED in 5.0s
//tensorflow/compiler/mlir/tosa/tests:tfl-to-tosa-stateful.mlir.test     PASSED in 1.0s
//tensorflow/compiler/mlir/tosa/tests:tfl-unequal-ranks.mlir.test        PASSED in 0.9s
//tensorflow/compiler/mlir/tosa/tests:tosa-legalize-tfl.mlir.test        PASSED in 1.0s
//tensorflow/compiler/mlir/tosa/tests:verify_fully_converted.mlir.test   PASSED in 0.8s

Executed 19 out of 19 tests: 19 tests pass.