### PR TITLE
Corrected padding in softmax. In FP16 without this the softmax for pa…

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/tasks/softmax.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/softmax.cc
@@ -95,8 +95,11 @@ std::string GetSoftmaxTwoPassKernelCode(const OperationDef& op_def,
   c += "    float4 m_i, n_i;\n";
   c += "    FLT4 result;\n";
   c += GetExpCalculation("t", "m_i", "n_i", exp_func);
-  c += "    result = TO_FLT4(m_i * " + pow_func +
-       "(2.0f, n_i - n_sum) / m_sum);\n";
+  c += "    float4 normalized = m_i * " + pow_func + "(2.0f, n_i - n_sum) / m_sum;\n";
+  c += "    if (d * 4 + 1 >= args.dst_tensor.Channels()) normalized.y = 0.0f;\n";
+  c += "    if (d * 4 + 2 >= args.dst_tensor.Channels()) normalized.z = 0.0f;\n";
+  c += "    if (d * 4 + 3 >= args.dst_tensor.Channels()) normalized.w = 0.0f;\n";
+  c += "    result = TO_FLT4(normalized);\n";
   c += "    args.dst_tensor.Write(result, X, Y, d);\n";
   c += "  }\n";
   c += "}\n";


### PR DESCRIPTION
Corrected padding in softmax. In FP16 without this the softmax for padded zeros in original image goes to inf. Since for padded values n_i is 0 and n_sum is not