### PR TITLE
Fix: Formatting and Cleanup in Python Wrapper/API Files

### DIFF
--- a/tensorflow/c/eager/c_api_experimental_reader.cc
+++ b/tensorflow/c/eager/c_api_experimental_reader.cc
@@ -1,6 +1,6 @@
 /* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");;
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/tensorflow/c/eager/c_api_experimental_reader.h
+++ b/tensorflow/c/eager/c_api_experimental_reader.h
@@ -1,6 +1,6 @@
 /* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");;
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/tensorflow/python/framework/python_memory_checker_helper.cc
+++ b/tensorflow/python/framework/python_memory_checker_helper.cc
@@ -1,6 +1,6 @@
 /* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");;
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/tensorflow/python/saved_model/pywrap_saved_model.cc
+++ b/tensorflow/python/saved_model/pywrap_saved_model.cc
@@ -1,6 +1,6 @@
 /* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");;
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/tensorflow/python/saved_model/pywrap_saved_model_constants.cc
+++ b/tensorflow/python/saved_model/pywrap_saved_model_constants.cc
@@ -1,6 +1,6 @@
 /* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");;
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/tensorflow/python/saved_model/pywrap_saved_model_fingerprinting.cc
+++ b/tensorflow/python/saved_model/pywrap_saved_model_fingerprinting.cc
@@ -1,6 +1,6 @@
 /* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");;
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/tensorflow/python/saved_model/pywrap_saved_model_metrics.cc
+++ b/tensorflow/python/saved_model/pywrap_saved_model_metrics.cc
@@ -1,6 +1,6 @@
 /* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");;
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/tensorflow/python/tfe_wrapper.cc
+++ b/tensorflow/python/tfe_wrapper.cc
@@ -1,6 +1,6 @@
 /* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");;
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/tensorflow/python/tfe_wrapper_monitoring_reader.cc
+++ b/tensorflow/python/tfe_wrapper_monitoring_reader.cc
@@ -1,6 +1,6 @@
 /* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");;
+Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 


### PR DESCRIPTION
Changes:
- Remove the extra semicolon after `("License");`