### PR TITLE
Add missing header inclusion

### DIFF
--- a/third_party/xla/xla/tsl/util/stats_calculator.h
+++ b/third_party/xla/xla/tsl/util/stats_calculator.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define XLA_TSL_UTIL_STATS_CALCULATOR_H_
 
 #include <stdlib.h>
+#include <stdint.h>
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
'#include <stdint.h>' is needed for int64_t.