### PR TITLE
ci: improve requirements updater BUILD targets with visibility, tags,…

### DIFF
--- a/ci/official/requirements_updater/BUILD.bazel
+++ b/ci/official/requirements_updater/BUILD.bazel
@@ -21,7 +21,9 @@ genrule(
     name = "nvidia_constraints",
     srcs = ["nvidia-requirements.txt"],
     outs = ["nvidia-constraints.txt"],
-    cmd = """sed -E "s/>=/==/" $(location nvidia-requirements.txt) > $@;""",
+    cmd = """sed -E "s/>=/==/" $(location nvidia-requirements.txt) > $@""",
+    visibility = ["//visibility:public"],
+    tags = ["ci_tool"],
 )
 
 compile_pip_requirements(
@@ -39,4 +41,7 @@ compile_pip_requirements(
     ],
     generate_hashes = True,
     requirements_txt = REQUIREMENTS,
+    visibility = ["//visibility:public"],
+    tags = ["ci_tool"],
+    timeout = "long",
 )


### PR DESCRIPTION
… and timeout  - Add explicit `visibility` to both genrule and compile_pip_requirements - Add `tags = ["ci_tool"]` to mark CI-related build targets - Add `timeout = "long"` for reliability on slower CI runners - Minor cleanup in genrule command formatting

### Summary

This PR improves the BUILD configuration for the requirements update logic under `ci/official/requirements_updater` by adding Bazel hygiene and CI-oriented metadata.

### Changes
- Added explicit `visibility = ["//visibility:public"]` to both targets.
- Added `tags = ["ci_tool"]` for clearer categorization in CI pipelines.
- Added `timeout = "long"` to prevent premature failures on slower runners.
- Cleaned up the `genrule` command by removing an unnecessary trailing semicolon.

### Why?

These changes make the CI tooling more robust, clearer to downstream targets, and more consistent with Bazel best practices.

This touches only CI infra and does not affect user-facing APIs or TensorFlow behavior.