### PR TITLE
Add tf_model_summary CLI for inspecting model architectures

### DIFF
--- a/tensorflow/tools/model_summary_cli/BUILD
+++ b/tensorflow/tools/model_summary_cli/BUILD
@@ -1,0 +1,86 @@
+# Description:
+#   TensorFlow Model Summary CLI tool
+
+load("//tensorflow:py.default.bzl", "py_library")
+load("//tensorflow:strict.default.bzl", "py_strict_library", "py_strict_test")
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = ["//tensorflow:internal"],
+    licenses = ["notice"],
+)
+
+py_strict_library(
+    name = "model_loader",
+    srcs = ["model_loader.py"],
+    deps = [
+        "//tensorflow/python/keras/saving",
+        "//tensorflow/python/platform:tf_logging",
+    ],
+)
+
+py_strict_library(
+    name = "layer_parser",
+    srcs = ["layer_parser.py"],
+    deps = [
+        "//tensorflow/python/keras/utils:layer_utils",
+    ],
+)
+
+py_strict_library(
+    name = "formatter",
+    srcs = ["formatter.py"],
+)
+
+py_strict_library(
+    name = "visualization",
+    srcs = ["visualization.py"],
+    deps = [
+        "//tensorflow/python/keras/utils:vis_utils",
+    ],
+)
+
+py_strict_library(
+    name = "cli",
+    srcs = ["cli.py"],
+    deps = [
+        ":formatter",
+        ":layer_parser",
+        ":model_loader",
+        ":visualization",
+        "@absl_py//absl:app",
+    ],
+)
+
+py_strict_test(
+    name = "model_loader_test",
+    srcs = ["model_loader_test.py"],
+    deps = [
+        ":model_loader",
+        "//tensorflow/python/keras:layers",
+        "//tensorflow/python/keras:models",
+        "//tensorflow/python/platform:test",
+    ],
+)
+
+py_strict_test(
+    name = "layer_parser_test",
+    srcs = ["layer_parser_test.py"],
+    deps = [
+        ":layer_parser",
+        "//tensorflow/python/keras:layers",
+        "//tensorflow/python/keras:models",
+        "//tensorflow/python/platform:test",
+    ],
+)
+
+py_strict_test(
+    name = "cli_test",
+    srcs = ["cli_test.py"],
+    deps = [
+        ":cli",
+        "//tensorflow/python/keras:layers",
+        "//tensorflow/python/keras:models",
+        "//tensorflow/python/platform:test",
+    ],
+)

--- a/tensorflow/tools/model_summary_cli/README.md
+++ b/tensorflow/tools/model_summary_cli/README.md
@@ -1,0 +1,149 @@
+# TensorFlow Model Summary CLI
+
+A command-line tool for inspecting TensorFlow/Keras model architectures without writing Python code.
+
+## Usage
+
+```bash
+tf_model_summary <model_path> [options]
+```
+
+## Supported Formats
+
+- **SavedModel**: Directory containing `saved_model.pb`
+- **HDF5**: `.h5`, `.hdf5` files
+- **Keras**: `.keras` files
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--plot FILE` | Export model graph to PNG or SVG file |
+| `--json` | Output model summary in JSON format |
+| `--line-length N` | Width of printed summary lines |
+| `--show-shapes` | Show input/output shapes in plot (default: True) |
+| `--show-layer-names` | Show layer names in plot (default: True) |
+| `--expand-nested` | Expand nested models in plot (default: False) |
+| `--dpi N` | DPI for plot output (default: 96) |
+| `-v, --version` | Show version number |
+
+## Examples
+
+### View Model Architecture
+
+```bash
+tf_model_summary ./saved_model/
+tf_model_summary ./model.h5
+tf_model_summary ./model.keras
+```
+
+### Export Visualization
+
+```bash
+tf_model_summary ./model.h5 --plot architecture.png
+tf_model_summary ./model.h5 --plot architecture.svg
+```
+
+### JSON Output for Scripting
+
+```bash
+tf_model_summary ./model.h5 --json
+tf_model_summary ./model.h5 --json | jq '.total_params'
+```
+
+### Customize Output
+
+```bash
+tf_model_summary ./model.h5 --line-length 120
+tf_model_summary ./model.h5 --plot out.png --expand-nested --dpi 150
+```
+
+## Sample Output
+
+### Standard Output
+
+```
+Model: ./model.keras
+
+Model: "sequential"
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
+┃ Layer (type)                    ┃ Output Shape           ┃       Param # ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
+│ dense (Dense)                   │ (None, 64)             │           704 │
+├─────────────────────────────────┼────────────────────────┼───────────────┤
+│ dense_1 (Dense)                 │ (None, 32)             │         2,080 │
+├─────────────────────────────────┼────────────────────────┼───────────────┤
+│ dense_2 (Dense)                 │ (None, 1)              │            33 │
+└─────────────────────────────────┴────────────────────────┴───────────────┘
+ Total params: 2,817 (11.00 KB)
+ Trainable params: 2,817 (11.00 KB)
+ Non-trainable params: 0 (0.00 B)
+```
+
+### JSON Output
+
+```json
+{
+  "model_name": "sequential",
+  "model_class": "Sequential",
+  "total_params": 2817,
+  "trainable_params": 2817,
+  "non_trainable_params": 0,
+  "layers": [
+    {
+      "name": "dense",
+      "class": "Dense",
+      "output_shape": "(None, 64)",
+      "params": 704,
+      "trainable": true
+    },
+    {
+      "name": "dense_1",
+      "class": "Dense",
+      "output_shape": "(None, 32)",
+      "params": 2080,
+      "trainable": true
+    },
+    {
+      "name": "dense_2",
+      "class": "Dense",
+      "output_shape": "(None, 1)",
+      "params": 33,
+      "trainable": true
+    }
+  ]
+}
+```
+
+## Optional Dependencies
+
+For visualization export (`--plot`), install:
+
+```bash
+pip install pydot
+# Plus graphviz via system package manager:
+# macOS: brew install graphviz
+# Ubuntu: apt-get install graphviz
+# Windows: choco install graphviz
+```
+
+## Module Structure
+
+```
+tensorflow/tools/model_summary_cli/
+├── __init__.py        # Package marker
+├── cli.py             # Main CLI entry point
+├── model_loader.py    # Model loading with format detection
+├── layer_parser.py    # Layer information extraction
+├── formatter.py       # Output formatting (JSON)
+├── visualization.py   # PNG/SVG export wrapper
+└── BUILD              # Bazel build file
+```
+
+## Entry Point
+
+Registered in `tensorflow/tools/pip_package/setup.py.tpl`:
+
+```python
+'tf_model_summary = tensorflow.tools.model_summary_cli.cli:cli_main'
+```

--- a/tensorflow/tools/model_summary_cli/__init__.py
+++ b/tensorflow/tools/model_summary_cli/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""TensorFlow Model Summary CLI tool."""

--- a/tensorflow/tools/model_summary_cli/cli.py
+++ b/tensorflow/tools/model_summary_cli/cli.py
@@ -1,0 +1,191 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""TensorFlow Model Summary CLI - inspect model architectures from command line."""
+
+import argparse
+import sys
+
+from absl import app
+
+from tensorflow.tools.model_summary_cli import model_loader
+
+
+FLAGS = None
+
+
+def create_parser():
+  """Create argument parser for tf_model_summary CLI."""
+  parser = argparse.ArgumentParser(
+      prog='tf_model_summary',
+      description='Inspect TensorFlow/Keras model architecture without writing Python code.',
+      formatter_class=argparse.RawDescriptionHelpFormatter,
+      epilog="""
+Examples:
+  # View model architecture
+  tf_model_summary ./saved_model/
+  tf_model_summary ./model.h5
+  tf_model_summary ./model.keras
+
+  # Export visualization
+  tf_model_summary ./model.h5 --plot architecture.png
+  tf_model_summary ./model.h5 --plot architecture.svg
+
+  # JSON output for scripting
+  tf_model_summary ./model.h5 --json
+  tf_model_summary ./model.h5 --json | jq '.total_params'
+
+  # Customize output
+  tf_model_summary ./model.h5 --line-length 120
+  tf_model_summary ./model.h5 --plot out.png --expand-nested --dpi 150
+
+Supported formats:
+  - SavedModel (directory containing saved_model.pb)
+  - HDF5 (.h5, .hdf5 files)
+  - Keras (.keras files)
+
+For visualization, install optional dependencies:
+  pip install pydot
+  # Plus graphviz via system package manager
+      """)
+
+  parser.register('type', 'bool', lambda v: v.lower() == 'true')
+
+  parser.add_argument(
+      'model_path',
+      type=str,
+      help='Path to the model file or SavedModel directory.')
+
+  parser.add_argument(
+      '--plot',
+      type=str,
+      default=None,
+      metavar='FILE',
+      help='Export model graph to PNG or SVG file (requires pydot and graphviz).')
+
+  parser.add_argument(
+      '--line-length',
+      type=int,
+      default=None,
+      dest='line_length',
+      help='Width of printed summary lines (default: auto-detect based on model type).')
+
+  parser.add_argument(
+      '--show-shapes',
+      nargs='?',
+      const=True,
+      type='bool',
+      default=True,
+      dest='show_shapes',
+      help='Show input/output shapes in plot output (default: True).')
+
+  parser.add_argument(
+      '--show-layer-names',
+      nargs='?',
+      const=True,
+      type='bool',
+      default=True,
+      dest='show_layer_names',
+      help='Show layer names in plot output (default: True).')
+
+  parser.add_argument(
+      '--expand-nested',
+      nargs='?',
+      const=True,
+      type='bool',
+      default=False,
+      dest='expand_nested',
+      help='Expand nested models in plot output (default: False).')
+
+  parser.add_argument(
+      '--dpi',
+      type=int,
+      default=96,
+      help='DPI for plot output (default: 96).')
+
+  parser.add_argument(
+      '--json',
+      action='store_true',
+      default=False,
+      help='Output model summary in JSON format.')
+
+  parser.add_argument(
+      '-v', '--version',
+      action='version',
+      version='tf_model_summary 1.0.0')
+
+  return parser
+
+
+def run_summary(args):
+  """Execute the model summary command."""
+  try:
+    model = model_loader.load_model(args.model_path)
+  except model_loader.ModelLoadError as e:
+    print(str(e), file=sys.stderr)
+    return 1
+
+  # JSON output mode
+  if args.json:
+    from tensorflow.tools.model_summary_cli import layer_parser
+    from tensorflow.tools.model_summary_cli import formatter
+    model_info = layer_parser.get_model_info(model)
+    print(formatter.format_model_summary_json(model_info))
+  else:
+    # Standard summary output
+    print(f"Model: {args.model_path}")
+    print()
+    try:
+      model.summary(line_length=args.line_length)
+    except Exception as e:
+      print(f"Error generating summary: {e}", file=sys.stderr)
+      return 1
+
+  # Handle plot export if requested
+  if args.plot:
+    from tensorflow.tools.model_summary_cli import visualization
+    try:
+      visualization.export_model_plot(
+          model,
+          args.plot,
+          show_shapes=args.show_shapes,
+          show_layer_names=args.show_layer_names,
+          expand_nested=args.expand_nested,
+          dpi=args.dpi
+      )
+      if not args.json:
+        print(f"\nModel graph exported to: {args.plot}")
+    except visualization.VisualizationError as e:
+      print(f"\nError: {e}", file=sys.stderr)
+      return 1
+
+  return 0
+
+
+def main(_):
+  """Main entry point."""
+  global FLAGS
+  return run_summary(FLAGS)
+
+
+def cli_main():
+  """CLI entry point for console_scripts."""
+  global FLAGS
+  parser = create_parser()
+  FLAGS, unparsed = parser.parse_known_args()
+  app.run(main=main, argv=[sys.argv[0]] + unparsed)
+
+
+if __name__ == '__main__':
+  cli_main()

--- a/tensorflow/tools/model_summary_cli/cli_test.py
+++ b/tensorflow/tools/model_summary_cli/cli_test.py
@@ -1,0 +1,105 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for CLI module."""
+
+import json
+import os
+import sys
+import tempfile
+from io import StringIO
+
+from tensorflow.python.keras import layers
+from tensorflow.python.keras import models
+from tensorflow.python.platform import test
+
+from tensorflow.tools.model_summary_cli import cli
+
+
+class CreateParserTest(test.TestCase):
+
+  def test_parser_creation(self):
+    parser = cli.create_parser()
+    self.assertIsNotNone(parser)
+
+  def test_parse_basic_args(self):
+    parser = cli.create_parser()
+    args = parser.parse_args(['./model.h5'])
+    self.assertEqual(args.model_path, './model.h5')
+    self.assertIsNone(args.plot)
+    self.assertFalse(args.json)
+
+  def test_parse_with_plot(self):
+    parser = cli.create_parser()
+    args = parser.parse_args(['./model.h5', '--plot', 'out.png'])
+    self.assertEqual(args.plot, 'out.png')
+
+  def test_parse_with_json(self):
+    parser = cli.create_parser()
+    args = parser.parse_args(['./model.h5', '--json'])
+    self.assertTrue(args.json)
+
+  def test_parse_with_line_length(self):
+    parser = cli.create_parser()
+    args = parser.parse_args(['./model.h5', '--line-length', '120'])
+    self.assertEqual(args.line_length, 120)
+
+
+class RunSummaryTest(test.TestCase):
+
+  def test_run_summary_json_output(self):
+    with tempfile.NamedTemporaryFile(suffix='.h5', delete=False) as f:
+      model = models.Sequential([
+          layers.Dense(10, input_shape=(5,), name='dense_1')
+      ])
+      model.save(f.name)
+
+      try:
+        parser = cli.create_parser()
+        args = parser.parse_args([f.name, '--json'])
+
+        # Capture stdout
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+
+        result = cli.run_summary(args)
+
+        output = sys.stdout.getvalue()
+        sys.stdout = old_stdout
+
+        self.assertEqual(result, 0)
+        # Verify JSON is valid
+        data = json.loads(output)
+        self.assertEqual(data['model_name'], 'sequential')
+        self.assertEqual(len(data['layers']), 1)
+      finally:
+        os.unlink(f.name)
+
+  def test_run_summary_nonexistent_model(self):
+    parser = cli.create_parser()
+    args = parser.parse_args(['/nonexistent/model'])
+
+    # Capture stderr
+    old_stderr = sys.stderr
+    sys.stderr = StringIO()
+
+    result = cli.run_summary(args)
+
+    sys.stderr = old_stderr
+
+    self.assertEqual(result, 1)
+
+
+if __name__ == '__main__':
+  test.main()

--- a/tensorflow/tools/model_summary_cli/formatter.py
+++ b/tensorflow/tools/model_summary_cli/formatter.py
@@ -1,0 +1,80 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Output formatting for tf_model_summary CLI."""
+
+
+def format_params(count, note=None):
+  """Format parameter count with optional note.
+
+  Args:
+    count: Integer parameter count.
+    note: Optional note string (e.g., 'unused').
+
+  Returns:
+    Formatted string.
+  """
+  if note:
+    return f"{count:,} ({note})"
+  return f"{count:,}"
+
+
+def format_shape(shape):
+  """Format a shape tuple for display.
+
+  Args:
+    shape: Shape tuple or string.
+
+  Returns:
+    Formatted string.
+  """
+  if isinstance(shape, str):
+    return shape
+  if shape is None:
+    return '?'
+  return str(shape)
+
+
+def format_model_summary_json(model_info):
+  """Format model information as JSON.
+
+  Args:
+    model_info: Dictionary from get_model_info().
+
+  Returns:
+    JSON string.
+  """
+  import json
+
+  # Convert to JSON-serializable format
+  output = {
+      'model_name': model_info['name'],
+      'model_class': model_info['class_name'],
+      'total_params': model_info['total_params'],
+      'trainable_params': model_info['trainable_params'],
+      'non_trainable_params': model_info['non_trainable_params'],
+      'layers': []
+  }
+
+  for layer in model_info['layers']:
+    layer_output = {
+        'name': layer['name'],
+        'class': layer['class_name'],
+        'output_shape': format_shape(layer['output_shape']),
+        'params': layer['params'],
+        'trainable': layer['trainable'],
+    }
+    output['layers'].append(layer_output)
+
+  return json.dumps(output, indent=2)

--- a/tensorflow/tools/model_summary_cli/layer_parser.py
+++ b/tensorflow/tools/model_summary_cli/layer_parser.py
@@ -1,0 +1,100 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Layer information extraction for tf_model_summary CLI."""
+
+
+def get_layer_info(layer):
+  """Extract information from a single layer.
+
+  Args:
+    layer: A Keras layer instance.
+
+  Returns:
+    A dictionary containing layer information.
+  """
+  info = {
+      'name': layer.name,
+      'class_name': layer.__class__.__name__,
+      'trainable': layer.trainable,
+      'dtype': str(layer.dtype) if hasattr(layer, 'dtype') else 'unknown',
+  }
+
+  # Get output shape safely
+  try:
+    info['output_shape'] = layer.output_shape
+  except AttributeError:
+    info['output_shape'] = 'multiple'
+  except RuntimeError:
+    info['output_shape'] = '?'
+
+  # Get parameter count safely
+  try:
+    if not layer.built:
+      info['params'] = 0
+      info['params_note'] = 'unused'
+    else:
+      info['params'] = layer.count_params()
+      info['params_note'] = None
+  except Exception:  # pylint: disable=broad-except
+    info['params'] = 0
+    info['params_note'] = 'error'
+
+  return info
+
+
+def get_model_info(model):
+  """Extract comprehensive information from a model.
+
+  Args:
+    model: A Keras model instance.
+
+  Returns:
+    A dictionary containing model information.
+  """
+  from tensorflow.python.keras.utils import layer_utils
+
+  # Determine model type
+  is_sequential = model.__class__.__name__ == 'Sequential'
+  is_graph_network = getattr(model, '_is_graph_network', False)
+
+  info = {
+      'name': model.name,
+      'class_name': model.__class__.__name__,
+      'is_sequential': is_sequential,
+      'is_graph_network': is_graph_network,
+      'layers': [],
+  }
+
+  # Extract layer information
+  for layer in model.layers:
+    info['layers'].append(get_layer_info(layer))
+
+  # Calculate parameter totals
+  try:
+    trainable_weights = getattr(
+        model, '_collected_trainable_weights',
+        model.trainable_weights
+    )
+    info['trainable_params'] = layer_utils.count_params(trainable_weights)
+    info['non_trainable_params'] = layer_utils.count_params(
+        model.non_trainable_weights
+    )
+    info['total_params'] = info['trainable_params'] + info['non_trainable_params']
+  except Exception:  # pylint: disable=broad-except
+    info['trainable_params'] = 0
+    info['non_trainable_params'] = 0
+    info['total_params'] = 0
+
+  return info

--- a/tensorflow/tools/model_summary_cli/layer_parser_test.py
+++ b/tensorflow/tools/model_summary_cli/layer_parser_test.py
@@ -1,0 +1,76 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for layer_parser module."""
+
+from tensorflow.python.keras import layers
+from tensorflow.python.keras import models
+from tensorflow.python.platform import test
+
+from tensorflow.tools.model_summary_cli import layer_parser
+
+
+class GetLayerInfoTest(test.TestCase):
+
+  def test_dense_layer_info(self):
+    layer = layers.Dense(10, input_shape=(5,), name='test_dense')
+    layer.build((None, 5))
+    info = layer_parser.get_layer_info(layer)
+
+    self.assertEqual(info['name'], 'test_dense')
+    self.assertEqual(info['class_name'], 'Dense')
+    self.assertEqual(info['trainable'], True)
+    self.assertEqual(info['params'], 60)  # 5*10 weights + 10 biases
+    self.assertIsNone(info['params_note'])
+
+  def test_unbuilt_layer_info(self):
+    layer = layers.Dense(10, name='unbuilt')
+    info = layer_parser.get_layer_info(layer)
+
+    self.assertEqual(info['params'], 0)
+    self.assertEqual(info['params_note'], 'unused')
+
+
+class GetModelInfoTest(test.TestCase):
+
+  def test_sequential_model_info(self):
+    model = models.Sequential([
+        layers.Dense(10, input_shape=(5,), name='dense_1'),
+        layers.Dense(1, name='dense_2')
+    ], name='test_model')
+
+    info = layer_parser.get_model_info(model)
+
+    self.assertEqual(info['name'], 'test_model')
+    self.assertEqual(info['class_name'], 'Sequential')
+    self.assertTrue(info['is_sequential'])
+    self.assertEqual(len(info['layers']), 2)
+    self.assertEqual(info['total_params'], 71)  # (5*10+10) + (10*1+1)
+
+  def test_functional_model_info(self):
+    inputs = layers.Input(shape=(5,), name='input')
+    x = layers.Dense(10, name='dense')(inputs)
+    outputs = layers.Dense(1, name='output')(x)
+    model = models.Model(inputs, outputs, name='functional_model')
+
+    info = layer_parser.get_model_info(model)
+
+    self.assertEqual(info['name'], 'functional_model')
+    self.assertEqual(info['class_name'], 'Functional')
+    self.assertFalse(info['is_sequential'])
+    self.assertTrue(info['is_graph_network'])
+
+
+if __name__ == '__main__':
+  test.main()

--- a/tensorflow/tools/model_summary_cli/model_loader.py
+++ b/tensorflow/tools/model_summary_cli/model_loader.py
@@ -1,0 +1,124 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Model loading utilities for tf_model_summary CLI."""
+
+import os
+
+from tensorflow.python.keras.saving import save as keras_save
+from tensorflow.python.platform import tf_logging as logging
+
+
+class ModelLoadError(Exception):
+  """Raised when a model cannot be loaded."""
+  pass
+
+
+def detect_format(model_path):
+  """Detect the format of a model file or directory.
+
+  Args:
+    model_path: Path to the model file or directory.
+
+  Returns:
+    A string indicating the format: 'savedmodel', 'h5', 'keras', or 'unknown'.
+  """
+  if not os.path.exists(model_path):
+    return 'not_found'
+
+  # Check if it's a directory (SavedModel)
+  if os.path.isdir(model_path):
+    # SavedModel should contain saved_model.pb or saved_model.pbtxt
+    pb_path = os.path.join(model_path, 'saved_model.pb')
+    pbtxt_path = os.path.join(model_path, 'saved_model.pbtxt')
+    if os.path.exists(pb_path) or os.path.exists(pbtxt_path):
+      return 'savedmodel'
+    return 'unknown'
+
+  # Check file extension for HDF5/Keras formats
+  if model_path.endswith('.h5') or model_path.endswith('.hdf5'):
+    return 'h5'
+  if model_path.endswith('.keras'):
+    return 'keras'
+
+  # Try to detect HDF5 format by file signature
+  try:
+    import h5py
+    if h5py.is_hdf5(model_path):
+      return 'h5'
+  except ImportError:
+    pass
+
+  return 'unknown'
+
+
+def load_model(model_path, compile_model=False):
+  """Load a TensorFlow/Keras model from disk.
+
+  Args:
+    model_path: Path to the model file or directory.
+    compile_model: Whether to compile the model after loading.
+
+  Returns:
+    A loaded Keras model.
+
+  Raises:
+    ModelLoadError: If the model cannot be loaded.
+  """
+  detected_format = detect_format(model_path)
+
+  if detected_format == 'not_found':
+    raise ModelLoadError(
+        f"Error: Path does not exist: '{model_path}'\n"
+        "Please provide a valid path to a SavedModel directory, "
+        ".h5 file, or .keras file."
+    )
+
+  if detected_format == 'unknown':
+    raise ModelLoadError(
+        f"Error: Could not determine model format for: '{model_path}'\n"
+        "Supported formats:\n"
+        "  - SavedModel (directory with saved_model.pb)\n"
+        "  - HDF5 (.h5, .hdf5 files)\n"
+        "  - Keras (.keras files)"
+    )
+
+  logging.info(f"Detected format: {detected_format}")
+  logging.info(f"Loading model from: {model_path}")
+
+  try:
+    model = keras_save.load_model(model_path, compile=compile_model)
+    return model
+  except Exception as e:
+    error_msg = str(e)
+
+    # Provide helpful context based on common errors
+    if 'custom_objects' in error_msg.lower():
+      raise ModelLoadError(
+          f"Error: Failed to load model from '{model_path}'\n"
+          f"The model contains custom layers or objects that could not be "
+          f"deserialized.\n"
+          f"Original error: {error_msg}"
+      )
+    elif 'No file or directory found' in error_msg:
+      raise ModelLoadError(
+          f"Error: Could not load model at '{model_path}'\n"
+          f"The path exists but does not contain a valid model.\n"
+          f"Original error: {error_msg}"
+      )
+    else:
+      raise ModelLoadError(
+          f"Error: Failed to load model from '{model_path}'\n"
+          f"Original error: {error_msg}"
+      )

--- a/tensorflow/tools/model_summary_cli/model_loader_test.py
+++ b/tensorflow/tools/model_summary_cli/model_loader_test.py
@@ -1,0 +1,116 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for model_loader module."""
+
+import os
+import tempfile
+
+from tensorflow.python.keras import layers
+from tensorflow.python.keras import models
+from tensorflow.python.platform import test
+
+from tensorflow.tools.model_summary_cli import model_loader
+
+
+class DetectFormatTest(test.TestCase):
+
+  def test_nonexistent_path(self):
+    result = model_loader.detect_format('/nonexistent/path')
+    self.assertEqual(result, 'not_found')
+
+  def test_h5_extension(self):
+    with tempfile.NamedTemporaryFile(suffix='.h5', delete=False) as f:
+      # Create a minimal valid model and save
+      model = models.Sequential([layers.Dense(1, input_shape=(1,))])
+      model.save(f.name)
+      try:
+        result = model_loader.detect_format(f.name)
+        self.assertEqual(result, 'h5')
+      finally:
+        os.unlink(f.name)
+
+  def test_keras_extension(self):
+    with tempfile.NamedTemporaryFile(suffix='.keras', delete=False) as f:
+      model = models.Sequential([layers.Dense(1, input_shape=(1,))])
+      model.save(f.name)
+      try:
+        result = model_loader.detect_format(f.name)
+        self.assertEqual(result, 'keras')
+      finally:
+        os.unlink(f.name)
+
+  def test_savedmodel_directory(self):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      model_path = os.path.join(tmpdir, 'saved_model')
+      model = models.Sequential([layers.Dense(1, input_shape=(1,))])
+      model.save(model_path, save_format='tf')
+      result = model_loader.detect_format(model_path)
+      self.assertEqual(result, 'savedmodel')
+
+  def test_unknown_format(self):
+    with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as f:
+      f.write(b'not a model')
+      try:
+        result = model_loader.detect_format(f.name)
+        self.assertEqual(result, 'unknown')
+      finally:
+        os.unlink(f.name)
+
+
+class LoadModelTest(test.TestCase):
+
+  def test_load_nonexistent_raises(self):
+    with self.assertRaises(model_loader.ModelLoadError) as ctx:
+      model_loader.load_model('/nonexistent/path')
+    self.assertIn('does not exist', str(ctx.exception))
+
+  def test_load_unknown_format_raises(self):
+    with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as f:
+      f.write(b'not a model')
+      try:
+        with self.assertRaises(model_loader.ModelLoadError) as ctx:
+          model_loader.load_model(f.name)
+        self.assertIn('could not determine', str(ctx.exception).lower())
+      finally:
+        os.unlink(f.name)
+
+  def test_load_h5_model(self):
+    with tempfile.NamedTemporaryFile(suffix='.h5', delete=False) as f:
+      original = models.Sequential([
+          layers.Dense(10, input_shape=(5,), name='dense_1'),
+          layers.Dense(1, name='dense_2')
+      ])
+      original.save(f.name)
+      try:
+        loaded = model_loader.load_model(f.name)
+        self.assertEqual(len(loaded.layers), 2)
+        self.assertEqual(loaded.layers[0].name, 'dense_1')
+      finally:
+        os.unlink(f.name)
+
+  def test_load_savedmodel(self):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      model_path = os.path.join(tmpdir, 'saved_model')
+      original = models.Sequential([
+          layers.Dense(10, input_shape=(5,), name='dense_1'),
+          layers.Dense(1, name='dense_2')
+      ])
+      original.save(model_path, save_format='tf')
+      loaded = model_loader.load_model(model_path)
+      self.assertEqual(len(loaded.layers), 2)
+
+
+if __name__ == '__main__':
+  test.main()

--- a/tensorflow/tools/model_summary_cli/visualization.py
+++ b/tensorflow/tools/model_summary_cli/visualization.py
@@ -1,0 +1,75 @@
+# Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Visualization utilities for tf_model_summary CLI."""
+
+
+class VisualizationError(Exception):
+  """Raised when visualization fails."""
+  pass
+
+
+def check_visualization_deps():
+  """Check if visualization dependencies are available.
+
+  Returns:
+    Tuple of (available: bool, message: str).
+  """
+  try:
+    from tensorflow.python.keras.utils import vis_utils
+    if vis_utils.check_pydot():
+      return True, "Visualization dependencies available."
+    else:
+      return False, (
+          "Visualization requires pydot and graphviz.\n"
+          "Install with:\n"
+          "  pip install pydot\n"
+          "  # And install graphviz via your system package manager"
+      )
+  except ImportError as e:
+    return False, f"Missing dependency: {e}"
+
+
+def export_model_plot(model, output_path, show_shapes=True,
+                      show_layer_names=True, expand_nested=False,
+                      dpi=96):
+  """Export model architecture to image file.
+
+  Args:
+    model: A Keras model instance.
+    output_path: Path for output file (PNG or SVG).
+    show_shapes: Whether to show shapes in the plot.
+    show_layer_names: Whether to show layer names.
+    expand_nested: Whether to expand nested models.
+    dpi: Image resolution.
+
+  Raises:
+    VisualizationError: If export fails.
+  """
+  available, message = check_visualization_deps()
+  if not available:
+    raise VisualizationError(message)
+
+  try:
+    from tensorflow.python.keras.utils import vis_utils
+    vis_utils.plot_model(
+        model,
+        to_file=output_path,
+        show_shapes=show_shapes,
+        show_layer_names=show_layer_names,
+        expand_nested=expand_nested,
+        dpi=dpi
+    )
+  except Exception as e:
+    raise VisualizationError(f"Failed to export plot: {e}")

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -226,6 +226,7 @@ COMMON_PIP_DEPS = [
     "//tensorflow/tools/common:test_module1",
     "//tensorflow/tools/common:traverse",
     "//tensorflow/tools/docs:tf_doctest_lib",
+    "//tensorflow/tools/model_summary_cli:cli",
     "@local_tsl//tsl/profiler/protobuf:trace_events_proto_py",
     "//tensorflow/python/distribute:parameter_server_strategy_v2",
     "//tensorflow/python/distribute/coordinator:cluster_coordinator",

--- a/tensorflow/tools/pip_package/setup.py.tpl
+++ b/tensorflow/tools/pip_package/setup.py.tpl
@@ -190,6 +190,7 @@ CONSOLE_SCRIPTS = [
     'tflite_convert = tensorflow.lite.python.tflite_convert:main',
     'toco = tensorflow.lite.python.tflite_convert:main',
     'saved_model_cli = tensorflow.python.tools.saved_model_cli:main',
+    'tf_model_summary = tensorflow.tools.model_summary_cli.cli:cli_main',
     (
         'import_pb_to_tensorboard ='
         ' tensorflow.python.tools.import_pb_to_tensorboard:main'


### PR DESCRIPTION
New command-line tool to inspect TensorFlow/Keras models without writing Python code. Supports SavedModel, HDF5, and .keras formats with options for JSON output and PNG/SVG visualization export.