### PR TITLE
Fix segmentation fault in AsString with large width values

### DIFF
--- a/tensorflow/core/kernels/as_string_op.cc
+++ b/tensorflow/core/kernels/as_string_op.cc
@@ -92,6 +92,16 @@ class AsStringOp : public OpKernel {
     if (width_ <= -1) {
       width_ = 0;
     }
+    
+    // Check for unreasonably large width values to prevent memory exhaustion
+    // and segmentation faults when absl::StrFormat tries to allocate buffers
+    const int kMaxReasonableWidth = 1000000;  // 1 million characters
+    OP_REQUIRES(ctx, width_ <= kMaxReasonableWidth,
+                errors::InvalidArgument(
+                    "Width value ", width_, " is too large. "
+                    "Maximum allowed width is ", kMaxReasonableWidth, ". "
+                    "Large width values can cause memory exhaustion and crashes."));
+    
     // If input is string and width unspecified, simply forward to output.
     if (dtype == DT_STRING && width_ <= 0) {
       return;

--- a/tensorflow/core/kernels/as_string_op_test.cc
+++ b/tensorflow/core/kernels/as_string_op_test.cc
@@ -252,5 +252,19 @@ TEST_F(AsStringGraphTest, FillWithChar4) {
   ASSERT_TRUE(absl::StrContains(s.message(), "Fill argument not supported"));
 }
 
+TEST_F(AsStringGraphTest, LargeWidthFailsGracefully) {
+  // Test that extremely large width values fail gracefully instead of crashing
+  int int_max = 2147483647;
+  absl::Status s = Init(DT_FLOAT, /*fill=*/"", /*width=*/int_max);
+  ASSERT_EQ(error::INVALID_ARGUMENT, s.code());
+  ASSERT_TRUE(absl::StrContains(s.message(), "too large"));
+  ASSERT_TRUE(absl::StrContains(s.message(), "Maximum allowed width"));
+  
+  // Test with very large but still reasonable width
+  absl::Status s2 = Init(DT_FLOAT, /*fill=*/"", /*width=*/2000000);
+  ASSERT_EQ(error::INVALID_ARGUMENT, s2.code());
+  ASSERT_TRUE(absl::StrContains(s2.message(), "too large"));
+}
+
 }  // end namespace
 }  // end namespace tensorflow

--- a/tensorflow/python/kernel_tests/strings_ops/as_string_op_test.py
+++ b/tensorflow/python/kernel_tests/strings_ops/as_string_op_test.py
@@ -204,6 +204,30 @@ class AsStringOpTest(test.TestCase):
     )
     self.assertAllEqual(widened_string, "       hello, world!")
 
+  def testLargeWidthFailsGracefully(self):
+    """Test that extremely large width values fail gracefully instead of crashing."""
+    input_data = ops.convert_to_tensor([3.1415926, 2.71828], dtype=dtypes.float32)
+    
+    # Test with INT_MAX width value (should fail gracefully)
+    int_max = 2147483647
+    with self.assertRaisesOpError("too large"):
+      self.evaluate(
+          string_ops.as_string(
+              input_data,
+              precision=2,
+              scientific=True,
+              shortest=False,
+              width=int_max,
+              fill='0'
+          )
+      )
+    
+    # Test with very large but still reasonable width
+    with self.assertRaisesOpError("too large"):
+      self.evaluate(
+          string_ops.as_string(input_data, width=2000000)
+      )
+
 
 if __name__ == "__main__":
   test.main()


### PR DESCRIPTION
Add bounds checking to prevent segmentation faults when AsString is called with extremely large width parameter values (e.g., INT_MAX).

The fix adds validation to check for unreasonably large width values before attempting string formatting operations that would cause memory exhaustion and crashes.

Changes:
1. Add width bounds checking (max 1 million characters)
2. Return clear InvalidArgument error instead of crashing
3. Add comprehensive test coverage for edge cases

Fixes #105292 where width=INT_MAX causes segfault.