### PR TITLE
Fix an error in the doc of tf.strided_slice

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -982,8 +982,8 @@ def slice(input_, begin, size, name=None):
 
   Args:
     input_: A `Tensor`.
-    begin: An `int32` or `int64` `Tensor`.
-    size: An `int32` or `int64` `Tensor`.
+    begin: An `int16`, `int32` or `int64` `Tensor`.
+    size: An `int16`, `int32` or `int64` `Tensor`.
     name: A name for the operation (optional).
 
   Returns:


### PR DESCRIPTION
As mentioned in https://github.com/tensorflow/tensorflow/issues/105470, there are inconsistencies between the implementation and documentation of tf.slice, same as https://github.com/tensorflow/tensorflow/pull/92956, this PR fixes this issue.