### PR TITLE
[oneDNN] Improve oneDNN primitive caching performance

### DIFF
--- a/tensorflow/core/util/BUILD
+++ b/tensorflow/core/util/BUILD
@@ -298,6 +298,7 @@ filegroup(
         "mkl_heuristics.h",
         "mkl_util.h",
         "onednn_env_vars.h",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@local_xla//xla/tsl/util:onednn_util_hdrs",
     ],
     visibility = ["//tensorflow/core:__pkg__"],

--- a/tensorflow/core/util/mkl_util.h
+++ b/tensorflow/core/util/mkl_util.h
@@ -24,6 +24,7 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "oneapi/dnnl/dnnl.hpp"
 #include "oneapi/dnnl/dnnl_threadpool.hpp"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -1963,7 +1964,7 @@ class LRUCache {
   size_t capacity_;
 
   // The cache, a map from string key to a LRU entry.
-  std::unordered_map<string, Entry> cache_;
+  absl::flat_hash_map<string, Entry> cache_;
 
   // The LRU list of entries.
   // The front of the list contains the key of the most recently accessed


### PR DESCRIPTION
This PR replaces std::unordered_map with **absl::flat_hash_map** for oneDNN primitive op "cache_" implementation.

Both GetOp() and SetOp() performance improves (about 4.7X and 1.13X for inner-product/matmul ops).