### PR TITLE
Fix MKL Conv1D crash with dynamic batch size

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
@@ -568,18 +568,19 @@ class MklConvCustomBackpropInputOp
   }
 
   // Handle dynamic shape of input tensor.
-  template <typename T>
+  template <typename TShape>
   std::vector<int64> HandleDynamicShape(const Tensor& input_tensor,
-                                          OpKernelContext* context) {
+                                        OpKernelContext* context) {
+
     // Returns a vector with the explicit shape if dynamic, or an empty vector otherwise.
     std::vector<int64> explicit_shape;
-    auto shape_vec = input_tensor.flat<T>();
+    auto shape_vec = input_tensor.flat<TShape>();
 
     if (shape_vec(0) == -1) {
       const Tensor& diff_dst_tensor = MklGetInput(context, kOutbpropIdx);
       int64 batch_size = diff_dst_tensor.dim_size(0);
       for (int i = 0; i < input_tensor.NumElements(); i++) {
-        T val = shape_vec(i);
+        TShape val = shape_vec(i);
         explicit_shape.push_back(val == -1 ? batch_size : val);
       }
     }

--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
@@ -551,7 +551,6 @@ class MklConvCustomBackpropInputOp
   }
 
  private:
-
   const int kInputIdx = 0, kFilterIdx = 1, kOutbpropIdx = 2;
   const int kDilationH = 0, kDilationW = 1;
 
@@ -570,11 +569,10 @@ class MklConvCustomBackpropInputOp
 
   // Handle dynamic shape of input tensor.
   template <typename T>
-  std::vector<int64_t> HandleDynamicShape(const Tensor& input_tensor,
+  std::vector<int64> HandleDynamicShape(const Tensor& input_tensor,
                                           OpKernelContext* context) {
-
     // Returns a vector with the explicit shape if dynamic, or an empty vector otherwise.
-    std::vector<int64_t> explicit_shape;
+    std::vector<int64> explicit_shape;
     auto shape_vec = input_tensor.flat<T>();
 
     if (shape_vec(0) == -1) {
@@ -595,7 +593,7 @@ class MklConvCustomBackpropInputOp
     CHECK_EQ(TensorShapeUtils::IsVector(input_tensor.shape()), true);
 
     if (input_tensor.NumElements() > 0) {
-      std::vector<int64_t> explicit_shape;
+      std::vector<int64> explicit_shape;
 
       if (input_tensor.dtype() == DT_INT32) {
         explicit_shape = HandleDynamicShape<int32>(input_tensor, context);


### PR DESCRIPTION
This PR fixes Issue #105331 where tf.nn.conv1d_transpose crashes when using the MKL backend with a dynamic batch size (-1). Root Cause : The function MakeInputTfShape was using tensor::MakeShape directly on the input tensor. tensor::MakeShape throws an INVALID_ARGUMENT error if it encounters a -1 dimension. Fix : Added logic to detect if the batch dimension is -1. If detected, the code now infers the correct batch size from the diff_dst (gradient) tensor before creating the shape. Note : I do not have an Intel MKL environment to verify this runtime fix locally, but the logic follows the standard pattern for handling dynamic shapes in other MKL kernels. 