### PR TITLE
Enhance FlatBuffers BUILD with runtime libraries

### DIFF
--- a/third_party/flatbuffers/BUILD.system
+++ b/third_party/flatbuffers/BUILD.system
@@ -1,43 +1,47 @@
 licenses(["notice"])  # Apache 2.0
 
+# Export the FlatBuffers license file
 filegroup(
     name = "LICENSE.txt",
     visibility = ["//visibility:public"],
 )
 
-# Public flatc library to compile flatbuffer files at runtime.
+# Public flatbuffers runtime library (C++)
 cc_library(
     name = "flatbuffers",
     linkopts = ["-lflatbuffers"],
     visibility = ["//visibility:public"],
 )
 
-# Public flatc compiler library.
+# Public flatc compiler library (same system lib)
 cc_library(
     name = "flatc_library",
     linkopts = ["-lflatbuffers"],
     visibility = ["//visibility:public"],
 )
 
-genrule(
-    name = "lnflatc",
-    outs = ["flatc.bin"],
-    cmd = "ln -s $$(which flatc) $@",
+genrule( 
+    name = "lnflatc", 
+    outs = ["flatc.bin"], 
+    cmd = "ln -s $$(which flatc) $@", 
 )
-
-# Public flatc compiler.
 sh_binary(
     name = "flatc",
     srcs = ["flatc.bin"],
     visibility = ["//visibility:public"],
 )
 
+# C++ Runtime: previously empty → added structure
 cc_library(
     name = "runtime_cc",
+    hdrs = glob(["include/flatbuffers/*.h"]),
+    includes = ["include"],  # makes <flatbuffers/...> work
     visibility = ["//visibility:public"],
 )
 
+# Python Runtime: supports imports like `import flatbuffers`
 py_library(
     name = "runtime_py",
+    srcs = glob(["python/flatbuffers/**/*.py"]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
added C++ and Python runtime libraries for FlatBuffers.


1.fixed runtime_py (was empty):
now includes actual Python source files:
2.fixed runtime_cc (was empty and unusable):
exports FlatBuffers headers with hdrs + includes and
makes #include <flatbuffers/foo.h> work.
3.better structure/Readability
