### PR TITLE
[tosa] Update pass macro usage to remove deprecated GEN_PASS_CLASSES API

### DIFF
--- a/tensorflow/compiler/mlir/tosa/transforms/passes.h
+++ b/tensorflow/compiler/mlir/tosa/transforms/passes.h
@@ -70,7 +70,6 @@ std::unique_ptr<OperationPass<func::FuncOp>> createVerifyFullyConvertedPass();
 std::unique_ptr<OperationPass<ModuleOp>> createLegalizeTFLStatefulPass();
 
 #define GEN_PASS_REGISTRATION
-#define GEN_PASS_CLASSES
 #define GEN_PASS_DECL_TOSALEGALIZETFPASS
 #define GEN_PASS_DECL_TOSALEGALIZETFLPASS
 #define GEN_PASS_DECL_TOSALEGALIZETFTFLPASS

--- a/tensorflow/compiler/mlir/tosa/transforms/strip_metadata.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/strip_metadata.cc
@@ -25,7 +25,8 @@ limitations under the License.
 
 namespace mlir::tosa {
 
-#define GEN_PASS_DEF_STRIPM
+#define GEN_PASS_DEF_STRIPFUNCTIONMETADATA
+#define GEN_PASS_DEF_STRIPMODULEMETADATA
 #include "tensorflow/compiler/mlir/tosa/transforms/passes.h.inc"
 
 namespace {
@@ -45,7 +46,7 @@ static bool isTFLAttr(NamedAttribute &namedAttr) {
 }
 
 class StripModuleMetadataPass
-    : public StripModuleMetadataBase<StripModuleMetadataPass> {
+    : public impl::StripModuleMetadataBase<StripModuleMetadataPass> {
  public:
   void runOnOperation() override {
     auto moduleOp = getOperation();
@@ -59,7 +60,7 @@ class StripModuleMetadataPass
 };
 
 class StripFunctionMetadataPass
-    : public StripFunctionMetadataBase<StripFunctionMetadataPass> {
+    : public impl::StripFunctionMetadataBase<StripFunctionMetadataPass> {
  public:
   void runOnOperation() override {
     auto funcOp = getOperation();


### PR DESCRIPTION
Recent LLVM changes have deprecated the GEN_PASS_CLASSES pass-registration interface in favor of per-pass GEN_PASS_DEF_*/GEN_PASS_DECL_* macros. This causes TOSA-related builds in TensorFlow to fail.

This change updates the TOSA pass registrations to the new API:

• Removes use of GEN_PASS_CLASSES in passes.h
• Adds the appropriate GEN_PASS_DEF_STRIPFUNCTIONMETADATA and
  GEN_PASS_DEF_STRIPMODULEMETADATA definitions
• Switches from Strip*MetadataBase to impl::Strip*MetadataBase to match the new
  TableGen-generated namespaces