### PR TITLE
Fix iOS build: correct apple_support platform paths

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -234,7 +234,7 @@ common:apple-toolchain --host_crosstool_top=@local_config_apple_cc//:toolchain
 common:macos_arm64 --cpu=darwin_arm64
 common:macos_arm64 --macos_minimum_os=11.0
 common:macos_arm64 --config=clang_local
-common:macos_arm64 --platforms=@build_bazel_apple_support//configs/platforms:darwin_arm64
+common:macos_arm64 --platforms=@build_bazel_apple_support//platforms:darwin_arm64
 
 # iOS configs for each architecture and the fat binary builds.
 common:ios --apple_platform_type=ios
@@ -247,16 +247,16 @@ common:ios_armv7 --cpu=ios_armv7
 common:ios_armv7 --platforms=@org_tensorflow//tensorflow/tools/toolchains/ios:ios_armv7
 common:ios_arm64 --config=ios
 common:ios_arm64 --cpu=ios_arm64
-common:ios_arm64 --platforms=@build_bazel_apple_support//configs/platforms:ios_arm64
+common:ios_arm64 --platforms=@build_bazel_apple_support//platforms:ios_arm64
 common:ios_arm64e --config=ios
 common:ios_arm64e --cpu=ios_arm64e
-common:ios_arm64e --platforms=@build_bazel_apple_support//configs/platforms:ios_arm64e
+common:ios_arm64e --platforms=@build_bazel_apple_support//platforms:ios_arm64e
 common:ios_sim_arm64 --config=ios
 common:ios_sim_arm64 --cpu=ios_sim_arm64
-common:ios_sim_arm64 --platforms=@build_bazel_apple_support//configs/platforms:ios_sim_arm64
+common:ios_sim_arm64 --platforms=@build_bazel_apple_support//platforms:ios_sim_arm64
 common:ios_x86_64 --config=ios
 common:ios_x86_64 --cpu=ios_x86_64
-common:ios_x86_64 --platforms=@build_bazel_apple_support//configs/platforms:ios_x86_64
+common:ios_x86_64 --platforms=@build_bazel_apple_support//platforms:ios_x86_64
 common:ios_fat --config=ios
 common:ios_fat --ios_multi_cpus=armv7,arm64,i386,x86_64
 


### PR DESCRIPTION
The platform references in .bazelrc were pointing to the incorrect path @build_bazel_apple_support//configs/platforms which doesn't exist in apple_support v1.24.5. Updated all 5 Apple platform configurations to use the correct path
@build_bazel_apple_support//platforms.

This fixes the build error:
'no such package @@build_bazel_apple_support//configs/platforms': BUILD file not found in directory 'configs/platforms'

Fixes [#105127](https://github.com/tensorflow/tensorflow/issues/105127)

Tested on:
- macOS Sequoia 26.0.1 (M1)
- Bazel 7.7.0 (via bazelisk 1.27.0)
- TensorFlow 2.20.0

All 5 platform configurations verified:
- ios_arm64
- ios_arm64e
- ios_sim_arm64
- ios_x86_64
- macos_arm64