### PR TITLE
[tosa] : Don't legalize pool/conv for SAME padding with dynamic spatial dims.

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -1367,6 +1367,25 @@ func.func @test_max_pool2d_slicing(%arg0: tensor<1x32x32x8xf32>) -> tensor<*xf32
 }
 
 // -----
+// CHECK-LABEL: max_pool_same_padding_static_dims
+// CHECK-NOT: tfl.max_pool_2d
+// CHECK: tosa.max_pool2d
+func.func @max_pool_same_padding_static_dims(%arg0: tensor<?x1x1x23xf32>) -> (tensor<?x1x1x23xf32>) {
+%0 = "tfl.max_pool_2d"(%arg0) <{filter_height = 1 : i32, filter_width = 4 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 4 : i32}> : (tensor<?x1x1x23xf32>) -> tensor<?x1x1x23xf32>
+return %0 : tensor<?x1x1x23xf32>
+}
+
+// -----
+// CHECK-LABEL: max_pool_same_padding_unit_stride_dynamic_dims
+// CHECK-NOT: tfl.max_pool_2d
+// CHECK: tosa.max_pool2d
+func.func @max_pool_same_padding_unit_stride_dynamic_dims(%arg0: tensor<?x?x?x23xf32>) -> (tensor<?x?x?x23xf32>) {
+%0 = "tfl.max_pool_2d"(%arg0) <{filter_height = 1 : i32, filter_width = 4 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 1 : i32}> : (tensor<?x?x?x23xf32>) -> tensor<?x?x?x23xf32>
+return %0 : tensor<?x?x?x23xf32>
+}
+
+
+// -----
 
 // CHECK-LABEL: test_reshape
 // CHECK-DAG: %[[VAR10:.*]] = tosa.const_shape {values = dense<[1, 819]> : tensor<2xindex>}

--- a/tensorflow/compiler/mlir/tosa/tests/tosa-legalize-tfl-negative.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tosa-legalize-tfl-negative.mlir
@@ -1,0 +1,42 @@
+// RUN: tf-tosa-opt --split-input-file --tosa-legalize-tfl --verify-diagnostics %s | FileCheck %s
+
+// -----
+// CHECK-LABEL: max_pool_same_padding_dyn
+// CHECK: tfl.max_pool_2d
+func.func @max_pool_same_padding_dyn(%arg0: tensor<?x1x?x23xf32>) -> (tensor<?x1x?x23xf32>) {
+%0 = "tfl.max_pool_2d"(%arg0) <{filter_height = 1 : i32, filter_width = 4 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 4 : i32}> : (tensor<?x1x?x23xf32>) -> tensor<?x1x?x23xf32>
+return %0 : tensor<?x1x?x23xf32>
+}
+
+// -----
+// CHECK-LABEL: avg_pool_same_padding_dyn
+// CHECK: tfl.average_pool_2d
+func.func @avg_pool_same_padding_dyn(%arg0: tensor<?x1x?x23xf32>) -> (tensor<?x1x?x23xf32>) {
+%0 = "tfl.average_pool_2d"(%arg0) <{filter_height = 1 : i32, filter_width = 4 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 4 : i32}> : (tensor<?x1x?x23xf32>) -> tensor<?x1x?x23xf32>
+return %0 : tensor<?x1x?x23xf32>
+}
+
+// -----
+// CHECK-LABEL: conv2d_same_padding_dyn
+// CHECK: tfl.conv_2d
+func.func @conv2d_same_padding_dyn(%input: tensor<1x?x32x8xf32>, %filter: tensor<5x3x3x8xf32>, %bias: tensor<5xf32>) -> tensor<1x32x32x5xf32> {
+  %0 = "tfl.conv_2d"(%input, %filter, %bias) {dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 4 : i32, stride_w = 1 : i32} : (tensor<1x?x32x8xf32>, tensor<5x3x3x8xf32>, tensor<5xf32>) -> tensor<1x32x32x5xf32>
+  return %0 : tensor<1x32x32x5xf32>
+}
+
+// -----
+// CHECK-LABEL: conv3d_same_padding_dyn
+// CHECK: tfl.conv_3d
+func.func @conv3d_same_padding_dyn(%arg0: tensor<2x2x7x?x2xf32>, %arg1: tensor<2x3x3x2x4xf32>) -> tensor<2x2x7x7x4xf32> {
+  %cst = "tfl.no_value"() {value} : () -> none
+  %0 = "tfl.conv_3d"(%arg0, %arg1, %cst) {dilation_d_factor = 1 : i32, dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_d = 1 : i32, stride_h = 1 : i32, stride_w = 4 : i32} : (tensor<2x2x7x?x2xf32>, tensor<2x3x3x2x4xf32>, none) -> tensor<2x2x7x7x4xf32>
+  func.return %0 : tensor<2x2x7x7x4xf32>
+}
+
+// -----
+// CHECK-LABEL: depthwise_conv2d_same_padding_dyn
+// CHECK: tfl.depthwise_conv_2d
+func.func @depthwise_conv2d_same_padding_dyn(%arg0: tensor<?x32x?x8xf32>, %arg1 : tensor<1x1x1x16xf32>, %arg2 : tensor<16xf32>) -> tensor<?x?x?x?xf32> {
+  %2 = "tfl.depthwise_conv_2d"(%arg0, %arg1, %arg2) {depth_multiplier = 2 : i32, dilation_h_factor = 1 : i32, dilation_w_factor = 1 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 3 : i32} : (tensor<?x32x?x8xf32>, tensor<1x1x1x16xf32>, tensor<16xf32>) -> tensor<?x?x?x?xf32>
+  func.return %2 : tensor<?x?x?x?xf32>
+}

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_utils.cc
@@ -1086,6 +1086,13 @@ bool getPaddingValuesFromPadType(tensorflow::Padding tf_pad,
     int64_t dim_dilation = dilations[i];
     int64_t dim_stride = strides[i];
 
+    // if input size is dynamic then we cannot compute static pad shapes for
+    // "SAME" padding for stride != 1
+    if (tf_pad == tensorflow::Padding::SAME && dim_stride != 1 &&
+        input_type.isDynamicDim(ifm_dim)) {
+      return false;
+    }
+
     int64_t ip_size = input_type.getDimSize(ifm_dim);
     int64_t f_size = filter_type.getDimSize(filter_dim);
     // If we have a dynamic shape we should assume it is wide enough.


### PR DESCRIPTION
Source IR:

```
func.func @max_pool_same_padding_dyn(%arg0: tensor<?x1x?x23xf32>) -> (tensor<?x1x?x23xf32>) {
%0 = "tfl.max_pool_2d"(%arg0) <{filter_height = 1 : i32, filter_width = 4 : i32, fused_activation_function = "NONE", padding = "SAME", stride_h = 1 : i32, stride_w = 4 : i32}> : (tensor<?x1x?x23xf32>) -> tensor<?x1x?x23xf32>
return %0 : tensor<?x1x?x23xf32>
}
```

when legalized produces

```
func.func @max_pool_same_padding_dyn(%arg0: tensor<?x1x?x23xf32>) -> tensor<?x1x?x23xf32> {
    %0 = tosa.max_pool2d %arg0 {kernel = array<i64: 1, 4>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 4>} : (tensor<?x1x?x23xf32>) -> tensor<?x1x?x23xf32>
    return %0 : tensor<?x1x?x23xf32>
  }
```

which is incorrect. The current pad computation for `SAME` padding https://github.com/tensorflow/tensorflow/blob/68062bd3ca8a6f938c50e0a778ad2557e64080de/tensorflow/core/framework/kernel_shape_util.cc#L49 doesn't handle dynamic dims. If you substitute `ShapedType::kDynamic` for input/output dim the pad value computed will be negative and then clamped to `0`. 

This is not an issue for `stride = 1` as the `ShapedType::kDynamic` usage will be cancelled out leading to correct computation of `pad`.

The fix here is to generate code to compute the `pad` at runtime based on the actual dimension information of input data. Since `pad` won't be compile time constant, we cannot use `tosa.pad` for this. Instead we will require use of `tensor.dim + tensor.pad`, however since the contract of `tosa-legalize-tfl` pass is to only legalize `tfl` ops with `tosa` ops, this PR is only adding the validation check to not produce the incorrect IR.