### PR TITLE
Clarify that bicubic resize falls back to CPU due to missing GPU kernel

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1717,6 +1717,12 @@ def resize_images_v2(images,
   >>> max_10_20 = tf.image.resize(image, [10,20], preserve_aspect_ratio=True)
   >>> max_10_20.shape.as_list()
   [1, 10, 10, 1]
+  
+  Note:
+    The `bicubic` interpolation method currently does not have a GPU kernel
+    implementation. As a result, `tf.image.resize(..., method='bicubic')`
+    always executes on the CPU, even when GPU devices are available.
+
 
   Args:
     images: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor


### PR DESCRIPTION
This PR adds a note to the `tf.image.resize` documentation to clarify that the
`bicubic` method does not have a GPU kernel and therefore always runs on CPU.
Fixes: #83877
