### PR TITLE
Docs: clarify fft_length behavior for tf.raw_ops.RFFT2D

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_RFFT2D.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_RFFT2D.pbtxt
@@ -38,5 +38,10 @@ positive-frequency terms.
 Along each axis `RFFT2D` is computed on, if `fft_length` is smaller than the
 corresponding dimension of `input`, the dimension is cropped. If it is larger,
 the dimension is padded with zeros.
+
+Note: Currently, if any value in `fft_length` is larger than the corresponding
+dimension of `input`, `tf.raw_ops.RFFT2D` raises an `InvalidArgumentError`
+instead of padding with zeros.
+
 END
 }


### PR DESCRIPTION
This PR clarifies the documentation for tf.raw_ops.RFFT2D to reflect the current
behavior when fft_length exceeds the corresponding input dimension.

Although the documentation previously suggested zero-padding, the operation
currently raises an InvalidArgumentError. This update aligns the documentation
with observed behavior in TensorFlow 2.19 and 2.20.

Related issue: #103640
