### PR TITLE
Fix TFL to TOSA constant truncation to i48 that broke tosa.greater legalization

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
+++ b/tensorflow/compiler/mlir/tosa/tests/tfl-to-tosa-pipeline.mlir
@@ -4168,8 +4168,8 @@ func.func @test_broadcast_to_qi8(%arg0: tensor<13x1x!quant.uniform<i16:f32, 1.0:
 // -----
 
 // CHECK-LABEL: test_broadcast_to_smaller_rank
-// CHECK: %[[VAL_0:.*]] = "tosa.const"() <{values = dense<[13, 7]> : tensor<2xi48>}
-// CHECK: %[[VAL_1:.*]] = "tfl.broadcast_to"(%arg0, %[[VAL_0]]) : (tensor<2x3x13x1xi32>, tensor<2xi48>) -> tensor<13x7xi32>
+// CHECK: %[[VAL_0:.*]] = "tosa.const"() <{values = dense<[13, 7]> : tensor<2xi64>}
+// CHECK: %[[VAL_1:.*]] = "tfl.broadcast_to"(%arg0, %[[VAL_0]]) : (tensor<2x3x13x1xi32>, tensor<2xi64>) -> tensor<13x7xi32>
 // CHECK: return %[[VAL_1]] : tensor<13x7xi32>
 func.func @test_broadcast_to_smaller_rank(%arg0: tensor<2x3x13x1xi32>) -> (tensor<13x7xi32>) {
   %shape = arith.constant dense<[13, 7]> : tensor<2xi64>
@@ -4180,8 +4180,8 @@ func.func @test_broadcast_to_smaller_rank(%arg0: tensor<2x3x13x1xi32>) -> (tenso
 // -----
 
 // CHECK-LABEL: test_broadcast_to_i48
-// CHECK: %[[VAL_0:.*]] = "tosa.const"() <{values = dense<[7, 7, 1, 7]> : tensor<4xi48>}
-// CHECK: %[[VAL_1:.*]] = "tfl.broadcast_to"(%arg0, %[[VAL_0]]) : (tensor<1x1x13x1xi48>, tensor<4xi48>) -> tensor<7x7x13x7xi48>
+// CHECK: %[[VAL_0:.*]] = "tosa.const"() <{values = dense<[7, 7, 1, 7]> : tensor<4xi64>}
+// CHECK: %[[VAL_1:.*]] = "tfl.broadcast_to"(%arg0, %[[VAL_0]]) : (tensor<1x1x13x1xi48>, tensor<4xi64>) -> tensor<7x7x13x7xi48>
 // CHECK: return %[[VAL_1]] : tensor<7x7x13x7xi48>
 func.func @test_broadcast_to_i48(%arg0: tensor<1x1x13x1xi48>) -> (tensor<7x7x13x7xi48>) {
   %shape = arith.constant dense<[7, 7, 1, 7]> : tensor<4xi64>

--- a/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
+++ b/tensorflow/compiler/mlir/tosa/transforms/legalize_tfl.cc
@@ -4339,14 +4339,6 @@ LogicalResult ConvertConstantOp::matchAndRewrite(
   ElementsAttr attr = dyn_cast<ElementsAttr>(tfl_const_op.getValueAttr());
 
   auto e_type = output_type.getElementType();
-  // TOSA only support up to 48-bits
-  // If source is higher than that, it's not representabble.
-  // For data type like 64 bits, we need to truncate them into 48 bits.
-  if (e_type.isInteger(64)) {
-    e_type = rewriter.getIntegerType(48);
-    attr = mlir::cast<DenseIntOrFPElementsAttr>(attr).mapValues(
-        e_type, [](const APInt& x) -> APInt { return x.trunc(48); });
-  }
 
   if (!output_type.hasRank()) {
     if (auto attr_type = dyn_cast<ShapedType>(attr.getType())) {


### PR DESCRIPTION
- removed the legacy code path that truncated every 64-bit TFLite constant down to 48 bits, which produced `tosa.greater` ops whose operands having mismatched integer widths violating the TOSA spec.

- updated the broadcast-to tests so their CHECK lines now expect i64 constants, as legalization now preserves the original element types all the way through.