### PR TITLE
Fix configure.py sysconfig fallback used for Python library path detection

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -160,7 +160,7 @@ def get_python_path(environ_cp, python_bin_path):
         run_shell([
             python_bin_path,
             '-c',
-            'import sysconfig;print(sysconfig.get_path("purelib")',
+            'import sysconfig; print(sysconfig.get_path("purelib"))',
         ])
     ]
 


### PR DESCRIPTION
### Summary
`configure.py:get_python_path()` probes Python’s site-packages via a `python -c` snippet using `site.getsitepackages()`. When that probe fails, it falls back to a `sysconfig.get_path("purelib")` snippet.

The fallback snippet was missing a closing `)`, causing the `python -c` call to raise a `SyntaxError` and potentially breaking `./configure` on environments where the fallback path is exercised.

### Changes
- Fix the sysconfig fallback `python -c` snippet in `configure.py`.

### Testing
- ./configure

### Notes
- Only the fallback command string is changed; the common `site.getsitepackages()` path is unchanged.