### PR TITLE
Go gpuoptions doc

### DIFF
--- a/tensorflow/go/README.md
+++ b/tensorflow/go/README.md
@@ -15,3 +15,35 @@ The TensorFlow team is not currently maintaining the Documentation for installin
 The instructions has been maintained by the third party contributor: @wamuir
 
 Please follow this [source](https://github.com/tensorflow/build/tree/master/golang_install_guide) by @wamuir for the installation of Golang with Tensorflow.
+
+
+## GPU Configuration
+
+The TensorFlow Go bindings do not currently expose `GPUOptions` as a
+first-class API.
+
+However, GPU-related options can be configured by passing a serialized
+`ConfigProto` to `SessionOptions.SetConfig`.
+
+### Example: Enable GPU memory growth
+
+```go
+import (
+    tf "github.com/tensorflow/tensorflow/tensorflow/go"
+    "google.golang.org/protobuf/proto"
+    "tensorflow/core/protobuf/config_pb2"
+)
+
+config := &config_pb2.ConfigProto{
+    GpuOptions: &config_pb2.GPUOptions{
+        AllowGrowth: true,
+    },
+}
+
+configBytes, err := proto.Marshal(config)
+if err != nil {
+    panic(err)
+}
+
+opts := tf.NewSessionOptions()
+opts.SetConfig(configBytes)

--- a/tensorflow/python/kernel_tests/linalg/norm_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/norm_op_test.py
@@ -115,3 +115,33 @@ if __name__ == "__main__":
                                           use_static_shape))
 
   test_lib.main()
+
+# =================================================================================
+import tensorflow as tf
+class NormGradientStabilityTest(tf.test.TestCase):
+
+    def test_gradient_at_zero(self):
+        x = tf.constant([0.0], dtype=tf.float32)
+
+        with tf.GradientTape() as tape:
+            tape.watch(x)
+            y = tf.norm(x)
+
+        grad = tape.gradient(y, x)
+
+        # Gradient should not be NaN or Inf
+        self.assertTrue(
+            tf.reduce_all(tf.math.is_finite(grad)) or grad.numpy()[0] == 0.0
+        )
+
+    def test_gradient_at_small_value(self):
+        x = tf.constant([1e-8], dtype=tf.float32)
+
+        with tf.GradientTape() as tape:
+            tape.watch(x)
+            y = tf.norm(x)
+
+        grad = tape.gradient(y, x)
+
+        # Gradient should be finite
+        self.assertTrue(tf.reduce_all(tf.math.is_finite(grad)))


### PR DESCRIPTION
This PR documents how GPU-related options can be configured in the
TensorFlow Go bindings by passing a serialized ConfigProto to
SessionOptions.SetConfig.

This clarifies the supported approach requested in #22926 without
requiring changes to TensorFlow core or Go bindings.
