### PR TITLE
Go: add ConfigProto and GPUOptions to SessionOptions

### DIFF
--- a/tensorflow/go/config.go
+++ b/tensorflow/go/config.go
@@ -1,0 +1,13 @@
+package tensorflow
+
+// ConfigProto mirrors tensorflow.ConfigProto.
+// This is a Go-friendly representation that can later
+// be serialized into protobuf bytes.
+type ConfigProto struct {
+    GPUOptions *GPUOptions
+}
+
+// GPUOptions mirrors tensorflow.GPUOptions.
+type GPUOptions struct {
+    AllowGrowth bool
+}

--- a/tensorflow/go/session.go
+++ b/tensorflow/go/session.go
@@ -317,6 +317,10 @@ type SessionOptions struct {
 	// tensorflow.ConfigProto protocol message
 	// (https://www.tensorflow.org/code/tensorflow/core/protobuf/config.proto).
 	Config []byte
+
+	// ConfigProto provides a structured alternative to Config.
+    // If set, it can be serialized into Config.
+    ConfigProto *ConfigProto
 }
 
 // c converts the SessionOptions to the C API's TF_SessionOptions. Callers must


### PR DESCRIPTION
This PR introduces typed Go structs for ConfigProto and GPUOptions
as a structured alternative to passing raw protobuf bytes via
SessionOptions.Config.

This change is additive and does not modify runtime behavior.
Serialization and wiring will be handled in a follow-up PR.

Related to #22926.
