### PR TITLE
SPAM: Bugfix: Warn nondeterministic behavior for tf.reduce_min with op determinism enabledBugfix deterministic reduce min

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -105,6 +105,9 @@ from tensorflow.python.util import nest
 from tensorflow.python.util.compat import collections_abc
 from tensorflow.python.util.tf_export import tf_export
 
+from tensorflow.python.framework import config
+from tensorflow.python.platform import tf_logging as logging
+# pylint: disable=redefined-outer-name, unused-import
 
 # Aliases for some automatically-generated names.
 nextafter = gen_math_ops.next_after
@@ -2971,11 +2974,23 @@ def reduce_min(input_tensor, axis=None, keepdims=False, name=None):
   @end_compatibility
   """
   keepdims = False if keepdims is None else bool(keepdims)
+
+  # Warn users when op determinism is enabled but reduce_min may still be nondeterministic.
+  from tensorflow.python.framework import config
+  from tensorflow.python.platform import tf_logging as logging
+
+  if config.is_op_determinism_enabled():
+    logging.warning(
+        "tf.reduce_min may produce nondeterministic results on some GPU "
+        "configurations even when op determinism is enabled."
+    )
+
   return _may_reduce_to_scalar(
       keepdims, axis,
       gen_math_ops._min(
           input_tensor, _ReductionDims(input_tensor, axis), keepdims,
           name=name))
+
 
 
 @tf_export(v1=["math.reduce_max", "reduce_max"])


### PR DESCRIPTION
Fixes #97882

Adds a warning message when `tf.reduce_min` is executed while deterministic
ops are enabled, informing users that this op may still produce nondeterministic
results on some GPU configurations.
