### PR TITLE
SPAM: Replace deprecated `assertRaisesRegexp` with `assertRaisesRegex`

### DIFF
--- a/tensorflow/python/distribute/cluster_resolver/kubernetes_cluster_resolver_test.py
+++ b/tensorflow/python/distribute/cluster_resolver/kubernetes_cluster_resolver_test.py
@@ -98,7 +98,7 @@ class KubernetesClusterResolverTest(test.TestCase):
 
     _mock_kubernetes_module()
 
-    with self.assertRaisesRegexp(ValueError, '.*'):
+    with self.assertRaisesRegex(ValueError, '.*'):
       KubernetesClusterResolver(executable_location=None)
 
   def testSingleItemSuccessfulRetrieval(self):


### PR DESCRIPTION
## Summary
Replace deprecated unittest API `assertRaisesRegexp` with `assertRaisesRegex` in KubernetesClusterResolver tests.

## Motivation
`assertRaisesRegexp` is deprecated in Python's unittest. Using `assertRaisesRegex` avoids deprecation warnings and improves forward-compatibility.

## Changes
- Update [KubernetesClusterResolverTest.testValueErrorRaisedOnInvalidExecutableLocation](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/App/Lanre/tensorflow/tensorflow/python/distribute/cluster_resolver/kubernetes_cluster_resolver_test.py:96:2-101:57) to use `assertRaisesRegex`.
