### PR TITLE
SPAM: Docs: Clarify tf.math.argmax behavior when axis=NoneDocs argmax only

### DIFF
--- a/tensorflow/python/keras/layers/dense_attention.py
+++ b/tensorflow/python/keras/layers/dense_attention.py
@@ -219,9 +219,12 @@ class BaseDenseAttention(Layer):
 class Attention(BaseDenseAttention):
   """Dot-product attention layer, a.k.a. Luong-style attention.
 
-  Inputs are `query` tensor of shape `[batch_size, Tq, dim]`, `value` tensor of
-  shape `[batch_size, Tv, dim]` and `key` tensor of shape
-  `[batch_size, Tv, dim]`. The calculation follows the steps:
+  Inputs are a `query` tensor of shape `[batch_size, Tq, dim]`,
+  a `value` tensor of shape `[batch_size, Tv, dim]`, and an optional
+  `key` tensor of shape `[batch_size, Tv, dim]`.
+  
+  If `key` is not provided, `value` is used as the key (the most
+  common case).
 
   1. Calculate scores with shape `[batch_size, Tq, Tv]` as a `query`-`key` dot
      product: `scores = tf.matmul(query, key, transpose_b=True)`.
@@ -245,9 +248,9 @@ class Attention(BaseDenseAttention):
     inputs: List of the following tensors:
       * query: Query `Tensor` of shape `[batch_size, Tq, dim]`.
       * value: Value `Tensor` of shape `[batch_size, Tv, dim]`.
-      * key: Optional key `Tensor` of shape `[batch_size, Tv, dim]`. If not
-        given, will use `value` for both `key` and `value`, which is the
-        most common case.
+      * key: Optional key `Tensor` of shape `[batch_size, Tv, dim]`.
+      If not provided, `value` is used as the key.
+
     mask: List of the following tensors:
       * query_mask: A boolean mask `Tensor` of shape `[batch_size, Tq]`.
         If given, the output will be zero at the positions where

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -104,10 +104,6 @@ from tensorflow.python.util import dispatch
 from tensorflow.python.util import nest
 from tensorflow.python.util.compat import collections_abc
 from tensorflow.python.util.tf_export import tf_export
-
-from tensorflow.python.framework import config
-from tensorflow.python.platform import tf_logging as logging
-
 # Aliases for some automatically-generated names.
 nextafter = gen_math_ops.next_after
 
@@ -125,7 +121,7 @@ def linspace_nd(start, stop, num, name=None, axis=0):
   If `num <= 0`, `ValueError` is raised.
 
   Matches
-  [np.linspace](https://docs.scipy.org/doc/numpy/reference/generated/numpy.linspace.html)'s
+  [np.linspace](https://docs.scipy.org/doc/numpy/reference/generated/nump\y.linspace.html)'s
   behaviour
   except when `num == 0`.
 
@@ -2973,23 +2969,11 @@ def reduce_min(input_tensor, axis=None, keepdims=False, name=None):
   @end_compatibility
   """
   keepdims = False if keepdims is None else bool(keepdims)
-
-  # Warn users when op determinism is enabled but reduce_min may still be nondeterministic.
-  from tensorflow.python.framework import config
-  from tensorflow.python.platform import tf_logging as logging
-
-  if config.is_op_determinism_enabled():
-    logging.warning(
-        "tf.reduce_min may produce nondeterministic results on some GPU "
-        "configurations even when op determinism is enabled."
-    )
-
   return _may_reduce_to_scalar(
       keepdims, axis,
       gen_math_ops._min(
           input_tensor, _ReductionDims(input_tensor, axis), keepdims,
           name=name))
-
 
 
 @tf_export(v1=["math.reduce_max", "reduce_max"])

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -105,6 +105,8 @@ from tensorflow.python.util import nest
 from tensorflow.python.util.compat import collections_abc
 from tensorflow.python.util.tf_export import tf_export
 
+from tensorflow.python.framework import config
+from tensorflow.python.platform import tf_logging as logging
 
 # Aliases for some automatically-generated names.
 nextafter = gen_math_ops.next_after
@@ -2971,11 +2973,23 @@ def reduce_min(input_tensor, axis=None, keepdims=False, name=None):
   @end_compatibility
   """
   keepdims = False if keepdims is None else bool(keepdims)
+
+  # Warn users when op determinism is enabled but reduce_min may still be nondeterministic.
+  from tensorflow.python.framework import config
+  from tensorflow.python.platform import tf_logging as logging
+
+  if config.is_op_determinism_enabled():
+    logging.warning(
+        "tf.reduce_min may produce nondeterministic results on some GPU "
+        "configurations even when op determinism is enabled."
+    )
+
   return _may_reduce_to_scalar(
       keepdims, axis,
       gen_math_ops._min(
           input_tensor, _ReductionDims(input_tensor, axis), keepdims,
           name=name))
+
 
 
 @tf_export(v1=["math.reduce_max", "reduce_max"])

--- a/tensorflow/python/ops/signal/spectral_ops.py
+++ b/tensorflow/python/ops/signal/spectral_ops.py
@@ -47,6 +47,8 @@ def stft(signals, frame_length, frame_step, fft_length=None,
     frame_step: An integer scalar `Tensor`. The number of samples to step.
     fft_length: An integer scalar `Tensor`. The size of the FFT to apply.
       If not provided, uses the smallest power of 2 enclosing `frame_length`.
+      If `fft_length` is greater than `frame_length`, the input frame is
+      zero-padded to `fft_length` before computing the FFT.
     window_fn: A callable that takes a window length and a `dtype` keyword
       argument and returns a `[window_length]` `Tensor` of samples in the
       provided datatype. If set to `None`, no windowing is used.


### PR DESCRIPTION
This PR clarifies the documentation for tf.math.argmax when axis=None and when ties occur.
It adds examples and wording to improve user understanding.

Fixes part of tensorflow#105721