### PR TITLE
[XLA:CPU]Resolves coredump caused by dereference nullptr of accelerator_device_info

### DIFF
--- a/tensorflow/compiler/jit/xla_launch_util.cc
+++ b/tensorflow/compiler/jit/xla_launch_util.cc
@@ -857,9 +857,12 @@ absl::Status RunPjRtExecutable(
     const XlaCompiler::CompilationResult& compilation_result,
     xla::PjRtClient* pjrt_client, xla::PjRtLoadedExecutable* executable,
     OpKernelContext* ctx) {
-  const bool use_pjrt_tensor_buffer = ctx->device()
-                                          ->tensorflow_accelerator_device_info()
-                                          ->use_pjrt_tensor_buffer;
+  const CompositeDevice::AcceleratorDeviceInfo* accelerator_device_info =
+      ctx->device()->tensorflow_accelerator_device_info();
+  const bool use_pjrt_tensor_buffer =
+      (accelerator_device_info == nullptr)
+          ? true
+          : accelerator_device_info->use_pjrt_tensor_buffer;
 
   const DeviceType& device_type = GetDeviceType(ctx);
   const int pjrt_device_id =


### PR DESCRIPTION
Fix [107818](https://github.com/tensorflow/tensorflow/issues/107818)
For cpu the device type is tensorflow::ThreadPoolDevice, I think it don't have tensorflow_accelerator_device_info, so need add nullptr check
<img width="776" height="68" alt="image" src="https://github.com/user-attachments/assets/09ca8d36-17d6-417c-a6d4-270ccb0ce1f1" />
