### PR TITLE
docs: Update legacy Java README with deprecation notice and SIG-JVM redirect

### DIFF
--- a/tensorflow/java/README.md
+++ b/tensorflow/java/README.md
@@ -1,9 +1,21 @@
-# TensorFlow for Java
 
-> *WARNING*: This version of the Java client is deprecated and has been replaced by a new version that is maintained 
-> in its own [repository](https://github.com/tensorflow/java) under the TensorFlow organization. 
->
-> For using TensorFlow on a JVM, please refer to new [TensorFlow Java](https://www.tensorflow.org/jvm/install).
-> For using TensorFlow on Android, refer instead to [TensorFlow Lite](https://www.tensorflow.org/code/tensorflow/lite/).
+# TensorFlow Java Client (Legacy)
 
-Follow this [link](LEGACY.md) for legacy instructions.
+> [!WARNING]
+> **This version of the Java client is deprecated.** It is based on the legacy TensorFlow 1.x architecture and is no longer actively maintained in this repository.
+
+### 🚀 Migration Guide
+For all current development, research, and production needs, please use the modern **TensorFlow Java** API maintained by **SIG-JVM**. This new version supports TensorFlow 2.x and provides the full suite of modern cryptographic and machine learning features.
+
+* **New Official Repository**: [https://github.com/tensorflow/java](https://github.com/tensorflow/java)
+* **Installation Guide**: [https://www.tensorflow.org/jvm/install](https://www.tensorflow.org/jvm/install)
+
+---
+
+### 📱 Android Development
+If you are looking for Java/Kotlin support on Android, please refer to **LiteRT** (formerly TensorFlow Lite):
+* **LiteRT Documentation**: [https://www.tensorflow.org/lite](https://www.tensorflow.org/lite)
+
+---
+
+*This folder is currently undergoing a phased deletion. For legacy instructions, see [LEGACY.md](LEGACY.md).*


### PR DESCRIPTION
## Summary
This PR updates the legacy `tensorflow/java/README.md` to provide a clearer deprecation warning and redirect users to the modern SIG-JVM repository, as discussed in #58424.

## Related Issues
Fixes #58424

## Changes Made
- Replaced the old README stub with a comprehensive deprecation notice.
- Added direct links to the new `tensorflow/java` repository and official JVM installation guides.
- Added a note regarding the phased deletion of this legacy directory.

## Verification
- Verified that all links are active and point to the correct SIG-JVM and LiteRT resources.

@mihaimaruseac: As we discussed, this is the first step (Documentation Update) before we proceed with the impact analysis for the folder deletion. Please let me know if any further adjustments are needed for the wording.