### PR TITLE
Fix crash when non-scalar step is passed to tf.summary APIs

### DIFF
--- a/tensorflow/python/ops/summary_ops_v2.py
+++ b/tensorflow/python/ops/summary_ops_v2.py
@@ -1044,7 +1044,7 @@ def graph_v1(param, step=None, name=None):
     TypeError: If `param` isn't already a `tf.Tensor` in graph mode.
   """
   if step is not None:
-      _choose_step(step)
+    _choose_step(step)
 
   if not context.executing_eagerly() and not isinstance(
       param, tensor_lib.Tensor

--- a/tensorflow/python/ops/summary_ops_v2.py
+++ b/tensorflow/python/ops/summary_ops_v2.py
@@ -767,6 +767,8 @@ def write(tag, tensor, step=None, metadata=None, name=None):
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
+  if step is not None:
+    _choose_step(step)
   with ops.name_scope(name, "write_summary") as scope:
     if _summary_state.writer is None:
       return constant_op.constant(False)
@@ -838,6 +840,8 @@ def write_raw_pb(tensor, step=None, name=None):
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
+  if step is not None:
+    _choose_step(step)
   with ops.name_scope(name, "write_raw_pb") as scope:
     if _summary_state.writer is None:
       return constant_op.constant(False)
@@ -902,7 +906,8 @@ def summary_writer_function(name, tensor, function, family=None):
 
 def generic(name, tensor, metadata=None, family=None, step=None):
   """Writes a tensor summary if possible."""
-
+  if step is not None:
+    _choose_step(step)
   def function(tag, scope):
     if metadata is None:
       serialized_metadata = constant_op.constant("")
@@ -940,7 +945,8 @@ def scalar(name, tensor, family=None, step=None):
     The created `tf.Operation` or a `tf.no_op` if summary writing has
     not been enabled for this context.
   """
-
+  if step is not None:
+    _choose_step(step)
   def function(tag, scope):
     # Note the identity to move the tensor to the CPU.
     return gen_summary_ops.write_scalar_summary(
@@ -955,7 +961,8 @@ def scalar(name, tensor, family=None, step=None):
 
 def histogram(name, tensor, family=None, step=None):
   """Writes a histogram summary if possible."""
-
+  if step is not None:
+    _choose_step(step)
   def function(tag, scope):
     # Note the identity to move the tensor to the CPU.
     return gen_summary_ops.write_histogram_summary(
@@ -970,7 +977,8 @@ def histogram(name, tensor, family=None, step=None):
 
 def image(name, tensor, bad_color=None, max_images=3, family=None, step=None):
   """Writes an image summary if possible."""
-
+  if step is not None:
+    _choose_step(step)
   def function(tag, scope):
     bad_color_ = (constant_op.constant([255, 0, 0, 255], dtype=dtypes.uint8)
                   if bad_color is None else bad_color)
@@ -989,7 +997,8 @@ def image(name, tensor, bad_color=None, max_images=3, family=None, step=None):
 
 def audio(name, tensor, sample_rate, max_outputs, family=None, step=None):
   """Writes an audio summary if possible."""
-
+  if step is not None:
+    _choose_step(step)
   def function(tag, scope):
     # Note the identity to move the tensor to the CPU.
     return gen_summary_ops.write_audio_summary(
@@ -1034,6 +1043,9 @@ def graph_v1(param, step=None, name=None):
   Raises:
     TypeError: If `param` isn't already a `tf.Tensor` in graph mode.
   """
+  if step is not None:
+      _choose_step(step)
+
   if not context.executing_eagerly() and not isinstance(
       param, tensor_lib.Tensor
   ):
@@ -1212,14 +1224,18 @@ def _serialize_graph(arbitrary_graph):
   else:
     return arbitrary_graph.SerializeToString()
 
-
 def _choose_step(step):
   if step is None:
     return training_util.get_or_create_global_step()
-  if not isinstance(step, tensor_lib.Tensor):
-    return ops.convert_to_tensor(step, dtypes.int64)
-  return step
 
+  step = ops.convert_to_tensor(step, dtypes.int64)
+
+  if step.shape.num_elements() != 1:
+    raise ValueError(
+        "Argument `step` must be a scalar. "
+        f"Received step with shape {step.shape}."
+    )
+  return step
 
 def _check_create_file_writer_args(inside_function, **kwargs):
   """Helper to check the validity of arguments to a create_file_writer() call.
@@ -1412,6 +1428,9 @@ def trace_export(name, step=None, profiler_outdir=None):
   # TODO(stephanlee): See if we can remove profiler_outdir and infer it from
   # the SummaryWriter's logdir.
   global _current_trace_context
+  if step is not None:
+    _choose_step(step)
+
 
   if ops.inside_function():
     logging.warn("Cannot export trace inside a tf.function.")

--- a/tensorflow/python/summary/summary_v2_test.py
+++ b/tensorflow/python/summary/summary_v2_test.py
@@ -69,6 +69,88 @@ class SummaryV2Test(test.TestCase):
     mock_scalar_v2.assert_not_called()
 
   @test_util.run_v2_only
+  def test_tf_summary_scalar_invalid_step_shapes_raise(self):
+    writer = summary_ops_v2.create_summary_file_writer(self.get_temp_dir())
+
+    invalid_steps = [
+        (),            # empty tuple
+        [],            # empty list
+        [1, 2],         # non-scalar list
+        (1, 2),         # non-scalar tuple
+        array_ops.ones((2,)),   # rank-1 tensor
+        array_ops.ones((1, 1)), # rank-2 tensor
+    ]
+
+    with writer.as_default(step=1):
+      for step in invalid_steps:
+        with self.assertRaises(ValueError):
+          summary_ops_v2.scalar("loss", 0.5, step=step)
+
+  @test_util.run_v2_only
+  def test_tf_summary_histogram_invalid_step_raises(self):
+    writer = summary_ops_v2.create_summary_file_writer(self.get_temp_dir())
+
+    with writer.as_default(step=1):
+      with self.assertRaises(ValueError):
+        summary_ops_v2.histogram(
+            "h",
+            array_ops.ones((10,)),
+            step=(),
+        )
+
+  @test_util.run_v2_only
+  def test_tf_summary_image_invalid_step_raises(self):
+    writer = summary_ops_v2.create_summary_file_writer(self.get_temp_dir())
+
+    image = array_ops.ones((1, 4, 4, 3))
+
+    with writer.as_default(step=1):
+      with self.assertRaises(ValueError):
+        summary_ops_v2.image(
+            "img",
+            image,
+            step=(),
+        )
+  @test_util.run_v2_only
+  def test_tf_summary_audio_invalid_step_raises(self):
+    writer = summary_ops_v2.create_summary_file_writer(self.get_temp_dir())
+
+    audio = array_ops.ones((1, 16000, 1))
+
+    with writer.as_default(step=1):
+      with self.assertRaises(ValueError):
+        summary_ops_v2.audio(
+            "audio",
+            audio,
+            sample_rate=16000,
+            max_outputs=1,
+            step=(),
+        )
+
+  @test_util.run_v2_only
+  def test_tf_summary_write_invalid_step_raises(self):
+    writer = summary_ops_v2.create_summary_file_writer(self.get_temp_dir())
+
+    with writer.as_default(step=1):
+      with self.assertRaises(ValueError):
+        summary_ops_v2.write(
+            tag="tag",
+            tensor=constant_op.constant(1.0),
+            step=(),
+        )
+
+  @test_util.run_v2_only
+  def test_tf_summary_trace_export_invalid_step_raises(self):
+    writer = summary_ops_v2.create_summary_file_writer(self.get_temp_dir())
+
+    with writer.as_default():
+      summary_ops_v2.trace_on(graph=True)
+
+      with self.assertRaises(ValueError):
+        summary_ops_v2.trace_export("trace", step=())
+
+
+  @test_util.run_v2_only
   def test_scalar_summary_v2__family(self):
     """Tests `family` arg handling when scalar v2 is invoked."""
     with test.mock.patch.object(


### PR DESCRIPTION
This PR fixes a crash caused by passing a non-scalar `step` to tf.summary APIs.

The root cause was missing Python-side validation before invoking C++ summary ops. A shared validator in `_choose_step` now ensures `step` is scalar and raises a ValueError otherwise.

Affected APIs:
- tf.summary.scalar
- tf.summary.write
- tf.summary.image
- tf.summary.histogram
- tf.summary.audio
- tf.summary.trace_export

The check was added to some other tf.summary APIs for homogeneity. 
Also adds regression tests to prevent future crashes.

Fixes #107978