### PR TITLE
Fix #108143: Constant fold extract_patches arguments for XLA/JIT compilation

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -6311,8 +6311,14 @@ def extract_image_patches_v2(images, sizes, strides, rates, padding, name=None):
   Returns:
     A 4-D Tensor of the same type as the input.
   """
-  return gen_array_ops.extract_image_patches(images, sizes, strides, rates,
-                                             padding, name)
+    if isinstance(sizes, (list, tuple)):
+        sizes = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in sizes]
+    if isinstance(strides, (list, tuple)):
+        strides = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in strides]
+    if isinstance(rates, (list, tuple)):
+        rates = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in rates]
+    return gen_array_ops.extract_image_patches(images, sizes, strides, rates,
+                                                 padding, name)
 
 
 @tf_export(v1=["image.extract_image_patches", "extract_image_patches"])
@@ -6357,8 +6363,14 @@ def extract_image_patches(  # pylint: disable=missing-docstring
   """
   ksizes = deprecation.deprecated_argument_lookup("sizes", sizes, "ksizes",
                                                   ksizes)
-  return gen_array_ops.extract_image_patches(images, ksizes, strides, rates,
-                                             padding, name)
+  if isinstance(ksizes, (list, tuple)):
+    ksizes = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in ksizes]
+  if isinstance(strides, (list, tuple)):
+    strides = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in strides]
+  if isinstance(rates, (list, tuple)):
+    rates = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in rates]
+
+  return gen_array_ops.extract_image_patches(images, ksizes, strides, rates, padding, name)
 
 
 extract_image_patches.__doc__ = gen_array_ops.extract_image_patches.__doc__

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -5572,8 +5572,8 @@ def tensor_scatter_nd_update(tensor, indices, updates, name=None):
     the index vectors each point to scalars in `tensor` and each update is a
     scalar.
   * If the length of the index vectors is less than the rank of `tensor`, then
-    the index vectors each point to the slices of `tensor` and shape of the updates
-    must match that slice.
+    the index vectors each point to the slices of `tensor` and shape of the 
+    updates must match that slice.
 
   Overall this leads to the following shape constraints:
 
@@ -6152,8 +6152,8 @@ def searchsorted(sorted_sequence,
 
   Note: This operation assumes that `sorted_sequence` **is sorted** along the
   innermost axis, maybe using `tf.sort(..., axis=-1)`. **If the sequence is not
-  sorted, no error is raised** and the content of the returned tensor is not well
-  defined.
+  sorted, no error is raised** and the content of the returned tensor is 
+  not well defined.
 
   Args:
     sorted_sequence: N-D `Tensor` containing a sorted sequence.
@@ -6311,14 +6311,24 @@ def extract_image_patches_v2(images, sizes, strides, rates, padding, name=None):
   Returns:
     A 4-D Tensor of the same type as the input.
   """
-    if isinstance(sizes, (list, tuple)):
-        sizes = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in sizes]
-    if isinstance(strides, (list, tuple)):
-        strides = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in strides]
-    if isinstance(rates, (list, tuple)):
-        rates = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in rates]
-    return gen_array_ops.extract_image_patches(images, sizes, strides, rates,
-                                                 padding, name)
+  if isinstance(sizes, (list, tuple)):
+    sizes = [
+        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
+        for s in sizes
+    ]
+  if isinstance(strides, (list, tuple)):
+    strides = [
+        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
+        for s in strides
+    ]
+  if isinstance(rates, (list, tuple)):
+    rates = [
+        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
+        for s in rates
+    ]
+
+  return gen_array_ops.extract_image_patches(
+    images, sizes, strides, rates, padding, name)
 
 
 @tf_export(v1=["image.extract_image_patches", "extract_image_patches"])
@@ -6364,13 +6374,23 @@ def extract_image_patches(  # pylint: disable=missing-docstring
   ksizes = deprecation.deprecated_argument_lookup("sizes", sizes, "ksizes",
                                                   ksizes)
   if isinstance(ksizes, (list, tuple)):
-    ksizes = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in ksizes]
+    ksizes = [
+        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
+        for s in ksizes
+    ]
   if isinstance(strides, (list, tuple)):
-    strides = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in strides]
+    strides = [
+        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
+        for s in strides
+    ]
   if isinstance(rates, (list, tuple)):
-    rates = [tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s for s in rates]
+    rates = [
+        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
+        for s in rates
+    ]
 
-  return gen_array_ops.extract_image_patches(images, ksizes, strides, rates, padding, name)
+  return gen_array_ops.extract_image_patches(
+    images, ksizes, strides, rates, padding, name)  
 
 
 extract_image_patches.__doc__ = gen_array_ops.extract_image_patches.__doc__
@@ -6673,8 +6693,8 @@ def repeat(input, repeats, axis=None, name=None):  # pylint: disable=redefined-b
     repeats: An 1-D `int` Tensor. The number of repetitions for each element.
       repeats is broadcasted to fit the shape of the given axis. `len(repeats)`
       must equal `input.shape[axis]` if axis is not None.
-    axis: An int. The axis along which to repeat values. By default, (axis=None),
-      use the flattened input array, and return a flat output array.
+    axis: An int. The axis along which to repeat values. By default,
+    (axis=None),use the flattened input array, and return a flat output array.
     name: A name for the operation.
 
   Returns:


### PR DESCRIPTION
This PR resolves issue #108143 by ensuring that the sizes (or ksizes), strides, and rates arguments in tf.image.extract_patches are folded into Python integers if they are passed as tf.constant. XLA compilation requires these kernel dimensions to be static integers at compile time. By using tensor_util.constant_value, we extract the literal values from symbolic tensors during graph construction, preventing the TypeError currently encountered when jit_compile=True is enabled. This fix is applied to both the V1 and V2 implementations to ensure consistent behavior across the API.