### PR TITLE
Fix softmax kernel to zero out invalid channels in output

### DIFF
--- a/tensorflow/lite/delegates/gpu/common/tasks/softmax.cc
+++ b/tensorflow/lite/delegates/gpu/common/tasks/softmax.cc
@@ -142,6 +142,9 @@ std::string GetSoftmaxThreePassKernelCode(const OperationDef& op_def) {
   c += "    float4 t = args.src_tensor.Read<float>(X, Y, d) - "
        "INIT_FLOAT4(maximum);\n";
   c += "    t = exp(t) / sum;\n";
+  c += "    if (d * 4 + 1 >= args.dst_tensor.Channels()) t.y = 0.0f;\n";
+  c += "    if (d * 4 + 2 >= args.dst_tensor.Channels()) t.z = 0.0f;\n";
+  c += "    if (d * 4 + 3 >= args.dst_tensor.Channels()) t.w = 0.0f;\n";
   c += "    FLT4 result = TO_FLT4(t);\n";
   c += "    args.dst_tensor.Write(result, X, Y, d);\n";
   c += "  }\n";


### PR DESCRIPTION
Fix softmax kernel to zero out invalid channels in output

The three-pass softmax kernel was missing boundary checks in the final
loop, causing padded channels to receive non-zero softmax values instead
of zero. When input channels are not a multiple of 4, padded zero values
become -maximum after subtraction, and exp(-maximum)/sum produces non-zero
results for invalid channels.

This bug causes incorrect results when:
- Tensors have channel counts not divisible by 4

Fixed by adding boundary checks to explicitly zero out invalid channel
components (t.y, t.z, t.w) before writing the result, ensuring padded
channels remain zero as expected.