### PR TITLE
[XLA:CPU] Add s390x support to XLA CPU intrinsic device detection

### DIFF
--- a/third_party/xla/xla/backends/cpu/codegen/ir_compiler.cc
+++ b/third_party/xla/xla/backends/cpu/codegen/ir_compiler.cc
@@ -355,6 +355,8 @@ llvm::Error IrCompiler::RunIrPasses(llvm::Module& module,
     }
   } else if (target_triple.isAArch64() || target_triple.isARM()) {
     device_type = xla::codegen::intrinsics::DeviceType::kArmCpu;
+  } else if (target_triple.isSystemZ()) {
+    device_type = xla::codegen::intrinsics::DeviceType::kSystemZCpu;
   } else {
     LOG(FATAL) << "Unsupported CPU type: " << target_triple.str();
   }

--- a/third_party/xla/xla/codegen/intrinsic/intrinsic.h
+++ b/third_party/xla/xla/codegen/intrinsic/intrinsic.h
@@ -40,6 +40,7 @@ enum class DeviceType {
   kAmdCpu,
   kIntelCpu,
   kArmCpu,
+  kSystemZCpu,
   kNvidiaGpu,
   kAmdGpu,
 };


### PR DESCRIPTION
Map the LLVM SystemZ target triple to a new DeviceType::kSystemZCpu in XLA CPU codegen, allowing intrinsic implementations to specialize for s390x platforms.