### PR TITLE
Link TargetParser to _pywrap_tfcompile for s390x.

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1524,6 +1524,18 @@ cc_library(
     ),
 )
 
+cc_library(
+    name = "_pywrap_lib_filter",
+    deps = if_pywrap(
+        if_true = select({
+            "@platforms//cpu:s390x": [
+                "@llvm-project//llvm:TargetParser",
+            ],
+            "//conditions:default": [],
+        }),
+    ),
+)
+
 pywrap_library(
     name = "_pywrap_tensorflow",
     # buildifier: disable=unsorted-dict-items
@@ -1608,6 +1620,7 @@ pywrap_library(
         "//tensorflow:macos": False,
         "//conditions:default": True,
     }),
+    pywrap_lib_filter = ":_pywrap_lib_filter",
     starlark_only_deps = [
         "//tensorflow/compiler/mlir/python/mlir_wrapper:filecheck_wrapper",
         "//tensorflow/compiler/mlir/quantization/stablehlo/python:pywrap_quantization",


### PR DESCRIPTION
tfcompile_wrapper.cc contains s390x-specific code that calls TargetParser methods. The new pywrap rules do not link the TargetParser library to the _pywrap_tfcompile Python extension, resulting in undefined reference errors on s390x systems.

This change adds TargetParser to pywrap_lib_filter for s390x machines so that individual Python extensions can link against it when required.