### PR TITLE
Add tensor dimension validation to WriteAudioSummary. Resolves - TensorFlow tf.raw_ops.WriteAudioSummary aborts when provided scalar tensor input #107977

### DIFF
--- a/tensorflow/core/kernels/summary_kernels.cc
+++ b/tensorflow/core/kernels/summary_kernels.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "absl/status/status.h"
 #include "tensorflow/core/framework/graph.pb.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/resource_mgr.h"
@@ -311,6 +312,10 @@ class WriteAudioSummaryOp : public OpKernel {
 
     const Tensor* t;
     OP_REQUIRES_OK(ctx, ctx->input("tensor", &t));
+    OP_REQUIRES(ctx, t->dims() >= 2,
+                absl::InvalidArgumentError(
+                    absl::StrCat("tensor must have at least 2 dims, got ",
+                                 t->shape().DebugString())));
 
     OP_REQUIRES_OK(ctx,
                    s->WriteAudio(step, *t, tag, max_outputs_, sample_rate));

--- a/tensorflow/python/kernel_tests/summary_ops/summary_v1_audio_op_test.py
+++ b/tensorflow/python/kernel_tests/summary_ops/summary_v1_audio_op_test.py
@@ -66,42 +66,34 @@ class SummaryV1AudioOpTest(test.TestCase):
         # Check the rest of the proto
         self._CheckProto(audio_summ, sample_rate, channels, num_frames)
 
-  def testAudioSummaryTensorDimensionValidation(self):
-    """Test that WriteAudioSummary rejects tensors with less than 2 dims."""
+  def _WriteAudioSummary(self, tensor):
+    """Helper to call write_audio_summary with standard test parameters."""
     logdir = self.get_temp_dir()
     with context.eager_mode():
       writer = summary_ops_v2.create_file_writer_v2(logdir)
       with writer.as_default():
-        # Test scalar tensor (0D) - should fail
-        with self.assertRaisesRegex(
-            errors.InvalidArgumentError, "at least 2"):
-          gen_summary_ops.write_audio_summary(
-              writer=writer._resource,
-              step=0,
-              tag="audio_test",
-              tensor=np.float32(1.0),  # scalar
-              sample_rate=16000.0,
-              max_outputs=3)
-
-        # Test 1D tensor - should fail
-        with self.assertRaisesRegex(
-            errors.InvalidArgumentError, "at least 2"):
-          gen_summary_ops.write_audio_summary(
-              writer=writer._resource,
-              step=0,
-              tag="audio_test",
-              tensor=np.array([1.0, 2.0], dtype=np.float32),  # 1D
-              sample_rate=16000.0,
-              max_outputs=3)
-
-        # Test 2D tensor - should succeed
         gen_summary_ops.write_audio_summary(
             writer=writer._resource,
             step=0,
             tag="audio_test",
-            tensor=np.zeros((1, 100), dtype=np.float32),  # 2D
+            tensor=tensor,
             sample_rate=16000.0,
             max_outputs=3)
+
+  def testWriteAudioSummaryRejectsScalarTensor(self):
+    scalar_tensor = np.float32(1.0)
+    with self.assertRaisesRegex(errors.InvalidArgumentError, "at least 2"):
+      self._WriteAudioSummary(scalar_tensor)
+
+  def testWriteAudioSummaryRejects1DTensor(self):
+    one_d_tensor = np.array([1.0, 2.0], dtype=np.float32)
+    with self.assertRaisesRegex(errors.InvalidArgumentError, "at least 2"):
+      self._WriteAudioSummary(one_d_tensor)
+
+  def testWriteAudioSummaryAccepts2DTensor(self):
+    two_d_tensor = np.zeros((1, 100), dtype=np.float32)
+    # no exception should be raised
+    self._WriteAudioSummary(two_d_tensor)
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/summary_ops/summary_v1_audio_op_test.py
+++ b/tensorflow/python/kernel_tests/summary_ops/summary_v1_audio_op_test.py
@@ -18,7 +18,6 @@ import numpy as np
 
 from tensorflow.core.framework import summary_pb2
 from tensorflow.python.eager import context
-from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import gen_summary_ops


### PR DESCRIPTION
  - Add dimension validation to WriteAudioSummaryOp kernel to require tensor rank >= 2
  - Previously, passing a scalar tensor caused Check failed: d < dims() (1 vs. 0) and process abort
  - Now returns  InvalidArgumentError with message indicating tensor must have at least 2 dimensions

The WriteAudioSummary op expects audio data in shape [batch_size, num_samples] (2D) or [batch_size, num_samples, num_channels] (3D). The underlying AddTensorAsAudioToSummary function in summary_converter.cc accesses tensor.dim_size(0) and tensor.dim_size(1) without validation, causing the crash in issue #107977 