### PR TITLE
mlir/tosa: Fix build by updating Affine pass include path

### DIFF
--- a/tensorflow/compiler/mlir/tosa/tf_passes.cc
+++ b/tensorflow/compiler/mlir/tosa/tf_passes.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #include "tensorflow/compiler/mlir/tosa/tf_passes.h"
 
-#include "mlir/Dialect/Affine/Passes.h"  // from @llvm-project
+#include "mlir/Dialect/Affine/Transforms/Passes.h"  // from @llvm-project
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"  // from @llvm-project
 #include "mlir/Pass/PassRegistry.h"  // from @llvm-project
 #include "mlir/Transforms/Passes.h"  // from @llvm-project

--- a/tensorflow/compiler/mlir/tosa/tf_tfl_passes.cc
+++ b/tensorflow/compiler/mlir/tosa/tf_tfl_passes.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #include "tensorflow/compiler/mlir/tosa/tf_tfl_passes.h"
 
-#include "mlir/Dialect/Affine/Passes.h"  // from @llvm-project
+#include "mlir/Dialect/Affine/Transforms/Passes.h"  // from @llvm-project
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"  // from @llvm-project
 #include "mlir/Pass/PassManager.h"  // from @llvm-project
 #include "mlir/Pass/PassRegistry.h"  // from @llvm-project

--- a/tensorflow/compiler/mlir/tosa/tfl_passes.cc
+++ b/tensorflow/compiler/mlir/tosa/tfl_passes.cc
@@ -16,7 +16,7 @@ limitations under the License.
 #include "tensorflow/compiler/mlir/tosa/tfl_passes.h"
 
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"  // from @llvm-project
-#include "mlir/Dialect/Affine/Passes.h"  // from @llvm-project
+#include "mlir/Dialect/Affine/Transforms/Passes.h"  // from @llvm-project
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"  // from @llvm-project
 #include "mlir/Pass/PassManager.h"  // from @llvm-project
 #include "mlir/Pass/PassRegistry.h"  // from @llvm-project


### PR DESCRIPTION
LLVM MLIR moved Affine pass declarations from
mlir/Dialect/Affine/Passes.h to
mlir/Dialect/Affine/Transforms/Passes.h.

Update TOSA TensorFlow MLIR pass sources to include the new header