### PR TITLE
docs: fix typo 'tesnor' -> 'tensor' in BertInputTensorsMd.md

### DIFF
--- a/tensorflow/lite/g3doc/api_docs/python/tflite_support/metadata_writers/metadata_info/BertInputTensorsMd.md
+++ b/tensorflow/lite/g3doc/api_docs/python/tflite_support/metadata_writers/metadata_info/BertInputTensorsMd.md
@@ -11,7 +11,7 @@ description: A container for the input tensor metadata information of Bert model
 <meta itemprop="path" content="Stable" />
 <meta itemprop="property" content="__init__"/>
 <meta itemprop="property" content="create_input_process_unit_metadata"/>
-<meta itemprop="property" content="create_input_tesnor_metadata"/>
+<meta itemprop="property" content="create_input_tensor_metadata"/>
 <meta itemprop="property" content="get_tokenizer_associated_files"/>
 </div>
 
@@ -149,15 +149,15 @@ https://github.com/tensorflow/tflite-support/blob/b80289c4cd1224d0e1836c7654e82f
 Creates the input process unit metadata.
 
 
-<h3 id="create_input_tesnor_metadata"><code>create_input_tesnor_metadata</code></h3>
+<h3 id="create_input_tensor_metadata"><code>create_input_tensor_metadata</code></h3>
 
 <a target="_blank" class="external" href="https://github.com/tensorflow/tflite-support/blob/v0.4.4/tensorflow_lite_support/metadata/python/metadata_writers/metadata_info.py#L792-L801">View source</a>
 
 <pre class="devsite-click-to-copy prettyprint lang-py tfo-signature-link">
-<code>create_input_tesnor_metadata() -> List[<a href="../../../tflite_support/metadata_schema_py_generated/TensorMetadataT"><code>tflite_support.metadata_schema_py_generated.TensorMetadataT</code></a>]
+<code>create_input_tensor_metadata() -> List[<a href="../../../tflite_support/metadata_schema_py_generated/TensorMetadataT"><code>tflite_support.metadata_schema_py_generated.TensorMetadataT</code></a>]
 </code></pre>
 
-Creates the input metadata for the three input tesnors.
+Creates the input metadata for the three input tensors.
 
 
 <h3 id="get_tokenizer_associated_files"><code>get_tokenizer_associated_files</code></h3>


### PR DESCRIPTION
# Description
This PR fixes multiple occurrences of the typo "tesnor" -> "tensor" in [tensorflow/lite/g3doc/api_docs/python/tflite_support/metadata_writers/metadata_info/BertInputTensorsMd.md](cci:7://file:///c:/Users/madha/code/opensource/tensorflow/tensorflow/lite/g3doc/api_docs/python/tflite_support/metadata_writers/metadata_info/BertInputTensorsMd.md:0:0-0:0).

These typos were present in:
- The `<meta>` property tag.
- The `<h3>` header id and display text.
- The method documentation string.

Fixes #108471

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes