### PR TITLE
Improve error message for tf.image.extract_patches with XLA

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -6194,6 +6194,43 @@ def searchsorted(sorted_sequence,
 quantize.__doc__ = gen_array_ops.quantize_v2.__doc__
 
 
+def _get_int_list_attr(values, name):
+  """Converts a list of values to a list of Python integers for op attributes.
+
+  This function is used to convert the `sizes`, `strides`, and `rates`
+  parameters of `extract_image_patches` to compile-time constant integers.
+
+  Args:
+    values: A list or tuple of integers, or tensors representing integers.
+    name: The name of the attribute, used for error messages.
+
+  Returns:
+    A list of Python integers if `values` is a list or tuple, otherwise
+    returns `values` unchanged.
+
+  Raises:
+    TypeError: If any value is a tensor whose value cannot be determined at
+      graph construction time (e.g., symbolic tensors in XLA compilation).
+  """
+  if not isinstance(values, (list, tuple)):
+    return values
+  result = []
+  for i, s in enumerate(values):
+    if tensor_util.is_tf_type(s):
+      val = tensor_util.constant_value(s)
+      if val is None:
+        raise TypeError(
+            f"'{name}' must contain compile-time constant values when using "
+            f"XLA compilation (jit_compile=True), but element {i} is a "
+            f"dynamic tensor: {s}. Use Python integers or values that can be "
+            f"evaluated at graph construction time."
+        )
+      result.append(int(val))
+    else:
+      result.append(s)
+  return result
+
+
 @tf_export("image.extract_patches")
 @dispatch.add_dispatch_support
 def extract_image_patches_v2(images, sizes, strides, rates, padding, name=None):
@@ -6312,21 +6349,9 @@ def extract_image_patches_v2(images, sizes, strides, rates, padding, name=None):
   Returns:
     A 4-D Tensor of the same type as the input.
   """
-  if isinstance(sizes, (list, tuple)):
-    sizes = [
-        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
-        for s in sizes
-    ]
-  if isinstance(strides, (list, tuple)):
-    strides = [
-        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
-        for s in strides
-    ]
-  if isinstance(rates, (list, tuple)):
-    rates = [
-        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
-        for s in rates
-    ]
+  sizes = _get_int_list_attr(sizes, 'sizes')
+  strides = _get_int_list_attr(strides, 'strides')
+  rates = _get_int_list_attr(rates, 'rates')
 
   return gen_array_ops.extract_image_patches(
       images, sizes, strides, rates, padding, name
@@ -6375,21 +6400,9 @@ def extract_image_patches(  # pylint: disable=missing-docstring
   """
   ksizes = deprecation.deprecated_argument_lookup("sizes", sizes, "ksizes",
                                                   ksizes)
-  if isinstance(ksizes, (list, tuple)):
-    ksizes = [
-        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
-        for s in ksizes
-    ]
-  if isinstance(strides, (list, tuple)):
-    strides = [
-        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
-        for s in strides
-    ]
-  if isinstance(rates, (list, tuple)):
-    rates = [
-        tensor_util.constant_value(s) if tensor_util.is_tf_type(s) else s
-        for s in rates
-    ]
+  ksizes = _get_int_list_attr(ksizes, 'sizes')
+  strides = _get_int_list_attr(strides, 'strides')
+  rates = _get_int_list_attr(rates, 'rates')
 
   return gen_array_ops.extract_image_patches(
       images, ksizes, strides, rates, padding, name


### PR DESCRIPTION
#### **Summary**
This PR improves the error message when `tf.image.extract_patches` is used within `@tf.function(jit_compile=True)` with non-constant windowing parameters (`sizes`, `strides`, or `rates`).

#### **Problem**
In TensorFlow, the `ExtractImagePatches` op treats windowing parameters as compile-time **attributes**, not inputs. When using XLA/JIT compilation, these values must be statically resolvable. Currently, if a dynamic tensor is passed, the Python wrapper fails with a cryptic `TypeError` from the C++ bindings:
`TypeError: Expected int for argument 'rates' not <tf.Tensor...>`

This does not clearly inform the user that the error is due to the lack of a compile-time constant.

#### **Solution**
Introduced a helper function `_get_int_list_attr` in `array_ops.py` that:
1.  Uses `tensor_util.constant_value` to attempt to extract static values from tensors.
2.  Raises a clear, descriptive `TypeError` if extraction fails, specifically mentioning the requirement for constants under XLA.

**New Error Example:**
> `TypeError: 'rates' must contain compile-time constant values when using XLA compilation (jit_compile=True), but element 0 is a dynamic tensor: <tf.Tensor...>. Use Python integers or values that can be evaluated at graph construction time.`

#### **Verification Plan**
- Verified that existing tests pass: `bazel test //tensorflow/python/ops:array_ops_test --test_filter=*extract*`
- Manually verified with the reproduction case in #108268 to ensure the new error message is displayed correctly.

Fixes #108268