### PR TITLE
Fixed rfft backprop shape mismatch when fft_length < input shape

### DIFF
--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -927,7 +927,7 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
     if rank == 3:
       return
     dims = rank + extra_dims
-    tol = 1e-2 if np_rtype == np.float32 else 1e-10
+    tol = 2e-2 if np_rtype == np.float32 else 1e-10
     re = np.random.rand(*((size,) * dims)).astype(np_rtype) * 2 - 1
     im = np.random.rand(*((size,) * dims)).astype(np_rtype) * 2 - 1
     fft_length = (size + dsize,) * rank

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -125,8 +125,8 @@ class BaseFFTOpsTest(test.TestCase):
     with self.cached_session(config=config, force_gpu=True):
       self._tf_fft(x, rank, fft_length=None)
 
-  def _check_grad_complex(self, func, x, y, result_is_complex=True,
-                          rtol=1e-2, atol=1e-2):
+  def _check_grad_complex(self, func, x, y, fft_length=None,
+                          result_is_complex=True, rtol=1e-2, atol=1e-2):
     with self.cached_session():
 
       def f(inx, iny):
@@ -134,7 +134,7 @@ class BaseFFTOpsTest(test.TestCase):
         iny.set_shape(y.shape)
         # func is a forward or inverse, real or complex, batched or unbatched
         # FFT function with a complex input.
-        z = func(math_ops.complex(inx, iny))
+        z = func(math_ops.complex(inx, iny), fft_length)
         # loss = sum(|z|^2)
         loss = math_ops.reduce_sum(math_ops.real(z * math_ops.conj(z)))
         return loss
@@ -145,11 +145,11 @@ class BaseFFTOpsTest(test.TestCase):
     self.assertAllClose(x_jacob_t, x_jacob_n, rtol=rtol, atol=atol)
     self.assertAllClose(y_jacob_t, y_jacob_n, rtol=rtol, atol=atol)
 
-  def _check_grad_real(self, func, x, rtol=1e-2, atol=1e-2):
+  def _check_grad_real(self, func, x, fft_length=None, rtol=1e-2, atol=1e-2):
     def f(inx):
       inx.set_shape(x.shape)
       # func is a forward RFFT function (batched or unbatched).
-      z = func(inx)
+      z = func(inx, fft_length)
       # loss = sum(|z|^2)
       loss = math_ops.reduce_sum(math_ops.real(z * math_ops.conj(z)))
       return loss
@@ -901,8 +901,8 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
           self.evaluate(irfft_fn(x, fft_length))
 
   @parameterized.parameters(itertools.product(
-      VALID_FFT_RANKS, range(2), (5, 6), (np.float32, np.float64)))
-  def test_grad_simple(self, rank, extra_dims, size, np_rtype):
+      VALID_FFT_RANKS, range(2), (5, 6), (-2, 0, 2), (np.float32, np.float64)))
+  def test_grad_simple(self, rank, extra_dims, size, dsize, np_rtype):
     # rfft3d/irfft3d do not have gradients yet.
     if rank == 3:
       return
@@ -910,18 +910,19 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
     tol = 1e-3 if np_rtype == np.float32 else 1e-10
     re = np.ones(shape=(size,) * dims, dtype=np_rtype)
     im = -np.ones(shape=(size,) * dims, dtype=np_rtype)
-    self._check_grad_real(self._tf_fft_for_rank(rank), re,
+    fft_length = (size + dsize,) * rank
+    self._check_grad_real(self._tf_fft_for_rank(rank), re, fft_length,
                           rtol=tol, atol=tol)
     if test.is_built_with_rocm():
       # Fails on ROCm because of irfft peculairity
       return
     self._check_grad_complex(
-        self._tf_ifft_for_rank(rank), re, im, result_is_complex=False,
-        rtol=tol, atol=tol)
+        self._tf_ifft_for_rank(rank), re, im, fft_length,
+        result_is_complex=False, rtol=tol, atol=tol)
 
   @parameterized.parameters(itertools.product(
-      VALID_FFT_RANKS, range(2), (5, 6), (np.float32, np.float64)))
-  def test_grad_random(self, rank, extra_dims, size, np_rtype):
+      VALID_FFT_RANKS, range(2), (5, 6), (-2, 0, 2), (np.float32, np.float64)))
+  def test_grad_random(self, rank, extra_dims, size, dsize, np_rtype):
     # rfft3d/irfft3d do not have gradients yet.
     if rank == 3:
       return
@@ -929,14 +930,15 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
     tol = 1e-2 if np_rtype == np.float32 else 1e-10
     re = np.random.rand(*((size,) * dims)).astype(np_rtype) * 2 - 1
     im = np.random.rand(*((size,) * dims)).astype(np_rtype) * 2 - 1
-    self._check_grad_real(self._tf_fft_for_rank(rank), re,
+    fft_length = (size + dsize,) * rank
+    self._check_grad_real(self._tf_fft_for_rank(rank), re, fft_length,
                           rtol=tol, atol=tol)
     if test.is_built_with_rocm():
-      # Fails on ROCm because of irfft peculairity
+      # Fails on ROCm because of irfft peculiarity
       return
     self._check_grad_complex(
-        self._tf_ifft_for_rank(rank), re, im, result_is_complex=False,
-        rtol=tol, atol=tol)
+        self._tf_ifft_for_rank(rank), re, im, fft_length,
+        result_is_complex=False, rtol=tol, atol=tol)
 
   def test_invalid_args(self):
     # Test case for GitHub issue 55263

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -21,9 +21,13 @@ from absl.testing import parameterized
 import numpy as np
 
 from tensorflow.core.protobuf import config_pb2
+from tensorflow.python.eager import backprop
 from tensorflow.python.eager import context
+from tensorflow.python.eager import def_function
+from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
+from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gen_spectral_ops
@@ -555,6 +559,39 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
     else:
       return c2r.astype(np_ctype)
 
+  def _assert_dynamic_grad_matches_static(self, transform_fn, input_value,
+                                          fft_length, rtol, atol):
+    input_tensor = constant_op.constant(input_value)
+    static_shape = input_value.shape
+    dynamic_shape = (None,) + input_value.shape[1:]
+
+    def loss_fn(x):
+      y = transform_fn(x, fft_length)
+      return math_ops.reduce_sum(math_ops.real(y * math_ops.conj(y)))
+
+    def make_grad_fn(input_shape):
+      @def_function.function(
+        input_signature=[
+            tensor_spec.TensorSpec(input_shape, dtype=input_tensor.dtype)
+        ])
+      def grad_fn(x):
+        with backprop.GradientTape() as tape:
+          tape.watch(x)
+          loss = loss_fn(x)
+        return tape.gradient(loss, x)
+      return grad_fn
+
+    static_grad_fn = make_grad_fn(static_shape)
+    dynamic_grad_fn = make_grad_fn(dynamic_shape)
+
+    expected_grad = static_grad_fn(input_tensor)
+    actual_grad = dynamic_grad_fn(input_tensor)
+
+    expected_grad, actual_grad = self.evaluate([expected_grad, actual_grad])
+
+    self.assertEqual(actual_grad.shape, input_value.shape)
+    self.assertAllClose(actual_grad, expected_grad, rtol=rtol, atol=atol)
+
   @parameterized.parameters(itertools.product(
       VALID_FFT_RANKS, range(3), (np.float32, np.float64)))
 
@@ -939,6 +976,31 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
     self._check_grad_complex(
         self._tf_ifft_for_rank(rank), re, im, fft_length,
         result_is_complex=False, rtol=tol, atol=tol)
+
+  @parameterized.parameters(itertools.product(
+    VALID_FFT_RANKS, range(2), (5, 6), (-2, 0, 2), (np.float32, np.float64)))
+  def test_grad_batched_truncate(self, rank, extra_dims, size, dsize, np_rtype):
+    if rank == 3:
+      return
+
+    dims = rank + extra_dims
+    tol = 1e-3 if np_rtype == np.float32 else 1e-10
+    re = np.ones(shape=(size,) * dims, dtype=np_rtype)
+    im = -np.ones(shape=(size,) * dims, dtype=np_rtype)
+    fft_length = (size + dsize,) * rank
+
+    self._assert_dynamic_grad_matches_static(
+      self._tf_fft_for_rank(rank),
+      re, fft_length, rtol=tol, atol=tol)
+
+    if test.is_built_with_rocm():
+      # Fails on ROCm because of irfft peculiarity
+      return
+
+    np_ctype = np.complex64 if np_rtype == np.float32 else np.complex128
+    self._assert_dynamic_grad_matches_static(
+      self._tf_ifft_for_rank(rank),
+      (re + im).astype(np_ctype), fft_length, rtol=tol, atol=tol)
 
   def test_invalid_args(self):
     # Test case for GitHub issue 55263

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -603,14 +603,6 @@ def _irfft_grad_helper(rank, rfft_fn):
       complex_dtype = _dtypes.complex128
     is_odd = _math_ops.mod(fft_length[-1], 2)
     original_input_shape = _array_ops.shape(op.inputs[0])
-    input_last_dimension = _math_ops.minimum(
-        original_input_shape[-1],
-        fft_length[-1]//2 + 1
-    )
-    mask = _array_ops.concat(
-        [[1.0], 2.0 * _array_ops.ones(
-            [input_last_dimension - 2 + is_odd], real_dtype),
-         _array_ops.ones([1 - is_odd], real_dtype)], 0)
 
     rsize = _math_ops.reciprocal(_math_ops.cast(
         _fft_size_for_grad(grad, rank), real_dtype))
@@ -620,6 +612,11 @@ def _irfft_grad_helper(rank, rfft_fn):
     # symmetric components of the RFFT by a factor of two, since these
     # components are de-duplicated in the RFFT.
     the_rfft = rfft_fn(grad, fft_length)
+    rfft_last_dimension = _array_ops.shape(the_rfft)[-1]
+    mask = _array_ops.concat(
+        [[1.0], 2.0 * _array_ops.ones(
+            [rfft_last_dimension - 2 + is_odd], real_dtype),
+         _array_ops.ones([1 - is_odd], real_dtype)], 0)
     return (
         _maybe_pad_for_rfft(
             the_rfft

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -574,7 +574,7 @@ def _rfft_grad_helper(rank, irfft_fn):
         _maybe_pad_for_rfft(
             0.5 * (the_irfft * input_size + _math_ops.real(extra_terms)),
             rank,
-            original_input_shape,
+            original_input_shape[-rank:],
         ),
         None,
     )
@@ -625,7 +625,7 @@ def _irfft_grad_helper(rank, rfft_fn):
             the_rfft
             * _math_ops.cast(rsize * mask, complex_dtype),
             rank,
-            original_input_shape,
+            original_input_shape[-rank:],
         ),
         None,
     )


### PR DESCRIPTION

## Description

Fix gradient computation for `tf.signal.rfft` when `fft_length` is smaller than the input size.

The forward `rfft` op implicitly truncates the input to `fft_length`, but the gradient path assumes the full input length, resulting in a shape mismatch during backpropagation.


## Changes Made

* Fix gradient handling for `tf.signal.rfft` when `fft_length < input.shape[-fft_rank:]`
* Add gradient test coverage for multiple `fft_length` cases


## How to Reproduce Error

```python
import tensorflow as tf

x = tf.random.uniform([1, 10])

with tf.GradientTape() as tape:
  tape.watch(x)
  y = tf.signal.rfft(x, fft_length=(5,))
  loss = tf.reduce_sum(tf.abs(y))

grad = tape.gradient(loss, x)
```

## Error Before Fix

```text
InvalidArgumentError: Incompatible shapes: [5] vs. [10]
```