### PR TITLE
spam: Add axis scalar validation to tf.concat Fixes #108486

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1439,6 +1439,8 @@ def concat(values, axis, name="concat"):
           axis, name="concat_dim",
           dtype=dtypes.int32).get_shape().assert_has_rank(0)
       return identity(values[0], name=name)
+  axis = ops.convert_to_tensor(axis, name="concat_dim", dtype=dtypes.int32)
+  axis.get_shape().assert_has_rank(0)
   return gen_array_ops.concat_v2(values=values, axis=axis, name=name)
 
 

--- a/tensorflow/python/ops/array_ops_test.py
+++ b/tensorflow/python/ops/array_ops_test.py
@@ -148,6 +148,14 @@ class ArrayOpTest(test.TestCase):
     self.assertFalse(flags.config().tf_shape_default_int64.value())
     s1 = array_ops.shape_v2(array_ops.zeros([1, 2]))
     self.assertEqual(s1.dtype, dtypes.int32)
+  
+  def testConcatAxisMustBeScalar(self):
+    a = array_ops.constant([[1, 2], [3, 4]])
+    b = array_ops.constant([[5, 6], [7, 8]])
+
+    # axis must be a scalar int32 tensor
+    with self.assertRaisesRegex(Exception, "rank"):
+      array_ops.concat([a, b], axis=[0, 1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change adds early validation to ensure `axis` is a scalar int32 tensor
for all `tf.concat` calls.

Previously, scalar validation was only performed in the single-input
(`len(values) == 1`) path, while the general path relied on lower-level
errors from `concat_v2`, which could be harder to interpret.

This makes axis validation consistent across all code paths and improves
error clarity without changing valid behavior.
