### PR TITLE
Fix docstring typo in ScopedTFImportGraphDefResults

### DIFF
--- a/tensorflow/python/framework/c_api_util.py
+++ b/tensorflow/python/framework/c_api_util.py
@@ -105,7 +105,7 @@ class ScopedTFImportGraphDefOptions(object):
 
 
 class ScopedTFImportGraphDefResults(object):
-  """Wrapper around TF_ImportGraphDefOptions that handles deletion."""
+  """Wrapper around TF_ImportGraphDefResults that handles deletion."""
 
   __slots__ = ["results"]
 


### PR DESCRIPTION
## Description
Fix docstring typo in `ScopedTFImportGraphDefResults` class.

The docstring incorrectly stated the class wraps `TF_ImportGraphDefOptions` 
when it actually wraps `TF_ImportGraphDefResults`. This was a copy-paste 
error from the `ScopedTFImportGraphDefOptions` class defined above it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This is a documentation/comment fix only

## Checklist
- [x] I have read the CONTRIBUTING guidelines
- [x] I have signed the CLA
- [x] My changes follow the code style of this project