### PR TITLE
Fix crash in transpose for invalid perm/axes

### DIFF
--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1985,7 +1985,9 @@ def transpose(a, perm=None, name="transpose", conjugate=False):
       rank = a.shape.rank
       if rank is not None:
         if len(perm) != rank:
-          raise ValueError("perm must have the same length as the rank of the tensor.")
+          raise ValueError(
+            "perm must have the same length as the rank of the tensor."
+            )
         if any(p < 0 or p>= rank for p in perm):
           raise ValueError("perm contains invalid axis.")
         if len(set(perm)) != len(perm):

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -1982,6 +1982,14 @@ def transpose(a, perm=None, name="transpose", conjugate=False):
       transpose_fn = gen_array_ops.transpose
 
     if perm is not None:
+      rank = a.shape.rank
+      if rank is not None:
+        if len(perm) != rank:
+          raise ValueError("perm must have the same length as the rank of the tensor.")
+        if any(p < 0 or p>= rank for p in perm):
+          raise ValueError("perm contains invalid axis.")
+        if len(set(perm)) != len(perm):
+          raise ValueError("perm must not contain duplicates.")
       return transpose_fn(a, perm, name=name)
 
     rank = a.shape.rank


### PR DESCRIPTION
Fixes crash in tf.experimental.numpy.transpose when invalid axes are provided.
Added validation to raise ValueError instead of aborting the process.
