### PR TITLE
Add docstring to include_frame function

### DIFF
--- a/tensorflow/python/util/traceback_utils.py
+++ b/tensorflow/python/util/traceback_utils.py
@@ -97,6 +97,19 @@ def disable_traceback_filtering():
 
 
 def include_frame(fname):
+  """Determines whether a frame should be included in filtered tracebacks.
+
+  This function checks if the given filename contains any of the excluded
+  paths. Frames from excluded paths (typically TensorFlow internal code) are
+  filtered out from stack traces to make them more readable for end users.
+
+  Args:
+    fname: A string representing the filename of the frame to check.
+
+  Returns:
+    True if the frame should be included in the traceback (i.e., it's not
+    from an excluded path), False otherwise.
+  """
   for exclusion in _EXCLUDED_PATHS:
     if exclusion in fname:
       return False


### PR DESCRIPTION
Add comprehensive docstring to the include_frame function in traceback_utils.py to document its purpose, arguments, and return value. This improves code documentation and helps developers understand how traceback filtering works.