### PR TITLE
Document XLA requirement for static Keras layer configuration values

### DIFF
--- a/tensorflow/python/keras/README.md
+++ b/tensorflow/python/keras/README.md
@@ -5,3 +5,11 @@ deleted. The current Keras code lives in
 [github/keras-team/keras](https://github.com/keras-team/keras).
 
 Please do not use the code from this folder.
+### XLA compilation note
+
+When using XLA (`jit_compile=True`), static configuration values such as
+layer dimensions (`d_model`, `num_heads`, etc.) should be Python primitives
+(e.g. `int`) and not `tf.Variable`.
+
+Using `tf.Variable` for static configuration may cause XLA compilation
+errors.


### PR DESCRIPTION
While investigating issue #108073, I was able to reproduce the XLA compilation error locally. The issue turned out to be caused by using tf.Variable for a static configuration value (d_model), which XLA expects to be a Python primitive.

What this PR does

This PR adds a short documentation note explaining that static configuration values (such as layer dimensions) should not be defined as tf.Variable when compiling with XLA.

Why this helps

This clarification should help prevent confusing XLA errors for users and make the expected usage clearer when defining custom Keras layers.

Related issue

Fixes #108073