### PR TITLE
Fix crash in tf.experimental.numpy.transpose with negative axes

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -907,6 +907,8 @@ def flatten(a, order='C'):
 def transpose(a, axes=None):
   a = asarray(a)
   if axes is not None:
+    if isinstance(axes, (list, tuple)) and a.shape.rank is not None:
+      axes = [x + a.shape.rank if x < 0 else x for x in axes]
     axes = asarray(axes)
   return array_ops.transpose(a=a, perm=axes)
 

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -1035,6 +1035,9 @@ class ArrayMethodsTest(test.TestCase):
     run_test(np.arange(30).reshape(2, 3, 5).tolist(), [1, 2, 0])
     run_test(np.arange(30).reshape(2, 3, 5).tolist(), [2, 0, 1])
     run_test(np.arange(30).reshape(2, 3, 5).tolist(), [2, 1, 0])
+    run_test(np.arange(6).reshape(2, 3).tolist(), [-1, 0])
+    run_test(np.arange(30).reshape(2, 3, 5).tolist(), [-1, 1, 0])
+    run_test(np.arange(30).reshape(2, 3, 5).tolist(), [-1, -2, -3])
 
   def match_shape(self, actual, expected, msg=None):
     if msg:


### PR DESCRIPTION
### Description
This PR fixes Issue #108488 where `tf.experimental.numpy.transpose` causes a process crash (core dump) when `axes` contains negative integers.

The internal C++ implementation of `tf.transpose` (`array_ops.transpose`) strictly requires positive permutation indices. This PR adds a normalization step in the Python wrapper to convert negative indices (e.g., `-1`) into their corresponding positive dimension indices (e.g., `rank - 1`) before passing them to the backend.

### Fixes
Fixes #108488

### Changes
1. `np_array_ops.py`: Added logic to normalize negative values in `axes` to positive integers based on the input tensor's rank.
2. `np_array_ops_test.py`: Added regression tests using negative axes (e.g., `[-1, 0]`) to ensure they match NumPy behavior and do not crash.