### PR TITLE
fix(gpu): adjust work-group size and remove Adreno-specific alignment

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/inference_context.cc
+++ b/tensorflow/lite/delegates/gpu/cl/inference_context.cc
@@ -179,9 +179,6 @@ absl::Status GetBufferAssignment(
       const size_t width = shape.b * shape.w;
       const size_t height = shape.h * DivideRoundUp(shape.c, 4);
       size_t width_pixel_alignment = gpu_info.opencl_info.image_pitch_alignment;
-      if (gpu_info.IsAdreno() && width_pixel_alignment % bytes_per_pixel == 0) {
-        width_pixel_alignment /= bytes_per_pixel;
-      }
       const size_t width_aligned = AlignByN(width, width_pixel_alignment);
       buffer_size = width_aligned * bytes_per_pixel * height;
     } else {
@@ -659,10 +656,6 @@ absl::Status InferenceContext::AllocateBufferBasedTensors(
                  : tensor_desc.GetBHWCShape().c);
         size_t width_pixel_alignment =
             gpu_info.opencl_info.image_pitch_alignment;
-        if (gpu_info.IsAdreno() &&
-            width_pixel_alignment % bytes_per_pixel == 0) {
-          width_pixel_alignment /= bytes_per_pixel;
-        }
         RETURN_IF_ERROR(CreateTensorSharedImage2DBuffer(
             *context, shared_buffers_[buffer_index].GetMemoryPtr(), tensor_desc,
             width_pixel_alignment, &shared_buffer_tensors_[tensor_index]));

--- a/tensorflow/lite/delegates/gpu/common/task/work_group_picking.cc
+++ b/tensorflow/lite/delegates/gpu/common/task/work_group_picking.cc
@@ -278,7 +278,7 @@ void GetPossibleWorkGroups(TuningType tuning_type, const GpuInfo& gpu_info,
   switch (tuning_type) {
     case TuningType::kFast:
       work_groups->push_back(
-          GetWorkGroup(grid, kernel_info.max_work_group_size));
+          GetWorkGroup(grid, std::min(kernel_info.max_work_group_size, gpu_info.GetMaxWorkGroupSizeForX())));
       return;
     case TuningType::kExhaustive: {
       GetWorkGroupsAlignedToGrid(gpu_info, kernel_info, grid, work_groups);


### PR DESCRIPTION
- Updated `GetPossibleWorkGroups()` in `work_group_picking.cc`: Use `std::min(kernel_info.max_work_group_size, gpu_info.GetMaxWorkGroupSizeForX())` to ensure work-group size respects GPU X-dimension limits.

- Removed Adreno-specific pitch alignment logic in `inference_context.cc`: Eliminated conditional division by `bytes_per_pixel` for width alignment to simplify and standardize buffer size calculation.

Impact:
- Improves compatibility across GPUs.
- Prevents oversized work-groups and incorrect buffer alignment on Adreno devices.
