### PR TITLE
Fix segfault in ImmutableConst with large shape dimensions

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -907,6 +907,7 @@ ARRAY_DEPS = [
     "//tensorflow/core/framework:bounds_check",
     "//tensorflow/core/profiler/lib:scoped_memory_debug_annotation",
     "//tensorflow/core/util:bad_indices_policy",
+    "//tensorflow/core/util:overflow",
     "@eigen_archive//:eigen3",
 ]
 

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -1102,7 +1102,7 @@ tf_kernel_library(
 tf_kernel_library(
     name = "one_hot_op",
     prefix = "one_hot_op",
-    deps = ARRAY_DEPS + ["//tensorflow/core/util:overflow"],
+    deps = ARRAY_DEPS,
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -1128,7 +1128,7 @@ tf_kernel_library(
 tf_kernel_library(
     name = "one_hot_op",
     prefix = "one_hot_op",
-    deps = ARRAY_DEPS + ["//tensorflow/core/util:overflow"],
+    deps = ARRAY_DEPS,
 )
 
 tf_kernel_library(

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -927,6 +927,7 @@ ARRAY_DEPS = [
     "//tensorflow/core/framework:bounds_check",
     "//tensorflow/core/profiler/lib:scoped_memory_debug_annotation",
     "//tensorflow/core/util:bad_indices_policy",
+    "//tensorflow/core/util:overflow",
     "@eigen_archive//:eigen3",
 ]
 

--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -927,14 +927,17 @@ ARRAY_DEPS = [
     "//tensorflow/core/framework:bounds_check",
     "//tensorflow/core/profiler/lib:scoped_memory_debug_annotation",
     "//tensorflow/core/util:bad_indices_policy",
-    "//tensorflow/core/util:overflow",
     "@eigen_archive//:eigen3",
 ]
 
 tf_kernel_library(
     name = "immutable_constant_op",
     prefix = "immutable_constant_op",
-    deps = ARRAY_DEPS,
+    deps = ARRAY_DEPS + [
+        "//tensorflow/core/util:overflow",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+    ],
 )
 
 tf_kernel_library(
@@ -1128,7 +1131,7 @@ tf_kernel_library(
 tf_kernel_library(
     name = "one_hot_op",
     prefix = "one_hot_op",
-    deps = ARRAY_DEPS,
+    deps = ARRAY_DEPS + ["//tensorflow/core/util:overflow"],
 )
 
 tf_kernel_library(
@@ -4159,6 +4162,7 @@ tf_cc_test(
         ":ops_testutil",
         ":ops_util",
         ":random_shuffle_op",
+        "@com_google_absl//absl/strings",
         "//tensorflow/cc:cc_ops",
         "//tensorflow/core:core_cpu",
         "//tensorflow/core:direct_session",

--- a/tensorflow/core/kernels/immutable_constant_op.cc
+++ b/tensorflow/core/kernels/immutable_constant_op.cc
@@ -113,13 +113,19 @@ void ImmutableConstantOp::Compute(OpKernelContext* ctx) {
   OP_REQUIRES(ctx, dtype_ != DT_STRING,
               absl::UnimplementedError("Sorry, DT_STRING is not currently "
                                        "supported for ImmutableConstOp."));
-
-  // Validate that the tensor size can be computed without overflow
-  const int64_t num_elements = shape_.num_elements();
-  OP_REQUIRES(ctx, num_elements >= 0,
-              absl::InvalidArgumentError(absl::StrCat(
-                  "Shape ", shape_.DebugString(),
-                  " results in overflow when computing number of elements")));
+  int64_t num_elements = 1;
+  for (int i = 0; i < shape_.dims(); ++i) {
+    const int64_t dim = shape_.dim_size(i);
+    OP_REQUIRES(ctx, dim >= 0,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "Shape ", shape_.DebugString(), " has negative dimension ",
+                    dim, " at index ", i)));
+    num_elements = MultiplyWithoutOverflow(num_elements, dim);
+    OP_REQUIRES(ctx, num_elements >= 0,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "Shape ", shape_.DebugString(),
+                    " results in overflow when computing number of elements")));
+  }
 
   // Check that num_elements fits in size_t
   OP_REQUIRES(
@@ -144,6 +150,14 @@ void ImmutableConstantOp::Compute(OpKernelContext* ctx) {
               absl::InvalidArgumentError(absl::StrCat(
                   "Tensor size computation overflows: ", num_elements,
                   " elements * ", element_size, " bytes per element")));
+
+  OP_REQUIRES(
+      ctx,
+      static_cast<uint64_t>(num_bytes_int64) <=
+          std::numeric_limits<size_t>::max(),
+      absl::InvalidArgumentError(absl::StrCat(
+          "Total byte size (", num_bytes_int64,
+          ") exceeds maximum representable size on this platform")));
 
   const size_t num_bytes = static_cast<size_t>(num_bytes_int64);
 

--- a/tensorflow/core/kernels/immutable_constant_op.cc
+++ b/tensorflow/core/kernels/immutable_constant_op.cc
@@ -15,9 +15,11 @@ limitations under the License.
 
 #include "tensorflow/core/kernels/immutable_constant_op.h"
 
+#include <limits>
 #include <unordered_set>
 
 #include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/util/overflow.h"
 
 namespace tensorflow {
 
@@ -63,6 +65,10 @@ class MemmappedTensorAllocator : public Allocator {
   const absl::Status& allocation_status() const { return allocation_status_; }
 
   void set_delete_on_deallocate() { delete_on_deallocate_ = true; }
+  
+  uint64_t memory_region_length() const {
+    return memory_region_ ? memory_region_->length() : 0;
+  }
 
   // Make sure tensors or complex types (strings, variants, resources) don't get
   // their constructor called via a placement new since that would require
@@ -104,6 +110,48 @@ void ImmutableConstantOp::Compute(OpKernelContext* ctx) {
   OP_REQUIRES(ctx, dtype_ != DT_STRING,
               absl::UnimplementedError("Sorry, DT_STRING is not currently "
                                        "supported for ImmutableConstOp."));
+
+  // Validate that the tensor size can be computed without overflow
+  const int64_t num_elements = shape_.num_elements();
+  OP_REQUIRES(ctx, num_elements >= 0,
+              errors::InvalidArgument(
+                  "Shape ", shape_.DebugString(),
+                  " results in overflow when computing number of elements"));
+
+  // Check that num_elements fits in size_t
+  OP_REQUIRES(
+      ctx,
+      static_cast<uint64_t>(num_elements) <=
+          std::numeric_limits<size_t>::max(),
+      errors::InvalidArgument(
+          "Number of elements (", num_elements,
+          ") exceeds maximum representable size on this platform"));
+
+  // Validate that the byte size doesn't overflow
+  const size_t element_size = DataTypeSize(dtype_);
+  OP_REQUIRES(ctx, element_size > 0,
+              errors::InvalidArgument(
+                  "Cannot determine element size for dtype ",
+                  DataTypeString(dtype_)));
+
+  // Check for overflow when computing total bytes
+  const int64_t num_bytes_int64 =
+      MultiplyWithoutOverflow(num_elements, element_size);
+  OP_REQUIRES(ctx, num_bytes_int64 >= 0,
+              errors::InvalidArgument(
+                  "Tensor size computation overflows: ", num_elements,
+                  " elements * ", element_size, " bytes per element"));
+
+  const size_t num_bytes = static_cast<size_t>(num_bytes_int64);
+
+  // Validate that the computed size matches the memory region size
+  const uint64_t region_length = allocator->memory_region_length();
+  OP_REQUIRES(ctx, num_bytes == region_length,
+              errors::InvalidArgument(
+                  "Memory region size (", region_length, " bytes) does not "
+                  "match expected tensor size (", num_bytes, " bytes) for shape ",
+                  shape_.DebugString(), " and dtype ",
+                  DataTypeString(dtype_)));
   ctx->set_output(0, Tensor(allocator.get(), dtype_, shape_));
   OP_REQUIRES_OK(ctx, allocator->allocation_status());
   // Allocator is owned by the tensor from this point.

--- a/tensorflow/core/kernels/immutable_constant_op.cc
+++ b/tensorflow/core/kernels/immutable_constant_op.cc
@@ -18,7 +18,10 @@ limitations under the License.
 #include <limits>
 #include <unordered_set>
 
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/util/overflow.h"
 
 namespace tensorflow {
@@ -114,44 +117,44 @@ void ImmutableConstantOp::Compute(OpKernelContext* ctx) {
   // Validate that the tensor size can be computed without overflow
   const int64_t num_elements = shape_.num_elements();
   OP_REQUIRES(ctx, num_elements >= 0,
-              errors::InvalidArgument(
+              absl::InvalidArgumentError(absl::StrCat(
                   "Shape ", shape_.DebugString(),
-                  " results in overflow when computing number of elements"));
+                  " results in overflow when computing number of elements")));
 
   // Check that num_elements fits in size_t
   OP_REQUIRES(
       ctx,
       static_cast<uint64_t>(num_elements) <=
           std::numeric_limits<size_t>::max(),
-      errors::InvalidArgument(
+      absl::InvalidArgumentError(absl::StrCat(
           "Number of elements (", num_elements,
-          ") exceeds maximum representable size on this platform"));
+          ") exceeds maximum representable size on this platform")));
 
   // Validate that the byte size doesn't overflow
   const size_t element_size = DataTypeSize(dtype_);
   OP_REQUIRES(ctx, element_size > 0,
-              errors::InvalidArgument(
+              absl::InvalidArgumentError(absl::StrCat(
                   "Cannot determine element size for dtype ",
-                  DataTypeString(dtype_)));
+                  DataTypeString(dtype_))));
 
   // Check for overflow when computing total bytes
   const int64_t num_bytes_int64 =
       MultiplyWithoutOverflow(num_elements, element_size);
   OP_REQUIRES(ctx, num_bytes_int64 >= 0,
-              errors::InvalidArgument(
+              absl::InvalidArgumentError(absl::StrCat(
                   "Tensor size computation overflows: ", num_elements,
-                  " elements * ", element_size, " bytes per element"));
+                  " elements * ", element_size, " bytes per element")));
 
   const size_t num_bytes = static_cast<size_t>(num_bytes_int64);
 
   // Validate that the computed size matches the memory region size
   const uint64_t region_length = allocator->memory_region_length();
   OP_REQUIRES(ctx, num_bytes == region_length,
-              errors::InvalidArgument(
+              absl::InvalidArgumentError(absl::StrCat(
                   "Memory region size (", region_length, " bytes) does not "
                   "match expected tensor size (", num_bytes, " bytes) for shape ",
                   shape_.DebugString(), " and dtype ",
-                  DataTypeString(dtype_)));
+                  DataTypeString(dtype_))));
   ctx->set_output(0, Tensor(allocator.get(), dtype_, shape_));
   OP_REQUIRES_OK(ctx, allocator->allocation_status());
   // Allocator is owned by the tensor from this point.

--- a/tensorflow/core/kernels/immutable_constant_op.cc
+++ b/tensorflow/core/kernels/immutable_constant_op.cc
@@ -21,7 +21,6 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "tensorflow/core/framework/types.pb.h"
-#include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/util/overflow.h"
 
 namespace tensorflow {
@@ -68,7 +67,7 @@ class MemmappedTensorAllocator : public Allocator {
   const absl::Status& allocation_status() const { return allocation_status_; }
 
   void set_delete_on_deallocate() { delete_on_deallocate_ = true; }
-  
+
   uint64_t memory_region_length() const {
     return memory_region_ ? memory_region_->length() : 0;
   }
@@ -113,6 +112,8 @@ void ImmutableConstantOp::Compute(OpKernelContext* ctx) {
   OP_REQUIRES(ctx, dtype_ != DT_STRING,
               absl::UnimplementedError("Sorry, DT_STRING is not currently "
                                        "supported for ImmutableConstOp."));
+  // The shape arrives as a graph attr, so fold the dimensions one at a time
+  // rather than trusting a precomputed element count that may have wrapped.
   int64_t num_elements = 1;
   for (int i = 0; i < shape_.dims(); ++i) {
     const int64_t dim = shape_.dim_size(i);
@@ -122,53 +123,40 @@ void ImmutableConstantOp::Compute(OpKernelContext* ctx) {
                     dim, " at index ", i)));
     num_elements = MultiplyWithoutOverflow(num_elements, dim);
     OP_REQUIRES(ctx, num_elements >= 0,
-                absl::InvalidArgumentError(absl::StrCat(
-                    "Shape ", shape_.DebugString(),
-                    " results in overflow when computing number of elements")));
+                absl::InvalidArgumentError(
+                    absl::StrCat("Shape ", shape_.DebugString(),
+                                 " overflows when computing element count")));
   }
 
-  // Check that num_elements fits in size_t
+  const int64_t element_size = DataTypeSize(dtype_);
   OP_REQUIRES(
-      ctx,
-      static_cast<uint64_t>(num_elements) <=
-          std::numeric_limits<size_t>::max(),
+      ctx, element_size > 0,
       absl::InvalidArgumentError(absl::StrCat(
-          "Number of elements (", num_elements,
-          ") exceeds maximum representable size on this platform")));
+          "Cannot determine element size for dtype ", DataTypeString(dtype_))));
 
-  // Validate that the byte size doesn't overflow
-  const size_t element_size = DataTypeSize(dtype_);
-  OP_REQUIRES(ctx, element_size > 0,
-              absl::InvalidArgumentError(absl::StrCat(
-                  "Cannot determine element size for dtype ",
-                  DataTypeString(dtype_))));
-
-  // Check for overflow when computing total bytes
-  const int64_t num_bytes_int64 =
+  const int64_t total_bytes =
       MultiplyWithoutOverflow(num_elements, element_size);
-  OP_REQUIRES(ctx, num_bytes_int64 >= 0,
+  OP_REQUIRES(ctx, total_bytes >= 0,
               absl::InvalidArgumentError(absl::StrCat(
-                  "Tensor size computation overflows: ", num_elements,
-                  " elements * ", element_size, " bytes per element")));
+                  "Tensor size overflows for shape ", shape_.DebugString(),
+                  " and dtype ", DataTypeString(dtype_))));
 
+  // size_t is narrower than int64 on 32 bit builds, and the allocation path
+  // downstream takes a size_t.
   OP_REQUIRES(
       ctx,
-      static_cast<uint64_t>(num_bytes_int64) <=
-          std::numeric_limits<size_t>::max(),
-      absl::InvalidArgumentError(absl::StrCat(
-          "Total byte size (", num_bytes_int64,
-          ") exceeds maximum representable size on this platform")));
+      static_cast<uint64_t>(total_bytes) <= std::numeric_limits<size_t>::max(),
+      absl::InvalidArgumentError(
+          absl::StrCat("Tensor size of ", total_bytes,
+                       " bytes is too large for this platform")));
 
-  const size_t num_bytes = static_cast<size_t>(num_bytes_int64);
-
-  // Validate that the computed size matches the memory region size
+  // The mapped region has to hold exactly the tensor we are about to hand out.
   const uint64_t region_length = allocator->memory_region_length();
-  OP_REQUIRES(ctx, num_bytes == region_length,
+  OP_REQUIRES(ctx, static_cast<uint64_t>(total_bytes) == region_length,
               absl::InvalidArgumentError(absl::StrCat(
-                  "Memory region size (", region_length, " bytes) does not "
-                  "match expected tensor size (", num_bytes, " bytes) for shape ",
-                  shape_.DebugString(), " and dtype ",
-                  DataTypeString(dtype_))));
+                  "Memory region of ", region_length, " bytes does not match ",
+                  total_bytes, " bytes needed for shape ", shape_.DebugString(),
+                  " and dtype ", DataTypeString(dtype_))));
   ctx->set_output(0, Tensor(allocator.get(), dtype_, shape_));
   OP_REQUIRES_OK(ctx, allocator->allocation_status());
   // Allocator is owned by the tensor from this point.

--- a/tensorflow/core/kernels/immutable_constant_op_test.cc
+++ b/tensorflow/core/kernels/immutable_constant_op_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <algorithm>
 #include <tuple>
 
+#include "absl/strings/match.h"
 #include "tensorflow/cc/ops/standard_ops.h"
 #include "tensorflow/core/framework/allocator.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -224,6 +225,39 @@ TEST(ImmutableConstantOpTest, FromFileStringUnimplmented) {
   EXPECT_EQ(
       session->Run({}, {result.node()->name() + ":0"}, {}, &outputs).code(),
       error::UNIMPLEMENTED);
+}
+
+TEST(ImmutableConstantOpTest, LargeShapeDimensionsOverflow) {
+  // Test that large shape dimensions that would overflow are caught
+  // and reported as an error rather than causing a segfault
+  Env* env = Env::Default();
+  auto root = Scope::DisabledShapeInferenceScope().ExitOnError();
+
+  // Create a small dummy file
+  std::string dummy_file;
+  TF_ASSERT_OK(CreateTempFileBadString(env, '\x00', 1, "overflow_test", 
+                                       &dummy_file));
+
+  // Use dimensions that multiply to overflow int64_t
+  // 2147482841 * 2147485163 would overflow
+  const TensorShape kOverflowShape({2147482841, 2147485163});
+  
+  auto result = ops::ImmutableConst(root, DT_FLOAT64, kOverflowShape, 
+                                    dummy_file);
+  GraphDef graph_def;
+  TF_ASSERT_OK(root.ToGraphDef(&graph_def));
+  SessionOptions session_options;
+  session_options.env = Env::Default();
+  std::unique_ptr<Session> session(NewSession(session_options));
+  ASSERT_TRUE(session != nullptr) << "Failed to create session";
+  TF_ASSERT_OK(session->Create(graph_def)) << "Can't create test graph";
+  std::vector<Tensor> outputs;
+  
+  // Check that the run returns an InvalidArgument error, not a segfault
+  auto status = session->Run({}, {result.node()->name() + ":0"}, {}, &outputs);
+  EXPECT_EQ(status.code(), error::INVALID_ARGUMENT);
+  EXPECT_TRUE(absl::StrContains(status.message(), "overflow") ||
+              absl::StrContains(status.message(), "does not match"));
 }
 
 }  // namespace

--- a/tensorflow/core/kernels/immutable_constant_op_test.cc
+++ b/tensorflow/core/kernels/immutable_constant_op_test.cc
@@ -144,7 +144,7 @@ TEST(ImmutableConstantOpTest, ExecutionError) {
   // Check that the run returned error.
   EXPECT_EQ(
       session->Run({}, {result.node()->name() + ":0"}, {}, &outputs).code(),
-      error::INTERNAL);
+      absl::StatusCode::kInvalidArgument);
 }
 
 absl::Status CreateTempFileFloat(Env* env, float value, uint64_t size,
@@ -242,7 +242,7 @@ TEST(ImmutableConstantOpTest, LargeShapeDimensionsOverflow) {
   // 2147482841 * 2147485163 would overflow
   const TensorShape kOverflowShape({2147482841, 2147485163});
   
-  auto result = ops::ImmutableConst(root, DT_FLOAT64, kOverflowShape, 
+  auto result = ops::ImmutableConst(root, DT_DOUBLE, kOverflowShape, 
                                     dummy_file);
   GraphDef graph_def;
   TF_ASSERT_OK(root.ToGraphDef(&graph_def));

--- a/tensorflow/core/kernels/immutable_constant_op_test.cc
+++ b/tensorflow/core/kernels/immutable_constant_op_test.cc
@@ -238,8 +238,12 @@ TEST(ImmutableConstantOpTest, LargeShapeDimensionsOverflow) {
   TF_ASSERT_OK(CreateTempFileBadString(env, '\x00', 1, "overflow_test", 
                                        &dummy_file));
 
-  // Use dimensions that multiply to overflow int64_t
-  // 2147482841 * 2147485163 would overflow
+  // These dimensions multiply to 4611681483743124083 elements, which still
+  // fits in int64. The overflow is triggered later in the kernel, when that
+  // element count is multiplied by the 8-byte element size of DT_DOUBLE, so
+  // this exercises the byte-size overflow check. Note we can't pick dimensions
+  // whose product itself overflows int64: TensorShape construction rejects
+  // those (via TF_CHECK_OK), which would abort before the op ever runs.
   const TensorShape kOverflowShape({2147482841, 2147485163});
   
   auto result = ops::ImmutableConst(root, DT_DOUBLE, kOverflowShape, 

--- a/tensorflow/core/kernels/immutable_constant_op_test.cc
+++ b/tensorflow/core/kernels/immutable_constant_op_test.cc
@@ -228,26 +228,21 @@ TEST(ImmutableConstantOpTest, FromFileStringUnimplmented) {
 }
 
 TEST(ImmutableConstantOpTest, LargeShapeDimensionsOverflow) {
-  // Test that large shape dimensions that would overflow are caught
-  // and reported as an error rather than causing a segfault
   Env* env = Env::Default();
   auto root = Scope::DisabledShapeInferenceScope().ExitOnError();
 
-  // Create a small dummy file
   std::string dummy_file;
-  TF_ASSERT_OK(CreateTempFileBadString(env, '\x00', 1, "overflow_test", 
-                                       &dummy_file));
+  TF_ASSERT_OK(
+      CreateTempFileBadString(env, '\x00', 1, "overflow_test", &dummy_file));
 
-  // These dimensions multiply to 4611681483743124083 elements, which still
-  // fits in int64. The overflow is triggered later in the kernel, when that
-  // element count is multiplied by the 8-byte element size of DT_DOUBLE, so
-  // this exercises the byte-size overflow check. Note we can't pick dimensions
-  // whose product itself overflows int64: TensorShape construction rejects
-  // those (via TF_CHECK_OK), which would abort before the op ever runs.
+  // These dimensions multiply to 4611687538844588083 elements, which still
+  // fits in int64. What overflows is that count times the 8 byte element size
+  // of DT_DOUBLE. Dimensions whose product alone overflows are no good here
+  // because TensorShape rejects them and aborts before the op ever runs.
   const TensorShape kOverflowShape({2147482841, 2147485163});
-  
-  auto result = ops::ImmutableConst(root, DT_DOUBLE, kOverflowShape, 
-                                    dummy_file);
+
+  auto result =
+      ops::ImmutableConst(root, DT_DOUBLE, kOverflowShape, dummy_file);
   GraphDef graph_def;
   TF_ASSERT_OK(root.ToGraphDef(&graph_def));
   SessionOptions session_options;
@@ -256,12 +251,12 @@ TEST(ImmutableConstantOpTest, LargeShapeDimensionsOverflow) {
   ASSERT_TRUE(session != nullptr) << "Failed to create session";
   TF_ASSERT_OK(session->Create(graph_def)) << "Can't create test graph";
   std::vector<Tensor> outputs;
-  
-  // Check that the run returns an InvalidArgument error, not a segfault
-  auto status = session->Run({}, {result.node()->name() + ":0"}, {}, &outputs);
-  EXPECT_EQ(status.code(), error::INVALID_ARGUMENT);
-  EXPECT_TRUE(absl::StrContains(status.message(), "overflow") ||
-              absl::StrContains(status.message(), "does not match"));
+
+  // The op has to report the bad size instead of taking the process down.
+  const absl::Status status =
+      session->Run({}, {result.node()->name() + ":0"}, {}, &outputs);
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_TRUE(absl::StrContains(status.message(), "overflows"));
 }
 
 }  // namespace


### PR DESCRIPTION
## What's the issue?

Running `tf.raw_ops.ImmutableConst` with really large shape dimensions causes a segfault. This came up in #108665 where someone tried using dimensions like `[2147482841, 2147485163]` and the whole process crashed instead of throwing an error.
**Fixes:** #108665