### PR TITLE
[tosa] Fix build rules after PR #108700

### DIFF
--- a/tensorflow/compiler/mlir/tosa/BUILD
+++ b/tensorflow/compiler/mlir/tosa/BUILD
@@ -101,7 +101,7 @@ cc_library(
         "@llvm-project//mlir:TosaDialect",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
-        "@local_xla//xla/tsl/framework/fixedpoint",
+        "@xla//xla/tsl/framework/fixedpoint",
     ],
 )
 
@@ -287,9 +287,9 @@ tf_cc_binary(
         "@llvm-project//mlir:MlirOptLib",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:Transforms",
-        "@local_xla//xla/mlir/framework/ir:xla_framework",
-        "@local_xla//xla/mlir/framework/transforms:passes",
-        "@local_xla//xla/mlir_hlo:all_passes",
+        "@xla//xla/mlir/framework/ir:xla_framework",
+        "@xla//xla/mlir/framework/transforms:passes",
+        "@xla//xla/mlir_hlo:all_passes",
     ],
 )
 

--- a/tensorflow/compiler/mlir/tosa/glob_lit_test.bzl
+++ b/tensorflow/compiler/mlir/tosa/glob_lit_test.bzl
@@ -8,7 +8,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
-    "@local_xla//xla:lit.bzl",
+    "@xla//xla:lit.bzl",
     "lit_script_with_xla_gpu_cuda_data_dir",
 )
 


### PR DESCRIPTION
After PR #108700, we just need to replace @local_xla -> @xla

Tested locally (`bazel test //tensorflow/compiler/mlir/tosa/tests:all`)