### PR TITLE
Fix NaN/Inf gradient for tf.norm with zero/small inputs

### DIFF
--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -61,13 +61,22 @@ def _EuclideanNormGrad(op: ops.Operation, grad):
 
   # Handle the case where norm is zero to avoid nan/inf gradients.
   # When norm is 0, we use a subgradient of 0.
+  #
+  # NOTE: When keep_dims=True the reshape above is skipped, so `output` has
+  # shape that may differ from op.inputs[0] (e.g. (1,1) vs (1,2)).  We must
+  # broadcast the zero-mask to the input shape before calling where_v2 to
+  # satisfy graph-mode shape requirements.
+  is_zero = math_ops.equal(output, 0)
   safe_output = array_ops.where_v2(
-      math_ops.equal(output, 0),
+      is_zero,
       array_ops.ones_like(output),
       output)
   grad_input = op.inputs[0] * math_ops.truediv(grad, safe_output)
+  # Broadcast the zero condition to the shape of grad_input and zero out.
+  zero_mask = array_ops.broadcast_to(
+      is_zero, array_ops.shape(grad_input))
   grad_input = array_ops.where_v2(
-      math_ops.equal(output, 0),
+      zero_mask,
       array_ops.zeros_like(grad_input),
       grad_input)
   return grad_input, None

--- a/tensorflow/python/ops/math_grad_test.py
+++ b/tensorflow/python/ops/math_grad_test.py
@@ -272,6 +272,7 @@ class EuclideanNormGradientTest(test.TestCase):
       self.assertAllClose(1.0 / dx, 1.0 / dx_answer)
 
   def testZeros(self):
+    # Previously returned NaN; the fix now returns a subgradient of 0.
     for dtype in [dtypes.float32, dtypes.float64]:
       x = constant_op.constant([0.0, -0.0], dtype=dtype)
 
@@ -280,9 +281,57 @@ class EuclideanNormGradientTest(test.TestCase):
         y = math_ops.reduce_euclidean_norm(x)
 
       dx = tape.gradient(y, x)
-      dx_answer = constant_op.constant(
-          [float("NaN"), float("NaN")], dtype=dtype)
+      dx_answer = constant_op.constant([0.0, 0.0], dtype=dtype)
       self.assertAllClose(dx, dx_answer)
+
+  def testZeroNormSubgradient(self):
+    """Gradient at zero input should be 0 (subgradient convention), not NaN."""
+    for dtype in [dtypes.float32, dtypes.float64]:
+      x = constant_op.constant([0.0, 0.0, 0.0], dtype=dtype)
+      with backprop.GradientTape() as tape:
+        tape.watch(x)
+        y = math_ops.reduce_euclidean_norm(x)
+      dx = tape.gradient(y, x)
+      self.assertAllClose(dx, np.zeros(x.shape.as_list(), dtype=dtype.as_numpy_dtype))
+
+  def testZeroNormSubgradientKeepdims(self):
+    """Zero-norm subgradient holds with keepdims=True."""
+    for dtype in [dtypes.float32, dtypes.float64]:
+      x = constant_op.constant([[0.0, 0.0]], dtype=dtype)
+      with backprop.GradientTape() as tape:
+        tape.watch(x)
+        y = math_ops.reduce_euclidean_norm(x, keepdims=True)
+      dx = tape.gradient(y, x)
+      self.assertAllClose(dx, np.zeros(x.shape.as_list(), dtype=dtype.as_numpy_dtype))
+
+  def testZeroNormSubgradient2D(self):
+    """Rows that are zero-vectors should receive a zero gradient."""
+    for dtype in [dtypes.float32, dtypes.float64]:
+      # Row 0 is the zero vector; row 1 is not.
+      x = constant_op.constant([[0.0, 0.0], [3.0, 4.0]], dtype=dtype)
+      with backprop.GradientTape() as tape:
+        tape.watch(x)
+        y = math_ops.reduce_euclidean_norm(x, axis=1)
+      dx = tape.gradient(y, x)
+      # Row 0: subgradient = 0; Row 1: x/||x|| = [0.6, 0.8]
+      expected = np.array([[0.0, 0.0], [0.6, 0.8]], dtype=dtype.as_numpy_dtype)
+      self.assertAllClose(dx, expected)
+
+  def testZeroNormGradientNoNanOrInf(self):
+    """Gradient should contain neither NaN nor Inf for any-zero input."""
+    for dtype in [dtypes.float32, dtypes.float64]:
+      x = constant_op.constant([0.0, 0.0, 0.0], dtype=dtype)
+      with backprop.GradientTape() as tape:
+        tape.watch(x)
+        y = math_ops.reduce_euclidean_norm(x)
+      dx = tape.gradient(y, x)
+      dx_val = self.evaluate(dx)
+      self.assertFalse(
+          np.any(np.isnan(dx_val)),
+          msg=f"Gradient contains NaN for dtype={dtype}: {dx_val}")
+      self.assertFalse(
+          np.any(np.isinf(dx_val)),
+          msg=f"Gradient contains Inf for dtype={dtype}: {dx_val}")
 
   def test2D_1(self):
     for dtype in [dtypes.float32, dtypes.float64]:


### PR DESCRIPTION
### Description
This PR addresses Issue #12071 where `tf.norm(x)` produces `NaN` gradients when `x` is zero and [Inf](cci:1://file:///Users/garrry/Downloads/Tensorflow/tensorflow/tensorflow/python/ops/math_grad.py:113:0-140:23) gradients when `x` is very small.

The issue arises because the gradient of the Euclidean norm `||x||` involves division by the norm itself: `x / ||x||`. When `||x||` is zero (or very close to it), this results in numerical instability.

### Fix
This change modifies [_EuclideanNormGrad](cci:1://file:///Users/garrry/Downloads/Tensorflow/tensorflow/tensorflow/python/ops/math_grad.py:44:0-72:25) in [tensorflow/python/ops/math_grad.py](cci:7://file:///Users/garrry/Downloads/Tensorflow/tensorflow/tensorflow/python/ops/math_grad.py:0:0-0:0) to handle the zero-norm case explicitly.
- Uses `tf.where` to replace the divisor with 1.0 when the norm is 0, ensuring safe division.
- Masks the final gradient to be 0.0 where the norm was 0, implementing the subgradient convention for the non-differentiable point at the origin.

### Mathematics
At `x=0`, the Euclidean norm is non-differentiable. A common convention in deep learning frameworks (e.g., PyTorch) is to set the subgradient to 0 at this point. This prevents model training from collapsing due to exploding or undefined gradients.

Fixes #12071