### PR TITLE
[AutoGraph] Add warning when Python random module is used inside tf.function

### DIFF
--- a/tensorflow/python/autograph/converters/call_trees.py
+++ b/tensorflow/python/autograph/converters/call_trees.py
@@ -227,7 +227,7 @@ class CallTreeTransformer(converter.Base):
             'unexpected behavior, especially with XLA compilation. '
             'Use `tf.random` functions instead for dynamic random values. '
             'For example, replace `random.randint(a, b)` with '
-            '`tf.random.uniform([], a, b, dtype=tf.int32)`. '
+            '`tf.random.uniform([], a, b + 1, dtype=tf.int32)`. '
             'See https://www.tensorflow.org/guide/function#executing_python_side_effects',
             full_name)
         python_random_warned = True

--- a/tensorflow/python/autograph/converters/call_trees_test.py
+++ b/tensorflow/python/autograph/converters/call_trees_test.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Tests for call_trees module."""
 
+import random
 import types
 
 from tensorflow.python.autograph.converters import call_trees
@@ -256,6 +257,53 @@ class CallTreesTest(converter_testing.TestCase):
 
     self.assertEqual(321, tr(tc, 1))
     self.assertListEqual(mock.calls, [((1,), None)])
+
+  def test_python_random_warning(self):
+    """Test that using Python random module triggers a warning."""
+    # Reset the warning flag for testing
+    call_trees.python_random_warned = False
+
+    def f():
+      return random.randint(1, 10)
+
+    # Transform should work and issue warning
+    tr, mock = self._transform_with_mock(f)
+
+    # The function should still be callable
+    result = tr()
+    self.assertIsInstance(result, int)
+    self.assertGreaterEqual(result, 1)
+    self.assertLessEqual(result, 10)
+
+  def test_python_random_randrange_warning(self):
+    """Test that using Python random.randrange triggers a warning."""
+    # Reset the warning flag for testing
+    call_trees.python_random_warned = False
+
+    def f():
+      return random.randrange(0, 100)
+
+    tr, mock = self._transform_with_mock(f)
+
+    # The function should still be callable
+    result = tr()
+    self.assertIsInstance(result, int)
+    self.assertGreaterEqual(result, 0)
+    self.assertLess(result, 100)
+
+  def test_python_random_choice_warning(self):
+    """Test that using Python random.choice triggers a warning."""
+    # Reset the warning flag for testing
+    call_trees.python_random_warned = False
+
+    def f():
+      return random.choice([1, 2, 3])
+
+    tr, mock = self._transform_with_mock(f)
+
+    # The function should still be callable
+    result = tr()
+    self.assertIn(result, [1, 2, 3])
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/autograph/converters/call_trees_test.py
+++ b/tensorflow/python/autograph/converters/call_trees_test.py
@@ -266,8 +266,12 @@ class CallTreesTest(converter_testing.TestCase):
     def f():
       return random.randint(1, 10)
 
-    # Transform should work and issue warning
-    tr, mock = self._transform_with_mock(f)
+    with self.assertLogs(level='WARNING') as logs:
+      tr, mock = self._transform_with_mock(f)
+
+    self.assertLen(logs.output, 1)
+    self.assertIn('Detected use of Python\'s `random.randint()` inside a tf.function.',
+                  logs.output[0])
 
     # The function should still be callable
     result = tr()
@@ -283,7 +287,12 @@ class CallTreesTest(converter_testing.TestCase):
     def f():
       return random.randrange(0, 100)
 
-    tr, mock = self._transform_with_mock(f)
+    with self.assertLogs(level='WARNING') as logs:
+      tr, mock = self._transform_with_mock(f)
+
+    self.assertLen(logs.output, 1)
+    self.assertIn('Detected use of Python\'s `random.randrange()` inside a tf.function.',
+                  logs.output[0])
 
     # The function should still be callable
     result = tr()
@@ -299,7 +308,12 @@ class CallTreesTest(converter_testing.TestCase):
     def f():
       return random.choice([1, 2, 3])
 
-    tr, mock = self._transform_with_mock(f)
+    with self.assertLogs(level='WARNING') as logs:
+      tr, mock = self._transform_with_mock(f)
+
+    self.assertLen(logs.output, 1)
+    self.assertIn('Detected use of Python\'s `random.choice()` inside a tf.function.',
+                  logs.output[0])
 
     # The function should still be callable
     result = tr()

--- a/tensorflow/python/autograph/converters/call_trees_test.py
+++ b/tensorflow/python/autograph/converters/call_trees_test.py
@@ -270,8 +270,9 @@ class CallTreesTest(converter_testing.TestCase):
       tr, mock = self._transform_with_mock(f)
 
     self.assertLen(logs.output, 1)
-    self.assertIn('Detected use of Python\'s `random.randint()` inside a tf.function.',
-                  logs.output[0])
+    self.assertIn(
+        'Detected use of Python\'s `random.randint()` inside a tf.function.',
+        logs.output[0])
 
     # The function should still be callable
     result = tr()
@@ -291,8 +292,9 @@ class CallTreesTest(converter_testing.TestCase):
       tr, mock = self._transform_with_mock(f)
 
     self.assertLen(logs.output, 1)
-    self.assertIn('Detected use of Python\'s `random.randrange()` inside a tf.function.',
-                  logs.output[0])
+    self.assertIn(
+        'Detected use of Python\'s `random.randrange()` inside a tf.function.',
+        logs.output[0])
 
     # The function should still be callable
     result = tr()
@@ -312,8 +314,9 @@ class CallTreesTest(converter_testing.TestCase):
       tr, mock = self._transform_with_mock(f)
 
     self.assertLen(logs.output, 1)
-    self.assertIn('Detected use of Python\'s `random.choice()` inside a tf.function.',
-                  logs.output[0])
+    self.assertIn(
+        'Detected use of Python\'s `random.choice()` inside a tf.function.',
+        logs.output[0])
 
     # The function should still be callable
     result = tr()


### PR DESCRIPTION
Fix #109111  
# Fix: Warn When Python `random` Module Is Used Inside `tf.function`

## Problem
Using Python’s `random` module (e.g., `random.randint()`) inside a `@tf.function` causes inconsistent behavior between eager execution and XLA compilation:

* In eager mode the random value is generated on each call.
* In a `tf.function` the value is computed only once during tracing and becomes a constant in the graph.
* When the function later runs with different input shapes, the constant shape may no longer match, leading to dimension‑mismatch errors—especially under XLA compilation.

## Solution
Added detection and a helpful warning in AutoGraph’s `call_trees.py` converter:

1. **Detection** – A frozenset `_PYTHON_RANDOM_FUNCTIONS` contains all Python `random` functions that can produce traced constants (`random.randint`, `random.randrange`, `random.random`, …).
2. **Warning** – The first time any of these functions is encountered inside a `tf.function`, a warning is emitted that:
   * Explains why the pattern is problematic.
   * Recommends using TensorFlow’s `tf.random` equivalents.
   * Provides an example conversion (e.g., `random.randint(a, b)` → `tf.random.uniform([], a, b, dtype=tf.int32)`).
   * Links to the TensorFlow function guide for more details.

3. **Test Coverage** – Added unit tests for `random.randint`, `random.randrange`, and `random.choice` to verify that the warning is triggered while the transformation still works correctly.

## Files Changed
- `tensorflow/python/autograph/converters/call_trees.py` – Added detection logic and warning.
- `tensorflow/python/autograph/converters/call_trees_test.py` – Added test cases.

## Example Warning Message
```
WARNING: Detected use of Python's `random.randint()` inside a tf.function. 
The random value is computed during tracing and becomes a constant in the graph, 
which may cause shape mismatches or unexpected behavior, especially with XLA compilation. 
Use `tf.random` functions instead for dynamic random values. 
For example, replace `random.randint(a, b)` with `tf.random.uniform([], a, b, dtype=tf.int32)`. 
See https://www.tensorflow.org/guide/function#executing_python_side_effects
```

## How to Test
Run the existing test suite for `call_trees_test.py`; the new tests should pass, confirming that the warning is correctly emitted without breaking existing functionality.

---

*This PR fixes issue #109111 and helps users avoid shape‑mismatch bugs when mixing Python random calls with TensorFlow graph execution.*