### PR TITLE
Add validation of rank of input tensor in ResourceGatherOp. Resolves tf.raw_ops.ResourceGather crashes when batch_dims is incompatible with resource and indices rank #106497

### DIFF
--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -778,6 +778,12 @@ class ResourceGatherOp : public OpKernel {
             "batch_dims (", batch_dims_, ") must be less than rank(params) (",
             params.dims(), ").")));
 
+    OP_REQUIRES(
+        c, batch_dims_ <= indices.dims(),
+        absl::InvalidArgumentError(absl::StrCat(
+            "Expected batch_dims <= rank(indices) (", indices.dims(),
+            "), but got ", batch_dims_)));
+
     // Check that we have enough index space
     const int64_t N = indices.NumElements();
     OP_REQUIRES(c, params.dim_size(0) <= std::numeric_limits<Index>::max(),

--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -767,14 +767,16 @@ class ResourceGatherOp : public OpKernel {
     tf_shared_lock ml(*v->mu());
     const Tensor& params = *v->tensor();
     const Tensor& indices = c->input(1);
+
     OP_REQUIRES(
         c, TensorShapeUtils::IsVectorOrHigher(params.shape()),
         absl::InvalidArgumentError("params must be at least 1 dimensional"));
-    OP_REQUIRES(c, params.shape().dims() >= batch_dims_,
-                absl::InvalidArgumentError(
-                    absl::StrCat("params must have at least ", batch_dims_,
-                                 " (batch_dims) dimensions but it has shape ",
-                                 params.shape().DebugString())));
+
+    OP_REQUIRES(
+        c, batch_dims_ < params.dims(),
+        absl::InvalidArgumentError(absl::StrCat(
+            "batch_dims (", batch_dims_, ") must be less than rank(params) (",
+            params.dims(), ").")));
 
     // Check that we have enough index space
     const int64_t N = indices.NumElements();

--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -778,11 +778,10 @@ class ResourceGatherOp : public OpKernel {
             "batch_dims (", batch_dims_, ") must be less than rank(params) (",
             params.dims(), ").")));
 
-    OP_REQUIRES(
-        c, batch_dims_ <= indices.dims(),
-        absl::InvalidArgumentError(absl::StrCat(
-            "Expected batch_dims <= rank(indices) (", indices.dims(),
-            "), but got ", batch_dims_)));
+    OP_REQUIRES(c, batch_dims_ <= indices.dims(),
+                absl::InvalidArgumentError(
+                    absl::StrCat("Expected batch_dims <= rank(indices) (",
+                                 indices.dims(), "), but got ", batch_dims_)));
 
     // Check that we have enough index space
     const int64_t N = indices.NumElements();

--- a/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
+++ b/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
@@ -1750,6 +1750,21 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
     self.assertAllEqual(output_shape, result.shape.as_list())
     self.assertAllEqual(expected, result)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testGatherWithBatchDimsEqualTensorRank(self):
+    var = resource_variable_ops.ResourceVariable(
+      [10, 20, 30, 40, 50], name="var0", dtype=dtypes.float32)
+    indices = constant_op.constant([1, 3, 4], dtype=dtypes.int32)
+    with self.assertRaisesRegex(
+                                errors.InvalidArgumentError, "rank"):
+      _ = resource_variable_ops.resource_gather(
+        resource=var.handle,
+        indices=indices,
+        dtype=dtypes.float32,
+        batch_dims=1,
+        validate_indices=True
+      )
+
   @parameterized.parameters([
       dict(dtype=dtypes.bool),
       dict(dtype=dtypes.int64),

--- a/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
+++ b/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
@@ -1765,6 +1765,22 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
         validate_indices=True
       )
 
+  @test_util.run_in_graph_and_eager_modes
+  def testGatherWithBatchDimsGreaterThanIndicesRank(self):
+    var = resource_variable_ops.ResourceVariable(
+        [[10, 20], [30, 40]], name="var0", dtype=dtypes.float32)
+    # indices has rank 0 (scalar)
+    indices = constant_op.constant(1, dtype=dtypes.int32)
+    # batch_dims = 1 > indices.dims() = 0
+    with self.assertRaisesRegex((errors.InvalidArgumentError, ValueError),
+                                "rank"):
+      _ = resource_variable_ops.resource_gather(
+          resource=var.handle,
+          indices=indices,
+          dtype=dtypes.float32,
+          batch_dims=1,
+          validate_indices=True)
+
   @parameterized.parameters([
       dict(dtype=dtypes.bool),
       dict(dtype=dtypes.int64),

--- a/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
+++ b/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
@@ -1755,8 +1755,8 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
     var = resource_variable_ops.ResourceVariable(
       [10, 20, 30, 40, 50], name="var0", dtype=dtypes.float32)
     indices = constant_op.constant([1, 3, 4], dtype=dtypes.int32)
-    with self.assertRaisesRegex(
-                                errors.InvalidArgumentError, "rank"):
+    with self.assertRaisesRegex((errors.InvalidArgumentError, ValueError), 
+                                "rank"):
       _ = resource_variable_ops.resource_gather(
         resource=var.handle,
         indices=indices,

--- a/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
+++ b/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
@@ -1750,22 +1750,22 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
     self.assertAllEqual(output_shape, result.shape.as_list())
     self.assertAllEqual(expected, result)
 
-    @test_util.run_in_graph_and_eager_modes
-    def testGatherWithBatchDimsEqualTensorRank(self):
-      var = resource_variable_ops.ResourceVariable(
-          [10, 20, 30, 40, 50], name="var0", dtype=dtypes.float32
+  @test_util.run_in_graph_and_eager_modes
+  def testGatherWithBatchDimsEqualTensorRank(self):
+    var = resource_variable_ops.ResourceVariable(
+        [10, 20, 30, 40, 50], name="var0", dtype=dtypes.float32
+    )
+    indices = constant_op.constant([1, 3, 4], dtype=dtypes.int32)
+    with self.assertRaisesRegex(
+        (errors.InvalidArgumentError, ValueError), "rank"
+    ):
+      _ = resource_variable_ops.resource_gather(
+          resource=var.handle,
+          indices=indices,
+          dtype=dtypes.float32,
+          batch_dims=1,
+          validate_indices=True,
       )
-      indices = constant_op.constant([1, 3, 4], dtype=dtypes.int32)
-      with self.assertRaisesRegex(
-          (errors.InvalidArgumentError, ValueError), "rank"
-      ):
-        _ = resource_variable_ops.resource_gather(
-            resource=var.handle,
-            indices=indices,
-            dtype=dtypes.float32,
-            batch_dims=1,
-            validate_indices=True,
-        )
 
   @test_util.run_in_graph_and_eager_modes
   def testGatherWithBatchDimsGreaterThanIndicesRank(self):

--- a/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
+++ b/tensorflow/python/kernel_tests/variables/resource_variable_ops_test.py
@@ -1750,36 +1750,41 @@ class ResourceVariableOpsTest(test_util.TensorFlowTestCase,
     self.assertAllEqual(output_shape, result.shape.as_list())
     self.assertAllEqual(expected, result)
 
-  @test_util.run_in_graph_and_eager_modes
-  def testGatherWithBatchDimsEqualTensorRank(self):
-    var = resource_variable_ops.ResourceVariable(
-      [10, 20, 30, 40, 50], name="var0", dtype=dtypes.float32)
-    indices = constant_op.constant([1, 3, 4], dtype=dtypes.int32)
-    with self.assertRaisesRegex((errors.InvalidArgumentError, ValueError), 
-                                "rank"):
-      _ = resource_variable_ops.resource_gather(
-        resource=var.handle,
-        indices=indices,
-        dtype=dtypes.float32,
-        batch_dims=1,
-        validate_indices=True
+    @test_util.run_in_graph_and_eager_modes
+    def testGatherWithBatchDimsEqualTensorRank(self):
+      var = resource_variable_ops.ResourceVariable(
+          [10, 20, 30, 40, 50], name="var0", dtype=dtypes.float32
       )
+      indices = constant_op.constant([1, 3, 4], dtype=dtypes.int32)
+      with self.assertRaisesRegex(
+          (errors.InvalidArgumentError, ValueError), "rank"
+      ):
+        _ = resource_variable_ops.resource_gather(
+            resource=var.handle,
+            indices=indices,
+            dtype=dtypes.float32,
+            batch_dims=1,
+            validate_indices=True,
+        )
 
   @test_util.run_in_graph_and_eager_modes
   def testGatherWithBatchDimsGreaterThanIndicesRank(self):
     var = resource_variable_ops.ResourceVariable(
-        [[10, 20], [30, 40]], name="var0", dtype=dtypes.float32)
+        [[10, 20], [30, 40]], name="var0", dtype=dtypes.float32
+    )
     # indices has rank 0 (scalar)
     indices = constant_op.constant(1, dtype=dtypes.int32)
     # batch_dims = 1 > indices.dims() = 0
-    with self.assertRaisesRegex((errors.InvalidArgumentError, ValueError),
-                                "rank"):
+    with self.assertRaisesRegex(
+        (errors.InvalidArgumentError, ValueError), "rank"
+    ):
       _ = resource_variable_ops.resource_gather(
           resource=var.handle,
           indices=indices,
           dtype=dtypes.float32,
           batch_dims=1,
-          validate_indices=True)
+          validate_indices=True,
+      )
 
   @parameterized.parameters([
       dict(dtype=dtypes.bool),


### PR DESCRIPTION
PR corrects a check that rank of `params` tensor is strictly greater that `batch_dims` in `ResourceGatherOp::Compute` and makes error message similar to analogous error message in `GatherOp::Compute`. Also adds a test to verify that an `InvalidArgumentError` is raised instead of a process crash. Fixes #106497. 