### PR TITLE
Fix SIGABRT in TensorShape::AddDim for zero dimensions (fixes #109148)

### DIFF
--- a/tensorflow/core/framework/tensor_shape.cc
+++ b/tensorflow/core/framework/tensor_shape.cc
@@ -419,9 +419,14 @@ void TensorShapeBase<Shape>::AddDim(int64_t size) {
   int64_t new_num_elements;
   if (kIsPartial && (num_elements() < 0 || size < 0)) {
     new_num_elements = -1;
+  } else if (num_elements() == 0 || size == 0) {
+    // If either operand is 0, the total elements must be 0.
+    // This prevents overflow checks from failing on massive dimensions
+    // when the total volume is mathematically zero.
+    new_num_elements = 0;
   } else {
     new_num_elements = MultiplyWithoutOverflow(num_elements(), size);
-    CHECK_LE(0, new_num_elements);
+    CHECK_LE(0, new_num_elements) << "Overflow computing total elements";
   }
   UnsafeAddDim(size, new_num_elements);
 }


### PR DESCRIPTION
## Description
This PR fixes a `SIGABRT` crash in `TensorShape::AddDim` triggered by `tf.math.reduce_variance` (and other reduction ops) on large shapes containing zero.

**Fixes #109148**

### The Issue
As reported in #109148, calling reduction operations on shapes like `(9, 9, 0, 9, 4, 2**63 - 2)` causes a process-level abort. This happens because the internal `AddDim` function uses a `CHECK_LE(0, new_num_elements)` assertion to validate shape sizes. 

In cases where a shape has a zero dimension followed by an extremely large dimension, the intermediate multiplication logic signals an integer overflow (returning a negative value) before the zero is accounted for. While $0 \times x$ should mathematically result in $0$, the assertion was killing the process before reaching that conclusion.



### The Fix
I implemented a **Zero-Guard** in `tensorflow/core/framework/tensor_shape.cc`:
- Added an explicit check: If either the current `num_elements` or the dimension `size` being added is `0`, `new_num_elements` is explicitly set to `0`.
- This bypasses the `MultiplyWithoutOverflow` call and the fatal `CHECK` assertion for cases where the result is mathematically guaranteed to be zero.

### Verification
- **Reproduction:** Confirmed the `SIGABRT` crash using the script provided in the issue on `tf-nightly`.
- **Unit Tests:** Passed `bazel test //tensorflow/core/framework:tensor_shape_test` (ran 10k+ actions).
- **Manual Test:** Verified that the reproduction script now exits cleanly and handles the shape correctly after the fix.