### PR TITLE
Replace CHECK_GE with OP_REQUIRES in ReductionOp::Compute

### DIFF
--- a/tensorflow/core/kernels/reduction_ops_common.h
+++ b/tensorflow/core/kernels/reduction_ops_common.h
@@ -146,7 +146,10 @@ class ReductionOp : public OpKernel {
 
     ReductionHelper helper;
     OP_REQUIRES_OK(ctx, helper.Simplify(data, axes, keep_dims_));
-    CHECK_GE(helper.ndims(), 0);
+    OP_REQUIRES(ctx, helper.ndims() >= 0,
+                errors::InvalidArgument(
+                    "Reduction helper returned negative ndims. Input shape: ",
+                    data.shape().DebugString()));
 
     bool is_scalar_identity = functor::ReducerTraits<Reducer>::IsScalarIdentity;
     bool is_trivial = helper.ndims() == 0 ||


### PR DESCRIPTION
## Summary
- `CHECK_GE(helper.ndims(), 0)` in `reduction_ops_common.h` is a fatal assertion that causes `SIGABRT` when triggered by tensors with zero-sized dimensions (e.g., via `tf.math.reduce_variance`)
- Replaced with `OP_REQUIRES` to return `InvalidArgumentError` instead of crashing the process

## Reproducer
```python
import tensorflow as tf
# This crashes with SIGABRT on current master
tf.math.reduce_variance(tf.zeros([1000000, 0, 5000]))
```

## Test plan
- [ ] Verify the reproducer raises `InvalidArgumentError` instead of crashing
- [ ] Run `bazel test //tensorflow/core/kernels:reduction_ops_test`
- [ ] Run `bazel test //tensorflow/python/ops:math_ops_test`

Fixes #109148