### PR TITLE
Validate window_size and stride in AudioSpectrogramOp constructor

### DIFF
--- a/tensorflow/core/kernels/spectrogram_op.cc
+++ b/tensorflow/core/kernels/spectrogram_op.cc
@@ -34,6 +34,11 @@ class AudioSpectrogramOp : public OpKernel {
     OP_REQUIRES_OK(context, context->GetAttr("stride", &stride_));
     OP_REQUIRES_OK(context,
                    context->GetAttr("magnitude_squared", &magnitude_squared_));
+    OP_REQUIRES(context, window_size_ > 1,
+                errors::InvalidArgument("window_size must be > 1, got ",
+                                        window_size_));
+    OP_REQUIRES(context, stride_ > 0,
+                errors::InvalidArgument("stride must be > 0, got ", stride_));
   }
 
   void Compute(OpKernelContext* context) override {


### PR DESCRIPTION
## Summary
- `tf.raw_ops.AudioSpectrogram` segfaults when given negative `window_size` or `stride` values
- The crash occurs because `Spectrogram::Initialize` calls `vector::resize` with a negative value (undefined behavior) before any validation check
- Added `OP_REQUIRES` validation in the kernel constructor to reject `window_size <= 1` and `stride <= 0` with `InvalidArgumentError`

## Reproducer
```python
import tensorflow as tf
# This segfaults on current master
tf.raw_ops.AudioSpectrogram(
    input=tf.zeros([8, 1]),
    window_size=-5,
    stride=-1
)
```

## Test plan
- [ ] Verify the reproducer raises `InvalidArgumentError` instead of segfaulting
- [ ] Run `bazel test //tensorflow/core/kernels:spectrogram_op_test`

Fixes #108664