### PR TITLE
Handle infinite clip_norm in tf.clip_by_norm

### DIFF
--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -223,6 +223,13 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
           math_ops.maximum(clip_norm, 0), dtype=values.dtype
       )
 
+    # If clip_norm is infinite, no clipping is needed — return input as-is.
+    if isinstance(clip_norm, (int, float)) and np.isinf(clip_norm):
+      if isinstance(t, indexed_slices.IndexedSlices):
+        return indexed_slices.IndexedSlices(
+            array_ops.identity(values, name=name), t.indices, t.dense_shape)
+      return array_ops.identity(values, name=name)
+
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
     l2sum = math_ops.reduce_sum(values * values, axes, keepdims=True)
     pred = l2sum > 0

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -232,7 +232,7 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
       clip_norm = math_ops.cast(clip_norm, dtype=values.dtype)
       clip_norm_safe = array_ops.where(
           is_clip_norm_inf,
-          constant_op.constant(1.0, dtype=values.dtype),
+          array_ops.ones_like(clip_norm),
           clip_norm)
 
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
@@ -386,7 +386,7 @@ def clip_by_global_norm(t_list, clip_norm, use_norm=None, name=None):
       is_clip_norm_inf = math_ops.is_inf(clip_norm)
       clip_norm_safe = array_ops.where(
           is_clip_norm_inf,
-          constant_op.constant(1.0, dtype=use_norm.dtype),
+          array_ops.ones_like(clip_norm),
           clip_norm)
       scale_for_finite = clip_norm_safe * math_ops.minimum(
           1.0 / use_norm,

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -217,7 +217,8 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
 
     is_clip_norm_inf = None
     if np.isscalar(clip_norm):
-      if np.isinf(clip_norm):
+      if (np.isposinf(clip_norm) or
+          clip_norm > values.dtype.real_dtype.max):
         if isinstance(t, indexed_slices.IndexedSlices):
           return indexed_slices.IndexedSlices(
               array_ops.identity(values, name=name), t.indices, t.dense_shape)
@@ -228,7 +229,7 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
     else:
       clip_norm = math_ops.maximum(clip_norm, 0)
       is_clip_norm_inf = math_ops.is_inf(
-          math_ops.cast(clip_norm, dtypes.float64))
+          math_ops.cast(clip_norm, values.dtype.real_dtype))
       clip_norm = math_ops.cast(clip_norm, dtype=values.dtype)
       clip_norm_safe = array_ops.where(
           is_clip_norm_inf,
@@ -372,7 +373,8 @@ def clip_by_global_norm(t_list, clip_norm, use_norm=None, name=None):
                       t_list + [clip_norm]) as name:
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
     if np.isscalar(clip_norm):
-      if np.isinf(clip_norm):
+      if (np.isposinf(clip_norm) or
+          clip_norm > use_norm.dtype.real_dtype.max):
         scale = constant_op.constant(1.0, dtype=use_norm.dtype)
       else:
         scale = clip_norm * math_ops.minimum(

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -215,20 +215,25 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
         t.values if isinstance(t, indexed_slices.IndexedSlices) else t,
         name="t")
 
+    is_clip_norm_inf = None
     if np.isscalar(clip_norm):
+      if np.isinf(clip_norm):
+        if isinstance(t, indexed_slices.IndexedSlices):
+          return indexed_slices.IndexedSlices(
+              array_ops.identity(values, name=name), t.indices, t.dense_shape)
+        return array_ops.identity(values, name=name)
       if clip_norm < 0:
         clip_norm = 0
+      clip_norm_safe = clip_norm
     else:
-      clip_norm = math_ops.cast(
-          math_ops.maximum(clip_norm, 0), dtype=values.dtype
-      )
-
-    # If clip_norm is infinite, no clipping is needed — return input as-is.
-    if isinstance(clip_norm, (int, float)) and np.isinf(clip_norm):
-      if isinstance(t, indexed_slices.IndexedSlices):
-        return indexed_slices.IndexedSlices(
-            array_ops.identity(values, name=name), t.indices, t.dense_shape)
-      return array_ops.identity(values, name=name)
+      clip_norm = math_ops.maximum(clip_norm, 0)
+      is_clip_norm_inf = math_ops.is_inf(
+          math_ops.cast(clip_norm, dtypes.float64))
+      clip_norm = math_ops.cast(clip_norm, dtype=values.dtype)
+      clip_norm_safe = array_ops.where(
+          is_clip_norm_inf,
+          constant_op.constant(1.0, dtype=values.dtype),
+          clip_norm)
 
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
     l2sum = math_ops.reduce_sum(values * values, axes, keepdims=True)
@@ -236,12 +241,14 @@ def clip_by_norm(t, clip_norm, axes=None, name=None):
     # Two-tap tf.where trick to bypass NaN gradients
     l2sum_safe = array_ops.where(pred, l2sum, array_ops.ones_like(l2sum))
     l2norm = array_ops.where(pred, math_ops.sqrt(l2sum_safe), l2sum)
-    intermediate = values * clip_norm
+    intermediate = values * clip_norm_safe
     # Assert that the shape is compatible with the initial shape,
     # to prevent unintentional broadcasting.
     values.shape.assert_is_compatible_with(intermediate.shape)
-    values_clip = array_ops.identity(
-        intermediate / math_ops.maximum(l2norm, clip_norm), name=name)
+    values_clip = intermediate / math_ops.maximum(l2norm, clip_norm_safe)
+    if is_clip_norm_inf is not None:
+      values_clip = array_ops.where(is_clip_norm_inf, values, values_clip)
+    values_clip = array_ops.identity(values_clip, name=name)
 
     if isinstance(t, indexed_slices.IndexedSlices):
       return indexed_slices.IndexedSlices(values_clip, t.indices, t.dense_shape)
@@ -364,12 +371,32 @@ def clip_by_global_norm(t_list, clip_norm, use_norm=None, name=None):
   with ops.name_scope(name, "clip_by_global_norm",
                       t_list + [clip_norm]) as name:
     # Calculate L2-norm, clip elements by ratio of clip_norm to L2-norm
-    scale_for_finite = clip_norm * math_ops.minimum(
-        1.0 / use_norm,
-        constant_op.constant(1.0, dtype=use_norm.dtype) / clip_norm)
-    # If use_norm is any finite number, this is a no-op. For inf/-inf/NaN,
-    # this will make scale NaN.
-    scale = scale_for_finite + (use_norm - use_norm)
+    if np.isscalar(clip_norm):
+      if np.isinf(clip_norm):
+        scale = constant_op.constant(1.0, dtype=use_norm.dtype)
+      else:
+        scale = clip_norm * math_ops.minimum(
+            1.0 / use_norm,
+            constant_op.constant(1.0, dtype=use_norm.dtype) / clip_norm)
+      # If use_norm is any finite number, this is a no-op. For inf/-inf/NaN,
+      # this will make scale NaN.
+      scale = scale + (use_norm - use_norm)
+    else:
+      clip_norm = math_ops.cast(clip_norm, dtype=use_norm.dtype)
+      is_clip_norm_inf = math_ops.is_inf(clip_norm)
+      clip_norm_safe = array_ops.where(
+          is_clip_norm_inf,
+          constant_op.constant(1.0, dtype=use_norm.dtype),
+          clip_norm)
+      scale_for_finite = clip_norm_safe * math_ops.minimum(
+          1.0 / use_norm,
+          constant_op.constant(1.0, dtype=use_norm.dtype) / clip_norm_safe)
+      # If use_norm is any finite number, this is a no-op. For inf/-inf/NaN,
+      # this will make scale NaN.
+      scale = scale_for_finite + (use_norm - use_norm)
+      scale_if_inf = constant_op.constant(1.0, dtype=use_norm.dtype) + (
+          use_norm - use_norm)
+      scale = array_ops.where(is_clip_norm_inf, scale_if_inf, scale)
 
     values = [
         ops.convert_to_tensor(

--- a/tensorflow/python/ops/clip_ops_test.py
+++ b/tensorflow/python/ops/clip_ops_test.py
@@ -91,6 +91,29 @@ class ClipOpsTest(test.TestCase):
                                      [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
 
   @test_util.run_deprecated_v1
+  def testClipTensorByNormInfinite(self):
+    self._testClipTensorByNorm([1.0, 2.0, 3.0], float("inf"),
+                               [1.0, 2.0, 3.0])
+    self._testClipTensorByNorm([1.0, 2.0, 3.0], np.float32(float("inf")),
+                               [1.0, 2.0, 3.0])
+
+    clipped = clip_ops.clip_by_norm(
+        constant_op.constant([1.0, 2.0, 3.0]),
+        constant_op.constant(float("inf")))
+    self.assertAllClose(self.evaluate(clipped), [1.0, 2.0, 3.0])
+
+  @test_util.run_deprecated_v1
+  def testClipTensorByGlobalNormInfinite(self):
+    self._testClipTensorByGlobalNorm([[1.0, 2.0, 3.0]], float("inf"),
+                                     [[1.0, 2.0, 3.0]])
+    self._testClipTensorByGlobalNorm([[1.0, 2.0, 3.0]],
+                                     np.float32(float("inf")),
+                                     [[1.0, 2.0, 3.0]])
+    self._testClipTensorByGlobalNorm(
+        [[1.0, 2.0, 3.0]], constant_op.constant(float("inf")),
+        [[1.0, 2.0, 3.0]])
+
+  @test_util.run_deprecated_v1
   def testClipTensorByGlobalNormMultipleDtypes(self):
     (a, b), _ = self.evaluate(
         clip_ops.clip_by_global_norm(

--- a/tensorflow/python/ops/clip_ops_test.py
+++ b/tensorflow/python/ops/clip_ops_test.py
@@ -113,6 +113,40 @@ class ClipOpsTest(test.TestCase):
         [[1.0, 2.0, 3.0]], constant_op.constant(float("inf")),
         [[1.0, 2.0, 3.0]])
 
+  def testClipTensorByNormOverflow(self):
+    clip_norm = constant_op.constant(1e300, dtype=dtypes.float64)
+    values = constant_op.constant([1.0, 2.0, 3.0], dtype=dtypes.float32)
+    result = self.evaluate(clip_ops.clip_by_norm(values, clip_norm))
+    self.assertFalse(np.any(np.isnan(result)))
+    self.assertAllClose(result, [1.0, 2.0, 3.0])
+
+  def testClipScalarByNormOverflow(self):
+    values = constant_op.constant([1.0, 2.0, 3.0], dtype=dtypes.float32)
+    result = self.evaluate(clip_ops.clip_by_norm(values, 1e300))
+    self.assertFalse(np.any(np.isnan(result)))
+    self.assertAllClose(result, [1.0, 2.0, 3.0])
+
+  def testClipScalarByNormNegativeInfinity(self):
+    values = constant_op.constant([1.0, 2.0, 3.0], dtype=dtypes.float32)
+    result = self.evaluate(clip_ops.clip_by_norm(values, float("-inf")))
+    self.assertAllClose(result, [0.0, 0.0, 0.0])
+
+  def testClipScalarByGlobalNormOverflow(self):
+    values = [
+        constant_op.constant([1.0, 2.0, 3.0], dtype=dtypes.float32)
+    ]
+    clipped, _ = clip_ops.clip_by_global_norm(values, 1e300)
+    result = self.evaluate(clipped[0])
+    self.assertFalse(np.any(np.isnan(result)))
+    self.assertAllClose(result, [1.0, 2.0, 3.0])
+
+  def testClipScalarByGlobalNormNegativeInfinity(self):
+    values = [
+        constant_op.constant([1.0, 2.0, 3.0], dtype=dtypes.float32)
+    ]
+    clipped, _ = clip_ops.clip_by_global_norm(values, float("-inf"))
+    self.assertTrue(np.all(np.isnan(self.evaluate(clipped[0]))))
+
   @test_util.run_deprecated_v1
   def testClipTensorByGlobalNormMultipleDtypes(self):
     (a, b), _ = self.evaluate(


### PR DESCRIPTION
## Summary

Fixes #109146.

Clipping now treats positive infinite or numerically unrepresentable `clip_norm` values as an unbounded no-op without allowing an overflowed cast to create NaNs. The fix covers scalar and Tensor limits in `tf.clip_by_norm`, plus scalar limits in `tf.clip_by_global_norm`.

## Changes

- Detect positive scalar infinity and values larger than the input real dtype before casting.
- Evaluate Tensor infinity after casting to the input real dtype so finite `float64` values that overflow `float32` are handled safely.
- Preserve documented negative-infinity behavior instead of conflating it with positive infinity.
- Add regressions for `1e300` scalar/Tensor limits and negative infinity in both clipping APIs.

## Testing

- PASS: `python -m py_compile tensorflow/python/ops/clip_ops.py tensorflow/python/ops/clip_ops_test.py`
- PASS: `git diff --check`
- PASS: focused local reviewer gate, including the negative-infinity regression found during review.
- NOT RUN locally: TensorFlow Bazel unit/build targets because Bazel, buildifier, and a built TensorFlow runtime are unavailable in this checkout.
- Fresh upstream CI was triggered by commit `131d2a9959e` and is pending.

## Risk

Low. The early no-op is limited to positive limits that cannot clip any representable value; negative limits and NaNs continue through their existing semantics.
