### PR TITLE
Apply tolerance formula for integer inputs in isclose

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -534,7 +534,14 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):  # pylint: disable=m
         result = result | (math_ops.is_nan(a) & math_ops.is_nan(b))
       return result
     else:
-      return a == b
+      # Cast integer types to float64 for tolerance comparison, matching NumPy.
+      a_float = math_ops.cast(a, dtypes.float64)
+      b_float = math_ops.cast(b, dtypes.float64)
+      rtol_ = ops.convert_to_tensor(rtol, dtypes.float64)
+      atol_ = ops.convert_to_tensor(atol, dtypes.float64)
+      return (
+          math_ops.abs(a_float - b_float) <= atol_ + rtol_ * math_ops.abs(
+              b_float))
 
   return _bin_op(f, a, b)
 


### PR DESCRIPTION
## Summary
- `tf.experimental.numpy.isclose` returns incorrect results for integer inputs
- Integer dtypes fail the `np.issubdtype(dtype, np.inexact)` check and fall through to strict equality (`a == b`), completely ignoring `atol` and `rtol` parameters
- NumPy handles this by casting integers to float before applying the tolerance formula
- Fixed by casting integer inputs to `float64` and applying `|a-b| <= atol + rtol * |b|`

## Reproducer
```python
import tensorflow as tf
a = tf.constant([1, 2, 3], dtype=tf.int32)
b = tf.constant([1, 3, 5], dtype=tf.int32)
# With atol=1.5, values within 1.5 of each other should be "close"
result = tf.experimental.numpy.isclose(a, b, atol=1.5, rtol=0)
print(result)  # Returns [True, False, False] on master, should be [True, True, False]
```

## Test plan
- [ ] Verify the reproducer matches NumPy behavior
- [ ] Run `bazel test //tensorflow/python/ops/numpy_ops:np_math_ops_test`

Fixes #108657