### PR TITLE
Fix numerical instability of tf.norm gradient (NaN at zero)

### DIFF
--- a/tensorflow/python/ops/linalg_ops.py
+++ b/tensorflow/python/ops/linalg_ops.py
@@ -763,9 +763,17 @@ def norm(tensor,
         # NOTE: we unfortunately cannot use tf.math.reduce_euclidean_norm, since
         # this introduces a new op that is not supported in XLA, and breaks
         # many existing TPU workloads (e.g. ResNet).
-        result = math_ops.sqrt(
-            math_ops.reduce_sum(
-                tensor * math_ops.conj(tensor), axis, keepdims=True))
+        sum_squares = math_ops.reduce_sum(
+            tensor * math_ops.conj(tensor), axis, keepdims=True)
+        # Use a safe sqrt to avoid NaN/inf gradients when sum_squares is zero.
+        # maximum(sum_squares, tiny) ensures the sqrt gradient denominator is
+        # never zero, and the where mask preserves exact zero forward output.
+        tiny = np.finfo(tensor.dtype.real_dtype.as_numpy_dtype).tiny
+        safe_sum = math_ops.maximum(sum_squares, tiny)
+        result = array_ops.where(
+            math_ops.equal(sum_squares, 0),
+            array_ops.zeros_like(safe_sum),
+            math_ops.sqrt(safe_sum))
     else:
       result = math_ops.abs(tensor)
       if ord == 1:

--- a/tensorflow/python/ops/linalg_ops.py
+++ b/tensorflow/python/ops/linalg_ops.py
@@ -768,8 +768,16 @@ def norm(tensor,
         # Use a safe sqrt to avoid NaN/inf gradients when sum_squares is zero.
         # maximum(sum_squares, tiny) ensures the sqrt gradient denominator is
         # never zero, and the where mask preserves exact zero forward output.
-        tiny = np.finfo(tensor.dtype.real_dtype.as_numpy_dtype).tiny
-        safe_sum = math_ops.maximum(sum_squares, tiny)
+        real_dtype = tensor.dtype.real_dtype
+        tiny_dtype = np.float32 if real_dtype == dtypes.bfloat16 else (
+            real_dtype.as_numpy_dtype)
+        tiny = np.finfo(tiny_dtype).tiny
+        if tensor.dtype.is_complex:
+          real_sum = math_ops.real(sum_squares)
+          safe_sum = math_ops.complex(
+              math_ops.maximum(real_sum, tiny), array_ops.zeros_like(real_sum))
+        else:
+          safe_sum = math_ops.maximum(sum_squares, tiny)
         result = array_ops.where(
             math_ops.equal(sum_squares, 0),
             array_ops.zeros_like(safe_sum),

--- a/tensorflow/python/ops/math_grad.py
+++ b/tensorflow/python/ops/math_grad.py
@@ -54,7 +54,7 @@ def _EuclideanNormGrad(op: ops.Operation, grad):
     output = array_ops.reshape(output, output_shape_kept_dims)
     grad = array_ops.reshape(grad, output_shape_kept_dims)
 
-  return math_ops.truediv(op.inputs[0], output / grad), None
+  return math_ops.div_no_nan(op.inputs[0], output) * grad, None
 
 
 def SmartBroadcastGradientArgs(x, y, grad=None):

--- a/tensorflow/python/ops/math_grad_test.py
+++ b/tensorflow/python/ops/math_grad_test.py
@@ -29,6 +29,7 @@ from tensorflow.python.ops import gradient_checker
 from tensorflow.python.ops import gradient_checker_v2
 from tensorflow.python.ops import gradients
 from tensorflow.python.ops import math_grad
+from tensorflow.python.ops import linalg_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.platform import test
 
@@ -280,8 +281,7 @@ class EuclideanNormGradientTest(test.TestCase):
         y = math_ops.reduce_euclidean_norm(x)
 
       dx = tape.gradient(y, x)
-      dx_answer = constant_op.constant(
-          [float("NaN"), float("NaN")], dtype=dtype)
+      dx_answer = constant_op.constant([0.0, 0.0], dtype=dtype)
       self.assertAllClose(dx, dx_answer)
 
   def test2D_1(self):
@@ -351,6 +351,33 @@ class EuclideanNormGradientTest(test.TestCase):
           lambda x: math_ops.reduce_euclidean_norm(x, 2), [x])
       err = gradient_checker_v2.max_error(*grads)
       self.assertLess(err, 2e-3)
+
+
+@test_util.run_all_in_graph_and_eager_modes
+class LinalgNormGradientTest(test.TestCase):
+
+  def testZeroGrad(self):
+    for dtype in [dtypes.float32, dtypes.float64]:
+      x = constant_op.constant([0.0, 0.0], dtype=dtype)
+
+      with backprop.GradientTape() as tape:
+        tape.watch(x)
+        y = linalg_ops.norm_v2(x)
+
+      dx = tape.gradient(y, x)
+      self.assertAllClose(dx, [0.0, 0.0])
+
+  def testNonZeroGrad(self):
+    for dtype in [dtypes.float32, dtypes.float64]:
+      x = constant_op.constant([3.0, 4.0], dtype=dtype)
+
+      with backprop.GradientTape() as tape:
+        tape.watch(x)
+        y = linalg_ops.norm_v2(x)
+
+      dx = tape.gradient(y, x)
+      # Expected: x / norm(x) = [3/5, 4/5]
+      self.assertAllClose(dx, [0.6, 0.8])
 
 
 class SegmentMinOrMaxGradientTest(test.TestCase):

--- a/tensorflow/python/ops/math_grad_test.py
+++ b/tensorflow/python/ops/math_grad_test.py
@@ -357,7 +357,9 @@ class EuclideanNormGradientTest(test.TestCase):
 class LinalgNormGradientTest(test.TestCase):
 
   def testZeroGrad(self):
-    for dtype in [dtypes.float32, dtypes.float64]:
+    for dtype in [
+        dtypes.float32, dtypes.float64, dtypes.complex64, dtypes.complex128
+    ]:
       x = constant_op.constant([0.0, 0.0], dtype=dtype)
 
       with backprop.GradientTape() as tape:
@@ -368,7 +370,9 @@ class LinalgNormGradientTest(test.TestCase):
       self.assertAllClose(dx, [0.0, 0.0])
 
   def testNonZeroGrad(self):
-    for dtype in [dtypes.float32, dtypes.float64]:
+    for dtype in [
+        dtypes.float32, dtypes.float64, dtypes.complex64, dtypes.complex128
+    ]:
       x = constant_op.constant([3.0, 4.0], dtype=dtype)
 
       with backprop.GradientTape() as tape:


### PR DESCRIPTION
## Summary

- The gradient of `tf.norm` / `tf.math.reduce_euclidean_norm` produces **NaN** when the input is zero and **inf** for very small values
- The gradient formula `x / norm(x)` is `0/0 = NaN` at zero; the correct subgradient is **0** (matching JAX and PyTorch)
- This has been an open issue for 8+ years

## Changes

Two code paths are fixed:

**1. `_EuclideanNormGrad`** (`math_grad.py`) — used by `tf.math.reduce_euclidean_norm`:
- Replace `truediv(x, output / grad)` with `div_no_nan(x, output) * grad`
- `div_no_nan` returns 0 when the denominator (norm) is 0

**2. `tf.linalg.norm` / `tf.norm`** (`linalg_ops.py`) — uses `sqrt(reduce_sum(x*x))`:
- The `sqrt` gradient `0.5/sqrt(x)` is inf when `x=0`
- Use `maximum(sum_squares, tiny)` to keep the sqrt gradient finite
- `where` mask preserves exact zero forward output
- Only XLA-compatible ops used (no new op types)

**3. Tests** (`math_grad_test.py`):
- Updated `testZeros` to expect gradient of `[0.0, 0.0]` instead of `[NaN, NaN]`
- Added `LinalgNormGradientTest` with zero and non-zero gradient tests

## Reproducer

```python
import tensorflow as tf

# Path A: reduce_euclidean_norm
x = tf.constant([0.0, 0.0])
with tf.GradientTape() as tape:
    tape.watch(x)
    y = tf.math.reduce_euclidean_norm(x)
print(tape.gradient(y, x))  # Was: [nan, nan], Now: [0, 0]

# Path B: tf.norm
with tf.GradientTape() as tape:
    tape.watch(x)
    y = tf.norm(x)
print(tape.gradient(y, x))  # Was: [nan, nan], Now: [0, 0]
```

## Test plan

- [ ] Run `bazel test //tensorflow/python/ops:math_grad_test --test_filter=*EuclideanNorm*`
- [ ] Run `bazel test //tensorflow/python/ops:math_grad_test --test_filter=*LinalgNorm*`
- [ ] Verify non-zero inputs still produce correct gradients (covered by existing tests)

Fixes #12071