### PR TITLE
Fix memory leak in @custom_gradient closures

### DIFF
--- a/tensorflow/python/ops/BUILD
+++ b/tensorflow/python/ops/BUILD
@@ -4335,6 +4335,7 @@ py_strict_library(
         "//tensorflow/python/eager:backprop",
         "//tensorflow/python/eager:context",
         "//tensorflow/python/eager:record",
+        "//tensorflow/python/framework:composite_tensor",
         "//tensorflow/python/framework:composite_tensor_gradient",
         "//tensorflow/python/framework:dtypes",
         "//tensorflow/python/framework:ops",

--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -17,6 +17,7 @@
 from tensorflow.python.eager import backprop
 from tensorflow.python.eager import context
 from tensorflow.python.eager import record
+from tensorflow.python.framework import composite_tensor
 from tensorflow.python.framework import composite_tensor_gradient
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -486,10 +487,27 @@ def _graph_mode_decorator(f, args, kwargs):
 
   all_tensors = flat_result + flat_args + variables
 
+  # Avoid capturing `result` in the gradient closure when it only contains
+  # plain tensors (non-composite). For plain tensors,
+  # replace_flat_tensors_for_gradients simply returns the grads unchanged,
+  # so the capture is unnecessary and prevents garbage collection of forward
+  # pass tensors (see https://github.com/tensorflow/tensorflow/issues/97697).
+  _flat_result_for_grad = nest.flatten(result)
+  _has_composite_result = any(
+      isinstance(x, composite_tensor.CompositeTensor)
+      for x in _flat_result_for_grad)
+  if not _has_composite_result:
+    _flat_result_for_grad = None
+
   def tape_grad_fn(*result_grad_components):
     """Custom grad fn wrapper."""
-    result_grads = composite_tensor_gradient.replace_flat_tensors_for_gradients(
-        nest.flatten(result), result_grad_components[:flat_result_len])
+    if _flat_result_for_grad is not None:
+      result_grads = (
+          composite_tensor_gradient.replace_flat_tensors_for_gradients(
+              _flat_result_for_grad,
+              result_grad_components[:flat_result_len]))
+    else:
+      result_grads = list(result_grad_components[:flat_result_len])
     if not isinstance(result_grads, (list, tuple)):
       result_grads = [result_grads]
 
@@ -567,10 +585,22 @@ def _eager_mode_decorator(f, args, kwargs):
   recorded_inputs = input_tensors
   arg_count = len(flat_args)
 
+  # Avoid capturing `result` in the gradient closure for non-composite tensors.
+  _flat_result_for_grad = nest.flatten(result)
+  _has_composite_result = any(
+      isinstance(x, composite_tensor.CompositeTensor)
+      for x in _flat_result_for_grad)
+  if not _has_composite_result:
+    _flat_result_for_grad = None
+
   def actual_grad_fn(*result_grad_components):
     """Custom grad fn wrapper."""
-    result_grads = composite_tensor_gradient.replace_flat_tensors_for_gradients(
-        nest.flatten(result), result_grad_components)
+    if _flat_result_for_grad is not None:
+      result_grads = (
+          composite_tensor_gradient.replace_flat_tensors_for_gradients(
+              _flat_result_for_grad, result_grad_components))
+    else:
+      result_grads = list(result_grad_components)
     if not isinstance(result_grads, (list, tuple)):
       result_grads = [result_grads]
 


### PR DESCRIPTION
## Summary
- The `tape_grad_fn` closure in `_graph_mode_decorator` and `_eager_mode_decorator` unnecessarily captures the full `result` tensor list, preventing garbage collection of forward-pass tensors
- For the common case (non-composite tensors), `replace_flat_tensors_for_gradients` is a no-op, so capturing `result` is unnecessary
- This change avoids capturing `result` when no composite tensors are present, allowing forward-pass tensors to be GC'd immediately after the forward pass

## Test plan
- [ ] Verify existing `custom_gradient` tests pass
- [ ] Confirm memory usage does not grow when `@custom_gradient` is used repeatedly in `tf.function`

Fixes #97697

## Testing
- PASS: python -m py_compile tensorflow/python/ops/custom_gradient.py
- PASS: git diff --check HEAD^..HEAD
- NOT RUN locally: TensorFlow Bazel targets (Bazel/buildifier are unavailable in this checkout environment).
