### PR TITLE
Add synchronous singularity check in batched GPU linalg.solve

### DIFF
--- a/tensorflow/core/kernels/linalg/matrix_solve_op.cc
+++ b/tensorflow/core/kernels/linalg/matrix_solve_op.cc
@@ -247,6 +247,25 @@ class MatrixSolveOpGpu : public AsyncOpKernel {
           solver->GetrfBatched(n, input_copy_ptrs_base, n, pivots_mat.data(),
                                &dev_info.back(), batch_size),
           done);
+      // Check for singularity before proceeding to the solve step.
+      // GetrfBatched writes per-batch info to device memory; copy it to
+      // host and verify that all info values are <= 0 (info > 0 indicates
+      // a singular matrix).
+      {
+        bool copy_ok = true;
+        auto host_getrf_info = dev_info.back().CopyToHost(&copy_ok);
+        OP_REQUIRES_ASYNC(
+            context, copy_ok,
+            errors::Internal("Failed to copy getrfBatched info to host"),
+            done);
+        auto* stream = context->op_device_context()->stream();
+        OP_REQUIRES_ASYNC(context, stream->BlockHostUntilDone().ok(),
+                          errors::Internal("Failed to sync stream"), done);
+        for (int i = 0; i < batch_size; ++i) {
+          OP_REQUIRES_ASYNC(context, host_getrf_info(i) <= 0,
+                            errors::InvalidArgument(kErrMsg), done);
+        }
+      }
     } else {
       // For small batch sizes or large matrices, we use the non-batched
       // interface from cuSolver, which is much faster for large matrices.

--- a/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
@@ -123,6 +123,18 @@ class MatrixSolveOpTest(test.TestCase):
       self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
 
   @test_util.run_in_graph_and_eager_modes(use_gpu=True)
+  def testNotInvertibleGpu(self):
+    for matrix_values in (
+        [[1., 2.], [2., 4.]],
+        [[1., 0., -1.], [-1., 1., 0.], [0., -1., 1.]],
+        [[[1., 0., -1.], [-1., 1., 0.], [0., -1., 1.]],
+         [[1., 0., -1.], [-1., 1., 0.], [0., -1., 1.]]],
+    ):
+      with self.assertRaisesOpError("Input matrix is not invertible."):
+        matrix = constant_op.constant(matrix_values)
+        self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=True)
   def testConcurrent(self):
     seed = [42, 24]
     matrix_shape = [3, 3]


### PR DESCRIPTION
## Summary
- `tf.linalg.solve` on GPU silently returns wrong results for singular matrices in the batched solver path
- The existing async `CheckLapackInfoAndDeleteSolverAsync` callback may not complete before the output tensor is returned
- This change adds a synchronous host-side check of `GetrfBatched` info values immediately after factorization, raising `InvalidArgument` for singular matrices before proceeding to `GetrsBatched`

## Test plan
- [ ] Verify `testNotInvertible` passes on GPU with singular 3x3 matrices
- [ ] Existing `linalg.solve` tests continue to pass for invertible matrices

Fixes #94657