### PR TITLE
Document gradient tie-breaking for reduce_min and reduce_max

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -2966,6 +2966,10 @@ def reduce_min(input_tensor, axis=None, keepdims=False, name=None):
   Returns:
     The reduced tensor.
 
+  Note: When computing gradients, if multiple elements are equal to the
+    minimum value along the reduced axes, the gradient is distributed equally
+    among all such elements.
+
   @compatibility(numpy)
   Equivalent to np.min
   @end_compatibility
@@ -3087,6 +3091,10 @@ def reduce_max(input_tensor, axis=None, keepdims=False, name=None):
 
   Returns:
     The reduced tensor.
+
+  Note: When computing gradients, if multiple elements are equal to the
+    maximum value along the reduced axes, the gradient is distributed equally
+    among all such elements.
   """
   return reduce_max_with_dims(input_tensor, axis, keepdims, name,
                               _ReductionDims(input_tensor, axis))


### PR DESCRIPTION
## Summary
- When multiple elements tie for the min/max value, the gradient is distributed equally among all tied elements
- This deterministic behavior was undocumented, potentially surprising users who expected the gradient to go to only one element
- Added a note to both `reduce_min` and `reduce_max` docstrings documenting this behavior

## Test plan
- [ ] Visual inspection of rendered docstrings

Fixes #97688