### PR TITLE
Fix tf.dynamic_stitch gradient for duplicate indices

### DIFF
--- a/tensorflow/python/kernel_tests/data_structures/dynamic_stitch_op_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/dynamic_stitch_op_test.py
@@ -175,6 +175,53 @@ class DynamicStitchTestBase(object):
       self.assertAllEqual(7. * self.evaluate(datum), grad)
 
   @test_util.run_deprecated_v1
+  def testGradientWithDuplicateIndicesSingleGroup(self):
+    # When duplicate indices exist, only the last writer should get gradient.
+    with test_util.use_gpu():
+      indices = [constant_op.constant([0, 0, 2])]
+      data = [constant_op.constant([1.0, 2.0, 3.0])]
+      stitched = self.stitch_op(indices, data)
+      # Forward: output[0] = 2.0 (last write wins), output[2] = 3.0
+      grads = gradients_impl.gradients(stitched, data)
+      grad_val = self.evaluate(grads[0])
+      # data[0] wrote to index 0 but was overwritten => gradient 0
+      # data[1] wrote to index 0, last writer => gets gradient
+      # data[2] wrote to index 2, sole writer => gets gradient
+      self.assertAllEqual([0.0, 1.0, 1.0], grad_val)
+
+  @test_util.run_deprecated_v1
+  def testGradientWithDuplicateIndicesMultiGroup(self):
+    # Second group overwrites first group's entry at index 0.
+    with test_util.use_gpu():
+      indices = [constant_op.constant([0, 1]), constant_op.constant([0])]
+      data = [
+          constant_op.constant([10.0, 20.0]),
+          constant_op.constant([30.0]),
+      ]
+      stitched = self.stitch_op(indices, data)
+      # Forward: output[0] = 30.0 (group 2 overwrites), output[1] = 20.0
+      grads = gradients_impl.gradients(stitched, data)
+      grad_vals = self.evaluate(grads)
+      # First group: index 0 overwritten -> grad 0; index 1 sole writer -> grad 1
+      self.assertAllEqual([0.0, 1.0], grad_vals[0])
+      # Second group: index 0 is last writer -> grad 1
+      self.assertAllEqual([1.0], grad_vals[1])
+
+  @test_util.run_deprecated_v1
+  def testGradientWithDuplicateIndicesHigherRank(self):
+    # Test duplicate indices with higher-rank (2D) data values.
+    with test_util.use_gpu():
+      indices = [constant_op.constant([0, 0])]
+      data = [constant_op.constant([[1.0, 2.0], [3.0, 4.0]])]
+      stitched = self.stitch_op(indices, data)
+      # Forward: output[0] = [3.0, 4.0] (last write wins)
+      grads = gradients_impl.gradients(stitched, data)
+      grad_val = self.evaluate(grads[0])
+      # First element overwritten => zero gradient row
+      # Second element is last writer => gets gradient
+      self.assertAllEqual([[0.0, 0.0], [1.0, 1.0]], grad_val)
+
+  @test_util.run_deprecated_v1
   def testErrorIndicesMultiDimensional(self):
     indices = [
         constant_op.constant([0, 4, 7]),

--- a/tensorflow/python/ops/data_flow_grad.py
+++ b/tensorflow/python/ops/data_flow_grad.py
@@ -58,7 +58,47 @@ def _DynamicStitchGrads(op, grad):
     output_shape = array_ops.shape(op.outputs[0])
     output_rows = output_shape[0]
     grad = math_ops.unsorted_segment_sum(grad.values, grad.indices, output_rows)
-  values_grad = [array_ops.gather(grad, inp) for inp in inputs]
+
+  # When duplicate indices exist, dynamic_stitch uses last-write-wins
+  # semantics: only the last value written to an output position contributes
+  # to the result. The gradient must therefore only flow to the last writer;
+  # overwritten entries should receive zero gradient.
+  #
+  # Strategy: assign each element a unique sequential flat ID, stitch those
+  # IDs with the same indices to find which ID "won" at each output position,
+  # then mask out non-winners.
+  flat_ids = []
+  offset = 0
+  for inp in inputs:
+    num_elems = array_ops.size(inp)
+    ids = array_ops.reshape(
+        math_ops.range(offset, offset + num_elems), array_ops.shape(inp))
+    flat_ids.append(ids)
+    offset = offset + num_elems
+
+  winner_ids = data_flow_ops.dynamic_stitch(inputs, flat_ids)
+
+  values_grad = []
+  offset = 0
+  for inp in inputs:
+    num_elems = array_ops.size(inp)
+    my_ids = array_ops.reshape(
+        math_ops.range(offset, offset + num_elems), array_ops.shape(inp))
+    winners_for_my_indices = array_ops.gather(winner_ids, inp)
+    mask = math_ops.cast(
+        math_ops.equal(my_ids, winners_for_my_indices), grad.dtype)
+    gathered = array_ops.gather(grad, inp)
+    # Broadcast mask for higher-rank values (e.g. 2D data tensors).
+    mask_shape = array_ops.concat(
+        [array_ops.shape(mask),
+         array_ops.ones(
+             [array_ops.rank(gathered) - array_ops.rank(mask)],
+             dtype=dtypes.int32)],
+        axis=0)
+    mask = array_ops.reshape(mask, mask_shape)
+    values_grad.append(gathered * mask)
+    offset = offset + num_elems
+
   return indices_grad + values_grad
 
 


### PR DESCRIPTION
## Summary
- `tf.dynamic_stitch` uses last-write-wins semantics for duplicate indices, but the gradient incorrectly sent output gradients to **all** writers instead of only the last one
- The fix assigns each input element a unique flat ID, uses `dynamic_stitch` itself to determine which ID "won" at each output position, then masks out gradients for overwritten entries
- This is a 10-year-old correctness bug affecting anyone using `dynamic_stitch` with overlapping indices in differentiable programs

## Test plan
- [ ] Added `testGradientWithDuplicateIndicesSingleGroup` — verifies overwritten entry gets zero gradient
- [ ] Added `testGradientWithDuplicateIndicesMultiGroup` — verifies cross-group overwrite behavior
- [ ] Added `testGradientWithDuplicateIndicesHigherRank` — verifies correct mask broadcasting for 2D values
- [ ] Existing gradient tests with unique indices continue to pass

Fixes #7397