### PR TITLE
Validate scalar shape for input_min/max in QuantizeAndDequantizeV3

### DIFF
--- a/tensorflow/core/kernels/quantize_and_dequantize_op.cc
+++ b/tensorflow/core/kernels/quantize_and_dequantize_op.cc
@@ -296,6 +296,16 @@ class QuantizeAndDequantizeV3Op : public OpKernel {
       input_min_tensor = ctx->input(1);
       input_max_tensor = ctx->input(2);
       if (axis_ == -1) {
+        OP_REQUIRES(
+            ctx, TensorShapeUtils::IsScalar(input_min_tensor.shape()),
+            InvalidArgument("input_min must be a scalar when axis is not "
+                            "specified. Got shape: ",
+                            input_min_tensor.shape().DebugString()));
+        OP_REQUIRES(
+            ctx, TensorShapeUtils::IsScalar(input_max_tensor.shape()),
+            InvalidArgument("input_max must be a scalar when axis is not "
+                            "specified. Got shape: ",
+                            input_max_tensor.shape().DebugString()));
         const auto min_val = input_min_tensor.scalar<T>()();
         const auto max_val = input_max_tensor.scalar<T>()();
         OP_REQUIRES(ctx, min_val <= max_val,

--- a/tensorflow/python/kernel_tests/quantization_ops/quantization_ops_test.py
+++ b/tensorflow/python/kernel_tests/quantization_ops/quantization_ops_test.py
@@ -487,6 +487,29 @@ class QuantizeAndDequantizeV3OpTest(test_util.TensorFlowTestCase):
           range_given=True,
       )
 
+  @test_util.run_in_graph_and_eager_modes
+  def test_invalid_non_scalar_min_max_with_default_axis(self):
+    input_value = constant_op.constant(
+        [-0.8, -0.5, 0, 0.3, 0.8, -2.0], shape=(6,), dtype=dtypes.float32)
+    input_min = constant_op.constant(
+        [-127, -127], shape=(2,), dtype=dtypes.float32)
+    input_max = constant_op.constant(
+        [127, 127], shape=(2,), dtype=dtypes.float32)
+    num_bits = 8
+
+    with self.assertRaisesRegex(
+        (errors.InvalidArgumentError, ValueError),
+        "input_min must be a scalar"):
+      self.evaluate(
+          array_ops.quantize_and_dequantize_v3(
+              input_value,
+              input_min,
+              input_max,
+              num_bits=num_bits,
+              signed_input=True,
+              range_given=True,
+          ))
+
 
 if __name__ == "__main__":
   googletest.main()

--- a/tensorflow/python/kernel_tests/quantization_ops/quantization_ops_test.py
+++ b/tensorflow/python/kernel_tests/quantization_ops/quantization_ops_test.py
@@ -499,7 +499,7 @@ class QuantizeAndDequantizeV3OpTest(test_util.TensorFlowTestCase):
 
     with self.assertRaisesRegex(
         (errors.InvalidArgumentError, ValueError),
-        "input_min must be a scalar"):
+        "(input_min must be a scalar|Shape must be rank 0)"):
       self.evaluate(
           array_ops.quantize_and_dequantize_v3(
               input_value,


### PR DESCRIPTION
## Summary
- `QuantizeAndDequantizeV3Op` crashed with a CHECK failure when non-scalar `input_min`/`input_max` tensors were passed with `axis=-1`
- The V2 op already had proper `OP_REQUIRES` validation; V3 was missing it
- Added `OP_REQUIRES` checks matching the V2 pattern to raise `InvalidArgumentError` instead of crashing

## Test plan
- [ ] Added `test_invalid_non_scalar_min_max_with_default_axis` — verifies `InvalidArgumentError` is raised
- [ ] Existing V3 tests continue to pass

Fixes #99458