### PR TITLE
Reject rank-0 shape tensors in tf.reshape for consistency

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/BUILD
+++ b/tensorflow/python/kernel_tests/array_ops/BUILD
@@ -560,6 +560,7 @@ cuda_py_strict_test(
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/ops:array_ops",
         "//tensorflow/python/ops:gradient_checker_v2",
+        "//tensorflow/python/ops:variables",
         "//tensorflow/python/platform:client_testlib",
         "//third_party/py/numpy",
     ],

--- a/tensorflow/python/kernel_tests/array_ops/reshape_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/reshape_op_test.py
@@ -163,6 +163,12 @@ class ReshapeTest(test.TestCase):
                                 "Cannot reshape a tensor with 4096 elements"):
       array_ops.reshape(z, [4095])
 
+  def testRejectsScalarShape(self):
+    t = constant_op.constant([1, 2, 3, 4, 5, 6])
+    scalar_shape = constant_op.constant(6)  # rank-0 tensor
+    with self.assertRaisesRegex(ValueError, "scalar.*rank-0"):
+      array_ops.reshape(t, scalar_shape)
+
   def testPartialShapes(self):
 
     # Testing unknown shapes in graph building.

--- a/tensorflow/python/kernel_tests/array_ops/reshape_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/reshape_op_test.py
@@ -169,6 +169,8 @@ class ReshapeTest(test.TestCase):
     scalar_shapes = (
         constant_op.constant(6),
         variables.Variable(6),
+        6,
+        np.int32(6),
         np.array(6),
     )
     for scalar_shape in scalar_shapes:

--- a/tensorflow/python/kernel_tests/array_ops/reshape_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/reshape_op_test.py
@@ -24,6 +24,7 @@ from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import gradient_checker_v2
+from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 
 
@@ -165,9 +166,15 @@ class ReshapeTest(test.TestCase):
 
   def testRejectsScalarShape(self):
     t = constant_op.constant([1, 2, 3, 4, 5, 6])
-    scalar_shape = constant_op.constant(6)  # rank-0 tensor
-    with self.assertRaisesRegex(ValueError, "scalar.*rank-0"):
-      array_ops.reshape(t, scalar_shape)
+    scalar_shapes = (
+        constant_op.constant(6),
+        variables.Variable(6),
+        np.array(6),
+    )
+    for scalar_shape in scalar_shapes:
+      with self.subTest(scalar_shape=scalar_shape):
+        with self.assertRaisesRegex(ValueError, "scalar.*rank-0"):
+          array_ops.reshape(t, scalar_shape)
 
   def testPartialShapes(self):
 

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -196,6 +196,14 @@ def reshape(tensor, shape, name=None):  # pylint: disable=redefined-outer-name
   Returns:
     A `Tensor`. Has the same type as `tensor`.
   """
+  # Reject scalar (rank-0) shape tensors for consistency between eager and
+  # tf.function modes. Use shape=[value] instead.
+  if isinstance(shape, ops.Tensor) and shape.shape.ndims == 0:
+    raise ValueError(
+        "tf.reshape `shape` argument must be a 1-D tensor or a Python "
+        "list/tuple, but got a scalar (rank-0) tensor. If you intended to "
+        "reshape to a 1-D tensor with a single dimension, use "
+        "`shape=[value]` instead.")
   result = gen_array_ops.reshape(tensor, shape, name)
   shape_util.maybe_set_static_shape(result, shape)
   return result

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -198,7 +198,8 @@ def reshape(tensor, shape, name=None):  # pylint: disable=redefined-outer-name
   """
   # Reject scalar (rank-0) shape tensors for consistency between eager and
   # tf.function modes. Use shape=[value] instead.
-  if isinstance(shape, ops.Tensor) and shape.shape.ndims == 0:
+  if ((tensor_util.is_tf_type(shape) and shape.shape.ndims == 0) or
+      (isinstance(shape, np.ndarray) and shape.ndim == 0)):
     raise ValueError(
         "tf.reshape `shape` argument must be a 1-D tensor or a Python "
         "list/tuple, but got a scalar (rank-0) tensor. If you intended to "

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -199,6 +199,7 @@ def reshape(tensor, shape, name=None):  # pylint: disable=redefined-outer-name
   # Reject scalar (rank-0) shape tensors for consistency between eager and
   # tf.function modes. Use shape=[value] instead.
   if ((tensor_util.is_tf_type(shape) and shape.shape.ndims == 0) or
+      isinstance(shape, (int, np.integer)) or
       (isinstance(shape, np.ndarray) and shape.ndim == 0)):
     raise ValueError(
         "tf.reshape `shape` argument must be a 1-D tensor or a Python "


### PR DESCRIPTION
## Summary
- `tf.reshape(tensor, scalar_tensor)` worked in eager mode but raised an error inside `tf.function`, creating an inconsistency between execution modes
- Added Python-level validation to reject scalar (rank-0) shape tensors in all modes with a clear error message suggesting `shape=[value]` instead
- This makes behavior consistent, matching the `tf.function` behavior as the correct one

## Test plan
- [ ] Added `testRejectsScalarShape` — verifies `ValueError` is raised for rank-0 shape tensors
- [ ] Existing reshape tests continue to pass

Fixes #51241

## Testing
- PASS: git diff --check HEAD^..HEAD
- PASS: python -m py_compile on the changed Python files
- NOT RUN locally: TensorFlow Bazel unit/build targets (Bazel/buildifier and a built TensorFlow runtime are unavailable in this checkout environment).
