### PR TITLE
feat(tflite): Add dynamic OpenCL library loading support

### DIFF
--- a/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.cc
+++ b/tensorflow/lite/delegates/gpu/cl/opencl_wrapper.cc
@@ -118,8 +118,12 @@ absl::Status LoadOpenCLOnce() {
 #ifdef __APPLE__
   static const char* kClLibName =
       "/System/Library/Frameworks/OpenCL.framework/OpenCL";
-#else
+#elif defined(TFLITE_OPENCL_LIBRARY_NAME)
+  static const char* kClLibName = TFLITE_OPENCL_LIBRARY_NAME;
+#elif defined(__ANDROID__)
   static const char* kClLibName = "libOpenCL.so";
+#else
+  static const char* kClLibName = "libOpenCL.so.1";
 #endif
 #ifdef __ANDROID__
   libopencl = AndroidDlopenSphalLibrary(kClLibName, RTLD_NOW | RTLD_LOCAL);


### PR DESCRIPTION
Use pkg-config to detect OpenCL installation and set library name based on OpenCL version. Pass library name as compile-time definition to OpenCL wrapper and modify wrapper to use configured name instead of hardcoded defaults. This fixes OpenCL library loading issues on systems with non-standard installations and various Linux distributions.
