### PR TITLE
cmake: Fix label image dependencies

### DIFF
--- a/tensorflow/lite/examples/label_image/CMakeLists.txt
+++ b/tensorflow/lite/examples/label_image/CMakeLists.txt
@@ -16,6 +16,8 @@
 
 # The label_image example for Tensorflow Lite.
 
+find_package(Protobuf REQUIRED)
+
 populate_source_vars("${TFLITE_SOURCE_DIR}/examples/label_image"
   TFLITE_LABEL_IMAGE_SRCS
   FILTER "_test\\.cc$"
@@ -84,5 +86,6 @@ target_compile_options(label_image
 target_link_libraries(label_image
   tensorflow-lite
   profiling_info_proto
-  libprotobuf
+  protobuf::libprotobuf
+  absl::log
 )


### PR DESCRIPTION
- Properly find Protobuf package
- Link with protobuf library from protobuf package
- Link with abseil dependency of protobuf
