### PR TITLE
Fix tf.cond to validate both branches in eager mode

### DIFF
--- a/tensorflow/python/ops/cond.py
+++ b/tensorflow/python/ops/cond.py
@@ -378,16 +378,26 @@ def _eager_cond_implementation(pred, true_fn, false_fn, strict, name):
       if functions_run_eagerly is not None:
         eager_function_run.run_functions_eagerly(functions_run_eagerly)
   else:
-    # For conditions which are eager tensors with a constant value (most of
-    # them), we only call the relevant branch function and execute it eagerly.
-    with ops.name_scope(name, "cond", [pred]):
-      if pred_constant_value:
-        result = true_fn()
-      else:
-        result = false_fn()
+    # For conditions which are eager tensors with a constant value,
+    # we still need to trace both branches for error detection to ensure
+    # consistency with XLA compilation mode.
+    from tensorflow.python.eager.polymorphic_function import polymorphic_function
+
+    if not isinstance(true_fn, core.PolymorphicFunction):
+      true_fn = polymorphic_function.function(true_fn)
+    if not isinstance(false_fn, core.PolymorphicFunction):
+      false_fn = polymorphic_function.function(false_fn)
+
+    functions_run_eagerly = eager_function_run.functions_run_eagerly()
+    eager_function_run.run_functions_eagerly(False)
+    try:
+      result = cond_v2.cond_v2(pred, true_fn, false_fn, name)
       if not strict:
         result = _UnpackIfSingleton(result)
       return result
+    finally:
+      if functions_run_eagerly is not None:
+        eager_function_run.run_functions_eagerly(functions_run_eagerly)
 
 
 def _cast_indexed_slice_indices(a, b):

--- a/tensorflow/python/ops/cond.py
+++ b/tensorflow/python/ops/cond.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 """Cond function for Control Flow Operations."""
 
+import os
+
 from tensorflow.python.eager import context
 from tensorflow.python.eager.polymorphic_function import eager_function_run
 from tensorflow.python.framework import dtypes
@@ -32,6 +34,16 @@ from tensorflow.python.util import deprecation
 from tensorflow.python.util import dispatch
 from tensorflow.python.util import nest
 from tensorflow.python.util.tf_export import tf_export
+
+
+# When True, eager tf.cond with a constant predicate also traces the inactive
+# branch so that errors in it are surfaced early, consistent with graph/XLA
+# compilation. Off by default: tracing the inactive branch runs its Python side
+# effects and is incompatible with some constructs (e.g. captured TensorArrays,
+# certain AutoGraph-generated closures), so it is opt-in via the
+# TF_COND_VALIDATE_INACTIVE_BRANCH=1 environment variable.
+_VALIDATE_INACTIVE_BRANCH = (
+    os.environ.get("TF_COND_VALIDATE_INACTIVE_BRANCH", "0") == "1")
 
 
 # pylint: disable=redefined-outer-name
@@ -378,30 +390,36 @@ def _eager_cond_implementation(pred, true_fn, false_fn, strict, name):
       if functions_run_eagerly is not None:
         eager_function_run.run_functions_eagerly(functions_run_eagerly)
   else:
-    # For conditions which are eager tensors with a constant value, we still
-    # trace both branches so that errors in the inactive branch are surfaced
-    # early, consistent with graph/XLA compilation mode. The selected branch is
-    # then executed eagerly using the original callable, which keeps standard
-    # eager execution and gradient-tape semantics intact (only the active
-    # branch's ops are recorded on the tape).
-    from tensorflow.python.eager.polymorphic_function import polymorphic_function  # pylint: disable=g-import-not-at-top
-
-    original_true_fn = true_fn
-    original_false_fn = false_fn
-
-    if not isinstance(true_fn, core.PolymorphicFunction):
-      true_fn = polymorphic_function.function(true_fn)
-    if not isinstance(false_fn, core.PolymorphicFunction):
-      false_fn = polymorphic_function.function(false_fn)
-
-    true_fn.get_concrete_function()
-    false_fn.get_concrete_function()
+    # For conditions which are eager tensors with a constant value (most of
+    # them), we only call the relevant branch function and execute it eagerly.
+    #
+    # When _VALIDATE_INACTIVE_BRANCH is enabled, both branches are additionally
+    # traced up front so that errors in the inactive branch are surfaced early,
+    # consistent with graph/XLA compilation. This is off by default because
+    # tracing the inactive branch runs its Python side effects and is
+    # incompatible with some constructs (e.g. captured TensorArrays, certain
+    # AutoGraph-generated closures). The selected branch is always executed
+    # eagerly using the original callable, so standard eager execution and
+    # gradient-tape semantics are unchanged (only the active branch's ops are
+    # recorded on the tape).
+    if _VALIDATE_INACTIVE_BRANCH:
+      # pylint: disable=g-import-not-at-top
+      from tensorflow.python.eager.polymorphic_function import polymorphic_function
+      # pylint: enable=g-import-not-at-top
+      validation_true_fn = (
+          true_fn if isinstance(true_fn, core.PolymorphicFunction)
+          else polymorphic_function.function(true_fn))
+      validation_false_fn = (
+          false_fn if isinstance(false_fn, core.PolymorphicFunction)
+          else polymorphic_function.function(false_fn))
+      validation_true_fn.get_concrete_function()
+      validation_false_fn.get_concrete_function()
 
     with ops.name_scope(name, "cond", [pred]):
       if pred_constant_value:
-        result = original_true_fn()
+        result = true_fn()
       else:
-        result = original_false_fn()
+        result = false_fn()
       if not strict:
         result = _UnpackIfSingleton(result)
       return result

--- a/tensorflow/python/ops/cond.py
+++ b/tensorflow/python/ops/cond.py
@@ -378,26 +378,33 @@ def _eager_cond_implementation(pred, true_fn, false_fn, strict, name):
       if functions_run_eagerly is not None:
         eager_function_run.run_functions_eagerly(functions_run_eagerly)
   else:
-    # For conditions which are eager tensors with a constant value,
-    # we still need to trace both branches for error detection to ensure
-    # consistency with XLA compilation mode.
-    from tensorflow.python.eager.polymorphic_function import polymorphic_function
+    # For conditions which are eager tensors with a constant value, we still
+    # trace both branches so that errors in the inactive branch are surfaced
+    # early, consistent with graph/XLA compilation mode. The selected branch is
+    # then executed eagerly using the original callable, which keeps standard
+    # eager execution and gradient-tape semantics intact (only the active
+    # branch's ops are recorded on the tape).
+    from tensorflow.python.eager.polymorphic_function import polymorphic_function  # pylint: disable=g-import-not-at-top
+
+    original_true_fn = true_fn
+    original_false_fn = false_fn
 
     if not isinstance(true_fn, core.PolymorphicFunction):
       true_fn = polymorphic_function.function(true_fn)
     if not isinstance(false_fn, core.PolymorphicFunction):
       false_fn = polymorphic_function.function(false_fn)
 
-    functions_run_eagerly = eager_function_run.functions_run_eagerly()
-    eager_function_run.run_functions_eagerly(False)
-    try:
-      result = cond_v2.cond_v2(pred, true_fn, false_fn, name)
+    true_fn.get_concrete_function()
+    false_fn.get_concrete_function()
+
+    with ops.name_scope(name, "cond", [pred]):
+      if pred_constant_value:
+        result = original_true_fn()
+      else:
+        result = original_false_fn()
       if not strict:
         result = _UnpackIfSingleton(result)
       return result
-    finally:
-      if functions_run_eagerly is not None:
-        eager_function_run.run_functions_eagerly(functions_run_eagerly)
 
 
 def _cast_indexed_slice_indices(a, b):

--- a/tensorflow/python/ops/control_flow_ops_test.py
+++ b/tensorflow/python/ops/control_flow_ops_test.py
@@ -460,6 +460,22 @@ class CondTest(test_util.TensorFlowTestCase):
     self.assertEqual(None if context.executing_eagerly() else 0.,
                      self.evaluate(grads_false[0]))
 
+  @test_util.run_in_graph_and_eager_modes
+  def testCondEagerConstantValidation(self):
+    if not context.executing_eagerly():
+      return
+
+    x = constant_op.constant(1.0, dtype=dtypes.float32)
+
+    def true_fn():
+      return constant_op.constant(5.0)
+
+    def false_fn():
+      return math_ops.add(x, constant_op.constant(1, dtype=dtypes.int32))
+
+    with self.assertRaises((TypeError, ValueError)):
+      tf_cond.cond(constant_op.constant(True), true_fn, false_fn)
+
   def testCondWithGroupAndSummaries(self):
     with ops.Graph().as_default():
       writer = summary_ops_v2.create_file_writer(self.get_temp_dir())

--- a/tensorflow/python/ops/control_flow_ops_test.py
+++ b/tensorflow/python/ops/control_flow_ops_test.py
@@ -471,10 +471,24 @@ class CondTest(test_util.TensorFlowTestCase):
       return constant_op.constant(5.0)
 
     def false_fn():
+      # Type mismatch: adding a float32 tensor and an int32 tensor. Only fails
+      # when false_fn is actually traced/executed.
       return math_ops.add(x, constant_op.constant(1, dtype=dtypes.int32))
 
-    with self.assertRaises((TypeError, ValueError)):
-      tf_cond.cond(constant_op.constant(True), true_fn, false_fn)
+    # By default the inactive branch is not validated, so the bug in false_fn is
+    # not surfaced when the constant predicate selects true_fn.
+    self.assertEqual(5.0, self.evaluate(
+        tf_cond.cond(constant_op.constant(True), true_fn, false_fn)))
+
+    # With validation opted in, both branches are traced up front, so the error
+    # in the inactive branch is raised even though true_fn is selected.
+    validation_was_enabled = tf_cond._VALIDATE_INACTIVE_BRANCH
+    tf_cond._VALIDATE_INACTIVE_BRANCH = True
+    try:
+      with self.assertRaises((TypeError, ValueError)):
+        tf_cond.cond(constant_op.constant(True), true_fn, false_fn)
+    finally:
+      tf_cond._VALIDATE_INACTIVE_BRANCH = validation_was_enabled
 
   def testCondWithGroupAndSummaries(self):
     with ops.Graph().as_default():


### PR DESCRIPTION
When using tf.cond with a constant condition, eager mode was only checking the branch that actually runs. This meant bugs in the other branch went unnoticed until XLA compilation found them, which was confusing.

Now both branches get validated regardless of which one executes, so you'll catch errors early no matter how your code runs.