### PR TITLE
Fix MatrixSolve GPU handling for singular matrices

### DIFF
--- a/tensorflow/core/kernels/linalg/matrix_solve_op.cc
+++ b/tensorflow/core/kernels/linalg/matrix_solve_op.cc
@@ -369,15 +369,14 @@ class MatrixSolveOpGpu : public AsyncOpKernel {
     auto info_checker = [context, done, dev_info](
                             const absl::Status& status,
                             const std::vector<HostLapackInfo>& host_infos) {
-      if (!status.ok() && absl::IsInvalidArgument(status) &&
-          !host_infos.empty()) {
+      if (!host_infos.empty()) {
         for (int i = 0; i < host_infos[0].size(); ++i) {
-          // Match the CPU error message for singular matrices. Otherwise
-          // just print the original error message from the status below.
+          // Match the CPU error message for singular matrices.
           OP_REQUIRES_ASYNC(context, host_infos[0].data()[i] <= 0,
                             absl::InvalidArgumentError(kErrMsg), done);
         }
       }
+
       OP_REQUIRES_OK_ASYNC(context, status, done);
       done();
     };

--- a/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
@@ -116,7 +116,14 @@ class MatrixSolveOpTest(test.TestCase):
 
   def testNotInvertible(self):
     # The input should be invertible.
+    matrix = np.array([[1., 2., 3.],
+                       [2., 4., 6.],
+                       [1., 2., 3.]], dtype=np.float32)
+    rhs = np.array([[1.],
+                    [2.],
+                    [1.]], dtype=np.float32)
     with self.assertRaisesOpError("Input matrix is not invertible."):
+      self.evaluate(linalg_ops.matrix_solve(matrix, rhs))
 
   def testSingularMatrixRaisesOnGpu(self):
     if not test_util.is_gpu_available(cuda_only=True):
@@ -134,8 +141,8 @@ class MatrixSolveOpTest(test.TestCase):
         self.evaluate(linalg_ops.matrix_solve(matrix, rhs))
       # All rows of the matrix below add to zero
       matrix = constant_op.constant([[1., 0., -1.], [-1., 1., 0.],
-                                     [0., -1., 1.]      self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
-
+                                     [0., -1., 1.]])
+      self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
 
   @test_util.run_in_graph_and_eager_modes(use_gpu=True)
   def testConcurrent(self):

--- a/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
@@ -117,10 +117,25 @@ class MatrixSolveOpTest(test.TestCase):
   def testNotInvertible(self):
     # The input should be invertible.
     with self.assertRaisesOpError("Input matrix is not invertible."):
+
+  def testSingularMatrixRaisesOnGpu(self):
+    if not test_util.is_gpu_available(cuda_only=True):
+      self.skipTest("CUDA GPU required")
+
+    matrix = np.array([[1., 2., 3.],
+                       [2., 4., 6.],
+                       [1., 2., 3.]], dtype=np.float32)
+    rhs = np.array([[1.],
+                    [2.],
+                    [1.]], dtype=np.float32)
+
+    with test_util.force_gpu():
+      with self.assertRaisesOpError("Input matrix is not invertible."):
+        self.evaluate(linalg_ops.matrix_solve(matrix, rhs))
       # All rows of the matrix below add to zero
       matrix = constant_op.constant([[1., 0., -1.], [-1., 1., 0.],
-                                     [0., -1., 1.]])
-      self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
+                                     [0., -1., 1.]      self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
+
 
   @test_util.run_in_graph_and_eager_modes(use_gpu=True)
   def testConcurrent(self):

--- a/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
@@ -142,7 +142,8 @@ class MatrixSolveOpTest(test.TestCase):
       # All rows of the matrix below add to zero
       matrix = constant_op.constant([[1., 0., -1.], [-1., 1., 0.],
                                      [0., -1., 1.]])
-      self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
+      with self.assertRaisesOpError("Input matrix is not invertible."):
+        self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
 
   @test_util.run_in_graph_and_eager_modes(use_gpu=True)
   def testConcurrent(self):

--- a/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
@@ -125,6 +125,12 @@ class MatrixSolveOpTest(test.TestCase):
     with self.assertRaisesOpError("Input matrix is not invertible."):
       self.evaluate(linalg_ops.matrix_solve(matrix, rhs))
 
+    # All rows of the matrix below add to zero
+    matrix = constant_op.constant([[1., 0., -1.], [-1., 1., 0.],
+                                   [0., -1., 1.]])
+    with self.assertRaisesOpError("Input matrix is not invertible."):
+      self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
+
   def testSingularMatrixRaisesOnGpu(self):
     if not test_util.is_gpu_available(cuda_only=True):
       self.skipTest("CUDA GPU required")
@@ -139,11 +145,6 @@ class MatrixSolveOpTest(test.TestCase):
     with test_util.force_gpu():
       with self.assertRaisesOpError("Input matrix is not invertible."):
         self.evaluate(linalg_ops.matrix_solve(matrix, rhs))
-      # All rows of the matrix below add to zero
-      matrix = constant_op.constant([[1., 0., -1.], [-1., 1., 0.],
-                                     [0., -1., 1.]])
-      with self.assertRaisesOpError("Input matrix is not invertible."):
-        self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
 
   @test_util.run_in_graph_and_eager_modes(use_gpu=True)
   def testConcurrent(self):


### PR DESCRIPTION
Fixes #94657

This change ensures that MatrixSolve on GPU consistently raises an error
for singular matrices, matching CPU behavior.

The LAPACK info is now checked regardless of the returned status, and
singular matrices raise the standard
"Input matrix is not invertible." error.

Tests:
- Added GPU regression coverage via existing MatrixSolve error checks.
