### PR TITLE
docs: improve docstrings with runnable examples and fix TFLite docs

### DIFF
--- a/tensorflow/lite/g3doc/guide/index.md
+++ b/tensorflow/lite/g3doc/guide/index.md
@@ -120,4 +120,6 @@ You can refer to the following guides based on your target device:
 *   *All TensorFlow models* ***cannot*** *be converted into TensorFlow Lite
     models*, refer to [Operator compatibility](ops_compatibility).
 
-*   *Unsupported on-device training*, however it is on our [Roadmap](roadmap).
+*   *On-device training is supported with limitations*, refer to
+    [on-device training example](../examples/on_device_training) and
+    [Roadmap](roadmap) for latest updates.

--- a/tensorflow/lite/g3doc/guide/python.md
+++ b/tensorflow/lite/g3doc/guide/python.md
@@ -26,10 +26,10 @@ Python class. This small package is ideal when all you want to do is execute
 Note: If you need access to other Python APIs, such as the
 [TensorFlow Lite Converter](../models/convert/), you must install the
 [full TensorFlow package](https://www.tensorflow.org/install/).
-For example, the [Select TF ops]
-(https://www.tensorflow.org/lite/guide/ops_select) are not included in the
-`tflite_runtime` package. If your models have any dependencies to the Select TF
-ops, you need to use the full TensorFlow package instead.
+For example, the [Select TF ops](https://www.tensorflow.org/lite/guide/ops_select)
+are not included in the `tflite_runtime` package. If your models have any
+dependencies to the Select TF ops, you need to use the full TensorFlow package
+instead.
 
 ## Install TensorFlow Lite for Python
 

--- a/tensorflow/lite/g3doc/guide/roadmap.md
+++ b/tensorflow/lite/g3doc/guide/roadmap.md
@@ -93,7 +93,7 @@ roadmap and provide us feedback in the
 
     *   Combine configurable training-time (pruning + quantization-aware
         training) APIs.
-    *   Increase sparity application on TF Model Garden models.
+    *   Increase sparsity application on TF Model Garden models.
     *   Sparse model execution support in TensorFlow Lite.
 
 ## Portability

--- a/tensorflow/python/ops/clip_ops.py
+++ b/tensorflow/python/ops/clip_ops.py
@@ -256,6 +256,18 @@ def global_norm(t_list, name=None):
 
   Any entries in `t_list` that are of type None are ignored.
 
+  For example:
+
+  >>> t1 = tf.constant([1.0, 2.0, 3.0])
+  >>> t2 = tf.constant([4.0, 5.0])
+  >>> tf.linalg.global_norm([t1, t2]).numpy()
+  7.4161983
+
+  `None` entries are silently ignored:
+
+  >>> tf.linalg.global_norm([t1, None, t2]).numpy()
+  7.4161983
+
   Args:
     t_list: A tuple or list of mixed `Tensors`, `IndexedSlices`, or None.
     name: A name for the operation (optional).
@@ -326,6 +338,25 @@ def clip_by_global_norm(t_list, clip_norm, use_norm=None, name=None):
 
   However, it is slower than `clip_by_norm()` because all the parameters must be
   ready before the clipping operation can be performed.
+
+  For example:
+
+  >>> t1 = tf.constant([1.0, 2.0, 3.0])
+  >>> t2 = tf.constant([4.0, 5.0, 6.0])
+  >>> clipped, gnorm = tf.clip_by_global_norm([t1, t2], clip_norm=5.0)
+  >>> gnorm.numpy()
+  9.539392
+  >>> clipped[0].numpy()
+  array([0.5241424, 1.0482848, 1.5724272], dtype=float32)
+  >>> clipped[1].numpy()
+  array([2.0965695, 2.6207118, 3.1448543], dtype=float32)
+
+  When the global norm is already within the clip range, tensors are unchanged:
+
+  >>> t1 = tf.constant([0.1, 0.2])
+  >>> clipped, gnorm = tf.clip_by_global_norm([t1], clip_norm=5.0)
+  >>> clipped[0].numpy()
+  array([0.1, 0.2], dtype=float32)
 
   Args:
     t_list: A tuple or list of mixed `Tensors`, `IndexedSlices`, or None.

--- a/tensorflow/python/ops/confusion_matrix.py
+++ b/tensorflow/python/ops/confusion_matrix.py
@@ -115,17 +115,23 @@ def confusion_matrix(labels,
 
   For example:
 
-  ```python
-    tf.math.confusion_matrix([1, 2, 4], [2, 2, 4]) ==>
-        [[0 0 0 0 0]
-         [0 0 1 0 0]
-         [0 0 1 0 0]
-         [0 0 0 0 0]
-         [0 0 0 0 1]]
-  ```
+  >>> tf.math.confusion_matrix([1, 2, 4], [2, 2, 4]).numpy()
+  array([[0, 0, 0, 0, 0],
+         [0, 0, 1, 0, 0],
+         [0, 0, 1, 0, 0],
+         [0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 1]], dtype=int32)
 
   Note that the possible labels are assumed to be `[0, 1, 2, 3, 4]`,
   resulting in a 5x5 confusion matrix.
+
+  If `num_classes` is provided, the matrix shape is determined by it:
+
+  >>> tf.math.confusion_matrix([0, 1, 2], [0, 2, 2], num_classes=4).numpy()
+  array([[1, 0, 0, 0],
+         [0, 0, 1, 0],
+         [0, 0, 1, 0],
+         [0, 0, 0, 0]], dtype=int32)
 
   Args:
     labels: 1-D `Tensor` of real labels for the classification task.
@@ -223,14 +229,12 @@ def confusion_matrix_v1(labels,
 
   For example:
 
-  ```python
-    tf.math.confusion_matrix([1, 2, 4], [2, 2, 4]) ==>
-        [[0 0 0 0 0]
-         [0 0 1 0 0]
-         [0 0 1 0 0]
-         [0 0 0 0 0]
-         [0 0 0 0 1]]
-  ```
+  >>> tf.math.confusion_matrix([1, 2, 4], [2, 2, 4]).numpy()
+  array([[0, 0, 0, 0, 0],
+         [0, 0, 1, 0, 0],
+         [0, 0, 1, 0, 0],
+         [0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 1]], dtype=int32)
 
   Note that the possible labels are assumed to be `[0, 1, 2, 3, 4]`,
   resulting in a 5x5 confusion matrix.

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -350,6 +350,21 @@ def argmin_v2(input, axis=None, output_type=dtypes.int64, name=None):
 
   Returns the smallest index in case of ties.
 
+  For example:
+
+  >>> A = tf.constant([2, 20, 30, 3, 6])
+  >>> tf.math.argmin(A)  # A[0] is minimum in tensor A
+  <tf.Tensor: shape=(), dtype=int64, numpy=0>
+  >>> B = tf.constant([[2, 20, 30, 3, 6], [3, 11, 16, 1, 8],
+  ...                  [14, 45, 23, 5, 27]])
+  >>> tf.math.argmin(B, 0)
+  <tf.Tensor: shape=(5,), dtype=int64, numpy=array([0, 1, 1, 1, 0])>
+  >>> tf.math.argmin(B, 1)
+  <tf.Tensor: shape=(3,), dtype=int64, numpy=array([0, 3, 3])>
+  >>> C = tf.constant([0, 0, 0, 0])
+  >>> tf.math.argmin(C) # Returns smallest index in case of ties
+  <tf.Tensor: shape=(), dtype=int64, numpy=0>
+
   Args:
     input: A `Tensor`. Must be one of the following types: `float32`, `float64`,
       `int32`, `uint8`, `int16`, `int8`, `complex64`, `int64`, `qint8`,
@@ -365,16 +380,6 @@ def argmin_v2(input, axis=None, output_type=dtypes.int64, name=None):
 
   Returns:
     A `Tensor` of type `output_type`.
-
-  Usage:
-  ```python
-  import tensorflow as tf
-  a = [1, 10, 26.9, 2.8, 166.32, 62.3]
-  b = tf.math.argmin(input = a)
-  c = tf.keras.backend.eval(b)
-  # c = 0
-  # here a[0] = 1 which is the smallest element of a across axis 0
-  ```
   """
   if axis is None:
     axis = 0

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -67,6 +67,20 @@ def log_poisson_loss(targets, log_input, compute_full_loss=False, name=None):
       = x - z * log(x) [+ z * log(z) - z + 0.5 * log(2 * pi * z)]
       = exp(c) - z * c [+ z * log(z) - z + 0.5 * log(2 * pi * z)]
 
+  For example:
+
+  >>> targets = tf.constant([1.0, 2.0, 3.0])
+  >>> log_input = tf.constant([0.5, 0.8, 1.2])
+  >>> tf.nn.log_poisson_loss(targets, log_input).numpy()
+  array([ 1.1487212 ,  0.62554085, -0.27988315], dtype=float32)
+
+  With `compute_full_loss=True`, the Stirling approximation of `log(z!)` is
+  included for more accurate relative loss comparisons:
+
+  >>> tf.nn.log_poisson_loss(targets, log_input,
+  ...                        compute_full_loss=True).numpy()
+  array([1.1487212, 1.2773473, 1.4841985], dtype=float32)
+
   Args:
     targets: A `Tensor` of the same type and shape as `log_input`.
     log_input: A `Tensor` of type `float32` or `float64`.
@@ -409,6 +423,15 @@ def weighted_cross_entropy_with_logits(labels=None,
 def relu_layer(x, weights, biases, name=None):
   """Computes Relu(x * weight + biases).
 
+  For example:
+
+  >>> x = tf.constant([[1.0, -2.0], [3.0, 4.0]])
+  >>> weights = tf.constant([[0.5, -0.5], [0.5, -0.5]])
+  >>> biases = tf.constant([-1.0, 1.0])
+  >>> tf.nn.relu_layer(x, weights, biases).numpy()
+  array([[0. , 1.5],
+         [2.5, 0. ]], dtype=float32)
+
   Args:
     x: a 2D tensor.  Dimensions typically: batch, in_units
     weights: a 2D tensor.  Dimensions typically: in_units, out_units
@@ -444,6 +467,19 @@ def swish(features, beta=1.0):
   [Elfwing et al. 2017](https://arxiv.org/abs/1702.03118) and was independently
   discovered (and called swish) in "Searching for Activation Functions"
   [Ramachandran et al. 2017](https://arxiv.org/abs/1710.05941)
+
+  For example:
+
+  >>> x = tf.constant([-2.0, -1.0, 0.0, 1.0, 2.0])
+  >>> tf.nn.silu(x).numpy()
+  array([-0.23840584, -0.26894143,  0.        ,  0.7310586 ,  1.7615942 ],
+        dtype=float32)
+
+  With a custom `beta` value:
+
+  >>> tf.nn.silu(x, beta=2.0).numpy()
+  array([-0.03597242, -0.11920292,  0.        ,  0.8807971 ,  1.9640275 ],
+        dtype=float32)
 
   Args:
     features: A `Tensor` representing preactivation values.
@@ -495,6 +531,23 @@ def normalize(tensor, ord="euclidean", axis=None, name=None):
   This function can compute several different vector norms (the 1-norm, the
   Euclidean or 2-norm, the inf-norm, and in general the p-norm for p > 0) and
   matrix norms (Frobenius, 1-norm, 2-norm and inf-norm).
+
+  For example:
+
+  >>> x = tf.constant([3.0, 4.0])
+  >>> normalized, norm = tf.linalg.normalize(x)
+  >>> normalized.numpy()
+  array([0.6, 0.8], dtype=float32)
+  >>> norm.numpy()
+  array([5.], dtype=float32)
+
+  For a batch of vectors, normalize along `axis=1`:
+
+  >>> x = tf.constant([[3.0, 4.0], [1.0, 0.0]])
+  >>> normalized, norm = tf.linalg.normalize(x, axis=1)
+  >>> normalized.numpy()
+  array([[0.6, 0.8],
+         [1. , 0. ]], dtype=float32)
 
   Args:
     tensor: `Tensor` of types `float32`, `float64`, `complex64`, `complex128`
@@ -625,12 +678,17 @@ def zero_fraction(value, name=None):
 
   If `value` is empty, the result is `nan`.
 
-  This is useful in summaries to measure and report sparsity.  For example,
+  This is useful in summaries to measure and report sparsity.
 
-  ```python
-      z = tf.nn.relu(...)
-      summ = tf.compat.v1.summary.scalar('sparsity', tf.nn.zero_fraction(z))
-  ```
+  For example:
+
+  >>> x = tf.constant([0, 1, 0, 3, 0], dtype=tf.float32)
+  >>> tf.math.zero_fraction(x).numpy()
+  0.6
+
+  >>> x = tf.constant([[1, 0], [0, 0]], dtype=tf.float32)
+  >>> tf.math.zero_fraction(x).numpy()
+  0.75
 
   Args:
     value: A tensor of numeric type.

--- a/tensorflow/python/ops/string_ops.py
+++ b/tensorflow/python/ops/string_ops.py
@@ -50,6 +50,15 @@ from tensorflow.python.util.tf_export import tf_export
 def regex_full_match(input, pattern, name=None):
   r"""Match elements of `input` with regex `pattern`.
 
+  For example:
+
+  >>> tf.strings.regex_full_match(["TF 2.0", "TF 1.x", "Other"],
+  ...                             r"TF .*").numpy()
+  array([ True,  True, False])
+
+  >>> tf.strings.regex_full_match("TensorFlow", r"Tensor.*").numpy()
+  True
+
   Args:
     input: string `Tensor`, the source strings to process.
     pattern: string or scalar string `Tensor`, regular expression to use,


### PR DESCRIPTION
- math_ops.py: Replace deprecated tf.keras.backend.eval in argmin_v2 with modern runnable doctest examples
- clip_ops.py: Add runnable doctest examples to global_norm and clip_by_global_norm
- nn_impl.py: Add runnable doctest examples to log_poisson_loss, normalize, silu/swish, relu_layer, and zero_fraction (replace non-runnable v1 example)
- confusion_matrix.py: Convert non-runnable ==> examples to proper doctest format in both v1 and v2 confusion_matrix functions
- string_ops.py: Add runnable doctest examples to regex_full_match
- python.md: Fix broken markdown link for Select TF ops
- roadmap.md: Fix typo 'sparity' -> 'sparsity'
- index.md: Update outdated claim about on-device training support