### PR TITLE
Fix confusing MemoryError in tf.squeeze with Tensor axis

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/shape_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/shape_ops_test.py
@@ -402,6 +402,24 @@ class ShapeOpsTest(test.TestCase):
         self.assertRaises(ValueError, array_ops.squeeze,
                           np.zeros([1, 2, 1]), [2, 3])
 
+  def testSqueezeWithTensorAxisError(self):
+    """Test that passing a Tensor as axis raises TypeError (issue #62504)."""
+    # Test with int tensor
+    input_tensor = constant_op.constant([[1, 2, 3]], dtype=dtypes.float32)
+    axis_tensor = constant_op.constant(0, dtype=dtypes.int32)
+    with self.assertRaisesRegex(
+        TypeError,
+        r"axis.*must be.*integer.*list.*not a Tensor"):
+      array_ops.squeeze(input_tensor, axis_tensor)
+
+    # Test with float tensor
+    input_tensor = constant_op.constant([1, 2, 3], dtype=dtypes.float32)
+    axis_tensor = constant_op.constant(0.0, dtype=dtypes.float32)
+    with self.assertRaisesRegex(
+        TypeError,
+        r"axis.*must be.*integer.*list.*not a Tensor"):
+      array_ops.squeeze(input_tensor, axis_tensor)
+
   @test_util.run_deprecated_v1
   def testSqueezeGradient(self):
     with self.cached_session():

--- a/tensorflow/python/kernel_tests/array_ops/shape_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/shape_ops_test.py
@@ -420,6 +420,14 @@ class ShapeOpsTest(test.TestCase):
         r"axis.*must be.*integer.*list.*not a Tensor"):
       array_ops.squeeze(input_tensor, axis_tensor)
 
+    # Test with a list containing a Tensor
+    input_tensor = constant_op.constant([[1, 2, 3]], dtype=dtypes.float32)
+    axis_list = [constant_op.constant(0, dtype=dtypes.int32)]
+    with self.assertRaisesRegex(
+        TypeError,
+        r"axis.*must be.*integer.*list.*cannot.*contain Tensors"):
+      array_ops.squeeze(input_tensor, axis_list)
+
   @test_util.run_deprecated_v1
   def testSqueezeGradient(self):
     with self.cached_session():

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4277,9 +4277,15 @@ def squeeze(input, axis=None, name=None, squeeze_dims=None):
 
   Raises:
     ValueError: When both `squeeze_dims` and `axis` are specified.
+    TypeError: When `axis` is a Tensor instead of an int or list of ints.
   """
   axis = deprecation.deprecated_argument_lookup("axis", axis, "squeeze_dims",
                                                 squeeze_dims)
+  # Validate that axis is not a Tensor
+  if axis is not None and tensor_util.is_tf_type(axis):
+    raise TypeError(
+        "`axis` must be an integer or a list of integers, not a Tensor. "
+        f"Received: axis={axis} (type: {type(axis).__name__})")
   if np.isscalar(axis):
     axis = [axis]
   return gen_array_ops.squeeze(input, axis, name)
@@ -4356,6 +4362,7 @@ def squeeze_v2(input, axis=None, name=None):
   Raises:
     ValueError: The input cannot be converted to a tensor, or the specified
       axis cannot be squeezed.
+    TypeError: When `axis` is a Tensor instead of an int or list of ints.
   """
   # pylint: disable=redefined-builtin
   return squeeze(input, axis, name)

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4281,11 +4281,19 @@ def squeeze(input, axis=None, name=None, squeeze_dims=None):
   """
   axis = deprecation.deprecated_argument_lookup("axis", axis, "squeeze_dims",
                                                 squeeze_dims)
-  # Validate that axis is not a Tensor
-  if axis is not None and tensor_util.is_tf_type(axis):
-    raise TypeError(
-        "`axis` must be an integer or a list of integers, not a Tensor. "
-        f"Received: axis={axis} (type: {type(axis).__name__})")
+  # Validate that axis is not a Tensor or a list/tuple containing a Tensor.
+  # This avoids a confusing MemoryError and keeps eager and graph mode
+  # behavior consistent, since `int(tensor)` only works in eager mode.
+  if axis is not None:
+    if tensor_util.is_tf_type(axis):
+      raise TypeError(
+          "`axis` must be an integer or a list of integers, not a Tensor. "
+          f"Received: axis={axis} (type: {type(axis).__name__})")
+    if isinstance(axis, (list, tuple)) and any(
+        tensor_util.is_tf_type(x) for x in axis):
+      raise TypeError(
+          "`axis` must be an integer or a list of integers, and cannot "
+          f"contain Tensors. Received: axis={axis}")
   if np.isscalar(axis):
     axis = [axis]
   return gen_array_ops.squeeze(input, axis, name)


### PR DESCRIPTION
This fixes the issue #62504 where passing a Tensor as the axis parameter to tf.squeeze raised a confusing MemoryError instead of a clear type error. The fix adds validation to check if axis is a Tensor and raises a descriptive TypeError with guidance on the expected input type. Test cases are included for both int and float tensor scenarios.