### PR TITLE
Fix Pylance/Pyright false type errors for Tensor/Variable (#105851)

### DIFF
--- a/tensorflow/python/framework/constant_op.py
+++ b/tensorflow/python/framework/constant_op.py
@@ -19,7 +19,6 @@ See the [constants guide](https://tensorflow.org/api_guides/python/constant_op).
 
 # Must be separate from array_ops to avoid a cyclic dependency.
 
-from typing import Union
 import numpy as np
 from tensorflow.core.framework import types_pb2
 from tensorflow.core.protobuf import struct_pb2
@@ -111,7 +110,7 @@ def convert_to_eager_tensor(value, ctx, dtype=None) -> ops._EagerTensorBase:
 @tf_export(v1=["constant"])
 def constant_v1(
     value, dtype=None, shape=None, name="Const", verify_shape=False
-) -> Union[ops.Operation, ops._EagerTensorBase]:
+) -> tensor_lib.Tensor:
   """Creates a constant tensor.
 
   The resulting tensor is populated with values of type `dtype`, as
@@ -177,7 +176,7 @@ def constant_v1(
 @tf_export("constant", v1=[])
 def constant(
     value, dtype=None, shape=None, name="Const"
-) -> Union[ops.Operation, ops._EagerTensorBase]:
+) -> tensor_lib.Tensor:
   """Creates a constant tensor from a tensor-like object.
 
   Note: All eager `tf.Tensor` values are immutable (in contrast to
@@ -262,7 +261,7 @@ def constant(
 
   Args:
     value: A constant value (or list) of output type `dtype`.
-    dtype: Optional type of the elements of the resulting tensor.
+    dtype: The type of the elements of the resulting tensor.
     shape: Optional dimensions of resulting tensor.
     name: Optional name for the tensor.
 
@@ -279,7 +278,7 @@ def constant(
 
 def _constant_impl(
     value, dtype, shape, name, verify_shape, allow_broadcast
-) -> Union[ops.Operation, ops._EagerTensorBase]:
+) -> tensor_lib.Tensor:
   """Implementation of constant."""
   ctx = context.context()
   if ctx.executing_eagerly():

--- a/tensorflow/python/framework/constant_op.py
+++ b/tensorflow/python/framework/constant_op.py
@@ -261,7 +261,7 @@ def constant(
 
   Args:
     value: A constant value (or list) of output type `dtype`.
-    dtype: The type of the elements of the resulting tensor.
+    dtype: Optional type of the elements of the resulting tensor.
     shape: Optional dimensions of resulting tensor.
     name: Optional name for the tensor.
 

--- a/tensorflow/python/framework/tensor.py
+++ b/tensorflow/python/framework/tensor.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Tensor and TensorSpec classes."""
 
-from typing import Optional, Type
+from typing import Any, Optional, Type
 
 import numpy as np
 
@@ -247,6 +247,136 @@ class Tensor(internal.NativeObject, core_tf_types.Symbol):
 
   # Whether to allow hashing or numpy-style equality
   _USE_EQUALITY = tf2.enabled()
+
+  # Type stubs for dynamically-added operators (for static type checkers).
+  # These methods are overridden at runtime by _override_operator().
+  def __getitem__(self, key: Any) -> "Tensor":
+    """Returns the specified slice or element of this tensor."""
+    ...
+
+  def __add__(self, other: Any) -> "Tensor":
+    """Returns the element-wise sum of this tensor and `other`."""
+    ...
+
+  def __radd__(self, other: Any) -> "Tensor":
+    """Returns the element-wise sum of `other` and this tensor."""
+    ...
+
+  def __sub__(self, other: Any) -> "Tensor":
+    """Returns the element-wise difference of this tensor and `other`."""
+    ...
+
+  def __rsub__(self, other: Any) -> "Tensor":
+    """Returns the element-wise difference of `other` and this tensor."""
+    ...
+
+  def __mul__(self, other: Any) -> "Tensor":
+    """Returns the element-wise product of this tensor and `other`."""
+    ...
+
+  def __rmul__(self, other: Any) -> "Tensor":
+    """Returns the element-wise product of `other` and this tensor."""
+    ...
+
+  def __div__(self, other: Any) -> "Tensor":
+    """Returns the element-wise quotient of this tensor and `other`."""
+    ...
+
+  def __rdiv__(self, other: Any) -> "Tensor":
+    """Returns the element-wise quotient of `other` and this tensor."""
+    ...
+
+  def __truediv__(self, other: Any) -> "Tensor":
+    """Returns the element-wise quotient of this tensor and `other`."""
+    ...
+
+  def __rtruediv__(self, other: Any) -> "Tensor":
+    """Returns the element-wise quotient of `other` and this tensor."""
+    ...
+
+  def __floordiv__(self, other: Any) -> "Tensor":
+    """Returns the element-wise floor division of this tensor and `other`."""
+    ...
+
+  def __rfloordiv__(self, other: Any) -> "Tensor":
+    """Returns the element-wise floor division of `other` and this tensor."""
+    ...
+
+  def __mod__(self, other: Any) -> "Tensor":
+    """Returns the element-wise modulo of this tensor and `other`."""
+    ...
+
+  def __rmod__(self, other: Any) -> "Tensor":
+    """Returns the element-wise modulo of `other` and this tensor."""
+    ...
+
+  def __pow__(self, other: Any) -> "Tensor":
+    """Returns this tensor raised to the power of `other`."""
+    ...
+
+  def __rpow__(self, other: Any) -> "Tensor":
+    """Returns `other` raised to the power of this tensor."""
+    ...
+
+  def __matmul__(self, other: Any) -> "Tensor":
+    """Returns the matrix product of this tensor and `other`."""
+    ...
+
+  def __rmatmul__(self, other: Any) -> "Tensor":
+    """Returns the matrix product of `other` and this tensor."""
+    ...
+
+  def __lt__(self, other: Any) -> "Tensor":
+    """Returns element-wise `self < other`."""
+    ...
+
+  def __le__(self, other: Any) -> "Tensor":
+    """Returns element-wise `self <= other`."""
+    ...
+
+  def __gt__(self, other: Any) -> "Tensor":
+    """Returns element-wise `self > other`."""
+    ...
+
+  def __ge__(self, other: Any) -> "Tensor":
+    """Returns element-wise `self >= other`."""
+    ...
+
+  def __neg__(self) -> "Tensor":
+    """Returns the element-wise negation of this tensor."""
+    ...
+
+  def __abs__(self) -> "Tensor":
+    """Returns the element-wise absolute value of this tensor."""
+    ...
+
+  def __invert__(self) -> "Tensor":
+    """Returns the element-wise bitwise inversion of this tensor."""
+    ...
+
+  def __and__(self, other: Any) -> "Tensor":
+    """Returns the element-wise logical AND of this tensor and `other`."""
+    ...
+
+  def __rand__(self, other: Any) -> "Tensor":
+    """Returns the element-wise logical AND of `other` and this tensor."""
+    ...
+
+  def __or__(self, other: Any) -> "Tensor":
+    """Returns the element-wise logical OR of this tensor and `other`."""
+    ...
+
+  def __ror__(self, other: Any) -> "Tensor":
+    """Returns the element-wise logical OR of `other` and this tensor."""
+    ...
+
+  def __xor__(self, other: Any) -> "Tensor":
+    """Returns the element-wise logical XOR of this tensor and `other`."""
+    ...
+
+  def __rxor__(self, other: Any) -> "Tensor":
+    """Returns the element-wise logical XOR of `other` and this tensor."""
+    ...
 
   def __getattr__(self, name):
     if name in {"T", "astype", "ravel", "transpose", "reshape", "clip", "size",

--- a/tensorflow/python/framework/tensor.py
+++ b/tensorflow/python/framework/tensor.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Tensor and TensorSpec classes."""
 
-from typing import Any, Optional, Type, Union
+from typing import Any, Optional, TYPE_CHECKING, Type, Union
 
 import numpy as np
 
@@ -247,156 +247,157 @@ class Tensor(internal.NativeObject, core_tf_types.Symbol):
 
   # Whether to allow hashing or numpy-style equality
   _USE_EQUALITY = tf2.enabled()
+    
+  if TYPE_CHECKING:
+    # Type stubs for dynamically-added operators (for static type checkers).
+    # These methods are overridden at runtime by _override_operator().
+    def __getitem__(self, key: Any) -> "Tensor":
+      """Returns the specified slice or element of this tensor."""
+      ...
 
-  # Type stubs for dynamically-added operators (for static type checkers).
-  # These methods are overridden at runtime by _override_operator().
-  def __getitem__(self, key: Any) -> "Tensor":
-    """Returns the specified slice or element of this tensor."""
-    ...
+    def __add__(self, other: Any) -> "Tensor":
+      """Returns the element-wise sum of this tensor and `other`."""
+      ...
 
-  def __add__(self, other: Any) -> "Tensor":
-    """Returns the element-wise sum of this tensor and `other`."""
-    ...
+    def __radd__(self, other: Any) -> "Tensor":
+      """Returns the element-wise sum of `other` and this tensor."""
+      ...
 
-  def __radd__(self, other: Any) -> "Tensor":
-    """Returns the element-wise sum of `other` and this tensor."""
-    ...
+    def __sub__(self, other: Any) -> "Tensor":
+      """Returns the element-wise difference of this tensor and `other`."""
+      ...
 
-  def __sub__(self, other: Any) -> "Tensor":
-    """Returns the element-wise difference of this tensor and `other`."""
-    ...
+    def __rsub__(self, other: Any) -> "Tensor":
+      """Returns the element-wise difference of `other` and this tensor."""
+      ...
 
-  def __rsub__(self, other: Any) -> "Tensor":
-    """Returns the element-wise difference of `other` and this tensor."""
-    ...
+    def __mul__(self, other: Any) -> "Tensor":
+      """Returns the element-wise product of this tensor and `other`."""
+      ...
 
-  def __mul__(self, other: Any) -> "Tensor":
-    """Returns the element-wise product of this tensor and `other`."""
-    ...
+    def __rmul__(self, other: Any) -> "Tensor":
+      """Returns the element-wise product of `other` and this tensor."""
+      ...
 
-  def __rmul__(self, other: Any) -> "Tensor":
-    """Returns the element-wise product of `other` and this tensor."""
-    ...
+    def __div__(self, other: Any) -> "Tensor":
+      """Returns the element-wise quotient of this tensor and `other`."""
+      ...
 
-  def __div__(self, other: Any) -> "Tensor":
-    """Returns the element-wise quotient of this tensor and `other`."""
-    ...
+    def __rdiv__(self, other: Any) -> "Tensor":
+      """Returns the element-wise quotient of `other` and this tensor."""
+      ...
 
-  def __rdiv__(self, other: Any) -> "Tensor":
-    """Returns the element-wise quotient of `other` and this tensor."""
-    ...
+    def __truediv__(self, other: Any) -> "Tensor":
+      """Returns the element-wise quotient of this tensor and `other`."""
+      ...
 
-  def __truediv__(self, other: Any) -> "Tensor":
-    """Returns the element-wise quotient of this tensor and `other`."""
-    ...
+    def __rtruediv__(self, other: Any) -> "Tensor":
+      """Returns the element-wise quotient of `other` and this tensor."""
+      ...
 
-  def __rtruediv__(self, other: Any) -> "Tensor":
-    """Returns the element-wise quotient of `other` and this tensor."""
-    ...
+    def __floordiv__(self, other: Any) -> "Tensor":
+      """Returns the element-wise floor division of this tensor and `other`."""
+      ...
 
-  def __floordiv__(self, other: Any) -> "Tensor":
-    """Returns the element-wise floor division of this tensor and `other`."""
-    ...
+    def __rfloordiv__(self, other: Any) -> "Tensor":
+      """Returns the element-wise floor division of `other` and this tensor."""
+      ...
 
-  def __rfloordiv__(self, other: Any) -> "Tensor":
-    """Returns the element-wise floor division of `other` and this tensor."""
-    ...
+    def __mod__(self, other: Any) -> "Tensor":
+      """Returns the element-wise modulo of this tensor and `other`."""
+      ...
 
-  def __mod__(self, other: Any) -> "Tensor":
-    """Returns the element-wise modulo of this tensor and `other`."""
-    ...
+    def __rmod__(self, other: Any) -> "Tensor":
+      """Returns the element-wise modulo of `other` and this tensor."""
+      ...
 
-  def __rmod__(self, other: Any) -> "Tensor":
-    """Returns the element-wise modulo of `other` and this tensor."""
-    ...
+    def __pow__(self, other: Any) -> "Tensor":
+      """Returns this tensor raised to the power of `other`."""
+      ...
 
-  def __pow__(self, other: Any) -> "Tensor":
-    """Returns this tensor raised to the power of `other`."""
-    ...
+    def __rpow__(self, other: Any) -> "Tensor":
+      """Returns `other` raised to the power of this tensor."""
+      ...
 
-  def __rpow__(self, other: Any) -> "Tensor":
-    """Returns `other` raised to the power of this tensor."""
-    ...
+    def __matmul__(self, other: Any) -> "Tensor":
+      """Returns the matrix product of this tensor and `other`."""
+      ...
 
-  def __matmul__(self, other: Any) -> "Tensor":
-    """Returns the matrix product of this tensor and `other`."""
-    ...
+    def __rmatmul__(self, other: Any) -> "Tensor":
+      """Returns the matrix product of `other` and this tensor."""
+      ...
 
-  def __rmatmul__(self, other: Any) -> "Tensor":
-    """Returns the matrix product of `other` and this tensor."""
-    ...
+    def __lt__(self, other: Any) -> "Tensor":
+      """Returns element-wise `self < other`."""
+      ...
 
-  def __lt__(self, other: Any) -> "Tensor":
-    """Returns element-wise `self < other`."""
-    ...
+    def __le__(self, other: Any) -> "Tensor":
+      """Returns element-wise `self <= other`."""
+      ...
 
-  def __le__(self, other: Any) -> "Tensor":
-    """Returns element-wise `self <= other`."""
-    ...
+    def __gt__(self, other: Any) -> "Tensor":
+      """Returns element-wise `self > other`."""
+      ...
 
-  def __gt__(self, other: Any) -> "Tensor":
-    """Returns element-wise `self > other`."""
-    ...
+    def __ge__(self, other: Any) -> "Tensor":
+      """Returns element-wise `self >= other`."""
+      ...
 
-  def __ge__(self, other: Any) -> "Tensor":
-    """Returns element-wise `self >= other`."""
-    ...
+    def __eq__(self, other: Any) -> Union["Tensor", bool]:
+      """Returns element-wise `self == other`.
 
-  def __eq__(self, other: Any) -> Union["Tensor", bool]:
-    """Returns element-wise `self == other`.
+      Returns a boolean `Tensor` when tensor equality is enabled (the
+      default in TF2, see `Tensor._USE_EQUALITY`) and we are executing
+      eagerly or building a `tf.function`. Otherwise falls back to plain
+      Python object-identity comparison and returns a `bool`.
+      """
+      ...
 
-    Returns a boolean `Tensor` when tensor equality is enabled (the
-    default in TF2, see `Tensor._USE_EQUALITY`) and we are executing
-    eagerly or building a `tf.function`. Otherwise falls back to plain
-    Python object-identity comparison and returns a `bool`.
-    """
-    ...
+    def __ne__(self, other: Any) -> Union["Tensor", bool]:
+      """Returns element-wise `self != other`.
 
-  def __ne__(self, other: Any) -> Union["Tensor", bool]:
-    """Returns element-wise `self != other`.
+      Returns a boolean `Tensor` when tensor equality is enabled (the
+      default in TF2, see `Tensor._USE_EQUALITY`) and we are executing
+      eagerly or building a `tf.function`. Otherwise falls back to plain
+      Python object-identity comparison and returns a `bool`.
+      """
+      ...
 
-    Returns a boolean `Tensor` when tensor equality is enabled (the
-    default in TF2, see `Tensor._USE_EQUALITY`) and we are executing
-    eagerly or building a `tf.function`. Otherwise falls back to plain
-    Python object-identity comparison and returns a `bool`.
-    """
-    ...
+    def __neg__(self) -> "Tensor":
+      """Returns the element-wise negation of this tensor."""
+      ...
 
-  def __neg__(self) -> "Tensor":
-    """Returns the element-wise negation of this tensor."""
-    ...
+    def __abs__(self) -> "Tensor":
+      """Returns the element-wise absolute value of this tensor."""
+      ...
 
-  def __abs__(self) -> "Tensor":
-    """Returns the element-wise absolute value of this tensor."""
-    ...
+    def __invert__(self) -> "Tensor":
+      """Returns the element-wise bitwise inversion of this tensor."""
+      ...
 
-  def __invert__(self) -> "Tensor":
-    """Returns the element-wise bitwise inversion of this tensor."""
-    ...
+    def __and__(self, other: Any) -> "Tensor":
+      """Returns the element-wise logical AND of this tensor and `other`."""
+      ...
 
-  def __and__(self, other: Any) -> "Tensor":
-    """Returns the element-wise logical AND of this tensor and `other`."""
-    ...
+    def __rand__(self, other: Any) -> "Tensor":
+      """Returns the element-wise logical AND of `other` and this tensor."""
+      ...
 
-  def __rand__(self, other: Any) -> "Tensor":
-    """Returns the element-wise logical AND of `other` and this tensor."""
-    ...
+    def __or__(self, other: Any) -> "Tensor":
+      """Returns the element-wise logical OR of this tensor and `other`."""
+      ...
 
-  def __or__(self, other: Any) -> "Tensor":
-    """Returns the element-wise logical OR of this tensor and `other`."""
-    ...
+    def __ror__(self, other: Any) -> "Tensor":
+      """Returns the element-wise logical OR of `other` and this tensor."""
+      ...
 
-  def __ror__(self, other: Any) -> "Tensor":
-    """Returns the element-wise logical OR of `other` and this tensor."""
-    ...
+    def __xor__(self, other: Any) -> "Tensor":
+      """Returns the element-wise logical XOR of this tensor and `other`."""
+      ...
 
-  def __xor__(self, other: Any) -> "Tensor":
-    """Returns the element-wise logical XOR of this tensor and `other`."""
-    ...
-
-  def __rxor__(self, other: Any) -> "Tensor":
-    """Returns the element-wise logical XOR of `other` and this tensor."""
-    ...
+    def __rxor__(self, other: Any) -> "Tensor":
+      """Returns the element-wise logical XOR of `other` and this tensor."""
+      ...
 
   def __getattr__(self, name):
     if name in {"T", "astype", "ravel", "transpose", "reshape", "clip", "size",

--- a/tensorflow/python/framework/tensor.py
+++ b/tensorflow/python/framework/tensor.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 """Tensor and TensorSpec classes."""
 
-from typing import Any, Optional, Type
+from typing import Any, Optional, Type, Union
 
 import numpy as np
 
@@ -340,6 +340,26 @@ class Tensor(internal.NativeObject, core_tf_types.Symbol):
 
   def __ge__(self, other: Any) -> "Tensor":
     """Returns element-wise `self >= other`."""
+    ...
+
+  def __eq__(self, other: Any) -> Union["Tensor", bool]:
+    """Returns element-wise `self == other`.
+
+    Returns a boolean `Tensor` when tensor equality is enabled (the
+    default in TF2, see `Tensor._USE_EQUALITY`) and we are executing
+    eagerly or building a `tf.function`. Otherwise falls back to plain
+    Python object-identity comparison and returns a `bool`.
+    """
+    ...
+
+  def __ne__(self, other: Any) -> Union["Tensor", bool]:
+    """Returns element-wise `self != other`.
+
+    Returns a boolean `Tensor` when tensor equality is enabled (the
+    default in TF2, see `Tensor._USE_EQUALITY`) and we are executing
+    eagerly or building a `tf.function`. Otherwise falls back to plain
+    Python object-identity comparison and returns a `bool`.
+    """
     ...
 
   def __neg__(self) -> "Tensor":

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -19,6 +19,7 @@ import enum
 import functools
 import itertools
 import os
+from typing import Any
 from typing_extensions import Self
 
 from tensorflow.core.framework import variable_pb2
@@ -388,6 +389,136 @@ class Variable(trackable.Trackable, metaclass=VariableMetaclass):
 
   def __repr__(self):
     raise NotImplementedError
+
+  # Type stubs for dynamically-added operators (for static type checkers).
+  # These methods are overridden at runtime by _OverloadAllOperators().
+  def __getitem__(self, key: Any) -> tensor_lib.Tensor:
+    """Returns the specified slice or element of this variable."""
+    ...
+
+  def __add__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise sum of this variable and `other`."""
+    ...
+
+  def __radd__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise sum of `other` and this variable."""
+    ...
+
+  def __sub__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise difference of this variable and `other`."""
+    ...
+
+  def __rsub__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise difference of `other` and this variable."""
+    ...
+
+  def __mul__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise product of this variable and `other`."""
+    ...
+
+  def __rmul__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise product of `other` and this variable."""
+    ...
+
+  def __div__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise quotient of this variable and `other`."""
+    ...
+
+  def __rdiv__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise quotient of `other` and this variable."""
+    ...
+
+  def __truediv__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise quotient of this variable and `other`."""
+    ...
+
+  def __rtruediv__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise quotient of `other` and this variable."""
+    ...
+
+  def __floordiv__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise floor division of this variable and `other`."""
+    ...
+
+  def __rfloordiv__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise floor division of `other` and this variable."""
+    ...
+
+  def __mod__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise modulo of this variable and `other`."""
+    ...
+
+  def __rmod__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise modulo of `other` and this variable."""
+    ...
+
+  def __pow__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns this variable raised to the power of `other`."""
+    ...
+
+  def __rpow__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns `other` raised to the power of this variable."""
+    ...
+
+  def __matmul__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the matrix product of this variable and `other`."""
+    ...
+
+  def __rmatmul__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the matrix product of `other` and this variable."""
+    ...
+
+  def __lt__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns element-wise `self < other`."""
+    ...
+
+  def __le__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns element-wise `self <= other`."""
+    ...
+
+  def __gt__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns element-wise `self > other`."""
+    ...
+
+  def __ge__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns element-wise `self >= other`."""
+    ...
+
+  def __neg__(self) -> tensor_lib.Tensor:
+    """Returns the element-wise negation of this variable."""
+    ...
+
+  def __abs__(self) -> tensor_lib.Tensor:
+    """Returns the element-wise absolute value of this variable."""
+    ...
+
+  def __invert__(self) -> tensor_lib.Tensor:
+    """Returns the element-wise bitwise inversion of this variable."""
+    ...
+
+  def __and__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise logical AND of this variable and `other`."""
+    ...
+
+  def __rand__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise logical AND of `other` and this variable."""
+    ...
+
+  def __or__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise logical OR of this variable and `other`."""
+    ...
+
+  def __ror__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise logical OR of `other` and this variable."""
+    ...
+
+  def __xor__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise logical XOR of this variable and `other`."""
+    ...
+
+  def __rxor__(self, other: Any) -> tensor_lib.Tensor:
+    """Returns the element-wise logical XOR of `other` and this variable."""
+    ...
 
   def value(self):
     """Returns the last snapshot of this variable.

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -1373,7 +1373,8 @@ class Variable(trackable.Trackable, metaclass=VariableMetaclass):
         synchronization=synchronization,
         aggregation=aggregation,
         shape=shape,
-        experimental_enable_variable_lifting=experimental_enable_variable_lifting,
+        experimental_enable_variable_lifting=(
+          experimental_enable_variable_lifting),
         **kwargs
     )
 

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -1374,7 +1374,7 @@ class Variable(trackable.Trackable, metaclass=VariableMetaclass):
         aggregation=aggregation,
         shape=shape,
         experimental_enable_variable_lifting=(
-          experimental_enable_variable_lifting),
+            experimental_enable_variable_lifting),
         **kwargs
     )
 

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -19,7 +19,7 @@ import enum
 import functools
 import itertools
 import os
-from typing import Any, Union
+from typing import Any, TYPE_CHECKING, Union
 from typing_extensions import Self
 
 from tensorflow.core.framework import variable_pb2
@@ -390,139 +390,140 @@ class Variable(trackable.Trackable, metaclass=VariableMetaclass):
   def __repr__(self):
     raise NotImplementedError
 
-  # Type stubs for dynamically-added operators (for static type checkers).
-  # These methods are overridden at runtime by _OverloadAllOperators().
-  # Note: __eq__ and __ne__ are intentionally NOT stubbed here. Unlike the
-  # operators below, they are excluded from _OverloadOperator() (see above)
-  # and are instead real, statically-defined methods further down in this
-  # class; their return type is annotated directly at their definition.
-  def __getitem__(self, key: Any) -> tensor_lib.Tensor:
-    """Returns the specified slice or element of this variable."""
-    ...
+  if TYPE_CHECKING:
+    # Type stubs for dynamically-added operators (for static type checkers).
+    # These methods are overridden at runtime by _OverloadAllOperators().
+    # Note: __eq__ and __ne__ are intentionally NOT stubbed here. Unlike the
+    # operators below, they are excluded from _OverloadOperator() (see above)
+    # and are instead real, statically-defined methods further down in this
+    # class; their return type is annotated directly at their definition.
+    def __getitem__(self, key: Any) -> tensor_lib.Tensor:
+      """Returns the specified slice or element of this variable."""
+      ...
 
-  def __add__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise sum of this variable and `other`."""
-    ...
+    def __add__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise sum of this variable and `other`."""
+      ...
 
-  def __radd__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise sum of `other` and this variable."""
-    ...
+    def __radd__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise sum of `other` and this variable."""
+      ...
 
-  def __sub__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise difference of this variable and `other`."""
-    ...
+    def __sub__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise difference of this variable and `other`."""
+      ...
 
-  def __rsub__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise difference of `other` and this variable."""
-    ...
+    def __rsub__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise difference of `other` and this variable."""
+      ...
 
-  def __mul__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise product of this variable and `other`."""
-    ...
+    def __mul__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise product of this variable and `other`."""
+      ...
 
-  def __rmul__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise product of `other` and this variable."""
-    ...
+    def __rmul__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise product of `other` and this variable."""
+      ...
 
-  def __div__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise quotient of this variable and `other`."""
-    ...
+    def __div__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise quotient of this variable and `other`."""
+      ...
 
-  def __rdiv__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise quotient of `other` and this variable."""
-    ...
+    def __rdiv__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise quotient of `other` and this variable."""
+      ...
 
-  def __truediv__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise quotient of this variable and `other`."""
-    ...
+    def __truediv__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise quotient of this variable and `other`."""
+      ...
 
-  def __rtruediv__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise quotient of `other` and this variable."""
-    ...
+    def __rtruediv__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise quotient of `other` and this variable."""
+      ...
 
-  def __floordiv__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise floor division of this variable and `other`."""
-    ...
+    def __floordiv__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise floor division of this variable and `other`."""
+      ...
 
-  def __rfloordiv__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise floor division of `other` and this variable."""
-    ...
+    def __rfloordiv__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise floor division of `other` and this variable."""
+      ...
 
-  def __mod__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise modulo of this variable and `other`."""
-    ...
+    def __mod__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise modulo of this variable and `other`."""
+      ...
 
-  def __rmod__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise modulo of `other` and this variable."""
-    ...
+    def __rmod__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise modulo of `other` and this variable."""
+      ...
 
-  def __pow__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns this variable raised to the power of `other`."""
-    ...
+    def __pow__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns this variable raised to the power of `other`."""
+      ...
 
-  def __rpow__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns `other` raised to the power of this variable."""
-    ...
+    def __rpow__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns `other` raised to the power of this variable."""
+      ...
 
-  def __matmul__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the matrix product of this variable and `other`."""
-    ...
+    def __matmul__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the matrix product of this variable and `other`."""
+      ...
 
-  def __rmatmul__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the matrix product of `other` and this variable."""
-    ...
+    def __rmatmul__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the matrix product of `other` and this variable."""
+      ...
 
-  def __lt__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns element-wise `self < other`."""
-    ...
+    def __lt__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns element-wise `self < other`."""
+      ...
 
-  def __le__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns element-wise `self <= other`."""
-    ...
+    def __le__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns element-wise `self <= other`."""
+      ...
 
-  def __gt__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns element-wise `self > other`."""
-    ...
+    def __gt__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns element-wise `self > other`."""
+      ...
 
-  def __ge__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns element-wise `self >= other`."""
-    ...
+    def __ge__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns element-wise `self >= other`."""
+      ...
 
-  def __neg__(self) -> tensor_lib.Tensor:
-    """Returns the element-wise negation of this variable."""
-    ...
+    def __neg__(self) -> tensor_lib.Tensor:
+      """Returns the element-wise negation of this variable."""
+      ...
 
-  def __abs__(self) -> tensor_lib.Tensor:
-    """Returns the element-wise absolute value of this variable."""
-    ...
+    def __abs__(self) -> tensor_lib.Tensor:
+      """Returns the element-wise absolute value of this variable."""
+      ...
 
-  def __invert__(self) -> tensor_lib.Tensor:
-    """Returns the element-wise bitwise inversion of this variable."""
-    ...
+    def __invert__(self) -> tensor_lib.Tensor:
+      """Returns the element-wise bitwise inversion of this variable."""
+      ...
 
-  def __and__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise logical AND of this variable and `other`."""
-    ...
+    def __and__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise logical AND of this variable and `other`."""
+      ...
 
-  def __rand__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise logical AND of `other` and this variable."""
-    ...
+    def __rand__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise logical AND of `other` and this variable."""
+      ...
 
-  def __or__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise logical OR of this variable and `other`."""
-    ...
+    def __or__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise logical OR of this variable and `other`."""
+      ...
 
-  def __ror__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise logical OR of `other` and this variable."""
-    ...
+    def __ror__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise logical OR of `other` and this variable."""
+      ...
 
-  def __xor__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise logical XOR of this variable and `other`."""
-    ...
+    def __xor__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise logical XOR of this variable and `other`."""
+      ...
 
-  def __rxor__(self, other: Any) -> tensor_lib.Tensor:
-    """Returns the element-wise logical XOR of `other` and this variable."""
-    ...
+    def __rxor__(self, other: Any) -> tensor_lib.Tensor:
+      """Returns the element-wise logical XOR of `other` and this variable."""
+      ...
 
   def value(self):
     """Returns the last snapshot of this variable.

--- a/tensorflow/python/ops/variables.py
+++ b/tensorflow/python/ops/variables.py
@@ -19,7 +19,7 @@ import enum
 import functools
 import itertools
 import os
-from typing import Any
+from typing import Any, Union
 from typing_extensions import Self
 
 from tensorflow.core.framework import variable_pb2
@@ -392,6 +392,10 @@ class Variable(trackable.Trackable, metaclass=VariableMetaclass):
 
   # Type stubs for dynamically-added operators (for static type checkers).
   # These methods are overridden at runtime by _OverloadAllOperators().
+  # Note: __eq__ and __ne__ are intentionally NOT stubbed here. Unlike the
+  # operators below, they are excluded from _OverloadOperator() (see above)
+  # and are instead real, statically-defined methods further down in this
+  # class; their return type is annotated directly at their definition.
   def __getitem__(self, key: Any) -> tensor_lib.Tensor:
     """Returns the specified slice or element of this variable."""
     ...
@@ -1164,7 +1168,7 @@ class Variable(trackable.Trackable, metaclass=VariableMetaclass):
       return id(self)
 
   # TODO(gjn): duplicate of math_ops.tensor_equals, consider removing
-  def __eq__(self, other):
+  def __eq__(self, other: Any) -> Union[tensor_lib.Tensor, bool]:
     """Compares two variables element-wise for equality."""
     if (
         tensor_lib.Tensor._USE_EQUALITY
@@ -1176,7 +1180,7 @@ class Variable(trackable.Trackable, metaclass=VariableMetaclass):
       return self is other
 
   # TODO(gjn): duplicate of math_ops.tensor_not_equals, consider removing
-  def __ne__(self, other):
+  def __ne__(self, other: Any) -> Union[tensor_lib.Tensor, bool]:
     """Compares two variables element-wise for equality."""
     if (
         tensor_lib.Tensor._USE_EQUALITY


### PR DESCRIPTION
- Fix return type annotations for tf.constant() from Union[ops.Operation, ops._EagerTensorBase] to tensor_lib.Tensor
- Add type stubs for dynamically-added operators in Tensor class
- Add type stubs for dynamically-added operators in Variable class

The operators (__getitem__, __add__, __mul__, etc.) are added at runtime via _override_operator(), making them invisible to static type checkers. These type stubs provide the necessary type information while the actual implementations remain dynamic.
Also fixes failed linit jobs here: [106057](https://github.com/tensorflow/tensorflow/pull/106057)
Closes #105851
