### PR TITLE
Fix i16 quantization support check

### DIFF
--- a/tensorflow/compiler/mlir/quantization/common/tf_uniform_quantized_types.cc
+++ b/tensorflow/compiler/mlir/quantization/common/tf_uniform_quantized_types.cc
@@ -199,8 +199,7 @@ bool IsI32F32UniformQuantizedPerAxisType(const Type type) {
 // Determines whether the storage type of a quantized type is supported by
 // `tfl.quantize` or `tfl.dequantize` ops. ui8, i8 and i16 are supported.
 bool IsSupportedByTfliteQuantizeOrDequantizeOps(IntegerType storage_type) {
-  if (storage_type.getWidth() == 8 ||
-      (storage_type.isSigned() && storage_type.getWidth() == 16)) {
+  if (storage_type.getWidth() == 8 || storage_type.isSignlessInteger(16)) {
     return true;
   }
   LLVM_DEBUG(llvm::dbgs()

--- a/tensorflow/compiler/mlir/quantization/common/uniform_quantized_types.cc
+++ b/tensorflow/compiler/mlir/quantization/common/uniform_quantized_types.cc
@@ -196,8 +196,7 @@ bool IsI32F32UniformQuantizedPerAxisType(const Type type) {
 // Determines whether the storage type of a quantized type is supported by
 // `tfl.quantize` or `tfl.dequantize` ops. ui8, i8 and i16 are supported.
 bool IsSupportedByTfliteQuantizeOrDequantizeOps(IntegerType storage_type) {
-  if (storage_type.getWidth() == 8 ||
-      (storage_type.isSigned() && storage_type.getWidth() == 16)) {
+  if (storage_type.getWidth() == 8 || storage_type.isSignlessInteger(16)) {
     return true;
   }
   LLVM_DEBUG(llvm::dbgs()

--- a/tensorflow/compiler/mlir/quantization/common/uniform_quantized_types_test.cc
+++ b/tensorflow/compiler/mlir/quantization/common/uniform_quantized_types_test.cc
@@ -575,7 +575,7 @@ TEST_F(IsSupportedByTfliteQuantizeOrDequantizeOpsTest, StorageTypeI8Succeeds) {
 
 TEST_F(IsSupportedByTfliteQuantizeOrDequantizeOpsTest, StorageTypeI16Succeeds) {
   auto qi16_type = quant::UniformQuantizedType::get(
-      /*flags=*/QuantizationFlags::Signed, builder_.getI8Type(),
+      /*flags=*/QuantizationFlags::Signed, builder_.getI16Type(),
       builder_.getF32Type(),
       /*scale=*/1.0,
       /*zeroPoint=*/0, /*storageTypeMin=*/-128, /*storageTypeMax=*/127);


### PR DESCRIPTION
This PR fixes the supported quantization type check for i16 quantization types. The check was incorrectly looking for a signed int16, which should instead be signless since the quantization type uses i16. This allows uniform_quantized_stablehlo_to_tfl_pass.cc to work with 16b quantization.

Also fixes the unit test for the function, which was incorrectly passing due to the commit 351eab8, which changed the i16 test to use an i8.

Minimal code example that can reproduce the StableHLO 16b quantization failure using [litert-torch](https://github.com/google-ai-edge/litert-torch) that this PR fixes:

```python
import torch
import ai_edge_torch
from ai_edge_torch.quantize import pt2e_quantizer
from ai_edge_torch.quantize import quant_config
from torch.ao.quantization import quantize_pt2e
from torch.ao.quantization.quantizer import QuantizationSpec
from ai_edge_torch.quantize.pt2e_quantizer_utils import QuantizationConfig


class M(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.conv = torch.nn.Conv2d(1, 1, 1, 1)
        self.act = torch.nn.ReLU()

    def forward(self, x):
        x = self.conv(x)
        return self.act(x)


def create_quantizer_i16_activation():
    qconfig = pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False)
    act_quantization_spec = QuantizationSpec(
        dtype=torch.int16,
        qscheme=torch.per_tensor_affine,
        is_dynamic=qconfig.is_dynamic,
        observer_or_fake_quant_ctr=qconfig.input_activation.observer_or_fake_quant_ctr,
    )
    qconfig = QuantizationConfig(
        act_quantization_spec,
        act_quantization_spec,
        qconfig.weight,
        qconfig.bias,
        qconfig.fixed_qparams,
        qconfig.is_qat,
        qconfig.is_dynamic,
    )

    quantizer = pt2e_quantizer.PT2EQuantizer().set_global(qconfig)
    return quantizer


m = M()
sample_inputs = (torch.randn(1, 1, 1, dtype=torch.float32),)


m = torch.export.export(m, sample_inputs).module()
quantizer = create_quantizer_i16_activation()
m = quantize_pt2e.prepare_pt2e(m, quantizer)
m(*sample_inputs)
m = quantize_pt2e.convert_pt2e(m, fold_quantize=False)

edge_model = ai_edge_torch.convert(
    m,
    sample_inputs,
    _saved_model_dir="model_out/",
    quant_config=quant_config.QuantConfig(pt2e_quantizer=quantizer),
)
edge_model.export("./model.tflite")
```