### PR TITLE
[mlir][tosa] Add README announcing migration

### DIFF
--- a/tensorflow/compiler/mlir/tosa/README.md
+++ b/tensorflow/compiler/mlir/tosa/README.md
@@ -1,0 +1,13 @@
+# TOSA legalizations for TensorFlow and TensorFlow Lite (Deprecated)
+
+## Deprecation notice
+
+This directory contains an archive of the Tensor Operator Set Architecture (TOSA) MLIR legalizations for the TensorFlow and TF Lite MLIR Dialects. For more information see the resources below.
+
+Support for these legalization paths has been **moved** to the [TOSA Converter for TFLite](https://gitlab.arm.com/tosa/tosa-converter-for-tflite) repository and is **not currently maintained nor kept up to date within this repository**.
+
+## Resources
+
+* [Tensor Operator Set Architecture (TOSA) Specification](https://www.mlplatform.org/tosa/tosa_spec.html)
+* [TOSA MLIR Dialect](https://mlir.llvm.org/docs/Dialects/TOSA/)
+* [TOSA Converter for TFLite](https://gitlab.arm.com/tosa/tosa-converter-for-tflite)


### PR DESCRIPTION
This README file is only meant to redirect users to the new location for development of TF -> TOSA and TFL -> TOSA legalizations.

Change-Id: Ib25cb4a7b5dbe6aac1370e8475c728084d931f2e