### PR TITLE
Inserted checks to ensure that bins are not negative in Bincount

### DIFF
--- a/tensorflow/core/kernels/bincount_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/bincount_op_gpu.cu.cc
@@ -118,7 +118,7 @@ __global__ void BincountReduceKernel(const Tidx* in, T* out, const int nthreads,
                                      const Tidx num_bins) {
   GPU_1D_KERNEL_LOOP(index, nthreads) {
     Tidx bin = ldg(in + index);
-    if (bin < num_bins) {
+    if (bin >= 0 && bin < num_bins) {
       out[bin] = T(1);
     }
   }
@@ -149,7 +149,7 @@ __global__ void BincountColReduceKernel(const Tidx* in, const T* weights,
   const int nthreads = num_rows * num_cols;
   GPU_1D_KERNEL_LOOP(index, nthreads) {
     Tidx bin = ldg(in + index);
-    if (bin < num_bins) {
+    if (bin >= 0 && bin < num_bins) {
       int row = index / num_cols;
       int offset = row * num_bins + bin;
       if (binary_count) {
@@ -179,7 +179,7 @@ __global__ void BincountColReduceSharedKernel(const Tidx* in, const T* weights,
   const int nthreads = num_rows * num_cols;
   GPU_1D_KERNEL_LOOP(index, nthreads) {
     Tidx bin = ldg(in + index);
-    if (bin < num_bins) {
+    if (bin >= 0 && bin < num_bins) {
       int row = index / num_cols;
       int offset = row * num_bins + bin;
       if (binary_count) {


### PR DESCRIPTION
Cuda kernels BincountReduceKernel, BincountColReduceKernel,BincountColReduceSharedKernel could be called with negative bins that lead to GPU OOB memory access.
Fixes #103995