### PR TITLE
Update lit pypi target reference

### DIFF
--- a/tensorflow/compiler/mlir/tosa/glob_lit_test.bzl
+++ b/tensorflow/compiler/mlir/tosa/glob_lit_test.bzl
@@ -62,7 +62,7 @@ def _run_lit_test(name, data, size, tags, driver, features, exec_properties):
             "@llvm-project//llvm:count",
             "@llvm-project//llvm:not",
         ],
-        deps = ["@pypi_lit//:pkg"],
+        deps = ["@pypi//lit"],
         size = size,
         main = "lit.py",
         exec_properties = exec_properties,


### PR DESCRIPTION
Needed for bzlmod. Part of #102891.

This needs to be merged on GitHub as it the file is not only available in OSS.
