### PR TITLE
Fix resource categorization for unsorted _read_only_resource_inputs

### DIFF
--- a/tensorflow/python/framework/auto_control_deps_test.py
+++ b/tensorflow/python/framework/auto_control_deps_test.py
@@ -922,7 +922,32 @@ class AutomaticControlDependenciesTest(test.TestCase):
       with self.assertRaises(ValueError):
         read_op1.get_attr("_has_manual_control_dependencies")
       with self.assertRaises(ValueError):
-        read_op2.get_attr("_has_manual_control_dependencies")
+        read_op2.get_attr("_has_manual_control_dependencies
+
+  def testGetReadOnlyResourceInputIndicesSorted(self):
+    """Checks that read-only resource indices are returned in sorted order."""
+    # Only import what is missing from the top of the file
+    from tensorflow.core.framework import attr_value_pb2
+    from tensorflow.python.framework import auto_control_deps_utils
+    
+    with ops.Graph().as_default():
+      # Use the 'ops' already imported at the top of the file
+      mock_op = ops.Operation(
+          node_def=None, g=ops.get_default_graph(), inputs=[], 
+          output_types=[], control_inputs=[], name="MockOp"
+      )
+      
+      # Set unsorted indices (8, 2, 4)
+      unsorted_indices = [8, 2, 4]
+      attr_value = attr_value_pb2.AttrValue(
+          list=attr_value_pb2.AttrValue.ListValue(i=unsorted_indices))
+      mock_op._set_attr("_read_only_resource_inputs", attr_value)
+
+      # Test your fix
+      result = auto_control_deps_utils._get_read_only_resource_input_indices_op(mock_op)
+
+      # Verify the result is sorted [2, 4, 8]
+      self.assertEqual(list(result), [2, 4, 8])
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/framework/auto_control_deps_test.py
+++ b/tensorflow/python/framework/auto_control_deps_test.py
@@ -950,7 +950,7 @@ class AutomaticControlDependenciesTest(test.TestCase):
           )
       )
       # Verify the result is sorted [2, 4, 8]
-      self.assertEqual(list(result), [2, 4, 8])
+      self.assertAllEqual(result, [2, 4, 8])
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/framework/auto_control_deps_test.py
+++ b/tensorflow/python/framework/auto_control_deps_test.py
@@ -944,8 +944,11 @@ class AutomaticControlDependenciesTest(test.TestCase):
       mock_op._set_attr("_read_only_resource_inputs", attr_value)
 
       # Test your fix
-      result = auto_control_deps_utils._get_read_only_resource_input_indices_op(mock_op)
-
+      result = (
+          auto_control_deps_utils._get_read_only_resource_input_indices_op(
+              mock_op
+          )
+      )
       # Verify the result is sorted [2, 4, 8]
       self.assertEqual(list(result), [2, 4, 8])
 

--- a/tensorflow/python/framework/auto_control_deps_test.py
+++ b/tensorflow/python/framework/auto_control_deps_test.py
@@ -922,7 +922,7 @@ class AutomaticControlDependenciesTest(test.TestCase):
       with self.assertRaises(ValueError):
         read_op1.get_attr("_has_manual_control_dependencies")
       with self.assertRaises(ValueError):
-        read_op2.get_attr("_has_manual_control_dependencies
+        read_op2.get_attr("_has_manual_control_dependencies")
 
   def testGetReadOnlyResourceInputIndicesSorted(self):
     """Checks that read-only resource indices are returned in sorted order."""

--- a/tensorflow/python/framework/auto_control_deps_utils.py
+++ b/tensorflow/python/framework/auto_control_deps_utils.py
@@ -62,7 +62,8 @@ def _get_read_only_resource_input_indices_op(op):
     return [i for i, t in enumerate(op.inputs) if t.dtype == dtypes.resource]
 
   try:
-    read_only_input_indices = sorted(op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
+    read_only_input_indices = sorted(
+      op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
   except ValueError:
     # Attr was not set. Add all resource inputs to `writes` and return.
     return []
@@ -102,7 +103,8 @@ def get_read_write_resource_inputs(op):
     return (reads, writes)
 
   try:
-    read_only_input_indices = sorted(op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
+    read_only_input_indices = sorted(
+      op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
   except ValueError:
     # Attr was not set. Add all resource inputs to `writes` and return.
     writes.update(t for t in op.inputs if t.dtype == dtypes.resource)
@@ -141,7 +143,8 @@ def _op_writes_to_resource(handle, op):
     return False
   input_index = _input_index(op, handle)
   try:
-    read_only_input_indices = sorted(op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
+    read_only_input_indices = sorted(
+      op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
   except ValueError:
     # Attr was not set. Conservatively assume that the resource is written to.
     return True

--- a/tensorflow/python/framework/auto_control_deps_utils.py
+++ b/tensorflow/python/framework/auto_control_deps_utils.py
@@ -63,7 +63,8 @@ def _get_read_only_resource_input_indices_op(op):
 
   try:
     read_only_input_indices = sorted(
-      op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
+      list(op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
+    )
   except ValueError:
     # Attr was not set. Add all resource inputs to `writes` and return.
     return []
@@ -104,7 +105,8 @@ def get_read_write_resource_inputs(op):
 
   try:
     read_only_input_indices = sorted(
-      op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
+      list(op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
+    )
   except ValueError:
     # Attr was not set. Add all resource inputs to `writes` and return.
     writes.update(t for t in op.inputs if t.dtype == dtypes.resource)
@@ -144,7 +146,8 @@ def _op_writes_to_resource(handle, op):
   input_index = _input_index(op, handle)
   try:
     read_only_input_indices = sorted(
-      op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
+      list(op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
+    )
   except ValueError:
     # Attr was not set. Conservatively assume that the resource is written to.
     return True

--- a/tensorflow/python/framework/auto_control_deps_utils.py
+++ b/tensorflow/python/framework/auto_control_deps_utils.py
@@ -62,7 +62,7 @@ def _get_read_only_resource_input_indices_op(op):
     return [i for i, t in enumerate(op.inputs) if t.dtype == dtypes.resource]
 
   try:
-    read_only_input_indices = op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR)
+    read_only_input_indices = sorted(op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
   except ValueError:
     # Attr was not set. Add all resource inputs to `writes` and return.
     return []
@@ -74,7 +74,7 @@ def _get_read_only_resource_input_indices_op(op):
       break
     if op.inputs[i].dtype != dtypes.resource:
       continue
-    if (read_only_index < len(read_only_input_indices) and
+    if (read_only_index < len(read_only_input_indices) and 
         i == read_only_input_indices[read_only_index]):
       result.append(i)
       read_only_index += 1
@@ -102,7 +102,7 @@ def get_read_write_resource_inputs(op):
     return (reads, writes)
 
   try:
-    read_only_input_indices = op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR)
+    read_only_input_indices = sorted(op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
   except ValueError:
     # Attr was not set. Add all resource inputs to `writes` and return.
     writes.update(t for t in op.inputs if t.dtype == dtypes.resource)
@@ -141,7 +141,7 @@ def _op_writes_to_resource(handle, op):
     return False
   input_index = _input_index(op, handle)
   try:
-    read_only_input_indices = op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR)
+    read_only_input_indices = sorted(op.get_attr(READ_ONLY_RESOURCE_INPUTS_ATTR))
   except ValueError:
     # Attr was not set. Conservatively assume that the resource is written to.
     return True


### PR DESCRIPTION
This change ensures that `_read_only_resource_inputs` attributes are sorted before processing. 

The previous logic assumed that these indices would always be provided in a sorted order. If they arrived unsorted from the backend, the categorization of resource inputs (read vs write) would fail or become inconsistent. Adding `sorted()` to the attribute retrieval fixes this logical flaw.

Fixes issue #110516.