### PR TITLE
Fix CHECK failure in MatrixDiagOp when band k=(low,high) with rank-1 diagonal inputFix CHECK failure in MatrixDiagOp when band k with rank-1 diagonal input

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/matrix_diag_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/matrix_diag_ops.cc
@@ -290,6 +290,16 @@ class MatrixDiagOp : public XlaOpKernel {
     const int64_t diag_rank = diag_shape.dims();
     const int64_t max_diag_len = diag_shape.dim_size(diag_rank - 1);
     const int64_t num_diags = upper_diag_index - lower_diag_index + 1;
+    // A band range k=(low, high) with low != high needs a diagonal-count
+    // dimension, so the diagonal must be at least 2-dim. Guard here before
+    // `diag_shape.dim_size(diag_rank - 2)` below indexes with a negative rank
+    // and CHECK-crashes during XLA compilation. See GitHub issue #110796.
+    OP_REQUIRES(
+        context, num_diags == 1 || diag_rank >= 2,
+        errors::InvalidArgument(
+            "diagonal must be at least 2-dim when a band range k=(low, high) "
+            "with low != high is given, but received shape: ",
+            diag_shape.DebugString()));
     OP_REQUIRES(
         context,
         num_diags == 1 || num_diags == diag_shape.dim_size(diag_rank - 2),

--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -1669,6 +1669,16 @@ absl::Status MatrixDiagV2Shape(shape_inference::InferenceContext* c) {
   // Checks if the number of diagonals provided matches what we imply from
   // lower_diag_index and upper_diag_index.
   const int32_t input_rank = c->Rank(input_shape);
+  // A band range k=(low, high) with low != high needs a diagonal-count
+  // dimension, so the diagonal must be at least 2-dim. Reject a rank-1 diagonal
+  // here at graph-construction time; otherwise `input_rank - 2` underflows below
+  // and yields a confusing (or crashing) shape error. See GitHub issue #110796.
+  if (lower_diag_index < upper_diag_index && input_rank < 2) {
+    return errors::InvalidArgument(
+        "diagonal must be at least 2-dim when a band range k=(low, high) "
+        "with low != high is given, but received shape: ",
+        c->DebugString(input_shape));
+  }
   if (lower_diag_index < upper_diag_index) {
     const int32_t num_diags = c->Value(c->Dim(input_shape, input_rank - 2));
     const int32_t other_dim = c->Value(c->Dim(input_shape, input_rank - 1));

--- a/tensorflow/core/kernels/linalg/matrix_diag_op.cc
+++ b/tensorflow/core/kernels/linalg/matrix_diag_op.cc
@@ -232,6 +232,12 @@ class MatrixDiagOp : public OpKernel {
                     "diagonal must be at least 1-dim, received shape: ",
                     diagonal.shape().DebugString()));
     OP_REQUIRES(
+        context, num_diags == 1 || diag_rank >= 2,
+        errors::InvalidArgument(
+            "diagonal must be at least 2-dim when a band range k=(low, high) "
+            "with low != high is given, but received shape: ",
+            diagonal.shape().DebugString()));
+    OP_REQUIRES(
         context, lower_diag_index <= upper_diag_index,
         errors::InvalidArgument(
             "lower_diag_index must not be larger than upper_diag_index: ",

--- a/tensorflow/python/kernel_tests/array_ops/diag_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/diag_op_test.py
@@ -546,6 +546,19 @@ class MatrixDiagTest(test.TestCase):
       with self.assertRaisesOpError("diagonal must be at least 1-dim"):
         array_ops.matrix_diag(v).eval(feed_dict={v: 0.0})
 
+  def testInvalidBandShapeAtEval(self):
+    # Regression test for GitHub issue #110796:
+    # tf.linalg.diag with a band k=(low, high) (low != high) requires the
+    # diagonal to be at least 2D.  Previously this aborted with a C++ CHECK
+    # failure inside tensor_shape.cc; it should now raise InvalidArgumentError.
+    with self.assertRaisesOpError(
+        "diagonal must be at least 2-dim when a band range"):
+      array_ops.matrix_diag(
+          constant_op.constant([1.0, 2.0, 3.0, 4.0]),
+          k=(-2, 1),
+          align="RIGHT_LEFT",
+      )
+
   @test_util.run_deprecated_v1
   def testGrad(self):
     shapes = ((3,), (7, 4))

--- a/tensorflow/python/kernel_tests/array_ops/diag_op_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/diag_op_test.py
@@ -559,6 +559,17 @@ class MatrixDiagTest(test.TestCase):
           align="RIGHT_LEFT",
       )
 
+  def testInvalidBandShape(self):
+    # Regression test for GitHub issue #110796 (rank-1 diagonal):
+    # tf.linalg.diag with a band k=(low, high) (low != high) must reject a
+    # rank-1 diagonal with InvalidArgumentError instead of crashing with a
+    # C++ CHECK failure.
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError),
+        "diagonal must be at least 2-dim when a band range"):
+      array_ops.matrix_diag(
+          constant_op.constant([1.0, 2.0, 3.0, 4.0]), k=(-2, 1))
+
   @test_util.run_deprecated_v1
   def testGrad(self):
     shapes = ((3,), (7, 4))


### PR DESCRIPTION
## Description

Fixes #110796

When `tf.linalg.diag` is called with a **band specification** `k=(low, high)` where `low != high` (`num_diags > 1`), but the diagonal input is **rank-1**, the op previously aborted the Python process with a C++ `CHECK` failure:

```
F0000 tensor_shape.cc:589] Check failed: d >= 0 (-1 vs. 0)
```

### Root Cause

In `MatrixDiagOp::Compute`, when building the output shape for a band output:

```cpp
} else {  // Output has rank `rank`
    output_shape.set_dim(diag_rank - 2, num_rows);  // ← CRASH when diag_rank==1
    output_shape.set_dim(diag_rank - 1, num_cols);
}
```

For a rank-1 diagonal, `diag_rank - 2 = -1`, which violates the `CHECK(d >= 0)` assertion inside `TensorShapeBase::set_dim`.

### Fix

Add an `OP_REQUIRES` guard in `MatrixDiagOp::Compute` that validates the diagonal tensor is at least 2-D when `num_diags > 1`. This converts the hard abort into a clean Python `InvalidArgumentError`.

### Changes

- `tensorflow/core/kernels/linalg/matrix_diag_op.cc`: Add `OP_REQUIRES` validation
- `tensorflow/python/kernel_tests/array_ops/diag_op_test.py`: Add `testInvalidBandShapeAtEval` regression test

### To reproduce (before fix):
```python
import tensorflow as tf

@tf.function
def f(x):
    return tf.linalg.diag(x, k=(-2, 1), align="RIGHT_LEFT")

x = tf.constant([1.0, 2.0, 3.0, 4.0])
f(x)  # Aborted (core dumped)
```

### After fix:
```
InvalidArgumentError: diagonal must be at least 2-dim when a band range k=(low, high) with low != high is given, but received shape: [4]
```