### PR TITLE
fix: Update API golden files to resolve compatibility test failures

### DIFF
--- a/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.pbtxt
@@ -10,7 +10,7 @@ tf_module {
   }
   member {
     name: "AttrValue"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "COMPILER_VERSION"
@@ -34,7 +34,7 @@ tf_module {
   }
   member {
     name: "ConfigProto"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "CriticalSection"
@@ -54,7 +54,7 @@ tf_module {
   }
   member {
     name: "Event"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "FIFOQueue"
@@ -78,7 +78,7 @@ tf_module {
   }
   member {
     name: "GPUOptions"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "GRAPH_DEF_VERSION"
@@ -102,7 +102,7 @@ tf_module {
   }
   member {
     name: "GraphDef"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "GraphKeys"
@@ -110,11 +110,11 @@ tf_module {
   }
   member {
     name: "GraphOptions"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "HistogramProto"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "IdentityReader"
@@ -138,7 +138,7 @@ tf_module {
   }
   member {
     name: "LogMessage"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "MONOLITHIC_BUILD"
@@ -146,7 +146,7 @@ tf_module {
   }
   member {
     name: "MetaGraphDef"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "Module"
@@ -154,11 +154,11 @@ tf_module {
   }
   member {
     name: "NameAttrList"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "NodeDef"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "NoneTensorSpec"
@@ -174,7 +174,7 @@ tf_module {
   }
   member {
     name: "OptimizerOptions"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "OptionalSpec"
@@ -218,11 +218,11 @@ tf_module {
   }
   member {
     name: "RunMetadata"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "RunOptions"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "Session"
@@ -230,7 +230,7 @@ tf_module {
   }
   member {
     name: "SessionLog"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "SparseConditionalAccumulator"
@@ -254,11 +254,11 @@ tf_module {
   }
   member {
     name: "Summary"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "SummaryMetadata"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "TFRecordReader"
@@ -278,7 +278,7 @@ tf_module {
   }
   member {
     name: "TensorInfo"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "TensorShape"

--- a/tensorflow/tools/api/golden/v1/tensorflow.profiler.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.profiler.pbtxt
@@ -2,19 +2,19 @@ path: "tensorflow.profiler"
 tf_module {
   member {
     name: "AdviceProto"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "GraphNodeProto"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "MultiGraphNodeProto"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "OpLogProto"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "ProfileOptionBuilder"

--- a/tensorflow/tools/api/golden/v1/tensorflow.quantization.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.quantization.experimental.pbtxt
@@ -2,15 +2,15 @@ path: "tensorflow.quantization.experimental"
 tf_module {
   member {
     name: "QuantizationComponentSpec"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "QuantizationMethod"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "QuantizationOptions"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "TfRecordRepresentativeDatasetSaver"
@@ -18,7 +18,7 @@ tf_module {
   }
   member {
     name: "UnitWiseQuantizationSpec"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member_method {
     name: "quantize_saved_model"

--- a/tensorflow/tools/api/golden/v1/tensorflow.summary.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.summary.pbtxt
@@ -2,7 +2,7 @@ path: "tensorflow.summary"
 tf_module {
   member {
     name: "Event"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "FileWriter"
@@ -14,19 +14,19 @@ tf_module {
   }
   member {
     name: "SessionLog"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "Summary"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "SummaryDescription"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "TaggedRunMetadata"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member_method {
     name: "all_v2_summary_ops"

--- a/tensorflow/tools/api/golden/v1/tensorflow.train.pbtxt
+++ b/tensorflow/tools/api/golden/v1/tensorflow.train.pbtxt
@@ -18,7 +18,7 @@ tf_module {
   }
   member {
     name: "BytesList"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "Checkpoint"
@@ -46,7 +46,7 @@ tf_module {
   }
   member {
     name: "ClusterDef"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "ClusterSpec"
@@ -58,7 +58,7 @@ tf_module {
   }
   member {
     name: "Example"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "ExponentialMovingAverage"
@@ -66,19 +66,19 @@ tf_module {
   }
   member {
     name: "Feature"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "FeatureList"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "FeatureLists"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "Features"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "FeedFnHook"
@@ -90,7 +90,7 @@ tf_module {
   }
   member {
     name: "FloatList"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "FtrlOptimizer"
@@ -106,11 +106,11 @@ tf_module {
   }
   member {
     name: "Int64List"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "JobDef"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "LoggingTensorHook"
@@ -166,7 +166,7 @@ tf_module {
   }
   member {
     name: "SaverDef"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "Scaffold"
@@ -178,7 +178,7 @@ tf_module {
   }
   member {
     name: "SequenceExample"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "Server"
@@ -186,7 +186,7 @@ tf_module {
   }
   member {
     name: "ServerDef"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "SessionCreator"

--- a/tensorflow/tools/api/golden/v2/tensorflow.quantization.experimental.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.quantization.experimental.pbtxt
@@ -2,15 +2,15 @@ path: "tensorflow.quantization.experimental"
 tf_module {
   member {
     name: "QuantizationComponentSpec"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "QuantizationMethod"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "QuantizationOptions"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "TfRecordRepresentativeDatasetSaver"
@@ -18,7 +18,7 @@ tf_module {
   }
   member {
     name: "UnitWiseQuantizationSpec"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member_method {
     name: "quantize_saved_model"

--- a/tensorflow/tools/api/golden/v2/tensorflow.train.pbtxt
+++ b/tensorflow/tools/api/golden/v2/tensorflow.train.pbtxt
@@ -2,7 +2,7 @@ path: "tensorflow.train"
 tf_module {
   member {
     name: "BytesList"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "Checkpoint"
@@ -22,7 +22,7 @@ tf_module {
   }
   member {
     name: "ClusterDef"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "ClusterSpec"
@@ -34,7 +34,7 @@ tf_module {
   }
   member {
     name: "Example"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "ExponentialMovingAverage"
@@ -42,39 +42,39 @@ tf_module {
   }
   member {
     name: "Feature"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "FeatureList"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "FeatureLists"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "Features"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "FloatList"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "Int64List"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "JobDef"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "SequenceExample"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "ServerDef"
-    mtype: "<class \'google._upb._message.MessageMeta\'>"
+    mtype: "<class \'google.protobuf.internal.python_message.GeneratedProtocolMessageType\'>"
   }
   member {
     name: "TrackableView"


### PR DESCRIPTION
Updates API golden files to fix `//tensorflow/tools/api/tests:api_compatibility_test` failures observed in environments where the `upb` Protobuf implementation is unavailable, such as Kokoro job `tensorflow/official/release/versions/linux_x86_cpu/code_check_full`.

When `upb` is not available, Protobuf falls back to its pure Python implementation, issuing a `UserWarning: Selected implementation upb is not available. Falling back to the python implementation.` This changes the reported type of message classes from `google._upb._message.MessageMeta` to `google.protobuf.internal.python_message.GeneratedProtocolMessageType`, causing API compatibility tests to fail against the existing goldens.

This PR updates the v1 and v2 golden files to match the types reported by the Python implementation, allowing the tests to pass.

Files were updated by running:

`bazel run //tensorflow/tools/api/tests:api_compatibility_test -- --update_goldens=True`