### PR TITLE
fix: replace 38 bare except clauses with except Exception

### DIFF
--- a/tensorflow/core/function/trace_type/trace_type_builder.py
+++ b/tensorflow/core/function/trace_type/trace_type_builder.py
@@ -201,7 +201,7 @@ def from_value(value: Any,
   except TypeError:
     try:
       return default_types.Literal(value)
-    except:
+    except Exception:
       raise TypeError(  # pylint: disable=raise-missing-from
           f"Could not generate a generic TraceType for {value!r}."
           f"Please verify that it is immutable/hashable. Otherwise, consider "

--- a/tensorflow/examples/speech_commands/input_data.py
+++ b/tensorflow/examples/speech_commands/input_data.py
@@ -226,7 +226,7 @@ class AudioProcessor(object):
 
       try:
         filepath, _ = urllib.request.urlretrieve(data_url, filepath, _progress)
-      except:
+      except Exception:
         tf.compat.v1.logging.error(
             'Failed to download URL: {0} to folder: {1}. Please make sure you '
             'have enough free space and an internet connection'.format(

--- a/tensorflow/lite/python/metrics/metrics_nonportable_test.py
+++ b/tensorflow/lite/python/metrics/metrics_nonportable_test.py
@@ -76,7 +76,7 @@ class MetricsNonportableTest(test_util.TensorFlowTestCase):
       gc.collect()
       stub2.increase_counter_debugger_creation()
       self.assertEqual(metrics._counter_debugger_creation.get_cell().value(), 3)
-    except:
+    except Exception:
       raise Exception('No exception should be raised.')
 
   def test_interpreter_creation_counter_increase_success(self):

--- a/tensorflow/python/autograph/converters/return_statements.py
+++ b/tensorflow/python/autograph/converters/return_statements.py
@@ -235,7 +235,7 @@ class ReturnStatementsTransformer(converter.Base):
       try:
         do_return_var_name = True
         retval_var_name = retval
-      except:
+      except Exception:
         do_return_var_name = False
         raise
     """

--- a/tensorflow/python/autograph/pyct/cfg.py
+++ b/tensorflow/python/autograph/pyct/cfg.py
@@ -696,7 +696,7 @@ class AstToCfg(gast.NodeVisitor):
 
     node = self.builder.add_exit_node(node, try_node, guards)
 
-    if may_exit_via_except:
+    if may_exit_via_except Exception:
       except_guards = self._get_enclosing_except_scopes(exits_nodes_of_type)
       self.builder.connect_raise_node(node, except_guards)
 

--- a/tensorflow/python/compiler/tensorrt/model_tests/model_handler.py
+++ b/tensorflow/python/compiler/tensorrt/model_tests/model_handler.py
@@ -337,7 +337,7 @@ class ModelHandlerV2(_ModelHandlerBase):
   def graph_func(self):
     try:
       return self._graph_func
-    except:
+    except Exception:
       graph_func = load_graph_func(
           saved_model_dir=self.model_config.saved_model_dir,
           saved_model_tags=self.model_config.saved_model_tags,

--- a/tensorflow/python/compiler/tensorrt/trt_convert.py
+++ b/tensorflow/python/compiler/tensorrt/trt_convert.py
@@ -799,7 +799,7 @@ class TrtGraphConverter(object):
             proto.ParseFromString(value)
             try:
               new_value = from_proto(proto, import_scope=scope)
-            except:
+            except Exception:
               continue
             dest_graph.add_to_collection(key, new_value)
         else:
@@ -1065,7 +1065,7 @@ def _convert_to_tensor(inp):
         args = map(ops.convert_to_tensor, inp)
       else:
         args = [ops.convert_to_tensor(inp)]
-  except:
+  except Exception:
     error_msg = "Failed to convert input to tensor."
     logging.error(error_msg + "\ninp = `{0}`\n".format(inp))
     raise RuntimeError(error_msg)

--- a/tensorflow/python/data/experimental/kernel_tests/service/fault_tolerance_test.py
+++ b/tensorflow/python/data/experimental/kernel_tests/service/fault_tolerance_test.py
@@ -188,7 +188,7 @@ class FaultToleranceTest(data_service_test_base.TestBase,
     try:
       import portpicker  # pylint: disable=g-import-not-at-top
       dispatcher_port = portpicker.pick_unused_port()
-    except:
+    except Exception:
       raise self.skipTest("Flakes in portpicker library do not represent "
                           "TensorFlow errors.")
     cluster = data_service_test_base.TestCluster(

--- a/tensorflow/python/eager/context_test.py
+++ b/tensorflow/python/eager/context_test.py
@@ -56,7 +56,7 @@ class ContextTest(test.TestCase, parameterized.TestCase):
       # from tensors created from Python.
       tensor2 = tensor1 * tensor1
       context._set_context(original_context)
-    except:
+    except Exception:
       context._set_context(original_context)
       raise
 

--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -528,7 +528,7 @@ def get_visible_devices(device_type=None):
   ...   visible_devices = tf.config.get_visible_devices()
   ...   for device in visible_devices:
   ...     assert device.device_type != 'GPU'
-  ... except:
+  ... except Exception:
   ...   # Invalid device or cannot modify virtual devices once initialized.
   ...   pass
 
@@ -562,7 +562,7 @@ def set_visible_devices(devices, device_type=None):
   ...   logical_devices = tf.config.list_logical_devices('GPU')
   ...   # Logical device was not created for first GPU
   ...   assert len(logical_devices) == len(physical_devices) - 1
-  ... except:
+  ... except Exception:
   ...   # Invalid device or cannot modify virtual devices once initialized.
   ...   pass
 
@@ -722,7 +722,7 @@ def get_memory_growth(device):
   >>> try:
   ...   tf.config.experimental.set_memory_growth(physical_devices[0], True)
   ...   assert tf.config.experimental.get_memory_growth(physical_devices[0])
-  ... except:
+  ... except Exception:
   ...   # Invalid device or cannot modify virtual devices once initialized.
   ...   pass
 
@@ -751,7 +751,7 @@ def set_memory_growth(device, enable):
   >>> physical_devices = tf.config.list_physical_devices('GPU')
   >>> try:
   ...   tf.config.experimental.set_memory_growth(physical_devices[0], True)
-  ... except:
+  ... except Exception:
   ...   # Invalid device or cannot modify virtual devices once initialized.
   ...   pass
 
@@ -837,7 +837,7 @@ def get_logical_device_configuration(device):
   ...   configs = tf.config.get_logical_device_configuration(
   ...     physical_devices[0])
   ...   assert len(configs) == 2
-  ... except:
+  ... except Exception:
   ...   # Cannot modify virtual devices once initialized.
   ...   pass
 
@@ -887,7 +887,7 @@ def set_logical_device_configuration(device, logical_devices):
   ...      tf.config.LogicalDeviceConfiguration(),
   ...      tf.config.LogicalDeviceConfiguration(),
   ...      tf.config.LogicalDeviceConfiguration()])
-  ... except:
+  ... except Exception:
   ...   # Cannot modify logical devices once initialized.
   ...   pass
 
@@ -907,7 +907,7 @@ def set_logical_device_configuration(device, logical_devices):
   ...     physical_devices[0],
   ...     [tf.config.LogicalDeviceConfiguration(memory_limit=10),
   ...      tf.config.LogicalDeviceConfiguration(memory_limit=10)])
-  ... except:
+  ... except Exception:
   ...   # Invalid device or cannot modify logical devices once initialized.
   ...   pass
 

--- a/tensorflow/python/framework/dtypes.py
+++ b/tensorflow/python/framework/dtypes.py
@@ -144,7 +144,7 @@ class DType(
     except:  # bare except as possible raises by finfo not documented
       try:
         return ml_dtypes.iinfo(self.as_numpy_dtype).min
-      except:
+      except Exception:
         raise TypeError(f"Cannot find minimum value of {self}.")
 
   @property
@@ -168,7 +168,7 @@ class DType(
     except:  # bare except as possible raises by finfo not documented
       try:
         return ml_dtypes.iinfo(self.as_numpy_dtype).max
-      except:
+      except Exception:
         raise TypeError(f"Cannot find maximum value of {self}.")
 
   @property

--- a/tensorflow/python/framework/errors_test.py
+++ b/tensorflow/python/framework/errors_test.py
@@ -110,7 +110,7 @@ class ErrorsTest(test.TestCase):
   def testStatusDoesNotLeak(self):
     try:
       _pywrap_file_io.DeleteFile(compat.as_bytes("/DOES_NOT_EXIST/"))
-    except:
+    except Exception:
       pass
     gc.collect()
     self.assertEqual(0, self._CountReferences(c_api_util.ScopedTFStatus))

--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -2961,7 +2961,7 @@ class Graph(pywrap_tf_session.PyGraph):
         try:
           op_name, out_n = name.split(":")
           out_n = int(out_n)
-        except:
+        except Exception:
           raise ValueError("The name %s looks a like a Tensor name, but is "
                            "not a valid one. Tensor names must be of the "
                            "form \"<op_name>:<output_index>\"." % repr(name))
@@ -2976,7 +2976,7 @@ class Graph(pywrap_tf_session.PyGraph):
 
         try:
           return op.outputs[out_n]
-        except:
+        except Exception:
           raise KeyError("The name %s refers to a Tensor which does not "
                          "exist. The operation, %s, exists but only has "
                          "%s outputs." %
@@ -5642,7 +5642,7 @@ class internal_name_scope_v1(contextlib.AbstractContextManager[str]):  # pylint:
     try:
       self._name_scope = g.name_scope(self._name)
       return self._name_scope.__enter__()
-    except:
+    except Exception:
       if self._g_manager is not None:
         self._g_manager.__exit__(*sys.exc_info())
       raise

--- a/tensorflow/python/keras/callbacks.py
+++ b/tensorflow/python/keras/callbacks.py
@@ -1623,7 +1623,7 @@ class BackupAndRestore(Callback):
   ...   model.fit(np.arange(100).reshape(5, 20), np.zeros(5), epochs=10,
   ...             batch_size=1, callbacks=[callback, InterruptingCallback()],
   ...             verbose=0)
-  ... except:
+  ... except Exception:
   ...   pass
   >>> history = model.fit(np.arange(100).reshape(5, 20), np.zeros(5), epochs=10,
   ...             batch_size=1, callbacks=[callback], verbose=0)

--- a/tensorflow/python/keras/utils/tf_inspect.py
+++ b/tensorflow/python/keras/utils/tf_inspect.py
@@ -22,7 +22,7 @@ from tensorflow.python.util import tf_decorator
 
 try:
   ArgSpec = _inspect.ArgSpec
-except:
+except Exception:
   pass
 
 

--- a/tensorflow/python/ops/check_ops.py
+++ b/tensorflow/python/ops/check_ops.py
@@ -1654,7 +1654,7 @@ def assert_shapes_v2(shapes, data=None, summarize=None, message=None,
   `InvalidArgumentError` is raised.
 
   Size entries in the specified shapes are checked against other entries by
-  their __hash__, except:
+  their __hash__, except Exception:
     - a size entry is interpreted as an explicit size if it can be parsed as an
       integer primitive.
     - a size entry is interpreted as *any* size if it is None or '.'.
@@ -1727,7 +1727,7 @@ def assert_shapes(shapes, data=None, summarize=None, message=None, name=None):
   `InvalidArgumentError` is raised.
 
   Size entries in the specified shapes are checked against other entries by
-  their __hash__, except:
+  their __hash__, except Exception:
     - a size entry is interpreted as an explicit size if it can be parsed as an
       integer primitive.
     - a size entry is interpreted as *any* size if it is None or '.'.

--- a/tensorflow/python/ops/parsing_ops.py
+++ b/tensorflow/python/ops/parsing_ops.py
@@ -372,7 +372,7 @@ def _parse_example_raw(serialized, names, params, name):
 def parse_single_example(serialized, features, name=None, example_names=None):
   """Parses a single `Example` proto.
 
-  Similar to `parse_example`, except:
+  Similar to `parse_example`, except Exception:
 
   For dense tensors, the returned `Tensor` is identical to the output of
   `parse_example`, except there is no batch dimension, the output shape is the
@@ -409,7 +409,7 @@ def parse_single_example_v2(
     ):
   """Parses a single `Example` proto.
 
-  Similar to `parse_example`, except:
+  Similar to `parse_example`, except Exception:
 
   For dense tensors, the returned `Tensor` is identical to the output of
   `parse_example`, except there is no batch dimension, the output shape is the

--- a/tensorflow/python/ops/template.py
+++ b/tensorflow/python/ops/template.py
@@ -366,7 +366,7 @@ class Template(trackable.Trackable):
           # Trackable).
           with trackable_util.capture_dependencies(template=self):
             result = self._func(*args, **kwargs)
-        except:
+        except Exception:
           self._first_call = True
           raise
         self._variables_created = True

--- a/tensorflow/python/ops/variable_scope.py
+++ b/tensorflow/python/ops/variable_scope.py
@@ -2387,7 +2387,7 @@ class variable_scope:
 
     try:
       return self._enter_scope_uncached()
-    except:
+    except Exception:
       if (self._in_graph_mode and not self._building_function and
           self._graph_context_manager is not None):
         self._graph_context_manager.__exit__(*sys.exc_info())
@@ -2432,7 +2432,7 @@ class variable_scope:
             name_scope, skip_on_eager=False)
         try:
           current_name_scope_name = current_name_scope.__enter__()
-        except:
+        except Exception:
           current_name_scope.__exit__(*sys.exc_info())
           raise
         self._current_name_scope = current_name_scope
@@ -2454,7 +2454,7 @@ class variable_scope:
             constraint=self._constraint)
         try:
           entered_pure_variable_scope = pure_variable_scope.__enter__()
-        except:
+        except Exception:
           pure_variable_scope.__exit__(*sys.exc_info())
           raise
         self._cached_pure_variable_scope = pure_variable_scope
@@ -2475,7 +2475,7 @@ class variable_scope:
             constraint=self._constraint)
         try:
           entered_pure_variable_scope = pure_variable_scope.__enter__()
-        except:
+        except Exception:
           pure_variable_scope.__exit__(*sys.exc_info())
           raise
         self._cached_pure_variable_scope = pure_variable_scope
@@ -2488,7 +2488,7 @@ class variable_scope:
           self._default_name, skip_on_eager=False)
       try:
         current_name_scope_name = current_name_scope.__enter__()
-      except:
+      except Exception:
         current_name_scope.__exit__(*sys.exc_info())
         raise
       self._current_name_scope = current_name_scope
@@ -2506,7 +2506,7 @@ class variable_scope:
           constraint=self._constraint)
       try:
         entered_pure_variable_scope = pure_variable_scope.__enter__()
-      except:
+      except Exception:
         pure_variable_scope.__exit__(*sys.exc_info())
         raise
       self._cached_pure_variable_scope = pure_variable_scope

--- a/tensorflow/python/training/coordinator.py
+++ b/tensorflow/python/training/coordinator.py
@@ -282,7 +282,7 @@ class Coordinator:
     ```python
     try:
       ...body...
-    except:
+    except Exception:
       coord.request_stop(sys.exc_info())
     ```
 

--- a/third_party/xla/third_party/gpus/find_sycl_config.py
+++ b/third_party/xla/third_party/gpus/find_sycl_config.py
@@ -51,7 +51,7 @@ def _get_basekit_path():
 def _get_basekit_version():
   try:
     version = _get_toolkit_path().split("/compiler/")[1].split("/")[0]
-  except:
+  except Exception:
     version = "unknown"
   return version
 


### PR DESCRIPTION
## What
Replace 38 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.