### PR TITLE
Added check to ensure input ranks are the same in kernel TridiagonalSolveOpGpu

### DIFF
--- a/tensorflow/core/kernels/linalg/tridiagonal_solve_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/linalg/tridiagonal_solve_op_gpu.cu.cc
@@ -253,6 +253,9 @@ class TridiagonalSolveOpGpu : public OpKernel {
     const Tensor& lhs = context->input(0);
     const Tensor& rhs = context->input(1);
     const int ndims = lhs.dims();
+    OP_REQUIRES(context, rhs.dims() == ndims,
+                errors::InvalidArgument("Input ranks must be the same.  Got ",
+                                        ndims, " vs ", rhs.dims()));
     const int64_t num_rhs = rhs.dim_size(rhs.dims() - 1);
     const int64_t matrix_size = lhs.dim_size(ndims - 1);
     int64_t batch_size = 1;


### PR DESCRIPTION
This code prevents a nullptr deref and OOB read on GPU kernel pcrGtsvBatchFirstPass.
Fixes #111069 