### PR TITLE
Fix model.fit() crash with unknown TensorShape from numpy_function

### DIFF
--- a/tensorflow/python/keras/engine/BUILD
+++ b/tensorflow/python/keras/engine/BUILD
@@ -1,8 +1,8 @@
 # Description:
 #   Contains the Keras engine API (internal TensorFlow version).
 
-load("//tensorflow:tensorflow.bzl", "tf_py_test")
 load("@xla//third_party/rules_python/python:defs.bzl", "py_library")
+load("//tensorflow:tensorflow.bzl", "tf_py_test")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],

--- a/tensorflow/python/keras/engine/BUILD
+++ b/tensorflow/python/keras/engine/BUILD
@@ -1,6 +1,7 @@
 # Description:
 #   Contains the Keras engine API (internal TensorFlow version).
 
+load("//tensorflow:tensorflow.bzl", "tf_py_test")
 load("@xla//third_party/rules_python/python:defs.bzl", "py_library")
 
 package(
@@ -263,5 +264,19 @@ py_library(
         "//tensorflow/python/keras/utils:tf_utils",
         "//tensorflow/python/util:nest",
         "//third_party/py/numpy",
+    ],
+)
+
+tf_py_test(
+    name = "compile_utils_test",
+    size = "medium",
+    srcs = ["compile_utils_test.py"],
+    python_version = "PY3",
+    deps = [
+        ":engine",
+        ":input_spec",
+        "//tensorflow:tensorflow_py",
+        "//tensorflow/python/framework:tensor_shape",
+        "//tensorflow/python/platform:client_testlib",
     ],
 )

--- a/tensorflow/python/keras/engine/compile_utils.py
+++ b/tensorflow/python/keras/engine/compile_utils.py
@@ -503,6 +503,16 @@ class MetricsContainer(Container):
     if str(metric).lower() not in ['accuracy', 'acc', 'crossentropy', 'ce']:
       metric_obj = metrics_mod.get(metric)
     else:
+      if y_t.shape.rank is None or y_p.shape.rank is None:
+        raise ValueError(
+            'Unable to auto-select a metric for inputs with unknown shapes. '
+            'The label shape is %s and the prediction shape is %s. '
+            'When using `tf.numpy_function` or other ops that produce '
+            'tensors with unknown shapes, you must set the shape using '
+            '`tensor.set_shape()` or `tf.ensure_shape()` before passing '
+            'the dataset to `model.fit()`. Alternatively, pass an '
+            'explicit metric object instead of a string like "accuracy".'
+            % (y_t.shape, y_p.shape))
       y_t_rank = len(y_t.shape.as_list())
       y_p_rank = len(y_p.shape.as_list())
       y_t_last_dim = y_t.shape.as_list()[-1]

--- a/tensorflow/python/keras/engine/compile_utils_test.py
+++ b/tensorflow/python/keras/engine/compile_utils_test.py
@@ -14,8 +14,6 @@
 # ==============================================================================
 """Tests for compile_utils."""
 
-import numpy as np
-
 import tensorflow as tf
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.keras.engine import compile_utils
@@ -24,48 +22,45 @@ from tensorflow.python.platform import test as test_lib
 
 class MetricsContainerTest(test_lib.TestCase):
 
-    def test_unknown_shape_raises_clear_error(self):
-        """Metric auto-selection raises a clear error for unknown shapes.
+  def test_unknown_shape_raises_clear_error(self):
+    """Metric auto-selection raises a clear error for unknown shapes.
 
-        When dataset elements come from tf.numpy_function without set_shape(),
-        shapes are unknown. The error message should guide the user to set
-        shapes or use an explicit metric object.
-        """
-        container = compile_utils.MetricsContainer(metrics=['accuracy'])
+    When dataset elements come from tf.numpy_function without set_shape(),
+    shapes are unknown. The error message should guide the user to set
+    shapes or use an explicit metric object.
+    """
+    container = compile_utils.MetricsContainer(metrics=['accuracy'])
 
-        # Create a placeholder-like tensor with completely unknown shape.
-        # This simulates the output of tf.numpy_function without set_shape().
-        y_t_spec = tf.TensorSpec(shape=None, dtype=tf.float32)
-        y_p_spec = tf.TensorSpec(shape=None, dtype=tf.float32)
+    y_t_spec = tf.TensorSpec(shape=None, dtype=tf.float32)
+    y_p_spec = tf.TensorSpec(shape=None, dtype=tf.float32)
 
-        @tf.function(input_signature=[y_t_spec, y_p_spec])
-        def call_get_metric(y_true, y_pred):
-            container._get_metric_object('accuracy', y_true, y_pred)
-            return tf.constant(0.0)
+    @tf.function(input_signature=[y_t_spec, y_p_spec])
+    def call_get_metric(y_true, y_pred):
+      container._get_metric_object('accuracy', y_true, y_pred)
+      return tf.constant(0.0)
 
-        with self.assertRaisesRegex(ValueError, 'unknown shapes'):
-            call_get_metric(
-                tf.constant([1.0, 0.0]),
-                tf.constant([0.9, 0.1]))
+    with self.assertRaisesRegex(ValueError, 'unknown shapes'):
+      call_get_metric(
+          tf.constant([1.0, 0.0]),
+          tf.constant([0.9, 0.1]))
 
 
 class DisplayShapeTest(test_lib.TestCase):
 
-    def test_display_shape_unknown_rank(self):
-        """display_shape should handle unknown-rank shapes gracefully."""
-        from tensorflow.python.keras.engine import input_spec
-        unknown_shape = tensor_shape.TensorShape(None)
-        result = input_spec.display_shape(unknown_shape)
-        # Should not raise, should return a string representation
-        self.assertIsInstance(result, str)
+  def test_display_shape_unknown_rank(self):
+    """display_shape should handle unknown-rank shapes gracefully."""
+    from tensorflow.python.keras.engine import input_spec  # pylint: disable=g-import-not-at-top
+    unknown_shape = tensor_shape.TensorShape(None)
+    result = input_spec.display_shape(unknown_shape)
+    self.assertIsInstance(result, str)
 
-    def test_display_shape_known_rank(self):
-        """display_shape works normally for known-rank shapes."""
-        from tensorflow.python.keras.engine import input_spec
-        known_shape = tensor_shape.TensorShape([2, 3])
-        result = input_spec.display_shape(known_shape)
-        self.assertEqual(result, '(2, 3)')
+  def test_display_shape_known_rank(self):
+    """display_shape works normally for known-rank shapes."""
+    from tensorflow.python.keras.engine import input_spec  # pylint: disable=g-import-not-at-top
+    known_shape = tensor_shape.TensorShape([2, 3])
+    result = input_spec.display_shape(known_shape)
+    self.assertEqual(result, '(2, 3)')
 
 
 if __name__ == '__main__':
-    test_lib.main()
+  test_lib.main()

--- a/tensorflow/python/keras/engine/compile_utils_test.py
+++ b/tensorflow/python/keras/engine/compile_utils_test.py
@@ -1,0 +1,71 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for compile_utils."""
+
+import numpy as np
+
+import tensorflow as tf
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.keras.engine import compile_utils
+from tensorflow.python.platform import test as test_lib
+
+
+class MetricsContainerTest(test_lib.TestCase):
+
+    def test_unknown_shape_raises_clear_error(self):
+        """Metric auto-selection raises a clear error for unknown shapes.
+
+        When dataset elements come from tf.numpy_function without set_shape(),
+        shapes are unknown. The error message should guide the user to set
+        shapes or use an explicit metric object.
+        """
+        container = compile_utils.MetricsContainer(metrics=['accuracy'])
+
+        # Create a placeholder-like tensor with completely unknown shape.
+        # This simulates the output of tf.numpy_function without set_shape().
+        y_t_spec = tf.TensorSpec(shape=None, dtype=tf.float32)
+        y_p_spec = tf.TensorSpec(shape=None, dtype=tf.float32)
+
+        @tf.function(input_signature=[y_t_spec, y_p_spec])
+        def call_get_metric(y_true, y_pred):
+            container._get_metric_object('accuracy', y_true, y_pred)
+            return tf.constant(0.0)
+
+        with self.assertRaisesRegex(ValueError, 'unknown shapes'):
+            call_get_metric(
+                tf.constant([1.0, 0.0]),
+                tf.constant([0.9, 0.1]))
+
+
+class DisplayShapeTest(test_lib.TestCase):
+
+    def test_display_shape_unknown_rank(self):
+        """display_shape should handle unknown-rank shapes gracefully."""
+        from tensorflow.python.keras.engine import input_spec
+        unknown_shape = tensor_shape.TensorShape(None)
+        result = input_spec.display_shape(unknown_shape)
+        # Should not raise, should return a string representation
+        self.assertIsInstance(result, str)
+
+    def test_display_shape_known_rank(self):
+        """display_shape works normally for known-rank shapes."""
+        from tensorflow.python.keras.engine import input_spec
+        known_shape = tensor_shape.TensorShape([2, 3])
+        result = input_spec.display_shape(known_shape)
+        self.assertEqual(result, '(2, 3)')
+
+
+if __name__ == '__main__':
+    test_lib.main()

--- a/tensorflow/python/keras/engine/input_spec.py
+++ b/tensorflow/python/keras/engine/input_spec.py
@@ -269,6 +269,8 @@ def assert_input_compatibility(input_spec, inputs, layer_name):
 
 
 def display_shape(shape):
+  if shape.rank is None:
+    return str(shape)
   return str(tuple(shape.as_list()))
 
 


### PR DESCRIPTION
Fixes ValueError: as_list() is not defined on an unknown TensorShape crash when model.fit() receives dataset elements with unknown shapes (e.g. from tf.numpy_function without set_shape()).

Adds a rank check in compile_utils._get_metric_object() before calling shape.as_list(), raising a clear error that tells the user to set shapes explicitly or use an explicit metric object. Also fixes display_shape() in input_spec.py to handle unknown-rank shapes gracefully.

Fixes #109333