### PR TITLE
Add path traversal security warning to tf.io.gfile docs

### DIFF
--- a/tensorflow/python/lib/io/file_io.py
+++ b/tensorflow/python/lib/io/file_io.py
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""File IO methods that wrap the C++ FileSystem API."""
+"""File IO methods that wrap the C++ FileSystem API.
+
+Security Note: These file I/O functions do not perform path validation or
+sandboxing. They do not prevent path traversal (e.g., using ``..``), do not
+restrict access to any directory, and will follow symbolic links. Applications
+that accept file paths from untrusted sources (such as user input, model
+configurations, or checkpoint metadata) must validate and canonicalize paths
+before passing them to these functions.
+"""
 import binascii
 import os
 from posixpath import join as urljoin

--- a/tensorflow/python/platform/gfile.py
+++ b/tensorflow/python/platform/gfile.py
@@ -108,6 +108,13 @@ class GFile(_FileIO):
   >>> f.tell()
   7
   >>> f.close()
+
+  **Security Note:** The ``tf.io.gfile`` APIs do not perform path validation
+  or sandboxing. They do not prevent path traversal (e.g., using ``..``), do
+  not restrict access to any directory, and will follow symbolic links. If your
+  application accepts file paths from untrusted sources (such as user input,
+  model configurations, or checkpoint metadata), you must validate and
+  canonicalize paths before passing them to these functions.
   """
 
   def __init__(self, name, mode='r'):


### PR DESCRIPTION
Adds security warnings to the `tf.io.gfile` documentation noting that these APIs do not perform path validation, sandboxing, or path traversal prevention. Applications that accept file paths from untrusted sources must validate and canonicalize paths before use.

Warnings added to:
- `file_io.py` module docstring (used by all gfile functions)
- `tf.io.gfile.GFile` class docstring

Fixes #110916