### PR TITLE
Remove tb dependency + partial rollback

### DIFF
--- a/tensorflow/python/ops/BUILD
+++ b/tensorflow/python/ops/BUILD
@@ -194,6 +194,7 @@ tf_gen_op_strict_wrapper_private_py(
         "//learning/brain/python/ops:__pkg__",
         "//tensorflow/examples/speech_commands:__pkg__",
         "//tensorflow/python:__pkg__",
+        "//tensorflow/python/summary:__pkg__",
     ],
 )
 

--- a/tensorflow/python/summary/BUILD
+++ b/tensorflow/python/summary/BUILD
@@ -110,6 +110,7 @@ tf_py_strict_test(
     srcs = ["summary_v2_test.py"],
     deps = [
         ":summary_py",
+        ":tb_summary",
         "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:dtypes",
         "//tensorflow/python/framework:ops",

--- a/tensorflow/python/summary/summary_v2_test.py
+++ b/tensorflow/python/summary/summary_v2_test.py
@@ -30,7 +30,10 @@ from tensorflow.python.summary import summary as summary_lib
 from tensorflow.python.summary import tb_summary
 from tensorflow.python.training import training_util
 
-TENSORBOARD_AVAILABLE = tb_summary.TENSORBOARD_AVAILABLE
+TENSORBOARD_AVAILABLE = (
+    hasattr(tb_summary, 'TENSORBOARD_AVAILABLE')
+    and tb_summary.TENSORBOARD_AVAILABLE
+)
 
 
 @unittest.skipIf(not TENSORBOARD_AVAILABLE, 'Tensorboard not installed.')

--- a/tensorflow/python/summary/summary_v2_test.py
+++ b/tensorflow/python/summary/summary_v2_test.py
@@ -17,7 +17,8 @@
 V1 summary ops will invoke V2 TensorBoard summary ops in eager mode.
 """
 
-from tensorboard.summary import v2 as summary_v2
+import unittest
+
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
@@ -26,16 +27,20 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import summary_ops_v2
 from tensorflow.python.platform import test
 from tensorflow.python.summary import summary as summary_lib
+from tensorflow.python.summary import tb_summary
 from tensorflow.python.training import training_util
 
+TENSORBOARD_AVAILABLE = tb_summary.TENSORBOARD_AVAILABLE
 
+
+@unittest.skipIf(not TENSORBOARD_AVAILABLE, 'Tensorboard not installed.')
 class SummaryV2Test(test.TestCase):
 
   @test_util.run_v2_only
   def test_scalar_summary_v2__w_writer(self):
     """Tests scalar v2 invocation with a v2 writer."""
     with test.mock.patch.object(
-        summary_v2, 'scalar', autospec=True) as mock_scalar_v2:
+        tb_summary, 'scalar', autospec=True) as mock_scalar_v2:
       with summary_ops_v2.create_summary_file_writer(
           self.get_temp_dir()).as_default(step=1):
         i = constant_op.constant(2.5)
@@ -43,9 +48,7 @@ class SummaryV2Test(test.TestCase):
     # Returns empty string.
     self.assertEqual(tensor.numpy(), b'')
     self.assertEqual(tensor.dtype, dtypes.string)
-    mock_scalar_v2.assert_called_once_with(
-        name='float', data=i, step=1, description=test.mock.ANY
-    )
+    mock_scalar_v2.assert_called_once_with(name='float', data=i, step=1)
 
   @test_util.run_v2_only
   def test_scalar_summary_v2__wo_writer(self):
@@ -53,7 +56,7 @@ class SummaryV2Test(test.TestCase):
     with self.assertWarnsRegex(
         UserWarning, 'default summary writer not found'):
       with test.mock.patch.object(
-          summary_v2, 'scalar', autospec=True) as mock_scalar_v2:
+          tb_summary, 'scalar', autospec=True) as mock_scalar_v2:
         summary_lib.scalar('float', constant_op.constant(2.5))
     mock_scalar_v2.assert_not_called()
 
@@ -62,7 +65,7 @@ class SummaryV2Test(test.TestCase):
     """Tests scalar v2 invocation when global step is not set."""
     with self.assertWarnsRegex(UserWarning, 'global step not set'):
       with test.mock.patch.object(
-          summary_v2, 'scalar', autospec=True) as mock_scalar_v2:
+          tb_summary, 'scalar', autospec=True) as mock_scalar_v2:
         with summary_ops_v2.create_summary_file_writer(
             self.get_temp_dir()).as_default():
           summary_lib.scalar('float', constant_op.constant(2.5))
@@ -154,7 +157,7 @@ class SummaryV2Test(test.TestCase):
   def test_scalar_summary_v2__family(self):
     """Tests `family` arg handling when scalar v2 is invoked."""
     with test.mock.patch.object(
-        summary_v2, 'scalar', autospec=True) as mock_scalar_v2:
+        tb_summary, 'scalar', autospec=True) as mock_scalar_v2:
       with summary_ops_v2.create_summary_file_writer(
           self.get_temp_dir()).as_default(step=1):
         tensor = summary_lib.scalar(
@@ -166,14 +169,13 @@ class SummaryV2Test(test.TestCase):
         name='otter/otter/float',
         data=constant_op.constant(2.5),
         step=1,
-        description=test.mock.ANY,
     )
 
   @test_util.run_v2_only
   def test_scalar_summary_v2__family_w_outer_scope(self):
     """Tests `family` arg handling when there is an outer scope."""
     with test.mock.patch.object(
-        summary_v2, 'scalar', autospec=True) as mock_scalar_v2:
+        tb_summary, 'scalar', autospec=True) as mock_scalar_v2:
       with summary_ops_v2.create_summary_file_writer(
           self.get_temp_dir()).as_default(step=1):
         with ops.name_scope_v2('sea'):
@@ -186,7 +188,6 @@ class SummaryV2Test(test.TestCase):
         name='crabnet/sea/crabnet/float',
         data=constant_op.constant(3.5),
         step=1,
-        description=test.mock.ANY,
     )
 
   @test_util.run_v2_only
@@ -195,7 +196,7 @@ class SummaryV2Test(test.TestCase):
     global_step = training_util.create_global_step()
     global_step.assign(1024)
     with test.mock.patch.object(
-        summary_v2, 'scalar', autospec=True) as mock_scalar_v2:
+        tb_summary, 'scalar', autospec=True) as mock_scalar_v2:
       with summary_ops_v2.create_summary_file_writer(
           self.get_temp_dir()).as_default():
         i = constant_op.constant(2.5)
@@ -203,15 +204,13 @@ class SummaryV2Test(test.TestCase):
     # Returns empty string.
     self.assertEqual(tensor.numpy(), b'')
     self.assertEqual(tensor.dtype, dtypes.string)
-    mock_scalar_v2.assert_called_once_with(
-        name='float', data=i, step=1024, description=test.mock.ANY
-    )
+    mock_scalar_v2.assert_called_once_with(name='float', data=i, step=1024)
 
   @test_util.run_v2_only
   def test_image_summary_v2(self):
     """Tests image v2 invocation."""
     with test.mock.patch.object(
-        summary_v2, 'image', autospec=True) as mock_image_v2:
+        tb_summary, 'image', autospec=True) as mock_image_v2:
       with summary_ops_v2.create_summary_file_writer(
           self.get_temp_dir()).as_default(step=2):
         i = array_ops.ones((5, 4, 4, 3))
@@ -225,14 +224,13 @@ class SummaryV2Test(test.TestCase):
         data=i,
         step=2,
         max_outputs=3,
-        description=test.mock.ANY,
     )
 
   @test_util.run_v2_only
   def test_histogram_summary_v2(self):
     """Tests histogram v2 invocation."""
     with test.mock.patch.object(
-        summary_v2, 'histogram', autospec=True) as mock_histogram_v2:
+        tb_summary, 'histogram', autospec=True) as mock_histogram_v2:
       with summary_ops_v2.create_summary_file_writer(
           self.get_temp_dir()).as_default(step=3):
         i = array_ops.ones((1024,))
@@ -244,15 +242,13 @@ class SummaryV2Test(test.TestCase):
         name='family/family/histogram',
         data=i,
         step=3,
-        buckets=test.mock.ANY,
-        description=test.mock.ANY,
     )
 
   @test_util.run_v2_only
   def test_audio_summary_v2(self):
     """Tests audio v2 invocation."""
     with test.mock.patch.object(
-        summary_v2, 'audio', autospec=True) as mock_audio_v2:
+        tb_summary, 'audio', autospec=True) as mock_audio_v2:
       with summary_ops_v2.create_summary_file_writer(
           self.get_temp_dir()).as_default(step=10):
         i = array_ops.ones((5, 3, 4))
@@ -267,15 +263,13 @@ class SummaryV2Test(test.TestCase):
         sample_rate=0.2,
         step=10,
         max_outputs=3,
-        encoding=test.mock.ANY,
-        description=test.mock.ANY,
     )
 
   @test_util.run_v2_only
   def test_audio_summary_v2__2d_tensor(self):
     """Tests audio v2 invocation with 2-D tensor input."""
     with test.mock.patch.object(
-        summary_v2, 'audio', autospec=True) as mock_audio_v2:
+        tb_summary, 'audio', autospec=True) as mock_audio_v2:
       with summary_ops_v2.create_summary_file_writer(
           self.get_temp_dir()).as_default(step=11):
         input_2d = array_ops.ones((5, 3))
@@ -291,8 +285,6 @@ class SummaryV2Test(test.TestCase):
         sample_rate=0.2,
         step=11,
         max_outputs=3,
-        encoding=test.mock.ANY,
-        description=test.mock.ANY,
     )
     input_3d = array_ops.ones((5, 3, 1))  # 3-D input tensor
     self.assertAllEqual(mock_audio_v2.call_args[1]['data'], input_3d)
@@ -301,7 +293,7 @@ class SummaryV2Test(test.TestCase):
   def test_text_summary_v2(self):
     """Tests text v2 invocation."""
     with test.mock.patch.object(
-        summary_v2, 'text', autospec=True) as mock_text_v2:
+        tb_summary, 'text', autospec=True) as mock_text_v2:
       with summary_ops_v2.create_summary_file_writer(
           self.get_temp_dir()).as_default(step=22):
         i = constant_op.constant('lorem ipsum', dtype=dtypes.string)
@@ -309,9 +301,7 @@ class SummaryV2Test(test.TestCase):
     # Returns empty string.
     self.assertEqual(tensor.numpy(), b'')
     self.assertEqual(tensor.dtype, dtypes.string)
-    mock_text_v2.assert_called_once_with(
-        name='text', data=i, step=22, description=test.mock.ANY
-    )
+    mock_text_v2.assert_called_once_with(name='text', data=i, step=22)
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/summary/tb_summary.py
+++ b/tensorflow/python/summary/tb_summary.py
@@ -26,23 +26,6 @@ class TBNotInstalledError(Exception):
     self.error_message = f"{_TENSORBOARD_NOT_INSTALLED_ERROR} {summary_api}"
     super().__init__(self.error_message)
 
-try:
-  from tensorboard.summary.v2 import audio as audio_v2  # pylint: disable=g-import-not-at-top
-  from tensorboard.summary.v2 import histogram as histogram_v2  # pylint: disable=g-import-not-at-top
-  from tensorboard.summary.v2 import image as image_v2  # pylint: disable=g-import-not-at-top
-  from tensorboard.summary.v2 import scalar as scalar_v2  # pylint: disable=g-import-not-at-top
-  from tensorboard.summary.v2 import text as text_v2  # pylint: disable=g-import-not-at-top
-  TENSORBOARD_AVAILABLE = True
-except ImportError:
-  def _tb_not_installed(*args, **kwargs):
-    raise TBNotInstalledError("tf.summary")
-  audio_v2 = _tb_not_installed
-  histogram_v2 = _tb_not_installed
-  image_v2 = _tb_not_installed
-  scalar_v2 = _tb_not_installed
-  text_v2 = _tb_not_installed
-  TENSORBOARD_AVAILABLE = False
-
 
 @tf_export("summary.audio", v1=[])
 def audio(
@@ -84,6 +67,10 @@ def audio(
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
+  try:
+    from tensorboard.summary.v2 import audio as audio_v2  # pylint: disable=g-import-not-at-top, g-importing-member
+  except ImportError as exc:
+    raise TBNotInstalledError("tf.summary.audio") from exc
   return audio_v2(
       name=name,
       data=data,
@@ -162,6 +149,10 @@ def histogram(name, data, step=None, buckets=None, description=None):
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
+  try:
+    from tensorboard.summary.v2 import histogram as histogram_v2  # pylint: disable=g-import-not-at-top, g-importing-member
+  except ImportError as exc:
+    raise TBNotInstalledError("tf.summary.histogram") from exc
   return histogram_v2(
       name=name, data=data, step=step, buckets=buckets, description=description
   )
@@ -236,6 +227,10 @@ def image(name, data, step=None, max_outputs=3, description=None):
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
+  try:
+    from tensorboard.summary.v2 import image as image_v2  # pylint: disable=g-import-not-at-top, g-importing-member
+  except ImportError as exc:
+    raise TBNotInstalledError("tf.summary.image") from exc
   return image_v2(
       name=name,
       data=data,
@@ -297,6 +292,10 @@ def scalar(name, data, step=None, description=None):
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
+  try:
+    from tensorboard.summary.v2 import scalar as scalar_v2  # pylint: disable=g-import-not-at-top, g-importing-member
+  except ImportError as exc:
+    raise TBNotInstalledError("tf.summary.scalar") from exc
   return scalar_v2(name=name, data=data, step=step, description=description)
 
 
@@ -364,5 +363,8 @@ def text(name, data, step=None, description=None):
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
+  try:
+    from tensorboard.summary.v2 import text as text_v2  # pylint: disable=g-import-not-at-top, g-importing-member
+  except ImportError as exc:
+    raise TBNotInstalledError("tf.summary.text") from exc
   return text_v2(name=name, data=data, step=step, description=description)
-

--- a/tensorflow/python/summary/tb_summary.py
+++ b/tensorflow/python/summary/tb_summary.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
 """Re-exports the APIs of TF2 summary that live in TensorBoard."""
 
 from tensorflow.python.util.tf_export import tf_export
@@ -23,10 +22,26 @@ _TENSORBOARD_NOT_INSTALLED_ERROR = (
 
 
 class TBNotInstalledError(Exception):
-
   def __init__(self, summary_api):
     self.error_message = f"{_TENSORBOARD_NOT_INSTALLED_ERROR} {summary_api}"
     super().__init__(self.error_message)
+
+try:
+  from tensorboard.summary.v2 import audio as audio_v2  # pylint: disable=g-import-not-at-top
+  from tensorboard.summary.v2 import histogram as histogram_v2  # pylint: disable=g-import-not-at-top
+  from tensorboard.summary.v2 import image as image_v2  # pylint: disable=g-import-not-at-top
+  from tensorboard.summary.v2 import scalar as scalar_v2  # pylint: disable=g-import-not-at-top
+  from tensorboard.summary.v2 import text as text_v2  # pylint: disable=g-import-not-at-top
+  TENSORBOARD_AVAILABLE = True
+except ImportError:
+  def _tb_not_installed(*args, **kwargs):
+    raise TBNotInstalledError("tf.summary")
+  audio_v2 = _tb_not_installed
+  histogram_v2 = _tb_not_installed
+  image_v2 = _tb_not_installed
+  scalar_v2 = _tb_not_installed
+  text_v2 = _tb_not_installed
+  TENSORBOARD_AVAILABLE = False
 
 
 @tf_export("summary.audio", v1=[])
@@ -62,19 +77,13 @@ def audio(
       if you want "wav" in particular, set this explicitly.
     description: Optional long-form description for this summary, as a constant
       `str`. Markdown is supported. Defaults to empty.
-
   Returns:
     True on success, or false if no summary was emitted because no default
     summary writer was available.
-
   Raises:
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
-  try:
-    from tensorboard.summary.v2 import audio as audio_v2  # pylint: disable=g-import-not-at-top, g-importing-member
-  except ImportError as exc:
-    raise TBNotInstalledError("tf.summary.audio") from exc
   return audio_v2(
       name=name,
       data=data,
@@ -153,10 +162,6 @@ def histogram(name, data, step=None, buckets=None, description=None):
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
-  try:
-    from tensorboard.summary.v2 import histogram as histogram_v2  # pylint: disable=g-import-not-at-top, g-importing-member
-  except ImportError as exc:
-    raise TBNotInstalledError("tf.summary.histogram") from exc
   return histogram_v2(
       name=name, data=data, step=step, buckets=buckets, description=description
   )
@@ -231,10 +236,6 @@ def image(name, data, step=None, max_outputs=3, description=None):
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
-  try:
-    from tensorboard.summary.v2 import image as image_v2  # pylint: disable=g-import-not-at-top, g-importing-member
-  except ImportError as exc:
-    raise TBNotInstalledError("tf.summary.image") from exc
   return image_v2(
       name=name,
       data=data,
@@ -296,10 +297,6 @@ def scalar(name, data, step=None, description=None):
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
-  try:
-    from tensorboard.summary.v2 import scalar as scalar_v2  # pylint: disable=g-import-not-at-top, g-importing-member
-  except ImportError as exc:
-    raise TBNotInstalledError("tf.summary.scalar") from exc
   return scalar_v2(name=name, data=data, step=step, description=description)
 
 
@@ -367,8 +364,5 @@ def text(name, data, step=None, description=None):
     ValueError: if a default writer exists, but no step was provided and
       `tf.summary.experimental.get_step()` is None.
   """
-  try:
-    from tensorboard.summary.v2 import text as text_v2  # pylint: disable=g-import-not-at-top, g-importing-member
-  except ImportError as exc:
-    raise TBNotInstalledError("tf.summary.text") from exc
   return text_v2(name=name, data=data, step=step, description=description)
+

--- a/tensorflow/python/tpu/BUILD
+++ b/tensorflow/python/tpu/BUILD
@@ -947,7 +947,7 @@ tpu_py_strict_test(
         ":functional",
         ":tpu_py",
         ":tpu_replication",
-        "//tensorflow/core/util:event_proto_py_proto",
+        "//tensorflow/core:protos_all_py",
         "//tensorflow/python/distribute:tpu_strategy",
         "//tensorflow/python/distribute/cluster_resolver:tpu_cluster_resolver_py",
         "//tensorflow/python/eager:def_function",

--- a/tensorflow/python/tpu/BUILD
+++ b/tensorflow/python/tpu/BUILD
@@ -947,7 +947,7 @@ tpu_py_strict_test(
         ":functional",
         ":tpu_py",
         ":tpu_replication",
-        "//tensorflow/core:protos_all_py",
+        "//tensorflow/core/util:event_proto_py_proto",
         "//tensorflow/python/distribute:tpu_strategy",
         "//tensorflow/python/distribute/cluster_resolver:tpu_cluster_resolver_py",
         "//tensorflow/python/eager:def_function",


### PR DESCRIPTION
This PR contains the changes of Removing Tensorboard as a dependency in TF and a partial rollback to fix build issues.

Note:

The test 'tpu_outside_compilation_test' its failing with the following message:

from tensorflow.python.platform import _pywrap_cpu_feature_guard
ImportError: cannot import name '_pywrap_cpu_feature_guard' from 'tensorflow.python.platform' (unknown location)

This test is also failing in Master, considering this test on the next task to work.

To replicate the test:
bazel test --test_output=errors --cache_test_results=no \
  --repo_env=USE_PYWRAP_RULES=False \
  //tensorflow/python/tpu:tpu_outside_compilation_test

