### PR TITLE
Fix polyval to broadcast single coefficient to match input shape

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -5527,6 +5527,8 @@ def polyval(coeffs, x, name=None):
     p = coeffs[0]
     for c in coeffs[1:]:
       p = c + p * x
+    # Broadcast result to match x's shape for NumPy compatibility
+    p = array_ops.broadcast_to(p, array_ops.shape(x))
     return p
 
 


### PR DESCRIPTION
Fixes #111413. When polyval is called with a single coefficient, it now broadcasts the result to match the input shape, matching NumPy behavior. Previously, the scalar coefficient was returned directly without broadcasting, causing shape mismatches and incorrect NaN propagation.