### PR TITLE
Reject complex dtypes in tf.math.round with clear error

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -954,14 +954,27 @@ def round(x, name=None):  # pylint: disable=redefined-builtin
   tf.round(x)  # [ 1.0, 2.0, 2.0, 2.0, -4.0 ]
   ```
 
+  Note: For integer inputs, the tensor is returned unchanged since rounding
+  has no effect on integers. Complex types (`complex64`, `complex128`) are
+  not supported even though they may appear in the raw op's type constraint.
+
   Args:
-    x: A `Tensor` of type `float16`, `float32`, `float64`, `int32`, or `int64`.
+    x: A `Tensor` of type `bfloat16`, `float16`, `float32`, `float64`,
+      `int32`, or `int64`.
     name: A name for the operation (optional).
 
   Returns:
     A `Tensor` of same shape and type as `x`.
+
+  Raises:
+    TypeError: If `x` is a complex tensor. Use `tf.math.round(tf.math.real(x))`
+      and `tf.math.round(tf.math.imag(x))` separately instead.
   """
   x = ops.convert_to_tensor(x, name="x")
+  if x.dtype.is_complex:
+    raise TypeError(
+        f"tf.math.round does not support complex dtypes, got {x.dtype}. "
+        "Consider rounding real and imaginary parts separately.")
   if x.dtype.is_integer:
     return x
   else:


### PR DESCRIPTION
The Round op schema lists complex64/complex128 in its type constraint but no CPU or GPU kernel is registered for these types. Passing a complex tensor to tf.math.round currently falls through to the generated op wrapper and fails with an unhelpful NotFoundError about no matching kernel.

Added an explicit TypeError check for complex inputs with a message that tells the user what happened and what to do instead. Also updated the docstring to include bfloat16 (which has had kernel support for a while but was missing from the docs).

Before:
```
tf.math.round(tf.constant([1.5+2.5j]))
-> NotFoundError: Could not find device for node: Round ...
```

After:
```
tf.math.round(tf.constant([1.5+2.5j]))
-> TypeError: tf.math.round does not support complex dtypes ...
```

Fixes #65317