### PR TITLE
Validate step shape in as_default() and set_step()

### DIFF
--- a/tensorflow/python/kernel_tests/summary_ops/summary_ops_test.py
+++ b/tensorflow/python/kernel_tests/summary_ops/summary_ops_test.py
@@ -581,6 +581,26 @@ class SummaryOpsCoreTest(test_util.TensorFlowTestCase):
         # Reset to default state for other tests.
         summary_ops.set_step(None)
 
+  def testSetStep_rejectsNonCastableValue(self):
+    with context.eager_mode():
+      with self.assertRaises(errors.OpError):
+        summary_ops.set_step('not-a-step')
+
+  def testSetStep_rejectsNonScalarValue(self):
+    with self.assertRaisesRegex(ValueError, 'step.*must be a scalar'):
+      summary_ops.set_step([1, 2])
+
+  def testAsDefault_rejectsNonCastableStep(self):
+    with context.eager_mode():
+      writer = summary_ops.create_file_writer_v2(self.get_temp_dir())
+      with self.assertRaises(errors.OpError):
+        writer.as_default(step='not-a-step')
+
+  def testAsDefault_rejectsNonScalarStep(self):
+    writer = summary_ops.create_file_writer_v2(self.get_temp_dir())
+    with self.assertRaisesRegex(ValueError, 'step.*must be a scalar'):
+      writer.as_default(step=[1, 2])
+
   def testGetSetStep_variable_fromFunction(self):
     with context.eager_mode():
       try:

--- a/tensorflow/python/ops/summary_ops_v2.py
+++ b/tensorflow/python/ops/summary_ops_v2.py
@@ -77,6 +77,14 @@ class _SummaryContextManager:
 
   def __init__(self, writer, step=None):
     self._writer = writer
+    if step is not None:
+      step_tensor = ops.convert_to_tensor(step)
+      n = step_tensor.shape.num_elements()
+      if n is not None and n != 1:
+        raise ValueError(
+            "Argument `step` must be a scalar. "
+            f"Received step with shape {step_tensor.shape}."
+        )
     self._step = step
     self._old_writer = None
     self._old_step = None
@@ -241,7 +249,18 @@ def set_step(step):
 
   Args:
     step: An `int64`-castable default step value, or None to unset.
+
+  Raises:
+    ValueError: If `step` is not a scalar.
   """
+  if step is not None:
+    step_tensor = ops.convert_to_tensor(step)
+    n = step_tensor.shape.num_elements()
+    if n is not None and n != 1:
+      raise ValueError(
+          "Argument `step` must be a scalar. "
+          f"Received step with shape {step_tensor.shape}."
+      )
   _summary_state.step = step
 
 

--- a/tensorflow/python/ops/summary_ops_v2.py
+++ b/tensorflow/python/ops/summary_ops_v2.py
@@ -85,6 +85,7 @@ class _SummaryContextManager:
             "Argument `step` must be a scalar. "
             f"Received step with shape {step_tensor.shape}."
         )
+      math_ops.cast(step_tensor, dtypes.int64)
     self._step = step
     self._old_writer = None
     self._old_step = None
@@ -261,6 +262,7 @@ def set_step(step):
           "Argument `step` must be a scalar. "
           f"Received step with shape {step_tensor.shape}."
       )
+    math_ops.cast(step_tensor, dtypes.int64)
   _summary_state.step = step
 
 


### PR DESCRIPTION
Passing a multi-element tensor as the step to writer.as_default(step=...) or tf.summary.experimental.set_step() causes a fatal CHECK failure in the C++ runtime (tensor.cc CheckIsAlignedAndSingleElement) instead of raising a Python exception. The process crashes with no way to catch the error.

The write() function already validates step through _choose_step(), but as_default() and set_step() store the value directly into thread-local state without any shape check. Added the same scalar validation at both entry points so users get a clear ValueError up front.

The check uses shape.num_elements() with a None guard to avoid breaking dynamic shapes in graph mode.

Fixes #108659