### PR TITLE
Validate dense_shape in sparse_tensor_dense_matmul

### DIFF
--- a/tensorflow/python/ops/sparse_ops.py
+++ b/tensorflow/python/ops/sparse_ops.py
@@ -2656,6 +2656,13 @@ def sparse_tensor_dense_matmul(sp_a,
 
   else:
     sp_a = _convert_to_sparse_tensor(sp_a)
+    # Validate dense_shape has no negative dimensions to avoid a
+    # fatal CHECK failure in the C++ kernel (b/107976).
+    shape_val = tensor_util.constant_value(sp_a.dense_shape)
+    if shape_val is not None and any(d < 0 for d in shape_val):
+      raise ValueError(
+          "SparseTensor dense_shape must not contain negative "
+          f"values, got {list(shape_val)}")
     with ops.name_scope(name, "SparseTensorDenseMatMul",
                         [sp_a.indices, sp_a.values, b]) as name:
       b = ops.convert_to_tensor(b, name="b")

--- a/tensorflow/python/ops/sparse_ops_test.py
+++ b/tensorflow/python/ops/sparse_ops_test.py
@@ -209,6 +209,23 @@ class SparseOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
         array_ops.transpose(dense_of_sparse))
     self.assertAllEqual(expected, result)
 
+
+  def testSparseTensorDenseMatMulNegativeShapeValueError(self):
+    sp = sparse_tensor.SparseTensor(
+        indices=[[0, 0]], values=[1.0], dense_shape=[-1, 4]
+    )
+    b = constant_op.constant([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
+    with self.assertRaisesRegex(
+        ValueError, 'dense_shape must not contain negative values'
+    ):
+      self.evaluate(sparse_ops.sparse_tensor_dense_matmul(sp, b))
+
+    a = constant_op.constant([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+    with self.assertRaisesRegex(
+        ValueError, 'dense_shape must not contain negative values'
+    ):
+      self.evaluate(sparse_ops.sparse_tensor_dense_matmul(a, sp))
+
   def testMapValues(self):
     # supplying no sparse tensor should result in ValueError
     with self.assertRaises(ValueError):


### PR DESCRIPTION
Passing a SparseTensor with a negative dimension in dense_shape (e.g. [-1, 4]) to sparse_tensor_dense_matmul crashes the process with a fatal CHECK failure in the C++ kernel. The kernel tries to construct an output TensorShape from the raw values without checking for negatives, and the internal shape validation aborts the process instead of raising through the normal error path.

Added a check in the Python wrapper that rejects negative dense_shape values with a clear ValueError when the shape is statically known. This catches the common eager-mode case and turns a process crash into a proper exception.

Fixes #107976