### PR TITLE
Validate shape dimensions in FixedLenSequenceFeature

### DIFF
--- a/tensorflow/python/kernel_tests/io_ops/parsing_ops_test.py
+++ b/tensorflow/python/kernel_tests/io_ops/parsing_ops_test.py
@@ -1452,6 +1452,14 @@ class ParseSequenceExampleTest(test.TestCase):
         }))
     value.SerializeToString()  # Smoke test
 
+  def testFixedLenSequenceFeatureInvalidShapes(self):
+    with self.assertRaisesRegex(ValueError, "dimensions must be positive"):
+      parsing_ops.FixedLenSequenceFeature(shape=[0], dtype=dtypes.float32)
+    with self.assertRaisesRegex(ValueError, "Dimension -1 must be >= 0"):
+      parsing_ops.FixedLenSequenceFeature(shape=[-1], dtype=dtypes.float32)
+    with self.assertRaisesRegex(ValueError, "dimensions must be fully defined"):
+      parsing_ops.FixedLenSequenceFeature(shape=[None], dtype=dtypes.float32)
+
   def _test(self,
             kwargs,
             expected_context_values=None,

--- a/tensorflow/python/kernel_tests/io_ops/parsing_ops_test.py
+++ b/tensorflow/python/kernel_tests/io_ops/parsing_ops_test.py
@@ -1457,8 +1457,6 @@ class ParseSequenceExampleTest(test.TestCase):
       parsing_ops.FixedLenSequenceFeature(shape=[0], dtype=dtypes.float32)
     with self.assertRaisesRegex(ValueError, "Dimension -1 must be >= 0"):
       parsing_ops.FixedLenSequenceFeature(shape=[-1], dtype=dtypes.float32)
-    with self.assertRaisesRegex(ValueError, "dimensions must be fully defined"):
-      parsing_ops.FixedLenSequenceFeature(shape=[None], dtype=dtypes.float32)
 
   def _test(self,
             kwargs,

--- a/tensorflow/python/ops/parsing_config.py
+++ b/tensorflow/python/ops/parsing_config.py
@@ -389,6 +389,12 @@ class FixedLenSequenceFeature(collections.namedtuple(
   """
 
   def __new__(cls, shape, dtype, allow_missing=False, default_value=None):
+    shape = tuple(shape) if shape else ()
+    for i, dim in enumerate(shape):
+      if dim < 1:
+        raise ValueError(
+            f"All shape dimensions must be positive, but "
+            f"dimension {i} is {dim}. Got shape={shape}")
     return super(FixedLenSequenceFeature, cls).__new__(
         cls, shape, dtype, allow_missing, default_value)
 

--- a/tensorflow/python/ops/parsing_config.py
+++ b/tensorflow/python/ops/parsing_config.py
@@ -389,12 +389,19 @@ class FixedLenSequenceFeature(collections.namedtuple(
   """
 
   def __new__(cls, shape, dtype, allow_missing=False, default_value=None):
-    shape = tuple(shape) if shape else ()
-    for i, dim in enumerate(shape):
-      if dim < 1:
+    try:
+      feature_shape = tensor_shape.as_shape(shape)
+    except Exception as e:
+      raise ValueError(f"Invalid shape: {shape}. Error: {e}") from e
+    for i, dim in enumerate(feature_shape.dims):
+      if dim.value is None:
+        raise ValueError(
+            f"All shape dimensions must be fully defined and positive, but "
+            f"dimension {i} is unknown (None). Got shape={shape}")
+      elif dim.value < 1:
         raise ValueError(
             f"All shape dimensions must be positive, but "
-            f"dimension {i} is {dim}. Got shape={shape}")
+            f"dimension {i} is {dim.value}. Got shape={shape}")
     return super(FixedLenSequenceFeature, cls).__new__(
         cls, shape, dtype, allow_missing, default_value)
 

--- a/tensorflow/python/ops/parsing_config.py
+++ b/tensorflow/python/ops/parsing_config.py
@@ -394,11 +394,7 @@ class FixedLenSequenceFeature(collections.namedtuple(
     except Exception as e:
       raise ValueError(f"Invalid shape: {shape}. Error: {e}") from e
     for i, dim in enumerate(feature_shape.dims):
-      if dim.value is None:
-        raise ValueError(
-            f"All shape dimensions must be fully defined and positive, but "
-            f"dimension {i} is unknown (None). Got shape={shape}")
-      elif dim.value < 1:
+      if dim.value is not None and dim.value < 1:
         raise ValueError(
             f"All shape dimensions must be positive, but "
             f"dimension {i} is {dim.value}. Got shape={shape}")


### PR DESCRIPTION
Passing a shape with a zero dimension (e.g. [0, 2]) to tf.io.FixedLenSequenceFeature causes the C++ parsing kernel to crash instead of raising a Python exception. The __new__ method accepted any shape without checking that dimensions are positive.

Added validation in __new__ that rejects zero and negative shape dimensions with a clear ValueError before the invalid shape reaches the C++ layer.

Fixes #108141