### PR TITLE
[ROCm] Remove ROCM macro, inadvertantly added to CUDA specific code

### DIFF
--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -675,13 +675,13 @@ __device__ inline Eigen::half GpuAtomicAdd(Eigen::half* ptr,
   return detail::GpuAtomicCasHelper(
       ptr, [value](Eigen::half a) { return a + value; });
 }
-#endif
 
-#if (__CUDA_ARCH__ < 600) || TENSORFLOW_USE_ROCM
+#if (__CUDA_ARCH__ < 600)
 __device__ inline double GpuAtomicAdd(double* ptr, double value) {
   return detail::GpuAtomicCasHelper(ptr,
                                     [value](double a) { return a + value; });
 }
+#endif
 #endif
 
 #if TENSORFLOW_USE_ROCM

--- a/tensorflow/core/util/gpu_device_functions.h
+++ b/tensorflow/core/util/gpu_device_functions.h
@@ -675,13 +675,13 @@ __device__ inline Eigen::half GpuAtomicAdd(Eigen::half* ptr,
   return detail::GpuAtomicCasHelper(
       ptr, [value](Eigen::half a) { return a + value; });
 }
+#endif
 
-#if (__CUDA_ARCH__ < 600)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 600)
 __device__ inline double GpuAtomicAdd(double* ptr, double value) {
   return detail::GpuAtomicCasHelper(ptr,
                                     [value](double a) { return a + value; });
 }
-#endif
 #endif
 
 #if TENSORFLOW_USE_ROCM

--- a/tensorflow/core/util/gpu_kernel_helper_test.cu.cc
+++ b/tensorflow/core/util/gpu_kernel_helper_test.cu.cc
@@ -312,6 +312,40 @@ TEST_F(GpuLaunchConfigTest, GetGpu3DLaunchConfig) {
 #undef TEST_LAUNCH_PARAMETER
 }
 
+__global__ void TestGpuAtomicAddDouble(double* ptr, double value) {
+  GpuAtomicAdd(ptr, value);
+}
+
+TEST_F(GpuLaunchConfigTest, GpuAtomicAddDoubleTest) {
+  double* d_ptr;
+#if GOOGLE_CUDA
+  cudaError_t err = cudaMallocManaged(&d_ptr, sizeof(double));
+#else
+  hipError_t err = hipMalloc(&d_ptr, sizeof(double));
+#endif
+  ASSERT_EQ(cudaSuccess, err) << cudaGetErrorString(err);
+
+  double init_val = 10.5;
+#if GOOGLE_CUDA
+  *d_ptr = init_val;
+#else
+  ASSERT_EQ(hipMemcpy(d_ptr, &init_val, sizeof(double), hipMemcpyHostToDevice), cudaSuccess);
+#endif
+
+  TF_EXPECT_OK(GpuLaunchKernel(TestGpuAtomicAddDouble, 1, 1, 0, d.stream(), d_ptr, 5.25));
+  CUDA_EXPECT_SUCCESS
+
+  double final_val;
+#if GOOGLE_CUDA
+  final_val = *d_ptr;
+#else
+  ASSERT_EQ(hipMemcpy(&final_val, d_ptr, sizeof(double), hipMemcpyDeviceToHost), cudaSuccess);
+#endif
+  EXPECT_DOUBLE_EQ(final_val, 15.75);
+
+  ASSERT_EQ(gpuFree(d_ptr), cudaSuccess);
+}
+
 TEST(CudaDeviceFunctionsTest, ShuffleGetSrcLane) {
   unsigned* failure_count;
 #if GOOGLE_CUDA


### PR DESCRIPTION
This introduces CAS operation for atomics which is slow on ROCm. Use ROCm specific atomics optimizations instead.