### PR TITLE
Fix tf.math.polyval to match numpy.polyval for single-coefficient polynomials

### DIFF
--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_test.py
@@ -1323,6 +1323,23 @@ class PolyvalTest(test.TestCase):
       tf_val = math_ops.polyval(coeffs, x)
       self.assertAllClose(np_val, self.evaluate(tf_val))
 
+  def testSingleCoeffNanPropagation(self):
+    x = np.array([1.0, float('nan'), 3.0], dtype=np.float32)
+    coeffs = [np.float32(2.0)]
+    np_val = np.polyval(coeffs, x)
+    with self.cached_session():
+      tf_val = math_ops.polyval(coeffs, x)
+      self.assertAllClose(np_val, self.evaluate(tf_val))
+
+  def testSingleCoeffShapeBroadcast(self):
+    x = np.random.rand(3, 4).astype(np.float32)
+    coeffs = [np.float32(5.0)]
+    np_val = np.polyval(coeffs, x)
+    with self.cached_session():
+      tf_val = math_ops.polyval(coeffs, x)
+      self.assertEqual(tf_val.shape, x.shape)
+      self.assertAllClose(np_val, self.evaluate(tf_val))
+
   def test_coeffs_raise(self):
     x = np.random.rand(2, 2).astype(np.float32)
     coeffs = {}

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -5527,6 +5527,11 @@ def polyval(coeffs, x, name=None):
     p = coeffs[0]
     for c in coeffs[1:]:
       p = c + p * x
+    # For single-coefficient polynomials, the loop above never executes,
+    # so x is unused. Add x*0 to broadcast against x's shape and
+    # propagate NaN, matching numpy.polyval behavior.
+    if len(coeffs) == 1:
+      p = p + x * 0
     return p
 
 


### PR DESCRIPTION
## Summary

Fixes #111413

When `tf.math.polyval` receives a single coefficient, the Horner's method loop never executes, so the input `x` is unused. This causes two inconsistencies with `numpy.polyval`:

1. **NaN values in `x` are not propagated** - `polyval([c], [1.0, NaN, 3.0])` returns `c` instead of `[c, NaN, c]`
2. **Output shape doesn't match `x`** - `polyval([c], x_2d)` returns a scalar instead of broadcasting to `x`'s shape

### Fix

Added `p = p + x * 0` in the single-coefficient case, which ensures both NaN propagation and shape broadcasting to match NumPy behavior.

### Before/After

```python
import numpy as np
import tensorflow as tf

coeffs = [1.21]
x = tf.constant([1.0, float('nan'), 3.0])

# Before: tf.Tensor(1.21, shape=(), dtype=float32)  -- wrong shape, no NaN
# After:  tf.Tensor([1.21,  nan, 1.21], shape=(3,))  -- matches numpy
# NumPy:  array([1.21,  nan, 1.21], dtype=float32)
```

## Test plan

- [x] Added `testSingleCoeffNanPropagation` - verifies NaN propagation matches NumPy
- [x] Added `testSingleCoeffShapeBroadcast` - verifies output shape matches x's shape
- [x] Existing `PolyvalTest` cases unaffected

This contribution was developed with AI assistance (Claude Code).