### PR TITLE
Document image-scaling attack risk in tf.image.resize

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -1723,6 +1723,19 @@ def resize_images_v2(images,
     implementation. As a result, `tf.image.resize(..., method='bicubic')`
     always executes on the CPU, even when GPU devices are available.
 
+  Warning:
+    When downscaling images, certain interpolation methods (particularly
+    `nearest` and `bilinear` without `antialias=True`) can be vulnerable to
+    **image-scaling attacks**. An adversary can craft an input image that
+    appears normal at its original resolution but produces attacker-controlled
+    content after downscaling. This is relevant for ML pipelines that resize
+    user-supplied images before feeding them to a model.
+
+    To reduce this risk, use `antialias=True` when downscaling, or use the
+    `area` interpolation method which always anti-aliases. For more details,
+    see Quiring et al., "Adversarial Preprocessing: Understanding and
+    Preventing Image-Scaling Attacks in Machine Learning" (USENIX Security
+    2020).
 
   Args:
     images: 4-D Tensor of shape `[batch, height, width, channels]` or 3-D Tensor


### PR DESCRIPTION
## Summary

Fixes #42388

Adds a `Warning` section to the `tf.image.resize` (v2) docstring documenting the risk of image-scaling attacks when downscaling images with certain interpolation methods.

As noted by @mihaimaruseac in the original issue, this is a known security concern: adversaries can craft images that appear normal at original resolution but produce attacker-controlled content after downscaling.

### What's added

A warning in the docstring that:
- Identifies vulnerable methods (`nearest`, `bilinear` without `antialias=True`)
- Recommends mitigations (`antialias=True` or `area` method)
- References the academic paper (Quiring et al., USENIX Security 2020)

### Why this matters

ML pipelines commonly resize user-supplied images before feeding them to models. Without awareness of this attack vector, developers may unknowingly use vulnerable configurations.

## Test plan

- [x] Pure documentation change - no code logic modified
- [x] Warning follows existing docstring style (matches the `Note:` block above it)

This contribution was developed with AI assistance (Claude Code).