### PR TITLE
Update add_metric() docstring for Keras 3 compatibility

### DIFF
--- a/tensorflow/python/keras/engine/base_layer.py
+++ b/tensorflow/python/keras/engine/base_layer.py
@@ -1566,8 +1566,14 @@ class Layer(module.Module, version_utils.LayerVersionSelector):
   def add_metric(self, value, name=None, **kwargs):
     """Adds metric tensor to the layer.
 
-    This method can be used inside the `call()` method of a subclassed layer
-    or model.
+    Note: In Keras 3 (default since TensorFlow 2.16+), calling `add_metric()`
+    inside `call()` is no longer supported and will raise an error. For Keras 3,
+    create a `keras.metrics.Metric` object in `__init__()`, call
+    `update_state()` during the forward pass, and expose metrics via the
+    `metrics` property. See the Keras 3 migration guide for details.
+
+    For legacy `tf.keras` (Keras 2), this method can be used inside the
+    `call()` method of a subclassed layer or model.
 
     ```python
     class MyMetricLayer(tf.keras.layers.Layer):


### PR DESCRIPTION
## Summary

Fixes #110884

The `add_metric()` docstring recommends calling it inside `call()` for subclassed layers/models. However, this pattern is **disabled in Keras 3** (default since TF 2.16+), causing confusion for users following the documented examples.

### Changes

Added a `Note` at the top of the `add_metric()` docstring in `base_layer.py` that:
- Warns that `add_metric()` inside `call()` is not supported in Keras 3
- Points users to the Keras 3-compatible approach:
  - Create `keras.metrics.Metric` objects in `__init__()`
  - Call `update_state()` during forward pass
  - Expose metrics via the `metrics` property
- Clarifies the existing example is for legacy `tf.keras` (Keras 2)

## Test plan

- [x] Pure documentation change - no code logic modified
- [x] Existing tests unaffected

This contribution was developed with AI assistance (Claude Code).