### PR TITLE
Fix Windows GPU warning triggering on internal Keras calls

### DIFF
--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -460,7 +460,7 @@ def list_physical_devices(device_type=None):
     List of discovered `tf.config.PhysicalDevice` objects
   """
   global _warned_windows_gpu
-  if not _warned_windows_gpu and platform.system() == 'Windows':
+  if not _warned_windows_gpu and platform.system() == 'Windows' and device_type == 'GPU':
     logging.warning(
         'TensorFlow GPU support is not available on native Windows for '
         'TensorFlow >= 2.11. Even if CUDA/cuDNN are installed, GPU will '

--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -460,7 +460,8 @@ def list_physical_devices(device_type=None):
     List of discovered `tf.config.PhysicalDevice` objects
   """
   global _warned_windows_gpu
-  if not _warned_windows_gpu and platform.system() == 'Windows' and device_type == 'GPU':
+  is_windows_gpu = (platform.system() == 'Windows' and device_type == 'GPU')
+  if not _warned_windows_gpu and is_windows_gpu:
     logging.warning(
         'TensorFlow GPU support is not available on native Windows for '
         'TensorFlow >= 2.11. Even if CUDA/cuDNN are installed, GPU will '

--- a/tensorflow/python/framework/config.py
+++ b/tensorflow/python/framework/config.py
@@ -460,8 +460,8 @@ def list_physical_devices(device_type=None):
     List of discovered `tf.config.PhysicalDevice` objects
   """
   global _warned_windows_gpu
-  is_windows_gpu = (platform.system() == 'Windows' and device_type == 'GPU')
-  if not _warned_windows_gpu and is_windows_gpu:
+  if (not _warned_windows_gpu and device_type == 'GPU'
+      and platform.system() == 'Windows'):
     logging.warning(
         'TensorFlow GPU support is not available on native Windows for '
         'TensorFlow >= 2.11. Even if CUDA/cuDNN are installed, GPU will '


### PR DESCRIPTION
Previously, the Windows GPU deprecation warning was triggered on any 
call to list_physical_devices(), including internal Keras calls during 
model.compile() (trainer.py:_resolve_auto_jit_compile).

Added device_type == 'GPU' check so the warning only appears when the 
user explicitly queries for GPU devices.

Fixes: warning appearing on every model.compile() without user 
explicitly calling list_physical_devices('GPU').

Related to #106807

<img width="950" height="327" alt="resim" src="https://github.com/user-attachments/assets/4c167baa-8a61-437d-815d-f49ac34844ba" />