### PR TITLE
xla/gpu: raise minimum PTX to 8.7 for Blackwell sm_120/sm_120a (fixes #111958)

### DIFF
--- a/third_party/xla/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter.cc
+++ b/third_party/xla/xla/backends/gpu/codegen/emitters/mlir_kernel_emitter.cc
@@ -628,6 +628,12 @@ void AddLoweringPasses(mlir::OpPassManager& pm,
     se::SemanticVersion ptx_version =
         nvptx::DetermineHighestSupportedPtxVersionFromCudaVersion(
             device.runtime_version());
+    // sm_120/sm_120a require PTX 8.7+; use at least that when targeting them.
+    se::SemanticVersion min_ptx =
+        nvptx::GetMinimumPtxVersionForComputeCapability(*cc);
+    if (min_ptx > ptx_version) {
+      ptx_version = min_ptx;
+    }
     pm.addPass(CreateConvertFloatNvidiaPass(cc->major, cc->minor,
                                             ptx_version.major_version(),
                                             ptx_version.minor_version()));

--- a/third_party/xla/xla/service/gpu/llvm_gpu_backend/BUILD
+++ b/third_party/xla/xla/service/gpu/llvm_gpu_backend/BUILD
@@ -65,7 +65,10 @@ cc_library(
     name = "ptx_version_util",
     srcs = ["ptx_version_util.cc"],
     hdrs = ["ptx_version_util.h"],
-    deps = ["//xla/stream_executor:semantic_version"],
+    deps = [
+        "//xla/stream_executor:semantic_version",
+        "//xla/stream_executor/cuda:cuda_compute_capability",
+    ],
 )
 
 cc_library(

--- a/third_party/xla/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
+++ b/third_party/xla/xla/service/gpu/llvm_gpu_backend/nvptx_backend.cc
@@ -29,7 +29,6 @@ limitations under the License.
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include "third_party/gpus/cuda/include/cuda.h"
 #include "llvm/ADT/FloatingPointMode.h"
 #include "llvm/Analysis/CGSCCPassManager.h"
 #include "llvm/Analysis/LazyCallGraph.h"
@@ -58,6 +57,7 @@ limitations under the License.
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/IPO/Internalize.h"
 #include "llvm/Transforms/Scalar.h"
+#include "third_party/gpus/cuda/include/cuda.h"
 #include "xla/service/gpu/llvm_gpu_backend/gpu_backend_lib.h"
 #include "xla/service/gpu/llvm_gpu_backend/load_ir_module.h"
 #include "xla/service/gpu/llvm_gpu_backend/nvptx_libdevice_path.h"
@@ -166,6 +166,13 @@ std::unique_ptr<llvm::TargetMachine> NVPTXGetTargetMachine(
 
   auto ptx_version = nvptx::DetermineHighestSupportedPtxVersionFromCudaVersion(
       highest_supported_cuda_version);
+  // sm_120/sm_120a (Blackwell) require PTX 8.7+; ensure we never emit PTX 8.5
+  // for those targets (see GitHub Issue #111958).
+  auto min_ptx_for_cc =
+      nvptx::GetMinimumPtxVersionForComputeCapability(compute_capability);
+  if (min_ptx_for_cc > ptx_version) {
+    ptx_version = min_ptx_for_cc;
+  }
   int highest_supported_ptx_version =
       ptx_version.major_version() * 10 + ptx_version.minor_version();
 

--- a/third_party/xla/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
+++ b/third_party/xla/xla/service/gpu/llvm_gpu_backend/nvptx_backend_test.cc
@@ -64,6 +64,29 @@ TEST(UtilsTest, TestGetSmName) {
   ASSERT_EQ(nvptx::GetSmName(se::CudaComputeCapability{13, 0}), "sm_121");
 }
 
+// Blackwell (sm_120/sm_120a) requires PTX 8.7+; verify minimum PTX is returned.
+TEST(UtilsTest, GetMinimumPtxVersionForComputeCapability) {
+  using FeatureExtension = se::CudaComputeCapability::FeatureExtension;
+  // sm_120 and sm_120a require PTX 8.7 (GitHub Issue #111958).
+  EXPECT_EQ(nvptx::GetMinimumPtxVersionForComputeCapability(
+                se::CudaComputeCapability{12, 0, FeatureExtension::kNone}),
+            se::SemanticVersion(8, 7, 0));
+  EXPECT_EQ(
+      nvptx::GetMinimumPtxVersionForComputeCapability(se::CudaComputeCapability{
+          12, 0, FeatureExtension::kAcceleratedFeatures}),
+      se::SemanticVersion(8, 7, 0));
+  EXPECT_EQ(nvptx::GetMinimumPtxVersionForComputeCapability(
+                se::CudaComputeCapability{12, 1, FeatureExtension::kNone}),
+            se::SemanticVersion(8, 7, 0));
+  // Older architectures get fallback (no minimum above baseline).
+  EXPECT_EQ(nvptx::GetMinimumPtxVersionForComputeCapability(
+                se::CudaComputeCapability{9, 0}),
+            se::SemanticVersion(6, 5, 0));
+  EXPECT_EQ(nvptx::GetMinimumPtxVersionForComputeCapability(
+                se::CudaComputeCapability{8, 0}),
+            se::SemanticVersion(6, 5, 0));
+}
+
 using VersionPair = std::pair<se::SemanticVersion, se::SemanticVersion>;
 using PtxVersionFromCudaVersionTest = ::testing::TestWithParam<VersionPair>;
 

--- a/third_party/xla/xla/service/gpu/llvm_gpu_backend/ptx_version_util.cc
+++ b/third_party/xla/xla/service/gpu/llvm_gpu_backend/ptx_version_util.cc
@@ -15,11 +15,15 @@ limitations under the License.
 
 #include "xla/service/gpu/llvm_gpu_backend/ptx_version_util.h"
 
+#include "xla/stream_executor/cuda/cuda_compute_capability.h"
+
 namespace xla::gpu::nvptx {
 
 namespace {
 constexpr stream_executor::SemanticVersion kFallbackPtxVersion{6, 5, 0};
 constexpr stream_executor::SemanticVersion kMaxPtxVersion{9, 0, 0};
+// Blackwell (sm_120/sm_120a) requires PTX 8.7+; PTX 8.5 does not support it.
+constexpr stream_executor::SemanticVersion kMinPtxVersionForSm120{8, 7, 0};
 }  // namespace
 
 stream_executor::SemanticVersion
@@ -52,4 +56,16 @@ DetermineHighestSupportedPtxVersionFromCudaVersion(
   // Return maximum known PTX version.
   return kMaxPtxVersion;
 }
+
+stream_executor::SemanticVersion GetMinimumPtxVersionForComputeCapability(
+    stream_executor::CudaComputeCapability compute_capability) {
+  // Blackwell (sm_120, sm_120a) requires PTX 8.7 or higher. PTX 8.5 does not
+  // support target 'sm_120' (LLVM ERROR). See e.g. GitHub Issue #111958.
+  if (compute_capability.major >= stream_executor::CudaComputeCapability::
+                                      CudaComputeCapabilities::kBlackwell_12) {
+    return kMinPtxVersionForSm120;
+  }
+  return kFallbackPtxVersion;
+}
+
 }  // namespace xla::gpu::nvptx

--- a/third_party/xla/xla/service/gpu/llvm_gpu_backend/ptx_version_util.h
+++ b/third_party/xla/xla/service/gpu/llvm_gpu_backend/ptx_version_util.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef XLA_SERVICE_GPU_LLVM_GPU_BACKEND_PTX_VERSION_UTIL_H_
 #define XLA_SERVICE_GPU_LLVM_GPU_BACKEND_PTX_VERSION_UTIL_H_
 
+#include "xla/stream_executor/cuda/cuda_compute_capability.h"
 #include "xla/stream_executor/semantic_version.h"
 
 namespace xla::gpu::nvptx {
@@ -24,6 +25,12 @@ namespace xla::gpu::nvptx {
 stream_executor::SemanticVersion
 DetermineHighestSupportedPtxVersionFromCudaVersion(
     stream_executor::SemanticVersion cuda_version);
+
+// Returns the minimum PTX version required for the given compute capability.
+// Used to ensure we emit PTX that the target GPU supports (e.g. sm_120/sm_120a
+// require PTX 8.7+ per NVIDIA; PTX 8.5 does not support them).
+stream_executor::SemanticVersion GetMinimumPtxVersionForComputeCapability(
+    stream_executor::CudaComputeCapability compute_capability);
 
 }  // namespace xla::gpu::nvptx
 


### PR DESCRIPTION
## Problem

Blackwell GPUs (compute capability sm_120/sm_120a, e.g. RTX 5060 Ti) require
PTX version 8.7 or higher. The current XLA/NVPTX backend derives the PTX
version only from the CUDA runtime version, which can yield PTX 8.5 — causing
a hard crash at JIT compilation time:

---
LLVM ERROR: PTX version 8.5 does not support target 'sm_120' (or 'sm_120a').
Minimum required PTX version is 8.7
---
This affects any user running TF nightly on a Blackwell GPU where the
CUDA-derived PTX version falls below 8.7.

Fixes #111958

---

## Solution

Introduce `GetMinimumPtxVersionForComputeCapability()` in `ptx_version_util`
that returns PTX 8.7 for compute capability major >= 12 (Blackwell), and
the existing fallback (6.5) for all older architectures.

Applied as a floor in two places:

1. `nvptx_backend.cc` — `NVPTXGetTargetMachine` (main JIT compilation path)
2. `emitter_base.cc` — `CreateConvertFloatNvidiaPass` (MLIR emitter path)

The fix is `max(cuda_derived_ptx, min_ptx_for_cc)` — fully backward compatible.

---

## Changes

| File | Change |
|------|--------|
| `ptx_version_util.h` | Declare `GetMinimumPtxVersionForComputeCapability()` |
| `ptx_version_util.cc` | Implement: returns PTX 8.7 for major >= 12, else 6.5 |
| `nvptx_backend.cc` | Apply PTX floor in `NVPTXGetTargetMachine` |
| `emitter_base.cc` | Apply PTX floor in MLIR emitter path |
| `BUILD` | Add `cuda_compute_capability` dep to `ptx_version_util` |
| `nvptx_backend_test.cc` | Tests for sm_120, sm_120a, sm_121, sm_90, sm_80 |

---

## What Was NOT Changed

- `kSupportedVersions` — sm_120/sm_120a already present, no change needed
- Triton path — already uses PTX 9.0 for major >= 9, no change needed
- Hermetic CUDA pins — CUDA 12.8 already maps to PTX 8.7, no change needed

---

## Tests

New test `GetMinimumPtxVersionForComputeCapability` in `nvptx_backend_test.cc`:

- `(12,0)` → PTX 8.7 ✅
- `(12,0,kAcceleratedFeatures)` (sm_120a) → PTX 8.7 ✅
- `(12,1)` → PTX 8.7 ✅
- `(9,0)` → PTX 6.5 (no regression) ✅
- `(8,0)` → PTX 6.5 (no regression) ✅

---

## Backward Compatibility

Only the minimum PTX version is raised when targeting sm_120/sm_120a.
sm_80, sm_86, sm_90 and all other existing targets are completely unaffected.