### PR TITLE
Fix integer overflow in GPU kernel loops for large tensors

### DIFF
--- a/tensorflow/core/kernels/population_count_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/population_count_op_gpu.cu.cc
@@ -36,7 +36,7 @@ template <typename T>
 __global__ void PopulationCountKernel(const int size,
                                       const T* __restrict__ input,
                                       uint8_t* __restrict__ output) {
-  GPU_1D_KERNEL_LOOP(i, size) { output[i] = __popc(ldg(input + i)); }
+  GPU_1D_KERNEL_LOOP(i, size, int64_t) { output[i] = __popc(ldg(input + i)); }
 }
 
 template <>
@@ -44,7 +44,7 @@ __global__ void PopulationCountKernel(const int size,
                                       const int8_t* __restrict__ input,
                                       uint8_t* __restrict__ output) {
   // For some reason, __popc on a negative int8 gets confused.
-  GPU_1D_KERNEL_LOOP(i, size) {
+  GPU_1D_KERNEL_LOOP(i, size, int64_t) {
     output[i] = __popc(ldg(reinterpret_cast<const uint8_t*>(input + i)));
   }
 }
@@ -54,7 +54,7 @@ __global__ void PopulationCountKernel(const int size,
                                       const int16_t* __restrict__ input,
                                       uint8_t* __restrict__ output) {
   // For some reason, __popc on a negative int16 gets confused.
-  GPU_1D_KERNEL_LOOP(i, size) {
+  GPU_1D_KERNEL_LOOP(i, size, int64_t) {
     output[i] = __popc(ldg(reinterpret_cast<const uint16_t*>(input + i)));
   }
 }
@@ -63,7 +63,7 @@ template <>
 __global__ void PopulationCountKernel<int64_t>(
     const int size, const int64_t* __restrict__ input,
     uint8_t* __restrict__ output) {
-  GPU_1D_KERNEL_LOOP(i, size) { output[i] = __popcll(ldg(input + i)); }
+  GPU_1D_KERNEL_LOOP(i, size, int64_t) { output[i] = __popcll(ldg(input + i)); }
 }
 
 #define DEFINE_GPU_SPECS(T)                                                   \

--- a/tensorflow/core/kernels/roll_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/roll_op_gpu.cu.cc
@@ -35,7 +35,7 @@ __global__ void RollKernel(const int32_t nthreads, const int32_t num_dims,
                            const int32_t* __restrict__ dim_size,
                            const int32_t* __restrict__ threshold,
                            const int64_t* __restrict__ dim_range) {
-  CUDA_1D_KERNEL_LOOP(out_idx, nthreads) {
+  CUDA_1D_KERNEL_LOOP(out_idx, nthreads, int64_t) {
     int64_t offset = 0;
     for (int i = 0; i < num_dims; i++) {
       const int64_t stride = dim_range[i] / dim_size[i];

--- a/tensorflow/core/util/gpu_kernel_helper.h
+++ b/tensorflow/core/util/gpu_kernel_helper.h
@@ -33,11 +33,32 @@ limitations under the License.
 #define TF_RED_WARPSIZE 64
 #endif
 
-// Deprecated, use 'for(int i : GpuGridRangeX(n))' instead.
-#define GPU_1D_KERNEL_LOOP(i, n) \
+#define GPU_1D_KERNEL_LOOP_2(i, n) \
   for (int i : ::tensorflow::GpuGridRangeX<int>(n))
-#define CUDA_1D_KERNEL_LOOP(i, n) \
+
+#define GPU_1D_KERNEL_LOOP_3(i, n, T) \
+  for (T i : ::tensorflow::GpuGridRangeX<T>(n))
+
+#define GPU_1D_KERNEL_LOOP_SELECT(_1, _2, _3, NAME, ...) NAME
+// if 2 arguments are passed, the legacy implementation is used with i as int
+// if 3 arguments are passed, the implementation is used with i as the type T
+#define GPU_1D_KERNEL_LOOP(...)                                \
+  GPU_1D_KERNEL_LOOP_SELECT(__VA_ARGS__, GPU_1D_KERNEL_LOOP_3, \
+                            GPU_1D_KERNEL_LOOP_2)              \
+  (__VA_ARGS__)
+#define CUDA_1D_KERNEL_LOOP_2(i, n) \
   for (int i : ::tensorflow::GpuGridRangeX<int>(n))
+
+#define CUDA_1D_KERNEL_LOOP_3(i, n, T) \
+  for (T i : ::tensorflow::GpuGridRangeX<T>(n))
+
+#define CUDA_1D_KERNEL_LOOP_SELECT(_1, _2, _3, NAME, ...) NAME
+
+#define CUDA_1D_KERNEL_LOOP(...)                                 \
+  CUDA_1D_KERNEL_LOOP_SELECT(__VA_ARGS__, CUDA_1D_KERNEL_LOOP_3, \
+                             CUDA_1D_KERNEL_LOOP_2)              \
+  (__VA_ARGS__)
+
 
 // Deprecated, use 'for(int i : GpuGridRange?(n))' instead.
 #define GPU_AXIS_KERNEL_LOOP(i, n, axis) \


### PR DESCRIPTION
`GPU_1D_KERNEL_LOOP` and `CUDA_1D_KERNEL_LOOP` currently hardcode the loop
index type to `int` via `GpuGridRangeX<int>`. That can be safe for some kernels, but
it becomes fragile for very large launches: when the iteration space is close to
the 32-bit limit, the range helper’s internal stride arithmetic can overflow,
which may yield incorrect indices.

This patch extends both macros with an optional explicit index type:
`GPU_1D_KERNEL_LOOP(i, n, T)` and `CUDA_1D_KERNEL_LOOP(i, n, T)`. Callers that
operate on large tensor sizes can now request `int64_t`, so the range/stride
computation is performed in 64-bit arithmetic.

The change is backward compatible. The existing 2-argument form is preserved and
continues to instantiate `GpuGridRangeX<int>`, while the new 3-argument form is
selected only for call sites that explicitly provide a type. This patch updates
the `population_count` and `roll` GPU kernels to use `int64_t` indices.
fixed issues #109520 #104077
There are ~20 open issues that can be fixed using this new macro, would you like me
to create one pull request that fixes them all or split in chunks?