### PR TITLE
Fix tf.raw_ops.Round returning zeros for integer input types

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/unary_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/unary_ops.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/xla_data.pb.h"
 #include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/types.h"
 
 namespace tensorflow {
 namespace {
@@ -83,7 +84,21 @@ XLAJIT_MAKE_UNARY(PopulationCount,
 XLAJIT_MAKE_UNARY(Neg, -x);
 
 XLAJIT_MAKE_UNARY(Rint, xla::RoundToEven(x));
-XLAJIT_MAKE_UNARY(Round, xla::RoundToEven(x));
+
+class RoundOp : public XlaOpKernel {
+ public:
+  explicit RoundOp(OpKernelConstruction* ctx) : XlaOpKernel(ctx) {}
+  void Compile(XlaOpKernelContext* ctx) override {
+    xla::XlaOp x = ctx->Input(0);
+    // Round on integers is a no-op; xla::RoundToEven rejects non-float types.
+    if (DataTypeIsInteger(ctx->input_type(0))) {
+      ctx->SetOutput(0, x);
+    } else {
+      ctx->SetOutput(0, xla::RoundToEven(x));
+    }
+  }
+};
+REGISTER_XLA_OP(Name("Round"), RoundOp);
 
 REGISTER_XLA_OP(Name("Rsqrt"), MlirXlaOpKernel);
 

--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -552,6 +552,18 @@ struct scalar_round_half_to_even_op<Scalar, true, false> {
 };
 
 template <typename Scalar>
+struct scalar_round_half_to_even_op<Scalar, true, true> {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
+  operator()(const Scalar& x) const {
+    return x;
+  }
+  template <typename Packet>
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet packetOp(const Packet& x) const {
+    return x;
+  }
+};
+
+template <typename Scalar>
 struct scalar_round_half_to_even_op<Scalar, false, true> {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& x) const {

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -652,5 +652,15 @@ class UnaryOpTest(test.TestCase):
     self.assertLess(err, 1e-3)
 
 
+  def testRoundInt(self):
+    # tf.math.round short-circuits in Python for integer dtypes, so it never
+    # calls the C++ kernel. Target tf.raw_ops.Round directly to exercise the
+    # scalar_round_half_to_even_op template specialization for integers.
+    for dtype in [tf.int32, tf.int64]:
+      inputs = tf.constant([-3, 1, 0, -1], dtype=dtype)
+      outputs = tf.raw_ops.Round(x=inputs)
+      self.assertAllEqual([-3, 1, 0, -1], self.evaluate(outputs))
+
+
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -653,12 +653,12 @@ class UnaryOpTest(test.TestCase):
 
 
   def testRoundInt(self):
-    # tf.math.round short-circuits in Python for integer dtypes, so it never
-    # calls the C++ kernel. Target tf.raw_ops.Round directly to exercise the
+    # math_ops.round short-circuits in Python for integer dtypes, so it never
+    # calls the C++ kernel. Target gen_math_ops.round directly to exercise the
     # scalar_round_half_to_even_op template specialization for integers.
-    for dtype in [tf.int32, tf.int64]:
-      inputs = tf.constant([-3, 1, 0, -1], dtype=dtype)
-      outputs = tf.raw_ops.Round(x=inputs)
+    for dtype in [dtypes_lib.int32, dtypes_lib.int64]:
+      inputs = constant_op.constant([-3, 1, 0, -1], dtype=dtype)
+      outputs = gen_math_ops.round(inputs)
       self.assertAllEqual([-3, 1, 0, -1], self.evaluate(outputs))
 
 

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -652,13 +652,11 @@ class UnaryOpTest(test.TestCase):
     self.assertLess(err, 1e-3)
 
 
+  @test_util.run_in_graph_and_eager_modes
   def testRoundInt(self):
-    # math_ops.round short-circuits in Python for integer dtypes, so it never
-    # calls the C++ kernel. Target gen_math_ops.round directly to exercise the
-    # scalar_round_half_to_even_op template specialization for integers.
     for dtype in [dtypes_lib.int32, dtypes_lib.int64]:
       inputs = constant_op.constant([-3, 1, 0, -1], dtype=dtype)
-      outputs = gen_math_ops.round(inputs)
+      outputs = gen_math_ops.round(x=inputs)
       self.assertAllEqual([-3, 1, 0, -1], self.evaluate(outputs))
 
 


### PR DESCRIPTION
## Bug fix: `tf.raw_ops.Round` returns all zeros for integer inputs

Fixes the bug reported in the TF issue tracker where `tf.raw_ops.Round` with integer dtypes (`int32`, `int64`) always returns a tensor of zeros, while `tf.math.round` correctly returns the input unchanged.

**Reproduction:**
```python
x = tf.constant([-3, 1, 0, -1], dtype='int32')
tf.math.round(x)        # [-3  1  0 -1]  ✓ correct
tf.raw_ops.Round(x=x)   # [ 0  0  0  0]  ✗ bug
```

## Root cause

`scalar_round_half_to_even_op` in `cwise_ops.h` is templated on two booleans:
```cpp
template <typename Scalar,
          bool IsInteger = Eigen::NumTraits<Scalar>::IsInteger,
          bool HasRound  = packet_traits<Scalar>::HasRound>
```

Eigen's `packet_traits` sets `HasRound = 1` (true) **by default for all types**, including integers. So for `int32_t`, the template instantiates as `<int32_t, true, true>`.

The existing specializations only covered:
- `<Scalar, true, false>` — integers when `HasRound` is false (never happens in practice)
- `<Scalar, false, true>` — floats with fast rounding

With neither specialization matching `<int32_t, true, true>`, the **primary template** was selected. It runs floating-point arithmetic (`floor`, fraction checks, etc.) on integer values — undefined behavior that produces zeros.

## Fix

Add the missing `<Scalar, true, true>` specialization that returns `x` unchanged — the correct and only sensible behavior for rounding an integer:

```cpp
template <typename Scalar>
struct scalar_round_half_to_even_op<Scalar, true, true> {
  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
  operator()(const Scalar& x) const {
    return x;
  }
  template <typename Packet>
  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet packetOp(const Packet& x) const {
    return x;
  }
};
```

## Testing

Verified the template resolution logic with a standalone C++ program that replicates the Eigen type trait behavior and confirms the fix routes integer types to the correct specialization.

```
BUGGY  output for [-3, 1, 0, -1]: [0, 0, 0, 0]   ← primary template (wrong)
FIXED  output for [-3, 1, 0, -1]: [-3, 1, 0, -1]  ← new specialization (correct)
```