### PR TITLE
Fix XLA strided-slice crash on degenerate dynamic ranges

### DIFF
--- a/tensorflow/compiler/tests/slice_ops_test.py
+++ b/tensorflow/compiler/tests/slice_ops_test.py
@@ -192,6 +192,16 @@ class StridedSliceTest(xla_test.XLATestCase):
 
         self.assertEqual(tensor_shape.TensorShape((0, 3)), result.shape)
 
+  def test2DDegenerateFromWhere(self):
+    with self.session():
+      with self.test_scope():
+        x = array_ops.placeholder(dtypes.bool)
+        indices = array_ops.where(x)
+        o = array_ops.strided_slice(indices, [-1, 0], [0, 3])
+      result = o.eval(feed_dict={x: [True, False, True]})
+
+      self.assertEqual(tensor_shape.TensorShape((0, 1)), result.shape)
+
   def test2DFullSlice(self):
     for dtype in self.numeric_types:
       with self.session():

--- a/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
@@ -380,11 +380,14 @@ class StridedSliceOp : public XlaOpKernel {
             }
             operand_size = xla::Min(operand_size, end_size);
           }
-          slice = xla::SetDimensionSize(
-              slice,
+          // Degenerate slices can produce begin > end after index wrapping;
+          // dynamic dimension sizes must stay non-negative.
+          xla::XlaOp dim_size =
               xla::Sub(operand_size, xla::ConstantR0<int32_t>(
-                                         ctx->builder(), begin[input_index])),
-              i);
+                                         ctx->builder(), begin[input_index]));
+          dim_size =
+              xla::Max(dim_size, xla::ConstantR0<int32_t>(ctx->builder(), 0));
+          slice = xla::SetDimensionSize(slice, dim_size, i);
         }
       }
       ctx->SetOutput(0, slice);


### PR DESCRIPTION
## Summary
This fixes a crash in XLA `StridedSlice` when dynamic dimension size is computed from a degenerate range (`begin > end` after index wrapping/clamping), which can yield a negative size before `SetDimensionSize`.

- Clamp computed dynamic dim size to be non-negative before calling `SetDimensionSize`.
- Add a regression test matching the `where(...)` + degenerate `strided_slice` pattern from the reported issue.

Fixes #112132

## Testing
- `bazelisk test //tensorflow/compiler/tests:slice_ops_test --test_filter=StridedSliceTest.test2DDegenerateFromWhere --test_output=errors --repo_env=HERMETIC_PYTHON_VERSION=3.11`
