### PR TITLE
Fix kaiser_window for negative beta values

### DIFF
--- a/tensorflow/python/ops/signal/window_ops.py
+++ b/tensorflow/python/ops/signal/window_ops.py
@@ -80,6 +80,10 @@ def kaiser_window(window_length, beta=12., dtype=dtypes.float32, name=None):
     # Convert everything into given dtype which can be float16.
     arg = math_ops.cast(arg, dtype=dtype)
     beta = math_ops.cast(beta, dtype=dtype)
+    # I0 (modified Bessel function of the first kind) is an even function,
+    # i.e., I0(-x) = I0(x). Take abs(beta) so that negative beta values
+    # produce the same (correct) result as positive ones.
+    beta = math_ops.abs(beta)
     one = math_ops.cast(1.0, dtype=dtype)
     halflen_float = math_ops.cast(halflen_float, dtype=dtype)
     num = beta * math_ops.sqrt(nn_ops.relu(


### PR DESCRIPTION
## Summary
- Fix `tf.signal.kaiser_window` producing incorrect results for negative `beta` values
- Add `math_ops.abs(beta)` since I0 (modified Bessel function of the first kind) is an even function: I0(-x) = I0(x)
- This ensures `kaiser_window(beta)` and `kaiser_window(-beta)` produce identical, correct results

Fixes #112200

## Test plan
- [ ] Verify `tf.signal.kaiser_window(10, beta=12.0)` and `tf.signal.kaiser_window(10, beta=-12.0)` produce identical output
- [ ] Verify existing kaiser_window tests still pass
- [ ] Verify `kaiser_bessel_derived_window` (which calls `kaiser_window`) also works correctly with negative beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)