### PR TITLE
Fix IRFFT crash on single-element complex input

### DIFF
--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -498,6 +498,24 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
           feed_dict=feed_dict,
       )
 
+  def testIRFFTZeroOrNegativeLengthRaisesError(self):
+    x = array_ops.ones([1], dtype=dtypes.complex64)
+    with self.assertRaisesRegex(ValueError, r"fft_length\[-1\] must be > 0"):
+      fft_ops.irfft(x)
+
+    x = array_ops.ones([5], dtype=dtypes.complex64)
+    with self.assertRaisesRegex(ValueError, r"fft_length\[-1\] must be > 0"):
+      fft_ops.irfft(x, fft_length=[0])
+    with self.assertRaisesRegex(ValueError, r"fft_length\[-1\] must be > 0"):
+      fft_ops.irfft(x, fft_length=[-5])
+
+  def testIRFFTNDZeroOrNegativeLengthRaisesError(self):
+    x = array_ops.ones([5, 5], dtype=dtypes.complex64)
+    with self.assertRaisesRegex(ValueError, r"fft_length\[-1\] must be > 0"):
+      fft_ops.irfftnd(x, fft_length=[5, 0])
+    with self.assertRaisesRegex(ValueError, r"fft_length\[-1\] must be > 0"):
+      fft_ops.irfftnd(x, fft_length=[5, -3])
+
   def _np_fftn(self, x, fft_length=None, axes=None, norm=None):
     return np.fft.rfftn(x, s=fft_length, axes=axes, norm=norm)
 

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -516,6 +516,13 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
     with self.assertRaisesRegex(ValueError, r"fft_length\[-1\] must be > 0"):
       fft_ops.irfftnd(x, fft_length=[5, -3])
 
+  def testIRFFTWrongLengthRaisesBeforeNegativeLastLength(self):
+    x = array_ops.ones([5, 5], dtype=dtypes.complex64)
+    with self.assertRaisesRegex(ValueError, "Dimension must be 1 but is 2"):
+      fft_ops.irfft(x, fft_length=[-5, -5])
+    with self.assertRaisesRegex(ValueError, "Dimension must be 2 but is 1"):
+      fft_ops.irfftnd(x, fft_length=[-5])
+
   def _np_fftn(self, x, fft_length=None, axes=None, norm=None):
     return np.fft.rfftn(x, s=fft_length, axes=axes, norm=norm)
 

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -189,6 +189,14 @@ def _irfft_wrapper(ifft_fn, fft_rank, default_name):
         fft_length = _infer_fft_length_for_irfft(input_tensor, fft_rank)
       else:
         fft_length = _ops.convert_to_tensor(fft_length, _dtypes.int32)
+      # Validate that fft_length does not contain zero or negative values,
+      # which would produce an empty or invalid output tensor.
+      fft_length_val = _tensor_util.constant_value(fft_length)
+      if fft_length_val is not None and fft_length_val[-1] <= 0:
+        raise ValueError(
+            "Input to IRFFT must have last dimension of at least 2 to "
+            "produce a non-empty output, but got shape: %s"
+            % input_tensor.shape)
       input_tensor = _maybe_pad_for_rfft(input_tensor, fft_rank, fft_length,
                                          is_reverse=True)
       fft_length_static = _tensor_util.constant_value(fft_length)

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -86,17 +86,19 @@ def _infer_fft_length_for_irfft(input_tensor, fft_rank):
   return _ops.convert_to_tensor(fft_length, _dtypes.int32)
 
 
-def _validate_static_irfft_fft_length(fft_length_static):
+def _validate_static_irfft_fft_length(fft_length_static, fft_rank):
   if fft_length_static is None:
     return
   fft_length_static = np.asarray(fft_length_static)
+  if fft_length_static.ndim != 1:
+    raise ValueError(
+        "Shape %s must have rank 1" % (fft_length_static.shape,))
+  if fft_length_static.size != fft_rank:
+    raise ValueError("Dimension must be %d but is %d" %
+                     (fft_rank, fft_length_static.size))
   if fft_length_static.size == 0:
     return
-  if fft_length_static.ndim > 1:
-    return
-  fft_length_last = (
-      fft_length_static.item()
-      if fft_length_static.ndim == 0 else fft_length_static[-1])
+  fft_length_last = fft_length_static[-1]
   if fft_length_last <= 0:
     raise ValueError("fft_length[-1] must be > 0, got %d" %
                      fft_length_last)
@@ -207,10 +209,8 @@ def _irfft_wrapper(ifft_fn, fft_rank, default_name):
         fft_length = _ops.convert_to_tensor(fft_length, _dtypes.int32)
       fft_length_static = _tensor_util.constant_value(fft_length)
       is_empty = input_tensor.shape.num_elements() == 0
-      wrong_length = (
-          fft_length_static is not None and fft_length_static.size != fft_rank)
-      if not is_empty and not wrong_length:
-        _validate_static_irfft_fft_length(fft_length_static)
+      if not is_empty:
+        _validate_static_irfft_fft_length(fft_length_static, fft_rank)
       input_tensor = _maybe_pad_for_rfft(input_tensor, fft_rank, fft_length,
                                          is_reverse=True)
       if fft_length_static is not None:
@@ -390,7 +390,7 @@ def _irfftn_wrapper(irfft_n, default_name):
         fft_length = _ops.convert_to_tensor(fft_length, _dtypes.int32)
       fft_length_static = _tensor_util.constant_value(fft_length)
       if input_tensor.shape.num_elements() != 0:
-        _validate_static_irfft_fft_length(fft_length_static)
+        _validate_static_irfft_fft_length(fft_length_static, fft_rank)
       input_tensor = _maybe_pad_for_rfft(
           input_tensor, fft_rank, fft_length, is_reverse=True
       )

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -92,6 +92,8 @@ def _validate_static_irfft_fft_length(fft_length_static):
   fft_length_static = np.asarray(fft_length_static)
   if fft_length_static.size == 0:
     return
+  if fft_length_static.ndim > 1:
+    return
   fft_length_last = (
       fft_length_static.item()
       if fft_length_static.ndim == 0 else fft_length_static[-1])
@@ -204,7 +206,11 @@ def _irfft_wrapper(ifft_fn, fft_rank, default_name):
       else:
         fft_length = _ops.convert_to_tensor(fft_length, _dtypes.int32)
       fft_length_static = _tensor_util.constant_value(fft_length)
-      _validate_static_irfft_fft_length(fft_length_static)
+      is_empty = input_tensor.shape.num_elements() == 0
+      wrong_length = (
+          fft_length_static is not None and fft_length_static.size != fft_rank)
+      if not is_empty and not wrong_length:
+        _validate_static_irfft_fft_length(fft_length_static)
       input_tensor = _maybe_pad_for_rfft(input_tensor, fft_rank, fft_length,
                                          is_reverse=True)
       if fft_length_static is not None:
@@ -383,7 +389,8 @@ def _irfftn_wrapper(irfft_n, default_name):
       else:
         fft_length = _ops.convert_to_tensor(fft_length, _dtypes.int32)
       fft_length_static = _tensor_util.constant_value(fft_length)
-      _validate_static_irfft_fft_length(fft_length_static)
+      if input_tensor.shape.num_elements() != 0:
+        _validate_static_irfft_fft_length(fft_length_static)
       input_tensor = _maybe_pad_for_rfft(
           input_tensor, fft_rank, fft_length, is_reverse=True
       )

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -86,6 +86,20 @@ def _infer_fft_length_for_irfft(input_tensor, fft_rank):
   return _ops.convert_to_tensor(fft_length, _dtypes.int32)
 
 
+def _validate_static_irfft_fft_length(fft_length_static):
+  if fft_length_static is None:
+    return
+  fft_length_static = np.asarray(fft_length_static)
+  if fft_length_static.size == 0:
+    return
+  fft_length_last = (
+      fft_length_static.item()
+      if fft_length_static.ndim == 0 else fft_length_static[-1])
+  if fft_length_last <= 0:
+    raise ValueError("fft_length[-1] must be > 0, got %d" %
+                     fft_length_last)
+
+
 def _maybe_pad_for_rfft(input_tensor, fft_rank, fft_length, is_reverse=False):
   """Pads `input_tensor` to `fft_length` on its inner-most `fft_rank` dims."""
   fft_shape = _tensor_util.constant_value_as_shape(fft_length)
@@ -189,17 +203,10 @@ def _irfft_wrapper(ifft_fn, fft_rank, default_name):
         fft_length = _infer_fft_length_for_irfft(input_tensor, fft_rank)
       else:
         fft_length = _ops.convert_to_tensor(fft_length, _dtypes.int32)
-      # Validate that fft_length does not contain zero or negative values,
-      # which would produce an empty or invalid output tensor.
-      fft_length_val = _tensor_util.constant_value(fft_length)
-      if fft_length_val is not None and fft_length_val[-1] <= 0:
-        raise ValueError(
-            "Input to IRFFT must have last dimension of at least 2 to "
-            "produce a non-empty output, but got shape: %s"
-            % input_tensor.shape)
+      fft_length_static = _tensor_util.constant_value(fft_length)
+      _validate_static_irfft_fft_length(fft_length_static)
       input_tensor = _maybe_pad_for_rfft(input_tensor, fft_rank, fft_length,
                                          is_reverse=True)
-      fft_length_static = _tensor_util.constant_value(fft_length)
       if fft_length_static is not None:
         fft_length = fft_length_static
       return ifft_fn(input_tensor, fft_length, Treal=real_dtype, name=name)
@@ -375,10 +382,11 @@ def _irfftn_wrapper(irfft_n, default_name):
         fft_length = _infer_fft_length_for_irfftn(input_tensor)
       else:
         fft_length = _ops.convert_to_tensor(fft_length, _dtypes.int32)
+      fft_length_static = _tensor_util.constant_value(fft_length)
+      _validate_static_irfft_fft_length(fft_length_static)
       input_tensor = _maybe_pad_for_rfft(
           input_tensor, fft_rank, fft_length, is_reverse=True
       )
-      fft_length_static = _tensor_util.constant_value(fft_length)
       if fft_length_static is not None:
         fft_length = fft_length_static
 


### PR DESCRIPTION
## Summary

Fixes #112406.

IRFFT now validates a statically known `fft_length` consistently before indexing its final element. Both the 1-D and N-D inverse-real FFT wrappers reject non-vector lengths, lengths with the wrong number of elements, and non-positive final lengths with a clear `ValueError` instead of reaching a crashing kernel path.

## Changes

- Centralize static IRFFT length validation in `_validate_static_irfft_fft_length`.
- Apply the same validation to `_irfft` and `_irfftn` while preserving dynamic-length and empty-input behavior.
- Add graph/eager regression coverage proving wrong-sized vectors are rejected before the negative-final-length check for both wrappers.

## Testing

- PASS: `python -m py_compile tensorflow/python/ops/signal/fft_ops.py tensorflow/python/kernel_tests/signal/fft_ops_test.py`
- PASS: `git diff --check`
- NOT RUN locally: TensorFlow Bazel unit/build targets because Bazel, buildifier, and a built TensorFlow runtime are unavailable in this checkout.
- Fresh upstream CI was triggered by commit `3f3af7464ea` and is pending.

## Risk

Low. Validation is limited to statically known, non-empty IRFFT lengths; runtime-defined lengths and the existing empty-input path are unchanged.
