### PR TITLE
Fix ctc_loss crash when logits has num_classes=0

### DIFF
--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -839,6 +839,19 @@ def ctc_loss_v2(labels,
         [Graves et al., 2006](https://dl.acm.org/citation.cfm?id=1143891)
         ([pdf](http://www.cs.toronto.edu/~graves/icml_2006.pdf))
   """
+  logits = ops.convert_to_tensor(logits, name="logits")
+  num_classes = tensor_shape.dimension_value(logits.shape[2])
+  if num_classes is not None:
+    if num_classes == 0:
+      raise ValueError(
+          "Logits must have at least 1 class, got 0 classes "
+          f"(logits shape: {logits.shape}).")
+    if blank_index is not None and blank_index >= 0 and blank_index >= num_classes:
+      raise ValueError(
+          f"Argument `blank_index` ({blank_index}) must be less than "
+          f"the number of classes ({num_classes}) "
+          f"(logits shape: {logits.shape}).")
+
   if isinstance(labels, sparse_tensor.SparseTensor):
     if blank_index is None:
       raise ValueError(
@@ -980,6 +993,19 @@ def ctc_loss_v3(labels,
 
       https://en.wikipedia.org/wiki/Connectionist_temporal_classification
   """
+  logits = ops.convert_to_tensor(logits, name="logits")
+  num_classes = tensor_shape.dimension_value(logits.shape[2])
+  if num_classes is not None:
+    if num_classes == 0:
+      raise ValueError(
+          "Logits must have at least 1 class, got 0 classes "
+          f"(logits shape: {logits.shape}).")
+    if blank_index is not None and blank_index >= 0 and blank_index >= num_classes:
+      raise ValueError(
+          f"Argument `blank_index` ({blank_index}) must be less than "
+          f"the number of classes ({num_classes}) "
+          f"(logits shape: {logits.shape}).")
+
   if isinstance(labels, sparse_tensor.SparseTensor):
     if blank_index is None:
       raise ValueError(
@@ -988,8 +1014,6 @@ def ctc_loss_v3(labels,
 
     if blank_index < 0:
       blank_index += _get_dim(logits, 2)
-
-    logits = ops.convert_to_tensor(logits, name="logits")
 
     params = {
         "labels": labels,


### PR DESCRIPTION
## Summary
- Fixes `tf.nn.ctc_loss` crash when logits tensor has a zero-sized class dimension (`num_classes=0`)
- Adds early `ValueError` with a clear message in both `ctc_loss_v2` and `ctc_loss_v3` when `num_classes` is statically known to be 0
- Also validates that `blank_index` (when non-negative) does not exceed the number of classes

Fixes #112407

## Reproduction
```python
import tensorflow as tf
logits = tf.random.uniform(shape=[2, 5, 0], dtype=tf.float32)
labels = tf.sparse.from_dense(tf.constant([[1, 2, 3], [2, 1, 0]], dtype=tf.int32))
loss = tf.nn.ctc_loss(labels=labels, logits=logits, label_length=tf.constant([3,3]),
                      logit_length=tf.constant([5,5]), logits_time_major=False, blank_index=-1)
```
Previously crashed with an obscure error; now raises:
```
ValueError: Logits must have at least 1 class, got 0 classes (logits shape: (2, 5, 0)).
```

## Test plan
- [ ] Verify `tf.nn.ctc_loss` raises `ValueError` with `num_classes=0`
- [ ] Verify `tf.nn.ctc_loss` raises `ValueError` when `blank_index >= num_classes`
- [ ] Verify normal usage with valid `num_classes` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)