### PR TITLE
Fix conv1d eager/graph mode inconsistency for zero-sized output

### DIFF
--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -60,24 +60,31 @@ absl::Status GetWindowedOutputSizeFromDimsV2(
     case Padding::VALID:
       padding_before = padding_after = 0;
       TF_FALLTHROUGH_INTENDED;
-    case Padding::EXPLICIT:
+    case Padding::EXPLICIT: {
       TF_RETURN_IF_ERROR(
           c->Add(input_size, padding_before + padding_after, &input_size));
+      DimensionHandle window_size = c->MakeDim(filter_size);
       if (dilation_rate > 1) {
-        DimensionHandle window_size;
         TF_RETURN_IF_ERROR(
-            c->Subtract(c->MakeDim(filter_size), 1, &window_size));
+            c->Subtract(window_size, 1, &window_size));
         TF_RETURN_IF_ERROR(
             c->Multiply(window_size, dilation_rate, &window_size));
         TF_RETURN_IF_ERROR(c->Add(window_size, 1, &window_size));
-        TF_RETURN_IF_ERROR(c->Subtract(input_size, window_size, output_size));
-      } else {
-        TF_RETURN_IF_ERROR(c->Subtract(input_size, filter_size, output_size));
       }
-      TF_RETURN_IF_ERROR(c->Add(*output_size, stride, output_size));
-      TF_RETURN_IF_ERROR(c->Divide(*output_size, stride,
-                                   /*evenly_divisible=*/false, output_size));
+      // A negative intermediate can still produce a valid zero after the
+      // stride is added, but DimensionHandle cannot represent that value.
+      if (c->ValueKnown(input_size) && c->ValueKnown(window_size) &&
+          c->Value(input_size) < c->Value(window_size) &&
+          c->Value(window_size) - c->Value(input_size) <= stride) {
+        *output_size = c->MakeDim(0);
+      } else {
+        TF_RETURN_IF_ERROR(c->Subtract(input_size, window_size, output_size));
+        TF_RETURN_IF_ERROR(c->Add(*output_size, stride, output_size));
+        TF_RETURN_IF_ERROR(c->Divide(*output_size, stride,
+                                     /*evenly_divisible=*/false, output_size));
+      }
       break;
+    }
     case Padding::SAME:
       TF_RETURN_IF_ERROR(c->Add(input_size, stride - 1, output_size));
       TF_RETURN_IF_ERROR(c->Divide(*output_size, stride,

--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -60,31 +60,24 @@ absl::Status GetWindowedOutputSizeFromDimsV2(
     case Padding::VALID:
       padding_before = padding_after = 0;
       TF_FALLTHROUGH_INTENDED;
-    case Padding::EXPLICIT: {
+    case Padding::EXPLICIT:
       TF_RETURN_IF_ERROR(
           c->Add(input_size, padding_before + padding_after, &input_size));
-      DimensionHandle window_size = c->MakeDim(filter_size);
       if (dilation_rate > 1) {
+        DimensionHandle window_size;
         TF_RETURN_IF_ERROR(
-            c->Subtract(window_size, 1, &window_size));
+            c->Subtract(c->MakeDim(filter_size), 1, &window_size));
         TF_RETURN_IF_ERROR(
             c->Multiply(window_size, dilation_rate, &window_size));
         TF_RETURN_IF_ERROR(c->Add(window_size, 1, &window_size));
-      }
-      // A negative intermediate can still produce a valid zero after the
-      // stride is added, but DimensionHandle cannot represent that value.
-      if (c->ValueKnown(input_size) && c->ValueKnown(window_size) &&
-          c->Value(input_size) < c->Value(window_size) &&
-          c->Value(window_size) - c->Value(input_size) <= stride) {
-        *output_size = c->MakeDim(0);
-      } else {
         TF_RETURN_IF_ERROR(c->Subtract(input_size, window_size, output_size));
-        TF_RETURN_IF_ERROR(c->Add(*output_size, stride, output_size));
-        TF_RETURN_IF_ERROR(c->Divide(*output_size, stride,
-                                     /*evenly_divisible=*/false, output_size));
+      } else {
+        TF_RETURN_IF_ERROR(c->Subtract(input_size, filter_size, output_size));
       }
+      TF_RETURN_IF_ERROR(c->Add(*output_size, stride, output_size));
+      TF_RETURN_IF_ERROR(c->Divide(*output_size, stride,
+                                   /*evenly_divisible=*/false, output_size));
       break;
-    }
     case Padding::SAME:
       TF_RETURN_IF_ERROR(c->Add(input_size, stride - 1, output_size));
       TF_RETURN_IF_ERROR(c->Divide(*output_size, stride,
@@ -598,6 +591,36 @@ absl::Status ShapeFromDimensions(DimensionHandle batch_dim,
 
 namespace {
 
+// Conv2D permits a zero-sized VALID output when adding the stride makes the
+// window formula non-negative. Keep this exception local to convolution:
+// pooling and the other users of GetWindowedOutputSizeFromDimsV2 require the
+// filter window to fit within the input.
+absl::Status GetConv2DWindowedOutputSizeFromDims(
+    shape_inference::InferenceContext* c,
+    shape_inference::DimensionHandle input_size,
+    shape_inference::DimensionOrConstant filter_size, int64_t dilation_rate,
+    int64_t stride, Padding padding_type, int64_t padding_before,
+    int64_t padding_after, shape_inference::DimensionHandle* output_size) {
+  if (padding_type == Padding::VALID && stride > 0 && dilation_rate >= 1) {
+    DimensionHandle window_size = c->MakeDim(filter_size);
+    if (dilation_rate > 1) {
+      TF_RETURN_IF_ERROR(c->Subtract(window_size, 1, &window_size));
+      TF_RETURN_IF_ERROR(
+          c->Multiply(window_size, dilation_rate, &window_size));
+      TF_RETURN_IF_ERROR(c->Add(window_size, 1, &window_size));
+    }
+    if (c->ValueKnown(input_size) && c->ValueKnown(window_size) &&
+        c->Value(input_size) < c->Value(window_size) &&
+        c->Value(window_size) - c->Value(input_size) <= stride) {
+      *output_size = c->MakeDim(0);
+      return absl::OkStatus();
+    }
+  }
+  return GetWindowedOutputSizeFromDimsV2(
+      c, input_size, filter_size, dilation_rate, stride, padding_type,
+      padding_before, padding_after, output_size);
+}
+
 absl::Status Conv2DShapeImpl(shape_inference::InferenceContext* c,
                              bool supports_explicit_padding) {
   std::string data_format_str, filter_format_str;
@@ -751,10 +774,10 @@ absl::Status Conv2DShapeImpl(shape_inference::InferenceContext* c,
     GetExplicitPaddingForDim(explicit_paddings, data_format, 'W',
                              &pad_cols_before, &pad_cols_after);
   }
-  TF_RETURN_IF_ERROR(GetWindowedOutputSizeFromDimsV2(
+  TF_RETURN_IF_ERROR(GetConv2DWindowedOutputSizeFromDims(
       c, input_spatial_dims[0], filter_rows_dim, dilation_rows, stride_rows,
       padding, pad_rows_before, pad_rows_after, &output_rows));
-  TF_RETURN_IF_ERROR(GetWindowedOutputSizeFromDimsV2(
+  TF_RETURN_IF_ERROR(GetConv2DWindowedOutputSizeFromDims(
       c, input_spatial_dims[1], filter_cols_dim, dilation_cols, stride_cols,
       padding, pad_cols_before, pad_cols_after, &output_cols));
 

--- a/tensorflow/core/framework/common_shape_fns_test.cc
+++ b/tensorflow/core/framework/common_shape_fns_test.cc
@@ -827,6 +827,13 @@ TEST_P(Conv2DShapeTest, Conv2DShapeTest) {
          /*data_format=*/"NHWC", /*filter_format=*/"HWIO");
   INFER_OK(op, "[1,4,4,1];[2,1,1,1]", "[d0_0,3,2,d1_3]");
 
+  // VALID padding permits zero-sized output dimensions but not negative ones.
+  set_op(/*strides=*/{{1, 1, 2, 1}}, /*padding=*/"VALID",
+         /*data_format=*/"NHWC", /*filter_format=*/"HWIO");
+  INFER_OK(op, "[1,1,3,1];[1,5,1,1]", "[d0_0,1,0,d1_3]");
+  INFER_ERROR("Negative dimension size", op,
+              "[1,1,2,1];[1,5,1,1]");
+
   // Unknown dims in the critical fields lead to partial inference.
   INFER_OK(op, "[1,4,4,1];[2,1,1,1]", "[d0_0,3,2,d1_3]");
   INFER_OK(op, "[1,?,4,1];[2,1,1,1]", "[d0_0,?,2,d1_3]");

--- a/tensorflow/core/framework/common_shape_fns_test.cc
+++ b/tensorflow/core/framework/common_shape_fns_test.cc
@@ -827,12 +827,14 @@ TEST_P(Conv2DShapeTest, Conv2DShapeTest) {
          /*data_format=*/"NHWC", /*filter_format=*/"HWIO");
   INFER_OK(op, "[1,4,4,1];[2,1,1,1]", "[d0_0,3,2,d1_3]");
 
-  // VALID padding permits zero-sized output dimensions but not negative ones.
-  set_op(/*strides=*/{{1, 1, 2, 1}}, /*padding=*/"VALID",
-         /*data_format=*/"NHWC", /*filter_format=*/"HWIO");
-  INFER_OK(op, "[1,1,3,1];[1,5,1,1]", "[d0_0,1,0,d1_3]");
-  INFER_ERROR("Negative dimension size", op,
-              "[1,1,2,1];[1,5,1,1]");
+  if (op_name == "Conv2D") {
+    // VALID padding permits zero-sized output dimensions but not negative ones.
+    set_op(/*strides=*/{{1, 1, 2, 1}}, /*padding=*/"VALID",
+           /*data_format=*/"NHWC", /*filter_format=*/"HWIO");
+    INFER_OK(op, "[1,1,3,1];[1,5,1,1]", "[d0_0,1,0,d1_3]");
+    INFER_ERROR("Negative dimension size", op,
+                "[1,1,2,1];[1,5,1,1]");
+  }
 
   // Unknown dims in the critical fields lead to partial inference.
   INFER_OK(op, "[1,4,4,1];[2,1,1,1]", "[d0_0,3,2,d1_3]");
@@ -1428,6 +1430,10 @@ TEST(CommonShapeFnsTest, MaxPool2DShapeTest) {
   // depth 3 stride, 1x1x1 filter, NCHW
   set_op({1, 3, 1, 1}, {1, 1, 1, 1}, "VALID", "NCHW");
   INFER_OK(op, "[1,7,5,5]", "[d0_0,3,5,5]");
+
+  // Pooling requires the filter window to fit within the input.
+  set_op({1, 1, 1, 1}, {1, 1, 2, 1}, "VALID", "NHWC");
+  INFER_ERROR("Negative dimension size", op, "[1,1,1,1]");
 
   // 5x7 input, 2x2 ksize, 1x1 stride, NCHW_VECT_C tests
   set_op({{1, 1, 1, 1}}, {1, 1, 2, 2}, "SAME", "NCHW_VECT_C");

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -874,7 +874,7 @@ class MklConvOp : public OpKernel {
         MklDnnShape dst_mkl_shape;
         dst_mkl_shape.SetMklTensor(false);
         AllocateOutputSetMklShape(context, kOutputIndex_Dst, &dst_tensor,
-                                  src_tf_shape, dst_mkl_shape, native_format);
+                                  dst_tf_shape, dst_mkl_shape, native_format);
 
         // MklConv2D/3D also outputs converted filter as 2nd output.
         filter_mkl_shape.SetMklTensor(false);

--- a/tensorflow/lite/testing/op_tests/conv.py
+++ b/tensorflow/lite/testing/op_tests/conv.py
@@ -145,4 +145,4 @@ def make_conv_tests(options):
       test_parameters,
       build_graph,
       build_inputs,
-      expected_tf_failures=60)
+      expected_tf_failures=18)

--- a/tensorflow/lite/testing/op_tests/conv_activation.py
+++ b/tensorflow/lite/testing/op_tests/conv_activation.py
@@ -122,7 +122,7 @@ def make_conv_activation_tests(activation_op):
         test_parameters,
         build_graph,
         build_inputs,
-        expected_tf_failures=48)
+        expected_tf_failures=12)
 
   return f
 

--- a/tensorflow/lite/testing/op_tests/identify_dilated_conv.py
+++ b/tensorflow/lite/testing/op_tests/identify_dilated_conv.py
@@ -89,4 +89,4 @@ def make_identify_dilated_conv_tests(options):
       test_parameters,
       build_graph,
       build_inputs,
-      expected_tf_failures=168)
+      expected_tf_failures=156)

--- a/tensorflow/lite/testing/op_tests/identify_dilated_conv1d.py
+++ b/tensorflow/lite/testing/op_tests/identify_dilated_conv1d.py
@@ -72,4 +72,4 @@ def make_identify_dilated_conv1d_tests(options):
       test_parameters,
       build_graph,
       build_inputs,
-      expected_tf_failures=16)
+      expected_tf_failures=6)

--- a/tensorflow/python/kernel_tests/nn_ops/conv1d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv1d_test.py
@@ -79,6 +79,19 @@ class Conv1DTest(test.TestCase):
               output,
               [[2 * 1 + 1 * 2, 2 * 3 + 1 * 4], [2 * 1 + 1 * 2, 2 * 3 + 1 * 4]])
 
+  def testTensorLikeInputsWithValidPadding(self):
+    values = [[[1.0], [2.0], [3.0]]]
+    filters = [[[1.0]], [[1.0]]]
+    for value, filter_value in (
+        (values, filters),
+        (np.asarray(values, dtype=np.float32),
+         np.asarray(filters, dtype=np.float32)),
+    ):
+      with self.subTest(input_type=type(value).__name__):
+        result = nn_ops.conv1d(
+            value, filter_value, stride=1, padding="VALID")
+        self.assertAllClose(self.evaluate(result), [[[3.0], [5.0]]])
+
   def testConv1DRejectsNegativeValidOutputShape(self):
     with context.eager_mode():
       x = array_ops.zeros([1, 2, 1])

--- a/tensorflow/python/kernel_tests/nn_ops/conv1d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv1d_test.py
@@ -86,6 +86,10 @@ class Conv1DTest(test.TestCase):
       with self.assertRaisesRegex(ValueError, "Negative dimension size"):
         nn_ops.conv1d(x, filters, stride=1, padding="VALID")
 
+      zero_output = nn_ops.conv1d(
+          array_ops.zeros([1, 3, 1]), filters, stride=2, padding="VALID")
+      self.assertAllEqual(zero_output.shape.as_list(), [1, 0, 1])
+
       valid_x = array_ops.zeros([1, 5, 1])
       self.evaluate(
           nn_ops.conv1d(valid_x, filters, stride=1, padding="VALID"))
@@ -113,6 +117,14 @@ class Conv1DTest(test.TestCase):
 
     with self.assertRaisesRegex(ValueError, "Negative dimension size"):
       graph_conv_invalid()
+
+    @def_function.function
+    def graph_conv_zero_output():
+      x = array_ops.zeros([1, 3, 1])
+      filters = array_ops.zeros([5, 1, 1])
+      return nn_ops.conv1d(x, filters, stride=2, padding="VALID")
+
+    self.assertAllEqual(graph_conv_zero_output().shape.as_list(), [1, 0, 1])
 
   def testConv1DTranspose(self):
     with self.cached_session():

--- a/tensorflow/python/kernel_tests/nn_ops/conv1d_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/conv1d_test.py
@@ -15,6 +15,8 @@
 """Tests for convolution related functionality in tensorflow.ops.nn."""
 import numpy as np
 
+from tensorflow.python.eager import context
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import array_ops
@@ -76,6 +78,41 @@ class Conv1DTest(test.TestCase):
           self.assertAllClose(
               output,
               [[2 * 1 + 1 * 2, 2 * 3 + 1 * 4], [2 * 1 + 1 * 2, 2 * 3 + 1 * 4]])
+
+  def testConv1DRejectsNegativeValidOutputShape(self):
+    with context.eager_mode():
+      x = array_ops.zeros([1, 2, 1])
+      filters = array_ops.zeros([5, 1, 1])
+      with self.assertRaisesRegex(ValueError, "Negative dimension size"):
+        nn_ops.conv1d(x, filters, stride=1, padding="VALID")
+
+      valid_x = array_ops.zeros([1, 5, 1])
+      self.evaluate(
+          nn_ops.conv1d(valid_x, filters, stride=1, padding="VALID"))
+      self.evaluate(nn_ops.conv1d(x, filters, stride=1, padding="SAME"))
+
+      dilated_filters = array_ops.zeros([3, 1, 1])
+      with self.assertRaisesRegex(ValueError, "Negative dimension size"):
+        nn_ops.conv1d(
+            x, dilated_filters, stride=1, padding="VALID", dilations=2)
+
+      expanded_batch_x = array_ops.zeros([2, 3, 2, 1])
+      with self.assertRaisesRegex(ValueError, "Negative dimension size"):
+        nn_ops.conv1d(expanded_batch_x, filters, stride=1, padding="VALID")
+
+      ncw_x = array_ops.zeros([2, 3, 1, 2])
+      with self.assertRaisesRegex(ValueError, "Negative dimension size"):
+        nn_ops.conv1d(
+            ncw_x, filters, stride=1, padding="VALID", data_format="NCW")
+
+    @def_function.function
+    def graph_conv_invalid():
+      x = array_ops.zeros([1, 2, 1])
+      filters = array_ops.zeros([5, 1, 1])
+      return nn_ops.conv1d(x, filters, stride=1, padding="VALID")
+
+    with self.assertRaisesRegex(ValueError, "Negative dimension size"):
+      graph_conv_invalid()
 
   def testConv1DTranspose(self):
     with self.cached_session():

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2067,6 +2067,30 @@ def conv1d(
     strides = [1] + _get_sequence(stride, 1, channel_index, "stride")
     dilations = [1] + _get_sequence(dilations, 1, channel_index, "dilations")
 
+    # Validate that the output spatial dimension is non-negative for VALID
+    # padding. In graph mode this check is performed during shape inference,
+    # but eager mode silently produces a zero-sized tensor which is almost
+    # never intended and causes confusing downstream errors.
+    if isinstance(padding, str) and padding.upper() == "VALID":
+      value_shape = value.shape
+      filters_shape = filters.shape
+      if value_shape.rank is not None and filters_shape.rank is not None:
+        if data_format == "NHWC":
+          in_width = value_shape[-2]
+        else:  # NCHW
+          in_width = value_shape[-1]
+        filter_width = filters_shape[0]
+        if in_width is not None and filter_width is not None:
+          dilation_rate = dilations[channel_index]
+          effective_filter_width = filter_width + (filter_width - 1) * (
+              dilation_rate - 1)
+          if in_width - effective_filter_width < 0:
+            raise ValueError(
+                f"Negative dimension size caused by subtracting "
+                f"{effective_filter_width} from {in_width} for conv1d with "
+                f"VALID padding. Input spatial dimension is too small for "
+                f"the filter size.")
+
     value = array_ops.expand_dims(value, spatial_start_dim)
     filters = array_ops.expand_dims(filters, 0)
     if value.shape.ndims in (4, 3, 2, 1, 0, None):

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2067,10 +2067,8 @@ def conv1d(
     strides = [1] + _get_sequence(stride, 1, channel_index, "stride")
     dilations = [1] + _get_sequence(dilations, 1, channel_index, "dilations")
 
-    # Validate that the output spatial dimension is non-negative for VALID
-    # padding. In graph mode this check is performed during shape inference,
-    # but eager mode silently produces a zero-sized tensor which is almost
-    # never intended and causes confusing downstream errors.
+    # Reject negative output spatial dimensions for VALID padding while
+    # preserving valid zero-sized outputs.
     if isinstance(padding, str) and padding.upper() == "VALID":
       value_shape = value.shape
       filters_shape = filters.shape
@@ -2082,7 +2080,7 @@ def conv1d(
           dilation_rate = dilations[spatial_idx]
           effective_filter_width = filter_width + (filter_width - 1) * (
               dilation_rate - 1)
-          if in_width - effective_filter_width < 0:
+          if in_width - effective_filter_width + strides[spatial_idx] < 0:
             raise ValueError(
                 f"Negative dimension size caused by subtracting "
                 f"{effective_filter_width} from {in_width} for conv1d with "

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2075,13 +2075,11 @@ def conv1d(
       value_shape = value.shape
       filters_shape = filters.shape
       if value_shape.rank is not None and filters_shape.rank is not None:
-        if data_format == "NHWC":
-          in_width = value_shape[-2]
-        else:  # NCHW
-          in_width = value_shape[-1]
-        filter_width = filters_shape[0]
+        spatial_idx = -2 if data_format == "NHWC" else -1
+        in_width = tensor_shape.dimension_value(value_shape[spatial_idx])
+        filter_width = tensor_shape.dimension_value(filters_shape[0])
         if in_width is not None and filter_width is not None:
-          dilation_rate = dilations[channel_index]
+          dilation_rate = dilations[spatial_idx]
           effective_filter_width = filter_width + (filter_width - 1) * (
               dilation_rate - 1)
           if in_width - effective_filter_width < 0:

--- a/tensorflow/python/ops/nn_ops.py
+++ b/tensorflow/python/ops/nn_ops.py
@@ -2048,10 +2048,14 @@ def conv1d(
     A `Tensor`.  Has the same type as input.
 
   Raises:
-    ValueError: if `data_format` is invalid.
+    ValueError: If `data_format` is invalid, or if `padding="VALID"` would
+      produce a statically known negative output width.
   """
   value = deprecation.deprecated_argument_lookup("input", input, "value", value)
   with ops.name_scope(name, "conv1d", [value, filters]) as name:
+    value = ops.convert_to_tensor(value, name="input")
+    filters = ops.convert_to_tensor(filters, name="filters")
+
     # Reshape the input tensor to batch_shape + [1, in_width, in_channels]
     if data_format is None or data_format == "NHWC" or data_format == "NWC":
       data_format = "NHWC"
@@ -2173,7 +2177,8 @@ def conv1d_v2(
     A `Tensor`.  Has the same type as input.
 
   Raises:
-    ValueError: if `data_format` is invalid.
+    ValueError: If `data_format` is invalid, or if `padding="VALID"` would
+      produce a statically known negative output width.
   """
   return conv1d(
       input,  # pylint: disable=redefined-builtin


### PR DESCRIPTION
## Summary

Fixes #112371.

`tf.nn.conv1d` now treats VALID-padding boundary shapes consistently in eager and graph execution: mathematically zero-width outputs are allowed, while statically known negative widths raise a clear `ValueError`. Conv2D shape inference and the oneDNN path preserve that same zero-sized output shape without changing pooling or other windowed-op contracts.

## Changes

- Validate only truly negative static Conv1D output widths, including dilation and both supported data formats.
- Preserve list and NumPy tensor-like inputs by converting them before static shape inspection.
- Add a private Conv2D-only shape helper for the exact VALID zero-output boundary; keep the public shared window helper unchanged for pooling, generic Conv, Conv3D, depthwise Conv2D, and explicit padding.
- Allocate the computed destination shape in the oneDNN zero-element early return.
- Add Python and C++ regressions for tensor-like inputs, eager/graph zero and negative cases, the Conv2D boundary, and MaxPool's existing oversized-window rejection.
- Document the new static validation in both exported Conv1D docstrings.

## Testing

- PASS: `python -m py_compile tensorflow/python/ops/nn_ops.py tensorflow/python/kernel_tests/nn_ops/conv1d_test.py`
- PASS: `git diff --check`
- PASS: independent arithmetic verification across 3,264 input/filter/dilation/stride combinations.
- PASS on replacement head `72bc71ac7a1`: Linux CPU, CUDA, CUDA 13, ARM64 build, PyLint, license, change scan, and CLA.
- PASS on Windows: `common_shape_fns_test`, `mkl_conv_ops_test`, `conv1d_test_cpu`, `pooling_ops_test_cpu`, and quantized pooling tests.
- UNRELATED WINDOWS FAILURE: `//tensorflow/core/platform:file_system_test` failed to link because `SnappyOutputBuffer` was undefined. No changed file or reviewed behavior is involved. A failed-job rerun was attempted but GitHub requires upstream repository admin rights.
- CI feedback addressed: the first run (`29774406327`) exposed a shared-helper leak into pooling; the replacement commit restores the public helper exactly and adds a focused MaxPool regression.
- NOT RUN locally: TensorFlow Bazel C++/Python targets because Bazel, buildifier, and a built TensorFlow runtime are unavailable in this checkout.

## Risk

Moderate. The zero-output exception is private to Conv2D shape inference, while all other shared-helper callers retain their historical behavior. Branch-relevant tests pass across the available Linux, CUDA, ARM, and Windows results; the PR still needs maintainer re-review and an authorized Windows rerun to clear external gates.
