### PR TITLE
Fix tf.io.encode_png crash on zero-dimension tensors

### DIFF
--- a/tensorflow/python/ops/image_ops_impl.py
+++ b/tensorflow/python/ops/image_ops_impl.py
@@ -3278,8 +3278,9 @@ def encode_png(image, compression=-1, name=None):
   Returns:
     A `Tensor` of type `string`.
   """
-  return gen_image_ops.encode_png(
-      ops.convert_to_tensor(image), compression, name)
+  image = ops.convert_to_tensor(image)
+  image = _AssertAtLeast3DImage(image)
+  return gen_image_ops.encode_png(image, compression, name)
 
 
 @tf_export(

--- a/tensorflow/python/ops/image_ops_test.py
+++ b/tensorflow/python/ops/image_ops_test.py
@@ -4823,6 +4823,15 @@ class PngTest(test_util.TensorFlowTestCase):
 
       self.assertAllEqual(png_stack.shape, (0, 4))
 
+  def testZeroDimensionImage(self):
+    # Encoding an image with a zero-sized dimension should raise a ValueError
+    # instead of crashing with SIGABRT. See GitHub issue #108916.
+    for shape in [(2, 0, 3), (0, 2, 3), (2, 3, 0)]:
+      with self.assertRaisesRegex(ValueError, "must be > 0"):
+        image = constant_op.constant(
+            np.zeros(shape, dtype=np.uint8))
+        image_ops.encode_png(image)
+
   def testShape(self):
     # Shape function requires placeholders and a graph.
     with ops.Graph().as_default():


### PR DESCRIPTION
## Summary
- Fixes #108916: `tf.io.encode_png` crashes with SIGABRT when given a tensor with a zero-sized dimension (e.g., shape `[2, 0, 3]`).
- Adds Python-level input validation in `encode_png` using the existing `_AssertAtLeast3DImage` helper, which checks rank >= 3 and all inner dimensions > 0.
- Now raises a clear `ValueError` instead of crashing the process.

## Test plan
- Added `testZeroDimensionImage` to `PngTest` covering shapes `(2, 0, 3)`, `(0, 2, 3)`, and `(2, 3, 0)`.
- All three cases verify that a `ValueError` with message "must be > 0" is raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)