### PR TITLE
Fix segfault when Session._session is set to None

### DIFF
--- a/tensorflow/python/client/session.py
+++ b/tensorflow/python/client/session.py
@@ -1085,6 +1085,9 @@ class BaseSession(SessionInterface):
     # Check session.
     if self._closed:
       raise RuntimeError('Attempted to use a closed Session.')
+    if self._session is None:
+      raise RuntimeError('Session is in an invalid state (underlying session '
+                         'has been closed or not yet created).')
     if self.graph.version == 0:
       raise RuntimeError('The Session graph is empty. Add operations to the '
                          'graph before calling run().')
@@ -1143,6 +1146,9 @@ class BaseSession(SessionInterface):
     # Check session.
     if self._closed:
       raise RuntimeError('Attempted to use a closed Session.')
+    if self._session is None:
+      raise RuntimeError('Session is in an invalid state (underlying session '
+                         'has been closed or not yet created).')
     if self.graph.version == 0:
       raise RuntimeError('The Session graph is empty. Add operations to the '
                          'graph before calling run().')
@@ -1480,11 +1486,17 @@ class BaseSession(SessionInterface):
 
   def _call_tf_sessionrun(self, options, feed_dict, fetch_list, target_list,
                           run_metadata):
+    if self._session is None:
+      raise RuntimeError('Session is in an invalid state (underlying session '
+                         'has been closed or not yet created).')
     return tf_session.TF_SessionRun_wrapper(self._session, options, feed_dict,
                                             fetch_list, target_list,
                                             run_metadata)
 
   def _call_tf_sessionprun(self, handle, feed_dict, fetch_list):
+    if self._session is None:
+      raise RuntimeError('Session is in an invalid state (underlying session '
+                         'has been closed or not yet created).')
     return tf_session.TF_SessionPRun_wrapper(self._session, handle, feed_dict,
                                              fetch_list)
 


### PR DESCRIPTION
## Summary
- Fixes #112405: `tf.compat.v1.Session` segfaults when `sess.__dict__['_session']` is set to `None` and `sess.run()` is called.
- Adds `None` checks for `self._session` in `_run`, `partial_run_setup`, `_call_tf_sessionrun`, and `_call_tf_sessionprun` to raise a `RuntimeError` instead of passing `None` to the C API and crashing.

## Test plan
- [ ] Verify that setting `sess.__dict__['_session'] = None` followed by `sess.run(...)` raises `RuntimeError` instead of segfaulting
- [ ] Verify that normal session usage (create, run, close) is unaffected
- [ ] Verify that `partial_run_setup` with a None session raises `RuntimeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)