### PR TITLE
Validate grad tensor rank in AvgPool3DGrad shape function

### DIFF
--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -2116,6 +2116,8 @@ absl::Status AvgPool3DGradShape(shape_inference::InferenceContext* c) {
   ShapeHandle s;
   TF_RETURN_IF_ERROR(c->MakeShapeFromShapeTensor(0, &s));
   TF_RETURN_IF_ERROR(c->WithRank(s, 5, &s));
+  ShapeHandle grad;
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 5, &grad));
   c->set_output(0, s);
   return absl::OkStatus();
 }


### PR DESCRIPTION
## Summary
- Fixes `tf.raw_ops.AvgPool3DGrad` crashing with `Check failed: d < dims()` when the `grad` tensor has the wrong rank (e.g., 2D instead of 5D).
- Adds rank-5 validation for the `grad` input in `AvgPool3DGradShape`, producing a clean `InvalidArgument` error instead of aborting.

Fixes #110797

## Test plan
- [ ] Verify that `tf.raw_ops.AvgPool3DGrad` with a non-5D grad tensor now raises an `InvalidArgument` error instead of crashing.
- [ ] Verify that valid 5D grad tensors continue to work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)