### PR TITLE
Fix crash in tf.nn.ctc_loss when num_classes=0

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
@@ -63,6 +63,19 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
       MklPoolParameters pool_params;
       // Check whether pooling is 2D or 3D.
       bool is_pool2d = (this->ksize_.size() == 4);
+
+      // Validate that the input tensor rank matches the pooling type.
+      // This prevents a CHECK failure in TFShapeToMklDnnDimsInNCDHW when
+      // the input does not have the expected number of dimensions.
+      if (!dnn_shape_input.IsMklTensor()) {
+        int expected_rank = is_pool2d ? 4 : 5;
+        OP_REQUIRES(
+            context, input_tensor.dims() == expected_rank,
+            absl::InvalidArgumentError(absl::StrCat(
+                "Input must be rank ", expected_rank, " but got rank ",
+                input_tensor.dims())));
+      }
+
       // Get the input tensor and initialize the pooling parameters
       TensorShape input_tensor_shape = input_tensor.shape();
       this->InitMklPoolParameters(context, &pool_params, dnn_shape_input,
@@ -287,6 +300,16 @@ class MklMaxPoolingGradOp : public MklPoolingBackwardOpBase<T> {
         return;
       }
       bool is_pool2d = (this->ksize_.size() == 4);
+
+      if (!orig_input_mkl_shape.IsMklTensor()) {
+        int expected_rank = is_pool2d ? 4 : 5;
+        OP_REQUIRES(
+            context, orig_input_tensor.dims() == expected_rank,
+            absl::InvalidArgumentError(absl::StrCat(
+                "Input must be rank ", expected_rank, " but got rank ",
+                orig_input_tensor.dims())));
+      }
+
       this->InitMklPoolParameters(context, &pool_params, orig_input_mkl_shape,
                                   orig_input_shape);
 

--- a/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
@@ -63,19 +63,6 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
       MklPoolParameters pool_params;
       // Check whether pooling is 2D or 3D.
       bool is_pool2d = (this->ksize_.size() == 4);
-
-      // Validate that the input tensor rank matches the pooling type.
-      // This prevents a CHECK failure in TFShapeToMklDnnDimsInNCDHW when
-      // the input does not have the expected number of dimensions.
-      if (!dnn_shape_input.IsMklTensor()) {
-        int expected_rank = is_pool2d ? 4 : 5;
-        OP_REQUIRES(
-            context, input_tensor.dims() == expected_rank,
-            absl::InvalidArgumentError(absl::StrCat(
-                "Input must be rank ", expected_rank, " but got rank ",
-                input_tensor.dims())));
-      }
-
       // Get the input tensor and initialize the pooling parameters
       TensorShape input_tensor_shape = input_tensor.shape();
       this->InitMklPoolParameters(context, &pool_params, dnn_shape_input,
@@ -300,16 +287,6 @@ class MklMaxPoolingGradOp : public MklPoolingBackwardOpBase<T> {
         return;
       }
       bool is_pool2d = (this->ksize_.size() == 4);
-
-      if (!orig_input_mkl_shape.IsMklTensor()) {
-        int expected_rank = is_pool2d ? 4 : 5;
-        OP_REQUIRES(
-            context, orig_input_tensor.dims() == expected_rank,
-            absl::InvalidArgumentError(absl::StrCat(
-                "Input must be rank ", expected_rank, " but got rank ",
-                orig_input_tensor.dims())));
-      }
-
       this->InitMklPoolParameters(context, &pool_params, orig_input_mkl_shape,
                                   orig_input_shape);
 

--- a/tensorflow/python/kernel_tests/nn_ops/ctc_loss_op_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/ctc_loss_op_test.py
@@ -78,6 +78,43 @@ def _ctc_loss_v2(labels, inputs, sequence_length,
       logits_time_major=time_major)
 
 
+class CTCLossValidationTest(test.TestCase):
+
+  def _callCtcLoss(self, ctc_loss_fn, logits, blank_index=0):
+    labels = constant_op.constant([[0]], dtype=dtypes.int32)
+    label_length = constant_op.constant([1], dtype=dtypes.int32)
+    logit_length = constant_op.constant([1], dtype=dtypes.int32)
+    return ctc_loss_fn(
+        labels=labels,
+        logits=logits,
+        label_length=label_length,
+        logit_length=logit_length,
+        blank_index=blank_index)
+
+  def testStaticLogitsRankTooSmallRejected(self):
+    logits = constant_op.constant([[1.0, 2.0]], dtype=dtypes.float32)
+    for ctc_loss_fn in [ctc_ops.ctc_loss_v2, ctc_ops.ctc_loss_v3]:
+      with self.subTest(ctc_loss_fn=ctc_loss_fn.__name__):
+        with self.assertRaisesRegex(ValueError, "rank at least 3"):
+          self._callCtcLoss(ctc_loss_fn, logits)
+
+  def testStaticZeroClassesRejected(self):
+    logits = constant_op.constant(
+        np.zeros([1, 1, 0], dtype=np.float32), dtype=dtypes.float32)
+    for ctc_loss_fn in [ctc_ops.ctc_loss_v2, ctc_ops.ctc_loss_v3]:
+      with self.subTest(ctc_loss_fn=ctc_loss_fn.__name__):
+        with self.assertRaisesRegex(ValueError, "at least 1 class"):
+          self._callCtcLoss(ctc_loss_fn, logits)
+
+  def testStaticBlankIndexOutOfRangeRejected(self):
+    logits = constant_op.constant(
+        np.zeros([1, 1, 3], dtype=np.float32), dtype=dtypes.float32)
+    for ctc_loss_fn in [ctc_ops.ctc_loss_v2, ctc_ops.ctc_loss_v3]:
+      with self.subTest(ctc_loss_fn=ctc_loss_fn.__name__):
+        with self.assertRaisesRegex(ValueError, r"must be in range \[-3, 3\)"):
+          self._callCtcLoss(ctc_loss_fn, logits, blank_index=-4)
+
+
 class CTCLossTest(test.TestCase):
 
   def _testCTCLoss(self,

--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -846,7 +846,8 @@ def ctc_loss_v2(labels,
       raise ValueError(
           "Logits must have at least 1 class, got 0 classes "
           f"(logits shape: {logits.shape}).")
-    if blank_index is not None and blank_index >= 0 and blank_index >= num_classes:
+    if (blank_index is not None and blank_index >= 0
+        and blank_index >= num_classes):
       raise ValueError(
           f"Argument `blank_index` ({blank_index}) must be less than "
           f"the number of classes ({num_classes}) "
@@ -1000,7 +1001,8 @@ def ctc_loss_v3(labels,
       raise ValueError(
           "Logits must have at least 1 class, got 0 classes "
           f"(logits shape: {logits.shape}).")
-    if blank_index is not None and blank_index >= 0 and blank_index >= num_classes:
+    if (blank_index is not None and blank_index >= 0
+        and blank_index >= num_classes):
       raise ValueError(
           f"Argument `blank_index` ({blank_index}) must be less than "
           f"the number of classes ({num_classes}) "

--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -839,6 +839,19 @@ def ctc_loss_v2(labels,
         [Graves et al., 2006](https://dl.acm.org/citation.cfm?id=1143891)
         ([pdf](http://www.cs.toronto.edu/~graves/icml_2006.pdf))
   """
+  logits = ops.convert_to_tensor(logits, name="logits")
+  num_classes = tensor_shape.dimension_value(logits.shape[2])
+  if num_classes is not None:
+    if num_classes == 0:
+      raise ValueError(
+          "Logits must have at least 1 class, got 0 classes "
+          f"(logits shape: {logits.shape}).")
+    if blank_index is not None and blank_index >= 0 and blank_index >= num_classes:
+      raise ValueError(
+          f"Argument `blank_index` ({blank_index}) must be less than "
+          f"the number of classes ({num_classes}) "
+          f"(logits shape: {logits.shape}).")
+
   if isinstance(labels, sparse_tensor.SparseTensor):
     if blank_index is None:
       raise ValueError(
@@ -980,6 +993,19 @@ def ctc_loss_v3(labels,
 
       https://en.wikipedia.org/wiki/Connectionist_temporal_classification
   """
+  logits = ops.convert_to_tensor(logits, name="logits")
+  num_classes = tensor_shape.dimension_value(logits.shape[2])
+  if num_classes is not None:
+    if num_classes == 0:
+      raise ValueError(
+          "Logits must have at least 1 class, got 0 classes "
+          f"(logits shape: {logits.shape}).")
+    if blank_index is not None and blank_index >= 0 and blank_index >= num_classes:
+      raise ValueError(
+          f"Argument `blank_index` ({blank_index}) must be less than "
+          f"the number of classes ({num_classes}) "
+          f"(logits shape: {logits.shape}).")
+
   if isinstance(labels, sparse_tensor.SparseTensor):
     if blank_index is None:
       raise ValueError(
@@ -988,8 +1014,6 @@ def ctc_loss_v3(labels,
 
     if blank_index < 0:
       blank_index += _get_dim(logits, 2)
-
-    logits = ops.convert_to_tensor(logits, name="logits")
 
     params = {
         "labels": labels,

--- a/tensorflow/python/ops/ctc_ops.py
+++ b/tensorflow/python/ops/ctc_ops.py
@@ -783,6 +783,28 @@ def _ctc_loss_shape(op):
   return [op.inputs[2].get_shape(), op.inputs[0].get_shape()]
 
 
+def _validate_ctc_loss_logits(logits, blank_index):
+  rank = logits.shape.rank
+  if rank is not None and rank < 3:
+    raise ValueError(
+        "Argument `logits` must be a tensor of rank at least 3, "
+        f"got shape {logits.shape}.")
+
+  num_classes = None if rank is None else tensor_shape.dimension_value(
+      logits.shape[2])
+  if num_classes is None:
+    return
+  if num_classes == 0:
+    raise ValueError(
+        "Logits must have at least 1 class, got 0 classes "
+        f"(logits shape: {logits.shape}).")
+  if blank_index is not None and (blank_index < -num_classes or
+                                  blank_index >= num_classes):
+    raise ValueError(
+        f"Argument `blank_index` ({blank_index}) must be in range "
+        f"[-{num_classes}, {num_classes}) (logits shape: {logits.shape}).")
+
+
 # pylint: disable=protected-access, invalid-name
 @tf_export(v1=["nn.ctc_loss_v2"])
 @dispatch.add_dispatch_support
@@ -840,18 +862,7 @@ def ctc_loss_v2(labels,
         ([pdf](http://www.cs.toronto.edu/~graves/icml_2006.pdf))
   """
   logits = ops.convert_to_tensor(logits, name="logits")
-  num_classes = tensor_shape.dimension_value(logits.shape[2])
-  if num_classes is not None:
-    if num_classes == 0:
-      raise ValueError(
-          "Logits must have at least 1 class, got 0 classes "
-          f"(logits shape: {logits.shape}).")
-    if (blank_index is not None and blank_index >= 0
-        and blank_index >= num_classes):
-      raise ValueError(
-          f"Argument `blank_index` ({blank_index}) must be less than "
-          f"the number of classes ({num_classes}) "
-          f"(logits shape: {logits.shape}).")
+  _validate_ctc_loss_logits(logits, blank_index)
 
   if isinstance(labels, sparse_tensor.SparseTensor):
     if blank_index is None:
@@ -995,18 +1006,7 @@ def ctc_loss_v3(labels,
       https://en.wikipedia.org/wiki/Connectionist_temporal_classification
   """
   logits = ops.convert_to_tensor(logits, name="logits")
-  num_classes = tensor_shape.dimension_value(logits.shape[2])
-  if num_classes is not None:
-    if num_classes == 0:
-      raise ValueError(
-          "Logits must have at least 1 class, got 0 classes "
-          f"(logits shape: {logits.shape}).")
-    if (blank_index is not None and blank_index >= 0
-        and blank_index >= num_classes):
-      raise ValueError(
-          f"Argument `blank_index` ({blank_index}) must be less than "
-          f"the number of classes ({num_classes}) "
-          f"(logits shape: {logits.shape}).")
+  _validate_ctc_loss_logits(logits, blank_index)
 
   if isinstance(labels, sparse_tensor.SparseTensor):
     if blank_index is None:


### PR DESCRIPTION
## Summary
- Fixes #112407
- Adds input validation in both `ctc_loss_v2` and `ctc_loss_v3` to check that the innermost dimension of the `logits` tensor (num_classes) is greater than 0
- Raises a clear `ValueError` instead of crashing when `logits` has shape `[batch, timesteps, 0]`
- Also validates that `blank_index` is within the valid range when specified as a non-negative value
- Moves `ops.convert_to_tensor` call earlier in `ctc_loss_v3` so the shape check works for all code paths

## Test plan
- [ ] Call `tf.nn.ctc_loss` with logits of shape `[batch, timesteps, 0]` and verify a `ValueError` is raised
- [ ] Call `tf.nn.ctc_loss` with valid logits and verify normal behavior is unchanged
- [ ] Verify both SparseTensor and dense label code paths work correctly
- [ ] Test with `blank_index` >= `num_classes` to verify the new bounds check

🤖 Generated with [Claude Code](https://claude.com/claude-code)