### PR TITLE
Validate negative parallelism thread counts in Session

### DIFF
--- a/tensorflow/python/client/session.py
+++ b/tensorflow/python/client/session.py
@@ -662,6 +662,8 @@ class BaseSession(SessionInterface):
       tf.errors.OpError: Or one of its subclasses if an error occurs while
         creating the TensorFlow session.
       TypeError: If one of the arguments has the wrong type.
+      ValueError: If `config.intra_op_parallelism_threads` or
+        `config.inter_op_parallelism_threads` is negative.
     """
     _python_session_create_counter.get_cell().increase_by(1)
     if graph is None:
@@ -697,6 +699,17 @@ class BaseSession(SessionInterface):
     if not isinstance(config, config_pb2.ConfigProto):
       raise TypeError('Argument `config` must be a tf.ConfigProto, but got '
                       f'"{type(config).__name__}"')
+
+    if config.intra_op_parallelism_threads < 0:
+      raise ValueError(
+          '`intra_op_parallelism_threads` must be >= 0, but got '
+          f'{config.intra_op_parallelism_threads}. '
+          'Use 0 to let the system determine an appropriate value.')
+    if config.inter_op_parallelism_threads < 0:
+      raise ValueError(
+          '`inter_op_parallelism_threads` must be >= 0, but got '
+          f'{config.inter_op_parallelism_threads}. '
+          'Use 0 to let the system determine an appropriate value.')
 
     if (mixed_precision_global_state.is_mixed_precision_graph_rewrite_enabled()
         and config.graph_options.rewrite_options.auto_mixed_precision !=


### PR DESCRIPTION
## Summary
- Fixes a crash when `tf.compat.v1.Session` is created with negative `intra_op_parallelism_threads` or `inter_op_parallelism_threads` in `ConfigProto`
- Adds Python-level validation in `BaseSession.__init__` to raise a clear `ValueError` before the value reaches the C++ layer, where it causes a fatal `CHECK` failure
- A value of `0` (let the system decide) remains valid; only negative values are rejected

Fixes #112404

## Test plan
- [ ] Verify `tf.compat.v1.Session(config=tf.compat.v1.ConfigProto(intra_op_parallelism_threads=-1))` now raises `ValueError` instead of crashing
- [ ] Verify `tf.compat.v1.Session(config=tf.compat.v1.ConfigProto(inter_op_parallelism_threads=-1))` now raises `ValueError` instead of crashing
- [ ] Verify `intra_op_parallelism_threads=0` and `inter_op_parallelism_threads=0` still work (system default)
- [ ] Verify positive values still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)