### PR TITLE
Fix irfft crash on complex64 tensor with shape (1,)

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
@@ -63,6 +63,19 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
       MklPoolParameters pool_params;
       // Check whether pooling is 2D or 3D.
       bool is_pool2d = (this->ksize_.size() == 4);
+
+      // Validate that the input tensor rank matches the pooling type.
+      // This prevents a CHECK failure in TFShapeToMklDnnDimsInNCDHW when
+      // the input does not have the expected number of dimensions.
+      if (!dnn_shape_input.IsMklTensor()) {
+        int expected_rank = is_pool2d ? 4 : 5;
+        OP_REQUIRES(
+            context, input_tensor.dims() == expected_rank,
+            absl::InvalidArgumentError(absl::StrCat(
+                "Input must be rank ", expected_rank, " but got rank ",
+                input_tensor.dims())));
+      }
+
       // Get the input tensor and initialize the pooling parameters
       TensorShape input_tensor_shape = input_tensor.shape();
       this->InitMklPoolParameters(context, &pool_params, dnn_shape_input,
@@ -287,6 +300,17 @@ class MklMaxPoolingGradOp : public MklPoolingBackwardOpBase<T> {
         return;
       }
       bool is_pool2d = (this->ksize_.size() == 4);
+
+      // Validate that the input tensor rank matches the pooling type.
+      if (!orig_input_mkl_shape.IsMklTensor()) {
+        int expected_rank = is_pool2d ? 4 : 5;
+        OP_REQUIRES(
+            context, orig_input_tensor.dims() == expected_rank,
+            absl::InvalidArgumentError(absl::StrCat(
+                "Input must be rank ", expected_rank, " but got rank ",
+                orig_input_tensor.dims())));
+      }
+
       this->InitMklPoolParameters(context, &pool_params, orig_input_mkl_shape,
                                   orig_input_shape);
 

--- a/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_maxpooling_op.cc
@@ -63,19 +63,6 @@ class MklMaxPoolingOp : public MklPoolingForwardOpBase<T> {
       MklPoolParameters pool_params;
       // Check whether pooling is 2D or 3D.
       bool is_pool2d = (this->ksize_.size() == 4);
-
-      // Validate that the input tensor rank matches the pooling type.
-      // This prevents a CHECK failure in TFShapeToMklDnnDimsInNCDHW when
-      // the input does not have the expected number of dimensions.
-      if (!dnn_shape_input.IsMklTensor()) {
-        int expected_rank = is_pool2d ? 4 : 5;
-        OP_REQUIRES(
-            context, input_tensor.dims() == expected_rank,
-            absl::InvalidArgumentError(absl::StrCat(
-                "Input must be rank ", expected_rank, " but got rank ",
-                input_tensor.dims())));
-      }
-
       // Get the input tensor and initialize the pooling parameters
       TensorShape input_tensor_shape = input_tensor.shape();
       this->InitMklPoolParameters(context, &pool_params, dnn_shape_input,
@@ -300,17 +287,6 @@ class MklMaxPoolingGradOp : public MklPoolingBackwardOpBase<T> {
         return;
       }
       bool is_pool2d = (this->ksize_.size() == 4);
-
-      // Validate that the input tensor rank matches the pooling type.
-      if (!orig_input_mkl_shape.IsMklTensor()) {
-        int expected_rank = is_pool2d ? 4 : 5;
-        OP_REQUIRES(
-            context, orig_input_tensor.dims() == expected_rank,
-            absl::InvalidArgumentError(absl::StrCat(
-                "Input must be rank ", expected_rank, " but got rank ",
-                orig_input_tensor.dims())));
-      }
-
       this->InitMklPoolParameters(context, &pool_params, orig_input_mkl_shape,
                                   orig_input_shape);
 

--- a/tensorflow/python/kernel_tests/signal/fft_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/fft_ops_test.py
@@ -544,6 +544,18 @@ class RFFTOpsTest(BaseFFTOpsTest, parameterized.TestCase):
     else:
       raise ValueError("invalid rank")
 
+  @parameterized.named_parameters(("Irfft", fft_ops.irfft),
+                                  ("IrfftNd", fft_ops.irfftnd))
+  def testIrfftRejectsStaticInnerDimLessThanTwo(self, irfft_fn):
+    with self.assertRaisesRegex(ValueError, "inner-most dimension"):
+      irfft_fn(np.zeros([1], dtype=np.complex64))
+
+  @test_util.run_deprecated_v1
+  def testIrfftAllowsUnknownRankConstruction(self):
+    x = array_ops.placeholder(dtype=dtypes.complex64)
+    y = fft_ops.irfft(x)
+    self.assertEqual(y.dtype, dtypes.float32)
+
   # rocFFT requires/assumes that the input to the irfft transform
   # is of the form that is a valid output from the rfft transform
   # (i.e. it cannot be a set of random numbers)

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -186,6 +186,17 @@ def _irfft_wrapper(ifft_fn, fft_rank, default_name):
       complex_dtype = input_tensor.dtype
       real_dtype = complex_dtype.real_dtype
       if fft_length is None:
+        # Validate that the innermost dimension is at least 2 when known.
+        # IRFFT computes fft_length = 2 * (input_size - 1), so input_size
+        # must be >= 2 to produce a valid (non-zero) fft_length.
+        inner_dim = input_tensor.shape[-1]
+        if inner_dim is not None and inner_dim < 2:
+          raise ValueError(
+              "IRFFT requires the inner-most dimension of the input to be "
+              "at least 2, but got inner dimension of %d. This is because "
+              "IRFFT computes fft_length = 2 * (input_size - 1), and an "
+              "input size of %d would result in an invalid fft_length of "
+              "%d." % (inner_dim, inner_dim, max(0, 2 * (inner_dim - 1))))
         fft_length = _infer_fft_length_for_irfft(input_tensor, fft_rank)
       else:
         fft_length = _ops.convert_to_tensor(fft_length, _dtypes.int32)
@@ -364,6 +375,17 @@ def _irfftn_wrapper(irfft_n, default_name):
       complex_dtype = input_tensor.dtype
       real_dtype = complex_dtype.real_dtype
       if fft_length is None:
+        # Validate that the innermost dimension is at least 2 when known.
+        # IRFFT computes fft_length = 2 * (input_size - 1), so input_size
+        # must be >= 2 to produce a valid (non-zero) fft_length.
+        inner_dim = input_tensor.shape[-1]
+        if inner_dim is not None and inner_dim < 2:
+          raise ValueError(
+              "IRFFT requires the inner-most dimension of the input to be "
+              "at least 2, but got inner dimension of %d. This is because "
+              "IRFFT computes fft_length = 2 * (input_size - 1), and an "
+              "input size of %d would result in an invalid fft_length of "
+              "%d." % (inner_dim, inner_dim, max(0, 2 * (inner_dim - 1))))
         fft_length = _infer_fft_length_for_irfftn(input_tensor)
       else:
         fft_length = _ops.convert_to_tensor(fft_length, _dtypes.int32)

--- a/tensorflow/python/ops/signal/fft_ops.py
+++ b/tensorflow/python/ops/signal/fft_ops.py
@@ -86,6 +86,19 @@ def _infer_fft_length_for_irfft(input_tensor, fft_rank):
   return _ops.convert_to_tensor(fft_length, _dtypes.int32)
 
 
+def _validate_static_irfft_inner_dim(input_tensor):
+  if input_tensor.shape.rank is None:
+    return
+  inner_dim = input_tensor.shape.as_list()[-1]
+  if inner_dim is not None and inner_dim < 2:
+    raise ValueError(
+        "IRFFT requires the inner-most dimension of the input to be at least "
+        "2, but got inner dimension of %d. This is because IRFFT computes "
+        "fft_length = 2 * (input_size - 1), and an input size of %d would "
+        "result in an invalid fft_length of %d." %
+        (inner_dim, inner_dim, max(0, 2 * (inner_dim - 1))))
+
+
 def _maybe_pad_for_rfft(input_tensor, fft_rank, fft_length, is_reverse=False):
   """Pads `input_tensor` to `fft_length` on its inner-most `fft_rank` dims."""
   fft_shape = _tensor_util.constant_value_as_shape(fft_length)
@@ -186,17 +199,7 @@ def _irfft_wrapper(ifft_fn, fft_rank, default_name):
       complex_dtype = input_tensor.dtype
       real_dtype = complex_dtype.real_dtype
       if fft_length is None:
-        # Validate that the innermost dimension is at least 2 when known.
-        # IRFFT computes fft_length = 2 * (input_size - 1), so input_size
-        # must be >= 2 to produce a valid (non-zero) fft_length.
-        inner_dim = input_tensor.shape[-1]
-        if inner_dim is not None and inner_dim < 2:
-          raise ValueError(
-              "IRFFT requires the inner-most dimension of the input to be "
-              "at least 2, but got inner dimension of %d. This is because "
-              "IRFFT computes fft_length = 2 * (input_size - 1), and an "
-              "input size of %d would result in an invalid fft_length of "
-              "%d." % (inner_dim, inner_dim, max(0, 2 * (inner_dim - 1))))
+        _validate_static_irfft_inner_dim(input_tensor)
         fft_length = _infer_fft_length_for_irfft(input_tensor, fft_rank)
       else:
         fft_length = _ops.convert_to_tensor(fft_length, _dtypes.int32)
@@ -375,17 +378,7 @@ def _irfftn_wrapper(irfft_n, default_name):
       complex_dtype = input_tensor.dtype
       real_dtype = complex_dtype.real_dtype
       if fft_length is None:
-        # Validate that the innermost dimension is at least 2 when known.
-        # IRFFT computes fft_length = 2 * (input_size - 1), so input_size
-        # must be >= 2 to produce a valid (non-zero) fft_length.
-        inner_dim = input_tensor.shape[-1]
-        if inner_dim is not None and inner_dim < 2:
-          raise ValueError(
-              "IRFFT requires the inner-most dimension of the input to be "
-              "at least 2, but got inner dimension of %d. This is because "
-              "IRFFT computes fft_length = 2 * (input_size - 1), and an "
-              "input size of %d would result in an invalid fft_length of "
-              "%d." % (inner_dim, inner_dim, max(0, 2 * (inner_dim - 1))))
+        _validate_static_irfft_inner_dim(input_tensor)
         fft_length = _infer_fft_length_for_irfftn(input_tensor)
       else:
         fft_length = _ops.convert_to_tensor(fft_length, _dtypes.int32)


### PR DESCRIPTION
## Summary
- Fixes #112406: `tf.compat.v1.spectral.irfft` crashes when given a complex64 tensor with shape `(1,)`.
- The root cause is that IRFFT computes `fft_length = 2 * (input_size - 1)`, which yields `0` when `input_size = 1`, leading to an invalid FFT operation.
- Added input validation in both `_irfft_wrapper` (used by `irfft`, `irfft2d`, `irfft3d`) and `_irfftn_wrapper` (used by `irfftnd`) to raise a clear `ValueError` when the innermost dimension is less than 2 and no explicit `fft_length` is provided.

## Test plan
- [ ] Verify that `tf.signal.irfft(tf.constant([1+2j], dtype=tf.complex64))` now raises a clear `ValueError` instead of crashing
- [ ] Verify that `tf.signal.irfft(tf.constant([1+2j, 3+4j], dtype=tf.complex64))` still works correctly (shape (2,) input)
- [ ] Verify that explicitly providing `fft_length` bypasses the validation (e.g., `tf.signal.irfft(tf.constant([1+2j]), fft_length=[4])`)
- [ ] Existing FFT tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)