### PR TITLE
Fix MKL Conv3D/Conv2D crash on non-matching input rank

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -809,6 +809,18 @@ class MklConvOp : public OpKernel {
           absl::InvalidArgumentError("filter must not have zero elements "
                                      "(i.e. all dimensions must be non-zero)"));
 
+      int expected_dims = strides_.size();
+      OP_REQUIRES(
+          context, src_tensor.dims() == expected_dims,
+          absl::InvalidArgumentError(absl::StrCat(
+              "input must be ", expected_dims, "-dimensional but got ",
+              src_tensor.shape().DebugString())));
+      OP_REQUIRES(
+          context, filter_tensor.dims() == expected_dims,
+          absl::InvalidArgumentError(absl::StrCat(
+              "filter must be ", expected_dims, "-dimensional but got ",
+              filter_tensor.shape().DebugString())));
+
       if (std::is_same<Tinput, float>::value) {
         (void)SetFPMathMode();
       }


### PR DESCRIPTION
## Summary
- Fixes MKL/oneDNN Conv3D (and Conv2D) kernel aborting with a `CHECK` failure when input or filter tensors have the wrong rank for the specified `data_format`
- Adds `OP_REQUIRES` rank validation in `MklConvOp::Compute` before any `GetTensorDim` calls, so an `InvalidArgument` error is returned instead of a process abort
- Validates both input and filter tensor ranks against the expected dimensionality (4 for Conv2D, 5 for Conv3D)

Fixes #111453

## Test plan
- [ ] Verify `tf.nn.conv3d` with rank-1 input raises `InvalidArgumentError` instead of aborting
- [ ] Verify `tf.nn.conv2d` with wrong-rank input raises `InvalidArgumentError` instead of aborting
- [ ] Verify normal Conv2D and Conv3D operations still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)