### PR TITLE
Fix AvgPool3DGrad CHECK failure on invalid grad rank in MKL path

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
@@ -221,6 +221,15 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
 
       bool is_pool2d = (this->ksize_.size() == 4);
 
+      // Validate grad tensor rank before accessing its dimensions.
+      // For 2D pooling, grad must be 4D; for 3D pooling, grad must be 5D.
+      int expected_grad_rank = is_pool2d ? 4 : 5;
+      OP_REQUIRES(
+          context, grad_tensor.dims() == expected_grad_rank,
+          absl::InvalidArgumentError(absl::StrCat(
+              "Expected grad to be rank ", expected_grad_rank,
+              " but got rank ", grad_tensor.dims())));
+
       // out-of-memory boundary index check for output_tensor in 2D case.
       const int depth_window = this->ksize_[3];
       if (is_pool2d && depth_window == 1) {


### PR DESCRIPTION
## Summary
- Fixes #110797
- When `tf.raw_ops.AvgPool3DGrad` receives a grad tensor with incorrect rank (e.g., 2D instead of the expected 5D for 3D pooling), `TFShapeToMklDnnDimsInNCDHW` calls `shape.dim_size()` with out-of-range indices, hitting a `CHECK(d < dims())` that aborts the process
- Added an `OP_REQUIRES` validation for the grad tensor rank early in `MklAvgPoolingGradOp::Compute()`, before any dimension access, so that an `InvalidArgumentError` is raised instead of crashing

## Test plan
- [ ] Pass a 2D grad tensor to `tf.raw_ops.AvgPool3DGrad` with `data_format='NDHWC'` and verify it raises `InvalidArgumentError` instead of aborting
- [ ] Pass a valid 5D grad tensor and verify normal operation is unaffected
- [ ] Verify the fix also protects `AvgPoolGrad` (2D) since `MklAvgPoolingGradOp` is shared between both ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)