### PR TITLE
Fix tf.linalg.logdet returning NaN for non-SPD matrices

### DIFF
--- a/tensorflow/python/kernel_tests/linalg/BUILD
+++ b/tensorflow/python/kernel_tests/linalg/BUILD
@@ -137,6 +137,7 @@ cuda_py_strict_test(
         "//tensorflow/python/framework:tensor",
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/ops:array_ops",
+        "//tensorflow/python/ops:gradient_checker_v2",
         "//tensorflow/python/ops:linalg_ops",
         "//tensorflow/python/ops:math_ops",
         "//tensorflow/python/ops:random_ops",

--- a/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
@@ -26,6 +26,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gradient_checker_v2
 from tensorflow.python.ops import linalg_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import random_ops
@@ -93,6 +94,25 @@ class LogdetTest(test.TestCase):
         with self.session():
           logdet_tf = linalg.logdet(matrix)
           self.assertAllClose(logdet_np, self.evaluate(logdet_tf), atol=atol)
+
+  def test_works_with_non_spd_positive_determinant_matrix(self):
+    matrix = np.array([[-1.0, 0.0], [0.0, -1.0]], dtype=np.float64)
+    _, logdet_np = np.linalg.slogdet(matrix)
+    with self.session():
+      logdet_tf = linalg.logdet(matrix)
+      self.assertAllClose(logdet_np, self.evaluate(logdet_tf), atol=1e-5)
+
+  def test_negative_determinant_returns_nan(self):
+    matrix = np.array([[1.0, 0.0], [0.0, -1.0]], dtype=np.float64)
+    with self.session():
+      logdet_tf = linalg.logdet(matrix)
+      self.assertTrue(np.isnan(self.evaluate(logdet_tf)))
+
+  def test_gradient_non_spd_positive_determinant_matrix(self):
+    matrix = np.array([[-1.0, 0.5], [0.0, -2.0]], dtype=np.float64)
+    theoretical, numerical = gradient_checker_v2.compute_gradient(
+        linalg.logdet, [matrix])
+    self.assertAllClose(theoretical, numerical, atol=1e-5, rtol=1e-5)
 
 
 class SlogdetTest(test.TestCase):

--- a/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
@@ -112,8 +112,9 @@ class LogdetTest(test.TestCase):
 
   def test_gradient_non_spd_positive_determinant_matrix(self):
     matrix = np.array([[-1.0, 0.5], [0.0, -2.0]], dtype=np.float64)
-    theoretical, numerical = gradient_checker_v2.compute_gradient(
-        linalg.logdet, [matrix])
+    with self.session():
+      theoretical, numerical = gradient_checker_v2.compute_gradient(
+          linalg.logdet, [matrix])
     self.assertAllClose(theoretical, numerical, atol=1e-5, rtol=1e-5)
 
 

--- a/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
@@ -83,6 +83,8 @@ class LogdetTest(test.TestCase):
             #     [_RandomPDMatrix(n, self.rng, np_dtype),
             #      _RandomPDMatrix(n, self.rng, np_dtype)]).astype(np_dtype)
             logdet_tf = linalg.logdet(matrix)
+            self.assertEqual(
+                logdet_tf.dtype, dtypes.as_dtype(np_dtype).real_dtype)
             self.assertAllClose(logdet_np, self.evaluate(logdet_tf), atol=atol)
 
   def test_works_with_underflow_case(self):

--- a/tensorflow/python/ops/linalg/linalg_impl.py
+++ b/tensorflow/python/ops/linalg/linalg_impl.py
@@ -24,7 +24,6 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import array_ops_stack
 from tensorflow.python.ops import check_ops
 from tensorflow.python.ops import cond as tf_cond
-from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gen_linalg_ops
 from tensorflow.python.ops import linalg_ops
 from tensorflow.python.ops import map_fn

--- a/tensorflow/python/ops/linalg/linalg_impl.py
+++ b/tensorflow/python/ops/linalg/linalg_impl.py
@@ -68,7 +68,15 @@ triangular_solve = linalg_ops.matrix_triangular_solve
 @tf_export('linalg.logdet')
 @dispatch.add_dispatch_support
 def logdet(matrix, name=None):
-  """Computes log of the determinant of a hermitian positive definite matrix.
+  """Computes log of the determinant of a square matrix.
+
+  Uses LU decomposition via ``tf.linalg.slogdet`` internally, so it works
+  for any non-singular matrix, not just hermitian positive definite (HPD)
+  matrices.
+
+  For real matrices whose determinant is negative the result will be NaN,
+  since the logarithm of a negative real number is undefined.  Use
+  ``tf.linalg.slogdet`` directly if you need to handle negative determinants.
 
   ```python
   # Compute the determinant of a matrix while reducing the chance of over- or
@@ -87,16 +95,12 @@ def logdet(matrix, name=None):
 
   @compatibility(numpy)
   Equivalent to numpy.linalg.slogdet, although no sign is returned since only
-  hermitian positive definite matrices are supported.
+  the log-determinant is computed.
   @end_compatibility
   """
-  # This uses the property that the log det(A) = 2*sum(log(real(diag(C))))
-  # where C is the cholesky decomposition of A.
   with ops.name_scope(name, 'logdet', [matrix]):
-    chol = gen_linalg_ops.cholesky(matrix)
-    return 2.0 * math_ops.reduce_sum(
-        math_ops.log(math_ops.real(array_ops.matrix_diag_part(chol))),
-        axis=[-1])
+    sign, log_abs_det = gen_linalg_ops.log_matrix_determinant(matrix)
+    return log_abs_det + math_ops.log(sign)
 
 
 @tf_export('linalg.adjoint')

--- a/tensorflow/python/ops/linalg/linalg_impl.py
+++ b/tensorflow/python/ops/linalg/linalg_impl.py
@@ -69,9 +69,9 @@ triangular_solve = linalg_ops.matrix_triangular_solve
 def logdet(matrix, name=None):
   """Computes log of the determinant of a square matrix.
 
-  Uses LU decomposition via ``tf.linalg.slogdet`` internally, so it works
-  for any non-singular matrix, not just hermitian positive definite (HPD)
-  matrices.
+  Real inputs use LU decomposition via ``tf.linalg.slogdet`` internally, so
+  they may be any non-singular square matrix. Complex inputs retain the
+  historical hermitian positive definite (HPD) behavior and real output dtype.
 
   For real matrices whose determinant is negative the result will be NaN,
   since the logarithm of a negative real number is undefined.  Use
@@ -98,6 +98,12 @@ def logdet(matrix, name=None):
   @end_compatibility
   """
   with ops.name_scope(name, 'logdet', [matrix]):
+    matrix = ops.convert_to_tensor(matrix)
+    if matrix.dtype.is_complex:
+      chol = gen_linalg_ops.cholesky(matrix)
+      return 2.0 * math_ops.reduce_sum(
+          math_ops.log(math_ops.real(array_ops.matrix_diag_part(chol))),
+          axis=[-1])
     sign, log_abs_det = gen_linalg_ops.log_matrix_determinant(matrix)
     return log_abs_det + math_ops.log(sign)
 


### PR DESCRIPTION
## Description
Updates `tf.linalg.logdet` to use the LU-based `slogdet` path so non-singular, non-HPD matrices with positive determinants produce the correct real log-determinant while preserving TensorFlow's real and complex dtype contracts.

## What and Why
- What changed: replaced the Cholesky-only implementation, added non-SPD value/dtype/gradient coverage, and repaired the strict Bazel dependency and graph-session setup for that coverage.
- Why it is needed: the previous implementation returned `NaN` for valid non-HPD inputs, and the new gradient test initially failed under strict Bazel/graph-mode execution.

## Changes
- Compute `logdet` from `slogdet`, preserving real outputs for complex inputs.
- Cover positive- and negative-determinant behavior and the non-SPD gradient.
- Add the direct `gradient_checker_v2` dependency to `linalg_ops_test`.
- Run `compute_gradient` inside a test session for graph-mode compatibility.

## Reviews and Follow-Up
- Addressed review `4736919428`: added the exact Bazel dependency and graph-mode session wrapper in commit `0a1983a9f47`.
- Follow-up needed: CI and maintainer re-review after this push.

## Files Changed
- `tensorflow/python/ops/linalg/linalg_impl.py`: LU-based `logdet` implementation and dtype handling.
- `tensorflow/python/kernel_tests/linalg/linalg_ops_test.py`: non-SPD value, dtype, and gradient regression coverage.
- `tensorflow/python/kernel_tests/linalg/BUILD`: strict dependency edge for `gradient_checker_v2`.

## Scope and Non-Scope
- In scope: `tf.linalg.logdet` behavior for non-singular non-HPD matrices and its focused tests.
- Not in scope: changing `tf.linalg.slogdet`, singular-matrix semantics, or unrelated linear algebra operations.

## Testing
- Existing regression coverage was expanded for positive-determinant non-SPD inputs, negative determinants, complex dtype behavior, and gradients.
- The latest review fix was checked with Python compilation and diff validation.
- TensorFlow Bazel tests were not run locally because Bazel/buildifier and a built TensorFlow runtime are unavailable; the push triggers repository CI.

## Validation
- `python -m py_compile tensorflow/python/kernel_tests/linalg/linalg_ops_test.py` - passed.
- `git diff --check HEAD^..HEAD` - passed.
- Pre-push correctness/security review - no blocking findings.

## Size
- Changed lines: 42 additions, 9 deletions across 3 files.
- PR size assessment: small and focused (51 changed lines).

## Notes
- Fixes #111470.
- The previous CI failures in `linalg_ops_test_cpu` were caused by the missing direct `gradient_checker_v2` Bazel dependency; commit `0a1983a9f47` addresses that failure.

