### PR TITLE
Fix GPU MatrixSolve singular matrix detection for all shapes

### DIFF
--- a/tensorflow/core/kernels/linalg/matrix_solve_op.cc
+++ b/tensorflow/core/kernels/linalg/matrix_solve_op.cc
@@ -34,6 +34,7 @@ limitations under the License.
 
 #if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 #include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
+#include "tensorflow/core/kernels/linalg/matrix_solve_op.h"
 #include "tensorflow/core/kernels/transpose_functor.h"
 #include "tensorflow/core/util/gpu_solvers.h"
 #endif
@@ -259,6 +260,16 @@ class MatrixSolveOpGpu : public AsyncOpKernel {
             done);
       }
     }
+
+    // 1b. Check the diagonal of the LU factorization for exact zeros to detect
+    // singular matrices. cuBLAS getrfBatched may not always report singularity
+    // via its info output, so we explicitly check for zero pivots on the
+    // diagonal of the factored matrix.
+    functor::CheckLUDiagonalForZerosFunctor<GPUDevice, Scalar> check_diag;
+    check_diag(device,
+               const_cast<const Tensor*>(&input_copy)
+                   ->template flat_inner_dims<Scalar, 3>(),
+               dev_info.back().mutable_data());
 
     // 2. Make a transposed copy of the right-hand sides. This is necessary
     // because cuBLAS/rocSolver assumes column-major storage while TensorFlow TF

--- a/tensorflow/core/kernels/linalg/matrix_solve_op.h
+++ b/tensorflow/core/kernels/linalg/matrix_solve_op.h
@@ -1,0 +1,40 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_CORE_KERNELS_LINALG_MATRIX_SOLVE_OP_H_
+#define TENSORFLOW_CORE_KERNELS_LINALG_MATRIX_SOLVE_OP_H_
+
+#include "tensorflow/core/framework/tensor_types.h"
+
+namespace tensorflow {
+namespace functor {
+
+// Functor to check the diagonal of a pivoted LU factorization for exact zeros.
+// For each batch element, if any diagonal entry of the LU factor is exactly
+// zero, the corresponding entry in `info` is set to a positive value
+// (the 1-based index of the first zero pivot). This is used to detect singular
+// matrices on GPU, where cuBLAS getrfBatched may not always report singularity
+// via its info output.
+template <typename Device, typename Scalar>
+struct CheckLUDiagonalForZerosFunctor {
+  void operator()(const Device& device,
+                  typename TTypes<Scalar, 3>::ConstTensor lu_factor,
+                  int* info);
+};
+
+}  // namespace functor
+}  // namespace tensorflow
+
+#endif  // TENSORFLOW_CORE_KERNELS_LINALG_MATRIX_SOLVE_OP_H_

--- a/tensorflow/core/kernels/linalg/matrix_solve_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/linalg/matrix_solve_op_gpu.cu.cc
@@ -1,0 +1,83 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include <complex>
+
+#include "unsupported/Eigen/CXX11/Tensor"  // from @eigen_archive
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/kernels/linalg/matrix_solve_op.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
+
+namespace tensorflow {
+namespace functor {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+// GPU kernel that checks the diagonal of the LU factorization for exact zeros.
+// If a zero diagonal is found, the corresponding info entry is set to the
+// 1-based index of the first zero pivot (matching LAPACK convention for
+// singular matrix detection).
+template <typename Scalar>
+__global__ void CheckLUDiagonalForZerosKernel(
+    int nthreads, int n, const Scalar* __restrict__ lu_factor,
+    int* __restrict__ info) {
+  typedef typename Eigen::NumTraits<Scalar>::Real RealScalar;
+  const int matrix_size = n * n;
+  const int stride = n + 1;
+  GPU_1D_KERNEL_LOOP(batch, nthreads) {
+    // Only update info if it was not already set to a positive value
+    // (i.e., getrfBatched didn't already detect the singularity).
+    if (info[batch] == 0) {
+      int base = matrix_size * batch;
+      for (int i = 0; i < n; ++i) {
+        if (Eigen::numext::abs(lu_factor[base + i * stride]) ==
+            RealScalar(0)) {
+          // Set info to 1-based index of the first zero pivot.
+          info[batch] = i + 1;
+          break;
+        }
+      }
+    }
+  }
+}
+
+template <typename Scalar>
+struct CheckLUDiagonalForZerosFunctor<GPUDevice, Scalar> {
+  void operator()(const GPUDevice& device,
+                  typename TTypes<Scalar, 3>::ConstTensor lu_factor,
+                  int* info) {
+    const int64_t num_matrices = lu_factor.dimension(0);
+    const int64_t n = lu_factor.dimension(2);
+    GpuLaunchConfig config = GetGpuLaunchConfig(num_matrices, device);
+    TF_CHECK_OK(GpuLaunchKernel(CheckLUDiagonalForZerosKernel<Scalar>,
+                                config.block_count, config.thread_per_block, 0,
+                                device.stream(), config.virtual_thread_count, n,
+                                lu_factor.data(), info));
+  }
+};
+
+template struct CheckLUDiagonalForZerosFunctor<GPUDevice, float>;
+template struct CheckLUDiagonalForZerosFunctor<GPUDevice, double>;
+template struct CheckLUDiagonalForZerosFunctor<GPUDevice, complex64>;
+template struct CheckLUDiagonalForZerosFunctor<GPUDevice, complex128>;
+
+}  // namespace functor
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow/core/kernels/linalg/matrix_solve_op_gpu.cu.cc
+++ b/tensorflow/core/kernels/linalg/matrix_solve_op_gpu.cu.cc
@@ -35,21 +35,21 @@ typedef Eigen::GpuDevice GPUDevice;
 // singular matrix detection).
 template <typename Scalar>
 __global__ void CheckLUDiagonalForZerosKernel(
-    int nthreads, int n, const Scalar* __restrict__ lu_factor,
+    int64_t nthreads, int64_t n, const Scalar* __restrict__ lu_factor,
     int* __restrict__ info) {
   typedef typename Eigen::NumTraits<Scalar>::Real RealScalar;
-  const int matrix_size = n * n;
-  const int stride = n + 1;
+  const int64_t matrix_size = n * n;
+  const int64_t stride = n + 1;
   GPU_1D_KERNEL_LOOP(batch, nthreads) {
     // Only update info if it was not already set to a positive value
     // (i.e., getrfBatched didn't already detect the singularity).
     if (info[batch] == 0) {
-      int base = matrix_size * batch;
-      for (int i = 0; i < n; ++i) {
+      const int64_t base = matrix_size * batch;
+      for (int64_t i = 0; i < n; ++i) {
         if (Eigen::numext::abs(lu_factor[base + i * stride]) ==
             RealScalar(0)) {
           // Set info to 1-based index of the first zero pivot.
-          info[batch] = i + 1;
+          info[batch] = static_cast<int>(i + 1);
           break;
         }
       }

--- a/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
+++ b/tensorflow/python/kernel_tests/linalg/matrix_solve_op_test.py
@@ -123,6 +123,18 @@ class MatrixSolveOpTest(test.TestCase):
       self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
 
   @test_util.run_in_graph_and_eager_modes(use_gpu=True)
+  def testNotInvertibleGpu(self):
+    for matrix_values in (
+        [[1., 2.], [2., 4.]],
+        [[1., 0., -1.], [-1., 1., 0.], [0., -1., 1.]],
+        [[[1., 0., -1.], [-1., 1., 0.], [0., -1., 1.]],
+         [[1., 0., -1.], [-1., 1., 0.], [0., -1., 1.]]],
+    ):
+      with self.assertRaisesOpError("Input matrix is not invertible."):
+        matrix = constant_op.constant(matrix_values)
+        self.evaluate(linalg_ops.matrix_solve(matrix, matrix))
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=True)
   def testConcurrent(self):
     seed = [42, 24]
     matrix_shape = [3, 3]


### PR DESCRIPTION
## Summary
- Fixes #94657: `tf.linalg.solve` on GPU silently returns incorrect results for certain singular matrices (e.g., 3x3) while correctly raising `InvalidArgumentError` for others (e.g., 2x2).
- Root cause: cuBLAS `getrfBatched` does not always report singularity via its info output for all matrix sizes.
- Fix: Added a GPU kernel (`CheckLUDiagonalForZerosFunctor`) that explicitly checks the diagonal of the LU factorization for exact zero pivots after the factorization step, ensuring the existing `info_checker` callback consistently detects singular matrices regardless of matrix shape.

## Test plan
- [ ] Existing `testNotInvertible` in `matrix_solve_op_test.py` should continue to pass on CPU
- [ ] On GPU, singular matrices of all sizes (2x2, 3x3, etc.) should now consistently raise `InvalidArgumentError: Input matrix is not invertible.`
- [ ] Non-singular matrices should be unaffected (the kernel only flags exact zero pivots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Testing
- PASS: git diff --check HEAD^..HEAD
- NOT RUN locally: TensorFlow Bazel unit/build targets (Bazel/buildifier and a built TensorFlow runtime are unavailable in this checkout environment).
