### PR TITLE
Fix Bzlmod compatibility for PIP package build

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -285,6 +285,7 @@ use_repo(
     "cuda_cusparse",
     "cuda_driver",
     "cuda_nvcc",
+    "cuda_nvjitlink",
     "cuda_nvml",
     "cuda_nvrtc",
     "cuda_nvtx",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -238,7 +238,9 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
     "3.13",
 ]]
 
-use_repo(pip, "pypi_mods", pypi = "tf_pypi")
+# tf_pypi_311_numpy should match the selected python version.
+# Change to tf_pypi_312_numpy for python 3.12, etc.
+use_repo(pip, "pypi_mods", pypi = "tf_pypi", pypi_numpy = "tf_pypi_311_numpy")
 
 python_version_ext = use_extension("//third_party/extensions:python_version.bzl", "python_version_ext")
 use_repo(python_version_ext, "python_version_repo")

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -25,7 +25,7 @@ load(
     "tf_cuda_tests_tags",
     "tf_exec_properties",
 )
-load("//tensorflow/tools/pip_package/utils:tf_wheel.bzl", "tf_wheel", "tf_wheel_dep")
+load("//tensorflow/tools/pip_package/utils:tf_wheel.bzl", "is_bzlmod_enabled", "tf_wheel", "tf_wheel_dep")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -365,6 +365,39 @@ tf_wheel(
         "//tensorflow/compiler/tf2xla:xla_compiled_cpu_runtime_srcs",
         ":xla_cmake",
     ],
+    external_repos = [
+        "com_google_absl",
+        "eigen_archive",
+        "jsoncpp_git",
+        "com_google_protobuf",
+        "xla",
+        "tsl",
+        "llvm-project",
+        "cpuinfo",
+        "FXdiv",
+        "net_zstd",
+        "org_brotli",
+        "pthreadpool",
+        "riegeli",
+        "XNNPACK",
+        "pypi",
+        "local_config_cuda",
+        "local_config_tensorrt",
+        "cuda_cccl",
+        "cuda_cublas",
+        "cuda_cudart",
+        "cuda_cudnn",
+        "cuda_cufft",
+        "cuda_cupti",
+        "cuda_curand",
+        "cuda_cusolver",
+        "cuda_cusparse",
+        "cuda_nvcc",
+        "cuda_nvml",
+        "cuda_nvrtc",
+        "cuda_nvtx",
+        "cuda_nvjitlink",
+    ],
 )
 
 genrule(
@@ -419,6 +452,7 @@ py_test(
     ],
     deps = [
         ":tf_py_import",
+        "@pybind11_abseil//pybind11_abseil:status_casters",
     ],
 )
 

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -365,6 +365,7 @@ tf_wheel(
         "//tensorflow/compiler/tf2xla:xla_compiled_cpu_runtime_srcs",
         ":xla_cmake",
     ],
+    # Explicitly list all external repositories that are needed in build_pip_package.py
     external_repos = [
         "com_google_absl",
         "eigen_archive",
@@ -470,6 +471,7 @@ py_test(
     ],
     deps = [
         ":tf_py_import",
+        "@pybind11_abseil//pybind11_abseil:status_casters",
     ],
 )
 

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -25,7 +25,7 @@ load(
     "tf_cuda_tests_tags",
     "tf_exec_properties",
 )
-load("//tensorflow/tools/pip_package/utils:tf_wheel.bzl", "is_bzlmod_enabled", "tf_wheel", "tf_wheel_dep")
+load("//tensorflow/tools/pip_package/utils:tf_wheel.bzl", "tf_wheel", "tf_wheel_dep")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tensorflow/tools/pip_package/BUILD
+++ b/tensorflow/tools/pip_package/BUILD
@@ -380,7 +380,7 @@ tf_wheel(
         "pthreadpool",
         "riegeli",
         "XNNPACK",
-        "pypi",
+        "pypi_numpy",
         "local_config_cuda",
         "local_config_tensorrt",
         "cuda_cccl",

--- a/tensorflow/tools/pip_package/build_pip_package.py
+++ b/tensorflow/tools/pip_package/build_pip_package.py
@@ -52,10 +52,10 @@ def get_repo_path(repo_name: str) -> str:
   Returns:
     The path to the external repository.
   """
-  env_key = repo_name.upper().replace("/", "_").replace("-", "_").replace(":", "_")
-  canonical_name = os.environ.get(
-      f"{env_key}_CANONICAL_REPO_NAME", repo_name
+  env_key = (
+      repo_name.upper().replace("/", "_").replace("-", "_").replace(":", "_")
   )
+  canonical_name = os.environ.get(f"{env_key}_CANONICAL_REPO_NAME", repo_name)
   return f"external/{canonical_name}/"
 
 
@@ -176,28 +176,54 @@ def prepare_headers(headers: list[str], srcs_dir: str) -> None:
       os.path.join(srcs_dir, "external/local_config_python")
   )
 
-  cuda_src_path = os.path.join(srcs_dir, get_repo_path("local_config_cuda") + "cuda")
+  cuda_src_path = os.path.join(
+      srcs_dir, get_repo_path("local_config_cuda") + "cuda"
+  )
   if os.path.exists(cuda_src_path):
     shutil.copytree(
         cuda_src_path,
         os.path.join(srcs_dir, "third_party/gpus"),
     )
   _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cccl"), "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cublas"), "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cudart"), "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cudnn"), "third_party/gpus/cudnn")
-  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cufft"), "third_party/gpus/cuda")
   _copy_cuda_tree(
-      srcs_dir, get_repo_path("cuda_cupti"), "third_party/gpus/cuda/extras/CUPTI"
+      srcs_dir, get_repo_path("cuda_cublas"), "third_party/gpus/cuda"
   )
-  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_curand"), "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cusolver"), "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cusparse"), "third_party/gpus/cuda")
+  _copy_cuda_tree(
+      srcs_dir, get_repo_path("cuda_cudart"), "third_party/gpus/cuda"
+  )
+  _copy_cuda_tree(
+      srcs_dir, get_repo_path("cuda_cudnn"), "third_party/gpus/cudnn"
+  )
+  _copy_cuda_tree(
+      srcs_dir, get_repo_path("cuda_cufft"), "third_party/gpus/cuda"
+  )
+  _copy_cuda_tree(
+      srcs_dir,
+      get_repo_path("cuda_cupti"),
+      "third_party/gpus/cuda/extras/CUPTI",
+  )
+  _copy_cuda_tree(
+      srcs_dir, get_repo_path("cuda_curand"), "third_party/gpus/cuda"
+  )
+  _copy_cuda_tree(
+      srcs_dir, get_repo_path("cuda_cusolver"), "third_party/gpus/cuda"
+  )
+  _copy_cuda_tree(
+      srcs_dir, get_repo_path("cuda_cusparse"), "third_party/gpus/cuda"
+  )
   _copy_cuda_tree(srcs_dir, get_repo_path("cuda_nvcc"), "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_nvjitlink"), "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_nvml"), "third_party/gpus/cuda/nvml")
-  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_nvrtc"), "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_nvtx"), "third_party/gpus/cuda")
+  _copy_cuda_tree(
+      srcs_dir, get_repo_path("cuda_nvjitlink"), "third_party/gpus/cuda"
+  )
+  _copy_cuda_tree(
+      srcs_dir, get_repo_path("cuda_nvml"), "third_party/gpus/cuda/nvml"
+  )
+  _copy_cuda_tree(
+      srcs_dir, get_repo_path("cuda_nvrtc"), "third_party/gpus/cuda"
+  )
+  _copy_cuda_tree(
+      srcs_dir, get_repo_path("cuda_nvtx"), "third_party/gpus/cuda"
+  )
 
   shutil.copytree(
       os.path.join(srcs_dir, "tensorflow/compiler/xla"),
@@ -434,7 +460,10 @@ def create_local_config_python(dst_dir: str) -> None:
         break
 
   if not numpy_include_dir:
-    raise FileNotFoundError(f"Could not find numpy include directory. patterns: {numpy_search_patterns}")
+    raise FileNotFoundError(
+        "Could not find numpy include directory. "
+        f"patterns: {numpy_search_patterns}"
+    )
 
   shutil.copytree(
       numpy_include_dir,
@@ -444,7 +473,7 @@ def create_local_config_python(dst_dir: str) -> None:
   # Search for python include directory in both Bzlmod and WORKSPACE.
   python_search_patterns = [
       "external/*python_*/include/python*",
-      "external/*python_*/include", # Windows
+      "external/*python_*/include",  # Windows
   ]
   python_include_dir = ""
   for pattern in python_search_patterns:
@@ -454,7 +483,10 @@ def create_local_config_python(dst_dir: str) -> None:
       break
 
   if not python_include_dir:
-    raise FileNotFoundError(f"Could not find python include directory. patterns: {python_search_patterns}")
+    raise FileNotFoundError(
+        f"Could not find python include directory. "
+        f"patterns: {python_search_patterns}"
+    )
 
   shutil.copytree(python_include_dir, os.path.join(dst_dir, "python_include"))
 

--- a/tensorflow/tools/pip_package/build_pip_package.py
+++ b/tensorflow/tools/pip_package/build_pip_package.py
@@ -416,17 +416,12 @@ def rename_libtensorflow(srcs_dir: str, version: str):
 def create_local_config_python(dst_dir: str) -> None:
   """Copy python and numpy header files to the destination directory."""
   # Search for numpy include directory in both Bzlmod and WORKSPACE.
-  pypi_repo_path = get_repo_path("pypi")
+  pypi_numpy_repo_path = get_repo_path("pypi_numpy")
   numpy_search_patterns = [
-      os.path.join(pypi_repo_path, "site-packages/numpy/_core/include"),
-      os.path.join(pypi_repo_path, "site-packages/numpy/core/include"),
-      os.path.join(pypi_repo_path, "numpy/_core/include"),
-      os.path.join(pypi_repo_path, "numpy/core/include"),
-      "external/pypi_numpy/site-packages/numpy/_core/include",
-      "external/pypi_numpy/site-packages/numpy/core/include",
-      "external/rules_python~~pip~tf_pypi_*numpy/site-packages/numpy/*/include",
+      os.path.join(pypi_numpy_repo_path, "site-packages/numpy/_core/include"),
+      os.path.join(pypi_numpy_repo_path, "site-packages/numpy/core/include"),
   ]
-  
+
   numpy_include_dir = ""
   for pattern in numpy_search_patterns:
     matches = glob.glob(pattern, recursive=True)

--- a/tensorflow/tools/pip_package/build_pip_package.py
+++ b/tensorflow/tools/pip_package/build_pip_package.py
@@ -40,6 +40,25 @@ from tensorflow.tools.pip_package.utils.utils import is_windows
 from tensorflow.tools.pip_package.utils.utils import replace_inplace
 
 
+def get_repo_path(repo_name: str) -> str:
+  """Returns the path to an external repository.
+
+  The canonical repository name is provided by the tf_wheel rule in
+  tensorflow/tools/pip_package/utils/tf_wheel.bzl.
+
+  Args:
+    repo_name: The apparent repository name.
+
+  Returns:
+    The path to the external repository.
+  """
+  env_key = repo_name.upper().replace("/", "_").replace("-", "_").replace(":", "_")
+  canonical_name = os.environ.get(
+      f"{env_key}_CANONICAL_REPO_NAME", repo_name
+  )
+  return f"external/{canonical_name}/"
+
+
 def parse_args() -> argparse.Namespace:
   """Arguments parser."""
   parser = argparse.ArgumentParser(
@@ -113,30 +132,30 @@ def prepare_headers(headers: list[str], srcs_dir: str) -> None:
       "cuda_nvml/_virtual_includes",
       "cuda_nvrtc/_virtual_includes",
       "cuda_nvtx/_virtual_includes",
-      "external/pypi",
-      "external/jsoncpp_git/src",
-      "local_config_cuda/cuda/_virtual_includes",
-      "local_config_tensorrt",
+      get_repo_path("pypi"),
+      get_repo_path("jsoncpp_git") + "src",
+      get_repo_path("local_config_cuda") + "cuda/_virtual_includes",
+      get_repo_path("local_config_tensorrt"),
       "python_x86_64",
       "python_aarch64",
-      "llvm-project/llvm/",
-      "external/cpuinfo",
-      "external/FXdiv",
-      "external/net_zstd",
-      "external/org_brotli/c",
-      "external/org_brotli/_virtual_includes",
-      "external/pthreadpool",
-      "external/riegeli/riegeli",
-      "external/XNNPACK/src/",
+      get_repo_path("llvm-project") + "llvm/",
+      get_repo_path("cpuinfo"),
+      get_repo_path("FXdiv"),
+      get_repo_path("net_zstd"),
+      get_repo_path("org_brotli") + "c",
+      get_repo_path("org_brotli") + "_virtual_includes",
+      get_repo_path("pthreadpool"),
+      get_repo_path("riegeli") + "riegeli",
+      get_repo_path("XNNPACK") + "src/",
   ]
 
   path_to_replace = {
-      "external/com_google_absl/": "",
-      "external/eigen_archive/": "",
-      "external/jsoncpp_git/": "",
-      "external/com_google_protobuf/src/": "",
-      "external/xla/": "tensorflow/compiler",
-      "external/tsl/": "tensorflow",
+      get_repo_path("com_google_absl"): "",
+      get_repo_path("eigen_archive"): "",
+      get_repo_path("jsoncpp_git"): "",
+      get_repo_path("com_google_protobuf") + "src/": "",
+      get_repo_path("xla"): "tensorflow/compiler",
+      get_repo_path("tsl"): "tensorflow",
   }
 
   for file in headers:
@@ -157,26 +176,28 @@ def prepare_headers(headers: list[str], srcs_dir: str) -> None:
       os.path.join(srcs_dir, "external/local_config_python")
   )
 
-  shutil.copytree(
-      os.path.join(srcs_dir, "external/local_config_cuda/cuda"),
-      os.path.join(srcs_dir, "third_party/gpus"),
-  )
-  _copy_cuda_tree(srcs_dir, "external/cuda_cccl", "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, "external/cuda_cublas", "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, "external/cuda_cudart", "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, "external/cuda_cudnn", "third_party/gpus/cudnn")
-  _copy_cuda_tree(srcs_dir, "external/cuda_cufft", "third_party/gpus/cuda")
+  cuda_src_path = os.path.join(srcs_dir, get_repo_path("local_config_cuda") + "cuda")
+  if os.path.exists(cuda_src_path):
+    shutil.copytree(
+        cuda_src_path,
+        os.path.join(srcs_dir, "third_party/gpus"),
+    )
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cccl"), "third_party/gpus/cuda")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cublas"), "third_party/gpus/cuda")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cudart"), "third_party/gpus/cuda")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cudnn"), "third_party/gpus/cudnn")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cufft"), "third_party/gpus/cuda")
   _copy_cuda_tree(
-      srcs_dir, "external/cuda_cupti", "third_party/gpus/cuda/extras/CUPTI"
+      srcs_dir, get_repo_path("cuda_cupti"), "third_party/gpus/cuda/extras/CUPTI"
   )
-  _copy_cuda_tree(srcs_dir, "external/cuda_curand", "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, "external/cuda_cusolver", "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, "external/cuda_cusparse", "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, "external/cuda_nvcc", "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, "external/cuda_nvjitlink", "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, "external/cuda_nvml", "third_party/gpus/cuda/nvml")
-  _copy_cuda_tree(srcs_dir, "external/cuda_nvrtc", "third_party/gpus/cuda")
-  _copy_cuda_tree(srcs_dir, "external/cuda_nvtx", "third_party/gpus/cuda")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_curand"), "third_party/gpus/cuda")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cusolver"), "third_party/gpus/cuda")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_cusparse"), "third_party/gpus/cuda")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_nvcc"), "third_party/gpus/cuda")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_nvjitlink"), "third_party/gpus/cuda")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_nvml"), "third_party/gpus/cuda/nvml")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_nvrtc"), "third_party/gpus/cuda")
+  _copy_cuda_tree(srcs_dir, get_repo_path("cuda_nvtx"), "third_party/gpus/cuda")
 
   shutil.copytree(
       os.path.join(srcs_dir, "tensorflow/compiler/xla"),
@@ -202,8 +223,8 @@ def prepare_srcs(
     srcs_dir: target directory where files are copied to.
   """
   path_to_replace = {
-      "external/xla/": "tensorflow/compiler",
-      "external/tsl/": "tensorflow",
+      get_repo_path("xla"): "tensorflow/compiler",
+      get_repo_path("tsl"): "tensorflow",
   }
 
   deps_mapping_dict = {}
@@ -235,10 +256,10 @@ def prepare_aot(aot: list[str], srcs_dir: str) -> None:
     srcs_dir: target directory where files are copied to.
   """
   for file in aot:
-    if "external/tsl/" in file:
-      copy_file(file, srcs_dir, "external/tsl/")
-    elif "external/xla/" in file:
-      copy_file(file, srcs_dir, "external/xla/")
+    if get_repo_path("tsl") in file:
+      copy_file(file, srcs_dir, get_repo_path("tsl"))
+    elif get_repo_path("xla") in file:
+      copy_file(file, srcs_dir, get_repo_path("xla"))
     else:
       copy_file(file, srcs_dir)
 
@@ -394,18 +415,53 @@ def rename_libtensorflow(srcs_dir: str, version: str):
 
 def create_local_config_python(dst_dir: str) -> None:
   """Copy python and numpy header files to the destination directory."""
-  numpy_include_dir = "external/pypi_numpy/site-packages/numpy/_core/include"
-  if not os.path.exists(numpy_include_dir):
-    numpy_include_dir = "external/pypi_numpy/site-packages/numpy/core/include"
+  # Search for numpy include directory in both Bzlmod and WORKSPACE.
+  pypi_repo_path = get_repo_path("pypi")
+  numpy_search_patterns = [
+      os.path.join(pypi_repo_path, "site-packages/numpy/_core/include"),
+      os.path.join(pypi_repo_path, "site-packages/numpy/core/include"),
+      os.path.join(pypi_repo_path, "numpy/_core/include"),
+      os.path.join(pypi_repo_path, "numpy/core/include"),
+      "external/pypi_numpy/site-packages/numpy/_core/include",
+      "external/pypi_numpy/site-packages/numpy/core/include",
+      "external/rules_python~~pip~tf_pypi_*numpy/site-packages/numpy/*/include",
+  ]
+  
+  numpy_include_dir = ""
+  for pattern in numpy_search_patterns:
+    matches = glob.glob(pattern, recursive=True)
+    if matches:
+      for m in matches:
+        if os.path.isdir(m):
+          numpy_include_dir = m
+          break
+      if numpy_include_dir:
+        break
+
+  if not numpy_include_dir:
+    raise FileNotFoundError(f"Could not find numpy include directory. patterns: {numpy_search_patterns}")
+
   shutil.copytree(
       numpy_include_dir,
       os.path.join(dst_dir, "numpy_include"),
   )
-  if is_windows():
-    path = "external/python_*/include"
-  else:
-    path = "external/python_*/include/python*"
-  shutil.copytree(glob.glob(path)[0], os.path.join(dst_dir, "python_include"))
+
+  # Search for python include directory in both Bzlmod and WORKSPACE.
+  python_search_patterns = [
+      "external/*python_*/include/python*",
+      "external/*python_*/include", # Windows
+  ]
+  python_include_dir = ""
+  for pattern in python_search_patterns:
+    matches = glob.glob(pattern)
+    if matches:
+      python_include_dir = matches[0]
+      break
+
+  if not python_include_dir:
+    raise FileNotFoundError(f"Could not find python include directory. patterns: {python_search_patterns}")
+
+  shutil.copytree(python_include_dir, os.path.join(dst_dir, "python_include"))
 
 
 def build_wheel(

--- a/tensorflow/tools/pip_package/utils/tf_wheel.bzl
+++ b/tensorflow/tools/pip_package/utils/tf_wheel.bzl
@@ -47,13 +47,6 @@ def get_canonical_repo_name(apparent_repo_name):
 
     return Label(apparent_repo_name).workspace_name
 
-def is_bzlmod_enabled():
-    """Determine whether bzlmod mode is enabled."""
-
-    # If bzlmod is enabled, then `str(Label(...))` returns a canonical label,
-    # these start with `@@`.
-    return str(Label("//tensorflow/tools/pip_package:wheel")).startswith("@@")
-
 def _get_wheel_platform_name(platform_name, platform_tag):
     macos_platform_version = "{}_".format(MACOSX_DEPLOYMENT_TARGET.replace(".", "_")) if MACOSX_DEPLOYMENT_TARGET else ""
     tag = platform_tag

--- a/tensorflow/tools/pip_package/utils/tf_wheel.bzl
+++ b/tensorflow/tools/pip_package/utils/tf_wheel.bzl
@@ -23,7 +23,7 @@ Should be set via --repo_env=WHEEL_NAME=tensorflow_cpu.
 6) `--dests` - json file with source to destination mappings for files whose original
 location does not match its destination in packaged wheel; if the destination is an
 empty string the source file will be ignored.
-7) `--xla_aot` - paths to files that should be in xla_aot directory. 
+7) `--xla_aot` - paths to files that should be in xla_aot directory.
 """
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
@@ -39,6 +39,20 @@ load(
     "TF_VERSION",
     "TF_WHEEL_VERSION_SUFFIX",
 )
+
+def get_canonical_repo_name(apparent_repo_name):
+    """Returns the canonical repo name for the given apparent repo name seen by the module this bzl file belongs to."""
+    if not apparent_repo_name.startswith("@"):
+        apparent_repo_name = "@" + apparent_repo_name
+
+    return Label(apparent_repo_name).workspace_name
+
+def is_bzlmod_enabled():
+    """Determine whether bzlmod mode is enabled."""
+
+    # If bzlmod is enabled, then `str(Label(...))` returns a canonical label,
+    # these start with `@@`.
+    return str(Label("//tensorflow/tools/pip_package:wheel")).startswith("@@")
 
 def _get_wheel_platform_name(platform_name, platform_tag):
     macos_platform_version = "{}_".format(MACOSX_DEPLOYMENT_TARGET.replace(".", "_")) if MACOSX_DEPLOYMENT_TARGET else ""
@@ -125,12 +139,18 @@ def _tf_wheel_impl(ctx):
 
     args.set_param_file_format("flag_per_line")
     args.use_param_file("@%s", use_always = False)
+
+    env = {}
+    for repo in ctx.attr.external_repos:
+        env[repo.upper().replace("-", "_").replace("/", "_") + "_CANONICAL_REPO_NAME"] = get_canonical_repo_name(repo)
+
     ctx.actions.run(
         arguments = [args],
         inputs = srcs + headers + xla_aot,
         outputs = [output_file],
         executable = executable,
         use_default_shell_env = True,
+        env = env,
     )
     return [DefaultInfo(files = depset(direct = [output_file]))]
 
@@ -149,6 +169,7 @@ tf_wheel = rule(
         "override_include_cuda_libs": attr.label(default = Label("@local_config_cuda//cuda:override_include_cuda_libs")),
         "platform_tag": attr.string(mandatory = True),
         "platform_name": attr.string(mandatory = True),
+        "external_repos": attr.string_list(),
     },
     implementation = _tf_wheel_impl,
 )


### PR DESCRIPTION
Fix and refactor the TensorFlow PIP package build system to ensure compatibility and identical wheel content between Bzlmod and legacy WORKSPACE modes.

Key Changes:
   * Repo Resolution: tf_wheel now resolves canonical repository names and exports them to the build environment via environment variables.
   * Path Robustness: build_pip_package.py uses these variables and flexible globs to locate NumPy and Python headers across varying Bzlmod/WORKSPACE layouts.
   * Bzlmod Fixes: Restores missing runtime dependencies (pybind11_abseil) to fix initialization errors in Bzlmod-based tests.
   * Consistency: Ensures identical wheel content and preserves support for CPU-only builds by making CUDA copies optional.

  Verification:
   * import_api_packages_test_cpu passes in both modes.
   * Gemini verified wheels contain identical header structures for WORKSPACE and Bzlmod.