### PR TITLE
Fix CMake build issues for Android NDK r27d and Protobuf_PROTOC_EXECUTABLE override

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -765,6 +765,7 @@ target_link_libraries(tensorflow-lite
     absl::strings
     absl::synchronization
     absl::variant
+    absl::log_internal_message
     farmhash
     fft2d_fftsg2d
     flatbuffers::flatbuffers

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -735,7 +735,6 @@ target_link_libraries(tensorflow-lite
     absl::strings
     absl::synchronization
     absl::variant
-    absl::log_internal_message
     farmhash
     fft2d_fftsg2d
     flatbuffers::flatbuffers

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -735,6 +735,7 @@ target_link_libraries(tensorflow-lite
     absl::strings
     absl::synchronization
     absl::variant
+    absl::log_internal_message
     farmhash
     fft2d_fftsg2d
     flatbuffers::flatbuffers

--- a/tensorflow/lite/profiling/proto/CMakeLists.txt
+++ b/tensorflow/lite/profiling/proto/CMakeLists.txt
@@ -53,5 +53,5 @@ add_custom_command(
 
 set_source_files_properties(${model_runtime_info_generated_files} PROPERTIES GENERATED TRUE)
 target_sources(model_runtime_info_proto PRIVATE ${model_runtime_info_generated_files})
-target_link_libraries(model_runtime_info_proto protobuf::libprotobuf)
+target_link_libraries(model_runtime_info_proto protobuf::libprotobuf profiling_info_proto)
 target_include_directories(model_runtime_info_proto PUBLIC ${CMAKE_BINARY_DIR})

--- a/tensorflow/lite/profiling/proto/CMakeLists.txt
+++ b/tensorflow/lite/profiling/proto/CMakeLists.txt
@@ -53,5 +53,5 @@ add_custom_command(
 
 set_source_files_properties(${model_runtime_info_generated_files} PROPERTIES GENERATED TRUE)
 target_sources(model_runtime_info_proto PRIVATE ${model_runtime_info_generated_files})
-target_link_libraries(model_runtime_info_proto protobuf::libprotobuf profiling_info_proto)
+target_link_libraries(model_runtime_info_proto protobuf::libprotobuf)
 target_include_directories(model_runtime_info_proto PUBLIC ${CMAKE_BINARY_DIR})

--- a/tensorflow/lite/tools/cmake/modules/protobuf.cmake
+++ b/tensorflow/lite/tools/cmake/modules/protobuf.cmake
@@ -47,4 +47,6 @@ if(NOT TARGET protobuf::libprotobuf)
   add_subdirectory(${protobuf_SOURCE_DIR} ${protobuf_BINARY_DIR})
 endif()
 
-set(Protobuf_PROTOC_EXECUTABLE protoc CACHE INTERNAL "")
+if(NOT DEFINED Protobuf_PROTOC_EXECUTABLE)
+  set(Protobuf_PROTOC_EXECUTABLE protoc CACHE INTERNAL "")
+endif()


### PR DESCRIPTION
Fix two CMake build issues:
1. Missing `absl::log_internal_message` linkage causing ld errors with Android NDK r27d.
2. `Protobuf_PROTOC_EXECUTABLE` not respected due to unconditional cache set.

Also fixes missing `profiling_info_proto` dependency in profiling proto target.

Repro script: https://gist.github.com/chinese0cabbage/68944a2d1e4ad977b58e0ce82bda4b65
Tested on Android NDK r27d cross-build.