### PR TITLE
Protect against integer overflow in TransposeConv and Conv3DTranspose col2im

### DIFF
--- a/tensorflow/lite/kernels/conv3d_transpose.cc
+++ b/tensorflow/lite/kernels/conv3d_transpose.cc
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 #include "tensorflow/lite/core/c/builtin_op_data.h"
 #include "tensorflow/lite/core/c/common.h"
@@ -124,8 +125,17 @@ TfLiteStatus ResizeOutputAndTemporaryTensors(
     const RuntimeShape& input_shape = GetTensorShape(input);
     col2im_shape_array->data[0] =
         input_shape.Dims(1) * input_shape.Dims(2) * input_shape.Dims(3);
-    col2im_shape_array->data[1] =
-        filter_depth * filter_height * filter_width * filter_shape.Dims(3);
+    const size_t col2im_dim1 =
+        static_cast<size_t>(filter_depth) * filter_height * filter_width *
+        filter_shape.Dims(3);
+    if (col2im_dim1 > std::numeric_limits<int32_t>::max()) {
+      TF_LITE_KERNEL_LOG(context,
+                         "Conv3DTranspose col2im elements (%zu) exceed the "
+                         "32-bit integer limit.",
+                         col2im_dim1);
+      return kTfLiteError;
+    }
+    col2im_shape_array->data[1] = static_cast<int>(col2im_dim1);
 
     col2im->type = kTfLiteFloat32;
     col2im->allocation_type = kTfLiteDynamic;

--- a/tensorflow/lite/kernels/transpose_conv.cc
+++ b/tensorflow/lite/kernels/transpose_conv.cc
@@ -16,6 +16,7 @@ limitations under the License.
 #include <stddef.h>
 #include <stdint.h>
 
+#include <limits>
 #include <vector>
 
 #include "tensorflow/lite/core/c/builtin_op_data.h"
@@ -217,8 +218,16 @@ TfLiteStatus ResizeCol2ImTensor(TfLiteContext* context,
   const RuntimeShape& input_shape = GetTensorShape(input);
   const RuntimeShape& weights_shape = GetTensorShape(weights);
   col2im_shape_array->data[0] = input_shape.Dims(1) * input_shape.Dims(2);
-  col2im_shape_array->data[1] =
-      weights_shape.Dims(0) * weights_shape.Dims(1) * weights_shape.Dims(2);
+  const size_t col2im_dim1 = static_cast<size_t>(weights_shape.Dims(0)) *
+                             weights_shape.Dims(1) * weights_shape.Dims(2);
+  if (col2im_dim1 > std::numeric_limits<int32_t>::max()) {
+    TF_LITE_KERNEL_LOG(
+        context,
+        "TransposeConv col2im elements (%zu) exceed the 32-bit integer limit.",
+        col2im_dim1);
+    return kTfLiteError;
+  }
+  col2im_shape_array->data[1] = static_cast<int>(col2im_dim1);
 
   col2im->type = input->type == kTfLiteFloat32 ? kTfLiteFloat32 : kTfLiteInt32;
   col2im->allocation_type = kTfLiteDynamic;


### PR DESCRIPTION
## Summary

Apply the same integer overflow protection used in Conv2D (commit 47894283) and
Conv3D (commit e07d5f1a) to TransposeConv and Conv3DTranspose kernels.

## Root Cause

In `transpose_conv.cc` line 221, three `int32` values were multiplied without
overflow protection:
```cpp
col2im_shape_array->data[1] =
    weights_shape.Dims(0) * weights_shape.Dims(1) * weights_shape.Dims(2);
```

In `conv3d_transpose.cc` line 128, four `int32` values were multiplied:
```cpp
col2im_shape_array->data[1] =
    filter_depth * filter_height * filter_width * filter_shape.Dims(3);
```

For large but individually valid dimensions, the product can exceed `INT32_MAX`,
causing signed integer overflow (undefined behavior in C++). The overflowed value
is then used as a tensor dimension for the col2im buffer, leading to an undersized
allocation and potential heap buffer overflow during inference.

## Fix

- Promote the first multiplicand to `size_t` via `static_cast` before multiplication
- Check the result against `std::numeric_limits<int32_t>::max()` before casting to `int`
- Return `kTfLiteError` with a descriptive log message if the limit is exceeded

This follows the exact same pattern applied to Conv2D and Conv3D.

## Test plan

- [x] Source-level vulnerability confirmed
- [x] Arithmetic overflow demonstrated with concrete values
- [ ] Run existing transpose_conv and conv3d_transpose tests