### PR TITLE
Fix integer overflow in Conv2D GEMM dimension calculations

### DIFF
--- a/tensorflow/core/kernels/conv_ops_using_gemm.cc
+++ b/tensorflow/core/kernels/conv_ops_using_gemm.cc
@@ -240,7 +240,8 @@ class Im2ColConvFunctor {
     if (filter_height == 1 && filter_width == 1 && stride_rows == 1 &&
         stride_cols == 1) {
       // The kernel is 1x1.
-      const int m = input_batches * input_height * input_width;
+      const int64_t m = static_cast<int64_t>(input_batches) * input_height *
+                        input_width;
       const int n = filter_count;
       const int k = input_depth;
       const int lda = k;
@@ -255,7 +256,8 @@ class Im2ColConvFunctor {
       // The input data and filter have the same height/width.
       const int m = input_batches;
       const int n = filter_count;
-      const int k = input_height * input_width * input_depth;
+      const int64_t k = static_cast<int64_t>(input_height) * input_width *
+                        input_depth;
       const int lda = k;
       const int ldb = filter_count;
       const int ldc = filter_count;
@@ -296,7 +298,8 @@ class Im2ColConvFunctor {
     // input, with the depth channel as the most contiguous in memory, followed
     // by the width, then the height. This is the standard memory order in the
     // image world if it helps to visualize it.
-    const int filter_value_count = filter_width * filter_height * input_depth;
+    const int64_t filter_value_count =
+        static_cast<int64_t>(filter_width) * filter_height * input_depth;
     OP_REQUIRES(context, (filter_value_count * sizeof(T1)) <= kMaxChunkSize,
                 errors::InvalidArgument("Im2Col patch too large for buffer"));
     const int64_t patches_per_chunk =
@@ -324,7 +327,8 @@ class Im2ColConvFunctor {
     core::ScopedUnref unref_buffer(im2col_buffer_resource);
     T1* im2col_buffer = im2col_buffer_resource->data;
 
-    const int64_t patch_count = (input_batches * output_height * output_width);
+    const int64_t patch_count = static_cast<int64_t>(input_batches) *
+                                output_height * output_width;
     const int64_t chunk_count =
         (patch_count + (patches_per_chunk - 1)) / patches_per_chunk;
     for (int64_t chunk_index = 0; chunk_index < chunk_count; ++chunk_index) {
@@ -337,7 +341,9 @@ class Im2ColConvFunctor {
         const int64_t out_y = (patch_index / output_width) % output_height;
         const int64_t out_x = patch_index % output_width;
         const T1* input_batch_start =
-            input_data + (batch * input_height * input_width * input_depth);
+            input_data +
+            (batch * static_cast<int64_t>(input_height) * input_width *
+             input_depth);
         const int in_y_origin = (out_y * stride_rows) - filter_top_offset;
         const int in_x_origin = (out_x * stride_cols) - filter_left_offset;
         const int patch_index_within_chunk = patch_index % patches_per_chunk;

--- a/tensorflow/core/kernels/conv_ops_using_gemm.cc
+++ b/tensorflow/core/kernels/conv_ops_using_gemm.cc
@@ -258,7 +258,7 @@ class Im2ColConvFunctor {
       const int n = filter_count;
       const int64_t k = static_cast<int64_t>(input_height) * input_width *
                         input_depth;
-      const int lda = k;
+      const int64_t lda = k;
       const int ldb = filter_count;
       const int ldc = filter_count;
       TGemmFunctor gemm_functor;
@@ -298,10 +298,13 @@ class Im2ColConvFunctor {
     // input, with the depth channel as the most contiguous in memory, followed
     // by the width, then the height. This is the standard memory order in the
     // image world if it helps to visualize it.
-    const int64_t filter_value_count =
+    const int64_t filter_value_count_64 =
         static_cast<int64_t>(filter_width) * filter_height * input_depth;
-    OP_REQUIRES(context, (filter_value_count * sizeof(T1)) <= kMaxChunkSize,
+    OP_REQUIRES(context, (filter_value_count_64 * sizeof(T1)) <= kMaxChunkSize,
                 errors::InvalidArgument("Im2Col patch too large for buffer"));
+    // Safe to narrow: OP_REQUIRES guarantees filter_value_count_64 * sizeof(T1)
+    // <= kMaxChunkSize (≤16 MB), so filter_value_count_64 fits in int32.
+    const int filter_value_count = static_cast<int>(filter_value_count_64);
     const int64_t patches_per_chunk =
         kMaxChunkSize / (filter_value_count * sizeof(T1));
     const int64_t chunk_value_count =


### PR DESCRIPTION
## Summary

Fix process crash (SIGABRT) caused by int32 overflow in Conv2D GEMM dimension
calculations when input dimension products exceed INT32_MAX.

## Root Cause

In `conv_ops_using_gemm.cc`, multiple dimension products are computed using `int`
(32-bit signed) arithmetic. When individual dimensions are large but valid (e.g.,
batch=46341, height=46341), their product overflows INT32_MAX:

```cpp
// Line 243 — overflows for batch*H*W > INT32_MAX
const int m = input_batches * input_height * input_width;

// Line 258 — overflows for H*W*depth > INT32_MAX
const int k = input_height * input_width * input_depth;

// Line 299 — overflows for W*H*depth > INT32_MAX
const int filter_value_count = filter_width * filter_height * input_depth;

// Line 327 — int32 overflow BEFORE assignment to int64_t
const int64_t patch_count = (input_batches * output_height * output_width);

// Line 340 — pointer arithmetic with overflowed offset
input_data + (batch * input_height * input_width * input_depth);
```

The overflowed value triggers a CHECK failure in tensor reshape, crashing the
process with SIGABRT.

## Reproduction

```python
import tensorflow as tf
# 46341 * 46341 = 2,147,488,281 > INT32_MAX
x = tf.zeros([46341, 46341, 1, 1], dtype=tf.float32)
k = tf.zeros([1, 1, 1, 1], dtype=tf.float32)
tf.nn.conv2d(x, k, strides=[1,1,1,1], padding='VALID')  # SIGABRT
```

```
F0000 tensor.h:870] Check failed: new_num_elements == NumElements()
    (-2147479015 vs. 2147488281)
```

## Fix

Promote first multiplicand to `int64_t` via `static_cast` before multiplication
at all five overflow sites.

## Test plan

- [x] Verified SIGABRT crash with PoC on TF 2.22.0-dev20260316
- [x] Verified safe dimensions still work correctly
- [ ] Run existing conv2d tests