### PR TITLE
Ensure quantized_dimension is zero in PrepareImpl for per-channel quantization

### DIFF
--- a/tensorflow/lite/kernels/fully_connected.cc
+++ b/tensorflow/lite/kernels/fully_connected.cc
@@ -452,6 +452,9 @@ TfLiteStatus PrepareImpl(TfLiteContext* context, TfLiteNode* node,
                                filter->type == kTfLiteInt2));
       TF_LITE_ENSURE_EQ(context, affine_quantization->scale->size,
                         per_channel_quantization_size);
+      // In Fully Connected layers, per-channel quantization is applied along
+      // the output channel dimension. so the quantized_dimension must be 0.
+      TF_LITE_ENSURE_EQ(context, affine_quantization->quantized_dimension, 0);
       TF_LITE_ENSURE_EQ(
           context, per_channel_quantization_size,
           filter->dims->data[affine_quantization->quantized_dimension]);


### PR DESCRIPTION
In Fully Connected layers, per-channel quantization is applied along the output channel dimension. so we should make sure the quantized_dimension is 0 before using it to resize the per_channel_output_multiplier. Otherwise, the heap buffer overflow issue will occur.

The corresponding Chromium issue: https://issues.chromium.org/issues/493319454