### PR TITLE
docs: Fix FFT raw ops padding documentation

### DIFF
--- a/tensorflow/core/api_def/base_api/api_def_FFTND.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_FFTND.pbtxt
@@ -36,7 +36,7 @@ designated dimensions of `input`. The designated dimensions of
 `input` are assumed to be the result of `FFTND`.
 
 If fft_length[i]<shape(input)[i], the input is cropped. If
-fft_length[i]>shape(input)[i], the input is padded with zeros. If fft_length
+fft_length[i]>shape(input)[i], an `InvalidArgumentError` is raised. If fft_length
 is not given, the default shape(input) is used.
 
 Axes mean the dimensions to perform the transform on. Default is to perform on

--- a/tensorflow/core/api_def/base_api/api_def_IFFTND.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_IFFTND.pbtxt
@@ -37,7 +37,7 @@ dimensions of `input`. The designated dimensions of `input` are assumed to be
 the result of `IFFTND`.
 
 If fft_length[i]<shape(input)[i], the input is cropped. If
-fft_length[i]>shape(input)[i], the input is padded with zeros. If fft_length
+fft_length[i]>shape(input)[i], an `InvalidArgumentError` is raised. If fft_length
 is not given, the default shape(input) is used.
 
 Axes mean the dimensions to perform the transform on. Default is to perform on

--- a/tensorflow/core/api_def/base_api/api_def_IRFFT.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_IRFFT.pbtxt
@@ -37,7 +37,6 @@ compute `input` is odd, it should be provided since it cannot be inferred
 properly.
 
 Along the axis `IRFFT` is computed on, if `fft_length / 2 + 1` is smaller
-than the corresponding dimension of `input`, the dimension is cropped. If it is
-larger, the dimension is padded with zeros.
+than the corresponding dimension of `input`, the dimension is cropped. If it is larger, an `InvalidArgumentError` is raised.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_IRFFT2D.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_IRFFT2D.pbtxt
@@ -39,6 +39,6 @@ properly.
 Along each axis `IRFFT2D` is computed on, if `fft_length` (or
 `fft_length / 2 + 1` for the inner-most dimension) is smaller than the
 corresponding dimension of `input`, the dimension is cropped. If it is larger,
-the dimension is padded with zeros.
+an `InvalidArgumentError` is raised.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_IRFFT3D.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_IRFFT3D.pbtxt
@@ -39,6 +39,6 @@ properly.
 Along each axis `IRFFT3D` is computed on, if `fft_length` (or
 `fft_length / 2 + 1` for the inner-most dimension) is smaller than the
 corresponding dimension of `input`, the dimension is cropped. If it is larger,
-the dimension is padded with zeros.
+an `InvalidArgumentError` is raised.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_IRFFTND.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_IRFFTND.pbtxt
@@ -37,7 +37,7 @@ assumed to be the result of `IRFFTND`. The inner-most dimension contains the
 `fft_length / 2 + 1` unique components of the DFT of a real-valued signal. 
 
 If fft_length[i]<shape(input)[i], the input is cropped. If
-fft_length[i]>shape(input)[i], the input is padded with zeros. If fft_length
+fft_length[i]>shape(input)[i], an `InvalidArgumentError` is raised. If fft_length
 is not given, the default shape(input) is used.
 
 Axes mean the dimensions to perform the transform on. Default is to perform on

--- a/tensorflow/core/api_def/base_api/api_def_RFFT.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_RFFT.pbtxt
@@ -42,6 +42,6 @@ followed by the `fft_length / 2` positive-frequency terms.
 
 Along the axis `RFFT` is computed on, if `fft_length` is smaller than the
 corresponding dimension of `input`, the dimension is cropped. If it is larger,
-the dimension is padded with zeros.
+an `InvalidArgumentError` is raised.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_RFFT2D.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_RFFT2D.pbtxt
@@ -44,6 +44,6 @@ positive-frequency terms.
 
 Along each axis `RFFT2D` is computed on, if `fft_length` is smaller than the
 corresponding dimension of `input`, the dimension is cropped. If it is larger,
-the dimension is padded with zeros.
+an `InvalidArgumentError` is raised.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_RFFT3D.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_RFFT3D.pbtxt
@@ -44,6 +44,6 @@ positive-frequency terms.
 
 Along each axis `RFFT3D` is computed on, if `fft_length` is smaller than the
 corresponding dimension of `input`, the dimension is cropped. If it is larger,
-the dimension is padded with zeros.
+an `InvalidArgumentError` is raised.
 END
 }

--- a/tensorflow/core/api_def/base_api/api_def_RFFTND.pbtxt
+++ b/tensorflow/core/api_def/base_api/api_def_RFFTND.pbtxt
@@ -44,7 +44,7 @@ the result of `RFFTND`. The length of the last axis transformed will be
 fft_length[-1]//2+1.
 
 If fft_length[i]<shape(input)[i], the input is cropped. If
-fft_length[i]>shape(input)[i], the input is padded with zeros. If fft_length
+fft_length[i]>shape(input)[i], an `InvalidArgumentError` is raised. If fft_length
 is not given, the default shape(input) is used.
 
 Axes mean the dimensions to perform the transform on. Default is to perform on


### PR DESCRIPTION
The C++ kernels for FFT/RFFT do not zero-pad when fft_length > input dimension, they throw an InvalidArgumentError. The zero padding is implemented by the Python tf.signal wrapper. This updates the raw ops documentation to correctly reflect the C++ kernel's behavior.

Fixes #103640