### PR TITLE
docs: Fix typo 'occured' to 'occurred' in metrics

### DIFF
--- a/tensorflow/core/framework/metrics.cc
+++ b/tensorflow/core/framework/metrics.cc
@@ -332,7 +332,7 @@ auto* tf_data_autotune_stopping_criteria_counter =
 
 auto* tf_data_debug = tsl::monitoring::Counter<1>::New(
     "/tensorflow/data/debug",
-    "The number of times this event occured, for debugging.", "event");
+    "The number of times this event occurred, for debugging.", "event");
 
 auto* tf_data_error = tsl::monitoring::Counter<2>::New(
     "/tensorflow/data/error",

--- a/tensorflow/core/framework/metrics.h
+++ b/tensorflow/core/framework/metrics.h
@@ -235,7 +235,7 @@ void RecordTFDataAutoShardRewriteBatchSize(
 // criterion is met.
 void RecordTFDataAutotuneStoppingCriteria(const std::string& name);
 
-// Records the number of times this event occured, for debugging.
+// Records the number of times this event occurred, for debugging.
 void RecordTFDataDebug(const std::string& event);
 
 // Records the number of times an error of this type occurred with this status


### PR DESCRIPTION
## Description

This PR fixes a minor spelling mistake in the [tensorflow/core/framework/metrics.h](cci:7://file:///c:/Users/siddh/Videos/tenserflow/tensorflow/core/framework/metrics.h:0:0-0:0) and [tensorflow/core/framework/metrics.cc](cci:7://file:///c:/Users/siddh/Videos/tenserflow/tensorflow/core/framework/metrics.cc:0:0-0:0) files where the word `"occurred"` was misspelled as `"occured"` in the data debug metrics comments and descriptions.

## Checklist
- [x] Read the contributing guidelines.
- [x] Read the Code of Conduct.
- [ ] Ensure you have signed the Contributor License Agreement (CLA).
- [x] Check if your changes are consistent with the guidelines.
- [x] Changes are consistent with the Coding Style.
- [x] Run the unit tests. (N/A — docstrings/comments edit only)
