### PR TITLE
Fix TFLite large_custom_options uint64 overflow bypassing bounds check

### DIFF
--- a/tensorflow/lite/core/interpreter_builder.cc
+++ b/tensorflow/lite/core/interpreter_builder.cc
@@ -375,9 +375,9 @@ TfLiteStatus InterpreterBuilder::ParseNodes(
         init_data = reinterpret_cast<const char*>(op->custom_options()->data());
         init_data_size = op->custom_options()->size();
       } else if (op->large_custom_options_offset() > 1 && allocation_) {
-        if (op->large_custom_options_offset() +
-                op->large_custom_options_size() >
-            allocation_->bytes()) {
+        if (op->large_custom_options_size() > allocation_->bytes() ||
+            op->large_custom_options_offset() >
+                allocation_->bytes() - op->large_custom_options_size()) {
           TF_LITE_REPORT_ERROR(
               error_reporter_,
               "Custom Option Offset for opcode_index %d is out of bound\n",


### PR DESCRIPTION
## Summary
Fix uint64 integer overflow in TFLite InterpreterBuilder that bypasses the bounds check for `large_custom_options`, enabling out-of-bounds read from the model buffer.

## Problem
At line 378, the bounds check computes `offset + size` in uint64 arithmetic. An attacker can set `large_custom_options_offset` and `large_custom_options_size` such that their sum wraps past 2^64 (e.g., offset=0xFFFFFFFFFFFFFF00, size=0x200, sum=0x100). The check passes because the wrapped sum is less than `allocation_->bytes()`. The subsequent `base() + offset` then reads far out of bounds.

## Fix
Rewrite the bounds check to avoid the addition entirely:
```cpp
if (size > total || offset > total - size)
```
This is mathematically equivalent to `offset + size > total` but cannot overflow. If `size > total`, we reject immediately. Otherwise `total - size` is safe and we check `offset` against it.

## Test
Craft a TFLite FlatBuffer with `large_custom_options_offset` and `large_custom_options_size` whose uint64 sum wraps past 2^64. Before fix: bounds check passes, OOB read. After fix: correctly rejected.
