### PR TITLE
Add missing `&` in `reinterpret_cast` in `KeyedDenseTensorColumn<int64_t>::Feature`. Resolves `tf.raw_ops.SparseCrossHashed` can crash when dense_inputs is non-empty #106498

### DIFF
--- a/tensorflow/core/kernels/sparse_cross_op.cc
+++ b/tensorflow/core/kernels/sparse_cross_op.cc
@@ -235,7 +235,7 @@ int64_t KeyedDenseTensorColumn<int64_t>::Feature(int64_t batch, int64_t n,
     }
     return StrongKeyedHash(
         key_,
-        {reinterpret_cast<const char*>(tensor_.matrix<int64_t>()(batch, n)),
+        {reinterpret_cast<const char*>(&tensor_.matrix<int64_t>()(batch, n)),
          sizeof(tensor_.dtype())});
   }
   if (DT_STRING == tensor_.dtype())

--- a/tensorflow/core/kernels/sparse_cross_op.cc
+++ b/tensorflow/core/kernels/sparse_cross_op.cc
@@ -236,7 +236,7 @@ int64_t KeyedDenseTensorColumn<int64_t>::Feature(int64_t batch, int64_t n,
     return StrongKeyedHash(
         key_,
         {reinterpret_cast<const char*>(&tensor_.matrix<int64_t>()(batch, n)),
-         sizeof(tensor_.dtype())});
+         sizeof(int64_t)});
   }
   if (DT_STRING == tensor_.dtype())
     return Fingerprint64(tensor_.matrix<tstring>()(batch, n));

--- a/tensorflow/core/kernels/sparse_cross_op.cc
+++ b/tensorflow/core/kernels/sparse_cross_op.cc
@@ -132,7 +132,7 @@ int64_t KeyedSparseTensorColumn<int64_t>::Feature(int64_t batch, int64_t n,
     return StrongKeyedHash(
         key_,
         {reinterpret_cast<const char*>(&values_.vec<int64_t>()(start + n)),
-         sizeof(values_.dtype())});
+         sizeof(int64_t)});
   }
   if (DT_STRING == values_.dtype())
     return Fingerprint64(values_.vec<tstring>()(start + n));

--- a/tensorflow/core/kernels/sparse_cross_op.cc
+++ b/tensorflow/core/kernels/sparse_cross_op.cc
@@ -138,7 +138,7 @@ int64_t KeyedSparseTensorColumn<int64_t>::Feature(int64_t batch, int64_t n,
     return Fingerprint64(values_.vec<tstring>()(start + n));
   return Fingerprint64(
       {reinterpret_cast<const char*>(&values_.vec<int64_t>()(start + n)),
-       sizeof(values_.dtype())});
+       sizeof(int64_t)});
 }
 
 // InternalType is string or StringPiece when using StringCrosser.

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_cross_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_cross_op_test.py
@@ -1076,5 +1076,32 @@ class SparseCrossHashedOpTest(BaseSparseCrossOpTest):
       )
       self.evaluate(op)
 
+  def test_sparse_cross_hashed_with_dense_inputs_and_strong_hash(self):
+    dense = constant_op.constant([[1], [2]], dtype=dtypes.int64)
+    idx = constant_op.constant([[0, 0], [1, 0]], dtype=dtypes.int64)
+    shape = constant_op.constant([2, 1], dtype=dtypes.int64)
+    val1 = constant_op.constant(["a", "b"], dtype=dtypes.string)
+    val2 = constant_op.constant(["c", "d"], dtype=dtypes.string)
+
+    indices = [idx, idx]
+    values = [val1, val2]
+    shapes = [shape, shape]
+    dense_inputs = [dense]
+    num_buckets = 101
+    salt = [1234, 5678]
+    strong_hash = True
+    _ = gen_sparse_ops.sparse_cross_hashed(
+      indices=indices,
+      values=values,
+      shapes=shapes,
+      dense_inputs=dense_inputs,
+      num_buckets=num_buckets,
+      salt=salt,
+      strong_hash=strong_hash,
+    )
+
+    with session.Session():
+      self.assertTrue(True)    
+
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_cross_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_cross_op_test.py
@@ -1081,8 +1081,8 @@ class SparseCrossHashedOpTest(BaseSparseCrossOpTest):
     dense = constant_op.constant([[1], [2]], dtype=dtypes.int64)
     idx = constant_op.constant([[0, 0], [1, 0]], dtype=dtypes.int64)
     shape = constant_op.constant([2, 1], dtype=dtypes.int64)
-    val1 = constant_op.constant(["a", "b"], dtype=dtypes.string)
-    val2 = constant_op.constant(["c", "d"], dtype=dtypes.string)
+    val1 = constant_op.constant(['a', 'b'], dtype=dtypes.string)
+    val2 = constant_op.constant(['c', 'd'], dtype=dtypes.string)
 
     indices = [idx, idx]
     values = [val1, val2]

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_cross_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_cross_op_test.py
@@ -1090,7 +1090,7 @@ class SparseCrossHashedOpTest(BaseSparseCrossOpTest):
     num_buckets = 101
     salt = [1234, 5678]
     strong_hash = True
-    _ = gen_sparse_ops.sparse_cross_hashed(
+    indices, values, shapes = gen_sparse_ops.sparse_cross_hashed(
       indices=indices,
       values=values,
       shapes=shapes,
@@ -1099,9 +1099,14 @@ class SparseCrossHashedOpTest(BaseSparseCrossOpTest):
       salt=salt,
       strong_hash=strong_hash,
     )
+    output = sparse_tensor.SparseTensor(
+      indices, 
+      values, 
+      shapes
+    )
 
-    with session.Session():
-      self.assertTrue(True)    
+    with self.session():
+      self.evaluate(output)    
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_cross_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_cross_op_test.py
@@ -1076,7 +1076,8 @@ class SparseCrossHashedOpTest(BaseSparseCrossOpTest):
       )
       self.evaluate(op)
 
-  def test_sparse_cross_hashed_with_dense_inputs_and_strong_hash(self):
+  def test_sparse_and_dense_hashed_strong_hash(self):
+    # test sparse_cross_hashed with mixed inputs and strong_hash
     dense = constant_op.constant([[1], [2]], dtype=dtypes.int64)
     idx = constant_op.constant([[0, 0], [1, 0]], dtype=dtypes.int64)
     shape = constant_op.constant([2, 1], dtype=dtypes.int64)
@@ -1107,6 +1108,21 @@ class SparseCrossHashedOpTest(BaseSparseCrossOpTest):
 
     with self.session():
       self.evaluate(output)    
+
+  def test_dense_hashed_strong_hash(self):
+    # test sparse_cross_hashed with only dense inputs and strong_hash 
+    dense_inp = constant_op.constant([[11, 12], [21, 22]], dtypes.int64)
+    inds, vals, shapes = gen_sparse_ops.sparse_cross_hashed(
+      indices=[],
+      values=[],
+      shapes=[],
+      dense_inputs=[dense_inp],
+      strong_hash=True,
+      num_buckets=10,
+      salt=[137, 173])
+    out = sparse_tensor.SparseTensor(inds, vals, shapes)
+    with self.cached_session():
+      self.evaluate(out)
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/kernel_tests/sparse_ops/sparse_cross_op_test.py
+++ b/tensorflow/python/kernel_tests/sparse_ops/sparse_cross_op_test.py
@@ -1092,34 +1092,34 @@ class SparseCrossHashedOpTest(BaseSparseCrossOpTest):
     salt = [1234, 5678]
     strong_hash = True
     indices, values, shapes = gen_sparse_ops.sparse_cross_hashed(
-      indices=indices,
-      values=values,
-      shapes=shapes,
-      dense_inputs=dense_inputs,
-      num_buckets=num_buckets,
-      salt=salt,
-      strong_hash=strong_hash,
+        indices=indices,
+        values=values,
+        shapes=shapes,
+        dense_inputs=dense_inputs,
+        num_buckets=num_buckets,
+        salt=salt,
+        strong_hash=strong_hash,
     )
     output = sparse_tensor.SparseTensor(
-      indices, 
-      values, 
-      shapes
+        indices, 
+        values,
+        shapes
     )
 
     with self.session():
-      self.evaluate(output)    
+      self.evaluate(output)
 
   def test_dense_hashed_strong_hash(self):
-    # test sparse_cross_hashed with only dense inputs and strong_hash 
+    # test sparse_cross_hashed with only dense inputs and strong_hash
     dense_inp = constant_op.constant([[11, 12], [21, 22]], dtypes.int64)
     inds, vals, shapes = gen_sparse_ops.sparse_cross_hashed(
-      indices=[],
-      values=[],
-      shapes=[],
-      dense_inputs=[dense_inp],
-      strong_hash=True,
-      num_buckets=10,
-      salt=[137, 173])
+        indices=[],
+        values=[],
+        shapes=[],
+        dense_inputs=[dense_inp],
+        strong_hash=True,
+        num_buckets=10,
+        salt=[137, 173])
     out = sparse_tensor.SparseTensor(inds, vals, shapes)
     with self.cached_session():
       self.evaluate(out)


### PR DESCRIPTION
PR adds a missing `&` in `reinterpret_cast` expression in `KeyedDenseTensorColumn<int64_t>::Feature` when `strong_hash` is `true`. Also adds a test to verify that with the fix operation runs successfully instead of segmentation fault. Fixes https://github.com/tensorflow/tensorflow/issues/106498.