### PR TITLE
[XLA:GPU] Restore cusolver rpath in all_runtime

### DIFF
--- a/third_party/xla/xla/stream_executor/cuda/BUILD
+++ b/third_party/xla/xla/stream_executor/cuda/BUILD
@@ -1653,6 +1653,7 @@ cc_library(
         ":redzone_allocator_kernel_cuda",
         ":repeat_buffer_kernel_cuda",
         ":topk_kernel_cuda",
+        "//xla/tsl/cuda:cusolver",
         "//xla/tsl/cuda:cusparse",
         "//xla/tsl/cuda:tensorrt_rpath",
     ],


### PR DESCRIPTION
#102733 removed cuda_solver_context from all_runtime, which inadvertently dropped the nvidia/cusolver/lib rpath entry from libtensorflow_framework.so.2. TF's linalg ops (SVD, eigendecomposition) still use cusolver directly via cuda_solvers.cc. The rpath is needed for dlopen to find libcusolver when using pip nvidia packages, since the if_cuda_libs() guard in gpu_runtime_hermetic_cuda_deps only applies to the hermetic CUDA build path.

Currently if you `pip install tf-nightly[and-cuda]` and run
```
python -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'))"
```
tensorflow will complain that it cannot dlopen gpu libraries and return an empty list. A temporary fix is to add cusolver to your ld library path, e.g.
```
export LD_LIBRARY_PATH="$VIRTUAL_ENV/lib/python3.12/site-packages/nvidia/cusolver/lib:$LD_LIBRARY_PATH"
```
if using a python3.12 virtualenv.