### PR TITLE
Fix oneDNN depthwise conv rank validation

### DIFF
--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   scan-scheduled:
     if: github.repository == 'tensorflow/tensorflow'
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.1"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@375a0e8ebdc98e99b02ac4338a724f5750f21213" # v2.3.1
     with:
       scan-args: |-
         --lockfile=requirements.txt:./requirements_lock_3_9.txt

--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -507,6 +507,7 @@ tf_cc_test_mkl(
         "//tensorflow/core/kernels:pad_op",
         "//tensorflow/core/kernels:relu_op",
         "//tensorflow/core/kernels/image",
+        "@abseil-cpp//absl/strings",
     ] + MKL_TEST_DEPS,
 )
 

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -804,6 +804,21 @@ class MklConvOp : public OpKernel {
       // Input tensors
       const Tensor& src_tensor = MklGetInput(context, kInputIndex_Src);
       const Tensor& filter_tensor = MklGetInput(context, kInputIndex_Filter);
+      if (is_depthwise) {
+        OP_REQUIRES(context, src_tensor.dims() == 4,
+                    absl::InvalidArgumentError(
+                        absl::StrCat("input must be 4-dimensional",
+                                    src_tensor.shape().DebugString())));
+        OP_REQUIRES(context, filter_tensor.dims() == 4,
+                    absl::InvalidArgumentError(
+                        absl::StrCat("filter must be 4-dimensional: ",
+                                    filter_tensor.shape().DebugString())));
+      }
+
+      OP_REQUIRES(
+          context, filter_tensor.NumElements() > 0,
+          absl::InvalidArgumentError("filter must not have zero elements "
+                                    "(i.e. all dimensions must be non-zero)"));
       OP_REQUIRES(
           context, filter_tensor.NumElements() > 0,
           absl::InvalidArgumentError("filter must not have zero elements "

--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
@@ -818,10 +818,6 @@ class MklConvOp : public OpKernel {
       OP_REQUIRES(
           context, filter_tensor.NumElements() > 0,
           absl::InvalidArgumentError("filter must not have zero elements "
-                                    "(i.e. all dimensions must be non-zero)"));
-      OP_REQUIRES(
-          context, filter_tensor.NumElements() > 0,
-          absl::InvalidArgumentError("filter must not have zero elements "
                                      "(i.e. all dimensions must be non-zero)"));
 
       if (std::is_same<Tinput, float>::value) {

--- a/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
@@ -712,9 +712,12 @@ TYPED_TEST_P(MklFusedDepthwiseConv2DWithBiasOpTest, InvalidInputDims) {
   Tensor bias(dtype, {3});
   bias.template flat<TypeParam>().setZero();
 
-  this->AddInputFromArray<TypeParam>(image.shape(), image.flat<TypeParam>());
-  this->AddInputFromArray<TypeParam>(filter.shape(), filter.flat<TypeParam>());
-  this->AddInputFromArray<TypeParam>(bias.shape(), bias.flat<TypeParam>());
+  this->template AddInputFromArray<TypeParam>(image.shape(),
+                                               image.flat<TypeParam>());
+  this->template AddInputFromArray<TypeParam>(filter.shape(),
+                                               filter.flat<TypeParam>());
+  this->template AddInputFromArray<TypeParam>(bias.shape(),
+                                               bias.flat<TypeParam>());
 
   absl::Status status = this->RunOpKernel();
   EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
@@ -746,9 +749,12 @@ TYPED_TEST_P(MklFusedDepthwiseConv2DWithBiasOpTest, InvalidFilterDims) {
   Tensor bias(dtype, {3});
   bias.template flat<TypeParam>().setZero();
 
-  this->AddInputFromArray<TypeParam>(image.shape(), image.flat<TypeParam>());
-  this->AddInputFromArray<TypeParam>(filter.shape(), filter.flat<TypeParam>());
-  this->AddInputFromArray<TypeParam>(bias.shape(), bias.flat<TypeParam>());
+  this->template AddInputFromArray<TypeParam>(image.shape(),
+                                               image.flat<TypeParam>());
+  this->template AddInputFromArray<TypeParam>(filter.shape(),
+                                               filter.flat<TypeParam>());
+  this->template AddInputFromArray<TypeParam>(bias.shape(),
+                                               bias.flat<TypeParam>());
 
   absl::Status status = this->RunOpKernel();
   EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);

--- a/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_fused_ops_test.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #if defined(INTEL_MKL)
+#include "absl/strings/match.h"
 #include "tensorflow/cc/ops/const_op.h"
 #include "tensorflow/cc/ops/image_ops.h"
 #include "tensorflow/cc/ops/nn_ops.h"
@@ -687,11 +688,81 @@ TYPED_TEST_P(MklFusedDepthwiseConv2DWithBiasOpTest, SpatialConvolutionAndElu) {
                                    {"BiasAdd", "Elu"});
 }
 
+TYPED_TEST_P(MklFusedDepthwiseConv2DWithBiasOpTest, InvalidInputDims) {
+  DataType dtype = DataTypeToEnum<TypeParam>::v();
+  TF_EXPECT_OK(NodeDefBuilder("fused_depthwise_conv_op",
+                              "_MklNativeFusedDepthwiseConv2dNative")
+                   .Input(FakeInput(dtype))
+                   .Input(FakeInput(dtype))
+                   .Input(FakeInput(1, dtype))
+                   .Attr("T", dtype)
+                   .Attr("num_args", 1)
+                   .Attr("strides", {1, 1, 1, 1})
+                   .Attr("padding", "SAME")
+                   .Attr("fused_ops", std::vector<string>{"BiasAdd"})
+                   .Attr("_kernel", "MklNameChangeOp")
+                   .Finalize(this->node_def()));
+
+  TF_EXPECT_OK(this->InitOp());
+
+  Tensor image(dtype, {2, 3, 3});
+  image.template flat<TypeParam>().setZero();
+  Tensor filter(dtype, {1, 1, 3, 1});
+  filter.template flat<TypeParam>().setZero();
+  Tensor bias(dtype, {3});
+  bias.template flat<TypeParam>().setZero();
+
+  this->AddInputFromArray<TypeParam>(image.shape(), image.flat<TypeParam>());
+  this->AddInputFromArray<TypeParam>(filter.shape(), filter.flat<TypeParam>());
+  this->AddInputFromArray<TypeParam>(bias.shape(), bias.flat<TypeParam>());
+
+  absl::Status status = this->RunOpKernel();
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_TRUE(absl::StrContains(status.message(), "input must be 4-dimensional"))
+      << status.message();
+}
+
+TYPED_TEST_P(MklFusedDepthwiseConv2DWithBiasOpTest, InvalidFilterDims) {
+  DataType dtype = DataTypeToEnum<TypeParam>::v();
+  TF_EXPECT_OK(NodeDefBuilder("fused_depthwise_conv_op",
+                              "_MklNativeFusedDepthwiseConv2dNative")
+                   .Input(FakeInput(dtype))
+                   .Input(FakeInput(dtype))
+                   .Input(FakeInput(1, dtype))
+                   .Attr("T", dtype)
+                   .Attr("num_args", 1)
+                   .Attr("strides", {1, 1, 1, 1})
+                   .Attr("padding", "SAME")
+                   .Attr("fused_ops", std::vector<string>{"BiasAdd"})
+                   .Attr("_kernel", "MklNameChangeOp")
+                   .Finalize(this->node_def()));
+
+  TF_EXPECT_OK(this->InitOp());
+
+  Tensor image(dtype, {1, 3, 3, 3});
+  image.template flat<TypeParam>().setZero();
+  Tensor filter(dtype, {1, 3, 1});
+  filter.template flat<TypeParam>().setZero();
+  Tensor bias(dtype, {3});
+  bias.template flat<TypeParam>().setZero();
+
+  this->AddInputFromArray<TypeParam>(image.shape(), image.flat<TypeParam>());
+  this->AddInputFromArray<TypeParam>(filter.shape(), filter.flat<TypeParam>());
+  this->AddInputFromArray<TypeParam>(bias.shape(), bias.flat<TypeParam>());
+
+  absl::Status status = this->RunOpKernel();
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_TRUE(
+      absl::StrContains(status.message(), "filter must be 4-dimensional"))
+      << status.message();
+}
+
 REGISTER_TYPED_TEST_SUITE_P(
     MklFusedDepthwiseConv2DWithBiasOpTest, OneByOneConvolution,
     SpatialConvolution, OneByOneConvolutionAndRelu, SpatialConvolutionAndRelu,
     OneByOneConvolutionAndRelu6, SpatialConvolutionAndRelu6,
-    OneByOneConvolutionAndElu, SpatialConvolutionAndElu);
+    OneByOneConvolutionAndElu, SpatialConvolutionAndElu, InvalidInputDims,
+    InvalidFilterDims);
 
 using MklFusedBiasAddDataTypes = ::testing::Types<float>;
 INSTANTIATE_TYPED_TEST_SUITE_P(Test, MklFusedDepthwiseConv2DWithBiasOpTest,


### PR DESCRIPTION
This PR fixes a crash in oneDNN depthwise convolution when invalid input tensors (non-4D) are provided.

Previously:
- With TF_ENABLE_ONEDNN_OPTS=1, invalid input rank caused a crash due to missing validation.

After this fix:
- The op correctly raises InvalidArgumentError, consistent with the non-oneDNN path.

Fixes #112536