### PR TITLE
Fix idct() documentation: n parameter is already supported

### DIFF
--- a/tensorflow/python/kernel_tests/signal/dct_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/dct_ops_test.py
@@ -153,21 +153,21 @@ class DCTOpsTest(parameterized.TestCase, test.TestCase):
     tf_dct = dct_ops.dct(signals, n=n, type=dct_type, norm=norm)
     self.assertEqual(tf_dct.dtype.as_numpy_dtype, signals.dtype)
     self.assertAllClose(np_dct, tf_dct, atol=atol, rtol=rtol)
-    np_idct = NP_IDCT[dct_type](signals, n=None, norm=norm)
-    tf_idct = dct_ops.idct(signals, type=dct_type, norm=norm)
+    np_idct = NP_IDCT[dct_type](signals, n=n, norm=norm)
+    tf_idct = dct_ops.idct(signals, n=n, type=dct_type, norm=norm)
     self.assertEqual(tf_idct.dtype.as_numpy_dtype, signals.dtype)
     self.assertAllClose(np_idct, tf_idct, atol=atol, rtol=rtol)
     if fftpack and dct_type != 4:
       scipy_dct = fftpack.dct(signals, n=n, type=dct_type, norm=norm)
       self.assertAllClose(scipy_dct, tf_dct, atol=atol, rtol=rtol)
-      scipy_idct = fftpack.idct(signals, type=dct_type, norm=norm)
+      scipy_idct = fftpack.idct(signals, n=n, type=dct_type, norm=norm)
       self.assertAllClose(scipy_idct, tf_idct, atol=atol, rtol=rtol)
     # Verify inverse(forward(s)) == s, up to a normalization factor.
-    # Since `n` is not implemented for IDCT operation, re-calculating tf_dct
-    # without n.
-    tf_dct = dct_ops.dct(signals, type=dct_type, norm=norm)
-    tf_idct_dct = dct_ops.idct(tf_dct, type=dct_type, norm=norm)
-    tf_dct_idct = dct_ops.dct(tf_idct, type=dct_type, norm=norm)
+    # Roundtrip is only valid without truncation/padding, so use n=None.
+    tf_dct_full = dct_ops.dct(signals, type=dct_type, norm=norm)
+    tf_idct_dct = dct_ops.idct(tf_dct_full, type=dct_type, norm=norm)
+    tf_idct_full = dct_ops.idct(signals, type=dct_type, norm=norm)
+    tf_dct_idct = dct_ops.dct(tf_idct_full, type=dct_type, norm=norm)
     if norm is None:
       if dct_type == 1:
         tf_idct_dct *= 0.5 / (signals.shape[-1] - 1)

--- a/tensorflow/python/ops/signal/dct_ops.py
+++ b/tensorflow/python/ops/signal/dct_ops.py
@@ -208,7 +208,7 @@ def _dct_internal(input, type=2, n=None, axis=-1, norm=None, name=None):  # pyli
       return dct4
 
 
-# TODO(rjryan): Implement `n` and `axis` parameters.
+# TODO(rjryan): Implement `axis` parameter.
 @tf_export("signal.idct", v1=["signal.idct", "spectral.idct"])
 @dispatch.add_dispatch_support
 def idct(input, type=2, n=None, axis=-1, norm=None, name=None):  # pylint: disable=redefined-builtin
@@ -233,7 +233,10 @@ def idct(input, type=2, n=None, axis=-1, norm=None, name=None):  # pylint: disab
     input: A `[..., samples]` `float32`/`float64` `Tensor` containing the
       signals to take the DCT of.
     type: The IDCT type to perform. Must be 1, 2, 3 or 4.
-    n: For future expansion. The length of the transform. Must be `None`.
+    n: The length of the transform. If length is less than sequence length,
+      only the first n elements of the sequence are considered for the IDCT.
+      If n is greater than the sequence length, zeros are padded and then
+      the IDCT is computed as usual.
     axis: For future expansion. The axis to compute the DCT along. Must be `-1`.
     norm: The normalization to apply. `None` for no normalization or `'ortho'`
       for orthonormal normalization.
@@ -244,8 +247,10 @@ def idct(input, type=2, n=None, axis=-1, norm=None, name=None):  # pylint: disab
     `input`.
 
   Raises:
-    ValueError: If `type` is not `1`, `2` or `3`, `n` is not `None, `axis` is
-      not `-1`, or `norm` is not `None` or `'ortho'`.
+    ValueError: If `type` is not `1`, `2`, `3` or `4`, `axis` is
+      not `-1`, `n` is not `None` or greater than 0,
+      or `norm` is not `None` or `'ortho'`.
+    ValueError: If `type` is `1` and `norm` is `ortho`.
 
   [idct]:
   https://en.wikipedia.org/wiki/Discrete_cosine_transform#Inverse_transforms


### PR DESCRIPTION
## Summary

- Updated `tf.signal.idct()` docstring to correctly document that the `n` parameter supports truncation and zero-padding, matching `tf.signal.dct()`'s existing documentation
- Removed stale `TODO` comment that said `n` needs to be implemented (it already works)
- Fixed the `Raises` section to include type 4 and the type-1/ortho restriction
- Updated tests to exercise `idct` with the `n` parameter, verifying correctness against NumPy and SciPy references

## Background

The `idct()` docstring incorrectly states that `n` "Must be `None`". In reality, `idct()` delegates to `_dct_internal()` which fully handles `n` (truncation and zero-padding). The feature works correctly — only the docs were wrong.

## Test plan

- Updated `_compare()` in `dct_ops_test.py` to pass `n` to `idct` (previously hardcoded to `None`)
- Updated SciPy comparison to also pass `n` to `fftpack.idct`
- Fixed roundtrip test to use separate `n=None` calls so shape assertions remain valid when `n != signals.shape[-1]`

Fixes #102418