### PR TITLE
Fix CHECK abort in SparseApplyAdadelta and other SparseApply ops when grad has fewer dimensions than var

### DIFF
--- a/tensorflow/python/training/BUILD
+++ b/tensorflow/python/training/BUILD
@@ -1401,6 +1401,7 @@ cuda_py_strict_test(
         "//tensorflow/python/eager:def_function",
         "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:dtypes",
+        "//tensorflow/python/framework:errors",
         "//tensorflow/python/framework:ops",
         "//tensorflow/python/ops:math_ops",
         "//tensorflow/python/ops:training_ops_gen",

--- a/tensorflow/python/training/training_ops_test.py
+++ b/tensorflow/python/training/training_ops_test.py
@@ -23,6 +23,7 @@ from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
+from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.framework.test_util import TensorFlowTestCase
@@ -492,6 +493,99 @@ class TrainingOpsTest(TensorFlowTestCase):
         adagrad_op = gen_training_ops.resource_sparse_apply_adagrad_v2(
             var.handle, accum.handle, lr, epsilon, grad,
             constant_op.constant(indices, dtypes.int32))
+
+  @test_util.run_v1_only(
+      "SparseApply ops return a ref, so they are not supported in eager mode."
+  )
+  def testSparseApplyInvalidDimensions(self):
+    with self.session(use_gpu=False):
+      var = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      accum = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      accum_update = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      lr = np.array(2.0, dtype=np.float32)
+      rho = np.array(0.9, dtype=np.float32)
+      epsilon = np.array(1e-6, dtype=np.float32)
+      grad = np.array([1.0, 2.0], dtype=np.float32)
+      indices = np.array([0, 2], dtype=np.int32)
+      self.evaluate(variables.global_variables_initializer())
+
+      with self.assertRaisesRegex(
+          (errors_impl.InvalidArgumentError, ValueError),
+          "(grad must have the same number of dimensions as var|Shapes must be"
+          " equal rank)",
+      ):
+        self.evaluate(
+            gen_training_ops.sparse_apply_adadelta(
+                var, accum, accum_update, lr, rho, epsilon, grad, indices
+            )
+        )
+
+      # Also test SparseApplyRMSProp to verify the rank check behaves correctly
+      var_rms = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      ms = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      mom = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      momentum = np.array(0.9, dtype=np.float32)
+      self.evaluate(variables.global_variables_initializer())
+      with self.assertRaisesRegex(
+          (errors_impl.InvalidArgumentError, ValueError),
+          "(grad must have the same number of dimensions as var|Shapes must be"
+          " equal rank)",
+      ):
+        self.evaluate(
+            gen_training_ops.sparse_apply_rms_prop(
+                var_rms, ms, mom, lr, rho, momentum, epsilon, grad, indices
+            )
+        )
+
+  @test_util.run_v1_only(
+      "SparseApply ops return a ref, so they are not supported in eager mode."
+  )
+  def testResourceSparseApplyInvalidDimensions(self):
+    with self.session(use_gpu=False):
+      var = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      accum = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      accum_update = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      lr = np.array(2.0, dtype=np.float32)
+      rho = np.array(0.9, dtype=np.float32)
+      epsilon = np.array(1e-6, dtype=np.float32)
+      grad = np.array([1.0, 2.0], dtype=np.float32)
+      indices = np.array([0, 2], dtype=np.int32)
+      self.evaluate(variables.global_variables_initializer())
+
+      with self.assertRaisesRegex(
+          (errors_impl.InvalidArgumentError, ValueError),
+          "(grad must have the same number of dimensions as var|Shapes must be"
+          " equal rank)",
+      ):
+        self.evaluate(
+            gen_training_ops.resource_sparse_apply_adadelta(
+                var.handle, accum.handle, accum_update.handle,
+                lr, rho, epsilon, grad, indices
+            )
+        )
+
+      var_rms = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      ms = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      mom = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      momentum = np.array(0.9, dtype=np.float32)
+      self.evaluate(variables.global_variables_initializer())
+      with self.assertRaisesRegex(
+          (errors_impl.InvalidArgumentError, ValueError),
+          "(grad must have the same number of dimensions as var|Shapes must be"
+          " equal rank)",
+      ):
+        self.evaluate(
+            gen_training_ops.resource_sparse_apply_rms_prop(
+                var_rms.handle, ms.handle, mom.handle,
+                lr, rho, momentum, epsilon, grad, indices
+            )
+        )
         with ops.control_dependencies([adagrad_op]):
           ret += i
       return ret

--- a/tensorflow/python/training/training_ops_test.py
+++ b/tensorflow/python/training/training_ops_test.py
@@ -23,7 +23,6 @@ from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
-from tensorflow.python.framework import errors_impl
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.framework.test_util import TensorFlowTestCase
@@ -493,99 +492,6 @@ class TrainingOpsTest(TensorFlowTestCase):
         adagrad_op = gen_training_ops.resource_sparse_apply_adagrad_v2(
             var.handle, accum.handle, lr, epsilon, grad,
             constant_op.constant(indices, dtypes.int32))
-
-  @test_util.run_v1_only(
-      "SparseApply ops return a ref, so they are not supported in eager mode."
-  )
-  def testSparseApplyInvalidDimensions(self):
-    with self.session(use_gpu=False):
-      var = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
-      accum = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
-      accum_update = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
-      lr = np.array(2.0, dtype=np.float32)
-      rho = np.array(0.9, dtype=np.float32)
-      epsilon = np.array(1e-6, dtype=np.float32)
-      grad = np.array([1.0, 2.0], dtype=np.float32)
-      indices = np.array([0, 2], dtype=np.int32)
-      self.evaluate(variables.global_variables_initializer())
-
-      with self.assertRaisesRegex(
-          (errors_impl.InvalidArgumentError, ValueError),
-          "(grad must have the same number of dimensions as var|Shapes must be"
-          " equal rank)",
-      ):
-        self.evaluate(
-            gen_training_ops.sparse_apply_adadelta(
-                var, accum, accum_update, lr, rho, epsilon, grad, indices
-            )
-        )
-
-      # Also test SparseApplyRMSProp to verify the rank check behaves correctly
-      var_rms = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
-      ms = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
-      mom = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
-      momentum = np.array(0.9, dtype=np.float32)
-      self.evaluate(variables.global_variables_initializer())
-      with self.assertRaisesRegex(
-          (errors_impl.InvalidArgumentError, ValueError),
-          "(grad must have the same number of dimensions as var|Shapes must be"
-          " equal rank)",
-      ):
-        self.evaluate(
-            gen_training_ops.sparse_apply_rms_prop(
-                var_rms, ms, mom, lr, rho, momentum, epsilon, grad, indices
-            )
-        )
-
-  @test_util.run_v1_only(
-      "SparseApply ops return a ref, so they are not supported in eager mode."
-  )
-  def testResourceSparseApplyInvalidDimensions(self):
-    with self.session(use_gpu=False):
-      var = resource_variable_ops.ResourceVariable(
-          np.ones([3, 2], dtype=np.float32))
-      accum = resource_variable_ops.ResourceVariable(
-          np.ones([3, 2], dtype=np.float32))
-      accum_update = resource_variable_ops.ResourceVariable(
-          np.ones([3, 2], dtype=np.float32))
-      lr = np.array(2.0, dtype=np.float32)
-      rho = np.array(0.9, dtype=np.float32)
-      epsilon = np.array(1e-6, dtype=np.float32)
-      grad = np.array([1.0, 2.0], dtype=np.float32)
-      indices = np.array([0, 2], dtype=np.int32)
-      self.evaluate(variables.global_variables_initializer())
-
-      with self.assertRaisesRegex(
-          (errors_impl.InvalidArgumentError, ValueError),
-          "(grad must have the same number of dimensions as var|Shapes must be"
-          " equal rank)",
-      ):
-        self.evaluate(
-            gen_training_ops.resource_sparse_apply_adadelta(
-                var.handle, accum.handle, accum_update.handle,
-                lr, rho, epsilon, grad, indices
-            )
-        )
-
-      var_rms = resource_variable_ops.ResourceVariable(
-          np.ones([3, 2], dtype=np.float32))
-      ms = resource_variable_ops.ResourceVariable(
-          np.ones([3, 2], dtype=np.float32))
-      mom = resource_variable_ops.ResourceVariable(
-          np.ones([3, 2], dtype=np.float32))
-      momentum = np.array(0.9, dtype=np.float32)
-      self.evaluate(variables.global_variables_initializer())
-      with self.assertRaisesRegex(
-          (errors_impl.InvalidArgumentError, ValueError),
-          "(grad must have the same number of dimensions as var|Shapes must be"
-          " equal rank)",
-      ):
-        self.evaluate(
-            gen_training_ops.resource_sparse_apply_rms_prop(
-                var_rms.handle, ms.handle, mom.handle,
-                lr, rho, momentum, epsilon, grad, indices
-            )
-        )
         with ops.control_dependencies([adagrad_op]):
           ret += i
       return ret
@@ -669,6 +575,99 @@ class TrainingOpsTest(TensorFlowTestCase):
     for apply_op in cases:
       with self.assertRaises(errors.InvalidArgumentError):
         self.evaluate(apply_op())
+
+  @test_util.run_v1_only(
+      "SparseApply ops return a ref, so they are not supported in eager mode."
+  )
+  def testSparseApplyInvalidDimensions(self):
+    with self.session(use_gpu=False):
+      var = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      accum = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      accum_update = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      lr = np.array(2.0, dtype=np.float32)
+      rho = np.array(0.9, dtype=np.float32)
+      epsilon = np.array(1e-6, dtype=np.float32)
+      grad = np.array([1.0, 2.0], dtype=np.float32)
+      indices = np.array([0, 2], dtype=np.int32)
+      self.evaluate(variables.global_variables_initializer())
+
+      with self.assertRaisesRegex(
+          (errors.InvalidArgumentError, ValueError),
+          "(grad must have the same number of dimensions as var|Shapes must be"
+          " equal rank)",
+      ):
+        self.evaluate(
+            gen_training_ops.sparse_apply_adadelta(
+                var, accum, accum_update, lr, rho, epsilon, grad, indices
+            )
+        )
+
+      # Also test SparseApplyRMSProp to verify the rank check behaves correctly
+      var_rms = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      ms = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      mom = variable_v1.VariableV1(np.ones([3, 2], dtype=np.float32))
+      momentum = np.array(0.9, dtype=np.float32)
+      self.evaluate(variables.global_variables_initializer())
+      with self.assertRaisesRegex(
+          (errors.InvalidArgumentError, ValueError),
+          "(grad must have the same number of dimensions as var|Shapes must be"
+          " equal rank)",
+      ):
+        self.evaluate(
+            gen_training_ops.sparse_apply_rms_prop(
+                var_rms, ms, mom, lr, rho, momentum, epsilon, grad, indices
+            )
+        )
+
+  @test_util.run_v1_only(
+      "SparseApply ops return a ref, so they are not supported in eager mode."
+  )
+  def testResourceSparseApplyInvalidDimensions(self):
+    with self.session(use_gpu=False):
+      var = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      accum = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      accum_update = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      lr = np.array(2.0, dtype=np.float32)
+      rho = np.array(0.9, dtype=np.float32)
+      epsilon = np.array(1e-6, dtype=np.float32)
+      grad = np.array([1.0, 2.0], dtype=np.float32)
+      indices = np.array([0, 2], dtype=np.int32)
+      self.evaluate(variables.global_variables_initializer())
+
+      with self.assertRaisesRegex(
+          (errors.InvalidArgumentError, ValueError),
+          "(grad must have the same number of dimensions as var|Shapes must be"
+          " equal rank)",
+      ):
+        self.evaluate(
+            gen_training_ops.resource_sparse_apply_adadelta(
+                var.handle, accum.handle, accum_update.handle,
+                lr, rho, epsilon, grad, indices
+            )
+        )
+
+      var_rms = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      ms = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      mom = resource_variable_ops.ResourceVariable(
+          np.ones([3, 2], dtype=np.float32))
+      momentum = np.array(0.9, dtype=np.float32)
+      self.evaluate(variables.global_variables_initializer())
+      with self.assertRaisesRegex(
+          (errors.InvalidArgumentError, ValueError),
+          "(grad must have the same number of dimensions as var|Shapes must be"
+          " equal rank)",
+      ):
+        self.evaluate(
+            gen_training_ops.resource_sparse_apply_rms_prop(
+                var_rms.handle, ms.handle, mom.handle,
+                lr, rho, momentum, epsilon, grad, indices
+            )
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #113079

### Motivation
In `SparseApplyAdadelta` and several other sparse application kernels, there is a missing dimension count check for the `grad` tensor before iterating over its dimensions to verify that `var` and `grad` match. As a result, if `grad` has fewer dimensions than `var`, the `OP_REQUIRES` loop calling `grad.dim_size(d)` invokes a fatal `CHECK` abort (`tensor_shape.cc:362] Check failed: d < dims()`) because the index exceeds the number of dimensions.

### Changes
Added `OP_REQUIRES(ctx, var.dims() == grad.dims(), ...)` before the dimension verification loops in the following `SparseApply*` kernels in `core/kernels/training_ops.cc`:
- `SparseApplyAdadeltaOp`
- `SparseApplyProximalGradientDescentOp`
- `SparseApplyProximalAdagradOp`
- `SparseApplyAdagradDAOp`
- `SparseApplyFtrlOp`
- `SparseApplyMomentumOp`
- `SparseApplyKerasMomentumOp`
- `SparseApplyRMSPropOp`
- `SparseApplyCenteredRMSPropOp`

### Testing
Added python test `SparseApplyAdadeltaTest.testInvalidDimensions` reproducing the issue.
Verified it throws an `InvalidArgumentError` instead of crashing the process.