### PR TITLE
tools/docs: normalize eager Tensor repr numpy fields

### DIFF
--- a/tensorflow/tools/docs/tf_doctest_lib.py
+++ b/tensorflow/tools/docs/tf_doctest_lib.py
@@ -106,9 +106,11 @@ class TfDoctestOutputChecker(doctest.OutputChecker, object):
     self.float_size_good = None
 
   _ADDRESS_RE = re.compile(r'\bat 0x[0-9a-f]*?>')
-  # TODO(yashkatariya): Add other tensor's string substitutions too.
-  # tf.RaggedTensor doesn't need one.
-  _NUMPY_OUTPUT_RE = re.compile(r'<tf.Tensor.*?numpy=(.*?)>', re.DOTALL)
+  # Normalize the `numpy=...` field in eager `*Tensor` reprs.
+  # tf.RaggedTensor doesn't need this normalization.
+  _NUMPY_OUTPUT_RE = re.compile(
+      r'<tf\.(?!RaggedTensor)(?:[A-Za-z0-9_]*Tensor).*?numpy=(.*?)>',
+      re.DOTALL)
 
   def _allclose(self, want, got, rtol=1e-3, atol=1e-3):
     return np.allclose(want, got, rtol=rtol, atol=atol)

--- a/tensorflow/tools/docs/tf_doctest_test.py
+++ b/tensorflow/tools/docs/tf_doctest_test.py
@@ -197,6 +197,10 @@ class TfDoctestOutputCheckerTest(parameterized.TestCase):
           ('<tf.RaggedTensor:... shape=(2, 2), numpy=1>', False)
       ],
       [
+          '<tf.SparseTensor: shape=(2, 2), dtype=float32, numpy=1>',
+          ('1', True)
+      ],
+      [
           """<tf.Tensor: shape=(2, 2), dtype=int32, numpy=
               array([[2, 2],
                      [3, 5]], dtype=int32)>""",


### PR DESCRIPTION
Normalize the 
umpy=... field in eager *Tensor reprs in TfDoctestOutputChecker (excluding 	f.RaggedTensor) and add unit test coverage.

Made with [Cursor](https://cursor.com)