### PR TITLE
Fix ResourceGather dtype mismatch CHECK failure (Issue #113076)

### DIFF
--- a/tensorflow/core/kernels/resource_variable_ops.cc
+++ b/tensorflow/core/kernels/resource_variable_ops.cc
@@ -751,6 +751,12 @@ class ResourceGatherOp : public OpKernel {
     // (potentially very large) tensor buffer.
     tf_shared_lock ml(*v->mu());
     const Tensor& params = *v->tensor();
+    OP_REQUIRES(
+        c, params.dtype() == DataTypeToEnum<T>::v(),
+        absl::InvalidArgumentError(absl::StrCat(
+            "dtype mismatch: expected ", DataTypeString(DataTypeToEnum<T>::v()),
+            " but got ", DataTypeString(params.dtype()),
+            " (resource variable dtype)")));
     const Tensor& indices = c->input(1);
     OP_REQUIRES(
         c, TensorShapeUtils::IsVectorOrHigher(params.shape()),
@@ -929,6 +935,12 @@ class ResourceGatherNdOp : public OpKernel {
     // (potentially very large) tensor buffer.
     tf_shared_lock ml(*v->mu());
     const Tensor& params = *v->tensor();
+    OP_REQUIRES(
+        c, params.dtype() == DataTypeToEnum<T>::v(),
+        absl::InvalidArgumentError(absl::StrCat(
+            "dtype mismatch: expected ", DataTypeString(DataTypeToEnum<T>::v()),
+            " but got ", DataTypeString(params.dtype()),
+            " (resource variable dtype)")));
     const Tensor& indices = c->input(1);
 
     Tensor out;


### PR DESCRIPTION
## Summary
Add dtype validation in ResourceGatherOp and ResourceGatherNdOp to check that the requested dtype matches the underlying resource variable dtype. This raises a proper InvalidArgumentError instead of aborting with an internal CHECK failure.

## Fixes
Fixes #113076

## Test
The fix can be tested by running the reproducer from the issue.

Before: Process aborts with "Check failed: dtype() == expected_dtype"
After: Raises InvalidArgumentError with clear error message