### PR TITLE
Fix DeleteMultiDeviceIterator crash (Issue #107121)

### DIFF
--- a/tensorflow/core/kernels/data/multi_device_iterator_ops.cc
+++ b/tensorflow/core/kernels/data/multi_device_iterator_ops.cc
@@ -856,7 +856,15 @@ class DeleteMultiDeviceIteratorOp : public OpKernel {
       : OpKernel(ctx) {}
 
   void Compute(OpKernelContext* ctx) override {
-    ResourceHandle handle = ctx->input(0).flat<ResourceHandle>()(0);
+    const Tensor& input = ctx->input(0);
+    OP_REQUIRES(ctx, input.dtype() == DT_RESOURCE,
+                absl::InvalidArgumentError(
+                    "Input 0 expected to be a resource handle, got: " +
+                    DataTypeString(input.dtype())));
+    OP_REQUIRES(ctx, input.NumElements() > 0,
+                absl::InvalidArgumentError(
+                    "Input 0 must have at least one element"));
+    ResourceHandle handle = input.flat<ResourceHandle>()(0);
     // The iterator resource is guaranteed to
     // exist because the variant tensor wrapping the deleter is provided as an
     // unused input to this op, which guarantees that it has not run yet.


### PR DESCRIPTION
## Summary
Add validation to check that input is a valid resource handle before accessing it, preventing segmentation fault when invalid input is provided.

## Fixes
Fixes #107121

## Test
The fix can be tested by running the reproducer from the issue.

Before: Segmentation fault (core dumped)
After: Raises InvalidArgumentError with clear error message