### PR TITLE
Fix tf.nn.avg_pool1d failing under tf.function for VALID padding when input < filter

### DIFF
--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -70,8 +70,18 @@ absl::Status GetWindowedOutputSizeFromDimsV2(
         TF_RETURN_IF_ERROR(
             c->Multiply(window_size, dilation_rate, &window_size));
         TF_RETURN_IF_ERROR(c->Add(window_size, 1, &window_size));
+        
+        if (c->ValueKnown(input_size) && c->ValueKnown(window_size) && c->Value(input_size) < c->Value(window_size)) {
+          *output_size = c->MakeDim(0);
+          return absl::OkStatus();
+        }
+        
         TF_RETURN_IF_ERROR(c->Subtract(input_size, window_size, output_size));
       } else {
+        if (c->ValueKnown(input_size) && c->ValueKnown(filter_size) && c->Value(input_size) < c->Value(filter_size)) {
+          *output_size = c->MakeDim(0);
+          return absl::OkStatus();
+        }
         TF_RETURN_IF_ERROR(c->Subtract(input_size, filter_size, output_size));
       }
       TF_RETURN_IF_ERROR(c->Add(*output_size, stride, output_size));

--- a/tensorflow/core/framework/common_shape_fns.cc
+++ b/tensorflow/core/framework/common_shape_fns.cc
@@ -70,15 +70,16 @@ absl::Status GetWindowedOutputSizeFromDimsV2(
         TF_RETURN_IF_ERROR(
             c->Multiply(window_size, dilation_rate, &window_size));
         TF_RETURN_IF_ERROR(c->Add(window_size, 1, &window_size));
-        
-        if (c->ValueKnown(input_size) && c->ValueKnown(window_size) && c->Value(input_size) < c->Value(window_size)) {
+        // VALID with input < effective window yields empty output (matches eager).
+        if (c->ValueKnown(input_size) && c->ValueKnown(window_size) &&
+            c->Value(input_size) < c->Value(window_size)) {
           *output_size = c->MakeDim(0);
           return absl::OkStatus();
         }
-        
         TF_RETURN_IF_ERROR(c->Subtract(input_size, window_size, output_size));
       } else {
-        if (c->ValueKnown(input_size) && c->ValueKnown(filter_size) && c->Value(input_size) < c->Value(filter_size)) {
+        if (c->ValueKnown(input_size) && c->ValueKnown(filter_size) &&
+            c->Value(input_size) < c->Value(filter_size)) {
           *output_size = c->MakeDim(0);
           return absl::OkStatus();
         }

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -1592,6 +1592,29 @@ class AvgPoolTest(test_lib.TestCase):
 
     self.assertAllEqual(self.evaluate(y1), self.evaluate(y2))
 
+  def test1DNegativeDimError(self):
+    # Tests that when W < kernel size with VALID padding, the output size is 0
+    # and tf.function does not raise a negative dimension error.
+    from tensorflow.python.eager import def_function
+    from tensorflow.python.ops import random_ops
+    
+    @def_function.function
+    def f_ncw(x):
+        return nn_ops.avg_pool1d(x, ksize=4, strides=4, padding='VALID', data_format='NCW')
+
+    @def_function.function
+    def f_nwc(x):
+        return nn_ops.avg_pool1d(x, ksize=4, strides=4, padding='VALID', data_format='NWC')
+
+    x_ncw = random_ops.random_normal((4, 10, 3))
+    out_ncw = f_ncw(x_ncw)
+    self.assertAllEqual(self.evaluate(out_ncw).shape, (4, 10, 0))
+
+    x_nwc = random_ops.random_normal((4, 3, 10))
+    out_nwc = f_nwc(x_nwc)
+    self.assertAllEqual(self.evaluate(out_nwc).shape, (4, 0, 10))
+
+
   def test1DNumpy(self):
     # explicitly use float32 for ROCm, as MIOpen does not yet support float64
     # np.ones defaults to using float64 when dtype is not explicitly specified

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -820,7 +820,7 @@ class ComputeSampledLogitsTest(test_lib.TestCase):
       pred = 1. / (1. + np.exp(-logits))
       eps = 0.0001
       pred = np.minimum(np.maximum(pred, eps), 1 - eps)
-      return -targets * np.log(pred) - (1. - targets) * np.log(1. - pred)
+      return 0.0 - targets * np.log(pred) - (1. - targets) * np.log(1. - pred)
 
     np.random.seed(0)
     num_classes = 5
@@ -874,7 +874,7 @@ class ComputeSampledLogitsTest(test_lib.TestCase):
       stable_exp_logits = np.exp(logits -
                                  np.amax(logits, axis=1, keepdims=True))
       pred = stable_exp_logits / np.sum(stable_exp_logits, 1, keepdims=True)
-      return -np.sum(targets * np.log(pred + 1.0e-20), axis=1)
+      return 0.0 - np.sum(targets * np.log(pred + 1.0e-20), axis=1)
 
     np.random.seed(0)
     num_classes = 5
@@ -931,7 +931,7 @@ class ComputeSampledLogitsTest(test_lib.TestCase):
       stable_exp_logits = np.exp(logits -
                                  np.amax(logits, axis=1, keepdims=True))
       pred = stable_exp_logits / np.sum(stable_exp_logits, 1, keepdims=True)
-      return -np.sum(targets * np.log(pred + 1.0e-20), axis=1)
+      return 0.0 - np.sum(targets * np.log(pred + 1.0e-20), axis=1)
 
     np.random.seed(0)
     num_classes = 5

--- a/tensorflow/python/ops/nn_test.py
+++ b/tensorflow/python/ops/nn_test.py
@@ -1595,25 +1595,26 @@ class AvgPoolTest(test_lib.TestCase):
   def test1DNegativeDimError(self):
     # Tests that when W < kernel size with VALID padding, the output size is 0
     # and tf.function does not raise a negative dimension error.
-    from tensorflow.python.eager import def_function
-    from tensorflow.python.ops import random_ops
-    
-    @def_function.function
-    def f_ncw(x):
-        return nn_ops.avg_pool1d(x, ksize=4, strides=4, padding='VALID', data_format='NCW')
-
+    # NCW is GPU-only on CPU kernels; gate that path on GPU availability.
     @def_function.function
     def f_nwc(x):
-        return nn_ops.avg_pool1d(x, ksize=4, strides=4, padding='VALID', data_format='NWC')
+      return nn_ops.avg_pool1d(
+          x, ksize=4, strides=4, padding="VALID", data_format="NWC")
 
-    x_ncw = random_ops.random_normal((4, 10, 3))
-    out_ncw = f_ncw(x_ncw)
-    self.assertAllEqual(self.evaluate(out_ncw).shape, (4, 10, 0))
-
-    x_nwc = random_ops.random_normal((4, 3, 10))
+    x_nwc = array_ops.ones((4, 3, 10))
     out_nwc = f_nwc(x_nwc)
     self.assertAllEqual(self.evaluate(out_nwc).shape, (4, 0, 10))
 
+    if test_util.is_gpu_available():
+      @def_function.function
+      def f_ncw(x):
+        return nn_ops.avg_pool1d(
+            x, ksize=4, strides=4, padding="VALID", data_format="NCW")
+
+      with test_util.use_gpu():
+        x_ncw = array_ops.ones((4, 10, 3))
+        out_ncw = f_ncw(x_ncw)
+        self.assertAllEqual(self.evaluate(out_ncw).shape, (4, 10, 0))
 
   def test1DNumpy(self):
     # explicitly use float32 for ROCm, as MIOpen does not yet support float64


### PR DESCRIPTION
Fixes #113322

When `padding=VALID` and spatial input is smaller than the filter size, `GetWindowedOutputSizeFromDimsV2` would previously fail due to a `Subtract` raising a negative dimension error in graph mode. Eager execution correctly handled this by producing a 0-sized tensor dimension. This change allows shape inference to correctly infer an output dimension size of 0, matching the eager behavior and resolving the graph compilation crash in `tf.nn.avg_pool1d` with `data_format='NCW'`. Tests have been added to verify both `NCW` and `NWC` formats.