### PR TITLE
Improve tf.matmul error message to show inner dimensions mismatch

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/matmul_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/matmul_op.cc
@@ -90,7 +90,10 @@ class MatMulOp : public XlaOpKernel {
                 a_shape.dim_size(first_index) == b_shape.dim_size(second_index),
                 errors::InvalidArgument(
                     "Matrix size-incompatible: In[0]: ", a_shape.DebugString(),
-                    ", In[1]: ", b_shape.DebugString()));
+                    ", In[1]: ", b_shape.DebugString(),
+                    ". The inner dimensions (",
+                    a_shape.dim_size(first_index), " and ",
+                    b_shape.dim_size(second_index), ") must match."));
 
     xla::XlaOp a = ctx->Input(0);
     xla::XlaOp b = ctx->Input(1);

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -691,7 +691,9 @@ class FusedMatMulOp : public OpKernel {
         ctx, a.dim_size(dim_pair[0].first) == b.dim_size(dim_pair[0].second),
         errors::InvalidArgument(
             "Matrix size-incompatible: In[0]: ", a.shape().DebugString(),
-            ", In[1]: ", b.shape().DebugString()));
+            ", In[1]: ", b.shape().DebugString(), ". The inner dimensions (",
+            a.dim_size(dim_pair[0].first), " and ",
+            b.dim_size(dim_pair[0].second), ") must match."));
     int a_dim_remaining = 1 - dim_pair[0].first;
     int b_dim_remaining = 1 - dim_pair[0].second;
     TensorShape out_shape(

--- a/tensorflow/core/kernels/matmul_op_impl.h
+++ b/tensorflow/core/kernels/matmul_op_impl.h
@@ -955,7 +955,9 @@ class BaseBatchMatMulOp : public OpKernel {
         ctx, d1 == d2,
         errors::InvalidArgument(
             "Matrix size-incompatible: In[0]: ", in0.shape().DebugString(),
-            ", In[1]: ", in1.shape().DebugString()));
+            ", In[1]: ", in1.shape().DebugString(),
+            ". The inner dimensions (", d1, " and ", d2,
+            ") must match. MatMul requires both inputs to be at least 2D."));
     OP_REQUIRES_OK(ctx, out_shape.AddDimWithStatus(d0));
     OP_REQUIRES_OK(ctx, out_shape.AddDimWithStatus(d3));
     Tensor* out = nullptr;

--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
@@ -133,7 +133,9 @@ class BatchMatMulMkl : public OpKernel {
         ctx, lhs_cols == rhs_rows,
         absl::InvalidArgumentError(absl::StrCat(
             "Matrix size-incompatible: In[0]: ", lhs.shape().DebugString(),
-            ", In[1]: ", rhs.shape().DebugString(), " ", adj_x_, " ", adj_y_)));
+            ", In[1]: ", rhs.shape().DebugString(),
+            ". The inner dimensions (", lhs_cols, " and ", rhs_rows,
+            ") must match.")));
 
     out_shape.AddDim(lhs_rows);
     out_shape.AddDim(rhs_cols);

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op.cc
@@ -64,7 +64,9 @@ class MklMatMulOp : public OpKernel {
         ctx, d1 == d2,
         absl::InvalidArgumentError(absl::StrCat(
             "Matrix size-incompatible: In[0]: ", a.shape().DebugString(),
-            ", In[1]: ", b.shape().DebugString())));
+            ", In[1]: ", b.shape().DebugString(),
+            ". The inner dimensions (", d1, " and ", d2,
+            ") must match.")));
     int a_dim_remaining = 1 - dim_pair[0].first;
     int b_dim_remaining = 1 - dim_pair[0].second;
     TensorShape out_shape(

--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
@@ -117,7 +117,9 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T2, Tbias, Toutput> {
         ctx, k == weight_tf_shape.dim_size(dim_pair[1]),
         absl::InvalidArgumentError(absl::StrCat(
             "Matrix size-incompatible: In[0]: ", src_tf_shape.DebugString(),
-            ", In[1]: ", weight_tf_shape.DebugString())));
+            ", In[1]: ", weight_tf_shape.DebugString(),
+            ". The inner dimensions (", k, " and ",
+            weight_tf_shape.dim_size(dim_pair[1]), ") must match.")));
     OP_REQUIRES(ctx, bias_tensor.dim_size(bias_tensor.dims() - 1) == channel,
                 absl::InvalidArgumentError(absl::StrCat(
                     "Must provide as many biases as the channel size: ",

--- a/tensorflow/core/kernels/quantized_matmul_op.cc
+++ b/tensorflow/core/kernels/quantized_matmul_op.cc
@@ -121,7 +121,11 @@ class QuantizedMatMulOp : public OpKernel {
                 a.dim_size(dim_pair[0].first) == b.dim_size(dim_pair[0].second),
                 errors::InvalidArgument("Matrix size-incompatible: In[0]: ",
                                         a.shape().DebugString(),
-                                        ", In[1]: ", b.shape().DebugString()));
+                                        ", In[1]: ", b.shape().DebugString(),
+                                        ". The inner dimensions (",
+                                        a.dim_size(dim_pair[0].first), " and ",
+                                        b.dim_size(dim_pair[0].second),
+                                        ") must match."));
 
     OP_REQUIRES(context, ((shift_c >= 0) && (shift_c <= 31)),
                 errors::InvalidArgument("shift_c must be between 0 and 31, "


### PR DESCRIPTION
## Summary
Improves the error message in tf.matmul to show which specific inner dimensions are incompatible.

## Changes
- Added explicit inner dimension values to error message (e.g., 'The inner dimensions (2 and 3) must match.')
- For the main matmul implementation, also notes that both inputs must be at least 2D.

## Before
ValueError: Matrix size-incompatible: In[0]: [1,2], In[1]: [3]

## After
ValueError: Matrix size-incompatible: In[0]: [1,2], In[1]: [3]. The inner dimensions (2 and 3) must match. MatMul requires both inputs to be at least 2D.

Fixes #110513