### PR TITLE
Improve AutoGraph if-expression error for mismatched branches

### DIFF
--- a/tensorflow/python/autograph/operators/BUILD
+++ b/tensorflow/python/autograph/operators/BUILD
@@ -1,3 +1,18 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 load("@xla//third_party/rules_python/python:py_library.bzl", "py_library")
 load("//tensorflow:pytype.default.bzl", "pytype_strict_library")
 load("//tensorflow:tensorflow.bzl", "py_test")
@@ -103,6 +118,8 @@ py_library(
         ":control_flow",
         "//tensorflow/python/autograph/utils:tensors",
         "//tensorflow/python/ops:cond",
+        "//tensorflow/python/util:nest",
+        "//tensorflow/python/util:variable_utils",
     ],
 )
 

--- a/tensorflow/python/autograph/operators/conditional_expressions.py
+++ b/tensorflow/python/autograph/operators/conditional_expressions.py
@@ -15,9 +15,13 @@
 """Conditional expressions (e.g. the ternary if statement)."""
 
 
+import functools
+
 from tensorflow.python.autograph.operators import control_flow
 from tensorflow.python.autograph.utils import tensors
 from tensorflow.python.ops import cond as tf_cond
+from tensorflow.python.util import nest
+from tensorflow.python.util import variable_utils
 
 
 def if_exp(cond, if_true, if_false, expr_repr):
@@ -36,16 +40,38 @@ def _tf_if_exp(cond, if_true, if_false, expr_repr):
   def true_fn():
     true_val.append(if_true())
     if true_val and false_val:
-      control_flow.verify_single_cond_var(expr_repr, true_val[0], false_val[0])
+      _verify_tf_if_exp_cond_var(expr_repr, true_val[0], false_val[0])
     return true_val[0]
 
   def false_fn():
     false_val.append(if_false())
     if true_val and false_val:
-      control_flow.verify_single_cond_var(expr_repr, true_val[0], false_val[0])
+      _verify_tf_if_exp_cond_var(expr_repr, true_val[0], false_val[0])
     return false_val[0]
 
   return tf_cond.cond(cond, true_fn, false_fn)
+
+
+def _verify_tf_if_exp_cond_var(expr_repr, true_val, false_val):
+  """Verifies that both branches of a conditional expression are compatible."""
+  try:
+    nest.assert_same_structure(true_val, false_val, expand_composites=True)
+  except (TypeError, ValueError):
+    try:
+      true_val = variable_utils.convert_variables_to_tensors(true_val)
+      false_val = variable_utils.convert_variables_to_tensors(false_val)
+      nest.assert_same_structure(true_val, false_val, expand_composites=True)
+    except (TypeError, ValueError) as e:
+      raise ValueError(
+          'conditional expression "{}" must return the same nested structure '
+          'in both branches. If you only need side effects, use a statement '
+          '`if:` instead; otherwise, make both branches return the same '
+          'structure or use `tf.cond` explicitly.'.format(expr_repr)) from e
+
+  nest.map_structure(
+      functools.partial(control_flow.verify_single_cond_var, expr_repr),
+      true_val,
+      false_val)
 
 
 def _py_if_exp(cond, if_true, if_false):

--- a/tensorflow/python/autograph/tests/basic_ifexp_test.py
+++ b/tensorflow/python/autograph/tests/basic_ifexp_test.py
@@ -46,12 +46,24 @@ def cond_with_multiple_values(x):
   return x, y, z
 
 
+def side_effect_only_ifexp_with_imbalanced_structure(x):
+  traced_args = tf.unstack(x) if tf.size(x) > 0 else []
+  tf.autograph.trace(*traced_args)
+  return x * 2 + 1
+
+
 class ReferenceTest(reference_test_base.TestCase):
 
   def test_basic(self):
     for x in [-1, 1, 5, tf.constant(-1), tf.constant(1), tf.constant(5)]:
       self.assertFunctionMatchesEager(consecutive_conds, x)
       self.assertFunctionMatchesEager(cond_with_multiple_values, x)
+
+  def test_imbalanced_conditional_expression_raises_value_error(self):
+    with self.assertRaisesRegex(
+        ValueError, 'must return the same nested structure in both branches'):
+      self.function(side_effect_only_ifexp_with_imbalanced_structure)(
+          tf.constant([1.0]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #99162

## Summary
- improve the AutoGraph error for conditional expressions whose two branches return different nested structures
- raise a user-facing `ValueError` instead of surfacing an internal assertion from `tf.cond`
- add a regression test covering the `tf.size(x) > 0` conditional-expression pattern from the issue report

## Testing
- python -m py_compile tensorflow/python/autograph/operators/conditional_expressions.py tensorflow/python/autograph/tests/basic_ifexp_test.py
