### PR TITLE
Fix XLA compilation failure for tf.random.shuffle (comparison type SIGNED vs TOTALORDER)

### DIFF
--- a/third_party/xla/third_party/stablehlo/temporary.patch
+++ b/third_party/xla/third_party/stablehlo/temporary.patch
@@ -78,7 +78,25 @@ diff --ruN a/stablehlo/stablehlo/integrations/python/StablehloModule.cpp b/stabl
 +        }
 +        return types;
 +      });
- 
+
    //
    // Attributes.
 
+diff --ruN a/stablehlo/stablehlo/dialect/StablehloOps.cpp b/stablehlo/stablehlo/dialect/StablehloOps.cpp
+--- stablehlo/stablehlo/dialect/StablehloOps.cpp
++++ stablehlo/stablehlo/dialect/StablehloOps.cpp
+@@ -4086,12 +4086,8 @@
+   // Use TOTALORDER comparison type instead of the default comparison if the
+   // element type is of type float.
+   std::optional<StringRef> compareType = std::nullopt;
+-  for (const auto& elementType : elementTypes) {
+-    if (isa<FloatType>(elementType)) {
+-      compareType.emplace("TOTALORDER");
+-      break;
+-    }
+-  }
++  if (!elementTypes.empty() && isa<FloatType>(elementTypes[0]))
++    compareType.emplace("TOTALORDER");
+   buildSortComparisonBody(elementTypes, direction, compareType,
+                           &sortOp.getComparator(), rewriter);
+   return sortOp;

--- a/third_party/xla/xla/mlir_hlo/mhlo/IR/hlo_ops.cc
+++ b/third_party/xla/xla/mlir_hlo/mhlo/IR/hlo_ops.cc
@@ -7755,13 +7755,12 @@ SortOp createSortOp(PatternRewriter* rewriter, const Location& loc,
       mhlo::SortOp::create(*rewriter, loc, operands, dimension, isStable);
 
   // Use TOTALORDER comparison type instead of the default comparison if the
-  // element type is of type float.
+  // sort key (first element type) is a float. The comparison is performed on
+  // the first element type only (block arguments 0 and 1), so we must only
+  // examine the first element type.
   std::optional<StringRef> compareType = std::nullopt;
-  for (auto const& elementType : elementTypes)
-    if (isa<FloatType>(elementType)) {
-      compareType.emplace("TOTALORDER");
-      break;
-    }
+  if (!elementTypes.empty() && isa<FloatType>(elementTypes[0]))
+    compareType.emplace("TOTALORDER");
   buildSortComparisonBody(elementTypes, direction, compareType,
                           &sortOp.getComparator(), rewriter);
   return sortOp;


### PR DESCRIPTION
When `tf.random.shuffle` is compiled with `jit_compile=True` on a float tensor, it internally sorts using `[i32 keys, f32 values]`. The `createSortOp` helper was scanning all element types for floats to decide on `TOTALORDER`, but the sort comparator only ever compares the first element type (the i32 keys). This caused XLA to reject the generated comparison op with "Expected comparison type SIGNED, actual: TOTALORDER".

The fix narrows the float check to only the first element type (the sort key), so integer keys correctly fall back to the default SIGNED comparison. Both `mhlo::createSortOp` and the external `stablehlo::createSortOp` (via patch) are updated.