### PR TITLE
Fix int16x8 quantization for SQRT op in TFLite

### DIFF
--- a/tensorflow/compiler/mlir/lite/tools/optimize/operator_property.cc
+++ b/tensorflow/compiler/mlir/lite/tools/optimize/operator_property.cc
@@ -85,6 +85,11 @@ OperatorProperty GetOperatorProperty(OpVariant op_variant, int number_of_bits) {
       property.outputs = {{0, tensor_property_default}};
       property.version = 2;
       break;
+    case BuiltinOperator_SQRT:
+      property.inputs = {{0, tensor_property_default}};
+      property.outputs = {{0, tensor_property_default}};
+      property.version = 2;
+      break;
     case BuiltinOperator_ADD:
       property.inputs = {{0, tensor_property_default},
                          {1, tensor_property_default}};


### PR DESCRIPTION
`BuiltinOperator_SQRT` was missing from the operator property switch in `operator_property.cc`, so it fell through to the default case which marks ops as non-quantizable. This caused the quantizer to wrap SQRT with Dequantize/Quantize ops instead of keeping it in the int16 path, as reported in #115046.

The kernel already handles int16 quantized SQRT (`SqrtEvalQuantized<int16_t>` in `elementwise.cc`), and the versioning infra already returns version 2 for int16 inputs. So this just registers it the same way `RSQRT` is already registered.