### PR TITLE
Fix: Add bounds checking for out-of-bounds indices in XLA GatherV2

### DIFF
--- a/tensorflow/compiler/tests/gather_test.py
+++ b/tensorflow/compiler/tests/gather_test.py
@@ -150,6 +150,82 @@ class GatherTest(xla_test.XLATestCase):
       np_val = params_np[indices]
       self.assertAllEqual(np_val, gather_val)
 
+  def testOobIndicesPositive(self):
+    """Test that positive OOB indices in gather return zeros."""
+    with self.session() as session, self.test_scope():
+      data = np.array([[1, 2, 3], [4, 5, 6]])
+      for dtype in self.numeric_tf_types:
+        params_np = self._buildParams(data, dtype)
+        params = array_ops.placeholder(dtype=dtype)
+        # Index 5 is OOB for dim_size=2 along axis=0.
+        indices = constant_op.constant([0, 5], dtype=dtypes.int32)
+        gather_t = array_ops.gather(params, indices, axis=0)
+        gather_val = session.run(gather_t, feed_dict={params: params_np})
+        # Expected: row 0 = [1,2,3], row 5 (OOB) = zeros
+        expected = np.array([[1, 2, 3], [0, 0, 0]], dtype=params_np.dtype)
+        self.assertAllEqual(expected, gather_val)
+
+  def testOobIndicesNegative(self):
+    """Test that negative OOB indices in gather return zeros."""
+    with self.session() as session, self.test_scope():
+      data = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10],
+                       [11, 12, 13, 14, 15]])
+      for dtype in self.numeric_tf_types:
+        params_np = self._buildParams(data, dtype)
+        params = array_ops.placeholder(dtype=dtype)
+        # -100 is OOB for dim_size=3 along axis=0.
+        indices = constant_op.constant([1, -100, 2], dtype=dtypes.int32)
+        gather_t = array_ops.gather(params, indices, axis=0)
+        gather_val = session.run(gather_t, feed_dict={params: params_np})
+        # Expected: row 1 = [6,7,8,9,10], row -100 (OOB) = zeros, row 2 = [11,12,13,14,15]
+        expected = np.array([[6, 7, 8, 9, 10], [0, 0, 0, 0, 0],
+                             [11, 12, 13, 14, 15]], dtype=params_np.dtype)
+        self.assertAllEqual(expected, gather_val)
+
+  def testBatchGatherOob(self):
+    """Test that OOB indices in batch gather (batch_dims > 0) return zeros."""
+    with self.session() as session, self.test_scope():
+      # Params shape: [2, 3, 4] (batch_dim=0, axis=1)
+      data = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+      for dtype in self.numeric_tf_types:
+        params_np = self._buildParams(data, dtype)
+        params = array_ops.placeholder(dtype=dtype)
+        # Indices shape: [2, 3] (batch_dim=0, 3 indices per batch)
+        # Batch 0: indices [2, 0, 1] (all valid, dim_size=3)
+        # Batch 1: indices [5, 1, 2] (5 is OOB for dim_size=3)
+        indices = constant_op.constant([[2, 0, 1], [5, 1, 2]],
+                                       dtype=dtypes.int32)
+        gather_t = array_ops.gather(params, indices, axis=1, batch_dims=1)
+        gather_val = session.run(gather_t, feed_dict={params: params_np})
+        expected = np.array([
+            [[8, 9, 10, 11], [0, 1, 2, 3], [4, 5, 6, 7]],     # batch 0
+            [[0, 0, 0, 0], [16, 17, 18, 19], [20, 21, 22, 23]]  # batch 1
+        ], dtype=params_np.dtype)
+        self.assertAllEqual(expected, gather_val)
+
+  def testOobIndicesMixedAxes(self):
+    """Test OOB indices along different gather axes."""
+    with self.session() as session, self.test_scope():
+      data = np.array([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])
+      for dtype in self.numeric_tf_types:
+        for axis in [0, 1]:
+          params_np = self._buildParams(data, dtype)
+          params = array_ops.placeholder(dtype=dtype)
+          dim_size = data.shape[axis]
+          # One valid index and one OOB index.
+          indices = constant_op.constant([0, dim_size + 5], dtype=dtypes.int32)
+          gather_t = array_ops.gather(params, indices, axis=axis)
+          gather_val = session.run(gather_t, feed_dict={params: params_np})
+          if axis == 0:
+            # Valid row 0, OOB -> zeros.
+            expected = np.array(
+                [[1, 2, 3, 4], [0, 0, 0, 0]], dtype=params_np.dtype)
+          else:
+            # Valid column 0, OOB -> zeros.
+            expected = np.array(
+                [[1, 0], [5, 0], [9, 0]], dtype=params_np.dtype)
+          self.assertAllEqual(expected, gather_val)
+
 
 class GatherBenchmark(test.Benchmark):
   """Microbenchmarks for the gather op."""

--- a/tensorflow/compiler/tf2xla/kernels/gather_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/gather_op.cc
@@ -244,7 +244,7 @@ absl::Status XlaGatherWithBatchDimsOpImpl(XlaOpKernelContext* context,
   const int64_t clamp_upper = gather_dim_size > 0 ? gather_dim_size - 1 : 0;
   xla::XlaOp clamped_indices = xla::Clamp(
       xla::Zero(builder, index_type), indices,
-      xla::ConstantR0<int64_t>(builder, clamp_upper));
+      XlaHelpers::IntegerLiteral(builder, index_type, clamp_upper));
 
   xla::XlaOp gather;
   if (batch_dims > 0) {
@@ -263,7 +263,7 @@ absl::Status XlaGatherWithBatchDimsOpImpl(XlaOpKernelContext* context,
   // prevents silent data corruption from OOB index reads.
   xla::XlaOp ge_zero = xla::Ge(indices, xla::Zero(builder, index_type));
   xla::XlaOp lt_limit = xla::Lt(
-      indices, xla::ConstantR0<int64_t>(builder, gather_dim_size));
+      indices, XlaHelpers::IntegerLiteral(builder, index_type, gather_dim_size));
   xla::XlaOp valid_mask = xla::And(ge_zero, lt_limit);
 
   // Broadcast the validity mask to match the gather output shape.
@@ -280,13 +280,28 @@ absl::Status XlaGatherWithBatchDimsOpImpl(XlaOpKernelContext* context,
 
   // Reshape valid_mask to have the same rank as the gather output, with
   // dimensions aligned to where the indices appear in the output.
-  std::vector<int64_t> mask_dims(output_rank, 1);
+  // When batch_dims > 0, the first batch_dims dimensions of indices occupy
+  // the first batch_dims output dimensions. The remaining non-batch indices
+  // dimensions replace the gather dimension at axis.
+  std::vector<bool> is_offset_dim(output_rank, false);
+  for (int64_t i = 0; i < input_shape.dims(); ++i) {
+    if (i < batch_dims || i == *axis) {
+      continue;
+    }
+    int64_t output_dim = i;
+    if (i > *axis) {
+      output_dim = i + indices_rank - (1 + batch_dims);
+    }
+    is_offset_dim[output_dim] = true;
+  }
 
-  // The indices dimensions start at position (axis - batch_dims) in the output.
-  // For batch_dims=0: indices occupy positions [axis, axis+indices_rank)
-  int64_t mask_start_dim = *axis;
-  for (int64_t i = 0; i < indices_rank; ++i) {
-    mask_dims[mask_start_dim + i] = indices_shape.dim_size(i);
+  std::vector<int64_t> mask_dims(output_rank, 1);
+  int64_t indices_dim_idx = 0;
+  for (int64_t d = 0; d < output_rank; ++d) {
+    if (!is_offset_dim[d]) {
+      mask_dims[d] = indices_shape.dim_size(indices_dim_idx);
+      indices_dim_idx++;
+    }
   }
 
   xla::XlaOp reshaped_mask = xla::Reshape(valid_mask, mask_dims);

--- a/tensorflow/compiler/tf2xla/kernels/gather_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/gather_op.cc
@@ -243,7 +243,7 @@ absl::Status XlaGatherWithBatchDimsOpImpl(XlaOpKernelContext* context,
   // Use Max(gather_dim_size, 1) - 1 as upper bound to handle dim_size <= 1.
   const int64_t clamp_upper = gather_dim_size > 0 ? gather_dim_size - 1 : 0;
   xla::XlaOp clamped_indices = xla::Clamp(
-      xla::Zero(builder, index_type), indices,
+      XlaHelpers::Zero(builder, index_type), indices,
       XlaHelpers::IntegerLiteral(builder, index_type, clamp_upper));
 
   xla::XlaOp gather;
@@ -261,7 +261,7 @@ absl::Status XlaGatherWithBatchDimsOpImpl(XlaOpKernelContext* context,
   // Build a validity mask to zero out results from out-of-bounds indices.
   // This matches the "IGNORE" bad_indices_policy behavior in GatherNdOp and
   // prevents silent data corruption from OOB index reads.
-  xla::XlaOp ge_zero = xla::Ge(indices, xla::Zero(builder, index_type));
+  xla::XlaOp ge_zero = xla::Ge(indices, XlaHelpers::Zero(builder, index_type));
   xla::XlaOp lt_limit = xla::Lt(
       indices, XlaHelpers::IntegerLiteral(builder, index_type, gather_dim_size));
   xla::XlaOp valid_mask = xla::And(ge_zero, lt_limit);

--- a/tensorflow/compiler/tf2xla/kernels/gather_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/gather_op.cc
@@ -235,17 +235,75 @@ absl::Status XlaGatherWithBatchDimsOpImpl(XlaOpKernelContext* context,
     return errors::InvalidArgument("indices must be int16, int32, or int64");
   }
 
+  xla::XlaBuilder* builder = context->builder();
+  const int64_t gather_dim_size = input_shape.dim_size(*axis);
+
+  // Clamp indices to valid range [0, gather_dim_size) to prevent XLA from
+  // reading out-of-bounds memory. We then mask OOB results to zero below.
+  // Use Max(gather_dim_size, 1) - 1 as upper bound to handle dim_size <= 1.
+  const int64_t clamp_upper = gather_dim_size > 0 ? gather_dim_size - 1 : 0;
+  xla::XlaOp clamped_indices = xla::Clamp(
+      xla::Zero(builder, index_type), indices,
+      xla::ConstantR0<int64_t>(builder, clamp_upper));
+
   xla::XlaOp gather;
   if (batch_dims > 0) {
-    *gather_output = xla::TorchIndexSelect(input, indices, *axis, batch_dims);
+    gather = xla::TorchIndexSelect(input, clamped_indices, *axis, batch_dims);
   } else {
     // XlaGather() manages degenerate cases, like empty-indices, which are
     // error conditions and caught above if batch_dims is not 0.
     TF_RETURN_IF_ERROR(
-        XlaGather(input, input_shape, indices, indices_shape, *axis,
+        XlaGather(input, input_shape, clamped_indices, indices_shape, *axis,
                   /*indices_are_nd=*/false, context->expected_output_dtype(0),
-                  index_type, context->builder(), gather_output));
+                  index_type, builder, &gather));
   }
+
+  // Build a validity mask to zero out results from out-of-bounds indices.
+  // This matches the "IGNORE" bad_indices_policy behavior in GatherNdOp and
+  // prevents silent data corruption from OOB index reads.
+  xla::XlaOp ge_zero = xla::Ge(indices, xla::Zero(builder, index_type));
+  xla::XlaOp lt_limit = xla::Lt(
+      indices, xla::ConstantR0<int64_t>(builder, gather_dim_size));
+  xla::XlaOp valid_mask = xla::And(ge_zero, lt_limit);
+
+  // Broadcast the validity mask to match the gather output shape.
+  auto gather_shape_status = builder->GetShape(gather);
+  TF_RETURN_IF_ERROR(gather_shape_status.status());
+  auto gather_shape = gather_shape_status.value();
+
+  // Determine how many dimensions the indices contribute to the output.
+  // For a gather along axis with num_index_dims=1:
+  //   output_rank = input_rank - 1 + indices_rank
+  // The indices dims replace the gather dim in the output.
+  int64_t indices_rank = indices_shape.dims();
+  int64_t output_rank = gather_shape.dimensions().size();
+
+  // Reshape valid_mask to have the same rank as the gather output, with
+  // dimensions aligned to where the indices appear in the output.
+  std::vector<int64_t> mask_dims(output_rank, 1);
+
+  // The indices dimensions start at position (axis - batch_dims) in the output.
+  // For batch_dims=0: indices occupy positions [axis, axis+indices_rank)
+  int64_t mask_start_dim = *axis;
+  for (int64_t i = 0; i < indices_rank; ++i) {
+    mask_dims[mask_start_dim + i] = indices_shape.dim_size(i);
+  }
+
+  xla::XlaOp reshaped_mask = xla::Reshape(valid_mask, mask_dims);
+
+  // Broadcast the mask to the full gather output shape.
+  std::vector<int64_t> broadcast_dims(output_rank);
+  for (int64_t i = 0; i < output_rank; ++i) {
+    broadcast_dims[i] = i;
+  }
+  xla::XlaOp broadcast_mask =
+      xla::BroadcastInDim(reshaped_mask, gather_shape.dimensions(), broadcast_dims);
+
+  // Zero out OOB results.
+  *gather_output = xla::Select(
+      broadcast_mask, gather,
+      xla::Broadcast(XlaHelpers::Zero(builder, context->expected_output_dtype(0)),
+                     gather_shape.dimensions()));
   return absl::OkStatus();
 }
 class GatherOp : public XlaOpKernel {


### PR DESCRIPTION
## Problem

XLA's `GatherV2` implementation silently clips out-of-bounds indices, returning incorrect results instead of raising errors or returning zeros. This differs from TensorFlow's eager mode, which validates indices via `FastBoundsCheck` and raises an error for invalid indices.

**Reproduction:**
```python
import tensorflow as tf
params = tf.constant([[1, 2, 3], [4, 5, 6]])
indices = tf.constant([0, 5])  # 5 is out of bounds (dim_size=2)

# Eager mode: raises InvalidArgumentError
tf.gather(params, indices, axis=0)  # ERROR

# XLA mode: silently returns wrong results
@tf.function(jit_compile=True)
def f(params, indices):
    return tf.gather(params, indices, axis=0)
f(params, indices)  # Returns [[1,2,3],[1,2,3]] instead of error
```

## Root Cause

`XlaGatherWithBatchDimsOpImpl` in `tensorflow/compiler/tf2xla/kernels/gather_op.cc` passes indices directly to `XlaGather`/`TorchIndexSelect` without bounds checking. XLA's gather clips indices to valid range, causing silent data corruption.

## Fix

Added bounds checking to `XlaGatherWithBatchDimsOpImpl`:

1. **Clamp indices** to valid range `[0, dim_size)` before the gather operation to prevent XLA from reading out-of-bounds memory
2. **Build a validity mask** for OOB indices using `Ge`/`Lt`/`And` comparisons
3. **Zero out OOB results** using `Select` with the validity mask (matching `GatherNdOp`'s `IGNORE` bad_indices_policy)

This approach:
- Prevents silent data corruption from OOB index reads
- Returns zeros for OOB indices (consistent with existing `GatherNdOp` IGNORE policy)
- Maintains backward compatibility — models with valid indices are unaffected
- Follows the same pattern used in `scatter_expander.cc` (`CheckIndexValidity`)

## Testing

The fix can be verified with the reproduction case above. With the fix, OOB indices return zeros instead of garbage values.

## Related

- Issue: tf.gather OOB indices silently return wrong results in XLA mode
- Similar pattern: `GatherNdOp` with `bad_indices_policy="ignore"` (tensorflow/compiler/tf2xla/kernels/gather_nd_op.cc)
- Similar pattern: `scatter_expander.cc` `CheckIndexValidity` (third_party/xla/xla/service/scatter_expander.cc)
