### PR TITLE
Docs/clarify where gradienttape unconnected

### DIFF
--- a/tensorflow/python/eager/backprop.py
+++ b/tensorflow/python/eager/backprop.py
@@ -976,6 +976,11 @@ class GradientTape:
     >>> g.gradient(y, x)
     <tf.RaggedTensor [[2.0, 4.0], [6.0]]>
 
+    Operations must connect `target` and `sources` within the tape scope. If
+    `target` is built after exiting the context (for example, reducing an
+    intermediate tensor outside the tape), the gradient can be unconnected and
+    `gradient` returns `None` by default.
+
     Args:
       target: a list or nested structure of Tensors or Variables or
         CompositeTensors to be differentiated.

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4589,6 +4589,11 @@ def where_v2(condition, x=None, y=None, name=None):
   because the gradient calculation for `tf.where` combines the two branches, for
   performance reasons.
 
+  When using `tf.where` with `tf.GradientTape`, ensure the target passed to
+  `tape.gradient` is built inside the tape context. For example, if `y` is
+  created in the tape scope but `tf.reduce_sum(y)` is created afterward, then
+  the default gradient result is `None` because that target is unconnected.
+
   A workaround is to use an inner `tf.where` to ensure the function has
   no asymptote, and to avoid computing a value whose gradient is `NaN` by
   replacing dangerous inputs with safe inputs.

--- a/tensorflow/python/ops/array_ops.py
+++ b/tensorflow/python/ops/array_ops.py
@@ -4593,6 +4593,8 @@ def where_v2(condition, x=None, y=None, name=None):
   `tape.gradient` is built inside the tape context. For example, if `y` is
   created in the tape scope but `tf.reduce_sum(y)` is created afterward, then
   the default gradient result is `None` because that target is unconnected.
+  For piecewise semantics where branch behavior should drive gradients, use
+  `tf.cond`, arithmetic masking, or a custom gradient.
 
   A workaround is to use an inner `tf.where` to ensure the function has
   no asymptote, and to avoid computing a value whose gradient is `NaN` by


### PR DESCRIPTION
I was having a similar issue as in #115116 so I figured documenting it might be helpful. For me the issue was that I was building the target outside GradientTape which returned None even though tf.where looked fine. Looking at the thread in the linked issue, using tf.cond/masking/custom gradient for piecewise intent seems useful to document as well. 