### PR TITLE
Validate row_splits bounds in RaggedTensorToTensor to prevent OOB read

### DIFF
--- a/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc
+++ b/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc
@@ -414,6 +414,13 @@ class RaggedTensorToTensorBaseOp : public OpKernel {
         new_output_index.clear();
       }
 
+      // Validate that row_splits do not reference beyond the values tensor.
+      OP_REQUIRES(context,
+                  static_cast<INDEX_TYPE>(output_index.size()) <= nvals,
+                  errors::InvalidArgument(
+                      "Row partition size (", output_index.size(),
+                      ") exceeds the number of values (", nvals, ")"));
+
       SetOutput(context, ragged_rank_, output_index, output_tensor);
     }
   }

--- a/tensorflow/python/ops/ragged/ragged_to_tensor_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_to_tensor_op_test.py
@@ -729,6 +729,22 @@ class RaggedTensorToTensorOpTest(test_util.TensorFlowTestCase,
     result = rt.to_tensor(shape=[2, constant_op.constant(2)])
     self.assertAllEqual(result, [[1, 2], [4, 0]])
 
+  def test_row_splits_out_of_bounds(self):
+    from tensorflow.python.ops import gen_ragged_conversion_ops
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError,
+        "Row partition size.*exceeds the number of values",
+    ):
+      self.evaluate(
+          gen_ragged_conversion_ops.ragged_tensor_to_tensor(
+              shape=[1, 100],
+              values=[42.0],
+              default_value=0.0,
+              row_partition_tensors=[[0, 100]],
+              row_partition_types=["ROW_SPLITS"],
+          )
+      )
+
 
 class RaggedToDenseBenchmark(googletest.Benchmark):
 


### PR DESCRIPTION
## Description

`RaggedTensorToTensor` does not check that the range implied by `row_splits` fits within the `values` tensor. When `row_splits` specifies more elements than `values` actually has, `SetOutput()` reads past the end of the values buffer, returning uninitialized heap memory in the output tensor.

This patch adds an `OP_REQUIRES` check after computing the output index to verify that the partition size does not exceed `values.dim_size(0)`.

`RaggedTensorToSparse` already validates this same condition and returns `InvalidArgumentError`. This change makes `RaggedTensorToTensor` consistent with that behavior.

Related: CVE-2021-29608 (GHSA-rgvq-pcvf-hx75) — that fix addressed empty partitions and `DCHECK` conversion, but did not add this bounds check.

## Reproducer

```python
import tensorflow as tf
import numpy as np

result = tf.raw_ops.RaggedTensorToTensor(
    shape=tf.constant([1, 100], dtype=tf.int64),
    values=tf.constant([42.0]),
    default_value=tf.constant(0.0),
    row_partition_tensors=[tf.constant([0, 100], dtype=tf.int64)],
    row_partition_types=["ROW_SPLITS"])

# Without fix: returns 99 elements of leaked heap data
# With fix: raises InvalidArgumentError
```