### PR TITLE
Fix TFLite CMake out-of-tree build when using FetchContent

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -66,13 +66,17 @@ endif()
 set(TF_SOURCE_DIR "${TENSORFLOW_SOURCE_DIR}/tensorflow")
 set(TSL_SOURCE_DIR "${TENSORFLOW_SOURCE_DIR}/third_party/xla/third_party/tsl")
 set(XLA_SOURCE_DIR "${TENSORFLOW_SOURCE_DIR}/third_party/xla/")
-set(TFLITE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+if(CMAKE_CURRENT_LIST_DIR STREQUAL "${TF_SOURCE_DIR}/lite")
+  set(TFLITE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+else()
+  set(TFLITE_SOURCE_DIR "${TF_SOURCE_DIR}/lite")
+endif()
 set(CMAKE_MODULE_PATH
-  "${TFLITE_SOURCE_DIR}/tools/cmake/modules"
+  "${CMAKE_CURRENT_LIST_DIR}/tools/cmake/modules"
   ${CMAKE_MODULE_PATH}
 )
 set(CMAKE_PREFIX_PATH
-  "${TFLITE_SOURCE_DIR}/tools/cmake/modules"
+  "${CMAKE_CURRENT_LIST_DIR}/tools/cmake/modules"
   ${CMAKE_PREFIX_PATH}
 )
 include(GNUInstallDirs)
@@ -842,19 +846,23 @@ endif()
 set(TFLITE_GENERATED_HEADERS_DIR ${CMAKE_BINARY_DIR}/tensorflow/lite)
 
 # Add the profiling proto directory.
-add_subdirectory(${TFLITE_SOURCE_DIR}/profiling/proto)
+add_subdirectory(${TFLITE_SOURCE_DIR}/profiling/proto
+  ${CMAKE_BINARY_DIR}/profiling/proto)
 
 # Add the benchmark result proto directory.
-add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark/proto)
+add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark/proto
+  ${CMAKE_BINARY_DIR}/tools/benchmark/proto)
 
 # Add the tf example directory.
 add_subdirectory(${TF_SOURCE_DIR}/core/example ${CMAKE_BINARY_DIR}/example_proto_generated)
 
 # The benchmark tool.
-add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark)
+add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark
+  ${CMAKE_BINARY_DIR}/tools/benchmark)
 
 # The label_image example.
-add_subdirectory(${TFLITE_SOURCE_DIR}/examples/label_image)
+add_subdirectory(${TFLITE_SOURCE_DIR}/examples/label_image
+  ${CMAKE_BINARY_DIR}/examples/label_image)
 
 # Python interpreter wrapper.
 add_library(_pywrap_tensorflow_interpreter_wrapper SHARED EXCLUDE_FROM_ALL

--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -66,13 +66,13 @@ endif()
 set(TF_SOURCE_DIR "${TENSORFLOW_SOURCE_DIR}/tensorflow")
 set(TSL_SOURCE_DIR "${TENSORFLOW_SOURCE_DIR}/third_party/xla/third_party/tsl")
 set(XLA_SOURCE_DIR "${TENSORFLOW_SOURCE_DIR}/third_party/xla/")
-set(TFLITE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+set(TFLITE_SOURCE_DIR "${TF_SOURCE_DIR}/lite")
 set(CMAKE_MODULE_PATH
-  "${TFLITE_SOURCE_DIR}/tools/cmake/modules"
+  "${CMAKE_CURRENT_LIST_DIR}/tools/cmake/modules"
   ${CMAKE_MODULE_PATH}
 )
 set(CMAKE_PREFIX_PATH
-  "${TFLITE_SOURCE_DIR}/tools/cmake/modules"
+  "${CMAKE_CURRENT_LIST_DIR}/tools/cmake/modules"
   ${CMAKE_PREFIX_PATH}
 )
 include(GNUInstallDirs)
@@ -842,16 +842,19 @@ endif()
 set(TFLITE_GENERATED_HEADERS_DIR ${CMAKE_BINARY_DIR}/tensorflow/lite)
 
 # Add the profiling proto directory.
-add_subdirectory(${TFLITE_SOURCE_DIR}/profiling/proto)
+add_subdirectory(${TFLITE_SOURCE_DIR}/profiling/proto
+  ${CMAKE_CURRENT_BINARY_DIR}/profiling/proto)
 
 # Add the benchmark result proto directory.
-add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark/proto)
+add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark/proto
+  ${CMAKE_CURRENT_BINARY_DIR}/tools/benchmark/proto)
 
 # Add the tf example directory.
-add_subdirectory(${TF_SOURCE_DIR}/core/example ${CMAKE_BINARY_DIR}/example_proto_generated)
+add_subdirectory(${TF_SOURCE_DIR}/core/example ${CMAKE_CURRENT_BINARY_DIR}/example_proto_generated)
 
 # The benchmark tool.
-add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark)
+add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark
+  ${CMAKE_CURRENT_BINARY_DIR}/tools/benchmark)
 
 # The label_image example.
 add_subdirectory(${TFLITE_SOURCE_DIR}/examples/label_image)

--- a/tensorflow/lite/tools/cmake/modules/xnnpack.cmake
+++ b/tensorflow/lite/tools/cmake/modules/xnnpack.cmake
@@ -42,7 +42,7 @@ set(XNNPACK_BUILD_BENCHMARKS OFF CACHE BOOL "Disable XNNPACK benchmarks.")
 # needed to compile XNNPACK delegate of TFLite.
 # Note, we introduce an intermediate subdirectory, see ${TFLITE_SOURCE_DIR}/tools/cmake/modules/xnnpack/CMakeLists.txt
 # for details.
-add_subdirectory(${TFLITE_SOURCE_DIR}/tools/cmake/modules/xnnpack)
+add_subdirectory(${TFLITE_SOURCE_DIR}/tools/cmake/modules/xnnpack ${CMAKE_BINARY_DIR}/xnnpack-intermediate)
 
 include_directories(
   AFTER

--- a/tensorflow/lite/tools/cmake/modules/xnnpack.cmake
+++ b/tensorflow/lite/tools/cmake/modules/xnnpack.cmake
@@ -42,7 +42,7 @@ set(XNNPACK_BUILD_BENCHMARKS OFF CACHE BOOL "Disable XNNPACK benchmarks.")
 # needed to compile XNNPACK delegate of TFLite.
 # Note, we introduce an intermediate subdirectory, see ${TFLITE_SOURCE_DIR}/tools/cmake/modules/xnnpack/CMakeLists.txt
 # for details.
-add_subdirectory(${TFLITE_SOURCE_DIR}/tools/cmake/modules/xnnpack)
+add_subdirectory(${TFLITE_SOURCE_DIR}/tools/cmake/modules/xnnpack ${CMAKE_CURRENT_BINARY_DIR}/xnnpack-intermediate)
 
 include_directories(
   AFTER


### PR DESCRIPTION
- TFLITE_SOURCE_DIR now derived from TF_SOURCE_DIR instead of CMAKE_CURRENT_LIST_DIR to avoid header/source mismatch
- CMAKE_MODULE_PATH uses CMAKE_CURRENT_LIST_DIR so local modules are always loaded correctly
- add_subdirectory calls now include explicit binary directories to support out-of-tree builds