### PR TITLE
Use allow_pickle=False in saved_model_cli input loading

### DIFF
--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -959,7 +959,7 @@ def load_inputs_from_input_arg_string(inputs_str, input_exprs_str,
   input_examples = preprocess_input_examples_arg_string(input_examples_str)
 
   for input_tensor_key, (filename, variable_name) in inputs.items():
-    data = np.load(file_io.FileIO(filename, mode='rb'), allow_pickle=True)  # pylint: disable=unexpected-keyword-arg
+    data = np.load(file_io.FileIO(filename, mode='rb'), allow_pickle=False)  # pylint: disable=unexpected-keyword-arg
 
     # When a variable_name key is specified for the input file
     if variable_name:


### PR DESCRIPTION
## Description

`saved_model_cli` loads user-provided .npy files with `np.load(allow_pickle=True)`. NumPy changed the default to `False` in 1.16.3 to prevent arbitrary code execution via crafted pickle payloads (CVE-2019-6446). The current code was updated in 2019 to explicitly override that default for backward compatibility, but normal tensor inputs (float32, int64, string, etc.) do not require pickle at all.

This patch switches to `allow_pickle=False`. Object arrays are not valid SavedModel inputs anyway — they would fail when fed to TensorFlow ops — so this does not break any real use case.

The same file already uses `ast.literal_eval` for `--input_exprs` to prevent code execution (fixed for CVE-2021-41228). This change makes `--inputs` consistent with that approach.

## Reproducer

```python
import numpy as np

class Payload:
    def __reduce__(self):
        return (exec, ("print('arbitrary code')",))

np.save('/tmp/bad.npy', np.array([Payload()], dtype=object), allow_pickle=True)

# Current behavior: executes Payload.__reduce__ on load
# After fix: raises ValueError ("Object arrays cannot be loaded")
```