### PR TITLE
Fix TypeError when sys.path contains PosixPath objects

### DIFF
--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -98,7 +98,7 @@ from tensorflow.python.lib.io import file_io as _fi
 _site_packages_dirs = []
 if _site.ENABLE_USER_SITE and _site.USER_SITE is not None:
   _site_packages_dirs += [_site.USER_SITE]
-_site_packages_dirs += [p for p in _sys.path if "site-packages" in p]
+_site_packages_dirs += [str(p) for p in _sys.path if "site-packages" in str(p)]
 if "getsitepackages" in dir(_site):
   _site_packages_dirs += _site.getsitepackages()
 

--- a/tensorflow/api_template_v1.__init__.py
+++ b/tensorflow/api_template_v1.__init__.py
@@ -143,7 +143,7 @@ from tensorflow.python.lib.io import file_io as _fi
 # Get sitepackages directories for the python installation.
 _site_packages_dirs = []
 _site_packages_dirs += [] if _site.USER_SITE is None else [_site.USER_SITE]
-_site_packages_dirs += [p for p in _sys.path if "site-packages" in p]
+_site_packages_dirs += [str(p) for p in _sys.path if "site-packages" in str(p)]
 if "getsitepackages" in dir(_site):
   _site_packages_dirs += _site.getsitepackages()
 


### PR DESCRIPTION
## Description

When libraries like Streamlit inject `PosixPath` objects into `sys.path`, TensorFlow crashes at import time with:

```
TypeError: argument of type 'PosixPath' is not iterable
```

This happens because the `in` operator is used to check for "site-packages" in path entries, but `PosixPath` objects don't support the `in` substring check the way strings do.

## Fix

Cast each `sys.path` element to `str()` before the substring check in both `api_template.__init__.py` and `api_template_v1.__init__.py`:

```python
# Before (crashes with PosixPath):
_site_packages_dirs += [p for p in _sys.path if "site-packages" in p]

# After (works with any path-like object):
_site_packages_dirs += [str(p) for p in _sys.path if "site-packages" in str(p)]
```

This is a no-op for normal string paths and correctly converts `PosixPath` objects to their string representation.

## Files Changed

- `tensorflow/api_template.__init__.py` -- Line 101
- - `tensorflow/api_template_v1.__init__.py` -- Line 146
Fixes #90353