### PR TITLE
Fix tf.math.cumulative_logsumexp NaN for +inf inputs

### DIFF
--- a/tensorflow/core/kernels/scan_ops.h
+++ b/tensorflow/core/kernels/scan_ops.h
@@ -60,7 +60,12 @@ struct LogSumExp {
         Eigen::internal::scalar_cmp_op<T, T, Eigen::internal::cmp_LT>();
 
     auto logsumexp = add(log1p(exp(sub(mi, ma))), ma);
-    return cmp_lt(ma, Eigen::NumTraits<T>::lowest()) ? ma : logsumexp;
+    // Return ma directly if it is -inf (all inputs -inf) or +inf
+    // (avoids inf - inf = NaN in the subtraction above).
+    return (cmp_lt(ma, Eigen::NumTraits<T>::lowest()) ||
+            cmp_lt(Eigen::NumTraits<T>::highest(), ma))
+               ? ma
+               : logsumexp;
   }
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T packetOp(const T& a,
                                                    const T& b) const {
@@ -70,12 +75,15 @@ struct LogSumExp {
     using Eigen::internal::pcmp_lt;
     using Eigen::internal::pexp;
     using Eigen::internal::plog1p;
+    using Eigen::internal::por;
     using Eigen::internal::pset1;
     using Eigen::internal::psub;
 
     auto logsumexp = padd(plog1p(pexp(psub(mi, ma))), ma);
-    return pselect(pcmp_lt(ma, pset1(Eigen::NumTraits<T>::lowest())), ma,
-                   logsumexp);
+    // Select ma directly if it is -inf or +inf.
+    auto is_inf = por(pcmp_lt(ma, pset1(Eigen::NumTraits<T>::lowest())),
+                      pcmp_lt(pset1(Eigen::NumTraits<T>::highest()), ma));
+    return pselect(is_inf, ma, logsumexp);
   }
 };
 

--- a/tensorflow/python/kernel_tests/math_ops/cumulative_logsumexp_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cumulative_logsumexp_test.py
@@ -116,6 +116,16 @@ class CumulativeLogsumexpTest(test.TestCase):
 
       self.assertAllClose(result_fused, result_map)
 
+  def testPlusInfinity(self):
+    x = [np.inf, np.inf, 1.0, np.inf]
+    for dtype in self.valid_dtypes:
+      for use_gpu in (True, False):
+        with self.cached_session(use_gpu=use_gpu):
+          x_tf = ops.convert_to_tensor(x, dtype=dtype)
+          result = self.evaluate(math_ops.cumulative_logsumexp(x_tf))
+          expected = np.array([np.inf, np.inf, np.inf, np.inf], dtype=x_tf.dtype.as_numpy_dtype)
+          self.assertAllClose(result, expected)
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/kernel_tests/math_ops/cumulative_logsumexp_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cumulative_logsumexp_test.py
@@ -123,7 +123,9 @@ class CumulativeLogsumexpTest(test.TestCase):
         with self.cached_session(use_gpu=use_gpu):
           x_tf = ops.convert_to_tensor(x, dtype=dtype)
           result = self.evaluate(math_ops.cumulative_logsumexp(x_tf))
-          expected = np.array([np.inf, np.inf, np.inf, np.inf], dtype=x_tf.dtype.as_numpy_dtype)
+          expected = np.array(
+              [np.inf, np.inf, np.inf, np.inf],
+              dtype=x_tf.dtype.as_numpy_dtype)
           self.assertAllClose(result, expected)
 
 


### PR DESCRIPTION
## Description

`tf.math.cumulative_logsumexp` produces NaN when the input contains multiple `+inf` values, although the mathematically expected result should remain `+inf`.

## Root Cause

The internal `LogSumExp` reducer computes:
```
log_add_exp(a, b) = log(1 + exp(min(a,b) - max(a,b))) + max(a,b)
```

When both `a` and `b` are `+inf`, `min - max = inf - inf = NaN`, which propagates through the entire computation.

## Fix

Added a `+inf` guard alongside the existing `-inf` guard in both the scalar and SIMD (packet) code paths. When the maximum value is infinite, the reducer returns it directly without computing the subtraction.

### File Changed

- `tensorflow/core/kernels/scan_ops.h`
Fixes #115091