### PR TITLE
Docs: Fix miscellaneous spelling typos across codebase

### DIFF
--- a/tensorflow/core/common_runtime/arg_ret_placement.h
+++ b/tensorflow/core/common_runtime/arg_ret_placement.h
@@ -144,12 +144,12 @@ MemoryType MemoryTypeFromFullTypeId(FullTypeId id);
 // Check that use_host_memory is true iff FT has type_id TFT_SHAPE_TENSOR
 // and logging of a warning if not can be enabled. Returns true if check passes.
 // Note the FT is expected to be the full type information for a tensor, not for
-// the whole ouput of an op, i.e. it should not have an outer TFT_PRODUCT.
+// the whole output of an op, i.e. it should not have an outer TFT_PRODUCT.
 bool LogMemoryTypeMismatch(bool use_host_memory, const FullTypeDef& ft);
 
 // Check that use_host_memory is true iff FT has type_id TFT_SHAPE_TENSOR
 // and raise an error if not. Note the FT is expected to be the full type
-// information for a tensor, not for the whole ouput of an op, i.e. it should
+// information for a tensor, not for the whole output of an op, i.e. it should
 // not have an outer TFT_PRODUCT.
 absl::Status CheckMemoryType(bool use_host_memory, const FullTypeDef& ft);
 

--- a/tensorflow/core/common_runtime/eager/execute_test.cc
+++ b/tensorflow/core/common_runtime/eager/execute_test.cc
@@ -173,7 +173,7 @@ TEST(ExecuteTest, SimpleFunctionInt32BadFullType) {
   EXPECT_TRUE(
       absl::StrContains(status.message(), "TFT_TENSOR has 0 args instead of 1"))
       << "Actual: " << status.message();
-  // Since an error occured before the function ran, retval[0] was never
+  // Since an error occurred before the function ran, retval[0] was never
   // assigned.
   ASSERT_EQ(retvals[0], nullptr);
   ctx->Unref();

--- a/tensorflow/core/common_runtime/next_pluggable_device/plugin_variable.h
+++ b/tensorflow/core/common_runtime/next_pluggable_device/plugin_variable.h
@@ -24,7 +24,7 @@ class Tensor;
 
 // A helper base class that wraps tensorflow::VariableInfo for the convenience
 // of passing between plugin and tensorflow. Similar to `PluginOpKernelContext`,
-// the implementations can accomodate for "Internal build" and "External build",
+// the implementations can accommodate for "Internal build" and "External build",
 // meaning the plugin is built with TensorFlow either together or separately. In
 // repsective build modes, the implementations can either include
 // tensorflow::VariableInfo and use C++ API directly, or include the C structure

--- a/tensorflow/core/kernels/sparse/sparse_mat_mul_op.cc
+++ b/tensorflow/core/kernels/sparse/sparse_mat_mul_op.cc
@@ -63,7 +63,7 @@ void SwapDimSizes(const int dim_a, const int dim_b, TensorShape* shape) {
 
 // Concatenates 'inputs' into a single tensor along the zeroth dimension.
 // Requires that all elements of 'inputs' have element type T, all inputs
-// have more than zero elements and ouput is preallocated.
+// have more than zero elements and output is preallocated.
 template <typename T>
 void ConcatHelper(OpKernelContext* context, const std::vector<Tensor>& inputs,
                   Tensor* output) {

--- a/tensorflow/lite/delegates/utils/experimental/sample_stable_delegate/sample_app_using_stable_delegate.cc
+++ b/tensorflow/lite/delegates/utils/experimental/sample_stable_delegate/sample_app_using_stable_delegate.cc
@@ -128,7 +128,7 @@ int main(int argc, char* argv[]) {
   CHECK(interpreter->Invoke() == kTfLiteOk);
 
   // Get output buffer.
-  // The only ouput to the test model is a single tensor of floats.
+  // The only output to the test model is a single tensor of floats.
   float* output = interpreter->typed_output_tensor<float>(0);
   int64_t num_output_elements =
       TfLiteTensorByteSize(interpreter->output_tensor(0)) / sizeof(float);

--- a/tensorflow/python/ops/custom_gradient.py
+++ b/tensorflow/python/ops/custom_gradient.py
@@ -711,7 +711,7 @@ def recompute_grad(f):
       result = f(*args, **kwargs)
 
     def grad_wrapper(*wrapper_args, variables=None):
-      """Wrapper function to accomodate lack of kwargs in graph mode custom_gradient."""
+      """Wrapper function to accommodate lack of kwargs in graph mode custom_gradient."""
 
       @custom_gradient
       def inner_recompute_grad(*dresult):


### PR DESCRIPTION
## Description
This PR fixes several minor spelling mistakes in comments and docstrings across various files. 

Fixes include:
 - ouput -> output
 - accomodate -> accommodate 
 - occured -> occurred

These changes do not affect functional code, only documentation strings and internal code comments.