### PR TITLE
Fix NaN issue in cumulative_logsumexp when input is infinity

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -4423,9 +4423,19 @@ def cumulative_logsumexp(x, axis=0, exclusive=False, reverse=False, name=None):
   """
   with ops.name_scope(name, "CumulativeLogsumexp", [x]) as name:
     x = ops.convert_to_tensor(x, name="x")
-    return gen_math_ops.cumulative_logsumexp(
+    # 1. تشغيل العملية الأصلية باستخدام الـ C++ Kernel
+    result = gen_math_ops.cumulative_logsumexp(
         x, axis, exclusive=exclusive, reverse=reverse, name=name)
-
+    
+    # 2. إضافة حماية (Guard): 
+    # لو النتيجة NaN والمدخل الأصلي كان Inf، رجع الـ Inf (اللي هو x)
+    return array_ops.where(
+        gen_math_ops.is_nan(result) & gen_math_ops.is_inf(x), 
+        x, 
+        result
+    )
+   
+    
 
 @tf_export("math.conj", v1=["math.conj", "conj"])
 @dispatch.register_unary_elementwise_api


### PR DESCRIPTION
Description:This PR addresses a numerical stability issue where cumulative_logsumexp returns NaN when inputs contain $+\infty$. This happens because the internal logic results in an $inf - inf$ operation.Changes:Added a guard using array_ops.where to detect NaN results and check if the original input was inf.If both conditions are met, the original inf is returned instead of NaN.Verification:
Verified the fix with a reproduction script; the output correctly returns inf instead of nan