### PR TITLE
removing google_pasta from 3.14+

### DIFF
--- a/ci/official/requirements_updater/numpy1_requirements/requirements.in
+++ b/ci/official/requirements_updater/numpy1_requirements/requirements.in
@@ -37,5 +37,5 @@ zstandard==0.23.0
 # The dependencies below are needed for TF wheel testing.
 tensorflow-io-gcs-filesystem==0.37.1 ; python_version <= "3.12"
 libclang >= 13.0.0
-google_pasta ~= 0.2
+google_pasta ~= 0.2 ; python_version < "3.14"
 flatbuffers ~= 25.9.23

--- a/ci/official/requirements_updater/requirements.in
+++ b/ci/official/requirements_updater/requirements.in
@@ -40,5 +40,5 @@ zstandard==0.25.0
 # The dependencies below are needed for TF wheel testing.
 tensorflow-io-gcs-filesystem==0.37.1 ; python_version <= "3.12"
 libclang >= 13.0.0
-google_pasta ~= 0.2
+google_pasta ~= 0.2 ; python_version < "3.14"
 flatbuffers ~= 25.9.23

--- a/requirements_lock_3_14.txt
+++ b/requirements_lock_3_14.txt
@@ -132,11 +132,6 @@ gast==0.4.0 \
     --hash=sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1 \
     --hash=sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4
     # via -r ci/official/requirements_updater/requirements.in
-google-pasta==0.2.0 \
-    --hash=sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954 \
-    --hash=sha256:b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed \
-    --hash=sha256:c9f2c8dfc8f96d0d5808299920721be30c9eec37f2389f28904f454565c8a16e
-    # via -r ci/official/requirements_updater/requirements.in
 grpcio==1.78.0 ; python_version == "3.14" \
     --hash=sha256:082653eecbdf290e6e3e2c276ab2c54b9e7c299e07f4221872380312d8cf395e \
     --hash=sha256:10a9a644b5dd5aec3b82b5b0b90d41c0fa94c85ef42cb42cf78a23291ddb5e7d \

--- a/tensorflow/tools/ci_build/release/requirements_common.txt
+++ b/tensorflow/tools/ci_build/release/requirements_common.txt
@@ -4,7 +4,7 @@
 absl-py ~= 1.0.0
 astunparse ~= 1.6.3
 flatbuffers ~= 25.9.23
-google_pasta ~= 0.2
+google_pasta ~= 0.2 ; python_version < "3.14"
 h5py ~= 3.10.0  # Earliest version for Python 3.12
 ml_dtypes ~= 0.5.1
 # TODO(b/262592253): Support older versions of NumPy for Python 3.10 and lower

--- a/tensorflow/tools/compatibility/ast_edits.py
+++ b/tensorflow/tools/compatibility/ast_edits.py
@@ -23,7 +23,13 @@ import sys
 import tempfile
 import traceback
 
-import pasta
+try:
+  import pasta
+except ImportError as e:
+  raise ImportError(
+      "google-pasta is required for the TF upgrade tool but is not "
+      "installed. google-pasta is not supported on Python 3.14+. "
+      "Please use Python 3.13 or earlier to run the TF upgrade tool.") from e
 
 
 # Some regular expressions we will need for parsing

--- a/tensorflow/tools/compatibility/tf_upgrade_v2.py
+++ b/tensorflow/tools/compatibility/tf_upgrade_v2.py
@@ -19,7 +19,13 @@ import copy
 import functools
 import sys
 
-import pasta
+try:
+  import pasta
+except ImportError as e:
+  raise ImportError(
+      "google-pasta is required for the TF upgrade tool but is not "
+      "installed. google-pasta is not supported on Python 3.14+. "
+      "Please use Python 3.13 or earlier to run the TF upgrade tool.") from e
 
 from tensorflow.tools.compatibility import all_renames_v2
 from tensorflow.tools.compatibility import ast_edits

--- a/tensorflow/tools/pip_package/setup.py.tpl
+++ b/tensorflow/tools/pip_package/setup.py.tpl
@@ -99,7 +99,7 @@ REQUIRED_PACKAGES = [
     'astunparse >= 1.6.0',
     'flatbuffers >= 25.9.23',
     'gast >=0.2.1,!=0.5.0,!=0.5.1,!=0.5.2',
-    'google_pasta >= 0.1.1',
+    'google_pasta >= 0.1.1; python_version < "3.14"',
     'libclang >= 13.0.0',
     'opt_einsum >= 2.3.2',
     'packaging',

--- a/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
+++ b/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
@@ -7,7 +7,7 @@
 absl-py ~= 1.0.0
 astunparse ~= 1.6.3
 flatbuffers ~= 25.9.23
-google_pasta ~= 0.2
+google_pasta ~= 0.2 ; python_version < "3.14"
 h5py ~= 3.11.0 # Earliest version for NumPy 2.0
 ml_dtypes ~= 0.5.1 # Earliest version with mxfloat types
 # TODO(b/366266944): Support older versions of NumPy to support TFX. Remove when


### PR DESCRIPTION
Summary
Remove google-pasta as a dependency for Python 3.14+, where it is not supported.
Changes

Add python_version < "3.14" environment marker to all dependency declarations (setup.py.tpl, requirements.in, requirements_common.txt, devel.requirements.txt)
Remove google-pasta entry from requirements_lock_3_14.txt
Re-raise ImportError with a clear message in ast_edits.py and tf_upgrade_v2.py directing users to Python 3.13 or earlier for the TF upgrade tool

Rationale
Breaking tf_upgrade_v2 on Python 3.14+ is acceptable: TensorFlow 1.x reached EOL in 2020, and google-pasta has had no release in over 6 years and does not support Python 3.14's updated AST. Rather than patch around an unmaintained dependency for a tool that migrates to an EOL framework, support is being explicitly dropped with a clear error directing users to Python 3.13 or earlier.