### PR TITLE
Fix CWE-770: Add upper-bound guard to TensorListReserve and TensorListResize

### DIFF
--- a/tensorflow/core/kernels/list_kernels.cc
+++ b/tensorflow/core/kernels/list_kernels.cc
@@ -360,7 +360,6 @@ class TensorListReserve : public OpKernel {
     TensorList output;
     output.element_shape = element_shape;
     output.element_dtype = element_dtype_;
-    output.max_num_elements = num_elements;
     output.tensors().resize(num_elements, Tensor(DT_INVALID));
     Tensor* result;
     AllocatorAttributes attr;

--- a/tensorflow/core/kernels/list_kernels.cc
+++ b/tensorflow/core/kernels/list_kernels.cc
@@ -343,9 +343,24 @@ class TensorListReserve : public OpKernel {
                     absl::StrCat("The num_elements to reserve must be a "
                                  "non negative number, but got ",
                                  num_elements)));
+    // Upper bound guard (CWE-770).  Each reserved slot is a Tensor object
+    // (~24-32 bytes), so INT32_MAX slots would allocate ~48-64 GB of
+    // metadata alone.  1 048 576 (2^20) slots use ~24 MB, which covers
+    // all practical ML workloads (RNNs, sequences, time series).
+    // For comparison, EmptyTensorList exposes a max_num_elements input
+    // that TensorListPushBack enforces; TensorListReserve lacked any
+    // equivalent guard.
+    static constexpr int32_t kMaxReserveElements = 1 << 20;  // 1 048 576
+    OP_REQUIRES(c, num_elements <= kMaxReserveElements,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "TensorListReserve: num_elements (", num_elements,
+                    ") exceeds maximum allowed (", kMaxReserveElements,
+                    "). Use EmptyTensorList with TensorListPushBack "
+                    "for dynamically-sized lists.")));
     TensorList output;
     output.element_shape = element_shape;
     output.element_dtype = element_dtype_;
+    output.max_num_elements = num_elements;
     output.tensors().resize(num_elements, Tensor(DT_INVALID));
     Tensor* result;
     AllocatorAttributes attr;
@@ -391,6 +406,13 @@ class TensorListResize : public OpKernel {
         c, size >= 0,
         absl::InvalidArgumentError(absl::StrCat(
             "TensorListSlice expects size to be non-negative. Got: ", size)));
+    // Same upper bound as TensorListReserve (CWE-770).
+    static constexpr int32_t kMaxResizeElements = 1 << 20;  // 1 048 576
+    OP_REQUIRES(c, size <= kMaxResizeElements,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "TensorListResize: size (", size,
+                    ") exceeds maximum allowed (", kMaxResizeElements,
+                    ").")));
 
     std::unique_ptr<Tensor> maybe_result =
         c->forward_input(0, 0, DT_VARIANT, TensorShape{},


### PR DESCRIPTION
## Summary

`TensorListReserve` accepts an `int32` `num_elements` parameter and immediately calls `std::vector<Tensor>::resize(num_elements)`.  Each slot is a `Tensor` object (~24-32 bytes), so `INT32_MAX` (2 147 483 647) allocates **~48-64 GB** of metadata from a single op call — a trivial OOM DoS.

`TensorListResize` has the same issue with its `size` parameter.

### Inconsistency within TensorList API

| Op | Has upper-bound guard? |
|----|----------------------|
| `EmptyTensorList` → `TensorListPushBack` | ✅ `max_num_elements` checked |
| **`TensorListReserve`** | ❌ Only checks `>= 0` |
| **`TensorListResize`** | ❌ Only checks `>= 0` |

`EmptyTensorList` exposes a `max_num_elements` input that `TensorListPushBack` enforces (list_kernels.cc line 220).  `TensorListReserve` was never given an equivalent guard.

### What this PR does

1. **Adds `OP_REQUIRES` upper-bound check** to both `TensorListReserve` and `TensorListResize`: max `2^20` (1 048 576) elements
2. **Sets `output.max_num_elements`** in `TensorListReserve` for consistency with `EmptyTensorList`

### Why 2^20 (1 048 576)?

- **Memory budget:** 1M × 24 bytes = ~24 MB — reasonable for a single op
- **ML coverage:** Covers extreme sequence lengths (max known: ~128K tokens in modern LLMs). 1M provides 8× safety margin
- **Attack mitigation:** Reduces max single-op allocation from ~48 GB to ~24 MB (1930× reduction)
- **Consistency:** `tf.while_loop` (the primary TensorList consumer) uses `EmptyTensorList` with `maximum_iterations` as bound — typical values: 100-10 000

### Attack scenario

A TF Serving endpoint or shared Jupyter notebook processes a request containing `tf.raw_ops.TensorListReserve(element_shape=[], num_elements=2147483647)`.  This single call allocates ~48 GB, crashing the service.

Bug: 501069108

## Test plan

- [ ] Existing `list_ops_test` suite passes
- [ ] Manual verification: `num_elements=2147483647` rejected with error
- [ ] Manual verification: `num_elements=1000` accepted