### PR TITLE
[Fix compilation error using MSVC] Add Tensor and Helper forward class declarations

### DIFF
--- a/tensorflow/lite/core/model_building.h
+++ b/tensorflow/lite/core/model_building.h
@@ -37,6 +37,8 @@ namespace model_builder {
 
 class InterpreterInfo;
 class Graph;
+class Tensor;
+class Helper;
 
 namespace internal {
 


### PR DESCRIPTION
To prevent compile error with MSVC and clang-cl, adding two missing classes forward declarations.