### PR TITLE
Security: add validation for reduction axes count in XNNPACK delegate VisitReduceNode

### DIFF
--- a/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc
+++ b/tensorflow/lite/delegates/xnnpack/xnnpack_delegate.cc
@@ -4939,6 +4939,14 @@ class Subgraph {
           "Not handling ill defined empty reduction in node #%d", node_index);
       return kTfLiteError;
     }
+    if (num_reduction_axes > XNN_MAX_TENSOR_DIMS) {
+      TF_LITE_MAYBE_KERNEL_LOG(
+          logging_context,
+          "unsupported number of reduction axes (%d) in node #%d: "
+          "must be <= %d",
+          num_reduction_axes, node_index, XNN_MAX_TENSOR_DIMS);
+      return kTfLiteError;
+    }
     const TfLiteTensor& output_tensor = tensors[node->outputs->data[0]];
     TF_LITE_ENSURE_STATUS(
         CheckTensorFloat32OrQUInt8Type(delegate, logging_context, output_tensor,


### PR DESCRIPTION
Add a bounds check in VisitReduceNode to validate that the number of reduction axes does not exceed XNN_MAX_TENSOR_DIMS. Previously, an excessively large num_reduction_axes could lead to out-of-bounds access when populating the reduction_axes array (which is sized to XNN_MAX_TENSOR_DIMS). This change adds an early check with a descriptive error log and returns kTfLiteError if the limit is exceeded.

The corresponding Chromium issue: https://issues.chromium.org/issues/501280398