### PR TITLE
security/fuzzing: add TFLite, ImportGraphDef, and checkpoint fuzz targets

### DIFF
--- a/tensorflow/security/fuzzing/cc/checkpoint/BUILD
+++ b/tensorflow/security/fuzzing/cc/checkpoint/BUILD
@@ -1,0 +1,21 @@
+# Raw-bytes fuzzer for the TensorFlow V2 checkpoint loader.
+
+load(
+    "//tensorflow/security/fuzzing:tf_fuzzing.bzl",
+    "tf_cc_fuzz_test",
+)
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    licenses = ["notice"],
+)
+
+tf_cc_fuzz_test(
+    name = "load_checkpoint_fuzz",
+    srcs = ["load_checkpoint_fuzz.cc"],
+    tags = ["no_oss"],
+    deps = [
+        "//tensorflow/c:checkpoint_reader",
+        "//tensorflow/c:tf_status",
+    ],
+)

--- a/tensorflow/security/fuzzing/cc/checkpoint/load_checkpoint_fuzz.cc
+++ b/tensorflow/security/fuzzing/cc/checkpoint/load_checkpoint_fuzz.cc
@@ -1,0 +1,90 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "fuzztest/fuzztest.h"
+#include "tensorflow/c/checkpoint_reader.h"
+#include "tensorflow/c/tf_status.h"
+
+// Raw-bytes fuzzer for tensorflow::checkpoint::CheckpointReader -- the
+// C++ entry point exercised by Python's tf.train.load_checkpoint().
+//
+// A V2 checkpoint consists of two files that share a prefix:
+//   <prefix>.index                     -- SSTable index
+//   <prefix>.data-00000-of-00001       -- tensor data payload
+//
+// The fuzzer splits its byte input in half: the first half becomes the
+// .index file, the second becomes the .data-00000-of-00001 file. The
+// CheckpointReader is then constructed on the shared prefix, which
+// exercises both SSTable parsing and BundleEntryProto deserialization
+// in BuildV2VarMaps().
+//
+// The existing //tensorflow/security/fuzzing/cc:checkpoint_reader_fuzz
+// takes a structured CheckpointReaderFuzzInput proto, pre-serializes
+// both files via TableBuilder, and has known build issues that remove
+// it from OSS-Fuzz target set. This raw-bytes harness is complementary:
+// it covers the bytes-on-disk path directly (crashes found here are
+// reproducible with the crashing .index/.data pair).
+
+namespace {
+
+void WriteFile(const std::string& path, std::string_view data) {
+  std::ofstream out(path, std::ios::binary);
+  if (!out) return;
+  out.write(data.data(), static_cast<std::streamsize>(data.size()));
+}
+
+void FuzzLoadCheckpoint(std::string_view data) {
+  if (data.size() < 2) return;
+
+  // Split input: first half -> .index, second half -> .data-00000-of-00001.
+  const size_t split = data.size() / 2;
+  const std::string_view index_bytes = data.substr(0, split);
+  const std::string_view data_bytes = data.substr(split);
+
+  // Build a fresh temp dir per iteration so earlier iterations' files
+  // don't influence this one. tmpnam would trigger -Wdeprecated; use
+  // mkdtemp.
+  char tmpl[] = "/tmp/tf_ckpt_fuzz_XXXXXX";
+  const char* dir = mkdtemp(tmpl);
+  if (dir == nullptr) return;
+
+  const std::string prefix = std::string(dir) + "/ckpt";
+  WriteFile(prefix + ".index", index_bytes);
+  WriteFile(prefix + ".data-00000-of-00001", data_bytes);
+
+  {
+    TF_Status* status = TF_NewStatus();
+    auto reader = std::make_unique<
+        tensorflow::checkpoint::CheckpointReader>(prefix, status);
+    // CheckpointReader construction runs BuildV2VarMaps, which is where
+    // the bugs tend to live; we don't need any further calls.
+    TF_DeleteStatus(status);
+  }
+
+  // Best-effort cleanup. Ignore errors.
+  std::remove((prefix + ".index").c_str());
+  std::remove((prefix + ".data-00000-of-00001").c_str());
+  std::remove(dir);
+}
+FUZZ_TEST(CC_FUZZING, FuzzLoadCheckpoint);
+
+}  // namespace

--- a/tensorflow/security/fuzzing/cc/graph/BUILD
+++ b/tensorflow/security/fuzzing/cc/graph/BUILD
@@ -1,0 +1,23 @@
+# Raw-bytes fuzzers for TensorFlow GraphDef-consuming APIs.
+
+load(
+    "//tensorflow/security/fuzzing:tf_fuzzing.bzl",
+    "tf_cc_fuzz_test",
+)
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    licenses = ["notice"],
+)
+
+tf_cc_fuzz_test(
+    name = "import_graph_def_fuzz",
+    srcs = ["import_graph_def_fuzz.cc"],
+    tags = ["no_oss"],
+    deps = [
+        "//tensorflow/core:core_cpu",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:protos_all_cc",
+        "//tensorflow/core/common_runtime:graph_constructor",
+    ],
+)

--- a/tensorflow/security/fuzzing/cc/graph/import_graph_def_fuzz.cc
+++ b/tensorflow/security/fuzzing/cc/graph/import_graph_def_fuzz.cc
@@ -1,0 +1,60 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <memory>
+#include <string_view>
+
+#include "fuzztest/fuzztest.h"
+#include "tensorflow/core/common_runtime/graph_constructor.h"
+#include "tensorflow/core/framework/graph.pb.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/graph/graph.h"
+
+// Raw-bytes fuzzer for tensorflow::ImportGraphDef -- the C++ entry point
+// exercised by Python's tf.import_graph_def().
+//
+// Why this exists alongside the structured-proto
+// //tensorflow/core/common_runtime:graph_constructor_fuzz (which takes
+// a typed GraphDef argument):
+//
+//  * This one takes std::string_view, parses the bytes as a GraphDef
+//    wire-format protobuf, and invokes ImportGraphDef. The structured
+//    fuzzer cannot synthesize certain specific graph shapes reliably --
+//    e.g. FunctionDefLibrary entries where two functions reference each
+//    other by name, which is the shape needed to trigger the
+//    import-graph-def mutual-recursion stack overflow.
+//  * Raw-bytes input also allows straightforward reproduction of a
+//    specific crashing .pb from disk via the standard libFuzzer repro
+//    workflow (`./binary <testcase>`).
+
+namespace {
+
+void FuzzImportGraphDef(std::string_view data) {
+  tensorflow::GraphDef graph_def;
+  if (!graph_def.ParseFromArray(data.data(),
+                                static_cast<int>(data.size()))) {
+    return;
+  }
+
+  tensorflow::Graph graph(tensorflow::OpRegistry::Global());
+  tensorflow::ImportGraphDefOptions opts;
+  // Ignore the returned status -- we only care about hard crashes
+  // (SIGSEGV, ASan reports, stack overflow), not well-formed errors.
+  (void)tensorflow::ImportGraphDef(opts, graph_def, &graph,
+                                   /*refiner=*/nullptr);
+}
+FUZZ_TEST(CC_FUZZING, FuzzImportGraphDef);
+
+}  // namespace

--- a/tensorflow/security/fuzzing/cc/lite/BUILD
+++ b/tensorflow/security/fuzzing/cc/lite/BUILD
@@ -1,0 +1,24 @@
+# Fuzzers for TensorFlow Lite.
+#
+# These targets fuzz the TFLite Interpreter load/prepare/invoke pipeline,
+# which is exercised by tf.lite.Interpreter(model_content=...) from Python.
+
+load(
+    "//tensorflow/security/fuzzing:tf_fuzzing.bzl",
+    "tf_cc_fuzz_test",
+)
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    licenses = ["notice"],
+)
+
+tf_cc_fuzz_test(
+    name = "tflite_interpreter_fuzz",
+    srcs = ["tflite_interpreter_fuzz.cc"],
+    tags = ["no_oss"],
+    deps = [
+        "//tensorflow/lite:framework",
+        "//tensorflow/lite/kernels:builtin_ops",
+    ],
+)

--- a/tensorflow/security/fuzzing/cc/lite/tflite_interpreter_fuzz.cc
+++ b/tensorflow/security/fuzzing/cc/lite/tflite_interpreter_fuzz.cc
@@ -1,0 +1,76 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstring>
+#include <memory>
+#include <string_view>
+
+#include "fuzztest/fuzztest.h"
+#include "tensorflow/lite/interpreter.h"
+#include "tensorflow/lite/interpreter_builder.h"
+#include "tensorflow/lite/kernels/register.h"
+#include "tensorflow/lite/model_builder.h"
+
+// Fuzzer for the TFLite Interpreter load/prepare/invoke pipeline.
+//
+// Attack surface: tflite::FlatBufferModel::BuildFromBuffer ->
+// InterpreterBuilder::operator() -> Interpreter::AllocateTensors ->
+// Interpreter::Invoke. This is the same path exercised by
+// tf.lite.Interpreter(model_content=...) from Python, so any crash here
+// is reachable by loading an untrusted .tflite model.
+//
+// Uses BuildFromBuffer (not VerifyAndBuildFromBuffer) on purpose: the
+// FlatBuffer verifier filters out a large class of inputs that TFLite
+// consumers are not actually protected against -- many historical
+// kernel-level bugs require a flatbuffer that is verifier-valid but
+// semantically inconsistent.
+//
+// Include set and deps match tensorflow/lite/examples/minimal, which is
+// the public-facing "how to embed the TFLite runtime" example.
+
+namespace {
+
+void FuzzTFLiteInterpreter(std::string_view data) {
+  if (data.empty()) return;
+
+  auto model = tflite::FlatBufferModel::BuildFromBuffer(data.data(),
+                                                        data.size());
+  if (model == nullptr) return;
+
+  tflite::ops::builtin::BuiltinOpResolver resolver;
+  std::unique_ptr<tflite::Interpreter> interpreter;
+  if (tflite::InterpreterBuilder(*model, resolver)(&interpreter) !=
+      kTfLiteOk) {
+    return;
+  }
+  if (interpreter == nullptr) return;
+
+  if (interpreter->AllocateTensors() != kTfLiteOk) return;
+
+  // Zero-fill inputs so Invoke has defined source bytes. The bug classes
+  // we want to find (OOB R/W, null deref, stack overflow) do not depend
+  // on input *content*, only on structural properties of the flatbuffer.
+  for (int i : interpreter->inputs()) {
+    TfLiteTensor* t = interpreter->tensor(i);
+    if (t != nullptr && t->data.raw != nullptr && t->bytes > 0) {
+      std::memset(t->data.raw, 0, t->bytes);
+    }
+  }
+
+  interpreter->Invoke();
+}
+FUZZ_TEST(CC_FUZZING, FuzzTFLiteInterpreter);
+
+}  // namespace


### PR DESCRIPTION
# PR for `tensorflow/tensorflow`

**Title:** `security/fuzzing: add TFLite, ImportGraphDef, and checkpoint fuzz targets`

## Summary

Adds three raw-bytes fuzz targets that cover untrusted-input attack surfaces currently not reached by any existing target in the OSS-Fuzz TensorFlow project:

| Target | Exercises | Python-level equivalent |
|---|---|---|
| `//tensorflow/security/fuzzing/cc/lite:tflite_interpreter_fuzz` | `FlatBufferModel::BuildFromBuffer` → `InterpreterBuilder` → `AllocateTensors` → `Invoke` | `tf.lite.Interpreter(model_content=...)` |
| `//tensorflow/security/fuzzing/cc/graph:import_graph_def_fuzz` | `GraphDef::ParseFromArray` → `tensorflow::ImportGraphDef` | `tf.import_graph_def(...)` |
| `//tensorflow/security/fuzzing/cc/checkpoint:load_checkpoint_fuzz` | Splits input into `.index` + `.data-00000-of-00001`, constructs `CheckpointReader` | `tf.train.load_checkpoint(path)` |

## Motivation

Coverage gaps in the current OSS-Fuzz TF project:

1. **TFLite has zero fuzz coverage.** No path under `//tensorflow/lite/...` is in `FUZZTEST_TARGET_FOLDER`. TFLite's model-loading pipeline is a well-known CVE hot zone (CVE-2022-23593, CVE-2022-21728, CVE-2021-29605, CVE-2020-15211, CVE-2022-23559, and many more).
2. **ImportGraphDef is only fuzzed structurally.** `//tensorflow/core/common_runtime:graph_constructor_fuzz` takes `const GraphDef&` and relies on fuzztest's proto domain to synthesize graphs. Certain specific shapes — e.g. `FunctionDefLibrary` entries where two functions reference each other by name — are statistically unreachable for a structured generator. A raw-bytes companion lets the fuzz engine explore at the wire-format level and also enables clean reproduction of specific crashing `.pb` files.
3. **CheckpointReader is not fuzzed at all in the OSS-Fuzz build.** The existing `//tensorflow/security/fuzzing/cc:checkpoint_reader_fuzz` is explicitly removed at build time (`build.sh` sed-deletes it due to known build failures) and takes a structured `CheckpointReaderFuzzInput` proto rather than raw bytes.

## Design choices

- **`std::string_view` arg on every target.** Matches the canonical TF pattern (`base64_fuzz.cc`, many others) and plugs straight into the libFuzzer adapter used by `tf_cc_fuzz_test`.
- **TFLite target uses `BuildFromBuffer` (not `VerifyAndBuildFromBuffer`).** The verifier filters out a large class of inputs that consumers are not actually protected against — historically most TFLite kernel bugs require verifier-valid but semantically inconsistent flatbuffers, and the verifier would drop those.
- **TFLite include set and deps match `tensorflow/lite/examples/minimal`.** That is the public-facing "how to embed the TFLite runtime" example, so its `//tensorflow/lite:framework` + `//tensorflow/lite/kernels:builtin_ops` recipe is the stable-API recipe to copy. The `//tensorflow/lite/core:*` headers are marked "not for direct inclusion" and have restricted visibility.
- **Checkpoint target splits input in half.** A V2 checkpoint is two paired files (`.index` SSTable + `.data-00000-of-00001` payload). The fuzzer writes both halves to a temp dir and opens on the shared prefix.
- **No seeds shipped.** `_seed_corpus.zip` files go through `fuzztest::ParseIRObject` under the libFuzzer compatibility adapter and are silently dropped unless they carry a `FUZZTESTv1` magic header, so shipping raw `.tflite`/`.pb` seeds would be misleading. If seeding becomes necessary, a follow-up can add `.WithSeeds(...)` in-source.

## Files added

```
tensorflow/security/fuzzing/cc/lite/BUILD
tensorflow/security/fuzzing/cc/lite/tflite_interpreter_fuzz.cc
tensorflow/security/fuzzing/cc/graph/BUILD
tensorflow/security/fuzzing/cc/graph/import_graph_def_fuzz.cc
tensorflow/security/fuzzing/cc/checkpoint/BUILD
tensorflow/security/fuzzing/cc/checkpoint/load_checkpoint_fuzz.cc
```

No changes to `tf_fuzzing.bzl` or any existing BUILD rules.

## Verification

All three targets analyze cleanly under the repo's default config:

```
$ bazel build --nobuild \
    //tensorflow/security/fuzzing/cc/lite:tflite_interpreter_fuzz \
    //tensorflow/security/fuzzing/cc/graph:import_graph_def_fuzz \
    //tensorflow/security/fuzzing/cc/checkpoint:load_checkpoint_fuzz
INFO: Analyzed 3 targets (211 packages loaded, 9359 targets configured).
INFO: Build completed successfully, 0 total actions
```

## Companion PR

A follow-up PR against `google/oss-fuzz` adds these three target folders to `projects/tensorflow/build.sh`'s `FUZZTEST_TARGET_FOLDER`. That PR is blocked on this one landing first.
