### PR TITLE
[TFLite] Fix FuseUnpackAndConcatToReshape incorrectly fusing permutations as reshape

### DIFF
--- a/tensorflow/compiler/mlir/lite/tests/optimize.mlir
+++ b/tensorflow/compiler/mlir/lite/tests/optimize.mlir
@@ -3378,6 +3378,16 @@ func.func @fuseUnpackAndConcatToReshape(%arg0: tensor<1x3x2xf32>) -> tensor<1x6x
   // CHECK: return %[[RES]]
 }
 
+// CHECK-LABEL: noFuseUnpackAndConcatToReshapeWhenAxesDiffer
+func.func @noFuseUnpackAndConcatToReshapeWhenAxesDiffer(%arg0: tensor<4x3x1xf32>) -> tensor<12x1xf32> {
+  %0:3 = "tfl.unpack"(%arg0) {axis = 1 : i32, num = 3 : i32} : (tensor<4x3x1xf32>) -> (tensor<4x1xf32>, tensor<4x1xf32>, tensor<4x1xf32>)
+  %1 = "tfl.concatenation"(%0#0, %0#1, %0#2) {axis = 0 : i32, fused_activation_function = "NONE"} : (tensor<4x1xf32>, tensor<4x1xf32>, tensor<4x1xf32>) -> tensor<12x1xf32>
+  func.return %1 : tensor<12x1xf32>
+  // CHECK-NOT: tfl.reshape
+  // CHECK: tfl.unpack
+  // CHECK: tfl.concatenation
+}
+
 // CHECK-LABEL: replaceReshapeEqualWithOneHotSingleDim
 func.func @replaceReshapeEqualWithOneHotSingleDim(%arg: tensor<1xi32>) -> tensor<3xi1> {
   %cst = arith.constant dense<[0, 1, 2]> : tensor<3xi32>

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_pass.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_pass.cc
@@ -2351,6 +2351,18 @@ struct FuseUnpackAndConcatToReshape
       return failure();
     }
 
+    // The fusion is only valid when concat_axis == unpack_axis (normalized).
+    if (unpack_op.getNum() > 1) {
+      int64_t output_rank = output_type.getRank();
+      int64_t unpack_input_rank =
+          mlir::cast<ShapedType>(unpack_op.getInput().getType()).getRank();
+      int64_t unpack_axis = unpack_op.getAxis();
+      if (unpack_axis < 0) unpack_axis += unpack_input_rank;
+      int64_t concat_axis = concat_op.getAxis();
+      if (concat_axis < 0) concat_axis += output_rank;
+      if (concat_axis != unpack_axis) return failure();
+    }
+
     auto new_shape_array = output_type.getShape();
     // This is to workaround the unnecessary cast i64 -> i32.
     SmallVector<int32_t, 4> new_shape_array_i32;

--- a/tensorflow/compiler/mlir/lite/transforms/optimize_pass.cc
+++ b/tensorflow/compiler/mlir/lite/transforms/optimize_pass.cc
@@ -2356,9 +2356,9 @@ struct FuseUnpackAndConcatToReshape
       int64_t output_rank = output_type.getRank();
       int64_t unpack_input_rank =
           mlir::cast<ShapedType>(unpack_op.getInput().getType()).getRank();
-      int64_t unpack_axis = unpack_op.getAxis();
+      int64_t unpack_axis = static_cast<int32_t>(unpack_op.getAxis());
       if (unpack_axis < 0) unpack_axis += unpack_input_rank;
-      int64_t concat_axis = concat_op.getAxis();
+      int64_t concat_axis = static_cast<int32_t>(concat_op.getAxis());
       if (concat_axis < 0) concat_axis += output_rank;
       if (concat_axis != unpack_axis) return failure();
     }


### PR DESCRIPTION
The `FuseUnpackAndConcatToReshape` optimization was blindly replacing any `unpack + concat` sequence with a `reshape`, but this is only correct when the concat axis matches the unpack axis. When they differ, the two ops together perform a data permutation that a plain reshape cannot replicate.

Added a guard that bails out of the fusion when the normalized concat axis differs from the unpack axis, and added a regression test covering the mismatched-axis case. Fixes #116047