### PR TITLE
[dlpack] Prevent size_t overflow in TFE_HandleFromDLPack tensor dimen…

### DIFF
--- a/tensorflow/c/eager/dlpack.cc
+++ b/tensorflow/c/eager/dlpack.cc
@@ -377,6 +377,13 @@ TFE_TensorHandle* TFE_HandleFromDLPack(void* dlm, TF_Status* status,
 
   size_t total_bytes = dl_tensor->dtype.bits / 8;
   for (int i = 0; i < num_dims; i++) {
+      if (dims[i] < 0 ||
+              (total_bytes != 0 &&
+               static_cast<size_t>(dims[i]) > SIZE_MAX / total_bytes)) {
+              status->status = tensorflow::errors::InvalidArgument(
+                      "DLPack tensor dimensions overflow size_t");
+          return nullptr;
+      }
     total_bytes *= dims[i];
   }
 

--- a/tensorflow/c/eager/dlpack_test.cc
+++ b/tensorflow/c/eager/dlpack_test.cc
@@ -109,5 +109,43 @@ TEST(DLPack, HandleFromDLPackStrides) {
   TF_DeleteStatus(status);
 }
 
+TEST(DLPack, HandleFromDLPackRejectsOverflowingDims) {
+  TF_Status* status = TF_NewStatus();
+  TFE_ContextOptions* opts = TFE_NewContextOptions();
+  TFE_Context* ctx = TFE_NewContext(opts, status);
+  ASSERT_EQ(TF_OK, TF_GetCode(status)) << TF_Message(status);
+  TFE_DeleteContextOptions(opts);
+
+  // Dimensions whose product would overflow size_t. Without the guard
+  // in TFE_HandleFromDLPack, total_bytes wraps to 0 and the resulting
+  // tensor permits heap OOB read/write via tf.experimental.dlpack.from_dlpack.
+  std::vector<int64_t> overflow_shape = {static_cast<int64_t>(1) << 32,
+                                         static_cast<int64_t>(1) << 32, 16};
+  DLManagedTensor dlm_in = {};
+  DLTensor* dltensor_in = &dlm_in.dl_tensor;
+  dltensor_in->data = nullptr;
+  dltensor_in->device = {kDLCPU, 0};
+  dltensor_in->ndim = static_cast<int32_t>(overflow_shape.size());
+  dltensor_in->dtype = {kDLFloat, 32, 1};
+  dltensor_in->shape = overflow_shape.data();
+  dltensor_in->strides = nullptr;
+  dltensor_in->byte_offset = 0;
+
+  TFE_TensorHandle* handle = TFE_HandleFromDLPack(&dlm_in, status, ctx);
+  EXPECT_EQ(handle, nullptr);
+  EXPECT_NE(TF_GetCode(status), TF_OK);
+
+  std::vector<int64_t> negative_shape = {-1, 4};
+  dltensor_in->ndim = static_cast<int32_t>(negative_shape.size());
+  dltensor_in->shape = negative_shape.data();
+  TF_SetStatus(status, TF_OK, "");
+  TFE_TensorHandle* handle_neg = TFE_HandleFromDLPack(&dlm_in, status, ctx);
+  EXPECT_EQ(handle_neg, nullptr);
+  EXPECT_NE(TF_GetCode(status), TF_OK);
+
+  TFE_DeleteContext(ctx);
+  TF_DeleteStatus(status);
+}
+
 }  // namespace
 }  // namespace tensorflow


### PR DESCRIPTION
…sions

The import path TFE_HandleFromDLPack multiplies the element size by every dimension without checking for overflow. Crafted DLTensor dimensions (e.g. [2**32, 2**32, 16] with int32) wrap size_t to 0, so a zero-byte allocation is treated as a tensor of logical size >= 2**68 bytes, producing heap OOB reads/writes on any subsequent element access. Reachable via tf.experimental.dlpack.from_dlpack(). Mirrors the fix already applied to the export path TFE_HandleToDLPack in commit 22e07fb. Also rejects negative dimensions.

## Summary

Adds a defensive bounds check in `TFE_HandleFromDLPack` to prevent `size_t` overflow when multiplying tensor dimensions. Without this check, crafted DLTensor dimensions can wrap the allocation size to 0 while TensorFlow treats the tensor as having its (much larger) logical size, producing heap out-of-bounds reads/writes on any subsequent element access.

## Root cause

```cpp
size_t total_bytes = dl_tensor->dtype.bits / 8;
for (int i = 0; i < num_dims; i++) {
  total_bytes *= dims[i];   // no overflow check, no negative-dim check
}
```

With `dims = [2**32, 2**32, 16]` and `dtype.bits = 32` (int32 / 4 bytes):
- Logical size = `4 * 2**32 * 2**32 * 16 = 2**68` bytes
- - 64-bit `size_t` wraps: `total_bytes = 0`
- - Allocator receives 0 bytes; TF treats the tensor as having 2**68 logical bytes
- - Any read/write is heap OOB
## Reachability

`tf.experimental.dlpack.from_dlpack()` is the Python entry point. Any application accepting DLPack tensors from untrusted sources (ML serving endpoints, multi-framework pipelines, etc.) can be attacked.

## Prior art

- Commit `22e07fb` applied the same integer-overflow fix on the **export** path `TFE_HandleToDLPack`. This PR applies the mirror fix on the **import** path `TFE_HandleFromDLPack`.
- - Similar overflow patterns in TFLite were tracked as CVE-2022-23558 and CVE-2022-23559.
## Fix

Before each multiplication, reject negative dimensions and reject dimensions whose product would exceed `SIZE_MAX`:

```cpp
if (dims[i] < 0 ||
    (total_bytes != 0 &&
     static_cast<size_t>(dims[i]) > SIZE_MAX / total_bytes)) {
  status->status = tensorflow::errors::InvalidArgument(
      "DLPack tensor dimensions overflow size_t");
  return nullptr;
}
```

## Tracking

Disclosed to Google Bug Hunters as b/503703564. The ticket initially closed as out-of-scope pending a merged patch; this PR is that patch.

Happy to add a regression test and/or an OSS-Fuzz harness for `TFE_HandleFromDLPack` in a follow-up — let me know which directory you'd prefer for each.