### PR TITLE
Validate size tensor element count in resize_bilinear

### DIFF
--- a/tensorflow/lite/kernels/resize_bilinear.cc
+++ b/tensorflow/lite/kernels/resize_bilinear.cc
@@ -74,6 +74,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // TODO(ahentz): Our current implementations rely on the inputs being 4D.
   TF_LITE_ENSURE_EQ(context, NumDimensions(input), 4);
   TF_LITE_ENSURE_EQ(context, NumDimensions(size), 1);
+  TF_LITE_ENSURE_EQ(context, size->dims->data[0], 2);
 
   TF_LITE_ENSURE_EQ(context, size->type, kTfLiteInt32);
   // ResizeBilinear creates a float tensor even when the input is made of

--- a/tensorflow/lite/kernels/resize_bilinear_test.cc
+++ b/tensorflow/lite/kernels/resize_bilinear_test.cc
@@ -465,5 +465,28 @@ TEST_P(ResizeBilinearOpTest, HorizontalResizeExtremeNegativeValuesInt16) {
 INSTANTIATE_TEST_SUITE_P(ResizeBilinearOpTest, ResizeBilinearOpTest,
                          testing::Values(TestType::kConst, TestType::kDynamic));
 
+TEST(ResizeBilinearOpTest, ModelWithIncorrectSizeTensorShapeIsRejected) {
+#if GTEST_HAS_DEATH_TEST
+  class ResizeBilinearOpModelInvalidSize : public SingleOpModel {
+   public:
+    ResizeBilinearOpModelInvalidSize() {
+      input_ = AddInput({TensorType_FLOAT32, {1, 1, 2, 1}});
+      size_ = AddConstInput(TensorType_INT32, {3}, {1});
+      output_ = AddOutput(TensorType_FLOAT32);
+      SetBuiltinOp(BuiltinOperator_RESIZE_BILINEAR,
+                   BuiltinOptions_ResizeBilinearOptions,
+                   CreateResizeBilinearOptions(builder_, false, false).Union());
+      BuildInterpreter({GetShape(input_)});
+    }
+
+   private:
+    int input_;
+    int size_;
+    int output_;
+  };
+  EXPECT_DEATH(ResizeBilinearOpModelInvalidSize(), "Cannot allocate tensors");
+#endif
+}
+
 }  // namespace
 }  // namespace tflite


### PR DESCRIPTION
## Summary

Ensure the size input tensor contains exactly 2 elements before accessing
them, matching the validation already present in `resize_nearest_neighbor`.

## Test plan

- [ ] Existing resize_bilinear tests pass
- [ ] Model with incorrect size tensor shape is rejected