### PR TITLE
Use overflow-safe multiplication in RuntimeShape::FlatSize

### DIFF
--- a/tensorflow/compiler/mlir/lite/kernels/internal/compatibility_macros.h
+++ b/tensorflow/compiler/mlir/lite/kernels/internal/compatibility_macros.h
@@ -58,6 +58,10 @@ limitations under the License.
 #define TFLITE_DCHECK_LT(x, y) ((x) < (y)) ? (void)0 : TFLITE_ASSERT_FALSE
 #endif
 
+#ifndef TFLITE_CHECK
+#define TFLITE_CHECK(condition) (condition) ? (void)0 : TFLITE_ABORT
+#endif
+
 // LINT.ThenChange(//tensorflow/lite/kernels/internal/compatibility.h)
 
 #endif  // TENSORFLOW_COMPILER_MLIR_LITE_KERNELS_INTERNAL_COMPATIBILITY_MACROS_H_

--- a/tensorflow/compiler/mlir/lite/kernels/internal/compatibility_macros.h
+++ b/tensorflow/compiler/mlir/lite/kernels/internal/compatibility_macros.h
@@ -62,6 +62,10 @@ limitations under the License.
 #define TFLITE_CHECK(condition) (condition) ? (void)0 : TFLITE_ABORT
 #endif
 
+#ifndef TFLITE_CHECK_LE
+#define TFLITE_CHECK_LE(x, y) ((x) <= (y)) ? (void)0 : TFLITE_ABORT
+#endif
+
 // LINT.ThenChange(//tensorflow/lite/kernels/internal/compatibility.h)
 
 #endif  // TENSORFLOW_COMPILER_MLIR_LITE_KERNELS_INTERNAL_COMPATIBILITY_MACROS_H_

--- a/tensorflow/compiler/mlir/lite/kernels/internal/runtime_shape.cc
+++ b/tensorflow/compiler/mlir/lite/kernels/internal/runtime_shape.cc
@@ -82,12 +82,11 @@ void RuntimeShape::ReplaceWith(int dimensions_count, const int32_t* dims_data) {
 }
 
 int RuntimeShape::FlatSize() const {
-  int buffer_size = 1;
-  const int* dims_data = reinterpret_cast<const int*>(DimsData());
-  for (int i = 0; i < size_; i++) {
-    buffer_size *= dims_data[i];
-  }
-  return buffer_size;
+  size_t flat_size;
+  TFLITE_CHECK(CheckedFlatSize(flat_size));
+  TFLITE_CHECK_LE(flat_size,
+                  static_cast<size_t>(std::numeric_limits<int>::max()));
+  return static_cast<int>(flat_size);
 }
 
 bool RuntimeShape::CheckedNumElementsInRange(int start, int end,

--- a/tensorflow/compiler/mlir/lite/kernels/internal/runtime_shape_test.cc
+++ b/tensorflow/compiler/mlir/lite/kernels/internal/runtime_shape_test.cc
@@ -375,6 +375,21 @@ TEST(RuntimeShapeTest, TestCheckedFlatSizeSkipDimRejectsOverflow) {
   EXPECT_FALSE(shape.CheckedFlatSizeSkipDim(/*skip_dim=*/0, flat_size));
 }
 
+TEST(RuntimeShapeTest, TestFlatSizeAbortsOnOverflow) {
+#if GTEST_HAS_DEATH_TEST
+  const RuntimeShape shape({std::numeric_limits<int32_t>::max(),
+                            std::numeric_limits<int32_t>::max()});
+  EXPECT_DEATH(shape.FlatSize(), "");
+#endif
+}
+
+TEST(RuntimeShapeTest, TestFlatSizeAbortsOnNegativeDim) {
+#if GTEST_HAS_DEATH_TEST
+  const RuntimeShape shape({2, -3, 4});
+  EXPECT_DEATH(shape.FlatSize(), "");
+#endif
+}
+
 #ifndef NDEBUG
 TEST(RuntimeShapeTest, NegativeDimensionsCountInConstructor) {
   EXPECT_DEATH(RuntimeShape shape(-1), "");

--- a/tensorflow/lite/kernels/internal/runtime_shape.cc
+++ b/tensorflow/lite/kernels/internal/runtime_shape.cc
@@ -81,12 +81,11 @@ void RuntimeShape::ReplaceWith(int dimensions_count, const int32_t* dims_data) {
 }
 
 int RuntimeShape::FlatSize() const {
-  int buffer_size = 1;
-  const int* dims_data = reinterpret_cast<const int*>(DimsData());
-  for (int i = 0; i < size_; i++) {
-    buffer_size *= dims_data[i];
-  }
-  return buffer_size;
+  size_t flat_size;
+  TFLITE_CHECK(CheckedFlatSize(flat_size));
+  TFLITE_CHECK_LE(flat_size,
+                  static_cast<size_t>(std::numeric_limits<int>::max()));
+  return static_cast<int>(flat_size);
 }
 
 bool RuntimeShape::CheckedNumElementsInRange(int start, int end,

--- a/tensorflow/lite/kernels/internal/runtime_shape_test.cc
+++ b/tensorflow/lite/kernels/internal/runtime_shape_test.cc
@@ -377,6 +377,21 @@ TEST(RuntimeShapeTest, TestCheckedFlatSizeSkipDimRejectsOverflow) {
   EXPECT_FALSE(shape.CheckedFlatSizeSkipDim(/*skip_dim=*/0, flat_size));
 }
 
+TEST(RuntimeShapeTest, TestFlatSizeAbortsOnOverflow) {
+#if GTEST_HAS_DEATH_TEST
+  const RuntimeShape shape({std::numeric_limits<int32_t>::max(),
+                            std::numeric_limits<int32_t>::max()});
+  EXPECT_DEATH(shape.FlatSize(), "");
+#endif
+}
+
+TEST(RuntimeShapeTest, TestFlatSizeAbortsOnNegativeDim) {
+#if GTEST_HAS_DEATH_TEST
+  const RuntimeShape shape({2, -3, 4});
+  EXPECT_DEATH(shape.FlatSize(), "");
+#endif
+}
+
 #ifndef NDEBUG
 TEST(RuntimeShapeTest, NegativeDimensionsCountInConstructor) {
   EXPECT_DEATH(RuntimeShape shape(-1), "");


### PR DESCRIPTION
## Summary

Accumulate the dimension product in `int64_t` and check that the result
fits in `int` after each multiplication. Update both the TFLite and MLIR
copies of `RuntimeShape::FlatSize`.

## Test plan

- [ ] Existing TFLite and MLIR tests pass
- [ ] Shapes with large dimensions that would overflow int32 are handled safely