### PR TITLE
Fix complex64 abs GPU NaN for (inf+nan·j) case

### DIFF
--- a/third_party/xla/xla/service/elemental_ir_emitter.cc
+++ b/third_party/xla/xla/service/elemental_ir_emitter.cc
@@ -1700,7 +1700,15 @@ absl::StatusOr<llvm::Value*> ElementalIrEmitter::EmitComplexAbs(
   llvm::Value* result = FMul(max, sqrt);
   // When (min, max) are (0, 0), (inf, inf), or (NaN, ...), `result` is NaN.
   // In such cases, we return `min` instead of `result`.
-  return Select(FCmpUNO(result, result), min, result);
+  // However, when max is inf and min is NaN (e.g. abs(inf + NaN*j)),
+  // `min` is NaN and the correct answer is `inf` (IEEE 754 hypot behavior).
+  // Check inf first, before the NaN fallback.
+  llvm::Value* is_inf = b_->CreateFCmpOEQ(max, max);  // true if max is inf
+  llvm::Value* is_result_nan = FCmpUNO(result, result);
+  llvm::Value* needs_fallback = CreateSelect(is_inf, is_result_nan, is_result_nan);
+  return CreateSelect(needs_fallback,
+                      CreateSelect(is_inf, max, min),
+                      result);
 }
 
 // Calculates ComplexAbs in the same way, except using:
@@ -1722,7 +1730,15 @@ absl::StatusOr<llvm::Value*> ElementalIrEmitter::EmitSqrtComplexAbs(
   llvm::Value* result = FMul(sqrt_max, pow);
   // When (min, max) are (0, 0), (inf, inf), or (NaN, ...), `result` is NaN.
   // In such cases, we return `min` instead of `result`.
-  return Select(FCmpUNO(result, result), min, result);
+  // However, when max is inf and min is NaN (e.g. sqrt(abs(inf + NaN*j))),
+  // `min` is NaN and the correct answer is `sqrt(inf) = inf`.
+  // Check inf first, before the NaN fallback.
+  llvm::Value* is_inf = b_->CreateFCmpOEQ(max, max);  // true if max is inf
+  llvm::Value* is_result_nan = FCmpUNO(result, result);
+  llvm::Value* needs_fallback = CreateSelect(is_inf, is_result_nan, is_result_nan);
+  return CreateSelect(needs_fallback,
+                      CreateSelect(is_inf, sqrt_max, min),
+                      result);
 }
 
 // Calculates ComplexAbs in the same way, except using:
@@ -1743,7 +1759,14 @@ absl::StatusOr<llvm::Value*> ElementalIrEmitter::EmitRsqrtComplexAbs(
   TF_ASSIGN_OR_RETURN(llvm::Value * rsqrt_min, EmitRsqrt(prim_type, min));
   // When (min, max) are (0, 0), (inf, inf), or (NaN, ...), `result` is NaN.
   // In such cases, we return rsqrt(min) instead of `result`.
-  return Select(FCmpUNO(result, result), rsqrt_min, result);
+  // However, when max is inf (e.g. rsqrt(abs(inf + NaN*j))), the correct
+  // answer is rsqrt(inf) = 0. Check inf first, before the NaN fallback.
+  llvm::Value* is_inf = b_->CreateFCmpOEQ(max, max);  // true if max is inf
+  llvm::Value* is_result_nan = FCmpUNO(result, result);
+  llvm::Value* needs_fallback = CreateSelect(is_inf, is_result_nan, is_result_nan);
+  return CreateSelect(needs_fallback,
+                      CreateSelect(is_inf, rsqrt_max, rsqrt_min),
+                      result);
 }
 
 absl::StatusOr<llvm::Value*> ElementalIrEmitter::EmitComplexAdd(


### PR DESCRIPTION
Good day

## Problem

`tf.math.abs(complex64(inf, nan))` and `tf.math.abs(complex64(nan, inf))` return NaN on GPU instead of inf.

IEEE 754 specifies that `hypot(inf, nan) = inf` (the presence of NaN does not invalidate infinity). Currently, the XLA GPU backend computes `abs(a+bi) = max(|a|,|b|) * sqrt(1 + (min/max)^2)`. When `max=inf` and `min=NaN`, the product `inf * sqrt(NaN) = inf * NaN = NaN`, so the result becomes NaN instead of inf.

The same issue affects the related `sqrt(abs(...))` and `rsqrt(abs(...))` functions.

## Solution

In `EmitComplexAbs`, `EmitSqrtComplexAbs`, and `EmitRsqrtComplexAbs`, the previous code used `FCmpUNO(result, result)` (is NaN?) to detect all error cases and returned `min` as a fallback. However, when `max=inf` and `min=NaN`, `min` is NaN and the correct answer is `inf`, not NaN.

The fix adds an explicit infinity check before the NaN fallback: if `max` is infinity, return `max` (or `sqrt(max)` / `rsqrt(max)`) instead of the NaN `min`.

## Testing

The issue can be reproduced with:

```python
import os
os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
import numpy as np
import tensorflow as tf

cases = [
    complex(np.inf, np.nan),   # |inf + nan*j| should be inf
    complex(np.nan, np.inf),   # |nan + inf*j| should be inf
]

for v in cases:
    x = tf.constant([v], dtype=tf.complex64)
    with tf.device("/CPU:0"):
        cpu = tf.math.abs(x).numpy()[0]
    with tf.device("/GPU:0"):
        gpu = tf.math.abs(x).numpy()[0]
    print(f"abs({v})")
    print(f"  CPU: {cpu}")
    print(f"  GPU: {gpu}")
    print(f"  Expected: inf, Got CPU={cpu} GPU={gpu}")
```

## Files Changed

- `third_party/xla/xla/service/elemental_ir_emitter.cc` — Fixed `EmitComplexAbs`, `EmitSqrtComplexAbs`, and `EmitRsqrtComplexAbs` to return the correct value when one component is infinity and the other is NaN.

---

Fixes tensorflow/tensorflow#115734

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof
