### PR TITLE
Fix heap OOB read in RaggedTensorToTensor when row_splits exceed values size

### DIFF
--- a/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc
+++ b/tensorflow/core/kernels/ragged_tensor_to_tensor_op.cc
@@ -490,6 +490,18 @@ class RaggedTensorToTensorOp : public RaggedTensorToTensorBaseOp<INDEX_TYPE> {
     int value_element_size = element_shape.num_elements();
     size_t output_index_size = output_index.size();
 
+    // Validate that output_index (derived from row_splits) does not reference
+    // more values than the values tensor actually contains. Without this check,
+    // the copy below would read past the values buffer into adjacent heap
+    // memory.
+    const int64_t num_values = values_tensor.dim_size(0);
+    OP_REQUIRES(
+        context, static_cast<int64_t>(output_index_size) <= num_values,
+        errors::InvalidArgument(
+            "row_partition_tensors indicate ", output_index_size,
+            " values, but the values tensor has only ", num_values,
+            " values"));
+
     // Broadcast the default value to value_element_size.  (We can skip this
     // if default_value_tensor.NumElements() == 1, since we use std::fill
     // when that's true.)

--- a/tensorflow/core/kernels/ragged_tensor_to_tensor_op_test.cc
+++ b/tensorflow/core/kernels/ragged_tensor_to_tensor_op_test.cc
@@ -524,6 +524,19 @@ TEST_F(RaggedTensorToTensorOpTest, ShapeWrongDimensions) {
   EXPECT_EQ(absl::IsInvalidArgument(RunOpKernel()), true);
 }
 
+TEST_F(RaggedTensorToTensorOpTest, ValuesFewerThanRowPartition) {
+  BuildRaggedTensorToTensorGraph<float, int32_t>(
+      TensorShape({4, 4}),         // shape
+      {"ROW_SPLITS"},              // row_partition_types
+      createVector<float>({1.0}),  // values
+      createScalar<float>(1.5),                 // default_value
+      {createVector<int32_t>({0, 3, 3, 7, 9})}  // row_partition_tensors
+  );
+  // Fails with an invalid argument because the row partitions indicate
+  // a size that is larger than the values tensor.
+  EXPECT_EQ(absl::IsInvalidArgument(RunOpKernel()), true);
+}
+
 class RaggedTensorToTensorOpUnknownShapeTest
     : public ::tensorflow::OpsTestBase {
  protected:


### PR DESCRIPTION
## Description

Add a bounds check in `SetOutput` to validate that `output_index` (derived from `row_splits`) does not reference more values than the `values` tensor actually contains.

Without this check, when `row_splits` claim more values than exist in the `values` tensor, `copy_array` at line 541 of `ragged_tensor_to_tensor_op.cc` reads past the values buffer into adjacent heap memory, causing a heap buffer over-read (CWE-126).

## Production Attack Scenario

This bug is exploitable through **standard TensorFlow APIs without code execution**. The attacker only needs to upload a crafted data file.

Many production ML pipelines accept user-uploaded TFRecord files and process them with `tf.io.RaggedFeature`, which reads both `values` and `row_splits` as **separate features from the same input file**. The attacker controls both independently.

**Server-side code (trusted, correct):**
```python
feature_spec = {
    'values': tf.io.RaggedFeature(
        dtype=tf.float32,
        value_key='values',
        partitions=[tf.io.RaggedFeature.RowSplits('row_splits')]
    )
}
parsed = tf.io.parse_single_example(record, feature_spec)
dense = parsed['values'].to_tensor()
```

**Attacker's crafted TFRecord (60 bytes):**
```python
example = tf.train.Example(features=tf.train.Features(feature={
    'values': tf.train.Feature(float_list=tf.train.FloatList(value=[0.0])),        # 1 value
    'row_splits': tf.train.Feature(int64_list=tf.train.Int64List(value=[0, 50])),  # claims 50
}))
```

**Result:** The server returns 50 float values, but only 1 is from the input file. The remaining 49 are **heap memory** from the TensorFlow process, potentially containing other users' tensor data.

**Verified:** On TensorFlow 2.16.1, the malicious TFRecord leaks 40 non-trivial heap values including memory addresses and internal TF strings. In multi-tenant serving environments, this can leak other users' sensitive data (financial records, medical data, embeddings).

## Basic PoC (Raw Op)

```python
import tensorflow as tf
result = tf.raw_ops.RaggedTensorToTensor(
    shape=[3, 3],
    values=tf.constant([1.0], dtype=tf.float32),
    default_value=0.0,
    row_partition_tensors=[tf.constant([0, 3, 6, 9], dtype=tf.int64)],
    row_partition_types=["ROW_SPLITS"])
print(result.numpy())
# Output: [[1.0, 6.1209e-41, 0.0], [0.0, 7.0065e-45, 0.0], ...]
# Values like 6.1209e-41 are heap memory leaked through the output.
```

## Fix

Added a check in `SetOutput` that validates `output_index.size() <= values.dim_size(0)` before the copy loop. This returns an `InvalidArgument` error instead of reading out of bounds.

## Testing

Verified on TensorFlow 2.16.1. After the fix, crafted inputs return:
```
InvalidArgument: row_partition_tensors indicate 9 values, but the values tensor has only 1 values
```