### PR TITLE
Fix tf.linalg.logdet to return -inf for singular matrices (Issue #115…

### DIFF
--- a/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
@@ -94,6 +94,32 @@ class LogdetTest(test.TestCase):
           logdet_tf = linalg.logdet(matrix)
           self.assertAllClose(logdet_np, self.evaluate(logdet_tf), atol=atol)
 
+  def test_singular_matrices_return_neg_inf(self):
+    """Test that singular matrices return -inf instead of NaN."""
+    for np_dtype in [np.float32, np.float64, np.complex64, np.complex128]:
+      with self.subTest(np_dtype=np_dtype):
+        # Rank-1 singular matrix (determinant = 0)
+        matrix = np.ones((8, 8), dtype=np_dtype)
+        _, logdet_np = np.linalg.slogdet(matrix)
+        with self.session():
+          logdet_tf = linalg.logdet(matrix)
+          result = self.evaluate(logdet_tf)
+          # Check that result matches NumPy's behavior (-inf for singular matrix)
+          self.assertEqual(result, logdet_np)
+          self.assertEqual(result, -np.inf)
+
+  def test_singular_matrices_batch(self):
+    """Test that batches of singular matrices return -inf."""
+    for np_dtype in [np.float32, np.float64]:
+      with self.subTest(np_dtype=np_dtype):
+        # Batch of singular matrices
+        matrices = np.ones((2, 4, 4), dtype=np_dtype)
+        with self.session():
+          logdet_tf = linalg.logdet(matrices)
+          result = self.evaluate(logdet_tf)
+          # All should be -inf for rank-1 singular matrices
+          np.testing.assert_array_equal(result, [-np.inf, -np.inf])
+
 
 class SlogdetTest(test.TestCase):
 

--- a/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
@@ -104,7 +104,7 @@ class LogdetTest(test.TestCase):
         with self.session():
           logdet_tf = linalg.logdet(matrix)
           result = self.evaluate(logdet_tf)
-          # Match NumPy's behavior (-inf for singular matrix)          
+          # Match NumPy's behavior(-inf for singular matrix)          
           self.assertEqual(result, logdet_np)
           self.assertEqual(result, -np.inf)
 

--- a/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
@@ -104,7 +104,7 @@ class LogdetTest(test.TestCase):
         with self.session():
           logdet_tf = linalg.logdet(matrix)
           result = self.evaluate(logdet_tf)
-          # Check that result matches NumPy's behavior (-inf for singular matrix)
+          # Match NumPy's behavior (-inf for singular matrix)          
           self.assertEqual(result, logdet_np)
           self.assertEqual(result, -np.inf)
 

--- a/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linalg_ops_test.py
@@ -104,7 +104,6 @@ class LogdetTest(test.TestCase):
         with self.session():
           logdet_tf = linalg.logdet(matrix)
           result = self.evaluate(logdet_tf)
-          # Match NumPy's behavior(-inf for singular matrix)          
           self.assertEqual(result, logdet_np)
           self.assertEqual(result, -np.inf)
 

--- a/tensorflow/python/ops/linalg/linalg_impl.py
+++ b/tensorflow/python/ops/linalg/linalg_impl.py
@@ -24,7 +24,6 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import array_ops_stack
 from tensorflow.python.ops import check_ops
 from tensorflow.python.ops import cond as tf_cond
-from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gen_linalg_ops
 from tensorflow.python.ops import linalg_ops
 from tensorflow.python.ops import map_fn

--- a/tensorflow/python/ops/linalg/linalg_impl.py
+++ b/tensorflow/python/ops/linalg/linalg_impl.py
@@ -68,7 +68,7 @@ triangular_solve = linalg_ops.matrix_triangular_solve
 @tf_export('linalg.logdet')
 @dispatch.add_dispatch_support
 def logdet(matrix, name=None):
-  """Computes log of the determinant of a hermitian positive definite matrix.
+  """Computes log of the determinant of a matrix.
 
   ```python
   # Compute the determinant of a matrix while reducing the chance of over- or
@@ -83,20 +83,19 @@ def logdet(matrix, name=None):
     name:  A name to give this `Op`.  Defaults to `logdet`.
 
   Returns:
-    The natural log of the determinant of `matrix`.
+    The natural log of the absolute value of the determinant of `matrix`.
+    For a singular matrix (determinant = 0), returns -inf.
 
   @compatibility(numpy)
-  Equivalent to numpy.linalg.slogdet, although no sign is returned since only
-  hermitian positive definite matrices are supported.
+  Equivalent to np.linalg.slogdet, returning only the log of the absolute 
+  determinant without the sign.
   @end_compatibility
   """
-  # This uses the property that the log det(A) = 2*sum(log(real(diag(C))))
-  # where C is the cholesky decomposition of A.
+  # Uses slogdet which handles singular matrices correctly.
+  # For a singular matrix, returns -inf instead of NaN.
   with ops.name_scope(name, 'logdet', [matrix]):
-    chol = gen_linalg_ops.cholesky(matrix)
-    return 2.0 * math_ops.reduce_sum(
-        math_ops.log(math_ops.real(array_ops.matrix_diag_part(chol))),
-        axis=[-1])
+    sign, log_abs_det = gen_linalg_ops.log_matrix_determinant(matrix)
+    return log_abs_det
 
 
 @tf_export('linalg.adjoint')

--- a/tensorflow/python/ops/linalg/linalg_impl.py
+++ b/tensorflow/python/ops/linalg/linalg_impl.py
@@ -94,7 +94,7 @@ def logdet(matrix, name=None):
   # Uses slogdet which handles singular matrices correctly.
   # For a singular matrix, returns -inf instead of NaN.
   with ops.name_scope(name, 'logdet', [matrix]):
-    sign, log_abs_det = gen_linalg_ops.log_matrix_determinant(matrix)
+    _, log_abs_det = gen_linalg_ops.log_matrix_determinant(matrix)
     return log_abs_det
 
 


### PR DESCRIPTION
## Fixes
Fixes #115768

## Description
This PR fixes an issue where `tf.linalg.logdet` was returning `NaN` for singular matrices instead of `-inf`, which is inconsistent with NumPy's `slogdet` behavior.

## Problem
`tf.linalg.logdet` returns `NaN` for singular matrices (determinant = 0) instead of `-inf`. NumPy correctly returns `-inf`:

```python
import tensorflow as tf
import numpy as np

A = tf.ones((8, 8))  # singular matrix, det=0

# Before fix:
print(tf.linalg.logdet(A))  # nan ❌ (WRONG)
print(np.linalg.slogdet(np.ones((8, 8)))[1])  # -inf ✓ (CORRECT)