### PR TITLE
tflite: fix uint64 addition overflow in external-offset bounds checks

### DIFF
--- a/tensorflow/lite/core/interpreter_builder.cc
+++ b/tensorflow/lite/core/interpreter_builder.cc
@@ -375,9 +375,15 @@ TfLiteStatus InterpreterBuilder::ParseNodes(
         init_data = reinterpret_cast<const char*>(op->custom_options()->data());
         init_data_size = op->custom_options()->size();
       } else if (op->large_custom_options_offset() > 1 && allocation_) {
-        if (op->large_custom_options_offset() +
-                op->large_custom_options_size() >
-            allocation_->bytes()) {
+        // Overflow-safe bounds check. The raw `offset + size > bytes`
+        // check is unsafe because both operands are uint64_t and wrap on
+        // overflow, letting a crafted model pass the check and then
+        // dereference base + offset below. See CVE-2021-29605,
+        // CVE-2022-23558, CVE-2022-23559 for the same class of bug in
+        // this component.
+        if (op->large_custom_options_offset() > allocation_->bytes() ||
+            op->large_custom_options_size() >
+                allocation_->bytes() - op->large_custom_options_offset()) {
           TF_LITE_REPORT_ERROR(
               error_reporter_,
               "Custom Option Offset for opcode_index %d is out of bound\n",
@@ -676,7 +682,13 @@ TfLiteStatus InterpreterBuilder::ParseTensors(
           *buffer_data = reinterpret_cast<const char*>(array->data());
           return kTfLiteOk;
         } else if (offset > 1 && allocation_) {
-          if (offset + buffer->size() > allocation_->bytes()) {
+          // Overflow-safe bounds check; see note above in
+          // large_custom_options branch. A crafted Buffer with
+          // (offset, size) chosen so their uint64_t sum wraps below
+          // allocation_->bytes() would otherwise produce a wild
+          // base + offset pointer that the runtime dereferences.
+          if (offset > allocation_->bytes() ||
+              buffer->size() > allocation_->bytes() - offset) {
             TF_LITE_REPORT_ERROR(
                 error_reporter_,
                 "Constant buffer %d specified an out of range offset.\n",

--- a/tensorflow/lite/core/model_test.cc
+++ b/tensorflow/lite/core/model_test.cc
@@ -39,6 +39,7 @@ limitations under the License.
 #include "tensorflow/lite/schema/schema_generated.h"
 #include "tensorflow/lite/string_util.h"
 #include "tensorflow/lite/testing/util.h"
+#include "tensorflow/lite/version.h"
 
 // Comparison for TfLiteRegistration. Since TfLiteRegistration is a C object,
 // we must declare this in global namespace, so argument-dependent operator

--- a/tensorflow/lite/core/model_test.cc
+++ b/tensorflow/lite/core/model_test.cc
@@ -815,4 +815,65 @@ TEST(BasicFlatBufferModel, TestHandleZeroSizeConstant) {
 // These tests will occur with the evaluation tests of individual operators,
 // not here.
 
+
+// Regression test for the uint64 overflow in interpreter_builder.cc's
+// external-offset bounds checks. A Buffer with (offset, size) chosen so
+// that their uint64_t sum wraps below allocation_->bytes() must be
+// rejected. Prior to the fix the check `offset + size > bytes` wraps
+// silently and the runtime proceeds to dereference a wild pointer.
+TEST(BasicFlatBufferModel, TestBufferOffsetOverflowRejected) {
+  flatbuffers::FlatBufferBuilder fbb;
+
+  // Buffer 0: empty (required by schema).
+  std::vector<flatbuffers::Offset<Buffer>> buffers_vec;
+  buffers_vec.push_back(CreateBuffer(fbb));
+
+  // Buffer 1: malicious. offset = 2**64 - 0x100, size = 0x100. Their
+  // uint64_t sum wraps to 0, which the legacy check would accept.
+  BufferBuilder bb(fbb);
+  bb.add_offset(0xFFFFFFFFFFFFFF00ULL);
+  bb.add_size(0x100ULL);
+  buffers_vec.push_back(bb.Finish());
+  auto buffers = fbb.CreateVector(buffers_vec);
+
+  // Minimal tensor referencing buffer 1.
+  auto shape = fbb.CreateVector<int32_t>({1, 8});
+  auto tname = fbb.CreateString("mal");
+  TensorBuilder tb(fbb);
+  tb.add_shape(shape);
+  tb.add_type(TensorType_FLOAT32);
+  tb.add_buffer(1);
+  tb.add_name(tname);
+  auto tensor = tb.Finish();
+  auto tensors = fbb.CreateVector(std::vector<flatbuffers::Offset<Tensor>>{tensor});
+  auto inputs_outputs = fbb.CreateVector<int32_t>({0});
+
+  SubGraphBuilder sgb(fbb);
+  sgb.add_tensors(tensors);
+  sgb.add_inputs(inputs_outputs);
+  sgb.add_outputs(inputs_outputs);
+  auto subgraph = sgb.Finish();
+  auto subgraphs = fbb.CreateVector(
+      std::vector<flatbuffers::Offset<SubGraph>>{subgraph});
+
+  auto desc = fbb.CreateString("overflow-test");
+  ModelBuilder mb(fbb);
+  mb.add_version(TFLITE_SCHEMA_VERSION);
+  mb.add_subgraphs(subgraphs);
+  mb.add_description(desc);
+  mb.add_buffers(buffers);
+  FinishModelBuffer(fbb, mb.Finish());
+
+  auto model = FlatBufferModel::BuildFromBuffer(
+      reinterpret_cast<const char*>(fbb.GetBufferPointer()), fbb.GetSize());
+  ASSERT_NE(model, nullptr);
+
+  ops::builtin::BuiltinOpResolver resolver;
+  std::unique_ptr<Interpreter> interpreter;
+  TfLiteStatus status = InterpreterBuilder(*model, resolver)(&interpreter);
+  EXPECT_NE(status, kTfLiteOk)
+      << "InterpreterBuilder must reject a Buffer with (offset, size) "
+         "that overflows when added as uint64_t";
+}
+
 }  // namespace tflite


### PR DESCRIPTION
### What

Fixes a pair of unchecked uint64 additions in
`tensorflow/lite/core/interpreter_builder.cc`:

- Line 380, in the `Operator.large_custom_options` path.
- Line 679, in the `Buffer.data` path.

Both sites compute `offset + size` with two `uint64_t` operands and
compare against `size_t` to bound an external-buffer pointer. When the
addition wraps on overflow, the check returns false; the code then
computes the dereference pointer with `allocation_->base() + offset`,
which also wraps. A crafted `.tflite` with `Buffer.offset` set near
`2**64` produces a pointer outside the model's mmap region. Depending
on the offset value, dereferencing it either crashes the process or
reads bytes from an adjacent memory mapping.

### How

Replace both `offset + size > bytes` checks with overflow-safe
arithmetic:

```cpp
if (offset > allocation_->bytes() ||
    size > allocation_->bytes() - offset) {
  return kTfLiteError;
}
```

No behavioural change for valid models: for any `(offset, size)` where
`offset + size <= allocation_->bytes()` without wrapping, the new
predicate and the old predicate agree.

### Class of bug

This is the same class of issue previously patched under
CVE-2021-29605, CVE-2022-23558, and CVE-2022-23559. Those fixes
targeted `int`-based arithmetic on user-controlled tensor metadata;
this change extends the same overflow-safe pattern to the
64-bit external-offset feature (`Buffer.offset`, `Buffer.size`,
`Operator.large_custom_options_offset`,
`Operator.large_custom_options_size`) added after those patches.

### Test

`TestBufferOffsetOverflowRejected`, added to
`tensorflow/lite/core/model_test.cc`, builds a minimal FlatBuffer model
with `Buffer[1].offset = 0xFFFFFFFFFFFFFF00` and `Buffer[1].size = 0x100`
(so the uint64 sum wraps to 0, which the pre-fix check accepts) and
asserts `InterpreterBuilder(*model, resolver)(&interpreter)` returns
non-Ok. The same arithmetic pattern covers the `large_custom_options`
path by construction.

To run:

```bash
bazel test //tensorflow/lite/core:model_test --test_filter=\
  BasicFlatBufferModel.TestBufferOffsetOverflowRejected
```