### PR TITLE
Grappler: don't rewrite ArgMin/ArgMax over non-strictly-monotonic ops

### DIFF
--- a/tensorflow/core/grappler/op_types.cc
+++ b/tensorflow/core/grappler/op_types.cc
@@ -225,8 +225,12 @@ bool IsDivNoNan(const NodeDef& node) { return node.op() == "DivNoNan"; }
 // Returns true if node represents a unary elementwise function that is
 // monotonic. If *is_non_decreasing is true, the function is non-decreasing,
 // e.g. sqrt, exp. *is_non_decreasing is false, the function is non-increasing,
-// e.g. inv.
-bool IsElementWiseMonotonic(const NodeDef& node, bool* is_non_decreasing) {
+// e.g. inv. If *is_strict is true, the function is strictly monotonic
+// (a < b => f(a) < f(b) for non-decreasing, or f(a) > f(b) for
+// non-increasing). Ops with flat regions (e.g. Relu, Floor) are monotonic
+// but not strictly monotonic.
+bool IsElementWiseMonotonic(const NodeDef& node, bool* is_non_decreasing,
+                            bool* is_strict) {
   static const gtl::FlatSet<std::string>* const kMonotonicNonDecreasingOps =
       CHECK_NOTNULL((new gtl::FlatSet<std::string>{
           "Acosh", "Asin", "Asinh",    "Atan",     "Atanh", "Ceil",
@@ -237,18 +241,27 @@ bool IsElementWiseMonotonic(const NodeDef& node, bool* is_non_decreasing) {
   static const gtl::FlatSet<std::string>* const kMonotonicNonIncreasingOps =
       CHECK_NOTNULL(
           (new gtl::FlatSet<std::string>{"Acos", "Erfc", "Neg", "Rsqrt"}));
-  if (kMonotonicNonDecreasingOps->count(node.op()) > 0) {
-    if (is_non_decreasing) {
-      *is_non_decreasing = true;
-    }
-    return true;
-  } else if (kMonotonicNonIncreasingOps->count(node.op()) > 0) {
-    if (is_non_decreasing) {
-      *is_non_decreasing = false;
-    }
-    return true;
+  // Subset of the above that have flat regions and are therefore monotonic
+  // but not strictly monotonic. Transformations that depend on tie-breaking
+  // (e.g. ArgMin/ArgMax) are unsafe for these ops.
+  static const gtl::FlatSet<std::string>* const kNonStrictMonotonicOps =
+      CHECK_NOTNULL((new gtl::FlatSet<std::string>{
+          "Ceil", "Floor", "Relu", "Relu6", "Rint", "Sign",
+      }));
+  const bool is_non_decreasing_op =
+      kMonotonicNonDecreasingOps->count(node.op()) > 0;
+  const bool is_non_increasing_op =
+      kMonotonicNonIncreasingOps->count(node.op()) > 0;
+  if (!is_non_decreasing_op && !is_non_increasing_op) {
+    return false;
   }
-  return false;
+  if (is_non_decreasing) {
+    *is_non_decreasing = is_non_decreasing_op;
+  }
+  if (is_strict) {
+    *is_strict = kNonStrictMonotonicOps->count(node.op()) == 0;
+  }
+  return true;
 }
 
 bool IsElu(const NodeDef& node) { return node.op() == "Elu"; }

--- a/tensorflow/core/grappler/op_types.h
+++ b/tensorflow/core/grappler/op_types.h
@@ -73,7 +73,8 @@ bool IsDepthwiseConv2dNativeBackpropInput(const NodeDef& node);
 bool IsDequeueOp(const NodeDef& node);
 bool IsDiv(const NodeDef& node);
 bool IsDivNoNan(const NodeDef& node);
-bool IsElementWiseMonotonic(const NodeDef& node, bool* is_non_decreasing);
+bool IsElementWiseMonotonic(const NodeDef& node, bool* is_non_decreasing,
+                            bool* is_strict = nullptr);
 bool IsElu(const NodeDef& node);
 bool IsEluGrad(const NodeDef& node);
 bool IsQuantizationEmulation(const NodeDef& node);

--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc
@@ -3548,6 +3548,10 @@ class OptimizeMaxOrMinOfMonotonicStage : public ArithmeticOptimizerStage {
     //    since we don't have MinPool operations.
     // 4. inner_functions is not a Relu node with an input from FusedBatchNorm
     //    or BiasAdd. This pattern will be fused later by remapper.
+    // 5. inner_function is strictly monotonic if the reduction is
+    //    ArgMin/ArgMax. Non-strictly-monotonic ops (e.g. Relu, Floor) have
+    //    flat regions where ties resolve to a different index than the
+    //    underlying input, breaking the rewrite (issue #116436).
     auto can_be_fused_by_remapper = [](const NodeDef& consumer,
                                        const NodeDef& producer) -> bool {
       if (IsRelu(consumer) || IsRelu6(consumer)) {
@@ -3558,8 +3562,13 @@ class OptimizeMaxOrMinOfMonotonicStage : public ArithmeticOptimizerStage {
       return false;
     };
     bool is_non_decreasing = false;
+    bool is_strict = false;
+    const bool is_arg_reduction =
+        IsArgMax(*reduction_node) || IsArgMin(*reduction_node);
     if (!IsInPreserveSet(*inner_function) &&
-        IsElementWiseMonotonic(*inner_function, &is_non_decreasing) &&
+        IsElementWiseMonotonic(*inner_function, &is_non_decreasing,
+                               &is_strict) &&
+        (!is_arg_reduction || is_strict) &&
         ctx().node_map->GetOutputs(inner_function->name()).size() == 1 &&
         (is_non_decreasing || !IsAnyMaxPool(*reduction_node)) &&
         !can_be_fused_by_remapper(*inner_function, *inner_function_input)) {

--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
@@ -4043,6 +4043,37 @@ TEST_F(ArithmeticOptimizerTest, OptimizeArgMaxOrArgMinOfMonotonicElementWise) {
 }
 
 TEST_F(ArithmeticOptimizerTest,
+       OptimizeArgMaxOrArgMinOfMonotonicElementWiseDoNotChangeNonStrict) {
+  // ArgMin(Relu(x)) must not be rewritten to ArgMin(x): Relu's flat region
+  // creates ties that resolve to a different index. See issue #116436.
+  tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+  const auto x =
+      ops::Const(s.WithOpName("x"), {1.0f, -1.0f, -5.0f, 2.0f}, {1, 4});
+  Output relu = ops::Relu(s.WithOpName("relu"), x);
+  Output arg_min = ops::ArgMin(s.WithOpName("arg_min"), relu, 1);
+  Output final_out = ops::Identity(s.WithOpName("final_out"), arg_min);
+
+  GrapplerItem item;
+  item.fetch = {"final_out"};
+  TF_CHECK_OK(s.ToGraphDef(&item.graph));
+  const auto tensors_expected = EvaluateNodes(item.graph, item.fetch);
+  ASSERT_EQ(tensors_expected.size(), 1);
+
+  GraphDef output;
+  ArithmeticOptimizer optimizer;
+  EnableOnlyOptimizeMaxOrMinOfMonotonic(&optimizer);
+  OptimizeTwice(&optimizer, &item, &output);
+
+  // Optimizer must leave the graph unchanged for non-strictly-monotonic ops
+  // feeding ArgMin/ArgMax.
+  VerifyGraphsMatch(item.graph, output, __LINE__);
+
+  const auto tensors = EvaluateNodes(output, item.fetch);
+  ASSERT_EQ(tensors.size(), 1);
+  test::ExpectTensorEqual<int64_t>(tensors[0], tensors_expected[0]);
+}
+
+TEST_F(ArithmeticOptimizerTest,
        OptimizeMaxOrMinOfMonotonicElementWiseDoNotChangeFetchNode) {
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
   auto x = ops::Const(s.WithOpName("x"), {1.0f, 2.0f}, {1, 2});


### PR DESCRIPTION
## Summary

- `OptimizeMaxOrMinOfMonotonicStage` rewrites `ArgMin(f(x)) -> ArgMin(x)` for any op tagged monotonic, but the rewrite is only valid when `f` is **strictly** monotonic. Ops like `Relu`, `Relu6`, `Floor`, `Ceil`, `Rint`, and `Sign` have flat regions: their ties resolve to a different index than the underlying input, so the rewrite returns the wrong index.
- `IsElementWiseMonotonic` now exposes an optional `is_strict` out-parameter that flags the non-strict subset. The optimizer uses it to skip the rewrite when the reduction is `ArgMin`/`ArgMax` and `f` is non-strict. Value-reduction rewrites (`Max`/`Min`/`MaxPool`) are unchanged because they only depend on the reduced value, not the index.

Fixes #116436.

## Test plan

Relying on internal CI to run the added test:

- `bazel test //tensorflow/core/grappler/optimizers:arithmetic_optimizer_test` — added `OptimizeArgMaxOrArgMinOfMonotonicElementWiseDoNotChangeNonStrict` covering `ArgMin(Relu(x))`; existing `OptimizeArgMaxOrArgMinOfMonotonicElementWise` (Sqrt — strict) should still pass.
- Repro from the issue: `tf.argmin(tf.nn.relu(x), axis=-1)` with `arithmetic_optimization=True` should return the same index as eager mode.