### PR TITLE
Remove setuptools from runtime dependencies

### DIFF
--- a/tensorflow/tools/pip_package/setup.py.tpl
+++ b/tensorflow/tools/pip_package/setup.py.tpl
@@ -105,7 +105,6 @@ REQUIRED_PACKAGES = [
     'packaging',
     'protobuf >= 6.31.1, < 8.0.0',
     'requests >= 2.21.0, < 3',
-    'setuptools',
     'six >= 1.12.0',
     'termcolor >= 1.1.0',
     'typing_extensions >= 3.6.6',


### PR DESCRIPTION
### Description: 
This PR removes setuptools from the list of required packages in the TensorFlow pip package setup template (tensorflow/tools/pip_package/setup.py.tpl).

setuptools is primarily a build and development dependency. By removing it from the runtime requirements, we prevent it from being unnecessarily installed for users when they run pip install tensorflow, which reduces the overall footprint and aligns with modern Python packaging best practices.

closes:#116860
