### PR TITLE
Validate SparseTensorDenseMatMul dense_shape before output allocation

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -5358,6 +5358,7 @@ tf_cuda_cc_tests(
     deps = [
         ":host_constant_op",
         ":ops_testutil",
+        "//tensorflow/core/framework:fake_input",
         ":ops_util",
         ":sparse",
         ":xent_op",

--- a/tensorflow/core/kernels/sparse_tensor_dense_matmul_op.cc
+++ b/tensorflow/core/kernels/sparse_tensor_dense_matmul_op.cc
@@ -81,6 +81,13 @@ class SparseTensorDenseMatMulOp : public OpKernel {
                     "number of entries in a_shape"));
 
     auto a_shape_t = a_shape->vec<int64_t>();
+    // `a_shape` is runtime-provided, so validate its logical dimensions before
+    // using them in shape arithmetic or output allocation.
+    OP_REQUIRES(
+        ctx, a_shape_t(0) >= 0 && a_shape_t(1) >= 0,
+        absl::InvalidArgumentError(absl::StrCat(
+            "Tensor 'a_shape' cannot contain negative dimensions, but got [",
+            a_shape_t(0), ", ", a_shape_t(1), "]")));
     const int64_t outer_left = (adjoint_a_) ? a_shape_t(1) : a_shape_t(0);
     const int64_t outer_right =
         (adjoint_b_) ? b->shape().dim_size(0) : b->shape().dim_size(1);

--- a/tensorflow/core/kernels/sparse_tensor_dense_matmul_op_test.cc
+++ b/tensorflow/core/kernels/sparse_tensor_dense_matmul_op_test.cc
@@ -14,10 +14,14 @@ limitations under the License.
 ==============================================================================*/
 
 #include <random>
+#include <vector>
 
+#include "absl/status/status.h"
 #include "tensorflow/core/common_runtime/kernel_benchmark_testlib.h"
+#include "tensorflow/core/framework/node_def_builder.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/graph/node_builder.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
 #include "tensorflow/core/platform/test.h"
 #include "tensorflow/core/platform/test_benchmark.h"
 
@@ -67,6 +71,46 @@ static Graph* SparseTensorDenseMatmul(int nnz, int m, int k, int n,
       test::graph::Constant(g, b), adjoint_a, adjoint_b);
   return g;
 }
+
+
+namespace {
+
+using ::testing::HasSubstr;
+
+class SparseTensorDenseMatMulOpValidationTest : public OpsTestBase {
+ protected:
+  void MakeOp(bool adjoint_a = false, bool adjoint_b = false) {
+    TF_ASSERT_OK(NodeDefBuilder("sparse_tensor_dense_matmul",
+                                "SparseTensorDenseMatMul")
+                     .Input(FakeInput(DT_INT64))
+                     .Input(FakeInput(DT_FLOAT))
+                     .Input(FakeInput(DT_INT64))
+                     .Input(FakeInput(DT_FLOAT))
+                     .Attr("T", DT_FLOAT)
+                     .Attr("adjoint_a", adjoint_a)
+                     .Attr("adjoint_b", adjoint_b)
+                     .Finalize(node_def()));
+    TF_ASSERT_OK(InitOp());
+  }
+};
+
+TEST_F(SparseTensorDenseMatMulOpValidationTest,
+       RejectsNegativeDimensionsInSparseShape) {
+  MakeOp();
+  AddInputFromArray<int64_t>(TensorShape({0, 2}), std::vector<int64_t>{});
+  AddInputFromArray<float>(TensorShape({0}), std::vector<float>{});
+  AddInputFromArray<int64_t>(TensorShape({2}), {1, -1});
+  AddInputFromArray<float>(TensorShape({1, 1}), {1.0f});
+
+  const absl::Status status = RunOpKernel();
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_THAT(
+      status.message(),
+      HasSubstr("Tensor 'a_shape' cannot contain negative dimensions"));
+}
+
+}  // namespace
 
 // NOLINTBEGIN
 #define BM_SparseTensorDenseMatmulDev(NNZ, M, K, N, TA, TB, DEVICE)                  \

--- a/tensorflow/core/kernels/sparse_tensor_dense_matmul_op_test.cc
+++ b/tensorflow/core/kernels/sparse_tensor_dense_matmul_op_test.cc
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "absl/status/status.h"
 #include "tensorflow/core/common_runtime/kernel_benchmark_testlib.h"
+#include "tensorflow/core/framework/fake_input.h"
 #include "tensorflow/core/framework/node_def_builder.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/graph/node_builder.h"


### PR DESCRIPTION
Fixes #112752.

This patch makes SparseTensorDenseMatMul fail fast when the input SparseTensor has a negative value in dense_shape.

This commit adds an explicit validation check for negative dimensions before any output shape arithmetic or allocation happens. For valid inputs, behavior is unchanged. For invalid inputs, the op now returns InvalidArgument, which is much easier to reason about and matches expected TensorFlow error handling.