### PR TITLE
lite: update TF_MINOR_VERSION to 21 in version.h

### DIFF
--- a/tensorflow/lite/version.h
+++ b/tensorflow/lite/version.h
@@ -24,7 +24,7 @@ limitations under the License.
 #define TF_MAJOR_VERSION 2
 #endif
 #ifndef TF_MINOR_VERSION
-#define TF_MINOR_VERSION 19
+#define TF_MINOR_VERSION 21
 #endif
 #ifndef TF_PATCH_VERSION
 #define TF_PATCH_VERSION 0


### PR DESCRIPTION
### Description
This PR fixes issue #116676 where `TfLiteVersion()` reports an outdated version string. 

During recent release cuts, the hardcoded `TF_MINOR_VERSION` macro in `tensorflow/lite/version.h` was overlooked. This PR bumps the fallback minor version to `21`.

**Note for Reviewers:** 
My IDE flagged that the canonical version on the `master` branch (`tensorflow/tf_version.bzl`) is currently `2.22.0`. I have bumped this specific file to `21` to fix the reported bug for the `2.21.0` release. 
* If you would prefer I bump this to `22` for the `master` branch so you can `cherry-pick` it back to `r2.21`, please let me know and I will update the commit immediately!

### Motivation and Context
Fixes #116676