### PR TITLE
fix keras backend: avoid catastrophic cancellation in elu for small negative inputs

### DIFF
--- a/tensorflow/python/keras/backend.py
+++ b/tensorflow/python/keras/backend.py
@@ -4654,7 +4654,10 @@ def elu(x, alpha=1.):
   if alpha == 1:
     return res
   else:
-    return array_ops.where_v2(x > 0, res, alpha * res)
+    # Use exp(x) - 1 for negative values to avoid catastrophic cancellation
+    # that occurs with alpha * res when res = exp(x) - 1 is near zero
+    x = math_ops.cast(x, res.dtype)
+    return array_ops.where_v2(x > 0, res, alpha * (math_ops.exp(x) - 1.0))
 
 
 @dispatch.add_dispatch_support


### PR DESCRIPTION
Fixes catastrophic cancellation in tf.nn.selu and tf.nn.elu that caused them to return 0 for small negative inputs (e.g. x=-1e-8). When alpha != 1, elu computed alpha * nn.elu(x) = alpha * (exp(x) - 1) for negative values, which loses precision when exp(x) - 1 is near zero. Using alpha * (exp(x) - 1) directly from x avoids this.