### PR TITLE
fix math_ops: use float64 for complex_abs in sign() to avoid underflow for small inputs

### DIFF
--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -807,13 +807,16 @@ def sign(x, name=None):
   """
   x = ops.convert_to_tensor(x)
   if x.dtype.is_complex:
+    # Use float64 for magnitude computation to avoid underflow for small complex64 values.
+    # |z| = sqrt(re² + im²) computed as float32 underflows for |z| < ~1.08e-19 (near sqrt(float32_min)),
+    # causing sign(0) instead of sign(x/|x|).
+    # Use float64 for intermediate magnitude regardless of input dtype.
     return gen_math_ops.div_no_nan(
         x,
         cast(
             gen_math_ops.complex_abs(
                 x,
-                Tout=dtypes.float32
-                if x.dtype == dtypes.complex64 else dtypes.float64),
+                Tout=dtypes.float64),  # Always use float64 to avoid underflow for small inputs
             dtype=x.dtype),
         name=name)
   return gen_math_ops.sign(x, name=name)
@@ -4699,7 +4702,7 @@ def sparse_segment_sum(
   tf.sparse.segment_sum(c, tf.constant([0, 1]), tf.constant([0, 0]))
   # => [[0 0 0 0]]
 
-  # Select two rows, two segment.
+  # Select two rows, two segments.
   tf.sparse.segment_sum(c, tf.constant([0, 1]), tf.constant([0, 1]))
   # => [[ 1  2  3  4]
   #     [-1 -2 -3 -4]]
@@ -4983,7 +4986,7 @@ def sparse_segment_sum_v2(
   tf.sparse.segment_sum(c, tf.constant([0, 1]), tf.constant([0, 0]))
   # => [[0 0 0 0]]
 
-  # Select two rows, two segment.
+  # Select two rows, two segments.
   tf.sparse.segment_sum(c, tf.constant([0, 1]), tf.constant([0, 1]))
   # => [[ 1  2  3  4]
   #     [-1 -2 -3 -4]]

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -820,15 +820,17 @@ def sign(x, name=None):
     #       smallest normal value, even when the divisor is computed in
     #       float64.
     # Casting the input itself to complex128 lifts both computations above
-    # the underflow threshold (~1e-154), and the kernel signatures match
-    # cleanly. The final result is cast back to the original dtype.
+    # the underflow threshold (~1e-154). The DivNoNan C++ kernel requires
+    # both operands to share the same dtype, so the float64 magnitude from
+    # complex_abs is cast back to complex128 before division. The final
+    # result is cast back to the original dtype.
     compute_dtype = dtypes.complex128
     x_compute = cast(x, compute_dtype) if x.dtype != compute_dtype else x
+    magnitude = cast(
+        gen_math_ops.complex_abs(x_compute, Tout=dtypes.float64),
+        compute_dtype)
     return cast(
-        gen_math_ops.div_no_nan(
-            x_compute,
-            gen_math_ops.complex_abs(x_compute, Tout=dtypes.float64),
-            name=name),
+        gen_math_ops.div_no_nan(x_compute, magnitude, name=name),
         dtype=x.dtype)
   return gen_math_ops.sign(x, name=name)
 

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -807,18 +807,29 @@ def sign(x, name=None):
   """
   x = ops.convert_to_tensor(x)
   if x.dtype.is_complex:
-    # Use float64 for magnitude computation to avoid underflow for small complex64 values.
-    # |z| = sqrt(re² + im²) computed as float32 underflows for |z| < ~1.08e-19 (near sqrt(float32_min)),
-    # causing sign(0) instead of sign(x/|x|).
-    # Use float64 for intermediate magnitude regardless of input dtype.
-    return gen_math_ops.div_no_nan(
-        x,
-        cast(
-            gen_math_ops.complex_abs(
-                x,
-                Tout=dtypes.float64),  # Always use float64 to avoid underflow for small inputs
-            dtype=x.dtype),
-        name=name)
+    # Promote to complex128 for the entire computation to avoid underflow for
+    # small complex64 values. Two distinct underflow hazards must be addressed:
+    #   (1) |z| = sqrt(re^2 + im^2) computed via complex_abs on complex64
+    #       underflows to 0 for |z| < ~1.08e-19 (sqrt(float32_min)). The
+    #       ComplexAbs C++ kernel also rejects mismatched input/output
+    #       precision (e.g. complex64 -> float64), so we cannot simply ask
+    #       the kernel for a float64 magnitude while feeding it complex64.
+    #   (2) The vectorized complex division (div_no_nan) involves an
+    #       intermediate conjugate product that still underflows on FTZ
+    #       systems when the divisor's magnitude is below the input dtype's
+    #       smallest normal value, even when the divisor is computed in
+    #       float64.
+    # Casting the input itself to complex128 lifts both computations above
+    # the underflow threshold (~1e-154), and the kernel signatures match
+    # cleanly. The final result is cast back to the original dtype.
+    compute_dtype = dtypes.complex128
+    x_compute = cast(x, compute_dtype) if x.dtype != compute_dtype else x
+    return cast(
+        gen_math_ops.div_no_nan(
+            x_compute,
+            gen_math_ops.complex_abs(x_compute, Tout=dtypes.float64),
+            name=name),
+        dtype=x.dtype)
   return gen_math_ops.sign(x, name=name)
 
 

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -1290,8 +1290,10 @@ class SignTest(test_util.TensorFlowTestCase):
         x = constant_op.constant(tiny + tiny * 1j, dtype=dtype)
         y = math_ops.sign(x)
         # Result should be x/|x| = (1+1j)/sqrt(2), not 0.
-        expected = np.complex(tiny, tiny) / np.abs(np.complex(tiny, tiny))
-        self.assertAllClose(y.numpy(), expected.astype(expected_dtype), atol=1e-6)
+        # Use builtin complex() instead of np.complex (deprecated in NumPy 1.20+).
+        expected = np.array(complex(tiny, tiny) / abs(complex(tiny, tiny)),
+                            dtype=expected_dtype)
+        self.assertAllClose(y.numpy(), expected, atol=1e-6)
         self.assertEqual(y.dtype.base_dtype, expected_dtype)
 
       # Also verify zero still returns zero (no division by zero crash).

--- a/tensorflow/python/ops/math_ops_test.py
+++ b/tensorflow/python/ops/math_ops_test.py
@@ -1277,6 +1277,27 @@ class SignTest(test_util.TensorFlowTestCase):
       self.assertAllClose(
           t.gradient(y, x), math_ops.complex(0.353553, -0.353553))
 
+  def test_complex_sign_tiny_no_underflow(self):
+    # Regression test for tf#116945: tf.math.sign returned 0 for small complex64
+    # inputs because complex_abs computed |z|^2 in float32, which underflows to
+    # 0 for |z| < ~1.08e-19. With the fix, the entire computation is promoted
+    # to complex128 and the result is cast back to the input dtype.
+    with context.eager_mode():
+      # |z| = sqrt(2) * 1e-20 ~= 1.41e-20, well below float32 underflow.
+      tiny = 1e-20
+      for dtype, expected_dtype in [(np.complex64, np.complex64),
+                                    (np.complex128, np.complex128)]:
+        x = constant_op.constant(tiny + tiny * 1j, dtype=dtype)
+        y = math_ops.sign(x)
+        # Result should be x/|x| = (1+1j)/sqrt(2), not 0.
+        expected = np.complex(tiny, tiny) / np.abs(np.complex(tiny, tiny))
+        self.assertAllClose(y.numpy(), expected.astype(expected_dtype), atol=1e-6)
+        self.assertEqual(y.dtype.base_dtype, expected_dtype)
+
+      # Also verify zero still returns zero (no division by zero crash).
+      z = constant_op.constant(0 + 0j, dtype=np.complex64)
+      self.assertAllEqual(math_ops.sign(z).numpy(), np.complex64(0))
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class ReciprocalNoNanTest(test_util.TensorFlowTestCase):


### PR DESCRIPTION
Fixes tf#116945: tf.math.sign returns 0 for small nonzero complex64 inputs in eager mode. Root cause: complex_abs computed |z|² as float32, which underflows to subnormal/zero for |z| < ~1.08e-19, causing sign(0) instead of sign(x/|x|). Fix: always use float64 for intermediate magnitude computation.