### PR TITLE
fix(tf2xla): propagate NaNs in min/max ops

### DIFF
--- a/tensorflow/compiler/tests/binary_ops_test.py
+++ b/tensorflow/compiler/tests/binary_ops_test.py
@@ -478,17 +478,15 @@ class BinaryOpsTest(xla_test.XLATestCase):
                             dtype=np.int64))
 
   def testMaximumMinimumPropagateNan(self):
-    if np.float32 not in self.float_types:
-      return
-    dtype = np.float32
-    values = np.array([[np.nan, 1.0], [5.0, np.nan]], dtype=dtype)
-    finite = np.array([2.0, 3.0], dtype=dtype)
-    maximum_expected = np.array([[np.nan, 3.0], [5.0, np.nan]], dtype=dtype)
-    minimum_expected = np.array([[np.nan, 1.0], [2.0, np.nan]], dtype=dtype)
-    self._testBinary(math_ops.maximum, values, finite, expected=maximum_expected)
-    self._testBinary(math_ops.maximum, finite, values, expected=maximum_expected)
-    self._testBinary(math_ops.minimum, values, finite, expected=minimum_expected)
-    self._testBinary(math_ops.minimum, finite, values, expected=minimum_expected)
+    for dtype in self.float_types:
+      values = np.array([[np.nan, 1.0], [5.0, np.nan]], dtype=dtype)
+      finite = np.array([2.0, 3.0], dtype=dtype)
+      maximum_expected = np.array([[np.nan, 3.0], [5.0, np.nan]], dtype=dtype)
+      minimum_expected = np.array([[np.nan, 1.0], [2.0, np.nan]], dtype=dtype)
+      self._testBinary(math_ops.maximum, values, finite, expected=maximum_expected)
+      self._testBinary(math_ops.maximum, finite, values, expected=maximum_expected)
+      self._testBinary(math_ops.minimum, values, finite, expected=minimum_expected)
+      self._testBinary(math_ops.minimum, finite, values, expected=minimum_expected)
 
   def testNextAfter(self):
     for dtype in self.numeric_types:

--- a/tensorflow/compiler/tests/binary_ops_test.py
+++ b/tensorflow/compiler/tests/binary_ops_test.py
@@ -477,6 +477,19 @@ class BinaryOpsTest(xla_test.XLATestCase):
           expected=np.array([1 << 32, 1 << 36, 1 << 32, 1 << 36],
                             dtype=np.int64))
 
+  def testMaximumMinimumPropagateNan(self):
+    if np.float32 not in self.float_types:
+      return
+    dtype = np.float32
+    values = np.array([[np.nan, 1.0], [5.0, np.nan]], dtype=dtype)
+    finite = np.array([2.0, 3.0], dtype=dtype)
+    maximum_expected = np.array([[np.nan, 3.0], [5.0, np.nan]], dtype=dtype)
+    minimum_expected = np.array([[np.nan, 1.0], [2.0, np.nan]], dtype=dtype)
+    self._testBinary(math_ops.maximum, values, finite, expected=maximum_expected)
+    self._testBinary(math_ops.maximum, finite, values, expected=maximum_expected)
+    self._testBinary(math_ops.minimum, values, finite, expected=minimum_expected)
+    self._testBinary(math_ops.minimum, finite, values, expected=minimum_expected)
+
   def testNextAfter(self):
     for dtype in self.numeric_types:
       if dtype in [np.float32, np.float64]:

--- a/tensorflow/compiler/tests/reduce_ops_test.py
+++ b/tensorflow/compiler/tests/reduce_ops_test.py
@@ -146,21 +146,22 @@ class ReduceOpsTest(xla_test.XLATestCase, parameterized.TestCase):
                           self.REAL_DATA, index_dtype)
 
   def testReduceMinMaxPropagateNan(self, index_dtype):
-    test_input = np.array([[np.nan, 4.0], [2.0, 3.0]], dtype=np.float32)
-    with self.session() as sess:
-      with self.test_scope():
-        a = array_ops.placeholder(np.float32)
-        index = array_ops.placeholder(index_dtype)
-        min_out = math_ops.reduce_min(a, index)
-        max_out = math_ops.reduce_max(a, index)
+    for dtype in self.float_types:
+      test_input = np.array([[np.nan, 4.0], [2.0, 3.0]], dtype=dtype)
+      with self.session() as sess:
+        with self.test_scope():
+          a = array_ops.placeholder(dtypes.as_dtype(dtype))
+          index = array_ops.placeholder(index_dtype)
+          min_out = math_ops.reduce_min(a, index)
+          max_out = math_ops.reduce_max(a, index)
 
-      min_result, max_result = sess.run(
-          [min_out, max_out], {a: test_input, index: [0]})
+        min_result, max_result = sess.run(
+            [min_out, max_out], {a: test_input, index: [0]})
 
-      self.assertTrue(np.isnan(min_result[0]))
-      self.assertEqual(min_result[1], 3.0)
-      self.assertTrue(np.isnan(max_result[0]))
-      self.assertEqual(max_result[1], 4.0)
+        self.assertTrue(np.isnan(min_result[0]))
+        self.assertAllClose(min_result[1], 3.0)
+        self.assertTrue(np.isnan(max_result[0]))
+        self.assertAllClose(max_result[1], 4.0)
 
   def testReduceMeanF32(self, index_dtype):
     # TODO(phawkins): mean on XLA currently returns 0 instead of NaN when

--- a/tensorflow/compiler/tests/reduce_ops_test.py
+++ b/tensorflow/compiler/tests/reduce_ops_test.py
@@ -145,6 +145,23 @@ class ReduceOpsTest(xla_test.XLATestCase, parameterized.TestCase):
                           functools.partial(reference_max, dtype), dtype,
                           self.REAL_DATA, index_dtype)
 
+  def testReduceMinMaxPropagateNan(self, index_dtype):
+    test_input = np.array([[np.nan, 4.0], [2.0, 3.0]], dtype=np.float32)
+    with self.session() as sess:
+      with self.test_scope():
+        a = array_ops.placeholder(np.float32)
+        index = array_ops.placeholder(index_dtype)
+        min_out = math_ops.reduce_min(a, index)
+        max_out = math_ops.reduce_max(a, index)
+
+      min_result, max_result = sess.run(
+          [min_out, max_out], {a: test_input, index: [0]})
+
+      self.assertTrue(np.isnan(min_result[0]))
+      self.assertEqual(min_result[1], 3.0)
+      self.assertTrue(np.isnan(max_result[0]))
+      self.assertEqual(max_result[1], 4.0)
+
   def testReduceMeanF32(self, index_dtype):
     # TODO(phawkins): mean on XLA currently returns 0 instead of NaN when
     # reducing across zero inputs.

--- a/tensorflow/compiler/tf2xla/kernels/binary_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/binary_ops.cc
@@ -107,6 +107,16 @@ static xla::XlaOp MulNoNanImpl(xla::XlaBuilder* b, DataType dtype, xla::XlaOp x,
 XLA_MAKE_BINARY(MulNoNan,
                 MulNoNanImpl(b, input_type(0), lhs, rhs, broadcast_helper));
 
+static xla::XlaOp MinMaxImpl(DataType dtype, bool is_max, xla::XlaOp x,
+                             xla::XlaOp y, const BCast& broadcast_helper) {
+  std::tie(x, y) = XlaBinaryOp::Broadcast(x, y, broadcast_helper);
+  xla::XlaOp result = is_max ? xla::Max(x, y) : xla::Min(x, y);
+  if (!DataTypeIsFloating(dtype)) {
+    return result;
+  }
+  return xla::Select(xla::IsNan(x), x, xla::Select(xla::IsNan(y), y, result));
+}
+
 // Implementation of FloorDiv.
 //
 // For floating-point values, simply returns floor(x / y).  For integers, does:
@@ -204,8 +214,12 @@ XLA_MAKE_BINARY(RightShift,
 XLA_MAKE_BINARY(LogicalAnd, xla::And(lhs, rhs, extend_dimensions));
 XLA_MAKE_BINARY(LogicalOr, xla::Or(lhs, rhs, extend_dimensions));
 XLA_MAKE_BINARY(Mod, xla::Rem(lhs, rhs, extend_dimensions));
-XLA_MAKE_BINARY(Maximum, xla::Max(lhs, rhs, extend_dimensions));
-XLA_MAKE_BINARY(Minimum, xla::Min(lhs, rhs, extend_dimensions));
+XLA_MAKE_BINARY(Maximum,
+                MinMaxImpl(input_type(0), /*is_max=*/true, lhs, rhs,
+                           broadcast_helper));
+XLA_MAKE_BINARY(Minimum,
+                MinMaxImpl(input_type(0), /*is_max=*/false, lhs, rhs,
+                           broadcast_helper));
 XLA_MAKE_BINARY(RealDiv, xla::Div(lhs, rhs, extend_dimensions));
 XLA_MAKE_BINARY(ReciprocalGrad, xla::Neg(xla::Mul(rhs, xla::Mul(lhs, lhs))));
 XLA_MAKE_BINARY(

--- a/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/reduction_ops.cc
@@ -25,7 +25,9 @@ limitations under the License.
 #include "tensorflow/compiler/tf2xla/xla_helpers.h"
 #include "tensorflow/compiler/tf2xla/xla_op_registry.h"
 #include "xla/hlo/builder/lib/constants.h"
+#include "xla/hlo/builder/lib/math.h"
 #include "xla/hlo/builder/xla_builder.h"
+#include "xla/primitive_util.h"
 #include "xla/shape.h"
 #include "xla/xla_data.pb.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -35,6 +37,19 @@ limitations under the License.
 
 namespace tensorflow {
 namespace {
+
+xla::XlaOp MinMaxWithNanPropagation(xla::PrimitiveType type, bool is_max,
+                                    const xla::XlaOp& scalar_lhs,
+                                    const xla::XlaOp& scalar_rhs) {
+  xla::XlaOp result =
+      is_max ? xla::Max(scalar_lhs, scalar_rhs)
+             : xla::Min(scalar_lhs, scalar_rhs);
+  if (!xla::primitive_util::IsFloatingPointType(type)) {
+    return result;
+  }
+  return xla::Select(xla::IsNan(scalar_lhs), scalar_lhs,
+                     xla::Select(xla::IsNan(scalar_rhs), scalar_rhs, result));
+}
 
 class SumOp : public XlaReductionOp {
  public:
@@ -83,7 +98,8 @@ class MinOp : public XlaReductionOp {
 
   void BuildReducer(xla::XlaBuilder* builder, const xla::XlaOp& scalar_lhs,
                     const xla::XlaOp& scalar_rhs) override {
-    xla::Min(scalar_lhs, scalar_rhs);
+    MinMaxWithNanPropagation(xla_reduction_type_, /*is_max=*/false, scalar_lhs,
+                             scalar_rhs);
   }
 };
 
@@ -116,7 +132,8 @@ class MaxOp : public XlaReductionOp {
 
   void BuildReducer(xla::XlaBuilder* builder, const xla::XlaOp& scalar_lhs,
                     const xla::XlaOp& scalar_rhs) override {
-    xla::Max(scalar_lhs, scalar_rhs);
+    MinMaxWithNanPropagation(xla_reduction_type_, /*is_max=*/true, scalar_lhs,
+                             scalar_rhs);
   }
 };
 


### PR DESCRIPTION
Fixes #116992

Summary:
- propagate NaNs explicitly for XLA Maximum/Minimum kernels
- propagate NaNs explicitly for XLA ReduceMin/ReduceMax reducer bodies
- add regression tests for binary maximum/minimum and reduce min/max NaN behavior

Test plan:
- git diff --check
- python3 -m py_compile tensorflow/compiler/tests/binary_ops_test.py tensorflow/compiler/tests/reduce_ops_test.py
- bazel tests not run locally: bazel is not installed in this environment