### PR TITLE
Fix MapUnstageNoKey crash on out-of-range index (#112757)

### DIFF
--- a/tensorflow/core/kernels/map_stage_op.cc
+++ b/tensorflow/core/kernels/map_stage_op.cc
@@ -448,10 +448,10 @@ class StagingMap : public ResourceBase {
 
     auto it = map_.begin();
 
+    *key = it->first;
+
     TF_RETURN_IF_ERROR(
         copy_or_move_tensors(&it->second, *key, *indices, tuple));
-
-    *key = it->first;
 
     // Remove entry if all the values have been consumed
     if (!std::any_of(

--- a/tensorflow/python/kernel_tests/data_structures/map_stage_op_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/map_stage_op_test.py
@@ -655,6 +655,69 @@ class MapStageTest(test.TestCase):
       )
       self.evaluate(v)
 
+  def testMapUnstageNoKeyOutOfRangeIndex(self):
+    # MapUnstageNoKey with an out-of-range index after MapStage must surface
+    # a normal InvalidArgumentError from check_index(), not a fatal CHECK
+    # inside Tensor::CheckIsAlignedAndSingleElement. The CHECK can fire if
+    # popitem() reaches copy_or_move_tensors() with an empty local key
+    # tensor, because check_index() formats its error using
+    # key.scalar<int64_t>()() and Tensor::scalar() requires a 1-element
+    # tensor.
+    data_flow_ops.gen_data_flow_ops.map_stage(
+        key=constant_op.constant([1], dtype=dtypes.int64),
+        indices=constant_op.constant([0], dtype=dtypes.int32),
+        values=[constant_op.constant([1.0], dtype=dtypes.float32)],
+        dtypes=[dtypes.float32],
+        capacity=10,
+        memory_limit=0,
+        container='',
+        shared_name='test_map_unstage_no_key_oob',
+        name=None,
+    )
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError, 'out of bounds'
+    ):
+      result = data_flow_ops.gen_data_flow_ops.map_unstage_no_key(
+          indices=[1],
+          dtypes=[dtypes.int64, dtypes.float32],
+          capacity=10,
+          memory_limit=0,
+          container='',
+          shared_name='test_map_unstage_no_key_oob',
+          name=None,
+      )
+      self.evaluate(result)
+
+  def testOrderedMapUnstageNoKeyOutOfRangeIndex(self):
+    # Parallel coverage for the ordered variant. OrderedMapUnstageNoKey
+    # shares StagingMap::popitem() with MapUnstageNoKey via the
+    # StagingMap<bool Ordered> template, so the same out-of-range-index
+    # path must surface InvalidArgumentError rather than abort.
+    data_flow_ops.gen_data_flow_ops.ordered_map_stage(
+        key=constant_op.constant([1], dtype=dtypes.int64),
+        indices=constant_op.constant([0], dtype=dtypes.int32),
+        values=[constant_op.constant([1.0], dtype=dtypes.float32)],
+        dtypes=[dtypes.float32],
+        capacity=10,
+        memory_limit=0,
+        container='',
+        shared_name='test_ordered_map_unstage_no_key_oob',
+        name=None,
+    )
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError, 'out of bounds'
+    ):
+      result = data_flow_ops.gen_data_flow_ops.ordered_map_unstage_no_key(
+          indices=[1],
+          dtypes=[dtypes.int64, dtypes.float32],
+          capacity=10,
+          memory_limit=0,
+          container='',
+          shared_name='test_ordered_map_unstage_no_key_oob',
+          name=None,
+      )
+      self.evaluate(result)
+
 
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/kernel_tests/data_structures/map_stage_op_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/map_stage_op_test.py
@@ -663,7 +663,7 @@ class MapStageTest(test.TestCase):
     # tensor, because check_index() formats its error using
     # key.scalar<int64_t>()() and Tensor::scalar() requires a 1-element
     # tensor.
-    data_flow_ops.gen_data_flow_ops.map_stage(
+    stage_op = data_flow_ops.gen_data_flow_ops.map_stage(
         key=constant_op.constant([1], dtype=dtypes.int64),
         indices=constant_op.constant([0], dtype=dtypes.int32),
         values=[constant_op.constant([1.0], dtype=dtypes.float32)],
@@ -674,6 +674,7 @@ class MapStageTest(test.TestCase):
         shared_name='test_map_unstage_no_key_oob',
         name=None,
     )
+    self.evaluate(stage_op)
     with self.assertRaisesRegex(
         errors.InvalidArgumentError, 'out of bounds'
     ):
@@ -693,7 +694,7 @@ class MapStageTest(test.TestCase):
     # shares StagingMap::popitem() with MapUnstageNoKey via the
     # StagingMap<bool Ordered> template, so the same out-of-range-index
     # path must surface InvalidArgumentError rather than abort.
-    data_flow_ops.gen_data_flow_ops.ordered_map_stage(
+    stage_op = data_flow_ops.gen_data_flow_ops.ordered_map_stage(
         key=constant_op.constant([1], dtype=dtypes.int64),
         indices=constant_op.constant([0], dtype=dtypes.int32),
         values=[constant_op.constant([1.0], dtype=dtypes.float32)],
@@ -704,6 +705,7 @@ class MapStageTest(test.TestCase):
         shared_name='test_ordered_map_unstage_no_key_oob',
         name=None,
     )
+    self.evaluate(stage_op)
     with self.assertRaisesRegex(
         errors.InvalidArgumentError, 'out of bounds'
     ):


### PR DESCRIPTION
## Overview

Fixes #112757. `tf.raw_ops.MapUnstageNoKey(indices=[1])` after `MapStage(...)` aborts the Python process with SIGABRT (exit 134) and a fatal CHECK in `tensor.cc`, instead of raising `tf.errors.InvalidArgumentError`.

This is a reliability bug, not a security issue per [`SECURITY.md`](https://github.com/tensorflow/tensorflow/blob/master/SECURITY.md). A recoverable `InvalidArgument` path was already designed into `check_index()`, but `popitem()` short-circuits it with a fatal CHECK before the InvalidArgument can be returned. The fix restores the intended error path.

The bug is still present on current master (`c67d2e09`). The buggy ordering at `tensorflow/core/kernels/map_stage_op.cc:451-454` is identical to v2.21.0.

### Proposed Fix

See the commit. In `StagingMap::popitem()`, assign `*key = it->first;` before calling `copy_or_move_tensors(...)` so `check_index()` has a 1-element key tensor when it formats its error message. Two-line reorder, no other behavior changes.

## Additional Information

### Root Cause Analysis

In `StagingMap::popitem()` (`map_stage_op.cc`), the local key tensor gets passed to `copy_or_move_tensors(&it->second, *key, *indices, tuple)` before `*key = it->first`. For an out-of-range index, `copy_or_move_tensors()` calls `check_index(key, index)`. `check_index()` builds the `InvalidArgument` message with `key.scalar<int64_t>()()` (`map_stage_op.cc:170`). On a zero-element key tensor, `Tensor::scalar()` calls `CheckIsAlignedAndSingleElement()`, whose `CHECK_EQ(1, NumElements())` fails (1 vs. 0) and aborts the process.

## Reproduction

PoC matching the issue's gist:

```python
import tensorflow as tf

tf.raw_ops.MapStage(
    key=tf.constant([1], dtype=tf.int64),
    indices=tf.constant([0], dtype=tf.int32),
    values=[tf.constant([1.0], dtype=tf.float32)],
    dtypes=[tf.float32],
    capacity=10, memory_limit=0, container="", shared_name="test_map",
)

tf.raw_ops.MapUnstageNoKey(
    indices=[1],
    dtypes=[tf.int64, tf.float32],
    capacity=10, memory_limit=0, container="", shared_name="test_map",
)
```

Pre-patch crash:

```
F0000 ... tensor.cc:904] Check failed: 1 == NumElements() (1 vs. 0) Must have a one element tensor
*** Check failure stack trace: ***
    @ ... tensorflow::Tensor::CheckIsAlignedAndSingleElement()
    @ ... tensorflow::(anonymous namespace)::StagingMap<>::copy_or_move_tensors()
    @ ... tensorflow::(anonymous namespace)::MapUnstageNoKeyOp<>::Compute()
[exit 134]
```

## Regression Test

This PR adds `MapStageTest.testMapUnstageNoKeyOutOfRangeIndex` and `MapStageTest.testOrderedMapUnstageNoKeyOutOfRangeIndex` in `tensorflow/python/kernel_tests/data_structures/map_stage_op_test.py`. Each test stages one float32 value at index 0 with int64 key 1, calls the corresponding `*MapUnstageNoKey(indices=[1])` op, and asserts the result is an `InvalidArgumentError` matching `"out of bounds"`. The ordered variant covers `OrderedMapUnstageNoKeyOp<true>`, which shares `StagingMap::popitem()` with the unordered `MapUnstageNoKeyOp<false>` via the `StagingMap<bool Ordered>` template, so both call into the same buggy path. Without the fix both tests crash the Python process. With the fix `check_index()` returns `InvalidArgument("Index '1' for key '1' was out of bounds '1'.")`, formatted at `map_stage_op.cc:169-171`.

The sibling ops `MapUnstageOp` and `MapPeekOp` (and their ordered variants) are not affected, because they call `map->pop(key_tensor, ...)` / `map->peek(key_tensor, ...)` with a user-supplied scalar key after an explicit `OP_REQUIRES(IsScalar(...))` check at `map_stage_op.cc:592-594`, so the empty-key path cannot be reached there.

## Independent Verification

A Docker image with `tensorflow-cpu==2.21.0` preinstalled and the issue's PoC bundled is available for independent verification:

```bash
docker pull songtli/secb.eval.x86_64.tensorflow.issue-112757:patch
```

In that container I confirmed master HEAD `c67d2e09` still has the buggy ordering, the patch applies cleanly, both regression tests reproduce the abort on the unpatched 2.21.0 wheel, all 17 existing `MapStageTest` tests still pass, and `clang-format --style=google` produces zero replacements. Detailed transcripts in a follow-up comment. Bazel-from-source runtime verification of the patched binary is left to TF CI.

## Requirements

- [x] I have read the [contributing guidelines](https://github.com/tensorflow/tensorflow/blob/master/CONTRIBUTING.md)
