### PR TITLE
changing some outdated NumPy API

### DIFF
--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_metal_plugin_test.py
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_metal_plugin_test.py
@@ -3861,7 +3861,7 @@ class Relu6Test(test.TestCase):
   def testNumbersGPU(self):
     if not test.is_gpu_available():
       self.skipTest("No GPU available")
-    for t in [np.float16, np.float64, np.double]:
+    for t in [np.float16, np.float32, np.double]:
       print(t)
       self._testRelu6(
           np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t)

--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_metal_plugin_test.py
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_metal_plugin_test.py
@@ -21,6 +21,7 @@ limitations under the License.
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-class-docstring
 # pylint: disable=protected-access
+# pylint: disable=too-many-function-args
 # pylint: disable=invalid-unary-operand-type
 from __future__ import absolute_import
 from __future__ import division

--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_metal_plugin_test.py
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_metal_plugin_test.py
@@ -21,6 +21,7 @@ limitations under the License.
 # pylint: disable=missing-function-docstring
 # pylint: disable=missing-class-docstring
 # pylint: disable=protected-access
+# pylint: disable=invalid-unary-operand-type
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/tensorflow/tools/ci_build/osx/arm64/tensorflow_metal_plugin_test.py
+++ b/tensorflow/tools/ci_build/osx/arm64/tensorflow_metal_plugin_test.py
@@ -2458,7 +2458,7 @@ class BroadcastToTest(test_util.TensorFlowTestCase):
   @test_util.run_deprecated_v1
   def testBroadcastScalarToNonScalar(self):
     with self.session(use_gpu=True):
-      x = np.array(1.0, dtype=np.float)
+      x = np.array(1.0, dtype=np.float64)
       v_tf = array_ops.broadcast_to(
           constant_op.constant(1.0), [2, 3, 4, 1, 1, 1]
       )
@@ -3860,7 +3860,7 @@ class Relu6Test(test.TestCase):
   def testNumbersGPU(self):
     if not test.is_gpu_available():
       self.skipTest("No GPU available")
-    for t in [np.float16, np.float, np.double]:
+    for t in [np.float16, np.float64, np.double]:
       print(t)
       self._testRelu6(
           np.array([[-9, 7, -5, 3, -1], [1, -3, 5, -7, 9]]).astype(t)
@@ -5341,8 +5341,8 @@ class SelectOpTest(test.TestCase):
         # care is taken with choosing the inputs and the delta. This is
         # a weaker check (in particular, it does not test the op itself,
         # only its gradient), but it's much better than nothing.
-        self._compareGradientX(fn, c, xt, yt, np.float)
-        self._compareGradientY(fn, c, xt, yt, np.float)
+        self._compareGradientX(fn, c, xt, yt, np.float64)
+        self._compareGradientY(fn, c, xt, yt, np.float64)
       else:
         self._compareGradientX(fn, c, xt, yt)
         self._compareGradientY(fn, c, xt, yt)
@@ -5835,7 +5835,7 @@ class MpsTest(test.TestCase):
         jacob_t, _ = gradient_checker.compute_gradient(
             inx, s, y, s, x_init_value=x
         )
-        xf = x.astype(np.float)
+        xf = x.astype(np.float64)
         inxf = ops.convert_to_tensor(xf)
         yf = tf_func(inxf)
         _, jacob_n = gradient_checker.compute_gradient(


### PR DESCRIPTION
### What this PR changes

This PR replaces outdated NumPy aliases and removed APIs with their supported equivalents.

NumPy 1.24 expired the deprecation for aliases such as `np.float`, `np.object`, and `np.str`:
https://numpy.org/doc/stable/release/1.24.0-notes.html

NumPy 2.0 removed APIs such as `np.cast` and `np.string_`:
https://numpy.org/doc/stable/release/2.0.0-notes.html

### Why

The current requirements use newer numpy versions, where those references may fail or be no longer supported. Updating them improves compatibility with and NumPy 2.x, which is the one used in all requirements files.

Most changes were 
`np.float` to  `np.float64`.

If the PR passes the checks, i may continue chaning outdated API