### PR TITLE
Fix XLA searchsorted side='right' for NaN values

### DIFF
--- a/tensorflow/compiler/tests/searchsorted_op_test.py
+++ b/tensorflow/compiler/tests/searchsorted_op_test.py
@@ -42,6 +42,25 @@ class SearchSorteddOpTest(xla_test.XLATestCase):
           tf_out = session.run(tf_ans)
           self.assertAllEqual(np_ans, tf_out)
 
+  def testNanValue(self):
+    for dtype in self.float_types:
+      sorted_sequence = np.array([[1, 3, 5, 7, 9]], dtype)
+      values = np.array([[np.nan]], dtype)
+
+      self._test2DExample(
+          dtype,
+          'left',
+          sorted_sequence,
+          values,
+          np.array([[0]], dtype=np.int32))
+
+      self._test2DExample(
+          dtype,
+          'right',
+          sorted_sequence,
+          values,
+          np.array([[5]], dtype=np.int32))
+
   def _test2DExample(self, dtype, side, sorted_sequence, values, correct_ans):
 
     with self.session() as session:

--- a/tensorflow/compiler/tf2xla/kernels/lower_upper_bound_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/lower_upper_bound_ops.cc
@@ -16,13 +16,13 @@ limitations under the License.
 #include "tensorflow/compiler/tf2xla/xla_helpers.h"
 #include "tensorflow/compiler/tf2xla/xla_op_kernel.h"
 #include "tensorflow/compiler/tf2xla/xla_op_registry.h"
-#include "xla/comparison_util.h"
-#include "xla/hlo/builder/xla_builder.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/op_requires.h"
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/types.pb.h"
 #include "tensorflow/core/platform/errors.h"
+#include "xla/comparison_util.h"
+#include "xla/hlo/builder/xla_builder.h"
 
 namespace tensorflow {
 namespace {
@@ -32,7 +32,8 @@ namespace {
 // Note that this is an O(MN) algorithm: all entries in each sorted_inputs row
 // are considered, and their sorted nature is not fully exploited.
 void BuildLowerUpperBoundOp(XlaOpKernelContext* ctx, DataType out_dtype,
-                            xla::ComparisonDirection comparison_direction) {
+                            xla::ComparisonDirection comparison_direction,
+                            bool nan_values_compare_greater = false) {
   const TensorShape sorted_inputs_shape = ctx->InputShape("sorted_inputs");
   const TensorShape values_shape = ctx->InputShape("values");
   const xla::XlaOp sorted_inputs = ctx->Input("sorted_inputs");
@@ -64,7 +65,13 @@ void BuildLowerUpperBoundOp(XlaOpKernelContext* ctx, DataType out_dtype,
   // dimensions are not explicitly specified.
   auto comparison = xla::Compare(values_reshaped, sorted_inputs_reshaped, {},
                                  comparison_direction);
-
+  if (nan_values_compare_greater) {
+    // Match eager searchsorted side='right' behavior for NaN search values.
+    // A NaN search value is placed after all entries in the sorted input row.
+    auto value_is_nan = xla::Compare(values_reshaped, values_reshaped, {},
+                                     xla::ComparisonDirection::kNe);
+    comparison = xla::Or(comparison, value_is_nan);
+  }
   const DataType accumulation_type = XlaHelpers::SumAccumulationType(out_dtype);
 
   // Convert boolean comparison results to integers so we can sum them.
@@ -104,7 +111,8 @@ class UpperBoundOp : public XlaOpKernel {
   }
 
   void Compile(XlaOpKernelContext* ctx) override {
-    BuildLowerUpperBoundOp(ctx, out_dtype_, xla::ComparisonDirection::kGe);
+    BuildLowerUpperBoundOp(ctx, out_dtype_, xla::ComparisonDirection::kGe,
+                           /*nan_values_compare_greater=*/true);
   }
 
  private:


### PR DESCRIPTION
Fixes #117804

This fixes an inconsistency between eager TensorFlow and XLA for
`tf.searchsorted(..., side="right")` when the search value is `NaN`

The XLA lowering for `UpperBound` was using `value >= sorted_input` to count the
matching positions. For `NaN`, that comparison is false for every sorted input
value, so XLA returned `0`

Eager TensorFlow places a `NaN` search value at the end of the row for
`side="right"`. This change keeps the existing comparison logic, but treats
`NaN` search values as greater than all sorted input values for `UpperBound`

I also added a regression test covering both `side="left"` and `side="right"`

Tested with:

`bazel test //tensorflow/compiler/tests:searchsorted_op_test_cpu --repo_env=HERMETIC_PYTHON_VERSION=3.12 --macos_sdk_version=15.5 --jobs=4 --local_ram_resources=4096`