### PR TITLE
Replace generic Exception with specific exception types in speech_commands

### DIFF
--- a/tensorflow/examples/speech_commands/freeze.py
+++ b/tensorflow/examples/speech_commands/freeze.py
@@ -79,7 +79,7 @@ def create_inference_graph(wanted_words, sample_rate, clip_duration_ms,
     Input and output tensor objects.
 
   Raises:
-    Exception: If the preprocessing mode isn't recognized.
+    ValueError: If the preprocessing mode isn't recognized.
   """
 
   words_list = input_data.prepare_words_list(wanted_words.split(','))
@@ -115,7 +115,7 @@ def create_inference_graph(wanted_words, sample_rate, clip_duration_ms,
         dct_coefficient_count=model_settings['fingerprint_width'])
   elif preprocess == 'micro':
     if not frontend_op:
-      raise Exception(
+      raise ImportError(
           'Micro frontend op is currently not available when running TensorFlow'
           ' directly from Python, you need to build and run through Bazel, for'
           ' example'
@@ -137,7 +137,7 @@ def create_inference_graph(wanted_words, sample_rate, clip_duration_ms,
         out_type=tf.float32)
     fingerprint_input = tf.multiply(micro_frontend, (10.0 / 256.0))
   else:
-    raise Exception('Unknown preprocess mode "%s" (should be "mfcc",'
+    raise ValueError('Unknown preprocess mode "%s" (should be "mfcc",'
                     ' "average", or "micro")' % (preprocess))
 
   fingerprint_size = model_settings['fingerprint_size']
@@ -234,7 +234,7 @@ def main(_):
   elif FLAGS.save_format == 'saved_model':
     save_saved_model(FLAGS.output_file, sess, input_tensor, output_tensor)
   else:
-    raise Exception('Unknown save format "%s" (should be "graph_def" or'
+    raise ValueError('Unknown save format "%s" (should be "graph_def" or'
                     ' "saved_model")' % (FLAGS.save_format))
 
 

--- a/tensorflow/examples/speech_commands/input_data.py
+++ b/tensorflow/examples/speech_commands/input_data.py
@@ -294,7 +294,7 @@ class AudioProcessor(object):
       raise FileNotFoundError('No .wavs found at ' + search_path)
     for index, wanted_word in enumerate(wanted_words):
       if wanted_word not in all_words:
-        raise FileNotFoundError('Expected to find ' + wanted_word +
+        raise ValueError('Expected to find ' + wanted_word +
                          ' in labels but only found ' +
                          ', '.join(all_words.keys()))
     # We need an arbitrary file to load as the input for the silence samples.

--- a/tensorflow/examples/speech_commands/input_data.py
+++ b/tensorflow/examples/speech_commands/input_data.py
@@ -162,7 +162,7 @@ def get_features_range(model_settings):
     Min/max float pair holding the range of features.
 
   Raises:
-    Exception: If preprocessing mode isn't recognized.
+    ValueError: If preprocessing mode isn't recognized.
   """
   # TODO(petewarden): These values have been derived from the observed ranges
   # of spectrogram and MFCC inputs. If the preprocessing pipeline changes,
@@ -177,7 +177,7 @@ def get_features_range(model_settings):
     features_min = 0.0
     features_max = 26.0
   else:
-    raise Exception('Unknown preprocess mode "%s" (should be "mfcc",'
+    raise ValueError('Unknown preprocess mode "%s" (should be "mfcc",'
                     ' "average", or "micro")' % (model_settings['preprocess']))
   return features_min, features_max
 
@@ -263,7 +263,7 @@ class AudioProcessor(object):
       and a lookup map for each class to determine its numeric index.
 
     Raises:
-      Exception: If expected files are not found.
+      FileNotFoundError: If expected files are not found.
     """
     # Make sure the shuffling and picking of unknowns is deterministic.
     random.seed(RANDOM_SEED)
@@ -291,12 +291,12 @@ class AudioProcessor(object):
       else:
         unknown_index[set_index].append({'label': word, 'file': wav_path})
     if not all_words:
-      raise Exception('No .wavs found at ' + search_path)
+      raise FileNotFoundError('No .wavs found at ' + search_path)
     for index, wanted_word in enumerate(wanted_words):
       if wanted_word not in all_words:
-        raise Exception('Expected to find ' + wanted_word +
-                        ' in labels but only found ' +
-                        ', '.join(all_words.keys()))
+        raise FileNotFoundError('Expected to find ' + wanted_word +
+                         ' in labels but only found ' +
+                         ', '.join(all_words.keys()))
     # We need an arbitrary file to load as the input for the silence samples.
     # It's multiplied by zero later, so the content doesn't matter.
     silence_wav_path = self.data_index['training'][0]['file']
@@ -341,7 +341,7 @@ class AudioProcessor(object):
       List of raw PCM-encoded audio samples of background noise.
 
     Raises:
-      Exception: If files aren't found in the folder.
+      FileNotFoundError: If files aren't found in the folder.
     """
     self.background_data = []
     background_dir = os.path.join(self.data_dir, BACKGROUND_NOISE_DIR_NAME)
@@ -359,7 +359,8 @@ class AudioProcessor(object):
             feed_dict={wav_filename_placeholder: wav_path}).audio.flatten()
         self.background_data.append(wav_data)
       if not self.background_data:
-        raise Exception('No background wav files were found in ' + search_path)
+        raise FileNotFoundError(
+            'No background wav files were found in ' + search_path)
 
   def prepare_processing_graph(self, model_settings, summaries_dir):
     """Builds a TensorFlow graph to apply the input distortions.
@@ -385,7 +386,7 @@ class AudioProcessor(object):
 
     Raises:
       ValueError: If the preprocessing mode isn't recognized.
-      Exception: If the preprocessor wasn't compiled in.
+      ImportError: If the preprocessor wasn't compiled in.
     """
     with tf.compat.v1.get_default_graph().name_scope('data'):
       desired_samples = model_settings['desired_samples']
@@ -455,7 +456,7 @@ class AudioProcessor(object):
             'mfcc', tf.expand_dims(self.output_, -1), max_outputs=1)
       elif model_settings['preprocess'] == 'micro':
         if not frontend_op:
-          raise Exception(
+          raise ImportError(
               'Micro frontend op is currently not available when running'
               ' TensorFlow directly from Python, you need to build and run'
               ' through Bazel')

--- a/tensorflow/examples/speech_commands/input_data_test.py
+++ b/tensorflow/examples/speech_commands/input_data_test.py
@@ -110,7 +110,7 @@ class InputDataTest(test.TestCase):
   def testPrepareDataIndexEmpty(self):
     tmp_dir = self.get_temp_dir()
     self._saveWavFolders(tmp_dir, ["a", "b", "c"], 0)
-    with self.assertRaises(Exception) as e:
+    with self.assertRaises(FileNotFoundError) as e:
       _ = input_data.AudioProcessor("", tmp_dir, 10, 10, ["a", "b"], 10, 10,
                                     self._model_settings(), tmp_dir)
     self.assertIn("No .wavs found", str(e.exception))
@@ -118,7 +118,7 @@ class InputDataTest(test.TestCase):
   def testPrepareDataIndexMissing(self):
     tmp_dir = self.get_temp_dir()
     self._saveWavFolders(tmp_dir, ["a", "b", "c"], 100)
-    with self.assertRaises(Exception) as e:
+    with self.assertRaises(ValueError) as e:
       _ = input_data.AudioProcessor("", tmp_dir, 10, 10, ["a", "b", "d"], 10,
                                     10, self._model_settings(), tmp_dir)
     self.assertIn("Expected to find", str(e.exception))

--- a/tensorflow/examples/speech_commands/models.py
+++ b/tensorflow/examples/speech_commands/models.py
@@ -120,7 +120,7 @@ def create_model(fingerprint_input, model_settings, model_architecture,
     placeholder.
 
   Raises:
-    Exception: If the architecture type isn't recognized.
+    ValueError: If the architecture type isn't recognized.
   """
   if model_architecture == 'single_fc':
     return create_single_fc_model(fingerprint_input, model_settings,
@@ -140,10 +140,10 @@ def create_model(fingerprint_input, model_settings, model_architecture,
     return create_tiny_embedding_conv_model(fingerprint_input, model_settings,
                                             is_training)
   else:
-    raise Exception('model_architecture argument "' + model_architecture +
-                    '" not recognized, should be one of "single_fc", "conv",' +
-                    ' "low_latency_conv, "low_latency_svdf",' +
-                    ' "tiny_conv", or "tiny_embedding_conv"')
+    raise ValueError('model_architecture argument "' + model_architecture +
+                     '" not recognized, should be one of "single_fc", "conv",' +
+                     ' "low_latency_conv, "low_latency_svdf",' +
+                     ' "tiny_conv", or "tiny_embedding_conv"')
 
 
 def load_variables_from_checkpoint(sess, start_checkpoint):

--- a/tensorflow/examples/speech_commands/models_test.py
+++ b/tensorflow/examples/speech_commands/models_test.py
@@ -94,7 +94,7 @@ class ModelsTest(test.TestCase):
     model_settings = self._modelSettings()
     with self.cached_session():
       fingerprint_input = tf.zeros([1, model_settings["fingerprint_size"]])
-      with self.assertRaises(Exception) as e:
+      with self.assertRaises(ValueError) as e:
         models.create_model(fingerprint_input, model_settings,
                             "bad_architecture", True)
       self.assertIn("not recognized", str(e.exception))

--- a/tensorflow/examples/speech_commands/train.py
+++ b/tensorflow/examples/speech_commands/train.py
@@ -111,7 +111,7 @@ def main(_):
   training_steps_list = list(map(int, FLAGS.how_many_training_steps.split(',')))
   learning_rates_list = list(map(float, FLAGS.learning_rate.split(',')))
   if len(training_steps_list) != len(learning_rates_list):
-    raise Exception(
+    raise ValueError(
         '--how_many_training_steps and --learning_rate must be equal length '
         'lists, but are %d and %d long instead' % (len(training_steps_list),
                                                    len(learning_rates_list)))
@@ -171,7 +171,7 @@ def main(_):
           learning_rate_input, .9,
           use_nesterov=True).minimize(cross_entropy_mean)
     else:
-      raise Exception('Invalid Optimizer')
+      raise ValueError('Invalid Optimizer')
   predicted_indices = tf.argmax(input=logits, axis=1)
   correct_prediction = tf.equal(predicted_indices, ground_truth_input)
   confusion_matrix = tf.math.confusion_matrix(labels=ground_truth_input,


### PR DESCRIPTION
## Description

Replace bare `raise Exception(...)` with appropriate built-in exception types across the `speech_commands` example code in `tensorflow/examples/speech_commands/`.

### Changes

| File | Lines Changed | Old -> New Exception | Reason |
|------|--------------|---------------------|--------|
| `train.py` | L114, L174 | `Exception` -> `ValueError` | Invalid/mismatched argument values |
| `models.py` | L143 | `Exception` -> `ValueError` | Unrecognized model architecture argument |
| `freeze.py` | L118 | `Exception` -> `ImportError` | Missing Bazel-built micro frontend op |
| `freeze.py` | L140, L237 | `Exception` -> `ValueError` | Unknown preprocess mode / save format |
| `input_data.py` | L180 | `Exception` -> `ValueError` | Unknown preprocess mode |
| `input_data.py` | L294, L297, L362 | `Exception` -> `FileNotFoundError` | Missing .wav files or expected labels |
| `input_data.py` | L458 | `Exception` -> `ImportError` | Missing Bazel-built micro frontend op |

Also updated the corresponding `Raises` docstrings to reflect the new exception types.

### Motivation

Using bare `Exception` is a Python anti-pattern ([PEP 8](https://peps.python.org/pep-0008/#programming-recommendations)). Specific exception types allow callers to catch and handle errors more precisely, and make the code more self-documenting about what went wrong.
