### PR TITLE
Fix core dump and int overflow in UnicodeDecodeWithOffsets

### DIFF
--- a/tensorflow/core/kernels/unicode_ops.cc
+++ b/tensorflow/core/kernels/unicode_ops.cc
@@ -454,7 +454,7 @@ class UnicodeDecodeBaseOp : public OpKernel {
     Tensor* output_char_values;
     OP_REQUIRES_OK(
         ctx, ctx->allocate_output(
-                 "char_values", {static_cast<SPLITS_TYPE>(char_values.size())},
+                 "char_values", {static_cast<int64_t>(char_values.size())},
                  &output_char_values));
     auto out_char_values = output_char_values->vec<int32_t>();
     if (generate_offsets_) {
@@ -469,9 +469,9 @@ class UnicodeDecodeBaseOp : public OpKernel {
       Tensor* output_offset_values;
       OP_REQUIRES_OK(ctx, ctx->allocate_output(
                               "char_to_byte_starts",
-                              {static_cast<SPLITS_TYPE>(offset_values.size())},
+                              {static_cast<int64_t>(offset_values.size())},
                               &output_offset_values));
-      auto out_offset_values = output_offset_values->vec<SPLITS_TYPE>();
+      auto out_offset_values = output_offset_values->vec<int64_t>();
 
       // Load output tensors from intermediate value arrays.
       for (size_t i = 0; i < char_values.size(); ++i) {

--- a/tensorflow/core/kernels/unicode_ops.cc
+++ b/tensorflow/core/kernels/unicode_ops.cc
@@ -372,7 +372,7 @@ class UnicodeDecodeBaseOp : public OpKernel {
   }
 
   void Decode(OpKernelContext* ctx, std::vector<UChar32>* char_values,
-              std::vector<SPLITS_TYPE>* offset_values, int* current_offset,
+              std::vector<int64_t>* offset_values, int64_t* current_offset,
               SPLITS_TYPE* next_row_split, UChar32 char_value, int char_length,
               bool found_any_format_error) {
     if (error_options_.error_on_malformatting && found_any_format_error) {
@@ -416,7 +416,7 @@ class UnicodeDecodeBaseOp : public OpKernel {
                     input_encoding_));
 
     std::vector<UChar32> char_values;
-    std::vector<SPLITS_TYPE> offset_values;
+    std::vector<int64_t> offset_values;
 
     Tensor* output_row_splits;
     OP_REQUIRES_OK(ctx, ctx->allocate_output("row_splits",
@@ -433,7 +433,7 @@ class UnicodeDecodeBaseOp : public OpKernel {
       // the fields needed to construct a RaggedTensor.
       out_row_splits(row_split_index) = next_row_split;
       row_split_index++;
-      int current_offset = 0;
+      int64_t current_offset = 0;
       IterateUnicodeString(
           input, input_encoder.converter_,
           std::bind(&UnicodeDecodeBaseOp::Decode, this, ctx, &char_values,

--- a/tensorflow/python/kernel_tests/strings_ops/unicode_decode_op_test.py
+++ b/tensorflow/python/kernel_tests/strings_ops/unicode_decode_op_test.py
@@ -463,6 +463,20 @@ class UnicodeDecodeTest(test_util.TensorFlowTestCase,
     self.assertAllEqual(expected_char_to_byte_starts,
                         result.char_to_byte_starts)
 
+  def testDecodeWithOffsetsInt32Splits(self):
+    """Verifies that Tsplits=dtypes.int32 processes correctly without type mismatch."""
+    input_data = constant_op.constant([b"hello", b"world"], dtype=dtypes.string)
+    
+    result = gen_string_ops.unicode_decode_with_offsets(
+      input=input_data,
+      input_encoding="UTF-8",
+      Tsplits=dtypes.int32
+    )
+    
+    self.assertEqual(result.row_splits.dtype, dtypes.int32)
+    self.assertEqual(result.char_to_byte_starts.dtype, dtypes.int64)
+    self.assertAllEqual(result.row_splits, [0, 5, 10])
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class UnicodeSplitTest(test_util.TensorFlowTestCase,

--- a/tensorflow/python/kernel_tests/strings_ops/unicode_decode_op_test.py
+++ b/tensorflow/python/kernel_tests/strings_ops/unicode_decode_op_test.py
@@ -466,13 +466,13 @@ class UnicodeDecodeTest(test_util.TensorFlowTestCase,
   def testDecodeWithOffsetsInt32Splits(self):
     """Verifies that Tsplits=dtypes.int32 processes correctly without type mismatch."""
     input_data = constant_op.constant([b"hello", b"world"], dtype=dtypes.string)
-    
+
     result = gen_string_ops.unicode_decode_with_offsets(
-      input=input_data,
-      input_encoding="UTF-8",
-      Tsplits=dtypes.int32
+        input=input_data,
+        input_encoding="UTF-8",
+        Tsplits=dtypes.int32
     )
-    
+
     self.assertEqual(result.row_splits.dtype, dtypes.int32)
     self.assertEqual(result.char_to_byte_starts.dtype, dtypes.int64)
     self.assertAllEqual(result.row_splits, [0, 5, 10])

--- a/tensorflow/python/kernel_tests/strings_ops/unicode_decode_op_test.py
+++ b/tensorflow/python/kernel_tests/strings_ops/unicode_decode_op_test.py
@@ -476,8 +476,14 @@ class UnicodeDecodeTest(test_util.TensorFlowTestCase,
     self.assertEqual(result.row_splits.dtype, dtypes.int32)
     self.assertEqual(result.char_to_byte_starts.dtype, dtypes.int64)
     self.assertAllEqual(result.row_splits, [0, 5, 10])
-    self.assertAllEqual(result.char_values, [104, 101, 108, 108, 111, 119, 111, 114, 108, 100])
-    self.assertAllEqual(result.char_to_byte_starts, [0, 1, 2, 3, 4, 0, 1, 2, 3, 4])
+    self.assertAllEqual(
+        result.char_values,
+        [104, 101, 108, 108, 111, 119, 111, 114, 108, 100]
+    )
+    self.assertAllEqual(
+        result.char_to_byte_starts,
+        [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]
+    )
 
 
 @test_util.run_all_in_graph_and_eager_modes

--- a/tensorflow/python/kernel_tests/strings_ops/unicode_decode_op_test.py
+++ b/tensorflow/python/kernel_tests/strings_ops/unicode_decode_op_test.py
@@ -476,6 +476,8 @@ class UnicodeDecodeTest(test_util.TensorFlowTestCase,
     self.assertEqual(result.row_splits.dtype, dtypes.int32)
     self.assertEqual(result.char_to_byte_starts.dtype, dtypes.int64)
     self.assertAllEqual(result.row_splits, [0, 5, 10])
+    self.assertAllEqual(result.char_values, [104, 101, 108, 108, 111, 119, 111, 114, 108, 100])
+    self.assertAllEqual(result.char_to_byte_starts, [0, 1, 2, 3, 4, 0, 1, 2, 3, 4])
 
 
 @test_util.run_all_in_graph_and_eager_modes


### PR DESCRIPTION
Fixes #104795 

**Changelog:**
- Fixed a dtype mismatch (`9 vs 3`) core dump when passing `Tsplits=int32` by strictly mapping the `out_offset_values` vector to `int64_t`.
- Upgraded loop counters to `int64_t` to prevent integer overflow when processing strings larger than 2.14 billion characters.
- Added missing Python unit tests in `unicode_decode_op_test.py` to verify `Tsplits=dtypes.int32` executes safely and returns the correct 64-bit offset tensors.