### PR TITLE
Use idiomatic Python patterns in speech_commands examples

### DIFF
--- a/tensorflow/examples/speech_commands/accuracy_utils.py
+++ b/tensorflow/examples/speech_commands/accuracy_utils.py
@@ -119,7 +119,7 @@ class StreamingAccuracyStats(object):
           continue
         ground_truth_label = ground_truth[0]
         if (ground_truth_label == found_label and
-            has_gt_matched.count(ground_truth_time) == 0):
+            ground_truth_time not in has_gt_matched):
           self._how_many_c += 1
         else:
           self._how_many_w += 1

--- a/tensorflow/examples/speech_commands/input_data.py
+++ b/tensorflow/examples/speech_commands/input_data.py
@@ -226,7 +226,7 @@ class AudioProcessor(object):
 
       try:
         filepath, _ = urllib.request.urlretrieve(data_url, filepath, _progress)
-      except:
+      except Exception:
         tf.compat.v1.logging.error(
             'Failed to download URL: {0} to folder: {1}. Please make sure you '
             'have enough free space and an internet connection'.format(

--- a/tensorflow/examples/speech_commands/recognize_commands.py
+++ b/tensorflow/examples/speech_commands/recognize_commands.py
@@ -133,7 +133,7 @@ class RecognizeCommands(object):
       raise ValueError("The results for recognition should contain {} "
                        "elements, but there are {} produced".format(
                            self._label_count, latest_results.shape[0]))
-    if (self._previous_results.__len__() != 0 and
+    if (len(self._previous_results) != 0 and
         current_time_ms < self._previous_results[0][0]):
       raise ValueError("Results must be fed in increasing time order, "
                        "but receive a timestamp of {}, which was earlier "
@@ -149,7 +149,7 @@ class RecognizeCommands(object):
       self._previous_results.popleft()
 
     # If there are too few results, the result will be unreliable and bail.
-    how_many_results = self._previous_results.__len__()
+    how_many_results = len(self._previous_results)
     earliest_time = self._previous_results[0][0]
     sample_duration = current_time_ms - earliest_time
     if (how_many_results < self._minimum_count or

--- a/tensorflow/examples/speech_commands/recognize_commands.py
+++ b/tensorflow/examples/speech_commands/recognize_commands.py
@@ -133,7 +133,7 @@ class RecognizeCommands(object):
       raise ValueError("The results for recognition should contain {} "
                        "elements, but there are {} produced".format(
                            self._label_count, latest_results.shape[0]))
-    if (len(self._previous_results) != 0 and
+    if (self._previous_results and
         current_time_ms < self._previous_results[0][0]):
       raise ValueError("Results must be fed in increasing time order, "
                        "but receive a timestamp of {}, which was earlier "


### PR DESCRIPTION
## Description

Apply Pythonic best practices to `speech_commands` example code across 3 files.

### Changes

| File | Before | After | Why |
|------|--------|-------|-----|
| `input_data.py:229` | `except:` | `except Exception:` | Bare `except` also catches `SystemExit` and `KeyboardInterrupt`, which should propagate ([PEP 8](https://peps.python.org/pep-0008/#programming-recommendations)) |
| `recognize_commands.py:136,152` | `deque.__len__()` | `len(deque)` | Use the built-in `len()` function instead of calling dunder methods directly |
| `accuracy_utils.py:122` | `list.count(x) == 0` | `x not in list` | More readable and can short-circuit on first match |

### Motivation

These are small but meaningful improvements that follow standard Python conventions. Each change makes the code more readable and idiomatic without altering any behavior.