### PR TITLE
Replace generic Exception with specific types in tensorflow/tools

### DIFF
--- a/tensorflow/tools/git/gen_git_source.py
+++ b/tensorflow/tools/git/gen_git_source.py
@@ -169,8 +169,9 @@ def get_git_version(git_base_path, git_tag_override):
     if git_tag_override and val:
       split_val = val.split(version_separator)
       if len(split_val) < 3:
-        raise Exception(
-            ("Expected git version in format 'TAG-COMMITS AFTER TAG-HASH' "
+        raise ValueError(
+            ("Expected git version in format "
+             "'TAG-COMMITS AFTER TAG-HASH' "
              "but got '%s'") % val)
       # There might be "-" in the tag name. But we can be sure that the final
       # two "-" are those inserted by the git describe command.

--- a/tensorflow/tools/pip_package/redundant_tensorflow_gpu/setup.py
+++ b/tensorflow/tools/pip_package/redundant_tensorflow_gpu/setup.py
@@ -33,8 +33,10 @@ information, see: pypi.org/project/tensorflow-gpu
 """
 
 # Cover all "pip install" situations
-if "bdist_wheel" in sys.argv or "install" in sys.argv or "bdist_egg" in sys.argv:
-  raise Exception(TF_REMOVAL_WARNING)
+if ("bdist_wheel" in sys.argv
+    or "install" in sys.argv
+    or "bdist_egg" in sys.argv):
+  raise RuntimeError(TF_REMOVAL_WARNING)
 
 if __name__ == "__main__":
   setuptools.setup()

--- a/tensorflow/tools/pip_package/redundant_tensorflow_gpu/setup.py
+++ b/tensorflow/tools/pip_package/redundant_tensorflow_gpu/setup.py
@@ -36,7 +36,7 @@ information, see: pypi.org/project/tensorflow-gpu
 if ("bdist_wheel" in sys.argv
     or "install" in sys.argv
     or "bdist_egg" in sys.argv):
-  raise RuntimeError(TF_REMOVAL_WARNING)
+  sys.exit(TF_REMOVAL_WARNING)
 
 if __name__ == "__main__":
   setuptools.setup()

--- a/tensorflow/tools/pip_package/redundant_tf_nightly_gpu/setup.py
+++ b/tensorflow/tools/pip_package/redundant_tf_nightly_gpu/setup.py
@@ -36,7 +36,7 @@ information, see: pypi.org/project/tf-nightly-gpu
 if ("bdist_wheel" in sys.argv
     or "install" in sys.argv
     or "bdist_egg" in sys.argv):
-  raise RuntimeError(TF_REMOVAL_WARNING)
+  sys.exit(TF_REMOVAL_WARNING)
 
 if __name__ == "__main__":
   setuptools.setup()

--- a/tensorflow/tools/pip_package/redundant_tf_nightly_gpu/setup.py
+++ b/tensorflow/tools/pip_package/redundant_tf_nightly_gpu/setup.py
@@ -33,8 +33,10 @@ information, see: pypi.org/project/tf-nightly-gpu
 """
 
 # Cover all "pip install" situations
-if "bdist_wheel" in sys.argv or "install" in sys.argv or "bdist_egg" in sys.argv:
-  raise Exception(TF_REMOVAL_WARNING)
+if ("bdist_wheel" in sys.argv
+    or "install" in sys.argv
+    or "bdist_egg" in sys.argv):
+  raise RuntimeError(TF_REMOVAL_WARNING)
 
 if __name__ == "__main__":
   setuptools.setup()

--- a/tensorflow/tools/tensorflow_builder/compat_checker/compat_checker.py
+++ b/tensorflow/tools/tensorflow_builder/compat_checker/compat_checker.py
@@ -768,8 +768,9 @@ class ConfigCompatChecker:
       elif p_item == "warning_msgs":
         _format("Warning Messages", self.warning_msg)
       else:
-        raise Exception(
-            "[Error] Wrong input provided for %s." % _get_func_name())
+        raise ValueError(
+            "[Error] Wrong input provided for %s."
+            % _get_func_name())
 
   def check_compatibility(self):
     """Checks version and dependency compatibility for a given configuration.


### PR DESCRIPTION
## Description

Replace bare `raise Exception(...)` with appropriate built-in exception types across `tensorflow/tools/`.

### Changes

| File | Old | New | Reason |
|------|-----|-----|--------|
| `git/gen_git_source.py` | `Exception` | `ValueError` | Invalid git version format |
| `tensorflow_builder/compat_checker/compat_checker.py` | `Exception` | `ValueError` | Invalid argument to `_print()` |
| `pip_package/redundant_tf_nightly_gpu/setup.py` | `Exception` | `RuntimeError` | Deprecated package install blocker |
| `pip_package/redundant_tensorflow_gpu/setup.py` | `Exception` | `RuntimeError` | Deprecated package install blocker |

### Motivation

Using bare `Exception` is discouraged by [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations). Specific exception types allow callers to catch and handle errors more precisely.