### PR TITLE
Fix XLA fake_quant rounding mismatch with eager execution

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/tests/lower_tf.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/lower_tf.mlir
@@ -423,46 +423,31 @@ func.func @fake_quant_with_min_max_args(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf
 }
 
 func.func @fake_quant_with_min_max_vars(%arg0 : tensor<?x?xf32>, %arg1 : tensor<f32>, %arg2 : tensor<f32>) -> tensor<?x?xf32> {
-  // CHECK-DAG: %[[ZERO:.*]] = "tf.Const"() <{value = dense<0.000000e+00> : tensor<f32>}> : () -> tensor<f32>
-  // CHECK-DAG: %[[VAL1:.*]] = "tf.Const"() <{value = dense<2.550000e+02> : tensor<f32>}> : () -> tensor<f32>
-  // CHECK-DAG: %[[VAL2:.*]] = "tf.Const"() <{value = dense<2.000000e+00> : tensor<f32>}> : () -> tensor<f32>
-  // CHECK-DAG: %[[VAL3:.*]] = "tf.Const"() <{value = dense<1.000000e+00> : tensor<f32>}> : () -> tensor<f32>
-  // CHECK-DAG: %[[VAL4:.*]] = "tf.Const"() <{value = dense<5.000000e-01> : tensor<f32>}> : () -> tensor<f32>
-  // CHECK-DAG: %[[VAL5:.*]] = "tf.Sub"(%arg2, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL6:.*]] = "tf.Div"(%[[VAL5]], %[[VAL1]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL7:.*]] = "tf.Div"(%[[VAL1]], %[[VAL5]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL8:.*]] = "tf.Div"(%arg1, %[[VAL6]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL9:.*]] = "tf.Sub"(%[[ZERO]], %[[VAL8]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL10:.*]] = "tf.Floor"(%[[VAL9]]) : (tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL11:.*]] = "tf.Sub"(%[[VAL9]], %[[VAL10]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL12:.*]] = "tf.Greater"(%[[VAL11]], %[[VAL4]]) : (tensor<f32>, tensor<f32>) -> tensor<i1>
-  // CHECK-DAG: %[[VAL13:.*]] = "tf.Equal"(%[[VAL11]], %[[VAL4]]) <{incompatible_shape_error = true}> : (tensor<f32>, tensor<f32>) -> tensor<i1>
-  // CHECK-DAG: %[[VAL14:.*]] = "tf.Mul"(%[[VAL9]], %[[VAL4]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL15:.*]] = "tf.Floor"(%[[VAL14]]) : (tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL16:.*]] = "tf.Mul"(%[[VAL15]], %[[VAL2]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL17:.*]] = "tf.Sub"(%[[VAL10]], %[[VAL16]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL18:.*]] = "tf.Equal"(%[[VAL17]], %[[VAL3]]) <{incompatible_shape_error = true}> : (tensor<f32>, tensor<f32>) -> tensor<i1>
-  // CHECK-DAG: %[[VAL19:.*]] = "tf.LogicalAnd"(%[[VAL13]], %[[VAL18]]) : (tensor<i1>, tensor<i1>) -> tensor<i1>
-  // CHECK-DAG: %[[VAL20:.*]] = "tf.LogicalOr"(%[[VAL12]], %[[VAL19]]) : (tensor<i1>, tensor<i1>) -> tensor<i1>
-  // CHECK-DAG: %[[VAL21:.*]] = "tf.AddV2"(%[[VAL10]], %[[VAL3]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[INNER_SELECT:.*]] = "tf.SelectV2"(%[[VAL20]], %[[VAL21]], %[[VAL10]]) : (tensor<i1>, tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[IS_ZERO:.*]] = "tf.Equal"(%[[INNER_SELECT]], %[[ZERO]]) <{incompatible_shape_error = true}>
-  // CHECK-DAG: %[[VAL22:.*]] = "tf.SelectV2"(%[[IS_ZERO]], %[[ZERO]], %[[INNER_SELECT]])
-  // CHECK-DAG: %[[VAL23:.*]] = "tf.ClipByValue"(%[[VAL22]], %[[ZERO]], %[[VAL1]]) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL24:.*]] = "tf.Sub"(%[[ZERO]], %[[VAL23]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL25:.*]] = "tf.Sub"(%[[VAL1]], %[[VAL23]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL26:.*]] = "tf.Mul"(%[[VAL24]], %[[VAL6]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL27:.*]] = "tf.Mul"(%[[VAL25]], %[[VAL6]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-  // CHECK-DAG: %[[VAL28:.*]] = "tf.ClipByValue"(%arg0, %[[VAL26]], %[[VAL27]]) : (tensor<?x?xf32>, tensor<f32>, tensor<f32>) -> tensor<?x?xf32>
-  // CHECK-DAG: %[[VAL29:.*]] = "tf.Sub"(%[[VAL28]], %[[VAL26]]) : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
-  // CHECK-DAG: %[[VAL30:.*]] = "tf.Mul"(%[[VAL29]], %[[VAL7]]) : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
-  // CHECK-DAG: %[[VAL31:.*]] = "tf.AddV2"(%[[VAL30]], %[[VAL4]]) : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
-  // CHECK-DAG: %[[VAL32:.*]] = "tf.Floor"(%[[VAL31]]) : (tensor<?x?xf32>) -> tensor<?x?xf32>
-  // CHECK-DAG: %[[VAL33:.*]] = "tf.Mul"(%[[VAL32]], %[[VAL6]]) : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
-  // CHECK-DAG: %[[VAL34:.*]] = "tf.AddV2"(%[[VAL33]], %[[VAL26]]) : (tensor<?x?xf32>, tensor<f32>) -> tensor<?x?xf32>
+  // CHECK-DAG: %[[ZERO:.*]] = "tf.Const"() <{value = dense<0.000000e+00> : tensor<f32>}>
+  // CHECK-DAG: %[[VAL1:.*]] = "tf.Const"() <{value = dense<2.550000e+02> : tensor<f32>}>
+  // CHECK-DAG: %[[VAL2:.*]] = "tf.Const"() <{value = dense<5.000000e-01> : tensor<f32>}>
+  // CHECK-DAG: %[[DIFF:.*]] = "tf.Sub"(%arg2, %arg1)
+  // CHECK-DAG: %[[SCALE:.*]] = "tf.Div"(%[[DIFF]], %[[VAL1]])
+  // CHECK-DAG: %[[INV_SCALE:.*]] = "tf.Div"(%[[VAL1]], %[[DIFF]])
+  // CHECK-DAG: %[[MIN_SCALED:.*]] = "tf.Div"(%arg1, %[[SCALE]])
+  // CHECK-DAG: %[[MIN_SCALED_SUB:.*]] = "tf.Sub"(%[[ZERO]], %[[MIN_SCALED]])
+  // CHECK-DAG: %[[ADD:.*]] = "tf.AddV2"(%[[MIN_SCALED_SUB]], %[[VAL2]])
+  // CHECK-DAG: %[[FLOOR:.*]] = "tf.Floor"(%[[ADD]])
+  // CHECK-DAG: %[[ZP:.*]] = "tf.ClipByValue"(%[[FLOOR]], %[[ZERO]], %[[VAL1]])
+  // CHECK-DAG: %[[SUB_MIN:.*]] = "tf.Sub"(%[[ZERO]], %[[ZP]])
+  // CHECK-DAG: %[[SUB_MAX:.*]] = "tf.Sub"(%[[VAL1]], %[[ZP]])
+  // CHECK-DAG: %[[NUDGED_MIN:.*]] = "tf.Mul"(%[[SUB_MIN]], %[[SCALE]])
+  // CHECK-DAG: %[[NUDGED_MAX:.*]] = "tf.Mul"(%[[SUB_MAX]], %[[SCALE]])
+  // CHECK-DAG: %[[CLIP:.*]] = "tf.ClipByValue"(%arg0, %[[NUDGED_MIN]], %[[NUDGED_MAX]])
+  // CHECK-DAG: %[[SUB:.*]] = "tf.Sub"(%[[CLIP]], %[[NUDGED_MIN]])
+  // CHECK-DAG: %[[MUL:.*]] = "tf.Mul"(%[[SUB]], %[[INV_SCALE]])
+  // CHECK-DAG: %[[ADD2:.*]] = "tf.AddV2"(%[[MUL]], %[[VAL2]])
+  // CHECK-DAG: %[[FLOOR2:.*]] = "tf.Floor"(%[[ADD2]])
+  // CHECK-DAG: %[[MUL2:.*]] = "tf.Mul"(%[[FLOOR2]], %[[SCALE]])
+  // CHECK-DAG: %[[RESULT:.*]] = "tf.AddV2"(%[[MUL2]], %[[NUDGED_MIN]])
   %0 = "tf.FakeQuantWithMinMaxVars"(%arg0, %arg1, %arg2) {narrow_range = false, num_bits = 8 : i64} : (tensor<?x?xf32>, tensor<f32>, tensor<f32>) -> tensor<?x?xf32>
 
-  // CHECK: return %[[VAL34]]
+  // CHECK: return %[[RESULT]]
   func.return %0 : tensor<?x?xf32>
 }
 

--- a/tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.cc
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.cc
@@ -496,10 +496,6 @@ class ConvertFakeQuantWithMinMaxVarsOp : public RewritePattern {
                                     quantized_input, float_to_quant);
 
     // Round the quantized input always to the positive direction.
-    auto half_val = ConstOp::create(
-        rewriter, op.getLoc(),
-        DenseElementsAttr::get(scalar_ty, ConvertToAPFloat(0.5, element_ty)));
-
     quantized_input = AddV2Op::create(rewriter, op.getLoc(), input_ty,
                                       quantized_input, half_val);
 

--- a/tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.cc
+++ b/tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.cc
@@ -461,8 +461,12 @@ class ConvertFakeQuantWithMinMaxVarsOp : public RewritePattern {
     auto min_scaled_sub =
         SubOp::create(rewriter, op.getLoc(), quant_min, min_scaled);
 
-    auto mid_rounded =
-        RoundOp::create(rewriter, op.getLoc(), scalar_ty, min_scaled_sub);
+    auto half_val = ConstOp::create(
+        rewriter, op.getLoc(),
+        DenseElementsAttr::get(scalar_ty, ConvertToAPFloat(0.5, element_ty)));
+    Value mid_added =
+        AddV2Op::create(rewriter, op.getLoc(), min_scaled_sub, half_val);
+    auto mid_rounded = FloorOp::create(rewriter, op.getLoc(), mid_added);
 
     auto nudged_zero_point_val = ClipByValueOp::create(
         rewriter, op.getLoc(), scalar_ty, mid_rounded, quant_min, quant_max);

--- a/tensorflow/compiler/tests/fake_quant_ops_test.py
+++ b/tensorflow/compiler/tests/fake_quant_ops_test.py
@@ -36,6 +36,15 @@ class FakeQuantWithMinMaxArgsTest(xla_test.XLATestCase):
   def testOp_with8BitsScalingAndNudgingBetween(self):
     self._TestOp(-0.1, 127.4, 8, False, 0.0, 127.5, 0.5)
 
+  def testOp_with8BitsRoundingHalfWayZeroPoint(self):
+    # zero_point_from_min lands at exactly 0.5 (half-integer boundary).
+    # Scale = (509.0 - (-1.0)) / (255 - 0) = 510.0 / 255.0 = 2.0
+    # zero_point_from_min = 0 - (-1.0) / 2.0 = 0.5
+    # Under round-half-away-from-zero: nudged_zero_point = 1.0
+    # nudged_min = (0 - 1.0) * 2.0 = -2.0
+    # nudged_max = (255 - 1.0) * 2.0 = 508.0
+    self._TestOp(-1.0, 509.0, 8, False, -2.0, 508.0, 2.0)
+
   # 8 bits, narrow range.
   def testOp_with8BitsNarrowRangeNoScalingNoNudging(self):
     self._TestOp(0.0, 254.0, 8, True, 0.0, 254.0, 1.0)

--- a/tensorflow/compiler/tf2xla/kernels/fake_quantize_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/fake_quantize_ops.cc
@@ -65,10 +65,12 @@ void XlaNudge(xla::XlaBuilder* b, const DataType data_type,
   xla::XlaOp zero_point_from_min = xla::Sub(quant_min, xla::Div(min, *scale));
   xla::XlaOp quant_max =
       XlaHelpers::FloatLiteral(b, data_type, quant_max_value);
+  xla::XlaOp half = XlaHelpers::FloatLiteral(b, data_type, 0.5f);
   xla::XlaOp nudged_zero_point =
       xla::Select(xla::Le(zero_point_from_min, quant_min), quant_min,
                   xla::Select(xla::Ge(zero_point_from_min, quant_max),
-                              quant_max, xla::Round(zero_point_from_min)));
+                              quant_max,
+                              xla::Floor(xla::Add(zero_point_from_min, half))));
   *nudged_min = xla::Mul(xla::Sub(quant_min, nudged_zero_point), *scale);
   *nudged_max = xla::Mul(xla::Sub(quant_max, nudged_zero_point), *scale);
 }


### PR DESCRIPTION
Fixes #117962
## Description
This PR fixes a bug where tf.quantization.fake_quant_* ops under XLA produced
different quantized values than in eager mode. The root cause was a different
rounding mode when computing the nudged zero point:

Eager execution uses round-half-away-from-zero (std::round)
XLA was using round-half-to-even

When the zero point is a half-integer, the nudged quantization range shifted
by one step, causing inaccuracies during XLA-compiled quantization-aware training.

## Changes
In tensorflow/compiler/tf2xla/kernels/fake_quantize_ops.cc:
Updated XlaNudge to use floor(x + 0.5) for rounding the zero point.

In tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.cc:
Updated the ConvertFakeQuantWithMinMaxVarsOp pattern with the same rounding logic.

// --- Fix in tensorflow/compiler/tf2xla/kernels/fake_quantize_ops.cc ---
// Before:
// nudged_zero_point = xla::Select(..., xla::Round(zero_point_from_min));

// After:
xla::XlaOp half = XlaHelpers::FloatLiteral(b, data_type, 0.5f);
nudged_zero_point = xla::Select(
    ...,
    xla::Floor(xla::Add(zero_point_from_min, half))
);


// --- Fix in tensorflow/compiler/mlir/tensorflow/transforms/lower_tf.cc ---
// Before:
// auto mid_rounded = RoundOp::create(rewriter, op.getLoc(), scalar_ty, min_scaled_sub);

// After:
auto half_val = ConstOp::create(
    rewriter,
    op.getLoc(),
    DenseElementsAttr::get(
        scalar_ty,
        ConvertToAPFloat(0.5, element_ty)
    )
);

auto mid_rounded = FloorOp::create(
    rewriter,
    op.getLoc(),
    AddV2Op::create(
        rewriter,
        op.getLoc(),
        min_scaled_sub,
        half_val
    )
);