### PR TITLE
util: dedupe decorator-injected suffixes in docstrings (#90927)

### DIFF
--- a/tensorflow/python/util/decorator_utils.py
+++ b/tensorflow/python/util/decorator_utils.py
@@ -102,7 +102,14 @@ def add_notice_to_docstring(doc,
     lines = [no_doc_str]
   else:
     lines = _normalize_docstring(doc).splitlines()
-    lines[0] += ' ' + suffix_str
+    # Avoid duplicating the suffix when this decorator is applied to a
+    # function that has already been decorated by a sibling that injected
+    # the same suffix (e.g. multiple stacked `@deprecated_args` decorators
+    # on `tf.function` previously produced
+    # "... (deprecated arguments) (deprecated arguments) (deprecated arguments)").
+    # See https://github.com/tensorflow/tensorflow/issues/90927.
+    if suffix_str and not lines[0].rstrip().endswith(suffix_str):
+      lines[0] += ' ' + suffix_str
 
   if not notice:
     raise ValueError('The `notice` arg must not be empty.')

--- a/tensorflow/python/util/decorator_utils_test.py
+++ b/tensorflow/python/util/decorator_utils_test.py
@@ -91,6 +91,16 @@ class AddNoticeToDocstringTest(test.TestCase):
     # 2 space second line indent, first line blank
     self._check("\n  Brief\n  Docstring", expected)
 
+  def test_suffix_not_duplicated_when_already_present(self):
+    # Regression for https://github.com/tensorflow/tensorflow/issues/90927:
+    # stacking decorators that share the same suffix (e.g. several
+    # `@deprecated_args` on `tf.function`) should append the suffix once,
+    # not once per decorator.
+    expected = "Brief (suffix)\n\nWarning: Go away\nInstructions"
+    self._check("Brief (suffix)", expected)
+    # Trailing whitespace on the first line must still be tolerated.
+    self._check("Brief (suffix)   ", expected)
+
 
 class ValidateCallableTest(test.TestCase):
 


### PR DESCRIPTION
## Summary

`tensorflow.python.util.decorator_utils.add_notice_to_docstring`
unconditionally appends `suffix_str` to the first line of the docstring.
When several decorators that share the same suffix stack on a single
function — concretely, the three `@deprecation.deprecated_args`
decorators applied to `tf.function` at
[`tensorflow/python/eager/polymorphic_function/polymorphic_function.py:1306-1316`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/eager/polymorphic_function/polymorphic_function.py#L1306-L1316)
— each decorator appends `(deprecated arguments)` once, so the final
docstring reads:

> Compiles a function into a callable TensorFlow graph. (deprecated arguments) (deprecated arguments) (deprecated arguments)

That string is what surfaces on
[https://www.tensorflow.org/api_docs/python/tf/function](https://www.tensorflow.org/api_docs/python/tf/function#features),
and the same problem affects every other helper in TF that stacks
multiple `@deprecated_args` (the suffix would also duplicate if a single
function were ever decorated with `@deprecated` *and* `@deprecated_args`,
since both pass `(deprecated)` / `(deprecated arguments)` through this
same helper).

Fixes tensorflow/tensorflow#90927.

## Context

- The duplicate suffix was reported in [#90927](https://github.com/tensorflow/tensorflow/issues/90927) and is still visible on the published API docs at the time of writing.
- The triple repetition is structural: `tf.function` carries three
  stacked `@deprecated_args` decorators, one per deprecated argument
  group, and each one rewrites `__doc__` independently.
- Other downstream helpers (`add_notice_to_docstring` is shared by
  `@deprecated`, `@deprecated_args`, and `@deprecated_arg_values`) inherit
  the same bug whenever decorators of the same family stack.

## Changes

- `tensorflow/python/util/decorator_utils.py` — only append `suffix_str`
  when the first line of the docstring does not already end with it. A
  short comment links back to the issue so a reviewer reading the diff
  cold sees why the conditional is there.
- `tensorflow/python/util/decorator_utils_test.py` — new test
  `test_suffix_not_duplicated_when_already_present` documenting the
  contract: feeding a docstring whose first line already ends with the
  suffix returns the unchanged first line. This fails on `master` and
  passes on this branch.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/tensorflow/tensorflow.git /tmp/repro && cd /tmp/repro

# Self-contained probe that imports decorator_utils directly (no full TF
# build needed). Stacks three calls to add_notice_to_docstring with the
# same suffix, mimicking the three @deprecated_args on tf.function.
cat > /tmp/probe.py <<'PY'
import importlib.util, sys
spec = importlib.util.spec_from_file_location(
    'decorator_utils', 'tensorflow/python/util/decorator_utils.py')
m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
doc = 'Brief'
for _ in range(3):
    doc = m.add_notice_to_docstring(
        doc=doc, instructions='Inst', no_doc_str='Nothing',
        suffix_str='(deprecated arguments)', notice=['Some args'])
first = doc.splitlines()[0]
print('first_line=', repr(first))
print('repeats=', first.count('(deprecated arguments)'))
PY

# --- BEFORE (origin/master) ---
git checkout origin/master -- tensorflow/python/util/decorator_utils.py
python3 /tmp/probe.py
# Expected: repeats= 3  (first_line ends with three " (deprecated arguments)")

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/tensorflow.git feat/90927-dedupe-deprecation-suffix
git checkout FETCH_HEAD -- tensorflow/python/util/decorator_utils.py
python3 /tmp/probe.py
# Expected: repeats= 1  (suffix appears exactly once)
```

## What I ran locally

- Direct execution of the probe above on `master` and on this branch — repeats went from 3 → 1.
- Direct execution of the new regression test
  `decorator_utils_test.AddNoticeToDocstringTest.test_suffix_not_duplicated_when_already_present`
  via the same lightweight loader — fails on `master`, passes here.
- Existing tests in `decorator_utils_test.py` (regular / brief-only /
  no-docstring / no-empty-line) re-checked under the new code — all
  still pass because their inputs don't end with the suffix, so the
  append branch is taken exactly as before.

I did not run the full Bazel test suite (the TF Bazel build is not
feasible in the sandbox used for this fix). The change is confined to
`add_notice_to_docstring`, which has no transitive C++ dependency, so
the lightweight unit test exercises the entire affected code path.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Suffix already present | first line ends with `(suffix)` | suffix not re-appended | `test_suffix_not_duplicated_when_already_present` |
| 2 | Suffix absent (typical case) | first line is `Brief` | suffix appended once | existing `test_regular`, `test_brief_only`, `test_no_empty_line` |
| 3 | Empty docstring | `None` / `""` | `no_doc_str` used; no suffix logic | existing `test_no_docstring` |
| 4 | Trailing whitespace before suffix | `Brief (suffix)   ` | suffix detected and not duplicated | new test (rstrip guard) |
| 5 | Different suffix from a different decorator family | first line already ends with `(deprecated)`, new suffix is `(deprecated arguments)` | new suffix appended (different string) | preserved by `endswith(suffix_str)` check, not re-tested explicitly |

## Risk / blast radius

- Behaviour for callers that did not previously hit a duplicate is
  unchanged: the `endswith` guard is False and the original `+= ' ' +
  suffix_str` runs.
- The only observable difference is the missing duplicate suffix. The
  generated `Warning:` / `Deprecated:` notice block is appended after the
  first line and is not affected.
- No public API changes, no behavioural changes outside docstring text.

## Release note

```release-note
Removed a long-standing docstring artifact where stacked deprecation
decorators (notably the three `@deprecated_args` on `tf.function`)
appended `(deprecated arguments)` once per decorator. The suffix is now
appended at most once.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against tensorflow/tensorflow's source: the three stacked
`@deprecated_args` decorators on `tf.function` were located at
`polymorphic_function.py:1306-1316`, the suffix-injection site at
`decorator_utils.py:104-105`, and the deduplication invariant
documented above. The reproducer block above was used during
development and was the exact probe that surfaced the bug; a reviewer
can paste it verbatim. Note that contributions to TensorFlow require
signing the [Google CLA](https://cla.developers.google.com/) before
the maintainers can merge.*
