### PR TITLE
Raise explicit error for remote DTensor meshes in to_numpy

### DIFF
--- a/tensorflow/dtensor/python/numpy_util.py
+++ b/tensorflow/dtensor/python/numpy_util.py
@@ -44,7 +44,9 @@ def to_numpy(tensor: TensorLike) -> np.ndarray:
   """Copy `input` DTensor to an equivalent local numpy array."""
   layout = api.fetch_layout(tensor)
   if layout.mesh.is_remote():
-    return np.array([None])
+    raise NotImplementedError(
+        "to_numpy does not support remote DTensor meshes."
+    )
 
   unpacked = [tensor.numpy() for tensor in api.unpack(tensor)]
   return unpacked_to_numpy(unpacked, layout)

--- a/tensorflow/dtensor/python/tests/numpy_util_test.py
+++ b/tensorflow/dtensor/python/tests/numpy_util_test.py
@@ -15,6 +15,7 @@
 """Tests for the buffer and DTensor conversion helpers."""
 
 import numpy as np
+from unittest import mock
 
 # pylint: disable=g-direct-tensorflow-import
 from tensorflow.dtensor.python import layout
@@ -121,6 +122,18 @@ class NumpyUtilTest(test_util.DTensorBaseTest):
     self.assertAllClose(
         numpy_util.unpacked_to_numpy(tensors, sharded_on_y_x),
         np.arange(16).reshape(4, 4))
+
+  def test_to_numpy_remote_mesh_raises(self):
+    mock_mesh = mock.Mock()
+    mock_mesh.is_remote.return_value = True
+
+    mock_layout = mock.Mock()
+    mock_layout.mesh = mock_mesh
+
+    with mock.patch.object(
+        numpy_util.api, 'fetch_layout', return_value=mock_layout):
+      with self.assertRaises(NotImplementedError):
+        numpy_util.to_numpy(mock.Mock())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

This PR improves error handling in `tensorflow/dtensor/python/numpy_util.py`.

Previously, `to_numpy()` returned `np.array([None])` for remote DTensor meshes, which could silently hide unsupported behavior.

This change raises a clear `NotImplementedError` instead and adds unit test coverage for the remote mesh case.

Note: Local execution from the TensorFlow source tree triggers TensorFlow's import guard. The change was syntax-validated locally, and CI should verify full test execution.
