### PR TITLE
Add validation for uneven DTensor shard splits

### DIFF
--- a/tensorflow/dtensor/python/numpy_util.py
+++ b/tensorflow/dtensor/python/numpy_util.py
@@ -33,11 +33,21 @@ from tensorflow.python.types.core import Tensor, TensorLike  # pylint: disable=g
 def _split(value, splits, axis=0, split_fn=np.split, stack_fn=np.stack):
   """Split `value` into a sharded nparray/tf tensor based on the number of splits.
   """
+  if value.shape[axis] % splits[0] != 0:
+    raise ValueError(
+        f"Tensor dimension {value.shape[axis]} on axis {axis} "
+        f"is not evenly divisible by {splits[0]} shards."
+    )
+
   children = split_fn(value, splits[0], axis=axis)
+
   if len(splits) > 1:
     splits = splits[1:]
     children = [_split(child, splits, axis + 1) for child in children]
+
   return stack_fn(children)
+
+
 
 
 def to_numpy(tensor: TensorLike) -> np.ndarray:

--- a/tensorflow/dtensor/python/tests/numpy_util_test.py
+++ b/tensorflow/dtensor/python/tests/numpy_util_test.py
@@ -16,8 +16,11 @@
 
 import numpy as np
 
+
+
 # pylint: disable=g-direct-tensorflow-import
 from tensorflow.dtensor.python import layout
+from tensorflow.dtensor.python import layout as layout_lib
 from tensorflow.dtensor.python import numpy_util
 from tensorflow.dtensor.python.tests import test_util
 from tensorflow.python.platform import test as tf_test
@@ -122,6 +125,22 @@ class NumpyUtilTest(test_util.DTensorBaseTest):
         numpy_util.unpacked_to_numpy(tensors, sharded_on_y_x),
         np.arange(16).reshape(4, 4))
 
+  def test_unpack_uneven_split_raises(self):
+    value = np.arange(5)
+
+    layout = layout_lib.Layout.batch_sharded(
+        self.mesh,
+        batch_dim="x",
+        rank=1
+    )
+
+    with self.assertRaisesRegex(
+        ValueError,
+        "not evenly divisible"
+    ):
+      numpy_util.unpack(value, layout)
+
+    
 
 if __name__ == '__main__':
   tf_test.main()


### PR DESCRIPTION
## Summary

This PR adds explicit validation for uneven shard splits in
`tensorflow/dtensor/python/numpy_util.py`.

Previously, `_split()` relied directly on `np.split()`, which raised a low-level NumPy error when tensor dimensions were not evenly divisible across shard counts.

This change:

* adds explicit DTensor-level validation,
* raises a clearer error message,
* and adds regression test coverage for uneven shard layouts.

Example failing case before this fix:

np.split(np.arange(5), 2)

Previously raised:
ValueError: array split does not result in an equal division

Tests:

* `numpy_util_test_cpu`
* `numpy_util_test_gpu`

Both pass locally using Bazel.
