### PR TITLE
Centralize BMP validation before decoding in label_image

### DIFF
--- a/tensorflow/lite/examples/label_image/bitmap_helpers.cc
+++ b/tensorflow/lite/examples/label_image/bitmap_helpers.cc
@@ -22,15 +22,100 @@ limitations under the License.
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <vector>
 
 #include "tensorflow/lite/examples/label_image/label_image.h"
 #include "tensorflow/lite/examples/label_image/log.h"
-#include "tsl/platform/ctstring_internal.h"
 
 namespace tflite {
 namespace label_image {
+namespace {
+
+constexpr size_t kBmpHeaderMinSize = 30;
+
+uint16_t ReadLe16(const std::vector<uint8_t>& bytes, size_t offset) {
+  return static_cast<uint16_t>(bytes[offset]) |
+         static_cast<uint16_t>(bytes[offset + 1]) << 8;
+}
+
+int32_t ReadLe32(const std::vector<uint8_t>& bytes, size_t offset) {
+  const uint32_t value = static_cast<uint32_t>(bytes[offset]) |
+                         static_cast<uint32_t>(bytes[offset + 1]) << 8 |
+                         static_cast<uint32_t>(bytes[offset + 2]) << 16 |
+                         static_cast<uint32_t>(bytes[offset + 3]) << 24;
+  return static_cast<int32_t>(value);
+}
+
+bool ValidateBmpAndGetPixelOffset(const std::vector<uint8_t>& img_bytes,
+                                  int* width, int* height, int* channels,
+                                  int* row_size, size_t* pixel_offset) {
+  *width = 0;
+  *height = 0;
+  *channels = 0;
+  *row_size = 0;
+  *pixel_offset = 0;
+
+  if (img_bytes.size() < kBmpHeaderMinSize || img_bytes[0] != 'B' ||
+      img_bytes[1] != 'M') {
+    LOG(ERROR) << "Invalid BMP header";
+    return false;
+  }
+
+  const int32_t parsed_pixel_offset = ReadLe32(img_bytes, 10);
+  const int32_t parsed_width = ReadLe32(img_bytes, 18);
+  const int32_t parsed_height = ReadLe32(img_bytes, 22);
+  const uint16_t bpp = ReadLe16(img_bytes, 28);
+
+  if (parsed_pixel_offset < 0 ||
+      static_cast<size_t>(parsed_pixel_offset) > img_bytes.size()) {
+    LOG(ERROR) << "BMP pixel data offset is outside the file";
+    return false;
+  }
+  if (parsed_width <= 0 || parsed_height == 0 || parsed_height == std::numeric_limits<int>::min()) {
+    LOG(ERROR) << "Invalid BMP dimensions";
+    return false;
+  }
+  if (bpp != 8 && bpp != 24 && bpp != 32) {
+    LOG(ERROR) << "Unsupported BMP bits per pixel: " << bpp;
+    return false;
+  }
+
+  const int parsed_channels = bpp / 8;
+  const int64_t abs_height = parsed_height < 0 ? -static_cast<int64_t>(parsed_height)
+                                               : static_cast<int64_t>(parsed_height);
+  const int64_t bits_per_row = static_cast<int64_t>(bpp) * parsed_width;
+  if (bits_per_row > (std::numeric_limits<int>::max() - 31)) {
+    LOG(ERROR) << "BMP row size overflow";
+    return false;
+  }
+  const int parsed_row_size = static_cast<int>((bits_per_row + 31) / 32 * 4);
+
+  const size_t pixel_bytes = img_bytes.size() - static_cast<size_t>(parsed_pixel_offset);
+  if (abs_height > 0 &&
+      static_cast<uint64_t>(parsed_row_size) >
+          std::numeric_limits<uint64_t>::max() /
+              static_cast<uint64_t>(abs_height)) {
+    LOG(ERROR) << "BMP pixel data size overflow";
+    return false;
+  }
+  const uint64_t required_pixel_bytes =
+      static_cast<uint64_t>(parsed_row_size) * static_cast<uint64_t>(abs_height);
+  if (required_pixel_bytes > pixel_bytes) {
+    LOG(ERROR) << "BMP pixel data is shorter than the declared dimensions";
+    return false;
+  }
+
+  *width = parsed_width;
+  *height = parsed_height;
+  *channels = parsed_channels;
+  *row_size = parsed_row_size;
+  *pixel_offset = static_cast<size_t>(parsed_pixel_offset);
+  return true;
+}
+
+}  // namespace
 
 std::vector<uint8_t> decode_bmp(const uint8_t* input, int row_size, int width,
                                 int height, int channels, bool top_down) {
@@ -94,31 +179,26 @@ std::vector<uint8_t> read_bmp(const std::string& input_bmp_name, int* width,
   std::vector<uint8_t> img_bytes(len);
   file.seekg(0, std::ios::beg);
   file.read(reinterpret_cast<char*>(img_bytes.data()), len);
-  const int32_t header_size =
-      TF_le32toh(*(reinterpret_cast<const int32_t*>(img_bytes.data() + 10)));
-  *width =
-      TF_le32toh(*(reinterpret_cast<const int32_t*>(img_bytes.data() + 18)));
-  *height =
-      TF_le32toh(*(reinterpret_cast<const int32_t*>(img_bytes.data() + 22)));
-  const int32_t bpp =
-      TF_le32toh(*(reinterpret_cast<const int32_t*>(img_bytes.data() + 28)));
-  *channels = bpp / 8;
+  int row_size = 0;
+  size_t header_size = 0;
+  if (!ValidateBmpAndGetPixelOffset(img_bytes, width, height, channels,
+                                    &row_size, &header_size)) {
+    return std::vector<uint8_t>();
+  }
 
   if (s->verbose)
     LOG(INFO) << "width, height, channels: " << *width << ", " << *height
               << ", " << *channels;
-
-  // there may be padding bytes when the width is not a multiple of 4 bytes
-  // 8 * channels == bits per pixel
-  const int row_size = (8 * *channels * *width + 31) / 32 * 4;
 
   // if height is negative, data layout is top down
   // otherwise, it's bottom up
   bool top_down = (*height < 0);
 
   // Decode image, allocating tensor once the image size is known
-  const uint8_t* bmp_pixels = &img_bytes[header_size];
-  return decode_bmp(bmp_pixels, row_size, *width, abs(*height), *channels,
+  const uint8_t* bmp_pixels = img_bytes.data() + header_size;
+  const int abs_height =
+      static_cast<int>(*height < 0 ? -static_cast<int64_t>(*height) : *height);
+  return decode_bmp(bmp_pixels, row_size, *width, abs_height, *channels,
                     top_down);
 }
 

--- a/tensorflow/lite/examples/label_image/bitmap_helpers.cc
+++ b/tensorflow/lite/examples/label_image/bitmap_helpers.cc
@@ -51,6 +51,12 @@ int32_t ReadLe32(const std::vector<uint8_t>& bytes, size_t offset) {
 bool ValidateBmpAndGetPixelOffset(const std::vector<uint8_t>& img_bytes,
                                   int* width, int* height, int* channels,
                                   int* row_size, size_t* pixel_offset) {
+  if (width == nullptr || height == nullptr || channels == nullptr ||
+      row_size == nullptr || pixel_offset == nullptr) {
+    LOG(ERROR)
+        << "Null pointer argument passed to ValidateBmpAndGetPixelOffset";
+    return false;
+  }
   *width = 0;
   *height = 0;
   *channels = 0;
@@ -68,12 +74,13 @@ bool ValidateBmpAndGetPixelOffset(const std::vector<uint8_t>& img_bytes,
   const int32_t parsed_height = ReadLe32(img_bytes, 22);
   const uint16_t bpp = ReadLe16(img_bytes, 28);
 
-  if (parsed_pixel_offset < 0 ||
+  if (parsed_pixel_offset < static_cast<int32_t>(kBmpHeaderMinSize) ||
       static_cast<size_t>(parsed_pixel_offset) > img_bytes.size()) {
-    LOG(ERROR) << "BMP pixel data offset is outside the file";
+    LOG(ERROR) << "BMP pixel data offset is invalid or outside the file";
     return false;
   }
-  if (parsed_width <= 0 || parsed_height == 0 || parsed_height == std::numeric_limits<int>::min()) {
+  if (parsed_width <= 0 || parsed_height == 0 ||
+      parsed_height == std::numeric_limits<int32_t>::min()) {
     LOG(ERROR) << "Invalid BMP dimensions";
     return false;
   }

--- a/tensorflow/lite/examples/label_image/bitmap_helpers.cc
+++ b/tensorflow/lite/examples/label_image/bitmap_helpers.cc
@@ -92,6 +92,13 @@ bool ValidateBmpAndGetPixelOffset(const std::vector<uint8_t>& img_bytes,
   const int parsed_channels = bpp / 8;
   const int64_t abs_height = parsed_height < 0 ? -static_cast<int64_t>(parsed_height)
                                                : static_cast<int64_t>(parsed_height);
+  const uint64_t total_output_bytes = static_cast<uint64_t>(parsed_width) *
+                                      static_cast<uint64_t>(abs_height) *
+                                      static_cast<uint64_t>(parsed_channels);
+  if (total_output_bytes > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+    LOG(ERROR) << "Decoded BMP size exceeds maximum supported size";
+    return false;
+  }
   const int64_t bits_per_row = static_cast<int64_t>(bpp) * parsed_width;
   if (bits_per_row > (std::numeric_limits<int>::max() - 31)) {
     LOG(ERROR) << "BMP row size overflow";
@@ -126,19 +133,23 @@ bool ValidateBmpAndGetPixelOffset(const std::vector<uint8_t>& img_bytes,
 
 std::vector<uint8_t> decode_bmp(const uint8_t* input, int row_size, int width,
                                 int height, int channels, bool top_down) {
-  std::vector<uint8_t> output(height * width * channels);
+  std::vector<uint8_t> output(static_cast<size_t>(height) *
+                              static_cast<size_t>(width) *
+                              static_cast<size_t>(channels));
   for (int i = 0; i < height; i++) {
-    int src_pos;
-    int dst_pos;
+    size_t src_pos;
+    size_t dst_pos;
 
     for (int j = 0; j < width; j++) {
       if (!top_down) {
-        src_pos = ((height - 1 - i) * row_size) + j * channels;
+        src_pos = static_cast<size_t>(height - 1 - i) * row_size +
+                  static_cast<size_t>(j) * channels;
       } else {
-        src_pos = i * row_size + j * channels;
+        src_pos = static_cast<size_t>(i) * row_size +
+                  static_cast<size_t>(j) * channels;
       }
 
-      dst_pos = (i * width + j) * channels;
+      dst_pos = (static_cast<size_t>(i) * width + j) * channels;
 
       switch (channels) {
         case 1:

--- a/tensorflow/lite/examples/label_image/label_image_test.cc
+++ b/tensorflow/lite/examples/label_image/label_image_test.cc
@@ -16,6 +16,8 @@ limitations under the License.
 #include "tensorflow/lite/examples/label_image/label_image.h"
 
 #include <cstdint>
+#include <fstream>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -27,6 +29,44 @@ limitations under the License.
 
 namespace tflite {
 namespace label_image {
+namespace {
+
+std::string WriteTestBmp(const std::vector<uint8_t>& bytes,
+                         const std::string& name) {
+  const testing::TestInfo* test_info =
+      testing::UnitTest::GetInstance()->current_test_info();
+  const std::string filename =
+      ::testing::TempDir() + test_info->test_suite_name() + "_" +
+      test_info->name() + "_" + name + ".bmp";
+  std::ofstream file(filename, std::ios::binary);
+  file.write(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+  return filename;
+}
+
+std::vector<uint8_t> ValidBmpHeader(int32_t pixel_offset, int32_t width,
+                                    int32_t height, uint16_t bpp) {
+  std::vector<uint8_t> bytes(pixel_offset, 0);
+  bytes[0] = 'B';
+  bytes[1] = 'M';
+  auto write_le16 = [&bytes](size_t offset, uint16_t value) {
+    bytes[offset] = value & 0xff;
+    bytes[offset + 1] = value >> 8;
+  };
+  auto write_le32 = [&bytes](size_t offset, int32_t value) {
+    const uint32_t unsigned_value = static_cast<uint32_t>(value);
+    bytes[offset] = unsigned_value & 0xff;
+    bytes[offset + 1] = (unsigned_value >> 8) & 0xff;
+    bytes[offset + 2] = (unsigned_value >> 16) & 0xff;
+    bytes[offset + 3] = (unsigned_value >> 24) & 0xff;
+  };
+  write_le32(10, pixel_offset);
+  write_le32(18, width);
+  write_le32(22, height);
+  write_le16(28, bpp);
+  return bytes;
+}
+
+}  // namespace
 
 TEST(LabelImageTest, GraceHopper) {
   std::string lena_file =
@@ -45,6 +85,43 @@ TEST(LabelImageTest, GraceHopper) {
   resize<uint8_t>(output.data(), input.data(), 606, 517, 3, 214, 214, 3, &s);
   ASSERT_EQ(output[0], 0x15);
   ASSERT_EQ(output[214 * 214 * 3 - 1], 0x11);
+}
+
+TEST(LabelImageTest, RejectsTruncatedBmpHeader) {
+  const std::string filename = WriteTestBmp({'B', 'M'}, "truncated_header");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LabelImageTest, RejectsPixelDataOutsideFile) {
+  std::vector<uint8_t> bytes = ValidBmpHeader(128, 1, 1, 24);
+  const std::string filename = WriteTestBmp(bytes, "bad_pixel_offset");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LabelImageTest, RejectsShortPixelData) {
+  std::vector<uint8_t> bytes = ValidBmpHeader(54, 2, 2, 24);
+  bytes.resize(54 + 8);
+  const std::string filename = WriteTestBmp(bytes, "short_pixel_data");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LabelImageTest, RejectsRowSizeOverflow) {
+  std::vector<uint8_t> bytes =
+      ValidBmpHeader(54, std::numeric_limits<int32_t>::max(), 1, 32);
+  const std::string filename = WriteTestBmp(bytes, "row_size_overflow");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
 }
 
 TEST(LabelImageTest, GetTopN) {

--- a/tensorflow/lite/examples/label_image/label_image_test.cc
+++ b/tensorflow/lite/examples/label_image/label_image_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tensorflow/lite/examples/label_image/label_image.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <limits>
@@ -45,7 +46,8 @@ std::string WriteTestBmp(const std::vector<uint8_t>& bytes,
 
 std::vector<uint8_t> ValidBmpHeader(int32_t pixel_offset, int32_t width,
                                     int32_t height, uint16_t bpp) {
-  std::vector<uint8_t> bytes(pixel_offset, 0);
+  std::vector<uint8_t> bytes(
+      std::max<size_t>(pixel_offset < 0 ? 30 : pixel_offset, 30), 0);
   bytes[0] = 'B';
   bytes[1] = 'M';
   auto write_le16 = [&bytes](size_t offset, uint16_t value) {

--- a/tensorflow/lite/examples/label_image/label_image_test.cc
+++ b/tensorflow/lite/examples/label_image/label_image_test.cc
@@ -117,9 +117,83 @@ TEST(LabelImageTest, RejectsShortPixelData) {
 }
 
 TEST(LabelImageTest, RejectsRowSizeOverflow) {
-  std::vector<uint8_t> bytes =
-      ValidBmpHeader(54, std::numeric_limits<int32_t>::max(), 1, 32);
+  // Output size (width * height * channels) fits in int, but the padded
+  // row size in bits (bpp * width) overflows.
+  std::vector<uint8_t> bytes = ValidBmpHeader(54, 100000000, 1, 32);
   const std::string filename = WriteTestBmp(bytes, "row_size_overflow");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LabelImageTest, RejectsZeroWidth) {
+  std::vector<uint8_t> bytes = ValidBmpHeader(54, 0, 1, 24);
+  const std::string filename = WriteTestBmp(bytes, "zero_width");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LabelImageTest, RejectsNegativeWidth) {
+  std::vector<uint8_t> bytes = ValidBmpHeader(54, -1, 1, 24);
+  const std::string filename = WriteTestBmp(bytes, "negative_width");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LabelImageTest, RejectsZeroHeight) {
+  std::vector<uint8_t> bytes = ValidBmpHeader(54, 1, 0, 24);
+  const std::string filename = WriteTestBmp(bytes, "zero_height");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LabelImageTest, RejectsInt32MinHeight) {
+  std::vector<uint8_t> bytes =
+      ValidBmpHeader(54, 1, std::numeric_limits<int32_t>::min(), 24);
+  const std::string filename = WriteTestBmp(bytes, "int32_min_height");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LabelImageTest, RejectsPixelOffsetInsideHeader) {
+  std::vector<uint8_t> bytes = ValidBmpHeader(10, 1, 1, 24);
+  const std::string filename = WriteTestBmp(bytes, "pixel_offset_in_header");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LabelImageTest, RejectsUnsupportedBpp4) {
+  std::vector<uint8_t> bytes = ValidBmpHeader(54, 1, 1, 4);
+  const std::string filename = WriteTestBmp(bytes, "bpp_4");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LabelImageTest, RejectsUnsupportedBpp16) {
+  std::vector<uint8_t> bytes = ValidBmpHeader(54, 1, 1, 16);
+  const std::string filename = WriteTestBmp(bytes, "bpp_16");
+  int height, width, channels;
+  Settings s;
+  auto result = read_bmp(filename, &width, &height, &channels, &s);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(LabelImageTest, RejectsOutputSizeOverflow) {
+  std::vector<uint8_t> bytes = ValidBmpHeader(54, 65536, 65536, 24);
+  const std::string filename = WriteTestBmp(bytes, "output_size_overflow");
   int height, width, channels;
   Settings s;
   auto result = read_bmp(filename, &width, &height, &channels, &s);


### PR DESCRIPTION
## Summary

Centralize BMP validation in `label_image` before decoding to reject malformed or truncated inputs safely and avoid unsafe header-derived arithmetic/indexing.

## Changes

* Add centralized BMP validation through `ValidateBmpAndGetPixelOffset()`
* Replace unaligned `reinterpret_cast` header reads with endian-safe byte readers
* Validate BMP header size and signature before accessing fixed offsets
* Reject invalid pixel offsets outside file bounds
* Reject invalid or unsupported BMP dimensions/BPP values
* Prevent row-size and pixel-span integer overflow during decode setup
* Reject truncated pixel data before decode begins
* Replace fatal parser termination with graceful parse failure
* Ensure output parameters remain deterministic on validation failure

## Tests

Added regression tests covering:

* Truncated BMP headers
* Pixel offsets outside file bounds
* Truncated pixel data
* Row-size overflow handling

## Notes

* Preserves existing supported BMP formats and decode behavior
* Keeps validation localized to BMP parsing setup without changing decode logic