### PR TITLE
Validate metadata-driven chunk indices before vector access

### DIFF
--- a/tensorflow/cc/saved_model/fingerprinting_utils.cc
+++ b/tensorflow/cc/saved_model/fingerprinting_utils.cc
@@ -219,6 +219,9 @@ absl::StatusOr<uint64_t> HashFields(
     if (chunked_message.has_chunk_index() && matches == field_tags.size()) {
       // chunked_field_tags are an exact match with field_tags. Hash referenced
       // chunk.
+      TF_RETURN_IF_ERROR(
+          tools::proto_splitter::ValidateChunkIndex(
+              chunked_message.chunk_index(), chunks_info.size()));
       TF_ASSIGN_OR_RETURN(
           std::string chunk,
           ReadChunk(reader, chunks_info[chunked_message.chunk_index()]));
@@ -244,6 +247,9 @@ absl::StatusOr<uint64_t> HashFields(
         merged_message =
             mfr.parent->GetReflection()->MutableMessage(mfr.parent, mfr.field);
       }
+      TF_RETURN_IF_ERROR(
+          tools::proto_splitter::ValidateChunkIndex(
+              chunked_message.chunk_index(), chunks_info.size()));
       TF_ASSIGN_OR_RETURN(
           std::string chunk,
           ReadChunk(reader, chunks_info[chunked_message.chunk_index()]));

--- a/tensorflow/cc/saved_model/fingerprinting_utils_test.cc
+++ b/tensorflow/cc/saved_model/fingerprinting_utils_test.cc
@@ -391,6 +391,41 @@ TEST(FingerprintingTest, TestHashSavedObjectGraph) {
       absl_testing::IsOkAndHolds(17454850744699451884U));
 }
 
+TEST(FingerprintingTest, TestHashFieldsReturnsErrorOnInvalidChunkIndex) {
+  std::string cpb_file = io::JoinPath(
+      TensorFlowSrcRoot(), "tools/proto_splitter/testdata", "many-field.cpb");
+  TF_ASSERT_OK_AND_ASSIGN(auto reader, GetRiegeliReader(cpb_file));
+
+  auto read_metadata = GetChunkMetadata(reader);
+  if (!read_metadata.ok()) {
+    reader.Close();
+    TF_ASSERT_OK(read_metadata.status());
+  }
+  ChunkMetadata chunk_metadata = read_metadata.value();
+
+  ChunkedMessage invalid_chunked_message;
+  invalid_chunked_message.set_chunk_index(0);
+  auto* invalid_field = invalid_chunked_message.add_chunked_fields();
+  invalid_field->add_field_tag()->set_field(1);
+
+  std::vector<ChunkInfo> chunks_info = std::vector<ChunkInfo>(
+      chunk_metadata.chunks().begin(), chunk_metadata.chunks().end());
+  invalid_field->mutable_message()->set_chunk_index(chunks_info.size());
+
+  RepeatedPtrField<FieldIndex> target_tags;
+  target_tags.Add()->set_field(1);
+
+  ManyFields merged_message;
+
+  auto statusor = HashFields(invalid_chunked_message, reader, chunks_info,
+                             target_tags, &merged_message);
+
+  EXPECT_FALSE(statusor.ok());
+  EXPECT_EQ(statusor.status().code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(statusor.status().message()),
+              ::testing::HasSubstr("is out of range"));
+}
+
 }  // namespace
 
 }  // namespace tensorflow::saved_model::fingerprinting

--- a/tensorflow/cc/saved_model/fingerprinting_utils_test.cc
+++ b/tensorflow/cc/saved_model/fingerprinting_utils_test.cc
@@ -416,6 +416,41 @@ TEST(FingerprintingTest, CreateFingerprintDefNonExistentDirectoryReturnsError) {
   EXPECT_FALSE(result.ok());
 }
 
+TEST(FingerprintingTest, TestHashFieldsReturnsErrorOnInvalidChunkIndex) {
+  std::string cpb_file = io::JoinPath(
+      TensorFlowSrcRoot(), "tools/proto_splitter/testdata", "many-field.cpb");
+  TF_ASSERT_OK_AND_ASSIGN(auto reader, GetRiegeliReader(cpb_file));
+
+  auto read_metadata = GetChunkMetadata(reader);
+  if (!read_metadata.ok()) {
+    reader.Close();
+    TF_ASSERT_OK(read_metadata.status());
+  }
+  ChunkMetadata chunk_metadata = read_metadata.value();
+
+  ChunkedMessage invalid_chunked_message;
+  invalid_chunked_message.set_chunk_index(0);
+  auto* invalid_field = invalid_chunked_message.add_chunked_fields();
+  invalid_field->add_field_tag()->set_field(1);
+
+  std::vector<ChunkInfo> chunks_info = std::vector<ChunkInfo>(
+      chunk_metadata.chunks().begin(), chunk_metadata.chunks().end());
+  invalid_field->mutable_message()->set_chunk_index(chunks_info.size());
+
+  RepeatedPtrField<FieldIndex> target_tags;
+  target_tags.Add()->set_field(1);
+
+  ManyFields merged_message;
+
+  auto statusor = HashFields(invalid_chunked_message, reader, chunks_info,
+                             target_tags, &merged_message);
+
+  EXPECT_FALSE(statusor.ok());
+  EXPECT_EQ(statusor.status().code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(statusor.status().message()),
+              ::testing::HasSubstr("is out of range"));
+}
+
 }  // namespace
 
 }  // namespace tensorflow::saved_model::fingerprinting

--- a/tensorflow/tools/proto_splitter/cc/util.cc
+++ b/tensorflow/tools/proto_splitter/cc/util.cc
@@ -801,5 +801,12 @@ absl::StatusOr<bool> OnlyContainsPb(absl::string_view prefix) {
   return false;
 }
 
+absl::Status ValidateChunkIndex(uint64_t chunk_index, size_t chunks_size) {
+  if (chunk_index < chunks_size) return absl::OkStatus();
+  return absl::FailedPreconditionError(absl::StrCat(
+      "Chunk index ", chunk_index, " is out of range for ", chunks_size,
+      " chunks."));
+}
+
 }  // namespace tools::proto_splitter
 }  // namespace tensorflow

--- a/tensorflow/tools/proto_splitter/cc/util.h
+++ b/tensorflow/tools/proto_splitter/cc/util.h
@@ -15,6 +15,7 @@ limitations under the License.
 #ifndef TENSORFLOW_TOOLS_PROTO_SPLITTER_CC_UTIL_H_
 #define TENSORFLOW_TOOLS_PROTO_SPLITTER_CC_UTIL_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -164,6 +165,9 @@ absl::StatusOr<std::string> ReadChunk(
 // Returns true if prefix can only be found as a .pb file, and false if a .cpb
 // file exists. Returns an error if neither .pb nor .cpb exist.
 absl::StatusOr<bool> OnlyContainsPb(absl::string_view prefix);
+
+// Validates that a chunk index is within the bounds of a chunks vector.
+absl::Status ValidateChunkIndex(uint64_t chunk_index, size_t chunks_size);
 
 }  // namespace tools::proto_splitter
 }  // namespace tensorflow

--- a/tensorflow/tools/proto_splitter/cc/util.h
+++ b/tensorflow/tools/proto_splitter/cc/util.h
@@ -15,6 +15,7 @@ limitations under the License.
 #ifndef TENSORFLOW_TOOLS_PROTO_SPLITTER_CC_UTIL_H_
 #define TENSORFLOW_TOOLS_PROTO_SPLITTER_CC_UTIL_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -163,6 +164,9 @@ absl::StatusOr<std::string> ReadChunk(
 // Returns true if prefix can only be found as a .pb file, and false if a .cpb
 // file exists. Returns an error if neither .pb nor .cpb exist.
 absl::StatusOr<bool> OnlyContainsPb(absl::string_view prefix);
+
+// Validates that a chunk index is within the bounds of a chunks vector.
+absl::Status ValidateChunkIndex(uint64_t chunk_index, size_t chunks_size);
 
 }  // namespace tools::proto_splitter
 }  // namespace tensorflow

--- a/tensorflow/tools/proto_splitter/merge.cc
+++ b/tensorflow/tools/proto_splitter/merge.cc
@@ -59,6 +59,8 @@ absl::Status Merger::Merge(const std::vector<std::unique_ptr<Message>>& chunks,
 
   if (chunked_message.has_chunk_index()) {
     // Chunks referenced by fields should be merged into the parent chunk.
+    TF_RETURN_IF_ERROR(
+        ValidateChunkIndex(chunked_message.chunk_index(), chunks.size()));
     merged_message->MergeFrom(*chunks[chunked_message.chunk_index()].get());
   }
 
@@ -194,6 +196,8 @@ absl::Status Merger::ReadFields(const ChunkedMessage& chunked_message,
                                 tsl::protobuf::Message* merged_message) {
   if (chunked_message.has_chunk_index()) {
     // Chunks referenced by fields should be merged into the parent chunk.
+    TF_RETURN_IF_ERROR(
+        ValidateChunkIndex(chunked_message.chunk_index(), chunks_info.size()));
     TF_ASSIGN_OR_RETURN(
         std::string chunk,
         ReadChunk(reader, chunks_info[chunked_message.chunk_index()]));
@@ -261,12 +265,18 @@ absl::Status Merger::ProcessField(
   std::string chunk;
   switch (op) {
     case MergerOp::READ: {
+      TF_RETURN_IF_ERROR(
+          ValidateChunkIndex(chunked_field.message().chunk_index(),
+                             chunks_info.size()));
       TF_ASSIGN_OR_RETURN(
           chunk, ReadChunk(reader,
                            chunks_info[chunked_field.message().chunk_index()]));
       break;
     }
     case MergerOp::MERGE: {
+      TF_RETURN_IF_ERROR(
+          ValidateChunkIndex(chunked_field.message().chunk_index(),
+                             chunks.size()));
       chunk =
           chunks[chunked_field.message().chunk_index()]->SerializeAsString();
       break;

--- a/tensorflow/tools/proto_splitter/merge.cc
+++ b/tensorflow/tools/proto_splitter/merge.cc
@@ -59,6 +59,8 @@ absl::Status Merger::Merge(const std::vector<std::unique_ptr<Message>>& chunks,
 
   if (chunked_message.has_chunk_index()) {
     // Chunks referenced by fields should be merged into the parent chunk.
+    TF_RETURN_IF_ERROR(
+        ValidateChunkIndex(chunked_message.chunk_index(), chunks.size()));
     merged_message->MergeFrom(*chunks[chunked_message.chunk_index()].get());
   }
 
@@ -237,6 +239,8 @@ absl::Status Merger::ReadFields(const ChunkedMessage& chunked_message,
                                 tsl::protobuf::Message* merged_message) {
   if (chunked_message.has_chunk_index()) {
     // Chunks referenced by fields should be merged into the parent chunk.
+    TF_RETURN_IF_ERROR(
+        ValidateChunkIndex(chunked_message.chunk_index(), chunks_info.size()));
     TF_ASSIGN_OR_RETURN(
         std::string chunk,
         ReadChunk(reader, chunks_info[chunked_message.chunk_index()]));
@@ -305,12 +309,18 @@ absl::Status Merger::ProcessField(
   std::string chunk;
   switch (op) {
     case MergerOp::READ: {
+      TF_RETURN_IF_ERROR(
+          ValidateChunkIndex(chunked_field.message().chunk_index(),
+                             chunks_info.size()));
       TF_ASSIGN_OR_RETURN(
           chunk, ReadChunk(reader,
                            chunks_info[chunked_field.message().chunk_index()]));
       break;
     }
     case MergerOp::MERGE: {
+      TF_RETURN_IF_ERROR(
+          ValidateChunkIndex(chunked_field.message().chunk_index(),
+                             chunks.size()));
       chunk =
           chunks[chunked_field.message().chunk_index()]->SerializeAsString();
       break;

--- a/tensorflow/tools/proto_splitter/merge_test.cc
+++ b/tensorflow/tools/proto_splitter/merge_test.cc
@@ -312,6 +312,72 @@ TEST(MergeTest, TestProcessFieldReturnsErrorOnInvalidFieldNumber) {
               ::testing::HasSubstr("not found in message descriptor"));
 }
 
+TEST(MergeTest, TestMergeReturnsErrorOnInvalidRootChunkIndex) {
+  ::tensorflow::proto_splitter::ChunkedMessage chunked_message;
+  chunked_message.set_chunk_index(1);
+
+  std::vector<std::unique_ptr<tsl::protobuf::Message>> chunks;
+  chunks.push_back(
+      std::make_unique<::tensorflow::proto_splitter_testdata::ManyFields>());
+
+  ::tensorflow::proto_splitter_testdata::ManyFields merged;
+  absl::Status status = Merger::Merge(chunks, chunked_message, &merged);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(status.message()),
+              ::testing::HasSubstr("Chunk index 1 is out of range"));
+}
+
+TEST(MergeTest, TestMergeReturnsErrorOnInvalidNestedChunkIndex) {
+  ::tensorflow::proto_splitter::ChunkedMessage chunked_message;
+  auto* chunk_field = chunked_message.add_chunked_fields();
+  auto* tag = chunk_field->add_field_tag();
+  tag->set_field(1);
+  chunk_field->mutable_message()->set_chunk_index(1);
+
+  std::vector<std::unique_ptr<tsl::protobuf::Message>> chunks;
+  chunks.push_back(
+      std::make_unique<::tensorflow::proto_splitter_testdata::ManyFields>());
+
+  ::tensorflow::proto_splitter_testdata::ManyFields merged;
+  absl::Status status = Merger::Merge(chunks, chunked_message, &merged);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(status.message()),
+              ::testing::HasSubstr("Chunk index 1 is out of range"));
+}
+
+TEST(MergeTest, TestReadPartialReturnsErrorOnInvalidRootChunkIndex) {
+  const std::string path =
+      io::JoinPath(testing::TensorFlowSrcRoot(),
+                   "tools/proto_splitter/testdata", "many-field");
+  TF_ASSERT_OK_AND_ASSIGN(auto reader, tools::proto_splitter::GetRiegeliReader(
+                                           absl::StrCat(path, ".cpb")));
+
+  auto read_metadata = GetChunkMetadata(reader);
+  if (!read_metadata.ok()) {
+    reader.Close();
+    TF_ASSERT_OK(read_metadata.status());
+  }
+  reader.Close();
+
+  ::tensorflow::proto_splitter::ChunkMetadata chunk_metadata =
+      read_metadata.value();
+  chunk_metadata.mutable_message()->set_chunk_index(
+      chunk_metadata.chunks_size());
+
+  proto_splitter_testdata::ManyFields merged_many_fields;
+  absl::Status status =
+      Merger::ReadPartial(path, chunk_metadata, &merged_many_fields);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(std::string(status.message()),
+              ::testing::HasSubstr("is out of range"));
+}
+
 }  // namespace
 
 }  // namespace tensorflow::tools::proto_splitter


### PR DESCRIPTION
## Summary

Adds centralized validation for metadata-driven `chunk_index` values before vector access in proto splitter merge and fingerprint parsing paths.

Malformed `.cpb` metadata could previously trigger unchecked indexing into `chunks` / `chunks_info` vectors during merge and fingerprint processing.

This change introduces a shared `ValidateChunkIndex()` helper and applies it consistently across all affected metadata-driven lookup paths.

## Changes

- Add shared `ValidateChunkIndex(uint64_t, size_t)` helper in `proto_splitter/cc/util.{h,cc}`
- Validate root chunk indices in `Merger::Merge()`
- Validate root chunk indices in `Merger::ReadFields()`
- Validate nested chunk indices in `Merger::ProcessField()` (`READ` and `MERGE`)
- Validate chunk indices in SavedModel fingerprint parsing paths
- Add regression coverage for invalid root and nested chunk indices
- Add regression coverage for invalid fingerprint metadata

## Behavior

Before:
- Malformed metadata could reach unchecked vector indexing paths

After:
- Invalid chunk indices fail deterministically with
  `absl::StatusCode::kFailedPrecondition`

## Testing

Added regression tests for:
- invalid root merge chunk index
- invalid nested merge chunk index
- invalid `ReadPartial()` metadata
- invalid fingerprint parsing chunk index