### PR TITLE
Enforce runtime vector rank invariants in StringNGrams

### DIFF
--- a/tensorflow/core/kernels/string_ngrams_op.cc
+++ b/tensorflow/core/kernels/string_ngrams_op.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include "absl/strings/str_cat.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/op_requires.h"
+#include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/platform/errors.h"
 #include "tensorflow/core/platform/types.h"
 
@@ -73,10 +74,17 @@ class StringNGramsOp : public tensorflow::OpKernel {
 
     const tensorflow::Tensor* data;
     OP_REQUIRES_OK(context, context->input("data", &data));
+    OP_REQUIRES(context, TensorShapeUtils::IsVector(data->shape()),
+                errors::InvalidArgument("data must be a vector, got shape: ",
+                                        data->shape().DebugString()));
     const auto& input_data = data->flat<tstring>().data();
 
     const tensorflow::Tensor* splits;
     OP_REQUIRES_OK(context, context->input("data_splits", &splits));
+    OP_REQUIRES(context, TensorShapeUtils::IsVector(splits->shape()),
+                errors::InvalidArgument(
+                    "data_splits must be a vector, got shape: ",
+                    splits->shape().DebugString()));
     const auto& splits_vec = splits->flat<SPLITS_TYPE>();
 
     // Validate that the splits are valid indices into data, only if there are

--- a/tensorflow/python/ops/raw_ops_test.py
+++ b/tensorflow/python/ops/raw_ops_test.py
@@ -76,6 +76,24 @@ class RawOpsTest(test.TestCase, parameterized.TestCase):
               pad_width=0,
               preserve_short_sequences=False))
 
+  @parameterized.parameters(
+      ([[["aa"], ["bb"]]], [0, 2], "data must be a vector"),
+      (["aa", "bb"], [[0, 2]], "data_splits must be a vector"),
+  )
+  def testStringNGramsRejectsNonVectorInputs(
+      self, data, data_splits, expected_error):
+    with self.assertRaisesRegex(errors.InvalidArgumentError, expected_error):
+      self.evaluate(
+          gen_string_ops.string_n_grams(
+              data=data,
+              data_splits=data_splits,
+              separator="",
+              ngram_widths=[1],
+              left_pad="",
+              right_pad="",
+              pad_width=0,
+              preserve_short_sequences=False))
+
   def testStringSplit(self):
     data = ["123456"]
     data_splits = [0, 1]

--- a/tensorflow/python/ops/raw_ops_test.py
+++ b/tensorflow/python/ops/raw_ops_test.py
@@ -82,17 +82,29 @@ class RawOpsTest(test.TestCase, parameterized.TestCase):
   )
   def testStringNGramsRejectsNonVectorInputs(
       self, data, data_splits, expected_error):
-    with self.assertRaisesRegex(errors.InvalidArgumentError, expected_error):
-      self.evaluate(
-          gen_string_ops.string_n_grams(
-              data=data,
-              data_splits=data_splits,
-              separator="",
-              ngram_widths=[1],
-              left_pad="",
-              right_pad="",
-              pad_width=0,
-              preserve_short_sequences=False))
+    if context.executing_eagerly():
+      with self.assertRaisesRegex(errors.InvalidArgumentError, expected_error):
+        self.evaluate(
+            gen_string_ops.string_n_grams(
+                data=data,
+                data_splits=data_splits,
+                separator="",
+                ngram_widths=[1],
+                left_pad="",
+                right_pad="",
+                pad_width=0,
+                preserve_short_sequences=False))
+    else:
+      with self.assertRaisesRegex(ValueError, "Shape must be rank 1"):
+        gen_string_ops.string_n_grams(
+            data=data,
+            data_splits=data_splits,
+            separator="",
+            ngram_widths=[1],
+            left_pad="",
+            right_pad="",
+            pad_width=0,
+            preserve_short_sequences=False)
 
   def testStringSplit(self):
     data = ["123456"]


### PR DESCRIPTION
## Summary
Enforce the existing rank-1 input contract for `StringNGrams` at runtime in eager/raw execution paths.

## What changed
- Added runtime `TensorShapeUtils::IsVector(...)` validation for:
  - `data`
  - `data_splits`
- Added regression tests covering non-vector inputs.

## Why
`StringNGrams` already declares rank-1 inputs in its op shape function, but eager/raw execution currently allows higher-rank tensors to reach the kernel where `flat<>()` silently flattens them.

This leads to inconsistent behavior between execution modes:
- Graph mode rejects malformed ranks during shape inference.
- Eager/raw execution accepts them and proceeds.

Example observed pre-patch behavior:
- Rank-3 `data` input executes successfully.
- Rank-2 `data_splits` input returns a rank-2 output splits tensor, violating the op’s declared vector invariant.

## Result
Runtime behavior is now consistent across execution modes:
- malformed higher-rank inputs are rejected early with `InvalidArgumentError`
- kernel execution no longer silently normalizes invalid tensor ranks

## Tests
Added regression coverage for:
- non-vector `data`
- non-vector `data_splits`