### PR TITLE
Validate VarianceScaling distribution type

### DIFF
--- a/tensorflow/python/kernel_tests/array_ops/init_ops_test.py
+++ b/tensorflow/python/kernel_tests/array_ops/init_ops_test.py
@@ -451,6 +451,14 @@ class VarianceScalingInitializationTest(test.TestCase):
     self.assertNear(np.mean(x), expect_mean, err=1e-2)
     self.assertNear(np.var(x), expect_var, err=1e-2)
 
+  @test_util.run_deprecated_v1
+  def testInvalidDistributionType(self):
+    with self.assertRaisesRegex(ValueError, "must be a string"):
+      init_ops.variance_scaling_initializer(distribution=None)
+    with self.assertRaisesRegex(ValueError, "must be a string"):
+      init_ops.variance_scaling_initializer(distribution=123)
+
+
 
 # TODO(vrv): move to sequence_ops_test?
 class RangeTest(test.TestCase):

--- a/tensorflow/python/ops/init_ops.py
+++ b/tensorflow/python/ops/init_ops.py
@@ -842,6 +842,9 @@ class VarianceScaling(Initializer):
     if mode not in {"fan_in", "fan_out", "fan_avg"}:
       raise ValueError("Argument `mode` should be one of ('fan_in', 'fan_out', "
                        f"'fan_avg'). Received: {mode}")
+    if not isinstance(distribution, str):
+      raise ValueError("Argument `distribution` must be a string. Received: "
+                       f"{distribution} (of type {type(distribution).__name__})")
     distribution = distribution.lower()
     if distribution not in {
         "normal", "uniform", "truncated_normal", "untruncated_normal"

--- a/tensorflow/python/ops/init_ops_v2.py
+++ b/tensorflow/python/ops/init_ops_v2.py
@@ -560,6 +560,9 @@ class VarianceScaling(Initializer):
     if mode not in {"fan_in", "fan_out", "fan_avg"}:
       raise ValueError("Argument `mode` should be one of ('fan_in', 'fan_out', "
                        f"'fan_avg'). Received: {mode}")
+    if not isinstance(distribution, str):
+      raise ValueError("Argument `distribution` must be a string. Received: "
+                       f"{distribution} (of type {type(distribution).__name__})")
     distribution = distribution.lower()
     # Compatibility with keras-team/keras.
     if distribution == "normal":

--- a/tensorflow/python/ops/init_ops_v2_test.py
+++ b/tensorflow/python/ops/init_ops_v2_test.py
@@ -384,6 +384,14 @@ class VarianceScalingInitializerTest(InitializersTest):
     self.assertNear(np.mean(x), expect_mean, err=2e-3)
     self.assertNear(np.var(x), expect_var, err=2e-3)
 
+  @test_util.run_in_graph_and_eager_modes
+  def testInvalidDistributionType(self):
+    with self.assertRaisesRegex(ValueError, "must be a string"):
+      init_ops_v2.VarianceScaling(distribution=None)
+    with self.assertRaisesRegex(ValueError, "must be a string"):
+      init_ops_v2.VarianceScaling(distribution=123)
+
+
 
 class OrthogonalInitializerTest(InitializersTest):
 


### PR DESCRIPTION
This PR improves input validation for `tf.keras.initializers.VarianceScaling` by adding a clear error message when `distribution` is not a string.

The change helps users understand the expected input type and includes a focused unit test to verify the behavior.