### PR TITLE
TFLite: validate malformed TfLiteIntArray sizes and harden delegate allocation arithmetic

### DIFF
--- a/tensorflow/lite/core/c/c_api_test.cc
+++ b/tensorflow/lite/core/c/c_api_test.cc
@@ -596,6 +596,56 @@ TEST(CApiSimple, OpaqueDelegate_TransferOperatorOwnershipWithoutNodeToReplace) {
   g_opaque_delegate_struct = nullptr;
 }
 
+TEST(CApiRobustness, ReplaceNodeSubsetsWithDelegateKernelsRejectsMalformedArray) {
+  // This test verifies that a delegate calling the public API with a
+  // malformed (negative-sized) TfLiteIntArray is rejected safely and does
+  // not lead to UB/crash.
+  TfLiteModel* model =
+      TfLiteModelCreateFromFile("tensorflow/lite/testdata/add.bin");
+
+  struct DelegateState {
+    bool delegate_prepared = false;
+  } delegate_state;
+
+  TfLiteOpaqueDelegateBuilder opaque_delegate_builder{};
+  opaque_delegate_builder.data = &delegate_state;
+  opaque_delegate_builder.Prepare = [](TfLiteOpaqueContext* opaque_context,
+                                       TfLiteOpaqueDelegate* opaque_delegate,
+                                       void* data) {
+    auto* state = static_cast<DelegateState*>(data);
+    state->delegate_prepared = true;
+
+    // Create a valid zero-sized array then flip its size to negative to
+    // simulate a malicious/corrupted external input.
+    TfLiteIntArray* malformed = TfLiteIntArrayCreate(0);
+    malformed->size = -1;
+
+    // Call the public API. Expect it to return an error rather than crash.
+    TfLiteStatus status = TfLiteOpaqueContextReplaceNodeSubsetsWithDelegateKernels(
+        opaque_context, CreateDelegateKernelExternalRegistration(), malformed,
+        opaque_delegate);
+    EXPECT_EQ(status, kTfLiteError);
+
+    TfLiteIntArrayFree(malformed);
+    return kTfLiteOk;
+  };
+
+  TfLiteOpaqueDelegate* opaque_delegate =
+      TfLiteOpaqueDelegateCreate(&opaque_delegate_builder);
+  TfLiteInterpreterOptions* options = TfLiteInterpreterOptionsCreate();
+  TfLiteInterpreterOptionsAddDelegate(options, opaque_delegate);
+  TfLiteInterpreter* interpreter =
+      TfLiteInterpreterCreate(model, options);
+
+  // Prepare should have run and not crashed.
+  EXPECT_TRUE(delegate_state.delegate_prepared);
+
+  TfLiteInterpreterDelete(interpreter);
+  TfLiteInterpreterOptionsDelete(options);
+  TfLiteOpaqueDelegateDelete(opaque_delegate);
+  TfLiteModelDelete(model);
+}
+
 using ::tflite::delegates::test_utils::TestFP16Delegation;
 
 TEST_F(TestFP16Delegation,

--- a/tensorflow/lite/core/c/common.cc
+++ b/tensorflow/lite/core/c/common.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #endif  // TF_LITE_STATIC_MEMORY
 
 #include <cstring>
+#include <limits>
 #include <new>
 #include <type_traits>
 #include <utility>
@@ -33,8 +34,17 @@ namespace {
 
 template <class T>
 size_t TfLiteVarArrayGetSizeInBytes(const int size) {
+  if (size < 0) {
+    return 0;
+  }
   constexpr size_t data_size = sizeof(std::declval<T>().data[0]);
-  size_t computed_size = sizeof(T) + data_size * size;
+  constexpr size_t fixed_size = sizeof(T);
+  const size_t array_size = static_cast<size_t>(size);
+  if (array_size >
+      (std::numeric_limits<size_t>::max() - fixed_size) / data_size) {
+    return 0;
+  }
+  size_t computed_size = fixed_size + data_size * array_size;
 #if defined(_MSC_VER)
   // Context for why this is needed is in http://b/189926408#comment21
   computed_size -= data_size;

--- a/tensorflow/lite/core/c/common_test.cc
+++ b/tensorflow/lite/core/c/common_test.cc
@@ -54,6 +54,8 @@ TEST(IntArray, TestIntArrayCreate) {
 TEST(IntArray, GetSizeInBytesRejectsNegativeSize) {
   EXPECT_EQ(TfLiteIntArrayGetSizeInBytes(-1), 0);
   EXPECT_EQ(TfLiteIntArrayCreate(-1), nullptr);
+  // Zero-sized arrays must keep working (0-D scalar tensors, empty lists).
+  EXPECT_GT(TfLiteIntArrayGetSizeInBytes(0), 0);
 }
 
 TEST(IntArray, TestIntArrayCopy) {

--- a/tensorflow/lite/core/c/common_test.cc
+++ b/tensorflow/lite/core/c/common_test.cc
@@ -51,6 +51,11 @@ TEST(IntArray, TestIntArrayCreate) {
   TfLiteIntArrayFree(b);
 }
 
+TEST(IntArray, GetSizeInBytesRejectsNegativeSize) {
+  EXPECT_EQ(TfLiteIntArrayGetSizeInBytes(-1), 0);
+  EXPECT_EQ(TfLiteIntArrayCreate(-1), nullptr);
+}
+
 TEST(IntArray, TestIntArrayCopy) {
   TfLiteIntArray* a = TfLiteIntArrayCreate(2);
   a->data[0] = 22;

--- a/tensorflow/lite/core/subgraph.cc
+++ b/tensorflow/lite/core/subgraph.cc
@@ -23,6 +23,7 @@ limitations under the License.
 #include <cstdlib>
 #include <cstring>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <string>
@@ -396,23 +397,48 @@ template <typename Params>
 Params* CreateDelegateParamsImpl(TfLiteDelegate* delegate,
                                  const NodeSubset& node_subset) {
   // Step 1: Calculate the allocation size.
-  int allocation_size = sizeof(Params);
+  size_t allocation_size = sizeof(Params);
+  auto add_to_allocation_size = [&allocation_size](size_t size) {
+    if (size > std::numeric_limits<size_t>::max() - allocation_size) {
+      return false;
+    }
+    allocation_size += size;
+    return true;
+  };
+  auto int_array_size_in_bytes = [](size_t elements) {
+    if (elements > static_cast<size_t>(std::numeric_limits<int>::max())) {
+      return size_t{0};
+    }
+    return TfLiteIntArrayGetSizeInBytes(static_cast<int>(elements));
+  };
 
-  int nodes_to_replace_size =
-      TfLiteIntArrayGetSizeInBytes(node_subset.nodes.size());
-  allocation_size += nodes_to_replace_size;
+  size_t nodes_to_replace_size =
+      int_array_size_in_bytes(node_subset.nodes.size());
+  if (nodes_to_replace_size == 0 ||
+      !add_to_allocation_size(nodes_to_replace_size)) {
+    return nullptr;
+  }
 
-  int input_tensors_size =
-      TfLiteIntArrayGetSizeInBytes(node_subset.input_tensors.size());
-  allocation_size += input_tensors_size;
+  size_t input_tensors_size =
+      int_array_size_in_bytes(node_subset.input_tensors.size());
+  if (input_tensors_size == 0 ||
+      !add_to_allocation_size(input_tensors_size)) {
+    return nullptr;
+  }
 
-  int output_tensors_size =
-      TfLiteIntArrayGetSizeInBytes(node_subset.output_tensors.size());
-  allocation_size += output_tensors_size;
+  size_t output_tensors_size =
+      int_array_size_in_bytes(node_subset.output_tensors.size());
+  if (output_tensors_size == 0 ||
+      !add_to_allocation_size(output_tensors_size)) {
+    return nullptr;
+  }
 
   // Step 2: Allocate the memory.
   // Use `char*` for conveniently step through the allocated space by bytes.
   char* allocation = static_cast<char*>(malloc(allocation_size));
+  if (allocation == nullptr) {
+    return nullptr;
+  }
 
   // Step 3: Fill all data structures.
   Params* params = reinterpret_cast<Params*>(allocation);
@@ -560,6 +586,13 @@ TfLiteStatus Subgraph::ReplaceNodeSubsetsWithDelegateKernels(
     }
   }
 
+  // Defensive validation: ensure externally-supplied arrays are sane. This
+  // prevents constructing a TfLiteIntArrayView from a negative size which
+  // results in invalid pointer arithmetic and undefined behavior.
+  TF_LITE_ENSURE(&context_, nodes_to_replace != nullptr);
+  TF_LITE_ENSURE_MSG(&context_, nodes_to_replace->size >= 0,
+                     "Invalid nodes_to_replace array (negative size).");
+
   // Ignore empty node replacement sets.
   if (!nodes_to_replace->size) {
     return kTfLiteOk;
@@ -609,6 +642,7 @@ TfLiteStatus Subgraph::ReplaceNodeSubsetsWithDelegateKernels(
               CreateDelegateParams(delegate, node_subset);
           delegate_params = params;
         }
+        TF_LITE_ENSURE(&context_, delegate_params != nullptr);
         TF_LITE_ENSURE_STATUS(AddNodeWithParameters(
             node_subset.input_tensors, node_subset.output_tensors, {}, nullptr,
             0, delegate_params, &registration, &node_index));

--- a/tensorflow/security/fuzzing/cc/BUILD
+++ b/tensorflow/security/fuzzing/cc/BUILD
@@ -253,3 +253,16 @@ tf_cc_fuzz_test(
         "@xla//xla/tsl/platform:env",
     ],
 )
+
+tf_cc_fuzz_test(
+    name = "tflite_intarray_fuzz",
+    srcs = ["tflite_intarray_fuzz.cc"],
+    data = ["//tensorflow/lite:testdata/add.bin"],
+    tags = ["no_oss"],
+    deps = [
+        "//tensorflow/lite:builtin_ops",
+        "//tensorflow/lite/c:c_api",
+        "//tensorflow/lite/c:c_api_experimental",
+        "//tensorflow/lite/c:common",
+    ],
+)

--- a/tensorflow/security/fuzzing/cc/tflite_intarray_fuzz.cc
+++ b/tensorflow/security/fuzzing/cc/tflite_intarray_fuzz.cc
@@ -1,0 +1,145 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include <cassert>
+#include <cstddef>
+
+#include "fuzztest/fuzztest.h"
+#include "tensorflow/lite/builtin_ops.h"
+#include "tensorflow/lite/c/c_api.h"
+#include "tensorflow/lite/c/c_api_opaque.h"
+#include "tensorflow/lite/c/common.h"
+
+// This fuzzer exercises the TfLiteIntArray/TfLiteFloatArray size handling and
+// the delegate setup path (`ReplaceNodeSubsetsWithDelegateKernels`) against
+// malformed array sizes. Negative sizes must be rejected without crashes or
+// undefined behavior, and valid sizes (including zero) must keep working.
+
+namespace {
+
+// Sizes above this bound are only run through the size arithmetic, not
+// through allocation, to keep the fuzzer's memory usage bounded.
+constexpr int kMaxAllocatedSize = 1 << 16;
+
+void FuzzArraySizeHandling(int size) {
+  const size_t int_array_bytes = TfLiteIntArrayGetSizeInBytes(size);
+  if (size < 0) {
+    assert(int_array_bytes == 0);
+  }
+  (void)int_array_bytes;
+
+  if (size > kMaxAllocatedSize) {
+    return;
+  }
+
+  TfLiteIntArray* int_array = TfLiteIntArrayCreate(size);
+  if (size < 0) {
+    assert(int_array == nullptr);
+  }
+  if (int_array != nullptr) {
+    assert(int_array->size == size);
+    // Touch every element so that sanitizers verify the allocation really
+    // covers the declared size.
+    for (int i = 0; i < size; ++i) {
+      int_array->data[i] = i;
+    }
+    TfLiteIntArrayFree(int_array);
+  }
+
+  TfLiteFloatArray* float_array = TfLiteFloatArrayCreate(size);
+  if (size < 0) {
+    assert(float_array == nullptr);
+  }
+  if (float_array != nullptr) {
+    assert(float_array->size == size);
+    for (int i = 0; i < size; ++i) {
+      float_array->data[i] = 0.0f;
+    }
+    TfLiteFloatArrayFree(float_array);
+  }
+}
+FUZZ_TEST(TfLiteArrayFuzz, FuzzArraySizeHandling);
+
+TfLiteOperator* CreateDelegateKernelRegistration() {
+  TfLiteOperator* registration = TfLiteOperatorCreate(
+      kTfLiteBuiltinDelegate, "FUZZ DELEGATE KERNEL", /*version=*/1,
+      /*user_data=*/nullptr);
+  TfLiteOperatorSetInitWithData(
+      registration,
+      [](void* user_data, TfLiteOpaqueContext* context, const char* buffer,
+         size_t length) -> void* { return nullptr; });
+  return registration;
+}
+
+void FuzzDelegateNodesToReplace(int raw_size) {
+  TfLiteModel* model =
+      TfLiteModelCreateFromFile("tensorflow/lite/testdata/add.bin");
+  assert(model != nullptr);
+
+  struct DelegateState {
+    int raw_size;
+  } delegate_state{raw_size};
+
+  TfLiteOpaqueDelegateBuilder opaque_delegate_builder{};
+  opaque_delegate_builder.data = &delegate_state;
+  opaque_delegate_builder.Prepare = [](TfLiteOpaqueContext* opaque_context,
+                                       TfLiteOpaqueDelegate* opaque_delegate,
+                                       void* data) -> TfLiteStatus {
+    const int raw_size = static_cast<DelegateState*>(data)->raw_size;
+
+    TfLiteIntArray* execution_plan = nullptr;
+    TfLiteStatus status =
+        TfLiteOpaqueContextGetExecutionPlan(opaque_context, &execution_plan);
+    assert(status == kTfLiteOk);
+
+    // Build an array whose allocation always covers the full execution plan
+    // and whose contents are valid node indices, then declare a fuzzed size:
+    // negative values must be rejected, values in [0, plan size] must be
+    // handled without crashing. Out-of-range positive values are not
+    // distinguishable from valid sizes at this API level, so they are folded
+    // into the valid range.
+    TfLiteIntArray* nodes_to_replace = TfLiteIntArrayCopy(execution_plan);
+    assert(nodes_to_replace != nullptr);
+    const int declared_size =
+        raw_size < 0 ? raw_size : raw_size % (execution_plan->size + 1);
+    nodes_to_replace->size = declared_size;
+
+    status = TfLiteOpaqueContextReplaceNodeSubsetsWithDelegateKernels(
+        opaque_context, CreateDelegateKernelRegistration(), nodes_to_replace,
+        opaque_delegate);
+    if (declared_size < 0) {
+      assert(status == kTfLiteError);
+    }
+    (void)status;
+
+    // Restore the real size so the free call sees the array it allocated.
+    nodes_to_replace->size = execution_plan->size;
+    TfLiteIntArrayFree(nodes_to_replace);
+    return kTfLiteOk;
+  };
+
+  TfLiteOpaqueDelegate* opaque_delegate =
+      TfLiteOpaqueDelegateCreate(&opaque_delegate_builder);
+  TfLiteInterpreterOptions* options = TfLiteInterpreterOptionsCreate();
+  TfLiteInterpreterOptionsAddDelegate(options, opaque_delegate);
+  TfLiteInterpreter* interpreter = TfLiteInterpreterCreate(model, options);
+
+  TfLiteInterpreterDelete(interpreter);
+  TfLiteInterpreterOptionsDelete(options);
+  TfLiteOpaqueDelegateDelete(opaque_delegate);
+  TfLiteModelDelete(model);
+}
+FUZZ_TEST(TfLiteDelegateFuzz, FuzzDelegateNodesToReplace);
+
+}  // namespace


### PR DESCRIPTION
## Summary
This change adds defensive validation for malformed `TfLiteIntArray` inputs and hardens delegate parameter allocation arithmetic against overflow and invalid size handling.

## Changes
- Reject negative sizes in `TfLiteVarArrayGetSizeInBytes`.
- Add overflow-safe allocation size calculations using checked `size_t` arithmetic.
- Prevent unsafe `size_t` → `int` narrowing during delegate parameter construction.
- Handle allocation failures safely before delegate parameter usage.
- Validate externally supplied `TfLiteIntArray` inputs before constructing `TfLiteIntArrayView`.
- Reject negative-sized arrays early to prevent invalid iterator arithmetic and undefined behavior.

## Tests
- Added regression coverage for negative `TfLiteIntArray` sizes.
- Added a delegate-driven API test verifying malformed external arrays are rejected safely without crashes or UB.

## Notes
- Keeps existing valid empty-array behavior unchanged.
- No ABI or public API changes.
- Changes are intentionally minimal and scoped to malformed-input handling and allocation safety.