### PR TITLE
preserve transactional state on malformed metadata

### DIFF
--- a/tensorflow/core/kernels/BUILD
+++ b/tensorflow/core/kernels/BUILD
@@ -3012,6 +3012,19 @@ cc_library(
     ],
 )
 
+tf_cc_test(
+    name = "tensor_list_test",
+    srcs = ["tensor_list_test.cc"],
+    deps = [
+        ":tensor_list",
+        "//tensorflow/core:framework",
+        "//tensorflow/core:lib",
+        "//tensorflow/core:test",
+        "//tensorflow/core:test_main",
+        "//tensorflow/core/framework:tensor_shape_proto_cc",
+    ],
+)
+
 cc_library(
     name = "tensor_list_util",
     srcs = ["tensor_list_util.cc"],

--- a/tensorflow/core/kernels/tensor_list.cc
+++ b/tensorflow/core/kernels/tensor_list.cc
@@ -14,6 +14,8 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/core/kernels/tensor_list.h"
 
+#include <limits>
+
 #include "tensorflow/core/framework/tensor_shape.h"
 #include "tensorflow/core/framework/tensor_shape.pb.h"
 #include "tensorflow/core/framework/variant_op_registry.h"
@@ -59,40 +61,75 @@ bool TensorList::Decode(const VariantTensorData& data) {
   data.get_metadata(&metadata);
   uint64_t scratch;
   absl::string_view iter(metadata);
-  std::vector<size_t> invalid_indices;
-  core::GetVarint64(&iter, &scratch);
-  size_t num_invalid_tensors = static_cast<size_t>(scratch);
-  invalid_indices.resize(num_invalid_tensors);
-  for (size_t i = 0; i < num_invalid_tensors; i++) {
-    core::GetVarint64(&iter, &scratch);
-    invalid_indices[i] = static_cast<size_t>(scratch);
-  }
+  if (!core::GetVarint64(&iter, &scratch)) return false;
+  if (scratch > std::numeric_limits<size_t>::max()) return false;
+  const size_t num_invalid_tensors = static_cast<size_t>(scratch);
 
-  size_t total_num_tensors = data.tensors().size() + num_invalid_tensors;
-  tensors().reserve(total_num_tensors);
-  std::vector<size_t>::iterator invalid_indices_it = invalid_indices.begin();
-  std::vector<Tensor>::const_iterator tensors_it = data.tensors().begin();
-  for (size_t i = 0; i < total_num_tensors; i++) {
-    if (invalid_indices_it != invalid_indices.end() &&
-        *invalid_indices_it == i) {
-      tensors().emplace_back(Tensor(DT_INVALID));
-      invalid_indices_it++;
-    } else if (tensors_it != data.tensors().end()) {
-      tensors().emplace_back(*tensors_it);
-      tensors_it++;
-    } else {
-      // VariantTensorData is corrupted.
+  if (num_invalid_tensors >
+      std::numeric_limits<size_t>::max() - data.tensors().size()) {
+    return false;
+  }
+  const size_t total_num_tensors = data.tensors().size() + num_invalid_tensors;
+
+  std::vector<Tensor> decoded_tensors;
+  if (total_num_tensors > decoded_tensors.max_size()) return false;
+  decoded_tensors.reserve(total_num_tensors);
+
+  size_t output_index = 0;
+  size_t tensor_index = 0;
+  bool have_previous_invalid_index = false;
+  size_t previous_invalid_index = 0;
+  for (size_t i = 0; i < num_invalid_tensors; ++i) {
+    if (!core::GetVarint64(&iter, &scratch)) return false;
+    if (scratch > std::numeric_limits<size_t>::max()) return false;
+    const size_t invalid_index = static_cast<size_t>(scratch);
+    if (invalid_index >= total_num_tensors) return false;
+    if (have_previous_invalid_index && invalid_index <= previous_invalid_index) {
       return false;
     }
+
+    while (output_index < invalid_index) {
+      if (tensor_index >= data.tensors().size()) return false;
+      decoded_tensors.emplace_back(data.tensors()[tensor_index]);
+      ++tensor_index;
+      ++output_index;
+    }
+    decoded_tensors.emplace_back(Tensor(DT_INVALID));
+    ++output_index;
+    previous_invalid_index = invalid_index;
+    have_previous_invalid_index = true;
   }
 
-  core::GetVarint64(&iter, &scratch);
-  element_dtype = static_cast<DataType>(scratch);
-  core::GetVarint64(&iter, &scratch);
-  max_num_elements = static_cast<int>(scratch);
+  while (output_index < total_num_tensors) {
+    if (tensor_index >= data.tensors().size()) return false;
+    decoded_tensors.emplace_back(data.tensors()[tensor_index]);
+    ++tensor_index;
+    ++output_index;
+  }
+  if (tensor_index != data.tensors().size()) return false;
+
+  if (!core::GetVarint64(&iter, &scratch)) return false;
+  if (scratch > std::numeric_limits<int>::max()) return false;
+  const DataType decoded_element_dtype = static_cast<DataType>(scratch);
+
+  if (!core::GetVarint64(&iter, &scratch)) return false;
+  int decoded_max_num_elements;
+  if (scratch == std::numeric_limits<uint64_t>::max()) {
+    decoded_max_num_elements = -1;
+  } else {
+    if (scratch > std::numeric_limits<int>::max()) return false;
+    decoded_max_num_elements = static_cast<int>(scratch);
+  }
+
   TensorShapeProto element_shape_proto;
-  element_shape_proto.ParseFromString(iter);
-  element_shape = PartialTensorShape(element_shape_proto);
+  if (!element_shape_proto.ParseFromString(iter)) return false;
+
+  const PartialTensorShape decoded_element_shape(element_shape_proto);
+
+  element_dtype = decoded_element_dtype;
+  max_num_elements = decoded_max_num_elements;
+  tensors() = std::move(decoded_tensors);
+  element_shape = decoded_element_shape;
   return true;
 }
 

--- a/tensorflow/core/kernels/tensor_list_test.cc
+++ b/tensorflow/core/kernels/tensor_list_test.cc
@@ -1,0 +1,160 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/kernels/tensor_list.h"
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "tensorflow/core/framework/tensor_shape.pb.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/lib/core/coding.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+namespace {
+
+std::string TensorListMetadata(const std::vector<uint64_t>& invalid_indices,
+                               uint64_t element_dtype,
+                               uint64_t max_num_elements,
+                               const std::string& shape_proto) {
+  std::string metadata;
+  core::PutVarint64(&metadata, invalid_indices.size());
+  for (uint64_t invalid_index : invalid_indices) {
+    core::PutVarint64(&metadata, invalid_index);
+  }
+  core::PutVarint64(&metadata, element_dtype);
+  core::PutVarint64(&metadata, max_num_elements);
+  metadata.append(shape_proto);
+  return metadata;
+}
+
+Tensor ScalarInt32Tensor(int32_t value) {
+  Tensor t(DT_INT32, TensorShape({}));
+  t.scalar<int32_t>()() = value;
+  return t;
+}
+
+TEST(TensorListTest, DecodeIsTransactionalOnFailure) {
+  VariantTensorData data;
+  data.set_metadata(TensorListMetadata(
+      /*invalid_indices=*/{}, static_cast<uint64_t>(DT_FLOAT),
+      std::numeric_limits<uint64_t>::max(), "not a shape proto"));
+  *data.add_tensors() = ScalarInt32Tensor(123);
+
+  TensorList list;
+  list.element_dtype = DT_INT32;
+  list.max_num_elements = 7;
+  list.element_shape = PartialTensorShape({2});
+  list.tensors().push_back(ScalarInt32Tensor(42));
+
+  EXPECT_FALSE(list.Decode(data));
+  EXPECT_EQ(list.element_dtype, DT_INT32);
+  EXPECT_EQ(list.max_num_elements, 7);
+  EXPECT_EQ(list.element_shape.dim_size(0), 2);
+  ASSERT_EQ(list.tensors().size(), 1);
+  EXPECT_EQ(list.tensors()[0].dtype(), DT_INT32);
+  EXPECT_EQ(list.tensors()[0].scalar<int32_t>()(), 42);
+}
+
+TEST(TensorListTest, DecodeRejectsMalformedShapeMetadata) {
+  TensorShapeProto shape;
+  shape.add_dim()->set_size(1);
+  VariantTensorData data;
+
+  data.set_metadata(TensorListMetadata(
+      /*invalid_indices=*/{}, static_cast<uint64_t>(DT_FLOAT),
+      std::numeric_limits<uint64_t>::max(), shape.SerializeAsString()));
+  EXPECT_TRUE(TensorList().Decode(data));
+
+  data.set_metadata(TensorListMetadata(
+      /*invalid_indices=*/{}, static_cast<uint64_t>(DT_FLOAT),
+      std::numeric_limits<uint64_t>::max(), "not a shape proto"));
+  EXPECT_FALSE(TensorList().Decode(data));
+}
+
+TEST(TensorListTest, DecodeRejectsDuplicateInvalidIndices) {
+  TensorShapeProto shape;
+  VariantTensorData data;
+  data.set_metadata(TensorListMetadata(
+      /*invalid_indices=*/{1, 1}, static_cast<uint64_t>(DT_INT32),
+      std::numeric_limits<uint64_t>::max(), shape.SerializeAsString()));
+  *data.add_tensors() = ScalarInt32Tensor(1);
+  EXPECT_FALSE(TensorList().Decode(data));
+}
+
+TEST(TensorListTest, DecodeRejectsDescendingInvalidIndices) {
+  TensorShapeProto shape;
+  VariantTensorData data;
+  data.set_metadata(TensorListMetadata(
+      /*invalid_indices=*/{2, 1}, static_cast<uint64_t>(DT_INT32),
+      std::numeric_limits<uint64_t>::max(), shape.SerializeAsString()));
+  *data.add_tensors() = ScalarInt32Tensor(1);
+  EXPECT_FALSE(TensorList().Decode(data));
+}
+
+TEST(TensorListTest, DecodePreservesSentinelMinusOne) {
+  TensorShapeProto shape;
+  VariantTensorData data;
+  data.set_metadata(TensorListMetadata(
+      /*invalid_indices=*/{}, static_cast<uint64_t>(DT_INT32),
+      std::numeric_limits<uint64_t>::max(), shape.SerializeAsString()));
+
+  TensorList decoded;
+  EXPECT_TRUE(decoded.Decode(data));
+  EXPECT_EQ(decoded.max_num_elements, -1);
+}
+
+TEST(TensorListTest, DecodeValidRoundTripCompatibility) {
+  TensorList list;
+  list.element_dtype = DT_INT32;
+  list.max_num_elements = -1;
+  list.element_shape = PartialTensorShape({});
+  list.tensors().push_back(Tensor(DT_INVALID));
+  list.tensors().push_back(ScalarInt32Tensor(7));
+  list.tensors().push_back(Tensor(DT_INVALID));
+  list.tensors().push_back(ScalarInt32Tensor(9));
+
+  VariantTensorData data;
+  list.Encode(&data);
+
+  TensorList decoded;
+  EXPECT_TRUE(decoded.Decode(data));
+  EXPECT_EQ(decoded.element_dtype, DT_INT32);
+  EXPECT_EQ(decoded.max_num_elements, -1);
+  EXPECT_TRUE(decoded.element_shape.IsIdenticalTo(list.element_shape));
+  ASSERT_EQ(decoded.tensors().size(), 4);
+  EXPECT_EQ(decoded.tensors()[0].dtype(), DT_INVALID);
+  EXPECT_EQ(decoded.tensors()[1].dtype(), DT_INT32);
+  EXPECT_EQ(decoded.tensors()[1].scalar<int32_t>()(), 7);
+  EXPECT_EQ(decoded.tensors()[2].dtype(), DT_INVALID);
+  EXPECT_EQ(decoded.tensors()[3].dtype(), DT_INT32);
+  EXPECT_EQ(decoded.tensors()[3].scalar<int32_t>()(), 9);
+}
+
+TEST(TensorListTest, DecodeRejectsOutOfRangeMaxNumElements) {
+  TensorShapeProto shape;
+  VariantTensorData data;
+  data.set_metadata(TensorListMetadata(
+      /*invalid_indices=*/{}, static_cast<uint64_t>(DT_INT32),
+      static_cast<uint64_t>(std::numeric_limits<int>::max()) + 1,
+      shape.SerializeAsString()));
+  EXPECT_FALSE(TensorList().Decode(data));
+}
+
+}  // namespace
+}  // namespace tensorflow


### PR DESCRIPTION
## Summary
This change makes `TensorList::Decode` fail deterministically on malformed metadata while preserving valid encode/decode behavior.

## What changed
- Added explicit varint parse failure checks during metadata decode.
- Made decode transactional by staging decoded state before committing.
- Reconstructed invalid tensor positions using streaming validation instead of pre-building an index table.
- Added overflow-safe arithmetic checks for tensor count reconstruction.
- Preserved the existing `-1` sentinel behavior for `max_num_elements`.
- Reject malformed `TensorShapeProto` metadata instead of silently accepting partial decode state.

## Tests
Added focused unit tests covering:
- transactional non-mutation on decode failure
- malformed shape metadata rejection
- duplicate invalid index rejection
- descending invalid index rejection
- valid encode/decode round-trip compatibility
- `-1` sentinel preservation
- out-of-range `max_num_elements` rejection