### PR TITLE
Fix TensorArray dynamic_size=0 under XLA while_loop

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/tensor_array_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/tensor_array_ops.cc
@@ -154,6 +154,11 @@ absl::Status GrowTensorArrayToFit(xla::XlaBuilder* builder,
 
   xla::XlaOp one = xla::ConstantR0<int32_t>(builder, 1);
   xla::XlaOp required_size = xla::Add(index, one);
+  if (resource->initialized()) {
+    xla::XlaOp current_size =
+        xla::GetDimensionSize(resource->value(), 0);
+    required_size = xla::Max(current_size, required_size);
+  }
   xla::XlaOp new_buf =
       CreateDynamicTensorArrayBuffer(builder, dtype, elem_shape, required_size);
 

--- a/tensorflow/compiler/tf2xla/kernels/tensor_array_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/tensor_array_ops.cc
@@ -71,8 +71,10 @@ absl::Status MaybeInitializeTensorArray(xla::XlaBuilder* builder,
 
   if (!resource->initialized()) {
     TF_RETURN_IF_ERROR(resource->SetTypeAndShape(dtype, elem_shape));
-    TF_RETURN_IF_ERROR(resource->SetZeroValue(builder));
-  } else {
+    if (!resource->tensor_array_dynamic_size()) {
+      TF_RETURN_IF_ERROR(resource->SetZeroValue(builder));
+    }
+  } else if (!resource->tensor_array_dynamic_size()) {
     // Checks the elem_shape matches the TensorArray shape.
     auto shape_or_status = builder->GetShape(resource->value());
     if (!shape_or_status.ok()) {
@@ -117,8 +119,53 @@ absl::Status CheckTensorArrayIsInitialized(const std::string& op_name,
 
 absl::Status GetTensorArrayShape(const XlaResource* resource,
                                  xla::XlaBuilder* builder, TensorShape* shape) {
+  if (resource->initialized()) {
+    TF_ASSIGN_OR_RETURN(xla::Shape xla_shape,
+                        builder->GetShape(resource->value()));
+    return XLAShapeToTensorShape(xla_shape, shape);
+  }
   *shape = resource->shape();
   shape->InsertDim(0, resource->max_array_size());
+  return absl::OkStatus();
+}
+
+// Creates a zero-filled TensorArray buffer with a dynamic leading dimension.
+xla::XlaOp CreateDynamicTensorArrayBuffer(xla::XlaBuilder* builder,
+                                          DataType dtype,
+                                          const TensorShape& elem_shape,
+                                          xla::XlaOp leading_dim_size) {
+  TensorShape ta_shape;
+  ta_shape.AddDim(0);
+  ta_shape.AppendShape(elem_shape);
+  xla::XlaOp zero = XlaHelpers::Zero(builder, dtype);
+  xla::XlaOp ta = xla::Broadcast(zero, ta_shape.dim_sizes());
+  return xla::SetDimensionSize(ta, leading_dim_size, 0);
+}
+
+// Grows a dynamic-size TensorArray so that `index` is a valid write index.
+absl::Status GrowTensorArrayToFit(xla::XlaBuilder* builder,
+                                  XlaResource* resource, xla::XlaOp index,
+                                  DataType dtype, const TensorShape& elem_shape,
+                                  xla::XlaOp* ta) {
+  if (!resource->tensor_array_dynamic_size()) {
+    *ta = resource->value();
+    return absl::OkStatus();
+  }
+
+  xla::XlaOp one = xla::ConstantR0<int32_t>(builder, 1);
+  xla::XlaOp required_size = xla::Add(index, one);
+  xla::XlaOp new_buf =
+      CreateDynamicTensorArrayBuffer(builder, dtype, elem_shape, required_size);
+
+  if (resource->initialized()) {
+    xla::XlaOp old = resource->value();
+    const int rank = elem_shape.dims() + 1;
+    std::vector<xla::XlaOp> starts(rank, xla::ConstantR0<int32_t>(builder, 0));
+    new_buf = xla::DynamicUpdateSlice(new_buf, old, starts);
+  }
+
+  TF_RETURN_IF_ERROR(resource->SetValue(new_buf));
+  *ta = new_buf;
   return absl::OkStatus();
 }
 
@@ -140,13 +187,7 @@ class TensorArrayOp : public XlaOpKernel {
   explicit TensorArrayOp(OpKernelConstruction* ctx) : XlaOpKernel(ctx) {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("element_shape", &element_shape_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("dtype", &dtype_));
-    bool dynamic_size;
-    OP_REQUIRES_OK(ctx, ctx->GetAttr("dynamic_size", &dynamic_size));
-    OP_REQUIRES(
-        ctx, !dynamic_size,
-        errors::Unimplemented(
-            "TensorArrays with dynamic size are not supported by XLA."));
-
+    OP_REQUIRES_OK(ctx, ctx->GetAttr("dynamic_size", &dynamic_size_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("tensor_array_name", &tensor_array_name_));
   }
 
@@ -162,7 +203,7 @@ class TensorArrayOp : public XlaOpKernel {
     // Otherwise, defer initialization to the first write.
     xla::XlaOp value;
     TensorShape shape;
-    if (element_shape_.IsFullyDefined()) {
+    if (element_shape_.IsFullyDefined() && !dynamic_size_) {
       CHECK(element_shape_.AsTensorShape(&shape));
       TensorShape ta_shape;
       ta_shape.AddDim(size);
@@ -174,7 +215,8 @@ class TensorArrayOp : public XlaOpKernel {
     XlaResource* var =
         ctx->xla_context()->AddResource(XlaResource::CreateTensorArray(
             /*name=*/absl::StrCat("TensorArray: ", tensor_array_name_), dtype_,
-            shape, /*initial_value=*/value, /*max_array_size=*/size));
+            shape, /*initial_value=*/value, /*max_array_size=*/size,
+            /*dynamic_size=*/dynamic_size_));
     ctx->SetResourceOutput(0, var);
 
     Tensor flow(DT_FLOAT, TensorShape({}));
@@ -185,6 +227,7 @@ class TensorArrayOp : public XlaOpKernel {
  private:
   PartialTensorShape element_shape_;
   DataType dtype_;
+  bool dynamic_size_;
   std::string tensor_array_name_;
 
   TensorArrayOp(const TensorArrayOp&) = delete;
@@ -212,7 +255,9 @@ class TensorArrayWriteOp : public XlaOpKernel {
     OP_REQUIRES_OK(ctx,
                    MaybeInitializeTensorArray(b, resource, dtype_, elem_shape));
 
-    xla::XlaOp ta = resource->value();
+    xla::XlaOp ta;
+    OP_REQUIRES_OK(ctx, GrowTensorArrayToFit(b, resource, ctx->Input(1),
+                                               dtype_, elem_shape, &ta));
     xla::XlaOp index = ctx->Input(1);
     xla::XlaOp value = ctx->Input(2);
     xla::XlaOp flow = ctx->Input(3);
@@ -570,10 +615,23 @@ class TensorArraySizeOp : public XlaOpKernel {
   void Compile(XlaOpKernelContext* ctx) override {
     XlaResource* var;
     OP_REQUIRES_OK(ctx, ctx->GetResourceInput(0, &var));
-    Tensor size_tensor(DT_INT32, {});
-    size_tensor.scalar<int32_t>()() =
-        static_cast<int32_t>(var->max_array_size());
-    ctx->SetConstantOutput(0, size_tensor);
+    if (var->tensor_array_dynamic_size()) {
+      if (!var->initialized()) {
+        Tensor size_tensor(DT_INT32, {});
+        size_tensor.scalar<int32_t>()() = 0;
+        ctx->SetConstantOutput(0, size_tensor);
+      } else {
+        xla::XlaOp size =
+            xla::GetDimensionSize(var->value(), 0);
+        size = xla::ConvertElementType(size, xla::S32);
+        ctx->SetOutput(0, size);
+      }
+    } else {
+      Tensor size_tensor(DT_INT32, {});
+      size_tensor.scalar<int32_t>()() =
+          static_cast<int32_t>(var->max_array_size());
+      ctx->SetConstantOutput(0, size_tensor);
+    }
   }
 
  private:

--- a/tensorflow/compiler/tf2xla/xla_compiler.cc
+++ b/tensorflow/compiler/tf2xla/xla_compiler.cc
@@ -1113,6 +1113,7 @@ absl::Status XlaCompiler::BuildArguments(
                 /*max_array_size=*/arg.max_array_size,
                 /*tensor_array_gradients=*/arg.tensor_array_gradients,
                 /*tensor_array_multiple_writes_aggregate=*/true,
+                /*tensor_array_dynamic_size=*/false,
                 arg.definition_stack_trace));
         arg_expression =
             arg.kind == XlaCompiler::Argument::kResource

--- a/tensorflow/compiler/tf2xla/xla_resource.cc
+++ b/tensorflow/compiler/tf2xla/xla_resource.cc
@@ -62,12 +62,13 @@ namespace tensorflow {
 
 /*static*/ std::unique_ptr<XlaResource> XlaResource::CreateTensorArray(
     std::string name, DataType type, TensorShape shape,
-    xla::XlaOp initial_value, int64_t max_array_size) {
+    xla::XlaOp initial_value, int64_t max_array_size, bool dynamic_size) {
   return std::make_unique<XlaResource>(
       XlaResource::kTensorArray, /*arg_num=*/-1, std::move(name), type, shape,
       initial_value, max_array_size,
       /*tensor_array_gradients=*/std::set<std::string>{},
-      /*tensor_array_multiple_writes_aggregate=*/false);
+      /*tensor_array_multiple_writes_aggregate=*/false,
+      /*tensor_array_dynamic_size=*/dynamic_size);
 }
 
 XlaResource::XlaResource(
@@ -75,6 +76,7 @@ XlaResource::XlaResource(
     xla::XlaOp initial_value, int64_t max_array_size,
     const std::set<std::string>& tensor_array_gradients,
     bool tensor_array_multiple_writes_aggregate,
+    bool tensor_array_dynamic_size,
     const std::optional<ManagedStackTrace>& definition_stack_trace)
     : kind_(kind),
       arg_num_(arg_num),
@@ -86,6 +88,7 @@ XlaResource::XlaResource(
       max_array_size_(max_array_size),
       tensor_array_multiple_writes_aggregate_(
           tensor_array_multiple_writes_aggregate),
+      tensor_array_dynamic_size_(tensor_array_dynamic_size),
       definition_stack_trace_(definition_stack_trace) {
   CHECK(kind_ != kInvalid);
 

--- a/tensorflow/compiler/tf2xla/xla_resource.h
+++ b/tensorflow/compiler/tf2xla/xla_resource.h
@@ -50,13 +50,15 @@ class XlaResource {
   // Creates a new TensorArray resource.
   static std::unique_ptr<XlaResource> CreateTensorArray(
       std::string name, DataType type, TensorShape shape,
-      xla::XlaOp initial_value, int64_t max_array_size);
+      xla::XlaOp initial_value, int64_t max_array_size,
+      bool dynamic_size = false);
 
   XlaResource(Kind kind, int arg_num, std::string name, DataType type,
               TensorShape shape, xla::XlaOp initial_value,
               int64_t max_array_size,
               const std::set<std::string>& tensor_array_gradients,
               bool tensor_array_multiple_writes_aggregate,
+              bool tensor_array_dynamic_size = false,
               const std::optional<ManagedStackTrace>& definition_stack_trace =
                   std::nullopt);
 
@@ -159,6 +161,10 @@ class XlaResource {
     return tensor_array_multiple_writes_aggregate_;
   }
 
+  bool tensor_array_dynamic_size() const {
+    return tensor_array_dynamic_size_;
+  }
+
   // 'tensor_array_gradient' is a map from TensorArrayGradV3 'source' attributes
   // to an XlaResource containing the gradient TensorArrays. We store a pointer
   // here since there should only be one gradient TensorArray per 'source'
@@ -186,6 +192,7 @@ class XlaResource {
 
   int64_t max_array_size_ = -1;
   bool tensor_array_multiple_writes_aggregate_ = false;
+  bool tensor_array_dynamic_size_ = false;
 
   std::map<std::string, std::unique_ptr<XlaResource>> tensor_array_gradients_;
   bool is_overwritten_ = false;

--- a/tensorflow/python/kernel_tests/data_structures/tensor_array_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/tensor_array_ops_test.py
@@ -1068,6 +1068,27 @@ class TensorArrayTest(test.TestCase):
     self._testWhileLoopWritePackGradients(
         dynamic_size=True, dtype=dtypes.float32)
 
+  def testWhileLoopDynamicSizeZeroXla(self):
+    # Regression test for b/119375: dynamic_size=True with size=0 under XLA.
+    def build_and_run():
+      ta = tensor_array_ops.TensorArray(
+          dtypes.int32, size=0, dynamic_size=True)
+      i = constant_op.constant(0)
+
+      def cond_fn(i, ta):
+        return i < 5
+
+      def body_fn(i, ta):
+        return i + 1, ta.write(i, math_ops.square(i) + 1)
+
+      _, ta = while_loop.while_loop(cond_fn, body_fn, [i, ta])
+      return ta.stack()
+
+    eager_out = build_and_run()
+    xla_out = def_function.function(build_and_run, jit_compile=True)()
+    self.assertAllEqual(eager_out, xla_out)
+    self.assertAllEqual(xla_out, [1, 2, 5, 10, 17])
+
   def testGradSerialTwoLoops(self):
     with self.session():
 


### PR DESCRIPTION
## Summary
- Implement dynamic TensorArray growth in tf2xla for `size=0, dynamic_size=True` inside `while_loop`
- Fix `TensorArraySizeV3` to return the live leading dimension under `dynamic_size` so `stack()` matches eager
- Add regression test from #119375

## Test plan
- [ ] `bazel test //tensorflow/python/kernel_tests/data_structures:tensor_array_ops_test --test_filter='*DynamicSizeZeroXla*'`
- [ ] Issue repro: eager output equals `jit_compile=True` output

Fixes #119375