### PR TITLE
Fix mnist_tflite tutorial runtime issues

### DIFF
--- a/tensorflow/lite/tutorials/BUILD
+++ b/tensorflow/lite/tutorials/BUILD
@@ -1,5 +1,6 @@
 load("@xla//third_party/rules_python/python:py_binary.bzl", "py_binary")
 load("@xla//third_party/rules_python/python:py_library.bzl", "py_library")
+load("//tensorflow:tensorflow.bzl", "py_test")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:LICENSE"],
@@ -12,9 +13,28 @@ py_binary(
     srcs = ["mnist_tflite.py"],
     strict_deps = True,
     deps = [
+        ":mnist_tflite_lib",
+    ],
+)
+
+py_library(
+    name = "mnist_tflite_lib",
+    srcs = ["mnist_tflite.py"],
+    strict_deps = True,
+    deps = [
         ":dataset",
         "//tensorflow:tensorflow_py",
         "//tensorflow/lite/python:lite",
+        "//third_party/py/numpy",
+    ],
+)
+
+py_test(
+    name = "mnist_tflite_test",
+    srcs = ["mnist_tflite_test.py"],
+    strict_deps = True,
+    deps = [
+        ":mnist_tflite_lib",
         "//third_party/py/numpy",
     ],
 )

--- a/tensorflow/lite/tutorials/dataset.py
+++ b/tensorflow/lite/tutorials/dataset.py
@@ -36,7 +36,7 @@ def read32(bytestream):
 
 def check_image_file_header(filename):
   """Validate that filename corresponds to images for the MNIST dataset."""
-  with tf.io.gfile.Gfile(filename, 'rb') as f:
+  with tf.io.gfile.GFile(filename, 'rb') as f:
     magic = read32(f)
     read32(f)  # num_images, unused
     rows = read32(f)
@@ -52,7 +52,7 @@ def check_image_file_header(filename):
 
 def check_labels_file_header(filename):
   """Validate that filename corresponds to labels for the MNIST dataset."""
-  with tf.gfile.Open(filename, 'rb') as f:
+  with tf.io.gfile.GFile(filename, 'rb') as f:
     magic = read32(f)
     read32(f)  # num_items, unused
     if magic != 2049:
@@ -72,7 +72,7 @@ def download(directory, filename):
   _, zipped_filepath = tempfile.mkstemp(suffix='.gz')
   print('Downloading %s to %s' % (url, zipped_filepath))
   urllib.request.urlretrieve(url, zipped_filepath)
-  with gzip.open(zipped_filepath, 'rb') as f_in, tf.io.gfile.Gfile(
+  with gzip.open(zipped_filepath, 'rb') as f_in, tf.io.gfile.GFile(
       filepath, 'wb'
   ) as f_out:
     shutil.copyfileobj(f_in, f_out)

--- a/tensorflow/lite/tutorials/mnist_tflite.py
+++ b/tensorflow/lite/tutorials/mnist_tflite.py
@@ -67,6 +67,8 @@ def run_eval(interpreter, input_image):
 
 
 def predicted_label(output):
+  if np.size(output) == 0:
+    raise ValueError('Output must not be empty.')
   return int(np.argmax(output))
 
 

--- a/tensorflow/lite/tutorials/mnist_tflite.py
+++ b/tensorflow/lite/tutorials/mnist_tflite.py
@@ -18,7 +18,7 @@ import numpy as np
 import tensorflow as tf  # pylint: disable=g-bad-import-order
 from tensorflow.lite.python import lite
 from tensorflow.lite.tutorials import dataset
-flags = tf.app.flags
+flags = tf.compat.v1.app.flags
 
 flags.DEFINE_string('data_dir', '/tmp/data_dir',
                     'Directory where data is stored.')
@@ -66,6 +66,14 @@ def run_eval(interpreter, input_image):
   return output
 
 
+def predicted_label(output):
+  return int(np.argmax(output))
+
+
+def is_correct_prediction(output, label):
+  return predicted_label(output) == int(label)
+
+
 def main(_):
   interpreter = lite.Interpreter(model_path=flags.model_file)
   interpreter.allocate_tensors()
@@ -73,7 +81,7 @@ def main(_):
   for input_data in test_image_generator():
     output = run_eval(interpreter, input_data[0])
     total += 1
-    if output == input_data[1]:
+    if is_correct_prediction(output, input_data[1]):
       num_correct += 1
     if total % 500 == 0:
       print('Accuracy after %i images: %f' %
@@ -81,5 +89,5 @@ def main(_):
 
 
 if __name__ == '__main__':
-  tf.logging.set_verbosity(tf.logging.INFO)
+  tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.INFO)
   tf.compat.v1.app.run(main)

--- a/tensorflow/lite/tutorials/mnist_tflite_test.py
+++ b/tensorflow/lite/tutorials/mnist_tflite_test.py
@@ -17,6 +17,12 @@ class MnistTfliteTest(unittest.TestCase):
 
     self.assertFalse(mnist_tflite.is_correct_prediction(output, 2))
 
+  def test_should_raise_value_error_if_output_is_empty(self):
+    output = np.array([], dtype=np.float32)
+
+    with self.assertRaisesRegex(ValueError, 'Output must not be empty.'):
+      mnist_tflite.predicted_label(output)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tensorflow/lite/tutorials/mnist_tflite_test.py
+++ b/tensorflow/lite/tutorials/mnist_tflite_test.py
@@ -1,0 +1,22 @@
+import unittest
+
+import numpy as np
+
+from tensorflow.lite.tutorials import mnist_tflite
+
+
+class MnistTfliteTest(unittest.TestCase):
+
+  def test_should_return_true_if_label_matches_argmax(self):
+    output = np.array([0.1, 0.2, 0.7], dtype=np.float32)
+
+    self.assertTrue(mnist_tflite.is_correct_prediction(output, 2))
+
+  def test_should_return_false_if_label_does_not_match_argmax(self):
+    output = np.array([0.1, 0.7, 0.2], dtype=np.float32)
+
+    self.assertFalse(mnist_tflite.is_correct_prediction(output, 2))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tensorflow/lite/tutorials/mnist_tflite_test.py
+++ b/tensorflow/lite/tutorials/mnist_tflite_test.py
@@ -1,3 +1,18 @@
+# Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 import unittest
 
 import numpy as np


### PR DESCRIPTION
## Summary

This fixes the `tensorflow/lite/tutorials/mnist_tflite.py` tutorial so it matches the current compat API surface and computes accuracy from the predicted class instead of comparing the raw output vector to the label.

It also updates the paired `tensorflow/lite/tutorials/dataset.py` helper to use `tf.io.gfile.GFile`, since that file is part of the same runnable tutorial path.

Fixes #119439.

## What changed

- switched `tf.app.flags` to `tf.compat.v1.app.flags`
- switched `tf.logging` to `tf.compat.v1.logging`
- compare `argmax(output)` against the label instead of comparing the raw output vector
- added a small regression test for the prediction logic
- replaced stale `tf.gfile.Open` usage in the tutorial dataset helper

## Validation

- `python3 -m py_compile tensorflow/lite/tutorials/mnist_tflite.py tensorflow/lite/tutorials/dataset.py tensorflow/lite/tutorials/mnist_tflite_test.py`
- lightweight smoke test for the new prediction helpers via direct module loading with minimal stubs

## Notes

I could not run `bazel test //tensorflow/lite/tutorials:mnist_tflite_test` in this environment because `bazel`/`bazelisk` is not installed on the machine.
