### PR TITLE
Fix ExtractImagePatches NaN propagation under XLA (padding=SAME)

### DIFF
--- a/tensorflow/compiler/tests/extract_image_patches_op_test.py
+++ b/tensorflow/compiler/tests/extract_image_patches_op_test.py
@@ -20,6 +20,7 @@ from tensorflow.compiler.tests import xla_test
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors_impl
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
 from tensorflow.python.platform import test
 
 
@@ -140,6 +141,32 @@ class ExtractImagePatches(xla_test.XLATestCase):
         rates=[1, 1],
         padding="VALID",
         patches=patches)
+
+  def testSamePaddingNaNDoesNotSpuriouslyPropagate(self):
+    """Regression for #119356: NaN must not poison unrelated patch elements."""
+    image = np.array(
+        [[[[0.0], [-0.0], [np.nan]],
+          [[1.0], [-1.0], [2.0]],
+          [[3.0], [4.0], [-5.0]]]],
+        dtype=np.float32)
+    ksizes = [1, 2, 2, 1]
+    strides = [1, 1, 1, 1]
+    rates = [1, 1, 1, 1]
+
+    with self.session():
+      image_placeholder = array_ops.placeholder(dtypes.float32)
+      with self.test_scope():
+        patches = array_ops.extract_image_patches(
+            image_placeholder,
+            ksizes=ksizes,
+            strides=strides,
+            rates=rates,
+            padding="SAME")
+        sum_finite = math_ops.reduce_sum(
+            array_ops.where(math_ops.is_nan(patches),
+                            array_ops.zeros_like(patches), patches))
+      feed_dict = {image_placeholder: image}
+      self.assertAllClose(8.0, sum_finite.eval(feed_dict=feed_dict))
 
   def testInvalidKernelSize(self):
     """Test that zero kernel size raises an error in XLA mode."""

--- a/tensorflow/compiler/tf2xla/kernels/extract_image_patches_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/extract_image_patches_op.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <cmath>
 #include <cstdint>
 #include <utility>
 #include <vector>
@@ -20,13 +21,16 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "tensorflow/compiler/tf2xla/kernels/conv_op_helpers.h"
+#include "tensorflow/compiler/tf2xla/lib/util.h"
 #include "tensorflow/compiler/tf2xla/type_util.h"
 #include "tensorflow/compiler/tf2xla/xla_helpers.h"
 #include "tensorflow/compiler/tf2xla/xla_op_kernel.h"
 #include "tensorflow/compiler/tf2xla/xla_op_registry.h"
 #include "xla/hlo/builder/lib/constants.h"
+#include "xla/hlo/builder/lib/math.h"
 #include "xla/hlo/builder/lib/matrix.h"
 #include "xla/hlo/builder/xla_builder.h"
+#include "xla/primitive_util.h"
 #include "xla/shape_util.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
@@ -37,6 +41,19 @@ limitations under the License.
 namespace tensorflow {
 
 namespace {
+
+// Reorders feature-group convolution output to extract_patches layout.
+xla::XlaOp ReshapeConvToPatches(xla::XlaBuilder* builder, xla::XlaOp conv,
+                                int64_t depth, int64_t kernel_size) {
+  std::vector<int64_t> conv_dims =
+      xla::SpanToVector(builder->GetShape(conv).value().dimensions());
+  conv_dims.back() = depth;
+  conv_dims.push_back(kernel_size);
+  conv = xla::TransposeInMinorDims(xla::Reshape(conv, conv_dims));
+  conv_dims.pop_back();
+  conv_dims.back() *= kernel_size;
+  return xla::Reshape(conv, conv_dims);
+}
 
 class ExtractImagePatchesOp : public XlaOpKernel {
  public:
@@ -168,20 +185,44 @@ class ExtractImagePatchesOp : public XlaOpKernel {
                    &padding[i].first, &padding[i].second));
     }
 
-    xla::XlaOp conv =
-        xla::ConvGeneralDilated(ctx->Input(0), filter, window_strides, padding,
-                                lhs_dilation, rhs_dilation, dims, depth);
-    // Feature group convolution, will end up with the kernel_size change more
-    // rapidly than the depth. Reshape, transpose and reshape to reorder them.
-    std::vector<int64_t> conv_dims =
-        xla::SpanToVector(builder->GetShape(conv).value().dimensions());
-    conv_dims.back() = depth;
-    conv_dims.push_back(kernel_size);
-    conv = xla::TransposeInMinorDims(xla::Reshape(conv, conv_dims));
-    conv_dims.pop_back();
-    conv_dims.back() *= kernel_size;
-    conv = xla::Reshape(conv, conv_dims);
-    ctx->SetOutput(0, conv);
+    xla::XlaOp input = ctx->Input(0);
+    xla::XlaOp output;
+
+    if (xla::primitive_util::IsFloatingPointType(type)) {
+      // One-hot conv computes sum(w_i * x_i). IEEE 0*NaN poisons the sum even
+      // when w_i=0, unlike eager im2col which copies a single index per patch.
+      xla::XlaOp is_nan = xla::IsNan(input);
+      xla::XlaOp zero = xla::Zero(builder, type);
+      xla::XlaOp input_safe = xla::Select(is_nan, zero, input);
+
+      xla::XlaOp conv_out = xla::ConvGeneralDilated(
+          input_safe, filter, window_strides, padding, lhs_dilation,
+          rhs_dilation, dims, depth);
+      conv_out = ReshapeConvToPatches(builder, conv_out, depth, kernel_size);
+
+      xla::XlaOp is_nan_as_input_type =
+          xla::ConvertElementType(is_nan, type);
+      xla::XlaOp nan_indicator = xla::ConvGeneralDilated(
+          is_nan_as_input_type, filter, window_strides, padding, lhs_dilation,
+          rhs_dilation, dims, depth);
+      nan_indicator =
+          ReshapeConvToPatches(builder, nan_indicator, depth, kernel_size);
+
+      xla::XlaOp nan_value =
+          FloatLiteral(builder, type, std::numeric_limits<double>::quiet_NaN());
+      output = xla::Select(
+          xla::Gt(nan_indicator, zero),
+          xla::Broadcast(nan_value,
+                         builder->GetShape(conv_out).value().dimensions()),
+          conv_out);
+    } else {
+      xla::XlaOp conv = xla::ConvGeneralDilated(
+          input, filter, window_strides, padding, lhs_dilation, rhs_dilation,
+          dims, depth);
+      output = ReshapeConvToPatches(builder, conv, depth, kernel_size);
+    }
+
+    ctx->SetOutput(0, output);
   }
 
  protected:

--- a/tensorflow/python/kernel_tests/image_ops/extract_image_patches_op_test.py
+++ b/tensorflow/python/kernel_tests/image_ops/extract_image_patches_op_test.py
@@ -16,6 +16,7 @@
 
 import numpy as np
 
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.ops import array_ops
@@ -149,6 +150,29 @@ class ExtractImagePatches(test.TestCase):
             rates=[1, 1],
             padding=padding,
             patches=patches)
+
+  def testExtractPatchesSamePaddingNaNXla(self):
+    """Regression for #119356: eager and jit_compile agree on finite patch sum."""
+    def kernel(x):
+      patches = array_ops.extract_image_patches(
+          images=x,
+          sizes=[1, 2, 2, 1],
+          strides=[1, 1, 1, 1],
+          rates=[1, 1, 1, 1],
+          padding="SAME",
+      )
+      return math_ops.reduce_sum(
+          array_ops.where(math_ops.is_nan(patches), 0.0, patches))
+
+    x = constant_op.constant(
+        [[[[0.0], [-0.0], [float("nan")]],
+          [[1.0], [-1.0], [2.0]],
+          [[3.0], [4.0], [-5.0]]]],
+        dtype=dtypes.float32)
+    eager_sum = kernel(x).numpy()
+    xla_sum = def_function.function(kernel, jit_compile=True)(x).numpy()
+    self.assertAllClose(8.0, eager_sum)
+    self.assertAllClose(eager_sum, xla_sum)
 
   def testInvalidAttributes(self):
     """Test for passing weird things into ksizes."""

--- a/tensorflow/python/kernel_tests/image_ops/extract_image_patches_op_test.py
+++ b/tensorflow/python/kernel_tests/image_ops/extract_image_patches_op_test.py
@@ -162,7 +162,8 @@ class ExtractImagePatches(test.TestCase):
           padding="SAME",
       )
       return math_ops.reduce_sum(
-          array_ops.where(math_ops.is_nan(patches), 0.0, patches))
+          array_ops.where(
+              math_ops.is_nan(patches), array_ops.zeros_like(patches), patches))
 
     x = constant_op.constant(
         [[[[0.0], [-0.0], [float("nan")]],


### PR DESCRIPTION
## Summary

- Fix incorrect NaN propagation in `tf.image.extract_patches` when compiled with `jit_compile=True` (fixes #119356).
- Root cause: tf2xla lowers extract-patches as a one-hot `ConvGeneralDilated`. IEEE `0.0 * NaN` poisons the convolution sum even when the filter weight is zero, unlike eager im2col which copies a single index per patch.
- Fix: for floating-point inputs, run conv on NaN-sanitized input and a second conv on `IsNan` mask, then restore NaN only where the selected index was NaN in the original tensor.

## Test plan

- [x] Added `testSamePaddingNaNDoesNotSpuriouslyPropagate` in `tensorflow/compiler/tests/extract_image_patches_op_test.py` (XLATestCase)
- [x] Added `testExtractPatchesSamePaddingNaNXla` in `tensorflow/python/kernel_tests/image_ops/extract_image_patches_op_test.py` (`jit_compile=True` vs eager)
- [x] Fixed graph-mode test failure (`zeros_like` in `where()`); CI re-run on fork PR