### PR TITLE
Fix ResizeNearestNeighbor reference offset overflow

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/resize_nearest_neighbor.h
+++ b/tensorflow/lite/kernels/internal/reference/resize_nearest_neighbor.h
@@ -71,9 +71,9 @@ inline void ResizeNearestNeighbor(
   int32_t output_height = output_size_data[0];
   int32_t output_width = output_size_data[1];
 
-  const int col_offset = input_shape.Dims(3);
-  const int row_offset = input_shape.Dims(2) * col_offset;
-  const int batch_offset = input_shape.Dims(1) * row_offset;
+  const int64_t col_offset = input_shape.Dims(3);
+  const int64_t row_offset = static_cast<int64_t>(input_shape.Dims(2)) * col_offset;
+  const int64_t batch_offset = static_cast<int64_t>(input_shape.Dims(1)) * row_offset;
 
   const T* input_ptr = input_data;
   T* output_ptr = output_data;


### PR DESCRIPTION
## Summary

This patch updates the TensorFlow Lite reference `ResizeNearestNeighbor` kernel to use 64-bit offset arithmetic for spatial tensor offsets.

The optimized implementation was recently updated to use `int64_t` for related scale/offset calculations, but the reference implementation still computes offsets using 32-bit `int` values.

In the reference kernel, `row_offset` is computed as:

```cpp
const int row_offset = input_shape.Dims(2) * col_offset;
```

When `input_shape.Dims(2) * input_shape.Dims(3)` exceeds `INT32_MAX`, this multiplication can overflow and produce an incorrect negative offset. That offset is later used to derive the input pointer passed to `memcpy`.

## Change

Update the reference kernel offset calculations from `int` to `int64_t`:

```cpp
const int64_t col_offset = input_shape.Dims(3);
const int64_t row_offset =
    static_cast<int64_t>(input_shape.Dims(2)) * col_offset;
const int64_t batch_offset =
    static_cast<int64_t>(input_shape.Dims(1)) * row_offset;
```

This mirrors the safer arithmetic already used in the optimized path and prevents 32-bit overflow in the reference implementation.

## Affected path

File:

```text
tensorflow/lite/kernels/internal/reference/resize_nearest_neighbor.h
```

The issue affects the reference implementation used by some TensorFlow Lite kernel paths, including types that do not have an optimized variant.

## Notes

This is a minimal arithmetic-safety fix intended to keep the reference implementation consistent with the optimized ResizeNearestNeighbor offset handling.