### PR TITLE
[TFLite][Security] Add bounds check to EMBEDDING_LOOKUP_SPARSE FinalizeAggregation

### DIFF
--- a/tensorflow/lite/kernels/embedding_lookup_sparse.cc
+++ b/tensorflow/lite/kernels/embedding_lookup_sparse.cc
@@ -240,9 +240,13 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     // If we are in a new aggregation bucket and the combiner is not the sum,
     // go back and finalize the result of the previous bucket.
     if (output_offset != current_output_offset) {
-      FinalizeAggregation(params->combiner, num_elements, current_total_weight,
-                          current_squares_weight, embedding_size.Value(),
-                          &output_ptr[current_output_offset]);
+      if (current_output_offset >= 0 &&
+          static_cast<size_t>(current_output_offset) + embedding_size.Value() <=
+              output_size.Value()) {
+        FinalizeAggregation(params->combiner, num_elements, current_total_weight,
+                            current_squares_weight, embedding_size.Value(),
+                            &output_ptr[current_output_offset]);
+      }
 
       // Track next bucket.
       num_elements = 0;
@@ -269,9 +273,13 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   }
 
   // Finalize last bucket.
-  FinalizeAggregation(params->combiner, num_elements, current_total_weight,
-                      current_squares_weight, embedding_size.Value(),
-                      &GetTensorData<float>(output)[current_output_offset]);
+  if (current_output_offset >= 0 &&
+      static_cast<size_t>(current_output_offset) + embedding_size.Value() <=
+          output_size.Value()) {
+    FinalizeAggregation(params->combiner, num_elements, current_total_weight,
+                        current_squares_weight, embedding_size.Value(),
+                        &GetTensorData<float>(output)[current_output_offset]);
+  }
 
   return kTfLiteOk;
 }

--- a/tensorflow/lite/kernels/embedding_lookup_sparse.cc
+++ b/tensorflow/lite/kernels/embedding_lookup_sparse.cc
@@ -240,13 +240,24 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     // If we are in a new aggregation bucket and the combiner is not the sum,
     // go back and finalize the result of the previous bucket.
     if (output_offset != current_output_offset) {
-      if (current_output_offset >= 0 &&
-          static_cast<size_t>(current_output_offset) + embedding_size.Value() <=
+      // The aggregation offset is derived from the untrusted sparse `indices`
+      // tensor, so a malformed model can drive it past the output buffer.
+      // Reject such inputs explicitly instead of silently skipping the
+      // aggregation (which would leave the output incomplete) or writing out
+      // of bounds.
+      if (current_output_offset < 0 ||
+          static_cast<size_t>(current_output_offset) + embedding_size.Value() >
               output_size.Value()) {
-        FinalizeAggregation(params->combiner, num_elements, current_total_weight,
-                            current_squares_weight, embedding_size.Value(),
-                            &output_ptr[current_output_offset]);
+        TF_LITE_KERNEL_LOG(
+            context,
+            "Embedding Lookup Sparse: output offset out of bounds. Got %d, "
+            "output size is %zu.",
+            current_output_offset, output_size.Value());
+        return kTfLiteError;
       }
+      FinalizeAggregation(params->combiner, num_elements, current_total_weight,
+                          current_squares_weight, embedding_size.Value(),
+                          &output_ptr[current_output_offset]);
 
       // Track next bucket.
       num_elements = 0;
@@ -273,13 +284,19 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   }
 
   // Finalize last bucket.
-  if (current_output_offset >= 0 &&
-      static_cast<size_t>(current_output_offset) + embedding_size.Value() <=
+  if (current_output_offset < 0 ||
+      static_cast<size_t>(current_output_offset) + embedding_size.Value() >
           output_size.Value()) {
-    FinalizeAggregation(params->combiner, num_elements, current_total_weight,
-                        current_squares_weight, embedding_size.Value(),
-                        &GetTensorData<float>(output)[current_output_offset]);
+    TF_LITE_KERNEL_LOG(
+        context,
+        "Embedding Lookup Sparse: output offset out of bounds. Got %d, "
+        "output size is %zu.",
+        current_output_offset, output_size.Value());
+    return kTfLiteError;
   }
+  FinalizeAggregation(params->combiner, num_elements, current_total_weight,
+                      current_squares_weight, embedding_size.Value(),
+                      &GetTensorData<float>(output)[current_output_offset]);
 
   return kTfLiteOk;
 }

--- a/tensorflow/lite/kernels/embedding_lookup_sparse_test.cc
+++ b/tensorflow/lite/kernels/embedding_lookup_sparse_test.cc
@@ -157,5 +157,45 @@ TEST(EmbeddingLookupSparseOpTest, Indices3DTest) {
               })));
 }
 
+// Regression tests for the EMBEDDING_LOOKUP_SPARSE out-of-bounds write: the
+// aggregation output offset is computed from the untrusted sparse `indices`
+// tensor, so a malformed model can drive it past the output buffer. The op
+// must reject such inputs with kTfLiteError instead of writing out of bounds
+// or silently returning incomplete output. In each model below dense_shape[0]
+// is 3 (valid buckets [0, 3)) and embedding_size is 6, so output_size is 18;
+// the offending sparse coordinate pushes the offset well beyond that.
+
+TEST(EmbeddingLookupSparseOpTest, OutOfBoundsLastBucketReturnsError) {
+  EmbeddingLookupSparseOpModel m(CombinerType_MEAN, {3}, {3, 2}, {2},
+                                 {4, 3, 2});
+  // The final lookup's row coordinate (999) is finalized by the trailing
+  // FinalizeAggregation after the loop.
+  m.SetInput({1, 3, 0}, {0, 0, 2, 0, 999, 0}, {3, 2}, {1.0, 2.0, 4.0});
+  m.Set3DWeightMatrix(
+      [](int i, int j, int k) { return i + j / 10.0f + k / 100.0f; });
+  EXPECT_EQ(m.Invoke(), kTfLiteError);
+}
+
+TEST(EmbeddingLookupSparseOpTest, OutOfBoundsMidBucketReturnsError) {
+  EmbeddingLookupSparseOpModel m(CombinerType_MEAN, {3}, {3, 2}, {2},
+                                 {4, 3, 2});
+  // The middle lookup carries the inflated coordinate, so the offending bucket
+  // is finalized during the loop on the next bucket transition.
+  m.SetInput({1, 3, 0}, {0, 0, 999, 0, 2, 1}, {3, 2}, {1.0, 2.0, 4.0});
+  m.Set3DWeightMatrix(
+      [](int i, int j, int k) { return i + j / 10.0f + k / 100.0f; });
+  EXPECT_EQ(m.Invoke(), kTfLiteError);
+}
+
+TEST(EmbeddingLookupSparseOpTest, NegativeSparseIndexReturnsError) {
+  EmbeddingLookupSparseOpModel m(CombinerType_MEAN, {3}, {3, 2}, {2},
+                                 {4, 3, 2});
+  // A negative sparse coordinate yields a negative output offset.
+  m.SetInput({1, 3, 0}, {0, 0, 2, 0, -5, 0}, {3, 2}, {1.0, 2.0, 4.0});
+  m.Set3DWeightMatrix(
+      [](int i, int j, int k) { return i + j / 10.0f + k / 100.0f; });
+  EXPECT_EQ(m.Invoke(), kTfLiteError);
+}
+
 }  // namespace
 }  // namespace tflite


### PR DESCRIPTION
## Summary

Add output-buffer bounds guard before each `FinalizeAggregation` call in
`tensorflow/lite/kernels/embedding_lookup_sparse.cc`.

## Problem

`TfLiteEmbeddingLookupSparseEval` does not validate that
`current_output_offset` is within the allocated output buffer before calling
`FinalizeAggregation`. An attacker-controlled `.tflite` model can craft
`sp_indices` values such that `output_bucket >= lookup_size`, placing
`current_output_offset` past the end of the output tensor.
`FinalizeAggregation` then performs `output[k] /= multiplier` for
`k in [0, embedding_size)` at that out-of-bounds offset — an OOB write.

Note: the inner per-element accumulation loop (lines 260–268) already guards
each individual write with `current_output_offset + k >= output_size`. This
patch extends the same protection to the finalisation divide-by-weight pass.

## Fix

Wrap both `FinalizeAggregation` call sites with:
```cpp
if (current_output_offset >= 0 &&
    static_cast<size_t>(current_output_offset) + embedding_size.Value() <=
        output_size.Value()) {
  FinalizeAggregation(...);
}
```

## Test plan

- [ ] `bazel test //tensorflow/lite/kernels:embedding_lookup_sparse_test`
- [ ] Verify with ASAN that a crafted model with out-of-range `sp_indices`
      no longer triggers a heap-buffer-overflow in `FinalizeAggregation`