### PR TITLE
Grappler: avoid ArgMin/ArgMax optimization for non-strict monotonic ops

### DIFF
--- a/tensorflow/core/grappler/op_types.cc
+++ b/tensorflow/core/grappler/op_types.cc
@@ -254,7 +254,7 @@ bool IsElementWiseMonotonic(const NodeDef& node, bool* is_non_decreasing) {
 // Returns true if node represents a unary elementwise function that is
 // strictly monotonic. If *is_non_decreasing is true, the function is strictly
 // increasing, e.g. exp, sqrt. If *is_non_decreasing is false, the function is
-// strictly decreasing, e.g. inv.
+// strictly decreasing, e.g. neg, rsqrt.
 //
 // Unlike IsElementWiseMonotonic(), this excludes functions that may map
 // distinct inputs to the same output value (e.g. Relu, Relu6, Floor, Ceil,

--- a/tensorflow/core/grappler/op_types.cc
+++ b/tensorflow/core/grappler/op_types.cc
@@ -251,6 +251,46 @@ bool IsElementWiseMonotonic(const NodeDef& node, bool* is_non_decreasing) {
   return false;
 }
 
+// Returns true if node represents a unary elementwise function that is
+// strictly monotonic. If *is_non_decreasing is true, the function is strictly
+// increasing, e.g. exp, sqrt. If *is_non_decreasing is false, the function is
+// strictly decreasing, e.g. inv.
+//
+// Unlike IsElementWiseMonotonic(), this excludes functions that may map
+// distinct inputs to the same output value (e.g. Relu, Relu6, Floor, Ceil,
+// Rint, Sign), since such functions do not preserve strict ordering and may
+// alter ArgMin/ArgMax tie-breaking semantics.
+bool IsElementWiseStrictlyMonotonic(const NodeDef& node,
+                                    bool* is_non_decreasing) {
+  static const gtl::FlatSet<std::string>* const
+      kStrictMonotonicNonDecreasingOps =
+          CHECK_NOTNULL((new gtl::FlatSet<std::string>{
+              "Acosh",    "Asin", "Asinh",   "Atan",  "Atanh",
+              "Elu",      "Erf",  "Exp",     "Expm1", "Log",
+              "Log1p",    "Selu", "Sigmoid", "Sinh",  "Softsign",
+              "Softplus", "Sqrt", "Tanh",
+          }));
+
+  static const gtl::FlatSet<std::string>* const
+      kStrictMonotonicNonIncreasingOps =
+          CHECK_NOTNULL(
+              (new gtl::FlatSet<std::string>{
+                "Acos", "Erfc", "Neg", "Rsqrt"
+          }));
+
+  if (kStrictMonotonicNonDecreasingOps->count(node.op()) > 0) {
+    if (is_non_decreasing) *is_non_decreasing = true;
+    return true;
+  }
+
+  if (kStrictMonotonicNonIncreasingOps->count(node.op()) > 0) {
+    if (is_non_decreasing) *is_non_decreasing = false;
+    return true;
+  }
+
+  return false;
+}
+
 bool IsElu(const NodeDef& node) { return node.op() == "Elu"; }
 
 bool IsEluGrad(const NodeDef& node) { return node.op() == "EluGrad"; }

--- a/tensorflow/core/grappler/op_types.h
+++ b/tensorflow/core/grappler/op_types.h
@@ -74,6 +74,8 @@ bool IsDequeueOp(const NodeDef& node);
 bool IsDiv(const NodeDef& node);
 bool IsDivNoNan(const NodeDef& node);
 bool IsElementWiseMonotonic(const NodeDef& node, bool* is_non_decreasing);
+bool IsElementWiseStrictlyMonotonic(const NodeDef& node,
+                                    bool* is_non_decreasing);
 bool IsElu(const NodeDef& node);
 bool IsEluGrad(const NodeDef& node);
 bool IsQuantizationEmulation(const NodeDef& node);

--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc
@@ -3560,7 +3560,7 @@ class OptimizeMaxOrMinOfMonotonicStage : public ArithmeticOptimizerStage {
     };
     bool is_non_decreasing = false;
     if (!IsInPreserveSet(*inner_function) &&
-        IsElementWiseMonotonic(*inner_function, &is_non_decreasing) &&
+        IsElementWiseStrictlyMonotonic(*inner_function, &is_non_decreasing) &&
         ctx().node_map->GetOutputs(inner_function->name()).size() == 1 &&
         (is_non_decreasing || !IsAnyMaxPool(*reduction_node)) &&
         !can_be_fused_by_remapper(*inner_function, *inner_function_input)) {

--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer.cc
@@ -3559,8 +3559,12 @@ class OptimizeMaxOrMinOfMonotonicStage : public ArithmeticOptimizerStage {
       return false;
     };
     bool is_non_decreasing = false;
-    if (!IsInPreserveSet(*inner_function) &&
-        IsElementWiseStrictlyMonotonic(*inner_function, &is_non_decreasing) &&
+    const bool is_monotonic =
+        IsArgMax(*reduction_node) || IsArgMin(*reduction_node)
+            ? IsElementWiseStrictlyMonotonic(*inner_function,
+                                             &is_non_decreasing)
+            : IsElementWiseMonotonic(*inner_function, &is_non_decreasing);
+    if (!IsInPreserveSet(*inner_function) && is_monotonic &&
         ctx().node_map->GetOutputs(inner_function->name()).size() == 1 &&
         (is_non_decreasing || !IsAnyMaxPool(*reduction_node)) &&
         !can_be_fused_by_remapper(*inner_function, *inner_function_input)) {

--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
@@ -4286,6 +4286,92 @@ TEST_F(ArithmeticOptimizerTest, OptimizeMaxOrMinOfMonotonicElementWiseMaxPool) {
   EXPECT_EQ(required_node_count, 2);
 }
 
+TEST_F(ArithmeticOptimizerTest, ArgMinReluIsNotOptimized) {
+  using tensorflow::ops::ArgMin;
+  using tensorflow::ops::Relu;
+
+  Scope scope = Scope::NewRootScope();
+
+  auto input = ops::Placeholder(scope.WithOpName("input"), DT_FLOAT);
+  auto relu = Relu(scope.WithOpName("relu"), input);
+  auto axis = ops::Const(scope.WithOpName("axis"), 1);
+  auto argmin = ArgMin(scope.WithOpName("argmin"), relu, axis);
+
+  GrapplerItem item;
+  TF_ASSERT_OK(scope.ToGraphDef(&item.graph));
+
+  ArithmeticOptimizer optimizer;
+  GraphDef output;
+  TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+  bool relu_found = false;
+
+  for (const NodeDef& node : output.node()) {
+    if (node.name() == "relu") {
+      relu_found = true;
+      break;
+    }
+  }
+
+  EXPECT_TRUE(relu_found);
+}
+
+TEST_F(ArithmeticOptimizerTest, ArgMaxReluIsNotOptimized) {
+  using tensorflow::ops::ArgMax;
+  using tensorflow::ops::Relu;
+
+  Scope scope = Scope::NewRootScope();
+
+  auto input = ops::Placeholder(scope.WithOpName("input"), DT_FLOAT);
+  auto relu = Relu(scope.WithOpName("relu"), input);
+  auto axis = ops::Const(scope.WithOpName("axis"), 1);
+  auto argmax = ArgMax(scope.WithOpName("argmax"), relu, axis);
+
+  GrapplerItem item;
+  TF_ASSERT_OK(scope.ToGraphDef(&item.graph));
+
+  ArithmeticOptimizer optimizer;
+  GraphDef output;
+  TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &output));
+
+  bool relu_found = false;
+
+  for (const NodeDef& node : output.node()) {
+    if (node.name() == "relu") {
+      relu_found = true;
+      break;
+    }
+  }
+
+  EXPECT_TRUE(relu_found);
+}
+
+TEST_F(ArithmeticOptimizerTest, ArgMinReluTieBreakingPreserved) {
+  Scope scope = Scope::NewRootScope();
+
+  Tensor input_tensor(DT_FLOAT, TensorShape({1, 5}));
+  test::FillValues<float>(
+      &input_tensor, {3.0f, -2.0f, -7.0f, 4.0f, -1.0f});
+
+  auto input = ops::Const(scope.WithOpName("input"), input_tensor);
+  auto relu = ops::Relu(scope.WithOpName("relu"), input);
+  auto axis = ops::Const(scope.WithOpName("axis"), 1);
+  auto argmin = ops::ArgMin(scope.WithOpName("argmin"), relu, axis);
+
+  GrapplerItem item;
+  TF_ASSERT_OK(scope.ToGraphDef(&item.graph));
+  item.fetch.push_back("argmin");
+
+  ArithmeticOptimizer optimizer;
+  GraphDef optimized_graph;
+  TF_ASSERT_OK(optimizer.Optimize(nullptr, item, &optimized_graph));
+
+  // Run optimized graph and verify result is still 1.
+  // Expected after ReLU:
+  // [3, 0, 0, 4, 0]
+  // first minimum is index 1.
+}
+
 TEST_F(ArithmeticOptimizerTest, UnaryOpsComposition) {
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
 

--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
@@ -4286,7 +4286,7 @@ TEST_F(ArithmeticOptimizerTest, OptimizeMaxOrMinOfMonotonicElementWiseMaxPool) {
   EXPECT_EQ(required_node_count, 2);
 }
 
-TEST_F(ArithmeticOptimizerTest, ArgMinReluIsNotOptimized) {
+TEST_F(ArithmeticOptimizerTest, ArgMinReluNodePreserved) {
   using tensorflow::ops::ArgMin;
   using tensorflow::ops::Relu;
 
@@ -4316,7 +4316,7 @@ TEST_F(ArithmeticOptimizerTest, ArgMinReluIsNotOptimized) {
   EXPECT_TRUE(relu_found);
 }
 
-TEST_F(ArithmeticOptimizerTest, ArgMaxReluIsNotOptimized) {
+TEST_F(ArithmeticOptimizerTest, ArgMaxReluNodePreserved) {
   using tensorflow::ops::ArgMax;
   using tensorflow::ops::Relu;
 
@@ -4370,6 +4370,14 @@ TEST_F(ArithmeticOptimizerTest, ArgMinReluTieBreakingPreserved) {
   // Expected after ReLU:
   // [3, 0, 0, 4, 0]
   // first minimum is index 1.
+    
+  std::vector<Tensor> tensors =
+      EvaluateNodes(optimized_graph, item.fetch);
+
+  ASSERT_EQ(tensors.size(), 1);
+
+  test::ExpectTensorEqual<int64_t>(
+      tensors[0], test::AsTensor<int64_t>({1}));
 }
 
 TEST_F(ArithmeticOptimizerTest, UnaryOpsComposition) {


### PR DESCRIPTION
## Motivation

Fixes #118374.

The optimization

    ArgMin(f(x)) -> ArgMin(x)
    ArgMax(f(x)) -> ArgMax(x)

is only valid for strictly monotonic functions.

Several operators currently classified as monotonic
(e.g. Relu, Relu6, Floor, Ceil, Rint, Sign)
may map distinct inputs to the same output value,
introducing ties and changing TensorFlow's
ArgMin/ArgMax tie-breaking semantics.

## Changes

- Added `IsElementWiseStrictlyMonotonic`.
- Updated `OptimizeMaxOrMinOfMonotonic` to require strict monotonicity.
- Added regression tests covering ArgMin/ArgMax with Relu.

## Example

Before:

```python
tf.argmin(tf.nn.relu([[3., -2., -7., 4., -1.]]), axis=-1)
```

could be optimized incorrectly and return:

```python
[2]
```

After:

```python
[1]
```

which matches TensorFlow semantics.