### PR TITLE
Fix XLA DenseBincount negative input validation

### DIFF
--- a/tensorflow/compiler/tests/bincount_op_test.py
+++ b/tensorflow/compiler/tests/bincount_op_test.py
@@ -35,6 +35,17 @@ class BincountTest(xla_test.XLATestCase):
       ):
         self.evaluate(bincount)
 
+  def testDenseBincountNegativeInputRaises(self):
+    with self.session():
+      with self.test_scope():
+        bincount = gen_math_ops.dense_bincount(
+            input=[0, -1, 2], size=3, weights=[]
+        )
+
+      with self.assertRaisesRegex(
+          errors.InvalidArgumentError, "Input arr must be non-negative"
+      ):
+        self.evaluate(bincount)
 
 if __name__ == "__main__":
   googletest.main()

--- a/tensorflow/compiler/tf2xla/kernels/bincount_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/bincount_op.cc
@@ -71,6 +71,14 @@ class DenseBincountOp : public XlaOpKernel {
     OP_REQUIRES(ctx, rank <= 2,
                 absl::InvalidArgumentError(absl::StrCat(
                     "Shape must be at most rank 2 but is rank ", rank)));
+    std::vector<int64_t> input_values;
+    if (ctx->ConstantInputReshapedToIntVector(0, &input_values).ok()) {
+      for (int64_t value : input_values) {
+        OP_REQUIRES(ctx, value >= 0,
+                    absl::InvalidArgumentError(
+                        "Input arr must be non-negative!"));
+      }
+    }
     xla::XlaOp weights = ctx->Input(2);
     absl::StatusOr<xla::Shape> weights_shape_or =
         ctx->builder()->GetShape(weights);


### PR DESCRIPTION
This PR addresses #117960 by adding validation for negative inputs in the XLA `DenseBincount` kernel when the input can be resolved as a compile-time constant.

Without this check, XLA scatter can silently ignore negative bin indices, while the non-XLA eager kernel raises `InvalidArgumentError` with `Input arr must be non-negative!`.

A regression test is added for `gen_math_ops.dense_bincount(input=[0, -1, 2], size=3, weights=[])` under the XLA test scope.