### PR TITLE
fix: add upper bound validation for cycle_length/block_length in InterleaveDatasetOp

### DIFF
--- a/tensorflow/core/kernels/data/interleave_dataset_op.cc
+++ b/tensorflow/core/kernels/data/interleave_dataset_op.cc
@@ -813,12 +813,27 @@ void InterleaveDatasetOp::MakeDataset(OpKernelContext* ctx, DatasetBase* input,
   OP_REQUIRES(
       ctx, cycle_length > 0,
       errors::InvalidArgument("cycle_length must be greater than zero."));
+  // Guard against excessively large cycle_length values that would cause
+  // integer overflow in modulo operations or allocate an unreasonably large
+  // vector in the iterator (see #116198).
+  static constexpr int64_t kMaxCycleLength = 1 << 20;  // 1M
+  OP_REQUIRES(
+      ctx, cycle_length <= kMaxCycleLength,
+      errors::InvalidArgument(
+          "cycle_length must be at most ", kMaxCycleLength,
+          ", got: ", cycle_length));
 
   int64_t block_length = 0;
   OP_REQUIRES_OK(ctx, ParseScalarArgument(ctx, kBlockLength, &block_length));
   OP_REQUIRES(
       ctx, block_length > 0,
       errors::InvalidArgument("block_length must be greater than zero."));
+  static constexpr int64_t kMaxBlockLength = 1 << 20;  // 1M
+  OP_REQUIRES(
+      ctx, block_length <= kMaxBlockLength,
+      errors::InvalidArgument(
+          "block_length must be at most ", kMaxBlockLength,
+          ", got: ", block_length));
 
   std::unique_ptr<CapturedFunction> captured_func;
   OP_REQUIRES_OK(ctx,

--- a/tensorflow/core/kernels/data/interleave_dataset_op_test.cc
+++ b/tensorflow/core/kernels/data/interleave_dataset_op_test.cc
@@ -585,6 +585,64 @@ TEST_F(InterleaveDatasetOpTest, InvalidLength) {
             absl::StatusCode::kInvalidArgument);
 }
 
+// test case 10: cycle_length exceeds kMaxCycleLength (1 << 20).
+InterleaveDatasetParams InterleaveDatasetParamsWithOverflowCycleLength() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/
+      {CreateTensor<int64_t>(TensorShape{3, 3, 1},
+                             {0, 1, 2, 3, 4, 5, 6, 7, 8})},
+      /*node_name=*/"tensor_slice_dataset");
+  return InterleaveDatasetParams(
+      std::move(tensor_slice_dataset_params),
+      /*other_arguments=*/{},
+      /*cycle_length=*/static_cast<int64_t>(1) << 21,  // 2M, exceeds 1M limit
+      /*block_length=*/1,
+      /*func=*/
+      MakeTensorSliceDatasetFunc(
+          DataTypeVector({DT_INT64}),
+          std::vector<PartialTensorShape>({PartialTensorShape({1})})),
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*node_name=*/kNodeName);
+}
+
+TEST_F(InterleaveDatasetOpTest, InvalidCycleLengthOverflow) {
+  auto dataset_params = InterleaveDatasetParamsWithOverflowCycleLength();
+  EXPECT_EQ(Initialize(dataset_params).code(),
+            absl::StatusCode::kInvalidArgument);
+}
+
+// test case 11: block_length exceeds kMaxBlockLength (1 << 20).
+InterleaveDatasetParams InterleaveDatasetParamsWithOverflowBlockLength() {
+  auto tensor_slice_dataset_params = TensorSliceDatasetParams(
+      /*components=*/
+      {CreateTensor<int64_t>(TensorShape{3, 3, 1},
+                             {0, 1, 2, 3, 4, 5, 6, 7, 8})},
+      /*node_name=*/"tensor_slice_dataset");
+  return InterleaveDatasetParams(
+      std::move(tensor_slice_dataset_params),
+      /*other_arguments=*/{},
+      /*cycle_length=*/1,
+      /*block_length=*/static_cast<int64_t>(1) << 21,  // 2M, exceeds 1M limit
+      /*func=*/
+      MakeTensorSliceDatasetFunc(
+          DataTypeVector({DT_INT64}),
+          std::vector<PartialTensorShape>({PartialTensorShape({1})})),
+      /*func_lib=*/{test::function::MakeTensorSliceDataset()},
+      /*type_arguments=*/{},
+      /*output_dtypes=*/{DT_INT64},
+      /*output_shapes=*/{PartialTensorShape({1})},
+      /*node_name=*/kNodeName);
+}
+
+TEST_F(InterleaveDatasetOpTest, InvalidBlockLengthOverflow) {
+  auto dataset_params = InterleaveDatasetParamsWithOverflowBlockLength();
+  EXPECT_EQ(Initialize(dataset_params).code(),
+            absl::StatusCode::kInvalidArgument);
+}
+
 }  // namespace
 }  // namespace data
 }  // namespace tensorflow


### PR DESCRIPTION
## Summary

Add upper bound validation for `cycle_length` and `block_length` in `InterleaveDatasetOp::MakeDataset` to prevent heap segmentation fault.

## Vulnerability (#116198)

`InterleaveDatasetOp::MakeDataset` only validates `cycle_length > 0` but enforces no upper bound. When a user provides `cycle_length=INT64_MAX`:

1. The `Iterator` constructor allocates `current_elements_(cycle_length)` — a vector of `INT64_MAX` elements — causing immediate OOM/SIGSEGV
2. The modulo operation `(cycle_index_ + 1) % cycle_length_` can overflow, leading to out-of-bounds memory access

## Fix

Add a reasonable upper bound (`1 << 20 = 1M`) for both `cycle_length` and `block_length`. Values above this threshold are rejected with `InvalidArgument` error. This is consistent with practical usage — no real workload needs more than 1M interleaved datasets.

## File Changed
- `tensorflow/core/kernels/data/interleave_dataset_op.cc`

Fixes #116198