### PR TITLE
fix: add upper bound validation for num_segments in UnsortedSegmentReductionOp

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -518,12 +518,22 @@ class UnsortedSegmentReductionOp : public OpKernel {
                    internal::ValidateUnsortedSegmentReduction(
                        this, context, data, segment_ids, num_segments));
     const auto segment_flat = segment_ids.flat<Index>();
-    const Index output_rows = internal::SubtleMustCopy(static_cast<Index>(
+    const int64_t num_segments_val =
         num_segments.dtype() == DT_INT32 ? num_segments.scalar<int32_t>()()
-                                         : num_segments.scalar<int64_t>()()));
-    OP_REQUIRES(context, output_rows >= 0,
-                errors::InvalidArgument("Input num_segments == ", output_rows,
+                                         : num_segments.scalar<int64_t>()();
+    OP_REQUIRES(context, num_segments_val >= 0,
+                errors::InvalidArgument("Input num_segments == ",
+                                        num_segments_val,
                                         " must not be negative."));
+    // Guard against excessively large num_segments that would cause integer
+    // overflow in output tensor size calculations, leading to illegal memory
+    // access or process abort (see #117549).
+    const int64_t kMaxSegments = static_cast<int64_t>(1) << 31;  // 2G
+    OP_REQUIRES(context, num_segments_val <= kMaxSegments,
+                errors::InvalidArgument(
+                    "Input num_segments == ", num_segments_val,
+                    " is too large. Must be at most ", kMaxSegments));
+    const Index output_rows = internal::SubtleMustCopy(static_cast<Index>(num_segments_val));
     TensorShape output_shape;
     OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(output_rows));
     for (int i = segment_ids.dims(); i < data.dims(); i++) {

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -525,10 +525,10 @@ class UnsortedSegmentReductionOp : public OpKernel {
         num_segments.dtype() == DT_INT32
             ? static_cast<int64_t>(num_segments.scalar<int32_t>()())
             : num_segments.scalar<int64_t>()());
-    OP_REQUIRES(
-        context, num_segments_val >= 0,
-        errors::InvalidArgument("Input num_segments == ", num_segments_val,
-                                " must not be negative."));
+    OP_REQUIRES(context, num_segments_val >= 0,
+                absl::InvalidArgumentError(
+                    absl::StrCat("Input num_segments == ", num_segments_val,
+                                 " must not be negative.")));
     // Guard against excessively large num_segments that would cause integer
     // overflow in output tensor size calculations, leading to illegal memory
     // access or process abort (see #117549). For 32-bit Index types the
@@ -539,9 +539,9 @@ class UnsortedSegmentReductionOp : public OpKernel {
         static_cast<int64_t>(1) << 31,  // 2G
         static_cast<int64_t>(std::numeric_limits<Index>::max()));
     OP_REQUIRES(context, num_segments_val <= kMaxSegments,
-                errors::InvalidArgument(
+                absl::InvalidArgumentError(absl::StrCat(
                     "Input num_segments == ", num_segments_val,
-                    " is too large. Must be at most ", kMaxSegments));
+                    " is too large. Must be at most ", kMaxSegments)));
     const Index output_rows =
         internal::SubtleMustCopy(static_cast<Index>(num_segments_val));
     TensorShape output_shape;

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -518,13 +518,17 @@ class UnsortedSegmentReductionOp : public OpKernel {
                    internal::ValidateUnsortedSegmentReduction(
                        this, context, data, segment_ids, num_segments));
     const auto segment_flat = segment_ids.flat<Index>();
-    const int64_t num_segments_val =
-        num_segments.dtype() == DT_INT32 ? num_segments.scalar<int32_t>()()
-                                         : num_segments.scalar<int64_t>()();
-    OP_REQUIRES(context, num_segments_val >= 0,
-                errors::InvalidArgument("Input num_segments == ",
-                                        num_segments_val,
-                                        " must not be negative."));
+    // Copy the value out of the (possibly shared) input buffer before any
+    // validation, so that the value that is checked is the same one that is
+    // subsequently used (see SubtleMustCopy).
+    const int64_t num_segments_val = internal::SubtleMustCopy(
+        num_segments.dtype() == DT_INT32
+            ? static_cast<int64_t>(num_segments.scalar<int32_t>()())
+            : num_segments.scalar<int64_t>()());
+    OP_REQUIRES(
+        context, num_segments_val >= 0,
+        errors::InvalidArgument("Input num_segments == ", num_segments_val,
+                                " must not be negative."));
     // Guard against excessively large num_segments that would cause integer
     // overflow in output tensor size calculations, leading to illegal memory
     // access or process abort (see #117549). For 32-bit Index types the
@@ -538,7 +542,8 @@ class UnsortedSegmentReductionOp : public OpKernel {
                 errors::InvalidArgument(
                     "Input num_segments == ", num_segments_val,
                     " is too large. Must be at most ", kMaxSegments));
-    const Index output_rows = internal::SubtleMustCopy(static_cast<Index>(num_segments_val));
+    const Index output_rows =
+        internal::SubtleMustCopy(static_cast<Index>(num_segments_val));
     TensorShape output_shape;
     OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(output_rows));
     for (int i = segment_ids.dims(); i < data.dims(); i++) {

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -527,8 +527,13 @@ class UnsortedSegmentReductionOp : public OpKernel {
                                         " must not be negative."));
     // Guard against excessively large num_segments that would cause integer
     // overflow in output tensor size calculations, leading to illegal memory
-    // access or process abort (see #117549).
-    const int64_t kMaxSegments = static_cast<int64_t>(1) << 31;  // 2G
+    // access or process abort (see #117549). For 32-bit Index types the
+    // effective limit is the largest value representable by Index (kint32max),
+    // since a larger value would overflow the static_cast<Index> below; cap
+    // kMaxSegments accordingly.
+    const int64_t kMaxSegments = std::min<int64_t>(
+        static_cast<int64_t>(1) << 31,  // 2G
+        static_cast<int64_t>(std::numeric_limits<Index>::max()));
     OP_REQUIRES(context, num_segments_val <= kMaxSegments,
                 errors::InvalidArgument(
                     "Input num_segments == ", num_segments_val,

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -533,17 +533,11 @@ class UnsortedSegmentReductionOp : public OpKernel {
     // overflow in output tensor size calculations, leading to illegal memory
     // access or process abort (see #117549).
     //
-    // The bound is kint32max for every Index type, not 2^31. Those differ by
-    // one, and the smaller value is the safe one: 2^31 is not representable in
-    // a signed 32-bit integer, so any downstream code that indexes with int32
-    // would wrap it to a negative value. Using kint32max also removes the
-    // asymmetry where a 64-bit index admitted one more segment than a 32-bit
-    // one for no reason a caller could observe or rely on.
-    //
-    // Nothing practical is given up. A single segment costs at least an entry
-    // in the CPU functor's std::vector<Index> row_counter, so kint32max
-    // segments is already tens of gigabytes of bookkeeping before any output
-    // element is written.
+    // Use kint32max for every index type. Although an int64 index could
+    // represent 2^31, that value is not representable as a signed int32 and
+    // would wrap if any downstream code performs 32-bit indexing; a uniform
+    // bound avoids that edge case. Nothing practical is lost, since the CPU
+    // functor already allocates std::vector<Index> row_counter(num_segments).
     const int64_t kMaxSegments =
         static_cast<int64_t>(std::numeric_limits<int32_t>::max());
     OP_REQUIRES(context, num_segments_val <= kMaxSegments,

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -531,13 +531,21 @@ class UnsortedSegmentReductionOp : public OpKernel {
                                  " must not be negative.")));
     // Guard against excessively large num_segments that would cause integer
     // overflow in output tensor size calculations, leading to illegal memory
-    // access or process abort (see #117549). For 32-bit Index types the
-    // effective limit is the largest value representable by Index (kint32max),
-    // since a larger value would overflow the static_cast<Index> below; cap
-    // kMaxSegments accordingly.
-    const int64_t kMaxSegments = std::min<int64_t>(
-        static_cast<int64_t>(1) << 31,  // 2G
-        static_cast<int64_t>(std::numeric_limits<Index>::max()));
+    // access or process abort (see #117549).
+    //
+    // The bound is kint32max for every Index type, not 2^31. Those differ by
+    // one, and the smaller value is the safe one: 2^31 is not representable in
+    // a signed 32-bit integer, so any downstream code that indexes with int32
+    // would wrap it to a negative value. Using kint32max also removes the
+    // asymmetry where a 64-bit index admitted one more segment than a 32-bit
+    // one for no reason a caller could observe or rely on.
+    //
+    // Nothing practical is given up. A single segment costs at least an entry
+    // in the CPU functor's std::vector<Index> row_counter, so kint32max
+    // segments is already tens of gigabytes of bookkeeping before any output
+    // element is written.
+    const int64_t kMaxSegments =
+        static_cast<int64_t>(std::numeric_limits<int32_t>::max());
     OP_REQUIRES(context, num_segments_val <= kMaxSegments,
                 absl::InvalidArgumentError(absl::StrCat(
                     "Input num_segments == ", num_segments_val,

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -521,10 +521,10 @@ class UnsortedSegmentReductionOp : public OpKernel {
     // Copy the value out of the (possibly shared) input buffer before any
     // validation, so that the value that is checked is the same one that is
     // subsequently used (see SubtleMustCopy).
-    const int64_t num_segments_val = internal::SubtleMustCopy(
+    const int64_t num_segments_val =
         num_segments.dtype() == DT_INT32
-            ? static_cast<int64_t>(num_segments.scalar<int32_t>()())
-            : num_segments.scalar<int64_t>()());
+            ? internal::SubtleMustCopy(num_segments.scalar<int32_t>()())
+            : internal::SubtleMustCopy(num_segments.scalar<int64_t>()());
     OP_REQUIRES(context, num_segments_val >= 0,
                 absl::InvalidArgumentError(
                     absl::StrCat("Input num_segments == ", num_segments_val,
@@ -542,8 +542,7 @@ class UnsortedSegmentReductionOp : public OpKernel {
                 absl::InvalidArgumentError(absl::StrCat(
                     "Input num_segments == ", num_segments_val,
                     " is too large. Must be at most ", kMaxSegments)));
-    const Index output_rows =
-        internal::SubtleMustCopy(static_cast<Index>(num_segments_val));
+    const Index output_rows = static_cast<Index>(num_segments_val);
     TensorShape output_shape;
     OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(output_rows));
     for (int i = segment_ids.dims(); i < data.dims(); i++) {

--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -523,7 +523,8 @@ class UnsortedSegmentReductionOp : public OpKernel {
     // subsequently used (see SubtleMustCopy).
     const int64_t num_segments_val =
         num_segments.dtype() == DT_INT32
-            ? internal::SubtleMustCopy(num_segments.scalar<int32_t>()())
+            ? static_cast<int64_t>(
+                  internal::SubtleMustCopy(num_segments.scalar<int32_t>()()))
             : internal::SubtleMustCopy(num_segments.scalar<int64_t>()());
     OP_REQUIRES(context, num_segments_val >= 0,
                 absl::InvalidArgumentError(

--- a/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
@@ -660,7 +660,7 @@ class UnsortedSegmentTest(SegmentReductionHelper, parameterized.TestCase):
       unsorted = math_ops.unsorted_segment_sum(
           np.ones((3)), segment_ids=898042203, num_segments=num_segments)
       with self.assertRaisesOpError(
-          "Encountered overflow when multiplying | must not be negative"
+          "Encountered overflow when multiplying | must not be negative | is too large"
       ):
         self.evaluate(unsorted)
 
@@ -724,6 +724,33 @@ class UnsortedSegmentTest(SegmentReductionHelper, parameterized.TestCase):
               self.assertTrue(np.isnan(evaluated_max[0][0]))
               self.assertAllClose(evaluated_max[0][1], 3.0)
 
+  def testNumSegmentsOverflow(self):
+    """Regression test: num_segments > 2G must raise InvalidArgumentError.
+
+    Excessively large num_segments values (near INT64_MAX) cause integer
+    overflow in internal size calculations, leading to illegal memory access
+    or process abort. The upper bound of 2^31 prevents this. See #117549.
+    """
+    data = constant_op.constant([1, 2, 3, 4], dtype=dtypes_lib.int32)
+    segment_ids = constant_op.constant([0, 1, 0, 1], dtype=dtypes_lib.int64)
+    # Just above the 2G limit (2^31 + 1).
+    num_segments = constant_op.constant((1 << 31) + 1, dtype=dtypes_lib.int64)
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                "is too large"):
+      self.evaluate(math_ops.unsorted_segment_sum(
+          data=data, segment_ids=segment_ids, num_segments=num_segments))
+
+  def testNumSegmentsOverflow_Int32Index(self):
+    """Regression test: num_segments > 2G must raise InvalidArgumentError even with int32 index.
+    """
+    data = constant_op.constant([1, 2, 3, 4], dtype=dtypes_lib.int32)
+    segment_ids = constant_op.constant([0, 1, 0, 1], dtype=dtypes_lib.int32)
+    # Just above the 2G limit (2^31 + 1).
+    num_segments = constant_op.constant((1 << 31) + 1, dtype=dtypes_lib.int64)
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                "is too large"):
+      self.evaluate(math_ops.unsorted_segment_sum(
+          data=data, segment_ids=segment_ids, num_segments=num_segments))
 
 class SparseSegmentReductionHelper(SegmentReductionHelper):
 

--- a/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
@@ -750,8 +750,24 @@ class UnsortedSegmentTest(SegmentReductionHelper, parameterized.TestCase):
     """
     data = constant_op.constant([1, 2, 3, 4], dtype=dtypes_lib.int32)
     segment_ids = constant_op.constant([0, 1, 0, 1], dtype=dtypes_lib.int32)
-    # Exactly the 2G boundary (2^31): valid for an int64 index but out of
-    # range for a signed int32 index.
+    # Exactly the 2^31 boundary: one past what a signed int32 can represent.
+    num_segments = constant_op.constant(1 << 31, dtype=dtypes_lib.int64)
+    with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
+                                "is too large"):
+      self.evaluate(math_ops.unsorted_segment_sum(
+          data=data, segment_ids=segment_ids, num_segments=num_segments))
+
+  def testNumSegmentsOverflow_Int64Index(self):
+    """num_segments == 2^31 must be rejected with an int64 index too.
+
+    The limit is kint32max for every index type, not 2^31. The two differ by
+    one, and an earlier revision of this check allowed 2^31 whenever Index was
+    wide enough to hold it -- which left a value that is not representable in a
+    signed 32-bit integer reaching any downstream code that indexes with int32.
+    This pins the 64-bit path to the same bound. See #117549.
+    """
+    data = constant_op.constant([1, 2, 3, 4], dtype=dtypes_lib.int32)
+    segment_ids = constant_op.constant([0, 1, 0, 1], dtype=dtypes_lib.int64)
     num_segments = constant_op.constant(1 << 31, dtype=dtypes_lib.int64)
     with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
                                 "is too large"):

--- a/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
@@ -660,7 +660,8 @@ class UnsortedSegmentTest(SegmentReductionHelper, parameterized.TestCase):
       unsorted = math_ops.unsorted_segment_sum(
           np.ones((3)), segment_ids=898042203, num_segments=num_segments)
       with self.assertRaisesOpError(
-          "Encountered overflow when multiplying | must not be negative | is too large"
+          "Encountered overflow when multiplying | must not be negative | "
+          "is too large"
       ):
         self.evaluate(unsorted)
 
@@ -741,12 +742,17 @@ class UnsortedSegmentTest(SegmentReductionHelper, parameterized.TestCase):
           data=data, segment_ids=segment_ids, num_segments=num_segments))
 
   def testNumSegmentsOverflow_Int32Index(self):
-    """Regression test: num_segments > 2G must raise InvalidArgumentError even with int32 index.
+    """num_segments == 2^31 must be rejected when the index type is int32.
+
+    With a signed int32 index the largest representable segment count is
+    kint32max (2^31 - 1), so exactly 2^31 must be flagged as too large
+    rather than silently overflowing the cast to Index. See #117549.
     """
     data = constant_op.constant([1, 2, 3, 4], dtype=dtypes_lib.int32)
     segment_ids = constant_op.constant([0, 1, 0, 1], dtype=dtypes_lib.int32)
-    # Just above the 2G limit (2^31 + 1).
-    num_segments = constant_op.constant((1 << 31) + 1, dtype=dtypes_lib.int64)
+    # Exactly the 2G boundary (2^31): valid for an int64 index but out of
+    # range for a signed int32 index.
+    num_segments = constant_op.constant(1 << 31, dtype=dtypes_lib.int64)
     with self.assertRaisesRegex(errors_impl.InvalidArgumentError,
                                 "is too large"):
       self.evaluate(math_ops.unsorted_segment_sum(

--- a/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
@@ -758,6 +758,7 @@ class UnsortedSegmentTest(SegmentReductionHelper, parameterized.TestCase):
       self.evaluate(math_ops.unsorted_segment_sum(
           data=data, segment_ids=segment_ids, num_segments=num_segments))
 
+
 class SparseSegmentReductionHelper(SegmentReductionHelper):
 
   def _sparse_input(self, input_shape, num_indices, dtype=dtypes_lib.int32):

--- a/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
@@ -726,11 +726,11 @@ class UnsortedSegmentTest(SegmentReductionHelper, parameterized.TestCase):
               self.assertAllClose(evaluated_max[0][1], 3.0)
 
   def testNumSegmentsOverflow(self):
-    """Regression test: num_segments > 2G must raise InvalidArgumentError.
+    """Regression test: an oversized num_segments raises InvalidArgumentError.
 
     Excessively large num_segments values (near INT64_MAX) cause integer
     overflow in internal size calculations, leading to illegal memory access
-    or process abort. The upper bound of 2^31 prevents this. See #117549.
+    or process abort. The kint32max upper bound prevents this. See #117549.
     """
     data = constant_op.constant([1, 2, 3, 4], dtype=dtypes_lib.int32)
     segment_ids = constant_op.constant([0, 1, 0, 1], dtype=dtypes_lib.int64)


### PR DESCRIPTION
## Summary

Add upper bound validation for `num_segments` in `UnsortedSegmentReductionOp::Compute` to prevent integer overflow in output tensor size calculations.

## Vulnerability (#117549)

`UnsortedSegmentSum` with extremely large `num_segments` (near `INT64_MAX`) causes integer overflow in internal size calculations when computing the output tensor shape. This leads to:

1. **Illegal memory access** detected by ASan (`allocation-size-too-big`)
2. **Process abort/crash** — denial of service via crafted input

### Reproduction
\\\python
import tensorflow as tf
data = tf.constant([1, 2, 3, 4], dtype=tf.uint16)
segment_ids = tf.constant([0, 1, 0, 1], dtype=tf.int64)
num_segments = tf.constant(9223372036854775807, dtype=tf.int64)  # INT64_MAX
tf.raw_ops.UnsortedSegmentSum(data=data, segment_ids=segment_ids, num_segments=num_segments)
# Crashes with SIGABRT
\\\

## Fix

Add a reasonable upper bound (2G = `1 << 31`) for `num_segments`. Values above this threshold are rejected with `InvalidArgument` error before any allocation attempt.

## File Changed
- `tensorflow/core/kernels/segment_reduction_ops_impl.h`

Fixes #117549