### PR TITLE
fix: add rank validation in MklAvgPoolingGradOp to prevent CHECK failure crash

### DIFF
--- a/tensorflow/core/kernels/mkl/BUILD
+++ b/tensorflow/core/kernels/mkl/BUILD
@@ -225,6 +225,18 @@ tf_cc_test_mkl(
 )
 
 tf_cc_test_mkl(
+    name = "mkl_avgpooling_op_test",
+    size = "small",
+    srcs = ["mkl_avgpooling_op_test.cc"],
+    linkstatic = 1,  # Fixes dyld error on MacOS.
+    deps = [
+        ":mkl_pooling_ops",
+        "//tensorflow/core:nn_ops_op_lib",
+        "//tensorflow/core:mkl_nn_ops_op_lib",
+    ] + MKL_TEST_DEPS,
+)
+
+tf_cc_test_mkl(
     name = "mkl_quantized_concat_op_test",
     size = "small",
     srcs = ["mkl_quantized_concat_op_test.cc"],

--- a/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
@@ -206,6 +206,28 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       const Tensor& grad_tensor =
           MklGetInput(context, kInputTensorIndexInputGradient);
 
+      // Verify that orig_input_tensor is a 1D vector before calling
+      // .vec<int32>(). A scalar or higher-rank tensor would cause an
+      // assertion crash.
+      OP_REQUIRES(context, orig_input_tensor.dims() == 1,
+                  errors::InvalidArgument(
+                      "orig_input_shape must be a 1D tensor, but got a ",
+                      orig_input_tensor.dims(), "D tensor with shape ",
+                      orig_input_tensor.shape().DebugString()));
+
+      // Defensive validation that ksize has the expected number of
+      // dimensions. The constructor already validates this, but we
+      // check here to guard against potential memory safety issues
+      // if ksize is somehow invalid at Compute time.
+      OP_REQUIRES(context,
+                  this->ksize_.size() == 4 || this->ksize_.size() == 5,
+                  errors::InvalidArgument(
+                      "ksize must have 4 or 5 elements, but got ",
+                      this->ksize_.size()));
+
+      bool is_pool2d = (this->ksize_.size() == 4);
+      int expected_rank = is_pool2d ? 4 : 5;
+
       // For empty tensor, avg_pool_3d_grad in oneDNN doesn't handle this case.
       // Follow what native TF does in this case.
 
@@ -214,12 +236,25 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       for (int64_t i = 0; i < orig_input_tensor.NumElements(); ++i) {
         OP_REQUIRES_OK(context, output_shape.AddDimWithStatus(shape_vec(i)));
       }
+
+      // Validate that output_shape and grad_tensor have the expected rank
+      // to prevent CHECK failure in TFShapeToMklDnnDims* functions which
+      // unconditionally access dim_size(N) (see #118354).
+      OP_REQUIRES(context, output_shape.dims() == expected_rank,
+                  errors::InvalidArgument(
+                      "Expected orig_input shape to represent a ",
+                      expected_rank, "D shape, but got a ",
+                      output_shape.dims(), "D shape."));
+      OP_REQUIRES(context, grad_tensor.dims() == expected_rank,
+                  errors::InvalidArgument(
+                      "Expected grad tensor to be ", expected_rank,
+                      "D, but got a ", grad_tensor.dims(), "D tensor."));
+
       Tensor* output_tensor = nullptr;
       OP_REQUIRES_OK(context,
                      context->allocate_output(0, output_shape, &output_tensor));
       output_tensor->flat<T>().setZero();
 
-      bool is_pool2d = (this->ksize_.size() == 4);
 
       // out-of-memory boundary index check for output_tensor in 2D case.
       const int depth_window = this->ksize_[3];

--- a/tensorflow/core/kernels/mkl/mkl_avgpooling_op_test.cc
+++ b/tensorflow/core/kernels/mkl/mkl_avgpooling_op_test.cc
@@ -1,0 +1,164 @@
+/* Copyright 2025 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#if defined(INTEL_MKL)
+
+#include "tensorflow/core/framework/fake_input.h"
+#include "tensorflow/core/framework/node_def_builder.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/types.pb.h"
+#include "tensorflow/core/kernels/ops_testutil.h"
+#include "tensorflow/core/lib/core/status_test_util.h"
+#include "tensorflow/core/platform/test.h"
+
+namespace tensorflow {
+
+// Regression tests for MklAvgPoolingGradOp input validation.
+// These tests verify that malformed inputs produce clean InvalidArgument
+// errors instead of crashing with CHECK failures (see #118354).
+
+class MklAvgPoolingGradOpTest : public OpsTestBase {};
+
+// ---------- 2D pooling gradient tests (_MklNativeAvgPoolGrad) ----------
+
+// Test: scalar orig_input_shape should return InvalidArgument, not crash.
+TEST_F(MklAvgPoolingGradOpTest, ScalarOrigInputShape_2D) {
+  TF_ASSERT_OK(NodeDefBuilder("avg_pool_grad", "_MklNativeAvgPoolGrad")
+                   .Input(FakeInput(DT_INT32))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("ksize", {1, 2, 2, 1})
+                   .Attr("strides", {1, 1, 1, 1})
+                   .Attr("padding", "VALID")
+                   .Attr("data_format", "NHWC")
+                   .Finalize(node_def()));
+  TF_ASSERT_OK(InitOp());
+
+  // Scalar orig_input_shape (0D) — should fail because it's not 1D.
+  AddInputFromArray<int32>(TensorShape({}), {0});
+  // Scalar grad tensor (0D).
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
+
+  Status s = RunOpKernel();
+  EXPECT_FALSE(s.ok());
+  EXPECT_TRUE(absl::IsInvalidArgument(s)) << s;
+  EXPECT_NE(s.message().find("orig_input_shape must be a 1D tensor"),
+            std::string::npos)
+      << s;
+}
+
+// Test: empty orig_input_shape (1D with 0 elements) produces rank-0
+// output_shape, which should fail the rank check.
+TEST_F(MklAvgPoolingGradOpTest, EmptyOrigInputShape_2D) {
+  TF_ASSERT_OK(NodeDefBuilder("avg_pool_grad", "_MklNativeAvgPoolGrad")
+                   .Input(FakeInput(DT_INT32))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("ksize", {1, 2, 2, 1})
+                   .Attr("strides", {1, 1, 1, 1})
+                   .Attr("padding", "VALID")
+                   .Attr("data_format", "NHWC")
+                   .Finalize(node_def()));
+  TF_ASSERT_OK(InitOp());
+
+  // 1D tensor with 0 elements — will produce a 0D output_shape.
+  AddInputFromArray<int32>(TensorShape({0}), {});
+  // Scalar grad tensor.
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
+
+  Status s = RunOpKernel();
+  EXPECT_FALSE(s.ok());
+  EXPECT_TRUE(absl::IsInvalidArgument(s)) << s;
+}
+
+// Test: valid orig_input_shape but wrong-rank grad tensor.
+TEST_F(MklAvgPoolingGradOpTest, WrongRankGrad_2D) {
+  TF_ASSERT_OK(NodeDefBuilder("avg_pool_grad", "_MklNativeAvgPoolGrad")
+                   .Input(FakeInput(DT_INT32))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("ksize", {1, 2, 2, 1})
+                   .Attr("strides", {1, 1, 1, 1})
+                   .Attr("padding", "VALID")
+                   .Attr("data_format", "NHWC")
+                   .Finalize(node_def()));
+  TF_ASSERT_OK(InitOp());
+
+  // Valid 4-element orig_input_shape representing a 4D tensor.
+  AddInputFromArray<int32>(TensorShape({4}), {1, 4, 4, 1});
+  // 1D grad tensor (wrong rank — should be 4D).
+  AddInputFromArray<float>(TensorShape({16}), {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                0, 0, 0, 0, 0, 0});
+
+  Status s = RunOpKernel();
+  EXPECT_FALSE(s.ok());
+  EXPECT_TRUE(absl::IsInvalidArgument(s)) << s;
+  EXPECT_NE(s.message().find("Expected grad tensor to be 4D"),
+            std::string::npos)
+      << s;
+}
+
+// ---------- 3D pooling gradient tests (_MklNativeAvgPool3DGrad) ----------
+
+// Test: scalar orig_input_shape should return InvalidArgument, not crash.
+TEST_F(MklAvgPoolingGradOpTest, ScalarOrigInputShape_3D) {
+  TF_ASSERT_OK(NodeDefBuilder("avg_pool_3d_grad", "_MklNativeAvgPool3DGrad")
+                   .Input(FakeInput(DT_INT32))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("ksize", {1, 2, 2, 2, 1})
+                   .Attr("strides", {1, 1, 1, 1, 1})
+                   .Attr("padding", "VALID")
+                   .Attr("data_format", "NDHWC")
+                   .Finalize(node_def()));
+  TF_ASSERT_OK(InitOp());
+
+  // Scalar orig_input_shape (0D).
+  AddInputFromArray<int32>(TensorShape({}), {0});
+  // Scalar grad tensor (0D).
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
+
+  Status s = RunOpKernel();
+  EXPECT_FALSE(s.ok());
+  EXPECT_TRUE(absl::IsInvalidArgument(s)) << s;
+  EXPECT_NE(s.message().find("orig_input_shape must be a 1D tensor"),
+            std::string::npos)
+      << s;
+}
+
+// Test: valid orig_input_shape but wrong-rank grad tensor for 3D pooling.
+TEST_F(MklAvgPoolingGradOpTest, WrongRankGrad_3D) {
+  TF_ASSERT_OK(NodeDefBuilder("avg_pool_3d_grad", "_MklNativeAvgPool3DGrad")
+                   .Input(FakeInput(DT_INT32))
+                   .Input(FakeInput(DT_FLOAT))
+                   .Attr("ksize", {1, 2, 2, 2, 1})
+                   .Attr("strides", {1, 1, 1, 1, 1})
+                   .Attr("padding", "VALID")
+                   .Attr("data_format", "NDHWC")
+                   .Finalize(node_def()));
+  TF_ASSERT_OK(InitOp());
+
+  // Valid 5-element orig_input_shape representing a 5D tensor.
+  AddInputFromArray<int32>(TensorShape({5}), {1, 4, 4, 4, 1});
+  // Scalar grad tensor (wrong rank — should be 5D).
+  AddInputFromArray<float>(TensorShape({}), {0.0f});
+
+  Status s = RunOpKernel();
+  EXPECT_FALSE(s.ok());
+  EXPECT_TRUE(absl::IsInvalidArgument(s)) << s;
+  EXPECT_NE(s.message().find("Expected grad tensor to be 5D"),
+            std::string::npos)
+      << s;
+}
+
+}  // namespace tensorflow
+
+#endif  // INTEL_MKL


### PR DESCRIPTION
## Summary

Add rank validation for `grad` tensor and `orig_input_shape` in `MklAvgPoolingGradOp::Compute` to prevent fatal CHECK failure crash on invalid input shapes.

## Vulnerability (#118354)

`MklAvgPoolingGradOp::Compute()` calls `TFShapeToMklDnnDimsInNCDHW()` which unconditionally accesses `dim_size(4)` on input shapes. When the grad tensor has 0 dimensions (scalar/empty), this triggers:

\\\
F0000 tensor_shape.cc:362] Check failed: d < dims() (4 vs. 0)
\\\

The process **aborts with SIGABRT** instead of returning a clean Python-level error, causing a denial-of-service condition.

## Fix

Add `OP_REQUIRES` validation that both `output_shape` (from `orig_input_shape`) and `grad_tensor` have the expected rank (4 for 2D pooling, 5 for 3D pooling) before any dimension access. Invalid inputs now return `InvalidArgument` error instead of crashing.

## File Changed
- `tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc`

Fixes #118354