### PR TITLE
fix: replace fatal DCHECK with LOG(WARNING) in OpLevelCostEstimator

### DIFF
--- a/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
+++ b/tensorflow/core/grappler/costs/op_level_cost_estimator.cc
@@ -189,9 +189,11 @@ bool IsTraining(const OpInfo& op_info) {
 std::vector<int64_t> GetStrides(const OpInfo& op_info) {
   if (op_info.attr().find("strides") != op_info.attr().end()) {
     const auto strides = op_info.attr().at("strides").list().i();
-    DCHECK(strides.size() == 4)
-        << "Attr strides is not a length-4 vector: " << op_info.DebugString();
-    if (strides.size() != 4) return {1, 1, 1, 1};
+    if (strides.size() != 4) {
+      LOG(WARNING) << "Attr strides is not a length-4 vector (size="
+                   << strides.size() << "): " << op_info.DebugString();
+      return {1, 1, 1, 1};
+    }
     return {strides[0], strides[1], strides[2], strides[3]};
   }
   return {1, 1, 1, 1};
@@ -200,9 +202,11 @@ std::vector<int64_t> GetStrides(const OpInfo& op_info) {
 std::vector<int64_t> GetKernelSize(const OpInfo& op_info) {
   if (op_info.attr().find("ksize") != op_info.attr().end()) {
     const auto ksize = op_info.attr().at("ksize").list().i();
-    DCHECK(ksize.size() == 4)
-        << "Attr ksize is not a length-4 vector: " << op_info.DebugString();
-    if (ksize.size() != 4) return {1, 1, 1, 1};
+    if (ksize.size() != 4) {
+      LOG(WARNING) << "Attr ksize is not a length-4 vector (size="
+                   << ksize.size() << "): " << op_info.DebugString();
+      return {1, 1, 1, 1};
+    }
     return {ksize[0], ksize[1], ksize[2], ksize[3]};
   }
   // Note that FusedBatchNorm doesn't have ksize attr, but GetKernelSize returns

--- a/tensorflow/core/grappler/costs/op_level_cost_estimator_test.cc
+++ b/tensorflow/core/grappler/costs/op_level_cost_estimator_test.cc
@@ -2376,5 +2376,34 @@ TEST_F(OpLevelCostEstimatorTest, GetDeviceInfo_EmptyCpu) {
   EXPECT_GT(device_info.gb_per_sec, 0);
 }
 
+TEST_F(OpLevelCostEstimatorTest, InvalidStridesOrKernelSize) {
+  // Test with invalid strides (e.g. size 3 instead of 4).
+  // PredictCosts() should log a warning but handle it gracefully using the
+  // fallback {1, 1, 1, 1}.
+  auto op_context = DescribePoolingOp("MaxPool", {16, 19, 19, 48},
+                                      {1, 1, 1, 1}, {1, 1, 1, 1}, "NHWC",
+                                      "SAME");
+  auto* attr = op_context.op_info.mutable_attr();
+  std::vector<int> invalid_strides = {1, 1, 1};
+  SetAttrValue(invalid_strides, &(*attr)["strides"]);
+
+  auto cost = PredictCosts(op_context);
+  EXPECT_GT(cost.execution_time.count(), 0);
+  EXPECT_FALSE(cost.inaccurate);
+
+  // Test with invalid ksize (e.g. size 3 instead of 4).
+  // PredictCosts() should log a warning but handle it gracefully using the
+  // fallback {1, 1, 1, 1}.
+  auto op_context_invalid_ksize = DescribePoolingOp(
+      "MaxPool", {16, 19, 19, 48}, {1, 1, 1, 1}, {1, 1, 1, 1}, "NHWC", "SAME");
+  auto* attr_invalid_ksize = op_context_invalid_ksize.op_info.mutable_attr();
+  std::vector<int> invalid_ksize = {1, 1, 1};
+  SetAttrValue(invalid_ksize, &(*attr_invalid_ksize)["ksize"]);
+
+  auto cost_invalid_ksize = PredictCosts(op_context_invalid_ksize);
+  EXPECT_GT(cost_invalid_ksize.execution_time.count(), 0);
+  EXPECT_FALSE(cost_invalid_ksize.inaccurate);
+}
+
 }  // end namespace grappler
 }  // end namespace tensorflow


### PR DESCRIPTION
## Summary

Replace fatal `DCHECK` assertions with `LOG(WARNING)` in `GetStrides()` and `GetKernelSize()` in `op_level_cost_estimator.cc` to prevent process abort on invalid attr sizes.

## Vulnerability (#118353)

`DepthwiseConv2dNativeBackpropInput` with malformed strides attr triggers a fatal `DCHECK` failure in `GetStrides()`:

\\\
F0000 op_level_cost_estimator.cc:192] Check failed: strides.size() == 4
\\\

The process **aborts with SIGABRT** in debug/sanitizer builds instead of returning a clean error. The same pattern exists in `GetKernelSize()` for ksize attrs.

## Fix

The code **already has graceful fallback** (returns `{1,1,1,1}` when size != 4), so the `DCHECK` is unnecessarily fatal. Replace with `LOG(WARNING)` to preserve the diagnostic message without crashing.

## File Changed
- `tensorflow/core/grappler/costs/op_level_cost_estimator.cc`

Fixes #118353