### PR TITLE
fix: heap corruption in OneDNN batch matmul with broadcast rank mismatch

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_helper.h
+++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_helper.h
@@ -40,7 +40,7 @@ struct MklBatchMatMulHelper {
     auto ndims_input = input_shape.dims();
     auto ndims_output = output_shape.dims();
     auto dim_offset = ndims_output - ndims_input;
-    DCHECK(dim_offset > 0);
+    DCHECK_GE(dim_offset, 0);
     reshaped_dims->clear();
     reshaped_dims->resize(ndims_output, 1);
     auto input_dims = input_shape.dim_sizes();
@@ -73,6 +73,19 @@ struct MklBatchMatMulHelper {
     auto lhs_strides = CalculateTFStrides(lhs_dims);
     auto rhs_strides = CalculateTFStrides(rhs_dims);
     auto out_strides = CalculateTFStrides(out_dims);
+
+    // When a dimension has size 1 and is broadcasted, its stride must be
+    // set to 0 so that OneDNN re-reads the same data for each index along
+    // this dimension instead of advancing the pointer beyond the actual
+    // tensor buffer (which causes heap corruption). See #117700.
+    for (int i = 0; i < ndims_out - 2; ++i) {
+      if (lhs_dims[i] == 1) {
+        lhs_strides[i] = 0;
+      }
+      if (rhs_dims[i] == 1) {
+        rhs_strides[i] = 0;
+      }
+    }
 
     if (adj_x) {
       int m_idx = ndims_out - 1;

--- a/tensorflow/python/kernel_tests/math_ops/batch_matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/batch_matmul_op_test.py
@@ -154,6 +154,39 @@ def _GetBatchMatmulOpBroadcastingTest(dtype, adjoint_a, adjoint_b,
   return Test
 
 
+class BatchMatmulBroadcastRankMismatchTest(test.TestCase):
+  """Regression test for rank-4 x rank-2 matmul broadcasting.
+
+  When OneDNN is enabled, broadcasting a rank-2 tensor to match a rank-4
+  tensor caused heap corruption because CalculateTFStrides computed non-zero
+  strides for the prepended broadcast dimensions. See #117700.
+  """
+
+  def testRank4xRank2(self):
+    np.random.seed(280958)
+    p = np.random.normal(size=[13, 1, 3, 4]).astype(np.float32)
+    w = np.random.normal(size=[4, 16]).astype(np.float32)
+    expected = np.matmul(p, w)
+    result = math_ops.matmul(p, w)
+    self.assertAllClose(self.evaluate(result), expected, rtol=1e-5, atol=1e-5)
+
+  def testRank4xRank2BatchDim(self):
+    np.random.seed(42)
+    p = np.random.normal(size=[2, 3, 4, 5]).astype(np.float32)
+    w = np.random.normal(size=[5, 7]).astype(np.float32)
+    expected = np.matmul(p, w)
+    result = math_ops.matmul(p, w)
+    self.assertAllClose(self.evaluate(result), expected, rtol=1e-5, atol=1e-5)
+
+  def testRank3xRank2(self):
+    np.random.seed(42)
+    p = np.random.normal(size=[5, 3, 4]).astype(np.float32)
+    w = np.random.normal(size=[4, 6]).astype(np.float32)
+    expected = np.matmul(p, w)
+    result = math_ops.matmul(p, w)
+    self.assertAllClose(self.evaluate(result), expected, rtol=1e-5, atol=1e-5)
+
+
 class BatchMatmulGradientTest(test.TestCase):
 
   # loss = sum(batch_matmul(x, y)). Verify dl/dx and dl/dy via the


### PR DESCRIPTION
## Summary

Fix heap corruption in OneDNN batch matmul when broadcasting tensors with mismatched ranks (e.g., rank-4 × rank-2).

## Vulnerability (#117700)

`tf.linalg.matmul` with a rank-4 tensor `[13, 1, 3, 4]` and rank-2 tensor `[4, 16]` causes **heap corruption** when OneDNN is enabled:

\\\
corrupted double-linked list
free(): invalid pointer
Segmentation fault (core dumped)
\\\

### Root Cause

When broadcasting rank-2 → rank-4, `ExpandInputDimsToOutputShape` expands `[4, 16]` to `[1, 1, 4, 16]`. Then `CalculateTFStrides` computes strides `[64, 64, 16, 1]`.

But the actual tensor only has **64 elements**. OneDNN uses these strides to access memory at offsets like `batch_idx × 64`, which reads **far beyond the tensor buffer** → heap corruption.

### Reproduction
\\\python
import os
os.environ['TF_ENABLE_ONEDNN_OPTS'] = '1'
import tensorflow as tf
tf.random.set_seed(280958)
p = tf.random.normal([13, 1, 3, 4])
w = tf.random.normal([4, 16])
out = tf.linalg.matmul(p, w)  # CRASH: corrupted double-linked list
\\\

## Fix

Set strides to **0** for prepended broadcast dimensions so OneDNN re-reads the same data for each batch index instead of advancing the pointer past the buffer. This is the standard OneDNN convention for broadcast dimensions.

## File Changed
- `tensorflow/core/kernels/mkl/mkl_batch_matmul_helper.h`

Fixes #117700