### PR TITLE
Fix TFLite sign NaN handling

### DIFF
--- a/tensorflow/lite/kernels/sign.cc
+++ b/tensorflow/lite/kernels/sign.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cmath>
+#include <type_traits>
 
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
@@ -90,6 +91,9 @@ TfLiteStatus PointwiseUnaryOpEval(TfLiteContext* context, TfLiteNode* node) {
 struct Sign {
   template <typename T>
   static T Eval(T x) {
+    if (IsNan(x)) {
+      return x;
+    }
     if (x > 0) {
       return 1;
     }
@@ -97,6 +101,19 @@ struct Sign {
       return -1;
     }
     return 0;
+  }
+
+ private:
+  template <typename T>
+  static typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+  IsNan(T x) {
+    return std::isnan(x);
+  }
+
+  template <typename T>
+  static typename std::enable_if<!std::is_floating_point<T>::value, bool>::type
+  IsNan(T) {
+    return false;
   }
 };
 

--- a/tensorflow/lite/kernels/sign_custom.cc
+++ b/tensorflow/lite/kernels/sign_custom.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cmath>
+#include <type_traits>
 
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/kernels/custom_ops_register.h"
@@ -87,6 +88,9 @@ TfLiteStatus PointwiseUnaryOpEval(TfLiteContext* context, TfLiteNode* node) {
 struct Sign {
   template <typename T>
   static T Eval(T x) {
+    if (IsNan(x)) {
+      return x;
+    }
     if (x > 0) {
       return 1;
     }
@@ -94,6 +98,19 @@ struct Sign {
       return -1;
     }
     return 0;
+  }
+
+ private:
+  template <typename T>
+  static typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+  IsNan(T x) {
+    return std::isnan(x);
+  }
+
+  template <typename T>
+  static typename std::enable_if<!std::is_floating_point<T>::value, bool>::type
+  IsNan(T) {
+    return false;
   }
 };
 

--- a/tensorflow/lite/kernels/sign_custom_test.cc
+++ b/tensorflow/lite/kernels/sign_custom_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cmath>
+#include <limits>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -93,6 +94,22 @@ TYPED_TEST(SignCustomTest, TestBatch) {
 
   EXPECT_EQ(got, std::vector<Float>(
       {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, 0.0}));
+}
+
+TEST(SignCustomTest, TestBatchFloat32PreservesNan) {
+  tflite::TensorData x = {TensorType_FLOAT32, {5}};
+  tflite::TensorData output = {TensorType_FLOAT32, {5}};
+  SignModel m(x, output);
+
+  auto got = m.GetOutput<float>(
+      {std::numeric_limits<float>::quiet_NaN(), 7.0, -0.0, -3.5, 0.0});
+
+  ASSERT_EQ(got.size(), 5);
+  EXPECT_TRUE(std::isnan(got[0]));
+  EXPECT_EQ(got[1], 1.0);
+  EXPECT_EQ(got[2], 0.0);
+  EXPECT_EQ(got[3], -1.0);
+  EXPECT_EQ(got[4], 0.0);
 }
 
 }  // namespace

--- a/tensorflow/lite/kernels/sign_test.cc
+++ b/tensorflow/lite/kernels/sign_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cmath>
+#include <limits>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -96,6 +97,22 @@ TYPED_TEST(SignTestFloat, TestBatchFloat) {
 
   EXPECT_EQ(got, std::vector<Float>(
       {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, 0.0}));
+}
+
+TEST(SignTestFloat, TestBatchFloat32PreservesNan) {
+  tflite::TensorData x = {TensorType_FLOAT32, {5}};
+  tflite::TensorData output = {TensorType_FLOAT32, {5}};
+  SignModel m(x, output);
+
+  auto got = m.GetOutput<float>(
+      {std::numeric_limits<float>::quiet_NaN(), 7.0, -0.0, -3.5, 0.0});
+
+  ASSERT_EQ(got.size(), 5);
+  EXPECT_TRUE(std::isnan(got[0]));
+  EXPECT_EQ(got[1], 1.0);
+  EXPECT_EQ(got[2], 0.0);
+  EXPECT_EQ(got[3], -1.0);
+  EXPECT_EQ(got[4], 0.0);
 }
 
 template <typename Int>


### PR DESCRIPTION
Fixes #120306.

TFLite `SIGN` currently returns `0` for floating-point NaN inputs because the kernel falls through the existing positive/negative/zero comparison path.

This preserves NaN for floating-point inputs before applying the existing sign logic. Non-NaN float behavior and int32 behavior are unchanged.

Added NaN coverage for builtin and custom TFLite Sign tests.

Validation:

* `git diff --check`

Attempted:

* `bazel test //tensorflow/lite/kernels:sign_test --test_output=errors`
* `bazel test //tensorflow/lite/kernels:sign_custom_test --test_output=errors`

Both Bazel targets failed before compilation due local TensorFlow hermetic Python setup, not test failures.
