### PR TITLE
Fix XLA dynamic slice shape for out-of-bounds slices

### DIFF
--- a/tensorflow/compiler/tests/slice_ops_test.py
+++ b/tensorflow/compiler/tests/slice_ops_test.py
@@ -151,6 +151,23 @@ class StridedSliceTest(xla_test.XLATestCase):
 
         self.assertAllEqual([0], result)
 
+  def testDynamicSliceOutOfBounds(self):
+    for dtype in self.numeric_types:
+      with self.session():
+        i = array_ops.placeholder(dtype, shape=[10])
+        begin = array_ops.placeholder(dtypes.int32, shape=[1])
+        end = array_ops.placeholder(dtypes.int32, shape=[1])
+        with self.test_scope():
+          o = array_ops.strided_slice(i, begin, end, [1])
+        params = {
+            i: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            begin: [5],
+            end: [15]
+        }
+        result = o.eval(feed_dict=params)
+
+        self.assertAllEqual([5, 6, 7, 8, 9], result)
+
   def test1DNegativeStride(self):
     for dtype in self.numeric_types:
       with self.session():

--- a/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
@@ -194,6 +194,7 @@ class StridedSliceOp : public XlaOpKernel {
           begin_index = xla::Select(index_negative, wrapped_index, begin_index);
         }
       }
+      begin_index = xla::Clamp(zero, begin_index, dim_size);
       start_indices.push_back(begin_index);
       if (end_mask) {
         end_index = dim_size;
@@ -208,6 +209,7 @@ class StridedSliceOp : public XlaOpKernel {
           end_index = xla::Select(index_negative, wrapped_index, end_index);
         }
       }
+      end_index = xla::Clamp(zero, end_index, dim_size);
       // This is safe to downcast as set dimension size  makes sure that the dim
       // in the input doesn't exceed INT32 max.
       xla::XlaOp size = xla::Max(xla::Sub(end_index, begin_index), zero);


### PR DESCRIPTION
Fixes #118384

XLA computes the dynamic slice size using the raw begin/end indices before computing the dynamic dimension metadata. For out-of-bounds slice limits, this can result in a dynamic size that exceeds the actual runtime slice extent.

In the reported reproducer, the incorrect dynamic shape propagates through `TensorArray.concat()`, causing XLA execution to return a different output shape than non-XLA execution.

This change clamps `begin_index` and `end_index` to the valid range `[0, dim_size]` before computing the dynamic slice size. This aligns the dynamic shape metadata with the actual runtime slice extent and matches TensorFlow slicing behavior.

Added a regression test in `slice_ops_test.py` covering an out-of-bounds dynamic slice (`[5:15]` on a tensor of length `10`) to verify the expected result `[5, 6, 7, 8, 9]`.
