### PR TITLE
fix: add integer overflow guard in TfLiteTensorResizeMaybeCopy to prevent heap buffer underallocation

### DIFF
--- a/tensorflow/lite/core/c/common.cc
+++ b/tensorflow/lite/core/c/common.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #endif  // TF_LITE_STATIC_MEMORY
 
 #include <cstring>
+#include <limits>
 #include <new>
 #include <type_traits>
 #include <utility>
@@ -460,15 +461,23 @@ TfLiteStatus TfLiteTensorCopy(const TfLiteTensor* src, TfLiteTensor* dst) {
 
 TfLiteStatus TfLiteTensorResizeMaybeCopy(size_t num_bytes, TfLiteTensor* tensor,
                                          bool preserve_data) {
+  if (tensor == nullptr) {
+    return kTfLiteError;
+  }
   if (tensor->allocation_type != kTfLiteDynamic &&
       tensor->allocation_type != kTfLitePersistentRo) {
     return kTfLiteOk;
+  }
+  // Guard against integer overflow: num_bytes + XNN_EXTRA_BYTES must not wrap.
+  constexpr size_t kXnnExtraBytes = 16;
+  if (num_bytes > std::numeric_limits<size_t>::max() - kXnnExtraBytes) {
+    return kTfLiteError;
   }
 #ifdef TF_LITE_TENSORFLOW_PROFILER
   tflite::PauseHeapMonitoring(/*pause=*/true);
 #endif
   // This buffer may be consumed by XNNPack.
-  size_t alloc_bytes = num_bytes + /*XNN_EXTRA_BYTES=*/16;
+  size_t alloc_bytes = num_bytes + kXnnExtraBytes;
   // TODO(b/145340303): Tensor data should be aligned.
   if (!tensor->data.data) {
     tensor->data.data = (char*)malloc(alloc_bytes);
@@ -502,6 +511,7 @@ TfLiteStatus TfLiteTensorResizeMaybeCopy(size_t num_bytes, TfLiteTensor* tensor,
   }
   return kTfLiteOk;
 }
+
 
 TfLiteStatus TfLiteTensorRealloc(size_t num_bytes, TfLiteTensor* tensor) {
   return TfLiteTensorResizeMaybeCopy(num_bytes, tensor, true);

--- a/tensorflow/lite/core/c/common_test.cc
+++ b/tensorflow/lite/core/c/common_test.cc
@@ -1081,4 +1081,24 @@ TEST(EnsureOk, WithMessage) {
 
 TEST(TensorFree, NullTensor_DoesNotCrash) { TfLiteTensorFree(nullptr); }
 
+// Regression tests for TfLiteTensorResizeMaybeCopy safety checks (#115068).
+
+TEST(TfLiteTensorResizeMaybeCopyTest, NullTensorReturnsError) {
+  EXPECT_EQ(TfLiteTensorResizeMaybeCopy(16, /*tensor=*/nullptr,
+                                         /*preserve_data=*/false),
+            kTfLiteError);
+}
+
+TEST(TfLiteTensorResizeMaybeCopyTest, IntegerOverflowReturnsError) {
+  TfLiteTensor tensor;
+  memset(&tensor, 0, sizeof(tensor));
+  tensor.allocation_type = kTfLiteDynamic;
+  // num_bytes close to SIZE_MAX — addition of 16 would overflow.
+  size_t huge = std::numeric_limits<size_t>::max() - 7;
+  EXPECT_EQ(TfLiteTensorResizeMaybeCopy(huge, &tensor,
+                                         /*preserve_data=*/false),
+            kTfLiteError);
+  // Clean up (no allocation should have happened).
+}
+
 }  // namespace tflite


### PR DESCRIPTION
## Summary

Add integer overflow guard in `TfLiteTensorResizeMaybeCopy()` before computing `alloc_bytes = num_bytes + 16` (XNN_EXTRA_BYTES) to prevent heap buffer underallocation via `size_t` wraparound.

## Vulnerability ([#115068](https://github.com/tensorflow/tensorflow/issues/115068))

`TfLiteTensorResizeMaybeCopy()` computes `alloc_bytes = num_bytes + 16` without checking for integer overflow. If `num_bytes` is close to `SIZE_MAX`, the addition wraps around and produces a **smaller allocation** than intended, creating a heap buffer that is too small for the tensor data. Subsequent writes to the tensor corrupt heap memory.

### Impact

- **Heap buffer overflow** (CWE-122) via integer overflow (CWE-190)
- Affects TFLite runtime on all platforms
- Exploitable via crafted model files that specify large tensor dimensions

### Reproduction

```cpp
num_bytes = std::numeric_limits<size_t>::max() - 7;
// alloc_bytes wraps to 8 — allocates 8 bytes for a near-SIZE_MAX tensor
```

## Fix

- Add overflow guard: return `kTfLiteError` if `num_bytes > SIZE_MAX - 16`
- Add null pointer check for `tensor` parameter
- Replace magic number `16` with named constant `kXnnExtraBytes`

### File Changed

`tensorflow/lite/core/c/common.cc`

Fixes #115068
