### PR TITLE
[TFLite] Validate MaxUnpooling2D indices before output writes

### DIFF
--- a/tensorflow/lite/kernels/perception/max_unpooling_2d.cc
+++ b/tensorflow/lite/kernels/perception/max_unpooling_2d.cc
@@ -33,14 +33,24 @@ constexpr int kOutputTensor = 0;
 
 // TODO(b/175003241): Move this logic to lite/kernels/internal when promoting
 // this op to a builtin op.
-inline void MaxUnpooling(const RuntimeShape& input_shape,
-                         const float* input_data, const int32_t* indices_data,
-                         const RuntimeShape& output_shape, float* output_data) {
+inline TfLiteStatus MaxUnpooling(TfLiteContext* context,
+                                 const RuntimeShape& input_shape,
+                                 const float* input_data,
+                                 const int32_t* indices_data,
+                                 const RuntimeShape& output_shape,
+                                 float* output_data) {
   std::memset(output_data, 0, output_shape.FlatSize() * sizeof(float));
   const int batches = MatchingDim(input_shape, 0, output_shape, 0);
   const int depth = MatchingDim(input_shape, 3, output_shape, 3);
   const int batch_stride =
       output_shape.Dims(1) * output_shape.Dims(2) * output_shape.Dims(3);
+  const int input_count = input_shape.FlatSize();
+  for (int i = 0; i < input_count; ++i) {
+    const int32_t idx = indices_data[i];
+    TF_LITE_ENSURE_MSG(context, idx >= 0 && idx < batch_stride,
+                       "Invalid MaxUnpooling2D index.");
+  }
+
   for (int batch = 0; batch < batches; ++batch) {
     for (int in_y = 0; in_y < input_shape.Dims(1); ++in_y) {
       for (int in_x = 0; in_x < input_shape.Dims(2); ++in_x) {
@@ -53,6 +63,7 @@ inline void MaxUnpooling(const RuntimeShape& input_shape,
       }
     }
   }
+  return kTfLiteOk;
 }
 
 TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
@@ -115,10 +126,10 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   const TfLiteTensor* indices = GetInput(context, node, kIndicesTensor);
   TF_LITE_ENSURE(context, indices != nullptr);
 
-  MaxUnpooling(GetTensorShape(input), GetTensorData<float>(input),
-               GetTensorData<int32_t>(indices), GetTensorShape(output),
-               GetTensorData<float>(output));
-  return kTfLiteOk;
+  return MaxUnpooling(context, GetTensorShape(input),
+                      GetTensorData<float>(input),
+                      GetTensorData<int32_t>(indices), GetTensorShape(output),
+                      GetTensorData<float>(output));
 }
 
 }  // namespace max_unpooling_2d

--- a/tensorflow/lite/kernels/perception/max_unpooling_2d_test.cc
+++ b/tensorflow/lite/kernels/perception/max_unpooling_2d_test.cc
@@ -96,6 +96,20 @@ TEST(MaxUnpoolingOpTest, SimpleTest) {
   EXPECT_THAT(model.GetOutput(), ElementsAreArray({0, 13, 0, 0, 0, 0, 4, 0}));
 }
 
+TEST(MaxUnpoolingOpTest, InvalidIndexReturnsError) {
+  MaxUnpoolingOpModel model(
+      /*input=*/{TensorType_FLOAT32, {1, 1, 2, 1}},
+      /*indices=*/{TensorType_INT32, {1, 1, 2, 1}},
+      /*stride_height=*/2, /*stride_width=*/2,
+      /*filter_height=*/2, /*filter_width=*/2,
+      /*padding=*/kTfLitePaddingSame,
+      /*output=*/{TensorType_FLOAT32, {}});
+  model.SetInput({13, 4});
+  model.SetIndices({-1, 8});
+
+  EXPECT_NE(model.Invoke(), kTfLiteOk);
+}
+
 TEST(MaxUnpoolingOpTest, Strides2x1Test) {
   constexpr int kInputB = 1;
   constexpr int kInputH = 2;


### PR DESCRIPTION
## Summary

- Validate `MaxUnpooling2D` runtime index values before using them as output offsets.
- Return `kTfLiteError` when an index is negative or outside the current output batch slice.
- Add a regression test covering invalid lower/upper index values.

## Why

`MaxUnpooling2D` currently reads `indices_data[input_offset]` and uses it directly in:

```cc
output_data[batch * batch_stride + idx]
```

Without validating `idx`, invalid runtime indices can target memory outside the intended output batch slice. That creates a potential out-of-bounds write / memory corruption condition. This patch rejects invalid indices before the output write is performed.

## Scope

This is intentionally limited to the index-validation issue. Broader pointer checks, integer-overflow hardening, and other adjacent robustness topics discussed in the superseded PR #120468 are not bundled here and should be handled separately if maintainers want those follow-ups.

## Tests

```text
bazel test //tensorflow/lite/kernels/perception:perception_ops_test --test_filter=MaxUnpoolingOpTest.InvalidIndexReturnsError --test_output=errors
bazel test //tensorflow/lite/kernels/perception:perception_ops_test --test_output=errors
```