### PR TITLE
Fix out-of-bounds write from failed bytes-list skips in fast parsing

### DIFF
--- a/tensorflow/core/util/example_proto_fast_parsing.cc
+++ b/tensorflow/core/util/example_proto_fast_parsing.cc
@@ -1902,7 +1902,9 @@ inline int ParseBytesFeature(protobuf::io::CodedInputStream* stream,
         return -1;
       }
       if (out == nullptr) {
-        stream->Skip(bytes_length);
+        if (!stream->Skip(bytes_length)) {
+          return -1;
+        }
       } else {
         out->resize_uninitialized(bytes_length);
         if (!stream->ReadRaw(out->data(), bytes_length)) {

--- a/tensorflow/core/util/example_proto_fast_parsing_test.cc
+++ b/tensorflow/core/util/example_proto_fast_parsing_test.cc
@@ -598,6 +598,27 @@ TEST(FastParse, DenseFloat_TooFewElements_ReportsError) {
             std::string::npos);
 }
 
+TEST(FastParseSequenceExample, SparseStringMalformedBytesListReportsError) {
+  static constexpr char kMalformed[] = {
+      '\x12', '\x0e', '\x0a', '\x0c', '\x0a', '\x01', '\x73', '\x12',
+      '\x07', '\x0a', '\x05', '\x0a', '\x03', '\x0a', '\x05', '\x41'};
+
+  FastParseExampleConfig context_config;
+  FastParseExampleConfig sequence_config;
+  AddSparseFeature("s", DT_STRING, &sequence_config);
+
+  Result context_result;
+  Result sequence_result;
+  std::vector<Tensor> dense_feature_lengths;
+  std::vector<tstring> serialized = {tstring(kMalformed, sizeof(kMalformed))};
+  absl::Status parse_status =
+      FastParseSequenceExample(context_config, sequence_config, serialized, {},
+                               nullptr, &context_result, &sequence_result,
+                               &dense_feature_lengths);
+
+  EXPECT_TRUE(absl::IsInvalidArgument(parse_status)) << parse_status;
+}
+
 }  // namespace
 }  // namespace example
 }  // namespace tensorflow


### PR DESCRIPTION
This change fixes a memory-safety issue in the fast example parser by making the bytes-list counting path reject failed `CodedInputStream::Skip()` calls.

Today the copy path returns an error when `ReadRaw()` fails, but the count path can continue after a failed `Skip()`. For malformed bytes-list input, that can make the parser record an element count during the count pass and then observe an error during the copy pass. In sparse `SequenceExample` parsing, that count/copy mismatch can lead to sparse-index writes past the allocated tensor buffer.

The fix propagates the failed `Skip()` as an error so malformed input is rejected consistently before sparse-index output construction.

A regression test covers a malformed sparse string `SequenceExample` where a bytes-list value declares more bytes than are present.

Tested:
- `git diff --check`
- Local focused parser test target with the same `Skip()` fix: PASSED
