### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal and input validation in saved_model_cli

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Path Traversal in SavedModel CLI Output
+**Vulnerability:** Path traversal in `saved_model_cli.py`'s `run_saved_model_with_feed_dict` function.
+**Learning:** The tool used output tensor names (keys) directly from the model signature as filenames. Since these keys are under the control of the model creator and not sanitized, a malicious model could cause the tool to write files to arbitrary locations on the filesystem using path traversal sequences like `../../`.
+**Prevention:** Always sanitize or validate filenames derived from external data. Use `os.path.commonpath` with absolute paths to verify that the final path is contained within the intended base directory.

--- a/tensorflow/python/tools/saved_model_cli.py
+++ b/tensorflow/python/tools/saved_model_cli.py
@@ -876,6 +876,13 @@ def run_saved_model_with_feed_dict(
         if not os.path.isdir(outdir):
           os.makedirs(outdir)
         output_full_path = os.path.join(outdir, output_tensor_key + '.npy')
+        if os.path.commonpath(
+            [os.path.abspath(outdir), os.path.abspath(output_full_path)]
+        ) != os.path.abspath(outdir):
+          raise ValueError(
+              f'Output tensor key "{output_tensor_key}" is invalid as it '
+              'results in a path outside of the output directory.'
+          )
 
         # If overwrite not enabled and file already exist, error out
         if not overwrite_flag and os.path.exists(output_full_path):
@@ -958,7 +965,7 @@ def preprocess_input_exprs_arg_string(input_exprs_str, safe=True):
   input_dict = {}
 
   for input_raw in filter(bool, input_exprs_str.split(';')):
-    if '=' not in input_exprs_str:
+    if '=' not in input_raw:
       raise RuntimeError(
           '--input_exprs "%s" format is incorrect. Please follow'
           '"<input_key>=<python expression>"' % input_exprs_str


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path Traversal and Input Validation Bug
🎯 Impact: A malicious model could cause `saved_model_cli` to write files outside the intended output directory using crafted tensor names. Malformed input expressions were also not correctly flagged.
🔧 Fix:
- Added a check using `os.path.commonpath` to ensure output files are written within the specified directory.
- Corrected the format check in `preprocess_input_exprs_arg_string` to inspect individual input segments.
✅ Verification: Verified using a standalone script that replicates the logic and confirms traversal is blocked and malformed input is caught.

---
*PR created automatically by Jules for task [1701739941690358930](https://jules.google.com/task/1701739941690358930) started by @bharatjetti*