### PR TITLE
Fix XLA resize bilinear NaN over-propagation in forward and backward …

### DIFF
--- a/tensorflow/compiler/tests/image_ops_test.py
+++ b/tensorflow/compiler/tests/image_ops_test.py
@@ -732,6 +732,25 @@ class ResizeBilinearTest(parameterized.TestCase, xla_test.XLATestCase):
         expected=np.array(result, dtype=np.float32),
         large_tolerance=True)
 
+  def testNaNPropagation(self):
+    # Test that a single NaN value in a bilinear resize only propagates to
+    # the local 2x2 interpolation neighborhood, and not the entire output.
+    # This regression test is for Issue #120240.
+    for dtype in self.float_types:
+      data = np.arange(1, 28, dtype=dtype).reshape(1, 3, 3, 3)
+      data[0, 1, 2, 0] = np.nan
+
+      with self.session() as sess:
+        x_tf = array_ops.placeholder(dtype, shape=data.shape)
+        with self.test_scope():
+          resized = gen_image_ops.resize_bilinear(x_tf, (5, 5))
+        out = sess.run(resized, feed_dict={x_tf: data})
+
+      # The NaN count in channel 0 should be exactly 6 (local neighborhood).
+      # If the bug is present, it will be 25 (entire channel).
+      nan_count = np.isnan(out[0, :, :, 0]).sum()
+      self.assertEqual(nan_count, 6)
+
 
 class ResizeBilinearGradTest(parameterized.TestCase, xla_test.XLATestCase):
 
@@ -813,6 +832,28 @@ class ResizeBilinearGradTest(parameterized.TestCase, xla_test.XLATestCase):
         np.array(input_data, dtype=np.float32), [src_y, src_x],
         expected=np.array(result, dtype=np.float32),
         large_tolerance=True)
+
+  def testNaNPropagation(self):
+    # Test that a single NaN value in the incoming gradient for bilinear resize
+    # only propagates to the local interpolation neighborhood in the input gradient.
+    # This regression test is for Issue #120240.
+    for dtype in self.float_types:
+      # Gradients shape: [batch, out_height, out_width, channels] -> [1, 5, 5, 1]
+      grads_np = np.ones([1, 5, 5, 1], dtype=dtype)
+      grads_np[0, 2, 2, 0] = np.nan
+
+      with self.session() as sess:
+        grads_tf = array_ops.placeholder(dtype, shape=grads_np.shape)
+        with self.test_scope():
+          dummy_image = array_ops.zeros([1, 3, 3, 1], dtype=dtype)
+          input_grads = gen_image_ops.resize_bilinear_grad(
+              grads_tf, dummy_image, align_corners=True)
+        out = sess.run(input_grads, feed_dict={grads_tf: grads_np})
+
+      # The NaN count in the input gradients [1, 3, 3, 1] should be exactly 1.
+      # If the bug is present, it will be 9 (entire image).
+      nan_count = np.isnan(out[0, :, :, 0]).sum()
+      self.assertEqual(nan_count, 1)
 
 
 class ResizeBilinearNonAlignCornersTest(xla_test.XLATestCase):

--- a/tensorflow/compiler/tf2xla/kernels/image_resize_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/image_resize_ops.cc
@@ -555,6 +555,19 @@ void GeneralCompile(XlaOpKernelContext* ctx, bool align_corners,
   dot_dnum.add_lhs_batch_dimensions(0);
   dot_dnum.add_rhs_batch_dimensions(4);
   dot_dnum.add_rhs_batch_dimensions(5);
+  if (is_kernel_bilinear) {
+    xla::Shape input_xla_shape = ctx->builder()->GetShape(input).value();
+    xla::XlaOp broadcasted_weights = xla::BroadcastInDim(
+        dot_weights, input_xla_shape.dimensions(), {5, 2, 4, 1});
+    xla::XlaOp zero_weight =
+        xla::ConvertElementType(xla::ConstantR0(ctx->builder(), 0.0f), input_type);
+    xla::XlaOp weight_is_zero = xla::Eq(broadcasted_weights, zero_weight);
+    xla::XlaOp zero_input = xla::ConvertElementType(
+        xla::Broadcast(xla::ConstantR0(ctx->builder(), 0.0f),
+                       input_xla_shape.dimensions()),
+        input_type);
+    input = xla::Select(weight_is_zero, zero_input, input);
+  }
   input = xla::DotGeneral(dot_weights, input, dot_dnum);
 
   absl::InlinedVector<int64_t, 4> perm = {2, 0, 1, 3};
@@ -599,29 +612,46 @@ void GeneralCompileGrad(XlaOpKernelContext* ctx, bool align_corners,
   //   {batch, out_size[0], out_size[1], channel}
   // After this step `grad` has dimensions
   //   {out_size[0], out_size[1], kernel_width, kernel_height, batch, channel}
-  xla::DotDimensionNumbers dot_dnum;
-  dot_dnum.add_lhs_batch_dimensions(2);
-  dot_dnum.add_lhs_batch_dimensions(0);
-  dot_dnum.add_rhs_batch_dimensions(1);
-  dot_dnum.add_rhs_batch_dimensions(2);
-  grad = xla::DotGeneral(dot_weights, grad, dot_dnum);
-  int dot_out_size_height_index = 0;
-  int dot_out_size_width_index = 1;
-  int dot_kernel_width_index = 2;
-  int dot_kernel_height_index = 3;
-  int dot_batch_index = 4;
-  int dot_channel_index = 5;
+  if (is_kernel_bilinear) {
+    std::vector<int64_t> target_dimensions = {batch, h_span_size, w_span_size,
+                                              channels, out_size[0], out_size[1]};
+    xla::XlaOp broadcasted_weights = xla::BroadcastInDim(
+        dot_weights, target_dimensions, {5, 2, 4, 1});
+    xla::XlaOp broadcasted_grad = xla::BroadcastInDim(
+        grad, target_dimensions, {0, 4, 5, 3});
 
-  // Transpose DotGeneral result's dimensions to be the same order as the
-  // forward direction's input to DotGeneral. This is needed because the
-  // backward's Scatter's input has the same order as the forward's Gather
-  // output.
-  // After this step `grad` has dimensions
-  //   {batch, kernel_height, kernel_width, channel, out_size[0], out_size[1]}
-  absl::InlinedVector<int64_t, 4> perm = {
-      dot_batch_index,   dot_kernel_height_index,   dot_kernel_width_index,
-      dot_channel_index, dot_out_size_height_index, dot_out_size_width_index};
-  grad = xla::Transpose(grad, perm);
+    xla::XlaOp zero_weight = xla::ConstantR0(b, 0.0f);
+    xla::XlaOp weight_is_zero = xla::Eq(
+        broadcasted_weights, xla::ConvertElementType(zero_weight, grad_type));
+    xla::XlaOp zero_grad = xla::Broadcast(xla::ConstantR0(b, 0.0f), target_dimensions);
+    xla::XlaOp multiplied = xla::Mul(broadcasted_weights, broadcasted_grad);
+    grad = xla::Select(
+        weight_is_zero, xla::ConvertElementType(zero_grad, grad_type), multiplied);
+  } else {
+    xla::DotDimensionNumbers dot_dnum;
+    dot_dnum.add_lhs_batch_dimensions(2);
+    dot_dnum.add_lhs_batch_dimensions(0);
+    dot_dnum.add_rhs_batch_dimensions(1);
+    dot_dnum.add_rhs_batch_dimensions(2);
+    grad = xla::DotGeneral(dot_weights, grad, dot_dnum);
+    int dot_out_size_height_index = 0;
+    int dot_out_size_width_index = 1;
+    int dot_kernel_width_index = 2;
+    int dot_kernel_height_index = 3;
+    int dot_batch_index = 4;
+    int dot_channel_index = 5;
+
+    // Transpose DotGeneral result's dimensions to be the same order as the
+    // forward direction's input to DotGeneral. This is needed because the
+    // backward's Scatter's input has the same order as the forward's Gather
+    // output.
+    // After this step `grad` has dimensions
+    //   {batch, kernel_height, kernel_width, channel, out_size[0], out_size[1]}
+    absl::InlinedVector<int64_t, 4> perm = {
+        dot_batch_index,   dot_kernel_height_index,   dot_kernel_width_index,
+        dot_channel_index, dot_out_size_height_index, dot_out_size_width_index};
+    grad = xla::Transpose(grad, perm);
+  }
 
   // A Scatter reverses the forward op's Gather. Gather can be thought of as a
   // matrix-vector multiply where each row has one 1 and the rest 0. The


### PR DESCRIPTION
## Status
This is a work-in-progress fix for the NaN propagation issue reported in #118382.

### Current progress:
- [x] Reproducer confirmed.
- [x] Candidate fix implemented.
- [x] Regression tests drafted for forward and backward bilinear resize paths.

### Remaining work:
- [ ] Run full TensorFlow/XLA validation and verify the new tests pass.
- [ ] Confirm there are no regressions in existing image resize tests.

_Opening as a draft for early feedback on the proposed approach._