### PR TITLE
Fix Dataset.save in debug mode without shard function

### DIFF
--- a/tensorflow/python/data/kernel_tests/BUILD
+++ b/tensorflow/python/data/kernel_tests/BUILD
@@ -1408,6 +1408,7 @@ py_test(
     deps = [
         ":checkpoint_test_base",
         ":test_base",
+        "//tensorflow/python/data/ops:debug_mode",
         "//tensorflow/python/data/ops:dataset_ops",
         "//tensorflow/python/eager:def_function",
         "//tensorflow/python/framework:combinations",

--- a/tensorflow/python/data/kernel_tests/io_test.py
+++ b/tensorflow/python/data/kernel_tests/io_test.py
@@ -23,6 +23,7 @@ from absl.testing import parameterized
 import numpy as np
 from tensorflow.python.data.kernel_tests import checkpoint_test_base
 from tensorflow.python.data.kernel_tests import test_base
+from tensorflow.python.data.ops import debug_mode
 from tensorflow.python.data.ops import dataset_ops
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import combinations
@@ -69,6 +70,15 @@ class IOTest(test_base.DatasetTestBase, parameterized.TestCase):
     self.evaluate(dataset.save(self._test_dir))
     dataset2 = dataset_ops.Dataset.load(self._test_dir, dataset.element_spec)
     self.assertEqual(self.evaluate(dataset2.cardinality()), 42)
+
+  @combinations.generate(test_base.eager_only_combinations())
+  def testSaveInDebugModeWithoutShardFunction(self):
+    debug_mode.toggle_debug_mode(True)
+    self.addCleanup(debug_mode.toggle_debug_mode, False)
+    dataset = dataset_ops.Dataset.range(42)
+    self.evaluate(dataset.save(self._test_dir))
+    dataset2 = dataset_ops.Dataset.load(self._test_dir, dataset.element_spec)
+    self.assertDatasetProduces(dataset2, range(42))
 
   @combinations.generate(test_base.default_test_combinations())
   def testCustomShardFunction(self):

--- a/tensorflow/python/data/ops/save_op.py
+++ b/tensorflow/python/data/ops/save_op.py
@@ -97,7 +97,7 @@ def set_save_dataset_attributes(dataset, shard_func, path):
   """Sets parameters for SaveDatasetOp and SaveDatasetV2Op."""
   if shard_func is None:
     use_shard_func = False
-    shard_func = lambda *x: None  # a dummy function that will not be used
+    shard_func = lambda *x: 0  # a dummy function that will not be used
   else:
     use_shard_func = True
   wrapped_func = structured_function.StructuredFunctionWrapper(


### PR DESCRIPTION
Fixes #60861.

This updates the dummy `shard_func` used by `Dataset.save()` when callers do not provide a shard function. The function is still traced by `StructuredFunctionWrapper`, and under tf.data debug mode the previous `None` return can be wrapped through `tf.py_function` as an operation rather than a tensor-compatible return value. Returning shard id `0` keeps the function traceable while preserving `use_shard_func=False`, so the save op still ignores the dummy function.

A regression test covers saving and loading a dataset with debug mode enabled and no custom shard function.

Verification:
- `python3 -m py_compile tensorflow/python/data/ops/save_op.py tensorflow/python/data/kernel_tests/io_test.py`
- `python3` AST parse for the touched Python files
- `git diff --check`

Note: I could not run the focused Bazel test locally because this environment does not have `bazel` or `bazelisk` installed.
