### PR TITLE
[XLA] Fix tf.image.extract_patches zero kernel size crash

### DIFF
--- a/tensorflow/compiler/tests/extract_image_patches_op_test.py
+++ b/tensorflow/compiler/tests/extract_image_patches_op_test.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors_impl
 from tensorflow.python.ops import array_ops
 from tensorflow.python.platform import test
 
@@ -139,6 +140,22 @@ class ExtractImagePatches(xla_test.XLATestCase):
         rates=[1, 1],
         padding="VALID",
         patches=patches)
+
+  def testInvalidKernelSize(self):
+    """Test that zero kernel size raises an error in XLA mode."""
+    with self.session():
+      image_placeholder = array_ops.placeholder(dtypes.float32)
+      with self.test_scope():
+        out_tensor = array_ops.extract_image_patches(
+            image_placeholder,
+            ksizes=[1, 0, 2, 1],
+            strides=[1, 1, 1, 1],
+            rates=[1, 1, 1, 1],
+            padding="VALID")
+      feed_dict = {image_placeholder: np.zeros([1, 4, 4, 1])}
+      with self.assertRaisesRegex(errors_impl.OutOfRangeError,
+                                 "Kernel size values must be positive"):
+        out_tensor.eval(feed_dict=feed_dict)
 
 
 if __name__ == "__main__":

--- a/tensorflow/compiler/tf2xla/kernels/extract_image_patches_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/extract_image_patches_op.cc
@@ -84,10 +84,10 @@ class ExtractImagePatchesOp : public XlaOpKernel {
     for (int i = 0; i < num_spatial_dims; ++i) {
       int input_dim = GetTensorSpatialDimIndex(num_dims, data_format, i);
       OP_REQUIRES(
-          ctx, ksizes_[input_dim] >= 0,
-          absl::UnimplementedError(absl::StrCat(
-              "Kernel size values must be non-negative; ", i,
-              "th spatial dimension had dilation ", dilations_[input_dim])));
+          ctx, ksizes_[input_dim] >= 1,
+          absl::OutOfRangeError(absl::StrCat(
+              "Kernel size values must be positive; ", i,
+              "th spatial dimension had kernel size ", ksizes_[input_dim])));
       OP_REQUIRES(
           ctx, strides_[input_dim] >= 1,
           absl::UnimplementedError(absl::StrCat(


### PR DESCRIPTION
tf.image.extract_patches rejects an invalid zero patch size in eager mode
with a catchable OutOfRangeError. However, when compiled with
tf.function(jit_compile=True), the process aborts with return code -11
(SIGSEGV) instead of raising an exception.

The XLA lowering in extract_image_patches_op.cc validated kernel sizes as
>= 0 instead of >= 1, allowing zero values. This caused kernel_size=0 which
created an invalid XLA shape, resulting in a crash.

This change validates kernel sizes >= 1 in the XLA lowering, changes the
error type to OutOfRangeError matching eager behavior, and adds a
regression test.

Fixes #120011