### PR TITLE
Include dtypes in TextFileInitializer shared_name

### DIFF
--- a/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py
@@ -888,6 +888,81 @@ class InitializeTableFromFileOpTest(BaseLookupTableTest):
       self.assertAllEqual([0, 1, -1], out2)
       self.assertAllEqual([0, 1, -1], out3)
 
+  def testInitializeSameFileWithDifferentDtypes(self, is_anonymous):
+    if is_anonymous and not tf2.enabled():
+      self.skipTest(SKIP_ANONYMOUS_IN_TF1_REASON)
+    vocabulary_file = self._createVocabFile(
+        "one_column_dtypes.txt", ("1", "2", "3"))
+
+    with self.cached_session():
+      default_value = -1
+      init1 = lookup_ops.TextFileInitializer(
+          vocabulary_file, dtypes.string, lookup_ops.TextFileIndex.WHOLE_LINE,
+          dtypes.int64, lookup_ops.TextFileIndex.LINE_NUMBER)
+      self.assertIn("one_column_dtypes.txt_-2_-1_string_int64",
+                    init1._shared_name)
+      table1 = self.getHashTable()(
+          init1, default_value, experimental_is_anonymous=is_anonymous)
+      init2 = lookup_ops.TextFileInitializer(
+          vocabulary_file, dtypes.int64, lookup_ops.TextFileIndex.WHOLE_LINE,
+          dtypes.int64, lookup_ops.TextFileIndex.LINE_NUMBER)
+      self.assertIn("one_column_dtypes.txt_-2_-1_int64_int64",
+                    init2._shared_name)
+      self.assertNotEqual(init1._shared_name, init2._shared_name)
+      table2 = self.getHashTable()(
+          init2, default_value, experimental_is_anonymous=is_anonymous)
+
+      self.evaluate(lookup_ops.tables_initializer())
+
+      output1 = table1.lookup(
+          constant_op.constant(["1", "2", "4"], dtype=dtypes.string))
+      output2 = table2.lookup(
+          constant_op.constant([1, 2, 4], dtype=dtypes.int64))
+
+      out1, out2 = self.evaluate([output1, output2])
+      self.assertAllEqual([0, 1, -1], out1)
+      self.assertAllEqual([0, 1, -1], out2)
+
+  def testTextFileInitializerSharedNameCombinations(self, is_anonymous):
+    del is_anonymous
+    filename = "test_vocab.txt"
+    key_dtype = dtypes.string
+    key_index = lookup_ops.TextFileIndex.WHOLE_LINE
+    value_dtype = dtypes.int64
+    value_index = lookup_ops.TextFileIndex.LINE_NUMBER
+
+    for vocab_size in (None, 10):
+      for offset in (0, 5):
+        init = lookup_ops.TextFileInitializer(
+            filename,
+            key_dtype,
+            key_index,
+            value_dtype,
+            value_index,
+            vocab_size=vocab_size,
+            value_index_offset=offset)
+
+        if vocab_size:
+          if offset:
+            expected = "hash_table_%s_%d_%s_%s_%s_%s_%s" % (
+                filename, vocab_size, key_index, value_index, offset,
+                key_dtype.name, value_dtype.name)
+          else:
+            expected = "hash_table_%s_%d_%s_%s_%s_%s" % (
+                filename, vocab_size, key_index, value_index, key_dtype.name,
+                value_dtype.name)
+        else:
+          if offset:
+            expected = "hash_table_%s_%s_%s_%s_%s_%s" % (
+                filename, key_index, value_index, offset, key_dtype.name,
+                value_dtype.name)
+          else:
+            expected = "hash_table_%s_%s_%s_%s_%s" % (
+                filename, key_index, value_index, key_dtype.name,
+                value_dtype.name)
+
+        self.assertEqual(expected, init._shared_name)
+
   def testInitializeTableWithNoFilename(self, is_anonymous):
     with self.cached_session():
       default_value = -1

--- a/tensorflow/python/ops/lookup_ops.py
+++ b/tensorflow/python/ops/lookup_ops.py
@@ -788,29 +788,14 @@ class TextFileInitializer(TableInitializerBase):
 
   @property
   def _shared_name(self):
+    shared_name_parts = ["hash_table", str(self._filename_arg)]
     if self._vocab_size:
-      # Keep the shared_name:
-      # <table_type>_<filename>_<vocab_size>_<key_index>_<value_index>_<offset>
-      if self._offset:
-        shared_name = "hash_table_%s_%d_%s_%s_%s" % (
-            self._filename_arg, self._vocab_size, self._key_index,
-            self._value_index, self._offset)
-      else:
-        shared_name = "hash_table_%s_%d_%s_%s" % (
-            self._filename_arg, self._vocab_size, self._key_index,
-            self._value_index)
-    else:
-      # Keep the shared_name
-      # <table_type>_<filename>_<key_index>_<value_index>_<offset>
-      if self._offset:
-        shared_name = "hash_table_%s_%s_%s_%s" % (
-            self._filename_arg, self._key_index, self._value_index,
-            self._offset)
-      else:
-        shared_name = "hash_table_%s_%s_%s" % (
-            self._filename_arg, self._key_index, self._value_index)
-
-    return shared_name
+      shared_name_parts.append(str(self._vocab_size))
+    shared_name_parts.extend([str(self._key_index), str(self._value_index)])
+    if self._offset:
+      shared_name_parts.append(str(self._offset))
+    shared_name_parts.extend([self.key_dtype.name, self.value_dtype.name])
+    return "_".join(shared_name_parts)
 
 
 class TextFileStringTableInitializer(TextFileInitializer):


### PR DESCRIPTION
The `_shared_name` for `TextFileInitializer` only incorporated the filename, vocab size, key/value indices, and offset, so two initializers built from the same vocabulary file but with different key or value dtypes ended up sharing a single resource. That collision caused `hash_table_v2` to fail with a conflicting key/value dtypes error. This change appends `key_dtype` and `value_dtype` to the generated shared name so that initializers with distinct dtypes produce distinct resources.

Resolves #62631

Changes:
- Extend the `TextFileInitializer._shared_name` formatting in `tensorflow/python/ops/lookup_ops.py` to include `self.key_dtype.name` and `self.value_dtype.name` across all four shared_name branches (with/without vocab size, with/without offset).
- Update the inline comments documenting the shared_name format to reflect the new fields.
- Add a new parameterized test `testInitializeSameFileWithDifferentDtypes` in `tensorflow/python/kernel_tests/data_structures/lookup_ops_test.py` that constructs two `TextFileInitializer` instances against the same vocab file with different key dtypes, asserts their `_shared_name` values differ and contain the dtype names, and verifies lookups on both tables return the expected results without collision.