### PR TITLE
[Fix] TFLite ParseExample crashes for empty serialized batch with sparse outputs

### DIFF
--- a/tensorflow/lite/CMakeLists.txt
+++ b/tensorflow/lite/CMakeLists.txt
@@ -852,6 +852,9 @@ add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark/proto)
 # Add the tf example directory.
 add_subdirectory(${TF_SOURCE_DIR}/core/example ${CMAKE_BINARY_DIR}/example_proto_generated)
 
+# Compile database coverage for the custom ParseExample op.
+add_subdirectory(${TFLITE_SOURCE_DIR}/kernels/parse_example)
+
 # The benchmark tool.
 add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark)
 

--- a/tensorflow/lite/kernels/parse_example/CMakeLists.txt
+++ b/tensorflow/lite/kernels/parse_example/CMakeLists.txt
@@ -1,0 +1,17 @@
+# ParseExample compile database coverage for CMake builds.
+
+add_library(tflite_parse_example_compiledb OBJECT EXCLUDE_FROM_ALL
+  example_proto_fast_parsing.cc
+  parse_example.cc
+  parse_example_test.cc
+)
+
+target_link_libraries(tflite_parse_example_compiledb
+  PRIVATE
+    example_proto
+    tensorflow-lite
+)
+
+if(TARGET gmock)
+  target_link_libraries(tflite_parse_example_compiledb PRIVATE gmock)
+endif()

--- a/tensorflow/lite/kernels/parse_example/parse_example.cc
+++ b/tensorflow/lite/kernels/parse_example/parse_example.cc
@@ -404,6 +404,7 @@ absl::Status FastParseSerializedExample(
 void CountSparseFeatures(const SparseBuffer& sparse_buffer,
                          size_t* total_num_features, size_t* max_num_features) {
   const std::vector<size_t>& end_indices = sparse_buffer.example_end_indices;
+  if (end_indices.empty()) return;
   *total_num_features += end_indices.back();
   *max_num_features = std::max(*max_num_features, end_indices[0]);
   for (size_t i = 1; i < end_indices.size(); ++i) {

--- a/tensorflow/lite/kernels/parse_example/parse_example_test.cc
+++ b/tensorflow/lite/kernels/parse_example/parse_example_test.cc
@@ -347,6 +347,18 @@ TEST(ParseExampleOpsTest, SparseTest) {
               ElementsAreArray(ArrayFloatNear({1, 1})));
 }
 
+TEST(ParseExampleOpsTest, SparseEmptyBatchDoesNotCrash) {
+  ParseExampleOpModel<float> m({}, {"time"}, {}, {}, {},
+                               {TensorType_FLOAT32}, kNodeDefTxt2, 0);
+
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(m.GetSparseIndicesOutput<int64_t>(0), testing::IsEmpty());
+  EXPECT_THAT(m.GetSparseValuesOutput<float>(0), testing::IsEmpty());
+  EXPECT_THAT(m.GetSparseShapesOutput<int64_t>(0),
+              testing::ElementsAreArray({0, 0}));
+}
+
 TEST(ParseExampleOpsTest, SimpleBytesTest) {
   tf::Example example;
   const std::string test_data = "simpletest";


### PR DESCRIPTION
Fixes: #121166 
Changed parse_example.cc (line 407) so `CountSparseFeatures()` returns early when `example_end_indices` is empty, avoiding the invalid back() / [0] access. Also added a regression test for the same.
It was a security issue fix.