### PR TITLE
Clarify the variable-creation error for layer/model call() and embedding_lookup

### DIFF
--- a/tensorflow/python/eager/polymorphic_function/polymorphic_function.py
+++ b/tensorflow/python/eager/polymorphic_function/polymorphic_function.py
@@ -702,7 +702,9 @@ class Function(core.PolymorphicFunction, trackable.Trackable):
       raise ValueError(
           "tf.function only supports singleton tf.Variables created on the "
           "first call. Make sure the tf.Variable is only created once or "
-          "created outside tf.function. See "
+          "created outside tf.function. This also applies when creating "
+          "tf.Variables in a layer or model call(), including tf.Variables "
+          "passed to ops such as tf.nn.embedding_lookup. See "
           "https://www.tensorflow.org/guide/function#creating_tfvariables "
           "for more information.")
 

--- a/tensorflow/python/eager/polymorphic_function/polymorphic_function_xla_jit_test.py
+++ b/tensorflow/python/eager/polymorphic_function/polymorphic_function_xla_jit_test.py
@@ -31,6 +31,7 @@ from tensorflow.python.ops import collective_ops
 from tensorflow.python.ops import cond
 from tensorflow.python.ops import control_flow_assert
 from tensorflow.python.ops import control_flow_util
+from tensorflow.python.ops import embedding_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import random_ops
 from tensorflow.python.ops import resource_variable_ops
@@ -775,6 +776,18 @@ class FunctionTest(xla_test.XLATestCase):
 
       outer()
       self.assertAllClose(c.v, 3.52)
+
+  def testEmbeddingLookupWithVariableCreationInFunctionRaises(self):
+    with ops.device('device:{}:0'.format(self.device)):
+
+      @polymorphic_function.function(jit_compile=True)
+      def lookup(ids):
+        return embedding_ops.embedding_lookup(
+            variables.Variable([[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]]), ids)
+
+      with self.assertRaisesRegex(
+          ValueError, 'tf.function only supports singleton.*embedding_lookup'):
+        lookup(constant_op.constant([0, 1], dtype=dtypes.int32))
 
   def testUpdateVariableMultipleOutputs(self):
     with ops.device('device:{}:0'.format(self.device)):


### PR DESCRIPTION
When `tf.Variable` instances are created inside a `tf.function` (including inside a Keras layer or model `call()`) and passed to ops such as `tf.nn.embedding_lookup`, XLA compilation fails with a `ValueError` that does not mention embedding lookup as a common trigger. This change expands the error message in `polymorphic_function.py` to call out that the same restriction applies to variables created in a layer/model `call()` and to variables passed to `tf.nn.embedding_lookup`.

A regression test in `polymorphic_function_xla_jit_test.py` asserts that the new error message is emitted when an embedding lookup is performed with a freshly created `tf.Variable` inside a `jit_compile=True` function.

Resolves #105644

Changes:
- Updated the singleton `tf.Variable` error message in `tensorflow/python/eager/polymorphic_function/polymorphic_function.py` to mention layer/model `call()` and `tf.nn.embedding_lookup` as common cases.
- Added `testEmbeddingLookupWithVariableCreationInFunctionRaises` to `polymorphic_function_xla_jit_test.py` covering the embedding lookup scenario under XLA.