### PR TITLE
Support __index__ on SymbolicTensor for static shape dimensions

### DIFF
--- a/tensorflow/python/framework/ops.py
+++ b/tensorflow/python/framework/ops.py
@@ -273,6 +273,55 @@ class SymbolicTensor(pywrap_tf_session.PyTensor, tensor_lib.Tensor):
     result.__dict__.update(self.__dict__)
     return result
 
+  def __index__(self) -> int:
+    constant_value = tensor_util.constant_value(self)
+    if constant_value is not None:
+      try:
+        return constant_value.__index__()
+      except (AttributeError, TypeError):
+        if isinstance(constant_value, np.ndarray) and constant_value.shape == ():
+          try:
+            return constant_value.item().__index__()
+          except (AttributeError, TypeError, ValueError):
+            pass
+
+    if self.op.type == "StridedSlice":
+      try:
+        begin = tensor_util.constant_value(self.op.inputs[1])
+        end = tensor_util.constant_value(self.op.inputs[2])
+        strides = tensor_util.constant_value(self.op.inputs[3])
+        if begin is not None and end is not None and strides is not None:
+          begin = begin[0]
+          end = end[0]
+          strides = strides[0]
+          input_shape = tensor_util.constant_value_as_shape(self.op.inputs[0])
+          begin_mask = self.op.get_attr("begin_mask")
+          end_mask = self.op.get_attr("end_mask")
+          ellipsis_mask = self.op.get_attr("ellipsis_mask")
+          new_axis_mask = self.op.get_attr("new_axis_mask")
+          shrink_axis_mask = self.op.get_attr("shrink_axis_mask")
+          valid_attributes = (
+              not ellipsis_mask and not new_axis_mask and
+              shrink_axis_mask == 1 and not begin_mask and not end_mask)
+          if valid_attributes and strides == 1 and end == begin + 1:
+            if begin >= 0:
+              axis = int(begin)
+            else:
+              rank = input_shape.rank
+              if rank is None or begin + rank < 0:
+                raise IndexError
+              axis = (int(begin) + rank) % rank
+            dimension = input_shape[axis]
+            dimension_value = getattr(dimension, "value", dimension)
+            if dimension_value is not None:
+              return dimension_value.__index__()
+      except (AttributeError, TypeError, ValueError, IndexError):
+        pass
+
+    raise TypeError(
+        f"'{type(self).__name__}' object cannot be interpreted as an integer"
+    )
+
 
 def _create_graph_constant(
     value, dtype, shape, name, verify_shape, allow_broadcast

--- a/tensorflow/python/framework/ops_test.py
+++ b/tensorflow/python/framework/ops_test.py
@@ -46,6 +46,7 @@ from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import tensor as tensor_lib
 from tensorflow.python.framework import tensor_conversion_registry
+from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import tensor_util
 from tensorflow.python.framework import test_ops
@@ -3748,6 +3749,47 @@ class TensorTest(test_util.TensorFlowTestCase):
     with self.assertRaisesRegex(NotImplementedError,
                                 "Cannot convert a symbolic tf.Tensor"):
       g()
+
+  def testSymbolicTensorIndexStaticShapeDimension(self):
+
+    @def_function.function(autograph=False)
+    def f(x):
+      features = array_ops.shape(x)[1]
+      total = 0
+      for i in range(features):
+        total += i
+      return constant_op.constant(total)
+
+    x = array_ops.zeros([4, 10])
+    self.assertEqual(self.evaluate(f(x)), 45)
+
+  def testSymbolicTensorIndexDynamicShapeDimension(self):
+
+    @def_function.function(autograph=False)
+    def f(x):
+      features = array_ops.shape(x)[1]
+      total = 0
+      for i in range(features):
+        total += i
+      return constant_op.constant(total)
+
+    with self.assertRaisesRegex(TypeError,
+                                "cannot be interpreted as an integer"):
+      f.get_concrete_function(
+          tensor_spec.TensorSpec([4, None], dtype=dtypes.float32))
+
+  def testSymbolicTensorIndexNegativeStaticShapeDimension(self):
+
+    @def_function.function(autograph=False)
+    def f(x):
+      features = array_ops.shape(x)[-1]
+      total = 0
+      for i in range(features):
+        total += i
+      return constant_op.constant(total)
+
+    x = array_ops.zeros([4, 10])
+    self.assertEqual(self.evaluate(f(x)), 45)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When a model is traced with XLA, iterating over a symbolic dimension derived from a known static shape (e.g. `range(tf.shape(x)[1])`) raises `TypeError: 'SymbolicTensor' object cannot be interpreted as an integer`, even though the dimension is statically known. The loop unroller used during tracing calls `__index__` on the loop bound, and SymbolicTensor did not implement that protocol.

This change adds a `__index__` method on `SymbolicTensor` in `tensorflow/python/framework/ops.py`. It first tries to obtain a constant value, falling back to a special case for `StridedSlice` ops with `shrink_axis_mask` and a unit step (the pattern produced by `tf.shape(x)[k]`), which extracts the corresponding dimension from the input's statically known shape. If the dimension is not statically resolvable, a `TypeError` is raised as before. Two regression tests are added to `ops_test.py` covering the static and dynamic shape cases.

Resolves #105642.

Changes:
- Implement `SymbolicTensor.__index__` that resolves constant values and the `StridedSlice` dimension pattern.
- Add tests in `ops_test.py` verifying `range` over a static shape dimension works, and over a dynamic shape dimension still raises a clear `TypeError`.