### PR TITLE
Handle symbolic tensor args with static values in autograph range_

### DIFF
--- a/tensorflow/python/autograph/operators/py_builtins.py
+++ b/tensorflow/python/autograph/operators/py_builtins.py
@@ -18,6 +18,9 @@ List of built-in functions: https://docs.python.org/3/library/functions.html
 """
 
 import inspect
+import operator
+
+import numpy as np
 
 from tensorflow.python.autograph.utils import tensors
 from tensorflow.python.autograph.utils import type_registry
@@ -373,8 +376,39 @@ def _py_max(*args, **kwargs):
 
 def range_(start_or_stop, stop=UNSPECIFIED, step=UNSPECIFIED):
   if any(tensor_util.is_tf_type(s) for s in (start_or_stop, stop, step)):
+    if any(_tf_range_arg_needs_py_value(s)
+           for s in (start_or_stop, stop, step)):
+      start_or_stop_ = _tf_type_to_py_index(start_or_stop)
+      stop_ = _tf_type_to_py_index(stop)
+      step_ = _tf_type_to_py_index(step)
+    else:
+      start_or_stop_ = stop_ = step_ = None
+    if start_or_stop_ is not None and stop_ is not None and step_ is not None:
+      return _py_range(start_or_stop_, stop_, step_)
     return _tf_range(start_or_stop, stop, step)
   return _py_range(start_or_stop, stop, step)
+
+
+def _tf_range_arg_needs_py_value(s):
+  return (isinstance(s, ops.SymbolicTensor) and
+          s.op is not None and
+          s.op.type != 'Const' and
+          tensor_util.constant_value(s) is not None)
+
+
+def _tf_type_to_py_index(s):
+  if s is UNSPECIFIED:
+    return s
+  if tensor_util.is_tf_type(s):
+    s = tensor_util.constant_value(s)
+  if s is None:
+    return None
+  if isinstance(s, np.ndarray) and s.size == 1:
+    s = s.item()
+  try:
+    return operator.index(s)
+  except (TypeError, ValueError):
+    return None
 
 
 def _tf_range(start_or_stop, stop, step):

--- a/tensorflow/python/autograph/operators/py_builtins_test.py
+++ b/tensorflow/python/autograph/operators/py_builtins_test.py
@@ -27,7 +27,9 @@ from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors_impl
+from tensorflow.python.framework import tensor_spec
 from tensorflow.python.framework import test_util
+from tensorflow.python.framework import tensor_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import tensor_array_ops
@@ -257,12 +259,42 @@ class PyBuiltinsTest(test.TestCase):
       r = py_builtins.range_(2, 0, constant_op.constant(-1))
       self.assertAllEqual(self.evaluate(r), [2, 1])
 
+  def test_range_tensor_static_invalid_python_range_values(self):
+    r = py_builtins.range_(array_ops.identity(constant_op.constant(0.5)))
+    self.assertTrue(tensor_util.is_tf_type(r))
+    self.assertEqual(
+        py_builtins._tf_type_to_py_index(  # pylint: disable=protected-access
+            array_ops.identity(constant_op.constant([3]))), 3)
+
+  def test_range_symbolic_tensor_static_value(self):
+    @def_function.function(autograph=False)
+    def test_fn(x):
+      return constant_op.constant(
+          list(py_builtins.range_(array_ops.identity(constant_op.constant(3)))))
+
+    self.assertAllEqual(
+        self.evaluate(test_fn(constant_op.constant([1, 2, 3]))), [0, 1, 2])
+
   def test_range_tensor_empty_range(self):
     with self.session() as sess:
       r = py_builtins.range_(constant_op.constant(-3))
       self.assertAllEqual(self.evaluate(r), [])
       r = py_builtins.range_(5, constant_op.constant(2))
       self.assertAllEqual(self.evaluate(r), [])
+
+  def test_range_nested_static_outer_dynamic_inner(self):
+    @def_function.function(
+        input_signature=[tensor_spec.TensorSpec(shape=[None])])
+    def test_fn(x):
+      total = constant_op.constant(0, dtype=dtypes.int32)
+      for _ in py_builtins.range_(3):  # static outer -> Python range path
+        # dynamic inner -> tf.range path
+        inner = py_builtins.range_(array_ops.shape(x)[0])
+        total = total + math_ops.reduce_sum(inner)
+      return total
+
+    self.assertAllEqual(
+        self.evaluate(test_fn(constant_op.constant([0.0, 0.0, 0.0, 0.0]))), 18)
 
   def test_enumerate(self):
     self.assertListEqual(


### PR DESCRIPTION
This change updates `py_builtins.range_` in `tensorflow/python/autograph/operators/py_builtins.py` to detect when a symbolic tensor argument to `range` has a statically known constant value, and, in that case, convert the arguments to Python integers and fall back to `_py_range` instead of building a TF range tensor. A small helper, `_tf_type_to_py_index`, uses `tensor_util.constant_value` and `operator.index` to attempt the conversion, returning `None` when the value cannot be interpreted as a Python integer so the caller can keep its existing behavior.

Resolves #105648

### Changes
- Add `_tf_range_arg_needs_py_value` to identify symbolic tensor arguments that have a static constant value.
- Add `_tf_type_to_py_index` to convert a tensor-like value to a Python index when possible.
- Update `range_` to try the Python `range` path when all three arguments can be converted; otherwise retain the existing `_tf_range` behavior.
- Add unit tests covering static-invalid range values and symbolic tensors with statically known values inside a `tf.function`.