### PR TITLE
Fix sumSquare docstring example to sum 1 to n inclusive.

### DIFF
--- a/tensorflow/python/ops/while_loop.py
+++ b/tensorflow/python/ops/while_loop.py
@@ -60,22 +60,22 @@ def while_loop_v2(cond,
 
   >>> @tf.function
   ... def sumSquare(n):
-  ...   i, result = tf.constant(0), tf.constant(0)
-  ...   while i < n: # AutoGraph converts while-loop to tf.while_loop().
+  ...   i, result = tf.constant(1), tf.constant(0)
+  ...   while i <= n: # AutoGraph converts while-loop to tf.while_loop().
   ...     result += i * i
   ...     i += 1
   ...   return result
   >>> print(sumSquare(10).numpy())
-  285
+  385
 
   >>> @tf.function
   ... def sumSquare2(n):
-  ...   i, result = tf.constant(0), tf.constant(0)
-  ...   c = lambda i, _: tf.less(i, n)
+  ...   i, result = tf.constant(1), tf.constant(0)
+  ...   c = lambda i, _: tf.less_equal(i, n)
   ...   b = lambda i, result: (i + 1, result + i * i)
   ...   return tf.while_loop(c, b, [i, result])[1]
   >>> print(sumSquare2(10).numpy())
-  285
+  385
 
   For more information, see [tf.function and AutoGraph guide
   ](https://www.tensorflow.org/guide/function#autograph_transformations).


### PR DESCRIPTION
Previously, the i < n meant exclusive sum. updated test and ran docString test. While the function's intent (inclusive vs. exclusive) was not provided, I believe that inclusive was the intention. 

docString test command + requests:
```
python tensorflow/tools/docs/tf_doctest.py --module=ops.while_loop
Running tests under Python 3.12.13: /Users/adiojha/.pyenv/versions/3.12.13/bin/python
[ RUN      ] TfTestCase.test_session
[  SKIPPED ] TfTestCase.test_session - Not a test.
[ RUN      ] tensorflow.python.ops.while_loop.while_loop_v2
WARNING:tensorflow:From <doctest tensorflow.python.ops.while_loop.while_loop_v2[21]>:5: Print (from tensorflow.python.ops.logging_ops) is deprecated and will be removed after 2018-08-20.
Instructions for updating:
Use tf.print instead of tf.Print. Note that tf.print returns a no-output operator that directly prints the output. Outside of defuns or eager mode, this operator will not be executed unless it is directly specified in session.run or used as a control dependency for other operators. This is only a concern in graph mode. Below is an example of how to ensure tf.print executes in graph mode:

W0614 06:53:11.103356 8449367680 deprecation.py:50] From <doctest tensorflow.python.ops.while_loop.while_loop_v2[21]>:5: Print (from tensorflow.python.ops.logging_ops) is deprecated and will be removed after 2018-08-20.
Instructions for updating:
Use tf.print instead of tf.Print. Note that tf.print returns a no-output operator that directly prints the output. Outside of defuns or eager mode, this operator will not be executed unless it is directly specified in session.run or used as a control dependency for other operators. This is only a concern in graph mode. Below is an example of how to ensure tf.print executes in graph mode:

WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1781445191.104823 1808838 mlir_graph_optimization_pass.cc:437] MLIR V1 optimization pass is not enabled
Updating i based on i == [0]
Updating i based on i == [1]
Updating i based on i == [2]
Updating i based on i == [3]
Updating i based on i == [4]
Updating i based on i == [5]
Updating i based on i == [6]
Updating i based on i == [7]
Updating i based on i == [8]
Updating i based on i == [9]
Updating x based on i == [0]
Updating x based on i == [1]
Updating x based on i == [2]
Updating x based on i == [3]
Updating x based on i == [4]
Updating x based on i == [5]
Updating x based on i == [6]
Updating x based on i == [7]
Updating x based on i == [8]
Updating x based on i == [9]
INFO:tensorflow:time(__main__.TfTestCase.runTest): 0.07s
I0614 06:53:11.108282 8449367680 test_util.py:2634] time(__main__.TfTestCase.runTest): 0.07s
[       OK ] tensorflow.python.ops.while_loop.while_loop_v2
----------------------------------------------------------------------
Ran 2 tests in 0.100s

OK (skipped=1)
```