### PR TITLE
Fix order-dependent NaN handling in unsorted_segment_min/max on CPU

### DIFF
--- a/tensorflow/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow/core/kernels/segment_reduction_ops_impl.h
@@ -461,20 +461,31 @@ struct SumOp {
   void operator()(const T& data, T& output) { output += data; }
 };
 
+// PropagateNumbers prefers the numeric operand and returns NaN only when both
+// operands are NaN, so the reduction is independent of input order. This
+// matches the GPU kernels, which use CUDA fminf/fmaxf via GpuAtomicMin/Max.
 template <typename T>
 struct MaxOp {
   void operator()(const constMatrixChip<T> data, MatrixChip<T> output) {
-    output = data.cwiseMax(output);
+    Eigen::internal::scalar_max_op<T, T, Eigen::PropagateNumbers> op;
+    output = data.binaryExpr(output, op);
   }
-  void operator()(const T& data, T& output) { output = std::max(data, output); }
+  void operator()(const T& data, T& output) {
+    Eigen::internal::scalar_max_op<T, T, Eigen::PropagateNumbers> op;
+    output = op(data, output);
+  }
 };
 
 template <typename T>
 struct MinOp {
   void operator()(const constMatrixChip<T> data, MatrixChip<T> output) {
-    output = data.cwiseMin(output);
+    Eigen::internal::scalar_min_op<T, T, Eigen::PropagateNumbers> op;
+    output = data.binaryExpr(output, op);
   }
-  void operator()(const T& data, T& output) { output = std::min(data, output); }
+  void operator()(const T& data, T& output) {
+    Eigen::internal::scalar_min_op<T, T, Eigen::PropagateNumbers> op;
+    output = op(data, output);
+  }
 };
 
 template <typename T>

--- a/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py
@@ -606,6 +606,46 @@ class UnsortedSegmentTest(SegmentReductionHelper, parameterized.TestCase):
       ):
         self.evaluate(unsorted)
 
+  @test_util.run_in_graph_and_eager_modes
+  @test_util.disable_xla("XLA handling of NaN is inconsistent")
+  def testOrderIndependentNaNHandling(self):
+    # MinOp and MaxOp use Eigen::PropagateNumbers, which prefers the numeric
+    # operand and returns NaN only when both operands are NaN. The reduction
+    # therefore returns the numeric min and max regardless of input order, and
+    # an all-NaN segment returns the reduction identity (the type maximum for
+    # min and the type minimum for max) rather than NaN.
+    for dtype in [np.float32, np.float64]:
+      hi = np.finfo(dtype).max
+      lo = np.finfo(dtype).min
+      # Each case is (data, segment_ids, expected_min, expected_max).
+      test_cases = [
+          # 1D inputs exercise the scalar path. Every ordering of a single NaN
+          # among the numbers {1, 3} reduces to min 1 and max 3.
+          ([1.0, np.nan, 3.0], [0, 0, 0], [1.0], [3.0]),
+          ([np.nan, 1.0, 3.0], [0, 0, 0], [1.0], [3.0]),
+          ([1.0, 3.0, np.nan], [0, 0, 0], [1.0], [3.0]),
+          ([3.0, np.nan, 1.0], [0, 0, 0], [1.0], [3.0]),
+          ([1.0, np.nan, 3.0, 2.0], [0, 0, 0, 0], [1.0], [3.0]),
+          # An all-NaN segment returns the identity: hi for min, lo for max.
+          ([np.nan, np.nan], [0, 0], [hi], [lo]),
+          # 2D inputs exercise the matrix-chip path. Column 0 reduces over
+          # {1, NaN} to 1 and column 1 reduces over {NaN, 3} to 3, for both
+          # min and max.
+          ([[1.0, np.nan], [np.nan, 3.0]], [0, 0], [[1.0, 3.0]], [[1.0, 3.0]]),
+          # All-NaN columns return the identity in every column.
+          ([[np.nan, np.nan], [np.nan, np.nan]], [0, 0],
+           [[hi, hi]], [[lo, lo]]),
+      ]
+      for data, seg_ids, expected_min, expected_max in test_cases:
+        data_np = np.array(data, dtype=dtype)
+        segment_ids = np.array(seg_ids, dtype=np.int32)
+        res_min = math_ops.unsorted_segment_min(
+            data_np, segment_ids, num_segments=1)
+        self.assertAllClose(self.evaluate(res_min), expected_min)
+        res_max = math_ops.unsorted_segment_max(
+            data_np, segment_ids, num_segments=1)
+        self.assertAllClose(self.evaluate(res_max), expected_max)
+
 
 class SparseSegmentReductionHelper(SegmentReductionHelper):
 


### PR DESCRIPTION
Fixes #117862

### Problem

`UnsortedSegmentMin` and `UnsortedSegmentMax` on CPU return order-dependent results when a segment contains NaN. The scalar reduction path used `std::min` and `std::max`, which rely on `<` and `>` comparisons that evaluate to false whenever either operand is NaN, so the value that survives the reduction depends on the order in which the elements are visited. The multi-dimensional path used Eigen `cwiseMin` and `cwiseMax` with the default NaN propagation, which is order-sensitive in the same way. As a result the same segment data, reordered, can reduce to a number in one arrangement and to NaN in another.

### Fix

Both the scalar path and the matrix-chip path of `MinOp` and `MaxOp` in `tensorflow/core/kernels/segment_reduction_ops_impl.h` now use `Eigen::internal::scalar_min_op` and `scalar_max_op` instantiated with `Eigen::PropagateNumbers`. PropagateNumbers prefers the numeric operand and returns NaN only when both operands are NaN, so the result is independent of input order. This is the NaN handling the GPU kernels already use, since `GpuAtomicMin` and `GpuAtomicMax` are built on CUDA `fminf` and `fmaxf`. A segment whose values are all NaN therefore reduces to the kernel identity, the type maximum for min and the type minimum for max, rather than to NaN.

### Open question for maintainers

With PropagateNumbers, CPU `UnsortedSegmentMin` and `UnsortedSegmentMax` will differ from CPU `reduce_min` and `reduce_max`, which use `Eigen::PropagateNaN`; this divergence already exists between the segment ops and the global reductions on GPU and is neither introduced nor removed here, so please confirm this is the intended direction before merge.

### Testing

Added `testOrderIndependentNaNHandling` to `tensorflow/python/kernel_tests/math_ops/segment_reduction_ops_test.py`. It runs in graph and eager modes for `float32` and `float64` and covers 1D inputs, which exercise the scalar path, and 2D inputs, which exercise the matrix-chip path, including all-NaN segments and several orderings of the same data. XLA is disabled for the test because the JIT compiler handles NaN comparisons differently. The Eigen functors were also checked in isolation by folding each test vector with `scalar_min_op` and `scalar_max_op` under PropagateNumbers and confirming the forward and reversed folds agree and that an all-NaN fold returns the identity.
