### PR TITLE
Fix heap out-of-bounds in TFLite Roll: validate axis against input rank

### DIFF
--- a/tensorflow/lite/kernels/roll.cc
+++ b/tensorflow/lite/kernels/roll.cc
@@ -209,6 +209,7 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   for (int i = 0; i < axis_data.size(); ++i) {
     int32_t axis_i = axis_data[i];
     if (axis_i < 0) axis_i += input_rank;
+    TF_LITE_ENSURE(context, axis_i >= 0 && axis_i < input_rank);
     shift_map[axis_i] += shift_data[i];
   }
 

--- a/tensorflow/lite/kernels/roll_test.cc
+++ b/tensorflow/lite/kernels/roll_test.cc
@@ -115,6 +115,17 @@ TYPED_TEST(RollOpTest, Roll1D) {
               ElementsAreArray({7, 8, 9, 0, 1, 2, 3, 4, 5, 6}));
 }
 
+TYPED_TEST(RollOpTest, AxisOutOfRangeReturnsError) {
+  // A malformed model can supply an axis outside [0, rank(input)); the kernel
+  // must reject it rather than indexing `shift_map` out of bounds.
+  BaseRollOpModel m(
+      /*input=*/{GetTensorType<TypeParam>(), {10}, 0, 31.875},
+      /*shift=*/{3}, /*axis=*/{5},
+      /*output=*/{GetTensorType<TypeParam>(), {}, 0, 31.875});
+  m.SetInput<TypeParam>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  ASSERT_EQ(m.Invoke(), kTfLiteError);
+}
+
 TYPED_TEST(RollOpTest, Roll3D) {
   BaseRollOpModel m(
       /*input=*/{GetTensorType<TypeParam>(), {2, 4, 4}, 0, 31.875},

--- a/tensorflow/lite/kernels/roll_test.cc
+++ b/tensorflow/lite/kernels/roll_test.cc
@@ -126,6 +126,17 @@ TYPED_TEST(RollOpTest, AxisOutOfRangeReturnsError) {
   ASSERT_EQ(m.Invoke(), kTfLiteError);
 }
 
+TYPED_TEST(RollOpTest, AxisNegativeOutOfRangeReturnsError) {
+  // A negative axis that is still out of bounds after adding input_rank
+  // (here -2 + 1 == -1 for a rank-1 input) must also be rejected.
+  BaseRollOpModel m(
+      /*input=*/{GetTensorType<TypeParam>(), {10}, 0, 31.875},
+      /*shift=*/{3}, /*axis=*/{-2},
+      /*output=*/{GetTensorType<TypeParam>(), {}, 0, 31.875});
+  m.SetInput<TypeParam>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  ASSERT_EQ(m.Invoke(), kTfLiteError);
+}
+
 TYPED_TEST(RollOpTest, Roll3D) {
   BaseRollOpModel m(
       /*input=*/{GetTensorType<TypeParam>(), {2, 4, 4}, 0, 31.875},


### PR DESCRIPTION
## What

`tensorflow/lite/kernels/roll.cc` (`Roll`/`RollV2`) reads `axis` values from an input tensor and uses them to index `shift_map`, whose size is `rank(input)`, **without a bounds check**:

```cpp
// Make sure axis is in range [0, rank(input)).
for (int i = 0; i < axis_data.size(); ++i) {
  int32_t axis_i = axis_data[i];
  if (axis_i < 0) axis_i += input_rank;   // only adjusts negatives
  shift_map[axis_i] += shift_data[i];      // unchecked index
}
```

The comment claims the axis is constrained to `[0, rank(input))`, but the loop only normalizes negative axes — it never verifies the result is in range. `axis` comes from a model-supplied tensor whose values the framework does not bound-check, so a malformed/adversarial model with an out-of-range axis causes an **attacker-controlled out-of-bounds heap write** into `shift_map`:

- `axis = 5` for a rank-1 input → `shift_map[5]` (size 1) → OOB write.
- a large negative axis (e.g. `-100` for a rank-3 input) → `axis_i` stays negative → OOB write before the buffer.

## Fix

Add the same bounds check the sibling axis-driven kernel `reverse` already performs right after its negative-axis adjustment ([`reverse.cc`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/kernels/reverse.cc)):

```cpp
if (axis_i < 0) axis_i += input_rank;
TF_LITE_ENSURE(context, axis_i >= 0 && axis_i < input_rank);
shift_map[axis_i] += shift_data[i];
```

This makes `Roll` reject the malformed input with `kTfLiteError` instead of corrupting the heap, matching the existing validation pattern used across TFLite axis-consuming ops (`reverse`, `pad`, etc.).

## Test

Adds `RollOpTest.AxisOutOfRangeReturnsError` to `roll_test.cc`: an out-of-range axis now makes `Invoke()` return `kTfLiteError` (previously an OOB write).

Note: `Roll` is registered in the custom-op namespace (`RollV2`); the kernel is shipped and reachable via the interpreter.
