### PR TITLE
Fix label_image CMake link error by building profile_buffer.cc

### DIFF
--- a/tensorflow/lite/examples/label_image/CMakeLists.txt
+++ b/tensorflow/lite/examples/label_image/CMakeLists.txt
@@ -23,6 +23,7 @@ populate_source_vars("${TFLITE_SOURCE_DIR}/examples/label_image"
 list(APPEND TFLITE_LABEL_IMAGE_SRCS
   ${XLA_SOURCE_DIR}/xla/tsl/util/stats_calculator.cc
   ${TFLITE_SOURCE_DIR}/profiling/memory_info.cc
+  ${TFLITE_SOURCE_DIR}/profiling/profile_buffer.cc
   ${TFLITE_SOURCE_DIR}/profiling/profile_summarizer.cc
   ${TFLITE_SOURCE_DIR}/profiling/profile_summary_formatter.cc
   ${TFLITE_SOURCE_DIR}/profiling/time.cc


### PR DESCRIPTION
The label_image example uses BufferedProfiler, whose EndEvent() and BeginEvent() forward to tflite::profiling::ProfileBuffer. ProfileBuffer is declared in profiling/profile_buffer.h and defined in profiling/profile_buffer.cc, which is not part of the tensorflow-lite library (it is omitted from TFLITE_PROFILER_SRCS in tensorflow/lite/CMakeLists.txt). Every CMake target that pulls in the profiler must therefore compile profile_buffer.cc itself: the benchmark_model target already lists it, but the label_image example does not.

As a result, linking label_image can fail with:

  undefined reference to
  'tflite::profiling::ProfileBuffer::EndEvent(unsigned int,
   long const*, long const*)'

Whether the reference survives depends on the compiler's inlining; it is reliably reproducible with GCC 16, while older compilers tended to inline it away.

Add profiling/profile_buffer.cc to TFLITE_LABEL_IMAGE_SRCS, mirroring the benchmark_model target. Its remaining dependencies (time.cc, memory_info.cc and minimal logging) are already linked, so no other sources are needed.