### PR TITLE
Validate geometry parameters against image size in ImagePreprocessingStage

### DIFF
--- a/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.cc
+++ b/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.cc
@@ -264,6 +264,15 @@ inline TfLiteStatus Pad(ImageData* image_data, const PaddingParams& params) {
                                     kNumChannels});
   tflite::RuntimeShape output_shape(
       {1, output_height, output_width, kNumChannels});
+  // Guards against integer overflow when computing the output buffer size for
+  // a very large target_size. output_width/height are validated > 0 and >= the
+  // image dimensions above, so the divisions are safe.
+  if (output_height > std::numeric_limits<int>::max() / output_width ||
+      output_width * output_height >
+          std::numeric_limits<int>::max() / kNumChannels) {
+    ABSL_LOG(ERROR) << "Padding output size is too large";
+    return kTfLiteError;
+  }
   int output_size = output_width * output_height * kNumChannels;
   std::vector<float> output_data(output_size, 0);
   tflite::reference_ops::Pad(pad_params, input_shape, image_data->data.data(),

--- a/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.cc
+++ b/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include <fstream>
 #include <ios>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -136,7 +137,8 @@ inline TfLiteStatus LoadImageJpeg(absl::string_view filename,
 }
 
 // Central-cropping.
-inline void Crop(ImageData* image_data, const CroppingParams& crop_params) {
+inline TfLiteStatus Crop(ImageData* image_data,
+                         const CroppingParams& crop_params) {
   int crop_height = 0;
   int crop_width = 0;
   int input_width = image_data->width;
@@ -154,6 +156,14 @@ inline void Crop(ImageData* image_data, const CroppingParams& crop_params) {
     crop_height = std::min(crop_height, crop_width);
     crop_width = crop_height;
   }
+  // The crop region must fit within the image. A larger crop than the image
+  // (possible with target_size, since the image dimensions come from the
+  // decoded input) would make the start offsets negative and cause
+  // GetData to read out of bounds.
+  if (crop_width > input_width || crop_height > input_height) {
+    ABSL_LOG(ERROR) << "Cropping size is larger than the image size";
+    return kTfLiteError;
+  }
   int start_w = static_cast<int>(round((input_width - crop_width) / 2.0));
   int start_h = static_cast<int>(round((input_height - crop_height) / 2.0));
   std::vector<float> cropped_image;
@@ -168,12 +178,13 @@ inline void Crop(ImageData* image_data, const CroppingParams& crop_params) {
   image_data->height = crop_height;
   image_data->width = crop_width;
   image_data->data = std::move(cropped_image);
+  return kTfLiteOk;
 }
 
 // Performs billinear interpolation for 3-channel RGB image.
 // See: https://en.wikipedia.org/wiki/Bilinear_interpolation
-inline void ResizeBilinear(ImageData* image_data,
-                           const ResizingParams& params) {
+inline TfLiteStatus ResizeBilinear(ImageData* image_data,
+                                   const ResizingParams& params) {
   tflite::ResizeBilinearParams resize_params;
   resize_params.align_corners = false;
   // TODO(b/143292772): Set this to true for more accurate behavior?
@@ -204,6 +215,15 @@ inline void ResizeBilinear(ImageData* image_data,
   std::vector<int32_t> output_size_data = {output_height, output_width};
   tflite::RuntimeShape output_shape(
       {1, output_height, output_width, kNumChannels});
+  // Guards against integer overflow when computing the output buffer size for
+  // a very large target_size.
+  if (output_width <= 0 || output_height <= 0 ||
+      output_height > std::numeric_limits<int>::max() / output_width ||
+      output_width * output_height >
+          std::numeric_limits<int>::max() / kNumChannels) {
+    ABSL_LOG(ERROR) << "Resizing output size is invalid or too large";
+    return kTfLiteError;
+  }
   int output_size = output_width * output_height * kNumChannels;
   std::vector<float> output_data(output_size, 0);
   tflite::reference_ops::ResizeBilinear(
@@ -212,12 +232,21 @@ inline void ResizeBilinear(ImageData* image_data,
   image_data->height = output_height;
   image_data->width = output_width;
   image_data->data = std::move(output_data);
+  return kTfLiteOk;
 }
 
 // Pads the image to a pre-defined size.
-inline void Pad(ImageData* image_data, const PaddingParams& params) {
+inline TfLiteStatus Pad(ImageData* image_data, const PaddingParams& params) {
   int output_width = params.target_size().width();
   int output_height = params.target_size().height();
+  // The padded output must be at least as large as the image. A smaller
+  // target than the image would make the padding counts negative and cause
+  // the pad kernel to read/write out of bounds.
+  if (output_width < static_cast<int>(image_data->width) ||
+      output_height < static_cast<int>(image_data->height)) {
+    ABSL_LOG(ERROR) << "Padding size is smaller than the image size";
+    return kTfLiteError;
+  }
   int pad_value = params.padding_value();
   tflite::PadParams pad_params{};
   pad_params.left_padding_count = 4;
@@ -242,6 +271,7 @@ inline void Pad(ImageData* image_data, const PaddingParams& params) {
   image_data->height = output_height;
   image_data->width = output_width;
   image_data->data = std::move(output_data);
+  return kTfLiteOk;
 }
 
 // Normalizes the image data to a specific range with mean and scale.
@@ -367,19 +397,20 @@ TfLiteStatus ImagePreprocessingStage::Run() {
         LOG(WARNING) << "Image cropping will not be performed on raw images";
         continue;
       }
-      Crop(&image_data, param.cropping_params());
+      TF_LITE_ENSURE_STATUS(Crop(&image_data, param.cropping_params()));
     } else if (param.has_resizing_params()) {
       if (is_raw_image) {
         LOG(WARNING) << "Image resizing will not be performed on raw images";
         continue;
       }
-      ResizeBilinear(&image_data, param.resizing_params());
+      TF_LITE_ENSURE_STATUS(
+          ResizeBilinear(&image_data, param.resizing_params()));
     } else if (param.has_padding_params()) {
       if (is_raw_image) {
         LOG(WARNING) << "Image padding will not be performed on raw images";
         continue;
       }
-      Pad(&image_data, param.padding_params());
+      TF_LITE_ENSURE_STATUS(Pad(&image_data, param.padding_params()));
     } else if (param.has_normalization_params()) {
       TF_LITE_ENSURE_STATUS(
           Normalize(&image_data, param.normalization_params()));

--- a/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.cc
+++ b/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.cc
@@ -160,8 +160,9 @@ inline TfLiteStatus Crop(ImageData* image_data,
   // (possible with target_size, since the image dimensions come from the
   // decoded input) would make the start offsets negative and cause
   // GetData to read out of bounds.
-  if (crop_width > input_width || crop_height > input_height) {
-    ABSL_LOG(ERROR) << "Cropping size is larger than the image size";
+  if (crop_width <= 0 || crop_height <= 0 || crop_width > input_width ||
+      crop_height > input_height) {
+    ABSL_LOG(ERROR) << "Cropping size is invalid or larger than the image size";
     return kTfLiteError;
   }
   int start_w = static_cast<int>(round((input_width - crop_width) / 2.0));
@@ -265,12 +266,13 @@ inline TfLiteStatus Pad(ImageData* image_data, const PaddingParams& params) {
   tflite::RuntimeShape output_shape(
       {1, output_height, output_width, kNumChannels});
   // Guards against integer overflow when computing the output buffer size for
-  // a very large target_size. output_width/height are validated > 0 and >= the
-  // image dimensions above, so the divisions are safe.
-  if (output_height > std::numeric_limits<int>::max() / output_width ||
+  // a very large target_size. The explicit > 0 checks keep the divisions safe
+  // and self-contained, matching ResizeBilinear.
+  if (output_width <= 0 || output_height <= 0 ||
+      output_height > std::numeric_limits<int>::max() / output_width ||
       output_width * output_height >
           std::numeric_limits<int>::max() / kNumChannels) {
-    ABSL_LOG(ERROR) << "Padding output size is too large";
+    ABSL_LOG(ERROR) << "Padding output size is invalid or too large";
     return kTfLiteError;
   }
   int output_size = output_width * output_height * kNumChannels;

--- a/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage_test.cc
+++ b/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage_test.cc
@@ -328,6 +328,21 @@ TEST(ImagePreprocessingStage, TestPaddingTargetSmallerThanImage) {
   EXPECT_EQ(stage.Run(), kTfLiteError);
 }
 
+TEST(ImagePreprocessingStage, TestPaddingTargetTooLarge) {
+  std::string image_path(kTestImage);
+
+  ImagePreprocessingConfigBuilder builder(
+      std::string(kImagePreprocessingStageName), kTfLiteFloat32);
+  // A padding target large enough to overflow the output buffer size
+  // computation must be rejected at run time.
+  builder.AddPaddingStep(/*width=*/100000, /*height=*/100000, 0);
+  builder.AddNormalizationStep(127.5, 1.0 / 127.5);
+  ImagePreprocessingStage stage(builder.build());
+  EXPECT_EQ(stage.Init(), kTfLiteOk);
+  stage.SetImagePath(&image_path);
+  EXPECT_EQ(stage.Run(), kTfLiteError);
+}
+
 TEST(ImagePreprocessingStage, TestInvalidRawImageSize) {
   std::string image_path = testing::TempDir() + "/invalid.rgb8";
   std::ofstream stream(image_path, std::ios::out | std::ios::binary);

--- a/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage_test.cc
+++ b/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage_test.cc
@@ -298,6 +298,36 @@ TEST(ImagePreprocessingStage, TestImagePreprocessingSubtractMean) {
   EXPECT_THAT(metrics, HasValidLatencyMetrics());
 }
 
+TEST(ImagePreprocessingStage, TestCropTargetLargerThanImage) {
+  std::string image_path(kTestImage);
+
+  ImagePreprocessingConfigBuilder builder(
+      std::string(kImagePreprocessingStageName), kTfLiteFloat32);
+  // A crop target larger than the image would produce negative start offsets
+  // and read out of bounds. It must be rejected at run time.
+  builder.AddCroppingStep(/*width=*/100000, /*height=*/100000);
+  builder.AddNormalizationStep(127.5, 1.0 / 127.5);
+  ImagePreprocessingStage stage(builder.build());
+  EXPECT_EQ(stage.Init(), kTfLiteOk);
+  stage.SetImagePath(&image_path);
+  EXPECT_EQ(stage.Run(), kTfLiteError);
+}
+
+TEST(ImagePreprocessingStage, TestPaddingTargetSmallerThanImage) {
+  std::string image_path(kTestImage);
+
+  ImagePreprocessingConfigBuilder builder(
+      std::string(kImagePreprocessingStageName), kTfLiteFloat32);
+  // A padding target smaller than the image would produce negative padding
+  // counts and write out of bounds. It must be rejected at run time.
+  builder.AddPaddingStep(/*width=*/1, /*height=*/1, 0);
+  builder.AddNormalizationStep(127.5, 1.0 / 127.5);
+  ImagePreprocessingStage stage(builder.build());
+  EXPECT_EQ(stage.Init(), kTfLiteOk);
+  stage.SetImagePath(&image_path);
+  EXPECT_EQ(stage.Run(), kTfLiteError);
+}
+
 TEST(ImagePreprocessingStage, TestInvalidRawImageSize) {
   std::string image_path = testing::TempDir() + "/invalid.rgb8";
   std::ofstream stream(image_path, std::ios::out | std::ios::binary);

--- a/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage_test.cc
+++ b/tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage_test.cc
@@ -305,7 +305,7 @@ TEST(ImagePreprocessingStage, TestCropTargetLargerThanImage) {
       std::string(kImagePreprocessingStageName), kTfLiteFloat32);
   // A crop target larger than the image would produce negative start offsets
   // and read out of bounds. It must be rejected at run time.
-  builder.AddCroppingStep(/*width=*/100000, /*height=*/100000);
+  builder.AddCroppingStep(/*width=*/100000U, /*height=*/100000U);
   builder.AddNormalizationStep(127.5, 1.0 / 127.5);
   ImagePreprocessingStage stage(builder.build());
   EXPECT_EQ(stage.Init(), kTfLiteOk);


### PR DESCRIPTION
### Problem

The cropping, padding and resizing steps in `ImagePreprocessingStage`
(`tensorflow/lite/tools/evaluation/stages/image_preprocessing_stage.cc`) use the
configured `target_size` without validating it against the actual image
dimensions. For JPEG inputs the image dimensions come from the decoded
(untrusted) image, and `ImageData::GetData` performs unchecked indexing
(`data[...]`), so an out-of-range `target_size` results in a heap
out-of-bounds access:

- **`Crop`**: with `target_size` larger than the image, the centered start
  offsets `start_w = round((input_width - crop_width) / 2.0)` and `start_h`
  become negative. The inner loop then calls `GetData(in_h, in_w, c)` with
  negative coordinates, `ImageArrayOffset` returns a negative index, and
  `data[negative]` reads out of bounds. `Init()` only checks that the crop
  `target_size` is `> 0`, never against the image dimensions.
- **`Pad`**: `output_width/height = params.target_size()`. With a target
  smaller than the image, `left_padding = round((output - input) / 2.0)` and
  `right_padding = output - left - input` become negative, so the pad reference
  kernel reads/writes out of bounds.
- **`ResizeBilinear`**: `output_size = output_width * output_height *
  kNumChannels` can integer-overflow for a very large `target_size`.

### Context

This complements daa44d25a ("Validate raw image size and image data size before
normalization to prevent heap buffer overflow in ImagePreprocessingStage"),
which hardened the image *load* path and the normalization step (and switched
`GetData` to unchecked indexing) but did not validate the crop/pad/resize
geometry that consumes `target_size`.

### Fix

- Change `Crop`, `ResizeBilinear` and `Pad` from `inline void` to
  `inline TfLiteStatus`, validate the geometry against the actual image
  dimensions at the top, and return `kTfLiteError` on an invalid combination,
  using the existing `ABSL_LOG(ERROR) << ...; return kTfLiteError;` pattern from
  this file:
  - `Crop`: require `crop_width <= input_width && crop_height <= input_height`
    (so the start offsets stay non-negative).
  - `Pad`: require the target to be at least the image size (so the padding
    counts stay non-negative).
  - `ResizeBilinear`: reject an output size that would overflow the buffer
    computation.
- Wire the calls in `Run()` through `TF_LITE_ENSURE_STATUS(...)`, the same way
  `Normalize` already is.
- Add two tests covering an oversized crop target and an undersized pad target;
  both now return `kTfLiteError` instead of crashing.

The change is limited to the two files for this stage and keeps the existing
style.
