### PR TITLE
Fix unclear shape mismatch error message in tf.matmul for 1D inputs

### DIFF
--- a/tensorflow/python/kernel_tests/math_ops/matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/matmul_op_test.py
@@ -212,12 +212,74 @@ except AttributeError:
 class MatMulInfixOperatorTest(test_lib.TestCase):
 
   def testMismatchedShape(self):
+    # The Python-level rank check now raises ValueError with a descriptive
+    # message before hitting the C++ kernel (which used to raise
+    # InvalidArgumentError).  We accept both the old C++ patterns (for
+    # graph-mode / non-eager paths that bypass the Python guard) and the new
+    # ValueError message so the test stays green across all execution modes.
     with self.assertRaisesRegex(
-        Exception, (r"(In\[0\] and In\[1\] has different ndims|In\[0\] "
-                    r"ndims must be >= 2|Shape must be rank 2 but is rank 1)")):
+        (ValueError, Exception),
+        (r"(must be at least rank 2"
+         r"|In\[0\] and In\[1\] has different ndims"
+         r"|In\[0\] ndims must be >= 2"
+         r"|Shape must be rank 2 but is rank 1)")):
       infix_matmul(
           ops.convert_to_tensor([10.0, 20.0, 30.0]),
           ops.convert_to_tensor([[40.0, 50.0], [60.0, 70.0]]))
+
+  def testMismatchedShapeErrorMessage(self):
+    """Verifies that the error message for rank < 2 inputs is descriptive."""
+    # --- `a` is rank-1 ---
+    with self.assertRaisesRegex(
+        ValueError,
+        r"Argument `a` passed to `tf.linalg.matmul` must be at least rank 2"):
+      math_ops.matmul(
+          ops.convert_to_tensor([1.0, 2.0, 3.0]),
+          ops.convert_to_tensor([[4.0, 5.0], [6.0, 7.0], [8.0, 9.0]]))
+
+    # The message should show the actual shape and rank.
+    try:
+      math_ops.matmul(
+          ops.convert_to_tensor([1.0, 2.0]),
+          ops.convert_to_tensor([[3.0, 4.0], [5.0, 6.0]]))
+    except ValueError as e:
+      msg = str(e)
+      self.assertIn("(2,)", msg,
+                    "Error message should include the actual shape (2,)")
+      self.assertIn("rank 1", msg,
+                    "Error message should mention 'rank 1'")
+
+    # The message should suggest tf.expand_dims or tf.reshape for `a`.
+    try:
+      math_ops.matmul(
+          ops.convert_to_tensor([1.0, 2.0]),
+          ops.convert_to_tensor([[3.0, 4.0], [5.0, 6.0]]))
+    except ValueError as e:
+      msg = str(e)
+      self.assertIn("tf.expand_dims", msg,
+                    "Error should suggest tf.expand_dims as a remediation")
+      self.assertIn("tf.reshape", msg,
+                    "Error should suggest tf.reshape as a remediation")
+
+    # --- `b` is rank-1 ---
+    with self.assertRaisesRegex(
+        ValueError,
+        r"Argument `b` passed to `tf.linalg.matmul` must be at least rank 2"):
+      math_ops.matmul(
+          ops.convert_to_tensor([[1.0, 2.0], [3.0, 4.0]]),
+          ops.convert_to_tensor([5.0, 6.0]))
+
+    # The message for `b` should also suggest tf.expand_dims and tf.reshape.
+    try:
+      math_ops.matmul(
+          ops.convert_to_tensor([[1.0, 2.0], [3.0, 4.0]]),
+          ops.convert_to_tensor([5.0, 6.0]))
+    except ValueError as e:
+      msg = str(e)
+      self.assertIn("tf.expand_dims", msg,
+                    "Error for `b` should suggest tf.expand_dims")
+      self.assertIn("tf.reshape", msg,
+                    "Error for `b` should suggest tf.reshape")
 
   def testMismatchedDimensions(self):
     with self.assertRaisesRegex(

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3636,13 +3636,19 @@ def matmul(
 
     if a_shape is not None and len(a_shape) < 2:
       raise ValueError(
-          f"Argument `a` passed to `tf.matmul` must be at least rank 2. "
-          f"Received shape: {a_shape} of rank {len(a_shape)}."
+          f"Argument `a` passed to `tf.linalg.matmul` must be at least rank 2."
+          f" Received `a` with shape {a_shape} (rank {len(a_shape)})."
+          f" To fix this, consider using `tf.expand_dims(a, axis=0)` to add a"
+          f" batch dimension, or `tf.reshape(a, [...])` to reshape it into a"
+          f" 2-D (or higher-rank) matrix before calling `tf.linalg.matmul`."
       )
     if b_shape is not None and len(b_shape) < 2:
       raise ValueError(
-          f"Argument `b` passed to `tf.matmul` must be at least rank 2. "
-          f"Received shape: {b_shape} of rank {len(b_shape)}."
+          f"Argument `b` passed to `tf.linalg.matmul` must be at least rank 2."
+          f" Received `b` with shape {b_shape} (rank {len(b_shape)})."
+          f" To fix this, consider using `tf.expand_dims(b, axis=-1)` to add a"
+          f" column dimension, or `tf.reshape(b, [...])` to reshape it into a"
+          f" 2-D (or higher-rank) matrix before calling `tf.linalg.matmul`."
       )
 
     output_may_have_non_empty_batch_shape = (

--- a/tensorflow/python/ops/math_ops.py
+++ b/tensorflow/python/ops/math_ops.py
@@ -3634,6 +3634,17 @@ def matmul(
     a_shape = a._shape_tuple()  # pylint: disable=protected-access
     b_shape = b._shape_tuple()  # pylint: disable=protected-access
 
+    if a_shape is not None and len(a_shape) < 2:
+      raise ValueError(
+          f"Argument `a` passed to `tf.matmul` must be at least rank 2. "
+          f"Received shape: {a_shape} of rank {len(a_shape)}."
+      )
+    if b_shape is not None and len(b_shape) < 2:
+      raise ValueError(
+          f"Argument `b` passed to `tf.matmul` must be at least rank 2. "
+          f"Received shape: {b_shape} of rank {len(b_shape)}."
+      )
+
     output_may_have_non_empty_batch_shape = (
         (a_shape is None or len(a_shape) > 2) or
         (b_shape is None or len(b_shape) > 2))


### PR DESCRIPTION
### Summary
Resolves the issue where passing a 1D tensor/input to `tf.matmul` yields an unclear, low-level error message (`InvalidArgumentError: In[1] ndims must be >= 2 [Op:MatMul]`).

### Description
Since `tf.matmul` requires inputs of at least rank 2, this PR introduces Python-side validation to raise a standard, descriptive `ValueError` before reaching the C++ kernel level.

### Validation
Verified that:
- Passing 1D inputs correctly raises the descriptive `ValueError`.
- Valid rank >= 2 matrix multiplications (including batch matmul) continue to work properly.
