### PR TITLE
Fix make_tensor_proto to normalize non-native NumPy byte order

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -677,6 +677,11 @@ def make_tensor_proto(values, dtype=None, shape=None, verify_shape=False,
     raise TypeError(f"`dtype` {dtype} is not compatible with {values} of "
                     f"dtype {nparray.dtype}.")
 
+  # Normalize byte order to native so that tobytes() and element access
+  # produce values in the host's expected representation.
+  if not nparray.dtype.isnative:
+    nparray = nparray.astype(nparray.dtype.newbyteorder('='))
+
   # If shape is not given, get the shape from the numpy array.
   if shape is None:
     shape = nparray.shape

--- a/tensorflow/python/framework/tensor_util_test.py
+++ b/tensorflow/python/framework/tensor_util_test.py
@@ -1043,6 +1043,18 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
     self.assertFalse(tensor_util.ShapeEquals(t, []))
     self.assertFalse(tensor_util.ShapeEquals(t, [2, 2, 1]))
 
+  def testNonNativeByteOrder(self):
+    for dtype in [np.int32, np.float32, np.int64]:
+      arr = np.array([1, 2, 3], dtype=dtype)
+      arr_swapped = arr.astype(arr.dtype.newbyteorder("S"))
+      self.assertFalse(arr_swapped.dtype.isnative)
+
+      t = tensor_util.make_tensor_proto(arr_swapped)
+      a = tensor_util.MakeNdarray(t)
+      self.assertTrue(a.dtype.isnative)
+      self.assertEqual(arr.dtype.type, a.dtype.type)
+      self.assertAllClose(arr, a)
+
 
 @test_util.run_all_in_graph_and_eager_modes
 class IsTensorTest(test.TestCase):


### PR DESCRIPTION
`tf.make_tensor_proto()` serializes incorrect tensor values when given a NumPy array with non-native byte order (e.g., big-endian int32 on a little-endian host). `nparray.tobytes()` emits bytes in the array's dtype byte order but TensorFlow assumes native byte order when deserializing `tensor_content`.

This adds a byte order normalization step before serialization using `nparray.dtype.isnative` and `astype(newbyteorder('='))`. Only non-native arrays are converted so native arrays are untouched.

Fixes #55789
