### PR TITLE
Fix out-of-bounds write in `TensorListScatterIntoExistingList` for negative indices

### DIFF
--- a/tensorflow/core/kernels/list_kernels.h
+++ b/tensorflow/core/kernels/list_kernels.h
@@ -893,11 +893,22 @@ class TensorListScatterIntoExistingList : public OpKernel {
     TensorList* output_list = nullptr;
     OP_REQUIRES_OK(c, ForwardInputOrCreateNewList(c, 0, 0, *l, &output_list));
     const auto indices_vec = indices.vec<int32_t>();
-    int32_t max_index =
-        (indices.NumElements() == 0)
-            ? -1
-            : *std::max_element(indices_vec.data(),
-                                indices_vec.data() + indices.NumElements());
+    // Reject negative indices (mirrors the sibling op TensorListScatter): a
+    // negative index reaches Scatter()'s std::swap(list->tensors()[i], ...)
+    // with i < 0, an out-of-bounds heap access. Do it in the same pass that
+    // finds the max via std::minmax_element, and reuse the max for the resize.
+    int32_t max_index = -1;
+    if (indices.NumElements() > 0) {
+      const auto minmax = std::minmax_element(
+          indices_vec.data(), indices_vec.data() + indices.NumElements());
+      OP_REQUIRES(
+          c, *minmax.first >= 0,
+          absl::InvalidArgumentError(absl::StrCat(
+              "Indices in TensorListScatterIntoExistingList must all be "
+              "non-negative; got ",
+              *minmax.first)));
+      max_index = *minmax.second;
+    }
     if (max_index + 1 > output_list->tensors().size()) {
       output_list->tensors().resize(max_index + 1);
     }

--- a/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
@@ -547,6 +547,22 @@ class ListOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
           c0, [1, 3], list_ops._build_element_shape([]), num_elements=3)
       self.evaluate(l)
 
+  def testScatterIntoExistingListFailsWithNegativeIndex(self):
+    # Regression test: a negative scatter index reaches the Scatter() helper's
+    # std::swap(list->tensors()[i], aligned) with i < 0, which indexes the
+    # backing std::vector before its buffer (out-of-bounds heap access). It must
+    # raise InvalidArgumentError, matching the sibling TensorListScatter.
+    l = list_ops.tensor_list_reserve(
+        element_dtype=dtypes.float32, element_shape=[], num_elements=3)
+    with self.assertRaisesRegex(
+        errors.InvalidArgumentError,
+        "Indices in TensorListScatterIntoExistingList must all be "
+        "non-negative"):
+      self.evaluate(
+          list_ops.tensor_list_scatter(
+              tensor=[2.0, 3.0], indices=[-1, 2], element_shape=[],
+              input_handle=l))
+
   def testScatterFailsWithInvalidNumElements(self):
     c0 = constant_op.constant([1.0, 2.0])
     with self.assertRaisesRegex(


### PR DESCRIPTION
## What
`TensorListScatterIntoExistingList::Compute` (`tensorflow/core/kernels/list_kernels.h`) validates dtype and shapes and resizes the list to `max_index + 1`, but never checks that the scatter indices are non-negative. The shared `Scatter()` helper then runs
`std::swap(list->tensors()[i], aligned)` with the attacker-supplied `int i`; for a negative `i` this indexes the backing `std::vector<Tensor>` *before* its buffer (`&tensors()[i] == data() + (size_t)i * sizeof(Tensor)`), an out-of-bounds heap access.

The sibling op `TensorListScatter` already rejects negative indices; this op was missing the same check.

## Why it matters
The offending index comes directly from an input tensor (`indices`), so this is reachable with input data on a valid graph (e.g. via `tf.TensorArray.scatter`, which lowers to this op). A negative index produces an out-of-bounds read/write of a `Tensor` object whose `TensorBuffer*` is subsequently dereferenced on destruction, so the impact goes beyond a crash.

## Fix
Validate the indices in `Compute` before scattering, mirroring `TensorListScatter`:

```cpp
const auto indices_vec = indices.vec<int32_t>();
for (int index = 0; index < indices.NumElements(); ++index) {
  OP_REQUIRES(c, indices_vec(index) >= 0,
              absl::InvalidArgumentError(absl::StrCat(
                  "Indices in TensorListScatterIntoExistingList must all be "
                  "non-negative; got ", indices_vec(index))));
}
```

## Test
Adds `ListOpsTest.testScatterIntoExistingListFailsWithNegativeIndex` in `tensorflow/python/kernel_tests/data_structures/list_ops_test.py`: scattering with `indices=[-1, 0]` into an existing list now raises `InvalidArgumentError` instead of performing an out-of-bounds access.

## Notes
- Reported via the Google OSS VRP / TensorFlow security process (reference the report ID to the maintainers as appropriate).
- Behavior change: negative scatter indices now raise `InvalidArgument` (previously out-of-bounds). Valid (non-negative) indices are unaffected.