### PR TITLE
Fix out-of-bounds read in Hexagon Concat/Pack builders due to unchecked input/output size

### DIFF
--- a/tensorflow/lite/delegates/hexagon/BUILD
+++ b/tensorflow/lite/delegates/hexagon/BUILD
@@ -171,6 +171,7 @@ cc_test(
     linkopts = tflite_linkopts() + ["-lm"],
     deps = [
         ":utils",
+        "//tensorflow/lite:builtin_ops",
         "//tensorflow/lite/core/c:common",
         "@com_google_googletest//:gtest_main",
     ],

--- a/tensorflow/lite/delegates/hexagon/builders/concat_builder.cc
+++ b/tensorflow/lite/delegates/hexagon/builders/concat_builder.cc
@@ -28,10 +28,19 @@ namespace hexagon {
 TfLiteStatus ConcatOpBuilder::PopulateSubGraph(const TfLiteIntArray* inputs,
                                                const TfLiteIntArray* outputs,
                                                TfLiteContext* context) {
+  TF_LITE_ENSURE(context, inputs != nullptr);
+  TF_LITE_ENSURE(context, outputs != nullptr);
+  TF_LITE_ENSURE(context, inputs->size >= 1);
+  TF_LITE_ENSURE(context, outputs->size >= 1);
+
   const TfLiteConcatenationParams* concat_params =
       reinterpret_cast<const TfLiteConcatenationParams*>(builtin_data_);
   int concat_axis = concat_params->axis;
-  const int output_dim_size = context->tensors[outputs->data[0]].dims->size;
+  const int output_tensor_id = outputs->data[0];
+  TF_LITE_ENSURE(context, output_tensor_id >= 0 &&
+                              output_tensor_id < context->tensors_size);
+  TF_LITE_ENSURE(context, context->tensors[output_tensor_id].dims != nullptr);
+  const int output_dim_size = context->tensors[output_tensor_id].dims->size;
   // Axis value is incremented if tensor dims are < 4 and/or axis < 0.
   concat_axis =
       concat_axis < 0 ? concat_axis + 4 : concat_axis + 4 - output_dim_size;
@@ -127,6 +136,8 @@ TfLiteStatus ConcatOpBuilder::PopulateSubGraph(const TfLiteIntArray* inputs,
 
 TfLiteStatus ConcatOpBuilder::RegisterOutputs(const TfLiteIntArray* outputs,
                                               TfLiteContext* context) {
+  TF_LITE_ENSURE(context, outputs != nullptr);
+  TF_LITE_ENSURE(context, outputs->size >= 1);
   // Should be only 1 output.
   graph_builder_->AddTensorWithID(outputs->data[0], node_output_.first,
                                   node_output_.second);

--- a/tensorflow/lite/delegates/hexagon/builders/pack_builder.cc
+++ b/tensorflow/lite/delegates/hexagon/builders/pack_builder.cc
@@ -24,8 +24,8 @@ namespace delegates {
 namespace hexagon {
 namespace {
 
-int GetAxis(int axis, const TfLiteIntArray* inputs, TfLiteContext* context) {
-  auto& input_tensor = context->tensors[inputs->data[0]];
+int GetAxis(int axis, int input_tensor_id, TfLiteContext* context) {
+  auto& input_tensor = context->tensors[input_tensor_id];
   // Handle -ve axis.
   if (axis < 0) {
     axis += input_tensor.dims->size + 1;
@@ -39,8 +39,21 @@ int GetAxis(int axis, const TfLiteIntArray* inputs, TfLiteContext* context) {
 TfLiteStatus PackOpBuilder::PopulateSubGraph(const TfLiteIntArray* inputs,
                                              const TfLiteIntArray* outputs,
                                              TfLiteContext* context) {
+  TF_LITE_ENSURE(context, inputs != nullptr);
+  TF_LITE_ENSURE(context, outputs != nullptr);
+  TF_LITE_ENSURE(context, inputs->size >= 1);
+  TF_LITE_ENSURE(context, outputs->size >= 1);
+  const int input_tensor_id = inputs->data[0];
+  TF_LITE_ENSURE(context, input_tensor_id >= 0 &&
+                              input_tensor_id < context->tensors_size);
+  TF_LITE_ENSURE(context, context->tensors[input_tensor_id].dims != nullptr);
+  const int output_tensor_id = outputs->data[0];
+  TF_LITE_ENSURE(context, output_tensor_id >= 0 &&
+                              output_tensor_id < context->tensors_size);
+  TF_LITE_ENSURE(context, context->tensors[output_tensor_id].dims != nullptr);
+
   auto* params = reinterpret_cast<TfLitePackParams*>(builtin_data_);
-  int axis = GetAxis(params->axis, inputs, context);
+  int axis = GetAxis(params->axis, input_tensor_id, context);
   // Add axis
   auto* axis_node = graph_builder_->AddConstNodeWithData(
       kScalarShape, reinterpret_cast<char*>(&axis), sizeof(axis));
@@ -79,7 +92,7 @@ TfLiteStatus PackOpBuilder::PopulateSubGraph(const TfLiteIntArray* inputs,
   int output_batch_size, output_height_size, output_width_size,
       output_depth_size;
   GetDims(&output_batch_size, &output_height_size, &output_width_size,
-          &output_depth_size, context->tensors[outputs->data[0]].dims);
+          &output_depth_size, context->tensors[output_tensor_id].dims);
 
   TensorID pack_out = AddOutput(sizeof(uint8_t), 4,
                                 {output_batch_size, output_height_size,
@@ -88,7 +101,7 @@ TfLiteStatus PackOpBuilder::PopulateSubGraph(const TfLiteIntArray* inputs,
   // Output min/max for requantization.
   float output_min, output_max;
   TF_LITE_ENSURE_STATUS(ComputeMinAndMaxQuantValues(
-      context->tensors[outputs->data[0]], &output_min, &output_max));
+      context->tensors[output_tensor_id], &output_min, &output_max));
   auto* output_min_const = graph_builder_->AddConstNodeWithData(
       kScalarShape, reinterpret_cast<char*>(&output_min), sizeof(output_min));
   auto* output_max_const = graph_builder_->AddConstNodeWithData(
@@ -116,6 +129,8 @@ TfLiteStatus PackOpBuilder::PopulateSubGraph(const TfLiteIntArray* inputs,
 
 TfLiteStatus PackOpBuilder::RegisterOutputs(const TfLiteIntArray* outputs,
                                             TfLiteContext* context) {
+  TF_LITE_ENSURE(context, outputs != nullptr);
+  TF_LITE_ENSURE(context, outputs->size >= 1);
   // Should be only 1 output.
   graph_builder_->AddTensorWithID(outputs->data[0], node_output_.first,
                                   node_output_.second);

--- a/tensorflow/lite/delegates/hexagon/utils.cc
+++ b/tensorflow/lite/delegates/hexagon/utils.cc
@@ -238,6 +238,10 @@ bool IsNodeSupportedByHexagon(const TfLiteRegistration* registration,
                   kTfLiteFullyConnectedWeightsFormatDefault);
     }
     case kTfLiteBuiltinConcatenation: {
+      // Requires at least one input and one output tensor.
+      if (node->inputs == nullptr || node->outputs == nullptr ||
+          node->inputs->size < 1 || node->outputs->size < 1)
+        return false;
       // All concatenated tensors must be 8-bit.
       for (int i = 0; i < node->inputs->size; ++i) {
         if (!TensorTypeMatch(node->inputs->data[i], context, kTfLiteUInt8) &&
@@ -438,6 +442,10 @@ bool IsNodeSupportedByHexagon(const TfLiteRegistration* registration,
                                      {kTfLiteInt32, kTfLiteInt64}});
     }
     case kTfLiteBuiltinPack: {
+      // Requires at least one input and one output tensor.
+      if (node->inputs == nullptr || node->outputs == nullptr ||
+          node->inputs->size < 1 || node->outputs->size < 1)
+        return false;
       // All tensors must be 8-bit.
       for (int i = 0; i < node->inputs->size; ++i) {
         if (!TensorTypeMatch(node->inputs->data[i], context, kTfLiteUInt8) &&

--- a/tensorflow/lite/delegates/hexagon/utils_test.cc
+++ b/tensorflow/lite/delegates/hexagon/utils_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 #include "tensorflow/lite/delegates/hexagon/utils.h"
 
 #include <gtest/gtest.h>
+#include "tensorflow/lite/builtin_ops.h"
 #include "tensorflow/lite/core/c/common.h"
 
 namespace tflite {
@@ -62,6 +63,63 @@ TEST(UtilsTest, Get4DShapeTest_5DInput) {
       kTfLiteError);
 
   TfLiteIntArrayFree(shape_5d);
+}
+
+// Regression test for the out-of-bounds access fixed in this change:
+// IsNodeSupportedByHexagon must reject CONCATENATION and PACK nodes that have
+// zero input or output tensors (which previously led to OOB reads in the
+// Concat/Pack builders).
+TEST(UtilsTest, ConcatAndPackEmptyInputsOrOutputsRejected) {
+  TfLiteContext context = {};
+  TfLiteRegistration reg = {};
+  TfLiteNode node = {};
+
+  TfLiteIntArray* empty_inputs = TfLiteIntArrayCreate(0);
+  TfLiteIntArray* empty_outputs = TfLiteIntArrayCreate(0);
+  TfLiteIntArray* valid_inputs = TfLiteIntArrayCreate(1);
+  valid_inputs->data[0] = 0;
+  TfLiteIntArray* valid_outputs = TfLiteIntArrayCreate(1);
+  valid_outputs->data[0] = 1;
+
+  TfLiteTensor tensors[2] = {};
+  TfLiteIntArray* dims = TfLiteIntArrayCreate(2);
+  dims->data[0] = 2;
+  dims->data[1] = 2;
+  tensors[0].dims = dims;
+  tensors[0].type = kTfLiteUInt8;
+  tensors[1].dims = dims;
+  tensors[1].type = kTfLiteUInt8;
+
+  context.tensors = tensors;
+  context.tensors_size = 2;
+
+  reg.version = 1;
+
+  for (const int builtin_code :
+       {kTfLiteBuiltinConcatenation, kTfLiteBuiltinPack}) {
+    reg.builtin_code = builtin_code;
+
+    // Empty inputs -> rejected.
+    node.inputs = empty_inputs;
+    node.outputs = valid_outputs;
+    EXPECT_FALSE(IsNodeSupportedByHexagon(&reg, &node, &context));
+
+    // Empty outputs -> rejected.
+    node.inputs = valid_inputs;
+    node.outputs = empty_outputs;
+    EXPECT_FALSE(IsNodeSupportedByHexagon(&reg, &node, &context));
+
+    // Valid inputs and outputs -> accepted.
+    node.inputs = valid_inputs;
+    node.outputs = valid_outputs;
+    EXPECT_TRUE(IsNodeSupportedByHexagon(&reg, &node, &context));
+  }
+
+  TfLiteIntArrayFree(empty_inputs);
+  TfLiteIntArrayFree(empty_outputs);
+  TfLiteIntArrayFree(valid_inputs);
+  TfLiteIntArrayFree(valid_outputs);
+  TfLiteIntArrayFree(dims);
 }
 
 }  // namespace


### PR DESCRIPTION
### What

`ConcatOpBuilder` and `PackOpBuilder` in the Hexagon delegate dereference
`inputs->data[0]` / `outputs->data[0]` without verifying that the operator's
input/output vectors are non-empty.

For most ops, `IsNodeSupportedByHexagon` pins the operand count (via
`InputsWithCorrectTypes` or an explicit size check), so a malformed arity is
rejected before the builder runs. For `CONCATENATION` and `PACK`, the support
check only iterates a size-bounded type loop and returns `true` — it never
requires a minimum number of inputs or outputs. `Subgraph::CheckTensorIndices`
at model load only validates indices that are present, so it does not enforce a
count either.

As a result, a model whose `PACK` op carries an empty `inputs` vector, or whose
`CONCATENATION` op carries an empty `outputs` vector, reaches the builder:

- `concat_builder.cc`: `context->tensors[outputs->data[0]].dims->size` reads past
  the end of a zero-length `TfLiteIntArray`.
- `pack_builder.cc` (`GetAxis`): `context->tensors[inputs->data[0]]` does the same.

The out-of-bounds value is then used to index `context->tensors[...]`, a second
out-of-bounds access. These builders run host-side during
`ModifyGraphWithDelegate`.

### Fix

- `concat_builder.cc` / `pack_builder.cc`: add `TF_LITE_ENSURE` non-null,
  minimum-size and tensor-id bounds checks before the `data[0]` dereferences,
  following the pattern of the recent `ArithmeticOpBuilder` fix. `GetAxis` now
  takes an already-validated tensor id.
- `utils.cc`: `IsNodeSupportedByHexagon` rejects `CONCATENATION` / `PACK` nodes
  with fewer than one input or output, so malformed nodes are not delegated.

No functional change for valid models.
