### PR TITLE
Fix tf.math.erfinv returning inf for inputs near +/-1

### DIFF
--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -728,17 +728,27 @@ struct functor_traits<xdivy_op<Scalar>> {
 template <typename T>
 struct scalar_erfinv_op {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE T operator()(const T& x) const {
+    // erfinv(x) = sqrt(1/2) * ndtri((1 + x) / 2). Forming (1 + x) / 2 directly
+    // loses precision near |x| == 1: for the largest-magnitude input below 1 it
+    // rounds to exactly 1 (or 0), and ndtri(1) is +inf, so erfinv would wrongly
+    // return +/-inf. Using the odd symmetry of erfinv together with the
+    // identity ndtri(p) = -ndtri(1 - p), feed ndtri the small tail probability
+    // (1 - |x|) / 2 instead, which stays representable (exact by Sterbenz for
+    // |x| in [1/2, 1]) and keeps the result finite.
     constexpr T half = T(0.5);
-    T y = numext::ndtri(half * x + half);
     constexpr T half_sqrt = T(M_SQRT1_2);
-    return y * half_sqrt;
+    const T tail = half * (T(1) - numext::abs(x));
+    const T magnitude = -half_sqrt * numext::ndtri(tail);
+    return numext::copysign(magnitude, x);
   }
   template <typename Packet>
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet packetOp(const Packet& x) const {
-    Packet half = pset1<Packet>(T(0.5));
-    Packet y = pndtri<Packet>(pmadd(half, x, half));
-    Packet half_sqrt = pset1<Packet>(T(M_SQRT1_2));
-    return pmul(y, half_sqrt);
+    const Packet half = pset1<Packet>(T(0.5));
+    const Packet one = pset1<Packet>(T(1));
+    const Packet neg_half_sqrt = pset1<Packet>(T(-M_SQRT1_2));
+    const Packet tail = pmul(half, psub(one, pabs(x)));
+    const Packet magnitude = pmul(neg_half_sqrt, pndtri<Packet>(tail));
+    return pselect(pcmp_lt(x, pzero(x)), pnegate(magnitude), magnitude);
   }
 };
 

--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -739,7 +739,9 @@ struct scalar_erfinv_op {
     constexpr T half_sqrt = T(M_SQRT1_2);
     const T tail = half * (T(1) - numext::abs(x));
     const T magnitude = -half_sqrt * numext::ndtri(tail);
-    return numext::copysign(magnitude, x);
+    // Restore the sign via odd symmetry (mirrors the packet path); avoids
+    // numext::copysign, which is absent in the pinned Eigen.
+    return x < T(0) ? -magnitude : magnitude;
   }
   template <typename Packet>
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet packetOp(const Packet& x) const {

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -247,9 +247,8 @@ class UnaryOpTest(test.TestCase):
     # the result stays finite.
     try:
       from scipy import special  # pylint: disable=g-import-not-at-top
-    except ImportError as e:
-      tf_logging.warn("Cannot test erfinv edge cases: %s" % str(e))
-      return
+    except ImportError:
+      self.skipTest("scipy is not installed")
     for dtype in (np.float32, np.float64):
       x = np.array([
           np.nextafter(dtype(1.0), dtype(0.0)),
@@ -261,7 +260,7 @@ class UnaryOpTest(test.TestCase):
           dtype(-0.99),
       ], dtype=dtype)
       with self.cached_session(use_gpu=False):
-        tf_ans = self.evaluate(math_ops.erfinv(ops.convert_to_tensor(x)))
+        tf_ans = self.evaluate(math_ops.erfinv(x))
       self.assertTrue(
           np.all(np.isfinite(tf_ans)),
           msg="erfinv produced non-finite output for %s: %s" % (dtype, tf_ans))

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -239,6 +239,34 @@ class UnaryOpTest(test.TestCase):
     self._compareBothSparse(y, np.sign, math_ops.sign)
     self._compareBothSparse(x, np.vectorize(math.erf), math_ops.erf)
 
+  def testErfinvEdge(self):
+    # Regression test for GitHub issue #121502: erfinv returned +/-inf for the
+    # largest-magnitude finite inputs below 1. The intermediate (1 + x) / 2
+    # rounds to exactly 1.0 (or 0.0) there, and ndtri(1.0) is +inf. The fix
+    # reformulates erfinv to feed ndtri the small tail probability instead, so
+    # the result stays finite.
+    try:
+      from scipy import special  # pylint: disable=g-import-not-at-top
+    except ImportError as e:
+      tf_logging.warn("Cannot test erfinv edge cases: %s" % str(e))
+      return
+    for dtype in (np.float32, np.float64):
+      x = np.array([
+          np.nextafter(dtype(1.0), dtype(0.0)),
+          np.nextafter(dtype(-1.0), dtype(0.0)),
+          dtype(0.0),
+          dtype(0.5),
+          dtype(-0.5),
+          dtype(0.99),
+          dtype(-0.99),
+      ], dtype=dtype)
+      with self.cached_session(use_gpu=False):
+        tf_ans = self.evaluate(math_ops.erfinv(ops.convert_to_tensor(x)))
+      self.assertTrue(
+          np.all(np.isfinite(tf_ans)),
+          msg="erfinv produced non-finite output for %s: %s" % (dtype, tf_ans))
+      self.assertAllClose(special.erfinv(x), tf_ans, rtol=1e-5, atol=1e-5)
+
   @test_util.run_deprecated_v1
   def testFloatTanhEdge(self):
     x = np.arange(40, 40 + 6).reshape(6).astype(np.float32)


### PR DESCRIPTION
Fixes #121502.

## Problem

`tf.math.erfinv` returns `inf` for the largest float32 value below 1.0. For example, `erfinv(np.nextafter(np.float32(1.0), np.float32(0.0)))` returns `inf` instead of the finite `~3.8325071`. The same bug affects `float64`.

## Root cause

The functor computes `erfinv(x) = sqrt(1/2) * ndtri((1 + x) / 2)`. For the largest-magnitude finite inputs below 1, the intermediate `(1 + x) / 2` rounds to **exactly** `1.0` (there is no representable float between `nextafter(1, 0)` and `1.0`), and `ndtri(1.0)` is `+inf`. The same happens near `-1` where the argument rounds to `0.0`.

## Fix

Reformulate `scalar_erfinv_op` (in `tensorflow/core/kernels/cwise_ops.h`) using the odd symmetry of `erfinv` and the identity `ndtri(p) = -ndtri(1 - p)`, feeding `ndtri` the small tail probability `(1 - |x|) / 2`:

- `tail = 0.5 * (1 - |x|)` — stays representable (exact by Sterbenz for `|x|` in `[1/2, 1]`), so it never collapses to `0` or `1`.
- `magnitude = -sqrt(1/2) * ndtri(tail)` — finite.
- restore the sign with `copysign(magnitude, x)` (packet path uses `pselect(pcmp_lt(x, 0), -magnitude, magnitude)`).

The reformulation is algebraically identical to the original everywhere it was already correct, so bulk values are unchanged; it only repairs the degenerate endpoints. Both the scalar and packet paths are updated and the fix applies to `float` and `double`.

## Test

Adds `testErfinvEdge` in `cwise_ops_unary_test.py`, covering `nextafter(+/-1, 0)` and bulk values (`0`, `+/-0.5`, `+/-0.99`) for both `float32` and `float64`, asserting outputs are finite and close to `scipy.special.erfinv`. Gradient checking is intentionally omitted because `erfinv` derivative diverges at `+/-1`.

## Validation

No local Bazel build environment, so correctness of the exact functor arithmetic was verified by simulating it in NumPy (same float32/float64 rounding, `scipy` `ndtri`) against `scipy.special.erfinv` for all test points — all finite and within tolerance. Relying on CI for the full build/test.