### PR TITLE
Validate the index in TensorListSetItem to prevent a segfault

### DIFF
--- a/tensorflow/core/kernels/list_kernels.cc
+++ b/tensorflow/core/kernels/list_kernels.cc
@@ -476,13 +476,25 @@ class TensorListSetItem : public OpKernel {
     TensorList* output_list = nullptr;
     OP_REQUIRES_OK(c, ForwardInputOrCreateNewList(c, 0, 0, *l, &output_list));
     int32_t index = c->input(1).scalar<int32_t>()();
+    OP_REQUIRES(c, index >= 0,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "Trying to modify element ", index,
+                    " in a list, but the index must be non-negative.")));
+    // Enforce the capacity cap, as TensorListPushBack does.
+    OP_REQUIRES(c, l->max_num_elements == -1 || index < l->max_num_elements,
+                absl::InvalidArgumentError(absl::StrCat(
+                    "Trying to modify element ", index,
+                    " in a list with max_num_elements ", l->max_num_elements,
+                    ".")));
     if (!resize_if_index_out_of_bounds_) {
       OP_REQUIRES(c, index < l->tensors().size(),
                   absl::InvalidArgumentError(absl::StrCat(
                       "Trying to modify element ", index, " in a list with ",
                       l->tensors().size(), " elements.")));
     } else if (index >= l->tensors().size()) {
-      output_list->tensors().resize(index + 1, Tensor(DT_INVALID));
+      // size_t cast avoids signed overflow when index == INT32_MAX.
+      output_list->tensors().resize(static_cast<size_t>(index) + 1,
+                                    Tensor(DT_INVALID));
     }
     output_list->tensors()[index] = value;
   }

--- a/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/list_ops_test.py
@@ -1015,6 +1015,28 @@ class ListOpsTest(test_util.TensorFlowTestCase, parameterized.TestCase):
       self.evaluate(list_ops.tensor_list_set_item(l, 20, 3.0))
 
   @test_util.run_deprecated_v1
+  def testSetItemWithOutOfRangeIndexFails(self):
+    # Regression test for #105302: a negative index used to segfault instead
+    # of raising, even with resize_if_index_out_of_bounds=True.
+    l = list_ops.empty_tensor_list(
+        element_dtype=dtypes.float32, element_shape=[], max_num_elements=5)
+    with self.assertRaises(errors.InvalidArgumentError):
+      self.evaluate(
+          gen_list_ops.tensor_list_set_item(
+              input_handle=l,
+              index=-1,
+              item=constant_op.constant(1.0),
+              resize_if_index_out_of_bounds=True))
+    # An index >= max_num_elements must not resize past capacity.
+    with self.assertRaises(errors.InvalidArgumentError):
+      self.evaluate(
+          gen_list_ops.tensor_list_set_item(
+              input_handle=l,
+              index=5,
+              item=constant_op.constant(1.0),
+              resize_if_index_out_of_bounds=True))
+
+  @test_util.run_deprecated_v1
   def testSkipEagerSetItemWithMismatchedShapeFails(self):
     with self.cached_session() as sess:
       ph = array_ops.placeholder(dtypes.float32)

--- a/tensorflow/python/kernel_tests/data_structures/tensor_array_ops_test.py
+++ b/tensorflow/python/kernel_tests/data_structures/tensor_array_ops_test.py
@@ -501,7 +501,8 @@ class TensorArrayTest(test.TestCase):
 
       if (control_flow_util.ENABLE_CONTROL_FLOW_V2 and
           not context.executing_eagerly()):
-        error_msg = "Trying to modify element -1 in a list with 3 elements."
+        error_msg = ("Trying to modify element -1 in a list, but the index "
+                     "must be non-negative.")
       else:
         error_msg = "index -1"
       with self.assertRaisesOpError(error_msg):


### PR DESCRIPTION
Fixes #105302.

### Problem

`tf.raw_ops.TensorListSetItem` segfaults when given an out-of-range index. The reproducer passes `index = 9223372036854775807` (`INT64_MAX`) with `dtype=tf.int32`, which truncates/wraps to `-1`:

```python
import tensorflow as tf
l = tf.raw_ops.EmptyTensorList(element_dtype=tf.float32,
                               element_shape=tf.TensorShape([2]),
                               max_num_elements=5)
idx = tf.constant(9223372036854775807, dtype=tf.int32)  # -> -1
tf.raw_ops.TensorListSetItem(input_handle=l, index=idx,
                             item=tf.constant([1.0, 2.0]),
                             resize_if_index_out_of_bounds=True)  # segfault
```

The kernel read `index` as `int32` and used it without validation. The comparison `index >= l->tensors().size()` promotes the negative `index` to `size_t` (a huge value), so the resize branch is taken, and then `tensors()[index]` indexes out of bounds → segmentation fault. A very large positive index is also problematic: it would resize the list to an enormous size, exceeding the list's declared capacity and risking OOM.

### Fix

Validate the index before using it:

- Reject negative indices with `InvalidArgument` instead of indexing out of bounds. This also makes the existing `index < size()` / `index >= size()` comparisons well-defined (the operand is now guaranteed non-negative).
- Reject indices that would grow a bounded list past `max_num_elements`, mirroring the existing capacity check in `TensorListPushBack`. This keeps `SetItem` consistent with the rest of the TensorList ops and avoids unbounded allocation for very large indices.
- In the resize path, cast to `size_t` before adding 1 (`static_cast<size_t>(index) + 1`) to avoid signed integer overflow when `index == INT32_MAX`.

Added a regression test (`testSetItemWithOutOfRangeIndexFails`) covering both a negative index and an index at `max_num_elements`, which now raise `InvalidArgumentError` instead of crashing.