### PR TITLE
Decode float8 e4m3fnuz/e4m3b11fnuz/e5m2fnuz scalars in MakeNdarray

### DIFF
--- a/tensorflow/python/framework/tensor_util.py
+++ b/tensorflow/python/framework/tensor_util.py
@@ -320,6 +320,15 @@ else:
       dtypes.float8_e4m3fn.as_numpy_dtype: (
           SlowAppendFloat8e4m3fnArrayToTensorProto
       ),
+      dtypes.float8_e4m3fnuz.as_numpy_dtype: (
+          SlowAppendFloat8e4m3fnuzArrayToTensorProto
+      ),
+      dtypes.float8_e4m3b11fnuz.as_numpy_dtype: (
+          SlowAppendFloat8e4m3b11fnuzArrayToTensorProto
+      ),
+      dtypes.float8_e5m2fnuz.as_numpy_dtype: (
+          SlowAppendFloat8e5m2fnuzArrayToTensorProto
+      ),
       dtypes.float4_e2m1fn.as_numpy_dtype: (
           SlowAppendFloat4e2m1fnArrayToTensorProto
       ),
@@ -806,6 +815,9 @@ def MakeNdarray(tensor):
   elif tensor_dtype in [
       dtypes.float8_e5m2,
       dtypes.float8_e4m3fn,
+      dtypes.float8_e4m3fnuz,
+      dtypes.float8_e4m3b11fnuz,
+      dtypes.float8_e5m2fnuz,
       dtypes.float4_e2m1fn
   ]:
     values = np.fromiter(tensor.float8_val, dtype=np.uint8)

--- a/tensorflow/python/framework/tensor_util_test.py
+++ b/tensorflow/python/framework/tensor_util_test.py
@@ -375,6 +375,33 @@ class TensorUtilTest(test.TestCase, parameterized.TestCase):
         t,
     )
 
+  def testFloat8e4m3fnuzScalarRoundTrip(self):
+    test_type = dtypes.float8_e4m3fnuz.as_numpy_dtype
+    # A scalar stores the value in float8_val (a multi-element array would use
+    # tensor_content and hide the decode gap).
+    t = tensor_util.make_tensor_proto(np.array(10.0, dtype=test_type))
+    a = tensor_util.MakeNdarray(t)
+    self.assertEqual(test_type, a.dtype)
+    self.assertAllClose(np.array(10.0, dtype=test_type), a)
+
+  def testFloat8e4m3b11fnuzScalarRoundTrip(self):
+    test_type = dtypes.float8_e4m3b11fnuz.as_numpy_dtype
+    # A scalar stores the value in float8_val (a multi-element array would use
+    # tensor_content and hide the decode gap).
+    t = tensor_util.make_tensor_proto(np.array(10.0, dtype=test_type))
+    a = tensor_util.MakeNdarray(t)
+    self.assertEqual(test_type, a.dtype)
+    self.assertAllClose(np.array(10.0, dtype=test_type), a)
+
+  def testFloat8e5m2fnuzScalarRoundTrip(self):
+    test_type = dtypes.float8_e5m2fnuz.as_numpy_dtype
+    # A scalar stores the value in float8_val (a multi-element array would use
+    # tensor_content and hide the decode gap).
+    t = tensor_util.make_tensor_proto(np.array(10.0, dtype=test_type))
+    a = tensor_util.MakeNdarray(t)
+    self.assertEqual(test_type, a.dtype)
+    self.assertAllClose(np.array(10.0, dtype=test_type), a)
+
   def testFloat4e2m1fn(self):
     test_type = dtypes.float4_e2m1fn.as_numpy_dtype
     t = tensor_util.make_tensor_proto(np.array([6, 0.5], dtype=test_type))


### PR DESCRIPTION
`tf.make_ndarray` (`tensor_util.MakeNdarray`) raises `TypeError: Unsupported tensor type` when decoding a scalar of the three "fnuz" float8 dtypes: `float8_e4m3fnuz`, `float8_e4m3b11fnuz`, `float8_e5m2fnuz`.

A scalar (or single-element) value is stored in the proto's `float8_val` field, but the `float8_val` decode branch in `MakeNdarray` only lists three of the six small-float dtypes (`float8_e5m2`, `float8_e4m3fn`, `float4_e2m1fn`), so the three fnuz dtypes fall through to the final `else` and raise. Multi-element tensors are unaffected because they serialize through `tensor_content`, which is why this stayed hidden (the existing fnuz tests use 2-element arrays and never call `MakeNdarray`).

The pure-Python `_NP_TO_APPEND_FN` fallback has the same omission on the encode side, while the compiled fast path and `_TENSOR_CONTENT_TYPES` already list all six.

Changes (only `tensor_util.py` and its test):
- add the three fnuz dtypes to the `MakeNdarray` `float8_val` decode branch.
- add them to the slow `_NP_TO_APPEND_FN` registration (the `SlowAppendFloat8e4m3fnuz*` helpers already exist), so the pure-Python encode path matches the fast path.
- add scalar round-trip tests for the three dtypes (a scalar is required to exercise the `float8_val` path; a multi-element array would use `tensor_content` and miss the gap).

Repro:
```python
import numpy as np
import tensorflow as tf
from tensorflow.python.framework import tensor_util, dtypes
t = tensor_util.make_tensor_proto(np.array(10.0, dtype=dtypes.float8_e4m3fnuz.as_numpy_dtype))
tensor_util.MakeNdarray(t)
# TypeError: Unsupported tensor type: 25. See https://www.tensorflow.org/api_docs/python/tf/dtypes ...
```

Fixes #121711
