### PR TITLE
docs: update PJRT plugin README to use kCpuPjrtName

### DIFF
--- a/third_party/xla/xla/pjrt/plugin/README.md
+++ b/third_party/xla/xla/pjrt/plugin/README.md
@@ -44,7 +44,7 @@ There are two primary ways to integrate a PJRT plugin into your application:
     *   **Example (Conceptual):**
 
         ```c++
-        const char* plugin_name = PJRT_PLUGIN_NAME_CPU;
+        const char* plugin_name = kCpuPjrtName;
         // Or another name from plugin_names.h
 
         absl::StatusOr<std::unique_ptr<PjrtClient>> client =


### PR DESCRIPTION
### What changed

Fixes #119584 (partially — PJRT README part).

The PJRT plugin README example used `PJRT_PLUGIN_NAME_CPU`, which was replaced by `kCpuPjrtName` in `plugin_names.h` (introduced in commit ed770aaa). The old constant no longer exists, making the example misleading for anyone trying to follow the documentation.

**Change:** One line in `third_party/xla/xla/pjrt/plugin/README.md` — replace `PJRT_PLUGIN_NAME_CPU` with `kCpuPjrtName` to match the current definition in `plugin_names.h`.

### Why

Stale constant name in an example confuses contributors and users trying to use the PJRT plugin API. The fix aligns the documentation with the actual source code.