### PR TITLE
docs: remove stale Java/JNI section from lib_package README

### DIFF
--- a/tensorflow/tools/lib_package/README.md
+++ b/tensorflow/tools/lib_package/README.md
@@ -24,30 +24,6 @@ distributed and installed using something like:
 tar -C /usr/local -xzf libtensorflow.tar.gz
 ```
 
-## Java library
-
-The TensorFlow [Java
-API](https://www.tensorflow.org/code/tensorflow/java/README.md)
-consists of a native library (`libtensorflow_jni.so`) and a Java archive (JAR).
-The following commands:
-
-```sh
-bazel test --config opt //tensorflow/tools/lib_package:libtensorflow_test
-bazel build --config opt \
-  //tensorflow/tools/lib_package:libtensorflow_jni.tar.gz \
-  //tensorflow/java:libtensorflow.jar \
-  //tensorflow/java:libtensorflow-src.jar
-```
-
-test and produce the following:
-
--   The native library (`libtensorflow_jni.so`) packaged in an archive at:
-    `bazel-bin/tensorflow/tools/lib_package/libtensorflow_jni.tar.gz`
--   The Java archive at:
-    `bazel-bin/tensorflow/java/libtensorflow.jar`
--   The Java archive for Java sources at:
-    `bazel-bin/tensorflow/java/libtensorflow-src.jar`
-
 ## Release
 
 Scripts to build these archives for TensorFlow releases are in


### PR DESCRIPTION
### What changed

Fixes #119584 (partially — lib_package README part).

The `tensorflow/tools/lib_package/README.md` contained a `## Java library` section documenting how to build `libtensorflow_jni.tar.gz`, `libtensorflow.jar`, and `libtensorflow-src.jar`. The corresponding Bazel targets (`//tensorflow/java:libtensorflow.jar`, etc.) were removed in commit 0ba4a4f4, so this section now documents targets that do not exist.

**Change:** Remove the 23-line `## Java library` section entirely. The `## C library` and `## Release` sections are unaffected.

### Why

Documentation pointing to removed Bazel targets causes build failures and confusion for anyone following the guide. Removing the stale section is cleaner than leaving misleading instructions.