### PR TITLE
Fix crash in SparseApplyMomentum with a grad of mismatched rank

### DIFF
--- a/tensorflow/core/kernels/training_ops.cc
+++ b/tensorflow/core/kernels/training_ops.cc
@@ -1259,6 +1259,9 @@ class SparseApplyAdadeltaOp : public OpKernel {
     OP_REQUIRES(ctx, TensorShapeUtils::IsVector(indices.shape()),
                 absl::InvalidArgumentError("indices must be one-dimensional"));
 
+    OP_REQUIRES(ctx, grad.dims() == var.dims(),
+                absl::InvalidArgumentError("grad must have the same number of "
+                                           "dimensions as var"));
     for (int d = 1; d < var.dims(); d++) {
       OP_REQUIRES(ctx, var.dim_size(d) == grad.dim_size(d),
                   absl::InvalidArgumentError(absl::StrCat(
@@ -1468,6 +1471,9 @@ class SparseApplyProximalGradientDescentOp : public OpKernel {
     OP_REQUIRES(ctx, TensorShapeUtils::IsVector(indices.shape()),
                 absl::InvalidArgumentError("indices must be one-dimensional"));
 
+    OP_REQUIRES(ctx, grad.dims() == var.dims(),
+                absl::InvalidArgumentError("grad must have the same number of "
+                                           "dimensions as var"));
     int64_t inner_dim = 1;
     for (int d = 1; d < var.dims(); d++) {
       OP_REQUIRES(ctx, var.dim_size(d) == grad.dim_size(d),
@@ -2228,6 +2234,9 @@ class SparseApplyProximalAdagradOp : public OpKernel {
     OP_REQUIRES(ctx, TensorShapeUtils::IsVector(indices.shape()),
                 absl::InvalidArgumentError("indices must be one-dimensional"));
 
+    OP_REQUIRES(ctx, grad.dims() == var.dims(),
+                absl::InvalidArgumentError("grad must have the same number of "
+                                           "dimensions as var"));
     int64_t inner_dim = 1;
     for (int d = 1; d < var.dims(); d++) {
       OP_REQUIRES(ctx, var.dim_size(d) == grad.dim_size(d),
@@ -2488,6 +2497,9 @@ class SparseApplyAdagradDAOp : public OpKernel {
                     absl::StrCat("global_step is not a scalar: ",
                                  global_step.shape().DebugString())));
 
+    OP_REQUIRES(ctx, grad.dims() == var.dims(),
+                absl::InvalidArgumentError("grad must have the same number of "
+                                           "dimensions as var"));
     int64_t inner_dim = 1;
     for (int d = 1; d < var.dims(); d++) {
       OP_REQUIRES(ctx, var.dim_size(d) == grad.dim_size(d),
@@ -2922,6 +2934,9 @@ class SparseApplyFtrlOp : public OpKernel {
                     absl::StrCat("lr_power is not a "
                                  "non-positive scalar: ",
                                  lr_power.shape().DebugString())));
+    OP_REQUIRES(ctx, grad.dims() == var.dims(),
+                absl::InvalidArgumentError("grad must have the same number of "
+                                           "dimensions as var"));
     int64_t inner_dim = 1;
     for (int d = 1; d < var.dims(); d++) {
       OP_REQUIRES(ctx, var.dim_size(d) == grad.dim_size(d),
@@ -3243,6 +3258,9 @@ class SparseApplyMomentumOp : public OpKernel {
     OP_REQUIRES(ctx, TensorShapeUtils::IsVector(indices.shape()),
                 absl::InvalidArgumentError("indices must be one-dimensional"));
 
+    OP_REQUIRES(ctx, grad.dims() == var.dims(),
+                absl::InvalidArgumentError("grad must have the same number of "
+                                           "dimensions as var"));
     for (int d = 1; d < var.dims(); d++) {
       OP_REQUIRES(ctx, var.dim_size(d) == grad.dim_size(d),
                   absl::InvalidArgumentError(absl::StrCat(
@@ -3465,6 +3483,9 @@ class SparseApplyKerasMomentumOp : public OpKernel {
     OP_REQUIRES(ctx, TensorShapeUtils::IsVector(indices.shape()),
                 absl::InvalidArgumentError("indices must be one-dimensional"));
 
+    OP_REQUIRES(ctx, grad.dims() == var.dims(),
+                absl::InvalidArgumentError("grad must have the same number of "
+                                           "dimensions as var"));
     for (int d = 1; d < var.dims(); d++) {
       OP_REQUIRES(ctx, var.dim_size(d) == grad.dim_size(d),
                   absl::InvalidArgumentError(absl::StrCat(
@@ -4266,6 +4287,9 @@ class SparseApplyRMSPropOp : public OpKernel {
     const Tensor& epsilon = ctx->input(6);
     const Tensor& grad = ctx->input(7);
     const Tensor& indices = ctx->input(8);
+    OP_REQUIRES(ctx, grad.dims() == var.dims(),
+                absl::InvalidArgumentError("grad must have the same number of "
+                                           "dimensions as var"));
 
     OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(lr.shape()),
                 absl::InvalidArgumentError(absl::StrCat(
@@ -4403,6 +4427,9 @@ class SparseApplyCenteredRMSPropOp : public OpKernel {
     const Tensor& epsilon = ctx->input(7);
     const Tensor& grad = ctx->input(8);
     const Tensor& indices = ctx->input(9);
+    OP_REQUIRES(ctx, grad.dims() == var.dims(),
+                absl::InvalidArgumentError("grad must have the same number of "
+                                           "dimensions as var"));
 
     OP_REQUIRES(ctx, TensorShapeUtils::IsScalar(lr.shape()),
                 absl::InvalidArgumentError(absl::StrCat(

--- a/tensorflow/python/_pywrap_tensorflow.def
+++ b/tensorflow/python/_pywrap_tensorflow.def
@@ -405,6 +405,7 @@ EXPORTS
  ?GetOutputString@StatsCalculator@tsl@@QEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ
  ?GetParameterLayouts@PjRtExecutable@xla@@UEBA?AV?$StatusOr@V?$vector@V?$shared_ptr@$$CBVPjRtLayout@xla@@@std@@V?$allocator@V?$shared_ptr@$$CBVPjRtLayout@xla@@@std@@@2@@std@@@lts_20260107@absl@@XZ
  ?GetParameterShardings@PjRtExecutable@xla@@UEBA?AV?$optional@V?$vector@VOpSharding@xla@@V?$allocator@VOpSharding@xla@@@std@@@std@@@std@@XZ
+ ?GetPythonAPIMaxIndex@tensorflow@@YAHAEBVPythonAPIInfo@1@@Z
  ?GetPythonWrappers@tensorflow@@YA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBD_K@Z
  ?GetRefForEmptyClass@container_internal@lts_20260107@absl@@YAPEAXAEAVCommonFields@123@@Z
  ?GetRegisteredOpConverters@tensorrt@tensorflow@@YA?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ

--- a/tensorflow/python/training/BUILD
+++ b/tensorflow/python/training/BUILD
@@ -1445,6 +1445,7 @@ distribute_py_strict_test(
         "//tensorflow/python/eager:def_function",
         "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:dtypes",
+        "//tensorflow/python/framework:errors",
         "//tensorflow/python/framework:ops",
         "//tensorflow/python/framework:test_lib",
         "//tensorflow/python/ops:math_ops",

--- a/tensorflow/python/training/training_ops_test.py
+++ b/tensorflow/python/training/training_ops_test.py
@@ -22,6 +22,7 @@ import numpy as np
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import test_util
 from tensorflow.python.framework.test_util import TensorFlowTestCase
@@ -505,6 +506,44 @@ class TrainingOpsTest(TensorFlowTestCase):
     thread2.start()
     thread1.join()
     thread2.join()
+
+  def testSparseApplyOpsRejectLowerRankGrad(self):
+    # Regression test for #94131: a grad of lower rank than var made the
+    # per-dimension shape check read past grad's rank and crash the process.
+    var, accum, accum2, accum3 = [
+        variables.Variable(np.ones((4, 4), np.float32)) for _ in range(4)
+    ]
+    self.evaluate(variables.global_variables_initializer())
+    s = np.float32(0.1)
+    grad = np.zeros(3, np.float32)  # rank 1, var is rank 2
+    idx = constant_op.constant([0, 1, 2], dtypes.int32)
+    g = gen_training_ops
+    cases = [
+        lambda: g.resource_sparse_apply_momentum(
+            var.handle, accum.handle, s, grad, idx, s),
+        lambda: g.resource_sparse_apply_keras_momentum(
+            var.handle, accum.handle, s, grad, idx, s),
+        lambda: g.resource_sparse_apply_adadelta(
+            var.handle, accum.handle, accum2.handle, s, s, s, grad, idx),
+        lambda: g.resource_sparse_apply_proximal_gradient_descent(
+            var.handle, s, s, s, grad, idx),
+        lambda: g.resource_sparse_apply_proximal_adagrad(
+            var.handle, accum.handle, s, s, s, grad, idx),
+        lambda: g.resource_sparse_apply_adagrad_da(
+            var.handle, accum.handle, accum2.handle, grad, idx, s, s, s,
+            np.int64(1)),
+        lambda: g.resource_sparse_apply_ftrl(
+            var.handle, accum.handle, accum2.handle, grad, idx, s, s, s,
+            np.float32(-0.5)),  # lr_power must be non-positive
+        lambda: g.resource_sparse_apply_rms_prop(
+            var.handle, accum.handle, accum2.handle, s, s, s, s, grad, idx),
+        lambda: g.resource_sparse_apply_centered_rms_prop(
+            var.handle, accum.handle, accum2.handle, accum3.handle, s, s, s, s,
+            grad, idx),
+    ]
+    for apply_op in cases:
+      with self.assertRaises(errors.InvalidArgumentError):
+        self.evaluate(apply_op())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #94131.

### Problem

`tf.raw_ops.ResourceSparseApplyMomentum` (and `SparseApplyMomentum`) crashes the process when `grad` has fewer dimensions than `var`:

```python
import numpy as np, tensorflow as tf
var = tf.Variable(np.zeros((6, 6), np.float32))
accum = tf.Variable(np.zeros((6, 6), np.float32))
tf.raw_ops.ResourceSparseApplyMomentum(
    var=var.handle, accum=accum.handle,
    lr=0.1, grad=tf.zeros([10]), indices=[0, 1, 2], momentum=0.9)  # crash
```

`SparseApplyMomentumOp::Compute` validates the per-dimension sizes of `grad` against `var` with a loop over `var.dims()`:

```cpp
for (int d = 1; d < var.dims(); d++) {
  OP_REQUIRES(ctx, var.dim_size(d) == grad.dim_size(d), ...);
}
```

but it never checks that `grad` has the same rank as `var` first. When `grad` is lower-rank, `grad.dim_size(d)` reads past `grad`'s rank and aborts the process.

### Fix

Add the same `grad.dims() == var.dims()` guard that the sibling sparse-apply kernels already perform before this loop (e.g. `SparseApplyProximalGradientDescentOp` and `SparseApplyAdagradOp` in the same file). This makes the subsequent `grad.dim_size(d)` accesses well-defined and turns the crash into an `InvalidArgument` error.

Added a regression test (`testResourceSparseApplyMomentumInvalidGradRank`).