### PR TITLE
[XLA] Fix Zeta(x, +inf) returning NaN instead of 0

### DIFF
--- a/third_party/xla/xla/hlo/builder/lib/math.cc
+++ b/third_party/xla/xla/hlo/builder/lib/math.cc
@@ -2143,8 +2143,20 @@ XlaOp Zeta(XlaOp x, XlaOp q) {
     const double inf = std::numeric_limits<double>::infinity();
     // Use the initial zeta sum without the correction term coming
     // from Euler-Maclaurin if it is accurate enough.
-    XlaOp output = Select(Lt(Abs(neg_power), Abs(S) * Epsilon(&builder, type)),
-                          S, accurate_result);
+    //
+    // When the running term `neg_power` has underflowed to exactly zero (for
+    // example when `q` is +inf, or `q` is so large that `pow(q, -x)`
+    // underflows), the Euler-Maclaurin correction is either zero or an
+    // indeterminate form: in particular `I = neg_power * acc / (x - 1)` becomes
+    // `0 * inf = NaN` for `q == +inf`, which poisons `accurate_result`. In that
+    // regime the partial sum `S` is already the answer, so fall back to it
+    // whenever `neg_power == 0`. This mirrors the `if (b == 0) return s;` guard
+    // in Eigen's CPU Cephes implementation and fixes `Zeta(x, +inf)` returning
+    // NaN instead of 0 on GPU (b/121501).
+    XlaOp use_series =
+        Or(Eq(neg_power, ScalarLike(neg_power, 0.)),
+           Lt(Abs(neg_power), Abs(S) * Epsilon(&builder, type)));
+    XlaOp output = Select(use_series, S, accurate_result);
 
     // This is the harmonic series.
     output = Select(Eq(x, ScalarLike(x, 1.)), ScalarLike(x, inf), output);

--- a/third_party/xla/xla/hlo/builder/lib/math_test.cc
+++ b/third_party/xla/xla/hlo/builder/lib/math_test.cc
@@ -842,5 +842,31 @@ TEST_F(MathTest, ZetaF64) {
                               ErrorSpec{0.00000000000001});
 }
 
+// Regression test for b/121501: for finite x > 1 and q -> +inf every term
+// (k + q)^-x is zero, so zeta(x, +inf) == 0. The Euler-Maclaurin correction
+// otherwise produces 0 * inf = NaN.
+TEST_F(MathTest, ZetaF64Infinity) {
+  const double inf = std::numeric_limits<double>::infinity();
+  XlaBuilder builder(TestName());
+  auto x = ConstantR1<double>(&builder, {2.0, 3.0, 2.0});
+  auto q = ConstantR1<double>(&builder, {inf, inf, 5.0});
+  Zeta(x, q);
+  std::vector<double> expected = {0.0, 0.0, 0.22132295573711525};
+
+  ComputeAndCompareR1<double>(&builder, expected, {},
+                              ErrorSpec{0.00000000000001});
+}
+
+TEST_F(MathTest, ZetaF32Infinity) {
+  const float inf = std::numeric_limits<float>::infinity();
+  XlaBuilder builder(TestName());
+  auto x = ConstantR1<float>(&builder, {2.0f, 3.0f});
+  auto q = ConstantR1<float>(&builder, {inf, inf});
+  Zeta(x, q);
+  std::vector<float> expected = {0.0f, 0.0f};
+
+  ComputeAndCompareR1<float>(&builder, expected, {}, ErrorSpec{1e-6});
+}
+
 }  // namespace
 }  // namespace xla


### PR DESCRIPTION
### Summary

Companion to the GPU fix for #121501 (`tf.math.zeta(s, +inf)` returns NaN instead of `0`). This fixes the same bug in XLA's C++ HLO builder `Zeta`, which is the `tf.function(jit_compile=True)` / tf2xla path.

ζ(s, q) = Σ_k (k+q)^-s → 0 as q → +∞ for s > 1, but the Euler–Maclaurin implementation returns NaN: the correction term `I = neg_power * acc / (x - 1)` evaluates to `0 * inf = NaN` when `q == +inf` (`neg_power` underflows to 0 while `acc` is `+inf`), and the "accurate enough" early-out `Abs(neg_power) < Abs(S) * Epsilon` is `false` when both `neg_power` and `S` are `0`, so the NaN `accurate_result` is selected instead of the partial sum `S` (= 0).

The eager-CPU path uses Eigen's Cephes zeta, which already guards this with `if (b == 0) return s;`. The eager-GPU path (StableHLO `materializeZeta`) is fixed in openxla/stablehlo#2957.

### Fix

Fall back to the partial sum `S` whenever `neg_power == 0`, mirroring Eigen's guard. Normal inputs are unaffected. Adds `ZetaF64Infinity` / `ZetaF32Infinity` regression tests.

### Verification

A float32 simulation of the exact algorithm: `zeta(2, inf)` and `zeta(3, inf)` go `nan → 0.0`; `zeta(2, 1) = π²/6`, `zeta(2, 5) = 0.2213230`, `zeta(4, 2.5) = 0.0373176` unchanged.

Note: not build-verified locally (XLA needs Bazel); please run `math_test` in CI.

