### PR TITLE
Fix int64-to-int32 truncation in StableHLO operator shape handling

### DIFF
--- a/tensorflow/lite/array.h
+++ b/tensorflow/lite/array.h
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include <cstring>
 #include <initializer_list>
+#include <limits>
 #include <memory>
 #include <type_traits>
 #include <vector>
@@ -102,6 +103,13 @@ TfLiteArrayUniquePtr<Type> BuildTfLiteArray(const int size,
       memcpy(array->data, values, size * sizeof(Type));
     } else {
       for (int i = 0; i < size; ++i) {
+        if (sizeof(Type) < sizeof(U) &&
+            (values[i] >
+                 static_cast<U>(std::numeric_limits<Type>::max()) ||
+             values[i] <
+                 static_cast<U>(std::numeric_limits<Type>::min()))) {
+          return {};
+        }
         array->data[i] = static_cast<Type>(values[i]);
       }
     }

--- a/tensorflow/lite/kernels/stablehlo_pad.cc
+++ b/tensorflow/lite/kernels/stablehlo_pad.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <numeric>
 
 #include "tensorflow/lite/c/c_api_types.h"
@@ -211,6 +212,12 @@ class PadData {
   }
 
   TfLiteIntArray* BuildOuputTensorDims() const {
+    for (int64_t i = 0; i < rank_; ++i) {
+      if (output_shape_[i] < 0 ||
+          output_shape_[i] > std::numeric_limits<int32_t>::max()) {
+        return nullptr;
+      }
+    }
     TfLiteIntArray* dims = TfLiteIntArrayCreate(rank_);
     for (int64_t i = 0; i < rank_; ++i) {
       dims->data[i] = output_shape_[i];
@@ -259,8 +266,10 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // Output tensor setup.
   TfLiteTensor* output_tensor = GetOutput(context, node, PadData::kOutput);
   TF_LITE_ENSURE(context, input_tensor->type == output_tensor->type);
-  context->ResizeTensor(context, output_tensor,
-                        pad_data.BuildOuputTensorDims());
+  TfLiteIntArray* output_dims = pad_data.BuildOuputTensorDims();
+  TF_LITE_ENSURE_MSG(context, output_dims != nullptr,
+                     "Output shape dimension exceeds int32 range.");
+  context->ResizeTensor(context, output_tensor, output_dims);
   return kTfLiteOk;
 }
 

--- a/tensorflow/lite/kernels/stablehlo_reduce_window.cc
+++ b/tensorflow/lite/kernels/stablehlo_reduce_window.cc
@@ -518,6 +518,13 @@ struct OpData {
   // Helper to resize a tensor.
   TfLiteStatus ResizeTensor(TfLiteTensor* const tensor,
                             const int64_t* const shape) {
+    for (int i = 0; i < rank; ++i) {
+      TF_LITE_ENSURE_MSG(
+          context,
+          shape[i] >= 0 &&
+              shape[i] <= std::numeric_limits<int32_t>::max(),
+          "Output shape dimension exceeds int32 range.");
+    }
     auto dims = BuildTfLiteArray<int32_t>(rank, shape);
     return context->ResizeTensor(context, tensor, dims.release());
   }
@@ -789,6 +796,14 @@ struct TFLiteData : public OpData {
         rank, input_dims, window_dimensions, window_strides, window_dilations);
 
     TfLiteTensor* const output_tensor = GetOutput(context, node, kOutput);
+    for (int i = 0; i < rank; ++i) {
+      TF_LITE_ENSURE_MSG(
+          context,
+          node_data.reduce_window_ctx.output_shape[i] >= 0 &&
+              node_data.reduce_window_ctx.output_shape[i] <=
+                  std::numeric_limits<int32_t>::max(),
+          "Output shape dimension exceeds int32 range.");
+    }
     return context->ResizeTensor(
         context, output_tensor,
         BuildTfLiteArray<int32_t>(rank,


### PR DESCRIPTION
### Summary

Add bounds checking for int64-to-int32 narrowing conversions in TF Lite's StableHLO operator shape handling. Without these checks, crafted models with large padding or dilation parameters can cause output shapes to silently truncate from int64 to int32, leading to undersized tensor allocations and heap buffer overflows.

### Changes

**`tensorflow/lite/array.h`**
- Add bounds validation in `BuildTfLiteArray` when performing narrowing type conversions (e.g., int64 to int32). Returns empty `unique_ptr` if any value exceeds the target type's range.

**`tensorflow/lite/kernels/stablehlo_reduce_window.cc`**
- Validate output shape dimensions against `INT32_MAX` in `OpData::ResizeTensor` before calling `BuildTfLiteArray<int32_t>`.
- Add the same validation in `TFLiteData::Setup` for the reduce_window output tensor.

**`tensorflow/lite/kernels/stablehlo_pad.cc`**
- Validate output shape dimensions in `PadData::BuildOuputTensorDims`, returning `nullptr` if any dimension exceeds int32 range.
- Check for `nullptr` in `Prepare` and return `kTfLiteError` with a descriptive message.

### Root Cause

`BuildTfLiteArray<int32_t>(rank, int64_shape)` uses `static_cast<int32_t>` for each element without verifying the value fits. When StableHLO operators compute output shapes as int64 (e.g., `(dim - 1) * dilation + 1`), large attacker-controlled parameters can produce values exceeding `INT32_MAX`. The truncated int32 value is used for allocation, but the original int64 value is used for memcpy operations, writing past the allocated buffer.

### Testing

Verified that loading a crafted `.tflite` model with `interior_padding = [4294967300]` now returns `kTfLiteError` during `allocate_tensors()` instead of crashing with SIGBUS.

Bug: 526539814