### PR TITLE
Introduce TFLITE_NO_SANITIZE_INTEGER_OVERFLOW macro

### DIFF
--- a/tensorflow/lite/core/macros.h
+++ b/tensorflow/lite/core/macros.h
@@ -65,4 +65,15 @@ limitations under the License.
 #define TFLITE_HAS_ATTRIBUTE_WEAK 0
 #endif
 
+// Disables UBSan's integer-overflow checks for an annotated function. Only use
+// this where the overflow merely yields a wrong numeric result and poses no
+// safety risk. Expands to nothing on compilers without the attribute.
+#if TFLITE_HAS_ATTRIBUTE(no_sanitize)
+#define TFLITE_NO_SANITIZE_INTEGER_OVERFLOW                                \
+  __attribute__((no_sanitize("signed-integer-overflow",                    \
+                             "unsigned-integer-overflow")))
+#else
+#define TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
+#endif
+
 #endif  // TENSORFLOW_LITE_CORE_MACROS_H_

--- a/tensorflow/lite/kernels/internal/common.cc
+++ b/tensorflow/lite/kernels/internal/common.cc
@@ -17,6 +17,15 @@ limitations under the License.
 
 namespace tflite {
 
+// Note on TFLITE_NO_SANITIZE_INTEGER_OVERFLOW below:
+//
+// These MultiplyByQuantizedMultiplier overloads do not intentionally wrap, so
+// they deliberately do NOT use WrappingMul/WrappingAdd. Under their documented
+// input contract (asserted below) the arithmetic does not overflow; the
+// attribute only silences UBSan reports at the contract's boundaries. Using
+// wrapping here would be wrong -- it would mask a contract violation (a real
+// bug) instead of letting it surface.
+
 // Single-rounding MultiplyByQuantizedMultiplier
 #if TFLITE_SINGLE_ROUNDING
 TFLITE_NO_SANITIZE_INTEGER_OVERFLOW

--- a/tensorflow/lite/kernels/internal/common.cc
+++ b/tensorflow/lite/kernels/internal/common.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "tensorflow/lite/core/macros.h"
 #include "tensorflow/lite/kernels/internal/common.h"
 
 namespace tflite {

--- a/tensorflow/lite/kernels/internal/common.cc
+++ b/tensorflow/lite/kernels/internal/common.cc
@@ -19,6 +19,7 @@ namespace tflite {
 
 // Single-rounding MultiplyByQuantizedMultiplier
 #if TFLITE_SINGLE_ROUNDING
+TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
 int32_t MultiplyByQuantizedMultiplier(int32_t x, int32_t quantized_multiplier,
                                       int shift) {
   TFLITE_DCHECK(quantized_multiplier >= 0);
@@ -34,6 +35,7 @@ int32_t MultiplyByQuantizedMultiplier(int32_t x, int32_t quantized_multiplier,
   return static_cast<int32_t>(result);
 }
 
+TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
 int32_t MultiplyByQuantizedMultiplier(int64_t x, int32_t quantized_multiplier,
                                       int shift) {
   // Inputs:
@@ -64,6 +66,7 @@ int32_t MultiplyByQuantizedMultiplier(int64_t x, int32_t quantized_multiplier,
 }
 // Double-rounding MultiplyByQuantizedMultiplier
 #else
+TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
 int32_t MultiplyByQuantizedMultiplier(int32_t x, int32_t quantized_multiplier,
                                       int shift) {
   using gemmlowp::RoundingDivideByPOT;
@@ -75,6 +78,7 @@ int32_t MultiplyByQuantizedMultiplier(int32_t x, int32_t quantized_multiplier,
                              right_shift);
 }
 
+TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
 int32_t MultiplyByQuantizedMultiplier(int64_t x, int32_t quantized_multiplier,
                                       int shift) {
   // Inputs:

--- a/tensorflow/lite/kernels/internal/common.h
+++ b/tensorflow/lite/kernels/internal/common.h
@@ -52,11 +52,21 @@ constexpr int kReverseShift = -1;
 //
 // For floating-point T these are plain a+b / a*b (no overflow concern); the
 // unsigned path is only taken for integral types.
+//
+// Note on integral promotion: for integer types narrower than int (e.g.
+// int16_t), the corresponding unsigned type (uint16_t) is still promoted to the
+// signed `int` before the arithmetic is performed. That promotion would
+// reintroduce signed overflow UB (e.g. 65535 * 65535 overflows int). To avoid
+// it we widen the operands to an unsigned type at least as wide as unsigned int
+// so the arithmetic itself stays unsigned, then truncate back down to the
+// narrow type -- both steps are well-defined.
 template <typename T>
 inline T WrappingAdd(T a, T b) {
   if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
     using U = std::make_unsigned_t<T>;
-    return static_cast<T>(static_cast<U>(a) + static_cast<U>(b));
+    using P = std::common_type_t<U, unsigned int>;
+    return static_cast<T>(static_cast<U>(static_cast<P>(static_cast<U>(a)) +
+                                         static_cast<P>(static_cast<U>(b))));
   } else {
     return a + b;
   }
@@ -66,7 +76,9 @@ template <typename T>
 inline T WrappingMul(T a, T b) {
   if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
     using U = std::make_unsigned_t<T>;
-    return static_cast<T>(static_cast<U>(a) * static_cast<U>(b));
+    using P = std::common_type_t<U, unsigned int>;
+    return static_cast<T>(static_cast<U>(static_cast<P>(static_cast<U>(a)) *
+                                         static_cast<P>(static_cast<U>(b))));
   } else {
     return a * b;
   }

--- a/tensorflow/lite/kernels/internal/common.h
+++ b/tensorflow/lite/kernels/internal/common.h
@@ -40,6 +40,38 @@ namespace tflite {
 
 constexpr int kReverseShift = -1;
 
+// Well-defined wrapping integer arithmetic helpers.
+//
+// Several elementwise/reduction kernels intentionally allow their value
+// arithmetic to wrap around for narrow integer types (the result is later
+// clamped, or wrapping is the documented behavior). Performing that wrap
+// directly on signed types is Undefined Behavior in C++, which the optimizer is
+// free to miscompile. These helpers instead perform the arithmetic in the
+// corresponding unsigned type -- where wrapping is fully defined -- and convert
+// the result back, so there is no UB even in optimized release builds.
+//
+// For floating-point T these are plain a+b / a*b (no overflow concern); the
+// unsigned path is only taken for integral types.
+template <typename T>
+inline T WrappingAdd(T a, T b) {
+  if constexpr (std::is_integral<T>::value && !std::is_same<T, bool>::value) {
+    using U = typename std::make_unsigned<T>::type;
+    return static_cast<T>(static_cast<U>(a) + static_cast<U>(b));
+  } else {
+    return a + b;
+  }
+}
+
+template <typename T>
+inline T WrappingMul(T a, T b) {
+  if constexpr (std::is_integral<T>::value && !std::is_same<T, bool>::value) {
+    using U = typename std::make_unsigned<T>::type;
+    return static_cast<T>(static_cast<U>(a) * static_cast<U>(b));
+  } else {
+    return a * b;
+  }
+}
+
 // Reduces and compresses dimensions so that broadcast handling becomes more
 // efficient. Returns true if the output shape is broadcastable; it doesn't
 // contain any degenerate dimension, i.e. shape dimension = 0. False otherwise.

--- a/tensorflow/lite/kernels/internal/common.h
+++ b/tensorflow/lite/kernels/internal/common.h
@@ -54,8 +54,8 @@ constexpr int kReverseShift = -1;
 // unsigned path is only taken for integral types.
 template <typename T>
 inline T WrappingAdd(T a, T b) {
-  if constexpr (std::is_integral<T>::value && !std::is_same<T, bool>::value) {
-    using U = typename std::make_unsigned<T>::type;
+  if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+    using U = std::make_unsigned_t<T>;
     return static_cast<T>(static_cast<U>(a) + static_cast<U>(b));
   } else {
     return a + b;
@@ -64,8 +64,8 @@ inline T WrappingAdd(T a, T b) {
 
 template <typename T>
 inline T WrappingMul(T a, T b) {
-  if constexpr (std::is_integral<T>::value && !std::is_same<T, bool>::value) {
-    using U = typename std::make_unsigned<T>::type;
+  if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+    using U = std::make_unsigned_t<T>;
     return static_cast<T>(static_cast<U>(a) * static_cast<U>(b));
   } else {
     return a * b;

--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -1950,7 +1950,6 @@ inline void MulElementwise(int size, const ArithmeticParams& params,
   }
 }
 
-TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
 inline void MulElementwise(int32_t n, const ArithmeticParams& params,
                            const int32_t* __restrict lhs,
                            const int32_t* __restrict rhs,
@@ -2003,8 +2002,9 @@ inline void MulElementwise(int32_t n, const ArithmeticParams& params,
 
   // This will handle leftovers when n is not aligned to 4 elements.
   for (; i < n; ++i) {
-    out[i] = ActivationFunctionWithMinMax(lhs[i] * rhs[i], activation_min_val,
-                                          activation_max_val);
+    out[i] =
+        ActivationFunctionWithMinMax(WrappingMul<int32_t>(lhs[i], rhs[i]),
+                                     activation_min_val, activation_max_val);
   }
 }
 
@@ -4957,7 +4957,6 @@ void TransposeIm2col(const ConvParams& params, uint8_t zero_byte,
 // filter_width, in_depth).  Implementation by Yangqing Jia (jiayq).
 // Copied from //tensorflow/core/kernels/conv_grad_input_ops.cc
 template <typename T>
-TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
 void Col2im(const T* col_data, const int depth, const int height,
             const int width, const int filter_h, const int filter_w,
             const int pad_t, const int pad_l, const int pad_b, const int pad_r,
@@ -4975,7 +4974,7 @@ void Col2im(const T* col_data, const int depth, const int height,
           if (ih >= 0 && ih < height && iw >= 0 && iw < width) {
             // TODO(andydavis) Vectorize this loop (if compiler does not).
             for (int i = 0; i < depth; ++i) {
-              im_patch_data[i] += col_data[i];
+              im_patch_data[i] = WrappingAdd<T>(im_patch_data[i], col_data[i]);
             }
           }
           im_patch_data += depth;
@@ -4992,7 +4991,6 @@ void Col2im(const T* col_data, const int depth, const int height,
 
 // TODO(b/188008864) Optimize this function by combining outer loops.
 template <typename T>
-TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
 void BiasAdd(T* im_data, const T* bias_data, const int batch_size,
              const int height, const int width, const int depth) {
   if (bias_data) {
@@ -5000,7 +4998,7 @@ void BiasAdd(T* im_data, const T* bias_data, const int batch_size,
       for (int h = 0; h < height; ++h) {
         for (int w = 0; w < width; ++w) {
           for (int d = 0; d < depth; ++d) {
-            im_data[d] += bias_data[d];
+            im_data[d] = WrappingAdd<T>(im_data[d], bias_data[d]);
           }
           im_data += depth;
         }

--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -7919,7 +7919,8 @@ void Col2im(const T* col_data, const int channel, const int planes,
               if (ip >= 0 && ip < planes && ih >= 0 && ih < height && iw >= 0 &&
                   iw < width) {
                 for (int i = 0; i < channel; ++i) {
-                  im_patch_data[i] += col_data[i];
+                  im_patch_data[i] =
+                      WrappingAdd<T>(im_patch_data[i], col_data[i]);
                 }
               }
               im_patch_data += channel;

--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -1950,6 +1950,7 @@ inline void MulElementwise(int size, const ArithmeticParams& params,
   }
 }
 
+TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
 inline void MulElementwise(int32_t n, const ArithmeticParams& params,
                            const int32_t* __restrict lhs,
                            const int32_t* __restrict rhs,
@@ -4956,6 +4957,7 @@ void TransposeIm2col(const ConvParams& params, uint8_t zero_byte,
 // filter_width, in_depth).  Implementation by Yangqing Jia (jiayq).
 // Copied from //tensorflow/core/kernels/conv_grad_input_ops.cc
 template <typename T>
+TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
 void Col2im(const T* col_data, const int depth, const int height,
             const int width, const int filter_h, const int filter_w,
             const int pad_t, const int pad_l, const int pad_b, const int pad_r,
@@ -4990,6 +4992,7 @@ void Col2im(const T* col_data, const int depth, const int height,
 
 // TODO(b/188008864) Optimize this function by combining outer loops.
 template <typename T>
+TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
 void BiasAdd(T* im_data, const T* bias_data, const int batch_size,
              const int height, const int width, const int depth) {
   if (bias_data) {

--- a/tensorflow/lite/kernels/internal/optimized/reduce.h
+++ b/tensorflow/lite/kernels/internal/optimized/reduce.h
@@ -22,7 +22,6 @@ limitations under the License.
 #include <vector>
 
 #include "ruy/profiler/instrumentation.h"  // from @ruy
-#include "tensorflow/lite/core/macros.h"
 #include "tensorflow/lite/kernels/cpu_backend_threadpool.h"
 #include "tensorflow/lite/kernels/internal/optimized/optimized_ops_utils.h"
 #include "tensorflow/lite/kernels/internal/optimized/reduce_utils.h"
@@ -263,17 +262,17 @@ inline void Mean(const tflite::MeanParams& op_params,
 template <typename T>
 struct SumOp {
   inline T operator()(const T& a) const { return a; }
-  TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
-  inline T operator()(const T& a, const T& b) const { return a + b; }
+  inline T operator()(const T& a, const T& b) const {
+    return WrappingAdd<T>(a, b);
+  }
   static constexpr T kNeutralElement = T(0);
 };
 
 template <typename T, typename U>
 struct CastSumOp {
   inline U operator()(const T& a) const { return static_cast<U>(a); }
-  TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
   inline U operator()(const U& a, const T& b) const {
-    return a + static_cast<U>(b);
+    return WrappingAdd<U>(a, static_cast<U>(b));
   }
   static constexpr U kNeutralElement = U(0);
 };
@@ -281,8 +280,9 @@ struct CastSumOp {
 template <typename T>
 struct ProdOp {
   inline T operator()(const T& a) const { return a; }
-  TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
-  inline T operator()(const T& a, const T& b) const { return a * b; }
+  inline T operator()(const T& a, const T& b) const {
+    return WrappingMul<T>(a, b);
+  }
   static constexpr T kNeutralElement = T(1);
 };
 

--- a/tensorflow/lite/kernels/internal/optimized/reduce.h
+++ b/tensorflow/lite/kernels/internal/optimized/reduce.h
@@ -261,17 +261,15 @@ inline void Mean(const tflite::MeanParams& op_params,
 
 template <typename T>
 struct SumOp {
-  inline T operator()(const T& a) const { return a; }
-  inline T operator()(const T& a, const T& b) const {
-    return WrappingAdd<T>(a, b);
-  }
+  T operator()(const T& a) const { return a; }
+  T operator()(const T& a, const T& b) const { return WrappingAdd<T>(a, b); }
   static constexpr T kNeutralElement = T(0);
 };
 
 template <typename T, typename U>
 struct CastSumOp {
-  inline U operator()(const T& a) const { return static_cast<U>(a); }
-  inline U operator()(const U& a, const T& b) const {
+  U operator()(const T& a) const { return static_cast<U>(a); }
+  U operator()(const U& a, const T& b) const {
     return WrappingAdd<U>(a, static_cast<U>(b));
   }
   static constexpr U kNeutralElement = U(0);
@@ -279,36 +277,34 @@ struct CastSumOp {
 
 template <typename T>
 struct ProdOp {
-  inline T operator()(const T& a) const { return a; }
-  inline T operator()(const T& a, const T& b) const {
-    return WrappingMul<T>(a, b);
-  }
+  T operator()(const T& a) const { return a; }
+  T operator()(const T& a, const T& b) const { return WrappingMul<T>(a, b); }
   static constexpr T kNeutralElement = T(1);
 };
 
 template <typename T>
 struct MaxOp {
-  inline T operator()(const T& a) const { return a; }
-  inline T operator()(const T& a, const T& b) const { return (a > b) ? a : b; }
+  T operator()(const T& a) const { return a; }
+  T operator()(const T& a, const T& b) const { return (a > b) ? a : b; }
   static constexpr T kNeutralElement = std::numeric_limits<T>::lowest();
 };
 
 template <typename T>
 struct MinOp {
-  inline T operator()(const T& a) const { return a; }
-  inline T operator()(const T& a, const T& b) const { return (a < b) ? a : b; }
+  T operator()(const T& a) const { return a; }
+  T operator()(const T& a, const T& b) const { return (a < b) ? a : b; }
   static constexpr T kNeutralElement = std::numeric_limits<T>::max();
 };
 
 struct AndOp {
-  inline bool operator()(bool a) const { return a; }
-  inline bool operator()(bool a, bool b) const { return a && b; }
+  bool operator()(bool a) const { return a; }
+  bool operator()(bool a, bool b) const { return a && b; }
   static constexpr bool kNeutralElement = true;
 };
 
 struct OrOp {
-  inline bool operator()(bool a) const { return a; }
-  inline bool operator()(bool a, bool b) const { return a || b; }
+  bool operator()(bool a) const { return a; }
+  bool operator()(bool a, bool b) const { return a || b; }
   static constexpr bool kNeutralElement = false;
 };
 

--- a/tensorflow/lite/kernels/internal/optimized/reduce.h
+++ b/tensorflow/lite/kernels/internal/optimized/reduce.h
@@ -22,6 +22,7 @@ limitations under the License.
 #include <vector>
 
 #include "ruy/profiler/instrumentation.h"  // from @ruy
+#include "tensorflow/lite/core/macros.h"
 #include "tensorflow/lite/kernels/cpu_backend_threadpool.h"
 #include "tensorflow/lite/kernels/internal/optimized/optimized_ops_utils.h"
 #include "tensorflow/lite/kernels/internal/optimized/reduce_utils.h"
@@ -262,6 +263,7 @@ inline void Mean(const tflite::MeanParams& op_params,
 template <typename T>
 struct SumOp {
   inline T operator()(const T& a) const { return a; }
+  TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
   inline T operator()(const T& a, const T& b) const { return a + b; }
   static constexpr T kNeutralElement = T(0);
 };
@@ -269,6 +271,7 @@ struct SumOp {
 template <typename T, typename U>
 struct CastSumOp {
   inline U operator()(const T& a) const { return static_cast<U>(a); }
+  TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
   inline U operator()(const U& a, const T& b) const {
     return a + static_cast<U>(b);
   }
@@ -278,6 +281,7 @@ struct CastSumOp {
 template <typename T>
 struct ProdOp {
   inline T operator()(const T& a) const { return a; }
+  TFLITE_NO_SANITIZE_INTEGER_OVERFLOW
   inline T operator()(const T& a, const T& b) const { return a * b; }
   static constexpr T kNeutralElement = T(1);
 };

--- a/tensorflow/lite/kernels/internal/reference/add.h
+++ b/tensorflow/lite/kernels/internal/reference/add.h
@@ -199,20 +199,22 @@ inline void Add(const ArithmeticParams& params,
 }
 
 template <typename T>
-TFLITE_NO_SANITIZE_INTEGER_OVERFLOW inline void AddBroadcast(
-    const T* input_data, const T* broadcast_data, T* output_data, size_t size,
-    T activation_min, T activation_max) {
+inline void AddBroadcast(const T* input_data, const T* broadcast_data,
+                         T* output_data, size_t size, T activation_min,
+                         T activation_max) {
   for (size_t c = 0; c < size; ++c) {
     output_data[c] = ActivationFunctionWithMinMax<T>(
-        input_data[c] + broadcast_data[0], activation_min, activation_max);
+        WrappingAdd<T>(input_data[c], broadcast_data[0]), activation_min,
+        activation_max);
   }
 }
 
 template <>
-TFLITE_NO_SANITIZE_INTEGER_OVERFLOW inline void AddBroadcast<int32_t>(
-    const int32_t* input_data, const int32_t* broadcast_data,
-    int32_t* output_data, size_t size, int32_t activation_min,
-    int32_t activation_max) {
+inline void AddBroadcast<int32_t>(const int32_t* input_data,
+                                  const int32_t* broadcast_data,
+                                  int32_t* output_data, size_t size,
+                                  int32_t activation_min,
+                                  int32_t activation_max) {
   size_t c = 0;
 #ifdef USE_NEON
   const int32x4_t vmax = vdupq_n_s32(activation_max);
@@ -228,7 +230,8 @@ TFLITE_NO_SANITIZE_INTEGER_OVERFLOW inline void AddBroadcast<int32_t>(
 #endif
   for (; c < size; ++c) {
     output_data[c] = ActivationFunctionWithMinMax<int32_t>(
-        input_data[c] + broadcast_data[0], activation_min, activation_max);
+        WrappingAdd<int32_t>(input_data[c], broadcast_data[0]), activation_min,
+        activation_max);
   }
 }
 

--- a/tensorflow/lite/kernels/internal/reference/add.h
+++ b/tensorflow/lite/kernels/internal/reference/add.h
@@ -199,9 +199,9 @@ inline void Add(const ArithmeticParams& params,
 }
 
 template <typename T>
-inline void AddBroadcast(const T* input_data, const T* broadcast_data,
-                         T* output_data, size_t size, T activation_min,
-                         T activation_max) {
+TFLITE_NO_SANITIZE_INTEGER_OVERFLOW inline void AddBroadcast(
+    const T* input_data, const T* broadcast_data, T* output_data, size_t size,
+    T activation_min, T activation_max) {
   for (size_t c = 0; c < size; ++c) {
     output_data[c] = ActivationFunctionWithMinMax<T>(
         input_data[c] + broadcast_data[0], activation_min, activation_max);
@@ -209,11 +209,10 @@ inline void AddBroadcast(const T* input_data, const T* broadcast_data,
 }
 
 template <>
-inline void AddBroadcast<int32_t>(const int32_t* input_data,
-                                  const int32_t* broadcast_data,
-                                  int32_t* output_data, size_t size,
-                                  int32_t activation_min,
-                                  int32_t activation_max) {
+TFLITE_NO_SANITIZE_INTEGER_OVERFLOW inline void AddBroadcast<int32_t>(
+    const int32_t* input_data, const int32_t* broadcast_data,
+    int32_t* output_data, size_t size, int32_t activation_min,
+    int32_t activation_max) {
   size_t c = 0;
 #ifdef USE_NEON
   const int32x4_t vmax = vdupq_n_s32(activation_max);

--- a/tensorflow/lite/kernels/internal/reference/mul.h
+++ b/tensorflow/lite/kernels/internal/reference/mul.h
@@ -49,10 +49,10 @@ inline void MulElementwise(int size, const ArithmeticParams& params,
 }
 
 template <typename T>
-inline void Mul(const ArithmeticParams& params,
-                const RuntimeShape& input1_shape, const T* input1_data,
-                const RuntimeShape& input2_shape, const T* input2_data,
-                const RuntimeShape& output_shape, T* output_data) {
+TFLITE_NO_SANITIZE_INTEGER_OVERFLOW inline void Mul(
+    const ArithmeticParams& params, const RuntimeShape& input1_shape,
+    const T* input1_data, const RuntimeShape& input2_shape,
+    const T* input2_data, const RuntimeShape& output_shape, T* output_data) {
   T output_activation_min;
   T output_activation_max;
   GetActivationParams(params, &output_activation_min, &output_activation_max);
@@ -131,10 +131,11 @@ BroadcastMul6DSlow(const ArithmeticParams& params,
   T output_activation_min;
   T output_activation_max;
   GetActivationParams(params, &output_activation_min, &output_activation_max);
-  auto op = [output_activation_min, output_activation_max](T a, T b) {
-    return ActivationFunctionWithMinMax<T>(a * b, output_activation_min,
-                                           output_activation_max);
-  };
+  auto op = [output_activation_min, output_activation_max](T a, T b)
+                TFLITE_NO_SANITIZE_INTEGER_OVERFLOW {
+                  return ActivationFunctionWithMinMax<T>(
+                      a * b, output_activation_min, output_activation_max);
+                };
   BroadcastBinaryOpSimple(unextended_input1_shape, input1_data,
                           unextended_input2_shape, input2_data,
                           unextended_output_shape, output_data, op);
@@ -147,7 +148,8 @@ inline void BroadcastMul6DSlow(const ArithmeticParams& params,
                                const std::complex<float>* input2_data,
                                const RuntimeShape& unextended_output_shape,
                                std::complex<float>* output_data) {
-  auto op = [](std::complex<float> a, std::complex<float> b) { return a * b; };
+  auto op = [](std::complex<float> a, std::complex<float> b)
+                TFLITE_NO_SANITIZE_INTEGER_OVERFLOW { return a * b; };
   BroadcastBinaryOpSimple(unextended_input1_shape, input1_data,
                           unextended_input2_shape, input2_data,
                           unextended_output_shape, output_data, op);

--- a/tensorflow/lite/kernels/internal/reference/mul.h
+++ b/tensorflow/lite/kernels/internal/reference/mul.h
@@ -49,10 +49,10 @@ inline void MulElementwise(int size, const ArithmeticParams& params,
 }
 
 template <typename T>
-TFLITE_NO_SANITIZE_INTEGER_OVERFLOW inline void Mul(
-    const ArithmeticParams& params, const RuntimeShape& input1_shape,
-    const T* input1_data, const RuntimeShape& input2_shape,
-    const T* input2_data, const RuntimeShape& output_shape, T* output_data) {
+inline void Mul(const ArithmeticParams& params,
+                const RuntimeShape& input1_shape, const T* input1_data,
+                const RuntimeShape& input2_shape, const T* input2_data,
+                const RuntimeShape& output_shape, T* output_data) {
   T output_activation_min;
   T output_activation_max;
   GetActivationParams(params, &output_activation_min, &output_activation_max);
@@ -61,7 +61,7 @@ TFLITE_NO_SANITIZE_INTEGER_OVERFLOW inline void Mul(
       MatchingExtendedShapeFlatSize(input1_shape, input2_shape, output_shape);
   for (int i = 0; i < flat_size; ++i) {
     output_data[i] = ActivationFunctionWithMinMax<T>(
-        input1_data[i] * input2_data[i], output_activation_min,
+        WrappingMul<T>(input1_data[i], input2_data[i]), output_activation_min,
         output_activation_max);
   }
 }
@@ -131,11 +131,10 @@ BroadcastMul6DSlow(const ArithmeticParams& params,
   T output_activation_min;
   T output_activation_max;
   GetActivationParams(params, &output_activation_min, &output_activation_max);
-  auto op = [output_activation_min, output_activation_max](T a, T b)
-                TFLITE_NO_SANITIZE_INTEGER_OVERFLOW {
-                  return ActivationFunctionWithMinMax<T>(
-                      a * b, output_activation_min, output_activation_max);
-                };
+  auto op = [output_activation_min, output_activation_max](T a, T b) {
+    return ActivationFunctionWithMinMax<T>(
+        WrappingMul<T>(a, b), output_activation_min, output_activation_max);
+  };
   BroadcastBinaryOpSimple(unextended_input1_shape, input1_data,
                           unextended_input2_shape, input2_data,
                           unextended_output_shape, output_data, op);
@@ -148,8 +147,7 @@ inline void BroadcastMul6DSlow(const ArithmeticParams& params,
                                const std::complex<float>* input2_data,
                                const RuntimeShape& unextended_output_shape,
                                std::complex<float>* output_data) {
-  auto op = [](std::complex<float> a, std::complex<float> b)
-                TFLITE_NO_SANITIZE_INTEGER_OVERFLOW { return a * b; };
+  auto op = [](std::complex<float> a, std::complex<float> b) { return a * b; };
   BroadcastBinaryOpSimple(unextended_input1_shape, input1_data,
                           unextended_input2_shape, input2_data,
                           unextended_output_shape, output_data, op);

--- a/tensorflow/lite/kernels/internal/reference/reference_ops.h
+++ b/tensorflow/lite/kernels/internal/reference/reference_ops.h
@@ -647,10 +647,12 @@ inline TfLiteStatus GatherNdString(const RuntimeShape& params_shape,
 #endif
 
 template <typename IndicesT, typename UpdatesT>
-TFLITE_NO_SANITIZE_INTEGER_OVERFLOW inline TfLiteStatus ScatterNd(
-    const RuntimeShape& indices_shape, const IndicesT* indices_data,
-    const RuntimeShape& updates_shape, const UpdatesT* updates_data,
-    const RuntimeShape& output_shape, UpdatesT* output_data) {
+inline TfLiteStatus ScatterNd(const RuntimeShape& indices_shape,
+                              const IndicesT* indices_data,
+                              const RuntimeShape& updates_shape,
+                              const UpdatesT* updates_data,
+                              const RuntimeShape& output_shape,
+                              UpdatesT* output_data) {
   ruy::profiler::ScopeLabel label("ScatterNd");
 
   int64_t n_slices = 1;
@@ -692,7 +694,8 @@ TFLITE_NO_SANITIZE_INTEGER_OVERFLOW inline TfLiteStatus ScatterNd(
       return kTfLiteError;
     }
     for (int j = 0; j < slice_size; j++) {
-      output_data[to_pos + j] += updates_data[i * slice_size + j];
+      output_data[to_pos + j] = WrappingAdd<UpdatesT>(
+          output_data[to_pos + j], updates_data[i * slice_size + j]);
     }
   }
   return kTfLiteOk;

--- a/tensorflow/lite/kernels/internal/reference/reference_ops.h
+++ b/tensorflow/lite/kernels/internal/reference/reference_ops.h
@@ -647,12 +647,10 @@ inline TfLiteStatus GatherNdString(const RuntimeShape& params_shape,
 #endif
 
 template <typename IndicesT, typename UpdatesT>
-inline TfLiteStatus ScatterNd(const RuntimeShape& indices_shape,
-                              const IndicesT* indices_data,
-                              const RuntimeShape& updates_shape,
-                              const UpdatesT* updates_data,
-                              const RuntimeShape& output_shape,
-                              UpdatesT* output_data) {
+TFLITE_NO_SANITIZE_INTEGER_OVERFLOW inline TfLiteStatus ScatterNd(
+    const RuntimeShape& indices_shape, const IndicesT* indices_data,
+    const RuntimeShape& updates_shape, const UpdatesT* updates_data,
+    const RuntimeShape& output_shape, UpdatesT* output_data) {
   ruy::profiler::ScopeLabel label("ScatterNd");
 
   int64_t n_slices = 1;


### PR DESCRIPTION
Introduce TFLITE_NO_SANITIZE_INTEGER_OVERFLOW macro and use it on functions where the chromium fuzzer has already detected the overflow. See chromium issue list: https://issues.chromium.org/issues?q=status:open%20componentid:1456757%20integer-overflow%20tflite