### PR TITLE
Fix FastModuleType callback parse errors

### DIFF
--- a/tensorflow/python/util/fast_module_type.cc
+++ b/tensorflow/python/util/fast_module_type.cc
@@ -102,6 +102,7 @@ static PyObject *ParseFunc(PyObject *args) {
 // corresponding to 'self'.
 static PyObject *SetGetattributeCallback(PyObject *self, PyObject *args) {
   PyObject *func = ParseFunc(args);
+  if (func == nullptr) return nullptr;
   FastModuleObject* fast_module = FastModuleObject::UncheckedCast(self);
   PyObject* old_func = nullptr;
   {
@@ -117,6 +118,7 @@ static PyObject *SetGetattributeCallback(PyObject *self, PyObject *args) {
 // corresponding to 'self'.
 static PyObject *SetGetattrCallback(PyObject *self, PyObject *args) {
   PyObject *func = ParseFunc(args);
+  if (func == nullptr) return nullptr;
   FastModuleObject* fast_module = FastModuleObject::UncheckedCast(self);
   PyObject* old_func = nullptr;
   {

--- a/tensorflow/python/util/fast_module_type_test.py
+++ b/tensorflow/python/util/fast_module_type_test.py
@@ -62,12 +62,31 @@ class FastModuleTypeTest(test.TestCase):
                                              ChildFastModule._getattribute1)
     self.assertEqual(2, module.foo)
 
+  def testInvalidGetattributeCallbackRaisesAndKeepsExistingCallback(self):
+    module = ChildFastModule("test")
+    FastModuleType.set_getattribute_callback(module,
+                                             ChildFastModule._getattribute1)
+
+    with self.assertRaisesRegex(TypeError, "input args must be callable"):
+      FastModuleType.set_getattribute_callback(module, 1)
+
+    self.assertEqual(2, module.foo)
+
   def testGetattrCallback(self):
     # Tests that functionality of __getattr__ can be set as a callback.
     module = ChildFastModule("test")
     FastModuleType.set_getattribute_callback(module,
                                              ChildFastModule._getattribute2)
     FastModuleType.set_getattr_callback(module, ChildFastModule._getattr)
+    self.assertEqual(3, module.foo)
+
+  def testInvalidGetattrCallbackRaisesAndKeepsExistingCallback(self):
+    module = ChildFastModule("test")
+    FastModuleType.set_getattr_callback(module, ChildFastModule._getattr)
+
+    with self.assertRaisesRegex(TypeError, "input args must be callable"):
+      FastModuleType.set_getattr_callback(module, 1)
+
     self.assertEqual(3, module.foo)
 
   def testFastdictApis(self):


### PR DESCRIPTION
Fixes #121925.

SetGetattributeCallback and SetGetattrCallback now return nullptr when callback parsing fails, preserving the pending Python exception and avoiding mutation of the stored callback slot on invalid input.

This adds regression coverage for both callback setters to verify invalid non-callable input raises TypeError and keeps the previously installed callback active.

Tests:
- git diff --check
- python -m py_compile tensorflow/python/util/fast_module_type_test.py

Not run:
- bazel test //tensorflow/python/util:fast_module_type_test because Bazel is not installed in this workspace.