### PR TITLE
Fix signed-integer-overflow UB in TFLite optimized integer Add kernel.

### DIFF
--- a/tensorflow/lite/kernels/add_test.cc
+++ b/tensorflow/lite/kernels/add_test.cc
@@ -17,8 +17,10 @@ limitations under the License.
 
 #include <algorithm>
 #include <array>
+#include <limits>
 #include <numeric>
 #include <random>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -734,6 +736,21 @@ TYPED_TEST(IntegerAddOpTest, Int32MultiDimBroadcast) {
   m.PopulateTensor<TypeParam>(m.input2(), {1, 4});
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
   EXPECT_THAT(m.GetOutput<TypeParam>(), ElementsAreArray({4, 6, 7, 9}));
+}
+
+TYPED_TEST(IntegerAddOpTest, OverflowWrapping) {
+  if (std::is_same<TypeParam, int32_t>::value ||
+      std::is_same<TypeParam, int64_t>::value) {
+    IntegerAddOpModel m(GetTensorType<TypeParam>(), {1, 2}, {1, 2},
+                        ActivationFunctionType_NONE);
+    m.PopulateTensor<TypeParam>(m.input1(),
+                                {std::numeric_limits<TypeParam>::max(), 5});
+    m.PopulateTensor<TypeParam>(m.input2(), {1, 5});
+    ASSERT_EQ(m.Invoke(), kTfLiteOk);
+    EXPECT_THAT(m.GetOutput<TypeParam>(),
+                ElementsAreArray<TypeParam>(
+                    {std::numeric_limits<TypeParam>::min(), 10}));
+  }
 }
 
 template <typename QuantizedType>

--- a/tensorflow/lite/kernels/add_test.cc
+++ b/tensorflow/lite/kernels/add_test.cc
@@ -753,6 +753,22 @@ TYPED_TEST(IntegerAddOpTest, OverflowWrapping) {
   }
 }
 
+TYPED_TEST(IntegerAddOpTest, OverflowWrappingBroadcast) {
+  if (std::is_same<TypeParam, int32_t>::value ||
+      std::is_same<TypeParam, int64_t>::value) {
+    IntegerAddOpModel m(GetTensorType<TypeParam>(), {1, 2}, {2, 1},
+                        ActivationFunctionType_NONE);
+    m.PopulateTensor<TypeParam>(m.input1(),
+                                {std::numeric_limits<TypeParam>::max(), 5});
+    m.PopulateTensor<TypeParam>(m.input2(), {1, 1});
+    ASSERT_EQ(m.Invoke(), kTfLiteOk);
+    EXPECT_THAT(m.GetOutput<TypeParam>(),
+                ElementsAreArray<TypeParam>(
+                    {std::numeric_limits<TypeParam>::min(), 6,
+                     std::numeric_limits<TypeParam>::min(), 6}));
+  }
+}
+
 template <typename QuantizedType>
 void TestQuantizedBroadcast(QuantizedAddOpModel& m,
                             const std::vector<int>& input1_shape,

--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -1829,20 +1829,32 @@ inline typename std::enable_if<is_int32_or_int64<T>::value, void>::type Add(
   auto input1_map = MapAsVector(input1_data, input1_shape);
   auto input2_map = MapAsVector(input2_data, input2_shape);
   auto output_map = MapAsVector(output_data, output_shape);
+  // The element-wise sum is performed in the unsigned domain so that any
+  // overflow wraps in a well-defined manner instead of triggering
+  // signed-integer-overflow UB inside Eigen's expression evaluators. The
+  // wrapped result is bit-identical to the previous two's-complement behavior
+  // and is then clamped back in the signed domain by the activation min/max.
+  using UnsignedT = typename std::make_unsigned<T>::type;
   if (input1_shape == input2_shape) {
-    output_map.array() = (input1_map.array() + input2_map.array())
+    output_map.array() = (input1_map.array().template cast<UnsignedT>() +
+                          input2_map.array().template cast<UnsignedT>())
+                             .template cast<T>()
                              .cwiseMax(activation_min)
                              .cwiseMin(activation_max);
   } else if (input2_shape.FlatSize() == 1) {
-    auto scalar = input2_data[0];
-    output_map.array() = (input1_map.array() + scalar)
-                             .cwiseMax(activation_min)
-                             .cwiseMin(activation_max);
+    UnsignedT scalar = static_cast<UnsignedT>(input2_data[0]);
+    output_map.array() =
+        (input1_map.array().template cast<UnsignedT>() + scalar)
+            .template cast<T>()
+            .cwiseMax(activation_min)
+            .cwiseMin(activation_max);
   } else if (input1_shape.FlatSize() == 1) {
-    auto scalar = input1_data[0];
-    output_map.array() = (scalar + input2_map.array())
-                             .cwiseMax(activation_min)
-                             .cwiseMin(activation_max);
+    UnsignedT scalar = static_cast<UnsignedT>(input1_data[0]);
+    output_map.array() =
+        (scalar + input2_map.array().template cast<UnsignedT>())
+            .template cast<T>()
+            .cwiseMax(activation_min)
+            .cwiseMin(activation_max);
   } else {
     reference_ops::BroadcastAdd6DSlow<T>(params, input1_shape, input1_data,
                                          input2_shape, input2_data,

--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -1828,20 +1828,32 @@ inline typename std::enable_if<is_int32_or_int64<T>::value, void>::type Add(
   auto input1_map = MapAsVector(input1_data, input1_shape);
   auto input2_map = MapAsVector(input2_data, input2_shape);
   auto output_map = MapAsVector(output_data, output_shape);
+  // The element-wise sum is performed in the unsigned domain so that any
+  // overflow wraps in a well-defined manner instead of triggering
+  // signed-integer-overflow UB inside Eigen's expression evaluators. The
+  // wrapped result is bit-identical to the previous two's-complement behavior
+  // and is then clamped back in the signed domain by the activation min/max.
+  using UnsignedT = typename std::make_unsigned<T>::type;
   if (input1_shape == input2_shape) {
-    output_map.array() = (input1_map.array() + input2_map.array())
+    output_map.array() = (input1_map.array().template cast<UnsignedT>() +
+                          input2_map.array().template cast<UnsignedT>())
+                             .template cast<T>()
                              .cwiseMax(activation_min)
                              .cwiseMin(activation_max);
   } else if (input2_shape.FlatSize() == 1) {
-    auto scalar = input2_data[0];
-    output_map.array() = (input1_map.array() + scalar)
-                             .cwiseMax(activation_min)
-                             .cwiseMin(activation_max);
+    UnsignedT scalar = static_cast<UnsignedT>(input2_data[0]);
+    output_map.array() =
+        (input1_map.array().template cast<UnsignedT>() + scalar)
+            .template cast<T>()
+            .cwiseMax(activation_min)
+            .cwiseMin(activation_max);
   } else if (input1_shape.FlatSize() == 1) {
-    auto scalar = input1_data[0];
-    output_map.array() = (scalar + input2_map.array())
-                             .cwiseMax(activation_min)
-                             .cwiseMin(activation_max);
+    UnsignedT scalar = static_cast<UnsignedT>(input1_data[0]);
+    output_map.array() =
+        (scalar + input2_map.array().template cast<UnsignedT>())
+            .template cast<T>()
+            .cwiseMax(activation_min)
+            .cwiseMin(activation_max);
   } else {
     reference_ops::BroadcastAdd6DSlow<T>(params, input1_shape, input1_data,
                                          input2_shape, input2_data,

--- a/tensorflow/lite/kernels/internal/reference/add.h
+++ b/tensorflow/lite/kernels/internal/reference/add.h
@@ -41,7 +41,8 @@ inline void Add(const ArithmeticParams& params,
       MatchingElementsSize(input1_shape, input2_shape, output_shape);
   for (int i = 0; i < flat_size; ++i) {
     output_data[i] = ActivationFunctionWithMinMax<T>(
-        input1_data[i] + input2_data[i], activation_min, activation_max);
+        WrappingAdd(input1_data[i], input2_data[i]), activation_min,
+        activation_max);
   }
 }
 
@@ -280,7 +281,7 @@ BroadcastAdd6DSlow(const ArithmeticParams& params,
   T activation_min, activation_max;
   GetActivationParams(params, &activation_min, &activation_max);
   auto op = [activation_min, activation_max](T a, T b) {
-    return ActivationFunctionWithMinMax<T>(a + b, activation_min,
+    return ActivationFunctionWithMinMax<T>(WrappingAdd(a, b), activation_min,
                                            activation_max);
   };
   BroadcastBinaryOpSimple(input1_shape, input1_data, input2_shape, input2_data,


### PR DESCRIPTION
The optimized integer `Add` kernel (`optimized_ops::Add`) can trigger signed-integer-overflow UB, reported by UBSan. The add is evaluated inside Eigen's expression templates, so it surfaces in Eigen rather than TFLite code.  An earlier attempt suppressed the check in Eigen itself (annotating Eigen's functors with a no_sanitize attribute: https://gitlab.com/libeigen/eigen/-/merge_requests/2662), but this was not accepted: if TFLite asks Eigen to perform integer operations that cause UB, the problem should be fixed at the root in TFLite, not by patching Eigen.

Fix: perform the sum in the unsigned domain (`make_unsigned<T>`), where overflow is well-defined, then cast back before the clamp. The result is bit-identical to the previous behavior, so there's no functional change — the UB is removed at the root without touching Eigen.

See chromium integer overflow issue: https://issues.chromium.org/issues/517483194