### PR TITLE
Remove references to XLA framework dialect and its passes

### DIFF
--- a/tensorflow/compiler/mlir/tosa/BUILD
+++ b/tensorflow/compiler/mlir/tosa/BUILD
@@ -287,8 +287,6 @@ tf_cc_binary(
         "@llvm-project//mlir:MlirOptLib",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:Transforms",
-        "@xla//xla/mlir/framework/ir:xla_framework",
-        "@xla//xla/mlir/framework/transforms:passes",
         "@xla//xla/mlir_hlo:all_passes",
     ],
 )

--- a/tensorflow/compiler/mlir/tosa/tf_tosa_opt.cc
+++ b/tensorflow/compiler/mlir/tosa/tf_tosa_opt.cc
@@ -37,7 +37,6 @@ limitations under the License.
 #include "tensorflow/compiler/mlir/tosa/tf_tfl_passes.h"
 #include "tensorflow/compiler/mlir/tosa/tfl_passes.h"
 #include "tensorflow/compiler/mlir/tosa/transforms/passes.h"
-#include "xla/mlir/framework/transforms/passes.h"
 #include "xla/mlir_hlo/mhlo/transforms/passes.h"
 
 int main(int argc, char** argv) {
@@ -58,7 +57,6 @@ int main(int argc, char** argv) {
   tensorflow::tf2xla::internal::registerTFXLABridgeClusteringPasses();
   tensorflow::tf2xla::internal::registerTFXLABridgeMlirToGraphPasses();
   mlir::tf_test::registerTensorFlowTestPasses();
-  mlir::xla_framework::registerXlaFrameworkPasses();
   tensorflow::RegisterConvertMlirToXlaHloPipelineWithDefaults();
   tensorflow::RegisterGraphOptimizationPasses();
   tensorflow::RegisterMlProgramPasses();


### PR DESCRIPTION
The xla_framework dialect and its associated passes (LegalizeXLAFrameworkToLLVM, OutlineWithXLAFramework) are legacy and no longer used.