### PR TITLE
Document lazy-init random seed behavior in tf.random.set_seed (eager/tf.function/XLA)

### DIFF
--- a/tensorflow/python/framework/random_seed.py
+++ b/tensorflow/python/framework/random_seed.py
@@ -352,6 +352,29 @@ def set_seed(seed):
   a new set of stateful random ops that use external variables to manage their
   states.
 
+  Note: `tf.random.set_seed` only governs TensorFlow's own stateful random
+  operations. It does not control seeds that higher-level components select for
+  themselves. In particular, Keras layer initializers create a variable's value
+  the first time the layer is built (lazily), and an unseeded initializer chooses
+  its own operation-level seed independently of the global seed. Resetting the
+  global seed alone therefore does not guarantee that such lazily-created
+  variables (for example, layer kernels) are initialized to the same values,
+  whether across re-runs of a program or across eager, `tf.function`, and
+  `tf.function(jit_compile=True)` execution. This is most surprising in
+  differential tests that compare those execution modes, where the differing
+  weights come from initialization rather than from compilation changing the
+  computation. For reproducible initialization, pass an explicit seed to the
+  initializer:
+
+  ```python
+  initializer = tf.keras.initializers.GlorotUniform(seed=1)
+  layer = tf.keras.layers.Dense(4, kernel_initializer=initializer)
+  ```
+
+  Note that an explicit seed makes eager and `tf.function` execution agree, but
+  XLA (`jit_compile=True`) may still produce different values because it can
+  lower the random-number generator differently.
+
   Args:
     seed: integer.
   """


### PR DESCRIPTION
Fixes #120627

### What
Adds a `Note:` to the `tf.random.set_seed` docstring explaining that the global
seed only governs TensorFlow's own stateful random ops — it does not control
seeds that higher-level components (e.g. Keras layer initializers) choose for
themselves. As a result, resetting the global seed alone does not guarantee that
lazily-created variables (like layer kernels) are initialized identically across
re-runs or across eager / `tf.function` / `tf.function(jit_compile=True)`
execution. The note shows the remedy (an explicit initializer seed) and is
careful not to over-promise: an explicit seed makes eager and `tf.function`
agree, but XLA may still differ because it can lower the RNG differently.

### Why
Per #120627, this behavior is surprising in differential tests that compare
eager/graph/XLA, where the differing weights are mistaken for compilation bugs.

### Scope
Docs-only, single file: `tensorflow/python/framework/random_seed.py`. No code or
behavior change. The Keras initializer's own docs live in the external `keras`
package, so this documents the TF-side primitive.

### Verification
- Reproduced on `tf-nightly 2.22.0.dev20260625` (Keras 3): with only a global
  seed, an unseeded initializer yields different values across eager/graph/XLA;
  an explicit initializer seed aligns eager and `tf.function` (XLA may still
  differ).
- `tf_doctest` runs clean on the module; the added `python` block is illustrative
  (no `>>>`), so doctests are unaffected.