### PR TITLE
ci: pin actions/checkout to full commit SHA in gemini.yml to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Validate Gemini Review Trigger
         run: |


### PR DESCRIPTION
## Summary

The `gemini.yml` workflow uses `actions/checkout@v4`, a **mutable version tag**. Version tags can be moved by an upstream repository maintainer (or attacker), causing a different — potentially malicious — version to execute silently in subsequent workflow runs.

## Vulnerability class

Supply-chain attack via mutable Action tag reference (CWE-829). See [GitHub Security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Fix

`actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`

The version tag is preserved as an inline comment for human readability.