### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Validate Gemini Review Trigger
         run: |


### PR DESCRIPTION
## Summary

Pin all unpinned GitHub Actions to immutable full-length commit SHAs.

**Why:** Mutable tags (`@v3`, `@main`) can be silently redirected to malicious commits. SHA-pinning ensures reviewed code runs in CI — defense-in-depth against supply-chain attacks.

**Changes:** 2 reference(s) across 1 workflow file(s). Version tags retained as inline comments.

**References:**
- [GitHub: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [OpenSSF Scorecard: Pinned-Dependencies](https://securityscorecards.dev)

*Automated security hardening PR.*