### PR TITLE
guard against detected-box count overflow in detection_postprocess

### DIFF
--- a/tensorflow/lite/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/kernels/detection_postprocess.cc
@@ -162,12 +162,25 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, NumDimensions(input_box_encodings), 3);
   TF_LITE_ENSURE_EQ(context, NumDimensions(input_class_predictions), 3);
   TF_LITE_ENSURE_EQ(context, NumDimensions(input_anchors), 2);
-  // number of detected boxes. max_detections and max_classes_per_detection come
+  // The class dimension of the predictions input sizes the temporary scores
+  // tensor and is indexed while writing results in Eval, so a zero here leaves
+  // those reads and writes out of bounds.
+  TF_LITE_ENSURE(context, input_class_predictions->dims->data[2] > 0);
+  // max_detections, max_classes_per_detection and the scale values all come
   // straight from the model's flexbuffer custom_options and are not checked by
-  // the flatbuffer verifier, so guard against a negative value or an overflow
-  // of the int multiply before it is used to size the output tensors.
+  // the flatbuffer verifier, so guard them before they size the output tensors
+  // or decode boxes.
   TF_LITE_ENSURE(context, op_data->max_detections >= 0);
-  TF_LITE_ENSURE(context, op_data->max_classes_per_detection >= 0);
+  // A zero max_classes_per_detection leaves the output tensors zero-sized while
+  // the regular NMS path still writes up to max_detections results, so require
+  // it to be strictly positive.
+  TF_LITE_ENSURE(context, op_data->max_classes_per_detection > 0);
+  // Zero scale values would divide by zero while decoding boxes.
+  TF_LITE_ENSURE(context, op_data->scale_values.y != 0);
+  TF_LITE_ENSURE(context, op_data->scale_values.x != 0);
+  TF_LITE_ENSURE(context, op_data->scale_values.h != 0);
+  TF_LITE_ENSURE(context, op_data->scale_values.w != 0);
+  // Guard against an overflow of the int multiply before it sizes the outputs.
   const int64_t num_detected_boxes_64 =
       static_cast<int64_t>(op_data->max_detections) *
       op_data->max_classes_per_detection;

--- a/tensorflow/lite/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/kernels/detection_postprocess.cc
@@ -162,6 +162,13 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, NumDimensions(input_box_encodings), 3);
   TF_LITE_ENSURE_EQ(context, NumDimensions(input_class_predictions), 3);
   TF_LITE_ENSURE_EQ(context, NumDimensions(input_anchors), 2);
+  // The box count has to agree across the three inputs. DecodeCenterSizeBoxes
+  // walks one anchor per box encoding and the class predictions are read per
+  // box in Eval, so a model that supplies fewer anchors or predictions than box
+  // encodings would read past those buffers.
+  const int num_boxes = input_box_encodings->dims->data[1];
+  TF_LITE_ENSURE_EQ(context, input_class_predictions->dims->data[1], num_boxes);
+  TF_LITE_ENSURE_EQ(context, input_anchors->dims->data[0], num_boxes);
   // The class dimension of the predictions input sizes the temporary scores
   // tensor and is indexed while writing results in Eval, so a zero here leaves
   // those reads and writes out of bounds.
@@ -170,11 +177,16 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // straight from the model's flexbuffer custom_options and are not checked by
   // the flatbuffer verifier, so guard them before they size the output tensors
   // or decode boxes.
-  TF_LITE_ENSURE(context, op_data->max_detections >= 0);
+  // A zero max_detections makes num_detections_per_class collapse to zero,
+  // which the regular NMS path rejects later in Eval, so require it up front.
+  TF_LITE_ENSURE(context, op_data->max_detections > 0);
   // A zero max_classes_per_detection leaves the output tensors zero-sized while
   // the regular NMS path still writes up to max_detections results, so require
   // it to be strictly positive.
   TF_LITE_ENSURE(context, op_data->max_classes_per_detection > 0);
+  // detections_per_class comes from the same custom options; a negative value
+  // otherwise only fails later in the regular NMS path, so reject it here too.
+  TF_LITE_ENSURE(context, op_data->detections_per_class >= 0);
   // Zero scale values would divide by zero while decoding boxes.
   TF_LITE_ENSURE(context, op_data->scale_values.y != 0);
   TF_LITE_ENSURE(context, op_data->scale_values.x != 0);

--- a/tensorflow/lite/kernels/detection_postprocess.cc
+++ b/tensorflow/lite/kernels/detection_postprocess.cc
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <algorithm>
 #include <initializer_list>
+#include <limits>
 #include <numeric>
 #include <vector>
 
@@ -161,9 +162,18 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_EQ(context, NumDimensions(input_box_encodings), 3);
   TF_LITE_ENSURE_EQ(context, NumDimensions(input_class_predictions), 3);
   TF_LITE_ENSURE_EQ(context, NumDimensions(input_anchors), 2);
-  // number of detected boxes
-  const int num_detected_boxes =
-      op_data->max_detections * op_data->max_classes_per_detection;
+  // number of detected boxes. max_detections and max_classes_per_detection come
+  // straight from the model's flexbuffer custom_options and are not checked by
+  // the flatbuffer verifier, so guard against a negative value or an overflow
+  // of the int multiply before it is used to size the output tensors.
+  TF_LITE_ENSURE(context, op_data->max_detections >= 0);
+  TF_LITE_ENSURE(context, op_data->max_classes_per_detection >= 0);
+  const int64_t num_detected_boxes_64 =
+      static_cast<int64_t>(op_data->max_detections) *
+      op_data->max_classes_per_detection;
+  TF_LITE_ENSURE(context, num_detected_boxes_64 <=
+                              std::numeric_limits<int>::max());
+  const int num_detected_boxes = static_cast<int>(num_detected_boxes_64);
 
   // Outputs: detection_boxes, detection_scores, detection_classes,
   // num_detections

--- a/tensorflow/lite/kernels/detection_postprocess_test.cc
+++ b/tensorflow/lite/kernels/detection_postprocess_test.cc
@@ -180,6 +180,12 @@ TEST(DetectionPostprocessOpTest, RejectsNegativeMaxDetections) {
   EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
 }
 
+TEST(DetectionPostprocessOpTest, RejectsNegativeMaxClassesPerDetection) {
+  PrepareOnlyDetectionPostprocessOpModel m(/*max_detections=*/1,
+                                           /*max_classes_per_detection=*/-1);
+  EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
+}
+
 TEST(DetectionPostprocessOpTest, FloatTest) {
   BaseDetectionPostprocessOpModel m(
       {TensorType_FLOAT32, {1, 6, 4}}, {TensorType_FLOAT32, {1, 6, 3}},

--- a/tensorflow/lite/kernels/detection_postprocess_test.cc
+++ b/tensorflow/lite/kernels/detection_postprocess_test.cc
@@ -129,9 +129,11 @@ class BaseDetectionPostprocessOpModel : public SingleOpModel {
 class PrepareOnlyDetectionPostprocessOpModel : public SingleOpModel {
  public:
   PrepareOnlyDetectionPostprocessOpModel(int max_detections,
-                                         int max_classes_per_detection) {
+                                         int max_classes_per_detection,
+                                         float scale = 10.0,
+                                         int num_class_predictions = 2) {
     input1_ = AddInput({TensorType_FLOAT32, {1, 1, 4}});
-    input2_ = AddInput({TensorType_FLOAT32, {1, 1, 2}});
+    input2_ = AddInput({TensorType_FLOAT32, {1, 1, num_class_predictions}});
     input3_ = AddInput({TensorType_FLOAT32, {1, 4}});
     AddOutput({TensorType_FLOAT32, {}});
     AddOutput({TensorType_FLOAT32, {}});
@@ -145,10 +147,10 @@ class PrepareOnlyDetectionPostprocessOpModel : public SingleOpModel {
       fbb.Float("nms_score_threshold", 0.0);
       fbb.Float("nms_iou_threshold", 0.5);
       fbb.Int("num_classes", 1);
-      fbb.Float("y_scale", 10.0);
-      fbb.Float("x_scale", 10.0);
-      fbb.Float("h_scale", 5.0);
-      fbb.Float("w_scale", 5.0);
+      fbb.Float("y_scale", scale);
+      fbb.Float("x_scale", scale);
+      fbb.Float("h_scale", scale);
+      fbb.Float("w_scale", scale);
     });
     fbb.Finish();
     SetCustomOp("TFLite_Detection_PostProcess", fbb.GetBuffer(),
@@ -183,6 +185,33 @@ TEST(DetectionPostprocessOpTest, RejectsNegativeMaxDetections) {
 TEST(DetectionPostprocessOpTest, RejectsNegativeMaxClassesPerDetection) {
   PrepareOnlyDetectionPostprocessOpModel m(/*max_detections=*/1,
                                            /*max_classes_per_detection=*/-1);
+  EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
+}
+
+// A zero max_classes_per_detection leaves the outputs zero-sized while the
+// regular NMS path still writes up to max_detections results, so Prepare() must
+// reject it.
+TEST(DetectionPostprocessOpTest, RejectsZeroMaxClassesPerDetection) {
+  PrepareOnlyDetectionPostprocessOpModel m(/*max_detections=*/1,
+                                           /*max_classes_per_detection=*/0);
+  EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
+}
+
+// A zero scale value would divide by zero while decoding boxes.
+TEST(DetectionPostprocessOpTest, RejectsZeroScale) {
+  PrepareOnlyDetectionPostprocessOpModel m(/*max_detections=*/1,
+                                           /*max_classes_per_detection=*/1,
+                                           /*scale=*/0.0);
+  EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
+}
+
+// A zero class dimension on the predictions input leaves the score reads and
+// writes in Eval out of bounds.
+TEST(DetectionPostprocessOpTest, RejectsZeroClassDimension) {
+  PrepareOnlyDetectionPostprocessOpModel m(/*max_detections=*/1,
+                                           /*max_classes_per_detection=*/1,
+                                           /*scale=*/10.0,
+                                           /*num_class_predictions=*/0);
   EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
 }
 

--- a/tensorflow/lite/kernels/detection_postprocess_test.cc
+++ b/tensorflow/lite/kernels/detection_postprocess_test.cc
@@ -131,10 +131,14 @@ class PrepareOnlyDetectionPostprocessOpModel : public SingleOpModel {
   PrepareOnlyDetectionPostprocessOpModel(int max_detections,
                                          int max_classes_per_detection,
                                          float scale = 10.0,
-                                         int num_class_predictions = 2) {
-    input1_ = AddInput({TensorType_FLOAT32, {1, 1, 4}});
-    input2_ = AddInput({TensorType_FLOAT32, {1, 1, num_class_predictions}});
-    input3_ = AddInput({TensorType_FLOAT32, {1, 4}});
+                                         int num_class_predictions = 2,
+                                         int num_boxes = 1, int num_anchors = 1,
+                                         int num_class_boxes = 1,
+                                         int detections_per_class = 100) {
+    input1_ = AddInput({TensorType_FLOAT32, {1, num_boxes, 4}});
+    input2_ =
+        AddInput({TensorType_FLOAT32, {1, num_class_boxes, num_class_predictions}});
+    input3_ = AddInput({TensorType_FLOAT32, {num_anchors, 4}});
     AddOutput({TensorType_FLOAT32, {}});
     AddOutput({TensorType_FLOAT32, {}});
     AddOutput({TensorType_FLOAT32, {}});
@@ -144,6 +148,7 @@ class PrepareOnlyDetectionPostprocessOpModel : public SingleOpModel {
     fbb.Map([&]() {
       fbb.Int("max_detections", max_detections);
       fbb.Int("max_classes_per_detection", max_classes_per_detection);
+      fbb.Int("detections_per_class", detections_per_class);
       fbb.Float("nms_score_threshold", 0.0);
       fbb.Float("nms_iou_threshold", 0.5);
       fbb.Int("num_classes", 1);
@@ -212,6 +217,51 @@ TEST(DetectionPostprocessOpTest, RejectsZeroClassDimension) {
                                            /*max_classes_per_detection=*/1,
                                            /*scale=*/10.0,
                                            /*num_class_predictions=*/0);
+  EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
+}
+
+// A zero max_detections collapses num_detections_per_class to zero, which the
+// regular NMS path rejects during Eval, so Prepare() rejects it up front.
+TEST(DetectionPostprocessOpTest, RejectsZeroMaxDetections) {
+  PrepareOnlyDetectionPostprocessOpModel m(/*max_detections=*/0,
+                                           /*max_classes_per_detection=*/1);
+  EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
+}
+
+// A negative detections_per_class otherwise only fails later in the regular NMS
+// path, so Prepare() rejects it early.
+TEST(DetectionPostprocessOpTest, RejectsNegativeDetectionsPerClass) {
+  PrepareOnlyDetectionPostprocessOpModel m(/*max_detections=*/1,
+                                           /*max_classes_per_detection=*/1,
+                                           /*scale=*/10.0,
+                                           /*num_class_predictions=*/2,
+                                           /*num_boxes=*/1, /*num_anchors=*/1,
+                                           /*num_class_boxes=*/1,
+                                           /*detections_per_class=*/-1);
+  EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
+}
+
+// Fewer anchors than box encodings would read past the anchors buffer while
+// decoding, so Prepare() must reject the mismatch.
+TEST(DetectionPostprocessOpTest, RejectsAnchorCountMismatch) {
+  PrepareOnlyDetectionPostprocessOpModel m(/*max_detections=*/1,
+                                           /*max_classes_per_detection=*/1,
+                                           /*scale=*/10.0,
+                                           /*num_class_predictions=*/2,
+                                           /*num_boxes=*/2, /*num_anchors=*/1,
+                                           /*num_class_boxes=*/2);
+  EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
+}
+
+// Fewer class prediction rows than box encodings would read past the scores
+// buffer, so Prepare() must reject the mismatch.
+TEST(DetectionPostprocessOpTest, RejectsClassPredictionCountMismatch) {
+  PrepareOnlyDetectionPostprocessOpModel m(/*max_detections=*/1,
+                                           /*max_classes_per_detection=*/1,
+                                           /*scale=*/10.0,
+                                           /*num_class_predictions=*/2,
+                                           /*num_boxes=*/2, /*num_anchors=*/2,
+                                           /*num_class_boxes=*/1);
   EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
 }
 

--- a/tensorflow/lite/kernels/detection_postprocess_test.cc
+++ b/tensorflow/lite/kernels/detection_postprocess_test.cc
@@ -123,6 +123,63 @@ class BaseDetectionPostprocessOpModel : public SingleOpModel {
   int output4_;
 };
 
+// Builds the op but stops short of allocating tensors, so a Prepare() failure
+// can be observed via AllocateTensors() instead of crashing during model
+// construction.
+class PrepareOnlyDetectionPostprocessOpModel : public SingleOpModel {
+ public:
+  PrepareOnlyDetectionPostprocessOpModel(int max_detections,
+                                         int max_classes_per_detection) {
+    input1_ = AddInput({TensorType_FLOAT32, {1, 1, 4}});
+    input2_ = AddInput({TensorType_FLOAT32, {1, 1, 2}});
+    input3_ = AddInput({TensorType_FLOAT32, {1, 4}});
+    AddOutput({TensorType_FLOAT32, {}});
+    AddOutput({TensorType_FLOAT32, {}});
+    AddOutput({TensorType_FLOAT32, {}});
+    AddOutput({TensorType_FLOAT32, {}});
+
+    flexbuffers::Builder fbb;
+    fbb.Map([&]() {
+      fbb.Int("max_detections", max_detections);
+      fbb.Int("max_classes_per_detection", max_classes_per_detection);
+      fbb.Float("nms_score_threshold", 0.0);
+      fbb.Float("nms_iou_threshold", 0.5);
+      fbb.Int("num_classes", 1);
+      fbb.Float("y_scale", 10.0);
+      fbb.Float("x_scale", 10.0);
+      fbb.Float("h_scale", 5.0);
+      fbb.Float("w_scale", 5.0);
+    });
+    fbb.Finish();
+    SetCustomOp("TFLite_Detection_PostProcess", fbb.GetBuffer(),
+                Register_DETECTION_POSTPROCESS);
+    BuildInterpreter({GetShape(input1_), GetShape(input2_), GetShape(input3_)},
+                     /*num_threads=*/1, /*allow_fp32_relax_to_fp16=*/false,
+                     /*apply_delegate=*/false,
+                     /*allocate_and_delegate=*/false);
+  }
+
+ private:
+  int input1_;
+  int input2_;
+  int input3_;
+};
+
+// max_detections * max_classes_per_detection overflows int and used to wrap to
+// a non-positive output dimension, producing undersized output tensors that the
+// kernel then wrote past. Prepare() must reject it instead.
+TEST(DetectionPostprocessOpTest, RejectsDetectedBoxesOverflow) {
+  PrepareOnlyDetectionPostprocessOpModel m(/*max_detections=*/1 << 29,
+                                           /*max_classes_per_detection=*/8);
+  EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
+}
+
+TEST(DetectionPostprocessOpTest, RejectsNegativeMaxDetections) {
+  PrepareOnlyDetectionPostprocessOpModel m(/*max_detections=*/-1,
+                                           /*max_classes_per_detection=*/1);
+  EXPECT_EQ(m.AllocateTensors(), kTfLiteError);
+}
+
 TEST(DetectionPostprocessOpTest, FloatTest) {
   BaseDetectionPostprocessOpModel m(
       {TensorType_FLOAT32, {1, 6, 4}}, {TensorType_FLOAT32, {1, 6, 3}},


### PR DESCRIPTION
max_detections and max_classes_per_detection in the TFLite_Detection_PostProcess op come straight from the model's flexbuffer custom_options, which the flatbuffer verifier does not inspect, and Prepare multiplies them as ints to size the detection output tensors. A crafted model can wrap that product round to zero or a negative value, leaving the output tensors undersized, after which the fast-NMS path in Eval writes past them. This computes the product in int64 and rejects it in Prepare when it is negative or larger than INT_MAX, in line with the surrounding TF_LITE_ENSURE checks, and adds a couple of prepare-only regression tests.