### PR TITLE
Fix TypeError in tf.nn.weighted_moments when axes is a tf.Tensor

### DIFF
--- a/tensorflow/python/ops/BUILD
+++ b/tensorflow/python/ops/BUILD
@@ -4372,6 +4372,7 @@ py_library(
         "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:dtypes",
         "//tensorflow/python/framework:ops",
+        "//tensorflow/python/framework:tensor_util",
         "//tensorflow/python/platform:device_context",
         "//tensorflow/python/util:deprecation",
         "//tensorflow/python/util:dispatch",

--- a/tensorflow/python/ops/nn_batchnorm_test.py
+++ b/tensorflow/python/ops/nn_batchnorm_test.py
@@ -693,6 +693,70 @@ class WeightedMomentsTest(MomentsTest):
       self.assertAllCloseAccordingToType(expected_mean, mean_v)
       self.assertAllCloseAccordingToType(expected_variance, var_v)
 
+  def testTensorAxesKeepdimsFalse(self):
+    """Regression test for GitHub issue #101580.
+
+    tf.nn.weighted_moments should work when `axes` is a tf.Tensor, not just a
+    Python list of ints.  The bug caused a TypeError from squeeze_eager_fallback
+    because it requires axis to be a list or tuple, not a tf.Tensor.  The fix
+    normalizes a constant-valued tf.Tensor axes to a Python list before squeeze.
+    """
+    x = constant_op.constant(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=dtypes.float32)
+    w = constant_op.constant(
+        [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], dtype=dtypes.float32)
+
+    # axes as a tf.Tensor - this is the failing case before the fix
+    axes_tensor = constant_op.constant([1], dtype=dtypes.int32)
+    mean, var = nn_impl.weighted_moments(
+        x, axes_tensor, w, keep_dims=False)
+
+    self.assertAllEqual(mean.shape, [2])
+    self.assertAllEqual(var.shape, [2])
+    self.assertAllClose(mean, [2.0, 5.0])
+    self.assertAllClose(var, [2.0 / 3.0, 2.0 / 3.0])
+
+  def testTensorAxesKeepdimsFalseAxis0(self):
+    """Test with axes=[0] as a tf.Tensor and keepdims=False."""
+    x = constant_op.constant(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=dtypes.float32)
+    w = constant_op.constant(
+        [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], dtype=dtypes.float32)
+
+    axes_tensor = constant_op.constant([0], dtype=dtypes.int32)
+    mean, var = nn_impl.weighted_moments(
+        x, axes_tensor, w, keep_dims=False)
+
+    self.assertAllEqual(mean.shape, [3])
+    self.assertAllEqual(var.shape, [3])
+    self.assertAllClose(mean, [2.5, 3.5, 4.5])
+
+  def testTensorAxesKeepdimsTrue(self):
+    """When keepdims=True, squeeze is skipped; tf.Tensor axes should work."""
+    x = constant_op.constant(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=dtypes.float32)
+    w = constant_op.constant(1.0, dtype=dtypes.float32)
+
+    axes_tensor = constant_op.constant([1], dtype=dtypes.int32)
+    mean, var = nn_impl.weighted_moments(
+        x, axes_tensor, w, keep_dims=True)
+
+    # keepdims=True keeps the reduced dimension as size 1
+    self.assertAllEqual(mean.shape, [2, 1])
+    self.assertAllEqual(var.shape, [2, 1])
+    self.assertAllClose(mean, [[2.0], [5.0]])
+
+  def testListAxesKeepdimsFalse(self):
+    """Plain Python list axes continue to work correctly after the fix."""
+    x = constant_op.constant(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=dtypes.float32)
+    w = constant_op.constant(1.0, dtype=dtypes.float32)
+
+    mean, var = nn_impl.weighted_moments(x, [1], w, keep_dims=False)
+
+    self.assertAllEqual(mean.shape, [2])
+    self.assertAllClose(mean, [2.0, 5.0])
+
   def testAllZeroMasks(self):
     x = np.random.normal(size=[8, 3, 4]).astype(np.float32)
     weights = np.zeros(shape=[8, 3, 1]).astype(np.float32)

--- a/tensorflow/python/ops/nn_impl.py
+++ b/tensorflow/python/ops/nn_impl.py
@@ -20,6 +20,7 @@ import warnings
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_util
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import array_ops_stack
 from tensorflow.python.ops import candidate_sampling_ops
@@ -39,6 +40,7 @@ from tensorflow.python.util import dispatch
 from tensorflow.python.util.deprecation import deprecated_args
 from tensorflow.python.util.deprecation import deprecated_argument_lookup
 from tensorflow.python.util.tf_export import tf_export
+
 
 
 @tf_export("nn.log_poisson_loss")
@@ -1390,9 +1392,21 @@ def weighted_moments(x, axes, frequency_weights, name=None, keep_dims=None,
     weighted_variance = math_ops.div_no_nan(weighted_distsq, sum_of_weights)
 
     if not keep_dims:
-      weighted_mean = array_ops.squeeze(weighted_mean, axis=axes)
+      # `tf.squeeze` requires axis to be a Python list or tuple in eager mode.
+      # Normalize `axes` here so that callers can pass either a Python list, a
+      # numpy array, or a `tf.Tensor` (as documented in the function signature),
+      # matching the behavior of `tf.nn.moments()`. See GitHub issue #101580.
+      squeeze_axes = axes
+      if tensor_util.is_tf_type(squeeze_axes):
+        static_axes = tensor_util.constant_value(squeeze_axes)
+        if static_axes is not None:
+          squeeze_axes = static_axes.tolist()
+      elif hasattr(squeeze_axes, "tolist"):
+        # numpy array or similar - convert to Python list
+        squeeze_axes = squeeze_axes.tolist()
+      weighted_mean = array_ops.squeeze(weighted_mean, axis=squeeze_axes)
       weighted_variance = array_ops.squeeze(
-          weighted_variance, axis=axes)
+          weighted_variance, axis=squeeze_axes)
 
     if needs_cast:
       weighted_mean = math_ops.cast(weighted_mean, dtypes.float16)


### PR DESCRIPTION
Fixes #101580 
## Problem

`tf.nn.weighted_moments(x, axes, w, keepdims=False)` raises a `TypeError` when `axes` is passed as a `tf.Tensor`:

```
TypeError: Expected list for 'axis' argument to 'squeeze' Op,
not <tf.Tensor: shape=(1,), dtype=int32, numpy=array([0])>.
```

`squeeze_eager_fallback` requires its `axis` argument to be a Python `list` or `tuple`. The function signature documents `axes` as a "1-d tensor of int32 values", so passing a `tf.Tensor` is a valid and expected use case. The bug only occurs when `keepdims=False` (the default).

The same issue applies to `numpy array` axes inputs.

## Root cause

In `weighted_moments()`, the squeeze calls were:
```python
weighted_mean = array_ops.squeeze(weighted_mean, axis=axes)
weighted_variance = array_ops.squeeze(weighted_variance, axis=axes)
```

`tf.squeeze` calls `squeeze_eager_fallback` in eager mode, which explicitly checks `isinstance(axis, (list, tuple))` and raises `TypeError` for anything else.

## Fix

Before calling `squeeze`, normalize `axes` to a Python list:
- If `axes` is a `tf.Tensor`, extract its value via `tensor_util.constant_value()` and convert to a list
- - If `axes` is a numpy array (which also fails the same check), call `.tolist()`
This matches the pattern used by `tensor_util.is_tf_type()` already established in `math_ops.py`.

## Reproducer

```python
import tensorflow as tf

data = tf.random.normal(shape=(1, 1000, 1000))
axes = tf.constant([0], dtype=tf.int32)  # tf.Tensor - previously crashed
frequency_weights = tf.constant([1.0] * 1000)

# Before fix: TypeError: Expected list for 'axis' argument to 'squeeze' Op
# After fix: works correctly
mean, var = tf.nn.weighted_moments(data, axes, frequency_weights, keepdims=False)
print(mean.shape)  # (1000, 1000)
```

## Tests

Added 4 regression tests to `WeightedMomentsTest` in `nn_batchnorm_test.py`:
- `testTensorAxesKeepdimsFalse` - main bug case: `axes=tf.constant([1])`, `keepdims=False`
- - `testTensorAxesKeepdimsFalseAxis0` - `axes=tf.constant([0])`, `keepdims=False`
- - `testTensorAxesKeepdimsTrue` - `keepdims=True` path unaffected
- - `testListAxesKeepdimsFalse` - Python list axes still work after fix
- 