### PR TITLE
fix uint32 overflow in table block DecodeEntry bounds check

### DIFF
--- a/third_party/xla/xla/tsl/lib/io/block.cc
+++ b/third_party/xla/xla/tsl/lib/io/block.cc
@@ -82,7 +82,12 @@ static inline const char* DecodeEntry(const char* p, const char* limit,
       return nullptr;
   }
 
-  if (static_cast<uint32_t>(limit - p) < (*non_shared + *value_length)) {
+  // *non_shared and *value_length are attacker-controlled 32-bit varints, so
+  // add them in 64 bits: a 32-bit sum can wrap around and spuriously pass this
+  // bounds check, letting callers read past `limit`.
+  const uint64_t entry_bytes =
+      static_cast<uint64_t>(*non_shared) + static_cast<uint64_t>(*value_length);
+  if (entry_bytes > static_cast<uint64_t>(limit - p)) {
     return nullptr;
   }
   return p;

--- a/third_party/xla/xla/tsl/lib/io/table_test.cc
+++ b/third_party/xla/xla/tsl/lib/io/table_test.cc
@@ -469,6 +469,40 @@ TEST_F(Harness, ZeroRestartPointsInBlock) {
   delete iter;
 }
 
+// A block whose entry lengths overflow a 32-bit sum must be rejected as
+// corrupt rather than driving an out-of-bounds read in DecodeEntry.
+TEST_F(Harness, DecodeEntryLengthOverflow) {
+  std::string data;
+  data.push_back(0);  // shared = 0
+  // non_shared = 0xFFFFFFFF (5-byte varint).
+  data.push_back('\xFF');
+  data.push_back('\xFF');
+  data.push_back('\xFF');
+  data.push_back('\xFF');
+  data.push_back('\x0F');
+  data.push_back(1);  // value_length = 1
+  // A handful of key/value bytes; far fewer than the lengths above claim.
+  data.append(8, 'x');
+  // Restart array: one restart pointing at offset 0, then num_restarts = 1.
+  for (int i = 0; i < 4; i++) data.push_back(0);
+  data.push_back(1);
+  for (int i = 0; i < 3; i++) data.push_back(0);
+
+  BlockContents contents;
+  contents.data = absl::string_view(data);
+  contents.cacheable = false;
+  contents.heap_allocated = false;
+  Block block(contents);
+  Iterator* iter = block.NewIterator();
+  // non_shared + value_length wraps to 0 in 32 bits and would slip past the
+  // bounds check, so this must surface as corruption instead of reading past
+  // the block buffer.
+  iter->SeekToFirst();
+  ASSERT_TRUE(!iter->Valid());
+  ASSERT_TRUE(!iter->status().ok());
+  delete iter;
+}
+
 // Test the empty key
 TEST_F(Harness, SimpleEmptyKey) {
   for (int i = 0; i < kNumTestArgs; i++) {


### PR DESCRIPTION
DecodeEntry validates the key delta and value length with `(uint32_t)(limit - p) < *non_shared + *value_length`, but both varints are attacker-controlled and summed in 32 bits, so a crafted block entry can wrap the sum below the number of bytes actually present and pass the check. When such a block comes from an untrusted checkpoint .index file, ParseNextKey's `key_.append(p, non_shared)` and the Seek binary search then read well past the block buffer. Add the two lengths in 64 bits before the comparison.