### PR TITLE
fixes : resolve ellipsis to explicit labels in xla einsum grad

### DIFF
--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -627,7 +627,8 @@ def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
   # Pick fresh single-char labels for the batch dims. Use letters
   # that do not already appear in the equation.
   used = set(left_explicit + right_explicit + output_explicit)
-  available = [c for c in 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ' if c not in used]
+  all_labels = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  available = [c for c in all_labels if c not in used]
   if len(available) < batch_ndims:
     # Not enough fresh labels; fall back to the original equation.
     return equation
@@ -649,8 +650,10 @@ def _einsum_grad(op, grad):
   # the gradient xla_einsum ops get concrete equations that XLA can lower to
   # efficient DOT/matmul kernels (fixes register-spill regression, #122274).
   if '...' in equation:
-    input0_shape = op.inputs[0].shape.as_list() if op.inputs[0].shape.ndims is not None else None
-    input1_shape = op.inputs[1].shape.as_list() if op.inputs[1].shape.ndims is not None else None
+    shape0 = op.inputs[0].shape
+    shape1 = op.inputs[1].shape
+    input0_shape = shape0.as_list() if shape0.ndims is not None else None
+    input1_shape = shape1.as_list() if shape1.ndims is not None else None
     equation = _resolve_xla_einsum_ellipsis(equation, input0_shape,
                                             input1_shape)
 

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -582,11 +582,75 @@ def bessel_y1(x, name=None):
     return gen_special_math_ops.bessel_y1(x)
 
 
+def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
+  """Resolves ellipsis in an XlaEinsum equation to explicit labels.
+
+  When an einsum equation contains '...', XLA may not lower the resulting
+  gradient operations to efficient DOT instructions, causing register spills
+  (see https://github.com/tensorflow/tensorflow/issues/122274). Replacing '...'
+  with explicit axis labels allows XLA to apply its standard matmul lowering.
+
+  Returns the equation with '...' replaced by concrete labels, or the original
+  equation unchanged if no ellipsis is present or shapes are not static.
+  """
+  if '...' not in equation:
+    return equation
+
+  inputs_str, output = equation.split('->')
+  left, right = inputs_str.split(',')
+
+  # Count the number of explicit (non-ellipsis) chars in each subscript.
+  left_explicit = left.replace('...', '')
+  right_explicit = right.replace('...', '')
+  output_explicit = output.replace('...', '')
+
+  # Determine the number of batch dims the ellipsis covers for each operand.
+  # The ellipsis covers (rank - explicit_count) dims for each operand.
+  rank0 = len(input0_shape) if input0_shape is not None else None
+  rank1 = len(input1_shape) if input1_shape is not None else None
+
+  if rank0 is None or rank1 is None:
+    # Cannot resolve without static shape info; return unchanged.
+    return equation
+
+  batch0 = rank0 - len(left_explicit)
+  batch1 = rank1 - len(right_explicit)
+  # The ellipsis covers the maximum batch dims across operands (broadcasting).
+  batch_ndims = max(batch0, batch1)
+
+  if batch_ndims <= 0:
+    # No actual batch dims: simply strip the ellipsis.
+    return '{},{}->{}'.format(left_explicit, right_explicit, output_explicit)
+
+  # Pick fresh single-char labels for the batch dims. Use lowercase letters
+  # that do not already appear in the equation.
+  used = set(left_explicit + right_explicit + output_explicit)
+  available = [c for c in 'abcdefghijklmnopqrstuvwxyz' if c not in used]
+  if len(available) < batch_ndims:
+    # Not enough fresh labels; fall back to the original equation.
+    return equation
+
+  batch_labels = ''.join(available[:batch_ndims])
+  resolved_left = left.replace('...', batch_labels)
+  resolved_right = right.replace('...', batch_labels)
+  resolved_output = output.replace('...', batch_labels)
+  return '{},{}->{}'.format(resolved_left, resolved_right, resolved_output)
+
+
 @ops.RegisterGradient('XlaEinsum')
 def _einsum_grad(op, grad):
   equation = op.get_attr('equation')
   if isinstance(equation, bytes):
     equation = equation.decode()
+
+  # When the equation has '...', resolve it to explicit batch labels so that
+  # the gradient xla_einsum ops get concrete equations that XLA can lower to
+  # efficient DOT/matmul kernels (fixes register-spill regression, #122274).
+  if '...' in equation:
+    input0_shape = op.inputs[0].shape.as_list() if op.inputs[0].shape else None
+    input1_shape = op.inputs[1].shape.as_list() if op.inputs[1].shape else None
+    equation = _resolve_xla_einsum_ellipsis(equation, input0_shape,
+                                            input1_shape)
 
   inputs, output = equation.split('->')
   left, right = inputs.split(',')

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -615,6 +615,8 @@ def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
 
   batch0 = rank0 - len(left_explicit)
   batch1 = rank1 - len(right_explicit)
+  if '...' in left and '...' in right and batch0 != batch1:
+    return equation
   # The ellipsis covers the maximum batch dims across operands (broadcasting).
   batch_ndims = max(batch0, batch1)
 
@@ -647,8 +649,8 @@ def _einsum_grad(op, grad):
   # the gradient xla_einsum ops get concrete equations that XLA can lower to
   # efficient DOT/matmul kernels (fixes register-spill regression, #122274).
   if '...' in equation:
-    input0_shape = op.inputs[0].shape.as_list() if op.inputs[0].shape else None
-    input1_shape = op.inputs[1].shape.as_list() if op.inputs[1].shape else None
+    input0_shape = op.inputs[0].shape.as_list() if op.inputs[0].shape.ndims is not None else None
+    input1_shape = op.inputs[1].shape.as_list() if op.inputs[1].shape.ndims is not None else None
     equation = _resolve_xla_einsum_ellipsis(equation, input0_shape,
                                             input1_shape)
 

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -622,10 +622,10 @@ def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
     # No actual batch dims: simply strip the ellipsis.
     return '{},{}->{}'.format(left_explicit, right_explicit, output_explicit)
 
-  # Pick fresh single-char labels for the batch dims. Use lowercase letters
+  # Pick fresh single-char labels for the batch dims. Use letters
   # that do not already appear in the equation.
   used = set(left_explicit + right_explicit + output_explicit)
-  available = [c for c in 'abcdefghijklmnopqrstuvwxyz' if c not in used]
+  available = [c for c in 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ' if c not in used]
   if len(available) < batch_ndims:
     # Not enough fresh labels; fall back to the original equation.
     return equation

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -590,9 +590,16 @@ def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
   (see https://github.com/tensorflow/tensorflow/issues/122274). Replacing '...'
   with explicit axis labels allows XLA to apply its standard matmul lowering.
 
+  Handles broadcasting cases by aligning ellipsis dimensions from the right
+  (standard NumPy broadcasting rules). Strips whitespace from the equation
+  before processing to avoid incorrect label counts.
+
   Returns the equation with '...' replaced by concrete labels, or the original
   equation unchanged if no ellipsis is present or shapes are not static.
   """
+  # Remove spaces to ensure correct length calculations (e.g. '...ab, bc->...ac').
+  equation = equation.replace(' ', '')
+
   if '...' not in equation:
     return equation
 
@@ -615,8 +622,7 @@ def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
 
   batch0 = rank0 - len(left_explicit)
   batch1 = rank1 - len(right_explicit)
-  if '...' in left and '...' in right and batch0 != batch1:
-    return equation
+
   # The ellipsis covers the maximum batch dims across operands (broadcasting).
   batch_ndims = max(batch0, batch1)
 
@@ -624,8 +630,10 @@ def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
     # No actual batch dims: simply strip the ellipsis.
     return '{},{}->{}'.format(left_explicit, right_explicit, output_explicit)
 
-  # Pick fresh single-char labels for the batch dims. Use letters
-  # that do not already appear in the equation.
+  # Pick fresh single-char labels for the batch dims. Use letters (both lower
+  # and upper case) that do not already appear in the equation. Including
+  # uppercase letters prevents running out of labels for equations with many
+  # existing lowercase labels.
   used = set(left_explicit + right_explicit + output_explicit)
   all_labels = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
   available = [c for c in all_labels if c not in used]
@@ -634,8 +642,14 @@ def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
     return equation
 
   batch_labels = ''.join(available[:batch_ndims])
-  resolved_left = left.replace('...', batch_labels)
-  resolved_right = right.replace('...', batch_labels)
+
+  # Align broadcasting from the right (standard broadcasting rules).
+  # An operand with fewer batch dims gets a suffix of the full batch_labels.
+  left_labels = batch_labels[-batch0:] if batch0 > 0 else ''
+  right_labels = batch_labels[-batch1:] if batch1 > 0 else ''
+
+  resolved_left = left.replace('...', left_labels)
+  resolved_right = right.replace('...', right_labels)
   resolved_output = output.replace('...', batch_labels)
   return '{},{}->{}'.format(resolved_left, resolved_right, resolved_output)
 

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -594,8 +594,22 @@ def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
   (standard NumPy broadcasting rules). Strips whitespace from the equation
   before processing to avoid incorrect label counts.
 
-  Returns the equation with '...' replaced by concrete labels, or the original
-  equation unchanged if no ellipsis is present or shapes are not static.
+  Args:
+    equation: A string representing the einsum equation, possibly containing
+      '...' to denote one or more batch dimensions. Whitespace in the string
+      is stripped before processing when an ellipsis is present.
+    input0_shape: A list of ints giving the shape of the first operand, or
+      None if the rank is not statically known.
+    input1_shape: A list of ints giving the shape of the second operand, or
+      None if the rank is not statically known.
+
+  Returns:
+    The equation string with every '...' replaced by concrete single-character
+    labels chosen from unused letters. Broadcasting is handled by
+    right-aligning the batch labels across operands. Returns the original
+    equation unchanged when no ellipsis is present, when either rank is
+    unknown, when the inputs appear malformed, or when there are not enough
+    unused letters to cover all batch dimensions.
   """
   if '...' not in equation:
     return equation

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -597,12 +597,12 @@ def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
   Returns the equation with '...' replaced by concrete labels, or the original
   equation unchanged if no ellipsis is present or shapes are not static.
   """
+  if '...' not in equation:
+    return equation
+
   # Remove spaces to ensure correct length calculations
   # (e.g. '...ab, bc->...ac').
   equation = equation.replace(' ', '')
-
-  if '...' not in equation:
-    return equation
 
   inputs_str, output = equation.split('->')
   left, right = inputs_str.split(',')
@@ -623,6 +623,11 @@ def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
 
   batch0 = rank0 - len(left_explicit)
   batch1 = rank1 - len(right_explicit)
+
+  # If either operand's rank is less than its explicit label count, the
+  # equation/shape is malformed; fall back to the original equation.
+  if batch0 < 0 or batch1 < 0:
+    return equation
 
   # The ellipsis covers the maximum batch dims across operands (broadcasting).
   batch_ndims = max(batch0, batch1)

--- a/tensorflow/python/ops/special_math_ops.py
+++ b/tensorflow/python/ops/special_math_ops.py
@@ -597,7 +597,8 @@ def _resolve_xla_einsum_ellipsis(equation, input0_shape, input1_shape):
   Returns the equation with '...' replaced by concrete labels, or the original
   equation unchanged if no ellipsis is present or shapes are not static.
   """
-  # Remove spaces to ensure correct length calculations (e.g. '...ab, bc->...ac').
+  # Remove spaces to ensure correct length calculations
+  # (e.g. '...ab, bc->...ac').
   equation = equation.replace(' ', '')
 
   if '...' not in equation:

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -1190,14 +1190,27 @@ class ResolveXlaEinsumEllipsisTest(test.TestCase):
     result = self._fn(eq, [2, 3, 4, 5], [5, 6])
     self.assertEqual(result, 'deab,bc->deac')
 
+  def test_no_ellipsis_with_spaces_unchanged(self):
+    """Equations without '...' are returned unchanged, even with spaces."""
+    eq = 'ab, bc -> ac'
+    result = self._fn(eq, [4, 5], [5, 6])
+    # No ellipsis: the original string (including spaces) must be returned.
+    self.assertEqual(result, eq)
+
+  def test_negative_batch_falls_back(self):
+    """Falls back when rank is less than explicit label count (malformed)."""
+    # rank0=1 but left_explicit='ab' (len 2) -> batch0 = 1-2 = -1
+    eq = '...ab,...bc->...ac'
+    result = self._fn(eq, [1], [3, 5, 6])
+    self.assertEqual(result, eq)
+
   def test_uppercase_labels_used_when_lowercase_exhausted(self):
     """Batch label is uppercase when all lowercase letters are in use."""
     # Use all 26 lowercase letters as explicit labels so that the helper must
     # fall back to uppercase letters for the single batch dimension.
-    explicit = 'abcdefghijklmnopqrstuvwxyz'
-    # Equation: '...<26 lower>,<26 lower>A->...A'
     # left_explicit  = 26 chars  -> rank 27 -> batch0 = 1
     # right_explicit = 27 chars  -> rank 28 -> batch1 = 1  (no ellipsis)
+    explicit = 'abcdefghijklmnopqrstuvwxyz'
     eq = '...{0},{0}A->...A'.format(explicit)
     shape0 = [1] * 27   # rank 27: 1 batch dim + 26 explicit dims
     shape1 = [1] * 28   # rank 28: 27 explicit dims (no ellipsis in right)
@@ -1205,14 +1218,15 @@ class ResolveXlaEinsumEllipsisTest(test.TestCase):
     # The ellipsis must have been resolved (no '...' remaining).
     self.assertNotIn('...', result)
     self.assertIn('->', result)
-    # The resolved batch label must be an uppercase letter ('A' is in 'used'
-    # via the 'A' in explicit right subscript and output, so expect 'B').
+    # All 26 lowercase letters are in 'used', and 'A' is also used, so the
+    # first available label is 'B' (uppercase).
     resolved_left = result.split('->')[0].split(',')[0]
     batch_label = resolved_left[0]   # first char of left subscript is batch
     self.assertTrue(
         batch_label.isupper(),
         msg=(f'Expected an uppercase batch label, '
              f'got {batch_label!r} in {result!r}'))
+    self.assertEqual(batch_label, 'B')
 
 
 class EinsumBenchmark(test.Benchmark):

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -1120,6 +1120,93 @@ class EinsumGradTest(test.TestCase):
       self._check_gradient(equation, *input_shapes)
 
 
+class ResolveXlaEinsumEllipsisTest(test.TestCase):
+  """Unit tests for _resolve_xla_einsum_ellipsis."""
+
+  def _fn(self, equation, shape0, shape1):
+    # Access the private helper directly for unit testing.
+    return special_math_ops._resolve_xla_einsum_ellipsis(
+        equation, shape0, shape1)
+
+  def test_no_ellipsis(self):
+    """Equations without '...' should be returned unchanged."""
+    eq = 'ab,bc->ac'
+    result = self._fn(eq, [4, 5], [5, 6])
+    self.assertEqual(result, 'ab,bc->ac')
+
+  def test_same_rank_both_ellipsis(self):
+    """Both operands have the same number of batch dims."""
+    eq = '...ab,...bc->...ac'
+    result = self._fn(eq, [2, 3, 4, 5], [2, 3, 5, 6])
+    self.assertEqual(result, 'deab,debc->deac')
+
+  def test_broadcasting_left_larger(self):
+    """Left operand has more batch dims than right (broadcasting)."""
+    eq = '...ab,...bc->...ac'
+    result = self._fn(eq, [2, 3, 4, 5], [3, 5, 6])
+    # batch_ndims=2, left gets 'de', right gets 'e' (right-aligned).
+    self.assertEqual(result, 'deab,ebc->deac')
+
+  def test_broadcasting_right_larger(self):
+    """Right operand has more batch dims than left (broadcasting)."""
+    eq = '...ab,...bc->...ac'
+    result = self._fn(eq, [3, 4, 5], [2, 3, 5, 6])
+    # batch_ndims=2, left gets 'e' (right-aligned), right gets 'de'.
+    self.assertEqual(result, 'eab,debc->deac')
+
+  def test_right_no_ellipsis(self):
+    """Only left operand has ellipsis."""
+    eq = '...ab,bc->...ac'
+    result = self._fn(eq, [2, 3, 4, 5], [5, 6])
+    self.assertEqual(result, 'deab,bc->deac')
+
+  def test_left_no_ellipsis(self):
+    """Only right operand has ellipsis."""
+    eq = 'ab,...bc->...ac'
+    result = self._fn(eq, [4, 5], [2, 3, 5, 6])
+    self.assertEqual(result, 'ab,debc->deac')
+
+  def test_unknown_rank_input0(self):
+    """Falls back to original equation when input0 shape is unknown."""
+    eq = '...ab,...bc->...ac'
+    result = self._fn(eq, None, [2, 3, 5, 6])
+    self.assertEqual(result, eq)
+
+  def test_unknown_rank_input1(self):
+    """Falls back to original equation when input1 shape is unknown."""
+    eq = '...ab,...bc->...ac'
+    result = self._fn(eq, [2, 3, 4, 5], None)
+    self.assertEqual(result, eq)
+
+  def test_zero_batch_dims(self):
+    """Ellipsis covers zero dims: strip it, return explicit equation."""
+    eq = '...ab,...bc->...ac'
+    result = self._fn(eq, [4, 5], [5, 6])
+    self.assertEqual(result, 'ab,bc->ac')
+
+  def test_spaces_in_equation(self):
+    """Spaces in the equation are stripped before processing."""
+    eq = '...ab,  bc -> ...ac'
+    result = self._fn(eq, [2, 3, 4, 5], [5, 6])
+    self.assertEqual(result, 'deab,bc->deac')
+
+  def test_uppercase_labels_used_when_lowercase_exhausted(self):
+    """Falls back to uppercase labels when many lowercase labels are in use."""
+    # Use 26 lowercase letters as explicit labels; batch dim should use 'A'.
+    explicit = 'abcdefghijklmnopqrstuvwxyz'
+    # Create equation: <26 chars>p,pq-><25 chars>q  (but use '...' on left)
+    # Actually just construct a scenario where 'a'-'z' are all taken.
+    # left_explicit uses all 26 lowercase letters, right uses 'A'
+    eq = '...{0},{0}A->...A'.format(explicit[0])  # '...a,aA->...A'
+    # All of 'a'-'z' are in used set already; batch label must come from upper.
+    shape0 = [1] + [1]  # rank 2, 1 explicit char 'a', batch = 1
+    shape1 = [1, 1]     # rank 2, explicit 'aA', no ellipsis
+    result = self._fn(eq, shape0, shape1)
+    # batch_ndims = 1; 'a' is used, next fresh label should be uppercase.
+    self.assertNotIn('...', result)
+    self.assertIn('->', result)
+
+
 class EinsumBenchmark(test.Benchmark):
   cases = [
       # Unary cases.

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -1191,20 +1191,27 @@ class ResolveXlaEinsumEllipsisTest(test.TestCase):
     self.assertEqual(result, 'deab,bc->deac')
 
   def test_uppercase_labels_used_when_lowercase_exhausted(self):
-    """Falls back to uppercase labels when many lowercase labels are in use."""
-    # Use 26 lowercase letters as explicit labels; batch dim should use 'A'.
+    """Batch label is uppercase when all lowercase letters are already in use."""
+    # Use all 26 lowercase letters as explicit labels so that the helper must
+    # fall back to uppercase letters for the single batch dimension.
     explicit = 'abcdefghijklmnopqrstuvwxyz'
-    # Create equation: <26 chars>p,pq-><25 chars>q  (but use '...' on left)
-    # Actually just construct a scenario where 'a'-'z' are all taken.
-    # left_explicit uses all 26 lowercase letters, right uses 'A'
-    eq = '...{0},{0}A->...A'.format(explicit[0])  # '...a,aA->...A'
-    # All of 'a'-'z' are in used set already; batch label must come from upper.
-    shape0 = [1] + [1]  # rank 2, 1 explicit char 'a', batch = 1
-    shape1 = [1, 1]     # rank 2, explicit 'aA', no ellipsis
+    # Equation: '...<26 lower>,<26 lower>A->...A'
+    # left_explicit  = 26 chars  -> rank 27 -> batch0 = 1
+    # right_explicit = 27 chars  -> rank 28 -> batch1 = 1  (no ellipsis)
+    eq = '...{0},{0}A->...A'.format(explicit)
+    shape0 = [1] * 27   # rank 27: 1 batch dim + 26 explicit dims
+    shape1 = [1] * 28   # rank 28: 27 explicit dims (no ellipsis in right)
     result = self._fn(eq, shape0, shape1)
-    # batch_ndims = 1; 'a' is used, next fresh label should be uppercase.
+    # The ellipsis must have been resolved (no '...' remaining).
     self.assertNotIn('...', result)
     self.assertIn('->', result)
+    # The resolved batch label must be an uppercase letter ('A' is in 'used'
+    # via the 'A' in explicit right subscript and output, so expect 'B').
+    resolved_left = result.split('->')[0].split(',')[0]
+    batch_label = resolved_left[0]   # first char of left subscript is batch
+    self.assertTrue(
+        batch_label.isupper(),
+        msg=f'Expected an uppercase batch label, got {batch_label!r} in {result!r}')
 
 
 class EinsumBenchmark(test.Benchmark):

--- a/tensorflow/python/ops/special_math_ops_test.py
+++ b/tensorflow/python/ops/special_math_ops_test.py
@@ -1191,7 +1191,7 @@ class ResolveXlaEinsumEllipsisTest(test.TestCase):
     self.assertEqual(result, 'deab,bc->deac')
 
   def test_uppercase_labels_used_when_lowercase_exhausted(self):
-    """Batch label is uppercase when all lowercase letters are already in use."""
+    """Batch label is uppercase when all lowercase letters are in use."""
     # Use all 26 lowercase letters as explicit labels so that the helper must
     # fall back to uppercase letters for the single batch dimension.
     explicit = 'abcdefghijklmnopqrstuvwxyz'
@@ -1211,7 +1211,8 @@ class ResolveXlaEinsumEllipsisTest(test.TestCase):
     batch_label = resolved_left[0]   # first char of left subscript is batch
     self.assertTrue(
         batch_label.isupper(),
-        msg=f'Expected an uppercase batch label, got {batch_label!r} in {result!r}')
+        msg=(f'Expected an uppercase batch label, '
+             f'got {batch_label!r} in {result!r}'))
 
 
 class EinsumBenchmark(test.Benchmark):


### PR DESCRIPTION
fixes #122274

when an einsum equation uses '...' notation, the _einsum_grad function was passing those literal '...' equations to xla_einsum for the gradient ops. in tf 2.21+ xla no longer normalises these internally before compilation, so the resulting kernels are treated as general einsum ops rather than efficient dot/matmul ops — causing large register spills (~50-90 KB vs ~8-84 B in tf 2.20) when jit_compile=True.

fix: add _resolve_xla_einsum_ellipsis() that replaces '...' with concrete single-char axis labels using the static input shapes available on the op. this allows xla to consistently lower the gradient ops to its standard dot/gemm path, restoring the pre-2.21 spill behaviour.

@Venkat6871 I took this issue, feel free to review and add/adjust if I missed something, I am totally fine to collaborate on this one if I missed something