### PR TITLE
Fix TypeError in MeanIoU.update_state when tracing with unknown-rank inputs

### DIFF
--- a/tensorflow/python/keras/metrics.py
+++ b/tensorflow/python/keras/metrics.py
@@ -2948,16 +2948,16 @@ class MeanIoU(Metric):
     y_true = math_ops.cast(y_true, self._dtype)
     y_pred = math_ops.cast(y_pred, self._dtype)
 
-    # Flatten the input if its rank > 1.
-    if y_pred.shape.ndims > 1:
+    # Flatten the input if its rank is unknown or > 1.
+    if y_pred.shape.ndims is None or y_pred.shape.ndims > 1:
       y_pred = array_ops.reshape(y_pred, [-1])
 
-    if y_true.shape.ndims > 1:
+    if y_true.shape.ndims is None or y_true.shape.ndims > 1:
       y_true = array_ops.reshape(y_true, [-1])
 
     if sample_weight is not None:
       sample_weight = math_ops.cast(sample_weight, self._dtype)
-      if sample_weight.shape.ndims > 1:
+      if sample_weight.shape.ndims is None or sample_weight.shape.ndims > 1:
         sample_weight = array_ops.reshape(sample_weight, [-1])
 
     # Accumulate the prediction to current confusion matrix.

--- a/tensorflow/python/kernel_tests/metrics_test.py
+++ b/tensorflow/python/kernel_tests/metrics_test.py
@@ -4595,5 +4595,63 @@ class TruePositivesAtThresholdsTest(test.TestCase):
       self.assertAllEqual((111.0, 37.0, 0.0), tp)
 
 
+class MeanIoUUnknownRankTest(test.TestCase):
+  """Regression tests for MeanIoU with unknown-rank inputs inside tf.function.
+
+  MeanIoU.update_state compared shape.ndims directly to an integer.
+  When a tf.function is traced with input_signature using TensorSpec(shape=None),
+  ndims is None at trace time, causing a TypeError at graph construction.
+  """
+
+  def test_update_state_unknown_rank_does_not_crash(self):
+    """MeanIoU must not crash when traced with fully-dynamic (rank-unknown) inputs."""
+    from tensorflow.python.keras import metrics as keras_metrics  # pylint: disable=g-import-not-at-top
+    from tensorflow.python.eager import def_function  # pylint: disable=g-import-not-at-top
+    from tensorflow.python.framework import tensor_spec  # pylint: disable=g-import-not-at-top
+    from tensorflow.python.framework import dtypes  # pylint: disable=g-import-not-at-top
+
+    metric = keras_metrics.MeanIoU(num_classes=3)
+
+    @def_function.function(input_signature=[
+        tensor_spec.TensorSpec(shape=None, dtype=dtypes.float32),
+        tensor_spec.TensorSpec(shape=None, dtype=dtypes.float32),
+    ])
+    def update(y_true, y_pred):
+      metric.update_state(y_true, y_pred)
+      return metric.result()
+
+    # All-correct predictions: IoU per class = 1.0, mean = 1.0.
+    result = update(
+        constant_op.constant([0.0, 1.0, 2.0]),
+        constant_op.constant([0.0, 1.0, 2.0]),
+    )
+    self.assertAllClose(result, 1.0)
+
+  def test_update_state_unknown_rank_with_sample_weight(self):
+    """sample_weight with unknown rank must not crash during tracing."""
+    from tensorflow.python.keras import metrics as keras_metrics  # pylint: disable=g-import-not-at-top
+    from tensorflow.python.eager import def_function  # pylint: disable=g-import-not-at-top
+    from tensorflow.python.framework import tensor_spec  # pylint: disable=g-import-not-at-top
+    from tensorflow.python.framework import dtypes  # pylint: disable=g-import-not-at-top
+
+    metric = keras_metrics.MeanIoU(num_classes=2)
+
+    @def_function.function(input_signature=[
+        tensor_spec.TensorSpec(shape=None, dtype=dtypes.float32),
+        tensor_spec.TensorSpec(shape=None, dtype=dtypes.float32),
+        tensor_spec.TensorSpec(shape=None, dtype=dtypes.float32),
+    ])
+    def update(y_true, y_pred, weights):
+      metric.update_state(y_true, y_pred, sample_weight=weights)
+      return metric.result()
+
+    result = update(
+        constant_op.constant([0.0, 1.0, 0.0, 1.0]),
+        constant_op.constant([0.0, 1.0, 0.0, 1.0]),
+        constant_op.constant([1.0, 1.0, 1.0, 1.0]),
+    )
+    self.assertAllClose(result, 1.0)
+
+
 if __name__ == '__main__':
   test.main()

--- a/tensorflow/python/kernel_tests/metrics_test.py
+++ b/tensorflow/python/kernel_tests/metrics_test.py
@@ -4599,8 +4599,9 @@ class MeanIoUUnknownRankTest(test.TestCase):
   """Regression tests for MeanIoU with unknown-rank inputs inside tf.function.
 
   MeanIoU.update_state compared shape.ndims directly to an integer.
-  When a tf.function is traced with input_signature using TensorSpec(shape=None),
-  ndims is None at trace time, causing a TypeError at graph construction.
+  When a tf.function is traced with input_signature using
+  TensorSpec(shape=None), ndims is None at trace time, causing a TypeError
+  at graph construction.
   """
 
   def test_update_state_unknown_rank_does_not_crash(self):


### PR DESCRIPTION
## Summary

`MeanIoU.update_state` raises a `TypeError` when called inside a
`tf.function` traced with `TensorSpec(shape=None)`. In this case,
`TensorShape.ndims` is `None` at trace time, but the current
implementation compares it directly to an integer:

```python
if y_pred.shape.ndims > 1:
```

This results in:

```
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

which prevents the `tf.function` from being traced.

## Fix

Guard each `ndims` comparison with an explicit `is None` check so that
tensors with unknown static rank are handled the same way as tensors
with rank greater than one by flattening them with
`array_ops.reshape(x, [-1])`.

The change is applied consistently to:

- `y_pred`
- `y_true`
- `sample_weight`

This preserves the existing behavior for tensors with known static rank
and only changes the previously failing case where `shape.ndims` is
`None`.

## Minimal reproduction

```python
metric = tf.keras.metrics.MeanIoU(num_classes=3)

@tf.function(input_signature=[
    tf.TensorSpec(shape=None, dtype=tf.float32),
    tf.TensorSpec(shape=None, dtype=tf.float32),
])
def step(y_true, y_pred):
    metric.update_state(y_true, y_pred)
    return metric.result()

step(tf.constant([0., 1., 2.]),
     tf.constant([0., 1., 2.]))
```

Before this change:

```
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

After this change, the function traces and executes successfully.

## Tests

Added regression tests in
`tensorflow/python/kernel_tests/metrics_test.py`:

- `test_update_state_unknown_rank_does_not_crash`
- `test_update_state_unknown_rank_with_sample_weight`

The new tests fail before this change and pass after it. Existing
`MeanIOUTest` cases continue to pass.