### PR TITLE
[TFLite/CoreML] Guard tensor rank before dims->data[] access in PAD and Conv delegate support checks

### DIFF
--- a/tensorflow/lite/delegates/coreml/builders/convolution_op_builder.cc
+++ b/tensorflow/lite/delegates/coreml/builders/convolution_op_builder.cc
@@ -346,6 +346,11 @@ bool IsConvolutionOpSupported(const TfLiteRegistration* registration,
   if (!IsConstantTensor(weights)) {
     return false;
   }
+  if (weights->dims->size != 4) {
+    TF_LITE_KERNEL_LOG(context,
+                       "Convolution weights tensor must have rank 4.");
+    return false;
+  }
   if (weights->dims->data[1] > max_kernel_size ||
       weights->dims->data[2] > max_kernel_size) {
     return false;

--- a/tensorflow/lite/delegates/coreml/builders/convolution_op_builder.cc
+++ b/tensorflow/lite/delegates/coreml/builders/convolution_op_builder.cc
@@ -29,6 +29,7 @@ limitations under the License.
 #include "tensorflow/lite/delegates/coreml/builders/op_builder.h"
 #include "tensorflow/lite/delegates/coreml/builders/op_factory.h"
 #include "tensorflow/lite/delegates/coreml/builders/op_validator.h"
+#include "tensorflow/lite/delegates/coreml/builders/util.h"
 #include "tensorflow/lite/kernels/internal/optimized/optimized_ops.h"
 #include "tensorflow/lite/kernels/internal/runtime_shape.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
@@ -346,7 +347,7 @@ bool IsConvolutionOpSupported(const TfLiteRegistration* registration,
   if (!IsConstantTensor(weights)) {
     return false;
   }
-  if (weights->dims == nullptr || weights->dims->size != 4) {
+  if (!TensorHasRank(weights, 4)) {
     TF_LITE_KERNEL_LOG(context,
                        "Convolution weights tensor must have rank 4.");
     return false;

--- a/tensorflow/lite/delegates/coreml/builders/convolution_op_builder.cc
+++ b/tensorflow/lite/delegates/coreml/builders/convolution_op_builder.cc
@@ -346,7 +346,7 @@ bool IsConvolutionOpSupported(const TfLiteRegistration* registration,
   if (!IsConstantTensor(weights)) {
     return false;
   }
-  if (weights->dims->size != 4) {
+  if (weights->dims == nullptr || weights->dims->size != 4) {
     TF_LITE_KERNEL_LOG(context,
                        "Convolution weights tensor must have rank 4.");
     return false;

--- a/tensorflow/lite/delegates/coreml/builders/pad_op_builder.cc
+++ b/tensorflow/lite/delegates/coreml/builders/pad_op_builder.cc
@@ -102,34 +102,37 @@ bool IsPadOpSupported(const TfLiteRegistration* registration,
   // padding is d x 2 tensor, where d is the dimension of input.
   const TfLiteTensor* padding;
   TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, 1, &padding));
+  // Tensor names may be null in TFLite; use a safe placeholder for logging.
+  const char* padding_name =
+      padding->name != nullptr ? padding->name : "(unnamed)";
   if (!IsConstantTensor(padding)) {
     TF_LITE_KERNEL_LOG(context,
                        "%s: Only constant padding is supported for PAD.",
-                       padding->name);
+                       padding_name);
     return false;
   }
-  if (padding->dims->size != 2) {
+  if (padding->dims == nullptr || padding->dims->size != 2) {
     TF_LITE_KERNEL_LOG(context, "%s: PAD padding tensor must be 2D.",
-                       padding->name);
+                       padding_name);
     return false;
   }
   if (padding->dims->data[0] != 4 || padding->dims->data[1] != 2) {
     TF_LITE_KERNEL_LOG(context, "%s: Only 4D inputs are supported for PAD.",
-                       padding->name);
+                       padding_name);
     return false;
   }
   const int32_t* padding_data = GetTensorData<int32_t>(padding);
   if (!(padding_data[0] == 0 && padding_data[1] == 0)) {
     TF_LITE_KERNEL_LOG(
         context, "%s: Padding for batch dimension is not supported in PAD.",
-        padding->name);
+        padding_name);
     return false;
   }
 
   if (!(padding_data[6] == 0 && padding_data[7] == 0)) {
     TF_LITE_KERNEL_LOG(
         context, "%s: Padding for channel dimension is not supported in PAD.",
-        padding->name);
+        padding_name);
     return false;
   }
   return true;

--- a/tensorflow/lite/delegates/coreml/builders/pad_op_builder.cc
+++ b/tensorflow/lite/delegates/coreml/builders/pad_op_builder.cc
@@ -103,9 +103,11 @@ bool IsPadOpSupported(const TfLiteRegistration* registration,
   // padding is d x 2 tensor, where d is the dimension of input.
   const TfLiteTensor* padding;
   TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, 1, &padding));
-  // Tensor names may be null in TFLite; use a safe placeholder for logging.
+  // `padding` and its name may be null in TFLite; use a safe placeholder for
+  // logging so neither is dereferenced before the checks below.
   const char* padding_name =
-      padding->name != nullptr ? padding->name : "(unnamed)";
+      (padding != nullptr && padding->name != nullptr) ? padding->name
+                                                       : "(unnamed)";
   if (!IsConstantTensor(padding)) {
     TF_LITE_KERNEL_LOG(context,
                        "%s: Only constant padding is supported for PAD.",

--- a/tensorflow/lite/delegates/coreml/builders/pad_op_builder.cc
+++ b/tensorflow/lite/delegates/coreml/builders/pad_op_builder.cc
@@ -108,6 +108,11 @@ bool IsPadOpSupported(const TfLiteRegistration* registration,
                        padding->name);
     return false;
   }
+  if (padding->dims->size != 2) {
+    TF_LITE_KERNEL_LOG(context, "%s: PAD padding tensor must be 2D.",
+                       padding->name);
+    return false;
+  }
   if (padding->dims->data[0] != 4 || padding->dims->data[1] != 2) {
     TF_LITE_KERNEL_LOG(context, "%s: Only 4D inputs are supported for PAD.",
                        padding->name);

--- a/tensorflow/lite/delegates/coreml/builders/pad_op_builder.cc
+++ b/tensorflow/lite/delegates/coreml/builders/pad_op_builder.cc
@@ -21,6 +21,7 @@ limitations under the License.
 #include "tensorflow/lite/core/c/builtin_op_data.h"
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/delegates/coreml/builders/op_factory.h"
+#include "tensorflow/lite/delegates/coreml/builders/util.h"
 #include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
 #include "tensorflow/lite/kernels/kernel_util.h"
 
@@ -111,7 +112,7 @@ bool IsPadOpSupported(const TfLiteRegistration* registration,
                        padding_name);
     return false;
   }
-  if (padding->dims == nullptr || padding->dims->size != 2) {
+  if (!TensorHasRank(padding, 2)) {
     TF_LITE_KERNEL_LOG(context, "%s: PAD padding tensor must be 2D.",
                        padding_name);
     return false;

--- a/tensorflow/lite/delegates/coreml/builders/util.cc
+++ b/tensorflow/lite/delegates/coreml/builders/util.cc
@@ -105,6 +105,11 @@ float GetScalarFloatFromTensor(const TfLiteTensor* tensor) {
   return GetTensorData<float>(tensor)[0];
 }
 
+bool TensorHasRank(const TfLiteTensor* tensor, int expected_rank) {
+  return tensor != nullptr && tensor->dims != nullptr &&
+         tensor->dims->size == expected_rank;
+}
+
 }  // namespace coreml
 }  // namespace delegates
 }  // namespace tflite

--- a/tensorflow/lite/delegates/coreml/builders/util.h
+++ b/tensorflow/lite/delegates/coreml/builders/util.h
@@ -34,6 +34,12 @@ bool IsBinaryOpSupported(const TfLiteRegistration* registration,
 // constant float32/float16 tensor of size 1.
 float GetScalarFloatFromTensor(const TfLiteTensor* tensor);
 
+// Returns true if `tensor` has a non-null `dims` array with exactly
+// `expected_rank` dimensions. Guards against a null `tensor` or null `dims`
+// (which can occur for uninitialized or scalar tensors in malformed models)
+// before dereferencing `dims`, preventing an out-of-bounds read.
+bool TensorHasRank(const TfLiteTensor* tensor, int expected_rank);
+
 }  // namespace coreml
 }  // namespace delegates
 }  // namespace tflite

--- a/tensorflow/lite/delegates/coreml/builders/util_test.cc
+++ b/tensorflow/lite/delegates/coreml/builders/util_test.cc
@@ -24,6 +24,7 @@ limitations under the License.
 #include "tensorflow/lite/core/c/common.h"
 
 using tflite::delegates::coreml::IsBinaryOpSupported;
+using tflite::delegates::coreml::TensorHasRank;
 
 namespace {
 
@@ -151,6 +152,30 @@ TEST(UtilTest, GetScalarFloatFromTensorTest) {
   tensor.data.data = float32.data();
   EXPECT_THAT(tflite::delegates::coreml::GetScalarFloatFromTensor(&tensor),
               testing::FloatNear(-535.54f, 0.f));
+}
+
+TEST(UtilTest, TensorHasRankTest) {
+  TfLiteTensor tensor = {};
+
+  // A null `dims` (as happens for uninitialized or scalar tensors in malformed
+  // models) is rejected for any rank, without dereferencing `dims`.
+  tensor.dims = nullptr;
+  EXPECT_FALSE(TensorHasRank(&tensor, 4));
+
+  // The rank must match exactly.
+  tensor.dims = TfLiteIntArrayCreate(4);
+  EXPECT_TRUE(TensorHasRank(&tensor, 4));
+  EXPECT_FALSE(TensorHasRank(&tensor, 2));
+  EXPECT_FALSE(TensorHasRank(&tensor, 0));
+  TfLiteIntArrayFree(tensor.dims);
+
+  tensor.dims = TfLiteIntArrayCreate(2);
+  EXPECT_TRUE(TensorHasRank(&tensor, 2));
+  EXPECT_FALSE(TensorHasRank(&tensor, 4));
+  TfLiteIntArrayFree(tensor.dims);
+
+  // A null tensor is rejected.
+  EXPECT_FALSE(TensorHasRank(nullptr, 4));
 }
 
 }  // namespace


### PR DESCRIPTION
`IsPadOpSupported` reads `padding->dims->data[0]`/`[1]` and `IsConvolutionOpSupported` reads `weights->dims->data[1]`/`[2]` (and the conv build path uses `RuntimeShape(4, weights_->dims->data)` + `data[0..3]`) without first checking the tensor rank. These run during `IsNodeSupported` on model-provided tensor ranks:

- A PAD node whose padding tensor has rank < 2 causes an out-of-bounds read of `padding->dims->data`.
- A convolution whose weights tensor has rank < 4 causes an out-of-bounds read of `weights->dims->data` (both the support check and the build path).

Add rank guards mirroring `pooling_layer_builder.cc`'s existing `if (input->dims->size != 4) return false;`. This extends the same fixed-4D-rank / `dims->size` hardening currently being applied to the CoreML delegate (GetDims in #120307, Get4DShape/IsBroadcastable in 142a87ef5) to the PAD and Conv builders so the delegate validates rank consistently before indexing `dims->data`.