### PR TITLE
Feature/add blackman window

### DIFF
--- a/tensorflow/python/kernel_tests/math_ops/matmul_op_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/matmul_op_test.py
@@ -255,7 +255,7 @@ class MatMulInfixOperatorTest(test_lib.TestCase):
       )
       self.assertIn("rank 1", msg, "Error message should mention 'rank 1'")
 
-    # The message should suggest tf.expand_dims and tf.reshape for `a`.
+    # The message should suggest tf.expand_dims or tf.reshape for `a`.
     try:
       math_ops.matmul(
           ops.convert_to_tensor([1.0, 2.0]),

--- a/tensorflow/python/kernel_tests/signal/window_ops_test.py
+++ b/tensorflow/python/kernel_tests/signal/window_ops_test.py
@@ -61,6 +61,30 @@ def _scipy_raised_cosine(length, symmetric=True, a=0.5, b=0.5):
     window = window[:-1]
   return window
 
+def _scipy_blackman(length, symmetric=True):
+  """A simple implementation of a Blackman window that matches SciPy.
+
+  https://en.wikipedia.org/wiki/Window_function#Blackman_window
+  https://github.com/scipy/scipy/blob/v0.14.0/scipy/signal/windows.py#L615
+
+  Args:
+    length: The window length.
+    symmetric: Whether to create a symmetric window.
+
+  Returns:
+    A Blackman window of length `length`.
+  """
+  if length == 1:
+    return np.ones(1)
+  odd = length % 2
+  if not symmetric and not odd:
+    length += 1
+  window = (0.42 - 0.5 * np.cos(2.0 * np.pi * np.arange(length) / (length - 1))
+            + 0.08 * np.cos(4.0 * np.pi * np.arange(length) / (length - 1)))
+  if not symmetric and not odd:
+    window = window[:-1]
+  return window
+
 
 @tf_test_util.run_all_in_graph_and_eager_modes
 class WindowOpsTest(test.TestCase, parameterized.TestCase):
@@ -147,7 +171,19 @@ class WindowOpsTest(test.TestCase, parameterized.TestCase):
 
   @parameterized.parameters(
       itertools.product(
+          _WINDOW_LENGTHS,
+          (False, True),
+          _TF_DTYPE_TOLERANCE))
+  def test_blackman_window(self, window_length, periodic, tf_dtype_tol):
+    """Check that blackman_window matches scipy.signal.blackman's behavior."""
+    self._compare_window_fns(
+        _scipy_blackman,
+        window_ops.blackman_window, window_length, periodic, tf_dtype_tol)
+
+  @parameterized.parameters(
+      itertools.product(
           (window_ops.hann_window, window_ops.hamming_window,
+           window_ops.blackman_window,
            window_ops.kaiser_window, window_ops.kaiser_bessel_derived_window,
            window_ops.vorbis_window),
           (False, True),

--- a/tensorflow/python/ops/signal/signal.py
+++ b/tensorflow/python/ops/signal/signal.py
@@ -39,6 +39,7 @@ from tensorflow.python.ops.signal.shape_ops import frame
 from tensorflow.python.ops.signal.spectral_ops import inverse_stft
 from tensorflow.python.ops.signal.spectral_ops import inverse_stft_window_fn
 from tensorflow.python.ops.signal.spectral_ops import stft
+from tensorflow.python.ops.signal.window_ops import blackman_window
 from tensorflow.python.ops.signal.window_ops import hamming_window
 from tensorflow.python.ops.signal.window_ops import hann_window
 # pylint: enable=unused-import

--- a/tensorflow/python/ops/signal/window_ops.py
+++ b/tensorflow/python/ops/signal/window_ops.py
@@ -199,6 +199,62 @@ def hamming_window(window_length, periodic=True, dtype=dtypes.float32,
                                dtype, 0.54, 0.46)
 
 
+@tf_export('signal.blackman_window')
+@dispatch.add_dispatch_support
+def blackman_window(window_length, periodic=True, dtype=dtypes.float32,
+                    name=None):
+  """Generate a [Blackman][blackman] window.
+
+  Args:
+    window_length: A scalar `Tensor` indicating the window length to generate.
+    periodic: A bool `Tensor` indicating whether to generate a periodic or
+      symmetric window. Periodic windows are typically used for spectral
+      analysis while symmetric windows are typically used for digital
+      filter design.
+    dtype: The data type to produce. Must be a floating point type.
+    name: An optional name for the operation.
+
+  Returns:
+    A `Tensor` of shape `[window_length]` of type `dtype`.
+
+  Raises:
+    ValueError: If `dtype` is not a floating point type.
+
+  [blackman]:
+    https://en.wikipedia.org/wiki/Window_function#Blackman_window
+  """
+  if not dtype.is_floating:
+    raise ValueError('dtype must be a floating point type. Found %s' % dtype)
+
+  with ops.name_scope(name, 'blackman_window', [window_length, periodic]):
+    window_length = ops.convert_to_tensor(window_length, dtype=dtypes.int32,
+                                          name='window_length')
+    window_length.shape.assert_has_rank(0)
+    window_length_const = tensor_util.constant_value(window_length)
+    if window_length_const == 1:
+      return array_ops.ones([1], dtype=dtype)
+    periodic = math_ops.cast(
+        ops.convert_to_tensor(periodic, dtype=dtypes.bool, name='periodic'),
+        dtypes.int32)
+    periodic.shape.assert_has_rank(0)
+    even = 1 - math_ops.mod(window_length, 2)
+
+    def _compute_window():
+      n = math_ops.cast(window_length + periodic * even - 1, dtype=dtype)
+      count = math_ops.cast(math_ops.range(window_length), dtype)
+      cos_arg = constant_op.constant(2 * np.pi, dtype=dtype) * count / n
+      return math_ops.cast(
+          0.42 - 0.5 * math_ops.cos(cos_arg) + 0.08 * math_ops.cos(2 * cos_arg),
+          dtype=dtype)
+
+    if window_length_const is not None:
+      return _compute_window()
+    return cond.cond(
+        math_ops.equal(window_length, 1),
+        lambda: array_ops.ones([window_length], dtype=dtype),
+        _compute_window)
+
+
 def _raised_cosine_window(name, default_name, window_length, periodic,
                           dtype, a, b):
   """Helper function for computing a raised cosine window.
@@ -236,13 +292,15 @@ def _raised_cosine_window(name, default_name, window_length, periodic,
     periodic.shape.assert_has_rank(0)
     even = 1 - math_ops.mod(window_length, 2)
 
-    n = math_ops.cast(window_length + periodic * even - 1, dtype=dtype)
-    count = math_ops.cast(math_ops.range(window_length), dtype)
-    cos_arg = constant_op.constant(2 * np.pi, dtype=dtype) * count / n
+    def _compute_window():
+      n = math_ops.cast(window_length + periodic * even - 1, dtype=dtype)
+      count = math_ops.cast(math_ops.range(window_length), dtype)
+      cos_arg = constant_op.constant(2 * np.pi, dtype=dtype) * count / n
+      return math_ops.cast(a - b * math_ops.cos(cos_arg), dtype=dtype)
 
     if window_length_const is not None:
-      return math_ops.cast(a - b * math_ops.cos(cos_arg), dtype=dtype)
+      return _compute_window()
     return cond.cond(
         math_ops.equal(window_length, 1),
         lambda: array_ops.ones([window_length], dtype=dtype),
-        lambda: math_ops.cast(a - b * math_ops.cos(cos_arg), dtype=dtype))
+        _compute_window)


### PR DESCRIPTION

This PR adds the standard Blackman window function (`tf.signal.blackman_window`) to the `tf.signal` module.

The Blackman window is a widely used window function in digital signal processing (DSP) to reduce spectral leakage. This implementation aligns with the existing window functions (like `hann_window` and `hamming_window`) in `tensorflow/python/ops/signal/window_ops.py`.

It uses standard TensorFlow math operations (`math_ops.cos`, `math_ops.cast`, etc.) to ensure full compatibility with graph execution, XLA, and differentiation.

### Motivation and Context
Currently, `tf.signal` provides Hann, Hamming, Vorbis, and Kaiser windows, but it lacks the Blackman window. Adding this function bridges this gap and expands the signal processing utility belt for TensorFlow users without needing them to build custom window ops from scratch or rely on external libraries.

### Implementation Details
- Added `blackman_window` in `tensorflow/python/ops/signal/window_ops.py`.
- Exported under the `tf.signal` namespace.
- Handled edge cases (e.g., `window_length = 1`) identical to the existing window functions.
