### PR TITLE
Fix integer overflow in TFLite buffer offset bounds check (interpreter_builder.cc)

### DIFF
--- a/tensorflow/lite/core/interpreter_builder.cc
+++ b/tensorflow/lite/core/interpreter_builder.cc
@@ -380,8 +380,9 @@ TfLiteStatus InterpreterBuilder::ParseNodes(
         // arithmetic overflow (including under UBSan sanitized builds).
         const uint64_t custom_opts_size = op->large_custom_options_size();
         const uint64_t custom_opts_offset = op->large_custom_options_offset();
-        if (custom_opts_size > allocation_->bytes() ||
-            custom_opts_offset > allocation_->bytes() - custom_opts_size) {
+        const uint64_t alloc_bytes_nodes = static_cast<uint64_t>(allocation_->bytes());
+        if (custom_opts_size > alloc_bytes_nodes ||
+            custom_opts_offset > alloc_bytes_nodes - custom_opts_size) {
           TF_LITE_REPORT_ERROR(
               error_reporter_,
               "Custom Option Offset for opcode_index %d is out of bound\n",
@@ -758,7 +759,7 @@ TfLiteStatus InterpreterBuilder::ParseTensors(
         return kTfLiteError;
       }
       if (auto* buffer = (*buffers)[tensor->buffer()]) {
-        auto offset = buffer->offset();
+        const uint64_t offset = buffer->offset();
         if (auto* array = buffer->data()) {
           *buffer_size = array->size();
           *buffer_data = reinterpret_cast<const char*>(array->data());
@@ -767,9 +768,10 @@ TfLiteStatus InterpreterBuilder::ParseTensors(
           // Validate that offset + size does not overflow and stays within the
           // allocation. Use subtraction from the upper bound to avoid any
           // arithmetic overflow (including under UBSan sanitized builds).
-          const uint64_t buffer_size = buffer->size();
-          if (buffer_size > allocation_->bytes() ||
-              offset > allocation_->bytes() - buffer_size) {
+          const uint64_t buf_sz = buffer->size();
+          const uint64_t alloc_bytes = static_cast<uint64_t>(allocation_->bytes());
+          if (buf_sz > alloc_bytes ||
+              offset > alloc_bytes - buf_sz) {
             TF_LITE_REPORT_ERROR(
                 error_reporter_,
                 "Constant buffer %d specified an out of range offset.\n",

--- a/tensorflow/lite/core/interpreter_builder.cc
+++ b/tensorflow/lite/core/interpreter_builder.cc
@@ -375,9 +375,13 @@ TfLiteStatus InterpreterBuilder::ParseNodes(
         init_data = reinterpret_cast<const char*>(op->custom_options()->data());
         init_data_size = op->custom_options()->size();
       } else if (op->large_custom_options_offset() > 1 && allocation_) {
-        if (op->large_custom_options_offset() +
-                op->large_custom_options_size() >
-            allocation_->bytes()) {
+        // Validate that offset + size does not overflow and stays within the
+        // allocation. Use subtraction from the upper bound to avoid any
+        // arithmetic overflow (including under UBSan sanitized builds).
+        const uint64_t custom_opts_size = op->large_custom_options_size();
+        const uint64_t custom_opts_offset = op->large_custom_options_offset();
+        if (custom_opts_size > allocation_->bytes() ||
+            custom_opts_offset > allocation_->bytes() - custom_opts_size) {
           TF_LITE_REPORT_ERROR(
               error_reporter_,
               "Custom Option Offset for opcode_index %d is out of bound\n",
@@ -760,7 +764,12 @@ TfLiteStatus InterpreterBuilder::ParseTensors(
           *buffer_data = reinterpret_cast<const char*>(array->data());
           return kTfLiteOk;
         } else if (offset > 1 && allocation_) {
-          if (offset + buffer->size() > allocation_->bytes()) {
+          // Validate that offset + size does not overflow and stays within the
+          // allocation. Use subtraction from the upper bound to avoid any
+          // arithmetic overflow (including under UBSan sanitized builds).
+          const uint64_t buffer_size = buffer->size();
+          if (buffer_size > allocation_->bytes() ||
+              offset > allocation_->bytes() - buffer_size) {
             TF_LITE_REPORT_ERROR(
                 error_reporter_,
                 "Constant buffer %d specified an out of range offset.\n",


### PR DESCRIPTION
Hi @sgarciagoogle,

The previous PR (#121262) was automatically closed by the project bot before you had a chance to re-review the updated fix. I have addressed your UBSan feedback — both call sites now use subtraction-based bounds checks instead of `CheckedInt` addition.

---

### What changed

Replaced both `CheckedInt<uint64_t>(offset) + size` addition-based checks with subtraction against the upper bound:

```cpp
if (size > allocation_->bytes() ||
    offset > allocation_->bytes() - size) { ... }
```

Subtraction from `allocation_->bytes()` cannot overflow, making both checks completely immune to sanitizer traps (UBSan `-fsanitize=unsigned-integer-overflow`) while preserving the same security guarantee.

**Two call sites updated in `tensorflow/lite/core/interpreter_builder.cc`:**
- `ParseNodes`: `large_custom_options_offset` / `large_custom_options_size`
- `ParseTensors`: `Buffer.offset` / `Buffer.size`

The regression test `BasicInterpreter.BufferOffsetWrappingIsRejected` is retained unchanged and now cleanly returns `kTfLiteError` under UBSan instead of crashing with SIGILL.

---

Would you be open to reviewing the fix here? Happy to rework anything if needed.