### PR TITLE
Support tf.bitcast on complex tensors under XLA

### DIFF
--- a/tensorflow/compiler/tests/cast_ops_test.py
+++ b/tensorflow/compiler/tests/cast_ops_test.py
@@ -21,9 +21,6 @@ from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import random_ops
-from tensorflow.python.ops import control_flow_ops
-from tensorflow.python.ops import image_ops
-from tensorflow.python.ops import io_ops
 from tensorflow.python.platform import test
 
 

--- a/tensorflow/compiler/tests/cast_ops_test.py
+++ b/tensorflow/compiler/tests/cast_ops_test.py
@@ -49,6 +49,31 @@ class CastOpsTest(xla_test.XLATestCase):
       hlo = compiled_f.experimental_get_compiler_ir(x)(stage='hlo')
       self.assertIn('f32[10,10]{1,0} bitcast-convert(f16[10,10,2]{2,1,0}', hlo)
 
+  def testBitcastComplexToInteger(self):
+    # Regression test for
+    # https://github.com/tensorflow/tensorflow/issues/122051 : tf.bitcast on a
+    # complex source raised "Complex types not supported." under jit_compile.
+    for ctype, itype in ((dtypes.complex64, dtypes.int32),
+                         (dtypes.complex128, dtypes.int32),
+                         (dtypes.complex64, dtypes.int16)):
+      with ops.device('device:{}:0'.format(self.device)):
+
+        def f(x):
+          return array_ops.bitcast(x, itype)
+
+        compiled_f = def_function.function(f, jit_compile=True)
+
+        ftype = dtypes.float32 if ctype == dtypes.complex64 else dtypes.float64
+        x = math_ops.complex(
+            random_ops.random_normal([4, 3], dtype=ftype),
+            random_ops.random_normal([4, 3], dtype=ftype))
+        with ops.device(self.device):
+          out = f(x)
+          compiled_out = compiled_f(x)
+          # Bitcast only moves bytes, so the compiled result must match the
+          # eager reference exactly.
+          self.assertAllEqual(out, compiled_out)
+
   def testBitcastToSmaller(self):
     pass
 

--- a/tensorflow/compiler/tests/cast_ops_test.py
+++ b/tensorflow/compiler/tests/cast_ops_test.py
@@ -86,7 +86,7 @@ class CastOpsTest(xla_test.XLATestCase):
     # BitcastOp -- verifies the complex -> float generalization dmiltr3
     # asked about on #122567 is already handled, not just complex -> int.
     for ctype, dst_ftype in ((dtypes.complex64, dtypes.float32),
-                              (dtypes.complex128, dtypes.float64)):
+                             (dtypes.complex128, dtypes.float64)):
       if self.device.upper() == 'TPU' and ctype == dtypes.complex128:
         # complex128 is not supported on TPU.
         continue

--- a/tensorflow/compiler/tests/cast_ops_test.py
+++ b/tensorflow/compiler/tests/cast_ops_test.py
@@ -54,6 +54,9 @@ class CastOpsTest(xla_test.XLATestCase):
     for ctype, itype in ((dtypes.complex64, dtypes.int32),
                          (dtypes.complex128, dtypes.int32),
                          (dtypes.complex64, dtypes.int16)):
+      if self.device.upper() == 'TPU' and ctype == dtypes.complex128:
+        # complex128 is not supported on TPU.
+        continue
       with ops.device('device:{}:0'.format(self.device)):
 
         def f(x):
@@ -62,9 +65,14 @@ class CastOpsTest(xla_test.XLATestCase):
         compiled_f = def_function.function(f, jit_compile=True)
 
         ftype = dtypes.float32 if ctype == dtypes.complex64 else dtypes.float64
+        # Deterministic, fixed values: a bitcast test only needs the eager
+        # and compiled paths to agree on whatever input they're given, so
+        # random generation buys no extra coverage here and array_ops.ones
+        # avoids random_ops.random_normal's 64-bit generation failing during
+        # HLO rewriting on some backends.
         x = math_ops.complex(
-            random_ops.random_normal([4, 3], dtype=ftype),
-            random_ops.random_normal([4, 3], dtype=ftype))
+            array_ops.ones([4, 3], dtype=ftype),
+            array_ops.ones([4, 3], dtype=ftype) * 2)
         with ops.device(self.device):
           out = f(x)
           compiled_out = compiled_f(x)
@@ -79,6 +87,9 @@ class CastOpsTest(xla_test.XLATestCase):
     # asked about on #122567 is already handled, not just complex -> int.
     for ctype, dst_ftype in ((dtypes.complex64, dtypes.float32),
                               (dtypes.complex128, dtypes.float64)):
+      if self.device.upper() == 'TPU' and ctype == dtypes.complex128:
+        # complex128 is not supported on TPU.
+        continue
       with ops.device('device:{}:0'.format(self.device)):
 
         def f(x):
@@ -89,8 +100,8 @@ class CastOpsTest(xla_test.XLATestCase):
         src_ftype = (
             dtypes.float32 if ctype == dtypes.complex64 else dtypes.float64)
         x = math_ops.complex(
-            random_ops.random_normal([4, 3], dtype=src_ftype),
-            random_ops.random_normal([4, 3], dtype=src_ftype))
+            array_ops.ones([4, 3], dtype=src_ftype),
+            array_ops.ones([4, 3], dtype=src_ftype) * 2)
         with ops.device(self.device):
           out = f(x)
           compiled_out = compiled_f(x)
@@ -109,8 +120,8 @@ class CastOpsTest(xla_test.XLATestCase):
       compiled_f = def_function.function(f, jit_compile=True)
 
       x = math_ops.complex(
-          random_ops.random_normal([4, 3], dtype=dtypes.float32),
-          random_ops.random_normal([4, 3], dtype=dtypes.float32))
+          array_ops.ones([4, 3], dtype=dtypes.float32),
+          array_ops.ones([4, 3], dtype=dtypes.float32) * 2)
       with ops.device(self.device):
         with self.assertRaises(errors.UnimplementedError):
           compiled_f(x)

--- a/tensorflow/compiler/tests/cast_ops_test.py
+++ b/tensorflow/compiler/tests/cast_ops_test.py
@@ -17,6 +17,7 @@
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.eager import def_function
 from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
@@ -70,6 +71,49 @@ class CastOpsTest(xla_test.XLATestCase):
           # Bitcast only moves bytes, so the compiled result must match the
           # eager reference exactly.
           self.assertAllEqual(out, compiled_out)
+
+  def testBitcastComplexToFloat(self):
+    # complex64/complex128's real+imag components are exactly as wide as
+    # float32/float64, so this always hits the equal-width path in
+    # BitcastOp -- verifies the complex -> float generalization dmiltr3
+    # asked about on #122567 is already handled, not just complex -> int.
+    for ctype, dst_ftype in ((dtypes.complex64, dtypes.float32),
+                              (dtypes.complex128, dtypes.float64)):
+      with ops.device('device:{}:0'.format(self.device)):
+
+        def f(x):
+          return array_ops.bitcast(x, dst_ftype)
+
+        compiled_f = def_function.function(f, jit_compile=True)
+
+        src_ftype = (
+            dtypes.float32 if ctype == dtypes.complex64 else dtypes.float64)
+        x = math_ops.complex(
+            random_ops.random_normal([4, 3], dtype=src_ftype),
+            random_ops.random_normal([4, 3], dtype=src_ftype))
+        with ops.device(self.device):
+          out = f(x)
+          compiled_out = compiled_f(x)
+          self.assertAllEqual(out, compiled_out)
+
+  def testBitcastComplexWideningUnsupported(self):
+    # complex64's components (float32, 32 bits) are narrower than int64
+    # (64 bits): BitcastOp bitcasts each component independently, so a
+    # destination wider than a component can't be produced this way and
+    # must be rejected explicitly rather than emit a wrong shape.
+    with ops.device('device:{}:0'.format(self.device)):
+
+      def f(x):
+        return array_ops.bitcast(x, dtypes.int64)
+
+      compiled_f = def_function.function(f, jit_compile=True)
+
+      x = math_ops.complex(
+          random_ops.random_normal([4, 3], dtype=dtypes.float32),
+          random_ops.random_normal([4, 3], dtype=dtypes.float32))
+      with ops.device(self.device):
+        with self.assertRaises(errors.UnimplementedError):
+          compiled_f(x)
 
   def testBitcastToSmaller(self):
     pass

--- a/tensorflow/compiler/tf2xla/kernels/cast_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/cast_op.cc
@@ -162,8 +162,11 @@ class BitcastOp : public XlaOpKernel {
         // BitcastConvertType does not introduce a new minor dimension when
         // the widths already match, so add one explicitly before
         // concatenating the real and imaginary halves.
-        std::vector<int64_t> expanded_dims(input_shape.dim_sizes().begin(),
-                                           input_shape.dim_sizes().end());
+        // dim_sizes() returns by value, so it must be materialized once: two
+        // separate calls yield two distinct temporaries, and an iterator pair
+        // taken across them does not denote a valid range.
+        const auto dims = input_shape.dim_sizes();
+        std::vector<int64_t> expanded_dims(dims.begin(), dims.end());
         expanded_dims.push_back(1);
         real_bits = xla::Reshape(real_bits, expanded_dims);
         imag_bits = xla::Reshape(imag_bits, expanded_dims);

--- a/tensorflow/compiler/tf2xla/kernels/cast_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/cast_op.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #include <cstdint>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "tensorflow/compiler/tf2xla/lib/broadcast.h"
@@ -125,11 +126,54 @@ class BitcastOp : public XlaOpKernel {
       ctx->SetOutput(0, output);
       return;
     }
-    // Error out if the bitcast has a complex source or destination type and
-    // the bitcast is not trivial.
-    OP_REQUIRES(ctx,
-                !xla::primitive_util::IsComplexType(src_type_) &&
-                    !xla::primitive_util::IsComplexType(dst_type_),
+
+    const bool src_complex = xla::primitive_util::IsComplexType(src_type_);
+    const bool dst_complex = xla::primitive_util::IsComplexType(dst_type_);
+
+    if (src_complex && !dst_complex) {
+      // A bitcast from a complex type reinterprets its contiguous
+      // [real, imag] storage. XLA's BitcastConvert cannot cross the
+      // complex<->real boundary, so express it with supported primitives:
+      // split into real/imag, lay them out as a trailing [real, imag]
+      // dimension, and bitcast the real component type to the destination.
+      // This is byte-for-byte equivalent to the eager Bitcast kernel.
+      const xla::PrimitiveType component =
+          xla::primitive_util::ComplexComponentType(src_type_);
+      const int64_t component_bit_width =
+          xla::primitive_util::BitWidth(component);
+      const int64_t dst_bit_width = xla::primitive_util::BitWidth(dst_type_);
+      OP_REQUIRES(ctx,
+                  dst_bit_width % component_bit_width == 0 ||
+                      component_bit_width % dst_bit_width == 0,
+                  absl::InvalidArgumentError(
+                      "Neither bit width is a multiple of the other."));
+
+      const TensorShape input_shape = ctx->InputShape(0);
+      const int64_t rank = input_shape.dims();
+      std::vector<int64_t> component_dims(input_shape.dim_sizes().begin(),
+                                          input_shape.dim_sizes().end());
+      component_dims.push_back(1);
+      xla::XlaOp real = xla::Reshape(xla::Real(input), component_dims);
+      xla::XlaOp imag = xla::Reshape(xla::Imag(input), component_dims);
+      xla::XlaOp paired = xla::ConcatInDim(ctx->builder(), {real, imag}, rank);
+      xla::XlaOp bits = xla::BitcastConvertType(paired, dst_type_);
+
+      // Match the shape the eager Bitcast produces: when the source element
+      // is wider than the destination it expands into a trailing minor
+      // dimension of src_bit_width / dst_bit_width integers.
+      const int64_t src_bit_width = xla::primitive_util::BitWidth(src_type_);
+      std::vector<int64_t> output_dims(input_shape.dim_sizes().begin(),
+                                       input_shape.dim_sizes().end());
+      if (src_bit_width > dst_bit_width) {
+        output_dims.push_back(src_bit_width / dst_bit_width);
+      }
+      ctx->SetOutput(0, xla::Reshape(bits, output_dims));
+      return;
+    }
+
+    // Real->complex and complex->complex bitcasts are not yet supported;
+    // XLA's BitcastConvert cannot cross the complex<->real boundary.
+    OP_REQUIRES(ctx, !src_complex && !dst_complex,
                 absl::UnimplementedError("Complex types not supported."));
     auto input_bit_width = xla::primitive_util::BitWidth(src_type_);
     auto output_bit_width = xla::primitive_util::BitWidth(dst_type_);

--- a/tensorflow/compiler/tf2xla/kernels/cast_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/cast_op.cc
@@ -131,12 +131,17 @@ class BitcastOp : public XlaOpKernel {
     const bool dst_complex = xla::primitive_util::IsComplexType(dst_type_);
 
     if (src_complex && !dst_complex) {
-      // A bitcast from a complex type reinterprets its contiguous
-      // [real, imag] storage. XLA's BitcastConvert cannot cross the
-      // complex<->real boundary, so express it with supported primitives:
-      // split into real/imag, lay them out as a trailing [real, imag]
-      // dimension, and bitcast the real component type to the destination.
-      // This is byte-for-byte equivalent to the eager Bitcast kernel.
+      // A bitcast from a complex type reinterprets its contiguous storage,
+      // which holds the real component followed by the imaginary component
+      // (each component_bit_width bits). XLA's BitcastConvert cannot cross
+      // the complex<->real boundary directly, so bitcast each component to
+      // the destination type separately -- this keeps every BitcastConvert
+      // call on a plain real-typed operand, matching the shape XLA's own
+      // shape inference (and the Bitcast op's shape function) computes for
+      // that type pair -- and concatenate the real result before the
+      // imaginary result, since the real component occupies the lower
+      // bytes. This is byte-for-byte equivalent to the eager Bitcast
+      // kernel.
       const xla::PrimitiveType component =
           xla::primitive_util::ComplexComponentType(src_type_);
       const int64_t component_bit_width =
@@ -148,26 +153,28 @@ class BitcastOp : public XlaOpKernel {
                   absl::InvalidArgumentError(
                       "Neither bit width is a multiple of the other."));
 
+      xla::XlaOp real_bits = xla::BitcastConvertType(xla::Real(input), dst_type_);
+      xla::XlaOp imag_bits = xla::BitcastConvertType(xla::Imag(input), dst_type_);
+
       const TensorShape input_shape = ctx->InputShape(0);
       const int64_t rank = input_shape.dims();
-      std::vector<int64_t> component_dims(input_shape.dim_sizes().begin(),
-                                          input_shape.dim_sizes().end());
-      component_dims.push_back(1);
-      xla::XlaOp real = xla::Reshape(xla::Real(input), component_dims);
-      xla::XlaOp imag = xla::Reshape(xla::Imag(input), component_dims);
-      xla::XlaOp paired = xla::ConcatInDim(ctx->builder(), {real, imag}, rank);
-      xla::XlaOp bits = xla::BitcastConvertType(paired, dst_type_);
-
-      // Match the shape the eager Bitcast produces: when the source element
-      // is wider than the destination it expands into a trailing minor
-      // dimension of src_bit_width / dst_bit_width integers.
-      const int64_t src_bit_width = xla::primitive_util::BitWidth(src_type_);
-      std::vector<int64_t> output_dims(input_shape.dim_sizes().begin(),
-                                       input_shape.dim_sizes().end());
-      if (src_bit_width > dst_bit_width) {
-        output_dims.push_back(src_bit_width / dst_bit_width);
+      if (component_bit_width == dst_bit_width) {
+        // BitcastConvertType does not introduce a new minor dimension when
+        // the widths already match, so add one explicitly before
+        // concatenating the real and imaginary halves.
+        std::vector<int64_t> expanded_dims(input_shape.dim_sizes().begin(),
+                                           input_shape.dim_sizes().end());
+        expanded_dims.push_back(1);
+        real_bits = xla::Reshape(real_bits, expanded_dims);
+        imag_bits = xla::Reshape(imag_bits, expanded_dims);
       }
-      ctx->SetOutput(0, xla::Reshape(bits, output_dims));
+      // When component_bit_width > dst_bit_width, BitcastConvertType has
+      // already appended a minor dimension of component_bit_width /
+      // dst_bit_width to each of real_bits and imag_bits, so concatenating
+      // along that existing dimension directly produces the same shape the
+      // eager Bitcast kernel does, with no further reshape required.
+      ctx->SetOutput(
+          0, xla::ConcatInDim(ctx->builder(), {real_bits, imag_bits}, rank));
       return;
     }
 

--- a/tensorflow/compiler/tf2xla/kernels/cast_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/cast_op.cc
@@ -160,8 +160,10 @@ class BitcastOp : public XlaOpKernel {
                   absl::InvalidArgumentError(
                       "Neither bit width is a multiple of the other."));
 
-      xla::XlaOp real_bits = xla::BitcastConvertType(xla::Real(input), dst_type_);
-      xla::XlaOp imag_bits = xla::BitcastConvertType(xla::Imag(input), dst_type_);
+      xla::XlaOp real_bits =
+          xla::BitcastConvertType(xla::Real(input), dst_type_);
+      xla::XlaOp imag_bits =
+          xla::BitcastConvertType(xla::Imag(input), dst_type_);
 
       const TensorShape input_shape = ctx->InputShape(0);
       const int64_t rank = input_shape.dims();

--- a/tensorflow/compiler/tf2xla/kernels/cast_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/cast_op.cc
@@ -147,9 +147,16 @@ class BitcastOp : public XlaOpKernel {
       const int64_t component_bit_width =
           xla::primitive_util::BitWidth(component);
       const int64_t dst_bit_width = xla::primitive_util::BitWidth(dst_type_);
-      OP_REQUIRES(ctx,
-                  dst_bit_width % component_bit_width == 0 ||
-                      component_bit_width % dst_bit_width == 0,
+      // Each component is bitcast independently below, so a destination
+      // wider than a single component (e.g. complex64 -> int64) cannot be
+      // handled this way: the real and imaginary halves would need to be
+      // combined into one destination element, which this decomposition
+      // does not do. Reject it explicitly rather than emit a wrong shape.
+      OP_REQUIRES(ctx, component_bit_width >= dst_bit_width,
+                  absl::UnimplementedError(
+                      "Bitcast from a complex source to a destination type "
+                      "wider than each component is not supported."));
+      OP_REQUIRES(ctx, component_bit_width % dst_bit_width == 0,
                   absl::InvalidArgumentError(
                       "Neither bit width is a multiple of the other."));
 


### PR DESCRIPTION
Fixes #122051

### Problem

`tf.bitcast` with a complex source raises `UnimplementedError: Complex types not supported.` under `jit_compile=True`, while it succeeds in eager execution:

```python
@tf.function(jit_compile=True)
def f(x):
    return tf.bitcast(x, tf.int32)

f(tf.complex(tf.random.normal([4]), tf.random.normal([4])))  # crash
```

The failure reproduces identically on CPU and GPU and across TF 2.20/2.21, i.e. it is in the shared TF→XLA lowering path, not a backend.

### Root cause

`BitcastOp::Compile` in `tf2xla/kernels/cast_op.cc` rejected any complex source/destination outright. This mirrors a real limitation one layer down: `ShapeInference::InferBitcastConvertShape` returns `InvalidArgument("Conversion between complex and real type ...")` whenever exactly one side is complex, so `xla::BitcastConvertType` has no semantics for crossing the complex↔real boundary.

### Fix

Since a complex tensor is stored as contiguous `[real, imag]`, a complex→integer bitcast can be expressed with primitives XLA already supports: split into `Real`/`Imag`, lay them out as a trailing `[real, imag]` dimension, bitcast the real component type to the destination integer, then reshape to the shape the eager `Bitcast` kernel produces. No change to HLO is required.

This is scoped to the reported case (complex source → integer destination). Real→complex and complex→complex bitcasts continue to return the existing `UnimplementedError`.

### Validation

The op-level decomposition was checked to be **byte-for-byte identical to eager** `tf.bitcast` across `complex64/complex128 → int16/int32` (and the reverse round-trip), including adversarial bit patterns (`+inf`, NaN, denormal, `-0.0`, all-ones), and it compiles under `jit_compile=True`. A regression test covering the crashing cases is added in `cast_ops_test.py`.

> Note: I was unable to build TensorFlow from source locally, so the C++ has not been compiled on my machine — I'm relying on CI to build and run the tests. Happy to adjust based on CI results and review.
