### PR TITLE
tf2xla: fix Round op crashing on integer input under jit_compile=True

### DIFF
--- a/tensorflow/compiler/tf2xla/kernels/unary_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/unary_ops.cc
@@ -27,6 +27,7 @@ limitations under the License.
 #include "xla/tsl/platform/statusor.h"
 #include "xla/xla_data.pb.h"
 #include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/types.h"
 
 namespace tensorflow {
 namespace {
@@ -83,7 +84,21 @@ XLAJIT_MAKE_UNARY(PopulationCount,
 XLAJIT_MAKE_UNARY(Neg, -x);
 
 XLAJIT_MAKE_UNARY(Rint, xla::RoundToEven(x));
-XLAJIT_MAKE_UNARY(Round, xla::RoundToEven(x));
+
+class RoundOp : public XlaOpKernel {
+ public:
+  explicit RoundOp(OpKernelConstruction* ctx) : XlaOpKernel(ctx) {}
+  void Compile(XlaOpKernelContext* ctx) override {
+    xla::XlaOp x = ctx->Input(0);
+    // Round on integers is a no-op; xla::RoundToEven rejects non-float types.
+    if (DataTypeIsInteger(ctx->input_type(0))) {
+      ctx->SetOutput(0, x);
+    } else {
+      ctx->SetOutput(0, xla::RoundToEven(x));
+    }
+  }
+};
+REGISTER_XLA_OP(Name("Round"), RoundOp);
 
 REGISTER_XLA_OP(Name("Rsqrt"), MlirXlaOpKernel);
 

--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -552,6 +552,18 @@ struct scalar_round_half_to_even_op<Scalar, true, false> {
 };
 
 template <typename Scalar>
+struct scalar_round_half_to_even_op<Scalar, true, true> {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
+  operator()(const Scalar& x) const {
+    return x;
+  }
+  template <typename Packet>
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet packetOp(const Packet& x) const {
+    return x;
+  }
+};
+
+template <typename Scalar>
 struct scalar_round_half_to_even_op<Scalar, false, true> {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& x) const {

--- a/tensorflow/python/kernel_tests/math_ops/BUILD
+++ b/tensorflow/python/kernel_tests/math_ops/BUILD
@@ -294,6 +294,7 @@ cuda_py_strict_test(
     # b/140155706: nans in result
     xla_enable_strict_auto_jit = False,
     deps = [
+        "//tensorflow/compiler/jit",
         "//tensorflow/python/eager:backprop",
         "//tensorflow/python/framework:constant_op",
         "//tensorflow/python/framework:for_generated_wrappers",

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -652,5 +652,15 @@ class UnaryOpTest(test.TestCase):
     self.assertLess(err, 1e-3)
 
 
+  def testRoundInt(self):
+    # tf.math.round short-circuits in Python for integer dtypes, so it never
+    # calls the C++ kernel. Target tf.raw_ops.Round directly to exercise the
+    # scalar_round_half_to_even_op template specialization for integers.
+    for dtype in [tf.int32, tf.int64]:
+      inputs = tf.constant([-3, 1, 0, -1], dtype=dtype)
+      outputs = tf.raw_ops.Round(x=inputs)
+      self.assertAllEqual([-3, 1, 0, -1], self.evaluate(outputs))
+
+
 if __name__ == "__main__":
   test.main()

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -19,6 +19,7 @@ import math
 import numpy as np
 
 from tensorflow.python.eager import backprop
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes as dtypes_lib
 from tensorflow.python.framework import ops
@@ -654,10 +655,24 @@ class UnaryOpTest(test.TestCase):
 
   @test_util.run_in_graph_and_eager_modes
   def testRoundInt(self):
+    # CPU kernel registers int32 and int64 only.
     for dtype in [dtypes_lib.int32, dtypes_lib.int64]:
       inputs = constant_op.constant([-3, 1, 0, -1], dtype=dtype)
       outputs = gen_math_ops.round(x=inputs)
       self.assertAllEqual([-3, 1, 0, -1], self.evaluate(outputs))
+
+  def testRoundIntXLA(self):
+    # XLA kernel registers int8, int16, int32, int64.
+    @def_function.function(jit_compile=True)
+    def round_fn(x):
+      return gen_math_ops.round(x=x)
+
+    for dtype in [
+        dtypes_lib.int8, dtypes_lib.int16,
+        dtypes_lib.int32, dtypes_lib.int64,
+    ]:
+      inputs = constant_op.constant([-3, 1, 0, -1], dtype=dtype)
+      self.assertAllEqual([-3, 1, 0, -1], round_fn(inputs))
 
 
 if __name__ == "__main__":

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -653,12 +653,12 @@ class UnaryOpTest(test.TestCase):
 
 
   def testRoundInt(self):
-    # tf.math.round short-circuits in Python for integer dtypes, so it never
-    # calls the C++ kernel. Target tf.raw_ops.Round directly to exercise the
+    # math_ops.round short-circuits in Python for integer dtypes, so it never
+    # calls the C++ kernel. Target gen_math_ops.round directly to exercise the
     # scalar_round_half_to_even_op template specialization for integers.
-    for dtype in [tf.int32, tf.int64]:
-      inputs = tf.constant([-3, 1, 0, -1], dtype=dtype)
-      outputs = tf.raw_ops.Round(x=inputs)
+    for dtype in [dtypes_lib.int32, dtypes_lib.int64]:
+      inputs = constant_op.constant([-3, 1, 0, -1], dtype=dtype)
+      outputs = gen_math_ops.round(inputs)
       self.assertAllEqual([-3, 1, 0, -1], self.evaluate(outputs))
 
 

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -652,13 +652,11 @@ class UnaryOpTest(test.TestCase):
     self.assertLess(err, 1e-3)
 
 
+  @test_util.run_in_graph_and_eager_modes
   def testRoundInt(self):
-    # math_ops.round short-circuits in Python for integer dtypes, so it never
-    # calls the C++ kernel. Target gen_math_ops.round directly to exercise the
-    # scalar_round_half_to_even_op template specialization for integers.
     for dtype in [dtypes_lib.int32, dtypes_lib.int64]:
       inputs = constant_op.constant([-3, 1, 0, -1], dtype=dtype)
-      outputs = gen_math_ops.round(inputs)
+      outputs = gen_math_ops.round(x=inputs)
       self.assertAllEqual([-3, 1, 0, -1], self.evaluate(outputs))
 
 


### PR DESCRIPTION
Fixes #122048

## Problem
`tf.math.round` / `tf.raw_ops.Round` on integer tensors compiles fine in eager mode but crashes under `jit_compile=True` with:
```
Operands to RoundToEven must be real-valued floating-point, but got S32
```

## Root cause
The XLA kernel for `Round` unconditionally called `xla::RoundToEven(x)`, which XLA rejects for non-float types.

## Fix
Replace the `XLAJIT_MAKE_UNARY` one-liner with a custom `RoundOp` that checks `DataTypeIsInteger(ctx->input_type(0))`:
- Integer input → identity (no-op, mathematically correct)
- Float input → `xla::RoundToEven(x)` as before