### PR TITLE
Fix duplicate CUDA plugin factory registration logs

### DIFF
--- a/third_party/xla/xla/stream_executor/cuda/cuda_blas.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_blas.cc
@@ -1421,7 +1421,7 @@ void initialize_cublas() {
             return blas;
           });
 
-  if (!status.ok()) {
+  if (!status.ok() && status.code() != absl::StatusCode::kAlreadyExists) {
     LOG(INFO) << "Unable to register cuBLAS factory: " << status.message();
   }
 }

--- a/third_party/xla/xla/stream_executor/cuda/cuda_blas.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_blas.cc
@@ -1421,7 +1421,7 @@ void initialize_cublas() {
             return blas;
           });
 
-  if (!status.ok() && status.code() != absl::StatusCode::kAlreadyExists) {
+  if (!status.ok() && !absl::IsAlreadyExists(status)) {
     LOG(INFO) << "Unable to register cuBLAS factory: " << status.message();
   }
 }

--- a/third_party/xla/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_dnn.cc
@@ -6977,7 +6977,7 @@ void initialize_cudnn() {
             return dnn;
           });
 
-  if (!status.ok()) {
+  if (!status.ok() && status.code() != absl::StatusCode::kAlreadyExists) {
     LOG(INFO) << "Unable to register cuDNN factory: " << status.message();
   }
 }

--- a/third_party/xla/xla/stream_executor/cuda/cuda_dnn.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_dnn.cc
@@ -6977,7 +6977,7 @@ void initialize_cudnn() {
             return dnn;
           });
 
-  if (!status.ok() && status.code() != absl::StatusCode::kAlreadyExists) {
+  if (!status.ok() && !absl::IsAlreadyExists(status)) {
     LOG(INFO) << "Unable to register cuDNN factory: " << status.message();
   }
 }

--- a/third_party/xla/xla/stream_executor/cuda/cuda_fft.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_fft.cc
@@ -477,7 +477,7 @@ void initialize_cufft() {
           [](StreamExecutor *parent) -> fft::FftSupport * {
             return new gpu::CUDAFft(parent);
           });
-  if (!status.ok()) {
+  if (!status.ok() && status.code() != absl::StatusCode::kAlreadyExists) {
     LOG(INFO) << "Unable to register cuFFT factory: " << status.message();
   }
 }

--- a/third_party/xla/xla/stream_executor/cuda/cuda_fft.cc
+++ b/third_party/xla/xla/stream_executor/cuda/cuda_fft.cc
@@ -477,7 +477,7 @@ void initialize_cufft() {
           [](StreamExecutor *parent) -> fft::FftSupport * {
             return new gpu::CUDAFft(parent);
           });
-  if (!status.ok() && status.code() != absl::StatusCode::kAlreadyExists) {
+  if (!status.ok() && !absl::IsAlreadyExists(status)) {
     LOG(INFO) << "Unable to register cuFFT factory: " << status.message();
   }
 }


### PR DESCRIPTION
This PR fixes the duplicate cuDNN, cuFFT, and cuBLAS registration warnings (Fixes #62075).

Instead of using an atomic flag (as attempted in previous PRs), this fix goes to the root of the issue by checking if the returned status from the plugin registry is absl::StatusCode::kAlreadyExists. If the factory is already registered, it silently skips logging the error. This safely relies on the thread-safe mutex already present inside PluginRegistry::RegisterFactory.

