### PR TITLE
Fix tf.experimental.numpy.isclose XLA shape mismatch

### DIFF
--- a/tensorflow/python/ops/numpy_ops/BUILD
+++ b/tensorflow/python/ops/numpy_ops/BUILD
@@ -239,6 +239,7 @@ cuda_py_strict_test(
         ":np_array_ops",
         ":np_arrays",
         ":np_math_ops",
+        "//tensorflow/python/eager:def_function",
         "//tensorflow/python/framework:errors",
         "//tensorflow/python/framework:ops",
         "//tensorflow/python/framework:tensor",

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -539,9 +539,27 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):  # pylint: disable=m
   return _bin_op(f, a, b)
 
 
+def _static_broadcast_compatible(a, b):
+  if a.shape.rank is None or b.shape.rank is None:
+    return None
+  if not a.shape.is_fully_defined() or not b.shape.is_fully_defined():
+    return None
+  try:
+    array_ops.broadcast_static_shape(a.shape, b.shape)
+  except ValueError:
+    return False
+  return True
+
+
 @tf_export.tf_export('experimental.numpy.allclose', v1=[])
 @np_utils.np_doc('allclose')
 def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
+  a, b = np_array_ops._promote_dtype_binary(a, b)  # pylint: disable=protected-access
+  if (
+      not np.issubdtype(a.dtype.as_numpy_dtype, np.inexact)
+      and _static_broadcast_compatible(a, b) is False
+  ):
+    return constant_op.constant(False)
   return np_array_ops.all(
       isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
   )

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -534,36 +534,20 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):  # pylint: disable=m
         result = result | (math_ops.is_nan(a) & math_ops.is_nan(b))
       return result
     else:
+      try:
+        array_ops.broadcast_static_shape(a.shape, b.shape)
+      except ValueError:
+        return constant_op.constant(False)
       return a == b
 
   return _bin_op(f, a, b)
 
-
-def _static_broadcast_compatible(a, b):
-  if a.shape.rank is None or b.shape.rank is None:
-    return None
-  if not a.shape.is_fully_defined() or not b.shape.is_fully_defined():
-    return None
-  try:
-    array_ops.broadcast_static_shape(a.shape, b.shape)
-  except ValueError:
-    return False
-  return True
-
-
 @tf_export.tf_export('experimental.numpy.allclose', v1=[])
 @np_utils.np_doc('allclose')
 def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
-  a, b = np_array_ops._promote_dtype_binary(a, b)  # pylint: disable=protected-access
-  if (
-      not np.issubdtype(a.dtype.as_numpy_dtype, np.inexact)
-      and _static_broadcast_compatible(a, b) is False
-  ):
-    return constant_op.constant(False)
   return np_array_ops.all(
       isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
   )
-
 
 def _tf_gcd(x1, x2):  # pylint: disable=missing-function-docstring
   def _gcd_cond_fn(_, x2):

--- a/tensorflow/python/ops/numpy_ops/np_math_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops.py
@@ -534,13 +534,10 @@ def isclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):  # pylint: disable=m
         result = result | (math_ops.is_nan(a) & math_ops.is_nan(b))
       return result
     else:
-      try:
-        array_ops.broadcast_static_shape(a.shape, b.shape)
-      except ValueError:
-        return constant_op.constant(False)
-      return a == b
+      return math_ops.equal(a, b)
 
   return _bin_op(f, a, b)
+
 
 @tf_export.tf_export('experimental.numpy.allclose', v1=[])
 @np_utils.np_doc('allclose')
@@ -548,6 +545,7 @@ def allclose(a, b, rtol=1e-05, atol=1e-08, equal_nan=False):
   return np_array_ops.all(
       isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
   )
+
 
 def _tf_gcd(x1, x2):  # pylint: disable=missing-function-docstring
   def _gcd_cond_fn(_, x2):

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -18,6 +18,7 @@ import itertools
 from absl.testing import parameterized
 import numpy as np
 
+from tensorflow.python.eager import def_function
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import tensor
@@ -227,6 +228,20 @@ class MathTest(test.TestCase, parameterized.TestCase):
     self.match(
         np_math_ops.isclose(a, b, equal_nan=equal_nan),
         np.isclose(a, b, equal_nan=equal_nan))
+
+  def testAllCloseNonBroadcastableShapesXla(self):
+    t = ops.convert_to_tensor(np.arange(8, dtype=np.complex64))
+
+    def model(x):
+      a = np_array_ops.hstack((5, 5, 5, 5))
+      b = np_math_ops.logical_xor(x, x)
+      return np_math_ops.allclose(a, b, atol=-2.92515058314041)
+
+    eager_out = model(t)
+    xla_out = def_function.function(model, jit_compile=True)(t)
+
+    self.assertAllEqual(eager_out, xla_out)
+    self.assertAllEqual(False, xla_out)
 
   def testAverageWrongShape(self):
     with self.assertRaisesWithPredicateMatch(errors.InvalidArgumentError, r''):

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -230,20 +230,28 @@ class MathTest(test.TestCase, parameterized.TestCase):
         np.isclose(a, b, equal_nan=equal_nan))
 
   @parameterized.named_parameters(
-      ('isclose', np_math_ops.isclose),
-      ('allclose', np_math_ops.allclose),
+      ('isclose_int32', np_math_ops.isclose, np.int32),
+      ('allclose_int32', np_math_ops.allclose, np.int32),
+      ('isclose_float32', np_math_ops.isclose, np.float32),
+      ('allclose_float32', np_math_ops.allclose, np.float32),
   )
-  def testCloseNonBroadcastableShapesXla(self, close_fn):
-    a = ops.convert_to_tensor(np.arange(4, dtype=np.int32))
-    b = ops.convert_to_tensor(np.arange(8, dtype=np.int32))
+  def testCloseNonBroadcastableShapesXla(self, close_fn, dtype):
+    a = ops.convert_to_tensor(np.arange(4, dtype=dtype))
+    b = ops.convert_to_tensor(np.arange(8, dtype=dtype))
 
-    eager_out = close_fn(a, b)
-    xla_out = def_function.function(
+    error_types = (ValueError, errors.InvalidArgumentError)
+    error_pattern = (
+        r'Incompatible shapes|Dimensions must be equal|broadcast'
+    )
+
+    with self.assertRaisesRegex(error_types, error_pattern):
+      close_fn(a, b)
+
+    compiled_close_fn = def_function.function(
         close_fn, jit_compile=True
-    )(a, b)
-
-    self.assertAllEqual(False, eager_out)
-    self.assertAllEqual(eager_out, xla_out)
+    )
+    with self.assertRaisesRegex(error_types, error_pattern):
+      compiled_close_fn(a, b)
 
   def testAverageWrongShape(self):
     with self.assertRaisesWithPredicateMatch(errors.InvalidArgumentError, r''):

--- a/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_math_ops_test.py
@@ -229,19 +229,21 @@ class MathTest(test.TestCase, parameterized.TestCase):
         np_math_ops.isclose(a, b, equal_nan=equal_nan),
         np.isclose(a, b, equal_nan=equal_nan))
 
-  def testAllCloseNonBroadcastableShapesXla(self):
-    t = ops.convert_to_tensor(np.arange(8, dtype=np.complex64))
+  @parameterized.named_parameters(
+      ('isclose', np_math_ops.isclose),
+      ('allclose', np_math_ops.allclose),
+  )
+  def testCloseNonBroadcastableShapesXla(self, close_fn):
+    a = ops.convert_to_tensor(np.arange(4, dtype=np.int32))
+    b = ops.convert_to_tensor(np.arange(8, dtype=np.int32))
 
-    def model(x):
-      a = np_array_ops.hstack((5, 5, 5, 5))
-      b = np_math_ops.logical_xor(x, x)
-      return np_math_ops.allclose(a, b, atol=-2.92515058314041)
+    eager_out = close_fn(a, b)
+    xla_out = def_function.function(
+        close_fn, jit_compile=True
+    )(a, b)
 
-    eager_out = model(t)
-    xla_out = def_function.function(model, jit_compile=True)(t)
-
+    self.assertAllEqual(False, eager_out)
     self.assertAllEqual(eager_out, xla_out)
-    self.assertAllEqual(False, xla_out)
 
   def testAverageWrongShape(self):
     with self.assertRaisesWithPredicateMatch(errors.InvalidArgumentError, r''):


### PR DESCRIPTION
Fixes #122052.

This change makes the non-inexact path of `tf.experimental.numpy.isclose` use strict TensorFlow equality for non-broadcastable inputs.

Tensor equality normally returns scalar `False` for incompatible shapes through the incompatible-shape fallback. Under `jit_compile=True`, the graph could still contain an `Equal` operation over incompatible shapes, causing XLA compilation to fail.

The non-inexact path now uses `math_ops.equal`, which applies strict broadcasting rules. As a result, non broadcastable inputs raise a `ValueError` or TensorFlow equivalent instead of returning `False` in eager execution and failing later during XLA compilation. This also keeps the behavior consistent with NumPy and with the existing inexact-type path.

The change is placed in `isclose` so that both direct `isclose` calls and `allclose`, which reduces the result of `isclose`, receive the fix.

The regression test covers both `isclose` and `allclose` with integer and floating-point inputs in eager and XLA-compiled execution.

## Testing

```bash
bazel test --config=linux -k \
  //tensorflow/python/ops/numpy_ops:np_math_ops_test \
  --test_filter='*CloseNonBroadcastableShapesXla*'

bazel test --config=linux -k \
  //tensorflow/python/ops/numpy_ops:np_math_ops_test
```