### PR TITLE
Fix false shape-mismatch in XLA Igamma/Igammac/Zeta for operands with identical logical shape

### DIFF
--- a/tensorflow/compiler/tests/special_math_test.py
+++ b/tensorflow/compiler/tests/special_math_test.py
@@ -22,6 +22,7 @@ from absl.testing import parameterized
 
 import numpy as np
 import scipy.special as sps
+import tensorflow as tf
 
 from tensorflow.compiler.tests import xla_test
 from tensorflow.python.eager import def_function
@@ -618,6 +619,41 @@ class IgammacTest(xla_test.XLATestCase, parameterized.TestCase):
         actual = sess.run(_igammac(a, x))
     self.assertAllClose(expected_values, actual, atol=atol, rtol=rtol)
 
+
+class DynamicShapeEqualityTest(xla_test.XLATestCase, parameterized.TestCase):
+
+  def _test_op_with_dynamic_shapes(self, op_fn, dtype):
+    tf.random.set_seed(3994)
+    t = tf.random.normal([1, 32], dtype=dtype)
+
+    def model(t):
+      a = tf.experimental.numpy.logaddexp(t, t)
+      b = tf.linspace(a, a, 6)
+      c = tf.linalg.lstsq(t, b)
+      d = tf.experimental.numpy.power(b, t)
+      return op_fn(a=c, x=d)
+
+    eager_out = model(t)
+    xla_out = def_function.function(model, jit_compile=True)(t)
+    self.assertAllClose(eager_out, xla_out, rtol=1e-5, atol=1e-5)
+
+  @parameterized.parameters(tf.float32, tf.float64)
+  def testIgammaDynamicShape(self, dtype):
+    if self.device not in ['XLA_GPU', 'XLA_CPU'] and dtype == tf.float64:
+      self.skipTest('Skipping test because some F64 operations not supported on TPU.')
+    self._test_op_with_dynamic_shapes(tf.raw_ops.Igamma, dtype)
+
+  @parameterized.parameters(tf.float32, tf.float64)
+  def testIgammacDynamicShape(self, dtype):
+    if self.device not in ['XLA_GPU', 'XLA_CPU'] and dtype == tf.float64:
+      self.skipTest('Skipping test because some F64 operations not supported on TPU.')
+    self._test_op_with_dynamic_shapes(tf.raw_ops.Igammac, dtype)
+
+  @parameterized.parameters(tf.float32, tf.float64)
+  def testZetaDynamicShape(self, dtype):
+    if self.device not in ['XLA_GPU', 'XLA_CPU'] and dtype == tf.float64:
+      self.skipTest('Skipping test because some F64 operations not supported on TPU.')
+    self._test_op_with_dynamic_shapes(lambda a, x: tf.raw_ops.Zeta(x=a, q=x), dtype)
 
 if __name__ == '__main__':
   os.environ['XLA_FLAGS'] = '--xla_cpu_enable_fast_math=false'

--- a/third_party/xla/xla/hlo/builder/lib/math.cc
+++ b/third_party/xla/xla/hlo/builder/lib/math.cc
@@ -40,6 +40,7 @@ limitations under the License.
 #include "xla/hlo/ir/hlo_opcode.h"
 #include "xla/primitive_util.h"
 #include "xla/shape.h"
+#include "xla/shape_util.h"
 #include "xla/status_macros.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
@@ -968,7 +969,7 @@ XlaOp Igamma(XlaOp a, XlaOp x) {
   return b.ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     ASSIGN_OR_RETURN(auto a_shape, b.GetShape(a));
     ASSIGN_OR_RETURN(auto x_shape, b.GetShape(x));
-    if (a_shape != x_shape) {
+    if (!ShapeUtil::Compatible(a_shape, x_shape)) {
       return InvalidArgument(
           "Arguments to Igamma must have equal shapes and types; got %s and %s",
           a_shape.ToString(), x_shape.ToString());
@@ -1022,7 +1023,7 @@ XlaOp IgammaGradA(XlaOp a, XlaOp x) {
   return b.ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     ASSIGN_OR_RETURN(auto a_shape, b.GetShape(a));
     ASSIGN_OR_RETURN(auto x_shape, b.GetShape(x));
-    if (a_shape != x_shape) {
+    if (!ShapeUtil::Compatible(a_shape, x_shape)) {
       return InvalidArgument(
           "Arguments to IgammaGradA must have equal shapes and types; got %s "
           "and %s",
@@ -1076,7 +1077,7 @@ XlaOp RandomGammaGrad(XlaOp a, XlaOp x) {
   return b.ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     ASSIGN_OR_RETURN(auto a_shape, b.GetShape(a));
     ASSIGN_OR_RETURN(auto x_shape, b.GetShape(x));
-    if (a_shape != x_shape) {
+    if (!ShapeUtil::Compatible(a_shape, x_shape)) {
       return InvalidArgument(
           "Arguments to RandomGammaGrad must have equal shapes and types; got "
           "%s and %s",
@@ -1121,7 +1122,7 @@ XlaOp Igammac(XlaOp a, XlaOp x) {
   return b.ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     ASSIGN_OR_RETURN(auto a_shape, b.GetShape(a));
     ASSIGN_OR_RETURN(auto x_shape, b.GetShape(x));
-    if (a_shape != x_shape) {
+    if (!ShapeUtil::Compatible(a_shape, x_shape)) {
       return InvalidArgument(
           "Arguments to Igammac must have equal shapes and types; "
           "got %s and %s",
@@ -2170,7 +2171,7 @@ XlaOp Zeta(XlaOp x, XlaOp q) {
   return builder.ReportErrorOrReturn([&]() -> absl::StatusOr<XlaOp> {
     ASSIGN_OR_RETURN(auto x_shape, builder.GetShape(x));
     ASSIGN_OR_RETURN(auto q_shape, builder.GetShape(q));
-    if (x_shape != q_shape) {
+    if (!ShapeUtil::Compatible(x_shape, q_shape)) {
       return InvalidArgument(
           "Arguments to Zeta must have equal shapes and types; got %s and %s",
           x_shape.ToString(), q_shape.ToString());

--- a/third_party/xla/xla/hlo/builder/lib/math_test.cc
+++ b/third_party/xla/xla/hlo/builder/lib/math_test.cc
@@ -550,6 +550,52 @@ TEST_F(MathTest, Igamma) {
   ComputeAndCompareR3<float>(&builder, expected, {}, kErrorSpec);
 }
 
+TEST_F(MathTest, IgammaDynamicShapeMismatch) {
+  XlaBuilder builder(TestName());
+  Shape shape_a = ShapeUtil::MakeShape(F32, {2, 2});
+  Shape shape_x = ShapeUtil::MakeShape(F32, {2, 2});
+  shape_a.set_dynamic_dimension(0, true);
+  
+  XlaOp a = Parameter(&builder, 0, shape_a, "a");
+  XlaOp x = Parameter(&builder, 1, shape_x, "x");
+  
+  Igamma(a, x);
+  
+  auto status = builder.Build().status();
+  ASSERT_TRUE(status.ok());
+}
+
+
+TEST_F(MathTest, IgammacDynamicShapeMismatch) {
+  XlaBuilder builder(TestName());
+  Shape shape_a = ShapeUtil::MakeShape(F32, {2, 2});
+  Shape shape_x = ShapeUtil::MakeShape(F32, {2, 2});
+  shape_a.set_dynamic_dimension(0, true);
+  
+  XlaOp a = Parameter(&builder, 0, shape_a, "a");
+  XlaOp x = Parameter(&builder, 1, shape_x, "x");
+  
+  Igammac(a, x);
+  
+  auto status = builder.Build().status();
+  ASSERT_TRUE(status.ok());
+}
+
+TEST_F(MathTest, ZetaDynamicShapeMismatch) {
+  XlaBuilder builder(TestName());
+  Shape shape_x = ShapeUtil::MakeShape(F32, {2, 2});
+  Shape shape_q = ShapeUtil::MakeShape(F32, {2, 2});
+  shape_x.set_dynamic_dimension(0, true);
+  
+  XlaOp x = Parameter(&builder, 0, shape_x, "x");
+  XlaOp q = Parameter(&builder, 1, shape_q, "q");
+  
+  Zeta(x, q);
+  
+  auto status = builder.Build().status();
+  ASSERT_TRUE(status.ok());
+}
+
 TEST_F(MathTest, IgammaSpecialValues) {
   SetFastMathDisabled(true);
   XlaBuilder builder(TestName());


### PR DESCRIPTION
Fixes issue #122047.

**Description**
The shape equality check in XLA operations `Igamma`, `IgammaGradA`, `RandomGammaGrad`, `Igammac`, and `Zeta` was previously using `operator!=` (`Shape::Equal()`). This strict equality check inappropriately compares dynamic-dimension bits and layouts in addition to logical dimensions and element types. 

When one operand originates from a path that propagates a dynamic-dimension bit (e.g. `tf.linalg.lstsq`) while the other operand does not (e.g., `tf.experimental.numpy.power`), the two `xla::Shape` objects compare as unequal. This triggers a failure even though their printed representation and logical semantics are identical. The check would confusingly fire with: `"must have equal shapes and types; got f64[6,32,32] and f64[6,32,32]"`.

**The Fix**
Replaced `operator!=` with `!ShapeUtil::Compatible()`, which is defined as `Shape::Equal().IgnoreDynamicDimension().IgnoreLayout()`. This safely accepts any pair of shapes that share the same rank, bounded dimensions, and element type, correctly validating the op constraints without falsely failing on dynamic dimension metadata.

**Testing**
- Added C++ unit tests in `math_test.cc` (`IgammaDynamicShapeMismatch`, `IgammacDynamicShapeMismatch`, and `ZetaDynamicShapeMismatch`) that verify the build succeeds when one operand carries a dynamic-dimension bit and the other does not.
- Added a Python regression test `DynamicShapeEqualityTest` in `special_math_test.py` that reliably reproduces the original failure chain (`logaddexp -> linspace -> lstsq/power -> Igamma/Igammac/Zeta`) under `jit_compile=True` and asserts that the eager execution outputs match the XLA execution outputs.

Existing shape-validation tests are unaffected; genuine rank or element-type mismatches still cleanly return `InvalidArgument`.
