### PR TITLE
Fix avgpool3dgrad crash

### DIFF
--- a/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
+++ b/tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc
@@ -206,6 +206,29 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       const Tensor& grad_tensor =
           MklGetInput(context, kInputTensorIndexInputGradient);
 
+      bool is_pool2d = (this->ksize_.size() == 4);
+      const int expected_dims = is_pool2d ? 4 : 5;
+
+      OP_REQUIRES(
+          context, orig_input_tensor.dims() == 1,
+          absl::InvalidArgumentError(
+              absl::StrCat("orig_input_shape must be 1-dimensional, but got ",
+                           orig_input_tensor.dims(), "-dimensional.")));
+
+      OP_REQUIRES(
+          context, orig_input_tensor.NumElements() == expected_dims,
+          absl::InvalidArgumentError(
+              absl::StrCat("orig_input_shape must have ", expected_dims,
+                           " elements, but got ", orig_input_tensor.NumElements(),
+                           " elements.")));
+
+      OP_REQUIRES(
+          context, grad_tensor.dims() == expected_dims,
+          absl::InvalidArgumentError(
+              absl::StrCat("grad_tensor must be ", expected_dims,
+                           "-dimensional, but got ", grad_tensor.dims(),
+                           "-dimensional.")));
+
       // For empty tensor, avg_pool_3d_grad in oneDNN doesn't handle this case.
       // Follow what native TF does in this case.
 
@@ -218,8 +241,6 @@ class MklAvgPoolingGradOp : public MklPoolingBackwardOpBase<T> {
       OP_REQUIRES_OK(context,
                      context->allocate_output(0, output_shape, &output_tensor));
       output_tensor->flat<T>().setZero();
-
-      bool is_pool2d = (this->ksize_.size() == 4);
 
       // Validate grad tensor rank before accessing its dimensions.
       // For 2D pooling, grad must be 4D; for 3D pooling, grad must be 5D.


### PR DESCRIPTION
Fixes #118354

### Description
This PR fixes a fatal `CHECK` failure in the `AvgPool3DGrad` C++ API kernel that occurs when invalid input shapes or gradients are provided.

Previously, `MklAvgPoolingGradOp::Compute` lacked validation for the rank of the gradient and input shape tensors before converting them to oneDNN formats (via `TFShapeToMklDnnDimsInNCDHW`). If a malformed tensor (such as a 0-rank scalar) was passed, the process would abort/core dump because the underlying utility expected at least a 4D or 5D shape.

### Changes Made
- Added rank and element count validation for `orig_input_tensor` inside `tensorflow/core/kernels/mkl/mkl_avgpooling_op.cc`
- Added rank validation for `grad_tensor` based on whether the op is configured for 2D or 3D pooling.
- Instead of terminating the host process, the kernel now gracefully returns an `absl::InvalidArgumentError` when an invalid shape is detected, matching the expected behavior of native TensorFlow kernels.

### Motivation and Context
Prevents malicious or accidental malformed graphs from crashing the host process, particularly important for runtime stability and security in distributed or production environments.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
