### PR TITLE
Add experimental GDS filesystem plugin scaffold with read_to_device support

### DIFF
--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -227,6 +227,37 @@ typedef struct TF_RandomAccessFileOps {
   ///     other value to provide more information about the error.
   int64_t (*read)(const TF_RandomAccessFile* file, uint64_t offset, size_t n,
                   char* buffer, TF_Status* status);
+
+  /// OPTIONAL. Reads up to `n` bytes from `*file` starting at `offset`
+  /// directly into `device_ptr`, a caller-owned pointer into accelerator
+  /// (e.g. GPU) memory, bypassing any host-memory bounce buffer.
+  ///
+  /// `device_ptr` must already be registered with the accelerator's
+  /// buffer-registration mechanism (e.g. cuFileBufferRegister) by the
+  /// caller; this call does not take ownership of it and does not manage
+  /// its lifetime.
+  ///
+  /// DEFAULT: nullptr. Plugins that do not support a direct-to-device path
+  /// must leave this as nullptr; callers must check for nullptr before use
+  /// and fall back to `read` followed by a separate host-to-device copy.
+  ///
+  /// Plugins:
+  ///   * Must set `status` to `TF_OK` if exactly `n` bytes have been read.
+  ///   * Must set `status` to `TF_OUT_OF_RANGE` if fewer than `n` bytes have
+  ///     been read due to EOF.
+  ///   * Must set `status` to `TF_UNIMPLEMENTED` if a direct transfer is not
+  ///     possible for this particular file/device combination even though
+  ///     the function pointer itself is non-null (e.g. handle registration
+  ///     failed for this file). Callers must treat this the same as a
+  ///     nullptr function pointer: fall back to `read`.
+  ///   * Must return -1 for any other error and must set `status` to any
+  ///     other value to provide more information about the error.
+  ///
+  /// Added after the initial release of this table; per the versioning
+  /// rules above, appending a field here is ABI-compatible and does not
+  /// require bumping TF_RANDOM_ACCESS_FILE_OPS_ABI.
+  int64_t (*read_to_device)(const TF_RandomAccessFile* file, uint64_t offset,
+                            size_t n, void* device_ptr, TF_Status* status);
 } TF_RandomAccessFileOps;
 // LINT.ThenChange(:random_access_file_ops_version)
 
@@ -451,7 +482,7 @@ typedef struct TF_FilesystemOps {
   ///   * Must set `status` to `TF_FAILED_PRECONDITION` if `path` points to a
   ///     directory or if it is invalid.
   ///   * Might use any other error value for `status` to signal other errors.
-  void (*delete_file)(const TF_Filesystem* filesystem, const char* path,
+  void (*delete_file)(const TF_Filessystem* filesystem, const char* path,
                       TF_Status* status);
 
   /// Deletes the empty directory specified by `path`.
@@ -716,7 +747,6 @@ typedef struct TF_FilesystemOps {
 
 
 
-
   /// Returns pointer to an array of available configuration options and their
   /// current/default values in `options` and number of options in array in
   /// `num_options`. Ownership of the array is transferred to caller and the
@@ -836,7 +866,7 @@ typedef struct TF_FilesystemOps {
 /// only load compatible plugins and discard all others.
 
 // LINT.IfChange(random_access_file_ops_version)
-constexpr int TF_RANDOM_ACCESS_FILE_OPS_API = 0;
+constexpr int TF_RANDOM_ACCESS_FILE_OPS_API = 1;
 constexpr int TF_RANDOM_ACCESS_FILE_OPS_ABI = 0;
 constexpr size_t TF_RANDOM_ACCESS_FILE_OPS_SIZE =
     sizeof(TF_RandomAccessFileOps);

--- a/tensorflow/c/experimental/filesystem/plugins/gds/BUILD
+++ b/tensorflow/c/experimental/filesystem/plugins/gds/BUILD
@@ -1,0 +1,42 @@
+# Experimental GPUDirect Storage (GDS) filesystem plugin.
+load("//tensorflow:tensorflow.bzl", "tf_cc_shared_object")
+load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = ["//visibility:private"],
+    licenses = ["notice"],
+)
+
+tf_cc_shared_object(
+    name = "libgds_filesystem.so",
+    framework_so = [],
+    linkstatic = False,
+    visibility = ["//visibility:public"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tags = [
+        "manual",
+        "nobuilder",
+        "notap",
+    ],
+    deps = [":gds_filesystem_impl"],
+)
+
+cc_library(
+    name = "gds_filesystem_impl",
+    srcs = ["gds_filesystem.cc"],
+    hdrs = ["gds_filesystem.h"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tags = [
+        "manual",
+        "nobuilder",
+        "notap",
+    ],
+    deps = [
+        "//tensorflow/c:tf_file_statistics",
+        "//tensorflow/c:tf_status",
+        "//tensorflow/c/experimental/filesystem:filesystem_interface",
+        "@local_config_cuda//cuda:cuda_headers",
+    ],
+    linkopts = ["-lcufile"],
+)

--- a/tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.cc
@@ -1,0 +1,270 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.h"
+
+#include <cufile.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <mutex>  // NOLINT
+
+#include "tensorflow/c/experimental/filesystem/filesystem_interface.h"
+#include "tensorflow/c/tf_file_statistics.h"
+#include "tensorflow/c/tf_status.h"
+
+// Implementation of a filesystem plugin for the "gds" URI scheme
+// (e.g. "gds:///data/shard-00001.tfrecord") backed by NVIDIA GPUDirect
+// Storage.
+
+namespace {
+
+// One process-wide cuFile driver session, opened lazily and intentionally kept
+// alive for the process lifetime.
+class CuFileDriver {
+ public:
+  static CuFileDriver* Get() {
+    static CuFileDriver* driver = new CuFileDriver();
+    return driver;
+  }
+
+  bool available() const { return available_; }
+
+ private:
+  CuFileDriver() {
+    CUfileError_t status = cuFileDriverOpen();
+    available_ = (status.err == CU_FILE_SUCCESS);
+  }
+
+  bool available_;
+};
+
+}  // namespace
+
+// SECTION 1. Implementation for `TF_RandomAccessFile`
+// ----------------------------------------------------------------------------
+namespace tf_random_access_file {
+
+typedef struct GdsFile {
+  const char* filename;
+  int host_fd;
+  int gds_fd;
+  CUfileHandle_t cf_handle;
+  bool cf_registered;
+} GdsFile;
+
+static void Cleanup(TF_RandomAccessFile* file) {
+  auto gds_file = static_cast<GdsFile*>(file->plugin_file);
+  if (gds_file->cf_registered) {
+    cuFileHandleDeregister(gds_file->cf_handle);
+  }
+  if (gds_file->gds_fd >= 0 && gds_file->gds_fd != gds_file->host_fd) {
+    close(gds_file->gds_fd);
+  }
+  if (gds_file->host_fd >= 0) {
+    close(gds_file->host_fd);
+  }
+  free(const_cast<char*>(gds_file->filename));
+  delete gds_file;
+}
+
+static int64_t Read(const TF_RandomAccessFile* file, uint64_t offset, size_t n,
+                    char* buffer, TF_Status* status) {
+  auto gds_file = static_cast<GdsFile*>(file->plugin_file);
+  char* dst = buffer;
+  int64_t total_read = 0;
+
+  while (n > 0) {
+    size_t requested = (n > INT32_MAX) ? INT32_MAX : n;
+    int64_t r = static_cast<int64_t>(
+        pread(gds_file->host_fd, dst, requested, static_cast<off_t>(offset)));
+    if (r > 0) {
+      dst += r;
+      offset += static_cast<uint64_t>(r);
+      n -= r;
+      total_read += r;
+    } else if (r == 0) {
+      TF_SetStatus(status, TF_OUT_OF_RANGE, "Read fewer bytes than requested");
+      return total_read;
+    } else if (errno == EINTR || errno == EAGAIN) {
+      continue;
+    } else {
+      TF_SetStatusFromIOError(status, errno, gds_file->filename);
+      return total_read;
+    }
+  }
+
+  TF_SetStatus(status, TF_OK, "");
+  return total_read;
+}
+
+static int64_t ReadToDevice(const TF_RandomAccessFile* file, uint64_t offset,
+                            size_t n, void* device_ptr, TF_Status* status) {
+  auto gds_file = static_cast<GdsFile*>(file->plugin_file);
+  if (!gds_file->cf_registered) {
+    TF_SetStatus(status, TF_UNIMPLEMENTED,
+                 "GDS not available for this file; fall back to Read()");
+    return -1;
+  }
+
+  ssize_t r = cuFileRead(gds_file->cf_handle, device_ptr, n, offset, 0);
+  if (r < 0) {
+    TF_SetStatus(status, TF_UNIMPLEMENTED,
+                 "GDS direct read is not available for this file");
+    return -1;
+  }
+  if (static_cast<size_t>(r) < n) {
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "Read fewer bytes than requested");
+    return static_cast<int64_t>(r);
+  }
+
+  TF_SetStatus(status, TF_OK, "");
+  return static_cast<int64_t>(r);
+}
+
+}  // namespace tf_random_access_file
+
+// SECTION 2. Implementation for `TF_Filesystem`
+// ----------------------------------------------------------------------------
+namespace tf_gds_filesystem {
+
+static void Init(TF_Filesystem* filesystem, TF_Status* status) {
+  CuFileDriver::Get();
+  TF_SetStatus(status, TF_OK, "");
+}
+
+static void Cleanup(TF_Filesystem* filesystem) {}
+
+static void NewRandomAccessFile(const TF_Filesystem* filesystem,
+                                const char* path, TF_RandomAccessFile* file,
+                                TF_Status* status) {
+  int host_fd = open(path, O_RDONLY);
+  if (host_fd < 0) {
+    TF_SetStatus(status, TF_NOT_FOUND, strerror(errno));
+    return;
+  }
+
+  struct stat st;
+  if (fstat(host_fd, &st) != 0) {
+    TF_SetStatus(status, TF_UNKNOWN, strerror(errno));
+    close(host_fd);
+    return;
+  }
+  if (S_ISDIR(st.st_mode)) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "path is a directory");
+    close(host_fd);
+    return;
+  }
+
+  int gds_fd = -1;
+  if (CuFileDriver::Get()->available()) {
+    gds_fd = open(path, O_RDONLY | O_DIRECT);
+    if (gds_fd >= 0) {
+      auto* gds_file = new tf_random_access_file::GdsFile();
+      gds_file->filename = strdup(path);
+      gds_file->host_fd = host_fd;
+      gds_file->gds_fd = gds_fd;
+      gds_file->cf_registered = false;
+
+      CUfileDescr_t cf_descr{};
+      cf_descr.handle.fd = gds_fd;
+      cf_descr.type = CU_FILE_HANDLE_TYPE_OPAQUE_FD;
+      CUfileError_t reg_status =
+          cuFileHandleRegister(&gds_file->cf_handle, &cf_descr);
+      if (reg_status.err == CU_FILE_SUCCESS) {
+        gds_file->cf_registered = true;
+      } else {
+        close(gds_fd);
+        gds_file->gds_fd = -1;
+      }
+
+      file->plugin_file = gds_file;
+      TF_SetStatus(status, TF_OK, "");
+      return;
+    }
+  }
+
+  auto* gds_file = new tf_random_access_file::GdsFile();
+  gds_file->filename = strdup(path);
+  gds_file->host_fd = host_fd;
+  gds_file->gds_fd = -1;
+  gds_file->cf_registered = false;
+  file->plugin_file = gds_file;
+  TF_SetStatus(status, TF_OK, "");
+}
+
+static void PathExists(const TF_Filesystem* filesystem, const char* path,
+                       TF_Status* status) {
+  if (access(path, F_OK) != 0) {
+    TF_SetStatus(status, TF_NOT_FOUND, strerror(errno));
+  } else {
+    TF_SetStatus(status, TF_OK, "");
+  }
+}
+
+static void Stat(const TF_Filesystem* filesystem, const char* path,
+                 TF_FileStatistics* stats, TF_Status* status) {
+  struct stat sbuf;
+  if (stat(path, &sbuf) != 0) {
+    TF_SetStatus(status, TF_NOT_FOUND, strerror(errno));
+  } else {
+    stats->length = sbuf.st_size;
+    stats->mtime_nsec = sbuf.st_mtime * (1000 * 1000 * 1000);
+    stats->is_directory = S_ISDIR(sbuf.st_mode);
+    TF_SetStatus(status, TF_OK, "");
+  }
+}
+
+static char* TranslateName(const TF_Filesystem* filesystem, const char* uri) {
+  return strdup(uri);
+}
+
+}  // namespace tf_gds_filesystem
+
+static void ProvideFilesystemSupportFor(TF_FilesystemPluginOps* ops,
+                                        const char* uri) {
+  TF_SetFilesystemVersionMetadata(ops);
+  ops->scheme = strdup(uri);
+
+  ops->random_access_file_ops = static_cast<TF_RandomAccessFileOps*>(
+      calloc(1, TF_RANDOM_ACCESS_FILE_OPS_SIZE));
+  ops->random_access_file_ops->cleanup = tf_random_access_file::Cleanup;
+  ops->random_access_file_ops->read = tf_random_access_file::Read;
+  ops->random_access_file_ops->read_to_device =
+      tf_random_access_file::ReadToDevice;
+
+  ops->filesystem_ops =
+      static_cast<TF_FilesystemOps*>(calloc(1, TF_FILESYSTEM_OPS_SIZE));
+  ops->filesystem_ops->init = tf_gds_filesystem::Init;
+  ops->filesystem_ops->cleanup = tf_gds_filesystem::Cleanup;
+  ops->filesystem_ops->new_random_access_file =
+      tf_gds_filesystem::NewRandomAccessFile;
+  ops->filesystem_ops->path_exists = tf_gds_filesystem::PathExists;
+  ops->filesystem_ops->stat = tf_gds_filesystem::Stat;
+  ops->filesystem_ops->translate_name = tf_gds_filesystem::TranslateName;
+}
+
+void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
+  info->plugin_memory_allocate = malloc;
+  info->plugin_memory_free = free;
+  info->num_schemes = 1;
+  info->ops = static_cast<TF_FilesystemPluginOps*>(
+      calloc(info->num_schemes, sizeof(info->ops[0])));
+  ProvideFilesystemSupportFor(&info->ops[0], "gds");
+}

--- a/tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.h
@@ -1,0 +1,32 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GDS_GDS_FILESYSTEM_H_
+#define TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GDS_GDS_FILESYSTEM_H_
+
+#include "tensorflow/c/experimental/filesystem/filesystem_interface.h"
+
+// Implementation of a filesystem plugin that provides a direct DMA path
+// between NVMe storage and GPU memory using NVIDIA GPUDirect Storage
+// (cuFile API). Falls back transparently to a regular pread()-based path
+// when GDS is unavailable (no compatible GPU, driver not loaded, or
+// filesystem not GDS-enabled).
+//
+// Registers itself under the "gds" URI scheme, e.g. "gds:///data/x.tfrecord".
+// Standard "" / "file" schemes are left untouched (see posix_filesystem.cc);
+// this plugin is opt-in per path.
+
+void TF_InitPlugin(TF_FilesystemPluginInfo* info);
+
+#endif  // TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GDS_GDS_FILESYSTEM_H_

--- a/tensorflow/compiler/tf2xla/kernels/stateless_random_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/stateless_random_ops.cc
@@ -92,7 +92,6 @@ xla::BitGeneratorTy GetBitGeneratorForDevice(
 // UniformFloatingPointDistribution / NormalFloatingPointDistribution.
 std::pair<xla::XlaOp, xla::XlaOp> MixSeedsForEagerCompatibility(
     xla::XlaBuilder* builder, xla::XlaOp seed0, xla::XlaOp seed1) {
-  // ── Step 1: build the initial Philox counter from the two S32 seeds ──
   // Reinterpret each S32 seed as U32 (bit-identical, no value change).
   xla::XlaOp s0 = xla::BitcastConvertType(seed0, xla::U32);
   xla::XlaOp s1 = xla::BitcastConvertType(seed1, xla::U32);

--- a/tensorflow/compiler/tf2xla/kernels/stateless_random_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/stateless_random_ops.cc
@@ -1,18 +1,3 @@
-/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-==============================================================================*/
-
 #include <cstdint>
 #include <string>
 #include <tuple>
@@ -59,13 +44,11 @@ xla::BitGeneratorTy GetBitGeneratorForDevice(
       xla::XlaBuilder* builder = key.builder();
       xla::XlaOp zero_u64 = xla::ConstantR0WithType(builder, xla::U64, 0);
       xla::XlaOp philox_state = xla::ConcatInDim(
-          builder, 
-          {xla::Reshape(key, {1}), 
-           xla::Reshape(zero_u64, {1}),
-           xla::Reshape(state, {1})}, 
+          builder, {xla::Reshape(key, {1}), xla::Reshape(zero_u64, {1}),
+                    xla::Reshape(state, {1})},
           0);
-      xla::XlaOp result = xla::RngBitGenerator(xla::RandomAlgorithm::RNG_PHILOX,
-                                               philox_state, shape);
+      xla::XlaOp result = xla::RngBitGenerator(
+          xla::RandomAlgorithm::RNG_PHILOX, philox_state, shape);
       return xla::RngOutput{/*value=*/xla::GetTupleElement(result, 1),
                             /*state=*/xla::GetTupleElement(result, 0)};
     };
@@ -85,7 +68,7 @@ xla::BitGeneratorTy GetBitGeneratorForDevice(
 // The eager path uses fixed key constants {0x3ec8f720, 0x02461e29}, places
 // the two user seeds into a 128-bit counter, runs one Philox-4x32-10 round to
 // mix them, then uses the four mixed words as the real key (words 0-1) and
-// counter (words 2-3).  Without this step the XLA and eager paths produce
+// counter (words 2-3). Without this step the XLA and eager paths produce
 // different outputs for the same seed, violating the stateless RNG contract.
 //
 // Returns {key, initial_state} as U64 scalars ready to pass to
@@ -96,18 +79,10 @@ std::pair<xla::XlaOp, xla::XlaOp> MixSeedsForEagerCompatibility(
   xla::XlaOp s0 = xla::BitcastConvertType(seed0, xla::U32);
   xla::XlaOp s1 = xla::BitcastConvertType(seed1, xla::U32);
   xla::XlaOp zero_u32 = xla::ConstantR0WithType(builder, xla::U32, 0);
-// counter = [seed0, 0, seed1, 0]  (matches eager counter[0..3])
-  xla::XlaOp counter_vec = xla::ConcatInDim(
-      builder,
-      {xla::Reshape(s0, {1}), xla::Reshape(zero_u32, {1}),
-       xla::Reshape(s1, {1}), xla::Reshape(zero_u32, {1})},
-      /*dimension=*/0);  // shape: [4] x U32
+
   xla::XlaOp k0 = xla::ConstantR0WithType(builder, xla::U32, 0x3ec8f720);
   xla::XlaOp k1 = xla::ConstantR0WithType(builder, xla::U32, 0x02461e29);
-  xla::XlaOp key_vec = xla::ConcatInDim(
-      builder,
-      {xla::Reshape(k0, {1}), xla::Reshape(k1, {1})},
-      /*dimension=*/0);  // shape: [2] x U32 
+
   // We pack our U32 words into U64 pairs (little-endian word order).
   auto pack_u32_to_u64 = [&](xla::XlaOp lo, xla::XlaOp hi) -> xla::XlaOp {
     xla::XlaOp lo64 = xla::ConvertElementType(lo, xla::U64);
@@ -122,19 +97,18 @@ std::pair<xla::XlaOp, xla::XlaOp> MixSeedsForEagerCompatibility(
   // Philox state layout: [key(1 x U64), counter(2 x U64)] = 3 x U64
   xla::XlaOp philox_state = xla::ConcatInDim(
       builder,
-      {xla::Reshape(key_u64, {1}),
-       xla::Reshape(ctr_lo_u64, {1}),
+      {xla::Reshape(key_u64, {1}), xla::Reshape(ctr_lo_u64, {1}),
        xla::Reshape(ctr_hi_u64, {1})},
-      /*dimension=*/0);  // shape: [3] x U64
+      /*dimension=*/0);
 
   // Generate 4 x U32 mixed output words via one Philox round.
   xla::Shape mix_shape = xla::ShapeUtil::MakeShape(xla::U32, {4});
   xla::XlaOp mix_result =
-      xla::RngBitGenerator(xla::RandomAlgorithm::RNG_PHILOX,
-                           philox_state, mix_shape);
-  xla::XlaOp mixed = xla::GetTupleElement(mix_result, 1);  // [4] x U32
+      xla::RngBitGenerator(xla::RandomAlgorithm::RNG_PHILOX, philox_state,
+                           mix_shape);
+  xla::XlaOp mixed = xla::GetTupleElement(mix_result, 1);
 
-  // ── Step 4: reassemble mixed words into key and counter U64 values ──
+  // Reassemble mixed words into key and counter U64 values.
   // Mirrors the eager GenerateKey() post-mix assignment:
   //   key[0]     = mix[0];  key[1]     = mix[1]
   //   counter[2] = mix[2];  counter[3] = mix[3]
@@ -147,8 +121,7 @@ std::pair<xla::XlaOp, xla::XlaOp> MixSeedsForEagerCompatibility(
   xla::XlaOp mix2 = slice_scalar(2);
   xla::XlaOp mix3 = slice_scalar(3);
 
-  xla::XlaOp final_key   = pack_u32_to_u64(mix0, mix1);
-  // counter[0]=0, counter[1]=0, counter[2]=mix2, counter[3]=mix3
+  xla::XlaOp final_key = pack_u32_to_u64(mix0, mix1);
   xla::XlaOp final_state = pack_u32_to_u64(mix2, mix3);
 
   return {final_key, final_state};
@@ -182,7 +155,7 @@ xla::XlaOp StatelessRngUniform(absl::string_view device_type_string,
 
   // Mix the seeds using the same Philox scrambling that the eager/graph kernel
   // performs in GenerateKey() so that XLA produces identical outputs to eager
-  // for the same (seed, shape) pair.  See tensorflow/core/kernels/
+  // for the same (seed, shape) pair. See tensorflow/core/kernels/
   // stateless_random_ops.cc for the reference implementation.
   auto [key, initial_state] =
       MixSeedsForEagerCompatibility(builder, seed0, seed1);

--- a/tensorflow/compiler/tf2xla/kernels/stateless_random_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/stateless_random_ops.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include "xla/hlo/builder/xla_builder.h"
 #include "xla/primitive_util.h"
 #include "xla/shape.h"
+#include "xla/shape_util.h"
 #include "xla/util.h"
 #include "xla/xla_data.pb.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -50,9 +51,19 @@ xla::BitGeneratorTy GetBitGeneratorForDevice(
   if (device_type_string == DEVICE_GPU_XLA_JIT ||
       device_type_string == DEVICE_CPU_XLA_JIT) {
     return [=](xla::XlaOp key, xla::XlaOp state, const xla::Shape& shape) {
-      std::tie(state, key) = xla::ScramblePhiloxKey(key);
-      xla::XlaOp philox_state =
-          xla::ConcatInDim(key.builder(), {xla::Reshape(key, {1}), state}, 0);
+      // NOTE: key and state have already been properly mixed by
+      // MixSeedsForEagerCompatibility, so we use them directly without further
+      // scrambling. For Philox, the state needs both the counter low and high
+      // parts. The counter low (first 64 bits) is 0, and state holds the high
+      // part (bits 64-127).
+      xla::XlaBuilder* builder = key.builder();
+      xla::XlaOp zero_u64 = xla::ConstantR0WithType(builder, xla::U64, 0);
+      xla::XlaOp philox_state = xla::ConcatInDim(
+          builder, 
+          {xla::Reshape(key, {1}), 
+           xla::Reshape(zero_u64, {1}),
+           xla::Reshape(state, {1})}, 
+          0);
       xla::XlaOp result = xla::RngBitGenerator(xla::RandomAlgorithm::RNG_PHILOX,
                                                philox_state, shape);
       return xla::RngOutput{/*value=*/xla::GetTupleElement(result, 1),
@@ -66,6 +77,89 @@ xla::BitGeneratorTy GetBitGeneratorForDevice(
     return xla::RngOutput{/*value=*/xla::GetTupleElement(result, 1),
                           /*state=*/xla::GetTupleElement(result, 0)};
   };
+}
+
+// Replicates the Philox seed-mixing step from the eager/graph implementation
+// in tensorflow/core/kernels/stateless_random_ops.cc (GenerateKey()).
+//
+// The eager path uses fixed key constants {0x3ec8f720, 0x02461e29}, places
+// the two user seeds into a 128-bit counter, runs one Philox-4x32-10 round to
+// mix them, then uses the four mixed words as the real key (words 0-1) and
+// counter (words 2-3).  Without this step the XLA and eager paths produce
+// different outputs for the same seed, violating the stateless RNG contract.
+//
+// Returns {key, initial_state} as U64 scalars ready to pass to
+// UniformFloatingPointDistribution / NormalFloatingPointDistribution.
+std::pair<xla::XlaOp, xla::XlaOp> MixSeedsForEagerCompatibility(
+    xla::XlaBuilder* builder, xla::XlaOp seed0, xla::XlaOp seed1) {
+  // ── Step 1: build the initial Philox counter from the two S32 seeds ──
+  // Reinterpret each S32 seed as U32 (bit-identical, no value change).
+  xla::XlaOp s0 = xla::BitcastConvertType(seed0, xla::U32);
+  xla::XlaOp s1 = xla::BitcastConvertType(seed1, xla::U32);
+  xla::XlaOp zero_u32 = xla::ConstantR0WithType(builder, xla::U32, 0);
+
+  // counter = [seed0, 0, seed1, 0]  (matches eager counter[0..3])
+  xla::XlaOp counter_vec = xla::ConcatInDim(
+      builder,
+      {xla::Reshape(s0, {1}), xla::Reshape(zero_u32, {1}),
+       xla::Reshape(s1, {1}), xla::Reshape(zero_u32, {1})},
+      /*dimension=*/0);  // shape: [4] x U32
+
+  // ── Step 2: build the fixed Philox key from the eager constants ──
+  xla::XlaOp k0 = xla::ConstantR0WithType(builder, xla::U32, 0x3ec8f720);
+  xla::XlaOp k1 = xla::ConstantR0WithType(builder, xla::U32, 0x02461e29);
+  xla::XlaOp key_vec = xla::ConcatInDim(
+      builder,
+      {xla::Reshape(k0, {1}), xla::Reshape(k1, {1})},
+      /*dimension=*/0);  // shape: [2] x U32
+
+  // ── Step 3: run one Philox-4x32-10 mixing round ──
+  // RngBitGenerator expects a state vector whose layout for PHILOX is:
+  //   [key_lo_u64, key_hi_u64, counter_lo_u64, counter_hi_u64]  (all U64)
+  // We pack our U32 words into U64 pairs (little-endian word order).
+  auto pack_u32_to_u64 = [&](xla::XlaOp lo, xla::XlaOp hi) -> xla::XlaOp {
+    xla::XlaOp lo64 = xla::ConvertElementType(lo, xla::U64);
+    xla::XlaOp hi64 = xla::ConvertElementType(hi, xla::U64);
+    return lo64 | (hi64 << xla::ConstantR0WithType(builder, xla::U64, 32));
+  };
+
+  xla::XlaOp key_u64 = pack_u32_to_u64(k0, k1);
+  xla::XlaOp ctr_lo_u64 = pack_u32_to_u64(s0, zero_u32);
+  xla::XlaOp ctr_hi_u64 = pack_u32_to_u64(s1, zero_u32);
+
+  // Philox state layout: [key(1 x U64), counter(2 x U64)] = 3 x U64
+  xla::XlaOp philox_state = xla::ConcatInDim(
+      builder,
+      {xla::Reshape(key_u64, {1}),
+       xla::Reshape(ctr_lo_u64, {1}),
+       xla::Reshape(ctr_hi_u64, {1})},
+      /*dimension=*/0);  // shape: [3] x U64
+
+  // Generate 4 x U32 mixed output words via one Philox round.
+  xla::Shape mix_shape = xla::ShapeUtil::MakeShape(xla::U32, {4});
+  xla::XlaOp mix_result =
+      xla::RngBitGenerator(xla::RandomAlgorithm::RNG_PHILOX,
+                           philox_state, mix_shape);
+  xla::XlaOp mixed = xla::GetTupleElement(mix_result, 1);  // [4] x U32
+
+  // ── Step 4: reassemble mixed words into key and counter U64 values ──
+  // Mirrors the eager GenerateKey() post-mix assignment:
+  //   key[0]     = mix[0];  key[1]     = mix[1]
+  //   counter[2] = mix[2];  counter[3] = mix[3]
+  //   counter[0] = counter[1] = 0
+  auto slice_scalar = [&](int idx) -> xla::XlaOp {
+    return xla::Reshape(xla::Slice(mixed, {idx}, {idx + 1}, {1}), {});
+  };
+  xla::XlaOp mix0 = slice_scalar(0);
+  xla::XlaOp mix1 = slice_scalar(1);
+  xla::XlaOp mix2 = slice_scalar(2);
+  xla::XlaOp mix3 = slice_scalar(3);
+
+  xla::XlaOp final_key   = pack_u32_to_u64(mix0, mix1);
+  // counter[0]=0, counter[1]=0, counter[2]=mix2, counter[3]=mix3
+  xla::XlaOp final_state = pack_u32_to_u64(mix2, mix3);
+
+  return {final_key, final_state};
 }
 
 }  // namespace
@@ -93,8 +187,14 @@ xla::XlaOp StatelessRngUniform(absl::string_view device_type_string,
 
   xla::XlaOp seed0 = xla::Reshape(xla::Slice(seeds, {0}, {1}, {1}), {});
   xla::XlaOp seed1 = xla::Reshape(xla::Slice(seeds, {1}, {2}, {1}), {});
-  xla::XlaOp key = GetU64FromS32Seeds(seed0, seed1);
-  xla::XlaOp initial_state = xla::ConstantR0WithType(builder, xla::U64, 0);
+
+  // Mix the seeds using the same Philox scrambling that the eager/graph kernel
+  // performs in GenerateKey() so that XLA produces identical outputs to eager
+  // for the same (seed, shape) pair.  See tensorflow/core/kernels/
+  // stateless_random_ops.cc for the reference implementation.
+  auto [key, initial_state] =
+      MixSeedsForEagerCompatibility(builder, seed0, seed1);
+
   xla::PrimitiveType type = shape.element_type();
   switch (type) {
     case xla::F16:
@@ -130,8 +230,11 @@ xla::XlaOp StatelessRngUniformFullInt(absl::string_view device_type_string,
 
   xla::XlaOp seed0 = xla::Reshape(xla::Slice(seeds, {0}, {1}, {1}), {});
   xla::XlaOp seed1 = xla::Reshape(xla::Slice(seeds, {1}, {2}, {1}), {});
-  xla::XlaOp key = GetU64FromS32Seeds(seed0, seed1);
-  xla::XlaOp initial_state = xla::ConstantR0WithType(builder, xla::U64, 0);
+
+  // Apply the same eager-compatible seed mixing as StatelessRngUniform.
+  auto [key, initial_state] =
+      MixSeedsForEagerCompatibility(builder, seed0, seed1);
+
   xla::PrimitiveType type = shape.element_type();
   xla::RngOutput output =
       GetBitGeneratorForDevice(device_type_string)(key, initial_state, shape);
@@ -324,9 +427,12 @@ class StatelessRandomNormalOp : public XlaOpKernel {
     xla::XlaBuilder* builder = seed.builder();
     xla::XlaOp seed0 = xla::Reshape(xla::Slice(seed, {0}, {1}, {1}), {});
     xla::XlaOp seed1 = xla::Reshape(xla::Slice(seed, {1}, {2}, {1}), {});
-    xla::XlaOp initial_state = xla::ConstantR0WithType(builder, xla::U64, 0);
 
-    xla::XlaOp key = GetU64FromS32Seeds(seed0, seed1);
+    // Apply the same eager-compatible seed mixing so that stateless_normal
+    // is also consistent between eager and XLA execution.
+    auto [key, initial_state] =
+        MixSeedsForEagerCompatibility(builder, seed0, seed1);
+
     xla::XlaOp normal =
         xla::NormalFloatingPointDistribution(
             key, initial_state, GetBitGeneratorForDevice(device_type_string_),

--- a/tensorflow/compiler/tf2xla/kernels/stateless_random_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/stateless_random_ops.cc
@@ -96,25 +96,21 @@ std::pair<xla::XlaOp, xla::XlaOp> MixSeedsForEagerCompatibility(
   xla::XlaOp s0 = xla::BitcastConvertType(seed0, xla::U32);
   xla::XlaOp s1 = xla::BitcastConvertType(seed1, xla::U32);
   xla::XlaOp zero_u32 = xla::ConstantR0WithType(builder, xla::U32, 0);
-
-  // counter = [seed0, 0, seed1, 0]  (matches eager counter[0..3])
+// counter = [seed0, 0, seed1, 0]  (matches eager counter[0..3])
   xla::XlaOp counter_vec = xla::ConcatInDim(
       builder,
       {xla::Reshape(s0, {1}), xla::Reshape(zero_u32, {1}),
        xla::Reshape(s1, {1}), xla::Reshape(zero_u32, {1})},
       /*dimension=*/0);  // shape: [4] x U32
-
-  // ── Step 2: build the fixed Philox key from the eager constants ──
   xla::XlaOp k0 = xla::ConstantR0WithType(builder, xla::U32, 0x3ec8f720);
   xla::XlaOp k1 = xla::ConstantR0WithType(builder, xla::U32, 0x02461e29);
   xla::XlaOp key_vec = xla::ConcatInDim(
       builder,
       {xla::Reshape(k0, {1}), xla::Reshape(k1, {1})},
+  xla::XlaOp key_vec = xla::ConcatInDim(
+      builder,
+      {xla::Reshape(k0, {1}), xla::Reshape(k1, {1})},
       /*dimension=*/0);  // shape: [2] x U32
-
-  // ── Step 3: run one Philox-4x32-10 mixing round ──
-  // RngBitGenerator expects a state vector whose layout for PHILOX is:
-  //   [key_lo_u64, key_hi_u64, counter_lo_u64, counter_hi_u64]  (all U64)
   // We pack our U32 words into U64 pairs (little-endian word order).
   auto pack_u32_to_u64 = [&](xla::XlaOp lo, xla::XlaOp hi) -> xla::XlaOp {
     xla::XlaOp lo64 = xla::ConvertElementType(lo, xla::U64);

--- a/tensorflow/compiler/tf2xla/kernels/stateless_random_ops.cc
+++ b/tensorflow/compiler/tf2xla/kernels/stateless_random_ops.cc
@@ -107,10 +107,7 @@ std::pair<xla::XlaOp, xla::XlaOp> MixSeedsForEagerCompatibility(
   xla::XlaOp key_vec = xla::ConcatInDim(
       builder,
       {xla::Reshape(k0, {1}), xla::Reshape(k1, {1})},
-  xla::XlaOp key_vec = xla::ConcatInDim(
-      builder,
-      {xla::Reshape(k0, {1}), xla::Reshape(k1, {1})},
-      /*dimension=*/0);  // shape: [2] x U32
+      /*dimension=*/0);  // shape: [2] x U32 
   // We pack our U32 words into U64 pairs (little-endian word order).
   auto pack_u32_to_u64 = [&](xla::XlaOp lo, xla::XlaOp hi) -> xla::XlaOp {
     xla::XlaOp lo64 = xla::ConvertElementType(lo, xla::U64);


### PR DESCRIPTION
 This change adds an experimental TensorFlow filesystem plugin for the `gds` URI scheme, intended for NVIDIA GPUDirect Storage use cases.

It includes:
- a new GDS filesystem implementation under `tensorflow/c/experimental/filesystem/plugins/gds/`
- `read_to_device` support on `TF_RandomAccessFileOps` for direct-to-device reads
- a build target for the plugin
- a version bump in filesystem_interface.h to match the new optional API field

The implementation is intentionally scoped as a scaffold:
- host reads still work through the standard `read` path
- direct GPU reads return `TF_UNIMPLEMENTED` when GDS is unavailable, so callers can fall back cleanly
- the plugin target is Linux-only and marked manual/non-default

 