### PR TITLE
Fix XLA nonnegative inference for signed integers

### DIFF
--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -135,6 +135,11 @@ bool IsAnyOperandComplex(const HloInstruction* hlo) {
   return false;
 }
 
+bool HasSignedIntegralElementType(const HloInstruction* hlo) {
+  return ShapeUtil::ElementIsIntegral(hlo->shape()) &&
+         ShapeUtil::ElementIsSigned(hlo->shape());
+}
+
 bool IsPositive(const HloInstruction* hlo,
                 const AlgebraicSimplifierOptions& options) {
   // Utility only handles real types.
@@ -534,12 +539,15 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
   }
   switch (hlo->opcode()) {
     case HloOpcode::kMultiply: {
-      return hlo->operand(0) == hlo->operand(1);
+      return hlo->operand(0) == hlo->operand(1) &&
+             !HasSignedIntegralElementType(hlo);
     }
-    case HloOpcode::kAbs:
     case HloOpcode::kExp:
     case HloOpcode::kIota: {
       return true;
+    }
+    case HloOpcode::kAbs: {
+      return !HasSignedIntegralElementType(hlo);
     }
     case HloOpcode::kBroadcast: {
       return IsNonNegative(hlo->operand(0), options);

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -553,7 +553,18 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
       return true;
     }
     case HloOpcode::kIota: {
-      return !HasSignedIntegralElementType(hlo);
+      if (!HasSignedIntegralElementType(hlo)) {
+        return true;
+      }
+      const auto* iota = Cast<HloIotaInstruction>(hlo);
+      const int64_t dim_size =
+          iota->shape().dimensions(iota->iota_dimension());
+      const int bit_width =
+          primitive_util::BitWidth(hlo->shape().element_type());
+      if (bit_width >= 64) {
+        return true;
+      }
+      return dim_size <= (1LL << (bit_width - 1));
     }
     case HloOpcode::kAbs: {
       return !HasSignedIntegralElementType(hlo);

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -161,6 +161,10 @@ bool IsPositive(const HloInstruction* hlo,
       }
     }
     case HloOpcode::kPower:
+      if (HasSignedIntegralElementType(hlo)) {
+        return false;
+      }
+      return IsPositive(hlo->operand(0), options);
     case HloOpcode::kAbs:
     case HloOpcode::kRsqrt:
     case HloOpcode::kSqrt:
@@ -545,9 +549,11 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
       return hlo->operand(0) == hlo->operand(1) &&
              !HasSignedIntegralElementType(hlo);
     }
-    case HloOpcode::kExp:
-    case HloOpcode::kIota: {
+    case HloOpcode::kExp: {
       return true;
+    }
+    case HloOpcode::kIota: {
+      return !HasSignedIntegralElementType(hlo);
     }
     case HloOpcode::kAbs: {
       return !HasSignedIntegralElementType(hlo);
@@ -571,7 +577,8 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
              IsNonNegative(hlo->operand(1), options);
     }
     case HloOpcode::kPower: {
-      return IsNonNegative(hlo->operand(0), options);
+      return !HasSignedIntegralElementType(hlo) &&
+             IsNonNegative(hlo->operand(0), options);
     }
     case HloOpcode::kSelect: {
       return IsNonNegative(hlo->operand(1), options) &&

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -167,6 +167,9 @@ bool IsPositive(const HloInstruction* hlo,
       return IsPositive(hlo->operand(0), options);
 
     case HloOpcode::kMultiply: {
+      if (HasSignedIntegralElementType(hlo)) {
+        return false;
+      }
       return hlo->operand(0) == hlo->operand(1) &&
              IsPositive(hlo->operand(0), options);
     }

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -567,7 +567,10 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
       return dim_size <= (1LL << (bit_width - 1));
     }
     case HloOpcode::kAbs: {
-      return !HasSignedIntegralElementType(hlo);
+      if (!HasSignedIntegralElementType(hlo)) {
+        return true;
+      }
+      return IsNonNegative(hlo->operand(0), options);
     }
     case HloOpcode::kBroadcast: {
       return IsNonNegative(hlo->operand(0), options);

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier.cc
@@ -135,11 +135,6 @@ bool IsAnyOperandComplex(const HloInstruction* hlo) {
   return false;
 }
 
-bool HasSignedIntegralElementType(const HloInstruction* hlo) {
-  return ShapeUtil::ElementIsIntegral(hlo->shape()) &&
-         ShapeUtil::ElementIsSigned(hlo->shape());
-}
-
 bool IsPositive(const HloInstruction* hlo,
                 const AlgebraicSimplifierOptions& options) {
   // Utility only handles real types.
@@ -161,7 +156,7 @@ bool IsPositive(const HloInstruction* hlo,
       }
     }
     case HloOpcode::kPower:
-      if (HasSignedIntegralElementType(hlo)) {
+      if (primitive_util::IsSignedIntegralType(hlo->shape().element_type())) {
         return false;
       }
       return IsPositive(hlo->operand(0), options);
@@ -171,7 +166,7 @@ bool IsPositive(const HloInstruction* hlo,
       return IsPositive(hlo->operand(0), options);
 
     case HloOpcode::kMultiply: {
-      if (HasSignedIntegralElementType(hlo)) {
+      if (primitive_util::IsSignedIntegralType(hlo->shape().element_type())) {
         return false;
       }
       return hlo->operand(0) == hlo->operand(1) &&
@@ -547,27 +542,30 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
   switch (hlo->opcode()) {
     case HloOpcode::kMultiply: {
       return hlo->operand(0) == hlo->operand(1) &&
-             !HasSignedIntegralElementType(hlo);
+             !primitive_util::IsSignedIntegralType(hlo->shape().element_type());
     }
     case HloOpcode::kExp: {
       return true;
     }
     case HloOpcode::kIota: {
-      if (!HasSignedIntegralElementType(hlo)) {
+      if (!primitive_util::IsSignedIntegralType(hlo->shape().element_type())) {
         return true;
       }
       const auto* iota = Cast<HloIotaInstruction>(hlo);
-      const int64_t dim_size =
-          iota->shape().dimensions(iota->iota_dimension());
+      const int64_t dim_size = iota->shape().dimensions(iota->iota_dimension());
       const int bit_width =
           primitive_util::BitWidth(hlo->shape().element_type());
       if (bit_width >= 64) {
         return true;
       }
-      return dim_size <= (1LL << (bit_width - 1));
+      // A signed b-bit iota can represent 2^(b-1) non-negative values. The
+      // 64-bit case is handled above, so this shift is at most 62 bits.
+      const uint64_t max_nonnegative_dimension_size = uint64_t{1}
+                                                      << (bit_width - 1);
+      return static_cast<uint64_t>(dim_size) <= max_nonnegative_dimension_size;
     }
     case HloOpcode::kAbs: {
-      if (!HasSignedIntegralElementType(hlo)) {
+      if (!primitive_util::IsSignedIntegralType(hlo->shape().element_type())) {
         return true;
       }
       return IsNonNegative(hlo->operand(0), options);
@@ -591,7 +589,8 @@ bool AlgebraicSimplifierVisitor::IsNonNegative(
              IsNonNegative(hlo->operand(1), options);
     }
     case HloOpcode::kPower: {
-      return !HasSignedIntegralElementType(hlo) &&
+      return !primitive_util::IsSignedIntegralType(
+                 hlo->shape().element_type()) &&
              IsNonNegative(hlo->operand(0), options);
     }
     case HloOpcode::kSelect: {

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -169,7 +169,8 @@ TEST_F(AlgebraicSimplifierTest, IsNonNegative_Op_NegativeTestCase) {
 
 TEST_F(AlgebraicSimplifierTest,
        IsNonNegativeSignedIntegerOverflowNegativeTestCase) {
-  for (const auto op : {"abs(p0)", "multiply(p0, p0)"}) {
+  for (const auto op : {"abs(p0)", "multiply(p0, p0)",
+                        "power(constant(10), constant(10))"}) {
     const auto kModuleStr = absl::StrFormat(R"(
       HloModule m
       test {
@@ -182,6 +183,17 @@ TEST_F(AlgebraicSimplifierTest,
     ASSERT_FALSE(AlgebraicSimplifierVisitor::IsNonNegative(
         m->entry_computation()->root_instruction(), default_options_));
   }
+}
+
+TEST_F(AlgebraicSimplifierTest, IsNonNegativeSignedIntegerIotaCanOverflow) {
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+    HloModule m
+    ENTRY test {
+      ROOT iota = s8[129] iota(), iota_dimension=0
+    }
+  )"));
+  ASSERT_FALSE(AlgebraicSimplifierVisitor::IsNonNegative(
+      m->entry_computation()->root_instruction(), default_options_));
 }
 
 // Test that the result of Broadcast is non-negative if its operand is

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -178,7 +178,7 @@ TEST_F(AlgebraicSimplifierTest,
       }
     )",
                                             op);
-    TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+    ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
     ASSERT_FALSE(AlgebraicSimplifierVisitor::IsNonNegative(
         m->entry_computation()->root_instruction(), default_options_));
   }
@@ -10365,7 +10365,7 @@ m {
 }
 
 TEST_F(AlgebraicSimplifierTest, DoesNotFoldSignedIntegerAbsLtZero) {
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
 m {
   p = s8[] parameter(0)
   a = s8[] abs(p)
@@ -12113,7 +12113,7 @@ TEST_F(AlgebraicSimplifierTest, AbsEliminationIota) {
 }
 
 TEST_F(AlgebraicSimplifierTest, DoesNotFoldSignedIntegerSquareAbsSelect) {
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
     HloModule m
     ENTRY test {
       p0 = s8[4]{0} parameter(0)

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -10350,18 +10350,32 @@ TEST_F(AlgebraicSimplifierTest, CompareIota) {
 }
 
 TEST_F(AlgebraicSimplifierTest, CompareAbsLtZeroBecomesFalse) {
-  // |x| < 0  ->  false
+  // Floating-point |x| < 0  ->  false.
   TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
 m {
-  p = s32[5] parameter(0)
-  a = s32[5] abs(p)
-  z = s32[] constant(0)
-  b = s32[5] broadcast(z)
+  p = f32[5] parameter(0)
+  a = f32[5] abs(p)
+  z = f32[] constant(0)
+  b = f32[5] broadcast(z)
   ROOT r = pred[5] compare(a, b), direction=LT
 })"));
   ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
   EXPECT_THAT(m->entry_computation()->root_instruction(),
               GmockMatch(m::Broadcast(m::ConstantScalar(false))));
+}
+
+TEST_F(AlgebraicSimplifierTest, DoesNotFoldSignedIntegerAbsLtZero) {
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+m {
+  p = s8[] parameter(0)
+  a = s8[] abs(p)
+  z = s8[] constant(0)
+  ROOT r = pred[] compare(a, z), direction=LT
+})"));
+  ASSERT_FALSE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+  EXPECT_THAT(m->entry_computation()->root_instruction(),
+              GmockMatch(m::Lt(m::Abs(m::Parameter(0)),
+                               m::ConstantEffectiveScalar(0))));
 }
 
 TEST_F(AlgebraicSimplifierTest, CompareLtZero) {

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -169,8 +169,7 @@ TEST_F(AlgebraicSimplifierTest, IsNonNegative_Op_NegativeTestCase) {
 
 TEST_F(AlgebraicSimplifierTest,
        IsNonNegativeSignedIntegerOverflowNegativeTestCase) {
-  for (const auto op : {"abs(p0)", "multiply(p0, p0)",
-                        "power(constant(10), constant(10))"}) {
+  for (const auto op : {"abs(p0)", "multiply(p0, p0)", "power(p0, p0)"}) {
     const auto kModuleStr = absl::StrFormat(R"(
       HloModule m
       test {
@@ -193,6 +192,17 @@ TEST_F(AlgebraicSimplifierTest, IsNonNegativeSignedIntegerIotaCanOverflow) {
     }
   )"));
   ASSERT_FALSE(AlgebraicSimplifierVisitor::IsNonNegative(
+      m->entry_computation()->root_instruction(), default_options_));
+}
+
+TEST_F(AlgebraicSimplifierTest, IsNonNegativeSignedIntegerIotaFitsRange) {
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+    HloModule m
+    ENTRY test {
+      ROOT iota = s8[128] iota(), iota_dimension=0
+    }
+  )"));
+  ASSERT_TRUE(AlgebraicSimplifierVisitor::IsNonNegative(
       m->entry_computation()->root_instruction(), default_options_));
 }
 

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -10351,7 +10351,7 @@ TEST_F(AlgebraicSimplifierTest, CompareIota) {
 
 TEST_F(AlgebraicSimplifierTest, CompareAbsLtZeroBecomesFalse) {
   // Floating-point |x| < 0  ->  false.
-  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
 m {
   p = f32[5] parameter(0)
   a = f32[5] abs(p)

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -167,6 +167,23 @@ TEST_F(AlgebraicSimplifierTest, IsNonNegative_Op_NegativeTestCase) {
   }
 }
 
+TEST_F(AlgebraicSimplifierTest,
+       IsNonNegativeSignedIntegerOverflowNegativeTestCase) {
+  for (const auto op : {"abs(p0)", "multiply(p0, p0)"}) {
+    const auto kModuleStr = absl::StrFormat(R"(
+      HloModule m
+      test {
+        p0 = s8[] parameter(0)
+        ROOT y = s8[] %s
+      }
+    )",
+                                            op);
+    TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(kModuleStr));
+    ASSERT_FALSE(AlgebraicSimplifierVisitor::IsNonNegative(
+        m->entry_computation()->root_instruction(), default_options_));
+  }
+}
+
 // Test that the result of Broadcast is non-negative if its operand is
 // non-negative
 TEST_F(AlgebraicSimplifierTest, IsNonNegative_Broadcast) {
@@ -12079,6 +12096,30 @@ TEST_F(AlgebraicSimplifierTest, AbsEliminationIota) {
   ASSERT_TRUE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
   EXPECT_THAT(m->entry_computation()->root_instruction(),
               GmockMatch(m::Iota()));
+}
+
+TEST_F(AlgebraicSimplifierTest, DoesNotFoldSignedIntegerSquareAbsSelect) {
+  TF_ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+    HloModule m
+    ENTRY test {
+      p0 = s8[4]{0} parameter(0)
+      mul = s8[4]{0} multiply(p0, p0)
+      zero = s8[] constant(0)
+      bcast = s8[4]{0} broadcast(zero), dimensions={}
+      cmp = pred[4]{0} compare(mul, bcast), direction=LT
+      abs = s8[4]{0} abs(mul)
+      ROOT select = s8[4]{0} select(cmp, abs, mul)
+    }
+  )"));
+  ASSERT_FALSE(AlgebraicSimplifier(default_options_).Run(m.get()).value());
+
+  HloInstruction* root = m->entry_computation()->root_instruction();
+  EXPECT_EQ(root->opcode(), HloOpcode::kSelect);
+  EXPECT_EQ(root->operand(0)->opcode(), HloOpcode::kCompare);
+  EXPECT_EQ(root->operand(1)->opcode(), HloOpcode::kAbs);
+  EXPECT_EQ(root->operand(2)->opcode(), HloOpcode::kMultiply);
+  EXPECT_EQ(root->operand(0)->operand(0), root->operand(2));
+  EXPECT_EQ(root->operand(1)->operand(0), root->operand(2));
 }
 
 TEST_F(AlgebraicSimplifierTest, SimplifyRedundantBitcastConvert) {

--- a/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
+++ b/third_party/xla/xla/hlo/transforms/simplifiers/algebraic_simplifier_test.cc
@@ -206,6 +206,19 @@ TEST_F(AlgebraicSimplifierTest, IsNonNegativeSignedIntegerIotaFitsRange) {
       m->entry_computation()->root_instruction(), default_options_));
 }
 
+TEST_F(AlgebraicSimplifierTest,
+       IsNonNegativeSignedIntegerAbsOfNonNegativeOperand) {
+  ASSERT_OK_AND_ASSIGN(auto m, ParseAndReturnVerifiedModule(R"(
+    HloModule m
+    ENTRY test {
+      iota = s8[128] iota(), iota_dimension=0
+      ROOT abs = s8[128] abs(iota)
+    }
+  )"));
+  ASSERT_TRUE(AlgebraicSimplifierVisitor::IsNonNegative(
+      m->entry_computation()->root_instruction(), default_options_));
+}
+
 // Test that the result of Broadcast is non-negative if its operand is
 // non-negative
 TEST_F(AlgebraicSimplifierTest, IsNonNegative_Broadcast) {


### PR DESCRIPTION
Fixes #118178.

This fixes an incorrect `AlgebraicSimplifier::IsNonNegative` inference for signed integer HLO. Signed integer `x * x` and `abs(x)` are not guaranteed to be non-negative because overflow can produce or preserve a negative value, as in the `s8` case from the issue.

The change keeps the simplifier conservative for signed integer `multiply(x, x)` and `abs(x)`, and adds regression coverage for the `s8` `compare` / `abs` / `select` pattern.

Validation:
- `git diff --check`
- Not run: `bazel test //xla/hlo/transforms/simplifiers:algebraic_simplifier_test --test_filter='*SignedInteger*:*DoesNotFoldSignedIntegerSquareAbsSelect*'` because `bazel` / `bazelisk` is not installed in this local environment.