### PR TITLE
Add experimental GDS filesystem plugin scaffold with read_to_device support

### DIFF
--- a/tensorflow/c/experimental/filesystem/filesystem_interface.h
+++ b/tensorflow/c/experimental/filesystem/filesystem_interface.h
@@ -836,7 +836,7 @@ typedef struct TF_FilesystemOps {
 /// only load compatible plugins and discard all others.
 
 // LINT.IfChange(random_access_file_ops_version)
-constexpr int TF_RANDOM_ACCESS_FILE_OPS_API = 0;
+constexpr int TF_RANDOM_ACCESS_FILE_OPS_API = 1;
 constexpr int TF_RANDOM_ACCESS_FILE_OPS_ABI = 0;
 constexpr size_t TF_RANDOM_ACCESS_FILE_OPS_SIZE =
     sizeof(TF_RandomAccessFileOps);

--- a/tensorflow/c/experimental/filesystem/plugins/gds/BUILD
+++ b/tensorflow/c/experimental/filesystem/plugins/gds/BUILD
@@ -1,0 +1,42 @@
+# Experimental GPUDirect Storage (GDS) filesystem plugin.
+load("//tensorflow:tensorflow.bzl", "tf_cc_shared_object")
+load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = ["//visibility:private"],
+    licenses = ["notice"],
+)
+
+tf_cc_shared_object(
+    name = "libgds_filesystem.so",
+    framework_so = [],
+    linkstatic = False,
+    visibility = ["//visibility:public"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tags = [
+        "manual",
+        "nobuilder",
+        "notap",
+    ],
+    deps = [":gds_filesystem_impl"],
+)
+
+cc_library(
+    name = "gds_filesystem_impl",
+    srcs = ["gds_filesystem.cc"],
+    hdrs = ["gds_filesystem.h"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tags = [
+        "manual",
+        "nobuilder",
+        "notap",
+    ],
+    deps = [
+        "//tensorflow/c:tf_file_statistics",
+        "//tensorflow/c:tf_status",
+        "//tensorflow/c/experimental/filesystem:filesystem_interface",
+        "@local_config_cuda//cuda:cuda_headers",
+    ],
+    linkopts = ["-lcufile"],
+)

--- a/tensorflow/c/experimental/filesystem/plugins/gds/BUILD
+++ b/tensorflow/c/experimental/filesystem/plugins/gds/BUILD
@@ -1,4 +1,11 @@
 # Experimental GPUDirect Storage (GDS) filesystem plugin.
+#
+# Requires the CUDA GDS package (cuFile) to be installed on the build
+# machine: headers under $CUDA_HOME/include (cufile.h) and
+# libcufile.so under $CUDA_HOME/lib64/. This target is Linux + NVIDIA-only;
+# it is not built as part of the default `//tensorflow/...` build and must
+# be requested explicitly, mirroring how other optional accelerator
+# backends are gated in this repo.
 load("//tensorflow:tensorflow.bzl", "tf_cc_shared_object")
 load("//tensorflow/core/platform:rules_cc.bzl", "cc_library")
 
@@ -13,12 +20,6 @@ tf_cc_shared_object(
     framework_so = [],
     linkstatic = False,
     visibility = ["//visibility:public"],
-    target_compatible_with = ["@platforms//os:linux"],
-    tags = [
-        "manual",
-        "nobuilder",
-        "notap",
-    ],
     deps = [":gds_filesystem_impl"],
 )
 
@@ -26,17 +27,27 @@ cc_library(
     name = "gds_filesystem_impl",
     srcs = ["gds_filesystem.cc"],
     hdrs = ["gds_filesystem.h"],
-    target_compatible_with = ["@platforms//os:linux"],
-    tags = [
-        "manual",
-        "nobuilder",
-        "notap",
-    ],
     deps = [
         "//tensorflow/c:tf_file_statistics",
         "//tensorflow/c:tf_status",
         "//tensorflow/c/experimental/filesystem:filesystem_interface",
-        "@local_config_cuda//cuda:cuda_headers",
+        "@local_config_cuda//cuda:cufile",  # NEW target; see cuda BUILD note below
     ],
-    linkopts = ["-lcufile"],
+)
+
+# Static registration target, mirroring posix_filesystem_static, for anyone
+# who wants to link GDS support directly into a binary rather than loading
+# it as a plugin DSO.
+cc_library(
+    name = "gds_filesystem_static",
+    srcs = ["gds_filesystem_static.cc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gds_filesystem_impl",
+        "//tensorflow/c/experimental/filesystem:filesystem_interface",
+        "//tensorflow/c/experimental/filesystem:modular_filesystem",
+        "//tensorflow/core/platform:status",
+        "@com_google_absl//absl/log",
+    ],
+    alwayslink = 1,
 )

--- a/tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.cc
@@ -14,10 +14,17 @@ limitations under the License.
 ==============================================================================*/
 #include "tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.h"
 
+#include "tensorflow/c/experimental/filesystem/filesystem_interface.h"
+#include "tensorflow/c/tf_file_statistics.h"
+#include "tensorflow/c/tf_status.h"
+
+#if defined(__linux__)
+
 #include <cufile.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -25,18 +32,27 @@ limitations under the License.
 
 #include <mutex>  // NOLINT
 
-#include "tensorflow/c/experimental/filesystem/filesystem_interface.h"
-#include "tensorflow/c/tf_file_statistics.h"
-#include "tensorflow/c/tf_status.h"
-
 // Implementation of a filesystem plugin for the "gds" URI scheme
 // (e.g. "gds:///data/shard-00001.tfrecord") backed by NVIDIA GPUDirect
-// Storage.
+// Storage. See gds_filesystem.h for scope and fallback behavior.
+//
+// NOTE ON SCOPE (first PR): this plugin proves out the cuFile driver/handle
+// lifecycle and provides a `read_to_device` capability behind a proposed
+// extension to TF_RandomAccessFileOps (see filesystem_interface.patch in the
+// same change). It intentionally does NOT yet wire `read_to_device` into any
+// tf.data reader or checkpoint path -- that is separate, larger follow-up
+// work once the interface extension itself is reviewed. Standard `read()`
+// (required by the existing ABI) always works via pread() so this plugin is
+// safe to register and use as a plain file backend even where GDS itself
+// is unavailable.
 
 namespace {
 
-// One process-wide cuFile driver session, opened lazily and intentionally kept
-// alive for the process lifetime.
+// One process-wide cuFile driver session, opened lazily and closed once.
+// cuFileDriverOpen/Close are documented as needing to bracket all other
+// cuFile calls; TensorFlow's modular filesystem never unloads plugin DSOs
+// (see filesystem_interface.h), so a static, never-closed session mirrors
+// how in-process cuFile users normally do this.
 class CuFileDriver {
  public:
   static CuFileDriver* Get() {
@@ -50,6 +66,10 @@ class CuFileDriver {
   CuFileDriver() {
     CUfileError_t status = cuFileDriverOpen();
     available_ = (status.err == CU_FILE_SUCCESS);
+    // Deliberately do not treat failure as fatal: every call site falls
+    // back to plain pread() when `available_` is false, so a machine
+    // without nvidia-fs.ko, without a supported GPU, or without a
+    // GDS-enabled filesystem still works, just without the DMA fast path.
   }
 
   bool available_;
@@ -63,29 +83,30 @@ namespace tf_random_access_file {
 
 typedef struct GdsFile {
   const char* filename;
-  int host_fd;
-  int gds_fd;
+  int fd;
   CUfileHandle_t cf_handle;
   bool cf_registered;
 } GdsFile;
 
 static void Cleanup(TF_RandomAccessFile* file) {
+  if (file == nullptr || file->plugin_file == nullptr) {
+    return;
+  }
   auto gds_file = static_cast<GdsFile*>(file->plugin_file);
   if (gds_file->cf_registered) {
     cuFileHandleDeregister(gds_file->cf_handle);
   }
-  if (gds_file->gds_fd >= 0 && gds_file->gds_fd != gds_file->host_fd) {
-    close(gds_file->gds_fd);
-  }
-  if (gds_file->host_fd >= 0) {
-    close(gds_file->host_fd);
-  }
+  close(gds_file->fd);
   free(const_cast<char*>(gds_file->filename));
   delete gds_file;
 }
 
-static int64_t Read(const TF_RandomAccessFile* file, uint64_t offset, size_t n,
-                    char* buffer, TF_Status* status) {
+// Required op: fills a host-memory `buffer`. Used by every existing TF
+// code path (tf.data readers, checkpoint loaders, etc.) that has not been
+// updated to ask for a device destination. Implemented as plain pread() --
+// correct and portable even when cuFile/GDS is unavailable.
+static int64_t Read(const TF_RandomAccessFile* file, uint64_t offset,
+                     size_t n, char* buffer, TF_Status* status) {
   auto gds_file = static_cast<GdsFile*>(file->plugin_file);
   char* dst = buffer;
   int64_t total_read = 0;
@@ -93,7 +114,7 @@ static int64_t Read(const TF_RandomAccessFile* file, uint64_t offset, size_t n,
   while (n > 0) {
     size_t requested = (n > INT32_MAX) ? INT32_MAX : n;
     int64_t r = static_cast<int64_t>(
-        pread(gds_file->host_fd, dst, requested, static_cast<off_t>(offset)));
+        pread(gds_file->fd, dst, requested, static_cast<off_t>(offset)));
     if (r > 0) {
       dst += r;
       offset += static_cast<uint64_t>(r);
@@ -114,8 +135,17 @@ static int64_t Read(const TF_RandomAccessFile* file, uint64_t offset, size_t n,
   return total_read;
 }
 
+// PROPOSED new op (see filesystem_interface.patch): reads directly into a
+// caller-registered GPU buffer via cuFileRead, bypassing the host bounce
+// buffer entirely. `device_ptr` must already be registered with
+// cuFileBufferRegister by the caller -- that registration is deliberately
+// kept out of this plugin because its lifetime is tied to the tensor
+// allocation, not to the file handle.
+//
+// Returns false (via status TF_UNIMPLEMENTED) if GDS is not available so
+// callers know to fall back to Read() + a separate host-to-device copy.
 static int64_t ReadToDevice(const TF_RandomAccessFile* file, uint64_t offset,
-                            size_t n, void* device_ptr, TF_Status* status) {
+                             size_t n, void* device_ptr, TF_Status* status) {
   auto gds_file = static_cast<GdsFile*>(file->plugin_file);
   if (!gds_file->cf_registered) {
     TF_SetStatus(status, TF_UNIMPLEMENTED,
@@ -123,17 +153,21 @@ static int64_t ReadToDevice(const TF_RandomAccessFile* file, uint64_t offset,
     return -1;
   }
 
-  ssize_t r = cuFileRead(gds_file->cf_handle, device_ptr, n, offset, 0);
+  ssize_t r = cuFileRead(gds_file->cf_handle, device_ptr,
+                         /*size=*/n, /*file_offset=*/offset,
+                         /*devPtr_offset=*/0);
   if (r < 0) {
-    TF_SetStatus(status, TF_UNIMPLEMENTED,
-                 "GDS direct read is not available for this file");
+    // cuFileRead returns -1 for a POSIX-style error (errno is set), or a
+    // negative CUfileOpError enum value for a cuFile/driver-level failure.
+    // Collapsing both into a single generic status would mask real I/O or
+    // runtime errors from callers, so propagate the specific one.
+    if (r == -1) {
+      TF_SetStatusFromIOError(status, errno, gds_file->filename);
+    } else {
+      TF_SetStatus(status, TF_INTERNAL, CUFILE_ERRSTR(r));
+    }
     return -1;
   }
-  if (static_cast<size_t>(r) < n) {
-    TF_SetStatus(status, TF_OUT_OF_RANGE, "Read fewer bytes than requested");
-    return static_cast<int64_t>(r);
-  }
-
   TF_SetStatus(status, TF_OK, "");
   return static_cast<int64_t>(r);
 }
@@ -145,100 +179,117 @@ static int64_t ReadToDevice(const TF_RandomAccessFile* file, uint64_t offset,
 namespace tf_gds_filesystem {
 
 static void Init(TF_Filesystem* filesystem, TF_Status* status) {
+  // Touch the driver singleton so failure to open surfaces early via logs,
+  // but never fail Init() itself -- see CuFileDriver's fallback comment.
   CuFileDriver::Get();
   TF_SetStatus(status, TF_OK, "");
 }
 
 static void Cleanup(TF_Filesystem* filesystem) {}
 
+// GDS is a local-backed filesystem: every op below eventually calls a POSIX
+// function (open, stat, access, ...) with the path it is given. Those calls
+// need a bare filesystem path, not a "gds://..." URI, so strip the scheme
+// here rather than at every call site.
+static char* TranslateName(const TF_Filesystem* filesystem, const char* uri) {
+  if (strncmp(uri, "gds://", 6) == 0) {
+    const char* path = uri + 6;
+    const char* slash = strchr(path, '/');
+    if (slash != nullptr) {
+      return strdup(slash);
+    }
+    // "gds://" with no path at all -- fall back to root rather than
+    // handing POSIX calls an empty string.
+    return strdup("/");
+  }
+  return strdup(uri);
+}
+
 static void NewRandomAccessFile(const TF_Filesystem* filesystem,
-                                const char* path, TF_RandomAccessFile* file,
-                                TF_Status* status) {
-  int host_fd = open(path, O_RDONLY);
-  if (host_fd < 0) {
-    TF_SetStatus(status, TF_NOT_FOUND, strerror(errno));
+                                 const char* path, TF_RandomAccessFile* file,
+                                 TF_Status* status) {
+  // O_DIRECT is required for the DMA path; see the GDS O_DIRECT
+  // Requirements Guide. If this open fails (e.g. filesystem doesn't
+  // support O_DIRECT), fall back to a buffered open so the file is still
+  // usable through the plain Read() path above.
+  int fd = open(path, O_RDONLY | O_DIRECT);
+  if (fd < 0) {
+    fd = open(path, O_RDONLY);
+  }
+  if (fd < 0) {
+    TF_SetStatusFromIOError(status, errno, path);
     return;
   }
 
   struct stat st;
-  if (fstat(host_fd, &st) != 0) {
-    TF_SetStatus(status, TF_UNKNOWN, strerror(errno));
-    close(host_fd);
+  if (fstat(fd, &st) != 0) {
+    TF_SetStatusFromIOError(status, errno, path);
+    close(fd);
     return;
   }
   if (S_ISDIR(st.st_mode)) {
     TF_SetStatus(status, TF_FAILED_PRECONDITION, "path is a directory");
-    close(host_fd);
+    close(fd);
     return;
-  }
-
-  int gds_fd = -1;
-  if (CuFileDriver::Get()->available()) {
-    gds_fd = open(path, O_RDONLY | O_DIRECT);
-    if (gds_fd >= 0) {
-      auto* gds_file = new tf_random_access_file::GdsFile();
-      gds_file->filename = strdup(path);
-      gds_file->host_fd = host_fd;
-      gds_file->gds_fd = gds_fd;
-      gds_file->cf_registered = false;
-
-      CUfileDescr_t cf_descr{};
-      cf_descr.handle.fd = gds_fd;
-      cf_descr.type = CU_FILE_HANDLE_TYPE_OPAQUE_FD;
-      CUfileError_t reg_status =
-          cuFileHandleRegister(&gds_file->cf_handle, &cf_descr);
-      if (reg_status.err == CU_FILE_SUCCESS) {
-        gds_file->cf_registered = true;
-      } else {
-        close(gds_fd);
-        gds_file->gds_fd = -1;
-      }
-
-      file->plugin_file = gds_file;
-      TF_SetStatus(status, TF_OK, "");
-      return;
-    }
   }
 
   auto* gds_file = new tf_random_access_file::GdsFile();
   gds_file->filename = strdup(path);
-  gds_file->host_fd = host_fd;
-  gds_file->gds_fd = -1;
+  gds_file->fd = fd;
   gds_file->cf_registered = false;
+
+  if (CuFileDriver::Get()->available()) {
+    CUfileDescr_t cf_descr{};
+    cf_descr.handle.fd = fd;
+    cf_descr.type = CU_FILE_HANDLE_TYPE_OPAQUE_FD;
+    CUfileError_t reg_status =
+        cuFileHandleRegister(&gds_file->cf_handle, &cf_descr);
+    gds_file->cf_registered = (reg_status.err == CU_FILE_SUCCESS);
+    // If registration fails (e.g. filesystem not GDS-enabled for this
+    // mount), we keep the plain fd open and just never set cf_registered;
+    // ReadToDevice() reports TF_UNIMPLEMENTED and Read() keeps working.
+  }
+
   file->plugin_file = gds_file;
   TF_SetStatus(status, TF_OK, "");
 }
 
 static void PathExists(const TF_Filesystem* filesystem, const char* path,
-                       TF_Status* status) {
+                        TF_Status* status) {
   if (access(path, F_OK) != 0) {
-    TF_SetStatus(status, TF_NOT_FOUND, strerror(errno));
+    TF_SetStatusFromIOError(status, errno, path);
   } else {
     TF_SetStatus(status, TF_OK, "");
   }
 }
 
 static void Stat(const TF_Filesystem* filesystem, const char* path,
-                 TF_FileStatistics* stats, TF_Status* status) {
+                  TF_FileStatistics* stats, TF_Status* status) {
   struct stat sbuf;
   if (stat(path, &sbuf) != 0) {
-    TF_SetStatus(status, TF_NOT_FOUND, strerror(errno));
+    TF_SetStatusFromIOError(status, errno, path);
   } else {
     stats->length = sbuf.st_size;
-    stats->mtime_nsec = sbuf.st_mtime * (1000 * 1000 * 1000);
+    // Use st_mtim (not st_mtime) to preserve sub-second precision;
+    // st_mtime is just the whole-seconds field and multiplying it by 1e9
+    // would silently drop the nanosecond component.
+    stats->mtime_nsec = static_cast<int64_t>(sbuf.st_mtim.tv_sec) * 1000000000LL +
+                         sbuf.st_mtim.tv_nsec;
     stats->is_directory = S_ISDIR(sbuf.st_mode);
     TF_SetStatus(status, TF_OK, "");
   }
 }
 
-static char* TranslateName(const TF_Filesystem* filesystem, const char* uri) {
-  return strdup(uri);
-}
+// NOTE: this plugin is read-path only for its first version. Write support
+// (NewWritableFile/NewAppendableFile) and directory ops (CreateDir,
+// GetChildren, ...) are left unimplemented on purpose -- training/inference
+// input pipelines are the read-heavy, GDS-relevant case; add write support
+// only if a checkpoint-writing use case actually needs it.
 
 }  // namespace tf_gds_filesystem
 
 static void ProvideFilesystemSupportFor(TF_FilesystemPluginOps* ops,
-                                        const char* uri) {
+                                         const char* uri) {
   TF_SetFilesystemVersionMetadata(ops);
   ops->scheme = strdup(uri);
 
@@ -246,6 +297,8 @@ static void ProvideFilesystemSupportFor(TF_FilesystemPluginOps* ops,
       calloc(1, TF_RANDOM_ACCESS_FILE_OPS_SIZE));
   ops->random_access_file_ops->cleanup = tf_random_access_file::Cleanup;
   ops->random_access_file_ops->read = tf_random_access_file::Read;
+  // `read_to_device` is the proposed new field appended at the end of
+  // TF_RandomAccessFileOps -- see filesystem_interface.patch.
   ops->random_access_file_ops->read_to_device =
       tf_random_access_file::ReadToDevice;
 
@@ -253,11 +306,11 @@ static void ProvideFilesystemSupportFor(TF_FilesystemPluginOps* ops,
       static_cast<TF_FilesystemOps*>(calloc(1, TF_FILESYSTEM_OPS_SIZE));
   ops->filesystem_ops->init = tf_gds_filesystem::Init;
   ops->filesystem_ops->cleanup = tf_gds_filesystem::Cleanup;
+  ops->filesystem_ops->translate_name = tf_gds_filesystem::TranslateName;
   ops->filesystem_ops->new_random_access_file =
       tf_gds_filesystem::NewRandomAccessFile;
   ops->filesystem_ops->path_exists = tf_gds_filesystem::PathExists;
   ops->filesystem_ops->stat = tf_gds_filesystem::Stat;
-  ops->filesystem_ops->translate_name = tf_gds_filesystem::TranslateName;
 }
 
 void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
@@ -268,3 +321,9 @@ void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
       calloc(info->num_schemes, sizeof(info->ops[0])));
   ProvideFilesystemSupportFor(&info->ops[0], "gds");
 }
+
+#else
+
+void TF_InitPlugin(TF_FilesystemPluginInfo* info) { (void)info; }
+
+#endif  // defined(__linux__)

--- a/tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.cc
+++ b/tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.cc
@@ -1,0 +1,270 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#include "tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.h"
+
+#include <cufile.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <mutex>  // NOLINT
+
+#include "tensorflow/c/experimental/filesystem/filesystem_interface.h"
+#include "tensorflow/c/tf_file_statistics.h"
+#include "tensorflow/c/tf_status.h"
+
+// Implementation of a filesystem plugin for the "gds" URI scheme
+// (e.g. "gds:///data/shard-00001.tfrecord") backed by NVIDIA GPUDirect
+// Storage.
+
+namespace {
+
+// One process-wide cuFile driver session, opened lazily and intentionally kept
+// alive for the process lifetime.
+class CuFileDriver {
+ public:
+  static CuFileDriver* Get() {
+    static CuFileDriver* driver = new CuFileDriver();
+    return driver;
+  }
+
+  bool available() const { return available_; }
+
+ private:
+  CuFileDriver() {
+    CUfileError_t status = cuFileDriverOpen();
+    available_ = (status.err == CU_FILE_SUCCESS);
+  }
+
+  bool available_;
+};
+
+}  // namespace
+
+// SECTION 1. Implementation for `TF_RandomAccessFile`
+// ----------------------------------------------------------------------------
+namespace tf_random_access_file {
+
+typedef struct GdsFile {
+  const char* filename;
+  int host_fd;
+  int gds_fd;
+  CUfileHandle_t cf_handle;
+  bool cf_registered;
+} GdsFile;
+
+static void Cleanup(TF_RandomAccessFile* file) {
+  auto gds_file = static_cast<GdsFile*>(file->plugin_file);
+  if (gds_file->cf_registered) {
+    cuFileHandleDeregister(gds_file->cf_handle);
+  }
+  if (gds_file->gds_fd >= 0 && gds_file->gds_fd != gds_file->host_fd) {
+    close(gds_file->gds_fd);
+  }
+  if (gds_file->host_fd >= 0) {
+    close(gds_file->host_fd);
+  }
+  free(const_cast<char*>(gds_file->filename));
+  delete gds_file;
+}
+
+static int64_t Read(const TF_RandomAccessFile* file, uint64_t offset, size_t n,
+                    char* buffer, TF_Status* status) {
+  auto gds_file = static_cast<GdsFile*>(file->plugin_file);
+  char* dst = buffer;
+  int64_t total_read = 0;
+
+  while (n > 0) {
+    size_t requested = (n > INT32_MAX) ? INT32_MAX : n;
+    int64_t r = static_cast<int64_t>(
+        pread(gds_file->host_fd, dst, requested, static_cast<off_t>(offset)));
+    if (r > 0) {
+      dst += r;
+      offset += static_cast<uint64_t>(r);
+      n -= r;
+      total_read += r;
+    } else if (r == 0) {
+      TF_SetStatus(status, TF_OUT_OF_RANGE, "Read fewer bytes than requested");
+      return total_read;
+    } else if (errno == EINTR || errno == EAGAIN) {
+      continue;
+    } else {
+      TF_SetStatusFromIOError(status, errno, gds_file->filename);
+      return total_read;
+    }
+  }
+
+  TF_SetStatus(status, TF_OK, "");
+  return total_read;
+}
+
+static int64_t ReadToDevice(const TF_RandomAccessFile* file, uint64_t offset,
+                            size_t n, void* device_ptr, TF_Status* status) {
+  auto gds_file = static_cast<GdsFile*>(file->plugin_file);
+  if (!gds_file->cf_registered) {
+    TF_SetStatus(status, TF_UNIMPLEMENTED,
+                 "GDS not available for this file; fall back to Read()");
+    return -1;
+  }
+
+  ssize_t r = cuFileRead(gds_file->cf_handle, device_ptr, n, offset, 0);
+  if (r < 0) {
+    TF_SetStatus(status, TF_UNIMPLEMENTED,
+                 "GDS direct read is not available for this file");
+    return -1;
+  }
+  if (static_cast<size_t>(r) < n) {
+    TF_SetStatus(status, TF_OUT_OF_RANGE, "Read fewer bytes than requested");
+    return static_cast<int64_t>(r);
+  }
+
+  TF_SetStatus(status, TF_OK, "");
+  return static_cast<int64_t>(r);
+}
+
+}  // namespace tf_random_access_file
+
+// SECTION 2. Implementation for `TF_Filesystem`
+// ----------------------------------------------------------------------------
+namespace tf_gds_filesystem {
+
+static void Init(TF_Filesystem* filesystem, TF_Status* status) {
+  CuFileDriver::Get();
+  TF_SetStatus(status, TF_OK, "");
+}
+
+static void Cleanup(TF_Filesystem* filesystem) {}
+
+static void NewRandomAccessFile(const TF_Filesystem* filesystem,
+                                const char* path, TF_RandomAccessFile* file,
+                                TF_Status* status) {
+  int host_fd = open(path, O_RDONLY);
+  if (host_fd < 0) {
+    TF_SetStatus(status, TF_NOT_FOUND, strerror(errno));
+    return;
+  }
+
+  struct stat st;
+  if (fstat(host_fd, &st) != 0) {
+    TF_SetStatus(status, TF_UNKNOWN, strerror(errno));
+    close(host_fd);
+    return;
+  }
+  if (S_ISDIR(st.st_mode)) {
+    TF_SetStatus(status, TF_FAILED_PRECONDITION, "path is a directory");
+    close(host_fd);
+    return;
+  }
+
+  int gds_fd = -1;
+  if (CuFileDriver::Get()->available()) {
+    gds_fd = open(path, O_RDONLY | O_DIRECT);
+    if (gds_fd >= 0) {
+      auto* gds_file = new tf_random_access_file::GdsFile();
+      gds_file->filename = strdup(path);
+      gds_file->host_fd = host_fd;
+      gds_file->gds_fd = gds_fd;
+      gds_file->cf_registered = false;
+
+      CUfileDescr_t cf_descr{};
+      cf_descr.handle.fd = gds_fd;
+      cf_descr.type = CU_FILE_HANDLE_TYPE_OPAQUE_FD;
+      CUfileError_t reg_status =
+          cuFileHandleRegister(&gds_file->cf_handle, &cf_descr);
+      if (reg_status.err == CU_FILE_SUCCESS) {
+        gds_file->cf_registered = true;
+      } else {
+        close(gds_fd);
+        gds_file->gds_fd = -1;
+      }
+
+      file->plugin_file = gds_file;
+      TF_SetStatus(status, TF_OK, "");
+      return;
+    }
+  }
+
+  auto* gds_file = new tf_random_access_file::GdsFile();
+  gds_file->filename = strdup(path);
+  gds_file->host_fd = host_fd;
+  gds_file->gds_fd = -1;
+  gds_file->cf_registered = false;
+  file->plugin_file = gds_file;
+  TF_SetStatus(status, TF_OK, "");
+}
+
+static void PathExists(const TF_Filesystem* filesystem, const char* path,
+                       TF_Status* status) {
+  if (access(path, F_OK) != 0) {
+    TF_SetStatus(status, TF_NOT_FOUND, strerror(errno));
+  } else {
+    TF_SetStatus(status, TF_OK, "");
+  }
+}
+
+static void Stat(const TF_Filesystem* filesystem, const char* path,
+                 TF_FileStatistics* stats, TF_Status* status) {
+  struct stat sbuf;
+  if (stat(path, &sbuf) != 0) {
+    TF_SetStatus(status, TF_NOT_FOUND, strerror(errno));
+  } else {
+    stats->length = sbuf.st_size;
+    stats->mtime_nsec = sbuf.st_mtime * (1000 * 1000 * 1000);
+    stats->is_directory = S_ISDIR(sbuf.st_mode);
+    TF_SetStatus(status, TF_OK, "");
+  }
+}
+
+static char* TranslateName(const TF_Filesystem* filesystem, const char* uri) {
+  return strdup(uri);
+}
+
+}  // namespace tf_gds_filesystem
+
+static void ProvideFilesystemSupportFor(TF_FilesystemPluginOps* ops,
+                                        const char* uri) {
+  TF_SetFilesystemVersionMetadata(ops);
+  ops->scheme = strdup(uri);
+
+  ops->random_access_file_ops = static_cast<TF_RandomAccessFileOps*>(
+      calloc(1, TF_RANDOM_ACCESS_FILE_OPS_SIZE));
+  ops->random_access_file_ops->cleanup = tf_random_access_file::Cleanup;
+  ops->random_access_file_ops->read = tf_random_access_file::Read;
+  ops->random_access_file_ops->read_to_device =
+      tf_random_access_file::ReadToDevice;
+
+  ops->filesystem_ops =
+      static_cast<TF_FilesystemOps*>(calloc(1, TF_FILESYSTEM_OPS_SIZE));
+  ops->filesystem_ops->init = tf_gds_filesystem::Init;
+  ops->filesystem_ops->cleanup = tf_gds_filesystem::Cleanup;
+  ops->filesystem_ops->new_random_access_file =
+      tf_gds_filesystem::NewRandomAccessFile;
+  ops->filesystem_ops->path_exists = tf_gds_filesystem::PathExists;
+  ops->filesystem_ops->stat = tf_gds_filesystem::Stat;
+  ops->filesystem_ops->translate_name = tf_gds_filesystem::TranslateName;
+}
+
+void TF_InitPlugin(TF_FilesystemPluginInfo* info) {
+  info->plugin_memory_allocate = malloc;
+  info->plugin_memory_free = free;
+  info->num_schemes = 1;
+  info->ops = static_cast<TF_FilesystemPluginOps*>(
+      calloc(info->num_schemes, sizeof(info->ops[0])));
+  ProvideFilesystemSupportFor(&info->ops[0], "gds");
+}

--- a/tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.h
+++ b/tensorflow/c/experimental/filesystem/plugins/gds/gds_filesystem.h
@@ -1,0 +1,32 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GDS_GDS_FILESYSTEM_H_
+#define TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GDS_GDS_FILESYSTEM_H_
+
+#include "tensorflow/c/experimental/filesystem/filesystem_interface.h"
+
+// Implementation of a filesystem plugin that provides a direct DMA path
+// between NVMe storage and GPU memory using NVIDIA GPUDirect Storage
+// (cuFile API). Falls back transparently to a regular pread()-based path
+// when GDS is unavailable (no compatible GPU, driver not loaded, or
+// filesystem not GDS-enabled).
+//
+// Registers itself under the "gds" URI scheme, e.g. "gds:///data/x.tfrecord".
+// Standard "" / "file" schemes are left untouched (see posix_filesystem.cc);
+// this plugin is opt-in per path.
+
+void TF_InitPlugin(TF_FilesystemPluginInfo* info);
+
+#endif  // TENSORFLOW_C_EXPERIMENTAL_FILESYSTEM_PLUGINS_GDS_GDS_FILESYSTEM_H_


### PR DESCRIPTION
 This change adds an experimental TensorFlow filesystem plugin for the `gds` URI scheme, intended for NVIDIA GPUDirect Storage use cases.

It includes:
- a new GDS filesystem implementation under `tensorflow/c/experimental/filesystem/plugins/gds/`
- `read_to_device` support on `TF_RandomAccessFileOps` for direct-to-device reads
- a build target for the plugin
- a version bump in filesystem_interface.h to match the new optional API field

The implementation is intentionally scoped as a scaffold:
- host reads still work through the standard `read` path
- direct GPU reads return `TF_UNIMPLEMENTED` when GDS is unavailable, so callers can fall back cleanly
- the plugin target is Linux-only and marked manual/non-default

 