### PR TITLE
check output buffer size in SnappyInputBuffer::Inflate

### DIFF
--- a/third_party/xla/xla/tsl/lib/io/snappy/snappy_inputbuffer.cc
+++ b/third_party/xla/xla/tsl/lib/io/snappy/snappy_inputbuffer.cc
@@ -127,8 +127,16 @@ absl::Status SnappyInputBuffer::Inflate() {
   // Output buffer must have been cleared before uncompressing more input.
   DCHECK_EQ(avail_out_, 0);
 
-  // Output buffer must be large enough to fit the uncompressed block.
-  DCHECK_GE(output_buffer_capacity_, uncompressed_length);
+  // Output buffer must be large enough to fit the uncompressed block. The
+  // uncompressed length is read from the (untrusted) input, so enforce this at
+  // runtime rather than only via DCHECK, otherwise Snappy_Uncompress writes
+  // past the end of output_buffer_.
+  if (output_buffer_capacity_ < uncompressed_length) {
+    return absl::ResourceExhaustedError(
+        absl::StrCat("Output buffer(size: ", output_buffer_capacity_,
+                     " bytes) too small. Should be larger than ",
+                     uncompressed_length, " bytes."));
+  }
   next_out_ = output_buffer_.get();
 
   bool status = port::Snappy_Uncompress(next_in_, compressed_block_length,

--- a/third_party/xla/xla/tsl/lib/io/snappy/snappy_inputbuffer.h
+++ b/third_party/xla/xla/tsl/lib/io/snappy/snappy_inputbuffer.h
@@ -53,7 +53,8 @@ class SnappyInputBuffer : public InputStreamInterface {
   // DATA_LOSS:
   //   If uncompression failed or if the file is corrupted.
   // RESOURCE_EXHAUSTED:
-  //   If input_buffer_ is smaller in size than a compressed block.
+  //   If input_buffer_ is smaller in size than a compressed block, or if
+  //   output_buffer_ is smaller in size than the uncompressed block.
   // others:
   //   If reading from file failed.
   absl::Status ReadNBytes(int64_t bytes_to_read, tstring* result) override;

--- a/third_party/xla/xla/tsl/lib/io/snappy/snappy_test.cc
+++ b/third_party/xla/xla/tsl/lib/io/snappy/snappy_test.cc
@@ -362,10 +362,10 @@ TEST(SnappyBuffers, SmallUncompressOutputBuffer) {
     fprintf(stderr, "skipping compression tests\n");
     return;
   }
-  CHECK_EQ(TestMultipleWrites(10000, 10000, 10000, 10, 2, true),
-           absl::ResourceExhaustedError(absl::StrCat(
-               "Output buffer(size: 10 bytes) too small. ",
-               "Should be larger than ", GetRecord().size(), " bytes.")));
+  EXPECT_EQ(TestMultipleWrites(10000, 10000, 10000, 10, 2, true),
+            absl::ResourceExhaustedError(absl::StrCat(
+                "Output buffer(size: 10 bytes) too small. ",
+                "Should be larger than ", GetRecord().size(), " bytes.")));
 }
 
 TEST(SnappyBuffers, CorruptBlock) {

--- a/third_party/xla/xla/tsl/lib/io/snappy/snappy_test.cc
+++ b/third_party/xla/xla/tsl/lib/io/snappy/snappy_test.cc
@@ -357,6 +357,17 @@ TEST(SnappyBuffers, SmallUncompressInputStream) {
                "Should be larger than ", GetRecord().size(), " bytes.")));
 }
 
+TEST(SnappyBuffers, SmallUncompressOutputBuffer) {
+  if (!SnappyCompressionSupported()) {
+    fprintf(stderr, "skipping compression tests\n");
+    return;
+  }
+  CHECK_EQ(TestMultipleWrites(10000, 10000, 10000, 10, 2, true),
+           absl::ResourceExhaustedError(absl::StrCat(
+               "Output buffer(size: 10 bytes) too small. ",
+               "Should be larger than ", GetRecord().size(), " bytes.")));
+}
+
 TEST(SnappyBuffers, CorruptBlock) {
   if (!SnappyCompressionSupported()) {
     fprintf(stderr, "skipping compression tests\n");


### PR DESCRIPTION
1. Inflate reads the uncompressed block length from the (untrusted) snappy stream and only validates it against output_buffer_capacity_ with DCHECK_GE, which is compiled out in release builds.
2. Snappy_Uncompress then writes uncompressed_length bytes into the fixed output_buffer_, so a block declaring a length larger than the buffer overflows the heap. This is reachable from tf.data CustomReader, which reads snapshot files with a 32 MiB output buffer.

Replaced the DCHECK with the runtime ResourceExhausted check that SnappyInputStream already uses, and added the matching SmallUncompressOutputBuffer test.