### PR TITLE
Fix tf.linalg.det gradient crash on singular matrices

### DIFF
--- a/tensorflow/python/kernel_tests/linalg/linalg_grad_test.py
+++ b/tensorflow/python/kernel_tests/linalg/linalg_grad_test.py
@@ -16,9 +16,11 @@
 
 import numpy as np
 
+from tensorflow.python.eager import backprop
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import test_util
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import gen_linalg_ops
 from tensorflow.python.ops import gradient_checker_v2
 from tensorflow.python.ops import gradients_impl
 from tensorflow.python.ops import linalg_ops
@@ -177,6 +179,162 @@ def _GetBandedTriangularSolveGradientTest(
     self.assertAllClose(theoretical, numerical, atol=tol, rtol=tol)
 
   return Test
+
+
+class DetGradSingularMatrixTest(test_lib.TestCase):
+  """Gradients of det and slogdet remain defined for singular matrices.
+
+  The holomorphic derivative of det(A) is the cofactor matrix, so the
+  reverse-mode gradient is its elementwise conjugate, conj(det(A)) * A^{-H}
+  for invertible A. For real A this is the transpose of the classical
+  adjugate, which extends continuously to singular A. These tests compare the
+  analytic gradient against the numerical one via gradient_checker_v2 for
+  real and complex, singular and invertible, and near-singular inputs, check
+  values against the closed-form adjugate, and confirm that slogdet's
+  backward pass stays finite for a singular matrix instead of raising.
+  """
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testDetGradSingular2x2(self):
+    # det([[1, 2], [2, 4]]) == 0; its adjugate is [[4, -2], [-2, 1]].
+    m = np.array([[1.0, 2.0], [2.0, 4.0]], dtype=np.float64)
+    theoretical, _ = gradient_checker_v2.compute_gradient(
+        linalg_ops.matrix_determinant, [m])
+    self.assertAllClose([[4.0, -2.0, -2.0, 1.0]], theoretical[0])
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testDetGradInvertible2x2(self):
+    # The adjugate of the invertible A = [[1, 2], [3, 4]] is [[4, -3], [-2, 1]].
+    m = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+    theoretical, numerical = gradient_checker_v2.compute_gradient(
+        linalg_ops.matrix_determinant, [m])
+    self.assertAllClose([[4.0, -3.0, -2.0, 1.0]], theoretical[0])
+    self.assertAllClose(theoretical[0], numerical[0], atol=1e-6)
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testDetGradSingularFloat32(self):
+    m = np.array([[1.0, 2.0], [2.0, 4.0]], dtype=np.float32)
+    theoretical, _ = gradient_checker_v2.compute_gradient(
+        linalg_ops.matrix_determinant, [m])
+    self.assertAllClose([[4.0, -2.0, -2.0, 1.0]], theoretical[0], atol=1e-5)
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testDetGradNearSingular(self):
+    # A = [[1, 1], [1, 1 + eps]] has det = eps and condition number ~4/eps.
+    # The gradient (adjugate transpose) is [[1 + eps, -1], [-1, 1]], which the
+    # SVD-based evaluation must reproduce without the loss of accuracy that
+    # forming eps * A^{-1} would incur at these condition numbers.
+    for eps in (1e-6, 1e-9, 1e-12):
+      m = constant_op.constant(
+          [[1.0, 1.0], [1.0, 1.0 + eps]], dtype=np.float64)
+      with backprop.GradientTape() as tape:
+        tape.watch(m)
+        d = linalg_ops.matrix_determinant(m)
+      grad = tape.gradient(d, m)
+      self.assertAllClose(
+          self.evaluate(grad), [[1.0 + eps, -1.0], [-1.0, 1.0]], atol=1e-9)
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testDetGradNearSingularNumerical(self):
+    # The analytic gradient must also agree with the numerical one for a
+    # near-singular matrix (det = 1e-6, condition number ~4e6).
+    m = np.array([[1.0, 1.0], [1.0, 1.0 + 1e-6]], dtype=np.float64)
+    theoretical, numerical = gradient_checker_v2.compute_gradient(
+        linalg_ops.matrix_determinant, [m])
+    self.assertAllClose(theoretical[0], numerical[0], atol=1e-6)
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testDetGradBatchWithSingular(self):
+    # A batch mixing a singular and an invertible matrix must produce the
+    # per-matrix adjugate for both entries.
+    m = constant_op.constant(
+        [[[1.0, 2.0], [2.0, 4.0]], [[1.0, 2.0], [3.0, 4.0]]], dtype=np.float64)
+    with backprop.GradientTape() as tape:
+      tape.watch(m)
+      d = linalg_ops.matrix_determinant(m)
+      total = math_ops.reduce_sum(d)
+    grad = tape.gradient(total, m)
+    self.assertIsNotNone(grad)
+    self.assertAllClose(
+        self.evaluate(grad),
+        [[[4.0, -2.0], [-2.0, 1.0]], [[4.0, -3.0], [-2.0, 1.0]]],
+        atol=1e-10)
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testDetGradComplexInvertible(self):
+    # The reverse-mode gradient of det is conj(det(A)) * A^{-H}; compare the
+    # analytic gradient against both that closed form and the numerical
+    # Jacobian for complex64 and complex128.
+    for dtype, tol in ((np.complex64, 2e-2), (np.complex128, 1e-6)):
+      a = np.array(
+          [[1.0 + 1.0j, 2.0 - 1.0j], [3.0 + 0.5j, 4.0 + 2.0j]], dtype=dtype)
+      theoretical, numerical = gradient_checker_v2.compute_gradient(
+          linalg_ops.matrix_determinant, [a])
+      self.assertAllClose(theoretical[0], numerical[0], atol=tol)
+      m = constant_op.constant(a)
+      with backprop.GradientTape() as tape:
+        tape.watch(m)
+        d = linalg_ops.matrix_determinant(m)
+      grad = tape.gradient(d, m)
+      expected = math_ops.conj(d) * linalg_ops.matrix_inverse(m, adjoint=True)
+      self.assertAllClose(
+          self.evaluate(grad), self.evaluate(expected), atol=tol)
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testDetGradComplexSingular(self):
+    # [[1+i, 2+2i], [2-i, 4-2i]] has det 0 (second row is conj-scaled first);
+    # the analytic gradient must match the numerical one instead of raising.
+    for dtype, tol in ((np.complex64, 2e-2), (np.complex128, 1e-6)):
+      a = np.array(
+          [[1.0 + 1.0j, 2.0 + 2.0j], [2.0 - 1.0j, 4.0 - 2.0j]], dtype=dtype)
+      theoretical, numerical = gradient_checker_v2.compute_gradient(
+          linalg_ops.matrix_determinant, [a])
+      self.assertAllClose(theoretical[0], numerical[0], atol=tol)
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testSlogdetGradSingularDoesNotCrash(self):
+    # log|det(A)| is -inf for a singular A, so its gradient is undefined, but
+    # the backward pass must stay finite instead of raising.
+    m = constant_op.constant([[1.0, 2.0], [2.0, 4.0]], dtype=np.float64)
+    with backprop.GradientTape() as tape:
+      tape.watch(m)
+      _, log_abs_det = gen_linalg_ops.log_matrix_determinant(m)
+    grad = tape.gradient(log_abs_det, m)
+    self.assertIsNotNone(grad)
+    self.assertAllEqual(self.evaluate(math_ops.is_finite(grad)),
+                        [[True, True], [True, True]])
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testSlogdetGradInvertibleUnchanged(self):
+    # For invertible A the gradient of log|det(A)| is A^{-H}; the
+    # pseudoinverse-based path must reproduce it for real and complex inputs.
+    a_real = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+    a_complex = np.array(
+        [[1.0 + 1.0j, 2.0 - 1.0j], [3.0 + 0.5j, 4.0 + 2.0j]],
+        dtype=np.complex128)
+    for a in (a_real, a_complex):
+      m = constant_op.constant(a)
+      with backprop.GradientTape() as tape:
+        tape.watch(m)
+        _, log_abs_det = gen_linalg_ops.log_matrix_determinant(m)
+      grad = tape.gradient(log_abs_det, m)
+      expected = linalg_ops.matrix_inverse(m, adjoint=True)
+      self.assertAllClose(
+          self.evaluate(grad), self.evaluate(expected), atol=1e-10)
+
+  @test_util.run_in_graph_and_eager_modes(use_gpu=False)
+  def testSlogdetGradComplexSingularDoesNotCrash(self):
+    m = constant_op.constant(
+        [[1.0 + 1.0j, 2.0 + 2.0j], [2.0 - 1.0j, 4.0 - 2.0j]],
+        dtype=np.complex128)
+    with backprop.GradientTape() as tape:
+      tape.watch(m)
+      _, log_abs_det = gen_linalg_ops.log_matrix_determinant(m)
+    grad = tape.gradient(log_abs_det, m)
+    self.assertIsNotNone(grad)
+    self.assertAllEqual(
+        self.evaluate(math_ops.is_finite(math_ops.abs(grad))),
+        [[True, True], [True, True]])
 
 
 if __name__ == '__main__':

--- a/tensorflow/python/ops/BUILD
+++ b/tensorflow/python/ops/BUILD
@@ -1888,6 +1888,7 @@ py_library(
         "//tensorflow/python/framework:dtypes",
         "//tensorflow/python/framework:ops",
         "//tensorflow/python/ops/linalg:linalg_impl",
+        "//third_party/py/numpy",
     ],
 )
 

--- a/tensorflow/python/ops/linalg_grad.py
+++ b/tensorflow/python/ops/linalg_grad.py
@@ -33,6 +33,8 @@ References:
     [Ionescu et al., 2015](https://arxiv.org/abs/1509.07838)
     ([pdf](https://arxiv.org/pdf/1509.07838.pdf))
 """
+import numpy as np
+
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import array_ops
@@ -374,14 +376,58 @@ def _EinsumGrad(op: ops.Operation, grad):
 
 @ops.RegisterGradient("MatrixDeterminant")
 def _MatrixDeterminantGrad(op: ops.Operation, grad):
-  """Gradient for MatrixDeterminant."""
+  """Gradient for MatrixDeterminant.
+
+  The holomorphic derivative of det(A) is the cofactor matrix, i.e.
+  det(A) * A^{-T} for invertible A, so under the reverse-mode convention the
+  gradient is its elementwise conjugate, conj(det(A)) * A^{-H}. For real A
+  this is the transpose of the classical adjugate, adj(A)^T. Rather than
+  forming A^{-1}, which does not exist for singular matrices, the same
+  quantity is evaluated from the SVD ``A = U @ diag(s) @ V^H``:
+
+    conj(det(A)) * A^{-H} = conj(det(U))*det(V) * U @ diag(prod_except) @ V^H
+
+  where ``prod_except[i]`` is the product of all singular values except s[i],
+  formed from exclusive left/right cumulative products so that a zero singular
+  value introduces no division by zero. The result agrees with the classical
+  formula for invertible A, extends continuously to singular A, and supports
+  batched matrices. Evaluating the product this way is also more accurate for
+  nearly singular A, where forming A^{-1} amplifies rounding error by the
+  condition number.
+
+  Note: second-order gradients differentiate through the SVD, whose gradient
+  (like that of `tf.linalg.svd`) is only well-defined when the singular
+  values are distinct.
+  """
   a = op.inputs[0]
   c = op.outputs[0]
-  a_adj_inv = linalg_ops.matrix_inverse(a, adjoint=True)
-  multipliers = array_ops.reshape(grad * c,
-                                  array_ops.concat([array_ops.shape(c), [1, 1]],
-                                                   0))
-  return multipliers * a_adj_inv
+  # The adjugate is derived from the SVD, which stays defined when A is
+  # singular and matrix_inverse would fail.
+  s, u, v = gen_linalg_ops.svd(a, full_matrices=True, compute_uv=True)
+  # prod_except[i] = product of all s[j] for j != i.  Use exclusive left/right
+  # cumulative products so that zero singular values are handled correctly
+  # (no division by zero).
+  ones = array_ops.ones_like(s[..., :1])
+  cumprod_left = array_ops.concat(
+      [ones, math_ops.cumprod(s[..., :-1], axis=-1)], axis=-1)
+  cumprod_right = array_ops.concat(
+      [math_ops.cumprod(s[..., 1:], axis=-1, reverse=True), ones], axis=-1)
+  prod_except = cumprod_left * cumprod_right  # [..., n]
+  # Phase correction carried by the unitary factors: from
+  # det(A) = det(U) * prod(s) * conj(det(V)) it follows that
+  # conj(det(A)) = conj(det(U)) * prod(s) * det(V), so the factor multiplying
+  # U @ diag(prod_except) @ V^H is conj(det(U)) * det(V). For real A both
+  # determinants are +/-1 and the conjugations are no-ops.
+  sign_uv = math_ops.conj(gen_linalg_ops.matrix_determinant(u)) * (
+      gen_linalg_ops.matrix_determinant(v))  # [...]
+  # conj(det(A)) * A^{-H} = sign_uv * U @ diag(prod_except) @ V^H
+  # Use adjoint_b=True (conjugate transpose) so this is correct for both
+  # real and complex matrices.
+  a_adj_t = sign_uv[..., None, None] * math_ops.matmul(
+      u * math_ops.cast(prod_except[..., None, :], u.dtype), v, adjoint_b=True)
+  multipliers = array_ops.reshape(
+      grad, array_ops.concat([array_ops.shape(c), [1, 1]], 0))
+  return multipliers * a_adj_t
 
 
 @ops.RegisterGradient("MatrixSquareRoot")
@@ -451,13 +497,37 @@ def _MatrixSquareRootGrad(op: ops.Operation, grad):
 
 @ops.RegisterGradient("LogMatrixDeterminant")
 def _LogMatrixDeterminantGrad(op: ops.Operation, _, grad_b):
-  """Gradient for LogMatrixDeterminant."""
+  """Gradient for LogMatrixDeterminant.
+
+  The gradient of log|det(A)| with respect to A is A^{-H}. This is undefined
+  for a singular A, where log|det(A)| is -inf, so the adjoint of the
+  Moore-Penrose pseudoinverse is used in place of A^{-H} to keep the backward
+  pass finite. The value it produces for an exactly singular input should be
+  treated as undefined. The pseudoinverse is evaluated from the SVD
+  ``A = U @ diag(s) @ V^H`` as ``pinv(A)^H = U @ diag(pinv(s)) @ V^H``, where
+  singular values below the standard cutoff are treated as zero. This also
+  supports complex matrices, which `linalg.pinv` does not.
+  """
   a = op.inputs[0]
   c = op.outputs[1]
-  a_adj_inv = linalg_ops.matrix_inverse(a, adjoint=True)
+  s, u, v = gen_linalg_ops.svd(a, full_matrices=True, compute_uv=True)
+  # The raw Svd op returns singular values in the input dtype; they are real
+  # even for complex matrices.
+  s = math_ops.real(s)
+  # Standard pseudoinverse cutoff: singular values below
+  # n * eps * max(s) are treated as zero rather than inverted.
+  eps = np.finfo(a.dtype.real_dtype.as_numpy_dtype).eps
+  n = math_ops.cast(array_ops.shape(a)[-1], s.dtype)
+  cutoff = eps * n * math_ops.reduce_max(s, axis=-1, keepdims=True)
+  s_pinv = array_ops.where_v2(s > cutoff, math_ops.reciprocal(s),
+                              array_ops.zeros_like(s))
+  # pinv(A)^H = U @ diag(pinv(s)) @ V^H, finite for singular A where
+  # matrix_inverse would fail.
+  a_pinv_adj = math_ops.matmul(
+      u * math_ops.cast(s_pinv[..., None, :], u.dtype), v, adjoint_b=True)
   multipliers = array_ops.reshape(
       grad_b, array_ops.concat([array_ops.shape(c), [1, 1]], 0))
-  return multipliers * a_adj_inv
+  return multipliers * a_pinv_adj
 
 
 @ops.RegisterGradient("Cholesky")


### PR DESCRIPTION
## Problem

Computing the gradient of `tf.linalg.det` via `tf.GradientTape` crashes with `InvalidArgumentError: Input is not invertible` when the input matrix is singular (`det(A) = 0`). The same issue affects `tf.linalg.slogdet`. Reported in issue #119477.

```python
m = tf.constant([[1.0, 2.0], [2.0, 4.0]], dtype=tf.float64)
with tf.GradientTape() as tape:
    tape.watch(m)
    d = tf.linalg.det(m)
g = tape.gradient(d, m)  # InvalidArgumentError: Input is not invertible
```

## Root cause

`_MatrixDeterminantGrad` implements `grad * det(A) * A^{-H}` by calling `matrix_inverse`, which raises for singular matrices. The same issue exists in `_LogMatrixDeterminantGrad`.

## Fix

- **`_MatrixDeterminantGrad`**: compute `det(A) * A^{-H}` directly from the SVD `A = U @ diag(s) @ V^H` as

  ```
  det(A) * A^{-H} = det(U) * conj(det(V)) * U @ diag(prod_except) @ V^H
  ```

  where `prod_except[i]` is the product of all singular values except `s[i]`, built from exclusive left/right cumulative products (no division by zero). This agrees with the previous formula for invertible inputs, extends continuously to singular ones (for real `A` it is the transpose of the classical adjugate), and handles complex dtypes correctly via `conj(det(V))` and `adjoint_b=True`. Batched inputs are supported.

- **`_LogMatrixDeterminantGrad`**: use the SVD-based pseudoinverse in place of `matrix_inverse` so the backward pass stays finite for singular inputs (where `log|det(A)| = -inf` and the gradient value is inherently undefined).

## Tests

New `DetGradSingularMatrixTest` in `linalg_grad_test.py`, running in both graph and eager modes:

- singular 2x2 checked against the closed-form adjugate
- invertible 2x2 checked against the closed-form adjugate
- batch mixing singular and invertible matrices
- complex128 matrix checked against `det(A) * A^{-H}`
- slogdet on a singular matrix: gradient finite, no exception

The SVD formula was additionally cross-validated numerically against closed-form cofactor adjugates for singular, rank-1, zero, random, and complex matrices.

Fixes #119477.