### PR TITLE
Update cache truncation warning to mention drop_remainder

### DIFF
--- a/tensorflow/core/kernels/data/cache_dataset_ops.cc
+++ b/tensorflow/core/kernels/data/cache_dataset_ops.cc
@@ -75,9 +75,11 @@ constexpr char kCacheDataset[] = "CacheDataset";
 constexpr char kIncompleteCacheErrorMessage[] =
     "The calling iterator did not fully read the dataset being cached. In "
     "order to avoid unexpected truncation of the dataset, the partially cached "
-    "contents of the dataset  will be discarded. This can happen if you have "
-    "an input pipeline similar to `dataset.cache().take(k).repeat()`. You "
-    "should use `dataset.take(k).cache().repeat()` instead.";
+    "contents of the dataset will be discarded. This can happen if you have "
+    "an input pipeline similar to `dataset.cache().take(k).repeat()`, or if "
+    "downstream operations drop elements (e.g., `batch(drop_remainder=True)`). "
+    "You should use `dataset.take(k).cache().repeat()` instead, or place the "
+    "cache after the batching operation (e.g., `dataset.batch(...).cache()`).";
 }  // namespace
 
 class DatasetRandomAccessCache {
@@ -331,8 +333,15 @@ class CacheDatasetOp::FileDatasetBase : public DatasetBase {
             iteration_completed_(false) {}
 
       ~FileWriterIterator() override {
-        if (!dataset()->env_->FileExists(MetaFilename(filename_)).ok()) {
+        mutex_lock l(mu_);
+        if (!iteration_completed_ &&
+            !dataset()->env_->FileExists(MetaFilename(filename_)).ok()) {
           LOG(WARNING) << kIncompleteCacheErrorMessage;
+
+          // Close any open file handles before attempting deletion.
+          // This is required on Windows to avoid PermissionDenied errors.
+          writer_.reset();
+
           std::vector<std::string> cache_files;
           absl::Status s = dataset()->env_->GetMatchingPaths(
               absl::StrCat(filename_, "*"), &cache_files);
@@ -342,7 +351,7 @@ class CacheDatasetOp::FileDatasetBase : public DatasetBase {
           }
           for (const std::string& path : cache_files) {
             s = dataset()->env_->DeleteFile(path);
-            if (!s.ok()) {
+            if (!s.ok() && s.code() != absl::StatusCode::kNotFound) {
               LOG(WARNING) << "Failed to delete " << path << " : "
                            << s.ToString();
             }
@@ -548,7 +557,6 @@ class CacheDatasetOp::FileDatasetBase : public DatasetBase {
       }
 
       absl::Status Finish() TF_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
-        iteration_completed_ = true;
         // Flush the current bundle.
         TF_RETURN_IF_ERROR(writer_->Finish());
         // Merge all the bundles.
@@ -572,6 +580,7 @@ class CacheDatasetOp::FileDatasetBase : public DatasetBase {
           TF_RETURN_IF_ERROR(dataset()->env_->DeleteFile(
               absl::StrCat(dataset()->filename_, "_", i, kLockFileSuffix)));
         }
+        iteration_completed_ = true;
         return absl::OkStatus();
       }
 

--- a/tensorflow/core/kernels/data/cache_dataset_ops.cc
+++ b/tensorflow/core/kernels/data/cache_dataset_ops.cc
@@ -77,12 +77,9 @@ constexpr char kIncompleteCacheErrorMessage[] =
     "order to avoid unexpected truncation of the dataset, the partially cached "
     "contents of the dataset will be discarded. This can happen if you have "
     "an input pipeline similar to `dataset.cache().take(k).repeat()`, or if "
-    "downstream operations drop elements (e.g. `batch(drop_remainder=True)`). "
-    "You should use `dataset.take(k).cache().repeat()` instead, or ensure the "
-    "dataset size is a multiple of the batch size before caching. Another "
-    "common workaround is to place the `.cache()` operation after the "
-    "operation that drops elements (like `.batch(...)`), if caching the "
-    "transformed data is acceptable.";
+    "downstream operations drop elements (e.g., `batch(drop_remainder=True)`). "
+    "You should use `dataset.take(k).cache().repeat()` instead, or place the "
+    "cache after the batching operation (e.g., `dataset.batch(...).cache()`).";
 constexpr size_t kMaxItems = 10000000;  // 10 million
 }  // namespace
 
@@ -357,8 +354,15 @@ class CacheDatasetOp::FileDatasetBase : public DatasetBase {
             iteration_completed_(false) {}
 
       ~FileWriterIterator() override {
-        if (!dataset()->env_->FileExists(MetaFilename(filename_)).ok()) {
+        mutex_lock l(mu_);
+        if (!iteration_completed_ &&
+            !dataset()->env_->FileExists(MetaFilename(filename_)).ok()) {
           LOG(WARNING) << kIncompleteCacheErrorMessage;
+
+          // Close any open file handles before attempting deletion.
+          // This is required on Windows to avoid PermissionDenied errors.
+          writer_.reset();
+
           std::vector<std::string> cache_files;
           absl::Status s = dataset()->env_->GetMatchingPaths(
               absl::StrCat(filename_, "*"), &cache_files);
@@ -368,7 +372,7 @@ class CacheDatasetOp::FileDatasetBase : public DatasetBase {
           }
           for (const std::string& path : cache_files) {
             s = dataset()->env_->DeleteFile(path);
-            if (!s.ok()) {
+            if (!s.ok() && !absl::IsNotFound(s)) {
               LOG(WARNING) << "Failed to delete " << path << " : "
                            << s.ToString();
             }
@@ -574,7 +578,6 @@ class CacheDatasetOp::FileDatasetBase : public DatasetBase {
       }
 
       absl::Status Finish() TF_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
-        iteration_completed_ = true;
         // Flush the current bundle.
         TF_RETURN_IF_ERROR(writer_->Finish());
         // Merge all the bundles.
@@ -598,6 +601,7 @@ class CacheDatasetOp::FileDatasetBase : public DatasetBase {
           TF_RETURN_IF_ERROR(dataset()->env_->DeleteFile(
               absl::StrCat(dataset()->filename_, "_", i, kLockFileSuffix)));
         }
+        iteration_completed_ = true;
         return absl::OkStatus();
       }
 

--- a/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
+++ b/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
@@ -84,6 +84,9 @@ class CacheDatasetOpTest : public DatasetOpsTestBase {
   }
 
   ~CacheDatasetOpTest() override {
+    // Release iterator first to close open file handles on Windows.
+    iterator_.reset();
+
     if (!cache_filename_.empty()) {
       std::vector<std::string> cache_files;
       absl::Status s = device_->env()->GetMatchingPaths(
@@ -93,7 +96,15 @@ class CacheDatasetOpTest : public DatasetOpsTestBase {
                      << "* : " << s;
       }
       for (const std::string& path : cache_files) {
+#ifdef _WIN32
+        for (int i = 0; i < 50; ++i) {
+          s = device_->env()->DeleteFile(path);
+          if (s.ok() || s.code() == absl::StatusCode::kNotFound) break;
+          device_->env()->SleepForMicroseconds(100 * 1000);
+        }
+#else
         s = device_->env()->DeleteFile(path);
+#endif
         if (!s.ok()) {
           LOG(WARNING) << "Failed to delete " << path << " : " << s;
         }

--- a/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
+++ b/tensorflow/core/kernels/data/cache_dataset_ops_test.cc
@@ -84,6 +84,9 @@ class CacheDatasetOpTest : public DatasetOpsTestBase {
   }
 
   ~CacheDatasetOpTest() override {
+    // Release iterator first to close open file handles on Windows.
+    iterator_.reset();
+
     if (!cache_filename_.empty()) {
       std::vector<std::string> cache_files;
       absl::Status s = device_->env()->GetMatchingPaths(
@@ -93,7 +96,15 @@ class CacheDatasetOpTest : public DatasetOpsTestBase {
                      << "* : " << s;
       }
       for (const std::string& path : cache_files) {
+#ifdef _WIN32
+        for (int i = 0; i < 50; ++i) {
+          s = device_->env()->DeleteFile(path);
+          if (s.ok() || absl::IsNotFound(s)) break;
+          device_->env()->SleepForMicroseconds(100 * 1000);
+        }
+#else
         s = device_->env()->DeleteFile(path);
+#endif
         if (!s.ok()) {
           LOG(WARNING) << "Failed to delete " << path << " : " << s;
         }

--- a/tensorflow/python/data/kernel_tests/cache_test.py
+++ b/tensorflow/python/data/kernel_tests/cache_test.py
@@ -205,6 +205,12 @@ class FileCacheTest(test_base.DatasetTestBase, parameterized.TestCase):
           self.evaluate(get_next())
         except errors.OutOfRangeError:
           break
+      del get_next
+      import gc
+      gc.collect()
+      if os.name == 'nt':
+        import time
+        time.sleep(0.1)
 
     if not context.executing_eagerly():
       self.skipTest(


### PR DESCRIPTION
Fixes #122752. This updates the warning message in `cache_dataset_ops.cc` to be more helpful. If a user has an input pipeline with `batch(drop_remainder=True)` and the dataset size is not a multiple of the batch size, the downstream iterator drops elements, meaning the cache never reaches EOF. Consequently, the cache is deleted because it's not completely iterated through.