### PR TITLE
Add descriptive message about your cFix: Resolve TypeError during import from sysconfig.get_path returning Nonehanges

### DIFF
--- a/tensorflow/api_template.__init__.py
+++ b/tensorflow/api_template.__init__.py
@@ -74,12 +74,12 @@ _tf_uses_legacy_keras = (
     _os.environ.get("TF_USE_LEGACY_KERAS", None) in ("true", "True", "1"))
 setattr(_current_module, "keras", _KerasLazyLoader(globals()))
 _module_dir = _module_util.get_parent_dir_for_name("keras._tf_keras.keras")
-_current_module.__path__ = [_module_dir] + _current_module.__path__
+_current_module.__path__ = [_module_dir] + list(_current_module.__path__)
 if _tf_uses_legacy_keras:
   _module_dir = _module_util.get_parent_dir_for_name("tf_keras.api._v2.keras")
 else:
   _module_dir = _module_util.get_parent_dir_for_name("keras.api._v2.keras")
-_current_module.__path__ = [_module_dir] + _current_module.__path__
+_current_module.__path__ = [_module_dir] + list(_current_module.__path__)
 
 
 # Enable TF2 behaviors
@@ -104,7 +104,9 @@ if "getsitepackages" in dir(_site):
 
 for _scheme in _sysconfig.get_scheme_names():
   for _name in ["purelib", "platlib"]:
-    _site_packages_dirs += [_sysconfig.get_path(_name, _scheme)]
+    _path = _sysconfig.get_path(_name, _scheme)
+    if _path is not None:
+      _site_packages_dirs.append(_path)
 
 _site_packages_dirs = list(set(_site_packages_dirs))
 

--- a/tensorflow/api_template_v1.__init__.py
+++ b/tensorflow/api_template_v1.__init__.py
@@ -74,12 +74,12 @@ _tf_uses_legacy_keras = (
     _os.environ.get("TF_USE_LEGACY_KERAS", None) in ("true", "True", "1"))
 setattr(_current_module, "keras", _KerasLazyLoader(globals(), mode="v1"))
 _module_dir = _module_util.get_parent_dir_for_name("keras._tf_keras.keras")
-_current_module.__path__ = [_module_dir] + _current_module.__path__
+_current_module.__path__ = [_module_dir] + list(_current_module.__path__)
 if _tf_uses_legacy_keras:
   _module_dir = _module_util.get_parent_dir_for_name("tf_keras.api._v1.keras")
 else:
   _module_dir = _module_util.get_parent_dir_for_name("keras.api._v1.keras")
-_current_module.__path__ = [_module_dir] + _current_module.__path__
+_current_module.__path__ = [_module_dir] + list(_current_module.__path__)
 
 _CONTRIB_WARNING = """
 The TensorFlow contrib module will not be included in TensorFlow 2.0.
@@ -95,7 +95,7 @@ contrib = _LazyLoader("contrib", globals(), "tensorflow.contrib",
 # sets the __all__ variable. If it does, we have to be sure to add
 # "contrib".
 if "__all__" in vars():
-  vars()["__all__"].append("contrib")
+  vars()["__all__"] = list(vars()["__all__"]) + ["contrib"]
 
 from tensorflow.python.platform import flags
 # The "app" module will be imported as part of the placeholder section above.
@@ -117,7 +117,7 @@ if _tf_uses_legacy_keras:
 else:
   _module_dir = _module_util.get_parent_dir_for_name(
       "keras.api._v1.keras.__internal__.legacy.layers")
-_current_module.__path__ = [_module_dir] + _current_module.__path__
+_current_module.__path__ = [_module_dir] + list(_current_module.__path__)
 
 _current_module.nn.rnn_cell = _KerasLazyLoader(
     globals(),
@@ -130,7 +130,7 @@ if _tf_uses_legacy_keras:
 else:
   _module_dir = _module_util.get_parent_dir_for_name(
       "keras.api._v1.keras.__internal__.legacy.rnn_cell")
-_current_module.nn.__path__ = [_module_dir] + _current_module.nn.__path__
+_current_module.nn.__path__ = [_module_dir] + list(_current_module.nn.__path__)
 
 del importlib
 
@@ -149,7 +149,9 @@ if "getsitepackages" in dir(_site):
 
 for _scheme in sysconfig.get_scheme_names():
   for _name in ["purelib", "platlib"]:
-    _site_packages_dirs += [sysconfig.get_path(_name, _scheme)]
+    _path = sysconfig.get_path(_name, _scheme)
+    if _path is not None:
+      _site_packages_dirs.append(_path)
 
 _site_packages_dirs = list(set(_site_packages_dirs))
 

--- a/tensorflow/compat_template_v1.__init__.py
+++ b/tensorflow/compat_template_v1.__init__.py
@@ -37,7 +37,7 @@ if _tf_uses_legacy_keras:
   _module_dir = _module_util.get_parent_dir_for_name("tf_keras.api._v1.keras")
 else:
   _module_dir = _module_util.get_parent_dir_for_name("keras.api._v1.keras")
-_current_module.__path__ = [_module_dir] + _current_module.__path__
+_current_module.__path__ = [_module_dir] + list(_current_module.__path__)
 
 
 from tensorflow.python.platform import flags  # pylint: disable=g-import-not-at-top
@@ -57,7 +57,7 @@ if _tf_uses_legacy_keras:
 else:
   _module_dir = _module_util.get_parent_dir_for_name(
       "keras.api._v1.keras.__internal__.legacy.layers")
-_current_module.__path__ = [_module_dir] + _current_module.__path__
+_current_module.__path__ = [_module_dir] + list(_current_module.__path__)
 
 _current_module.nn.rnn_cell = _KerasLazyLoader(
     globals(),
@@ -70,4 +70,4 @@ if _tf_uses_legacy_keras:
 else:
   _module_dir = _module_util.get_parent_dir_for_name(
       "keras.api._v1.keras.__internal__.legacy.rnn_cell")
-_current_module.nn.__path__ = [_module_dir] + _current_module.nn.__path__
+_current_module.nn.__path__ = [_module_dir] + list(_current_module.nn.__path__)


### PR DESCRIPTION
1. Fix TypeError caused by sysconfig.get_path() returning None (Critical)  Issue: On certain operating systems and Python distributions (e.g., Debian, Ubuntu, or macOS Homebrew), sysconfig.get_path(_name, _scheme) can legitimately return None for schemes that aren't fully configured in that environment (like posix_local or osx_framework_user). Previously, this appended None directly to the _site_packages_dirs list. Impact: This caused fatal crashes during import in two places: _current_file_location.startswith(dir_) raised TypeError: startswith first arg must be str or a tuple of str, not NoneType. os.path.join(_s, "tensorflow-plugins") raised TypeError: expected str, bytes or os.PathLike object, not NoneType. Fix: Added a strict None check before appending the path to _site_packages_dirs ensuring only valid strings are processed.

 2. Safely handle __path__ concatenation for PEP 420 Namespace Packages  Issue: Since Python 3.3, package __path__ attributes are not strictly required to be a standard Python list; they can be an instance of _NamespacePath if implicit namespace packages are used. Impact: Using the + operator to concatenate a list with a _NamespacePath raises TypeError: can only concatenate list (not "_NamespacePath") to list. Fix: Explicitly cast __path__ attributes (like _current_module.__path__ and _current_module.nn.__path__) to a list prior to appending _module_dir. This guarantees safe concatenation regardless of the package type. 
 
 3. Prevent AttributeError when __all__ is declared as a tuple  Issue: The templated code replacing API IMPORTS PLACEHOLDER sometimes defines __all__ as a tuple (e.g., __all__ = ('a', 'b')). Impact: Calling .append("contrib") directly on __all__ would crash with AttributeError: 'tuple' object has no attribute 'append'. Fix: Converted the modification to use list concatenation (list(vars()["__all__"]) + ["contrib"]), safely mutating the variable irrespective of whether it was originally defined as a list or a tuple.out your changes