### PR TITLE
Fix XLA memory corruption on zero-dimension StridedSlice

### DIFF
--- a/tensorflow/compiler/tests/slice_ops_test.py
+++ b/tensorflow/compiler/tests/slice_ops_test.py
@@ -164,6 +164,19 @@ class StridedSliceTest(xla_test.XLATestCase):
 
         self.assertAllEqual([5, 6, 7, 8, 9], result)
 
+  def testZeroStridedSlice(self):
+    for dtype in self.numeric_types:
+      with self.session() as sess:
+        i = array_ops.placeholder(dtype, shape=[10])
+        with self.test_scope():
+          o1 = array_ops.strided_slice(i, [0], [5], [1])
+          o2 = array_ops.strided_slice(i, [10], [15], [1])
+        params = {i: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}
+        result1, result2 = sess.run([o1, o2], feed_dict=params)
+
+        self.assertAllEqual([0, 1, 2, 3, 4], result1)
+        self.assertAllEqual([], result2)
+
   def test1DNegativeStride(self):
     for dtype in self.numeric_types:
       with self.session():

--- a/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
+++ b/tensorflow/compiler/tf2xla/kernels/strided_slice_op.cc
@@ -298,6 +298,14 @@ class StridedSliceOp : public XlaOpKernel {
                           "shape for strided slice: ",
                           partial_final_shape.DebugString(),
                           ", output shape must be a compile-time constant"));
+
+      if (final_shape.num_elements() == 0) {
+        xla::XlaOp zero = xla::Zero(ctx->builder(), ctx->input_xla_type(0));
+        xla::XlaOp slice = xla::Broadcast(zero, final_shape.dim_sizes());
+        ctx->SetOutput(0, slice);
+        return;
+      }
+
       absl::InlinedVector<int64_t, 4> dimensions_to_reverse;
       absl::InlinedVector<int64_t, 4> slice_begin, slice_end, slice_strides;
       for (int i = 0; i < begin.size(); ++i) {


### PR DESCRIPTION
Fixes #122952

### Description
This PR resolves an issue where out-of-bounds `StridedSlice` operations that result in a 0-dimension tensor trigger a memory corruption bug during XLA compilation. When `jit_compile=True` is used, the XLA compiler generates an `xla::Slice` operation that correctly evaluates to an empty tensor, but passing this zero-sized slice further through the HLO graph causes severe memory corruption across other valid tensor partitions (resulting in non-deterministic values across runs). 

This fix bypasses `xla::Slice` generation in `StridedSliceOp::Compile` whenever the evaluated static `final_shape` has 0 elements. Instead, it emits a zero-dimension broadcast (`xla::Broadcast(xla::Zero(...), final_shape)`), which safely preserves the shape semantics while preventing the underlying XLA memory overlap issue.
