### PR TITLE
check stored slice shape against full shape in GetSliceValue

### DIFF
--- a/tensorflow/core/util/tensor_bundle/tensor_bundle.cc
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle.cc
@@ -1168,6 +1168,24 @@ absl::Status BundleReader::GetSliceValue(
       return status_;
     }
 
+    // The stored slice's recorded shape must match the geometry obtained by
+    // applying "stored_slice" to the full tensor shape. The copy below walks
+    // "stored_slice_tensor" using the latter, so a smaller recorded shape (from
+    // a crafted checkpoint) would read past the backing buffer. This mirrors
+    // the size check in TensorSliceReader::CopySliceData.
+    TensorShape expected_slice_shape;
+    status_ = stored_slice.SliceTensorShape(full_shape, &expected_slice_shape);
+    if (!status_.ok()) return status_;
+    if (stored_slice_shape != expected_slice_shape) {
+      status_ = absl::DataLossError(absl::StrCat(
+          "Stored slice shape ", stored_slice_shape.DebugString(),
+          " for tensor ", full_tensor_key,
+          " does not match the expected slice shape ",
+          expected_slice_shape.DebugString(), " derived from full shape ",
+          full_shape.DebugString()));
+      return status_;
+    }
+
     Tensor stored_slice_tensor(stored_slice_entry.dtype(), stored_slice_shape);
     status_ = GetValue(stored_slice_entry, &stored_slice_tensor);
     if (!status_.ok()) return status_;

--- a/tensorflow/core/util/tensor_bundle/tensor_bundle_test.cc
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle_test.cc
@@ -198,6 +198,49 @@ absl::Status FlipEndiannessBit(const std::string& prefix) {
   return metadata_file->Close();
 }
 
+// Rewrites the bundle's metadata file, replacing the recorded shape of the
+// entry stored under <key> with <new_shape>. Used to simulate a crafted
+// checkpoint whose full-tensor shape disagrees with the shapes of its stored
+// slices.
+absl::Status RewriteEntryShape(const std::string& prefix,
+                               const std::string& key,
+                               const TensorShape& new_shape) {
+  Env* env = Env::Default();
+  const std::string metadata_tmp_path = Prefix("rewrite_tmp_path");
+  std::unique_ptr<WritableFile> metadata_file;
+  TF_RETURN_IF_ERROR(env->NewWritableFile(metadata_tmp_path, &metadata_file));
+  std::unique_ptr<table::TableBuilder> builder;
+  {
+    const std::string filename = MetaFilename(prefix);
+    uint64_t file_size;
+    TF_RETURN_IF_ERROR(env->GetFileSize(filename, &file_size));
+    std::unique_ptr<RandomAccessFile> file;
+    TF_RETURN_IF_ERROR(env->NewRandomAccessFile(filename, &file));
+
+    table::Table* table = nullptr;
+    TF_RETURN_IF_ERROR(
+        table::Table::Open(table::Options(), file.get(), file_size, &table));
+    std::unique_ptr<table::Table> table_deleter(table);
+    std::unique_ptr<table::Iterator> iter(table->NewIterator());
+
+    builder.reset(
+        new table::TableBuilder(table::Options(), metadata_file.get()));
+    for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+      if (iter->key() == key) {
+        BundleEntryProto entry;
+        CHECK(entry.ParseFromArray(iter->value().data(), iter->value().size()));
+        new_shape.AsProto(entry.mutable_shape());
+        builder->Add(iter->key(), entry.SerializeAsString());
+      } else {
+        builder->Add(iter->key(), iter->value());
+      }
+    }
+  }
+  TF_RETURN_IF_ERROR(builder->Finish());
+  TF_RETURN_IF_ERROR(env->RenameFile(metadata_tmp_path, MetaFilename(prefix)));
+  return metadata_file->Close();
+}
+
 template <typename T>
 void TestBasic() {
   {
@@ -648,6 +691,35 @@ TEST(TensorBundleTest, PartitionedVariables) {
     TF_ASSERT_OK(reader.LookupSlice("foo", distinct_slice, &val));
     test::ExpectTensorEqual<float>(val,
                                    Constant<float>(1., TensorShape({5, 2})));
+  }
+}
+
+// A crafted checkpoint can record a full-tensor shape that is inconsistent with
+// the shapes of the tensor's stored slices. Reading such a slice must not walk
+// the stored-slice buffer using the (larger) geometry implied by the full
+// shape, which would read out of bounds.
+TEST(TensorBundleTest, SliceShapeMismatch) {
+  const TensorShape kFullShape({5, 10});
+  const TensorSlice slice1 = TensorSlice::ParseOrDie("-:0,1");
+  const TensorSlice slice2 = TensorSlice::ParseOrDie("-:1,9");
+  {
+    BundleWriter writer(Env::Default(), Prefix("foo"));
+    TF_ASSERT_OK(writer.AddSlice("foo", kFullShape, slice1,
+                                 Constant<float>(0., TensorShape({5, 1}))));
+    TF_ASSERT_OK(writer.AddSlice("foo", kFullShape, slice2,
+                                 Constant<float>(1., TensorShape({5, 9}))));
+    TF_ASSERT_OK(writer.Finish());
+  }
+  // Enlarge the recorded full shape. Applying either stored slice to it now
+  // yields more rows than the stored slice buffers actually hold.
+  const TensorShape kTamperedShape({50, 10});
+  TF_ASSERT_OK(RewriteEntryShape(Prefix("foo"), "foo", kTamperedShape));
+  {
+    BundleReader reader(Env::Default(), Prefix("foo"));
+    TF_ASSERT_OK(reader.status());
+    Tensor val(DT_FLOAT, kTamperedShape);
+    const absl::Status status = reader.Lookup("foo", &val);
+    EXPECT_TRUE(absl::IsDataLoss(status)) << status;
   }
 }
 

--- a/tensorflow/core/util/tensor_bundle/tensor_bundle_test.cc
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle_test.cc
@@ -721,6 +721,8 @@ TEST(TensorBundleTest, SliceShapeMismatch) {
     Tensor val(DT_FLOAT, kTamperedShape);
     const absl::Status status = reader.Lookup("foo", &val);
     EXPECT_TRUE(absl::IsDataLoss(status)) << status;
+    EXPECT_TRUE(absl::StrContains(status.ToString(), "Stored slice shape"))
+        << status;
   }
 }
 

--- a/tensorflow/core/util/tensor_bundle/tensor_bundle_test.cc
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle_test.cc
@@ -223,8 +223,8 @@ absl::Status RewriteEntryShape(const std::string& prefix,
     std::unique_ptr<table::Table> table_deleter(table);
     std::unique_ptr<table::Iterator> iter(table->NewIterator());
 
-    builder.reset(
-        new table::TableBuilder(table::Options(), metadata_file.get()));
+    builder = std::make_unique<table::TableBuilder>(table::Options(),
+                                                    metadata_file.get());
     for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
       if (iter->key() == key) {
         BundleEntryProto entry;
@@ -237,8 +237,9 @@ absl::Status RewriteEntryShape(const std::string& prefix,
     }
   }
   TF_RETURN_IF_ERROR(builder->Finish());
-  TF_RETURN_IF_ERROR(env->RenameFile(metadata_tmp_path, MetaFilename(prefix)));
-  return metadata_file->Close();
+  builder.reset();
+  TF_RETURN_IF_ERROR(metadata_file->Close());
+  return env->RenameFile(metadata_tmp_path, MetaFilename(prefix));
 }
 
 template <typename T>


### PR DESCRIPTION
BundleReader::GetSliceValue sizes stored_slice_tensor from the slice entry's own recorded shape, but the following CopyDataFromTensorSliceToTensorSlice walks that buffer using the geometry that stored_slice applied to the full-tensor shape produces. A crafted checkpoint can record a slice shape with fewer elements than that geometry, so restoring a partitioned tensor reads past the buffer. Add the shape-consistency check that TensorSliceReader::CopySliceData already performs before the copy.