### PR TITLE
Support tuple and list axis in tf.experimental.numpy.flip

### DIFF
--- a/tensorflow/python/ops/numpy_ops/np_array_ops.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops.py
@@ -1438,9 +1438,12 @@ def flip(m, axis=None):  # pylint: disable=missing-docstring
   if axis is None:
     return array_ops.reverse(m, math_ops.range(array_ops.rank(m)))
 
-  axis = np_utils._canonicalize_axis(axis, array_ops.rank(m))  # pylint: disable=protected-access
+  if np_utils.isscalar(axis):
+    axis = [axis]
 
-  return array_ops.reverse(m, [axis])
+  axis = np_utils._canonicalize_axes(axis, array_ops.rank(m))  # pylint: disable=protected-access
+
+  return array_ops.reverse(m, axis)
 
 
 @tf_export.tf_export('experimental.numpy.flipud', v1=[])

--- a/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
+++ b/tensorflow/python/ops/numpy_ops/np_array_ops_test.py
@@ -27,6 +27,7 @@ from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import indexed_slices
 from tensorflow.python.framework import ops
+from tensorflow.python.framework import random_seed
 from tensorflow.python.framework import tensor_shape
 from tensorflow.python.framework import tensor_spec
 from tensorflow.python.ops import array_ops
@@ -1145,6 +1146,31 @@ class ArrayMethodsTest(test.TestCase):
     _test(a, tuple(range(6)), tuple(range(6)))
     _test(a, tuple(range(6)), tuple(reversed(range(6))))
     _test(a, (), ())
+
+  def testFlip(self):
+    np.random.seed(0)
+    random_seed.set_seed(0)
+
+    def _test(*args, **kwargs):
+      expected = np.flip(*args, **kwargs)
+      raw_ans = np_array_ops.flip(*args, **kwargs)
+
+      self.assertAllEqual(expected, raw_ans)
+
+    a = np.random.rand(2, 3, 4)
+
+    # No axis reverses every dimension.
+    _test(a)
+    # A single axis, including negative values.
+    _test(a, axis=0)
+    _test(a, axis=2)
+    _test(a, axis=-1)
+    # A tuple, list or range of axes, including negative values.
+    _test(a, axis=(0, 1))
+    _test(a, axis=(-1, -3))
+    _test(a, axis=[0, 2])
+    _test(a, axis=(0, 1, 2))
+    _test(a, axis=range(3))
 
   def testNdim(self):
     self.assertAllEqual(0, np_array_ops.ndim(0.5))


### PR DESCRIPTION
`tf.experimental.numpy.flip` raised a `TypeError` whenever `axis` was a tuple or list, for example `flip(x, axis=(0, 1))`, even though NumPy's `flip` accepts an int, a tuple of ints, or `None`.

It happened because `flip` used the singular `_canonicalize_axis` helper and wrapped its result in a list, so only a single integer axis was ever handled.

The fix normalizes `axis` to a list and uses `_canonicalize_axes`, so every requested axis is reversed together and the behavior matches NumPy. A regression test covering int, negative, tuple and list axes is included.
