### PR TITLE
Fix incorrect trip count calculation for integer while loops in XLA

### DIFF
--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -1732,9 +1732,7 @@ pywrap_library(
         "//tensorflow/python/util:_tf_stack",
         "//tensorflow/python/util:fast_module_type",
         "//tensorflow/python/util:pywrap_xla_ops",
-    ] + if_windows([
-        "//tensorflow/python/framework:python_api_parameter_converter_alwayslink",
-    ]),
+    ],
 )
 
 pywrap_common_library(

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -846,7 +846,6 @@ pywrap_tensorflow_macro(
         "//tensorflow/python/framework:op_def_util_cc",
         "//tensorflow/python/framework:python_api_dispatcher",
         "//tensorflow/python/framework:python_api_info",
-        "//tensorflow/python/framework:python_api_parameter_converter",
         "//tensorflow/python/framework:python_op_gen",
         "//tensorflow/python/framework:python_tensor_converter",
         "//tensorflow/python/grappler:cost_analyzer_lib",
@@ -1732,7 +1731,9 @@ pywrap_library(
         "//tensorflow/python/util:_tf_stack",
         "//tensorflow/python/util:fast_module_type",
         "//tensorflow/python/util:pywrap_xla_ops",
-    ],
+    ] + if_windows([
+        "//tensorflow/python/framework:python_api_parameter_converter_alwayslink",
+    ]),
 )
 
 pywrap_common_library(

--- a/tensorflow/python/BUILD
+++ b/tensorflow/python/BUILD
@@ -846,6 +846,7 @@ pywrap_tensorflow_macro(
         "//tensorflow/python/framework:op_def_util_cc",
         "//tensorflow/python/framework:python_api_dispatcher",
         "//tensorflow/python/framework:python_api_info",
+        "//tensorflow/python/framework:python_api_parameter_converter",
         "//tensorflow/python/framework:python_op_gen",
         "//tensorflow/python/framework:python_tensor_converter",
         "//tensorflow/python/grappler:cost_analyzer_lib",

--- a/tensorflow/python/framework/BUILD
+++ b/tensorflow/python/framework/BUILD
@@ -3383,3 +3383,9 @@ cc_library(
         "@pybind11",
     ],
 )
+
+cc_library(
+    name = "python_api_parameter_converter_alwayslink",
+    deps = [":python_api_parameter_converter"],
+    alwayslink = 1,
+)

--- a/tensorflow/python/framework/BUILD
+++ b/tensorflow/python/framework/BUILD
@@ -3386,6 +3386,7 @@ cc_library(
 
 cc_library(
     name = "python_api_parameter_converter_alwayslink",
+    visibility = ["//visibility:public"],
     deps = [":python_api_parameter_converter"],
     alwayslink = 1,
 )

--- a/tensorflow/python/framework/BUILD
+++ b/tensorflow/python/framework/BUILD
@@ -1908,6 +1908,7 @@ pytype_strict_library(
     srcs = ["type_spec_registry.py"],
     visibility = visibility + ["//third_party/py/tensorflow_gnn:__subpackages__"],
     deps = [
+        "//tensorflow/python/platform:tf_logging",
         "//tensorflow/python/types:internal",
     ],
 )
@@ -3382,11 +3383,4 @@ cc_library(
         "//tensorflow/core:framework",
         "@pybind11",
     ],
-)
-
-cc_library(
-    name = "python_api_parameter_converter_alwayslink",
-    visibility = ["//visibility:public"],
-    deps = [":python_api_parameter_converter"],
-    alwayslink = 1,
 )

--- a/third_party/xla/xla/hlo/analysis/while_loop_analysis.cc
+++ b/third_party/xla/xla/hlo/analysis/while_loop_analysis.cc
@@ -860,24 +860,19 @@ optional<int64_t> MatchTrivialLoopTripCount(const HloInstruction* while_op,
             << while_cond_root->ToString();
     optional<int64_t> trips =
         CheckedSubtract(*while_cond_bound_val, *indvar_init_val);
-    if (trips) {
-      const int64_t remainder = std::remainder(*trips, trip_count_step);
-      const int64_t div = std::floor(*trips / trip_count_step);
-      if (remainder == 0) {
-        return std::max(int64_t{0}, div);
-      }
-      trips = CheckedAdd(div, 1);
-      if (!trips) {
-        VLOG(2) << "Pattern-match failed: Trip count exceeds INT64_MAX.";
-        return nullopt;
-      }
-      if (*trips < *while_cond_bound_val) {
-        return std::max(int64_t{0}, *trips);
-      }
-      return std::max(int64_t{0}, div);
+    if (!trips) {
+      VLOG(2) << "Pattern-match failed: Trip count exceeds INT64_MAX.";
+      return nullopt;
     }
-    VLOG(2) << "Pattern-match failed: Trip count exceeds INT64_MAX.";
-    return nullopt;
+    if (*trips <= 0) {
+      return 0;
+    }
+    trips = CheckedAdd(*trips, trip_count_step - 1);
+    if (!trips) {
+      VLOG(2) << "Pattern-match failed: Trip count exceeds INT64_MAX.";
+      return nullopt;
+    }
+    return *trips / trip_count_step;
   }
 
   // Handle `i = init; i <= N; i+=k`.
@@ -893,12 +888,10 @@ optional<int64_t> MatchTrivialLoopTripCount(const HloInstruction* while_op,
       VLOG(2) << "Pattern-match failed: Trip count exceeds INT64_MAX";
       return nullopt;
     }
-    trips = CheckedAdd(std::floor(*trips / trip_count_step), 1);
-    if (!trips) {
-      VLOG(2) << "Pattern-match failed: Trip count exceeds INT64_MAX";
-      return nullopt;
+    if (*trips < 0) {
+      return 0;
     }
-    return std::max<int64_t>(0, *trips);
+    return *trips / trip_count_step + 1;
   }
 
   VLOG(2) << "Pattern-match failed: while condition follows unknown pattern: "

--- a/third_party/xla/xla/hlo/analysis/while_loop_analysis.cc
+++ b/third_party/xla/xla/hlo/analysis/while_loop_analysis.cc
@@ -891,7 +891,12 @@ optional<int64_t> MatchTrivialLoopTripCount(const HloInstruction* while_op,
     if (*trips < 0) {
       return 0;
     }
-    return *trips / trip_count_step + 1;
+    optional<int64_t> trip_count = CheckedAdd(*trips / trip_count_step, 1);
+    if (!trip_count) {
+      VLOG(2) << "Pattern-match failed: Trip count exceeds INT64_MAX";
+      return nullopt;
+    }
+    return *trip_count;
   }
 
   VLOG(2) << "Pattern-match failed: while condition follows unknown pattern: "

--- a/third_party/xla/xla/hlo/analysis/while_loop_analysis.cc
+++ b/third_party/xla/xla/hlo/analysis/while_loop_analysis.cc
@@ -16,7 +16,6 @@ limitations under the License.
 #include "xla/hlo/analysis/while_loop_analysis.h"
 
 #include <algorithm>
-#include <cmath>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -864,15 +863,23 @@ optional<int64_t> MatchTrivialLoopTripCount(const HloInstruction* while_op,
       VLOG(2) << "Pattern-match failed: Trip count exceeds INT64_MAX.";
       return nullopt;
     }
+    // The loop does not execute at all if N <= init.
     if (*trips <= 0) {
       return 0;
     }
-    trips = CheckedAdd(*trips, trip_count_step - 1);
-    if (!trips) {
+    // Trip count is ceil((N - init) / k). Compute it as
+    // (N - init - 1) / k + 1 to avoid the overflow that
+    // (N - init + k - 1) / k can hit when N - init is close to INT64_MAX.
+    // Here *trips >= 1, so (*trips - 1) is safe and the division result is
+    // at most *trips - 1, so adding 1 cannot overflow; use CheckedAdd anyway
+    // for uniformity.
+    optional<int64_t> trip_count =
+        CheckedAdd((*trips - 1) / trip_count_step, 1);
+    if (!trip_count) {
       VLOG(2) << "Pattern-match failed: Trip count exceeds INT64_MAX.";
       return nullopt;
     }
-    return *trips / trip_count_step;
+    return *trip_count;
   }
 
   // Handle `i = init; i <= N; i+=k`.
@@ -888,9 +895,12 @@ optional<int64_t> MatchTrivialLoopTripCount(const HloInstruction* while_op,
       VLOG(2) << "Pattern-match failed: Trip count exceeds INT64_MAX";
       return nullopt;
     }
+    // The loop does not execute at all if N < init.
     if (*trips < 0) {
       return 0;
     }
+    // Trip count is floor((N - init) / k) + 1. Integer division of
+    // non-negative values already floors, and CheckedAdd guards the +1.
     optional<int64_t> trip_count = CheckedAdd(*trips / trip_count_step, 1);
     if (!trip_count) {
       VLOG(2) << "Pattern-match failed: Trip count exceeds INT64_MAX";

--- a/third_party/xla/xla/hlo/analysis/while_loop_analysis_test.cc
+++ b/third_party/xla/xla/hlo/analysis/while_loop_analysis_test.cc
@@ -356,6 +356,18 @@ TEST_F(WhileLoopAnalysisTest, ExactBoundTrivialTripCount) {
   EXPECT_EQ(
       MakeWhileLoopAndGetTripCount(0, 40, 5, ComparisonDirection::kLt).value(),
       CalculateTripCount(0, 40, 5, ComparisonDirection::kLt));
+  // Verify small limits and large steps.
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(0, 1, 5, ComparisonDirection::kLt).value(),
+      CalculateTripCount(0, 1, 5, ComparisonDirection::kLt));
+  // Verify negative limits/init.
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(-10, 0, 3, ComparisonDirection::kLt).value(),
+      CalculateTripCount(-10, 0, 3, ComparisonDirection::kLt));
+  // Verify zero iterations.
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(6, 5, 5, ComparisonDirection::kLt).value(),
+      CalculateTripCount(6, 5, 5, ComparisonDirection::kLt));
 
   // LE cases
   EXPECT_EQ(
@@ -370,6 +382,14 @@ TEST_F(WhileLoopAnalysisTest, ExactBoundTrivialTripCount) {
   EXPECT_EQ(
       MakeWhileLoopAndGetTripCount(0, 40, 5, ComparisonDirection::kLe).value(),
       CalculateTripCount(0, 40, 5, ComparisonDirection::kLe));
+  // Verify negative limits/init.
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(-10, 0, 3, ComparisonDirection::kLe).value(),
+      CalculateTripCount(-10, 0, 3, ComparisonDirection::kLe));
+  // Verify zero iterations.
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(6, 5, 5, ComparisonDirection::kLe).value(),
+      CalculateTripCount(6, 5, 5, ComparisonDirection::kLe));
 }
 
 // Regression test for a bug where a non-divisible step combined with a small

--- a/third_party/xla/xla/hlo/analysis/while_loop_analysis_test.cc
+++ b/third_party/xla/xla/hlo/analysis/while_loop_analysis_test.cc
@@ -372,6 +372,48 @@ TEST_F(WhileLoopAnalysisTest, ExactBoundTrivialTripCount) {
       CalculateTripCount(0, 40, 5, ComparisonDirection::kLe));
 }
 
+// Regression test for a bug where a non-divisible step combined with a small
+// loop bound caused the trip count to be undercounted (often to zero), which
+// made the simplify-while-loop pass incorrectly fold an integer while loop to
+// its initial value. See https://github.com/tensorflow/tensorflow/issues/123067
+// The cases below are miscounted by the old kLt/kLe logic but must match the
+// reference `CalculateTripCount` implementation.
+TEST_F(WhileLoopAnalysisTest, NonDivisibleStepDoesNotUndercount) {
+  // kLt cases. The old code returned 0 for these single-iteration loops (i < N
+  // with N <= step), folding the loop to its initial value.
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(0, 1, 2, ComparisonDirection::kLt).value(),
+      CalculateTripCount(0, 1, 2, ComparisonDirection::kLt));
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(0, 1, 3, ComparisonDirection::kLt).value(),
+      CalculateTripCount(0, 1, 3, ComparisonDirection::kLt));
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(0, 1, 5, ComparisonDirection::kLt).value(),
+      CalculateTripCount(0, 1, 5, ComparisonDirection::kLt));
+  // kLt cases with a negative init that the old code undercounted to a nonzero
+  // but still-wrong value.
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(-2, 1, 2, ComparisonDirection::kLt).value(),
+      CalculateTripCount(-2, 1, 2, ComparisonDirection::kLt));
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(1, 10, 3, ComparisonDirection::kLt).value(),
+      CalculateTripCount(1, 10, 3, ComparisonDirection::kLt));
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(0, 7, 2, ComparisonDirection::kLt).value(),
+      CalculateTripCount(0, 7, 2, ComparisonDirection::kLt));
+
+  // kLe cases with a non-divisible step.
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(0, 1, 2, ComparisonDirection::kLe).value(),
+      CalculateTripCount(0, 1, 2, ComparisonDirection::kLe));
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(0, 10, 3, ComparisonDirection::kLe).value(),
+      CalculateTripCount(0, 10, 3, ComparisonDirection::kLe));
+  EXPECT_EQ(
+      MakeWhileLoopAndGetTripCount(2, 2, 5, ComparisonDirection::kLe).value(),
+      CalculateTripCount(2, 2, 5, ComparisonDirection::kLe));
+}
+
 TEST_F(WhileLoopAnalysisTest, NoAIVNoConstChain) {
   absl::string_view kHloModule = R"(
     HloModule ModuleWithWhile


### PR DESCRIPTION
### Description
This PR fixes an issue where XLA's `simplify-while-loops` pass incorrectly folds an integer `tf.while_loop` to its initial value. 
The root cause was buggy integer arithmetic in `MatchTrivialLoopTripCount` in `xla/hlo/analysis/while_loop_analysis.cc` for both `i < N` (`kLt`) and `i <= N` (`kLe`) comparison directions.
The old implementation mistakenly used `std::remainder` and `std::floor` on integer division limits, and applied an incorrect sanity check comparing the calculated trip count directly with the loop bound limit, returning `0` incorrectly for valid loops.

### Fixes
- `kLt` (`i < N`): Correctly calculates `ceil((N - init) / k)` as `(N - init + k - 1) / k` for valid ranges.
- `kLe` (`i <= N`): Correctly calculates `floor((N - init) / k) + 1` for ranges where `N >= init` and defaults to `0` otherwise.

Fixes #123067.
