### PR TITLE
Fix as string segfault

### DIFF
--- a/tensorflow/core/kernels/as_string_op.cc
+++ b/tensorflow/core/kernels/as_string_op.cc
@@ -56,6 +56,15 @@ class AsStringOp : public OpKernel {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("shortest", &shortest));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("width", &width_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("fill", &fill_string));
+    constexpr int64_t kMaxPaddingSize = 131072;
+    OP_REQUIRES(ctx, width_ >= -kMaxPaddingSize && width_ <= kMaxPaddingSize,
+                absl::InvalidArgumentError(
+                    absl::StrCat("width must be between -", kMaxPaddingSize,
+                                 " and ", kMaxPaddingSize, ", got ", width_)));
+    OP_REQUIRES(ctx, precision_ >= -kMaxPaddingSize && precision_ <= kMaxPaddingSize,
+                absl::InvalidArgumentError(
+                    absl::StrCat("precision must be between -", kMaxPaddingSize,
+                                 " and ", kMaxPaddingSize, ", got ", precision_)));
     if (dtype != DT_STRING && !DataTypeIsFloating(dtype) &&
         !DataTypeIsComplex(dtype)) {
       OP_REQUIRES(ctx, !(scientific || shortest),

--- a/tensorflow/core/kernels/as_string_op_test.cc
+++ b/tensorflow/core/kernels/as_string_op_test.cc
@@ -366,5 +366,25 @@ TEST_F(AsStringGraphTest, StringWidth) {
   test::ExpectTensorEqual<tstring>(expected, *GetOutput(0));
 }
 
+TEST_F(AsStringGraphTest, WidthTooLarge) {
+  absl::Status s = Init(DT_INT32, /*fill=*/"", /*width=*/200000);
+  ASSERT_EQ(error::INVALID_ARGUMENT, s.code());
+  ASSERT_TRUE(absl::StrContains(s.message(), "width must be between -131072 and 131072"));
+
+  s = Init(DT_INT32, /*fill=*/"", /*width=*/-200000);
+  ASSERT_EQ(error::INVALID_ARGUMENT, s.code());
+  ASSERT_TRUE(absl::StrContains(s.message(), "width must be between -131072 and 131072"));
+}
+
+TEST_F(AsStringGraphTest, PrecisionTooLarge) {
+  absl::Status s = Init(DT_FLOAT, /*fill=*/"", /*width=*/-1, /*precision=*/200000);
+  ASSERT_EQ(error::INVALID_ARGUMENT, s.code());
+  ASSERT_TRUE(absl::StrContains(s.message(), "precision must be between -131072 and 131072"));
+
+  s = Init(DT_FLOAT, /*fill=*/"", /*width=*/-1, /*precision=*/-200000);
+  ASSERT_EQ(error::INVALID_ARGUMENT, s.code());
+  ASSERT_TRUE(absl::StrContains(s.message(), "precision must be between -131072 and 131072"));
+}
+
 }  // end namespace
 }  // end namespace tensorflow

--- a/tensorflow/python/ops/summary_ops_v2.py
+++ b/tensorflow/python/ops/summary_ops_v2.py
@@ -1082,8 +1082,8 @@ def graph(graph_data):
 
   @tf.function
   def f():
-    x = constant_op.constant(2)
-    y = constant_op.constant(3)
+    x = tf.constant(2)
+    y = tf.constant(3)
     return x**y
 
   with writer.as_default():


### PR DESCRIPTION
### PR Description
#### Goal
This pull request fixes a segmentation fault in tf.raw_ops.AsString (reported in Issue #105292) that occurs when calling the operator with excessively large width or precision values (such as INT_MAX).
#### Cause
In AsStringOp's C++ constructor (tensorflow/core/kernels/as_string_op.cc), the format string template (e.g., "%*.*g") is parsed and passed to absl::StrFormat. If the attributes width or precision are configured to be extremely large, absl::StrFormat attempts to allocate a formatted string of that size, triggering out-of-memory crashes or segmentation faults.
#### Proposed Changes
- Added validation constraints to the constructor of AsStringOp in tensorflow/core/kernels/as_string_op.cc to ensure that both width_ and precision_ are <= 131072 (128 KB).
- Returning absl::InvalidArgumentError via OP_REQUIRES if either constraint is violated.
- Added new C++ unit tests (WidthTooLarge and PrecisionTooLarge) in tensorflow/core/kernels/as_string_op_test.cc to cover these constraints.
#### Verification
- Run unit tests locally or on CI:
  bazel test //tensorflow/core/kernels:as_string_op_test
Closes #105292