### PR TITLE
check sparse indices and values row counts in ragged cross

### DIFF
--- a/tensorflow/core/kernels/ragged_cross_op.cc
+++ b/tensorflow/core/kernels/ragged_cross_op.cc
@@ -410,6 +410,13 @@ class RaggedCrossOp : public OpKernel {
         return absl::InvalidArgumentError(
             "tf.ragged.cross only supports inputs with rank=2.");
       }
+      if (sparse_indices_list[i].shape().dim_size(0) !=
+          sparse_values_list[i].shape().dim_size(0)) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "Expected size of values to be ",
+            sparse_indices_list[i].shape().dim_size(0), " got ",
+            sparse_values_list[i].shape().dim_size(0), " at position ", i));
+      }
     }
     for (int i = 0; i < dense_list.size(); ++i) {
       if (!TensorShapeUtils::IsMatrix(dense_list[i].shape())) {

--- a/tensorflow/python/ops/ragged/ragged_cross_op_test.py
+++ b/tensorflow/python/ops/ragged/ragged_cross_op_test.py
@@ -446,6 +446,26 @@ class RaggedCrossOpTest(test_util.TensorFlowTestCase, parameterized.TestCase):
           out_values_type=dtypes.string,
           out_row_splits_type=dtypes.int64))
 
+  def testSparseIndicesAndValuesRowCountMustMatch(self):
+    # A sparse input whose values are longer than its indices matrix used to
+    # walk the indices tensor out of bounds while building the row splits.
+    with self.assertRaisesRegex(
+        (ValueError, errors.InvalidArgumentError),
+        'Expected size of values'):
+      self.evaluate(gen_ragged_array_ops.RaggedCross(
+          ragged_values=[],
+          ragged_row_splits=[],
+          sparse_indices=[[[0, 0]]],
+          sparse_values=[['a', 'b', 'c']],
+          sparse_shape=[[1, 10]],
+          dense_inputs=[],
+          input_order='S',
+          hashed_output=False,
+          num_buckets=0,
+          hash_key=2,
+          out_values_type=dtypes.string,
+          out_row_splits_type=dtypes.int64))
+
   def testRaggedValuesAndSplitsMustMatch(self):
     with self.assertRaisesRegex(
         (ValueError, errors.InvalidArgumentError),


### PR DESCRIPTION
RaggedCross validates each sparse input's shapes but never checks that the indices matrix has as many rows as the values vector. SparseFeatureReader then advances its value index up to the values length while dereferencing indices(i, 0), so a sparse input whose values are longer than its indices reads past the end of the indices buffer while building the row splits. The sibling SparseCross op already enforces this in its own ValidateInput, so add the same length check here.