### PR TITLE
Pin two GitHub Actions to full commit SHAs in write-scoped workflows

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Validate Gemini Review Trigger
         run: |

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   scan-scheduled:
     if: github.repository == 'tensorflow/tensorflow'
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.1"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@375a0e8ebdc98e99b02ac4338a724f5750f21213" # v2.3.1
     with:
       scan-args: |-
         --lockfile=requirements.txt:./requirements_lock_3_9.txt


### PR DESCRIPTION
Two GitHub Actions references were still on mutable tags in jobs that hold write permissions, while the rest of the repo pins external actions to full commit SHAs:

| workflow | action | job permission |
| --- | --- | --- |
| `.github/workflows/gemini.yml` (line 33) | `actions/checkout@v4` | `pull-requests: write` |
| `.github/workflows/osv-scanner-scheduled.yml` (line 31) | `osv-scanner-reusable.yml@v2.3.1` | `security-events: write` |

A mutable tag can be repointed by whoever controls it (as in the `tj-actions/changed-files` incident), so a compromise would run in these write-scoped jobs. This pins both to the SHA the tag currently resolves to, with the version in a trailing comment — the same convention used across the repo's other workflows. No behavior change (same versions, pinned immutably).

```
actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
osv-scanner-reusable.yml@375a0e8ebdc98e99b02ac4338a724f5750f21213 # v2.3.1
```

2 files, 2 lines.

<sub>I used an AI assistant to find these and resolve the SHAs; I verified each SHA against the action's tag and read the diff myself.</sub>
