### PR TITLE
security/fuzzing: add TFLite model load + interpreter invoke fuzz target

### DIFF
--- a/tensorflow/security/fuzzing/cc/BUILD
+++ b/tensorflow/security/fuzzing/cc/BUILD
@@ -253,3 +253,12 @@ tf_cc_fuzz_test(
         "@xla//xla/tsl/platform:env",
     ],
 )
+
+tf_cc_fuzz_test(
+    name = "tflite_interp_overflow_fuzz",
+    srcs = ["tflite_interp_overflow_fuzz.cc"],
+    deps = [
+        "//tensorflow/lite:framework",
+        "//tensorflow/lite/kernels:builtin_ops",
+    ],
+)

--- a/tensorflow/security/fuzzing/cc/tflite_interp_overflow_fuzz.cc
+++ b/tensorflow/security/fuzzing/cc/tflite_interp_overflow_fuzz.cc
@@ -1,0 +1,54 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// FuzzTest coverage for TFLite model loading, interpreter build, and invoke.
+// This exercises interpreter_builder.cc get_readonly_data / ParseTensors, which
+// perform an unchecked uint64 addition (offset + size > allocation_->bytes())
+// on attacker-controlled external-buffer offsets. On overflow the check is
+// bypassed and a wild pointer (allocation_->base() + offset) is used as tensor
+// data, which is dereferenced during Invoke. The OSS-Fuzz tensorflow build has
+// no TFLite target that reaches this path.
+
+#include <memory>
+#include <string>
+
+#include "fuzztest/fuzztest.h"
+#include "tensorflow/lite/core/interpreter.h"
+#include "tensorflow/lite/core/interpreter_builder.h"
+#include "tensorflow/lite/core/model_builder.h"
+#include "tensorflow/lite/kernels/register.h"
+
+namespace {
+
+void FuzzModelBuildAndInvoke(const std::string& model_bytes) {
+  auto model = tflite::FlatBufferModel::BuildFromBuffer(model_bytes.data(),
+                                                        model_bytes.size());
+  if (model == nullptr) return;
+
+  tflite::ops::builtin::BuiltinOpResolver resolver;
+  std::unique_ptr<tflite::Interpreter> interpreter;
+  if (tflite::InterpreterBuilder(*model, resolver)(&interpreter) != kTfLiteOk) {
+    return;
+  }
+  if (interpreter == nullptr) return;
+  if (interpreter->AllocateTensors() != kTfLiteOk) return;
+
+  // The unchecked external-offset arithmetic sets a wild read-only tensor
+  // pointer that is dereferenced here.
+  interpreter->Invoke();
+}
+FUZZ_TEST(TfliteInterpreterBuilder, FuzzModelBuildAndInvoke);
+
+}  // namespace

--- a/tensorflow/security/fuzzing/cc/tflite_interp_overflow_fuzz.cc
+++ b/tensorflow/security/fuzzing/cc/tflite_interp_overflow_fuzz.cc
@@ -21,6 +21,7 @@ limitations under the License.
 // data, which is dereferenced during Invoke. The OSS-Fuzz tensorflow build has
 // no TFLite target that reaches this path.
 
+#include <cstring>
 #include <memory>
 #include <string>
 

--- a/tensorflow/security/fuzzing/cc/tflite_interp_overflow_fuzz.cc
+++ b/tensorflow/security/fuzzing/cc/tflite_interp_overflow_fuzz.cc
@@ -46,6 +46,14 @@ void FuzzModelBuildAndInvoke(const std::string& model_bytes) {
   if (interpreter == nullptr) return;
   if (interpreter->AllocateTensors() != kTfLiteOk) return;
 
+  // Zero-initialize runtime inputs so MSan does not flag uninitialized reads.
+  for (int input_index : interpreter->inputs()) {
+    TfLiteTensor* tensor = interpreter->tensor(input_index);
+    if (tensor != nullptr && tensor->data.raw != nullptr) {
+      std::memset(tensor->data.raw, 0, tensor->bytes);
+    }
+  }
+
   // The unchecked external-offset arithmetic sets a wild read-only tensor
   // pointer that is dereferenced here.
   interpreter->Invoke();


### PR DESCRIPTION
### What
Adds a FuzzTest target under `tensorflow/security/fuzzing/cc/` that loads a serialized `.tflite` model, builds an interpreter with the builtin op resolver, allocates tensors, and invokes. The OSS-Fuzz `tensorflow` build currently has no target that reaches TFLite model load / interpreter build / invoke, so this path is unfuzzed upstream.

### Why
`FlatBufferModel` -> `InterpreterBuilder` -> `AllocateTensors` -> `Invoke` parses attacker-supplied model structure, including external-buffer descriptors handled in `interpreter_builder.cc` (`get_readonly_data` / `ParseTensors`). That path performs a `uint64` `offset + size` addition and compares it against `allocation_->bytes()`. Adding coverage here lets OSS-Fuzz continuously exercise external-offset handling, tensor wiring, and builtin-kernel eval on malformed models, which is a class of input the existing core fuzzers do not reach.

### Change
One new file plus a `tf_cc_fuzz_test` entry in `security/fuzzing/cc/BUILD`:

```python
tf_cc_fuzz_test(
    name = "tflite_interp_overflow_fuzz",
    srcs = ["tflite_interp_overflow_fuzz.cc"],
    deps = [
        "//tensorflow/lite:framework",
        "//tensorflow/lite/kernels:builtin_ops",
    ],
)
```

The target uses only the public `//tensorflow/lite:framework` and `//tensorflow/lite/kernels:builtin_ops`, so no visibility changes are needed. The BUILD already loads `tf_cc_fuzz_test` (sibling targets use it). The harness returns early on any non-OK status so benign malformed inputs are not treated as findings; only a genuine memory-safety violation surfaces as a crash.

### Notes for review
- Dep closure is the public framework + builtin ops; if CI's linker wants a narrower or additional core target for the `tensorflow/lite/core/*` headers, I will adjust to match.
- Happy to add a seed corpus entry in a follow-up if the fuzzing infra owners prefer a seeded start.