### PR TITLE
Support int32 argmax in CPU MaxPool gradients

### DIFF
--- a/tensorflow/core/kernels/maxpooling_op.cc
+++ b/tensorflow/core/kernels/maxpooling_op.cc
@@ -1056,11 +1056,11 @@ class MaxPoolingWithArgmaxOp : public OpKernel {
   bool include_batch_in_index_;
 };
 
-template <typename Device, typename T>
+template <typename Device, typename T, typename Targmax>
 struct LaunchMaxPoolingGradWithArgmax;
 
-template <typename T>
-struct LaunchMaxPoolingGradWithArgmax<CPUDevice, T> {
+template <typename T, typename Targmax>
+struct LaunchMaxPoolingGradWithArgmax<CPUDevice, T, Targmax> {
   typedef Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>>
       EigenMatrixMap;
 
@@ -1080,7 +1080,7 @@ struct LaunchMaxPoolingGradWithArgmax<CPUDevice, T> {
 
       {
         auto grad_out_flat = grad_out->flat<T>();
-        auto argmax_flat = argmax.flat<int64_t>();
+        auto argmax_flat = argmax.flat<Targmax>();
         auto grad_in_flat = grad_in.flat<T>();
 
         const int64_t output_start = start * output_size_per_batch;
@@ -1116,8 +1116,7 @@ struct LaunchMaxPoolingGradWithArgmax<CPUDevice, T> {
   }
 };
 
-// TODO(b/175733711): Support int32 argmax type in MaxPoolGradWithArgmax op.
-template <typename Device, typename T>
+template <typename Device, typename T, typename Targmax>
 class MaxPoolingGradWithArgmaxOp : public OpKernel {
  public:
   explicit MaxPoolingGradWithArgmaxOp(OpKernelConstruction* context)
@@ -1195,7 +1194,7 @@ class MaxPoolingGradWithArgmaxOp : public OpKernel {
 
     if (out_shape.num_elements() == 0) return;  // nothing to be done
 
-    LaunchMaxPoolingGradWithArgmax<Device, T>::launch(
+    LaunchMaxPoolingGradWithArgmax<Device, T, Targmax>::launch(
         context, params, grad_in, argmax, grad_out, include_batch_in_index_);
   }
 
@@ -1529,7 +1528,7 @@ struct LaunchMaxPoolingWithArgmax<Eigen::GpuDevice, T, int64_t> {
 };
 
 template <typename T>
-struct LaunchMaxPoolingGradWithArgmax<Eigen::GpuDevice, T> {
+struct LaunchMaxPoolingGradWithArgmax<Eigen::GpuDevice, T, int64_t> {
   static void launch(OpKernelContext* context, const PoolParameters& params,
                      const Tensor& grad_in, const Tensor& argmax,
                      Tensor* grad_out, const bool include_batch_in_index) {
@@ -1605,21 +1604,26 @@ struct LaunchMaxPoolingGradGradWithArgmax<Eigen::GpuDevice, T> {
                               .Device(DEVICE_##D)                        \
                               .TypeConstraint<T>("T")                    \
                               .TypeConstraint<int64_t>("Targmax"),       \
-                          MaxPoolingGradWithArgmaxOp<D##Device, T>);
+                          MaxPoolingGradWithArgmaxOp<D##Device, T, int64_t>);
 
 // Below kernels implemented only for CPU device.
-#define REGISTER_CPU_ONLY_POOL_KERNELS(T)                          \
-  REGISTER_KERNEL_BUILDER(                                         \
-      Name("MaxPool").Device(DEVICE_CPU).TypeConstraint<T>("T"),   \
-      MaxPoolingOp<CPUDevice, T>);                                 \
-  REGISTER_KERNEL_BUILDER(                                         \
-      Name("MaxPoolV2").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
-      MaxPoolingV2Op<CPUDevice, T>);                               \
-  REGISTER_KERNEL_BUILDER(Name("MaxPoolWithArgmax")                \
-                              .Device(DEVICE_CPU)                  \
-                              .TypeConstraint<int32>("Targmax")    \
-                              .TypeConstraint<T>("T"),             \
-                          MaxPoolingWithArgmaxOp<CPUDevice, T, int32>);
+#define REGISTER_CPU_ONLY_POOL_KERNELS(T)                               \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("MaxPool").Device(DEVICE_CPU).TypeConstraint<T>("T"),        \
+      MaxPoolingOp<CPUDevice, T>);                                      \
+  REGISTER_KERNEL_BUILDER(                                              \
+      Name("MaxPoolV2").Device(DEVICE_CPU).TypeConstraint<T>("T"),      \
+      MaxPoolingV2Op<CPUDevice, T>);                                    \
+  REGISTER_KERNEL_BUILDER(Name("MaxPoolWithArgmax")                     \
+                              .Device(DEVICE_CPU)                       \
+                              .TypeConstraint<int32>("Targmax")         \
+                              .TypeConstraint<T>("T"),                  \
+                          MaxPoolingWithArgmaxOp<CPUDevice, T, int32>); \
+  REGISTER_KERNEL_BUILDER(Name("MaxPoolGradWithArgmax")                 \
+                              .Device(DEVICE_CPU)                       \
+                              .TypeConstraint<T>("T")                   \
+                              .TypeConstraint<int32>("Targmax"),        \
+                          MaxPoolingGradWithArgmaxOp<CPUDevice, T, int32>);
 TF_CALL_REAL_NUMBER_TYPES(REGISTER_CPU_ONLY_POOL_KERNELS);
 #undef REGISTER_CPU_ONLY_POOL_KERNELS
 

--- a/tensorflow/python/kernel_tests/nn_ops/pooling_ops_test.py
+++ b/tensorflow/python/kernel_tests/nn_ops/pooling_ops_test.py
@@ -1091,12 +1091,14 @@ class PoolingTest(test.TestCase, parameterized.TestCase):
     tensor_input = [11.0, 12.0, 13.0, 14.0, 21.0, 22.0, 23.0, 24.0]
 
     Config = collections.namedtuple(
-        "Config", ["use_gpu", "include_batch_in_index", "argmax"])
+        "Config", ["use_gpu", "include_batch_in_index", "argmax", "Targmax"])
     configs = [
-        Config(False, False, [0, 1, 3, 5, 0, 2, 6, 8]),
-        Config(False, True, [0, 1, 3, 5, 9, 11, 15, 17]),
-        Config(True, False, [0, 1, 3, 5, 0, 2, 6, 8]),
-        Config(True, True, [0, 1, 3, 5, 9, 11, 15, 17])
+        Config(False, False, [0, 1, 3, 5, 0, 2, 6, 8], dtypes.int64),
+        Config(False, True, [0, 1, 3, 5, 9, 11, 15, 17], dtypes.int64),
+        Config(False, False, [0, 1, 3, 5, 0, 2, 6, 8], dtypes.int32),
+        Config(False, True, [0, 1, 3, 5, 9, 11, 15, 17], dtypes.int32),
+        Config(True, False, [0, 1, 3, 5, 0, 2, 6, 8], dtypes.int64),
+        Config(True, True, [0, 1, 3, 5, 9, 11, 15, 17], dtypes.int64),
     ]
 
     for config in configs:
@@ -1104,7 +1106,7 @@ class PoolingTest(test.TestCase, parameterized.TestCase):
         orig_in = constant_op.constant(orig_input, shape=[2, 3, 3, 1])
         t = constant_op.constant(tensor_input, shape=[2, 2, 2, 1])
         argmax_t = constant_op.constant(
-            config.argmax, shape=[2, 2, 2, 1], dtype=dtypes.int64)
+            config.argmax, shape=[2, 2, 2, 1], dtype=config.Targmax)
         out_op = gen_nn_ops.max_pool_grad_with_argmax(
             orig_in,
             t,


### PR DESCRIPTION
Fixes #103454

`MaxPoolWithArgmax` already supports `output_dtype=tf.int32` on CPU, but its gradient only registered an int64 argmax kernel. This caused automatic differentiation to fail with “No OpKernel was registered” when users selected int32 output indices.

Template the CPU gradient implementation on the argmax dtype, register the existing CPU gradient for `Targmax=int32`, and extend the pooling gradient test matrix to validate both int32 and int64 CPU argmax tensors. GPU remains unchanged because its forward argmax kernel only supports int64.

Validation: `git diff --check`; `python3 -m py_compile tensorflow/python/kernel_tests/nn_ops/pooling_ops_test.py`; `bazel build --config=macos_arm64 //tensorflow/core/kernels:pooling_ops` is running locally.