### PR TITLE
Exclude Reciprocal from Grappler involution simplification

### DIFF
--- a/tensorflow/core/grappler/op_types.cc
+++ b/tensorflow/core/grappler/op_types.cc
@@ -797,9 +797,14 @@ OPDEF_PROPERTY_HELPER(Aggregate, aggregate)
 OPDEF_PROPERTY_HELPER(Commutative, commutative)
 
 bool IsInvolution(const NodeDef& node) {
+  // An involution f satisfies f(f(x)) == x exactly, which lets a pair of them
+  // be cancelled without changing the result. Reciprocal is intentionally
+  // excluded: in floating point 1 / (1 / x) does not round-trip to x because
+  // the first reciprocal is already rounded, so eliminating the pair would
+  // alter the numerical output.
   static const gtl::FlatSet<std::string>* const kInvolutionOps =
       CHECK_NOTNULL((new gtl::FlatSet<std::string>{
-          "Conj", "Reciprocal", "Invert", "Neg", "LogicalNot"}));
+          "Conj", "Invert", "Neg", "LogicalNot"}));
   return kInvolutionOps->count(node.op()) > 0;
 }
 

--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
@@ -597,9 +597,7 @@ TEST_F(ArithmeticOptimizerTest, RemoveInvolutionAdjacentNodes) {
   auto c = ops::Const(s.WithOpName("c"), {1.0f, 2.0f}, {1, 2});
   auto neg1 = ops::Neg(s.WithOpName("neg1"), c);
   auto neg2 = ops::Neg(s.WithOpName("neg2"), neg1);
-  auto recip1 = ops::Reciprocal(s.WithOpName("recip1"), neg2);
-  auto recip2 = ops::Reciprocal(s.WithOpName("recip2"), recip1);
-  auto id = ops::Identity(s.WithOpName("id"), recip2);
+  auto id = ops::Identity(s.WithOpName("id"), neg2);
 
   GrapplerItem item;
   item.fetch = {"id"};
@@ -612,7 +610,7 @@ TEST_F(ArithmeticOptimizerTest, RemoveInvolutionAdjacentNodes) {
   EnableOnlyRemoveInvolution(&optimizer);
   OptimizeAndPrune(&optimizer, &item, &output);
 
-  // Negation and Reciprocal nodes cancelled each other.
+  // The two adjacent Neg nodes cancelled each other.
   ASSERT_EQ(output.node_size(), 2);
   EXPECT_EQ(output.node(1).name(), "id");
   ASSERT_EQ(output.node(1).input_size(), 1);
@@ -627,11 +625,11 @@ TEST_F(ArithmeticOptimizerTest, RemoveInvolutionAroundValuePreservingChain) {
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
 
   auto c = ops::Const(s.WithOpName("c"), {1.0f, 2.0f}, {1, 2});
-  auto recip1 = ops::Reciprocal(s.WithOpName("recip1"), c);
-  auto id1 = ops::Identity(s.WithOpName("id1"), recip1);
+  auto neg1 = ops::Neg(s.WithOpName("neg1"), c);
+  auto id1 = ops::Identity(s.WithOpName("id1"), neg1);
   auto squeeze = ops::Squeeze(s.WithOpName("squeeze"), id1);
-  auto recip2 = ops::Reciprocal(s.WithOpName("recip2"), squeeze);
-  auto id2 = ops::Identity(s.WithOpName("id2"), recip2);
+  auto neg2 = ops::Neg(s.WithOpName("neg2"), squeeze);
+  auto id2 = ops::Identity(s.WithOpName("id2"), neg2);
 
   std::vector<std::string> fetch = {"id2"};
 
@@ -646,7 +644,7 @@ TEST_F(ArithmeticOptimizerTest, RemoveInvolutionAroundValuePreservingChain) {
   EnableOnlyRemoveInvolution(&optimizer);
   OptimizeTwiceAndPrune(&optimizer, &item, &output);
 
-  // Check that Reciprocal nodes were removed from the graph.
+  // Check that the Neg nodes were removed from the graph.
   EXPECT_EQ(output.node_size(), 3);
 
   // And const directly flows into squeeze.
@@ -673,12 +671,12 @@ TEST_F(ArithmeticOptimizerTest, RemoveInvolutionSkipControlDependencies) {
   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
 
   auto c = ops::Const(s.WithOpName("c"), {1.0f, 2.0f}, {1, 2});
-  auto recip1 = ops::Reciprocal(s.WithOpName("recip1"), c);
-  auto id1 = ops::Identity(s.WithOpName("id1"), recip1);
+  auto neg1 = ops::Neg(s.WithOpName("neg1"), c);
+  auto id1 = ops::Identity(s.WithOpName("id1"), neg1);
   auto squeeze = ops::Squeeze(s.WithOpName("squeeze"), id1);
-  auto recip2 = ops::Reciprocal(
-      s.WithOpName("recip2").WithControlDependencies(squeeze), c);
-  auto id2 = ops::Identity(s.WithOpName("id2"), recip2);
+  auto neg2 = ops::Neg(
+      s.WithOpName("neg2").WithControlDependencies(squeeze), c);
+  auto id2 = ops::Identity(s.WithOpName("id2"), neg2);
 
   std::vector<std::string> fetch = {"id2"};
 
@@ -698,6 +696,36 @@ TEST_F(ArithmeticOptimizerTest, RemoveInvolutionSkipControlDependencies) {
   VerifyGraphsMatch(item.graph, output, __LINE__);
 
   auto tensors = EvaluateNodes(output, fetch);
+  ASSERT_EQ(tensors.size(), 1);
+  test::ExpectTensorNear<float>(tensors[0], tensors_expected[0], 1e-6);
+}
+
+TEST_F(ArithmeticOptimizerTest, DoNotRemoveReciprocalInvolution) {
+  tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+
+  // reciprocal(reciprocal(x)) is not the identity in floating point: the first
+  // reciprocal is already rounded, so the second cannot recover x exactly.
+  // The two ops must therefore survive the involution removal pass.
+  auto c = ops::Const(s.WithOpName("c"), {1.0f, 2.0f, 7.0f}, {1, 3});
+  auto recip1 = ops::Reciprocal(s.WithOpName("recip1"), c);
+  auto recip2 = ops::Reciprocal(s.WithOpName("recip2"), recip1);
+  auto id = ops::Identity(s.WithOpName("id"), recip2);
+
+  GrapplerItem item;
+  item.fetch = {"id"};
+  TF_CHECK_OK(s.ToGraphDef(&item.graph));
+  auto tensors_expected = EvaluateNodes(item.graph, item.fetch);
+  ASSERT_EQ(tensors_expected.size(), 1);
+
+  GraphDef output;
+  ArithmeticOptimizer optimizer;
+  EnableOnlyRemoveInvolution(&optimizer);
+  OptimizeTwice(&optimizer, &item, &output);
+
+  // Both Reciprocal nodes are preserved.
+  VerifyGraphsMatch(item.graph, output, __LINE__);
+
+  auto tensors = EvaluateNodes(output, item.fetch);
   ASSERT_EQ(tensors.size(), 1);
   test::ExpectTensorNear<float>(tensors[0], tensors_expected[0], 1e-6);
 }

--- a/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
+++ b/tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc
@@ -727,7 +727,10 @@ TEST_F(ArithmeticOptimizerTest, DoNotRemoveReciprocalInvolution) {
 
   auto tensors = EvaluateNodes(output, item.fetch);
   ASSERT_EQ(tensors.size(), 1);
-  test::ExpectTensorNear<float>(tensors[0], tensors_expected[0], 1e-6);
+  // The graphs are identical, so the results must match bitwise. A tolerance
+  // here (e.g. 1e-6) would be looser than the ~5e-7 rounding error for 7.0f and
+  // would fail to catch the involution being incorrectly applied.
+  test::ExpectTensorEqual<float>(tensors[0], tensors_expected[0]);
 }
 
 TEST_F(ArithmeticOptimizerTest, TrivialSumsSimple) {


### PR DESCRIPTION
## Summary

Grappler's `ArithmeticOptimizer` `RemoveInvolution` stage cancels pairs of ops that are mathematical involutions (`f(f(x)) == x`). `Reciprocal` was in this set, but floating-point reciprocal is **not** an exact involution: `1 / (1 / x)` does not round-trip to `x` because the first reciprocal is already rounded.

As a result, `tf.math.reciprocal(tf.math.reciprocal(x))` inside a `tf.function` silently returned the exact original value instead of the correctly rounded result, diverging from eager execution:

```
reciprocal(7.0)           = 0.14285714...
reciprocal(0.14285714...) = 6.9999995   != 7.0
```

## Changes

- **`tensorflow/core/grappler/op_types.cc`** — remove `Reciprocal` from the op set in `IsInvolution`. The remaining entries (`Conj`, `Invert`, `Neg`, `LogicalNot`) are all exact involutions. Added a comment documenting the reasoning.
- **`tensorflow/core/grappler/optimizers/arithmetic_optimizer_test.cc`** — the three existing `RemoveInvolution*` tests used `Reciprocal` as their example involution; switched them to `Neg`, a float-safe exact involution. Added `DoNotRemoveReciprocalInvolution`, which asserts the pass leaves `reciprocal(reciprocal(x))` unchanged.

Fixes #119429.