### PR TITLE
Remove incorrect TF_Involution trait from tf.Reciprocal

### DIFF
--- a/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
+++ b/tensorflow/compiler/mlir/tensorflow/ir/tf_generated_ops.td
@@ -12716,30 +12716,6 @@ If `x` and `y` are reals, this will return the floating-point division.
   let hasFolder = 1;
 }
 
-def TF_ReciprocalOp : TF_Op<"Reciprocal", [Pure, TF_Involution, TF_SameOperandsAndResultTypeResolveRef]> {
-  let summary = "Computes the reciprocal of x element-wise.";
-
-  let description = [{
-I.e., \\(y = 1 / x\\).
-  }];
-
-  let arguments = (ins
-    TensorOf<[TF_Bfloat16, TF_Complex128, TF_Complex64, TF_Float16, TF_Float32, TF_Float64, TF_Int16, TF_Int32, TF_Int64, TF_Int8]>:$x
-  );
-
-  let results = (outs
-    TensorOf<[TF_Bfloat16, TF_Complex128, TF_Complex64, TF_Float16, TF_Float32, TF_Float64, TF_Int16, TF_Int32, TF_Int64, TF_Int8]>:$y
-  );
-
-  TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
-
-  let extraClassDeclaration = [{
-    static bool isCompatibleReturnTypes(TypeRange inferred, TypeRange actual) {
-      return ArraysAreCastCompatible(inferred, actual);
-    }
-  }];
-}
-
 def TF_ReciprocalGradOp : TF_Op<"ReciprocalGrad", [Pure, TF_SameOperandsAndResultTypeResolveRef]> {
   let summary = "Computes the gradient for the inverse of `x` wrt its input.";
 

--- a/tensorflow/compiler/mlir/tensorflow/ir/tf_ops.td
+++ b/tensorflow/compiler/mlir/tensorflow/ir/tf_ops.td
@@ -3255,5 +3255,34 @@ def TF_XlaSparseGradientsStackOp : TF_Op<"XlaSparseGradientsStack", [Pure]> {
   TF_DerivedOperandTypeAttr input_dtype = TF_DerivedOperandTypeAttr<0>;
   TF_DerivedResultTypeAttr dtype = TF_DerivedResultTypeAttr<0>;
 }
+
+// Reciprocal deliberately does not carry the TF_Involution trait: it is not
+// an exact involution. In floating point 1 / (1 / x) does not round-trip to x
+// because the inner reciprocal is already rounded, and for integer types
+// 1 / x truncates to zero for |x| > 1, so folding a Reciprocal pair would
+// change the computed result.
+def TF_ReciprocalOp : TF_Op<"Reciprocal", [Pure, TF_SameOperandsAndResultTypeResolveRef]> {
+  let summary = "Computes the reciprocal of x element-wise.";
+
+  let description = [{
+I.e., \\(y = 1 / x\\).
+  }];
+
+  let arguments = (ins
+    TensorOf<[TF_Bfloat16, TF_Complex128, TF_Complex64, TF_Float16, TF_Float32, TF_Float64, TF_Int16, TF_Int32, TF_Int64, TF_Int8]>:$x
+  );
+
+  let results = (outs
+    TensorOf<[TF_Bfloat16, TF_Complex128, TF_Complex64, TF_Float16, TF_Float32, TF_Float64, TF_Int16, TF_Int32, TF_Int64, TF_Int8]>:$y
+  );
+
+  TF_DerivedOperandTypeAttr T = TF_DerivedOperandTypeAttr<0>;
+
+  let extraClassDeclaration = [{
+    static bool isCompatibleReturnTypes(TypeRange inferred, TypeRange actual) {
+      return ArraysAreCastCompatible(inferred, actual);
+    }
+  }];
+}
 #endif // TF_OPS
 

--- a/tensorflow/compiler/mlir/tensorflow/tests/canonicalize.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/canonicalize.mlir
@@ -565,13 +565,18 @@ func.func @testDoubleNeg(%arg0: tensor<8x16x32x64xi32>) -> tensor<8x16x32x64xi32
 // CHECK: return %arg0
 }
 
+// Reciprocal is not an exact involution (1 / (1 / x) rounds in floating
+// point and truncates to zero for integer |x| > 1), so a Reciprocal pair
+// must not fold away.
 // CHECK-LABEL: testDoubleReciprocal
 func.func @testDoubleReciprocal(%arg0: tensor<8x16x32x64xi32>) -> tensor<8x16x32x64xi32> {
   %0 = "tf.Reciprocal"(%arg0) : (tensor<8x16x32x64xi32>) -> tensor<8x16x32x64xi32>
   %1 = "tf.Reciprocal"(%0) : (tensor<8x16x32x64xi32>) -> tensor<8x16x32x64xi32>
   func.return %1: tensor<8x16x32x64xi32>
 
-// CHECK: return %arg0
+// CHECK: %[[RECIPROCAL0:.*]] = "tf.Reciprocal"(%arg0)
+// CHECK: %[[RECIPROCAL1:.*]] = "tf.Reciprocal"(%[[RECIPROCAL0]])
+// CHECK: return %[[RECIPROCAL1]]
 }
 
 // CHECK-LABEL: testRedundantReshape

--- a/tensorflow/compiler/mlir/tensorflow/tests/canonicalize.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/canonicalize.mlir
@@ -579,6 +579,17 @@ func.func @testDoubleReciprocal(%arg0: tensor<8x16x32x64xi32>) -> tensor<8x16x32
 // CHECK: return %[[RECIPROCAL1]]
 }
 
+// CHECK-LABEL: testDoubleReciprocalFloat
+func.func @testDoubleReciprocalFloat(%arg0: tensor<8x16x32x64xf32>) -> tensor<8x16x32x64xf32> {
+  %0 = "tf.Reciprocal"(%arg0) : (tensor<8x16x32x64xf32>) -> tensor<8x16x32x64xf32>
+  %1 = "tf.Reciprocal"(%0) : (tensor<8x16x32x64xf32>) -> tensor<8x16x32x64xf32>
+  func.return %1: tensor<8x16x32x64xf32>
+
+// CHECK: %[[RECIPROCAL0:.*]] = "tf.Reciprocal"(%arg0)
+// CHECK: %[[RECIPROCAL1:.*]] = "tf.Reciprocal"(%[[RECIPROCAL0]])
+// CHECK: return %[[RECIPROCAL1]]
+}
+
 // CHECK-LABEL: testRedundantReshape
 func.func @testRedundantReshape(%arg0: tensor<4x4xi32>) -> tensor<2x8xi32> {
   %0 = "tf.Const"() {value = dense<[8, 2]> : tensor<2xi32>} : () -> tensor<2xi32>

--- a/tensorflow/compiler/mlir/tensorflow/tests/tf_trait_folds.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/tf_trait_folds.mlir
@@ -65,6 +65,17 @@ func.func @testTripleReciprocal(%arg0: tensor<i32>) -> tensor<i32> {
   func.return %2: tensor<i32>
 }
 
+// CHECK-LABEL: func @testDoubleReciprocalFloat
+// CHECK-SAME:  ([[ARG0:%.+]]: tensor<f32>)
+func.func @testDoubleReciprocalFloat(%arg0: tensor<f32>) -> tensor<f32> {
+  // CHECK: [[RECIPROCAL0:%.+]] = "tf.Reciprocal"([[ARG0]])
+  %0 = "tf.Reciprocal"(%arg0) : (tensor<f32>) -> tensor<f32>
+  // CHECK: [[RECIPROCAL1:%.+]] = "tf.Reciprocal"([[RECIPROCAL0]])
+  %1 = "tf.Reciprocal"(%0) : (tensor<f32>) -> tensor<f32>
+  // CHECK: return [[RECIPROCAL1]]
+  func.return %1: tensor<f32>
+}
+
 // CHECK-LABEL: func @testSingleInvert
 // CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
 func.func @testSingleInvert(%arg0: tensor<i32>) -> tensor<i32> {

--- a/tensorflow/compiler/mlir/tensorflow/tests/tf_trait_folds.mlir
+++ b/tensorflow/compiler/mlir/tensorflow/tests/tf_trait_folds.mlir
@@ -38,23 +38,30 @@ func.func @testSingleReciprocal(%arg0: tensor<i32>) -> tensor<i32> {
   func.return %0: tensor<i32>
 }
 
+// Reciprocal is not an exact involution (1 / (1 / x) rounds in floating
+// point and truncates to zero for integer |x| > 1), so a Reciprocal pair
+// must not fold away.
 // CHECK-LABEL: func @testDoubleReciprocal
 // CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
 func.func @testDoubleReciprocal(%arg0: tensor<i32>) -> tensor<i32> {
+  // CHECK: [[RECIPROCAL0:%.+]] = "tf.Reciprocal"([[ARG0]])
   %0 = "tf.Reciprocal"(%arg0) : (tensor<i32>) -> tensor<i32>
+  // CHECK: [[RECIPROCAL1:%.+]] = "tf.Reciprocal"([[RECIPROCAL0]])
   %1 = "tf.Reciprocal"(%0) : (tensor<i32>) -> tensor<i32>
-  // CHECK: return [[ARG0]]
+  // CHECK: return [[RECIPROCAL1]]
   func.return %1: tensor<i32>
 }
 
 // CHECK-LABEL: func @testTripleReciprocal
 // CHECK-SAME:  ([[ARG0:%.+]]: tensor<i32>)
 func.func @testTripleReciprocal(%arg0: tensor<i32>) -> tensor<i32> {
-  // CHECK: [[RECIPROCAL:%.+]] = "tf.Reciprocal"([[ARG0]])
+  // CHECK: [[RECIPROCAL0:%.+]] = "tf.Reciprocal"([[ARG0]])
   %0 = "tf.Reciprocal"(%arg0) : (tensor<i32>) -> tensor<i32>
+  // CHECK: [[RECIPROCAL1:%.+]] = "tf.Reciprocal"([[RECIPROCAL0]])
   %1 = "tf.Reciprocal"(%0) : (tensor<i32>) -> tensor<i32>
+  // CHECK: [[RECIPROCAL2:%.+]] = "tf.Reciprocal"([[RECIPROCAL1]])
   %2 = "tf.Reciprocal"(%1) : (tensor<i32>) -> tensor<i32>
-  // CHECK: return [[RECIPROCAL]]
+  // CHECK: return [[RECIPROCAL2]]
   func.return %2: tensor<i32>
 }
 


### PR DESCRIPTION
## Summary

The MLIR TF dialect marks `tf.Reciprocal` with the `TF_Involution` trait, whose fold hook rewrites `Reciprocal(Reciprocal(x))` to `x`. Reciprocal is not an exact involution:

- In floating point, `1 / (1 / x)` does not round-trip to `x` because the inner reciprocal is already rounded (`reciprocal(reciprocal(7.0)) = 6.9999995`).
- For integer types, `1 / x` truncates to zero for `|x| > 1`, so `reciprocal(reciprocal(3))` is `0`, not `3`.

The fold silently changes computed results wherever the TF MLIR canonicalization pipeline runs. This is the MLIR counterpart of #123195, which fixed the same root cause (#119429) in Grappler's `RemoveInvolution` stage.

## Changes

- **`tf_generated_ops.td` / `tf_ops.td`** — drop `TF_Involution` from `TF_ReciprocalOp`. Per the generated file's header, the modified definition moves to `tf_ops.td`, with a comment documenting why the trait is absent. The remaining `TF_Involution` ops (`Conj`, `Invert`, `LogicalNot`, `Neg`) are all exact involutions.
- **`tests/tf_trait_folds.mlir`, `tests/canonicalize.mlir`** — the double/triple Reciprocal tests now assert the ops are preserved instead of folding to the argument.