### PR TITLE
fix complex dtype byte-swap overrun in ByteSwapBuffer

### DIFF
--- a/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
+++ b/tensorflow/core/util/tensor_bundle/byte_swap_tensor.cc
@@ -93,17 +93,18 @@ absl::Status ByteSwapBuffer(char* buff, size_t size, DataType dtype,
       array_len = (array_len == -1) ? size / bytes_per_elem : array_len;
       break;
 
-    // Complex types need special handling
+    // Complex types have two components per element. When the count comes from
+    // num_of_elem it is an element count and must be doubled to reach the
+    // component count; when it is derived from size it already counts the
+    // bytes_per_elem-sized components, so doubling it would run off the buffer.
     case DT_COMPLEX64:
       bytes_per_elem = 4;
-      array_len = (array_len == -1) ? size / bytes_per_elem : array_len;
-      array_len *= 2;
+      array_len = (array_len == -1) ? size / bytes_per_elem : array_len * 2;
       break;
 
     case DT_COMPLEX128:
       bytes_per_elem = 8;
-      array_len = (array_len == -1) ? size / bytes_per_elem : array_len;
-      array_len *= 2;
+      array_len = (array_len == -1) ? size / bytes_per_elem : array_len * 2;
       break;
 
     // Types that ought to be supported in the future

--- a/tensorflow/core/util/tensor_bundle/tensor_bundle_test.cc
+++ b/tensorflow/core/util/tensor_bundle/tensor_bundle_test.cc
@@ -25,6 +25,7 @@ limitations under the License.
 
 #include "absl/status/status.h"
 #include "xla/tsl/platform/errors.h"
+#include "tensorflow/core/framework/tensor.pb.h"
 #include "tensorflow/core/framework/tensor_testutil.h"
 #include "tensorflow/core/framework/tensor_util.h"
 #include "tensorflow/core/framework/types.pb.h"
@@ -389,6 +390,38 @@ TEST(TensorBundleTest, SwapBytes) {
 
   TF_EXPECT_OK(ByteSwapTensor(&forward_complex128));
   test::ExpectTensorEqual<complex128>(forward_complex128, swapped_complex128);
+}
+
+// ByteSwapTensorProto reaches ByteSwapBuffer with num_of_elem == -1, so the
+// element count is derived from the byte size. For complex dtypes that count
+// already covers both components, so it must not be doubled again or the swap
+// runs past the end of the tensor_content buffer.
+TEST(TensorBundleTest, ByteSwapTensorProtoComplex) {
+  Tensor forward_complex64 =
+      Constant_2x3<complex64>(std::complex<float>(1.5f, -2.5f));
+  Tensor forward_complex128 =
+      Constant_2x3<complex128>(std::complex<double>(3.5, -4.5));
+
+  for (const Tensor* forward : {&forward_complex64, &forward_complex128}) {
+    TensorProto proto;
+    forward->AsProtoTensorContent(&proto);
+    const size_t content_size = proto.tensor_content().size();
+
+    // Swapping twice must restore the original bytes without overrunning the
+    // content buffer (an out-of-bounds write is caught here under ASAN).
+    TF_EXPECT_OK(ByteSwapTensorProto(&proto));
+    EXPECT_EQ(proto.tensor_content().size(), content_size);
+    TF_EXPECT_OK(ByteSwapTensorProto(&proto));
+    EXPECT_EQ(proto.tensor_content().size(), content_size);
+
+    Tensor roundtrip(forward->dtype());
+    ASSERT_TRUE(roundtrip.FromProto(proto));
+    if (forward->dtype() == DT_COMPLEX64) {
+      test::ExpectTensorEqual<complex64>(roundtrip, *forward);
+    } else {
+      test::ExpectTensorEqual<complex128>(roundtrip, *forward);
+    }
+  }
 }
 
 // Basic test of alternate-endianness support. Generates a bundle in


### PR DESCRIPTION
ByteSwapBuffer computes the number of components to swap, then ByteSwapArray walks that many words in place. On the num_of_elem == -1 path the count comes from the byte size: array_len = size / bytes_per_elem, where bytes_per_elem is the 4- or 8-byte component size, so array_len already counts every component in the buffer. For DT_COMPLEX64/DT_COMPLEX128 the code then does array_len *= 2, so ByteSwapArray swaps twice as many words as the buffer holds and reads/writes size bytes past the end. This path is taken when a cross-endian SavedModel or GraphDef is loaded on a big-endian host (ByteSwapTensorContentInNode, and the public ByteSwapTensorProto), where the dtype and tensor_content length come straight from the file, so a complex Const overruns the copy buffer.

Only double the count on the num_of_elem branch, where it is an element count that has to become a component count; the size-derived branch is already the component count. The sibling ByteSwapTensor path (which passes t->NumElements()) confirms the intended arithmetic. Added a regression test that runs ByteSwapTensorProto over both complex dtypes and checks the content round-trips without overrunning.