### PR TITLE
Fix Round returning zeros for integer tensors (#74789)

### DIFF
--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -539,8 +539,14 @@ struct scalar_round_half_to_even_op {
   }
 };
 
-template <typename Scalar>
-struct scalar_round_half_to_even_op<Scalar, true, false> {
+// Integer types are already rounded, so rounding is the identity. This holds
+// regardless of whether the packet traits advertise rounding support, so the
+// specialization must match any value of the HasRint template parameter.
+// Otherwise integer types whose packet_traits report HasRound == true
+// instantiate as <Scalar, true, true>, miss this specialization, fall through
+// to the floating-point primary template, and produce zeros (issue #74789).
+template <typename Scalar, bool HasRint>
+struct scalar_round_half_to_even_op<Scalar, true, HasRint> {
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Scalar
   operator()(const Scalar& x) const {
     return x;

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -533,6 +533,17 @@ class UnaryOpTest(test.TestCase):
     self._compareCpu(x, np.square, math_ops.square)
     self._compareBothSparse(x, np.square, math_ops.square)
 
+  def testRoundIntIsIdentity(self):
+    # Rounding an integer tensor must be the identity. Regression test for
+    # https://github.com/tensorflow/tensorflow/issues/74789, where the CPU
+    # Round kernel returned all zeros for integer inputs. gen_math_ops.round
+    # is used directly because math_ops.round short-circuits integer dtypes in
+    # Python and would not exercise the kernel.
+    for dtype in (np.int32, np.int64):
+      x = np.array([[-3, -2, -1], [0, 1, 2]], dtype=dtype)
+      with test_util.force_cpu():
+        self.assertAllEqual(x, self.evaluate(gen_math_ops.round(x)))
+
   def testUInt64Basic(self):
     x = np.arange(6).reshape(1, 3, 2).astype(np.uint64)
     self._compareBoth(x, np.square, math_ops.square)


### PR DESCRIPTION
### Problem

`tf.raw_ops.Round` (and any op using `functor::round`) returns all zeros for integer tensors instead of the input values:

```python
>>> tf.raw_ops.Round(x=tf.constant([-2, -1, 1, 2, 3], dtype=tf.int32))
<tf.Tensor: shape=(5,), dtype=int32, numpy=array([0, 0, 0, 0, 0])>  # expected [-2, -1, 1, 2, 3]
```

This is a regression: TF 2.16 returned the input unchanged; TF 2.17+ returns zeros.

Fixes #74789

### Root cause

`scalar_round_half_to_even_op<Scalar, IsInteger, HasRint>` in `tensorflow/core/kernels/cwise_ops.h` has an integer specialization that was tightened to `<Scalar, true, /*HasRint=*/false>` when the `HasRint` template parameter was introduced. For integer types where `packet_traits<Scalar>::HasRound == true`, the type instantiates as `<Scalar, true, true>`, no longer matches the identity specialization, and falls through to the floating-point primary template — producing zeros.

### Fix

Relax the integer specialization to `<Scalar, true, HasRint>` so integer rounding is the identity for any value of `HasRint`, restoring the pre-regression behavior. The float `rint` path (`<Scalar, false, true>`) is untouched and there is no partial-ordering ambiguity.

### Testing

Adds `UnaryOpTest.testRoundIntIsIdentity` in `cwise_ops_unary_test.py`, asserting the kernel is the identity for `int32`/`int64`. It calls `gen_math_ops.round` directly, because `math_ops.round` short-circuits integer dtypes in Python and would not exercise the kernel (which is why existing coverage missed the regression).

CC @mihaimaruseac