### PR TITLE
Fix tf.sigmoid on bfloat16 CPU non-monotonicity and rounding issues

### DIFF
--- a/tensorflow/core/kernels/cwise_ops.h
+++ b/tensorflow/core/kernels/cwise_ops.h
@@ -30,6 +30,26 @@ limitations under the License.
 namespace Eigen {
 namespace internal {
 
+template <>
+struct scalar_logistic_op<Eigen::bfloat16> {
+  EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Eigen::bfloat16 operator()(
+      const Eigen::bfloat16& x) const {
+    float x_f = static_cast<float>(x);
+    const float cst_exp_hi = 16.6355324f;
+    const float e = Eigen::numext::exp(Eigen::numext::mini(x_f, cst_exp_hi));
+    return static_cast<Eigen::bfloat16>(e / (1.0f + e));
+  }
+};
+
+template <>
+struct functor_traits<scalar_logistic_op<Eigen::bfloat16>> {
+  enum {
+    Cost = NumTraits<Eigen::bfloat16>::AddCost * 15 +
+           NumTraits<Eigen::bfloat16>::MulCost * 11,
+    PacketAccess = false
+  };
+};
+
 #if GOOGLE_CUDA
 template <>
 struct scalar_arg_op<std::complex<float>> {

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -473,6 +473,30 @@ class UnaryOpTest(test.TestCase):
     self._compareBoth(x, compute_f32(np.vectorize(math.erf)), math_ops.erf)
     self._compareBoth(x, compute_f32(np.vectorize(math.erfc)), math_ops.erfc)
     self._compareBoth(x, compute_f32(np.square), math_ops.square)
+    self._compareBoth(x, compute_f32(self._sigmoid), math_ops.sigmoid)
+
+  def testBFloat16SigmoidMonotonicityAndRounding(self):
+    # Test values near the rounding threshold where sigmoid was non-monotonic
+    # and incorrectly rounded in eager/graph mode on CPU.
+    # Reference:
+    # exact sigmoid(5.5)  = 0.9959299... -> correctly rounded bfloat16: 0.99609375
+    # exact sigmoid(5.75) = 0.9968171... -> correctly rounded bfloat16: 0.99609375
+    # exact sigmoid(6.0)  = 0.9975274... -> correctly rounded bfloat16: 0.99609375
+    # exact sigmoid(6.25) = 0.9980757... -> correctly rounded bfloat16: 1.0
+    bfloat16 = dtypes_lib.bfloat16.as_numpy_dtype
+    x_val = np.array([5.5, 5.75, 6.0, 6.25], dtype=bfloat16)
+    x = constant_op.constant(x_val, dtype=dtypes_lib.bfloat16)
+    
+    # Calculate using tf.sigmoid
+    y = math_ops.sigmoid(x)
+    y_val = self.evaluate(y)
+    
+    # Assert correctness
+    expected = np.array([0.99609375, 0.99609375, 0.99609375, 1.0], dtype=bfloat16)
+    self.assertAllClose(y_val, expected)
+    
+    # Assert monotonicity: y[0] <= y[1] <= y[2] <= y[3]
+    self.assertTrue(np.all(y_val[:-1] <= y_val[1:]))
 
   def testInt8Basic(self):
     x = np.arange(-6, 6, 2).reshape(1, 3, 2).astype(np.int8)

--- a/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
+++ b/tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py
@@ -473,6 +473,31 @@ class UnaryOpTest(test.TestCase):
     self._compareBoth(x, compute_f32(np.vectorize(math.erf)), math_ops.erf)
     self._compareBoth(x, compute_f32(np.vectorize(math.erfc)), math_ops.erfc)
     self._compareBoth(x, compute_f32(np.square), math_ops.square)
+    self._compareBoth(x, compute_f32(self._sigmoid), math_ops.sigmoid)
+
+  def testBFloat16SigmoidMonotonicityAndRounding(self):
+    # Test values near the rounding threshold where sigmoid was non-monotonic
+    # and incorrectly rounded in eager/graph mode on CPU.
+    # Ref values near 1: 0.99609375 (0x3F7F), 1.0 (0x3F80)
+    # - exact sigmoid(5.5)  = 0.9959299... -> rounds to 0.99609375
+    # - exact sigmoid(5.75) = 0.9968171... -> rounds to 0.99609375
+    # - exact sigmoid(6.0)  = 0.9975274... -> rounds to 0.99609375
+    # - exact sigmoid(6.25) = 0.9980757... -> rounds to 1.0
+    bfloat16 = dtypes_lib.bfloat16.as_numpy_dtype
+    x_val = np.array([5.5, 5.75, 6.0, 6.25], dtype=bfloat16)
+    x = constant_op.constant(x_val, dtype=dtypes_lib.bfloat16)
+    
+    # Calculate using tf.sigmoid
+    y = math_ops.sigmoid(x)
+    y_val = self.evaluate(y)
+    
+    # Assert correctness
+    expected = np.array(
+        [0.99609375, 0.99609375, 0.99609375, 1.0], dtype=bfloat16)
+    self.assertAllClose(y_val, expected)
+    
+    # Assert monotonicity: y[0] <= y[1] <= y[2] <= y[3]
+    self.assertTrue(np.all(y_val[:-1] <= y_val[1:]))
 
   def testInt8Basic(self):
     x = np.arange(-6, 6, 2).reshape(1, 3, 2).astype(np.int8)


### PR DESCRIPTION
# Fix non-monotonicity and incorrect rounding of tf.sigmoid on bfloat16 CPU

Fixes #123104

### Problem
When evaluating `tf.sigmoid` (logistic function) on `bfloat16` CPU inputs in eager/graph mode, the results are non-monotonic and not correctly rounded (unlike in XLA, which returns correctly rounded values). 

For example:
* `sigmoid(5.5)` yields `0.99609375`
* `sigmoid(5.75)` yields `0.9921875` (a smaller output for a larger input, violating monotonicity).

This behavior stems from the default template implementation of Eigen's `scalar_logistic_op` evaluated directly in `bfloat16` precision. Because `bfloat16` has only 7 mantissa bits, performing three consecutive low-precision operations (`exp(x)`, then `1 + exp(x)`, and finally `exp(x) / (1 + exp(x))`) accumulates significant rounding errors.

### Solution
This PR fixes the issue by specializing `scalar_logistic_op<Eigen::bfloat16>` and its corresponding `functor_traits` in `tensorflow/core/kernels/cwise_ops.h`:
1. It casts `bfloat16` inputs to `float32` (`float`), performs the sigmoid computation in high-precision, and casts the result back to `bfloat16` once at the very end.
2. It sets `PacketAccess` to `false` for `Eigen::bfloat16` in `functor_traits` to disable SIMD packet vectorization on CPU, ensuring computations route correctly through the high-precision scalar specialization.

This ensures a maximum of one rounding operation, guaranteeing correct rounding and strict monotonicity.

---

### Changes

#### 1. Core Kernels
* **`tensorflow/core/kernels/cwise_ops.h`**:
  * Specialized `scalar_logistic_op<Eigen::bfloat16>` to calculate sigmoid values in `float` precision.
  * Specialized `functor_traits<scalar_logistic_op<Eigen::bfloat16>>` to set `PacketAccess = false`.

#### 2. Tests
* **`tensorflow/python/kernel_tests/math_ops/cwise_ops_unary_test.py`**:
  * Added `math_ops.sigmoid` to basic `bfloat16` tests (`testBFloat16Basic`).
  * Added `testBFloat16SigmoidMonotonicityAndRounding` to verify `sigmoid` correctness and monotonicity near the rounding threshold (specifically testing inputs `5.5`, `5.75`, `6.0`, and `6.25`).

---

### Verification
The changes were verified using the newly added test case `testBFloat16SigmoidMonotonicityAndRounding` which specifically tests:
* **Correct Rounding**:
  * `sigmoid(5.5)` $\rightarrow$ `0.99609375` (exact `0.995929...`)
  * `sigmoid(5.75)` $\rightarrow$ `0.99609375` (exact `0.996817...`)
  * `sigmoid(6.0)` $\rightarrow$ `0.99609375` (exact `0.997527...`)
  * `sigmoid(6.25)` $\rightarrow$ `1.0` (exact `0.998075...`)
* **Strict Monotonicity**: Asserts that `y_val[i] <= y_val[i+1]` across the tested range.